### PR TITLE
[Merged by Bors] - chore(GroupTheory): review porting notes

### DIFF
--- a/Mathlib/Algebra/Group/Basic.lean
+++ b/Mathlib/Algebra/Group/Basic.lean
@@ -181,6 +181,14 @@ lemma mul_right_iterate (a : M) : ∀ n : ℕ, (· * a)^[n] = (· * a ^ n)
   | 0 => by ext; simp
   | n + 1 => by simp [pow_succ', mul_right_iterate]
 
+/-- Version of `mul_left_iterate` that is fully applied, for `rw`. -/
+@[to_additive /-- Version of `add_left_iterate` that is fully applied, for `rw`. -/]
+lemma mul_left_iterate_apply (a b : M) : (a * ·)^[n] b = a ^ n * b := by simp
+
+/-- Version of `mul_right_iterate` that is fully applied, for `rw`. -/
+@[to_additive /-- Version of `add_right_iterate` that is fully applied, for `rw`. -/ ]
+lemma mul_right_iterate_apply (a b : M) : (· * a)^[n] b = b * a ^ n := by simp
+
 @[to_additive]
 lemma mul_left_iterate_apply_one (a : M) : (a * ·)^[n] 1 = a ^ n := by simp
 

--- a/Mathlib/GroupTheory/Complement.lean
+++ b/Mathlib/GroupTheory/Complement.lean
@@ -32,8 +32,15 @@ namespace Subgroup
 variable {G : Type*} [Group G] (H K : Subgroup G) (S T : Set G)
 
 /-- `S` and `T` are complements if `(*) : S × T → G` is a bijection.
-  This notion generalizes left transversals, right transversals, and complementary subgroups. -/
-@[to_additive /-- `S` and `T` are complements if `(+) : S × T → G` is a bijection -/]
+This notion generalizes left transversals, right transversals, and complementary subgroups.
+
+If `S` and `T` are `SetLike`s such as `Subgroup`s, see `isComplement_iff_bijective` for a
+more ergonomic way to unfold.
+-/
+@[to_additive /-- `S` and `T` are complements if `(+) : S × T → G` is a bijection
+
+If `S` and `T` are `SetLike`s such as `AddSubgroup`s, see `isComplement_iff_bijective` for a
+more ergonomic way to unfold. -/]
 def IsComplement : Prop :=
   Function.Bijective fun x : S × T => x.1.1 * x.2.1
 

--- a/Mathlib/GroupTheory/Complement.lean
+++ b/Mathlib/GroupTheory/Complement.lean
@@ -44,6 +44,12 @@ abbrev IsComplement' :=
 
 variable {H K S T}
 
+/-- The correct way to unfold `IsComplement` for `SetLike`s such as `Subgroup`s -/
+@[to_additive /-- The correct way to unfold `IsComplement` for `SetLike`s such as `AddSubgroup`s -/]
+theorem isComplement_iff_bijective {S : Type*} [SetLike S G] (s t : S) :
+    IsComplement (G := G) s t ↔ Function.Bijective fun x : s × t => (x.1 : G) * (x.2 : G) :=
+  Iff.rfl
+
 @[to_additive]
 theorem isComplement'_def : IsComplement' H K ↔ IsComplement (H : Set G) (K : Set G) :=
   Iff.rfl
@@ -65,9 +71,8 @@ theorem IsComplement'.symm (h : IsComplement' H K) : IsComplement' K H := by
       (fun x => Prod.ext (inv_inv _) (inv_inv _)) fun x => Prod.ext (inv_inv _) (inv_inv _)
   let ψ : G ≃ G := Equiv.mk (fun g : G => g⁻¹) (fun g : G => g⁻¹) inv_inv inv_inv
   suffices hf : (ψ ∘ fun x : H × K => x.1.1 * x.2.1) = (fun x : K × H => x.1.1 * x.2.1) ∘ ϕ by
