### PR TITLE
chore(CategoryTheory): align `refl` and `rfl` declarations in CategoryTheory

### DIFF
--- a/Mathlib/CategoryTheory/Adjunction/Basic.lean
+++ b/Mathlib/CategoryTheory/Adjunction/Basic.lean
@@ -658,7 +658,7 @@ lemma isLeftAdjoint_inverse : e.inverse.IsLeftAdjoint :=
 lemma isRightAdjoint_functor : e.functor.IsRightAdjoint :=
   e.symm.isRightAdjoint_inverse
 
-lemma refl_toAdjunction : (refl (C := C)).toAdjunction = Adjunction.id := rfl
+lemma refl_toAdjunction : (refl C).toAdjunction = Adjunction.id := rfl
 
 lemma trans_toAdjunction {E : Type*} [Category E] (e' : D ≌ E) :
     (e.trans e').toAdjunction = e.toAdjunction.comp e'.toAdjunction := rfl

--- a/Mathlib/CategoryTheory/Enriched/Ordinary/Basic.lean
+++ b/Mathlib/CategoryTheory/Enriched/Ordinary/Basic.lean
@@ -218,7 +218,7 @@ instance : Category (TransportEnrichment F C) := inferInstanceAs (Category C)
 /-- If `C` is an ordinary enriched category, the category structure on `TransportEnrichment F C`
 is trivially equivalent to the one on `C` itself. -/
 def TransportEnrichment.ofOrdinaryEnrichedCategoryEquiv : TransportEnrichment F C ≌ C :=
-  Equivalence.refl
+  Equivalence.rfl
 
 open EnrichedCategory
 

--- a/Mathlib/CategoryTheory/Equivalence.lean
+++ b/Mathlib/CategoryTheory/Equivalence.lean
@@ -339,13 +339,18 @@ end
 protected def mk (F : C ⥤ D) (G : D ⥤ C) (η : 𝟭 C ≅ F ⋙ G) (ε : G ⋙ F ≅ 𝟭 D) : C ≌ D :=
   ⟨F, G, adjointifyη η ε, ε, adjointify_η_ε η ε⟩
 
+variable (C) in
 /-- Equivalence of categories is reflexive. -/
 @[refl, simps]
 def refl : C ≌ C :=
-  ⟨𝟭 C, 𝟭 C, Iso.refl _, Iso.refl _, fun _ => Category.id_comp _⟩
+  ⟨𝟭 C, 𝟭 C, Iso.rfl, Iso.rfl, fun _ => Category.id_comp _⟩
+
+/-- The same as `Equivalence.refl` but with the argument implicit. -/
+@[simp]
+protected abbrev rfl : C ≌ C := refl C
 
 instance : Inhabited (C ≌ C) :=
-  ⟨refl⟩
+  ⟨.rfl⟩
 
 /-- Equivalence of categories is symmetric. -/
 @[symm, simps]
@@ -496,7 +501,7 @@ section
 -- The power structure is nevertheless useful.
 /-- Natural number powers of an auto-equivalence.  Use `(^)` instead. -/
 def powNat (e : C ≌ C) : ℕ → (C ≌ C)
-  | 0 => Equivalence.refl
+  | 0 => Equivalence.rfl
   | 1 => e
   | n + 2 => e.trans (powNat e (n + 1))
 
@@ -509,7 +514,7 @@ instance : Pow (C ≌ C) ℤ :=
   ⟨pow⟩
 
 @[simp]
-theorem pow_zero (e : C ≌ C) : e ^ (0 : ℤ) = Equivalence.refl :=
+theorem pow_zero (e : C ≌ C) : e ^ (0 : ℤ) = Equivalence.rfl :=
   rfl
 
 @[simp]
@@ -632,7 +637,7 @@ noncomputable def asEquivalence (F : C ⥤ D) [F.IsEquivalence] : C ≌ D where
   counitIso := NatIso.ofComponents F.objObjPreimageIso (by simp [inv])
 
 instance isEquivalence_refl : IsEquivalence (𝟭 C) :=
-  Equivalence.refl.isEquivalence_functor
+  Equivalence.rfl.isEquivalence_functor
 
 instance isEquivalence_inv (F : C ⥤ D) [IsEquivalence F] : IsEquivalence F.inv :=
   F.asEquivalence.symm.isEquivalence_functor

--- a/Mathlib/CategoryTheory/IsConnected.lean
+++ b/Mathlib/CategoryTheory/IsConnected.lean
@@ -276,6 +276,9 @@ def Zag (j₁ j₂ : J) : Prop :=
 
 @[refl] theorem Zag.refl (X : J) : Zag X X := Or.inl ⟨𝟙 _⟩
 
+/-- The same as `Zag.refl` but with the argument implicit -/
+theorem Zag.rfl {X : J} : Zag X X := Zag.refl X
+
 theorem zag_symmetric : Symmetric (@Zag J _) := fun _ _ h => h.symm
 
 @[symm] theorem Zag.symm {j₁ j₂ : J} (h : Zag j₁ j₂) : Zag j₂ j₁ := zag_symmetric h
@@ -298,6 +301,9 @@ theorem zigzag_equivalence : _root_.Equivalence (@Zigzag J _) :=
   (fun h g => Relation.transitive_reflTransGen h g)
 
 @[refl] theorem Zigzag.refl (X : J) : Zigzag X X := zigzag_equivalence.refl _
+
+/-- The same as `Zigzag.refl` but with the argument implicit. -/
+theorem Zigzag.rfl {X : J} : Zigzag X X := Zigzag.refl X
 
 @[symm] theorem Zigzag.symm {j₁ j₂ : J} (h : Zigzag j₁ j₂) : Zigzag j₂ j₁ := zigzag_symmetric h
 

--- a/Mathlib/CategoryTheory/Iso.lean
+++ b/Mathlib/CategoryTheory/Iso.lean
@@ -114,6 +114,10 @@ def refl (X : C) : X ≅ X where
 
 attribute [grind =] refl_hom refl_inv
 
+/-- The same as `Iso.refl` except with the argument implicit. -/
+@[simp]
+protected abbrev rfl {X : C} : X ≅ X := refl X
+
 instance : Inhabited (X ≅ X) := ⟨Iso.refl X⟩
 
 theorem nonempty_iso_refl (X : C) : Nonempty (X ≅ X) := ⟨default⟩

--- a/Mathlib/CategoryTheory/Monoidal/Functor.lean
+++ b/Mathlib/CategoryTheory/Monoidal/Functor.lean
@@ -1102,11 +1102,11 @@ lemma ε_comp_map_ε : ε e.inverse ≫ e.inverse.map (ε e.functor) = e.unit.ap
 lemma map_η_comp_η : e.functor.map (η e.inverse) ≫ η e.functor = e.counit.app (𝟙_ D) :=
   e.toAdjunction.map_η_comp_η
 
-instance : (refl (C := C)).functor.Monoidal := inferInstanceAs (𝟭 C).Monoidal
-instance : (refl (C := C)).inverse.Monoidal := inferInstanceAs (𝟭 C).Monoidal
+instance : (refl C).functor.Monoidal := inferInstanceAs (𝟭 C).Monoidal
+instance : (refl C).inverse.Monoidal := inferInstanceAs (𝟭 C).Monoidal
 
 /-- The obvious auto-equivalence of a monoidal category is monoidal. -/
-instance isMonoidal_refl : (Equivalence.refl (C := C)).IsMonoidal :=
+instance isMonoidal_refl : (Equivalence.refl C).IsMonoidal :=
   inferInstanceAs (Adjunction.id (C := C)).IsMonoidal
 
 /-- The inverse of a monoidal category equivalence is also a monoidal category equivalence. -/

--- a/Mathlib/CategoryTheory/Retract.lean
+++ b/Mathlib/CategoryTheory/Retract.lean
@@ -55,10 +55,14 @@ instance : IsSplitMono h.i := ⟨⟨h.splitMono⟩⟩
 
 variable (X) in
 /-- Any object is a retract of itself. -/
-@[simps]
+@[refl, simps]
 def refl : Retract X X where
   i := 𝟙 X
   r := 𝟙 X
+
+/-- The same as `Retract.refl` except with the object implicit -/
+@[simp]
+protected abbrev rfl : Retract X X := refl X
 
 /-- A retract of a retract is a retract. -/
 @[simps]

--- a/Mathlib/CategoryTheory/Shift/Adjunction.lean
+++ b/Mathlib/CategoryTheory/Shift/Adjunction.lean
@@ -532,7 +532,7 @@ instance : (Equivalence.refl C).inverse.CommShift A := by
 /--
 The identity equivalence is compatible with shifts.
 -/
-instance : (rfl (C := C)).CommShift A := by
+instance : (Equivalence.refl C).CommShift A := by
   dsimp [Equivalence.CommShift, refl_toAdjunction]
   infer_instance
 

--- a/Mathlib/CategoryTheory/Shift/Adjunction.lean
+++ b/Mathlib/CategoryTheory/Shift/Adjunction.lean
@@ -518,21 +518,21 @@ lemma mk' (h : NatTrans.CommShift E.unitIso.hom A) :
 /--
 The forward functor of the identity equivalence is compatible with shifts.
 -/
-instance : (Equivalence.refl (C := C)).functor.CommShift A := by
+instance : (Equivalence.refl C).functor.CommShift A := by
   dsimp
   infer_instance
 
 /--
 The inverse functor of the identity equivalence is compatible with shifts.
 -/
-instance : (Equivalence.refl (C := C)).inverse.CommShift A := by
+instance : (Equivalence.refl C).inverse.CommShift A := by
   dsimp
   infer_instance
 
 /--
 The identity equivalence is compatible with shifts.
 -/
-instance : (Equivalence.refl (C := C)).CommShift A := by
+instance : (rfl (C := C)).CommShift A := by
   dsimp [Equivalence.CommShift, refl_toAdjunction]
   infer_instance
 

--- a/Mathlib/CategoryTheory/Sums/Products.lean
+++ b/Mathlib/CategoryTheory/Sums/Products.lean
@@ -156,9 +156,9 @@ variable (T : Type*) [Category T]
 @[simps! hom_app_fst hom_app_snd_fst hom_app_snd_snd inv_app_fst inv_app_snd_fst inv_app_snd_snd]
 def associativityFunctorEquivNaturalityFunctorIso :
     ((sum.associativity A A' T).congrLeft.trans <| (Sum.functorEquiv A (A' ⊕ T) B).trans <|
-      Equivalence.refl.prod <| Sum.functorEquiv _ _ B).functor ≅
+      Equivalence.rfl.prod <| Sum.functorEquiv _ _ B).functor ≅
         (Sum.functorEquiv (A ⊕ A') T B).trans
-          ((Sum.functorEquiv A A' B).prod Equivalence.refl)|>.trans
+          ((Sum.functorEquiv A A' B).prod Equivalence.rfl)|>.trans
             (prod.associativity _ _ _)|>.functor :=
   NatIso.ofComponents (fun E ↦ Iso.prod
     ((Functor.associator _ _ _).symm ≪≫

--- a/Mathlib/CategoryTheory/Triangulated/Adjunction.lean
+++ b/Mathlib/CategoryTheory/Triangulated/Adjunction.lean
@@ -203,7 +203,7 @@ lemma mk'' (h : E.inverse.IsTriangulated) : E.IsTriangulated where
 /--
 The identity equivalence is triangulated.
 -/
-instance refl : (Equivalence.refl (C := C)).IsTriangulated := by
+instance refl : (Equivalence.refl C).IsTriangulated := by
   dsimp [Equivalence.IsTriangulated]
   rw [refl_toAdjunction]
   infer_instance

--- a/Mathlib/RingTheory/Morita/Basic.lean
+++ b/Mathlib/RingTheory/Morita/Basic.lean
@@ -71,7 +71,7 @@ instance {A : Type u₁} [Ring A] [Algebra R A] {B : Type u₂} [Ring B] [Algebr
 For any `R`-algebra `A`, `A` is Morita equivalent to itself.
 -/
 def refl (A : Type u₁) [Ring A] [Algebra R A] : MoritaEquivalence R A A where
-  eqv := CategoryTheory.Equivalence.refl
+  eqv := CategoryTheory.Equivalence.rfl
   linear := Functor.instLinearId
 
 /--


### PR DESCRIPTION
In general, theorems and declarations named `refl` take an explicit argument and prove/construct something of type `r X X`, whereas the `rfl` versions take the argument implicitly.
This PR adds missing `rfl` declarations to the CategoryTheory library, and makes sure `Equivalence.refl` takes an explicit argument.

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include at least one commit authored by each
co-author among the commits in the pull request. If necessary, you may 
create empty commits to indicate co-authorship, using commands like so:

git commit --author="Author Name <author@email.com>" --allow-empty -m "add Author Name as coauthor"

When merging, all the commits will be squashed into a single commit listing all co-authors.

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
