### PR TITLE
feat: add linter for deprecations on different dates not separated by a blank line

### DIFF
--- a/Mathlib.lean
+++ b/Mathlib.lean
@@ -6072,6 +6072,7 @@ import Mathlib.Tactic.LinearCombination'
 import Mathlib.Tactic.LinearCombination.Lemmas
 import Mathlib.Tactic.Linter
 import Mathlib.Tactic.Linter.CommandStart
+import Mathlib.Tactic.Linter.DeprecatedDates
 import Mathlib.Tactic.Linter.DeprecatedModule
 import Mathlib.Tactic.Linter.DeprecatedSyntaxLinter
 import Mathlib.Tactic.Linter.DirectoryDependency

--- a/Mathlib/Tactic.lean
+++ b/Mathlib/Tactic.lean
@@ -149,6 +149,7 @@ import Mathlib.Tactic.LinearCombination'
 import Mathlib.Tactic.LinearCombination.Lemmas
 import Mathlib.Tactic.Linter
 import Mathlib.Tactic.Linter.CommandStart
+import Mathlib.Tactic.Linter.DeprecatedDates
 import Mathlib.Tactic.Linter.DeprecatedModule
 import Mathlib.Tactic.Linter.DeprecatedSyntaxLinter
 import Mathlib.Tactic.Linter.DirectoryDependency

