### PR TITLE
doc: hyphenate attributive compound adjectives ending in "exact"

### DIFF
--- a/Mathlib/Algebra/Category/ContinuousCohomology/Basic.lean
+++ b/Mathlib/Algebra/Category/ContinuousCohomology/Basic.lean
@@ -38,7 +38,7 @@ See `ContinuousCohomology.MultiInd.d`.
 ## TODO
 - Show that it coincides with `groupCohomology` for discrete groups.
 - Give the usual description of cochains in terms of `n`-ary functions for locally compact groups.
-- Show that short exact sequences induce long exact sequences in certain scenarios.
+- Show that short-exact sequences induce long-exact sequences in certain scenarios.
 -/
 
 open CategoryTheory Functor ContinuousMap

--- a/Mathlib/Algebra/Category/ModuleCat/Free.lean
+++ b/Mathlib/Algebra/Category/ModuleCat/Free.lean
@@ -13,13 +13,13 @@ This file proves results about linear independence and span in exact sequences o
 
 ## Main theorems
 
-* `linearIndependent_shortExact`: Given a short exact sequence `0 ⟶ X₁ ⟶ X₂ ⟶ X₃ ⟶ 0` of
+* `linearIndependent_shortExact`: Given a short-exact sequence `0 ⟶ X₁ ⟶ X₂ ⟶ X₃ ⟶ 0` of
   `R`-modules and linearly independent families `v : ι → X₁` and `w : ι' → X₃`, we get a linearly
   independent family `ι ⊕ ι' → X₂`
 * `span_rightExact`: Given an exact sequence `X₁ ⟶ X₂ ⟶ X₃ ⟶ 0` of `R`-modules and spanning
   families `v : ι → X₁` and `w : ι' → X₃`, we get a spanning family `ι ⊕ ι' → X₂`
 * Using `linearIndependent_shortExact` and `span_rightExact`, we prove `free_shortExact`: In a
-  short exact sequence `0 ⟶ X₁ ⟶ X₂ ⟶ X₃ ⟶ 0` where `X₁` and `X₃` are free, `X₂` is free as well.
+  short-exact sequence `0 ⟶ X₁ ⟶ X₂ ⟶ X₃ ⟶ 0` where `X₁` and `X₃` are free, `X₂` is free as well.
 
 ## Tags
 linear algebra, module, free
@@ -74,7 +74,7 @@ theorem linearIndependent_leftExact : LinearIndependent R u := by
 end
 
 include hS' hv in
