### PR TITLE
[Merged by Bors] - chore: minimize `fun_prop` imports

### DIFF
--- a/Mathlib/Tactic/FunProp/Mor.lean
+++ b/Mathlib/Tactic/FunProp/Mor.lean
@@ -3,7 +3,7 @@ Copyright (c) 2024 Tomáš Skřivan. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Tomáš Skřivan
 -/
-import Mathlib.Util.CompileInductive
+import Mathlib.Init
 
 /-!
 ## `funProp` Meta programming functions like in Lean.Expr.* but for working with bundled morphisms.

--- a/Mathlib/Tactic/FunProp/Mor.lean
+++ b/Mathlib/Tactic/FunProp/Mor.lean
@@ -3,7 +3,7 @@ Copyright (c) 2024 Tomáš Skřivan. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Tomáš Skřivan
 -/
-import Mathlib.Data.FunLike.Basic
+import Mathlib.Util.CompileInductive
 
 /-!
 ## `funProp` Meta programming functions like in Lean.Expr.* but for working with bundled morphisms.

--- a/Mathlib/Topology/ContinuousMap/Defs.lean
+++ b/Mathlib/Topology/ContinuousMap/Defs.lean
@@ -3,6 +3,7 @@ Copyright (c) 2020 Nicolò Cavalleri. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Nicolò Cavalleri, Yury Kudryashov
 -/
+import Mathlib.Data.FunLike.Basic
 import Mathlib.Tactic.Continuity
 import Mathlib.Tactic.Lift
 import Mathlib.Topology.Defs.Basic

--- a/scripts/noshake.json
+++ b/scripts/noshake.json
@@ -279,7 +279,6 @@
   "Mathlib.Tactic.GCongr.CoreAttrs": ["Mathlib.Tactic.GCongr.Core"],
   "Mathlib.Tactic.GCongr.Core": ["Mathlib.Order.Defs"],
   "Mathlib.Tactic.GCongr": ["Mathlib.Tactic.Positivity.Core"],
-  "Mathlib.Tactic.FunProp.Mor": ["Mathlib.Data.FunLike.Basic"],
   "Mathlib.Tactic.FunProp.Differentiable":
   ["Mathlib.Analysis.Calculus.Deriv.Inv",
    "Mathlib.Analysis.Calculus.FDeriv.Add",


### PR DESCRIPTION
This is both general import hygiene with the usual benefits (parallelism, potentially fewer rebuilds, etc.),
and has the practical benefit of enabling direct tagging of `Function.Injective` and friends with fun_prop.
Previously, this was impossible due to import cycles.

Zulip discussion: https://leanprover.zulipchat.com/#narrow/channel/144837-PR-reviews/topic/.2328191.20tag.20Injective.2C.20Surjective.2C.20and.20Bijective.20with.20fun_pro/with/536662776

---

<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include at least one commit authored by each
co-author among the commits in the pull request. If necessary, you may 
create empty commits to indicate co-authorship, using commands like so:

git commit --author="Author Name <author@email.com>" --allow-empty -m "add Author Name as coauthor"

When merging, all the commits will be squashed into a single commit listing all co-authors.

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
