### PR TITLE
[Merged by Bors] - feat: a better version of `LinearOrder.lift`

### DIFF
--- a/Counterexamples/MapFloor.lean
+++ b/Counterexamples/MapFloor.lean
@@ -57,10 +57,9 @@ namespace IntWithEpsilon
 instance linearOrder : LinearOrder ℤ[ε] :=
   LinearOrder.lift' (toLex ∘ coeff) coeff_injective
 
-instance isOrderedAddMonoid : IsOrderedAddMonoid ℤ[ε] := by
-  refine (toLex.injective.comp coeff_injective).isOrderedAddMonoid _ ?_ ?_ ?_ <;>
-  (first | rfl | intros) <;> funext <;>
-  (simp only [comp_apply, Pi.toLex_apply, coeff_add]; rfl)
+instance isOrderedAddMonoid : IsOrderedAddMonoid ℤ[ε] :=
+  Function.Injective.isOrderedAddMonoid
+    (toLex ∘ coeff) (fun _ _ => funext fun _ => coeff_add _ _ _) .rfl
 
 theorem pos_iff {p : ℤ[ε]} : 0 < p ↔ 0 < p.trailingCoeff := by
   rw [trailingCoeff]

--- a/Mathlib/Algebra/Group/Subgroup/Order.lean
+++ b/Mathlib/Algebra/Group/Subgroup/Order.lean
@@ -76,7 +76,7 @@ variable {G : Type*}
 @[to_additive /-- An `AddSubgroup` of an `AddOrderedCommGroup` is an `AddOrderedCommGroup`. -/]
 instance toIsOrderedMonoid [CommGroup G] [PartialOrder G] [IsOrderedMonoid G] (H : Subgroup G) :
     IsOrderedMonoid H :=
-  Subtype.coe_injective.isOrderedMonoid _ rfl (fun _ _ => rfl) fun _ _ => rfl
+  Function.Injective.isOrderedMonoid Subtype.val (fun _ _ => rfl) .rfl
 
 end Subgroup
 

--- a/Mathlib/Algebra/Module/Submodule/Order.lean
+++ b/Mathlib/Algebra/Module/Submodule/Order.lean
@@ -20,14 +20,14 @@ variable [Semiring R]
 instance toIsOrderedAddMonoid [AddCommMonoid M] [PartialOrder M] [IsOrderedAddMonoid M]
     [Module R M] (S : Submodule R M) :
     IsOrderedAddMonoid S :=
-  Subtype.coe_injective.isOrderedAddMonoid Subtype.val rfl (fun _ _ => rfl) fun _ _ => rfl
+  Function.Injective.isOrderedAddMonoid Subtype.val (fun _ _ => rfl) .rfl
 
 /-- A submodule of an ordered cancellative additive monoid is an ordered cancellative additive
 monoid. -/
 instance toIsOrderedCancelAddMonoid [AddCommMonoid M] [PartialOrder M]
     [IsOrderedCancelAddMonoid M] [Module R M] (S : Submodule R M) :
     IsOrderedCancelAddMonoid S :=
-  Subtype.coe_injective.isOrderedCancelAddMonoid Subtype.val rfl (fun _ _ => rfl) fun _ _ => rfl
+  Function.Injective.isOrderedCancelAddMonoid Subtype.val (fun _ _ => rfl) .rfl
 
 end OrderedMonoid
 

--- a/Mathlib/Algebra/Order/Field/Subfield.lean
+++ b/Mathlib/Algebra/Order/Field/Subfield.lean
@@ -17,7 +17,7 @@ variable {K : Type*}
 /-- A subfield of an ordered field is a ordered field. -/
 instance toIsStrictOrderedRing [Field K] [LinearOrder K] [IsStrictOrderedRing K] (s : Subfield K) :
     IsStrictOrderedRing s :=
-  Subtype.coe_injective.isStrictOrderedRing Subtype.val rfl rfl (fun _ _ => rfl) (fun _ _ => rfl)
-    (fun _ _ => rfl) (fun _ _ => rfl) fun _ => rfl
+  Function.Injective.isStrictOrderedRing
+    Subtype.val rfl rfl (fun _ _ => rfl) (fun _ _ => rfl) .rfl .rfl
 
 end Subfield

--- a/Mathlib/Algebra/Order/GroupWithZero/Canonical.lean
+++ b/Mathlib/Algebra/Order/GroupWithZero/Canonical.lean
@@ -58,16 +58,20 @@ The following facts are true more generally in a (linearly) ordered commutative 
 /-- Pullback a `LinearOrderedCommMonoidWithZero` under an injective map.
 See note [reducible non-instances]. -/
 abbrev Function.Injective.linearOrderedCommMonoidWithZero {β : Type*} [Zero β] [Bot β] [One β]
