### PR TITLE
[Merged by Bors] - chore(Topology/CWComplex/Classical): reverse accidental renaming

### DIFF
--- a/Mathlib/Topology/CWComplex/Classical/Basic.lean
+++ b/Mathlib/Topology/CWComplex/Classical/Basic.lean
@@ -140,7 +140,7 @@ class CWComplex.{u} {X : Type u} [TopologicalSpace X] (C : Set X) where
     (univ : Set (Σ n, cell n)).PairwiseDisjoint (fun ni ↦ map ni.1 ni.2 '' ball 0 1)
   /-- The boundary of a cell is contained in a finite union of closed cells of a lower dimension.
   Use `CWComplex.mapsTo` or `CWComplex.cellFrontier_subset_finite_closedCell` instead. -/
-  protected mapsTo_iff_image_subset (n : ℕ) (i : cell n) : ∃ I : Π m, Finset (cell m),
+  protected mapsTo' (n : ℕ) (i : cell n) : ∃ I : Π m, Finset (cell m),
     MapsTo (map n i) (sphere 0 1) (⋃ (m < n) (j ∈ I m), map m j '' closedBall 0 1)
   /-- A CW complex has weak topology, i.e. a set `A` in `X` is closed iff its intersection with
   every closed cell is closed. Use `CWComplex.closed` instead. -/
@@ -159,7 +159,7 @@ instance (priority := high) CWComplex.instRelCWComplex {X : Type*} [TopologicalS
   continuousOn_symm := CWComplex.continuousOn_symm
   pairwiseDisjoint' := CWComplex.pairwiseDisjoint'
   disjointBase' := by simp [disjoint_empty]
-  mapsTo := by simpa only [empty_union] using CWComplex.mapsTo_iff_image_subset
+  mapsTo := by simpa only [empty_union] using CWComplex.mapsTo'
   closed' := by simpa only [inter_empty, isClosed_empty, and_true] using CWComplex.closed'
   isClosedBase := isClosed_empty
   union' := by simpa only [empty_union] using CWComplex.union'
@@ -174,7 +174,7 @@ def RelCWComplex.toCWComplex {X : Type*} [TopologicalSpace X] (C : Set X) [RelCW
   continuousOn := continuousOn
   continuousOn_symm := continuousOn_symm
   pairwiseDisjoint' := pairwiseDisjoint'
-  mapsTo_iff_image_subset := by simpa using mapsTo (C := C)
+  mapsTo' := by simpa using mapsTo (C := C)
   closed' := by simpa using closed' (C := C)
   union' := by simpa using union' (C := C)
 

--- a/Mathlib/Topology/CWComplex/Classical/Finite.lean
+++ b/Mathlib/Topology/CWComplex/Classical/Finite.lean
@@ -143,7 +143,7 @@ def CWComplex.mkFiniteType.{u} {X : Type u} [TopologicalSpace X] (C : Set X)
   continuousOn := continuousOn
   continuousOn_symm := continuousOn_symm
   pairwiseDisjoint' := pairwiseDisjoint'
-  mapsTo_iff_image_subset n i := by
+  mapsTo' n i := by
     use fun m ↦ finite_univ.toFinset (s := (univ : Set (cell m)))
     simp only [Finite.mem_toFinset, mem_univ, iUnion_true]
     exact mapsTo n i


### PR DESCRIPTION
#27551 which renames `Set.mapsTo'` also accidentally renamed `Topology.CWComplex.mapsTo'`. This PR reverses that change.

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include at least one commit authored by each
co-author among the commits in the pull request. If necessary, you may 
create empty commits to indicate co-authorship, using commands like so:

git commit --author="Author Name <author@email.com>" --allow-empty -m "add Author Name as coauthor"

When merging, all the commits will be squashed into a single commit listing all co-authors.

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
