### PR TITLE
[Merged by Bors] - refactor(CategoryTheory/Sites): make `Coverage` and `Pretopology` extend `Precoverage`

### DIFF
--- a/Mathlib.lean
+++ b/Mathlib.lean
@@ -2694,6 +2694,7 @@ import Mathlib.CategoryTheory.Sites.NonabelianCohomology.H1
 import Mathlib.CategoryTheory.Sites.OneHypercover
 import Mathlib.CategoryTheory.Sites.Over
 import Mathlib.CategoryTheory.Sites.Plus
+import Mathlib.CategoryTheory.Sites.Precoverage
 import Mathlib.CategoryTheory.Sites.Preserves
 import Mathlib.CategoryTheory.Sites.PreservesLocallyBijective
 import Mathlib.CategoryTheory.Sites.PreservesSheafification

--- a/Mathlib/CategoryTheory/Sites/Coherent/Basic.lean
+++ b/Mathlib/CategoryTheory/Sites/Coherent/Basic.lean
@@ -64,7 +64,7 @@ class Precoherent : Prop where
 The coherent coverage on a precoherent category `C`.
 -/
 def coherentCoverage [Precoherent C] : Coverage C where
-  covering B := { S | ∃ (α : Type) (_ : Finite α) (X : α → C) (π : (a : α) → (X a ⟶ B)),
+  coverings B := { S | ∃ (α : Type) (_ : Finite α) (X : α → C) (π : (a : α) → (X a ⟶ B)),
     S = Presieve.ofArrows X π ∧ EffectiveEpiFamily X π }
   pullback := by
     rintro B₁ B₂ f S ⟨α, _, X₁, π₁, rfl, hS⟩
@@ -105,7 +105,7 @@ class Preregular : Prop where
 The regular coverage on a regular category `C`.
 -/
 def regularCoverage [Preregular C] : Coverage C where
-  covering B := { S | ∃ (X : C) (f : X ⟶ B), S = Presieve.ofArrows (fun (_ : Unit) ↦ X)
+  coverings B := { S | ∃ (X : C) (f : X ⟶ B), S = Presieve.ofArrows (fun (_ : Unit) ↦ X)
     (fun (_ : Unit) ↦ f) ∧ EffectiveEpi f }
   pullback := by
     intro X Y f S ⟨Z, π, hπ, h_epi⟩
@@ -132,7 +132,7 @@ The extensive coverage on an extensive category `C`
 TODO: use general colimit API instead of `IsIso (Sigma.desc π)`
 -/
 def extensiveCoverage [FinitaryPreExtensive C] : Coverage C where
-  covering B := { S | ∃ (α : Type) (_ : Finite α) (X : α → C) (π : (a : α) → (X a ⟶ B)),
+  coverings B := { S | ∃ (α : Type) (_ : Finite α) (X : α → C) (π : (a : α) → (X a ⟶ B)),
     S = Presieve.ofArrows X π ∧ IsIso (Sigma.desc π) }
   pullback := by
     intro X Y f S ⟨α, hα, Z, π, hS, h_iso⟩

--- a/Mathlib/CategoryTheory/Sites/Coverage.lean
+++ b/Mathlib/CategoryTheory/Sites/Coverage.lean
@@ -3,8 +3,8 @@ Copyright (c) 2023 Adam Topaz. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Adam Topaz
 -/
+import Mathlib.CategoryTheory.Sites.Precoverage
 import Mathlib.CategoryTheory.Sites.Sheaf
-import Mathlib.CategoryTheory.Limits.Shapes.Pullback.CommSq
 
 /-!
 
@@ -150,18 +150,19 @@ Explicitly, this condition says that whenever `S` is a covering presieve for `X`
 such that `T` factors through `S` along `f`.
 -/
 @[ext]
-structure Coverage where
-  /-- The collection of covering presieves for an object `X`. -/
-  covering : ∀ (X : C), Set (Presieve X)
+structure Coverage extends Precoverage C where
   /-- Given any covering sieve `S` on `X` and a morphism `f : Y ⟶ X`, there exists
   some covering sieve `T` on `Y` such that `T` factors through `S` along `f`. -/
-  pullback : ∀ ⦃X Y : C⦄ (f : Y ⟶ X) (S : Presieve X) (_ : S ∈ covering X),
-    ∃ (T : Presieve Y), T ∈ covering Y ∧ T.FactorsThruAlong S f
+  pullback : ∀ ⦃X Y : C⦄ (f : Y ⟶ X) (S : Presieve X) (_ : S ∈ coverings X),
+    ∃ (T : Presieve Y), T ∈ coverings Y ∧ T.FactorsThruAlong S f
 
 namespace Coverage
 
+@[deprecated (since := "2025-08-28")]
+alias covering := Precoverage.coverings
+
 instance : CoeFun (Coverage C) (fun _ => (X : C) → Set (Presieve X)) where
-  coe := covering
+  coe J := J.coverings
 
 variable (C) in
 /--
@@ -171,7 +172,7 @@ If `J` is a Grothendieck topology, and `K` is the associated coverage, then a pr
 covering sieve for `J`.
 -/
 def ofGrothendieck (J : GrothendieckTopology C) : Coverage C where
-  covering X := { S | Sieve.generate S ∈ J X }
+  coverings X := { S | Sieve.generate S ∈ J X }
   pullback := by
     intro X Y f S (hS : Sieve.generate S ∈ J X)
     refine ⟨(Sieve.generate S).pullback f, ?_, fun Z g h => h⟩
@@ -247,7 +248,7 @@ def toGrothendieck (K : Coverage C) : GrothendieckTopology C where
   transitive' _ _ hS _ hR := .transitive _ _ _ hS hR
 
 instance : PartialOrder (Coverage C) where
-  le A B := A.covering ≤ B.covering
+  le A B := A.coverings ≤ B.coverings
   le_refl _ _ := le_refl _
   le_trans _ _ _ h1 h2 X := le_trans (h1 X) (h2 X)
   le_antisymm _ _ h1 h2 := Coverage.ext <| funext <|
@@ -295,7 +296,7 @@ theorem toGrothendieck_eq_sInf (K : Coverage C) : toGrothendieck _ K =
 
 instance : SemilatticeSup (Coverage C) where
   sup x y :=
-  { covering := fun B ↦ x.covering B ∪ y.covering B
+  { coverings := fun B ↦ x B ∪ y B
     pullback := by
       rintro X Y f S (hx | hy)
       · obtain ⟨T, hT⟩ := x.pullback f S hx
@@ -309,7 +310,7 @@ instance : SemilatticeSup (Coverage C) where
 
 @[simp]
 lemma sup_covering (x y : Coverage C) (B : C) :
-    (x ⊔ y).covering B = x.covering B ∪ y.covering B :=
+    (x ⊔ y) B = x B ∪ y B :=
   rfl
 
 /--
@@ -317,40 +318,14 @@ Any sieve that contains a covering presieve for a coverage is a covering sieve f
 Grothendieck topology.
 -/
 theorem mem_toGrothendieck_sieves_of_superset (K : Coverage C) {X : C} {S : Sieve X}
-    {R : Presieve X} (h : R ≤ S) (hR : R ∈ K.covering X) : S ∈ (K.toGrothendieck C) X :=
+    {R : Presieve X} (h : R ≤ S) (hR : R ∈ K X) : S ∈ (K.toGrothendieck C) X :=
   K.saturate_of_superset ((Sieve.generate_le_iff _ _).mpr h) (Coverage.Saturate.of X _ hR)
-
-/-- A coverage is stable under base change if pullbacks of covering presieves
-are covering presieves.
-Note: This is stronger than the analogous requirement for a `Pretopology`, because
-`IsPullback` does not imply equality with the (arbitrarily) chosen pullbacks in `C`. -/
-class IsStableUnderBaseChange (J : Coverage C) : Prop where
-  mem_covering_of_isPullback {ι : Type w} {S : C} {X : ι → C} (f : ∀ i, X i ⟶ S)
-    (hR : Presieve.ofArrows X f ∈ J S) {Y : C} (g : Y ⟶ S)
-    {P : ι → C} (p₁ : ∀ i, P i ⟶ Y) (p₂ : ∀ i, P i ⟶ X i)
-    (h : ∀ i, IsPullback (p₁ i) (p₂ i) g (f i)) :
-    .ofArrows P p₁ ∈ J Y
-
-/-- A coverage is stable under composition if the indexed composition
-of coverings is again a covering.
-Note: This is stronger than the analogous requirement for a `Pretopology`, because
-this is in general not equal to a `Presieve.bind`. -/
-class IsStableUnderComposition (J : Coverage C) : Prop where
-  mem_covering_comp {ι : Type w}
-    {S : C} {X : ι → C} (f : ∀ i, X i ⟶ S) (hf : Presieve.ofArrows X f ∈ J S)
-    {σ : ι → Type w'} {Y : ∀ (i : ι), σ i → C}
-    (g : ∀ i j, Y i j ⟶ X i) (hg : ∀ i, Presieve.ofArrows (Y i) (g i) ∈ J (X i)) :
-    .ofArrows (fun p : Σ i, σ i ↦ Y _ p.2) (fun _ ↦ g _ _ ≫ f _) ∈ J S
-
-alias mem_covering_of_isPullback := IsStableUnderBaseChange.mem_covering_of_isPullback
-
-alias mem_covering_comp := IsStableUnderComposition.mem_covering_comp
 
 end Coverage
 
 /-- Any pretopology is a coverage. -/
 def Pretopology.toCoverage [HasPullbacks C] (J : Pretopology C) : Coverage C where
-  covering := J
+  coverings := J
   pullback _ _ f R hR := ⟨R.pullbackArrows f, J.pullbacks _ _ hR, .pullbackArrows f R⟩
 
 open Coverage
@@ -454,7 +429,7 @@ namespace Presheaf
 
 theorem isSheaf_iff_isLimit_coverage (K : Coverage C) (P : Cᵒᵖ ⥤ D) :
     Presheaf.IsSheaf (toGrothendieck _ K) P ↔ ∀ ⦃X : C⦄ (R : Presieve X),
-      R ∈ K.covering X →
+      R ∈ K X →
         Nonempty (IsLimit (P.mapCone (Sieve.generate R).arrows.cocone.op)) := by
   simp only [Presheaf.IsSheaf, Presieve.isSheaf_coverage, isLimit_iff_isSheafFor,
     ← Presieve.isSheafFor_iff_generate]

--- a/Mathlib/CategoryTheory/Sites/Precoverage.lean
+++ b/Mathlib/CategoryTheory/Sites/Precoverage.lean
@@ -1,0 +1,126 @@
+/-
+Copyright (c) 2025 Christian Merten. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Christian Merten
+-/
+import Mathlib.CategoryTheory.Limits.Shapes.Pullback.CommSq
+import Mathlib.CategoryTheory.Sites.Sieves
+import Mathlib.Order.ConditionallyCompleteLattice.Basic
+
+/-!
+
+# Precoverages
+
+A precoverage `K` on a category `C` is a set of presieves associated to every object `X : C`,
+called "covering presieves".
+There are no conditions on this set. Common extensions of a precoverage are:
+
+- `CategoryTheory.Coverage`: A coverage is a precoverage that satisfies a pullback compatibility
+  condition, saying that whenever `S` is a covering presieve on `X` and `f : Y ⟶ X` is a morphism,
+  then there exists some covering sieve `T` on `Y` such that `T` factors through `S` along `f`.
+- `CategoryTheory.Pretopology`: If `C` has pullbacks, a pretopology on `C` is a precoverage that
+  has isomorphisms and is stable under pullback and refinement.
+
+These two are defined in later files. For precoverages, we define stability conditions:
+
+- `CategoryTheory.Precoverage.HasIsos`: Singleton presieves by isomorphisms are covering.
+- `CategoryTheory.Precoverage.IsStableUnderBaseChange`: The pullback of a covering presieve is again
+  covering.
+- `CategoryTheory.Precoverage.IsStableUnderComposition`: Refining a covering presieve by covering
+  presieves yields a covering presieve.
+
+-/
+
+universe w w' v u
+
+namespace CategoryTheory
+
+/-- A precoverage is a collection of *covering* presieves on every object `X : C`.
+See `CategoryTheory.Coverage` and `CategoryTheory.Pretopology` for common extensions of this. -/
+@[ext]
+structure Precoverage (C : Type*) [Category C] where
+  /-- The collection of covering presieves for an object `X`. -/
+  coverings : ∀ (X : C), Set (Presieve X)
+
+namespace Precoverage
+
+variable {C : Type u} [Category.{v} C]
+
+instance : CoeFun (Precoverage C) (fun _ => (X : C) → Set (Presieve X)) where
+  coe := coverings
+
+instance : PartialOrder (Precoverage C) where
+  le A B := A.coverings ≤ B.coverings
+  le_refl _ _ := le_refl _
+  le_trans _ _ _ h1 h2 X := le_trans (h1 X) (h2 X)
+  le_antisymm _ _ h1 h2 := Precoverage.ext <| funext <|
+    fun X => le_antisymm (h1 X) (h2 X)
+
+instance : Min (Precoverage C) where
+  min A B := ⟨A.coverings ⊓ B.coverings⟩
+
+instance : Max (Precoverage C) where
+  max A B := ⟨A.coverings ⊔ B.coverings⟩
+
+instance : SupSet (Precoverage C) where
+  sSup A := ⟨⨆ K ∈ A, K.coverings⟩
+
+instance : InfSet (Precoverage C) where
+  sInf A := ⟨⨅ K ∈ A, K.coverings⟩
+
+instance : Top (Precoverage C) where
+  top.coverings _ := .univ
+
+instance : Bot (Precoverage C) where
+  bot.coverings _ := ∅
+
+instance : CompleteLattice (Precoverage C) :=
+  Function.Injective.completeLattice Precoverage.coverings (fun _ _ hab ↦ Precoverage.ext hab)
+    (fun _ _ ↦ rfl) (fun _ _ ↦ rfl) (fun _ ↦ rfl) (fun _ ↦ rfl) rfl rfl
+
+/-- A precoverage has isomorphisms if singleton presieves by isomorphisms are covering. -/
+class HasIsos (J : Precoverage C) : Prop where
+  mem_coverings_of_isIso {S T : C} (f : S ⟶ T) [IsIso f] : .singleton f ∈ J T
+
+/-- A precoverage is stable under base change if pullbacks of covering presieves
+are covering presieves.
+Note: This is stronger than the analogous requirement for a `Pretopology`, because
+`IsPullback` does not imply equality with the (arbitrarily) chosen pullbacks in `C`. -/
+class IsStableUnderBaseChange (J : Precoverage C) : Prop where
+  mem_coverings_of_isPullback {ι : Type w} {S : C} {X : ι → C} (f : ∀ i, X i ⟶ S)
+    (hR : Presieve.ofArrows X f ∈ J S) {Y : C} (g : Y ⟶ S)
+    {P : ι → C} (p₁ : ∀ i, P i ⟶ Y) (p₂ : ∀ i, P i ⟶ X i)
+    (h : ∀ i, IsPullback (p₁ i) (p₂ i) g (f i)) :
+    .ofArrows P p₁ ∈ J Y
+
+/-- A precoverage is stable under composition if the indexed composition
+of coverings is again a covering.
+Note: This is stronger than the analogous requirement for a `Pretopology`, because
+this is in general not equal to a `Presieve.bind`. -/
+class IsStableUnderComposition (J : Precoverage C) : Prop where
+  comp_mem_coverings {ι : Type w}
+    {S : C} {X : ι → C} (f : ∀ i, X i ⟶ S) (hf : Presieve.ofArrows X f ∈ J S)
+    {σ : ι → Type w'} {Y : ∀ (i : ι), σ i → C}
+    (g : ∀ i j, Y i j ⟶ X i) (hg : ∀ i, Presieve.ofArrows (Y i) (g i) ∈ J (X i)) :
+    .ofArrows (fun p : Σ i, σ i ↦ Y _ p.2) (fun _ ↦ g _ _ ≫ f _) ∈ J S
+
+alias mem_coverings_of_isIso := HasIsos.mem_coverings_of_isIso
+alias mem_coverings_of_isPullback := IsStableUnderBaseChange.mem_coverings_of_isPullback
+alias comp_mem_coverings := IsStableUnderComposition.comp_mem_coverings
+
+instance (J K : Precoverage C) [HasIsos J] [HasIsos K] : HasIsos (J ⊓ K) where
+  mem_coverings_of_isIso f _ := ⟨mem_coverings_of_isIso f, mem_coverings_of_isIso f⟩
+
+instance (J K : Precoverage C) [IsStableUnderBaseChange.{w} J] [IsStableUnderBaseChange.{w} K] :
+    IsStableUnderBaseChange.{w} (J ⊓ K) where
+  mem_coverings_of_isPullback _ hf _ _ _ _ _ h :=
+    ⟨mem_coverings_of_isPullback _ hf.1 _ _ _ h, mem_coverings_of_isPullback _ hf.2 _ _ _ h⟩
+
+instance (J K : Precoverage C) [IsStableUnderComposition.{w, w'} J]
+    [IsStableUnderComposition.{w, w'} K] : IsStableUnderComposition.{w, w'} (J ⊓ K) where
+  comp_mem_coverings _ h _ _ _ H :=
+    ⟨comp_mem_coverings _ h.1 _ fun i ↦ (H i).1, comp_mem_coverings _ h.2 _ fun i ↦ (H i).2⟩
+
+end Precoverage
+
+end CategoryTheory

--- a/Mathlib/CategoryTheory/Sites/Pretopology.lean
+++ b/Mathlib/CategoryTheory/Sites/Pretopology.lean
@@ -264,4 +264,35 @@ lemma mem_inf (t₁ t₂ : Pretopology C) {X : C} (S : Presieve X) :
 
 end Pretopology
 
+/-- If `J` is a precoverage that has isomorphisms and is stable under composition and
+base change, it defines a pretopology. -/
+@[simps toPrecoverage]
+def Precoverage.toPretopology [HasPullbacks C] (J : Precoverage C) [J.HasIsos]
+    [J.IsStableUnderBaseChange] [J.IsStableUnderComposition] : Pretopology C where
+  __ := J
+  has_isos X Y f hf := mem_coverings_of_isIso f
+  pullbacks X Y f R hR := by
+    obtain ⟨ι, Z, g, rfl⟩ := R.exists_eq_ofArrows
+    rw [← Presieve.ofArrows_pullback]
+    exact mem_coverings_of_isPullback _ hR _ _ _ fun i ↦ (IsPullback.of_hasPullback _ _).flip
+  transitive X R Ti hR hTi := by
+    obtain ⟨ι, Z, g, rfl⟩ := R.exists_eq_ofArrows
+    choose κ W p hp using fun ⦃Y⦄ (f : Y ⟶ X) hf ↦ (Ti f hf).exists_eq_ofArrows
+    have : (Presieve.ofArrows Z g).bind Ti =
+        .ofArrows (fun ij : Σ i, κ (g i) ⟨i⟩ ↦ W _ _ ij.2) (fun ij ↦ p _ _ ij.2 ≫ g ij.1) := by
+      apply le_antisymm
+      · rintro T u ⟨S, v, w, ⟨i⟩, hv, rfl⟩
+        rw [hp] at hv
+        obtain ⟨j⟩ := hv
+        exact .mk <| Sigma.mk (β := fun i : ι ↦ κ (g i) ⟨i⟩) i j
+      · rintro T u ⟨ij⟩
+        use Z ij.1, p (g ij.1) ⟨ij.1⟩ ij.2, g ij.1, ⟨ij.1⟩
+        rw [hp]
+        exact ⟨⟨_⟩, rfl⟩
+    rw [this]
+    refine J.comp_mem_coverings (Y := fun (i : ι) (j : κ (g i) ⟨i⟩) ↦ W _ _ j)
+      (g := fun i j ↦ p _ _ j) _ hR fun i ↦ ?_
+    rw [← hp]
+    exact hTi _ _
+
 end CategoryTheory

--- a/Mathlib/CategoryTheory/Sites/Pretopology.lean
+++ b/Mathlib/CategoryTheory/Sites/Pretopology.lean
@@ -4,6 +4,7 @@ Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Bhavik Mehta
 -/
 import Mathlib.CategoryTheory.Sites.Grothendieck
+import Mathlib.CategoryTheory.Sites.Precoverage
 
 /-!
 # Grothendieck pretopologies
@@ -56,9 +57,8 @@ See: https://ncatlab.org/nlab/show/Grothendieck+pretopology or [MM92] Chapter II
 Section 2, Definition 2. -/
 @[ext, stacks 00VH "Note that Stacks calls a category together with a pretopology a site,
 and [MM92] calls this a basis for a topology."]
-structure Pretopology where
+structure Pretopology extends Precoverage C where
   /-- For all `X : C`, the coverings of `X` (sets of families of morphisms with target `X`) -/
-  coverings : ∀ X : C, Set (Presieve X)
   has_isos : ∀ ⦃X Y⦄ (f : Y ⟶ X) [IsIso f], Presieve.singleton f ∈ coverings X
   pullbacks : ∀ ⦃X Y⦄ (f : Y ⟶ X) (S), S ∈ coverings X → pullbackArrows f S ∈ coverings Y
   transitive :
@@ -68,7 +68,7 @@ structure Pretopology where
 namespace Pretopology
 
 instance : CoeFun (Pretopology C) fun _ => ∀ X : C, Set (Presieve X) :=
-  ⟨coverings⟩
+  ⟨fun J ↦ J.coverings⟩
 
 variable {C}
 
@@ -206,7 +206,7 @@ theorem toGrothendieck_bot : toGrothendieck C ⊥ = ⊥ :=
 
 instance : InfSet (Pretopology C) where
   sInf T := {
-    coverings := sInf (coverings '' T)
+    coverings := sInf ((fun J ↦ J.coverings) '' T)
     has_isos := fun X Y f _ ↦ by
       simp only [sInf_apply, Set.iInf_eq_iInter, Set.iInter_coe_set, Set.mem_image,
         Set.iInter_exists,
@@ -227,7 +227,7 @@ instance : InfSet (Pretopology C) where
 
 lemma mem_sInf (T : Set (Pretopology C)) {X : C} (S : Presieve X) :
     S ∈ sInf T X ↔ ∀ t ∈ T, S ∈ t X := by
-  change S ∈ sInf (Pretopology.coverings '' T) X ↔ _
+  change S ∈ sInf ((fun J : Pretopology C ↦ J.coverings) '' T) X ↔ _
   simp
 
 lemma sInf_ofGrothendieck (T : Set (GrothendieckTopology C)) :
@@ -236,7 +236,7 @@ lemma sInf_ofGrothendieck (T : Set (GrothendieckTopology C)) :
   simp [mem_sInf, mem_ofGrothendieck, GrothendieckTopology.mem_sInf]
 
 lemma isGLB_sInf (T : Set (Pretopology C)) : IsGLB T (sInf T) :=
-  IsGLB.of_image (f := coverings) Iff.rfl (_root_.isGLB_sInf _)
+  IsGLB.of_image (f := fun J ↦ J.coverings) Iff.rfl (_root_.isGLB_sInf _)
 
 /-- The complete lattice structure on pretopologies. This is induced by the `InfSet` instance, but
 with good definitional equalities for `⊥`, `⊤` and `⊓`. -/

--- a/Mathlib/CategoryTheory/Sites/Sieves.lean
+++ b/Mathlib/CategoryTheory/Sites/Sieves.lean
@@ -184,6 +184,12 @@ theorem ofArrows_surj {ι : Type*} {Y : ι → C} (f : ∀ i, Y i ⟶ X) {Z : C}
   obtain ⟨i⟩ := hg
   exact ⟨i, rfl, by simp only [eqToHom_refl, id_comp]⟩
 
+lemma exists_eq_ofArrows (R : Presieve X) :
+    ∃ (ι : Type (max u₁ v₁)) (Y : ι → C) (f : ∀ i, Y i ⟶ X), R = .ofArrows Y f := by
+  let ι := { x : Σ Z, (Z ⟶ X) // R x.2 }
+  use ι, fun x ↦ x.1.1, fun x ↦ x.1.2
+  exact le_antisymm (fun Z g hg ↦ .mk (⟨⟨_, _⟩, hg⟩ : ι)) fun Z g ⟨x⟩ ↦ x.2
+
 /-- A convenient constructor for a refinement of a presieve of the form `Presieve.ofArrows`.
 This contains a sieve obtained by `Sieve.bind` and `Sieve.ofArrows`, see
 `Presieve.bind_ofArrows_le_bindOfArrows`, but has better definitional properties. -/

--- a/Mathlib/CategoryTheory/Sites/ZeroHypercover.lean
+++ b/Mathlib/CategoryTheory/Sites/ZeroHypercover.lean
@@ -3,7 +3,7 @@ Copyright (c) 2025 Christian Merten. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Christian Merten
 -/
-import Mathlib.CategoryTheory.Sites.Coverage
+import Mathlib.CategoryTheory.Sites.Precoverage
 
 /-!
 # 0-hypercovers
@@ -130,9 +130,9 @@ end Category
 
 end PreZeroHypercover
 
-namespace Coverage
+namespace Precoverage
 
-variable (J : Coverage C)
+variable (J : Precoverage C)
 
 /-- The type of `0`-hypercovers of an object `S : C` in a category equipped with a
 coverage `J`. This can be constructed from a covering of `S`. -/
@@ -158,7 +158,7 @@ def pullback₁ [J.IsStableUnderBaseChange] [Limits.HasPullbacks C] (f : S ⟶ T
     (E : ZeroHypercover.{w} J T) :
     J.ZeroHypercover S where
   __ := E.toPreZeroHypercover.pullback₁ f
-  mem₀ := J.mem_covering_of_isPullback E.f E.mem₀ f _
+  mem₀ := J.mem_coverings_of_isPullback E.f E.mem₀ f _
     (fun _ ↦ pullback.snd _ _) fun i ↦ IsPullback.of_hasPullback f (E.f i)
 
 /-- Pullback of a `0`-hypercover along a morphism. The components are `pullback (E.f i) f`. -/
@@ -168,7 +168,7 @@ def pullback₂ [J.IsStableUnderBaseChange] [Limits.HasPullbacks C] (f : S ⟶ T
     (E : ZeroHypercover.{w} J T) :
     J.ZeroHypercover S where
   __ := E.toPreZeroHypercover.pullback₂ f
-  mem₀ := J.mem_covering_of_isPullback E.f E.mem₀ f _
+  mem₀ := J.mem_coverings_of_isPullback E.f E.mem₀ f _
     (fun _ ↦ pullback.fst _ _) fun i ↦ (IsPullback.of_hasPullback (E.f i) f).flip
 
 /-- Refining each component of a `0`-hypercover yields a refined `0`-hypercover of the base. -/
@@ -177,7 +177,7 @@ def bind [J.IsStableUnderComposition] (E : ZeroHypercover.{w} J T)
     ZeroHypercover.{max w w'} J T where
   __ := E.toPreZeroHypercover.bind (fun i ↦ (F i).toPreZeroHypercover)
   mem₀ :=
-    mem_covering_comp (f := E.f) (g := fun i j ↦ (F i).f j) E.mem₀ (fun i ↦ (F i).mem₀)
+    comp_mem_coverings (f := E.f) (g := fun i j ↦ (F i).f j) E.mem₀ (fun i ↦ (F i).mem₀)
 
 /-- A morphism of `0`-hypercovers is a morphism of the underlying pre-`0`-hypercovers. -/
 abbrev Hom (E : ZeroHypercover.{w} J S) (F : ZeroHypercover.{w'} J S) :=
@@ -191,6 +191,6 @@ instance : Category (ZeroHypercover.{w} J S) where
 
 end ZeroHypercover
 
-end Coverage
+end Precoverage
 
 end CategoryTheory


### PR DESCRIPTION
We add a new structure `CategoryTheory.Precoverage` which only contains a family of covering presieves with no stability conditions. The existing `CategoryTheory.Pretopology` and `CategoryTheory.Coverage` are changed to extend `CategoryTheory.Precoverage`.

The main motivation for this refactor is to reduce the assumptions needed for using `Coverage.ZeroHypercover` (which is now `Precoverage.ZeroHypercover`): If `P` is a morphism property in a category `C`, the precoverage given by families satisfying `P` is only a coverage if `C` has pullbacks and `P` is stable under base change. In applications, this can either be not true or not known yet (For example the category of schemes has pullbacks and the relevant properties are stable under base change, but the cover API is used to deduce these results so we can't assume them a priori.)
The second motivation is to unify the common parts of `Coverage` and `Pretopology`.

The existing stability conditions `Coverage.IsStableUnderComposition` and `Coverage.IsStableUnderBaseChange` are defined for `Precoverage` instead.

Main (breaking) API change: `Coverage.covering` is now `Precoverage.coverings`.

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include at least one commit authored by each
co-author among the commits in the pull request. If necessary, you may 
create empty commits to indicate co-authorship, using commands like so:

git commit --author="Author Name <author@email.com>" --allow-empty -m "add Author Name as coauthor"

When merging, all the commits will be squashed into a single commit listing all co-authors.

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
