### PR TITLE
[Merged by Bors] - chore: remove `CanonicallyOrderedAddCommMonoid`

### DIFF
--- a/Mathlib/Algebra/Order/BigOperators/Group/Finset.lean
+++ b/Mathlib/Algebra/Order/BigOperators/Group/Finset.lean
@@ -371,10 +371,16 @@ See also `Finset.single_le_prod'`. -/
 @[to_additive /-- In a canonically-ordered additive monoid, a sum bounds each of its terms.
 
 See also `Finset.single_le_sum`. -/]
-lemma _root_.CanonicallyOrderedCommMonoid.single_le_prod {i : ι} (hi : i ∈ s) :
+lemma single_le_prod_of_canonicallyOrdered {i : ι} (hi : i ∈ s) :
     f i ≤ ∏ j ∈ s, f j :=
   have := CanonicallyOrderedMul.toIsOrderedMonoid (α := M)
   single_le_prod' (fun _ _ ↦ one_le _) hi
+
+@[deprecated (since := "2025-09-06")]
+alias _root_.CanonicallyOrderedCommMonoid.single_le_prod := single_le_prod_of_canonicallyOrdered
+
+@[deprecated (since := "2025-09-06")]
+alias _root_.CanonicallyOrderedAddCommMonoid.single_le_sum := single_le_sum_of_canonicallyOrdered
 
 @[to_additive sum_le_sum_of_subset]
 theorem prod_le_prod_of_subset' (h : s ⊆ t) : ∏ x ∈ s, f x ≤ ∏ x ∈ t, f x :=

--- a/Mathlib/Algebra/Order/Field/Canonical.lean
+++ b/Mathlib/Algebra/Order/Field/Canonical.lean
@@ -3,7 +3,7 @@ Copyright (c) 2014 Robert Y. Lewis. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Robert Y. Lewis, Leonardo de Moura, Mario Carneiro, Floris van Doorn
 -/
-import Mathlib.Algebra.Order.Field.Defs
+import Mathlib.Algebra.Field.Defs
 import Mathlib.Algebra.Order.GroupWithZero.Canonical
 import Mathlib.Algebra.Order.Ring.Canonical
 

--- a/Mathlib/Algebra/Order/Field/Canonical.lean
+++ b/Mathlib/Algebra/Order/Field/Canonical.lean
@@ -11,16 +11,6 @@ import Mathlib.Algebra.Order.Ring.Canonical
 # Canonically ordered semifields
 -/
 
-set_option linter.deprecated false in
-/-- A canonically linear ordered field is a linear ordered field in which `a ≤ b` iff there exists
-`c` with `b = a + c`. -/
-@[deprecated "Use `[LinearOrderedSemifield α] [CanonicallyOrderedAdd α]` instead."
-  (since := "2025-01-13")]
-structure CanonicallyLinearOrderedSemifield (α : Type*) extends CanonicallyOrderedCommSemiring α,
-  LinearOrderedSemifield α
-
-attribute [nolint docBlame] CanonicallyLinearOrderedSemifield.toLinearOrderedSemifield
-
 variable {α : Type*} [Semifield α] [LinearOrder α] [CanonicallyOrderedAdd α]
 
 -- See note [reducible non-instances]

--- a/Mathlib/Algebra/Order/Monoid/Canonical/Defs.lean
+++ b/Mathlib/Algebra/Order/Monoid/Canonical/Defs.lean
@@ -45,41 +45,6 @@ class CanonicallyOrderedMul (α : Type*) [Mul α] [LE α] : Prop
 
 attribute [instance 50] CanonicallyOrderedMul.toExistsMulOfLE
 
-set_option linter.deprecated false in
-/-- A canonically ordered additive monoid is an ordered commutative additive monoid
-  in which the ordering coincides with the subtractibility relation,
-  which is to say, `a ≤ b` iff there exists `c` with `b = a + c`.
-  This is satisfied by the natural numbers, for example, but not
-  the integers or other nontrivial `OrderedAddCommGroup`s. -/
-@[deprecated "Use `[OrderedAddCommMonoid α] [CanonicallyOrderedAdd α]` instead."
-  (since := "2025-01-13")]
-structure CanonicallyOrderedAddCommMonoid (α : Type*) extends
-    OrderedAddCommMonoid α, OrderBot α where
-  /-- For `a ≤ b`, there is a `c` so `b = a + c`. -/
-  protected exists_add_of_le : ∀ {a b : α}, a ≤ b → ∃ c, b = a + c
-  /-- For any `a` and `b`, `a ≤ a + b` -/
-  protected le_self_add : ∀ a b : α, a ≤ a + b
-
-set_option linter.deprecated false in
-set_option linter.existingAttributeWarning false in
-/-- A canonically ordered monoid is an ordered commutative monoid
-  in which the ordering coincides with the divisibility relation,
-  which is to say, `a ≤ b` iff there exists `c` with `b = a * c`.
-  Examples seem rare; it seems more likely that the `OrderDual`
-  of a naturally-occurring lattice satisfies this than the lattice
-  itself (for example, dual of the lattice of ideals of a PID or
-  Dedekind domain satisfy this; collections of all things ≤ 1 seem to
-  be more natural that collections of all things ≥ 1).
--/
-@[to_additive,
-  deprecated "Use `[OrderedCommMonoid α] [CanonicallyOrderedMul α]` instead."
-  (since := "2025-01-13")]
-structure CanonicallyOrderedCommMonoid (α : Type*) extends OrderedCommMonoid α, OrderBot α where
-  /-- For `a ≤ b`, there is a `c` so `b = a * c`. -/
-  protected exists_mul_of_le : ∀ {a b : α}, a ≤ b → ∃ c, b = a * c
-  /-- For any `a` and `b`, `a ≤ a * b` -/
-  protected le_self_mul : ∀ a b : α, a ≤ a * b
-
 section Mul
 variable [Mul α]
 
