### PR TITLE
[Merged by Bors] - chore(1000.yaml): add declarations for various theorems

### DIFF
--- a/docs/1000.yaml
+++ b/docs/1000.yaml
@@ -3814,11 +3814,13 @@ Q7996766:
 Q7996769:
   title: Whitney immersion theorem
 
-# TODO: This is in PNT+
-# and should be added to this file once the prime number theorem itself is added
-# https://alexkontorovich.github.io/PrimeNumberTheoremAnd/docs/PrimeNumberTheoremAnd/Wiener.html#WienerIkeharaTheorem'
 Q7999144:
   title: Wiener–Ikehara theorem
+  authors : Alex Kontorovich, Terry Tao, and the Prime Number Theorem + Project
+  url: https://github.com/AlexKontorovich/PrimeNumberTheoremAnd
+  date: 2024
+  # TODO: cannot display several URLs nicely yet
+  # link: https://github.com/AlexKontorovich/PrimeNumberTheoremAnd/blob/655055549f8725b3fd4de577435259932129dc4c/PrimeNumberTheoremAnd/Wiener.lean#L2078
 
 Q7999797:
   title: Beer's theorem

--- a/docs/1000.yaml
+++ b/docs/1000.yaml
@@ -3381,7 +3381,7 @@ Q6777133:
 
 Q6783821:
   title: Mason–Stothers theorem
-  decl: Polynomial.
+  decl: Polynomial.abc
   authors: Jineon Baek, Seewoo Lee
   date: 2024
 

--- a/docs/1000.yaml
+++ b/docs/1000.yaml
@@ -843,6 +843,9 @@ Q791258:
 
 Q791663:
   title: Beatty's theorem
+  decls:
+    - Irrational.beattySeq_symmDiff_beattySeq_pos
+    - compl_beattySeq
 
 Q794269:
   title: Betti's theorem
@@ -1472,6 +1475,11 @@ Q1227702:
 
 Q1227703:
   title: Dirichlet's approximation theorem
+  decls:
+    - AddCircle.exists_norm_nsmul_le
+    - Real.exists_int_int_abs_mul_sub_le
+    - Real.exists_nat_abs_mul_sub_round_le
+    - Real.exists_rat_abs_sub_le_and_den_le
 
 Q1242398:
   title: Doob decomposition theorem
@@ -3369,6 +3377,7 @@ Q6777133:
 
 Q6783821:
   title: Mason–Stothers theorem
+  decl: Polynomial.abc
 
 Q6795637:
   title: Maximal ergodic theorem
@@ -3805,6 +3814,8 @@ Q7996766:
 Q7996769:
   title: Whitney immersion theorem
 
+# Note: This is in PNT+
+# https://alexkontorovich.github.io/PrimeNumberTheoremAnd/docs/PrimeNumberTheoremAnd/Wiener.html#WienerIkeharaTheorem'
 Q7999144:
   title: Wiener–Ikehara theorem
 

--- a/docs/1000.yaml
+++ b/docs/1000.yaml
@@ -846,6 +846,8 @@ Q791663:
   decls:
     - Irrational.beattySeq_symmDiff_beattySeq_pos
     - compl_beattySeq
+  authors: Jason Yuen
+  date: 2023
 
 Q794269:
   title: Betti's theorem
@@ -1480,6 +1482,8 @@ Q1227703:
     - Real.exists_int_int_abs_mul_sub_le
     - Real.exists_nat_abs_mul_sub_round_le
     - Real.exists_rat_abs_sub_le_and_den_le
+  authors: Michael Geißer, Michael Stoll
+  date: 2022
 
 Q1242398:
   title: Doob decomposition theorem
@@ -3377,7 +3381,9 @@ Q6777133:
 
 Q6783821:
   title: Mason–Stothers theorem
-  decl: Polynomial.abc
+  decl: Polynomial.
+  authors: Jineon Baek, Seewoo Lee
+  date: 2024
 
 Q6795637:
   title: Maximal ergodic theorem

--- a/docs/1000.yaml
+++ b/docs/1000.yaml
@@ -3814,7 +3814,8 @@ Q7996766:
 Q7996769:
   title: Whitney immersion theorem
 
-# Note: This is in PNT+
+# TODO: This is in PNT+
+# and should be added to this file once the prime number theorem itself is added
 # https://alexkontorovich.github.io/PrimeNumberTheoremAnd/docs/PrimeNumberTheoremAnd/Wiener.html#WienerIkeharaTheorem'
 Q7999144:
   title: Wiener–Ikehara theorem


### PR DESCRIPTION
This PR adds a number of theorems missing from this yaml file that are already in mathlib. (Also adds another todo for a theorem from the PNT+ project)

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include at least one commit authored by each
co-author among the commits in the pull request. If necessary, you may 
create empty commits to indicate co-authorship, using commands like so:

git commit --author="Author Name <author@email.com>" --allow-empty -m "add Author Name as coauthor"

When merging, all the commits will be squashed into a single commit listing all co-authors.

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
