### PR TITLE
[Merged by Bors] - chore: rename hom_to_functor, id_to_functor

### DIFF
--- a/Mathlib/AlgebraicTopology/FundamentalGroupoid/InducedMaps.lean
+++ b/Mathlib/AlgebraicTopology/FundamentalGroupoid/InducedMaps.lean
@@ -231,7 +231,7 @@ open scoped ContinuousMap
 def equivOfHomotopyEquiv (hequiv : X ≃ₕ Y) : πₓ X ≌ πₓ Y := by
   apply CategoryTheory.Equivalence.mk (πₘ (TopCat.ofHom hequiv.toFun) : πₓ X ⥤ πₓ Y)
     (πₘ (TopCat.ofHom hequiv.invFun) : πₓ Y ⥤ πₓ X) <;>
-    simp only [Grpd.id_to_functor]
+    simp only [← Grpd.id_eq_id]
   · convert (asIso (homotopicMapsNatIso hequiv.left_inv.some)).symm
     exacts [((π).map_id X).symm, ((π).map_comp _ _).symm]
   · convert asIso (homotopicMapsNatIso hequiv.right_inv.some)

--- a/Mathlib/CategoryTheory/Category/Grpd.lean
+++ b/Mathlib/CategoryTheory/Category/Grpd.lean
@@ -87,6 +87,12 @@ theorem comp_eq_comp {C D E : Grpd.{v, u}} (f : C ⟶ D) (g : D ⟶ E) : f ≫ g
 theorem id_eq_id {C : Grpd.{v, u}} : 𝟙 C = 𝟭 C  :=
   rfl
 
+@[deprecated (since := "2025-09-04")] alias hom_to_functor := comp_eq_comp
+
+@[deprecated "Deprecated in favor of using `CategoryTheory.Grpd.id_eq_id`" (since := "2025-09-04")]
+theorem id_to_functor {C : Grpd.{v, u}} : 𝟭 C = 𝟙 C :=
+  rfl
+
 section Products
 
 /-- Construct the product over an indexed family of groupoids, as a fan. -/

--- a/Mathlib/CategoryTheory/Category/Grpd.lean
+++ b/Mathlib/CategoryTheory/Category/Grpd.lean
@@ -80,11 +80,11 @@ instance forgetToCat_faithful : forgetToCat.Faithful where
 
 /-- Convert arrows in the category of groupoids to functors,
 which sometimes helps in applying simp lemmas -/
-theorem hom_to_functor {C D E : Grpd.{v, u}} (f : C ⟶ D) (g : D ⟶ E) : f ≫ g = f ⋙ g :=
+theorem comp_eq_comp {C D E : Grpd.{v, u}} (f : C ⟶ D) (g : D ⟶ E) : f ≫ g = f ⋙ g :=
   rfl
 
 /-- Converts identity in the category of groupoids to the functor identity -/
-theorem id_to_functor {C : Grpd.{v, u}} : 𝟭 C = 𝟙 C :=
+theorem id_eq_id {C : Grpd.{v, u}} : 𝟙 C = 𝟭 C  :=
   rfl
 
 section Products
@@ -99,7 +99,7 @@ def piLimitFanIsLimit ⦃J : Type u⦄ (F : J → Grpd.{u, u}) : Limits.IsLimit 
     (by
       intros
       dsimp only [piLimitFan]
-      simp [hom_to_functor])
+      simp [comp_eq_comp])
     (by
       intro s m w
       apply Functor.pi_ext


### PR DESCRIPTION
The files `CategoryTheory.Category.Grpd` and `CategoryTheory.Category.Cat` should be consistent in naming conventions and style. Here I renamed `CategoryTheory.Grpd.hom_to_functor` to `CategoryTheory.Grpd.comp_eq_comp` to mirror `CategoryTheory.Cat.comp_eq_comp`. Similarly I renamed `CategoryTheory.Grpd.id_to_functor` to `CategoryTheory.Grpd.id_eq_eq`

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include at least one commit authored by each
co-author among the commits in the pull request. If necessary, you may 
create empty commits to indicate co-authorship, using commands like so:

git commit --author="Author Name <author@email.com>" --allow-empty -m "add Author Name as coauthor"

When merging, all the commits will be squashed into a single commit listing all co-authors.

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
