### PR TITLE
[Merged by Bors] - refactor(Geometry/Euclidean/Altitude,Geometry/Euclidean/Incenter): use `Nat.AtLeastTwo`

### DIFF
--- a/Mathlib/Geometry/Euclidean/Altitude.lean
+++ b/Mathlib/Geometry/Euclidean/Altitude.lean
@@ -194,11 +194,11 @@ example {n : ℕ} [NeZero n] (s : Simplex ℝ P n) (i : Fin (n + 1)) : 0 < s.hei
 
 open scoped RealInnerProductSpace
 
-variable {n : ℕ} [NeZero n] (s : Simplex ℝ P n)
+variable {n : ℕ} (s : Simplex ℝ P n)
 
 /-- The inner product of an edge from `j` to `i` and the vector from the foot of `i` to `i`
 is the square of the height. -/
-lemma inner_vsub_vsub_altitudeFoot_eq_height_sq {i j : Fin (n + 1)} (h : i ≠ j) :
+lemma inner_vsub_vsub_altitudeFoot_eq_height_sq [NeZero n] {i j : Fin (n + 1)} (h : i ≠ j) :
     ⟪s.points i -ᵥ s.points j, s.points i -ᵥ s.altitudeFoot i⟫ = s.height i ^ 2 := by
   suffices ⟪s.points j -ᵥ s.altitudeFoot i, s.points i -ᵥ s.altitudeFoot i⟫ = 0 by
     rwa [height, inner_vsub_vsub_left_eq_dist_sq_right_iff, inner_vsub_left_eq_zero_symm]
