### PR TITLE
[Merged by Bors] - feat(Algebra/Order): Generalize IsMulTorsionFree to linearly ordered monoid

### DIFF
--- a/Mathlib/Algebra/Order/Group/Basic.lean
+++ b/Mathlib/Algebra/Order/Group/Basic.lean
@@ -89,9 +89,6 @@ lemma zpow_le_zpow_iff_left (hn : 0 < n) : a ^ n ≤ b ^ n ↔ a ≤ b :=
 lemma zpow_lt_zpow_iff_left (hn : 0 < n) : a ^ n < b ^ n ↔ a < b :=
   (zpow_left_strictMono α hn).lt_iff_lt
 
-@[to_additive]
-instance : IsMulTorsionFree α where pow_left_injective _ hn := (pow_left_strictMono hn).injective
-
 variable (α) in
 /-- A nontrivial densely linear ordered commutative group can't be a cyclic group. -/
 @[to_additive

--- a/Mathlib/Algebra/Order/Monoid/Unbundled/Pow.lean
+++ b/Mathlib/Algebra/Order/Monoid/Unbundled/Pow.lean
@@ -290,6 +290,10 @@ theorem Right.pow_lt_one_iff [MulRightStrictMono M] {n : ℕ} {x : M}
   haveI := mulRightMono_of_mulRightStrictMono M
   ⟨fun H => not_le.mp fun k => H.not_ge <| Right.one_le_pow_of_le k, Right.pow_lt_one_of_lt hn⟩
 
+@[to_additive]
+instance [MulLeftStrictMono M] [MulRightStrictMono M] : IsMulTorsionFree M where
+  pow_left_injective _ hn := (pow_left_strictMono hn).injective
+
 end LinearOrder
 
 end Monoid


### PR DESCRIPTION
Signature change:
```diff
-instance {α : Type*} [CommGroup α] [LinearOrder α] [IsOrderedMonoid α] : IsMulTorsionFree α
+instance {α : Type*} [Monoid α] [LinearOrder α] [MulLeftStrictMono α] [MulRightStrictMono α] : IsMulTorsionFree α
```

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include at least one commit authored by each
co-author among the commits in the pull request. If necessary, you may 
create empty commits to indicate co-authorship, using commands like so:

git commit --author="Author Name <author@email.com>" --allow-empty -m "add Author Name as coauthor"

When merging, all the commits will be squashed into a single commit listing all co-authors.

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
