### PR TITLE
[Merged by Bors] - refactor(Algebra/Order/Module): don't use `elim` as a field name

### DIFF
--- a/Mathlib/Algebra/Order/Module/Defs.lean
+++ b/Mathlib/Algebra/Order/Module/Defs.lean
@@ -138,7 +138,8 @@ You should usually not use this very granular typeclass directly, but rather a t
 `OrderedSMul`. -/
 class PosSMulMono : Prop where
   /-- Do not use this. Use `smul_le_smul_of_nonneg_left` instead. -/
-  protected elim ⦃a : α⦄ (ha : 0 ≤ a) ⦃b₁ b₂ : β⦄ (hb : b₁ ≤ b₂) : a • b₁ ≤ a • b₂
+  protected smul_le_smul_of_nonneg_left ⦃a : α⦄ (ha : 0 ≤ a) ⦃b₁ b₂ : β⦄ (hb : b₁ ≤ b₂) :
+    a • b₁ ≤ a • b₂
 
 /-- Typeclass for strict monotonicity of scalar multiplication by positive elements on the left,
 namely `b₁ < b₂ → a • b₁ < a • b₂` if `0 < a`.
@@ -147,7 +148,8 @@ You should usually not use this very granular typeclass directly, but rather a t
 `OrderedSMul`. -/
 class PosSMulStrictMono : Prop where
   /-- Do not use this. Use `smul_lt_smul_of_pos_left` instead. -/
-  protected elim ⦃a : α⦄ (ha : 0 < a) ⦃b₁ b₂ : β⦄ (hb : b₁ < b₂) : a • b₁ < a • b₂
+  protected smul_lt_smul_of_pos_left ⦃a : α⦄ (ha : 0 < a) ⦃b₁ b₂ : β⦄ (hb : b₁ < b₂) :
+    a • b₁ < a • b₂
 
 /-- Typeclass for strict reverse monotonicity of scalar multiplication by nonnegative elements on
 the left, namely `a • b₁ < a • b₂ → b₁ < b₂` if `0 ≤ a`.
@@ -156,7 +158,8 @@ You should usually not use this very granular typeclass directly, but rather a t
 `OrderedSMul`. -/
 class PosSMulReflectLT : Prop where
   /-- Do not use this. Use `lt_of_smul_lt_smul_left` instead. -/
-  protected elim ⦃a : α⦄ (ha : 0 ≤ a) ⦃b₁ b₂ : β⦄ (hb : a • b₁ < a • b₂) : b₁ < b₂
+  protected lt_of_smul_lt_smul_left ⦃a : α⦄ (ha : 0 ≤ a) ⦃b₁ b₂ : β⦄ (hb : a • b₁ < a • b₂) :
+    b₁ < b₂
 
 /-- Typeclass for reverse monotonicity of scalar multiplication by positive elements on the left,
 namely `a • b₁ ≤ a • b₂ → b₁ ≤ b₂` if `0 < a`.
@@ -164,8 +167,9 @@ namely `a • b₁ ≤ a • b₂ → b₁ ≤ b₂` if `0 < a`.
 You should usually not use this very granular typeclass directly, but rather a typeclass like
 `OrderedSMul`. -/
 class PosSMulReflectLE : Prop where
-  /-- Do not use this. Use `le_of_smul_lt_smul_left` instead. -/
-  protected elim ⦃a : α⦄ (ha : 0 < a) ⦃b₁ b₂ : β⦄ (hb : a • b₁ ≤ a • b₂) : b₁ ≤ b₂
+  /-- Do not use this. Use `le_of_smul_le_smul_left` instead. -/
+  protected le_of_smul_le_smul_left ⦃a : α⦄ (ha : 0 < a) ⦃b₁ b₂ : β⦄ (hb : a • b₁ ≤ a • b₂) :
+    b₁ ≤ b₂
 
 end Left
 
@@ -179,7 +183,8 @@ You should usually not use this very granular typeclass directly, but rather a t
 `OrderedSMul`. -/
 class SMulPosMono : Prop where
   /-- Do not use this. Use `smul_le_smul_of_nonneg_right` instead. -/
-  protected elim ⦃b : β⦄ (hb : 0 ≤ b) ⦃a₁ a₂ : α⦄ (ha : a₁ ≤ a₂) : a₁ • b ≤ a₂ • b
+  protected smul_le_smul_of_nonneg_right ⦃b : β⦄ (hb : 0 ≤ b) ⦃a₁ a₂ : α⦄ (ha : a₁ ≤ a₂) :
+    a₁ • b ≤ a₂ • b
 
 /-- Typeclass for strict monotonicity of scalar multiplication by positive elements on the left,
 namely `a₁ < a₂ → a₁ • b < a₂ • b` if `0 < b`.
@@ -188,7 +193,8 @@ You should usually not use this very granular typeclass directly, but rather a t
 `OrderedSMul`. -/
 class SMulPosStrictMono : Prop where
   /-- Do not use this. Use `smul_lt_smul_of_pos_right` instead. -/
-  protected elim ⦃b : β⦄ (hb : 0 < b) ⦃a₁ a₂ : α⦄ (ha : a₁ < a₂) : a₁ • b < a₂ • b
+  protected smul_lt_smul_of_pos_right ⦃b : β⦄ (hb : 0 < b) ⦃a₁ a₂ : α⦄ (ha : a₁ < a₂) :
+    a₁ • b < a₂ • b
 
 /-- Typeclass for strict reverse monotonicity of scalar multiplication by nonnegative elements on
 the left, namely `a₁ • b < a₂ • b → a₁ < a₂` if `0 ≤ b`.
@@ -197,7 +203,8 @@ You should usually not use this very granular typeclass directly, but rather a t
 `OrderedSMul`. -/
 class SMulPosReflectLT : Prop where
   /-- Do not use this. Use `lt_of_smul_lt_smul_right` instead. -/
-  protected elim ⦃b : β⦄ (hb : 0 ≤ b) ⦃a₁ a₂ : α⦄ (hb : a₁ • b < a₂ • b) : a₁ < a₂
+  protected lt_of_smul_lt_smul_right ⦃b : β⦄ (hb : 0 ≤ b) ⦃a₁ a₂ : α⦄ (hb : a₁ • b < a₂ • b) :
+    a₁ < a₂
 
 /-- Typeclass for reverse monotonicity of scalar multiplication by positive elements on the left,
 namely `a₁ • b ≤ a₂ • b → a₁ ≤ a₂` if `0 < b`.
