### PR TITLE
[Merged by Bors] - chore(CategoryTheory): remove redundant `have`:s in `CategoryTheory/`

### DIFF
--- a/Mathlib/CategoryTheory/Abelian/Injective/Resolution.lean
+++ b/Mathlib/CategoryTheory/Abelian/Injective/Resolution.lean
@@ -263,9 +263,6 @@ theorem exact_f_d {X Y : C} (f : X ⟶ Y) :
     { τ₁ := 𝟙 _
       τ₂ := 𝟙 _
       τ₃ := Injective.ι _  }
-  have : Epi α.τ₁ := by dsimp; infer_instance
-  have : IsIso α.τ₂ := by dsimp; infer_instance
-  have : Mono α.τ₃ := by dsimp; infer_instance
   rw [← ShortComplex.exact_iff_of_epi_of_isIso_of_mono α]
   apply ShortComplex.exact_of_g_is_cokernel
   apply cokernelIsCokernel

--- a/Mathlib/CategoryTheory/Abelian/Projective/Resolution.lean
+++ b/Mathlib/CategoryTheory/Abelian/Projective/Resolution.lean
@@ -259,9 +259,6 @@ theorem exact_d_f {X Y : C} (f : X ⟶ Y) :
     { τ₁ := Projective.π _
       τ₂ := 𝟙 _
       τ₃ := 𝟙 _ }
-  have : Epi α.τ₁ := by dsimp; infer_instance
-  have : IsIso α.τ₂ := by dsimp; infer_instance
-  have : Mono α.τ₃ := by dsimp; infer_instance
   rw [ShortComplex.exact_iff_of_epi_of_isIso_of_mono α]
   apply ShortComplex.exact_of_f_is_kernel
   apply kernelIsKernel

