### PR TITLE
refactor: switch to [] notation for Stream'

### DIFF
--- a/Mathlib/Algebra/ContinuedFractions/Basic.lean
+++ b/Mathlib/Algebra/ContinuedFractions/Basic.lean
@@ -297,13 +297,16 @@ def nextConts (a b : K) (ppred pred : Pair K) : Pair K :=
   ⟨nextNum a b ppred.a pred.a, nextDen a b ppred.b pred.b⟩
 
 /-- Returns the continuants `⟨Aₙ₋₁, Bₙ₋₁⟩` of `g`. -/
-def contsAux (g : GenContFract K) : Stream' (Pair K)
+def contsAux (g : GenContFract K) : Stream' (Pair K) where
+  get'
+where
+  get'
   | 0 => ⟨1, 0⟩
   | 1 => ⟨g.h, 1⟩
   | n + 2 =>
     match g.s.get? n with
-    | none => contsAux g (n + 1)
-    | some gp => nextConts gp.a gp.b (contsAux g n) (contsAux g (n + 1))
+    | none => get' (n + 1)
+    | some gp => nextConts gp.a gp.b (get' n) (get' (n + 1))
 
 /-- Returns the continuants `⟨Aₙ, Bₙ⟩` of `g`. -/
 def conts (g : GenContFract K) : Stream' (Pair K) :=
@@ -318,8 +321,8 @@ def dens (g : GenContFract K) : Stream' K :=
   g.conts.map Pair.b
 
 /-- Returns the convergents `Aₙ / Bₙ` of `g`, where `Aₙ, Bₙ` are the nth continuants of `g`. -/
-def convs (g : GenContFract K) : Stream' K :=
-  fun n : ℕ ↦ g.nums n / g.dens n
+def convs (g : GenContFract K) : Stream' K where
+  get' n := g.nums[n] / g.dens[n]
 
 /--
 Returns the approximation of the fraction described by the given sequence up to a given position n.

--- a/Mathlib/Algebra/ContinuedFractions/Computation/Basic.lean
+++ b/Mathlib/Algebra/ContinuedFractions/Computation/Basic.lean
@@ -135,10 +135,13 @@ For example, let `(v : ℚ) := 3.4`. The process goes as follows:
 - `stream v 2 = some ⟨⌊0.5⁻¹⌋, 0.5⁻¹ - ⌊0.5⁻¹⌋⟩ = some ⟨⌊2⌋, 2 - ⌊2⌋⟩ = some ⟨2, 0⟩`
 - `stream v n = none`, for `n ≥ 3`
 -/
-protected def stream (v : K) : Stream' <| Option (IntFractPair K)
+protected def stream (v : K) : Stream' <| Option (IntFractPair K) where
+  get'
+where
+  get'
   | 0 => some (IntFractPair.of v)
   | n + 1 =>