@@ -205,8 +212,9 @@ namely `a₁ • b ≤ a₂ • b → a₁ ≤ a₂` if `0 < b`.
 You should usually not use this very granular typeclass directly, but rather a typeclass like
 `OrderedSMul`. -/
 class SMulPosReflectLE : Prop where
-  /-- Do not use this. Use `le_of_smul_lt_smul_right` instead. -/
-  protected elim ⦃b : β⦄ (hb : 0 < b) ⦃a₁ a₂ : α⦄ (hb : a₁ • b ≤ a₂ • b) : a₁ ≤ a₂
+  /-- Do not use this. Use `le_of_smul_le_smul_right` instead. -/
+  protected le_of_smul_le_smul_right ⦃b : β⦄ (hb : 0 < b) ⦃a₁ a₂ : α⦄ (hb : a₁ • b ≤ a₂ • b) :
+    a₁ ≤ a₂
 
 end Right
 end Defs
@@ -218,55 +226,67 @@ variable [Zero α] [Mul α] [Preorder α]
 
 -- See note [lower instance priority]
 instance (priority := 100) PosMulMono.toPosSMulMono [PosMulMono α] : PosSMulMono α α where
-  elim _a ha _b₁ _b₂ hb := mul_le_mul_of_nonneg_left hb ha
+  smul_le_smul_of_nonneg_left _a ha _b₁ _b₂ hb := mul_le_mul_of_nonneg_left hb ha
 
 -- See note [lower instance priority]
 instance (priority := 100) PosMulStrictMono.toPosSMulStrictMono [PosMulStrictMono α] :
     PosSMulStrictMono α α where
-  elim _a ha _b₁ _b₂ hb := mul_lt_mul_of_pos_left hb ha
+  smul_lt_smul_of_pos_left _a ha _b₁ _b₂ hb := mul_lt_mul_of_pos_left hb ha
 
 -- See note [lower instance priority]
 instance (priority := 100) PosMulReflectLT.toPosSMulReflectLT [PosMulReflectLT α] :
     PosSMulReflectLT α α where
-  elim _a ha _b₁ _b₂ h := lt_of_mul_lt_mul_left h ha
+  lt_of_smul_lt_smul_left _a ha _b₁ _b₂ h := lt_of_mul_lt_mul_left h ha
 
 -- See note [lower instance priority]
 instance (priority := 100) PosMulReflectLE.toPosSMulReflectLE [PosMulReflectLE α] :
     PosSMulReflectLE α α where
-  elim _a ha _b₁ _b₂ h := le_of_mul_le_mul_left h ha
+  le_of_smul_le_smul_left _a ha _b₁ _b₂ h := le_of_mul_le_mul_left h ha
 
 -- See note [lower instance priority]
 instance (priority := 100) MulPosMono.toSMulPosMono [MulPosMono α] : SMulPosMono α α where
-  elim _b hb _a₁ _a₂ ha := mul_le_mul_of_nonneg_right ha hb
+  smul_le_smul_of_nonneg_right _b hb _a₁ _a₂ ha := mul_le_mul_of_nonneg_right ha hb
 
 -- See note [lower instance priority]
 instance (priority := 100) MulPosStrictMono.toSMulPosStrictMono [MulPosStrictMono α] :
     SMulPosStrictMono α α where
-  elim _b hb _a₁ _a₂ ha := mul_lt_mul_of_pos_right ha hb
+  smul_lt_smul_of_pos_right _b hb _a₁ _a₂ ha := mul_lt_mul_of_pos_right ha hb
 
 -- See note [lower instance priority]
 instance (priority := 100) MulPosReflectLT.toSMulPosReflectLT [MulPosReflectLT α] :
     SMulPosReflectLT α α where
-  elim _b hb _a₁ _a₂ h := lt_of_mul_lt_mul_right h hb
+  lt_of_smul_lt_smul_right _b hb _a₁ _a₂ h := lt_of_mul_lt_mul_right h hb
 
 -- See note [lower instance priority]
 instance (priority := 100) MulPosReflectLE.toSMulPosReflectLE [MulPosReflectLE α] :
     SMulPosReflectLE α α where
-  elim _b hb _a₁ _a₂ h := le_of_mul_le_mul_right h hb
+  le_of_smul_le_smul_right _b hb _a₁ _a₂ h := le_of_mul_le_mul_right h hb
 
 end Mul
 
 instance {M : Type*} [PartialOrder M] [AddCommMonoid M] [IsOrderedAddMonoid M] :
     PosSMulMono ℕ M where
-  elim _n _ _m₁ _m₂ hm := nsmul_le_nsmul_right hm _
+  smul_le_smul_of_nonneg_left _n _ _a _b hab := nsmul_le_nsmul_right hab _
+
+instance {M : Type*} [PartialOrder M] [AddCommMonoid M] [IsOrderedAddMonoid M] :
+    SMulPosMono ℕ M where
+  smul_le_smul_of_nonneg_right _a ha _m _n hmn := nsmul_le_nsmul_left ha hmn
 
 instance {M : Type*} [PartialOrder M] [AddCancelCommMonoid M] [IsOrderedAddMonoid M] :
     PosSMulStrictMono ℕ M where
-  elim _n hn _m₁ _m₂ := nsmul_lt_nsmul_right hn.ne'
+  smul_lt_smul_of_pos_left _n hn _m₁ _m₂ := nsmul_lt_nsmul_right hn.ne'
+
+instance {M : Type*} [PartialOrder M] [AddCommMonoid M] [IsOrderedCancelAddMonoid M] :
+    SMulPosStrictMono ℕ M where
+  smul_lt_smul_of_pos_right _a ha _m _n hmn := nsmul_lt_nsmul_left ha hmn
 
 instance {G : Type*} [PartialOrder G] [AddCommGroup G] [IsOrderedAddMonoid G] :
     PosSMulStrictMono ℤ G where
-  elim _n hn _m₁ _m₂ := zsmul_lt_zsmul_right hn
+  smul_lt_smul_of_pos_left _n hn _m₁ _m₂ := zsmul_lt_zsmul_right hn
+
+instance {G : Type*} [PartialOrder G] [AddCommGroup G] [IsOrderedAddMonoid G] :
+    SMulPosStrictMono ℤ G where
+  smul_lt_smul_of_pos_right _a ha _m _n hmn := zsmul_lt_zsmul_left ha hmn
 
 section SMul
 variable [SMul α β]
