### PR TITLE
[Merged by Bors] - fix(TacticAnalysis): remove syntax range check

### DIFF
--- a/Mathlib/Tactic/TacticAnalysis.lean
+++ b/Mathlib/Tactic/TacticAnalysis.lean
@@ -147,7 +147,7 @@ own sequence.
 -/
 def findTacticSeqs (stx : Syntax) (tree : InfoTree) :
     CommandElabM (Array (Array (ContextInfo × TacticInfo))) := do
-  let some enclosingRange := stx.getRange? |
+  let some _enclosingRange := stx.getRange? |
     throw (Exception.error stx m!"operating on syntax without range")
   -- Turn the CommandElabM into a surrounding context for traversing the tree.
   let ctx ← read
@@ -155,8 +155,12 @@ def findTacticSeqs (stx : Syntax) (tree : InfoTree) :
   let ctxInfo := { env := state.env, fileMap := ctx.fileMap, ngen := state.ngen }
   let out ← tree.visitM (m := CommandElabM) (ctx? := some ctxInfo)
     (fun _ i _ => do
-      if let some range := i.stx.getRange? then
-        pure <| enclosingRange.start <= range.start && range.stop <= enclosingRange.stop
+      if let some _range := i.stx.getRange? then
+        -- It turns out some syntax replacements change the ranges, so we get misleading answers.
+        -- Comment out the check for now, since the worst that can happen is we analyze a piece
+        -- of syntax that belongs to another declaration (that would be analyzed later on anyway).
+        -- pure <| enclosingRange.start <= range.start && range.stop <= enclosingRange.stop
+        pure true
       else pure false)
     (fun ctx i _c cs => do
       let relevantChildren := (cs.filterMap id).toArray

--- a/Mathlib/Tactic/TacticAnalysis.lean
+++ b/Mathlib/Tactic/TacticAnalysis.lean
@@ -156,9 +156,12 @@ def findTacticSeqs (stx : Syntax) (tree : InfoTree) :
   let out ← tree.visitM (m := CommandElabM) (ctx? := some ctxInfo)
     (fun _ i _ => do
       if let some _range := i.stx.getRange? then
-        -- It turns out some syntax replacements change the ranges, so we get misleading answers.
-        -- Comment out the check for now, since the worst that can happen is we analyze a piece
-        -- of syntax that belongs to another declaration (that would be analyzed later on anyway).
+        /-
+        It turns out some syntax replacements change the ranges, so we get misleading answers.
+        Comment out the check for now, since the worst that can happen is we analyze a piece
+        of syntax that belongs to another declaration (that would be analyzed later on anyway).
+        See [Zulip](https://leanprover.zulipchat.com/#narrow/channel/270676-lean4/topic/What.20can.20one.20actually.20do.20with.20docs.23Syntax.2EgetRange.3F/with/536203324).
+        -/
         -- pure <| enclosingRange.start <= range.start && range.stop <= enclosingRange.stop
         pure true
       else pure false)

--- a/MathlibTest/TacticAnalysis.lean
+++ b/MathlibTest/TacticAnalysis.lean
@@ -36,6 +36,19 @@ example : x = z := by
   rw [xy]
   rw [yz]
 
+-- Definitions using `where` clauses did not get picked up by the framework,
+-- since apparently their syntax bounds do not match the original.
+structure Fact (p : Prop) : Prop where
+  out : p
+/--
+warning: Try this: rw [xy, yz]
+-/
+#guard_msgs in
+example : Fact (x = z) where
+  out := by
+    rw [xy]
+    rw [yz]
+
 end rwMerge
 
 section mergeWithGrind


### PR DESCRIPTION
In #28802 we discovered the tactic analysis framework does not fire on declarations using `where` clauses. The reason is that `def foo where ...` gets turned into `def foo := { ... }`, and the `{ ... }` syntax is assigned a range outside of the `where ...` syntax; this causes the syntax range check to omit the whole declaration body. Moreover, [Verso involves pieces of syntax without any range at all](https://leanprover.zulipchat.com/#narrow/channel/287929-mathlib4/topic/Possible.20Verso.E2.80.93Mathlib.20conflict/with/543352839). So the range of a piece of syntax is essentially meaningless and we should not check it at all.

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include at least one commit authored by each
co-author among the commits in the pull request. If necessary, you may 
create empty commits to indicate co-authorship, using commands like so:

git commit --author="Author Name <author@email.com>" --allow-empty -m "add Author Name as coauthor"

When merging, all the commits will be squashed into a single commit listing all co-authors.

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
