### PR TITLE
[Merged by Bors] - chore(Computability): review porting notes

### DIFF
--- a/Mathlib/Computability/Primrec.lean
+++ b/Mathlib/Computability/Primrec.lean
@@ -881,21 +881,21 @@ theorem sumCasesOn {f : α → β ⊕ γ} {g : α → β → σ} {h : α → γ 
 @[deprecated (since := "2025-02-21")] alias sum_casesOn := Primrec.sumCasesOn
 
 theorem list_cons : Primrec₂ (@List.cons α) :=
-  list_cons' Primcodable.prim
+  list_cons' (Primcodable.prim _)
 
 theorem list_casesOn {f : α → List β} {g : α → σ} {h : α → β × List β → σ} :
     Primrec f →
       Primrec g →
         Primrec₂ h → @Primrec _ σ _ _ fun a => List.casesOn (f a) (g a) fun b l => h a (b, l) :=
-  list_casesOn' Primcodable.prim
+  list_casesOn' (Primcodable.prim _)
 
 theorem list_foldl {f : α → List β} {g : α → σ} {h : α → σ × β → σ} :
     Primrec f →
       Primrec g → Primrec₂ h → Primrec fun a => (f a).foldl (fun s b => h a (s, b)) (g a) :=
-  list_foldl' Primcodable.prim
+  list_foldl' (Primcodable.prim _)
 
 theorem list_reverse : Primrec (@List.reverse α) :=
-  list_reverse' Primcodable.prim
+  list_reverse' (Primcodable.prim _)
 
 theorem list_foldr {f : α → List β} {g : α → σ} {h : α → β × σ → σ} (hf : Primrec f)
     (hg : Primrec g) (hh : Primrec₂ h) :

--- a/Mathlib/Computability/Primrec.lean
+++ b/Mathlib/Computability/Primrec.lean
@@ -83,7 +83,6 @@ theorem prec1 {f} (m : ℕ) (hf : Nat.Primrec f) :
 theorem casesOn1 {f} (m : ℕ) (hf : Nat.Primrec f) : Nat.Primrec (Nat.casesOn · m f) :=
   (prec1 m (hf.comp left)).of_eq <| by simp
 
--- Porting note: `Nat.Primrec.casesOn` is already declared as a recursor.
 theorem casesOn' {f g} (hf : Nat.Primrec f) (hg : Nat.Primrec g) :
     Nat.Primrec (unpaired fun z n => n.casesOn (f z) fun y => g <| Nat.pair z y) :=
   (prec hf (hg.comp (pair left (left.comp right)))).of_eq fun n => by simp
@@ -128,9 +127,7 @@ Thus, in a way, the added requirement ensures that no predicates
 can be smuggled in through a cunning choice of the subset of `ℕ` into
 which the type is encoded. -/
 class Primcodable (α : Type*) extends Encodable α where
-  -- Porting note: was `prim [] `.
-  -- This means that `prim` does not take the type explicitly in Lean 4
-  prim : Nat.Primrec fun n => Encodable.encode (decode n)
+  prim (α) : Nat.Primrec fun n => Encodable.encode (decode n)
 
 namespace Primcodable
 
@@ -142,7 +139,7 @@ instance (priority := 10) ofDenumerable (α) [Denumerable α] : Primcodable α :
 /-- Builds a `Primcodable` instance from an equivalence to a `Primcodable` type. -/
 def ofEquiv (α) {β} [Primcodable α] (e : β ≃ α) : Primcodable β :=
   { __ := Encodable.ofEquiv α e
-    prim := (@Primcodable.prim α _).of_eq fun n => by
+    prim := (Primcodable.prim α).of_eq fun n => by
       rw [decode_ofEquiv]
       cases (@decode α _ n) <;>
         simp [encode_ofEquiv] }
@@ -154,7 +151,7 @@ instance unit : Primcodable PUnit :=
   ⟨(casesOn1 1 zero).of_eq fun n => by cases n <;> simp⟩
 
 instance option {α : Type*} [h : Primcodable α] : Primcodable (Option α) :=
-  ⟨(casesOn1 1 ((casesOn1 0 (.comp .succ .succ)).comp (@Primcodable.prim α _))).of_eq fun n => by
+  ⟨(casesOn1 1 ((casesOn1 0 (.comp .succ .succ)).comp (Primcodable.prim α))).of_eq fun n => by
     cases n with
       | zero => rfl
       | succ n =>
@@ -182,10 +179,10 @@ variable [Primcodable α] [Primcodable β] [Primcodable σ]
 open Nat.Primrec
 
 protected theorem encode : Primrec (@encode α _) :=
-  (@Primcodable.prim α _).of_eq fun n => by cases @decode α _ n <;> rfl
+  (Primcodable.prim α).of_eq fun n => by cases @decode α _ n <;> rfl
 
 protected theorem decode : Primrec (@decode α _) :=
-  Nat.Primrec.succ.comp (@Primcodable.prim α _)
+  Nat.Primrec.succ.comp (Primcodable.prim α)
 
 theorem dom_denumerable {α β} [Denumerable α] [Primcodable β] {f : α → β} :
     Primrec f ↔ Nat.Primrec fun n => encode (f (ofNat α n)) :=
@@ -196,24 +193,24 @@ theorem nat_iff {f : ℕ → ℕ} : Primrec f ↔ Nat.Primrec f :=
   dom_denumerable
 
 theorem encdec : Primrec fun n => encode (@decode α _ n) :=
-  nat_iff.2 Primcodable.prim
+  nat_iff.2 (Primcodable.prim _)
 
 theorem option_some : Primrec (@some α) :=
-  ((casesOn1 0 (Nat.Primrec.succ.comp .succ)).comp (@Primcodable.prim α _)).of_eq fun n => by
+  ((casesOn1 0 (Nat.Primrec.succ.comp .succ)).comp (Primcodable.prim α)).of_eq fun n => by
     cases @decode α _ n <;> simp
 
 theorem of_eq {f g : α → σ} (hf : Primrec f) (H : ∀ n, f n = g n) : Primrec g :=
   (funext H : f = g) ▸ hf
 
 theorem const (x : σ) : Primrec fun _ : α => x :=
-  ((casesOn1 0 (.const (encode x).succ)).comp (@Primcodable.prim α _)).of_eq fun n => by
+  ((casesOn1 0 (.const (encode x).succ)).comp (Primcodable.prim α)).of_eq fun n => by
     cases @decode α _ n <;> rfl
 
 protected theorem id : Primrec (@id α) :=
-  (@Primcodable.prim α).of_eq <| by simp
+  (Primcodable.prim α).of_eq <| by simp
 
 theorem comp {f : β → σ} {g : α → β} (hf : Primrec f) (hg : Primrec g) : Primrec fun a => f (g a) :=
-  ((casesOn1 0 (.comp hf (pred.comp hg))).comp (@Primcodable.prim α _)).of_eq fun n => by
+  ((casesOn1 0 (.comp hf (pred.comp hg))).comp (Primcodable.prim α)).of_eq fun n => by
     cases @decode α _ n <;> simp [encodek]
 
 theorem succ : Primrec Nat.succ :=
@@ -266,8 +263,8 @@ namespace Primcodable
 open Nat.Primrec
 
 instance prod {α β} [Primcodable α] [Primcodable β] : Primcodable (α × β) :=
-  ⟨((casesOn' zero ((casesOn' zero .succ).comp (pair right ((@Primcodable.prim β).comp left)))).comp
-          (pair right ((@Primcodable.prim α).comp left))).of_eq
+  ⟨((casesOn' zero ((casesOn' zero .succ).comp (pair right ((Primcodable.prim β).comp left)))).comp
+          (pair right ((Primcodable.prim α).comp left))).of_eq
       fun n => by
       simp only [Nat.unpaired, Nat.unpair_pair, decode_prod_val]
       cases @decode α _ n.unpair.1; · simp