@@ -278,10 +298,10 @@ section Left
 variable [Zero α]
 
 lemma monotone_smul_left_of_nonneg [PosSMulMono α β] (ha : 0 ≤ a) : Monotone ((a • ·) : β → β) :=
-  PosSMulMono.elim ha
+  PosSMulMono.smul_le_smul_of_nonneg_left ha
 
 lemma strictMono_smul_left_of_pos [PosSMulStrictMono α β] (ha : 0 < a) :
-    StrictMono ((a • ·) : β → β) := PosSMulStrictMono.elim ha
+    StrictMono ((a • ·) : β → β) := PosSMulStrictMono.smul_lt_smul_of_pos_left ha
 
 @[gcongr] lemma smul_le_smul_of_nonneg_left [PosSMulMono α β] (hb : b₁ ≤ b₂) (ha : 0 ≤ a) :
     a • b₁ ≤ a • b₂ := monotone_smul_left_of_nonneg ha hb
@@ -290,10 +310,10 @@ lemma strictMono_smul_left_of_pos [PosSMulStrictMono α β] (ha : 0 < a) :
     a • b₁ < a • b₂ := strictMono_smul_left_of_pos ha hb
 
 lemma lt_of_smul_lt_smul_left [PosSMulReflectLT α β] (h : a • b₁ < a • b₂) (ha : 0 ≤ a) : b₁ < b₂ :=
-  PosSMulReflectLT.elim ha h
+  PosSMulReflectLT.lt_of_smul_lt_smul_left ha h
 
 lemma le_of_smul_le_smul_left [PosSMulReflectLE α β] (h : a • b₁ ≤ a • b₂) (ha : 0 < a) : b₁ ≤ b₂ :=
-  PosSMulReflectLE.elim ha h
+  PosSMulReflectLE.le_of_smul_le_smul_left ha h
 
 alias lt_of_smul_lt_smul_of_nonneg_left := lt_of_smul_lt_smul_left
 alias le_of_smul_le_smul_of_pos_left := le_of_smul_le_smul_left
@@ -314,10 +334,10 @@ section Right
 variable [Zero β]
 
 lemma monotone_smul_right_of_nonneg [SMulPosMono α β] (hb : 0 ≤ b) : Monotone ((· • b) : α → β) :=
-  SMulPosMono.elim hb
+  SMulPosMono.smul_le_smul_of_nonneg_right hb
 
 lemma strictMono_smul_right_of_pos [SMulPosStrictMono α β] (hb : 0 < b) :
-    StrictMono ((· • b) : α → β) := SMulPosStrictMono.elim hb
+    StrictMono ((· • b) : α → β) := SMulPosStrictMono.smul_lt_smul_of_pos_right hb
 
 @[gcongr] lemma smul_le_smul_of_nonneg_right [SMulPosMono α β] (ha : a₁ ≤ a₂) (hb : 0 ≤ b) :
     a₁ • b ≤ a₂ • b := monotone_smul_right_of_nonneg hb ha
@@ -326,10 +346,10 @@ lemma strictMono_smul_right_of_pos [SMulPosStrictMono α β] (hb : 0 < b) :
     a₁ • b < a₂ • b := strictMono_smul_right_of_pos hb ha
 
 lemma lt_of_smul_lt_smul_right [SMulPosReflectLT α β] (h : a₁ • b < a₂ • b) (hb : 0 ≤ b) :
-    a₁ < a₂ := SMulPosReflectLT.elim hb h
+    a₁ < a₂ := SMulPosReflectLT.lt_of_smul_lt_smul_right hb h
 
 lemma le_of_smul_le_smul_right [SMulPosReflectLE α β] (h : a₁ • b ≤ a₂ • b) (hb : 0 < b) :
-    a₁ ≤ a₂ := SMulPosReflectLE.elim hb h
+    a₁ ≤ a₂ := SMulPosReflectLE.le_of_smul_le_smul_right hb h
 
 alias lt_of_smul_lt_smul_of_nonneg_right := lt_of_smul_lt_smul_right
 alias le_of_smul_le_smul_of_pos_right := le_of_smul_le_smul_right
@@ -393,19 +413,21 @@ variable [Zero α]
 -- See note [lower instance priority]
 instance (priority := 100) PosSMulStrictMono.toPosSMulReflectLE [PosSMulStrictMono α β] :
     PosSMulReflectLE α β where
-  elim _a ha _b₁ _b₂ := (strictMono_smul_left_of_pos ha).le_iff_le.1
+  le_of_smul_le_smul_left _a ha _b₁ _b₂ := (strictMono_smul_left_of_pos ha).le_iff_le.1
 
 lemma PosSMulReflectLE.toPosSMulStrictMono [PosSMulReflectLE α β] : PosSMulStrictMono α β where
-  elim _a ha _b₁ _b₂ hb := not_le.1 fun h ↦ hb.not_ge <| le_of_smul_le_smul_left h ha
+  smul_lt_smul_of_pos_left _a ha _b₁ _b₂ hb :=
+    not_le.1 fun h ↦ hb.not_ge <| le_of_smul_le_smul_left h ha
 
 lemma posSMulStrictMono_iff_PosSMulReflectLE : PosSMulStrictMono α β ↔ PosSMulReflectLE α β :=
   ⟨fun _ ↦ inferInstance, fun _ ↦ PosSMulReflectLE.toPosSMulStrictMono⟩
 
 instance PosSMulMono.toPosSMulReflectLT [PosSMulMono α β] : PosSMulReflectLT α β where
-  elim _a ha _b₁ _b₂ := (monotone_smul_left_of_nonneg ha).reflect_lt
+  lt_of_smul_lt_smul_left _a ha _b₁ _b₂ := (monotone_smul_left_of_nonneg ha).reflect_lt
 
 lemma PosSMulReflectLT.toPosSMulMono [PosSMulReflectLT α β] : PosSMulMono α β where
-  elim _a ha _b₁ _b₂ hb := not_lt.1 fun h ↦ hb.not_gt <| lt_of_smul_lt_smul_left h ha
+  smul_le_smul_of_nonneg_left _a ha _b₁ _b₂ hb :=
+    not_lt.1 fun h ↦ hb.not_gt <| lt_of_smul_lt_smul_left h ha
 
 lemma posSMulMono_iff_posSMulReflectLT : PosSMulMono α β ↔ PosSMulReflectLT α β :=
   ⟨fun _ ↦ PosSMulMono.toPosSMulReflectLT, fun _ ↦ PosSMulReflectLT.toPosSMulMono⟩
