### PR TITLE
[Merged by Bors] - chore: refactor `BinomialRing` to avoid bad instances

### DIFF
--- a/Mathlib/NumberTheory/Padics/MahlerBasis.lean
+++ b/Mathlib/NumberTheory/Padics/MahlerBasis.lean
@@ -66,9 +66,11 @@ lemma norm_ascPochhammer_le (k : ℕ) (x : ℤ_[p]) :
     ← Ring.factorial_nsmul_multichoose_eq_ascPochhammer, smul_eq_mul, Nat.cast_mul, norm_mul]
   exact mul_le_of_le_one_right (norm_nonneg _) (norm_le_one _)
 
+local instance : IsAddTorsionFree ℤ_[p] where
+  nsmul_right_injective _ := smul_right_injective ℤ_[p]
+
 /-- The p-adic integers are a binomial ring, i.e. a ring where binomial coefficients make sense. -/
 noncomputable instance instBinomialRing : BinomialRing ℤ_[p] where
-  nsmul_right_injective n := smul_right_injective ℤ_[p]
   -- We define `multichoose` as a fraction in `ℚ_[p]` together with a proof that its norm is `≤ 1`.
   multichoose x k := ⟨(ascPochhammer ℤ_[p] k).eval x / (k.factorial : ℚ_[p]), by
     rw [norm_div, div_le_one (by simpa using k.factorial_ne_zero)]

--- a/Mathlib/NumberTheory/Padics/MahlerBasis.lean
+++ b/Mathlib/NumberTheory/Padics/MahlerBasis.lean
@@ -66,7 +66,7 @@ lemma norm_ascPochhammer_le (k : ℕ) (x : ℤ_[p]) :
     ← Ring.factorial_nsmul_multichoose_eq_ascPochhammer, smul_eq_mul, Nat.cast_mul, norm_mul]
   exact mul_le_of_le_one_right (norm_nonneg _) (norm_le_one _)
 
-local instance : IsAddTorsionFree ℤ_[p] where
+instance : IsAddTorsionFree ℤ_[p] where
   nsmul_right_injective _ := smul_right_injective ℤ_[p]
 
 /-- The p-adic integers are a binomial ring, i.e. a ring where binomial coefficients make sense. -/

--- a/Mathlib/RingTheory/Binomial.lean
+++ b/Mathlib/RingTheory/Binomial.lean
@@ -69,6 +69,8 @@ suitable factorials. We define this notion as a mixin for additive commutative m
 number powers, but retain the ring name. We introduce `Ring.multichoose` as the uniquely defined
 quotient. -/
 class BinomialRing (R : Type*) [AddCommMonoid R] [Pow R ℕ] where
+  -- This base class has been demoted to a field, to avoid creating
+  -- an expensive global instance.
   [toIsAddTorsionFree : IsAddTorsionFree R]
   /-- A multichoose function, giving the quotient of Pochhammer evaluations by factorials. -/
   multichoose : R → ℕ → R

--- a/Mathlib/RingTheory/Binomial.lean
+++ b/Mathlib/RingTheory/Binomial.lean
@@ -260,8 +260,8 @@ instance Int.instBinomialRing : BinomialRing ℤ where
         ← Int.neg_ofNat_succ, ascPochhammer_smeval_neg_eq_descPochhammer]
       norm_cast
 
-local instance {R : Type*} [AddCommMonoid R] [Module ℚ≥0 R] :
-    IsAddTorsionFree R where
+-- This instance will fire for any type `R`, so is local unless needed elsewhere.
+local instance {R : Type*} [AddCommMonoid R] [Module ℚ≥0 R] : IsAddTorsionFree R where
   nsmul_right_injective {n} hn r s hrs := by
     rw [← one_smul ℚ≥0 r, ← one_smul ℚ≥0 s, show 1 = (n : ℚ≥0)⁻¹ • (n : ℚ≥0) by simp_all]
     simp_all only [smul_assoc, Nat.cast_smul_eq_nsmul]

--- a/Mathlib/RingTheory/Binomial.lean
+++ b/Mathlib/RingTheory/Binomial.lean
@@ -69,23 +69,12 @@ suitable factorials. We define this notion as a mixin for additive commutative m
 number powers, but retain the ring name. We introduce `Ring.multichoose` as the uniquely defined
 quotient. -/
 class BinomialRing (R : Type*) [AddCommMonoid R] [Pow R ℕ] where
-  -- This field of `IsAddTorsionFree` has been inlined, to avoid creating
-  -- `BinomialRing.toIsAddTorsionFree` as a global instance.
-  /-- Binomial rings are torsion free. -/
   [toIsAddTorsionFree : IsAddTorsionFree R]
   /-- A multichoose function, giving the quotient of Pochhammer evaluations by factorials. -/
   multichoose : R → ℕ → R
   /-- The `n`th ascending Pochhammer polynomial evaluated at any element is divisible by `n!` -/
   factorial_nsmul_multichoose (r : R) (n : ℕ) :
     n.factorial • multichoose r n = (ascPochhammer ℕ n).smeval r
