### PR TITLE
[Merged by Bors] - feat(Data/Nat): p.Coprime factorial and choose

### DIFF
--- a/Mathlib/Data/Nat/Choose/Dvd.lean
+++ b/Mathlib/Data/Nat/Choose/Dvd.lean
@@ -31,6 +31,12 @@ lemma dvd_choose (hp : Prime p) (ha : a < p) (hab : b - a < p) (h : p ≤ b) : p
 lemma dvd_choose_self (hp : Prime p) (hk : k ≠ 0) (hkp : k < p) : p ∣ choose p k :=
   hp.dvd_choose hkp (sub_lt ((zero_le _).trans_lt hkp) <| zero_lt_of_ne_zero hk) le_rfl
 
+lemma coprime_choose_of_lt (hp : p.Prime) (hb : b < p) (ha : a ≤ b) :
+    p.Coprime (b.choose a) := by
+  rw [Nat.choose_eq_descFactorial_div_factorial]
+  exact (hp.coprime_descFactorial_of_lt_of_le hb ha).coprime_div_right
+    (Nat.factorial_dvd_descFactorial b a)
+
 end Prime
 
 end Nat

--- a/Mathlib/Data/Nat/Prime/Factorial.lean
+++ b/Mathlib/Data/Nat/Prime/Factorial.lean
@@ -33,4 +33,14 @@ theorem coprime_factorial_iff {m n : ℕ} (hm : m ≠ 1) :
   · rintro ⟨p, hp, hdvd, hdvd'⟩
     exact le_trans (minFac_le_of_dvd hp.two_le hdvd) (hp.dvd_factorial.mp hdvd')
 
+lemma Prime.coprime_factorial_of_lt {p n : ℕ} (hp : p.Prime) (hn : n < p) :
+    p.Coprime n.factorial := by
+  rwa [hp.coprime_iff_not_dvd, hp.dvd_factorial, not_le]
+
+lemma Prime.coprime_descFactorial_of_lt_of_le {p n k : ℕ} (hp : p.Prime) (hn : n < p) (hk : k ≤ n) :
+    p.Coprime (n.descFactorial k) := by
+  rw [Nat.descFactorial_eq_div hk]
+  refine (hp.coprime_factorial_of_lt hn).coprime_div_right ?_
+  simp [Nat.factorial_dvd_factorial]
+
 end Nat


### PR DESCRIPTION
And descFactorial, for n < p


---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include at least one commit authored by each
co-author among the commits in the pull request. If necessary, you may 
create empty commits to indicate co-authorship, using commands like so:

git commit --author="Author Name <author@email.com>" --allow-empty -m "add Author Name as coauthor"

When merging, all the commits will be squashed into a single commit listing all co-authors.

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
