### PR TITLE
[Merged by Bors] - feat(Analysis/Meromorphic): MeromorphicAt.comp_analyticAt

### DIFF
--- a/Mathlib/Analysis/Meromorphic/Order.lean
+++ b/Mathlib/Analysis/Meromorphic/Order.lean
@@ -740,8 +740,7 @@ lemma MeromorphicAt.comp_analyticAt {g : 𝕜 → 𝕜}
     filter_upwards [nhdsWithin_le_nhds <| analyticOrderAt_eq_top.mp hg'] with z hz
     grind
   · -- interesting case: `g z - g x` looks like `(z - x) ^ n` times a non-vanishing function
-    rw [← Ne, WithTop.ne_top_iff_exists] at hg'
-    obtain ⟨n, hn⟩ := hg'
+    obtain ⟨n, hn⟩ := WithTop.ne_top_iff_exists.mp hg'
     obtain ⟨h, han, hne, heq⟩ := (hg.fun_sub analyticAt_const).analyticOrderAt_eq_natCast.mp hn.symm
     refine ⟨n * r, (((han.fun_inv hne).pow r).smul (hr.comp hg)).congr ?_⟩
     filter_upwards [heq, han.continuousAt.tendsto.eventually_ne hne] with z hz hzne

--- a/Mathlib/Analysis/Meromorphic/Order.lean
+++ b/Mathlib/Analysis/Meromorphic/Order.lean
@@ -730,3 +730,21 @@ theorem codiscrete_setOf_meromorphicOrderAt_eq_zero_or_top (hf : MeromorphicOn f
 alias codiscrete_setOf_order_eq_zero_or_top := codiscrete_setOf_meromorphicOrderAt_eq_zero_or_top
 
 end MeromorphicOn
+
+lemma MeromorphicAt.comp_analyticAt {g : 𝕜 → 𝕜}
+    (hf : MeromorphicAt f (g x)) (hg : AnalyticAt 𝕜 g x) : MeromorphicAt (f ∘ g) x := by
+  obtain ⟨r, hr⟩ := hf
+  by_cases hg' : analyticOrderAt (g · - g x) x = ⊤
+  · -- trivial case: `g` is locally constant near `x`
+    refine .congr (.const (f (g x)) x) ?_
+    filter_upwards [nhdsWithin_le_nhds <| analyticOrderAt_eq_top.mp hg'] with z hz
+    grind
+  · -- interesting case: `g z - g x` looks like `(z - x) ^ n` times a non-vanishing function
+    rw [← Ne, WithTop.ne_top_iff_exists] at hg'
+    obtain ⟨n, hn⟩ := hg'
+    obtain ⟨h, han, hne, heq⟩ := (hg.fun_sub analyticAt_const).analyticOrderAt_eq_natCast.mp hn.symm
+    refine ⟨n * r, (((han.fun_inv hne).pow r).smul (hr.comp hg)).congr ?_⟩
+    filter_upwards [heq, han.continuousAt.tendsto.eventually_ne hne] with z hz hzne
+    simp only [Pi.smul_apply', Pi.pow_apply, inv_pow, Function.comp_apply]
+    rw [inv_smul_eq_iff₀ (pow_ne_zero r hzne), ← mul_smul (h z ^ r), mul_comm, pow_mul,
+      ← mul_pow, ← smul_eq_mul, ← hz]

--- a/Mathlib/Analysis/Meromorphic/Order.lean
+++ b/Mathlib/Analysis/Meromorphic/Order.lean
@@ -742,8 +742,9 @@ lemma MeromorphicAt.comp_analyticAt {g : 𝕜 → 𝕜}
   · -- interesting case: `g z - g x` looks like `(z - x) ^ n` times a non-vanishing function
     obtain ⟨n, hn⟩ := WithTop.ne_top_iff_exists.mp hg'
     obtain ⟨h, han, hne, heq⟩ := (hg.fun_sub analyticAt_const).analyticOrderAt_eq_natCast.mp hn.symm
-    refine ⟨n * r, (((han.fun_inv hne).pow r).smul (hr.comp hg)).congr ?_⟩
+    set j := fun z ↦ (z - g x) ^ r • f z
+    have : AnalyticAt 𝕜 (fun z ↦ (h z)⁻¹ ^ r • j (g z)) x := by fun_prop (disch := assumption)
+    refine ⟨n * r, this.congr ?_⟩
     filter_upwards [heq, han.continuousAt.tendsto.eventually_ne hne] with z hz hzne
-    simp only [Pi.smul_apply', Pi.pow_apply, inv_pow, Function.comp_apply]
-    rw [inv_smul_eq_iff₀ (pow_ne_zero r hzne), ← mul_smul (h z ^ r), mul_comm, pow_mul,
-      ← mul_pow, ← smul_eq_mul, ← hz]
+    simp only [inv_pow, Function.comp_apply, inv_smul_eq_iff₀ (pow_ne_zero r hzne)]
+    rw [← mul_smul (h z ^ r), mul_comm, pow_mul, ← mul_pow, ← smul_eq_mul, ← hz]


### PR DESCRIPTION
The composite of a meromorphic function and an analytic function is meromorphic.

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include at least one commit authored by each
co-author among the commits in the pull request. If necessary, you may 
create empty commits to indicate co-authorship, using commands like so:

git commit --author="Author Name <author@email.com>" --allow-empty -m "add Author Name as coauthor"

When merging, all the commits will be squashed into a single commit listing all co-authors.

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->
Result of an accidental self-nerd-snipe when reviewing #27500.

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