-    rw [isComplement'_def, IsComplement, ← Equiv.bijective_comp ϕ]
-    apply (congr_arg Function.Bijective hf).mp -- Porting note: This was a `rw` in mathlib3
-    rwa [ψ.comp_bijective]
+    rwa [isComplement'_def, isComplement_iff_bijective, ← Equiv.bijective_comp ϕ, ← hf,
+      ψ.comp_bijective]
   exact funext fun x => mul_inv_rev _ _
 
 @[to_additive]

--- a/Mathlib/GroupTheory/Congruence/Basic.lean
+++ b/Mathlib/GroupTheory/Congruence/Basic.lean
@@ -168,7 +168,7 @@ theorem le_iff {c d : Con M} : c ≤ d ↔ (c : Submonoid (M × M)) ≤ d :=
 variable (x y : M)
 
 @[to_additive (attr := simp)]
--- Porting note: removed dot notation
+-- Porting note (https://github.com/leanprover-community/mathlib4/pull/11036): removed dot notation
 theorem mrange_mk' : MonoidHom.mrange c.mk' = ⊤ :=
   MonoidHom.mrange_eq_top.2 mk'_surjective
 

--- a/Mathlib/GroupTheory/Congruence/Defs.lean
+++ b/Mathlib/GroupTheory/Congruence/Defs.lean
@@ -195,7 +195,6 @@ def toQuotient : M → c.Quotient :=
 
 variable (c)
 
--- Porting note: was `priority 0`. why?
 /-- Coercion from a type with a multiplication to its quotient by a congruence relation.
 
 See Note [use has_coe_t]. -/

--- a/Mathlib/GroupTheory/CoprodI.lean
+++ b/Mathlib/GroupTheory/CoprodI.lean
@@ -122,8 +122,7 @@ theorem of_apply {i} (m : M i) : of m = Con.mk' _ (FreeMonoid.of <| Sigma.mk i m
 variable {N : Type*} [Monoid N]
 
 /-- See note [partially-applied ext lemmas]. -/
--- Porting note: higher `ext` priority
-@[ext 1100]
+@[ext 1100] -- This needs a higher `ext` priority
 theorem ext_hom (f g : CoprodI M →* N) (h : ∀ i, f.comp (of : M i →* _) = g.comp of) : f = g :=
   (MonoidHom.cancel_right Con.mk'_surjective).mp <|
     FreeMonoid.hom_eq fun ⟨i, x⟩ => by

--- a/Mathlib/GroupTheory/Coset/Card.lean
+++ b/Mathlib/GroupTheory/Coset/Card.lean
@@ -27,6 +27,10 @@ instance fintype [Fintype α] (s : Subgroup α) [DecidableRel (leftRel s).r] : F
   Quotient.fintype (leftRel s)
 
 @[to_additive]
+instance (priority := 100) finite [Finite α] : Finite (α ⧸ s) :=
+  Quotient.finite _
+
+@[to_additive]
 instance fintypeQuotientRightRel [Fintype (α ⧸ s)] :
     Fintype (Quotient (QuotientGroup.rightRel s)) :=
   .ofEquiv (α ⧸ s) (QuotientGroup.quotientRightRelEquivQuotientLeftRel s).symm

--- a/Mathlib/GroupTheory/Coset/Defs.lean
+++ b/Mathlib/GroupTheory/Coset/Defs.lean
@@ -45,7 +45,7 @@ open scoped Pointwise
 
 variable {α : Type*}
 
--- Porting note: see https://leanprover.zulipchat.com/#narrow/stream/287929-mathlib4/topic/.E2.9C.94.20to_additive.2Emap_namespace
+-- See https://leanprover.zulipchat.com/#narrow/stream/287929-mathlib4/topic/.E2.9C.94.20to_additive.2Emap_namespace
 run_cmd Lean.Elab.Command.liftCoreM <| ToAdditive.insertTranslation `QuotientGroup `QuotientAddGroup
 
 namespace QuotientGroup
@@ -124,12 +124,10 @@ def quotientRightRelEquivQuotientLeftRel : Quotient (QuotientGroup.rightRel s) �
     Quotient.map' (fun g => g⁻¹) fun a b => by
       rw [leftRel_apply, rightRel_apply]
       exact fun h => (congr_arg (· ∈ s) (by simp)).mp (s.inv_mem h)
-      -- Porting note: replace with `by group`
   invFun :=
     Quotient.map' (fun g => g⁻¹) fun a b => by
       rw [leftRel_apply, rightRel_apply]
       exact fun h => (congr_arg (· ∈ s) (by simp)).mp (s.inv_mem h)
-      -- Porting note: replace with `by group`
   left_inv g :=
     Quotient.inductionOn' g fun g =>
       Quotient.sound'

--- a/Mathlib/GroupTheory/Divisible.lean
+++ b/Mathlib/GroupTheory/Divisible.lean
@@ -218,8 +218,9 @@ def rootableByNatOfRootableByInt [RootableBy A ℤ] : RootableBy A ℕ where
   root a n := RootableBy.root a (n : ℤ)
   root_zero a := RootableBy.root_zero a
   root_cancel {n} a hn := by
-    -- Porting note: replaced `norm_num`
-    simpa only [zpow_natCast] using RootableBy.root_cancel a (show (n : ℤ) ≠ 0 from mod_cast hn)
+    have := RootableBy.root_cancel a (show (n : ℤ) ≠ 0 from mod_cast hn)
+    norm_num at this
+    exact this
 
 end Group
 

--- a/Mathlib/GroupTheory/Exponent.lean
+++ b/Mathlib/GroupTheory/Exponent.lean
@@ -454,7 +454,7 @@ theorem exists_orderOf_eq_exponent (hG : ExponentExists G) : ∃ g : G, orderOf 
       simp [k, hp]
     rw [this]
     -- Porting note: convert made to_additive complain
-    apply Nat.pow_succ_factorization_not_dvd (hG.orderOf_pos <| t ^ p ^ k).ne' hp
+    exact Nat.pow_succ_factorization_not_dvd (hG.orderOf_pos <| t ^ p ^ k).ne' hp
   rw [(Commute.all _ g).orderOf_mul_eq_mul_orderOf_of_coprime hcoprime, hpk',
     hg, ha, hk, pow_add, pow_add, pow_one, ← mul_assoc, ← mul_assoc,
     Nat.div_mul_cancel, mul_assoc, lt_mul_iff_one_lt_right <| hG.orderOf_pos t, ← pow_succ]

--- a/Mathlib/GroupTheory/FreeAbelianGroup.lean
+++ b/Mathlib/GroupTheory/FreeAbelianGroup.lean
@@ -120,11 +120,11 @@ variable {β : Type v} [AddCommGroup β] (f : α → β)
 
 open FreeAbelianGroup
 
--- Porting note: needed to add `(β := Multiplicative β)` and `using 1`.
+-- Porting note: needed to add `(β := Multiplicative β)`
 @[simp]
 theorem lift_apply_of (x : α) : lift f (of x) = f x := by
   convert Abelianization.lift_apply_of
-     (FreeGroup.lift f (β := Multiplicative β)) (FreeGroup.of x) using 1
+     (FreeGroup.lift f (β := Multiplicative β)) (FreeGroup.of x)
   exact (FreeGroup.lift_apply_of (β := Multiplicative β)).symm
 
 @[deprecated (since := "2025-07-23")] protected alias lift.of := lift_apply_of

--- a/Mathlib/GroupTheory/FreeGroup/Basic.lean
+++ b/Mathlib/GroupTheory/FreeGroup/Basic.lean
@@ -57,9 +57,8 @@ variable {α : Type u}
 
 attribute [local simp] List.append_eq_has_append
 
--- Porting note: to_additive.map_namespace is not supported yet
--- worked around it by putting a few extra manual mappings (but not too many all in all)
--- run_cmd to_additive.map_namespace `FreeGroup `FreeAddGroup
+-- See https://leanprover.zulipchat.com/#narrow/stream/287929-mathlib4/topic/.E2.9C.94.20to_additive.2Emap_namespace
+run_cmd Lean.Elab.Command.liftCoreM <| ToAdditive.insertTranslation `FreeGroup `FreeAddGroup
 
 /-- Reduction step for the additive free group relation: `w + x + (-x) + v ~> w + v` -/
 inductive FreeAddGroup.Red.Step : List (α × Bool) → List (α × Bool) → Prop
@@ -68,7 +67,7 @@ inductive FreeAddGroup.Red.Step : List (α × Bool) → List (α × Bool) → Pr
 attribute [simp] FreeAddGroup.Red.Step.not
 
 /-- Reduction step for the multiplicative free group relation: `w * x * x⁻¹ * v ~> w * v` -/
-@[to_additive FreeAddGroup.Red.Step]
+@[to_additive]
 inductive FreeGroup.Red.Step : List (α × Bool) → List (α × Bool) → Prop
   | not {L₁ L₂ x b} : FreeGroup.Red.Step (L₁ ++ (x, b) :: (x, not b) :: L₂) (L₁ ++ L₂)
 
@@ -79,7 +78,7 @@ namespace FreeGroup
 variable {L L₁ L₂ L₃ L₄ : List (α × Bool)}
 
 /-- Reflexive-transitive closure of `Red.Step` -/
-@[to_additive FreeAddGroup.Red /-- Reflexive-transitive closure of `Red.Step` -/]
+@[to_additive /-- Reflexive-transitive closure of `Red.Step` -/]
 def Red : List (α × Bool) → List (α × Bool) → Prop :=
   ReflTransGen Red.Step
 
@@ -354,18 +353,18 @@ theorem antisymm (h₁₂ : Red L₁ L₂) (h₂₁ : Red L₂ L₁) : L₁ = L�
 
 end Red
 
-@[to_additive FreeAddGroup.equivalence_join_red]
+@[to_additive]
 theorem equivalence_join_red : Equivalence (Join (@Red α)) :=
   equivalence_join_reflTransGen fun _ b c hab hac =>
     match b, c, Red.Step.diamond hab hac rfl with
     | b, _, Or.inl rfl => ⟨b, by rfl, by rfl⟩
     | _, _, Or.inr ⟨d, hbd, hcd⟩ => ⟨d, ReflGen.single hbd, ReflTransGen.single hcd⟩
 
-@[to_additive FreeAddGroup.join_red_of_step]
+@[to_additive]
 theorem join_red_of_step (h : Red.Step L₁ L₂) : Join Red L₁ L₂ :=
   join_of_single reflexive_reflTransGen h.to_red
 
-@[to_additive FreeAddGroup.eqvGen_step_iff_join_red]
+@[to_additive]
 theorem eqvGen_step_iff_join_red : EqvGen Red.Step L₁ L₂ ↔ Join Red L₁ L₂ :=
   Iff.intro
     (fun h =>
@@ -378,7 +377,7 @@ theorem eqvGen_step_iff_join_red : EqvGen Red.Step L₁ L₂ ↔ Join Red L₁ L
 
 /-- Predicate asserting that the word `L` admits no reduction steps, i.e., no two neighboring
 elements of the word cancel. -/
-@[to_additive FreeAddGroup.IsReduced /-- Predicate asserting the word `L` admits no reduction steps,
+@[to_additive /-- Predicate asserting the word `L` admits no reduction steps,
 i.e., no two neighboring elements of the word cancel. -/]
 def IsReduced (L : List (α × Bool)) : Prop := L.Chain' fun a b ↦ a.1 = b.1 → a.2 = b.2
 
@@ -392,7 +391,7 @@ theorem IsReduced.nil : IsReduced ([] : List (α × Bool)) := chain'_nil
 @[to_additive (attr := simp)]
 theorem IsReduced.singleton {a : α × Bool} : IsReduced [a] := chain'_singleton a
 
-@[to_additive (attr := simp) FreeAddGroup.isReduced_cons_cons]
+@[to_additive (attr := simp)]
 theorem isReduced_cons_cons {a b : (α × Bool)} :
     IsReduced (a :: b :: L) ↔ (a.1 = b.1 → a.2 = b.2) ∧ IsReduced (b :: L) := chain'_cons_cons
 
@@ -415,7 +414,7 @@ lemma IsReduced.of_forall_not_step :
     rintro rfl
     exact hL₁ L₁ <| .not (L₁ := [])
 
-@[to_additive FreeAddGroup.isReduced_iff_not_step]
+@[to_additive]
 theorem isReduced_iff_not_step : IsReduced L₁ ↔ ∀ L₂, ¬ Red.Step L₁ L₂ where
   mp h _ := h.not_step
   mpr := .of_forall_not_step

--- a/Mathlib/GroupTheory/FreeGroup/NielsenSchreier.lean
+++ b/Mathlib/GroupTheory/FreeGroup/NielsenSchreier.lean
@@ -52,8 +52,6 @@ noncomputable section
 
 universe v u
 
-/- Porting note: ./././Mathport/Syntax/Translate/Command.lean:229:11:unsupported:
-unusual advanced open style -/
 open CategoryTheory CategoryTheory.ActionCategory CategoryTheory.SingleObj Quiver FreeGroup
 
 /-- `IsFreeGroupoid.Generators G` is a type synonym for `G`. We think of this as
@@ -153,7 +151,6 @@ private def root' : G :=
 -- this has to be marked noncomputable, see issue https://github.com/leanprover-community/mathlib4/pull/451.
 -- It might be nicer to define this in terms of `composePath`
 /-- A path in the tree gives a hom, by composition. -/
--- Porting note: removed noncomputable. This is already declared at the beginning of the section.
 def homOfPath : ∀ {a : G}, Path (root T) a → (root' T ⟶ a)
   | _, Path.nil => 𝟙 _
   | _, Path.cons p f => homOfPath p ≫ Sum.recOn f.val (fun e => of e) fun e => inv (of e)

--- a/Mathlib/GroupTheory/GroupAction/Hom.lean
+++ b/Mathlib/GroupTheory/GroupAction/Hom.lean
@@ -84,8 +84,6 @@ structure MulActionHom where
   /-- The proposition that the function commutes with the actions. -/
   protected map_smul' : ∀ (m : M) (x : X), toFun (m • x) = (φ m) • toFun x
 
-/- Porting note: local notation given a name, conflict with Algebra.Hom.GroupAction
-see https://github.com/leanprover/lean4/issues/2000 -/
 /-- `φ`-equivariant functions `X → Y`,
 where `φ : M → N`, where `M` and `N` act on `X` and `Y` respectively. -/
 notation:25 (name := «MulActionHomLocal≺») X " →ₑ[" φ:25 "] " Y:0 => MulActionHom φ X Y
@@ -567,8 +565,6 @@ add_decl_doc DistribMulActionHom.toAddMonoidHom
 /-- Reinterpret an equivariant additive monoid homomorphism as an equivariant function. -/
 add_decl_doc DistribMulActionHom.toMulActionHom
 
-/- Porting note: local notation given a name, conflict with Algebra.Hom.Freiman
-see https://github.com/leanprover/lean4/issues/2000 -/
 @[inherit_doc]
 notation:25 (name := «DistribMulActionHomLocal≺»)
   A " →ₑ+[" φ:25 "] " B:0 => DistribMulActionHom φ A B
@@ -782,8 +778,6 @@ add_decl_doc MulSemiringActionHom.toRingHom
 /-- Reinterpret an equivariant ring homomorphism as an equivariant additive monoid homomorphism. -/
 add_decl_doc MulSemiringActionHom.toDistribMulActionHom
 
-/- Porting note: local notation given a name, conflict with Algebra.Hom.Freiman
-see https://github.com/leanprover/lean4/issues/2000 -/
 @[inherit_doc]
 notation:25 (name := «MulSemiringActionHomLocal≺»)
   R " →ₑ+*[" φ:25 "] " S:0 => MulSemiringActionHom φ R S

--- a/Mathlib/GroupTheory/GroupAction/SubMulAction.lean
+++ b/Mathlib/GroupTheory/GroupAction/SubMulAction.lean
@@ -102,14 +102,10 @@ instance instSMulCommClass [Mul M] [MulMemClass S M] [SMulCommClass R M M]
     (s : S) : SMulCommClass R s s where
   smul_comm r x y := Subtype.ext <| smul_comm r (x : M) (y : M)
 
--- Porting note (https://github.com/leanprover-community/mathlib4/issues/11215): TODO lower priority not actually there
--- lower priority so later simp lemmas are used first; to appease simp_nf
 @[to_additive (attr := simp, norm_cast)]
 protected theorem val_smul (r : R) (x : s) : (↑(r • x) : M) = r • (x : M) :=
   rfl
 
--- Porting note (https://github.com/leanprover-community/mathlib4/issues/11215): TODO lower priority not actually there
--- lower priority so later simp lemmas are used first; to appease simp_nf
 @[to_additive (attr := simp)]
 theorem mk_smul_mk (r : R) (x : M) (hx : x ∈ s) : r • (⟨x, hx⟩ : s) = ⟨r • x, smul_mem r hx⟩ :=
   rfl

--- a/Mathlib/GroupTheory/Index.lean
+++ b/Mathlib/GroupTheory/Index.lean
@@ -594,10 +594,9 @@ theorem finiteIndex_of_finite_quotient [Finite (G ⧸ H)] : FiniteIndex H :=
 theorem finiteIndex_iff_finite_quotient : FiniteIndex H ↔ Finite (G ⧸ H) :=
   ⟨fun _ ↦ inferInstance, fun _ ↦ finiteIndex_of_finite_quotient⟩
 
--- Porting note: had to manually provide finite instance for quotient when it should be automatic
 @[to_additive]
 instance (priority := 100) finiteIndex_of_finite [Finite G] : FiniteIndex H :=
-  @finiteIndex_of_finite_quotient _ _ H (Quotient.finite _)
+  finiteIndex_of_finite_quotient
 
 variable (H) in
 @[to_additive]

--- a/Mathlib/GroupTheory/MonoidLocalization/Basic.lean
+++ b/Mathlib/GroupTheory/MonoidLocalization/Basic.lean
@@ -114,16 +114,15 @@ end Submonoid
 
 namespace Localization
 
--- Porting note: this does not work so it is done explicitly instead
--- run_cmd to_additive.map_namespace `Localization `AddLocalization
--- run_cmd Elab.Command.liftCoreM <| ToAdditive.insertTranslation `Localization `AddLocalization
+-- See https://leanprover.zulipchat.com/#narrow/stream/287929-mathlib4/topic/.E2.9C.94.20to_additive.2Emap_namespace
+run_cmd Lean.Elab.Command.liftCoreM <| ToAdditive.insertTranslation `Localization `AddLocalization
 
 /-- The congruence relation on `M × S`, `M` a `CommMonoid` and `S` a submonoid of `M`, whose
 quotient is the localization of `M` at `S`, defined as the unique congruence relation on
 `M × S` such that for any other congruence relation `s` on `M × S` where for all `y ∈ S`,
 `(1, 1) ∼ (y, y)` under `s`, we have that `(x₁, y₁) ∼ (x₂, y₂)` by `r` implies
 `(x₁, y₁) ∼ (x₂, y₂)` by `s`. -/
-@[to_additive AddLocalization.r
+@[to_additive
 /-- The congruence relation on `M × S`, `M` an `AddCommMonoid` and `S` an `AddSubmonoid` of `M`,
 whose quotient is the localization of `M` at `S`, defined as the unique congruence relation on
 `M × S` such that for any other congruence relation `s` on `M × S` where for all `y ∈ S`,
@@ -134,7 +133,7 @@ def r (S : Submonoid M) : Con (M × S) :=
 
 /-- An alternate form of the congruence relation on `M × S`, `M` a `CommMonoid` and `S` a
 submonoid of `M`, whose quotient is the localization of `M` at `S`. -/
-@[to_additive AddLocalization.r'
+@[to_additive
 /-- An alternate form of the congruence relation on `M × S`, `M` a `CommMonoid` and `S` a
 submonoid of `M`, whose quotient is the localization of `M` at `S`. -/]
 def r' : Con (M × S) := by
@@ -159,7 +158,7 @@ def r' : Con (M × S) := by
 /-- The congruence relation used to localize a `CommMonoid` at a submonoid can be expressed
 equivalently as an infimum (see `Localization.r`) or explicitly
 (see `Localization.r'`). -/
-@[to_additive AddLocalization.r_eq_r'
+@[to_additive
 /-- The additive congruence relation used to localize an `AddCommMonoid` at a submonoid can be
 expressed equivalently as an infimum (see `AddLocalization.r`) or explicitly
 (see `AddLocalization.r'`). -/]
@@ -174,11 +173,11 @@ theorem r_eq_r' : r S = r' S :=
 
 variable {S}
 
-@[to_additive AddLocalization.r_iff_exists]
+@[to_additive]
 theorem r_iff_exists {x y : M × S} : r S x y ↔ ∃ c : S, ↑c * (↑y.2 * x.1) = c * (x.2 * y.1) := by
   simp only [r_eq_r' S, r', Con.rel_mk]
 
-@[to_additive AddLocalization.r_iff_oreEqv_r]
+@[to_additive]
 theorem r_iff_oreEqv_r {x y : M × S} : r S x y ↔ (OreLocalization.oreEqv S M).r x y := by
   simp only [r_iff_exists, Subtype.exists, exists_prop, OreLocalization.oreEqv, smul_eq_mul,
     Submonoid.mk_smul]

--- a/Mathlib/GroupTheory/OrderOfElement.lean
+++ b/Mathlib/GroupTheory/OrderOfElement.lean
@@ -47,10 +47,9 @@ variable [Monoid G] {a b x y : G} {n m : ℕ}
 
 section IsOfFinOrder
 
--- Porting note (https://github.com/leanprover-community/mathlib4/issues/12129): additional beta reduction needed
 @[to_additive]
 theorem isPeriodicPt_mul_iff_pow_eq_one (x : G) : IsPeriodicPt (x * ·) n 1 ↔ x ^ n = 1 := by
-  rw [IsPeriodicPt, IsFixedPt, mul_left_iterate]; beta_reduce; rw [mul_one]
+  rw [IsPeriodicPt, IsFixedPt, mul_left_iterate_apply_one]
 
 /-- `IsOfFinOrder` is a predicate on an element `x` of a monoid to be of finite order, i.e. there
 exists `n ≥ 1` such that `x ^ n = 1`. -/
@@ -181,8 +180,7 @@ protected lemma IsOfFinOrder.orderOf_pos (h : IsOfFinOrder x) : 0 < orderOf x :=
 @[to_additive addOrderOf_nsmul_eq_zero]
 theorem pow_orderOf_eq_one (x : G) : x ^ orderOf x = 1 := by
   convert Eq.trans _ (isPeriodicPt_minimalPeriod (x * ·) 1)
-  -- Porting note (https://github.com/leanprover-community/mathlib4/issues/12129): additional beta reduction needed in the middle of the rewrite
-  rw [orderOf, mul_left_iterate]; beta_reduce; rw [mul_one]
+  rw [orderOf, mul_left_iterate_apply_one]
 
 @[to_additive]
 theorem orderOf_eq_zero (h : ¬IsOfFinOrder x) : orderOf x = 0 := by
@@ -266,7 +264,7 @@ theorem orderOf_pow_dvd (n : ℕ) : orderOf (x ^ n) ∣ orderOf x := by
 
 @[to_additive]
 lemma pow_injOn_Iio_orderOf : (Set.Iio <| orderOf x).InjOn (x ^ ·) := by
-  simpa only [mul_left_iterate, mul_one]
+  simpa only [mul_left_iterate_apply_one]
     using iterate_injOn_Iio_minimalPeriod (f := (x * ·)) (x := 1)
 
 @[to_additive]

--- a/Mathlib/GroupTheory/QuotientGroup/Basic.lean
+++ b/Mathlib/GroupTheory/QuotientGroup/Basic.lean
@@ -278,9 +278,6 @@ noncomputable def quotientInfEquivProdNormalizerQuotient (H N : Subgroup G)
       rw [coe_mul_of_left_le_normalizer_right H N hLE] at hy
       rcases hy with ⟨h, hh, n, hn, rfl⟩
       use ⟨h, hh⟩
-      let _ : Setoid ↑(H ⊔ N) :=
-        (@leftRel ↑(H ⊔ N) (H ⊔ N : Subgroup G).toGroup (N.subgroupOf (H ⊔ N)))
-      -- Porting note: Lean couldn't find this automatically
       refine Quotient.eq.mpr ?_
       change leftRel _ _ _
       rw [leftRel_apply]

--- a/Mathlib/GroupTheory/SemidirectProduct.lean
+++ b/Mathlib/GroupTheory/SemidirectProduct.lean
@@ -46,8 +46,7 @@ structure SemidirectProduct (φ : G →* MulAut N) where
   right : G
   deriving DecidableEq
 
--- Porting note: unknown attribute
--- attribute [pp_using_anonymous_constructor] SemidirectProduct
+attribute [pp_using_anonymous_constructor] SemidirectProduct
 
 @[inherit_doc]
 notation:35 N " ⋊[" φ:35 "] " G:35 => SemidirectProduct N G φ

--- a/Mathlib/GroupTheory/SpecificGroups/Alternating.lean
+++ b/Mathlib/GroupTheory/SpecificGroups/Alternating.lean
@@ -274,7 +274,7 @@ theorem normalClosure_finRotate_five : normalClosure ({⟨finRotate 5,
         (⟨finRotate 5, finRotate_bit1_mem_alternatingGroup (n := 2)⟩ : alternatingGroup (Fin 5)) ∈
           normalClosure _ :=
         SetLike.mem_coe.1 (subset_normalClosure (Set.mem_singleton _))
-      -- Porting note: added `:` to help the elaborator
+      -- Porting note: added `:` to help the elaborator (otherwise we get a timeout)
       exact (mul_mem (Subgroup.normalClosure_normal.conj_mem _ h
         ⟨Fin.cycleRange 2, Fin.isThreeCycle_cycleRange_two.mem_alternatingGroup⟩) (inv_mem h) :))
 

--- a/Mathlib/GroupTheory/Subsemigroup/Center.lean
+++ b/Mathlib/GroupTheory/Subsemigroup/Center.lean
@@ -40,8 +40,6 @@ def center : Subsemigroup M where
   carrier := Set.center M
   mul_mem' := Set.mul_mem_center
 
--- Porting note: `coe_center` is now redundant
-
 variable {M}
 
 /-- The center of a magma is commutative and associative. -/


### PR DESCRIPTION
Go through and fix the porting notes in the GroupTheory folder that have an obvious fix.


---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include at least one commit authored by each
co-author among the commits in the pull request. If necessary, you may 
create empty commits to indicate co-authorship, using commands like so:

git commit --author="Author Name <author@email.com>" --allow-empty -m "add Author Name as coauthor"

When merging, all the commits will be squashed into a single commit listing all co-authors.

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
