### PR TITLE
[Merged by Bors] - doc: hyphenize "well-ordered" when used attributively

### DIFF
--- a/Mathlib/AlgebraicTopology/RelativeCellComplex/Basic.lean
+++ b/Mathlib/AlgebraicTopology/RelativeCellComplex/Basic.lean
@@ -37,7 +37,7 @@ variable {C : Type u} [Category.{v} C]
   {α : J → Type t} {A B : (j : J) → α j → C}
   (basicCell : (j : J) → (i : α j) → A j i ⟶ B j i) {X Y : C} (f : X ⟶ Y)
 
-/-- Let `J` be a well ordered type. Assume that for each `j : J`, we
+/-- Let `J` be a well-ordered type. Assume that for each `j : J`, we
 have a family `basicCell j` of morphisms. A relative cell complex
 is a morphism `f : X ⟶ Y` which is a transfinite composition of morphisms
 in such a way that at the step `j : J`, we attach cells in the family `basicCell j`. -/

--- a/Mathlib/CategoryTheory/Abelian/GrothendieckCategory/EnoughInjectives.lean
+++ b/Mathlib/CategoryTheory/Abelian/GrothendieckCategory/EnoughInjectives.lean
@@ -210,7 +210,7 @@ variable (A₀ : Subobject X) (J : Type w) [LinearOrder J] [OrderBot J] [SuccOrd
   [WellFoundedLT J]
 
 /-- Let `C` be a Grothendieck abelian category with a generator (`hG`),
-`X : C`, `A₀ : Subobject X`. Let `J` be a well ordered type. This is
+`X : C`, `A₀ : Subobject X`. Let `J` be a well-ordered type. This is
 the functor `J ⥤ MonoOver X` which corresponds to the evaluation
 at `A₀` of the transfinite iteration of the map
 `largerSubobject hG : Subobject X → Subobject X`. -/

--- a/Mathlib/CategoryTheory/Limits/Preserves/Shapes/Preorder.lean
+++ b/Mathlib/CategoryTheory/Limits/Preserves/Shapes/Preorder.lean
@@ -10,7 +10,7 @@ import Mathlib.CategoryTheory.Limits.Preserves.Basic
 /-!
 # Preservation of well order continuous functors
 
-Given a well ordered type `J` and a functor `G : C ⥤ D`,
+Given a well-ordered type `J` and a functor `G : C ⥤ D`,
 we define a type class `PreservesWellOrderContinuousOfShape J G`
 saying that `G` preserves colimits of shape `Set.Iio j`
 for any limit element `j : J`. It follows that if

--- a/Mathlib/CategoryTheory/Limits/Shapes/Preorder/WellOrderContinuous.lean
+++ b/Mathlib/CategoryTheory/Limits/Shapes/Preorder/WellOrderContinuous.lean
@@ -16,9 +16,9 @@ import Mathlib.Order.SuccPred.Limit
 import Mathlib.Order.SuccPred.LinearLocallyFinite
 
 /-!
-# Continuity of functors from well ordered types
+# Continuity of functors from well-ordered types
 
-Let `F : J ⥤ C` be functor from a well ordered type `J`.
+Let `F : J ⥤ C` be functor from a well-ordered type `J`.
 We introduce the typeclass `F.IsWellOrderContinuous`
 to say that if `m` is a limit element, then `F.obj m`
 is the colimit of the `F.obj j` for `j < m`.

--- a/Mathlib/CategoryTheory/MorphismProperty/TransfiniteComposition.lean
+++ b/Mathlib/CategoryTheory/MorphismProperty/TransfiniteComposition.lean
@@ -11,7 +11,7 @@ import Mathlib.Order.Shrink
 /-!
 # Classes of morphisms that are stable under transfinite composition
 
-Given a well ordered type `J`, `W : MorphismProperty C` and
+Given a well-ordered type `J`, `W : MorphismProperty C` and
 a morphism `f : X ⟶ Y`, we define a structure `W.TransfiniteCompositionOfShape J f`
 which expresses that `f` is a transfinite composition of shape `J` of morphisms in `W`.
 This structures extends `CategoryTheory.TransfiniteCompositionOfShape` which was
@@ -23,7 +23,7 @@ In particular, if `J := ℕ`, we define `W.IsStableUnderInfiniteComposition`,
 
 Finally, we introduce the class `W.IsStableUnderTransfiniteComposition`
 which says that `W.IsStableUnderTransfiniteCompositionOfShape J`
-holds for any well ordered type `J` in a certain universe `w`.
+holds for any well-ordered type `J` in a certain universe `w`.
 
 -/
 

--- a/Mathlib/CategoryTheory/SmallObject/Basic.lean
+++ b/Mathlib/CategoryTheory/SmallObject/Basic.lean
@@ -28,7 +28,7 @@ obtained in this file are:
 * the class `I.rlp.llp` of morphisms that have the left lifting property with
   respect to the maps that have the right lifting property with respect
   to `I` are exactly the retracts of transfinite compositions (indexed
-  by a suitable well ordered type `J`) of pushouts of coproducts of
+  by a suitable well-ordered type `J`) of pushouts of coproducts of
   morphisms in `I`;
 * morphisms in `C` have a functorial factorization as a morphism in
   `I.rlp.llp` followed by a morphism in `I.rlp`.

