### PR TITLE
[Merged by Bors] - feat(Topology/Algebra/Module/ClosedSubmodule): add instances `Lattice` `CompleteLattice`

### DIFF
--- a/Mathlib/Topology/Algebra/Module/ClosedSubmodule.lean
+++ b/Mathlib/Topology/Algebra/Module/ClosedSubmodule.lean
@@ -188,8 +188,8 @@ protected def closure (s : Submodule R M) : ClosedSubmodule R M where
 lemma mem_closure_iff {x : M} {s : Submodule R M} : x ∈ s.closure ↔ x ∈ s.topologicalClosure :=
   Iff.rfl
 
-lemma mem_closure_iff' {x : M} {s : Submodule R M} : x ∈ s.closure ↔ x ∈ s.closure.toSubmodule := by
-  rfl
+lemma mem_closure_iff' {x : M} {s : Submodule R M} : x ∈ s.closure ↔ x ∈ s.closure.toSubmodule :=
+  Iff.rfl
 
 lemma mem_closure_iff_of_isClosed {x : M} {s : Submodule R M} (hs : IsClosed s.carrier) :
     x ∈ s.closure ↔ x ∈ s := by

--- a/Mathlib/Topology/Algebra/Module/ClosedSubmodule.lean
+++ b/Mathlib/Topology/Algebra/Module/ClosedSubmodule.lean
@@ -198,9 +198,7 @@ lemma mem_closure_iff_of_isClosed {x : M} {s : Submodule R M} (hs : IsClosed s.c
 @[simp]
 lemma closure_toSubmodule_eq {s : ClosedSubmodule R M} : s.toSubmodule.closure = s := by
   ext x
-  simp only [carrier_eq_coe, ClosedSubmodule.coe_toSubmodule, coe_closure, SetLike.mem_coe]
-  rw [closure_eq_iff_isClosed.mpr (ClosedSubmodule.isClosed s)]
-  exact SetLike.mem_coe
+  simp [closure_eq_iff_isClosed.mpr (ClosedSubmodule.isClosed s)]
 
 lemma mem_toSubmodule_iff {x : M} {t : ClosedSubmodule R M} :
     x ∈ t.toSubmodule ↔ x ∈ t.toSubmodule.closure := by

--- a/Mathlib/Topology/Algebra/Module/ClosedSubmodule.lean
+++ b/Mathlib/Topology/Algebra/Module/ClosedSubmodule.lean
@@ -188,25 +188,16 @@ protected def closure (s : Submodule R M) : ClosedSubmodule R M where
 lemma mem_closure_iff {x : M} {s : Submodule R M} : x ∈ s.closure ↔ x ∈ s.topologicalClosure :=
   Iff.rfl
 
-lemma mem_closure_iff_of_isClosed {x : M} {s : Submodule R M} (hs : IsClosed s.carrier) :
-    x ∈ s.closure ↔ x ∈ s := by
-  rw [mem_closure_iff, IsClosed.submodule_topologicalClosure_eq hs]
-
-@[simp]
-lemma closure_toSubmodule_eq {s : ClosedSubmodule R M} : s.toSubmodule.closure = s := by
-  ext x
-  simp [closure_eq_iff_isClosed.mpr (ClosedSubmodule.isClosed s)]
-
-lemma mem_toSubmodule_iff {x : M} {t : ClosedSubmodule R M} :
-    x ∈ t.toSubmodule ↔ x ∈ t.toSubmodule.closure := by
-  simp only [closure_toSubmodule_eq]
-  exact Iff.rfl
-
 end Submodule
 
 namespace ClosedSubmodule
 
 variable [ContinuousAdd N] [ContinuousConstSMul R N] {f : M →L[R] N}
+
+@[simp]
+lemma closure_toSubmodule_eq {s : ClosedSubmodule R N} : s.toSubmodule.closure = s := by
+  ext x
+  simp [closure_eq_iff_isClosed.mpr (ClosedSubmodule.isClosed s)]
 
 /-- The closure of the image of a closed submodule under a continuous linear map is a closed
 submodule.
@@ -285,7 +276,7 @@ instance : CompleteSemilatticeSup (ClosedSubmodule R N) where
   le_sSup s a ha x hx := subset_closure <| Submodule.mem_iSup_of_mem _ <|
     Submodule.mem_iSup_of_mem ha hx
   sSup_le s a h x := by
-    nth_rw 2 [Submodule.mem_toSubmodule_iff]
+    rw [← ClosedSubmodule.closure_toSubmodule_eq (s := a)]
     apply closure_mono
     simp only [Submodule.coe_toAddSubmonoid, coe_toSubmodule]
     intro y hy

--- a/Mathlib/Topology/Algebra/Module/ClosedSubmodule.lean
+++ b/Mathlib/Topology/Algebra/Module/ClosedSubmodule.lean
@@ -185,8 +185,8 @@ protected def closure (s : Submodule R M) : ClosedSubmodule R M where
   t.isClosed.closure_subset_iff
 
 @[simp]
-lemma mem_closure_iff {x : M} {s : Submodule R M} : x ∈ s.closure ↔ x ∈ s.topologicalClosure := by
-  exact Eq.to_iff rfl
+lemma mem_closure_iff {x : M} {s : Submodule R M} : x ∈ s.closure ↔ x ∈ s.topologicalClosure :=
+  Iff.rfl
 
 lemma mem_closure_iff' {x : M} {s : Submodule R M} : x ∈ s.closure ↔ x ∈ s.closure.toSubmodule := by
   rfl

--- a/Mathlib/Topology/Algebra/Module/ClosedSubmodule.lean
+++ b/Mathlib/Topology/Algebra/Module/ClosedSubmodule.lean
@@ -268,7 +268,7 @@ lemma coe_sSup (S : Set (ClosedSubmodule R N)) :
 @[simp, norm_cast]
 lemma coe_iSup (f : ι → ClosedSubmodule R N) :
     ↑(⨆ i, f i) = closure (⨆ i, (f i).toSubmodule).carrier := by
-  simp [← coe_toSubmodule]
+  simp only [← coe_toSubmodule, toSubmodule_iSup, Submodule.carrier_eq_coe]
   rfl
 
 @[simp] lemma mem_sSup {S : Set (ClosedSubmodule R N)} :

--- a/Mathlib/Topology/Algebra/Module/ClosedSubmodule.lean
+++ b/Mathlib/Topology/Algebra/Module/ClosedSubmodule.lean
@@ -245,8 +245,7 @@ lemma coe_sup :
   simp only [coe_toSubmodule, Submodule.coe_closure, Submodule.carrier_eq_coe]
 
 @[simp] lemma mem_sup :
-    x ∈ s ⊔ t ↔ x ∈ closure (s.toSubmodule ⊔ t.toSubmodule).carrier := by
-  simp [← SetLike.mem_coe]
+    x ∈ s ⊔ t ↔ x ∈ closure (s.toSubmodule ⊔ t.toSubmodule).carrier := Iff.rfl
 
 instance : SupSet (ClosedSubmodule R N) where
   sSup S := ⟨(⨆ s ∈ S, s.toSubmodule).closure, isClosed_closure⟩

--- a/Mathlib/Topology/Algebra/Module/ClosedSubmodule.lean
+++ b/Mathlib/Topology/Algebra/Module/ClosedSubmodule.lean
@@ -188,9 +188,6 @@ protected def closure (s : Submodule R M) : ClosedSubmodule R M where
 lemma mem_closure_iff {x : M} {s : Submodule R M} : x ∈ s.closure ↔ x ∈ s.topologicalClosure :=
   Iff.rfl
 
-lemma mem_closure_iff' {x : M} {s : Submodule R M} : x ∈ s.closure ↔ x ∈ s.closure.toSubmodule :=
-  Iff.rfl
-
 lemma mem_closure_iff_of_isClosed {x : M} {s : Submodule R M} (hs : IsClosed s.carrier) :
     x ∈ s.closure ↔ x ∈ s := by
   rw [mem_closure_iff, IsClosed.submodule_topologicalClosure_eq hs]

--- a/Mathlib/Topology/Algebra/Module/ClosedSubmodule.lean
+++ b/Mathlib/Topology/Algebra/Module/ClosedSubmodule.lean
@@ -285,28 +285,15 @@ instance : SemilatticeSup (ClosedSubmodule R N) where
   sup_le _ _ _ ha hb := Submodule.closure_le.mpr <| sup_le_iff.mpr ⟨ha, hb⟩
 
 instance : CompleteSemilatticeSup (ClosedSubmodule R N) where
-  le_sSup s a := by
-    intro ha x
-    simp only [toSubmodule_sSup]
-    intro hx
-    apply subset_closure
-    simp only [Submodule.coe_toAddSubmonoid, SetLike.mem_coe]
-    apply Submodule.mem_iSup_of_mem
-    exact Submodule.mem_iSup_of_mem ha hx
-  sSup_le s a := by
-    intro h x
-    simp only [toSubmodule_sSup]
+  le_sSup s a ha x hx := subset_closure <| Submodule.mem_iSup_of_mem _ <|
+    Submodule.mem_iSup_of_mem ha hx
+  sSup_le s a h x := by
     nth_rw 2 [Submodule.mem_toSubmodule_iff]
     apply closure_mono
     simp only [Submodule.coe_toAddSubmonoid, coe_toSubmodule]
     intro y hy
-    simp only [SetLike.mem_coe] at hy
-    rw [Submodule.mem_iSup] at hy
-    apply hy
-    intro b z hz
-    rw [Submodule.mem_iSup] at hz
-    apply hz
-    exact fun hb ↦ h b hb
+    simp only [SetLike.mem_coe, Submodule.mem_iSup] at hy
+    exact hy a fun b _ hz ↦ Submodule.mem_iSup _ |>.mp hz _ <| fun hb ↦ h b hb
 
 instance : Lattice (ClosedSubmodule R N) where
 

--- a/Mathlib/Topology/Algebra/Module/ClosedSubmodule.lean
+++ b/Mathlib/Topology/Algebra/Module/ClosedSubmodule.lean
@@ -280,21 +280,9 @@ lemma coe_iSup (f : ι → ClosedSubmodule R N) :
 
 instance : SemilatticeSup (ClosedSubmodule R N) where
   sup s t := s ⊔ t
-  le_sup_left s t := by
-    intro x hx
-    apply subset_closure
-    simp only [Submodule.coe_toAddSubmonoid, SetLike.mem_coe]
-    exact Submodule.mem_sup_left hx
-  le_sup_right s t := by
-    intro x hx
-    apply subset_closure
-    simp only [Submodule.coe_toAddSubmonoid, SetLike.mem_coe]
-    exact Submodule.mem_sup_right hx
-  sup_le a b c := by
-    intro ha hb
-    apply Submodule.closure_le.mpr
-    simp only [sup_le_iff, toSubmodule_le_toSubmodule]
-    exact ⟨ha, hb⟩
+  le_sup_left _ _ _ hx := subset_closure <| Submodule.mem_sup_left hx
+  le_sup_right _ _ _ hx := subset_closure <| Submodule.mem_sup_right hx
+  sup_le _ _ _ ha hb := Submodule.closure_le.mpr <| sup_le_iff.mpr ⟨ha, hb⟩
 
 instance : CompleteSemilatticeSup (ClosedSubmodule R N) where
   le_sSup s a := by

--- a/Mathlib/Topology/Algebra/Module/ClosedSubmodule.lean
+++ b/Mathlib/Topology/Algebra/Module/ClosedSubmodule.lean
@@ -139,12 +139,10 @@ lemma toSubmodule_inf (s t : ClosedSubmodule R M) :
 @[simp] lemma mem_inf : x ∈ s ⊓ t ↔ x ∈ s ∧ x ∈ t := .rfl
 
 instance : CompleteSemilatticeInf (ClosedSubmodule R M) where
-  sInf_le s a := by
-    intro ha _
+  sInf_le s a ha _ := by
     simp only [toSubmodule_sInf, Submodule.mem_iInf]
     exact fun h ↦ h a ha
-  le_sInf s a := by
-    intro ha b
+  le_sInf s a ha b := by
     simp only [toSubmodule_sInf, Submodule.mem_iInf]
     exact fun a i hi ↦ ha i hi a
 

--- a/Mathlib/Topology/Algebra/Module/ClosedSubmodule.lean
+++ b/Mathlib/Topology/Algebra/Module/ClosedSubmodule.lean
@@ -272,8 +272,7 @@ lemma coe_iSup (f : ι → ClosedSubmodule R N) :
   rfl
 
 @[simp] lemma mem_sSup {S : Set (ClosedSubmodule R N)} :
-    x ∈ sSup S ↔ x ∈ closure (⨆ s ∈ S, s.toSubmodule).carrier := by
-  simp [← SetLike.mem_coe]
+    x ∈ sSup S ↔ x ∈ closure (⨆ s ∈ S, s.toSubmodule).carrier := Iff.rfl
 
 @[simp] lemma mem_iSup {f : ι → ClosedSubmodule R N} :
     x ∈ ⨆ i, f i ↔ x ∈ closure (⨆ i, (f i).toSubmodule).carrier := by

--- a/Mathlib/Topology/Algebra/Module/ClosedSubmodule.lean
+++ b/Mathlib/Topology/Algebra/Module/ClosedSubmodule.lean
@@ -203,7 +203,7 @@ lemma closure_toSubmodule_eq {s : ClosedSubmodule R M} : s.toSubmodule.closure =
 lemma mem_toSubmodule_iff {x : M} {t : ClosedSubmodule R M} :
     x ∈ t.toSubmodule ↔ x ∈ t.toSubmodule.closure := by
   simp only [closure_toSubmodule_eq]
-  exact Eq.to_iff rfl
+  exact Iff.rfl
 
 end Submodule
 


### PR DESCRIPTION
add necessary definitions and lemmas to get instances `Lattice` `CompleteLattice` for closed submodules.

motivation: needed to define standard subspaces in a Hilbert space #29251
https://ems.press/content/serial-article-files/48171