### PR TITLE
chore(Analysis/RCLike/Basic): split file

### DIFF
--- a/Mathlib.lean
+++ b/Mathlib.lean
@@ -1889,8 +1889,11 @@ import Mathlib.Analysis.Polynomial.CauchyBound
 import Mathlib.Analysis.Quaternion
 import Mathlib.Analysis.RCLike.Basic
 import Mathlib.Analysis.RCLike.BoundedContinuous
+import Mathlib.Analysis.RCLike.ContinuousLinearMap
 import Mathlib.Analysis.RCLike.Inner
 import Mathlib.Analysis.RCLike.Lemmas
+import Mathlib.Analysis.RCLike.Order
+import Mathlib.Analysis.RCLike.Real
 import Mathlib.Analysis.RCLike.TangentCone
 import Mathlib.Analysis.Real.Cardinality
 import Mathlib.Analysis.Real.Hyperreal

--- a/Mathlib.lean
+++ b/Mathlib.lean
@@ -1821,6 +1821,7 @@ import Mathlib.Analysis.Normed.Operator.Mul
 import Mathlib.Analysis.Normed.Operator.NNNorm
 import Mathlib.Analysis.Normed.Operator.NormedSpace
 import Mathlib.Analysis.Normed.Operator.Prod
+import Mathlib.Analysis.Normed.Operator.Star
 import Mathlib.Analysis.Normed.Order.Basic
 import Mathlib.Analysis.Normed.Order.Hom.Basic
 import Mathlib.Analysis.Normed.Order.Hom.Ultra

--- a/Mathlib/Analysis/CStarAlgebra/Basic.lean
+++ b/Mathlib/Analysis/CStarAlgebra/Basic.lean
@@ -5,7 +5,6 @@ Authors: Frédéric Dupuis
 -/
 import Mathlib.Analysis.Normed.Group.Hom
 import Mathlib.Analysis.Normed.Module.Basic
-import Mathlib.Analysis.Normed.Operator.LinearIsometry
 import Mathlib.Algebra.Star.Pi
 import Mathlib.Algebra.Star.SelfAdjoint
 import Mathlib.Algebra.Star.Subalgebra
@@ -31,6 +30,8 @@ Note that the type classes corresponding to C⋆-algebras are defined in
   definition of C*-algebras in some sources (e.g. Wikipedia).
 
 -/
+
+assert_not_exists ContinuousLinearMap.bound
 
 open Topology
 
