### PR TITLE
[Merged by Bors] - chore(Topology): process porting notes

### DIFF
--- a/Mathlib/Topology/Algebra/Module/CharacterSpace.lean
+++ b/Mathlib/Topology/Algebra/Module/CharacterSpace.lean
@@ -62,8 +62,8 @@ instance instContinuousLinearMapClass : ContinuousLinearMapClass (characterSpace
   map_add φ := (φ : WeakDual 𝕜 A).map_add
   map_continuous φ := (φ : WeakDual 𝕜 A).cont
 
--- Porting note: moved because Lean 4 doesn't see the `DFunLike` instance on `characterSpace 𝕜 A`
--- until the `ContinuousLinearMapClass` instance is declared
+/-- This has to come after `WeakDual.CharacterSpace.instFunLike`, otherwise the right-hand side
+gets coerced via `Subtype.val` instead of directly via `DFunLike`. -/
 @[simp, norm_cast]
 protected theorem coe_coe (φ : characterSpace 𝕜 A) : ⇑(φ : WeakDual 𝕜 A) = (φ : A → 𝕜) :=
   rfl

--- a/Mathlib/Topology/Algebra/Monoid.lean
+++ b/Mathlib/Topology/Algebra/Monoid.lean
@@ -217,12 +217,8 @@ theorem ContinuousMul.of_nhds_one {M : Type u} [Monoid M] [TopologicalSpace M]
       map (uncurry (· * ·)) (𝓝 (x₀, y₀)) = map (uncurry (· * ·)) (𝓝 x₀ ×ˢ 𝓝 y₀) := by
         rw [nhds_prod_eq]
       _ = map (fun p : M × M => x₀ * p.1 * (p.2 * y₀)) (𝓝 1 ×ˢ 𝓝 1) := by
-        -- Porting note: `rw` was able to prove this
-        -- Now it fails with `failed to rewrite using equation theorems for 'Function.uncurry'`
-        -- and `failed to rewrite using equation theorems for 'Function.comp'`.
-        -- Removing those two lemmas, the `rw` would succeed, but then needs a `rfl`.
-        simp +unfoldPartialApp only [uncurry]
-        simp_rw [hleft x₀, hright y₀, prod_map_map_eq, Filter.map_map, Function.comp_def]
+        unfold uncurry
+        rw [hleft x₀, hright y₀, prod_map_map_eq, Filter.map_map, Function.comp_def]
       _ = map ((fun x => x₀ * x) ∘ fun x => x * y₀) (map (uncurry (· * ·)) (𝓝 1 ×ˢ 𝓝 1)) := by
         rw [key, ← Filter.map_map]
       _ ≤ map ((fun x : M => x₀ * x) ∘ fun x => x * y₀) (𝓝 1) := map_mono hmul

--- a/Mathlib/Topology/Algebra/MulAction.lean
+++ b/Mathlib/Topology/Algebra/MulAction.lean
@@ -248,15 +248,14 @@ variable {ι : Sort*} {M X : Type*} [TopologicalSpace M] [SMul M X]
 @[to_additive]
 theorem continuousSMul_sInf {ts : Set (TopologicalSpace X)}
     (h : ∀ t ∈ ts, @ContinuousSMul M X _ _ t) : @ContinuousSMul M X _ _ (sInf ts) :=
-  -- Porting note: {} doesn't work because `sInf ts` isn't found by TC search. `(_)` finds it by
-  -- unification instead.
-  @ContinuousSMul.mk M X _ _ (_) <| by
+  let _ := sInf ts
+  { continuous_smul := by
       -- Porting note: needs `( :)`
-      rw [← (@sInf_singleton _ _ ‹TopologicalSpace M›:)]
+      rw [← (sInf_singleton (a := ‹TopologicalSpace M›):)]
       exact
         continuous_sInf_rng.2 fun t ht =>
           continuous_sInf_dom₂ (Eq.refl _) ht
-            (@ContinuousSMul.continuous_smul _ _ _ _ t (h t ht))
+            (@ContinuousSMul.continuous_smul _ _ _ _ t (h t ht)) }
 
 @[to_additive]
 theorem continuousSMul_iInf {ts' : ι → TopologicalSpace X}

--- a/Mathlib/Topology/Algebra/Ring/Ideal.lean
+++ b/Mathlib/Topology/Algebra/Ring/Ideal.lean
@@ -33,9 +33,7 @@ protected def Ideal.closure (I : Ideal R) : Ideal R :=
 theorem Ideal.coe_closure (I : Ideal R) : (I.closure : Set R) = closure I :=
   rfl
 
--- Porting note: removed `@[simp]` because we make the instance argument explicit since otherwise
--- it causes timeouts as `simp` tries and fails to generated an `IsClosed` instance.
--- https://leanprover.zulipchat.com/#narrow/stream/287929-mathlib4/topic/!4.234852.20heartbeats.20of.20the.20linter
+@[simp]
 theorem Ideal.closure_eq_of_isClosed (I : Ideal R) (hI : IsClosed (I : Set R)) : I.closure = I :=
   SetLike.ext' hI.closure_eq
 

--- a/Mathlib/Topology/Algebra/Ring/Ideal.lean
+++ b/Mathlib/Topology/Algebra/Ring/Ideal.lean
@@ -33,7 +33,11 @@ protected def Ideal.closure (I : Ideal R) : Ideal R :=
 theorem Ideal.coe_closure (I : Ideal R) : (I.closure : Set R) = closure I :=
   rfl
 
-@[simp]
+/--
+This is not `@[simp]` since otherwise it causes timeouts downstream as `simp` tries and fails to
+generate an `IsClosed` instance.
+https://leanprover.zulipchat.com/#narrow/stream/287929-mathlib4/topic/!4.234852.20heartbeats.20of.20the.20linter
+-/
 theorem Ideal.closure_eq_of_isClosed (I : Ideal R) (hI : IsClosed (I : Set R)) : I.closure = I :=
   SetLike.ext' hI.closure_eq
 

--- a/Mathlib/Topology/Bases.lean
+++ b/Mathlib/Topology/Bases.lean
@@ -296,12 +296,10 @@ variable (α)
 If `α` is a uniform space with countably generated uniformity filter (e.g., an `EMetricSpace`), then
 this condition is equivalent to `SecondCountableTopology α`. In this case the
 latter should be used as a typeclass argument in theorems because Lean can automatically deduce
-`TopologicalSpace.SeparableSpace` from `SecondCountableTopology` but it can't
-deduce `SecondCountableTopology` from `TopologicalSpace.SeparableSpace`.
-
-Porting note (https://github.com/leanprover-community/mathlib4/issues/11215): TODO: the previous paragraph describes the state of the art in Lean 3.
-We can have instance cycles in Lean 4 but we might want to
-postpone adding them till after the port. -/
+`TopologicalSpace.SeparableSpace` from `SecondCountableTopology` using
+`TopologicalSpace.SecondCountableTopology.to_separableSpace`, but deducing
+`SecondCountableTopology` from `TopologicalSpace.SeparableSpace` requires more assumptions.
+-/
 @[mk_iff] class SeparableSpace : Prop where
   /-- There exists a countable dense set. -/
   exists_countable_dense : ∃ s : Set α, s.Countable ∧ Dense s

--- a/Mathlib/Topology/Bornology/Basic.lean
+++ b/Mathlib/Topology/Bornology/Basic.lean
@@ -45,27 +45,13 @@ variable {ι α β : Type*}
 Such spaces are equivalently specified by their bounded sets, see `Bornology.ofBounded`
 and `Bornology.ext_iff_isBounded` -/
 class Bornology (α : Type*) where
-  /-- The filter of cobounded sets in a bornology. This is a field of the structure, but one
-  should always prefer `Bornology.cobounded` because it makes the `α` argument explicit. -/
-  cobounded' : Filter α
-  /-- The cobounded filter in a bornology is smaller than the cofinite filter. This is a field of
-  the structure, but one should always prefer `Bornology.le_cofinite` because it makes the `α`
-  argument explicit. -/
-  le_cofinite' : cobounded' ≤ cofinite
+  /-- The filter of cobounded sets in a bornology. -/
+  cobounded (α) : Filter α
+  /-- The cobounded filter in a bornology is smaller than the cofinite filter. -/
+  le_cofinite (α) : cobounded ≤ cofinite
 
-/- porting note: Because Lean 4 doesn't accept the `[]` syntax to make arguments of structure
-fields explicit, we have to define these separately, prove the `ext` lemmas manually, and
-initialize new `simps` projections. -/
-
-/-- The filter of cobounded sets in a bornology. -/
-def Bornology.cobounded (α : Type*) [Bornology α] : Filter α := Bornology.cobounded'
-
-alias Bornology.Simps.cobounded := Bornology.cobounded
-
-lemma Bornology.le_cofinite (α : Type*) [Bornology α] : cobounded α ≤ cofinite :=
-Bornology.le_cofinite'
-
-initialize_simps_projections Bornology (cobounded' → cobounded)
+@[deprecated (since := "2025-09-06")] alias Bornology.cobounded' := Bornology.cobounded
+@[deprecated (since := "2025-09-06")] alias Bornology.le_cofinite' := Bornology.le_cofinite
 
 @[ext]
 lemma Bornology.ext (t t' : Bornology α)
@@ -83,8 +69,8 @@ def Bornology.ofBounded {α : Type*} (B : Set (Set α))
     (subset_mem : ∀ s₁ ∈ B, ∀ s₂ ⊆ s₁, s₂ ∈ B)
     (union_mem : ∀ s₁ ∈ B, ∀ s₂ ∈ B, s₁ ∪ s₂ ∈ B)
     (singleton_mem : ∀ x, {x} ∈ B) : Bornology α where
-  cobounded' := comk (· ∈ B) empty_mem subset_mem union_mem
-  le_cofinite' := by simpa [le_cofinite_iff_compl_singleton_mem]
+  cobounded := comk (· ∈ B) empty_mem subset_mem union_mem
+  le_cofinite := by simpa [le_cofinite_iff_compl_singleton_mem]
 
 /-- A constructor for bornologies by specifying the bounded sets,
 and showing that they satisfy the appropriate conditions. -/
@@ -276,8 +262,8 @@ instance : Bornology PUnit :=
 
 /-- The cofinite filter as a bornology -/
 abbrev Bornology.cofinite : Bornology α where
-  cobounded' := Filter.cofinite
-  le_cofinite' := le_rfl
+  cobounded := Filter.cofinite
+  le_cofinite := le_rfl
 
 /-- A space with a `Bornology` is a **bounded space** if `Set.univ : Set α` is bounded. -/
 class BoundedSpace (α : Type*) [Bornology α] : Prop where

--- a/Mathlib/Topology/Bornology/Constructions.lean
+++ b/Mathlib/Topology/Bornology/Constructions.lean
@@ -23,18 +23,18 @@ variable {α β ι : Type*} {X : ι → Type*} [Bornology α] [Bornology β]
   [∀ i, Bornology (X i)]
 
 instance Prod.instBornology : Bornology (α × β) where
-  cobounded' := (cobounded α).coprod (cobounded β)
-  le_cofinite' :=
+  cobounded := (cobounded α).coprod (cobounded β)
+  le_cofinite :=
     @coprod_cofinite α β ▸ coprod_mono ‹Bornology α›.le_cofinite ‹Bornology β›.le_cofinite
 
 instance Pi.instBornology : Bornology (∀ i, X i) where
-  cobounded' := Filter.coprodᵢ fun i => cobounded (X i)
-  le_cofinite' := iSup_le fun _ ↦ (comap_mono (Bornology.le_cofinite _)).trans (comap_cofinite_le _)
+  cobounded := Filter.coprodᵢ fun i => cobounded (X i)
+  le_cofinite := iSup_le fun _ ↦ (comap_mono (Bornology.le_cofinite _)).trans (comap_cofinite_le _)
 
 /-- Inverse image of a bornology. -/
 abbrev Bornology.induced {α β : Type*} [Bornology β] (f : α → β) : Bornology α where
-  cobounded' := comap f (cobounded β)
-  le_cofinite' := (comap_mono (Bornology.le_cofinite β)).trans (comap_cofinite_le _)
+  cobounded := comap f (cobounded β)
+  le_cofinite := (comap_mono (Bornology.le_cofinite β)).trans (comap_cofinite_le _)
 
 instance {p : α → Prop} : Bornology (Subtype p) :=
   Bornology.induced (Subtype.val : Subtype p → α)

--- a/Mathlib/Topology/Category/Profinite/CofilteredLimit.lean
+++ b/Mathlib/Topology/Category/Profinite/CofilteredLimit.lean
@@ -45,9 +45,7 @@ theorem exists_isClopen_of_cofiltered {U : Set C.pt} (hC : IsLimit C) (hU : IsCl
     change TopologicalSpace.IsTopologicalBasis {W : Set (F.obj i) | IsClopen W}
     apply isTopologicalBasis_isClopen
   · rintro i j f V (hV : IsClopen _)
-    exact ⟨hV.1.preimage ((F ⋙ toTopCat).map f).hom.continuous,
-      hV.2.preimage ((F ⋙ toTopCat).map f).hom.continuous⟩
-    -- Porting note: `<;> continuity` fails
+    refine ⟨hV.1.preimage ?_, hV.2.preimage ?_⟩ <;> continuity
   -- Using this, since `U` is open, we can write `U` as a union of clopen sets all of which
   -- are preimages of clopens from the factors in the limit.
   obtain ⟨S, hS, h⟩ := hB.open_eq_sUnion hU.2
@@ -69,7 +67,6 @@ theorem exists_isClopen_of_cofiltered {U : Set C.pt} (hC : IsLimit C) (hU : IsCl
     dsimp only
     rwa [← (hV ⟨T, hT⟩).2]
   have := hU.1.isCompact.elim_finite_subcover (fun s : S => C.π.app (j s) ⁻¹' V s) hUo hsU
-  -- Porting note: same remark as after `hB`
   -- We thus obtain a finite set `G : Finset J` and a clopen set of `F.obj j` for each
   -- `j ∈ G` such that `U` is the union of the preimages of these clopen sets.
   obtain ⟨G, hG⟩ := this
@@ -86,8 +83,7 @@ theorem exists_isClopen_of_cofiltered {U : Set C.pt} (hC : IsLimit C) (hU : IsCl
     intro s hs
     dsimp [W]
     rw [dif_pos hs]
-    exact ⟨(hV s).1.1.preimage (F.map _).hom.continuous,
-      (hV s).1.2.preimage (F.map _).hom.continuous⟩
+    refine ⟨(hV s).1.1.preimage ?_, (hV s).1.2.preimage ?_⟩ <;> fun_prop
   · ext x
     constructor
     · intro hx

--- a/Mathlib/Topology/Category/TopCat/Limits/Basic.lean
+++ b/Mathlib/Topology/Category/TopCat/Limits/Basic.lean
@@ -31,6 +31,7 @@ section Limits
 
 variable {J : Type v} [Category.{w} J]
 
+attribute [local fun_prop] continuous_subtype_val
 /-- A choice of limit cone for a functor `F : J ⥤ TopCat`.
 Generally you should just use `limit.cone F`, unless you need the actual definition
 (which is in terms of `Types.limitCone`).

--- a/Mathlib/Topology/Category/TopCat/Limits/Cofiltered.lean
+++ b/Mathlib/Topology/Category/TopCat/Limits/Cofiltered.lean
@@ -90,10 +90,7 @@ theorem isTopologicalBasis_cofiltered_limit (hC : IsLimit C) (T : ∀ j, Set (Se
       rw [Set.preimage_iInter]
       apply congrArg
       ext1 he
-      -- Porting note: needed more hand holding here
-      change (C.π.app e)⁻¹' U e =
-        (C.π.app j) ⁻¹' if h : e ∈ G then F.map (g e h) ⁻¹' U e else Set.univ
-      simp [he, ← Set.preimage_comp, ← coe_comp]
+      simp [Vs, dif_pos he, ← Set.preimage_comp, ← coe_comp]
 
 end CofilteredLimit
 

--- a/Mathlib/Topology/Compactness/Compact.lean
+++ b/Mathlib/Topology/Compactness/Compact.lean
@@ -628,8 +628,8 @@ variable (X) in
 `Filter.cocompact`. See also `Bornology.relativelyCompact` the bornology of sets with compact
 closure. -/
 def inCompact : Bornology X where
-  cobounded' := Filter.cocompact X
-  le_cofinite' := Filter.cocompact_le_cofinite
+  cobounded := Filter.cocompact X
+  le_cofinite := Filter.cocompact_le_cofinite
 
 theorem inCompact.isBounded_iff : @IsBounded _ (inCompact X) s ↔ ∃ t, IsCompact t ∧ s ⊆ t := by
   change sᶜ ∈ Filter.cocompact X ↔ _

--- a/Mathlib/Topology/Constructions/SumProd.lean
+++ b/Mathlib/Topology/Constructions/SumProd.lean
@@ -248,7 +248,7 @@ theorem continuous_curry {g : X × Y → Z} (x : X) (h : Continuous g) : Continu
 theorem IsOpen.prod {s : Set X} {t : Set Y} (hs : IsOpen s) (ht : IsOpen t) : IsOpen (s ×ˢ t) :=
   (hs.preimage continuous_fst).inter (ht.preimage continuous_snd)
 
--- Porting note (https://github.com/leanprover-community/mathlib4/issues/11215): TODO: Lean fails to find `t₁` and `t₂` by unification
+-- Porting note: Lean fails to find `t₁` and `t₂` by unification
 theorem nhds_prod_eq {x : X} {y : Y} : 𝓝 (x, y) = 𝓝 x ×ˢ 𝓝 y := by
   rw [prod_eq_inf, instTopologicalSpaceProd, nhds_inf (t₁ := TopologicalSpace.induced Prod.fst _)
     (t₂ := TopologicalSpace.induced Prod.snd _), nhds_induced, nhds_induced]

--- a/Mathlib/Topology/ContinuousMap/Periodic.lean
+++ b/Mathlib/Topology/ContinuousMap/Periodic.lean
@@ -29,14 +29,11 @@ theorem periodic_tsum_comp_add_zsmul [AddCommGroup X] [ContinuousAdd X] [AddComm
   intro x
   by_cases h : Summable fun n : ℤ => f.comp (ContinuousMap.addRight (n • p))
   · convert congr_arg (fun f : C(X, Y) => f x) ((Equiv.addRight (1 : ℤ)).tsum_eq _) using 1
-    -- Porting note: in mathlib3 the proof from here was:
-    -- simp_rw [← tsum_apply h, ← tsum_apply ((equiv.add_right (1 : ℤ)).summable_iff.mpr h),
-    --   equiv.coe_add_right, comp_apply, coe_add_right, add_one_zsmul, add_comm (_ • p) p,
-    --   ← add_assoc]
-    -- However now the second `← tsum_apply` doesn't fire unless we use `erw`.
-    simp_rw [← tsum_apply h]
-    erw [← tsum_apply ((Equiv.addRight (1 : ℤ)).summable_iff.mpr h)]
-    simp [coe_addRight, add_one_zsmul, add_comm (_ • p) p, ← add_assoc]
+    -- This `have` unfolds the function composition in `Equiv.summable_iff`.
+    have : Summable fun (c : ℤ) => f.comp (ContinuousMap.addRight (Equiv.addRight 1 c • p)) :=
+      (Equiv.addRight (1 : ℤ)).summable_iff.mpr h
+    simp_rw [← tsum_apply h, ← tsum_apply this]
+    simp [Equiv.coe_addRight, comp_apply, add_one_zsmul, add_comm (_ • p) p, ← add_assoc]
   · rw [tsum_eq_zero_of_not_summable h]
     simp only [coe_zero, Pi.zero_apply]
 

--- a/Mathlib/Topology/ContinuousMap/ZeroAtInfty.lean
+++ b/Mathlib/Topology/ContinuousMap/ZeroAtInfty.lean
@@ -201,9 +201,7 @@ instance instAddZeroClass [AddZeroClass β] [ContinuousAdd β] : AddZeroClass C�
 
 instance instSMul [Zero β] {R : Type*} [Zero R] [SMulWithZero R β] [ContinuousConstSMul R β] :
     SMul R C₀(α, β) :=
-  -- Porting note: Original version didn't have `Continuous.const_smul f.continuous r`
-  ⟨fun r f => ⟨⟨r • ⇑f, Continuous.const_smul f.continuous r⟩,
-    by simpa [smul_zero] using (zero_at_infty f).const_smul r⟩⟩
+  ⟨fun r f => ⟨r • f, by simpa [smul_zero] using (zero_at_infty f).const_smul r⟩⟩
 
 @[simp, norm_cast]
 theorem coe_smul [Zero β] {R : Type*} [Zero R] [SMulWithZero R β] [ContinuousConstSMul R β] (r : R)

--- a/Mathlib/Topology/DiscreteQuotient.lean
+++ b/Mathlib/Topology/DiscreteQuotient.lean
@@ -281,8 +281,7 @@ theorem map_proj (cond : LEComap f A B) (x : X) : map f cond (A.proj x) = B.proj
 @[simp]
 theorem map_id : map _ (leComap_id A) = id := by ext ⟨⟩; rfl
 
--- Porting note (https://github.com/leanprover-community/mathlib4/issues/11215): TODO: figure out why `simpNF` says this is a bad `@[simp]` lemma
--- See https://github.com/leanprover-community/batteries/issues/365
+/- This can't be a `@[simp]` lemma since `h1` and `h2` can't be found by unification in a Prop. -/
 theorem map_comp (h1 : LEComap g B C) (h2 : LEComap f A B) :
     map (g.comp f) (h1.comp h2) = map g h1 ∘ map f h2 := by
   ext ⟨⟩

--- a/Mathlib/Topology/Gluing.lean
+++ b/Mathlib/Topology/Gluing.lean
@@ -142,9 +142,7 @@ theorem rel_equiv : Equivalence D.Rel :=
 open CategoryTheory.Limits.WalkingParallelPair
 
 theorem eqvGen_of_π_eq
-    -- Porting note: was `{x y : ∐ D.U}`
-    {x y : sigmaObj (β := D.toGlueData.J) (C := TopCat) D.toGlueData.U}
-    (h : 𝖣.π x = 𝖣.π y) :
+    {x y : ↑(∐ D.U)} (h : 𝖣.π x = 𝖣.π y) :
     Relation.EqvGen
       (Function.Coequalizer.Rel 𝖣.diagram.fstSigmaMap 𝖣.diagram.sndSigmaMap) x y := by
   delta GlueData.π Multicoequalizer.sigmaπ at h
@@ -165,13 +163,8 @@ theorem eqvGen_of_π_eq
           (colimit.isoColimitCocone (Types.coequalizerColimit _ _)).hom)
         this :
       _)
-  -- Porting note: was
-  -- simp only [eqToHom_refl, types_comp_apply, colimit.ι_map_assoc,
-  --   diagramIsoParallelPair_hom_app, colimit.isoColimitCocone_ι_hom, types_id_apply] at this
-  -- See https://github.com/leanprover-community/mathlib4/issues/5026
-  rw [colimit.ι_map_assoc, diagramIsoParallelPair_hom_app, eqToHom_refl,
-    colimit.isoColimitCocone_ι_hom, types_comp_apply, types_id_apply, types_comp_apply,
-    types_id_apply] at this
+  simp only [eqToHom_refl, colimit.ι_map_assoc, diagramIsoParallelPair_hom_app,
+    colimit.isoColimitCocone_ι_hom, Category.id_comp] at this
   exact Quot.eq.1 this
 
 theorem ι_eq_iff_rel (i j : D.J) (x : D.U i) (y : D.U j) :
@@ -295,7 +288,6 @@ structure MkCore where
   t_inter : ∀ ⦃i j⦄ (k) (x : V i j), ↑x ∈ V i k → (((↑) : (V j i) → (U j)) (t i j x)) ∈ V j k
   cocycle :
     ∀ (i j k) (x : V i j) (h : ↑x ∈ V i k),
-      -- Porting note: the underscore in the next line was `↑(t i j x)`, but Lean type-mismatched
       (((↑) : (V k j) → (U k)) (t j k ⟨_, t_inter k x h⟩)) = ((↑) : (V k i) → (U k)) (t i k ⟨x, h⟩)
 
 theorem MkCore.t_inv (h : MkCore) (i j : h.J) (x : h.V j i) : h.t i j ((h.t j i) x) = x := by

--- a/Mathlib/Topology/Homotopy/Basic.lean
+++ b/Mathlib/Topology/Homotopy/Basic.lean
@@ -378,7 +378,7 @@ The type of homotopies between `f₀ f₁ : C(X, Y)`, where the intermediate map
 `P : C(X, Y) → Prop`
 -/
 structure HomotopyWith (f₀ f₁ : C(X, Y)) (P : C(X, Y) → Prop) extends Homotopy f₀ f₁ where
-  -- Porting note (https://github.com/leanprover-community/mathlib4/issues/11215): TODO: use `toHomotopy.curry t`
+  -- TODO: use `toHomotopy.curry t`
   /-- the intermediate maps of the homotopy satisfy the property -/
   prop' : ∀ t, P ⟨fun x => toFun (t, x),
     Continuous.comp continuous_toFun (continuous_const.prodMk continuous_id')⟩
@@ -512,7 +512,6 @@ namespace HomotopicWith
 
 variable {P : C(X, Y) → Prop}
 
--- Porting note: removed @[refl]
 theorem refl (f : C(X, Y)) (hf : P f) : HomotopicWith f f P :=
   ⟨HomotopyWith.refl f hf⟩
 
@@ -633,7 +632,6 @@ variable {S : Set X}
 protected theorem homotopic {f₀ f₁ : C(X, Y)} (h : HomotopicRel f₀ f₁ S) : Homotopic f₀ f₁ :=
   h.map fun F ↦ F.1
 
--- Porting note: removed @[refl]
 theorem refl (f : C(X, Y)) : HomotopicRel f f S :=
   ⟨HomotopyRel.refl f S⟩
 

--- a/Mathlib/Topology/Homotopy/Equiv.lean
+++ b/Mathlib/Topology/Homotopy/Equiv.lean
@@ -52,17 +52,7 @@ structure HomotopyEquiv (X : Type u) (Y : Type v) [TopologicalSpace X] [Topologi
 
 namespace HomotopyEquiv
 
-/-- Coercion of a `HomotopyEquiv` to function. While the Lean 4 way is to unfold coercions, this
-auxiliary definition will make porting of Lean 3 code easier.
-
-Porting note (https://github.com/leanprover-community/mathlib4/issues/11215): TODO: drop this definition. -/
-@[coe] def toFun' (e : X ≃ₕ Y) : X → Y := e.toFun
-
-instance : CoeFun (X ≃ₕ Y) fun _ => X → Y := ⟨toFun'⟩
-
-@[simp]
-theorem toFun_eq_coe (h : HomotopyEquiv X Y) : (h.toFun : X → Y) = h :=
-  rfl
+instance : CoeFun (X ≃ₕ Y) fun _ => X → Y := ⟨fun f => f.toFun⟩
 
 @[continuity]
 theorem continuous (h : HomotopyEquiv X Y) : Continuous h :=

--- a/Mathlib/Topology/Homotopy/HomotopyGroup.lean
+++ b/Mathlib/Topology/Homotopy/HomotopyGroup.lean
@@ -124,8 +124,6 @@ instance instContinuousEvalConst : ContinuousEvalConst (Ω^ N X x) (I^N) X := in
 def copy (f : Ω^ N X x) (g : (I^N) → X) (h : g = f) : Ω^ N X x :=
   ⟨⟨g, h.symm ▸ f.1.2⟩, by convert f.2⟩
 
-/- porting note: this now requires the `instFunLike` instance,
-  so the instance is now put before `copy`. -/
 theorem coe_copy (f : Ω^ N X x) {g : (I^N) → X} (h : g = f) : ⇑(copy f g h) = g :=
   rfl
 

--- a/Mathlib/Topology/LocallyConstant/Basic.lean
+++ b/Mathlib/Topology/LocallyConstant/Basic.lean
@@ -259,8 +259,6 @@ protected theorem continuous : Continuous f :=
 /-- As a shorthand, `LocallyConstant.toContinuousMap` is available as a coercion -/
 instance : Coe (LocallyConstant X Y) C(X, Y) := ⟨toContinuousMap⟩
 
--- Porting note: became a syntactic `rfl`
-
 @[simp] theorem coe_continuousMap : ((f : C(X, Y)) : X → Y) = (f : X → Y) := rfl
 
 theorem toContinuousMap_injective :

--- a/Mathlib/Topology/MetricSpace/Algebra.lean
+++ b/Mathlib/Topology/MetricSpace/Algebra.lean
@@ -45,13 +45,10 @@ in the two arguments. -/
 class LipschitzMul [Monoid β] : Prop where
   lipschitz_mul : ∃ C, LipschitzWith C fun p : β × β => p.1 * p.2
 
-/-- The Lipschitz constant of an `AddMonoid` `β` satisfying `LipschitzAdd` -/
-def LipschitzAdd.C [AddMonoid β] [_i : LipschitzAdd β] : ℝ≥0 := Classical.choose _i.lipschitz_add
-
 variable [Monoid β]
 
 /-- The Lipschitz constant of a monoid `β` satisfying `LipschitzMul` -/
-@[to_additive existing] -- Porting note: had to add `LipschitzAdd.C`. to_additive silently failed
+@[to_additive]
 def LipschitzMul.C [_i : LipschitzMul β] : ℝ≥0 := Classical.choose _i.lipschitz_mul
 
 variable {β}

--- a/Mathlib/Topology/MetricSpace/Algebra.lean
+++ b/Mathlib/Topology/MetricSpace/Algebra.lean
@@ -48,7 +48,7 @@ class LipschitzMul [Monoid β] : Prop where
 variable [Monoid β]
 
 /-- The Lipschitz constant of a monoid `β` satisfying `LipschitzMul` -/
-@[to_additive]
+@[to_additive /-- The Lipschitz constant of an `AddMonoid` `β` satisfying `LipschitzAdd` -/]
 def LipschitzMul.C [_i : LipschitzMul β] : ℝ≥0 := Classical.choose _i.lipschitz_mul
 
 variable {β}

--- a/Mathlib/Topology/MetricSpace/Equicontinuity.lean
+++ b/Mathlib/Topology/MetricSpace/Equicontinuity.lean
@@ -85,9 +85,7 @@ theorem equicontinuousAt_of_continuity_modulus {ι : Type*} [TopologicalSpace β
     (H : ∀ᶠ x in 𝓝 x₀, ∀ i, dist (F i x₀) (F i x) ≤ b x) : EquicontinuousAt F x₀ := by
   rw [Metric.equicontinuousAt_iff_right]
   intro ε ε0
-  -- Porting note: Lean 3 didn't need `Filter.mem_map.mp` here
-  filter_upwards [Filter.mem_map.mp <| b_lim (Iio_mem_nhds ε0), H] using
-    fun x hx₁ hx₂ i => (hx₂ i).trans_lt hx₁
+  filter_upwards [b_lim (Iio_mem_nhds ε0), H] using fun x hx₁ hx₂ i => (hx₂ i).trans_lt hx₁
 
 /-- For a family of functions between (pseudo) metric spaces, a convenient way to prove
 uniform equicontinuity is to show that all of the functions share a common *global* continuity

--- a/Mathlib/Topology/MetricSpace/GromovHausdorff.lean
+++ b/Mathlib/Topology/MetricSpace/GromovHausdorff.lean
@@ -680,10 +680,7 @@ instance : SecondCountableTopology GHSpace := by
       /- the distance between `x` and `y` is encoded in `F p`, and the distance between
             `Φ x` and `Φ y` (two points of `s q`) is encoded in `F q`, all this up to `ε`.
             As `F p = F q`, the distances are almost equal. -/
-      -- Porting note: we have to circumvent the absence of `change … with … `
       intro x y
-      -- have : dist (Φ x) (Φ y) = dist (Ψ x) (Ψ y) := rfl
-      rw [show dist (Φ x) (Φ y) = dist (Ψ x) (Ψ y) from rfl]
       -- introduce `i`, that codes both `x` and `Φ x` in `Fin (N p) = Fin (N q)`
       let i : ℕ := E p x
       have hip : i < N p := ((E p) x).2
@@ -704,9 +701,7 @@ instance : SecondCountableTopology GHSpace := by
         simp only [F, (E q).symm_apply_apply]
       have Aq : (F q).2 ⟨i, hiq⟩ ⟨j, hjq⟩ = ⌊ε⁻¹ * dist (Ψ x) (Ψ y)⌋ := by
         rw [← this]
-        -- Porting note: `congr` fails to make progress
-        refine congr_arg₂ (F q).2 ?_ ?_ <;> ext1
-        exacts [i', j']
+        congr!
       -- use the equality between `F p` and `F q` to deduce that the distances have equal
       -- integer parts
       have : (F p).2 ⟨i, hip⟩ ⟨j, hjp⟩ = (F q).2 ⟨i, hiq⟩ ⟨j, hjq⟩ := by
@@ -851,8 +846,7 @@ theorem totallyBounded {t : Set GHSpace} {C : ℝ} {u : ℕ → ℝ} {K : ℕ �
       have Aq : ((F q).2 ⟨i, hiq⟩ ⟨j, hjq⟩).1 = ⌊ε⁻¹ * dist (Ψ x) (Ψ y)⌋₊ :=
         calc
           ((F q).2 ⟨i, hiq⟩ ⟨j, hjq⟩).1 = ((F q).2 ((E q) (Ψ x)) ((E q) (Ψ y))).1 := by
-            -- Porting note: `congr` drops `Fin.val` but fails to make further progress
-            exact congr_arg₂ (Fin.val <| (F q).2 · ·) (Fin.ext i') (Fin.ext j')
+            congr!
           _ = min M ⌊ε⁻¹ * dist (Ψ x) (Ψ y)⌋₊ := by simp only [F, (E q).symm_apply_apply]
           _ = ⌊ε⁻¹ * dist (Ψ x) (Ψ y)⌋₊ := by
             refine min_eq_right (Nat.floor_mono ?_)

--- a/Mathlib/Topology/MetricSpace/IsometricSMul.lean
+++ b/Mathlib/Topology/MetricSpace/IsometricSMul.lean
@@ -39,23 +39,20 @@ universe u v w
 variable (M : Type u) (G : Type v) (X : Type w)
 
 /-- An additive action is isometric if each map `x ↦ c +ᵥ x` is an isometry. -/
-class IsIsometricVAdd [PseudoEMetricSpace X] [VAdd M X] : Prop where
-  protected isometry_vadd : ∀ c : M, Isometry ((c +ᵥ ·) : X → X)
+class IsIsometricVAdd (X : Type w) [PseudoEMetricSpace X] [VAdd M X] : Prop where
+  isometry_vadd (X) : ∀ c : M, Isometry ((c +ᵥ ·) : X → X)
 
 @[deprecated (since := "2025-03-10")] alias IsometricVAdd := IsIsometricVAdd
 
 /-- A multiplicative action is isometric if each map `x ↦ c • x` is an isometry. -/
 @[to_additive]
-class IsIsometricSMul [PseudoEMetricSpace X] [SMul M X] : Prop where
-  protected isometry_smul : ∀ c : M, Isometry ((c • ·) : X → X)
+class IsIsometricSMul (X : Type w) [PseudoEMetricSpace X] [SMul M X] : Prop where
+  isometry_smul (X) : ∀ c : M, Isometry ((c • ·) : X → X)
 
 @[deprecated (since := "2025-03-10")] alias IsometricSMul := IsIsometricSMul
 
--- Porting note: Lean 4 doesn't support `[]` in classes, so make a lemma instead of `export`ing
-@[to_additive]
-theorem isometry_smul {M : Type u} (X : Type w) [PseudoEMetricSpace X] [SMul M X]
-    [IsIsometricSMul M X] (c : M) : Isometry (c • · : X → X) :=
-  IsIsometricSMul.isometry_smul c
+export IsIsometricSMul (isometry_smul)
+export IsIsometricVAdd (isometry_vadd)
 
 @[to_additive]
 instance (priority := 100) IsIsometricSMul.to_continuousConstSMul [PseudoEMetricSpace X] [SMul M X]

--- a/Mathlib/Topology/Order.lean
+++ b/Mathlib/Topology/Order.lean
@@ -606,7 +606,7 @@ theorem nhds_sInf {s : Set (TopologicalSpace α)} {a : α} :
     @nhds α (sInf s) a = ⨅ t ∈ s, @nhds α t a :=
   (gc_nhds a).u_sInf
 
--- Porting note: timeouts without `b₁ := t₁`
+-- Porting note: type error without `b₁ := t₁`
 theorem nhds_inf {t₁ t₂ : TopologicalSpace α} {a : α} :
     @nhds α (t₁ ⊓ t₂) a = @nhds α t₁ a ⊓ @nhds α t₂ a :=
   (gc_nhds a).u_inf (b₁ := t₁)

--- a/Mathlib/Topology/Order/Compact.lean
+++ b/Mathlib/Topology/Order/Compact.lean
@@ -88,14 +88,14 @@ instance (priority := 100) ConditionallyCompleteLinearOrder.toCompactIccSpace (�
   have ha : a ∈ s := by simp [s, hpt, hab]
   rcases hab.eq_or_lt with (rfl | _hlt)
   · exact ha.2
-  -- Porting note: the `obtain` below was instead
-  -- `set c := Sup s`
-  -- `have hsc : IsLUB s c := isLUB_csSup ⟨a, ha⟩ sbd`
-  obtain ⟨c, hsc⟩ : ∃ c, IsLUB s c := ⟨sSup s, isLUB_csSup ⟨a, ha⟩ ⟨b, hsb⟩⟩
+  let c := sSup s
+  have hsc : IsLUB s c := isLUB_csSup ⟨a, ha⟩ ⟨b, hsb⟩
   have hc : c ∈ Icc a b := ⟨hsc.1 ha, hsc.2 hsb⟩
   specialize hf c hc
   have hcs : c ∈ s := by
-    rcases hc.1.eq_or_lt with (rfl | hlt); · assumption
+    -- rcases ... with (rfl | ... ) fails here, rewrite manually.
+    rcases hc.1.eq_or_lt with (h | hlt)
+    · rwa [h] at ha
     refine ⟨hc, fun hcf => hf fun U hU => ?_⟩
     rcases (mem_nhdsLE_iff_exists_Ioc_subset' hlt).1 (mem_nhdsWithin_of_mem_nhds hU)
       with ⟨x, hxc, hxU⟩
@@ -105,8 +105,9 @@ instance (priority := 100) ConditionallyCompleteLinearOrder.toCompactIccSpace (�
     rw [diff_subset_iff]
     exact Subset.trans Icc_subset_Icc_union_Ioc <| union_subset_union Subset.rfl <|
       Ioc_subset_Ioc_left hy.1.le
-  rcases hc.2.eq_or_lt with (rfl | hlt)
-  · exact hcs.2
+  -- rcases ... with (rfl | ... ) fails here, rewrite manually.
+  rcases hc.2.eq_or_lt with (h | hlt)
+  · simpa [h] using hcs.2
   exfalso
   refine hf fun U hU => ?_
   rcases (mem_nhdsGE_iff_exists_mem_Ioc_Ico_subset hlt).1 (mem_nhdsWithin_of_mem_nhds hU)

--- a/Mathlib/Topology/Separation/Basic.lean
+++ b/Mathlib/Topology/Separation/Basic.lean
@@ -310,8 +310,8 @@ variable (X) in
 Its cobounded filter is `Filter.coclosedCompact`.
 See also `Bornology.inCompact` the bornology of sets contained in a compact set. -/
 def Bornology.relativelyCompact : Bornology X where
-  cobounded' := Filter.coclosedCompact X
-  le_cofinite' := Filter.coclosedCompact_le_cofinite
+  cobounded := Filter.coclosedCompact X
+  le_cofinite := Filter.coclosedCompact_le_cofinite
 
 theorem Bornology.relativelyCompact.isBounded_iff {s : Set X} :
     @Bornology.IsBounded _ (Bornology.relativelyCompact X) s ↔ IsCompact (closure s) :=

--- a/Mathlib/Topology/Sheaves/CommRingCat.lean
+++ b/Mathlib/Topology/Sheaves/CommRingCat.lean
@@ -133,10 +133,7 @@ noncomputable def toTotalQuotientPresheaf : F ⟶ F.totalQuotientPresheaf :=
 deriving Epi
 
 instance (F : X.Sheaf CommRingCat.{w}) : Mono F.presheaf.toTotalQuotientPresheaf := by
-  -- Porting note: was an `apply (config := { instances := false })`
-  -- See https://github.com/leanprover/lean4/issues/2273
-  suffices ∀ (U : (Opens ↑X)ᵒᵖ), Mono (F.presheaf.toTotalQuotientPresheaf.app U) from
-    NatTrans.mono_of_mono_app _
+  apply (config := { allowSynthFailures := true }) NatTrans.mono_of_mono_app
   intro U
   apply ConcreteCategory.mono_of_injective
   dsimp [toTotalQuotientPresheaf]

--- a/Mathlib/Topology/Sheaves/SheafCondition/EqualizerProducts.lean
+++ b/Mathlib/Topology/Sheaves/SheafCondition/EqualizerProducts.lean
@@ -68,11 +68,20 @@ def res : F.obj (op (iSup U)) ⟶ piOpens.{v'} F U :=
 theorem res_π (i : ι) : res F U ≫ limit.π _ ⟨i⟩ = F.map (Opens.leSupr U i).op := by
   rw [res, limit.lift_π, Fan.mk_π_app]
 
+/-- Copy of `limit.hom_ext`, specialized to `piOpens` for use by the `ext` tactic. -/
+@[ext] theorem piOpens.hom_ext
+  {X : C} {f f' : X ⟶ piOpens F U} (w : ∀ j, f ≫ limit.π _ j = f' ≫ limit.π _ j) : f = f' :=
+  limit.hom_ext w
+
+/-- Copy of `limit.hom_ext`, specialized to `piInters` for use by the `ext` tactic. -/
+@[ext] theorem piInters.hom_ext
+  {X : C} {f f' : X ⟶ piInters F U} (w : ∀ j, f ≫ limit.π _ j = f' ≫ limit.π _ j) : f = f' :=
+  limit.hom_ext w
+
 @[elementwise]
 theorem w : res F U ≫ leftRes F U = res F U ≫ rightRes F U := by
   dsimp [res, leftRes, rightRes]
-  -- Porting note (https://github.com/leanprover-community/mathlib4/issues/11041): `ext` can't see `limit.hom_ext` applies here:
-  refine limit.hom_ext (fun _ => ?_)
+  ext
   simp only [limit.lift_π, limit.lift_π_assoc, Fan.mk_π_app, Category.assoc]
   rw [← F.map_comp]
   rw [← F.map_comp]
@@ -101,8 +110,7 @@ theorem fork_ι : (fork F U).ι = res F U :=
 theorem fork_π_app_walkingParallelPair_zero : (fork F U).π.app WalkingParallelPair.zero = res F U :=
   rfl
 
--- Porting note: Shortcut simplifier
-@[simp (high)]
+@[simp]
 theorem fork_π_app_walkingParallelPair_one :
     (fork F U).π.app WalkingParallelPair.one = res F U ≫ leftRes F U :=
   rfl
@@ -128,16 +136,14 @@ def diagram.isoOfIso (α : F ≅ G) : diagram F U ≅ diagram.{v'} G U :=
     (by
       rintro ⟨⟩ ⟨⟩ ⟨⟩
       · simp
-      · -- Porting note (https://github.com/leanprover-community/mathlib4/issues/11041): `ext` can't see `limit.hom_ext` applies here:
-        refine limit.hom_ext (fun _ => ?_)
-        simp only [leftRes, piOpens.isoOfIso, piInters.isoOfIso, parallelPair_map_left,
-          Functor.mapIso_hom, lim_map, limit.lift_map, limit.lift_π, Cones.postcompose_obj_π,
+      · dsimp
+        ext
+        simp only [leftRes, limit.lift_map, limit.lift_π, Cones.postcompose_obj_π,
           NatTrans.comp_app, Fan.mk_π_app, Discrete.natIso_hom_app, Iso.app_hom, Category.assoc,
           NatTrans.naturality, limMap_π_assoc]
-      · -- Porting note (https://github.com/leanprover-community/mathlib4/issues/11041): `ext` can't see `limit.hom_ext` applies here:
-        refine limit.hom_ext (fun _ => ?_)
-        simp only [rightRes, piOpens.isoOfIso, piInters.isoOfIso, parallelPair_map_right,
-          Functor.mapIso_hom, lim_map, limit.lift_map, limit.lift_π, Cones.postcompose_obj_π,
+      · dsimp [diagram]
+        ext
+        simp only [rightRes, limit.lift_map, limit.lift_π, Cones.postcompose_obj_π,
           NatTrans.comp_app, Fan.mk_π_app, Discrete.natIso_hom_app, Iso.app_hom, Category.assoc,
           NatTrans.naturality, limMap_π_assoc]
       · simp)
@@ -151,11 +157,11 @@ def fork.isoOfIso (α : F ≅ G) :
     fork F U ≅ (Cones.postcompose (diagram.isoOfIso U α).inv).obj (fork G U) := by
   fapply Fork.ext
   · apply α.app
-  · -- Porting note (https://github.com/leanprover-community/mathlib4/issues/11041): `ext` can't see `limit.hom_ext` applies here:
-    refine limit.hom_ext (fun _ => ?_)
+  · dsimp
+    ext
     dsimp only [Fork.ι]
     -- Ugh, `simp` can't unfold abbreviations.
-    simp only [res, diagram.isoOfIso, Iso.app_hom, piOpens.isoOfIso, Cones.postcompose_obj_π,
+    simp only [res, diagram.isoOfIso, piOpens.isoOfIso, Cones.postcompose_obj_π,
       NatTrans.comp_app, fork_π_app_walkingParallelPair_zero, NatIso.ofComponents_inv_app,
       Functor.mapIso_inv, lim_map, limit.lift_map, Category.assoc, limit.lift_π, Fan.mk_π_app,
       Discrete.natIso_inv_app, Iso.app_inv, NatTrans.naturality, Iso.hom_inv_id_app_assoc]
@@ -191,36 +197,22 @@ def coneEquivFunctorObj (c : Cone ((diagram U).op ⋙ F)) :
           (Pi.lift fun b : ι × ι => c.π.app (op (pair b.1 b.2)))
       naturality := fun Y Z f => by
         cases Y <;> cases Z <;> cases f
-        · -- Porting note (https://github.com/leanprover-community/mathlib4/issues/11041): `ext` can't see `limit.hom_ext` applies here:
-          refine limit.hom_ext fun i => ?_
-          dsimp
-          simp only [limit.lift_π, Category.id_comp, Fan.mk_π_app, CategoryTheory.Functor.map_id,
-            Category.assoc]
-          dsimp
-          simp only [limit.lift_π, Category.id_comp, Fan.mk_π_app]
-        · -- Porting note (https://github.com/leanprover-community/mathlib4/issues/11041): `ext` can't see `limit.hom_ext` applies here:
-          refine limit.hom_ext fun ⟨i, j⟩ => ?_
-          dsimp [SheafConditionEqualizerProducts.leftRes]
-          simp only [limit.lift_π, limit.lift_π_assoc, Category.id_comp, Fan.mk_π_app,
-            Category.assoc]
-          have h := c.π.naturality (Quiver.Hom.op (Hom.left i j))
-          dsimp at h
-          simpa using h
-        · -- Porting note (https://github.com/leanprover-community/mathlib4/issues/11041): `ext` can't see `limit.hom_ext` applies here:
-          refine limit.hom_ext fun ⟨i, j⟩ => ?_
-          dsimp [SheafConditionEqualizerProducts.rightRes]
-          simp only [limit.lift_π, limit.lift_π_assoc, Category.id_comp, Fan.mk_π_app,
-            Category.assoc]
-          have h := c.π.naturality (Quiver.Hom.op (Hom.right i j))
-          dsimp at h
-          simpa using h
-        · -- Porting note (https://github.com/leanprover-community/mathlib4/issues/11041): `ext` can't see `limit.hom_ext` applies here:
-          refine limit.hom_ext fun i => ?_
-          dsimp
-          simp only [limit.lift_π, Category.id_comp, Fan.mk_π_app, CategoryTheory.Functor.map_id,
-            Category.assoc]
-          dsimp
-          simp only [limit.lift_π, Category.id_comp, Fan.mk_π_app] }
+        · dsimp
+          ext
+          simp
+        · dsimp
+          ext ij
+          rcases ij with ⟨i, j⟩
+          simpa [SheafConditionEqualizerProducts.leftRes]
+            using c.π.naturality (Quiver.Hom.op (Hom.left i j))
+        · dsimp
+          ext ij
+          rcases ij with ⟨i, j⟩
+          simpa [SheafConditionEqualizerProducts.rightRes]
+            using c.π.naturality (Quiver.Hom.op (Hom.right i j))
+        · dsimp
+          ext
+          simp }
 
 section
 
@@ -234,10 +226,9 @@ def coneEquivFunctor :
     { hom := f.hom
       w := fun j => by
         cases j <;>
-          · -- Porting note (https://github.com/leanprover-community/mathlib4/issues/11041): `ext` can't see `limit.hom_ext` applies here:
-            refine limit.hom_ext fun i => ?_
-            simp only [Limits.Fan.mk_π_app, Limits.ConeMorphism.w, Limits.limit.lift_π,
-              Category.assoc, coneEquivFunctorObj_π_app] }
+          · dsimp
+            ext
+            simp }
 
 end
 
@@ -342,26 +333,22 @@ def coneEquivCounitIso :
           { hom := 𝟙 _
             w := by
               rintro ⟨_ | _⟩
-              · -- Porting note (https://github.com/leanprover-community/mathlib4/issues/11041): `ext` can't see `limit.hom_ext` applies here:
-                refine limit.hom_ext fun ⟨j⟩ => ?_
-                dsimp [coneEquivInverse]
-                simp only [Limits.Fan.mk_π_app, Category.id_comp, Limits.limit.lift_π]
-              · -- Porting note (https://github.com/leanprover-community/mathlib4/issues/11041): `ext` can't see `limit.hom_ext` applies here:
-                refine limit.hom_ext fun ⟨i, j⟩ => ?_
-                dsimp [coneEquivInverse]
-                simp only [Limits.Fan.mk_π_app, Category.id_comp, Limits.limit.lift_π] }
+              · dsimp
+                ext
+                simp
+              · dsimp
+                ext
+                simp }
         inv :=
           { hom := 𝟙 _
             w := by
               rintro ⟨_ | _⟩
-              · -- Porting note (https://github.com/leanprover-community/mathlib4/issues/11041): `ext` can't see `limit.hom_ext` applies here:
-                refine limit.hom_ext fun ⟨j⟩ => ?_
-                dsimp [coneEquivInverse]
-                simp only [Limits.Fan.mk_π_app, Category.id_comp, Limits.limit.lift_π]
-              · -- Porting note (https://github.com/leanprover-community/mathlib4/issues/11041): `ext` can't see `limit.hom_ext` applies here:
-                refine limit.hom_ext fun ⟨i, j⟩ => ?_
-                dsimp [coneEquivInverse]
-                simp only [Limits.Fan.mk_π_app, Category.id_comp, Limits.limit.lift_π] } })
+              · dsimp
+                ext
+                simp
+              · dsimp
+                ext
+                simp } })
     fun {c d} f => by
     ext
     dsimp
@@ -426,8 +413,8 @@ def isLimitSheafConditionForkOfIsLimitMapCone (Q : IsLimit (F.mapCone (cocone U)
             rintro ⟨⟩
             · simp
               rfl
-            · -- Porting note (https://github.com/leanprover-community/mathlib4/issues/11041): `ext` can't see `limit.hom_ext` applies here:
-              refine limit.hom_ext fun ⟨i, j⟩ => ?_
+            · dsimp
+              ext
               dsimp [coneEquivInverse, SheafConditionEqualizerProducts.res,
                 SheafConditionEqualizerProducts.leftRes]
               simp only [limit.lift_π, limit.lift_π_assoc, Category.id_comp, Fan.mk_π_app,
@@ -440,8 +427,8 @@ def isLimitSheafConditionForkOfIsLimitMapCone (Q : IsLimit (F.mapCone (cocone U)
             rintro ⟨⟩
             · simp
               rfl
-            · -- Porting note (https://github.com/leanprover-community/mathlib4/issues/11041): `ext` can't see `limit.hom_ext` applies here:
-              refine limit.hom_ext fun ⟨i, j⟩ => ?_
+            · dsimp
+              ext
               dsimp [coneEquivInverse, SheafConditionEqualizerProducts.res,
                 SheafConditionEqualizerProducts.leftRes]
               simp only [limit.lift_π, limit.lift_π_assoc, Category.id_comp, Fan.mk_π_app,

--- a/Mathlib/Topology/Sheaves/Sheafify.lean
+++ b/Mathlib/Topology/Sheaves/Sheafify.lean
@@ -73,7 +73,7 @@ def toSheafify : F ⟶ F.sheafify.1 where
   app U f := ⟨fun x => F.germ _ x x.2 f, PrelocalPredicate.sheafifyOf ⟨f, fun x => rfl⟩⟩
   naturality U U' f := by
     ext x
-    apply Subtype.ext -- Porting note: Added `apply`
+    apply Subtype.ext -- Porting note (https://github.com/leanprover-community/mathlib4/issues/11041): Added `apply`
     ext ⟨u, m⟩
     exact germ_res_apply F f.unop u m x
 

--- a/Mathlib/Topology/Sheaves/Stalks.lean
+++ b/Mathlib/Topology/Sheaves/Stalks.lean
@@ -384,8 +384,6 @@ section Concrete
 variable {C} {CC : C → Type v} [∀ X Y, FunLike (FC X Y) (CC X) (CC Y)]
 variable [instCC : ConcreteCategory.{v} C FC]
 
--- Porting note (https://github.com/leanprover-community/mathlib4/issues/11215): TODO: @[ext] attribute only applies to structures or lemmas proving x = y
--- @[ext]
 theorem germ_ext (F : X.Presheaf C) {U V : Opens X} {x : X} {hxU : x ∈ U} {hxV : x ∈ V}
     (W : Opens X) (hxW : x ∈ W) (iWU : W ⟶ U) (iWV : W ⟶ V)
     {sU : ToType (F.obj (op U))} {sV : ToType (F.obj (op V))}

--- a/Mathlib/Topology/UniformSpace/Cauchy.lean
+++ b/Mathlib/Topology/UniformSpace/Cauchy.lean
@@ -833,9 +833,7 @@ instance (priority := 100) firstCountableTopology : FirstCountableTopology α :=
 
 /-- A separable uniform space with countably generated uniformity filter is second countable:
 one obtains a countable basis by taking the balls centered at points in a dense subset,
-and with rational "radii" from a countable open symmetric antitone basis of `𝓤 α`. We do not
-register this as an instance, as there is already an instance going in the other direction
-from second countable spaces to separable spaces, and we want to avoid loops. -/
+and with rational "radii" from a countable open symmetric antitone basis of `𝓤 α`. -/
 instance secondCountable_of_separable [SeparableSpace α] : SecondCountableTopology α := by
   rcases exists_countable_dense α with ⟨s, hsc, hsd⟩
   obtain

--- a/Mathlib/Topology/UniformSpace/Cauchy.lean
+++ b/Mathlib/Topology/UniformSpace/Cauchy.lean
@@ -836,7 +836,7 @@ one obtains a countable basis by taking the balls centered at points in a dense 
 and with rational "radii" from a countable open symmetric antitone basis of `𝓤 α`. We do not
 register this as an instance, as there is already an instance going in the other direction
 from second countable spaces to separable spaces, and we want to avoid loops. -/
-theorem secondCountable_of_separable [SeparableSpace α] : SecondCountableTopology α := by
+instance secondCountable_of_separable [SeparableSpace α] : SecondCountableTopology α := by
   rcases exists_countable_dense α with ⟨s, hsc, hsd⟩
   obtain
     ⟨t : ℕ → Set (α × α), hto : ∀ i : ℕ, t i ∈ (𝓤 α).sets ∧ IsOpen (t i) ∧ IsSymmetricRel (t i),

--- a/Mathlib/Topology/UniformSpace/UniformConvergenceTopology.lean
+++ b/Mathlib/Topology/UniformSpace/UniformConvergenceTopology.lean
@@ -233,7 +233,7 @@ protected def filter (𝓕 : Filter <| β × β) : Filter ((α →ᵤ β) × (α
 protected def phi (α β : Type*) (uvx : ((α →ᵤ β) × (α →ᵤ β)) × α) : β × β :=
   (uvx.fst.fst uvx.2, uvx.1.2 uvx.2)
 
-set_option quotPrecheck false -- Porting note: error message suggested to do this
+set_option quotPrecheck false -- Porting note: we need a `[quot_precheck]` instance on fbinop%
 /- This is a lower adjoint to `UniformFun.filter` (see `UniformFun.gc`).
 The exact definition of the lower adjoint `l` is not interesting; we will only use that it exists
 (in `UniformFun.mono` and `UniformFun.iInf_eq`) and that


### PR DESCRIPTION
Go through the porting notes in the Topology folder and solve the ones with an obvious fix.

This last batch of porting notes should bring us below 500 open porting notes in Mathlib, when the RingTheory ones get merged too!


---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include at least one commit authored by each
co-author among the commits in the pull request. If necessary, you may 
create empty commits to indicate co-authorship, using commands like so:

git commit --author="Author Name <author@email.com>" --allow-empty -m "add Author Name as coauthor"

When merging, all the commits will be squashed into a single commit listing all co-authors.

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
