### PR TITLE
[Merged by Bors] - chore: remove triangleRemovalBound positivity extension

### DIFF
--- a/Mathlib/Combinatorics/Additive/Corner/Roth.lean
+++ b/Mathlib/Combinatorics/Additive/Corner/Roth.lean
@@ -89,8 +89,8 @@ theorem corners_theorem (ε : ℝ) (hε : 0 < ε) (hG : cornersTheoremBound ε �
   have := noAccidental hA
   rw [Nat.floor_lt' (by positivity), inv_lt_iff_one_lt_mul₀'] at hG
   swap
-  · have : ε / 9 ≤ 1 := by linarith
-    positivity
+  · have := triangleRemovalBound_pos (ε := ε / 9) (by linarith) (by linarith)
+    linarith
   refine hG.not_ge (le_of_mul_le_mul_right ?_ (by positivity : (0 : ℝ) < card G ^ 2))
   classical
   have h₁ := (farFromTriangleFree_graph hAε).le_card_cliqueFinset

--- a/Mathlib/Combinatorics/SimpleGraph/Triangle/Removal.lean
+++ b/Mathlib/Combinatorics/SimpleGraph/Triangle/Removal.lean
@@ -154,24 +154,3 @@ lemma triangle_removal (hG : #(G.cliqueFinset 3) < triangleRemovalBound ε * car
   exact le_of_not_gt fun i ↦ h G' hG _ i hG'
 
 end SimpleGraph
-
-namespace Mathlib.Meta.Positivity
-open Lean.Meta Qq SimpleGraph
-
-/-- Extension for the `positivity` tactic: `SimpleGraph.triangleRemovalBound ε` is positive if
-`0 < ε ≤ 1`.
-
-Note this looks for `ε ≤ 1` in the context. -/
-@[positivity triangleRemovalBound _]
-def evalTriangleRemovalBound : PositivityExt where eval {u α} _zα _pα e := do
-  match u, α, e with
-  | 0, ~q(ℝ), ~q(triangleRemovalBound $ε) =>
-    let some hε₁ ← findLocalDeclWithTypeQ? q($ε ≤ 1) | failure
-    let .positive hε ← core q(inferInstance) q(inferInstance) ε | failure
-    assertInstancesCommute
-    pure (.positive q(triangleRemovalBound_pos $hε $hε₁))
-  | _, _, _ => throwError "failed to match on Int.ceil application"
-
-example (ε : ℝ) (hε₀ : 0 < ε) (hε₁ : ε ≤ 1) : 0 < triangleRemovalBound ε := by positivity
-
-end Mathlib.Meta.Positivity


### PR DESCRIPTION
This extension just applies src#SimpleGraph.triangleRemovalBound_pos, discharging an `ε ≤ 1` by hoping it is there as a hypothesis(!!), and discharging the other argument by a recursive call to `positivity`.

This is used in a single proof, as
```
  · have : ε / 9 ≤ 1 := by linarith
    positivity
```

My complaint here is that this is completely unreadable. One can only understand why the `have` statement is introduced here by *reading meta code*. (First of all one has to use `show_term` or similar to even work out which lemma is being applied, then some grepping to find the positivity extension, and finally the surprising discovery that the `have` statement is there because the extension goes out look for exactly this fact.)