### PR TITLE
[Merged by Bors] - chore(CategoryTheory/Limits): remove four uses of `erw` in `colimit{Coyoneda,Yoneda}HomIsoLimit{,'}_π_apply`

### DIFF
--- a/Mathlib/CategoryTheory/Limits/IndYoneda.lean
+++ b/Mathlib/CategoryTheory/Limits/IndYoneda.lean
@@ -154,7 +154,6 @@ lemma colimitCoyonedaHomIsoLimit_π_apply (f : colimit (D.rightOp ⋙ coyoneda) 
     HasLimit.isoOfNatIso_hom_π]
   rw [← Category.assoc, colimitHomIsoLimitYoneda_hom_comp_π]
   dsimp [coyonedaLemma, types_comp_apply]
-  erw [coyonedaEquiv_comp, coyonedaEquiv_apply]
   rfl
 
 end ProCoyonedaContravariant
@@ -207,7 +206,6 @@ lemma colimitYonedaHomIsoLimit_π_apply (f : colimit (D.unop ⋙ yoneda) ⟶ F) 
   simp only [colimitYonedaHomIsoLimit, Iso.trans_hom, Category.assoc, HasLimit.isoOfNatIso_hom_π]
   rw [← Category.assoc, colimitHomIsoLimitYoneda_hom_comp_π]
   dsimp [yonedaLemma]
-  erw [yonedaEquiv_comp, yonedaEquiv_apply]
   rfl
 
 end IndYonedaCovariant
@@ -258,7 +256,6 @@ lemma colimitCoyonedaHomIsoLimit'_π_apply (f : colimit (D.op ⋙ coyoneda) ⟶ 
   simp only [colimitCoyonedaHomIsoLimit', Iso.trans_hom, Category.assoc, HasLimit.isoOfNatIso_hom_π]
   rw [← Category.assoc, colimitHomIsoLimitYoneda'_hom_comp_π]
   dsimp [coyonedaLemma]
-  erw [coyonedaEquiv_comp, coyonedaEquiv_apply]
   rfl
 
 end ProCoyonedaCovariant
@@ -310,7 +307,6 @@ lemma colimitYonedaHomIsoLimit'_π_apply (f : colimit (D.leftOp ⋙ yoneda) ⟶ 
   simp only [colimitYonedaHomIsoLimit', Iso.trans_hom, Category.assoc, HasLimit.isoOfNatIso_hom_π]
   rw [← Category.assoc, colimitHomIsoLimitYoneda'_hom_comp_π]
   dsimp [yonedaLemma]
-  erw [yonedaEquiv_comp, yonedaEquiv_apply]
   rfl
 
 end IndYonedaContravariant


### PR DESCRIPTION
---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include at least one commit authored by each
co-author among the commits in the pull request. If necessary, you may 
create empty commits to indicate co-authorship, using commands like so:

git commit --author="Author Name <author@email.com>" --allow-empty -m "add Author Name as coauthor"

When merging, all the commits will be squashed into a single commit listing all co-authors.

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
