### PR TITLE
[Merged by Bors] - chore(Analysis/Convex): move to new file StdSimplex

### DIFF
--- a/Mathlib.lean
+++ b/Mathlib.lean
@@ -1615,6 +1615,7 @@ import Mathlib.Analysis.Convex.SpecificFunctions.Basic
 import Mathlib.Analysis.Convex.SpecificFunctions.Deriv
 import Mathlib.Analysis.Convex.SpecificFunctions.Pow
 import Mathlib.Analysis.Convex.Star
+import Mathlib.Analysis.Convex.StdSimplex
 import Mathlib.Analysis.Convex.StoneSeparation
 import Mathlib.Analysis.Convex.Strict
 import Mathlib.Analysis.Convex.StrictConvexBetween

--- a/Mathlib/Analysis/Convex/Basic.lean
+++ b/Mathlib/Analysis/Convex/Basic.lean
@@ -12,15 +12,12 @@ import Mathlib.Tactic.NoncommRing
 import Mathlib.LinearAlgebra.AffineSpace.AffineSubspace.Defs
 
 /-!
-# Convex sets and functions in vector spaces
+# Convex sets
 
-In a 𝕜-vector space, we define the following objects and properties.
+In a 𝕜-vector space, we define the following property:
 * `Convex 𝕜 s`: A set `s` is convex if for any two points `x y ∈ s` it includes `segment 𝕜 x y`.
-* `stdSimplex 𝕜 ι`: The standard simplex in `ι → 𝕜` (currently requires `Fintype ι`). It is the
-  intersection of the positive quadrant with the hyperplane `s.sum = 1`.
 
-We also provide various equivalent versions of the definitions above, prove that some specific sets
-are convex.
+We provide various equivalent versions, and prove that some specific sets are convex.
 
 ## TODO
 
@@ -583,93 +580,3 @@ protected theorem starConvex (K : Submodule 𝕜 E) : StarConvex 𝕜 (0 : E) K 
   K.convex K.zero_mem
 
 end Submodule
