### PR TITLE
[Merged by Bors] - chore(Tactic.MoveAdd): deprecate Expr.size

### DIFF
--- a/Mathlib/Tactic/MoveAdd.lean
+++ b/Mathlib/Tactic/MoveAdd.lean
@@ -114,8 +114,8 @@ def Lean.Expr.getExprInputs : Expr → Array Expr
   | _ => #[]
 
 /-- `size e` returns the number of subexpressions of `e`. -/
-partial
-def Lean.Expr.size (e : Expr) : ℕ := (e.getExprInputs.map size).foldl (· + ·) 1
+@[deprecated Lean.Expr.sizeWithoutSharing (since := "2025-09-04")]
+partial def Lean.Expr.size (e : Expr) : ℕ := (e.getExprInputs.map size).foldl (· + ·) 1
 
 namespace Mathlib.MoveAdd
 
@@ -286,7 +286,7 @@ def rankSums (tgt : Expr) (instructions : List (Expr × Bool)) : MetaM (List (Ex
     let resummed := sumList (prepareOp sum) left_assoc? reord
     if (resummed != sum) then some (sum, resummed) else none
   return (candidates.toList.reduceOption.toArray.qsort
-    (fun x y : Expr × Expr ↦ (y.1.size  ≤ x.1.size))).toList
+    (fun x y : Expr × Expr ↦ (y.1.sizeWithoutSharing  ≤ x.1.sizeWithoutSharing))).toList
 
 /-- `permuteExpr op tgt instructions` takes the same input as `rankSums` and returns the
 expression obtained from `tgt` by replacing all `old_sum`s by the corresponding `new_sum`.


### PR DESCRIPTION
Deprecate `Lean.Expr.size`. It is equivalent to `Lean.Expr.sizeWithoutSharing`, but slower because it constructs an intermediate array.

---

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
