### PR TITLE
[Merged by Bors] - refactor(Analysis/Calculus/IteratedDeriv/Defs): tweak statement of `iteratedDerivWithin_one`

### DIFF
--- a/Mathlib/Analysis/Calculus/IteratedDeriv/Defs.lean
+++ b/Mathlib/Analysis/Calculus/IteratedDeriv/Defs.lean
@@ -106,8 +106,9 @@ theorem iteratedDerivWithin_zero : iteratedDerivWithin 0 f s = f := by
   simp [iteratedDerivWithin]
 
 @[simp]
-theorem iteratedDerivWithin_one {x : 𝕜} :
-    iteratedDerivWithin 1 f s x = derivWithin f s x := by
+theorem iteratedDerivWithin_one :
+    iteratedDerivWithin 1 f s = derivWithin f s := by
+  ext x
   by_cases hsx : AccPt x (𝓟 s)
   · simp only [iteratedDerivWithin, iteratedFDerivWithin_one_apply hsx.uniqueDiffWithinAt,
       derivWithin]


### PR DESCRIPTION
This PR removes the `x` from `iteratedDerivWithin_one` to make it match `iteratedDerivWithin_zero`.

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include at least one commit authored by each
co-author among the commits in the pull request. If necessary, you may 
create empty commits to indicate co-authorship, using commands like so:

git commit --author="Author Name <author@email.com>" --allow-empty -m "add Author Name as coauthor"

When merging, all the commits will be squashed into a single commit listing all co-authors.

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
