### PR TITLE
chore: in BinomialRing, IsAddTorsionFree is a parameter, not a parent

### DIFF
--- a/Mathlib/NumberTheory/Padics/MahlerBasis.lean
+++ b/Mathlib/NumberTheory/Padics/MahlerBasis.lean
@@ -66,9 +66,11 @@ lemma norm_ascPochhammer_le (k : ℕ) (x : ℤ_[p]) :
     ← Ring.factorial_nsmul_multichoose_eq_ascPochhammer, smul_eq_mul, Nat.cast_mul, norm_mul]
   exact mul_le_of_le_one_right (norm_nonneg _) (norm_le_one _)
 
+noncomputable instance instIsAddTorsionFree : IsAddTorsionFree ℤ_[p] where
+  nsmul_right_injective _ := smul_right_injective ℤ_[p]
+
 /-- The p-adic integers are a binomial ring, i.e. a ring where binomial coefficients make sense. -/
 noncomputable instance instBinomialRing : BinomialRing ℤ_[p] where
-  nsmul_right_injective n := smul_right_injective ℤ_[p]
   -- We define `multichoose` as a fraction in `ℚ_[p]` together with a proof that its norm is `≤ 1`.
   multichoose x k := ⟨(ascPochhammer ℤ_[p] k).eval x / (k.factorial : ℚ_[p]), by
     rw [norm_div, div_le_one (by simpa using k.factorial_ne_zero)]

--- a/Mathlib/RingTheory/PowerSeries/Binomial.lean
+++ b/Mathlib/RingTheory/PowerSeries/Binomial.lean
@@ -35,7 +35,7 @@ variable {R A : Type*}
 
 namespace PowerSeries
 
-variable [CommRing R] [BinomialRing R]
+variable [CommRing R] [IsAddTorsionFree R] [BinomialRing R]
 
 /-- The power series for `(1 + X) ^ r`. -/
 def binomialSeries (A) [One A] [SMul R A] (r : R) : PowerSeries A :=


### PR DESCRIPTION
---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include at least one commit authored by each
co-author among the commits in the pull request. If necessary, you may 
create empty commits to indicate co-authorship, using commands like so:

git commit --author="Author Name <author@email.com>" --allow-empty -m "add Author Name as coauthor"

When merging, all the commits will be squashed into a single commit listing all co-authors.

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