-
-/--
-The parent projection to `IsAddTorsionFree`,
-defined separately so we can make it a local instance.
--/
-theorem BinomialRing.toIsAddTorsionFree (R : Type*) [AddCommMonoid R] [Pow R ℕ] [BinomialRing R] :
-    IsAddTorsionFree R :=
-  { nsmul_right_injective := BinomialRing.nsmul_right_injective }
 
 -- This is only a local instance as it otherwise causes significant slow downs
 -- to every call to `grind` involving a ring. Please do not make it a global instance.
@@ -242,7 +231,6 @@ section Basic_Instances
 open Polynomial
 
 instance Nat.instBinomialRing : BinomialRing ℕ where
-  nsmul_right_injective n hn _ _ := Nat.eq_of_mul_eq_mul_left (by omega)
   multichoose := Nat.multichoose
   factorial_nsmul_multichoose r n := by
     rw [smul_eq_mul, Nat.multichoose_eq r n, ← Nat.descFactorial_eq_factorial_mul_choose,
@@ -255,7 +243,6 @@ def Int.multichoose (n : ℤ) (k : ℕ) : ℤ :=
   | negSucc n => Int.negOnePow k * Nat.choose (n + 1) k
 
 instance Int.instBinomialRing : BinomialRing ℤ where
-  nsmul_right_injective n hn _ _ := Int.eq_of_mul_eq_mul_left (by omega)
   multichoose := Int.multichoose
   factorial_nsmul_multichoose r k := by
     rw [Int.multichoose.eq_def, nsmul_eq_mul]
@@ -271,10 +258,13 @@ instance Int.instBinomialRing : BinomialRing ℤ where
         ← Int.neg_ofNat_succ, ascPochhammer_smeval_neg_eq_descPochhammer]
       norm_cast
 
-noncomputable instance {R : Type*} [AddCommMonoid R] [Module ℚ≥0 R] [Pow R ℕ] : BinomialRing R where
+noncomputable local instance {R : Type*} [AddCommMonoid R] [Module ℚ≥0 R] [Pow R ℕ] :
+    IsAddTorsionFree R where
   nsmul_right_injective {n} hn r s hrs := by
     rw [← one_smul ℚ≥0 r, ← one_smul ℚ≥0 s, show 1 = (n : ℚ≥0)⁻¹ • (n : ℚ≥0) by simp_all]
     simp_all only [smul_assoc, Nat.cast_smul_eq_nsmul]
+
+noncomputable instance {R : Type*} [AddCommMonoid R] [Module ℚ≥0 R] [Pow R ℕ] : BinomialRing R where
   multichoose r n := (n.factorial : ℚ≥0)⁻¹ • Polynomial.smeval (ascPochhammer ℕ n) r
   factorial_nsmul_multichoose r n := by
     match_scalars

--- a/Mathlib/RingTheory/Binomial.lean
+++ b/Mathlib/RingTheory/Binomial.lean
@@ -260,7 +260,7 @@ instance Int.instBinomialRing : BinomialRing ℤ where
         ← Int.neg_ofNat_succ, ascPochhammer_smeval_neg_eq_descPochhammer]
       norm_cast
 
-noncomputable local instance {R : Type*} [AddCommMonoid R] [Module ℚ≥0 R] [Pow R ℕ] :
+local instance {R : Type*} [AddCommMonoid R] [Module ℚ≥0 R] :
     IsAddTorsionFree R where
   nsmul_right_injective {n} hn r s hrs := by
     rw [← one_smul ℚ≥0 r, ← one_smul ℚ≥0 s, show 1 = (n : ℚ≥0)⁻¹ • (n : ℚ≥0) by simp_all]

--- a/Mathlib/RingTheory/Binomial.lean
+++ b/Mathlib/RingTheory/Binomial.lean
@@ -72,7 +72,7 @@ class BinomialRing (R : Type*) [AddCommMonoid R] [Pow R ℕ] where
   -- This field of `IsAddTorsionFree` has been inlined, to avoid creating
   -- `BinomialRing.toIsAddTorsionFree` as a global instance.
   /-- Binomial rings are torsion free. -/
-  protected nsmul_right_injective ⦃n : ℕ⦄ (hn : n ≠ 0) : Injective fun a : R ↦ n • a
+  [toIsAddTorsionFree : IsAddTorsionFree R]
   /-- A multichoose function, giving the quotient of Pochhammer evaluations by factorials. -/
   multichoose : R → ℕ → R
   /-- The `n`th ascending Pochhammer polynomial evaluated at any element is divisible by `n!` -/

