### PR TITLE
[Merged by Bors] - chore(LinearAlgebra/Span/Basic): some API for `toSpanSingleton`

### DIFF
--- a/Mathlib/LinearAlgebra/Span/Basic.lean
+++ b/Mathlib/LinearAlgebra/Span/Basic.lean
@@ -681,7 +681,6 @@ variable (R) (M) [Semiring R] [AddCommMonoid M] [Module R M]
 def toSpanSingleton (x : M) : R →ₗ[R] M :=
   LinearMap.id.smulRight x
 
-@[simp]
 theorem toSpanSingleton_one (x : M) : toSpanSingleton R M x 1 = x :=
   one_smul _ _
 

--- a/Mathlib/LinearAlgebra/Span/Basic.lean
+++ b/Mathlib/LinearAlgebra/Span/Basic.lean
@@ -681,6 +681,7 @@ variable (R) (M) [Semiring R] [AddCommMonoid M] [Module R M]
 def toSpanSingleton (x : M) : R →ₗ[R] M :=
   LinearMap.id.smulRight x
 
+@[simp]
 theorem toSpanSingleton_one (x : M) : toSpanSingleton R M x 1 = x :=
   one_smul _ _
 

--- a/Mathlib/LinearAlgebra/Span/Basic.lean
+++ b/Mathlib/LinearAlgebra/Span/Basic.lean
@@ -681,12 +681,6 @@ variable (R) (M) [Semiring R] [AddCommMonoid M] [Module R M]
 def toSpanSingleton (x : M) : R →ₗ[R] M :=
   LinearMap.id.smulRight x
 
-/-- The range of `toSpanSingleton x` is the span of `x`. -/
-theorem span_singleton_eq_range (x : M) : (R ∙ x) = range (toSpanSingleton R M x) :=
-  Submodule.ext fun y => by
-    refine Iff.trans ?_ LinearMap.mem_range.symm
-    exact mem_span_singleton
-
 theorem toSpanSingleton_one (x : M) : toSpanSingleton R M x 1 = x :=
   one_smul _ _
 
@@ -703,6 +697,15 @@ theorem toSpanSingleton_eq_zero_iff {x : M} : toSpanSingleton R M x = 0 ↔ x = 
 
 variable {R M}
 
