### PR TITLE
[Merged by Bors] - refactor(CategoryTheory/Sites/Sieves): avoid `HasPullbacks C` in `Presieve.pullbackArrows`

### DIFF
--- a/Mathlib/CategoryTheory/Sites/Coherent/ExtensiveSheaves.lean
+++ b/Mathlib/CategoryTheory/Sites/Coherent/ExtensiveSheaves.lean
@@ -37,7 +37,7 @@ class Presieve.Extensive {X : C} (R : Presieve X) : Prop where
   arrows_nonempty_isColimit : ∃ (α : Type) (_ : Finite α) (Z : α → C) (π : (a : α) → (Z a ⟶ X)),
     R = Presieve.ofArrows Z π ∧ Nonempty (IsColimit (Cofan.mk X π))
 
-instance {X : C} (S : Presieve X) [S.Extensive] : S.hasPullbacks where
+instance {X : C} (S : Presieve X) [S.Extensive] : S.HasPairwisePullbacks where
   has_pullbacks := by
     obtain ⟨_, _, _, _, rfl, ⟨hc⟩⟩ := Presieve.Extensive.arrows_nonempty_isColimit (R := S)
     intro _ _ _ _ _ hg
@@ -51,8 +51,8 @@ A finite product preserving presheaf is a sheaf for the extensive topology on a 
 theorem isSheafFor_extensive_of_preservesFiniteProducts {X : C} (S : Presieve X) [S.Extensive]
     (F : Cᵒᵖ ⥤ Type w) [PreservesFiniteProducts F] : S.IsSheafFor F  := by
   obtain ⟨α, _, Z, π, rfl, ⟨hc⟩⟩ := Extensive.arrows_nonempty_isColimit (R := S)
-  have : (ofArrows Z (Cofan.mk X π).inj).hasPullbacks :=
-    (inferInstance : (ofArrows Z π).hasPullbacks)
+  have : (ofArrows Z (Cofan.mk X π).inj).HasPairwisePullbacks :=
+    (inferInstance : (ofArrows Z π).HasPairwisePullbacks)
   cases nonempty_fintype α
   exact isSheafFor_of_preservesProduct F _ hc
 
@@ -83,8 +83,8 @@ theorem Presieve.isSheaf_iff_preservesFiniteProducts (F : Cᵒᵖ ⥤ Type w) :
   refine ⟨fun hF ↦ ⟨fun n ↦ ⟨fun {K} ↦ ?_⟩⟩, fun hF ↦ ?_⟩
   · rw [extensiveTopology, isSheaf_coverage] at hF
     let Z : Fin n → C := fun i ↦ unop (K.obj ⟨i⟩)
-    have : (ofArrows Z (Cofan.mk (∐ Z) (Sigma.ι Z)).inj).hasPullbacks :=
-      inferInstanceAs (ofArrows Z (Sigma.ι Z)).hasPullbacks
+    have : (ofArrows Z (Cofan.mk (∐ Z) (Sigma.ι Z)).inj).HasPairwisePullbacks :=
+      inferInstanceAs (ofArrows Z (Sigma.ι Z)).HasPairwisePullbacks
     have : ∀ (i : Fin n), Mono (Cofan.inj (Cofan.mk (∐ Z) (Sigma.ι Z)) i) :=
       inferInstanceAs <| ∀ (i : Fin n), Mono (Sigma.ι Z i)
     let i : K ≅ Discrete.functor (fun i ↦ op (Z i)) := Discrete.natIsoFunctor

--- a/Mathlib/CategoryTheory/Sites/Coverage.lean
+++ b/Mathlib/CategoryTheory/Sites/Coverage.lean
@@ -68,10 +68,11 @@ def FactorsThruAlong {X Y : C} (S : Presieve Y) (T : Presieve X) (f : Y ⟶ X) :
   ∀ ⦃Z : C⦄ ⦃g : Z ⟶ Y⦄, S g →
   ∃ (W : C) (i : Z ⟶ W) (e : W ⟶ X), T e ∧ i ≫ e = g ≫ f
 
-lemma FactorsThruAlong.pullbackArrows [HasPullbacks C] {X Y : C} (f : X ⟶ Y)
-    (R : Presieve Y) :
+lemma FactorsThruAlong.pullbackArrows {X Y : C} (f : X ⟶ Y)
+    (R : Presieve Y) [R.HasPullbacks f] :
     (Presieve.pullbackArrows f R).FactorsThruAlong R f := by
   intro Z g ⟨W, b, hb⟩
+  have := R.hasPullback f hb
   refine ⟨_, pullback.fst _ _, b, hb, pullback.condition⟩
 
 /--

--- a/Mathlib/CategoryTheory/Sites/EqualizerSheafCondition.lean
+++ b/Mathlib/CategoryTheory/Sites/EqualizerSheafCondition.lean
@@ -172,7 +172,7 @@ https://stacks.math.columbia.edu/tag/00VM and the definition of `isSheafFor`.
 
 namespace Presieve
 
