### PR TITLE
chore: change from `:= by rfl` to `:= rfl`

### DIFF
--- a/Mathlib/Algebra/Algebra/NonUnitalHom.lean
+++ b/Mathlib/Algebra/Algebra/NonUnitalHom.lean
@@ -199,8 +199,7 @@ theorem coe_mk (f : A → B) (h₁ h₂ h₃ h₄) : ⇑(⟨⟨⟨f, h₁⟩, h�
   rfl
 
 @[simp]
-theorem mk_coe (f : A →ₛₙₐ[φ] B) (h₁ h₂ h₃ h₄) : (⟨⟨⟨f, h₁⟩, h₂, h₃⟩, h₄⟩ : A →ₛₙₐ[φ] B) = f := by
-  rfl
+theorem mk_coe (f : A →ₛₙₐ[φ] B) (h₁ h₂ h₃ h₄) : (⟨⟨⟨f, h₁⟩, h₂, h₃⟩, h₄⟩ : A →ₛₙₐ[φ] B) = f := rfl
 
 @[simp] lemma addHomMk_coe (f : A →ₛₙₐ[φ] B) : AddHom.mk f (map_add f) = f := rfl
 
@@ -231,13 +230,11 @@ theorem to_mulHom_injective {f g : A →ₛₙₐ[φ] B} (h : (f : A →ₙ* B) 
 
 @[norm_cast]
 theorem coe_distribMulActionHom_mk (f : A →ₛₙₐ[φ] B) (h₁ h₂ h₃ h₄) :
-    ((⟨⟨⟨f, h₁⟩, h₂, h₃⟩, h₄⟩ : A →ₛₙₐ[φ] B) : A →ₑ+[φ] B) = ⟨⟨f, h₁⟩, h₂, h₃⟩ := by
-  rfl
+    ((⟨⟨⟨f, h₁⟩, h₂, h₃⟩, h₄⟩ : A →ₛₙₐ[φ] B) : A →ₑ+[φ] B) = ⟨⟨f, h₁⟩, h₂, h₃⟩ := rfl
 
 @[norm_cast]
 theorem coe_mulHom_mk (f : A →ₛₙₐ[φ] B) (h₁ h₂ h₃ h₄) :
-    ((⟨⟨⟨f, h₁⟩, h₂, h₃⟩, h₄⟩ : A →ₛₙₐ[φ] B) : A →ₙ* B) = ⟨f, h₄⟩ := by
-  rfl
+    ((⟨⟨⟨f, h₁⟩, h₂, h₃⟩, h₄⟩ : A →ₛₙₐ[φ] B) : A →ₙ* B) = ⟨f, h₄⟩ := rfl
 
 @[simp] -- Marked as `@[simp]` because `MulActionSemiHomClass.map_smulₛₗ` can't be.
 protected theorem map_smul (f : A →ₛₙₐ[φ] B) (c : R) (x : A) : f (c • x) = (φ c) • f x :=
@@ -377,12 +374,10 @@ theorem coe_prod (f : A →ₙₐ[R] B) (g : A →ₙₐ[R] C) : ⇑(f.prod g) =
   rfl
 
 @[simp]
-theorem fst_prod (f : A →ₙₐ[R] B) (g : A →ₙₐ[R] C) : (fst R B C).comp (prod f g) = f := by
-  rfl
+theorem fst_prod (f : A →ₙₐ[R] B) (g : A →ₙₐ[R] C) : (fst R B C).comp (prod f g) = f := rfl
 
 @[simp]
-theorem snd_prod (f : A →ₙₐ[R] B) (g : A →ₙₐ[R] C) : (snd R B C).comp (prod f g) = g := by
-  rfl
+theorem snd_prod (f : A →ₙₐ[R] B) (g : A →ₙₐ[R] C) : (snd R B C).comp (prod f g) = g := rfl
 
 @[simp]
 theorem prod_fst_snd : prod (fst R A B) (snd R A B) = 1 :=

--- a/Mathlib/Algebra/Category/ModuleCat/Presheaf.lean
+++ b/Mathlib/Algebra/Category/ModuleCat/Presheaf.lean
@@ -87,13 +87,11 @@ lemma hom_ext {f g : M₁ ⟶ M₂} (h : ∀ (X : Cᵒᵖ), f.app X = g.app X) :
     f = g := Hom.ext (by ext1; apply h)
 
 @[simp]
-lemma id_app (M : PresheafOfModules R) (X : Cᵒᵖ) : Hom.app (𝟙 M) X = 𝟙 _ := by
-  rfl
+lemma id_app (M : PresheafOfModules R) (X : Cᵒᵖ) : Hom.app (𝟙 M) X = 𝟙 _ := rfl
 
 @[simp]
 lemma comp_app {M₁ M₂ M₃ : PresheafOfModules R} (f : M₁ ⟶ M₂) (g : M₂ ⟶ M₃) (X : Cᵒᵖ) :
-    (f ≫ g).app X = f.app X ≫ g.app X := by
-  rfl
+    (f ≫ g).app X = f.app X ≫ g.app X := rfl
 
 lemma naturality_apply (f : M₁ ⟶ M₂) {X Y : Cᵒᵖ} (g : X ⟶ Y) (x : M₁.obj X) :
     Hom.app f Y (M₁.map g x) = M₂.map g (Hom.app f X x) :=

--- a/Mathlib/Algebra/DirectSum/Module.lean
+++ b/Mathlib/Algebra/DirectSum/Module.lean
@@ -150,8 +150,7 @@ variable {ι M}
 
 @[simp]
 theorem linearEquivFunOnFintype_lof [Fintype ι] (i : ι) (m : M i) :
-    (linearEquivFunOnFintype R ι M) (lof R ι M i m) = Pi.single i m := by
-  rfl
+    (linearEquivFunOnFintype R ι M) (lof R ι M i m) = Pi.single i m := rfl
 
 @[simp]
 theorem linearEquivFunOnFintype_symm_single [Fintype ι] (i : ι) (m : M i) :

--- a/Mathlib/Algebra/DirectSum/Ring.lean
+++ b/Mathlib/Algebra/DirectSum/Ring.lean
@@ -480,8 +480,7 @@ instance : IntCast (A 0) :=
   ⟨GRing.intCast⟩
 
 @[simp]
-theorem of_intCast (n : ℤ) : of A 0 n = n := by
-  rfl
+theorem of_intCast (n : ℤ) : of A 0 n = n := rfl
 
 /-- The `Ring` derived from `GSemiring A`. -/
 instance GradeZero.ring : Ring (A 0) :=

--- a/Mathlib/Algebra/Group/AddChar.lean
+++ b/Mathlib/Algebra/Group/AddChar.lean
@@ -100,8 +100,7 @@ initialize_simps_projections AddChar (toFun → apply) -- needs to come after Fu
 
 @[simp] lemma coe_mk (f : A → M)
     (map_zero_eq_one' : f 0 = 1) (map_add_eq_mul' : ∀ a b : A, f (a + b) = f a * f b) :
-    AddChar.mk f map_zero_eq_one' map_add_eq_mul' = f := by
-  rfl
+    AddChar.mk f map_zero_eq_one' map_add_eq_mul' = f := rfl
 
 /-- An additive character maps `0` to `1`. -/
 @[simp] lemma map_zero_eq_one (ψ : AddChar A M) : ψ 0 = 1 := ψ.map_zero_eq_one'

--- a/Mathlib/Algebra/Group/Subgroup/Defs.lean
+++ b/Mathlib/Algebra/Group/Subgroup/Defs.lean
@@ -233,8 +233,7 @@ lemma subtype_injective :
   Subtype.coe_injective
 
 @[to_additive (attr := simp)]
-theorem coe_subtype : (SubgroupClass.subtype H : H → G) = ((↑) : H → G) := by
-  rfl
+theorem coe_subtype : (SubgroupClass.subtype H : H → G) = ((↑) : H → G) := rfl
 
 variable {H}
 

--- a/Mathlib/Algebra/GroupWithZero/ProdHom.lean
+++ b/Mathlib/Algebra/GroupWithZero/ProdHom.lean
@@ -89,8 +89,8 @@ lemma inr_apply_unit [DecidablePred fun x : H₀ ↦ x = 0] (x : H₀ˣ) :
     inr G₀ H₀ x = (((1 : G₀ˣ), x) : WithZero (G₀ˣ × H₀ˣ)) := by
   simp [inr]
 
-@[simp] lemma fst_apply_coe (x : G₀ˣ × H₀ˣ) : fst G₀ H₀ x = x.fst := by rfl
-@[simp] lemma snd_apply_coe (x : G₀ˣ × H₀ˣ) : snd G₀ H₀ x = x.snd := by rfl
+@[simp] lemma fst_apply_coe (x : G₀ˣ × H₀ˣ) : fst G₀ H₀ x = x.fst := rfl
+@[simp] lemma snd_apply_coe (x : G₀ˣ × H₀ˣ) : snd G₀ H₀ x = x.snd := rfl
 
 @[simp]
 theorem fst_inl [DecidablePred fun x : G₀ ↦ x = 0] (x : G₀) :

--- a/Mathlib/Algebra/Homology/HomotopyCategory/HomComplex.lean
+++ b/Mathlib/Algebra/Homology/HomotopyCategory/HomComplex.lean
@@ -607,7 +607,7 @@ instance : SMul R (Cocycle F G n) where
 variable (F G n)
 
 @[simp]
-lemma coe_zero : (↑(0 : Cocycle F G n) : Cochain F G n) = 0 := by rfl
+lemma coe_zero : (↑(0 : Cocycle F G n) : Cochain F G n) = 0 := rfl
 
 variable {F G n}
 

--- a/Mathlib/Algebra/Homology/ShortComplex/LeftHomology.lean
+++ b/Mathlib/Algebra/Homology/ShortComplex/LeftHomology.lean
@@ -152,8 +152,7 @@ def ofIsColimitCokernelCofork (hg : S.g = 0) (c : CokernelCofork S.f) (hc : IsCo
   hπ := IsColimit.ofIsoColimit hc (Cofork.ext (Iso.refl _))
 
 @[simp] lemma ofIsColimitCokernelCofork_f' (hg : S.g = 0) (c : CokernelCofork S.f)
-    (hc : IsColimit c) : (ofIsColimitCokernelCofork S hg c hc).f' = S.f := by
-  rfl
+    (hc : IsColimit c) : (ofIsColimitCokernelCofork S hg c hc).f' = S.f := rfl
 
 /-- When the second map `S.g` is zero, this is the left homology data on `S` given by
 the chosen `cokernel S.f` -/

--- a/Mathlib/Algebra/Homology/Single.lean
+++ b/Mathlib/Algebra/Homology/Single.lean
@@ -315,7 +315,6 @@ lemma toSingle₀Equiv_symm_apply_f_zero
 @[simp]
 lemma toSingle₀Equiv_symm_apply_f_succ
     {C : CochainComplex V ℕ} {X : V} (f : C.X 0 ⟶ X) (n : ℕ) :
-    ((toSingle₀Equiv C X).symm f).f (n + 1) = 0 := by
-  rfl
+    ((toSingle₀Equiv C X).symm f).f (n + 1) = 0 := rfl
 
 end CochainComplex

--- a/Mathlib/Algebra/Lie/Basic.lean
+++ b/Mathlib/Algebra/Lie/Basic.lean
@@ -762,16 +762,13 @@ theorem congr_fun {f g : M →ₗ⁅R,L⁆ N} (h : f = g) (x : M) : f x = g x :=
   h ▸ rfl
 
 @[simp]
-theorem mk_coe (f : M →ₗ⁅R,L⁆ N) (h) : (⟨f, h⟩ : M →ₗ⁅R,L⁆ N) = f := by
-  rfl
+theorem mk_coe (f : M →ₗ⁅R,L⁆ N) (h) : (⟨f, h⟩ : M →ₗ⁅R,L⁆ N) = f := rfl
 
 @[simp]
-theorem coe_mk (f : M →ₗ[R] N) (h) : ((⟨f, h⟩ : M →ₗ⁅R,L⁆ N) : M → N) = f := by
-  rfl
+theorem coe_mk (f : M →ₗ[R] N) (h) : ((⟨f, h⟩ : M →ₗ⁅R,L⁆ N) : M → N) = f := rfl
 
 @[norm_cast]
-theorem coe_linear_mk (f : M →ₗ[R] N) (h) : ((⟨f, h⟩ : M →ₗ⁅R,L⁆ N) : M →ₗ[R] N) = f := by
-  rfl
+theorem coe_linear_mk (f : M →ₗ[R] N) (h) : ((⟨f, h⟩ : M →ₗ⁅R,L⁆ N) : M →ₗ[R] N) = f := rfl
 
 /-- The composition of Lie module morphisms is a morphism. -/
 def comp (f : N →ₗ⁅R,L⁆ P) (g : M →ₗ⁅R,L⁆ N) : M →ₗ⁅R,L⁆ P :=

--- a/Mathlib/Algebra/Lie/OfAssociative.lean
+++ b/Mathlib/Algebra/Lie/OfAssociative.lean
@@ -341,8 +341,7 @@ theorem toEnd_comp_subtype_mem (m : M) (hm : m ∈ (N : Submodule R M)) :
 
 @[simp]
 theorem toEnd_restrict_eq_toEnd (h := N.toEnd_comp_subtype_mem x) :
-    (toEnd R L M x).restrict h = toEnd R L N x := by
-  rfl
+    (toEnd R L M x).restrict h = toEnd R L N x := rfl
 
 lemma mapsTo_pow_toEnd_sub_algebraMap {φ : R} {k : ℕ} {x : L} :
     MapsTo ((toEnd R L M x - algebraMap R (Module.End R M) φ) ^ k) N N := by

--- a/Mathlib/Algebra/Lie/Submodule.lean
+++ b/Mathlib/Algebra/Lie/Submodule.lean
@@ -385,8 +385,7 @@ instance : SupSet (LieSubmodule R L M) where
 
 @[norm_cast, simp]
 theorem sup_toSubmodule :
-    (↑(N ⊔ N') : Submodule R M) = (N : Submodule R M) ⊔ (N' : Submodule R M) := by
-  rfl
+    (↑(N ⊔ N') : Submodule R M) = (N : Submodule R M) ⊔ (N' : Submodule R M) := rfl
 
 @[simp]
 theorem sSup_toSubmodule (S : Set (LieSubmodule R L M)) :

--- a/Mathlib/Algebra/Order/Hom/MonoidWithZero.lean
+++ b/Mathlib/Algebra/Order/Hom/MonoidWithZero.lean
@@ -234,13 +234,11 @@ variable {hα : Preorder α} {hα' : MulZeroOneClass α} {hβ : Preorder β} {h�
   {hγ : Preorder γ} {hγ' : MulZeroOneClass γ}
 
 @[simp]
-theorem toMonoidWithZeroHom_eq_coe (f : α →*₀o β) : f.toMonoidWithZeroHom = f := by
-  rfl
+theorem toMonoidWithZeroHom_eq_coe (f : α →*₀o β) : f.toMonoidWithZeroHom = f := rfl
 
 @[simp]
 theorem toMonoidWithZeroHom_mk (f : α →*₀ β) (hf : Monotone f) :
-    ((OrderMonoidWithZeroHom.mk f hf) : α →*₀ β) = f := by
-  rfl
+    ((OrderMonoidWithZeroHom.mk f hf) : α →*₀ β) = f := rfl
 
 @[simp]
 lemma toMonoidWithZeroHom_coe (f : β →*₀o γ) (g : α →*₀o β) :

--- a/Mathlib/Algebra/Order/Hom/Ring.lean
+++ b/Mathlib/Algebra/Order/Hom/Ring.lean
@@ -354,8 +354,7 @@ instance : Inhabited (α ≃+*o α) :=
   ⟨OrderRingIso.refl α⟩
 
 @[simp]
-theorem refl_apply (x : α) : OrderRingIso.refl α x = x := by
-  rfl
+theorem refl_apply (x : α) : OrderRingIso.refl α x = x := rfl
 
 @[simp]
 theorem coe_ringEquiv_refl : (OrderRingIso.refl α : α ≃+* α) = RingEquiv.refl α :=

--- a/Mathlib/Algebra/Polynomial/AlgebraMap.lean
+++ b/Mathlib/Algebra/Polynomial/AlgebraMap.lean
@@ -174,8 +174,7 @@ theorem mapAlgHom_comp (C : Type*) [Semiring C] [Algebra R C] (f : B →ₐ[R] C
   ext <;> simp
 
 theorem mapAlgHom_eq_eval₂AlgHom'_CAlgHom (f : A →ₐ[R] B) : mapAlgHom f = eval₂AlgHom'
-    (CAlgHom.comp f) X (fun a => (commute_X (C (f a))).symm) := by
-  rfl
+    (CAlgHom.comp f) X (fun a => (commute_X (C (f a))).symm) := rfl
 
 /-- If `A` and `B` are isomorphic as `R`-algebras, then so are their polynomial rings -/
 def mapAlgEquiv (f : A ≃ₐ[R] B) : Polynomial A ≃ₐ[R] Polynomial B :=
@@ -241,8 +240,7 @@ lemma eval_map_algebraMap (P : R[X]) (b : B) :
 
 /-- `mapAlg` is the morphism induced by `R → S`. -/
 theorem mapAlg_eq_map (S : Type v) [Semiring S] [Algebra R S] (p : R[X]) :
-    mapAlg R S p = map (algebraMap R S) p := by
-  rfl
+    mapAlg R S p = map (algebraMap R S) p := rfl
 
 theorem aeval_zero : aeval x (0 : R[X]) = 0 :=
   map_zero (aeval x)

--- a/Mathlib/Algebra/Polynomial/Derivation.lean
+++ b/Mathlib/Algebra/Polynomial/Derivation.lean
@@ -61,8 +61,7 @@ def mkDerivation : A →ₗ[R] Derivation R R[X] A where
   map_smul' := fun t a ↦ by ext; simp
 
 lemma mkDerivation_apply (a : A) (f : R[X]) :
-    mkDerivation R a f = derivative f • a := by
-  rfl
+    mkDerivation R a f = derivative f • a := rfl
 
 @[simp]
 theorem mkDerivation_X (a : A) : mkDerivation R a X = a := by simp [mkDerivation_apply]
@@ -86,8 +85,7 @@ def mkDerivationEquiv : A ≃ₗ[R] Derivation R R[X] A :=
       right_inv := fun _ => mkDerivation_X _ _ }
 
 @[simp] lemma mkDerivationEquiv_apply (a : A) :
-    mkDerivationEquiv R a = mkDerivation R a := by
-  rfl
+    mkDerivationEquiv R a = mkDerivation R a := rfl
 
 @[simp] lemma mkDerivationEquiv_symm_apply (D : Derivation R R[X] A) :
     (mkDerivationEquiv R).symm D = D X := rfl

--- a/Mathlib/Algebra/Polynomial/Module/Basic.lean
+++ b/Mathlib/Algebra/Polynomial/Module/Basic.lean
@@ -88,8 +88,7 @@ noncomputable instance polynomialModule : Module R[X] (PolynomialModule R M) :=
   inferInstanceAs (Module R[X] (Module.AEval' (Finsupp.lmapDomain M R Nat.succ)))
 
 lemma smul_def (f : R[X]) (m : PolynomialModule R M) :
-    f • m = aeval (Finsupp.lmapDomain M R Nat.succ) f m := by
-  rfl
+    f • m = aeval (Finsupp.lmapDomain M R Nat.succ) f m := rfl
 
 instance (M : Type u) [AddCommGroup M] [Module R M] [Module S M] [IsScalarTower S R M] :
     IsScalarTower S R (PolynomialModule R M) :=

--- a/Mathlib/Algebra/Ring/Hom/Defs.lean
+++ b/Mathlib/Algebra/Ring/Hom/Defs.lean
@@ -389,8 +389,7 @@ instance coeToMonoidHom : Coe (α →+* β) (α →* β) :=
 theorem toMonoidHom_eq_coe (f : α →+* β) : f.toMonoidHom = f :=
   rfl
 
-theorem toMonoidWithZeroHom_eq_coe (f : α →+* β) : (f.toMonoidWithZeroHom : α → β) = f := by
-  rfl
+theorem toMonoidWithZeroHom_eq_coe (f : α →+* β) : (f.toMonoidWithZeroHom : α → β) = f := rfl
 
 @[simp]
 theorem coe_monoidHom_mk (f : α →* β) (h₁ h₂) : ((⟨f, h₁, h₂⟩ : α →+* β) : α →* β) = f :=

--- a/Mathlib/Algebra/RingQuot.lean
+++ b/Mathlib/Algebra/RingQuot.lean
@@ -240,8 +240,7 @@ theorem sub_quot {R : Type uR} [Ring R] (r : R → R → Prop) {a b} :
   rfl
 
 theorem smul_quot [Algebra S R] {n : S} {a : R} :
-    (n • ⟨Quot.mk _ a⟩ : RingQuot r) = ⟨Quot.mk _ (n • a)⟩ := by
-  rfl
+    (n • ⟨Quot.mk _ a⟩ : RingQuot r) = ⟨Quot.mk _ (n • a)⟩ := rfl
 
 instance instIsScalarTower [CommSemiring T] [SMul S T] [Algebra S R] [Algebra T R]
     [IsScalarTower S T R] : IsScalarTower S T (RingQuot r) :=

--- a/Mathlib/Algebra/Vertex/HVertexOperator.lean
+++ b/Mathlib/Algebra/Vertex/HVertexOperator.lean
@@ -141,8 +141,7 @@ def comp : HVertexOperator (Γ' ×ₗ Γ) R U W where
 
 @[simp]
 theorem coeff_comp (g : Γ' ×ₗ Γ) :
-    (comp A B).coeff g = A.coeff (ofLex g).2 ∘ₗ B.coeff (ofLex g).1 := by
-  rfl
+    (comp A B).coeff g = A.coeff (ofLex g).2 ∘ₗ B.coeff (ofLex g).1 := rfl
 
 end Products
 

--- a/Mathlib/Algebra/Vertex/VertexOperator.lean
+++ b/Mathlib/Algebra/Vertex/VertexOperator.lean
@@ -86,8 +86,7 @@ noncomputable def of_coeff (f : ℤ → Module.End R V)
 @[simp]
 theorem of_coeff_apply_coeff (f : ℤ → Module.End R V)
     (hf : ∀ (x : V), ∃ n, ∀ m < n, (f m) x = 0) (x : V) (n : ℤ) :
-    ((HahnModule.of R).symm ((of_coeff f hf) x)).coeff n = (f n) x := by
-  rfl
+    ((HahnModule.of R).symm ((of_coeff f hf) x)).coeff n = (f n) x := rfl
 
 @[simp]
 theorem ncoeff_of_coeff (f : ℤ → Module.End R V)

--- a/Mathlib/AlgebraicTopology/SimplicialSet/StdSimplex.lean
+++ b/Mathlib/AlgebraicTopology/SimplicialSet/StdSimplex.lean
@@ -101,8 +101,7 @@ def asOrderHom {n} {m} (α : Δ[n].obj m) : OrderHom (Fin (m.unop.len + 1)) (Fin
 
 lemma map_apply {m₁ m₂ : SimplexCategoryᵒᵖ} (f : m₁ ⟶ m₂) {n : SimplexCategory}
     (x : (stdSimplex.{u}.obj n).obj m₁) :
-    (stdSimplex.{u}.obj n).map f x = objEquiv.symm (f.unop ≫ objEquiv x) := by
-  rfl
+    (stdSimplex.{u}.obj n).map f x = objEquiv.symm (f.unop ≫ objEquiv x) := rfl
 
 /-- The canonical bijection `(stdSimplex.obj n ⟶ X) ≃ X.obj (op n)`. -/
 def _root_.SSet.yonedaEquiv {X : SSet.{u}} {n : SimplexCategory} :
@@ -189,8 +188,7 @@ lemma range_eq_ofSimplex {n : ℕ} (f : Δ[n] ⟶ X) :
 lemma yonedaEquiv_coe {A : X.Subcomplex} {n : SimplexCategory}
     (f : stdSimplex.obj n ⟶ A) :
     (DFunLike.coe (F := ((stdSimplex.obj n ⟶ Subpresheaf.toPresheaf A) ≃ A.obj (op n)))
-      yonedaEquiv f).val = yonedaEquiv (f ≫ A.ι) := by
-  rfl
+      yonedaEquiv f).val = yonedaEquiv (f ≫ A.ι) := rfl
 
 end Subcomplex
 

--- a/Mathlib/Analysis/Asymptotics/ExpGrowth.lean
+++ b/Mathlib/Analysis/Asymptotics/ExpGrowth.lean
@@ -37,12 +37,10 @@ noncomputable def expGrowthInf (u : ℕ → ℝ≥0∞) : EReal := liminf (fun n
 noncomputable def expGrowthSup (u : ℕ → ℝ≥0∞) : EReal := limsup (fun n ↦ log (u n) / n) atTop
 
 lemma expGrowthInf_def {u : ℕ → ℝ≥0∞} :
-    expGrowthInf u = linearGrowthInf (log ∘ u) := by
-  rfl
+    expGrowthInf u = linearGrowthInf (log ∘ u) := rfl
 
 lemma expGrowthSup_def {u : ℕ → ℝ≥0∞} :
-    expGrowthSup u = linearGrowthSup (log ∘ u) := by
-  rfl
+    expGrowthSup u = linearGrowthSup (log ∘ u) := rfl
 
 /-! ### Basic properties -/
 

--- a/Mathlib/Analysis/CStarAlgebra/GelfandDuality.lean
+++ b/Mathlib/Analysis/CStarAlgebra/GelfandDuality.lean
@@ -258,8 +258,7 @@ B  --- η B ---> C(characterSpace ℂ B, ℂ)
 theorem gelfandStarTransform_naturality {A B : Type*} [CommCStarAlgebra A] [CommCStarAlgebra B]
     (φ : A →⋆ₐ[ℂ] B) :
     (gelfandStarTransform B : _ →⋆ₐ[ℂ] _).comp φ =
-      (compContinuousMap φ |>.compStarAlgHom' ℂ ℂ).comp (gelfandStarTransform A : _ →⋆ₐ[ℂ] _) := by
-  rfl
+      (compContinuousMap φ |>.compStarAlgHom' ℂ ℂ).comp (gelfandStarTransform A : _ →⋆ₐ[ℂ] _) := rfl
 
 /--
 Consider the contravariant functors between compact Hausdorff spaces and commutative unital

--- a/Mathlib/Analysis/Calculus/FDeriv/Prod.lean
+++ b/Mathlib/Analysis/Calculus/FDeriv/Prod.lean
@@ -448,7 +448,7 @@ theorem hasFDerivWithinAt_apply (i : ι) (f : ∀ i, F' i) (s' : Set (∀ i, F' 
   let id' := ContinuousLinearMap.id 𝕜 (∀ i, F' i)
   have h := ((hasFDerivWithinAt_pi'
              (Φ := fun (f : ∀ i, F' i) (i' : ι) => f i') (Φ' := id') (x := f) (s := s'))).1
-  have h' : comp (proj i) id' = proj i := by rfl
+  have h' : comp (proj i) id' = proj i := rfl
   rw [← h']; apply h; apply hasFDerivWithinAt_id
 
 theorem hasFDerivWithinAt_pi :

--- a/Mathlib/Analysis/Complex/UpperHalfPlane/Basic.lean
+++ b/Mathlib/Analysis/Complex/UpperHalfPlane/Basic.lean
@@ -80,8 +80,7 @@ theorem coe_mk (z : ℂ) (h : 0 < z.im) : (mk z h : ℂ) = z :=
 
 @[simp]
 lemma coe_mk_subtype {z : ℂ} (hz : 0 < z.im) :
-    UpperHalfPlane.coe ⟨z, hz⟩ = z := by
-  rfl
+    UpperHalfPlane.coe ⟨z, hz⟩ = z := rfl
 
 @[simp]
 theorem mk_coe (z : ℍ) (h : 0 < (z : ℂ).im := z.2) : mk z h = z :=

--- a/Mathlib/Analysis/Distribution/SchwartzSpace.lean
+++ b/Mathlib/Analysis/Distribution/SchwartzSpace.lean
@@ -1187,7 +1187,7 @@ def integralCLM : 𝓢(D, V) →L[𝕜] V := by
 
 variable (𝕜) in
 @[simp]
-lemma integralCLM_apply (f : 𝓢(D, V)) : integralCLM 𝕜 μ f = ∫ x, f x ∂μ := by rfl
+lemma integralCLM_apply (f : 𝓢(D, V)) : integralCLM 𝕜 μ f = ∫ x, f x ∂μ := rfl
 
 end Integration
 

--- a/Mathlib/Analysis/Normed/Affine/Isometry.lean
+++ b/Mathlib/Analysis/Normed/Affine/Isometry.lean
@@ -75,8 +75,7 @@ instance : FunLike (P →ᵃⁱ[𝕜] P₂) P P₂ where
   coe_injective' f g := by cases f; cases g; simp
 
 @[simp]
-theorem coe_toAffineMap : ⇑f.toAffineMap = f := by
-  rfl
+theorem coe_toAffineMap : ⇑f.toAffineMap = f := rfl
 
 theorem toAffineMap_injective : Injective (toAffineMap : (P →ᵃⁱ[𝕜] P₂) → P →ᵃ[𝕜] P₂) := by
   rintro ⟨f, _⟩ ⟨g, _⟩ rfl
@@ -347,8 +346,7 @@ def toAffineIsometryEquiv : V ≃ᵃⁱ[𝕜] V₂ :=
   { e.toLinearEquiv.toAffineEquiv with norm_map := e.norm_map }
 
 @[simp]
-theorem coe_toAffineIsometryEquiv : ⇑(e.toAffineIsometryEquiv : V ≃ᵃⁱ[𝕜] V₂) = e := by
-  rfl
+theorem coe_toAffineIsometryEquiv : ⇑(e.toAffineIsometryEquiv : V ≃ᵃⁱ[𝕜] V₂) = e := rfl
 
 @[simp]
 theorem toAffineIsometryEquiv_linearIsometryEquiv :

--- a/Mathlib/Analysis/Normed/Group/Seminorm.lean
+++ b/Mathlib/Analysis/Normed/Group/Seminorm.lean
@@ -441,8 +441,7 @@ instance nonarchAddGroupSeminormClass :
   map_neg_eq_map' f := f.neg'
 
 @[simp]
-theorem toZeroHom_eq_coe : ⇑p.toZeroHom = p := by
-  rfl
+theorem toZeroHom_eq_coe : ⇑p.toZeroHom = p := rfl
 
 @[ext]
 theorem ext : (∀ x, p x = q x) → p = q :=

--- a/Mathlib/Analysis/Normed/Module/Span.lean
+++ b/Mathlib/Analysis/Normed/Module/Span.lean
@@ -109,7 +109,6 @@ noncomputable def toSpanUnitSingleton (x : E) (hx : ‖x‖ = 1) :
     rw [LinearEquiv.toSpanNonzeroSingleton_homothety, hx, one_mul]
 
 @[simp] theorem toSpanUnitSingleton_apply (x : E) (hx : ‖x‖ = 1) (r : 𝕜) :
-    toSpanUnitSingleton x hx r = (⟨r • x, by aesop⟩ : 𝕜 ∙ x) := by
-  rfl
+    toSpanUnitSingleton x hx r = (⟨r • x, by aesop⟩ : 𝕜 ∙ x) := rfl
 
 end LinearIsometryEquiv

--- a/Mathlib/Analysis/SpecialFunctions/Complex/CircleAddChar.lean
+++ b/Mathlib/Analysis/SpecialFunctions/Complex/CircleAddChar.lean
@@ -100,8 +100,7 @@ noncomputable def rootsOfUnityAddChar (n : ℕ) [NeZero n] :
   map_add_eq_mul' _ _:= by ext; simp [AddChar.map_add_eq_mul]
 
 @[simp] lemma rootsOfUnityAddChar_val (n : ℕ) [NeZero n] (x : ZMod n) :
-    (rootsOfUnityAddChar n x).val = toCircle x := by
-  rfl
+    (rootsOfUnityAddChar n x).val = toCircle x := rfl
 
 end ZMod
 

--- a/Mathlib/Analysis/SpecialFunctions/Stirling.lean
+++ b/Mathlib/Analysis/SpecialFunctions/Stirling.lean
@@ -198,7 +198,7 @@ theorem tendsto_self_div_two_mul_self_add_one :
 `n`-th partial product of Wallis' formula for `π / 2`. -/
 theorem stirlingSeq_pow_four_div_stirlingSeq_pow_two_eq (n : ℕ) (hn : n ≠ 0) :
     stirlingSeq n ^ 4 / stirlingSeq (2 * n) ^ 2 * (n / (2 * n + 1)) = Wallis.W n := by
-  have : 4 = 2 * 2 := by rfl
+  have : 4 = 2 * 2 := rfl
   rw [stirlingSeq, this, pow_mul, stirlingSeq, Wallis.W_eq_factorial_ratio]
   simp_rw [div_pow, mul_pow]
   rw [sq_sqrt, sq_sqrt]

--- a/Mathlib/CategoryTheory/Closed/Monoidal.lean
+++ b/Mathlib/CategoryTheory/Closed/Monoidal.lean
@@ -177,8 +177,7 @@ theorem eq_curry_iff (f : A ⊗ Y ⟶ X) (g : Y ⟶ A ⟶[C] X) : g = curry f �
   Adjunction.eq_homEquiv_apply (ihom.adjunction A) f g
 
 -- I don't think these two should be simp.
-theorem uncurry_eq (g : Y ⟶ A ⟶[C] X) : uncurry g = (A ◁ g) ≫ (ihom.ev A).app X := by
-  rfl
+theorem uncurry_eq (g : Y ⟶ A ⟶[C] X) : uncurry g = (A ◁ g) ≫ (ihom.ev A).app X := rfl
 
 theorem curry_eq (g : A ⊗ Y ⟶ X) : curry g = (ihom.coev A).app Y ≫ (ihom A).map g :=
   rfl

--- a/Mathlib/CategoryTheory/Distributive/Monoidal.lean
+++ b/Mathlib/CategoryTheory/Distributive/Monoidal.lean
@@ -113,7 +113,7 @@ lemma IsMonoidalLeftDistrib.of_isIso_coprodComparisonTensorLeft
 /-- The forward direction of the left distributivity isomorphism is the cogap morphism
 `coprod.desc (_ ◁ coprod.inl) (_ ◁ coprod.inr) : (X ⊗ Y) ⨿ (X ⊗ Z) ⟶ X ⊗ (Y ⨿ Z)`. -/
 lemma leftDistrib_hom [IsMonoidalLeftDistrib C] {X Y Z : C} :
-    (∂L X Y Z).hom = coprod.desc (_ ◁ coprod.inl) (_ ◁ coprod.inr) := by rfl
+    (∂L X Y Z).hom = coprod.desc (_ ◁ coprod.inl) (_ ◁ coprod.inr) := rfl
 
 @[reassoc (attr := simp)]
 lemma coprod_inl_leftDistrib_hom [IsMonoidalLeftDistrib C] {X Y Z : C} :
@@ -169,7 +169,7 @@ lemma IsMonoidalRightDistrib.of_isIso_coprodComparisonTensorRight
 /-- The forward direction of the right distributivity isomorphism is equal to the cogap morphism
 `coprod.desc (coprod.inl ▷ _) (coprod.inr ▷ _) : (Y ⊗ X) ⨿ (Z ⊗ X) ⟶ (Y ⨿ Z) ⊗ X`. -/
 lemma rightDistrib_hom [IsMonoidalRightDistrib C] {X Y Z : C} :
-    (∂R X Y Z).hom = coprod.desc (coprod.inl ▷ _) (coprod.inr ▷ _) := by rfl
+    (∂R X Y Z).hom = coprod.desc (coprod.inl ▷ _) (coprod.inr ▷ _) := rfl
 
 @[reassoc (attr := simp)]
 lemma coprod_inl_rightDistrib_hom [IsMonoidalRightDistrib C] {X Y Z : C} :

--- a/Mathlib/CategoryTheory/Limits/Presheaf.lean
+++ b/Mathlib/CategoryTheory/Limits/Presheaf.lean
@@ -125,8 +125,7 @@ def restrictedULiftYonedaHomEquiv' (P : Cᵒᵖ ⥤ Type (max w v₁ v₂)) (E :
 lemma restrictedULiftYonedaHomEquiv'_symm_naturality_right (P : Cᵒᵖ ⥤ Type (max w v₁ v₂)) {E E' : ℰ}
     (g : E ⟶ E') (f : (P ⟶ (restrictedULiftYoneda.{max w v₁} A).obj E)) :
     (restrictedULiftYonedaHomEquiv' A P E').symm (f ≫ (restrictedULiftYoneda A).map g) =
-      (restrictedULiftYonedaHomEquiv' A P E).symm f ≫ (Functor.const _ ).map g := by
-  rfl
+      (restrictedULiftYonedaHomEquiv' A P E).symm f ≫ (Functor.const _ ).map g := rfl
 
 @[reassoc]
 lemma restrictedULiftYonedaHomEquiv'_symm_app_naturality_left

--- a/Mathlib/CategoryTheory/Limits/Shapes/Pullback/Cospan.lean
+++ b/Mathlib/CategoryTheory/Limits/Shapes/Pullback/Cospan.lean
@@ -364,8 +364,7 @@ theorem cospanExt_inv_app_right :
   rfl
 
 @[simp]
-theorem cospanExt_inv_app_one : (cospanExt iX iY iZ wf wg).inv.app WalkingCospan.one = iZ.inv := by
-  rfl
+theorem cospanExt_inv_app_one : (cospanExt iX iY iZ wf wg).inv.app WalkingCospan.one = iZ.inv := rfl
 
 end
 

--- a/Mathlib/CategoryTheory/Monoidal/Comon_.lean
+++ b/Mathlib/CategoryTheory/Monoidal/Comon_.lean
@@ -354,8 +354,7 @@ the version provided in `tensorObj_comul` below.
 -/
 theorem tensorObj_comul' (A B : C) [ComonObj A] [ComonObj B] :
     Δ[A ⊗ B] =
-      (Δ[A] ⊗ₘ Δ[B]) ≫ (tensorμ (op A) (op B) (op A) (op B)).unop := by
-  rfl
+      (Δ[A] ⊗ₘ Δ[B]) ≫ (tensorμ (op A) (op B) (op A) (op B)).unop := rfl
 
 /--
 The comultiplication on the tensor product of two comonoids is

--- a/Mathlib/CategoryTheory/Monoidal/Mod_.lean
+++ b/Mathlib/CategoryTheory/Monoidal/Mod_.lean
@@ -181,8 +181,7 @@ lemma hom_ext {M N : Mod_ D A} (f₁ f₂ : M ⟶ N) (h : f₁.hom = f₂.hom) :
   Hom.ext h
 
 @[simp]
-theorem id_hom' (M : Mod_ D A) : (𝟙 M : M ⟶ M).hom = 𝟙 M.X := by
-  rfl
+theorem id_hom' (M : Mod_ D A) : (𝟙 M : M ⟶ M).hom = 𝟙 M.X := rfl
 
 @[simp]
 theorem comp_hom' {M N K : Mod_ D A} (f : M ⟶ N) (g : N ⟶ K) :

--- a/Mathlib/CategoryTheory/Yoneda.lean
+++ b/Mathlib/CategoryTheory/Yoneda.lean
@@ -741,8 +741,7 @@ lemma coyonedaEquiv_naturality {X Y : C} {F : C ⥤ Type v₁} (f : coyoneda.obj
   simp
 
 lemma coyonedaEquiv_comp {X : C} {F G : C ⥤ Type v₁} (α : coyoneda.obj (op X) ⟶ F) (β : F ⟶ G) :
-    coyonedaEquiv (α ≫ β) = β.app _ (coyonedaEquiv α) := by
-  rfl
+    coyonedaEquiv (α ≫ β) = β.app _ (coyonedaEquiv α) := rfl
 
 lemma coyonedaEquiv_coyoneda_map {X Y : C} (f : X ⟶ Y) :
     coyonedaEquiv (coyoneda.map f.op) = f := by
@@ -935,14 +934,12 @@ def Functor.sectionsEquivHom (F : C ⥤ Type u₂) (X : Type u₂) [Unique X] :
 
 lemma Functor.sectionsEquivHom_naturality {F G : C ⥤ Type u₂} (f : F ⟶ G) (X : Type u₂) [Unique X]
     (x : F.sections) :
-    (G.sectionsEquivHom X) ((sectionsFunctor C).map f x) = (F.sectionsEquivHom X) x ≫ f := by
-  rfl
+    (G.sectionsEquivHom X) ((sectionsFunctor C).map f x) = (F.sectionsEquivHom X) x ≫ f := rfl
 
 lemma Functor.sectionsEquivHom_naturality_symm {F G : C ⥤ Type u₂} (f : F ⟶ G) (X : Type u₂)
     [Unique X] (τ : (const C).obj X ⟶ F) :
     (G.sectionsEquivHom X).symm (τ ≫ f) =
-      (sectionsFunctor C).map f ((F.sectionsEquivHom X).symm τ) := by
-  rfl
+      (sectionsFunctor C).map f ((F.sectionsEquivHom X).symm τ) := rfl
 
 /-- A natural isomorphism between the sections functor `(C ⥤ Type _) ⥤ Type _` and the co-Yoneda
 embedding of a terminal functor, specifically a constant functor on a given singleton type `X`. -/

--- a/Mathlib/Combinatorics/SimpleGraph/Walk.lean
+++ b/Mathlib/Combinatorics/SimpleGraph/Walk.lean
@@ -933,7 +933,7 @@ def notNilRec {motive : {u w : V} → (p : G.Walk u w) → (h : ¬ p.Nil) → So
 lemma notNilRec_cons {motive : {u w : V} → (p : G.Walk u w) → ¬ p.Nil → Sort*}
     (cons : {u v w : V} → (h : G.Adj u v) → (q : G.Walk v w) →
     motive (q.cons h) Walk.not_nil_cons) (h' : G.Adj u v) (q' : G.Walk v w) :
-    @Walk.notNilRec _ _ _ _ _ cons _ _ = cons h' q' := by rfl
+    @Walk.notNilRec _ _ _ _ _ cons _ _ = cons h' q' := rfl
 
 theorem end_mem_tail_support {u v : V} {p : G.Walk u v} (h : ¬ p.Nil) : v ∈ p.support.tail :=
   p.notNilRec (by simp) h

--- a/Mathlib/Computability/AkraBazzi/AkraBazzi.lean
+++ b/Mathlib/Computability/AkraBazzi/AkraBazzi.lean
@@ -259,7 +259,7 @@ lemma rpow_p_mul_one_sub_smoothingFn_le :
     rw [Set.mem_Ioi] at hz
     exact ne_of_gt <| zero_lt_one.trans hz
   have h_deriv_q : deriv q =O[atTop] fun x => x ^ ((p a b) - 1) := calc deriv q
-    _ = deriv fun x => (fun z => z ^ (p a b)) x * (fun z => 1 - ε z) x := by rfl
+    _ = deriv fun x => (fun z => z ^ (p a b)) x * (fun z => 1 - ε z) x := rfl
     _ =ᶠ[atTop] fun x => deriv (fun z => z ^ (p a b)) x * (1 - ε x) +
           x ^ (p a b) * deriv (fun z => 1 - ε z) x := by
       filter_upwards [eventually_ne_atTop 0, eventually_gt_atTop 1] with x hx hx'
@@ -350,7 +350,7 @@ lemma rpow_p_mul_one_add_smoothingFn_ge :
     exact ne_of_gt <| zero_lt_one.trans hz
   have h_deriv_q : deriv q =O[atTop] fun x => x ^ ((p a b) - 1) :=
     calc deriv q
-      _ = deriv fun x => (fun z => z ^ (p a b)) x * (fun z => 1 + ε z) x := by rfl
+      _ = deriv fun x => (fun z => z ^ (p a b)) x * (fun z => 1 + ε z) x := rfl
       _ =ᶠ[atTop] fun x => deriv (fun z => z ^ (p a b)) x * (1 + ε x)
           + x ^ (p a b) * deriv (fun z => 1 + ε z) x := by
         filter_upwards [eventually_ne_atTop 0, eventually_gt_atTop 1] with x hx hx'

--- a/Mathlib/Computability/AkraBazzi/SumTransform.lean
+++ b/Mathlib/Computability/AkraBazzi/SumTransform.lean
@@ -593,7 +593,7 @@ lemma eventually_atTop_sumTransform_le :
   cases le_or_gt 0 (p a b + 1) with
   | inl hp => -- 0 ≤ p a b + 1
     calc sumTransform (p a b) g (r i n) n
-           = n ^ (p a b) * (∑ u ∈ Finset.Ico (r i n) n, g u / u ^ ((p a b) + 1)) := by rfl
+           = n ^ (p a b) * (∑ u ∈ Finset.Ico (r i n) n, g u / u ^ ((p a b) + 1)) := rfl
          _ ≤ n ^ (p a b) * (∑ u ∈ Finset.Ico (r i n) n, c₂ * g n / u ^ ((p a b) + 1)) := by
           gcongr with u hu
           rw [Finset.mem_Ico] at hu
@@ -625,7 +625,7 @@ lemma eventually_atTop_sumTransform_le :
          _ ≤ max c₂ (c₂ / c₁ ^ ((p a b) + 1)) * g n := by gcongr; exact le_max_right _ _
   | inr hp => -- p a b + 1 < 0
     calc sumTransform (p a b) g (r i n) n
-      _ = n ^ (p a b) * (∑ u ∈ Finset.Ico (r i n) n, g u / u ^ ((p a b) + 1)) := by rfl
+      _ = n ^ (p a b) * (∑ u ∈ Finset.Ico (r i n) n, g u / u ^ ((p a b) + 1)) := rfl
       _ ≤ n ^ (p a b) * (∑ u ∈ Finset.Ico (r i n) n, c₂ * g n / u ^ ((p a b) + 1)) := by
         gcongr with u hu
         rw [Finset.mem_Ico] at hu
@@ -706,7 +706,7 @@ lemma eventually_atTop_sumTransform_ge :
         gcongr; exact min_le_left _ _
   | inr hp => -- (p a b) + 1 < 0
     calc sumTransform (p a b) g (r i n) n
-        = n ^ (p a b) * (∑ u ∈ Finset.Ico (r i n) n, g u / u^((p a b) + 1))        := by rfl
+        = n ^ (p a b) * (∑ u ∈ Finset.Ico (r i n) n, g u / u^((p a b) + 1))        := rfl
       _ ≥ n ^ (p a b) * (∑ u ∈ Finset.Ico (r i n) n, c₂ * g n / u ^ ((p a b) + 1)) := by
         gcongr with u hu
         rw [Finset.mem_Ico] at hu

--- a/Mathlib/Data/Matrix/Basic.lean
+++ b/Mathlib/Data/Matrix/Basic.lean
@@ -305,8 +305,7 @@ def entryAddMonoidHom (i : m) (j : n) : Matrix m n α →+ α where
 lemma entryAddMonoidHom_eq_comp {i : m} {j : n} :
     entryAddMonoidHom α i j =
       ((Pi.evalAddMonoidHom (fun _ => α) j).comp (Pi.evalAddMonoidHom _ i)).comp
-        (AddMonoidHomClass.toAddMonoidHom ofAddEquiv.symm) := by
-  rfl
+        (AddMonoidHomClass.toAddMonoidHom ofAddEquiv.symm) := rfl
 
 @[simp] lemma evalAddMonoidHom_comp_diagAddMonoidHom (i : m) :
     (Pi.evalAddMonoidHom _ i).comp (diagAddMonoidHom m α) = entryAddMonoidHom α i i := by
@@ -337,8 +336,7 @@ def entryLinearMap (i : m) (j : n) :
 -- for unification to succeed
 lemma entryLinearMap_eq_comp {i : m} {j : n} :
     entryLinearMap R α i j =
-      LinearMap.proj j ∘ₗ LinearMap.proj i ∘ₗ (ofLinearEquiv R).symm.toLinearMap := by
-  rfl
+      LinearMap.proj j ∘ₗ LinearMap.proj i ∘ₗ (ofLinearEquiv R).symm.toLinearMap := rfl
 
 @[simp] lemma proj_comp_diagLinearMap (i : m) :
     LinearMap.proj i ∘ₗ diagLinearMap m R α = entryLinearMap R α i i := by
@@ -571,8 +569,7 @@ theorem mapMatrix_trans (f : α ≃ₛₗ[σᵣₛ] β) (g : β ≃ₛₗ[σₛ�
   rfl
 
 @[simp] lemma mapMatrix_toLinearMap (f : α ≃ₛₗ[σᵣₛ] β) :
-    (f.mapMatrix : _ ≃ₛₗ[_] Matrix m n β).toLinearMap = f.toLinearMap.mapMatrix := by
-  rfl
+    (f.mapMatrix : _ ≃ₛₗ[_] Matrix m n β).toLinearMap = f.toLinearMap.mapMatrix := rfl
 
 lemma entryLinearMap_comp_mapMatrix (f : α ≃ₛₗ[σᵣₛ] β) (i : m) (j : n) :
     (entryLinearMap S _ i j).comp f.mapMatrix.toLinearMap =

--- a/Mathlib/Data/Nat/Factorization/PrimePow.lean
+++ b/Mathlib/Data/Nat/Factorization/PrimePow.lean
@@ -160,8 +160,7 @@ def Nat.Primes.prodNatEquiv : Nat.Primes × ℕ ≃ {n : ℕ // IsPrimePow n} wh
 
 @[simp]
 lemma Nat.Primes.prodNatEquiv_apply (p : Nat.Primes) (k : ℕ) :
-    prodNatEquiv (p, k) = ⟨p ^ (k + 1), p, k + 1, prime_iff.mp p.prop, k.add_one_pos, rfl⟩ := by
-  rfl
+    prodNatEquiv (p, k) = ⟨p ^ (k + 1), p, k + 1, prime_iff.mp p.prop, k.add_one_pos, rfl⟩ := rfl
 
 @[simp]
 lemma Nat.Primes.coe_prodNatEquiv_apply (p : Nat.Primes) (k : ℕ) :

--- a/Mathlib/Data/Nat/PartENat.lean
+++ b/Mathlib/Data/Nat/PartENat.lean
@@ -177,8 +177,7 @@ theorem get_natCast {x : ℕ} : get (x : PartENat) (dom_natCast x) = x :=
   get_natCast' _ _
 
 theorem coe_add_get {x : ℕ} {y : PartENat} (h : ((x : PartENat) + y).Dom) :
-    get ((x : PartENat) + y) h = x + get y h.2 := by
-  rfl
+    get ((x : PartENat) + y) h = x + get y h.2 := rfl
 
 @[simp]
 theorem get_add {x y : PartENat} (h : (x + y).Dom) : get (x + y) h = x.get h.1 + y.get h.2 :=

--- a/Mathlib/Data/PFunctor/Multivariate/Basic.lean
+++ b/Mathlib/Data/PFunctor/Multivariate/Basic.lean
@@ -122,16 +122,13 @@ def comp.get (x : comp P Q α) : P (fun i => Q i α) :=
   ⟨x.1.1, fun i a => ⟨x.fst.snd i a, fun (j : Fin2 m) (b : (Q i).B _ j) => x.snd j ⟨i, ⟨a, b⟩⟩⟩⟩
 
 theorem comp.get_map (f : α ⟹ β) (x : comp P Q α) :
-    comp.get (f <$$> x) = (fun i (x : Q i α) => f <$$> x) <$$> comp.get x := by
-  rfl
+    comp.get (f <$$> x) = (fun i (x : Q i α) => f <$$> x) <$$> comp.get x := rfl
 
 @[simp]
-theorem comp.get_mk (x : P (fun i => Q i α)) : comp.get (comp.mk x) = x := by
-  rfl
+theorem comp.get_mk (x : P (fun i => Q i α)) : comp.get (comp.mk x) = x := rfl
 
 @[simp]
-theorem comp.mk_get (x : comp P Q α) : comp.mk (comp.get x) = x := by
-  rfl
+theorem comp.mk_get (x : comp P Q α) : comp.mk (comp.get x) = x := rfl
 
 /-
 lifting predicates and relations

--- a/Mathlib/Data/Real/Embedding.lean
+++ b/Mathlib/Data/Real/Embedding.lean
@@ -197,7 +197,7 @@ def embedReal : M →+o ℝ where
   map_add' := embedRealFun_add
   monotone' := (embedRealFun_strictMono M).monotone
 
-theorem embedReal_apply (a : M) :  embedReal M a = embedRealFun a := by rfl
+theorem embedReal_apply (a : M) :  embedReal M a = embedRealFun a := rfl
 
 variable (M) in
 theorem embedReal_injective : Function.Injective (embedReal M) :=

--- a/Mathlib/Data/Rel.lean
+++ b/Mathlib/Data/Rel.lean
@@ -559,8 +559,7 @@ lemma SetRel.exists_graph_eq_iff (R : SetRel α β) :
 
 namespace Set
 
-theorem image_eq (f : α → β) (s : Set α) : f '' s = (Function.graph f).image s := by
-  rfl
+theorem image_eq (f : α → β) (s : Set α) : f '' s = (Function.graph f).image s := rfl
 
 theorem preimage_eq (f : α → β) (s : Set β) : f ⁻¹' s = (Function.graph f).preimage s := by
   simp [Set.preimage, SetRel.preimage]

--- a/Mathlib/Data/Seq/Basic.lean
+++ b/Mathlib/Data/Seq/Basic.lean
@@ -149,8 +149,7 @@ theorem take_zero {s : Seq α} : s.take 0 = [] := by
 
 @[simp]
 theorem take_succ_cons {n : ℕ} {x : α} {s : Seq α} :
-    (cons x s).take (n + 1) = x :: s.take n := by
-  rfl
+    (cons x s).take (n + 1) = x :: s.take n := rfl
 
 @[simp]
 theorem getElem?_take : ∀ (n k : ℕ) (s : Seq α),

--- a/Mathlib/Data/Set/Lattice.lean
+++ b/Mathlib/Data/Set/Lattice.lean
@@ -1327,8 +1327,7 @@ noncomputable def unionEqSigmaOfDisjoint {t : α → Set β}
 @[simp]
 lemma coe_unionEqSigmaOfDisjoint_symm_apply {α β : Type*} {t : α → Set β}
     (h : Pairwise (Disjoint on t)) (x : (i : α) × t i) :
-    ((Set.unionEqSigmaOfDisjoint h).symm x : β) = x.2 := by
-  rfl
+    ((Set.unionEqSigmaOfDisjoint h).symm x : β) = x.2 := rfl
 
 @[simp]
 lemma coe_snd_unionEqSigmaOfDisjoint {α β : Type*} {t : α → Set β}

--- a/Mathlib/Data/Set/Pairwise/Lattice.lean
+++ b/Mathlib/Data/Set/Pairwise/Lattice.lean
@@ -129,8 +129,7 @@ noncomputable def biUnionEqSigmaOfDisjoint {s : Set ι} {f : ι → Set α} (h :
 @[simp]
 lemma coe_biUnionEqSigmaOfDisjoint_symm_apply {α ι : Type*} {s : Set ι}
     {f : ι → Set α} (h : s.PairwiseDisjoint f) (x : (i : s) × f i) :
-    ((Set.biUnionEqSigmaOfDisjoint h).symm x : α) = x.2 := by
-  rfl
+    ((Set.biUnionEqSigmaOfDisjoint h).symm x : α) = x.2 := rfl
 
 @[simp]
 lemma coe_snd_biUnionEqSigmaOfDisjoint {α ι : Type*} {s : Set ι}

--- a/Mathlib/Data/Subtype.lean
+++ b/Mathlib/Data/Subtype.lean
@@ -120,8 +120,7 @@ def restrict {α} {β : α → Type*} (p : α → Prop) (f : ∀ x, β x) (x : S
 
 @[simp, grind =]
 theorem restrict_apply {α} {β : α → Type*} (f : ∀ x, β x) (p : α → Prop) (x : Subtype p) :
-    restrict p f x = f x.1 := by
-  rfl
+    restrict p f x = f x.1 := rfl
 
 theorem restrict_def {α β} (f : α → β) (p : α → Prop) :
     restrict p f = f ∘ (fun (a : Subtype p) ↦ a) := rfl

--- a/Mathlib/Geometry/Manifold/Bordism.lean
+++ b/Mathlib/Geometry/Manifold/Bordism.lean
@@ -181,8 +181,7 @@ noncomputable def comap (s : SingularManifold X k I)
 
 @[simp, mfld_simps]
 lemma comap_M (s : SingularManifold X k I) {φ : M → s.M} (hφ : Continuous φ) :
-    (s.comap hφ).M = M := by
-  rfl
+    (s.comap hφ).M = M := rfl
 
 @[simp, mfld_simps]
 lemma comap_f (s : SingularManifold X k I) {φ : M → s.M} (hφ : Continuous φ) :

--- a/Mathlib/GroupTheory/Coxeter/Basic.lean
+++ b/Mathlib/GroupTheory/Coxeter/Basic.lean
@@ -311,7 +311,7 @@ private def restrictUnit {G : Type*} [Monoid G] {f : B → G} (hf : IsLiftable M
 private theorem toMonoidHom_apply_symm_apply (a : PresentedGroup (M.relationsSet)) :
     (MulEquiv.toMonoidHom cs.mulEquiv : W →* PresentedGroup (M.relationsSet))
     ((MulEquiv.symm cs.mulEquiv) a) = a := calc
-  _ = cs.mulEquiv ((MulEquiv.symm cs.mulEquiv) a) := by rfl
+  _ = cs.mulEquiv ((MulEquiv.symm cs.mulEquiv) a) := rfl
   _ = _ := by rw [MulEquiv.apply_symm_apply]
 
 /-- The universal mapping property of Coxeter systems. For any monoid `G`,

--- a/Mathlib/GroupTheory/GroupAction/Hom.lean
+++ b/Mathlib/GroupTheory/GroupAction/Hom.lean
@@ -311,8 +311,7 @@ def inverse' (f : X →ₑ[φ] Y) (g : Y → X) (k : Function.RightInverse φ' �
 @[to_additive]
 lemma inverse_eq_inverse' (f : X →[M] Y₁) (g : Y₁ → X)
     (h₁ : Function.LeftInverse g f) (h₂ : Function.RightInverse g f) :
-    inverse f g h₁ h₂ = inverse' f g (congrFun rfl) h₁ h₂ := by
-  rfl
+    inverse f g h₁ h₂ = inverse' f g (congrFun rfl) h₁ h₂ := rfl
 
 @[to_additive]
 theorem inverse'_inverse'
@@ -682,8 +681,7 @@ protected def id : A →+[M] A :=
   ⟨MulActionHom.id _, rfl, fun _ _ => rfl⟩
 
 @[simp]
-theorem id_apply (x : A) : DistribMulActionHom.id M x = x := by
-  rfl
+theorem id_apply (x : A) : DistribMulActionHom.id M x = x := rfl
 
 variable {M C ψ χ}
 

--- a/Mathlib/GroupTheory/SpecificGroups/Quaternion.lean
+++ b/Mathlib/GroupTheory/SpecificGroups/Quaternion.lean
@@ -119,8 +119,7 @@ theorem xa_mul_xa (i j : ZMod (2 * n)) : xa i * xa j = a ((n : ZMod (2 * n)) + j
   rfl
 
 @[simp]
-theorem a_zero : a 0 = (1 : QuaternionGroup n) := by
-  rfl
+theorem a_zero : a 0 = (1 : QuaternionGroup n) := rfl
 
 theorem one_def : (1 : QuaternionGroup n) = a 0 :=
   rfl

--- a/Mathlib/LinearAlgebra/AffineSpace/Simplex/Basic.lean
+++ b/Mathlib/LinearAlgebra/AffineSpace/Simplex/Basic.lean
@@ -260,8 +260,7 @@ theorem restrict_map_inclusion {n : ℕ} (s : Affine.Simplex k P n)
 theorem map_subtype_restrict
     {n : ℕ} (S : AffineSubspace k P) [Nonempty S] (s : Affine.Simplex k S n) :
     (s.map (AffineSubspace.subtype _) Subtype.coe_injective).restrict
-      S (affineSpan_le.2 <| by rintro x ⟨y, rfl⟩; exact Subtype.prop _) = s := by
-  rfl
+      S (affineSpan_le.2 <| by rintro x ⟨y, rfl⟩; exact Subtype.prop _) = s := rfl
 
 /-- Restricting to `S₁` then mapping through the restriction of `f` to `S₁ →ᵃ[k] S₂` is the same
 as mapping through unrestricted `f`, then restricting to `S₂`. -/
@@ -275,8 +274,7 @@ theorem restrict_map_restrict
       (s.map f hf).restrict S₂ (
         Eq.trans_le
           (by simp [AffineSubspace.map_span, Set.range_comp])
-          (AffineSubspace.map_mono f hS₁) |>.trans hfS) := by
-  rfl
+          (AffineSubspace.map_mono f hS₁) |>.trans hfS) := rfl
 
 /-- Restricting to `affineSpan k (Set.range s.points)` can be reversed by mapping through
 `AffineSubspace.subtype`. -/

--- a/Mathlib/LinearAlgebra/Dual/Defs.lean
+++ b/Mathlib/LinearAlgebra/Dual/Defs.lean
@@ -165,8 +165,7 @@ theorem LinearEquiv.dualMap_trans {M₃ : Type*} [AddCommMonoid M₃] [Module R 
   rfl
 
 theorem Module.Dual.eval_naturality (f : M₁ →ₗ[R] M₂) :
-    f.dualMap.dualMap ∘ₗ eval R M₁ = eval R M₂ ∘ₗ f := by
-  rfl
+    f.dualMap.dualMap ∘ₗ eval R M₁ = eval R M₂ ∘ₗ f := rfl
 
 @[simp]
 lemma Dual.apply_one_mul_eq (f : Dual R R) (r : R) :

--- a/Mathlib/LinearAlgebra/Lagrange.lean
+++ b/Mathlib/LinearAlgebra/Lagrange.lean
@@ -461,8 +461,7 @@ theorem nodal_eq (s : Finset ι) (v : ι → R) : nodal s v = ∏ i ∈ s, (X - 
   rfl
 
 @[simp]
-theorem nodal_empty : nodal ∅ v = 1 := by
-  rfl
+theorem nodal_empty : nodal ∅ v = 1 := rfl
 
 @[simp]
 theorem natDegree_nodal [Nontrivial R] : (nodal s v).natDegree = #s := by

--- a/Mathlib/LinearAlgebra/Matrix/GeneralLinearGroup/Defs.lean
+++ b/Mathlib/LinearAlgebra/Matrix/GeneralLinearGroup/Defs.lean
@@ -133,8 +133,7 @@ theorem map_id : map (RingHom.id R) = MonoidHom.id (GL n R) :=
   rfl
 
 @[simp]
-protected lemma map_apply (f : R →+* S) (i j : n) (g : GL n R) : map f g i j = f (g i j) := by
-  rfl
+protected lemma map_apply (f : R →+* S) (i j : n) (g : GL n R) : map f g i j = f (g i j) := rfl
 
 @[simp]
 theorem map_comp (f : T →+* R) (g : R →+* S) :

--- a/Mathlib/LinearAlgebra/Multilinear/TensorProduct.lean
+++ b/Mathlib/LinearAlgebra/Multilinear/TensorProduct.lean
@@ -56,8 +56,7 @@ def domCoprodDep' :
 @[simp]
 theorem domCoprodDep'_apply (a : MultilinearMap R (fun i₁ ↦ N (.inl i₁)) N₁)
     (b : MultilinearMap R (fun i₂ ↦ N (.inr i₂)) N₂) :
-    domCoprodDep' (a ⊗ₜ b) = domCoprodDep a b := by
-  rfl
+    domCoprodDep' (a ⊗ₜ b) = domCoprodDep a b := rfl
 
 end
 

--- a/Mathlib/LinearAlgebra/Projectivization/Action.lean
+++ b/Mathlib/LinearAlgebra/Projectivization/Action.lean
@@ -32,8 +32,7 @@ instance : MulAction G (ℙ K V) where
     rw [map_comp, Function.comp_apply]
 
 lemma generalLinearGroup_smul_def (g : LinearMap.GeneralLinearGroup K V) (x : ℙ K V) :
-    g • x = x.map g.toLinearEquiv.toLinearMap g.toLinearEquiv.injective := by
-  rfl
+    g • x = x.map g.toLinearEquiv.toLinearMap g.toLinearEquiv.injective := rfl
 
 @[simp]
 lemma smul_mk (g : G) {v : V} (hv : v ≠ 0) :

--- a/Mathlib/LinearAlgebra/RootSystem/Hom.lean
+++ b/Mathlib/LinearAlgebra/RootSystem/Hom.lean
@@ -330,8 +330,7 @@ lemma toHom_comp {ι₁ M₁ N₁ ι₂ M₂ N₂ : Type*} [AddCommGroup M₁] [
     [Module R N₁] [AddCommGroup M₂] [Module R M₂] [AddCommGroup N₂] [Module R N₂]
     {P : RootPairing ι R M N} {P₁ : RootPairing ι₁ R M₁ N₁} {P₂ : RootPairing ι₂ R M₂ N₂}
     (g : RootPairing.Equiv P₁ P₂) (f : RootPairing.Equiv P P₁) :
-    (Equiv.comp g f).toHom = Hom.comp g.toHom f.toHom := by
-  rfl
+    (Equiv.comp g f).toHom = Hom.comp g.toHom f.toHom := rfl
 
 @[simp]
 lemma id_comp {ι₂ M₂ N₂ : Type*}
@@ -391,8 +390,7 @@ lemma weightEquiv_comp_toLin {P : RootPairing ι R M N} (x y : RootPairing.Equiv
 
 @[simp]
 lemma weightEquiv_mul {P : RootPairing ι R M N} (x y : RootPairing.Equiv P P) :
-    weightEquiv P P x * weightEquiv P P y = weightEquiv P P y ≪≫ₗ weightEquiv P P x := by
-  rfl
+    weightEquiv P P x * weightEquiv P P y = weightEquiv P P y ≪≫ₗ weightEquiv P P x := rfl
 
 @[simp]
 lemma coweightEquiv_comp_toLin {P : RootPairing ι R M N} (x y : RootPairing.Equiv P P) :
@@ -401,8 +399,7 @@ lemma coweightEquiv_comp_toLin {P : RootPairing ι R M N} (x y : RootPairing.Equ
 
 @[simp]
 lemma coweightEquiv_mul {P : RootPairing ι R M N} (x y : RootPairing.Equiv P P) :
-    coweightEquiv P P x * coweightEquiv P P y = coweightEquiv P P y ≪≫ₗ coweightEquiv P P x := by
-  rfl
+    coweightEquiv P P x * coweightEquiv P P y = coweightEquiv P P y ≪≫ₗ coweightEquiv P P x := rfl
 
 /-- The inverse of a root pairing equivalence. -/
 def symm {ι₂ M₂ N₂ : Type*} [AddCommGroup M₂] [Module R M₂] [AddCommGroup N₂] [Module R N₂]

--- a/Mathlib/LinearAlgebra/RootSystem/Reduced.lean
+++ b/Mathlib/LinearAlgebra/RootSystem/Reduced.lean
@@ -185,7 +185,7 @@ lemma linearIndependent_iff_coxeterWeight_ne_four :
   suffices P.coxeterWeight i j • P.root i = (4 : R) • P.root i from
     smul_left_injective R (P.ne_zero i) this
   calc P.coxeterWeight i j • P.root i
-      = (P.pairing i j * P.pairing j i) • P.root i := by rfl
+      = (P.pairing i j * P.pairing j i) • P.root i := rfl
     _ = P.pairing i j • (2 : R) • P.root j := by rw [mul_smul, h₁]
     _ = (4 : R) • P.root i := by rw [smul_comm, h₂, ← mul_smul]; norm_num
 

--- a/Mathlib/LinearAlgebra/Span/Basic.lean
+++ b/Mathlib/LinearAlgebra/Span/Basic.lean
@@ -823,8 +823,7 @@ def toSpanNonzeroSingleton : R ≃ₗ[R] R ∙ x :=
 
 @[simp] theorem toSpanNonzeroSingleton_apply (t : R) :
     toSpanNonzeroSingleton R M x h t =
-      (⟨t • x, Submodule.smul_mem _ _ (Submodule.mem_span_singleton_self x)⟩ : R ∙ x) := by
-  rfl
+      (⟨t • x, Submodule.smul_mem _ _ (Submodule.mem_span_singleton_self x)⟩ : R ∙ x) := rfl
 
 @[simp]
 lemma toSpanNonzeroSingleton_symm_apply_smul (m : R ∙ x) :

--- a/Mathlib/LinearAlgebra/TensorProduct/Pi.lean
+++ b/Mathlib/LinearAlgebra/TensorProduct/Pi.lean
@@ -92,8 +92,7 @@ def piRight : N ⊗[R] (∀ i, M i) ≃ₗ[S] ∀ i, N ⊗[R] M i :=
 
 @[simp]
 lemma piRight_apply (x : N ⊗[R] (∀ i, M i)) :
-    piRight R S N M x = piRightHom R S N M x := by
-  rfl
+    piRight R S N M x = piRightHom R S N M x := rfl
 
 @[simp]
 lemma piRight_symm_apply (x : N) (m : ∀ i, M i) :
@@ -156,8 +155,7 @@ def piScalarRight : N ⊗[R] (ι → R) ≃ₗ[S] (ι → N) :=
 
 @[simp]
 lemma piScalarRight_apply (x : N ⊗[R] (ι → R)) :
-    piScalarRight R S N ι x = piScalarRightHom R S N ι x := by
-  rfl
+    piScalarRight R S N ι x = piScalarRightHom R S N ι x := rfl
 
 @[simp]
 lemma piScalarRight_symm_single (x : N) (i : ι) :

--- a/Mathlib/MeasureTheory/MeasurableSpace/Embedding.lean
+++ b/Mathlib/MeasureTheory/MeasurableSpace/Embedding.lean
@@ -491,7 +491,7 @@ def piCongrLeft (f : δ ≃ δ') : (∀ b, π (f b)) ≃ᵐ ∀ a, π a where
     exact fun i => measurable_pi_apply (f i)
 
 theorem coe_piCongrLeft (f : δ ≃ δ') :
-    ⇑(MeasurableEquiv.piCongrLeft π f) = f.piCongrLeft π := by rfl
+    ⇑(MeasurableEquiv.piCongrLeft π f) = f.piCongrLeft π := rfl
 
 lemma piCongrLeft_apply_apply {ι ι' : Type*} (e : ι ≃ ι') {β : ι' → Type*}
     [∀ i', MeasurableSpace (β i')] (x : (i : ι) → β (e i)) (i : ι) :
@@ -591,10 +591,10 @@ def sumPiEquivProdPi (α : δ ⊕ δ' → Type*) [∀ i, MeasurableSpace (α i)]
     · exact measurable_pi_iff.1 measurable_snd _
 
 theorem coe_sumPiEquivProdPi (α : δ ⊕ δ' → Type*) [∀ i, MeasurableSpace (α i)] :
-    ⇑(MeasurableEquiv.sumPiEquivProdPi α) = Equiv.sumPiEquivProdPi α := by rfl
+    ⇑(MeasurableEquiv.sumPiEquivProdPi α) = Equiv.sumPiEquivProdPi α := rfl
 
 theorem coe_sumPiEquivProdPi_symm (α : δ ⊕ δ' → Type*) [∀ i, MeasurableSpace (α i)] :
-    ⇑(MeasurableEquiv.sumPiEquivProdPi α).symm = (Equiv.sumPiEquivProdPi α).symm := by rfl
+    ⇑(MeasurableEquiv.sumPiEquivProdPi α).symm = (Equiv.sumPiEquivProdPi α).symm := rfl
 
 /-- The measurable equivalence for (dependent) functions on an Option type
   `(∀ i : Option δ, α i) ≃ᵐ (∀ (i : δ), α i) × α none`. -/

--- a/Mathlib/ModelTheory/Semantics.lean
+++ b/Mathlib/ModelTheory/Semantics.lean
@@ -77,8 +77,7 @@ theorem realize_func (v : α → M) {n} (f : L.Functions n) (ts) :
 
 @[simp]
 theorem realize_function_term {n} (v : Fin n → M) (f : L.Functions n) :
-    f.term.realize v = funMap f v := by
-  rfl
+    f.term.realize v = funMap f v := rfl
 
 @[simp]
 theorem realize_relabel {t : L.Term α} {g : α → β} {v : β → M} :

--- a/Mathlib/NumberTheory/FLT/Polynomial.lean
+++ b/Mathlib/NumberTheory/FLT/Polynomial.lean
@@ -222,7 +222,7 @@ theorem Polynomial.flt
   have hn' : 0 < n := by linarith
   rw [← sub_eq_zero, ← one_mul (a ^ n), ← one_mul (b ^ n), ← one_mul (c ^ n), sub_eq_add_neg,
     ← neg_mul] at heq
-  have hone : (1 : k[X]) = C 1 := by rfl
+  have hone : (1 : k[X]) = C 1 := rfl
   have hneg_one : (-1 : k[X]) = C (-1) := by simp only [map_neg, map_one]
   simp_rw [hneg_one, hone] at heq
   apply flt_catalan hn'.ne' hn'.ne' hn'.ne' _

--- a/Mathlib/NumberTheory/FactorisationProperties.lean
+++ b/Mathlib/NumberTheory/FactorisationProperties.lean
@@ -80,7 +80,7 @@ theorem abundant_twelve : Abundant 12 := by
 
 theorem weird_seventy : Weird 70 := by
   rw [Weird, Abundant, not_pseudoperfect_iff_forall]
-  have h : properDivisors 70 = {1, 2, 5, 7, 10, 14, 35} := by rfl
+  have h : properDivisors 70 = {1, 2, 5, 7, 10, 14, 35} := rfl
   constructor
   · rw [h]
     repeat norm_num

--- a/Mathlib/NumberTheory/Harmonic/ZetaAsymp.lean
+++ b/Mathlib/NumberTheory/Harmonic/ZetaAsymp.lean
@@ -148,7 +148,7 @@ lemma term_of_lt {n : ℕ} (hn : 0 < n) {s : ℝ} (hs : 1 < s) :
     rw [uIcc_of_le (by simp only [le_add_iff_nonneg_right, zero_le_one])] at hx
     exact (Nat.cast_pos.mpr hn).trans_le hx.1
   calc term n s
-    _ = ∫ x : ℝ in n..(n + 1), (x - n) / x ^ (s + 1) := by rfl
+    _ = ∫ x : ℝ in n..(n + 1), (x - n) / x ^ (s + 1) := rfl
     _ = ∫ x : ℝ in n..(n + 1), (x ^ (-s) - n * x ^ (-(s + 1))) := by
       refine intervalIntegral.integral_congr (fun x hx ↦ ?_)
       rw [sub_div, rpow_add_one (hv x hx).ne', mul_comm, ← div_div, div_self (hv x hx).ne',

--- a/Mathlib/NumberTheory/Padics/WithVal.lean
+++ b/Mathlib/NumberTheory/Padics/WithVal.lean
@@ -131,8 +131,7 @@ lemma coe_withValRingEquiv :
 @[simp]
 lemma coe_withValRingEquiv_symm :
     ⇑(Padic.withValRingEquiv (p := p)).symm =
-      Padic.isDenseInducing_cast_withVal.extend Completion.coe' := by
-  rfl
+      Padic.isDenseInducing_cast_withVal.extend Completion.coe' := rfl
 
 /-- The `p`-adic numbers are isomophic as uniform spaces to the completion of the rationals at
 the `p`-adic valuation. -/

--- a/Mathlib/Order/BoundedOrder/Basic.lean
+++ b/Mathlib/Order/BoundedOrder/Basic.lean
@@ -388,8 +388,7 @@ theorem bot_def [∀ i, Bot (α' i)] : (⊥ : ∀ i, α' i) = fun _ => ⊥ :=
   rfl
 
 @[simp]
-theorem bot_comp {α β γ : Type*} [Bot γ] (x : α → β) : (⊥ : β → γ) ∘ x = ⊥ := by
-  rfl
+theorem bot_comp {α β γ : Type*} [Bot γ] (x : α → β) : (⊥ : β → γ) ∘ x = ⊥ := rfl
 
 instance [∀ i, Top (α' i)] : Top (∀ i, α' i) :=
   ⟨fun _ => ⊤⟩
@@ -403,8 +402,7 @@ theorem top_def [∀ i, Top (α' i)] : (⊤ : ∀ i, α' i) = fun _ => ⊤ :=
   rfl
 
 @[simp]
-theorem top_comp {α β γ : Type*} [Top γ] (x : α → β) : (⊤ : β → γ) ∘ x = ⊤ := by
-  rfl
+theorem top_comp {α β γ : Type*} [Top γ] (x : α → β) : (⊤ : β → γ) ∘ x = ⊤ := rfl
 
 instance instOrderTop [∀ i, LE (α' i)] [∀ i, OrderTop (α' i)] : OrderTop (∀ i, α' i) where
   le_top _ := fun _ => le_top

--- a/Mathlib/RepresentationTheory/Coinvariants.lean
+++ b/Mathlib/RepresentationTheory/Coinvariants.lean
@@ -231,7 +231,7 @@ noncomputable def coinvariantsFinsuppLEquiv :
 
 @[simp]
 lemma coinvariantsFinsuppLEquiv_apply (x : Coinvariants (ρ.finsupp α)) :
-    coinvariantsFinsuppLEquiv ρ α x = coinvariantsToFinsupp ρ α x := by rfl
+    coinvariantsFinsuppLEquiv ρ α x = coinvariantsToFinsupp ρ α x := rfl
 
 end Finsupp
 
@@ -277,8 +277,7 @@ noncomputable def coinvariantsTprodLeftRegularLEquiv :
 
 @[simp]
 lemma coinvariantsTprodLeftRegularLEquiv_apply (x : (ρ.tprod (leftRegular k G)).Coinvariants) :
-    coinvariantsTprodLeftRegularLEquiv ρ x = ofCoinvariantsTprodLeftRegular ρ x := by
-  rfl
+    coinvariantsTprodLeftRegularLEquiv ρ x = ofCoinvariantsTprodLeftRegular ρ x := rfl
 
 end TensorProduct
 end Representation
@@ -380,8 +379,7 @@ noncomputable def coinvariantsAdjunction : coinvariantsFunctor k G ⊣ trivialFu
 @[simp]
 theorem coinvariantsAdjunction_homEquiv_apply_hom {X : Rep k G} {Y : ModuleCat k}
     (f : (coinvariantsFunctor k G).obj X ⟶ Y) :
-    ((coinvariantsAdjunction k G).homEquiv X Y f).hom = (coinvariantsMk k G).app X ≫ f := by
-  rfl
+    ((coinvariantsAdjunction k G).homEquiv X Y f).hom = (coinvariantsMk k G).app X ≫ f := rfl
 
 @[simp]
 theorem coinvariantsAdjunction_homEquiv_symm_apply_hom {X : Rep k G} {Y : ModuleCat k}
@@ -500,8 +498,7 @@ noncomputable abbrev coinvariantsTensorFreeLEquiv :
 @[simp]
 lemma coinvariantsTensorFreeLEquiv_apply (x : (A ⊗ free k G α).ρ.Coinvariants) :
     DFunLike.coe (F := (A.ρ.tprod (Representation.free k G α)).Coinvariants →ₗ[k] α →₀ A)
-      (A.coinvariantsTensorFreeToFinsupp α) x = coinvariantsTensorFreeToFinsupp A α x := by
-  rfl
+      (A.coinvariantsTensorFreeToFinsupp α) x = coinvariantsTensorFreeToFinsupp A α x := rfl
 
 end Finsupp
 

--- a/Mathlib/RepresentationTheory/Homological/GroupCohomology/Functoriality.lean
+++ b/Mathlib/RepresentationTheory/Homological/GroupCohomology/Functoriality.lean
@@ -84,7 +84,7 @@ lemma cochainsMap_id_comp {A B C : Rep k G} (φ : A ⟶ B) (ψ : B ⟶ C) :
   rfl
 
 @[simp]
-lemma cochainsMap_zero : cochainsMap (A := A) (B := B) f 0 = 0 := by rfl
+lemma cochainsMap_zero : cochainsMap (A := A) (B := B) f 0 = 0 := rfl
 
 lemma cochainsMap_f_map_mono (hf : Function.Surjective f) [Mono φ] (i : ℕ) :
     Mono ((cochainsMap f φ).f i) := by

--- a/Mathlib/RepresentationTheory/Homological/GroupHomology/LowDegree.lean
+++ b/Mathlib/RepresentationTheory/Homological/GroupHomology/LowDegree.lean
@@ -1001,8 +1001,7 @@ lemma H1AddEquivOfIsTrivial_single (g : G) (a : A) :
 @[simp]
 lemma H1AddEquivOfIsTrivial_symm_tmul (g : G) (a : A) :
     (H1AddEquivOfIsTrivial A).symm (Additive.ofMul (Abelianization.of g) ⊗ₜ[ℤ] a) =
-      H1π A ((cycles₁IsoOfIsTrivial A).inv <| single g a) := by
-  rfl
+      H1π A ((cycles₁IsoOfIsTrivial A).inv <| single g a) := rfl
 
 end IsTrivial
 

--- a/Mathlib/RingTheory/AlgebraTower.lean
+++ b/Mathlib/RingTheory/AlgebraTower.lean
@@ -67,8 +67,7 @@ noncomputable def algebraMapCoeffs : Basis ι A M :=
 
 @[simp]
 theorem algebraMapCoeffs_repr (m : M) :
-    (b.algebraMapCoeffs A h).repr m = (b.repr m).mapRange (algebraMap R A) (map_zero _) := by
-  rfl
+    (b.algebraMapCoeffs A h).repr m = (b.repr m).mapRange (algebraMap R A) (map_zero _) := rfl
 
 theorem algebraMapCoeffs_apply (i : ι) : b.algebraMapCoeffs A h i = b i :=
   b.mapCoeffs_apply _ _ _

--- a/Mathlib/RingTheory/Bialgebra/Hom.lean
+++ b/Mathlib/RingTheory/Bialgebra/Hom.lean
@@ -145,8 +145,7 @@ theorem coe_mks {f : A → B} (h₀ h₁ h₂ h₃ h₄ h₅) :
 
 @[simp, norm_cast]
 theorem coe_coalgHom_mk {f : A →ₗc[R] B} (h h₁) :
-    ((⟨f, h, h₁⟩ : A →ₐc[R] B) : A →ₗc[R] B) = f := by
-  rfl
+    ((⟨f, h, h₁⟩ : A →ₐc[R] B) : A →ₗc[R] B) = f := rfl
 
 @[simp, norm_cast]
 theorem coe_toCoalgHom (f : A →ₐc[R] B) : ⇑(f : A →ₗc[R] B) = f :=
@@ -163,8 +162,7 @@ theorem coe_toAlgHom (f : A →ₐc[R] B) : ⇑(f : A →ₐ[R] B) = f :=
   rfl
 
 theorem toAlgHom_toLinearMap (f : A →ₐc[R] B) :
-    ((f : A →ₐ[R] B) : A →ₗ[R] B) = f := by
-  rfl
+    ((f : A →ₐ[R] B) : A →ₗ[R] B) = f := rfl
 
 variable (φ : A →ₐc[R] B)
 

--- a/Mathlib/RingTheory/HahnSeries/Addition.lean
+++ b/Mathlib/RingTheory/HahnSeries/Addition.lean
@@ -536,7 +536,7 @@ def truncLTLinearMap [DecidableLT Γ] (c : Γ) : HahnSeries Γ V →ₗ[R] HahnS
 variable (R) in
 @[simp]
 theorem coe_truncLTLinearMap [DecidableLT Γ] (c : Γ) :
-    (truncLTLinearMap R c : HahnSeries Γ V → HahnSeries Γ V) = truncLT c := by rfl
+    (truncLTLinearMap R c : HahnSeries Γ V → HahnSeries Γ V) = truncLT c := rfl
 
 end Module
 

--- a/Mathlib/RingTheory/Ideal/Norm/AbsNorm.lean
+++ b/Mathlib/RingTheory/Ideal/Norm/AbsNorm.lean
@@ -54,8 +54,7 @@ This is used to define the absolute ideal norm `Ideal.absNorm`.
 noncomputable def cardQuot (S : Submodule R M) : ℕ :=
   AddSubgroup.index S.toAddSubgroup
 
-theorem cardQuot_apply (S : Submodule R M) : cardQuot S = Nat.card (M ⧸ S) := by
-  rfl
+theorem cardQuot_apply (S : Submodule R M) : cardQuot S = Nat.card (M ⧸ S) := rfl
 
 variable (R M)
 

--- a/Mathlib/RingTheory/Ideal/Quotient/Operations.lean
+++ b/Mathlib/RingTheory/Ideal/Quotient/Operations.lean
@@ -486,8 +486,7 @@ def kerLiftAlg (f : A →ₐ[R₁] B) : A ⧸ (RingHom.ker f) →ₐ[R₁] B :=
 
 @[simp]
 theorem kerLiftAlg_mk (f : A →ₐ[R₁] B) (a : A) :
-    kerLiftAlg f (Quotient.mk (RingHom.ker f) a) = f a := by
-  rfl
+    kerLiftAlg f (Quotient.mk (RingHom.ker f) a) = f a := rfl
 
 @[simp]
 theorem kerLiftAlg_toRingHom (f : A →ₐ[R₁] B) :
@@ -821,8 +820,7 @@ theorem quotQuotEquivComm_comp_quotQuotMk :
   RingHom.ext <| quotQuotEquivComm_quotQuotMk I J
 
 @[simp]
-theorem quotQuotEquivComm_symm : (quotQuotEquivComm I J).symm = quotQuotEquivComm J I := by
-  rfl
+theorem quotQuotEquivComm_symm : (quotQuotEquivComm I J).symm = quotQuotEquivComm J I := rfl
 
 variable {I J}
 
@@ -976,8 +974,7 @@ theorem coe_quotQuotEquivCommₐ : ⇑(quotQuotEquivCommₐ R I J) = ⇑(quotQuo
   rfl
 
 @[simp]
-theorem quotQuotEquivComm_symmₐ : (quotQuotEquivCommₐ R I J).symm = quotQuotEquivCommₐ R J I := by
-  rfl
+theorem quotQuotEquivComm_symmₐ : (quotQuotEquivCommₐ R I J).symm = quotQuotEquivCommₐ R J I := rfl
 
 @[simp]
 theorem quotQuotEquivComm_comp_quotQuotMkₐ :

--- a/Mathlib/SetTheory/Surreal/Basic.lean
+++ b/Mathlib/SetTheory/Surreal/Basic.lean
@@ -360,12 +360,12 @@ instance isOrderedAddMonoid : IsOrderedAddMonoid Surreal where
   add_le_add_left := by rintro ⟨_⟩ ⟨_⟩ hx ⟨_⟩; exact @add_le_add_left PGame _ _ _ _ _ hx _
 
 lemma mk_add {x y : PGame} (hx : x.Numeric) (hy : y.Numeric) :
-    Surreal.mk (x + y) (hx.add hy) = Surreal.mk x hx + Surreal.mk y hy := by rfl
+    Surreal.mk (x + y) (hx.add hy) = Surreal.mk x hx + Surreal.mk y hy := rfl
 
 lemma mk_sub {x y : PGame} (hx : x.Numeric) (hy : y.Numeric) :
-    Surreal.mk (x - y) (hx.sub hy) = Surreal.mk x hx - Surreal.mk y hy := by rfl
+    Surreal.mk (x - y) (hx.sub hy) = Surreal.mk x hx - Surreal.mk y hy := rfl
 
-lemma zero_def : 0 = mk 0 numeric_zero := by rfl
+lemma zero_def : 0 = mk 0 numeric_zero := rfl
 
 noncomputable instance : LinearOrder Surreal :=
   { Surreal.partialOrder with

--- a/Mathlib/SetTheory/ZFC/Class.lean
+++ b/Mathlib/SetTheory/ZFC/Class.lean
@@ -130,8 +130,7 @@ def congToClass (x : Set Class.{u}) : Class.{u} :=
   { y | ↑y ∈ x }
 
 @[simp]
-theorem congToClass_empty : congToClass ∅ = ∅ := by
-  rfl
+theorem congToClass_empty : congToClass ∅ = ∅ := rfl
 
 /-- Convert a class into a conglomerate (a collection of classes) -/
 def classToCong (x : Class.{u}) : Set Class.{u} :=

--- a/Mathlib/Tactic/Module.lean
+++ b/Mathlib/Tactic/Module.lean
@@ -60,8 +60,7 @@ forming the "linear combination" it specifies: scalar-multiply each `R` term to 
 def eval [Add M] [Zero M] [SMul R M] (l : NF R M) : M := (l.map (fun (⟨r, x⟩ : R × M) ↦ r • x)).sum
 
 @[simp] theorem eval_cons [AddMonoid M] [SMul R M] (p : R × M) (l : NF R M) :
-    (p ::ᵣ l).eval = p.1 • p.2 + l.eval := by
-  rfl
+    (p ::ᵣ l).eval = p.1 • p.2 + l.eval := rfl
 
 theorem atom_eq_eval [AddMonoid M] (x : M) : x = NF.eval [(1, x)] := by simp [eval]
 

--- a/Mathlib/Tactic/NormNum/PowMod.lean
+++ b/Mathlib/Tactic/NormNum/PowMod.lean
@@ -55,8 +55,7 @@ theorem natPow_zero_natMod_one : Nat.mod (Nat.pow a (nat_lit 0)) (nat_lit 1) = n
   simp [Nat.mod, Nat.modCore_eq]
 
 theorem natPow_zero_natMod_succ_succ :
-    Nat.mod (Nat.pow a (nat_lit 0)) (Nat.succ (Nat.succ m)) = nat_lit 1 := by
-  rfl
+    Nat.mod (Nat.pow a (nat_lit 0)) (Nat.succ (Nat.succ m)) = nat_lit 1 := rfl
 
 theorem natPow_one_natMod : Nat.mod (Nat.pow a (nat_lit 1)) m = Nat.mod a m := by rw [natPow_one]
 

--- a/Mathlib/Topology/Algebra/Algebra/Equiv.lean
+++ b/Mathlib/Topology/Algebra/Algebra/Equiv.lean
@@ -232,8 +232,7 @@ theorem symm_trans_apply (e₁ : B ≃A[R] A) (e₂ : C ≃A[R] B) (a : A) :
   rfl
 
 theorem comp_coe (e₁ : A ≃A[R] B) (e₂ : B ≃A[R] C) :
-    e₂.toAlgHom.comp e₁.toAlgHom = e₁.trans e₂ := by
-  rfl
+    e₂.toAlgHom.comp e₁.toAlgHom = e₁.trans e₂ := rfl
 
 @[simp high]
 theorem coe_comp_coe_symm (e : A ≃A[R] B) :

--- a/Mathlib/Topology/Algebra/Module/WeakDual.lean
+++ b/Mathlib/Topology/Algebra/Module/WeakDual.lean
@@ -188,7 +188,7 @@ def toWeakSpaceCLM : E →L[𝕜] WeakSpace 𝕜 E where
 variable (𝕜 E) in
 @[simp]
 theorem toWeakSpaceCLM_eq_toWeakSpace (x : E) :
-    toWeakSpaceCLM 𝕜 E x = toWeakSpace 𝕜 E x := by rfl
+    toWeakSpaceCLM 𝕜 E x = toWeakSpace 𝕜 E x := rfl
 
 theorem toWeakSpaceCLM_bijective :
     Function.Bijective (toWeakSpaceCLM 𝕜 E) :=

--- a/Mathlib/Topology/Category/Profinite/Nobeling/Basic.lean
+++ b/Mathlib/Topology/Category/Profinite/Nobeling/Basic.lean
@@ -555,8 +555,7 @@ def πs (o : Ordinal) : LocallyConstant (π C (ord I · < o)) ℤ →ₗ[ℤ] Lo
   LocallyConstant.comapₗ ℤ ⟨(ProjRestrict C (ord I · < o)), (continuous_projRestrict _ _)⟩
 
 theorem coe_πs (o : Ordinal) (f : LocallyConstant (π C (ord I · < o)) ℤ) :
-    πs C o f = f ∘ ProjRestrict C (ord I · < o) := by
-  rfl
+    πs C o f = f ∘ ProjRestrict C (ord I · < o) := rfl
 
 theorem injective_πs (o : Ordinal) : Function.Injective (πs C o) :=
   LocallyConstant.comap_injective ⟨_, (continuous_projRestrict _ _)⟩
@@ -572,8 +571,7 @@ def πs' {o₁ o₂ : Ordinal} (h : o₁ ≤ o₂) :
     (continuous_projRestricts _ _)⟩
 
 theorem coe_πs' {o₁ o₂ : Ordinal} (h : o₁ ≤ o₂) (f : LocallyConstant (π C (ord I · < o₁)) ℤ) :
-    (πs' C h f).toFun = f.toFun ∘ (ProjRestricts C (fun _ hh ↦ lt_of_lt_of_le hh h)) := by
-  rfl
+    (πs' C h f).toFun = f.toFun ∘ (ProjRestricts C (fun _ hh ↦ lt_of_lt_of_le hh h)) := rfl
 
 theorem injective_πs' {o₁ o₂ : Ordinal} (h : o₁ ≤ o₂) : Function.Injective (πs' C h) :=
   LocallyConstant.comap_injective ⟨_, (continuous_projRestricts _ _)⟩

--- a/Mathlib/Topology/Category/Profinite/Nobeling/ZeroLimit.lean
+++ b/Mathlib/Topology/Category/Profinite/Nobeling/ZeroLimit.lean
@@ -173,7 +173,7 @@ def range_equiv_smaller (o : Ordinal) : range (π C (ord I · < o)) ≃ smaller 
 
 theorem smaller_factorization (o : Ordinal) :
     (fun (p : smaller C o) ↦ p.1) ∘ (range_equiv_smaller C o).toFun =
-    (πs C o) ∘ (fun (p : range (π C (ord I · < o))) ↦ p.1) := by rfl
+    (πs C o) ∘ (fun (p : range (π C (ord I · < o))) ↦ p.1) := rfl
 
 theorem linearIndependent_iff_smaller (o : Ordinal) :
     LinearIndependent ℤ (GoodProducts.eval (π C (ord I · < o))) ↔

--- a/Mathlib/Topology/Category/TopCat/Opens.lean
+++ b/Mathlib/Topology/Category/TopCat/Opens.lean
@@ -224,8 +224,7 @@ def mapId : map (𝟙 X) ≅ 𝟭 (Opens X) where
   hom := { app := fun U => eqToHom (map_id_obj U) }
   inv := { app := fun U => eqToHom (map_id_obj U).symm }
 
-theorem map_id_eq : map (𝟙 X) = 𝟭 (Opens X) := by
-  rfl
+theorem map_id_eq : map (𝟙 X) = 𝟭 (Opens X) := rfl
 
 end
 

--- a/Mathlib/Topology/ContinuousMap/Units.lean
+++ b/Mathlib/Topology/ContinuousMap/Units.lean
@@ -51,8 +51,7 @@ lemma unitsLift_apply_inv_apply (f : C(X, Mˣ)) (x : X) :
 
 @[to_additive (attr := simp)]
 lemma unitsLift_symm_apply_apply_inv' (f : C(X, M)ˣ) (x : X) :
-    (ContinuousMap.unitsLift.symm f x)⁻¹ = (↑f⁻¹ : C(X, M)) x := by
-  rfl
+    (ContinuousMap.unitsLift.symm f x)⁻¹ = (↑f⁻¹ : C(X, M)) x := rfl
 
 end Monoid
 

--- a/Mathlib/Topology/LocallyFinsupp.lean
+++ b/Mathlib/Topology/LocallyFinsupp.lean
@@ -383,7 +383,7 @@ noncomputable def restrictMonoidHom [AddCommGroup Y] {V : Set X} (h : V ⊆ U) :
 @[simp]
 lemma restrictMonoidHom_apply [AddCommGroup Y] {V : Set X} (D : locallyFinsuppWithin U Y)
     (h : V ⊆ U) :
-    restrictMonoidHom h D = D.restrict h := by rfl
+    restrictMonoidHom h D = D.restrict h := rfl
 
 /-- Restriction as a lattice morphism -/
 noncomputable def restrictLatticeHom [AddCommGroup Y] [Lattice Y] {V : Set X} (h : V ⊆ U) :
@@ -401,6 +401,6 @@ noncomputable def restrictLatticeHom [AddCommGroup Y] [Lattice Y] {V : Set X} (h
 @[simp]
 lemma restrictLatticeHom_apply [AddCommGroup Y] [Lattice Y] {V : Set X}
     (D : locallyFinsuppWithin U Y) (h : V ⊆ U) :
-    restrictLatticeHom h D = D.restrict h := by rfl
+    restrictLatticeHom h D = D.restrict h := rfl
 
 end Function.locallyFinsuppWithin

--- a/Mathlib/Topology/PartitionOfUnity.lean
+++ b/Mathlib/Topology/PartitionOfUnity.lean
@@ -355,8 +355,7 @@ protected def single (i : ι) (s : Set X) : BumpCovering ι X s where
 
 open Classical in
 @[simp]
-theorem coe_single (i : ι) (s : Set X) : ⇑(BumpCovering.single i s) = Pi.single i 1 := by
-  rfl
+theorem coe_single (i : ι) (s : Set X) : ⇑(BumpCovering.single i s) = Pi.single i 1 := rfl
 
 instance [Inhabited ι] : Inhabited (BumpCovering ι X s) :=
   ⟨BumpCovering.single default s⟩

--- a/Mathlib/Topology/Sets/Closeds.lean
+++ b/Mathlib/Topology/Sets/Closeds.lean
@@ -115,8 +115,7 @@ instance : Inhabited (Closeds α) :=
   ⟨⊥⟩
 
 @[simp, norm_cast]
-theorem coe_sup (s t : Closeds α) : (↑(s ⊔ t) : Set α) = ↑s ∪ ↑t := by
-  rfl
+theorem coe_sup (s t : Closeds α) : (↑(s ⊔ t) : Set α) = ↑s ∪ ↑t := rfl
 
 @[simp, norm_cast]
 theorem coe_inf (s t : Closeds α) : (↑(s ⊓ t) : Set α) = ↑s ∩ ↑t :=
@@ -147,7 +146,7 @@ theorem coe_sInf {S : Set (Closeds α)} : (↑(sInf S) : Set α) = ⋂ i ∈ S, 
 
 @[simp]
 lemma coe_sSup {S : Set (Closeds α)} : ((sSup S : Closeds α) : Set α) =
-    closure (⋃₀ ((↑) '' S)) := by rfl
+    closure (⋃₀ ((↑) '' S)) := rfl
 
 @[simp, norm_cast]
 theorem coe_finset_sup (f : ι → Closeds α) (s : Finset ι) :


### PR DESCRIPTION
For `@[simp]` lemmas this makes them usable by `dsimp`; others are stylistic cleanup (but they're now "`dsimp`-ready" if tagged later).

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include at least one commit authored by each
co-author among the commits in the pull request. If necessary, you may 
create empty commits to indicate co-authorship, using commands like so:

git commit --author="Author Name <author@email.com>" --allow-empty -m "add Author Name as coauthor"

When merging, all the commits will be squashed into a single commit listing all co-authors.

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