-
-/-! ### Simplex -/
-
-
-section Simplex
-
-section OrderedSemiring
-
-variable (𝕜) (ι : Type*) [Semiring 𝕜] [PartialOrder 𝕜] [Fintype ι]
-
-/-- The standard simplex in the space of functions `ι → 𝕜` is the set of vectors with non-negative
-coordinates with total sum `1`. This is the free object in the category of convex spaces. -/
-def stdSimplex : Set (ι → 𝕜) :=
-  { f | (∀ x, 0 ≤ f x) ∧ ∑ x, f x = 1 }
-
-theorem stdSimplex_eq_inter : stdSimplex 𝕜 ι = (⋂ x, { f | 0 ≤ f x }) ∩ { f | ∑ x, f x = 1 } := by
-  ext f
-  simp only [stdSimplex, Set.mem_inter_iff, Set.mem_iInter, Set.mem_setOf_eq]
-
-theorem convex_stdSimplex [IsOrderedRing 𝕜] : Convex 𝕜 (stdSimplex 𝕜 ι) := by
-  refine fun f hf g hg a b ha hb hab => ⟨fun x => ?_, ?_⟩
-  · apply_rules [add_nonneg, mul_nonneg, hf.1, hg.1]
-  · simp_rw [Pi.add_apply, Pi.smul_apply]
-    rwa [Finset.sum_add_distrib, ← Finset.smul_sum, ← Finset.smul_sum, hf.2, hg.2, smul_eq_mul,
-      smul_eq_mul, mul_one, mul_one]
-
-@[nontriviality] lemma stdSimplex_of_subsingleton [Subsingleton 𝕜] : stdSimplex 𝕜 ι = univ :=
-  eq_univ_of_forall fun _ ↦ ⟨fun _ ↦ (Subsingleton.elim _ _).le, Subsingleton.elim _ _⟩
-
-/-- The standard simplex in the zero-dimensional space is empty. -/
-lemma stdSimplex_of_isEmpty_index [IsEmpty ι] [Nontrivial 𝕜] : stdSimplex 𝕜 ι = ∅ :=
-  eq_empty_of_forall_notMem <| by rintro f ⟨-, hf⟩; simp at hf
-
-lemma stdSimplex_unique [ZeroLEOneClass 𝕜] [Nonempty ι] [Subsingleton ι] :
-    stdSimplex 𝕜 ι = {fun _ ↦ 1} := by
-  cases nonempty_unique ι
-  refine eq_singleton_iff_unique_mem.2 ⟨⟨fun _ ↦ zero_le_one, Fintype.sum_unique _⟩, ?_⟩
-  rintro f ⟨-, hf⟩
-  rw [Fintype.sum_unique] at hf
-  exact funext (Unique.forall_iff.2 hf)
-
-variable {ι} [DecidableEq ι] [ZeroLEOneClass 𝕜]
-
-theorem single_mem_stdSimplex (i : ι) : Pi.single i 1 ∈ stdSimplex 𝕜 ι :=
-  ⟨le_update_iff.2 ⟨zero_le_one, fun _ _ ↦ le_rfl⟩, by simp⟩
-
-theorem ite_eq_mem_stdSimplex (i : ι) : (if i = · then (1 : 𝕜) else 0) ∈ stdSimplex 𝕜 ι := by
-  simpa only [@eq_comm _ i, ← Pi.single_apply] using single_mem_stdSimplex 𝕜 i
-
-variable [IsOrderedRing 𝕜]
-
-#adaptation_note /-- nightly-2024-03-11
-we need a type annotation on the segment in the following two lemmas. -/
-
-/-- The edges are contained in the simplex. -/
-lemma segment_single_subset_stdSimplex (i j : ι) :
-    ([Pi.single i 1 -[𝕜] Pi.single j 1] : Set (ι → 𝕜)) ⊆ stdSimplex 𝕜 ι :=
-  (convex_stdSimplex 𝕜 ι).segment_subset (single_mem_stdSimplex _ _) (single_mem_stdSimplex _ _)
-
-lemma stdSimplex_fin_two :
-    stdSimplex 𝕜 (Fin 2) = ([Pi.single 0 1 -[𝕜] Pi.single 1 1] : Set (Fin 2 → 𝕜)) := by
-  refine Subset.antisymm ?_ (segment_single_subset_stdSimplex 𝕜 (0 : Fin 2) 1)
-  rintro f ⟨hf₀, hf₁⟩
-  rw [Fin.sum_univ_two] at hf₁
-  refine ⟨f 0, f 1, hf₀ 0, hf₀ 1, hf₁, funext <| Fin.forall_fin_two.2 ?_⟩
-  simp
-
-end OrderedSemiring
-
-section OrderedRing
-
-variable (𝕜) [Ring 𝕜] [PartialOrder 𝕜] [IsOrderedRing 𝕜]
-
-/-- The standard one-dimensional simplex in `Fin 2 → 𝕜` is equivalent to the unit interval. -/
-@[simps -fullyApplied]
-def stdSimplexEquivIcc : stdSimplex 𝕜 (Fin 2) ≃ Icc (0 : 𝕜) 1 where
-  toFun f := ⟨f.1 0, f.2.1 _, f.2.2 ▸
-    Finset.single_le_sum (fun i _ ↦ f.2.1 i) (Finset.mem_univ _)⟩
-  invFun x := ⟨![x, 1 - x], Fin.forall_fin_two.2 ⟨x.2.1, sub_nonneg.2 x.2.2⟩,
-    calc
-      ∑ i : Fin 2, ![(x : 𝕜), 1 - x] i = x + (1 - x) := Fin.sum_univ_two _
-      _ = 1 := add_sub_cancel _ _⟩
-  left_inv f := Subtype.eq <| funext <| Fin.forall_fin_two.2 <| .intro rfl <|
-      calc
-        (1 : 𝕜) - f.1 0 = f.1 0 + f.1 1 - f.1 0 := by rw [← Fin.sum_univ_two f.1, f.2.2]
-        _ = f.1 1 := add_sub_cancel_left _ _
-
-end OrderedRing
-
-end Simplex