@@ -422,10 +444,12 @@ section Right
 variable [Zero β]
 
 lemma SMulPosReflectLE.toSMulPosStrictMono [SMulPosReflectLE α β] : SMulPosStrictMono α β where
-  elim _b hb _a₁ _a₂ ha := not_le.1 fun h ↦ ha.not_ge <| le_of_smul_le_smul_of_pos_right h hb
+  smul_lt_smul_of_pos_right _b hb _a₁ _a₂ ha :=
+    not_le.1 fun h ↦ ha.not_ge <| le_of_smul_le_smul_of_pos_right h hb
 
 lemma SMulPosReflectLT.toSMulPosMono [SMulPosReflectLT α β] : SMulPosMono α β where
-  elim _b hb _a₁ _a₂ ha := not_lt.1 fun h ↦ ha.not_gt <| lt_of_smul_lt_smul_right h hb
+  smul_le_smul_of_nonneg_right _b hb _a₁ _a₂ ha :=
+    not_lt.1 fun h ↦ ha.not_gt <| lt_of_smul_lt_smul_right h hb
 
 end Right
 end LinearOrder
@@ -439,10 +463,12 @@ variable [Zero β]
 -- See note [lower instance priority]
 instance (priority := 100) SMulPosStrictMono.toSMulPosReflectLE [SMulPosStrictMono α β] :
     SMulPosReflectLE α β where
-  elim _b hb _a₁ _a₂ h := not_lt.1 fun ha ↦ h.not_gt <| smul_lt_smul_of_pos_right ha hb
+  le_of_smul_le_smul_right _b hb _a₁ _a₂ h :=
+    not_lt.1 fun ha ↦ h.not_gt <| smul_lt_smul_of_pos_right ha hb
 
 lemma SMulPosMono.toSMulPosReflectLT [SMulPosMono α β] : SMulPosReflectLT α β where
-  elim _b hb _a₁ _a₂ h := not_le.1 fun ha ↦ h.not_ge <| smul_le_smul_of_nonneg_right ha hb
+  lt_of_smul_lt_smul_right _b hb _a₁ _a₂ h :=
+    not_le.1 fun ha ↦ h.not_ge <| smul_le_smul_of_nonneg_right ha hb
 
 end Right
 end LinearOrder
@@ -541,7 +567,7 @@ variable [PartialOrder α] [Preorder β]
 `0 < a` -/
 lemma PosSMulMono.of_pos (h₀ : ∀ a : α, 0 < a → ∀ b₁ b₂ : β, b₁ ≤ b₂ → a • b₁ ≤ a • b₂) :
     PosSMulMono α β where
-  elim a ha b₁ b₂ h := by
+  smul_le_smul_of_nonneg_left a ha b₁ b₂ h := by
     obtain ha | ha := ha.eq_or_lt
     · simp [← ha]
     · exact h₀ _ ha _ _ h