@@ -284,8 +281,8 @@ open Nat.Primrec
 theorem fst {α β} [Primcodable α] [Primcodable β] : Primrec (@Prod.fst α β) :=
   ((casesOn' zero
             ((casesOn' zero (Nat.Primrec.succ.comp left)).comp
-              (pair right ((@Primcodable.prim β).comp left)))).comp
-        (pair right ((@Primcodable.prim α).comp left))).of_eq
+              (pair right ((Primcodable.prim β).comp left)))).comp
+        (pair right ((Primcodable.prim α).comp left))).of_eq
     fun n => by
     simp only [Nat.unpaired, Nat.unpair_pair, decode_prod_val]
     cases @decode α _ n.unpair.1 <;> simp
@@ -294,8 +291,8 @@ theorem fst {α β} [Primcodable α] [Primcodable β] : Primrec (@Prod.fst α β
 theorem snd {α β} [Primcodable α] [Primcodable β] : Primrec (@Prod.snd α β) :=
   ((casesOn' zero
             ((casesOn' zero (Nat.Primrec.succ.comp right)).comp
-              (pair right ((@Primcodable.prim β).comp left)))).comp
-        (pair right ((@Primcodable.prim α).comp left))).of_eq
+              (pair right ((Primcodable.prim β).comp left)))).comp
+        (pair right ((Primcodable.prim α).comp left))).of_eq
     fun n => by
     simp only [Nat.unpaired, Nat.unpair_pair, decode_prod_val]
     cases @decode α _ n.unpair.1 <;> simp
