### PR TITLE
[Merged by Bors] - feat(NormNum): add extension for `Nat.ModEq`, `Int.ModEq`

### DIFF
--- a/Mathlib.lean
+++ b/Mathlib.lean
@@ -6069,6 +6069,7 @@ import Mathlib.Tactic.NormNum.Inv
 import Mathlib.Tactic.NormNum.Irrational
 import Mathlib.Tactic.NormNum.IsCoprime
 import Mathlib.Tactic.NormNum.LegendreSymbol
+import Mathlib.Tactic.NormNum.ModEq
 import Mathlib.Tactic.NormNum.NatFactorial
 import Mathlib.Tactic.NormNum.NatFib
 import Mathlib.Tactic.NormNum.NatLog

--- a/Mathlib/Tactic.lean
+++ b/Mathlib/Tactic.lean
@@ -195,6 +195,7 @@ import Mathlib.Tactic.NormNum.Inv
 import Mathlib.Tactic.NormNum.Irrational
 import Mathlib.Tactic.NormNum.IsCoprime
 import Mathlib.Tactic.NormNum.LegendreSymbol
+import Mathlib.Tactic.NormNum.ModEq
 import Mathlib.Tactic.NormNum.NatFactorial
 import Mathlib.Tactic.NormNum.NatFib
 import Mathlib.Tactic.NormNum.NatLog

--- a/Mathlib/Tactic/NormNum/ModEq.lean
+++ b/Mathlib/Tactic/NormNum/ModEq.lean
@@ -17,10 +17,10 @@ namespace Mathlib.Meta.NormNum
 open Qq
 
 /-- `norm_num` extension for `Nat.ModEq`. -/
-@[norm_num Nat.ModEq _ _ _]
+@[norm_num _ ≡ _ [MOD _]]
 def evalNatModEq : NormNumExt where eval {u αP} e := do
   match u, αP, e with
-  | 0, ~q(Prop), ~q(Nat.ModEq $n $a $b) =>
+  | 0, ~q(Prop), ~q($a ≡ $b [MOD $n]) =>
     let ⟨b, pb⟩ ← deriveBoolOfIff _ e q(Nat.modEq_iff_dvd.symm)
     return .ofBoolResult pb
   | _, _, _ => failure

--- a/Mathlib/Tactic/NormNum/ModEq.lean
+++ b/Mathlib/Tactic/NormNum/ModEq.lean
@@ -1,0 +1,37 @@
+/-
+Copyright (c) 2025 Concordance Inc. dba Harmonic. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Yury Kudryashov
+-/
+import Mathlib.Tactic.NormNum.DivMod
+import Mathlib.Data.Int.ModEq
+
+/-!
+# `norm_num` extensions for `Nat.ModEq` and `Int.ModEq`
+
+In this file we define `norm_num` extensions for `a ≡ b [MOD n]` and `a ≡ b [ZMOD n]`.
+-/
+
+namespace Mathlib.Meta.NormNum
+
+open Qq
+
+/-- `norm_num` extension for `Nat.ModEq`. -/
+@[norm_num Nat.ModEq _ _ _]
+def evalNatModEq : NormNumExt where eval {u αP} e := do
+  match u, αP, e with
+  | 0, ~q(Prop), ~q(Nat.ModEq $n $a $b) =>
+    let ⟨b, pb⟩ ← deriveBoolOfIff _ e q(Nat.modEq_iff_dvd.symm)
+    return .ofBoolResult pb
+  | _, _, _ => failure
+
+/-- `norm_num` extension for `Int.ModEq`. -/
+@[norm_num Int.ModEq _ _ _]
+def evalIntModEq : NormNumExt where eval {u αP} e := do
+  match u, αP, e with
+  | 0, ~q(Prop), ~q(Int.ModEq $n $a $b) =>
+    let ⟨b, pb⟩ ← deriveBoolOfIff _ e q(Int.modEq_iff_dvd.symm)
+    return .ofBoolResult pb
+  | _, _, _ => failure
+
+end Mathlib.Meta.NormNum

--- a/Mathlib/Tactic/NormNum/ModEq.lean
+++ b/Mathlib/Tactic/NormNum/ModEq.lean
@@ -26,10 +26,10 @@ def evalNatModEq : NormNumExt where eval {u αP} e := do
   | _, _, _ => failure
 
 /-- `norm_num` extension for `Int.ModEq`. -/
-@[norm_num Int.ModEq _ _ _]
+@[norm_num _ ≡ _ [ZMOD _]]
 def evalIntModEq : NormNumExt where eval {u αP} e := do
   match u, αP, e with
