### PR TITLE
[Merged by Bors] - doc: hyphenize "well-defined" where applicable

### DIFF
--- a/Mathlib/Algebra/Module/LocalizedModule/Basic.lean
+++ b/Mathlib/Algebra/Module/LocalizedModule/Basic.lean
@@ -19,9 +19,9 @@ localize `M` by `S`. This gives us a `Localization S`-module.
   `(m, s) ≈ (m', s')` if and only if there is some `u : S` such that `u • s' • m = u • s • m'`.
 * `LocalizedModule M S`: the localized module by `S`.
 * `LocalizedModule.mk`: the canonical map sending `(m, s) : M × S ↦ m/s : LocalizedModule M S`
-* `LocalizedModule.liftOn`: any well defined function `f : M × S → α` respecting `r` descents to
+* `LocalizedModule.liftOn`: any well-defined function `f : M × S → α` respecting `r` descents to
   a function `LocalizedModule M S → α`
-* `LocalizedModule.liftOn₂`: any well defined function `f : M × S → M × S → α` respecting `r`
+* `LocalizedModule.liftOn₂`: any well-defined function `f : M × S → M × S → α` respecting `r`
   descents to a function `LocalizedModule M S → LocalizedModule M S`
 * `LocalizedModule.mk_add_mk`: in the localized module
   `mk m s + mk m' s' = mk (s' • m + s • m') (s * s')`

--- a/Mathlib/AlgebraicGeometry/ProjectiveSpectrum/Scheme.lean
+++ b/Mathlib/AlgebraicGeometry/ProjectiveSpectrum/Scheme.lean
@@ -50,7 +50,7 @@ open sets in `Proj`, more specifically:
       `ProjIsoSpecTopComponent.FromSpec.carrier.relevant`;
     * This ideal is prime, the proof can be found in
       `ProjIsoSpecTopComponent.FromSpec.carrier.asIdeal.prime`.
-    Hence we have a well defined function `Spec.T A⁰_f → Proj.T | (pbo f)`, this function is called
+    Hence we have a well-defined function `Spec.T A⁰_f → Proj.T | (pbo f)`, this function is called
     `ProjIsoSpecTopComponent.FromSpec.toFun`. But to prove the continuity of this function, we need
     to prove `fromSpec ∘ toSpec` and `toSpec ∘ fromSpec` are both identities; these are achieved in
     `ProjIsoSpecTopComponent.fromSpec_toSpec` and `ProjIsoSpecTopComponent.toSpec_fromSpec`.

--- a/Mathlib/Order/JordanHolder.lean
+++ b/Mathlib/Order/JordanHolder.lean
@@ -56,7 +56,7 @@ the Jordan-Hölder theorem for modules/groups and the API should be transferred 
 theorems in this file will have stronger versions for modules. There will also need to be an API for
 mapping composition series across homomorphisms. It is also probably possible to
 provide an instance of `JordanHolderLattice` for any `ModularLattice`, and in this case the
-Jordan-Hölder theorem will say that there is a well defined notion of length of a modular lattice.
+Jordan-Hölder theorem will say that there is a well-defined notion of length of a modular lattice.
 However an instance of `JordanHolderLattice` for a modular lattice will not be able to contain
 the correct notion of isomorphism for modules, so a separate instance for modules will still be
 required and this will clash with the instance for modular lattices, and so at least one of these

--- a/scripts/README.md
+++ b/scripts/README.md
@@ -57,7 +57,7 @@ to learn about it as well!
   Requires GitHub CLI (`gh`) installed and authenticated. Safe to run multiple times.
 - `githelper.py`
   The subcommand `githelper.py fix` helps contributors fix their git repository setup
-  by step-by-step converting it from its current state to a well defined target state.
+  by step-by-step converting it from its current state to a well-defined target state.
   The target state mostly matches the state after of a freshly cloned fork (`gh repo clone <fork>`)
   and looks like this:
 


### PR DESCRIPTION
Compound adjectives appearing before the noun they are modifying should be hyphenated in order to avoid ambiguity. This PR hyphenates the compound adjective "well-defined".

It does not cover cases where the compound adjective is appearing after its noun, as hyphenation is then regarded as a stylistic choice, as opposed to a grammatical tool.

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include at least one commit authored by each
co-author among the commits in the pull request. If necessary, you may 
create empty commits to indicate co-authorship, using commands like so:

git commit --author="Author Name <author@email.com>" --allow-empty -m "add Author Name as coauthor"

When merging, all the commits will be squashed into a single commit listing all co-authors.

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
