### PR TITLE
[Merged by Bors] - feat: more lemmas about `Matrix.vecMulVec`

### DIFF
--- a/Mathlib/Data/Matrix/Mul.lean
+++ b/Mathlib/Data/Matrix/Mul.lean
@@ -579,6 +579,9 @@ theorem transpose_vecMulVec [CommMagma α] (w : m → α) (v : n → α) :
     (vecMulVec w v)ᵀ = vecMulVec v w :=
   ext fun _ _ => mul_comm _ _
 
+@[simp]
+theorem diag_vecMulVec [Mul α] (u v : n → α) : diag (vecMulVec u v) = u * v := rfl
+
 section NonUnitalNonAssocSemiring
 
 variable [NonUnitalNonAssocSemiring α]

--- a/Mathlib/LinearAlgebra/Matrix/Determinant/Basic.lean
+++ b/Mathlib/LinearAlgebra/Matrix/Determinant/Basic.lean
@@ -492,6 +492,21 @@ theorem det_eq_zero_of_not_linearIndependent_cols [IsDomain R] {A : Matrix m m R
   contrapose! hA
   exact linearIndependent_cols_of_det_ne_zero hA
 
+theorem det_vecMulVec [Nontrivial n] (u v : n → R) : (vecMulVec u v).det = 0 := by
+  obtain ⟨i, j, hij⟩ := exists_pair_ne n
+  let uv' := ((vecMulVec u v).updateRow i v).updateRow j v
+  have huv' : uv'.det = 0 := by
+    refine detRowAlternating.map_eq_zero_of_eq _ ?_ hij
+    simp [uv', hij]
+  have : vecMulVec u v =
+      (uv'.updateRow i (u i • uv' i)).updateRow j (u j • uv'.updateRow i (u i • uv' i) j) := by
+    unfold uv'
+    rw [updateRow_comm _ hij, updateRow_idem, updateRow_ne hij.symm, updateRow_ne hij,
+      updateRow_self, updateRow_self, updateRow_comm _ hij, updateRow_idem,
+      ← update_vecMulVec u v j, update_eq_self, ← update_vecMulVec u v i, update_eq_self]
+  rw [this, det_updateRow_smul, updateRow_eq_self, det_updateRow_smul, updateRow_eq_self, huv',
+    mul_zero, mul_zero]
+
 theorem det_eq_of_forall_row_eq_smul_add_const_aux {A B : Matrix n n R} {s : Finset n} :
     ∀ (c : n → R) (_ : ∀ i, i ∉ s → c i = 0) (k : n) (_ : k ∉ s)
       (_ : ∀ i j, A i j = B i j + c i * B k j), det A = det B := by

--- a/Mathlib/LinearAlgebra/Matrix/RowCol.lean
+++ b/Mathlib/LinearAlgebra/Matrix/RowCol.lean
@@ -356,6 +356,23 @@ theorem diagonal_updateRow_single [DecidableEq n] [Zero α] (v : n → α) (i : 
     (diagonal v).updateRow i (Pi.single i x) = diagonal (Function.update v i x) := by
   rw [← diagonal_transpose, updateRow_transpose, diagonal_updateCol_single, diagonal_transpose]
 
+@[simp]
+theorem updateRow_idem [DecidableEq m] (A : Matrix m n α) (i : m) (x y : n → α) :
+    (A.updateRow i x).updateRow i y = A.updateRow i y := Function.update_idem _ _ _
+
+theorem updateRow_comm [DecidableEq m] (A : Matrix m n α) {i i' : m} (h : i ≠ i') (x y : n → α) :
+    (A.updateRow i x).updateRow i' y = (A.updateRow i' y).updateRow i x :=
+  Function.update_comm h _ _ _
+
+@[simp]
+theorem updateCol_idem [DecidableEq n] (A : Matrix m n α) (j : n) (x y : m → α) :
+    (A.updateCol j x).updateCol j y = A.updateCol j y := by
+  simpa only [updateRow_transpose] using congr_arg transpose <| updateRow_idem Aᵀ j x y
+
+theorem updateCol_comm [DecidableEq n] (A : Matrix m n α) {j j' : n} (h : j ≠ j') (x y : m → α) :
+    (A.updateCol j x).updateCol j' y = (A.updateCol j' y).updateCol j x := by
+  simpa only [updateRow_transpose] using congr_arg transpose <| updateRow_comm Aᵀ h x y
+
 /-! Updating rows and columns commutes in the obvious way with reindexing the matrix. -/
 
 
@@ -429,6 +446,20 @@ theorem vecMul_updateCol [DecidableEq n] [Fintype m] [NonUnitalNonAssocSemiring 
   obtain rfl | hj := eq_or_ne j' j
   · simp [vecMul]
   · simp [vecMul, hj]
+
+theorem update_vecMulVec [DecidableEq m] [Mul α] (u : m → α) (v : n → α) (i : m) (a : α) :
+    vecMulVec (Function.update u i a) v = (vecMulVec u v).updateRow i (a • v) := by
+  ext i' j
+  obtain rfl | hi := eq_or_ne i' i
+  · simp [vecMulVec_apply]
+  · simp [vecMulVec_apply, hi]
+
+theorem vecMulVec_update [DecidableEq n] [Mul α] (u : m → α) (v : n → α) (j : n) (a : α) :
+    vecMulVec u (Function.update v j a) = (vecMulVec u v).updateCol j (MulOpposite.op a • u) := by
+  ext i j'
+  obtain rfl | hi := eq_or_ne j' j
+  · simp [vecMulVec_apply]
+  · simp [vecMulVec_apply, hi]
 
 theorem updateRow_mul [DecidableEq l] [Fintype m] [NonUnitalNonAssocSemiring α]
     (A : Matrix l m α) (i : l) (r : m → α) (B : Matrix m n α) :

--- a/Mathlib/LinearAlgebra/Matrix/Trace.lean
+++ b/Mathlib/LinearAlgebra/Matrix/Trace.lean
@@ -170,6 +170,11 @@ theorem trace_replicateCol_mul_replicateRow {ι : Type*} [Unique ι] [NonUnitalN
 
 @[deprecated (since := "2025-03-20")] alias trace_col_mul_row := trace_replicateCol_mul_replicateRow
 
+@[simp]
+theorem trace_vecMulVec [NonUnitalNonAssocSemiring R] (a b : n → R) :
+    trace (vecMulVec a b) = a ⬝ᵥ b := by
+  rw [vecMulVec_eq Unit, trace_replicateCol_mul_replicateRow]
+
 end Mul
 
 lemma trace_submatrix_succ {n : ℕ} [AddCommMonoid R]


### PR DESCRIPTION
The most interesting of these is `(vecMulVec u v).det = 0`.

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include at least one commit authored by each
co-author among the commits in the pull request. If necessary, you may 
create empty commits to indicate co-authorship, using commands like so:

git commit --author="Author Name <author@email.com>" --allow-empty -m "add Author Name as coauthor"

When merging, all the commits will be squashed into a single commit listing all co-authors.

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
