### PR TITLE
[Merged by Bors] - chore(*): replace `simp says` with a finishing tactic

### DIFF
--- a/Mathlib/Analysis/Calculus/SmoothSeries.lean
+++ b/Mathlib/Analysis/Calculus/SmoothSeries.lean
@@ -59,7 +59,7 @@ theorem summable_of_summable_hasDerivAt_of_isPreconnected (hu : Summable u) (ht 
     (hy : y ∈ t) : Summable fun n => g n y := by
   simp_rw [hasDerivAt_iff_hasFDerivAt] at hg
   refine summable_of_summable_hasFDerivAt_of_isPreconnected hu ht h't hg ?_ hy₀ hg0 hy
-  simpa? says simpa only [ContinuousLinearMap.norm_smulRight_apply, norm_one, one_mul]
+  simpa
 
 /-- Consider a series of functions `∑' n, f n x` on a preconnected open set. If the series converges
 at a point, and all functions in the series are differentiable with a summable bound on the
@@ -91,7 +91,7 @@ theorem hasDerivAt_tsum_of_isPreconnected (hu : Summable u) (ht : IsOpen t)
   convert hasFDerivAt_tsum_of_isPreconnected hu ht h't hg ?_ hy₀ hg0 hy
   · exact (ContinuousLinearMap.smulRightL 𝕜 𝕜 F 1).map_tsum <|
       .of_norm_bounded hu fun n ↦ hg' n y hy
-  · simpa? says simpa only [ContinuousLinearMap.norm_smulRight_apply, norm_one, one_mul]
+  · simpa
 
 /-- Consider a series of functions `∑' n, f n x`. If the series converges at a
 point, and all functions in the series are differentiable with a summable bound on the derivatives,
@@ -156,7 +156,7 @@ theorem differentiable_tsum' (hu : Summable u) (hg : ∀ n y, HasDerivAt (g n) (
     (hg' : ∀ n y, ‖g' n y‖ ≤ u n) : Differentiable 𝕜 fun z => ∑' n, g n z := by
   simp_rw [hasDerivAt_iff_hasFDerivAt] at hg
   refine differentiable_tsum hu hg ?_
-  simpa? says simpa only [ContinuousLinearMap.norm_smulRight_apply, norm_one, one_mul]
+  simpa
 
 theorem fderiv_tsum_apply (hu : Summable u) (hf : ∀ n, Differentiable 𝕜 (f n))
     (hf' : ∀ n x, ‖fderiv 𝕜 (f n) x‖ ≤ u n) (hf0 : Summable fun n => f n x₀) (x : E) :

--- a/Mathlib/Analysis/Convex/SpecificFunctions/Deriv.lean
+++ b/Mathlib/Analysis/Convex/SpecificFunctions/Deriv.lean
@@ -61,8 +61,7 @@ theorem Finset.prod_nonneg_of_card_nonpos_even {α β : Type*}
       Finset.prod_nonneg fun x _ => by
         split_ifs with hx
         · simp [hx]
-        simp? at hx ⊢ says simp only [not_le, one_mul] at hx ⊢
-        exact le_of_lt hx
+        linarith
     _ = _ := by
       rw [Finset.prod_mul_distrib, Finset.prod_ite, Finset.prod_const_one, mul_one,
         Finset.prod_const, neg_one_pow_eq_pow_mod_two, Nat.even_iff.1 h0, pow_zero, one_mul]

--- a/Mathlib/Analysis/SpecialFunctions/Bernstein.lean
+++ b/Mathlib/Analysis/SpecialFunctions/Bernstein.lean
@@ -104,9 +104,7 @@ local postfix:90 "/ₙ" => z
 theorem probability (n : ℕ) (x : I) : (∑ k : Fin (n + 1), bernstein n k x) = 1 := by
   have := bernsteinPolynomial.sum ℝ n
   apply_fun fun p => Polynomial.aeval (x : ℝ) p at this
-  simp? [map_sum, Finset.sum_range] at this says
-    simp only [Finset.sum_range, map_sum, Polynomial.coe_aeval_eq_eval, Polynomial.eval_one] at this
-  exact this
+  simpa [Finset.sum_range]
 
 theorem variance {n : ℕ} (hn : n ≠ 0) (x : I) :
     (∑ k : Fin (n + 1), (x - k/ₙ : ℝ) ^ 2 * bernstein n k x) = (x : ℝ) * (1 - x) / n := by

--- a/Mathlib/Analysis/SpecialFunctions/Gamma/Beta.lean
+++ b/Mathlib/Analysis/SpecialFunctions/Gamma/Beta.lean
@@ -86,15 +86,9 @@ theorem betaIntegral_convergent {u v : ℂ} (hu : 0 < re u) (hv : 0 < re v) :
   · norm_num
 
 theorem betaIntegral_symm (u v : ℂ) : betaIntegral v u = betaIntegral u v := by
-  rw [betaIntegral, betaIntegral]
-  have := intervalIntegral.integral_comp_mul_add (a := 0) (b := 1) (c := -1)
-    (fun x : ℝ => (x : ℂ) ^ (u - 1) * (1 - (x : ℂ)) ^ (v - 1)) neg_one_lt_zero.ne 1
-  rw [inv_neg, inv_one, neg_one_smul, ← intervalIntegral.integral_symm] at this
-  simp? at this says
-    simp only [neg_mul, one_mul, ofReal_add, ofReal_neg, ofReal_one, sub_add_cancel_right, neg_neg,
-      mul_one, neg_add_cancel, mul_zero, zero_add] at this
-  conv_lhs at this => arg 1; intro x; rw [add_comm, ← sub_eq_add_neg, mul_comm]
-  exact this
+  simpa [betaIntegral, ← intervalIntegral.integral_symm, add_comm, mul_comm, sub_eq_add_neg]
+    using intervalIntegral.integral_comp_mul_add (a := 0) (b := 1) (c := -1)
+      (fun x : ℝ => (x : ℂ) ^ (u - 1) * (1 - (x : ℂ)) ^ (v - 1)) neg_one_lt_zero.ne 1
 
 theorem betaIntegral_eval_one_right {u : ℂ} (hu : 0 < re u) : betaIntegral u 1 = 1 / u := by
   simp_rw [betaIntegral, sub_self, cpow_zero, mul_one]

--- a/Mathlib/CategoryTheory/Limits/Fubini.lean
+++ b/Mathlib/CategoryTheory/Limits/Fubini.lean
@@ -102,24 +102,10 @@ def coneOfConeUncurry {D : DiagramOfCones F} (Q : ∀ j, IsLimit (D.obj j))
             π :=
               { app := fun k => c.π.app (j, k)
                 naturality := fun k k' f => by
-                  dsimp; simp only [Category.id_comp]
-                  have := @NatTrans.naturality _ _ _ _ _ _ c.π (j, k) (j, k') (𝟙 j, f)
-                  dsimp at this
-                  simp? at this says
-                    simp only [Category.id_comp, map_id, NatTrans.id_app] at this
-                  exact this } }
+                  simpa using @NatTrans.naturality _ _ _ _ _ _ c.π (j, k) (j, k') (𝟙 j, f) } }
       naturality := fun j j' f =>
         (Q j').hom_ext
-          (by
-            dsimp
-            intro k
-            simp only [Limits.ConeMorphism.w, Limits.Cones.postcompose_obj_π,
-              Limits.IsLimit.fac_assoc, Limits.IsLimit.fac, NatTrans.comp_app, Category.id_comp,
-              Category.assoc]
-            have := @NatTrans.naturality _ _ _ _ _ _ c.π (j, k) (j', k) (f, 𝟙 k)
-            dsimp at this
-            simp only [Category.id_comp, Category.comp_id, CategoryTheory.Functor.map_id] at this
-            exact this) }
+          (fun k => by simpa using @NatTrans.naturality _ _ _ _ _ _ c.π (j, k) (j', k) (f, 𝟙 k)) }
 
 /-- Given a diagram `D` of limit cones over the `curry.obj G j`, and a cone over `G`,
 we can construct a cone over the diagram consisting of the cone points from `D`.

--- a/Mathlib/CategoryTheory/Monoidal/Preadditive.lean
+++ b/Mathlib/CategoryTheory/Monoidal/Preadditive.lean
@@ -295,10 +295,7 @@ theorem leftDistributor_ext_left {J : Type} [Finite J] {X Y : C} {f : J → C} {
   cases nonempty_fintype J
   apply (cancel_epi (leftDistributor X f).inv).mp
   ext
-  simp? [leftDistributor_inv, Preadditive.comp_sum_assoc, biproduct.ι_π_assoc, dite_comp] says
-    simp only [leftDistributor_inv, Preadditive.comp_sum_assoc, biproduct.ι_π_assoc, dite_comp,
-      zero_comp, Finset.sum_dite_eq, Finset.mem_univ, ↓reduceIte, eqToHom_refl, Category.id_comp]
-  apply w
+  simp [w]
 
 @[ext]
 theorem leftDistributor_ext_right {J : Type} [Finite J] {X Y : C} {f : J → C} {g h : X ⟶ Y ⊗ ⨁ f}
@@ -307,11 +304,7 @@ theorem leftDistributor_ext_right {J : Type} [Finite J] {X Y : C} {f : J → C} 
   cases nonempty_fintype J
   apply (cancel_mono (leftDistributor Y f).hom).mp
   ext
-  simp? [leftDistributor_hom, Preadditive.sum_comp, Preadditive.comp_sum_assoc, biproduct.ι_π,
-      comp_dite] says
-    simp only [leftDistributor_hom, Category.assoc, Preadditive.sum_comp, biproduct.ι_π, comp_dite,
-      comp_zero, Finset.sum_dite_eq', Finset.mem_univ, ↓reduceIte, eqToHom_refl, Category.comp_id]
-  apply w
+  simp [w]
 
 -- One might wonder how many iterated tensor products we need simp lemmas for.
 -- The answer is two: this lemma is needed to verify the pentagon identity.
@@ -341,10 +334,7 @@ theorem rightDistributor_ext_left {J : Type} [Finite J]
   cases nonempty_fintype J
   apply (cancel_epi (rightDistributor f X).inv).mp
   ext
-  simp? [rightDistributor_inv, Preadditive.comp_sum_assoc, biproduct.ι_π_assoc, dite_comp] says
-    simp only [rightDistributor_inv, Preadditive.comp_sum_assoc, biproduct.ι_π_assoc, dite_comp,
-      zero_comp, Finset.sum_dite_eq, Finset.mem_univ, ↓reduceIte, eqToHom_refl, Category.id_comp]
-  apply w
+  simp [w]
 
 @[ext]
 theorem rightDistributor_ext_right {J : Type} [Finite J]
@@ -354,11 +344,7 @@ theorem rightDistributor_ext_right {J : Type} [Finite J]
   cases nonempty_fintype J
   apply (cancel_mono (rightDistributor f Y).hom).mp
   ext
-  simp? [rightDistributor_hom, Preadditive.sum_comp, Preadditive.comp_sum_assoc, biproduct.ι_π,
-      comp_dite] says
-    simp only [rightDistributor_hom, Category.assoc, Preadditive.sum_comp, biproduct.ι_π, comp_dite,
-      comp_zero, Finset.sum_dite_eq', Finset.mem_univ, ↓reduceIte, eqToHom_refl, Category.comp_id]
-  apply w
+  simp [w]
 
 @[ext]
 theorem rightDistributor_ext₂_left {J : Type} [Finite J]

--- a/Mathlib/Data/List/Sigma.lean
+++ b/Mathlib/Data/List/Sigma.lean
@@ -719,10 +719,7 @@ theorem mem_dlookup_kunion {a} {b : β a} {l₁ l₂ : List (Sigma β)} :
     by_cases h₁ : a = a'
     · subst h₁
       simp
-    · let h₂ := @ih (kerase a' l₂)
-      simp? [h₁] at h₂ says
-        simp only [Option.mem_def, ne_eq, h₁, not_false_eq_true, dlookup_kerase_ne] at h₂
-      simp [h₁, h₂]
+    · simp [h₁, @ih (kerase a' l₂)]
 
 @[simp]
 theorem dlookup_kunion_eq_some {a} {b : β a} {l₁ l₂ : List (Sigma β)} :

--- a/Mathlib/Data/Nat/Pairing.lean
+++ b/Mathlib/Data/Nat/Pairing.lean
@@ -113,9 +113,8 @@ theorem pair_lt_pair_left {a₁ a₂} (b) (h : a₁ < a₂) : pair a₁ b < pair
   · by_cases h₂ : a₂ < b
     · simp [h₂, h]
     simp only [h₂, ↓reduceIte]
-    simp? at h₂ says simp only [not_lt] at h₂
     apply Nat.add_lt_add_of_le_of_lt
-    · exact Nat.mul_self_le_mul_self h₂
+    · exact Nat.mul_self_le_mul_self (not_lt.mp h₂)
     · exact Nat.lt_add_right _ h
   · simp at h₁
     simp only [not_lt_of_gt (lt_of_le_of_lt h₁ h), ite_false]
@@ -129,10 +128,9 @@ theorem pair_lt_pair_right (a) {b₁ b₂} (h : b₁ < b₂) : pair a b₁ < pai
   · simp only [pair, h₁, ↓reduceIte, Nat.add_assoc]
     by_cases h₂ : a < b₂; swap; · simp [h₂, h]
     simp only [h₂, ↓reduceIte]
-    simp? at h₁ says simp only [not_lt] at h₁
     rw [Nat.add_comm, Nat.add_comm _ a, Nat.add_assoc, Nat.add_lt_add_iff_left]
     rwa [Nat.add_comm, ← sqrt_lt, sqrt_add_eq]
-    exact le_trans h₁ (Nat.le_add_left _ _)
+    exact le_trans (not_lt.mp h₁) (Nat.le_add_left _ _)
 
 theorem pair_lt_max_add_one_sq (m n : ℕ) : pair m n < (max m n + 1) ^ 2 := by
   simp only [pair, Nat.pow_two, Nat.mul_add, Nat.add_mul, Nat.mul_one, Nat.one_mul, Nat.add_assoc]

--- a/Mathlib/Data/Seq/Parallel.lean
+++ b/Mathlib/Data/Seq/Parallel.lean
@@ -209,8 +209,7 @@ theorem exists_of_mem_parallel {S : WSeq (Computation α)} {a} (h : a ∈ parall
           apply ret_mem
         · intro a' h
           rcases h with ⟨d, dm, ad⟩
-          simp? at dm says simp only [List.mem_cons] at dm
-          rcases dm with e | dl
+          rcases List.mem_cons.mp dm with e | dl
           · rw [e] at ad
             refine ⟨c, List.mem_cons_self, ?_⟩
             rw [destruct_eq_think h]

--- a/Mathlib/Data/Stream/Init.lean
+++ b/Mathlib/Data/Stream/Init.lean
@@ -596,10 +596,7 @@ lemma drop_append_of_le_length (h : n ≤ x.length) :
 theorem take_theorem (s₁ s₂ : Stream' α) : (∀ n : ℕ, take n s₁ = take n s₂) → s₁ = s₂ := by
   intro h; apply Stream'.ext; intro n
   induction' n with n _
-  · have aux := h 1
-    simp? [take] at aux says
-      simp only [take, List.cons.injEq, and_true] at aux
-    exact aux
+  · simpa [take] using h 1
   · have h₁ : some (get s₁ (succ n)) = some (get s₂ (succ n)) := by
       rw [← getElem?_take_succ, ← getElem?_take_succ, h (succ (succ n))]
     injection h₁

--- a/Mathlib/Geometry/Manifold/PartitionOfUnity.lean
+++ b/Mathlib/Geometry/Manifold/PartitionOfUnity.lean
@@ -797,8 +797,7 @@ theorem exists_msmooth_support_eq_eq_one_iff
         apply lt_of_le_of_ne (g_pos x) (Ne.symm ?_)
         rw [← mem_support, g_supp]
         contrapose! xs
-        simp? at xs says simp only [mem_compl_iff, Decidable.not_not] at xs
-        exact h.trans f_supp.symm.subset xs
+        exact h.trans f_supp.symm.subset (by simpa using xs)
       linarith [f_pos x]
   refine ⟨fun x ↦ f x / (f x + g x), ?_, ?_, ?_, ?_⟩
   -- show that `f / (f + g)` is smooth

--- a/Mathlib/GroupTheory/FreeGroup/Reduce.lean
+++ b/Mathlib/GroupTheory/FreeGroup/Reduce.lean
@@ -95,9 +95,7 @@ theorem reduce.not {p : Prop} :
       dsimp; intro h
       exfalso
       have := congr_arg List.length h
-      simp? [List.length] at this says
-        simp only [List.length, zero_add, List.length_append] at this
-      omega
+      grind
     | cons hd tail =>
       obtain ⟨y, c⟩ := hd
       dsimp only

--- a/Mathlib/LinearAlgebra/SesquilinearForm.lean
+++ b/Mathlib/LinearAlgebra/SesquilinearForm.lean
@@ -264,10 +264,7 @@ variable [CommSemiring R] [AddCommGroup M] [Module R M] [CommSemiring R₁] [Add
 
 theorem neg (H : B.IsAlt) (x y : M₁) : -B x y = B y x := by
   have H1 : B (y + x) (y + x) = 0 := self_eq_zero H (y + x)
-  simp? [map_add, self_eq_zero H] at H1 says
-    simp only [map_add, add_apply, self_eq_zero H, zero_add, add_zero] at H1
-  rw [add_eq_zero_iff_neg_eq] at H1
-  exact H1
+  simpa [map_add, self_eq_zero H, add_eq_zero_iff_neg_eq] using H1
 
 theorem isRefl (H : B.IsAlt) : B.IsRefl := by
   intro x y h

--- a/Mathlib/Logic/Equiv/Set.lean
+++ b/Mathlib/Logic/Equiv/Set.lean
@@ -248,7 +248,6 @@ theorem union_symm_apply_right {α} {s t : Set α} [DecidablePred fun x => x ∈
 /-- A singleton set is equivalent to a `PUnit` type. -/
 protected def singleton {α} (a : α) : ({a} : Set α) ≃ PUnit.{u} :=
   ⟨fun _ => PUnit.unit, fun _ => ⟨a, mem_singleton _⟩, fun ⟨x, h⟩ => by
-    simp? at h says simp only [mem_singleton_iff] at h
     subst x
     rfl, fun ⟨⟩ => rfl⟩
 

--- a/Mathlib/MeasureTheory/Measure/Decomposition/Lebesgue.lean
+++ b/Mathlib/MeasureTheory/Measure/Decomposition/Lebesgue.lean
@@ -740,12 +740,7 @@ theorem exists_positive_of_not_mutuallySingular (μ ν : Measure α) [IsFiniteMe
       rw [← ENNReal.coe_le_coe, ENNReal.coe_mul]
       exact hA₃ n
     · rw [not_lt, le_zero_iff] at hb
-      specialize hA₃ 0
-      simp? [hb] at hA₃ says
-        simp only [CharP.cast_eq_zero, zero_add, ne_eq, one_ne_zero, not_false_eq_true, div_self,
-          ENNReal.coe_one, hb, ENNReal.coe_zero, mul_zero, nonpos_iff_eq_zero,
-          ENNReal.coe_eq_zero] at hA₃
-      assumption
+      simpa [hb] using hA₃ 0
   -- since `μ` and `ν` are not mutually singular, `μ A = 0` implies `ν Aᶜ > 0`
   rw [MutuallySingular] at h; push_neg at h
   have := h _ hAmeas hμ

--- a/Mathlib/ModelTheory/Algebra/Ring/Definability.lean
+++ b/Mathlib/ModelTheory/Algebra/Ring/Definability.lean
@@ -38,13 +38,7 @@ theorem mvPolynomial_zeroLocus_definable {ι K : Type*} [Field K]
           (Sum.map (fun p => ⟨p.1.1.coeff p.2.1, by
             simp only [Set.mem_iUnion]
             exact ⟨p.1.1, p.1.2, Set.mem_image_of_mem _ p.2.2⟩⟩) id)) 0), ?_⟩
-  -- Squeezing this simp slows it down significantly. Please measure before removing.
-  simp? [Formula.Realize, Term.equal, Function.comp_def, p', MvPolynomial.aeval_eq_eval₂Hom] says
-    simp only [Finset.mem_coe, aeval_eq_eval₂Hom, Algebra.algebraMap_self, coe_eval₂Hom, eval₂_id,
-      Formula.Realize, Term.equal, Term.relabel_relabel, Function.comp_def, realize_iInf,
-      realize_bdEqual, Term.realize_relabel, Sum.elim_inl, realize_termOfFreeCommRing,
-      lift_genericPolyMap, Sum.map_inr, id_eq, Sum.elim_inr, Sum.map_inl,
-      MvPolynomialSupportLEEquiv_symm_apply_coeff, realize_zero, Subtype.forall, p']
+  simp [Formula.Realize, Term.equal, Function.comp_def, p', MvPolynomial.aeval_eq_eval₂Hom]
 
 end Ring
 

--- a/Mathlib/Probability/ProbabilityMassFunction/Monad.lean
+++ b/Mathlib/Probability/ProbabilityMassFunction/Monad.lean
@@ -260,11 +260,10 @@ theorem bindOnSupport_bindOnSupport (p : PMF α) (f : ∀ a ∈ p.support, PMF �
   classical
   simp only [ENNReal.tsum_eq_zero]
   refine ENNReal.tsum_comm.trans (tsum_congr fun a' => tsum_congr fun b => ?_)
-  split_ifs with h _ h_1 _ h_2
+  split_ifs with h _ h_1 H h_2
   any_goals ring1
-  · have := h_1 a'
-    simp? [h] at this says simp only [h, ↓reduceDIte, mul_eq_zero, false_or] at this
-    contradiction
+  · absurd H
+    simpa [h] using h_1 a'
   · simp [h_2]
 
 theorem bindOnSupport_comm (p : PMF α) (q : PMF β) (f : ∀ a ∈ p.support, ∀ b ∈ q.support, PMF γ) :

--- a/Mathlib/RingTheory/DedekindDomain/Factorization.lean
+++ b/Mathlib/RingTheory/DedekindDomain/Factorization.lean
@@ -73,8 +73,7 @@ theorem Ideal.finite_factors {I : Ideal R} (hI : I ≠ 0) :
   refine
     Finite.of_injective (fun v => (⟨(v : HeightOneSpectrum R).asIdeal, v.2⟩ : { x // x ∣ I })) ?_
   intro v w hvw
-  simp? at hvw says simp only [Subtype.mk.injEq] at hvw
-  exact Subtype.coe_injective (HeightOneSpectrum.ext hvw)
+  exact Subtype.coe_injective (HeightOneSpectrum.ext (by simpa using hvw))
 
 open scoped Classical in
 /-- For every nonzero ideal `I` of `v`, there are finitely many maximal ideals `v` such that the

--- a/Mathlib/Topology/MetricSpace/Completion.lean
+++ b/Mathlib/Topology/MetricSpace/Completion.lean
@@ -124,11 +124,8 @@ protected theorem mem_uniformity_dist (s : Set (Completion α × Completion α))
     have A : ∀ a b : Completion α, (a, b) ∈ t1 → dist a b < ε := by
       intro a b hab
       have : ((a, b), (a, a)) ∈ t1 ×ˢ t2 := ⟨hab, refl_mem_uniformity ht2⟩
-      have I := ht this
-      simp? [r, Completion.dist_self, Real.dist_eq, Completion.dist_comm] at I says
-        simp only [Real.dist_eq, mem_setOf_eq, preimage_setOf_eq, Completion.dist_self,
-          Completion.dist_comm, zero_sub, abs_neg, r] at I
-      exact lt_of_le_of_lt (le_abs_self _) I
+      exact lt_of_le_of_lt (le_abs_self _)
+        (by simpa [r, Completion.dist_self, Real.dist_eq, Completion.dist_comm] using ht this)
     grind
 
 /-- Reformulate `Completion.mem_uniformity_dist` in terms that are suitable for the definition


### PR DESCRIPTION
Go through all the occurrences of `simp says` and, whenever a finishing tactic (`simp`, `simpa`, `linarith`, `grind`, ...) works in the same place, use that.

I hope this is the least controversial of the three PRs I plan to make.

Zulip thread: https://leanprover.zulipchat.com/#narrow/channel/287929-mathlib4/topic/noisy.20simp.20says.20in.20CI


---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include at least one commit authored by each
co-author among the commits in the pull request. If necessary, you may 
create empty commits to indicate co-authorship, using commands like so:

git commit --author="Author Name <author@email.com>" --allow-empty -m "add Author Name as coauthor"

When merging, all the commits will be squashed into a single commit listing all co-authors.

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