-variable [R.hasPullbacks]
+variable [R.HasPairwisePullbacks]
 
 /--
 The rightmost object of the fork diagram of the Stacks entry, which
@@ -181,14 +181,14 @@ contains the data used to check a family of elements for a presieve is compatibl
 @[simp, stacks 00VM "This is the rightmost object of the fork diagram there."]
 def SecondObj : Type max v u :=
   ∏ᶜ fun fg : (Σ Y, { f : Y ⟶ X // R f }) × Σ Z, { g : Z ⟶ X // R g } =>
-    haveI := Presieve.hasPullbacks.has_pullbacks fg.1.2.2 fg.2.2.2
+    haveI := Presieve.HasPairwisePullbacks.has_pullbacks fg.1.2.2 fg.2.2.2
     P.obj (op (pullback fg.1.2.1 fg.2.2.1))
 
 /-- The map `pr₀*` of the Stacks entry. -/
 @[stacks 00VM "This is the map `pr₀*` there."]
 def firstMap : FirstObj P R ⟶ SecondObj P R :=
   Pi.lift fun fg =>
-    haveI := Presieve.hasPullbacks.has_pullbacks fg.1.2.2 fg.2.2.2
+    haveI := Presieve.HasPairwisePullbacks.has_pullbacks fg.1.2.2 fg.2.2.2
     Pi.π _ _ ≫ P.map (pullback.fst _ _).op
 
 instance [HasPullbacks C] : Inhabited (SecondObj P (⊥ : Presieve X)) :=
@@ -198,7 +198,7 @@ instance [HasPullbacks C] : Inhabited (SecondObj P (⊥ : Presieve X)) :=
 @[stacks 00VM "This is the map `pr₁*` there."]
 def secondMap : FirstObj P R ⟶ SecondObj P R :=
   Pi.lift fun fg =>
-    haveI := Presieve.hasPullbacks.has_pullbacks fg.1.2.2 fg.2.2.2
+    haveI := Presieve.HasPairwisePullbacks.has_pullbacks fg.1.2.2 fg.2.2.2
     Pi.π _ _ ≫ P.map (pullback.snd _ _).op
 
 theorem w : forkMap P R ≫ firstMap P R = forkMap P R ≫ secondMap P R := by
@@ -206,7 +206,7 @@ theorem w : forkMap P R ≫ firstMap P R = forkMap P R ≫ secondMap P R := by
   ext fg
   simp only [firstMap, secondMap, forkMap]
   simp only [limit.lift_π, limit.lift_π_assoc, assoc, Fan.mk_π_app]
-  haveI := Presieve.hasPullbacks.has_pullbacks fg.1.2.2 fg.2.2.2
+  haveI := Presieve.HasPairwisePullbacks.has_pullbacks fg.1.2.2 fg.2.2.2
   rw [← P.map_comp, ← op_comp, pullback.condition]
   simp
 
@@ -252,7 +252,7 @@ variable (P : Cᵒᵖ ⥤ Type w) {X : C} (R : Presieve X) (S : Sieve X)
 open Presieve
 
 variable {B : C} {I : Type t} [Small.{w} I] (X : I → C) (π : (i : I) → X i ⟶ B)
-    [(Presieve.ofArrows X π).hasPullbacks]
+    [(Presieve.ofArrows X π).HasPairwisePullbacks]
 
 /--
 The middle object of the fork diagram of the Stacks entry.
@@ -316,7 +316,7 @@ See `CategoryTheory.Equalizer.Presieve.Arrows.compatible_iff_of_small` for a ver
 less universe assumptions.
 -/
 theorem compatible_iff {I : Type w} (X : I → C) (π : (i : I) → X i ⟶ B)
-    [(Presieve.ofArrows X π).hasPullbacks] (x : FirstObj P X) :
+    [(Presieve.ofArrows X π).HasPairwisePullbacks] (x : FirstObj P X) :
     (Arrows.Compatible P π ((Types.productIso _).hom x)) ↔
       firstMap P X π x = secondMap P X π x := by
   rw [Arrows.pullbackCompatible_iff]

--- a/Mathlib/CategoryTheory/Sites/IsSheafFor.lean
+++ b/Mathlib/CategoryTheory/Sites/IsSheafFor.lean
@@ -168,20 +168,21 @@ using the notation defined there.
 For a more explicit version in the case where `R` is of the form `Presieve.ofArrows`, see
 `CategoryTheory.Presieve.Arrows.PullbackCompatible`.
 -/
-def FamilyOfElements.PullbackCompatible (x : FamilyOfElements P R) [R.hasPullbacks] : Prop :=
+def FamilyOfElements.PullbackCompatible (x : FamilyOfElements P R) [R.HasPairwisePullbacks] :
+    Prop :=
   ∀ ⦃Y₁ Y₂⦄ ⦃f₁ : Y₁ ⟶ X⦄ ⦃f₂ : Y₂ ⟶ X⦄ (h₁ : R f₁) (h₂ : R f₂),
-    haveI := hasPullbacks.has_pullbacks h₁ h₂
+    haveI := HasPairwisePullbacks.has_pullbacks h₁ h₂
     P.map (pullback.fst f₁ f₂).op (x f₁ h₁) = P.map (pullback.snd f₁ f₂).op (x f₂ h₂)
 
-theorem pullbackCompatible_iff (x : FamilyOfElements P R) [R.hasPullbacks] :
+theorem pullbackCompatible_iff (x : FamilyOfElements P R) [R.HasPairwisePullbacks] :
     x.Compatible ↔ x.PullbackCompatible := by
   constructor
   · intro t Y₁ Y₂ f₁ f₂ hf₁ hf₂
     apply t
-    haveI := hasPullbacks.has_pullbacks hf₁ hf₂
+    haveI := HasPairwisePullbacks.has_pullbacks hf₁ hf₂
     apply pullback.condition
   · intro t Y₁ Y₂ Z g₁ g₂ f₁ f₂ hf₁ hf₂ comm
-    haveI := hasPullbacks.has_pullbacks hf₁ hf₂
+    haveI := HasPairwisePullbacks.has_pullbacks hf₁ hf₂
     rw [← pullback.lift_fst _ _ comm, op_comp, FunctorToTypes.map_comp_apply, t hf₁ hf₂,
       ← FunctorToTypes.map_comp_apply, ← op_comp, pullback.lift_snd]
 
@@ -771,7 +772,7 @@ theorem isSheafFor_arrows_iff : (ofArrows X π).IsSheafFor P ↔
       (fun i j Z gi gj ↦ hx gi gj (ofArrows.mk _) (ofArrows.mk _))
     exact ⟨t, fun Y f ⟨i⟩ ↦ hA i, fun y hy ↦ ht y (fun i ↦ hy (π i) (ofArrows.mk _))⟩
 
-variable [(ofArrows X π).hasPullbacks]
+variable [(ofArrows X π).HasPairwisePullbacks]
 
 /--
 A more explicit version of `FamilyOfElements.PullbackCompatible` for a `Presieve.ofArrows`.

--- a/Mathlib/CategoryTheory/Sites/OneHypercover.lean
+++ b/Mathlib/CategoryTheory/Sites/OneHypercover.lean
@@ -289,7 +289,7 @@ lemma sieve₁'_cylinder (i j : Σ (i : E.I₀), F.I₁ (f.s₀ i) (g.s₀ i)) :
     simp only [cylinder_Y, cylinder_f, toPullback_cylinder, pullback.condition]
   · rw [sieve₁', Sieve.ofArrows, ← Sieve.pullbackArrows_comm, Sieve.generate_le_iff]
     rintro Z u ⟨W, v, ⟨k⟩⟩
-    rw [← pullbackSymmetry_inv_comp_fst]
+    simp_rw [← pullbackSymmetry_inv_comp_fst]
     apply (((cylinder f g).sieve₁' i j)).downward_closed
     rw [sieve₁']
     convert Sieve.ofArrows_mk _ _ (ULift.up k)

--- a/Mathlib/CategoryTheory/Sites/Preserves.lean
+++ b/Mathlib/CategoryTheory/Sites/Preserves.lean
@@ -89,7 +89,7 @@ theorem piComparison_fac :
   rw [hh, ← desc_op_comp_opCoproductIsoProduct'_hom hc]
   simp
 
-variable [(ofArrows X c.inj).hasPullbacks]
+variable [(ofArrows X c.inj).HasPairwisePullbacks]
 
 include hc in
 /--


### PR DESCRIPTION
We introduce a new typeclass `Presieve.HasPullbacks R f` which says that the pullbacks of the component maps of `R` along `f` exist. This is used instead of `HasPullbacks C` in `Presieve.pullbackArrows`.

The motivation for this is to be able to use `Presieve.pullbackArrows` in situations where either not all pullbacks exist or it is not yet known that all pullbacks exist. An example is the category of schemes, where existence of pullbacks along open immersions is shown as a step towards the proof of existence of all pullbacks.

The already existing `Presieve.hasPullbacks` is renamed to `Presieve.HasPairwisePullbacks` to make the distinction clear.

This refactor also opens up the possibility to weaken the `HasPullbacks C` assumption from `Pretopology`.

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include at least one commit authored by each
co-author among the commits in the pull request. If necessary, you may 
create empty commits to indicate co-authorship, using commands like so:

git commit --author="Author Name <author@email.com>" --allow-empty -m "add Author Name as coauthor"

When merging, all the commits will be squashed into a single commit listing all co-authors.

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
