### PR TITLE
[Merged by Bors] - chore: deprecate PartENat

### DIFF
--- a/Mathlib/Data/Nat/PartENat.lean
+++ b/Mathlib/Data/Nat/PartENat.lean
@@ -61,6 +61,8 @@ open Part hiding some
 def PartENat : Type :=
   Part ℕ
 
+set_option linter.deprecated false
+
 namespace PartENat
 
 /-- The computable embedding `ℕ → PartENat`.

--- a/Mathlib/Data/Nat/PartENat.lean
+++ b/Mathlib/Data/Nat/PartENat.lean
@@ -43,6 +43,10 @@ Before the `open scoped Classical` line, various proofs are made with decidabili
 This can cause issues -- see for example the non-simp lemma `toWithTopZero` proved by `rfl`,
 followed by `@[simp] lemma toWithTopZero'` whose proof uses `convert`.
 
+## Deprecation
+
+As it appears this has been unused since 2018, we are now deprecating it.
+If `ENat` does not serve your purposes, please raise this on the community Zulip.
 
 ## Tags
 
@@ -53,6 +57,7 @@ PartENat, ℕ∞
 open Part hiding some
 
 /-- Type of natural numbers with infinity (`⊤`) -/
+@[deprecated ENat (since := "2025-09-01")]
 def PartENat : Type :=
   Part ℕ
 


### PR DESCRIPTION
See [#mathlib4 > deprecate Mathlib.Data.Nat.PartENat?](https://leanprover.zulipchat.com/#narrow/channel/287929-mathlib4/topic/deprecate.20Mathlib.2EData.2ENat.2EPartENat.3F).