### PR TITLE
[Merged by Bors] - fix: squeeze some non-terminal simps

### DIFF
--- a/Mathlib/Computability/Tape.lean
+++ b/Mathlib/Computability/Tape.lean
@@ -5,7 +5,6 @@ Authors: Mario Carneiro
 -/
 import Mathlib.Data.Vector.Basic
 import Mathlib.Logic.Function.Iterate
-import Mathlib.Order.Basic
 import Mathlib.Tactic.ApplyFun
 import Mathlib.Data.List.GetD
 

--- a/Mathlib/Data/List/Basic.lean
+++ b/Mathlib/Data/List/Basic.lean
@@ -986,11 +986,9 @@ theorem filterMap_eq_map_iff_forall_eq_some {f : α → Option β} {g : α → �
   mp := by
     induction l with | nil => simp | cons a l ih => ?_
     rcases ha : f a with - | b
-    · simp only [ha, filterMap_cons_none, map_cons, mem_cons, forall_eq_or_imp, reduceCtorEq,
-        false_and, imp_false]
-      intro h
-      simpa [show (filterMap f l).length = l.length + 1 from by simp [h], Nat.add_one_le_iff]
-        using List.length_filterMap_le f l
+    · intro h
+      have : (filterMap f l).length = l.length + 1 := by grind
+      grind
     · simp +contextual [ha, ih]
   mpr h := Eq.trans (filterMap_congr <| by simpa) (congr_fun filterMap_eq_map _)
 

--- a/Mathlib/Data/List/Basic.lean
+++ b/Mathlib/Data/List/Basic.lean
@@ -985,12 +985,13 @@ theorem filterMap_eq_map_iff_forall_eq_some {f : α → Option β} {g : α → �
     l.filterMap f = l.map g ↔ ∀ x ∈ l, f x = some (g x) where
   mp := by
     induction l with | nil => simp | cons a l ih => ?_
-    rcases ha : f a with - | b <;> simp [ha]
-    · intro h
+    rcases ha : f a with - | b
+    · simp only [ha, filterMap_cons_none, map_cons, mem_cons, forall_eq_or_imp, reduceCtorEq,
+        false_and, imp_false]
+      intro h
       simpa [show (filterMap f l).length = l.length + 1 from by simp [h], Nat.add_one_le_iff]
         using List.length_filterMap_le f l
-    · rintro rfl h
-      exact ⟨rfl, ih h⟩
+    · simp +contextual [ha, ih]
   mpr h := Eq.trans (filterMap_congr <| by simpa) (congr_fun filterMap_eq_map _)
 
 /-! ### filter -/

--- a/Mathlib/Data/List/Basic.lean
+++ b/Mathlib/Data/List/Basic.lean
@@ -10,7 +10,6 @@ import Mathlib.Data.List.Defs
 import Mathlib.Data.List.Monad
 import Mathlib.Logic.OpClass
 import Mathlib.Logic.Unique
-import Mathlib.Order.Basic
 import Mathlib.Tactic.Common
 
 /-!

--- a/Mathlib/Data/List/Infix.lean
+++ b/Mathlib/Data/List/Infix.lean
@@ -5,6 +5,7 @@ Authors: Mario Carneiro
 -/
 import Mathlib.Data.List.TakeDrop
 import Mathlib.Data.List.Induction
+import Mathlib.Order.Basic
 
 /-!
 # Prefixes, suffixes, infixes

--- a/Mathlib/Data/List/InsertIdx.lean
+++ b/Mathlib/Data/List/InsertIdx.lean
@@ -4,6 +4,7 @@ Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Parikshit Khanna, Jeremy Avigad, Leonardo de Moura, Floris van Doorn, Mario Carneiro
 -/
 import Mathlib.Data.List.Basic
+import Mathlib.Order.Basic
 
 /-!
 # insertIdx

--- a/Mathlib/Data/List/Nodup.lean
+++ b/Mathlib/Data/List/Nodup.lean
@@ -4,6 +4,7 @@ Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Mario Carneiro, Kenny Lau
 -/
 import Mathlib.Data.List.Forall2
+import Mathlib.Order.Basic
 
 /-!
 # Lists with no duplicates

--- a/Mathlib/Data/List/ReduceOption.lean
+++ b/Mathlib/Data/List/ReduceOption.lean
@@ -118,7 +118,7 @@ theorem reduceOption_length_lt_iff {l : List (Option α)} :
     reduceOption_length_eq_iff]
   induction l
   · simp
-  · simp; rw [@eq_comm _ none, ← Option.not_isSome_iff_eq_none, Decidable.imp_iff_not_or]
+  · grind [cases Option]
 
 theorem reduceOption_singleton (x : Option α) : [x].reduceOption = x.toList := by cases x <;> rfl
 

--- a/Mathlib/Data/List/ReduceOption.lean
+++ b/Mathlib/Data/List/ReduceOption.lean
@@ -116,8 +116,9 @@ theorem reduceOption_length_lt_iff {l : List (Option α)} :
     l.reduceOption.length < l.length ↔ none ∈ l := by
   rw [Nat.lt_iff_le_and_ne, and_iff_right (reduceOption_length_le l), Ne,
     reduceOption_length_eq_iff]
-  induction l <;> simp
-  rw [@eq_comm _ none, ← Option.not_isSome_iff_eq_none, Decidable.imp_iff_not_or]
+  induction l
+  · simp
+  · simp; rw [@eq_comm _ none, ← Option.not_isSome_iff_eq_none, Decidable.imp_iff_not_or]
 
 theorem reduceOption_singleton (x : Option α) : [x].reduceOption = x.toList := by cases x <;> rfl
 

--- a/Mathlib/Data/Nat/PSub.lean
+++ b/Mathlib/Data/Nat/PSub.lean
@@ -71,11 +71,13 @@ theorem psub_eq_some {m : ℕ} : ∀ {n k}, psub m n = some k ↔ k + n = m
     simp [add_comm, add_left_comm]
 
 theorem psub_eq_none {m n : ℕ} : psub m n = none ↔ m < n := by
-  rcases s : psub m n <;> simp [eq_comm]
-  · refine lt_of_not_ge fun h => ?_
+  rcases s : psub m n
+  · simp only [true_iff]
+    refine lt_of_not_ge fun h => ?_
     obtain ⟨k, e⟩ := le.dest h
     injection s.symm.trans (psub_eq_some.2 <| (add_comm _ _).trans e)
-  · rw [← psub_eq_some.1 s]
+  · simp only [eq_comm, reduceCtorEq, false_iff, not_lt]
+    rw [← psub_eq_some.1 s]
     apply Nat.le_add_left
 
 theorem ppred_eq_pred {n} (h : 0 < n) : ppred n = some (pred n) :=

--- a/Mathlib/Data/Nat/PSub.lean
+++ b/Mathlib/Data/Nat/PSub.lean
@@ -76,9 +76,7 @@ theorem psub_eq_none {m n : ℕ} : psub m n = none ↔ m < n := by
     refine lt_of_not_ge fun h => ?_
     obtain ⟨k, e⟩ := le.dest h
     injection s.symm.trans (psub_eq_some.2 <| (add_comm _ _).trans e)
-  · simp only [eq_comm, reduceCtorEq, false_iff, not_lt]
-    rw [← psub_eq_some.1 s]
-    apply Nat.le_add_left
+  · grind [psub_eq_some]
 
 theorem ppred_eq_pred {n} (h : 0 < n) : ppred n = some (pred n) :=
   ppred_eq_some.2 <| succ_pred_eq_of_pos h

--- a/Mathlib/Data/Part.lean
+++ b/Mathlib/Data/Part.lean
@@ -261,9 +261,10 @@ theorem getOrElse_some (a : α) (d : α) [Decidable (some a).Dom] : getOrElse (s
 -- `simp`-normal form is `toOption_eq_some_iff`.
 theorem mem_toOption {o : Part α} [Decidable o.Dom] {a : α} : a ∈ toOption o ↔ a ∈ o := by
   unfold toOption
-  by_cases h : o.Dom <;> simp [h]
-  · exact ⟨fun h => ⟨_, h⟩, fun ⟨_, h⟩ => h⟩
-  · exact mt Exists.fst h
+  by_cases h : o.Dom
+  · simpa [h] using ⟨fun h => ⟨_, h⟩, fun ⟨_, h⟩ => h⟩
+  · simp only [h, ↓reduceDIte, Option.mem_def, reduceCtorEq, false_iff]
+    exact mt Exists.fst h
 
 @[simp]
 theorem toOption_eq_some_iff {o : Part α} [Decidable o.Dom] {a : α} :

--- a/Mathlib/Data/Sum/Order.lean
+++ b/Mathlib/Data/Sum/Order.lean
@@ -679,7 +679,7 @@ def sumLexDualAntidistrib (α β : Type*) [LE α] [LE β] : (α ⊕ₗ β)ᵒᵈ
   { Equiv.sumComm α β with
     map_rel_iff' := fun {a b} => by
       rcases a with (a | a) <;> rcases b with (b | b)
-      · simp
+      · simp only [ge_iff_le]
         change
           toLex (inr <| toDual a) ≤ toLex (inr <| toDual b) ↔
             toDual (toLex <| inl a) ≤ toDual (toLex <| inl b)

--- a/Mathlib/Order/Defs/LinearOrder.lean
+++ b/Mathlib/Order/Defs/LinearOrder.lean
@@ -255,16 +255,16 @@ lemma compare_eq_iff_eq : compare a b = .eq ↔ a = b := by
   case _ _ h => rwa [false_iff]
 
 lemma compare_le_iff_le : compare a b ≠ .gt ↔ a ≤ b := by
-  cases h : compare a b <;> simp
-  · exact le_of_lt <| compare_lt_iff_lt.1 h
-  · exact le_of_eq <| compare_eq_iff_eq.1 h
-  · exact compare_gt_iff_gt.1 h
+  cases h : compare a b
+  · simpa using le_of_lt <| compare_lt_iff_lt.1 h
+  · simpa using le_of_eq <| compare_eq_iff_eq.1 h
+  · simpa using compare_gt_iff_gt.1 h
 
 lemma compare_ge_iff_ge : compare a b ≠ .lt ↔ b ≤ a := by
-  cases h : compare a b <;> simp
-  · exact compare_lt_iff_lt.1 h
-  · exact le_of_eq <| (·.symm) <| compare_eq_iff_eq.1 h
-  · exact le_of_lt <| compare_gt_iff_gt.1 h
+  cases h : compare a b
+  · simpa using compare_lt_iff_lt.1 h
+  · simpa using le_of_eq <| (·.symm) <| compare_eq_iff_eq.1 h
+  · simpa using le_of_lt <| compare_gt_iff_gt.1 h
 
 lemma compare_iff (a b : α) {o : Ordering} : compare a b = o ↔ o.Compares a b := by
   cases o <;> simp only [Ordering.Compares]


### PR DESCRIPTION
---

Found by the flexible linter in #28962.

<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include at least one commit authored by each
co-author among the commits in the pull request. If necessary, you may 
create empty commits to indicate co-authorship, using commands like so:

git commit --author="Author Name <author@email.com>" --allow-empty -m "add Author Name as coauthor"

When merging, all the commits will be squashed into a single commit listing all co-authors.

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
