### PR TITLE
[Merged by Bors] - feat: a root system is determined by its Cartan matrix

### DIFF
--- a/Mathlib/LinearAlgebra/RootSystem/CartanMatrix.lean
+++ b/Mathlib/LinearAlgebra/RootSystem/CartanMatrix.lean
@@ -21,6 +21,7 @@ This file contains definitions and basic results about Cartan matrices of root p
 * `RootPairing.Base.cartanMatrix_nondegenerate`: the Cartan matrix is non-degenerate.
 * `RootPairing.Base.induction_on_cartanMatrix`: an induction principle expressing the connectedness
   of the Dynkin diagram of an irreducible root pairing.
+* `RootPairing.Base.equivOfCartanMatrixEq`: a root system is determined by its Cartan matrix.
 
 -/
 
@@ -259,6 +260,58 @@ lemma exists_mem_span_pairingIn_ne_zero_and_pairwise_ne
       apply b.injective_pairingIn
       aesop
     simpa [f, sub_eq_zero] using ⟨fun i ↦ P.pairingIn ℤ i k, subset_span ⟨⟨k, hk⟩, rfl⟩, by simpa⟩
+
+section Uniqueness
+
+variable {ι₂ M₂ N₂ : Type*} [AddCommGroup M₂] [Module R M₂] [AddCommGroup N₂] [Module R N₂]
+  {P : RootSystem ι R M N} [P.IsCrystallographic] [P.IsReduced] (b : P.Base)
+  {P₂ : RootSystem ι₂ R M₂ N₂} [P₂.IsCrystallographic] (b₂ : P₂.Base)
+  (e : b.support ≃ b₂.support) (he : ∀ i j, b₂.cartanMatrix (e i) (e j) = b.cartanMatrix i j)
+
+include he
+
+lemma apply_mem_range_root_of_cartanMatrixEq
+    (f : M ≃ₗ[R] M₂) (hf : ∀ i : b.support, f (P.root i) = P₂.root (e i))
+    (m : M) (hm : m ∈ range P.root) :
+    f m ∈ range P₂.root := by
+  have (k : b.support) : (P.reflection k).trans f = f.trans (P₂.reflection (e k)) := by
+    suffices ∀ j : b.support,
+        (P.reflection k).trans f (P.root j) = f.trans (P₂.reflection (e k)) (P.root j) by
+      rw [← LinearEquiv.toLinearMap_inj]
+      exact b.toWeightBasis.ext fun j ↦ by simpa using this j
+    intro j
+    suffices P₂.pairing (e j) (e k) = P.pairing j k by simp [reflection_apply, hf, this]
+    simpa only [cartanMatrixIn_def, algebraMap_pairingIn] using congr_arg (algebraMap ℤ R) (he j k)
+  obtain ⟨i, rfl⟩ := hm
+  apply b.induction_reflect i
+  · exact fun j ⟨k, hk⟩ ↦ ⟨P₂.reflectionPerm k k, by simpa⟩
+  · exact fun j hj ↦ ⟨e ⟨j, hj⟩, (hf _).symm⟩
+  · intro j k ⟨l, hl⟩ hk
+    replace this : f (P.reflection k (P.root j)) = (P₂.reflection (e ⟨k, hk⟩)) (f (P.root j)) := by
+      simpa using LinearEquiv.congr_fun (this ⟨k, hk⟩) (P.root j)
+    rw [root_reflectionPerm, this, ← hl, ← root_reflectionPerm]
+    exact mem_range_self _
+
+/-- A root system is determined by its Cartan matrix. -/
+def equivOfCartanMatrixEq [Finite ι₂] [P₂.IsReduced] :
+    P.Equiv P₂.toRootPairing :=
+  let f : M ≃ₗ[R] M₂ := b.toWeightBasis.equiv b₂.toWeightBasis e
+  have hf : ∀ m, f m ∈ range P₂.root ↔ m ∈ range P.root := by
+    refine fun m ↦ ⟨fun h ↦ ?_, fun h ↦ ?_⟩
+    · simpa using apply_mem_range_root_of_cartanMatrixEq _ b e.symm (by simp [(he _ _).symm]) f.symm
+        (by simp [f, Module.Basis.equiv]) (f m) h
+    · exact apply_mem_range_root_of_cartanMatrixEq b b₂ e he f (by simp [f, Module.Basis.equiv]) m h
+  let : Fintype ι := Fintype.ofFinite _
+  let : Fintype ι₂ := Fintype.ofFinite _
+  have : DecidableEq M := Classical.typeDecidableEq M
+  have : DecidableEq M₂ := Classical.typeDecidableEq M₂
+  let e' : ι ≃ ι₂ := P.root.toEquivRange.trans <| (f.bijOn hf).equiv.trans P₂.root.toEquivRange.symm
+  have he' (i : ι) : f (P.root i) = P₂.root (e' i) := by
+    simp [f, e', BijOn.equiv, Embedding.toEquivRange]
+  have : Module.IsReflexive R M₂ := .of_isPerfPair P₂.toLinearMap
+  Equiv.mk' P P₂ (b.toWeightBasis.equiv b₂.toWeightBasis e) e' he'
+
+end Uniqueness
 
 end IsCrystallographic
 

--- a/Mathlib/LinearAlgebra/RootSystem/CartanMatrix.lean
+++ b/Mathlib/LinearAlgebra/RootSystem/CartanMatrix.lean
@@ -266,13 +266,12 @@ section Uniqueness
 variable {ι₂ M₂ N₂ : Type*} [AddCommGroup M₂] [Module R M₂] [AddCommGroup N₂] [Module R N₂]
   {P : RootSystem ι R M N} [P.IsCrystallographic] [P.IsReduced] (b : P.Base)
   {P₂ : RootSystem ι₂ R M₂ N₂} [P₂.IsCrystallographic] (b₂ : P₂.Base)
-  (e : b.support ≃ b₂.support) (he : ∀ i j, b₂.cartanMatrix (e i) (e j) = b.cartanMatrix i j)
-
-include he
+  (e : b.support ≃ b₂.support)
 
 lemma apply_mem_range_root_of_cartanMatrixEq
     (f : M ≃ₗ[R] M₂) (hf : ∀ i : b.support, f (P.root i) = P₂.root (e i))
-    (m : M) (hm : m ∈ range P.root) :
+    (m : M) (hm : m ∈ range P.root)
+    (he : ∀ i j, b₂.cartanMatrix (e i) (e j) = b.cartanMatrix i j) :
     f m ∈ range P₂.root := by
   have (k : b.support) : (P.reflection k).trans f = f.trans (P₂.reflection (e k)) := by
     suffices ∀ j : b.support,
@@ -293,14 +292,15 @@ lemma apply_mem_range_root_of_cartanMatrixEq
     exact mem_range_self _
 
 /-- A root system is determined by its Cartan matrix. -/
-def equivOfCartanMatrixEq [Finite ι₂] [P₂.IsReduced] :
+def equivOfCartanMatrixEq [Finite ι₂] [P₂.IsReduced]
+    (he : ∀ i j, b₂.cartanMatrix (e i) (e j) = b.cartanMatrix i j) :
     P.Equiv P₂.toRootPairing :=
   let f : M ≃ₗ[R] M₂ := b.toWeightBasis.equiv b₂.toWeightBasis e
   have hf : ∀ m, f m ∈ range P₂.root ↔ m ∈ range P.root := by
     refine fun m ↦ ⟨fun h ↦ ?_, fun h ↦ ?_⟩
-    · simpa using apply_mem_range_root_of_cartanMatrixEq _ b e.symm (by simp [(he _ _).symm]) f.symm
-        (by simp [f, Module.Basis.equiv]) (f m) h
-    · exact apply_mem_range_root_of_cartanMatrixEq b b₂ e he f (by simp [f, Module.Basis.equiv]) m h
+    · simpa using apply_mem_range_root_of_cartanMatrixEq _ b e.symm f.symm
+        (by simp [f, Module.Basis.equiv]) (f m) h (by simp [(he _ _).symm])
+    · exact apply_mem_range_root_of_cartanMatrixEq b b₂ e f (by simp [f, Module.Basis.equiv]) m h he
   let : Fintype ι := Fintype.ofFinite _
   let : Fintype ι₂ := Fintype.ofFinite _
   have : DecidableEq M := Classical.typeDecidableEq M

--- a/Mathlib/LinearAlgebra/RootSystem/Defs.lean
+++ b/Mathlib/LinearAlgebra/RootSystem/Defs.lean
@@ -59,7 +59,7 @@ require that it is compatible with reflections and coreflections.
 
 open Set Function
 open Module hiding reflection
-open Submodule (span)
+open Submodule (span span_image)
 open AddSubgroup (zmultiples)
 
 noncomputable section
@@ -715,5 +715,34 @@ lemma isFixedPt_reflectionPerm_iff [NeZero (2 : R)] [NoZeroSMulDivisors R M] :
 
 @[deprecated (since := "2025-05-28")]
 alias isFixedPt_reflection_perm_iff := isFixedPt_reflectionPerm_iff
+
+section Map
+
+variable {ι₂ M₂ N₂ : Type*} [AddCommGroup M₂] [Module R M₂] [AddCommGroup N₂] [Module R N₂]
+
+/-- Push forward a root pairing along linear equivalences, also reindexing the (co)roots. -/
+protected def map (e : ι ≃ ι₂) (f : M ≃ₗ[R] M₂) (g : N ≃ₗ[R] N₂) :
+    RootPairing ι₂ R M₂ N₂ where
+  __ := (f.symm.trans P.toPerfPair).trans g.symm.dualMap
+  isPerfPair_toLinearMap := by
+    have : IsReflexive R N := .of_isPerfPair P.flip.toLinearMap
+    have : IsReflexive R N₂ := equiv g
+    infer_instance
+  root := (e.symm.toEmbedding.trans P.root).trans f.toEmbedding
+  coroot := (e.symm.toEmbedding.trans P.coroot).trans g.toEmbedding
+  root_coroot_two i := by simp
+  reflectionPerm i := e.symm.trans <| (P.reflectionPerm (e.symm i)).trans e
+  reflectionPerm_root i j := by simp [reflection_apply]
+  reflectionPerm_coroot i j := by simp [coreflection_apply]
+
+/-- Push forward a root system along linear equivalences, also reindexing the (co)roots. -/
+protected def _root_.RootSystem.map {P : RootSystem ι R M N}
+    (e : ι ≃ ι₂) (f : M ≃ₗ[R] M₂) (g : N ≃ₗ[R] N₂) :
+    RootSystem ι₂ R M₂ N₂ where
+  __ := P.toRootPairing.map e f g
+  span_root_eq_top := by simp [Embedding.coe_trans, range_comp, span_image, RootPairing.map]
+  span_coroot_eq_top := by simp [Embedding.coe_trans, range_comp, span_image, RootPairing.map]
+
+end Map
 
 end RootPairing

--- a/Mathlib/LinearAlgebra/RootSystem/Hom.lean
+++ b/Mathlib/LinearAlgebra/RootSystem/Hom.lean
@@ -3,6 +3,7 @@ Copyright (c) 2024 Scott Carnahan. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Scott Carnahan
 -/
+import Mathlib.LinearAlgebra.RootSystem.Basic
 import Mathlib.LinearAlgebra.RootSystem.Defs
 
 /-!
@@ -475,6 +476,30 @@ instance (P : RootPairing ι R M N) : Group (RootPairing.Equiv P P) where
     · rw [← coweightEquiv_apply]
       simp
     · simp
+
+/-- For finite roots systems in characteristic zero, a linear equivalence preserving roots, also
+preserves coroots, and is thus an equivalence of root systems. -/
+def mk' [CharZero R] [NoZeroSMulDivisors R M₂] [Finite ι₂]
+    (P : RootSystem ι R M N) (Q : RootSystem ι₂ R M₂ N₂)
+    (f : M ≃ₗ[R] M₂) (e : ι ≃ ι₂) (hf : ∀ i, f (P.root i) = Q.root (e i)) :
+    P.Equiv Q.toRootPairing where
+  weightMap := f
+  coweightMap := Q.flip.toPerfPair.trans (f.dualMap.trans P.flip.toPerfPair.symm)
+  indexEquiv := e
+  weight_coweight_transpose := by ext; simp [RootSystem.flip]
+  root_weightMap := by ext; simp [hf]
+  coroot_coweightMap := by
+    let g : N ≃ₗ[R] N₂ := P.flip.toPerfPair.trans <| f.symm.dualMap.trans Q.flip.toPerfPair.symm
+    suffices Q = P.map e f g by
+      ext i
+      rw [LinearEquiv.coe_coe, comp_apply, ← LinearEquiv.eq_symm_apply]
+      conv_lhs => rw [this]
+      rfl
+    ext m n
+    · simp [RootSystem.map, RootPairing.map, RootSystem.flip, g]
+    · simp [hf, RootSystem.map, RootPairing.map]
+  bijective_weightMap := LinearEquiv.bijective _
+  bijective_coweightMap := LinearEquiv.bijective _
 
 end Equiv
 

--- a/Mathlib/LinearAlgebra/RootSystem/RootPositive.lean
+++ b/Mathlib/LinearAlgebra/RootSystem/RootPositive.lean
@@ -4,7 +4,6 @@ Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Scott Carnahan
 -/
 import Mathlib.LinearAlgebra.RootSystem.IsValuedIn
-import Mathlib.LinearAlgebra.RootSystem.WeylGroup
 
 /-!
 # Invariant and root-positive bilinear forms on root pairings
@@ -75,18 +74,6 @@ lemma pairing_mul_eq_pairing_mul_swap :
 lemma apply_reflection_reflection (x y : M) :
     B.form (P.reflection i x) (P.reflection i y) = B.form x y :=
   B.isOrthogonal_reflection i x y
-
-@[simp]
-lemma apply_weylGroup_smul (g : P.weylGroup) (x y : M) :
-    B.form (g • x) (g • y) = B.form x y := by
-  revert x y
-  obtain ⟨g, hg⟩ := g
-  induction hg using weylGroup.induction with
-  | mem i => simp
-  | one => simp
-  | mul g₁ g₂ hg₁ hg₂ hg₁' hg₂' =>
-    intro x y
-    rw [← Submonoid.mk_mul_mk _ _ _ hg₁ hg₂, mul_smul, mul_smul, hg₁', hg₂']
 
 @[simp]
 lemma apply_root_root_zero_iff [IsDomain R] [NeZero (2 : R)] :

--- a/Mathlib/LinearAlgebra/RootSystem/WeylGroup.lean
+++ b/Mathlib/LinearAlgebra/RootSystem/WeylGroup.lean
@@ -186,4 +186,16 @@ lemma weylGroup_apply_root (g : P.weylGroup) (i : ι) :
     g • P.root i = P.root (P.weylGroupToPerm g i) :=
   Hom.root_weightMap_apply _ _ _ _
 
+@[simp]
+lemma InvariantForm.apply_weylGroup_smul {B : P.InvariantForm} (g : P.weylGroup) (x y : M) :
+    B.form (g • x) (g • y) = B.form x y := by
+  revert x y
+  obtain ⟨g, hg⟩ := g
+  induction hg using weylGroup.induction with
+  | mem i => simp
+  | one => simp
+  | mul g₁ g₂ hg₁ hg₂ hg₁' hg₂' =>
+    intro x y
+    rw [← Submonoid.mk_mul_mk _ _ _ hg₁ hg₂, mul_smul, mul_smul, hg₁', hg₂']
+
 end RootPairing


### PR DESCRIPTION
Moving the lemma `RootPairing.InvariantForm.apply_weylGroup_smul` allows us to drop an import in `Mathlib.LinearAlgebra.RootSystem.RootPositive` and thus to import `Mathlib.LinearAlgebra.RootSystem.Basic` in `Mathlib.LinearAlgebra.RootSystem.Hom`. This is necessary to make the key lemma `RootSystem.ext` available for the proof of `RootPairing.Equiv.mk'`.

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include at least one commit authored by each
co-author among the commits in the pull request. If necessary, you may 
create empty commits to indicate co-authorship, using commands like so:

git commit --author="Author Name <author@email.com>" --allow-empty -m "add Author Name as coauthor"

When merging, all the commits will be squashed into a single commit listing all co-authors.

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
