### PR TITLE
[Merged by Bors] - feat(Combinatorics/SimpleGraph/Coloring): Replace `Colorable.of_embedding` with `Colorable.of_hom`

### DIFF
--- a/Mathlib/Combinatorics/SimpleGraph/Coloring.lean
+++ b/Mathlib/Combinatorics/SimpleGraph/Coloring.lean
@@ -238,7 +238,7 @@ theorem Colorable.of_hom {V' : Type*} {G' : SimpleGraph V'} (f : G →g G') {n :
     (h : G'.Colorable n) : G.Colorable n :=
   ⟨(h.toColoring (by simp)).comp f⟩
 
-@[deprecated "Use `SimpleGraph.Colorable.of_hom` instead." (since := "2025-09-01")]
+@[deprecated SimpleGraph.Colorable.of_hom (since := "2025-09-01")]
 theorem Colorable.of_embedding {V' : Type*} {G' : SimpleGraph V'} (f : G ↪g G') {n : ℕ}
     (h : G'.Colorable n) : G.Colorable n :=
   Colorable.of_hom f h
@@ -370,7 +370,7 @@ theorem chromaticNumber_mono_of_hom {V' : Type*} {G' : SimpleGraph V'}
     (f : G →g G') : G.chromaticNumber ≤ G'.chromaticNumber :=
   chromaticNumber_le_of_forall_imp fun _ => Colorable.of_hom f
 
-@[deprecated "Use `SimpleGraph.chromaticNumber_mono_of_hom` instead." (since := "2025-09-01")]
+@[deprecated SimpleGraph.chromaticNumber_mono_of_hom (since := "2025-09-01")]
 theorem chromaticNumber_mono_of_embedding {V' : Type*} {G' : SimpleGraph V'}
     (f : G ↪g G') : G.chromaticNumber ≤ G'.chromaticNumber :=
   chromaticNumber_mono_of_hom f

--- a/Mathlib/Combinatorics/SimpleGraph/Coloring.lean
+++ b/Mathlib/Combinatorics/SimpleGraph/Coloring.lean
@@ -234,9 +234,14 @@ noncomputable def Colorable.toColoring [Fintype α] {n : ℕ} (hc : G.Colorable 
   rw [← Fintype.card_fin n] at hn
   exact G.recolorOfCardLE hn hc.some
 
-theorem Colorable.of_embedding {V' : Type*} {G' : SimpleGraph V'} (f : G ↪g G') {n : ℕ}
+theorem Colorable.of_hom {V' : Type*} {G' : SimpleGraph V'} (f : G →g G') {n : ℕ}
     (h : G'.Colorable n) : G.Colorable n :=
   ⟨(h.toColoring (by simp)).comp f⟩
+
+@[deprecated "Use `SimpleGraph.Colorable.of_hom` instead." (since := "2025-09-01")]
+theorem Colorable.of_embedding {V' : Type*} {G' : SimpleGraph V'} (f : G ↪g G') {n : ℕ}
+    (h : G'.Colorable n) : G.Colorable n :=
+  Colorable.of_hom f h
 
 theorem colorable_iff_exists_bdd_nat_coloring (n : ℕ) :
     G.Colorable n ↔ ∃ C : G.Coloring ℕ, ∀ v, C v < n := by
@@ -361,9 +366,14 @@ theorem chromaticNumber_mono (G' : SimpleGraph V)
     (h : G ≤ G') : G.chromaticNumber ≤ G'.chromaticNumber :=
   chromaticNumber_le_of_forall_imp fun _ => Colorable.mono_left h
 
+theorem chromaticNumber_mono_of_hom {V' : Type*} {G' : SimpleGraph V'}
+    (f : G →g G') : G.chromaticNumber ≤ G'.chromaticNumber :=
+  chromaticNumber_le_of_forall_imp fun _ => Colorable.of_hom f
+
+@[deprecated "Use `SimpleGraph.chromaticNumber_mono_of_hom` instead." (since := "2025-09-01")]
 theorem chromaticNumber_mono_of_embedding {V' : Type*} {G' : SimpleGraph V'}
     (f : G ↪g G') : G.chromaticNumber ≤ G'.chromaticNumber :=
-  chromaticNumber_le_of_forall_imp fun _ => Colorable.of_embedding f
+  chromaticNumber_mono_of_hom f
 
 lemma card_le_chromaticNumber_iff_forall_surjective [Fintype α] :
     card α ≤ G.chromaticNumber ↔ ∀ C : G.Coloring α, Surjective C := by

--- a/Mathlib/Combinatorics/SimpleGraph/CompleteMultipartite.lean
+++ b/Mathlib/Combinatorics/SimpleGraph/CompleteMultipartite.lean
@@ -96,7 +96,7 @@ lemma isCompleteMultipartite_iff : G.IsCompleteMultipartite ↔ ∃ (ι : Type u
 lemma IsCompleteMultipartite.colorable_of_cliqueFree {n : ℕ} (h : G.IsCompleteMultipartite)
     (hc : G.CliqueFree n) : G.Colorable (n - 1) :=
   (completeMultipartiteGraph.colorable_of_cliqueFree _ (fun _ ↦ ⟨_, h.setoid.refl _⟩) <|
-    hc.comap h.iso.symm.toEmbedding).of_embedding h.iso.toEmbedding
+    hc.comap h.iso.symm.toEmbedding).of_hom h.iso
 
 variable (G) in
 /--


### PR DESCRIPTION
Replace `Colorable.of_embedding` with `Colorable.of_hom`. The embedding assumption is unnecessary, the same proof works for any homomorphism.
Similarly replace `chromaticNumber_mono_of_embedding` with `chromaticNumber_mono_of_hom`.

---

There aren't any uses of `chromaticNumber_mono_of_embedding` in mathlib. There is one use of `Colorable.of_embedding` in mathlib, which I've replaced to use `Colorable.of_hom`.

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
