### PR TITLE
[Merged by Bors] - chore(*): replace `simp? says` with `suffices`/`have`

### DIFF
--- a/Mathlib/Algebra/Category/MonCat/FilteredColimits.lean
+++ b/Mathlib/Algebra/Category/MonCat/FilteredColimits.lean
@@ -110,8 +110,7 @@ theorem colimitMulAux_eq_of_rel_left {x x' y : Σ j, F.obj j}
     colimitMulAux.{v, u} F x y = colimitMulAux.{v, u} F x' y := by
   obtain ⟨j₁, x⟩ := x; obtain ⟨j₂, y⟩ := y; obtain ⟨j₃, x'⟩ := x'
   obtain ⟨l, f, g, hfg⟩ := hxx'
-  simp? at hfg says
-    simp only [Functor.comp_obj, Functor.comp_map, ConcreteCategory.forget_map_eq_coe] at hfg
+  replace hfg : F.map f x = F.map g x' := by simpa
   obtain ⟨s, α, β, γ, h₁, h₂, h₃⟩ :=
     IsFiltered.tulip (IsFiltered.leftToMax j₁ j₂) (IsFiltered.rightToMax j₁ j₂)
       (IsFiltered.rightToMax j₃ j₂) (IsFiltered.leftToMax j₃ j₂) f g

--- a/Mathlib/AlgebraicTopology/FundamentalGroupoid/Basic.lean
+++ b/Mathlib/AlgebraicTopology/FundamentalGroupoid/Basic.lean
@@ -85,9 +85,8 @@ def reflTransSymm (p : Path x₀ x₁) : Homotopy (Path.refl x₀) (p.trans p.sy
     cases le_or_gt (x : ℝ) 2⁻¹ with
     | inl hx => simp [hx, ← extend_extends]
     | inr hx =>
-      simp? [hx.not_ge, ← extend_extends] says
-        simp only [one_div, hx.not_ge, ↓reduceIte, Set.Icc.coe_one, one_mul, ← extend_extends,
-          extend_symm, ContinuousMap.coe_mk, Function.comp_apply]
+      suffices p.extend (2 - 2 * ↑x) = p.extend (1 - (2 * ↑x - 1)) by
+        simpa [hx.not_ge, ← extend_extends]
       ring_nf
   prop' t := by norm_num [reflTransSymmAux]
 

--- a/Mathlib/AlgebraicTopology/FundamentalGroupoid/Basic.lean
+++ b/Mathlib/AlgebraicTopology/FundamentalGroupoid/Basic.lean
@@ -85,9 +85,8 @@ def reflTransSymm (p : Path x₀ x₁) : Homotopy (Path.refl x₀) (p.trans p.sy
     cases le_or_gt (x : ℝ) 2⁻¹ with
     | inl hx => simp [hx, ← extend_extends]
     | inr hx =>
-      suffices p.extend (2 - 2 * ↑x) = p.extend (1 - (2 * ↑x - 1)) by
-        simpa [hx.not_ge, ← extend_extends]
-      ring_nf
+      have : p.extend (2 - 2 * ↑x) = p.extend (1 - (2 * ↑x - 1)) := by ring_nf
+      simpa [hx.not_ge, ← extend_extends]
   prop' t := by norm_num [reflTransSymmAux]
 
 /-- For any path `p` from `x₀` to `x₁`, we have a homotopy from the constant path based at `x₁` to

--- a/Mathlib/Analysis/Calculus/IteratedDeriv/FaaDiBruno.lean
+++ b/Mathlib/Analysis/Calculus/IteratedDeriv/FaaDiBruno.lean
@@ -167,13 +167,13 @@ theorem iteratedDerivWithin_scomp_three
       3 • iteratedDerivWithin 2 f s x • derivWithin f s x • iteratedDerivWithin 2 g t (f x) +
       iteratedDerivWithin 3 f s x • derivWithin g t (f x) := by
   rw [iteratedDerivWithin_vcomp_three hg hf ht hs hx hst]
-  simp? [← derivWithin_fderivWithin, mul_smul, smul_comm (iteratedDerivWithin 2 f s x),
-      iteratedFDerivWithin_apply_eq_iteratedDerivWithin_mul_prod] says
-    simp only [iteratedFDerivWithin_apply_eq_iteratedDerivWithin_mul_prod, Finset.prod_const,
-      Finset.card_univ, Fintype.card_fin, Fin.prod_univ_two, Fin.isValue, Matrix.cons_val_zero,
-      Matrix.cons_val_one, Matrix.cons_val_fin_one, mul_smul,
-      smul_comm (iteratedDerivWithin 2 f s x), ← derivWithin_fderivWithin,
-      ContinuousLinearMap.smulRight_apply, ContinuousLinearMap.one_apply, add_left_inj]
+  suffices derivWithin f s x ^ 3 • iteratedDerivWithin 3 g t (f x) +
+      derivWithin f s x • iteratedDerivWithin 2 f s x • iteratedDerivWithin 2 g t (f x) +
+      2 • derivWithin f s x • iteratedDerivWithin 2 f s x • iteratedDerivWithin 2 g t (f x) =
+    derivWithin f s x ^ 3 • iteratedDerivWithin 3 g t (f x) +
+      3 • derivWithin f s x • iteratedDerivWithin 2 f s x • iteratedDerivWithin 2 g t (f x) by
+    simpa [← derivWithin_fderivWithin, mul_smul, smul_comm (iteratedDerivWithin 2 f s x),
+      iteratedFDerivWithin_apply_eq_iteratedDerivWithin_mul_prod]
   abel
 
 theorem iteratedDeriv_scomp_three (hg : ContDiffAt 𝕜 3 g (f x)) (hf : ContDiffAt 𝕜 3 f x) :

--- a/Mathlib/Analysis/Calculus/IteratedDeriv/FaaDiBruno.lean
+++ b/Mathlib/Analysis/Calculus/IteratedDeriv/FaaDiBruno.lean
@@ -167,13 +167,8 @@ theorem iteratedDerivWithin_scomp_three
       3 • iteratedDerivWithin 2 f s x • derivWithin f s x • iteratedDerivWithin 2 g t (f x) +
       iteratedDerivWithin 3 f s x • derivWithin g t (f x) := by
   rw [iteratedDerivWithin_vcomp_three hg hf ht hs hx hst]
-  suffices derivWithin f s x ^ 3 • iteratedDerivWithin 3 g t (f x) +
-      derivWithin f s x • iteratedDerivWithin 2 f s x • iteratedDerivWithin 2 g t (f x) +
-      2 • derivWithin f s x • iteratedDerivWithin 2 f s x • iteratedDerivWithin 2 g t (f x) =
-    derivWithin f s x ^ 3 • iteratedDerivWithin 3 g t (f x) +
-      3 • derivWithin f s x • iteratedDerivWithin 2 f s x • iteratedDerivWithin 2 g t (f x) by
-    simpa [← derivWithin_fderivWithin, mul_smul, smul_comm (iteratedDerivWithin 2 f s x),
-      iteratedFDerivWithin_apply_eq_iteratedDerivWithin_mul_prod]
+  simp [← derivWithin_fderivWithin, mul_smul, smul_comm (iteratedDerivWithin 2 f s x),
+        iteratedFDerivWithin_apply_eq_iteratedDerivWithin_mul_prod]
   abel
 
 theorem iteratedDeriv_scomp_three (hg : ContDiffAt 𝕜 3 g (f x)) (hf : ContDiffAt 𝕜 3 f x) :

--- a/Mathlib/Analysis/Convex/Function.lean
+++ b/Mathlib/Analysis/Convex/Function.lean
@@ -780,8 +780,7 @@ theorem neg_convexOn_iff : ConvexOn 𝕜 s (-f) ↔ ConcaveOn 𝕜 s f := by
   constructor
   · rintro ⟨hconv, h⟩
     refine ⟨hconv, fun x hx y hy a b ha hb hab => ?_⟩
-    have h := h hx hy ha hb hab
-    simpa [add_comm] using h
+    simpa [add_comm] using h hx hy ha hb hab
   · rintro ⟨hconv, h⟩
     refine ⟨hconv, fun x hx y hy a b ha hb hab => ?_⟩
     rw [← neg_le_neg_iff]

--- a/Mathlib/Analysis/Convex/Function.lean
+++ b/Mathlib/Analysis/Convex/Function.lean
@@ -780,10 +780,8 @@ theorem neg_convexOn_iff : ConvexOn 𝕜 s (-f) ↔ ConcaveOn 𝕜 s f := by
   constructor
   · rintro ⟨hconv, h⟩
     refine ⟨hconv, fun x hx y hy a b ha hb hab => ?_⟩
-    simp? [neg_apply, neg_le, add_comm] at h says
-      simp only [Pi.neg_apply, smul_neg, le_add_neg_iff_add_le, add_comm,
-        add_neg_le_iff_le_add] at h
-    exact h hx hy ha hb hab
+    have h := h hx hy ha hb hab
+    simpa [add_comm] using h
   · rintro ⟨hconv, h⟩
     refine ⟨hconv, fun x hx y hy a b ha hb hab => ?_⟩
     rw [← neg_le_neg_iff]

--- a/Mathlib/CategoryTheory/Abelian/Transfer.lean
+++ b/Mathlib/CategoryTheory/Abelian/Transfer.lean
@@ -52,21 +52,19 @@ variable (G : D ⥤ C) [Functor.PreservesZeroMorphisms G]
 
 /-- No point making this an instance, as it requires `i`. -/
 theorem hasKernels [PreservesFiniteLimits G] (i : F ⋙ G ≅ 𝟭 C) : HasKernels C :=
-  { has_limit := fun f => by
-      have := NatIso.naturality_1 i f
-      simp? at this says
-        simp only [Functor.id_obj, Functor.comp_obj, Functor.comp_map, Functor.id_map] at this
+  { has_limit {X Y} f := by
+      have : i.inv.app X ≫ G.map (F.map f) ≫ i.hom.app Y = f := by
+        simpa using NatIso.naturality_1 i f
       rw [← this]
       haveI : HasKernel (G.map (F.map f) ≫ i.hom.app _) := Limits.hasKernel_comp_mono _ _
       apply Limits.hasKernel_iso_comp }
 
 /-- No point making this an instance, as it requires `i` and `adj`. -/
 theorem hasCokernels (i : F ⋙ G ≅ 𝟭 C) (adj : G ⊣ F) : HasCokernels C :=
-  { has_colimit := fun f => by
+  { has_colimit {X Y} f := by
       have : PreservesColimits G := adj.leftAdjoint_preservesColimits
-      have := NatIso.naturality_1 i f
-      simp? at this says
-        simp only [Functor.id_obj, Functor.comp_obj, Functor.comp_map, Functor.id_map] at this
+      have : i.inv.app X ≫ G.map (F.map f) ≫ i.hom.app Y = f := by
+        simpa using NatIso.naturality_1 i f
       rw [← this]
       haveI : HasCokernel (G.map (F.map f) ≫ i.hom.app _) := Limits.hasCokernel_comp_iso _ _
       apply Limits.hasCokernel_epi_comp }

--- a/Mathlib/CategoryTheory/GradedObject.lean
+++ b/Mathlib/CategoryTheory/GradedObject.lean
@@ -265,7 +265,8 @@ instance : (total β C).Faithful where
     ext i
     replace w := Sigma.ι (fun i : β => X i) i ≫= w
     erw [colimit.ι_map, colimit.ι_map] at w
-    simp? at * says simp only [Discrete.functor_obj_eq_as, Discrete.natTrans_app] at *
+    replace w : f i ≫ colimit.ι (Discrete.functor Y) ⟨i⟩ =
+      g i ≫ colimit.ι (Discrete.functor Y) ⟨i⟩ := by simpa
     exact Mono.right_cancellation _ _ w
 
 end GradedObject

--- a/Mathlib/CategoryTheory/Limits/Shapes/BinaryProducts.lean
+++ b/Mathlib/CategoryTheory/Limits/Shapes/BinaryProducts.lean
@@ -1392,15 +1392,11 @@ protected def IsLimit.assoc (P : IsLimit sXY) (Q : IsLimit sYZ) {s : BinaryFan s
     · apply P.hom_ext
       rintro ⟨⟨⟩⟩ <;> simp
       · exact w ⟨.left⟩
-      · specialize w ⟨.right⟩
-        simp? at w says
-          simp only [pair_obj_right, BinaryFan.assoc_snd,
-            Functor.const_obj_obj, pair_obj_left] at w
+      · replace w : m ≫ Q.lift (BinaryFan.mk (s.fst ≫ sXY.snd) s.snd) = t.π.app ⟨.right⟩ := by
+          simpa using w ⟨.right⟩
         simp [← w]
-    · specialize w ⟨.right⟩
-      simp? at w says
-        simp only [pair_obj_right, BinaryFan.assoc_snd,
-          Functor.const_obj_obj, pair_obj_left] at w
+    · replace w : m ≫ Q.lift (BinaryFan.mk (s.fst ≫ sXY.snd) s.snd) = t.π.app ⟨.right⟩ := by
+        simpa using w ⟨.right⟩
       simp [← w]
 
 /-- Given two pairs of limit cones corresponding to the parenthesisations of `X × Y × Z`,

--- a/Mathlib/CategoryTheory/Limits/Shapes/Images.lean
+++ b/Mathlib/CategoryTheory/Limits/Shapes/Images.lean
@@ -102,7 +102,7 @@ theorem ext {F F' : MonoFactorisation f} (hI : F.I = F'.I)
     (hm : F.m = eqToHom hI ≫ F'.m) : F = F' := by
   obtain ⟨_, Fm, _, Ffac⟩ := F; obtain ⟨_, Fm', _, Ffac'⟩ := F'
   cases hI
-  simp? at hm says simp only [eqToHom_refl, Category.id_comp] at hm
+  replace hm : Fm = Fm' := by simpa using hm
   congr
   apply (cancel_mono Fm).1
   rw [Ffac, hm, Ffac']

--- a/Mathlib/CategoryTheory/Sites/ConstantSheaf.lean
+++ b/Mathlib/CategoryTheory/Sites/ConstantSheaf.lean
@@ -193,11 +193,8 @@ lemma constantSheafAdj_counit_w {T : C} (hT : IsTerminal T) :
   rw [comp_val, constantCommuteCompose_hom_app_val, assoc, Iso.inv_comp_eq]
   apply sheafify_hom_ext _ _ _ ((sheafCompose J U).obj F).cond
   ext x
-  suffices U.map _ = U.map ((toSheafify _ _).app x) ≫
-      U.map (((presheafToSheaf _ _).map ((constantPresheafAdj _ _).counit.app _)).val.app x) ≫
-      U.map ((sheafifyLift _ _ _).app x) by
-    simpa
-  simp [← map_comp, ← NatTrans.comp_app]
+  simp [NatTrans.comp_app] -- simp [NatTrans.comp_app] to unfold some definitions
+  simp [← map_comp, ← NatTrans.comp_app] -- simp [← NatTrans.comp_app] to simplify some compositions
 
 lemma Sheaf.isConstant_of_forget [constantSheaf J D |>.Faithful] [constantSheaf J D |>.Full]
     [constantSheaf J B |>.Faithful] [constantSheaf J B |>.Full]

--- a/Mathlib/CategoryTheory/Sites/ConstantSheaf.lean
+++ b/Mathlib/CategoryTheory/Sites/ConstantSheaf.lean
@@ -192,14 +192,11 @@ lemma constantSheafAdj_counit_w {T : C} (hT : IsTerminal T) :
   apply Sheaf.hom_ext
   rw [comp_val, constantCommuteCompose_hom_app_val, assoc, Iso.inv_comp_eq]
   apply sheafify_hom_ext _ _ _ ((sheafCompose J U).obj F).cond
-  ext
-  simp? says simp only [comp_obj, const_obj_obj, sheafCompose_obj_val, id_obj,
-      constantSheafAdj_counit_app, comp_val,
-      sheafificationAdjunction_counit_app_val, sheafifyMap_sheafifyLift, comp_id,
-      toSheafify_sheafifyLift, NatTrans.comp_app, constComp_hom_app,
-      constantPresheafAdj_counit_app_app, Functor.comp_map, id_comp, flip_obj_obj,
-      sheafToPresheaf_obj, map_comp, sheafCompose_map_val, sheafComposeIso_hom_fac_assoc,
-      whiskerRight_app]
+  ext x
+  suffices U.map _ = U.map ((toSheafify _ _).app x) ≫
+      U.map (((presheafToSheaf _ _).map ((constantPresheafAdj _ _).counit.app _)).val.app x) ≫
+      U.map ((sheafifyLift _ _ _).app x) by
+    simpa
   simp [← map_comp, ← NatTrans.comp_app]
 
 lemma Sheaf.isConstant_of_forget [constantSheaf J D |>.Faithful] [constantSheaf J D |>.Full]

--- a/Mathlib/Condensed/Discrete/Colimit.lean
+++ b/Mathlib/Condensed/Discrete/Colimit.lean
@@ -258,17 +258,11 @@ lemma isoLocallyConstantOfIsColimit_inv (X : Profinite.{u}ᵒᵖ ⥤ Type (u + 1
   ext S : 2
   apply colimit.hom_ext
   intro ⟨Y, _, g⟩
-  simp? [locallyConstantIsoFinYoneda, isoFinYoneda, counitApp] says
-    simp only [comp_obj, CostructuredArrow.proj_obj, op_obj, functorToPresheaves_obj_obj,
-      isoFinYoneda, locallyConstantIsoFinYoneda, finYoneda_obj, LocallyConstant.toFun_eq_coe,
-      NatTrans.comp_app, pointwiseLeftKanExtension_obj, lanPresheafExt_inv, Iso.trans_inv,
-      Iso.symm_inv, whiskerLeft_comp, lanPresheafNatIso_hom_app, Opposite.op_unop, colimit.map_desc,
-      colimit.ι_desc, Cocones.precompose_obj_pt, Profinite.Extend.cocone_pt,
-      Cocones.precompose_obj_ι, Category.assoc, const_obj_obj, whiskerLeft_app,
-      NatIso.ofComponents_hom_app, NatIso.ofComponents_inv_app, Profinite.Extend.cocone_ι_app,
-      counitApp, colimit.ι_desc_assoc]
+  suffices _ ≫ (isoFinYonedaComponents _ _).inv ≫ X.map g =
+    (locallyConstantPresheaf _).map g ≫ counitAppApp (Opposite.unop S) X by
+      simpa [locallyConstantIsoFinYoneda, isoFinYoneda, counitApp]
   erw [(counitApp.{u, u + 1} X).naturality]
-  simp only [← Category.assoc]
+  simp only [← Category.assoc, op_obj, functorToPresheaves_obj_obj]
   congr
   ext f
   simp only [types_comp_apply, counitApp_app]
@@ -532,17 +526,11 @@ lemma isoLocallyConstantOfIsColimit_inv (X : LightProfinite.{u}ᵒᵖ ⥤ Type u
   ext S : 2
   apply colimit.hom_ext
   intro ⟨Y, _, g⟩
-  simp? [locallyConstantIsoFinYoneda, isoFinYoneda, counitApp] says
-    simp only [comp_obj, CostructuredArrow.proj_obj, op_obj, functorToPresheaves_obj_obj,
-      isoFinYoneda, locallyConstantIsoFinYoneda, finYoneda_obj, LocallyConstant.toFun_eq_coe,
-      NatTrans.comp_app, pointwiseLeftKanExtension_obj, lanPresheafExt_inv, Iso.trans_inv,
-      Iso.symm_inv, whiskerLeft_comp, lanPresheafNatIso_hom_app, Opposite.op_unop, colimit.map_desc,
-      colimit.ι_desc, Cocones.precompose_obj_pt, LightProfinite.Extend.cocone_pt,
-      Cocones.precompose_obj_ι, Category.assoc, const_obj_obj, whiskerLeft_app,
-      NatIso.ofComponents_hom_app, NatIso.ofComponents_inv_app, LightProfinite.Extend.cocone_ι_app,
-      counitApp, colimit.ι_desc_assoc]
+  suffices _ ≫ (isoFinYonedaComponents _ _).inv ≫ X.map g =
+    (locallyConstantPresheaf _).map g ≫ counitAppApp (Opposite.unop S) X by
+      simpa [locallyConstantIsoFinYoneda, isoFinYoneda, counitApp]
   erw [(counitApp.{u, u} X).naturality]
-  simp only [← Category.assoc]
+  simp only [← Category.assoc, op_obj, functorToPresheaves_obj_obj]
   congr
   ext f
   simp only [types_comp_apply, counitApp_app]

--- a/Mathlib/Data/List/Basic.lean
+++ b/Mathlib/Data/List/Basic.lean
@@ -441,8 +441,8 @@ theorem tail_append_singleton_of_ne_nil {a : α} {l : List α} (h : l ≠ nil) :
 theorem cons_head?_tail : ∀ {l : List α} {a : α}, a ∈ head? l → a :: tail l = l
   | [], a, h => by contradiction
   | b :: l, a, h => by
-    simp? at h says simp only [head?_cons, Option.mem_def, Option.some.injEq] at h
-    simp [h]
+    have : b = a := by simpa using h
+    simp [this]
 
 theorem head!_mem_head? [Inhabited α] : ∀ {l : List α}, l ≠ [] → head! l ∈ head? l
   | [], h => by contradiction

--- a/Mathlib/Data/List/Sigma.lean
+++ b/Mathlib/Data/List/Sigma.lean
@@ -181,8 +181,8 @@ theorem of_mem_dlookup {a : α} {b : β a} :
   | ⟨a', b'⟩ :: l, H => by
     by_cases h : a = a'
     · subst a'
-      simp? at H says simp only [dlookup_cons_eq, Option.mem_def, Option.some.injEq] at H
-      simp [H]
+      have : b' = b := by simpa using H
+      simp [this]
     · simp only [ne_eq, h, not_false_iff, dlookup_cons_ne] at H
       simp [of_mem_dlookup H]
 

--- a/Mathlib/Data/List/Sublists.lean
+++ b/Mathlib/Data/List/Sublists.lean
@@ -362,10 +362,8 @@ theorem revzip_sublists (l : List α) : ∀ l₁ l₂, (l₁, l₂) ∈ revzip l
   rw [revzip]
   induction' l using List.reverseRecOn with l' a ih
   · intro l₁ l₂ h
-    simp? at h says
-      simp only [sublists_nil, reverse_cons, reverse_nil, nil_append, zip_cons_cons, zip_nil_right,
-        mem_cons, Prod.mk.injEq, not_mem_nil, or_false] at h
-    simp [h]
+    have : l₁ = [] ∧ l₂ = [] := by simpa using h
+    simp [this]
   · intro l₁ l₂ h
     rw [sublists_concat, reverse_append, zip_append (by simp), ← map_reverse, zip_map_right,
       zip_map_left] at *

--- a/Mathlib/Data/Nat/Bits.lean
+++ b/Mathlib/Data/Nat/Bits.lean
@@ -74,10 +74,8 @@ lemma bodd_mul (m n : ℕ) : bodd (m * n) = (bodd m && bodd n) := by
     cases bodd m <;> cases bodd n <;> rfl
 
 lemma mod_two_of_bodd (n : ℕ) : n % 2 = (bodd n).toNat := by
-  have := congr_arg bodd (mod_add_div n 2)
-  simp? [not] at this says
-    simp only [bodd_add, bodd_mul, bodd_succ, not, bodd_zero, Bool.false_and, Bool.bne_false]
-      at this
+  have : (n % 2).bodd = n.bodd := by
+    simpa using congr_arg bodd (mod_add_div n 2)
   have _ : ∀ b, and false b = false := by
     intro b
     cases b <;> rfl

--- a/Mathlib/Data/WSeq/Basic.lean
+++ b/Mathlib/Data/WSeq/Basic.lean
@@ -706,7 +706,7 @@ theorem exists_of_mem_join {a : α} : ∀ {S : WSeq (WSeq α)}, a ∈ join S →
       simp only [join_cons, nil_append, mem_think, mem_cons_iff, exists_eq_or_imp] at m ⊢
       exact IH s S rfl m
     · apply Or.inr
-      simp? at m says simp only [join_think, nil_append, mem_think] at m
+      replace m : a ∈ S.join := by simpa using m
       rcases (IH nil S (by simp) (by simp [m])).resolve_left (notMem_nil _) with ⟨s, sS, as⟩
       exact ⟨s, by simp [sS], as⟩
     · simp only [think_append, mem_think] at m IH ⊢

--- a/Mathlib/Geometry/Euclidean/Circumcenter.lean
+++ b/Mathlib/Geometry/Euclidean/Circumcenter.lean
@@ -157,10 +157,8 @@ theorem _root_.AffineIndependent.existsUnique_dist_eq {ι : Type*} [hne : Nonemp
       · simp_rw [hi default, Set.singleton_subset_iff]
         exact ⟨⟨⟩, by simp only [Metric.sphere_zero, Set.mem_singleton_iff]⟩
       · rintro ⟨cc, cr⟩
-        simp only
         rintro ⟨rfl, hdist⟩
-        simp? [Set.singleton_subset_iff] at hdist says
-          simp only [Set.singleton_subset_iff, Metric.mem_sphere, dist_self] at hdist
+        replace hdist : 0 = cr := by simpa using hdist
         rw [hi default, hdist]
     · have i := hne.some
       let ι2 := { x // x ≠ i }

--- a/Mathlib/Geometry/Manifold/Instances/Icc.lean
+++ b/Mathlib/Geometry/Manifold/Instances/Icc.lean
@@ -68,13 +68,7 @@ lemma contMDiff_subtype_coe_Icc :
   -- We come back to the definition: we should check that, in each chart, the map is smooth.
   -- There are two charts, and we check things separately in each of them using the
   -- explicit formulas.
-  simp? says
-    simp only [extChartAt, PartialHomeomorph.extend, PartialHomeomorph.refl_partialEquiv,
-      PartialEquiv.refl_source, PartialHomeomorph.singletonChartedSpace_chartAt_eq,
-      modelWithCornersSelf_partialEquiv, PartialEquiv.trans_refl, PartialEquiv.refl_coe,
-      Icc_chartedSpaceChartAt, PartialEquiv.coe_trans_symm, PartialHomeomorph.coe_coe_symm,
-      ModelWithCorners.toPartialEquiv_coe_symm, CompTriple.comp_eq, PartialEquiv.coe_trans,
-      ModelWithCorners.toPartialEquiv_coe, PartialHomeomorph.toFun_eq_coe, Function.comp_apply]
+  suffices ContDiffWithinAt ℝ n _ (range ↑(𝓡∂ 1)) _ by simpa
   split_ifs with hz
   · simp? [IccLeftChart, Function.comp_def, modelWithCornersEuclideanHalfSpace] says
       simp only [IccLeftChart, Fin.isValue, PartialHomeomorph.mk_coe_symm, PartialEquiv.coe_symm_mk,
@@ -115,38 +109,28 @@ lemma contMDiffOn_projIcc :
   -- We come back to the definition: we should check that, in each chart, the map is smooth
   -- There are two charts, and we check things separately in each of them using the
   -- explicit formulas.
-  simp? says
-    simp only [extChartAt, PartialHomeomorph.extend, Icc_chartedSpaceChartAt,
-      PartialEquiv.coe_trans, ModelWithCorners.toPartialEquiv_coe, PartialHomeomorph.toFun_eq_coe,
-      PartialHomeomorph.refl_partialEquiv, PartialEquiv.refl_source,
-      PartialHomeomorph.singletonChartedSpace_chartAt_eq, modelWithCornersSelf_partialEquiv,
-      PartialEquiv.trans_refl, PartialEquiv.refl_symm, PartialEquiv.refl_coe, CompTriple.comp_eq,
-      preimage_id_eq, id_eq, modelWithCornersSelf_coe, range_id, inter_univ]
+  suffices ContDiffWithinAt ℝ n _ (Icc x y) z by simpa
   split_ifs with h'z
-  · simp? [IccLeftChart, Function.comp_def, modelWithCornersEuclideanHalfSpace, projIcc] says
-      simp only [modelWithCornersEuclideanHalfSpace, Fin.isValue, ModelWithCorners.mk_coe,
-        IccLeftChart, PartialHomeomorph.mk_coe, Function.comp_def, projIcc]
-    have : ContDiff ℝ n (fun (w : ℝ) ↦
+  · have : ContDiff ℝ n (fun (w : ℝ) ↦
         (show EuclideanSpace ℝ (Fin 1) from fun (_ : Fin 1) ↦ w - x)) := by
       dsimp
       apply contDiff_euclidean.2 (fun i ↦ by fun_prop)
     apply this.contDiffWithinAt.congr_of_eventuallyEq_of_mem _ hz
     filter_upwards [self_mem_nhdsWithin] with w hw
     ext i
-    simp only [sub_left_inj]
+    suffices max x (min y w) - x = w - x by
+      simpa [modelWithCornersEuclideanHalfSpace, IccLeftChart]
     rw [max_eq_right, min_eq_right hw.2]
     simp [hw.1, h.out.le]
-  · simp? [IccRightChart, Function.comp_def, modelWithCornersEuclideanHalfSpace, projIcc] says
-      simp only [modelWithCornersEuclideanHalfSpace, Fin.isValue, ModelWithCorners.mk_coe,
-        IccRightChart, PartialHomeomorph.mk_coe, Function.comp_def, projIcc]
-    have : ContDiff ℝ n (fun (w : ℝ) ↦
+  · have : ContDiff ℝ n (fun (w : ℝ) ↦
         (show EuclideanSpace ℝ (Fin 1) from fun (_ : Fin 1) ↦ y - w)) := by
       dsimp
       apply contDiff_euclidean.2 (fun i ↦ by fun_prop)
     apply this.contDiffWithinAt.congr_of_eventuallyEq_of_mem _ hz
     filter_upwards [self_mem_nhdsWithin] with w hw
     ext i
-    simp only [sub_right_inj]
+    suffices y - max x (min y w) = y - w by
+      simpa [modelWithCornersEuclideanHalfSpace, IccRightChart]
     rw [max_eq_right, min_eq_right hw.2]
     simp [hw.1, h.out.le]
 

--- a/Mathlib/Geometry/Manifold/MFDeriv/Atlas.lean
+++ b/Mathlib/Geometry/Manifold/MFDeriv/Atlas.lean
@@ -369,13 +369,9 @@ theorem TangentBundle.symmL_trivializationAt
     {x₀ x : M} (hx : x ∈ (chartAt H x₀).source) :
     (trivializationAt E (TangentSpace I) x₀).symmL 𝕜 x =
       mfderivWithin 𝓘(𝕜, E) I (extChartAt I x₀).symm (range I) (extChartAt I x₀ x) := by
-  have : MDifferentiableWithinAt 𝓘(𝕜, E) I (extChartAt I x₀).symm (range I) (extChartAt I x₀ x) :=
-    mdifferentiableWithinAt_extChartAt_symm (by simp [hx])
-  simp? at this says
-    simp only [extChartAt, PartialHomeomorph.extend, PartialEquiv.coe_trans_symm,
-      PartialHomeomorph.coe_coe_symm, ModelWithCorners.toPartialEquiv_coe_symm,
-      PartialEquiv.coe_trans, ModelWithCorners.toPartialEquiv_coe, PartialHomeomorph.toFun_eq_coe,
-      Function.comp_apply] at this
+  have : MDifferentiableWithinAt 𝓘(𝕜, E) I ((chartAt H x₀).symm ∘ I.symm) (range I)
+      (I (chartAt H x₀ x)) := by
+    simpa using mdifferentiableWithinAt_extChartAt_symm (by simp [hx])
   simp [hx, mfderivWithin, this]
 
 end extChartAt

--- a/Mathlib/GroupTheory/SpecificGroups/Cyclic.lean
+++ b/Mathlib/GroupTheory/SpecificGroups/Cyclic.lean
@@ -687,10 +687,9 @@ lemma not_isCyclic_iff_exponent_eq_prime [Group α] {p : ℕ} (hp : p.Prime)
   orders of `g` are `1`, `p`, or `p ^ 2`. It can't be the former because `g ≠ 1`, and it can't
   the latter because the group isn't cyclic. -/
   have := (Nat.mem_divisors (m := p ^ 2)).mpr ⟨hα ▸ orderOf_dvd_natCard (x := g), by aesop⟩
-  simp? [Nat.divisors_prime_pow hp 2] at this says
-    simp only [Nat.divisors_prime_pow hp 2, Nat.reduceAdd, Finset.mem_map, Finset.mem_range,
-      Function.Embedding.coeFn_mk] at this
-  obtain ⟨a, ha, ha'⟩ := this
+  have : ∃ a < 3, p ^ a = orderOf g := by
+    simpa [Nat.divisors_prime_pow hp 2] using this
+  obtain ⟨a, ha, ha'⟩ := by simpa using this
   interval_cases a
   · exact False.elim <| hg <| orderOf_eq_one_iff.mp <| by simp_all
   · simp_all

--- a/Mathlib/LinearAlgebra/AffineSpace/AffineMap.lean
+++ b/Mathlib/LinearAlgebra/AffineSpace/AffineMap.lean
@@ -603,10 +603,7 @@ lemma lineMap_mono [LinearOrder k] [Preorder V1] [AddRightMono V1] [SMulPosMono 
     {p₀ p₁ : V1} (h : p₀ ≤ p₁) :
     Monotone (lineMap (k := k) p₀ p₁) := by
   intro x y hxy
-  simp? [lineMap] says
-    simp only [lineMap, vsub_eq_sub, vadd_eq_add, coe_add, LinearMap.coe_toAffineMap,
-      LinearMap.coe_smulRight, LinearMap.id_coe, id_eq, coe_const, Pi.add_apply,
-      Function.const_apply, add_le_add_iff_right]
+  suffices x • (p₁ - p₀) ≤ y • (p₁ - p₀) by simpa [lineMap]
   gcongr
   simpa
 
@@ -614,10 +611,7 @@ lemma lineMap_anti [LinearOrder k] [Preorder V1] [AddLeftMono V1] [SMulPosMono k
     {p₀ p₁ : V1} (h : p₁ ≤ p₀) :
     Antitone (lineMap (k := k) p₀ p₁) := by
   intro x y hxy
-  simp? [lineMap] says
-    simp only [lineMap, vsub_eq_sub, vadd_eq_add, coe_add, LinearMap.coe_toAffineMap,
-      LinearMap.coe_smulRight, LinearMap.id_coe, id_eq, coe_const, Pi.add_apply,
-      Function.const_apply, add_le_add_iff_right]
+  suffices y • (p₁ - p₀) ≤ x • (p₁ - p₀) by simpa [lineMap]
   rw [← neg_le_neg_iff, ← smul_neg, ← smul_neg]
   gcongr
   simpa

--- a/Mathlib/LinearAlgebra/TensorProduct/RightExactness.lean
+++ b/Mathlib/LinearAlgebra/TensorProduct/RightExactness.lean
@@ -223,9 +223,8 @@ lemma lTensor.inverse_of_rightInverse_apply
   apply LinearMap.congr_fun
   apply TensorProduct.ext'
   intro n q
-  simp? [lTensor.inverse_of_rightInverse] says
-    simp only [inverse_of_rightInverse, coe_comp, Function.comp_apply, lTensor_tmul,
-      lift.tmul, flip_apply, coe_mk, AddHom.coe_mk, mk_apply, Submodule.mkQ_apply]
+  suffices Submodule.Quotient.mk (n ⊗ₜ[R] h (g q)) = Submodule.Quotient.mk (n ⊗ₜ[R] q) by
+    simpa
   rw [Submodule.Quotient.eq, ← TensorProduct.tmul_sub]
   apply le_comap_range_lTensor f n
   rw [← hfg, mem_ker, map_sub, sub_eq_zero, hgh]
@@ -330,9 +329,7 @@ lemma rTensor.inverse_of_rightInverse_apply
   apply LinearMap.congr_fun
   apply TensorProduct.ext'
   intro n q
-  simp? [rTensor.inverse_of_rightInverse] says
-    simp only [inverse_of_rightInverse, coe_comp, Function.comp_apply, rTensor_tmul,
-      lift.tmul, coe_mk, AddHom.coe_mk, mk_apply, Submodule.mkQ_apply]
+  suffices Submodule.Quotient.mk (h (g n) ⊗ₜ[R] q) = Submodule.Quotient.mk (n ⊗ₜ[R] q) by simpa
   rw [Submodule.Quotient.eq, ← TensorProduct.sub_tmul]
   apply le_comap_range_rTensor f
   rw [← hfg, mem_ker, map_sub, sub_eq_zero, hgh]

--- a/Mathlib/MeasureTheory/Covering/Besicovitch.lean
+++ b/Mathlib/MeasureTheory/Covering/Besicovitch.lean
@@ -294,7 +294,7 @@ theorem lastStep_nonempty :
   simp only [iUnionUpTo, not_exists, exists_prop, mem_iUnion, not_and,
     Subtype.exists] at A
   specialize A x H
-  simp? [hxy] at A says simp only [hxy, mem_ball, dist_self, not_lt] at A
+  replace A : p.r (p.index y) ≤ 0 := by simpa [hxy] using A
   exact (lt_irrefl _ ((p.rpos (p.index y)).trans_le A)).elim
 
 /-- Every point is covered by chosen balls, before `p.lastStep`. -/

--- a/Mathlib/MeasureTheory/Measure/Lebesgue/VolumeOfBalls.lean
+++ b/Mathlib/MeasureTheory/Measure/Lebesgue/VolumeOfBalls.lean
@@ -386,10 +386,8 @@ lemma volume_ball_of_dim_odd {k : ℕ} (hk : finrank ℝ E = 2 * k + 1) (x : E) 
   have : Nontrivial E := Module.nontrivial_of_finrank_pos (R := ℝ) (hk ▸ (2 * k).succ_pos)
   rw [volume_ball, hk, pow_succ (√π), pow_mul, sq_sqrt pi_nonneg, mul_div_assoc, mul_div_assoc]
   congr 3
-  simp? [add_div, add_right_comm, -one_div, Gamma_nat_add_one_add_half] says
-    simp only [Nat.cast_add, Nat.cast_mul, Nat.cast_ofNat, Nat.cast_one, add_div, ne_eq,
-      OfNat.ofNat_ne_zero, not_false_eq_true, mul_div_cancel_left₀, add_right_comm,
-      Gamma_nat_add_one_add_half]
+  suffices √π / (↑(2 * k + 1)‼ * √π / 2 ^ (k + 1)) = 2 ^ (k + 1) / ↑(2 * k + 1)‼ by
+    simpa [add_div, add_right_comm, -one_div, Gamma_nat_add_one_add_half]
   field_simp
 
 lemma volume_closedBall_of_dim_odd {k : ℕ} (hk : finrank ℝ E = 2 * k + 1) (x : E) (r : ℝ) :

--- a/Mathlib/MeasureTheory/Measure/Stieltjes.lean
+++ b/Mathlib/MeasureTheory/Measure/Stieltjes.lean
@@ -375,7 +375,7 @@ theorem measure_singleton (a : ℝ) : f.measure {a} = ofReal (f a - leftLim f a)
     exists_seq_strictMono_tendsto a
   have A : {a} = ⋂ n, Ioc (u n) a := by
     refine Subset.antisymm (fun x hx => by simp [mem_singleton_iff.1 hx, u_lt_a]) fun x hx => ?_
-    simp? at hx says simp only [mem_iInter, mem_Ioc] at hx
+    replace hx : ∀ (i : ℕ), u i < x ∧ x ≤ a := by simpa using hx
     have : a ≤ x := le_of_tendsto' u_lim fun n => (hx n).1.le
     simp [le_antisymm this (hx 0).2]
   have L1 : Tendsto (fun n => f.measure (Ioc (u n) a)) atTop (𝓝 (f.measure {a})) := by

--- a/Mathlib/NumberTheory/Bernoulli.lean
+++ b/Mathlib/NumberTheory/Bernoulli.lean
@@ -279,7 +279,7 @@ theorem sum_range_pow (n p : ℕ) :
     intro m h
     simp only [exp_pow_eq_rescale_exp, rescale, RingHom.coe_mk]
     -- manipulate factorials and binomial coefficients
-    simp? at h says simp only [succ_eq_add_one, mem_range] at h
+    have h : m < q + 1 := by simpa using h
     rw [choose_eq_factorial_div_factorial h.le, eq_comm, div_eq_iff (hne q.succ), succ_eq_add_one,
       mul_assoc _ _ (q.succ ! : ℚ), mul_comm _ (q.succ ! : ℚ), ← mul_assoc, div_mul_eq_mul_div]
     simp only [MonoidHom.coe_mk, OneHom.coe_mk, coeff_exp, Algebra.algebraMap_self, one_div,

--- a/Mathlib/NumberTheory/Dioph.lean
+++ b/Mathlib/NumberTheory/Dioph.lean
@@ -303,9 +303,8 @@ theorem DiophList.forall (l : List (Set <| α → ℕ)) (d : l.Forall Dioph) :
     let ⟨β, pl, h⟩ := this
     ⟨β, Poly.sumsq pl, fun v => (h v).trans <| exists_congr fun t => (Poly.sumsq_eq_zero _ _).symm⟩
   induction l with | nil => exact ⟨ULift Empty, [], fun _ => by simp⟩ | cons S l IH =>
-  simp? at d says simp only [List.forall_cons] at d
+  obtain ⟨⟨β, p, pe⟩, dl⟩ := (List.forall_cons _ _ _).mp d
   exact
-    let ⟨⟨β, p, pe⟩, dl⟩ := d
     let ⟨γ, pl, ple⟩ := IH dl
     ⟨β ⊕ γ, p.map (inl ⊗ inr ∘ inl)::pl.map fun q => q.map (inl ⊗ inr ∘ inr),
       fun v => by

--- a/Mathlib/NumberTheory/LucasLehmer.lean
+++ b/Mathlib/NumberTheory/LucasLehmer.lean
@@ -211,13 +211,8 @@ theorem residue_eq_zero_iff_sMod_eq_zero (p : ℕ) (w : 1 < p) :
   · -- We want to use that fact that `0 ≤ s_mod p (p-2) < 2^p - 1`
     -- and `lucas_lehmer_residue p = 0 → 2^p - 1 ∣ s_mod p (p-2)`.
     intro h
-    --Simp is inconsistent about using pow_pos or pow_succ_pos, which leads to noise in the
-    --"simp? says" linter everytime the environment changes a little. By adding pow_pos as
-    --an explicit argument, it takes priority and we avoid the noise.
-    simp? [ZMod.intCast_zmod_eq_zero_iff_dvd, pow_pos] at h says
-      simp only [ZMod.intCast_zmod_eq_zero_iff_dvd, ofNat_pos, pow_pos, cast_pred,
-        cast_pow, cast_ofNat] at h
-    apply Int.eq_zero_of_dvd_of_nonneg_of_lt _ _ h <;> clear h
+    apply Int.eq_zero_of_dvd_of_nonneg_of_lt _ _
+      (by simpa [ZMod.intCast_zmod_eq_zero_iff_dvd] using h) <;> clear h
     · exact sMod_nonneg _ (by positivity) _
     · exact sMod_lt _ (by positivity) _
   · intro h

--- a/Mathlib/RingTheory/Henselian.lean
+++ b/Mathlib/RingTheory/Henselian.lean
@@ -75,7 +75,7 @@ theorem isLocalHom_of_le_jacobson_bot {R : Type*} [CommRing R] (I : Ideal R)
   rw [← (Ideal.Quotient.mk _).map_mul, ← (Ideal.Quotient.mk _).map_one, Ideal.Quotient.eq,
     Ideal.mem_jacobson_bot] at h1 h2
   specialize h1 1
-  simp? at h1 says simp only [mul_one, sub_add_cancel, IsUnit.mul_iff] at h1
+  have h1 : IsUnit a ∧ IsUnit y := by simpa using h1
   exact h1.1
 
 /-- A ring `R` is *Henselian* at an ideal `I` if the following condition holds:

--- a/Mathlib/RingTheory/Unramified/Finite.lean
+++ b/Mathlib/RingTheory/Unramified/Finite.lean
@@ -195,11 +195,9 @@ lemma finite_of_free [Module.Free R S] : Module.Finite R S := by
     apply Finsupp.finsuppProdEquiv.symm.injective
     apply (Finsupp.equivCongrLeft (Equiv.prodComm I I)).injective
     apply (b.tensorProduct b).repr.symm.injective
-    simp? [Finsupp.linearCombination_apply, Finsupp.sum_uncurry_index] says
-      simp only [Finsupp.finsuppProdEquiv_symm_apply, Finsupp.equivCongrLeft_apply,
-        Basis.repr_symm_apply, Finsupp.linearCombination_apply, Finsupp.sum_equivMapDomain,
-        Equiv.prodComm_apply, Finsupp.sum_uncurry_index, Prod.swap_prod_mk,
-        Basis.tensorProduct_apply]
+    suffices (F.sum fun a f ↦ f.sum fun b' c ↦ c • b b' ⊗ₜ[R] b a) =
+        G.sum fun a f ↦ f.sum fun b' c ↦ c • b b' ⊗ₜ[R] b a by
+      simpa [Finsupp.linearCombination_apply, Finsupp.sum_uncurry_index]
     rw [Finsupp.onFinset_sum, Finsupp.onFinset_sum]
     have : ∀ i, ((b.repr (x * f i)).sum fun j k ↦ k • b j ⊗ₜ[R] b i) = (x * f i) ⊗ₜ[R] b i := by
       intro i

--- a/Mathlib/SetTheory/Cardinal/Pigeonhole.lean
+++ b/Mathlib/SetTheory/Cardinal/Pigeonhole.lean
@@ -93,7 +93,7 @@ theorem le_range_of_union_finset_eq_top {α β : Type*} [Infinite β] (f : α �
   let u' : β → range f := fun b => ⟨f (u b).choose, by simp⟩
   have v' : ∀ a, u' ⁻¹' {⟨f a, by simp⟩} ≤ f a := by
     rintro a p m
-    simp? [u']  at m says simp only [mem_preimage, mem_singleton_iff, Subtype.mk.injEq, u'] at m
+    have m : f (u p).choose = f a := by simpa [u'] using m
     rw [← m]
     apply fun b => (u b).choose_spec
   obtain ⟨⟨-, ⟨a, rfl⟩⟩, p⟩ := exists_infinite_fiber u' h k

--- a/Mathlib/Topology/UniformSpace/Cauchy.lean
+++ b/Mathlib/Topology/UniformSpace/Cauchy.lean
@@ -602,8 +602,7 @@ theorem TotallyBounded.image [UniformSpace β] {f : α → β} {s : Set α} (hs 
   ⟨f '' c, hfc.image f, by
     simp only [mem_image, iUnion_exists, biUnion_and', iUnion_iUnion_eq_right, image_subset_iff,
       preimage_iUnion, preimage_setOf_eq]
-    simp? [subset_def] at hct says
-      simp only [mem_setOf_eq, subset_def, mem_iUnion, exists_prop] at hct
+    have hct : ∀ x ∈ s, ∃ i ∈ c, (f x, f i) ∈ t := by simpa [subset_def] using hct
     intro x hx
     simpa using hct x hx⟩
 


### PR DESCRIPTION
Go through occurrences of `simp? says` and, where the goal is not too long, replace them with `suffices ... := by simpa`. Similarly for hypotheses, replace `simp? at H says ...` with `replace H : ... := by simpa`.

I think this improves maintainability by declaring which shape we want to end up in, instead of the rewrites we want to use to achieve that shape.

Zulip thread: https://leanprover.zulipchat.com/#narrow/channel/287929-mathlib4/topic/noisy.20simp.20says.20in.20CI


---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include at least one commit authored by each
co-author among the commits in the pull request. If necessary, you may 
create empty commits to indicate co-authorship, using commands like so:

git commit --author="Author Name <author@email.com>" --allow-empty -m "add Author Name as coauthor"

When merging, all the commits will be squashed into a single commit listing all co-authors.

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
