### PR TITLE
[Merged by Bors] - fix: add Elab.async false in #count_heartbeats

### DIFF
--- a/Mathlib/Util/CountHeartbeats.lean
+++ b/Mathlib/Util/CountHeartbeats.lean
@@ -36,7 +36,8 @@ def runTacForHeartbeats (tac : TSyntax `Lean.Parser.Tactic.tacticSeq) (revert : 
     TacticM Nat := do
   let start ← IO.getNumHeartbeats
   let s ← saveState
-  evalTactic tac
+  withOptions (fun opts => opts.set ``Elab.async false) do
+    evalTactic tac
   if revert then restoreState s
   return (← IO.getNumHeartbeats) - start
 
@@ -157,7 +158,7 @@ elab "guard_min_heartbeats " approx:(&"approximately ")? n:(num)? "in" ppLine cm
            | none => max
   let start ← IO.getNumHeartbeats
   try
-    elabCommand (← `(command| set_option maxHeartbeats 0 in $cmd))
+    elabCommand (← `(command| set_option Elab.async false in set_option maxHeartbeats 0 in $cmd))
   finally
     let finish ← IO.getNumHeartbeats
     let elapsed := (finish - start) / 1000


### PR DESCRIPTION
See [#mathlib4 > Is count_heartbeats broken](https://leanprover.zulipchat.com/#narrow/channel/287929-mathlib4/topic/Is.20count_heartbeats.20broken)

I have not yet added an effective test. Could someone else please attempt that, either here or in a different PR? I'd prefer not to take that on.

I did verify that it works as expected at [docs#FractionIdeal.quotientEquiv](https://leanprover-community.github.io/mathlib4_docs/find/?pattern=FractionalIdeal.quotientEquiv#doc).