### PR TITLE
doc: unhyphenate non-zero

### DIFF
--- a/Counterexamples/CanonicallyOrderedCommSemiringTwoMul.lean
+++ b/Counterexamples/CanonicallyOrderedCommSemiringTwoMul.lean
@@ -9,7 +9,7 @@ import Mathlib.Data.ZMod.Basic
 /-!
 
 A canonically ordered commutative semiring with two different elements `a` and `b` such that
-`a ≠ b` and `2 * a = 2 * b`.  Thus, multiplication by a fixed non-zero element of a canonically
+`a ≠ b` and `2 * a = 2 * b`.  Thus, multiplication by a fixed nonzero element of a canonically
 ordered semiring need not be injective.  In particular, multiplying by a strictly positive element
 need not be strictly monotone.
 

--- a/Counterexamples/CliffordAlgebraNotInjective.lean
+++ b/Counterexamples/CliffordAlgebraNotInjective.lean
@@ -260,7 +260,7 @@ theorem algebraMap_αβγ_eq_zero : algebraMap K (CliffordAlgebra Q) (α * β * 
   rw [Algebra.algebraMap_eq_smul_one, αβγ_smul_eq_zero]
 
 /-- Our final result: for the quadratic form `Q60596.Q`, the algebra map to the Clifford algebra
-is not injective, as it sends the non-zero `α * β * γ` to zero. -/
+is not injective, as it sends the nonzero `α * β * γ` to zero. -/
 theorem algebraMap_not_injective : ¬Function.Injective (algebraMap K <| CliffordAlgebra Q) :=
   fun h => αβγ_ne_zero <| h <| by rw [algebraMap_αβγ_eq_zero, RingHom.map_zero]
 

--- a/Counterexamples/ZeroDivisorsInAddMonoidAlgebras.lean
+++ b/Counterexamples/ZeroDivisorsInAddMonoidAlgebras.lean
@@ -13,8 +13,8 @@ import Mathlib.Data.ZMod.Basic
 # Examples of zero-divisors in `AddMonoidAlgebra`s
 
 This file contains an easy source of zero-divisors in an `AddMonoidAlgebra`.
-If `k` is a field and `G` is an additive group containing a non-zero torsion element, then
-`k[G]` contains non-zero zero-divisors: this is lemma `zero_divisors_of_torsion`.
+If `k` is a field and `G` is an additive group containing a nonzero torsion element, then
+`k[G]` contains nonzero zero-divisors: this is lemma `zero_divisors_of_torsion`.
 
 There is also a version for periodic elements of an additive monoid: `zero_divisors_of_periodic`.
 
@@ -23,7 +23,7 @@ The converse of this statement is
 
 The formalized example generalizes in trivial ways the assumptions: the field `k` can be any
 nontrivial ring `R` and the additive group `G` with a torsion element can be any additive monoid
-`A` with a non-zero periodic element.
+`A` with a nonzero periodic element.
 
 Besides this example, we also address a comment in `Data.Finsupp.Lex` to the effect that the proof
 that addition is monotone on `α →₀ N` uses that it is *strictly* monotone on `N`.
@@ -49,8 +49,8 @@ namespace Counterexample
 
 /-- This is a simple example showing that if `R` is a non-trivial ring and `A` is an additive
 monoid with an element `a` satisfying `n • a = a` and `(n - 1) • a ≠ a`, for some `2 ≤ n`,
-then `R[A]` contains non-zero zero-divisors.  The elements are easy to write down:
-`[a]` and `[a] ^ (n - 1) - 1` are non-zero elements of `R[A]` whose product
+then `R[A]` contains nonzero zero-divisors.  The elements are easy to write down:
+`[a]` and `[a] ^ (n - 1) - 1` are nonzero elements of `R[A]` whose product
 is zero.
 
 Observe that such an element `a` *cannot* be invertible.  In particular, this lemma never applies
@@ -68,9 +68,9 @@ theorem single_zero_one {R A} [Semiring R] [Zero A] :
   rfl
 
 /-- This is a simple example showing that if `R` is a non-trivial ring and `A` is an additive
-monoid with a non-zero element `a` of finite order `oa`, then `R[A]` contains
-non-zero zero-divisors.  The elements are easy to write down:
-`∑ i ∈ Finset.range oa, [a] ^ i` and `[a] - 1` are non-zero elements of `R[A]`
+monoid with a nonzero element `a` of finite order `oa`, then `R[A]` contains
+nonzero zero-divisors.  The elements are easy to write down:
+`∑ i ∈ Finset.range oa, [a] ^ i` and `[a] - 1` are nonzero elements of `R[A]`
 whose product is zero.
 
 In particular, this applies whenever the additive monoid `A` is an additive group with a non-zero

--- a/Counterexamples/ZeroDivisorsInAddMonoidAlgebras.lean
+++ b/Counterexamples/ZeroDivisorsInAddMonoidAlgebras.lean
@@ -73,7 +73,7 @@ nonzero zero-divisors.  The elements are easy to write down:
 `∑ i ∈ Finset.range oa, [a] ^ i` and `[a] - 1` are nonzero elements of `R[A]`
 whose product is zero.
 
-In particular, this applies whenever the additive monoid `A` is an additive group with a non-zero
+In particular, this applies whenever the additive monoid `A` is an additive group with a nonzero
 torsion element. -/
 theorem zero_divisors_of_torsion {R A} [Nontrivial R] [Ring R] [AddMonoid A] (a : A)
     (o2 : 2 ≤ addOrderOf a) : ∃ f g : R[A], f ≠ 0 ∧ g ≠ 0 ∧ f * g = 0 := by

--- a/Mathlib/Algebra/CharP/Defs.lean
+++ b/Mathlib/Algebra/CharP/Defs.lean
@@ -241,7 +241,7 @@ lemma char_is_prime_or_zero (p : ℕ) [hc : CharP R p] : Nat.Prime p ∨ p = 0 :
   | 1, hc => absurd (Eq.refl (1 : ℕ)) (@char_ne_one R _ _ (1 : ℕ) hc)
   | m + 2, hc => Or.inl (@char_is_prime_of_two_le R _ _ (m + 2) hc (Nat.le_add_left 2 m))
 
-/-- The characteristic is prime if it is non-zero. -/
+/-- The characteristic is prime if it is nonzero. -/
 lemma char_prime_of_ne_zero {p : ℕ} [CharP R p] (hp : p ≠ 0) : p.Prime :=
   (CharP.char_is_prime_or_zero R p).resolve_right hp
 

--- a/Mathlib/Algebra/CharZero/Defs.lean
+++ b/Mathlib/Algebra/CharZero/Defs.lean
@@ -10,7 +10,7 @@ import Mathlib.Logic.Basic
 
 # Characteristic zero
 
-A ring `R` is called of characteristic zero if every natural number `n` is non-zero when considered
+A ring `R` is called of characteristic zero if every natural number `n` is nonzero when considered
 as an element of `R`. Since this definition doesn't mention the multiplicative structure of `R`
 except for the existence of `1` in this file characteristic zero is defined for additive monoids
 with `1`.

--- a/Mathlib/Algebra/Field/Defs.lean
+++ b/Mathlib/Algebra/Field/Defs.lean
@@ -19,7 +19,7 @@ statements about them. For a more extensive theory of fields, see the `FieldTheo
 * `Semifield`: Commutative division semiring.
 * `Field`: Commutative division ring.
 * `IsField`: Predicate on a (semi)ring that it is a (semi)field, i.e. that the multiplication is
-  commutative, that it has more than one element and that all non-zero elements have a
+  commutative, that it has more than one element and that all nonzero elements have a
   multiplicative inverse. In contrast to `Field`, which contains the data of a function associating
   to an element of the field its multiplicative inverse, this predicate only assumes the existence
   and can therefore more easily be used to e.g. transfer along ring isomorphisms.

--- a/Mathlib/Algebra/Field/IsField.lean
+++ b/Mathlib/Algebra/Field/IsField.lean
@@ -10,7 +10,7 @@ import Mathlib.Tactic.Common
 # `IsField` predicate
 
 Predicate on a (semi)ring that it is a (semi)field, i.e. that the multiplication is
-commutative, that it has more than one element and that all non-zero elements have a
+commutative, that it has more than one element and that all nonzero elements have a
 multiplicative inverse. In contrast to `Field`, which contains the data of a function associating
 to an element of the field its multiplicative inverse, this predicate only assumes the existence
 and can therefore more easily be used to e.g. transfer along ring isomorphisms.

--- a/Mathlib/Algebra/GCDMonoid/Basic.lean
+++ b/Mathlib/Algebra/GCDMonoid/Basic.lean
@@ -70,7 +70,7 @@ class NormalizationMonoid (α : Type*) [CancelCommMonoidWithZero α] where
   normUnit : α → αˣ
   /-- The proposition that `normUnit` maps `0` to the identity. -/
   normUnit_zero : normUnit 0 = 1
-  /-- The proposition that `normUnit` respects multiplication of non-zero elements. -/
+  /-- The proposition that `normUnit` respects multiplication of nonzero elements. -/
   normUnit_mul : ∀ {a b}, a ≠ 0 → b ≠ 0 → normUnit (a * b) = normUnit a * normUnit b
   /-- The proposition that `normUnit` maps units to their inverses. -/
   normUnit_coe_units : ∀ u : αˣ, normUnit u = u⁻¹

--- a/Mathlib/Algebra/Group/Defs.lean
+++ b/Mathlib/Algebra/Group/Defs.lean
@@ -662,13 +662,13 @@ lemma pow_right_comm (a : M) (m n : ℕ) : (a ^ m) ^ n = (a ^ n) ^ m := by
 
 end Monoid
 
-/-- An additive monoid is torsion-free if scalar multiplication by every non-zero element `n : ℕ` is
+/-- An additive monoid is torsion-free if scalar multiplication by every nonzero element `n : ℕ` is
 injective. -/
 @[mk_iff]
 class IsAddTorsionFree (M : Type*) [AddMonoid M] where
   protected nsmul_right_injective ⦃n : ℕ⦄ (hn : n ≠ 0) : Injective fun a : M ↦ n • a
 
-/-- A monoid is torsion-free if power by every non-zero element `n : ℕ` is injective. -/
+/-- A monoid is torsion-free if power by every nonzero element `n : ℕ` is injective. -/
 @[to_additive, mk_iff]
 class IsMulTorsionFree (M : Type*) [Monoid M] where
   protected pow_left_injective ⦃n : ℕ⦄ (hn : n ≠ 0) : Injective fun a : M ↦ a ^ n

--- a/Mathlib/Algebra/Group/Irreducible/Defs.lean
+++ b/Mathlib/Algebra/Group/Irreducible/Defs.lean
@@ -34,7 +34,7 @@ variable [Monoid M] {p q a b : M}
 
 /-- `Irreducible p` states that `p` is non-unit and only factors into units.
 
-We explicitly avoid stating that `p` is non-zero, this would require a semiring. Assuming only a
+We explicitly avoid stating that `p` is nonzero, this would require a semiring. Assuming only a
 monoid allows us to reuse irreducible for associated elements. -/
 @[to_additive]
 structure Irreducible (p : M) : Prop where

--- a/Mathlib/Algebra/Group/Torsion.lean
+++ b/Mathlib/Algebra/Group/Torsion.lean
@@ -10,7 +10,7 @@ import Mathlib.Tactic.MkIffOfInductiveProp
 # Torsion-free monoids and groups
 
 This file proves lemmas about torsion-free monoids.
-A monoid `M` is *torsion-free* if `n • · : M → M` is injective for all non-zero natural numbers `n`.
+A monoid `M` is *torsion-free* if `n • · : M → M` is injective for all nonzero natural numbers `n`.
 -/
 
 open Function

--- a/Mathlib/Algebra/GroupWithZero/Action/End.lean
+++ b/Mathlib/Algebra/GroupWithZero/Action/End.lean
@@ -70,7 +70,7 @@ instance AddMonoid.End.applyFaithfulSMul [AddMonoid α] :
     FaithfulSMul (AddMonoid.End α) α :=
   ⟨fun {_ _ h} => AddMonoidHom.ext h⟩
 
-/-- Each non-zero element of a `GroupWithZero` defines an additive monoid isomorphism of an
+/-- Each nonzero element of a `GroupWithZero` defines an additive monoid isomorphism of an
 `AddMonoid` on which it acts distributively.
 This is a stronger version of `DistribMulAction.toAddMonoidHom`. -/
 def DistribMulAction.toAddEquiv₀ {α : Type*} (β : Type*) [GroupWithZero α] [AddMonoid β]

--- a/Mathlib/Algebra/GroupWithZero/Defs.lean
+++ b/Mathlib/Algebra/GroupWithZero/Defs.lean
@@ -116,7 +116,7 @@ theorem pow_mul_apply_eq_pow_mul {M : Type*} [Monoid M] (f : M₀ → M) {x : M�
 end MonoidWithZero
 
 /-- A type `M` is a `CancelMonoidWithZero` if it is a monoid with zero element, `0` is left
-and right absorbing, and left/right multiplication by a non-zero element is injective. -/
+and right absorbing, and left/right multiplication by a nonzero element is injective. -/
 class CancelMonoidWithZero (M₀ : Type*) extends MonoidWithZero M₀, IsCancelMulZero M₀
 
 /-- A type `M` is a commutative “monoid with zero” if it is a commutative monoid with zero
@@ -161,7 +161,7 @@ end CommSemigroup
 
 /-- A type `M` is a `CancelCommMonoidWithZero` if it is a commutative monoid with zero element,
 `0` is left and right absorbing,
-and left/right multiplication by a non-zero element is injective. -/
+and left/right multiplication by a nonzero element is injective. -/
 class CancelCommMonoidWithZero (M₀ : Type*) extends CommMonoidWithZero M₀, IsLeftCancelMulZero M₀
 
 -- See note [lower cancel priority]

--- a/Mathlib/Algebra/GroupWithZero/NonZeroDivisors.lean
+++ b/Mathlib/Algebra/GroupWithZero/NonZeroDivisors.lean
@@ -20,7 +20,7 @@ non-commutative monoids.
 
 This file declares the notations:
 - `M₀⁰` for the submonoid of non-zero-divisors of `M₀`, in the locale `nonZeroDivisors`.
-- `M₀⁰[M]` for the submonoid of non-zero smul-divisors of `M₀` with respect to `M`, in the locale
+- `M₀⁰[M]` for the submonoid of nonzero smul-divisors of `M₀` with respect to `M`, in the locale
   `nonZeroSMulDivisors`
 
 Use the statement `open scoped nonZeroDivisors nonZeroSMulDivisors` to access this notation in
@@ -96,11 +96,11 @@ end
 def nonZeroDivisors (M₀ : Type*) [MonoidWithZero M₀] : Submonoid M₀ :=
   nonZeroDivisorsLeft M₀ ⊓ nonZeroDivisorsRight M₀
 
-/-- The notation for the submonoid of non-zero divisors. -/
+/-- The notation for the submonoid of nonzero divisors. -/
 scoped[nonZeroDivisors] notation:9000 M₀ "⁰" => nonZeroDivisors M₀
 
 /-- Let `M₀` be a monoid with zero and `M` an additive monoid with an `M₀`-action, then the
-collection of non-zero smul-divisors forms a submonoid.
+collection of nonzero smul-divisors forms a submonoid.
 
 These elements are also called `M`-regular. -/
 def nonZeroSMulDivisors (M₀ : Type*) [MonoidWithZero M₀] (M : Type*) [Zero M] [MulAction M₀ M] :
@@ -109,7 +109,7 @@ def nonZeroSMulDivisors (M₀ : Type*) [MonoidWithZero M₀] (M : Type*) [Zero M
   one_mem' m h := (one_smul M₀ m) ▸ h
   mul_mem' {r₁ r₂} h₁ h₂ m H := h₂ _ <| h₁ _ <| mul_smul r₁ r₂ m ▸ H
 
-/-- The notation for the submonoid of non-zero smul-divisors. -/
+/-- The notation for the submonoid of nonzero smul-divisors. -/
 scoped[nonZeroSMulDivisors] notation:9000 M₀ "⁰[" M "]" => nonZeroSMulDivisors M₀ M
 
 open nonZeroDivisors
@@ -374,7 +374,7 @@ variable {M₀}
 section MonoidWithZero
 variable [MonoidWithZero M₀] {a b : M₀⁰}
 
-/-- The units of the monoid of non-zero divisors of `M₀` are equivalent to the units of `M₀`. -/
+/-- The units of the monoid of nonzero divisors of `M₀` are equivalent to the units of `M₀`. -/
 @[simps]
 def unitsNonZeroDivisorsEquiv : M₀⁰ˣ ≃* M₀ˣ where
   __ := Units.map M₀⁰.subtype
@@ -400,8 +400,8 @@ theorem mk_mem_nonZeroDivisors_associates : Associates.mk a ∈ (Associates M₀
   · refine fun ⟨b, hb₁, hb₂⟩ ↦ ⟨Associates.mk b, ?_, by rwa [Associates.mk_ne_zero]⟩
     rw [Associates.mk_mul_mk, hb₁, Associates.mk_zero]
 
-/-- The non-zero divisors of associates of a monoid with zero `M₀` are isomorphic to the associates
-of the non-zero divisors of `M₀` under the map `⟨⟦a⟧, _⟩ ↦ ⟦⟨a, _⟩⟧`. -/
+/-- The nonzero divisors of associates of a monoid with zero `M₀` are isomorphic to the associates
+of the nonzero divisors of `M₀` under the map `⟨⟦a⟧, _⟩ ↦ ⟦⟨a, _⟩⟧`. -/
 def associatesNonZeroDivisorsEquiv : (Associates M₀)⁰ ≃* Associates M₀⁰ where
   toEquiv := .subtypeQuotientEquivQuotientSubtype _ (s₂ := Associated.setoid _)
     (· ∈ nonZeroDivisors _)

--- a/Mathlib/Algebra/GroupWithZero/Regular.lean
+++ b/Mathlib/Algebra/GroupWithZero/Regular.lean
@@ -94,7 +94,7 @@ end MulZeroClass
 section CancelMonoidWithZero
 variable [MulZeroClass R] [IsCancelMulZero R] {a : R}
 
-/-- Non-zero elements of an integral domain are regular. -/
+/-- Nonzero elements of an integral domain are regular. -/
 theorem isRegular_of_ne_zero (a0 : a ≠ 0) : IsRegular a :=
   ⟨fun _ _ => mul_left_cancel₀ a0, fun _ _ => mul_right_cancel₀ a0⟩
 

--- a/Mathlib/Algebra/GroupWithZero/Regular.lean
+++ b/Mathlib/Algebra/GroupWithZero/Regular.lean
@@ -52,21 +52,21 @@ theorem isRegular_iff_subsingleton : IsRegular (0 : R) ↔ Subsingleton R :=
   ⟨fun h => h.left.subsingleton, fun h =>
     ⟨isLeftRegular_zero_iff_subsingleton.mpr h, isRightRegular_zero_iff_subsingleton.mpr h⟩⟩
 
-/-- A left-regular element of a `Nontrivial` `MulZeroClass` is non-zero. -/
+/-- A left-regular element of a `Nontrivial` `MulZeroClass` is nonzero. -/
 theorem IsLeftRegular.ne_zero [Nontrivial R] (la : IsLeftRegular a) : a ≠ 0 := by
   rintro rfl
   rcases exists_pair_ne R with ⟨x, y, xy⟩
   refine xy (la ?_)
   simp
 
-/-- A right-regular element of a `Nontrivial` `MulZeroClass` is non-zero. -/
+/-- A right-regular element of a `Nontrivial` `MulZeroClass` is nonzero. -/
 theorem IsRightRegular.ne_zero [Nontrivial R] (ra : IsRightRegular a) : a ≠ 0 := by
   rintro rfl
   rcases exists_pair_ne R with ⟨x, y, xy⟩
   refine xy (ra ?_)
   simp
 
-/-- A regular element of a `Nontrivial` `MulZeroClass` is non-zero. -/
+/-- A regular element of a `Nontrivial` `MulZeroClass` is nonzero. -/
 theorem IsRegular.ne_zero [Nontrivial R] (la : IsRegular a) : a ≠ 0 :=
   la.left.ne_zero
 
@@ -98,7 +98,7 @@ variable [MulZeroClass R] [IsCancelMulZero R] {a : R}
 theorem isRegular_of_ne_zero (a0 : a ≠ 0) : IsRegular a :=
   ⟨fun _ _ => mul_left_cancel₀ a0, fun _ _ => mul_right_cancel₀ a0⟩
 
-/-- In a non-trivial integral domain, an element is regular iff it is non-zero. -/
+/-- In a non-trivial integral domain, an element is regular iff it is nonzero. -/
 theorem isRegular_iff_ne_zero [Nontrivial R] : IsRegular a ↔ a ≠ 0 :=
   ⟨IsRegular.ne_zero, isRegular_of_ne_zero⟩
 

--- a/Mathlib/Algebra/GroupWithZero/Units/Basic.lean
+++ b/Mathlib/Algebra/GroupWithZero/Units/Basic.lean
@@ -153,7 +153,7 @@ namespace Units
 
 variable [GroupWithZero G₀]
 
-/-- Embed a non-zero element of a `GroupWithZero` into the unit group.
+/-- Embed a nonzero element of a `GroupWithZero` into the unit group.
   By combining this function with the operations on units,
   or the `/ₚ` operation, it is possible to write a division
   as a partial function with three arguments. -/

--- a/Mathlib/Algebra/Homology/AlternatingConst.lean
+++ b/Mathlib/Algebra/Homology/AlternatingConst.lean
@@ -156,7 +156,7 @@ variable [HasZeroMorphisms C] [HasZeroObject C]
 
 open ZeroObject
 
-/-- The `n`-th homology of the alternating constant complex is zero for non-zero even `n`. -/
+/-- The `n`-th homology of the alternating constant complex is zero for nonzero even `n`. -/
 noncomputable
 def alternatingConstHomologyDataEvenNEZero (X : C) (n : ℕ) (hn : Even n) (h₀ : n ≠ 0) :
     ((alternatingConst.obj X).sc n).HomologyData :=

--- a/Mathlib/Algebra/Homology/ComplexShape.lean
+++ b/Mathlib/Algebra/Homology/ComplexShape.lean
@@ -47,7 +47,7 @@ with chain groups indexed by `ι`.
 Typically `ι` will be `ℕ`, `ℤ`, or `Fin n`.
 
 There is a relation `Rel : ι → ι → Prop`,
-and we will only allow a non-zero differential from `i` to `j` when `Rel i j`.
+and we will only allow a nonzero differential from `i` to `j` when `Rel i j`.
 
 There are axioms which imply `{ j // c.Rel i j }` and `{ i // c.Rel i j }` are subsingletons.
 This means that the shape consists of some union of lines, rays, intervals, and circles.

--- a/Mathlib/Algebra/Lie/CartanExists.lean
+++ b/Mathlib/Algebra/Lie/CartanExists.lean
@@ -251,7 +251,7 @@ lemma engel_isBot_of_isMin (hLK : finrank K L ≤ #K) (U : LieSubalgebra K L)
     use n + 1
     rwa [pow_succ]
   -- Now we find a subset `s` of `K` of size `≥ r`
-  -- such that `constantCoeff ψ` takes non-zero values on all of `s`.
+  -- such that `constantCoeff ψ` takes nonzero values on all of `s`.
   -- This turns out to be the subset that we alluded to earlier.
   obtain ⟨s, hs, hsψ⟩ : ∃ s : Finset K, r ≤ s.card ∧ ∀ α ∈ s, (constantCoeff ψ).eval α ≠ 0 := by
     classical
@@ -267,7 +267,7 @@ lemma engel_isBot_of_isMin (hLK : finrank K L ≤ #K) (U : LieSubalgebra K L)
       suffices finrank K Q + r = finrank K L by rw [← this, zero_add, Nat.add_sub_cancel]
       apply Submodule.finrank_quotient_add_finrank
     -- Hence there exists a subset of size `≥ r` in the complement of `t`,
-    -- and `constantCoeff ψ` takes non-zero values on all of this subset.
+    -- and `constantCoeff ψ` takes nonzero values on all of this subset.
     obtain ⟨s, hs⟩ := exists_finset_le_card K _ hLK
     use s \ t
     refine ⟨?_, ?_⟩
@@ -328,7 +328,7 @@ lemma engel_isBot_of_isMin (hLK : finrank K L ≤ #K) (U : LieSubalgebra K L)
   obtain hn₀|⟨k, hk⟩ : n = 0 ∨ ∃ k, n = k + 1 := by cases n <;> simp
   · simpa only [hn₀, pow_zero, Module.End.one_apply] using hn
   -- If `n = k + 1`, then we can write `⁅v, _⁆ ^ n = ⁅v, _⁆ ∘ ⁅v, _⁆ ^ k`.
-  -- Recall that `constantCoeff ψ` is non-zero on `α`, and `v = α • u + x`.
+  -- Recall that `constantCoeff ψ` is nonzero on `α`, and `v = α • u + x`.
   specialize hsψ α hα
   -- Hence `⁅v, _⁆` acts injectively on `Q`.
   rw [← coe_evalRingHom, constantCoeff_apply, ← coeff_map, lieCharpoly_map_eval,
@@ -338,7 +338,7 @@ lemma engel_isBot_of_isMin (hLK : finrank K L ≤ #K) (U : LieSubalgebra K L)
   -- Indeed `⁅v, _⁆` kills `⁅v, _⁆ ^ k` applied to `z'`.
   use (toEnd K U Q v ^ k) z'
   refine ⟨?_, ?_⟩
-  · -- And `⁅v, _⁆ ^ k` applied to `z'` is non-zero by definition of `n`.
+  · -- And `⁅v, _⁆ ^ k` applied to `z'` is nonzero by definition of `n`.
     apply Nat.find_min hz'; omega
   · rw [← hn, hk, pow_succ', Module.End.mul_apply]
 

--- a/Mathlib/Algebra/Lie/CartanMatrix.lean
+++ b/Mathlib/Algebra/Lie/CartanMatrix.lean
@@ -246,7 +246,7 @@ The corresponding Dynkin diagram is:
 o ≡>≡ o
 ```
 Actually we are using the transpose of Bourbaki's matrix. This is to make this matrix consistent
-with `CartanMatrix.F₄`, in the sense that all non-zero values below the diagonal are -1. -/
+with `CartanMatrix.F₄`, in the sense that all nonzero values below the diagonal are -1. -/
 def G₂ : Matrix (Fin 2) (Fin 2) ℤ :=
   !![2, -3; -1, 2]
 

--- a/Mathlib/Algebra/Lie/DirectSum.lean
+++ b/Mathlib/Algebra/Lie/DirectSum.lean
@@ -179,14 +179,14 @@ def toLieAlgebra [DecidableEq ι] (L' : Type w₁) [LieRing L'] [LieAlgebra R L'
     map_lie' := fun {x y} => by
       let f' i := (f i : L i →ₗ[R] L')
       /- The goal is linear in `y`. We can use this to reduce to the case that `y` has only one
-        non-zero component. -/
+        nonzero component. -/
       suffices ∀ (i : ι) (y : L i),
           toModule R ι L' f' ⁅x, of L i y⁆ =
             ⁅toModule R ι L' f' x, toModule R ι L' f' (of L i y)⁆ by
         simp only [← LieAlgebra.ad_apply R]
         rw [← LinearMap.comp_apply, ← LinearMap.comp_apply]
         congr; clear y; ext i y; exact this i y
-      -- Similarly, we can reduce to the case that `x` has only one non-zero component.
+      -- Similarly, we can reduce to the case that `x` has only one nonzero component.
       suffices ∀ (i j) (y : L i) (x : L j),
           toModule R ι L' f' ⁅of L j x, of L i y⁆ =
             ⁅toModule R ι L' f' (of L j x), toModule R ι L' f' (of L i y)⁆ by

--- a/Mathlib/Algebra/Lie/Engel.lean
+++ b/Mathlib/Algebra/Lie/Engel.lean
@@ -41,9 +41,9 @@ be proper.
 
 The first part of the traditional statement of Engel's theorem consists of the statement that if `M`
 is a non-trivial `R`-module and `L ⊆ End(M)` is a finite-dimensional Lie subalgebra of nilpotent
-elements, then there exists a non-zero element `m : M` that is annihilated by every element of `L`.
+elements, then there exists a nonzero element `m : M` that is annihilated by every element of `L`.
 This follows trivially from the result established here `LieModule.isNilpotent_iff_forall`, that
-`M` is a nilpotent Lie module over `L`, since the last non-zero term in the lower central series
+`M` is a nilpotent Lie module over `L`, since the last nonzero term in the lower central series
 will consist of such elements `m` (see: `LieModule.nontrivial_max_triv_of_isNilpotent`). It seems
 that this result has not previously been established at this level of generality.
 

--- a/Mathlib/Algebra/Lie/Nilpotent.lean
+++ b/Mathlib/Algebra/Lie/Nilpotent.lean
@@ -473,7 +473,7 @@ theorem lowerCentralSeriesLast_le_of_not_isTrivial [IsNilpotent L M] (h : ¬ IsT
 variable [LieModule R L M]
 
 /-- For a nilpotent Lie module `M` of a Lie algebra `L`, the first term in the lower central series
-of `M` contains a non-zero element on which `L` acts trivially unless the entire action is trivial.
+of `M` contains a nonzero element on which `L` acts trivially unless the entire action is trivial.
 
 Taking `M = L`, this provides a useful characterisation of Abelian-ness for nilpotent Lie
 algebras. -/

--- a/Mathlib/Algebra/Lie/Rank.lean
+++ b/Mathlib/Algebra/Lie/Rank.lean
@@ -17,7 +17,7 @@ Then the coefficients of the characteristic polynomial of `ad R L x` are polynom
 The *rank* of `L` is the smallest `n` for which the `n`-th coefficient is not the zero polynomial.
 
 Continuing to write `n` for the rank of `L`, an element `x` of `L` is *regular*
-if the `n`-th coefficient of the characteristic polynomial of `ad R L x` is non-zero.
+if the `n`-th coefficient of the characteristic polynomial of `ad R L x` is nonzero.
 
 ## Main declarations
 
@@ -85,7 +85,7 @@ lemma rank_le_natTrailingDegree_charpoly_ad [Nontrivial R] :
 
 /-- Let `x` be an element of a Lie algebra `L` over `R`, and write `n` for `rank R L`.
 Then `x` is *regular*
-if the `n`-th coefficient of the characteristic polynomial of `ad R L x` is non-zero. -/
+if the `n`-th coefficient of the characteristic polynomial of `ad R L x` is nonzero. -/
 def IsRegular (x : L) : Prop := LinearMap.IsNilRegular φ x
 
 lemma isRegular_def :
@@ -157,7 +157,7 @@ lemma rank_le_natTrailingDegree_charpoly_ad [Nontrivial R] :
 
 /-- Let `x` be an element of a Lie algebra `L` over `R`, and write `n` for `rank R L`.
 Then `x` is *regular*
-if the `n`-th coefficient of the characteristic polynomial of `ad R L x` is non-zero. -/
+if the `n`-th coefficient of the characteristic polynomial of `ad R L x` is nonzero. -/
 abbrev IsRegular (x : L) : Prop := LieModule.IsRegular R L x
 
 lemma isRegular_def :

--- a/Mathlib/Algebra/Lie/TraceForm.lean
+++ b/Mathlib/Algebra/Lie/TraceForm.lean
@@ -424,7 +424,7 @@ lemma traceForm_eq_sum_finrank_nsmul :
   simp
 
 /-- A variant of `LieModule.traceForm_eq_sum_finrank_nsmul` in which the sum is taken only over the
-non-zero weights. -/
+nonzero weights. -/
 lemma traceForm_eq_sum_finrank_nsmul' :
     traceForm K L M = ∑ χ ∈ {χ : Weight K L M | χ.IsNonZero}, finrank K (genWeightSpace M χ) •
       (χ : L →ₗ[K] K).smulRight (χ : L →ₗ[K] K) := by

--- a/Mathlib/Algebra/Lie/Weights/Basic.lean
+++ b/Mathlib/Algebra/Lie/Weights/Basic.lean
@@ -257,7 +257,7 @@ lemma isZero_iff_eq_zero [Nontrivial (genWeightSpace M (0 : L → R))] {χ : Wei
 
 lemma isZero_zero [Nontrivial (genWeightSpace M (0 : L → R))] : IsZero (0 : Weight R L M) := rfl
 
-/-- The proposition that a weight of a Lie module is non-zero. -/
+/-- The proposition that a weight of a Lie module is nonzero. -/
 abbrev IsNonZero (χ : Weight R L M) := ¬ IsZero (χ : Weight R L M)
 
 lemma isNonZero_iff_ne_zero [Nontrivial (genWeightSpace M (0 : L → R))] {χ : Weight R L M} :

--- a/Mathlib/Algebra/Lie/Weights/RootSystem.lean
+++ b/Mathlib/Algebra/Lie/Weights/RootSystem.lean
@@ -26,7 +26,7 @@ characteristic 0 form a root system. We achieve this by studying root chains.
   The `α`-chain through `β` (`β - qα ... β ... β + rα`) are the only roots of the form `β + kα`.
 
 - `LieAlgebra.IsKilling.eq_neg_or_eq_of_eq_smul`:
-  `±α` are the only `K`-multiples of a root `α` that are also (non-zero) roots.
+  `±α` are the only `K`-multiples of a root `α` that are also (nonzero) roots.
 
 - `LieAlgebra.IsKilling.rootSystem`: The root system of a finite-dimensional Lie algebra with
   non-degenerate Killing form over a field of characteristic zero,
@@ -343,7 +343,7 @@ lemma eq_neg_one_or_eq_zero_or_eq_one_of_eq_smul
       sub_add_sub_cancel', add_sub_cancel_left, ne_eq] at this
     cases this (rootSpace_one_div_two_smul α hα)
 
-/-- `±α` are the only `K`-multiples of a root `α` that are also (non-zero) roots. -/
+/-- `±α` are the only `K`-multiples of a root `α` that are also (nonzero) roots. -/
 lemma eq_neg_or_eq_of_eq_smul (hβ : β.IsNonZero) (k : K) (h : (β : H → K) = k • α) :
     β = -α ∨ β = α := by
   by_cases hα : α.IsZero

--- a/Mathlib/Algebra/Module/LinearMap/Polynomial.lean
+++ b/Mathlib/Algebra/Module/LinearMap/Polynomial.lean
@@ -39,7 +39,7 @@ that evaluates on elements `x` of `L` to the characteristic polynomial of `φ x`
   is the characteristic polynomial of `φ x`.
 * `LinearMap.polyCharpoly_coeff_isHomogeneous`: the coefficients of `polyCharpoly`
   are homogeneous polynomials in the parameters.
-* `LinearMap.nilRank`: the smallest index at which `polyCharpoly` has a non-zero coefficient,
+* `LinearMap.nilRank`: the smallest index at which `polyCharpoly` has a nonzero coefficient,
   which is independent of the choice of basis for `L`.
 * `LinearMap.IsNilRegular`: an element `x` of `L` is *nil-regular* with respect to `φ`
   if the `n`-th coefficient of the characteristic polynomial of `φ x` is non-zero,
@@ -423,7 +423,7 @@ section aux
 Let `L` and `M` be finite free modules over `R`,
 and let `φ : L →ₗ[R] Module.End R M` be a linear family of endomorphisms.
 Then `LinearMap.nilRankAux φ b` is the smallest index
-at which `LinearMap.polyCharpoly φ b` has a non-zero coefficient.
+at which `LinearMap.polyCharpoly φ b` has a nonzero coefficient.
 
 This number does not depend on the choice of `b`, see `nilRankAux_basis_indep`. -/
 noncomputable
@@ -452,7 +452,7 @@ variable [Module.Finite R L] [Module.Free R L]
 /-- Let `L` and `M` be finite free modules over `R`,
 and let `φ : L →ₗ[R] Module.End R M` be a linear family of endomorphisms.
 Then `LinearMap.nilRank φ b` is the smallest index
-at which `LinearMap.polyCharpoly φ b` has a non-zero coefficient.
+at which `LinearMap.polyCharpoly φ b` has a nonzero coefficient.
 
 This number does not depend on the choice of `b`,
 see `LinearMap.nilRank_eq_polyCharpoly_natTrailingDegree`. -/

--- a/Mathlib/Algebra/Module/LinearMap/Polynomial.lean
+++ b/Mathlib/Algebra/Module/LinearMap/Polynomial.lean
@@ -42,7 +42,7 @@ that evaluates on elements `x` of `L` to the characteristic polynomial of `φ x`
 * `LinearMap.nilRank`: the smallest index at which `polyCharpoly` has a nonzero coefficient,
   which is independent of the choice of basis for `L`.
 * `LinearMap.IsNilRegular`: an element `x` of `L` is *nil-regular* with respect to `φ`
-  if the `n`-th coefficient of the characteristic polynomial of `φ x` is non-zero,
+  if the `n`-th coefficient of the characteristic polynomial of `φ x` is nonzero,
   where `n` denotes the nil-rank of `φ`.
 
 ## Implementation details
@@ -499,7 +499,7 @@ and let `φ : L →ₗ[R] Module.End R M` be a linear family of endomorphisms,
 and denote `n := nilRank φ`.
 
 An element `x : L` is *nil-regular* with respect to `φ`
-if the `n`-th coefficient of the characteristic polynomial of `φ x` is non-zero. -/
+if the `n`-th coefficient of the characteristic polynomial of `φ x` is nonzero. -/
 def IsNilRegular (x : L) : Prop :=
   Polynomial.coeff (φ x).charpoly (nilRank φ) ≠ 0
 

--- a/Mathlib/Algebra/Module/Torsion.lean
+++ b/Mathlib/Algebra/Module/Torsion.lean
@@ -44,7 +44,7 @@ import Mathlib.RingTheory.SimpleModule.Basic
   `p i`-torsion submodules when the `p i` are pairwise coprime. A more general version with coprime
   ideals is `Submodule.torsionBySet_is_internal`.
 * `Submodule.noZeroSMulDivisors_iff_torsion_bot` : a module over a domain has
-  `NoZeroSMulDivisors` (that is, there is no non-zero `a`, `x` such that `a • x = 0`)
+  `NoZeroSMulDivisors` (that is, there is no nonzero `a`, `x` such that `a • x = 0`)
   iff its torsion submodule is trivial.
 * `Submodule.QuotientTorsion.torsion_eq_bot` : quotienting by the torsion submodule makes the
   torsion submodule of the new module trivial. If `R` is a domain, we can derive an instance

--- a/Mathlib/Algebra/MonoidAlgebra/Degree.lean
+++ b/Mathlib/Algebra/MonoidAlgebra/Degree.lean
@@ -33,9 +33,9 @@ For an element `f : R[A]`, this file defines
 
 If the grading type `A` is a linearly ordered additive monoid, then these two notions of degree
 coincide with the standard one:
-* the sup-degree is the maximum of the exponents of the monomials that appear with non-zero
+* the sup-degree is the maximum of the exponents of the monomials that appear with nonzero
   coefficient in `f`, or `⊥`, if `f = 0`;
-* the inf-degree is the minimum of the exponents of the monomials that appear with non-zero
+* the inf-degree is the minimum of the exponents of the monomials that appear with nonzero
   coefficient in `f`, or `⊤`, if `f = 0`.
 
 The main results are

--- a/Mathlib/Algebra/MonoidAlgebra/NoZeroDivisors.lean
+++ b/Mathlib/Algebra/MonoidAlgebra/NoZeroDivisors.lean
@@ -23,7 +23,7 @@ In this file we show that if `R` satisfies `NoZeroDivisors` and `A` is a grading
 also satisfies `NoZeroDivisors`.
 
 Because of the instances to `UniqueProds/Sums`, we obtain a formalization of the well-known result
-that if `R` is a field and `A` is a left-ordered group, then `R[A]` contains no non-zero
+that if `R` is a field and `A` is a left-ordered group, then `R[A]` contains no nonzero
 zero-divisors.
 The actual assumptions on `R` are weaker.
 
@@ -39,10 +39,10 @@ The actual assumptions on `R` are weaker.
   `NoZeroDivisors R[A]`.
 
 TODO: move the rest of the docs to UniqueProds?
-* `NoZeroDivisors.of_left_ordered` shows that if `R` is a semiring with no non-zero
+* `NoZeroDivisors.of_left_ordered` shows that if `R` is a semiring with no nonzero
   zero-divisors, `A` is a linearly ordered, add right cancel semigroup with strictly monotone
   left addition, then `R[A]` has no nonzero zero-divisors.
-* `NoZeroDivisors.of_right_ordered` shows that if `R` is a semiring with no non-zero
+* `NoZeroDivisors.of_right_ordered` shows that if `R` is a semiring with no nonzero
   zero-divisors, `A` is a linearly ordered, add left cancel semigroup with strictly monotone
   right addition, then `R[A]` has no nonzero zero-divisors.
 

--- a/Mathlib/Algebra/MonoidAlgebra/NoZeroDivisors.lean
+++ b/Mathlib/Algebra/MonoidAlgebra/NoZeroDivisors.lean
@@ -7,10 +7,10 @@ import Mathlib.Algebra.Group.UniqueProds.Basic
 import Mathlib.Algebra.MonoidAlgebra.Opposite
 
 /-!
-# Variations on non-zero divisors in `AddMonoidAlgebra`s
+# Variations on nonzero divisors in `AddMonoidAlgebra`s
 
 This file studies the interaction between typeclass assumptions on two Types `R` and `A` and
-whether `R[A]` has non-zero zero-divisors.  For some background on related
+whether `R[A]` has nonzero zero-divisors.  For some background on related
 questions, see [Kaplansky's Conjectures](https://en.wikipedia.org/wiki/Kaplansky%27s_conjectures),
 especially the *zero divisor conjecture*.
 
@@ -41,10 +41,10 @@ The actual assumptions on `R` are weaker.
 TODO: move the rest of the docs to UniqueProds?
 * `NoZeroDivisors.of_left_ordered` shows that if `R` is a semiring with no non-zero
   zero-divisors, `A` is a linearly ordered, add right cancel semigroup with strictly monotone
-  left addition, then `R[A]` has no non-zero zero-divisors.
+  left addition, then `R[A]` has no nonzero zero-divisors.
 * `NoZeroDivisors.of_right_ordered` shows that if `R` is a semiring with no non-zero
   zero-divisors, `A` is a linearly ordered, add left cancel semigroup with strictly monotone
-  right addition, then `R[A]` has no non-zero zero-divisors.
+  right addition, then `R[A]` has no nonzero zero-divisors.
 
 The conditions on `A` imposed in `NoZeroDivisors.of_left_ordered` are sometimes referred to as
 `left-ordered`.

--- a/Mathlib/Algebra/MvPolynomial/Basic.lean
+++ b/Mathlib/Algebra/MvPolynomial/Basic.lean
@@ -52,7 +52,7 @@ In the definitions below, we use the following notation:
 ## Implementation notes
 
 Recall that if `Y` has a zero, then `X →₀ Y` is the type of functions from `X` to `Y` with finite
-support, i.e. such that only finitely many elements of `X` get sent to non-zero terms in `Y`.
+support, i.e. such that only finitely many elements of `X` get sent to nonzero terms in `Y`.
 The definition of `MvPolynomial σ R` is `(σ →₀ ℕ) →₀ R`; here `σ →₀ ℕ` denotes the space of all
 monomials in the variables, and the function to `R` sends a monomial to its coefficient in
 the polynomial being represented.
@@ -496,7 +496,7 @@ theorem linearMap_ext {M : Type*} [AddCommMonoid M] [Module R M] {f g : MvPolyno
 
 section Support
 
-/-- The finite set of all `m : σ →₀ ℕ` such that `X^m` has a non-zero coefficient. -/
+/-- The finite set of all `m : σ →₀ ℕ` such that `X^m` has a nonzero coefficient. -/
 def support (p : MvPolynomial σ R) : Finset (σ →₀ ℕ) :=
   Finsupp.support p
 

--- a/Mathlib/Algebra/MvPolynomial/Degrees.lean
+++ b/Mathlib/Algebra/MvPolynomial/Degrees.lean
@@ -18,7 +18,7 @@ monomial of $P$.
 ## Main declarations
 
 * `MvPolynomial.degrees p` : the multiset of variables representing the union of the multisets
-  corresponding to each non-zero monomial in `p`.
+  corresponding to each nonzero monomial in `p`.
   For example if `7 ≠ 0` in `R` and `p = x²y+7y³` then `degrees p = {x, x, y, y, y}`
 
 * `MvPolynomial.degreeOf n p : ℕ` : the total degree of `p` with respect to the variable `n`.

--- a/Mathlib/Algebra/Order/Archimedean/Class.lean
+++ b/Mathlib/Algebra/Order/Archimedean/Class.lean
@@ -586,7 +586,7 @@ It is defined as the subtype of non-top elements of `MulArchimedeanClass M`
 
 This is useful since the family of non-top archimedean classes is linearly independent. -/
 @[to_additive FiniteArchimedeanClass
-/-- `FiniteArchimedeanClass M` is the quotient of the non-zero elements of the additive group `M` by
+/-- `FiniteArchimedeanClass M` is the quotient of the nonzero elements of the additive group `M` by
 additive archimedean equivalence, where two elements `a` and `b` are in the same class iff
 `(∃ m : ℕ, |b| ≤ m • |a|) ∧ (∃ n : ℕ, |a| ≤ n • |b|)`.
 
@@ -599,7 +599,7 @@ abbrev FiniteMulArchimedeanClass := {A : MulArchimedeanClass M // A ≠ ⊤}
 namespace FiniteMulArchimedeanClass
 
 /-- Create a `FiniteMulArchimedeanClass` from a non-one element. -/
-@[to_additive /-- Create a `FiniteArchimedeanClass` from a non-zero element. -/]
+@[to_additive /-- Create a `FiniteArchimedeanClass` from a nonzero element. -/]
 def mk (a : M) (h : a ≠ 1) : FiniteMulArchimedeanClass M :=
   ⟨MulArchimedeanClass.mk a, MulArchimedeanClass.mk_eq_top_iff.not.mpr h⟩
 

--- a/Mathlib/Algebra/Polynomial/Basic.lean
+++ b/Mathlib/Algebra/Polynomial/Basic.lean
@@ -365,7 +365,7 @@ theorem toFinsupp_sum {ι : Type*} (s : Finset ι) (f : ι → R[X]) :
     (∑ i ∈ s, f i : R[X]).toFinsupp = ∑ i ∈ s, (f i).toFinsupp :=
   map_sum (toFinsuppIso R) f s
 
-/-- The set of all `n` such that `X^n` has a non-zero coefficient. -/
+/-- The set of all `n` such that `X^n` has a nonzero coefficient. -/
 def support : R[X] → Finset ℕ
   | ⟨p⟩ => p.support
 

--- a/Mathlib/Algebra/Polynomial/Degree/Lemmas.lean
+++ b/Mathlib/Algebra/Polynomial/Degree/Lemmas.lean
@@ -117,7 +117,7 @@ theorem natDegree_mul_C_eq_of_mul_eq_one {ai : R} (au : a * ai = 1) :
       _ ≤ (p * C a).natDegree := natDegree_mul_C_le (p * C a) ai)
 
 /-- Although not explicitly stated, the assumptions of lemma `natDegree_mul_C_eq_of_mul_ne_zero`
-force the polynomial `p` to be non-zero, via `p.leadingCoeff ≠ 0`.
+force the polynomial `p` to be nonzero, via `p.leadingCoeff ≠ 0`.
 -/
 theorem natDegree_mul_C_eq_of_mul_ne_zero (h : p.leadingCoeff * a ≠ 0) :
     (p * C a).natDegree = p.natDegree := by
@@ -126,7 +126,7 @@ theorem natDegree_mul_C_eq_of_mul_ne_zero (h : p.leadingCoeff * a ≠ 0) :
   rwa [coeff_mul_C]
 
 /-- Although not explicitly stated, the assumptions of lemma `natDegree_C_mul_of_mul_ne_zero`
-force the polynomial `p` to be non-zero, via `p.leadingCoeff ≠ 0`.
+force the polynomial `p` to be nonzero, via `p.leadingCoeff ≠ 0`.
 -/
 theorem natDegree_C_mul_of_mul_ne_zero (h : a * p.leadingCoeff ≠ 0) :
     (C a * p).natDegree = p.natDegree := by

--- a/Mathlib/Algebra/Polynomial/Inductions.lean
+++ b/Mathlib/Algebra/Polynomial/Inductions.lean
@@ -175,11 +175,11 @@ theorem degree_pos_induction_on {P : R[X] → Prop} (p : R[X]) (h0 : 0 < degree 
         exact hC fun h : coeff p 0 = 0 => by simp [h] at h0')
     h0
 
-/-- A property holds for all polynomials of non-zero `natDegree` with coefficients in a
+/-- A property holds for all polynomials of nonzero `natDegree` with coefficients in a
 semiring `R` if it holds for
 * `p + a`, with `a ∈ R`, `p ∈ R[X]`,
 * `p + q`, with `p, q ∈ R[X]`,
-* monomials with nonzero coefficient and non-zero exponent,
+* monomials with nonzero coefficient and nonzero exponent,
 with appropriate restrictions on each term.
 Note that multiplication is "hidden" in the assumption on monomials, so there is no explicit
 multiplication in the statement.

--- a/Mathlib/Algebra/Regular/Basic.lean
+++ b/Mathlib/Algebra/Regular/Basic.lean
@@ -11,8 +11,8 @@ import Mathlib.Algebra.Regular.Defs
 /-!
 # Regular elements
 
-By definition, a regular element in a commutative ring is a non-zero divisor.
-Lemma `isRegular_of_ne_zero` implies that every non-zero element of an integral domain is regular.
+By definition, a regular element in a commutative ring is a nonzero divisor.
+Lemma `isRegular_of_ne_zero` implies that every nonzero element of an integral domain is regular.
 Since it assumes that the ring is a `CancelMonoidWithZero` it applies also, for instance, to `ℕ`.
 
 The lemmas in Section `MulZeroClass` show that the `0` element is (left/right-)regular if and

--- a/Mathlib/Algebra/Ring/Periodic.lean
+++ b/Mathlib/Algebra/Ring/Periodic.lean
@@ -224,7 +224,7 @@ theorem Periodic.lift_coe [AddGroup α] (h : Periodic f c) (a : α) :
   rfl
 
 /-- A periodic function `f : R → X` on a semiring (or, more generally, `AddZeroClass`)
-of non-zero period is not injective. -/
+of nonzero period is not injective. -/
 lemma Periodic.not_injective {R X : Type*} [AddZeroClass R] {f : R → X} {c : R}
     (hf : Periodic f c) (hc : c ≠ 0) : ¬ Injective f := fun h ↦ hc <| h hf.eq
 

--- a/Mathlib/Algebra/TrivSqZeroExt.lean
+++ b/Mathlib/Algebra/TrivSqZeroExt.lean
@@ -1017,7 +1017,7 @@ theorem range_liftAux (f : R →ₐ[S] A) (g : M →ₗ[S] A)
 
 /-- A universal property of the trivial square-zero extension, providing a unique
 `TrivSqZeroExt R M →ₐ[R] A` for every pair of maps `f : R →ₐ[S] A` and `g : M →ₗ[S] A`,
-where the range of `g` has no non-zero products, and scaling the input to `g` on the left or right
+where the range of `g` has no nonzero products, and scaling the input to `g` on the left or right
 amounts to a corresponding multiplication by `f` in the output.
 
 This isomorphism is named to match the very similar `Complex.lift`. -/

--- a/Mathlib/AlgebraicGeometry/EllipticCurve/Affine/Point.lean
+++ b/Mathlib/AlgebraicGeometry/EllipticCurve/Affine/Point.lean
@@ -361,7 +361,7 @@ lemma XYIdeal_mul_XYIdeal [DecidableEq F] {x₁ x₂ y₁ y₂ : F}
     C_simp
     ring1
 
-/-- The non-zero fractional ideal `⟨X - x, Y - y⟩` of `F(W)` for some `x` and `y` in `F`. -/
+/-- The nonzero fractional ideal `⟨X - x, Y - y⟩` of `F(W)` for some `x` and `y` in `F`. -/
 noncomputable def XYIdeal' {x y : F} (h : W.Nonsingular x y) :
     (FractionalIdeal W.CoordinateRing⁰ W.FunctionField)ˣ :=
   Units.mkOfMulEqOne _ _ <| by
@@ -579,7 +579,7 @@ variable [DecidableEq K] [DecidableEq L]
 /-! ## Group law in affine coordinates -/
 
 /-- The group homomorphism mapping a nonsingular affine point `(x, y)` of a Weierstrass curve `W` to
-the class of the non-zero fractional ideal `⟨X - x, Y - y⟩` in the ideal class group of `F[W]`. -/
+the class of the nonzero fractional ideal `⟨X - x, Y - y⟩` in the ideal class group of `F[W]`. -/
 @[simps]
 noncomputable def toClass : W.Point →+ Additive (ClassGroup W.CoordinateRing) where
   toFun P := match P with

--- a/Mathlib/AlgebraicGeometry/EllipticCurve/Weierstrass.lean
+++ b/Mathlib/AlgebraicGeometry/EllipticCurve/Weierstrass.lean
@@ -26,7 +26,7 @@ of algebro-geometric machinery) that every elliptic curve `E` is a projective pl
 to a Weierstrass curve given by the equation `Y² + a₁XY + a₃Y = X³ + a₂X² + a₄X + a₆` for some `aᵢ`
 in `R`, and such that a certain quantity called the discriminant of `E` is a unit in `R`. If `R` is
 a field, this quantity divides the discriminant of a cubic polynomial whose roots over a splitting
-field of `R` are precisely the `X`-coordinates of the non-zero 2-torsion points of `E`.
+field of `R` are precisely the `X`-coordinates of the nonzero 2-torsion points of `E`.
 
 ## Main definitions
 
@@ -294,7 +294,7 @@ section TorsionPolynomial
 
 /-- A cubic polynomial whose discriminant is a multiple of the Weierstrass curve discriminant. If
 `W` is an elliptic curve over a field `R` of characteristic different from 2, then its roots over a
-splitting field of `R` are precisely the `X`-coordinates of the non-zero 2-torsion points of `W`. -/
+splitting field of `R` are precisely the `X`-coordinates of the nonzero 2-torsion points of `W`. -/
 def twoTorsionPolynomial : Cubic R :=
   ⟨4, W.b₂, 2 * W.b₄, W.b₆⟩
 

--- a/Mathlib/Analysis/Analytic/OfScalars.lean
+++ b/Mathlib/Analysis/Analytic/OfScalars.lean
@@ -289,7 +289,7 @@ theorem ofScalars_radius_eq_zero_of_tendsto [NormOneClass E]
       simp [this]
 
 /-- This theorem combines the results of the special cases above, using `ENNReal` division to remove
-the requirement that the ratio is eventually non-zero. -/
+the requirement that the ratio is eventually nonzero. -/
 theorem ofScalars_radius_eq_inv_of_tendsto_ENNReal [NormOneClass E] {r : ℝ≥0∞}
     (hc' : Tendsto (fun n ↦ ENNReal.ofReal ‖c n.succ‖ / ENNReal.ofReal ‖c n‖) atTop (𝓝 r)) :
       (ofScalars E c).radius = r⁻¹ := by

--- a/Mathlib/Analysis/Analytic/OfScalars.lean
+++ b/Mathlib/Analysis/Analytic/OfScalars.lean
@@ -216,7 +216,7 @@ theorem ofScalars_radius_ge_inv_of_tendsto {r : ℝ≥0} (hr : r ≠ 0)
     gcongr
     exact ofScalars_norm_le E c n (Nat.pos_iff_ne_zero.mpr hn)
 
-/-- The radius of convergence of a scalar series is the inverse of the non-zero limit
+/-- The radius of convergence of a scalar series is the inverse of the nonzero limit
 `fun n ↦ ‖c n.succ‖ / ‖c n‖`. -/
 theorem ofScalars_radius_eq_inv_of_tendsto [NormOneClass E] {r : ℝ≥0} (hr : r ≠ 0)
     (hc : Tendsto (fun n ↦ ‖c n.succ‖ / ‖c n‖) atTop (𝓝 r)) :
@@ -242,7 +242,7 @@ theorem ofScalars_radius_eq_of_tendsto [NormOneClass E] {r : NNReal} (hr : r ≠
   simp
 
 /-- The ratio test stating that if `‖c n.succ‖ / ‖c n‖` tends to zero, the radius is unbounded.
-This requires that the coefficients are eventually non-zero as
+This requires that the coefficients are eventually nonzero as
 `‖c n.succ‖ / 0 = 0` by convention. -/
 theorem ofScalars_radius_eq_top_of_tendsto (hc : ∀ᶠ n in atTop, c n ≠ 0)
     (hc' : Tendsto (fun n ↦ ‖c n.succ‖ / ‖c n‖) atTop (𝓝 0)) : (ofScalars E c).radius = ⊤ := by

--- a/Mathlib/Analysis/Asymptotics/LinearGrowth.lean
+++ b/Mathlib/Analysis/Asymptotics/LinearGrowth.lean
@@ -540,7 +540,7 @@ lemma _root_.Monotone.linearGrowthInf_comp {a : EReal} (h : Monotone u)
     rw [← hv.liminf_eq] at ha
     exact ha.symm.lt_of_le (linearGrowthInf_natCast_nonneg v)
   have v_top := tendsto_atTop_of_linearGrowthInf_natCast_pos hv₁.ne.symm
-  -- Either `u = 0`, or `u` is non-zero and bounded by `1`, or `u` is eventually larger than one.
+  -- Either `u = 0`, or `u` is nonzero and bounded by `1`, or `u` is eventually larger than one.
   -- In the latter case, we apply `le_linearGrowthInf_comp` and `linearGrowthInf_comp_le`.
   by_cases u_0 : u = ⊥
   · rw [u_0, Pi.bot_comp, linearGrowthInf_bot, ← hv.liminf_eq, mul_bot_of_pos hv₁]
@@ -569,7 +569,7 @@ lemma _root_.Monotone.linearGrowthSup_comp {a : EReal} (h : Monotone u)
     rw [← hv.liminf_eq] at ha
     exact ha.symm.lt_of_le (linearGrowthInf_natCast_nonneg v)
   have v_top := tendsto_atTop_of_linearGrowthInf_natCast_pos hv₁.ne.symm
-  -- Either `u = 0`, or `u` is non-zero and bounded by `1`, or `u` is eventually larger than one.
+  -- Either `u = 0`, or `u` is nonzero and bounded by `1`, or `u` is eventually larger than one.
   -- In the latter case, we apply `le_linearGrowthSup_comp` and `linearGrowthSup_comp_le`.
   by_cases u_0 : u = ⊥
   · rw [u_0, Pi.bot_comp, linearGrowthSup_bot, ← hv.liminf_eq, mul_bot_of_pos hv₁]

--- a/Mathlib/Analysis/Calculus/FormalMultilinearSeries.lean
+++ b/Mathlib/Analysis/Calculus/FormalMultilinearSeries.lean
@@ -253,7 +253,7 @@ variable [Semiring 𝕜] {n : ℕ} [AddCommMonoid E] [Module 𝕜 E] [Topologica
   [TopologicalSpace F] [ContinuousAdd F] [ContinuousConstSMul 𝕜 F]
   {p : FormalMultilinearSeries 𝕜 E F}
 
-/-- The index of the first non-zero coefficient in `p` (or `0` if all coefficients are zero). This
+/-- The index of the first nonzero coefficient in `p` (or `0` if all coefficients are zero). This
   is the order of the isolated zero of an analytic function `f` at a point if `p` is the Taylor
   series of `f` at that point. -/
 noncomputable def order (p : FormalMultilinearSeries 𝕜 E F) : ℕ :=

--- a/Mathlib/Analysis/Calculus/InverseFunctionTheorem/Deriv.lean
+++ b/Mathlib/Analysis/Calculus/InverseFunctionTheorem/Deriv.lean
@@ -45,7 +45,7 @@ end HasStrictDerivAt
 
 variable {f}
 
-/-- If a function has a non-zero strict derivative at all points, then it is an open map. -/
+/-- If a function has a nonzero strict derivative at all points, then it is an open map. -/
 theorem isOpenMap_of_hasStrictDerivAt {f' : 𝕜 → 𝕜}
     (hf : ∀ x, HasStrictDerivAt f (f' x) x) (h0 : ∀ x, f' x ≠ 0) : IsOpenMap f :=
   isOpenMap_iff_nhds_le.2 fun x => ((hf x).map_nhds_eq (h0 x)).ge

--- a/Mathlib/Analysis/Complex/Angle.lean
+++ b/Mathlib/Analysis/Complex/Angle.lean
@@ -30,7 +30,7 @@ open scoped Real
 namespace Complex
 variable {a x y : ℂ}
 
-/-- The angle between two non-zero complex numbers is the absolute value of the argument of their
+/-- The angle between two nonzero complex numbers is the absolute value of the argument of their
 quotient.
 
 Note that this does not hold when `x` or `y` is `0` as the LHS is `π / 2` while the RHS is `0`. -/

--- a/Mathlib/Analysis/Complex/Basic.lean
+++ b/Mathlib/Analysis/Complex/Basic.lean
@@ -582,7 +582,7 @@ def slitPlane : Set ℂ := {z | 0 < z.re ∨ z.im ≠ 0}
 
 lemma mem_slitPlane_iff {z : ℂ} : z ∈ slitPlane ↔ 0 < z.re ∨ z.im ≠ 0 := Set.mem_setOf
 
-/- If `z` is non-zero, then either `z` or `-z` is in `slitPlane`. -/
+/- If `z` is nonzero, then either `z` or `-z` is in `slitPlane`. -/
 lemma mem_slitPlane_or_neg_mem_slitPlane {z : ℂ} (hz : z ≠ 0) :
     z ∈ slitPlane ∨ -z ∈ slitPlane := by
   rw [mem_slitPlane_iff, mem_slitPlane_iff]

--- a/Mathlib/Analysis/Convex/Integral.lean
+++ b/Mathlib/Analysis/Convex/Integral.lean
@@ -78,14 +78,14 @@ theorem Convex.integral_mem [IsProbabilityMeasure μ] (hs : Convex ℝ s) (hsc :
     apply (range g).inter_subset_right
     exact SimpleFunc.approxOn_mem hgm.measurable h₀ _ _
 
-/-- If `μ` is a non-zero finite measure on `α`, `s` is a convex closed set in `E`, and `f` is an
+/-- If `μ` is a nonzero finite measure on `α`, `s` is a convex closed set in `E`, and `f` is an
 integrable function sending `μ`-a.e. points to `s`, then the average value of `f` belongs to `s`:
 `⨍ x, f x ∂μ ∈ s`. See also `Convex.centerMass_mem` for a finite sum version of this lemma. -/
 theorem Convex.average_mem [IsFiniteMeasure μ] [NeZero μ] (hs : Convex ℝ s) (hsc : IsClosed s)
     (hfs : ∀ᵐ x ∂μ, f x ∈ s) (hfi : Integrable f μ) : (⨍ x, f x ∂μ) ∈ s :=
   hs.integral_mem hsc (ae_mono' smul_absolutelyContinuous hfs) hfi.to_average
 
-/-- If `μ` is a non-zero finite measure on `α`, `s` is a convex closed set in `E`, and `f` is an
+/-- If `μ` is a nonzero finite measure on `α`, `s` is a convex closed set in `E`, and `f` is an
 integrable function sending `μ`-a.e. points to `s`, then the average value of `f` belongs to `s`:
 `⨍ x, f x ∂μ ∈ s`. See also `Convex.centerMass_mem` for a finite sum version of this lemma. -/
 theorem Convex.set_average_mem (hs : Convex ℝ s) (hsc : IsClosed s) (h0 : μ t ≠ 0) (ht : μ t ≠ ∞)
@@ -94,7 +94,7 @@ theorem Convex.set_average_mem (hs : Convex ℝ s) (hsc : IsClosed s) (h0 : μ t
   have := NeZero.mk h0
   hs.average_mem hsc hfs hfi
 
-/-- If `μ` is a non-zero finite measure on `α`, `s` is a convex set in `E`, and `f` is an integrable
+/-- If `μ` is a nonzero finite measure on `α`, `s` is a convex set in `E`, and `f` is an integrable
 function sending `μ`-a.e. points to `s`, then the average value of `f` belongs to `closure s`:
 `⨍ x, f x ∂μ ∈ s`. See also `Convex.centerMass_mem` for a finite sum version of this lemma. -/
 theorem Convex.set_average_mem_closure (hs : Convex ℝ s) (h0 : μ t ≠ 0) (ht : μ t ≠ ∞)
@@ -119,7 +119,7 @@ theorem ConcaveOn.average_mem_hypograph [IsFiniteMeasure μ] [NeZero μ] (hg : C
     hg.neg.average_mem_epigraph hgc.neg hsc hfs hfi hgi.neg
 
 /-- **Jensen's inequality**: if a function `g : E → ℝ` is convex and continuous on a convex closed
-set `s`, `μ` is a finite non-zero measure on `α`, and `f : α → E` is a function sending
+set `s`, `μ` is a finite nonzero measure on `α`, and `f : α → E` is a function sending
 `μ`-a.e. points to `s`, then the value of `g` at the average value of `f` is less than or equal to
 the average value of `g ∘ f` provided that both `f` and `g ∘ f` are integrable. See also
 `ConvexOn.map_centerMass_le` for a finite sum version of this lemma. -/
@@ -130,7 +130,7 @@ theorem ConvexOn.map_average_le [IsFiniteMeasure μ] [NeZero μ]
   (hg.average_mem_epigraph hgc hsc hfs hfi hgi).2
 
 /-- **Jensen's inequality**: if a function `g : E → ℝ` is concave and continuous on a convex closed
-set `s`, `μ` is a finite non-zero measure on `α`, and `f : α → E` is a function sending
+set `s`, `μ` is a finite nonzero measure on `α`, and `f : α → E` is a function sending
 `μ`-a.e. points to `s`, then the average value of `g ∘ f` is less than or equal to the value of `g`
 at the average value of `f` provided that both `f` and `g ∘ f` are integrable. See also
 `ConcaveOn.le_map_centerMass` for a finite sum version of this lemma. -/
@@ -141,7 +141,7 @@ theorem ConcaveOn.le_map_average [IsFiniteMeasure μ] [NeZero μ]
   (hg.average_mem_hypograph hgc hsc hfs hfi hgi).2
 
 /-- **Jensen's inequality**: if a function `g : E → ℝ` is convex and continuous on a convex closed
-set `s`, `μ` is a finite non-zero measure on `α`, and `f : α → E` is a function sending
+set `s`, `μ` is a finite nonzero measure on `α`, and `f : α → E` is a function sending
 `μ`-a.e. points of a set `t` to `s`, then the value of `g` at the average value of `f` over `t` is
 less than or equal to the average value of `g ∘ f` over `t` provided that both `f` and `g ∘ f` are
 integrable. -/
@@ -154,7 +154,7 @@ theorem ConvexOn.set_average_mem_epigraph (hg : ConvexOn ℝ s g) (hgc : Continu
   hg.average_mem_epigraph hgc hsc hfs hfi hgi
 
 /-- **Jensen's inequality**: if a function `g : E → ℝ` is concave and continuous on a convex closed
-set `s`, `μ` is a finite non-zero measure on `α`, and `f : α → E` is a function sending
+set `s`, `μ` is a finite nonzero measure on `α`, and `f : α → E` is a function sending
 `μ`-a.e. points of a set `t` to `s`, then the average value of `g ∘ f` over `t` is less than or
 equal to the value of `g` at the average value of `f` over `t` provided that both `f` and `g ∘ f`
 are integrable. -/
@@ -166,7 +166,7 @@ theorem ConcaveOn.set_average_mem_hypograph (hg : ConcaveOn ℝ s g) (hgc : Cont
     hg.neg.set_average_mem_epigraph hgc.neg hsc h0 ht hfs hfi hgi.neg
 
 /-- **Jensen's inequality**: if a function `g : E → ℝ` is convex and continuous on a convex closed
-set `s`, `μ` is a finite non-zero measure on `α`, and `f : α → E` is a function sending
+set `s`, `μ` is a finite nonzero measure on `α`, and `f : α → E` is a function sending
 `μ`-a.e. points of a set `t` to `s`, then the value of `g` at the average value of `f` over `t` is
 less than or equal to the average value of `g ∘ f` over `t` provided that both `f` and `g ∘ f` are
 integrable. -/
@@ -177,7 +177,7 @@ theorem ConvexOn.map_set_average_le (hg : ConvexOn ℝ s g) (hgc : ContinuousOn 
   (hg.set_average_mem_epigraph hgc hsc h0 ht hfs hfi hgi).2
 
 /-- **Jensen's inequality**: if a function `g : E → ℝ` is concave and continuous on a convex closed
-set `s`, `μ` is a finite non-zero measure on `α`, and `f : α → E` is a function sending
+set `s`, `μ` is a finite nonzero measure on `α`, and `f : α → E` is a function sending
 `μ`-a.e. points of a set `t` to `s`, then the average value of `g ∘ f` over `t` is less than or
 equal to the value of `g` at the average value of `f` over `t` provided that both `f` and `g ∘ f`
 are integrable. -/

--- a/Mathlib/Analysis/InnerProductSpace/GramSchmidtOrtho.lean
+++ b/Mathlib/Analysis/InnerProductSpace/GramSchmidtOrtho.lean
@@ -22,7 +22,7 @@ and outputs a set of orthogonal vectors which have the same span.
 - `gramSchmidt_linearIndependent`: if the input vectors of `gramSchmidt` are linearly independent,
   then so are the output vectors.
 - `gramSchmidt_ne_zero`: if the input vectors of `gramSchmidt` are linearly independent,
-  then the output vectors are non-zero.
+  then the output vectors are nonzero.
 - `gramSchmidtBasis`: the basis produced by the Gram-Schmidt process when given a basis as input
 - `gramSchmidtNormed`:
   the normalized `gramSchmidt` process, i.e each vector in `gramSchmidtNormed` has unit length
@@ -201,7 +201,7 @@ theorem gramSchmidt_ne_zero_coe {f : ι → E} (n : ι)
   simp only [Set.mem_Iio, lt_self_iff_false, not_false_iff]
 
 /-- If the input vectors of `gramSchmidt` are linearly independent,
-then the output vectors are non-zero. -/
+then the output vectors are nonzero. -/
 theorem gramSchmidt_ne_zero {f : ι → E} (n : ι) (h₀ : LinearIndependent 𝕜 f) :
     gramSchmidt 𝕜 f n ≠ 0 :=
   gramSchmidt_ne_zero_coe _ (LinearIndependent.comp h₀ _ Subtype.coe_injective)

--- a/Mathlib/Analysis/MeanInequalities.lean
+++ b/Mathlib/Analysis/MeanInequalities.lean
@@ -126,14 +126,14 @@ version for real-valued nonnegative functions. -/
 theorem geom_mean_le_arith_mean_weighted (w z : ι → ℝ) (hw : ∀ i ∈ s, 0 ≤ w i)
     (hw' : ∑ i ∈ s, w i = 1) (hz : ∀ i ∈ s, 0 ≤ z i) :
     ∏ i ∈ s, z i ^ w i ≤ ∑ i ∈ s, w i * z i := by
-  -- If some number `z i` equals zero and has non-zero weight, then LHS is 0 and RHS is nonnegative.
+  -- If some number `z i` equals zero and has nonzero weight, then LHS is 0 and RHS is nonnegative.
   by_cases A : ∃ i ∈ s, z i = 0 ∧ w i ≠ 0
   · rcases A with ⟨i, his, hzi, hwi⟩
     rw [prod_eq_zero his]
     · exact sum_nonneg fun j hj => mul_nonneg (hw j hj) (hz j hj)
     · rw [hzi]
       exact zero_rpow hwi
-  -- If all numbers `z i` with non-zero weight are positive, then we apply Jensen's inequality
+  -- If all numbers `z i` with nonzero weight are positive, then we apply Jensen's inequality
   -- for `exp` and numbers `log (z i)` with weights `w i`.
   · simp only [not_exists, not_and, Ne, Classical.not_not] at A
     have := convexOn_exp.map_sum_le hw hw' fun i _ => Set.mem_univ <| log (z i)

--- a/Mathlib/Analysis/Meromorphic/FactorizedRational.lean
+++ b/Mathlib/Analysis/Meromorphic/FactorizedRational.lean
@@ -85,7 +85,7 @@ theorem analyticAt {d : 𝕜 → ℤ} {x : 𝕜} (h : 0 ≤ d x) :
     rwa [sub_ne_zero]
 
 /--
-Factorized rational functions are non-zero wherever the exponent is zero.
+Factorized rational functions are nonzero wherever the exponent is zero.
 -/
 theorem ne_zero {d : 𝕜 → ℤ} {x : 𝕜} (h : d x = 0) :
     (∏ᶠ u, (· - u) ^ d u) x ≠ 0 := by

--- a/Mathlib/Analysis/Normed/Group/Basic.lean
+++ b/Mathlib/Analysis/Normed/Group/Basic.lean
@@ -1405,7 +1405,7 @@ def evalMulNorm : PositivityExt where eval {u α} _ _ e := do
   | _, _, _ => throwError "not `‖·‖`"
 
 /-- Extension for the `positivity` tactic: additive norms are always nonnegative, and positive
-on non-zero inputs. -/
+on nonzero inputs. -/
 @[positivity ‖_‖]
 def evalAddNorm : PositivityExt where eval {u α} _ _ e := do
   match u, α, e with

--- a/Mathlib/Analysis/NormedSpace/ENormedSpace.lean
+++ b/Mathlib/Analysis/NormedSpace/ENormedSpace.lean
@@ -133,7 +133,7 @@ instance partialOrder : PartialOrder (ENormedSpace 𝕜 V) where
   le_trans _ _ _ h₁₂ h₂₃ x := le_trans (h₁₂ x) (h₂₃ x)
   le_antisymm _ _ h₁₂ h₂₁ := ext fun x => le_antisymm (h₁₂ x) (h₂₁ x)
 
-/-- The `ENormedSpace` sending each non-zero vector to infinity. -/
+/-- The `ENormedSpace` sending each nonzero vector to infinity. -/
 noncomputable instance : Top (ENormedSpace 𝕜 V) :=
   ⟨{  toFun := fun x => open scoped Classical in if x = 0 then 0 else ⊤
       eq_zero' := fun x => by split_ifs <;> simp [*]

--- a/Mathlib/Analysis/SpecialFunctions/Complex/CircleAddChar.lean
+++ b/Mathlib/Analysis/SpecialFunctions/Complex/CircleAddChar.lean
@@ -12,7 +12,7 @@ import Mathlib.Topology.Instances.AddCircle.Real
 # Additive characters valued in the unit circle
 
 This file defines additive characters, valued in the unit circle, from either
-* the ring `ZMod N` for any non-zero natural `N`,
+* the ring `ZMod N` for any nonzero natural `N`,
 * the additive circle `ℝ / T ⬝ ℤ`, for any real `T`.
 
 These results are separate from `Analysis.SpecialFunctions.Complex.Circle` in order to reduce

--- a/Mathlib/CategoryTheory/Galois/Basic.lean
+++ b/Mathlib/CategoryTheory/Galois/Basic.lean
@@ -368,7 +368,7 @@ lemma lt_card_fiber_of_mono_of_notIso {X Y : C} (f : X ⟶ Y) [Mono f]
   exact Nat.le_antisymm
     (Finite.card_le_of_injective (F.map f) (injective_of_mono_of_preservesPullback (F.map f))) hlt
 
-/-- The cardinality of the fiber of a not-initial object is non-zero. -/
+/-- The cardinality of the fiber of a not-initial object is nonzero. -/
 lemma non_zero_card_fiber_of_not_initial (X : C) (h : IsInitial X → False) :
     Nat.card (F.obj X) ≠ 0 := by
   intro hzero

--- a/Mathlib/CategoryTheory/Subobject/ArtinianObject.lean
+++ b/Mathlib/CategoryTheory/Subobject/ArtinianObject.lean
@@ -140,11 +140,11 @@ theorem exists_simple_subobject {X : C} [IsArtinianObject X] (h : ¬IsZero X) :
   obtain ⟨Y, s⟩ := (IsAtomic.eq_bot_or_exists_atom_le (⊤ : Subobject X)).resolve_left top_ne_bot
   exact ⟨Y, (subobject_simple_iff_isAtom _).mpr s.1⟩
 
-/-- Choose an arbitrary simple subobject of a non-zero Artinian object. -/
+/-- Choose an arbitrary simple subobject of a nonzero Artinian object. -/
 noncomputable def simpleSubobject {X : C} [IsArtinianObject X] (h : ¬IsZero X) : C :=
   (exists_simple_subobject h).choose
 
-/-- The monomorphism from the arbitrary simple subobject of a non-zero Artinian object. -/
+/-- The monomorphism from the arbitrary simple subobject of a nonzero Artinian object. -/
 noncomputable def simpleSubobjectArrow {X : C} [IsArtinianObject X] (h : ¬IsZero X) :
     simpleSubobject h ⟶ X :=
   (exists_simple_subobject h).choose.arrow

--- a/Mathlib/Combinatorics/SimpleGraph/Girth.lean
+++ b/Mathlib/Combinatorics/SimpleGraph/Girth.lean
@@ -15,7 +15,7 @@ cycle, they give `0` or `∞` respectively if the graph is acyclic.
 ## TODO
 
 - Prove that `G.egirth ≤ 2 * G.ediam + 1` and `G.girth ≤ 2 * G.diam + 1` when the diameter is
-  non-zero.
+  nonzero.
 
 -/
 

--- a/Mathlib/Data/DFinsupp/Submonoid.lean
+++ b/Mathlib/Data/DFinsupp/Submonoid.lean
@@ -50,7 +50,7 @@ theorem dfinsuppSumAddHom_mem [∀ i, AddZeroClass (β i)] [AddCommMonoid γ] {S
 
 /-- The supremum of a family of commutative additive submonoids is equal to the range of
 `DFinsupp.sumAddHom`; that is, every element in the `iSup` can be produced from taking a finite
-number of non-zero elements of `S i`, coercing them to `γ`, and summing them. -/
+number of nonzero elements of `S i`, coercing them to `γ`, and summing them. -/
 theorem AddSubmonoid.iSup_eq_mrange_dfinsuppSumAddHom
     [AddCommMonoid γ] (S : ι → AddSubmonoid γ) :
     iSup S = AddMonoidHom.mrange (DFinsupp.sumAddHom fun i => (S i).subtype) := by
@@ -63,7 +63,7 @@ theorem AddSubmonoid.iSup_eq_mrange_dfinsuppSumAddHom
 
 /-- The bounded supremum of a family of commutative additive submonoids is equal to the range of
 `DFinsupp.sumAddHom` composed with `DFinsupp.filterAddMonoidHom`; that is, every element in the
-bounded `iSup` can be produced from taking a finite number of non-zero elements from the `S i` that
+bounded `iSup` can be produced from taking a finite number of nonzero elements from the `S i` that
 satisfy `p i`, coercing them to `γ`, and summing them. -/
 theorem AddSubmonoid.bsupr_eq_mrange_dfinsuppSumAddHom (p : ι → Prop) [DecidablePred p]
     [AddCommMonoid γ] (S : ι → AddSubmonoid γ) :

--- a/Mathlib/Data/Fin/Basic.lean
+++ b/Mathlib/Data/Fin/Basic.lean
@@ -369,7 +369,7 @@ whose value is the original number. -/
 theorem val_cast_of_lt {n : ℕ} [NeZero n] {a : ℕ} (h : a < n) : (a : Fin n).val = a :=
   Nat.mod_eq_of_lt h
 
-/-- If `n` is non-zero, converting the value of a `Fin n` to `Fin n` results
+/-- If `n` is nonzero, converting the value of a `Fin n` to `Fin n` results
 in the same value. -/
 @[simp, norm_cast] theorem cast_val_eq_self {n : ℕ} [NeZero n] (a : Fin n) : (a.val : Fin n) = a :=
   Fin.ext <| val_cast_of_lt a.isLt

--- a/Mathlib/Data/Finsupp/Basic.lean
+++ b/Mathlib/Data/Finsupp/Basic.lean
@@ -13,7 +13,7 @@ import Mathlib.Data.Rat.BigOperators
 
 ## Main declarations
 
-* `Finsupp.graph`: the finset of input and output pairs with non-zero outputs.
+* `Finsupp.graph`: the finset of input and output pairs with nonzero outputs.
 * `Finsupp.mapRange.equiv`: `Finsupp.mapRange` as an equiv.
 * `Finsupp.mapDomain`: maps the domain of a `Finsupp` by a function and by summing.
 * `Finsupp.comapDomain`: postcomposition of a `Finsupp` with a function injective on the preimage
@@ -50,7 +50,7 @@ section Graph
 variable [Zero M]
 
 /-- The graph of a finitely supported function over its support, i.e. the finset of input and output
-pairs with non-zero outputs. -/
+pairs with nonzero outputs. -/
 def graph (f : α →₀ M) : Finset (α × M) :=
   f.support.map ⟨fun a => Prod.mk a (f a), fun _ _ h => (Prod.mk.inj h).1⟩
 

--- a/Mathlib/Data/Int/Log.lean
+++ b/Mathlib/Data/Int/Log.lean
@@ -14,7 +14,7 @@ This file defines two `ℤ`-valued analogs of the logarithm of `r : R` with base
 * `Int.log b r`: Lower logarithm, or floor **log**. Greatest `k` such that `↑b^k ≤ r`.
 * `Int.clog b r`: Upper logarithm, or **c**eil **log**. Least `k` such that `r ≤ ↑b^k`.
 
-Note that `Int.log` gives the position of the left-most non-zero digit:
+Note that `Int.log` gives the position of the left-most nonzero digit:
 ```lean
 #eval (Int.log 10 (0.09 : ℚ), Int.log 10 (0.10 : ℚ), Int.log 10 (0.11 : ℚ))
 --    (-2,                    -1,                    -1)

--- a/Mathlib/Data/List/ToFinsupp.lean
+++ b/Mathlib/Data/List/ToFinsupp.lean
@@ -40,7 +40,7 @@ variable {M : Type*} [Zero M] (l : List M) [DecidablePred (getD l · 0 ≠ 0)] (
 
 /-- Indexing into a `l : List M`, as a finitely-supported function,
 where the support are all the indices within the length of the list
-that index to a non-zero value. Indices beyond the end of the list are sent to 0.
+that index to a nonzero value. Indices beyond the end of the list are sent to 0.
 
 This is a computable version of the `Finsupp.onFinset` construction.
 -/

--- a/Mathlib/Data/Matrix/Basis.lean
+++ b/Mathlib/Data/Matrix/Basis.lean
@@ -6,7 +6,7 @@ Authors: Jalex Stark, Kim Morrison, Eric Wieser, Oliver Nash, Wen Yang
 import Mathlib.Data.Matrix.Basic
 
 /-!
-# Matrices with a single non-zero element.
+# Matrices with a single nonzero element.
 
 This file provides `Matrix.single`. The matrix `Matrix.single i j c` has `c`
 at position `(i, j)`, and zeroes elsewhere.

--- a/Mathlib/Data/Matrix/Rank.lean
+++ b/Mathlib/Data/Matrix/Rank.lean
@@ -317,7 +317,7 @@ section Field
 
 variable [Field R]
 
-/-- The rank of a diagonal matrix is the count of non-zero elements on its main diagonal -/
+/-- The rank of a diagonal matrix is the count of nonzero elements on its main diagonal -/
 theorem rank_diagonal [Fintype m] [DecidableEq m] [DecidableEq R] (w : m → R) :
     (diagonal w).rank = Fintype.card {i // (w i) ≠ 0} := by
   rw [Matrix.rank, ← Matrix.toLin'_apply', Module.finrank, ← LinearMap.rank,

--- a/Mathlib/Data/Nat/Digits/Lemmas.lean
+++ b/Mathlib/Data/Nat/Digits/Lemmas.lean
@@ -133,7 +133,7 @@ theorem pow_length_le_mul_ofDigits {b : ℕ} {l : List ℕ} (hl : l ≠ []) (hl2
   convert Nat.mul_le_mul_left ((b + 2) ^ (l.length - 1)) this using 1
   rw [Nat.mul_one]
 
-/-- Any non-zero natural number `m` is greater than
+/-- Any nonzero natural number `m` is greater than
 (b+2)^((number of digits in the base (b+2) representation of m) - 1)
 -/
 theorem base_pow_length_digits_le' (b m : ℕ) (hm : m ≠ 0) :
@@ -143,7 +143,7 @@ theorem base_pow_length_digits_le' (b m : ℕ) (hm : m ≠ 0) :
     this (getLast_digit_ne_zero _ hm)
   rw [ofDigits_digits]
 
-/-- Any non-zero natural number `m` is greater than
+/-- Any nonzero natural number `m` is greater than
 b^((number of digits in the base b representation of m) - 1)
 -/
 theorem base_pow_length_digits_le (b m : ℕ) (hb : 1 < b) :

--- a/Mathlib/Data/Nat/Factorization/Defs.lean
+++ b/Mathlib/Data/Nat/Factorization/Defs.lean
@@ -162,7 +162,7 @@ theorem factorization_le_iff_dvd {d n : ℕ} (hd : d ≠ 0) (hn : n ≠ 0) :
     rw [factorization_mul hd (right_ne_zero_of_mul hn)]
     simp
 
-/-- For any `p : ℕ` and any function `g : α → ℕ` that's non-zero on `S : Finset α`,
+/-- For any `p : ℕ` and any function `g : α → ℕ` that's nonzero on `S : Finset α`,
 the power of `p` in `S.prod g` equals the sum over `x ∈ S` of the powers of `p` in `g x`.
 Generalises `factorization_mul`, which is the special case where `#S = 2` and `g = id`. -/
 theorem factorization_prod {α : Type*} {S : Finset α} {g : α → ℕ} (hS : ∀ x ∈ S, g x ≠ 0) :

--- a/Mathlib/Data/Nat/Init.lean
+++ b/Mathlib/Data/Nat/Init.lean
@@ -18,7 +18,7 @@ import Mathlib.Util.AssertExists
 This file contains:
 * some basic lemmas about natural numbers
 * extra recursors:
-  * `leRecOn`, `le_induction`: recursion and induction principles starting at non-zero numbers
+  * `leRecOn`, `le_induction`: recursion and induction principles starting at nonzero numbers
   * `decreasing_induction`: recursion growing downwards
   * `le_rec_on'`, `decreasing_induction'`: versions with slightly weaker assumptions
   * `strong_rec'`: recursion based on strong inequalities
@@ -141,7 +141,7 @@ lemma rec_add_one {C : ℕ → Sort*} (h0 : C 0) (h : ∀ n, C n → C (n + 1)) 
 @[simp] lemma rec_one {C : ℕ → Sort*} (h0 : C 0) (h : ∀ n, C n → C (n + 1)) :
     Nat.rec (motive := C) h0 h 1 = h 0 h0 := rfl
 
-/-- Recursion starting at a non-zero number: given a map `C k → C (k+1)` for each `k ≥ n`,
+/-- Recursion starting at a nonzero number: given a map `C k → C (k+1)` for each `k ≥ n`,
 there is a map from `C n` to each `C m`, `n ≤ m`.
 
 This is a version of `Nat.le.rec` that works for `Sort u`.
@@ -208,7 +208,7 @@ lemma leRec_succ_left {motive : (m : ℕ) → n ≤ m → Sort*}
       leRec (motive := motive) refl le_succ_of_le h1 := by
   rw [leRec_trans _ _ (le_succ n) h2, leRec_succ']
 
-/-- Recursion starting at a non-zero number: given a map `C k → C (k + 1)` for each `k`,
+/-- Recursion starting at a nonzero number: given a map `C k → C (k + 1)` for each `k`,
 there is a map from `C n` to each `C m`, `n ≤ m`. For a version where the assumption is only made
 when `k ≥ n`, see `Nat.leRec`. -/
 @[elab_as_elim]
@@ -251,7 +251,7 @@ lemma strongRecOn'_beta {P : ℕ → Sort*} {h} :
     (strongRecOn' n h : P n) = h n fun m _ ↦ (strongRecOn' m h : P m) := by
   simp only [strongRecOn']; rw [Nat.strongRec']
 
-/-- Induction principle starting at a non-zero number.
+/-- Induction principle starting at a nonzero number.
 To use in an induction proof, the syntax is `induction n, hn using Nat.le_induction` (or the same
 for `induction'`).
 

--- a/Mathlib/Data/ZMod/Basic.lean
+++ b/Mathlib/Data/ZMod/Basic.lean
@@ -38,7 +38,7 @@ namespace ZMod
 
 instance : IsDomain (ZMod 0) := inferInstanceAs (IsDomain ℤ)
 
-/-- For non-zero `n : ℕ`, the ring `Fin n` is equivalent to `ZMod n`. -/
+/-- For nonzero `n : ℕ`, the ring `Fin n` is equivalent to `ZMod n`. -/
 def finEquiv : ∀ (n : ℕ) [NeZero n], Fin n ≃+* ZMod n
   | 0, h => (h.ne _ rfl).elim
   | _ + 1, _ => .refl _

--- a/Mathlib/Dynamics/Ergodic/Conservative.lean
+++ b/Mathlib/Dynamics/Ergodic/Conservative.lean
@@ -51,7 +51,7 @@ open Measure
 returns back to `s` under some iteration of `f`. -/
 structure Conservative (f : α → α) (μ : Measure α) : Prop extends QuasiMeasurePreserving f μ μ where
   /-- If `f` is a conservative self-map and `s` is a measurable set of nonzero measure,
-  then there exists a point `x ∈ s` that returns to `s` under a non-zero iteration of `f`. -/
+  then there exists a point `x ∈ s` that returns to `s` under a nonzero iteration of `f`. -/
   exists_mem_iterate_mem' : ∀ ⦃s⦄, MeasurableSet s → μ s ≠ 0 → ∃ x ∈ s, ∃ m ≠ 0, f^[m] x ∈ s
 
 /-- A self-map preserving a finite measure is conservative. -/
@@ -88,7 +88,7 @@ theorem _root_.MeasureTheory.conservative_congr {ν : Measure α} (h : ae μ = a
   ⟨(congr_ae · h), (congr_ae · h.symm)⟩
 
 /-- If `f` is a conservative self-map and `s` is a null measurable set of nonzero measure,
-then there exists a point `x ∈ s` that returns to `s` under a non-zero iteration of `f`. -/
+then there exists a point `x ∈ s` that returns to `s` under a nonzero iteration of `f`. -/
 theorem exists_mem_iterate_mem (hf : Conservative f μ)
     (hsm : NullMeasurableSet s μ) (hs₀ : μ s ≠ 0) :
     ∃ x ∈ s, ∃ m ≠ 0, f^[m] x ∈ s := by

--- a/Mathlib/FieldTheory/Finite/Basic.lean
+++ b/Mathlib/FieldTheory/Finite/Basic.lean
@@ -794,7 +794,7 @@ theorem unit_isSquare_iff (hF : ringChar F ≠ 2) (a : Fˣ) :
       dsimp
       rw [mul_comm, pow_mul, pow_two]
 
-/-- A non-zero `a : F` is a square if and only if `a ^ (#F / 2) = 1`. -/
+/-- A nonzero `a : F` is a square if and only if `a ^ (#F / 2) = 1`. -/
 theorem isSquare_iff (hF : ringChar F ≠ 2) {a : F} (ha : a ≠ 0) :
     IsSquare a ↔ a ^ (Fintype.card F / 2) = 1 := by
   apply

--- a/Mathlib/FieldTheory/JacobsonNoether.lean
+++ b/Mathlib/FieldTheory/JacobsonNoether.lean
@@ -132,7 +132,7 @@ theorem exists_separable_and_not_isCentral (H : k ≠ (⊤ : Subring D)) :
         rwa [h_find]
       rw [not_lt, Nat.le_zero, ht, Nat.sub_eq_zero_iff_le] at h_pos
       linarith [(Nat.find_spec h_exist).1]
-  -- We define `c` to be the value that we proved above to be non-zero.
+  -- We define `c` to be the value that we proved above to be nonzero.
   set c := (ad k D a)^[n] b with hc_def
   let _ : Invertible c := ⟨c⁻¹, inv_mul_cancel₀ hb.1, mul_inv_cancel₀ hb.1⟩
   -- We prove that `c` commutes with `a`.

--- a/Mathlib/FieldTheory/Separable.lean
+++ b/Mathlib/FieldTheory/Separable.lean
@@ -451,7 +451,7 @@ theorem card_rootSet_eq_natDegree [Algebra F K] {p : F[X]} (hsep : p.Separable)
   simp_rw [rootSet_def, Finset.coe_sort_coe, Fintype.card_coe]
   rw [Multiset.toFinset_card_of_nodup (nodup_roots hsep.map), ← natDegree_eq_card_roots hsplit]
 
-/-- If a non-zero polynomial splits, then it has no repeated roots on that field
+/-- If a nonzero polynomial splits, then it has no repeated roots on that field
 if and only if it is separable. -/
 theorem nodup_roots_iff_of_splits {f : F[X]} (hf : f ≠ 0) (h : f.Splits (RingHom.id F)) :
     f.roots.Nodup ↔ f.Separable := by
@@ -463,7 +463,7 @@ theorem nodup_roots_iff_of_splits {f : F[X]} (hf : f ≠ 0) (h : f.Splits (RingH
   simp_rw [Multiset.nodup_iff_count_le_one, not_forall, not_le]
   exact ⟨x, ((one_lt_rootMultiplicity_iff_isRoot_gcd hf).2 hx).trans_eq f.count_roots.symm⟩
 
-/-- If a non-zero polynomial over `F` splits in `K`, then it has no repeated roots on `K`
+/-- If a nonzero polynomial over `F` splits in `K`, then it has no repeated roots on `K`
 if and only if it is separable. -/
 @[stacks 09H3 "Here we only require `f` splits instead of `K` is algebraically closed."]
 theorem nodup_aroots_iff_of_splits [Algebra F K] {f : F[X]} (hf : f ≠ 0)

--- a/Mathlib/FieldTheory/SeparableDegree.lean
+++ b/Mathlib/FieldTheory/SeparableDegree.lean
@@ -72,7 +72,7 @@ This file contains basics about the separable degree of a field extension.
 - `Polynomial.natSepDegree_le_natDegree`: the separable degree of a polynomial is smaller than
   its degree.
 
-- `Polynomial.natSepDegree_eq_natDegree_iff`: the separable degree of a non-zero polynomial is
+- `Polynomial.natSepDegree_eq_natDegree_iff`: the separable degree of a nonzero polynomial is
   equal to its degree if and only if it is separable.
 
 - `Polynomial.natSepDegree_eq_of_splits`: if a polynomial splits over `E`, then its separable degree
@@ -326,7 +326,7 @@ theorem natSepDegree_zero : (0 : F[X]).natSepDegree = 0 := by
 theorem natSepDegree_one : (1 : F[X]).natSepDegree = 0 := by
   rw [← C_1, natSepDegree_C]
 
-/-- A non-constant polynomial has non-zero separable degree. -/
+/-- A non-constant polynomial has nonzero separable degree. -/
 theorem natSepDegree_ne_zero (h : f.natDegree ≠ 0) : f.natSepDegree ≠ 0 := by
   rw [natSepDegree, ne_eq, Finset.card_eq_zero, ← ne_eq, ← Finset.nonempty_iff_ne_empty]
   use rootOfSplits _ (SplittingField.splits f) (ne_of_apply_ne _ h)
@@ -338,11 +338,11 @@ theorem natSepDegree_ne_zero (h : f.natDegree ≠ 0) : f.natSepDegree ≠ 0 := b
 theorem natSepDegree_eq_zero_iff : f.natSepDegree = 0 ↔ f.natDegree = 0 :=
   ⟨(natSepDegree_ne_zero f).mtr, natSepDegree_eq_zero f⟩
 
-/-- A polynomial has non-zero separable degree if and only if it is non-constant. -/
+/-- A polynomial has nonzero separable degree if and only if it is non-constant. -/
 theorem natSepDegree_ne_zero_iff : f.natSepDegree ≠ 0 ↔ f.natDegree ≠ 0 :=
   Iff.not <| natSepDegree_eq_zero_iff f
 
-/-- The separable degree of a non-zero polynomial is equal to its degree if and only if
+/-- The separable degree of a nonzero polynomial is equal to its degree if and only if
 it is separable. -/
 theorem natSepDegree_eq_natDegree_iff (hf : f ≠ 0) :
     f.natSepDegree = f.natDegree ↔ f.Separable := by
@@ -550,7 +550,7 @@ alias natSepDegree_eq_one_iff_of_irreducible' := Irreducible.natSepDegree_eq_one
 alias natSepDegree_eq_one_iff_of_irreducible := Irreducible.natSepDegree_eq_one_iff_of_monic
 
 /-- If a monic polynomial of separable degree one splits, then it is of form `(X - C y) ^ m` for
-some non-zero natural number `m` and some element `y` of `F`. -/
+some nonzero natural number `m` and some element `y` of `F`. -/
 theorem eq_X_sub_C_pow_of_natSepDegree_eq_one_of_splits (hm : f.Monic)
     (hs : f.Splits (RingHom.id F))
     (h : f.natSepDegree = 1) : ∃ (m : ℕ) (y : F), m ≠ 0 ∧ f = (X - C y) ^ m := by
@@ -581,7 +581,7 @@ theorem eq_X_pow_char_pow_sub_C_of_natSepDegree_eq_one_of_irreducible (q : ℕ) 
     exact not_irreducible_pow hq.ne_one hi
 
 /-- If a monic polynomial over a field `F` of exponential characteristic `q` has separable degree
-one, then it is of the form `(X ^ (q ^ n) - C y) ^ m` for some non-zero natural number `m`,
+one, then it is of the form `(X ^ (q ^ n) - C y) ^ m` for some nonzero natural number `m`,
 some natural number `n`, and some element `y` of `F`, such that either `n = 0` or `y` has no
 `q`-th root in `F`. -/
 theorem eq_X_pow_char_pow_sub_C_pow_of_natSepDegree_eq_one (q : ℕ) [ExpChar F q] (hm : f.Monic)
@@ -604,7 +604,7 @@ theorem eq_X_pow_char_pow_sub_C_pow_of_natSepDegree_eq_one (q : ℕ) [ExpChar F 
     mul_one, ← hp] using hf
 
 /-- A monic polynomial over a field `F` of exponential characteristic `q` has separable degree one
-if and only if it is of the form `(X ^ (q ^ n) - C y) ^ m` for some non-zero natural number `m`,
+if and only if it is of the form `(X ^ (q ^ n) - C y) ^ m` for some nonzero natural number `m`,
 some natural number `n`, and some element `y` of `F`. -/
 theorem natSepDegree_eq_one_iff (q : ℕ) [ExpChar F q] (hm : f.Monic) :
     f.natSepDegree = 1 ↔ ∃ (m n : ℕ) (y : F), m ≠ 0 ∧ f = (X ^ q ^ n - C y) ^ m := by

--- a/Mathlib/Geometry/Euclidean/Angle/Unoriented/Basic.lean
+++ b/Mathlib/Geometry/Euclidean/Angle/Unoriented/Basic.lean
@@ -217,7 +217,7 @@ theorem inner_eq_neg_mul_norm_of_angle_eq_pi {x y : V} (h : angle x y = π) :
 theorem inner_eq_mul_norm_of_angle_eq_zero {x y : V} (h : angle x y = 0) : ⟪x, y⟫ = ‖x‖ * ‖y‖ := by
   simp [← cos_angle_mul_norm_mul_norm, h]
 
-/-- The inner product of two non-zero vectors equals the negative product of their norms
+/-- The inner product of two nonzero vectors equals the negative product of their norms
 if and only if the angle between the two vectors is π. -/
 theorem inner_eq_neg_mul_norm_iff_angle_eq_pi {x y : V} (hx : x ≠ 0) (hy : y ≠ 0) :
     ⟪x, y⟫ = -(‖x‖ * ‖y‖) ↔ angle x y = π := by
@@ -225,7 +225,7 @@ theorem inner_eq_neg_mul_norm_iff_angle_eq_pi {x y : V} (hx : x ≠ 0) (hy : y �
   have h₁ : ‖x‖ * ‖y‖ ≠ 0 := (mul_pos (norm_pos_iff.mpr hx) (norm_pos_iff.mpr hy)).ne'
   rw [angle, h, neg_div, div_self h₁, Real.arccos_neg_one]
 
-/-- The inner product of two non-zero vectors equals the product of their norms
+/-- The inner product of two nonzero vectors equals the product of their norms
 if and only if the angle between the two vectors is 0. -/
 theorem inner_eq_mul_norm_iff_angle_eq_zero {x y : V} (hx : x ≠ 0) (hy : y ≠ 0) :
     ⟪x, y⟫ = ‖x‖ * ‖y‖ ↔ angle x y = 0 := by
@@ -257,7 +257,7 @@ theorem norm_sub_eq_abs_sub_norm_of_angle_eq_zero {x y : V} (h : angle x y = 0) 
     inner_eq_mul_norm_of_angle_eq_zero h, sq_abs (‖x‖ - ‖y‖)]
   ring
 
-/-- The norm of the difference of two non-zero vectors equals the sum of their norms
+/-- The norm of the difference of two nonzero vectors equals the sum of their norms
 if and only the angle between the two vectors is π. -/
 theorem norm_sub_eq_add_norm_iff_angle_eq_pi {x y : V} (hx : x ≠ 0) (hy : y ≠ 0) :
     ‖x - y‖ = ‖x‖ + ‖y‖ ↔ angle x y = π := by
@@ -269,7 +269,7 @@ theorem norm_sub_eq_add_norm_iff_angle_eq_pi {x y : V} (hx : x ≠ 0) (hy : y �
     ⟪x, y⟫ = (‖x‖ ^ 2 + ‖y‖ ^ 2 - (‖x‖ + ‖y‖) ^ 2) / 2 := by linarith
     _ = -(‖x‖ * ‖y‖) := by ring
 
-/-- The norm of the sum of two non-zero vectors equals the sum of their norms
+/-- The norm of the sum of two nonzero vectors equals the sum of their norms
 if and only the angle between the two vectors is 0. -/
 theorem norm_add_eq_add_norm_iff_angle_eq_zero {x y : V} (hx : x ≠ 0) (hy : y ≠ 0) :
     ‖x + y‖ = ‖x‖ + ‖y‖ ↔ angle x y = 0 := by
@@ -281,7 +281,7 @@ theorem norm_add_eq_add_norm_iff_angle_eq_zero {x y : V} (hx : x ≠ 0) (hy : y 
     ⟪x, y⟫ = ((‖x‖ + ‖y‖) ^ 2 - ‖x‖ ^ 2 - ‖y‖ ^ 2) / 2 := by linarith
     _ = ‖x‖ * ‖y‖ := by ring
 
-/-- The norm of the difference of two non-zero vectors equals the absolute value
+/-- The norm of the difference of two nonzero vectors equals the absolute value
 of the difference of their norms if and only the angle between the two vectors is 0. -/
 theorem norm_sub_eq_abs_sub_norm_iff_angle_eq_zero {x y : V} (hx : x ≠ 0) (hy : y ≠ 0) :
     ‖x - y‖ = |‖x‖ - ‖y‖| ↔ angle x y = 0 := by

--- a/Mathlib/Geometry/Manifold/Algebra/LieGroup.lean
+++ b/Mathlib/Geometry/Manifold/Algebra/LieGroup.lean
@@ -195,9 +195,9 @@ instance instNormedSpaceLieAddGroup {𝕜 : Type*} [NontriviallyNormedField 𝕜
 
 /-! ## `C^n` manifolds with `C^n` inversion away from zero
 
-Typeclass for `C^n` manifolds with `0` and `Inv` such that inversion is `C^n` at all non-zero
+Typeclass for `C^n` manifolds with `0` and `Inv` such that inversion is `C^n` at all nonzero
 points. (This includes multiplicative Lie groups, but also complete normed semifields.)
-Point-wise inversion is `C^n` when the function/denominator is non-zero. -/
+Point-wise inversion is `C^n` when the function/denominator is nonzero. -/
 section ContMDiffInv₀
 
 -- See note [Design choices about smooth algebraic structures]
@@ -286,7 +286,7 @@ end ContMDiffInv₀
 /-! ### Point-wise division of `C^n` functions
 
 If `[ContMDiffMul I n N]` and `[ContMDiffInv₀ I n N]`, point-wise division of `C^n`
-functions `f : M → N` is `C^n` whenever the denominator is non-zero.
+functions `f : M → N` is `C^n` whenever the denominator is nonzero.
 (This includes `N` being a completely normed field.)
 -/
 section Div

--- a/Mathlib/Geometry/Manifold/Algebra/LieGroup.lean
+++ b/Mathlib/Geometry/Manifold/Algebra/LieGroup.lean
@@ -21,7 +21,7 @@ groups here are not necessarily finite dimensional.
 * `LieAddGroup I G` : a Lie additive group where `G` is a manifold on the model with corners `I`.
 * `LieGroup I G` : a Lie multiplicative group where `G` is a manifold on the model with corners `I`.
 * `ContMDiffInv₀`: typeclass for `C^n` manifolds with `0` and `Inv` such that inversion is `C^n`
-  map at each non-zero point. This includes complete normed fields and (multiplicative) Lie groups.
+  map at each nonzero point. This includes complete normed fields and (multiplicative) Lie groups.
 
 
 ## Main results

--- a/Mathlib/GroupTheory/GroupAction/Period.lean
+++ b/Mathlib/GroupTheory/GroupAction/Period.lean
@@ -52,9 +52,9 @@ theorem period_eq_one_iff {m : M} {a : α} : period m a = 1 ↔ m • a = a :=
     (period_le_of_fixed one_pos (by simpa))
     (period_pos_of_fixed one_pos (by simpa))⟩
 
-/-- For any non-zero `n` less than the period of `m` on `a`, `a` is moved by `m ^ n`. -/
+/-- For any nonzero `n` less than the period of `m` on `a`, `a` is moved by `m ^ n`. -/
 @[to_additive
-/-- For any non-zero `n` less than the period of `m` on `a`, `a` is moved by `n • m`. -/]
+/-- For any nonzero `n` less than the period of `m` on `a`, `a` is moved by `n • m`. -/]
 theorem pow_smul_ne_of_lt_period {m : M} {a : α} {n : ℕ} (n_pos : 0 < n)
     (n_lt_period : n < period m a) : m ^ n • a ≠ a := fun a_fixed =>
   not_le_of_gt n_lt_period <| period_le_of_fixed n_pos a_fixed

--- a/Mathlib/GroupTheory/GroupAction/SubMulAction.lean
+++ b/Mathlib/GroupTheory/GroupAction/SubMulAction.lean
@@ -510,7 +510,7 @@ namespace Units
 
 variable (R M : Type*) [Monoid R] [AddCommMonoid M] [DistribMulAction R M]
 
-/-- The non-zero elements of `M` are invariant under the action by the units of `R`. -/
+/-- The nonzero elements of `M` are invariant under the action by the units of `R`. -/
 def nonZeroSubMul : SubMulAction Rˣ M where
   carrier := { x : M | x ≠ 0 }
   smul_mem' := by simp [Units.smul_def]

--- a/Mathlib/InformationTheory/Hamming.lean
+++ b/Mathlib/InformationTheory/Hamming.lean
@@ -18,7 +18,7 @@ code.
 
 ## Main definitions
 * `hammingDist x y`: the Hamming distance between `x` and `y`, the number of entries which differ.
-* `hammingNorm x`: the Hamming norm of `x`, the number of non-zero entries.
+* `hammingNorm x`: the Hamming norm of `x`, the number of nonzero entries.
 * `Hamming β`: a type synonym for `Π i, β i` with `dist` and `norm` provided by the above.
 * `Hamming.toHamming`, `Hamming.ofHamming`: functions for casting between `Hamming β` and
   `Π i, β i`.

--- a/Mathlib/LinearAlgebra/AnnihilatingPolynomial.lean
+++ b/Mathlib/LinearAlgebra/AnnihilatingPolynomial.lean
@@ -107,7 +107,7 @@ theorem mem_iff_eq_smul_annIdealGenerator {p : 𝕜[X]} (a : A) :
     p ∈ annIdeal 𝕜 a ↔ ∃ s : 𝕜[X], p = s • annIdealGenerator 𝕜 a := by
   simp_rw [@eq_comm _ p, ← mem_span_singleton, ← span_singleton_annIdealGenerator 𝕜 a, Ideal.span]
 
-/-- The generator we chose for the annihilating ideal is monic when the ideal is non-zero. -/
+/-- The generator we chose for the annihilating ideal is monic when the ideal is nonzero. -/
 theorem monic_annIdealGenerator (a : A) (hg : annIdealGenerator 𝕜 a ≠ 0) :
     Monic (annIdealGenerator 𝕜 a) :=
   monic_mul_leadingCoeff_inv (mul_ne_zero_iff.mp hg).1

--- a/Mathlib/LinearAlgebra/AnnihilatingPolynomial.lean
+++ b/Mathlib/LinearAlgebra/AnnihilatingPolynomial.lean
@@ -129,7 +129,7 @@ theorem mem_iff_annIdealGenerator_dvd {p : 𝕜[X]} {a : A} :
   rw [← Ideal.mem_span_singleton, span_singleton_annIdealGenerator]
 
 /-- The generator of the annihilating ideal has minimal degree among
-the non-zero members of the annihilating ideal -/
+the nonzero members of the annihilating ideal -/
 theorem degree_annIdealGenerator_le_of_mem (a : A) (p : 𝕜[X]) (hp : p ∈ annIdeal 𝕜 a)
     (hpn0 : p ≠ 0) : degree (annIdealGenerator 𝕜 a) ≤ degree p :=
   degree_le_of_dvd (mem_iff_annIdealGenerator_dvd.1 hp) hpn0

--- a/Mathlib/LinearAlgebra/DFinsupp.lean
+++ b/Mathlib/LinearAlgebra/DFinsupp.lean
@@ -360,7 +360,7 @@ theorem dfinsuppSumAddHom_mem {β : ι → Type*} [∀ i, AddZeroClass (β i)] (
 @[deprecated (since := "2025-04-06")] alias dfinsupp_sumAddHom_mem := dfinsuppSumAddHom_mem
 
 /-- The supremum of a family of submodules is equal to the range of `DFinsupp.lsum`; that is
-every element in the `iSup` can be produced from taking a finite number of non-zero elements
+every element in the `iSup` can be produced from taking a finite number of nonzero elements
 of `p i`, coercing them to `N`, and summing them. -/
 theorem iSup_eq_range_dfinsupp_lsum (p : ι → Submodule R N) :
     iSup p = LinearMap.range (DFinsupp.lsum ℕ fun i => (p i).subtype) := by
@@ -374,7 +374,7 @@ theorem iSup_eq_range_dfinsupp_lsum (p : ι → Submodule R N) :
 
 /-- The bounded supremum of a family of commutative additive submonoids is equal to the range of
 `DFinsupp.sumAddHom` composed with `DFinsupp.filter_add_monoid_hom`; that is, every element in the
-bounded `iSup` can be produced from taking a finite number of non-zero elements from the `S i` that
+bounded `iSup` can be produced from taking a finite number of nonzero elements from the `S i` that
 satisfy `p i`, coercing them to `γ`, and summing them. -/
 theorem biSup_eq_range_dfinsupp_lsum (p : ι → Prop) [DecidablePred p] (S : ι → Submodule R N) :
     ⨆ (i) (_ : p i), S i =

--- a/Mathlib/LinearAlgebra/Dimension/Basic.lean
+++ b/Mathlib/LinearAlgebra/Dimension/Basic.lean
@@ -111,7 +111,7 @@ section
 variable [AddCommMonoid M'] [Module R' M']
 
 /-- If `M / R` and `M' / R'` are modules, `i : R' → R` is an injective map
-non-zero elements, `j : M →+ M'` is an injective monoid homomorphism, such that the scalar
+nonzero elements, `j : M →+ M'` is an injective monoid homomorphism, such that the scalar
 multiplications on `M` and `M'` are compatible, then the rank of `M / R` is smaller than or equal to
 the rank of `M' / R'`. As a special case, taking `R = R'` it is
 `LinearMap.lift_rank_le_of_injective`. -/
@@ -178,8 +178,8 @@ end Semiring
 section Ring
 variable [Ring R] [AddCommGroup M] [Module R M] [Ring R']
 
-/-- If `M / R` and `M' / R'` are modules, `i : R' → R` is a map which sends non-zero elements to
-non-zero elements, `j : M →+ M'` is an injective group homomorphism, such that the scalar
+/-- If `M / R` and `M' / R'` are modules, `i : R' → R` is a map which sends nonzero elements to
+nonzero elements, `j : M →+ M'` is an injective group homomorphism, such that the scalar
 multiplications on `M` and `M'` are compatible, then the rank of `M / R` is smaller than or equal to
 the rank of `M' / R'`. As a special case, taking `R = R'` it is
 `LinearMap.lift_rank_le_of_injective`. -/

--- a/Mathlib/LinearAlgebra/Dimension/FreeAndStrongRankCondition.lean
+++ b/Mathlib/LinearAlgebra/Dimension/FreeAndStrongRankCondition.lean
@@ -97,7 +97,7 @@ theorem rank_le_one_iff [Module.Free K V] :
     simp
 
 /-- A vector space has dimension `1` if and only if there is a
-single non-zero vector of which all vectors are multiples. -/
+single nonzero vector of which all vectors are multiples. -/
 theorem rank_eq_one_iff [Module.Free K V] :
     Module.rank K V = 1 ↔ ∃ v₀ : V, v₀ ≠ 0 ∧ ∀ v, ∃ r : K, r • v₀ = v := by
   haveI := nontrivial_of_invariantBasisNumber K
@@ -123,7 +123,7 @@ theorem rank_submodule_le_one_iff (s : Submodule K V) [Module.Free K s] :
   simp
 
 /-- A submodule has dimension `1` if and only if there is a
-single non-zero vector in the submodule such that the submodule is contained in
+single nonzero vector in the submodule such that the submodule is contained in
 its span. -/
 theorem rank_submodule_eq_one_iff (s : Submodule K V) [Module.Free K s] :
     Module.rank K s = 1 ↔ ∃ v₀ ∈ s, v₀ ≠ 0 ∧ s ≤ K ∙ v₀ := by

--- a/Mathlib/LinearAlgebra/LinearIndependent/Basic.lean
+++ b/Mathlib/LinearAlgebra/LinearIndependent/Basic.lean
@@ -376,7 +376,7 @@ theorem LinearIndependent.map' (hv : LinearIndependent R v) (f : M →ₗ[R] M')
   hv.map <| by simp_rw [hf_inj, disjoint_bot_right]
 
 /-- If `M / R` and `M' / R'` are modules, `i : R' → R` is a map, `j : M →+ M'` is a monoid map,
-such that they send non-zero elements to non-zero elements, and compatible with the scalar
+such that they send nonzero elements to nonzero elements, and compatible with the scalar
 multiplications on `M` and `M'`, then `j` sends linearly independent families of vectors to
 linearly independent families of vectors. As a special case, taking `R = R'`
 it is `LinearIndependent.map'`. -/
@@ -390,7 +390,7 @@ theorem LinearIndependent.map_of_injective_injective {R' M' : Type*}
   exact hi _ <| hv _ _ (hj _ H) s hs
 
 /-- If `M / R` and `M' / R'` are modules, `i : R → R'` is a surjective map which maps zero to zero,
-`j : M →+ M'` is a monoid map which sends non-zero elements to non-zero elements, such that the
+`j : M →+ M'` is a monoid map which sends nonzero elements to nonzero elements, such that the
 scalar multiplications on `M` and `M'` are compatible, then `j` sends linearly independent families
 of vectors to linearly independent families of vectors. As a special case, taking `R = R'`
 it is `LinearIndependent.map'`. -/

--- a/Mathlib/LinearAlgebra/LinearPMap.lean
+++ b/Mathlib/LinearAlgebra/LinearPMap.lean
@@ -155,7 +155,7 @@ theorem mkSpanSingleton'_apply_self (x : E) (y : F) (H : ∀ c : R, c • x = 0 
     rw [one_smul]
   · rwa [one_smul]
 
-/-- The unique `LinearPMap` on `span R {x}` that sends a non-zero vector `x` to `y`.
+/-- The unique `LinearPMap` on `span R {x}` that sends a nonzero vector `x` to `y`.
 This version works for modules over division rings. -/
 noncomputable abbrev mkSpanSingleton {K E F : Type*} [DivisionRing K] [AddCommGroup E] [Module K E]
     [AddCommGroup F] [Module K F] (x : E) (y : F) (hx : x ≠ 0) : E →ₗ.[K] F :=

--- a/Mathlib/LinearAlgebra/Matrix/Adjugate.lean
+++ b/Mathlib/LinearAlgebra/Matrix/Adjugate.lean
@@ -334,7 +334,7 @@ theorem det_adjugate (A : Matrix n n α) : (adjugate A).det = A.det ^ (Fintype.c
     rw [h_card, Nat.zero_sub, pow_zero, adjugate_subsingleton, det_one]
   replace h_card := tsub_add_cancel_of_le h_card.nat_succ_le
   -- express `A` as an evaluation of a polynomial in n^2 variables, and solve in the polynomial ring
-  -- where `A'.det` is non-zero.
+  -- where `A'.det` is nonzero.
   let A' := mvPolynomialX n n ℤ
   suffices A'.adjugate.det = A'.det ^ (Fintype.card n - 1) by
     rw [← mvPolynomialX_mapMatrix_aeval ℤ A, ← AlgHom.map_adjugate, ← AlgHom.map_det, ←
@@ -486,7 +486,7 @@ theorem adjugate_adjugate (A : Matrix n n α) (h : Fintype.card n ≠ 1) :
   · exact (h h_card).elim
   rw [← h_card]
   -- express `A` as an evaluation of a polynomial in n^2 variables, and solve in the polynomial ring
-  -- where `A'.det` is non-zero.
+  -- where `A'.det` is nonzero.
   let A' := mvPolynomialX n n ℤ
   suffices adjugate (adjugate A') = det A' ^ (Fintype.card n - 2) • A' by
     rw [← mvPolynomialX_mapMatrix_aeval ℤ A, ← AlgHom.map_adjugate, ← AlgHom.map_adjugate, this,

--- a/Mathlib/LinearAlgebra/Matrix/GeneralLinearGroup/Defs.lean
+++ b/Mathlib/LinearAlgebra/Matrix/GeneralLinearGroup/Defs.lean
@@ -85,7 +85,7 @@ def mk' (A : Matrix n n R) (_ : Invertible (Matrix.det A)) : GL n R :=
 noncomputable def mk'' (A : Matrix n n R) (h : IsUnit (Matrix.det A)) : GL n R :=
   nonsingInvUnit A h
 
-/-- Given a matrix with non-zero determinant over a field, we get an element of `GL n K`. -/
+/-- Given a matrix with nonzero determinant over a field, we get an element of `GL n K`. -/
 @[simps! val]
 def mkOfDetNeZero {K : Type*} [Field K] (A : Matrix n n K) (h : Matrix.det A ≠ 0) : GL n K :=
   mk' A (invertibleOfNonzero h)

--- a/Mathlib/LinearAlgebra/Matrix/Ideal.lean
+++ b/Mathlib/LinearAlgebra/Matrix/Ideal.lean
@@ -91,7 +91,7 @@ open Matrix
 variable {R : Type*} [Ring R] {n : Type*} [Fintype n] [DecidableEq n]
 
 /-- A standard basis matrix is in $J(Mₙ(I))$
-as long as its one possibly non-zero entry is in $J(I)$. -/
+as long as its one possibly nonzero entry is in $J(I)$. -/
 theorem single_mem_jacobson_matrix (I : Ideal R) :
     ∀ x ∈ I.jacobson, ∀ (i j : n), single i j x ∈ (I.matrix n).jacobson := by
   -- Proof generalized from example 8 in

--- a/Mathlib/LinearAlgebra/Matrix/Integer.lean
+++ b/Mathlib/LinearAlgebra/Matrix/Integer.lean
@@ -17,7 +17,7 @@ Here we collect some results about matrices over `ℚ` and `ℤ`.
 ## Main definitions and results
 
 * `Matrix.num`, `Matrix.den`: express a rational matrix `A` as the quotient of an integer matrix
-  by a (non-zero) natural.
+  by a (nonzero) natural.
 
 ## TODO
 

--- a/Mathlib/LinearAlgebra/Matrix/MvPolynomial.lean
+++ b/Mathlib/LinearAlgebra/Matrix/MvPolynomial.lean
@@ -63,7 +63,7 @@ theorem mvPolynomialX_mapMatrix_aeval [Fintype m] [DecidableEq m] [CommSemiring 
 
 variable (m)
 
-/-- In a nontrivial ring, `Matrix.mvPolynomialX m m R` has non-zero determinant. -/
+/-- In a nontrivial ring, `Matrix.mvPolynomialX m m R` has nonzero determinant. -/
 theorem det_mvPolynomialX_ne_zero [DecidableEq m] [Fintype m] [CommRing R] [Nontrivial R] :
     det (mvPolynomialX m m R) ≠ 0 := by
   intro h_det

--- a/Mathlib/LinearAlgebra/Projectivization/Basic.lean
+++ b/Mathlib/LinearAlgebra/Projectivization/Basic.lean
@@ -68,7 +68,7 @@ instance [Nontrivial V] : Nonempty (ℙ K V) :=
 
 variable {K}
 
-/-- A function on non-zero vectors which is independent of scale, descends to a function on the
+/-- A function on nonzero vectors which is independent of scale, descends to a function on the
 projectivization. -/
 protected def lift {α : Type*} (f : { v : V // v ≠ 0 } → α)
     (hf : ∀ (a b : { v : V // v ≠ 0 }) (t : K), a = t • (b : V) → f a = f b)

--- a/Mathlib/LinearAlgebra/Projectivization/Cardinality.lean
+++ b/Mathlib/LinearAlgebra/Projectivization/Cardinality.lean
@@ -24,11 +24,11 @@ section
 
 variable (k V : Type*) [DivisionRing k] [AddCommGroup V] [Module k V]
 
-/-- `ℙ k V` is equivalent to the quotient of the non-zero elements of `V` by `kˣ`. -/
+/-- `ℙ k V` is equivalent to the quotient of the nonzero elements of `V` by `kˣ`. -/
 def equivQuotientOrbitRel : ℙ k V ≃ Quotient (MulAction.orbitRel kˣ { v : V // v ≠ 0 }) :=
   Quotient.congr (Equiv.refl _) (fun x y ↦ (Units.orbitRel_nonZero_iff k V x y).symm)
 
-/-- The non-zero elements of `V` are equivalent to the product of `ℙ k V` with the units of `k`. -/
+/-- The nonzero elements of `V` are equivalent to the product of `ℙ k V` with the units of `k`. -/
 noncomputable def nonZeroEquivProjectivizationProdUnits : { v : V // v ≠ 0 } ≃ ℙ k V × kˣ :=
   let e := MulAction.selfEquivOrbitsQuotientProd <| fun b ↦ by
     rw [(Units.nonZeroSubMul k V).stabilizer_of_subMul,

--- a/Mathlib/LinearAlgebra/QuadraticForm/Basic.lean
+++ b/Mathlib/LinearAlgebra/QuadraticForm/Basic.lean
@@ -974,7 +974,7 @@ instance canLift' :
   prf B hB := ⟨B.toQuadraticMap, associated_left_inverse' _ hB⟩
 
 /-- There exists a non-null vector with respect to any quadratic form `Q` whose associated
-bilinear form is non-zero, i.e. there exists `x` such that `Q x ≠ 0`. -/
+bilinear form is nonzero, i.e. there exists `x` such that `Q x ≠ 0`. -/
 theorem exists_quadraticMap_ne_zero {Q : QuadraticMap R M N}
     -- Porting note: added implicit argument
     (hB₁ : associated' (N := N) Q ≠ 0) :

--- a/Mathlib/LinearAlgebra/QuadraticForm/Real.lean
+++ b/Mathlib/LinearAlgebra/QuadraticForm/Real.lean
@@ -26,7 +26,7 @@ namespace QuadraticForm
 variable {ι : Type*} [Fintype ι]
 
 /-- The isometry between a weighted sum of squares with weights `u` on the
-(non-zero) real numbers and the weighted sum of squares with weights `sign ∘ u`. -/
+(nonzero) real numbers and the weighted sum of squares with weights `sign ∘ u`. -/
 noncomputable def isometryEquivSignWeightedSumSquares (w : ι → ℝ) :
     IsometryEquiv (weightedSumSquares ℝ w)
       (weightedSumSquares ℝ (fun i ↦ (sign (w i) : ℝ))) := by

--- a/Mathlib/LinearAlgebra/Ray.lean
+++ b/Mathlib/LinearAlgebra/Ray.lean
@@ -271,7 +271,7 @@ section Action
 
 variable {G : Type*} [Group G] [DistribMulAction G M]
 
-/-- Any invertible action preserves the non-zeroness of ray vectors. This is primarily of interest
+/-- Any invertible action preserves the nonzeroness of ray vectors. This is primarily of interest
 when `G = Rˣ` -/
 instance {R : Type*} : MulAction G (RayVector R M) where
   smul r := Subtype.map (r • ·) fun _ => (smul_ne_zero_iff_ne _).2
@@ -280,7 +280,7 @@ instance {R : Type*} : MulAction G (RayVector R M) where
 
 variable [SMulCommClass R G M]
 
-/-- Any invertible action preserves the non-zeroness of rays. This is primarily of interest when
+/-- Any invertible action preserves the nonzeroness of rays. This is primarily of interest when
 `G = Rˣ` -/
 instance : MulAction G (Module.Ray R M) where
   smul r := Quotient.map (r • ·) fun _ _ h => h.smul _

--- a/Mathlib/LinearAlgebra/RootSystem/Finite/Nondegenerate.lean
+++ b/Mathlib/LinearAlgebra/RootSystem/Finite/Nondegenerate.lean
@@ -26,7 +26,7 @@ Weyl group.
 ## Main results:
 * `RootPairing.IsAnisotropic`: We say a finite root pairing is anisotropic if there are no roots /
   coroots which have length zero wrt the root / coroot forms.
-* `RootPairing.rootForm_pos_of_nonzero`: `RootForm` is strictly positive on non-zero linear
+* `RootPairing.rootForm_pos_of_nonzero`: `RootForm` is strictly positive on nonzero linear
   combinations of roots. This gives us a convenient way to eliminate certain Dynkin diagrams from
   the classification, since it suffices to produce a nonzero linear combination of simple roots with
   non-positive norm.

--- a/Mathlib/MeasureTheory/Group/GeometryOfNumbers.lean
+++ b/Mathlib/MeasureTheory/Group/GeometryOfNumbers.lean
@@ -56,7 +56,7 @@ theorem exists_pair_mem_lattice_not_disjoint_vadd [AddGroup L] [Countable L] [Ad
       (measure_mono <| Set.iUnion_subset fun _ => Set.inter_subset_right)
 
 /-- The **Minkowski Convex Body Theorem**. If `s` is a convex symmetric domain of `E` whose volume
-is large enough compared to the covolume of a lattice `L` of `E`, then it contains a non-zero
+is large enough compared to the covolume of a lattice `L` of `E`, then it contains a nonzero
 lattice point of `L`. -/
 theorem exists_ne_zero_mem_lattice_of_measure_mul_two_pow_lt_measure [NormedAddCommGroup E]
     [NormedSpace ℝ E] [BorelSpace E] [FiniteDimensional ℝ E] [IsAddHaarMeasure μ]

--- a/Mathlib/MeasureTheory/Group/GeometryOfNumbers.lean
+++ b/Mathlib/MeasureTheory/Group/GeometryOfNumbers.lean
@@ -19,7 +19,7 @@ Hermann Minkowski.
   points in a subgroup such that the translates of a set by these two points are not disjoint when
   the covolume of the subgroup is larger than the volume of the set.
 * `exists_ne_zero_mem_lattice_of_measure_mul_two_pow_lt_measure`: Minkowski's theorem, existence of
-  a non-zero lattice point inside a convex symmetric domain of large enough volume.
+  a nonzero lattice point inside a convex symmetric domain of large enough volume.
 
 ## TODO
 
@@ -81,7 +81,7 @@ theorem exists_ne_zero_mem_lattice_of_measure_mul_two_pow_lt_measure [NormedAddC
 
 /-- The **Minkowski Convex Body Theorem for compact domain**. If `s` is a convex compact symmetric
 domain of `E` whose volume is large enough compared to the covolume of a lattice `L` of `E`, then it
-contains a non-zero lattice point of `L`. Compared to
+contains a nonzero lattice point of `L`. Compared to
 `exists_ne_zero_mem_lattice_of_measure_mul_two_pow_lt_measure`, this version requires in addition
 that `s` is compact and `L` is discrete but provides a weaker inequality rather than a strict
 inequality. -/

--- a/Mathlib/MeasureTheory/Integral/MeanInequalities.lean
+++ b/Mathlib/MeasureTheory/Integral/MeanInequalities.lean
@@ -97,7 +97,7 @@ theorem lintegral_rpow_funMulInvSnorm_eq_one {p : ℝ} (hp0_lt : 0 < p) {f : α 
   rw [lintegral_mul_const', ENNReal.mul_inv_cancel hf_nonzero hf_top]
   rwa [inv_ne_top]
 
-/-- Hölder's inequality in case of finite non-zero integrals -/
+/-- Hölder's inequality in case of finite nonzero integrals -/
 theorem lintegral_mul_le_Lp_mul_Lq_of_ne_zero_of_ne_top {p q : ℝ} (hpq : p.HolderConjugate q)
     {f g : α → ℝ≥0∞} (hf : AEMeasurable f μ) (hf_nontop : (∫⁻ a, f a ^ p ∂μ) ≠ ⊤)
     (hg_nontop : (∫⁻ a, g a ^ q ∂μ) ≠ ⊤) (hf_nonzero : (∫⁻ a, f a ^ p ∂μ) ≠ 0)
@@ -158,7 +158,7 @@ theorem lintegral_mul_le_Lp_mul_Lq (μ : Measure α) {p q : ℝ} (hpq : p.Holder
   by_cases hg_top : ∫⁻ a, g a ^ q ∂μ = ⊤
   · rw [mul_comm, mul_comm ((∫⁻ a : α, f a ^ p ∂μ) ^ (1 / p))]
     exact lintegral_mul_le_Lp_mul_Lq_of_ne_zero_of_eq_top hpq.symm.pos hpq.nonneg hg_top hf_zero
-  -- non-⊤ non-zero case
+  -- non-⊤ nonzero case
   exact ENNReal.lintegral_mul_le_Lp_mul_Lq_of_ne_zero_of_ne_top hpq hf hf_top hg_top hf_zero hg_zero
 
 /-- A different formulation of Hölder's inequality for two functions, with two exponents that sum to

--- a/Mathlib/MeasureTheory/Measure/Haar/Unique.lean
+++ b/Mathlib/MeasureTheory/Measure/Haar/Unique.lean
@@ -410,7 +410,7 @@ lemma haarScalarFactor_eq_mul (μ' μ ν : Measure G)
     (haarScalarFactor μ' μ * haarScalarFactor μ ν : ℝ≥0) * ∫ (x : G), g x ∂ν at Z
   simpa only [mul_eq_mul_right_iff (M₀ := ℝ), int_g_pos.ne', or_false, ← NNReal.eq_iff] using Z
 
-/-- The scalar factor between two left-invariant measures is non-zero when both measures are
+/-- The scalar factor between two left-invariant measures is nonzero when both measures are
 positive on open sets. -/
 @[to_additive]
 lemma haarScalarFactor_pos_of_isHaarMeasure (μ' μ : Measure G) [IsHaarMeasure μ]

--- a/Mathlib/MeasureTheory/Measure/WithDensityFinite.lean
+++ b/Mathlib/MeasureTheory/Measure/WithDensityFinite.lean
@@ -51,7 +51,7 @@ noncomputable def Measure.toFiniteAux (μ : Measure α) [SFinite μ] : Measure �
 /-- A finite measure obtained from an s-finite measure `μ`, such that
 `μ = μ.toFinite.withDensity (μ.rnDeriv µ.toFinite)`
 (see `MeasureTheory.Measure.withDensity_rnDeriv_eq` along with
-`MeasureTheory.absolutelyContinuous_toFinite`). If `μ` is non-zero, then `μ.toFinite` is a
+`MeasureTheory.absolutelyContinuous_toFinite`). If `μ` is nonzero, then `μ.toFinite` is a
 probability measure. -/
 noncomputable def Measure.toFinite (μ : Measure α) [SFinite μ] : Measure α :=
   μ.toFiniteAux[|univ]

--- a/Mathlib/NumberTheory/Bernoulli.lean
+++ b/Mathlib/NumberTheory/Bernoulli.lean
@@ -304,7 +304,7 @@ theorem sum_range_pow (n p : ℕ) :
       rw [← div_eq_iff (hne p), div_eq_mul_inv, sum_mul]
       rw [PowerSeries.ext_iff] at this
       simpa using this p
-    -- the power series `exp ℚ - 1` is non-zero, a fact we need in order to use `mul_right_inj'`
+    -- the power series `exp ℚ - 1` is nonzero, a fact we need in order to use `mul_right_inj'`
     have hexp : exp ℚ - 1 ≠ 0 := by
       simp only [exp, PowerSeries.ext_iff, Ne, not_forall]
       use 1

--- a/Mathlib/NumberTheory/FLT/Four.lean
+++ b/Mathlib/NumberTheory/FLT/Four.lean
@@ -11,14 +11,14 @@ import Mathlib.Tactic.LinearCombination
 
 /-!
 # Fermat's Last Theorem for the case n = 4
-There are no non-zero integers `a`, `b` and `c` such that `a ^ 4 + b ^ 4 = c ^ 4`.
+There are no nonzero integers `a`, `b` and `c` such that `a ^ 4 + b ^ 4 = c ^ 4`.
 -/
 
 assert_not_exists TwoSidedIdeal
 
 noncomputable section
 
-/-- Shorthand for three non-zero integers `a`, `b`, and `c` satisfying `a ^ 4 + b ^ 4 = c ^ 2`.
+/-- Shorthand for three nonzero integers `a`, `b`, and `c` satisfying `a ^ 4 + b ^ 4 = c ^ 2`.
 We will show that no integers satisfy this equation. Clearly Fermat's Last theorem for n = 4
 follows. -/
 def Fermat42 (a b c : ℤ) : Prop :=
@@ -180,7 +180,7 @@ theorem not_minimal {a b c : ℤ} (h : Minimal a b c) (ha2 : a % 2 = 1) (hc : 0 
     apply @IsCoprime.of_mul_left_left _ _ _ a
     rw [← sq, ht1, (by ring : m ^ 2 - n ^ 2 = m ^ 2 + -n * n)]
     exact (Int.isCoprime_iff_gcd_eq_one.mpr ht4).pow_left.add_mul_right_left (-n)
-  -- m is positive because b is non-zero and b ^ 2 = 2 * m * n and we already have 0 ≤ m.
+  -- m is positive because b is nonzero and b ^ 2 = 2 * m * n and we already have 0 ≤ m.
   have hb20 : b ^ 2 ≠ 0 := mt pow_eq_zero h.1.2.1
   have h4 : 0 < m := by
     apply lt_of_le_of_ne ht6

--- a/Mathlib/NumberTheory/FLT/Four.lean
+++ b/Mathlib/NumberTheory/FLT/Four.lean
@@ -262,7 +262,7 @@ theorem not_fermat_42 {a b c : ℤ} (ha : a ≠ 0) (hb : b ≠ 0) : a ^ 4 + b ^ 
   apply Fermat42.not_minimal hf h2 hp
 
 /--
-Fermat's Last Theorem for $n=4$: if `a b c : ℕ` are all non-zero
+Fermat's Last Theorem for $n=4$: if `a b c : ℕ` are all nonzero
 then `a ^ 4 + b ^ 4 ≠ c ^ 4`.
 -/
 theorem fermatLastTheoremFour : FermatLastTheoremFor 4 := by

--- a/Mathlib/NumberTheory/FLT/Three.lean
+++ b/Mathlib/NumberTheory/FLT/Three.lean
@@ -14,7 +14,7 @@ import Mathlib.Algebra.Ring.Divisibility.Lemmas
 The goal of this file is to prove Fermat's Last Theorem in the case `n = 3`.
 
 ## Main results
-* `fermatLastTheoremThree`: Fermat's Last Theorem for `n = 3`: if `a b c : ℕ` are all non-zero then
+* `fermatLastTheoremThree`: Fermat's Last Theorem for `n = 3`: if `a b c : ℕ` are all nonzero then
   `a ^ 3 + b ^ 3 ≠ c ^ 3`.
 
 ## Implementation details
@@ -738,7 +738,7 @@ end eisenstein
 
 end case2
 
-/-- Fermat's Last Theorem for `n = 3`: if `a b c : ℕ` are all non-zero then
+/-- Fermat's Last Theorem for `n = 3`: if `a b c : ℕ` are all nonzero then
 `a ^ 3 + b ^ 3 ≠ c ^ 3`. -/
 theorem fermatLastTheoremThree : FermatLastTheoremFor 3 := by
   classical

--- a/Mathlib/NumberTheory/LSeries/HurwitzZetaValues.lean
+++ b/Mathlib/NumberTheory/LSeries/HurwitzZetaValues.lean
@@ -10,7 +10,7 @@ import Mathlib.NumberTheory.LSeries.RiemannZeta
 /-!
 # Special values of Hurwitz and Riemann zeta functions
 
-This file gives the formula for `ζ (2 * k)`, for `k` a non-zero integer, in terms of Bernoulli
+This file gives the formula for `ζ (2 * k)`, for `k` a nonzero integer, in terms of Bernoulli
 numbers. More generally, we give formulae for any Hurwitz zeta functions at any (strictly) negative
 integer in terms of Bernoulli polynomials.
 

--- a/Mathlib/NumberTheory/LSeries/Nonvanishing.lean
+++ b/Mathlib/NumberTheory/LSeries/Nonvanishing.lean
@@ -18,7 +18,7 @@ then the L-function of `χ` does not vanish at `s`.
 
 As a consequence, we have the corresponding statement for the Riemann ζ function:
 `riemannZeta_ne_zero_of_one_le_re` (which does not require `s ≠ 1`, since the junk value at `s = 1`
-happens to be non-zero).
+happens to be nonzero).
 
 These results are prerequisites for the **Prime Number Theorem** and
 **Dirichlet's Theorem** on primes in arithmetic progressions.

--- a/Mathlib/NumberTheory/LegendreSymbol/QuadraticChar/Basic.lean
+++ b/Mathlib/NumberTheory/LegendreSymbol/QuadraticChar/Basic.lean
@@ -29,7 +29,7 @@ We define the quadratic character of a finite field `F` with values in ℤ.
 section Define
 
 /-- Define the quadratic character with values in ℤ on a monoid with zero `α`.
-It takes the value zero at zero; for non-zero argument `a : α`, it is `1`
+It takes the value zero at zero; for nonzero argument `a : α`, it is `1`
 if `a` is a square, otherwise it is `-1`.
 
 This only deserves the name "character" when it is multiplicative,

--- a/Mathlib/NumberTheory/MulChar/Lemmas.lean
+++ b/Mathlib/NumberTheory/MulChar/Lemmas.lean
@@ -163,7 +163,7 @@ end Fintype
 variable {F : Type*} [Field F] [Finite F]
 variable {R : Type*} [CommRing R]
 
-/- The non-zero values of a multiplicative character of order `n` are `n`th roots of unity. -/
+/- The nonzero values of a multiplicative character of order `n` are `n`th roots of unity. -/
 lemma apply_mem_rootsOfUnity_orderOf (χ : MulChar F R) {a : F} (ha : a ≠ 0) :
     ∃ ζ ∈ rootsOfUnity (orderOf χ) R, ζ = χ a := by
   have hu : IsUnit (χ a) := ha.isUnit.map χ
@@ -173,7 +173,7 @@ lemma apply_mem_rootsOfUnity_orderOf (χ : MulChar F R) {a : F} (ha : a ≠ 0) :
     show a = (isUnit_iff_ne_zero.mpr ha).unit by simp only [IsUnit.unit_spec],
     MulChar.one_apply_coe]
 
-/-- The non-zero values of a multiplicative character `χ` such that `χ^n = 1`
+/-- The nonzero values of a multiplicative character `χ` such that `χ^n = 1`
 are `n`th roots of unity. -/
 lemma apply_mem_rootsOfUnity_of_pow_eq_one {χ : MulChar F R} {n : ℕ} (hχ : χ ^ n = 1)
     {a : F} (ha : a ≠ 0) :

--- a/Mathlib/NumberTheory/NumberField/FinitePlaces.lean
+++ b/Mathlib/NumberTheory/NumberField/FinitePlaces.lean
@@ -13,18 +13,18 @@ import Mathlib.Topology.Algebra.Valued.NormedValued
 /-!
 # Finite places of number fields
 This file defines finite places of a number field `K` as absolute values coming from an embedding
-into a completion of `K` associated to a non-zero prime ideal of `𝓞 K`.
+into a completion of `K` associated to a nonzero prime ideal of `𝓞 K`.
 
 ## Main Definitions and Results
 * `NumberField.adicAbv`: a `v`-adic absolute value on `K`.
 * `NumberField.FinitePlace`: the type of finite places of a number field `K`.
 * `NumberField.FinitePlace.embedding`: the canonical embedding of a number field `K` to the
-  `v`-adic completion `v.adicCompletion K` of `K`, where `v` is a non-zero prime ideal of `𝓞 K`
+  `v`-adic completion `v.adicCompletion K` of `K`, where `v` is a nonzero prime ideal of `𝓞 K`
 * `NumberField.FinitePlace.norm_def`: the norm of `embedding v x` is the same as the `v`-adic
   absolute value of `x`. See also `NumberField.FinitePlace.norm_def'` and
   `NumberField.FinitePlace.norm_def_int` for versions where the `v`-adic absolute value is
   unfolded.
-* `NumberField.FinitePlace.mulSupport_finite`: the `v`-adic absolute value of a non-zero element of
+* `NumberField.FinitePlace.mulSupport_finite`: the `v`-adic absolute value of a nonzero element of
   `K` is different from 1 for at most finitely many `v`.
 
 ## Tags

--- a/Mathlib/NumberTheory/NumberField/House.lean
+++ b/Mathlib/NumberTheory/NumberField/House.lean
@@ -275,7 +275,7 @@ private theorem house_le_bound : ∀ l, house (ξ K x l).1 ≤ (c₁ K) *
   · rw [mul_comm (q : ℝ) (c₁ K)]; rfl
 
 include hpq h0p cardα cardβ ha habs in
-/-- There exists a "small" non-zero algebraic integral solution of an
+/-- There exists a "small" nonzero algebraic integral solution of an
 non-trivial underdetermined system of linear equations with algebraic integer coefficients. -/
 theorem exists_ne_zero_int_vec_house_le :
     ∃ (ξ : β → 𝓞 K), ξ ≠ 0 ∧ a *ᵥ ξ = 0 ∧

--- a/Mathlib/NumberTheory/NumberField/ProductFormula.lean
+++ b/Mathlib/NumberTheory/NumberField/ProductFormula.lean
@@ -9,20 +9,20 @@ import Mathlib.NumberTheory.NumberField.InfinitePlace.Basic
 /-!
 # The Product Formula for number fields
 
-In this file we prove the Product Formula for number fields: for any non-zero element `x` of a
+In this file we prove the Product Formula for number fields: for any nonzero element `x` of a
 number field `K`, we have `∏ |x|ᵥ=1` where the product runs over the equivalence classes of absolute
 values of `K`. The `|⬝|ᵥ` are normalized as follows:
 - for the infinite places, `|⬝|ᵥ` is the absolute value on `K` induced by the corresponding field
 embedding in `ℂ` and the usual absolute value on `ℂ`;
-- for the finite places and a non-zero `x`, `|x|ᵥ` is equal to the norm of the corresponding maximal
+- for the finite places and a nonzero `x`, `|x|ᵥ` is equal to the norm of the corresponding maximal
 ideal of `𝓞 K` raised to the power of the `v`-adic valuation of `x`.
 
 ## Main Results
 
-* `NumberField.FinitePlace.prod_eq_inv_abs_norm`: for any non-zero element `x` of a number field
+* `NumberField.FinitePlace.prod_eq_inv_abs_norm`: for any nonzero element `x` of a number field
   `K`, the product `∏ |x|ᵥ` of the absolute values of `x` associated to the finite places of `K` is
   equal to the inverse of the norm of `x`.
-* `NumberField.prod_abs_eq_one`: for any non-zero element `x` of a number field `K`, we have
+* `NumberField.prod_abs_eq_one`: for any nonzero element `x` of a number field `K`, we have
   `∏ |x|ᵥ=1`, where the product runs over the equivalence classes of absolute values of `K`.
 
 ## Tags
@@ -36,7 +36,7 @@ variable {K : Type*} [Field K] [NumberField K]
 open Algebra
 
 open Function Ideal IsDedekindDomain HeightOneSpectrum in
-/-- For any non-zero `x` in `𝓞 K`, the product of `w x`, where `w` runs over `FinitePlace K`, is
+/-- For any nonzero `x` in `𝓞 K`, the product of `w x`, where `w` runs over `FinitePlace K`, is
 equal to the inverse of the absolute value of `Algebra.norm ℤ x`. -/
 theorem FinitePlace.prod_eq_inv_abs_norm_int {x : 𝓞 K} (h_x_nezero : x ≠ 0) :
     ∏ᶠ w : FinitePlace K, w x = (|norm ℤ x| : ℝ)⁻¹ := by
@@ -68,7 +68,7 @@ theorem FinitePlace.prod_eq_inv_abs_norm_int {x : 𝓞 K} (h_x_nezero : x ≠ 0)
   rw [h_prod, ← finprod_mul_distrib h_fin₁ h_fin₂]
   exact finprod_eq_one_of_forall_eq_one fun v ↦ v.embedding_mul_absNorm h_x_nezero
 
-/-- For any non-zero `x` in `K`, the product of `w x`, where `w` runs over `FinitePlace K`, is
+/-- For any nonzero `x` in `K`, the product of `w x`, where `w` runs over `FinitePlace K`, is
 equal to the inverse of the absolute value of `Algebra.norm ℚ x`. -/
 theorem FinitePlace.prod_eq_inv_abs_norm {x : K} (h_x_nezero : x ≠ 0) :
     ∏ᶠ w : FinitePlace K, w x = |(Algebra.norm ℚ) x|⁻¹ := by

--- a/Mathlib/NumberTheory/Padics/PadicVal/Basic.lean
+++ b/Mathlib/NumberTheory/Padics/PadicVal/Basic.lean
@@ -365,7 +365,7 @@ lemma self_pow_inv (r : ℕ) : padicValRat p ((p : ℚ) ^ r)⁻¹ = -r := by
       padicValRat.self hp.elim.one_lt, mul_one]
 
 /-- A finite sum of rationals with positive `p`-adic valuation has positive `p`-adic valuation
-(if the sum is non-zero). -/
+(if the sum is nonzero). -/
 theorem sum_pos_of_pos {n : ℕ} {F : ℕ → ℚ} (hF : ∀ i, i < n → 0 < padicValRat p (F i))
     (hn0 : ∑ i ∈ Finset.range n, F i ≠ 0) : 0 < padicValRat p (∑ i ∈ Finset.range n, F i) := by
   induction n with

--- a/Mathlib/NumberTheory/SiegelsLemma.lean
+++ b/Mathlib/NumberTheory/SiegelsLemma.lean
@@ -12,13 +12,13 @@ import Mathlib.Tactic.Rify
 
 In this file we introduce and prove Siegel's Lemma in its most basic version. This is a fundamental
 tool in diophantine approximation and transcendence and says that there exists a "small" integral
-non-zero solution of a non-trivial underdetermined system of linear equations with integer
+nonzero solution of a non-trivial underdetermined system of linear equations with integer
 coefficients.
 
 ## Main results
 
-- `exists_ne_zero_int_vec_norm_le`: Given a non-zero `m × n` matrix `A` with `m < n` the linear
-system it determines has a non-zero integer solution `t` with
+- `exists_ne_zero_int_vec_norm_le`: Given a nonzero `m × n` matrix `A` with `m < n` the linear
+system it determines has a nonzero integer solution `t` with
 `‖t‖ ≤ ((n * ‖A‖) ^ ((m : ℝ) / (n - m)))`
 
 ## Notation
@@ -115,7 +115,7 @@ private lemma card_S_eq [DecidableEq α] : #(Finset.Icc N P) = ∏ i : α, (P i 
   rw [Int.card_Icc_of_le (N i) (P i) (N_le_P_add_one A i)]
   exact add_sub_right_comm (P i) 1 (N i)
 
-/-- The sup norm of a non-zero integer matrix is at least one -/
+/-- The sup norm of a nonzero integer matrix is at least one -/
 lemma one_le_norm_A_of_ne_zero (hA : A ≠ 0) : 1 ≤ ‖A‖ := by
   by_contra! h
   apply hA

--- a/Mathlib/NumberTheory/SmoothNumbers.lean
+++ b/Mathlib/NumberTheory/SmoothNumbers.lean
@@ -171,7 +171,7 @@ lemma factoredNumbers_insert (s : Finset ℕ) {N : ℕ} (hN : ¬ N.Prime) :
     factoredNumbers s ⊆ factoredNumbers t :=
   fun _ hx ↦ ⟨hx.1, fun p hp ↦ hst <| hx.2 p hp⟩
 
-/-- The non-zero non-`s`-factored numbers are `≥ N` when `s` contains all primes less than `N`. -/
+/-- The nonzero non-`s`-factored numbers are `≥ N` when `s` contains all primes less than `N`. -/
 lemma factoredNumbers_compl {N : ℕ} {s : Finset ℕ} (h : primesBelow N ≤ s) :
     (factoredNumbers s)ᶜ \ {0} ⊆ {n | N ≤ n} := by
   intro n hn
@@ -365,7 +365,7 @@ lemma mem_smoothNumbers_of_lt {m n : ℕ} (hm : 0 < m) (hmn : m < n) : m ∈ n.s
   smoothNumbers_eq_factoredNumbers _ ▸ ⟨ne_zero_of_lt hm,
   fun _ h => Finset.mem_range.mpr <| lt_of_le_of_lt (le_of_mem_primeFactorsList h) hmn⟩
 
-/-- The non-zero non-`N`-smooth numbers are `≥ N`. -/
+/-- The nonzero non-`N`-smooth numbers are `≥ N`. -/
 lemma smoothNumbers_compl (N : ℕ) : (N.smoothNumbers)ᶜ \ {0} ⊆ {n | N ≤ n} := by
   simpa only [smoothNumbers_eq_factoredNumbers]
     using factoredNumbers_compl <| Finset.filter_subset _ (Finset.range N)

--- a/Mathlib/NumberTheory/Transcendental/Liouville/Basic.lean
+++ b/Mathlib/NumberTheory/Transcendental/Liouville/Basic.lean
@@ -56,7 +56,7 @@ protected theorem irrational {x : ℝ} (h : Liouville x) : Irrational x := by
     exact mod_cast a0
   -- Actually, `q` is a natural number
   lift q to ℕ using (zero_lt_one.trans q1).le
-  -- Looks innocuous, but we now have an integer with non-zero absolute value: this is at
+  -- Looks innocuous, but we now have an integer with nonzero absolute value: this is at
   -- least one away from zero.  The gain here is what gets the proof going.
   have ap : 0 < |a * ↑q - ↑b * p| := abs_pos.mpr a0
   -- Actually, the absolute value of an integer is a natural number
@@ -173,7 +173,7 @@ theorem exists_pos_real_of_irrational_root {α : ℝ} (ha : Irrational α) {f : 
 /-- **Liouville's Theorem** -/
 protected theorem transcendental {x : ℝ} (lx : Liouville x) : Transcendental ℤ x := by
   -- Proceed by contradiction: if `x` is algebraic, then `x` is the root (`ef0`) of a
-  -- non-zero (`f0`) polynomial `f`
+  -- nonzero (`f0`) polynomial `f`
   rintro ⟨f : ℤ[X], f0, ef0⟩
   -- Change `aeval x f = 0` to `eval (map _ f) = 0`, who knew.
   replace ef0 : (f.map (algebraMap ℤ ℝ)).eval x = 0 := by

--- a/Mathlib/NumberTheory/Transcendental/Liouville/Basic.lean
+++ b/Mathlib/NumberTheory/Transcendental/Liouville/Basic.lean
@@ -124,7 +124,7 @@ theorem exists_pos_real_of_irrational_root {α : ℝ} (ha : Irrational α) {f : 
       (1 : ℝ) ≤ ((b : ℝ) + 1) ^ f.natDegree * (|α - a / (b + 1)| * A) := by
   -- `fR` is `f` viewed as a polynomial with `ℝ` coefficients.
   set fR : ℝ[X] := map (algebraMap ℤ ℝ) f
-  -- `fR` is non-zero, since `f` is non-zero.
+  -- `fR` is nonzero, since `f` is nonzero.
   obtain fR0 : fR ≠ 0 := fun fR0 =>
     (map_injective (algebraMap ℤ ℝ) fun _ _ A => Int.cast_inj.mp A).ne f0
       (fR0.trans (Polynomial.map_zero _).symm)

--- a/Mathlib/Order/SupIndep.lean
+++ b/Mathlib/Order/SupIndep.lean
@@ -277,7 +277,7 @@ theorem sSupIndep.disjoint_sSup {x : α} {y : Set α} (hx : x ∈ s) (hy : y ⊆
 /-- An independent indexed family of elements in a complete lattice is one in which every element
   is disjoint from the `iSup` of the rest.
 
-  Example: an indexed family of non-zero elements in a
+  Example: an indexed family of nonzero elements in a
   vector space is linearly independent iff the indexed family of subspaces they generate is
   independent in this sense.
 

--- a/Mathlib/Probability/ConditionalProbability.lean
+++ b/Mathlib/Probability/ConditionalProbability.lean
@@ -45,7 +45,7 @@ Use of `@[simp]` generally follows the rule of removing conditions on a measure
 when possible.
 
 Hypotheses that are used to "define" a conditional distribution by requiring that
-the conditioning set has non-zero measure should be named using the abbreviation
+the conditioning set has nonzero measure should be named using the abbreviation
 "c" (which stands for "conditionable") rather than "nz". For example `(hci : μ (s ∩ t) ≠ 0)`
 (rather than `hnzi`) should be used for a hypothesis ensuring that `μ[|s ∩ t]` is defined.
 

--- a/Mathlib/Probability/Distributions/Uniform.lean
+++ b/Mathlib/Probability/Distributions/Uniform.lean
@@ -213,7 +213,7 @@ open scoped NNReal ENNReal
 
 section UniformOfFinset
 
-/-- Uniform distribution taking the same non-zero probability on the nonempty finset `s` -/
+/-- Uniform distribution taking the same nonzero probability on the nonempty finset `s` -/
 def uniformOfFinset (s : Finset α) (hs : s.Nonempty) : PMF α := by
   classical
   refine ofFinset (fun a => if a ∈ s then s.card⁻¹ else 0) s ?_ ?_

--- a/Mathlib/Probability/Kernel/CondDistrib.lean
+++ b/Mathlib/Probability/Kernel/CondDistrib.lean
@@ -66,7 +66,7 @@ instance [MeasurableSpace β] : IsMarkovKernel (condDistrib Y X μ) := by
 
 variable {mβ : MeasurableSpace β} {s : Set Ω} {t : Set β} {f : β × Ω → F}
 
-/-- If the singleton `{x}` has non-zero mass for `μ.map X`, then for all `s : Set Ω`,
+/-- If the singleton `{x}` has nonzero mass for `μ.map X`, then for all `s : Set Ω`,
 `condDistrib Y X μ x s = (μ.map X {x})⁻¹ * μ.map (fun a => (X a, Y a)) ({x} ×ˢ s)` . -/
 lemma condDistrib_apply_of_ne_zero [MeasurableSingletonClass β]
     (hY : Measurable Y) (x : β) (hX : μ.map X {x} ≠ 0) (s : Set Ω) :

--- a/Mathlib/Probability/Kernel/Disintegration/Basic.lean
+++ b/Mathlib/Probability/Kernel/Disintegration/Basic.lean
@@ -84,7 +84,7 @@ private lemma IsCondKernel.apply_of_ne_zero_of_measurableSet [MeasurableSingleto
   simp only [Measure.restrict_singleton, lintegral_smul_measure, lintegral_dirac, smul_eq_mul]
   rw [← mul_assoc, ENNReal.inv_mul_cancel hx (measure_ne_top _ _), one_mul]
 
-/-- If the singleton `{x}` has non-zero mass for `ρ.fst`, then for all `s : Set Ω`,
+/-- If the singleton `{x}` has nonzero mass for `ρ.fst`, then for all `s : Set Ω`,
 `ρCond x s = (ρ.fst {x})⁻¹ * ρ ({x} ×ˢ s)` . -/
 lemma IsCondKernel.apply_of_ne_zero [MeasurableSingletonClass α] {x : α}
     (hx : ρ.fst {x} ≠ 0) (s : Set Ω) : ρCond x s = (ρ.fst {x})⁻¹ * ρ ({x} ×ˢ s) := by

--- a/Mathlib/Probability/Kernel/Disintegration/StandardBorel.lean
+++ b/Mathlib/Probability/Kernel/Disintegration/StandardBorel.lean
@@ -379,7 +379,7 @@ instance _root_.MeasureTheory.Measure.instIsMarkovKernelCondKernel
   rw [Measure.condKernel]
   infer_instance
 
-/-- If the singleton `{x}` has non-zero mass for `ρ.fst`, then for all `s : Set Ω`,
+/-- If the singleton `{x}` has nonzero mass for `ρ.fst`, then for all `s : Set Ω`,
 `ρ.condKernel x s = (ρ.fst {x})⁻¹ * ρ ({x} ×ˢ s)` . -/
 lemma _root_.MeasureTheory.Measure.condKernel_apply_of_ne_zero [MeasurableSingletonClass α]
     {x : α} (hx : ρ.fst {x} ≠ 0) (s : Set Ω) :

--- a/Mathlib/Probability/ProbabilityMassFunction/Constructions.lean
+++ b/Mathlib/Probability/ProbabilityMassFunction/Constructions.lean
@@ -239,7 +239,7 @@ end OfFintype
 
 section normalize
 
-/-- Given an `f` with non-zero and non-infinite sum, get a `PMF` by normalizing `f` by its `tsum`.
+/-- Given an `f` with nonzero and non-infinite sum, get a `PMF` by normalizing `f` by its `tsum`.
 -/
 def normalize (f : α → ℝ≥0∞) (hf0 : tsum f ≠ 0) (hf : tsum f ≠ ∞) : PMF α :=
   ⟨fun a => f a * (∑' x, f x)⁻¹,
@@ -260,7 +260,7 @@ end normalize
 
 section Filter
 
-/-- Create new `PMF` by filtering on a set with non-zero measure and normalizing. -/
+/-- Create new `PMF` by filtering on a set with nonzero measure and normalizing. -/
 def filter (p : PMF α) (s : Set α) (h : ∃ a ∈ s, a ∈ p.support) : PMF α :=
   PMF.normalize (s.indicator p) (by simpa using h) (p.tsum_coe_indicator_ne_top s)
 

--- a/Mathlib/RingTheory/DedekindDomain/Different.lean
+++ b/Mathlib/RingTheory/DedekindDomain/Different.lean
@@ -212,7 +212,7 @@ variable [IsDomain A] [IsFractionRing B L] [Nontrivial B] [NoZeroDivisors B]
 namespace FractionalIdeal
 
 open scoped Classical in
-/-- The dual of a non-zero fractional ideal is the dual of the submodule under the trace form. -/
+/-- The dual of a nonzero fractional ideal is the dual of the submodule under the trace form. -/
 noncomputable
 def dual (I : FractionalIdeal B⁰ L) :
     FractionalIdeal B⁰ L :=

--- a/Mathlib/RingTheory/DedekindDomain/Factorization.lean
+++ b/Mathlib/RingTheory/DedekindDomain/Factorization.lean
@@ -636,7 +636,7 @@ lemma IsDedekindDomain.exists_sup_span_eq {I J : Ideal R} (hIJ : I ≤ J) (hI : 
     exact Ideal.prod_le_inf.trans (Finset.inf_le (b := q) (by simpa [hq] using hqp))
 
 /-- In a Dedekind domain, any ideal is spanned by two elements, where one of the element
-could be any fixed non-zero element in the ideal. -/
+could be any fixed nonzero element in the ideal. -/
 lemma IsDedekindDomain.exists_eq_span_pair {I : Ideal R} {x : R} (hxI : x ∈ I) (hx : x ≠ 0) :
     ∃ y, I = .span {x, y} := by
   obtain ⟨y, rfl⟩ := exists_sup_span_eq (I.span_singleton_le_iff_mem.mpr hxI) (by simpa)

--- a/Mathlib/RingTheory/DedekindDomain/Ideal/Lemmas.lean
+++ b/Mathlib/RingTheory/DedekindDomain/Ideal/Lemmas.lean
@@ -488,7 +488,7 @@ theorem ideal_ne_top_iff_exists (hR : ¬IsField R) (I : Ideal R) :
 variable (R)
 
 /-- A Dedekind domain is equal to the intersection of its localizations at all its height one
-non-zero prime ideals viewed as subalgebras of its field of fractions. -/
+nonzero prime ideals viewed as subalgebras of its field of fractions. -/
 theorem iInf_localization_eq_bot [Algebra R K] [hK : IsFractionRing R K] :
     (⨅ v : HeightOneSpectrum R,
         Localization.subalgebra.ofField K _ v.asIdeal.primeCompl_le_nonZeroDivisors) = ⊥ := by

--- a/Mathlib/RingTheory/DedekindDomain/SelmerGroup.lean
+++ b/Mathlib/RingTheory/DedekindDomain/SelmerGroup.lean
@@ -75,7 +75,7 @@ universe u v
 variable {R : Type u} [CommRing R] [IsDedekindDomain R] {K : Type v} [Field K]
   [Algebra R K] [IsFractionRing R K] (v : HeightOneSpectrum R)
 
-/-! ### Valuations of non-zero elements -/
+/-! ### Valuations of nonzero elements -/
 
 
 namespace HeightOneSpectrum

--- a/Mathlib/RingTheory/DiscreteValuationRing/Basic.lean
+++ b/Mathlib/RingTheory/DiscreteValuationRing/Basic.lean
@@ -20,7 +20,7 @@ for them.
 
 There are various definitions of a DVR in the literature; we define a DVR to be a local PID
 which is not a field (the first definition in Wikipedia) and prove that this is equivalent
-to being a PID with a unique non-zero prime ideal (the definition in Serre's
+to being a PID with a unique nonzero prime ideal (the definition in Serre's
 book "Local Fields").
 
 Let R be an integral domain, assumed to be a principal ideal ring and a local ring.
@@ -103,7 +103,7 @@ theorem exists_irreducible : ∃ ϖ : R, Irreducible ϖ := by
 theorem exists_prime : ∃ ϖ : R, Prime ϖ :=
   (exists_irreducible R).imp fun _ => irreducible_iff_prime.1
 
-/-- An integral domain is a DVR iff it's a PID with a unique non-zero prime ideal. -/
+/-- An integral domain is a DVR iff it's a PID with a unique nonzero prime ideal. -/
 theorem iff_pid_with_one_nonzero_prime (R : Type u) [CommRing R] [IsDomain R] :
     IsDiscreteValuationRing R ↔ IsPrincipalIdealRing R ∧ ∃! P : Ideal R, P ≠ ⊥ ∧ IsPrime P := by
   constructor

--- a/Mathlib/RingTheory/DiscreteValuationRing/TFAE.lean
+++ b/Mathlib/RingTheory/DiscreteValuationRing/TFAE.lean
@@ -153,7 +153,7 @@ The following are equivalent:
 0. `R` is a PID
 1. `R` is a valuation ring
 2. `R` is a Dedekind domain
-3. `R` is integrally closed with at most one non-zero prime ideal
+3. `R` is integrally closed with at most one nonzero prime ideal
 4. `m` is principal
 5. `dimₖ m/m² ≤ 1`
 6. Every nonzero ideal is a power of `m`.
@@ -195,7 +195,7 @@ Noetherian local domain that is not a field `(R, m, k)`:
 0. `R` is a discrete valuation ring
 1. `R` is a valuation ring
 2. `R` is a Dedekind domain
-3. `R` is integrally closed with a unique non-zero prime ideal
+3. `R` is integrally closed with a unique nonzero prime ideal
 4. `m` is principal
 5. `dimₖ m/m² = 1`
 6. Every nonzero ideal is a power of `m`.

--- a/Mathlib/RingTheory/FractionalIdeal/Operations.lean
+++ b/Mathlib/RingTheory/FractionalIdeal/Operations.lean
@@ -321,7 +321,7 @@ section Quotient
 
 This section defines the ideal quotient of fractional ideals.
 
-In this section we need that each non-zero `y : R` has an inverse in
+In this section we need that each nonzero `y : R` has an inverse in
 the localization, i.e. that the localization is a field. We satisfy this
 assumption by taking `S = nonZeroDivisors R`, `R`'s localization at which
 is a field because `R` is a domain.

--- a/Mathlib/RingTheory/Ideal/GoingUp.lean
+++ b/Mathlib/RingTheory/Ideal/GoingUp.lean
@@ -96,7 +96,7 @@ theorem quotient_mk_maps_eq (P : Ideal R[X]) :
   rw [quotientMap_mk, coe_mapRingHom, map_C]
 
 /-- This technical lemma asserts the existence of a polynomial `p` in an ideal `P ⊂ R[x]`
-that is non-zero in the quotient `R / (P ∩ R) [x]`.  The assumptions are equivalent to
+that is nonzero in the quotient `R / (P ∩ R) [x]`.  The assumptions are equivalent to
 `P ≠ 0` and `P ∩ R = (0)`.
 -/
 theorem exists_nonzero_mem_of_ne_bot {P : Ideal R[X]} (Pb : P ≠ ⊥) (hP : ∀ x : R, C x ∈ P → x = 0) :

--- a/Mathlib/RingTheory/IntegralClosure/Algebra/Basic.lean
+++ b/Mathlib/RingTheory/IntegralClosure/Algebra/Basic.lean
@@ -83,7 +83,7 @@ theorem isIntegral_of_submodule_noetherian (S : Subalgebra R B)
     (H : IsNoetherian R (Subalgebra.toSubmodule S)) (x : B) (hx : x ∈ S) : IsIntegral R x :=
   .of_mem_of_fg _ ((fg_top _).mp <| H.noetherian _) _ hx
 
-/-- Suppose `A` is an `R`-algebra, `M` is an `A`-module such that `a • m ≠ 0` for all non-zero `a`
+/-- Suppose `A` is an `R`-algebra, `M` is an `A`-module such that `a • m ≠ 0` for all nonzero `a`
 and `m`. If `x : A` fixes a nontrivial f.g. `R`-submodule `N` of `M`, then `x` is `R`-integral. -/
 theorem isIntegral_of_smul_mem_submodule {M : Type*} [AddCommGroup M] [Module R M] [Module A M]
     [IsScalarTower R A M] [NoZeroSMulDivisors A M] (N : Submodule R M) (hN : N ≠ ⊥) (hN' : N.FG)

--- a/Mathlib/RingTheory/LaurentSeries.lean
+++ b/Mathlib/RingTheory/LaurentSeries.lean
@@ -42,9 +42,9 @@ type with a zero. They are denoted `R⸨X⸩`.
 
 * Basic properties of Hasse derivatives
 ### About the `X`-Adic valuation:
-* The (integral) valuation of a power series is the order of the first non-zero coefficient, see
+* The (integral) valuation of a power series is the order of the first nonzero coefficient, see
   `LaurentSeries.intValuation_le_iff_coeff_lt_eq_zero`.
-* The valuation of a Laurent series is the order of the first non-zero coefficient, see
+* The valuation of a Laurent series is the order of the first nonzero coefficient, see
   `LaurentSeries.valuation_le_iff_coeff_lt_eq_zero`.
 * Every Laurent series of valuation less than `(1 : ℤᵐ⁰)` comes from a power series, see
   `LaurentSeries.val_le_one_iff_eq_coe`.
@@ -513,7 +513,7 @@ theorem coeff_zero_of_lt_intValuation {n d : ℕ} {f : K⟦X⟧}
     intValuation_le_pow_iff_dvd (PowerSeries.idealX K) f d, PowerSeries.idealX,
     Ideal.span_singleton_pow, span_singleton_dvd_span_singleton_iff_dvd] at H
 
-/- The valuation of a power series is the order of the first non-zero coefficient. -/
+/- The valuation of a power series is the order of the first nonzero coefficient. -/
 theorem intValuation_le_iff_coeff_lt_eq_zero {d : ℕ} (f : K⟦X⟧) :
     Valued.v (f : K⸨X⸩) ≤ Multiplicative.ofAdd (-d : ℤ) ↔
       ∀ n : ℕ, n < d → coeff n f = 0 := by
@@ -551,7 +551,7 @@ theorem coeff_zero_of_lt_valuation {n D : ℤ} {f : K⸨X⸩}
       ofAdd_add, valuation_single_zpow, neg_neg, WithZero.coe_mul,
       mul_le_mul_left (by simp only [ne_eq, WithZero.coe_ne_zero, not_false_iff, zero_lt_iff])]
 
-/- The valuation of a Laurent series is the order of the first non-zero coefficient. -/
+/- The valuation of a Laurent series is the order of the first nonzero coefficient. -/
 theorem valuation_le_iff_coeff_lt_eq_zero {D : ℤ} {f : K⸨X⸩} :
     Valued.v f ≤ ↑(Multiplicative.ofAdd (-D : ℤ)) ↔ ∀ n : ℤ, n < D → f.coeff n = 0 := by
   refine ⟨fun hnD n hn => coeff_zero_of_lt_valuation K hnD hn, fun h_val_f => ?_⟩

--- a/Mathlib/RingTheory/Localization/Defs.lean
+++ b/Mathlib/RingTheory/Localization/Defs.lean
@@ -875,12 +875,12 @@ variable [IsDomain R]
 
 variable (S) in
 /-- A `CommRing` `S` which is the localization of an integral domain `R` at a subset of
-non-zero elements is an integral domain. -/
+nonzero elements is an integral domain. -/
 theorem isDomain_of_le_nonZeroDivisors (hM : M ≤ nonZeroDivisors R) : IsDomain S where
   __ : IsCancelMulZero S := (toLocalizationMap M S).isCancelMulZero
   __ : Nontrivial S := (toLocalizationMap M S).nontrivial fun h ↦ zero_notMem_nonZeroDivisors (hM h)
 
-/-- The localization of an integral domain to a set of non-zero elements is an integral domain. -/
+/-- The localization of an integral domain to a set of nonzero elements is an integral domain. -/
 theorem isDomain_localization {M : Submonoid R} (hM : M ≤ nonZeroDivisors R) :
     IsDomain (Localization M) :=
   isDomain_of_le_nonZeroDivisors _ hM

--- a/Mathlib/RingTheory/MvPolynomial/Homogeneous.lean
+++ b/Mathlib/RingTheory/MvPolynomial/Homogeneous.lean
@@ -241,7 +241,7 @@ end CommRing
 
 /-- The homogeneous degree bounds the total degree.
 
-See also `MvPolynomial.IsHomogeneous.totalDegree` when `φ` is non-zero. -/
+See also `MvPolynomial.IsHomogeneous.totalDegree` when `φ` is nonzero. -/
 lemma totalDegree_le (hφ : IsHomogeneous φ n) : φ.totalDegree ≤ n := by
   apply Finset.sup_le
   intro d hd

--- a/Mathlib/RingTheory/Polynomial/Quotient.lean
+++ b/Mathlib/RingTheory/Polynomial/Quotient.lean
@@ -154,7 +154,7 @@ theorem isDomain_map_C_quotient {P : Ideal R} (_ : IsPrime P) :
 /-- Given any ring `R` and an ideal `I` of `R[X]`, we get a map `R → R[x] → R[x]/I`.
   If we let `R` be the image of `R` in `R[x]/I` then we also have a map `R[x] → R'[x]`.
   In particular we can map `I` across this map, to get `I'` and a new map `R' → R'[x] → R'[x]/I`.
-  This theorem shows `I'` will not contain any non-zero constant polynomials. -/
+  This theorem shows `I'` will not contain any nonzero constant polynomials. -/
 theorem eq_zero_of_polynomial_mem_map_range (I : Ideal R[X]) (x : ((Quotient.mk I).comp C).range)
     (hx : C x ∈ I.map (Polynomial.mapRingHom ((Quotient.mk I).comp C).rangeRestrict)) : x = 0 := by
   let i := ((Quotient.mk I).comp C).rangeRestrict

--- a/Mathlib/RingTheory/Polynomial/UniqueFactorization.lean
+++ b/Mathlib/RingTheory/Polynomial/UniqueFactorization.lean
@@ -88,7 +88,7 @@ instance (priority := 100) uniqueFactorizationMonoid : UniqueFactorizationMonoid
   letI := Classical.arbitrary (NormalizedGCDMonoid D)
   exact ufm_of_decomposition_of_wfDvdMonoid
 
-/-- If `D` is a unique factorization domain, `f` is a non-zero polynomial in `D[X]`, then `f` has
+/-- If `D` is a unique factorization domain, `f` is a nonzero polynomial in `D[X]`, then `f` has
 only finitely many monic factors.
 (Note that its factors up to unit may be more than monic factors.)
 See also `UniqueFactorizationMonoid.fintypeSubtypeDvd`. -/

--- a/Mathlib/RingTheory/PowerSeries/Inverse.lean
+++ b/Mathlib/RingTheory/PowerSeries/Inverse.lean
@@ -199,7 +199,7 @@ theorem X_inv : (X : k⟦X⟧)⁻¹ = 0 :=
 theorem smul_inv (r : k) (φ : k⟦X⟧) : (r • φ)⁻¹ = r⁻¹ • φ⁻¹ :=
   MvPowerSeries.smul_inv _ _
 
-/-- `firstUnitCoeff` is the non-zero coefficient whose index is `f.order`, seen as a unit of the
+/-- `firstUnitCoeff` is the nonzero coefficient whose index is `f.order`, seen as a unit of the
   field. It is obtained using `divided_by_X_pow_order`, defined in `PowerSeries.Order`. -/
 def firstUnitCoeff {f : k⟦X⟧} (hf : f ≠ 0) : kˣ :=
   have : Invertible (constantCoeff (divXPowOrder f)) := by
@@ -207,7 +207,7 @@ def firstUnitCoeff {f : k⟦X⟧} (hf : f ≠ 0) : kˣ :=
     simpa [constantCoeff_divXPowOrder_eq_zero_iff.not]
   unitOfInvertible (constantCoeff (divXPowOrder f))
 
-/-- `Inv_divided_by_X_pow_order` is the inverse of the element obtained by diving a non-zero power
+/-- `Inv_divided_by_X_pow_order` is the inverse of the element obtained by diving a nonzero power
 series by the largest power of `X` dividing it. Useful to create a term of type `Units`, done in
 `Unit_divided_by_X_pow_order` -/
 def Inv_divided_by_X_pow_order {f : k⟦X⟧} (hf : f ≠ 0) : k⟦X⟧ :=

--- a/Mathlib/RingTheory/PowerSeries/Inverse.lean
+++ b/Mathlib/RingTheory/PowerSeries/Inverse.lean
@@ -225,7 +225,7 @@ theorem Inv_divided_by_X_pow_order_leftInv {f : k⟦X⟧} (hf : f ≠ 0) :
   exact mul_invOfUnit (divXPowOrder f) (firstUnitCoeff hf) rfl
 
 open scoped Classical in
-/-- `Unit_of_divided_by_X_pow_order` is the unit power series obtained by dividing a non-zero
+/-- `Unit_of_divided_by_X_pow_order` is the unit power series obtained by dividing a nonzero
 power series by the largest power of `X` that divides it. -/
 def Unit_of_divided_by_X_pow_order (f : k⟦X⟧) : k⟦X⟧ˣ :=
   if hf : f = 0 then 1

--- a/Mathlib/RingTheory/PowerSeries/Order.lean
+++ b/Mathlib/RingTheory/PowerSeries/Order.lean
@@ -19,7 +19,7 @@ We prove that if the commutative ring `R` of coefficients is an integral domain,
 then the ring `R⟦X⟧` of formal power series in one variable over `R`
 is an integral domain.
 
-Given a non-zero power series `f`, `divided_by_X_pow_order f` is the power series obtained by
+Given a nonzero power series `f`, `divided_by_X_pow_order f` is the power series obtained by
 dividing out the largest power of X that divides `f`, that is its order. This is useful when
 proving that `R⟦X⟧` is a normalization monoid, which is done in `PowerSeries.Inverse`.
 
@@ -236,7 +236,7 @@ theorem coeff_mul_prod_one_sub_of_lt_order {R ι : Type*} [CommRing R] (k : ℕ)
     rw [Finset.prod_insert ha, ← mul_assoc, mul_right_comm, coeff_mul_one_sub_of_lt_order _ t.1]
     exact ih t.2
 
-/-- Given a non-zero power series `f`, `divXPowOrder f` is the power series obtained by
+/-- Given a nonzero power series `f`, `divXPowOrder f` is the power series obtained by
 dividing out the largest power of X that divides `f`, that is its order -/
 def divXPowOrder (f : R⟦X⟧) : R⟦X⟧ :=
   .mk fun n ↦ coeff (n + f.order.toNat) f

--- a/Mathlib/RingTheory/PrincipalIdealDomain.lean
+++ b/Mathlib/RingTheory/PrincipalIdealDomain.lean
@@ -30,7 +30,7 @@ Theorems about PID's are in the `PrincipalIdealRing` namespace.
 
 # Main results
 
-- `Ideal.IsPrime.to_maximal_ideal`: a non-zero prime ideal in a PID is maximal.
+- `Ideal.IsPrime.to_maximal_ideal`: a nonzero prime ideal in a PID is maximal.
 - `EuclideanDomain.to_principal_ideal_domain` : a Euclidean domain is a PID.
 - `IsBezout.nonemptyGCDMonoid`: Every Bézout domain is a GCD domain.
 

--- a/Mathlib/RingTheory/Radical.lean
+++ b/Mathlib/RingTheory/Radical.lean
@@ -124,7 +124,7 @@ lemma primeFactors_val_eq_normalizedFactors (ha : IsRadical a) :
   rw [primeFactors, Multiset.toFinset_val, Multiset.dedup_eq_self]
   exact normalizedFactors_nodup ha
 
--- Note that the non-zero assumptions are necessary here.
+-- Note that the nonzero assumptions are necessary here.
 theorem primeFactors_mul_eq_union [DecidableEq M] (ha : a ≠ 0) (hb : b ≠ 0) :
     primeFactors (a * b) = primeFactors a ∪ primeFactors b := by
   ext p

--- a/Mathlib/RingTheory/RootsOfUnity/Basic.lean
+++ b/Mathlib/RingTheory/RootsOfUnity/Basic.lean
@@ -29,7 +29,7 @@ and it will mainly be applied to rings (e.g. the ring of integers in a number fi
 We therefore implement it as a subgroup of the units of a commutative monoid.
 
 We have chosen to define `rootsOfUnity n` for `n : ℕ` and add a `[NeZero n]` typeclass
-assumption when we need `n` to be non-zero (which is the case for most interesting statements).
+assumption when we need `n` to be nonzero (which is the case for most interesting statements).
 Note that `rootsOfUnity 0 M` is the top subgroup of `Mˣ` (as the condition `ζ^0 = 1` is
 satisfied for all units).
 -/

--- a/Mathlib/RingTheory/Spectrum/Prime/Basic.lean
+++ b/Mathlib/RingTheory/Spectrum/Prime/Basic.lean
@@ -456,7 +456,7 @@ theorem exists_primeSpectrum_prod_le (I : Ideal R) :
   apply sup_le (show span R {x} * M ≤ M from Ideal.mul_le_left)
   rwa [span_mul_span, Set.singleton_mul_singleton, span_singleton_le_iff_mem]
 
-/-- In a Noetherian integral domain which is not a field, every nonzero ideal contains a non-zero
+/-- In a Noetherian integral domain which is not a field, every nonzero ideal contains a nonzero
   product of prime ideals; in a field, the whole ring is a nonzero ideal containing only 0 as
   product or prime ideals ([samuel1967, § 3.3, Lemma 3]) -/
 theorem exists_primeSpectrum_prod_le_and_ne_bot_of_domain (h_fA : ¬IsField A) {I : Ideal A}

--- a/Mathlib/RingTheory/Spectrum/Prime/Basic.lean
+++ b/Mathlib/RingTheory/Spectrum/Prime/Basic.lean
@@ -456,8 +456,8 @@ theorem exists_primeSpectrum_prod_le (I : Ideal R) :
   apply sup_le (show span R {x} * M ≤ M from Ideal.mul_le_left)
   rwa [span_mul_span, Set.singleton_mul_singleton, span_singleton_le_iff_mem]
 
-/-- In a Noetherian integral domain which is not a field, every non-zero ideal contains a non-zero
-  product of prime ideals; in a field, the whole ring is a non-zero ideal containing only 0 as
+/-- In a Noetherian integral domain which is not a field, every nonzero ideal contains a non-zero
+  product of prime ideals; in a field, the whole ring is a nonzero ideal containing only 0 as
   product or prime ideals ([samuel1967, § 3.3, Lemma 3]) -/
 theorem exists_primeSpectrum_prod_le_and_ne_bot_of_domain (h_fA : ¬IsField A) {I : Ideal A}
     (h_nzI : I ≠ ⊥) :

--- a/Mathlib/RingTheory/Spectrum/Prime/IsOpenComapC.lean
+++ b/Mathlib/RingTheory/Spectrum/Prime/IsOpenComapC.lean
@@ -36,7 +36,7 @@ theorem isOpen_imageOfDf : IsOpen (imageOfDf f) := by
   exact isOpen_iUnion fun i => isOpen_basicOpen
 
 /-- If a point of `Spec R[x]` is not contained in the vanishing set of `f`, then its image in
-`Spec R` is contained in the open set where at least one of the coefficients of `f` is non-zero.
+`Spec R` is contained in the open set where at least one of the coefficients of `f` is nonzero.
 This lemma is a reformulation of `exists_C_coeff_notMem`. -/
 theorem comap_C_mem_imageOfDf {I : PrimeSpectrum R[X]}
     (H : I ∈ (zeroLocus {f} : Set (PrimeSpectrum R[X]))ᶜ) :

--- a/Mathlib/RingTheory/UniqueFactorizationDomain/Ideal.lean
+++ b/Mathlib/RingTheory/UniqueFactorizationDomain/Ideal.lean
@@ -18,7 +18,7 @@ import Mathlib.RingTheory.UniqueFactorizationDomain.Defs
 variable {α : Type*}
 
 open UniqueFactorizationMonoid in
-/-- Every non-zero prime ideal in a unique factorization domain contains a prime element. -/
+/-- Every nonzero prime ideal in a unique factorization domain contains a prime element. -/
 theorem Ideal.IsPrime.exists_mem_prime_of_ne_bot {R : Type*} [CommSemiring R] [IsDomain R]
     [UniqueFactorizationMonoid R] {I : Ideal R} (hI₂ : I.IsPrime) (hI : I ≠ ⊥) :
     ∃ x ∈ I, Prime x := by

--- a/Mathlib/SetTheory/Ordinal/CantorNormalForm.lean
+++ b/Mathlib/SetTheory/Ordinal/CantorNormalForm.lean
@@ -11,7 +11,7 @@ import Mathlib.SetTheory.Ordinal.Family
 # Cantor Normal Form
 
 The Cantor normal form of an ordinal is generally defined as its base `ω` expansion, with its
-non-zero exponents in decreasing order. Here, we more generally define a base `b` expansion
+nonzero exponents in decreasing order. Here, we more generally define a base `b` expansion
 `Ordinal.CNF` in this manner, which is well-behaved for any `b ≥ 2`.
 
 # Implementation notes

--- a/Mathlib/Tactic/ComputeDegree.lean
+++ b/Mathlib/Tactic/ComputeDegree.lean
@@ -423,7 +423,7 @@ if `norm_num`med.
   --- reducing to `False` means that there is a term of degree that is apparently too large.
 
 The cases `a ≠ b` and `a = b` are not a perfect match with the top coefficient:
-reducing to `False` is not exactly correlated with a coefficient being non-zero.
+reducing to `False` is not exactly correlated with a coefficient being nonzero.
 It does mean that `compute_degree` reduced the initial goal to an unprovable state
 (unless there was already a contradiction in the initial hypotheses!), but it is indicative that
 there may be some problem.

--- a/Mathlib/Tactic/ComputeDegree.lean
+++ b/Mathlib/Tactic/ComputeDegree.lean
@@ -155,7 +155,7 @@ They achieve the following goals.
   but it "picks it up along the way".
 * They split checking the inequality `coeff p n ≠ 0` into the task of
   finding a value `c` for the `coeff` and then
-  proving that this value is non-zero by `coeff_ne_zero`.
+  proving that this value is nonzero by `coeff_ne_zero`.
 -/
 theorem natDegree_eq_of_le_of_coeff_ne_zero' {deg m o : ℕ} {c : R} {p : R[X]}
     (h_natDeg_le : natDegree p ≤ m) (coeff_eq : coeff p o = c)

--- a/Mathlib/Topology/Algebra/ConstMulAction.lean
+++ b/Mathlib/Topology/Algebra/ConstMulAction.lean
@@ -301,7 +301,7 @@ theorem continuousAt_const_smul_iff₀ (hc : c ≠ 0) :
 theorem continuous_const_smul_iff₀ (hc : c ≠ 0) : (Continuous fun x => c • f x) ↔ Continuous f :=
   continuous_const_smul_iff (Units.mk0 c hc)
 
-/-- Scalar multiplication by a non-zero element of a group with zero acting on `α` is a
+/-- Scalar multiplication by a nonzero element of a group with zero acting on `α` is a
 homeomorphism from `α` onto itself. -/
 @[simps! -fullyApplied apply]
 protected def Homeomorph.smulOfNeZero (c : G₀) (hc : c ≠ 0) : α ≃ₜ α :=

--- a/Mathlib/Topology/Algebra/Field.lean
+++ b/Mathlib/Topology/Algebra/Field.lean
@@ -14,7 +14,7 @@ import Mathlib.Topology.Order.LocalExtr
 # Topological fields
 
 A topological division ring is a topological ring whose inversion function is continuous at every
-non-zero element.
+nonzero element.
 
 -/
 

--- a/Mathlib/Topology/Algebra/GroupWithZero.lean
+++ b/Mathlib/Topology/Algebra/GroupWithZero.lean
@@ -86,7 +86,7 @@ variable [Zero G₀] [Inv G₀] [TopologicalSpace G₀] [HasContinuousInv₀ G�
   {s : Set α} {a : α}
 
 /-!
-### Continuity of `fun x ↦ x⁻¹` at a non-zero point
+### Continuity of `fun x ↦ x⁻¹` at a nonzero point
 
 We define `HasContinuousInv₀` to be a `GroupWithZero` such that the operation `x ↦ x⁻¹`
 is continuous at all nonzero points. In this section we prove dot-style `*.inv₀` lemmas for

--- a/Mathlib/Topology/Algebra/Ring/Compact.lean
+++ b/Mathlib/Topology/Algebra/Ring/Compact.lean
@@ -27,7 +27,7 @@ import Mathlib.Topology.Algebra.Ring.Ideal
 - `IsLocalRing.isOpen_iff_finite_quotient`:
   An ideal in a compact Hausdorff Noetherian local ring is open iff it has finite index.
 - `IsDedekindDomain.isOpen_iff`:
-  An ideal in a compact Hausdorff Dedekind domain (that is not a field) is open iff it is non-zero.
+  An ideal in a compact Hausdorff Dedekind domain (that is not a field) is open iff it is nonzero.
 
 ## Future projects
 Show that compact Hausdorff rings are totally disconnected and linearly topologized.

--- a/Mathlib/Topology/Algebra/Support.lean
+++ b/Mathlib/Topology/Algebra/Support.lean
@@ -405,7 +405,7 @@ of open sets, then for any point we can find a neighbourhood on which only finit
 `f` are not equal to 1. -/
 @[to_additive /-- If a family of functions `f` has locally-finite support, subordinate to a family
 of open sets, then for any point we can find a neighbourhood on which only finitely-many members of
-`f` are non-zero. -/]
+`f` are nonzero. -/]
 theorem LocallyFinite.exists_finset_nhds_mulSupport_subset {U : ι → Set X} [One R] {f : ι → X → R}
     (hlf : LocallyFinite fun i => mulSupport (f i)) (hso : ∀ i, mulTSupport (f i) ⊆ U i)
     (ho : ∀ i, IsOpen (U i)) (x : X) :

--- a/Mathlib/Topology/Algebra/Valued/LocallyCompact.lean
+++ b/Mathlib/Topology/Algebra/Valued/LocallyCompact.lean
@@ -177,7 +177,7 @@ lemma locallyFiniteOrder_units_mrange_of_isCompact_integer (hc : IsCompact (X :=
   constructor
   refine LocallyFiniteOrder.ofFiniteIcc ?_
   -- We only need to show that we can construct a finite set for some set between
-  -- a non-zero `z : Γ₀` and 1, because we can scale/invert this set to cover the whole group.
+  -- a nonzero `z : Γ₀` and 1, because we can scale/invert this set to cover the whole group.
   suffices ∀ z : (MonoidHom.mrange (Valued.v : Valuation K Γ₀))ˣ, (Set.Icc z 1).Finite by
     rintro x y
     rcases lt_trichotomy y x with hxy | rfl | hxy

--- a/Mathlib/Topology/Algebra/Valued/ValuedField.lean
+++ b/Mathlib/Topology/Algebra/Valued/ValuedField.lean
@@ -18,7 +18,7 @@ We already know from valuation.topology that one can build a topology on `K` whi
 makes it a topological ring.
 
 The first goal is to show `K` is a topological *field*, i.e. inversion is continuous
-at every non-zero element.
+at every nonzero element.
 
 The next goal is to prove `K` is a *completable* topological field. This gives us
 a completion `hat K` which is a topological field. We also prove that `K` is automatically

--- a/Mathlib/Topology/Algebra/WithZeroTopology.lean
+++ b/Mathlib/Topology/Algebra/WithZeroTopology.lean
@@ -73,7 +73,7 @@ theorem tendsto_zero : Tendsto f l (𝓝 (0 : Γ₀)) ↔ ∀ (γ₀) (_ : γ₀
   simp [nhds_zero]
 
 /-!
-### Neighbourhoods of non-zero elements
+### Neighbourhoods of nonzero elements
 -/
 
 /-- The neighbourhood filter of a nonzero element consists of all sets containing that

--- a/MathlibTest/ComputeDegree.lean
+++ b/MathlibTest/ComputeDegree.lean
@@ -96,7 +96,7 @@ example : 0 ≤ 0 := by compute_degree!
 --  OfNat.ofNat 0
 example : natDegree (0 : ℤ[X]) ≤ 5 := by compute_degree!
 
---  OfNat.ofNat (non-zero)
+--  OfNat.ofNat (nonzero)
 example : natDegree (1 : ℤ[X]) ≤ 5 := by compute_degree!
 
 --  NatCast.natCast
@@ -128,7 +128,7 @@ variable [Ring R]
 --  OfNat.ofNat 0
 example : natDegree (0 : R[X]) ≤ 5 := by compute_degree!
 
---  OfNat.ofNat (non-zero)
+--  OfNat.ofNat (nonzero)
 example : natDegree (1 : R[X]) ≤ 5 := by compute_degree!
 
 --  NatCast.natCast

--- a/MathlibTest/FieldSimp.lean
+++ b/MathlibTest/FieldSimp.lean
@@ -129,7 +129,7 @@ example : P (x ^ 2 * x ^ (-2 : ℤ)) := by test_field_simp
 #guard_msgs in
 example : P (x ^ (-37 : ℤ) * x ^ 37) := by test_field_simp
 
--- If x is non-zero, we do cancel.
+-- If x is nonzero, we do cancel.
 
 /-- info: P 1 -/
 #guard_msgs in


### PR DESCRIPTION
Hyphenating adjectives starting with "non-" is not preferred, with a few exceptions. "Non-zero" is not one of those exceptions.

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include at least one commit authored by each
co-author among the commits in the pull request. If necessary, you may 
create empty commits to indicate co-authorship, using commands like so:

git commit --author="Author Name <author@email.com>" --allow-empty -m "add Author Name as coauthor"

When merging, all the commits will be squashed into a single commit listing all co-authors.

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
