### PR TITLE
[Merged by Bors] - doc: attach "quasi" as a prefix where it is currently freestanding

### DIFF
--- a/Mathlib/AlgebraicGeometry/Morphisms/Descent.lean
+++ b/Mathlib/AlgebraicGeometry/Morphisms/Descent.lean
@@ -39,7 +39,7 @@ namespace AlgebraicGeometry
 variable (P P' : MorphismProperty Scheme.{u})
 
 /--
-If `P` is local at the source, every quasi compact scheme is dominated by an
+If `P` is local at the source, every quasi-compact scheme is dominated by an
 affine scheme via `p : Y ⟶ X` such that `p` satisfies `P`.
 -/
 lemma Scheme.exists_hom_isAffine_of_isLocalAtSource (X : Scheme.{u}) [CompactSpace X]

--- a/Mathlib/Dynamics/BirkhoffSum/QuasiMeasurePreserving.lean
+++ b/Mathlib/Dynamics/BirkhoffSum/QuasiMeasurePreserving.lean
@@ -7,7 +7,7 @@ import Mathlib.Dynamics.BirkhoffSum.Average
 import Mathlib.MeasureTheory.Measure.QuasiMeasurePreserving
 
 /-!
-# Birkhoff sum and average for quasi measure preserving maps
+# Birkhoff sum and average for quasi-measure-preserving maps
 
 Given a map `f` and measure `μ`, under the assumption of `QuasiMeasurePreserving f μ μ` we prove:
 

--- a/Mathlib/Dynamics/Ergodic/Ergodic.lean
+++ b/Mathlib/Dynamics/Ergodic/Ergodic.lean
@@ -15,16 +15,16 @@ respect to `μ` (or `μ` is ergodic with respect to `f`) if the only measurable 
 
 In this file we define ergodic maps / measures together with quasi-ergodic maps / measures and
 provide some basic API. Quasi-ergodicity is a weaker condition than ergodicity for which the measure
-preserving condition is relaxed to quasi measure preserving.
+preserving condition is relaxed to quasi-measure-preserving.
 
 # Main definitions:
 
 * `PreErgodic`: the ergodicity condition without the measure preserving condition. This exists
   to share code between the `Ergodic` and `QuasiErgodic` definitions.
 * `Ergodic`: the definition of ergodic maps / measures.
-* `QuasiErgodic`: the definition of quasi ergodic maps / measures.
-* `Ergodic.quasiErgodic`: an ergodic map / measure is quasi ergodic.
-* `QuasiErgodic.ae_empty_or_univ'`: when the map is quasi measure preserving, one may relax the
+* `QuasiErgodic`: the definition of quasi-ergodic maps / measures.
+* `Ergodic.quasiErgodic`: an ergodic map / measure is quasi-ergodic.
+* `QuasiErgodic.ae_empty_or_univ'`: when the map is quasi-measure-preserving, one may relax the
   strict invariance condition to almost invariance in the ergodicity condition.
 
 -/
@@ -46,8 +46,8 @@ preserving and pre-ergodic. -/
 structure Ergodic (f : α → α) (μ : Measure α := by volume_tac) : Prop extends
   MeasurePreserving f μ μ, PreErgodic f μ
 
-/-- A map `f : α → α` is said to be quasi ergodic with respect to a measure `μ` if it is quasi
-measure preserving and pre-ergodic. -/
+/-- A map `f : α → α` is said to be quasi-ergodic with respect to a measure `μ` if it is
+quasi-measure-preserving and pre-ergodic. -/
 structure QuasiErgodic (f : α → α) (μ : Measure α := by volume_tac) : Prop extends
   QuasiMeasurePreserving f μ μ, PreErgodic f μ
 
@@ -121,14 +121,14 @@ theorem aeconst_set₀ (hf : QuasiErgodic f μ) (hsm : NullMeasurableSet s μ) (
   let ⟨_t, h₀, h₁, h₂⟩ := hf.toQuasiMeasurePreserving.exists_preimage_eq_of_preimage_ae hsm hs
   (hf.aeconst_set h₀ h₂).congr h₁
 
-/-- For a quasi ergodic map, sets that are almost invariant (rather than strictly invariant) are
+/-- For a quasi-ergodic map, sets that are almost invariant (rather than strictly invariant) are
 still either almost empty or full. -/
 theorem ae_empty_or_univ₀ (hf : QuasiErgodic f μ) (hsm : NullMeasurableSet s μ)
     (hs : f ⁻¹' s =ᵐ[μ] s) :
     s =ᵐ[μ] (∅ : Set α) ∨ s =ᵐ[μ] univ :=
   eventuallyConst_set'.mp <| hf.aeconst_set₀ hsm hs
 
-/-- For a quasi ergodic map, sets that are almost invariant (rather than strictly invariant) are
+/-- For a quasi-ergodic map, sets that are almost invariant (rather than strictly invariant) are
 still either almost empty or full. -/
 theorem ae_mem_or_ae_notMem₀ (hf : QuasiErgodic f μ) (hsm : NullMeasurableSet s μ)
     (hs : f ⁻¹' s =ᵐ[μ] s) :
@@ -150,7 +150,7 @@ end QuasiErgodic
 
 namespace Ergodic
 
-/-- An ergodic map is quasi ergodic. -/
+/-- An ergodic map is quasi-ergodic. -/
 theorem quasiErgodic (hf : Ergodic f μ) : QuasiErgodic f μ :=
   { hf.toPreErgodic, hf.toMeasurePreserving.quasiMeasurePreserving with }
 

--- a/Mathlib/Dynamics/Ergodic/Function.lean
+++ b/Mathlib/Dynamics/Ergodic/Function.lean
@@ -48,7 +48,7 @@ theorem PreErgodic.ae_eq_const_of_ae_eq_comp (h : PreErgodic f μ) (hgm : Measur
   exists_eventuallyEq_const_of_forall_separating MeasurableSet fun U hU ↦
     h.ae_mem_or_ae_notMem (s := g ⁻¹' U) (hgm hU) <| by rw [← preimage_comp, hg_eq]
 
-/-- Let `f : α → α` be a quasi ergodic map.
+/-- Let `f : α → α` be a quasi-ergodic map.
 Let `g : α → X` be a null-measurable function from `α` to a nonempty measurable space
 with a countable family of measurable sets separating the points of `X`.
 If `g` is a.e.-invariant under `f`, then `g` is a.e. constant. -/
@@ -70,7 +70,7 @@ variable [TopologicalSpace X] [MetrizableSpace X] [Nonempty X] {f : α → α}
 
 namespace QuasiErgodic
 
-/-- Let `f : α → α` be a quasi ergodic map.
+/-- Let `f : α → α` be a quasi-ergodic map.
 Let `g : α → X` be an a.e. strongly measurable function
 from `α` to a nonempty metrizable topological space.
 If `g` is a.e.-invariant under `f`, then `g` is a.e. constant. -/

--- a/Mathlib/GroupTheory/GroupAction/DomAct/Basic.lean
+++ b/Mathlib/GroupTheory/GroupAction/DomAct/Basic.lean
@@ -63,7 +63,7 @@ library) include:
   generates an action on `R`-linear maps from this module;
 - a continuous action on `X` generates an action on `C(X, Y)`;
 - a measurable action on `X` generates an action on `{ f : X → Y // Measurable f }`;
-- a quasi measure preserving action on `X` generates an action on `X →ₘ[μ] Y`;
+- a quasi-measure-preserving action on `X` generates an action on `X →ₘ[μ] Y`;
 - a measure preserving action generates an isometric action on `MeasureTheory.Lp _ _ _`.
 
 ### Left action vs right action

--- a/Mathlib/MeasureTheory/Function/AEEqFun.lean
+++ b/Mathlib/MeasureTheory/Function/AEEqFun.lean
@@ -206,7 +206,7 @@ variable [TopologicalSpace γ] [MeasurableSpace β] {ν : MeasureTheory.Measure 
 
 open MeasureTheory.Measure (QuasiMeasurePreserving)
 
-/-- Composition of an almost everywhere equal function and a quasi measure preserving function.
+/-- Composition of an almost everywhere equal function and a quasi-measure-preserving function.
 
 See also `AEEqFun.compMeasurePreserving`. -/
 def compQuasiMeasurePreserving (g : β →ₘ[ν] γ) (f : α → β) (hf : QuasiMeasurePreserving f μ ν) :
@@ -237,7 +237,7 @@ section compMeasurePreserving
 variable [TopologicalSpace γ] [MeasurableSpace β] {ν : MeasureTheory.Measure β}
   {f : α → β} {g : β → γ}
 
-/-- Composition of an almost everywhere equal function and a quasi measure preserving function.
+/-- Composition of an almost everywhere equal function and a quasi-measure-preserving function.
 
 This is an important special case of `AEEqFun.compQuasiMeasurePreserving`. We use a separate
 definition so that lemmas that need `f` to be measure preserving can be `@[simp]` lemmas. -/

--- a/Mathlib/MeasureTheory/Function/AEEqFun/DomAct.lean
+++ b/Mathlib/MeasureTheory/Function/AEEqFun/DomAct.lean
@@ -16,8 +16,8 @@ about it.
 
 ## Implementation notes
 
-In fact, it suffices to require that `(c • ·)` is only quasi measure-preserving but we don't have a
-typeclass for quasi measure-preserving actions yet.
+In fact, it suffices to require that `(c • ·)` is only quasi-measure-preserving but we don't have a
+typeclass for quasi-measure-preserving actions yet.
 
 ## Keywords
 

--- a/Mathlib/MeasureTheory/Function/AEEqFun/DomAct.lean
+++ b/Mathlib/MeasureTheory/Function/AEEqFun/DomAct.lean
@@ -16,7 +16,7 @@ about it.
 
 ## Implementation notes
 
-In fact, it suffices to require that `(c • ·)` is only quasi-measure-preserving but we don't have a
+In fact, it suffices to require that `(c • ·)` is only quasi-measure-preserving but we do not have a
 typeclass for quasi-measure-preserving actions yet.
 
 ## Keywords

--- a/Mathlib/MeasureTheory/Group/AEStabilizer.lean
+++ b/Mathlib/MeasureTheory/Group/AEStabilizer.lean
@@ -23,7 +23,7 @@ The converse is true for an ergodic action and a null-measurable set.
 We define the a.e. stabilizer as a bundled `Subgroup`,
 thus we do not deal with monoid actions.
 
-Also, many lemmas in this file are true for a *quasi measure-preserving* action,
+Also, many lemmas in this file are true for a *quasi-measure-preserving* action,
 but we don't have the corresponding typeclass.
 -/
 

--- a/Mathlib/MeasureTheory/Measure/QuasiMeasurePreserving.lean
+++ b/Mathlib/MeasureTheory/Measure/QuasiMeasurePreserving.lean
@@ -9,14 +9,14 @@ import Mathlib.MeasureTheory.OuterMeasure.BorelCantelli
 /-!
 # Quasi Measure Preserving Functions
 
-A map `f : α → β` is said to be *quasi measure preserving* (a.k.a. non-singular) w.r.t. measures
+A map `f : α → β` is said to be *quasi-measure-preserving* (a.k.a. non-singular) w.r.t. measures
 `μa` and `μb` if it is measurable and `μb s = 0` implies `μa (f ⁻¹' s) = 0`.
 That last condition can also be written `μa.map f ≪ μb` (the map of `μa` by `f` is
 absolutely continuous with respect to `μb`).
 
 ## Main definitions
 
-* `MeasureTheory.Measure.QuasiMeasurePreserving f μa μb`: `f` is quasi measure preserving with
+* `MeasureTheory.Measure.QuasiMeasurePreserving f μa μb`: `f` is quasi-measure-preserving with
   respect to `μa` and `μb`.
 
 -/
@@ -33,7 +33,7 @@ variable {mα : MeasurableSpace α} {mβ : MeasurableSpace β} {mγ : Measurable
 
 namespace Measure
 
-/-- A map `f : α → β` is said to be *quasi measure preserving* (a.k.a. non-singular) w.r.t. measures
+/-- A map `f : α → β` is said to be *quasi-measure-preserving* (a.k.a. non-singular) w.r.t. measures
 `μa` and `μb` if it is measurable and `μb s = 0` implies `μa (f ⁻¹' s) = 0`. -/
 @[fun_prop]
 structure QuasiMeasurePreserving {m0 : MeasurableSpace α} (f : α → β)
@@ -158,7 +158,7 @@ theorem liminf_preimage_iterate_ae_eq {f : α → α} (hf : QuasiMeasurePreservi
   liminf_ae_eq_of_forall_ae_eq (fun n => (preimage f)^[n] s) fun n ↦ by
     simpa only [Set.preimage_iterate_eq] using hf.preimage_iterate_ae_eq n hs
 
-/-- For a quasi measure preserving self-map `f`, if a null measurable set `s` is a.e. invariant,
+/-- For a quasi-measure-preserving self-map `f`, if a null measurable set `s` is a.e. invariant,
 then it is a.e. equal to a measurable invariant set.
 -/
 theorem exists_preimage_eq_of_preimage_ae {f : α → α} (h : QuasiMeasurePreserving f μ μ)

--- a/Mathlib/MeasureTheory/Measure/Restrict.lean
+++ b/Mathlib/MeasureTheory/Measure/Restrict.lean
@@ -383,8 +383,8 @@ theorem exists_mem_of_measure_ne_zero_of_ae (hs : μ s ≠ 0) {p : α → Prop}
   rw [← μ.restrict_apply_self, ← frequently_ae_mem_iff] at hs
   exact (hs.and_eventually hp).exists
 
-/-- If a quasi measure preserving map `f` maps a set `s` to a set `t`,
-then it is quasi measure preserving with respect to the restrictions of the measures. -/
+/-- If a quasi-measure-preserving map `f` maps a set `s` to a set `t`,
+then it is quasi-measure-preserving with respect to the restrictions of the measures. -/
 theorem QuasiMeasurePreserving.restrict {ν : Measure β} {f : α → β}
     (hf : QuasiMeasurePreserving f μ ν) {t : Set β} (hmaps : MapsTo f s t) :
     QuasiMeasurePreserving f (μ.restrict s) (ν.restrict t) where


### PR DESCRIPTION
Quasi is rarely used as a free-standing adjective. Rather, it is commonly understood as just a prefix modifying some other concept. This PR takes this into account by attaching the prefix to whatever it is modifying. 

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include at least one commit authored by each
co-author among the commits in the pull request. If necessary, you may 
create empty commits to indicate co-authorship, using commands like so:

git commit --author="Author Name <author@email.com>" --allow-empty -m "add Author Name as coauthor"

When merging, all the commits will be squashed into a single commit listing all co-authors.

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
