### PR TITLE
[Merged by Bors] - refactor: make `PosMulMono` and alike custom classes

### DIFF
--- a/Counterexamples/CanonicallyOrderedCommSemiringTwoMul.lean
+++ b/Counterexamples/CanonicallyOrderedCommSemiringTwoMul.lean
@@ -75,36 +75,24 @@ theorem lt_def : a < b ↔ a.1 < b.1 := by
   rw [k] at h
   exact Nat.lt_asymm h h
 
-theorem add_left_cancel : ∀ a b c : ℕ × ZMod 2, a + b = a + c → b = c := fun a _ _ h =>
-  (add_right_inj a).mp h
-
-theorem add_le_add_left : ∀ a b : ℕ × ZMod 2, a ≤ b → ∀ c : ℕ × ZMod 2, c + a ≤ c + b := by
-  rintro a b (rfl | ab) c
-  · rfl
-  · exact Or.inr (by simpa)
-
-theorem le_of_add_le_add_left : ∀ a b c : ℕ × ZMod 2, a + b ≤ a + c → b ≤ c := by
-  rintro a b c (bc | bc)
-  · exact le_of_eq ((add_right_inj a).mp bc)
-  · exact Or.inr (by simpa using bc)
-
 instance : ZeroLEOneClass (ℕ × ZMod 2) :=
   ⟨by dsimp only [LE.le]; decide⟩
 
 instance : PosMulStrictMono (ℕ × ZMod 2) where
-  elim := by
-    rintro ⟨a, ha⟩ b c hbc; dsimp at *; rw [lt_def] at *; exact mul_lt_mul_of_pos_left hbc ha
+  mul_lt_mul_of_pos_left a ha b c hbc := by rw [lt_def] at *; exact mul_lt_mul_of_pos_left hbc ha
 
 instance : MulPosStrictMono (ℕ × ZMod 2) where
-  elim := by
-    rintro ⟨a, ha⟩ b c hbc; dsimp at *; rw [lt_def] at *; exact mul_lt_mul_of_pos_right hbc ha
+  mul_lt_mul_of_pos_right a ha b c hbc := by rw [lt_def] at *; exact mul_lt_mul_of_pos_right hbc ha
 
-instance isorN2 : IsStrictOrderedRing (ℕ × ZMod 2) :=
-  { add_le_add_left := add_le_add_left
-    le_of_add_le_add_left := le_of_add_le_add_left
-    zero_le_one := zero_le_one
-    mul_lt_mul_of_pos_left _ _ _ := mul_lt_mul_of_pos_left
-    mul_lt_mul_of_pos_right _ _ _ := mul_lt_mul_of_pos_right }
+instance isStrictOrderedRing_N2 : IsStrictOrderedRing (ℕ × ZMod 2) where
+  add_le_add_left := by
+    rintro a b (rfl | ab) c
+    · rfl
+    · exact .inr (by simpa)
+  le_of_add_le_add_left := by
+    rintro a b c (hbc | hbc)
+    · exact (add_right_injective _ hbc).le
+    · exact .inr (by simpa using hbc)
 
 end Nxzmod2
 

--- a/Mathlib/Algebra/Algebra/Operations.lean
+++ b/Mathlib/Algebra/Algebra/Operations.lean
@@ -559,8 +559,6 @@ instance idemSemiring : IdemSemiring (Submodule R A) where
   bot_le _ := bot_le
 
 instance : IsOrderedRing (Submodule R A) where
-  mul_le_mul_of_nonneg_left _ _ _ h _ := mul_le_mul_left' h _
-  mul_le_mul_of_nonneg_right _ _ _ h _ := mul_le_mul_right' h _
 
 variable (M)
 

--- a/Mathlib/Algebra/Order/GroupWithZero/Canonical.lean
+++ b/Mathlib/Algebra/Order/GroupWithZero/Canonical.lean
@@ -114,14 +114,6 @@ section LinearOrderedCommGroupWithZero
 variable [LinearOrderedCommGroupWithZero α] {a b c d : α} {m n : ℕ}
 
 -- See note [lower instance priority]