-  | 0, ~q(Prop), ~q(Int.ModEq $n $a $b) =>
+  | 0, ~q(Prop), ~q($a ≡ $b [ZMOD $n]) =>
     let ⟨b, pb⟩ ← deriveBoolOfIff _ e q(Int.modEq_iff_dvd.symm)
     return .ofBoolResult pb
   | _, _, _ => failure

--- a/MathlibTest/norm_num_ext.lean
+++ b/MathlibTest/norm_num_ext.lean
@@ -481,10 +481,16 @@ example : ¬ (553105253 : ℤ) ∣ 553105253 * 776531401 + 1 := by norm_num1
 
 example : 10 ≡ 7 [MOD 3] := by norm_num1
 example : ¬ (10 ≡ 7 [MOD 5]) := by norm_num1
+
 example : 10 ≡ 7 [ZMOD 3] := by norm_num1
 example : ¬ (10 ≡ 7 [ZMOD 5]) := by norm_num1
 example : -3 ≡ 7 [ZMOD 5] := by norm_num1
 example : ¬ (-3 ≡ 7 [ZMOD 50]) := by norm_num1
+
+example : 10 ≡ 7 [ZMOD -3] := by norm_num1
+example : ¬ (10 ≡ 7 [ZMOD -5]) := by norm_num1
+example : -3 ≡ 7 [ZMOD -5] := by norm_num1
+example : ¬ (-3 ≡ 7 [ZMOD -50]) := by norm_num1
 
 end mod
 

--- a/MathlibTest/norm_num_ext.lean
+++ b/MathlibTest/norm_num_ext.lean
@@ -7,6 +7,7 @@ import Mathlib.Tactic.NormNum.BigOperators
 import Mathlib.Tactic.NormNum.GCD
 import Mathlib.Tactic.NormNum.IsCoprime
 import Mathlib.Tactic.NormNum.DivMod
+import Mathlib.Tactic.NormNum.ModEq
 import Mathlib.Tactic.NormNum.NatFactorial
 import Mathlib.Tactic.NormNum.NatFib
 import Mathlib.Tactic.NormNum.NatLog
@@ -477,6 +478,13 @@ example : (2 : ℤ) ∣ 4 := by norm_num1
 example : ¬ (2 : ℤ) ∣ 5 := by norm_num1
 example : (553105253 : ℤ) ∣ 553105253 * 776531401 := by norm_num1
 example : ¬ (553105253 : ℤ) ∣ 553105253 * 776531401 + 1 := by norm_num1
+
+example : 10 ≡ 7 [MOD 3] := by norm_num1
+example : ¬ (10 ≡ 7 [MOD 5]) := by norm_num1
+example : 10 ≡ 7 [ZMOD 3] := by norm_num1
+example : ¬ (10 ≡ 7 [ZMOD 5]) := by norm_num1
+example : -3 ≡ 7 [ZMOD 5] := by norm_num1
+example : ¬ (-3 ≡ 7 [ZMOD 50]) := by norm_num1
 
 end mod
 

--- a/scripts/noshake.json
+++ b/scripts/noshake.json
@@ -43,7 +43,6 @@
   "Mathlib.Data.Finsupp.Notation",
   "Mathlib.Data.Int.Defs",
   "Mathlib.Data.Int.Notation",
-  "Mathlib.LinearAlgebra.Matrix.Notation",
   "Mathlib.Data.Matroid.Init",
   "Mathlib.Data.Nat.Notation",
   "Mathlib.Data.Rat.Init",
@@ -53,6 +52,7 @@
   "Mathlib.Geometry.Manifold.Instances.Real",
   "Mathlib.Init",
   "Mathlib.LinearAlgebra.AffineSpace.Basic",
+  "Mathlib.LinearAlgebra.Matrix.Notation",
   "Mathlib.Mathport.Attributes",
   "Mathlib.Mathport.Notation",
   "Mathlib.Mathport.Rename",
@@ -254,6 +254,8 @@
    "Mathlib.Data.PNat.Defs"],
   "Mathlib.Tactic.Order.CollectFacts":
   ["Mathlib.Order.BoundedOrder.Basic", "Mathlib.Order.Lattice"],
+  "Mathlib.Tactic.NormNum.ModEq":
+  ["Mathlib.Data.Int.ModEq", "Mathlib.Tactic.NormNum.DivMod"],
   "Mathlib.Tactic.NormNum.Ineq":
   ["Mathlib.Algebra.Order.Field.Defs", "Mathlib.Algebra.Order.Monoid.WithTop"],
   "Mathlib.Tactic.NormNum.BigOperators":


### PR DESCRIPTION
---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include at least one commit authored by each
co-author among the commits in the pull request. If necessary, you may 
create empty commits to indicate co-authorship, using commands like so:

git commit --author="Author Name <author@email.com>" --allow-empty -m "add Author Name as coauthor"

When merging, all the commits will be squashed into a single commit listing all co-authors.

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
