### PR TITLE
[Merged by Bors] - chore: add `Iff` version of `Commute.map`

### DIFF
--- a/Mathlib/Algebra/Group/Commute/Hom.lean
+++ b/Mathlib/Algebra/Group/Commute/Hom.lean
@@ -26,7 +26,7 @@ protected theorem Commute.map [MulHomClass F M N] (h : Commute x y) (f : F) : Co
   SemiconjBy.map h f
 
 @[to_additive]
-protected theorem SemiconjBy.of_map [MulHomClass F M N] (f : F) (hf : Function.Injective f)
+protected theorem SemiconjBy.of_map [MulHomClass F M N] {f : F} (hf : Function.Injective f)
     (h : SemiconjBy (f a) (f x) (f y)) : SemiconjBy a x y :=
   hf (by simpa only [SemiconjBy, map_mul] using h)
 
@@ -34,5 +34,15 @@ protected theorem SemiconjBy.of_map [MulHomClass F M N] (f : F) (hf : Function.I
 theorem Commute.of_map [MulHomClass F M N] {f : F} (hf : Function.Injective f)
     (h : Commute (f x) (f y)) : Commute x y :=
   hf (by simpa only [map_mul] using h.eq)
+
+@[to_additive]
+theorem semiconjBy_map_iff [MulHomClass F M N] {f : F} (hf : Function.Injective f) {x y : M} :
+    SemiconjBy (f a) (f x) (f y) ↔ SemiconjBy a x y :=
+  ⟨.of_map hf, (.map · f)⟩
+
+@[to_additive]
+theorem commute_map_iff [MulHomClass F M N] {f : F} (hf : Function.Injective f) {x y : M} :
+    Commute (f x) (f y) ↔ Commute x y :=
+  ⟨.of_map hf, (.map · f)⟩
 
 end Commute


### PR DESCRIPTION
We already had the two directions separately.

Also adjusts an implicit argument for consistency


---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include at least one commit authored by each
co-author among the commits in the pull request. If necessary, you may 
create empty commits to indicate co-authorship, using commands like so:

git commit --author="Author Name <author@email.com>" --allow-empty -m "add Author Name as coauthor"

When merging, all the commits will be squashed into a single commit listing all co-authors.

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
