### PR TITLE
feat(MeasureTheory): add `LInfty.lean` with `Mul` and `const` related results.

### DIFF
--- a/Mathlib.lean
+++ b/Mathlib.lean
@@ -4423,6 +4423,7 @@ import Mathlib.MeasureTheory.Function.L1Space.AEEqFun
 import Mathlib.MeasureTheory.Function.L1Space.HasFiniteIntegral
 import Mathlib.MeasureTheory.Function.L1Space.Integrable
 import Mathlib.MeasureTheory.Function.L2Space
+import Mathlib.MeasureTheory.Function.LInfty
 import Mathlib.MeasureTheory.Function.LocallyIntegrable
 import Mathlib.MeasureTheory.Function.LpOrder
 import Mathlib.MeasureTheory.Function.LpSeminorm.Basic

--- a/Mathlib/MeasureTheory/Function/LInfty.lean
+++ b/Mathlib/MeasureTheory/Function/LInfty.lean
@@ -8,7 +8,7 @@ import Mathlib.MeasureTheory.Function.LpSpace.Basic
 import Mathlib.MeasureTheory.Function.Holder
 
 /-!
-# The `L∞` (i.e. `Lp _ ⊤`) API and pointwise multiplication
+# The API for multiplicative structure on `L∞`
 
 This file develops the basic results specific to `Lp R ∞ μ` when `R` is a
 `NormedRing`.  The main goal is to equip `L∞` with its natural pointwise multiplicative

--- a/Mathlib/MeasureTheory/Function/LInfty.lean
+++ b/Mathlib/MeasureTheory/Function/LInfty.lean
@@ -8,9 +8,23 @@ import Mathlib.MeasureTheory.Function.LpSpace.Basic
 import Mathlib.MeasureTheory.Function.Holder
 
 /-!
+# The `L∞` (i.e. `Lp _ ⊤`) API and pointwise multiplication
 
-This file contains basic results specific to `Lp R ∞ μ`, with `R` a `NormedRing`, notably
-results surrounding its multiplicative structure.
+This file develops the basic results specific to `Lp R ∞ μ` when `R` is a
+`NormedRing`.  The main goal is to equip `L∞` with its natural pointwise multiplicative
+structure (defined a.e.) and to register the constant embedding.  This is a small,
+self-contained layer intended to be imported later by files that build richer structure
+(e.g. the commutative C⋆-algebra structure when `R = 𝕜`).
+
+## Main definitions
+
+* `instance : Mul (Lp R ⊤ μ)` – pointwise (a.e.) multiplication on `L∞`.
+* `Linfty.const : R →+ Lp R ⊤ μ` – additive monoid hom sending a scalar to the corresponding
+  constant `L∞` function.
+
+## Tags
+
+Lp, L∞
 
 -/
 

--- a/Mathlib/MeasureTheory/Function/LInfty.lean
+++ b/Mathlib/MeasureTheory/Function/LInfty.lean
@@ -14,7 +14,7 @@ This file develops the basic results specific to `Lp R ∞ μ` when `R` is a
 `NormedRing`.  The main goal is to equip `L∞` with its natural pointwise multiplicative
 structure (defined a.e.) and to register the constant embedding.  This is a small,
 self-contained layer intended to be imported later by files that build richer structure
-(e.g. the commutative C⋆-algebra structure when `R = 𝕜`).
+(e.g. the commutative C⋆-algebra structure when `R = 𝕜`, for `RCLike 𝕜`).
 
 ## Main definitions
 

--- a/Mathlib/MeasureTheory/Function/LInfty.lean
+++ b/Mathlib/MeasureTheory/Function/LInfty.lean
@@ -59,7 +59,7 @@ theorem const_mem_Linfty (c : R) :
     @AEEqFun.const α _ _ μ _ c ∈ Lp R ∞ μ :=
   (memLinfty_const c).eLpNorm_mk_lt_top
 
-/- The constant L∞ function. -/
+/-- The constant L∞ function. -/
 def Linfty.const : R →+ Lp R ∞ μ where
   toFun c := ⟨AEEqFun.const α c, const_mem_Linfty c⟩
   map_zero' := rfl

