### PR TITLE
[Merged by Bors] - refactor: correct names of Zsqrtd lemmas

### DIFF
--- a/Mathlib/NumberTheory/PellMatiyasevic.lean
+++ b/Mathlib/NumberTheory/PellMatiyasevic.lean
@@ -171,9 +171,13 @@ def pellZd (n : ℕ) : ℤ√(d a1) :=
 theorem re_pellZd (n : ℕ) : (pellZd a1 n).re = xn a1 n :=
   rfl
 
+@[deprecated (since := "2025-08-31")] alias pellZd_re := re_pellZd
+
 @[simp]
 theorem im_pellZd (n : ℕ) : (pellZd a1 n).im = yn a1 n :=
   rfl
+
+@[deprecated (since := "2025-08-31")] alias pellZd_im := im_pellZd
 
 theorem isPell_nat {x y : ℕ} : IsPell (⟨x, y⟩ : ℤ√(d a1)) ↔ x * x - d a1 * y * y = 1 :=
   ⟨fun h =>

--- a/Mathlib/NumberTheory/PellMatiyasevic.lean
+++ b/Mathlib/NumberTheory/PellMatiyasevic.lean
@@ -168,11 +168,11 @@ def pellZd (n : ℕ) : ℤ√(d a1) :=
   ⟨xn a1 n, yn a1 n⟩
 
 @[simp]
-theorem pellZd_re (n : ℕ) : (pellZd a1 n).re = xn a1 n :=
+theorem re_pellZd (n : ℕ) : (pellZd a1 n).re = xn a1 n :=
   rfl
 
 @[simp]
-theorem pellZd_im (n : ℕ) : (pellZd a1 n).im = yn a1 n :=
+theorem im_pellZd (n : ℕ) : (pellZd a1 n).im = yn a1 n :=
   rfl
 
 theorem isPell_nat {x y : ℕ} : IsPell (⟨x, y⟩ : ℤ√(d a1)) ↔ x * x - d a1 * y * y = 1 :=
@@ -265,8 +265,8 @@ theorem eq_pell_lem : ∀ (n) (b : ℤ√(d a1)), 1 ≤ b → IsPell b →
                       (mul_le_mul_of_nonneg_left hn (le_trans zero_le_one h1)) a1p
               rw [bm, one_mul, mul_assoc, Eq.trans (mul_comm _ _) a1m, mul_one] at t
               exact ha t
-        simp only [sub_self, sub_neg_eq_add] at y0l; simp only [Zsqrtd.neg_re, add_neg_cancel,
-          Zsqrtd.neg_im, neg_neg] at yl2
+        simp only [sub_self, sub_neg_eq_add] at y0l; simp only [Zsqrtd.re_neg, add_neg_cancel,
+          Zsqrtd.im_neg, neg_neg] at yl2
         exact
           match y, y0l, (yl2 : (⟨_, _⟩ : ℤ√_) < ⟨_, _⟩) with
           | 0, y0l, _ => y0l (le_refl 0)

--- a/Mathlib/NumberTheory/Zsqrtd/Basic.lean
+++ b/Mathlib/NumberTheory/Zsqrtd/Basic.lean
@@ -45,10 +45,10 @@ variable {d : ℤ}
 def ofInt (n : ℤ) : ℤ√d :=
   ⟨n, 0⟩
 
-theorem ofInt_re (n : ℤ) : (ofInt n : ℤ√d).re = n :=
+theorem re_ofInt (n : ℤ) : (ofInt n : ℤ√d).re = n :=
   rfl
 
-theorem ofInt_im (n : ℤ) : (ofInt n : ℤ√d).im = 0 :=
+theorem im_ofInt (n : ℤ) : (ofInt n : ℤ√d).im = 0 :=
   rfl
 
 /-- The zero of the ring -/
@@ -56,11 +56,11 @@ instance : Zero (ℤ√d) :=
   ⟨ofInt 0⟩
 
 @[simp]
-theorem zero_re : (0 : ℤ√d).re = 0 :=
+theorem re_zero : (0 : ℤ√d).re = 0 :=
   rfl
 
 @[simp]
-theorem zero_im : (0 : ℤ√d).im = 0 :=
+theorem im_zero : (0 : ℤ√d).im = 0 :=
   rfl
 
 instance : Inhabited (ℤ√d) :=
@@ -71,11 +71,11 @@ instance : One (ℤ√d) :=
   ⟨ofInt 1⟩
 
 @[simp]
