### PR TITLE
[Merged by Bors] - fix(TacticAnalysis): don't re-export imported analysis passes

### DIFF
--- a/Mathlib/Tactic/TacticAnalysis.lean
+++ b/Mathlib/Tactic/TacticAnalysis.lean
@@ -89,13 +89,19 @@ instance : Ord Entry where
 
 /-- Environment extensions for `tacticAnalysis` declarations -/
 initialize tacticAnalysisExt : PersistentEnvExtension Entry (Entry × Pass)
-    (Array (Entry × Pass)) ←
+    -- Like `SimplePersistentEnvExtension`, store the locally declared entries separately from all
+    -- of the passes. Otherwise we end up re-exporting the entries and spending a lot of time
+    -- deduplicating them downstream.
+    (List Entry × Array Pass) ←
   registerPersistentEnvExtension {
-    mkInitial := pure #[]
-    addImportedFn s := s.flatten.sortDedup.mapM fun e => do
-      return (e, ← e.import)
-    addEntryFn := Array.push
-    exportEntriesFn s := s.map (· |>.1)
+    mkInitial := pure ([], #[])
+    addImportedFn s := do
+      let localEntries := []
+      let allPasses ← s.flatten.mapM fun e => e.import
+      return (localEntries, allPasses)
+    addEntryFn := fun (localEntries, allPasses) (entry, pass) =>
+      (entry :: localEntries, allPasses.push pass)
+    exportEntriesFn := fun (localEntries, _) => localEntries.reverse.toArray
   }
 
 /-- Attribute adding a tactic analysis pass from a `Config` structure. -/
@@ -210,7 +216,7 @@ def tacticAnalysis : Linter where run := withSetOptionIn fun stx => do
   if (← get).messages.hasErrors then
     return
   let env ← getEnv
-  let configs := (tacticAnalysisExt.getState env).map (· |>.snd)
+  let configs := (tacticAnalysisExt.getState env).2
   let trees ← getInfoTrees
   runPasses configs stx trees
 

--- a/Mathlib/Tactic/TacticAnalysis.lean
+++ b/Mathlib/Tactic/TacticAnalysis.lean
@@ -4,7 +4,6 @@ Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Anne Baanen
 -/
 
-import Batteries.Data.Array.Merge
 import Lean.Elab.Tactic.Meta
 import Lean.Util.Heartbeats
 import Lean.Server.InfoUtils


### PR DESCRIPTION
Marc reported that importing Mathlib on nightly-testing is a lot slower, and traced this back to tactic analysis. It turns out the issue is that each pass from an imported file is re-exported, and then the whole is deduplicated. But we already get the passes from transitive imports, so we do not need to re-export.

Instead, keep a list of entries for the current file we want to export, and an array of all passes encountered so far. Only the list is exported, and this already guarantees uniqueness since each dependency only occurs once per file we build.

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include at least one commit authored by each
co-author among the commits in the pull request. If necessary, you may 
create empty commits to indicate co-authorship, using commands like so:

git commit --author="Author Name <author@email.com>" --allow-empty -m "add Author Name as coauthor"

When merging, all the commits will be squashed into a single commit listing all co-authors.

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