-    [Mul β] [Pow β ℕ] [Max β] [Min β] (f : β → α) (hf : Function.Injective f) (zero : f 0 = 0)
+    [Mul β] [Pow β ℕ] [LE β] [LT β] [Max β] [Min β] [Ord β]
+    [DecidableEq β] [DecidableLE β] [DecidableLT β]
+    (f : β → α) (hf : Function.Injective f) (zero : f 0 = 0)
     (one : f 1 = 1) (mul : ∀ x y, f (x * y) = f x * f y) (npow : ∀ (x) (n : ℕ), f (x ^ n) = f x ^ n)
+    (le : ∀ {x y}, f x ≤ f y ↔ x ≤ y) (lt : ∀ {x y}, f x < f y ↔ x < y)
     (hsup : ∀ x y, f (x ⊔ y) = max (f x) (f y)) (hinf : ∀ x y, f (x ⊓ y) = min (f x) (f y))
-    (bot : f ⊥ = ⊥) : LinearOrderedCommMonoidWithZero β where
-  __ := LinearOrder.lift f hf hsup hinf
-  __ := hf.isOrderedMonoid f one mul npow
+    (bot : f ⊥ = ⊥)
+    (compare : ∀ x y, compare (f x) (f y) = compare x y) :
+    LinearOrderedCommMonoidWithZero β where
+  __ := hf.linearOrder f le lt hinf hsup compare
   __ := hf.commMonoidWithZero f zero one mul npow
-  zero_le_one :=
-      show f 0 ≤ f 1 by simp only [zero, one, LinearOrderedCommMonoidWithZero.zero_le_one]
-  bot_le a := show f ⊥ ≤ f a from bot ▸ bot_le
+  __ := Function.Injective.isOrderedMonoid f mul le
+  zero_le_one := le.1 <| by simp only [zero, one, LinearOrderedCommMonoidWithZero.zero_le_one]
+  bot_le a := le.1 <| bot ▸ bot_le
 
 @[simp] lemma zero_le' : 0 ≤ a := by
   simpa only [mul_zero, mul_one] using mul_le_mul_left' (zero_le_one' α) a

--- a/Mathlib/Algebra/Order/Monoid/Basic.lean
+++ b/Mathlib/Algebra/Order/Monoid/Basic.lean
@@ -4,7 +4,6 @@ Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Jeremy Avigad, Leonardo de Moura, Mario Carneiro, Johannes Hölzl
 -/
 import Mathlib.Algebra.Order.Monoid.Defs
-import Mathlib.Algebra.Group.InjSurj
 import Mathlib.Order.Hom.Basic
 
 /-!

--- a/Mathlib/Algebra/Order/Monoid/Basic.lean
+++ b/Mathlib/Algebra/Order/Monoid/Basic.lean
@@ -22,40 +22,31 @@ variable {α : Type u} {β : Type*} [CommMonoid α] [PartialOrder α]
 
 /-- Pullback an `IsOrderedMonoid` under an injective map. -/
 @[to_additive /-- Pullback an `IsOrderedAddMonoid` under an injective map. -/]