-theorem one_re : (1 : ℤ√d).re = 1 :=
+theorem re_one : (1 : ℤ√d).re = 1 :=
   rfl
 
 @[simp]
-theorem one_im : (1 : ℤ√d).im = 0 :=
+theorem im_one : (1 : ℤ√d).im = 0 :=
   rfl
 
 /-- The representative of `√d` in the ring -/
@@ -83,11 +83,11 @@ def sqrtd : ℤ√d :=
   ⟨0, 1⟩
 
 @[simp]
-theorem sqrtd_re : (sqrtd : ℤ√d).re = 0 :=
+theorem re_sqrtd : (sqrtd : ℤ√d).re = 0 :=
   rfl
 
 @[simp]
-theorem sqrtd_im : (sqrtd : ℤ√d).im = 1 :=
+theorem im_sqrtd : (sqrtd : ℤ√d).im = 1 :=
   rfl
 
 /-- Addition of elements of `ℤ√d` -/
@@ -99,11 +99,11 @@ theorem add_def (x y x' y' : ℤ) : (⟨x, y⟩ + ⟨x', y'⟩ : ℤ√d) = ⟨x
   rfl
 
 @[simp]
-theorem add_re (z w : ℤ√d) : (z + w).re = z.re + w.re :=
+theorem re_add (z w : ℤ√d) : (z + w).re = z.re + w.re :=
   rfl
 
 @[simp]
-theorem add_im (z w : ℤ√d) : (z + w).im = z.im + w.im :=
+theorem im_add (z w : ℤ√d) : (z + w).im = z.im + w.im :=
   rfl
 
 /-- Negation in `ℤ√d` -/
@@ -111,11 +111,11 @@ instance : Neg (ℤ√d) :=
   ⟨fun z => ⟨-z.1, -z.2⟩⟩
 
 @[simp]
-theorem neg_re (z : ℤ√d) : (-z).re = -z.re :=
+theorem re_neg (z : ℤ√d) : (-z).re = -z.re :=
   rfl
 
 @[simp]
-theorem neg_im (z : ℤ√d) : (-z).im = -z.im :=
+theorem im_neg (z : ℤ√d) : (-z).im = -z.im :=
   rfl
 
 /-- Multiplication in `ℤ√d` -/
@@ -123,11 +123,11 @@ instance : Mul (ℤ√d) :=
   ⟨fun z w => ⟨z.1 * w.1 + d * z.2 * w.2, z.1 * w.2 + z.2 * w.1⟩⟩
 
 @[simp]
-theorem mul_re (z w : ℤ√d) : (z * w).re = z.re * w.re + d * z.im * w.im :=
+theorem re_mul (z w : ℤ√d) : (z * w).re = z.re * w.re + d * z.im * w.im :=
   rfl
 
 @[simp]
-theorem mul_im (z w : ℤ√d) : (z * w).im = z.re * w.im + z.im * w.re :=
+theorem im_mul (z w : ℤ√d) : (z * w).im = z.re * w.im + z.im * w.re :=
   rfl
 
 instance addCommGroup : AddCommGroup (ℤ√d) := by
@@ -148,11 +148,11 @@ instance addCommGroup : AddCommGroup (ℤ√d) := by
   simp [add_comm, add_left_comm]
 
 @[simp]
-theorem sub_re (z w : ℤ√d) : (z - w).re = z.re - w.re :=
+theorem re_sub (z w : ℤ√d) : (z - w).re = z.re - w.re :=
   rfl
 
 @[simp]
-theorem sub_im (z w : ℤ√d) : (z - w).im = z.im - w.im :=
+theorem im_sub (z w : ℤ√d) : (z - w).im = z.im - w.im :=
   rfl
 
 instance addGroupWithOne : AddGroupWithOne (ℤ√d) :=
@@ -211,11 +211,11 @@ theorem star_mk (x y : ℤ) : star (⟨x, y⟩ : ℤ√d) = ⟨x, -y⟩ :=
   rfl
 
 @[simp]
-theorem star_re (z : ℤ√d) : (star z).re = z.re :=
+theorem re_star (z : ℤ√d) : (star z).re = z.re :=
   rfl
 
 @[simp]
-theorem star_im (z : ℤ√d) : (star z).im = -z.im :=
+theorem im_star (z : ℤ√d) : (star z).im = -z.im :=
   rfl
 
 instance : StarRing (ℤ√d) where