--- a/Mathlib/Analysis/Convex/Combination.lean
+++ b/Mathlib/Analysis/Convex/Combination.lean
@@ -457,45 +457,6 @@ theorem convexHull_sum {ι} (s : Finset ι) (t : ι → Set E) :
     convexHull R (∑ i ∈ s, t i) = ∑ i ∈ s, convexHull R (t i) :=
   map_sum (convexHullAddMonoidHom R E) _ _
 
-/-! ### `stdSimplex` -/
-
-
-variable (ι) [Fintype ι] {f : ι → R}
-
-/-- `stdSimplex 𝕜 ι` is the convex hull of the canonical basis in `ι → 𝕜`. -/
-theorem convexHull_basis_eq_stdSimplex [DecidableEq ι] :
-    convexHull R (range fun i j : ι => if i = j then (1 : R) else 0) = stdSimplex R ι := by
-  refine Subset.antisymm (convexHull_min ?_ (convex_stdSimplex R ι)) ?_
-  · rintro _ ⟨i, rfl⟩
-    exact ite_eq_mem_stdSimplex R i
-  · rintro w ⟨hw₀, hw₁⟩
-    rw [pi_eq_sum_univ w, ← Finset.univ.centerMass_eq_of_sum_1 _ hw₁]
-    exact Finset.univ.centerMass_mem_convexHull (fun i _ => hw₀ i) (hw₁.symm ▸ zero_lt_one)
-      fun i _ => mem_range_self i
-
-variable {ι}
-
-/-- The convex hull of a finite set is the image of the standard simplex in `s → ℝ`
-under the linear map sending each function `w` to `∑ x ∈ s, w x • x`.
-
-Since we have no sums over finite sets, we use sum over `@Finset.univ _ hs.fintype`.
-The map is defined in terms of operations on `(s → ℝ) →ₗ[ℝ] ℝ` so that later we will not need
-to prove that this map is linear. -/
-theorem Set.Finite.convexHull_eq_image {s : Set E} (hs : s.Finite) : convexHull R s =
-    haveI := hs.fintype
-    (⇑(∑ x : s, (@LinearMap.proj R s _ (fun _ => R) _ _ x).smulRight x.1)) '' stdSimplex R s := by
-  classical
-  letI := hs.fintype
-  rw [← convexHull_basis_eq_stdSimplex, LinearMap.image_convexHull, ← Set.range_comp]
-  apply congr_arg
-  simp_rw [Function.comp_def]
-  convert Subtype.range_coe.symm
-  simp [LinearMap.sum_apply, ite_smul, Finset.mem_univ]
-
-/-- All values of a function `f ∈ stdSimplex 𝕜 ι` belong to `[0, 1]`. -/
-theorem mem_Icc_of_mem_stdSimplex (hf : f ∈ stdSimplex R ι) (x) : f x ∈ Icc (0 : R) 1 :=
-  ⟨hf.1 x, hf.2 ▸ Finset.single_le_sum (fun y _ => hf.1 y) (Finset.mem_univ x)⟩
-
 /-- The convex hull of an affine basis is the intersection of the half-spaces defined by the
 corresponding barycentric coordinates. -/
 theorem AffineBasis.convexHull_eq_nonneg_coord {ι : Type*} (b : AffineBasis ι R E) :