@@ -550,7 +576,7 @@ lemma PosSMulMono.of_pos (h₀ : ∀ a : α, 0 < a → ∀ b₁ b₂ : β, b₁ 
 when `0 < a` -/
 lemma PosSMulReflectLT.of_pos (h₀ : ∀ a : α, 0 < a → ∀ b₁ b₂ : β, a • b₁ < a • b₂ → b₁ < b₂) :
     PosSMulReflectLT α β where
-  elim a ha b₁ b₂ h := by
+  lt_of_smul_lt_smul_left a ha b₁ b₂ h := by
     obtain ha | ha := ha.eq_or_lt
     · simp [← ha] at h
     · exact h₀ _ ha _ _ h
@@ -564,7 +590,7 @@ variable [Preorder α] [PartialOrder β]
 `0 < b` -/
 lemma SMulPosMono.of_pos (h₀ : ∀ b : β, 0 < b → ∀ a₁ a₂ : α, a₁ ≤ a₂ → a₁ • b ≤ a₂ • b) :
     SMulPosMono α β where
-  elim b hb a₁ a₂ h := by
+  smul_le_smul_of_nonneg_right b hb a₁ a₂ h := by
     obtain hb | hb := hb.eq_or_lt
     · simp [← hb]
     · exact h₀ _ hb _ _ h
@@ -573,7 +599,7 @@ lemma SMulPosMono.of_pos (h₀ : ∀ b : β, 0 < b → ∀ a₁ a₂ : α, a₁ 
 when `0 < b` -/
 lemma SMulPosReflectLT.of_pos (h₀ : ∀ b : β, 0 < b → ∀ a₁ a₂ : α, a₁ • b < a₂ • b → a₁ < a₂) :
     SMulPosReflectLT α β where
-  elim b hb a₁ a₂ h := by
+  lt_of_smul_lt_smul_right b hb a₁ a₂ h := by
     obtain hb | hb := hb.eq_or_lt
     · simp [← hb] at h
     · exact h₀ _ hb _ _ h
@@ -774,13 +800,13 @@ section Left
 variable [Preorder α] [Preorder β] [SMul α β] [Zero α]
 
 instance instPosSMulMono [PosSMulMono α β] : PosSMulMono α βᵒᵈ where
-  elim _a ha _b₁ _b₂ hb := smul_le_smul_of_nonneg_left (β := β) hb ha
+  smul_le_smul_of_nonneg_left _a ha _b₁ _b₂ hb := smul_le_smul_of_nonneg_left (β := β) hb ha
 instance instPosSMulStrictMono [PosSMulStrictMono α β] : PosSMulStrictMono α βᵒᵈ where
-  elim _a ha _b₁ _b₂ hb := smul_lt_smul_of_pos_left (β := β) hb ha
+  smul_lt_smul_of_pos_left _a ha _b₁ _b₂ hb := smul_lt_smul_of_pos_left (β := β) hb ha
 instance instPosSMulReflectLT [PosSMulReflectLT α β] : PosSMulReflectLT α βᵒᵈ where
-  elim _a ha _b₁ _b₂ h := lt_of_smul_lt_smul_of_nonneg_left (β := β) h ha
+  lt_of_smul_lt_smul_left _a ha _b₁ _b₂ h := lt_of_smul_lt_smul_of_nonneg_left (β := β) h ha
 instance instPosSMulReflectLE [PosSMulReflectLE α β] : PosSMulReflectLE α βᵒᵈ where
-  elim _a ha _b₁ _b₂ h := le_of_smul_le_smul_of_pos_left (β := β) h ha
+  le_of_smul_le_smul_left _a ha _b₁ _b₂ h := le_of_smul_le_smul_of_pos_left (β := β) h ha
 
 end Left
 
@@ -789,22 +815,22 @@ variable [Preorder α] [Monoid α] [AddCommGroup β] [PartialOrder β] [IsOrdere
   [DistribMulAction α β]
 
 instance instSMulPosMono [SMulPosMono α β] : SMulPosMono α βᵒᵈ where
-  elim _b hb a₁ a₂ ha := by
+  smul_le_smul_of_nonneg_right _b hb a₁ a₂ ha := by
     rw [← neg_le_neg_iff, ← smul_neg, ← smul_neg]
     exact smul_le_smul_of_nonneg_right (β := β) ha <| neg_nonneg.2 hb
 
 instance instSMulPosStrictMono [SMulPosStrictMono α β] : SMulPosStrictMono α βᵒᵈ where
-  elim _b hb a₁ a₂ ha := by
+  smul_lt_smul_of_pos_right _b hb a₁ a₂ ha := by
     rw [← neg_lt_neg_iff, ← smul_neg, ← smul_neg]
     exact smul_lt_smul_of_pos_right (β := β) ha <| neg_pos.2 hb
 
 instance instSMulPosReflectLT [SMulPosReflectLT α β] : SMulPosReflectLT α βᵒᵈ where
-  elim _b hb a₁ a₂ h := by
+  lt_of_smul_lt_smul_right _b hb a₁ a₂ h := by
     rw [← neg_lt_neg_iff, ← smul_neg, ← smul_neg] at h
     exact lt_of_smul_lt_smul_right (β := β) h <| neg_nonneg.2 hb
 
 instance instSMulPosReflectLE [SMulPosReflectLE α β] : SMulPosReflectLE α βᵒᵈ where
-  elim _b hb a₁ a₂ h := by
+  le_of_smul_le_smul_right _b hb a₁ a₂ h := by
     rw [← neg_le_neg_iff, ← smul_neg, ← smul_neg] at h
     exact le_of_smul_le_smul_right (β := β) h <| neg_pos.2 hb
 
@@ -869,7 +895,8 @@ lemma antitone_smul_left (ha : a ≤ 0) : Antitone ((a • ·) : β → β) :=
   fun _ _ h ↦ smul_le_smul_of_nonpos_left h ha
 
 instance PosSMulMono.toSMulPosMono : SMulPosMono α β where
-  elim _b hb a₁ a₂ ha := by rw [← sub_nonneg, ← sub_smul]; exact smul_nonneg (sub_nonneg.2 ha) hb
+  smul_le_smul_of_nonneg_right _b hb a₁ a₂ ha := by
+    rw [← sub_nonneg, ← sub_smul]; exact smul_nonneg (sub_nonneg.2 ha) hb
 
 end PosSMulMono
 
@@ -884,7 +911,8 @@ lemma strictAnti_smul_left (ha : a < 0) : StrictAnti ((a • ·) : β → β) :=
   fun _ _ h ↦ smul_lt_smul_of_neg_left h ha
 
 instance PosSMulStrictMono.toSMulPosStrictMono : SMulPosStrictMono α β where
-  elim _b hb a₁ a₂ ha := by rw [← sub_pos, ← sub_smul]; exact smul_pos (sub_pos.2 ha) hb
+  smul_lt_smul_of_pos_right _b hb a₁ a₂ ha := by
+    rw [← sub_pos, ← sub_smul]; exact smul_pos (sub_pos.2 ha) hb
 
 end PosSMulStrictMono
 
@@ -979,16 +1007,16 @@ section SMulZeroClass
 variable [Preorder α] [∀ i, Preorder (β i)] [∀ i, SMulZeroClass α (β i)]
 
 instance instPosSMulMono [∀ i, PosSMulMono α (β i)] : PosSMulMono α (∀ i, β i) where
-  elim _a ha _b₁ _b₂ hb i := smul_le_smul_of_nonneg_left (hb i) ha
+  smul_le_smul_of_nonneg_left _a ha _b₁ _b₂ hb i := smul_le_smul_of_nonneg_left (hb i) ha
 
 instance instSMulPosMono [∀ i, SMulPosMono α (β i)] : SMulPosMono α (∀ i, β i) where
-  elim _b hb _a₁ _a₂ ha i := smul_le_smul_of_nonneg_right ha (hb i)
+  smul_le_smul_of_nonneg_right _b hb _a₁ _a₂ ha i := smul_le_smul_of_nonneg_right ha (hb i)
 
 instance instPosSMulReflectLE [∀ i, PosSMulReflectLE α (β i)] : PosSMulReflectLE α (∀ i, β i) where
-  elim _a ha _b₁ _b₂ h i := le_of_smul_le_smul_left (h i) ha
+  le_of_smul_le_smul_left _a ha _b₁ _b₂ h i := le_of_smul_le_smul_left (h i) ha
 
 instance instSMulPosReflectLE [∀ i, SMulPosReflectLE α (β i)] : SMulPosReflectLE α (∀ i, β i) where
-  elim _b hb _a₁ _a₂ h := by
+  le_of_smul_le_smul_right _b hb _a₁ _a₂ h := by
     obtain ⟨-, i, hi⟩ := lt_def.1 hb; exact le_of_smul_le_smul_right (h _) hi
 
 end SMulZeroClass
@@ -998,14 +1026,14 @@ variable [PartialOrder α] [∀ i, PartialOrder (β i)] [∀ i, SMulWithZero α 
 
 instance instPosSMulStrictMono [∀ i, PosSMulStrictMono α (β i)] :
     PosSMulStrictMono α (∀ i, β i) where
-  elim := by
+  smul_lt_smul_of_pos_left := by
     simp_rw [lt_def]
     rintro _a ha _b₁ _b₂ ⟨hb, i, hi⟩
     exact ⟨smul_le_smul_of_nonneg_left hb ha.le, i, smul_lt_smul_of_pos_left hi ha⟩
 
 instance instSMulPosStrictMono [∀ i, SMulPosStrictMono α (β i)] :
     SMulPosStrictMono α (∀ i, β i) where
-  elim := by
+  smul_lt_smul_of_pos_right := by
     simp_rw [lt_def]
     rintro a ⟨ha, i, hi⟩ _b₁ _b₂ hb
     exact ⟨smul_le_smul_of_nonneg_right hb.le ha, i, smul_lt_smul_of_pos_right hb hi⟩
@@ -1014,7 +1042,7 @@ instance instSMulPosStrictMono [∀ i, SMulPosStrictMono α (β i)] :
 -- implied by the other instances
 
 instance instSMulPosReflectLT [∀ i, SMulPosReflectLT α (β i)] : SMulPosReflectLT α (∀ i, β i) where
-  elim := by
+  lt_of_smul_lt_smul_right := by
     simp_rw [lt_def]
     rintro b hb _a₁ _a₂ ⟨-, i, hi⟩
     exact lt_of_smul_lt_smul_right hi <| hb _
@@ -1032,23 +1060,25 @@ variable [Zero α]
 lemma PosSMulMono.lift [PosSMulMono α γ]
     (hf : ∀ {b₁ b₂}, f b₁ ≤ f b₂ ↔ b₁ ≤ b₂)
     (smul : ∀ (a : α) b, f (a • b) = a • f b) : PosSMulMono α β where
-  elim a ha b₁ b₂ hb := by simp only [← hf, smul] at *; exact smul_le_smul_of_nonneg_left hb ha
+  smul_le_smul_of_nonneg_left a ha b₁ b₂ hb := by
+    simp only [← hf, smul] at *; exact smul_le_smul_of_nonneg_left hb ha
 
 lemma PosSMulStrictMono.lift [PosSMulStrictMono α γ]
     (hf : ∀ {b₁ b₂}, f b₁ ≤ f b₂ ↔ b₁ ≤ b₂)
     (smul : ∀ (a : α) b, f (a • b) = a • f b) : PosSMulStrictMono α β where
-  elim a ha b₁ b₂ hb := by
+  smul_lt_smul_of_pos_left a ha b₁ b₂ hb := by
     simp only [← lt_iff_lt_of_le_iff_le' hf hf, smul] at *; exact smul_lt_smul_of_pos_left hb ha
 
 lemma PosSMulReflectLE.lift [PosSMulReflectLE α γ]
     (hf : ∀ {b₁ b₂}, f b₁ ≤ f b₂ ↔ b₁ ≤ b₂)
     (smul : ∀ (a : α) b, f (a • b) = a • f b) : PosSMulReflectLE α β where
-  elim a ha b₁ b₂ h := hf.1 <| le_of_smul_le_smul_left (by simpa only [smul] using hf.2 h) ha
+  le_of_smul_le_smul_left a ha b₁ b₂ h :=
+    hf.1 <| le_of_smul_le_smul_left (by simpa only [smul] using hf.2 h) ha
 
 lemma PosSMulReflectLT.lift [PosSMulReflectLT α γ]
     (hf : ∀ {b₁ b₂}, f b₁ ≤ f b₂ ↔ b₁ ≤ b₂)
     (smul : ∀ (a : α) b, f (a • b) = a • f b) : PosSMulReflectLT α β where
-  elim a ha b₁ b₂ h := by
+  lt_of_smul_lt_smul_left a ha b₁ b₂ h := by
     simp only [← lt_iff_lt_of_le_iff_le' hf hf, smul] at *; exact lt_of_smul_lt_smul_left h ha
 
 end
@@ -1060,14 +1090,14 @@ lemma SMulPosMono.lift [SMulPosMono α γ]
     (hf : ∀ {b₁ b₂}, f b₁ ≤ f b₂ ↔ b₁ ≤ b₂)
     (smul : ∀ (a : α) b, f (a • b) = a • f b)
     (zero : f 0 = 0) : SMulPosMono α β where
-  elim b hb a₁ a₂ ha := by
+  smul_le_smul_of_nonneg_right b hb a₁ a₂ ha := by
     simp only [← hf, zero, smul] at *; exact smul_le_smul_of_nonneg_right ha hb
 
 lemma SMulPosStrictMono.lift [SMulPosStrictMono α γ]
     (hf : ∀ {b₁ b₂}, f b₁ ≤ f b₂ ↔ b₁ ≤ b₂)
     (smul : ∀ (a : α) b, f (a • b) = a • f b)
     (zero : f 0 = 0) : SMulPosStrictMono α β where
-  elim b hb a₁ a₂ ha := by
+  smul_lt_smul_of_pos_right b hb a₁ a₂ ha := by
     simp only [← lt_iff_lt_of_le_iff_le' hf hf, zero, smul] at *
     exact smul_lt_smul_of_pos_right ha hb
 
@@ -1075,7 +1105,7 @@ lemma SMulPosReflectLE.lift [SMulPosReflectLE α γ]
     (hf : ∀ {b₁ b₂}, f b₁ ≤ f b₂ ↔ b₁ ≤ b₂)
     (smul : ∀ (a : α) b, f (a • b) = a • f b)
     (zero : f 0 = 0) : SMulPosReflectLE α β where
-  elim b hb a₁ a₂ h := by
+  le_of_smul_le_smul_right b hb a₁ a₂ h := by
     simp only [← hf, ← lt_iff_lt_of_le_iff_le' hf hf, zero, smul] at *
     exact le_of_smul_le_smul_right h hb
 
@@ -1083,7 +1113,7 @@ lemma SMulPosReflectLT.lift [SMulPosReflectLT α γ]
     (hf : ∀ {b₁ b₂}, f b₁ ≤ f b₂ ↔ b₁ ≤ b₂)
     (smul : ∀ (a : α) b, f (a • b) = a • f b)
     (zero : f 0 = 0) : SMulPosReflectLT α β where
-  elim b hb a₁ a₂ h := by
+  lt_of_smul_lt_smul_right b hb a₁ a₂ h := by
     simp only [← hf, ← lt_iff_lt_of_le_iff_le' hf hf, zero, smul] at *
     exact lt_of_smul_lt_smul_right h hb
 
@@ -1095,21 +1125,21 @@ section Nat
 
 instance OrderedSemiring.toPosSMulMonoNat [Semiring α] [PartialOrder α] [IsOrderedRing α] :
     PosSMulMono ℕ α where
-  elim _n _ _a _b hab := nsmul_le_nsmul_right hab _
+  smul_le_smul_of_nonneg_left _n _ _a _b hab := nsmul_le_nsmul_right hab _
 
 instance OrderedSemiring.toSMulPosMonoNat [Semiring α] [PartialOrder α] [IsOrderedRing α] :
     SMulPosMono ℕ α where
-  elim _a ha _m _n hmn := nsmul_le_nsmul_left ha hmn
+  smul_le_smul_of_nonneg_right _a ha _m _n hmn := nsmul_le_nsmul_left ha hmn
 
 instance StrictOrderedSemiring.toPosSMulStrictMonoNat
     [Semiring α] [PartialOrder α] [IsStrictOrderedRing α] :
     PosSMulStrictMono ℕ α where
-  elim _n hn _a _b hab := nsmul_right_strictMono hn.ne' hab
+  smul_lt_smul_of_pos_left _n hn _a _b hab := nsmul_right_strictMono hn.ne' hab
 
 instance StrictOrderedSemiring.toSMulPosStrictMonoNat
     [Semiring α] [PartialOrder α] [IsStrictOrderedRing α] :
     SMulPosStrictMono ℕ α where
-  elim _a ha _m _n hmn := nsmul_lt_nsmul_left ha hmn
+  smul_lt_smul_of_pos_right _a ha _m _n hmn := nsmul_lt_nsmul_left ha hmn
 
 end Nat
 

--- a/Mathlib/Algebra/Order/Module/Field.lean
+++ b/Mathlib/Algebra/Order/Module/Field.lean
@@ -21,14 +21,13 @@ variable [Semifield 𝕜] [LinearOrder 𝕜] [IsStrictOrderedRing 𝕜] [AddComm
 -- See note [lower instance priority]
 instance (priority := 100) PosSMulMono.toPosSMulReflectLE [MulAction 𝕜 G] [PosSMulMono 𝕜 G] :
     PosSMulReflectLE 𝕜 G where
-  elim _a ha b₁ b₂ h := by
+  le_of_smul_le_smul_left _a ha b₁ b₂ h := by
     simpa [ha.ne'] using smul_le_smul_of_nonneg_left h <| inv_nonneg.2 ha.le
 
 -- See note [lower instance priority]
 instance (priority := 100) PosSMulStrictMono.toPosSMulReflectLT [MulActionWithZero 𝕜 G]
     [PosSMulStrictMono 𝕜 G] : PosSMulReflectLT 𝕜 G :=
-  PosSMulReflectLT.of_pos fun a ha b₁ b₂ h ↦ by
-    simpa [ha.ne'] using smul_lt_smul_of_pos_left h <| inv_pos.2 ha
+  .of_pos fun a ha b₁ b₂ h ↦ by simpa [ha.ne'] using smul_lt_smul_of_pos_left h <| inv_pos.2 ha
 
 end LinearOrderedSemifield
 

--- a/Mathlib/Algebra/Order/Module/OrderedSMul.lean
+++ b/Mathlib/Algebra/Order/Module/OrderedSMul.lean
@@ -59,10 +59,10 @@ variable [Semiring R] [PartialOrder R] [AddCommMonoid M] [PartialOrder M]
   [SMulWithZero R M] [OrderedSMul R M]
 
 instance OrderedSMul.toPosSMulStrictMono : PosSMulStrictMono R M where
-  elim _a ha _b₁ _b₂ hb := OrderedSMul.smul_lt_smul_of_pos hb ha
+  smul_lt_smul_of_pos_left _a ha _b₁ _b₂ hb := OrderedSMul.smul_lt_smul_of_pos hb ha
 
 instance OrderedSMul.toPosSMulReflectLT : PosSMulReflectLT R M :=
-  PosSMulReflectLT.of_pos fun _a ha _b₁ _b₂ h ↦ OrderedSMul.lt_of_smul_lt_smul_of_pos h ha
+  .of_pos fun _a ha _b₁ _b₂ h ↦ OrderedSMul.lt_of_smul_lt_smul_of_pos h ha
 
 instance OrderDual.instOrderedSMul : OrderedSMul R Mᵒᵈ where
   smul_lt_smul_of_pos := OrderedSMul.smul_lt_smul_of_pos (M := M)

--- a/Mathlib/Algebra/Order/Module/Rat.lean
+++ b/Mathlib/Algebra/Order/Module/Rat.lean
@@ -14,10 +14,12 @@ import Mathlib.Data.Rat.Cast.Order
 variable {α : Type*}
 
 instance PosSMulMono.nnrat_of_rat [Preorder α] [MulAction ℚ α] [PosSMulMono ℚ α] :
-    PosSMulMono ℚ≥0 α where elim _q hq _a₁ _a₂ ha := smul_le_smul_of_nonneg_left (α := ℚ) ha hq
+    PosSMulMono ℚ≥0 α where
+  smul_le_smul_of_nonneg_left _q hq _a₁ _a₂ ha := smul_le_smul_of_nonneg_left (α := ℚ) ha hq
 
 instance PosSMulStrictMono.nnrat_of_rat [Preorder α] [MulAction ℚ α] [PosSMulStrictMono ℚ α] :
-    PosSMulStrictMono ℚ≥0 α where elim _q hq _a₁ _a₂ ha := smul_lt_smul_of_pos_left (α := ℚ) ha hq
+    PosSMulStrictMono ℚ≥0 α where
+  smul_lt_smul_of_pos_left _q hq _a₁ _a₂ ha := smul_lt_smul_of_pos_left (α := ℚ) ha hq
 
 section LinearOrderedAddCommGroup
 variable [AddCommGroup α] [LinearOrder α] [IsOrderedAddMonoid α]
@@ -37,7 +39,7 @@ section LinearOrderedSemifield
 variable [Semifield α] [LinearOrder α] [IsStrictOrderedRing α]
 
 instance LinearOrderedSemifield.toPosSMulStrictMono_rat : PosSMulStrictMono ℚ≥0 α where
-  elim q hq a b hab := by
+  smul_lt_smul_of_pos_left q hq a b hab := by
     rw [NNRat.smul_def, NNRat.smul_def]; exact mul_lt_mul_of_pos_left hab <| NNRat.cast_pos.2 hq
 
 end LinearOrderedSemifield
@@ -46,7 +48,7 @@ section LinearOrderedField
 variable [Field α] [LinearOrder α] [IsStrictOrderedRing α]
 
 instance LinearOrderedField.toPosSMulStrictMono_rat : PosSMulStrictMono ℚ α where
-  elim q hq a b hab := by
+  smul_lt_smul_of_pos_left q hq a b hab := by
     rw [Rat.smul_def, Rat.smul_def]; exact mul_lt_mul_of_pos_left hab <| Rat.cast_pos.2 hq
 
 end LinearOrderedField

--- a/Mathlib/Algebra/Order/Star/Basic.lean
+++ b/Mathlib/Algebra/Order/Star/Basic.lean
@@ -359,14 +359,14 @@ variable [Semiring R] [PartialOrder R] [StarRing R] [StarOrderedRing R]
   [StarModule R A] [IsScalarTower R A A] [SMulCommClass R A A]
 
 instance : PosSMulMono R A where
-  elim r hr a b hab := by
+  smul_le_smul_of_nonneg_left r hr a b hab := by
     rw [StarOrderedRing.nonneg_iff] at hr
     rw [StarOrderedRing.le_iff] at hab ⊢
     obtain ⟨a, ha, rfl⟩ := hab
     exact ⟨r • a, smul_mem_closure_star_mul hr ha, smul_add ..⟩
 
 instance : SMulPosMono R A where
-  elim a ha r s hrs := by
+  smul_le_smul_of_nonneg_right a ha r s hrs := by
     rw [StarOrderedRing.nonneg_iff] at ha
     rw [StarOrderedRing.le_iff] at hrs ⊢
     obtain ⟨r, hr, rfl⟩ := hrs
@@ -375,7 +375,7 @@ instance : SMulPosMono R A where
 variable [IsCancelAdd A] [NoZeroSMulDivisors R A]
 
 instance : PosSMulStrictMono R A where
-  elim r hr a b hab := by
+  smul_lt_smul_of_pos_left r hr a b hab := by
     rw [StarOrderedRing.pos_iff] at hr
     rw [StarOrderedRing.lt_iff] at hab ⊢
     obtain ⟨a, ha₀, ha, rfl⟩ := hab
@@ -383,7 +383,7 @@ instance : PosSMulStrictMono R A where
     exact ⟨r • a, smul_ne_zero hr₀ ha₀, smul_mem_closure_star_mul hr ha, smul_add ..⟩
 
 instance [IsCancelAdd R] : SMulPosStrictMono R A where
-  elim a ha r s hrs := by
+  smul_lt_smul_of_pos_right a ha r s hrs := by
     rw [StarOrderedRing.pos_iff] at ha
     rw [StarOrderedRing.lt_iff] at hrs ⊢
     obtain ⟨r, hr₀, hr, rfl⟩ := hrs

--- a/Mathlib/Data/ENNReal/Action.lean
+++ b/Mathlib/Data/ENNReal/Action.lean
@@ -88,10 +88,11 @@ theorem toReal_smul (r : ℝ≥0) (s : ℝ≥0∞) : (r • s).toReal = r • s.
   rfl
 
 instance : PosSMulStrictMono ℝ≥0 ℝ≥0∞ where
-  elim _r hr _a _b hab := ENNReal.mul_lt_mul_left' (coe_pos.2 hr).ne' coe_ne_top hab
+  smul_lt_smul_of_pos_left _r hr _a _b hab :=
+    ENNReal.mul_lt_mul_left' (coe_pos.2 hr).ne' coe_ne_top hab
 
 instance : SMulPosMono ℝ≥0 ℝ≥0∞ where
-  elim _r _ _a _b hab := mul_le_mul_right' (coe_le_coe.2 hab) _
+  smul_le_smul_of_nonneg_right _r _ _a _b hab := mul_le_mul_right' (coe_le_coe.2 hab) _
 
 end Actions
 

--- a/Mathlib/Data/Finsupp/Weight.lean
+++ b/Mathlib/Data/Finsupp/Weight.lean
@@ -137,11 +137,6 @@ variable [AddCommMonoid M] [PartialOrder M] [IsOrderedAddMonoid M] (w : σ → M
   {R : Type*} [CommSemiring R] [PartialOrder R] [IsOrderedRing R]
   [CanonicallyOrderedAdd R] [NoZeroDivisors R] [Module R M]
 
-instance : SMulPosMono ℕ M :=
-  ⟨fun b hb m m' h ↦ by
-    rw [← Nat.add_sub_of_le h, add_smul]
-    exact le_add_of_nonneg_right (nsmul_nonneg hb (m' - m))⟩
-
 variable {w} in
 theorem le_weight_of_ne_zero (hw : ∀ s, 0 ≤ w s) {s : σ} {f : σ →₀ ℕ} (hs : f s ≠ 0) :
     w s ≤ weight w f := by

--- a/Mathlib/Data/NNReal/Defs.lean
+++ b/Mathlib/Data/NNReal/Defs.lean
@@ -393,11 +393,11 @@ example : NoMaxOrder ℝ≥0 := by infer_instance
 
 instance instPosSMulStrictMono {α} [Preorder α] [MulAction ℝ α] [PosSMulStrictMono ℝ α] :
     PosSMulStrictMono ℝ≥0 α where
-  elim _r hr _a₁ _a₂ ha := (smul_lt_smul_of_pos_left ha (coe_pos.2 hr):)
+  smul_lt_smul_of_pos_left _r hr _a₁ _a₂ ha := (smul_lt_smul_of_pos_left ha (coe_pos.2 hr) :)
 
 instance instSMulPosStrictMono {α} [Zero α] [Preorder α] [MulAction ℝ α] [SMulPosStrictMono ℝ α] :
     SMulPosStrictMono ℝ≥0 α where
-  elim _a ha _r₁ _r₂ hr := (smul_lt_smul_of_pos_right (coe_lt_coe.2 hr) ha :)
+  smul_lt_smul_of_pos_right _a ha _r₁ _r₂ hr := (smul_lt_smul_of_pos_right (coe_lt_coe.2 hr) ha :)
 
 /-- If `a` is a nonnegative real number, then the closed interval `[0, a]` in `ℝ` is order
 isomorphic to the interval `Set.Iic a`. -/


### PR DESCRIPTION
This prevented us from defining further typeclasses by extending.

Also move earlier an instance that somehow got stranded in `Data.Finsupp.Weight`.

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include at least one commit authored by each
co-author among the commits in the pull request. If necessary, you may 
create empty commits to indicate co-authorship, using commands like so:

git commit --author="Author Name <author@email.com>" --allow-empty -m "add Author Name as coauthor"

When merging, all the commits will be squashed into a single commit listing all co-authors.

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
