### PR TITLE
chore: remove redundant `simp_rw` invocations

### DIFF
--- a/Mathlib/Algebra/Algebra/Operations.lean
+++ b/Mathlib/Algebra/Algebra/Operations.lean
@@ -611,7 +611,6 @@ protected theorem pow_induction_on_right' {C : ∀ (n : ℕ) (x), x ∈ M ^ n �
     exact algebraMap r
   | succ n n_ih =>
     revert hx
-    simp_rw [pow_succ]
     exact fun hx ↦ Submodule.mul_induction_on' (fun m hm x ih => mul_mem _ _ hm (n_ih _) _ ih)
       (fun x hx y hy Cx Cy => add _ _ _ _ _ Cx Cy) hx
 

--- a/Mathlib/Algebra/Category/ModuleCat/Monoidal/Symmetric.lean
+++ b/Mathlib/Algebra/Category/ModuleCat/Monoidal/Symmetric.lean
@@ -35,13 +35,11 @@ theorem braiding_naturality {X₁ X₂ Y₁ Y₂ : ModuleCat.{u} R} (f : X₁ �
 @[simp]
 theorem braiding_naturality_left {X Y : ModuleCat R} (f : X ⟶ Y) (Z : ModuleCat R) :
     f ▷ Z ≫ (braiding Y Z).hom = (braiding X Z).hom ≫ Z ◁ f := by
-  simp_rw [← id_tensorHom]
   apply braiding_naturality
 
 @[simp]
 theorem braiding_naturality_right (X : ModuleCat R) {Y Z : ModuleCat R} (f : Y ⟶ Z) :
     X ◁ f ≫ (braiding X Z).hom = (braiding X Y).hom ≫ f ▷ X := by
-  simp_rw [← id_tensorHom]
   apply braiding_naturality
 
 @[simp]

--- a/Mathlib/Algebra/Group/Pointwise/Set/BigOperators.lean
+++ b/Mathlib/Algebra/Group/Pointwise/Set/BigOperators.lean
@@ -113,7 +113,6 @@ theorem list_prod_singleton {M : Type*} [Monoid M] (s : List M) :
 theorem multiset_prod_mem_multiset_prod (t : Multiset ι) (f : ι → Set α) (g : ι → α)
     (hg : ∀ i ∈ t, g i ∈ f i) : (t.map g).prod ∈ (t.map f).prod := by
   induction t using Quotient.inductionOn
-  simp_rw [Multiset.quot_mk_to_coe, Multiset.map_coe, Multiset.prod_coe]
   exact list_prod_mem_list_prod _ _ _ hg
 
 /-- An n-ary version of `Set.mul_subset_mul`. -/
@@ -121,7 +120,6 @@ theorem multiset_prod_mem_multiset_prod (t : Multiset ι) (f : ι → Set α) (g
 theorem multiset_prod_subset_multiset_prod (t : Multiset ι) (f₁ f₂ : ι → Set α)
     (hf : ∀ i ∈ t, f₁ i ⊆ f₂ i) : (t.map f₁).prod ⊆ (t.map f₂).prod := by
   induction t using Quotient.inductionOn
-  simp_rw [Multiset.quot_mk_to_coe, Multiset.map_coe, Multiset.prod_coe]
   exact list_prod_subset_list_prod _ _ _ hf
 
 @[to_additive]

--- a/Mathlib/Algebra/Lie/Submodule.lean
+++ b/Mathlib/Algebra/Lie/Submodule.lean
@@ -696,7 +696,6 @@ lemma isCompactElement_lieSpan_singleton (m : M) :
 @[simp]
 lemma sSup_image_lieSpan_singleton : sSup ((fun x ↦ lieSpan R L {x}) '' N) = N := by
   refine le_antisymm (sSup_le <| by simp) ?_
-  simp_rw [← toSubmodule_le_toSubmodule, sSup_toSubmodule, Set.mem_image, SetLike.mem_coe]
   refine fun m hm ↦ Submodule.mem_sSup.mpr fun N' hN' ↦ ?_
   replace hN' : ∀ m ∈ N, lieSpan R L {m} ≤ N' := by simpa using hN'
   exact hN' _ hm (subset_lieSpan rfl)

--- a/Mathlib/Algebra/Lie/Weights/Chain.lean
+++ b/Mathlib/Algebra/Lie/Weights/Chain.lean
@@ -232,7 +232,6 @@ lemma exists_forall_mem_corootSpace_smul_add_eq_zero
     The `erw` causes a kernel timeout if there is no `subst`. -/
   subst a b N
   erw [LinearMap.trace_eq_sum_trace_restrict_of_eq_biSup _ h₁ h₂ (genWeightSpaceChain M α χ p q) h₃]
-  simp_rw [LieSubmodule.toEnd_restrict_eq_toEnd]
   convert_to _ =
     ∑ k ∈ Finset.Ioo p q, (LinearMap.trace R { x // x ∈ (genWeightSpace M (k • α + χ)) })
       ((toEnd R { x // x ∈ H } { x // x ∈ genWeightSpace M (k • α + χ) }) x)

--- a/Mathlib/Algebra/MvPolynomial/Degrees.lean
+++ b/Mathlib/Algebra/MvPolynomial/Degrees.lean
@@ -120,7 +120,6 @@ theorem degrees_sum_le {ι : Type*} [DecidableEq σ] (s : Finset ι) (f : ι →
 
 theorem degrees_mul_le {p q : MvPolynomial σ R} : (p * q).degrees ≤ p.degrees + q.degrees := by
   classical
-  simp_rw [degrees_def]
   exact supDegree_mul_le (map_add _)
 
 theorem degrees_prod_le {ι : Type*} {s : Finset ι} {f : ι → MvPolynomial σ R} :

--- a/Mathlib/Algebra/Order/Antidiag/Pi.lean
+++ b/Mathlib/Algebra/Order/Antidiag/Pi.lean
@@ -145,8 +145,6 @@ lemma piAntidiag_empty (n : μ) : piAntidiag (∅ : Finset ι) n = if n = 0 then
 lemma finsetCongr_piAntidiag_eq_antidiag (n : μ) :
     Equiv.finsetCongr (Equiv.boolArrowEquivProd _) (piAntidiag univ n) = antidiagonal n := by
   ext ⟨x₁, x₂⟩
-  simp_rw [Equiv.finsetCongr_apply, mem_map, Equiv.toEmbedding, Function.Embedding.coeFn_mk,
-    ← Equiv.eq_symm_apply]
   simp [add_comm]
 
 end AddCommMonoid

--- a/Mathlib/Algebra/Order/BigOperators/Group/Multiset.lean
+++ b/Mathlib/Algebra/Order/BigOperators/Group/Multiset.lean
@@ -161,7 +161,6 @@ lemma max_prod_le [CommMonoid α] [LinearOrder α] [IsOrderedMonoid α]
     {s : Multiset ι} {f g : ι → α} :
     max (s.map f).prod (s.map g).prod ≤ (s.map fun i ↦ max (f i) (g i)).prod := by
   obtain ⟨l⟩ := s
-  simp_rw [Multiset.quot_mk_to_coe'', Multiset.map_coe, Multiset.prod_coe]
   apply List.max_prod_le
 
 @[to_additive]
@@ -169,7 +168,6 @@ lemma prod_min_le [CommMonoid α] [LinearOrder α] [IsOrderedMonoid α]
     {s : Multiset ι} {f g : ι → α} :
     (s.map fun i ↦ min (f i) (g i)).prod ≤ min (s.map f).prod (s.map g).prod := by
   obtain ⟨l⟩ := s
-  simp_rw [Multiset.quot_mk_to_coe'', Multiset.map_coe, Multiset.prod_coe]
   apply List.prod_min_le
 
 lemma abs_sum_le_sum_abs [AddCommGroup α] [LinearOrder α] [IsOrderedAddMonoid α] {s : Multiset α} :


### PR DESCRIPTION
---
**Note:** Although technically redundant, some of these may be worth keeping for readability, or other reasons. Let me know if you think any should stay.

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include at least one commit authored by each
co-author among the commits in the pull request. If necessary, you may 
create empty commits to indicate co-authorship, using commands like so:

git commit --author="Author Name <author@email.com>" --allow-empty -m "add Author Name as coauthor"

When merging, all the commits will be squashed into a single commit listing all co-authors.

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