--- a/Mathlib/Analysis/Convex/StdSimplex.lean
+++ b/Mathlib/Analysis/Convex/StdSimplex.lean
@@ -1,0 +1,191 @@
+/-
+Copyright (c) 2019 Alexander Bentkamp. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Alexander Bentkamp, Yury Kudryashov, Yaël Dillies
+-/
+import Mathlib.Analysis.Convex.Combination
+import Mathlib.Topology.MetricSpace.ProperSpace.Real
+import Mathlib.Topology.UnitInterval
+
+/-!
+# The standard simplex
+
+In this file, given an ordered semiring `𝕜` and a finite type `ι`,
+we define `stdSimplex : Set (ι → 𝕜)` as the set of vectors with non-negative
+coordinates with total sum `1`.
+
+-/
+
+open Set Convex Bornology
+
+section OrderedSemiring
+
+variable (𝕜) (ι : Type*) [Semiring 𝕜] [PartialOrder 𝕜] [Fintype ι]
+
+/-- The standard simplex in the space of functions `ι → 𝕜` is the set of vectors with non-negative
+coordinates with total sum `1`. This is the free object in the category of convex spaces. -/
+def stdSimplex : Set (ι → 𝕜) :=
+  { f | (∀ x, 0 ≤ f x) ∧ ∑ x, f x = 1 }
+
+theorem stdSimplex_eq_inter : stdSimplex 𝕜 ι = (⋂ x, { f | 0 ≤ f x }) ∩ { f | ∑ x, f x = 1 } := by
+  ext f
+  simp only [stdSimplex, Set.mem_inter_iff, Set.mem_iInter, Set.mem_setOf_eq]
+
+theorem convex_stdSimplex [IsOrderedRing 𝕜] : Convex 𝕜 (stdSimplex 𝕜 ι) := by
+  refine fun f hf g hg a b ha hb hab => ⟨fun x => ?_, ?_⟩
+  · apply_rules [add_nonneg, mul_nonneg, hf.1, hg.1]
+  · simp_rw [Pi.add_apply, Pi.smul_apply]
+    rwa [Finset.sum_add_distrib, ← Finset.smul_sum, ← Finset.smul_sum, hf.2, hg.2, smul_eq_mul,
+      smul_eq_mul, mul_one, mul_one]
+
+@[nontriviality] lemma stdSimplex_of_subsingleton [Subsingleton 𝕜] : stdSimplex 𝕜 ι = univ :=
+  eq_univ_of_forall fun _ ↦ ⟨fun _ ↦ (Subsingleton.elim _ _).le, Subsingleton.elim _ _⟩
+
+/-- The standard simplex in the zero-dimensional space is empty. -/
+lemma stdSimplex_of_isEmpty_index [IsEmpty ι] [Nontrivial 𝕜] : stdSimplex 𝕜 ι = ∅ :=
+  eq_empty_of_forall_notMem <| by rintro f ⟨-, hf⟩; simp at hf
+
+lemma stdSimplex_unique [ZeroLEOneClass 𝕜] [Nonempty ι] [Subsingleton ι] :
+    stdSimplex 𝕜 ι = {fun _ ↦ 1} := by
+  cases nonempty_unique ι
+  refine eq_singleton_iff_unique_mem.2 ⟨⟨fun _ ↦ zero_le_one, Fintype.sum_unique _⟩, ?_⟩
+  rintro f ⟨-, hf⟩
+  rw [Fintype.sum_unique] at hf
+  exact funext (Unique.forall_iff.2 hf)
+
+variable {ι}
+
+variable {𝕜} in
+/-- All values of a function `f ∈ stdSimplex 𝕜 ι` belong to `[0, 1]`. -/
+theorem mem_Icc_of_mem_stdSimplex [IsOrderedAddMonoid 𝕜]
+    {f : ι → 𝕜} (hf : f ∈ stdSimplex 𝕜 ι) (x) :
+    f x ∈ Icc (0 : 𝕜) 1 :=
+  ⟨hf.1 x, hf.2 ▸ Finset.single_le_sum (fun y _ => hf.1 y) (Finset.mem_univ x)⟩
+
+variable [DecidableEq ι] [ZeroLEOneClass 𝕜]
+
+theorem single_mem_stdSimplex (i : ι) : Pi.single i 1 ∈ stdSimplex 𝕜 ι :=
+  ⟨le_update_iff.2 ⟨zero_le_one, fun _ _ ↦ le_rfl⟩, by simp⟩
+
+theorem ite_eq_mem_stdSimplex (i : ι) : (if i = · then (1 : 𝕜) else 0) ∈ stdSimplex 𝕜 ι := by
+  simpa only [@eq_comm _ i, ← Pi.single_apply] using single_mem_stdSimplex 𝕜 i
+
+variable [IsOrderedRing 𝕜]
+
+#adaptation_note /-- nightly-2024-03-11
+we need a type annotation on the segment in the following two lemmas. -/
+
+/-- The edges are contained in the simplex. -/
+lemma segment_single_subset_stdSimplex (i j : ι) :
+    ([Pi.single i 1 -[𝕜] Pi.single j 1] : Set (ι → 𝕜)) ⊆ stdSimplex 𝕜 ι :=
+  (convex_stdSimplex 𝕜 ι).segment_subset (single_mem_stdSimplex _ _) (single_mem_stdSimplex _ _)
+
+lemma stdSimplex_fin_two :
+    stdSimplex 𝕜 (Fin 2) = ([Pi.single 0 1 -[𝕜] Pi.single 1 1] : Set (Fin 2 → 𝕜)) := by
+  refine Subset.antisymm ?_ (segment_single_subset_stdSimplex 𝕜 (0 : Fin 2) 1)
+  rintro f ⟨hf₀, hf₁⟩
+  rw [Fin.sum_univ_two] at hf₁
+  refine ⟨f 0, f 1, hf₀ 0, hf₀ 1, hf₁, funext <| Fin.forall_fin_two.2 ?_⟩
+  simp
+
+end OrderedSemiring
+
+section OrderedRing
+
+variable (𝕜) [Ring 𝕜] [PartialOrder 𝕜] [IsOrderedRing 𝕜]
+
+/-- The standard one-dimensional simplex in `Fin 2 → 𝕜` is equivalent to the unit interval. -/
+@[simps -fullyApplied]
+def stdSimplexEquivIcc : stdSimplex 𝕜 (Fin 2) ≃ Icc (0 : 𝕜) 1 where
+  toFun f := ⟨f.1 0, f.2.1 _, f.2.2 ▸
+    Finset.single_le_sum (fun i _ ↦ f.2.1 i) (Finset.mem_univ _)⟩
+  invFun x := ⟨![x, 1 - x], Fin.forall_fin_two.2 ⟨x.2.1, sub_nonneg.2 x.2.2⟩,
+    calc
+      ∑ i : Fin 2, ![(x : 𝕜), 1 - x] i = x + (1 - x) := Fin.sum_univ_two _
+      _ = 1 := add_sub_cancel _ _⟩
+  left_inv f := Subtype.eq <| funext <| Fin.forall_fin_two.2 <| .intro rfl <|
+      calc
+        (1 : 𝕜) - f.1 0 = f.1 0 + f.1 1 - f.1 0 := by rw [← Fin.sum_univ_two f.1, f.2.2]
+        _ = f.1 1 := add_sub_cancel_left _ _
+
+end OrderedRing
+
+section Field
+
+variable (R : Type*) (ι : Type*) [Field R] [LinearOrder R] [IsStrictOrderedRing R] [Fintype ι]
+
+/-- `stdSimplex 𝕜 ι` is the convex hull of the canonical basis in `ι → 𝕜`. -/
+theorem convexHull_basis_eq_stdSimplex [DecidableEq ι] :
+    convexHull R (range fun i j : ι => if i = j then (1 : R) else 0) = stdSimplex R ι := by
+  refine Subset.antisymm (convexHull_min ?_ (convex_stdSimplex R ι)) ?_
+  · rintro _ ⟨i, rfl⟩
+    exact ite_eq_mem_stdSimplex R i
+  · rintro w ⟨hw₀, hw₁⟩
+    rw [pi_eq_sum_univ w]
+    rw [← Finset.univ.centerMass_eq_of_sum_1 _ hw₁]
+    exact Finset.univ.centerMass_mem_convexHull (fun i _ => hw₀ i) (hw₁.symm ▸ zero_lt_one)
+      fun i _ => mem_range_self i
+
+variable {R}
+/-- The convex hull of a finite set is the image of the standard simplex in `s → ℝ`
+under the linear map sending each function `w` to `∑ x ∈ s, w x • x`.
+
+Since we have no sums over finite sets, we use sum over `@Finset.univ _ hs.fintype`.
+The map is defined in terms of operations on `(s → ℝ) →ₗ[ℝ] ℝ` so that later we will not need
+to prove that this map is linear. -/
+theorem Set.Finite.convexHull_eq_image {E : Type*} [AddCommGroup E] [Module R E]
+    {s : Set E} (hs : s.Finite) : convexHull R s =
+    haveI := hs.fintype
+    (⇑(∑ x : s, (@LinearMap.proj R s _ (fun _ => R) _ _ x).smulRight x.1)) '' stdSimplex R s := by
+  classical
+  letI := hs.fintype
+  rw [← convexHull_basis_eq_stdSimplex, LinearMap.image_convexHull, ← Set.range_comp]
+  apply congr_arg
+  simp_rw [Function.comp_def]
+  convert Subtype.range_coe.symm
+  simp [LinearMap.sum_apply, ite_smul, Finset.mem_univ]
+
+end Field
+
+section Topology
+
+variable {ι : Type*} [Fintype ι]
+
+/-- Every vector in `stdSimplex 𝕜 ι` has `max`-norm at most `1`. -/
+theorem stdSimplex_subset_closedBall : stdSimplex ℝ ι ⊆ Metric.closedBall 0 1 := fun f hf ↦ by
+  rw [Metric.mem_closedBall, dist_pi_le_iff zero_le_one]
+  intro x
+  rw [Pi.zero_apply, Real.dist_0_eq_abs, abs_of_nonneg <| hf.1 x]
+  exact (mem_Icc_of_mem_stdSimplex hf x).2
+
+variable (ι)
+
+/-- `stdSimplex ℝ ι` is bounded. -/
+theorem bounded_stdSimplex : IsBounded (stdSimplex ℝ ι) :=
+  (Metric.isBounded_iff_subset_closedBall 0).2 ⟨1, stdSimplex_subset_closedBall⟩
+
+/-- `stdSimplex ℝ ι` is closed. -/
+theorem isClosed_stdSimplex : IsClosed (stdSimplex ℝ ι) :=
+  (stdSimplex_eq_inter ℝ ι).symm ▸
+    IsClosed.inter (isClosed_iInter fun i => isClosed_le continuous_const (continuous_apply i))
+      (isClosed_eq (continuous_finset_sum _ fun x _ => continuous_apply x) continuous_const)
+
+/-- `stdSimplex ℝ ι` is compact. -/
+theorem isCompact_stdSimplex : IsCompact (stdSimplex ℝ ι) :=
+  Metric.isCompact_iff_isClosed_bounded.2 ⟨isClosed_stdSimplex ι, bounded_stdSimplex ι⟩
+
+instance stdSimplex.instCompactSpace_coe : CompactSpace ↥(stdSimplex ℝ ι) :=
+  isCompact_iff_compactSpace.mp <| isCompact_stdSimplex _
+
+/-- The standard one-dimensional simplex in `ℝ² = Fin 2 → ℝ`
+is homeomorphic to the unit interval. -/
+@[simps! -fullyApplied]
+def stdSimplexHomeomorphUnitInterval : stdSimplex ℝ (Fin 2) ≃ₜ unitInterval where
+  toEquiv := stdSimplexEquivIcc ℝ
+  continuous_toFun := .subtype_mk ((continuous_apply 0).comp continuous_subtype_val) _
+  continuous_invFun := by
+    apply Continuous.subtype_mk
+    exact (continuous_pi <| Fin.forall_fin_two.2
+      ⟨continuous_subtype_val, continuous_const.sub continuous_subtype_val⟩)
+
+end Topology