-lemma Function.Injective.isOrderedMonoid [IsOrderedMonoid α] [One β] [Mul β]
-    [Pow β ℕ] (f : β → α) (hf : Function.Injective f) (one : f 1 = 1)
-    (mul : ∀ x y, f (x * y) = f x * f y) (npow : ∀ (x) (n : ℕ), f (x ^ n) = f x ^ n) :
-    let _ : CommMonoid β := hf.commMonoid f one mul npow
-    let _ : PartialOrder β := PartialOrder.lift f hf
-    IsOrderedMonoid β :=
-  let _ : CommMonoid β := hf.commMonoid f one mul npow
-  let _ : PartialOrder β := PartialOrder.lift f hf
-  { mul_le_mul_left a b ab c := show f (c * a) ≤ f (c * b) by
-      rw [mul, mul]; apply mul_le_mul_left'; exact ab }
+lemma Function.Injective.isOrderedMonoid [IsOrderedMonoid α] [CommMonoid β]
+    [PartialOrder β] (f : β → α) (mul : ∀ x y, f (x * y) = f x * f y)
+    (le : ∀ {x y}, f x ≤ f y ↔ x ≤ y) :
+    IsOrderedMonoid β where
+  mul_le_mul_left a b ab c := le.1 <| by
+      rw [mul, mul]; apply mul_le_mul_left'; exact le.2 ab
 
 /-- Pullback an `IsOrderedMonoid` under a strictly monotone map. -/
 @[to_additive /-- Pullback an `IsOrderedAddMonoid` under a strictly monotone map. -/]
 lemma StrictMono.isOrderedMonoid [IsOrderedMonoid α] [CommMonoid β] [LinearOrder β]
     (f : β → α) (hf : StrictMono f) (mul : ∀ x y, f (x * y) = f x * f y) :
-    IsOrderedMonoid β where
-  mul_le_mul_left _ _ h _ := by
-    simp_rw [← hf.le_iff_le, mul] at h ⊢
-    simpa using mul_le_mul_left' h _
+    IsOrderedMonoid β :=
+  Function.Injective.isOrderedMonoid f mul hf.le_iff_le
 
 /-- Pullback an `IsOrderedCancelMonoid` under an injective map. -/
 @[to_additive Function.Injective.isOrderedCancelAddMonoid
     /-- Pullback an `IsOrderedCancelAddMonoid` under an injective map. -/]
-lemma Function.Injective.isOrderedCancelMonoid [IsOrderedCancelMonoid α] [One β] [Mul β]
-    [Pow β ℕ] (f : β → α) (hf : Injective f) (one : f 1 = 1) (mul : ∀ x y, f (x * y) = f x * f y)
-    (npow : ∀ (x) (n : ℕ), f (x ^ n) = f x ^ n) :
-    let _ : CommMonoid β := hf.commMonoid f one mul npow
-    let _ : PartialOrder β := PartialOrder.lift f hf
-    IsOrderedCancelMonoid β :=
-  let _ : CommMonoid β := hf.commMonoid f one mul npow
-  let _ : PartialOrder β := PartialOrder.lift f hf
-  { __ := hf.isOrderedMonoid f one mul npow
-    le_of_mul_le_mul_left a b c (bc : f (a * b) ≤ f (a * c)) :=
-      (mul_le_mul_iff_left (f a)).1 (by rwa [← mul, ← mul]) }
+lemma Function.Injective.isOrderedCancelMonoid [IsOrderedCancelMonoid α] [CommMonoid β]
+    [PartialOrder β]
+    (f : β → α) (mul : ∀ x y, f (x * y) = f x * f y)
+    (le : ∀ {x y}, f x ≤ f y ↔ x ≤ y) :
+    IsOrderedCancelMonoid β where
+  __ := Function.Injective.isOrderedMonoid f mul le
+  le_of_mul_le_mul_left a b c bc := le.1 <|
+      (mul_le_mul_iff_left (f a)).1 (by rwa [← mul, ← mul, le])
 
 /-- Pullback an `IsOrderedCancelMonoid` under a strictly monotone map. -/
 @[to_additive /-- Pullback an `IsOrderedAddCancelMonoid` under a strictly monotone map. -/]

--- a/Mathlib/Algebra/Order/Monoid/Submonoid.lean
+++ b/Mathlib/Algebra/Order/Monoid/Submonoid.lean
@@ -21,7 +21,7 @@ variable {M S : Type*} [SetLike S M]
 @[to_additive /-- An `AddSubmonoid` of an ordered additive monoid is an ordered additive monoid. -/]
 instance (priority := 75) toIsOrderedMonoid [CommMonoid M] [PartialOrder M] [IsOrderedMonoid M]
     [SubmonoidClass S M] (s : S) : IsOrderedMonoid s :=
-  Subtype.coe_injective.isOrderedMonoid Subtype.val rfl (fun _ _ => rfl) fun _ _ => rfl
+  Function.Injective.isOrderedMonoid Subtype.val (fun _ _ => rfl) .rfl
 
 -- Prefer subclasses of `Monoid` over subclasses of `SubmonoidClass`.
 /-- A submonoid of an ordered cancellative monoid is an ordered cancellative monoid. -/
@@ -31,7 +31,7 @@ instance (priority := 75) toIsOrderedMonoid [CommMonoid M] [PartialOrder M] [IsO
 instance (priority := 75) toIsOrderedCancelMonoid
     [CommMonoid M] [PartialOrder M] [IsOrderedCancelMonoid M]
     [SubmonoidClass S M] (s : S) : IsOrderedCancelMonoid s :=
-  Subtype.coe_injective.isOrderedCancelMonoid Subtype.val rfl (fun _ _ => rfl) fun _ _ => rfl
+  Function.Injective.isOrderedCancelMonoid Subtype.val (fun _ _ => rfl) .rfl
 
 
 end SubmonoidClass
@@ -43,7 +43,7 @@ variable {M : Type*}
 @[to_additive /-- An `AddSubmonoid` of an ordered additive monoid is an ordered additive monoid. -/]
 instance toIsOrderedMonoid [CommMonoid M] [PartialOrder M] [IsOrderedMonoid M]
     (S : Submonoid M) : IsOrderedMonoid S :=
-  Subtype.coe_injective.isOrderedMonoid Subtype.val rfl (fun _ _ => rfl) fun _ _ => rfl
+  Function.Injective.isOrderedMonoid Subtype.val (fun _ _ => rfl) .rfl
 
 /-- A submonoid of an ordered cancellative monoid is an ordered cancellative monoid. -/
 @[to_additive AddSubmonoid.toIsOrderedCancelAddMonoid
@@ -51,7 +51,7 @@ instance toIsOrderedMonoid [CommMonoid M] [PartialOrder M] [IsOrderedMonoid M]
       additive monoid. -/]
 instance toIsOrderedCancelMonoid [CommMonoid M] [PartialOrder M] [IsOrderedCancelMonoid M]
     (S : Submonoid M) : IsOrderedCancelMonoid S :=
-  Subtype.coe_injective.isOrderedCancelMonoid Subtype.val rfl (fun _ _ => rfl) fun _ _ => rfl
+  Function.Injective.isOrderedCancelMonoid Subtype.val (fun _ _ => rfl) .rfl
 
 section Preorder
 variable (M)

--- a/Mathlib/Algebra/Order/Monoid/Units.lean
+++ b/Mathlib/Algebra/Order/Monoid/Units.lean
@@ -32,21 +32,39 @@ instance instPartialOrderUnits [Monoid α] [PartialOrder α] : PartialOrder αˣ
   PartialOrder.lift val val_injective
 
 @[to_additive]
+instance [Monoid α] [LinearOrder α] : Max αˣ where
+  max a b := if a ≤ b then b else a
+
+@[to_additive]
+instance [Monoid α] [LinearOrder α] : Min αˣ where
+  min a b := if a ≤ b then a else b
+
+
+@[to_additive (attr := simp, norm_cast)]
+theorem max_val [Monoid α] [LinearOrder α] (a b : αˣ) : (max a b).val = max a.val b.val := by
+  simp_rw [max_def, val_le_val, ← apply_ite]
+  rfl
+
+@[to_additive (attr := simp, norm_cast)]
+theorem min_val [Monoid α] [LinearOrder α] (a b : αˣ) : (min a b).val = min a.val b.val := by
+  simp_rw [min_def, val_le_val, ← apply_ite]
+  rfl
+
+@[to_additive]
+instance [Monoid α] [Ord α] : Ord αˣ where
+  compare a b := compare a.val b.val
+
+@[to_additive]
+theorem compare_val [Monoid α] [Ord α] (a b : αˣ) : compare a.val b.val = compare a b := rfl
+
+@[to_additive]
 instance [Monoid α] [LinearOrder α] : LinearOrder αˣ :=
-  LinearOrder.lift' val val_injective
+  val_injective.linearOrder _ val_le_val val_lt_val min_val max_val compare_val
 
 /-- `val : αˣ → α` as an order embedding. -/
 @[to_additive (attr := simps -fullyApplied)
   /-- `val : add_units α → α` as an order embedding. -/]
 def orderEmbeddingVal [Monoid α] [LinearOrder α] : αˣ ↪o α :=
   ⟨⟨val, val_injective⟩, .rfl⟩
-
-@[to_additive (attr := simp, norm_cast)]
-theorem max_val [Monoid α] [LinearOrder α] {a b : αˣ} : (max a b).val = max a.val b.val :=
-  Monotone.map_max orderEmbeddingVal.monotone
-
-@[to_additive (attr := simp, norm_cast)]
-theorem min_val [Monoid α] [LinearOrder α] {a b : αˣ} : (min a b).val = min a.val b.val :=
-  Monotone.map_min orderEmbeddingVal.monotone
 
 end Units

--- a/Mathlib/Algebra/Order/Monoid/Units.lean
+++ b/Mathlib/Algebra/Order/Monoid/Units.lean
@@ -4,7 +4,6 @@ Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Jeremy Avigad, Leonardo de Moura, Mario Carneiro, Johannes Hölzl
 -/
 import Mathlib.Order.Hom.Basic
-import Mathlib.Order.MinMax
 import Mathlib.Algebra.Group.Units.Defs
 
 /-!

--- a/Mathlib/Algebra/Order/Nonneg/Ring.lean
+++ b/Mathlib/Algebra/Order/Nonneg/Ring.lean
@@ -42,23 +42,21 @@ namespace Nonneg
 
 instance isOrderedAddMonoid [AddCommMonoid α] [PartialOrder α] [IsOrderedAddMonoid α] :
     IsOrderedAddMonoid { x : α // 0 ≤ x } :=
-  Subtype.coe_injective.isOrderedAddMonoid _ Nonneg.coe_zero (fun _ _ => rfl) fun _ _ => rfl
+  Function.Injective.isOrderedAddMonoid Subtype.val Nonneg.coe_add .rfl
 
 instance isOrderedCancelAddMonoid [AddCommMonoid α] [PartialOrder α] [IsOrderedCancelAddMonoid α] :
     IsOrderedCancelAddMonoid { x : α // 0 ≤ x } :=
-  Subtype.coe_injective.isOrderedCancelAddMonoid _ Nonneg.coe_zero (fun _ _ => rfl) fun _ _ => rfl
+  Function.Injective.isOrderedCancelAddMonoid _ Nonneg.coe_add .rfl
 
 instance isOrderedRing [Semiring α] [PartialOrder α] [IsOrderedRing α] :
     IsOrderedRing { x : α // 0 ≤ x } :=
-  Subtype.coe_injective.isOrderedRing _ Nonneg.coe_zero Nonneg.coe_one
-    (fun _ _ => rfl) (fun _ _=> rfl) (fun _ _ => rfl)
-    (fun _ _ => rfl) fun _ => rfl
+  Function.Injective.isOrderedRing Subtype.val Nonneg.coe_zero Nonneg.coe_one Nonneg.coe_add
+    Nonneg.coe_mul .rfl
 
 instance isStrictOrderedRing [Semiring α] [PartialOrder α] [IsStrictOrderedRing α] :
     IsStrictOrderedRing { x : α // 0 ≤ x } :=
-  Subtype.coe_injective.isStrictOrderedRing _ Nonneg.coe_zero Nonneg.coe_one
-    (fun _ _ => rfl) (fun _ _ => rfl)
-    (fun _ _ => rfl) (fun _ _ => rfl) fun _ => rfl
+  Function.Injective.isStrictOrderedRing Subtype.val Nonneg.coe_zero Nonneg.coe_one Nonneg.coe_add
+    Nonneg.coe_mul .rfl .rfl
 
 instance existsAddOfLE [Semiring α] [PartialOrder α] [IsStrictOrderedRing α] [ExistsAddOfLE α] :
     ExistsAddOfLE { x : α // 0 ≤ x } :=

--- a/Mathlib/Algebra/Order/Ring/InjSurj.lean
+++ b/Mathlib/Algebra/Order/Ring/InjSurj.lean
@@ -15,42 +15,35 @@ variable {R S : Type*}
 
 namespace Function.Injective
 variable [Semiring R] [PartialOrder R]
-  [Zero S] [One S] [Add S] [Mul S] [SMul ℕ S] [Pow S ℕ] [NatCast S] (f : S → R) (hf : Injective f)
+-- variable [Zero S] [One S] [Add S] [Mul S] [SMul ℕ S] [Pow S ℕ] [NatCast S]
+-- variable (f : S → R) (hf : Injective f)
 
 /-- Pullback an `IsOrderedRing` under an injective map. -/
-protected lemma isOrderedRing [IsOrderedRing R] (zero : f 0 = 0) (one : f 1 = 1)
+protected lemma isOrderedRing [IsOrderedRing R] [Semiring S] [PartialOrder S]
+    (f : S → R) (zero : f 0 = 0) (one : f 1 = 1)
     (add : ∀ x y, f (x + y) = f x + f y) (mul : ∀ x y, f (x * y) = f x * f y)
-    (nsmul : ∀ (n : ℕ) (x), f (n • x) = n • f x) (npow : ∀ (x) (n : ℕ), f (x ^ n) = f x ^ n)
-    (natCast : ∀ n : ℕ, f n = n) :
-    letI _ : Semiring S := hf.semiring f zero one add mul nsmul npow natCast
-    letI _ : PartialOrder S := PartialOrder.lift f hf
+    (le : ∀ {x y}, f x ≤ f y ↔ x ≤ y) :
     IsOrderedRing S :=
-  letI _ : Semiring S := hf.semiring f zero one add mul nsmul npow natCast
-  letI _ : PartialOrder S := PartialOrder.lift f hf
-  { __ := hf.isOrderedAddMonoid f zero add (swap nsmul)
-    zero_le_one := show f 0 ≤ f 1 by simp only [zero, one, zero_le_one]
-    mul_le_mul_of_nonneg_left a b c h hc := show f (c * a) ≤ f (c * b) by
-      rw [mul, mul]; refine mul_le_mul_of_nonneg_left h ?_; rwa [← zero]
-    mul_le_mul_of_nonneg_right a b c h hc := show f (a * c) ≤ f (b * c) by
-      rw [mul, mul]; refine mul_le_mul_of_nonneg_right h ?_; rwa [← zero] }
+  { __ := Function.Injective.isOrderedAddMonoid f add le
+    zero_le_one := le.1 <| by simp only [zero, one, zero_le_one]
+    mul_le_mul_of_nonneg_left a b c h hc := le.1 <| by
+      rw [mul, mul]; refine mul_le_mul_of_nonneg_left (le.2 h) ?_; rwa [← zero, le]
+    mul_le_mul_of_nonneg_right a b c h hc := le.1 <| by
+      rw [mul, mul]; refine mul_le_mul_of_nonneg_right (le.2 h) ?_; rwa [← zero, le] }
 
 /-- Pullback a `IsStrictOrderedRing` under an injective map. -/
-protected lemma isStrictOrderedRing [IsStrictOrderedRing R] (zero : f 0 = 0) (one : f 1 = 1)
+protected lemma isStrictOrderedRing [IsStrictOrderedRing R] [Semiring S] [PartialOrder S]
+    (f : S → R) (zero : f 0 = 0) (one : f 1 = 1)
     (add : ∀ x y, f (x + y) = f x + f y) (mul : ∀ x y, f (x * y) = f x * f y)
-    (nsmul : ∀ (n : ℕ) (x), f (n • x) = n • f x) (npow : ∀ (x) (n : ℕ), f (x ^ n) = f x ^ n)
-    (natCast : ∀ n : ℕ, f n = n) :
-    letI _ : Semiring S := hf.semiring f zero one add mul nsmul npow natCast
-    letI _ : PartialOrder S := PartialOrder.lift f hf
+    (le : ∀ {x y}, f x ≤ f y ↔ x ≤ y) (lt : ∀ {x y}, f x < f y ↔ x < y) :
     IsStrictOrderedRing S :=
-  letI _ : Semiring S := hf.semiring f zero one add mul nsmul npow natCast
-  letI _ : PartialOrder S := PartialOrder.lift f hf
-  { __ := hf.isOrderedCancelAddMonoid f zero add (swap nsmul)
+  { __ := Function.Injective.isOrderedCancelAddMonoid f add le
     __ := domain_nontrivial f zero one
-    __ := hf.isOrderedRing f zero one add mul nsmul npow natCast
-    mul_lt_mul_of_pos_left a b c h hc := show f (c * a) < f (c * b) by
-      simpa only [mul, zero] using mul_lt_mul_of_pos_left ‹f a < f b› (by rwa [← zero])
-    mul_lt_mul_of_pos_right a b c h hc := show f (a * c) < f (b * c) by
-      simpa only [mul, zero] using mul_lt_mul_of_pos_right ‹f a < f b› (by rwa [← zero]) }
+    __ := Function.Injective.isOrderedRing f zero one add mul le
+    mul_lt_mul_of_pos_left a b c h hc := lt.1 <| by
+      simpa only [mul, zero] using mul_lt_mul_of_pos_left (lt.2 h) (by rwa [← zero, lt])
+    mul_lt_mul_of_pos_right a b c h hc := lt.1 <| by
+      simpa only [mul, zero] using mul_lt_mul_of_pos_right (lt.2 h) (by rwa [← zero, lt]) }
 
 @[deprecated (since := "2025-04-10")]
 protected alias orderedSemiring := Function.Injective.isOrderedRing

--- a/Mathlib/Algebra/Order/Ring/InjSurj.lean
+++ b/Mathlib/Algebra/Order/Ring/InjSurj.lean
@@ -5,7 +5,6 @@ Authors: Jeremy Avigad, Leonardo de Moura, Mario Carneiro
 -/
 import Mathlib.Algebra.Order.Monoid.Basic
 import Mathlib.Algebra.Order.Ring.Defs
-import Mathlib.Algebra.Ring.InjSurj
 
 /-!
 # Pulling back ordered rings along injective maps

--- a/Mathlib/Algebra/Ring/Subring/Order.lean
+++ b/Mathlib/Algebra/Ring/Subring/Order.lean
@@ -27,14 +27,13 @@ variable {R : Type*}
 /-- A subring of an ordered ring is an ordered ring. -/
 instance toIsOrderedRing [Ring R] [PartialOrder R] [IsOrderedRing R] (s : Subring R) :
     IsOrderedRing s :=
-  Subtype.coe_injective.isOrderedRing Subtype.val rfl rfl (fun _ _ => rfl) (fun _ _ => rfl)
-    (fun _ _ => rfl) (fun _ _ => rfl) fun _ => rfl
+  Function.Injective.isOrderedRing Subtype.val rfl rfl (fun _ _ => rfl) (fun _ _ => rfl) .rfl
 
 /-- A subring of a strict ordered ring is a strict ordered ring. -/
 instance toIsStrictOrderedRing [Ring R] [PartialOrder R] [IsStrictOrderedRing R]
     (s : Subring R) : IsStrictOrderedRing s :=
-  Subtype.coe_injective.isStrictOrderedRing Subtype.val rfl rfl (fun _ _ => rfl) (fun _ _ => rfl)
-    (fun _ _ => rfl) (fun _ _ => rfl) fun _ => rfl
+  Function.Injective.isStrictOrderedRing Subtype.val
+    rfl rfl (fun _ _ => rfl) (fun _ _ => rfl) .rfl .rfl
 
 /-- The inclusion `S → R` of a subring, as an ordered ring homomorphism. -/
 def orderedSubtype {R : Type*} [Ring R] [PartialOrder R] (s : Subring R) :

--- a/Mathlib/Algebra/Ring/Subsemiring/Order.lean
+++ b/Mathlib/Algebra/Ring/Subsemiring/Order.lean
@@ -18,14 +18,13 @@ variable {R S : Type*} [SetLike S R] (s : S)
 /-- A subsemiring of an ordered semiring is an ordered semiring. -/
 instance toIsOrderedRing [Semiring R] [PartialOrder R] [IsOrderedRing R] [SubsemiringClass S R] :
     IsOrderedRing s :=
-  Subtype.coe_injective.isOrderedRing Subtype.val rfl rfl (fun _ _ => rfl) (fun _ _ => rfl)
-    (fun _ _ => rfl) (fun _ _ => rfl) fun _ => rfl
+  Function.Injective.isOrderedRing Subtype.val rfl rfl (fun _ _ => rfl) (fun _ _ => rfl) .rfl
 
 /-- A subsemiring of a strict ordered semiring is a strict ordered semiring. -/
 instance toIsStrictOrderedRing [Semiring R] [PartialOrder R] [IsStrictOrderedRing R]
     [SubsemiringClass S R] : IsStrictOrderedRing s :=
-  Subtype.coe_injective.isStrictOrderedRing Subtype.val rfl rfl (fun _ _ => rfl) (fun _ _ => rfl)
-    (fun _ _ => rfl) (fun _ _ => rfl) fun _ => rfl
+  Function.Injective.isStrictOrderedRing Subtype.val
+    rfl rfl (fun _ _ => rfl) (fun _ _ => rfl) .rfl .rfl
 
 end SubsemiringClass
 
@@ -36,14 +35,12 @@ variable {R : Type*}
 /-- A subsemiring of an ordered semiring is an ordered semiring. -/
 instance toIsOrderedRing [Semiring R] [PartialOrder R] [IsOrderedRing R] (s : Subsemiring R) :
     IsOrderedRing s :=
-  Subtype.coe_injective.isOrderedRing Subtype.val rfl rfl (fun _ _ => rfl) (fun _ _ => rfl)
-    (fun _ _ => rfl) (fun _ _ => rfl) fun _ => rfl
+  SubsemiringClass.toIsOrderedRing _
 
 /-- A subsemiring of a strict ordered semiring is a strict ordered semiring. -/
 instance toIsStrictOrderedRing [Semiring R] [PartialOrder R] [IsStrictOrderedRing R]
     (s : Subsemiring R) : IsStrictOrderedRing s :=
-  Subtype.coe_injective.isStrictOrderedRing Subtype.val rfl rfl (fun _ _ => rfl) (fun _ _ => rfl)
-    (fun _ _ => rfl) (fun _ _ => rfl) fun _ => rfl
+  SubsemiringClass.toIsStrictOrderedRing _
 
 section nonneg
 

--- a/Mathlib/Analysis/Seminorm.lean
+++ b/Mathlib/Analysis/Seminorm.lean
@@ -187,7 +187,7 @@ instance instPartialOrder : PartialOrder (Seminorm 𝕜 E) :=
   PartialOrder.lift _ DFunLike.coe_injective
 
 instance instIsOrderedCancelAddMonoid : IsOrderedCancelAddMonoid (Seminorm 𝕜 E) :=
-  DFunLike.coe_injective.isOrderedCancelAddMonoid _ rfl coe_add fun _ _ => rfl
+  Function.Injective.isOrderedCancelAddMonoid DFunLike.coe coe_add .rfl
 
 instance instMulAction [Monoid R] [MulAction R ℝ] [SMul R ℝ≥0] [IsScalarTower R ℝ≥0 ℝ] :
     MulAction R (Seminorm 𝕜 E) :=

--- a/Mathlib/Order/Fin/Basic.lean
+++ b/Mathlib/Order/Fin/Basic.lean
@@ -42,10 +42,23 @@ variable {m n : ℕ}
 
 /-! ### Instances -/
 
+instance : Max (Fin n) where max x y := ⟨max x y, max_rec' (· < n) x.2 y.2⟩
+instance : Min (Fin n) where min x y := ⟨min x y, min_rec' (· < n) x.2 y.2⟩
+
+@[simp, norm_cast]
+theorem coe_max (a b : Fin n) : ↑(max a b) = (max a b : ℕ) := rfl
+
+@[simp, norm_cast]
+theorem coe_min (a b : Fin n) : ↑(min a b) = (min a b : ℕ) := rfl
+
+theorem compare_eq_compare_val (a b : Fin n) : compare a b = compare a.val b.val := rfl
+
+@[deprecated (since := "2025-03-01")] alias coe_sup := coe_max
+@[deprecated (since := "2025-03-01")] alias coe_inf := coe_min
+
 instance instLinearOrder : LinearOrder (Fin n) :=
-  @LinearOrder.liftWithOrd (Fin n) _ _ ⟨fun x y => ⟨max x y, max_rec' (· < n) x.2 y.2⟩⟩
-    ⟨fun x y => ⟨min x y, min_rec' (· < n) x.2 y.2⟩⟩ _ Fin.val Fin.val_injective (fun _ _ ↦ rfl)
-    (fun _ _ ↦ rfl) (fun _ _ ↦ rfl)
+  Fin.val_injective.linearOrder _
+    Fin.le_iff_val_le_val Fin.lt_iff_val_lt_val coe_min coe_max compare_eq_compare_val
 
 instance instBoundedOrder [NeZero n] : BoundedOrder (Fin n) where
   top := rev 0
@@ -56,14 +69,6 @@ instance instBoundedOrder [NeZero n] : BoundedOrder (Fin n) where
 instance instBiheytingAlgebra [NeZero n] : BiheytingAlgebra (Fin n) :=
   LinearOrder.toBiheytingAlgebra (Fin n)
 
-@[simp, norm_cast]
-theorem coe_max (a b : Fin n) : ↑(max a b) = (max a b : ℕ) := rfl
-
-@[simp, norm_cast]
-theorem coe_min (a b : Fin n) : ↑(min a b) = (min a b : ℕ) := rfl
-
-@[deprecated (since := "2025-03-01")] alias coe_sup := coe_max
-@[deprecated (since := "2025-03-01")] alias coe_inf := coe_min
 
 /- There is a slight asymmetry here, in the sense that `0` is of type `Fin n` when we have
 `[NeZero n]` whereas `last n` is of type `Fin (n + 1)`. To address this properly would

--- a/Mathlib/Order/Lattice.lean
+++ b/Mathlib/Order/Lattice.lean
@@ -1267,8 +1267,7 @@ instance [DistribLattice α] : DistribLattice (ULift.{v} α) :=
   ULift.down_injective.distribLattice _ down_sup down_inf
 
 instance [LinearOrder α] : LinearOrder (ULift.{v} α) :=
-  LinearOrder.liftWithOrd ULift.down ULift.down_injective down_sup down_inf
-    fun _x _y => (down_compare _ _).symm
+  ULift.down_injective.linearOrder _ down_le down_lt down_inf down_sup down_compare
 
 end ULift
 


### PR DESCRIPTION
This adds the following, which do not construct any new data and instead assume compatibility:

* `Function.Injective.preorder` (a generalization of `PreOrder.lift`)
* `Function.Injective.partialOrder` (a generalization of `PartialOrder.lift`)
* `Function.Injective.linearOrder` (a generalization of `LinearOrder.liftWithOrd` and the other three variants)

The following existing constructions are modified to do the same (and confusingly no longer assume injectivity):

* `Function.Injective.isOrderedAddMonoid`
* `Function.Injective.isOrderedRing`
* `Function.Injective.isStrictOrderedRing`

This fixes the instance diamond in [#mathlib4 > Instance diamond in DecidableEq Fin @ 💬](https://leanprover.zulipchat.com/#narrow/channel/287929-mathlib4/topic/Instance.20diamond.20in.20DecidableEq.20Fin/near/538119386) (which was discovered in #29418), by reusing the existing `Decidable` instance rather than constructing defeq-but-only-without-smart-unfolding instance from scratch.

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include at least one commit authored by each
co-author among the commits in the pull request. If necessary, you may 
create empty commits to indicate co-authorship, using commands like so:

git commit --author="Author Name <author@email.com>" --allow-empty -m "add Author Name as coauthor"

When merging, all the commits will be squashed into a single commit listing all co-authors.

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
