### PR TITLE
[Merged by Bors] - chore(RingTheory): process porting notes, part 2

### DIFF
--- a/Mathlib/Algebra/Module/Equiv/Defs.lean
+++ b/Mathlib/Algebra/Module/Equiv/Defs.lean
@@ -525,10 +525,16 @@ theorem symm_mk (f h₁ h₂ h₃ h₄) :
         invFun := e } :=
   rfl
 
-@[simp]
+/-- For a more powerful version, see `coe_symm_mk'`. -/
 theorem coe_symm_mk [Module R M] [Module R M₂]
     {to_fun inv_fun map_add map_smul left_inv right_inv} :
     ⇑(⟨⟨⟨to_fun, map_add⟩, map_smul⟩, inv_fun, left_inv, right_inv⟩ : M ≃ₗ[R] M₂).symm = inv_fun :=
+  rfl
+
+@[simp]
+theorem coe_symm_mk' [Module R M] [Module R M₂]
+    {f inv_fun left_inv right_inv} :
+    ⇑(⟨f, inv_fun, left_inv, right_inv⟩ : M ≃ₗ[R] M₂).symm = inv_fun :=
   rfl
 
 protected theorem bijective : Function.Bijective e :=

--- a/Mathlib/Algebra/Module/LocalizedModule/Basic.lean
+++ b/Mathlib/Algebra/Module/LocalizedModule/Basic.lean
@@ -535,16 +535,15 @@ variable (f : M →ₗ[R] M') (g : M →ₗ[R] M'')
 `IsLocalizedModule S f` describes that `f : M ⟶ M'` is the localization map identifying `M'` as
 `LocalizedModule S M`.
 -/
-@[mk_iff] class IsLocalizedModule : Prop where
+@[mk_iff] class IsLocalizedModule (S : Submonoid R) (f : M →ₗ[R] M') : Prop where
   map_units : ∀ x : S, IsUnit (algebraMap R (Module.End R M') x)
-  surj' : ∀ y : M', ∃ x : M × S, x.2 • y = f x.1
+  surj (S f) : ∀ y : M', ∃ x : M × S, x.2 • y = f x.1
   exists_of_eq : ∀ {x₁ x₂}, f x₁ = f x₂ → ∃ c : S, c • x₁ = c • x₂
 
-attribute [nolint docBlame] IsLocalizedModule.map_units IsLocalizedModule.surj'
+attribute [nolint docBlame] IsLocalizedModule.map_units IsLocalizedModule.surj
   IsLocalizedModule.exists_of_eq
 
-lemma IsLocalizedModule.surj [IsLocalizedModule S f] (y : M') : ∃ x : M × S, x.2 • y = f x.1 :=
-  surj' y
+@[deprecated (since := "2025-09-05")] alias IsLocalizedModule.surj' := IsLocalizedModule.surj
 
 lemma IsLocalizedModule.eq_iff_exists [IsLocalizedModule S f] {x₁ x₂} :
     f x₁ = f x₂ ↔ ∃ c : S, c • x₁ = c • x₂ :=
@@ -564,8 +563,8 @@ instance IsLocalizedModule.of_linearEquiv (e : M' ≃ₗ[R] M'') [hf : IsLocaliz
       by ext; simp, Module.End.isUnit_iff, LinearMap.coe_comp, LinearMap.coe_comp,
       LinearEquiv.coe_coe, LinearEquiv.coe_coe, EquivLike.comp_bijective, EquivLike.bijective_comp]
     exact (Module.End.isUnit_iff _).mp <| hf.map_units s
-  surj' x := by
-    obtain ⟨p, h⟩ := hf.surj' (e.symm x)
+  surj x := by
+    obtain ⟨p, h⟩ := hf.surj (e.symm x)
     exact ⟨p, by rw [LinearMap.coe_comp, LinearEquiv.coe_coe, Function.comp_apply, ← e.congr_arg h,
       Submonoid.smul_def, Submonoid.smul_def, LinearEquiv.map_smul, LinearEquiv.apply_symm_apply]⟩
   exists_of_eq h := by
@@ -576,8 +575,8 @@ instance IsLocalizedModule.of_linearEquiv (e : M' ≃ₗ[R] M'') [hf : IsLocaliz
 instance IsLocalizedModule.of_linearEquiv_right (e : M'' ≃ₗ[R] M) [hf : IsLocalizedModule S f] :
     IsLocalizedModule S (f ∘ₗ e : M'' →ₗ[R] M') where
   map_units s := hf.map_units s
-  surj' x := by
-    obtain ⟨⟨p, s⟩, h⟩ := hf.surj' x
+  surj x := by
+    obtain ⟨⟨p, s⟩, h⟩ := hf.surj x
     exact ⟨⟨e.symm p, s⟩, by simpa using h⟩
   exists_of_eq h := by
     simp_rw [LinearMap.coe_comp, LinearEquiv.coe_coe, Function.comp_apply] at h
@@ -590,7 +589,7 @@ lemma isLocalizedModule_id (R') [CommSemiring R'] [Algebra R R'] [IsLocalization
     [IsScalarTower R R' M] : IsLocalizedModule S (.id : M →ₗ[R] M) where
   map_units s := by
     rw [← (Algebra.lsmul R (A := R') R M).commutes]; exact (IsLocalization.map_units R' s).map _
-  surj' m := ⟨(m, 1), one_smul _ _⟩
+  surj m := ⟨(m, 1), one_smul _ _⟩
   exists_of_eq h := ⟨1, congr_arg _ h⟩
 
 namespace LocalizedModule
@@ -708,7 +707,7 @@ instance localizedModuleIsLocalizedModule :
         p.induction_on <| by
           intros
           rfl⟩
-  surj' p :=
+  surj p :=
     p.induction_on fun m t => by
       refine ⟨⟨m, t⟩, ?_⟩
       rw [Submonoid.smul_def, LocalizedModule.smul'_mk, LocalizedModule.mkLinearMap_apply,
@@ -725,7 +724,7 @@ lemma IsLocalizedModule.of_restrictScalars (S : Submonoid R)
     have := IsLocalizedModule.map_units (f.restrictScalars R) ⟨x, hx⟩
     simp only [← IsScalarTower.algebraMap_apply, Module.End.isUnit_iff] at this ⊢
     exact this
-  surj' y := by
+  surj y := by
     obtain ⟨⟨x, t⟩, e⟩ := IsLocalizedModule.surj S (f.restrictScalars R) y
     exact ⟨⟨x, ⟨_, t, t.2, rfl⟩⟩, by simpa [Submonoid.smul_def] using e⟩
   exists_of_eq {x₁ x₂} e := by
@@ -741,7 +740,7 @@ lemma IsLocalizedModule.of_exists_mul_mem {N : Type*} [AddCommMonoid N] [Module 
     have := IsLocalizedModule.map_units f ⟨_, mx⟩
     rw [map_mul, (Algebra.commute_algebraMap_left _ _).isUnit_mul_iff] at this
     exact this.2
-  surj' y := by
+  surj y := by
     obtain ⟨⟨x, t⟩, e⟩ := IsLocalizedModule.surj S f y
     exact ⟨⟨x, ⟨t, h t.2⟩⟩, e⟩
   exists_of_eq {x₁ x₂} e := by
@@ -847,15 +846,15 @@ theorem iso_symm_apply_aux (m : M') :
   apply_fun iso S f using LinearEquiv.injective (iso S f)
   rw [LinearEquiv.apply_symm_apply]
   simp [iso, fromLocalizedModule, Module.End.algebraMap_isUnit_inv_apply_eq_iff',
-    ← Submonoid.smul_def, (surj' _).choose_spec]
+    ← Submonoid.smul_def, (surj _ _ _).choose_spec]
 
 theorem iso_symm_apply' (m : M') (a : M) (b : S) (eq1 : b • m = f a) :
     (iso S f).symm m = LocalizedModule.mk a b :=
   (iso_symm_apply_aux S f m).trans <|
     LocalizedModule.mk_eq.mpr <| by
       rw [← IsLocalizedModule.eq_iff_exists S f, Submonoid.smul_def, Submonoid.smul_def, f.map_smul,
-        f.map_smul, ← (surj' _).choose_spec, ← Submonoid.smul_def, ← Submonoid.smul_def, ← mul_smul,
-        mul_comm, mul_smul, eq1]
+        f.map_smul, ← (surj _ _ _).choose_spec, ← Submonoid.smul_def, ← Submonoid.smul_def,
+        ← mul_smul, mul_comm, mul_smul, eq1]
 
 theorem iso_symm_comp : (iso S f).symm.toLinearMap.comp f = LocalizedModule.mkLinearMap S M := by
   ext m
@@ -1119,7 +1118,7 @@ lemma liftOfLE_mk' (m : M) (s : S₁) :
 
 instance : IsLocalizedModule S₂ (liftOfLE S₁ S₂ h f₁ f₂) where
   map_units := map_units f₂
-  surj' y := by
+  surj y := by
     obtain ⟨⟨y', s⟩, e⟩ := IsLocalizedModule.surj S₂ f₂ y
     exact ⟨⟨f₁ y', s⟩, by simpa⟩
   exists_of_eq := by

--- a/Mathlib/Algebra/Module/LocalizedModule/Submodule.lean
+++ b/Mathlib/Algebra/Module/LocalizedModule/Submodule.lean
@@ -169,7 +169,7 @@ instance : IsLocalizedModule p (M'.toLocalized₀ p f) where
       refine ⟨⟨IsLocalizedModule.mk' f m (s * x), ⟨_, hm, _, rfl⟩⟩, Subtype.ext ?_⟩
       rw [Module.algebraMap_end_apply, SetLike.val_smul_of_tower,
         ← IsLocalizedModule.mk'_smul, ← Submonoid.smul_def, IsLocalizedModule.mk'_cancel_right]
-  surj' := by
+  surj := by
     rintro ⟨y, x, hx, s, rfl⟩
     exact ⟨⟨⟨x, hx⟩, s⟩, by ext; simp⟩
   exists_of_eq e := by simpa [Subtype.ext_iff] using
@@ -230,7 +230,7 @@ instance IsLocalizedModule.toLocalizedQuotient' (M' : Submodule R M) :
     simp only [Module.algebraMap_end_apply, ← mk_smul, Submodule.Quotient.eq, ← smul_sub] at e
     replace e := Submodule.smul_mem _ (IsLocalization.mk' S 1 x) e
     rwa [smul_comm, ← smul_assoc, smul_mk'_one, mk'_self', one_smul, ← Submodule.Quotient.eq] at e
-  surj' y := by
+  surj y := by
     obtain ⟨y, rfl⟩ := mk_surjective _ y
     obtain ⟨⟨y, s⟩, rfl⟩ := IsLocalizedModule.mk'_surjective p f y
     exact ⟨⟨Submodule.Quotient.mk y, s⟩,

--- a/Mathlib/Algebra/Polynomial/Laurent.lean
+++ b/Mathlib/Algebra/Polynomial/Laurent.lean
@@ -497,11 +497,11 @@ theorem algebraMap_eq_toLaurent (f : R[X]) : algebraMap R[X] R[T;T⁻¹] f = toL
   rfl
 
 instance isLocalization : IsLocalization.Away (X : R[X]) R[T;T⁻¹] :=
-  { map_units' := fun ⟨t, ht⟩ => by
+  { map_units := fun ⟨t, ht⟩ => by
       obtain ⟨n, rfl⟩ := ht
       rw [algebraMap_eq_toLaurent, toLaurent_X_pow]
       exact isUnit_T ↑n
-    surj' f := by
+    surj f := by
       induction f using LaurentPolynomial.induction_on_mul_T with | _ f n
       have : X ^ n ∈ Submonoid.powers (X : R[X]) := ⟨n, rfl⟩
       refine ⟨(f, ⟨_, this⟩), ?_⟩

--- a/Mathlib/FieldTheory/RatFunc/Basic.lean
+++ b/Mathlib/FieldTheory/RatFunc/Basic.lean
@@ -660,13 +660,13 @@ variable (K)
 
 /-- `RatFunc K` is the field of fractions of the polynomials over `K`. -/
 instance : IsFractionRing K[X] (RatFunc K) where
-  map_units' y := by
+  map_units y := by
     rw [← ofFractionRing_algebraMap]
     exact (toFractionRingRingEquiv K).symm.toRingHom.isUnit_map (IsLocalization.map_units _ y)
   exists_of_eq {x y} := by
     rw [← ofFractionRing_algebraMap, ← ofFractionRing_algebraMap]
     exact fun h ↦ IsLocalization.exists_of_eq ((toFractionRingRingEquiv K).symm.injective h)
-  surj' := by
+  surj := by
     rintro ⟨z⟩
     convert IsLocalization.surj K[X]⁰ z
     simp only [← ofFractionRing_algebraMap, ← ofFractionRing_mul,

--- a/Mathlib/NumberTheory/Cyclotomic/Basic.lean
+++ b/Mathlib/NumberTheory/Cyclotomic/Basic.lean
@@ -806,12 +806,12 @@ instance isCyclotomicExtension [IsFractionRing A K] [NeZero ((n : ℕ) : A)] :
 
 instance [IsFractionRing A K] [IsDomain A] [NeZero (n : A)] :
     IsFractionRing (CyclotomicRing n A K) (CyclotomicField n K) where
-  map_units' := fun ⟨x, hx⟩ => by
+  map_units := fun ⟨x, hx⟩ => by
     rw [isUnit_iff_ne_zero]
     apply map_ne_zero_of_mem_nonZeroDivisors
     · apply adjoin_algebra_injective
     · exact hx
-  surj' x := by
+  surj x := by
     have : NeZero (n : K) := NeZero.nat_of_injective (IsFractionRing.injective A K)
     refine
       Algebra.adjoin_induction

--- a/Mathlib/NumberTheory/NumberField/FractionalIdeal.lean
+++ b/Mathlib/NumberTheory/NumberField/FractionalIdeal.lean
@@ -50,7 +50,7 @@ instance (I : (FractionalIdeal (𝓞 K)⁰ K)ˣ) :
     rw [← (Algebra.lmul _ _).commutes, Algebra.lmul_isUnit_iff, isUnit_iff_ne_zero, eq_intCast,
       Int.cast_ne_zero]
     exact nonZeroDivisors.coe_ne_zero x
-  surj' x := by
+  surj x := by
     obtain ⟨⟨a, _, d, hd, rfl⟩, h⟩ := IsLocalization.surj (Algebra.algebraMapSubmonoid (𝓞 K) ℤ⁰) x
     refine ⟨⟨⟨Ideal.absNorm I.1.num * (algebraMap _ K a), I.1.num_le ?_⟩, d * Ideal.absNorm I.1.num,
       ?_⟩, ?_⟩

--- a/Mathlib/NumberTheory/Padics/PadicIntegers.lean
+++ b/Mathlib/NumberTheory/Padics/PadicIntegers.lean
@@ -513,10 +513,10 @@ theorem algebraMap_apply (x : ℤ_[p]) : algebraMap ℤ_[p] ℚ_[p] x = x :=
   rfl
 
 instance isFractionRing : IsFractionRing ℤ_[p] ℚ_[p] where
-  map_units' := fun ⟨x, hx⟩ => by
+  map_units := fun ⟨x, hx⟩ => by
     rwa [algebraMap_apply, isUnit_iff_ne_zero, PadicInt.coe_ne_zero, ←
       mem_nonZeroDivisors_iff_ne_zero]
-  surj' x := by
+  surj x := by
     by_cases hx : ‖x‖ ≤ 1
     · use (⟨x, hx⟩, 1)
       rw [Submonoid.coe_one, map_one, mul_one, PadicInt.algebraMap_apply, Subtype.coe_mk]

--- a/Mathlib/RingTheory/Extension/Presentation/Submersive.lean
+++ b/Mathlib/RingTheory/Extension/Presentation/Submersive.lean
@@ -488,7 +488,7 @@ noncomputable def localizationAway : SubmersivePresentation R S Unit Unit where
   __ := PreSubmersivePresentation.localizationAway S r
   jacobian_isUnit := by
     rw [localizationAway_jacobian]
-    apply IsLocalization.map_units' (⟨r, 1, by simp⟩ : Submonoid.powers r)
+    apply IsLocalization.map_units _ (⟨r, 1, by simp⟩ : Submonoid.powers r)
 
 end Localization
 

--- a/Mathlib/RingTheory/LaurentSeries.lean
+++ b/Mathlib/RingTheory/LaurentSeries.lean
@@ -268,13 +268,13 @@ theorem coe_algebraMap [CommSemiring R] :
 @[simps (rhsMd := .all) +simpRhs]
 instance of_powerSeries_localization [CommRing R] :
     IsLocalization (Submonoid.powers (PowerSeries.X : R⟦X⟧)) R⸨X⸩ where
-  map_units' := by
+  map_units := by
     rintro ⟨_, n, rfl⟩
     refine ⟨⟨single (n : ℤ) 1, single (-n : ℤ) 1, ?_, ?_⟩, ?_⟩
     · simp
     · simp
     · dsimp; rw [ofPowerSeries_X_pow]
-  surj' z := by
+  surj z := by
     by_cases h : 0 ≤ z.order
     · refine ⟨⟨PowerSeries.X ^ Int.natAbs z.order * powerSeriesPart z, 1⟩, ?_⟩
       simp only [RingHom.map_one, mul_one, RingHom.map_mul, coe_algebraMap, ofPowerSeries_X_pow,

--- a/Mathlib/RingTheory/LocalRing/ResidueField/Ideal.lean
+++ b/Mathlib/RingTheory/LocalRing/ResidueField/Ideal.lean
@@ -82,9 +82,9 @@ lemma Ideal.injective_algebraMap_quotient_residueField :
   rw [Ideal.ker_algebraMap_residueField, map_quotient_self]
 
 instance : IsFractionRing (R ⧸ I) I.ResidueField where
-  map_units' y := isUnit_iff_ne_zero.mpr
+  map_units y := isUnit_iff_ne_zero.mpr
     (map_ne_zero_of_mem_nonZeroDivisors _ I.injective_algebraMap_quotient_residueField y.2)
-  surj' x := by
+  surj x := by
     obtain ⟨x, rfl⟩ := IsLocalRing.residue_surjective x
     obtain ⟨x, ⟨s, hs⟩, rfl⟩ := IsLocalization.mk'_surjective I.primeCompl x
     refine ⟨⟨Ideal.Quotient.mk _ x, ⟨Ideal.Quotient.mk _ s, ?_⟩⟩, ?_⟩

--- a/Mathlib/RingTheory/Localization/Algebra.lean
+++ b/Mathlib/RingTheory/Localization/Algebra.lean
@@ -40,7 +40,7 @@ instance Algebra.idealMap_isLocalizedModule (I : Ideal R) :
       (by simpa [Algebra.smul_def] using congr(($e).1))),
       fun a ↦ ⟨⟨_, Ideal.mul_mem_left _ (map_units S x).unit⁻¹.1 a.2⟩,
         Subtype.ext (by simp [Algebra.smul_def, ← mul_assoc])⟩⟩
-  surj' y :=
+  surj y :=
     have ⟨x, hx⟩ := (mem_map_algebraMap_iff M S).mp y.property
     ⟨x, Subtype.ext (by simp [Submonoid.smul_def, Algebra.smul_def, mul_comm, hx])⟩
   exists_of_eq h := ⟨_, Subtype.ext (exists_of_eq congr(($h).1)).choose_spec⟩

--- a/Mathlib/RingTheory/Localization/AtPrime/Basic.lean
+++ b/Mathlib/RingTheory/Localization/AtPrime/Basic.lean
@@ -180,11 +180,11 @@ variable (I : Ideal R) [hI : I.IsPrime]
 variable {I}
 
 /-- The unique maximal ideal of the localization at `I.primeCompl` lies over the ideal `I`. -/
-nonrec theorem AtPrime.comap_maximalIdeal :
+theorem AtPrime.comap_maximalIdeal :
     Ideal.comap (algebraMap R (Localization.AtPrime I))
         (IsLocalRing.maximalIdeal (Localization I.primeCompl)) =
       I :=
-  AtPrime.comap_maximalIdeal _ _
+  IsLocalization.AtPrime.comap_maximalIdeal _ _
 
 /-- The image of `I` in the localization at `I.primeCompl` is a maximal ideal, and in particular
 it is the unique maximal ideal given by the local ring structure `AtPrime.isLocalRing` -/

--- a/Mathlib/RingTheory/Localization/AtPrime/Basic.lean
+++ b/Mathlib/RingTheory/Localization/AtPrime/Basic.lean
@@ -62,8 +62,7 @@ theorem AtPrime.nontrivial [IsLocalization.AtPrime S P] : Nontrivial S :=
 @[deprecated (since := "2025-07-31")] alias AtPrime.Nontrivial := IsLocalization.AtPrime.nontrivial
 
 theorem AtPrime.isLocalRing [IsLocalization.AtPrime S P] : IsLocalRing S :=
-  -- Porting note: since I couldn't get local instance running, I just specify it manually
-  letI := AtPrime.nontrivial S P
+  letI := AtPrime.nontrivial S P -- Can't be a local instance because we can't figure out `P`.
   IsLocalRing.of_nonunits_add
     (by
       intro x y hx hy hu
@@ -181,22 +180,18 @@ variable (I : Ideal R) [hI : I.IsPrime]
 variable {I}
 
 /-- The unique maximal ideal of the localization at `I.primeCompl` lies over the ideal `I`. -/
-theorem AtPrime.comap_maximalIdeal :
+nonrec theorem AtPrime.comap_maximalIdeal :
     Ideal.comap (algebraMap R (Localization.AtPrime I))
         (IsLocalRing.maximalIdeal (Localization I.primeCompl)) =
       I :=
-  -- Porting note: need to provide full name
-  IsLocalization.AtPrime.comap_maximalIdeal _ _
+  AtPrime.comap_maximalIdeal _ _
 
 /-- The image of `I` in the localization at `I.primeCompl` is a maximal ideal, and in particular
 it is the unique maximal ideal given by the local ring structure `AtPrime.isLocalRing` -/
 theorem AtPrime.map_eq_maximalIdeal :
     Ideal.map (algebraMap R (Localization.AtPrime I)) I =
       IsLocalRing.maximalIdeal (Localization I.primeCompl) := by
-  convert congr_arg (Ideal.map (algebraMap R (Localization.AtPrime I)))
-  -- Porting note: `algebraMap R ...` cannot be solve by unification
-    (AtPrime.comap_maximalIdeal (hI := hI)).symm
-  -- Porting note: cannot find `hI`
+  convert congr_arg (Ideal.map _) AtPrime.comap_maximalIdeal.symm
   rw [map_comap I.primeCompl]
 
 lemma AtPrime.eq_maximalIdeal_iff_comap_eq {J : Ideal (Localization.AtPrime I)} :
@@ -254,7 +249,7 @@ theorem localRingHom_unique (J : Ideal P) [J.IsPrime] (f : R →+* P) (hIJ : I =
 theorem localRingHom_id : localRingHom I I (RingHom.id R) (Ideal.comap_id I).symm = RingHom.id _ :=
   localRingHom_unique _ _ _ _ fun _ => rfl
 
--- Porting note: simplifier won't pick up this lemma, so deleted @[simp]
+-- `simp` can't figure out `J` so this can't be a `@[simp]` lemma.
 theorem localRingHom_comp {S : Type*} [CommSemiring S] (J : Ideal S) [hJ : J.IsPrime] (K : Ideal P)
     [hK : K.IsPrime] (f : R →+* S) (hIJ : I = J.comap f) (g : S →+* P) (hJK : J = K.comap g) :
     localRingHom I K (g.comp f) (by rw [hIJ, hJK, Ideal.comap_comap f g]) =

--- a/Mathlib/RingTheory/Localization/Away/AdjoinRoot.lean
+++ b/Mathlib/RingTheory/Localization/Away/AdjoinRoot.lean
@@ -15,25 +15,19 @@ open Polynomial AdjoinRoot Localization
 
 variable {R : Type*} [CommRing R]
 
--- Porting note: removed `IsLocalization.algHom_subsingleton` due to
--- `cannot find synthesization order for instance`
 attribute [local instance] AdjoinRoot.algHom_subsingleton
 
 /-- The `R`-`AlgEquiv` between the localization of `R` away from `r` and
 `R` with an inverse of `r` adjoined. -/
 noncomputable def Localization.awayEquivAdjoin (r : R) : Away r ≃ₐ[R] AdjoinRoot (C r * X - 1) :=
   AlgEquiv.ofAlgHom
-    { awayLift _ r
-      -- Porting note: This argument used to be found automatically, i.e. `_`
-      (isUnit_of_mul_eq_one ((algebraMap R (AdjoinRoot (C r * X - 1))) r) (root (C r * X - 1))
-        (root_isInv r)) with
+    { awayLift _ r _ with
       commutes' :=
         IsLocalization.Away.lift_eq r (isUnit_of_mul_eq_one _ _ <| root_isInv r) }
     (liftHom _ (IsLocalization.Away.invSelf r) <| by
       simp only [map_sub, map_mul, aeval_C, aeval_X, IsLocalization.Away.mul_invSelf, aeval_one,
         sub_self])
     (Subsingleton.elim _ _)
-    -- Porting note: fix since `IsLocalization.algHom_subsingleton` is no local instance anymore
     (Subsingleton.elim (h := IsLocalization.algHom_subsingleton (Submonoid.powers r)) _ _)
 
 theorem IsLocalization.adjoin_inv (r : R) : IsLocalization.Away r (AdjoinRoot <| C r * X - 1) :=

--- a/Mathlib/RingTheory/Localization/Away/Basic.lean
+++ b/Mathlib/RingTheory/Localization/Away/Basic.lean
@@ -101,11 +101,11 @@ lemma mk (r : R) (map_unit : IsUnit (algebraMap R S r))
     (surj : ∀ s, ∃ (n : ℕ) (a : R), s * algebraMap R S r ^ n = algebraMap R S a)
     (exists_of_eq : ∀ a b, algebraMap R S a = algebraMap R S b → ∃ (n : ℕ), r ^ n * a = r ^ n * b) :
     IsLocalization.Away r S where
-  map_units' := by
+  map_units := by
     rintro ⟨-, n, rfl⟩
     simp only [map_pow]
     exact IsUnit.pow _ map_unit
-  surj' z := by
+  surj z := by
     obtain ⟨n, a, hn⟩ := surj z
     use ⟨a, ⟨r ^ n, n, rfl⟩⟩
     simpa using hn
@@ -303,10 +303,10 @@ noncomputable def atOne [IsLocalization.Away (1 : R) S] : R ≃ₐ[R] S :=
 theorem away_of_isUnit_of_bijective {R : Type*} (S : Type*) [CommSemiring R] [CommSemiring S]
     [Algebra R S] {r : R} (hr : IsUnit r) (H : Function.Bijective (algebraMap R S)) :
     IsLocalization.Away r S :=
-  { map_units' := by
+  { map_units := by
       rintro ⟨_, n, rfl⟩
       exact (algebraMap R S).isUnit_map (hr.pow _)
-    surj' := fun z => by
+    surj := fun z => by
       obtain ⟨z', rfl⟩ := H.2 z
       exact ⟨⟨z', 1⟩, by simp⟩
     exists_of_eq := fun {x y} => by
@@ -323,10 +323,10 @@ lemma away_of_isIdempotentElem_of_mul {R S} [CommSemiring R] [CommSemiring S] [A
     (H : ∀ x y, algebraMap R S x = algebraMap R S y ↔ e * x = e * y)
     (H' : Function.Surjective (algebraMap R S)) :
     IsLocalization.Away e S where
-  map_units' r := by
+  map_units r := by
     obtain ⟨r, n, rfl⟩ := r
     simp [show algebraMap R S e = 1 by rw [← (algebraMap R S).map_one, H, mul_one, he]]
-  surj' z := by
+  surj z := by
     obtain ⟨z, rfl⟩ := H' z
     exact ⟨⟨z, 1⟩, by simp⟩
   exists_of_eq {x y} h := ⟨⟨e, Submonoid.mem_powers e⟩, (H x y).mp h⟩

--- a/Mathlib/RingTheory/Localization/Basic.lean
+++ b/Mathlib/RingTheory/Localization/Basic.lean
@@ -338,15 +338,15 @@ lemma commutes (S₁ S₂ T : Type*) [CommSemiring S₁]
     [IsLocalization M₁ S₁] [IsLocalization M₂ S₂]
     [IsLocalization (Algebra.algebraMapSubmonoid S₂ M₁) T] :
     IsLocalization (Algebra.algebraMapSubmonoid S₁ M₂) T where
-  map_units' := by
+  map_units := by
     rintro ⟨m, ⟨a, ha, rfl⟩⟩
     rw [← IsScalarTower.algebraMap_apply, IsScalarTower.algebraMap_apply R S₂ T]
-    exact IsUnit.map _ (IsLocalization.map_units' ⟨a, ha⟩)
-  surj' a := by
+    exact IsUnit.map _ (IsLocalization.map_units _ ⟨a, ha⟩)
+  surj a := by
     obtain ⟨⟨y, -, m, hm, rfl⟩, hy⟩ := surj (M := Algebra.algebraMapSubmonoid S₂ M₁) a
     rw [← IsScalarTower.algebraMap_apply, IsScalarTower.algebraMap_apply R S₁ T] at hy
     obtain ⟨⟨z, n, hn⟩, hz⟩ := IsLocalization.surj (M := M₂) y
-    have hunit : IsUnit (algebraMap R S₁ m) := map_units' ⟨m, hm⟩
+    have hunit : IsUnit (algebraMap R S₁ m) := map_units _ ⟨m, hm⟩
     use ⟨algebraMap R S₁ z * hunit.unit⁻¹, ⟨algebraMap R S₁ n, n, hn, rfl⟩⟩
     rw [map_mul, ← IsScalarTower.algebraMap_apply, IsScalarTower.algebraMap_apply R S₂ T]
     conv_rhs => rw [← IsScalarTower.algebraMap_apply]

--- a/Mathlib/RingTheory/Localization/Defs.lean
+++ b/Mathlib/RingTheory/Localization/Defs.lean
@@ -93,12 +93,12 @@ variable [Algebra R S] {P : Type*} [CommSemiring P]
 
 /-- The typeclass `IsLocalization (M : Submonoid R) S` where `S` is an `R`-algebra
 expresses that `S` is isomorphic to the localization of `R` at `M`. -/
-@[mk_iff] class IsLocalization : Prop where
-  -- Porting note: add ' to fields, and made new versions of these with either `S` or `M` explicit.
+@[mk_iff]
+class IsLocalization (M : Submonoid R) (S : Type*) [CommSemiring S] [Algebra R S] : Prop where
   /-- Everything in the image of `algebraMap` is a unit -/
-  map_units' : ∀ y : M, IsUnit (algebraMap R S y)
+  map_units (S) : ∀ y : M, IsUnit (algebraMap R S y)
   /-- The `algebraMap` is surjective -/
-  surj' : ∀ z : S, ∃ x : R × M, z * algebraMap R S x.2 = algebraMap R S x.1
+  surj (M) : ∀ z : S, ∃ x : R × M, z * algebraMap R S x.2 = algebraMap R S x.1
   /-- The kernel of `algebraMap` is contained in the annihilator of `M`;
       it is then equal to the annihilator by `map_units'` -/
   exists_of_eq : ∀ {x y}, algebraMap R S x = algebraMap R S y → ∃ c : M, ↑c * x = ↑c * y
@@ -113,14 +113,10 @@ variable [IsLocalization M S]
 
 section
 
-@[inherit_doc IsLocalization.map_units']
-theorem map_units : ∀ y : M, IsUnit (algebraMap R S y) :=
-  IsLocalization.map_units'
+@[deprecated (since := "2025-09-04")] alias map_units' := IsLocalization.map_units
+@[deprecated (since := "2025-09-04")] alias surj' := IsLocalization.surj
 
 variable (M) {S}
-@[inherit_doc IsLocalization.surj']
-theorem surj : ∀ z : S, ∃ x : R × M, z * algebraMap R S x.2 = algebraMap R S x.1 :=
-  IsLocalization.surj'
 
 variable (S) in
 @[inherit_doc IsLocalization.exists_of_eq]
@@ -136,8 +132,8 @@ theorem injective_iff_isRegular : Injective (algebraMap R S) ↔ ∀ c : M, IsRe
 
 theorem of_le (N : Submonoid R) (h₁ : M ≤ N) (h₂ : ∀ r ∈ N, IsUnit (algebraMap R S r)) :
     IsLocalization N S where
-  map_units' r := h₂ r r.2
-  surj' s :=
+  map_units r := h₂ r r.2
+  surj s :=
     have ⟨⟨x, y, hy⟩, H⟩ := IsLocalization.surj M s
     ⟨⟨x, y, h₁ hy⟩, H⟩
   exists_of_eq {x y} := by
@@ -591,7 +587,6 @@ section
 variable (hy : M ≤ T.comap g)
 include hy
 
--- Porting note: added `simp` attribute, since it proves very similar lemmas marked `simp`
 @[simp]
 theorem map_eq (x) : map Q g hy ((algebraMap R S) x) = algebraMap P Q (g x) :=
   lift_eq (fun y => map_units _ ⟨g y, hy y.2⟩) x
@@ -691,8 +686,8 @@ end Map
 section at_units
 lemma at_units (S : Submonoid R)
     (hS : S ≤ IsUnit.submonoid R) : IsLocalization S R where
-  map_units' y := hS y.prop
-  surj' := fun s ↦ ⟨⟨s, 1⟩, by simp⟩
+  map_units y := hS y.prop
+  surj := fun s ↦ ⟨⟨s, 1⟩, by simp⟩
   exists_of_eq := fun {x y} (e : x = y) ↦ ⟨1, e ▸ rfl⟩
 
 end at_units
@@ -813,8 +808,8 @@ theorem mk_multiset_sum (l : Multiset R) (b : M) : mk l.sum b = (l.map fun a => 
   (mkAddMonoidHom b).map_multiset_sum l
 
 instance isLocalization : IsLocalization M (Localization M) where
-  map_units' := (Localization.monoidOf M).map_units
-  surj' := (Localization.monoidOf M).surj
+  map_units := (Localization.monoidOf M).map_units
+  surj := (Localization.monoidOf M).surj
   exists_of_eq := (Localization.monoidOf M).eq_iff_exists.mp
 
 instance [NoZeroDivisors R] : NoZeroDivisors (Localization M) := IsLocalization.noZeroDivisors M
@@ -834,8 +829,6 @@ theorem mk_one_eq_algebraMap (x) : mk x 1 = algebraMap R (Localization M) x :=
 theorem mk_eq_mk'_apply (x y) : mk x y = IsLocalization.mk' (Localization M) x y := by
   rw [mk_eq_monoidOf_mk'_apply, mk', toLocalizationMap_eq_monoidOf]
 
--- Porting note: removed `simp`. Left-hand side can be simplified; not clear what normal form should
---be.
 theorem mk_eq_mk' : (mk : R → M → Localization M) = IsLocalization.mk' (Localization M) :=
   mk_eq_monoidOf_mk'
 

--- a/Mathlib/RingTheory/Localization/FractionRing.lean
+++ b/Mathlib/RingTheory/Localization/FractionRing.lean
@@ -78,8 +78,8 @@ instance : IsLocalization (Submonoid.pos ℤ) ℚ where
 
 /-- `NNRat` is the ring of fractions of `Nat`. -/
 instance NNRat.isFractionRing : IsFractionRing ℕ ℚ≥0 where
-  map_units' y := by simp
-  surj' z := ⟨⟨z.num, ⟨z.den, by simp⟩⟩, by simp⟩
+  map_units y := by simp
+  surj z := ⟨⟨z.num, ⟨z.den, by simp⟩⟩, by simp⟩
   exists_of_eq {x y} h := ⟨1, by simpa using h⟩
 
 namespace IsFractionRing

--- a/Mathlib/RingTheory/Localization/FractionRing.lean
+++ b/Mathlib/RingTheory/Localization/FractionRing.lean
@@ -52,11 +52,11 @@ instance {R : Type*} [Field R] : IsFractionRing R R :=
 
 /-- The cast from `Int` to `Rat` as a `FractionRing`. -/
 instance Rat.isFractionRing : IsFractionRing ℤ ℚ where
-  map_units' := by
+  map_units := by
     rintro ⟨x, hx⟩
     rw [mem_nonZeroDivisors_iff_ne_zero] at hx
     simpa only [eq_intCast, isUnit_iff_ne_zero, Int.cast_eq_zero, Ne, Subtype.coe_mk] using hx
-  surj' := by
+  surj := by
     rintro ⟨n, d, hd, h⟩
     refine ⟨⟨n, ⟨d, ?_⟩⟩, Rat.mul_den_eq_num _⟩
     rw [mem_nonZeroDivisors_iff_ne_zero, Int.natCast_ne_zero_iff_pos]
@@ -68,8 +68,8 @@ instance Rat.isFractionRing : IsFractionRing ℤ ℚ where
 
 /-- As a corollary, `Rat` is also a localization at only positive integers. -/
 instance : IsLocalization (Submonoid.pos ℤ) ℚ where
-  map_units' y := by simpa using y.prop.ne'
-  surj' z := by
+  map_units y := by simpa using y.prop.ne'
+  surj z := by
     obtain ⟨⟨x1, x2⟩, hx⟩ := IsLocalization.surj (nonZeroDivisors ℤ) z
     obtain hx2 | hx2 := lt_or_gt_of_ne (show x2.val ≠ 0 by simp)
     · exact ⟨⟨-x1, ⟨-x2.val, by simpa using hx2⟩⟩, by simpa using hx⟩
@@ -92,9 +92,9 @@ theorem of_field [Field K] [Algebra R K] [FaithfulSMul R K]
   have inj := FaithfulSMul.algebraMap_injective R K
   have := inj.noZeroDivisors _ (map_zero _) (map_mul _)
   have := Module.nontrivial R K
-{ map_units' x :=
+{ map_units x :=
     .mk0 _ <| (map_ne_zero_iff _ inj).mpr <| mem_nonZeroDivisors_iff_ne_zero.mp x.2
-  surj' z := by
+  surj z := by
     have ⟨x, y, eq⟩ := surj z
     obtain rfl | hy := eq_or_ne y 0
     · obtain rfl : z = 0 := by simpa using eq
@@ -122,9 +122,9 @@ instance (priority := 100) : FaithfulSMul R K :=
 
 variable {R K}
 
+open algebraMap in
 @[norm_cast, simp]
--- Porting note: using `↑` didn't work, so I needed to explicitly put in the cast myself
-theorem coe_inj {a b : R} : (Algebra.cast a : K) = Algebra.cast b ↔ a = b :=
+theorem coe_inj {a b : R} : (↑a : K) = ↑b ↔ a = b :=
   (IsFractionRing.injective R K).eq_iff
 
 protected theorem to_map_ne_zero_of_mem_nonZeroDivisors [Nontrivial R] {x : R}
@@ -516,8 +516,6 @@ instance [Nontrivial R] : Nontrivial (FractionRing R) := inferInstance
 
 variable [IsDomain A]
 
-/-- Porting note: if the fields of this instance are explicitly defined as they were
-in mathlib3, the last instance in this file suffers a TC timeout -/
 noncomputable instance field : Field (FractionRing A) := inferInstance
 
 @[simp]
@@ -539,7 +537,6 @@ noncomputable abbrev liftAlgebra : Algebra (FractionRing R) K :=
 
 attribute [local instance] liftAlgebra
 
--- Porting note: had to fill in the `_` by hand for this instance
 instance isScalarTower_liftAlgebra : IsScalarTower R (FractionRing R) K :=
   have := (FaithfulSMul.algebraMap_injective R K).isDomain
   .of_algebraMap_eq fun x ↦

--- a/Mathlib/RingTheory/Localization/Ideal.lean
+++ b/Mathlib/RingTheory/Localization/Ideal.lean
@@ -311,10 +311,10 @@ lemma of_surjective {R' S' : Type*} [CommRing R'] [CommRing S'] [Algebra R' S']
     (f : R →+* R') (hf : Function.Surjective f) (g : S →+* S') (hg : Function.Surjective g)
     (H : g.comp (algebraMap R S) = (algebraMap _ _).comp f)
     (H' : RingHom.ker g ≤ (RingHom.ker f).map (algebraMap R S)) : IsLocalization (M.map f) S' where
-  map_units' := by
+  map_units := by
     rintro ⟨_, y, hy, rfl⟩
     simpa only [← RingHom.comp_apply, H] using (IsLocalization.map_units S ⟨y, hy⟩).map g
-  surj' := by
+  surj := by
     intro z
     obtain ⟨z, rfl⟩ := hg z
     obtain ⟨⟨r, s⟩, e⟩ := IsLocalization.surj M z

--- a/Mathlib/RingTheory/Localization/Integral.lean
+++ b/Mathlib/RingTheory/Localization/Integral.lean
@@ -82,7 +82,6 @@ theorem integerNormalization_spec (p : S[X]) :
         (Classical.choose_spec (exist_integer_multiples_of_finset M (p.support.image p.coeff))
           (p.coeff i) (Finset.mem_image.mpr ⟨i, hi, rfl⟩))
   · rw [RingHom.map_zero, notMem_support_iff.mp hi, smul_zero]
-    -- Porting note: was `convert (smul_zero _).symm, ...`
 
 theorem integerNormalization_map_to_map (p : S[X]) :
     ∃ b : M, (integerNormalization M p).map (algebraMap R S) = (b : R) • p :=
@@ -120,8 +119,7 @@ theorem integerNormalization_eq_zero_iff {p : K[X]} :
   refine Polynomial.ext_iff.trans (Polynomial.ext_iff.trans ?_).symm
   obtain ⟨⟨b, nonzero⟩, hb⟩ := integerNormalization_spec (nonZeroDivisors A) p
   constructor <;> intro h i
-  · -- Porting note: avoided some defeq abuse
-    rw [coeff_zero, ← to_map_eq_zero_iff (K := K), hb i, h i, coeff_zero, smul_zero]
+  · rw [coeff_zero, ← to_map_eq_zero_iff (K := K), hb i, h i, coeff_zero, smul_zero]
   · have hi := h i
     rw [Polynomial.coeff_zero, ← @to_map_eq_zero_iff A _ K, hb i, Algebra.smul_def] at hi
     apply Or.resolve_left (eq_zero_or_eq_zero_of_mul_eq_zero hi)
@@ -195,7 +193,6 @@ theorem is_integral_localization_at_leadingCoeff {x : S} (p : R[X]) (hp : aeval 
             (show _ ≤ (Algebra.algebraMapSubmonoid S M).comap _ from M.le_comap_map) :
           Rₘ →+* _).IsIntegralElem
       (algebraMap S Sₘ x) :=
-  -- Porting note: added `haveI`
   haveI : IsLocalization (Submonoid.map (algebraMap R S) M) Sₘ :=
     inferInstanceAs (IsLocalization (Algebra.algebraMapSubmonoid S M) Sₘ)
   (algebraMap R S).isIntegralElem_localization_at_leadingCoeff x p hp M hM
@@ -220,14 +217,11 @@ theorem isIntegral_localization [Algebra.IsIntegral R S] :
   · obtain ⟨p, hp⟩ := Algebra.IsIntegral.isIntegral (R := R) s
     exact hx.symm ▸ is_integral_localization_at_leadingCoeff p hp.2 (hp.1.symm ▸ M.one_mem)
 
-@[nolint unusedHavesSuffices] -- It claims the `have : IsLocalization` line is unnecessary,
-                              -- but remove it and the proof won't work.
 theorem isIntegral_localization' {R S : Type*} [CommRing R] [CommRing S] {f : R →+* S}
     (hf : f.IsIntegral) (M : Submonoid R) :
     (map (Localization (M.map (f : R →* S))) f
           (M.le_comap_map : _ ≤ Submonoid.comap (f : R →* S) _) :
         Localization M →+* _).IsIntegral :=
-  -- Porting note: added
   let _ := f.toAlgebra
   have : Algebra.IsIntegral R S := ⟨hf⟩
   have : IsLocalization (Algebra.algebraMapSubmonoid S M)
@@ -293,12 +287,12 @@ open Algebra
 the integral closure `C` of `A` in `L` has fraction field `L`. -/
 theorem isFractionRing_of_algebraic [Algebra.IsAlgebraic A L]
     (inj : ∀ x, algebraMap A L x = 0 → x = 0) : IsFractionRing C L :=
-  { map_units' := fun ⟨y, hy⟩ =>
+  { map_units := fun ⟨y, hy⟩ =>
       IsUnit.mk0 _
         (show algebraMap C L y ≠ 0 from fun h =>
           mem_nonZeroDivisors_iff_ne_zero.mp hy
             ((injective_iff_map_eq_zero (algebraMap C L)).mp (algebraMap_injective C A L) _ h))
-    surj' := fun z =>
+    surj := fun z =>
       let ⟨x, hx, int⟩ := (Algebra.IsAlgebraic.isAlgebraic z).exists_integral_multiple
       ⟨⟨mk' C _ int, algebraMap _ _ x, mem_nonZeroDivisors_of_ne_zero fun h ↦
         hx (inj _ <| by rw [IsScalarTower.algebraMap_apply A C L, h, RingHom.map_zero])⟩, by

--- a/Mathlib/RingTheory/Localization/InvSubmonoid.lean
+++ b/Mathlib/RingTheory/Localization/InvSubmonoid.lean
@@ -73,7 +73,8 @@ theorem smul_toInvSubmonoid (m : M) : m • (toInvSubmonoid M S m : S) = 1 := by
 
 variable {S}
 
--- Porting note: `surj'` was taken, so use `surj''` instead
+-- `surj'` was taken, so use `surj''` instead
+-- TODO: this can be fixed after the deprecations of 2025-09-04 are removed.
 theorem surj'' (z : S) : ∃ (r : R) (m : M), z = r • (toInvSubmonoid M S m : S) := by
   rcases IsLocalization.surj M z with ⟨⟨r, m⟩, e : z * _ = algebraMap R S r⟩
   refine ⟨r, m, ?_⟩

--- a/Mathlib/RingTheory/Localization/LocalizationLocalization.lean
+++ b/Mathlib/RingTheory/Localization/LocalizationLocalization.lean
@@ -105,10 +105,10 @@ theorem localization_localization_exists_of_eq [IsLocalization N T] (x y : R) :
 `N ⁻¹ S = T = (f⁻¹ (N • f(M))) ⁻¹ R`. I.e., the localization of a localization is a localization.
 -/
 theorem localization_localization_isLocalization [IsLocalization N T] :
-    IsLocalization (localizationLocalizationSubmodule M N) T :=
-  { map_units' := localization_localization_map_units M N T
-    surj' := localization_localization_surj M N T
-    exists_of_eq := localization_localization_exists_of_eq M N T _ _ }
+    IsLocalization (localizationLocalizationSubmodule M N) T where
+  map_units := localization_localization_map_units M N T
+  surj := localization_localization_surj M N T
+  exists_of_eq := localization_localization_exists_of_eq M N T _ _
 
 include M in
 /-- Given submodules `M ⊆ R` and `N ⊆ S = M⁻¹R`, with `f : R →+* S` the localization map, if
@@ -190,53 +190,53 @@ instance {R : Type*} [CommRing R] [IsDomain R] (p : Ideal R) [p.IsPrime] :
 /-- If `M ≤ N` are submonoids of `R`, then `N⁻¹S` is also the localization of `M⁻¹S` at `N`. -/
 theorem isLocalization_of_submonoid_le (M N : Submonoid R) (h : M ≤ N) [IsLocalization M S]
     [IsLocalization N T] [Algebra S T] [IsScalarTower R S T] :
-    IsLocalization (N.map (algebraMap R S)) T :=
-  { map_units' := by
-      rintro ⟨_, ⟨y, hy, rfl⟩⟩
-      convert IsLocalization.map_units T ⟨y, hy⟩
-      exact (IsScalarTower.algebraMap_apply _ _ _ _).symm
-    surj' := fun y => by
-      obtain ⟨⟨x, s⟩, e⟩ := IsLocalization.surj N y
-      refine ⟨⟨algebraMap R S x, _, _, s.prop, rfl⟩, ?_⟩
-      simpa [← IsScalarTower.algebraMap_apply] using e
-    exists_of_eq := fun {x₁ x₂} => by
-      obtain ⟨⟨y₁, s₁⟩, e₁⟩ := IsLocalization.surj M x₁
-      obtain ⟨⟨y₂, s₂⟩, e₂⟩ := IsLocalization.surj M x₂
-      refine (Set.exists_image_iff (algebraMap R S) N fun c => c * x₁ = c * x₂).mpr.comp ?_
-      dsimp only at e₁ e₂ ⊢
-      suffices algebraMap R T (y₁ * s₂) = algebraMap R T (y₂ * s₁) →
-          ∃ a : N, algebraMap R S (a * (y₁ * s₂)) = algebraMap R S (a * (y₂ * s₁)) by
-        have h₁ := @IsUnit.mul_left_inj T _ _ (algebraMap S T x₁) (algebraMap S T x₂)
-          (IsLocalization.map_units T ⟨(s₁ : R), h s₁.prop⟩)
-        have h₂ := @IsUnit.mul_left_inj T _ _ ((algebraMap S T x₁) * (algebraMap R T s₁))
-          ((algebraMap S T x₂) * (algebraMap R T s₁))
-          (IsLocalization.map_units T ⟨(s₂ : R), h s₂.prop⟩)
-        simp only [IsScalarTower.algebraMap_apply R S T] at h₁ h₂
-        simp only [IsScalarTower.algebraMap_apply R S T, map_mul, ← e₁, ← e₂, ← mul_assoc,
-          mul_right_comm _ (algebraMap R S s₂),
-          (IsLocalization.map_units S s₁).mul_left_inj,
-          (IsLocalization.map_units S s₂).mul_left_inj] at this
-        rw [h₂, h₁] at this
-        simpa only [mul_comm] using this
-      simp_rw [IsLocalization.eq_iff_exists N T, IsLocalization.eq_iff_exists M S]
-      intro ⟨a, e⟩
-      exact ⟨a, 1, by convert e using 1 <;> simp⟩ }
+    IsLocalization (N.map (algebraMap R S)) T where
+  map_units := by
+    rintro ⟨_, ⟨y, hy, rfl⟩⟩
+    convert IsLocalization.map_units T ⟨y, hy⟩
+    exact (IsScalarTower.algebraMap_apply _ _ _ _).symm
+  surj y := by
+    obtain ⟨⟨x, s⟩, e⟩ := IsLocalization.surj N y
+    refine ⟨⟨algebraMap R S x, _, _, s.prop, rfl⟩, ?_⟩
+    simpa [← IsScalarTower.algebraMap_apply] using e
+  exists_of_eq {x₁ x₂} := by
+    obtain ⟨⟨y₁, s₁⟩, e₁⟩ := IsLocalization.surj M x₁
+    obtain ⟨⟨y₂, s₂⟩, e₂⟩ := IsLocalization.surj M x₂
+    refine (Set.exists_image_iff (algebraMap R S) N fun c => c * x₁ = c * x₂).mpr.comp ?_
+    dsimp only at e₁ e₂ ⊢
+    suffices algebraMap R T (y₁ * s₂) = algebraMap R T (y₂ * s₁) →
+        ∃ a : N, algebraMap R S (a * (y₁ * s₂)) = algebraMap R S (a * (y₂ * s₁)) by
+      have h₁ := @IsUnit.mul_left_inj T _ _ (algebraMap S T x₁) (algebraMap S T x₂)
+        (IsLocalization.map_units T ⟨(s₁ : R), h s₁.prop⟩)
+      have h₂ := @IsUnit.mul_left_inj T _ _ ((algebraMap S T x₁) * (algebraMap R T s₁))
+        ((algebraMap S T x₂) * (algebraMap R T s₁))
+        (IsLocalization.map_units T ⟨(s₂ : R), h s₂.prop⟩)
+      simp only [IsScalarTower.algebraMap_apply R S T] at h₁ h₂
+      simp only [IsScalarTower.algebraMap_apply R S T, map_mul, ← e₁, ← e₂, ← mul_assoc,
+        mul_right_comm _ (algebraMap R S s₂),
+        (IsLocalization.map_units S s₁).mul_left_inj,
+        (IsLocalization.map_units S s₂).mul_left_inj] at this
+      rw [h₂, h₁] at this
+      simpa only [mul_comm] using this
+    simp_rw [IsLocalization.eq_iff_exists N T, IsLocalization.eq_iff_exists M S]
+    intro ⟨a, e⟩
+    exact ⟨a, 1, by convert e using 1 <;> simp⟩
 
 /-- If `M ≤ N` are submonoids of `R` such that `∀ x : N, ∃ m : R, m * x ∈ M`, then the
 localization at `N` is equal to the localization of `M`. -/
 theorem isLocalization_of_is_exists_mul_mem (M N : Submonoid R) [IsLocalization M S] (h : M ≤ N)
-    (h' : ∀ x : N, ∃ m : R, m * x ∈ M) : IsLocalization N S :=
-  { map_units' := fun y => by
-      obtain ⟨m, hm⟩ := h' y
-      have := IsLocalization.map_units S ⟨_, hm⟩
-      rw [map_mul] at this
-      exact (IsUnit.mul_iff.mp this).2
-    surj' := fun z => by
-      obtain ⟨⟨y, s⟩, e⟩ := IsLocalization.surj M z
-      exact ⟨⟨y, _, h s.prop⟩, e⟩
-    exists_of_eq := fun {_ _} => by
-      rw [IsLocalization.eq_iff_exists M]
-      exact fun ⟨x, hx⟩ => ⟨⟨_, h x.prop⟩, hx⟩ }
+    (h' : ∀ x : N, ∃ m : R, m * x ∈ M) : IsLocalization N S where
+  map_units y := by
+    obtain ⟨m, hm⟩ := h' y
+    have := IsLocalization.map_units S ⟨_, hm⟩
+    rw [map_mul] at this
+    exact (IsUnit.mul_iff.mp this).2
+  surj z := by
+    obtain ⟨⟨y, s⟩, e⟩ := IsLocalization.surj M z
+    exact ⟨⟨y, _, h s.prop⟩, e⟩
+  exists_of_eq {_ _} := by
+    rw [IsLocalization.eq_iff_exists M]
+    exact fun ⟨x, hx⟩ => ⟨⟨_, h x.prop⟩, hx⟩
 
 theorem mk'_eq_algebraMap_mk'_of_submonoid_le {M N : Submonoid R} (h : M ≤ N) [IsLocalization M S]
     [IsLocalization N T] [Algebra S T] [IsScalarTower R S T] (x : R) (y : {a : R // a ∈ M}) :

--- a/Mathlib/RingTheory/Localization/NumDen.lean
+++ b/Mathlib/RingTheory/Localization/NumDen.lean
@@ -52,7 +52,7 @@ noncomputable def den (x : K) : nonZeroDivisors A :=
 theorem num_den_reduced (x : K) : IsRelPrime (num A x) (den A x) :=
   (Classical.choose_spec (Classical.choose_spec (exists_reduced_fraction A x))).1
 
--- @[simp] -- Porting note: LHS reduces to give the simp lemma below
+-- `@[simp]` normal form is called `mk'_num_den'`.
 theorem mk'_num_den (x : K) : mk' K (num A x) (den A x) = x :=
   (Classical.choose_spec (Classical.choose_spec (exists_reduced_fraction A x))).2
 

--- a/Mathlib/RingTheory/Localization/Pi.lean
+++ b/Mathlib/RingTheory/Localization/Pi.lean
@@ -38,8 +38,8 @@ variable {ι : Type*} (R S : ι → Type*)
 then `Π i, S i` is a localization of `Π i, R i` at the product submonoid. -/
 instance (M : Π i, Submonoid (R i)) [∀ i, IsLocalization (M i) (S i)] :
     IsLocalization (.pi .univ M) (Π i, S i) where
-  map_units' m := Pi.isUnit_iff.mpr fun i ↦ map_units _ ⟨m.1 i, m.2 i ⟨⟩⟩
-  surj' z := by
+  map_units m := Pi.isUnit_iff.mpr fun i ↦ map_units _ ⟨m.1 i, m.2 i ⟨⟩⟩
+  surj z := by
     choose rm h using fun i ↦ surj (M := M i) (z i)
     exact ⟨(fun i ↦ (rm i).1, ⟨_, fun i _ ↦ (rm i).2.2⟩), funext h⟩
   exists_of_eq {x y} eq := by

--- a/Mathlib/RingTheory/MatrixAlgebra.lean
+++ b/Mathlib/RingTheory/MatrixAlgebra.lean
@@ -201,8 +201,8 @@ theorem matrixEquivTensor_apply (M : Matrix n n A) :
     matrixEquivTensor n R A M = ∑ p : n × n, M p.1 p.2 ⊗ₜ single p.1 p.2 1 :=
   rfl
 
--- Porting note: short circuiting simplifier from simplifying left-hand side
-@[simp (high)]
+-- High priority, to go before `matrixEquivTensor_apply`
+@[simp high]
 theorem matrixEquivTensor_apply_single (i j : n) (x : A) :
     matrixEquivTensor n R A (single i j x) = x ⊗ₜ single i j 1 := by
   have t : ∀ p : n × n, i = p.1 ∧ j = p.2 ↔ p = (i, j) := by aesop

--- a/Mathlib/RingTheory/Multiplicity.lean
+++ b/Mathlib/RingTheory/Multiplicity.lean
@@ -597,8 +597,6 @@ section CancelCommMonoidWithZero
 
 variable [CancelCommMonoidWithZero α]
 
-/- Porting note:
-Pulled a b intro parameters since Lean parses that more easily -/
 theorem finiteMultiplicity_mul_aux {p : α} (hp : Prime p) {a b : α} :
     ∀ {n m : ℕ}, ¬p ^ (n + 1) ∣ a → ¬p ^ (m + 1) ∣ b → ¬p ^ (n + m + 1) ∣ a * b
   | n, m => fun ha hb ⟨s, hs⟩ =>

--- a/Mathlib/RingTheory/MvPolynomial/Tower.lean
+++ b/Mathlib/RingTheory/MvPolynomial/Tower.lean
@@ -45,9 +45,7 @@ variable {R A}
 theorem aeval_algebraMap_apply (x : σ → A) (p : MvPolynomial σ R) :
     aeval (algebraMap A B ∘ x) p = algebraMap A B (MvPolynomial.aeval x p) := by
   rw [aeval_def, aeval_def, ← coe_eval₂Hom, ← coe_eval₂Hom, map_eval₂Hom, ←
-    IsScalarTower.algebraMap_eq]
-  -- Porting note: added
-  simp only [Function.comp_def]
+    IsScalarTower.algebraMap_eq, Function.comp_def]
 
 theorem aeval_algebraMap_eq_zero_iff [NoZeroSMulDivisors A B] [Nontrivial B] (x : σ → A)
     (p : MvPolynomial σ R) : aeval (algebraMap A B ∘ x) p = 0 ↔ aeval x p = 0 := by

--- a/Mathlib/RingTheory/MvPowerSeries/Basic.lean
+++ b/Mathlib/RingTheory/MvPowerSeries/Basic.lean
@@ -781,7 +781,6 @@ open Finsupp
 
 variable {σ : Type*} {R : Type*} [CommSemiring R] (φ ψ : MvPolynomial σ R)
 
--- Porting note: added so we can add the `@[coe]` attribute
 /-- The natural inclusion from multivariate polynomials into multivariate formal power series. -/
 @[coe]
 def toMvPowerSeries : MvPolynomial σ R → MvPowerSeries σ R :=

--- a/Mathlib/RingTheory/Noetherian/Defs.lean
+++ b/Mathlib/RingTheory/Noetherian/Defs.lean
@@ -54,7 +54,7 @@ open Set Pointwise
 /-- `IsNoetherian R M` is the proposition that `M` is a Noetherian `R`-module,
 implemented as the predicate that all `R`-submodules of `M` are finitely generated.
 -/
--- Porting note: should this be renamed to `Noetherian`?
+-- TODO: should this be renamed to `Noetherian`?
 class IsNoetherian (R M) [Semiring R] [AddCommMonoid M] [Module R M] : Prop where
   noetherian : ∀ s : Submodule R M, s.FG
 
@@ -111,9 +111,7 @@ variable {R M P : Type*} {N : Type w} [Semiring R] [AddCommMonoid M] [Module R M
   [Module R N] [AddCommMonoid P] [Module R P]
 
 theorem isNoetherian_iff' : IsNoetherian R M ↔ WellFoundedGT (Submodule R M) := by
-  have := (CompleteLattice.wellFoundedGT_characterisations <| Submodule R M).out 0 3
-  -- Porting note: inlining this makes rw complain about it being a metavariable
-  rw [this]
+  refine .trans ?_ ((CompleteLattice.wellFoundedGT_characterisations <| Submodule R M).out 0 3).symm
   exact
     ⟨fun ⟨h⟩ => fun k => (fg_iff_compact k).mp (h k), fun h =>
       ⟨fun k => (fg_iff_compact k).mpr (h k)⟩⟩

--- a/Mathlib/RingTheory/NonUnitalSubsemiring/Basic.lean
+++ b/Mathlib/RingTheory/NonUnitalSubsemiring/Basic.lean
@@ -601,8 +601,7 @@ theorem mem_iSup_of_directed {ι} [hι : Nonempty ι] {S : ι → NonUnitalSubse
     NonUnitalSubsemiring.mk' (⋃ i, (S i : Set R))
       (⨆ i, (S i).toSubsemigroup) (Subsemigroup.coe_iSup_of_directed hS)
       (⨆ i, (S i).toAddSubmonoid) (AddSubmonoid.coe_iSup_of_directed hS)
-  -- Porting note `@this` doesn't work
-  suffices H : ⨆ i, S i ≤ U by simpa [U] using @H x
+  suffices ⨆ i, S i ≤ U by simpa [U] using @this x
   exact iSup_le fun i x hx => Set.mem_iUnion.2 ⟨i, hx⟩
 
 theorem coe_iSup_of_directed {ι} [hι : Nonempty ι] {S : ι → NonUnitalSubsemiring R}

--- a/Mathlib/RingTheory/Nullstellensatz.lean
+++ b/Mathlib/RingTheory/Nullstellensatz.lean
@@ -126,8 +126,8 @@ theorem vanishingIdeal_pointToPoint (V : Set (σ → K)) :
     PrimeSpectrum.vanishingIdeal (pointToPoint '' V) = MvPolynomial.vanishingIdeal k V :=
   le_antisymm
     (fun _ hp x hx =>
-      (((PrimeSpectrum.mem_vanishingIdeal _ _).1 hp) ⟨vanishingIdeal k {x}, by infer_instance⟩ <| by
-          exact ⟨x, ⟨hx, rfl⟩⟩) -- Porting note: tactic mode code compiles but term mode does not
+      (((PrimeSpectrum.mem_vanishingIdeal _ _).1 hp) ⟨vanishingIdeal k {x}, by infer_instance⟩
+        (⟨x, hx, rfl⟩ : _))
         x rfl)
     fun _ hp =>
     (PrimeSpectrum.mem_vanishingIdeal _ _).2 fun _ hI =>
@@ -175,8 +175,7 @@ theorem vanishingIdeal_zeroLocus_eq_radical (I : Ideal (MvPolynomial σ k)) :
   rw [← mem_vanishingIdeal_singleton_iff, Set.mem_singleton_iff.1 hy, ← hx]
   exact hJI hp
 
--- Porting note: marked this as high priority to short cut simplifier
-@[simp (high)]
+@[simp high] -- This needs to fire before `vanishingIdeal_zeroLocus_eq_radical`
 theorem IsPrime.vanishingIdeal_zeroLocus (P : Ideal (MvPolynomial σ k)) [h : P.IsPrime] :
     vanishingIdeal k (zeroLocus K P) = P :=
   Trans.trans (vanishingIdeal_zeroLocus_eq_radical P) h.radical

--- a/Mathlib/RingTheory/Polynomial/Bernstein.lean
+++ b/Mathlib/RingTheory/Polynomial/Bernstein.lean
@@ -117,10 +117,8 @@ theorem derivative_succ_aux (n ν : ℕ) :
     norm_cast
     congr 1
     convert (Nat.choose_mul_succ_eq n (ν + 1)).symm using 1
-    · -- Porting note: was
-      -- convert mul_comm _ _ using 2
-      -- simp
-      rw [mul_comm, Nat.succ_sub_succ_eq_sub]
+    · convert mul_comm _ _ using 2
+      simp
     · apply mul_comm
 
 theorem derivative_succ (n ν : ℕ) : Polynomial.derivative (bernsteinPolynomial R n (ν + 1)) =

--- a/Mathlib/RingTheory/Polynomial/Content.lean
+++ b/Mathlib/RingTheory/Polynomial/Content.lean
@@ -154,7 +154,7 @@ theorem content_eq_zero_iff {p : R[X]} : content p = 0 ↔ p = 0 := by
   · intro x
     simp [h]
 
--- Porting note: this reduced with simp so created `normUnit_content` and put simp on it
+-- `simp`-normal form is `normUnit_content`
 theorem normalize_content {p : R[X]} : normalize p.content = p.content :=
   Finset.normalize_gcd
 

--- a/Mathlib/RingTheory/Polynomial/Cyclotomic/Roots.lean
+++ b/Mathlib/RingTheory/Polynomial/Cyclotomic/Roots.lean
@@ -109,12 +109,8 @@ theorem roots_cyclotomic_nodup [NeZero (n : R)] : (cyclotomic n R).roots.Nodup :
 theorem cyclotomic.roots_to_finset_eq_primitiveRoots [NeZero (n : R)] :
     (⟨(cyclotomic n R).roots, roots_cyclotomic_nodup⟩ : Finset _) = primitiveRoots n R := by
   ext a
-  -- Porting note: was
-  -- `simp [cyclotomic_ne_zero n R, isRoot_cyclotomic_iff, mem_primitiveRoots,`
-  -- `  NeZero.pos_of_neZero_natCast R]`
-  simp only [mem_primitiveRoots, NeZero.pos_of_neZero_natCast R]
-  convert isRoot_cyclotomic_iff (n := n) (μ := a) using 0
-  simp [cyclotomic_ne_zero n R]
+  simp [cyclotomic_ne_zero n R, ← isRoot_cyclotomic_iff, mem_primitiveRoots,
+    NeZero.pos_of_neZero_natCast R]
 
 theorem cyclotomic.roots_eq_primitiveRoots_val [NeZero (n : R)] :
     (cyclotomic n R).roots = (primitiveRoots n R).val := by

--- a/Mathlib/RingTheory/Polynomial/Dickson.lean
+++ b/Mathlib/RingTheory/Polynomial/Dickson.lean
@@ -128,7 +128,6 @@ theorem dickson_one_one_eval_add_inv (x y : R) (h : x * y = 1) :
 
 variable (R)
 
--- Porting note: Added 2 new theorems for convenience
 private theorem two_mul_C_half_eq_one [Invertible (2 : R)] : 2 * C (⅟2 : R) = 1 := by
   rw [two_mul, ← C_add, invOf_two_add_invOf_two, C_1]
 

--- a/Mathlib/RingTheory/Polynomial/Eisenstein/Basic.lean
+++ b/Mathlib/RingTheory/Polynomial/Eisenstein/Basic.lean
@@ -132,8 +132,6 @@ theorem exists_mem_adjoin_mul_eq_pow_natDegree_le {x : S} (hx : aeval x f = 0) (
 
 end Principal
 
--- Porting note: `Ideal.neg_mem_iff` was `neg_mem_iff` on line 142 but Lean was not able to find
--- NegMemClass
 theorem pow_natDegree_le_of_root_of_monic_mem (hf : f.IsWeaklyEisensteinAt 𝓟)
     {x : R} (hroot : IsRoot f x) (hmo : f.Monic) :
     ∀ i, f.natDegree ≤ i → x ^ i ∈ 𝓟 := by
@@ -144,7 +142,7 @@ theorem pow_natDegree_le_of_root_of_monic_mem (hf : f.IsWeaklyEisensteinAt 𝓟)
   rw [IsRoot.def, eval_eq_sum_range, Finset.range_add_one,
     Finset.sum_insert Finset.notMem_range_self, Finset.sum_range, hmo.coeff_natDegree, one_mul] at
     *
-  rw [eq_neg_of_add_eq_zero_left hroot, Ideal.neg_mem_iff]
+  rw [eq_neg_of_add_eq_zero_left hroot, neg_mem_iff]
   exact Submodule.sum_mem _ fun i _ => mul_mem_right _ _ (hf.mem (Fin.is_lt i))
 
 theorem pow_natDegree_le_of_aeval_zero_of_monic_mem_map (hf : f.IsWeaklyEisensteinAt 𝓟)

--- a/Mathlib/RingTheory/Polynomial/GaussLemma.lean
+++ b/Mathlib/RingTheory/Polynomial/GaussLemma.lean
@@ -163,7 +163,6 @@ theorem Monic.irreducible_iff_irreducible_map_fraction_map [IsIntegrallyClosed R
   refine
     IsUnit.mul (IsUnit.map _ (Or.resolve_left (hp.isUnit_or_isUnit ?_) (show ¬IsUnit a' from ?_)))
       (isUnit_iff_exists_inv'.mpr
-        -- Porting note(https://github.com/leanprover-community/mathlib4/issues/5073): was `rwa`
         (Exists.intro (C a.leadingCoeff) <| by rw [← C_mul, this, C_1]))
   · exact Polynomial.map_injective _ (IsFractionRing.injective R K) H
   · by_contra h_contra
@@ -172,7 +171,6 @@ theorem Monic.irreducible_iff_irreducible_map_fraction_map [IsIntegrallyClosed R
     exact
       IsUnit.mul (IsUnit.map _ h_contra)
         (isUnit_iff_exists_inv.mpr
-          -- Porting note(https://github.com/leanprover-community/mathlib4/issues/5073): was `rwa`
           (Exists.intro (C b.leadingCoeff) <| by rw [← C_mul, this, C_1]))
 
 /-- Integrally closed domains are precisely the domains for in which Gauss's lemma holds
@@ -235,10 +233,9 @@ theorem isUnit_or_eq_zero_of_isUnit_integerNormalization_primPart {p : K[X]} (h0
   irreducible in the fraction field. -/
 theorem IsPrimitive.irreducible_iff_irreducible_map_fraction_map {p : R[X]} (hp : p.IsPrimitive) :
     Irreducible p ↔ Irreducible (p.map (algebraMap R K)) := by
-  -- Porting note: was `(IsFractionRing.injective _ _)`
   refine
     ⟨fun hi => ⟨fun h => hi.not_isUnit (hp.isUnit_iff_isUnit_map.2 h), fun a b hab => ?_⟩,
-      hp.irreducible_of_irreducible_map_of_injective (IsFractionRing.injective R K)⟩
+      hp.irreducible_of_irreducible_map_of_injective (IsFractionRing.injective _ _)⟩
   obtain ⟨⟨c, c0⟩, hc⟩ := integerNormalization_map_to_map R⁰ a
   obtain ⟨⟨d, d0⟩, hd⟩ := integerNormalization_map_to_map R⁰ b
   rw [Algebra.smul_def, algebraMap_apply, Subtype.coe_mk] at hc hd

--- a/Mathlib/RingTheory/Polynomial/Hermite/Basic.lean
+++ b/Mathlib/RingTheory/Polynomial/Hermite/Basic.lean
@@ -140,9 +140,8 @@ theorem coeff_hermite_explicit :
   | 0, _ => by simp
   | n + 1, 0 => by
     convert coeff_hermite_succ_zero (2 * n + 1) using 1
-    -- Porting note: ring_nf did not solve the goal on line 165
-    rw [coeff_hermite_explicit n 1, (by rw [Nat.left_distrib, mul_one, Nat.add_one_sub_one] :
-      2 * (n + 1) - 1 = 2 * n + 1), Nat.doubleFactorial_add_one, Nat.choose_zero_right,
+    rw [coeff_hermite_explicit n 1, (by grind : 2 * (n + 1) - 1 = 2 * n + 1),
+      Nat.doubleFactorial_add_one, Nat.choose_zero_right,
       Nat.choose_one_right, pow_succ]
     push_cast
     ring
@@ -162,8 +161,7 @@ theorem coeff_hermite_explicit :
       congr 2
       -- Factor out double factorials.
       norm_cast
-      -- Porting note: ring_nf did not solve the goal on line 186
-      rw [(by rw [Nat.left_distrib, mul_one, Nat.add_one_sub_one] : 2 * (n + 1) - 1 = 2 * n + 1),
+      rw [(by grind : 2 * (n + 1) - 1 = 2 * n + 1),
         Nat.doubleFactorial_add_one, mul_comm (2 * n + 1)]
       simp only [mul_assoc, ← mul_add]
       congr 1
@@ -184,8 +182,7 @@ theorem coeff_hermite_of_even_add {n k : ℕ} (hnk : Even (n + k)) :
   rcases le_or_gt k n with h_le | h_lt
   · rw [Nat.even_add, ← Nat.even_sub h_le] at hnk
     obtain ⟨m, hm⟩ := hnk
-    -- Porting note: linarith failed to find a contradiction by itself
-    rw [(by omega : n = 2 * m + k),
+    rw [(by grind : n = 2 * m + k),
       Nat.add_sub_cancel, Nat.mul_div_cancel_left _ (Nat.succ_pos 1), coeff_hermite_explicit]
   · simp [Nat.choose_eq_zero_of_lt h_lt, coeff_hermite_of_lt h_lt]
 

--- a/Mathlib/RingTheory/Polynomial/Hermite/Gaussian.lean
+++ b/Mathlib/RingTheory/Polynomial/Hermite/Gaussian.lean
@@ -46,7 +46,8 @@ theorem deriv_gaussian_eq_hermite_mul_gaussian (n : ℕ) (x : ℝ) :
     have deriv_gaussian :
       deriv (fun y => Real.exp (-(y ^ 2 / 2))) x = -x * Real.exp (-(x ^ 2 / 2)) := by
       -- Porting note (https://github.com/leanprover-community/mathlib4/issues/10745): was `simp [mul_comm, ← neg_mul]`
-      rw [deriv_exp (by simp)]; simp; ring
+      rw [deriv_exp (by simp)]
+      simp [mul_comm]
     rw [Function.iterate_succ_apply', ih, deriv_const_mul_field, deriv_fun_mul, pow_succ (-1 : ℝ),
       deriv_gaussian, hermite_succ, map_sub, map_mul, aeval_X, Polynomial.deriv_aeval]
     · ring

--- a/Mathlib/RingTheory/Polynomial/RationalRoot.lean
+++ b/Mathlib/RingTheory/Polynomial/RationalRoot.lean
@@ -38,7 +38,6 @@ open Finsupp IsFractionRing IsLocalization Polynomial
 theorem scaleRoots_aeval_eq_zero_of_aeval_mk'_eq_zero {p : A[X]} {r : A} {s : M}
     (hr : aeval (mk' S r s) p = 0) : aeval (algebraMap A S r) (scaleRoots p s) = 0 := by
   convert scaleRoots_eval₂_eq_zero (algebraMap A S) hr
-  -- Porting note: added
   funext
   rw [aeval_def, mk'_spec' _ r s]
 

--- a/Mathlib/RingTheory/PowerSeries/Basic.lean
+++ b/Mathlib/RingTheory/PowerSeries/Basic.lean
@@ -62,10 +62,6 @@ variable {R : Type*}
 
 section
 
--- Porting note: not available in Lean 4
--- local reducible PowerSeries
-
-
 /--
 `R⟦X⟧` is notation for `PowerSeries R`,
 the semiring of formal power series in one variable over a semiring `R`.

--- a/Mathlib/RingTheory/ReesAlgebra.lean
+++ b/Mathlib/RingTheory/ReesAlgebra.lean
@@ -77,12 +77,10 @@ theorem monomial_mem_adjoin_monomial {I : Ideal R} {n : ℕ} {r : R} (hr : r ∈
   induction n generalizing r with
   | zero => exact Subalgebra.algebraMap_mem _ _
   | succ n hn =>
-    rw [pow_succ'] at hr
-    apply Submodule.smul_induction_on
-      -- Porting note: did not need help with motive previously
-      (p := fun r => (monomial (Nat.succ n)) r ∈ Algebra.adjoin R (Submodule.map (monomial 1) I)) hr
+  · rw [pow_succ'] at hr
+    refine Submodule.smul_induction_on hr ?_ ?_
     · intro r hr s hs
-      rw [Nat.succ_eq_one_add, smul_eq_mul, ← monomial_mul_monomial]
+      rw [add_comm n 1, smul_eq_mul, ← monomial_mul_monomial]
       exact Subalgebra.mul_mem _ (Algebra.subset_adjoin (Set.mem_image_of_mem _ hr)) (hn hs)
     · intro x y hx hy
       rw [monomial_add]

--- a/Mathlib/RingTheory/RingHomProperties.lean
+++ b/Mathlib/RingTheory/RingHomProperties.lean
@@ -149,9 +149,7 @@ theorem IsStableUnderBaseChange.mk (h₁ : RespectsIso @P)
   have hemul (x y : _) : e (x * y) = e x * e y := by simp_rw [hef, map_mul]
   convert h₁.1 _ { e with map_mul' := hemul } (h₂ H)
   ext x
-  change _ = e (x ⊗ₜ[R] 1)
-  -- Porting note: Had `dsimp only [e]` here, which didn't work anymore
-  rw [h.symm.1.equiv_tmul, Algebra.smul_def, AlgHom.toLinearMap_apply, map_one, mul_one]
+  simp [e, h.symm.1.equiv_tmul, Algebra.smul_def]
 
 attribute [local instance] Algebra.TensorProduct.rightAlgebra
 

--- a/Mathlib/RingTheory/RingInvo.lean
+++ b/Mathlib/RingTheory/RingInvo.lean
@@ -87,7 +87,7 @@ def mk' (f : R →+* Rᵐᵒᵖ) (involution : ∀ r, (f (f r).unop).unop = r) :
 theorem involution (f : RingInvo R) (x : R) : (f (f x).unop).unop = x :=
   f.involution' x
 
--- Porting note: remove Coe instance, not needed
+-- We might want to restore the below instance if we remove `RingEquivClass.toRingEquiv`.
 -- instance hasCoeToRingEquiv : Coe (RingInvo R) (R ≃+* Rᵐᵒᵖ) :=
 --   ⟨RingInvo.toRingEquiv⟩
 

--- a/Mathlib/RingTheory/RootsOfUnity/Basic.lean
+++ b/Mathlib/RingTheory/RootsOfUnity/Basic.lean
@@ -245,7 +245,7 @@ section Reduced
 
 variable (R) [CommRing R] [IsReduced R]
 
--- @[simp] -- Porting note: simp normal form is `mem_rootsOfUnity_prime_pow_mul_iff'`
+-- simp normal form is `mem_rootsOfUnity_prime_pow_mul_iff'`
 theorem mem_rootsOfUnity_prime_pow_mul_iff (p k : ℕ) (m : ℕ) [ExpChar R p] {ζ : Rˣ} :
     ζ ∈ rootsOfUnity (p ^ k * m) R ↔ ζ ∈ rootsOfUnity m R := by
   simp only [mem_rootsOfUnity', ExpChar.pow_prime_pow_mul_eq_one_iff]

--- a/Mathlib/RingTheory/RootsOfUnity/Minpoly.lean
+++ b/Mathlib/RingTheory/RootsOfUnity/Minpoly.lean
@@ -34,9 +34,6 @@ variable {n : ℕ} {K : Type*} [CommRing K] {μ : K} (h : IsPrimitiveRoot μ n)
 include h
 
 /-- `μ` is integral over `ℤ`. -/
--- Porting note: `hpos` was in the `variable` line, with an `omit` in mathlib3 just after this
--- declaration. For some reason, in Lean4, `hpos` gets included also in the declarations below,
--- even if it is not used in the proof.
 theorem isIntegral (hpos : 0 < n) : IsIntegral ℤ μ := by
   use X ^ n - 1
   constructor

--- a/Mathlib/RingTheory/SimpleModule/Basic.lean
+++ b/Mathlib/RingTheory/SimpleModule/Basic.lean
@@ -524,38 +524,20 @@ noncomputable instance _root_.Module.End.instDivisionRing
 
 end LinearMap
 
--- Porting note: adding a namespace with all the new statements; existing result is not used in ML3
 namespace JordanHolderModule
-
--- Porting note: jordanHolderModule was timing out so outlining the fields
-
-/-- An isomorphism `X₂ / X₁ ∩ X₂ ≅ Y₂ / Y₁ ∩ Y₂` of modules for pairs
-`(X₁,X₂) (Y₁,Y₂) : Submodule R M` -/
-def Iso (X Y : Submodule R M × Submodule R M) : Prop :=
-  Nonempty <| (X.2 ⧸ X.1.comap X.2.subtype) ≃ₗ[R] Y.2 ⧸ Y.1.comap Y.2.subtype
-
-theorem iso_symm {X Y : Submodule R M × Submodule R M} : Iso X Y → Iso Y X :=
-  fun ⟨f⟩ => ⟨f.symm⟩
-
-theorem iso_trans {X Y Z : Submodule R M × Submodule R M} : Iso X Y → Iso Y Z → Iso X Z :=
-  fun ⟨f⟩ ⟨g⟩ => ⟨f.trans g⟩
-
-@[nolint unusedArguments]
-theorem second_iso {X Y : Submodule R M} (_ : X ⋖ X ⊔ Y) :
-    Iso (X,X ⊔ Y) (X ⊓ Y,Y) := by
-  constructor
-  rw [sup_comm, inf_comm]
-  dsimp
-  exact (LinearMap.quotientInfEquivSupQuotient Y X).symm
 
 instance instJordanHolderLattice : JordanHolderLattice (Submodule R M) where
   IsMaximal := (· ⋖ ·)
   lt_of_isMaximal := CovBy.lt
   sup_eq_of_isMaximal hxz hyz := WCovBy.sup_eq hxz.wcovBy hyz.wcovBy
   isMaximal_inf_left_of_isMaximal_sup := inf_covBy_of_covBy_sup_of_covBy_sup_left
-  Iso := Iso
-  iso_symm := iso_symm
-  iso_trans := iso_trans
-  second_iso := second_iso
+  Iso X Y := Nonempty <| (X.2 ⧸ X.1.comap X.2.subtype) ≃ₗ[R] Y.2 ⧸ Y.1.comap Y.2.subtype
+  iso_symm := fun ⟨f⟩ => ⟨f.symm⟩
+  iso_trans := fun ⟨f⟩ ⟨g⟩ => ⟨f.trans g⟩
+  second_iso {X} {Y} _ := by
+    constructor
+    rw [sup_comm, inf_comm]
+    dsimp
+    exact (LinearMap.quotientInfEquivSupQuotient Y X).symm
 
 end JordanHolderModule

--- a/Mathlib/RingTheory/Smooth/Basic.lean
+++ b/Mathlib/RingTheory/Smooth/Basic.lean
@@ -28,7 +28,6 @@ localization at an element.
 
 -/
 
--- Porting note: added to make the syntax work below.
 open scoped TensorProduct
 
 universe u
@@ -274,9 +273,6 @@ variable [Algebra R S] [Algebra R Sₘ] [Algebra S Sₘ] [Algebra R Rₘ] [Algeb
 variable [IsScalarTower R Rₘ Sₘ] [IsScalarTower R S Sₘ]
 variable [IsLocalization M Rₘ] [IsLocalization (M.map (algebraMap R S)) Sₘ]
 include M
-
--- Porting note: no longer supported
--- attribute [local elab_as_elim] Ideal.IsNilpotent.induction_on
 
 theorem of_isLocalization : FormallySmooth R Rₘ := by
   constructor

--- a/Mathlib/RingTheory/Spectrum/Prime/Basic.lean
+++ b/Mathlib/RingTheory/Spectrum/Prime/Basic.lean
@@ -429,10 +429,9 @@ variable {A : Type u} [CommRing A] [IsDomain A] [IsNoetherianRing A]
 ([samuel1967, § 3.3, Lemma 3]). -/
 theorem exists_primeSpectrum_prod_le (I : Ideal R) :
     ∃ Z : Multiset (PrimeSpectrum R), Multiset.prod (Z.map asIdeal) ≤ I := by
-  -- Porting note: Need to specify `P` explicitly
-  refine IsNoetherian.induction
-    (P := fun I => ∃ Z : Multiset (PrimeSpectrum R), Multiset.prod (Z.map asIdeal) ≤ I)
-    (fun (M : Ideal R) hgt => ?_) I
+  induction I using IsNoetherian.induction
+  case hgt M hgt =>
+  change Ideal R at M
   by_cases h_prM : M.IsPrime
   · use {⟨M, h_prM⟩}
     rw [Multiset.map_singleton, Multiset.prod_singleton]
@@ -463,12 +462,9 @@ theorem exists_primeSpectrum_prod_le_and_ne_bot_of_domain (h_fA : ¬IsField A) {
     (h_nzI : I ≠ ⊥) :
     ∃ Z : Multiset (PrimeSpectrum A),
       Multiset.prod (Z.map asIdeal) ≤ I ∧ Multiset.prod (Z.map asIdeal) ≠ ⊥ := by
-  revert h_nzI
-  -- Porting note: Need to specify `P` explicitly
-  refine IsNoetherian.induction (P := fun I => I ≠ ⊥ → ∃ Z : Multiset (PrimeSpectrum A),
-      Multiset.prod (Z.map asIdeal) ≤ I ∧ Multiset.prod (Z.map asIdeal) ≠ ⊥)
-    (fun (M : Ideal A) hgt => ?_) I
-  intro h_nzM
+  induction I using IsNoetherian.induction
+  case hgt M hgt =>
+  change Ideal A at M
   have hA_nont : Nontrivial A := IsDomain.toNontrivial
   by_cases h_topM : M = ⊤
   · rcases h_topM with rfl
@@ -479,7 +475,7 @@ theorem exists_primeSpectrum_prod_le_and_ne_bot_of_domain (h_fA : ¬IsField A) {
   by_cases h_prM : M.IsPrime
   · use ({⟨M, h_prM⟩} : Multiset (PrimeSpectrum A))
     rw [Multiset.map_singleton, Multiset.prod_singleton]
-    exact ⟨le_rfl, h_nzM⟩
+    exact ⟨le_rfl, h_nzI⟩
   obtain ⟨x, hx, y, hy, h_xy⟩ := (Ideal.not_isPrime_iff.mp h_prM).resolve_left h_topM
   have lt_add : ∀ z ∉ M, M < M + span A {z} := by
     intro z hz

--- a/Mathlib/RingTheory/TensorProduct/Free.lean
+++ b/Mathlib/RingTheory/TensorProduct/Free.lean
@@ -66,12 +66,11 @@ noncomputable def basis : Basis ι A (A ⊗[R] M) where
 @[simp]
 theorem basis_repr_tmul (a : A) (m : M) :
     (basis A b).repr (a ⊗ₜ m) = a • Finsupp.mapRange (algebraMap R A) (map_zero _) (b.repr m) :=
-  basisAux_tmul b a m -- Porting note: Lean 3 had _ _ _
+  basisAux_tmul b _ _
 
 theorem basis_repr_symm_apply (a : A) (i : ι) :
     (basis A b).repr.symm (Finsupp.single i a) = a ⊗ₜ b.repr.symm (Finsupp.single i 1) := by
-  rw [basis, LinearEquiv.coe_symm_mk] -- Porting note: `coe_symm_mk` isn't firing in `simp`
-  simp [Equiv.uniqueProd_symm_apply, basisAux]
+  simp [basis, LinearEquiv.coe_symm_mk', Equiv.uniqueProd_symm_apply, basisAux]
 
 @[simp]
 theorem basis_apply (i : ι) : basis A b i = 1 ⊗ₜ b i := basis_repr_symm_apply b 1 i

--- a/Mathlib/RingTheory/Trace/Basic.lean
+++ b/Mathlib/RingTheory/Trace/Basic.lean
@@ -215,17 +215,15 @@ theorem trace_eq_sum_embeddings_gen (pb : PowerBasis K L)
     algebraMap K E (Algebra.trace K L pb.gen) =
       (@Finset.univ _ (PowerBasis.AlgHom.fintype pb)).sum fun σ => σ pb.gen := by
   letI := Classical.decEq E
-  -- Porting note: the following `letI` was not needed.
   letI : Fintype (L →ₐ[K] E) := PowerBasis.AlgHom.fintype pb
   rw [pb.trace_gen_eq_sum_roots hE, Fintype.sum_equiv pb.liftEquiv', Finset.sum_mem_multiset,
     Finset.sum_eq_multiset_sum, Multiset.toFinset_val, Multiset.dedup_eq_self.mpr _,
     Multiset.map_id]
   · exact nodup_roots ((separable_map _).mpr hfx)
-  -- Porting note: the following goal does not exist in mathlib3.
-  · exact (fun x => x.1)
+  swap
   · intro x; rfl
   · intro σ
-    rw [PowerBasis.liftEquiv'_apply_coe]
+    rw [PowerBasis.liftEquiv'_apply_coe, id_def]
 
 variable [IsAlgClosed E]
 
@@ -242,11 +240,8 @@ theorem sum_embeddings_eq_finrank_mul [FiniteDimensional K F] [Algebra.IsSeparab
       Finset.univ_sigma_univ, Finset.sum_sigma, ← Finset.sum_nsmul]
     · refine Finset.sum_congr rfl fun σ _ => ?_
       letI : Algebra L E := σ.toRingHom.toAlgebra
-      -- Porting note: `Finset.card_univ` was inside `simp only`.
-      simp only [Finset.sum_const]
-      congr
-      rw [← AlgHom.card L F E]
-      exact Finset.card_univ (α := F →ₐ[L] E)
+      simp only [Finset.sum_const, Finset.card_univ, ← AlgHom.card L F E]
+      congr!
     · intro σ
       simp only [algHomEquivSigma, Equiv.coe_fn_mk, AlgHom.restrictDomain, AlgHom.comp_apply,
         IsScalarTower.coe_toAlgHom']

--- a/Mathlib/RingTheory/Unramified/Basic.lean
+++ b/Mathlib/RingTheory/Unramified/Basic.lean
@@ -288,6 +288,7 @@ consistency. See `Algebra.FormallyUnramified.of_comp` instead.
 
 The intended use is for copying proofs between `Formally{Unramified, Smooth, Etale}`
 without the need to change anything (including removing redundant arguments). -/
+@[nolint unusedArguments]
 theorem localization_base [FormallyUnramified R Sₘ] : FormallyUnramified Rₘ Sₘ :=
   FormallyUnramified.of_comp R Rₘ Sₘ
 

--- a/Mathlib/RingTheory/Unramified/Basic.lean
+++ b/Mathlib/RingTheory/Unramified/Basic.lean
@@ -30,7 +30,6 @@ localization at an element.
 
 -/
 
--- Porting note: added to make the syntax work below.
 open scoped TensorProduct
 
 universe u v w
@@ -283,15 +282,13 @@ instance [FormallyUnramified R S] (M : Submonoid S) : FormallyUnramified R (Loca
   have := of_isLocalization (Rₘ := Localization M) M
   .comp _ S _
 
+set_option linter.unusedSectionVars false in
 /-- This actually does not need the localization instance, and is stated here again for
 consistency. See `Algebra.FormallyUnramified.of_comp` instead.
 
 The intended use is for copying proofs between `Formally{Unramified, Smooth, Etale}`
 without the need to change anything (including removing redundant arguments). -/
--- @[nolint unusedArguments] -- Porting note: removed
 theorem localization_base [FormallyUnramified R Sₘ] : FormallyUnramified Rₘ Sₘ :=
-  -- Porting note: added
-  let _ := M
   FormallyUnramified.of_comp R Rₘ Sₘ
 
 theorem localization_map [FormallyUnramified R S] :

--- a/Mathlib/RingTheory/Valuation/Basic.lean
+++ b/Mathlib/RingTheory/Valuation/Basic.lean
@@ -148,7 +148,7 @@ protected theorem map_one : v 1 = 1 :=
 protected theorem map_mul : ∀ x y, v (x * y) = v x * v y :=
   v.map_mul'
 
--- Porting note: LHS side simplified so created map_add'
+-- `simp`-normal form is `map_add'`
 protected theorem map_add : ∀ x y, v (x + y) ≤ max (v x) (v y) :=
   v.map_add_le_max'
 
@@ -801,7 +801,6 @@ theorem ofValuation_apply (v : Valuation R (Multiplicative Γ₀ᵒᵈ)) (r : R)
 
 end
 
--- Porting note: Lean get confused about namespaces and instances below
 @[simp]
 theorem map_zero : v 0 = (⊤ : Γ₀) :=
   Valuation.map_zero v
@@ -810,15 +809,17 @@ theorem map_zero : v 0 = (⊤ : Γ₀) :=
 theorem map_one : v 1 = (0 : Γ₀) :=
   Valuation.map_one v
 
-/- Porting note: helper wrapper to coerce `v` to the correct function type -/
-/-- A helper function for Lean to inferring types correctly -/
-def asFun : R → Γ₀ := v
+/-- A helper function for Lean to inferring types correctly.
+
+Deprecated since it is unused.
+-/
+@[deprecated "Use `⇑v` instead" (since := "2025-09-04")] def asFun : R → Γ₀ := v
 
 @[simp]
 theorem map_mul : ∀ (x y : R), v (x * y) = v x + v y :=
   Valuation.map_mul v
 
--- Porting note: LHS simplified so created map_add' and removed simp tag
+-- `simp`-normal form is `map_add'`
 theorem map_add : ∀ (x y : R), min (v x) (v y) ≤ v (x + y) :=
   Valuation.map_add v
 

--- a/Mathlib/RingTheory/Valuation/Quotient.lean
+++ b/Mathlib/RingTheory/Valuation/Quotient.lean
@@ -78,8 +78,6 @@ variable {R Γ₀ : Type*}
 variable [CommRing R] [LinearOrderedAddCommMonoidWithTop Γ₀]
 variable (v : AddValuation R Γ₀)
 
--- attribute [local reducible] AddValuation -- Porting note: reducible not supported
-
 /-- If `hJ : J ⊆ supp v` then `onQuotVal hJ` is the induced function on `R / J` as a function.
 Note: it's just the function; the valuation is `onQuot hJ`. -/
 def onQuotVal {J : Ideal R} (hJ : J ≤ supp v) : R ⧸ J → Γ₀ :=

--- a/Mathlib/RingTheory/Valuation/ValuationRing.lean
+++ b/Mathlib/RingTheory/Valuation/ValuationRing.lean
@@ -58,9 +58,8 @@ lemma PreValuationRing.cond {A : Type u} [Mul A] [PreValuationRing A] (a b : A) 
 of elements `a b : A`, either `a` divides `b` or vice versa. -/
 class ValuationRing (A : Type u) [CommRing A] [IsDomain A] : Prop extends PreValuationRing A
 
--- Porting note: this lemma is needed since infer kinds are unsupported in Lean 4
-lemma ValuationRing.cond {A : Type u} [Mul A] [PreValuationRing A] (a b : A) :
-    ∃ c : A, a * c = b ∨ b * c = a := PreValuationRing.cond _ _
+/-- An abbreviation for `PreValuationRing.cond` which should save some writing. -/
+alias ValuationRing.cond := PreValuationRing.cond
 
 namespace ValuationRing
 
@@ -141,8 +140,6 @@ protected theorem le_total (a b : ValueGroup A K) : a ≤ b ∨ b ≤ a := by
     field_simp
     simp only [← RingHom.map_mul]; congr 1; linear_combination h
 
--- Porting note: it is much faster to split the instance `LinearOrderedCommGroupWithZero`
--- into two parts
 noncomputable instance linearOrder : LinearOrder (ValueGroup A K) where
   le_refl := by rintro ⟨⟩; use 1; rw [one_smul]
   le_trans := by rintro ⟨a⟩ ⟨b⟩ ⟨c⟩ ⟨e, rfl⟩ ⟨f, rfl⟩; use e * f; rw [mul_smul]

--- a/Mathlib/RingTheory/Valuation/ValuationSubring.lean
+++ b/Mathlib/RingTheory/Valuation/ValuationSubring.lean
@@ -121,16 +121,15 @@ instance : ValuationRing A where
 
 instance : Algebra A K := inferInstanceAs <| Algebra A.toSubring K
 
--- Porting note: Somehow it cannot find this instance and I'm too lazy to debug. wrong prio?
-instance isLocalRing : IsLocalRing A := ValuationRing.isLocalRing A
+instance isLocalRing : IsLocalRing A := inferInstance
 
 @[simp]
 theorem algebraMap_apply (a : A) : algebraMap A K a = a := rfl
 
 instance : IsFractionRing A K where
-  map_units' := fun ⟨y, hy⟩ =>
+  map_units := fun ⟨y, hy⟩ =>
     (Units.mk0 (y : K) fun c => nonZeroDivisors.ne_zero hy <| Subtype.ext c).isUnit
-  surj' z := by
+  surj z := by
     by_cases h : z = 0; · use (0, 1); simp [h]
     rcases A.mem_or_inv_mem z with hh | hh
     · use (⟨z, hh⟩, 1); simp
@@ -422,9 +421,7 @@ def unitGroupMulEquiv : A.unitGroup ≃* Aˣ where
   toFun x :=
     { val := ⟨(x : Kˣ), mem_of_valuation_le_one A _ x.prop.le⟩
       inv := ⟨((x⁻¹ : A.unitGroup) : Kˣ), mem_of_valuation_le_one _ _ x⁻¹.prop.le⟩
-      -- Porting note: was `Units.mul_inv x`
       val_inv := Subtype.ext (by simp)
-      -- Porting note: was `Units.inv_mul x`
       inv_val := Subtype.ext (by simp) }
   invFun x := ⟨Units.map A.subtype.toMonoidHom x, A.valuation_unit x⟩
   map_mul' a b := by ext; rfl
@@ -477,7 +474,6 @@ section nonunits
 /-- The nonunits of a valuation subring of `K`, as a subsemigroup of `K` -/
 def nonunits : Subsemigroup K where
   carrier := {x | A.valuation x < 1}
-  -- Porting note: added `Set.mem_setOf.mp`
   mul_mem' ha hb := (mul_lt_mul'' (Set.mem_setOf.mp ha) (Set.mem_setOf.mp hb)
     zero_le' zero_le').trans_eq <| mul_one _
 
@@ -657,10 +653,6 @@ def unitsModPrincipalUnitsEquivResidueFieldUnits :
     A.unitGroup ⧸ A.principalUnitGroup.comap A.unitGroup.subtype ≃* (IsLocalRing.ResidueField A)ˣ :=
   (QuotientGroup.quotientMulEquivOfEq A.ker_unitGroupToResidueFieldUnits.symm).trans
     (QuotientGroup.quotientKerEquivOfSurjective _ A.surjective_unitGroupToResidueFieldUnits)
-
-/-- Porting note: Lean needs to be reminded of this instance -/
-local instance : MulOneClass ({ x // x ∈ unitGroup A } ⧸
-    Subgroup.comap (Subgroup.subtype (unitGroup A)) (principalUnitGroup A)) := inferInstance
 
 theorem unitsModPrincipalUnitsEquivResidueFieldUnits_comp_quotientGroup_mk :
     (A.unitsModPrincipalUnitsEquivResidueFieldUnits : _ ⧸ Subgroup.comap _ _ →* _).comp

--- a/Mathlib/RingTheory/WittVector/Basic.lean
+++ b/Mathlib/RingTheory/WittVector/Basic.lean
@@ -66,25 +66,22 @@ def mapFun (f : α → β) : 𝕎 α → 𝕎 β := fun x => mk _ (f ∘ x.coeff
 
 namespace mapFun
 
--- Porting note: switched the proof to tactic mode. I think that `ext` was the issue.
-theorem injective (f : α → β) (hf : Injective f) : Injective (mapFun f : 𝕎 α → 𝕎 β) := by
-  intro _ _ h
-  ext p
-  exact hf (congr_arg (fun x => coeff x p) h :)
+theorem injective (f : α → β) (hf : Injective f) : Injective (mapFun f : 𝕎 α → 𝕎 β) :=
+  fun _ _ h => ext fun n => hf (congr_arg (fun x => coeff x n) h :)
 
 theorem surjective (f : α → β) (hf : Surjective f) : Surjective (mapFun f : 𝕎 α → 𝕎 β) := fun x =>
   ⟨mk _ fun n => Classical.choose <| hf <| x.coeff n,
     by ext n; simp only [mapFun, coeff_mk, comp_apply, Classical.choose_spec (hf (x.coeff n))]⟩
 
 /-- Auxiliary tactic for showing that `mapFun` respects the ring operations. -/
--- porting note: a very crude port.
 macro "map_fun_tac" : tactic => `(tactic| (
+  -- TODO: the Lean 3 version of this tactic was more functional
   ext n
   simp only [mapFun, mk, comp_apply, zero_coeff, map_zero,
-    -- Porting note: the lemmas on the next line do not have the `simp` tag in mathlib4
+    -- the lemmas on the next line do not have the `simp` tag in mathlib4
     add_coeff, sub_coeff, mul_coeff, neg_coeff, nsmul_coeff, zsmul_coeff, pow_coeff,
     peval, map_aeval, algebraMap_int_eq, coe_eval₂Hom] <;>
-  try { cases n <;> simp <;> done } <;> -- Porting note: this line solves `one`
+  try { cases n <;> simp <;> done } <;> -- this line solves `one`
   apply eval₂Hom_congr (RingHom.ext_int _ _) _ rfl <;>
   ext ⟨i, k⟩ <;>
     fin_cases i <;> rfl))

--- a/Mathlib/RingTheory/WittVector/Frobenius.lean
+++ b/Mathlib/RingTheory/WittVector/Frobenius.lean
@@ -219,17 +219,15 @@ The underlying function of this morphism is `WittVector.frobeniusFun`.
 def frobenius : 𝕎 R →+* 𝕎 R where
   toFun := frobeniusFun
   map_zero' := by
-    -- Porting note: removing the placeholders give an error
-    refine IsPoly.ext (@IsPoly.comp p _ _ (frobeniusFun_isPoly p) WittVector.zeroIsPoly)
-      (@IsPoly.comp p _ _ WittVector.zeroIsPoly
-      (frobeniusFun_isPoly p)) ?_ _ 0
+    refine IsPoly.ext (IsPoly.comp (hg := frobeniusFun_isPoly p) (hf := WittVector.zeroIsPoly))
+      (IsPoly.comp (hg := WittVector.zeroIsPoly) (hf := frobeniusFun_isPoly p))
+      ?_ _ 0
     simp only [Function.comp_apply, map_zero, forall_const]
     ghost_simp
   map_one' := by
     refine
-      -- Porting note: removing the placeholders give an error
-      IsPoly.ext (@IsPoly.comp p _ _ (frobeniusFun_isPoly p) WittVector.oneIsPoly)
-        (@IsPoly.comp p _ _ WittVector.oneIsPoly (frobeniusFun_isPoly p)) ?_ _ 0
+      IsPoly.ext (IsPoly.comp (hg := frobeniusFun_isPoly p) (hf := WittVector.oneIsPoly))
+        (IsPoly.comp (hg := WittVector.oneIsPoly) (hf := frobeniusFun_isPoly p)) ?_ _ 0
     simp only [Function.comp_apply, map_one, forall_const]
     ghost_simp
   map_add' := by ghost_calc _ _; ghost_simp

--- a/Mathlib/RingTheory/WittVector/Identities.lean
+++ b/Mathlib/RingTheory/WittVector/Identities.lean
@@ -35,7 +35,7 @@ local notation "𝕎" => WittVector p
 
 noncomputable section
 
--- Porting note: `ghost_calc` failure: `simp only []` and the manual instances had to be added.
+-- Porting note: `ghost_calc` failure: the manual instances had to be added.
 /-- The composition of Frobenius and Verschiebung is multiplication by `p`. -/
 theorem frobenius_verschiebung (x : 𝕎 R) : frobenius (verschiebung x) = x * p := by
   have : IsPoly p fun {R} [CommRing R] x ↦ frobenius (verschiebung x) :=
@@ -90,7 +90,7 @@ theorem FractionRing.p_nonzero [Nontrivial R] [CharP R p] : (p : FractionRing (�
 
 variable {p R}
 
--- Porting note: `ghost_calc` failure: `simp only []` and the manual instances had to be added.
+-- Porting note: `ghost_calc` failure: the manual instances had to be added.
 /-- The “projection formula” for Frobenius and Verschiebung. -/
 theorem verschiebung_mul_frobenius (x y : 𝕎 R) :
     verschiebung (x * frobenius y) = verschiebung x * y := by

--- a/Mathlib/RingTheory/WittVector/IsPoly.lean
+++ b/Mathlib/RingTheory/WittVector/IsPoly.lean
@@ -319,7 +319,6 @@ theorem IsPoly.map [Fact p.Prime] {f} (hf : IsPoly p f) (g : R →+* S) (x : �
 
 namespace IsPoly₂
 
--- porting note: the argument `(fun _ _ => (· + ·))` to `IsPoly₂` was just `_`.
 instance [Fact p.Prime] : Inhabited (IsPoly₂ p (fun _ _ => (· + ·))) :=
   ⟨addIsPoly₂⟩
 

--- a/Mathlib/RingTheory/WittVector/MulCoeff.lean
+++ b/Mathlib/RingTheory/WittVector/MulCoeff.lean
@@ -136,9 +136,6 @@ theorem mul_polyOfInterest_aux3 (p n : ℕ) : wittPolyProd p (n + 1) =
     remainder p n := by
   -- a useful auxiliary fact
   have mvpz : (p : 𝕄) ^ (n + 1) = MvPolynomial.C ((p : ℤ) ^ (n + 1)) := by norm_cast
-  -- Porting note: the original proof applies `sum_range_succ` through a non-`conv` rewrite,
-  -- but this does not work in Lean 4; the whole proof also times out very badly. The proof has been
-  -- nearly totally rewritten here and now finishes quite fast.
   rw [wittPolyProd, wittPolynomial, map_sum, map_sum]
   conv_lhs =>
     arg 1


### PR DESCRIPTION
This PR goes through all the remaining porting notes in the RingTheory folder and fixes the ones that have an obvious solution.


---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include at least one commit authored by each
co-author among the commits in the pull request. If necessary, you may 
create empty commits to indicate co-authorship, using commands like so:

git commit --author="Author Name <author@email.com>" --allow-empty -m "add Author Name as coauthor"

When merging, all the commits will be squashed into a single commit listing all co-authors.

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