@@ -306,7 +303,7 @@ theorem pair {α β γ} [Primcodable α] [Primcodable β] [Primcodable γ] {f : 
   ((casesOn1 0
             (Nat.Primrec.succ.comp <|
               .pair (Nat.Primrec.pred.comp hf) (Nat.Primrec.pred.comp hg))).comp
-        (@Primcodable.prim α _)).of_eq
+        (Primcodable.prim α)).of_eq
     fun n => by cases @decode α _ n <;> simp [encodek]
 
 theorem unpair : Primrec Nat.unpair :=
@@ -508,7 +505,7 @@ theorem nat_rec {f : α → β} {g : α → ℕ × β → β} (hf : Primrec f) (
                         (Nat.Primrec.left.comp .right).pair <|
                           Nat.Primrec.pred.comp <| Nat.Primrec.right.comp .right).comp <|
                 Nat.Primrec.right.pair <| Nat.Primrec.right.comp Nat.Primrec.left).comp <|
-          Nat.Primrec.id.pair <| (@Primcodable.prim α).comp Nat.Primrec.left).of_eq
+          Nat.Primrec.id.pair <| (Primcodable.prim α).comp Nat.Primrec.left).of_eq
       fun n => by
       simp only [Nat.unpaired, id_eq, Nat.unpair_pair, decode_prod_val, decode_nat,
         Option.bind_some, Option.map_map, Option.map_some]
@@ -686,9 +683,6 @@ theorem dom_finite [Finite α] (f : α → σ) : Primrec f :=
 
 @[deprecated (since := "2025-08-23")] alias dom_fintype := dom_finite
 
--- Porting note: These are new lemmas
--- I added it because it actually simplified the proofs
--- and because I couldn't understand the original proof
 /-- A function is `PrimrecBounded` if its size is bounded by a primitive recursive function -/
 def PrimrecBounded (f : α → β) : Prop :=
   ∃ g : α → ℕ, Primrec g ∧ ∀ x, encode (f x) ≤ g x
@@ -835,7 +829,7 @@ instance sum : Primcodable (α ⊕ β) :=
           · cases @decode β _ n.div2 <;> rfl⟩
 
 instance list : Primcodable (List α) :=
