### PR TITLE
[Merged by Bors] - chore(Data): move results about the Vandermonde matrix to `LinearAlgebra`

### DIFF
--- a/Mathlib/Data/Nat/Factorial/SuperFactorial.lean
+++ b/Mathlib/Data/Nat/Factorial/SuperFactorial.lean
@@ -4,10 +4,7 @@ Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Moritz Firsching
 -/
 import Mathlib.Algebra.BigOperators.Intervals
-import Mathlib.Algebra.Polynomial.Monic
-import Mathlib.Data.Nat.Factorial.Basic
-import Mathlib.LinearAlgebra.Vandermonde
-import Mathlib.RingTheory.Polynomial.Pochhammer
+import Mathlib.Tactic.Ring
 
 /-!
 # Superfactorial
@@ -67,21 +64,6 @@ theorem prod_range_succ_factorial : ∀ n : ℕ, ∏ x ∈ range (n + 1), x ! = 
   | n + 1 => by
     rw [prod_range_succ, prod_range_succ_factorial n, mul_comm, superFactorial]
 
-variable {R : Type*} [CommRing R]
-
-theorem det_vandermonde_id_eq_superFactorial (n : ℕ) :
-    (Matrix.vandermonde (fun (i : Fin (n + 1)) ↦ (i : R))).det = Nat.superFactorial n := by
-  induction' n with n hn
-  · simp
-  · rw [Nat.superFactorial, Matrix.det_vandermonde, Fin.prod_univ_succAbove _ 0]
-    push_cast
-    congr
-    · simp only [Fin.val_zero, Nat.cast_zero, sub_zero]
-      norm_cast
-      simp [Fin.prod_univ_eq_prod_range (fun i ↦ (↑i + 1)) (n + 1)]
-    · rw [Matrix.det_vandermonde] at hn
-      simp [hn]
-
 theorem superFactorial_two_mul : ∀ n : ℕ,
     sf (2 * n) = (∏ i ∈ range n, (2 * i + 1) !) ^ 2 * 2 ^ n * n !
   | 0 => rfl