--- a/Mathlib/CategoryTheory/SmallObject/IsCardinalForSmallObjectArgument.lean
+++ b/Mathlib/CategoryTheory/SmallObject/IsCardinalForSmallObjectArgument.lean
@@ -67,7 +67,7 @@ namespace MorphismProperty
 /-- Given `I : MorphismProperty C` and a regular cardinal `κ : Cardinal.{w}`,
 this property asserts the technical conditions which allow to proceed
 to the small object argument by doing a construction by transfinite
-induction indexed by the well ordered type `κ.ord.toType`. -/
+induction indexed by the well-ordered type `κ.ord.toType`. -/
 class IsCardinalForSmallObjectArgument (κ : Cardinal.{w}) [Fact κ.IsRegular]
     [OrderBot κ.ord.toType] : Prop where
   isSmall : IsSmall.{w} I := by infer_instance

--- a/Mathlib/CategoryTheory/SmallObject/Iteration/Nonempty.lean
+++ b/Mathlib/CategoryTheory/SmallObject/Iteration/Nonempty.lean
@@ -11,7 +11,7 @@ import Mathlib.CategoryTheory.SmallObject.Iteration.FunctorOfCocone
 # Existence of the iteration of a successor structure
 
 Given `Φ : SuccStruct C`, we show by transfinite induction
-that for any element `j` in a well ordered set `J`,
+that for any element `j` in a well-ordered set `J`,
 the type `Φ.Iteration j` is nonempty.
 
 -/

--- a/Mathlib/Data/Finsupp/MonomialOrder.lean
+++ b/Mathlib/Data/Finsupp/MonomialOrder.lean
@@ -53,7 +53,7 @@ it is customary to order them using the opposite order : `MvPolynomial.X 0 > MvP
 
 -/
 
-/-- Monomial orders : equivalence of `σ →₀ ℕ` with a well ordered type -/
+/-- Monomial orders : equivalence of `σ →₀ ℕ` with a well-ordered type -/
 structure MonomialOrder (σ : Type*) where
   /-- The synonym type -/
   syn : Type*

--- a/Mathlib/Data/Finsupp/PWO.lean
+++ b/Mathlib/Data/Finsupp/PWO.lean
@@ -10,12 +10,12 @@ import Mathlib.Order.WellFoundedSet
 # Partial well ordering on finsupps
 
 This file contains the fact that finitely supported functions from a fintype are
-partially well ordered when the codomain is a linear order that is well ordered.
+partially well-ordered when the codomain is a linear order that is well ordered.
 It is in a separate file for now so as to not add imports to the file `Order.WellFoundedSet`.
 
 ## Main statements
 
-* `Finsupp.isPWO` - finitely supported functions from a fintype are partially well ordered when
+* `Finsupp.isPWO` - finitely supported functions from a fintype are partially well-ordered when
   the codomain is a linear order that is well ordered
 
 ## Tags

--- a/Mathlib/Order/WellFoundedSet.lean
+++ b/Mathlib/Order/WellFoundedSet.lean
@@ -38,7 +38,7 @@ This file introduces versions of `WellFounded` and `WellQuasiOrdered` for sets.
 
 ## TODO
 
-* Prove that `s` is partial well ordered iff it has no infinite descending chain or antichain.
+* Prove that `s` is partially well-ordered iff it has no infinite descending chain or antichain.
 * Rename `Set.PartiallyWellOrderedOn` to `Set.WellQuasiOrderedOn` and `Set.IsPWO` to `Set.IsWQO`.
 
 ## References
@@ -877,7 +877,7 @@ end Set.PartiallyWellOrderedOn
 ordered, when `σ` is a `Fintype` and each `α s` is a linear well order.
 This includes the classical case of Dickson's lemma that `ℕ ^ n` is a well partial order.
 Some generalizations would be possible based on this proof, to include cases where the target is
-partially well ordered, and also to consider the case of `Set.PartiallyWellOrderedOn` instead of
+partially well-ordered, and also to consider the case of `Set.PartiallyWellOrderedOn` instead of
 `Set.IsPWO`. -/
 theorem Pi.isPWO {α : ι → Type*} [∀ i, LinearOrder (α i)] [∀ i, IsWellOrder (α i) (· < ·)]
     [Finite ι] (s : Set (∀ i, α i)) : s.IsPWO := by


### PR DESCRIPTION
---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include at least one commit authored by each
co-author among the commits in the pull request. If necessary, you may 
create empty commits to indicate co-authorship, using commands like so:

git commit --author="Author Name <author@email.com>" --allow-empty -m "add Author Name as coauthor"

When merging, all the commits will be squashed into a single commit listing all co-authors.

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
