### PR TITLE
[Merged by Bors] - fix: squeeze a few more non-terminal simps

### DIFF
--- a/Mathlib/Algebra/Category/Grp/Adjunctions.lean
+++ b/Mathlib/Algebra/Category/Grp/Adjunctions.lean
@@ -70,7 +70,8 @@ def adj : free ⊣ forget AddCommGrp.{u} :=
       homEquiv_naturality_left_symm := by
         intros
         ext
-        simp
+        simp only [free_obj_coe, Equiv.symm_trans_apply, Equiv.symm_symm, hom_comp,
+          AddMonoidHom.coe_comp, Function.comp_apply]
         apply FreeAbelianGroup.lift_comp }
 
 instance : free.{u}.IsLeftAdjoint :=

--- a/Mathlib/Algebra/ContinuedFractions/Computation/CorrectnessTerminating.lean
+++ b/Mathlib/Algebra/ContinuedFractions/Computation/CorrectnessTerminating.lean
@@ -166,7 +166,8 @@ theorem compExactValue_correctness_of_stream_eq_some :
       have : compExactValue ppconts pconts ifp_n.fr =
           (ppA + ifp_n.fr⁻¹ * pA) / (ppB + ifp_n.fr⁻¹ * pB) := by
         -- unfold compExactValue and the convergent computation once
-        simp [ifp_n_fract_ne_zero, compExactValue, nextConts, nextNum, nextDen, ppA, ppB]
+        simp only [compExactValue, ifp_n_fract_ne_zero, ↓reduceIte, nextConts, nextNum, one_mul,
+          nextDen, ppA, ppB]
         ac_rfl
       rw [this]
       -- two calculations needed to show the claim
@@ -179,9 +180,9 @@ theorem compExactValue_correctness_of_stream_eq_some :
       rw [inv_eq_one_div] at tmp_calc tmp_calc'
       -- now unfold the recurrence one step and simplify both sides to arrive at the conclusion
       dsimp only [conts, pconts, ppconts]
+      have hfr : (IntFractPair.of (1 / ifp_n.fr)).fr = f := rfl
       simp [compExactValue, contsAux_recurrence s_nth_eq ppconts_eq pconts_eq,
         nextConts, nextNum, nextDen]
-      have hfr : (IntFractPair.of (1 / ifp_n.fr)).fr = f := rfl
       grind
 
 open GenContFract (of_terminatedAt_n_iff_succ_nth_intFractPair_stream_eq_none)

--- a/Mathlib/Algebra/GCDMonoid/Multiset.lean
+++ b/Mathlib/Algebra/GCDMonoid/Multiset.lean
@@ -79,7 +79,8 @@ variable [DecidableEq α]
 @[simp]
 theorem lcm_dedup (s : Multiset α) : (dedup s).lcm = s.lcm :=
   Multiset.induction_on s (by simp) fun a s IH ↦ by
-    by_cases h : a ∈ s <;> simp [IH, h]
+    by_cases h : a ∈ s; swap; · simp [IH, h]
+    simp only [h, dedup_cons_of_mem, IH, lcm_cons]
     unfold lcm
     rw [← cons_erase h, fold_cons_left, ← lcm_assoc, lcm_same]
     apply lcm_eq_of_associated_left (associated_normalize _)
@@ -165,7 +166,8 @@ variable [DecidableEq α]
 @[simp]
 theorem gcd_dedup (s : Multiset α) : (dedup s).gcd = s.gcd :=
   Multiset.induction_on s (by simp) fun a s IH ↦ by
-    by_cases h : a ∈ s <;> simp [IH, h]
+    by_cases h : a ∈ s; swap; · simp [IH, h]
+    simp only [h, dedup_cons_of_mem, IH, gcd_cons]
     unfold gcd
     rw [← cons_erase h, fold_cons_left, ← gcd_assoc, gcd_same]
     apply (associated_normalize _).gcd_eq_left

