### PR TITLE
chore(GroupTheory/GroupAction/Basic): don't import `Module`

### DIFF
--- a/Mathlib/GroupTheory/GroupAction/Basic.lean
+++ b/Mathlib/GroupTheory/GroupAction/Basic.lean
@@ -7,8 +7,7 @@ import Mathlib.Algebra.Group.Action.End
 import Mathlib.Algebra.Group.Action.Pointwise.Set.Basic
 import Mathlib.Algebra.Group.Action.Prod
 import Mathlib.Algebra.Group.Subgroup.Map
-import Mathlib.Algebra.Module.Defs
-import Mathlib.Algebra.NoZeroSMulDivisors.Defs
+import Mathlib.Algebra.GroupWithZero.Action.Defs
 import Mathlib.Data.Finite.Sigma
 import Mathlib.Data.Set.Finite.Range
 import Mathlib.Data.Setoid.Basic
@@ -30,6 +29,7 @@ of `•` belong elsewhere.
 
 -/
 
+assert_not_exists Module
 
 universe u v
 
@@ -101,7 +101,7 @@ end MulAction
 
 /-- `smul` by a `k : M` over a group is injective, if `k` is not a zero divisor.
 The general theory of such `k` is elaborated by `IsSMulRegular`.
-The typeclass that restricts all terms of `M` to have this property is `NoZeroSMulDivisors`. -/
+The typeclass that restricts all terms of `M` to have this property is `Module.IsTorsionFree`. -/
 theorem smul_cancel_of_non_zero_divisor {M G : Type*} [Monoid M] [AddGroup G]
     [DistribMulAction M G] (k : M) (h : ∀ x : G, k • x = 0 → x = 0) {a b : G} (h' : k • a = k • b) :
     a = b := by
@@ -381,17 +381,3 @@ theorem le_stabilizer_iff_smul_le (s : Set α) (H : Subgroup G) :
     · simp only [smul_inv_smul]
 
 end MulAction
-
-section
-
-variable (R M : Type*) [Ring R] [AddCommGroup M] [Module R M] [NoZeroSMulDivisors R M]
-
-variable {M} in
-lemma Module.stabilizer_units_eq_bot_of_ne_zero {x : M} (hx : x ≠ 0) :
-    MulAction.stabilizer Rˣ x = ⊥ := by
-  rw [eq_bot_iff]
-  intro g (hg : g.val • x = x)
-  ext
-  rw [← sub_eq_zero, ← smul_eq_zero_iff_left hx, Units.val_one, sub_smul, hg, one_smul, sub_self]
-
-end

--- a/Mathlib/LinearAlgebra/Projectivization/Cardinality.lean
+++ b/Mathlib/LinearAlgebra/Projectivization/Cardinality.lean
@@ -16,6 +16,13 @@ We compute the cardinality of `ℙ k V` if `k` is a finite field.
 
 -/
 
+lemma Module.stabilizer_units_eq_bot_of_ne_zero (R : Type*) {M : Type*} [Ring R] [AddCommGroup M]
+    [Module R M] [NoZeroSMulDivisors R M] {x : M} (hx : x ≠ 0) : MulAction.stabilizer Rˣ x = ⊥ := by
+  rw [eq_bot_iff]
+  intro g (hg : g.val • x = x)
+  ext
+  rw [← sub_eq_zero, ← smul_eq_zero_iff_left hx, Units.val_one, sub_smul, hg, one_smul, sub_self]
+
 namespace Projectivization
 
 open scoped LinearAlgebra.Projectivization

--- a/Mathlib/LinearAlgebra/Projectivization/Cardinality.lean
+++ b/Mathlib/LinearAlgebra/Projectivization/Cardinality.lean
@@ -16,6 +16,12 @@ We compute the cardinality of `ℙ k V` if `k` is a finite field.
 
 -/
 
+/- TODO: Move me to a better place, maybe a file under `Algebra.Module`? Current required imports:
+import Mathlib.Algebra.Group.Subgroup.Lattice
+import Mathlib.Algebra.Module.Defs
+import Mathlib.Algebra.NoZeroSMulDivisors.Defs
+import Mathlib.GroupTheory.GroupAction.Defs
+-/
 lemma Module.stabilizer_units_eq_bot_of_ne_zero (R : Type*) {M : Type*} [Ring R] [AddCommGroup M]
     [Module R M] [NoZeroSMulDivisors R M] {x : M} (hx : x ≠ 0) : MulAction.stabilizer Rˣ x = ⊥ := by
   rw [eq_bot_iff]


### PR DESCRIPTION
This is useful to be able to replace `NoZeroSMulDivisors` with `Module.IsTorsionFree` later.


---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include at least one commit authored by each
co-author among the commits in the pull request. If necessary, you may 
create empty commits to indicate co-authorship, using commands like so:

git commit --author="Author Name <author@email.com>" --allow-empty -m "add Author Name as coauthor"

When merging, all the commits will be squashed into a single commit listing all co-authors.

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