--- a/Mathlib/MeasureTheory/Function/LInfty.lean
+++ b/Mathlib/MeasureTheory/Function/LInfty.lean
@@ -1,0 +1,61 @@
+/-
+Copyright (c) 2025 Jon Bannon. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Jon Bannon, Jireh Loreaux
+-/
+
+import Mathlib.MeasureTheory.Function.LpSpace.Basic
+import Mathlib.MeasureTheory.Function.Holder
+
+/-!
+
+This file contains basic results specific to `Lp R ∞ μ`, with `R` a `NormedRing`, notably
+results surrounding its multiplicative structure.
+
+-/
+
+namespace MeasureTheory
+
+open ENNReal
+
+variable {α : Type*} {m : MeasurableSpace α} {μ : Measure α}
+variable {R : Type*} [NormedRing R]
+
+section Mul
+
+noncomputable instance : Mul (Lp R ∞ μ) where
+  mul f g := f • g
+
+lemma Linfty.coeFn_mul (f g : Lp R ∞ μ) : f * g =ᵐ[μ] ⇑f * g :=
+  Lp.coeFn_lpSMul f g
+
+end Mul
+
+section Const
+
+/-- Note: Unlike for general Lp, this does not require `IsFiniteMeasure` instance. -/
+theorem memLinfty_const (c : R) : MemLp (fun _ : α => c) ∞ μ := by
+  refine ⟨aestronglyMeasurable_const, ?_⟩
+  by_cases hμ : μ = 0
+  · simp [hμ]
+  · rw [eLpNorm_const c (ENNReal.top_ne_zero) hμ]
+    simp
+
+theorem const_mem_Linfty (c : R) :
+    @AEEqFun.const α _ _ μ _ c ∈ Lp R ∞ μ :=
+  (memLinfty_const c).eLpNorm_mk_lt_top
+
+def Linfty.const : R →+ Lp R ∞ μ where
+  toFun c := ⟨AEEqFun.const α c, const_mem_Linfty c⟩
+  map_zero' := rfl
+  map_add' _ _ := rfl
+
+@[simp]
+lemma Linfty.const_val (c : R) : (Linfty.const c).1 = AEEqFun.const (β := R) (μ := μ) α c := rfl
+
+lemma Linfty.coeFn_const (c : R) : Linfty.const (μ := μ) c =ᵐ[μ] Function.const α c :=
+  AEEqFun.coeFn_const α c
+
+end Const
+
+end MeasureTheory

--- a/Mathlib/MeasureTheory/Function/LInfty.lean
+++ b/Mathlib/MeasureTheory/Function/LInfty.lean
@@ -59,6 +59,7 @@ theorem const_mem_Linfty (c : R) :
     @AEEqFun.const α _ _ μ _ c ∈ Lp R ∞ μ :=
   (memLinfty_const c).eLpNorm_mk_lt_top
 
+/- The constant L∞ function. -/
 def Linfty.const : R →+ Lp R ∞ μ where
   toFun c := ⟨AEEqFun.const α c, const_mem_Linfty c⟩
   map_zero' := rfl

--- a/Mathlib/MeasureTheory/Function/LInfty.lean
+++ b/Mathlib/MeasureTheory/Function/LInfty.lean
@@ -35,18 +35,14 @@ open ENNReal
 variable {α : Type*} {m : MeasurableSpace α} {μ : Measure α}
 variable {R : Type*} [NormedRing R]
 
-namespace Linfty
 section Mul
 
-/-- We use the existing `HSMul (Lp R ∞ μ) (Lp R ∞ μ) (Lp R ∞ μ)` instance to define
-   `Mul (Lp R ∞ μ)`, to ensure compatibility of the former with the latter. -/
+/-- We obtain the `Mul (Lp R ∞ μ)` instance using the existing
+  `HSMul (Lp R ∞ μ) (Lp R ∞ μ) (Lp R ∞ μ)` instance. -/
 noncomputable instance : Mul (Lp R ∞ μ) where
   mul f g := f • g
 
-/-- Check for diamonds, to guard against future refactors that try to change the def of `Mul`. -/
-example : (· * ·) = (· • · : Lp R ∞ μ → Lp R ∞ μ → Lp R ∞ μ) := by with_reducible_and_instances rfl
-
-lemma coeFn_mul (f g : Lp R ∞ μ) : f * g =ᵐ[μ] ⇑f * g :=
+lemma Linfty.coeFn_mul (f g : Lp R ∞ μ) : f * g =ᵐ[μ] ⇑f * g :=
   Lp.coeFn_lpSMul f g
 
 end Mul