--- a/Mathlib/CategoryTheory/FiberedCategory/Cocartesian.lean
+++ b/Mathlib/CategoryTheory/FiberedCategory/Cocartesian.lean
@@ -303,7 +303,6 @@ protected lemma of_comp [IsStronglyCocartesian p f φ] [IsStronglyCocartesian p 
     [IsHomLift p g ψ] : IsStronglyCocartesian p g ψ where
   universal_property' := by
     intro c' h τ hτ
-    have h₁ : IsHomLift p (f ≫ g ≫ h) (φ ≫ τ) := by simpa using IsHomLift.comp p f (g ≫ h) φ τ
     /- We get a morphism `π : c ⟶ c'` such that `(φ ≫ ψ) ≫ π = φ ≫ τ` from the universal property
     of `φ ≫ ψ`. This will be the morphism induced by `φ`. -/
     use map p (f ≫ g) (φ ≫ ψ) (f' := f ≫ g ≫ h) (assoc f g h).symm (φ ≫ τ)

--- a/Mathlib/CategoryTheory/Galois/Decomposition.lean
+++ b/Mathlib/CategoryTheory/Galois/Decomposition.lean
@@ -128,7 +128,6 @@ variable (F : C ⥤ FintypeCat.{w}) [FiberFunctor F]
 lemma fiber_in_connected_component (X : C) (x : F.obj X) : ∃ (Y : C) (i : Y ⟶ X) (y : F.obj Y),
     F.map i y = x ∧ IsConnected Y ∧ Mono i := by
   obtain ⟨ι, f, g, hl, hc, he⟩ := has_decomp_connected_components X
-  have : Fintype ι := Fintype.ofFinite ι
   let s : Cocone (Discrete.functor f ⋙ F) := F.mapCocone (Cofan.mk X g)
   let s' : IsColimit s := isColimitOfPreserves F hl
   obtain ⟨⟨j⟩, z, h⟩ := Concrete.isColimit_exists_rep _ s' x

--- a/Mathlib/CategoryTheory/Galois/Full.lean
+++ b/Mathlib/CategoryTheory/Galois/Full.lean
@@ -70,10 +70,6 @@ lemma exists_lift_of_mono (X : C) (Y : Action FintypeCat.{u} (Aut F))
     (u : Y ≅ (functorToAction F).obj Z), Mono f ∧ u.hom ≫ (functorToAction F).map f = i := by
   obtain ⟨ι, hf, f, t, hc⟩ := has_decomp_connected_components' Y
   let i' (j : ι) : f j ⟶ (functorToAction F).obj X := Sigma.ι f j ≫ t.hom ≫ i
-  have (j : ι) : Mono (i' j) :=
-    have : Mono (Sigma.ι f j) := MonoCoprod.mono_ι f j
-    have : Mono (t.hom ≫ i) := mono_comp _ _
-    mono_comp _ _
   choose gZ gf gu _ _ h using fun i ↦ exists_lift_of_mono_of_isConnected F X (f i) (i' i)
   let is2 : (functorToAction F).obj (∐ gZ) ≅ ∐ fun i => (functorToAction F).obj (gZ i) :=
     PreservesCoproduct.iso (functorToAction F) gZ

--- a/Mathlib/CategoryTheory/GradedObject/Associator.lean
+++ b/Mathlib/CategoryTheory/GradedObject/Associator.lean
@@ -63,8 +63,6 @@ lemma ι_mapBifunctorAssociator_hom (i₁ : I₁) (i₂ : I₂) (i₃ : I₃) (j
       (mapBifunctorAssociator associator ρ₁₂ ρ₂₃ X₁ X₂ X₃).hom j =
         ((associator.hom.app (X₁ i₁)).app (X₂ i₂)).app (X₃ i₃) ≫
           ιMapBifunctorBifunctor₂₃MapObj F G₂₃ ρ₂₃ X₁ X₂ X₃ i₁ i₂ i₃ j h := by
-  have := H₁₂.hasMap
-  have := H₂₃.hasMap
   dsimp [mapBifunctorAssociator]
   rw [ι_mapBifunctorComp₁₂MapObjIso_inv_assoc, ιMapTrifunctorMapObj,
     ι_mapMap_assoc, mapTrifunctorMapNatTrans_app_app_app]

--- a/Mathlib/CategoryTheory/Limits/Shapes/Products.lean
+++ b/Mathlib/CategoryTheory/Limits/Shapes/Products.lean
@@ -93,16 +93,12 @@ abbrev HasCoproduct (f : β → C) :=
 
 lemma hasCoproduct_of_equiv_of_iso (f : α → C) (g : β → C)
     [HasCoproduct f] (e : β ≃ α) (iso : ∀ j, g j ≅ f (e j)) : HasCoproduct g := by
-  have : HasColimit ((Discrete.equivalence e).functor ⋙ Discrete.functor f) :=
-    hasColimit_equivalence_comp _
   have α : Discrete.functor g ≅ (Discrete.equivalence e).functor ⋙ Discrete.functor f :=
     Discrete.natIso (fun ⟨j⟩ => iso j)
   exact hasColimit_of_iso α
 
 lemma hasProduct_of_equiv_of_iso (f : α → C) (g : β → C)
     [HasProduct f] (e : β ≃ α) (iso : ∀ j, g j ≅ f (e j)) : HasProduct g := by
-  have : HasLimit ((Discrete.equivalence e).functor ⋙ Discrete.functor f) :=
-    hasLimit_equivalence_comp _
   have α : Discrete.functor g ≅ (Discrete.equivalence e).functor ⋙ Discrete.functor f :=
     Discrete.natIso (fun ⟨j⟩ => iso j)
   exact hasLimit_of_iso α.symm

--- a/Mathlib/CategoryTheory/Limits/Shapes/SingleObj.lean
+++ b/Mathlib/CategoryTheory/Limits/Shapes/SingleObj.lean
@@ -78,7 +78,6 @@ equivalent to the `MulAction.orbitRel` equivalence relation on `J.obj (SingleObj
 lemma colimitTypeRel_iff_orbitRel (x y : J.obj (SingleObj.star G)) :
     J.ColimitTypeRel ⟨SingleObj.star G, x⟩ ⟨SingleObj.star G, y⟩ ↔
       MulAction.orbitRel G (J.obj (SingleObj.star G)) x y := by
-  have h (g : G) : y = g • x ↔ g • x = y := ⟨symm, symm⟩
   conv => rhs; rw [Setoid.comm']
   change (∃ g : G, y = g • x) ↔ (∃ g : G, g • x = y)
   grind

--- a/Mathlib/CategoryTheory/Limits/VanKampen.lean
+++ b/Mathlib/CategoryTheory/Limits/VanKampen.lean
@@ -135,7 +135,6 @@ theorem IsUniversalColimit.of_iso {F : J ⥤ C} {c c' : Cocone F} (hc : IsUniver
   apply hc c'' α (f ≫ e.inv.1) (by rw [Functor.map_comp, ← reassoc_of% h, this]) hα
   intro j
   rw [← Category.comp_id (α.app j)]
-  have : IsIso e.inv.hom := Functor.map_isIso (Cocones.forget _) e.inv
   exact (H j).paste_vert (IsPullback.of_vert_isIso ⟨by simp⟩)
 
 theorem IsVanKampenColimit.of_iso {F : J ⥤ C} {c c' : Cocone F} (H : IsVanKampenColimit c)
@@ -226,7 +225,6 @@ theorem IsUniversalColimit.whiskerEquivalence {K : Type*} [Category K] (e : J �
   · intro k
     rw [← Category.comp_id f]
     refine (H (e.inverse.obj k)).paste_vert ?_
-    have : IsIso (𝟙 (Cocone.whisker e.functor c).pt) := inferInstance
     exact IsPullback.of_vert_isIso ⟨by simp⟩
 
 theorem IsUniversalColimit.whiskerEquivalence_iff {K : Type*} [Category K] (e : J ≌ K)

--- a/Mathlib/CategoryTheory/Localization/CalculusOfFractions/OfAdjunction.lean
+++ b/Mathlib/CategoryTheory/Localization/CalculusOfFractions/OfAdjunction.lean
@@ -73,8 +73,6 @@ lemma isLocalization_leftAdjoint
     rw [NatTrans.isIso_iff_isIso_app]
     intro X
     exact Localization.inverts W.Q W _ (hW' X)
-  have : Localization.Lifting W.Q W (G ⋙ F ⋙ W.Q) (Φ ⋙ F ⋙ W.Q) :=
-    ⟨(Functor.associator _ _ _).symm ≪≫ Functor.isoWhiskerRight e _⟩
   exact Functor.IsLocalization.of_equivalence_target W.Q W _
     (Equivalence.mk Φ (F ⋙ W.Q)
       (Localization.liftNatIso W.Q W W.Q (G ⋙ F ⋙ W.Q) _ _

--- a/Mathlib/CategoryTheory/Localization/SmallHom.lean
+++ b/Mathlib/CategoryTheory/Localization/SmallHom.lean
@@ -50,7 +50,6 @@ lemma hasSmallLocalizedHom_iff :
     HasSmallLocalizedHom.{w} W X Y ↔ Small.{w} (L.obj X ⟶ L.obj Y) := by
   constructor
   · intro h
-    have := h.small
     exact small_map (homEquiv W W.Q L).symm
   · intro h
     exact ⟨small_map (homEquiv W W.Q L)⟩

--- a/Mathlib/CategoryTheory/Preadditive/Injective/Preserves.lean
+++ b/Mathlib/CategoryTheory/Preadditive/Injective/Preserves.lean
@@ -57,7 +57,6 @@ theorem Functor.preservesMonomorphisms_of_adjunction_of_preservesInjectiveObject
     F.PreservesMonomorphisms where
   preserves {X Y} f _ := by
     suffices ∃ h, F.map f ≫ h = Injective.ι (F.obj X) from mono_of_mono_fac this.choose_spec
-    have : Injective (G.obj (Injective.under (F.obj X))) := G.injective_obj _
     exact ⟨F.map (Injective.factorThru (adj.unit.app X ≫ G.map (Injective.ι _)) f) ≫
       adj.counit.app (Injective.under (F.obj X)), by simp [← Functor.map_comp_assoc]⟩
 

--- a/Mathlib/CategoryTheory/Preadditive/Projective/Preserves.lean
+++ b/Mathlib/CategoryTheory/Preadditive/Projective/Preserves.lean
@@ -56,7 +56,6 @@ theorem Functor.preservesEpimorphisms_of_adjunction_of_preservesProjectiveObject
     G.PreservesEpimorphisms where
   preserves {X Y} f _ := by
     suffices ∃ h, h ≫ G.map f = Projective.π (G.obj Y) from epi_of_epi_fac this.choose_spec
-    have : Projective (F.obj (Projective.over (G.obj Y))) := F.projective_obj _
     refine ⟨adj.unit.app (Projective.over (G.obj Y)) ≫
       G.map (Projective.factorThru (F.map (Projective.π _) ≫ adj.counit.app Y) f), ?_⟩
     rw [Category.assoc, ← Functor.map_comp]

--- a/Mathlib/CategoryTheory/Yoneda.lean
+++ b/Mathlib/CategoryTheory/Yoneda.lean
@@ -645,7 +645,6 @@ lemma isIso_of_yoneda_map_bijective {X Y : C} (f : X ⟶ Y)
 lemma isIso_iff_yoneda_map_bijective {X Y : C} (f : X ⟶ Y) :
     IsIso f ↔ (∀ (T : C), Function.Bijective (fun (x : T ⟶ X) => x ≫ f)) := by
   refine ⟨fun _ ↦ ?_, fun hf ↦ isIso_of_yoneda_map_bijective f hf⟩
-  have : IsIso (yoneda.map f) := inferInstance
   intro T
   rw [← isIso_iff_bijective]
   exact inferInstanceAs (IsIso ((yoneda.map f).app _))
@@ -873,7 +872,6 @@ lemma isIso_of_coyoneda_map_bijective {X Y : C} (f : X ⟶ Y)
 lemma isIso_iff_coyoneda_map_bijective {X Y : C} (f : X ⟶ Y) :
     IsIso f ↔ (∀ (T : C), Function.Bijective (fun (x : Y ⟶ T) => f ≫ x)) := by
   refine ⟨fun _ ↦ ?_, fun hf ↦ isIso_of_coyoneda_map_bijective f hf⟩
-  have : IsIso (coyoneda.map f.op) := inferInstance
   intro T
   rw [← isIso_iff_bijective]
   exact inferInstanceAs (IsIso ((coyoneda.map f.op).app _))


### PR DESCRIPTION
---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include at least one commit authored by each
co-author among the commits in the pull request. If necessary, you may 
create empty commits to indicate co-authorship, using commands like so:

git commit --author="Author Name <author@email.com>" --allow-empty -m "add Author Name as coauthor"

When merging, all the commits will be squashed into a single commit listing all co-authors.

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
