### PR TITLE
[Merged by Bors] - chore: Revert "feat: computable shrink (#28112)"

### DIFF
--- a/Mathlib/Logic/Small/Defs.lean
+++ b/Mathlib/Logic/Small/Defs.lean
@@ -1,7 +1,7 @@
 /-
 Copyright (c) 2021 Kim Morrison. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
-Authors: Kim Morrison, William Sørensen, Robin Arnez
+Authors: Kim Morrison
 -/
 import Mathlib.Logic.Equiv.Defs
 import Mathlib.Tactic.MkIffOfInductiveProp
@@ -12,7 +12,7 @@ import Mathlib.Tactic.PPWithUniv
 
 A type is `w`-small if there exists an equivalence to some `S : Type w`.
 
-We provide a model `Shrink α : Type w`, and `equivShrink α : α ≃ Shrink α`.
+We provide a noncomputable model `Shrink α : Type w`, and `equivShrink α : α ≃ Shrink α`.
 
 A subsingleton type is `w`-small for any `w`.
 
@@ -41,23 +41,9 @@ theorem Small.mk' {α : Type v} {S : Type w} (e : α ≃ S) : Small.{w} α :=
 def Shrink (α : Type v) [Small.{w} α] : Type w :=
   Classical.choose (@Small.equiv_small α _)
 
-/--
-A computable implementation of `equivShrink`.
-
-The `implemented_by` using this to implement `equivShrink` is safe because:
-* `Shrink α` has no memory layout in the compiler that needs to be conformed to.
-* There is no other computable way to construct or destructure an object of type `Shrink α`.
-* There is also no other computable way to modify the content of a shrink
-  (as it always needs `Classical.choose_spec`).
+/-- The noncomputable equivalence between a `w`-small type and a model.
 -/
-@[inline]
-private unsafe def equivShrinkImpl (α : Type v) [Small.{u, v} α] : α ≃ Shrink.{u, v} α :=
-  ⟨unsafeCast, unsafeCast, lcProof, lcProof⟩
-
-/-- The equivalence between a `w`-small type and a model.
--/
-@[implemented_by equivShrinkImpl]
-def equivShrink (α : Type v) [Small.{w} α] : α ≃ Shrink α :=
+noncomputable def equivShrink (α : Type v) [Small.{w} α] : α ≃ Shrink α :=
   Nonempty.some (Classical.choose_spec (@Small.equiv_small α _))
 
 @[ext]
@@ -69,7 +55,7 @@ theorem Shrink.ext {α : Type v} [Small.{w} α] {x y : Shrink α}
 -- https://github.com/JLimperg/aesop/issues/59
 -- is resolved.
 @[induction_eliminator]
-protected def Shrink.rec {α : Type*} [Small.{w} α] {F : Shrink α → Sort v}
+protected noncomputable def Shrink.rec {α : Type*} [Small.{w} α] {F : Shrink α → Sort v}
     (h : ∀ X, F (equivShrink _ X)) : ∀ X, F X :=
   fun X => ((equivShrink _).apply_symm_apply X) ▸ (h _)
 


### PR DESCRIPTION
This reverts #28112, as it introduced a proof of `False` via `native_decide`.

See [#general > Cardinality model incompatible with Lean compiler @ 💬](https://leanprover.zulipchat.com/#narrow/channel/113488-general/topic/Cardinality.20model.20incompatible.20with.20Lean.20compiler/near/538013012)

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include at least one commit authored by each
co-author among the commits in the pull request. If necessary, you may 
create empty commits to indicate co-authorship, using commands like so:

git commit --author="Author Name <author@email.com>" --allow-empty -m "add Author Name as coauthor"

When merging, all the commits will be squashed into a single commit listing all co-authors.

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
