### PR TITLE
[Merged by Bors] - chore(Data/Nat/Cast/Order/Ring): generalize typeclasses

### DIFF
--- a/Mathlib/Data/Nat/Cast/Order/Ring.lean
+++ b/Mathlib/Data/Nat/Cast/Order/Ring.lean
@@ -82,17 +82,6 @@ theorem cast_tsub [CommSemiring α] [PartialOrder α] [IsOrderedRing α] [Canoni
   · rcases le_iff_exists_add'.mp h with ⟨m, rfl⟩
     rw [add_tsub_cancel_right, cast_add, add_tsub_cancel_right]
 
-section PartialOrderedRing
-variable [Ring R] [PartialOrder R] [IsStrictOrderedRing R] {m n : ℕ}
-
-@[simp, norm_cast] lemma neg_cast_eq_cast : (-m : R) = n ↔ m = 0 ∧ n = 0 := by
-  simp [neg_eq_iff_add_eq_zero, ← cast_add]
-
-@[simp, norm_cast] lemma cast_eq_neg_cast : (m : R) = -n ↔ m = 0 ∧ n = 0 := by
-  simp [eq_neg_iff_add_eq_zero, ← cast_add]
-
-end PartialOrderedRing
-
 section Lattice
 variable [Ring R] [Lattice R] [IsOrderedRing R]
 
@@ -103,6 +92,17 @@ theorem abs_cast (n : ℕ) : |(n : R)| = n := abs_of_nonneg n.cast_nonneg
 theorem abs_ofNat (n : ℕ) [n.AtLeastTwo] : |(ofNat(n) : R)| = ofNat(n) := abs_cast n
 
 end Lattice
+
+section PartialOrderedRing
+variable [Ring R] [PartialOrder R] [IsStrictOrderedRing R] {m n : ℕ}
+
+@[simp, norm_cast] lemma neg_cast_eq_cast : (-m : R) = n ↔ m = 0 ∧ n = 0 := by
+  simp [neg_eq_iff_add_eq_zero, ← cast_add]
+
+@[simp, norm_cast] lemma cast_eq_neg_cast : (m : R) = -n ↔ m = 0 ∧ n = 0 := by
+  simp [eq_neg_iff_add_eq_zero, ← cast_add]
+
+end PartialOrderedRing
 
 lemma mul_le_pow {a : ℕ} (ha : a ≠ 1) (b : ℕ) :
     a * b ≤ a ^ b := by

--- a/Mathlib/Data/Nat/Cast/Order/Ring.lean
+++ b/Mathlib/Data/Nat/Cast/Order/Ring.lean
@@ -82,14 +82,8 @@ theorem cast_tsub [CommSemiring α] [PartialOrder α] [IsOrderedRing α] [Canoni
   · rcases le_iff_exists_add'.mp h with ⟨m, rfl⟩
     rw [add_tsub_cancel_right, cast_add, add_tsub_cancel_right]
 
-section LinearOrderedRing
-variable [Ring R] [LinearOrder R] [IsStrictOrderedRing R] {m n : ℕ} {m n : ℕ}
-
-@[simp, norm_cast]
-theorem abs_cast (n : ℕ) : |(n : R)| = n := abs_of_nonneg n.cast_nonneg
-
-@[simp]
-theorem abs_ofNat (n : ℕ) [n.AtLeastTwo] : |(ofNat(n) : R)| = ofNat(n) := abs_cast n
+section PartialOrderedRing
+variable [Ring R] [PartialOrder R] [IsStrictOrderedRing R] {m n : ℕ}
 
 @[simp, norm_cast] lemma neg_cast_eq_cast : (-m : R) = n ↔ m = 0 ∧ n = 0 := by
   simp [neg_eq_iff_add_eq_zero, ← cast_add]
@@ -97,7 +91,18 @@ theorem abs_ofNat (n : ℕ) [n.AtLeastTwo] : |(ofNat(n) : R)| = ofNat(n) := abs_
 @[simp, norm_cast] lemma cast_eq_neg_cast : (m : R) = -n ↔ m = 0 ∧ n = 0 := by
   simp [eq_neg_iff_add_eq_zero, ← cast_add]
 
-end LinearOrderedRing
+end PartialOrderedRing
+
+section Lattice
+variable [Ring R] [Lattice R] [IsOrderedRing R]
+
+@[simp, norm_cast]
+theorem abs_cast (n : ℕ) : |(n : R)| = n := abs_of_nonneg n.cast_nonneg
+
+@[simp]
+theorem abs_ofNat (n : ℕ) [n.AtLeastTwo] : |(ofNat(n) : R)| = ofNat(n) := abs_cast n
+
+end Lattice
 
 lemma mul_le_pow {a : ℕ} (ha : a ≠ 1) (b : ℕ) :
     a * b ≤ a ^ b := by


### PR DESCRIPTION
---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include at least one commit authored by each
co-author among the commits in the pull request. If necessary, you may 
create empty commits to indicate co-authorship, using commands like so:

git commit --author="Author Name <author@email.com>" --allow-empty -m "add Author Name as coauthor"

When merging, all the commits will be squashed into a single commit listing all co-authors.

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
