### PR TITLE
[Merged by Bors] - doc(ModelTheory): clarify free and (in-scope) bound variables in `BoundedFormula`

### DIFF
--- a/Mathlib/ModelTheory/Semantics.lean
+++ b/Mathlib/ModelTheory/Semantics.lean
@@ -34,11 +34,8 @@ in a style inspired by the [Flypitch project](https://flypitch.github.io/).
 
 ## Implementation Notes
 
-- Formulas use a modified version of de Bruijn variables. Specifically, a `L.BoundedFormula α n`
-  is a formula with some variables indexed by a type `α`, which cannot be quantified over, and some
-  indexed by `Fin n`, which can. For any `φ : L.BoundedFormula α (n + 1)`, we define the formula
-  `∀' φ : L.BoundedFormula α n` by universally quantifying over the variable indexed by
-  `n : Fin (n + 1)`.
+- `BoundedFormula` uses a locally nameless representation with bound variables as well-scoped de
+  Bruijn levels. See the implementation note in `Syntax.lean` for details.
 
 ## References
 
@@ -231,7 +228,8 @@ namespace BoundedFormula
 
 open Term
 
-/-- A bounded formula can be evaluated as true or false by giving values to each free variable. -/
+/-- A bounded formula can be evaluated as true or false by giving values to each free and bound
+variable. -/
 def Realize : ∀ {l} (_f : L.BoundedFormula α l) (_v : α → M) (_xs : Fin l → M), Prop
   | _, falsum, _v, _xs => False
   | _, equal t₁ t₂, v, xs => t₁.realize (Sum.elim v xs) = t₂.realize (Sum.elim v xs)

--- a/Mathlib/ModelTheory/Syntax.lean
+++ b/Mathlib/ModelTheory/Syntax.lean
@@ -26,9 +26,9 @@ This file defines first-order terms, formulas, sentences, and theories in a styl
   `FirstOrder.Language.BoundedFormula.relabel`, and `FirstOrder.Language.Formula.relabel`.
 - Given an operation on terms and an operation on relations,
   `FirstOrder.Language.BoundedFormula.mapTermRel` gives an operation on formulas.
-- `FirstOrder.Language.BoundedFormula.castLE` adds more `Fin`-indexed variables.
-- `FirstOrder.Language.BoundedFormula.liftAt` raises the indexes of the `Fin`-indexed variables
-  above a particular index.
+- `FirstOrder.Language.BoundedFormula.castLE` adds more bound variables.
+- `FirstOrder.Language.BoundedFormula.liftAt` raises the indexes of the bound variables above a
+  particular index.
 - `FirstOrder.Language.Term.subst` and `FirstOrder.Language.BoundedFormula.subst` substitute
   variables with given terms.
 - `FirstOrder.Language.Term.substFunc` instead substitutes function definitions with given terms.
@@ -36,15 +36,16 @@ This file defines first-order terms, formulas, sentences, and theories in a styl
   `FirstOrder.Language.LHom.onFormula`.
 - `FirstOrder.Language.Term.constantsVarsEquiv` and
   `FirstOrder.Language.BoundedFormula.constantsVarsEquiv` switch terms and formulas between having
-  constants in the language and having extra variables indexed by the same type.
+  constants in the language and having extra free variables indexed by the same type.
 
 ## Implementation Notes
 
-- Formulas use a modified version of de Bruijn variables. Specifically, a `L.BoundedFormula α n`
-  is a formula with some variables indexed by a type `α`, which cannot be quantified over, and some
-  indexed by `Fin n`, which can. For any `φ : L.BoundedFormula α (n + 1)`, we define the formula
-  `∀' φ : L.BoundedFormula α n` by universally quantifying over the variable indexed by
-  `n : Fin (n + 1)`.
+- `BoundedFormula` uses a locally nameless representation with bound variables as well-scoped de
+  Bruijn levels (the variable bounded by the outermost quantifier is indexed by `0`). Specifically,
+  a `L.BoundedFormula α n` is a formula with free variables indexed by a type `α`, which cannot be
+  quantified over, and bound variables indexed by `Fin n`, which can. For any
+  `φ : L.BoundedFormula α (n + 1)`, we define the formula `∀' φ : L.BoundedFormula α n` by
+  universally quantifying over the variable indexed by `n : Fin (n + 1)`.
 
 ## References
 
@@ -69,8 +70,8 @@ open FirstOrder
 
 open Structure Fin
 
-/-- A term on `α` is either a variable indexed by an element of `α`
-  or a function symbol applied to simpler terms. -/
+/-- A term on `α` is either a variable indexed by an element of `α` or a function symbol applied to
+simpler terms. -/
 inductive Term (α : Type u') : Type max u u'
   | var : α → Term α
   | func : ∀ {l : ℕ} (_f : L.Functions l) (_ts : Fin l → Term α), Term α
@@ -256,7 +257,7 @@ theorem substFunc_term (t : L.Term α) : t.substFunc Functions.term = t := by
 
 end Term
 
-/-- `&n` is notation for the `n`-th free variable of a bounded formula. -/
+/-- `&n` is notation for the bound variable indexed by `n` in a bounded formula. -/
 scoped[FirstOrder] prefix:arg "&" => FirstOrder.Language.Term.var ∘ Sum.inr
 
 namespace LHom
@@ -301,18 +302,19 @@ def LEquiv.onTerm (φ : L ≃ᴸ L') : L.Term α ≃ L'.Term α where
 
 variable (L) (α)
 
-/-- `BoundedFormula α n` is the type of formulas with free variables indexed by `α` and up to `n`
-  additional free variables. -/
+/-- `BoundedFormula α n` is the type of formulas with free variables indexed by `α` and `n` in-scope
+bound variables indexed by `Fin n`. -/
 inductive BoundedFormula : ℕ → Type max u v u'
   | falsum {n} : BoundedFormula n
   | equal {n} (t₁ t₂ : L.Term (α ⊕ (Fin n))) : BoundedFormula n
   | rel {n l : ℕ} (R : L.Relations l) (ts : Fin l → L.Term (α ⊕ (Fin n))) : BoundedFormula n
-  /-- The implication between two bounded formulas -/
+  /-- The implication between two bounded formulas. -/
   | imp {n} (f₁ f₂ : BoundedFormula n) : BoundedFormula n
-  /-- The universal quantifier over bounded formulas -/
+  /-- The universal quantifier over bounded formulas. -/
   | all {n} (f : BoundedFormula (n + 1)) : BoundedFormula n
 
-/-- `Formula α` is the type of formulas with all free variables indexed by `α`. -/
+/-- `Formula α` is the type of formulas with free variables indexed by `α` and no bound variables in
+scope. -/
 abbrev Formula :=
   L.BoundedFormula α 0
 
@@ -345,7 +347,7 @@ def Relations.boundedFormula₂ (r : L.Relations 2) (t₁ t₂ : L.Term (α ⊕ 
 def Term.bdEqual (t₁ t₂ : L.Term (α ⊕ (Fin n))) : L.BoundedFormula α n :=
   BoundedFormula.equal t₁ t₂
 
-/-- Applies a relation to terms as a bounded formula. -/
+/-- Applies a relation to terms as a formula. -/
 def Relations.formula (R : L.Relations n) (ts : Fin n → L.Term α) : L.Formula α :=
   R.boundedFormula fun i => (ts i).relabel Sum.inl
 
@@ -394,7 +396,7 @@ protected def iff (φ ψ : L.BoundedFormula α n) :=
 
 open Finset
 
-/-- The `Finset` of variables used in a given formula. -/
+/-- The `Finset` of free variables used in a given formula. -/
 @[simp]
 def freeVarFinset [DecidableEq α] : ∀ {n}, L.BoundedFormula α n → Finset α
   | _n, falsum => ∅
@@ -459,12 +461,12 @@ def restrictFreeVar [DecidableEq α] :
       (φ₂.restrictFreeVar (f ∘ Set.inclusion subset_union_right))
   | _n, all φ, f => (φ.restrictFreeVar f).all
 
-/-- Places universal quantifiers on all extra variables of a bounded formula. -/
+/-- Places universal quantifiers on all in-scope bound variables of a bounded formula. -/
 def alls : ∀ {n}, L.BoundedFormula α n → L.Formula α
   | 0, φ => φ
   | _n + 1, φ => φ.all.alls
 
-/-- Places existential quantifiers on all extra variables of a bounded formula. -/
+/-- Places existential quantifiers on all in-scope bound variables of a bounded formula. -/
 def exs : ∀ {n}, L.BoundedFormula α n → L.Formula α
   | 0, φ => φ
   | _n + 1, φ => φ.ex.exs
@@ -480,7 +482,7 @@ def mapTermRel {g : ℕ → ℕ} (ft : ∀ n, L.Term (α ⊕ (Fin n)) → L'.Ter
   | _n, imp φ₁ φ₂ => (φ₁.mapTermRel ft fr h).imp (φ₂.mapTermRel ft fr h)
   | n, all φ => (h n (φ.mapTermRel ft fr h)).all
 
-/-- Raises all of the `Fin`-indexed variables of a formula greater than or equal to `m` by `n'`. -/
+/-- Raises all of the bound variables of a formula greater than or equal to `m` by `n'`. -/
 def liftAt : ∀ {n : ℕ} (n' _m : ℕ), L.BoundedFormula α n → L.BoundedFormula α (n + n') :=
   fun {_} n' m φ =>
   φ.mapTermRel (fun _ t => t.liftAt n' m) (fun _ => id) fun _ =>
@@ -589,16 +591,17 @@ theorem relabel_sumInl (φ : L.BoundedFormula α n) :
   | imp _ _ ih1 ih2 => simp_all [mapTermRel]
   | all _ ih3 => simp_all [mapTermRel]
 
-/-- Substitutes the variables in a given formula with terms. -/
+/-- Substitutes the free variables in a bounded formula with terms, leaving bound variables
+unchanged. -/
 def subst {n : ℕ} (φ : L.BoundedFormula α n) (f : α → L.Term β) : L.BoundedFormula β n :=
   φ.mapTermRel (fun _ t => t.subst (Sum.elim (Term.relabel Sum.inl ∘ f) (var ∘ Sum.inr)))
     (fun _ => id) fun _ => id
 
-/-- A bijection sending formulas with constants to formulas with extra variables. -/
+/-- A bijection sending formulas with constants to formulas with extra free variables. -/
 def constantsVarsEquiv : L[[γ]].BoundedFormula α n ≃ L.BoundedFormula (γ ⊕ α) n :=
   mapTermRelEquiv (fun _ => Term.constantsVarsEquivLeft) fun _ => Equiv.sumEmpty _ _
 
-/-- Turns the extra variables of a bounded formula into free variables. -/
+/-- Turns all the in-scope bound variables into free variables. -/
 @[simp]
 def toFormula : ∀ {n : ℕ}, L.BoundedFormula α n → L.Formula (α ⊕ (Fin n))
   | _n, falsum => falsum


### PR DESCRIPTION
The current design of `BoundedFormula` is actually a locally nameless representation. Following PL convention, we should call the `α` indexed variables as free variables, and the `Fin n` indexed variables as (in-scope) bound variables.

Also clarify that the bound variables are actually de Bruijn levels.

Some references:
- <https://jesper.sikanda.be/posts/1001-syntax-representations.html>
- [Locally nameless in CSLib](https://github.com/leanprover/cslib/blob/4734d98a80d82e8bb15cbb64b6cfaa30c08691a8/Cslib/Languages/LambdaCalculus/LocallyNameless/Untyped/Basic.lean)
- [Locally nameless in Lean core](https://github.com/leanprover/lean4/blob/540e9e85f3317d04133aa2a69d5a24fb31e92d8b/src/Lean/Expr.lean#L238)

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include at least one commit authored by each
co-author among the commits in the pull request. If necessary, you may 
create empty commits to indicate co-authorship, using commands like so:

git commit --author="Author Name <author@email.com>" --allow-empty -m "add Author Name as coauthor"

When merging, all the commits will be squashed into a single commit listing all co-authors.

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
