### PR TITLE
[Merged by Bors] - chore: update gh-get-current-pr workflow to v4

### DIFF
--- a/.github/build.in.yml
+++ b/.github/build.in.yml
@@ -574,10 +574,9 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       # This action is used to determine the PR metadata in the event of a push.
-      # If it is called from a PR from a fork, it will find nothing/irrelevant data.
       - if: github.event_name != 'pull_request_target'
         id: PR_from_push
-        uses: 8BitJonny/gh-get-current-pr@08e737c57a3a4eb24cec6487664b243b77eb5e36 # 3.0.0
+        uses: 8BitJonny/gh-get-current-pr@4056877062a1f3b624d5d4c2bedefa9cf51435c9 # 4.0.0
         # TODO: this may not work properly if the same commit is pushed to multiple branches:
         # https://github.com/8BitJonny/gh-get-current-pr/issues/8
         with:

--- a/.github/workflows/bors.yml
+++ b/.github/workflows/bors.yml
@@ -584,10 +584,9 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       # This action is used to determine the PR metadata in the event of a push.
-      # If it is called from a PR from a fork, it will find nothing/irrelevant data.
       - if: github.event_name != 'pull_request_target'
         id: PR_from_push
-        uses: 8BitJonny/gh-get-current-pr@08e737c57a3a4eb24cec6487664b243b77eb5e36 # 3.0.0
+        uses: 8BitJonny/gh-get-current-pr@4056877062a1f3b624d5d4c2bedefa9cf51435c9 # 4.0.0
         # TODO: this may not work properly if the same commit is pushed to multiple branches:
         # https://github.com/8BitJonny/gh-get-current-pr/issues/8
         with:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -591,10 +591,9 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       # This action is used to determine the PR metadata in the event of a push.
-      # If it is called from a PR from a fork, it will find nothing/irrelevant data.
       - if: github.event_name != 'pull_request_target'
         id: PR_from_push
-        uses: 8BitJonny/gh-get-current-pr@08e737c57a3a4eb24cec6487664b243b77eb5e36 # 3.0.0
+        uses: 8BitJonny/gh-get-current-pr@4056877062a1f3b624d5d4c2bedefa9cf51435c9 # 4.0.0
         # TODO: this may not work properly if the same commit is pushed to multiple branches:
         # https://github.com/8BitJonny/gh-get-current-pr/issues/8
         with:

--- a/.github/workflows/build_fork.yml
+++ b/.github/workflows/build_fork.yml
@@ -588,10 +588,9 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       # This action is used to determine the PR metadata in the event of a push.
-      # If it is called from a PR from a fork, it will find nothing/irrelevant data.
       - if: github.event_name != 'pull_request_target'
         id: PR_from_push
-        uses: 8BitJonny/gh-get-current-pr@08e737c57a3a4eb24cec6487664b243b77eb5e36 # 3.0.0
+        uses: 8BitJonny/gh-get-current-pr@4056877062a1f3b624d5d4c2bedefa9cf51435c9 # 4.0.0
         # TODO: this may not work properly if the same commit is pushed to multiple branches:
         # https://github.com/8BitJonny/gh-get-current-pr/issues/8
         with:

--- a/.github/workflows/update_dependencies.yml
+++ b/.github/workflows/update_dependencies.yml
@@ -32,7 +32,7 @@ jobs:
       - name: Get PR and labels
         if: ${{ steps.sha.outputs.sha }}
         id: PR # all the steps below are skipped if 'ready-to-merge' is in the list of labels found here
-        uses: 8BitJonny/gh-get-current-pr@08e737c57a3a4eb24cec6487664b243b77eb5e36 # 3.0.0
+        uses: 8BitJonny/gh-get-current-pr@4056877062a1f3b624d5d4c2bedefa9cf51435c9 # 4.0.0
         # TODO: this may not work properly if the same commit is pushed to multiple branches:
         # https://github.com/8BitJonny/gh-get-current-pr/issues/8
         with:


### PR DESCRIPTION
This should hopefully fix the issue where the `bench-after-ci` label doesn't work if it is applied after CI begins. 

cf. [Release notes](https://github.com/8BitJonny/gh-get-current-pr/releases/tag/4.0.0)

---

@Vierkantor We might be able to remove the fallback in the `PR` step in `build.in.yml` that you added as well; it's probably worth making sure that this works as expected first though.