### PR TITLE
[Merged by Bors] - chore(RingTheory/TensorProduct/Basic): generalize result

### DIFF
--- a/Mathlib/RingTheory/TensorProduct/Basic.lean
+++ b/Mathlib/RingTheory/TensorProduct/Basic.lean
@@ -1350,13 +1350,6 @@ theorem linearMap_comp_mul' :
     Algebra.linearMap_apply, map_one, LinearMap.coe_comp, Function.comp_apply,
     LinearMap.mul'_apply, mul_one, Algebra.TensorProduct.one_def]
 
-@[simp]
-theorem mul'_comp_tensorTensorTensorComm :
-    LinearMap.mul' R (A ⊗[R] B) ∘ₗ tensorTensorTensorComm R A A B B =
-      map (LinearMap.mul' R A) (LinearMap.mul' R B) := by
-  ext
-  simp
-
 end Lemmas
 
 end TensorProduct.Algebra
@@ -1411,6 +1404,17 @@ end
 variable {R A B : Type*} [CommSemiring R] [NonUnitalNonAssocSemiring A]
   [NonUnitalNonAssocSemiring B] [Module R A] [Module R B] [SMulCommClass R A A]
   [SMulCommClass R B B] [IsScalarTower R A A] [IsScalarTower R B B]
+
+@[simp]
+theorem TensorProduct.Algebra.mul'_comp_tensorTensorTensorComm :
+    LinearMap.mul' R (A ⊗[R] B) ∘ₗ tensorTensorTensorComm R A A B B =
+      map (LinearMap.mul' R A) (LinearMap.mul' R B) := by
+  ext
+  simp
+
+lemma LinearMap.mul'_tensor :
+    mul' R (A ⊗[R] B) = map (mul' R A) (mul' R B) ∘ₗ tensorTensorTensorComm R A B A B :=
+  ext_fourfold' <| by simp
 
 lemma LinearMap.mulLeft_tmul (a : A) (b : B) :
     mulLeft R (a ⊗ₜ[R] b) = map (mulLeft R a) (mulLeft R b) := by


### PR DESCRIPTION
Generalize `TensorProduct.Algebra.mul'_comp_tensorTensorTensorComm` to use `NonUnitalNonAssocSemiring` instead of `Semiring` and add `LinearMap.mul'_tensor` (moved these down so that we can use the variables instead of reintroducing the same variables).

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include at least one commit authored by each
co-author among the commits in the pull request. If necessary, you may 
create empty commits to indicate co-authorship, using commands like so:

git commit --author="Author Name <author@email.com>" --allow-empty -m "add Author Name as coauthor"

When merging, all the commits will be squashed into a single commit listing all co-authors.

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
