### PR TITLE
[Merged by Bors] - chore(Combinatorics): review porting notes

### DIFF
--- a/Mathlib/Combinatorics/Derangements/Basic.lean
+++ b/Mathlib/Combinatorics/Derangements/Basic.lean
@@ -81,7 +81,6 @@ def atMostOneFixedPointEquivSum_derangements [DecidableEq α] (a : α) :
       (Equiv.sumCompl _).symm
     _ ≃ { f : Perm α // fixedPoints f ⊆ {a} ∧ a ∈ fixedPoints f } ⊕
           { f : Perm α // fixedPoints f ⊆ {a} ∧ a ∉ fixedPoints f } := by
-      -- Porting note: `subtypeSubtypeEquivSubtypeInter` no longer works with placeholder `_`s.
       refine Equiv.sumCongr ?_ ?_
       · exact subtypeSubtypeEquivSubtypeInter
           (fun x : Perm α => fixedPoints x ⊆ {a})

--- a/Mathlib/Combinatorics/Derangements/Finite.lean
+++ b/Mathlib/Combinatorics/Derangements/Finite.lean
@@ -32,8 +32,9 @@ variable {α : Type*} [DecidableEq α] [Fintype α]
 
 instance : DecidablePred (derangements α) := fun _ => Fintype.decidableForallFintype
 
--- Porting note: used to use the tactic delta_instance
-instance : Fintype (derangements α) := Subtype.fintype (fun (_ : Perm α) => ∀ (x_1 : α), ¬_ = x_1)
+instance : Fintype (derangements α) :=
+  inferInstanceAs <| Fintype { f : Perm α | ∀ x : α, f x ≠ x }
+
 
 theorem card_derangements_invariant {α β : Type*} [Fintype α] [DecidableEq α] [Fintype β]
     [DecidableEq β] (h : card α = card β) : card (derangements α) = card (derangements β) :=

--- a/Mathlib/Combinatorics/Hindman.lean
+++ b/Mathlib/Combinatorics/Hindman.lean
@@ -81,17 +81,29 @@ namespace Hindman
 /-- `FS a` is the set of finite sums in `a`, i.e. `m ∈ FS a` if `m` is the sum of a nonempty
 subsequence of `a`. We give a direct inductive definition instead of talking about subsequences. -/
 inductive FS {M} [AddSemigroup M] : Stream' M → Set M
-  | head (a : Stream' M) : FS a a.head
-  | tail (a : Stream' M) (m : M) (h : FS a.tail m) : FS a m
-  | cons (a : Stream' M) (m : M) (h : FS a.tail m) : FS a (a.head + m)
+  | head' (a : Stream' M) : FS a a.head
+  | tail' (a : Stream' M) (m : M) (h : FS a.tail m) : FS a m
+  | cons' (a : Stream' M) (m : M) (h : FS a.tail m) : FS a (a.head + m)
 
 /-- `FP a` is the set of finite products in `a`, i.e. `m ∈ FP a` if `m` is the product of a nonempty
 subsequence of `a`. We give a direct inductive definition instead of talking about subsequences. -/
 @[to_additive FS]
 inductive FP {M} [Semigroup M] : Stream' M → Set M
-  | head (a : Stream' M) : FP a a.head
-  | tail (a : Stream' M) (m : M) (h : FP a.tail m) : FP a m
-  | cons (a : Stream' M) (m : M) (h : FP a.tail m) : FP a (a.head * m)
+  | head' (a : Stream' M) : FP a a.head
+  | tail' (a : Stream' M) (m : M) (h : FP a.tail m) : FP a m
+  | cons' (a : Stream' M) (m : M) (h : FP a.tail m) : FP a (a.head * m)
+
+section Aliases
+
+/-! Since the constructors for `FS` and `FP` cheat using the `Set M = M → Prop` defeq,
+we provide match patterns that preserve the defeq correctly in their type. -/
+
+variable {M} [Semigroup M] (a : Stream' M) (m : M) (h : FP a.tail m)
+@[to_additive (attr := match_pattern)] abbrev FP.head : a.head ∈ FP a := FP.head' a
+@[to_additive (attr := match_pattern)] abbrev FP.tail : m ∈ FP a := FP.tail' a m h
+@[to_additive (attr := match_pattern)] abbrev FP.cons : a.head * m ∈ FP a := FP.cons' a m h
+
+end Aliases
 
 /-- If `m` and `m'` are finite products in `M`, then so is `m * m'`, provided that `m'` is obtained
 from a subsequence of `M` starting sufficiently late. -/
@@ -100,13 +112,13 @@ is obtained from a subsequence of `M` starting sufficiently late. -/]
 theorem FP.mul {M} [Semigroup M] {a : Stream' M} {m : M} (hm : m ∈ FP a) :
     ∃ n, ∀ m' ∈ FP (a.drop n), m * m' ∈ FP a := by
   induction hm with
-  | head a => exact ⟨1, fun m hm => FP.cons a m hm⟩
-  | tail a m _ ih =>
+  | head' a => exact ⟨1, fun m hm => FP.cons a m hm⟩
+  | tail' a m _ ih =>
     obtain ⟨n, hn⟩ := ih
     use n + 1
     intro m' hm'
     exact FP.tail _ _ (hn _ hm')
-  | cons a m _ ih =>
+  | cons' a m _ ih =>
     obtain ⟨n, hn⟩ := ih
     use n + 1
     intro m' hm'
@@ -166,15 +178,15 @@ theorem exists_FP_of_large {M} [Semigroup M] (U : Ultrafilter M) (U_idem : U * U
   clear sU s₀
   intro a m h
   induction h with
-  | head b =>
+  | head' b =>
     rintro p rfl
     rw [Stream'.corec_eq, Stream'.head_cons]
     exact Set.inter_subset_left (Set.Nonempty.some_mem _)
-  | tail b n h ih =>
+  | tail' b n h ih =>
     rintro p rfl
     refine Set.inter_subset_left (ih (succ p) ?_)
     rw [Stream'.corec_eq, Stream'.tail_cons]
-  | cons b n h ih =>
+  | cons' b n h ih =>
     rintro p rfl
     have := Set.inter_subset_right (ih (succ p) ?_)
     · simpa only using this
@@ -222,8 +234,6 @@ theorem FP.mul_two {M} [Semigroup M] (a : Stream' M) (i j : ℕ) (ij : i < j) :
   rw [← Stream'.head_drop]
   apply FP.cons
   rcases Nat.exists_eq_add_of_le (Nat.succ_le_of_lt ij) with ⟨d, hd⟩
-  -- Porting note: need to fix breakage of Set notation
-  change _ ∈ FP _
   have := FP.singleton (a.drop i).tail d
   rw [Stream'.tail_eq_drop, Stream'.get_drop, Stream'.get_drop] at this
   convert this

--- a/Mathlib/Combinatorics/Hindman.lean
+++ b/Mathlib/Combinatorics/Hindman.lean
@@ -99,9 +99,18 @@ section Aliases
 we provide match patterns that preserve the defeq correctly in their type. -/
 
 variable {M} [Semigroup M] (a : Stream' M) (m : M) (h : FP a.tail m)
-@[to_additive (attr := match_pattern)] abbrev FP.head : a.head ∈ FP a := FP.head' a
-@[to_additive (attr := match_pattern)] abbrev FP.tail : m ∈ FP a := FP.tail' a m h
-@[to_additive (attr := match_pattern)] abbrev FP.cons : a.head * m ∈ FP a := FP.cons' a m h
+/-- Constructor for `FP`. This is the preferred spelling over `FP.head'`. -/
+@[to_additive (attr := match_pattern, nolint defLemma)
+  /-- Constructor for `FS`. This is the preferred spelling over `FS.head'`. -/]
+abbrev FP.head : a.head ∈ FP a := FP.head' a
+/-- Constructor for `FP`. This is the preferred spelling over `FP.tail'`. -/
+@[to_additive (attr := match_pattern, nolint defLemma)
+  /-- Constructor for `FS`. This is the preferred spelling over `FS.tail'`. -/]
+abbrev FP.tail : m ∈ FP a := FP.tail' a m h
+/-- Constructor for `FP`. This is the preferred spelling over `FP.cons'`. -/
+@[to_additive (attr := match_pattern, nolint defLemma)
+  /-- Constructor for `FS`. This is the preferred spelling over `FS.cons'`. -/]
+abbrev FP.cons : a.head * m ∈ FP a := FP.cons' a m h
 
 end Aliases
 

--- a/Mathlib/Combinatorics/Quiver/Covering.lean
+++ b/Mathlib/Combinatorics/Quiver/Covering.lean
@@ -187,7 +187,6 @@ theorem Prefunctor.pathStar_injective (hφ : ∀ u, Injective (φ.star u)) (u : 
     rcases p₂ with - | ⟨p₂, e₂⟩
     · intro; rfl -- Porting note: goal not present in lean3.
     · intro h
-      -- Porting note: added `Sigma.mk.inj_iff`
       simp only [mapPath_cons, Sigma.mk.inj_iff] at h
       exfalso
       obtain ⟨h, h'⟩ := h

--- a/Mathlib/Combinatorics/Quiver/Subquiver.lean
+++ b/Mathlib/Combinatorics/Quiver/Subquiver.lean
@@ -50,7 +50,6 @@ noncomputable instance {V} [Quiver V] : Inhabited (WideSubquiver V) :=
 
 -- TODO Unify with `CategoryTheory.Arrow`? (The fields have been named to match.)
 /-- `Total V` is the type of _all_ arrows of `V`. -/
--- Porting note: no hasNonemptyInstance linter yet https://github.com/leanprover-community/mathlib4/issues/5171
 @[ext]
 structure Total (V : Type u) [Quiver.{v} V] : Sort max (u + 1) v where
   /-- the source vertex of an arrow -/

--- a/Mathlib/Combinatorics/SimpleGraph/Basic.lean
+++ b/Mathlib/Combinatorics/SimpleGraph/Basic.lean
@@ -787,7 +787,7 @@ theorem incidence_other_prop {v : V} {e : Sym2 V} (h : e ∈ G.incidenceSet v) :
   obtain ⟨he, hv⟩ := h
   rwa [← Sym2.other_spec' hv, mem_edgeSet] at he
 
--- Porting note: as a simp lemma this does not apply even to itself
+@[simp]
 theorem incidence_other_neighbor_edge {v w : V} (h : w ∈ G.neighborSet v) :
     G.otherVertexOfIncident (G.mem_incidence_iff_neighbor.mpr h) = w :=
   Sym2.congr_right.mp (Sym2.other_spec' (G.mem_incidence_iff_neighbor.mpr h).right)

--- a/Mathlib/Combinatorics/SimpleGraph/Finsubgraph.lean
+++ b/Mathlib/Combinatorics/SimpleGraph/Finsubgraph.lean
@@ -179,7 +179,7 @@ theorem nonempty_hom_of_forall_finite_subgraph_hom [Finite W]
       Quiver.Hom.op (CategoryTheory.homOfLE singletonFinsubgraph_le_adj_right)
     rw [← hu hv, ← hu hv']
     -- Porting note: was `apply Hom.map_adj`
-    refine Hom.map_adj (u (Opposite.op (finsubgraphOfAdj e))) ?_
+    apply Hom.map_adj (u _) ?_
     -- `v` and `v'` are definitionally adjacent in `finsubgraphOfAdj e`
     simp [finsubgraphOfAdj]
 

--- a/Mathlib/Combinatorics/SimpleGraph/Maps.lean
+++ b/Mathlib/Combinatorics/SimpleGraph/Maps.lean
@@ -54,8 +54,7 @@ protected def map (f : V ↪ W) (G : SimpleGraph V) : SimpleGraph W where
   Adj := Relation.Map G.Adj f f
   symm a b := by
     rintro ⟨v, w, h, _⟩
-    have := h.symm -- Porting note: `obviously` didn't need this hint while `aesop` does.
-    aesop (add norm unfold Relation.Map)
+    aesop (add norm unfold Relation.Map) (add forward safe Adj.symm)
   loopless a := by aesop (add norm unfold Relation.Map)
 
 instance instDecidableMapAdj {f : V ↪ W} {a b} [Decidable (Relation.Map G.Adj f f a b)] :

--- a/Mathlib/Combinatorics/SimpleGraph/Matching.lean
+++ b/Mathlib/Combinatorics/SimpleGraph/Matching.lean
@@ -221,10 +221,6 @@ theorem IsMatching.even_card [Fintype M.verts] (h : M.IsMatching) : Even M.verts
   rw [isMatching_iff_forall_degree] at h
   use M.coe.edgeFinset.card
   rw [← two_mul, ← M.coe.sum_degrees_eq_twice_card_edges]
-  -- Porting note: `SimpleGraph.Subgraph.coe_degree` does not trigger because it uses
-  -- instance arguments instead of implicit arguments for the first `Fintype` argument.
-  -- Using a `convert_to` to swap out the `Fintype` instance to the "right" one.
-  convert_to _ = Finset.sum Finset.univ fun v => SimpleGraph.degree (Subgraph.coe M) v using 3
   simp [h, Finset.card_univ]
 
 theorem isPerfectMatching_iff : M.IsPerfectMatching ↔ ∀ v, ∃! w, M.Adj v w := by

--- a/Mathlib/Combinatorics/SimpleGraph/Paths.lean
+++ b/Mathlib/Combinatorics/SimpleGraph/Paths.lean
@@ -65,27 +65,22 @@ structure IsTrail {u v : V} (p : G.Walk u v) : Prop where
 
 /-- A *path* is a walk with no repeating vertices.
 Use `SimpleGraph.Walk.IsPath.mk'` for a simpler constructor. -/
-structure IsPath {u v : V} (p : G.Walk u v) : Prop extends IsTrail p where
+structure IsPath {u v : V} (p : G.Walk u v) : Prop extends isTrail : IsTrail p where
   support_nodup : p.support.Nodup
-
--- Porting note: used to use `extends to_trail : is_trail p` in structure
-protected lemma IsPath.isTrail {p : Walk G u v} (h : IsPath p) : IsTrail p := h.toIsTrail
 
 /-- A *circuit* at `u : V` is a nonempty trail beginning and ending at `u`. -/
 @[mk_iff isCircuit_def]
-structure IsCircuit {u : V} (p : G.Walk u u) : Prop extends IsTrail p where
+structure IsCircuit {u : V} (p : G.Walk u u) : Prop extends isTrail : IsTrail p where
   ne_nil : p ≠ nil
-
--- Porting note: used to use `extends to_trail : is_trail p` in structure
-protected lemma IsCircuit.isTrail {p : Walk G u u} (h : IsCircuit p) : IsTrail p := h.toIsTrail
 
 /-- A *cycle* at `u : V` is a circuit at `u` whose only repeating vertex
 is `u` (which appears exactly twice). -/
-structure IsCycle {u : V} (p : G.Walk u u) : Prop extends IsCircuit p where
+structure IsCycle {u : V} (p : G.Walk u u) : Prop extends isCircuit : IsCircuit p where
   support_nodup : p.support.tail.Nodup
 
--- Porting note: used to use `extends to_circuit : is_circuit p` in structure
-protected lemma IsCycle.isCircuit {p : Walk G u u} (h : IsCycle p) : IsCircuit p := h.toIsCircuit
+@[deprecated (since := "2025-08-26")] protected alias IsPath.toIsTrail := IsPath.isTrail
+@[deprecated (since := "2025-08-26")] protected alias IsCircuit.toIsTrail := IsCircuit.isTrail
+@[deprecated (since := "2025-08-26")] protected alias IsCycle.toIsCircuit := IsCycle.isCircuit
 
 @[simp]
 theorem isTrail_copy {u v u' v'} (p : G.Walk u v) (hu : u = u') (hv : v = v') :

--- a/Mathlib/Combinatorics/SimpleGraph/Regularity/Bound.lean
+++ b/Mathlib/Combinatorics/SimpleGraph/Regularity/Bound.lean
@@ -219,17 +219,11 @@ theorem add_div_le_sum_sq_div_card (hst : s ⊆ t) (f : ι → 𝕜) (d : 𝕜) 
   rw [← mul_div_right_comm, le_div_iff₀ htcard, add_mul, div_mul_cancel₀ _ htcard.ne']
   have h₃ := mul_sq_le_sum_sq hst (fun i => (f i - (∑ j ∈ t, f j) / #t)) h₂ hscard.ne'
   apply (add_le_add_left h₃ _).trans
-  -- Porting note: was
-  -- simp [← mul_div_right_comm _ (#t : 𝕜), sub_div' _ _ _ htcard.ne', ← sum_div, ← add_div,
-  --   mul_pow, div_le_iff₀ (sq_pos_of_ne_zero htcard.ne'), sub_sq, sum_add_distrib, ← sum_mul,
-  --   ← mul_sum]
-  simp_rw [sub_div' htcard.ne']
-  conv_lhs => enter [2, 2, x]; rw [div_pow]
-  rw [div_pow, ← sum_div, ← mul_div_right_comm _ (#t : 𝕜), ← add_div,
-    div_le_iff₀ (sq_pos_of_ne_zero htcard.ne')]
-  simp_rw [sub_sq, sum_add_distrib, sum_const, nsmul_eq_mul, sum_sub_distrib, mul_pow, ← sum_mul,
-    ← mul_sum, ← sum_mul]
-  ring_nf; rfl
+  simp only [sub_div' htcard.ne', div_pow, ← sum_div, ← mul_div_right_comm _ (#t : 𝕜), ← add_div,
+    div_le_iff₀ (sq_pos_of_ne_zero htcard.ne'), sub_sq, sum_add_distrib, sum_const,
+    sum_sub_distrib, mul_pow, ← sum_mul, nsmul_eq_mul, two_mul]
+  ring_nf
+  rfl
 
 end SzemerediRegularity
 

--- a/Mathlib/Combinatorics/SimpleGraph/Regularity/Equitabilise.lean
+++ b/Mathlib/Combinatorics/SimpleGraph/Regularity/Equitabilise.lean
@@ -54,11 +54,13 @@ theorem equitabilise_aux (hs : a * m + b * (m + 1) = #s) :
   induction s using Finset.strongInduction generalizing a b with | H s ih => _
   -- If `a = b = 0`, then `s = ∅` and we can partition into zero parts
   by_cases hab : a = 0 ∧ b = 0
-  · simp only [hab.1, hab.2, add_zero, zero_mul, eq_comm, card_eq_zero] at hs
+  · -- Rewrite using `← bot_eq_empty` because we have theorems about `Finpartition ⊥`,
+    -- and nothing about `Finpartition ∅`, even though they are defeq in this case.
+    -- TODO: specialize the `Finpartition ⊥` lemmas to `Finpartition ∅`?
+    simp only [hab.1, hab.2, add_zero, zero_mul, eq_comm, card_eq_zero, ← bot_eq_empty] at hs
     subst hs
-    -- Porting note: to synthesize `Finpartition ∅`, `have` is required
-    have : P = Finpartition.empty _ := Unique.eq_default (α := Finpartition ⊥) P
-    exact ⟨Finpartition.empty _, by simp, by simp [this], by simp [hab.2]⟩
+    exact ⟨Finpartition.empty _, by simp, by simp [Unique.eq_default P, -bot_eq_empty],
+      by simp [hab.2]⟩
   simp_rw [not_and_or, ← Ne.eq_def, ← pos_iff_ne_zero] at hab
   -- `n` will be the size of the smallest part
   set n := if 0 < a then m else m + 1 with hn
@@ -178,8 +180,7 @@ theorem card_filter_equitabilise_small (hm : m ≠ 0) :
 theorem card_parts_equitabilise (hm : m ≠ 0) : #(P.equitabilise h).parts = a + b := by
   rw [← filter_true_of_mem fun x => card_eq_of_mem_parts_equitabilise, filter_or,
     card_union_of_disjoint, P.card_filter_equitabilise_small _ hm, P.card_filter_equitabilise_big]
-  -- Porting note (https://github.com/leanprover-community/mathlib4/issues/11187): was `infer_instance`
-  exact disjoint_filter.2 fun x _ h₀ h₁ => Nat.succ_ne_self m <| h₁.symm.trans h₀
+  aesop (add norm disjoint_filter)
 
 theorem card_parts_equitabilise_subset_le :
     t ∈ P.parts → #(t \ {u ∈ (P.equitabilise h).parts | u ⊆ t}.biUnion id) ≤ m :=

--- a/Mathlib/Combinatorics/Young/YoungDiagram.lean
+++ b/Mathlib/Combinatorics/Young/YoungDiagram.lean
@@ -68,7 +68,6 @@ structure YoungDiagram where
 namespace YoungDiagram
 
 instance : SetLike YoungDiagram (ℕ × ℕ) where
-  -- Porting note (https://github.com/leanprover-community/mathlib4/issues/11215): TODO: figure out how to do this correctly
   coe y := y.cells
   coe_injective' μ ν h := by rwa [YoungDiagram.ext_iff, ← Finset.coe_inj]
 

--- a/Mathlib/GroupTheory/OrderOfElement.lean
+++ b/Mathlib/GroupTheory/OrderOfElement.lean
@@ -199,6 +199,12 @@ theorem orderOf_eq_zero_iff' : orderOf x = 0 ↔ ∀ n : ℕ, 0 < n → x ^ n �
 @[to_additive]
 lemma orderOf_ne_zero_iff : orderOf x ≠ 0 ↔ IsOfFinOrder x := orderOf_eq_zero_iff.not_left
 
+/-- In a nontrivial monoid with zero, the order of the zero element is zero. -/
+@[simp]
+lemma orderOf_zero (M₀ : Type*) [MonoidWithZero M₀] [Nontrivial M₀] : orderOf (0 : M₀) = 0 := by
+  rw [orderOf_eq_zero_iff, isOfFinOrder_iff_pow_eq_one]
+  simp +contextual [ne_of_gt]
+
 @[to_additive]
 theorem orderOf_eq_iff {n} (h : 0 < n) :
     orderOf x = n ↔ x ^ n = 1 ∧ ∀ m, m < n → 0 < m → x ^ m ≠ 1 := by
@@ -344,9 +350,13 @@ theorem Function.Injective.isOfFinOrder_iff [Monoid H] {f : G →* H} (hf : Inje
 theorem orderOf_submonoid {H : Submonoid G} (y : H) : orderOf (y : G) = orderOf y :=
   orderOf_injective H.subtype Subtype.coe_injective y
 
-@[to_additive]
+@[to_additive (attr := norm_cast)]
 theorem orderOf_units {y : Gˣ} : orderOf (y : G) = orderOf y :=
   orderOf_injective (Units.coeHom G) Units.val_injective y
+
+@[to_additive (attr := norm_cast)]
+theorem Units.isOfFinOrder_val {u : Gˣ} : IsOfFinOrder (u : G) ↔ IsOfFinOrder u :=
+  Units.coeHom_injective.isOfFinOrder_iff
 
 /-- If the order of `x` is finite, then `x` is a unit with inverse `x ^ (orderOf x - 1)`. -/
 @[to_additive (attr := simps) /-- If the additive order of `x` is finite, then `x` is an additive
@@ -833,6 +843,21 @@ lemma orderOf_eq_card_powers : orderOf x = Fintype.card (powers x : Submonoid G)
     Fintype.card_eq.2 ⟨finEquivPowers <| isOfFinOrder_of_finite _⟩
 
 end FiniteCancelMonoid
+
+lemma isOfFinOrder_iff_isUnit [Monoid G] [Finite Gˣ] {x : G} : IsOfFinOrder x ↔ IsUnit x := by
+  use IsOfFinOrder.isUnit
+  rintro ⟨u, rfl⟩
+  rw [Units.isOfFinOrder_val]
+  apply isOfFinOrder_of_finite
+
+alias ⟨_, IsUnit.isOfFinOrder⟩ := isOfFinOrder_iff_isUnit
+
+lemma orderOf_eq_zero_iff_eq_zero {G₀ : Type*} [GroupWithZero G₀] [Finite G₀] {a : G₀} :
+    orderOf a = 0 ↔ a = 0 := by
+  -- Prove an instance inline to avoid extra imports.
+  -- TODO: move this instance elsewhere?
+  have : Finite G₀ˣ := .of_injective _ Units.val_injective
+  simp [isOfFinOrder_iff_isUnit]
 
 section FiniteGroup
 variable [Group G] {x y : G}

--- a/Mathlib/GroupTheory/OrderOfElement.lean
+++ b/Mathlib/GroupTheory/OrderOfElement.lean
@@ -199,12 +199,6 @@ theorem orderOf_eq_zero_iff' : orderOf x = 0 ↔ ∀ n : ℕ, 0 < n → x ^ n �
 @[to_additive]
 lemma orderOf_ne_zero_iff : orderOf x ≠ 0 ↔ IsOfFinOrder x := orderOf_eq_zero_iff.not_left
 
-/-- In a nontrivial monoid with zero, the order of the zero element is zero. -/
-@[simp]
-lemma orderOf_zero (M₀ : Type*) [MonoidWithZero M₀] [Nontrivial M₀] : orderOf (0 : M₀) = 0 := by
-  rw [orderOf_eq_zero_iff, isOfFinOrder_iff_pow_eq_one]
-  simp +contextual [ne_of_gt]
-
 @[to_additive]
 theorem orderOf_eq_iff {n} (h : 0 < n) :
     orderOf x = n ↔ x ^ n = 1 ∧ ∀ m, m < n → 0 < m → x ^ m ≠ 1 := by
@@ -350,13 +344,9 @@ theorem Function.Injective.isOfFinOrder_iff [Monoid H] {f : G →* H} (hf : Inje
 theorem orderOf_submonoid {H : Submonoid G} (y : H) : orderOf (y : G) = orderOf y :=
   orderOf_injective H.subtype Subtype.coe_injective y
 
-@[to_additive (attr := norm_cast)]
+@[to_additive]
 theorem orderOf_units {y : Gˣ} : orderOf (y : G) = orderOf y :=
   orderOf_injective (Units.coeHom G) Units.val_injective y
-
-@[to_additive (attr := norm_cast)]
-theorem Units.isOfFinOrder_val {u : Gˣ} : IsOfFinOrder (u : G) ↔ IsOfFinOrder u :=
-  Units.coeHom_injective.isOfFinOrder_iff
 
 /-- If the order of `x` is finite, then `x` is a unit with inverse `x ^ (orderOf x - 1)`. -/
 @[to_additive (attr := simps) /-- If the additive order of `x` is finite, then `x` is an additive
@@ -843,21 +833,6 @@ lemma orderOf_eq_card_powers : orderOf x = Fintype.card (powers x : Submonoid G)
     Fintype.card_eq.2 ⟨finEquivPowers <| isOfFinOrder_of_finite _⟩
 
 end FiniteCancelMonoid
-
-lemma isOfFinOrder_iff_isUnit [Monoid G] [Finite Gˣ] {x : G} : IsOfFinOrder x ↔ IsUnit x := by
-  use IsOfFinOrder.isUnit
-  rintro ⟨u, rfl⟩
-  rw [Units.isOfFinOrder_val]
-  apply isOfFinOrder_of_finite
-
-alias ⟨_, IsUnit.isOfFinOrder⟩ := isOfFinOrder_iff_isUnit
-
-lemma orderOf_eq_zero_iff_eq_zero {G₀ : Type*} [GroupWithZero G₀] [Finite G₀] {a : G₀} :
-    orderOf a = 0 ↔ a = 0 := by
-  -- Prove an instance inline to avoid extra imports.
-  -- TODO: move this instance elsewhere?
-  have : Finite G₀ˣ := .of_injective _ Units.val_injective
-  simp [isOfFinOrder_iff_isUnit]
 
 section FiniteGroup
 variable [Group G] {x y : G}


### PR DESCRIPTION
Go through all the porting notes in the Combinatorics folder and deal with those that have an obvious solution. Some are easy fixes, others we won't fix (such as being stricter about defeqs).

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include at least one commit authored by each
co-author among the commits in the pull request. If necessary, you may 
create empty commits to indicate co-authorship, using commands like so:

git commit --author="Author Name <author@email.com>" --allow-empty -m "add Author Name as coauthor"

When merging, all the commits will be squashed into a single commit listing all co-authors.

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