--- a/Mathlib/Analysis/Convex/Topology.lean
+++ b/Mathlib/Analysis/Convex/Topology.lean
@@ -3,12 +3,10 @@ Copyright (c) 2020 Yury Kudryashov. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Alexander Bentkamp, Yury Kudryashov
 -/
-import Mathlib.Analysis.Convex.Combination
 import Mathlib.Analysis.Convex.Strict
+import Mathlib.Analysis.Convex.StdSimplex
 import Mathlib.Topology.Algebra.Affine
 import Mathlib.Topology.Algebra.Module.Basic
-import Mathlib.Topology.MetricSpace.ProperSpace.Real
-import Mathlib.Topology.UnitInterval
 
 /-!
 # Topological properties of convex sets
@@ -48,48 +46,6 @@ alias ⟨_, IsPreconnected.convex⟩ := Real.convex_iff_isPreconnected
 /-! ### Standard simplex -/
 
 
-section stdSimplex
-
-variable [Fintype ι]
-
-/-- Every vector in `stdSimplex 𝕜 ι` has `max`-norm at most `1`. -/
-theorem stdSimplex_subset_closedBall : stdSimplex ℝ ι ⊆ Metric.closedBall 0 1 := fun f hf ↦ by
-  rw [Metric.mem_closedBall, dist_pi_le_iff zero_le_one]
-  intro x
-  rw [Pi.zero_apply, Real.dist_0_eq_abs, abs_of_nonneg <| hf.1 x]
-  exact (mem_Icc_of_mem_stdSimplex hf x).2
-
-variable (ι)
-
-/-- `stdSimplex ℝ ι` is bounded. -/
-theorem bounded_stdSimplex : IsBounded (stdSimplex ℝ ι) :=
-  (Metric.isBounded_iff_subset_closedBall 0).2 ⟨1, stdSimplex_subset_closedBall⟩
-
-/-- `stdSimplex ℝ ι` is closed. -/
-theorem isClosed_stdSimplex : IsClosed (stdSimplex ℝ ι) :=
-  (stdSimplex_eq_inter ℝ ι).symm ▸
-    IsClosed.inter (isClosed_iInter fun i => isClosed_le continuous_const (continuous_apply i))
-      (isClosed_eq (continuous_finset_sum _ fun x _ => continuous_apply x) continuous_const)
-
-/-- `stdSimplex ℝ ι` is compact. -/
-theorem isCompact_stdSimplex : IsCompact (stdSimplex ℝ ι) :=
-  Metric.isCompact_iff_isClosed_bounded.2 ⟨isClosed_stdSimplex ι, bounded_stdSimplex ι⟩
-
-instance stdSimplex.instCompactSpace_coe : CompactSpace ↥(stdSimplex ℝ ι) :=
-  isCompact_iff_compactSpace.mp <| isCompact_stdSimplex _
-
-/-- The standard one-dimensional simplex in `ℝ² = Fin 2 → ℝ`
-is homeomorphic to the unit interval. -/
-@[simps! -fullyApplied]
-def stdSimplexHomeomorphUnitInterval : stdSimplex ℝ (Fin 2) ≃ₜ unitInterval where
-  toEquiv := stdSimplexEquivIcc ℝ
-  continuous_toFun := .subtype_mk ((continuous_apply 0).comp continuous_subtype_val) _
-  continuous_invFun := by
-    apply Continuous.subtype_mk
-    exact (continuous_pi <| Fin.forall_fin_two.2
-      ⟨continuous_subtype_val, continuous_const.sub continuous_subtype_val⟩)
-
-end stdSimplex
 
 /-! ### Topological vector spaces -/
 section TopologicalSpace


### PR DESCRIPTION
Definitions relative to the standard simplex are moved to a new file `Analysis.Convex.StdSimplex`.

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include at least one commit authored by each
co-author among the commits in the pull request. If necessary, you may 
create empty commits to indicate co-authorship, using commands like so:

git commit --author="Author Name <author@email.com>" --allow-empty -m "add Author Name as coauthor"

When merging, all the commits will be squashed into a single commit listing all co-authors.

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
