### PR TITLE
[Merged by Bors] - feat(SetTheory/Cardinal): generalize and rename theorems on `Cardinal.sum`

### DIFF
--- a/Mathlib/Data/W/Cardinal.lean
+++ b/Mathlib/Data/W/Cardinal.lean
@@ -63,7 +63,7 @@ theorem cardinalMk_le_max_aleph0_of_finite' [∀ a, Finite (β a)] :
     cardinalMk_le_of_le' <|
       calc
         (Cardinal.sum fun a => m ^ lift.{u} #(β a)) ≤ lift.{v} #α * ⨆ a, m ^ lift.{u} #(β a) :=
-          Cardinal.sum_le_iSup_lift _
+          Cardinal.sum_le_lift_mk_mul_iSup _
         _ ≤ m * ⨆ a, m ^ lift.{u} #(β a) := mul_le_mul' (le_max_left _ _) le_rfl
         _ = m :=
           mul_eq_left (le_max_right _ _)

--- a/Mathlib/ModelTheory/Encoding.lean
+++ b/Mathlib/ModelTheory/Encoding.lean
@@ -109,7 +109,7 @@ theorem card_le : #(L.Term α) ≤ max ℵ₀ #(α ⊕ (Σ i, L.Functions i)) :=
 theorem card_sigma : #(Σ n, L.Term (α ⊕ (Fin n))) = max ℵ₀ #(α ⊕ (Σ i, L.Functions i)) := by
   refine le_antisymm ?_ ?_
   · rw [mk_sigma]
-    refine (sum_le_iSup_lift _).trans ?_
+    refine (sum_le_lift_mk_mul_iSup _).trans ?_
     rw [mk_nat, lift_aleph0, mul_eq_max_of_aleph0_le_left le_rfl, max_le_iff,
       ciSup_le_iff' (bddAbove_range _)]
     · refine ⟨le_max_left _ _, fun i => card_le.trans ?_⟩

--- a/Mathlib/SetTheory/Cardinal/Arithmetic.lean
+++ b/Mathlib/SetTheory/Cardinal/Arithmetic.lean
@@ -415,7 +415,7 @@ protected theorem ciSup_mul_ciSup (g : ι' → Cardinal.{v}) :
 theorem sum_eq_iSup_lift {f : ι → Cardinal.{max u v}} (hι : ℵ₀ ≤ #ι)
     (h : lift.{v} #ι ≤ iSup f) : sum f = iSup f := by
   apply (iSup_le_sum f).antisymm'
-  convert sum_le_iSup_lift f
+  convert sum_le_lift_mk_mul_iSup f
   rw [mul_eq_max (aleph0_le_lift.mpr hι) ((aleph0_le_lift.mpr hι).trans h), max_eq_right h]
 
 theorem sum_eq_iSup {f : ι → Cardinal.{u}} (hι : ℵ₀ ≤ #ι) (h : #ι ≤ iSup f) : sum f = iSup f :=

--- a/Mathlib/SetTheory/Cardinal/Arithmetic.lean
+++ b/Mathlib/SetTheory/Cardinal/Arithmetic.lean
@@ -412,14 +412,26 @@ protected theorem ciSup_mul_ciSup (g : ι' → Cardinal.{v}) :
     (⨆ i, f i) * (⨆ j, g j) = ⨆ (i) (j), f i * g j := by
   simp_rw [Cardinal.ciSup_mul f, Cardinal.mul_ciSup g]
 
-theorem sum_eq_iSup_lift {f : ι → Cardinal.{max u v}} (hι : ℵ₀ ≤ #ι)
-    (h : lift.{v} #ι ≤ iSup f) : sum f = iSup f := by
-  apply (iSup_le_sum f).antisymm'
-  convert sum_le_lift_mk_mul_iSup f
-  rw [mul_eq_max (aleph0_le_lift.mpr hι) ((aleph0_le_lift.mpr hι).trans h), max_eq_right h]
+theorem sum_eq_lift_iSup_of_lift_mk_le_lift_iSup [Small.{v} ι] {f : ι → Cardinal.{v}} (hι : ℵ₀ ≤ #ι)
+    (h : lift.{v} #ι ≤ lift.{u} (⨆ i, f i)) : sum f = lift (⨆ i, f i) := by
+  rw [lift_iSup (bddAbove_of_small _)] at h
+  apply (lift_iSup_le_sum f).antisymm'
+  convert sum_le_lift_mk_mul_iSup_lift f
+  rw [mul_eq_max (aleph0_le_lift.mpr hι) ((aleph0_le_lift.mpr hι).trans h), max_eq_right h,
+    lift_iSup (bddAbove_of_small _)]
 
-theorem sum_eq_iSup {f : ι → Cardinal.{u}} (hι : ℵ₀ ≤ #ι) (h : #ι ≤ iSup f) : sum f = iSup f :=
-  sum_eq_iSup_lift hι ((lift_id #ι).symm ▸ h)
+theorem sum_eq_iSup_of_lift_mk_le_iSup {f : ι → Cardinal.{max u v}} (hι : ℵ₀ ≤ #ι)
+    (h : lift.{v} #ι ≤ ⨆ i, f i) : sum f = ⨆ i, f i := by
+  rw [← lift_id'.{u, v} (iSup _)]
+  apply sum_eq_lift_iSup_of_lift_mk_le_lift_iSup hι
+  rwa [lift_umax, lift_id'.{u, v}]
+
+theorem sum_eq_iSup_of_mk_le_iSup {f : ι → Cardinal.{u}} (hι : ℵ₀ ≤ #ι) (h : #ι ≤ iSup f) :
+    sum f = ⨆ i, f i :=
+  sum_eq_iSup_of_lift_mk_le_iSup hι ((lift_id #ι).symm ▸ h)
+
+@[deprecated (since := "2025-09-06")] alias sum_eq_iSup_lift := sum_eq_iSup_of_lift_mk_le_iSup
+@[deprecated (since := "2025-09-06")] alias sum_eq_iSup := sum_eq_iSup_of_lift_mk_le_iSup
 
 end ciSup
 

--- a/Mathlib/SetTheory/Cardinal/Arithmetic.lean
+++ b/Mathlib/SetTheory/Cardinal/Arithmetic.lean
@@ -431,7 +431,7 @@ theorem sum_eq_iSup_of_mk_le_iSup {f : ι → Cardinal.{u}} (hι : ℵ₀ ≤ #�
   sum_eq_iSup_of_lift_mk_le_iSup hι ((lift_id #ι).symm ▸ h)
 
 @[deprecated (since := "2025-09-06")] alias sum_eq_iSup_lift := sum_eq_iSup_of_lift_mk_le_iSup
-@[deprecated (since := "2025-09-06")] alias sum_eq_iSup := sum_eq_iSup_of_lift_mk_le_iSup
+@[deprecated (since := "2025-09-06")] alias sum_eq_iSup := sum_eq_iSup_of_mk_le_iSup
 
 end ciSup
 

--- a/Mathlib/SetTheory/Cardinal/Basic.lean
+++ b/Mathlib/SetTheory/Cardinal/Basic.lean
@@ -187,8 +187,8 @@ instance uncountable : Uncountable Cardinal.{u} :=
 
 /-! ### Bounds on suprema -/
 
-theorem sum_le_lift_mk_mul_iSup_lift {ι} (f : ι → Cardinal.{v}) :
-    sum f ≤ lift #ι * ⨆ i, lift.{u} (f i) := by
+theorem sum_le_lift_mk_mul_iSup_lift {ι : Type u} (f : ι → Cardinal.{v}) :
+    sum f ≤ lift #ι * ⨆ i, lift (f i) := by
   rw [← (sum f).lift_id, lift_sum, ← lift_umax.{u, v}, ← (⨆ i, lift (f i)).lift_id,
     lift_umax.{max v u, u}, ← sum_const]
   refine sum_le_sum _ _ fun i => ?_
@@ -200,7 +200,7 @@ theorem sum_le_lift_mk_mul_iSup {ι : Type u} (f : ι → Cardinal.{max u v}) :
   simpa [← lift_umax] using sum_le_lift_mk_mul_iSup_lift f
 
 theorem sum_le_mk_mul_iSup {ι : Type u} (f : ι → Cardinal.{u}) : sum f ≤ #ι * ⨆ i, f i := by
-  simpa using sum_le_lift_mk_mul_iSup.{u, u} f
+  simpa using sum_le_lift_mk_mul_iSup_lift f
 
 @[deprecated (since := "2025-09-04")] alias sum_le_iSup_lift := sum_le_lift_mk_mul_iSup
 @[deprecated (since := "2025-09-04")] alias sum_le_iSup := sum_le_mk_mul_iSup

--- a/Mathlib/SetTheory/Cardinal/Basic.lean
+++ b/Mathlib/SetTheory/Cardinal/Basic.lean
@@ -187,14 +187,23 @@ instance uncountable : Uncountable Cardinal.{u} :=
 
 /-! ### Bounds on suprema -/
 
-theorem sum_le_iSup_lift {ι : Type u}
-    (f : ι → Cardinal.{max u v}) : sum f ≤ Cardinal.lift #ι * iSup f := by
-  rw [← (iSup f).lift_id, ← lift_umax, lift_umax.{max u v, u}, ← sum_const]
-  exact sum_le_sum _ _ (le_ciSup <| bddAbove_of_small _)
+theorem sum_le_lift_mk_mul_iSup_lift {ι} (f : ι → Cardinal.{v}) :
+    sum f ≤ lift #ι * ⨆ i, lift.{u} (f i) := by
+  rw [← (sum f).lift_id, lift_sum, ← lift_umax.{u, v}, ← (⨆ i, lift (f i)).lift_id,
+    lift_umax.{max v u, u}, ← sum_const]
+  refine sum_le_sum _ _ fun i => ?_
+  rw [lift_umax.{v, u}]
+  exact le_ciSup (bddAbove_of_small _) i
 
-theorem sum_le_iSup {ι : Type u} (f : ι → Cardinal.{u}) : sum f ≤ #ι * iSup f := by
-  rw [← lift_id #ι]
-  exact sum_le_iSup_lift f
+theorem sum_le_lift_mk_mul_iSup {ι : Type u} (f : ι → Cardinal.{max u v}) :
+    sum f ≤ lift #ι * iSup f := by
+  simpa [← lift_umax] using sum_le_lift_mk_mul_iSup_lift f
+
+theorem sum_le_mk_mul_iSup {ι : Type u} (f : ι → Cardinal.{u}) : sum f ≤ #ι * iSup f := by
+  simpa using sum_le_lift_mk_mul_iSup.{u, u} f
+
+@[deprecated (since := "2025-09-04")] alias sum_le_iSup_lift := sum_le_lift_mk_mul_iSup
+@[deprecated (since := "2025-09-04")] alias sum_le_iSup := sum_le_mk_mul_iSup
 
 /-- The lift of a supremum is the supremum of the lifts. -/
 theorem lift_sSup {s : Set Cardinal} (hs : BddAbove s) :
@@ -716,11 +725,11 @@ theorem mk_iUnion_eq_sum_mk_lift {α : Type u} {ι : Type v} {f : ι → Set α}
     _ = sum fun i => #(f i) := mk_sigma _
 
 theorem mk_iUnion_le {α ι : Type u} (f : ι → Set α) : #(⋃ i, f i) ≤ #ι * ⨆ i, #(f i) :=
-  mk_iUnion_le_sum_mk.trans (sum_le_iSup _)
+  mk_iUnion_le_sum_mk.trans (sum_le_mk_mul_iSup _)
 
 theorem mk_iUnion_le_lift {α : Type u} {ι : Type v} (f : ι → Set α) :
     lift.{v} #(⋃ i, f i) ≤ lift.{u} #ι * ⨆ i, lift.{v} #(f i) := by
-  refine mk_iUnion_le_sum_mk_lift.trans <| Eq.trans_le ?_ (sum_le_iSup_lift _)
+  refine mk_iUnion_le_sum_mk_lift.trans <| Eq.trans_le ?_ (sum_le_lift_mk_mul_iSup _)
   rw [← lift_sum, lift_id'.{_,u}]
 
 theorem mk_sUnion_le {α : Type u} (A : Set (Set α)) : #(⋃₀ A) ≤ #A * ⨆ s : A, #s := by

--- a/Mathlib/SetTheory/Cardinal/Basic.lean
+++ b/Mathlib/SetTheory/Cardinal/Basic.lean
@@ -254,7 +254,7 @@ theorem lift_iSup_le_lift_iSup' {ι : Type v} {ι' : Type v'} {f : ι → Cardin
     (h : ∀ i, lift.{v'} (f i) ≤ lift.{v} (f' (g i))) : lift.{v'} (iSup f) ≤ lift.{v} (iSup f') :=
   lift_iSup_le_lift_iSup hf hf' h
 
-theorem lift_iSup_le_sum {ι} [Small.{v, u} ι] (f : ι → Cardinal.{v}) :
+theorem lift_iSup_le_sum {ι : Type u} [Small.{v} ι] (f : ι → Cardinal.{v}) :
     lift (⨆ i, f i) ≤ sum f := by
   rw [lift_iSup (bddAbove_of_small _)]
   exact ciSup_le' fun i => lift_le_sum f i

--- a/Mathlib/SetTheory/Cardinal/Basic.lean
+++ b/Mathlib/SetTheory/Cardinal/Basic.lean
@@ -254,6 +254,11 @@ theorem lift_iSup_le_lift_iSup' {ι : Type v} {ι' : Type v'} {f : ι → Cardin
     (h : ∀ i, lift.{v'} (f i) ≤ lift.{v} (f' (g i))) : lift.{v'} (iSup f) ≤ lift.{v} (iSup f') :=
   lift_iSup_le_lift_iSup hf hf' h
 
+theorem lift_iSup_le_sum {ι} [Small.{v, u} ι] (f : ι → Cardinal.{v}) :
+    lift (⨆ i, f i) ≤ sum f := by
+  rw [lift_iSup (bddAbove_of_small _)]
+  exact ciSup_le' fun i => lift_le_sum f i
+
 /-! ### Properties about the cast from `ℕ` -/
 
 theorem mk_finset_of_fintype [Fintype α] : #(Finset α) = 2 ^ Fintype.card α := by

--- a/Mathlib/SetTheory/Cardinal/Basic.lean
+++ b/Mathlib/SetTheory/Cardinal/Basic.lean
@@ -196,10 +196,10 @@ theorem sum_le_lift_mk_mul_iSup_lift {ι} (f : ι → Cardinal.{v}) :
   exact le_ciSup (bddAbove_of_small _) i
 
 theorem sum_le_lift_mk_mul_iSup {ι : Type u} (f : ι → Cardinal.{max u v}) :
-    sum f ≤ lift #ι * iSup f := by
+    sum f ≤ lift #ι * ⨆ i, f i := by
   simpa [← lift_umax] using sum_le_lift_mk_mul_iSup_lift f
 
-theorem sum_le_mk_mul_iSup {ι : Type u} (f : ι → Cardinal.{u}) : sum f ≤ #ι * iSup f := by
+theorem sum_le_mk_mul_iSup {ι : Type u} (f : ι → Cardinal.{u}) : sum f ≤ #ι * ⨆ i, f i := by
   simpa using sum_le_lift_mk_mul_iSup.{u, u} f
 
 @[deprecated (since := "2025-09-04")] alias sum_le_iSup_lift := sum_le_lift_mk_mul_iSup

--- a/Mathlib/SetTheory/Cardinal/Cofinality.lean
+++ b/Mathlib/SetTheory/Cardinal/Cofinality.lean
@@ -661,7 +661,7 @@ theorem mk_bounded_subset {α : Type*} (h : ∀ x < #α, 2 ^ x < #α) {r : α �
   apply le_antisymm
   · have : { s : Set α | Bounded r s } = ⋃ i, 𝒫{ j | r j i } := setOf_exists _
     rw [← coe_setOf, this]
-    refine mk_iUnion_le_sum_mk.trans ((sum_le_iSup (fun i => #(𝒫{ j | r j i }))).trans
+    refine mk_iUnion_le_sum_mk.trans ((sum_le_mk_mul_iSup (fun i => #(𝒫{ j | r j i }))).trans
       ((mul_le_max_of_aleph0_le_left ha).trans ?_))
     rw [max_eq_left]
     apply ciSup_le' _

--- a/Mathlib/SetTheory/Cardinal/Defs.lean
+++ b/Mathlib/SetTheory/Cardinal/Defs.lean
@@ -442,16 +442,20 @@ theorem prod_eq_zero {ι} (f : ι → Cardinal.{u}) : prod f = 0 ↔ ∃ i, f i 
 
 theorem prod_ne_zero {ι} (f : ι → Cardinal) : prod f ≠ 0 ↔ ∀ i, f i ≠ 0 := by simp [prod_eq_zero]
 
-theorem power_sum {ι} (a : Cardinal) (f : ι → Cardinal) :
-    a ^ sum f = prod fun i ↦ a ^ f i := by
+theorem lift_power_sum {ι} (a : Cardinal) (f : ι → Cardinal) :
+    (Cardinal.lift.{u, v} a) ^ sum f = prod fun i ↦ a ^ f i := by
   induction a using Cardinal.inductionOn with | _ α =>
   induction f using induction_on_pi with | _ f =>
-  simp_rw [prod, sum, power_def]
+  simp_rw [← mk_uLift, prod, sum, power_def]
   apply mk_congr
-  refine (Equiv.piCurry fun _ _ => α).trans ?_
+  refine (Equiv.piCurry fun _ _ => ULift α).trans ?_
   refine Equiv.piCongrRight fun b => ?_
-  refine (Equiv.arrowCongr outMkEquiv (Equiv.refl α)).trans ?_
+  refine (Equiv.arrowCongr outMkEquiv Equiv.ulift).trans ?_
   exact outMkEquiv.symm
+
+theorem power_sum {ι} (a : Cardinal) (f : ι → Cardinal) :
+    a ^ sum f = prod fun i ↦ a ^ f i := by
+  simpa [← lift_umax] using lift_power_sum a f
 
 @[simp]
 theorem lift_prod {ι : Type u} (c : ι → Cardinal.{v}) :

--- a/Mathlib/SetTheory/Cardinal/Defs.lean
+++ b/Mathlib/SetTheory/Cardinal/Defs.lean
@@ -442,8 +442,8 @@ theorem prod_eq_zero {ι} (f : ι → Cardinal.{u}) : prod f = 0 ↔ ∃ i, f i 
 
 theorem prod_ne_zero {ι} (f : ι → Cardinal) : prod f ≠ 0 ↔ ∀ i, f i ≠ 0 := by simp [prod_eq_zero]
 
-theorem lift_power_sum {ι} (a : Cardinal) (f : ι → Cardinal) :
-    (Cardinal.lift.{u, v} a) ^ sum f = prod fun i ↦ a ^ f i := by
+theorem lift_power_sum {ι : Type u} (a : Cardinal.{v}) (f : ι → Cardinal.{v}) :
+    lift.{u, v} a ^ sum f = prod fun i ↦ a ^ f i := by
   induction a using Cardinal.inductionOn with | _ α =>
   induction f using induction_on_pi with | _ f =>
   simp_rw [← mk_uLift, prod, sum, power_def]
@@ -453,7 +453,7 @@ theorem lift_power_sum {ι} (a : Cardinal) (f : ι → Cardinal) :
   refine (Equiv.arrowCongr outMkEquiv Equiv.ulift).trans ?_
   exact outMkEquiv.symm
 
-theorem power_sum {ι} (a : Cardinal) (f : ι → Cardinal) :
+theorem power_sum {ι : Type u} (a : Cardinal.{max u v}) (f : ι → Cardinal.{max u v}) :
     a ^ sum f = prod fun i ↦ a ^ f i := by
   simpa [← lift_umax] using lift_power_sum a f
 

--- a/Mathlib/SetTheory/Cardinal/Order.lean
+++ b/Mathlib/SetTheory/Cardinal/Order.lean
@@ -457,11 +457,11 @@ theorem not_isStrongLimit_zero : ¬ IsStrongLimit (0 : Cardinal) :=
 
 /-! ### Indexed cardinal `sum` -/
 
-theorem lift_le_sum {ι} (f : ι → Cardinal) (i) : lift.{u, v} (f i) ≤ sum f := by
+theorem lift_le_sum {ι : Type u} (f : ι → Cardinal.{v}) (i) : lift.{u, v} (f i) ≤ sum f := by
   rw [← Quotient.out_eq (f i)]
   exact ⟨⟨fun a => ⟨i, a.down⟩, fun a b h => by simpa using h⟩⟩
 
-theorem le_sum {ι} (f : ι → Cardinal) (i) : f i ≤ sum f := by
+theorem le_sum {ι : Type u} (f : ι → Cardinal.{max u v}) (i) : f i ≤ sum f := by
   simpa [← lift_umax] using lift_le_sum f i
 
 theorem iSup_le_sum {ι} (f : ι → Cardinal) : iSup f ≤ sum f :=

--- a/Mathlib/SetTheory/Cardinal/Order.lean
+++ b/Mathlib/SetTheory/Cardinal/Order.lean
@@ -457,9 +457,12 @@ theorem not_isStrongLimit_zero : ¬ IsStrongLimit (0 : Cardinal) :=
 
 /-! ### Indexed cardinal `sum` -/
 
-theorem le_sum {ι} (f : ι → Cardinal) (i) : f i ≤ sum f := by
+theorem lift_le_sum {ι} (f : ι → Cardinal) (i) : lift.{u, v} (f i) ≤ sum f := by
   rw [← Quotient.out_eq (f i)]
-  exact ⟨⟨fun a => ⟨i, a⟩, fun a b h => by injection h⟩⟩
+  exact ⟨⟨fun a => ⟨i, a.down⟩, fun a b h => by simpa using h⟩⟩
+
+theorem le_sum {ι} (f : ι → Cardinal) (i) : f i ≤ sum f := by
+  simpa [← lift_umax] using lift_le_sum f i
 
 theorem iSup_le_sum {ι} (f : ι → Cardinal) : iSup f ≤ sum f :=
   ciSup_le' <| le_sum _

--- a/Mathlib/SetTheory/Cardinal/Ordinal.lean
+++ b/Mathlib/SetTheory/Cardinal/Ordinal.lean
@@ -67,7 +67,7 @@ theorem card_iSup_Iio_le_sum_card {o : Ordinal.{u}} (f : Iio o → Ordinal.{max 
 theorem card_iSup_Iio_le_card_mul_iSup {o : Ordinal.{u}} (f : Iio o → Ordinal.{max u v}) :
     (⨆ a : Iio o, f a).card ≤ Cardinal.lift.{v} o.card * ⨆ a : Iio o, (f a).card := by
   apply (card_iSup_Iio_le_sum_card f).trans
-  convert ← sum_le_iSup_lift _
+  convert ← sum_le_lift_mk_mul_iSup _
   · exact mk_toType o
   · exact (enumIsoToType o).symm.iSup_comp (g := fun x ↦ (f x).card)
 

--- a/Mathlib/SetTheory/Cardinal/Pigeonhole.lean
+++ b/Mathlib/SetTheory/Cardinal/Pigeonhole.lean
@@ -30,8 +30,8 @@ theorem infinite_pigeonhole {β α : Type u} (f : β → α) (h₁ : ℵ₀ ≤ 
     apply mk_univ.not_lt
     rw [← preimage_univ, ← iUnion_of_singleton, preimage_iUnion]
     exact
-      mk_iUnion_le_sum_mk.trans_lt
-        ((sum_le_iSup _).trans_lt <| mul_lt_of_lt h₁ (h₂.trans_le <| cof_ord_le _) (iSup_lt h₂ h))
+      mk_iUnion_le_sum_mk.trans_lt <| (sum_le_mk_mul_iSup _).trans_lt <|
+        mul_lt_of_lt h₁ (h₂.trans_le <| cof_ord_le _) (iSup_lt h₂ h)
   obtain ⟨x, h⟩ := this
   refine ⟨x, h.antisymm' ?_⟩
   rw [le_mk_iff_exists_set]

--- a/Mathlib/SetTheory/Cardinal/Regular.lean
+++ b/Mathlib/SetTheory/Cardinal/Regular.lean
@@ -145,18 +145,23 @@ theorem iSup_lt_of_isRegular {ι} {f : ι → Cardinal} {c} (hc : IsRegular c) (
     (∀ i, f i < c) → iSup f < c :=
   iSup_lt (by rwa [hc.cof_eq])
 
-theorem sum_lt_lift_of_isRegular' {ι} {f : ι → Cardinal} {c : Cardinal} (hc : IsRegular c)
-    (hι : Cardinal.lift.{v, u} #ι < c) (hf : ∀ i, lift (f i) < c) : sum f < c :=
+theorem IsRegular.sum_lt_of_lift_mk_lt_of_lift_lt {ι} {f : ι → Cardinal} {c : Cardinal}
+    (hc : IsRegular c) (hι : lift.{v, u} #ι < c) (hf : ∀ i, lift (f i) < c) : sum f < c :=
   (sum_le_lift_mk_mul_iSup_lift _).trans_lt <| mul_lt_of_lt hc.1 hι <|
     iSup_lt_lift_of_isRegular hc hι hf
 
-theorem sum_lt_lift_of_isRegular {ι : Type u} {f : ι → Cardinal} {c : Cardinal} (hc : IsRegular c)
-    (hι : Cardinal.lift.{v, u} #ι < c) (hf : ∀ i, f i < c) : sum f < c :=
-  sum_lt_lift_of_isRegular' hc (by rwa [lift_umax]) (by simpa [← lift_umax])
+theorem IsRegular.sum_lt_of_lift_mk_lt_of_lt {ι : Type u} {f : ι → Cardinal} {c : Cardinal}
+    (hc : IsRegular c) (hι : lift.{v, u} #ι < c) (hf : ∀ i, f i < c) : sum f < c :=
+  hc.sum_lt_of_lift_mk_lt_of_lift_lt (by rwa [lift_umax]) (by simpa [← lift_umax])
 
-theorem sum_lt_of_isRegular {ι : Type u} {f : ι → Cardinal} {c : Cardinal} (hc : IsRegular c)
-    (hι : #ι < c) : (∀ i, f i < c) → sum f < c :=
-  sum_lt_lift_of_isRegular.{u, u} hc (by rwa [lift_id])
+theorem IsRegular.sum_lt_of_mk_lt_of_lt {ι : Type u} {f : ι → Cardinal} {c : Cardinal}
+    (hc : IsRegular c) (hι : #ι < c) (hf : ∀ i, f i < c) : sum f < c :=
+  hc.sum_lt_of_lift_mk_lt_of_lt (by rwa [lift_id]) hf
+
+@[deprecated (since := "2025-09-06")]
+alias sum_lt_lift_of_isRegular := IsRegular.sum_lt_of_lift_mk_lt_of_lt
+
+@[deprecated (since := "2025-09-06")] alias sum_lt_of_isRegular := IsRegular.sum_lt_of_mk_lt_of_lt
 
 @[simp]
 theorem card_lt_of_card_iUnion_lt {ι : Type u} {α : Type u} {t : ι → Set α} {c : Cardinal}

--- a/Mathlib/SetTheory/Cardinal/Regular.lean
+++ b/Mathlib/SetTheory/Cardinal/Regular.lean
@@ -145,23 +145,13 @@ theorem iSup_lt_of_isRegular {ι} {f : ι → Cardinal} {c} (hc : IsRegular c) (
     (∀ i, f i < c) → iSup f < c :=
   iSup_lt (by rwa [hc.cof_eq])
 
-theorem IsRegular.sum_lt_of_lift_mk_lt_of_lift_lt {ι} {f : ι → Cardinal} {c : Cardinal}
-    (hc : IsRegular c) (hι : lift.{v, u} #ι < c) (hf : ∀ i, lift (f i) < c) : sum f < c :=
-  (sum_le_lift_mk_mul_iSup_lift _).trans_lt <| mul_lt_of_lt hc.1 hι <|
-    iSup_lt_lift_of_isRegular hc hι hf
+theorem sum_lt_lift_of_isRegular {ι : Type u} {f : ι → Cardinal} {c : Cardinal} (hc : IsRegular c)
+    (hι : Cardinal.lift.{v, u} #ι < c) (hf : ∀ i, f i < c) : sum f < c :=
+  (sum_le_lift_mk_mul_iSup _).trans_lt <| mul_lt_of_lt hc.1 hι (iSup_lt_lift_of_isRegular hc hι hf)
 
-theorem IsRegular.sum_lt_of_lift_mk_lt_of_lt {ι : Type u} {f : ι → Cardinal} {c : Cardinal}
-    (hc : IsRegular c) (hι : lift.{v, u} #ι < c) (hf : ∀ i, f i < c) : sum f < c :=
-  hc.sum_lt_of_lift_mk_lt_of_lift_lt (by rwa [lift_umax]) (by simpa [← lift_umax])
-
-theorem IsRegular.sum_lt_of_mk_lt_of_lt {ι : Type u} {f : ι → Cardinal} {c : Cardinal}
-    (hc : IsRegular c) (hι : #ι < c) (hf : ∀ i, f i < c) : sum f < c :=
-  hc.sum_lt_of_lift_mk_lt_of_lt (by rwa [lift_id]) hf
-
-@[deprecated (since := "2025-09-06")]
-alias sum_lt_lift_of_isRegular := IsRegular.sum_lt_of_lift_mk_lt_of_lt
-
-@[deprecated (since := "2025-09-06")] alias sum_lt_of_isRegular := IsRegular.sum_lt_of_mk_lt_of_lt
+theorem sum_lt_of_isRegular {ι : Type u} {f : ι → Cardinal} {c : Cardinal} (hc : IsRegular c)
+    (hι : #ι < c) : (∀ i, f i < c) → sum f < c :=
+  sum_lt_lift_of_isRegular.{u, u} hc (by rwa [lift_id])
 
 @[simp]
 theorem card_lt_of_card_iUnion_lt {ι : Type u} {α : Type u} {t : ι → Set α} {c : Cardinal}

--- a/Mathlib/SetTheory/Cardinal/Regular.lean
+++ b/Mathlib/SetTheory/Cardinal/Regular.lean
@@ -145,9 +145,14 @@ theorem iSup_lt_of_isRegular {ι} {f : ι → Cardinal} {c} (hc : IsRegular c) (
     (∀ i, f i < c) → iSup f < c :=
   iSup_lt (by rwa [hc.cof_eq])
 
+theorem sum_lt_lift_of_isRegular' {ι} {f : ι → Cardinal} {c : Cardinal} (hc : IsRegular c)
+    (hι : Cardinal.lift.{v, u} #ι < c) (hf : ∀ i, lift (f i) < c) : sum f < c :=
+  (sum_le_lift_mk_mul_iSup_lift _).trans_lt <| mul_lt_of_lt hc.1 hι <|
+    iSup_lt_lift_of_isRegular hc hι hf
+
 theorem sum_lt_lift_of_isRegular {ι : Type u} {f : ι → Cardinal} {c : Cardinal} (hc : IsRegular c)
     (hι : Cardinal.lift.{v, u} #ι < c) (hf : ∀ i, f i < c) : sum f < c :=
-  (sum_le_iSup_lift _).trans_lt <| mul_lt_of_lt hc.1 hι (iSup_lt_lift_of_isRegular hc hι hf)
+  sum_lt_lift_of_isRegular' hc (by rwa [lift_umax]) (by simpa [← lift_umax])
 
 theorem sum_lt_of_isRegular {ι : Type u} {f : ι → Cardinal} {c : Cardinal} (hc : IsRegular c)
     (hι : #ι < c) : (∀ i, f i < c) → sum f < c :=


### PR DESCRIPTION
Some theorems on `Cardinal.sum f` are taking `f : ι → Cardinal.{max u v}`, which can be generalized to `f : ι → Cardinal.{v}`. Also rename `sum_le_iSup_lift`, `sum_eq_iSup_lift` etc. to reflect their signatures in names.

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include at least one commit authored by each
co-author among the commits in the pull request. If necessary, you may 
create empty commits to indicate co-authorship, using commands like so:

git commit --author="Author Name <author@email.com>" --allow-empty -m "add Author Name as coauthor"

When merging, all the commits will be squashed into a single commit listing all co-authors.

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
