### PR TITLE
[Merged by Bors] - feat(SimpleGraph): Hall's Marriage Theorem for bipartite graphs

### DIFF
--- a/Mathlib.lean
+++ b/Mathlib.lean
@@ -2987,6 +2987,7 @@ import Mathlib.Combinatorics.SimpleGraph.Finite
 import Mathlib.Combinatorics.SimpleGraph.Finsubgraph
 import Mathlib.Combinatorics.SimpleGraph.FiveWheelLike
 import Mathlib.Combinatorics.SimpleGraph.Girth
+import Mathlib.Combinatorics.SimpleGraph.Hall
 import Mathlib.Combinatorics.SimpleGraph.Hamiltonian
 import Mathlib.Combinatorics.SimpleGraph.Hasse
 import Mathlib.Combinatorics.SimpleGraph.IncMatrix

--- a/Mathlib/Combinatorics/Hall/Basic.lean
+++ b/Mathlib/Combinatorics/Hall/Basic.lean
@@ -41,10 +41,6 @@ The core of this module is constructing the inverse system: for every finite sub
   `r : α → β → Prop` on finite types, with the Hall condition given in terms of
   `finset.univ.filter`.
 
-## TODO
-
-* The statement of the theorem in terms of bipartite graphs is in preparation.
-
 ## Tags
 
 Hall's Marriage Theorem, indexed families

--- a/Mathlib/Combinatorics/SimpleGraph/Hall.lean
+++ b/Mathlib/Combinatorics/SimpleGraph/Hall.lean
@@ -82,7 +82,7 @@ lemma union_eq_univ_of_forall_ncard_le (h₁ : G.IsBipartiteWith p₁ p₂)
   have := h₁.mem_of_adj <| G.mem_neighborFinset _ _ |>.mp (hf₂ x)
   grind
 
-lemma exists_bijective_of_forall_ncard_le [DecidablePred (· ∈ p₁)] (h₁ : G.IsBipartiteWith p₁ p₂)
+lemma exists_bijective_of_forall_ncard_le (h₁ : G.IsBipartiteWith p₁ p₂)
     (h₂ : ∀ s : Set V, s.ncard ≤ (⋃ x ∈ s, G.neighborSet x).ncard) :
     ∃ (h : p₁ → p₂), Function.Bijective h ∧ ∀ (a : p₁), G.Adj a (h a) := by
   obtain ⟨f, hf₁, hf₂⟩ := Finset.all_card_le_biUnion_card_iff_exists_injective