@@ -228,36 +228,36 @@ instance nontrivial : Nontrivial (ℤ√d) :=
   ⟨⟨0, 1, Zsqrtd.ext_iff.not.mpr (by simp)⟩⟩
 
 @[simp]
-theorem natCast_re (n : ℕ) : (n : ℤ√d).re = n :=
+theorem re_natCast (n : ℕ) : (n : ℤ√d).re = n :=
   rfl
 
 @[simp]
-theorem ofNat_re (n : ℕ) [n.AtLeastTwo] : (ofNat(n) : ℤ√d).re = n :=
+theorem re_ofNat (n : ℕ) [n.AtLeastTwo] : (ofNat(n) : ℤ√d).re = n :=
   rfl
 
 @[simp]
-theorem natCast_im (n : ℕ) : (n : ℤ√d).im = 0 :=
+theorem im_natCast (n : ℕ) : (n : ℤ√d).im = 0 :=
   rfl
 
 @[simp]
-theorem ofNat_im (n : ℕ) [n.AtLeastTwo] : (ofNat(n) : ℤ√d).im = 0 :=
+theorem im_ofNat (n : ℕ) [n.AtLeastTwo] : (ofNat(n) : ℤ√d).im = 0 :=
   rfl
 
 theorem natCast_val (n : ℕ) : (n : ℤ√d) = ⟨n, 0⟩ :=
   rfl
 
 @[simp]
-theorem intCast_re (n : ℤ) : (n : ℤ√d).re = n := by cases n <;> rfl
+theorem re_intCast (n : ℤ) : (n : ℤ√d).re = n := by cases n <;> rfl
 
 @[simp]
-theorem intCast_im (n : ℤ) : (n : ℤ√d).im = 0 := by cases n <;> rfl
+theorem im_intCast (n : ℤ) : (n : ℤ√d).im = 0 := by cases n <;> rfl
 
 theorem intCast_val (n : ℤ) : (n : ℤ√d) = ⟨n, 0⟩ := by ext <;> simp
 
 instance : CharZero (ℤ√d) where cast_injective m n := by simp [Zsqrtd.ext_iff]
 
 @[simp]
-theorem ofInt_eq_intCast (n : ℤ) : (ofInt n : ℤ√d) = n := by ext <;> simp [ofInt_re, ofInt_im]
+theorem ofInt_eq_intCast (n : ℤ) : (ofInt n : ℤ√d) = n := by ext <;> simp [re_ofInt, im_ofInt]
 
 @[simp]
 theorem nsmul_val (n : ℕ) (x y : ℤ) : (n : ℤ√d) * ⟨x, y⟩ = ⟨n * x, n * y⟩ := by ext <;> simp
@@ -265,9 +265,9 @@ theorem nsmul_val (n : ℕ) (x y : ℤ) : (n : ℤ√d) * ⟨x, y⟩ = ⟨n * x,
 @[simp]
 theorem smul_val (n x y : ℤ) : (n : ℤ√d) * ⟨x, y⟩ = ⟨n * x, n * y⟩ := by ext <;> simp
 
-theorem smul_re (a : ℤ) (b : ℤ√d) : (↑a * b).re = a * b.re := by simp
+theorem re_smul (a : ℤ) (b : ℤ√d) : (↑a * b).re = a * b.re := by simp
 
-theorem smul_im (a : ℤ) (b : ℤ√d) : (↑a * b).im = a * b.im := by simp
+theorem im_smul (a : ℤ) (b : ℤ√d) : (↑a * b).im = a * b.im := by simp
 
 @[simp]
 theorem muld_val (x y : ℤ) : sqrtd (d := d) * ⟨x, y⟩ = ⟨d * y, x⟩ := by ext <;> simp
@@ -286,8 +286,8 @@ theorem mul_star {x y : ℤ} : (⟨x, y⟩ * star ⟨x, y⟩ : ℤ√d) = x * x 
 theorem intCast_dvd (z : ℤ) (a : ℤ√d) : ↑z ∣ a ↔ z ∣ a.re ∧ z ∣ a.im := by
   constructor
   · rintro ⟨x, rfl⟩
