### PR TITLE
chore(Data/NNReal): change `NNReal` from a `def` to an `abbrev`

### DIFF
--- a/Mathlib/Analysis/BoxIntegral/Basic.lean
+++ b/Mathlib/Analysis/BoxIntegral/Basic.lean
@@ -182,7 +182,7 @@ theorem hasIntegral_iff : HasIntegral I l f vol y ↔
     ∀ ε > (0 : ℝ), ∃ r : ℝ≥0 → ℝⁿ → Ioi (0 : ℝ), (∀ c, l.RCond (r c)) ∧
       ∀ c π, l.MemBaseSet I c (r c) π → IsPartition π → dist (integralSum f vol π) y ≤ ε :=
   ((l.hasBasis_toFilteriUnion_top I).tendsto_iff nhds_basis_closedBall).trans <| by
-    simp [@forall_swap ℝ≥0 (TaggedPrepartition I)]
+    simp [-Subtype.forall, -Subtype.exists, @forall_swap ℝ≥0 (TaggedPrepartition I)]
 
 /-- Quite often it is more natural to prove an estimate of the form `a * ε`, not `ε` in the RHS of
 `BoxIntegral.hasIntegral_iff`, so we provide this auxiliary lemma. -/

--- a/Mathlib/Analysis/CStarAlgebra/ContinuousFunctionalCalculus/Order.lean
+++ b/Mathlib/Analysis/CStarAlgebra/ContinuousFunctionalCalculus/Order.lean
@@ -123,7 +123,7 @@ lemma cfc_nnreal_le_iff {A : Type*} [TopologicalSpace A] [Ring A] [StarRing A] [
   have hf' := hf.ofReal_map_toNNReal <| ha_spec.image ▸ Set.mapsTo_image ..
   have hg' := hg.ofReal_map_toNNReal <| ha_spec.image ▸ Set.mapsTo_image ..
   rw [cfc_nnreal_eq_real, cfc_nnreal_eq_real, cfc_le_iff ..]
-  simp [NNReal.coe_le_coe, ← ha_spec.image]
+  simp [← ha_spec.image]
 
 open ContinuousFunctionalCalculus in
 /-- In a unital `ℝ`-algebra `A` with a continuous functional calculus, an element `a : A` is larger

--- a/Mathlib/Analysis/CStarAlgebra/ContinuousFunctionalCalculus/Unique.lean
+++ b/Mathlib/Analysis/CStarAlgebra/ContinuousFunctionalCalculus/Unique.lean
@@ -175,14 +175,15 @@ instance NNReal.instContinuousMap.UniqueHom [T2Space A] :
     let s' : Set ℝ := (↑) '' s
     let e : s ≃ₜ s' :=
       { toFun := Subtype.map (↑) (by simp [s'])
-        invFun := Subtype.map Real.toNNReal (by simp [s'])
+        invFun := Subtype.map Real.toNNReal (by simp [s', -Subtype.exists, -Subtype.forall])
         left_inv := fun _ ↦ by ext; simp
         right_inv := fun x ↦ by
           ext
           obtain ⟨y, -, hy⟩ := x.2
           simpa using hy ▸ NNReal.coe_nonneg y
         continuous_toFun := continuous_coe.subtype_map (by simp [s'])
-        continuous_invFun := continuous_real_toNNReal.subtype_map (by simp [s']) }
+        continuous_invFun := continuous_real_toNNReal.subtype_map
+          (by simp [s', -Subtype.exists, -Subtype.forall]) }
     have (ξ : C(s, ℝ≥0) →⋆ₐ[ℝ≥0] A) (hξ : Continuous ξ) :
         (let ξ' := ξ.realContinuousMapOfNNReal.comp <| ContinuousMap.compStarAlgHom' ℝ ℝ e
         Continuous ξ' ∧ ξ' (.restrict s' <| .id ℝ) = ξ (.restrict s <| .id ℝ≥0)) := by
@@ -255,9 +256,9 @@ lemma toContinuousMapHom_toNNReal (f : C(X, ℝ)₀) :
 lemma toNNReal_smul (r : ℝ≥0) (f : C(X, ℝ)₀) : (r • f).toNNReal = r • f.toNNReal := by
   ext x
   by_cases h : 0 ≤ f x
-  · simpa [max_eq_left h, NNReal.smul_def] using mul_nonneg r.coe_nonneg h
+  · simpa [max_eq_left h, NNReal.smul_def, -Nonneg.coe_smul] using mul_nonneg r.coe_nonneg h
   · push_neg at h
-    simpa [max_eq_right h.le, NNReal.smul_def]
+    simpa [max_eq_right h.le, NNReal.smul_def, -Nonneg.coe_smul]
       using mul_nonpos_of_nonneg_of_nonpos r.coe_nonneg h.le
 
 @[simp]
@@ -364,14 +365,15 @@ instance NNReal.instContinuousMapZero.UniqueHom
     let s' : Set ℝ := (↑) '' s
     let e : s ≃ₜ s' :=
       { toFun := Subtype.map (↑) (by simp [s'])
-        invFun := Subtype.map Real.toNNReal (by simp [s'])
+        invFun := Subtype.map Real.toNNReal (by simp [s', -Subtype.exists, -Subtype.forall])
         left_inv := fun _ ↦ by ext; simp
         right_inv := fun x ↦ by
           ext
           obtain ⟨y, -, hy⟩ := x.2
           simpa using hy ▸ NNReal.coe_nonneg y
         continuous_toFun := continuous_coe.subtype_map (by simp [s'])
-        continuous_invFun := continuous_real_toNNReal.subtype_map (by simp [s']) }
+        continuous_invFun := continuous_real_toNNReal.subtype_map
+          (by simp [s', -Subtype.exists, -Subtype.forall]) }
     let _inst₁ : Zero s' := ⟨0, ⟨0, h0 ▸ Subtype.property (0 : s), coe_zero⟩⟩
     have h0' : ((0 : s') : ℝ) = 0 := rfl
     have e0 : e 0 = 0 := by ext; simp [e, h0, h0']

--- a/Mathlib/Analysis/FunctionalSpaces/SobolevInequality.lean
+++ b/Mathlib/Analysis/FunctionalSpaces/SobolevInequality.lean
@@ -680,9 +680,7 @@ theorem eLpNorm_le_eLpNorm_fderiv_of_le [FiniteDimensional ℝ F]
         convert eLpNorm_le_eLpNorm_mul_rpow_measure_univ this hu.continuous.aestronglyMeasurable
         rw [ENNReal.coe_rpow_of_nonneg]
         · simp [ENNReal.coe_toNNReal hs.measure_lt_top.ne]
-        · rw [one_div, one_div]
-          norm_cast
-          rw [hp']
+        · rw [one_div, one_div, ← NNReal.coe_inv, ← NNReal.coe_inv, hp']
           simpa using hpq
     _ = eLpNorm u p' μ * t := by rw [eLpNorm_restrict_eq_of_support_subset h2u]
     _ ≤ (C * eLpNorm (fderiv ℝ u) p μ) * t := by

--- a/Mathlib/Analysis/Normed/Algebra/Spectrum.lean
+++ b/Mathlib/Analysis/Normed/Algebra/Spectrum.lean
@@ -798,22 +798,22 @@ lemma real_iff [Algebra ℂ A] {a : A} :
 lemma nnreal_le_iff [Algebra ℝ A] {a : A}
     (ha : SpectrumRestricts a ContinuousMap.realToNNReal) {r : ℝ≥0} :
     (∀ x ∈ spectrum ℝ≥0 a, r ≤ x) ↔ ∀ x ∈ spectrum ℝ a, r ≤ x := by
-  simp [← ha.algebraMap_image]
+  simp [← ha.algebraMap_image, -Subtype.forall, -Subtype.exists]
 
 lemma nnreal_lt_iff [Algebra ℝ A] {a : A}
     (ha : SpectrumRestricts a ContinuousMap.realToNNReal) {r : ℝ≥0} :
     (∀ x ∈ spectrum ℝ≥0 a, r < x) ↔ ∀ x ∈ spectrum ℝ a, r < x := by
-  simp [← ha.algebraMap_image]
+  simp [← ha.algebraMap_image, -Subtype.forall, -Subtype.exists]
 
 lemma le_nnreal_iff [Algebra ℝ A] {a : A}
     (ha : SpectrumRestricts a ContinuousMap.realToNNReal) {r : ℝ≥0} :
     (∀ x ∈ spectrum ℝ≥0 a, x ≤ r) ↔ ∀ x ∈ spectrum ℝ a, x ≤ r := by
-  simp [← ha.algebraMap_image]
+  simp [← ha.algebraMap_image, -Subtype.forall, -Subtype.exists]
 
 lemma lt_nnreal_iff [Algebra ℝ A] {a : A}
     (ha : SpectrumRestricts a ContinuousMap.realToNNReal) {r : ℝ≥0} :
     (∀ x ∈ spectrum ℝ≥0 a, x < r) ↔ ∀ x ∈ spectrum ℝ a, x < r := by
-  simp [← ha.algebraMap_image]
+  simp [← ha.algebraMap_image, -Subtype.forall, -Subtype.exists]
 
 lemma nnreal_iff_spectralRadius_le [Algebra ℝ A] {a : A} {t : ℝ≥0} (ht : spectralRadius ℝ a ≤ t) :
     SpectrumRestricts a ContinuousMap.realToNNReal ↔
@@ -895,12 +895,12 @@ lemma real_iff [Module ℂ A] [IsScalarTower ℂ A A] [SMulCommClass ℂ A A] {a
 lemma le_nnreal_iff [Module ℝ A] [IsScalarTower ℝ A A] [SMulCommClass ℝ A A] {a : A}
     (ha : QuasispectrumRestricts a ContinuousMap.realToNNReal) {r : ℝ≥0} :
     (∀ x ∈ quasispectrum ℝ≥0 a, x ≤ r) ↔ ∀ x ∈ quasispectrum ℝ a, x ≤ r := by
-  simp [← ha.algebraMap_image]
+  simp [← ha.algebraMap_image, -Subtype.forall, -Subtype.exists]
 
 lemma lt_nnreal_iff [Module ℝ A] [IsScalarTower ℝ A A] [SMulCommClass ℝ A A] {a : A}
     (ha : QuasispectrumRestricts a ContinuousMap.realToNNReal) {r : ℝ≥0} :
     (∀ x ∈ quasispectrum ℝ≥0 a, x < r) ↔ ∀ x ∈ quasispectrum ℝ a, x < r := by
-  simp [← ha.algebraMap_image]
+  simp [← ha.algebraMap_image, -Subtype.forall, -Subtype.exists]
 
 end QuasispectrumRestricts
 

--- a/Mathlib/Analysis/ODE/PicardLindelof.lean
+++ b/Mathlib/Analysis/ODE/PicardLindelof.lean
@@ -452,7 +452,7 @@ lemma exists_forall_closedBall_funSpace_dist_le_mul [CompleteSpace E]
     apply Filter.Tendsto.mul_const
     apply Filter.Tendsto.const_mul
     convert hasSum_geometric_of_lt_one C.2 (h y hy).1 |>.tendsto_sum_nat
-    simp [NNReal.coe_sub <| le_of_lt (h y hy).1, NNReal.coe_one]
+    simp [NNReal.coe_sub <| le_of_lt (h y hy).1]
 
 end
 

--- a/Mathlib/Analysis/Seminorm.lean
+++ b/Mathlib/Analysis/Seminorm.lean
@@ -785,13 +785,13 @@ theorem ball_finset_sup_eq_iInter (p : ι → Seminorm 𝕜 E) (s : Finset ι) (
     (hr : 0 < r) : ball (s.sup p) x r = ⋂ i ∈ s, ball (p i) x r := by
   lift r to NNReal using hr.le
   simp_rw [ball, iInter_setOf, finset_sup_apply, NNReal.coe_lt_coe,
-    Finset.sup_lt_iff (show ⊥ < r from hr), ← NNReal.coe_lt_coe, NNReal.coe_mk]
+    Finset.sup_lt_iff (show ⊥ < r from hr), ← NNReal.coe_lt_coe]
 
 theorem closedBall_finset_sup_eq_iInter (p : ι → Seminorm 𝕜 E) (s : Finset ι) (x : E) {r : ℝ}
     (hr : 0 ≤ r) : closedBall (s.sup p) x r = ⋂ i ∈ s, closedBall (p i) x r := by
   lift r to NNReal using hr
   simp_rw [closedBall, iInter_setOf, finset_sup_apply, NNReal.coe_le_coe, Finset.sup_le_iff, ←
-    NNReal.coe_le_coe, NNReal.coe_mk]
+    NNReal.coe_le_coe]
 
 theorem ball_finset_sup (p : ι → Seminorm 𝕜 E) (s : Finset ι) (x : E) {r : ℝ} (hr : 0 < r) :
     ball (s.sup p) x r = s.inf fun i => ball (p i) x r := by

--- a/Mathlib/Analysis/SpecificLimits/Basic.lean
+++ b/Mathlib/Analysis/SpecificLimits/Basic.lean
@@ -368,7 +368,7 @@ theorem tsum_geometric_two' (a : ℝ) : ∑' n : ℕ, a / 2 / 2 ^ n = a :=
 theorem NNReal.hasSum_geometric {r : ℝ≥0} (hr : r < 1) : HasSum (fun n : ℕ ↦ r ^ n) (1 - r)⁻¹ := by
   apply NNReal.hasSum_coe.1
   push_cast
-  rw [NNReal.coe_sub (le_of_lt hr)]
+  simp only [NNReal.val_eq_coe, NNReal.coe_sub (le_of_lt hr)]
   exact hasSum_geometric_of_lt_one r.coe_nonneg hr
 
 theorem NNReal.summable_geometric {r : ℝ≥0} (hr : r < 1) : Summable fun n : ℕ ↦ r ^ n :=

--- a/Mathlib/Data/NNReal/Defs.lean
+++ b/Mathlib/Data/NNReal/Defs.lean
@@ -51,59 +51,26 @@ open Function
 
 -- to ensure these instances are computable
 /-- Nonnegative real numbers, denoted as `ℝ≥0` within the NNReal namespace -/
-def NNReal := { r : ℝ // 0 ≤ r } deriving
+abbrev NNReal := { r : ℝ // 0 ≤ r } /- deriving
   Zero, One, Semiring, CommMonoidWithZero, CommSemiring,
   PartialOrder, SemilatticeInf, SemilatticeSup, DistribLattice,
-  Nontrivial, Inhabited
+  Nontrivial, Inhabited -/
 
 namespace NNReal
 
 @[inherit_doc] scoped notation "ℝ≥0" => NNReal
 
-instance : CanonicallyOrderedAdd ℝ≥0 := Nonneg.canonicallyOrderedAdd
-instance : NoZeroDivisors ℝ≥0 := Nonneg.noZeroDivisors
-instance instDenselyOrdered : DenselyOrdered ℝ≥0 := Nonneg.instDenselyOrdered
-instance : OrderBot ℝ≥0 := Nonneg.orderBot
-instance instArchimedean : Archimedean ℝ≥0 := Nonneg.instArchimedean
-instance instMulArchimedean : MulArchimedean ℝ≥0 := Nonneg.instMulArchimedean
 instance : Min ℝ≥0 := SemilatticeInf.toMin
 instance : Max ℝ≥0 := SemilatticeSup.toMax
-instance : Sub ℝ≥0 := Nonneg.sub
-instance : OrderedSub ℝ≥0 := Nonneg.orderedSub
 
 -- a computable copy of `Nonneg.instNNRatCast`
 instance : NNRatCast ℝ≥0 where nnratCast r := ⟨r, r.cast_nonneg⟩
-
-noncomputable instance : LinearOrder ℝ≥0 :=
-  Subtype.instLinearOrder _
-
-noncomputable instance : Semifield ℝ≥0 :=
-  Nonneg.semifield
-
-instance : IsOrderedRing ℝ≥0 :=
-  Nonneg.isOrderedRing
-
-instance : IsStrictOrderedRing ℝ≥0 :=
-  Nonneg.isStrictOrderedRing
-
-noncomputable instance : LinearOrderedCommGroupWithZero ℝ≥0 where
-  /- Both `LinearOrderedCommGroupWithZero` and `Semifield` inherit from `CommGroupWithZero`.
-  However, if we project both of them into a `GroupWithZero` and try to unify them
-  at `reducible_and_instances` transparency, then we unfold `instSemifield` into `Nonneg.semifield`
-  which also causes an unfolding of `NNReal` to `{x // 0 ≤ x}`. Those two are (intentionally!)
-  not defeq at `reducible_and_instances`, even though the instances on them are.
-
-  So we either need to copy all the `Nonneg` instances and redefine them specifically for `NNReal`,
-  or we need to avoid the unfold in the unification. The latter has a smaller impact.
-  -/
-  __ := instSemifield.toCommGroupWithZero.toGroupWithZero
-  __ := Nonneg.linearOrderedCommGroupWithZero
 
 example {p q : ℝ≥0} (h1p : 0 < p) (h2p : p ≤ q) : q⁻¹ ≤ p⁻¹ := by
   with_reducible_and_instances exact inv_anti₀ h1p h2p
 
 /-- Coercion `ℝ≥0 → ℝ`. -/
-@[coe] def toReal : ℝ≥0 → ℝ := Subtype.val
+@[coe] abbrev toReal : ℝ≥0 → ℝ := Subtype.val
 
 instance : Coe ℝ≥0 ℝ := ⟨toReal⟩
 

--- a/Mathlib/MeasureTheory/Function/L1Space/Integrable.lean
+++ b/Mathlib/MeasureTheory/Function/L1Space/Integrable.lean
@@ -783,8 +783,8 @@ theorem integrable_withDensity_iff_integrable_coe_smul {f : α → ℝ≥0} (hf 
   · simp only [Integrable, aestronglyMeasurable_withDensity_iff hf, hasFiniteIntegral_iff_enorm, H,
       true_and]
     rw [lintegral_withDensity_eq_lintegral_mul₀' hf.coe_nnreal_ennreal.aemeasurable]
-    · simp [enorm_smul]
-    · simpa [aemeasurable_withDensity_ennreal_iff hf, enorm_smul] using H.enorm
+    · simp [enorm_smul, -Nonneg.coe_smul]
+    · simpa [aemeasurable_withDensity_ennreal_iff hf, enorm_smul, -Nonneg.coe_smul] using H.enorm
   · simp only [Integrable, aestronglyMeasurable_withDensity_iff hf, H, false_and]
 
 theorem integrable_withDensity_iff_integrable_smul {f : α → ℝ≥0} (hf : Measurable f) {g : α → E} :
@@ -893,7 +893,7 @@ noncomputable def withDensitySMulLI {f : α → ℝ≥0} (f_meas : Measurable f)
     apply lintegral_congr_ae
     filter_upwards [(memL1_smul_of_L1_withDensity f_meas u).coeFn_toLp] with x hx
     rw [hx]
-    simp [NNReal.smul_def, enorm_smul]
+    simp [NNReal.smul_def, enorm_smul, -Nonneg.coe_smul]
 
 @[simp]
 theorem withDensitySMulLI_apply {f : α → ℝ≥0} (f_meas : Measurable f)

--- a/Mathlib/MeasureTheory/Measure/Haar/Unique.lean
+++ b/Mathlib/MeasureTheory/Measure/Haar/Unique.lean
@@ -272,7 +272,7 @@ lemma exists_integral_isMulLeftInvariant_eq_smul_of_hasCompactSupport (μ' μ : 
     integral_isMulLeftInvariant_isMulRightInvariant_combo f_cont f_comp g_cont g_comp g_nonneg g_one
   /- Since the `ν`-factor is the same for `μ` and `μ'`, this gives the result. -/
   rw [← A, mul_assoc, mul_comm] at B
-  simp [B, integral_smul_nnreal_measure, c, NNReal.smul_def]
+  simp [B, integral_smul_nnreal_measure, c]
 
 open scoped Classical in
 /-- Given two left-invariant measures which are finite on compacts, `haarScalarFactor μ' μ` is a

--- a/Mathlib/RingTheory/Polynomial/Cyclotomic/Eval.lean
+++ b/Mathlib/RingTheory/Polynomial/Cyclotomic/Eval.lean
@@ -191,8 +191,7 @@ theorem sub_one_pow_totient_lt_cyclotomic_eval {n : ℕ} {q : ℝ} (hn' : 2 ≤ 
   suffices Units.mk0 (Real.toNNReal (q - 1)) (by simp [hq']) ^ totient n <
       Units.mk0 ‖(cyclotomic n ℂ).eval ↑q‖₊ (by simp_all) by
     simp [← Units.val_lt_val, Units.val_pow_eq_pow_val, Units.val_mk0, ← NNReal.coe_lt_coe,
-      hq'.le, coe_nnnorm, NNReal.coe_pow,
-      Real.coe_toNNReal', sub_nonneg] at this
+      hq'.le, coe_nnnorm, Real.coe_toNNReal', sub_nonneg] at this
     convert this
     rw [eq_comm]
     simp [cyclotomic_nonneg n hq'.le]

--- a/Mathlib/Topology/ContinuousMap/CompactlySupported.lean
+++ b/Mathlib/Topology/ContinuousMap/CompactlySupported.lean
@@ -667,7 +667,7 @@ protected lemma exists_add_of_le {f₁ f₂ : C_c(α, ℝ≥0)} (h : f₁ ≤ f�
       ne_eq, not_or, Decidable.not_not, ContinuousMap.coe_sub, Pi.sub_apply] at hx ⊢
     simp [hx.1, hx.2]
   · ext x
-    simpa [← NNReal.coe_add] using add_tsub_cancel_of_le (h x)
+    simpa [← NNReal.coe_add, -Nonneg.coe_add] using add_tsub_cancel_of_le (h x)
 
 /-- The nonnegative part of a bounded continuous `ℝ`-valued function as a bounded
 continuous `ℝ≥0`-valued function. -/
@@ -739,7 +739,7 @@ lemma exists_add_nnrealPart_add_eq (f g : C_c(α, ℝ)) : ∃ (h : C_c(α, ℝ�
         ring
   · rcases le_total 0 (g x) with hgx | hgx
     · rcases le_total 0 (f x + g x) with hfgx | hfgx
-      · simp only [hfgx, sup_of_le_left, add_comm, hfx, sup_of_le_right, hgx, zero_add] at hhx
+      · simp only [hfgx, sup_of_le_left, hfx, sup_of_le_right, hgx, zero_add] at hhx
         rw [sup_of_le_left (neg_nonneg.mpr hfx), sup_of_le_right (neg_nonpos.mpr hgx),
           sup_of_le_right (neg_nonpos.mpr hfgx), zero_add, add_zero]
         linarith
@@ -823,8 +823,11 @@ noncomputable def toRealPositiveLinear (Λ : C_c(α, ℝ≥0) →ₗ[ℝ≥0] �
       map_add' f g := by
         simp only [neg_add_rev]
         obtain ⟨h, hh⟩ := exists_add_nnrealPart_add_eq f g
-        rw [← add_zero ((Λ (f + g).nnrealPart).toReal - (Λ (-g + -f).nnrealPart).toReal),
-          ← sub_self (Λ h).toReal, sub_add_sub_comm, ← NNReal.coe_add, ← NNReal.coe_add,
+        rw [← add_zero ((Λ (f + g).nnrealPart).toReal - (Λ (-g + -f).nnrealPart).toReal)]
+        conv_lhs =>
+          right
+          rw [← sub_self (Λ h).toReal]
+        rw [sub_add_sub_comm, ← NNReal.coe_add, ← NNReal.coe_add,
           ← LinearMap.map_add, ← LinearMap.map_add, hh.1, add_comm (-g) (-f), hh.2]
         simp only [map_add, NNReal.coe_add]
         ring

--- a/Mathlib/Topology/ContinuousMap/ContinuousSqrt.lean
+++ b/Mathlib/Topology/ContinuousMap/ContinuousSqrt.lean
@@ -40,4 +40,5 @@ noncomputable instance : ContinuousSqrt ℝ≥0 where
   sqrt := NNReal.sqrt ∘ (fun x ↦ x.2 - x.1)
   continuousOn_sqrt := by fun_prop
   sqrt_nonneg := by simp
-  sqrt_mul_sqrt := by simpa using fun _ _ h ↦ Eq.symm <| add_tsub_cancel_of_le h
+  sqrt_mul_sqrt := by simpa using
+    fun (a a_1 : ℝ≥0) (h : a ≤ a_1) ↦ Eq.symm <| add_tsub_cancel_of_le h

--- a/Mathlib/Topology/Instances/ENNReal/Lemmas.lean
+++ b/Mathlib/Topology/Instances/ENNReal/Lemmas.lean
@@ -966,9 +966,8 @@ theorem tsum_strict_mono {f g : α → ℝ≥0} (hg : Summable g) (h : f < g) : 
   let ⟨hle, _i, hi⟩ := Pi.lt_def.mp h
   tsum_lt_tsum hle hi hg
 
-theorem tsum_pos {g : α → ℝ≥0} (hg : Summable g) (i : α) (hi : 0 < g i) : 0 < ∑' b, g b := by
-  rw [← tsum_zero]
-  exact tsum_lt_tsum (fun a => zero_le _) hi hg
+theorem tsum_pos {g : α → ℝ≥0} (hg : Summable g) (i : α) (hi : 0 < g i) : 0 < ∑' b, g b :=
+  tsum_zero.symm.trans_lt (tsum_lt_tsum (fun _ => zero_le _) hi hg)
 
 open Classical in
 theorem tsum_eq_add_tsum_ite {f : α → ℝ≥0} (hf : Summable f) (i : α) :


### PR DESCRIPTION
The instances on `NNReal` are defined to equal those from `Nonneg`, but this leads to defeq mismatches since `NNReal` is a non-reducible definition. If we change it to an `abbrev` we get rid of the mismatch.

Unfortunately, the `simp` sets for `NNReal` and `Subtype`/`Nonneg` are different, so we need quite a few fixes downstream where they pull in opposite directions. I am not convinced that this is the best solution.


---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include at least one commit authored by each
co-author among the commits in the pull request. If necessary, you may 
create empty commits to indicate co-authorship, using commands like so:

git commit --author="Author Name <author@email.com>" --allow-empty -m "add Author Name as coauthor"

When merging, all the commits will be squashed into a single commit listing all co-authors.

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