@@ -54,7 +50,7 @@ end Mul
 section Const
 
 /-- Note: Unlike for general Lp, this does not require `IsFiniteMeasure` instance. -/
-theorem memLp_const (c : R) : MemLp (fun _ : α => c) ∞ μ := by
+theorem memLinfty_const (c : R) : MemLp (fun _ : α => c) ∞ μ := by
   refine ⟨aestronglyMeasurable_const, ?_⟩
   by_cases hμ : μ = 0
   · simp [hμ]
@@ -63,22 +59,20 @@ theorem memLp_const (c : R) : MemLp (fun _ : α => c) ∞ μ := by
 
 theorem const_mem_Linfty (c : R) :
     @AEEqFun.const α _ _ μ _ c ∈ Lp R ∞ μ :=
-  (memLp_const c).eLpNorm_mk_lt_top
+  (memLinfty_const c).eLpNorm_mk_lt_top
 
 /-- The constant L∞ function. -/
-def const : R →+ Lp R ∞ μ where
+def Linfty.const : R →+ Lp R ∞ μ where
   toFun c := ⟨AEEqFun.const α c, const_mem_Linfty c⟩
   map_zero' := rfl
   map_add' _ _ := rfl
 
 @[simp]
-lemma const_val (c : R) : (Linfty.const c).1 = AEEqFun.const (β := R) (μ := μ) α c := rfl
+lemma Linfty.const_val (c : R) : (Linfty.const c).1 = AEEqFun.const (β := R) (μ := μ) α c := rfl
 
-lemma coeFn_const (c : R) : Linfty.const (μ := μ) c =ᵐ[μ] Function.const α c :=
+lemma Linfty.coeFn_const (c : R) : Linfty.const (μ := μ) c =ᵐ[μ] Function.const α c :=
   AEEqFun.coeFn_const α c
 
 end Const
-
-end Linfty
 
 end MeasureTheory

--- a/Mathlib/MeasureTheory/Function/LInfty.lean
+++ b/Mathlib/MeasureTheory/Function/LInfty.lean
@@ -35,12 +35,18 @@ open ENNReal
 variable {α : Type*} {m : MeasurableSpace α} {μ : Measure α}
 variable {R : Type*} [NormedRing R]
 
+namespace Linfty
 section Mul
 
+/-- We use the existing `HSMul (Lp R ∞ μ) (Lp R ∞ μ) (Lp R ∞ μ)` instance to define
+   `Mul (Lp R ∞ μ)`, to ensure compatibility of the former with the latter. -/
 noncomputable instance : Mul (Lp R ∞ μ) where
   mul f g := f • g
 
-lemma Linfty.coeFn_mul (f g : Lp R ∞ μ) : f * g =ᵐ[μ] ⇑f * g :=
+/-- Check for diamonds, to guard against future refactors that try to change the def of `Mul`. -/
+example : (· * ·) = (· • · : Lp R ∞ μ → Lp R ∞ μ → Lp R ∞ μ) := by with_reducible_and_instances rfl
+
+lemma coeFn_mul (f g : Lp R ∞ μ) : f * g =ᵐ[μ] ⇑f * g :=
   Lp.coeFn_lpSMul f g
 
 end Mul
@@ -48,7 +54,7 @@ end Mul
 section Const
 
 /-- Note: Unlike for general Lp, this does not require `IsFiniteMeasure` instance. -/
-theorem memLinfty_const (c : R) : MemLp (fun _ : α => c) ∞ μ := by
+theorem memLp_const (c : R) : MemLp (fun _ : α => c) ∞ μ := by
   refine ⟨aestronglyMeasurable_const, ?_⟩
   by_cases hμ : μ = 0
   · simp [hμ]
@@ -57,10 +63,10 @@ theorem memLinfty_const (c : R) : MemLp (fun _ : α => c) ∞ μ := by
 
 theorem const_mem_Linfty (c : R) :
     @AEEqFun.const α _ _ μ _ c ∈ Lp R ∞ μ :=
-  (memLinfty_const c).eLpNorm_mk_lt_top
+  (memLp_const c).eLpNorm_mk_lt_top
 
 /-- The constant L∞ function. -/