-    simp only [add_zero, intCast_re, zero_mul, mul_im, dvd_mul_right, and_self_iff,
-      mul_re, mul_zero, intCast_im]
+    simp only [add_zero, re_intCast, zero_mul, im_mul, dvd_mul_right, and_self_iff,
+      re_mul, mul_zero, im_intCast]
   · rintro ⟨⟨r, hr⟩, ⟨i, hi⟩⟩
     use ⟨r, i⟩
     rw [smul_val, Zsqrtd.ext_iff]
@@ -298,19 +298,19 @@ theorem intCast_dvd_intCast (a b : ℤ) : (a : ℤ√d) ∣ b ↔ a ∣ b := by
   rw [intCast_dvd]
   constructor
   · rintro ⟨hre, -⟩
-    rwa [intCast_re] at hre
-  · rw [intCast_re, intCast_im]
+    rwa [re_intCast] at hre
+  · rw [re_intCast, im_intCast]
     exact fun hc => ⟨hc, dvd_zero a⟩
 
 protected theorem eq_of_smul_eq_smul_left {a : ℤ} {b c : ℤ√d} (ha : a ≠ 0) (h : ↑a * b = a * c) :
     b = c := by
   rw [Zsqrtd.ext_iff] at h ⊢
-  apply And.imp _ _ h <;> simpa only [smul_re, smul_im] using mul_left_cancel₀ ha
+  apply And.imp _ _ h <;> simpa only [re_smul, im_smul] using mul_left_cancel₀ ha
 
 section Gcd
 
 theorem gcd_eq_zero_iff (a : ℤ√d) : Int.gcd a.re a.im = 0 ↔ a = 0 := by
-  simp only [Int.gcd_eq_zero_iff, Zsqrtd.ext_iff, zero_im, zero_re]
+  simp only [Int.gcd_eq_zero_iff, Zsqrtd.ext_iff, im_zero, re_zero]
 
 theorem gcd_pos_iff (a : ℤ√d) : 0 < Int.gcd a.re a.im ↔ a ≠ 0 :=
   pos_iff_ne_zero.trans <| not_congr a.gcd_eq_zero_iff