@@ -97,29 +79,6 @@ theorem superFactorial_four_mul (n : ℕ) :
       rw [← superFactorial_two_mul, ← mul_assoc, Nat.mul_two]
     _ = ((∏ i ∈ range (2 * n), (2 * i + 1) !) * 2 ^ n) ^ 2 * (2 * n) ! := by
       rw [pow_mul', mul_pow]
-
-private theorem matrixOf_eval_descPochhammer_eq_mul_matrixOf_choose {n : ℕ} (v : Fin n → ℕ) :
-    (Matrix.of (fun (i j : Fin n) => (descPochhammer ℤ j).eval (v i : ℤ))).det =
-    (∏ i : Fin n, Nat.factorial i) *
-      (Matrix.of (fun (i j : Fin n) => (Nat.choose (v i) (j : ℕ) : ℤ))).det := by
-  convert Matrix.det_mul_row (fun (i : Fin n) => ((Nat.factorial (i : ℕ)) : ℤ)) _
-  · rw [Matrix.of_apply, descPochhammer_eval_eq_descFactorial ℤ _ _]
-    congr
-    exact Nat.descFactorial_eq_factorial_mul_choose _ _
-  · rw [Nat.cast_prod]
-
-theorem superFactorial_dvd_vandermonde_det {n : ℕ} (v : Fin (n + 1) → ℤ) :
-    ↑(Nat.superFactorial n) ∣ (Matrix.vandermonde v).det := by
-  let m := inf' univ ⟨0, mem_univ _⟩ v
-  let w' := fun i ↦ (v i - m).toNat
-  have hw' : ∀ i, (w' i : ℤ) = v i - m := fun i ↦ Int.toNat_sub_of_le (inf'_le _ (mem_univ _))
-  have h := Matrix.det_eval_matrixOfPolynomials_eq_det_vandermonde (fun i ↦ ↑(w' i))
-      (fun i => descPochhammer ℤ i)
-      (fun i => descPochhammer_natDegree ℤ i)
-      (fun i => monic_descPochhammer ℤ i)
-  conv_lhs at h => simp only [hw', Matrix.det_vandermonde_sub]
-  use (Matrix.of (fun (i j : Fin (n + 1)) => (Nat.choose (w' i) (j : ℕ) : ℤ))).det
-  simp [h, matrixOf_eval_descPochhammer_eq_mul_matrixOf_choose w', Fin.prod_univ_eq_prod_range]
 
 end SuperFactorial
 

--- a/Mathlib/LinearAlgebra/Vandermonde.lean
+++ b/Mathlib/LinearAlgebra/Vandermonde.lean
@@ -3,6 +3,7 @@ Copyright (c) 2020 Anne Baanen. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Anne Baanen, Peter Nelson
 -/
+import Mathlib.Data.Nat.Factorial.SuperFactorial
 import Mathlib.LinearAlgebra.Matrix.Block
 import Mathlib.LinearAlgebra.Matrix.Nondegenerate
 import Mathlib.RingTheory.Localization.FractionRing
@@ -274,5 +275,41 @@ theorem det_eval_matrixOfPolynomials_eq_det_vandermonde (v : Fin n → R) (p : F
   rw [Matrix.eval_matrixOfPolynomials_eq_vandermonde_mul_matrixOfPolynomials v p (fun i ↦
       Nat.le_of_eq (h_deg i)), Matrix.det_mul,
       Matrix.det_matrixOfPolynomials p h_deg h_monic, mul_one]
+
+lemma det_vandermonde_id_eq_superFactorial (n : ℕ) :
+    (vandermonde fun (i : Fin (n + 1)) ↦ (i : R)).det = Nat.superFactorial n := by
+  induction' n with n hn
+  · simp
+  · rw [Nat.superFactorial, det_vandermonde, Fin.prod_univ_succAbove _ 0]
+    push_cast
+    congr
+    · simp only [Fin.val_zero, Nat.cast_zero, sub_zero]
+      norm_cast
+      simp [Fin.prod_univ_eq_prod_range (fun i ↦ (↑i + 1)) (n + 1)]
+    · rw [det_vandermonde] at hn
+      simp [hn]
+
+private lemma of_eval_descPochhammer_eq_mul_of_choose {n : ℕ} (v : Fin n → ℕ) :
+    (of fun i j : Fin n => (descPochhammer ℤ j).eval (v i : ℤ)).det =
+    (∏ i : Fin n, Nat.factorial i) *
+      (of fun i j : Fin n => (Nat.choose (v i) j : ℤ)).det := by
+  convert det_mul_row (fun (i : Fin n) => ((Nat.factorial (i : ℕ)) : ℤ)) _
+  · rw [of_apply, descPochhammer_eval_eq_descFactorial ℤ _ _]
+    congr
+    exact Nat.descFactorial_eq_factorial_mul_choose _ _
+  · rw [Nat.cast_prod]
+
+lemma superFactorial_dvd_vandermonde_det {n : ℕ} (v : Fin (n + 1) → ℤ) :
+    ↑n.superFactorial ∣ (vandermonde v).det := by
+  let m := inf' univ ⟨0, mem_univ _⟩ v
+  let w' := fun i ↦ (v i - m).toNat
+  have hw' : ∀ i, (w' i : ℤ) = v i - m := fun i ↦ Int.toNat_sub_of_le (inf'_le _ (mem_univ _))
+  have h := det_eval_matrixOfPolynomials_eq_det_vandermonde (fun i ↦ ↑(w' i))
+      (fun i => descPochhammer ℤ i)
+      (fun i => descPochhammer_natDegree ℤ i)
+      (fun i => monic_descPochhammer ℤ i)
+  conv_lhs at h => simp only [hw', det_vandermonde_sub]
+  use (of (fun (i j : Fin (n + 1)) => (Nat.choose (w' i) (j : ℕ) : ℤ))).det
+  simp [h, of_eval_descPochhammer_eq_mul_of_choose w', Fin.prod_univ_eq_prod_range]
 
 end Matrix

--- a/Mathlib/LinearAlgebra/Vandermonde.lean
+++ b/Mathlib/LinearAlgebra/Vandermonde.lean
@@ -7,6 +7,7 @@ import Mathlib.Data.Nat.Factorial.SuperFactorial
 import Mathlib.LinearAlgebra.Matrix.Block
 import Mathlib.LinearAlgebra.Matrix.Nondegenerate
 import Mathlib.RingTheory.Localization.FractionRing
+import Mathlib.RingTheory.Polynomial.Pochhammer
 
 /-!
 # Vandermonde matrix
@@ -277,7 +278,7 @@ theorem det_eval_matrixOfPolynomials_eq_det_vandermonde (v : Fin n → R) (p : F
       Matrix.det_matrixOfPolynomials p h_deg h_monic, mul_one]
 
 lemma det_vandermonde_id_eq_superFactorial (n : ℕ) :
-    (vandermonde fun (i : Fin (n + 1)) ↦ (i : R)).det = Nat.superFactorial n := by
+    (vandermonde fun i : Fin (n + 1) ↦ (i : R)).det = n.superFactorial := by
   induction' n with n hn
   · simp
   · rw [Nat.superFactorial, det_vandermonde, Fin.prod_univ_succAbove _ 0]


### PR DESCRIPTION
These have nothing to do with data structures.


---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include at least one commit authored by each
co-author among the commits in the pull request. If necessary, you may 
create empty commits to indicate co-authorship, using commands like so:

git commit --author="Author Name <author@email.com>" --allow-empty -m "add Author Name as coauthor"

When merging, all the commits will be squashed into a single commit listing all co-authors.

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
