### PR TITLE
[Merged by Bors] - feat: group objects form a cartesian-monoidal category

### DIFF
--- a/Mathlib/CategoryTheory/Monoidal/Grp_.lean
+++ b/Mathlib/CategoryTheory/Monoidal/Grp_.lean
@@ -411,7 +411,7 @@ instance : (forget₂Mon_ C).Monoidal where
   «η» := 𝟙 _
   δ G H := 𝟙 _
 
-attribute [local simp] Mon_Class.tensorObj.mul_def mul_eq_mul comp_mul in
+attribute [local simp] MonObj.tensorObj.mul_def mul_eq_mul comp_mul in
 instance instBraidedCategory : BraidedCategory (Grp_ C) :=
   .ofFaithful (forget₂Mon_ C) fun G H ↦ Grp_.mkIso (β_ G.X H.X)
 

--- a/Mathlib/CategoryTheory/Monoidal/Grp_.lean
+++ b/Mathlib/CategoryTheory/Monoidal/Grp_.lean
@@ -347,6 +347,77 @@ instance uniqueHomFromTrivial (A : Grp_ C) : Unique (trivial C ⟶ A) :=
 instance : HasInitial (Grp_ C) :=
   hasInitial_of_unique (trivial C)
 
+/-! ### `Grp_ C` is cartesian-monoidal -/
+
+variable [BraidedCategory C] {G H H₁ H₂ : Grp_ C}
+
+@[simps! tensorObj_X tensorHom_hom]
+instance instMonoidalCategoryStruct : MonoidalCategoryStruct (Grp_ C) where
+  tensorObj G H := ⟨G.X ⊗ H.X⟩
+  tensorHom := tensorHom (C := Mon_ C)
+  whiskerRight f G := whiskerRight (C := Mon_ C) f G.toMon_
+  whiskerLeft G _ _ f := MonoidalCategoryStruct.whiskerLeft (C := Mon_ C) G.toMon_ f
+  tensorUnit := ⟨𝟙_ C⟩
+  associator X Y Z :=
+    (Grp_.fullyFaithfulForget₂Mon_ C).preimageIso (associator X.toMon_ Y.toMon_ Z.toMon_)
+  leftUnitor G := (Grp_.fullyFaithfulForget₂Mon_ C).preimageIso (leftUnitor G.toMon_)
+  rightUnitor G := (Grp_.fullyFaithfulForget₂Mon_ C).preimageIso (rightUnitor G.toMon_)
+
+@[simp] lemma tensorUnit_X : (𝟙_ (Grp_ C)).X = 𝟙_ C := rfl
+
+@[simp] lemma tensorUnit_one : η[(𝟙_ (Grp_ C)).X] = η[𝟙_ C] := rfl
+@[simp] lemma tensorUnit_mul : μ[(𝟙_ (Grp_ C)).X] = μ[𝟙_ C] := rfl
+
+@[simp] lemma tensorObj_one (G H : Grp_ C) : η[(G ⊗ H).X] = η[G.X ⊗ H.X] := rfl
+@[simp] lemma tensorObj_mul (G H : Grp_ C) : μ[(G ⊗ H).X] = μ[G.X ⊗ H.X] := rfl
+
+@[simp] lemma whiskerLeft_hom {G H : Grp_ C} (f : G ⟶ H) (I : Grp_ C) :
+    (f ▷ I).hom = f.hom ▷ I.X := rfl
+
+@[simp] lemma whiskerRight_hom (G : Grp_ C) {H I : Grp_ C} (f : H ⟶ I) :
+    (G ◁ f).hom = G.X ◁ f.hom := rfl
+
+@[simp] lemma leftUnitor_hom_hom (G : Grp_ C) : (λ_ G).hom.hom = (λ_ G.X).hom := rfl
+@[simp] lemma leftUnitor_inv_hom (G : Grp_ C) : (λ_ G).inv.hom = (λ_ G.X).inv := rfl
+@[simp] lemma rightUnitor_hom_hom (G : Grp_ C) : (ρ_ G).hom.hom = (ρ_ G.X).hom := rfl
+@[simp] lemma rightUnitor_inv_hom (G : Grp_ C) : (ρ_ G).inv.hom = (ρ_ G.X).inv := rfl
+
+@[simp] lemma associator_hom_hom (G H I : Grp_ C) : (α_ G H I).hom.hom = (α_ G.X H.X I.X).hom := rfl
+@[simp] lemma associator_inv_hom (G H I : Grp_ C) : (α_ G H I).inv.hom = (α_ G.X H.X I.X).inv := rfl
+
+instance instMonoidalCategory : MonoidalCategory (Grp_ C) where
+  tensorHom_def := by intros; ext; simp [tensorHom_def]
+  triangle _ _ := by ext; exact triangle _ _
+
+instance instCartesianMonoidalCategory : CartesianMonoidalCategory (Grp_ C) where
+  isTerminalTensorUnit :=
+    .ofUniqueHom (fun G ↦ toUnit G.toMon_) fun G f ↦ by ext; exact toUnit_unique ..
+  fst G H := fst G.toMon_ H.toMon_
+  snd G H := snd G.toMon_ H.toMon_
+  tensorProductIsBinaryProduct G H :=
+    BinaryFan.IsLimit.mk _ (fun {T} f g ↦ .mk (lift f.hom g.hom))
+      (by aesop_cat) (by aesop_cat) (by aesop_cat)
+  fst_def G H := Mon_.Hom.ext <| fst_def _ _
+  snd_def G H := Mon_.Hom.ext <| snd_def _ _
+
+@[simp] lemma lift_hom (f : G ⟶ H₁) (g : G ⟶ H₂) : (lift f g).hom = lift f.hom g.hom := rfl
+@[simp] lemma fst_hom (G H : Grp_ C) : (fst G H).hom = fst G.X H.X := rfl
+@[simp] lemma snd_hom (G H : Grp_ C) : (snd G H).hom = snd G.X H.X := rfl
+
+@[simps]
+instance : (forget₂Mon_ C).Monoidal where
+  ε := 𝟙 _
+  «μ» G H := 𝟙 _
+  «η» := 𝟙 _
+  δ G H := 𝟙 _
+
+attribute [local simp] Mon_Class.tensorObj.mul_def mul_eq_mul comp_mul in
+instance instBraidedCategory : BraidedCategory (Grp_ C) :=
+  .ofFaithful (forget₂Mon_ C) fun G H ↦ Grp_.mkIso (β_ G.X H.X)
+
+@[simp] lemma braiding_hom_hom (G H : Grp_ C) : (β_ G H).hom.hom = (β_ G.X H.X).hom := rfl
+@[simp] lemma braiding_inv_hom (G H : Grp_ C) : (β_ G H).inv.hom = (β_ G.X H.X).inv := rfl
+
 end Grp_
 
 namespace CategoryTheory


### PR DESCRIPTION
From Toric


---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include at least one commit authored by each
co-author among the commits in the pull request. If necessary, you may 
create empty commits to indicate co-authorship, using commands like so:

git commit --author="Author Name <author@email.com>" --allow-empty -m "add Author Name as coauthor"

When merging, all the commits will be squashed into a single commit listing all co-authors.

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