@@ -321,7 +321,7 @@ theorem isCoprime_of_dvd_isCoprime {a b : ℤ√d} (hcoprime : IsCoprime a.re a.
   · rintro ⟨hre, him⟩
     obtain rfl : b = 0 := Zsqrtd.ext hre him
     rw [zero_dvd_iff] at hdvd
-    simp [hdvd, zero_im, zero_re, not_isCoprime_zero_zero] at hcoprime
+    simp [hdvd, im_zero, re_zero, not_isCoprime_zero_zero] at hcoprime
   · rintro z hz - hzdvdu hzdvdv
     apply hz
     obtain ⟨ha, hb⟩ : z ∣ a.re ∧ z ∣ a.im := by
@@ -445,7 +445,7 @@ theorem norm_natCast (n : ℕ) : norm (n : ℤ√d) = n * n :=
 
 @[simp]
 theorem norm_mul (n m : ℤ√d) : norm (n * m) = norm n * norm m := by
-  simp only [norm, mul_im, mul_re]
+  simp only [norm, im_mul, re_mul]
   ring
 
 /-- `norm` as a `MonoidHom`. -/
@@ -872,7 +872,7 @@ theorem norm_eq_zero {d : ℤ} (h_nonsquare : ∀ n : ℤ, d ≠ n * n) (a : ℤ
   · push_neg at h
     suffices a.re * a.re = 0 by
       rw [eq_zero_of_mul_self_eq_zero this] at ha ⊢
-      simpa only [true_and, or_self_right, zero_re, zero_im, eq_self_iff_true, zero_eq_mul,
+      simpa only [true_and, or_self_right, re_zero, im_zero, eq_self_iff_true, zero_eq_mul,
         mul_zero, mul_eq_zero, h.ne, false_or, or_self_iff] using ha
     apply _root_.le_antisymm _ (mul_self_nonneg _)
     rw [ha, mul_assoc]
@@ -882,7 +882,7 @@ variable {R : Type}
 
 @[ext]
 theorem hom_ext [NonAssocRing R] {d : ℤ} (f g : ℤ√d →+* R) (h : f sqrtd = g sqrtd) : f = g := by
-  ext ⟨x_re, x_im⟩
+  ext ⟨re_x, im_x⟩
   simp [decompose, h]
 
 variable [CommRing R]
@@ -895,7 +895,7 @@ def lift {d : ℤ} : { r : R // r * r = ↑d } ≃ (ℤ√d →+* R) where
     { toFun := fun a => a.1 + a.2 * (r : R)
       map_zero' := by simp
       map_add' := fun a b => by
-        simp only [add_re, Int.cast_add, add_im]
+        simp only [re_add, Int.cast_add, im_add]
         ring
       map_one' := by simp
       map_mul' := fun a b => by
@@ -903,7 +903,7 @@ def lift {d : ℤ} : { r : R // r * r = ↑d } ≃ (ℤ√d →+* R) where
           (a.re + a.im * r : R) * (b.re + b.im * r) =
             a.re * b.re + (a.re * b.im + a.im * b.re) * r + a.im * b.im * (r * r) := by
           ring
-        simp only [mul_re, Int.cast_add, Int.cast_mul, mul_im, this, r.prop]
+        simp only [re_mul, Int.cast_add, Int.cast_mul, im_mul, this, r.prop]
         ring }
   invFun f := ⟨f sqrtd, by rw [← f.map_mul, dmuld, map_intCast]⟩
   left_inv r := by simp
@@ -918,7 +918,7 @@ theorem lift_injective [CharZero R] {d : ℤ} (r : { r : R // r * r = ↑d })
   (injective_iff_map_eq_zero (lift r)).mpr fun a ha => by
     have h_inj : Function.Injective ((↑) : ℤ → R) := Int.cast_injective
     suffices lift r a.norm = 0 by
-      simp only [intCast_re, add_zero, lift_apply_apply, intCast_im, Int.cast_zero,
+      simp only [re_intCast, add_zero, lift_apply_apply, im_intCast, Int.cast_zero,
         zero_mul] at this
       rwa [← Int.cast_zero, h_inj.eq_iff, norm_eq_zero hd] at this
     rw [norm_eq_mul_conj, RingHom.map_mul, ha, zero_mul]

--- a/Mathlib/NumberTheory/Zsqrtd/Basic.lean
+++ b/Mathlib/NumberTheory/Zsqrtd/Basic.lean
@@ -48,8 +48,12 @@ def ofInt (n : ℤ) : ℤ√d :=
 theorem re_ofInt (n : ℤ) : (ofInt n : ℤ√d).re = n :=
   rfl
 
+@[deprecated (since := "2025-08-31")] alias ofInt_re := re_ofInt
+
 theorem im_ofInt (n : ℤ) : (ofInt n : ℤ√d).im = 0 :=
   rfl
+
+@[deprecated (since := "2025-08-31")] alias ofInt_im := im_ofInt
 
 /-- The zero of the ring -/
 instance : Zero (ℤ√d) :=
@@ -59,9 +63,13 @@ instance : Zero (ℤ√d) :=
 theorem re_zero : (0 : ℤ√d).re = 0 :=
   rfl
 
+@[deprecated (since := "2025-08-31")] alias zero_re := re_zero
+
 @[simp]
 theorem im_zero : (0 : ℤ√d).im = 0 :=
   rfl
+
+@[deprecated (since := "2025-08-31")] alias zero_im := im_zero
 
 instance : Inhabited (ℤ√d) :=
   ⟨0⟩
@@ -74,9 +82,13 @@ instance : One (ℤ√d) :=
 theorem re_one : (1 : ℤ√d).re = 1 :=
   rfl
 
+@[deprecated (since := "2025-08-31")] alias one_re := re_one
+
 @[simp]
 theorem im_one : (1 : ℤ√d).im = 0 :=
   rfl
+
+@[deprecated (since := "2025-08-31")] alias one_im := im_one
 
 /-- The representative of `√d` in the ring -/
 def sqrtd : ℤ√d :=
@@ -86,9 +98,13 @@ def sqrtd : ℤ√d :=
 theorem re_sqrtd : (sqrtd : ℤ√d).re = 0 :=
   rfl
 
+@[deprecated (since := "2025-08-31")] alias sqrtd_re := re_sqrtd
+
 @[simp]
 theorem im_sqrtd : (sqrtd : ℤ√d).im = 1 :=
   rfl
+
+@[deprecated (since := "2025-08-31")] alias sqrtd_im := im_sqrtd
 
 /-- Addition of elements of `ℤ√d` -/
 instance : Add (ℤ√d) :=
@@ -102,9 +118,13 @@ theorem add_def (x y x' y' : ℤ) : (⟨x, y⟩ + ⟨x', y'⟩ : ℤ√d) = ⟨x
 theorem re_add (z w : ℤ√d) : (z + w).re = z.re + w.re :=
   rfl
 
+@[deprecated (since := "2025-08-31")] alias add_re := re_add
+
 @[simp]
 theorem im_add (z w : ℤ√d) : (z + w).im = z.im + w.im :=
   rfl
+
+@[deprecated (since := "2025-08-31")] alias add_im := im_add
 
 /-- Negation in `ℤ√d` -/
 instance : Neg (ℤ√d) :=
@@ -114,9 +134,13 @@ instance : Neg (ℤ√d) :=
 theorem re_neg (z : ℤ√d) : (-z).re = -z.re :=
   rfl
 
+@[deprecated (since := "2025-08-31")] alias neg_re := re_neg
+
 @[simp]
 theorem im_neg (z : ℤ√d) : (-z).im = -z.im :=
   rfl
+
+@[deprecated (since := "2025-08-31")] alias neg_im := im_neg
 
 /-- Multiplication in `ℤ√d` -/
 instance : Mul (ℤ√d) :=
@@ -126,9 +150,13 @@ instance : Mul (ℤ√d) :=
 theorem re_mul (z w : ℤ√d) : (z * w).re = z.re * w.re + d * z.im * w.im :=
   rfl
 
+@[deprecated (since := "2025-08-31")] alias mul_re := re_mul
+
 @[simp]
 theorem im_mul (z w : ℤ√d) : (z * w).im = z.re * w.im + z.im * w.re :=
   rfl
+
+@[deprecated (since := "2025-08-31")] alias mul_im := im_mul
 
 instance addCommGroup : AddCommGroup (ℤ√d) := by
   refine
@@ -151,9 +179,13 @@ instance addCommGroup : AddCommGroup (ℤ√d) := by
 theorem re_sub (z w : ℤ√d) : (z - w).re = z.re - w.re :=
   rfl
 
+@[deprecated (since := "2025-08-31")] alias sub_re := re_sub
+
 @[simp]
 theorem im_sub (z w : ℤ√d) : (z - w).im = z.im - w.im :=
   rfl
+
+@[deprecated (since := "2025-08-31")] alias sub_im := im_sub
 
 instance addGroupWithOne : AddGroupWithOne (ℤ√d) :=
   { Zsqrtd.addCommGroup with
@@ -214,9 +246,13 @@ theorem star_mk (x y : ℤ) : star (⟨x, y⟩ : ℤ√d) = ⟨x, -y⟩ :=
 theorem re_star (z : ℤ√d) : (star z).re = z.re :=
   rfl
 
+@[deprecated (since := "2025-08-31")] alias star_re := re_star
+
 @[simp]
 theorem im_star (z : ℤ√d) : (star z).im = -z.im :=
   rfl
+
+@[deprecated (since := "2025-08-31")] alias star_im := im_star
 
 instance : StarRing (ℤ√d) where
   star_involutive _ := Zsqrtd.ext rfl (neg_neg _)
@@ -231,17 +267,25 @@ instance nontrivial : Nontrivial (ℤ√d) :=
 theorem re_natCast (n : ℕ) : (n : ℤ√d).re = n :=
   rfl
 
+@[deprecated (since := "2025-08-31")] alias natCast_re := re_natCast
+
 @[simp]
 theorem re_ofNat (n : ℕ) [n.AtLeastTwo] : (ofNat(n) : ℤ√d).re = n :=
   rfl
+
+@[deprecated (since := "2025-08-31")] alias ofNat_re := re_ofNat
 
 @[simp]
 theorem im_natCast (n : ℕ) : (n : ℤ√d).im = 0 :=
   rfl
 
+@[deprecated (since := "2025-08-31")] alias natCast_im := im_natCast
+
 @[simp]
 theorem im_ofNat (n : ℕ) [n.AtLeastTwo] : (ofNat(n) : ℤ√d).im = 0 :=
   rfl
+
+@[deprecated (since := "2025-08-31")] alias ofNat_im := im_ofNat
 
 theorem natCast_val (n : ℕ) : (n : ℤ√d) = ⟨n, 0⟩ :=
   rfl
@@ -249,8 +293,12 @@ theorem natCast_val (n : ℕ) : (n : ℤ√d) = ⟨n, 0⟩ :=
 @[simp]
 theorem re_intCast (n : ℤ) : (n : ℤ√d).re = n := by cases n <;> rfl
 
+@[deprecated (since := "2025-08-31")] alias intCast_re := re_intCast
+
 @[simp]
 theorem im_intCast (n : ℤ) : (n : ℤ√d).im = 0 := by cases n <;> rfl
+
+@[deprecated (since := "2025-08-31")] alias intCast_im := im_intCast
 
 theorem intCast_val (n : ℤ) : (n : ℤ√d) = ⟨n, 0⟩ := by ext <;> simp
 
@@ -267,7 +315,11 @@ theorem smul_val (n x y : ℤ) : (n : ℤ√d) * ⟨x, y⟩ = ⟨n * x, n * y⟩
 
 theorem re_smul (a : ℤ) (b : ℤ√d) : (↑a * b).re = a * b.re := by simp
 
+@[deprecated (since := "2025-08-31")] alias smul_re := re_smul
+
 theorem im_smul (a : ℤ) (b : ℤ√d) : (↑a * b).im = a * b.im := by simp
+
+@[deprecated (since := "2025-08-31")] alias smul_im := im_smul
 
 @[simp]
 theorem muld_val (x y : ℤ) : sqrtd (d := d) * ⟨x, y⟩ = ⟨d * y, x⟩ := by ext <;> simp

--- a/Mathlib/NumberTheory/Zsqrtd/GaussianInt.lean
+++ b/Mathlib/NumberTheory/Zsqrtd/GaussianInt.lean
@@ -78,16 +78,16 @@ theorem toComplex_def₂ (x : ℤ[i]) : (x : ℂ) = ⟨x.re, x.im⟩ := by
   apply Complex.ext <;> simp [toComplex_def]
 
 @[simp]
-theorem to_real_re (x : ℤ[i]) : ((x.re : ℤ) : ℝ) = (x : ℂ).re := by simp [toComplex_def]
+theorem intCast_re (x : ℤ[i]) : ((x.re : ℤ) : ℝ) = (x : ℂ).re := by simp [toComplex_def]
 
 @[simp]
-theorem to_real_im (x : ℤ[i]) : ((x.im : ℤ) : ℝ) = (x : ℂ).im := by simp [toComplex_def]
+theorem intCast_im (x : ℤ[i]) : ((x.im : ℤ) : ℝ) = (x : ℂ).im := by simp [toComplex_def]
 
 @[simp]
-theorem toComplex_re (x y : ℤ) : ((⟨x, y⟩ : ℤ[i]) : ℂ).re = x := by simp [toComplex_def]
+theorem re_toComplex (x y : ℤ) : ((⟨x, y⟩ : ℤ[i]) : ℂ).re = x := by simp [toComplex_def]
 
 @[simp]
-theorem toComplex_im (x y : ℤ) : ((⟨x, y⟩ : ℤ[i]) : ℂ).im = y := by simp [toComplex_def]
+theorem im_toComplex (x y : ℤ) : ((⟨x, y⟩ : ℤ[i]) : ℂ).im = y := by simp [toComplex_def]
 
 theorem toComplex_add (x y : ℤ[i]) : ((x + y : ℤ[i]) : ℂ) = x + y :=
   toComplex.map_add _ _
@@ -163,11 +163,11 @@ theorem div_def (x y : ℤ[i]) :
     x / y = ⟨round ((x * star y).re / norm y : ℚ), round ((x * star y).im / norm y : ℚ)⟩ :=
   show Zsqrtd.mk _ _ = _ by simp [div_eq_mul_inv]
 
-theorem toComplex_div_re (x y : ℤ[i]) : ((x / y : ℤ[i]) : ℂ).re = round (x / y : ℂ).re := by
+theorem toComplex_re_div (x y : ℤ[i]) : ((x / y : ℤ[i]) : ℂ).re = round (x / y : ℂ).re := by
   rw [div_def, ← @Rat.round_cast ℝ _ _]
   simp [-Rat.round_cast, mul_assoc, div_eq_mul_inv, add_mul]
 
-theorem toComplex_div_im (x y : ℤ[i]) : ((x / y : ℤ[i]) : ℂ).im = round (x / y : ℂ).im := by
+theorem toComplex_im_div (x y : ℤ[i]) : ((x / y : ℤ[i]) : ℂ).im = round (x / y : ℂ).im := by
   rw [div_def, ← @Rat.round_cast ℝ _ _, ← @Rat.round_cast ℝ _ _]
   simp [-Rat.round_cast, mul_assoc, div_eq_mul_inv, add_mul]
 
@@ -189,8 +189,8 @@ theorem normSq_div_sub_div_lt_one (x y : ℤ[i]) :
     _ ≤ Complex.normSq (1 / 2 + 1 / 2 * I) := by
       have : |(2⁻¹ : ℝ)| = 2⁻¹ := abs_of_nonneg (by norm_num)
       exact normSq_le_normSq_of_re_le_of_im_le
-        (by rw [toComplex_div_re]; simp [normSq, this]; simpa using abs_sub_round (x / y : ℂ).re)
-        (by rw [toComplex_div_im]; simp [normSq, this]; simpa using abs_sub_round (x / y : ℂ).im)
+        (by rw [toComplex_re_div]; simp [normSq, this]; simpa using abs_sub_round (x / y : ℂ).re)
+        (by rw [toComplex_im_div]; simp [normSq, this]; simpa using abs_sub_round (x / y : ℂ).im)
     _ < 1 := by simp [normSq]; norm_num
 
 instance : Mod ℤ[i] :=

--- a/Mathlib/NumberTheory/Zsqrtd/GaussianInt.lean
+++ b/Mathlib/NumberTheory/Zsqrtd/GaussianInt.lean
@@ -80,14 +80,22 @@ theorem toComplex_def₂ (x : ℤ[i]) : (x : ℂ) = ⟨x.re, x.im⟩ := by
 @[simp]
 theorem intCast_re (x : ℤ[i]) : ((x.re : ℤ) : ℝ) = (x : ℂ).re := by simp [toComplex_def]
 
+@[deprecated (since := "2025-08-31")] alias to_real_re := intCast_re
+
 @[simp]
 theorem intCast_im (x : ℤ[i]) : ((x.im : ℤ) : ℝ) = (x : ℂ).im := by simp [toComplex_def]
+
+@[deprecated (since := "2025-08-31")] alias to_real_im := intCast_im
 
 @[simp]
 theorem re_toComplex (x y : ℤ) : ((⟨x, y⟩ : ℤ[i]) : ℂ).re = x := by simp [toComplex_def]
 
+@[deprecated (since := "2025-08-31")] alias toComplex_re := re_toComplex
+
 @[simp]
 theorem im_toComplex (x y : ℤ) : ((⟨x, y⟩ : ℤ[i]) : ℂ).im = y := by simp [toComplex_def]
+
+@[deprecated (since := "2025-08-31")] alias toComplex_im := im_toComplex
 
 theorem toComplex_add (x y : ℤ[i]) : ((x + y : ℤ[i]) : ℂ) = x + y :=
   toComplex.map_add _ _
@@ -167,9 +175,13 @@ theorem toComplex_re_div (x y : ℤ[i]) : ((x / y : ℤ[i]) : ℂ).re = round (x
   rw [div_def, ← @Rat.round_cast ℝ _ _]
   simp [-Rat.round_cast, mul_assoc, div_eq_mul_inv, add_mul]
 
+@[deprecated (since := "2025-08-31")] alias toComplex_div_re := toComplex_re_div
+
 theorem toComplex_im_div (x y : ℤ[i]) : ((x / y : ℤ[i]) : ℂ).im = round (x / y : ℂ).im := by
   rw [div_def, ← @Rat.round_cast ℝ _ _, ← @Rat.round_cast ℝ _ _]
   simp [-Rat.round_cast, mul_assoc, div_eq_mul_inv, add_mul]
+
+@[deprecated (since := "2025-08-31")] alias toComplex_div_im := toComplex_im_div
 
 theorem normSq_le_normSq_of_re_le_of_im_le {x y : ℂ} (hre : |x.re| ≤ |y.re|)
     (him : |x.im| ≤ |y.im|) : Complex.normSq x ≤ Complex.normSq y := by


### PR DESCRIPTION
This renames lemmas of the form `(foo x).re` to be called `re_foo` instead of `foo_re`, and similarly for `im`, to match the naming guide.

These are then all deprecated with the deprecation script.

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include at least one commit authored by each
co-author among the commits in the pull request. If necessary, you may 
create empty commits to indicate co-authorship, using commands like so:

git commit --author="Author Name <author@email.com>" --allow-empty -m "add Author Name as coauthor"

When merging, all the commits will be squashed into a single commit listing all co-authors.

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]

-->

- [x] depends on: #29190

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