-instance (priority := 100) LinearOrderedCommGroupWithZero.toMulPosMono : MulPosMono α where
-  elim _a _b _c hbc := mul_le_mul_right' hbc _
-
--- See note [lower instance priority]
-instance (priority := 100) LinearOrderedCommGroupWithZero.toPosMulMono : PosMulMono α where
-  elim _a _b _c hbc := mul_le_mul_left' hbc _
-
--- See note [lower instance priority]
 instance (priority := 100) LinearOrderedCommGroupWithZero.toPosMulReflectLE :
     PosMulReflectLE α where
   elim a b c hbc := by simpa [a.2.ne'] using mul_le_mul_left' hbc a⁻¹
@@ -135,17 +127,13 @@ instance (priority := 100) LinearOrderedCommGroupWithZero.toMulPosReflectLE :
 instance (priority := 100) LinearOrderedCommGroupWithZero.toPosMulReflectLT :
     PosMulReflectLT α where elim _a _b _c := lt_of_mul_lt_mul_left'
 
-#adaptation_note /-- 2025-03-29 https://github.com/leanprover/lean4/issues/7717 Needed to add `dsimp only` -/
 -- See note [lower instance priority]
 instance (priority := 100) LinearOrderedCommGroupWithZero.toPosMulStrictMono :
-    PosMulStrictMono α where
-  elim a b c hbc := by dsimp only; by_contra! h; exact hbc.not_ge <| (mul_le_mul_iff_right₀ a.2).1 h
+    PosMulStrictMono α := PosMulReflectLE.toPosMulStrictMono
 
-#adaptation_note /-- 2025-03-29 https://github.com/leanprover/lean4/issues/7717 Needed to add `dsimp only` -/
 -- See note [lower instance priority]
 instance (priority := 100) LinearOrderedCommGroupWithZero.toMulPosStrictMono :
-    MulPosStrictMono α where
-  elim a b c hbc := by dsimp only; by_contra! h; exact hbc.not_ge <| (mul_le_mul_iff_left₀ a.2).1 h
+    MulPosStrictMono α := MulPosReflectLE.toMulPosStrictMono
 
 @[simp]
 theorem Units.zero_lt (u : αˣ) : (0 : α) < u :=

--- a/Mathlib/Algebra/Order/GroupWithZero/Unbundled/Basic.lean
+++ b/Mathlib/Algebra/Order/GroupWithZero/Unbundled/Basic.lean
@@ -109,20 +109,22 @@ local notation3 "α>0" => { x : α // 0 < x }
 variable [PartialOrder α]
 
 theorem posMulMono_iff_covariant_pos :
-    PosMulMono α ↔ CovariantClass α>0 α (fun x y => x * y) (· ≤ ·) :=
-  ⟨@PosMulMono.to_covariantClass_pos_mul_le _ _ _ _, fun h =>
-    { elim a b c h := by
-        obtain ha | ha := a.prop.eq_or_lt
+    PosMulMono α ↔ CovariantClass α>0 α (fun x y => x * y) (· ≤ ·) where
+  mp _ := PosMulMono.to_covariantClass_pos_mul_le
+  mpr h :=
+    { mul_le_mul_of_nonneg_left a ha b c hbc := by
+        obtain ha | ha := ha.eq_or_lt
         · simp [← ha]
-        · exact @CovariantClass.elim α>0 α (fun x y => x * y) (· ≤ ·) _ ⟨_, ha⟩ _ _ h }⟩
+        · exact @CovariantClass.elim α>0 α (fun x y => x * y) (· ≤ ·) _ ⟨_, ha⟩ _ _ hbc }
 
 theorem mulPosMono_iff_covariant_pos :
-    MulPosMono α ↔ CovariantClass α>0 α (fun x y => y * x) (· ≤ ·) :=
-  ⟨@MulPosMono.to_covariantClass_pos_mul_le _ _ _ _, fun h =>
-    { elim a b c h := by
-        obtain ha | ha := a.prop.eq_or_lt
+    MulPosMono α ↔ CovariantClass α>0 α (fun x y => y * x) (· ≤ ·) where
+  mp _ := MulPosMono.to_covariantClass_pos_mul_le
+  mpr h :=
+    { mul_le_mul_of_nonneg_right a ha b c hbc := by
+        obtain ha | ha := ha.eq_or_lt
         · simp [← ha]
-        · exact @CovariantClass.elim α>0 α (fun x y => y * x) (· ≤ ·) _ ⟨_, ha⟩ _ _ h }⟩
+        · exact @CovariantClass.elim α>0 α (fun x y => y * x) (· ≤ ·) _ ⟨_, ha⟩ _ _ hbc }
 
 theorem posMulReflectLT_iff_contravariant_pos :
     PosMulReflectLT α ↔ ContravariantClass α>0 α (fun x y => x * y) (· < ·) :=
@@ -705,15 +707,15 @@ section PartialOrder
 variable [PartialOrder α]
 
 theorem PosMulMono.toPosMulStrictMono [PosMulMono α] : PosMulStrictMono α where
-  elim := fun x _ _ h => (mul_le_mul_of_nonneg_left h.le x.2.le).lt_of_ne
-    (h.ne ∘ mul_left_cancel₀ x.2.ne')
+  mul_lt_mul_of_pos_left _a ha _b _c hbc :=
+    (mul_le_mul_of_nonneg_left hbc.le ha.le).lt_of_ne (hbc.ne ∘ mul_left_cancel₀ ha.ne')
 
 theorem posMulMono_iff_posMulStrictMono : PosMulMono α ↔ PosMulStrictMono α :=
   ⟨@PosMulMono.toPosMulStrictMono α _ _, @PosMulStrictMono.toPosMulMono α _ _⟩
 
 theorem MulPosMono.toMulPosStrictMono [MulPosMono α] : MulPosStrictMono α where
-  elim := fun x _ _ h => (mul_le_mul_of_nonneg_right h.le x.2.le).lt_of_ne
-    (h.ne ∘ mul_right_cancel₀ x.2.ne')
+  mul_lt_mul_of_pos_right _a ha _b _c hbc :=
+    (mul_le_mul_of_nonneg_right hbc.le ha.le).lt_of_ne (hbc.ne ∘ mul_right_cancel₀ ha.ne')
 
 theorem mulPosMono_iff_mulPosStrictMono : MulPosMono α ↔ MulPosStrictMono α :=
   ⟨@MulPosMono.toMulPosStrictMono α _ _, @MulPosStrictMono.toMulPosMono α _ _⟩
@@ -829,10 +831,8 @@ lemma one_div_nonneg : 0 ≤ 1 / a ↔ 0 ≤ a := one_div a ▸ inv_nonneg
 variable (G₀) in
 /-- For a group with zero, `PosMulReflectLT G₀` implies `PosMulStrictMono G₀`. -/
 theorem PosMulReflectLT.toPosMulStrictMono : PosMulStrictMono G₀ where
-  elim := by
-    rintro ⟨a, ha⟩ b c hlt
-    apply lt_of_mul_lt_mul_left _ (inv_pos_of_pos ha).le
-    simpa [ha.ne']
+  mul_lt_mul_of_pos_left a ha b c hbc :=
+    lt_of_mul_lt_mul_left (by simpa [ha.ne']) (inv_pos_of_pos ha).le
 
 variable (G₀) in
 /-- For a group with zero, `PosMulReflectLT G₀`
@@ -1061,10 +1061,8 @@ lemma inv_pos : 0 < a⁻¹ ↔ 0 < a := by
 variable (G₀) in
 /-- For a group with zero, `MulPosReflectLT G₀` implies `MulPosStrictMono G₀`. -/
 theorem _root_.MulPosReflectLT.toMulPosStrictMono : MulPosStrictMono G₀ where
-  elim := by
-    rintro ⟨a, ha⟩ b c hlt
-    apply lt_of_mul_lt_mul_right _ (inv_pos.2 ha).le
-    simpa [ha.ne']
+  mul_lt_mul_of_pos_right a ha b c hbc :=
+    lt_of_mul_lt_mul_right (by simpa [ha.ne']) (inv_pos.2 ha).le
 
 lemma inv_nonneg : 0 ≤ a⁻¹ ↔ 0 ≤ a := by simp only [le_iff_eq_or_lt, inv_pos, zero_eq_inv]
 

--- a/Mathlib/Algebra/Order/GroupWithZero/Unbundled/Defs.lean
+++ b/Mathlib/Algebra/Order/GroupWithZero/Unbundled/Defs.lean
@@ -93,7 +93,7 @@ namely `a₁ ≤ a₂ → b * a₁ ≤ b * a₂` if `0 ≤ b`.
 You should usually not use this very granular typeclass directly, but rather a typeclass like
 `OrderedSemiring`. -/
 @[mk_iff] class PosMulMono : Prop where
-  /-- Do not use this. Use `mul_le_mul_of_nonneg_left` instead. -/
+  /-- Do not use this. Use `_root_.mul_le_mul_of_nonneg_left` instead. -/
   protected mul_le_mul_of_nonneg_left ⦃a : α⦄ (ha : 0 ≤ a) ⦃b c : α⦄ (hbc : b ≤ c) : a * b ≤ a * c
 
 /-- Typeclass for strict monotonicity of multiplication by positive elements on the left,
@@ -102,7 +102,7 @@ namely `a₁ < a₂ → b * a₁ < b * a₂` if `0 < b`.
 You should usually not use this very granular typeclass directly, but rather a typeclass like
 `StrictOrderedSemiring`. -/
 @[mk_iff] class PosMulStrictMono : Prop where
-  /-- Do not use this. Use `mul_lt_mul_of_pos_left` instead. -/
+  /-- Do not use this. Use `_root_.mul_lt_mul_of_pos_left` instead. -/
   protected mul_lt_mul_of_pos_left ⦃a : α⦄ (ha : 0 < a) ⦃b c : α⦄ (hbc : b < c) : a * b < a * c
 
 /-- Typeclass for strict reverse monotonicity of multiplication by nonnegative elements on
@@ -125,7 +125,7 @@ namely `a₁ ≤ a₂ → a₁ * b ≤ a₂ * b` if `0 ≤ b`.
 You should usually not use this very granular typeclass directly, but rather a typeclass like
 `OrderedSemiring`. -/
 @[mk_iff] class MulPosMono : Prop where
-  /-- Do not use this. Use `mul_le_mul_of_nonneg_right` instead. -/
+  /-- Do not use this. Use `_root_.mul_le_mul_of_nonneg_right` instead. -/
   protected mul_le_mul_of_nonneg_right ⦃c : α⦄ (hc : 0 ≤ c) ⦃a b : α⦄ (hab : a ≤ b) : a * c ≤ b * c
 
 /-- Typeclass for strict monotonicity of multiplication by positive elements on the right,
@@ -134,7 +134,7 @@ namely `a₁ < a₂ → a₁ * b < a₂ * b` if `0 < b`.
 You should usually not use this very granular typeclass directly, but rather a typeclass like
 `StrictOrderedSemiring`. -/
 @[mk_iff] class MulPosStrictMono : Prop where
-  /-- Do not use this. Use `mul_lt_mul_of_pos_right` instead. -/
+  /-- Do not use this. Use `_root_.mul_lt_mul_of_pos_right` instead. -/
   protected mul_lt_mul_of_pos_right ⦃c : α⦄ (hc : 0 < c) ⦃a b : α⦄ (hab : a < b) : a * c < b * c
 
 /-- Typeclass for strict reverse monotonicity of multiplication by nonnegative elements on
@@ -159,6 +159,14 @@ variable [Mul α] [Zero α]
 section Preorder
 
 variable [Preorder α] {a b c d : α}
+
+instance PosMulMono.to_covariantClass_nonneg_mul_le [PosMulMono α] :
+    CovariantClass α≥0 α (fun x y => x * y) (· ≤ ·) where
+  elim a _b _c hbc := PosMulMono.mul_le_mul_of_nonneg_left a.2 hbc
+
+instance MulPosMono.to_covariantClass_nonneg_mul_le [MulPosMono α] :
+    CovariantClass α≥0 α (fun x y => y * x) (· ≤ ·) where
+  elim a _b _c hbc := MulPosMono.mul_le_mul_of_nonneg_right a.2 hbc
 
 instance PosMulMono.to_covariantClass_pos_mul_le [PosMulMono α] :
     CovariantClass α>0 α (fun x y => x * y) (· ≤ ·) where

--- a/Mathlib/Algebra/Order/GroupWithZero/Unbundled/Defs.lean
+++ b/Mathlib/Algebra/Order/GroupWithZero/Unbundled/Defs.lean
@@ -92,14 +92,18 @@ namely `a₁ ≤ a₂ → b * a₁ ≤ b * a₂` if `0 ≤ b`.
 
 You should usually not use this very granular typeclass directly, but rather a typeclass like
 `OrderedSemiring`. -/
-@[mk_iff] class PosMulMono : Prop extends CovariantClass α≥0 α (fun x y => x * y) (· ≤ ·)
+@[mk_iff] class PosMulMono : Prop where
+  /-- Do not use this. Use `mul_le_mul_of_nonneg_left` instead. -/
+  protected mul_le_mul_of_nonneg_left ⦃a : α⦄ (ha : 0 ≤ a) ⦃b c : α⦄ (hbc : b ≤ c) : a * b ≤ a * c
 
 /-- Typeclass for strict monotonicity of multiplication by positive elements on the left,
 namely `a₁ < a₂ → b * a₁ < b * a₂` if `0 < b`.
 
 You should usually not use this very granular typeclass directly, but rather a typeclass like
 `StrictOrderedSemiring`. -/
-@[mk_iff] class PosMulStrictMono : Prop extends CovariantClass α>0 α (fun x y => x * y) (· < ·)
+@[mk_iff] class PosMulStrictMono : Prop where
+  /-- Do not use this. Use `mul_lt_mul_of_pos_left` instead. -/
+  protected mul_lt_mul_of_pos_left ⦃a : α⦄ (ha : 0 < a) ⦃b c : α⦄ (hbc : b < c) : a * b < a * c
 
 /-- Typeclass for strict reverse monotonicity of multiplication by nonnegative elements on
 the left, namely `b * a₁ < b * a₂ → a₁ < a₂` if `0 ≤ b`.
@@ -120,14 +124,18 @@ namely `a₁ ≤ a₂ → a₁ * b ≤ a₂ * b` if `0 ≤ b`.
 
 You should usually not use this very granular typeclass directly, but rather a typeclass like
 `OrderedSemiring`. -/
-@[mk_iff] class MulPosMono : Prop extends CovariantClass α≥0 α (fun x y => y * x) (· ≤ ·)
+@[mk_iff] class MulPosMono : Prop where
+  /-- Do not use this. Use `mul_le_mul_of_nonneg_right` instead. -/
+  protected mul_le_mul_of_nonneg_right ⦃c : α⦄ (hc : 0 ≤ c) ⦃a b : α⦄ (hab : a ≤ b) : a * c ≤ b * c
 
 /-- Typeclass for strict monotonicity of multiplication by positive elements on the right,
 namely `a₁ < a₂ → a₁ * b < a₂ * b` if `0 < b`.
 
 You should usually not use this very granular typeclass directly, but rather a typeclass like
 `StrictOrderedSemiring`. -/
-@[mk_iff] class MulPosStrictMono : Prop extends CovariantClass α>0 α (fun x y => y * x) (· < ·)
+@[mk_iff] class MulPosStrictMono : Prop where
+  /-- Do not use this. Use `mul_lt_mul_of_pos_right` instead. -/
+  protected mul_lt_mul_of_pos_right ⦃c : α⦄ (hc : 0 < c) ⦃a b : α⦄ (hab : a < b) : a * c < b * c
 
 /-- Typeclass for strict reverse monotonicity of multiplication by nonnegative elements on
 the right, namely `a₁ * b < a₂ * b → a₁ < a₂` if `0 ≤ b`.
@@ -153,12 +161,20 @@ section Preorder
 variable [Preorder α] {a b c d : α}
 
 instance PosMulMono.to_covariantClass_pos_mul_le [PosMulMono α] :
-    CovariantClass α>0 α (fun x y => x * y) (· ≤ ·) :=
-  ⟨fun a _ _ bc => @CovariantClass.elim α≥0 α (fun x y => x * y) (· ≤ ·) _ ⟨_, a.2.le⟩ _ _ bc⟩
+    CovariantClass α>0 α (fun x y => x * y) (· ≤ ·) where
+  elim a _b _c hbc := PosMulMono.mul_le_mul_of_nonneg_left a.2.le hbc
 
 instance MulPosMono.to_covariantClass_pos_mul_le [MulPosMono α] :
-    CovariantClass α>0 α (fun x y => y * x) (· ≤ ·) :=
-  ⟨fun a _ _ bc => @CovariantClass.elim α≥0 α (fun x y => y * x) (· ≤ ·) _ ⟨_, a.2.le⟩ _ _ bc⟩
+    CovariantClass α>0 α (fun x y => y * x) (· ≤ ·) where
+  elim a _b _c hbc := MulPosMono.mul_le_mul_of_nonneg_right a.2.le hbc
+
+instance PosMulStrictMono.to_covariantClass_pos_mul_le [PosMulStrictMono α] :
+    CovariantClass α>0 α (fun x y => x * y) (· < ·) where
+  elim a _b _c hbc := PosMulStrictMono.mul_lt_mul_of_pos_left a.2 hbc
+
+instance MulPosStrictMono.to_covariantClass_pos_mul_le [MulPosStrictMono α] :
+    CovariantClass α>0 α (fun x y => y * x) (· < ·) where
+  elim a _b _c hbc := MulPosStrictMono.mul_lt_mul_of_pos_right a.2 hbc
 
 instance PosMulReflectLT.to_contravariantClass_pos_mul_lt [PosMulReflectLT α] :
     ContravariantClass α>0 α (fun x y => x * y) (· < ·) :=
@@ -169,16 +185,16 @@ instance MulPosReflectLT.to_contravariantClass_pos_mul_lt [MulPosReflectLT α] :
   ⟨fun a _ _ bc => @ContravariantClass.elim α≥0 α (fun x y => y * x) (· < ·) _ ⟨_, a.2.le⟩ _ _ bc⟩
 
 instance (priority := 100) MulLeftMono.toPosMulMono [MulLeftMono α] :
-    PosMulMono α where elim _ _ := ‹MulLeftMono α›.elim _
+    PosMulMono α where mul_le_mul_of_nonneg_left _ _ _ _ := ‹MulLeftMono α›.elim _
 
 instance (priority := 100) MulRightMono.toMulPosMono [MulRightMono α] :
-    MulPosMono α where elim _ _ := ‹MulRightMono α›.elim _
+    MulPosMono α where mul_le_mul_of_nonneg_right _ _ _ _ := ‹MulRightMono α›.elim _
 
 instance (priority := 100) MulLeftStrictMono.toPosMulStrictMono [MulLeftStrictMono α] :
-    PosMulStrictMono α where elim _ _ := ‹MulLeftStrictMono α›.elim _
+    PosMulStrictMono α where mul_lt_mul_of_pos_left _ _ _ _ := ‹MulLeftStrictMono α›.elim _
 
 instance (priority := 100) MulRightStrictMono.toMulPosStrictMono [MulRightStrictMono α] :
-    MulPosStrictMono α where elim _ _ := ‹MulRightStrictMono α›.elim _
+    MulPosStrictMono α where mul_lt_mul_of_pos_right _ _ _ _ := ‹MulRightStrictMono α›.elim _
 
 instance (priority := 100) MulLeftMono.toPosMulReflectLT [MulLeftReflectLT α] :
     PosMulReflectLT α where elim _ _ := ‹MulLeftReflectLT α›.elim _
@@ -193,20 +209,20 @@ instance (priority := 100) MulRightStrictMono.toMulPosReflectLE [MulRightReflect
     MulPosReflectLE α where elim _ _ := ‹MulRightReflectLE α›.elim _
 
 @[gcongr]
-theorem mul_le_mul_of_nonneg_left [PosMulMono α] (h : b ≤ c) (a0 : 0 ≤ a) : a * b ≤ a * c :=
-  @CovariantClass.elim α≥0 α (fun x y => x * y) (· ≤ ·) _ ⟨a, a0⟩ _ _ h
+theorem mul_le_mul_of_nonneg_left [PosMulMono α] (hbc : b ≤ c) (ha : 0 ≤ a) : a * b ≤ a * c :=
+  PosMulMono.mul_le_mul_of_nonneg_left ha hbc
 
 @[gcongr]
-theorem mul_le_mul_of_nonneg_right [MulPosMono α] (h : b ≤ c) (a0 : 0 ≤ a) : b * a ≤ c * a :=
-  @CovariantClass.elim α≥0 α (fun x y => y * x) (· ≤ ·) _ ⟨a, a0⟩ _ _ h
+theorem mul_le_mul_of_nonneg_right [MulPosMono α] (hbc : b ≤ c) (ha : 0 ≤ a) : b * a ≤ c * a :=
+  MulPosMono.mul_le_mul_of_nonneg_right ha hbc
 
 @[gcongr]
-theorem mul_lt_mul_of_pos_left [PosMulStrictMono α] (bc : b < c) (a0 : 0 < a) : a * b < a * c :=
-  @CovariantClass.elim α>0 α (fun x y => x * y) (· < ·) _ ⟨a, a0⟩ _ _ bc
+theorem mul_lt_mul_of_pos_left [PosMulStrictMono α] (hbc : b < c) (ha : 0 < a) : a * b < a * c :=
+  PosMulStrictMono.mul_lt_mul_of_pos_left ha hbc
 
 @[gcongr]
-theorem mul_lt_mul_of_pos_right [MulPosStrictMono α] (bc : b < c) (a0 : 0 < a) : b * a < c * a :=
-  @CovariantClass.elim α>0 α (fun x y => y * x) (· < ·) _ ⟨a, a0⟩ _ _ bc
+theorem mul_lt_mul_of_pos_right [MulPosStrictMono α] (hbc : b < c) (ha : 0 < a) : b * a < c * a :=
+  MulPosStrictMono.mul_lt_mul_of_pos_right ha hbc
 
 theorem lt_of_mul_lt_mul_left [PosMulReflectLT α] (h : a * b < a * c) (a0 : 0 ≤ a) : b < c :=
   @ContravariantClass.elim α≥0 α (fun x y => x * y) (· < ·) _ ⟨a, a0⟩ _ _ h
@@ -227,15 +243,17 @@ alias le_of_mul_le_mul_of_pos_right := le_of_mul_le_mul_right
 
 @[simp]
 theorem mul_lt_mul_iff_right₀ [PosMulStrictMono α] [PosMulReflectLT α] (a0 : 0 < a) :
-    a * b < a * c ↔ b < c :=
-  @rel_iff_cov α>0 α (fun x y => x * y) (· < ·) _ _ ⟨a, a0⟩ _ _
+    a * b < a * c ↔ b < c where
+  mp h := lt_of_mul_lt_mul_left h a0.le
+  mpr h := mul_lt_mul_of_pos_left h a0
 
 @[deprecated (since := "2025-09-25")] alias mul_lt_mul_left := mul_lt_mul_iff_right₀
 
 @[simp]
 theorem mul_lt_mul_iff_left₀ [MulPosStrictMono α] [MulPosReflectLT α] (a0 : 0 < a) :
-    b * a < c * a ↔ b < c :=
-  @rel_iff_cov α>0 α (fun x y => y * x) (· < ·) _ _ ⟨a, a0⟩ _ _
+    b * a < c * a ↔ b < c where
+  mp h := lt_of_mul_lt_mul_right h a0.le
+  mpr h := mul_lt_mul_of_pos_right h a0
 
 @[deprecated (since := "2025-09-25")] alias mul_lt_mul_right := mul_lt_mul_iff_left₀
 
@@ -379,10 +397,12 @@ instance (priority := 100) MulPosStrictMono.toMulPosReflectLE [MulPosStrictMono 
   elim := (covariant_lt_iff_contravariant_le _ _ _).1 CovariantClass.elim
 
 theorem PosMulReflectLE.toPosMulStrictMono [PosMulReflectLE α] : PosMulStrictMono α where
-  elim := (covariant_lt_iff_contravariant_le _ _ _).2 ContravariantClass.elim
+  mul_lt_mul_of_pos_left _a ha _b _c hbc :=
+    not_le.1 fun h ↦ hbc.not_ge <| le_of_mul_le_mul_left h ha
 
 theorem MulPosReflectLE.toMulPosStrictMono [MulPosReflectLE α] : MulPosStrictMono α where
-  elim := (covariant_lt_iff_contravariant_le _ _ _).2 ContravariantClass.elim
+  mul_lt_mul_of_pos_right _a ha _b _c hbc :=
+    not_le.1 fun h ↦ hbc.not_ge <| le_of_mul_le_mul_right h ha
 
 theorem posMulStrictMono_iff_posMulReflectLE : PosMulStrictMono α ↔ PosMulReflectLE α :=
   ⟨@PosMulStrictMono.toPosMulReflectLE _ _ _ _, @PosMulReflectLE.toPosMulStrictMono _ _ _ _⟩
@@ -391,16 +411,20 @@ theorem mulPosStrictMono_iff_mulPosReflectLE : MulPosStrictMono α ↔ MulPosRef
   ⟨@MulPosStrictMono.toMulPosReflectLE _ _ _ _, @MulPosReflectLE.toMulPosStrictMono _ _ _ _⟩
 
 theorem PosMulReflectLT.toPosMulMono [PosMulReflectLT α] : PosMulMono α where
-  elim := (covariant_le_iff_contravariant_lt _ _ _).2 ContravariantClass.elim
+  mul_le_mul_of_nonneg_left _a ha _b _c hbc :=
+    not_lt.1 fun h ↦ hbc.not_gt <| lt_of_mul_lt_mul_left h ha
 
 theorem MulPosReflectLT.toMulPosMono [MulPosReflectLT α] : MulPosMono α where
-  elim := (covariant_le_iff_contravariant_lt _ _ _).2 ContravariantClass.elim
+  mul_le_mul_of_nonneg_right _a ha _b _c hbc :=
+    not_lt.1 fun h ↦ hbc.not_gt <| lt_of_mul_lt_mul_right h ha
 
 theorem PosMulMono.toPosMulReflectLT [PosMulMono α] : PosMulReflectLT α where
-  elim := (covariant_le_iff_contravariant_lt _ _ _).1 CovariantClass.elim
+  elim := (covariant_le_iff_contravariant_lt _ _ _).1
+    fun a _b _c hbc ↦ mul_le_mul_of_nonneg_left hbc a.2
 
 theorem MulPosMono.toMulPosReflectLT [MulPosMono α] : MulPosReflectLT α where
-  elim := (covariant_le_iff_contravariant_lt _ _ _).1 CovariantClass.elim
+  elim := (covariant_le_iff_contravariant_lt _ _ _).1
+    fun a _b _c hbc ↦ mul_le_mul_of_nonneg_right hbc a.2
 
 /- TODO: Currently, only one in four of the above are made instances; we could consider making
   both directions of `covariant_le_iff_contravariant_lt` and `covariant_lt_iff_contravariant_le`

--- a/Mathlib/Algebra/Order/GroupWithZero/WithZero.lean
+++ b/Mathlib/Algebra/Order/GroupWithZero/WithZero.lean
@@ -30,54 +30,34 @@ assert_not_exists Ring
 -- this makes `mul_lt_mul_iff_right₀`, `mul_pos` etc. work on `ℤᵐ⁰`
 instance {α : Type*} [Mul α] [Preorder α] [MulLeftStrictMono α] :
     PosMulStrictMono (WithZero α) where
-  elim := @fun
-    | ⟨(x : α), hx⟩, 0, (b : α), _ => by
-        simpa only [mul_zero] using WithZero.zero_lt_coe _
-    | ⟨(x : α), hx⟩, (a : α), (b : α), h => by
-        dsimp only at h ⊢
-        norm_cast at h ⊢
-        gcongr
+  mul_lt_mul_of_pos_left
+  | (x : α), hx, 0, (b : α), _ => by simpa only [mul_zero] using WithZero.zero_lt_coe _
+  | (x : α), hx, (a : α), (b : α), h => by norm_cast at h ⊢; exact mul_lt_mul_left' h x
 
 open Function in
 instance {α : Type*} [Mul α] [Preorder α] [MulRightStrictMono α] :
     MulPosStrictMono (WithZero α) where
-  elim := @fun
-    | ⟨(x : α), hx⟩, 0, (b : α), _ => by
-        simpa only [mul_zero] using WithZero.zero_lt_coe _
-    | ⟨(x : α), hx⟩, (a : α), (b : α), h => by
-        dsimp only at h ⊢
-        norm_cast at h ⊢
-        gcongr
+  mul_lt_mul_of_pos_right
+  | (x : α), hx, 0, (b : α), _ => by simpa only [mul_zero] using WithZero.zero_lt_coe _
+  | (x : α), hx, (a : α), (b : α), h => by norm_cast at h ⊢; exact mul_lt_mul_right' h x
 
 instance {α : Type*} [Mul α] [Preorder α] [MulLeftMono α] :
     PosMulMono (WithZero α) where
-  elim := @fun
-    | ⟨0, _⟩, a, b, _ => by
-        simp only [zero_mul, le_refl]
-    | ⟨(x : α), _⟩, 0, _, _ => by
-        simp only [mul_zero, WithZero.zero_le]
-    | ⟨(x : α), _⟩, (a : α), 0, h =>
-        (lt_irrefl 0 (lt_of_lt_of_le (WithZero.zero_lt_coe a) h)).elim
-    | ⟨(x : α), hx⟩, (a : α), (b : α), h => by
-        dsimp only at h ⊢
-        norm_cast at h ⊢
-        gcongr
+  mul_le_mul_of_nonneg_left
+  | 0, _, a, b, _ => by simp
+  | (x : α), _, 0, _, _ => by simp
+  | (x : α), _, (a : α), 0, h => by simp at h
+  | (x : α), hx, (a : α), (b : α), h => by norm_cast at h ⊢; exact mul_le_mul_left' h x
 
 -- This makes `lt_mul_of_le_of_one_lt'` work on `ℤᵐ⁰`
 open Function in
 instance {α : Type*} [Mul α] [Preorder α] [MulRightMono α] :
     MulPosMono (WithZero α) where
-  elim := @fun
-    | ⟨0, _⟩, a, b, _ => by
-        simp only [mul_zero, le_refl]
-    | ⟨(x : α), _⟩, 0, _, _ => by
-        simp only [zero_mul, WithZero.zero_le]
-    | ⟨(x : α), _⟩, (a : α), 0, h =>
-        (lt_irrefl 0 (lt_of_lt_of_le (WithZero.zero_lt_coe a) h)).elim
-    | ⟨(x : α), hx⟩, (a : α), (b : α), h => by
-        dsimp only at h ⊢
-        norm_cast at h ⊢
-        gcongr
+  mul_le_mul_of_nonneg_right
+  | 0, _, a, b, _ => by simp
+  | (x : α), _, 0, _, _ => by simp
+  | (x : α), _, (a : α), 0, h => by simp at h
+  | (x : α), hx, (a : α), (b : α), h => by norm_cast at h ⊢; exact mul_le_mul_right' h x
 
 section Units
 

--- a/Mathlib/Algebra/Order/Pi.lean
+++ b/Mathlib/Algebra/Order/Pi.lean
@@ -58,8 +58,8 @@ instance isOrderedRing [∀ i, Semiring (f i)] [∀ i, PartialOrder (f i)] [∀ 
     IsOrderedRing (∀ i, f i) where
   add_le_add_left _ _ hab _ := fun _ => add_le_add_left (hab _) _
   zero_le_one := fun i => zero_le_one (α := f i)
-  mul_le_mul_of_nonneg_left _ _ _ hab hc := fun _ => mul_le_mul_of_nonneg_left (hab _) <| hc _
-  mul_le_mul_of_nonneg_right _ _ _ hab hc := fun _ => mul_le_mul_of_nonneg_right (hab _) <| hc _
+  mul_le_mul_of_nonneg_left _ hc _ _ hab := fun _ => mul_le_mul_of_nonneg_left (hab _) <| hc _
+  mul_le_mul_of_nonneg_right _ hc _ _ hab := fun _ => mul_le_mul_of_nonneg_right (hab _) <| hc _
 
 end Pi
 

--- a/Mathlib/Algebra/Order/Ring/Canonical.lean
+++ b/Mathlib/Algebra/Order/Ring/Canonical.lean
@@ -58,10 +58,7 @@ lemma toIsOrderedMonoid : IsOrderedMonoid R where
 
 -- TODO: make it an instance
 lemma toIsOrderedRing : IsOrderedRing R where
-  zero_le_one := zero_le _
   add_le_add_left _ _ := add_le_add_left
-  mul_le_mul_of_nonneg_left _ _ _ h _ := mul_le_mul_left' h _
-  mul_le_mul_of_nonneg_right _ _ _ h _ := mul_le_mul_right' h _
 
 @[simp]
 protected theorem mul_pos [NoZeroDivisors R] {a b : R} :

--- a/Mathlib/Algebra/Order/Ring/Defs.lean
+++ b/Mathlib/Algebra/Order/Ring/Defs.lean
@@ -115,63 +115,43 @@ variable {R : Type u}
 /-- An ordered semiring is a semiring with a partial order such that addition is monotone and
 multiplication by a nonnegative number is monotone. -/
 class IsOrderedRing (R : Type*) [Semiring R] [PartialOrder R] extends
-    IsOrderedAddMonoid R, ZeroLEOneClass R where
-  /-- In an ordered semiring, we can multiply an inequality `a ≤ b` on the left
-  by a non-negative element `0 ≤ c` to obtain `c * a ≤ c * b`. -/
-  protected mul_le_mul_of_nonneg_left : ∀ a b c : R, a ≤ b → 0 ≤ c → c * a ≤ c * b
-  /-- In an ordered semiring, we can multiply an inequality `a ≤ b` on the right
-  by a non-negative element `0 ≤ c` to obtain `a * c ≤ b * c`. -/
-  protected mul_le_mul_of_nonneg_right : ∀ a b c : R, a ≤ b → 0 ≤ c → a * c ≤ b * c
+    IsOrderedAddMonoid R, ZeroLEOneClass R, PosMulMono R, MulPosMono R where
 
 attribute [instance 100] IsOrderedRing.toZeroLEOneClass
+attribute [instance 200] IsOrderedRing.toPosMulMono
+attribute [instance 200] IsOrderedRing.toMulPosMono
 
 /-- A strict ordered semiring is a nontrivial semiring with a partial order such that addition is
 strictly monotone and multiplication by a positive number is strictly monotone. -/
 class IsStrictOrderedRing (R : Type*) [Semiring R] [PartialOrder R] extends
-    IsOrderedCancelAddMonoid R, ZeroLEOneClass R, Nontrivial R where
-  /-- In a strict ordered semiring, we can multiply an inequality `a < b` on the left
-  by a positive element `0 < c` to obtain `c * a < c * b`. -/
-  protected mul_lt_mul_of_pos_left : ∀ a b c : R, a < b → 0 < c → c * a < c * b
-  /-- In a strict ordered semiring, we can multiply an inequality `a < b` on the right
-  by a positive element `0 < c` to obtain `a * c < b * c`. -/
-  protected mul_lt_mul_of_pos_right : ∀ a b c : R, a < b → 0 < c → a * c < b * c
+    IsOrderedCancelAddMonoid R, ZeroLEOneClass R, Nontrivial R, PosMulStrictMono R,
+    MulPosStrictMono R where
 
 attribute [instance 100] IsStrictOrderedRing.toZeroLEOneClass
 attribute [instance 100] IsStrictOrderedRing.toNontrivial
+attribute [instance 200] IsStrictOrderedRing.toPosMulStrictMono
+attribute [instance 200] IsStrictOrderedRing.toMulPosStrictMono
 
 instance [Semiring R] [PartialOrder R] [IsStrictOrderedRing R] : Lean.Grind.OrderedRing R where
   zero_lt_one := zero_lt_one
-  mul_lt_mul_of_pos_left := IsStrictOrderedRing.mul_lt_mul_of_pos_left _ _ _
-  mul_lt_mul_of_pos_right := IsStrictOrderedRing.mul_lt_mul_of_pos_right _ _ _
+  mul_lt_mul_of_pos_left := mul_lt_mul_of_pos_left
+  mul_lt_mul_of_pos_right := mul_lt_mul_of_pos_right
 
 lemma IsOrderedRing.of_mul_nonneg [Ring R] [PartialOrder R] [IsOrderedAddMonoid R]
     [ZeroLEOneClass R] (mul_nonneg : ∀ a b : R, 0 ≤ a → 0 ≤ b → 0 ≤ a * b) :
     IsOrderedRing R where
-  mul_le_mul_of_nonneg_left a b c ab hc := by
-    simpa only [mul_sub, sub_nonneg] using mul_nonneg _ _ hc (sub_nonneg.2 ab)
-  mul_le_mul_of_nonneg_right a b c ab hc := by
-    simpa only [sub_mul, sub_nonneg] using mul_nonneg _ _ (sub_nonneg.2 ab) hc
+  mul_le_mul_of_nonneg_left a ha b c hbc := by
+    simpa only [mul_sub, sub_nonneg] using mul_nonneg _ _ ha (sub_nonneg.2 hbc)
+  mul_le_mul_of_nonneg_right a ha b c hbc := by
+    simpa only [sub_mul, sub_nonneg] using mul_nonneg _ _ (sub_nonneg.2 hbc) ha
 
 lemma IsStrictOrderedRing.of_mul_pos [Ring R] [PartialOrder R] [IsOrderedAddMonoid R]
     [ZeroLEOneClass R] [Nontrivial R] (mul_pos : ∀ a b : R, 0 < a → 0 < b → 0 < a * b) :
     IsStrictOrderedRing R where
-  mul_lt_mul_of_pos_left a b c ab hc := by
-    simpa only [mul_sub, sub_pos] using mul_pos _ _ hc (sub_pos.2 ab)
-  mul_lt_mul_of_pos_right a b c ab hc := by
-    simpa only [sub_mul, sub_pos] using mul_pos _ _ (sub_pos.2 ab) hc
-
-section IsOrderedRing
-variable [Semiring R] [PartialOrder R] [IsOrderedRing R]
-
--- see Note [lower instance priority]
-instance (priority := 200) IsOrderedRing.toPosMulMono : PosMulMono R where
-  elim x _ _ h := IsOrderedRing.mul_le_mul_of_nonneg_left _ _ _ h x.2
-
--- see Note [lower instance priority]
-instance (priority := 200) IsOrderedRing.toMulPosMono : MulPosMono R where
-  elim x _ _ h := IsOrderedRing.mul_le_mul_of_nonneg_right _ _ _ h x.2
-
-end IsOrderedRing
+  mul_lt_mul_of_pos_left a ha b c hbc := by
+    simpa only [mul_sub, sub_pos] using mul_pos _ _ ha (sub_pos.2 hbc)
+  mul_lt_mul_of_pos_right a ha b c hbc := by
+    simpa only [sub_mul, sub_pos] using mul_pos _ _ (sub_pos.2 hbc) ha
 
 -- see Note [lower instance priority]
 /-- Turn an ordered domain into a strict ordered ring. -/
@@ -184,18 +164,8 @@ section IsStrictOrderedRing
 variable [Semiring R] [PartialOrder R] [IsStrictOrderedRing R]
 
 -- see Note [lower instance priority]
-instance (priority := 200) IsStrictOrderedRing.toPosMulStrictMono : PosMulStrictMono R where
-  elim x _ _ h := IsStrictOrderedRing.mul_lt_mul_of_pos_left _ _ _ h x.prop
-
--- see Note [lower instance priority]
-instance (priority := 200) IsStrictOrderedRing.toMulPosStrictMono : MulPosStrictMono R where
-  elim x _ _ h := IsStrictOrderedRing.mul_lt_mul_of_pos_right _ _ _ h x.prop
-
--- see Note [lower instance priority]
 instance (priority := 100) IsStrictOrderedRing.toIsOrderedRing : IsOrderedRing R where
   __ := ‹IsStrictOrderedRing R›
-  mul_le_mul_of_nonneg_left _ _ _ := mul_le_mul_of_nonneg_left
-  mul_le_mul_of_nonneg_right _ _ _ := mul_le_mul_of_nonneg_right
 
 /-- This is not an instance, as it would loop with `NeZero.charZero_one`. -/
 theorem AddMonoidWithOne.toCharZero {R}

--- a/Mathlib/Algebra/Order/Ring/Defs.lean
+++ b/Mathlib/Algebra/Order/Ring/Defs.lean
@@ -117,6 +117,7 @@ multiplication by a nonnegative number is monotone. -/
 class IsOrderedRing (R : Type*) [Semiring R] [PartialOrder R] extends
     IsOrderedAddMonoid R, ZeroLEOneClass R, PosMulMono R, MulPosMono R where
 
+-- See note [lower instance priority]
 attribute [instance 100] IsOrderedRing.toZeroLEOneClass
 attribute [instance 200] IsOrderedRing.toPosMulMono
 attribute [instance 200] IsOrderedRing.toMulPosMono
@@ -127,6 +128,7 @@ class IsStrictOrderedRing (R : Type*) [Semiring R] [PartialOrder R] extends
     IsOrderedCancelAddMonoid R, ZeroLEOneClass R, Nontrivial R, PosMulStrictMono R,
     MulPosStrictMono R where
 
+-- See note [lower instance priority]
 attribute [instance 100] IsStrictOrderedRing.toZeroLEOneClass
 attribute [instance 100] IsStrictOrderedRing.toNontrivial
 attribute [instance 200] IsStrictOrderedRing.toPosMulStrictMono

--- a/Mathlib/Algebra/Order/Ring/InjSurj.lean
+++ b/Mathlib/Algebra/Order/Ring/InjSurj.lean
@@ -20,27 +20,27 @@ protected lemma isOrderedRing [IsOrderedRing R] [Semiring S] [PartialOrder S]
     (f : S → R) (zero : f 0 = 0) (one : f 1 = 1)
     (add : ∀ x y, f (x + y) = f x + f y) (mul : ∀ x y, f (x * y) = f x * f y)
     (le : ∀ {x y}, f x ≤ f y ↔ x ≤ y) :
-    IsOrderedRing S :=
-  { __ := Function.Injective.isOrderedAddMonoid f add le
-    zero_le_one := le.1 <| by simp only [zero, one, zero_le_one]
-    mul_le_mul_of_nonneg_left a b c h hc := le.1 <| by
-      rw [mul, mul]; refine mul_le_mul_of_nonneg_left (le.2 h) ?_; rwa [← zero, le]
-    mul_le_mul_of_nonneg_right a b c h hc := le.1 <| by
-      rw [mul, mul]; refine mul_le_mul_of_nonneg_right (le.2 h) ?_; rwa [← zero, le] }
+    IsOrderedRing S where
+  __ := Function.Injective.isOrderedAddMonoid f add le
+  zero_le_one := by simp only [← le, zero, one, zero_le_one]
+  mul_le_mul_of_nonneg_left a ha b c hbc := by
+    rw [← le, mul, mul]; refine mul_le_mul_of_nonneg_left (le.2 hbc) ?_; rwa [← zero, le]
+  mul_le_mul_of_nonneg_right a ha b c hbc := by
+    rw [← le, mul, mul]; refine mul_le_mul_of_nonneg_right (le.2 hbc) ?_; rwa [← zero, le]
 
 /-- Pullback a `IsStrictOrderedRing` under an injective map. -/
 protected lemma isStrictOrderedRing [IsStrictOrderedRing R] [Semiring S] [PartialOrder S]
     (f : S → R) (zero : f 0 = 0) (one : f 1 = 1)
     (add : ∀ x y, f (x + y) = f x + f y) (mul : ∀ x y, f (x * y) = f x * f y)
     (le : ∀ {x y}, f x ≤ f y ↔ x ≤ y) (lt : ∀ {x y}, f x < f y ↔ x < y) :
-    IsStrictOrderedRing S :=
-  { __ := Function.Injective.isOrderedCancelAddMonoid f add le
-    __ := domain_nontrivial f zero one
-    __ := Function.Injective.isOrderedRing f zero one add mul le
-    mul_lt_mul_of_pos_left a b c h hc := lt.1 <| by
-      simpa only [mul, zero] using mul_lt_mul_of_pos_left (lt.2 h) (by rwa [← zero, lt])
-    mul_lt_mul_of_pos_right a b c h hc := lt.1 <| by
-      simpa only [mul, zero] using mul_lt_mul_of_pos_right (lt.2 h) (by rwa [← zero, lt]) }
+    IsStrictOrderedRing S where
+  __ := Function.Injective.isOrderedCancelAddMonoid f add le
+  __ := domain_nontrivial f zero one
+  __ := Function.Injective.isOrderedRing f zero one add mul le
+  mul_lt_mul_of_pos_left a ha b c hbc := by
+    rw [← lt, mul, mul]; refine mul_lt_mul_of_pos_left (lt.2 hbc) ?_; rwa [← zero, lt]
+  mul_lt_mul_of_pos_right a ha b c hbc := by
+    rw [← lt, mul, mul]; refine mul_lt_mul_of_pos_right (lt.2 hbc) ?_; rwa [← zero, lt]
 
 @[deprecated (since := "2025-04-10")]
 protected alias orderedSemiring := Function.Injective.isOrderedRing

--- a/Mathlib/Algebra/Order/Ring/Nat.lean
+++ b/Mathlib/Algebra/Order/Ring/Nat.lean
@@ -25,8 +25,8 @@ instance instIsStrictOrderedRing : IsStrictOrderedRing ℕ where
   add_le_add_left := @Nat.add_le_add_left
   le_of_add_le_add_left := @Nat.le_of_add_le_add_left
   zero_le_one := Nat.le_of_lt (Nat.zero_lt_succ 0)
-  mul_lt_mul_of_pos_left := @Nat.mul_lt_mul_of_pos_left
-  mul_lt_mul_of_pos_right := @Nat.mul_lt_mul_of_pos_right
+  mul_lt_mul_of_pos_left _a ha _b _c hbc := Nat.mul_lt_mul_of_pos_left hbc ha
+  mul_lt_mul_of_pos_right _a ha _b _c hbc := Nat.mul_lt_mul_of_pos_right hbc ha
   exists_pair_ne := ⟨0, 1, ne_of_lt Nat.zero_lt_one⟩
 
 instance instLinearOrderedCommMonoidWithZero : LinearOrderedCommMonoidWithZero ℕ where

--- a/Mathlib/Algebra/Order/Ring/Opposite.lean
+++ b/Mathlib/Algebra/Order/Ring/Opposite.lean
@@ -19,8 +19,8 @@ namespace MulOpposite
 
 instance [Semiring R] [PartialOrder R] [IsOrderedRing R] : IsOrderedRing Rᵐᵒᵖ where
   zero_le_one := zero_le_one (α := R)
-  mul_le_mul_of_nonneg_left _ _ _ := mul_le_mul_of_nonneg_right (α := R)
-  mul_le_mul_of_nonneg_right _ _ _ := mul_le_mul_of_nonneg_left (α := R)
+  mul_le_mul_of_nonneg_left _a ha _b _c hbc := mul_le_mul_of_nonneg_right (α := R) hbc ha
+  mul_le_mul_of_nonneg_right _a ha _b _c hbc := mul_le_mul_of_nonneg_left (α := R) hbc ha
 
 end MulOpposite
 
@@ -28,7 +28,7 @@ namespace AddOpposite
 
 instance [Semiring R] [PartialOrder R] [IsOrderedRing R] : IsOrderedRing Rᵃᵒᵖ where
   zero_le_one := zero_le_one (α := R)
-  mul_le_mul_of_nonneg_left _ _ _ := mul_le_mul_of_nonneg_left (α := R)
-  mul_le_mul_of_nonneg_right _ _ _ := mul_le_mul_of_nonneg_right (α := R)
+  mul_le_mul_of_nonneg_left _a ha _b _c hbc := mul_le_mul_of_nonneg_left (α := R) hbc ha
+  mul_le_mul_of_nonneg_right _a ha _b _c hbc := mul_le_mul_of_nonneg_right (α := R) hbc ha
 
 end AddOpposite

--- a/Mathlib/Algebra/Order/Ring/Prod.lean
+++ b/Mathlib/Algebra/Order/Ring/Prod.lean
@@ -14,9 +14,9 @@ import Mathlib.Algebra.Ring.Prod
 variable {α β : Type*}
 
 instance [Semiring α] [PartialOrder α] [IsOrderedRing α]
-    [Semiring β] [PartialOrder β] [IsOrderedRing β] : IsOrderedRing (α × β) :=
-  { zero_le_one := ⟨zero_le_one, zero_le_one⟩
-    mul_le_mul_of_nonneg_left := fun _ _ _ hab hc =>
-      ⟨mul_le_mul_of_nonneg_left hab.1 hc.1, mul_le_mul_of_nonneg_left hab.2 hc.2⟩
-    mul_le_mul_of_nonneg_right := fun _ _ _ hab hc =>
-      ⟨mul_le_mul_of_nonneg_right hab.1 hc.1, mul_le_mul_of_nonneg_right hab.2 hc.2⟩ }
+    [Semiring β] [PartialOrder β] [IsOrderedRing β] : IsOrderedRing (α × β) where
+  zero_le_one := ⟨zero_le_one, zero_le_one⟩
+  mul_le_mul_of_nonneg_left _a ha _b _c hbc :=
+    ⟨mul_le_mul_of_nonneg_left hbc.1 ha.1, mul_le_mul_of_nonneg_left hbc.2 ha.2⟩
+  mul_le_mul_of_nonneg_right _a ha _b _c hbc :=
+    ⟨mul_le_mul_of_nonneg_right hbc.1 ha.1, mul_le_mul_of_nonneg_right hbc.2 ha.2⟩

--- a/Mathlib/Algebra/Order/Ring/Star.lean
+++ b/Mathlib/Algebra/Order/Ring/Star.lean
@@ -31,27 +31,10 @@ example {R : Type*} [Semiring R] [PartialOrder R] [IsOrderedRing R]
   rw [← IsSelfAdjoint.of_nonneg (mul_nonneg hy hx), star_mul, IsSelfAdjoint.of_nonneg hx,
     IsSelfAdjoint.of_nonneg hy]
 
-/- This will be implied by the instance below, we only prove it to avoid duplicating the
-argument in the instance below for `mul_le_mul_of_nonneg_right`. -/
-private lemma mul_le_mul_of_nonneg_left {R : Type*} [NonUnitalCommSemiring R] [PartialOrder R]
-    [StarRing R] [StarOrderedRing R] {a b c : R} (hab : a ≤ b) (hc : 0 ≤ c) : c * a ≤ c * b := by
-  rw [StarOrderedRing.nonneg_iff] at hc
-  induction hc using AddSubmonoid.closure_induction with
-  | mem _ h =>
-    obtain ⟨x, rfl⟩ := h
-    simp_rw [mul_assoc, mul_comm x, ← mul_assoc]
-    exact conjugate_le_conjugate hab x
-  | zero => simp
-  | add x hx y hy =>
-    simp only [← nonneg_iff, add_mul] at hx hy ⊢
-    apply add_le_add <;> simp_all
-
 /-- A commutative star-ordered semiring is an ordered semiring. -/
 instance toIsOrderedRing (R : Type*) [CommSemiring R] [PartialOrder R]
     [StarRing R] [StarOrderedRing R] : IsOrderedRing R where
-  add_le_add_left _ _ := add_le_add_left
-  zero_le_one := zero_le_one
-  mul_le_mul_of_nonneg_left _ _ _ := mul_le_mul_of_nonneg_left
-  mul_le_mul_of_nonneg_right a b c := by simpa only [mul_comm _ c] using mul_le_mul_of_nonneg_left
+  mul_le_mul_of_nonneg_left _a ha _b _c hbc := smul_le_smul_of_nonneg_left hbc ha
+  mul_le_mul_of_nonneg_right _a ha _b _c hbc := smul_le_smul_of_nonneg_right hbc ha
 
 end StarOrderedRing

--- a/Mathlib/Algebra/Order/Ring/WithTop.lean
+++ b/Mathlib/Algebra/Order/Ring/WithTop.lean
@@ -374,9 +374,7 @@ instance instCommSemiring [CommSemiring α] [PartialOrder α] [CanonicallyOrdere
   WithTop.instCommSemiring
 
 instance [MulZeroClass α] [Preorder α] [PosMulMono α] : PosMulMono (WithBot α) where
-  elim := by
-    intro ⟨x, x0⟩ a b h
-    simp only
+  mul_le_mul_of_nonneg_left x x0 a b h := by
     rcases eq_or_ne x 0 with rfl | x0'
     · simp
     lift x to α
@@ -391,9 +389,7 @@ instance [MulZeroClass α] [Preorder α] [PosMulMono α] : PosMulMono (WithBot �
     exact mul_le_mul_of_nonneg_left h x0
 
 instance [MulZeroClass α] [Preorder α] [MulPosMono α] : MulPosMono (WithBot α) where
-  elim := by
-    intro ⟨x, x0⟩ a b h
-    simp only
+  mul_le_mul_of_nonneg_right x x0 a b h := by
     rcases eq_or_ne x 0 with rfl | x0'
     · simp
     lift x to α
@@ -408,9 +404,7 @@ instance [MulZeroClass α] [Preorder α] [MulPosMono α] : MulPosMono (WithBot �
     exact mul_le_mul_of_nonneg_right h x0
 
 instance [MulZeroClass α] [Preorder α] [PosMulStrictMono α] : PosMulStrictMono (WithBot α) where
-  elim := by
-    intro ⟨x, x0⟩ a b h
-    simp only
+  mul_lt_mul_of_pos_left x x0 a b h := by
     lift x to α using x0.ne_bot
     cases b
     · exact absurd h not_lt_bot
@@ -421,9 +415,7 @@ instance [MulZeroClass α] [Preorder α] [PosMulStrictMono α] : PosMulStrictMon
     exact mul_lt_mul_of_pos_left h x0
 
 instance [MulZeroClass α] [Preorder α] [MulPosStrictMono α] : MulPosStrictMono (WithBot α) where
-  elim := by
-    intro ⟨x, x0⟩ a b h
-    simp only
+  mul_lt_mul_of_pos_right x x0 a b h := by
     lift x to α using x0.ne_bot
     cases b
     · exact absurd h not_lt_bot
@@ -500,7 +492,5 @@ instance [MulZeroClass α] [Preorder α] [MulPosReflectLE α] : MulPosReflectLE 
 instance instIsOrderedRing [CommSemiring α] [PartialOrder α] [IsOrderedRing α]
     [CanonicallyOrderedAdd α] [NoZeroDivisors α] [Nontrivial α] :
     IsOrderedRing (WithBot α) where
-  mul_le_mul_of_nonneg_left  _ _ _ := mul_le_mul_of_nonneg_left
-  mul_le_mul_of_nonneg_right _ _ _ := mul_le_mul_of_nonneg_right
 
 end WithBot

--- a/Mathlib/Data/NNRat/Defs.lean
+++ b/Mathlib/Data/NNRat/Defs.lean
@@ -54,9 +54,8 @@ instance Rat.instZeroLEOneClass : ZeroLEOneClass ℚ where
   zero_le_one := rfl
 
 instance Rat.instPosMulMono : PosMulMono ℚ where
-  elim := fun r p q h => by
-    simp only [mul_comm]
-    simpa [sub_mul, sub_nonneg] using Rat.mul_nonneg (sub_nonneg.2 h) r.2
+  mul_le_mul_of_nonneg_left r hr p q hpq := by
+    simpa [mul_sub, sub_nonneg] using Rat.mul_nonneg hr (sub_nonneg.2 hpq)
 
 deriving instance CommSemiring for NNRat
 deriving instance LinearOrder for NNRat

--- a/Mathlib/Data/Num/Lemmas.lean
+++ b/Mathlib/Data/Num/Lemmas.lean
@@ -388,17 +388,17 @@ instance linearOrder : LinearOrder Num :=
     -- See https://github.com/leanprover/lean4/issues/2343
     toDecidableEq := instDecidableEqNum }
 
-instance isStrictOrderedRing : IsStrictOrderedRing Num :=
-  { zero_le_one := by decide
-    mul_lt_mul_of_pos_left := by
-      intro a b c
-      transfer_rw
-      apply mul_lt_mul_of_pos_left
-    mul_lt_mul_of_pos_right := by
-      intro a b c
-      transfer_rw
-      apply mul_lt_mul_of_pos_right
-    exists_pair_ne := ⟨0, 1, by decide⟩ }
+instance isStrictOrderedRing : IsStrictOrderedRing Num where
+  zero_le_one := by decide
+  exists_pair_ne := ⟨0, 1, by decide⟩
+  mul_lt_mul_of_pos_left a ha b c := by
+    revert ha
+    transfer_rw
+    apply flip mul_lt_mul_of_pos_left
+  mul_lt_mul_of_pos_right a ha b c := by
+    revert ha
+    transfer_rw
+    apply flip mul_lt_mul_of_pos_right
 
 @[norm_cast]
 theorem add_of_nat (m n) : ((m + n : ℕ) : Num) = m + n :=

--- a/Mathlib/Order/Filter/FilterProduct.lean
+++ b/Mathlib/Order/Filter/FilterProduct.lean
@@ -90,10 +90,10 @@ noncomputable instance instLinearOrder [LinearOrder β] : LinearOrder β* :=
 
 instance instIsStrictOrderedRing [Semiring β] [PartialOrder β] [IsStrictOrderedRing β] :
     IsStrictOrderedRing β* where
-  mul_lt_mul_of_pos_left x y z := inductionOn₃ x y z fun _f _g _h hfg hh ↦
-    coe_lt.2 <| (coe_lt.1 hh).mp <| (coe_lt.1 hfg).mono fun _a ↦ mul_lt_mul_of_pos_left
-  mul_lt_mul_of_pos_right x y z := inductionOn₃ x y z fun _f _g _h hfg hh ↦
-    coe_lt.2 <| (coe_lt.1 hh).mp <| (coe_lt.1 hfg).mono fun _a ↦ mul_lt_mul_of_pos_right
+  mul_lt_mul_of_pos_left x := inductionOn x fun _f hf y z ↦ inductionOn₂ y z fun _g _h hgh ↦
+    coe_lt.2 <| (coe_lt.1 hf).mp <| (coe_lt.1 hgh).mono fun _a ↦ mul_lt_mul_of_pos_left
+  mul_lt_mul_of_pos_right x := inductionOn x fun _f hf y z ↦ inductionOn₂ y z fun _g _h hgh ↦
+    coe_lt.2 <| (coe_lt.1 hf).mp <| (coe_lt.1 hgh).mono fun _a ↦ mul_lt_mul_of_pos_right
 
 theorem max_def [LinearOrder β] (x y : β*) : max x y = map₂ max x y :=
   inductionOn₂ x y fun a b => by

--- a/Mathlib/Order/Filter/Ring.lean
+++ b/Mathlib/Order/Filter/Ring.lean
@@ -44,10 +44,12 @@ variable {l : Filter α}
 instance instIsOrderedRing [Semiring β] [PartialOrder β] [IsOrderedRing β] :
     IsOrderedRing (Germ l β) where
   zero_le_one := const_le zero_le_one
-  mul_le_mul_of_nonneg_left x y z := inductionOn₃ x y z fun _f _g _h hfg hh ↦ hh.mp <| hfg.mono
-    fun _a ↦ mul_le_mul_of_nonneg_left
-  mul_le_mul_of_nonneg_right x y z := inductionOn₃ x y z fun _f _g _h hfg hh ↦ hh.mp <| hfg.mono
-    fun _a ↦ mul_le_mul_of_nonneg_right
+  mul_le_mul_of_nonneg_left x :=
+    inductionOn x fun _f hx y z ↦ inductionOn₂ y z fun _g _h hfg ↦ hx.mp <| hfg.mono
+      fun _a ↦ mul_le_mul_of_nonneg_left
+  mul_le_mul_of_nonneg_right x :=
+    inductionOn x fun _f hx y z ↦ inductionOn₂ y z fun _g _h hfg ↦ hx.mp <| hfg.mono
+      fun _a ↦ mul_le_mul_of_nonneg_right
 
 end Germ
 

--- a/Mathlib/SetTheory/Ordinal/Arithmetic.lean
+++ b/Mathlib/SetTheory/Ordinal/Arithmetic.lean
@@ -730,7 +730,7 @@ theorem lt_mul_iff_of_isSuccLimit {a b c : Ordinal} (h : IsSuccLimit c) :
 alias lt_mul_of_limit := lt_mul_iff_of_isSuccLimit
 
 instance : PosMulStrictMono Ordinal where
-  elim a _b _c h := (isNormal_mul_right a.2).strictMono h
+  mul_lt_mul_of_pos_left _a ha := (isNormal_mul_right ha).strictMono
 
 @[deprecated mul_lt_mul_iff_right₀ (since := "2025-08-26")]
 theorem mul_lt_mul_iff_left {a b c : Ordinal} (a0 : 0 < a) : a * b < a * c ↔ b < c :=

--- a/Mathlib/SetTheory/Ordinal/NaturalOps.lean
+++ b/Mathlib/SetTheory/Ordinal/NaturalOps.lean
@@ -692,9 +692,11 @@ instance : CommSemiring NatOrdinal :=
     mul_one := nmul_one
     mul_comm := nmul_comm }
 
-instance : IsOrderedRing NatOrdinal :=
-  { mul_le_mul_of_nonneg_left := fun _ _ c h _ => nmul_le_nmul_left h c
-    mul_le_mul_of_nonneg_right := fun _ _ c h _ => nmul_le_nmul_right h c }
+instance : IsOrderedMonoid NatOrdinal where
+  mul_le_mul_left _a _b hab _c := nmul_le_nmul_left hab _
+  mul_le_mul_right _a _b hab _c := nmul_le_nmul_right hab _
+
+instance : IsOrderedRing NatOrdinal where
 
 end NatOrdinal
 

--- a/MathlibTest/GRewrite.lean
+++ b/MathlibTest/GRewrite.lean
@@ -215,7 +215,7 @@ the inequality goes in the wrong direction). -/
 /--
 error: Tactic `grewrite` failed: could not discharge x ≤ y using x ≥ y
 
-case h₁.h
+case h₁.hbc
 α : Type u_1
 inst✝² : CommRing α
 inst✝¹ : LinearOrder α
@@ -262,7 +262,7 @@ example {Prime : ℕ → Prop} {a a' : ℕ} (h₁ : Prime (a + 1)) (h₂ : a = a
 /--
 error: Tactic `grewrite` failed: could not discharge b ≤ a using a ≤ b
 
-case h₁.h
+case h₁.hbc
 α : Type u_1
 inst✝² : CommRing α
 inst✝¹ : LinearOrder α


### PR DESCRIPTION
In the current setup, users get confusing non-beta-reduced goals involving a subtype when trying to provide an instance of `PosMulMono`.
This PR changes it to be a custom structure with the expected fields.
This follows `PosSMulMono` and alike.


---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include at least one commit authored by each
co-author among the commits in the pull request. If necessary, you may 
create empty commits to indicate co-authorship, using commands like so:

git commit --author="Author Name <author@email.com>" --allow-empty -m "add Author Name as coauthor"

When merging, all the commits will be squashed into a single commit listing all co-authors.

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
