### PR TITLE
[Merged by Bors] - chore(Tactic): process three porting notes

### DIFF
--- a/Mathlib/Tactic/ApplyFun.lean
+++ b/Mathlib/Tactic/ApplyFun.lean
@@ -12,8 +12,9 @@ import Mathlib.Order.Hom.Basic
 
 Apply a function to an equality or inequality in either a local hypothesis or the goal.
 
-## Porting notes
-When the `mono` tactic has been ported we can attempt to automatically discharge `Monotone f` goals.
+## Future work
+
+Using the `mono` tactic, we can attempt to automatically discharge `Monotone f` goals.
 -/
 
 namespace Mathlib.Tactic

--- a/Mathlib/Tactic/Attr/Core.lean
+++ b/Mathlib/Tactic/Attr/Core.lean
@@ -17,7 +17,6 @@ attribute [simp] id_map'
 attribute [functor_norm, monad_norm] seq_assoc pure_seq pure_bind bind_assoc bind_pure map_pure
 attribute [monad_norm] seq_eq_bind_map
 
--- Porting note: changed some `iff` lemmas to `eq` lemmas
 attribute [mfld_simps] id and_true true_and Function.comp_apply and_self eq_self not_false
   true_or or_true heq_eq_eq forall_const and_imp
 

--- a/Mathlib/Tactic/CategoryTheory/Slice.lean
+++ b/Mathlib/Tactic/CategoryTheory/Slice.lean
@@ -19,8 +19,6 @@ open Lean Parser.Tactic Elab Command Elab.Tactic Meta
 
 -- TODO someone might like to generalise this tactic to work with other associative structures.
 
-/- Porting note: moved `repeat_with_results` to `repeat_count` to `Mathlib/Tactic/Core.lean` -/
-
 open Parser.Tactic.Conv
 
 /--


### PR DESCRIPTION
We can drop a few porting notes that became outdated or do not imply a regression.


---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include at least one commit authored by each
co-author among the commits in the pull request. If necessary, you may 
create empty commits to indicate co-authorship, using commands like so:

git commit --author="Author Name <author@email.com>" --allow-empty -m "add Author Name as coauthor"

When merging, all the commits will be squashed into a single commit listing all co-authors.

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
