### PR TITLE
feat(Mathlib/Analysis): deriv_eq_self and deriv_exp_iff

### DIFF
--- a/Mathlib/Analysis/SpecialFunctions/ExpDeriv.lean
+++ b/Mathlib/Analysis/SpecialFunctions/ExpDeriv.lean
@@ -6,6 +6,7 @@ Authors: Chris Hughes, Abhimanyu Pallavi Sudhir, Jean Lo, Calle Sönne
 module
 
 public import Mathlib.Analysis.Calculus.ContDiff.RCLike
+public import Mathlib.Analysis.Calculus.Deriv.Inv
 public import Mathlib.Analysis.Calculus.IteratedDeriv.Lemmas
 public import Mathlib.Analysis.Complex.RealDeriv
 public import Mathlib.Analysis.SpecialFunctions.Exp
@@ -210,6 +211,29 @@ theorem iteratedDeriv_cexp_const_mul (n : ℕ) (c : ℂ) :
     (iteratedDeriv n fun s : ℂ => exp (c * s)) = fun s => c ^ n * exp (c * s) := by
   rw [iteratedDeriv_comp_const_mul contDiff_exp, iteratedDeriv_eq_iterate, iter_deriv_exp]
 
+theorem deriv_eq_self_iff {𝕜 : Type*} [RCLike 𝕜]
+  {f : 𝕜 → 𝕜}
+  (g : 𝕜 → 𝕜)
+  (hf : Differentiable 𝕜 f)
+  (hg : Differentiable 𝕜 g)
+  (hg_deriv_self : deriv g = g)
+  (hg_ne_zero : ∀ z, g z ≠ 0) :
+    deriv f = f ↔ f = ((f 0) * (g 0)⁻¹) • g where
+  mp h := by
+    have f_g_deriv y : deriv (f / g) y = 0 := by
+      rw [deriv_div (hf _) (hg _) (hg_ne_zero _)]
+      simp [h, hg_deriv_self]
+    ext
+    rw [Pi.smul_apply, smul_eq_mul, ← div_eq_iff (hg_ne_zero _), eq_comm, ← div_eq_mul_inv,
+        ← Pi.div_apply, ← Pi.div_apply]
+    apply is_const_of_deriv_eq_zero (by fun_prop (disch := assumption)) f_g_deriv 0
+  mpr h := by rw [h]; simp [Pi.smul_def, hg_deriv_self]
+
+open Complex in
+theorem deriv_eq_self_iff_smul_cexp {f : ℂ → ℂ} (hf : Differentiable ℂ f) :
+  deriv f = f ↔ f = f 0 • exp := by
+    simpa using deriv_eq_self_iff exp hf (by simp) (by simp) (by simp)
+
 /-! ## `Real.exp` -/
 
 section
@@ -391,3 +415,8 @@ open Real in
 theorem iteratedDeriv_exp_const_mul (n : ℕ) (c : ℝ) :
     (iteratedDeriv n fun s => exp (c * s)) = fun s => c ^ n * exp (c * s) := by
   rw [iteratedDeriv_comp_const_mul contDiff_exp, iteratedDeriv_eq_iterate, iter_deriv_exp]
+
+open Real in
+theorem deriv_eq_self_iff_smul_rexp {f : ℝ → ℝ} (hf : Differentiable ℝ f) :
+  deriv f = f ↔ f = f 0 • exp := by
+    simpa using deriv_eq_self_iff exp hf (by simp) (by simp) (by simp)


### PR DESCRIPTION
---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include at least one commit authored by each
co-author among the commits in the pull request. If necessary, you may 
create empty commits to indicate co-authorship, using commands like so:

git commit --author="Author Name <author@email.com>" --allow-empty -m "add Author Name as coauthor"

When merging, all the commits will be squashed into a single commit listing all co-authors.

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
