### PR TITLE
[Merged by Bors] - refactor: correct names of quaternion lemmas

### DIFF
--- a/Mathlib/Algebra/Quaternion.lean
+++ b/Mathlib/Algebra/Quaternion.lean
@@ -625,25 +625,17 @@ instance instStarQuaternionAlgebra : Star ℍ[R,c₁,c₂,c₃] where star a :=
 
 @[simp] theorem re_star : (star a).re = a.re + c₂ * a.imI := rfl
 
-@[deprecated (since := "2025-08-31")] alias star_re := re_star
-
 @[simp]
 theorem imI_star : (star a).imI = -a.imI :=
   rfl
-
-@[deprecated (since := "2025-08-31")] alias star_imI := imI_star
 
 @[simp]
 theorem imJ_star : (star a).imJ = -a.imJ :=
   rfl
 
-@[deprecated (since := "2025-08-31")] alias star_imJ := imJ_star
-
 @[simp]
 theorem imK_star : (star a).imK = -a.imK :=
   rfl
-
-@[deprecated (since := "2025-08-31")] alias star_imK := imK_star
 
 @[simp]
 theorem im_star : (star a).im = -a.im :=
@@ -1328,7 +1320,11 @@ instance instRatCast : RatCast ℍ[R] where ratCast q := (q : R)
 @[simp, norm_cast] lemma imJ_ratCast (q : ℚ) : (q : ℍ[R]).imJ = 0 := rfl
 @[simp, norm_cast] lemma imK_ratCast (q : ℚ) : (q : ℍ[R]).imK = 0 := rfl
 
-@[deprecated (since := "2025-08-31")] alias ratCast_imK := re_ratCast
+@[deprecated (since := "2025-08-31")] alias ratCast_re := re_ratCast
+@[deprecated (since := "2025-08-31")] alias ratCast_im := im_ratCast
+@[deprecated (since := "2025-08-31")] alias ratCast_imI := imI_ratCast
+@[deprecated (since := "2025-08-31")] alias ratCast_imJ := imJ_ratCast
+@[deprecated (since := "2025-08-31")] alias ratCast_imK := imK_ratCast
 
 @[norm_cast] lemma coe_nnratCast (q : ℚ≥0) : ↑(q : R) = (q : ℍ[R]) := rfl
 

--- a/Mathlib/Algebra/Quaternion.lean
+++ b/Mathlib/Algebra/Quaternion.lean
@@ -649,8 +649,6 @@ theorem imK_star : (star a).imK = -a.imK :=
 theorem im_star : (star a).im = -a.im :=
   QuaternionAlgebra.ext neg_zero.symm rfl rfl rfl
 
-@[deprecated (since := "2025-08-31")] alias star_im := im_star
-
 @[simp]
 theorem star_mk (a₁ a₂ a₃ a₄ : R) : star (mk a₁ a₂ a₃ a₄ : ℍ[R,c₁,c₂,c₃]) =
     ⟨a₁ + c₂ * a₂, -a₂, -a₃, -a₄⟩ := rfl
@@ -683,8 +681,6 @@ instance : IsStarNormal a :=
 theorem star_coe : star (x : ℍ[R,c₁,c₂,c₃]) = x := by ext <;> simp
 
 @[simp] theorem star_im : star a.im = -a.im + c₂ * a.imI := by ext <;> simp
-
-@[deprecated (since := "2025-08-31")] alias im_star := star_im
 
 @[simp]
 theorem star_smul [Monoid S] [DistribMulAction S R] [SMulCommClass S R R]
@@ -1148,8 +1144,6 @@ theorem finrank_eq_four [StrongRankCondition R] : Module.finrank R ℍ[R] = 4 :=
 
 @[simp] theorem im_star : (star a).im = -a.im := QuaternionAlgebra.im_star a
 