-/-- Given a short exact sequence `0 ⟶ X₁ ⟶ X₂ ⟶ X₃ ⟶ 0` of `R`-modules and linearly independent
+/-- Given a short-exact sequence `0 ⟶ X₁ ⟶ X₂ ⟶ X₃ ⟶ 0` of `R`-modules and linearly independent
 families `v : ι → N` and `w : ι' → P`, we get a linearly independent family `ι ⊕ ι' → M` -/
 theorem linearIndependent_shortExact {w : ι' → S.X₃} (hw : LinearIndependent R w) :
     LinearIndependent R (Sum.elim (S.f ∘ v) (S.g.hom.toFun.invFun ∘ w)) := by
@@ -148,7 +148,7 @@ theorem span_rightExact {w : ι' → S.X₃} (hv : ⊤ ≤ span R (range v))
 
 end Span
 
-/-- In a short exact sequence `0 ⟶ X₁ ⟶ X₂ ⟶ X₃ ⟶ 0`, given bases for `X₁` and `X₃`
+/-- In a short-exact sequence `0 ⟶ X₁ ⟶ X₂ ⟶ X₃ ⟶ 0`, given bases for `X₁` and `X₃`
 indexed by `ι` and `ι'` respectively, we get a basis for `X₂` indexed by `ι ⊕ ι'`. -/
 noncomputable
 def Basis.ofShortExact
@@ -158,7 +158,7 @@ def Basis.ofShortExact
 
 include hS'
 
-/-- In a short exact sequence `0 ⟶ X₁ ⟶ X₂ ⟶ X₃ ⟶ 0`, if `X₁` and `X₃` are free,
+/-- In a short-exact sequence `0 ⟶ X₁ ⟶ X₂ ⟶ X₃ ⟶ 0`, if `X₁` and `X₃` are free,
 then `X₂` is free. -/
 theorem free_shortExact [Module.Free R S.X₁] [Module.Free R S.X₃] :
     Module.Free R S.X₂ :=

--- a/Mathlib/Algebra/Homology/ConcreteCategory.lean
+++ b/Mathlib/Algebra/Homology/ConcreteCategory.lean
@@ -68,7 +68,7 @@ lemma δ_apply' (x₃ : (forget₂ C Ab).obj (S.X₃.homology i))
 set_option linter.style.commandStart false in
 include hS in
 /--
-In the short exact sequence of complexes
+In the short-exact sequence of complexes
 ```
        0            0            0
        |            |            |

--- a/Mathlib/Algebra/Homology/DerivedCategory/Basic.lean
+++ b/Mathlib/Algebra/Homology/DerivedCategory/Basic.lean
@@ -47,7 +47,7 @@ instance should be obtained at the beginning of the proof, using the term
 
 ## TODO (@joelriou)
 
-- construct the distinguished triangle associated to a short exact sequence
+- construct the distinguished triangle associated to a short-exact sequence
 of cochain complexes (done), and compare the associated connecting homomorphism
 with the one defined in `Algebra.Homology.HomologySequence`.
 

--- a/Mathlib/Algebra/Homology/DerivedCategory/Ext/ExactSequences.lean
+++ b/Mathlib/Algebra/Homology/DerivedCategory/Ext/ExactSequences.lean
@@ -9,10 +9,10 @@ import Mathlib.CategoryTheory.Triangulated.Yoneda
 /-!
 # Long exact sequences of `Ext`-groups
 
-In this file, we obtain the covariant long exact sequence of `Ext` when `n₀ + 1 = n₁`:
+In this file, we obtain the covariant long-exact sequence of `Ext` when `n₀ + 1 = n₁`:
 `Ext X S.X₁ n₀ → Ext X S.X₂ n₀ → Ext X S.X₃ n₀ → Ext X S.X₁ n₁ → Ext X S.X₂ n₁ → Ext X S.X₃ n₁`
-when `S` is a short exact short complex in an abelian category `C`, `n₀ + 1 = n₁` and `X : C`.
-Similarly, if `Y : C`, there is a contravariant long exact sequence :
+when `S` is a short-exact short complex in an abelian category `C`, `n₀ + 1 = n₁` and `X : C`.
+Similarly, if `Y : C`, there is a contravariant long-exact sequence :
 `Ext S.X₃ Y n₀ → Ext S.X₂ Y n₀ → Ext S.X₁ Y n₀ → Ext S.X₃ Y n₁ → Ext S.X₂ Y n₁ → Ext S.X₁ Y n₁`.
 
 -/
@@ -113,8 +113,8 @@ lemma covariant_sequence_exact₁' :
 
 open ComposableArrows
 
-/-- Given a short exact short complex `S` in an abelian category `C` and an object `X : C`,
-this is the long exact sequence
+/-- Given a short-exact short complex `S` in an abelian category `C` and an object `X : C`,
+this is the long-exact sequence
 `Ext X S.X₁ n₀ → Ext X S.X₂ n₀ → Ext X S.X₃ n₀ → Ext X S.X₁ n₁ → Ext X S.X₂ n₁ → Ext X S.X₃ n₁`
 when `n₀ + 1 = n₁` -/
 noncomputable def covariantSequence : ComposableArrows AddCommGrp.{w} 5 :=
@@ -231,8 +231,8 @@ lemma contravariant_sequence_exact₃' :
 
 open ComposableArrows
 
-/-- Given a short exact short complex `S` in an abelian category `C` and an object `Y : C`,
-this is the long exact sequence
+/-- Given a short-exact short complex `S` in an abelian category `C` and an object `Y : C`,
+this is the long-exact sequence
 `Ext S.X₃ Y n₀ → Ext S.X₂ Y n₀ → Ext S.X₁ Y n₀ → Ext S.X₃ Y n₁ → Ext S.X₂ Y n₁ → Ext S.X₁ Y n₁`
 when `1 + n₀ = n₁`. -/
 noncomputable def contravariantSequence : ComposableArrows AddCommGrp.{w} 5 :=

--- a/Mathlib/Algebra/Homology/DerivedCategory/Ext/ExtClass.lean
+++ b/Mathlib/Algebra/Homology/DerivedCategory/Ext/ExtClass.lean
@@ -7,9 +7,9 @@ import Mathlib.Algebra.Homology.DerivedCategory.Ext.Basic
 import Mathlib.Algebra.Homology.DerivedCategory.SingleTriangle
 
 /-!
-# The Ext class of a short exact sequence
+# The Ext class of a short-exact sequence
 
-In this file, given a short exact short complex `S : ShortComplex C`
+In this file, given a short-exact short complex `S : ShortComplex C`
 in an abelian category, we construct the associated class in
 `Ext S.X₃ S.X₁ 1`.
 
@@ -65,7 +65,7 @@ private lemma hasSmallLocalizedShiftedHom_K_S'_X₁ :
   rw [Localization.hasSmallLocalizedShiftedHom_iff_source.{w} W ℤ qis hqis (S').X₁]
   infer_instance
 
-/-- The class in `Ext S.X₃ S.X₁ 1` that is attached to a short exact
+/-- The class in `Ext S.X₃ S.X₁ 1` that is attached to a short-exact
 short complex `S` in an abelian category. -/
 noncomputable def extClass : Ext.{w} S.X₃ S.X₁ 1 := by
   have := hS.hasSmallLocalizedHom_S'_X₃_K

--- a/Mathlib/Algebra/Homology/DerivedCategory/HomologySequence.lean
+++ b/Mathlib/Algebra/Homology/DerivedCategory/HomologySequence.lean
@@ -11,7 +11,7 @@ import Mathlib.Algebra.Homology.DerivedCategory.Basic
 
 In this file, we construct `homologyFunctor C n : DerivedCategory C ⥤ C` for all `n : ℤ`,
 show that they are homological functors which form a shift sequence, and construct
-the long exact homology sequences associated to distinguished triangles in the
+the long-exact homology sequences associated to distinguished triangles in the
 derived category.
 
 -/

--- a/Mathlib/Algebra/Homology/DerivedCategory/ShortExact.lean
+++ b/Mathlib/Algebra/Homology/DerivedCategory/ShortExact.lean
@@ -7,9 +7,9 @@ import Mathlib.Algebra.Homology.HomotopyCategory.ShortExact
 import Mathlib.Algebra.Homology.DerivedCategory.Basic
 
 /-!
-# The distinguished triangle attached to a short exact sequence of cochain complexes
+# The distinguished triangle attached to a short-exact sequence of cochain complexes
 
-Given a short exact short complex `S` in the category `CochainComplex C ℤ`,
+Given a short-exact short complex `S` in the category `CochainComplex C ℤ`,
 we construct a distinguished triangle
 `Q.obj S.X₁ ⟶ Q.obj S.X₂ ⟶  Q.obj S.X₃ ⟶ (Q.obj S.X₃)⟦1⟧`
 in the derived category of `C`.
@@ -29,7 +29,7 @@ variable {C : Type u} [Category.{v} C] [Abelian C] [HasDerivedCategory.{w} C]
   {S : ShortComplex (CochainComplex C ℤ)} (hS : S.ShortExact)
 
 /-- The connecting homomorphism `Q.obj (S.X₃) ⟶ (Q.obj S.X₁)⟦(1 : ℤ)⟧`
-in the derived category when `S` is a short exact short complex of
+in the derived category when `S` is a short-exact short complex of
 cochain complexes in an abelian category. -/
 noncomputable def triangleOfSESδ :
     Q.obj (S.X₃) ⟶ (Q.obj S.X₁)⟦(1 : ℤ)⟧ :=
@@ -38,13 +38,13 @@ noncomputable def triangleOfSESδ :
     Q.map (CochainComplex.mappingCone.triangle S.f).mor₃ ≫
     (Q.commShiftIso (1 : ℤ)).hom.app S.X₁
 
-/-- The distinguished triangle in the derived category associated to a short
-exact sequence of cochain complexes. -/
+/-- The distinguished triangle in the derived category associated to a
+short-exact sequence of cochain complexes. -/
 @[simps!]
 noncomputable def triangleOfSES : Triangle (DerivedCategory C) :=
   Triangle.mk (Q.map S.f) (Q.map S.g) (triangleOfSESδ hS)
 
-/-- The triangle `triangleOfSES` attached to a short exact sequence `S` of cochain
+/-- The triangle `triangleOfSES` attached to a short-exact sequence `S` of cochain
 complexes is isomorphism to the standard distinguished triangle associated to
 the morphism `S.f`. -/
 noncomputable def triangleOfSESIso :

--- a/Mathlib/Algebra/Homology/DerivedCategory/SingleTriangle.lean
+++ b/Mathlib/Algebra/Homology/DerivedCategory/SingleTriangle.lean
@@ -6,9 +6,9 @@ Authors: Joël Riou
 import Mathlib.Algebra.Homology.DerivedCategory.ShortExact
 
 /-!
-# The distinguished triangle of a short exact sequence in an abelian category
+# The distinguished triangle of a short-exact sequence in an abelian category
 
-Given a short exact short complex `S` in an abelian category, we construct
+Given a short-exact short complex `S` in an abelian category, we construct
 the associated distinguished triangle in the derived category:
 `(singleFunctor C 0).obj S.X₁ ⟶ (singleFunctor C 0).obj S.X₂ ⟶ (singleFunctor C 0).obj S.X₃ ⟶ ...`
 
@@ -37,7 +37,7 @@ namespace ShortExact
 
 /-- The connecting homomorphism
 `(singleFunctor C 0).obj S.X₃ ⟶ ((singleFunctor C 0).obj S.X₁)⟦(1 : ℤ)⟧` in the derived
-category of `C` when `S` is a short exact short complex in `C`. -/
+category of `C` when `S` is a short-exact short complex in `C`. -/
 noncomputable def singleδ : (singleFunctor C 0).obj S.X₃ ⟶
     ((singleFunctor C 0).obj S.X₁)⟦(1 : ℤ)⟧ :=
   (((SingleFunctors.evaluation _ _ 0).mapIso (singleFunctorsPostcompQIso C)).hom.app S.X₃) ≫
@@ -46,15 +46,15 @@ noncomputable def singleδ : (singleFunctor C 0).obj S.X₃ ⟶
       (singleFunctorsPostcompQIso C)).inv.app S.X₁)⟦(1 : ℤ)⟧'
 
 /-- The (distinguished) triangle in the derived category of `C` given by a
-short exact short complex in `C`. -/
+short-exact short complex in `C`. -/
 @[simps!]
 noncomputable def singleTriangle : Triangle (DerivedCategory C) :=
   Triangle.mk ((singleFunctor C 0).map S.f)
     ((singleFunctor C 0).map S.g) hS.singleδ
 
-/-- Given a short exact complex `S` in `C` that is short exact (`hS`), this is the
+/-- Given a short-exact complex `S` in `C` that is short exact (`hS`), this is the
 canonical isomorphism between the triangle `hS.singleTriangle` in the derived category
-and the triangle attached to the corresponding short exact sequence of cochain complexes
+and the triangle attached to the corresponding short-exact sequence of cochain complexes
 after the application of the single functor. -/
 @[simps!]
 noncomputable def singleTriangleIso :
@@ -70,7 +70,7 @@ noncomputable def singleTriangleIso :
     rw [comp_id]
 
 /-- The distinguished triangle in the derived category of `C` given by a
-short exact short complex in `C`. -/
+short-exact short complex in `C`. -/
 lemma singleTriangle_distinguished :
     hS.singleTriangle ∈ distTriang (DerivedCategory C) :=
   isomorphic_distinguished _ (triangleOfSES_distinguished (hS.map_of_exact

--- a/Mathlib/Algebra/Homology/HomologySequence.lean
+++ b/Mathlib/Algebra/Homology/HomologySequence.lean
@@ -11,10 +11,10 @@ import Mathlib.Algebra.Homology.HomologicalComplexLimits
 /-!
 # The homology sequence
 
-If `0 ⟶ X₁ ⟶ X₂ ⟶ X₃ ⟶ 0` is a short exact sequence in a category of complexes
+If `0 ⟶ X₁ ⟶ X₂ ⟶ X₃ ⟶ 0` is a short-exact sequence in a category of complexes
 `HomologicalComplex C c` in an abelian category (i.e. `S` is a short complex in
 that category and satisfies `hS : S.ShortExact`), then whenever `i` and `j` are degrees
-such that `hij : c.Rel i j`, then there is a long exact sequence :
+such that `hij : c.Rel i j`, then there is a long-exact sequence :
 `... ⟶ S.X₁.homology i ⟶ S.X₂.homology i ⟶ S.X₃.homology i ⟶ S.X₁.homology j ⟶ ...`.
 The connecting homomorphism `S.X₃.homology i ⟶ S.X₁.homology j` is `hS.δ i j hij`, and
 the exactness is asserted as lemmas `hS.homology_exact₁`, `hS.homology_exact₂` and
@@ -214,7 +214,7 @@ variable {S : ShortComplex (HomologicalComplex C c)}
 
 namespace HomologySequence
 
-/-- Given a short exact short complex `S : HomologicalComplex C c`, and degrees `i` and `j`
+/-- Given a short-exact short complex `S : HomologicalComplex C c`, and degrees `i` and `j`
 such that `c.Rel i j`, this is the snake diagram whose four lines are respectively
 obtained by applying the functors `homologyFunctor C c i`, `opcyclesFunctor C c i`,
 `cyclesFunctor C c j`, `homologyFunctor C c j` to `S`. Applying the snake lemma to this
@@ -272,7 +272,7 @@ namespace ShortComplex
 
 namespace ShortExact
 
-/-- The connecting homomorphism `S.X₃.homology i ⟶ S.X₁.homology j` for a short exact
+/-- The connecting homomorphism `S.X₃.homology i ⟶ S.X₁.homology j` for a short-exact
 short complex `S`. -/
 noncomputable def δ : S.X₃.homology i ⟶ S.X₁.homology j := (snakeInput hS i j hij).δ
 

--- a/Mathlib/Algebra/Homology/HomologySequenceLemmas.lean
+++ b/Mathlib/Algebra/Homology/HomologySequenceLemmas.lean
@@ -10,7 +10,7 @@ import Mathlib.CategoryTheory.Abelian.DiagramLemmas.Four
 /-!
 # Consequences of the homology sequence
 
-Given a morphism `φ : S₁ ⟶ S₂` between two short exact sequences
+Given a morphism `φ : S₁ ⟶ S₂` between two short-exact sequences
 of homological complexes in an abelian category, we show the naturality
 of the homology sequence of `S₁` and `S₂` with respect to `φ`
 (see `HomologicalComplex.HomologySequence.δ_naturality`).
@@ -66,7 +66,7 @@ lemma composableArrows₂_exact (hS₁ : S₁.ShortExact) (i : ι) :
 
 /-- The (exact) sequence
 `H_i(S.X₁) ⟶ H_i(S.X₂) ⟶ H_i(S.X₃) ⟶ H_j(S.X₁) ⟶ H_j(S.X₂) ⟶ H_j(S.X₃)` when `c.Rel i j`
-and `S` is a short exact short complex of homological complexes in an abelian category. -/
+and `S` is a short-exact short complex of homological complexes in an abelian category. -/
 @[simp]
 noncomputable def composableArrows₅ (i j : ι) (hij : c.Rel i j) : ComposableArrows C 5 :=
   mk₅ (homologyMap S₁.f i) (homologyMap S₁.g i) (hS₁.δ i j hij)
@@ -90,7 +90,7 @@ noncomputable def mapComposableArrows₂ (i : ι) : composableArrows₂ S₁ i �
     simp only [← homologyMap_comp, φ.comm₂₃])
 
 /-- The map `composableArrows₅ hS₁ i j hij ⟶ composableArrows₅ hS₂ i j hij` of exact
-sequences induced by a morphism `φ : S₁ ⟶ S₂` between short exact short complexes of
+sequences induced by a morphism `φ : S₁ ⟶ S₂` between short-exact short complexes of
 homological complexes. -/
 @[simp]
 noncomputable def mapComposableArrows₅ (i j : ι) (hij : c.Rel i j) :

--- a/Mathlib/Algebra/Homology/HomotopyCategory/DegreewiseSplit.lean
+++ b/Mathlib/Algebra/Homology/HomotopyCategory/DegreewiseSplit.lean
@@ -12,7 +12,7 @@ The main result of this file is the lemma
 `HomotopyCategory.distinguished_iff_iso_trianglehOfDegreewiseSplit` which asserts
 that a triangle in `HomotopyCategory C (ComplexShape.up ℤ)`
 is distinguished iff it is isomorphic to the triangle attached to a
-degreewise split short exact sequence of cochain complexes.
+degreewise split short-exact sequence of cochain complexes.
 
 -/
 
@@ -33,7 +33,7 @@ open HomologicalComplex HomComplex
 variable (S : ShortComplex (CochainComplex C ℤ))
   (σ : ∀ n, (S.map (eval C _ n)).Splitting)
 
-/-- The `1`-cocycle attached to a degreewise split short exact sequence of cochain complexes. -/
+/-- The `1`-cocycle attached to a degreewise split short-exact sequence of cochain complexes. -/
 def cocycleOfDegreewiseSplit : Cocycle S.X₃ S.X₁ 1 :=
   Cocycle.mk
     (Cochain.mk (fun p q _ => (σ p).s ≫ S.X₂.d p q ≫ (σ q).r)) 2 (by omega) (by
@@ -53,7 +53,7 @@ def cocycleOfDegreewiseSplit : Cocycle S.X₃ S.X₁ 1 :=
         sub_zero, neg_add_cancel])
 
 /-- The canonical morphism `S.X₃ ⟶ S.X₁⟦(1 : ℤ)⟧` attached to a degreewise split
-short exact sequence of cochain complexes. -/
+short-exact sequence of cochain complexes. -/
 def homOfDegreewiseSplit : S.X₃ ⟶ S.X₁⟦(1 : ℤ)⟧ :=
   ((Cocycle.equivHom _ _).symm ((cocycleOfDegreewiseSplit S σ).rightShift 1 0 (zero_add 1)))
 
@@ -63,14 +63,14 @@ lemma homOfDegreewiseSplit_f (n : ℤ) :
       (cocycleOfDegreewiseSplit S σ).1.v n (n + 1) rfl := by
   simp [homOfDegreewiseSplit, Cochain.rightShift_v _ _ _ _ _ _ _ _ rfl]
 
-/-- The triangle in `CochainComplex C ℤ` attached to a degreewise split short exact sequence
+/-- The triangle in `CochainComplex C ℤ` attached to a degreewise split short-exact sequence
 of cochain complexes. -/
 @[simps! obj₁ obj₂ obj₃ mor₁ mor₂ mor₃]
 def triangleOfDegreewiseSplit : Triangle (CochainComplex C ℤ) :=
   Triangle.mk S.f S.g (homOfDegreewiseSplit S σ)
 
 /-- The (distinguished) triangle in `HomotopyCategory C (ComplexShape.up ℤ)` attached to a
-degreewise split short exact sequence of cochain complexes. -/
+degreewise split short-exact sequence of cochain complexes. -/
 noncomputable abbrev trianglehOfDegreewiseSplit :
     Triangle (HomotopyCategory C (ComplexShape.up ℤ)) :=
   (HomotopyCategory.quotient C (ComplexShape.up ℤ)).mapTriangle.obj (triangleOfDegreewiseSplit S σ)
@@ -155,7 +155,7 @@ lemma mappingConeHomOfDegreewiseSplitIso_inv_comp_triangle_mor₃ :
 
 /-- The canonical isomorphism of triangles
 `(triangleOfDegreewiseSplit S σ).rotate.rotate ≅ mappingCone.triangle (homOfDegreewiseSplit S σ)`
-when `S` is a degreewise split short exact sequence of cochain complexes. -/
+when `S` is a degreewise split short-exact sequence of cochain complexes. -/
 noncomputable def triangleOfDegreewiseSplitRotateRotateIso :
     (triangleOfDegreewiseSplit S σ).rotate.rotate ≅
       mappingCone.triangle (homOfDegreewiseSplit S σ) :=
@@ -168,7 +168,7 @@ noncomputable def triangleOfDegreewiseSplitRotateRotateIso :
 
 /-- The canonical isomorphism between `(trianglehOfDegreewiseSplit S σ).rotate.rotate` and
 `mappingCone.triangleh (homOfDegreewiseSplit S σ)` when `S` is a degreewise split
-short exact sequence of cochain complexes. -/
+short-exact sequence of cochain complexes. -/
 noncomputable def trianglehOfDegreewiseSplitRotateRotateIso :
     (trianglehOfDegreewiseSplit S σ).rotate.rotate ≅
       mappingCone.triangleh (homOfDegreewiseSplit S σ) :=
@@ -187,7 +187,7 @@ given by `(triangle φ).rotate`. -/
 noncomputable def triangleRotateShortComplex : ShortComplex (CochainComplex C ℤ) :=
   ShortComplex.mk (triangle φ).rotate.mor₁ (triangle φ).rotate.mor₂ (by simp)
 
-/-- `triangleRotateShortComplex φ` is a degreewise split short exact sequence of
+/-- `triangleRotateShortComplex φ` is a degreewise split short-exact sequence of
 cochain complexes. -/
 @[simps]
 noncomputable def triangleRotateShortComplexSplitting (n : ℤ) :
@@ -203,7 +203,7 @@ lemma cocycleOfDegreewiseSplit_triangleRotateShortComplexSplitting_v (p : ℤ) :
   simp [cocycleOfDegreewiseSplit, d_snd_v φ p (p + 1) rfl]
 
 /-- The triangle `(triangle φ).rotate` is isomorphic to a triangle attached to a
-degreewise split short exact sequence of cochain complexes. -/
+degreewise split short-exact sequence of cochain complexes. -/
 noncomputable def triangleRotateIsoTriangleOfDegreewiseSplit :
     (triangle φ).rotate ≅
       triangleOfDegreewiseSplit _ (triangleRotateShortComplexSplitting φ) :=
@@ -211,7 +211,7 @@ noncomputable def triangleRotateIsoTriangleOfDegreewiseSplit :
     (by simp) (by simp) (by ext; simp)
 
 /-- The triangle `(triangleh φ).rotate` is isomorphic to a triangle attached to a
-degreewise split short exact sequence of cochain complexes. -/
+degreewise split short-exact sequence of cochain complexes. -/
 noncomputable def trianglehRotateIsoTrianglehOfDegreewiseSplit :
     (triangleh φ).rotate ≅
       trianglehOfDegreewiseSplit _ (triangleRotateShortComplexSplitting φ) :=

--- a/Mathlib/Algebra/Homology/HomotopyCategory/HomologicalFunctor.lean
+++ b/Mathlib/Algebra/Homology/HomotopyCategory/HomologicalFunctor.lean
@@ -14,8 +14,8 @@ In this file, it is shown that if `C` is an abelian category,
 then `homologyFunctor C (ComplexShape.up ℤ) n` is a homological functor
 `HomotopyCategory C (ComplexShape.up ℤ) ⥤ C`. As distinguished triangles
 in the homotopy category can be characterized in terms of degreewise split
-short exact sequences of cochain complexes, this follows from the homology
-sequence of a short exact sequences of homological complexes.
+short-exact sequences of cochain complexes, this follows from the homology
+sequence of a short-exact sequences of homological complexes.
 
 -/
 

--- a/Mathlib/Algebra/Homology/HomotopyCategory/Pretriangulated.lean
+++ b/Mathlib/Algebra/Homology/HomotopyCategory/Pretriangulated.lean
@@ -18,7 +18,7 @@ cochain complexes `φ : K ⟶ L`.
 
 This result first appeared in the Liquid Tensor Experiment. In the LTE, the
 formalization followed the Stacks Project: in particular, the distinguished
-triangles were defined using degreewise-split short exact sequences of cochain
+triangles were defined using degreewise-split short-exact sequences of cochain
 complexes. Here, we follow the original definitions in [Verdiers's thesis, I.3][verdier1996]
 (with the better sign conventions from the introduction of
 [Brian Conrad's book *Grothendieck duality and base change*][conrad2000]).

--- a/Mathlib/Algebra/Homology/HomotopyCategory/ShortExact.lean
+++ b/Mathlib/Algebra/Homology/HomotopyCategory/ShortExact.lean
@@ -11,7 +11,7 @@ import Mathlib.Algebra.Homology.Refinements
 /-!
 # The mapping cone of a monomorphism, up to a quasi-isomophism
 
-If `S` is a short exact short complex of cochain complexes in an abelian category,
+If `S` is a short-exact short complex of cochain complexes in an abelian category,
 we construct a quasi-isomorphism `descShortComplex S : mappingCone S.f ⟶ S.X₃`.
 
 We obtain this by comparing the homology sequence of `S` and the homology

--- a/Mathlib/Algebra/Homology/LocalCohomology.lean
+++ b/Mathlib/Algebra/Homology/LocalCohomology.lean
@@ -42,7 +42,7 @@ local cohomology, local cohomology modules
     * the right-derived functor definition
     * the characterization as the limit of Koszul homology
     * the characterization as the cohomology of a Cech-like complex
-* Establish long exact sequence(s) in local cohomology
+* Establish long-exact sequence(s) in local cohomology
 -/
 
 

--- a/Mathlib/Algebra/Homology/ShortComplex/ExactFunctor.lean
+++ b/Mathlib/Algebra/Homology/ShortComplex/ExactFunctor.lean
@@ -27,7 +27,7 @@ Let `F : C ⥤ D` be an additive functor:
 If we further assume that `C` and `D` are abelian categories, then we have:
 
 - `Functor.preservesFiniteLimits_tfae`: the following are equivalent:
-  1. for every short exact sequence `0 ⟶ A ⟶ B ⟶ C ⟶ 0`,
+  1. for every short-exact sequence `0 ⟶ A ⟶ B ⟶ C ⟶ 0`,
     `0 ⟶ F(A) ⟶ F(B) ⟶ F(C) ⟶ 0` is exact.
   2. for every exact sequence `A ⟶ B ⟶ C` where `A ⟶ B` is mono,
     `F(A) ⟶ F(B) ⟶ F(C)` is exact and `F(A) ⟶ F(B)` is mono.
@@ -35,7 +35,7 @@ If we further assume that `C` and `D` are abelian categories, then we have:
   4. `F` preserves finite limits.
 
 - `Functor.preservesFiniteColimits_tfae`: the following are equivalent:
-  1. for every short exact sequence `0 ⟶ A ⟶ B ⟶ C ⟶ 0`,
+  1. for every short-exact sequence `0 ⟶ A ⟶ B ⟶ C ⟶ 0`,
     `F(A) ⟶ F(B) ⟶ F(C) ⟶ 0` is exact.
   2. for every exact sequence `A ⟶ B ⟶ C` where `B ⟶ C` is epi,
     `F(A) ⟶ F(B) ⟶ F(C)` is exact and `F(B) ⟶ F(C)` is epi.
@@ -43,7 +43,7 @@ If we further assume that `C` and `D` are abelian categories, then we have:
   4. `F` preserves finite colimits.
 
 - `Functor.exact_tfae`: the following are equivalent:
-  1. for every short exact sequence `0 ⟶ A ⟶ B ⟶ C ⟶ 0`,
+  1. for every short-exact sequence `0 ⟶ A ⟶ B ⟶ C ⟶ 0`,
     `0 ⟶ F(A) ⟶ F(B) ⟶ F(C) ⟶ 0` is exact.
   2. for every exact sequence `A ⟶ B ⟶ C`, `F(A) ⟶ F(B) ⟶ F(C)` is exact.
   3. `F` preserves homology.
@@ -90,7 +90,7 @@ variable {C D : Type*} [Category C] [Category D] [Abelian C] [Abelian D]
 variable (F : C ⥤ D) [F.Additive]
 
 /--
-If a functor `F : C ⥤ D` preserves short exact sequences on the left-hand side, (i.e.
+If a functor `F : C ⥤ D` preserves short-exact sequences on the left-hand side, (i.e.
 if `0 ⟶ A ⟶ B ⟶ C ⟶ 0` is exact then `0 ⟶ F(A) ⟶ F(B) ⟶ F(C)` is exact)
 then it preserves monomorphism.
 -/
@@ -101,7 +101,7 @@ lemma preservesMonomorphisms_of_preserves_shortExact_left
 
 /--
 For an additive functor `F : C ⥤ D` between abelian categories, the following are equivalent:
-- `F` preserves short exact sequences on the left-hand side, i.e. if `0 ⟶ A ⟶ B ⟶ C ⟶ 0` is exact
+- `F` preserves short-exact sequences on the left-hand side, i.e. if `0 ⟶ A ⟶ B ⟶ C ⟶ 0` is exact
   then `0 ⟶ F(A) ⟶ F(B) ⟶ F(C)` is exact.
 - `F` preserves exact sequences on the left-hand side, i.e. if `A ⟶ B ⟶ C` is exact where `A ⟶ B`
   is mono, then `F(A) ⟶ F(B) ⟶ F(C)` is exact and `F(A) ⟶ F(B)` is mono as well.
@@ -155,7 +155,7 @@ lemma preservesEpimorphisms_of_preserves_shortExact_right
 
 /--
 For an additive functor `F : C ⥤ D` between abelian categories, the following are equivalent:
-- `F` preserves short exact sequences on the right-hand side, i.e. if `0 ⟶ A ⟶ B ⟶ C ⟶ 0` is
+- `F` preserves short-exact sequences on the right-hand side, i.e. if `0 ⟶ A ⟶ B ⟶ C ⟶ 0` is
   exact then `F(A) ⟶ F(B) ⟶ F(C) ⟶ 0` is exact.
 - `F` preserves exact sequences on the right-hand side, i.e. if `A ⟶ B ⟶ C` is exact where `B ⟶ C`
   is epi, then `F(A) ⟶ F(B) ⟶ F(C) ⟶ 0` is exact and `F(B) ⟶ F(C)` is epi as well.
@@ -199,7 +199,7 @@ lemma preservesFiniteColimits_tfae : List.TFAE
 
 /--
 For an additive functor `F : C ⥤ D` between abelian categories, the following are equivalent:
-- `F` preserves short exact sequences, i.e. if `0 ⟶ A ⟶ B ⟶ C ⟶ 0` is exact then
+- `F` preserves short-exact sequences, i.e. if `0 ⟶ A ⟶ B ⟶ C ⟶ 0` is exact then
   `0 ⟶ F(A) ⟶ F(B) ⟶ F(C) ⟶ 0` is exact.
 - `F` preserves exact sequences, i.e. if `A ⟶ B ⟶ C` is exact then `F(A) ⟶ F(B) ⟶ F(C)` is exact.
 - `F` preserves homology.

--- a/Mathlib/Algebra/Homology/ShortComplex/ShortExact.lean
+++ b/Mathlib/Algebra/Homology/ShortComplex/ShortExact.lean
@@ -151,14 +151,14 @@ lemma isIso₂_of_shortExact_of_isIso₁₃' [Balanced C] {S₁ S₂ : ShortComp
     (h₁ : S₁.ShortExact) (h₂ : S₂.ShortExact) (_ : IsIso φ.τ₁) (_ : IsIso φ.τ₃) : IsIso φ.τ₂ :=
   isIso₂_of_shortExact_of_isIso₁₃ φ h₁ h₂
 
-/-- If `S` is a short exact short complex in a balanced category,
+/-- If `S` is a short-exact short complex in a balanced category,
 then `S.X₁` is the kernel of `S.g`. -/
 noncomputable def ShortExact.fIsKernel [Balanced C] {S : ShortComplex C} (hS : S.ShortExact) :
     IsLimit (KernelFork.ofι S.f S.zero) := by
   have := hS.mono_f
   exact hS.exact.fIsKernel
 
-/-- If `S` is a short exact short complex in a balanced category,
+/-- If `S` is a short-exact short complex in a balanced category,
 then `S.X₃` is the cokernel of `S.f`. -/
 noncomputable def ShortExact.gIsCokernel [Balanced C] {S : ShortComplex C} (hS : S.ShortExact) :
     IsColimit (CokernelCofork.ofπ S.g S.zero) := by
@@ -166,7 +166,7 @@ noncomputable def ShortExact.gIsCokernel [Balanced C] {S : ShortComplex C} (hS :
   exact hS.exact.gIsCokernel
 
 /-- Is `S` is an exact short complex and `h : S.HomologyData`, there is
-a short exact sequence `0 ⟶ h.left.K ⟶ S.X₂ ⟶ h.right.Q ⟶ 0`. -/
+a short-exact sequence `0 ⟶ h.left.K ⟶ S.X₂ ⟶ h.right.Q ⟶ 0`. -/
 lemma Exact.shortExact {S : ShortComplex C} (hS : S.Exact) (h : S.HomologyData) :
     (ShortComplex.mk _ _ (h.exact_iff_i_p_zero.1 hS)).ShortExact where
   exact := by
@@ -194,7 +194,7 @@ lemma Splitting.shortExact {S : ShortComplex C} [HasZeroObject C] (s : S.Splitti
 
 namespace ShortExact
 
-/-- A choice of splitting for a short exact short complex `S` in a balanced category
+/-- A choice of splitting for a short-exact short complex `S` in a balanced category
 such that `S.X₁` is injective. -/
 noncomputable def splittingOfInjective {S : ShortComplex C} (hS : S.ShortExact)
     [Injective S.X₁] [Balanced C] :
@@ -202,7 +202,7 @@ noncomputable def splittingOfInjective {S : ShortComplex C} (hS : S.ShortExact)
   have := hS.mono_f
   Splitting.ofExactOfRetraction S hS.exact (Injective.factorThru (𝟙 S.X₁) S.f) (by simp) hS.epi_g
 
-/-- A choice of splitting for a short exact short complex `S` in a balanced category
+/-- A choice of splitting for a short-exact short complex `S` in a balanced category
 such that `S.X₃` is projective. -/
 noncomputable def splittingOfProjective {S : ShortComplex C} (hS : S.ShortExact)
     [Projective S.X₃] [Balanced C] :

--- a/Mathlib/Algebra/Lie/Extension.lean
+++ b/Mathlib/Algebra/Lie/Extension.lean
@@ -7,7 +7,7 @@ import Mathlib.Algebra.Lie.Ideal
 
 /-!
 # Extensions of Lie algebras
-This file defines extensions of Lie algebras, given by short exact sequences of Lie algebra
+This file defines extensions of Lie algebras, given by short-exact sequences of Lie algebra
 homomorphisms. They are implemented in two ways: `IsExtension` is a `Prop`-valued class taking two
 homomorphisms as parameters, and `Extension` is a structure that includes the middle Lie algebra.
 
@@ -40,7 +40,7 @@ class IsExtension (i : N →ₗ⁅R⁆ L) (p : L →ₗ⁅R⁆ M) : Prop where
   exact : i.range = p.ker
 
 variable (R N M) in
-/-- The type of all Lie extensions of `M` by `N`.  That is, short exact sequences of `R`-Lie algebra
+/-- The type of all Lie extensions of `M` by `N`.  That is, short-exact sequences of `R`-Lie algebra
 homomorphisms `0 → N → L → M → 0` where `R`, `M`, and `N` are fixed. -/
 structure Extension where
   /-- The middle object in the sequence. -/

--- a/Mathlib/CategoryTheory/Abelian/DiagramLemmas/KernelCokernelComp.lean
+++ b/Mathlib/CategoryTheory/Abelian/DiagramLemmas/KernelCokernelComp.lean
@@ -9,7 +9,7 @@ import Mathlib.Algebra.Homology.ShortComplex.SnakeLemma
 # Long exact sequence for the kernel and cokernel of a composition
 
 If `f : X ⟶ Y` and `g : Y ⟶ Z` are composable morphisms in an
-abelian category, we construct a long exact sequence :
+abelian category, we construct a long-exact sequence :
 `0 ⟶ ker f ⟶ ker (f ≫ g) ⟶ ker g ⟶ coker f ⟶ coker (f ≫ g) ⟶ coker g ⟶ 0`.
 
 This is obtained by applying the snake lemma to the following morphism of
@@ -27,7 +27,7 @@ and `φ` is given by the following matrix:
 ```
 
 Indeed the snake lemma gives an exact sequence involving the kernels and cokernels
-of the vertical maps: in order to get the expected long exact sequence, it suffices
+of the vertical maps: in order to get the expected long-exact sequence, it suffices
 to obtain isomorphisms `ker φ ≅ ker (f ≫ g)` and `coker φ ≅ coker (f ⋙ g)`.
 
 -/
@@ -190,7 +190,7 @@ end kernelCokernelCompSequence
 open kernelCokernelCompSequence
 
 /-- If `f : X ⟶ Y` and `g : Y ⟶ Z` are composable morphisms in an
-abelian category, this is the long exact sequence
+abelian category, this is the long-exact sequence
 `0 ⟶ ker f ⟶ ker (f ≫ g) ⟶ ker g ⟶ coker f ⟶ coker (f ≫ g) ⟶ coker g ⟶ 0`. -/
 noncomputable abbrev kernelCokernelCompSequence : ComposableArrows C 5 :=
   .mk₅ (kernel.map f (f ≫ g) (𝟙 _) g (by simp))

--- a/Mathlib/CategoryTheory/Abelian/GrothendieckAxioms/Basic.lean
+++ b/Mathlib/CategoryTheory/Abelian/GrothendieckAxioms/Basic.lean
@@ -32,10 +32,10 @@ in `HasExactColimitsOfShape.of_domain_equivalence` and
 
 ## Remarks
 
-For `AB4` and `AB5`, we only require left exactness as right exactness is automatic.
+For `AB4` and `AB5`, we only require left-exactness as right-exactness is automatic.
 A comparison with Grothendieck's original formulation of the properties can be found in the
 comments of the linked Stacks page.
-Exactness as the preservation of short exact sequences is introduced in
+Exactness as the preservation of short-exact sequences is introduced in
 `CategoryTheory.Abelian.Exact`.
 
 We do not require `Abelian` in the definition of `AB4` and `AB5` because these classes represent

--- a/Mathlib/CategoryTheory/Abelian/GrothendieckCategory/ModuleEmbedding/GabrielPopescu.lean
+++ b/Mathlib/CategoryTheory/Abelian/GrothendieckCategory/ModuleEmbedding/GabrielPopescu.lean
@@ -133,7 +133,7 @@ theorem GabrielPopescu.preservesInjectiveObjects (G : C) (hG : IsSeparator G) :
     · rw [ModuleCat.mono_iff_injective]
       cat_disch
 
-/-- Right exactness follows because `tensorObj G` is a left adjoint. -/
+/-- Right-exactness follows because `tensorObj G` is a left adjoint. -/
 theorem GabrielPopescu.preservesFiniteLimits (G : C) (hG : IsSeparator G) :
     PreservesFiniteLimits (tensorObj G) := by
   have := preservesInjectiveObjects G hG

--- a/Mathlib/CategoryTheory/Functor/Flat.lean
+++ b/Mathlib/CategoryTheory/Functor/Flat.lean
@@ -22,7 +22,7 @@ Remark C2.3.7, and this name is suggested by Mike Shulman in
 https://golem.ph.utexas.edu/category/2011/06/flat_functors_and_morphisms_of.html to avoid
 confusion with other notions of flatness.
 
-This definition is equivalent to left exact functors (functors that preserves finite limits) when
+This definition is equivalent to left-exact functors (functors that preserves finite limits) when
 `C` has all finite limits.
 
 ## Main results

--- a/Mathlib/CategoryTheory/Limits/ExactFunctor.lean
+++ b/Mathlib/CategoryTheory/Limits/ExactFunctor.lean
@@ -11,7 +11,7 @@ import Mathlib.CategoryTheory.Limits.Preserves.Finite
 We say that a functor `F` is left exact if it preserves finite limits, it is right exact if it
 preserves finite colimits, and it is exact if it is both left exact and right exact.
 
-In this file, we define the categories of bundled left exact, right exact and exact functors.
+In this file, we define the categories of bundled left-exact, right-exact and exact functors.
 
 -/
 
@@ -35,10 +35,10 @@ def LeftExactFunctor :=
 instance : Category (LeftExactFunctor C D) :=
   ObjectProperty.FullSubcategory.category _
 
-/-- `C ⥤ₗ D` denotes left exact functors `C ⥤ D` -/
+/-- `C ⥤ₗ D` denotes left-exact functors `C ⥤ D` -/
 infixr:26 " ⥤ₗ " => LeftExactFunctor
 
-/-- A left exact functor is in particular a functor. -/
+/-- A left-exact functor is in particular a functor. -/
 def LeftExactFunctor.forget : (C ⥤ₗ D) ⥤ C ⥤ D :=
   ObjectProperty.ι _
 
@@ -48,7 +48,7 @@ instance : (LeftExactFunctor.forget C D).Full :=
 instance : (LeftExactFunctor.forget C D).Faithful :=
   ObjectProperty.faithful_ι _
 
-/-- The inclusion of left exact functors into functors is fully faithful. -/
+/-- The inclusion of left-exact functors into functors is fully faithful. -/
 abbrev LeftExactFunctor.fullyFaithful : (LeftExactFunctor.forget C D).FullyFaithful :=
   ObjectProperty.fullyFaithfulι _
 
@@ -59,10 +59,10 @@ def RightExactFunctor :=
 instance : Category (RightExactFunctor C D) :=
   ObjectProperty.FullSubcategory.category _
 
-/-- `C ⥤ᵣ D` denotes right exact functors `C ⥤ D` -/
+/-- `C ⥤ᵣ D` denotes right-exact functors `C ⥤ D` -/
 infixr:26 " ⥤ᵣ " => RightExactFunctor
 
-/-- A right exact functor is in particular a functor. -/
+/-- A right-exact functor is in particular a functor. -/
 def RightExactFunctor.forget : (C ⥤ᵣ D) ⥤ C ⥤ D :=
   ObjectProperty.ι _
 
@@ -72,7 +72,7 @@ instance : (RightExactFunctor.forget C D).Full :=
 instance : (RightExactFunctor.forget C D).Faithful :=
   ObjectProperty.faithful_ι _
 
-/-- The inclusion of right exact functors into functors is fully faithful. -/
+/-- The inclusion of right-exact functors into functors is fully faithful. -/
 abbrev RightExactFunctor.fullyFaithful : (RightExactFunctor.forget C D).FullyFaithful :=
   ObjectProperty.fullyFaithfulι _
 
@@ -97,7 +97,7 @@ instance : (ExactFunctor.forget C D).Full :=
 instance : (ExactFunctor.forget C D).Faithful :=
   ObjectProperty.faithful_ι _
 
-/-- Turn an exact functor into a left exact functor. -/
+/-- Turn an exact functor into a left-exact functor. -/
 def LeftExactFunctor.ofExact : (C ⥤ₑ D) ⥤ C ⥤ₗ D :=
   ObjectProperty.ιOfLE (fun _ => And.left)
 
@@ -107,7 +107,7 @@ instance : (LeftExactFunctor.ofExact C D).Full :=
 instance : (LeftExactFunctor.ofExact C D).Faithful :=
   ObjectProperty.faithful_ιOfLE _
 
-/-- Turn an exact functor into a left exact functor. -/
+/-- Turn an exact functor into a left-exact functor. -/
 def RightExactFunctor.ofExact : (C ⥤ₑ D) ⥤ C ⥤ᵣ D :=
   ObjectProperty.ιOfLE (fun _ => And.right)
 
@@ -165,11 +165,11 @@ theorem RightExactFunctor.forget_map {F G : C ⥤ᵣ D} (α : F ⟶ G) :
 theorem ExactFunctor.forget_map {F G : C ⥤ₑ D} (α : F ⟶ G) : (ExactFunctor.forget C D).map α = α :=
   rfl
 
-/-- Turn a left exact functor into an object of the category `LeftExactFunctor C D`. -/
+/-- Turn a left-exact functor into an object of the category `LeftExactFunctor C D`. -/
 def LeftExactFunctor.of (F : C ⥤ D) [PreservesFiniteLimits F] : C ⥤ₗ D :=
   ⟨F, inferInstance⟩
 
-/-- Turn a right exact functor into an object of the category `RightExactFunctor C D`. -/
+/-- Turn a right-exact functor into an object of the category `RightExactFunctor C D`. -/
 def RightExactFunctor.of (F : C ⥤ D) [PreservesFiniteColimits F] : C ⥤ᵣ D :=
   ⟨F, inferInstance⟩
 
@@ -222,7 +222,7 @@ section
 
 variable (C D E)
 
-/-- Whiskering a left exact functor by a left exact functor yields a left exact functor. -/
+/-- Whiskering a left-exact functor by a left-exact functor yields a left-exact functor. -/
 @[simps! obj_obj obj_map map_app_app]
 def LeftExactFunctor.whiskeringLeft : (C ⥤ₗ D) ⥤ (D ⥤ₗ E) ⥤ (C ⥤ₗ E) where
   obj F := ObjectProperty.lift _ (forget _ _ ⋙ (Functor.whiskeringLeft C D E).obj F.obj)
@@ -237,7 +237,7 @@ def LeftExactFunctor.whiskeringLeft : (C ⥤ₗ D) ⥤ (D ⥤ₗ E) ⥤ (C ⥤�
     rw [ObjectProperty.FullSubcategory.comp_def]
     cat_disch
 
-/-- Whiskering a left exact functor by a left exact functor yields a left exact functor. -/
+/-- Whiskering a left-exact functor by a left-exact functor yields a left-exact functor. -/
 @[simps! obj_obj obj_map map_app_app]
 def LeftExactFunctor.whiskeringRight : (D ⥤ₗ E) ⥤ (C ⥤ₗ D) ⥤ (C ⥤ₗ E) where
   obj F := ObjectProperty.lift _ (forget _ _ ⋙ (Functor.whiskeringRight C D E).obj F.obj)
@@ -246,7 +246,7 @@ def LeftExactFunctor.whiskeringRight : (D ⥤ₗ E) ⥤ (C ⥤ₗ D) ⥤ (C ⥤�
     { app := fun H => ((Functor.whiskeringRight C D E).map η).app H.obj
       naturality := fun _ _ f => ((Functor.whiskeringRight C D E).map η).naturality f }
 
-/-- Whiskering a right exact functor by a right exact functor yields a right exact functor. -/
+/-- Whiskering a right-exact functor by a right-exact functor yields a right-exact functor. -/
 @[simps! obj_obj obj_map map_app_app]
 def RightExactFunctor.whiskeringLeft : (C ⥤ᵣ D) ⥤ (D ⥤ᵣ E) ⥤ (C ⥤ᵣ E) where
   obj F := ObjectProperty.lift _ (forget _ _ ⋙ (Functor.whiskeringLeft C D E).obj F.obj)
@@ -261,7 +261,7 @@ def RightExactFunctor.whiskeringLeft : (C ⥤ᵣ D) ⥤ (D ⥤ᵣ E) ⥤ (C ⥤�
     rw [ObjectProperty.FullSubcategory.comp_def]
     cat_disch
 
-/-- Whiskering a right exact functor by a right exact functor yields a right exact functor. -/
+/-- Whiskering a right-exact functor by a right-exact functor yields a right-exact functor. -/
 @[simps! obj_obj obj_map map_app_app]
 def RightExactFunctor.whiskeringRight : (D ⥤ᵣ E) ⥤ (C ⥤ᵣ D) ⥤ (C ⥤ᵣ E) where
   obj F := ObjectProperty.lift _ (forget _ _ ⋙ (Functor.whiskeringRight C D E).obj F.obj)

--- a/Mathlib/CategoryTheory/Limits/Preserves/Finite.lean
+++ b/Mathlib/CategoryTheory/Limits/Preserves/Finite.lean
@@ -9,7 +9,7 @@ import Mathlib.CategoryTheory.Limits.Shapes.FiniteProducts
 /-!
 # Preservation of finite (co)limits.
 
-These functors are also known as lef-exact (flat) or right-exact functors when the categories
+These functors are also known as left-exact (flat) or right-exact functors when the categories
 involved are abelian, or more generally, finitely (co)complete.
 
 ## Related results

--- a/Mathlib/CategoryTheory/Limits/Preserves/Finite.lean
+++ b/Mathlib/CategoryTheory/Limits/Preserves/Finite.lean
@@ -9,7 +9,7 @@ import Mathlib.CategoryTheory.Limits.Shapes.FiniteProducts
 /-!
 # Preservation of finite (co)limits.
 
-These functors are also known as left exact (flat) or right exact functors when the categories
+These functors are also known as lef-exact (flat) or right-exact functors when the categories
 involved are abelian, or more generally, finitely (co)complete.
 
 ## Related results
@@ -79,7 +79,7 @@ lemma preservesFiniteLimits_of_preservesFiniteLimitsOfSize (F : C ⥤ D)
         haveI := h (ULiftHom (ULift J)) CategoryTheory.finCategoryUlift
         exact preservesLimitsOfShape_of_equiv (ULiftHomULiftCategory.equiv J).symm F
 
-/-- The composition of two left exact functors is left exact. -/
+/-- The composition of two left-exact functors is left exact. -/
 lemma comp_preservesFiniteLimits (F : C ⥤ D) (G : D ⥤ E) [PreservesFiniteLimits F]
     [PreservesFiniteLimits G] : PreservesFiniteLimits (F ⋙ G) :=
   ⟨fun _ _ _ => inferInstance⟩
@@ -235,7 +235,7 @@ lemma preservesFiniteColimits_of_preservesFiniteColimitsOfSize (F : C ⥤ D)
         haveI := h (ULiftHom (ULift J)) CategoryTheory.finCategoryUlift
         exact preservesColimitsOfShape_of_equiv (ULiftHomULiftCategory.equiv J).symm F
 
-/-- The composition of two right exact functors is right exact. -/
+/-- The composition of two right-exact functors is right exact. -/
 lemma comp_preservesFiniteColimits (F : C ⥤ D) (G : D ⥤ E) [PreservesFiniteColimits F]
     [PreservesFiniteColimits G] : PreservesFiniteColimits (F ⋙ G) :=
   ⟨fun _ _ _ => inferInstance⟩

--- a/Mathlib/CategoryTheory/Limits/Preserves/Presheaf.lean
+++ b/Mathlib/CategoryTheory/Limits/Preserves/Presheaf.lean
@@ -14,7 +14,7 @@ is a presheaf, then `CostructuredArrow yoneda A` is filtered (equivalently, the 
 elements of `A` is cofiltered) if and only if `A` preserves finite limits.
 
 This is one of the keys steps of establishing the equivalence `Ind C ≌ (Cᵒᵖ ⥤ₗ Type u)` (here,
-`Cᵒᵖ ⥤ₗ Type u` is the category of left exact functors) for a *small* finitely cocomplete category
+`Cᵒᵖ ⥤ₗ Type u` is the category of left-exact functors) for a *small* finitely cocomplete category
 `C`.
 
 ## Implementation notes

--- a/Mathlib/CategoryTheory/ObjectProperty/Extensions.lean
+++ b/Mathlib/CategoryTheory/ObjectProperty/Extensions.lean
@@ -32,7 +32,7 @@ section
 variable [HasZeroMorphisms C]
 
 /-- Given `P : ObjectProperty C`, we say that `P` is closed under extensions
-if whenever `0 ⟶ X₁ ⟶ X₂ ⟶ X₃ ⟶ 0` is a short exact short complex,
+if whenever `0 ⟶ X₁ ⟶ X₂ ⟶ X₃ ⟶ 0` is a short-exact short complex,
 then `P X₁` and `P X₃` implies `P X₂`. -/
 class IsClosedUnderExtensions : Prop where
   prop_X₂_of_shortExact {S : ShortComplex C} (hS : S.ShortExact)

--- a/Mathlib/CategoryTheory/Preadditive/AdditiveFunctor.lean
+++ b/Mathlib/CategoryTheory/Preadditive/AdditiveFunctor.lean
@@ -269,7 +269,7 @@ attribute [local instance] preservesBinaryBiproducts_of_preservesBinaryProducts
 
 attribute [local instance] preservesBinaryBiproducts_of_preservesBinaryCoproducts
 
-/-- Turn a left exact functor into an additive functor. -/
+/-- Turn a left-exact functor into an additive functor. -/
 def AdditiveFunctor.ofLeftExact : (C ⥤ₗ D) ⥤ C ⥤+ D :=
   ObjectProperty.ιOfLE fun F ⟨_⟩ =>
     Functor.additive_of_preservesBinaryBiproducts F
@@ -277,7 +277,7 @@ def AdditiveFunctor.ofLeftExact : (C ⥤ₗ D) ⥤ C ⥤+ D :=
 instance : (AdditiveFunctor.ofLeftExact C D).Full := ObjectProperty.full_ιOfLE _
 instance : (AdditiveFunctor.ofLeftExact C D).Faithful := ObjectProperty.faithful_ιOfLE _
 
-/-- Turn a right exact functor into an additive functor. -/
+/-- Turn a right-exact functor into an additive functor. -/
 def AdditiveFunctor.ofRightExact : (C ⥤ᵣ D) ⥤ C ⥤+ D :=
   ObjectProperty.ιOfLE fun F ⟨_⟩ =>
     Functor.additive_of_preservesBinaryBiproducts F

--- a/Mathlib/CategoryTheory/Preadditive/LeftExact.lean
+++ b/Mathlib/CategoryTheory/Preadditive/LeftExact.lean
@@ -8,10 +8,10 @@ import Mathlib.CategoryTheory.Limits.Preserves.Shapes.Kernels
 import Mathlib.CategoryTheory.Preadditive.AdditiveFunctor
 
 /-!
-# Left exactness of functors between preadditive categories
+# Left-exactness of functors between preadditive categories
 
 We show that a functor is left exact in the sense that it preserves finite limits, if it
-preserves kernels. The dual result holds for right exact functors and cokernels.
+preserves kernels. The dual result holds for right-exact functors and cokernels.
 
 ## Main results
 

--- a/Mathlib/CategoryTheory/Shift/ShiftSequence.lean
+++ b/Mathlib/CategoryTheory/Shift/ShiftSequence.lean
@@ -14,7 +14,7 @@ shift by an additive monoid `M`. In this file, we define a typeclass
 `F.shift a : C ⥤ A` for all `a : A`. For each `a : A`, we have
 an isomorphism `F.isoShift a : shiftFunctor C a ⋙ F ≅ F.shift a` which
 satisfies some coherence relations. This allows to state results
-(e.g. the long exact sequence of an homology functor (TODO)) using
+(e.g. the long-exact sequence of an homology functor (TODO)) using
 functors `F.shift a` rather than `shiftFunctor C a ⋙ F`. The reason
 for this design is that we can often choose functors `F.shift a` that
 have better definitional properties than `shiftFunctor C a ⋙ F`.

--- a/Mathlib/CategoryTheory/Sites/Grothendieck.lean
+++ b/Mathlib/CategoryTheory/Sites/Grothendieck.lean
@@ -46,7 +46,7 @@ TODO (BM): Add the definition from Stacks, as a pretopology, and complete to a t
 
 This is so that we can produce a bijective correspondence between Grothendieck topologies on a
 small category and Lawvere-Tierney topologies on its presheaf topos, as well as the equivalence
-between Grothendieck topoi and left exact reflective subcategories of presheaf toposes.
+between Grothendieck topoi and left-exact reflective subcategories of presheaf toposes.
 -/
 
 

--- a/Mathlib/CategoryTheory/Sites/LeftExact.lean
+++ b/Mathlib/CategoryTheory/Sites/LeftExact.lean
@@ -9,7 +9,7 @@ import Mathlib.CategoryTheory.Adhesive
 import Mathlib.CategoryTheory.Sites.ConcreteSheafification
 
 /-!
-# Left exactness of sheafification
+# Left-exactness of sheafification
 In this file we show that sheafification commutes with finite limits.
 -/
 

--- a/Mathlib/CategoryTheory/Sites/MayerVietorisSquare.lean
+++ b/Mathlib/CategoryTheory/Sites/MayerVietorisSquare.lean
@@ -17,18 +17,18 @@ import Mathlib.CategoryTheory.Sites.Sheafification
 /-!
 # Mayer-Vietoris squares
 
-The purpose of this file is to allow the formalization of long exact
+The purpose of this file is to allow the formalization of long-exact
 Mayer-Vietoris sequences in sheaf cohomology. If `X₄` is an open subset
 of a topological space that is covered by two open subsets `X₂` and `X₃`,
-it is known that there is a long exact sequence
+it is known that there is a long-exact sequence
 `... ⟶ H^q(X₄) ⟶ H^q(X₂) ⊞ H^q(X₃) ⟶ H^q(X₁) ⟶ H^{q+1}(X₄) ⟶ ...`
 where `X₁` is the intersection of `X₂` and `X₃`, and `H^q` are the
 cohomology groups with values in an abelian sheaf.
 
 In this file, we introduce a structure
 `GrothendieckTopology.MayerVietorisSquare` which extends `Square C`,
-and asserts properties which shall imply the existence of long
-exact Mayer-Vietoris sequences in sheaf cohomology (TODO).
+and asserts properties which shall imply the existence of long-exact
+Mayer-Vietoris sequences in sheaf cohomology (TODO).
 We require that the map `X₁ ⟶ X₃` is a monomorphism and
 that the square in `C` becomes a pushout square in
 the category of sheaves after the application of the

--- a/Mathlib/CategoryTheory/Sites/NonabelianCohomology/H1.lean
+++ b/Mathlib/CategoryTheory/Sites/NonabelianCohomology/H1.lean
@@ -20,7 +20,7 @@ case, it would be a particular case of Čech cohomology (TODO).
 
 ## TODO
 
-* show that if `1 ⟶ G₁ ⟶ G₂ ⟶ G₃ ⟶ 1` is a short exact sequence of sheaves
+* show that if `1 ⟶ G₁ ⟶ G₂ ⟶ G₃ ⟶ 1` is a short-exact sequence of sheaves
   of groups, and `x₃` is a global section of `G₃` which can be locally lifted
   to a section of `G₂`, there is an associated canonical cohomology class of `G₁`
   which is trivial iff `x₃` can be lifted to a global section of `G₂`.

--- a/Mathlib/CategoryTheory/Sites/Sheafification.lean
+++ b/Mathlib/CategoryTheory/Sites/Sheafification.lean
@@ -12,7 +12,7 @@ import Mathlib.CategoryTheory.Limits.Preserves.Finite
 # Sheafification
 
 Given a site `(C, J)` we define a typeclass `HasSheafify J A` saying that the inclusion functor from
-`A`-valued sheaves on `C` to presheaves admits a left exact left adjoint (sheafification).
+`A`-valued sheaves on `C` to presheaves admits a left-exact left adjoint (sheafification).
 
 Note: to access the `HasSheafify` instance for suitable concrete categories, import the file
 `Mathlib/CategoryTheory/Sites/LeftExact.lean`.
@@ -33,7 +33,7 @@ A proposition saying that the inclusion functor from sheaves to presheaves admit
 abbrev HasWeakSheafify : Prop := (sheafToPresheaf J A).IsRightAdjoint
 
 /--
-`HasSheafify` means that the inclusion functor from sheaves to presheaves admits a left exact
+`HasSheafify` means that the inclusion functor from sheaves to presheaves admits a left-exact
 left adjoint (sheafification).
 
 Given a finite limit preserving functor `F : (Cᵒᵖ ⥤ A) ⥤ Sheaf J A` and an adjunction

--- a/Mathlib/CategoryTheory/Triangulated/HomologicalFunctor.lean
+++ b/Mathlib/CategoryTheory/Triangulated/HomologicalFunctor.lean
@@ -23,10 +23,10 @@ we have isomorphisms `(F.shift n).obj X ≅ F.obj (X⟦n⟧)`, but through the c
 Given a triangle `T` in `C`, we define a connecting homomorphism
 `F.homologySequenceδ T n₀ n₁ h : (F.shift n₀).obj T.obj₃ ⟶ (F.shift n₁).obj T.obj₁`
 under the assumption `h : n₀ + 1 = n₁`. When `T` is distinguished, this connecting
-homomorphism is part of a long exact sequence
+homomorphism is part of a long-exact sequence
 `... ⟶ (F.shift n₀).obj T.obj₁ ⟶ (F.shift n₀).obj T.obj₂ ⟶ (F.shift n₀).obj T.obj₃ ⟶ ...`
 
-The exactness of this long exact sequence is given by three lemmas
+The exactness of this long-exact sequence is given by three lemmas
 `F.homologySequence_exact₁`, `F.homologySequence_exact₂` and `F.homologySequence_exact₃`.
 
 If `F` is a homological functor, we define the strictly full triangulated subcategory
@@ -163,7 +163,7 @@ end Pretriangulated
 
 section
 
-/-- The connecting homomorphism in the long exact sequence attached to an homological
+/-- The connecting homomorphism in the long-exact sequence attached to an homological
 functor and a distinguished triangle. -/
 noncomputable def homologySequenceδ
     [F.ShiftSequence ℤ] (T : Triangle C) (n₀ n₁ : ℤ) (h : n₀ + 1 = n₁) :

--- a/Mathlib/GroupTheory/GroupExtension/Defs.lean
+++ b/Mathlib/GroupTheory/GroupExtension/Defs.lean
@@ -15,7 +15,7 @@ such as splittings and equivalences.
 
 ## Main definitions
 
-- `(Add?)GroupExtension N E G`: structure for extensions of `G` by `N` as short exact sequences
+- `(Add?)GroupExtension N E G`: structure for extensions of `G` by `N` as short-exact sequences
   `1 → N → E → G → 1` (`0 → N → E → G → 0` for additive groups)
 - `(Add?)GroupExtension.Equiv S S'`: structure for equivalences of two group extensions `S` and `S'`
   as specific homomorphisms `E → E'` such that each diagram below is commutative
@@ -52,7 +52,7 @@ If `N` is abelian,
 
 variable (N E G : Type*)
 
-/-- `AddGroupExtension N E G` is a short exact sequence of additive groups `0 → N → E → G → 0`. -/
+/-- `AddGroupExtension N E G` is a short-exact sequence of additive groups `0 → N → E → G → 0`. -/
 structure AddGroupExtension [AddGroup N] [AddGroup E] [AddGroup G] where
   /-- The inclusion homomorphism `N →+ E` -/
   inl : N →+ E
@@ -65,7 +65,7 @@ structure AddGroupExtension [AddGroup N] [AddGroup E] [AddGroup G] where
   /-- The projection map is surjective. -/
   rightHom_surjective : Function.Surjective rightHom
 
-/-- `GroupExtension N E G` is a short exact sequence of groups `1 → N → E → G → 1`. -/
+/-- `GroupExtension N E G` is a short-exact sequence of groups `1 → N → E → G → 1`. -/
 @[to_additive]
 structure GroupExtension [Group N] [Group E] [Group G] where
   /-- The inclusion homomorphism `N →* E` -/

--- a/Mathlib/GroupTheory/MonoidLocalization/GrothendieckGroup.lean
+++ b/Mathlib/GroupTheory/MonoidLocalization/GrothendieckGroup.lean
@@ -13,7 +13,7 @@ containing `M`, in the sense that monoid homs `M → H` are in bijection with mo
 any commutative group `H`.
 
 Note that "Grothendieck group" also refers to the analogous construction in an abelian category
-obtained by formally making the last term of each short exact sequence invertible.
+obtained by formally making the last term of each short-exact sequence invertible.
 
 ### References
 

--- a/Mathlib/LinearAlgebra/TensorProduct/RightExactness.lean
+++ b/Mathlib/LinearAlgebra/TensorProduct/RightExactness.lean
@@ -23,14 +23,14 @@ import Mathlib.RingTheory.TensorProduct.Basic
   More generally, `LinearMap.lTensor_range`  computes the range of
   `LinearMap.lTensor`
 
-* `TensorProduct.rTensor_exact` says that when one tensors a short exact
-  sequence on the right, one still gets a short exact sequence
+* `TensorProduct.rTensor_exact` says that when one tensors a short-exact
+  sequence on the right, one still gets a short-exact sequence
   (right-exactness of `TensorProduct.rTensor`),
   and `rTensor.equiv` gives the LinearEquiv that follows from this
   combined with `LinearMap.rTensor_surjective`.
 
-* `TensorProduct.lTensor_exact` says that when one tensors a short exact
-  sequence on the left, one still gets a short exact sequence
+* `TensorProduct.lTensor_exact` says that when one tensors a short-exact
+  sequence on the left, one still gets a short-exact sequence
   (right-exactness of `TensorProduct.rTensor`)
   and `lTensor.equiv` gives the LinearEquiv that follows from this
   combined with `LinearMap.lTensor_surjective`.
@@ -40,7 +40,7 @@ import Mathlib.RingTheory.TensorProduct.Basic
   and `lTensor_mkQ` compute `ker (lTensor Q (N.mkQ))` and similarly for `rTensor_mkQ`
 
 * `TensorProduct.map_ker` computes the kernel of `TensorProduct.map f g'`
-  in the presence of two short exact sequences.
+  in the presence of two short-exact sequences.
 
 The proofs are those of [bourbaki1989] (chap. 2, §3, n°6)
 
@@ -570,7 +570,7 @@ lemma Ideal.map_includeRight_eq (I : Ideal B) :
         rw [map_add]
         apply Submodule.add_mem _ hx hy
 
--- Now, we can prove the right exactness properties of the tensor product,
+-- Now, we can prove the right-exactness properties of the tensor product,
 -- in its versions for algebras
 
 variable {R : Type*} [CommRing R]

--- a/Mathlib/RepresentationTheory/Coinvariants.lean
+++ b/Mathlib/RepresentationTheory/Coinvariants.lean
@@ -305,7 +305,7 @@ abbrev toCoinvariants : Rep k G := Rep.of (A.ρ.toCoinvariants S)
 the coinvariants of `ρ|_S`. -/
 abbrev quotientToCoinvariants : Rep k (G ⧸ S) := ofQuotient (toCoinvariants A S) S
 
-/-- Given a normal subgroup `S ≤ G`, a `G`-representation `A` induces a short exact sequence of
+/-- Given a normal subgroup `S ≤ G`, a `G`-representation `A` induces a short-exact sequence of
 `G`-representations `0 ⟶ Ker(mk) ⟶ A ⟶ A_S ⟶ 0` where `mk` is the quotient map to the
 `S`-coinvariants `A_S`. -/
 @[simps X₁ X₂ X₃ f g]

--- a/Mathlib/RepresentationTheory/Homological/GroupCohomology/LongExactSequence.lean
+++ b/Mathlib/RepresentationTheory/Homological/GroupCohomology/LongExactSequence.lean
@@ -10,13 +10,13 @@ import Mathlib.RepresentationTheory.Homological.GroupCohomology.Functoriality
 /-!
 # Long exact sequence in group cohomology
 
-Given a commutative ring `k` and a group `G`, this file shows that a short exact sequence of
-`k`-linear `G`-representations `0 ⟶ X₁ ⟶ X₂ ⟶ X₃ ⟶ 0` induces a short exact sequence of
+Given a commutative ring `k` and a group `G`, this file shows that a short-exact sequence of
+`k`-linear `G`-representations `0 ⟶ X₁ ⟶ X₂ ⟶ X₃ ⟶ 0` induces a short-exact sequence of
 complexes
 `0 ⟶ inhomogeneousCochains X₁ ⟶ inhomogeneousCochains X₂ ⟶ inhomogeneousCochains X₃ ⟶ 0`.
 
 Since the cohomology of `inhomogeneousCochains Xᵢ` is the group cohomology of `Xᵢ`, this allows us
-to specialize API about long exact sequences to group cohomology.
+to specialize API about long-exact sequences to group cohomology.
 
 ## Main definitions
 
@@ -107,7 +107,7 @@ noncomputable abbrev cocyclesMkOfCompEqD {i j : ℕ} {y : (Fin i → G) → X.X�
       (by simpa using hx) (j + 1))
 
 theorem δ_apply {i j : ℕ} (hij : i + 1 = j)
-    -- Let `0 ⟶ X₁ ⟶f X₂ ⟶g X₃ ⟶ 0` be a short exact sequence of `G`-representations.
+    -- Let `0 ⟶ X₁ ⟶f X₂ ⟶g X₃ ⟶ 0` be a short-exact sequence of `G`-representations.
     -- Let `z` be an `i`-cocycle for `X₃`
     (z : (Fin i → G) → X.X₃) (hz : (inhomogeneousCochains X.X₃).d i j z = 0)
     -- Let `y` be an `i`-cochain for `X₂` such that `g ∘ y = z`
@@ -132,7 +132,7 @@ theorem mem_cocycles₁_of_comp_eq_d₀₁
 alias mem_oneCocycles_of_comp_eq_dZero := mem_cocycles₁_of_comp_eq_d₀₁
 
 theorem δ₀_apply
-    -- Let `0 ⟶ X₁ ⟶f X₂ ⟶g X₃ ⟶ 0` be a short exact sequence of `G`-representations.
+    -- Let `0 ⟶ X₁ ⟶f X₂ ⟶g X₃ ⟶ 0` be a short-exact sequence of `G`-representations.
     -- Let `z : X₃ᴳ` and `y : X₂` be such that `g(y) = z`.
     (z : X.X₃.ρ.invariants) (y : X.X₂) (hy : X.g.hom y = z)
     -- Let `x` be a 1-cochain for `X₁` such that `f ∘ x = d(y)`.
@@ -158,7 +158,7 @@ theorem mem_cocycles₂_of_comp_eq_d₁₂
 alias mem_twoCocycles_of_comp_eq_dOne := mem_cocycles₂_of_comp_eq_d₁₂
 
 theorem δ₁_apply
-    -- Let `0 ⟶ X₁ ⟶f X₂ ⟶g X₃ ⟶ 0` be a short exact sequence of `G`-representations.
+    -- Let `0 ⟶ X₁ ⟶f X₂ ⟶g X₃ ⟶ 0` be a short-exact sequence of `G`-representations.
     -- Let `z` be a 1-cocycle for `X₃` and `y` be a 1-cochain for `X₂` such that `g ∘ y = z`.
     (z : cocycles₁ X.X₃) (y : G → X.X₂) (hy : X.g.hom ∘ y = z)
     -- Let `x` be a 2-cochain for `X₁` such that `f ∘ x = d(y)`.

--- a/Mathlib/RepresentationTheory/Homological/GroupHomology/LongExactSequence.lean
+++ b/Mathlib/RepresentationTheory/Homological/GroupHomology/LongExactSequence.lean
@@ -10,13 +10,13 @@ import Mathlib.RepresentationTheory.Homological.GroupHomology.Functoriality
 /-!
 # Long exact sequence in group homology
 
-Given a commutative ring `k` and a group `G`, this file shows that a short exact sequence of
-`k`-linear `G`-representations `0 ⟶ X₁ ⟶ X₂ ⟶ X₃ ⟶ 0` induces a short exact sequence of
+Given a commutative ring `k` and a group `G`, this file shows that a short-exact sequence of
+`k`-linear `G`-representations `0 ⟶ X₁ ⟶ X₂ ⟶ X₃ ⟶ 0` induces a short-exact sequence of
 complexes
 `0 ⟶ inhomogeneousChains X₁ ⟶ inhomogeneousChains X₂ ⟶ inhomogeneousChains X₃ ⟶ 0`.
 
 Since the homology of `inhomogeneousChains Xᵢ` is the group homology of `Xᵢ`, this allows us
-to specialize API about long exact sequences to group homology.
+to specialize API about long-exact sequences to group homology.
 
 ## Main definitions
 
@@ -109,7 +109,7 @@ noncomputable abbrev cyclesMkOfCompEqD {i j : ℕ} {y : (Fin i → G) →₀ X.X
       (by simpa using hx) _
 
 theorem δ_apply {i j : ℕ} (hij : j + 1 = i)
-    -- Let `0 ⟶ X₁ ⟶f X₂ ⟶g X₃ ⟶ 0` be a short exact sequence of `G`-representations.
+    -- Let `0 ⟶ X₁ ⟶f X₂ ⟶g X₃ ⟶ 0` be a short-exact sequence of `G`-representations.
     -- Let `z` be an `j + 1`-cycle for `X₃`
     (z : (Fin i → G) →₀ X.X₃) (hz : (inhomogeneousChains X.X₃).d i j z = 0)
     -- Let `y` be an `j + 1`-chain for `X₂` such that `g ∘ y = z`
@@ -123,7 +123,7 @@ theorem δ_apply {i j : ℕ} (hij : j + 1 = i)
   exact (map_chainsFunctor_shortExact hX).δ_apply i j hij z hz y hy x (by simpa using hx) _ rfl
 
 theorem δ₀_apply
-    -- Let `0 ⟶ X₁ ⟶f X₂ ⟶g X₃ ⟶ 0` be a short exact sequence of `G`-representations.
+    -- Let `0 ⟶ X₁ ⟶f X₂ ⟶g X₃ ⟶ 0` be a short-exact sequence of `G`-representations.
     -- Let `z` by a 1-cycle for `X₃` and `y` a 1-chain for `X₂` such that `g ∘ y = z`.
     (z : cycles₁ X.X₃) (y : G →₀ X.X₂) (hy : mapRange.linearMap X.g.hom.hom y = z.1)
     -- Let `x : X₁` be such that `f(x) = d(y)`.
@@ -144,7 +144,7 @@ theorem mem_cycles₁_of_comp_eq_d₂₁
   simp_all [shortComplexH1]
 
 theorem δ₁_apply
-    -- Let `0 ⟶ X₁ ⟶f X₂ ⟶g X₃ ⟶ 0` be a short exact sequence of `G`-representations.
+    -- Let `0 ⟶ X₁ ⟶f X₂ ⟶g X₃ ⟶ 0` be a short-exact sequence of `G`-representations.
     -- Let `z` by a 2-cycle for `X₃` and `y` a 2-chain for `X₂` such that `g ∘ y = z`.
     (z : cycles₂ X.X₃) (y : G × G →₀ X.X₂) (hy : mapRange.linearMap X.g.hom.hom y = z.1)
     -- Let `x` be a 1-chain for `X₁` such that `f ∘ x = d(y)`.

--- a/Mathlib/RingTheory/DedekindDomain/SelmerGroup.lean
+++ b/Mathlib/RingTheory/DedekindDomain/SelmerGroup.lean
@@ -18,7 +18,7 @@ valuation divisible by $n$ for all prime ideals $v$ away from $S$. In other word
 $$ K(S, n) := \{x(K^\times)^n \in K^\times / (K^\times)^n \ \mid \
                 \forall v \notin S, \ \mathrm{ord}_v(x) \equiv 0 \pmod n\}. $$
 
-There is a fundamental short exact sequence
+There is a fundamental short-exact sequence
 $$ 1 \to R_S^\times / (R_S^\times)^n \to K(S, n) \to \mathrm{Cl}_S(R)[n] \to 0, $$
 where $R_S^\times$ is the $S$-unit group of $R$ and $\mathrm{Cl}_S(R)$ is the $S$-class group of
 $R$. If the flanking groups are both finite, then $K(S, n)$ is finite by the first isomorphism
@@ -47,8 +47,8 @@ This file defines the Selmer group $K(S, n)$ and some basic facts.
 The Selmer group is typically defined as a subgroup of the Galois cohomology group $H^1(K, \mu_n)$
 with certain local conditions defined by $v$-adic valuations, where $\mu_n$ is the group of $n$-th
 roots of unity over a separable closure of $K$. Here $H^1(K, \mu_n)$ is identified with
-$K^\times / (K^\times)^n$ by the long exact sequence from Kummer theory and Hilbert's theorem 90,
-and the fundamental short exact sequence becomes an easy consequence of the snake lemma. This file
+$K^\times / (K^\times)^n$ by the long-exact sequence from Kummer theory and Hilbert's theorem 90,
+and the fundamental short-exact sequence becomes an easy consequence of the snake lemma. This file
 will define all the maps explicitly for computational purposes, but isomorphisms to the Galois
 cohomological definition will be provided when possible.
 

--- a/Mathlib/RingTheory/Flat/CategoryTheory.lean
+++ b/Mathlib/RingTheory/Flat/CategoryTheory.lean
@@ -18,7 +18,7 @@ In this file we prove that tensoring with a flat module is an exact functor.
   for every exact sequence `A ⟶ B ⟶ C`, `M ⊗ A ⟶ M ⊗ B ⟶ M ⊗ C` is also exact.
 
 - `Module.Flat.iff_rTensor_preserves_shortComplex_exact`: an `R`-module `M` is flat if and only if
-  for every short exact sequence `A ⟶ B ⟶ C`, `A ⊗ M ⟶ B ⊗ M ⟶ C ⊗ M` is also exact.
+  for every short-exact sequence `A ⟶ B ⟶ C`, `A ⊗ M ⟶ B ⊗ M ⟶ C ⊗ M` is also exact.
 
 ## TODO
 

--- a/Mathlib/RingTheory/Ideal/AssociatedPrime/Finiteness.lean
+++ b/Mathlib/RingTheory/Ideal/AssociatedPrime/Finiteness.lean
@@ -27,7 +27,7 @@ associated primes.
 
   - it holds for zero module,
   - it holds for any module isomorphic to some `A ⧸ p` where `p` is a prime ideal of `A`,
-  - it is stable by short exact sequences,
+  - it is stable by short-exact sequences,
 
   then the property holds for every finitely generated modules.
 
@@ -99,7 +99,7 @@ theorem IsNoetherianRing.exists_relSeries_isQuotientEquivQuotientPrime :
 - it holds for zero module (it's formalized as it holds for any module which is subsingleton),
 - it holds for `A ⧸ p` for every prime ideal `p` of `A` (to avoid universe problem,
   it's formalized as it holds for any module isomorphic to `A ⧸ p`),
-- it is stable by short exact sequences,
+- it is stable by short-exact sequences,
 
 then the property holds for every finitely generated modules.
 

--- a/Mathlib/RingTheory/Regular/IsSMulRegular.lean
+++ b/Mathlib/RingTheory/Regular/IsSMulRegular.lean
@@ -103,7 +103,7 @@ alias isSMulRegular_on_quot_iff_smul_mem_implies_mem := isSMulRegular_quotient_i
 @[deprecated (since := "2025-08-04")]
 alias mem_of_isSMulRegular_on_quot_of_smul_mem := mem_of_isSMulRegular_quotient_of_smul_mem
 
-/-- Given a left exact sequence `0 → M → M' → M''`, if `r` is regular on both
+/-- Given a left-exact sequence `0 → M → M' → M''`, if `r` is regular on both
 `M` and `M''` it's regular `M'` too. -/
 lemma isSMulRegular_of_range_eq_ker {f : M →ₗ[R] M'} {g : M' →ₗ[R] M''}
     (hf : Function.Injective f) (hfg : LinearMap.range f = LinearMap.ker g)

--- a/Mathlib/Topology/Category/Profinite/Nobeling/Successor.lean
+++ b/Mathlib/Topology/Category/Profinite/Nobeling/Successor.lean
@@ -27,11 +27,11 @@ The right map in the exact sequence     |`Linear_CC'`
 ```
 
 When comparing the proof of the successor case in Theorem 5.4 in [scholze2019condensed] with this
-proof, one should read the phrase "is a basis" as "is linearly independent". Also, the short exact
+proof, one should read the phrase "is a basis" as "is linearly independent". Also, the short-exact
 sequence in [scholze2019condensed] is only proved to be left exact here (indeed, that is enough
 since we are only proving linear independence).
 
-This section is split into two sections. The first one, `ExactSequence` defines the left exact
+This section is split into two sections. The first one, `ExactSequence` defines the left-exact
 sequence mentioned in the previous paragraph (see `succ_mono` and `succ_exact`). It corresponds to
 the penultimate paragraph of the proof in [scholze2019condensed]. The second one, `GoodProducts`
 corresponds to the last paragraph in the proof in [scholze2019condensed].


### PR DESCRIPTION
Compound adjectives that are attributive (coming before their noun) should almost always be hyphenated in English.

This PR covers such adjectives that are ending in "exact".

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include at least one commit authored by each
co-author among the commits in the pull request. If necessary, you may 
create empty commits to indicate co-authorship, using commands like so:

git commit --author="Author Name <author@email.com>" --allow-empty -m "add Author Name as coauthor"

When merging, all the commits will be squashed into a single commit listing all co-authors.

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