-    (IntFractPair.stream v n).bind fun ap_n =>
+    (get' n).bind fun ap_n =>
       if ap_n.fr = 0 then none else some (IntFractPair.of ap_n.fr⁻¹)
 
 /-- Shows that `IntFractPair.stream` has the sequence property, that is once we return `none` at
@@ -146,7 +149,8 @@ position `n`, we also return `none` at `n + 1`.
 -/
 theorem stream_isSeq (v : K) : (IntFractPair.stream v).IsSeq := by
   intro _ hyp
-  simp [IntFractPair.stream, hyp]
+  simp [IntFractPair.stream, IntFractPair.stream.get', hyp]
+  sorry
 
 /--
 Uses `IntFractPair.stream` to create a sequence with head (i.e. `seq1`) of integer and fractional

--- a/Mathlib/Algebra/ContinuedFractions/Translations.lean
+++ b/Mathlib/Algebra/ContinuedFractions/Translations.lean
@@ -76,65 +76,65 @@ continued fraction.
 
 variable {K : Type*} {g : GenContFract K} {n : ℕ} [DivisionRing K]
 
-theorem nth_cont_eq_succ_nth_contAux : g.conts n = g.contsAux (n + 1) :=
+theorem nth_cont_eq_succ_nth_contAux : g.conts[n] = g.contsAux[n + 1] :=
   rfl
 
-theorem num_eq_conts_a : g.nums n = (g.conts n).a :=
+theorem num_eq_conts_a : g.nums[n] = g.conts[n].a :=
   rfl
 
-theorem den_eq_conts_b : g.dens n = (g.conts n).b :=
+theorem den_eq_conts_b : g.dens[n] = g.conts[n].b :=
   rfl
 
-theorem conv_eq_num_div_den : g.convs n = g.nums n / g.dens n :=
+theorem conv_eq_num_div_den : g.convs[n] = g.nums[n] / g.dens[n] :=
   rfl
 
 theorem conv_eq_conts_a_div_conts_b :
-    g.convs n = (g.conts n).a / (g.conts n).b :=
+    g.convs[n] = g.conts[n].a / g.conts[n].b :=
   rfl
 
-theorem exists_conts_a_of_num {A : K} (nth_num_eq : g.nums n = A) :
-    ∃ conts, g.conts n = conts ∧ conts.a = A := by simpa
+theorem exists_conts_a_of_num {A : K} (nth_num_eq : g.nums[n] = A) :
+    ∃ conts, g.conts[n] = conts ∧ conts.a = A := by simpa
 
-theorem exists_conts_b_of_den {B : K} (nth_denom_eq : g.dens n = B) :
-    ∃ conts, g.conts n = conts ∧ conts.b = B := by simpa
-
-@[simp]
-theorem zeroth_contAux_eq_one_zero : g.contsAux 0 = ⟨1, 0⟩ :=
-  rfl
+theorem exists_conts_b_of_den {B : K} (nth_denom_eq : g.dens[n] = B) :
+    ∃ conts, g.conts[n] = conts ∧ conts.b = B := by simpa
 
 @[simp]
-theorem first_contAux_eq_h_one : g.contsAux 1 = ⟨g.h, 1⟩ :=
+theorem zeroth_contAux_eq_one_zero : g.contsAux[0] = ⟨1, 0⟩ :=
   rfl
 
 @[simp]
-theorem zeroth_cont_eq_h_one : g.conts 0 = ⟨g.h, 1⟩ :=
+theorem first_contAux_eq_h_one : g.contsAux[1] = ⟨g.h, 1⟩ :=
   rfl
 
 @[simp]
-theorem zeroth_num_eq_h : g.nums 0 = g.h :=
+theorem zeroth_cont_eq_h_one : g.conts[0] = ⟨g.h, 1⟩ :=
   rfl
 
 @[simp]
-theorem zeroth_den_eq_one : g.dens 0 = 1 :=
+theorem zeroth_num_eq_h : g.nums[0] = g.h :=
   rfl
 
 @[simp]
-theorem zeroth_conv_eq_h : g.convs 0 = g.h := by
+theorem zeroth_den_eq_one : g.dens[0] = 1 :=
+  rfl
+
+@[simp]
+theorem zeroth_conv_eq_h : g.convs[0] = g.h := by
   simp [conv_eq_num_div_den, num_eq_conts_a, den_eq_conts_b, div_one]
 
 theorem second_contAux_eq {gp : Pair K} (zeroth_s_eq : g.s.get? 0 = some gp) :
-    g.contsAux 2 = ⟨gp.b * g.h + gp.a, gp.b⟩ := by
-  simp [zeroth_s_eq, contsAux, nextConts, nextDen, nextNum]
+    g.contsAux[2] = ⟨gp.b * g.h + gp.a, gp.b⟩ := by
+  simp [zeroth_s_eq, contsAux, contsAux.get', nextConts, nextDen, nextNum]
 
 theorem first_cont_eq {gp : Pair K} (zeroth_s_eq : g.s.get? 0 = some gp) :
-    g.conts 1 = ⟨gp.b * g.h + gp.a, gp.b⟩ := by
+    g.conts[1] = ⟨gp.b * g.h + gp.a, gp.b⟩ := by
   simp [nth_cont_eq_succ_nth_contAux, second_contAux_eq zeroth_s_eq]
 
 theorem first_num_eq {gp : Pair K} (zeroth_s_eq : g.s.get? 0 = some gp) :
-    g.nums 1 = gp.b * g.h + gp.a := by simp [num_eq_conts_a, first_cont_eq zeroth_s_eq]
+    g.nums[1] = gp.b * g.h + gp.a := by simp [num_eq_conts_a, first_cont_eq zeroth_s_eq]
 
 theorem first_den_eq {gp : Pair K} (zeroth_s_eq : g.s.get? 0 = some gp) :
-    g.dens 1 = gp.b := by simp [den_eq_conts_b, first_cont_eq zeroth_s_eq]
+    g.dens[1] = gp.b := by simp [den_eq_conts_b, first_cont_eq zeroth_s_eq]
 
 @[simp]
 theorem zeroth_conv'Aux_eq_zero {s : Stream'.Seq <| Pair K} :

--- a/Mathlib/Combinatorics/Hindman.lean
+++ b/Mathlib/Combinatorics/Hindman.lean
@@ -231,14 +231,14 @@ theorem FP_drop_subset_FP {M} [Semigroup M] (a : Stream' M) (n : ℕ) : FP (a.dr
     exact _root_.trans (FP.tail _) ih
 
 @[to_additive]
-theorem FP.singleton {M} [Semigroup M] (a : Stream' M) (i : ℕ) : a.get i ∈ FP a := by
+theorem FP.singleton {M} [Semigroup M] (a : Stream' M) (i : ℕ) : a[i] ∈ FP a := by
   induction i generalizing a with
   | zero => exact FP.head _
   | succ i ih => exact FP.tail _ _ (ih _)
 
 @[to_additive]
 theorem FP.mul_two {M} [Semigroup M] (a : Stream' M) (i j : ℕ) (ij : i < j) :
-    a.get i * a.get j ∈ FP a := by
+    a[i] * a[j] ∈ FP a := by
   refine FP_drop_subset_FP _ i ?_
   rw [← Stream'.head_drop]
   apply FP.cons
@@ -250,7 +250,7 @@ theorem FP.mul_two {M} [Semigroup M] (a : Stream' M) (i j : ℕ) (ij : i < j) :
 
 @[to_additive]
 theorem FP.finset_prod {M} [CommMonoid M] (a : Stream' M) (s : Finset ℕ) (hs : s.Nonempty) :
-    (s.prod fun i => a.get i) ∈ FP a := by
+    (s.prod fun i => a[i]) ∈ FP a := by
   refine FP_drop_subset_FP _ (s.min' hs) ?_
   induction s using Finset.eraseInduction with | H s ih => _
   rw [← Finset.mul_prod_erase _ _ (s.min'_mem hs), ← Stream'.head_drop]

--- a/Mathlib/Control/LawfulFix.lean
+++ b/Mathlib/Control/LawfulFix.lean
@@ -43,21 +43,21 @@ namespace Fix
 
 variable (f : ((a : _) → Part <| β a) →o (a : _) → Part <| β a)
 
-theorem approx_mono' {i : ℕ} : Fix.approx f i ≤ Fix.approx f (succ i) := by
+theorem approx_mono' {i : ℕ} : (approx f)[i] ≤ (approx f)[succ i] := by
   induction i with
   | zero => dsimp [approx]; apply @bot_le _ _ _ (f ⊥)
   | succ _ i_ih => intro; apply f.monotone; apply i_ih
 
-theorem approx_mono ⦃i j : ℕ⦄ (hij : i ≤ j) : approx f i ≤ approx f j := by
+theorem approx_mono ⦃i j : ℕ⦄ (hij : i ≤ j) : (approx f)[i] ≤ (approx f)[j] := by
   induction j with
   | zero => cases hij; exact le_rfl
   | succ j ih =>
     cases hij; · exact le_rfl
     exact le_trans (ih ‹_›) (approx_mono' f)
 
-theorem mem_iff (a : α) (b : β a) : b ∈ Part.fix f a ↔ ∃ i, b ∈ approx f i a := by
+theorem mem_iff (a : α) (b : β a) : b ∈ Part.fix f a ↔ ∃ i : ℕ, b ∈ (approx f)[i] a := by
   classical
-  by_cases h₀ : ∃ i : ℕ, (approx f i a).Dom
+  by_cases h₀ : ∃ i : ℕ, ((approx f)[i] a).Dom
   · simp only [Part.fix_def f h₀]
     constructor <;> intro hh
     · exact ⟨_, hh⟩
@@ -78,12 +78,12 @@ theorem mem_iff (a : α) (b : β a) : b ∈ Part.fix f a ↔ ∃ i, b ∈ approx
     simp only [dom_iff_mem, not_exists] at h₀
     intro; apply h₀
 
-theorem approx_le_fix (i : ℕ) : approx f i ≤ Part.fix f := fun a b hh ↦ by
+theorem approx_le_fix (i : ℕ) : (approx f)[i] ≤ Part.fix f := fun a b hh ↦ by
   rw [mem_iff f]
   exact ⟨_, hh⟩
 
-theorem exists_fix_le_approx (x : α) : ∃ i, Part.fix f x ≤ approx f i x := by
-  by_cases hh : ∃ i b, b ∈ approx f i x
+theorem exists_fix_le_approx (x : α) : ∃ i : ℕ, Part.fix f x ≤ (approx f)[i] x := by
+  by_cases hh : ∃ i : ℕ, ∃ b, b ∈ (approx f)[i] x
   · rcases hh with ⟨i, b, hb⟩
     exists i
     intro b' h'
@@ -99,14 +99,14 @@ theorem exists_fix_le_approx (x : α) : ∃ i, Part.fix f x ≤ approx f i x := 
 
 /-- The series of approximations of `fix f` (see `approx`) as a `Chain` -/
 def approxChain : Chain ((a : _) → Part <| β a) :=
-  ⟨approx f, approx_mono f⟩
+  ⟨((approx f)[·]), approx_mono f⟩
 
 theorem le_f_of_mem_approx {x} : x ∈ approxChain f → x ≤ f x := by
   simp only [Membership.mem, forall_exists_index]
   rintro i rfl
   apply approx_mono'
 
-theorem approx_mem_approxChain {i} : approx f i ∈ approxChain f :=
+theorem approx_mem_approxChain {i : ℕ} : (approx f)[i] ∈ approxChain f :=
   Stream'.mem_of_get_eq rfl
 
 end Fix
@@ -120,7 +120,7 @@ theorem fix_eq_ωSup : Part.fix f = ωSup (approxChain f) := by
   apply le_antisymm
   · intro x
     obtain ⟨i, hx⟩ := exists_fix_le_approx f x
-    trans approx f i.succ x
+    trans (approx f)[i.succ] x
     · trans
       · apply hx
       · apply approx_mono' f

--- a/Mathlib/Data/Seq/Computation.lean
+++ b/Mathlib/Data/Seq/Computation.lean
@@ -101,10 +101,11 @@ theorem destruct_eq_pure {s : Computation α} {a : α} : destruct s = Sum.inl a 
   induction' f0 : s.1[0] with _ <;> intro h
   · contradiction
   · apply Subtype.eq
-    ext n
+    ext n : 1
     induction' n with n IH
     · injection h with h'
-      rwa [h'] at f0
+      dsimp [pure]
+      rw [f0, h']
     · exact s.2 IH
 
 theorem destruct_eq_think {s : Computation α} {s'} : destruct s = Sum.inr s' → s = think s' := by

--- a/Mathlib/Data/Seq/Defs.lean
+++ b/Mathlib/Data/Seq/Defs.lean
@@ -10,13 +10,13 @@ import Mathlib.Data.Seq.Computation
 # Possibly infinite lists
 
 This file provides `Stream'.Seq α`, a type representing possibly infinite lists (referred here as
-sequences). It is encoded as an infinite stream of options such that if `f n = none`, then
-`f m = none` for all `m ≥ n`.
+sequences). It is encoded as an infinite stream of options such that if `f[n] = none`, then
+`f[m] = none` for all `m ≥ n`.
 
 ## Main definitions
 
 * `Seq α`: The type of possibly infinite lists (sequences) encoded as streams of options. It is
-  encoded as `Stream' (Option α)` such that if `f n = none`, then `f m = none` for all `m ≥ n`.
+  encoded as `Stream' (Option α)` such that if `f[n] = none`, then `f[m] = none` for all `m ≥ n`.
   It has two "constructors": `nil` and `cons`, and a destructor `destruct`.
 * `Seq1 α`: The type of nonempty sequences
 * `Seq.get?`: Extract the nth element of a sequence (if it exists).
@@ -48,11 +48,11 @@ coinductive seq (α : Type u) : Type u
 /-- A stream `s : Option α` is a sequence if `s.get n = none` implies `s.get (n + 1) = none`.
 -/
 def IsSeq {α : Type u} (s : Stream' (Option α)) : Prop :=
-  ∀ {n : ℕ}, s n = none → s (n + 1) = none
+  ∀ {n : ℕ}, s[n] = none → s[n + 1] = none
 
 /-- `Seq α` is the type of possibly infinite lists (referred here as sequences).
-  It is encoded as an infinite stream of options such that if `f n = none`, then
-  `f m = none` for all `m ≥ n`. -/
+  It is encoded as an infinite stream of options such that if `f[n] = none`, then
+  `f[m] = none` for all `m ≥ n`. -/
 def Seq (α : Type u) : Type u :=
   { f : Stream' (Option α) // f.IsSeq }
 
@@ -66,14 +66,14 @@ variable {α : Type u} {β : Type v} {γ : Type w}
 
 /-- Get the nth element of a sequence (if it exists) -/
 def get? : Seq α → ℕ → Option α :=
-  Subtype.val
+  (fun s n => s.val[n])
 
 @[simp]
-theorem val_eq_get (s : Seq α) (n : ℕ) : s.val n = s.get? n :=
+theorem val_eq_get (s : Seq α) (n : ℕ) : s.val[n] = s.get? n :=
   rfl
 
 @[simp]
-theorem get?_mk (f hf) : @get? α ⟨f, hf⟩ = f :=
+theorem get?_mk (f hf) : @get? α ⟨f, hf⟩ = (f[·]) :=
   rfl
 
 theorem le_stable (s : Seq α) {m n} (h : m ≤ n) : s.get? m = none → s.get? n = none := by
@@ -92,7 +92,7 @@ theorem ge_stable (s : Seq α) {aₙ : α} {n m : ℕ} (m_le_n : m ≤ n)
 
 @[ext]
 protected theorem ext {s t : Seq α} (h : ∀ n : ℕ, s.get? n = t.get? n) : s = t :=
-  Subtype.eq <| funext h
+  Subtype.eq <| Stream'.ext h
 
 /-!
 ### Constructors
@@ -201,7 +201,7 @@ theorem destruct_eq_none {s : Seq α} : destruct s = none → s = nil := by
   dsimp [destruct]
   induction' f0 : get? s 0 <;> intro h
   · apply Subtype.eq
-    funext n
+    ext n : 1
     induction' n with n IH
     exacts [f0, s.2 IH]
   · contradiction
@@ -288,7 +288,7 @@ def Corec.f (f : β → Option (α × β)) : Option β → Option α × Option �
 def corec (f : β → Option (α × β)) (b : β) : Seq α := by
   refine ⟨Stream'.corec' (Corec.f f) (some b), fun {n} h => ?_⟩
   rw [Stream'.corec'_eq]
-  change Stream'.corec' (Corec.f f) (Corec.f f (some b)).2 n = none
+  change (Stream'.corec' (Corec.f f) (Corec.f f (some b)).2)[n] = none
   revert h; generalize some b = o; revert o
   induction' n with n IH <;> intro o
   · change (Corec.f f o).1 = none → (Corec.f f (Corec.f f o).2).1 = none
@@ -306,8 +306,8 @@ def corec (f : β → Option (α × β)) (b : β) : Seq α := by
 @[simp]
 theorem corec_eq (f : β → Option (α × β)) (b : β) :
     destruct (corec f b) = omap (corec f) (f b) := by
-  dsimp [corec, destruct, get]
-  rw [show Stream'.corec' (Corec.f f) (some b) 0 = (Corec.f f (some b)).1 from rfl]
+  dsimp [corec, destruct]
+  rw [show (Stream'.corec' (Corec.f f) (some b))[0] = (Corec.f f (some b)).1 from rfl]
   dsimp [Corec.f]
   induction' h : f b with s; · rfl
   obtain ⟨a, b'⟩ := s; dsimp [Corec.f]
@@ -529,7 +529,7 @@ theorem mem_cons_iff {a b : α} {s : Seq α} : a ∈ cons b s ↔ a = b ∨ a �
 
 theorem mem_rec_on {C : Seq α → Prop} {a s} (M : a ∈ s)
     (h1 : ∀ b s', a = b ∨ C s' → C (cons b s')) : C s := by
-  obtain ⟨k, e⟩ := M; unfold Stream'.get at e
+  obtain ⟨k, e⟩ := M
   induction' k with k IH generalizing s
   · have TH : s = cons a (tail s) := by
       apply destruct_eq_cons
@@ -541,7 +541,7 @@ theorem mem_rec_on {C : Seq α → Prop} {a s} (M : a ∈ s)
   cases s with
   | nil => injection e
   | cons b s' =>
-    have h_eq : (cons b s').val (Nat.succ k) = s'.val k := by cases s' using Subtype.recOn; rfl
+    have h_eq : (cons b s').val[Nat.succ k] = s'.val[k] := by cases s' using Subtype.recOn; rfl
     rw [h_eq] at e
     apply h1 _ _ (Or.inr (IH e))
 
@@ -552,8 +552,8 @@ theorem mem_rec_on {C : Seq α → Prop} {a s} (M : a ∈ s)
 /-- Embed a list as a sequence -/
 @[coe]
 def ofList (l : List α) : Seq α :=
-  ⟨(l[·]?), fun {n} h => by
-    rw [List.getElem?_eq_none_iff] at h ⊢
+  ⟨.mk (l[·]?), fun {n} h => by
+    rw [get_mk, List.getElem?_eq_none_iff] at h ⊢
     exact Nat.le_succ_of_le h⟩
 
 instance coeList : Coe (List α) (Seq α) :=
@@ -572,7 +572,7 @@ theorem ofList_cons (a : α) (l : List α) : ofList (a::l) = cons a (ofList l) :
   ext1 (_ | n) <;> simp
 
 theorem ofList_injective : Function.Injective (ofList : List α → _) :=
-  fun _ _ h => List.ext_getElem? fun _ => congr_fun (Subtype.ext_iff.1 h) _
+  fun _ _ h => List.ext_getElem? fun i => Seq.ext_iff.1 h i
 
 /-- Embed an infinite stream as a sequence -/
 @[coe]
@@ -623,8 +623,8 @@ def toList (s : Seq α) (h : s.Terminates) : List α :=
   take (length s h) s
 
 /-- Convert a sequence which is known not to terminate into a stream -/
-def toStream (s : Seq α) (h : ¬s.Terminates) : Stream' α := fun n =>
-  Option.get _ <| not_terminates_iff.1 h n
+def toStream (s : Seq α) (h : ¬s.Terminates) : Stream' α where
+  get' n := Option.get _ <| not_terminates_iff.1 h n
 
 /-- Convert a sequence into either a list or a stream depending on whether
   it is finite or infinite. (Without decidability of the infiniteness predicate,
@@ -661,8 +661,8 @@ def append (s₁ s₂ : Seq α) : Seq α :=
 def map (f : α → β) : Seq α → Seq β
   | ⟨s, al⟩ =>
     ⟨s.map (Option.map f), fun {n} => by
-      dsimp [Stream'.map, Stream'.get]
-      induction' e : s n with e <;> intro
+      dsimp [Stream'.map]
+      induction' e : s[n] with e <;> intro
       · rw [al e]
         assumption
       · contradiction⟩
@@ -700,7 +700,7 @@ def splitAt : ℕ → Seq α → List α × Seq α
 
 /-- Combine two sequences with a function -/
 def zipWith (f : α → β → γ) (s₁ : Seq α) (s₂ : Seq β) : Seq γ :=
-  ⟨fun n => Option.map₂ f (s₁.get? n) (s₂.get? n), fun {_} hn =>
+  ⟨.mk fun n => Option.map₂ f (s₁.get? n) (s₂.get? n), fun {_} hn =>
     Option.map₂_eq_none_iff.2 <| (Option.map₂_eq_none_iff.1 hn).imp s₁.2 s₂.2⟩
 
 /-- Pair two sequences into a sequence of pairs -/
@@ -731,11 +731,11 @@ def fold (s : Seq α) (init : β) (f : β → α → β) : Seq β :=
 /-- Applies `f` to the `n`th element of the sequence, if it exists, replacing that element
 with the result. -/
 def update (s : Seq α) (n : ℕ) (f : α → α) : Seq α where
-  val := Function.update s.val n ((s.val n).map f)
+  val := .mk <| Function.update (s.get? ·) n ((s.get? n).map f)
   property := by
-    have (i : ℕ) : Function.update s.val n ((s.get? n).map f) i = none ↔ s.get? i = none := by
+    have (i : ℕ) : Function.update (s.get? ·) n ((s.get? n).map f) i = none ↔ s.get? i = none := by
       by_cases hi : i = n <;> simp [Function.update, hi]
-    simp only [IsSeq, val_eq_get, this]
+    simp only [IsSeq, this, get_mk]
     exact @s.prop
 
 /-- Sets the value of sequence `s` at index `n` to `a`. If the `n`th element does not exist

--- a/Mathlib/Data/Stream/Init.lean
+++ b/Mathlib/Data/Stream/Init.lean
@@ -23,18 +23,21 @@ variable (m n : ℕ) (x y : List α) (a b : Stream' α)
 instance [Inhabited α] : Inhabited (Stream' α) :=
   ⟨Stream'.const default⟩
 
+@[ext]
+protected theorem ext {s₁ s₂ : Stream' α} (h : ∀ n : ℕ, s₁[n] = s₂[n]) : s₁ = s₂ := by
+  cases s₁; cases s₂; congr; ext n; exact h n
+
 @[simp] protected theorem eta (s : Stream' α) : head s :: tail s = s :=
-  funext fun i => by cases i <;> rfl
+  Stream'.ext fun i => by cases i <;> rfl
+
+@[simp]
+theorem get_mk (f : ℕ → α) (n : ℕ) : (Stream'.mk f)[n] = f n := rfl
 
 /-- Alias for `Stream'.eta` to match `List` API. -/
 alias cons_head_tail := Stream'.eta
 
-@[ext]
-protected theorem ext {s₁ s₂ : Stream' α} : (∀ n, get s₁ n = get s₂ n) → s₁ = s₂ :=
-  fun h => funext h
-
 @[simp]
-theorem get_zero_cons (a : α) (s : Stream' α) : get (a::s) 0 = a :=
+theorem get_zero_cons (a : α) (s : Stream' α) : (a::s)[0] = a :=
   rfl
 
 @[simp]
@@ -46,7 +49,7 @@ theorem tail_cons (a : α) (s : Stream' α) : tail (a::s) = s :=
   rfl
 
 @[simp]
-theorem get_drop (n m : ℕ) (s : Stream' α) : get (drop m s) n = get s (m + n) := by
+theorem get_drop (n m : ℕ) (s : Stream' α) : (drop m s)[n] = s[m + n] := by
   rw [Nat.add_comm]
   rfl
 
@@ -57,7 +60,7 @@ theorem tail_eq_drop (s : Stream' α) : tail s = drop 1 s :=
 theorem drop_drop (n m : ℕ) (s : Stream' α) : drop n (drop m s) = drop (m + n) s := by
   ext; simp [Nat.add_assoc]
 
-@[simp] theorem get_tail {n : ℕ} {s : Stream' α} : s.tail.get n = s.get (n + 1) := rfl
+@[simp] theorem get_tail {n : ℕ} {s : Stream' α} : s.tail[n] = s[n + 1] := rfl
 
 @[simp] theorem tail_drop' {i : ℕ} {s : Stream' α} : tail (drop i s) = s.drop (i + 1) := by
   ext; simp [Nat.add_comm, Nat.add_left_comm]
@@ -66,15 +69,15 @@ theorem drop_drop (n m : ℕ) (s : Stream' α) : drop n (drop m s) = drop (m + n
 
 theorem tail_drop (n : ℕ) (s : Stream' α) : tail (drop n s) = drop n (tail s) := by simp
 
-theorem get_succ (n : ℕ) (s : Stream' α) : get s (succ n) = get (tail s) n :=
+theorem get_succ (n : ℕ) (s : Stream' α) : s[succ n] = (tail s)[n] :=
   rfl
 
 @[simp]
-theorem get_succ_cons (n : ℕ) (s : Stream' α) (x : α) : get (x :: s) n.succ = get s n :=
+theorem get_succ_cons (n : ℕ) (s : Stream' α) (x : α) : (x :: s)[n.succ] = s[n] :=
   rfl
 
 @[simp] lemma get_cons_append_zero {a : α} {x : List α} {s : Stream' α} :
-    (a :: x ++ₛ s).get 0 = a := rfl
+    (a :: x ++ₛ s)[0] = a := rfl
 
 @[simp] lemma append_eq_cons {a : α} {as : Stream' α} : [a] ++ₛ as = a :: as := rfl
 
@@ -83,7 +86,7 @@ theorem get_succ_cons (n : ℕ) (s : Stream' α) (x : α) : get (x :: s) n.succ 
 theorem drop_succ (n : ℕ) (s : Stream' α) : drop (succ n) s = drop n (tail s) :=
   rfl
 
-theorem head_drop (a : Stream' α) (n : ℕ) : (a.drop n).head = a.get n := by simp
+theorem head_drop (a : Stream' α) (n : ℕ) : (a.drop n).head = a[n] := by simp
 
 theorem cons_injective2 : Function.Injective2 (cons : α → Stream' α → Stream' α) := fun x y s t h =>
   ⟨by rw [← get_zero_cons x s, h, get_zero_cons],
@@ -95,10 +98,10 @@ theorem cons_injective_left (s : Stream' α) : Function.Injective fun x => cons 
 theorem cons_injective_right (x : α) : Function.Injective (cons x) :=
   cons_injective2.right _
 
-theorem all_def (p : α → Prop) (s : Stream' α) : All p s = ∀ n, p (get s n) :=
+theorem all_def (p : α → Prop) (s : Stream' α) : All p s = ∀ n : ℕ, p s[n] :=
   rfl
 
-theorem any_def (p : α → Prop) (s : Stream' α) : Any p s = ∃ n, p (get s n) :=
+theorem any_def (p : α → Prop) (s : Stream' α) : Any p s = ∃ n : ℕ, p s[n] :=
   rfl
 
 @[simp]
@@ -117,7 +120,7 @@ theorem eq_or_mem_of_mem_cons {a b : α} {s : Stream' α} : (a ∈ b::s) → a =
     rw [get_succ, tail_cons] at h
     exact ⟨n', h⟩
 
-theorem mem_of_get_eq {n : ℕ} {s : Stream' α} {a : α} : a = get s n → a ∈ s := fun h =>
+theorem mem_of_get_eq {n : ℕ} {s : Stream' α} {a : α} : a = s[n] → a ∈ s := fun h =>
   Exists.intro n h
 
 section Map
@@ -128,7 +131,7 @@ theorem drop_map (n : ℕ) (s : Stream' α) : drop n (map f s) = map f (drop n s
   Stream'.ext fun _ => rfl
 
 @[simp]
-theorem get_map (n : ℕ) (s : Stream' α) : get (map f s) n = f (get s n) :=
+theorem get_map (n : ℕ) (s : Stream' α) : (map f s)[n] = f s[n] :=
   rfl
 
 theorem tail_map (s : Stream' α) : tail (map f s) = map f (tail s) := rfl
@@ -159,7 +162,7 @@ theorem mem_map {a : α} {s : Stream' α} : a ∈ s → f a ∈ map f s := fun �
   Exists.intro n (by rw [get_map, h])
 
 theorem exists_of_mem_map {f} {b : β} {s : Stream' α} : b ∈ map f s → ∃ a, a ∈ s ∧ f a = b :=
-  fun ⟨n, h⟩ => ⟨get s n, ⟨n, rfl⟩, h.symm⟩
+  fun ⟨n, h⟩ => ⟨s[n], ⟨n, rfl⟩, h.symm⟩
 
 end Map
 
@@ -173,7 +176,7 @@ theorem drop_zip (n : ℕ) (s₁ : Stream' α) (s₂ : Stream' β) :
 
 @[simp]
 theorem get_zip (n : ℕ) (s₁ : Stream' α) (s₂ : Stream' β) :
-    get (zip f s₁ s₂) n = f (get s₁ n) (get s₂ n) :=
+    (zip f s₁ s₂)[n] = f s₁[n] s₂[n] :=
   rfl
 
 theorem head_zip (s₁ : Stream' α) (s₂ : Stream' β) : head (zip f s₁ s₂) = f (head s₁) (head s₂) :=
@@ -188,7 +191,7 @@ theorem zip_eq (s₁ : Stream' α) (s₂ : Stream' β) :
   rw [← Stream'.eta (zip f s₁ s₂)]; rfl
 
 @[simp]
-theorem get_enum (s : Stream' α) (n : ℕ) : get (enum s) n = (n, s.get n) :=
+theorem get_enum (s : Stream' α) (n : ℕ) : (enum s)[n] = (n, s[n]) :=
   rfl
 
 theorem enum_eq_zip (s : Stream' α) : enum s = zip Prod.mk nats s :=
@@ -214,7 +217,7 @@ theorem map_const (f : α → β) (a : α) : map f (const a) = const (f a) :=
   rfl
 
 @[simp]
-theorem get_const (n : ℕ) (a : α) : get (const a) n = a :=
+theorem get_const (n : ℕ) (a : α) : (const a)[n] = a :=
   rfl
 
 @[simp]
@@ -226,7 +229,7 @@ theorem head_iterate (f : α → α) (a : α) : head (iterate f a) = a :=
   rfl
 
 theorem get_succ_iterate' (n : ℕ) (f : α → α) (a : α) :
-    get (iterate f a) (succ n) = f (get (iterate f a) n) := rfl
+    (iterate f a)[succ n] = f (iterate f a)[n] := Function.iterate_succ_apply' _ _ _
 
 theorem tail_iterate (f : α → α) (a : α) : tail (iterate f a) = iterate f (f a) := by
   ext n
@@ -240,11 +243,11 @@ theorem iterate_eq (f : α → α) (a : α) : iterate f a = a::iterate f (f a) :
   rw [tail_iterate]; rfl
 
 @[simp]
-theorem get_zero_iterate (f : α → α) (a : α) : get (iterate f a) 0 = a :=
+theorem get_zero_iterate (f : α → α) (a : α) : (iterate f a)[0] = a :=
   rfl
 
 theorem get_succ_iterate (n : ℕ) (f : α → α) (a : α) :
-    get (iterate f a) (succ n) = get (iterate f (f a)) n := by rw [get_succ, tail_iterate]
+    (iterate f a)[succ n] = (iterate f (f a))[n] := by rw [get_succ, tail_iterate]
 
 section Bisim
 
@@ -260,7 +263,7 @@ def IsBisimulation :=
       head s₁ = head s₂ ∧ tail s₁ ~ tail s₂
 
 theorem get_of_bisim (bisim : IsBisimulation R) {s₁ s₂} :
-    ∀ n, s₁ ~ s₂ → get s₁ n = get s₂ n ∧ drop (n + 1) s₁ ~ drop (n + 1) s₂
+    ∀ n, s₁ ~ s₂ → s₁[n] = s₂[n] ∧ drop (n + 1) s₁ ~ drop (n + 1) s₂
   | 0, h => bisim h
   | n + 1, h =>
     match bisim h with
@@ -306,13 +309,10 @@ theorem iterate_id (a : α) : iterate id a = const a :=
   coinduction rfl fun β fr ch => by rw [tail_iterate, tail_const]; exact ch
 
 theorem map_iterate (f : α → α) (a : α) : iterate f (f a) = map f (iterate f a) := by
-  funext n
+  ext n
   induction' n with n' ih
   · rfl
-  · unfold map iterate get
-    rw [map, get] at ih
-    rw [iterate]
-    exact congrArg f ih
+  · rw [get_succ_iterate', ← Nat.succ_eq_add_one, get_map, get_succ_iterate, ih]
 
 section Corec
 
@@ -341,7 +341,7 @@ theorem unfolds_eq (g : α → β) (f : α → α) (a : α) : unfolds g f a = g 
   unfold unfolds; rw [corec_eq]
 
 theorem get_unfolds_head_tail : ∀ (n : ℕ) (s : Stream' α),
-    get (unfolds head tail s) n = get s n := by
+    (unfolds head tail s)[n] = s[n] := by
   intro n; induction' n with n' ih
   · intro s
     rfl
@@ -363,19 +363,19 @@ theorem interleave_tail_tail (s₁ s₂ : Stream' α) : tail s₁ ⋈ tail s₂ 
   rw [interleave_eq s₁ s₂]; rfl
 
 theorem get_interleave_left : ∀ (n : ℕ) (s₁ s₂ : Stream' α),
-    get (s₁ ⋈ s₂) (2 * n) = get s₁ n
+    (s₁ ⋈ s₂)[2 * n] = s₁[n]
   | 0, _, _ => rfl
   | n + 1, s₁, s₂ => by
-    change get (s₁ ⋈ s₂) (succ (succ (2 * n))) = get s₁ (succ n)
+    change (s₁ ⋈ s₂)[succ (succ (2 * n))] = s₁[succ n]
     rw [get_succ, get_succ, interleave_eq, tail_cons, tail_cons]
     rw [get_interleave_left n (tail s₁) (tail s₂)]
     rfl
 
 theorem get_interleave_right : ∀ (n : ℕ) (s₁ s₂ : Stream' α),
-    get (s₁ ⋈ s₂) (2 * n + 1) = get s₂ n
+    (s₁ ⋈ s₂)[2 * n + 1] = s₂[n]
   | 0, _, _ => rfl
   | n + 1, s₁, s₂ => by
-    change get (s₁ ⋈ s₂) (succ (succ (2 * n + 1))) = get s₂ (succ n)
+    change (s₁ ⋈ s₂)[succ (succ (2 * n + 1))] = s₂[succ n]
     rw [get_succ, get_succ, interleave_eq, tail_cons, tail_cons,
       get_interleave_right n (tail s₁) (tail s₂)]
     rfl
@@ -422,13 +422,13 @@ theorem interleave_even_odd (s₁ : Stream' α) : even s₁ ⋈ odd s₁ = s₁ 
       · simp [odd_eq, odd_eq, tail_interleave, tail_even])
     rfl
 
-theorem get_even : ∀ (n : ℕ) (s : Stream' α), get (even s) n = get s (2 * n)
+theorem get_even : ∀ (n : ℕ) (s : Stream' α), (even s)[n] = s[2 * n]
   | 0, _ => rfl
   | succ n, s => by
-    change get (even s) (succ n) = get s (succ (succ (2 * n)))
+    change (even s)[succ n] = s[succ (succ (2 * n))]
     rw [get_succ, get_succ, tail_even, get_even n]; rfl
 
-theorem get_odd : ∀ (n : ℕ) (s : Stream' α), get (odd s) n = get s (2 * n + 1) := fun n s => by
+theorem get_odd : ∀ (n : ℕ) (s : Stream' α), (odd s)[n] = s[2 * n + 1] := fun n s => by
   rw [odd_eq, get_even]; rfl
 
 theorem mem_of_mem_even (a : α) (s : Stream' α) : a ∈ even s → a ∈ s := fun ⟨n, h⟩ =>
@@ -450,20 +450,20 @@ theorem cons_append_stream (a : α) (l : List α) (s : Stream' α) :
   | List.cons a l₁, l₂, s => by
     rw [List.cons_append, cons_append_stream, cons_append_stream, append_append_stream l₁]
 
-lemma get_append_left (h : n < x.length) : (x ++ₛ a).get n = x[n] := by
+lemma get_append_left (h : n < x.length) : (x ++ₛ a)[n] = x[n] := by
   induction' x with b x ih generalizing n
   · simp at h
   · rcases n with (_ | n)
     · simp
     · simp [ih n (by simpa using h), cons_append_stream]
 
-@[simp] lemma get_append_right : (x ++ₛ a).get (x.length + n) = a.get n := by
+@[simp] lemma get_append_right : (x ++ₛ a)[x.length + n] = a[n] := by
   induction' x <;> simp [Nat.succ_add, *, cons_append_stream]
 
-@[simp] lemma get_append_length : (x ++ₛ a).get x.length = a.get 0 := get_append_right 0 x a
+@[simp] lemma get_append_length : (x ++ₛ a)[x.length] = a[0] := get_append_right 0 x a
 
 lemma append_right_injective (h : x ++ₛ a = x ++ₛ b) : a = b := by
-  ext n; replace h := congr_arg (fun a ↦ a.get (x.length + n)) h; simpa using h
+  ext n; replace h := congr_arg (fun a ↦ a[x.length + n]) h; simpa using h
 
 @[simp] lemma append_right_inj : x ++ₛ a = x ++ₛ b ↔ a = b :=
   ⟨append_right_injective x a b, by simp +contextual⟩
@@ -512,7 +512,7 @@ theorem take_succ (n : ℕ) (s : Stream' α) : take (succ n) s = head s::take n 
 @[simp] theorem take_succ_cons {a : α} (n : ℕ) (s : Stream' α) :
     take (n+1) (a::s) = a :: take n s := rfl
 
-theorem take_succ' {s : Stream' α} : ∀ n, s.take (n+1) = s.take n ++ [s.get n]
+theorem take_succ' {s : Stream' α} : ∀ n, s.take (n+1) = s.take n ++ [s[n]]
   | 0 => rfl
   | n+1 => by rw [take_succ, take_succ' n, ← List.cons_append, ← take_succ, get_tail]
 
@@ -526,16 +526,16 @@ theorem take_take {s : Stream' α} : ∀ {m n}, (s.take n).take m = s.take (min 
   | m, 0 => by rw [Nat.zero_min, take_zero, List.take_nil]
   | m+1, n+1 => by rw [take_succ, List.take_succ_cons, Nat.succ_min_succ, take_succ, take_take]
 
-@[simp] theorem concat_take_get {n : ℕ} {s : Stream' α} : s.take n ++ [s.get n] = s.take (n + 1) :=
+@[simp] theorem concat_take_get {n : ℕ} {s : Stream' α} : s.take n ++ [s[n]] = s.take (n + 1) :=
   (take_succ' n).symm
 
-theorem getElem?_take {s : Stream' α} : ∀ {k n}, k < n → (s.take n)[k]? = s.get k
+theorem getElem?_take {s : Stream' α} : ∀ {k n}, k < n → (s.take n)[k]? = s[k]
   | 0, _+1, _ => by simp only [length_take, zero_lt_succ, List.getElem?_eq_getElem]; rfl
   | k+1, n+1, h => by
     rw [take_succ, List.getElem?_cons_succ, getElem?_take (Nat.lt_of_succ_lt_succ h), get_succ]
 
 theorem getElem?_take_succ (n : ℕ) (s : Stream' α) :
-    (take (succ n) s)[n]? = some (get s n) :=
+    (take (succ n) s)[n]? = some s[n] :=
   getElem?_take (Nat.lt_succ_self n)
 
 @[simp] theorem dropLast_take {n : ℕ} {xs : Stream' α} :
@@ -557,7 +557,7 @@ theorem append_take_drop : ∀ (n : ℕ) (s : Stream' α),
 lemma append_take : x ++ (a.take n) = (x ++ₛ a).take (x.length + n) := by
   induction' x <;> simp [take, Nat.add_comm, cons_append_stream, *]
 
-@[simp] lemma take_get (h : m < (a.take n).length) : (a.take n)[m] = a.get m := by
+@[simp] lemma take_get (h : m < (a.take n).length) : (a.take n)[m] = a[m] := by
   nth_rw 2 [← append_take_drop n a]; rw [get_append_left]
 
 theorem take_append_of_le_length (h : n ≤ x.length) :
@@ -597,7 +597,7 @@ theorem take_theorem (s₁ s₂ : Stream' α) : (∀ n : ℕ, take n s₁ = take
   intro h; apply Stream'.ext; intro n
   induction' n with n _
   · simpa [take] using h 1
-  · have h₁ : some (get s₁ (succ n)) = some (get s₂ (succ n)) := by
+  · have h₁ : some s₁[succ n] = some s₂[succ n] := by
       rw [← getElem?_take_succ, ← getElem?_take_succ, h (succ (succ n))]
     injection h₁
 
@@ -631,7 +631,7 @@ theorem tails_eq (s : Stream' α) : tails s = tail s::tails (tail s) := by
   unfold tails; rw [corec_eq]; rfl
 
 @[simp]
-theorem get_tails : ∀ (n : ℕ) (s : Stream' α), get (tails s) n = drop n (tail s) := by
+theorem get_tails : ∀ (n : ℕ) (s : Stream' α), (tails s)[n] = drop n (tail s) := by
   intro n; induction' n with n' ih
   · intros
     rfl
@@ -656,7 +656,7 @@ theorem inits_tail (s : Stream' α) : inits (tail s) = initsCore [head (tail s)]
 
 theorem cons_get_inits_core :
     ∀ (a : α) (n : ℕ) (l : List α) (s : Stream' α),
-      (a::get (initsCore l s) n) = get (initsCore (a::l) s) n := by
+      (a::(initsCore l s)[n]) = (initsCore (a::l) s)[n] := by
   intro a n
   induction' n with n' ih
   · intros
@@ -666,7 +666,7 @@ theorem cons_get_inits_core :
     rfl
 
 @[simp]
-theorem get_inits : ∀ (n : ℕ) (s : Stream' α), get (inits s) n = take (succ n) s := by
+theorem get_inits : ∀ (n : ℕ) (s : Stream' α), (inits s)[n] = take (succ n) s := by
   intro n; induction' n with n' ih
   · intros
     rfl
@@ -703,7 +703,7 @@ theorem interchange (fs : Stream' (α → β)) (a : α) :
 theorem map_eq_apply (f : α → β) (s : Stream' α) : map f s = pure f ⊛ s :=
   rfl
 
-theorem get_nats (n : ℕ) : get nats n = n :=
+theorem get_nats (n : ℕ) : nats[n] = n :=
   rfl
 
 theorem nats_eq : nats = cons 0 (map succ nats) := by

--- a/Mathlib/Data/WSeq/Basic.lean
+++ b/Mathlib/Data/WSeq/Basic.lean
@@ -451,7 +451,7 @@ theorem mem_cons (s : WSeq α) (a) : a ∈ cons a s :=
   (mem_cons_iff _ _).2 (Or.inl rfl)
 
 theorem mem_of_mem_tail {s : WSeq α} {a} : a ∈ tail s → a ∈ s := by
-  intro h; have := h; obtain ⟨n, e⟩ := h; revert s; simp only [Stream'.get]
+  intro h; have := h; obtain ⟨n, e⟩ := h; revert s
   induction' n with n IH <;> intro s <;> induction' s using WSeq.recOn with x s s <;>
     simp <;> intro m e <;>
     injections

--- a/Mathlib/Data/WSeq/Productive.lean
+++ b/Mathlib/Data/WSeq/Productive.lean
@@ -53,7 +53,7 @@ theorem productive_congr {s t : WSeq α} (h : s ~ʷ t) : Productive s ↔ Produc
 /-- Given a productive weak sequence, we can collapse all the `think`s to
   produce a sequence. -/
 def toSeq (s : WSeq α) [Productive s] : Seq α :=
-  ⟨fun n => (get? s n).get,
+  ⟨.mk fun n => (get? s n).get,
    fun {n} h => by
     cases e : Computation.get (get? s (n + 1))
     · assumption
@@ -64,7 +64,7 @@ def toSeq (s : WSeq α) [Productive s] : Seq α :=
     contradiction⟩
 
 theorem toSeq_ofSeq (s : Seq α) : toSeq (ofSeq s) = s := by
-  apply Subtype.eq; funext n
+  apply Subtype.eq; ext n : 1
   dsimp [toSeq]; apply get_eq_of_mem
   rw [get?_ofSeq]; apply ret_mem
 


### PR DESCRIPTION
I'll continue fixing this only if people agree this is a good use of this notation.

[#mathlib4 > Changing &#96;Stream.Seq&#96; to use &#96;GetElem&#96; @ 💬](https://leanprover.zulipchat.com/#narrow/channel/287929-mathlib4/topic/Changing.20.60Stream.2ESeq.60.20to.20use.20.60GetElem.60/near/538548680)

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include at least one commit authored by each
co-author among the commits in the pull request. If necessary, you may 
create empty commits to indicate co-authorship, using commands like so:

git commit --author="Author Name <author@email.com>" --allow-empty -m "add Author Name as coauthor"

When merging, all the commits will be squashed into a single commit listing all co-authors.

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
