### PR TITLE
[Merged by Bors] - doc(Algebra/Order/Monoid/Associated): update module doc

### DIFF
--- a/Mathlib/Algebra/Order/Monoid/Associated.lean
+++ b/Mathlib/Algebra/Order/Monoid/Associated.lean
@@ -1,26 +1,15 @@
 /-
-Copyright (c) 2018 Johannes Hölzl. All rights reserved.
+Copyright (c) 2022 Paul Lezeau. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
-Authors: Johannes Hölzl, Jens Wagemaker
+Authors: Paul Lezeau
 -/
 import Mathlib.Algebra.GroupWithZero.Associated
 import Mathlib.Algebra.Order.Monoid.Canonical.Defs
 
 /-!
-# Associated, prime, and irreducible elements.
+# Order on associates
 
-In this file we define the predicate `Prime p`
-saying that an element of a commutative monoid with zero is prime.
-Namely, `Prime p` means that `p` isn't zero, it isn't a unit,
-and `p ∣ a * b → p ∣ a ∨ p ∣ b` for all `a`, `b`;
-
-In decomposition monoids (e.g., `ℕ`, `ℤ`), this predicate is equivalent to `Irreducible`,
-however this is not true in general.
-
-We also define an equivalence relation `Associated`
-saying that two elements of a monoid differ by a multiplication by a unit.
-Then we show that the quotient type `Associates` is a monoid
-and prove basic properties of this quotient.
+This file shows that divisibility makes associates into a canonically ordered monoid.
 -/
 
 variable {M : Type*} [CancelCommMonoidWithZero M]


### PR DESCRIPTION
It was very inaccurate, probably due to not being updated after the file was split.

The new copyright comes from https://github.com/leanprover-community/mathlib3/pull/12863.


---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include at least one commit authored by each
co-author among the commits in the pull request. If necessary, you may 
create empty commits to indicate co-authorship, using commands like so:

git commit --author="Author Name <author@email.com>" --allow-empty -m "add Author Name as coauthor"

When merging, all the commits will be squashed into a single commit listing all co-authors.

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