-  ⟨letI H := @Primcodable.prim (List ℕ) _
+  ⟨letI H := Primcodable.prim (List ℕ)
     have : Primrec₂ fun (a : α) (o : Option (List ℕ)) => o.map (List.cons (encode a)) :=
       option_map snd <| (list_cons' H).comp ((@Primrec.encode α _).comp (fst.comp fst)) snd
     have :
@@ -1263,7 +1257,7 @@ theorem subtype_val {p : α → Prop} [DecidablePred p] {hp : PrimrecPred p} :
     haveI := Primcodable.subtype hp
     Primrec (@Subtype.val α p) := by
   letI := Primcodable.subtype hp
-  refine (@Primcodable.prim (Subtype p)).of_eq fun n => ?_
+  refine (Primcodable.prim (Subtype p)).of_eq fun n => ?_
   rcases @decode (Subtype p) _ n with (_ | ⟨a, h⟩) <;> rfl
 
 theorem subtype_val_iff {p : β → Prop} [DecidablePred p] {hp : PrimrecPred p} {f : α → Subtype p} :

--- a/Mathlib/Computability/RegularExpressions.lean
+++ b/Mathlib/Computability/RegularExpressions.lean
@@ -86,10 +86,11 @@ theorem plus_def (P Q : RegularExpression α) : plus P Q = P + Q :=
 theorem comp_def (P Q : RegularExpression α) : comp P Q = P * Q :=
   rfl
 
--- This was renamed to `matches'` during the port of Lean 4 as `matches` is a reserved word.
-/-- `matches' P` provides a language which contains all strings that `P` matches -/
--- Porting note: was '@[simp] but removed based on
--- https://leanprover.zulipchat.com/#narrow/stream/287929-mathlib4/topic/simpNF.20issues.20in.20Computability.2ERegularExpressions.20!4.232306/near/328355362
+/-- `matches' P` provides a language which contains all strings that `P` matches.
+
+Not named `matches` since that is a reserved word.
+-/
+@[simp]
 def matches' : RegularExpression α → Language α
   | 0 => 0
   | 1 => 1
@@ -98,23 +99,18 @@ def matches' : RegularExpression α → Language α
   | P * Q => P.matches' * Q.matches'
   | star P => P.matches'∗
 
-@[simp]
 theorem matches'_zero : (0 : RegularExpression α).matches' = 0 :=
   rfl
 
-@[simp]
 theorem matches'_epsilon : (1 : RegularExpression α).matches' = 1 :=
   rfl
 
-@[simp]
 theorem matches'_char (a : α) : (char a).matches' = {[a]} :=
   rfl
 
-@[simp]
 theorem matches'_add (P Q : RegularExpression α) : (P + Q).matches' = P.matches' + Q.matches' :=
   rfl
 
-@[simp]
 theorem matches'_mul (P Q : RegularExpression α) : (P * Q).matches' = P.matches' * Q.matches' :=
   rfl
 
@@ -125,7 +121,6 @@ theorem matches'_pow (P : RegularExpression α) : ∀ n : ℕ, (P ^ n).matches' 
       (congrFun (congrArg HMul.hMul (matches'_pow P n)) (matches' P))
       (pow_succ _ n).symm
 
-@[simp]
 theorem matches'_star (P : RegularExpression α) : P.star.matches' = P.matches'∗ :=
   rfl
 

--- a/Mathlib/Computability/Tape.lean
+++ b/Mathlib/Computability/Tape.lean
@@ -285,7 +285,6 @@ instance {Γ Γ'} [Inhabited Γ] [Inhabited Γ'] : Inhabited (PointedMap Γ Γ')
 instance {Γ Γ'} [Inhabited Γ] [Inhabited Γ'] : CoeFun (PointedMap Γ Γ') fun _ ↦ Γ → Γ' :=
   ⟨PointedMap.f⟩
 
--- @[simp] -- Porting note (https://github.com/leanprover-community/mathlib4/issues/10685): dsimp can prove this
 theorem PointedMap.mk_val {Γ Γ'} [Inhabited Γ] [Inhabited Γ'] (f : Γ → Γ') (pt) :
     (PointedMap.mk f pt : Γ → Γ') = f :=
   rfl
@@ -335,8 +334,8 @@ theorem ListBlank.map_cons {Γ Γ'} [Inhabited Γ] [Inhabited Γ'] (f : PointedM
 theorem ListBlank.nth_map {Γ Γ'} [Inhabited Γ] [Inhabited Γ'] (f : PointedMap Γ Γ')
     (l : ListBlank Γ) (n : ℕ) : (l.map f).nth n = f (l.nth n) := by
   refine l.inductionOn fun l ↦ ?_
-  -- Porting note: Added `suffices` to get `simp` to work.
-  suffices ((mk l).map f).nth n = f ((mk l).nth n) by exact this
+  -- Rewrite `Quotient.mk` to `ListBlank.mk`
+  change ((mk l).map f).nth n = f ((mk l).nth n)
   simp only [ListBlank.map_mk, ListBlank.nth_mk, ← List.getD_default_eq_getI]
   rw [← List.getD_map _ _ f]
   simp
@@ -371,8 +370,8 @@ theorem ListBlank.append_mk {Γ} [Inhabited Γ] (l₁ l₂ : List Γ) :
 theorem ListBlank.append_assoc {Γ} [Inhabited Γ] (l₁ l₂ : List Γ) (l₃ : ListBlank Γ) :
     ListBlank.append (l₁ ++ l₂) l₃ = ListBlank.append l₁ (ListBlank.append l₂ l₃) := by
   refine l₃.inductionOn fun l ↦ ?_
-  -- Porting note: Added `suffices` to get `simp` to work.
-  suffices append (l₁ ++ l₂) (mk l) = append l₁ (append l₂ (mk l)) by exact this
+  -- Rewrite `Quotient.mk` to `ListBlank.mk`
+  change append (l₁ ++ l₂) (mk l) = append l₁ (append l₂ (mk l))
   simp only [ListBlank.append_mk, List.append_assoc]
 
 /-- The `flatMap` function on lists is well defined on `ListBlank`s provided that the default
@@ -398,8 +397,8 @@ theorem ListBlank.flatMap_mk
 theorem ListBlank.cons_flatMap {Γ Γ'} [Inhabited Γ] [Inhabited Γ'] (a : Γ) (l : ListBlank Γ)
     (f : Γ → List Γ') (hf) : (l.cons a).flatMap f hf = (l.flatMap f hf).append (f a) := by
   refine l.inductionOn fun l ↦ ?_
-  -- Porting note: Added `suffices` to get `simp` to work.
-  suffices ((mk l).cons a).flatMap f hf = ((mk l).flatMap f hf).append (f a) by exact this
+  -- Rewrite `Quotient.mk` to `ListBlank.mk`
+  change ((mk l).cons a).flatMap f hf = ((mk l).flatMap f hf).append (f a)
   simp only [ListBlank.append_mk, ListBlank.flatMap_mk, ListBlank.cons_mk, List.flatMap_cons]
 
 end ListBlank

--- a/Mathlib/Computability/Tape.lean
+++ b/Mathlib/Computability/Tape.lean
@@ -333,9 +333,7 @@ theorem ListBlank.map_cons {Γ Γ'} [Inhabited Γ] [Inhabited Γ'] (f : PointedM
 @[simp]
 theorem ListBlank.nth_map {Γ Γ'} [Inhabited Γ] [Inhabited Γ'] (f : PointedMap Γ Γ')
     (l : ListBlank Γ) (n : ℕ) : (l.map f).nth n = f (l.nth n) := by
-  refine l.inductionOn fun l ↦ ?_
-  -- Rewrite `Quotient.mk` to `ListBlank.mk`
-  change ((mk l).map f).nth n = f ((mk l).nth n)
+  refine l.induction_on fun l ↦ ?_
   simp only [ListBlank.map_mk, ListBlank.nth_mk, ← List.getD_default_eq_getI]
   rw [← List.getD_map _ _ f]
   simp
@@ -369,9 +367,7 @@ theorem ListBlank.append_mk {Γ} [Inhabited Γ] (l₁ l₂ : List Γ) :
 
 theorem ListBlank.append_assoc {Γ} [Inhabited Γ] (l₁ l₂ : List Γ) (l₃ : ListBlank Γ) :
     ListBlank.append (l₁ ++ l₂) l₃ = ListBlank.append l₁ (ListBlank.append l₂ l₃) := by
-  refine l₃.inductionOn fun l ↦ ?_
-  -- Rewrite `Quotient.mk` to `ListBlank.mk`
-  change append (l₁ ++ l₂) (mk l) = append l₁ (append l₂ (mk l))
+  refine l₃.induction_on fun l ↦ ?_
   simp only [ListBlank.append_mk, List.append_assoc]
 
 /-- The `flatMap` function on lists is well defined on `ListBlank`s provided that the default
@@ -396,9 +392,7 @@ theorem ListBlank.flatMap_mk
 @[simp]
 theorem ListBlank.cons_flatMap {Γ Γ'} [Inhabited Γ] [Inhabited Γ'] (a : Γ) (l : ListBlank Γ)
     (f : Γ → List Γ') (hf) : (l.cons a).flatMap f hf = (l.flatMap f hf).append (f a) := by
-  refine l.inductionOn fun l ↦ ?_
-  -- Rewrite `Quotient.mk` to `ListBlank.mk`
-  change ((mk l).cons a).flatMap f hf = ((mk l).flatMap f hf).append (f a)
+  refine l.induction_on fun l ↦ ?_
   simp only [ListBlank.append_mk, ListBlank.flatMap_mk, ListBlank.cons_mk, List.flatMap_cons]
 
 end ListBlank

--- a/Mathlib/Computability/TuringMachine.lean
+++ b/Mathlib/Computability/TuringMachine.lean
@@ -675,7 +675,6 @@ theorem tr_respects_aux {q v T k} {S : ∀ k, List (Γ k)}
 attribute [local simp] Respects TM2.step TM2.stepAux trNormal
 
 theorem tr_respects : Respects (TM2.step M) (TM1.step (tr M)) TrCfg := by
-  -- Porting note (https://github.com/leanprover-community/mathlib4/issues/12129): additional beta reduction needed
   intro c₁ c₂ h
   obtain @⟨- | l, v, S, L, hT⟩ := h; · constructor
   rsuffices ⟨b, c, r⟩ : ∃ b, _ ∧ Reaches (TM1.step (tr M)) _ _
@@ -687,6 +686,7 @@ theorem tr_respects : Respects (TM2.step M) (TM1.step (tr M)) TrCfg := by
   | load a _ IH => exact IH _ hT
   | branch p q₁ q₂ IH₁ IH₂ =>
     unfold TM2.stepAux trNormal TM1.stepAux
+    -- Porting note (https://github.com/leanprover-community/mathlib4/issues/12129): additional beta reduction needed
     beta_reduce
     cases p v <;> [exact IH₂ _ hT; exact IH₁ _ hT]
   | goto => exact ⟨_, ⟨_, hT⟩, ReflTransGen.refl⟩


### PR DESCRIPTION
Go through porting notes in the Computability folder and make the obvious fixes.


---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include at least one commit authored by each
co-author among the commits in the pull request. If necessary, you may 
create empty commits to indicate co-authorship, using commands like so:

git commit --author="Author Name <author@email.com>" --allow-empty -m "add Author Name as coauthor"

When merging, all the commits will be squashed into a single commit listing all co-authors.

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
