### PR TITLE
[Merged by Bors] - feat: monotone helper lemmas for sin/cos

### DIFF
--- a/Mathlib/Analysis/SpecialFunctions/Trigonometric/Basic.lean
+++ b/Mathlib/Analysis/SpecialFunctions/Trigonometric/Basic.lean
@@ -547,6 +547,9 @@ theorem sin_lt_sin_of_lt_of_le_pi_div_two {x y : ℝ} (hx₁ : -(π / 2) ≤ x) 
 theorem strictMonoOn_sin : StrictMonoOn sin (Icc (-(π / 2)) (π / 2)) := fun _ hx _ hy hxy =>
   sin_lt_sin_of_lt_of_le_pi_div_two hx.1 hy.2 hxy
 
+theorem monotoneOn_sin : MonotoneOn sin (Set.Icc (-(π / 2)) (π / 2)) :=
+  StrictMonoOn.monotoneOn strictMonoOn_sin
+
 theorem cos_lt_cos_of_nonneg_of_le_pi {x y : ℝ} (hx₁ : 0 ≤ x) (hy₂ : y ≤ π) (hxy : x < y) :
     cos y < cos x := by
   rw [← sin_pi_div_two_sub, ← sin_pi_div_two_sub]
@@ -558,6 +561,9 @@ theorem cos_lt_cos_of_nonneg_of_le_pi_div_two {x y : ℝ} (hx₁ : 0 ≤ x) (hy�
 
 theorem strictAntiOn_cos : StrictAntiOn cos (Icc 0 π) := fun _ hx _ hy hxy =>
   cos_lt_cos_of_nonneg_of_le_pi hx.1 hy.2 hxy
+
+theorem antitoneOn_cos : AntitoneOn cos (Set.Icc 0 π) :=
+  StrictAntiOn.antitoneOn strictAntiOn_cos
 
 theorem cos_le_cos_of_nonneg_of_le_pi {x y : ℝ} (hx₁ : 0 ≤ x) (hy₂ : y ≤ π) (hxy : x ≤ y) :
     cos y ≤ cos x :=

--- a/Mathlib/Analysis/SpecialFunctions/Trigonometric/Basic.lean
+++ b/Mathlib/Analysis/SpecialFunctions/Trigonometric/Basic.lean
@@ -548,7 +548,7 @@ theorem strictMonoOn_sin : StrictMonoOn sin (Icc (-(π / 2)) (π / 2)) := fun _ 
   sin_lt_sin_of_lt_of_le_pi_div_two hx.1 hy.2 hxy
 
 theorem monotoneOn_sin : MonotoneOn sin (Set.Icc (-(π / 2)) (π / 2)) :=
-  StrictMonoOn.monotoneOn strictMonoOn_sin
+  strictMonoOn_sin.monotoneOn
 
 theorem cos_lt_cos_of_nonneg_of_le_pi {x y : ℝ} (hx₁ : 0 ≤ x) (hy₂ : y ≤ π) (hxy : x < y) :
     cos y < cos x := by
@@ -563,7 +563,7 @@ theorem strictAntiOn_cos : StrictAntiOn cos (Icc 0 π) := fun _ hx _ hy hxy =>
   cos_lt_cos_of_nonneg_of_le_pi hx.1 hy.2 hxy
 
 theorem antitoneOn_cos : AntitoneOn cos (Set.Icc 0 π) :=
-  StrictAntiOn.antitoneOn strictAntiOn_cos
+  strictAntiOn_cos.antitoneOn
 
 theorem cos_le_cos_of_nonneg_of_le_pi {x y : ℝ} (hx₁ : 0 ≤ x) (hy₂ : y ≤ π) (hxy : x ≤ y) :
     cos y ≤ cos x :=


### PR DESCRIPTION
This PR adds `theorem monotoneOn_sin : MonotoneOn sin (Set.Icc (-(π / 2)) (π / 2)) := StrictMonoOn.monotoneOn strictMonoOn_sin` and the corresponding theorem for `cos`, for convenience for people like me who don't immediately decide to search for the strict version.

(This is part of several PRs preparing for an example propagator for an interval arithmetic tactic.)