--- a/Mathlib/RingTheory/Binomial.lean
+++ b/Mathlib/RingTheory/Binomial.lean
@@ -83,10 +83,13 @@ class BinomialRing (R : Type*) [AddCommMonoid R] [Pow R ℕ] where
 The parent projection to `IsAddTorsionFree`,
 defined separately so we can make it a local instance.
 -/
-def BinomialRing.toIsAddTorsionFree (R : Type*) [AddCommMonoid R] [Pow R ℕ] [BinomialRing R] :
+theorem BinomialRing.toIsAddTorsionFree (R : Type*) [AddCommMonoid R] [Pow R ℕ] [BinomialRing R] :
     IsAddTorsionFree R :=
   { nsmul_right_injective := BinomialRing.nsmul_right_injective }
 
+-- This is only a local instance as it otherwise causes significant slow downs
+-- to every call to `grind` involving a ring. Please do not make it a global instance.
+-- (~1500 heartbeats measured on `nightly-testing-2025-09-09`.)
 attribute [local instance] BinomialRing.toIsAddTorsionFree
 
 section Multichoose

--- a/Mathlib/RingTheory/Binomial.lean
+++ b/Mathlib/RingTheory/Binomial.lean
@@ -61,7 +61,6 @@ Further results in Elliot's paper:
   `1 + I`.
 
 -/
-section Multichoose
 
 open Function Polynomial
 
@@ -69,12 +68,28 @@ open Function Polynomial
 suitable factorials. We define this notion as a mixin for additive commutative monoids with natural
 number powers, but retain the ring name. We introduce `Ring.multichoose` as the uniquely defined
 quotient. -/
-class BinomialRing (R : Type*) [AddCommMonoid R] [Pow R ℕ] extends IsAddTorsionFree R where
+class BinomialRing (R : Type*) [AddCommMonoid R] [Pow R ℕ] where
+  -- This field of `IsAddTorsionFree` has been inlined, to avoid creating
+  -- `BinomialRing.toIsAddTorsionFree` as a global instance.
+  /-- Binomial rings are torsion free. -/
+  protected nsmul_right_injective ⦃n : ℕ⦄ (hn : n ≠ 0) : Injective fun a : R ↦ n • a
   /-- A multichoose function, giving the quotient of Pochhammer evaluations by factorials. -/
   multichoose : R → ℕ → R
   /-- The `n`th ascending Pochhammer polynomial evaluated at any element is divisible by `n!` -/
   factorial_nsmul_multichoose (r : R) (n : ℕ) :
     n.factorial • multichoose r n = (ascPochhammer ℕ n).smeval r
+
+/--
+The parent projection to `IsAddTorsionFree`,
+defined separately so we can make it a local instance.
+-/
+def BinomialRing.toIsAddTorsionFree (R : Type*) [AddCommMonoid R] [Pow R ℕ] [BinomialRing R] :
+    IsAddTorsionFree R :=
+  { nsmul_right_injective := BinomialRing.nsmul_right_injective }
+
+attribute [local instance] BinomialRing.toIsAddTorsionFree
+
+section Multichoose
 
 namespace Ring
 

--- a/MathlibTest/slow_instances.lean
+++ b/MathlibTest/slow_instances.lean
@@ -2,11 +2,7 @@ import Mathlib
 
 variable {K : Type*} [Field K] {x : K}
 
--- This one is dismally slow:
--- #time
--- #synth NoZeroSMulDivisors ℕ K
-
-set_option maxHeartbeats 3000 in -- uses under 2000 as of 2025-08-06
+set_option maxHeartbeats 1500 in -- uses about 1000 as of 2025-09-10
 /--
 error: failed to synthesize
   Lean.Grind.NoNatZeroDivisors K
@@ -16,5 +12,16 @@ Hint: Additional diagnostic information may be available using the `set_option d
 #guard_msgs in
 #synth Lean.Grind.NoNatZeroDivisors K
 
-set_option maxHeartbeats 6000 in -- uses about 4000 as of 2025-08-06
+set_option maxHeartbeats 3000 in -- uses about 2500 as of 2025-09-10
 example : x ^ 3 * x ^ 42 = x ^ 45 := by grind
+
+-- This one is dismally slow (~0.5s, 18_000 heartbeats). However it doesn't affect `grind` directly.
+set_option maxHeartbeats 20_000 in
+/--
+error: failed to synthesize
+  NoZeroSMulDivisors ℕ K
+
+Hint: Additional diagnostic information may be available using the `set_option diagnostics true` command.
+-/
+#guard_msgs in
+#synth NoZeroSMulDivisors ℕ K


### PR DESCRIPTION
This instance was doubling (measured on `nightly-testing`) the run-time of the failed search

```
import Mathlib

variable {K : Type*} [Field K] {x : K}

example : Lean.Grind.NoNatZeroDivisors K := inferInstance
```

`grind` hits this search case often, so we'd like to keep this failing fast.