### PR TITLE
feat(Trigonometric): Taylor series bounds for sin and cos

### DIFF
--- a/Mathlib.lean
+++ b/Mathlib.lean
@@ -1978,6 +1978,7 @@ import Mathlib.Analysis.SpecialFunctions.Trigonometric.EulerSineProd
 import Mathlib.Analysis.SpecialFunctions.Trigonometric.Inverse
 import Mathlib.Analysis.SpecialFunctions.Trigonometric.InverseDeriv
 import Mathlib.Analysis.SpecialFunctions.Trigonometric.Series
+import Mathlib.Analysis.SpecialFunctions.Trigonometric.SeriesBounds
 import Mathlib.Analysis.SpecialFunctions.Trigonometric.Sinc
 import Mathlib.Analysis.SpecificLimits.Basic
 import Mathlib.Analysis.SpecificLimits.FloorPow

--- a/Mathlib/Algebra/BigOperators/Group/Finset/Lemmas.lean
+++ b/Mathlib/Algebra/BigOperators/Group/Finset/Lemmas.lean
@@ -4,9 +4,9 @@ Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Johannes Hölzl
 -/
 import Mathlib.Algebra.BigOperators.Group.Finset.Basic
+import Mathlib.Algebra.Group.Even
 import Mathlib.Algebra.Group.Pi.Lemmas
 import Mathlib.Algebra.Notation.Support
-import Mathlib.Algebra.Ring.Parity
 
 /-!
 # Miscellaneous lemmas on big operators
