### PR TITLE
[Merged by Bors] - chore(Data/Set): golf a lemma that is a duplicate

### DIFF
--- a/Mathlib/Data/Set/Functor.lean
+++ b/Mathlib/Data/Set/Functor.lean
@@ -139,8 +139,7 @@ variable {β : Set α} {γ : Set β} {a : α}
 theorem mem_image_val_of_mem (ha : a ∈ β) (ha' : ⟨a, ha⟩ ∈ γ) : a ∈ (γ : Set α) :=
   ⟨_, ha', rfl⟩
 
-theorem image_val_subset : (γ : Set α) ⊆ β := by
-  rintro _ ⟨⟨_, ha⟩, _, rfl⟩; exact ha
+theorem image_val_subset : (γ : Set α) ⊆ β := Subtype.coe_image_subset _ _
 
 theorem mem_of_mem_image_val (ha : a ∈ (γ : Set α)) : ⟨a, image_val_subset ha⟩ ∈ γ := by
   rcases ha with ⟨_, ha, rfl⟩; exact ha


### PR DESCRIPTION
The Subtype API is still full of `coe` vs `val` duplication.

This serves simply to record yet another pair, rather than to try and solve this problem.

Note that `Subtype.image_val_subset` is in a different namespace and has different argument explicitness.

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include at least one commit authored by each
co-author among the commits in the pull request. If necessary, you may 
create empty commits to indicate co-authorship, using commands like so:

git commit --author="Author Name <author@email.com>" --allow-empty -m "add Author Name as coauthor"

When merging, all the commits will be squashed into a single commit listing all co-authors.

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
