### PR TITLE
[Merged by Bors] - chore (Algebra/Vertex): linearize coefficient functions

### DIFF
--- a/Mathlib/Algebra/Vertex/HVertexOperator.lean
+++ b/Mathlib/Algebra/Vertex/HVertexOperator.lean
@@ -17,10 +17,6 @@ here allows us to consider composites and scalar-multiply by multivariable Laure
 ## Main results
 * Ext
 ## TODO
-* `HahnSeries Γ R`-module structure on `HVertexOperator Γ R V W`
-  (needs https://github.com/leanprover-community/mathlib4/pull/19062.
-  This means we can consider products of the form `(X-Y)^n A(X)B(Y)` for all integers `n`,
-  where `(X-Y)^n` is expanded as `X^n(1-Y/X)^n` in `R((X))((Y))`.
 * curry for tensor product inputs
 * more API to make ext comparisons easier.
 * formal variable API, e.g., like the `T` function for Laurent polynomials.
@@ -53,21 +49,23 @@ open HahnModule
 theorem ext (A B : HVertexOperator Γ R V W) (h : ∀ v : V, A v = B v) :
     A = B := LinearMap.ext h
 
-/-- The coefficient of a heterogeneous vertex operator, viewed as a formal power series with
-coefficients in linear maps. -/
+/-- The coefficients of a heterogeneous vertex operator, viewed as a linear map to formal power
+series with coefficients in linear maps. -/
 @[simps]
-def coeff (A : HVertexOperator Γ R V W) (n : Γ) : V →ₗ[R] W where
-  toFun v := ((of R).symm (A v)).coeff n
-  map_add' _ _ := by simp
-  map_smul' _ _ := by
-    simp only [map_smul, RingHom.id_apply, of_symm_smul, HahnSeries.coeff_smul]
+def coeff : HVertexOperator Γ R V W →ₗ[R] Γ → V →ₗ[R] W where
+  toFun A n := {
+    toFun v := ((of R).symm (A v)).coeff n
+    map_add' u v := by simp
+    map_smul' r v := by simp }
+  map_add' _ _ := by ext; simp
+  map_smul' _ _ := by ext; simp
 
 theorem coeff_isPWOsupport (A : HVertexOperator Γ R V W) (v : V) :
     ((of R).symm (A v)).coeff.support.IsPWO :=
   ((of R).symm (A v)).isPWO_support'
 
 @[ext]
-theorem coeff_inj : Function.Injective (coeff : HVertexOperator Γ R V W → Γ → (V →ₗ[R] W)) := by
+theorem coeff_inj : Function.Injective (coeff : HVertexOperator Γ R V W →ₗ[R] Γ → (V →ₗ[R] W)) := by
   intro _ _ h
   ext v n
   exact congrFun (congrArg DFunLike.coe (congrFun h n)) v
@@ -75,21 +73,23 @@ theorem coeff_inj : Function.Injective (coeff : HVertexOperator Γ R V W → Γ 
 /-- Given a coefficient function valued in linear maps satisfying a partially well-ordered support
 condition, we produce a heterogeneous vertex operator. -/
 @[simps]
-def of_coeff (f : Γ → V →ₗ[R] W)
-    (hf : ∀ (x : V), (Function.support (f · x)).IsPWO) : HVertexOperator Γ R V W where
+def of_coeff (f : Γ → V →ₗ[R] W) (hf : ∀ (x : V), (Function.support (f · x)).IsPWO) :
+    HVertexOperator Γ R V W where
   toFun x := (of R) { coeff := fun g => f g x, isPWO_support' := hf x }
   map_add' _ _ := by ext; simp
   map_smul' _ _ := by ext; simp
 
-@[simp]
-theorem coeff_add (A B : HVertexOperator Γ R V W) : (A + B).coeff = A.coeff + B.coeff := by
-  ext
-  simp
+@[deprecated (since := "2025-08-30")] alias coeff_add := map_add
+@[deprecated (since := "2025-08-30")] alias coeff_smul := map_smul
 
 @[simp]
-theorem coeff_smul (A : HVertexOperator Γ R V W) (r : R) : (r • A).coeff = r • (A.coeff) := by
-  ext
-  simp
+theorem coeff_of_coeff (f : Γ → V →ₗ[R] W)
+    (hf : ∀ (x : V), (Function.support (fun g => f g x)).IsPWO) : (of_coeff f hf).coeff = f :=
+  rfl
+
+@[simp]
+theorem of_coeff_coeff (A : HVertexOperator Γ R V W) : of_coeff A.coeff A.coeff_isPWOsupport = A :=
+  rfl
 
 end Coeff
 
@@ -108,24 +108,22 @@ def compHahnSeries (u : U) : HahnSeries Γ' (HahnSeries Γ W) where
   coeff g' := A (coeff B g' u)
   isPWO_support' := by
     refine Set.IsPWO.mono (((of R).symm (B u)).isPWO_support') ?_
-    simp_all only [coeff_apply, Function.support_subset_iff, ne_eq, Function.mem_support]
+    simp only [coeff_apply_apply, Function.support_subset_iff, ne_eq, Function.mem_support]
     intro g' hg' hAB
-    apply hg'
-    simp_rw [hAB]
-    simp_all only [map_zero, not_true_eq_false]
+    exact hg' (by simp [hAB])
 
 @[simp]
 theorem compHahnSeries_add (u v : U) :
     compHahnSeries A B (u + v) = compHahnSeries A B u + compHahnSeries A B v := by
   ext
-  simp only [compHahnSeries_coeff, map_add, coeff_apply, HahnSeries.coeff_add', Pi.add_apply]
+  simp only [compHahnSeries_coeff, map_add, coeff_apply_apply, HahnSeries.coeff_add', Pi.add_apply]
   rw [← HahnSeries.coeff_add]
 
 @[simp]
 theorem compHahnSeries_smul (r : R) (u : U) :
     compHahnSeries A B (r • u) = r • compHahnSeries A B u := by
   ext
-  simp only [compHahnSeries_coeff, LinearMapClass.map_smul, coeff_apply, HahnSeries.coeff_smul]
+  simp only [compHahnSeries_coeff, map_smul, coeff_apply_apply, HahnSeries.coeff_smul]
   rw [← HahnSeries.coeff_smul]
 
 /-- The composite of two heterogeneous vertex operators, as a heterogeneous vertex operator. -/
@@ -135,13 +133,11 @@ def comp : HVertexOperator (Γ' ×ₗ Γ) R U W where
   map_add' := by
     intro u v
     ext g
-    simp only [HahnSeries.ofIterate, compHahnSeries_add, Equiv.symm_apply_apply,
-      HahnModule.of_symm_add, HahnSeries.coeff_add', Pi.add_apply]
+    simp [HahnSeries.ofIterate]
   map_smul' := by
     intro r x
     ext g
-    simp only [HahnSeries.ofIterate, compHahnSeries_smul, HahnSeries.coeff_smul,
-      compHahnSeries_coeff, coeff_apply, Equiv.symm_apply_apply, RingHom.id_apply, of_symm_smul]
+    simp [HahnSeries.ofIterate]
 
 @[simp]
 theorem coeff_comp (g : Γ' ×ₗ Γ) :

--- a/Mathlib/Algebra/Vertex/VertexOperator.lean
+++ b/Mathlib/Algebra/Vertex/VertexOperator.lean
@@ -44,8 +44,13 @@ theorem ext (A B : VertexOperator R V) (h : ∀ v : V, A v = B v) :
     A = B := LinearMap.ext h
 
 /-- The coefficient of a vertex operator under normalized indexing. -/
-def ncoeff {R} [CommRing R] [AddCommGroup V] [Module R V] (A : VertexOperator R V) (n : ℤ) :
-    Module.End R V := HVertexOperator.coeff A (-n - 1)
+def ncoeff : VertexOperator R V →ₗ[R] ℤ → Module.End R V where
+  toFun A n := HVertexOperator.coeff A (-n - 1)
+  map_add' _ _ := by ext; simp
+  map_smul' _ _ := by ext; simp
+
+theorem ncoeff_apply (A : VertexOperator R V) (n : ℤ) : ncoeff A n = coeff A (-n - 1) :=
+  rfl
 
 /-- In the literature, the `n`th normalized coefficient of a vertex operator `A` is written as
 either `Aₙ` or `A(n)`. -/
@@ -54,15 +59,10 @@ scoped[VertexOperator] notation A "[[" n "]]" => ncoeff A n
 @[simp]
 theorem coeff_eq_ncoeff (A : VertexOperator R V)
     (n : ℤ) : HVertexOperator.coeff A n = A [[-n - 1]] := by
-  rw [ncoeff, neg_sub, sub_neg_eq_add, add_sub_cancel_left]
+  rw [ncoeff_apply, neg_sub, Int.sub_neg, add_sub_cancel_left]
 
-@[simp]
-theorem ncoeff_add (A B : VertexOperator R V) (n : ℤ) : (A + B) [[n]] = A [[n]] + B [[n]] := by
-  rw [ncoeff, ncoeff, ncoeff, coeff_add, Pi.add_apply]
-
-@[simp]
-theorem ncoeff_smul (A : VertexOperator R V) (r : R) (n : ℤ) : (r • A) [[n]] = r • A [[n]] := by
-  rw [ncoeff, ncoeff, coeff_smul, Pi.smul_apply]
+@[deprecated (since := "2025-08-30")] alias ncoeff_add := map_add
+@[deprecated (since := "2025-08-30")] alias ncoeff_smul := map_smul
 
 theorem ncoeff_eq_zero_of_lt_order (A : VertexOperator R V) (n : ℤ) (x : V)
     (h : -n - 1 < HahnSeries.order ((HahnModule.of R).symm (A x))) : (A [[n]]) x = 0 := by
@@ -77,10 +77,10 @@ theorem coeff_eq_zero_of_lt_order (A : VertexOperator R V) (n : ℤ) (x : V)
 /-- Given an endomorphism-valued function on integers satisfying a pointwise bounded-pole condition,
 we produce a vertex operator. -/
 noncomputable def of_coeff (f : ℤ → Module.End R V)
-    (hf : ∀ (x : V), ∃ (n : ℤ), ∀ (m : ℤ), m < n → (f m) x = 0) : VertexOperator R V :=
+    (hf : ∀ x : V, ∃ n : ℤ, ∀ m : ℤ, m < n → f m x = 0) : VertexOperator R V :=
   HVertexOperator.of_coeff f
-    (fun x => HahnSeries.suppBddBelow_supp_PWO (fun n => (f n) x)
-      (HahnSeries.forallLTEqZero_supp_BddBelow (fun n => (f n) x)
+    (fun x => HahnSeries.suppBddBelow_supp_PWO (fun n => f n x)
+      (HahnSeries.forallLTEqZero_supp_BddBelow (fun n => f n x)
         (Exists.choose (hf x)) (Exists.choose_spec (hf x))))
 
 @[simp]
@@ -94,6 +94,6 @@ theorem ncoeff_of_coeff (f : ℤ → Module.End R V)
     (hf : ∀ (x : V), ∃ (n : ℤ), ∀ (m : ℤ), m < n → (f m) x = 0) (n : ℤ) :
     (of_coeff f hf) [[n]] = f (-n - 1) := by
   ext v
-  rw [ncoeff, coeff_apply, of_coeff_apply_coeff]
+  rw [ncoeff_apply, coeff_apply_apply, of_coeff_apply_coeff]
 
 end VertexOperator


### PR DESCRIPTION
This PR upgrades the coefficient functions of vertex operators and heterogeneous vertex operators to be linear maps instead of just functions. We also deprecate the corresponding linearity lemmas, and add two rfl simp lemmas.

---


[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