-def Linfty.const : R →+ Lp R ∞ μ where
+def const : R →+ Lp R ∞ μ where
   toFun c := ⟨AEEqFun.const α c, const_mem_Linfty c⟩
   map_zero' := rfl
   map_add' _ _ := rfl

--- a/Mathlib/MeasureTheory/Function/LInfty.lean
+++ b/Mathlib/MeasureTheory/Function/LInfty.lean
@@ -65,6 +65,14 @@ theorem const_mem_Linfty (c : R) :
     @AEEqFun.const α _ _ μ _ c ∈ Lp R ∞ μ :=
   (memLp_top_const c).eLpNorm_mk_lt_top
 
+/- We are going to need a new typeclass
+
+class MemLp.Const where
+  eLpNorm_const (c : E) : eLpNorm (fun _ : α => c) p μ < ∞
+
+and this will require a refactor of other bits of the library. Sounds substantial.
+-/
+
 /-- The constant L∞ function. -/
 def Linfty.const : R →+ Lp R ∞ μ where
   toFun c := ⟨AEEqFun.const α c, const_mem_Linfty c⟩

--- a/Mathlib/MeasureTheory/Function/LInfty.lean
+++ b/Mathlib/MeasureTheory/Function/LInfty.lean
@@ -72,11 +72,13 @@ def const : R →+ Lp R ∞ μ where
   map_add' _ _ := rfl
 
 @[simp]
-lemma Linfty.const_val (c : R) : (Linfty.const c).1 = AEEqFun.const (β := R) (μ := μ) α c := rfl
+lemma const_val (c : R) : (Linfty.const c).1 = AEEqFun.const (β := R) (μ := μ) α c := rfl
 
-lemma Linfty.coeFn_const (c : R) : Linfty.const (μ := μ) c =ᵐ[μ] Function.const α c :=
+lemma coeFn_const (c : R) : Linfty.const (μ := μ) c =ᵐ[μ] Function.const α c :=
   AEEqFun.coeFn_const α c
 
 end Const
+
+end Linfty
 
 end MeasureTheory

--- a/Mathlib/MeasureTheory/Function/LInfty.lean
+++ b/Mathlib/MeasureTheory/Function/LInfty.lean
@@ -49,6 +49,8 @@ end Mul
 
 section Const
 
+/- We just found  `memLp_top_const`, so the following theorem isn't needed. -/
+
 /-- Note: Unlike for general Lp, this does not require `IsFiniteMeasure` instance. -/
 theorem memLinfty_const (c : R) : MemLp (fun _ : α => c) ∞ μ := by
   refine ⟨aestronglyMeasurable_const, ?_⟩
@@ -57,9 +59,11 @@ theorem memLinfty_const (c : R) : MemLp (fun _ : α => c) ∞ μ := by
   · rw [eLpNorm_const c (ENNReal.top_ne_zero) hμ]
     simp
 
+/- There is `memLp_top_const` with `IsFiniteMeasure` assumption, in the `LpSpace.Basic` file.
+Should this go there, as well? How to square with our new `Const` instance? -/
 theorem const_mem_Linfty (c : R) :
     @AEEqFun.const α _ _ μ _ c ∈ Lp R ∞ μ :=
-  (memLinfty_const c).eLpNorm_mk_lt_top
+  (memLp_top_const c).eLpNorm_mk_lt_top
 
 /-- The constant L∞ function. -/
 def Linfty.const : R →+ Lp R ∞ μ where


### PR DESCRIPTION
Continuing to develop pieces needed for a `CStarAlgebra` instance for `Lp R ∞ μ`, we introduce a file `MeasureTheory.Function.LInfty.lean` that takes `MeasureTheory.Function.LpSpace.Basic` and `MeasureTheory.Function.Holder` as imports, and introduces the `Mul` instance on Linfty, and const-related results. In a future PR we will handle `One`, as this will require dealing with `AEEqFun` as well as `Lp` level objects and it's probably best to handle these together in a single PR. We opted to add this file to keep imports light, since adding the `Mul` results to `Basic` would require importing `Holder`, and including these results in `Holder` seemed too specific and would make `Holder` heavier.

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include at least one commit authored by each
co-author among the commits in the pull request. If necessary, you may 
create empty commits to indicate co-authorship, using commands like so:

git commit --author="Author Name <author@email.com>" --allow-empty -m "add Author Name as coauthor"

When merging, all the commits will be squashed into a single commit listing all co-authors.

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