--- a/Mathlib/Tactic/Linter/DeprecatedDates.lean
+++ b/Mathlib/Tactic/Linter/DeprecatedDates.lean
@@ -1,0 +1,132 @@
+/-
+Copyright (c) 2025 Lean FRO, LLC. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Kim Morrison
+-/
+import Lean.Elab.Command
+import Batteries.Data.String.Matcher
+import Mathlib.Tactic.Linter.Header
+
+/-!
+# The "deprecatedDates" linter
+
+The "deprecatedDates" linter emits a warning when consecutive deprecated declarations
+have different dates but are not separated by a blank line.
+
+When multiple declarations are deprecated, they should either:
+- Have the same deprecation date (if they were deprecated together), or
+- Be separated by a blank line (if they were deprecated at different times).
+
+This helps maintain readability and makes the history of deprecations clearer.
+-/
+
+open Lean Elab Command Linter
+
+namespace Mathlib.Linter
+
+/-- The "deprecatedDates" linter emits a warning when consecutive deprecated declarations
+have different dates but are not separated by a blank line. -/
+register_option linter.style.deprecatedDates : Bool := {
+  defValue := false
+  descr := "enable the deprecatedDates linter"
+}
+
+namespace Style.DeprecatedDates
+
+/-- Check if there's a blank line between two positions in the source. -/
+def hasBlankLineBetween (fm : FileMap) (endPos : String.Pos) (startPos : String.Pos) : Bool :=
+  if endPos ≥ startPos then
+    false
+  else
+    let substring := { str := fm.source, startPos := endPos, stopPos := startPos : Substring }
+    -- Split into lines and check if any line is empty (after trimming)
+    substring.toString.split (· == '\n') |>.any (·.trim.isEmpty)
+
+@[inherit_doc Mathlib.Linter.linter.style.deprecatedDates]
+def deprecatedDatesLinter : Linter where
+  run := withSetOptionIn fun stx ↦ do
+    unless getLinterValue linter.style.deprecatedDates (← getLinterOptions) do
+      return
+    if (← get).messages.hasErrors then
+      return
+
+    -- Only check declaration commands
+    unless [``Lean.Parser.Command.declaration, `lemma].contains stx.getKind do
+      return
+
+    -- Get the declaration id directly from the syntax tree
+    let declId :=
+      if stx[1].isOfKind ``Lean.Parser.Command.instance then
+        stx[1][3][0]
+      else
+        stx[1][1]
+    if let .missing := declId then return
+
+    -- Extract the declaration name with proper namespace handling
+    let declName : Name :=
+      if let `_root_ :: rest := declId[0].getId.components then
+        rest.foldl (· ++ ·) default
+      else (← getCurrNamespace) ++ declId[0].getId
+
+    -- Check if this declaration has a deprecated attribute with a date
+    let env ← getEnv
+    let some info := Lean.Linter.deprecatedAttr.getParam? env declName
+      | return -- Not deprecated
+    let some currentDate := info.since?
+      | return -- Deprecated but no date
+
+    -- Get the file map for checking blank lines
+    let fm ← getFileMap
+
+    -- Get the position of the current declaration
+    let some currentPos := stx.getPos? | return
+
+    -- Look for the immediately previous declaration in the source
+    -- by finding the last deprecated declaration before this position
+    let sourceBeforeDecl := { str := fm.source, startPos := ⟨0⟩, stopPos := currentPos : Substring }
+    let textBefore := sourceBeforeDecl.toString
+
+    -- Find the immediately previous deprecated declaration
+    -- Look for the last @[deprecated line before this declaration
+    let lines := textBefore.split (· == '\n')
+
+    -- Find the most recent @[deprecated line
+    let mut foundPrevDeprecated := false
+    let mut prevDate : Option String := none
+    let mut prevDeprecatedLineIdx := 0
+
+    for i in [:lines.length] do
+      let lineIdx := lines.length - 1 - i  -- Go backwards
+      if lineIdx >= 0 && lineIdx < lines.length then
+        let line := lines[lineIdx]!
+        if line.containsSubstr "@[deprecated" && line.containsSubstr "since" then
+          -- Extract date from the line
+          if let some startIdx := line.toList.findIdx? (fun c => c == '"') then
+            let afterQuote := line.drop (startIdx + 1)
+            if let some endIdx := afterQuote.toList.findIdx? (fun c => c == '"') then
+              prevDate := some (afterQuote.take endIdx)
+              foundPrevDeprecated := true
+              prevDeprecatedLineIdx := lineIdx
+              break
+
+    if foundPrevDeprecated then
+      if let some pd := prevDate then
+        -- Check if there's a blank line between the previous deprecated line and current
+        -- Skip the last line since it might be empty due to how we split the text
+        let mut hasBlankLine := false
+        let checkUntil := if lines.length > 0 then lines.length - 1 else lines.length
+        for i in [prevDeprecatedLineIdx + 1:checkUntil] do
+          if lines[i]!.trim.isEmpty then
+            hasBlankLine := true
+            break
+
+        if pd != currentDate && !hasBlankLine then
+          logLint linter.style.deprecatedDates stx
+            m!"Consecutive deprecated declarations have different dates \
+              ('{pd}' and '{currentDate}') but are not separated by a blank line"
+
+initialize addLinter deprecatedDatesLinter
+
+end Style.DeprecatedDates
+
+end Mathlib.Linter

--- a/MathlibTest/Linter/DeprecatedDates.lean
+++ b/MathlibTest/Linter/DeprecatedDates.lean
@@ -1,0 +1,64 @@
+/-
+Copyright (c) 2025 Mathlib Contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Mathlib Contributors
+-/
+import Mathlib.Tactic.Linter.DeprecatedDates
+
+/-!
+# Tests for the DeprecatedDates linter
+
+Tests for the linter that checks consecutive deprecated declarations
+have consistent date formatting.
+-/
+
+set_option linter.style.deprecatedDates true
+
+-- Define replacement definitions first
+def newFoo := 1
+def newBar := 2
+def newBaz := 3
+
+section ConsecutiveDifferentDates
+
+-- Test: consecutive deprecated declarations with different dates and no blank line (should warn)
+@[deprecated newFoo (since := "2025-01-01")]
+def oldFoo := 1
+@[deprecated newBar (since := "2025-02-01")]
+def oldBar := 2
+
+end ConsecutiveDifferentDates
+
+section ConsecutiveSameDates
+
+-- Test: consecutive deprecated declarations with same date (should be OK)
+@[deprecated newFoo (since := "2025-01-01")]
+def oldFoo2 := 1
+@[deprecated newBar (since := "2025-01-01")]
+def oldBar2 := 2
+
+end ConsecutiveSameDates
+
+section WithBlankLine
+
+-- Test: consecutive deprecated declarations with different dates but with blank line (should be OK)
+@[deprecated newFoo (since := "2025-01-01")]
+def oldFoo3 := 1
+
+@[deprecated newBar (since := "2025-02-01")]
+def oldBar3 := 2
+
+end WithBlankLine
+
+section NonConsecutive
+
+-- Test: non-deprecated declaration in between resets the state (should be OK)
+@[deprecated newFoo (since := "2025-01-01")]
+def oldFoo4 := 1
+
+def normalDecl := 5
+
+@[deprecated newBar (since := "2025-02-01")]
+def oldBar4 := 2
+
+end NonConsecutive


### PR DESCRIPTION
Written by claude. Seems to behave correctly, but I have no opinion on the implementation. I can't work out how to test the behaviour using `#guard_msgs`, however.