--- a/Mathlib/Combinatorics/SimpleGraph/Hall.lean
+++ b/Mathlib/Combinatorics/SimpleGraph/Hall.lean
@@ -73,7 +73,7 @@ theorem exists_IsMatching_of_forall_ncard_le [DecidablePred (· ∈ p₁)] (h₁
   · use x
     have := hx₂ ▸ (this x hx₁)
     simp only [this, ↓reduceDIte, hx₁, hx₂, dite_else_false, forall_exists_index, true_and]
-    exact fun _ _ k ↦ Subtype.ext_iff_val.mp <| hf₁ (hx₂ ▸ k)
+    exact fun _ _ k ↦ Subtype.ext_iff.mp <| hf₁ (hx₂ ▸ k)
 
 private
 lemma union_eq_univ_of_forall_ncard_le (h₁ : G.IsBipartiteWith p₁ p₂)

--- a/Mathlib/Combinatorics/SimpleGraph/Hall.lean
+++ b/Mathlib/Combinatorics/SimpleGraph/Hall.lean
@@ -15,8 +15,8 @@ This file derives Hall's Marriage Theorem for bipartite graphs from the combinat
 
 ## Main statements
 
-* `SimpleGraph.exists_IsMatching_of_forall_ncard_le`: Hall's marriage theorem for a matching for a
-  matching on a single partition of a bipartite graph.
+* `SimpleGraph.exists_IsMatching_of_forall_ncard_le`: Hall's marriage theorem for a matching on a
+  single partition of a bipartite graph.
 * `SimpleGraph.exists_IsPerfectMatching_of_forall_ncard_le`: Hall's marriage theorem for a perfect
   matching on a bipartite graph.
 
@@ -65,7 +65,7 @@ theorem exists_IsMatching_of_forall_ncard_le [DecidablePred (· ∈ p₁)] (h₁
     simpa [← Set.ncard_coe_finset, neighborFinset_def]
   have (x : V) (h : x ∈ p₁) : f ⟨x, h⟩ ∉ p₁ := h₁.disjoint |>.notMem_of_mem_right <|
     isBipartiteWith_neighborSet_subset h₁ h <| Set.mem_toFinset.mp <| hf₂ ⟨x, h⟩
-  use hall_subgraph f this (fun v h ↦ G.mem_neighborFinset _ _ |>.mp (hf₂ ⟨v, by assumption⟩))
+  use hall_subgraph f this (fun v _ ↦ G.mem_neighborFinset _ _ |>.mp <| hf₂ ⟨v, by assumption⟩)
   refine ⟨by simp, fun v hv ↦ ?_⟩
   simp only [Set.mem_union, Set.mem_range, Subtype.exists] at hv ⊢
   rcases hv with h' | ⟨x, hx₁, hx₂⟩
@@ -76,15 +76,13 @@ theorem exists_IsMatching_of_forall_ncard_le [DecidablePred (· ∈ p₁)] (h₁
     exact fun _ _ k ↦ Subtype.ext_iff_val.mp <| hf₁ (hx₂ ▸ k)
 
 private
-lemma union_eq_set_univ_of_forall_ncard_le (h₁ : G.IsBipartiteWith p₁ p₂)
+lemma union_eq_univ_of_forall_ncard_le (h₁ : G.IsBipartiteWith p₁ p₂)
     (h₂ : ∀ s : Set V, s.ncard ≤ (⋃ x ∈ s, G.neighborSet x).ncard) : p₁ ∪ p₂ = Set.univ := by
   obtain ⟨f, _, hf₂⟩ := Finset.all_card_le_biUnion_card_iff_exists_injective
       (fun x ↦ G.neighborFinset x) |>.mp fun s ↦ by
     have := h₂ s
     simpa [← Set.ncard_coe_finset, neighborFinset_def]
   refine Set.eq_univ_iff_forall.mpr fun x ↦ ?_
-  have := hf₂ x
-  have := G.mem_neighborFinset _ _ |>.mp (hf₂ x)
   have := h₁.mem_of_adj <| G.mem_neighborFinset _ _ |>.mp (hf₂ x)
   grind
 
@@ -101,10 +99,10 @@ lemma exists_bijective_of_forall_ncard_le [DecidablePred (· ∈ p₁)] (h₁ : 
   have (x : V) (h : x ∈ p₂) : f x ∉ p₂ := h₁.disjoint |>.notMem_of_mem_left <|
     isBipartiteWith_neighborSet_subset h₁.symm h <| Set.mem_toFinset.mp <| hf₂ x
   have (x : V) : f x ∈ p₁ ∨ f x ∈ p₂ := by
-    simp [union_eq_set_univ_of_forall_ncard_le h₁ h₂, p₁.mem_union (f x) p₂ |>.mp]
+    simp [union_eq_univ_of_forall_ncard_le h₁ h₂, p₁.mem_union (f x) p₂ |>.mp]
   let f' (x : p₁) : p₂ := ⟨f x, by grind⟩
   let g' (x : p₂) : p₁ := ⟨f x, by grind⟩
-  refine Embedding.schroeder_bernstein' (f := f') (g := g') ?_ ?_ (fun x y ↦ G.Adj x y) ?_ ?_
+  refine Embedding.schroeder_bernstein_of_rel (f := f') (g := g') ?_ ?_ (fun x y ↦ G.Adj x y) ?_ ?_
   · exact Injective.of_comp (f := Subtype.val) <| hf₁.comp <| Subtype.val_injective
   · exact Injective.of_comp (f := Subtype.val) <| hf₁.comp <| Subtype.val_injective
   · exact fun v ↦ mem_neighborFinset _ _ _ |>.mp (hf₂ v)
@@ -116,11 +114,11 @@ theorem exists_IsPerfectMatching_of_forall_ncard_le [DecidablePred (· ∈ p₁)
     (h₁ : G.IsBipartiteWith p₁ p₂) (h₂ : ∀ s : Set V, s.ncard ≤ (⋃ x ∈ s, G.neighborSet x).ncard) :
     ∃ M : Subgraph G, M.IsPerfectMatching := by
   obtain ⟨b, hb₁, hb₂⟩ := exists_bijective_of_forall_ncard_le h₁ h₂
-  use hall_subgraph (fun v ↦ (b v).1) (fun v hv ↦ h₁.disjoint |>.notMem_of_mem_right (b ⟨v, hv⟩).2)
-    (fun v h ↦ hb₂ ⟨v, by assumption⟩)
+  use hall_subgraph (fun v ↦ b v) (fun v hv ↦ h₁.disjoint.notMem_of_mem_right (b ⟨v, hv⟩).property)
+    (fun v hv ↦ hb₂ ⟨v, hv⟩)
   have : p₁ ∪ (Set.range (fun v ↦ (b v).1)) = Set.univ := by
     rw [Set.range_comp', hb₁.surjective.range_eq, Subtype.coe_image_univ]
-    exact union_eq_set_univ_of_forall_ncard_le h₁ h₂
+    exact union_eq_univ_of_forall_ncard_le h₁ h₂
   refine ⟨fun v _ ↦ ?_, by simp [Subgraph.IsSpanning, this]⟩
   simp only [dite_else_false]
   split

--- a/Mathlib/Combinatorics/SimpleGraph/Hall.lean
+++ b/Mathlib/Combinatorics/SimpleGraph/Hall.lean
@@ -116,7 +116,7 @@ theorem exists_IsPerfectMatching_of_forall_ncard_le [DecidablePred (· ∈ p₁)
   obtain ⟨b, hb₁, hb₂⟩ := exists_bijective_of_forall_ncard_le h₁ h₂
   use hall_subgraph (fun v ↦ b v) (fun v hv ↦ h₁.disjoint.notMem_of_mem_right (b ⟨v, hv⟩).property)
     (fun v hv ↦ hb₂ ⟨v, hv⟩)
-  have : p₁ ∪ (Set.range (fun v ↦ (b v).1)) = Set.univ := by
+  have : p₁ ∪ Set.range (fun v ↦ (b v).1) = Set.univ := by
     rw [Set.range_comp', hb₁.surjective.range_eq, Subtype.coe_image_univ]
     exact union_eq_univ_of_forall_ncard_le h₁ h₂
   refine ⟨fun v _ ↦ ?_, by simp [Subgraph.IsSpanning, this]⟩

--- a/Mathlib/Combinatorics/SimpleGraph/Hall.lean
+++ b/Mathlib/Combinatorics/SimpleGraph/Hall.lean
@@ -15,10 +15,10 @@ This file derives Hall's Marriage Theorem for bipartite graphs from the combinat
 
 ## Main statements
 
-* `SimpleGraph.exists_IsMatching_of_forall_ncard_le`: Hall's marriage theorem for a matching on a
-  single partition of a bipartite graph.
-* `SimpleGraph.exists_IsPerfectMatching_of_forall_ncard_le`: Hall's marriage theorem for a perfect
-  matching on a bipartite graph.
+* `exists_isMatching_of_forall_ncard_le`: Hall's marriage theorem for a matching on a single
+  partition of a bipartite graph.
+* `exists_isPerfectMatching_of_forall_ncard_le`: Hall's marriage theorem for a perfect matching on a
+  bipartite graph.
 
 ## Tags
 
@@ -52,7 +52,7 @@ variable [DecidableEq V] [G.LocallyFinite] {p₁ p₂ : Set V}
 /-- This is the version of **Hall's marriage theorem** for bipartite graphs that finds a matching
 for a single partition given that the neighborhood-condition only holds for elements of that
 partition. -/
-theorem exists_IsMatching_of_forall_ncard_le [DecidablePred (· ∈ p₁)] (h₁ : G.IsBipartiteWith p₁ p₂)
+theorem exists_isMatching_of_forall_ncard_le [DecidablePred (· ∈ p₁)] (h₁ : G.IsBipartiteWith p₁ p₂)
     (h₂ : ∀ s ⊆ p₁, s.ncard ≤ (⋃ x ∈ s, G.neighborSet x).ncard) :
     ∃ M : Subgraph G, p₁ ⊆ M.verts ∧ M.IsMatching := by
   obtain ⟨f, hf₁, hf₂⟩ := Finset.all_card_le_biUnion_card_iff_exists_injective
@@ -72,7 +72,6 @@ theorem exists_IsMatching_of_forall_ncard_le [DecidablePred (· ∈ p₁)] (h₁
     simp only [this, ↓reduceDIte, hx₁, hx₂, dite_else_false, forall_exists_index, true_and]
     exact fun _ _ k ↦ Subtype.ext_iff.mp <| hf₁ (hx₂ ▸ k)
 
-private
 lemma union_eq_univ_of_forall_ncard_le (h₁ : G.IsBipartiteWith p₁ p₂)
     (h₂ : ∀ s : Set V, s.ncard ≤ (⋃ x ∈ s, G.neighborSet x).ncard) : p₁ ∪ p₂ = Set.univ := by
   obtain ⟨f, _, hf₂⟩ := Finset.all_card_le_biUnion_card_iff_exists_injective
@@ -83,7 +82,6 @@ lemma union_eq_univ_of_forall_ncard_le (h₁ : G.IsBipartiteWith p₁ p₂)
   have := h₁.mem_of_adj <| G.mem_neighborFinset _ _ |>.mp (hf₂ x)
   grind
 
-private
 lemma exists_bijective_of_forall_ncard_le [DecidablePred (· ∈ p₁)] (h₁ : G.IsBipartiteWith p₁ p₂)
     (h₂ : ∀ s : Set V, s.ncard ≤ (⋃ x ∈ s, G.neighborSet x).ncard) :
     ∃ (h : p₁ → p₂), Function.Bijective h ∧ ∀ (a : p₁), G.Adj a (h a) := by
@@ -107,7 +105,7 @@ lemma exists_bijective_of_forall_ncard_le [DecidablePred (· ∈ p₁)] (h₁ : 
 
 /-- This is the version of **Hall's marriage theorem** for bipartite graphs that finds a perfect
 matching given that the neighborhood-condition holds globally. -/
-theorem exists_IsPerfectMatching_of_forall_ncard_le [DecidablePred (· ∈ p₁)]
+theorem exists_isPerfectMatching_of_forall_ncard_le [DecidablePred (· ∈ p₁)]
     (h₁ : G.IsBipartiteWith p₁ p₂) (h₂ : ∀ s : Set V, s.ncard ≤ (⋃ x ∈ s, G.neighborSet x).ncard) :
     ∃ M : Subgraph G, M.IsPerfectMatching := by
   obtain ⟨b, hb₁, hb₂⟩ := exists_bijective_of_forall_ncard_le h₁ h₂

--- a/Mathlib/Combinatorics/SimpleGraph/Hall.lean
+++ b/Mathlib/Combinatorics/SimpleGraph/Hall.lean
@@ -25,6 +25,8 @@ This file derives Hall's Marriage Theorem for bipartite graphs from the combinat
 Hall's Marriage Theorem
 -/
 
+open Function
+
 namespace SimpleGraph
 
 variable {V : Type*} {G : SimpleGraph V}
@@ -48,11 +50,12 @@ abbrev hall_subgraph {p : Set V} [DecidablePred (· ∈ p)] (f : p → V)
   edge_vert {v w} := by grind
   symm {x y} := by grind
 
+variable [DecidableEq V] [G.LocallyFinite] {p₁ p₂ : Set V}
+
 /-- This is the version of **Hall's marriage theorem** for bipartite graphs that finds a matching
 for a single partition given that the neighborhood-condition only holds for elements of that
 partition. -/
-theorem exists_IsMatching_of_forall_ncard_le [DecidableEq V] [G.LocallyFinite]
-    {p₁ p₂ : Set V} [DecidablePred (· ∈ p₁)] (h₁ : G.IsBipartiteWith p₁ p₂)
+theorem exists_IsMatching_of_forall_ncard_le [DecidablePred (· ∈ p₁)] (h₁ : G.IsBipartiteWith p₁ p₂)
     (h₂ : ∀ s ⊆ p₁, s.ncard ≤ (⋃ x ∈ s, G.neighborSet x).ncard) :
     ∃ M : Subgraph G, p₁ ⊆ M.verts ∧ M.IsMatching := by
   obtain ⟨f, hf₁, hf₂⟩ := Finset.all_card_le_biUnion_card_iff_exists_injective
@@ -72,12 +75,23 @@ theorem exists_IsMatching_of_forall_ncard_le [DecidableEq V] [G.LocallyFinite]
     simp only [this, ↓reduceDIte, hx₁, hx₂, dite_else_false, forall_exists_index, true_and]
     exact fun _ _ k ↦ Subtype.ext_iff_val.mp <| hf₁ (hx₂ ▸ k)
 
-/-- This is the version of **Hall's marriage theorem** for bipartite graphs that finds a perfect
-matching given that the neighborhood-condition holds globally. -/
-theorem exists_IsPerfectMatching_of_forall_ncard_le [DecidableEq V] [G.LocallyFinite]
-    {p₁ p₂ : Set V} [DecidablePred (· ∈ p₁)] (h₁ : G.IsBipartiteWith p₁ p₂)
+private
+lemma union_eq_set_univ_of_forall_ncard_le (h₁ : G.IsBipartiteWith p₁ p₂)
+    (h₂ : ∀ s : Set V, s.ncard ≤ (⋃ x ∈ s, G.neighborSet x).ncard) : p₁ ∪ p₂ = Set.univ := by
+  obtain ⟨f, _, hf₂⟩ := Finset.all_card_le_biUnion_card_iff_exists_injective
+      (fun x ↦ G.neighborFinset x) |>.mp fun s ↦ by
+    have := h₂ s
+    simpa [← Set.ncard_coe_finset, neighborFinset_def]
+  refine Set.eq_univ_iff_forall.mpr fun x ↦ ?_
+  have := hf₂ x
+  have := G.mem_neighborFinset _ _ |>.mp (hf₂ x)
+  have := h₁.mem_of_adj <| G.mem_neighborFinset _ _ |>.mp (hf₂ x)
+  grind
+
+private
+lemma exists_bijective_of_forall_ncard_le [DecidablePred (· ∈ p₁)] (h₁ : G.IsBipartiteWith p₁ p₂)
     (h₂ : ∀ s : Set V, s.ncard ≤ (⋃ x ∈ s, G.neighborSet x).ncard) :
-    ∃ M : Subgraph G, M.IsPerfectMatching := by
+    ∃ (h : p₁ → p₂), Function.Bijective h ∧ ∀ (a : p₁), G.Adj a (h a) := by
   obtain ⟨f, hf₁, hf₂⟩ := Finset.all_card_le_biUnion_card_iff_exists_injective
       (fun x ↦ G.neighborFinset x) |>.mp fun s ↦ by
     have := h₂ s
@@ -86,27 +100,32 @@ theorem exists_IsPerfectMatching_of_forall_ncard_le [DecidableEq V] [G.LocallyFi
     isBipartiteWith_neighborSet_subset h₁ h <| Set.mem_toFinset.mp <| hf₂ x
   have (x : V) (h : x ∈ p₂) : f x ∉ p₂ := h₁.disjoint |>.notMem_of_mem_left <|
     isBipartiteWith_neighborSet_subset h₁.symm h <| Set.mem_toFinset.mp <| hf₂ x
-  have : p₁ ∪ p₂ = Set.univ := by
-    refine Set.eq_univ_iff_forall.mpr fun x ↦ ?_
-    have := h₁.mem_of_adj <| G.mem_neighborFinset _ _ |>.mp (hf₂ x)
-    grind
-  have (x : V) : f x ∈ p₁ ∨ f x ∈ p₂ := by simp [this, Set.mem_union (f x) p₁ p₂ |>.mp]
+  have (x : V) : f x ∈ p₁ ∨ f x ∈ p₂ := by
+    simp [union_eq_set_univ_of_forall_ncard_le h₁ h₂, p₁.mem_union (f x) p₂ |>.mp]
   let f' (x : p₁) : p₂ := ⟨f x, by grind⟩
   let g' (x : p₂) : p₁ := ⟨f x, by grind⟩
-  have := Function.Embedding.schroeder_bernstein' (f := f') (g := g') ?_ ?_ (fun x y ↦ G.Adj x y)
-    (fun v ↦ mem_neighborFinset _ _ _ |>.mp (hf₂ v))
-    (fun v ↦ mem_neighborFinset _ _ _ |>.mp (hf₂ v) |>.symm)
-  · obtain ⟨b, hb₁, hb₂⟩ := this
-    use hall_subgraph (fun v ↦ (b v).1) (by grind) (fun v h ↦ hb₂ ⟨v, by assumption⟩)
-    have : p₁ ∪ (Set.range (fun v ↦ (b v).1)) = Set.univ := by
-      rwa [Set.range_comp', hb₁.surjective.range_eq, Subtype.coe_image_univ]
-    refine ⟨fun v _ ↦ ?_, by simp [Subgraph.IsSpanning, this]⟩
-    simp only [dite_else_false]
-    split
-    · exact existsUnique_eq'
-    · obtain ⟨x, _⟩ := hb₁.existsUnique ⟨v, by grind⟩
-      exact ⟨x, by grind⟩
-  · exact Function.Injective.of_comp (f := Subtype.val) <| hf₁.comp <| Subtype.val_injective
-  · exact Function.Injective.of_comp (f := Subtype.val) <| hf₁.comp <| Subtype.val_injective
+  refine Embedding.schroeder_bernstein' (f := f') (g := g') ?_ ?_ (fun x y ↦ G.Adj x y) ?_ ?_
+  · exact Injective.of_comp (f := Subtype.val) <| hf₁.comp <| Subtype.val_injective
+  · exact Injective.of_comp (f := Subtype.val) <| hf₁.comp <| Subtype.val_injective
+  · exact fun v ↦ mem_neighborFinset _ _ _ |>.mp (hf₂ v)
+  · exact fun v ↦ mem_neighborFinset _ _ _ |>.mp (hf₂ v) |>.symm
+
+/-- This is the version of **Hall's marriage theorem** for bipartite graphs that finds a perfect
+matching given that the neighborhood-condition holds globally. -/
+theorem exists_IsPerfectMatching_of_forall_ncard_le [DecidablePred (· ∈ p₁)]
+    (h₁ : G.IsBipartiteWith p₁ p₂) (h₂ : ∀ s : Set V, s.ncard ≤ (⋃ x ∈ s, G.neighborSet x).ncard) :
+    ∃ M : Subgraph G, M.IsPerfectMatching := by
+  obtain ⟨b, hb₁, hb₂⟩ := exists_bijective_of_forall_ncard_le h₁ h₂
+  use hall_subgraph (fun v ↦ (b v).1) (fun v hv ↦ h₁.disjoint |>.notMem_of_mem_right (b ⟨v, hv⟩).2)
+    (fun v h ↦ hb₂ ⟨v, by assumption⟩)
+  have : p₁ ∪ (Set.range (fun v ↦ (b v).1)) = Set.univ := by
+    rw [Set.range_comp', hb₁.surjective.range_eq, Subtype.coe_image_univ]
+    exact union_eq_set_univ_of_forall_ncard_le h₁ h₂
+  refine ⟨fun v _ ↦ ?_, by simp [Subgraph.IsSpanning, this]⟩
+  simp only [dite_else_false]
+  split
+  · exact existsUnique_eq'
+  · obtain ⟨x, _⟩ := hb₁.existsUnique ⟨v, by grind⟩
+    exact ⟨x, by grind⟩
 
 end SimpleGraph

--- a/Mathlib/Combinatorics/SimpleGraph/Hall.lean
+++ b/Mathlib/Combinatorics/SimpleGraph/Hall.lean
@@ -1,0 +1,112 @@
+/-
+Copyright (c) 2025 Vlad Tsyrklevich. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Vlad Tsyrklevich
+-/
+import Mathlib.Combinatorics.Hall.Basic
+import Mathlib.Combinatorics.SimpleGraph.Bipartite
+import Mathlib.Combinatorics.SimpleGraph.Matching
+
+/-!
+# Hall's Marriage Theorem
+
+This file derives Hall's Marriage Theorem for bipartite graphs from the combinatorial formulation in
+`Mathlib/Combinatorics/Hall/Basic.lean`.
+
+## Main statements
+
+* `SimpleGraph.exists_IsMatching_of_forall_ncard_le`: Hall's marriage theorem for a matching for a
+  matching on a single partition of a bipartite graph.
+* `SimpleGraph.exists_IsPerfectMatching_of_forall_ncard_le`: Hall's marriage theorem for a perfect
+  matching on a bipartite graph.
+
+## Tags
+
+Hall's Marriage Theorem
+-/
+
+namespace SimpleGraph
+
+variable {V : Type*} {G : SimpleGraph V}
+
+private
+abbrev hall_subgraph {p : Set V} [DecidablePred (· ∈ p)] (f : p → V)
+    (h : ∀ x : V, (h : x ∈ p) → f ⟨x, h⟩ ∉ p)
+    (h₂ : ∀ x : V, (h : x ∈ p) → G.Adj x (f ⟨x, h⟩)) : Subgraph G where
+  verts := p ∪ Set.range f
+  Adj v w :=
+    if h : v ∈ p then f ⟨v, h⟩ = w
+    else if h : w ∈ p then f ⟨w, h⟩ = v
+    else False
+  adj_sub {v w} h := by
+    repeat' split at h
+    · have := h₂ v (by assumption)
+      rwa [← h]
+    · have := h₂ w (by assumption) |>.symm
+      rwa [← h]
+    · contradiction
+  edge_vert {v w} := by grind
+  symm {x y} := by grind
+
+/-- This is the version of **Hall's marriage theorem** for bipartite graphs that finds a matching
+for a single partition given that the neighborhood-condition only holds for elements of that
+partition. -/
+theorem exists_IsMatching_of_forall_ncard_le [DecidableEq V] [G.LocallyFinite]
+    {p₁ p₂ : Set V} [DecidablePred (· ∈ p₁)] (h₁ : G.IsBipartiteWith p₁ p₂)
+    (h₂ : ∀ s ⊆ p₁, s.ncard ≤ (⋃ x ∈ s, G.neighborSet x).ncard) :
+    ∃ M : Subgraph G, p₁ ⊆ M.verts ∧ M.IsMatching := by
+  obtain ⟨f, hf₁, hf₂⟩ := Finset.all_card_le_biUnion_card_iff_exists_injective
+      (fun (x : p₁) ↦ G.neighborFinset x) |>.mp fun s ↦ by
+    have := h₂ (s.image Subtype.val) (by simp)
+    rw [Set.ncard_coe_finset, Finset.card_image_of_injective _ Subtype.val_injective] at this
+    simpa [← Set.ncard_coe_finset, neighborFinset_def]
+  have (x : V) (h : x ∈ p₁) : f ⟨x, h⟩ ∉ p₁ := h₁.disjoint |>.notMem_of_mem_right <|
+    isBipartiteWith_neighborSet_subset h₁ h <| Set.mem_toFinset.mp <| hf₂ ⟨x, h⟩
+  use hall_subgraph f this (fun v h ↦ G.mem_neighborFinset _ _ |>.mp (hf₂ ⟨v, by assumption⟩))
+  refine ⟨by simp, fun v hv ↦ ?_⟩
+  simp only [Set.mem_union, Set.mem_range, Subtype.exists] at hv ⊢
+  rcases hv with h' | ⟨x, hx₁, hx₂⟩
+  · exact ⟨f ⟨v, h'⟩, by simp_all⟩
+  · use x
+    have := hx₂ ▸ (this x hx₁)
+    simp only [this, ↓reduceDIte, hx₁, hx₂, dite_else_false, forall_exists_index, true_and]
+    exact fun _ _ k ↦ Subtype.ext_iff_val.mp <| hf₁ (hx₂ ▸ k)
+
+/-- This is the version of **Hall's marriage theorem** for bipartite graphs that finds a perfect
+matching given that the neighborhood-condition holds globally. -/
+theorem exists_IsPerfectMatching_of_forall_ncard_le [DecidableEq V] [G.LocallyFinite]
+    {p₁ p₂ : Set V} [DecidablePred (· ∈ p₁)] (h₁ : G.IsBipartiteWith p₁ p₂)
+    (h₂ : ∀ s : Set V, s.ncard ≤ (⋃ x ∈ s, G.neighborSet x).ncard) :
+    ∃ M : Subgraph G, M.IsPerfectMatching := by
+  obtain ⟨f, hf₁, hf₂⟩ := Finset.all_card_le_biUnion_card_iff_exists_injective
+      (fun x ↦ G.neighborFinset x) |>.mp fun s ↦ by
+    have := h₂ s
+    simpa [← Set.ncard_coe_finset, neighborFinset_def]
+  have (x : V) (h : x ∈ p₁) : f x ∉ p₁ := h₁.disjoint |>.notMem_of_mem_right <|
+    isBipartiteWith_neighborSet_subset h₁ h <| Set.mem_toFinset.mp <| hf₂ x
+  have (x : V) (h : x ∈ p₂) : f x ∉ p₂ := h₁.disjoint |>.notMem_of_mem_left <|
+    isBipartiteWith_neighborSet_subset h₁.symm h <| Set.mem_toFinset.mp <| hf₂ x
+  have : p₁ ∪ p₂ = Set.univ := by
+    refine Set.eq_univ_iff_forall.mpr fun x ↦ ?_
+    have := h₁.mem_of_adj <| G.mem_neighborFinset _ _ |>.mp (hf₂ x)
+    grind
+  have (x : V) : f x ∈ p₁ ∨ f x ∈ p₂ := by simp [this, Set.mem_union (f x) p₁ p₂ |>.mp]
+  let f' (x : p₁) : p₂ := ⟨f x, by grind⟩
+  let g' (x : p₂) : p₁ := ⟨f x, by grind⟩
+  have := Function.Embedding.schroeder_bernstein' (f := f') (g := g') ?_ ?_ (fun x y ↦ G.Adj x y)
+    (fun v ↦ mem_neighborFinset _ _ _ |>.mp (hf₂ v))
+    (fun v ↦ mem_neighborFinset _ _ _ |>.mp (hf₂ v) |>.symm)
+  · obtain ⟨b, hb₁, hb₂⟩ := this
+    use hall_subgraph (fun v ↦ (b v).1) (by grind) (fun v h ↦ hb₂ ⟨v, by assumption⟩)
+    have : p₁ ∪ (Set.range (fun v ↦ (b v).1)) = Set.univ := by
+      rwa [Set.range_comp', hb₁.surjective.range_eq, Subtype.coe_image_univ]
+    refine ⟨fun v _ ↦ ?_, by simp [Subgraph.IsSpanning, this]⟩
+    simp only [dite_else_false]
+    split
+    · exact existsUnique_eq'
+    · obtain ⟨x, _⟩ := hb₁.existsUnique ⟨v, by grind⟩
+      exact ⟨x, by grind⟩
+  · exact Function.Injective.of_comp (f := Subtype.val) <| hf₁.comp <| Subtype.val_injective
+  · exact Function.Injective.of_comp (f := Subtype.val) <| hf₁.comp <| Subtype.val_injective
+
+end SimpleGraph

--- a/Mathlib/Combinatorics/SimpleGraph/Hall.lean
+++ b/Mathlib/Combinatorics/SimpleGraph/Hall.lean
@@ -31,6 +31,8 @@ namespace SimpleGraph
 
 variable {V : Type*} {G : SimpleGraph V}
 
+/- Given a partition `p` and a function `f` mapping vertices in `p` to the other partition, create
+the subgraph including only the edges between `x` and `f x` for all `x` in `p`. -/
 private
 abbrev hall_subgraph {p : Set V} [DecidablePred (· ∈ p)] (f : p → V) (h₁ : ∀ x : p, f x ∉ p)
     (h₂ : ∀ x : p, G.Adj x (f x)) : Subgraph G where

--- a/Mathlib/Combinatorics/SimpleGraph/Matching.lean
+++ b/Mathlib/Combinatorics/SimpleGraph/Matching.lean
@@ -256,12 +256,33 @@ lemma IsPerfectMatching.toSubgraph_iff (h : M.spanningCoe ≤ G') :
     (G'.toSubgraph M.spanningCoe h).IsPerfectMatching ↔ M.IsPerfectMatching := by
   simp only [isPerfectMatching_iff, toSubgraph_adj, spanningCoe_adj]
 
+private
+abbrev hall_subgraph {p : Set V} [DecidablePred (· ∈ p)] (f : p → V)
+    (h : ∀ x : V, (h : x ∈ p) → f ⟨x, h⟩ ∉ p)
+    (h₂ : ∀ x : V, (h : x ∈ p) → G.Adj x (f ⟨x, h⟩)) : Subgraph G :=
+  {
+    verts := p ∪ Set.range f
+    Adj v w :=
+      if h : v ∈ p then f ⟨v, h⟩ = w
+      else if h : w ∈ p then f ⟨w, h⟩ = v
+      else False
+    adj_sub {v w} h := by
+      repeat' split at h
+      · have := h₂ v (by assumption)
+        rwa [← h]
+      · have := h₂ w (by assumption) |>.symm
+        rwa [← h]
+      · contradiction
+    edge_vert {v w} := by grind
+    symm {x y} := by grind
+  }
+
 /-- This is the version of **Hall's marriage theorem** for bipartite graphs that finds a matching
 for a single partition given that the neighborhood-condition only holds for elements of that
 partition. -/
-theorem exists_IsMatching_of_forall_ncard_le [DecidableEq V] [DecidableRel G.Adj]
-    [G.LocallyFinite] {p₁ p₂ : Set V} (h₁ : G.IsBipartiteWith p₁ p₂)
-    [DecidablePred (· ∈ p₁)] (h₂ : ∀ s ⊆ p₁, s.ncard ≤ (⋃ x ∈ s, G.neighborSet x).ncard) :
+theorem exists_IsMatching_of_forall_ncard_le [DecidableEq V] [G.LocallyFinite]
+    {p₁ p₂ : Set V} [DecidablePred (· ∈ p₁)] (h₁ : G.IsBipartiteWith p₁ p₂)
+    (h₂ : ∀ s ⊆ p₁, s.ncard ≤ (⋃ x ∈ s, G.neighborSet x).ncard) :
     ∃ M : Subgraph G, p₁ ⊆ M.verts ∧ M.IsMatching := by
   obtain ⟨f, hf₁, hf₂⟩ := Finset.all_card_le_biUnion_card_iff_exists_injective
       (fun (x : p₁) ↦ G.neighborFinset x) |>.mp fun s ↦ by
@@ -270,22 +291,7 @@ theorem exists_IsMatching_of_forall_ncard_le [DecidableEq V] [DecidableRel G.Adj
     simpa [← Set.ncard_coe_finset, SimpleGraph.neighborFinset_def]
   have (x : V) (h : x ∈ p₁) : f ⟨x, h⟩ ∉ p₁ := h₁.disjoint |>.notMem_of_mem_right <|
     SimpleGraph.isBipartiteWith_neighborSet_subset h₁ h <| Set.mem_toFinset.mp <| hf₂ ⟨x, h⟩
-  use {
-    verts := p₁ ∪ Set.range f
-    Adj v w :=
-      if h : v ∈ p₁ then f ⟨v, h⟩ = w
-      else if h : w ∈ p₁ then f ⟨w, h⟩ = v
-      else False
-    adj_sub {v w} h := by
-      repeat' split at h
-      · have := G.mem_neighborFinset _ _ |>.mp (hf₂ ⟨v, by assumption⟩)
-        rwa [← h]
-      · have := G.mem_neighborFinset _ _ |>.mp (hf₂ ⟨w, by assumption⟩) |>.symm
-        rwa [← h]
-      · contradiction
-    edge_vert {v w} := by grind
-    symm {x y} := by grind
-  }
+  use hall_subgraph f this (fun v h ↦ G.mem_neighborFinset _ _ |>.mp (hf₂ ⟨v, by assumption⟩))
   refine ⟨by simp, fun v hv ↦ ?_⟩
   simp only [Set.mem_union, Set.mem_range, Subtype.exists] at hv ⊢
   rcases hv with h' | ⟨x, hx₁, hx₂⟩
@@ -297,9 +303,9 @@ theorem exists_IsMatching_of_forall_ncard_le [DecidableEq V] [DecidableRel G.Adj
 
 /-- This is the version of **Hall's marriage theorem** for bipartite graphs that finds a perfect
 matching given that the neighborhood-condition holds globally. -/
-theorem exists_IsPerfectMatching_of_forall_ncard_le [DecidableEq V] [DecidableRel G.Adj]
-    [G.LocallyFinite] (p₁ p₂ : Set V) (h₁ : G.IsBipartiteWith p₁ p₂)
-    [DecidablePred (· ∈ p₁)] (h₂ : ∀ s : Set V, s.ncard ≤ (⋃ x ∈ s, G.neighborSet x).ncard) :
+theorem exists_IsPerfectMatching_of_forall_ncard_le [DecidableEq V] [G.LocallyFinite]
+    {p₁ p₂ : Set V} [DecidablePred (· ∈ p₁)] (h₁ : G.IsBipartiteWith p₁ p₂)
+    (h₂ : ∀ s : Set V, s.ncard ≤ (⋃ x ∈ s, G.neighborSet x).ncard) :
     ∃ M : Subgraph G, M.IsPerfectMatching := by
   obtain ⟨f, hf₁, hf₂⟩ := Finset.all_card_le_biUnion_card_iff_exists_injective
       (fun x ↦ G.neighborFinset x) |>.mp fun s ↦ by
@@ -320,23 +326,10 @@ theorem exists_IsPerfectMatching_of_forall_ncard_le [DecidableEq V] [DecidableRe
     (fun v ↦ mem_neighborFinset _ _ _ |>.mp (hf₂ v))
     (fun v ↦ mem_neighborFinset _ _ _ |>.mp (hf₂ v) |>.symm)
   · obtain ⟨b, hb₁, hb₂⟩ := this
-    use {
-      verts := Set.univ
-      Adj v w :=
-        if h : v ∈ p₁ then b ⟨v, h⟩ = w
-        else if h : w ∈ p₁ then b ⟨w, h⟩ = v
-        else False
-      adj_sub {v w} h := by
-        repeat' split at h
-        · have := hb₂ ⟨v, by assumption⟩
-          simpa [h] using this
-        · have := hb₂ ⟨w, by assumption⟩ |>.symm
-          simpa [h] using this
-        · contradiction
-      edge_vert {v w} := by grind
-      symm {x y} := by grind
-    }
-    refine ⟨fun v _ ↦ ?_, by simp [IsSpanning]⟩
+    use hall_subgraph (fun v ↦ (b v).1) (by grind) (fun v h ↦ hb₂ ⟨v, by assumption⟩)
+    have : p₁ ∪ (Set.range (fun v ↦ (b v).1)) = Set.univ := by
+      rwa [Set.range_comp', hb₁.surjective.range_eq, Subtype.coe_image_univ]
+    refine ⟨fun v _ ↦ ?_, by simp [IsSpanning, this]⟩
     simp only [dite_else_false]
     split
     · exact existsUnique_eq'

--- a/Mathlib/Combinatorics/SimpleGraph/Matching.lean
+++ b/Mathlib/Combinatorics/SimpleGraph/Matching.lean
@@ -3,8 +3,6 @@ Copyright (c) 2020 Alena Gusakov. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Alena Gusakov, Arthur Paulino, Kyle Miller, Pim Otte
 -/
-import Mathlib.Combinatorics.Hall.Basic
-import Mathlib.Combinatorics.SimpleGraph.Bipartite
 import Mathlib.Combinatorics.SimpleGraph.Clique
 import Mathlib.Combinatorics.SimpleGraph.Connectivity.Subgraph
 import Mathlib.Combinatorics.SimpleGraph.Connectivity.WalkCounting
@@ -255,88 +253,6 @@ lemma IsPerfectMatching.induce_connectedComponent_isMatching (h : M.IsPerfectMat
 lemma IsPerfectMatching.toSubgraph_iff (h : M.spanningCoe ≤ G') :
     (G'.toSubgraph M.spanningCoe h).IsPerfectMatching ↔ M.IsPerfectMatching := by
   simp only [isPerfectMatching_iff, toSubgraph_adj, spanningCoe_adj]
-
-private
-abbrev hall_subgraph {p : Set V} [DecidablePred (· ∈ p)] (f : p → V)
-    (h : ∀ x : V, (h : x ∈ p) → f ⟨x, h⟩ ∉ p)
-    (h₂ : ∀ x : V, (h : x ∈ p) → G.Adj x (f ⟨x, h⟩)) : Subgraph G :=
-  {
-    verts := p ∪ Set.range f
-    Adj v w :=
-      if h : v ∈ p then f ⟨v, h⟩ = w
-      else if h : w ∈ p then f ⟨w, h⟩ = v
-      else False
-    adj_sub {v w} h := by
-      repeat' split at h
-      · have := h₂ v (by assumption)
-        rwa [← h]
-      · have := h₂ w (by assumption) |>.symm
-        rwa [← h]
-      · contradiction
-    edge_vert {v w} := by grind
-    symm {x y} := by grind
-  }
-
-/-- This is the version of **Hall's marriage theorem** for bipartite graphs that finds a matching
-for a single partition given that the neighborhood-condition only holds for elements of that
-partition. -/
-theorem exists_IsMatching_of_forall_ncard_le [DecidableEq V] [G.LocallyFinite]
-    {p₁ p₂ : Set V} [DecidablePred (· ∈ p₁)] (h₁ : G.IsBipartiteWith p₁ p₂)
-    (h₂ : ∀ s ⊆ p₁, s.ncard ≤ (⋃ x ∈ s, G.neighborSet x).ncard) :
-    ∃ M : Subgraph G, p₁ ⊆ M.verts ∧ M.IsMatching := by
-  obtain ⟨f, hf₁, hf₂⟩ := Finset.all_card_le_biUnion_card_iff_exists_injective
-      (fun (x : p₁) ↦ G.neighborFinset x) |>.mp fun s ↦ by
-    have := h₂ (s.image Subtype.val) (by simp)
-    rw [Set.ncard_coe_finset, Finset.card_image_of_injective _ Subtype.val_injective] at this
-    simpa [← Set.ncard_coe_finset, SimpleGraph.neighborFinset_def]
-  have (x : V) (h : x ∈ p₁) : f ⟨x, h⟩ ∉ p₁ := h₁.disjoint |>.notMem_of_mem_right <|
-    SimpleGraph.isBipartiteWith_neighborSet_subset h₁ h <| Set.mem_toFinset.mp <| hf₂ ⟨x, h⟩
-  use hall_subgraph f this (fun v h ↦ G.mem_neighborFinset _ _ |>.mp (hf₂ ⟨v, by assumption⟩))
-  refine ⟨by simp, fun v hv ↦ ?_⟩
-  simp only [Set.mem_union, Set.mem_range, Subtype.exists] at hv ⊢
-  rcases hv with h' | ⟨x, hx₁, hx₂⟩
-  · exact ⟨f ⟨v, h'⟩, by simp_all⟩
-  · use x
-    have := hx₂ ▸ (this x hx₁)
-    simp only [this, ↓reduceDIte, hx₁, hx₂, dite_else_false, forall_exists_index, true_and]
-    exact fun _ _ k ↦ Subtype.ext_iff_val.mp <| hf₁ (hx₂ ▸ k)
-
-/-- This is the version of **Hall's marriage theorem** for bipartite graphs that finds a perfect
-matching given that the neighborhood-condition holds globally. -/
-theorem exists_IsPerfectMatching_of_forall_ncard_le [DecidableEq V] [G.LocallyFinite]
-    {p₁ p₂ : Set V} [DecidablePred (· ∈ p₁)] (h₁ : G.IsBipartiteWith p₁ p₂)
-    (h₂ : ∀ s : Set V, s.ncard ≤ (⋃ x ∈ s, G.neighborSet x).ncard) :
-    ∃ M : Subgraph G, M.IsPerfectMatching := by
-  obtain ⟨f, hf₁, hf₂⟩ := Finset.all_card_le_biUnion_card_iff_exists_injective
-      (fun x ↦ G.neighborFinset x) |>.mp fun s ↦ by
-    have := h₂ s
-    simpa [← Set.ncard_coe_finset, SimpleGraph.neighborFinset_def]
-  have (x : V) (h : x ∈ p₁) : f x ∉ p₁ := h₁.disjoint |>.notMem_of_mem_right <|
-    SimpleGraph.isBipartiteWith_neighborSet_subset h₁ h <| Set.mem_toFinset.mp <| hf₂ x
-  have (x : V) (h : x ∈ p₂) : f x ∉ p₂ := h₁.disjoint |>.notMem_of_mem_left <|
-    SimpleGraph.isBipartiteWith_neighborSet_subset h₁.symm h <| Set.mem_toFinset.mp <| hf₂ x
-  have : p₁ ∪ p₂ = Set.univ := by
-    refine Set.eq_univ_iff_forall.mpr fun x ↦ ?_
-    have := h₁.mem_of_adj <| G.mem_neighborFinset _ _ |>.mp (hf₂ x)
-    grind
-  have (x : V) : f x ∈ p₁ ∨ f x ∈ p₂ := by simp [this, Set.mem_union (f x) p₁ p₂ |>.mp]
-  let f' (x : p₁) : p₂ := ⟨f x, by grind⟩
-  let g' (x : p₂) : p₁ := ⟨f x, by grind⟩
-  have := Function.Embedding.schroeder_bernstein' (f := f') (g := g') ?_ ?_ (fun x y ↦ G.Adj x y)
-    (fun v ↦ mem_neighborFinset _ _ _ |>.mp (hf₂ v))
-    (fun v ↦ mem_neighborFinset _ _ _ |>.mp (hf₂ v) |>.symm)
-  · obtain ⟨b, hb₁, hb₂⟩ := this
-    use hall_subgraph (fun v ↦ (b v).1) (by grind) (fun v h ↦ hb₂ ⟨v, by assumption⟩)
-    have : p₁ ∪ (Set.range (fun v ↦ (b v).1)) = Set.univ := by
-      rwa [Set.range_comp', hb₁.surjective.range_eq, Subtype.coe_image_univ]
-    refine ⟨fun v _ ↦ ?_, by simp [IsSpanning, this]⟩
-    simp only [dite_else_false]
-    split
-    · exact existsUnique_eq'
-    · obtain ⟨x, _⟩ := hb₁.existsUnique ⟨v, by grind⟩
-      exact ⟨x, by grind⟩
-  · exact Injective.of_comp (f := Subtype.val) <| hf₁.comp <| Subtype.val_injective
-  · exact Injective.of_comp (f := Subtype.val) <| hf₁.comp <| Subtype.val_injective
 
 end Subgraph
 

--- a/Mathlib/Combinatorics/SimpleGraph/Matching.lean
+++ b/Mathlib/Combinatorics/SimpleGraph/Matching.lean
@@ -3,6 +3,8 @@ Copyright (c) 2020 Alena Gusakov. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Alena Gusakov, Arthur Paulino, Kyle Miller, Pim Otte
 -/
+import Mathlib.Combinatorics.Hall.Basic
+import Mathlib.Combinatorics.SimpleGraph.Bipartite
 import Mathlib.Combinatorics.SimpleGraph.Clique
 import Mathlib.Combinatorics.SimpleGraph.Connectivity.Subgraph
 import Mathlib.Combinatorics.SimpleGraph.Connectivity.WalkCounting
@@ -45,8 +47,6 @@ one edge, and the edges of the subgraph represent the paired vertices.
 * Provide a bicoloring for matchings (https://leanprover.zulipchat.com/#narrow/stream/252551-graph-theory/topic/matchings/near/265495120)
 
 * Tutte's Theorem
-
-* Hall's Marriage Theorem (see `Mathlib/Combinatorics/Hall/Basic.lean`)
 -/
 
 assert_not_exists Field TwoSidedIdeal
@@ -255,6 +255,95 @@ lemma IsPerfectMatching.induce_connectedComponent_isMatching (h : M.IsPerfectMat
 lemma IsPerfectMatching.toSubgraph_iff (h : M.spanningCoe ≤ G') :
     (G'.toSubgraph M.spanningCoe h).IsPerfectMatching ↔ M.IsPerfectMatching := by
   simp only [isPerfectMatching_iff, toSubgraph_adj, spanningCoe_adj]
+
+/-- This is the version of **Hall's marriage theorem** for bipartite graphs that finds a matching
+for a single partition given that the neighborhood-condition only holds for elements of that
+partition. -/
+theorem exists_IsMatching_of_forall_ncard_le [DecidableEq V] [DecidableRel G.Adj]
+    [G.LocallyFinite] {p₁ p₂ : Set V} (h₁ : G.IsBipartiteWith p₁ p₂)
+    [DecidablePred (· ∈ p₁)] (h₂ : ∀ s ⊆ p₁, s.ncard ≤ (⋃ x ∈ s, G.neighborSet x).ncard) :
+    ∃ M : Subgraph G, p₁ ⊆ M.verts ∧ M.IsMatching := by
+  obtain ⟨f, hf₁, hf₂⟩ := Finset.all_card_le_biUnion_card_iff_exists_injective
+      (fun (x : p₁) ↦ G.neighborFinset x) |>.mp fun s ↦ by
+    have := h₂ (s.image Subtype.val) (by simp)
+    rw [Set.ncard_coe_finset, Finset.card_image_of_injective _ Subtype.val_injective] at this
+    simpa [← Set.ncard_coe_finset, SimpleGraph.neighborFinset_def]
+  have (x : V) (h : x ∈ p₁) : f ⟨x, h⟩ ∉ p₁ := h₁.disjoint |>.notMem_of_mem_right <|
+    SimpleGraph.isBipartiteWith_neighborSet_subset h₁ h <| Set.mem_toFinset.mp <| hf₂ ⟨x, h⟩
+  use {
+    verts := p₁ ∪ Set.range f
+    Adj v w :=
+      if h : v ∈ p₁ then f ⟨v, h⟩ = w
+      else if h : w ∈ p₁ then f ⟨w, h⟩ = v
+      else False
+    adj_sub {v w} h := by
+      repeat' split at h
+      · have := G.mem_neighborFinset _ _ |>.mp (hf₂ ⟨v, by assumption⟩)
+        rwa [← h]
+      · have := G.mem_neighborFinset _ _ |>.mp (hf₂ ⟨w, by assumption⟩) |>.symm
+        rwa [← h]
+      · contradiction
+    edge_vert {v w} := by grind
+    symm {x y} := by grind
+  }
+  refine ⟨by simp, fun v hv ↦ ?_⟩
+  simp only [Set.mem_union, Set.mem_range, Subtype.exists] at hv ⊢
+  rcases hv with h' | ⟨x, hx₁, hx₂⟩
+  · exact ⟨f ⟨v, h'⟩, by simp_all⟩
+  · use x
+    have := hx₂ ▸ (this x hx₁)
+    simp only [this, ↓reduceDIte, hx₁, hx₂, dite_else_false, forall_exists_index, true_and]
+    exact fun _ _ k ↦ Subtype.ext_iff_val.mp <| hf₁ (hx₂ ▸ k)
+
+/-- This is the version of **Hall's marriage theorem** for bipartite graphs that finds a perfect
+matching given that the neighborhood-condition holds globally. -/
+theorem exists_IsPerfectMatching_of_forall_ncard_le [DecidableEq V] [DecidableRel G.Adj]
+    [G.LocallyFinite] (p₁ p₂ : Set V) (h₁ : G.IsBipartiteWith p₁ p₂)
+    [DecidablePred (· ∈ p₁)] (h₂ : ∀ s : Set V, s.ncard ≤ (⋃ x ∈ s, G.neighborSet x).ncard) :
+    ∃ M : Subgraph G, M.IsPerfectMatching := by
+  obtain ⟨f, hf₁, hf₂⟩ := Finset.all_card_le_biUnion_card_iff_exists_injective
+      (fun x ↦ G.neighborFinset x) |>.mp fun s ↦ by
+    have := h₂ s
+    simpa [← Set.ncard_coe_finset, SimpleGraph.neighborFinset_def]
+  have (x : V) (h : x ∈ p₁) : f x ∉ p₁ := h₁.disjoint |>.notMem_of_mem_right <|
+    SimpleGraph.isBipartiteWith_neighborSet_subset h₁ h <| Set.mem_toFinset.mp <| hf₂ x
+  have (x : V) (h : x ∈ p₂) : f x ∉ p₂ := h₁.disjoint |>.notMem_of_mem_left <|
+    SimpleGraph.isBipartiteWith_neighborSet_subset h₁.symm h <| Set.mem_toFinset.mp <| hf₂ x
+  have : p₁ ∪ p₂ = Set.univ := by
+    refine Set.eq_univ_iff_forall.mpr fun x ↦ ?_
+    have := h₁.mem_of_adj <| G.mem_neighborFinset _ _ |>.mp (hf₂ x)
+    grind
+  have (x : V) : f x ∈ p₁ ∨ f x ∈ p₂ := by simp [this, Set.mem_union (f x) p₁ p₂ |>.mp]
+  let f' (x : p₁) : p₂ := ⟨f x, by grind⟩
+  let g' (x : p₂) : p₁ := ⟨f x, by grind⟩
+  have := Function.Embedding.schroeder_bernstein' (f := f') (g := g') ?_ ?_ (fun x y ↦ G.Adj x y)
+    (fun v ↦ mem_neighborFinset _ _ _ |>.mp (hf₂ v))
+    (fun v ↦ mem_neighborFinset _ _ _ |>.mp (hf₂ v) |>.symm)
+  · obtain ⟨b, hb₁, hb₂⟩ := this
+    use {
+      verts := Set.univ
+      Adj v w :=
+        if h : v ∈ p₁ then b ⟨v, h⟩ = w
+        else if h : w ∈ p₁ then b ⟨w, h⟩ = v
+        else False
+      adj_sub {v w} h := by
+        repeat' split at h
+        · have := hb₂ ⟨v, by assumption⟩
+          simpa [h] using this
+        · have := hb₂ ⟨w, by assumption⟩ |>.symm
+          simpa [h] using this
+        · contradiction
+      edge_vert {v w} := by grind
+      symm {x y} := by grind
+    }
+    refine ⟨fun v _ ↦ ?_, by simp [IsSpanning]⟩
+    simp only [dite_else_false]
+    split
+    · exact existsUnique_eq'
+    · obtain ⟨x, _⟩ := hb₁.existsUnique ⟨v, by grind⟩
+      exact ⟨x, by grind⟩
+  · exact Injective.of_comp (f := Subtype.val) <| hf₁.comp <| Subtype.val_injective
+  · exact Injective.of_comp (f := Subtype.val) <| hf₁.comp <| Subtype.val_injective
 
 end Subgraph
 

--- a/docs/1000.yaml
+++ b/docs/1000.yaml
@@ -515,7 +515,10 @@ Q535366:
 
 Q536640:
   title: Hall's marriage theorem
-  decl: Finset.all_card_le_biUnion_card_iff_exists_injective
+  decls:
+    - Finset.all_card_le_biUnion_card_iff_exists_injective
+    - SimpleGraph.exists_IsPerfectMatching_of_forall_ncard_le
+  authors: Alena Gusakov, Bhavik Mehta, Kyle Miller
 
 Q537618:
   title: Banach–Alaoglu theorem

--- a/docs/1000.yaml
+++ b/docs/1000.yaml
@@ -517,7 +517,7 @@ Q536640:
   title: Hall's marriage theorem
   decls:
     - Finset.all_card_le_biUnion_card_iff_exists_injective
-    - SimpleGraph.exists_IsPerfectMatching_of_forall_ncard_le
+    - SimpleGraph.exists_isPerfectMatching_of_forall_ncard_le
   authors: Alena Gusakov, Bhavik Mehta, Kyle Miller
 
 Q537618:


### PR DESCRIPTION
Derive the graph theoretic proof of Hall's marriage theorem from the combinatorial version.

Note that I specifically implement this for the more general case of infinite graphs that are locally finite (e.g. every vertex has only finite neighbors.) As a result, the theorem depends on some category theoretic infrastructure required for the infinite combinatorial formulation of Hall's Marriage Theorem and hence I've placed the theorems into their own file to avoid requiring it in `Matching.lean`

- [ ] depends on: #29162