### PR TITLE
[Merged by Bors] - feat(Data/Set/Functor): lemmas for `*>` and `<*` on `Set`

### DIFF
--- a/Mathlib/Data/Set/Functor.lean
+++ b/Mathlib/Data/Set/Functor.lean
@@ -26,6 +26,8 @@ variable {α β : Type u} {s : Set α} {f : α → Set β}
 instance : Alternative Set where
   pure a := {a}
   seq s t := s.seq (t ())
+  seqLeft s t := {a | a ∈ s ∧ (t ()).Nonempty}
+  seqRight s t := {b | s.Nonempty ∧ b ∈ t ()}
   map := Set.image
   orElse s t := s ∪ t ()
   failure := ∅
@@ -36,6 +38,14 @@ theorem fmap_eq_image (f : α → β) : f <$> s = f '' s :=
 
 @[simp]
 theorem seq_eq_set_seq (s : Set (α → β)) (t : Set α) : s <*> t = s.seq t :=
+  rfl
+
+@[simp]
+theorem seqLeft_def (s : Set α) (t : Set β) : s <* t = {a | a ∈ s ∧ t.Nonempty} :=
+  rfl
+
+@[simp]
+theorem seqRight_def (s : Set α) (t : Set β) : s *> t = {a | s.Nonempty ∧ a ∈ t} :=
   rfl
 
 @[simp]
@@ -59,8 +69,8 @@ theorem image2_def {α β γ : Type u} (f : α → β → γ) (s : Set α) (t : 
 
 instance : LawfulAlternative Set where
   pure_seq _ _ := Set.singleton_seq
-  seqLeft_eq _ _ := rfl
-  seqRight_eq _ _ := rfl
+  seqLeft_eq _ _ := by simp [Set.seq, Set.image2, Set.nonempty_def]
+  seqRight_eq s t := by simp [Set.seq, Set.image2, Set.nonempty_def]
   map_pure _ _ := Set.image_singleton
   seq_pure _ _ := Set.seq_singleton
   seq_assoc _ _ _ := Set.seq_seq


### PR DESCRIPTION
This changes the defeq to be slightly more illustrative.

The definitions are uniquely determined by the lawfulness, so the new definitions is propositionally equal to the old one.


---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include at least one commit authored by each
co-author among the commits in the pull request. If necessary, you may 
create empty commits to indicate co-authorship, using commands like so:

git commit --author="Author Name <author@email.com>" --allow-empty -m "add Author Name as coauthor"

When merging, all the commits will be squashed into a single commit listing all co-authors.

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
