### PR TITLE
[Merged by Bors] - chore(LinearAlgebra/Span/Basic): more API for `toSpanSingleton`

### DIFF
--- a/Mathlib/Analysis/InnerProductSpace/Adjoint.lean
+++ b/Mathlib/Analysis/InnerProductSpace/Adjoint.lean
@@ -249,8 +249,12 @@ theorem isAdjointPair_inner (A : E →L[𝕜] F) :
   simp only [sesqFormOfInner_apply_apply, adjoint_inner_left]
 
 theorem adjoint_innerSL_apply (x : E) :
-    adjoint (innerSL 𝕜 x) = (lsmul 𝕜 𝕜).flip x :=
+    adjoint (innerSL 𝕜 x) = toSpanSingleton 𝕜 x :=
   ext_ring <| ext_inner_left 𝕜 <| fun _ => by simp [adjoint_inner_right]
+
+theorem adjoint_toSpanSingleton (x : E) :
+    adjoint (toSpanSingleton 𝕜 x) = innerSL 𝕜 x := by
+  simp [← adjoint_innerSL_apply]
 
 theorem innerSL_apply_comp (x : F) (f : E →L[𝕜] F) :
     innerSL 𝕜 x ∘L f = innerSL 𝕜 (adjoint f x) := by

--- a/Mathlib/Analysis/NormedSpace/OperatorNorm/Mul.lean
+++ b/Mathlib/Analysis/NormedSpace/OperatorNorm/Mul.lean
@@ -192,15 +192,12 @@ theorem lsmul_apply (c : R) (x : E) : lsmul 𝕜 R c x = c • x :=
   rfl
 
 variable {𝕜} in
+@[simp]
 theorem lsmul_flip_apply (x : E) :
     (lsmul 𝕜 𝕜).flip x = toSpanSingleton 𝕜 x :=
   rfl
 
-variable {𝕜} in
-theorem comp_lsmul_flip_apply {F : Type*} [SeminormedAddCommGroup F] [NormedSpace 𝕜 F]
-    (f : E →L[𝕜] F) (x : E) :
-    f ∘L (lsmul 𝕜 𝕜).flip x = (lsmul 𝕜 𝕜).flip (f x) := by
-  ext; simp
+@[deprecated (since := "29-08-2025")] alias comp_lsmul_flip_apply := comp_toSpanSingleton
 
 variable {𝕜} in
 theorem lsmul_flip_inj {x y : E} :

--- a/Mathlib/LinearAlgebra/BilinearForm/Basic.lean
+++ b/Mathlib/LinearAlgebra/BilinearForm/Basic.lean
@@ -150,4 +150,7 @@ def restrict (B : BilinForm R M) (W : Submodule R M) : BilinForm R W :=
 
 end BilinForm
 
+@[simp]
+theorem lsmul_flip_apply (m : M) : (lsmul R M).flip m = toSpanSingleton R M m := rfl
+
 end LinearMap

--- a/Mathlib/LinearAlgebra/Span/Basic.lean
+++ b/Mathlib/LinearAlgebra/Span/Basic.lean
@@ -729,6 +729,10 @@ theorem span_singleton_eq_range (x : M) :
     (R ∙ x) = range (toSpanSingleton R M x) :=
   range_toSpanSingleton x |>.symm
 
+theorem comp_toSpanSingleton [AddCommMonoid M₂] [Module R M₂] (f : M →ₗ[R] M₂) (x : M) :
+    f ∘ₗ toSpanSingleton R M x = toSpanSingleton R M₂ (f x) := by
+  ext; simp
+
 theorem submoduleOf_span_singleton_of_mem (N : Submodule R M) {x : M} (hx : x ∈ N) :
     (span R {x}).submoduleOf N = span R {⟨x, hx⟩} := by
   ext y

--- a/Mathlib/Topology/Algebra/Module/LinearMap.lean
+++ b/Mathlib/Topology/Algebra/Module/LinearMap.lean
@@ -715,6 +715,7 @@ def toSpanSingleton (x : M₁) : R₁ →L[R₁] M₁ where
   toLinearMap := LinearMap.toSpanSingleton R₁ M₁ x
   cont := continuous_id.smul continuous_const
 
+@[simp]
 theorem toSpanSingleton_apply (x : M₁) (r : R₁) : toSpanSingleton R₁ x r = r • x :=
   rfl
 
@@ -739,6 +740,11 @@ theorem one_smulRight_eq_toSpanSingleton (x : M₁) :
 @[simp]
 theorem toLinearMap_toSpanSingleton (x : M₁) :
     (toSpanSingleton R₁ x).toLinearMap = LinearMap.toSpanSingleton R₁ M₁ x := rfl
+
+variable {R₁} in
+theorem comp_toSpanSingleton (f : M₁ →L[R₁] M₂) (x : M₁) :
+    f ∘L toSpanSingleton R₁ x = toSpanSingleton R₁ (f x) :=
+  coe_inj.mp <| LinearMap.comp_toSpanSingleton _ _
 
 end ToSpanSingleton
 


### PR DESCRIPTION
Make `(lsmul _ _).flip _ = toSpanSingleton _ _` a `simp`.

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include at least one commit authored by each
co-author among the commits in the pull request. If necessary, you may 
create empty commits to indicate co-authorship, using commands like so:

git commit --author="Author Name <author@email.com>" --allow-empty -m "add Author Name as coauthor"

When merging, all the commits will be squashed into a single commit listing all co-authors.

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
