### PR TITLE
[Merged by Bors] - feat(GroupTheory/Finiteness): `Submonoid.FG`, `Subgroup.FG` on supremums

### DIFF
--- a/Mathlib/GroupTheory/Finiteness.lean
+++ b/Mathlib/GroupTheory/Finiteness.lean
@@ -70,6 +70,33 @@ theorem AddSubmonoid.fg_iff_mul_fg {M : Type*} [AddMonoid M] (P : AddSubmonoid M
     P.FG ↔ P.toSubmonoid.FG := by
   convert (Submonoid.fg_iff_add_fg (toSubmonoid P)).symm
 
+@[to_additive]
+theorem Submonoid.FG.bot : FG (⊥ : Submonoid M) :=
+  ⟨∅, by simp⟩
+
+@[to_additive]
+theorem Submonoid.FG.sup {Q : Submonoid M} (hP : P.FG) (hQ : Q.FG) : (P ⊔ Q).FG := by
+  classical
+  rcases hP with ⟨s, rfl⟩
+  rcases hQ with ⟨t, rfl⟩
+  exact ⟨s ∪ t, by simp [closure_union]⟩
+
+@[to_additive]
+theorem Submonoid.FG.finset_sup {ι : Type*} (s : Finset ι) (P : ι → Submonoid M)
+    (hP : ∀ i ∈ s, (P i).FG) : (s.sup P).FG :=
+  Finset.sup_induction bot (fun _ ha _ hb => ha.sup hb) hP
+
+@[to_additive]
+theorem Submonoid.FG.biSup {ι : Type*} (s : Finset ι) (P : ι → Submonoid M)
+    (hP : ∀ i ∈ s, (P i).FG) : (⨆ i ∈ s, P i).FG := by
+  simpa only [Finset.sup_eq_iSup] using finset_sup s P hP
+
+@[to_additive]
+theorem Submonoid.FG.iSup {ι : Sort*} [Finite ι] (P : ι → Submonoid M) (hP : ∀ i, (P i).FG) :
+    (iSup P).FG := by
+  haveI := Fintype.ofFinite (PLift ι)
+  simpa [iSup_plift_down] using biSup Finset.univ (P ∘ PLift.down) fun i _ => hP i.down
+
 /-- The product of two finitely generated submonoids is finitely generated. -/
 @[to_additive prod
 /-- The product of two finitely generated additive submonoids is finitely generated. -/]
@@ -270,6 +297,33 @@ theorem Subgroup.fg_iff_add_fg (P : Subgroup G) : P.FG ↔ P.toAddSubgroup.FG :=
 theorem AddSubgroup.fg_iff_mul_fg (P : AddSubgroup H) : P.FG ↔ P.toSubgroup.FG := by
   rw [AddSubgroup.fg_iff_addSubmonoid_fg, Subgroup.fg_iff_submonoid_fg]
   exact AddSubmonoid.fg_iff_mul_fg (AddSubgroup.toAddSubmonoid P)
+
+@[to_additive]
+theorem Subgroup.FG.bot : FG (⊥ : Subgroup G) :=
+  ⟨∅, by simp⟩
+
+@[to_additive]
+theorem Subgroup.FG.sup {P Q : Subgroup G} (hP : P.FG) (hQ : Q.FG) : (P ⊔ Q).FG := by
+  classical
+  rcases hP with ⟨s, rfl⟩
+  rcases hQ with ⟨t, rfl⟩
+  exact ⟨s ∪ t, by simp [closure_union]⟩
+
+@[to_additive]
+theorem Subgroup.FG.finset_sup {ι : Type*} (s : Finset ι) (P : ι → Subgroup G)
+    (hP : ∀ i ∈ s, (P i).FG) : (s.sup P).FG :=
+  Finset.sup_induction bot (fun _ ha _ hb => ha.sup hb) hP
+
+@[to_additive]
+theorem Subgroup.FG.biSup {ι : Type*} (s : Finset ι) (P : ι → Subgroup G)
+    (hP : ∀ i ∈ s, (P i).FG) : (⨆ i ∈ s, P i).FG := by
+  simpa only [Finset.sup_eq_iSup] using finset_sup s P hP
+
+@[to_additive]
+theorem Subgroup.FG.iSup {ι : Sort*} [Finite ι] (P : ι → Subgroup G) (hP : ∀ i, (P i).FG) :
+    (iSup P).FG := by
+  haveI := Fintype.ofFinite (PLift ι)
+  simpa [iSup_plift_down] using biSup Finset.univ (P ∘ PLift.down) fun i _ => hP i.down
 
 /-- The product of two finitely generated subgroups is finitely generated. -/
 @[to_additive prod


### PR DESCRIPTION
---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include at least one commit authored by each
co-author among the commits in the pull request. If necessary, you may 
create empty commits to indicate co-authorship, using commands like so:

git commit --author="Author Name <author@email.com>" --allow-empty -m "add Author Name as coauthor"

When merging, all the commits will be squashed into a single commit listing all co-authors.

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