@@ -251,33 +252,6 @@ theorem IsSelfAdjoint.nnnorm_pow_two_pow [NormedRing E] [StarRing E] [CStarRing 
 theorem selfAdjoint.nnnorm_pow_two_pow [NormedRing E] [StarRing E] [CStarRing E] (x : selfAdjoint E)
     (n : ℕ) : ‖x ^ 2 ^ n‖₊ = ‖x‖₊ ^ 2 ^ n :=
   x.prop.nnnorm_pow_two_pow _
-
-section starₗᵢ
-
-variable [CommSemiring 𝕜] [StarRing 𝕜]
-variable [SeminormedAddCommGroup E] [StarAddMonoid E] [NormedStarGroup E]
-variable [Module 𝕜 E] [StarModule 𝕜 E]
-
-variable (𝕜) in
-/-- `star` bundled as a linear isometric equivalence -/
-def starₗᵢ : E ≃ₗᵢ⋆[𝕜] E :=
-  { starAddEquiv with
-    map_smul' := star_smul
-    norm_map' := norm_star }
-
-@[simp]
-theorem coe_starₗᵢ : (starₗᵢ 𝕜 : E → E) = star :=
-  rfl
-
-theorem starₗᵢ_apply {x : E} : starₗᵢ 𝕜 x = star x :=
-  rfl
-
-@[simp]
-theorem starₗᵢ_toContinuousLinearEquiv :
-    (starₗᵢ 𝕜 : E ≃ₗᵢ⋆[𝕜] E).toContinuousLinearEquiv = (starL 𝕜 : E ≃L⋆[𝕜] E) :=
-  ContinuousLinearEquiv.ext rfl
-
-end starₗᵢ
 
 namespace StarSubalgebra
 

--- a/Mathlib/Analysis/Normed/Operator/Star.lean
+++ b/Mathlib/Analysis/Normed/Operator/Star.lean
@@ -1,0 +1,37 @@
+/-
+Copyright (c) 2021 Frédéric Dupuis. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Frédéric Dupuis
+-/
+import Mathlib.Analysis.CStarAlgebra.Basic
+import Mathlib.Analysis.Normed.Operator.LinearIsometry
+
+/-! `star` as a linear isometry -/
+
+section starₗᵢ
+
+variable {𝕜 E : Type*}
+variable [CommSemiring 𝕜] [StarRing 𝕜]
+variable [SeminormedAddCommGroup E] [StarAddMonoid E] [NormedStarGroup E]
+variable [Module 𝕜 E] [StarModule 𝕜 E]
+
+variable (𝕜) in
+/-- `star` bundled as a linear isometric equivalence -/
+def starₗᵢ : E ≃ₗᵢ⋆[𝕜] E :=
+  { starAddEquiv with
+    map_smul' := star_smul
+    norm_map' := norm_star }
+
+@[simp]
+theorem coe_starₗᵢ : (starₗᵢ 𝕜 : E → E) = star :=
+  rfl
+
+theorem starₗᵢ_apply {x : E} : starₗᵢ 𝕜 x = star x :=
+  rfl
+
+@[simp]
+theorem starₗᵢ_toContinuousLinearEquiv :
+    (starₗᵢ 𝕜 : E ≃ₗᵢ⋆[𝕜] E).toContinuousLinearEquiv = (starL 𝕜 : E ≃L⋆[𝕜] E) :=
+  ContinuousLinearEquiv.ext rfl
+
+end starₗᵢ

--- a/Mathlib/Analysis/RCLike/Basic.lean
+++ b/Mathlib/Analysis/RCLike/Basic.lean
@@ -24,7 +24,7 @@ complex case. One typically produces the definitions and proof for an arbitrary 
 typeclass, which basically amounts to doing the complex case, and the two cases then fall out
 immediately from the two instances of the class.
 
-The instance for `ℝ` is registered in this file.
+The instance for `ℝ` is registered in `Mathlib/Analysis/RCLike/Real.lean`.
 The instance for `ℂ` is declared in `Mathlib/Analysis/Complex/Basic.lean`.
 
 ## Implementation notes

--- a/Mathlib/Analysis/RCLike/ContinuousLinearMap.lean
+++ b/Mathlib/Analysis/RCLike/ContinuousLinearMap.lean
@@ -1,0 +1,111 @@
+import Mathlib.Analysis.RCLike.Basic
+
+
+/-- The real part in an `RCLike` field, as a continuous linear map. -/
+noncomputable def reCLM : StrongDual ℝ K :=
+  reLm.mkContinuous 1 fun x => by
+    rw [one_mul]
+    exact abs_re_le_norm x
+
+@[simp, rclike_simps, norm_cast]
+theorem reCLM_coe : ((reCLM : StrongDual ℝ K) : K →ₗ[ℝ] ℝ) = reLm :=
+  rfl
+
+@[simp, rclike_simps]
+theorem reCLM_apply : ((reCLM : StrongDual ℝ K) : K → ℝ) = re :=
+  rfl
+
+@[continuity, fun_prop]
+theorem continuous_re : Continuous (re : K → ℝ) :=
+  reCLM.continuous
+
+/-- The imaginary part in an `RCLike` field, as a continuous linear map. -/
+noncomputable def imCLM : StrongDual ℝ K :=
+  imLm.mkContinuous 1 fun x => by
+    rw [one_mul]
+    exact abs_im_le_norm x
+
+@[simp, rclike_simps, norm_cast]
+theorem imCLM_coe : ((imCLM : StrongDual ℝ K) : K →ₗ[ℝ] ℝ) = imLm :=
+  rfl
+
+@[simp, rclike_simps]
+theorem imCLM_apply : ((imCLM : StrongDual ℝ K) : K → ℝ) = im :=
+  rfl
+
+@[continuity, fun_prop]
+theorem continuous_im : Continuous (im : K → ℝ) :=
+  imCLM.continuous
+
+/-- Conjugate as a linear isometry -/
+noncomputable def conjLIE : K ≃ₗᵢ[ℝ] K :=
+  ⟨conjAe.toLinearEquiv, norm_conj⟩
+
+@[simp, rclike_simps]
+theorem conjLIE_apply : (conjLIE : K → K) = conj :=
+  rfl
+
+/-- Conjugate as a continuous linear equivalence -/
+noncomputable def conjCLE : K ≃L[ℝ] K :=
+  @conjLIE K _
+
+@[simp, rclike_simps]
+theorem conjCLE_coe : (@conjCLE K _).toLinearEquiv = conjAe.toLinearEquiv :=
+  rfl
+
+@[simp, rclike_simps]
+theorem conjCLE_apply : (conjCLE : K → K) = conj :=
+  rfl
+
+instance (priority := 100) : ContinuousStar K :=
+  ⟨conjLIE.continuous⟩
+
+@[continuity, fun_prop]
+theorem continuous_conj : Continuous (conj : K → K) :=
+  continuous_star
+
+/-- The ℝ → K coercion, as a linear isometry -/
+noncomputable def ofRealLI : ℝ →ₗᵢ[ℝ] K where
+  toLinearMap := ofRealAm.toLinearMap
+  norm_map' := norm_ofReal
+
+@[simp, rclike_simps]
+theorem ofRealLI_apply : (ofRealLI : ℝ → K) = ofReal :=
+  rfl
+
+/-- The `ℝ → K` coercion, as a continuous linear map -/
+noncomputable def ofRealCLM : ℝ →L[ℝ] K :=
+  ofRealLI.toContinuousLinearMap
+
+@[simp, rclike_simps]
+theorem ofRealCLM_coe : (@ofRealCLM K _ : ℝ →ₗ[ℝ] K) = ofRealAm.toLinearMap :=
+  rfl
+
+@[simp, rclike_simps]
+theorem ofRealCLM_apply : (ofRealCLM : ℝ → K) = ofReal :=
+  rfl
+
+@[continuity, fun_prop]
+theorem continuous_ofReal : Continuous (ofReal : ℝ → K) :=
+  ofRealLI.continuous
+
+@[continuity]
+theorem continuous_normSq : Continuous (normSq : K → ℝ) :=
+  (continuous_re.mul continuous_re).add (continuous_im.mul continuous_im)
+
+theorem lipschitzWith_ofReal : LipschitzWith 1 (ofReal : ℝ → K) :=
+  ofRealLI.lipschitz
+
+lemma lipschitzWith_re : LipschitzWith 1 (re (K := K)) := by
+  intro x y
+  simp only [ENNReal.coe_one, one_mul, edist_eq_enorm_sub]
+  calc ‖re x - re y‖ₑ
+  _ = ‖re (x - y)‖ₑ := by rw [ AddMonoidHom.map_sub re x y]
+  _ ≤ ‖x - y‖ₑ := by rw [enorm_le_iff_norm_le]; exact norm_re_le_norm (x - y)
+
+lemma lipschitzWith_im : LipschitzWith 1 (im (K := K)) := by
+  intro x y
+  simp only [ENNReal.coe_one, one_mul, edist_eq_enorm_sub]
+  calc ‖im x - im y‖ₑ
+  _ = ‖im (x - y)‖ₑ := by rw [ AddMonoidHom.map_sub im x y]
+  _ ≤ ‖x - y‖ₑ := by rw [enorm_le_iff_norm_le]; exact norm_im_le_norm (x - y)

--- a/Mathlib/Analysis/RCLike/Order.lean
+++ b/Mathlib/Analysis/RCLike/Order.lean
@@ -1,0 +1,222 @@
+import Mathlib.Analysis.RCLike.Basic
+
+
+variable {K : Type*} [RCLike K]
+
+
+/-- With `z ≤ w` iff `w - z` is real and nonnegative, `ℝ` and `ℂ` are star ordered rings.
+(That is, a star ring in which the nonnegative elements are those of the form `star z * z`.)
+
+Note this is only an instance with `open scoped ComplexOrder`. -/
+lemma toStarOrderedRing : StarOrderedRing K :=
+  StarOrderedRing.of_nonneg_iff'
+    (h_add := fun {x y} hxy z => by
+      rw [RCLike.le_iff_re_im] at *
+      simpa [map_add, add_le_add_iff_left, add_right_inj] using hxy)
+    (h_nonneg_iff := fun x => by
+      rw [nonneg_iff]
+      refine ⟨fun h ↦ ⟨√(re x), by simp [ext_iff (K := K), h.1, h.2]⟩, ?_⟩
+      rintro ⟨s, rfl⟩
+      simp [mul_comm, mul_self_nonneg, add_nonneg])
+
+scoped[ComplexOrder] attribute [instance] RCLike.toStarOrderedRing
+
+lemma toZeroLEOneClass : ZeroLEOneClass K where
+  zero_le_one := by simp [@RCLike.le_iff_re_im K]
+
+scoped[ComplexOrder] attribute [instance] RCLike.toZeroLEOneClass
+
+lemma toIsOrderedAddMonoid : IsOrderedAddMonoid K where
+  add_le_add_left _ _ := add_le_add_left
+
+scoped[ComplexOrder] attribute [instance] RCLike.toIsOrderedAddMonoid
+
+/-- With `z ≤ w` iff `w - z` is real and nonnegative, `ℝ` and `ℂ` are strictly ordered rings.
+
+Note this is only an instance with `open scoped ComplexOrder`. -/
+lemma toIsStrictOrderedRing : IsStrictOrderedRing K :=
+  .of_mul_pos fun z w hz hw ↦ by
+    rw [lt_iff_re_im, map_zero] at hz hw ⊢
+    simp [mul_re, mul_im, ← hz.2, ← hw.2, mul_pos hz.1 hw.1]
+
+scoped[ComplexOrder] attribute [instance] RCLike.toIsStrictOrderedRing
+
+lemma toPosMulReflectLT : PosMulReflectLT K where
+  elim := by
+    rintro ⟨x, hx⟩ y z hyz
+    dsimp at *
+    rw [RCLike.le_iff_re_im, map_zero, map_zero, eq_comm] at hx
+    obtain ⟨r, rfl⟩ := ((is_real_TFAE x).out 3 1).1 hx.2
+    simp only [RCLike.lt_iff_re_im (K := K), mul_re, ofReal_re, ofReal_im, zero_mul, sub_zero,
+      mul_im, add_zero, mul_eq_mul_left_iff] at hyz ⊢
+    refine ⟨lt_of_mul_lt_mul_of_nonneg_left hyz.1 <| by simpa using hx, hyz.2.resolve_right ?_⟩
+    rintro rfl
+    simp at hyz
+
+scoped[ComplexOrder] attribute [instance] RCLike.toPosMulReflectLT
+
+theorem toOrderedSMul : OrderedSMul ℝ K :=
+  OrderedSMul.mk' fun a b r hab hr => by
+    replace hab := hab.le
+    rw [RCLike.le_iff_re_im] at hab
+    rw [RCLike.le_iff_re_im, smul_re, smul_re, smul_im, smul_im]
+    exact hab.imp (fun h => mul_le_mul_of_nonneg_left h hr.le) (congr_arg _)
+
+scoped[ComplexOrder] attribute [instance] RCLike.toOrderedSMul
+
+/-- A star algebra over `K` has a scalar multiplication that respects the order. -/
+lemma _root_.StarModule.instOrderedSMul {A : Type*} [NonUnitalRing A] [StarRing A] [PartialOrder A]
+    [StarOrderedRing A] [Module K A] [StarModule K A] [IsScalarTower K A A] [SMulCommClass K A A] :
+    OrderedSMul K A := .mk' fun _a _b _zc hab hc ↦ (smul_lt_smul_of_pos_left hab hc).le
+
+instance {A : Type*} [NonUnitalRing A] [StarRing A] [PartialOrder A] [StarOrderedRing A]
+    [Module ℝ A] [StarModule ℝ A] [IsScalarTower ℝ A A] [SMulCommClass ℝ A A] :
+    OrderedSMul ℝ A :=
+  StarModule.instOrderedSMul
+
+scoped[ComplexOrder] attribute [instance] StarModule.instOrderedSMul
+
+theorem ofReal_mul_pos_iff (x : ℝ) (z : K) :
+    0 < x * z ↔ (x < 0 ∧ z < 0) ∨ (0 < x ∧ 0 < z) := by
+  simp only [pos_iff (K := K), neg_iff (K := K), re_ofReal_mul, im_ofReal_mul]
+  obtain hx | hx | hx := lt_trichotomy x 0
+  · simp only [mul_pos_iff, not_lt_of_gt hx, false_and, hx, true_and, false_or, mul_eq_zero, hx.ne,
+      or_false]
+  · simp only [hx, zero_mul, lt_self_iff_false, false_and, false_or]
+  · simp only [mul_pos_iff, hx, true_and, not_lt_of_gt hx, false_and, or_false, mul_eq_zero,
+      hx.ne', false_or]
+
+theorem ofReal_mul_neg_iff (x : ℝ) (z : K) :
+    x * z < 0 ↔ (x < 0 ∧ 0 < z) ∨ (0 < x ∧ z < 0) := by
+  simpa only [mul_neg, neg_pos, neg_neg_iff_pos] using ofReal_mul_pos_iff x (-z)
+
+lemma instPosMulReflectLE : PosMulReflectLE K where
+  elim a b c h := by
+    obtain ⟨a', ha1, ha2⟩ := pos_iff_exists_ofReal.mp a.2
+    rw [← sub_nonneg]
+    #adaptation_note /-- 2025-03-29 need beta reduce for lean4#7717 -/
+    beta_reduce at h
+    rw [← ha2, ← sub_nonneg, ← mul_sub, le_iff_lt_or_eq] at h
+    rcases h with h | h
+    · rw [ofReal_mul_pos_iff] at h
+      exact le_of_lt <| h.rec (False.elim <| not_lt_of_gt ·.1 ha1) (·.2)
+    · exact ((mul_eq_zero_iff_left <| ofReal_ne_zero.mpr ha1.ne').mp h.symm).ge
+
+scoped[ComplexOrder] attribute [instance] RCLike.instPosMulReflectLE
+
+section Order
+
+open scoped ComplexOrder
+variable {z w : K}
+
+theorem lt_iff_re_im : z < w ↔ re z < re w ∧ im z = im w := by
+  simp_rw [lt_iff_le_and_ne, @RCLike.le_iff_re_im K]
+  constructor
+  · rintro ⟨⟨hr, hi⟩, heq⟩
+    exact ⟨⟨hr, mt (fun hreq => ext hreq hi) heq⟩, hi⟩
+  · rintro ⟨⟨hr, hrn⟩, hi⟩
+    exact ⟨⟨hr, hi⟩, ne_of_apply_ne _ hrn⟩
+
+theorem nonneg_iff : 0 ≤ z ↔ 0 ≤ re z ∧ im z = 0 := by
+  simpa only [map_zero, eq_comm] using le_iff_re_im (z := 0) (w := z)
+
+theorem pos_iff : 0 < z ↔ 0 < re z ∧ im z = 0 := by
+  simpa only [map_zero, eq_comm] using lt_iff_re_im (z := 0) (w := z)
+
+theorem nonpos_iff : z ≤ 0 ↔ re z ≤ 0 ∧ im z = 0 := by
+  simpa only [map_zero] using le_iff_re_im (z := z) (w := 0)
+
+theorem neg_iff : z < 0 ↔ re z < 0 ∧ im z = 0 := by
+  simpa only [map_zero] using lt_iff_re_im (z := z) (w := 0)
+
+lemma nonneg_iff_exists_ofReal : 0 ≤ z ↔ ∃ x ≥ (0 : ℝ), x = z := by
+  simp_rw [nonneg_iff (K := K), ext_iff (K := K)]; aesop
+
+lemma pos_iff_exists_ofReal : 0 < z ↔ ∃ x > (0 : ℝ), x = z := by
+  simp_rw [pos_iff (K := K), ext_iff (K := K)]; aesop
+
+lemma nonpos_iff_exists_ofReal : z ≤ 0 ↔ ∃ x ≤ (0 : ℝ), x = z := by
+  simp_rw [nonpos_iff (K := K), ext_iff (K := K)]; aesop
+
+lemma neg_iff_exists_ofReal : z < 0 ↔ ∃ x < (0 : ℝ), x = z := by
+  simp_rw [neg_iff (K := K), ext_iff (K := K)]; aesop
+
+@[simp, norm_cast]
+lemma ofReal_le_ofReal {x y : ℝ} : (x : K) ≤ (y : K) ↔ x ≤ y := by
+  rw [le_iff_re_im]
+  simp
+
+@[simp, norm_cast]
+lemma ofReal_lt_ofReal {x y : ℝ} : (x : K) < (y : K) ↔ x < y := by
+  rw [lt_iff_re_im]
+  simp
+
+@[simp, norm_cast]
+lemma ofReal_nonneg {x : ℝ} : 0 ≤ (x : K) ↔ 0 ≤ x := by
+  rw [← ofReal_zero, ofReal_le_ofReal]
+
+@[simp, norm_cast]
+lemma ofReal_nonpos {x : ℝ} : (x : K) ≤ 0 ↔ x ≤ 0 := by
+  rw [← ofReal_zero, ofReal_le_ofReal]
+
+@[simp, norm_cast]
+lemma ofReal_pos {x : ℝ} : 0 < (x : K) ↔ 0 < x := by
+  rw [← ofReal_zero, ofReal_lt_ofReal]
+
+@[simp, norm_cast]
+lemma ofReal_lt_zero {x : ℝ} : (x : K) < 0 ↔ x < 0 := by
+  rw [← ofReal_zero, ofReal_lt_ofReal]
+
+lemma norm_le_re_iff_eq_norm {z : K} :
+    ‖z‖ ≤ re z ↔ z = ‖z‖ := by
+  refine ⟨fun h ↦ ?_, fun h ↦ ?_⟩
+  · have h' : ‖z‖ = re z := (le_antisymm (re_le_norm z) h).symm
+    rw [h', re_eq_self_of_le h]
+  · rw [h]
+    simp
+
+lemma re_le_neg_norm_iff_eq_neg_norm {z : K} :
+    re z ≤ -‖z‖ ↔ z = -‖z‖ := by
+  simpa [neg_eq_iff_eq_neg, le_neg] using norm_le_re_iff_eq_norm (z := -z)
+
+lemma norm_of_nonneg' {x : K} (hx : 0 ≤ x) : ‖x‖ = x := by
+  rw [eq_comm, ← norm_le_re_iff_eq_norm, ← sqrt_normSq_eq_norm, normSq_apply]
+  simp [nonneg_iff.mp hx]
+
+lemma re_nonneg_of_nonneg {x : K} (hx : IsSelfAdjoint x) : 0 ≤ re x ↔ 0 ≤ x := by
+  simp [nonneg_iff (K := K), conj_eq_iff_im.mp hx]
+
+@[gcongr]
+lemma re_le_re {x y : K} (h : x ≤ y) : re x ≤ re y := by
+  rw [RCLike.le_iff_re_im] at h
+  exact h.1
+
+lemma re_monotone : Monotone (re : K → ℝ) :=
+  fun _ _ => re_le_re
+
+protected lemma inv_pos_of_pos (hz : 0 < z) : 0 < z⁻¹ := by
+  rw [pos_iff_exists_ofReal] at hz
+  obtain ⟨x, hx, hx'⟩ := hz
+  rw [← hx', ← ofReal_inv, ofReal_pos]
+  exact inv_pos_of_pos hx
+
+protected lemma inv_pos : 0 < z⁻¹ ↔ 0 < z := by
+  refine ⟨fun h => ?_, fun h => RCLike.inv_pos_of_pos h⟩
+  rw [← inv_inv z]
+  exact RCLike.inv_pos_of_pos h
+
+
+lemma norm_le_im_iff_eq_I_mul_norm {z : K} :
+    ‖z‖ ≤ im z ↔ z = I * ‖z‖ := by
+  obtain (h | h) := I_eq_zero_or_im_I_eq_one (K := K)
+  · simp [h, im_eq_zero]
+  · have : (I : K) ≠ 0 := fun _ ↦ by simp_all
+    rw [← mul_right_inj' (neg_ne_zero.mpr this)]
+    convert norm_le_re_iff_eq_norm (z := -I * z) using 2
+    all_goals simp [neg_mul, ← mul_assoc, I_mul_I_of_nonzero this, norm_I_of_ne_zero this]
+
+lemma im_le_neg_norm_iff_eq_neg_I_mul_norm {z : K} :
+    im z ≤ -‖z‖ ↔ z = -(I * ‖z‖) := by
+  simpa [neg_eq_iff_eq_neg, le_neg] using norm_le_im_iff_eq_I_mul_norm (z := -z)
+
+end Order

--- a/Mathlib/Analysis/RCLike/Real.lean
+++ b/Mathlib/Analysis/RCLike/Real.lean
@@ -1,0 +1,106 @@
+import Mathlib.Analysis.RCLike.Basic
+import Mathlib.Data.Real.Star
+
+open scoped ComplexConjugate
+
+variable {K : Type*} [RCLike K]
+
+namespace RCLike
+
+section Instances
+
+instance (priority := 100) : CStarRing K where
+  norm_mul_self_le x := le_of_eq <| ((norm_mul _ _).trans <| congr_arg (· * ‖x‖) (norm_conj _)).symm
+
+instance : StarModule ℝ K where
+  star_smul r a := by
+    apply RCLike.ext <;> simp [RCLike.smul_re, RCLike.smul_im]
+
+noncomputable instance Real.instRCLike : RCLike ℝ where
+  re := AddMonoidHom.id ℝ
+  im := 0
+  I := 0
+  I_re_ax := by simp only [AddMonoidHom.map_zero]
+  I_mul_I_ax := Or.intro_left _ rfl
+  re_add_im_ax z := by
+    simp only [add_zero, mul_zero, Algebra.algebraMap_self, RingHom.id_apply, AddMonoidHom.id_apply]
+  ofReal_re_ax _ := rfl
+  ofReal_im_ax _ := rfl
+  mul_re_ax z w := by simp only [sub_zero, mul_zero, AddMonoidHom.zero_apply, AddMonoidHom.id_apply]
+  mul_im_ax z w := by simp only [add_zero, zero_mul, mul_zero, AddMonoidHom.zero_apply]
+  conj_re_ax z := by simp only [starRingEnd_apply, star_id_of_comm]
+  conj_im_ax _ := by simp only [neg_zero, AddMonoidHom.zero_apply]
+  conj_I_ax := by simp only [RingHom.map_zero, neg_zero]
+  norm_sq_eq_def_ax z := by simp only [sq, Real.norm_eq_abs, ← abs_mul, abs_mul_self z, add_zero,
+    mul_zero, AddMonoidHom.zero_apply, AddMonoidHom.id_apply]
+  mul_im_I_ax _ := by simp only [mul_zero, AddMonoidHom.zero_apply]
+  le_iff_re_im := (and_iff_left rfl).symm
+
+end Instances
+
+
+section CleanupLemmas
+
+local notation "reR" => @RCLike.re ℝ _
+local notation "imR" => @RCLike.im ℝ _
+local notation "IR" => @RCLike.I ℝ _
+local notation "normSqR" => @RCLike.normSq ℝ _
+
+@[simp, rclike_simps]
+theorem re_to_real {x : ℝ} : reR x = x :=
+  rfl
+
+@[simp, rclike_simps]
+theorem im_to_real {x : ℝ} : imR x = 0 :=
+  rfl
+
+@[rclike_simps]
+theorem conj_to_real {x : ℝ} : conj x = x :=
+  rfl
+
+@[simp, rclike_simps]
+theorem I_to_real : IR = 0 :=
+  rfl
+
+@[simp, rclike_simps]
+theorem normSq_to_real {x : ℝ} : normSq x = x * x := by simp [RCLike.normSq]
+
+@[simp]
+theorem ofReal_real_eq_id : @ofReal ℝ _ = id :=
+  rfl
+
+end CleanupLemmas
+
+
+/-!
+### ℝ-dependent results
+
+Here we gather results that depend on whether `K` is `ℝ`.
+-/
+section CaseSpecific
+
+lemma im_eq_zero (h : I = (0 : K)) (z : K) : im z = 0 := by
+  rw [← re_add_im z, h]
+  simp
+
+/-- The natural isomorphism between `𝕜` satisfying `RCLike 𝕜` and `ℝ` when `RCLike.I = 0`. -/
+@[simps]
+def realRingEquiv (h : I = (0 : K)) : K ≃+* ℝ where
+  toFun := re
+  invFun := (↑)
+  left_inv x := by nth_rw 2 [← re_add_im x]; simp [h]
+  right_inv := ofReal_re
+  map_add' := map_add re
+  map_mul' := by simp [im_eq_zero h]
+
+/-- The natural `ℝ`-linear isometry equivalence between `𝕜` satisfying `RCLike 𝕜` and `ℝ` when
+`RCLike.I = 0`. -/
+@[simps]
+noncomputable def realLinearIsometryEquiv (h : I = (0 : K)) : K ≃ₗᵢ[ℝ] ℝ where
+  map_smul' := smul_re
+  norm_map' z := by rw [← re_add_im z]; simp [- re_add_im, h]
+  __ := realRingEquiv h
+
+end CaseSpecific
+
+end RCLike

--- a/Mathlib/Analysis/RCLike/Real.lean
+++ b/Mathlib/Analysis/RCLike/Real.lean
@@ -1,5 +1,18 @@
+/-
+Copyright (c) 2020 Frédéric Dupuis. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Frédéric Dupuis
+-/
+import Mathlib.Analysis.CStarAlgebra.Basic
 import Mathlib.Analysis.RCLike.Basic
 import Mathlib.Data.Real.Star
+
+/-!
+# `ℝ` is an `RCLike` field
+
+This contains the instance of `RCLike ℝ` as well as some convenience lemmas about `RCLike` specific
+to the case `K := ℝ`.
+-/
 
 open scoped ComplexConjugate
 
@@ -9,6 +22,8 @@ namespace RCLike
 
 section Instances
 
+-- should we move this elsewhere, especially since we have reduced the imports of
+-- `CStarAlgebra.Basic`?
 instance (priority := 100) : CStarRing K where
   norm_mul_self_le x := le_of_eq <| ((norm_mul _ _).trans <| congr_arg (· * ‖x‖) (norm_conj _)).symm
 
@@ -92,14 +107,6 @@ def realRingEquiv (h : I = (0 : K)) : K ≃+* ℝ where
   right_inv := ofReal_re
   map_add' := map_add re
   map_mul' := by simp [im_eq_zero h]
-
-/-- The natural `ℝ`-linear isometry equivalence between `𝕜` satisfying `RCLike 𝕜` and `ℝ` when
-`RCLike.I = 0`. -/
-@[simps]
-noncomputable def realLinearIsometryEquiv (h : I = (0 : K)) : K ≃ₗᵢ[ℝ] ℝ where
-  map_smul' := smul_re
-  norm_map' z := by rw [← re_add_im z]; simp [- re_add_im, h]
-  __ := realRingEquiv h
 
 end CaseSpecific
 


### PR DESCRIPTION
This splits the basic file about `RCLike` into a few pieces:

1. `Basic`: keep definitions and basic properties
2. `Real`: the instance `RCLike ℝ`.
3. `Order`: for properties using the `ComplexOrder` scope
4. `ContinuousLinearMap`: for bundled isometries and continuous linear maps between `ℝ` and `K`.

The main purpose of this is to avoid importing `Analysis/Normed/Operator/Basic` just to talk about `RCLike`.

---
- [ ] depends on: #29370

<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include at least one commit authored by each
co-author among the commits in the pull request. If necessary, you may 
create empty commits to indicate co-authorship, using commands like so:

git commit --author="Author Name <author@email.com>" --allow-empty -m "add Author Name as coauthor"

When merging, all the commits will be squashed into a single commit listing all co-authors.

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
