### PR TITLE
[Merged by Bors] - feat: faster implementations of Nat.factorial

### DIFF
--- a/Mathlib/Data/Nat/Factorial/Basic.lean
+++ b/Mathlib/Data/Nat/Factorial/Basic.lean
@@ -505,6 +505,7 @@ Now we can go much further,. We're limited now by speed, not stack space.
 def factorialBinarySplitting (n : Nat) : Nat :=
   prodRange 1 (n + 1)
 where
+  /-- `prodRange lo hi` is the product of the range `lo` to `hi`, computed by binary splitting.-/
   prodRange (lo hi : Nat) : Nat :=
     if hi ≤ lo then 1
     else if hi = lo + 1 then lo

--- a/Mathlib/Data/Nat/Factorial/Basic.lean
+++ b/Mathlib/Data/Nat/Factorial/Basic.lean
@@ -459,13 +459,9 @@ lemma two_pow_mul_factorial_le_factorial_two_mul (n : ℕ) : 2 ^ n * n ! ≤ (2 
 
 
 /-!
-# Optimized Factorial Implementations
+# Factorial via binary splitting.
 
-We now provide optimized implementations of factorial computation:
-* `Nat.factorialFold`: Using `Nat.fold` rather than the default non-tail-recursive implementation.
-* `Nat.factorialBinarySplitting`: Using binary splitting.
-
-We prove these are equal to the standard factorial and mark them `@[csimp]`.
+We prove this is equal to the standard factorial and mark it `@[csimp]`.
 
 We could proceed further, with either Legendre or Luschny methods.
 -/
@@ -477,28 +473,9 @@ This is the highest factorial I can `#eval` using the naive implementation witho
 #guard_msgs in
 #eval 9718 ! |>.log2
 ```
--/
 
-/-- Factorial implemented using `Nat.fold`, which is tail-recursive. -/
-def factorialFold (n : Nat) := Nat.fold n (fun i _ acc => (i+1) * acc) 1
-
-/-- Theorem: `factorialFold` equals the standard `factorial`. -/
-@[csimp]
-theorem factorial_eq_factorialFold : @factorial = @factorialFold := by
-  ext n
-  rw [factorialFold]
-  induction n with
-  | zero =>
-    grind [factorial_zero]
-  | succ n ih =>
-    grind [fold_succ, factorial_succ]
-
-/-!
-Now we can go much further,. We're limited now by speed, not stack space.
-```
-#time -- Approx 2s:
-#eval (10^5) ! |>.log2
-```
+We could implement a tail-recursive version (or just use `Nat.fold`),
+but instead lets jump straight to binary splitting.
 -/
 
 /-- Factorial implemented using binary splitting. -/
@@ -532,9 +509,12 @@ theorem factorialBinarySplitting_eq_factorial : @factorial = @factorialBinarySpl
   rw [factorialBinarySplitting, ← factorialBinarySplitting.factorial_mul_prodRange 0 n (by grind)]
   simp
 
-/-! This is again much faster.
+/-!
+We are now limited by time, not stack space,
+and this is much faster than even the tail-recursive version.
+
 ```
-#time -- Less than 1s, for 10x further.
+#time -- Less than 1s. (Tail-recursive version takes longer for `(10^5) !`.)
 #eval (10^6) ! |>.log2
 ```
 -/

--- a/Mathlib/Data/Nat/Factorial/Basic.lean
+++ b/Mathlib/Data/Nat/Factorial/Basic.lean
@@ -485,7 +485,10 @@ the big-integer operands to each are much smaller. -/
 def factorialBinarySplitting (n : Nat) : Nat :=
   if _ : n = 0 then 1 else prodRange 1 (n + 1)
 where
-  /-- `prodRange lo hi` is the product of the range `lo` to `hi`, computed by binary splitting.-/
+  /-- 
+  `prodRange lo hi` is the product of the range `lo` to `hi` (exclusive),
+  computed by binary splitting.
+  -/
   prodRange (lo hi : Nat) (h : lo < hi := by grind) : Nat :=
     if _ : hi = lo + 1 then lo
     else

--- a/Mathlib/Data/Nat/Factorial/Basic.lean
+++ b/Mathlib/Data/Nat/Factorial/Basic.lean
@@ -475,7 +475,7 @@ This is the highest factorial I can `#eval` using the naive implementation witho
 ```
 
 We could implement a tail-recursive version (or just use `Nat.fold`),
-but instead lets jump straight to binary splitting.
+but instead let's jump straight to binary splitting.
 -/
 
 /-- Factorial implemented using binary splitting. -/

--- a/Mathlib/Data/Nat/Factorial/Basic.lean
+++ b/Mathlib/Data/Nat/Factorial/Basic.lean
@@ -480,34 +480,33 @@ but instead let's jump straight to binary splitting.
 
 /-- Factorial implemented using binary splitting. -/
 def factorialBinarySplitting (n : Nat) : Nat :=
-  prodRange 1 (n + 1)
+  if _ : n = 0 then 1 else prodRange 1 (n + 1)
 where
   /-- `prodRange lo hi` is the product of the range `lo` to `hi`, computed by binary splitting.-/
-  prodRange (lo hi : Nat) : Nat :=
-    if hi ≤ lo then 1
-    else if hi = lo + 1 then lo
+  prodRange (lo hi : Nat) (h : lo < hi := by grind) : Nat :=
+    if _ : hi = lo + 1 then lo
     else
       let mid := (lo + hi) / 2
       prodRange lo mid * prodRange mid hi
 
-theorem factorialBinarySplitting.factorial_mul_prodRange (lo hi : Nat) (h : lo ≤ hi) :
+theorem factorialBinarySplitting.factorial_mul_prodRange (lo hi : Nat) (h : lo < hi) :
     lo ! * prodRange (lo + 1) (hi + 1) = hi ! := by
   rw [prodRange]
   split
-  · grind
-  · split
-    · grind [factorial_succ]
-    · dsimp only
-      rw [← Nat.mul_assoc]
-      rw [show (lo + 1 + (hi + 1)) / 2 = (lo + hi) / 2 + 1 by grind]
-      rw [factorial_mul_prodRange, factorial_mul_prodRange]
-      all_goals grind
+  · grind [factorial_succ]
+  · dsimp only
+    rw [← Nat.mul_assoc]
+    simp_rw [show (lo + 1 + (hi + 1)) / 2 = (lo + hi) / 2 + 1 by grind]
+    rw [factorial_mul_prodRange, factorial_mul_prodRange]
+    all_goals grind
 
 @[csimp]
 theorem factorialBinarySplitting_eq_factorial : @factorial = @factorialBinarySplitting := by
   ext n
-  rw [factorialBinarySplitting, ← factorialBinarySplitting.factorial_mul_prodRange 0 n (by grind)]
-  simp
+  by_cases h : n = 0
+  · simp [h, factorialBinarySplitting]
+  · rw [factorialBinarySplitting, ← factorialBinarySplitting.factorial_mul_prodRange 0 n (by grind)]
+    simp [h]
 
 /-!
 We are now limited by time, not stack space,

--- a/Mathlib/Data/Nat/Factorial/Basic.lean
+++ b/Mathlib/Data/Nat/Factorial/Basic.lean
@@ -478,7 +478,10 @@ We could implement a tail-recursive version (or just use `Nat.fold`),
 but instead let's jump straight to binary splitting.
 -/
 
-/-- Factorial implemented using binary splitting. -/
+/-- Factorial implemented using binary splitting.
+
+While this still performs the same number of multiplications,
+the big-integer operands to each are much smaller. -/
 def factorialBinarySplitting (n : Nat) : Nat :=
   if _ : n = 0 then 1 else prodRange 1 (n + 1)
 where

--- a/Mathlib/Data/Nat/Factorial/Basic.lean
+++ b/Mathlib/Data/Nat/Factorial/Basic.lean
@@ -485,7 +485,7 @@ the big-integer operands to each are much smaller. -/
 def factorialBinarySplitting (n : Nat) : Nat :=
   if _ : n = 0 then 1 else prodRange 1 (n + 1)
 where
-  /-- 
+  /--
   `prodRange lo hi` is the product of the range `lo` to `hi` (exclusive),
   computed by binary splitting.
   -/

--- a/MathlibTest/factorial.lean
+++ b/MathlibTest/factorial.lean
@@ -1,0 +1,18 @@
+import Mathlib.Data.Nat.Factorial.Basic
+
+/-!
+We check that ``1_000_000 !` evaluates in less than 10 seconds.
+(This should be a conservative upper bound that will work on most hardware,
+but still tight enough that we couldn't achieve it without binary splitting.)
+-/
+
+open Nat
+
+/-- info: 18488884 -/
+#guard_msgs in
+run_elab show Lean.Elab.TermElabM Unit from do
+  let start ← IO.monoNanosNow
+  let result ← Lean.Elab.Term.evalTerm ℕ Lean.Nat.mkType (← `(1_000_000 ! |>.log2))
+  IO.println result
+  let finish ← IO.monoNanosNow
+  guard (finish - start < 10_000_000_000)


### PR DESCRIPTION
This PR adds a faster implementation of `Nat.factorial` via binary splitting (this is faster not because of fewer multiplications, but because of smaller arguments to the multiplications), and replaces it at runtime via a `@[csimp]` lemma.

If anyone would like to implement one of the really fast implementations, that might be a fun project!

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include at least one commit authored by each
co-author among the commits in the pull request. If necessary, you may 
create empty commits to indicate co-authorship, using commands like so:

git commit --author="Author Name <author@email.com>" --allow-empty -m "add Author Name as coauthor"

When merging, all the commits will be squashed into a single commit listing all co-authors.

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