+lemma toSpanSingleton_add (x y : M) :
+    toSpanSingleton R M (x + y) = toSpanSingleton R M x + toSpanSingleton R M y := by
+  ext; simp
+
+theorem toSpanSingleton_smul {S : Type*} [Monoid S] [DistribMulAction S M]
+    [SMulCommClass R S M] (r : S) (x : M) :
+    toSpanSingleton R M (r • x) = r • toSpanSingleton R M x := by
+  ext; simp
+
 theorem toSpanSingleton_isIdempotentElem_iff {e : R} :
     IsIdempotentElem (toSpanSingleton R R e) ↔ IsIdempotentElem e := by
   simp_rw [IsIdempotentElem, LinearMap.ext_iff, Module.End.mul_apply, toSpanSingleton_apply,
@@ -716,9 +719,15 @@ theorem isIdempotentElem_apply_one_iff {f : Module.End R R} :
   simp_rw [Module.End.mul_apply]
   exact ⟨fun h r ↦ by rw [← mul_one r, ← smul_eq_mul, map_smul, map_smul, h], (· 1)⟩
 
+/-- The range of `toSpanSingleton x` is the span of `x`. -/
 theorem range_toSpanSingleton (x : M) :
     range (toSpanSingleton R M x) = .span R {x} :=
   SetLike.coe_injective (Submodule.span_singleton_eq_range R x).symm
+
+variable (R) in
+theorem span_singleton_eq_range (x : M) :
+    (R ∙ x) = range (toSpanSingleton R M x) :=
+  range_toSpanSingleton x |>.symm
 
 theorem submoduleOf_span_singleton_of_mem (N : Submodule R M) {x : M} (hx : x ∈ N) :
     (span R {x}).submoduleOf N = span R {⟨x, hx⟩} := by
@@ -806,7 +815,7 @@ def toSpanNonzeroSingleton : R ≃ₗ[R] R ∙ x :=
   LinearEquiv.trans
     (LinearEquiv.ofInjective (LinearMap.toSpanSingleton R M x)
       (ker_eq_bot.1 <| ker_toSpanSingleton R M h))
-    (LinearEquiv.ofEq (range <| toSpanSingleton R M x) (R ∙ x) (span_singleton_eq_range R M x).symm)
+    (LinearEquiv.ofEq (range <| toSpanSingleton R M x) (R ∙ x) (range_toSpanSingleton x))
 
 @[simp] theorem toSpanNonzeroSingleton_apply (t : R) :
     toSpanNonzeroSingleton R M x h t =

--- a/Mathlib/LinearAlgebra/Span/Basic.lean
+++ b/Mathlib/LinearAlgebra/Span/Basic.lean
@@ -724,7 +724,7 @@ theorem range_toSpanSingleton (x : M) :
     range (toSpanSingleton R M x) = .span R {x} :=
   SetLike.coe_injective (Submodule.span_singleton_eq_range R x).symm
 
-variable (R) in
+variable (R M) in
 theorem span_singleton_eq_range (x : M) :
     (R ∙ x) = range (toSpanSingleton R M x) :=
   range_toSpanSingleton x |>.symm

--- a/Mathlib/MeasureTheory/Function/ConditionalExpectation/CondexpL1.lean
+++ b/Mathlib/MeasureTheory/Function/ConditionalExpectation/CondexpL1.lean
@@ -113,7 +113,7 @@ theorem condExpIndL1Fin_smul' [NormedSpace ℝ F] [SMulCommClass ℝ 𝕜 F] (hs
   ext1
   refine (MemLp.coeFn_toLp q).trans ?_
   refine EventuallyEq.trans ?_ (Lp.coeFn_smul _ _).symm
-  rw [condExpIndSMul_smul' hs hμs c x]
+  rw [condExpIndSMul_smul hs hμs c x]
   refine (Lp.coeFn_smul _ _).trans ?_
   refine (condExpIndL1Fin_ae_eq_condExpIndSMul hm hs hμs x).mono fun y hy => ?_
   simp only [Pi.smul_apply, hy]

--- a/Mathlib/MeasureTheory/Function/ConditionalExpectation/CondexpL2.lean
+++ b/Mathlib/MeasureTheory/Function/ConditionalExpectation/CondexpL2.lean
@@ -363,15 +363,13 @@ theorem condExpIndSMul_add (hs : MeasurableSet s) (hμs : μ s ≠ ∞) (x y : G
     condExpIndSMul hm hs hμs (x + y) = condExpIndSMul hm hs hμs x + condExpIndSMul hm hs hμs y := by
   simp_rw [condExpIndSMul]; rw [toSpanSingleton_add, add_compLpL, add_apply]
 
-theorem condExpIndSMul_smul (hs : MeasurableSet s) (hμs : μ s ≠ ∞) (c : ℝ) (x : G) :
-    condExpIndSMul hm hs hμs (c • x) = c • condExpIndSMul hm hs hμs x := by
-  simp_rw [condExpIndSMul]; rw [toSpanSingleton_smul, smul_compLpL, smul_apply]
-
-theorem condExpIndSMul_smul' [NormedSpace ℝ F] [SMulCommClass ℝ 𝕜 F] (hs : MeasurableSet s)
+theorem condExpIndSMul_smul [NormedSpace ℝ F] [SMulCommClass ℝ 𝕜 F] (hs : MeasurableSet s)
     (hμs : μ s ≠ ∞) (c : 𝕜) (x : F) :
     condExpIndSMul hm hs hμs (c • x) = c • condExpIndSMul hm hs hμs x := by
   rw [condExpIndSMul, condExpIndSMul, toSpanSingleton_smul',
     (toSpanSingleton ℝ x).smul_compLpL c, smul_apply]
+
+@[deprecated (since := 28-08-2025)] alias condExpIndSMul_smul' := condExpIndSMul_smul
 
 theorem condExpIndSMul_ae_eq_smul (hm : m ≤ m0) (hs : MeasurableSet s) (hμs : μ s ≠ ∞) (x : G) :
     condExpIndSMul hm hs hμs x =ᵐ[μ] fun a =>

--- a/Mathlib/MeasureTheory/Function/ConditionalExpectation/CondexpL2.lean
+++ b/Mathlib/MeasureTheory/Function/ConditionalExpectation/CondexpL2.lean
@@ -366,7 +366,7 @@ theorem condExpIndSMul_add (hs : MeasurableSet s) (hμs : μ s ≠ ∞) (x y : G
 theorem condExpIndSMul_smul [NormedSpace ℝ F] [SMulCommClass ℝ 𝕜 F] (hs : MeasurableSet s)
     (hμs : μ s ≠ ∞) (c : 𝕜) (x : F) :
     condExpIndSMul hm hs hμs (c • x) = c • condExpIndSMul hm hs hμs x := by
-  rw [condExpIndSMul, condExpIndSMul, toSpanSingleton_smul',
+  rw [condExpIndSMul, condExpIndSMul, toSpanSingleton_smul,
     (toSpanSingleton ℝ x).smul_compLpL c, smul_apply]
 
 @[deprecated (since := 28-08-2025)] alias condExpIndSMul_smul' := condExpIndSMul_smul

--- a/Mathlib/MeasureTheory/Function/ConditionalExpectation/CondexpL2.lean
+++ b/Mathlib/MeasureTheory/Function/ConditionalExpectation/CondexpL2.lean
@@ -366,8 +366,7 @@ theorem condExpIndSMul_add (hs : MeasurableSet s) (hμs : μ s ≠ ∞) (x y : G
 theorem condExpIndSMul_smul [NormedSpace ℝ F] [SMulCommClass ℝ 𝕜 F] (hs : MeasurableSet s)
     (hμs : μ s ≠ ∞) (c : 𝕜) (x : F) :
     condExpIndSMul hm hs hμs (c • x) = c • condExpIndSMul hm hs hμs x := by
-  rw [condExpIndSMul, condExpIndSMul, toSpanSingleton_smul,
-    (toSpanSingleton ℝ x).smul_compLpL c, smul_apply]
+  simp_rw [condExpIndSMul, toSpanSingleton_smul, smul_compLpL, smul_apply]
 
 @[deprecated (since := "28-08-2025")] alias condExpIndSMul_smul' := condExpIndSMul_smul
 

--- a/Mathlib/MeasureTheory/Function/ConditionalExpectation/CondexpL2.lean
+++ b/Mathlib/MeasureTheory/Function/ConditionalExpectation/CondexpL2.lean
@@ -369,7 +369,7 @@ theorem condExpIndSMul_smul [NormedSpace ℝ F] [SMulCommClass ℝ 𝕜 F] (hs :
   rw [condExpIndSMul, condExpIndSMul, toSpanSingleton_smul,
     (toSpanSingleton ℝ x).smul_compLpL c, smul_apply]
 
-@[deprecated (since := 28-08-2025)] alias condExpIndSMul_smul' := condExpIndSMul_smul
+@[deprecated (since := "28-08-2025")] alias condExpIndSMul_smul' := condExpIndSMul_smul
 
 theorem condExpIndSMul_ae_eq_smul (hm : m ≤ m0) (hs : MeasurableSet s) (hμs : μ s ≠ ∞) (x : G) :
     condExpIndSMul hm hs hμs x =ᵐ[μ] fun a =>

--- a/Mathlib/Topology/Algebra/Module/LinearMap.lean
+++ b/Mathlib/Topology/Algebra/Module/LinearMap.lean
@@ -718,6 +718,10 @@ def toSpanSingleton (x : M₁) : R₁ →L[R₁] M₁ where
 theorem toSpanSingleton_apply (x : M₁) (r : R₁) : toSpanSingleton R₁ x r = r • x :=
   rfl
 
+@[simp]
+theorem toSpanSingleton_one (x : M₁) : toSpanSingleton R₁ x 1 = x :=
+  one_smul _ _
+
 theorem toSpanSingleton_add [ContinuousAdd M₁] (x y : M₁) :
     toSpanSingleton R₁ (x + y) = toSpanSingleton R₁ x + toSpanSingleton R₁ y :=
   coe_inj.mp <| LinearMap.toSpanSingleton_add _ _
@@ -733,6 +737,7 @@ theorem one_smulRight_eq_toSpanSingleton (x : M₁) :
     (1 : R₁ →L[R₁] R₁).smulRight x = toSpanSingleton R₁ x :=
   rfl
 
+@[simp]
 theorem toLinearMap_toSpanSingleton (x : M₁) :
     (toSpanSingleton R₁ x).toLinearMap = LinearMap.toSpanSingleton R₁ M₁ x := rfl
 

--- a/Mathlib/Topology/Algebra/Module/LinearMap.lean
+++ b/Mathlib/Topology/Algebra/Module/LinearMap.lean
@@ -719,19 +719,15 @@ theorem toSpanSingleton_apply (x : M₁) (r : R₁) : toSpanSingleton R₁ x r =
   rfl
 
 theorem toSpanSingleton_add [ContinuousAdd M₁] (x y : M₁) :
-    toSpanSingleton R₁ (x + y) = toSpanSingleton R₁ x + toSpanSingleton R₁ y := by
-  ext1; simp [toSpanSingleton_apply]
+    toSpanSingleton R₁ (x + y) = toSpanSingleton R₁ x + toSpanSingleton R₁ y :=
+  coe_inj.mp <| LinearMap.toSpanSingleton_add _ _
 
-theorem toSpanSingleton_smul' {α} [Monoid α] [DistribMulAction α M₁] [ContinuousConstSMul α M₁]
+theorem toSpanSingleton_smul {α} [Monoid α] [DistribMulAction α M₁] [ContinuousConstSMul α M₁]
     [SMulCommClass R₁ α M₁] (c : α) (x : M₁) :
-    toSpanSingleton R₁ (c • x) = c • toSpanSingleton R₁ x := by
-  ext1; rw [toSpanSingleton_apply, smul_apply, toSpanSingleton_apply, smul_comm]
+    toSpanSingleton R₁ (c • x) = c • toSpanSingleton R₁ x :=
+  coe_inj.mp <| LinearMap.toSpanSingleton_smul _ _
 
-/-- A special case of `to_span_singleton_smul'` for when `R` is commutative. -/
-theorem toSpanSingleton_smul (R) {M₁} [CommSemiring R] [AddCommMonoid M₁] [Module R M₁]
-    [TopologicalSpace R] [TopologicalSpace M₁] [ContinuousSMul R M₁] (c : R) (x : M₁) :
-    toSpanSingleton R (c • x) = c • toSpanSingleton R x :=
-  toSpanSingleton_smul' R c x
+@[deprecated (since := "28-08-2025")] alias toSpanSingleton_smul' := toSpanSingleton_smul
 
 theorem one_smulRight_eq_toSpanSingleton (x : M₁) :
     (1 : R₁ →L[R₁] R₁).smulRight x = toSpanSingleton R₁ x :=

--- a/Mathlib/Topology/Algebra/Module/LinearMap.lean
+++ b/Mathlib/Topology/Algebra/Module/LinearMap.lean
@@ -733,6 +733,9 @@ theorem one_smulRight_eq_toSpanSingleton (x : M₁) :
     (1 : R₁ →L[R₁] R₁).smulRight x = toSpanSingleton R₁ x :=
   rfl
 
+theorem toLinearMap_toSpanSingleton (x : M₁) :
+    (toSpanSingleton R₁ x).toLinearMap = LinearMap.toSpanSingleton R₁ M₁ x := rfl
+
 end ToSpanSingleton
 
 end Semiring

--- a/Mathlib/Topology/Algebra/Module/LinearMap.lean
+++ b/Mathlib/Topology/Algebra/Module/LinearMap.lean
@@ -718,7 +718,6 @@ def toSpanSingleton (x : M₁) : R₁ →L[R₁] M₁ where
 theorem toSpanSingleton_apply (x : M₁) (r : R₁) : toSpanSingleton R₁ x r = r • x :=
   rfl
 
-@[simp]
 theorem toSpanSingleton_one (x : M₁) : toSpanSingleton R₁ x 1 = x :=
   one_smul _ _
 


### PR DESCRIPTION
Adds `LinearMap.toSpanSingleton_add` and `LinearMap.toSpanSingleton_smul`.

`LinearMap.span_singleton_eq_range` is `LinearMap.range_toSpanSingleton.symm`, kept it (for the sake of the name) but moved it so we can use `range_toSpanSingleton` as its proof.

Renamed `ContinuousLinearMap.toSpanSingleton_smul'` to `_smul` and deleted the old `_smul` because everything in `_smul'` can be inferred when `R` is commutative, so it seemed natural to me to do so.

Similarly, renamed `MeasureTheory.condExpIndSMul_smul'` to `_smul` and deleted the old `_smul` because everything can be inferred.

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include at least one commit authored by each
co-author among the commits in the pull request. If necessary, you may 
create empty commits to indicate co-authorship, using commands like so:

git commit --author="Author Name <author@email.com>" --allow-empty -m "add Author Name as coauthor"

When merging, all the commits will be squashed into a single commit listing all co-authors.

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
