### PR TITLE
[Merged by Bors] - chore(Data/Multiset): repair markdown link by removing line break

### DIFF
--- a/Mathlib/Data/Multiset/DershowitzManna.lean
+++ b/Mathlib/Data/Multiset/DershowitzManna.lean
@@ -24,8 +24,7 @@ the Dershowitz-Manna ordering defined over multisets is also well-founded.
 
 ## References
 
-* [Wikipedia, Dershowitz–Manna ordering*]
-(https://en.wikipedia.org/wiki/Dershowitz%E2%80%93Manna_ordering)
+* [Wikipedia, Dershowitz–Manna ordering](https://en.wikipedia.org/wiki/Dershowitz%E2%80%93Manna_ordering)
 
 * [CoLoR](https://github.com/fblanqui/color), a Coq library on rewriting theory and termination.
   Our code here is inspired by their formalization and the theorem is called `mOrd_wf` in the file


### PR DESCRIPTION
repair markdown link by removing line break

---

I guess a "too long" line is tolerated when it is due to  URL?