@@ -52,13 +52,5 @@ lemma isSquare_prod {s : Finset ι} (f : ι → M) (h : ∀ c ∈ s, IsSquare (f
   ext i
   rw [← @sq]
   exact ((isSquare_iff_exists_sq _).mp (h _ i.2)).choose_spec
-
-/-- Double the range of a `Finset.sum` -/
-@[to_additive]
-theorem prod_range_even (n : ℕ) (f : ℕ → M) :
-    ∏ k ∈ range n, f k = ∏ k ∈ range (2 * n), if Even k then f (k / 2) else 1 := by
-  induction n with
-  | zero => simp
-  | succ n h => simp [prod_range_succ, h, Nat.mul_add_one]
 
 end Finset

--- a/Mathlib/Algebra/BigOperators/Group/Finset/Lemmas.lean
+++ b/Mathlib/Algebra/BigOperators/Group/Finset/Lemmas.lean
@@ -4,9 +4,9 @@ Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Johannes Hölzl
 -/
 import Mathlib.Algebra.BigOperators.Group.Finset.Basic
-import Mathlib.Algebra.Group.Even
 import Mathlib.Algebra.Group.Pi.Lemmas
 import Mathlib.Algebra.Notation.Support
+import Mathlib.Algebra.Ring.Parity
 
 /-!
 # Miscellaneous lemmas on big operators
@@ -52,5 +52,13 @@ lemma isSquare_prod {s : Finset ι} (f : ι → M) (h : ∀ c ∈ s, IsSquare (f
   ext i
   rw [← @sq]
   exact ((isSquare_iff_exists_sq _).mp (h _ i.2)).choose_spec
+
+/-- Double the range of a `Finset.sum` -/
+@[to_additive]
+theorem prod_range_even (n : ℕ) (f : ℕ → M) :
+    ∏ k ∈ range n, f k = ∏ k ∈ range (2 * n), if Even k then f (k / 2) else 1 := by
+  induction n with
+  | zero => simp
+  | succ n h => simp [prod_range_succ, h, Nat.mul_add_one]
 
 end Finset

--- a/Mathlib/Algebra/BigOperators/Ring/Finset.lean
+++ b/Mathlib/Algebra/BigOperators/Ring/Finset.lean
@@ -30,6 +30,14 @@ lemma prod_neg [CommMonoid M] [HasDistribNeg M] (f : ι → M) :
     ∏ x ∈ s, -f x = (-1) ^ #s * ∏ x ∈ s, f x := by
   simpa using (s.1.map f).prod_map_neg
 
+/-- Double the range of a `Finset.sum` -/
+@[to_additive]
+theorem prod_range_even [CommMonoid M] (n : ℕ) (f : ℕ → M) :
+    ∏ k ∈ range n, f k = ∏ k ∈ range (2 * n), if Even k then f (k / 2) else 1 := by
+  induction n with
+  | zero => simp
+  | succ n h => simp [prod_range_succ, h, Nat.mul_add_one]
+
 section AddCommMonoidWithOne
 variable [AddCommMonoidWithOne R]
 

--- a/Mathlib/Analysis/SpecialFunctions/Trigonometric/Bounds.lean
+++ b/Mathlib/Analysis/SpecialFunctions/Trigonometric/Bounds.lean
@@ -230,15 +230,34 @@ theorem cos_le_one_div_sqrt_sq_add_one {x : ℝ} (hx1 : -(3 * π / 2) ≤ x) (hx
   · exact (cos_lt_one_div_sqrt_sq_add_one hx1 hx2 hx3).le
 
 /-- All the intervals on which `sin` is increasing -/
-lemma sin_monotone (n : ℤ) : MonotoneOn sin (Icc (n * (2 * π) - π / 2) (n * (2 * π) + π / 2)) := by
-  apply monotoneOn_of_deriv_nonneg
-  · apply convex_Icc
-  · fun_prop
-  · fun_prop
-  · intro x m
-    simp only [interior_Icc, mem_Ioo, deriv_sin] at m ⊢
-    rw [← cos_sub_int_mul_two_pi _ n]
-    exact Real.cos_nonneg_of_mem_Icc ⟨by linarith, by linarith⟩
+/-- All the intervals on which `sin` is increasing -/
+lemma monotoneOn_sin' (n : ℤ) :
+    MonotoneOn sin (Icc (n * (2 * π) - π / 2) (n * (2 * π) + π / 2)) := by
+  intro a ha b hb hab
+  rw [← Real.sin_sub_int_mul_two_pi a n, ← Real.sin_sub_int_mul_two_pi b n]
+  apply Real.monotoneOn_sin <;> simp at * <;> (try constructor) <;> linarith
+
+
+/-- All the intervals on which `sin` is decreasing -/
+lemma antitoneOn_sin' (n : ℤ) :
+    AntitoneOn sin (Icc (n * (2 * π) + π / 2) (n * (2 * π) + 3 * π / 2)) := by
+  intro a ha b hb hab
+  rw [← Real.cos_sub_pi_div_two, ← Real.cos_sub_int_mul_two_pi _ n,
+    ← Real.sin_sub_int_mul_two_pi _ n, ← Real.cos_sub_pi_div_two]
+  apply Real.antitoneOn_cos <;> simp at * <;> (try constructor) <;> linarith
+
+/-- All the intervals on which `cos` is increasing -/
+lemma monotoneOn_cos' (n : ℤ) : MonotoneOn cos (Icc (n * (2 * π) - π) (n * (2 * π))) := by
+  intro a ha b hb hab
+  rw [← Real.sin_add_pi_div_two, ← Real.cos_sub_int_mul_two_pi _ n,
+    ← Real.sin_sub_int_mul_two_pi _ n, ← Real.sin_add_pi_div_two]
+  apply Real.monotoneOn_sin <;> simp at * <;> (try constructor) <;> linarith
+
+/-- All the intervals on which `cos` is decreasing -/
+lemma antitoneOn_cos' (n : ℤ) : AntitoneOn cos (Icc (n * (2 * π)) (n * (2 * π) + π)) := by
+  intro a ha b hb hab
+  rw [← Real.cos_sub_int_mul_two_pi a n, ← Real.cos_sub_int_mul_two_pi b n]
+  apply Real.antitoneOn_cos <;> simp at * <;> (try constructor) <;> linarith
 
 /-- All the intervals on which `sin` is decreasing -/
 lemma sin_antitone (n : ℤ) :

--- a/Mathlib/Analysis/SpecialFunctions/Trigonometric/Bounds.lean
+++ b/Mathlib/Analysis/SpecialFunctions/Trigonometric/Bounds.lean
@@ -233,8 +233,8 @@ theorem cos_le_one_div_sqrt_sq_add_one {x : ℝ} (hx1 : -(3 * π / 2) ≤ x) (hx
 lemma sin_monotone (n : ℤ) : MonotoneOn sin (Icc (n * (2 * π) - π / 2) (n * (2 * π) + π / 2)) := by
   apply monotoneOn_of_deriv_nonneg
   · apply convex_Icc
-  · exact Continuous.continuousOn (by continuity)
-  · exact differentiable_sin.differentiableOn
+  · fun_prop
+  · fun_prop
   · intro x m
     simp only [interior_Icc, mem_Ioo, deriv_sin] at m ⊢
     rw [← cos_sub_int_mul_two_pi _ n]
@@ -254,8 +254,8 @@ lemma sin_antitone (n : ℤ) :
 lemma cos_monotone (n : ℤ) : MonotoneOn cos (Icc (n * (2 * π) - π) (n * (2 * π))) := by
   apply monotoneOn_of_deriv_nonneg
   · apply convex_Icc
-  · exact Continuous.continuousOn (by continuity)
-  · exact differentiable_cos.differentiableOn
+  · fun_prop
+  · fun_prop
   · intro x m
     simp only [interior_Icc, mem_Ioo, deriv_cos, Left.nonneg_neg_iff] at m ⊢
     rw [← sin_sub_int_mul_two_pi _ n]

--- a/Mathlib/Analysis/SpecialFunctions/Trigonometric/Bounds.lean
+++ b/Mathlib/Analysis/SpecialFunctions/Trigonometric/Bounds.lean
@@ -229,4 +229,45 @@ theorem cos_le_one_div_sqrt_sq_add_one {x : ℝ} (hx1 : -(3 * π / 2) ≤ x) (hx
   · simp
   · exact (cos_lt_one_div_sqrt_sq_add_one hx1 hx2 hx3).le
 
+/-- All the intervals on which `sin` is increasing -/
+lemma sin_monotone (n : ℤ) : MonotoneOn sin (Icc (n * (2 * π) - π / 2) (n * (2 * π) + π / 2)) := by
+  apply monotoneOn_of_deriv_nonneg
+  · apply convex_Icc
+  · exact Continuous.continuousOn (by continuity)
+  · exact differentiable_sin.differentiableOn
+  · intro x m
+    simp only [interior_Icc, mem_Ioo, deriv_sin] at m ⊢
+    rw [← cos_sub_int_mul_two_pi _ n]
+    exact Real.cos_nonneg_of_mem_Icc ⟨by linarith, by linarith⟩
+
+/-- All the intervals on which `sin` is decreasing -/
+lemma sin_antitone (n : ℤ) :
+    AntitoneOn sin (Icc (n * (2 * π) + π / 2) (n * (2 * π) + 3 * π / 2)) := by
+  intro x xm y ym xy
+  simp only [mem_Icc] at xm ym
+  rw [← neg_neg (sin x), ← Real.sin_sub_pi x, ← neg_neg (sin y), ← Real.sin_sub_pi y,
+    neg_le_neg_iff]
+  refine Real.sin_monotone (n := n) ⟨?_, ?_⟩ ⟨?_, ?_⟩ ?_
+  all_goals linarith
+
+/-- All the intervals on which `cos` is increasing -/
+lemma cos_monotone (n : ℤ) : MonotoneOn cos (Icc (n * (2 * π) - π) (n * (2 * π))) := by
+  apply monotoneOn_of_deriv_nonneg
+  · apply convex_Icc
+  · exact Continuous.continuousOn (by continuity)
+  · exact differentiable_cos.differentiableOn
+  · intro x m
+    simp only [interior_Icc, mem_Ioo, deriv_cos, Left.nonneg_neg_iff] at m ⊢
+    rw [← sin_sub_int_mul_two_pi _ n]
+    exact sin_nonpos_of_nonpos_of_neg_pi_le (by linarith) (by linarith)
+
+/-- All the intervals on which `cos` is decreasing -/
+lemma cos_antitone (n : ℤ) : AntitoneOn cos (Icc (n * (2 * π)) (n * (2 * π) + π)) := by
+  intro x xm y ym xy
+  simp only [mem_Icc] at xm ym
+  rw [← neg_neg (cos x), ← Real.cos_sub_pi x, ← neg_neg (cos y), ← Real.cos_sub_pi y,
+    neg_le_neg_iff]
+  refine Real.cos_monotone (n := n) ⟨?_, ?_⟩ ⟨?_, ?_⟩ ?_
+  all_goals linarith
+
 end Real

--- a/Mathlib/Analysis/SpecialFunctions/Trigonometric/SeriesBounds.lean
+++ b/Mathlib/Analysis/SpecialFunctions/Trigonometric/SeriesBounds.lean
@@ -1,0 +1,103 @@
+/-
+Copyright (c) 2025 Geoffrey Irving. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Geoffrey Irving
+-/
+
+import Mathlib.Algebra.BigOperators.Field
+import Mathlib.Analysis.Complex.Basic
+import Mathlib.Analysis.Complex.Trigonometric
+
+/-!
+# Taylor series bounds for trigonometric functions
+
+## Main statements
+
+We prove Taylor series bounds with optimal remainder for `sin` and `cos`, over both `ℂ` and `ℝ`.
+See `Trigonometric.Bounds` for simpler inequalities and monotonicity in various intervals, and
+`Trigonometric.Basic` for even even simpler inequalities and monotonicity results.
+
+## Tags
+
+sin, cos
+-/
+
+open Set
+open scoped Real
+
+/-- Double the range of a `Finset.sum` -/
+lemma Finset.sum_range_even {M : Type*} [AddCommMonoid M] (n : ℕ) (f : ℕ → M) :
+    ∑ k ∈ Finset.range n, f k = ∑ k ∈ Finset.range (2 * n), if Even k then f (k / 2) else 0 := by
+  induction' n with n h
+  · simp
+  · simp [Finset.sum_range_succ, h, mul_add]
+
+lemma Complex.sin_series_bound {z : ℂ} (z1 : ‖z‖ ≤ 1) (n : ℕ) :
+    ‖sin z - z * ∑ k ∈ Finset.range n, (-1) ^ k * z ^ (2 * k) / (2 * k + 1).factorial‖ ≤
+      ‖z‖ ^ (2 * n + 1) * ((2 * n + 2) / ((2 * n + 1).factorial * (2 * n + 1))) := by
+  have e : z * ∑ k ∈ Finset.range n, (-1) ^ k * z ^ (2 * k) / (2 * k + 1).factorial =
+      (∑ k ∈ Finset.range (2 * n + 1), (-z * I) ^ k / k.factorial -
+       ∑ k ∈ Finset.range (2 * n + 1), (z * I) ^ k / k.factorial) * I / 2 := by
+    simp only [← Finset.sum_sub_distrib, ← sub_div, Finset.sum_range_even n, Finset.sum_div,
+      Finset.mul_sum, Finset.sum_mul]
+    simp only [Finset.sum_range_succ', pow_zero, Nat.factorial_zero, sub_self, zero_div, add_zero,
+      zero_mul]
+    refine Finset.sum_congr rfl fun k _ ↦ ?_
+    rcases Nat.even_or_odd' k with ⟨a, e | e⟩
+    · simp only [e, even_two, Even.mul_right, ↓reduceIte, ne_eq, OfNat.ofNat_ne_zero,
+      not_false_eq_true, mul_div_cancel_left₀, pow_mul, pow_succ', pow_zero, mul_one, mul_pow,
+      neg_mul, mul_neg, neg_neg]
+      ring_nf
+      simp only [mul_comm _ 2, pow_mul, I_sq, mul_neg]
+      simp only [neg_mul, neg_neg, mul_one]
+    · simp [e, pow_mul, pow_add, mul_pow]
+  have r : ∀ a b c d : ℂ, (a - b) - (c - d) = (a - c) - (b - d) := fun _ _ _ _ ↦ by ring
+  rw [sin, e, ← sub_div, ← sub_mul, r, norm_div, Complex.norm_two, div_le_iff₀ (by norm_num),
+    norm_mul, Complex.norm_I, mul_one]
+  refine le_trans (norm_sub_le _ _) ?_
+  refine le_trans (add_le_add (Complex.exp_bound (x := -z * I) (by simpa) (by omega))
+    (Complex.exp_bound (x := z * I) (by simpa) (by omega))) (le_of_eq ?_)
+  simp only [norm_mul, Complex.norm_I, norm_neg, Nat.succ_eq_add_one,
+    Nat.cast_add, Nat.cast_mul]
+  ring_nf
+
+lemma Complex.cos_series_bound {z : ℂ} (z1 : ‖z‖ ≤ 1) {n : ℕ} (n0 : 0 < n) :
+    ‖cos z - ∑ k ∈ Finset.range n, (-1) ^ k * z ^ (2 * k) / (2 * k).factorial‖ ≤
+      ‖z‖ ^ (2 * n) * ((2 * n + 1) / ((2 * n).factorial * (2 * n))) := by
+  have e : ∑ k ∈ Finset.range n, (-1) ^ k * z ^ (2 * k) / (2 * k).factorial =
+      (∑ k ∈ Finset.range (2 * n), (z * I) ^ k / k.factorial +
+       ∑ k ∈ Finset.range (2 * n), (-z * I) ^ k / k.factorial) / 2 := by
+    simp only [← Finset.sum_add_distrib, Finset.sum_range_even n, Finset.sum_div]
+    refine Finset.sum_congr rfl fun k _ ↦ ?_
+    rcases Nat.even_or_odd' k with ⟨a, e | e⟩
+    · simp only [e, even_two, Even.mul_right, ↓reduceIte, ne_eq, OfNat.ofNat_ne_zero,
+        not_false_eq_true, mul_div_cancel_left₀, pow_mul, mul_pow, I_sq, mul_neg, mul_one, neg_mul,
+        Even.neg_pow, ← add_div, neg_pow' (z^2), mul_comm _ ((-1 : ℂ) ^ a), ← add_mul]
+      ring
+    · simp [e, pow_mul, pow_add, mul_pow, neg_div]
+  have r : ∀ a b c d : ℂ, (a + b) - (c + d) = (a - c) + (b - d) := fun _ _ _ _ ↦ by ring
+  rw [cos, e, ← sub_div, r, norm_div, Complex.norm_two, div_le_iff₀ (by norm_num)]
+  refine le_trans (norm_add_le _ _) ?_
+  refine le_trans (add_le_add (Complex.exp_bound (x := z * I) (by simpa) (by omega))
+    (Complex.exp_bound (x := -z * I) (by simpa) (by omega))) (le_of_eq ?_)
+  simp only [norm_mul, Complex.norm_I, norm_neg, Nat.succ_eq_add_one,
+    Nat.cast_add, Nat.cast_mul]
+  ring_nf
+
+lemma Real.sin_series_bound {x : ℝ} (x1 : |x| ≤ 1) (n : ℕ) :
+    |sin x - x * ∑ k ∈ Finset.range n, (-1) ^ k * x ^ (2 * k) / (2 * k + 1).factorial| ≤
+      |x| ^ (2 * n + 1) * ((2 * n + 2) / ((2 * n + 1).factorial * (2 * n + 1))) := by
+  have b := Complex.sin_series_bound (z := x) (by simpa only [Complex.norm_real]) n
+  simp only [← Complex.ofReal_sin, ← Complex.ofReal_pow, ← Complex.ofReal_one,
+    ← Complex.ofReal_neg, ← Complex.ofReal_mul, ← Complex.ofReal_natCast, ← Complex.ofReal_div,
+    ← Complex.ofReal_sum, ← Complex.ofReal_sub, Complex.norm_real] at b
+  exact b
+
+lemma Real.cos_series_bound {x : ℝ} (x1 : |x| ≤ 1) {n : ℕ} (n0 : 0 < n) :
+    |cos x - ∑ k ∈ Finset.range n, (-1) ^ k * x ^ (2 * k) / (2 * k).factorial| ≤
+      |x| ^ (2 * n) * ((2 * n + 1) / ((2 * n).factorial * (2 * n))) := by
+  have b := Complex.cos_series_bound (z := x) (by simpa only [Complex.norm_real]) n0
+  simp only [← Complex.ofReal_cos, ← Complex.ofReal_pow, ← Complex.ofReal_one,
+    ← Complex.ofReal_neg, ← Complex.ofReal_mul, ← Complex.ofReal_natCast, ← Complex.ofReal_div,
+    ← Complex.ofReal_sum, ← Complex.ofReal_sub, Complex.norm_real] at b
+  exact b

--- a/Mathlib/Analysis/SpecialFunctions/Trigonometric/SeriesBounds.lean
+++ b/Mathlib/Analysis/SpecialFunctions/Trigonometric/SeriesBounds.lean
@@ -16,7 +16,7 @@ import Mathlib.Analysis.Complex.Trigonometric
 We prove Taylor series bounds with optimal remainder for `sin` and `cos`, over both `ℂ` and `ℝ`.
 See `Mathlib/Analysis/SpecialFunctions/Trigonometric/Bounds.lean` for simpler inequalities and
 monotonicity in various intervals, and `Mathlib/Analysis/SpecialFunctions/Trigonometric/Basic.lean`
-for even even simpler inequalities and monotonicity results.
+for even simpler inequalities and monotonicity results.
 
 ## Tags
 

--- a/Mathlib/Analysis/SpecialFunctions/Trigonometric/SeriesBounds.lean
+++ b/Mathlib/Analysis/SpecialFunctions/Trigonometric/SeriesBounds.lean
@@ -26,13 +26,6 @@ sin, cos
 open Set
 open scoped Real
 
-/-- Double the range of a `Finset.sum` -/
-lemma Finset.sum_range_even {M : Type*} [AddCommMonoid M] (n : ℕ) (f : ℕ → M) :
-    ∑ k ∈ Finset.range n, f k = ∑ k ∈ Finset.range (2 * n), if Even k then f (k / 2) else 0 := by
-  induction n with
-  | zero => simp
-  | succ n h => simp [Finset.sum_range_succ, h, mul_add]
-
 lemma Complex.sin_series_bound {z : ℂ} (z1 : ‖z‖ ≤ 1) (n : ℕ) :
     ‖sin z - z * ∑ k ∈ Finset.range n, (-1) ^ k * z ^ (2 * k) / (2 * k + 1).factorial‖ ≤
       ‖z‖ ^ (2 * n + 1) * ((2 * n + 2) / ((2 * n + 1).factorial * (2 * n + 1))) := by

--- a/Mathlib/Analysis/SpecialFunctions/Trigonometric/SeriesBounds.lean
+++ b/Mathlib/Analysis/SpecialFunctions/Trigonometric/SeriesBounds.lean
@@ -14,8 +14,9 @@ import Mathlib.Analysis.Complex.Trigonometric
 ## Main statements
 
 We prove Taylor series bounds with optimal remainder for `sin` and `cos`, over both `ℂ` and `ℝ`.
-See `Trigonometric.Bounds` for simpler inequalities and monotonicity in various intervals, and
-`Trigonometric.Basic` for even even simpler inequalities and monotonicity results.
+See `Mathlib/Analysis/SpecialFunctions/Trigonometric/Bounds.lean` for simpler inequalities and
+monotonicity in various intervals, and `Mathlib/Analysis/SpecialFunctions/Trigonometric/Basic.lean`
+for even even simpler inequalities and monotonicity results.
 
 ## Tags
 
@@ -45,8 +46,8 @@ lemma Complex.sin_series_bound {z : ℂ} (z1 : ‖z‖ ≤ 1) (n : ℕ) :
     refine Finset.sum_congr rfl fun k _ ↦ ?_
     rcases Nat.even_or_odd' k with ⟨a, e | e⟩
     · simp only [e, even_two, Even.mul_right, ↓reduceIte, ne_eq, OfNat.ofNat_ne_zero,
-      not_false_eq_true, mul_div_cancel_left₀, pow_mul, pow_succ', pow_zero, mul_one, mul_pow,
-      neg_mul, mul_neg, neg_neg]
+        not_false_eq_true, mul_div_cancel_left₀, pow_mul, pow_succ', pow_zero, mul_one, mul_pow,
+        neg_mul, mul_neg, neg_neg]
       ring_nf
       simp only [mul_comm _ 2, pow_mul, I_sq, mul_neg]
       simp only [neg_mul, neg_neg, mul_one]
@@ -72,7 +73,7 @@ lemma Complex.cos_series_bound {z : ℂ} (z1 : ‖z‖ ≤ 1) {n : ℕ} (n0 : 0 
     rcases Nat.even_or_odd' k with ⟨a, e | e⟩
     · simp only [e, even_two, Even.mul_right, ↓reduceIte, ne_eq, OfNat.ofNat_ne_zero,
         not_false_eq_true, mul_div_cancel_left₀, pow_mul, mul_pow, I_sq, mul_neg, mul_one, neg_mul,
-        Even.neg_pow, ← add_div, neg_pow' (z^2), mul_comm _ ((-1 : ℂ) ^ a), ← add_mul]
+        Even.neg_pow, ← add_div, neg_pow' (z ^ 2), mul_comm _ ((-1 : ℂ) ^ a), ← add_mul]
       ring
     · simp [e, pow_mul, pow_add, mul_pow, neg_div]
   have r : ∀ a b c d : ℂ, (a + b) - (c + d) = (a - c) + (b - d) := fun _ _ _ _ ↦ by ring
@@ -97,7 +98,4 @@ lemma Real.cos_series_bound {x : ℝ} (x1 : |x| ≤ 1) {n : ℕ} (n0 : 0 < n) :
     |cos x - ∑ k ∈ Finset.range n, (-1) ^ k * x ^ (2 * k) / (2 * k).factorial| ≤
       |x| ^ (2 * n) * ((2 * n + 1) / ((2 * n).factorial * (2 * n))) := by
   have b := Complex.cos_series_bound (z := x) (by simpa only [Complex.norm_real]) n0
-  simp only [← Complex.ofReal_cos, ← Complex.ofReal_pow, ← Complex.ofReal_one,
-    ← Complex.ofReal_neg, ← Complex.ofReal_mul, ← Complex.ofReal_natCast, ← Complex.ofReal_div,
-    ← Complex.ofReal_sum, ← Complex.ofReal_sub, Complex.norm_real] at b
-  exact b
+  convert b <;> norm_cast

--- a/Mathlib/Analysis/SpecialFunctions/Trigonometric/SeriesBounds.lean
+++ b/Mathlib/Analysis/SpecialFunctions/Trigonometric/SeriesBounds.lean
@@ -80,10 +80,7 @@ lemma Real.sin_series_bound {x : ℝ} (x1 : |x| ≤ 1) (n : ℕ) :
     |sin x - x * ∑ k ∈ Finset.range n, (-1) ^ k * x ^ (2 * k) / (2 * k + 1).factorial| ≤
       |x| ^ (2 * n + 1) * ((2 * n + 2) / ((2 * n + 1).factorial * (2 * n + 1))) := by
   have b := Complex.sin_series_bound (z := x) (by simpa only [Complex.norm_real]) n
-  simp only [← Complex.ofReal_sin, ← Complex.ofReal_pow, ← Complex.ofReal_one,
-    ← Complex.ofReal_neg, ← Complex.ofReal_mul, ← Complex.ofReal_natCast, ← Complex.ofReal_div,
-    ← Complex.ofReal_sum, ← Complex.ofReal_sub, Complex.norm_real] at b
-  exact b
+  convert b <;> norm_cast
 
 lemma Real.cos_series_bound {x : ℝ} (x1 : |x| ≤ 1) {n : ℕ} (n0 : 0 < n) :
     |cos x - ∑ k ∈ Finset.range n, (-1) ^ k * x ^ (2 * k) / (2 * k).factorial| ≤

--- a/Mathlib/Analysis/SpecialFunctions/Trigonometric/SeriesBounds.lean
+++ b/Mathlib/Analysis/SpecialFunctions/Trigonometric/SeriesBounds.lean
@@ -29,9 +29,9 @@ open scoped Real
 /-- Double the range of a `Finset.sum` -/
 lemma Finset.sum_range_even {M : Type*} [AddCommMonoid M] (n : ℕ) (f : ℕ → M) :
     ∑ k ∈ Finset.range n, f k = ∑ k ∈ Finset.range (2 * n), if Even k then f (k / 2) else 0 := by
-  induction' n with n h
-  · simp
-  · simp [Finset.sum_range_succ, h, mul_add]
+  induction n with
+  | zero => simp
+  | succ n h => simp [Finset.sum_range_succ, h, mul_add]
 
 lemma Complex.sin_series_bound {z : ℂ} (z1 : ‖z‖ ≤ 1) (n : ℕ) :
     ‖sin z - z * ∑ k ∈ Finset.range n, (-1) ^ k * z ^ (2 * k) / (2 * k + 1).factorial‖ ≤
@@ -52,9 +52,8 @@ lemma Complex.sin_series_bound {z : ℂ} (z1 : ‖z‖ ≤ 1) (n : ℕ) :
       simp only [mul_comm _ 2, pow_mul, I_sq, mul_neg]
       simp only [neg_mul, neg_neg, mul_one]
     · simp [e, pow_mul, pow_add, mul_pow]
-  have r : ∀ a b c d : ℂ, (a - b) - (c - d) = (a - c) - (b - d) := fun _ _ _ _ ↦ by ring
-  rw [sin, e, ← sub_div, ← sub_mul, r, norm_div, Complex.norm_two, div_le_iff₀ (by norm_num),
-    norm_mul, Complex.norm_I, mul_one]
+  rw [sin, e, ← sub_div, ← sub_mul, sub_sub_sub_comm, norm_div, Complex.norm_two,
+    div_le_iff₀ (by norm_num), norm_mul, Complex.norm_I, mul_one]
   refine le_trans (norm_sub_le _ _) ?_
   refine le_trans (add_le_add (Complex.exp_bound (x := -z * I) (by simpa) (by omega))
     (Complex.exp_bound (x := z * I) (by simpa) (by omega))) (le_of_eq ?_)
@@ -76,8 +75,7 @@ lemma Complex.cos_series_bound {z : ℂ} (z1 : ‖z‖ ≤ 1) {n : ℕ} (n0 : 0 
         Even.neg_pow, ← add_div, neg_pow' (z ^ 2), mul_comm _ ((-1 : ℂ) ^ a), ← add_mul]
       ring
     · simp [e, pow_mul, pow_add, mul_pow, neg_div]
-  have r : ∀ a b c d : ℂ, (a + b) - (c + d) = (a - c) + (b - d) := fun _ _ _ _ ↦ by ring
-  rw [cos, e, ← sub_div, r, norm_div, Complex.norm_two, div_le_iff₀ (by norm_num)]
+  rw [cos, e, ← sub_div, add_sub_add_comm, norm_div, Complex.norm_two, div_le_iff₀ (by norm_num)]
   refine le_trans (norm_add_le _ _) ?_
   refine le_trans (add_le_add (Complex.exp_bound (x := z * I) (by simpa) (by omega))
     (Complex.exp_bound (x := -z * I) (by simpa) (by omega))) (le_of_eq ?_)


### PR DESCRIPTION
Zulip discussion here:

  https://leanprover.zulipchat.com/#narrow/channel/217875-Is-there-code-for-X.3F/topic/Better.20.60Real.2Esin.60.20bounds/near/535035576

We also include the full set of intervals on which sin and cos are monotone/antitone.

---

Questions to resolve as part of review:

1. I've left the `Finset.sum_range_even` in the new `SeriesBounds` file, but presumably it should go somewhere else (unless you want me to inline it, but that seems worse).
2. Is putting the new Taylor series bounds in a new `SeriesBounds` file right, or should it go in the current `Bounds.lean` file? When I started writing the PR I thought the new bounds would need more imports via more analysis, but it turns out the only new import needed would be `Mathlib.Algebra.BigOperators.Field` which seems lightweight. I am happy with whatever the preference is in terms of file structure.

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
