### PR TITLE
[Merged by Bors] - chore: fix recursor names around `Nat.bit`

### DIFF
--- a/Mathlib/Algebra/Group/Defs.lean
+++ b/Mathlib/Algebra/Group/Defs.lean
@@ -519,9 +519,9 @@ theorem npowBinRec.go_spec {M : Type*} [Semigroup M] [One M] (k : ℕ) (m n : M)
   generalize hk : k + 1 = k'
   replace hk : k' ≠ 0 := by omega
   induction k' using Nat.binaryRecFromOne generalizing n m with
-  | z₀ => simp at hk
-  | z₁ => simp [npowRec']
-  | f b k' k'0 ih =>
+  | zero => simp at hk
+  | one => simp [npowRec']
+  | bit b k' k'0 ih =>
     rw [Nat.binaryRec_eq _ _ (Or.inl rfl), ih _ _ k'0]
     cases b <;> simp only [Nat.bit, cond_false, cond_true, npowRec'_two_mul]
     rw [npowRec'_succ (by omega), npowRec'_two_mul, ← npowRec'_two_mul,

--- a/Mathlib/Data/Nat/BinaryRec.lean
+++ b/Mathlib/Data/Nat/BinaryRec.lean
@@ -44,7 +44,7 @@ theorem bit_eq_zero_iff {n : Nat} {b : Bool} : bit b n = 0 ↔ n = 0 ∧ b = fal
 /-- For a predicate `motive : Nat → Sort u`, if instances can be
   constructed for natural numbers of the form `bit b n`,
   they can be constructed for any given natural number. -/
-@[elab_as_elim, inline]
+@[inline]
 def bitCasesOn {motive : Nat → Sort u} (n) (bit : ∀ b n, motive (bit b n)) : motive n :=
   -- `1 &&& n != 0` is faster than `n.testBit 0`. This may change when we have faster `testBit`.
   let x := bit (1 &&& n != 0) (n >>> 1)
@@ -113,10 +113,10 @@ theorem testBit_bit_zero (b n) : (bit b n).testBit 0 = b := by
 variable {motive : Nat → Sort u}
 
 @[simp]
-theorem bitCasesOn_bit (bit : ∀ b n, motive (bit b n)) (b : Bool) (n : Nat) :
-    bitCasesOn (n.bit b) bit = bit b n := by
-  change congrArg motive (n.bit b).bit_testBit_zero_shiftRight_one ▸ bit _ _ = bit b n
-  generalize congrArg motive (n.bit b).bit_testBit_zero_shiftRight_one = e; revert e
+theorem bitCasesOn_bit (h : ∀ b n, motive (bit b n)) (b : Bool) (n : Nat) :
+    bitCasesOn (bit b n) h = h b n := by
+  change congrArg motive (bit b n).bit_testBit_zero_shiftRight_one ▸ h _ _ = h b n
+  generalize congrArg motive (bit b n).bit_testBit_zero_shiftRight_one = e; revert e
   rw [testBit_bit_zero, bit_shiftRight_one]
   intros; rfl
 

--- a/Mathlib/Data/Nat/BinaryRec.lean
+++ b/Mathlib/Data/Nat/BinaryRec.lean
@@ -44,10 +44,10 @@ theorem bit_eq_zero_iff {n : Nat} {b : Bool} : bit b n = 0 ↔ n = 0 ∧ b = fal
 /-- For a predicate `motive : Nat → Sort u`, if instances can be
   constructed for natural numbers of the form `bit b n`,
   they can be constructed for any given natural number. -/
-@[inline]
-def bitCasesOn {motive : Nat → Sort u} (n) (h : ∀ b n, motive (bit b n)) : motive n :=
+@[elab_as_elim, inline]
+def bitCasesOn {motive : Nat → Sort u} (n) (bit : ∀ b n, motive (bit b n)) : motive n :=
   -- `1 &&& n != 0` is faster than `n.testBit 0`. This may change when we have faster `testBit`.
-  let x := h (1 &&& n != 0) (n >>> 1)
+  let x := bit (1 &&& n != 0) (n >>> 1)
   -- `congrArg motive _ ▸ x` is defeq to `x` in non-dependent case
   congrArg motive n.bit_testBit_zero_shiftRight_one ▸ x
 
@@ -56,39 +56,39 @@ def bitCasesOn {motive : Nat → Sort u} (n) (h : ∀ b n, motive (bit b n)) : m
   constructed for natural numbers of the form `bit b n`,
   they can be constructed for all natural numbers. -/
 @[elab_as_elim, specialize]
-def binaryRec {motive : Nat → Sort u} (z : motive 0) (f : ∀ b n, motive n → motive (bit b n))
+def binaryRec {motive : Nat → Sort u} (zero : motive 0) (bit : ∀ b n, motive n → motive (bit b n))
     (n : Nat) : motive n :=
-  if n0 : n = 0 then congrArg motive n0 ▸ z
+  if n0 : n = 0 then congrArg motive n0 ▸ zero
   else
-    let x := f (1 &&& n != 0) (n >>> 1) (binaryRec z f (n >>> 1))
+    let x := bit (1 &&& n != 0) (n >>> 1) (binaryRec zero bit (n >>> 1))
     congrArg motive n.bit_testBit_zero_shiftRight_one ▸ x
 decreasing_by exact bitwise_rec_lemma n0
 
 /-- The same as `binaryRec`, but the induction step can assume that if `n=0`,
   the bit being appended is `true` -/
 @[elab_as_elim, specialize]
-def binaryRec' {motive : Nat → Sort u} (z : motive 0)
-    (f : ∀ b n, (n = 0 → b = true) → motive n → motive (bit b n)) :
+def binaryRec' {motive : Nat → Sort u} (zero : motive 0)
+    (bit : ∀ b n, (n = 0 → b = true) → motive n → motive (bit b n)) :
     ∀ n, motive n :=
-  binaryRec z fun b n ih =>
-    if h : n = 0 → b = true then f b n h ih
+  binaryRec zero fun b n ih =>
+    if h : n = 0 → b = true then bit b n h ih
     else
-      have : bit b n = 0 := by
+      have : n.bit b = 0 := by
         rw [bit_eq_zero_iff]
         cases n <;> cases b <;> simp at h ⊢
-      congrArg motive this ▸ z
+      congrArg motive this ▸ zero
 
 /-- The same as `binaryRec`, but special casing both 0 and 1 as base cases -/
 @[elab_as_elim, specialize]
-def binaryRecFromOne {motive : Nat → Sort u} (z₀ : motive 0) (z₁ : motive 1)
-    (f : ∀ b n, n ≠ 0 → motive n → motive (bit b n)) :
+def binaryRecFromOne {motive : Nat → Sort u} (zero : motive 0) (one : motive 1)
+    (bit : ∀ b n, n ≠ 0 → motive n → motive (bit b n)) :
     ∀ n, motive n :=
-  binaryRec' z₀ fun b n h ih =>
+  binaryRec' zero fun b n h ih =>
     if h' : n = 0 then
-      have : bit b n = bit true 0 := by
+      have : n.bit b = Nat.bit true 0 := by
         rw [h', h h']
-      congrArg motive this ▸ z₁
-    else f b n h' ih
+      congrArg motive this ▸ one
+    else bit b n h' ih
 
 theorem bit_val (b n) : bit b n = 2 * n + b.toNat := by
   cases b <;> rfl
@@ -113,30 +113,30 @@ theorem testBit_bit_zero (b n) : (bit b n).testBit 0 = b := by
 variable {motive : Nat → Sort u}
 
 @[simp]
-theorem bitCasesOn_bit (h : ∀ b n, motive (bit b n)) (b : Bool) (n : Nat) :
-    bitCasesOn (bit b n) h = h b n := by
-  change congrArg motive (bit b n).bit_testBit_zero_shiftRight_one ▸ h _ _ = h b n
-  generalize congrArg motive (bit b n).bit_testBit_zero_shiftRight_one = e; revert e
+theorem bitCasesOn_bit (bit : ∀ b n, motive (bit b n)) (b : Bool) (n : Nat) :
+    bitCasesOn (n.bit b) bit = bit b n := by
+  change congrArg motive (n.bit b).bit_testBit_zero_shiftRight_one ▸ bit _ _ = bit b n
+  generalize congrArg motive (n.bit b).bit_testBit_zero_shiftRight_one = e; revert e
   rw [testBit_bit_zero, bit_shiftRight_one]
   intros; rfl
 
 @[simp]
-theorem binaryRec_zero (z : motive 0) (f : ∀ b n, motive n → motive (bit b n)) :
-    binaryRec z f 0 = z := by
+theorem binaryRec_zero (zero : motive 0) (bit : ∀ b n, motive n → motive (bit b n)) :
+    binaryRec zero bit 0 = zero := by
   rw [binaryRec]
   simp
 
 @[simp]
-theorem binaryRec_one (z : motive 0) (f : ∀ b n, motive n → motive (bit b n)) :
-    binaryRec (motive := motive) z f 1 = f true 0 z := by
+theorem binaryRec_one (zero : motive 0) (bit : ∀ b n, motive n → motive (bit b n)) :
+    binaryRec (motive := motive) zero bit 1 = bit true 0 zero := by
   rw [binaryRec]
   simp only [add_one_ne_zero, ↓reduceDIte, Nat.reduceShiftRight, binaryRec_zero]
   rfl
 
-theorem binaryRec_eq {z : motive 0} {f : ∀ b n, motive n → motive (bit b n)}
-    (b n) (h : f false 0 z = z ∨ (n = 0 → b = true)) :
-    binaryRec z f (bit b n) = f b n (binaryRec z f n) := by
-  by_cases h' : bit b n = 0
+theorem binaryRec_eq {zero : motive 0} {bit : ∀ b n, motive n → motive (bit b n)}
+    (b n) (h : bit false 0 zero = zero ∨ (n = 0 → b = true)) :
+    binaryRec zero bit (n.bit b) = bit b n (binaryRec zero bit n) := by
+  by_cases h' : n.bit b = 0
   case pos =>
     obtain ⟨rfl, rfl⟩ := bit_eq_zero_iff.mp h'
     simp only [Bool.false_eq_true, imp_false, not_true_eq_false, or_false] at h
@@ -144,8 +144,8 @@ theorem binaryRec_eq {z : motive 0} {f : ∀ b n, motive n → motive (bit b n)}
     exact h.symm
   case neg =>
     rw [binaryRec, dif_neg h']
-    change congrArg motive (bit b n).bit_testBit_zero_shiftRight_one ▸ f _ _ _ = _
-    generalize congrArg motive (bit b n).bit_testBit_zero_shiftRight_one = e; revert e
+    change congrArg motive (n.bit b).bit_testBit_zero_shiftRight_one ▸ bit _ _ _ = _
+    generalize congrArg motive (n.bit b).bit_testBit_zero_shiftRight_one = e; revert e
     rw [testBit_bit_zero, bit_shiftRight_one]
     intros; rfl
 

--- a/Mathlib/Data/Nat/Bits.lean
+++ b/Mathlib/Data/Nat/Bits.lean
@@ -286,12 +286,12 @@ theorem one_bits : Nat.bits 1 = [true] := by
 
 theorem bodd_eq_bits_head (n : ℕ) : n.bodd = n.bits.headI := by
   induction n using Nat.binaryRec' with
-  | z => simp
-  | f _ _ h _ => simp [bodd_bit, bits_append_bit _ _ h]
+  | zero => simp
+  | bit _ _ h => simp [bodd_bit, bits_append_bit _ _ h]
 
 theorem div2_bits_eq_tail (n : ℕ) : n.div2.bits = n.bits.tail := by
   induction n using Nat.binaryRec' with
-  | z => simp
-  | f _ _ h _ => simp [div2_bit, bits_append_bit _ _ h]
+  | zero => simp
+  | bit _ _ h => simp [div2_bit, bits_append_bit _ _ h]
 
 end Nat

--- a/Mathlib/Data/Nat/Bitwise.lean
+++ b/Mathlib/Data/Nat/Bitwise.lean
@@ -70,7 +70,7 @@ theorem binaryRec_of_ne_zero {C : Nat → Sort*} (z : C 0) (f : ∀ b n, C n →
     (h : n ≠ 0) :
     binaryRec z f n = bit_decomp n ▸ f (bodd n) (div2 n) (binaryRec z f (div2 n)) := by
   cases n using bitCasesOn with
-  | h b n =>
+  | bit b n =>
     rw [binaryRec_eq _ _ (by right; simpa [bit_eq_zero_iff] using h)]
     generalize_proofs h; revert h
     rw [bodd_bit, div2_bit]
@@ -162,19 +162,19 @@ lemma bitwise_eq_binaryRec (f : Bool → Bool → Bool) :
       binaryRec (cond (f true false) (bit a m) 0) fun b n _ => bit (f a b) (Ia n) := by
   funext x y
   induction x using binaryRec' generalizing y with
-  | z => simp only [bitwise_zero_left, binaryRec_zero, Bool.cond_eq_ite]
-  | f xb x hxb ih =>
+  | zero => simp only [bitwise_zero_left, binaryRec_zero, Bool.cond_eq_ite]
+  | bit xb x hxb ih =>
     rw [← bit_ne_zero_iff] at hxb
     simp_rw [binaryRec_of_ne_zero _ _ hxb, bodd_bit, div2_bit, eq_rec_constant]
     induction y using binaryRec' with
-    | z => simp only [bitwise_zero_right, binaryRec_zero, Bool.cond_eq_ite]
-    | f yb y hyb =>
+    | zero => simp only [bitwise_zero_right, binaryRec_zero, Bool.cond_eq_ite]
+    | bit yb y hyb =>
       rw [← bit_ne_zero_iff] at hyb
       simp_rw [binaryRec_of_ne_zero _ _ hyb, bitwise_of_ne_zero hxb hyb, bodd_bit, ← div2_val,
         div2_bit, eq_rec_constant, ih]
 
 theorem zero_of_testBit_eq_false {n : ℕ} (h : ∀ i, testBit n i = false) : n = 0 := by
-  induction n using Nat.binaryRec with | z => rfl | f b n hn => ?_
+  induction n using Nat.binaryRec with | zero => rfl | bit b n hn => ?_
   have : b = false := by simpa using h 0
   rw [this, bit_false, hn fun i => by rw [← h (i + 1), testBit_bit_succ]]
 
@@ -195,7 +195,7 @@ theorem testBit_eq_inth (n i : ℕ) : n.testBit i = n.bits.getI i := by
 
 theorem exists_most_significant_bit {n : ℕ} (h : n ≠ 0) :
     ∃ i, testBit n i = true ∧ ∀ j, i < j → testBit n j = false := by
-  induction n using Nat.binaryRec with | z => exact False.elim (h rfl) | f b n hn => ?_
+  induction n using Nat.binaryRec with | zero => exact False.elim (h rfl) | bit b n hn => ?_
   by_cases h' : n = 0
   · subst h'
     rw [show b = true by
@@ -212,14 +212,14 @@ theorem exists_most_significant_bit {n : ℕ} (h : n ≠ 0) :
 theorem lt_of_testBit {n m : ℕ} (i : ℕ) (hn : testBit n i = false) (hm : testBit m i = true)
     (hnm : ∀ j, i < j → testBit n j = testBit m j) : n < m := by
   induction n using Nat.binaryRec generalizing i m with
-  | z =>
+  | zero =>
     rw [Nat.pos_iff_ne_zero]
     rintro rfl
     simp at hm
-  | f b n hn' =>
+  | bit b n hn' =>
     induction m using Nat.binaryRec generalizing i with
-    | z => exact False.elim (Bool.false_ne_true ((zero_testBit i).symm.trans hm))
-    | f b' m hm' =>
+    | zero => exact False.elim (Bool.false_ne_true ((zero_testBit i).symm.trans hm))
+    | bit b' m hm' =>
       by_cases hi : i = 0
       · subst hi
         simp only [testBit_bit_zero] at hn hm
@@ -274,8 +274,8 @@ lemma two_pow_and (n i : ℕ) : 2 ^ i &&& n = 2 ^ i * (n.testBit i).toNat := by
 /-- Proving associativity of bitwise operations in general essentially boils down to a huge case
     distinction, so it is shorter to use this tactic instead of proving it in the general case. -/
 macro "bitwise_assoc_tac" : tactic => set_option hygiene false in `(tactic| (
-  induction n using Nat.binaryRec generalizing m k with | z => simp | f b n hn => ?_
-  induction m using Nat.binaryRec with | z => simp | f b' m hm => ?_
+  induction n using Nat.binaryRec generalizing m k with | zero => simp | bit b n hn => ?_
+  induction m using Nat.binaryRec with | zero => simp | bit b' m hm => ?_
   induction k using Nat.binaryRec <;>
     simp [hn, Bool.or_assoc, Bool.and_assoc, Bool.bne_eq_xor]))
 

--- a/Mathlib/Data/Nat/Size.lean
+++ b/Mathlib/Data/Nat/Size.lean
@@ -92,8 +92,8 @@ theorem size_le {m n : ℕ} : size m ≤ n ↔ m < 2 ^ n :=
   ⟨fun h => lt_of_lt_of_le (lt_size_self _) (Nat.pow_le_pow_right (by decide) h), by
     rw [← one_shiftLeft]
     induction m using binaryRec generalizing n with
-    | z => simp
-    | f b m IH =>
+    | zero => simp
+    | bit b m IH =>
       intro h
       by_cases e : bit b m = 0
       · simp [e]
@@ -124,8 +124,8 @@ theorem size_le_size {m n : ℕ} (h : m ≤ n) : size m ≤ size n :=
 
 theorem size_eq_bits_len (n : ℕ) : n.bits.length = n.size := by
   induction n using Nat.binaryRec' with
-  | z => simp
-  | f _ _ h ih =>
+  | zero => simp
+  | bit _ _ h ih =>
     rw [size_bit, bits_append_bit _ _ h]
     · simp [ih]
     · simpa [bit_eq_zero_iff]


### PR DESCRIPTION
From #29123. The recursor names in `Data.Nat.BinaryRec` are fixed, and then I fix from there.