### PR TITLE
[Merged by Bors] - chore: squeeze a few more non-terminal simps

### DIFF
--- a/Mathlib/CategoryTheory/Limits/Sifted.lean
+++ b/Mathlib/CategoryTheory/Limits/Sifted.lean
@@ -77,8 +77,7 @@ instance [IsSifted C] : IsConnected C :=
         constructor
         · constructor
           · exact Zag.of_hom X.hom.fst
-          · simp
-            exact Zag.of_inv X.hom.snd
+          · simpa using Zag.of_inv X.hom.snd
         · rfl)
 
 /-- A category with binary coproducts is sifted or empty. -/

--- a/Mathlib/Order/Birkhoff.lean
+++ b/Mathlib/Order/Birkhoff.lean
@@ -222,9 +222,7 @@ noncomputable def birkhoffFinset : α ↪o Finset {a : α // SupIrred a} := by
   classical
   -- TODO: This should be a single `simp` call but `simp` refuses to use
   -- `OrderIso.coe_toOrderEmbedding` and `Fintype.coe_finsetOrderIsoSet_symm`
-  simp only [le_eq_subset, birkhoffFinset, Set.le_eq_subset, RelEmbedding.coe_trans, comp_apply]
-  rw [OrderIso.coe_toOrderEmbedding, Fintype.coe_finsetOrderIsoSet_symm]
-  simp
+  simp [birkhoffFinset, (OrderIso.coe_toOrderEmbedding)]
 
 @[simp] lemma birkhoffSet_sup (a b : α) : birkhoffSet (a ⊔ b) = birkhoffSet a ∪ birkhoffSet b := by
   unfold OrderEmbedding.birkhoffSet; split <;> simp [eq_iff_true_of_subsingleton]
@@ -234,10 +232,8 @@ noncomputable def birkhoffFinset : α ↪o Finset {a : α // SupIrred a} := by
 
 @[simp] lemma birkhoffSet_apply [OrderBot α] (a : α) :
     birkhoffSet a = OrderIso.lowerSetSupIrred a := by
-  simp only [Set.le_eq_subset, birkhoffSet, not_isEmpty_of_nonempty, ↓reduceDIte,
-    RelEmbedding.coe_trans, RelEmbedding.coe_mk, Embedding.coeFn_mk, OrderIso.coe_toOrderEmbedding,
-    comp_apply, SetLike.coe_set_eq]
-  have : Subsingleton (OrderBot α) := inferInstance; convert rfl
+  have : Subsingleton (OrderBot α) := inferInstance
+  simp [birkhoffSet, this.allEq]
 
 variable [DecidableEq α]
 

--- a/Mathlib/Order/Birkhoff.lean
+++ b/Mathlib/Order/Birkhoff.lean
@@ -222,7 +222,7 @@ noncomputable def birkhoffFinset : α ↪o Finset {a : α // SupIrred a} := by
   classical
   -- TODO: This should be a single `simp` call but `simp` refuses to use
   -- `OrderIso.coe_toOrderEmbedding` and `Fintype.coe_finsetOrderIsoSet_symm`
-  simp [birkhoffFinset]
+  simp only [le_eq_subset, birkhoffFinset, Set.le_eq_subset, RelEmbedding.coe_trans, comp_apply]
   rw [OrderIso.coe_toOrderEmbedding, Fintype.coe_finsetOrderIsoSet_symm]
   simp
 
@@ -234,7 +234,10 @@ noncomputable def birkhoffFinset : α ↪o Finset {a : α // SupIrred a} := by
 
 @[simp] lemma birkhoffSet_apply [OrderBot α] (a : α) :
     birkhoffSet a = OrderIso.lowerSetSupIrred a := by
-  simp [birkhoffSet]; have : Subsingleton (OrderBot α) := inferInstance; convert rfl
+  simp only [Set.le_eq_subset, birkhoffSet, not_isEmpty_of_nonempty, ↓reduceDIte,
+    RelEmbedding.coe_trans, RelEmbedding.coe_mk, Embedding.coeFn_mk, OrderIso.coe_toOrderEmbedding,
+    comp_apply, SetLike.coe_set_eq]
+  have : Subsingleton (OrderBot α) := inferInstance; convert rfl
 
 variable [DecidableEq α]
 

--- a/Mathlib/Order/Interval/Set/LinearOrder.lean
+++ b/Mathlib/Order/Interval/Set/LinearOrder.lean
@@ -211,9 +211,9 @@ theorem Ioo_union_Ioi' (h₁ : c < b) : Ioo a b ∪ Ioi c = Ioi (min a c) := by
     tauto
 
 theorem Ioo_union_Ioi (h : c < max a b) : Ioo a b ∪ Ioi c = Ioi (min a c) := by
-  rcases le_total a b with hab | hab <;> simp [hab] at h
-  · exact Ioo_union_Ioi' h
-  · rw [min_comm]
+  rcases le_total a b with hab | hab
+  · simp only [hab, sup_of_le_right] at h; exact Ioo_union_Ioi' h
+  · simp [hab] at h; rw [min_comm]
     simp [*, min_eq_left_of_lt]
 
 theorem Ioi_subset_Ioo_union_Ici : Ioi a ⊆ Ioo a b ∪ Ici b := fun x hx =>
@@ -239,9 +239,9 @@ theorem Ico_union_Ici' (h₁ : c ≤ b) : Ico a b ∪ Ici c = Ici (min a c) := b
     tauto
 
 theorem Ico_union_Ici (h : c ≤ max a b) : Ico a b ∪ Ici c = Ici (min a c) := by
-  rcases le_total a b with hab | hab <;> simp [hab] at h
-  · exact Ico_union_Ici' h
-  · simp [*]
+  rcases le_total a b with hab | hab
+  · simp only [hab, sup_of_le_right] at h; exact Ico_union_Ici' h
+  · simp_all
 
 theorem Ioi_subset_Ioc_union_Ioi : Ioi a ⊆ Ioc a b ∪ Ioi b := fun x hx =>
   (le_or_gt x b).elim (fun hxb => Or.inl ⟨hx, hxb⟩) fun hxb => Or.inr hxb
@@ -259,9 +259,9 @@ theorem Ioc_union_Ioi' (h₁ : c ≤ b) : Ioc a b ∪ Ioi c = Ioi (min a c) := b
     tauto
 
 theorem Ioc_union_Ioi (h : c ≤ max a b) : Ioc a b ∪ Ioi c = Ioi (min a c) := by
-  rcases le_total a b with hab | hab <;> simp [hab] at h
-  · exact Ioc_union_Ioi' h
-  · simp [*]
+  rcases le_total a b with hab | hab
+  · simp only [hab, sup_of_le_right] at h; exact Ioc_union_Ioi' h
+  · simp_all
 
 theorem Ici_subset_Icc_union_Ioi : Ici a ⊆ Icc a b ∪ Ioi b := fun x hx =>
   (le_or_gt x b).elim (fun hxb => Or.inl ⟨hx, hxb⟩) fun hxb => Or.inr hxb
@@ -294,9 +294,9 @@ theorem Icc_union_Ici' (h₁ : c ≤ b) : Icc a b ∪ Ici c = Ici (min a c) := b
     tauto
 
 theorem Icc_union_Ici (h : c ≤ max a b) : Icc a b ∪ Ici c = Ici (min a c) := by
-  rcases le_or_gt a b with hab | hab <;> simp [hab] at h
-  · exact Icc_union_Ici' h
-  · rcases h with h | h
+  rcases le_or_gt a b with hab | hab
+  · simp only [hab, sup_of_le_right] at h; exact Icc_union_Ici' h
+  · simp only [le_sup_iff] at h; rcases h with h | h
     · simp [*]
     · have hca : c ≤ a := h.trans hab.le
       simp [*]
@@ -328,9 +328,9 @@ theorem Iio_union_Ico' (h₁ : c ≤ b) : Iio b ∪ Ico c d = Iio (max b d) := b
     tauto
 
 theorem Iio_union_Ico (h : min c d ≤ b) : Iio b ∪ Ico c d = Iio (max b d) := by
-  rcases le_total c d with hcd | hcd <;> simp [hcd] at h
-  · exact Iio_union_Ico' h
-  · simp [*]
+  rcases le_total c d with hcd | hcd
+  · simp only [hcd, inf_of_le_left] at h; exact Iio_union_Ico' h
+  · simp_all
 
 theorem Iic_subset_Iic_union_Ioc : Iic b ⊆ Iic a ∪ Ioc a b := fun x hx =>
   (le_or_gt x a).elim (fun hxa => Or.inl hxa) fun hxa => Or.inr ⟨hxa, hx⟩
@@ -349,9 +349,10 @@ theorem Iic_union_Ioc' (h₁ : c < b) : Iic b ∪ Ioc c d = Iic (max b d) := by
     tauto
 
 theorem Iic_union_Ioc (h : min c d < b) : Iic b ∪ Ioc c d = Iic (max b d) := by
-  rcases le_total c d with hcd | hcd <;> simp [hcd] at h
-  · exact Iic_union_Ioc' h
+  rcases le_total c d with hcd | hcd
+  · simp only [hcd, inf_of_le_left] at h; exact Iic_union_Ioc' h
   · rw [max_comm]
+    simp [hcd] at h
     simp [*, max_eq_right_of_lt h]
 
 theorem Iio_subset_Iic_union_Ioo : Iio b ⊆ Iic a ∪ Ioo a b := fun x hx =>
@@ -371,9 +372,9 @@ theorem Iio_union_Ioo' (h₁ : c < b) : Iio b ∪ Ioo c d = Iio (max b d) := by
     exact fun h₂ => ⟨h₁.trans_le hba, h₂⟩
 
 theorem Iio_union_Ioo (h : min c d < b) : Iio b ∪ Ioo c d = Iio (max b d) := by
-  rcases le_total c d with hcd | hcd <;> simp [hcd] at h
-  · exact Iio_union_Ioo' h
-  · rw [max_comm]
+  rcases le_total c d with hcd | hcd
+  · simp only [hcd, inf_of_le_left] at h; exact Iio_union_Ioo' h
+  · simp [hcd] at h; rw [max_comm]
     simp [*, max_eq_right_of_lt h]
 
 theorem Iic_subset_Iic_union_Icc : Iic b ⊆ Iic a ∪ Icc a b :=
@@ -393,9 +394,9 @@ theorem Iic_union_Icc' (h₁ : c ≤ b) : Iic b ∪ Icc c d = Iic (max b d) := b
     tauto
 
 theorem Iic_union_Icc (h : min c d ≤ b) : Iic b ∪ Icc c d = Iic (max b d) := by
-  rcases le_or_gt c d with hcd | hcd <;> simp [hcd] at h
-  · exact Iic_union_Icc' h
-  · rcases h with h | h
+  rcases le_or_gt c d with hcd | hcd
+  · simp only [hcd, inf_of_le_left] at h; exact Iic_union_Icc' h
+  · simp only [inf_le_iff] at h; rcases h with h | h
     · have hdb : d ≤ b := hcd.le.trans h
       simp [*]
     · simp [*]

--- a/Mathlib/Order/Interval/Set/LinearOrder.lean
+++ b/Mathlib/Order/Interval/Set/LinearOrder.lean
@@ -213,8 +213,8 @@ theorem Ioo_union_Ioi' (h₁ : c < b) : Ioo a b ∪ Ioi c = Ioi (min a c) := by
 theorem Ioo_union_Ioi (h : c < max a b) : Ioo a b ∪ Ioi c = Ioi (min a c) := by
   rcases le_total a b with hab | hab
   · simp only [hab, sup_of_le_right] at h; exact Ioo_union_Ioi' h
-  · simp [hab] at h; rw [min_comm]
-    simp [*, min_eq_left_of_lt]
+  · rw [min_comm]
+    simp_all [min_eq_left_of_lt]
 
 theorem Ioi_subset_Ioo_union_Ici : Ioi a ⊆ Ioo a b ∪ Ici b := fun x hx =>
   (lt_or_ge x b).elim (fun hxb => Or.inl ⟨hx, hxb⟩) fun hxb => Or.inr hxb
@@ -352,8 +352,7 @@ theorem Iic_union_Ioc (h : min c d < b) : Iic b ∪ Ioc c d = Iic (max b d) := b
   rcases le_total c d with hcd | hcd
   · simp only [hcd, inf_of_le_left] at h; exact Iic_union_Ioc' h
   · rw [max_comm]
-    simp [hcd] at h
-    simp [*, max_eq_right_of_lt h]
+    simp_all [max_eq_right_of_lt]
 
 theorem Iio_subset_Iic_union_Ioo : Iio b ⊆ Iic a ∪ Ioo a b := fun x hx =>
   (le_or_gt x a).elim (fun hxa => Or.inl hxa) fun hxa => Or.inr ⟨hxa, hx⟩
@@ -374,8 +373,8 @@ theorem Iio_union_Ioo' (h₁ : c < b) : Iio b ∪ Ioo c d = Iio (max b d) := by
 theorem Iio_union_Ioo (h : min c d < b) : Iio b ∪ Ioo c d = Iio (max b d) := by
   rcases le_total c d with hcd | hcd
   · simp only [hcd, inf_of_le_left] at h; exact Iio_union_Ioo' h
-  · simp [hcd] at h; rw [max_comm]
-    simp [*, max_eq_right_of_lt h]
+  · rw [max_comm]
+    simp_all [max_eq_right_of_lt]
 
 theorem Iic_subset_Iic_union_Icc : Iic b ⊆ Iic a ∪ Icc a b :=
   Subset.trans Iic_subset_Iic_union_Ioc (union_subset_union_right _ Ioc_subset_Icc_self)


### PR DESCRIPTION
Found by the flexible linter in #28962.

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include at least one commit authored by each
co-author among the commits in the pull request. If necessary, you may 
create empty commits to indicate co-authorship, using commands like so:

git commit --author="Author Name <author@email.com>" --allow-empty -m "add Author Name as coauthor"

When merging, all the commits will be squashed into a single commit listing all co-authors.

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
