### PR TITLE
[Merged by Bors] - feat: `grind` annotations for `Nat.count`

### DIFF
--- a/Mathlib/Algebra/Group/Embedding.lean
+++ b/Mathlib/Algebra/Group/Embedding.lean
@@ -25,6 +25,8 @@ def mulLeftEmbedding [Mul G] [IsLeftCancelMul G] (g : G) : G ↪ G where
   toFun h := g * h
   inj' := mul_right_injective g
 
+attribute [grind =] addLeftEmbedding_apply mulLeftEmbedding_apply
+
 /-- If right-multiplication by any element is cancellative, right-multiplication by `g` is an
 embedding. -/
 @[to_additive (attr := simps)
@@ -33,6 +35,8 @@ embedding. -/
 def mulRightEmbedding [Mul G] [IsRightCancelMul G] (g : G) : G ↪ G where
   toFun h := h * g
   inj' := mul_left_injective g
+
+attribute [grind =] addRightEmbedding_apply mulRightEmbedding_apply
 
 @[to_additive]
 theorem mulLeftEmbedding_eq_mulRightEmbedding [CommMagma G] [IsCancelMul G] (g : G) :

--- a/Mathlib/Data/Nat/Count.lean
+++ b/Mathlib/Data/Nat/Count.lean
@@ -33,9 +33,8 @@ variable [DecidablePred p]
 def count (n : ℕ) : ℕ :=
   (List.range n).countP p
 
-@[simp]
-theorem count_zero : count p 0 = 0 := by
-  rw [count, List.range_zero, List.countP, List.countP.go]
+@[simp, grind =]
+theorem count_zero : count p 0 = 0 := by simp [count]
 
 /-- A fintype instance for the set relevant to `Nat.count`. Locally an instance in scope `count` -/
 def CountSet.fintype (n : ℕ) : Fintype { i // i < n ∧ p i } := by
@@ -61,23 +60,19 @@ theorem count_le {n : ℕ} : count p n ≤ n := by
   rw [count_eq_card_filter_range]
   exact (card_filter_le _ _).trans_eq (card_range _)
 
+@[grind =]
 theorem count_succ (n : ℕ) : count p (n + 1) = count p n + if p n then 1 else 0 := by
-  split_ifs with h <;> simp [count, List.range_succ, h]
+  grind [count, List.range_succ]
 
 @[mono]
 theorem count_monotone : Monotone (count p) :=
-  monotone_nat_of_le_succ fun n ↦ by by_cases h : p n <;> simp [count_succ, h]
+  monotone_nat_of_le_succ (by grind)
 
 theorem count_add (a b : ℕ) : count p (a + b) = count p a + count (fun k ↦ p (a + k)) b := by
   have : Disjoint {x ∈ range a | p x} {x ∈ (range b).map <| addLeftEmbedding a | p x} := by
-    apply disjoint_filter_filter
-    rw [Finset.disjoint_left]
-    simp_rw [mem_map, mem_range, addLeftEmbedding_apply]
-    rintro x hx ⟨c, _, rfl⟩
-    exact (Nat.le_add_right _ _).not_gt hx
+    grind [Finset.disjoint_left]
   simp_rw [count_eq_card_filter_range, range_add, filter_union, card_union_of_disjoint this,
-    filter_map, addLeftEmbedding, card_map]
-  rfl
+    filter_map, addLeftEmbedding, card_map, Function.Embedding.coeFn_mk, Function.comp_def]
 
 theorem count_add' (a b : ℕ) : count p (a + b) = count (fun k ↦ p (k + b)) a + count p b := by
   rw [add_comm, count_add, add_comm]
@@ -92,14 +87,11 @@ theorem count_succ' (n : ℕ) :
 variable {p}
 
 @[simp]
-theorem count_lt_count_succ_iff {n : ℕ} : count p n < count p (n + 1) ↔ p n := by
-  by_cases h : p n <;> simp [count_succ, h]
+theorem count_lt_count_succ_iff {n : ℕ} : count p n < count p (n + 1) ↔ p n := by grind
 
-theorem count_succ_eq_succ_count_iff {n : ℕ} : count p (n + 1) = count p n + 1 ↔ p n := by
-  by_cases h : p n <;> simp [h, count_succ]
+theorem count_succ_eq_succ_count_iff {n : ℕ} : count p (n + 1) = count p n + 1 ↔ p n := by grind
 
-theorem count_succ_eq_count_iff {n : ℕ} : count p (n + 1) = count p n ↔ ¬p n := by
-  by_cases h : p n <;> simp [h, count_succ]
+theorem count_succ_eq_count_iff {n : ℕ} : count p (n + 1) = count p n ↔ ¬p n := by grind
 
 alias ⟨_, count_succ_eq_succ_count⟩ := count_succ_eq_succ_count_iff
 
@@ -114,7 +106,7 @@ theorem count_strict_mono {m n : ℕ} (hm : p m) (hmn : m < n) : count p m < cou
 theorem count_injective {m n : ℕ} (hm : p m) (hn : p n) (heq : count p m = count p n) : m = n := by
   by_contra! h : m ≠ n
   wlog hmn : m < n
-  · exact this hn hm heq.symm h.symm (h.lt_or_gt.resolve_left hmn)
+  · exact this hn hm heq.symm h.symm (by grind)
   · simpa [heq] using count_strict_mono hm hmn
 
 theorem count_le_card (hp : (setOf p).Finite) (n : ℕ) : count p n ≤ #hp.toFinset := by
@@ -148,7 +140,7 @@ lemma exists_of_count_lt_count {a b : ℕ} (h : a.count p < b.count p) : ∃ x �
   rw [add_assoc, count_add, Nat.lt_add_right_iff_pos] at h
   obtain ⟨t, ht, hp⟩ := count_ne_iff_exists.mp h.ne'
   simp_rw [Set.mem_Ico]
-  exact ⟨a + t, ⟨le_add_right _ _, by rwa [add_assoc _ k, Nat.add_lt_add_iff_left]⟩, hp⟩
+  exact ⟨a + t, by grind⟩
 
 variable {q : ℕ → Prop}
 variable [DecidablePred q]


### PR DESCRIPTION
---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include at least one commit authored by each
co-author among the commits in the pull request. If necessary, you may 
create empty commits to indicate co-authorship, using commands like so:

git commit --author="Author Name <author@email.com>" --allow-empty -m "add Author Name as coauthor"

When merging, all the commits will be squashed into a single commit listing all co-authors.

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