-@[deprecated (since := "2025-08-31")] alias star_im := im_star
-
 nonrec theorem self_add_star' : a + star a = ↑(2 * a.re) := by
   simp [a.self_add_star', Quaternion.coe]
 
@@ -1171,8 +1165,6 @@ theorem star_coe : star (x : ℍ[R]) = x :=
 
 @[simp]
 theorem star_im : star a.im = -a.im := by ext <;> simp
-
-@[deprecated (since := "2025-08-31")] alias im_star := star_im
 
 @[simp]
 theorem star_smul [Monoid S] [DistribMulAction S R] (s : S) (a : ℍ[R]) :

--- a/Mathlib/Algebra/Quaternion.lean
+++ b/Mathlib/Algebra/Quaternion.lean
@@ -120,17 +120,25 @@ def im (x : ℍ[R,c₁,c₂,c₃]) : ℍ[R,c₁,c₂,c₃] :=
 theorem re_im : a.im.re = 0 :=
   rfl
 
+@[deprecated (since := "2025-08-31")] alias im_re := re_im
+
 @[simp]
 theorem imI_im : a.im.imI = a.imI :=
   rfl
+
+@[deprecated (since := "2025-08-31")] alias im_imI := imI_im
 
 @[simp]
 theorem imJ_im : a.im.imJ = a.imJ :=
   rfl
 
+@[deprecated (since := "2025-08-31")] alias im_imJ := imJ_im
+
 @[simp]
 theorem imK_im : a.im.imK = a.imK :=
   rfl
+
+@[deprecated (since := "2025-08-31")] alias im_imK := imK_im
 
 @[simp]
 theorem im_idem : a.im.im = a.im :=
@@ -144,14 +152,22 @@ instance : CoeTC R ℍ[R,c₁,c₂,c₃] := ⟨coe⟩
 @[simp, norm_cast]
 theorem re_coe : (x : ℍ[R,c₁,c₂,c₃]).re = x := rfl
 
+@[deprecated (since := "2025-08-31")] alias coe_re := re_coe
+
 @[simp, norm_cast]
 theorem imI_coe : (x : ℍ[R,c₁,c₂,c₃]).imI = 0 := rfl
+
+@[deprecated (since := "2025-08-31")] alias coe_imI := imI_coe
 
 @[simp, norm_cast]
 theorem imJ_coe : (x : ℍ[R,c₁,c₂,c₃]).imJ = 0 := rfl
 
+@[deprecated (since := "2025-08-31")] alias coe_imJ := imJ_coe
+
 @[simp, norm_cast]
 theorem imK_coe : (x : ℍ[R,c₁,c₂,c₃]).imK = 0 := rfl
+
+@[deprecated (since := "2025-08-31")] alias coe_imK := imK_coe
 
 theorem coe_injective : Function.Injective (coe : R → ℍ[R,c₁,c₂,c₃]) := fun _ _ h => congr_arg re h
 
@@ -163,6 +179,8 @@ theorem coe_inj {x y : R} : (x : ℍ[R,c₁,c₂,c₃]) = y ↔ x = y :=
 instance : Zero ℍ[R,c₁,c₂,c₃] := ⟨⟨0, 0, 0, 0⟩⟩
 
 @[scoped simp] theorem im_zero : (0 : ℍ[R,c₁,c₂,c₃]).im = 0 := rfl
+
+@[deprecated (since := "2025-08-31")] alias zero_im := im_zero
 
 @[simp, norm_cast]
 theorem coe_zero : ((0 : R) : ℍ[R,c₁,c₂,c₃]) = 0 := rfl
@@ -176,6 +194,8 @@ variable [One R]
 instance : One ℍ[R,c₁,c₂,c₃] := ⟨⟨1, 0, 0, 0⟩⟩
 
 @[scoped simp] theorem im_one : (1 : ℍ[R,c₁,c₂,c₃]).im = 0 := rfl
+
+@[deprecated (since := "2025-08-31")] alias one_im := im_one
 
 @[simp, norm_cast]
 theorem coe_one : ((1 : R) : ℍ[R,c₁,c₂,c₃]) = 1 := rfl
@@ -203,6 +223,8 @@ variable [AddZeroClass R]
 @[simp] theorem im_add : (a + b).im = a.im + b.im :=
   QuaternionAlgebra.ext (zero_add _).symm rfl rfl rfl
 
+@[deprecated (since := "2025-08-31")] alias add_im := im_add
+
 @[simp, norm_cast]
 theorem coe_add : ((x + y : R) : ℍ[R,c₁,c₂,c₃]) = x + y := by ext <;> simp
 
@@ -226,6 +248,8 @@ variable [AddGroup R]
 @[simp] theorem im_neg : (-a).im = -a.im :=
   QuaternionAlgebra.ext neg_zero.symm rfl rfl rfl
 
+@[deprecated (since := "2025-08-31")] alias neg_im := im_neg
+
 @[simp, norm_cast]
 theorem coe_neg : ((-x : R) : ℍ[R,c₁,c₂,c₃]) = -x := by ext <;> simp
 
@@ -235,6 +259,8 @@ instance : Sub ℍ[R,c₁,c₂,c₃] :=
 
 @[simp] theorem im_sub : (a - b).im = a.im - b.im :=
   QuaternionAlgebra.ext (sub_zero _).symm rfl rfl rfl
+
+@[deprecated (since := "2025-08-31")] alias sub_im := im_sub
 
 @[simp]
 theorem mk_sub_mk (a₁ a₂ a₃ a₄ b₁ b₂ b₃ b₄ : R) :
@@ -246,6 +272,8 @@ theorem mk_sub_mk (a₁ a₂ a₃ a₄ b₁ b₂ b₃ b₄ : R) :
 theorem im_coe : (x : ℍ[R,c₁,c₂,c₃]).im = 0 :=
   rfl
 
+@[deprecated (since := "2025-08-31")] alias coe_im := im_coe
+
 @[simp]
 theorem re_add_im : ↑a.re + a.im = a :=
   QuaternionAlgebra.ext (add_zero _) (zero_add _) (zero_add _) (zero_add _)
@@ -254,9 +282,13 @@ theorem re_add_im : ↑a.re + a.im = a :=
 theorem sub_im_self : a - a.im = a.re :=
   QuaternionAlgebra.ext (sub_zero _) (sub_self _) (sub_self _) (sub_self _)
 
+@[deprecated (since := "2025-08-31")] alias sub_self_im := sub_im_self
+
 @[simp]
 theorem sub_re_self : a - a.re = a.im :=
   QuaternionAlgebra.ext (sub_self _) (sub_zero _) (sub_zero _) (sub_zero _)
+
+@[deprecated (since := "2025-08-31")] alias sub_self_re := sub_re_self
 
 end AddGroup
 
@@ -307,6 +339,8 @@ instance [SMulCommClass S T R] : SMulCommClass S T ℍ[R,c₁,c₂,c₃] where
 @[simp] theorem im_smul {S} [CommRing R] [SMulZeroClass S R] (s : S) : (s • a).im = s • a.im :=
   QuaternionAlgebra.ext (smul_zero s).symm rfl rfl rfl
 
+@[deprecated (since := "2025-08-31")] alias smul_im := im_smul
+
 @[simp]
 theorem smul_mk (re im_i im_j im_k : R) :
     s • (⟨re, im_i, im_j, im_k⟩ : ℍ[R,c₁,c₂,c₃]) = ⟨s • re, s • im_i, s • im_j, s • im_k⟩ :=
@@ -340,21 +374,31 @@ instance : AddCommGroupWithOne ℍ[R,c₁,c₂,c₃] where
 theorem re_natCast (n : ℕ) : (n : ℍ[R,c₁,c₂,c₃]).re = n :=
   rfl
 
+@[deprecated (since := "2025-08-31")] alias natCast_re := re_natCast
+
 @[simp, norm_cast]
 theorem imI_natCast (n : ℕ) : (n : ℍ[R,c₁,c₂,c₃]).imI = 0 :=
   rfl
+
+@[deprecated (since := "2025-08-31")] alias natCast_imI := imI_natCast
 
 @[simp, norm_cast]
 theorem imJ_natCast (n : ℕ) : (n : ℍ[R,c₁,c₂,c₃]).imJ = 0 :=
   rfl
 
+@[deprecated (since := "2025-08-31")] alias natCast_imJ := imJ_natCast
+
 @[simp, norm_cast]
 theorem imK_natCast (n : ℕ) : (n : ℍ[R,c₁,c₂,c₃]).imK = 0 :=
   rfl
 
+@[deprecated (since := "2025-08-31")] alias natCast_imK := imK_natCast
+
 @[simp, norm_cast]
 theorem im_natCast (n : ℕ) : (n : ℍ[R,c₁,c₂,c₃]).im = 0 :=
   rfl
+
+@[deprecated (since := "2025-08-31")] alias natCast_im := im_natCast
 
 @[norm_cast]
 theorem coe_natCast (n : ℕ) : ↑(n : R) = (n : ℍ[R,c₁,c₂,c₃]) :=
@@ -364,36 +408,56 @@ theorem coe_natCast (n : ℕ) : ↑(n : R) = (n : ℍ[R,c₁,c₂,c₃]) :=
 theorem re_intCast (z : ℤ) : (z : ℍ[R,c₁,c₂,c₃]).re = z :=
   rfl
 
+@[deprecated (since := "2025-08-31")] alias intCast_re := re_intCast
+
 @[scoped simp]
 theorem re_ofNat (n : ℕ) [n.AtLeastTwo] : (ofNat(n) : ℍ[R,c₁,c₂,c₃]).re = ofNat(n) := rfl
+
+@[deprecated (since := "2025-08-31")] alias ofNat_re := re_ofNat
 
 @[scoped simp]
 theorem imI_ofNat (n : ℕ) [n.AtLeastTwo] : (ofNat(n) : ℍ[R,c₁,c₂,c₃]).imI = 0 := rfl
 
+@[deprecated (since := "2025-08-31")] alias ofNat_imI := imI_ofNat
+
 @[scoped simp]
 theorem imJ_ofNat (n : ℕ) [n.AtLeastTwo] : (ofNat(n) : ℍ[R,c₁,c₂,c₃]).imJ = 0 := rfl
+
+@[deprecated (since := "2025-08-31")] alias ofNat_imJ := imJ_ofNat
 
 @[scoped simp]
 theorem imK_ofNat (n : ℕ) [n.AtLeastTwo] : (ofNat(n) : ℍ[R,c₁,c₂,c₃]).imK = 0 := rfl
 
+@[deprecated (since := "2025-08-31")] alias ofNat_imK := imK_ofNat
+
 @[scoped simp]
 theorem im_ofNat (n : ℕ) [n.AtLeastTwo] : (ofNat(n) : ℍ[R,c₁,c₂,c₃]).im = 0 := rfl
+
+@[deprecated (since := "2025-08-31")] alias ofNat_im := im_ofNat
 
 @[simp, norm_cast]
 theorem imI_intCast (z : ℤ) : (z : ℍ[R,c₁,c₂,c₃]).imI = 0 :=
   rfl
 
+@[deprecated (since := "2025-08-31")] alias intCast_imI := imI_intCast
+
 @[simp, norm_cast]
 theorem imJ_intCast (z : ℤ) : (z : ℍ[R,c₁,c₂,c₃]).imJ = 0 :=
   rfl
+
+@[deprecated (since := "2025-08-31")] alias intCast_imJ := imJ_intCast
 
 @[simp, norm_cast]
 theorem imK_intCast (z : ℤ) : (z : ℍ[R,c₁,c₂,c₃]).imK = 0 :=
   rfl
 
+@[deprecated (since := "2025-08-31")] alias intCast_imK := imK_intCast
+
 @[simp, norm_cast]
 theorem im_intCast (z : ℤ) : (z : ℍ[R,c₁,c₂,c₃]).im = 0 :=
   rfl
+
+@[deprecated (since := "2025-08-31")] alias intCast_im := im_intCast
 
 @[norm_cast]
 theorem coe_intCast (z : ℤ) : ↑(z : R) = (z : ℍ[R,c₁,c₂,c₃]) :=
@@ -561,21 +625,31 @@ instance instStarQuaternionAlgebra : Star ℍ[R,c₁,c₂,c₃] where star a :=
 
 @[simp] theorem re_star : (star a).re = a.re + c₂ * a.imI := rfl
 
+@[deprecated (since := "2025-08-31")] alias star_re := re_star
+
 @[simp]
 theorem imI_star : (star a).imI = -a.imI :=
   rfl
+
+@[deprecated (since := "2025-08-31")] alias star_imI := imI_star
 
 @[simp]
 theorem imJ_star : (star a).imJ = -a.imJ :=
   rfl
 
+@[deprecated (since := "2025-08-31")] alias star_imJ := imJ_star
+
 @[simp]
 theorem imK_star : (star a).imK = -a.imK :=
   rfl
 
+@[deprecated (since := "2025-08-31")] alias star_imK := imK_star
+
 @[simp]
 theorem im_star : (star a).im = -a.im :=
   QuaternionAlgebra.ext neg_zero.symm rfl rfl rfl
+
+@[deprecated (since := "2025-08-31")] alias star_im := im_star
 
 @[simp]
 theorem star_mk (a₁ a₂ a₃ a₄ : R) : star (mk a₁ a₂ a₃ a₄ : ℍ[R,c₁,c₂,c₃]) =
@@ -609,6 +683,8 @@ instance : IsStarNormal a :=
 theorem star_coe : star (x : ℍ[R,c₁,c₂,c₃]) = x := by ext <;> simp
 
 @[simp] theorem star_im : star a.im = -a.im + c₂ * a.imI := by ext <;> simp
+
+@[deprecated (since := "2025-08-31")] alias im_star := star_im
 
 @[simp]
 theorem star_smul [Monoid S] [DistribMulAction S R] [SMulCommClass S R R]
@@ -731,11 +807,19 @@ nonrec def im (x : ℍ[R]) : ℍ[R] := x.im
 
 @[simp] theorem re_im : a.im.re = 0 := rfl
 
+@[deprecated (since := "2025-08-31")] alias im_re := re_im
+
 @[simp] theorem imI_im : a.im.imI = a.imI := rfl
+
+@[deprecated (since := "2025-08-31")] alias im_imI := imI_im
 
 @[simp] theorem imJ_im : a.im.imJ = a.imJ := rfl
 
+@[deprecated (since := "2025-08-31")] alias im_imJ := imJ_im
+
 @[simp] theorem imK_im : a.im.imK = a.imK := rfl
+
+@[deprecated (since := "2025-08-31")] alias im_imK := imK_im
 
 @[simp] theorem im_idem : a.im.im = a.im := rfl
 
@@ -743,58 +827,102 @@ nonrec def im (x : ℍ[R]) : ℍ[R] := x.im
 
 @[simp] nonrec theorem sub_im_self : a - a.im = a.re := a.sub_im_self
 
+@[deprecated (since := "2025-08-31")] alias sub_self_im := sub_im_self
+
 @[simp] nonrec theorem sub_re_self : a - ↑a.re = a.im := a.sub_re_self
+
+@[deprecated (since := "2025-08-31")] alias sub_self_re := sub_re_self
 
 @[simp, norm_cast]
 theorem re_coe : (x : ℍ[R]).re = x := rfl
 
+@[deprecated (since := "2025-08-31")] alias coe_re := re_coe
+
 @[simp, norm_cast]
 theorem imI_coe : (x : ℍ[R]).imI = 0 := rfl
+
+@[deprecated (since := "2025-08-31")] alias coe_imI := imI_coe
 
 @[simp, norm_cast]
 theorem imJ_coe : (x : ℍ[R]).imJ = 0 := rfl
 
+@[deprecated (since := "2025-08-31")] alias coe_imJ := imJ_coe
+
 @[simp, norm_cast]
 theorem imK_coe : (x : ℍ[R]).imK = 0 := rfl
+
+@[deprecated (since := "2025-08-31")] alias coe_imK := imK_coe
 
 @[simp, norm_cast]
 theorem im_coe : (x : ℍ[R]).im = 0 := rfl
 
+@[deprecated (since := "2025-08-31")] alias coe_im := im_coe
+
 @[scoped simp] theorem re_zero : (0 : ℍ[R]).re = 0 := rfl
+
+@[deprecated (since := "2025-08-31")] alias zero_re := re_zero
 
 @[scoped simp] theorem imI_zero : (0 : ℍ[R]).imI = 0 := rfl
 
+@[deprecated (since := "2025-08-31")] alias zero_imI := imI_zero
+
 @[scoped simp] theorem imJ_zero : (0 : ℍ[R]).imJ = 0 := rfl
+
+@[deprecated (since := "2025-08-31")] alias zero_imJ := imJ_zero
 
 @[scoped simp] theorem imK_zero : (0 : ℍ[R]).imK = 0 := rfl
 
+@[deprecated (since := "2025-08-31")] alias zero_imK := imK_zero
+
 @[scoped simp] theorem im_zero : (0 : ℍ[R]).im = 0 := rfl
+
+@[deprecated (since := "2025-08-31")] alias zero_im := im_zero
 
 @[simp, norm_cast]
 theorem coe_zero : ((0 : R) : ℍ[R]) = 0 := rfl
 
 @[scoped simp] theorem re_one : (1 : ℍ[R]).re = 1 := rfl
 
+@[deprecated (since := "2025-08-31")] alias one_re := re_one
+
 @[scoped simp] theorem imI_one : (1 : ℍ[R]).imI = 0 := rfl
+
+@[deprecated (since := "2025-08-31")] alias one_imI := imI_one
 
 @[scoped simp] theorem imJ_one : (1 : ℍ[R]).imJ = 0 := rfl
 
+@[deprecated (since := "2025-08-31")] alias one_imJ := imJ_one
+
 @[scoped simp] theorem imK_one : (1 : ℍ[R]).imK = 0 := rfl
 
+@[deprecated (since := "2025-08-31")] alias one_imK := imK_one
+
 @[scoped simp] theorem im_one : (1 : ℍ[R]).im = 0 := rfl
+
+@[deprecated (since := "2025-08-31")] alias one_im := im_one
 
 @[simp, norm_cast]
 theorem coe_one : ((1 : R) : ℍ[R]) = 1 := rfl
 
 @[simp] theorem re_add : (a + b).re = a.re + b.re := rfl
 
+@[deprecated (since := "2025-08-31")] alias add_re := re_add
+
 @[simp] theorem imI_add : (a + b).imI = a.imI + b.imI := rfl
+
+@[deprecated (since := "2025-08-31")] alias add_imI := imI_add
 
 @[simp] theorem imJ_add : (a + b).imJ = a.imJ + b.imJ := rfl
 
+@[deprecated (since := "2025-08-31")] alias add_imJ := imJ_add
+
 @[simp] theorem imK_add : (a + b).imK = a.imK + b.imK := rfl
 
+@[deprecated (since := "2025-08-31")] alias add_imK := imK_add
+
 @[simp] nonrec theorem im_add : (a + b).im = a.im + b.im := a.im_add b
+
+@[deprecated (since := "2025-08-31")] alias add_im := im_add
 
 @[simp, norm_cast]
 theorem coe_add : ((x + y : R) : ℍ[R]) = x + y :=
@@ -802,13 +930,23 @@ theorem coe_add : ((x + y : R) : ℍ[R]) = x + y :=
 
 @[simp] theorem re_neg : (-a).re = -a.re := rfl
 
+@[deprecated (since := "2025-08-31")] alias neg_re := re_neg
+
 @[simp] theorem imI_neg : (-a).imI = -a.imI := rfl
+
+@[deprecated (since := "2025-08-31")] alias neg_imI := imI_neg
 
 @[simp] theorem imJ_neg : (-a).imJ = -a.imJ := rfl
 
+@[deprecated (since := "2025-08-31")] alias neg_imJ := imJ_neg
+
 @[simp] theorem imK_neg : (-a).imK = -a.imK := rfl
 
+@[deprecated (since := "2025-08-31")] alias neg_imK := imK_neg
+
 @[simp] nonrec theorem im_neg : (-a).im = -a.im := a.im_neg
+
+@[deprecated (since := "2025-08-31")] alias neg_im := im_neg
 
 @[simp, norm_cast]
 theorem coe_neg : ((-x : R) : ℍ[R]) = -x :=
@@ -816,13 +954,23 @@ theorem coe_neg : ((-x : R) : ℍ[R]) = -x :=
 
 @[simp] theorem re_sub : (a - b).re = a.re - b.re := rfl
 
+@[deprecated (since := "2025-08-31")] alias sub_re := re_sub
+
 @[simp] theorem imI_sub : (a - b).imI = a.imI - b.imI := rfl
+
+@[deprecated (since := "2025-08-31")] alias sub_imI := imI_sub
 
 @[simp] theorem imJ_sub : (a - b).imJ = a.imJ - b.imJ := rfl
 
+@[deprecated (since := "2025-08-31")] alias sub_imJ := imJ_sub
+
 @[simp] theorem imK_sub : (a - b).imK = a.imK - b.imK := rfl
 
+@[deprecated (since := "2025-08-31")] alias sub_imK := imK_sub
+
 @[simp] nonrec theorem im_sub : (a - b).im = a.im - b.im := a.im_sub b
+
+@[deprecated (since := "2025-08-31")] alias sub_im := im_sub
 
 @[simp, norm_cast]
 theorem coe_sub : ((x - y : R) : ℍ[R]) = x - y :=
@@ -832,17 +980,25 @@ theorem coe_sub : ((x - y : R) : ℍ[R]) = x - y :=
 theorem re_mul : (a * b).re = a.re * b.re - a.imI * b.imI - a.imJ * b.imJ - a.imK * b.imK :=
   (QuaternionAlgebra.re_mul a b).trans <| by simp [one_mul, neg_mul, sub_eq_add_neg, neg_neg]
 
+@[deprecated (since := "2025-08-31")] alias mul_re := re_mul
+
 @[simp]
 theorem imI_mul : (a * b).imI = a.re * b.imI + a.imI * b.re + a.imJ * b.imK - a.imK * b.imJ :=
   (QuaternionAlgebra.imI_mul a b).trans <| by ring
+
+@[deprecated (since := "2025-08-31")] alias mul_imI := imI_mul
 
 @[simp]
 theorem imJ_mul : (a * b).imJ = a.re * b.imJ - a.imI * b.imK + a.imJ * b.re + a.imK * b.imI :=
   (QuaternionAlgebra.imJ_mul a b).trans <| by ring
 
+@[deprecated (since := "2025-08-31")] alias mul_imJ := imJ_mul
+
 @[simp]
 theorem imK_mul : (a * b).imK = a.re * b.imK + a.imI * b.imJ - a.imJ * b.imI + a.imK * b.re :=
   (QuaternionAlgebra.imK_mul a b).trans <| by ring
+
+@[deprecated (since := "2025-08-31")] alias mul_imK := imK_mul
 
 @[simp, norm_cast]
 theorem coe_mul : ((x * y : R) : ℍ[R]) = x * y := QuaternionAlgebra.coe_mul x y
@@ -854,17 +1010,27 @@ theorem coe_pow (n : ℕ) : (↑(x ^ n) : ℍ[R]) = (x : ℍ[R]) ^ n :=
 @[simp, norm_cast]
 theorem re_natCast (n : ℕ) : (n : ℍ[R]).re = n := rfl
 
+@[deprecated (since := "2025-08-31")] alias natCast_re := re_natCast
+
 @[simp, norm_cast]
 theorem imI_natCast (n : ℕ) : (n : ℍ[R]).imI = 0 := rfl
+
+@[deprecated (since := "2025-08-31")] alias natCast_imI := imI_natCast
 
 @[simp, norm_cast]
 theorem imJ_natCast (n : ℕ) : (n : ℍ[R]).imJ = 0 := rfl
 
+@[deprecated (since := "2025-08-31")] alias natCast_imJ := imJ_natCast
+
 @[simp, norm_cast]
 theorem imK_natCast (n : ℕ) : (n : ℍ[R]).imK = 0 := rfl
 
+@[deprecated (since := "2025-08-31")] alias natCast_imK := imK_natCast
+
 @[simp, norm_cast]
 theorem im_natCast (n : ℕ) : (n : ℍ[R]).im = 0 := rfl
+
+@[deprecated (since := "2025-08-31")] alias natCast_im := im_natCast
 
 @[norm_cast]
 theorem coe_natCast (n : ℕ) : ↑(n : R) = (n : ℍ[R]) := rfl
@@ -872,17 +1038,27 @@ theorem coe_natCast (n : ℕ) : ↑(n : R) = (n : ℍ[R]) := rfl
 @[simp, norm_cast]
 theorem re_intCast (z : ℤ) : (z : ℍ[R]).re = z := rfl
 
+@[deprecated (since := "2025-08-31")] alias intCast_re := re_intCast
+
 @[simp, norm_cast]
 theorem imI_intCast (z : ℤ) : (z : ℍ[R]).imI = 0 := rfl
+
+@[deprecated (since := "2025-08-31")] alias intCast_imI := imI_intCast
 
 @[simp, norm_cast]
 theorem imJ_intCast (z : ℤ) : (z : ℍ[R]).imJ = 0 := rfl
 
+@[deprecated (since := "2025-08-31")] alias intCast_imJ := imJ_intCast
+
 @[simp, norm_cast]
 theorem imK_intCast (z : ℤ) : (z : ℍ[R]).imK = 0 := rfl
 
+@[deprecated (since := "2025-08-31")] alias intCast_imK := imK_intCast
+
 @[simp, norm_cast]
 theorem im_intCast (z : ℤ) : (z : ℍ[R]).im = 0 := rfl
+
+@[deprecated (since := "2025-08-31")] alias intCast_im := im_intCast
 
 @[norm_cast]
 theorem coe_intCast (z : ℤ) : ↑(z : R) = (z : ℍ[R]) := rfl
@@ -898,15 +1074,25 @@ theorem coe_inj {x y : R} : (x : ℍ[R]) = y ↔ x = y :=
 theorem re_smul [SMul S R] (s : S) : (s • a).re = s • a.re :=
   rfl
 
+@[deprecated (since := "2025-08-31")] alias smul_re := re_smul
+
 @[simp] theorem imI_smul [SMul S R] (s : S) : (s • a).imI = s • a.imI := rfl
+
+@[deprecated (since := "2025-08-31")] alias smul_imI := imI_smul
 
 @[simp] theorem imJ_smul [SMul S R] (s : S) : (s • a).imJ = s • a.imJ := rfl
 
+@[deprecated (since := "2025-08-31")] alias smul_imJ := imJ_smul
+
 @[simp] theorem imK_smul [SMul S R] (s : S) : (s • a).imK = s • a.imK := rfl
+
+@[deprecated (since := "2025-08-31")] alias smul_imK := imK_smul
 
 @[simp]
 nonrec theorem im_smul [SMulZeroClass S R] (s : S) : (s • a).im = s • a.im :=
   a.im_smul s
+
+@[deprecated (since := "2025-08-31")] alias smul_im := im_smul
 
 @[simp, norm_cast]
 theorem coe_smul [SMulZeroClass S R] (s : S) (r : R) : (↑(s • r) : ℍ[R]) = s • (r : ℍ[R]) :=
@@ -946,13 +1132,23 @@ theorem finrank_eq_four [StrongRankCondition R] : Module.finrank R ℍ[R] = 4 :=
 @[simp] theorem re_star : (star a).re = a.re := by
   rw [QuaternionAlgebra.re_star, zero_mul, add_zero]
 
+@[deprecated (since := "2025-08-31")] alias star_re := re_star
+
 @[simp] theorem imI_star : (star a).imI = -a.imI := rfl
+
+@[deprecated (since := "2025-08-31")] alias star_imI := imI_star
 
 @[simp] theorem imJ_star : (star a).imJ = -a.imJ := rfl
 
+@[deprecated (since := "2025-08-31")] alias star_imJ := imJ_star
+
 @[simp] theorem imK_star : (star a).imK = -a.imK := rfl
 
+@[deprecated (since := "2025-08-31")] alias star_imK := imK_star
+
 @[simp] theorem im_star : (star a).im = -a.im := QuaternionAlgebra.im_star a
+
+@[deprecated (since := "2025-08-31")] alias star_im := im_star
 
 nonrec theorem self_add_star' : a + star a = ↑(2 * a.re) := by
   simp [a.self_add_star', Quaternion.coe]
@@ -975,6 +1171,8 @@ theorem star_coe : star (x : ℍ[R]) = x :=
 
 @[simp]
 theorem star_im : star a.im = -a.im := by ext <;> simp
+
+@[deprecated (since := "2025-08-31")] alias im_star := star_im
 
 @[simp]
 theorem star_smul [Monoid S] [DistribMulAction S R] (s : S) (a : ℍ[R]) :
@@ -1137,6 +1335,8 @@ instance instRatCast : RatCast ℍ[R] where ratCast q := (q : R)
 @[simp, norm_cast] lemma imI_ratCast (q : ℚ) : (q : ℍ[R]).imI = 0 := rfl
 @[simp, norm_cast] lemma imJ_ratCast (q : ℚ) : (q : ℍ[R]).imJ = 0 := rfl
 @[simp, norm_cast] lemma imK_ratCast (q : ℚ) : (q : ℍ[R]).imK = 0 := rfl
+
+@[deprecated (since := "2025-08-31")] alias ratCast_imK := re_ratCast
 
 @[norm_cast] lemma coe_nnratCast (q : ℚ≥0) : ↑(q : R) = (q : ℍ[R]) := rfl
 

--- a/Mathlib/Algebra/Quaternion.lean
+++ b/Mathlib/Algebra/Quaternion.lean
@@ -66,6 +66,9 @@ structure QuaternionAlgebra (R : Type*) (a b c : R) where
   /-- Third imaginary part (k) of a quaternion. -/
   imK : R
 
+initialize_simps_projections QuaternionAlgebra
+  (as_prefix re, as_prefix imI, as_prefix imJ, as_prefix imK)
+
 @[inherit_doc]
 scoped[Quaternion] notation "ℍ[" R "," a "," b "," c "]" =>
     QuaternionAlgebra R a b c
@@ -114,19 +117,19 @@ def im (x : ℍ[R,c₁,c₂,c₃]) : ℍ[R,c₁,c₂,c₃] :=
   ⟨0, x.imI, x.imJ, x.imK⟩
 
 @[simp]
-theorem im_re : a.im.re = 0 :=
+theorem re_im : a.im.re = 0 :=
   rfl
 
 @[simp]
-theorem im_imI : a.im.imI = a.imI :=
+theorem imI_im : a.im.imI = a.imI :=
   rfl
 
 @[simp]
-theorem im_imJ : a.im.imJ = a.imJ :=
+theorem imJ_im : a.im.imJ = a.imJ :=
   rfl
 
 @[simp]
-theorem im_imK : a.im.imK = a.imK :=
+theorem imK_im : a.im.imK = a.imK :=
   rfl
 
 @[simp]
@@ -139,16 +142,16 @@ theorem im_idem : a.im.im = a.im :=
 instance : CoeTC R ℍ[R,c₁,c₂,c₃] := ⟨coe⟩
 
 @[simp, norm_cast]
-theorem coe_re : (x : ℍ[R,c₁,c₂,c₃]).re = x := rfl
+theorem re_coe : (x : ℍ[R,c₁,c₂,c₃]).re = x := rfl
 
 @[simp, norm_cast]
-theorem coe_imI : (x : ℍ[R,c₁,c₂,c₃]).imI = 0 := rfl
+theorem imI_coe : (x : ℍ[R,c₁,c₂,c₃]).imI = 0 := rfl
 
 @[simp, norm_cast]
-theorem coe_imJ : (x : ℍ[R,c₁,c₂,c₃]).imJ = 0 := rfl
+theorem imJ_coe : (x : ℍ[R,c₁,c₂,c₃]).imJ = 0 := rfl
 
 @[simp, norm_cast]
-theorem coe_imK : (x : ℍ[R,c₁,c₂,c₃]).imK = 0 := rfl
+theorem imK_coe : (x : ℍ[R,c₁,c₂,c₃]).imK = 0 := rfl
 
 theorem coe_injective : Function.Injective (coe : R → ℍ[R,c₁,c₂,c₃]) := fun _ _ h => congr_arg re h
 
@@ -159,7 +162,7 @@ theorem coe_inj {x y : R} : (x : ℍ[R,c₁,c₂,c₃]) = y ↔ x = y :=
 @[simps]
 instance : Zero ℍ[R,c₁,c₂,c₃] := ⟨⟨0, 0, 0, 0⟩⟩
 
-@[scoped simp] theorem zero_im : (0 : ℍ[R,c₁,c₂,c₃]).im = 0 := rfl
+@[scoped simp] theorem im_zero : (0 : ℍ[R,c₁,c₂,c₃]).im = 0 := rfl
 
 @[simp, norm_cast]
 theorem coe_zero : ((0 : R) : ℍ[R,c₁,c₂,c₃]) = 0 := rfl
@@ -172,7 +175,7 @@ variable [One R]
 @[simps]
 instance : One ℍ[R,c₁,c₂,c₃] := ⟨⟨1, 0, 0, 0⟩⟩
 
-@[scoped simp] theorem one_im : (1 : ℍ[R,c₁,c₂,c₃]).im = 0 := rfl
+@[scoped simp] theorem im_one : (1 : ℍ[R,c₁,c₂,c₃]).im = 0 := rfl
 
 @[simp, norm_cast]
 theorem coe_one : ((1 : R) : ℍ[R,c₁,c₂,c₃]) = 1 := rfl
@@ -197,7 +200,7 @@ end Add
 section AddZeroClass
 variable [AddZeroClass R]
 
-@[simp] theorem add_im : (a + b).im = a.im + b.im :=
+@[simp] theorem im_add : (a + b).im = a.im + b.im :=
   QuaternionAlgebra.ext (zero_add _).symm rfl rfl rfl
 
 @[simp, norm_cast]
@@ -220,7 +223,7 @@ end Neg
 section AddGroup
 variable [AddGroup R]
 
-@[simp] theorem neg_im : (-a).im = -a.im :=
+@[simp] theorem im_neg : (-a).im = -a.im :=
   QuaternionAlgebra.ext neg_zero.symm rfl rfl rfl
 
 @[simp, norm_cast]
@@ -230,7 +233,7 @@ theorem coe_neg : ((-x : R) : ℍ[R,c₁,c₂,c₃]) = -x := by ext <;> simp
 instance : Sub ℍ[R,c₁,c₂,c₃] :=
   ⟨fun a b => ⟨a.1 - b.1, a.2 - b.2, a.3 - b.3, a.4 - b.4⟩⟩
 
-@[simp] theorem sub_im : (a - b).im = a.im - b.im :=
+@[simp] theorem im_sub : (a - b).im = a.im - b.im :=
   QuaternionAlgebra.ext (sub_zero _).symm rfl rfl rfl
 
 @[simp]
@@ -240,7 +243,7 @@ theorem mk_sub_mk (a₁ a₂ a₃ a₄ b₁ b₂ b₃ b₄ : R) :
   rfl
 
 @[simp, norm_cast]
-theorem coe_im : (x : ℍ[R,c₁,c₂,c₃]).im = 0 :=
+theorem im_coe : (x : ℍ[R,c₁,c₂,c₃]).im = 0 :=
   rfl
 
 @[simp]
@@ -248,11 +251,11 @@ theorem re_add_im : ↑a.re + a.im = a :=
   QuaternionAlgebra.ext (add_zero _) (zero_add _) (zero_add _) (zero_add _)
 
 @[simp]
-theorem sub_self_im : a - a.im = a.re :=
+theorem sub_im_self : a - a.im = a.re :=
   QuaternionAlgebra.ext (sub_zero _) (sub_self _) (sub_self _) (sub_self _)
 
 @[simp]
-theorem sub_self_re : a - a.re = a.im :=
+theorem sub_re_self : a - a.re = a.im :=
   QuaternionAlgebra.ext (sub_self _) (sub_zero _) (sub_zero _) (sub_zero _)
 
 end AddGroup
@@ -301,7 +304,7 @@ instance [SMul S T] [IsScalarTower S T R] : IsScalarTower S T ℍ[R,c₁,c₂,c�
 instance [SMulCommClass S T R] : SMulCommClass S T ℍ[R,c₁,c₂,c₃] where
   smul_comm s t x := by ext <;> exact smul_comm _ _ _
 
-@[simp] theorem smul_im {S} [CommRing R] [SMulZeroClass S R] (s : S) : (s • a).im = s • a.im :=
+@[simp] theorem im_smul {S} [CommRing R] [SMulZeroClass S R] (s : S) : (s • a).im = s • a.im :=
   QuaternionAlgebra.ext (smul_zero s).symm rfl rfl rfl
 
 @[simp]
@@ -334,23 +337,23 @@ instance : AddCommGroupWithOne ℍ[R,c₁,c₂,c₃] where
     rw [Int.cast_negSucc, coe_neg]
 
 @[simp, norm_cast]
-theorem natCast_re (n : ℕ) : (n : ℍ[R,c₁,c₂,c₃]).re = n :=
+theorem re_natCast (n : ℕ) : (n : ℍ[R,c₁,c₂,c₃]).re = n :=
   rfl
 
 @[simp, norm_cast]
-theorem natCast_imI (n : ℕ) : (n : ℍ[R,c₁,c₂,c₃]).imI = 0 :=
+theorem imI_natCast (n : ℕ) : (n : ℍ[R,c₁,c₂,c₃]).imI = 0 :=
   rfl
 
 @[simp, norm_cast]
-theorem natCast_imJ (n : ℕ) : (n : ℍ[R,c₁,c₂,c₃]).imJ = 0 :=
+theorem imJ_natCast (n : ℕ) : (n : ℍ[R,c₁,c₂,c₃]).imJ = 0 :=
   rfl
 
 @[simp, norm_cast]
-theorem natCast_imK (n : ℕ) : (n : ℍ[R,c₁,c₂,c₃]).imK = 0 :=
+theorem imK_natCast (n : ℕ) : (n : ℍ[R,c₁,c₂,c₃]).imK = 0 :=
   rfl
 
 @[simp, norm_cast]
-theorem natCast_im (n : ℕ) : (n : ℍ[R,c₁,c₂,c₃]).im = 0 :=
+theorem im_natCast (n : ℕ) : (n : ℍ[R,c₁,c₂,c₃]).im = 0 :=
   rfl
 
 @[norm_cast]
@@ -358,38 +361,38 @@ theorem coe_natCast (n : ℕ) : ↑(n : R) = (n : ℍ[R,c₁,c₂,c₃]) :=
   rfl
 
 @[simp, norm_cast]
-theorem intCast_re (z : ℤ) : (z : ℍ[R,c₁,c₂,c₃]).re = z :=
+theorem re_intCast (z : ℤ) : (z : ℍ[R,c₁,c₂,c₃]).re = z :=
   rfl
 
 @[scoped simp]
-theorem ofNat_re (n : ℕ) [n.AtLeastTwo] : (ofNat(n) : ℍ[R,c₁,c₂,c₃]).re = ofNat(n) := rfl
+theorem re_ofNat (n : ℕ) [n.AtLeastTwo] : (ofNat(n) : ℍ[R,c₁,c₂,c₃]).re = ofNat(n) := rfl
 
 @[scoped simp]
-theorem ofNat_imI (n : ℕ) [n.AtLeastTwo] : (ofNat(n) : ℍ[R,c₁,c₂,c₃]).imI = 0 := rfl
+theorem imI_ofNat (n : ℕ) [n.AtLeastTwo] : (ofNat(n) : ℍ[R,c₁,c₂,c₃]).imI = 0 := rfl
 
 @[scoped simp]
-theorem ofNat_imJ (n : ℕ) [n.AtLeastTwo] : (ofNat(n) : ℍ[R,c₁,c₂,c₃]).imJ = 0 := rfl
+theorem imJ_ofNat (n : ℕ) [n.AtLeastTwo] : (ofNat(n) : ℍ[R,c₁,c₂,c₃]).imJ = 0 := rfl
 
 @[scoped simp]
-theorem ofNat_imK (n : ℕ) [n.AtLeastTwo] : (ofNat(n) : ℍ[R,c₁,c₂,c₃]).imK = 0 := rfl
+theorem imK_ofNat (n : ℕ) [n.AtLeastTwo] : (ofNat(n) : ℍ[R,c₁,c₂,c₃]).imK = 0 := rfl
 
 @[scoped simp]
-theorem ofNat_im (n : ℕ) [n.AtLeastTwo] : (ofNat(n) : ℍ[R,c₁,c₂,c₃]).im = 0 := rfl
+theorem im_ofNat (n : ℕ) [n.AtLeastTwo] : (ofNat(n) : ℍ[R,c₁,c₂,c₃]).im = 0 := rfl
 
 @[simp, norm_cast]
-theorem intCast_imI (z : ℤ) : (z : ℍ[R,c₁,c₂,c₃]).imI = 0 :=
+theorem imI_intCast (z : ℤ) : (z : ℍ[R,c₁,c₂,c₃]).imI = 0 :=
   rfl
 
 @[simp, norm_cast]
-theorem intCast_imJ (z : ℤ) : (z : ℍ[R,c₁,c₂,c₃]).imJ = 0 :=
+theorem imJ_intCast (z : ℤ) : (z : ℍ[R,c₁,c₂,c₃]).imJ = 0 :=
   rfl
 
 @[simp, norm_cast]
-theorem intCast_imK (z : ℤ) : (z : ℍ[R,c₁,c₂,c₃]).imK = 0 :=
+theorem imK_intCast (z : ℤ) : (z : ℍ[R,c₁,c₂,c₃]).imK = 0 :=
   rfl
 
 @[simp, norm_cast]
-theorem intCast_im (z : ℤ) : (z : ℍ[R,c₁,c₂,c₃]).im = 0 :=
+theorem im_intCast (z : ℤ) : (z : ℍ[R,c₁,c₂,c₃]).im = 0 :=
   rfl
 
 @[norm_cast]
@@ -619,7 +622,7 @@ theorem star_smul' [Monoid S] [DistribMulAction S R] (s : S) (a : ℍ[R,c₁,0,c
     star (s • a) = s • star a :=
   QuaternionAlgebra.ext (by simp) (smul_neg _ _).symm (smul_neg _ _).symm (smul_neg _ _).symm
 
-theorem eq_re_of_eq_coe {a : ℍ[R,c₁,c₂,c₃]} {x : R} (h : a = x) : a = a.re := by rw [h, coe_re]
+theorem eq_re_of_eq_coe {a : ℍ[R,c₁,c₂,c₃]} {x : R} (h : a = x) : a = a.re := by rw [h, re_coe]
 
 theorem eq_re_iff_mem_range_coe {a : ℍ[R,c₁,c₂,c₃]} :
     a = a.re ↔ a ∈ Set.range (coe : R → ℍ[R,c₁,c₂,c₃]) :=
@@ -726,120 +729,120 @@ theorem ext : a.re = b.re → a.imI = b.imI → a.imJ = b.imJ → a.imK = b.imK 
 /-- The imaginary part of a quaternion. -/
 nonrec def im (x : ℍ[R]) : ℍ[R] := x.im
 
-@[simp] theorem im_re : a.im.re = 0 := rfl
+@[simp] theorem re_im : a.im.re = 0 := rfl
 
-@[simp] theorem im_imI : a.im.imI = a.imI := rfl
+@[simp] theorem imI_im : a.im.imI = a.imI := rfl
 
-@[simp] theorem im_imJ : a.im.imJ = a.imJ := rfl
+@[simp] theorem imJ_im : a.im.imJ = a.imJ := rfl
 
-@[simp] theorem im_imK : a.im.imK = a.imK := rfl
+@[simp] theorem imK_im : a.im.imK = a.imK := rfl
 
 @[simp] theorem im_idem : a.im.im = a.im := rfl
 
 @[simp] nonrec theorem re_add_im : ↑a.re + a.im = a := a.re_add_im
 
-@[simp] nonrec theorem sub_self_im : a - a.im = a.re := a.sub_self_im
+@[simp] nonrec theorem sub_im_self : a - a.im = a.re := a.sub_im_self
 
-@[simp] nonrec theorem sub_self_re : a - ↑a.re = a.im := a.sub_self_re
-
-@[simp, norm_cast]
-theorem coe_re : (x : ℍ[R]).re = x := rfl
+@[simp] nonrec theorem sub_re_self : a - ↑a.re = a.im := a.sub_re_self
 
 @[simp, norm_cast]
-theorem coe_imI : (x : ℍ[R]).imI = 0 := rfl
+theorem re_coe : (x : ℍ[R]).re = x := rfl
 
 @[simp, norm_cast]
-theorem coe_imJ : (x : ℍ[R]).imJ = 0 := rfl
+theorem imI_coe : (x : ℍ[R]).imI = 0 := rfl
 
 @[simp, norm_cast]
-theorem coe_imK : (x : ℍ[R]).imK = 0 := rfl
+theorem imJ_coe : (x : ℍ[R]).imJ = 0 := rfl
 
 @[simp, norm_cast]
-theorem coe_im : (x : ℍ[R]).im = 0 := rfl
+theorem imK_coe : (x : ℍ[R]).imK = 0 := rfl
 
-@[scoped simp] theorem zero_re : (0 : ℍ[R]).re = 0 := rfl
+@[simp, norm_cast]
+theorem im_coe : (x : ℍ[R]).im = 0 := rfl
 
-@[scoped simp] theorem zero_imI : (0 : ℍ[R]).imI = 0 := rfl
+@[scoped simp] theorem re_zero : (0 : ℍ[R]).re = 0 := rfl
 
-@[scoped simp] theorem zero_imJ : (0 : ℍ[R]).imJ = 0 := rfl
+@[scoped simp] theorem imI_zero : (0 : ℍ[R]).imI = 0 := rfl
 
-@[scoped simp] theorem zero_imK : (0 : ℍ[R]).imK = 0 := rfl
+@[scoped simp] theorem imJ_zero : (0 : ℍ[R]).imJ = 0 := rfl
 
-@[scoped simp] theorem zero_im : (0 : ℍ[R]).im = 0 := rfl
+@[scoped simp] theorem imK_zero : (0 : ℍ[R]).imK = 0 := rfl
+
+@[scoped simp] theorem im_zero : (0 : ℍ[R]).im = 0 := rfl
 
 @[simp, norm_cast]
 theorem coe_zero : ((0 : R) : ℍ[R]) = 0 := rfl
 
-@[scoped simp] theorem one_re : (1 : ℍ[R]).re = 1 := rfl
+@[scoped simp] theorem re_one : (1 : ℍ[R]).re = 1 := rfl
 
-@[scoped simp] theorem one_imI : (1 : ℍ[R]).imI = 0 := rfl
+@[scoped simp] theorem imI_one : (1 : ℍ[R]).imI = 0 := rfl
 
-@[scoped simp] theorem one_imJ : (1 : ℍ[R]).imJ = 0 := rfl
+@[scoped simp] theorem imJ_one : (1 : ℍ[R]).imJ = 0 := rfl
 
-@[scoped simp] theorem one_imK : (1 : ℍ[R]).imK = 0 := rfl
+@[scoped simp] theorem imK_one : (1 : ℍ[R]).imK = 0 := rfl
 
-@[scoped simp] theorem one_im : (1 : ℍ[R]).im = 0 := rfl
+@[scoped simp] theorem im_one : (1 : ℍ[R]).im = 0 := rfl
 
 @[simp, norm_cast]
 theorem coe_one : ((1 : R) : ℍ[R]) = 1 := rfl
 
-@[simp] theorem add_re : (a + b).re = a.re + b.re := rfl
+@[simp] theorem re_add : (a + b).re = a.re + b.re := rfl
 
-@[simp] theorem add_imI : (a + b).imI = a.imI + b.imI := rfl
+@[simp] theorem imI_add : (a + b).imI = a.imI + b.imI := rfl
 
-@[simp] theorem add_imJ : (a + b).imJ = a.imJ + b.imJ := rfl
+@[simp] theorem imJ_add : (a + b).imJ = a.imJ + b.imJ := rfl
 
-@[simp] theorem add_imK : (a + b).imK = a.imK + b.imK := rfl
+@[simp] theorem imK_add : (a + b).imK = a.imK + b.imK := rfl
 
-@[simp] nonrec theorem add_im : (a + b).im = a.im + b.im := a.add_im b
+@[simp] nonrec theorem im_add : (a + b).im = a.im + b.im := a.im_add b
 
 @[simp, norm_cast]
 theorem coe_add : ((x + y : R) : ℍ[R]) = x + y :=
   QuaternionAlgebra.coe_add x y
 
-@[simp] theorem neg_re : (-a).re = -a.re := rfl
+@[simp] theorem re_neg : (-a).re = -a.re := rfl
 
-@[simp] theorem neg_imI : (-a).imI = -a.imI := rfl
+@[simp] theorem imI_neg : (-a).imI = -a.imI := rfl
 
-@[simp] theorem neg_imJ : (-a).imJ = -a.imJ := rfl
+@[simp] theorem imJ_neg : (-a).imJ = -a.imJ := rfl
 
-@[simp] theorem neg_imK : (-a).imK = -a.imK := rfl
+@[simp] theorem imK_neg : (-a).imK = -a.imK := rfl
 
-@[simp] nonrec theorem neg_im : (-a).im = -a.im := a.neg_im
+@[simp] nonrec theorem im_neg : (-a).im = -a.im := a.im_neg
 
 @[simp, norm_cast]
 theorem coe_neg : ((-x : R) : ℍ[R]) = -x :=
   QuaternionAlgebra.coe_neg x
 
-@[simp] theorem sub_re : (a - b).re = a.re - b.re := rfl
+@[simp] theorem re_sub : (a - b).re = a.re - b.re := rfl
 
-@[simp] theorem sub_imI : (a - b).imI = a.imI - b.imI := rfl
+@[simp] theorem imI_sub : (a - b).imI = a.imI - b.imI := rfl
 
-@[simp] theorem sub_imJ : (a - b).imJ = a.imJ - b.imJ := rfl
+@[simp] theorem imJ_sub : (a - b).imJ = a.imJ - b.imJ := rfl
 
-@[simp] theorem sub_imK : (a - b).imK = a.imK - b.imK := rfl
+@[simp] theorem imK_sub : (a - b).imK = a.imK - b.imK := rfl
 
-@[simp] nonrec theorem sub_im : (a - b).im = a.im - b.im := a.sub_im b
+@[simp] nonrec theorem im_sub : (a - b).im = a.im - b.im := a.im_sub b
 
 @[simp, norm_cast]
 theorem coe_sub : ((x - y : R) : ℍ[R]) = x - y :=
   QuaternionAlgebra.coe_sub x y
 
 @[simp]
-theorem mul_re : (a * b).re = a.re * b.re - a.imI * b.imI - a.imJ * b.imJ - a.imK * b.imK :=
-  (QuaternionAlgebra.mul_re a b).trans <| by simp [one_mul, neg_mul, sub_eq_add_neg, neg_neg]
+theorem re_mul : (a * b).re = a.re * b.re - a.imI * b.imI - a.imJ * b.imJ - a.imK * b.imK :=
+  (QuaternionAlgebra.re_mul a b).trans <| by simp [one_mul, neg_mul, sub_eq_add_neg, neg_neg]
 
 @[simp]
-theorem mul_imI : (a * b).imI = a.re * b.imI + a.imI * b.re + a.imJ * b.imK - a.imK * b.imJ :=
-  (QuaternionAlgebra.mul_imI a b).trans <| by ring
+theorem imI_mul : (a * b).imI = a.re * b.imI + a.imI * b.re + a.imJ * b.imK - a.imK * b.imJ :=
+  (QuaternionAlgebra.imI_mul a b).trans <| by ring
 
 @[simp]
-theorem mul_imJ : (a * b).imJ = a.re * b.imJ - a.imI * b.imK + a.imJ * b.re + a.imK * b.imI :=
-  (QuaternionAlgebra.mul_imJ a b).trans <| by ring
+theorem imJ_mul : (a * b).imJ = a.re * b.imJ - a.imI * b.imK + a.imJ * b.re + a.imK * b.imI :=
+  (QuaternionAlgebra.imJ_mul a b).trans <| by ring
 
 @[simp]
-theorem mul_imK : (a * b).imK = a.re * b.imK + a.imI * b.imJ - a.imJ * b.imI + a.imK * b.re :=
-  (QuaternionAlgebra.mul_imK a b).trans <| by ring
+theorem imK_mul : (a * b).imK = a.re * b.imK + a.imI * b.imJ - a.imJ * b.imI + a.imK * b.re :=
+  (QuaternionAlgebra.imK_mul a b).trans <| by ring
 
 @[simp, norm_cast]
 theorem coe_mul : ((x * y : R) : ℍ[R]) = x * y := QuaternionAlgebra.coe_mul x y
@@ -849,37 +852,37 @@ theorem coe_pow (n : ℕ) : (↑(x ^ n) : ℍ[R]) = (x : ℍ[R]) ^ n :=
   QuaternionAlgebra.coe_pow x n
 
 @[simp, norm_cast]
-theorem natCast_re (n : ℕ) : (n : ℍ[R]).re = n := rfl
+theorem re_natCast (n : ℕ) : (n : ℍ[R]).re = n := rfl
 
 @[simp, norm_cast]
-theorem natCast_imI (n : ℕ) : (n : ℍ[R]).imI = 0 := rfl
+theorem imI_natCast (n : ℕ) : (n : ℍ[R]).imI = 0 := rfl
 
 @[simp, norm_cast]
-theorem natCast_imJ (n : ℕ) : (n : ℍ[R]).imJ = 0 := rfl
+theorem imJ_natCast (n : ℕ) : (n : ℍ[R]).imJ = 0 := rfl
 
 @[simp, norm_cast]
-theorem natCast_imK (n : ℕ) : (n : ℍ[R]).imK = 0 := rfl
+theorem imK_natCast (n : ℕ) : (n : ℍ[R]).imK = 0 := rfl
 
 @[simp, norm_cast]
-theorem natCast_im (n : ℕ) : (n : ℍ[R]).im = 0 := rfl
+theorem im_natCast (n : ℕ) : (n : ℍ[R]).im = 0 := rfl
 
 @[norm_cast]
 theorem coe_natCast (n : ℕ) : ↑(n : R) = (n : ℍ[R]) := rfl
 
 @[simp, norm_cast]
-theorem intCast_re (z : ℤ) : (z : ℍ[R]).re = z := rfl
+theorem re_intCast (z : ℤ) : (z : ℍ[R]).re = z := rfl
 
 @[simp, norm_cast]
-theorem intCast_imI (z : ℤ) : (z : ℍ[R]).imI = 0 := rfl
+theorem imI_intCast (z : ℤ) : (z : ℍ[R]).imI = 0 := rfl
 
 @[simp, norm_cast]
-theorem intCast_imJ (z : ℤ) : (z : ℍ[R]).imJ = 0 := rfl
+theorem imJ_intCast (z : ℤ) : (z : ℍ[R]).imJ = 0 := rfl
 
 @[simp, norm_cast]
-theorem intCast_imK (z : ℤ) : (z : ℍ[R]).imK = 0 := rfl
+theorem imK_intCast (z : ℤ) : (z : ℍ[R]).imK = 0 := rfl
 
 @[simp, norm_cast]
-theorem intCast_im (z : ℤ) : (z : ℍ[R]).im = 0 := rfl
+theorem im_intCast (z : ℤ) : (z : ℍ[R]).im = 0 := rfl
 
 @[norm_cast]
 theorem coe_intCast (z : ℤ) : ↑(z : R) = (z : ℍ[R]) := rfl
@@ -892,18 +895,18 @@ theorem coe_inj {x y : R} : (x : ℍ[R]) = y ↔ x = y :=
   coe_injective.eq_iff
 
 @[simp]
-theorem smul_re [SMul S R] (s : S) : (s • a).re = s • a.re :=
+theorem re_smul [SMul S R] (s : S) : (s • a).re = s • a.re :=
   rfl
 
-@[simp] theorem smul_imI [SMul S R] (s : S) : (s • a).imI = s • a.imI := rfl
+@[simp] theorem imI_smul [SMul S R] (s : S) : (s • a).imI = s • a.imI := rfl
 
-@[simp] theorem smul_imJ [SMul S R] (s : S) : (s • a).imJ = s • a.imJ := rfl
+@[simp] theorem imJ_smul [SMul S R] (s : S) : (s • a).imJ = s • a.imJ := rfl
 
-@[simp] theorem smul_imK [SMul S R] (s : S) : (s • a).imK = s • a.imK := rfl
+@[simp] theorem imK_smul [SMul S R] (s : S) : (s • a).imK = s • a.imK := rfl
 
 @[simp]
-nonrec theorem smul_im [SMulZeroClass S R] (s : S) : (s • a).im = s • a.im :=
-  a.smul_im s
+nonrec theorem im_smul [SMulZeroClass S R] (s : S) : (s • a).im = s • a.im :=
+  a.im_smul s
 
 @[simp, norm_cast]
 theorem coe_smul [SMulZeroClass S R] (s : S) (r : R) : (↑(s • r) : ℍ[R]) = s • (r : ℍ[R]) :=
@@ -940,16 +943,16 @@ theorem rank_eq_four [StrongRankCondition R] : Module.rank R ℍ[R] = 4 :=
 theorem finrank_eq_four [StrongRankCondition R] : Module.finrank R ℍ[R] = 4 :=
   QuaternionAlgebra.finrank_eq_four _ _ _
 
-@[simp] theorem star_re : (star a).re = a.re := by
+@[simp] theorem re_star : (star a).re = a.re := by
   rw [QuaternionAlgebra.re_star, zero_mul, add_zero]
 
-@[simp] theorem star_imI : (star a).imI = -a.imI := rfl
+@[simp] theorem imI_star : (star a).imI = -a.imI := rfl
 
-@[simp] theorem star_imJ : (star a).imJ = -a.imJ := rfl
+@[simp] theorem imJ_star : (star a).imJ = -a.imJ := rfl
 
-@[simp] theorem star_imK : (star a).imK = -a.imK := rfl
+@[simp] theorem imK_star : (star a).imK = -a.imK := rfl
 
-@[simp] theorem star_im : (star a).im = -a.im := a.im_star
+@[simp] theorem im_star : (star a).im = -a.im := QuaternionAlgebra.im_star a
 
 nonrec theorem self_add_star' : a + star a = ↑(2 * a.re) := by
   simp [a.self_add_star', Quaternion.coe]
@@ -971,7 +974,7 @@ theorem star_coe : star (x : ℍ[R]) = x :=
   QuaternionAlgebra.star_coe x
 
 @[simp]
-theorem im_star : star a.im = -a.im := by ext <;> simp
+theorem star_im : star a.im = -a.im := by ext <;> simp
 
 @[simp]
 theorem star_smul [Monoid S] [DistribMulAction S R] (s : S) (a : ℍ[R]) :
@@ -1016,8 +1019,8 @@ theorem coe_starAe : ⇑(starAe : ℍ[R] ≃ₐ[R] ℍ[R]ᵐᵒᵖ) = op ∘ sta
 /-- Square of the norm. -/
 def normSq : ℍ[R] →*₀ R where
   toFun a := (a * star a).re
-  map_zero' := by simp only [star_zero, zero_mul, zero_re]
-  map_one' := by simp only [star_one, one_mul, one_re]
+  map_zero' := by simp only [star_zero, zero_mul, re_zero]
+  map_one' := by simp only [star_one, one_mul, re_one]
   map_mul' x y := coe_injective <| by
     conv_lhs => rw [← mul_star_eq_coe, star_mul, mul_assoc, ← mul_assoc y, y.mul_star_eq_coe,
       coe_commutes, ← mul_assoc, x.mul_star_eq_coe, ← coe_mul]
@@ -1025,11 +1028,11 @@ def normSq : ℍ[R] →*₀ R where
 theorem normSq_def : normSq a = (a * star a).re := rfl
 
 theorem normSq_def' : normSq a = a.1 ^ 2 + a.2 ^ 2 + a.3 ^ 2 + a.4 ^ 2 := by
-  simp only [normSq_def, sq, mul_neg, sub_neg_eq_add, mul_re, star_re, star_imI, star_imJ,
-    star_imK]
+  simp only [normSq_def, sq, mul_neg, sub_neg_eq_add, re_mul, re_star, imI_star, imJ_star,
+    imK_star]
 
 theorem normSq_coe : normSq (x : ℍ[R]) = x ^ 2 := by
-  rw [normSq_def, star_coe, ← coe_mul, coe_re, sq]
+  rw [normSq_def, star_coe, ← coe_mul, re_coe, sq]
 
 @[simp]
 theorem normSq_star : normSq (star a) = normSq a := by simp [normSq_def']
@@ -1050,21 +1053,21 @@ theorem self_mul_star : a * star a = normSq a := by rw [mul_star_eq_coe, normSq_
 theorem star_mul_self : star a * a = normSq a := by rw [star_comm_self, self_mul_star]
 
 theorem im_sq : a.im ^ 2 = -normSq a.im := by
-  simp_rw [sq, ← star_mul_self, im_star, neg_mul, neg_neg]
+  simp_rw [sq, ← star_mul_self, star_im, neg_mul, neg_neg]
 
 theorem coe_normSq_add : normSq (a + b) = normSq a + a * star b + b * star a + normSq b := by
   simp only [star_add, ← self_mul_star, mul_add, add_mul, add_assoc, add_left_comm]
 
 theorem normSq_smul (r : R) (q : ℍ[R]) : normSq (r • q) = r ^ 2 * normSq q := by
-  simp only [normSq_def', smul_re, smul_imI, smul_imJ, smul_imK, mul_pow, mul_add, smul_eq_mul]
+  simp only [normSq_def', re_smul, imI_smul, imJ_smul, imK_smul, mul_pow, mul_add, smul_eq_mul]
 
 theorem normSq_add (a b : ℍ[R]) : normSq (a + b) = normSq a + normSq b + 2 * (a * star b).re :=
   calc
     normSq (a + b) = normSq a + (a * star b).re + ((b * star a).re + normSq b) := by
-      simp_rw [normSq_def, star_add, add_mul, mul_add, add_re]
+      simp_rw [normSq_def, star_add, add_mul, mul_add, re_add]
     _ = normSq a + normSq b + ((a * star b).re + (b * star a).re) := by abel
     _ = normSq a + normSq b + 2 * (a * star b).re := by
-      rw [← add_re, ← star_mul_star a b, self_add_star', coe_re]
+      rw [← re_add, ← star_mul_star a b, self_add_star', re_coe]
 
 end Quaternion
 
@@ -1129,11 +1132,11 @@ instance instRatCast : RatCast ℍ[R] where ratCast q := (q : R)
 @[simp, norm_cast] lemma imI_nnratCast (q : ℚ≥0) : (q : ℍ[R]).imI = 0 := rfl
 @[simp, norm_cast] lemma imJ_nnratCast (q : ℚ≥0) : (q : ℍ[R]).imJ = 0 := rfl
 @[simp, norm_cast] lemma imK_nnratCast (q : ℚ≥0) : (q : ℍ[R]).imK = 0 := rfl
-@[simp, norm_cast] lemma ratCast_re (q : ℚ) : (q : ℍ[R]).re = q := rfl
-@[simp, norm_cast] lemma ratCast_im (q : ℚ) : (q : ℍ[R]).im = 0 := rfl
-@[simp, norm_cast] lemma ratCast_imI (q : ℚ) : (q : ℍ[R]).imI = 0 := rfl
-@[simp, norm_cast] lemma ratCast_imJ (q : ℚ) : (q : ℍ[R]).imJ = 0 := rfl
-@[simp, norm_cast] lemma ratCast_imK (q : ℚ) : (q : ℍ[R]).imK = 0 := rfl
+@[simp, norm_cast] lemma re_ratCast (q : ℚ) : (q : ℍ[R]).re = q := rfl
+@[simp, norm_cast] lemma im_ratCast (q : ℚ) : (q : ℍ[R]).im = 0 := rfl
+@[simp, norm_cast] lemma imI_ratCast (q : ℚ) : (q : ℍ[R]).imI = 0 := rfl
+@[simp, norm_cast] lemma imJ_ratCast (q : ℚ) : (q : ℍ[R]).imJ = 0 := rfl
+@[simp, norm_cast] lemma imK_ratCast (q : ℚ) : (q : ℍ[R]).imK = 0 := rfl
 
 @[norm_cast] lemma coe_nnratCast (q : ℚ≥0) : ↑(q : R) = (q : ℍ[R]) := rfl
 

--- a/Mathlib/Algebra/QuaternionBasis.lean
+++ b/Mathlib/Algebra/QuaternionBasis.lean
@@ -45,6 +45,9 @@ structure Basis {R : Type*} (A : Type*) [CommRing R] [Ring A] [Algebra R A] (c�
   i_mul_j : i * j = k
   j_mul_i : j * i = c₂ • j - k
 
+initialize_simps_projections Basis
+  (as_prefix i, as_prefix j, as_prefix k)
+
 variable {R : Type*} {A B : Type*} [CommRing R] [Ring A] [Ring B] [Algebra R A] [Algebra R B]
 variable {c₁ c₂ c₃ : R}
 
@@ -111,7 +114,7 @@ theorem lift_zero : q.lift (0 : ℍ[R,c₁,c₂,c₃]) = 0 := by simp [lift]
 theorem lift_one : q.lift (1 : ℍ[R,c₁,c₂,c₃]) = 1 := by simp [lift]
 
 theorem lift_add (x y : ℍ[R,c₁,c₂,c₃]) : q.lift (x + y) = q.lift x + q.lift y := by
-  simp only [lift, add_re, map_add, add_imI, add_smul, add_imJ, add_imK]
+  simp only [lift, re_add, map_add, imI_add, add_smul, imJ_add, imK_add]
   abel
 
 theorem lift_mul (x y : ℍ[R,c₁,c₂,c₃]) : q.lift (x * y) = q.lift x * q.lift y := by
@@ -123,7 +126,7 @@ theorem lift_mul (x y : ℍ[R,c₁,c₂,c₃]) : q.lift (x * y) = q.lift x * q.l
   simp only [mul_comm _ c₁]
   simp only [mul_right_comm _ _ c₃]
   simp only [← mul_assoc]
-  simp only [mul_re, sub_eq_add_neg, add_smul, neg_smul, mul_imI, ← add_assoc, mul_imJ, mul_imK]
+  simp only [re_mul, sub_eq_add_neg, add_smul, neg_smul, imI_mul, ← add_assoc, imJ_mul, imK_mul]
   linear_combination (norm := module)
 
 theorem lift_smul (r : R) (x : ℍ[R,c₁,c₂,c₃]) : q.lift (r • x) = r • q.lift x := by

--- a/Mathlib/Analysis/Normed/Algebra/QuaternionExponential.lean
+++ b/Mathlib/Analysis/Normed/Algebra/QuaternionExponential.lean
@@ -101,7 +101,7 @@ theorem exp_of_re_eq_zero (q : Quaternion ℝ) (hq : q.re = 0) :
 /-- The closed form for the quaternion exponential on arbitrary quaternions. -/
 theorem exp_eq (q : Quaternion ℝ) :
     exp ℝ q = exp ℝ q.re • (↑(Real.cos ‖q.im‖) + (Real.sin ‖q.im‖ / ‖q.im‖) • q.im) := by
-  rw [← exp_of_re_eq_zero q.im q.im_re, ← coe_mul_eq_smul, ← exp_coe, ← exp_add_of_commute,
+  rw [← exp_of_re_eq_zero q.im q.re_im, ← coe_mul_eq_smul, ← exp_coe, ← exp_add_of_commute,
     re_add_im]
   exact Algebra.commutes q.re (_ : ℍ[ℝ])
 
@@ -121,7 +121,7 @@ theorem normSq_exp (q : ℍ[ℝ]) : normSq (exp ℝ q) = exp ℝ q.re ^ 2 :=
       congr 1
       obtain hv | hv := eq_or_ne ‖q.im‖ 0
       · simp [hv]
-      rw [normSq_add, normSq_smul, star_smul, coe_mul_eq_smul, smul_re, smul_re, star_re, im_re,
+      rw [normSq_add, normSq_smul, star_smul, coe_mul_eq_smul, re_smul, re_smul, re_star, re_im,
         smul_zero, smul_zero, mul_zero, add_zero, div_pow, normSq_coe,
         normSq_eq_norm_mul_self, ← sq, div_mul_cancel₀ _ (pow_ne_zero _ hv)]
     _ = exp ℝ q.re ^ 2 := by rw [Real.cos_sq_add_sin_sq, mul_one]

--- a/Mathlib/Analysis/Quaternion.lean
+++ b/Mathlib/Analysis/Quaternion.lean
@@ -101,17 +101,25 @@ instance : Coe ℂ ℍ := ⟨coeComplex⟩
 theorem re_coeComplex (z : ℂ) : (z : ℍ).re = z.re :=
   rfl
 
+@[deprecated (since := "2025-08-31")] alias coeComplex_re := re_coeComplex
+
 @[simp, norm_cast]
 theorem imI_coeComplex (z : ℂ) : (z : ℍ).imI = z.im :=
   rfl
+
+@[deprecated (since := "2025-08-31")] alias coeComplex_imI := imI_coeComplex
 
 @[simp, norm_cast]
 theorem imJ_coeComplex (z : ℂ) : (z : ℍ).imJ = 0 :=
   rfl
 
+@[deprecated (since := "2025-08-31")] alias coeComplex_imJ := imJ_coeComplex
+
 @[simp, norm_cast]
 theorem imK_coeComplex (z : ℂ) : (z : ℍ).imK = 0 :=
   rfl
+
+@[deprecated (since := "2025-08-31")] alias coeComplex_imK := imK_coeComplex
 
 @[simp, norm_cast]
 theorem coeComplex_add (z w : ℂ) : ↑(z + w) = (z + w : ℍ) := by ext <;> simp

--- a/Mathlib/Analysis/Quaternion.lean
+++ b/Mathlib/Analysis/Quaternion.lean
@@ -52,7 +52,7 @@ noncomputable instance : NormedAddCommGroup ℍ :=
       conj_inner_symm := fun x y => by simp [inner_def, mul_comm]
       re_inner_nonneg := fun _ => normSq_nonneg
       definite := fun _ => normSq_eq_zero.1
-      add_left := fun x y z => by simp only [inner_def, add_mul, add_re]
+      add_left := fun x y z => by simp only [inner_def, add_mul, re_add]
       smul_left := fun x y r => by simp [inner_def] }
 
 noncomputable instance : InnerProductSpace ℝ ℍ :=
@@ -98,19 +98,19 @@ instance : CStarRing ℍ where
 instance : Coe ℂ ℍ := ⟨coeComplex⟩
 
 @[simp, norm_cast]
-theorem coeComplex_re (z : ℂ) : (z : ℍ).re = z.re :=
+theorem re_coeComplex (z : ℂ) : (z : ℍ).re = z.re :=
   rfl
 
 @[simp, norm_cast]
-theorem coeComplex_imI (z : ℂ) : (z : ℍ).imI = z.im :=
+theorem imI_coeComplex (z : ℂ) : (z : ℍ).imI = z.im :=
   rfl
 
 @[simp, norm_cast]
-theorem coeComplex_imJ (z : ℂ) : (z : ℍ).imJ = 0 :=
+theorem imJ_coeComplex (z : ℂ) : (z : ℍ).imJ = 0 :=
   rfl
 
 @[simp, norm_cast]
-theorem coeComplex_imK (z : ℂ) : (z : ℍ).imK = 0 :=
+theorem imK_coeComplex (z : ℂ) : (z : ℍ).imK = 0 :=
   rfl
 
 @[simp, norm_cast]
@@ -189,7 +189,7 @@ theorem continuous_imK : Continuous fun q : ℍ => q.imK :=
 
 @[continuity]
 theorem continuous_im : Continuous fun q : ℍ => q.im := by
-  simpa only [← sub_self_re] using continuous_id.sub (continuous_coe.comp continuous_re)
+  simpa only [← sub_re_self] using continuous_id.sub (continuous_coe.comp continuous_re)
 
 instance : CompleteSpace ℍ :=
   haveI : IsUniformEmbedding linearIsometryEquivTuple.toLinearEquiv.toEquiv.symm :=
@@ -212,7 +212,7 @@ theorem summable_coe {f : α → ℝ} : (Summable fun a => (f a : ℍ)) ↔ Summ
   simpa only using
     Summable.map_iff_of_leftInverse (algebraMap ℝ ℍ) (show ℍ →ₗ[ℝ] ℝ from
       QuaternionAlgebra.reₗ _ _ _)
-      (continuous_algebraMap _ _) continuous_re coe_re
+      (continuous_algebraMap _ _) continuous_re re_coe
 
 @[norm_cast]
 theorem tsum_coe (f : α → ℝ) : (∑' a, (f a : ℍ)) = ↑(∑' a, f a) := by


### PR DESCRIPTION
This renames lemmas of the form `(foo x).re` to be called `re_foo` instead of `foo_re`, and similarly for `imI`, `imJ`, `imK`, and `im`, to match the naming guide.

These are then all deprecated with the deprecation script.
I did not attempt to deprecated the relocated `simps` lemmas.
Some lemmas ended up exchanged and could not be deprecated, listed below:

Moves:
- Quaternion.im_star -> Quaternion.star_im
- Quaternion.star_im-> Quaternion.im_star
- QuaternionAlgebra.im_star -> QuaternionAlgebra.star_im
- QuaternionAlgebra.star_im-> QuaternionAlgebra.im_star

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include at least one commit authored by each
co-author among the commits in the pull request. If necessary, you may 
create empty commits to indicate co-authorship, using commands like so:

git commit --author="Author Name <author@email.com>" --allow-empty -m "add Author Name as coauthor"

When merging, all the commits will be squashed into a single commit listing all co-authors.

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