--- a/Mathlib/Algebra/Order/CauSeq/Basic.lean
+++ b/Mathlib/Algebra/Order/CauSeq/Basic.lean
@@ -603,7 +603,9 @@ protected theorem mul_pos {f g : CauSeq α abs} : Pos f → Pos g → Pos (f * g
       mul_le_mul h₁ h₂ (le_of_lt G0) (le_trans (le_of_lt F0) h₁)⟩
 
 theorem trichotomy (f : CauSeq α abs) : Pos f ∨ LimZero f ∨ Pos (-f) := by
-  rcases Classical.em (LimZero f) with h | h <;> simp [*]
+  rcases Classical.em (LimZero f) with h | h
+  · simp [*]
+  simp only [false_or, h]
   rcases abv_pos_of_not_limZero h with ⟨K, K0, hK⟩
   rcases exists_forall_ge_and hK (f.cauchy₃ K0) with ⟨i, hi⟩
   refine (le_total 0 (f i)).imp ?_ ?_ <;>

--- a/Mathlib/CategoryTheory/FiberedCategory/Cocartesian.lean
+++ b/Mathlib/CategoryTheory/FiberedCategory/Cocartesian.lean
@@ -357,7 +357,7 @@ noncomputable def codomainIsoOfBaseIso {R S S' : 𝒮} {a b b' : 𝒳} {f : R �
     [IsStronglyCocartesian p f' φ'] : b ≅ b' where
   hom := map p f φ h φ'
   inv := @map _ _ _ _ p _ _ _ _ f' φ' _ _ _ _ _ (congrArg (· ≫ g.inv) h.symm) φ
-    (by simp; infer_instance)
+    (by simp only [assoc, Iso.hom_inv_id, comp_id]; infer_instance)
 
 end IsStronglyCocartesian
 

--- a/Mathlib/CategoryTheory/Limits/Shapes/Pullback/Pasting.lean
+++ b/Mathlib/CategoryTheory/Limits/Shapes/Pullback/Pasting.lean
@@ -309,7 +309,7 @@ def rightSquareIsPushout (H : IsColimit t₁) (H' : IsColimit (t₁.pasteHoriz t
     (by rw [reassoc_of% t₁.condition, ← hi₂, s.condition, Category.assoc])
   refine ⟨l, ?_, hl', ?_⟩
   -- To check that `l` is compatible with the projections, we use the universal property of `t₁`
-  · simp at hl hl'
+  · simp only [PushoutCocone.mk_pt, PushoutCocone.mk_ι_app, Category.assoc] at hl hl'
     apply PushoutCocone.IsColimit.hom_ext H hl
     rw [← Category.assoc, ← hi₂, t₂.condition, s.condition, Category.assoc, hl']
   -- Uniqueness of the lift follows from the universal property of the big square

--- a/Mathlib/CategoryTheory/Monoidal/Rigid/Braided.lean
+++ b/Mathlib/CategoryTheory/Monoidal/Rigid/Braided.lean
@@ -53,7 +53,10 @@ private theorem evaluation_coevaluation_braided' [inst : ExactPairing X Y] :
     _ = 𝟙 Y ⊗≫ η_ X Y ▷ Y ⊗≫ (𝟙 ((X ⊗ Y) ⊗ Y) ⊗≫ X ◁ (β_ Y Y).hom ⊗≫ (β_ X Y).hom ▷ Y
         ⊗≫ Y ◁ (β_ Y X).inv ⊗≫ (β_ Y Y).inv ▷ X ⊗≫ 𝟙 (Y ⊗ Y ⊗ X)) ⊗≫ Y ◁ ε_ X Y ⊗≫ 𝟙 Y := by
       congr 3
-      all_goals simp [monoidalComp]
+      on_goal 2 => simp [monoidalComp]
+      simp only [monoidalComp, MonoidalCoherence.assoc_iso, MonoidalCoherence.whiskerRight_iso,
+        MonoidalCoherence.refl_iso, whiskerRightIso_refl, Iso.trans_refl,
+        MonoidalCoherence.assoc'_iso, Iso.refl_trans, Iso.symm_hom, comp_id, id_comp]
       iterate 2 rw [← IsIso.eq_inv_comp]
       repeat rw [← assoc]
       iterate 4 rw [← IsIso.comp_inv_eq]

--- a/Mathlib/CategoryTheory/Shift/Basic.lean
+++ b/Mathlib/CategoryTheory/Shift/Basic.lean
@@ -733,8 +733,9 @@ def hasShift :
       zero_add_hom_app := fun n X => hF.map_injective (by
         have this := dcongr_arg (fun a => (i a).hom.app X) (zero_add n)
         rw [← cancel_mono ((i n).hom.app ((s 0).obj X)) ]
-        simp [this, map_add_hom_app,
-          shiftFunctorAdd_zero_add_hom_app, eqToHom_map]
+        simp only [comp_obj, map_add_hom_app, this, shiftFunctorAdd_zero_add_hom_app, id_obj,
+          Category.assoc, eqToHom_trans_assoc, eqToHom_refl, Category.id_comp, Iso.inv_hom_id_app,
+          Category.comp_id, map_comp, eqToHom_map]
         congr 1
         erw [(i n).hom.naturality]
         simp)

--- a/Mathlib/Combinatorics/Quiver/ReflQuiver.lean
+++ b/Mathlib/Combinatorics/Quiver/ReflQuiver.lean
@@ -78,7 +78,6 @@ theorem ext' {V W : Type u} [ReflQuiver.{v} V] [ReflQuiver.{v} W]
       F.map f = Quiver.homOfEq (G.map f) (h_obj _).symm (h_obj _).symm) : F = G := by
   obtain ⟨Fpre, Fid⟩ := F
   obtain ⟨Gpre, Gid⟩ := G
-  simp at h_obj h_map
   obtain rfl : Fpre = Gpre := Prefunctor.ext' (V := V) (W := W) h_obj h_map
   rfl
 

--- a/Mathlib/Control/EquivFunctor/Instances.lean
+++ b/Mathlib/Control/EquivFunctor/Instances.lean
@@ -31,9 +31,7 @@ instance EquivFunctorFinset : EquivFunctor Finset where
   map e s := s.map e.toEmbedding
   map_refl' α := by ext; simp
   map_trans' k h := by
-    ext _ a
-    simp
-    constructor <;> intro h'
+    ext _ a; simp; constructor <;> intro h'
     · let ⟨a, ha₁, ha₂⟩ := h'
       rw [← ha₂]; simpa
     · exists (Equiv.symm k) ((Equiv.symm h) a)

--- a/Mathlib/Control/EquivFunctor/Instances.lean
+++ b/Mathlib/Control/EquivFunctor/Instances.lean
@@ -31,7 +31,9 @@ instance EquivFunctorFinset : EquivFunctor Finset where
   map e s := s.map e.toEmbedding
   map_refl' α := by ext; simp
   map_trans' k h := by
-    ext _ a; simp; constructor <;> intro h'
+    ext _ a
+    simp
+    constructor <;> intro h'
     · let ⟨a, ha₁, ha₂⟩ := h'
       rw [← ha₂]; simpa
     · exists (Equiv.symm k) ((Equiv.symm h) a)

--- a/Mathlib/Data/ENat/Basic.lean
+++ b/Mathlib/Data/ENat/Basic.lean
@@ -251,8 +251,8 @@ theorem toNat_sub {n : ℕ∞} (hn : n ≠ ⊤) (m : ℕ∞) : toNat (m - n) = t
 @[simp] theorem toNat_mul (a b : ℕ∞) : (a * b).toNat = a.toNat * b.toNat := by
   cases a <;> cases b
   · simp
-  · simp; rename_i b; cases b <;> simp
-  · simp; rename_i a; cases a <;> simp
+  · rename_i b; cases b <;> simp
+  · rename_i a; cases a <;> simp
   · simp only [toNat_coe]; rw [← coe_mul, toNat_coe]
 
 theorem toNat_eq_iff {m : ℕ∞} {n : ℕ} (hn : n ≠ 0) : toNat m = n ↔ m = n := by

--- a/Mathlib/Data/ENat/Basic.lean
+++ b/Mathlib/Data/ENat/Basic.lean
@@ -249,10 +249,11 @@ theorem toNat_sub {n : ℕ∞} (hn : n ≠ ⊤) (m : ℕ∞) : toNat (m - n) = t
   · rw [← coe_sub, toNat_coe, toNat_coe, toNat_coe]
 
 @[simp] theorem toNat_mul (a b : ℕ∞) : (a * b).toNat = a.toNat * b.toNat := by
-  cases a <;> cases b <;> simp
-  · rename_i b; cases b <;> simp
-  · rename_i a; cases a <;> simp
-  · rw [← coe_mul, toNat_coe]
+  cases a <;> cases b
+  · simp
+  · simp; rename_i b; cases b <;> simp
+  · simp; rename_i a; cases a <;> simp
+  · simp only [toNat_coe]; rw [← coe_mul, toNat_coe]
 
 theorem toNat_eq_iff {m : ℕ∞} {n : ℕ} (hn : n ≠ 0) : toNat m = n ↔ m = n := by
   induction m <;> simp [hn.symm]

--- a/Mathlib/Data/Fin/Tuple/Embedding.lean
+++ b/Mathlib/Data/Fin/Tuple/Embedding.lean
@@ -108,10 +108,10 @@ def twoEmbeddingEquiv : (Fin 2 ↪ α) ≃ { (a, b) : α × α | a ≠ b } where
         · simp [hj] at hij; exact False.elim (h hij.symm)
         · rw [eq_one_of_ne_zero j hj] }
   left_inv e := by
-    ext i; simp
+    ext i
     by_cases hi : i = 0
-    · rw [if_pos hi, hi]
-    · rw [if_neg hi, Fin.eq_one_of_ne_zero i hi]
+    · simp [hi]
+    · simp [Fin.eq_one_of_ne_zero i hi]
 
 /-- Two distinct elements of `α` give an embedding `Fin 2 ↪ α`. -/
 def embFinTwo {a b : α} (h : a ≠ b) : Fin 2 ↪ α :=

--- a/Mathlib/Data/List/Sigma.lean
+++ b/Mathlib/Data/List/Sigma.lean
@@ -692,14 +692,16 @@ theorem Perm.kunion {l₁ l₂ l₃ l₄ : List (Sigma β)} (nd₃ : l₃.NodupK
 @[simp]
 theorem dlookup_kunion_left {a} {l₁ l₂ : List (Sigma β)} (h : a ∈ l₁.keys) :
     dlookup a (kunion l₁ l₂) = dlookup a l₁ := by
-  induction' l₁ with s _ ih generalizing l₂ <;> simp at h; rcases h with h | h <;> obtain ⟨a'⟩ := s
-  · subst h
-    simp
-  · rw [kunion_cons]
-    by_cases h' : a = a'
-    · subst h'
-      simp
-    · simp [h', ih h]
+  induction' l₁ with s _ ih generalizing l₂
+  · simp at h
+  · simp only [keys_cons, mem_cons] at h
+    rcases h with rfl | h <;> obtain ⟨a'⟩ := s
+    · simp
+    · rw [kunion_cons]
+      by_cases h' : a = a'
+      · subst h'
+        simp
+      · simp [h', ih h]
 
 @[simp]
 theorem dlookup_kunion_right {a} {l₁ l₂ : List (Sigma β)} (h : a ∉ l₁.keys) :

--- a/Mathlib/Data/List/Sym.lean
+++ b/Mathlib/Data/List/Sym.lean
@@ -161,7 +161,8 @@ theorem map_mk_disjoint_sym2 (x : α) (xs : List α) (h : x ∉ xs) :
       rw [List.mem_map] at hx hy
       obtain ⟨a, hx, rfl⟩ := hx
       obtain ⟨b, hy, hx⟩ := hy
-      simp [Ne.symm h.1] at hx
+      simp only [Sym2.eq, Sym2.rel_iff', Prod.mk.injEq, Ne.symm h.1, false_and, Prod.swap_prod_mk,
+        false_or] at hx
       obtain ⟨rfl, rfl⟩ := hx
       exact h.2 hy
     · exact ih h.2

--- a/Mathlib/Data/Multiset/Fold.lean
+++ b/Mathlib/Data/Multiset/Fold.lean
@@ -89,7 +89,8 @@ theorem fold_union_inter [DecidableEq α] (s₁ s₂ : Multiset α) (b₁ b₂ :
 theorem fold_dedup_idem [DecidableEq α] [hi : Std.IdempotentOp op] (s : Multiset α) (b : α) :
     (dedup s).fold op b = s.fold op b :=
   Multiset.induction_on s (by simp) fun a s IH => by
-    by_cases h : a ∈ s <;> simp [IH, h]
+    by_cases h : a ∈ s; swap; · simp [IH, h]
+    simp only [h, dedup_cons_of_mem, IH, fold_cons_left]
     show fold op b s = op a (fold op b s)
     rw [← cons_erase h, fold_cons_left, ← ha.assoc, hi.idempotent]
 

--- a/Mathlib/Data/Nat/Pairing.lean
+++ b/Mathlib/Data/Nat/Pairing.lean
@@ -83,7 +83,7 @@ theorem pair_eq_pair {a b c d : ℕ} : pair a b = pair c d ↔ a = c ∧ b = d :
 theorem unpair_lt {n : ℕ} (n1 : 1 ≤ n) : (unpair n).1 < n := by
   let s := sqrt n
   simp only [unpair]
-  by_cases h : n - s * s < s <;> simp [s, h, ↓reduceIte]
+  by_cases h : n - s * s < s <;> simp only [h, ↓reduceIte, gt_iff_lt, s]
   · exact lt_of_lt_of_le h (sqrt_le_self _)
   · simp only [not_lt] at h
     have s0 : 0 < s := sqrt_pos.2 n1
@@ -109,8 +109,10 @@ theorem unpair_right_le (n : ℕ) : (unpair n).2 ≤ n := by
   simpa using right_le_pair n.unpair.1 n.unpair.2
 
 theorem pair_lt_pair_left {a₁ a₂} (b) (h : a₁ < a₂) : pair a₁ b < pair a₂ b := by
-  by_cases h₁ : a₁ < b <;> simp [pair, h₁, Nat.add_assoc]
-  · by_cases h₂ : a₂ < b <;> simp [h₂, h]
+  by_cases h₁ : a₁ < b <;> simp only [pair, h₁, ↓reduceIte, Nat.add_assoc]
+  · by_cases h₂ : a₂ < b
+    · simp [h₂, h]
+    simp only [h₂, ↓reduceIte]
     simp? at h₂ says simp only [not_lt] at h₂
     apply Nat.add_lt_add_of_le_of_lt
     · exact Nat.mul_self_le_mul_self h₂
@@ -125,7 +127,8 @@ theorem pair_lt_pair_right (a) {b₁ b₂} (h : b₁ < b₂) : pair a b₁ < pai
   by_cases h₁ : a < b₁
   · simpa [pair, h₁, Nat.add_assoc, lt_trans h₁ h, h] using mul_self_lt_mul_self h
   · simp only [pair, h₁, ↓reduceIte, Nat.add_assoc]
-    by_cases h₂ : a < b₂ <;> simp [h₂, h]
+    by_cases h₂ : a < b₂; swap; · simp [h₂, h]
+    simp only [h₂, ↓reduceIte]
     simp? at h₁ says simp only [not_lt] at h₁
     rw [Nat.add_comm, Nat.add_comm _ a, Nat.add_assoc, Nat.add_lt_add_iff_left]
     rwa [Nat.add_comm, ← sqrt_lt, sqrt_add_eq]

--- a/Mathlib/Data/PNat/Xgcd.lean
+++ b/Mathlib/Data/PNat/Xgcd.lean
@@ -136,7 +136,9 @@ theorem isSpecial_iff : u.IsSpecial ↔ u.IsSpecial' := by
   constructor <;> intro h <;> simp only [w, succPNat, succ_eq_add_one, z] at * <;>
     simp only [← coe_inj, mul_coe, mk_coe] at *
   · simp_all [← h]; ring
-  · simp [Nat.mul_add, Nat.add_mul, ← Nat.add_assoc] at h; rw [← h]; ring
+  · simp only [Nat.mul_add, Nat.add_mul, one_mul, mul_one, ← Nat.add_assoc,
+      Nat.add_right_cancel_iff] at h
+    rw [← h]; ring
 
 /-- `IsReduced` holds if the two entries in the vector are the
 same.  The reduction algorithm will produce a system with this

--- a/Mathlib/Data/Seq/Computation.lean
+++ b/Mathlib/Data/Seq/Computation.lean
@@ -796,14 +796,18 @@ theorem orElse_think (c₁ c₂ : Computation α) : (think c₁ <|> think c₂) 
 theorem empty_orElse (c) : (empty α <|> c) = c := by
   apply eq_of_bisim (fun c₁ c₂ => (empty α <|> c₂) = c₁) _ rfl
   intro s' s h; rw [← h]
-  apply recOn s <;> intro s <;> rw [think_empty] <;> simp
+  apply recOn s <;> intro s <;> rw [think_empty]
+  · simp
+  simp only [BisimO, orElse_think, destruct_think]
   rw [← think_empty]
 
 @[simp]
 theorem orElse_empty (c : Computation α) : (c <|> empty α) = c := by
   apply eq_of_bisim (fun c₁ c₂ => (c₂ <|> empty α) = c₁) _ rfl
   intro s' s h; rw [← h]
-  apply recOn s <;> intro s <;> rw [think_empty] <;> simp
+  apply recOn s <;> intro s <;> rw [think_empty]
+  · simp
+  simp only [BisimO, orElse_think, destruct_think]
   rw [← think_empty]
 
 /-- `c₁ ~ c₂` asserts that `c₁` and `c₂` either both terminate with the same result,

--- a/Mathlib/Data/WSeq/Defs.lean
+++ b/Mathlib/Data/WSeq/Defs.lean
@@ -234,8 +234,9 @@ theorem length_eq_map (s : WSeq α) : length s = Computation.map List.length (to
               | some (some a, s') => Sum.inr (a::l, s')) (l, s)))
       ?_ ⟨[], s, rfl, rfl⟩
   intro s1 s2 h; rcases h with ⟨l, s, h⟩; rw [h.left, h.right]
-  induction' s using WSeq.recOn with a s s <;> simp [nil, cons, think]
-  · refine ⟨a::l, s, ?_, ?_⟩ <;> simp
-  · refine ⟨l, s, ?_, ?_⟩ <;> simp
+  induction' s using WSeq.recOn with a s s
+  · simp [nil]
+  · simpa using ⟨a::l, s, by simp, by simp⟩
+  · simpa using ⟨l, s, by simp, by simp⟩
 
 end Stream'.WSeq

--- a/Mathlib/Order/CompleteLattice/Basic.lean
+++ b/Mathlib/Order/CompleteLattice/Basic.lean
@@ -38,10 +38,10 @@ open Function OrderDual Set
 variable {α β γ : Type*} {ι ι' : Sort*} {κ : ι → Sort*} {κ' : ι' → Sort*}
 
 @[simp] lemma iSup_ulift {ι : Type*} [SupSet α] (f : ULift ι → α) :
-    ⨆ i : ULift ι, f i = ⨆ i, f (.up i) := by simp [iSup]; congr with x; simp
+    ⨆ i : ULift ι, f i = ⨆ i, f (.up i) := by simp only [iSup]; congr with x; simp
 
 @[simp] lemma iInf_ulift {ι : Type*} [InfSet α] (f : ULift ι → α) :
-    ⨅ i : ULift ι, f i = ⨅ i, f (.up i) := by simp [iInf]; congr with x; simp
+    ⨅ i : ULift ι, f i = ⨅ i, f (.up i) := by simp only [iInf]; congr with x; simp
 
 section
 

--- a/Mathlib/Order/SuccPred/CompleteLinearOrder.lean
+++ b/Mathlib/Order/SuccPred/CompleteLinearOrder.lean
@@ -73,7 +73,7 @@ noncomputable def ConditionallyCompleteLinearOrder.toSuccOrder [WellFoundedLT α
     rw [not_isMax_iff] at h
     exact hs.not_gt (csInf_mem h)
   succ_le_of_lt {a b} ha := by
-    simp [ha.not_isMax]
+    simp only [ha.not_isMax, ↓reduceIte]
     exact csInf_le ⟨a, fun _ hc => hc.le⟩ ha
 
 end ConditionallyCompleteLinearOrder

--- a/Mathlib/Tactic/NormNum/Ineq.lean
+++ b/Mathlib/Tactic/NormNum/Ineq.lean
@@ -83,7 +83,8 @@ theorem isNNRat_le_true [Semiring α] [LinearOrder α] [IsStrictOrderedRing α] 
     have hb : 0 ≤ ⅟(db : α) := invOf_nonneg.mpr <| Nat.cast_nonneg db
     have h := (mul_le_mul_of_nonneg_left · hb) <| mul_le_mul_of_nonneg_right h ha
     rw [← mul_assoc, Nat.commute_cast] at h
-    simp at h; rwa [Nat.commute_cast] at h
+    simp only [Nat.mul_eq, Nat.cast_mul, mul_invOf_cancel_right'] at h
+    rwa [Nat.commute_cast] at h
 
 theorem isNNRat_lt_true [Semiring α] [LinearOrder α] [IsStrictOrderedRing α] [Nontrivial α] :
     {a b : α} → {na nb : ℕ} → {da db : ℕ} →
@@ -117,7 +118,9 @@ theorem isRat_le_true [Ring α] [LinearOrder α] [IsStrictOrderedRing α] :
     have hb : 0 ≤ ⅟(db : α) := invOf_nonneg.mpr <| Nat.cast_nonneg db
     have h := (mul_le_mul_of_nonneg_left · hb) <| mul_le_mul_of_nonneg_right h ha
     rw [← mul_assoc, Int.commute_cast] at h
-    simp at h; rwa [Int.commute_cast] at h
+    simp only [Int.ofNat_eq_coe, Int.mul_def, Int.cast_mul, Int.cast_natCast,
+      mul_invOf_cancel_right'] at h
+    rwa [Int.commute_cast] at h
 
 theorem isRat_lt_true [Ring α] [LinearOrder α] [IsStrictOrderedRing α] [Nontrivial α] :
     {a b : α} → {na nb : ℤ} → {da db : ℕ} →


### PR DESCRIPTION
---

Found by the flexible linter in #28962.

<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include at least one commit authored by each
co-author among the commits in the pull request. If necessary, you may 
create empty commits to indicate co-authorship, using commands like so:

git commit --author="Author Name <author@email.com>" --allow-empty -m "add Author Name as coauthor"

When merging, all the commits will be squashed into a single commit listing all co-authors.

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