@@ -211,12 +211,14 @@ lemma inner_vsub_vsub_altitudeFoot_eq_height_sq {i j : Fin (n + 1)} (h : i ≠ j
   rw [← direction_affineSpan, ← range_faceOpposite_points]
   exact vsub_orthogonalProjection_mem_direction_orthogonal _ _
 
+variable [Nat.AtLeastTwo n]
+
 /--
 The inner product of two distinct altitudes has absolute value strictly less than the product of
 their lengths.
 
 Equivalently, neither vector is a multiple of the other; the angle between them is not 0 or π. -/
-lemma abs_inner_vsub_altitudeFoot_lt_mul {i j : Fin (n + 1)} (hij : i ≠ j) (hn : 1 < n) :
+lemma abs_inner_vsub_altitudeFoot_lt_mul {i j : Fin (n + 1)} (hij : i ≠ j) :
     |⟪s.points i -ᵥ s.altitudeFoot i, s.points j -ᵥ s.altitudeFoot j⟫|
       < s.height i * s.height j := by
   apply lt_of_le_of_ne
@@ -234,7 +236,8 @@ lemma abs_inner_vsub_altitudeFoot_lt_mul {i j : Fin (n + 1)} (hij : i ≠ j) (hn
     · refine SetLike.le_def.1 (affineSpan_mono _ ?_) (Subtype.property _)
       simp
     · rw [SetLike.mem_coe]
-      have hk : ∃ k, k ≠ i ∧ k ≠ j := Fin.exists_ne_and_ne_of_two_lt i j (by linarith only [hn])
+      have hk : ∃ k, k ≠ i ∧ k ≠ j := Fin.exists_ne_and_ne_of_two_lt i j
+        (by linarith only [Nat.AtLeastTwo.one_lt (n := n)])
       have hs : vectorSpan ℝ (Set.range s.points) =
           vectorSpan ℝ (Set.range (s.faceOpposite i).points) ⊔
             vectorSpan ℝ (Set.range (s.faceOpposite j).points) := by
@@ -264,7 +267,7 @@ lemma abs_inner_vsub_altitudeFoot_lt_mul {i j : Fin (n + 1)} (hij : i ≠ j) (hn
 The inner product of two altitudes has value strictly greater than the negated product of
 their lengths.
 -/
-lemma neg_mul_lt_inner_vsub_altitudeFoot (i j : Fin (n + 1)) (hn : 1 < n) :
+lemma neg_mul_lt_inner_vsub_altitudeFoot (i j : Fin (n + 1)) :
     -(s.height i * s.height j)
       < ⟪s.points i -ᵥ s.altitudeFoot i, s.points j -ᵥ s.altitudeFoot j⟫ := by
   obtain rfl | hij := eq_or_ne i j
@@ -276,23 +279,22 @@ lemma neg_mul_lt_inner_vsub_altitudeFoot (i j : Fin (n + 1)) (hn : 1 < n) :
   rw [neg_lt]
   refine lt_of_abs_lt ?_
   rw [abs_neg]
-  exact abs_inner_vsub_altitudeFoot_lt_mul s hij hn
+  exact abs_inner_vsub_altitudeFoot_lt_mul s hij
 
-lemma abs_inner_vsub_altitudeFoot_div_lt_one {i j : Fin (n + 1)} (hij : i ≠ j) (hn : 1 < n) :
+lemma abs_inner_vsub_altitudeFoot_div_lt_one {i j : Fin (n + 1)} (hij : i ≠ j) :
     |⟪s.points i -ᵥ s.altitudeFoot i, s.points j -ᵥ s.altitudeFoot j⟫
             / (s.height i * s.height j)| < 1 := by
   rw [abs_div, div_lt_one (by simp [height])]
   nth_rw 2 [abs_eq_self.2]
-  · exact abs_inner_vsub_altitudeFoot_lt_mul _ hij hn
+  · exact abs_inner_vsub_altitudeFoot_lt_mul _ hij
   · simp only [height]
     positivity
 
-lemma neg_one_lt_inner_vsub_altitudeFoot_div
-    {n : ℕ} [NeZero n] (s : Simplex ℝ P n) (i j : Fin (n + 1)) (hn : 1 < n) :
+lemma neg_one_lt_inner_vsub_altitudeFoot_div (s : Simplex ℝ P n) (i j : Fin (n + 1)) :
     -1 < ⟪s.points i -ᵥ s.altitudeFoot i, s.points j -ᵥ s.altitudeFoot j⟫
             / (s.height i * s.height j) := by
   rw [neg_lt, neg_div', div_lt_one (by simp [height]), neg_lt]
-  exact neg_mul_lt_inner_vsub_altitudeFoot _ _ _ hn
+  exact neg_mul_lt_inner_vsub_altitudeFoot _ _ _
 
 end Simplex
 

--- a/Mathlib/Geometry/Euclidean/Incenter.lean
+++ b/Mathlib/Geometry/Euclidean/Incenter.lean
@@ -183,7 +183,7 @@ lemma inv_height_eq_sum_mul_inv_dist (i : Fin (n + 1)) :
 quantity for the other vertices. This implies the existence of the excenter opposite that vertex;
 it also implies that the image of the incenter under a homothety with scale factor 2 about a
 vertex lies outside the simplex. -/
-lemma inv_height_lt_sum_inv_height (hn : 1 < n) (i : Fin (n + 1)) :
+lemma inv_height_lt_sum_inv_height [Nat.AtLeastTwo n] (i : Fin (n + 1)) :
     (s.height i)⁻¹ < ∑ j ∈ {k | k ≠ i}, (s.height j)⁻¹ := by
   rw [inv_height_eq_sum_mul_inv_dist]
   refine Finset.sum_lt_sum_of_nonempty ?_ ?_
@@ -195,14 +195,14 @@ lemma inv_height_lt_sum_inv_height (hn : 1 < n) (i : Fin (n + 1)) :
     refine mul_lt_of_lt_one_left ?_ ?_
     · simp [height_pos]
     · rw [neg_lt]
-      exact neg_one_lt_inner_vsub_altitudeFoot_div _ _ _ hn
+      exact neg_one_lt_inner_vsub_altitudeFoot_div _ _ _
 
-lemma sum_excenterWeightsUnnorm_singleton_pos (hn : 1 < n) (i : Fin (n + 1)) :
+lemma sum_excenterWeightsUnnorm_singleton_pos [Nat.AtLeastTwo n] (i : Fin (n + 1)) :
     0 < ∑ j, s.excenterWeightsUnnorm {i} j := by
   rw [← Finset.sum_add_sum_compl {i}, Finset.sum_singleton]
   nth_rw 1 [excenterWeightsUnnorm]
   simp only [Finset.mem_singleton, ↓reduceIte, neg_mul, one_mul, lt_neg_add_iff_add_lt, add_zero]
-  convert s.inv_height_lt_sum_inv_height hn i using 2 with j h
+  convert s.inv_height_lt_sum_inv_height i using 2 with j h
   · ext j
     simp
   · rw [Finset.mem_filter_univ] at h
@@ -210,8 +210,8 @@ lemma sum_excenterWeightsUnnorm_singleton_pos (hn : 1 < n) (i : Fin (n + 1)) :
 
 /-- The existence of the excenter opposite a vertex (in two or more dimensions), expressed in
 terms of `ExcenterExists`. -/
-lemma excenterExists_singleton (hn : 1 < n) (i : Fin (n + 1)) : s.ExcenterExists {i} :=
-  (s.sum_excenterWeightsUnnorm_singleton_pos hn i).ne'
+lemma excenterExists_singleton [Nat.AtLeastTwo n] (i : Fin (n + 1)) : s.ExcenterExists {i} :=
+  (s.sum_excenterWeightsUnnorm_singleton_pos i).ne'
 
 /-- The exsphere with signs determined by the given set of indices (for the empty set, this is
 the insphere; for a singleton set, this is the exsphere opposite a vertex).  This is only
@@ -303,8 +303,8 @@ lemma ExcenterExists.exradius_pos {signs : Finset (Fin (n + 1))} (h : s.Excenter
 lemma inradius_pos : 0 < s.inradius :=
   s.excenterExists_empty.exradius_pos
 
-lemma exradius_singleton_pos (hn : 1 < n) (i : Fin (n + 1)) : 0 < s.exradius {i} :=
-  (s.excenterExists_singleton hn i).exradius_pos
+lemma exradius_singleton_pos [Nat.AtLeastTwo n] (i : Fin (n + 1)) : 0 < s.exradius {i} :=
+  (s.excenterExists_singleton i).exradius_pos
 
 variable {s} in
 lemma ExcenterExists.excenter_mem_affineSpan_range {signs : Finset (Fin (n + 1))}
@@ -314,9 +314,9 @@ lemma ExcenterExists.excenter_mem_affineSpan_range {signs : Finset (Fin (n + 1))
 lemma incenter_mem_affineSpan_range : s.incenter ∈ affineSpan ℝ (Set.range s.points) :=
   s.excenterExists_empty.excenter_mem_affineSpan_range
 
-lemma excenter_singleton_mem_affineSpan_range (hn : 1 < n) (i : Fin (n + 1)) :
+lemma excenter_singleton_mem_affineSpan_range [Nat.AtLeastTwo n] (i : Fin (n + 1)) :
     s.excenter {i} ∈ affineSpan ℝ (Set.range s.points) :=
-  (s.excenterExists_singleton hn i).excenter_mem_affineSpan_range
+  (s.excenterExists_singleton i).excenter_mem_affineSpan_range
 
 variable {s} in
 lemma ExcenterExists.signedInfDist_excenter_eq_mul_sum_inv {signs : Finset (Fin (n + 1))}


### PR DESCRIPTION
Using `[Nat.AtLeastTwo n]` in place of `(hn : 1 < n)` saves passing various explicit hypotheses around, and is convenient in particular if applying lemmas in the common use case of a triangle.

As [discussed on Zulip](https://leanprover.zulipchat.com/#narrow/channel/345428-mathlib-reviewers/topic/Use.20of.20.60Nat.2EAtLeastTwo.60/with/539258835), `AtLeastTwo` is mainly used with literals at present, and there is no clear consensus about broader use in groups of lemmas sharing a common value of `n`, but `NeZero` is used in a similar way in the `rootsOfUnity` API.

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include at least one commit authored by each
co-author among the commits in the pull request. If necessary, you may 
create empty commits to indicate co-authorship, using commands like so:

git commit --author="Author Name <author@email.com>" --allow-empty -m "add Author Name as coauthor"

When merging, all the commits will be squashed into a single commit listing all co-authors.

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
