### PR TITLE
[Merged by Bors] - feat: closed point of scheme gives maximal ideal in affine open

### DIFF
--- a/Mathlib/AlgebraicGeometry/AffineScheme.lean
+++ b/Mathlib/AlgebraicGeometry/AffineScheme.lean
@@ -722,6 +722,16 @@ theorem primeIdealOf_eq_map_closedPoint (x : U) :
     hU.primeIdealOf x = (Spec.map (X.presheaf.germ _ x x.2)).base (closedPoint _) :=
   hU.isoSpec_hom_base_apply _
 
+/-- A point `x : U` is a closed point if and only if its corresponding prime ideal is maximal. -/
+theorem isClosed_iff_primeIdealOf_isMaximal {x : U} :
+    IsClosed {x} ↔ (hU.primeIdealOf x).asIdeal.IsMaximal := by
+  refine Iff.trans ?_ (hU.primeIdealOf x).isClosed_singleton_iff_isMaximal
+  rw [primeIdealOf, ← Set.image_singleton]
+  refine Topology.IsClosedEmbedding.isClosed_iff_image_isClosed <|
+    IsHomeomorph.isClosedEmbedding ?_
+  apply (TopCat.isIso_iff_isHomeomorph _).mp
+  infer_instance
+
 theorem isLocalization_stalk' (y : PrimeSpectrum Γ(X, U)) (hy : hU.fromSpec.base y ∈ U) :
     @IsLocalization.AtPrime
       (R := Γ(X, U))

--- a/Mathlib/AlgebraicGeometry/AffineScheme.lean
+++ b/Mathlib/AlgebraicGeometry/AffineScheme.lean
@@ -722,13 +722,16 @@ theorem primeIdealOf_eq_map_closedPoint (x : U) :
     hU.primeIdealOf x = (Spec.map (X.presheaf.germ _ x x.2)).base (closedPoint _) :=
   hU.isoSpec_hom_base_apply _
 
-/-- A point `x : U` is a closed point if and only if its corresponding prime ideal is maximal. -/
-theorem isClosed_iff_primeIdealOf_isMaximal {x : U} :
-    IsClosed {x} ↔ (hU.primeIdealOf x).asIdeal.IsMaximal := by
-  refine Iff.trans ?_ (hU.primeIdealOf x).isClosed_singleton_iff_isMaximal
+/-- If a point `x : U` is a closed point, then its corresponding prime ideal is maximal. -/
+theorem primeIdealOf_isMaximal_of_isClosed (x : U) (hx : IsClosed {x.1}) :
+    (hU.primeIdealOf x).asIdeal.IsMaximal := by
+  have hx₀ : IsClosed {x} := by
+    simpa [← Set.image_singleton, Set.preimage_image_eq _ Subtype.val_injective]
+      using hx.preimage U.isOpenEmbedding'.continuous
+  apply (hU.primeIdealOf x).isClosed_singleton_iff_isMaximal.mp
   rw [primeIdealOf, ← Set.image_singleton]
-  refine Topology.IsClosedEmbedding.isClosed_iff_image_isClosed <|
-    IsHomeomorph.isClosedEmbedding ?_
+  refine (Topology.IsClosedEmbedding.isClosed_iff_image_isClosed <|
+    IsHomeomorph.isClosedEmbedding ?_).mp hx₀
   apply (TopCat.isIso_iff_isHomeomorph _).mp
   infer_instance
 

--- a/Mathlib/AlgebraicGeometry/AffineScheme.lean
+++ b/Mathlib/AlgebraicGeometry/AffineScheme.lean
@@ -723,7 +723,7 @@ theorem primeIdealOf_eq_map_closedPoint (x : U) :
   hU.isoSpec_hom_base_apply _
 
 /-- If a point `x : U` is a closed point, then its corresponding prime ideal is maximal. -/
-theorem primeIdealOf_isMaximal_of_isClosed (x : U) (hx : IsClosed {x.1}) :
+theorem primeIdealOf_isMaximal_of_isClosed (x : U) (hx : IsClosed {(x : X)}) :
     (hU.primeIdealOf x).asIdeal.IsMaximal := by
   have hx₀ : IsClosed {x} := by
     simpa [← Set.image_singleton, Set.preimage_image_eq _ Subtype.val_injective]


### PR DESCRIPTION
If a point `x` is a closed point in a scheme `X`, then its corresponding prime ideal in an affine open, `primeIdealOf x`, is maximal.

The converse is not true in general, but is true for schemes locally of finite type over a field. 

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include at least one commit authored by each
co-author among the commits in the pull request. If necessary, you may 
create empty commits to indicate co-authorship, using commands like so:

git commit --author="Author Name <author@email.com>" --allow-empty -m "add Author Name as coauthor"

When merging, all the commits will be squashed into a single commit listing all co-authors.

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
