### PR TITLE
chore: remove redundant `refine` invocations

### DIFF
--- a/Mathlib/Algebra/Order/GroupWithZero/Lex.lean
+++ b/Mathlib/Algebra/Order/GroupWithZero/Lex.lean
@@ -32,11 +32,10 @@ variable {M₀ N₀ : Type*}
 
 lemma inl_mono [LinearOrderedCommGroupWithZero M₀] [GroupWithZero N₀] [Preorder N₀]
     [DecidablePred fun x : M₀ ↦ x = 0] : Monotone (inl M₀ N₀) := by
-  refine (WithZero.map'_mono MonoidHom.inl_mono).comp ?_
   intro x y
   obtain rfl | ⟨x, rfl⟩ := GroupWithZero.eq_zero_or_unit x <;>
   obtain rfl | ⟨y, rfl⟩ := GroupWithZero.eq_zero_or_unit y <;>
-  · simp [WithZero.withZeroUnitsEquiv]
+  · simp
 
 lemma inl_strictMono [LinearOrderedCommGroupWithZero M₀] [GroupWithZero N₀] [PartialOrder N₀]
     [DecidablePred fun x : M₀ ↦ x = 0] : StrictMono (inl M₀ N₀) :=
@@ -44,11 +43,10 @@ lemma inl_strictMono [LinearOrderedCommGroupWithZero M₀] [GroupWithZero N₀] 
 
 lemma inr_mono [GroupWithZero M₀] [Preorder M₀] [LinearOrderedCommGroupWithZero N₀]
     [DecidablePred fun x : N₀ ↦ x = 0] : Monotone (inr M₀ N₀) := by
-  refine (WithZero.map'_mono MonoidHom.inr_mono).comp ?_
   intro x y
   obtain rfl | ⟨x, rfl⟩ := GroupWithZero.eq_zero_or_unit x <;>
   obtain rfl | ⟨y, rfl⟩ := GroupWithZero.eq_zero_or_unit y <;>
-  · simp [WithZero.withZeroUnitsEquiv]
+  · simp
 
 lemma inr_strictMono [GroupWithZero M₀] [PartialOrder M₀] [LinearOrderedCommGroupWithZero N₀]
     [DecidablePred fun x : N₀ ↦ x = 0] : StrictMono (inr M₀ N₀) :=

--- a/Mathlib/Algebra/Order/GroupWithZero/Lex.lean
+++ b/Mathlib/Algebra/Order/GroupWithZero/Lex.lean
@@ -35,7 +35,7 @@ lemma inl_mono [LinearOrderedCommGroupWithZero M₀] [GroupWithZero N₀] [Preor
   intro x y
   obtain rfl | ⟨x, rfl⟩ := GroupWithZero.eq_zero_or_unit x <;>
   obtain rfl | ⟨y, rfl⟩ := GroupWithZero.eq_zero_or_unit y <;>
-  · simp
+  simp
 
 lemma inl_strictMono [LinearOrderedCommGroupWithZero M₀] [GroupWithZero N₀] [PartialOrder N₀]
     [DecidablePred fun x : M₀ ↦ x = 0] : StrictMono (inl M₀ N₀) :=
@@ -46,7 +46,7 @@ lemma inr_mono [GroupWithZero M₀] [Preorder M₀] [LinearOrderedCommGroupWithZ
   intro x y
   obtain rfl | ⟨x, rfl⟩ := GroupWithZero.eq_zero_or_unit x <;>
   obtain rfl | ⟨y, rfl⟩ := GroupWithZero.eq_zero_or_unit y <;>
-  · simp
+  simp
 
 lemma inr_strictMono [GroupWithZero M₀] [PartialOrder M₀] [LinearOrderedCommGroupWithZero N₀]
     [DecidablePred fun x : N₀ ↦ x = 0] : StrictMono (inr M₀ N₀) :=

--- a/Mathlib/Algebra/Polynomial/Smeval.lean
+++ b/Mathlib/Algebra/Polynomial/Smeval.lean
@@ -310,9 +310,8 @@ theorem smeval_commute (hc : Commute x y) : Commute (p.smeval x) (q.smeval y) :=
     | succ n ih =>
       refine (commute_iff_eq (x ^ (n + 1)) (q.smeval y)).mpr ?_
       rw [commute_iff_eq (x ^ n) (q.smeval y)] at ih
-      have hxq : x * q.smeval y = q.smeval y * x := by
-        refine (commute_iff_eq x (q.smeval y)).mp ?_
-        exact Commute.symm (smeval_commute_left R q (Commute.symm hc))
+      have hxq : x * q.smeval y = q.smeval y * x :=
+        Commute.symm (smeval_commute_left R q (Commute.symm hc))
       rw [pow_succ, ← mul_assoc, ← ih, mul_assoc, hxq, mul_assoc]
 
 end Commute

--- a/Mathlib/Algebra/Polynomial/Smeval.lean
+++ b/Mathlib/Algebra/Polynomial/Smeval.lean
@@ -311,7 +311,7 @@ theorem smeval_commute (hc : Commute x y) : Commute (p.smeval x) (q.smeval y) :=
       refine (commute_iff_eq (x ^ (n + 1)) (q.smeval y)).mpr ?_
       rw [commute_iff_eq (x ^ n) (q.smeval y)] at ih
       have hxq : x * q.smeval y = q.smeval y * x :=
-        Commute.symm (smeval_commute_left R q (Commute.symm hc))
+        (smeval_commute_left R q (hc.symm)).symm
       rw [pow_succ, ← mul_assoc, ← ih, mul_assoc, hxq, mul_assoc]
 
 end Commute

--- a/Mathlib/AlgebraicGeometry/Limits.lean
+++ b/Mathlib/AlgebraicGeometry/Limits.lean
@@ -202,7 +202,6 @@ lemma sigmaMk_mk (i) (x : f i) :
     (colimit.isoColimitCocone ⟨_, TopCat.sigmaCofanIsColimit _⟩).inv ≫ _) x =
       Scheme.forgetToTop.map (Sigma.ι f i) x
   congr 2
-  refine (colimit.isoColimitCocone_ι_inv_assoc ⟨_, TopCat.sigmaCofanIsColimit _⟩ _ _).trans ?_
   exact ι_comp_sigmaComparison Scheme.forgetToTop _ _
 
 open scoped Function in
@@ -313,7 +312,6 @@ lemma coprodMk_inl (x : X) :
     (colimit.isoColimitCocone ⟨_, TopCat.binaryCofanIsColimit _ _⟩).inv ≫ _) x =
       Scheme.forgetToTop.map coprod.inl x
   congr 2
-  refine (colimit.isoColimitCocone_ι_inv_assoc ⟨_, TopCat.binaryCofanIsColimit _ _⟩ _ _).trans ?_
   exact coprodComparison_inl Scheme.forgetToTop
 
 @[simp]
@@ -323,7 +321,6 @@ lemma coprodMk_inr (x : Y) :
     (colimit.isoColimitCocone ⟨_, TopCat.binaryCofanIsColimit _ _⟩).inv ≫ _) x =
       Scheme.forgetToTop.map coprod.inr x
   congr 2
-  refine (colimit.isoColimitCocone_ι_inv_assoc ⟨_, TopCat.binaryCofanIsColimit _ _⟩ _ _).trans ?_
   exact coprodComparison_inr Scheme.forgetToTop
 
 /-- The open cover of the coproduct of two schemes. -/

--- a/Mathlib/Geometry/Manifold/LocalInvariantProperties.lean
+++ b/Mathlib/Geometry/Manifold/LocalInvariantProperties.lean
@@ -291,7 +291,6 @@ theorem liftPropWithinAt_indep_chart_source [HasGroupoid M G] (he : e ∈ G.maxi
     LiftPropWithinAt P g s x ↔ LiftPropWithinAt P (g ∘ e.symm) (e.symm ⁻¹' s) (e x) := by
   rw [liftPropWithinAt_self_source, liftPropWithinAt_iff',
     e.symm.continuousWithinAt_iff_continuousWithinAt_comp_right xe, e.symm_symm]
-  refine and_congr Iff.rfl ?_
   rw [Function.comp_apply, e.left_inv xe, ← Function.comp_assoc,
     hG.liftPropWithinAt_indep_chart_source_aux (chartAt _ (g x) ∘ g) (chart_mem_maximalAtlas G x)
       (mem_chart_source _ x) he xe, Function.comp_assoc]

--- a/Mathlib/Probability/Density.lean
+++ b/Mathlib/Probability/Density.lean
@@ -285,7 +285,6 @@ theorem hasFiniteIntegral_mul {f : ℝ → ℝ} {g : ℝ → ℝ≥0∞} (hg : p
   have : (fun x => ‖f x‖ₑ * g x) =ᵐ[volume] fun x => ‖f x * (pdf X ℙ volume x).toReal‖ₑ := by
     refine ae_eq_trans ((ae_eq_refl _).fun_mul (ae_eq_trans hg.symm ofReal_toReal_ae_eq.symm)) ?_
     simp_rw [← smul_eq_mul, enorm_smul, smul_eq_mul]
-    refine .fun_mul (ae_eq_refl _) ?_
     simp only [Real.enorm_eq_ofReal ENNReal.toReal_nonneg, ae_eq_refl]
   rwa [lt_top_iff_ne_top, ← lintegral_congr_ae this]
 


### PR DESCRIPTION
---
**Note:** Although technically redundant, some of these may be worth keeping for readability, or other reasons. Let me know if you think any should stay.

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include at least one commit authored by each
co-author among the commits in the pull request. If necessary, you may 
create empty commits to indicate co-authorship, using commands like so:

git commit --author="Author Name <author@email.com>" --allow-empty -m "add Author Name as coauthor"

When merging, all the commits will be squashed into a single commit listing all co-authors.

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
