### PR TITLE
feat: 'said' tactic

### DIFF
--- a/Mathlib/Tactic/Linter/UnusedTactic.lean
+++ b/Mathlib/Tactic/Linter/UnusedTactic.lean
@@ -87,6 +87,7 @@ unevaluated tactics.
 -/
 initialize ignoreTacticKindsRef : IO.Ref NameHashSet ←
   IO.mkRef <| .ofArray #[
+    `Mathlib.Tactic.Says.said,
     `Mathlib.Tactic.Says.says,
     ``Parser.Term.binderTactic,
     ``Lean.Parser.Term.dynamicQuot,

--- a/Mathlib/Tactic/Linter/UnusedTacticExtension.lean
+++ b/Mathlib/Tactic/Linter/UnusedTacticExtension.lean
@@ -49,6 +49,7 @@ This can be increased dynamically, using `#allow_unused_tactic`.
 initialize allowedRef : IO.Ref (Std.HashSet SyntaxNodeKind) ←
   IO.mkRef <| .ofArray #[
     `Mathlib.Tactic.Says.says,
+    `Mathlib.Tactic.Says.said,
     `Batteries.Tactic.«tacticOn_goal-_=>_»,
     `by,
     `null,

--- a/Mathlib/Tactic/Says.lean
+++ b/Mathlib/Tactic/Says.lean
@@ -135,6 +135,38 @@ elab_rules : tactic
 
 initialize Batteries.Linter.UnreachableTactic.addIgnoreTacticKind `Mathlib.Tactic.Says.says
 
+/--
+`X said Y` is a variant of the `says` tactic which is supposed to come with no _guarantees_ about
+the relationship of `Y`, other than that `X` was used in the developer's decision to write `Y`. As
+such, as it does not have any verification.
+
+Main uses are where a `says` tactic is liable to change too often to be checked (but we
+still want generally want `says.verify` on), or where the relationship between input and output is
+more up to human intervention.
+
+For example, `exact? says [a long proof term]` might be unstable due to slight changes in the output
+of `exact?`, where many different proof terms would work.
+
+For `simp?`, it is the case that `simp` should generally be confluent, but
+there can be different orders rewrites that get the same conclusion, so it could be that
+```
+simp only [A, B]
+simp only [C, D]
+```
+do the same transformation, and all four are tagged `@[simp]`. Then the particular output of `simp?`
+will be very sensitive to the environment in picking one or the other, and so `simp? says` changes
+regularly; in this case, `simp? said simp only [A, B]` implies that the exact output of `simp?` is
+unstable.
+
+Finally, you could do things like `simp? [*] said exact h₁.myStandardTheorem h₂` or even
+`ring said grind [add_pow_char_pow_of_commute]` if that's what you want.
+-/
+syntax (name := said) tactic " said" colGt tacticSeq : tactic
+
+macro_rules | `(tactic| $_:tactic said%$_ $result:tacticSeq) =>  `(tactic| ($result))
+
+initialize Batteries.Linter.UnreachableTactic.addIgnoreTacticKind `Mathlib.Tactic.Says.said
+
 end Says
 
 end Mathlib.Tactic

--- a/MathlibTest/says.lean
+++ b/MathlibTest/says.lean
@@ -111,3 +111,9 @@ info: Try this: aesop? says
 #guard_msgs in
 example : P := by
   aesop? says
+
+-- Check that there's no output even with says.verify
+#guard_msgs in
+set_option says.verify true in
+example : let x := 3 + 5; x = 8 := by
+  rw [Nat.add_comm, margle_morbs] said rfl


### PR DESCRIPTION
Functionally similar to `says`, but explicitly not for checking output or even saying there ever was output. `X said Y` just means that `X` was part of the process for (a human, or machine, or both) to generate `Y`.

Based on this [#mathlib4 > noisy simp says in CI @ 💬](https://leanprover.zulipchat.com/#narrow/channel/287929-mathlib4/topic/noisy.20simp.20says.20in.20CI/near/538443152) Zulip discussion

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include at least one commit authored by each
co-author among the commits in the pull request. If necessary, you may 
create empty commits to indicate co-authorship, using commands like so:

git commit --author="Author Name <author@email.com>" --allow-empty -m "add Author Name as coauthor"

When merging, all the commits will be squashed into a single commit listing all co-authors.

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
