### PR TITLE
[Merged by Bors] - feat(Logic/Equiv/Defs): Equiv.trans_cancel_left / right

### DIFF
--- a/Mathlib/Logic/Equiv/Defs.lean
+++ b/Mathlib/Logic/Equiv/Defs.lean
@@ -316,9 +316,17 @@ theorem symm_bijective : Function.Bijective (Equiv.symm : (α ≃ β) → β ≃
 theorem trans_assoc {δ} (ab : α ≃ β) (bc : β ≃ γ) (cd : γ ≃ δ) :
     (ab.trans bc).trans cd = ab.trans (bc.trans cd) := by grind
 
-theorem leftInverse_symm (f : Equiv α β) : LeftInverse f.symm f := f.left_inv
+theorem trans_cancel_left (e : α ≃ β) (f : β ≃ γ) (g : α ≃ γ) :
+    e.trans f = g ↔ f = e.symm.trans g := by
+  constructor <;> (rintro rfl; simp [← Equiv.trans_assoc])
 
-theorem rightInverse_symm (f : Equiv α β) : Function.RightInverse f.symm f := f.right_inv
+theorem trans_cancel_right (e : α ≃ β) (f : β ≃ γ) (g : α ≃ γ) :
+    e.trans f = g ↔ e = g.trans f.symm := by
+  constructor <;> (rintro rfl; simp [Equiv.trans_assoc])
+
+theorem leftInverse_symm (f : α ≃ β) : LeftInverse f.symm f := f.left_inv
+
+theorem rightInverse_symm (f : α ≃ β) : Function.RightInverse f.symm f := f.right_inv
 
 theorem injective_comp (e : α ≃ β) (f : β → γ) : Injective (f ∘ e) ↔ Injective f :=
   EquivLike.injective_comp e f


### PR DESCRIPTION
Given an equation `e.trans f = g`, lets you move either e or f over to the rhs with a rewrite.

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include at least one commit authored by each
co-author among the commits in the pull request. If necessary, you may 
create empty commits to indicate co-authorship, using commands like so:

git commit --author="Author Name <author@email.com>" --allow-empty -m "add Author Name as coauthor"

When merging, all the commits will be squashed into a single commit listing all co-authors.

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