@@ -314,27 +279,6 @@ theorem of_ge {M} [AddZeroClass M] [PartialOrder M] [CanonicallyOrderedAdd M]
   of_pos <| lt_of_lt_of_le (pos x) h
 
 end NeZero
-
-set_option linter.deprecated false in
-/-- A canonically linear-ordered additive monoid is a canonically ordered additive monoid
-whose ordering is a linear order. -/
-@[deprecated "Use `[LinearOrderedAddCommMonoid α] [CanonicallyOrderedAdd α]` instead."
-  (since := "2025-01-13")]
-structure CanonicallyLinearOrderedAddCommMonoid (α : Type*)
-  extends CanonicallyOrderedAddCommMonoid α, LinearOrderedAddCommMonoid α
-
-set_option linter.deprecated false in
-set_option linter.existingAttributeWarning false in
-/-- A canonically linear-ordered monoid is a canonically ordered monoid
-whose ordering is a linear order. -/
-@[to_additive,
-  deprecated "Use `[LinearOrderedCommMonoid α] [CanonicallyOrderedMul α]` instead."
-  (since := "2025-01-13")]
-structure CanonicallyLinearOrderedCommMonoid (α : Type*)
-  extends CanonicallyOrderedCommMonoid α, LinearOrderedCommMonoid α
-
-attribute [nolint docBlame] CanonicallyLinearOrderedAddCommMonoid.toLinearOrderedAddCommMonoid
-attribute [nolint docBlame] CanonicallyLinearOrderedCommMonoid.toLinearOrderedCommMonoid
 
 section CanonicallyLinearOrderedCommMonoid
 

--- a/Mathlib/Algebra/Order/Ring/Canonical.lean
+++ b/Mathlib/Algebra/Order/Ring/Canonical.lean
@@ -19,19 +19,6 @@ universe u
 
 variable {R : Type u}
 
-set_option linter.deprecated false in
-/-- A canonically ordered commutative semiring is an ordered, commutative semiring in which `a ≤ b`
-iff there exists `c` with `b = a + c`. This is satisfied by the natural numbers, for example, but
-not the integers or other ordered groups. -/
-@[deprecated "Use `[OrderedCommSemiring R] [CanonicallyOrderedAdd R] [NoZeroDivisors R]` instead."
-  (since := "2025-01-13")]
-structure CanonicallyOrderedCommSemiring (R : Type*) extends CanonicallyOrderedAddCommMonoid R,
-    CommSemiring R where
-  /-- No zero divisors. -/
-  protected eq_zero_or_eq_zero_of_mul_eq_zero : ∀ {a b : R}, a * b = 0 → a = 0 ∨ b = 0
-
-attribute [nolint docBlame] CanonicallyOrderedCommSemiring.toCommSemiring
-
 -- see Note [lower instance priority]
 instance (priority := 10) CanonicallyOrderedAdd.toZeroLEOneClass
     [AddZeroClass R] [One R] [LE R] [CanonicallyOrderedAdd R] : ZeroLEOneClass R where

--- a/Mathlib/Data/Finsupp/Weight.lean
+++ b/Mathlib/Data/Finsupp/Weight.lean
@@ -229,7 +229,7 @@ theorem le_degree {R : Type*}
     (s : σ) (f : σ →₀ R) :
     f s ≤ degree f := by
   by_cases h : s ∈ f.support
-  · exact CanonicallyOrderedAddCommMonoid.single_le_sum h
+  · exact Finset.single_le_sum_of_canonicallyOrderedm h
   · simp only [notMem_support_iff] at h
     simp only [h, zero_le]
 

--- a/Mathlib/Data/Finsupp/Weight.lean
+++ b/Mathlib/Data/Finsupp/Weight.lean
@@ -229,7 +229,7 @@ theorem le_degree {R : Type*}
     (s : σ) (f : σ →₀ R) :
     f s ≤ degree f := by
   by_cases h : s ∈ f.support
-  · exact Finset.single_le_sum_of_canonicallyOrderedm h
+  · exact Finset.single_le_sum_of_canonicallyOrdered h
   · simp only [notMem_support_iff] at h
     simp only [h, zero_le]
 


### PR DESCRIPTION
This is a 6+ month old deprecation. I want to modify `CanonicallyOrderedAdd` in #29084, and it would neither make much sense to leave these deprecated classes as is, nor would it make sense to update them.

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include at least one commit authored by each
co-author among the commits in the pull request. If necessary, you may 
create empty commits to indicate co-authorship, using commands like so:

git commit --author="Author Name <author@email.com>" --allow-empty -m "add Author Name as coauthor"

When merging, all the commits will be squashed into a single commit listing all co-authors.

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
