### PR TITLE
feat: `WellFoundedLT (LowerSet α)`

### DIFF
--- a/Mathlib.lean
+++ b/Mathlib.lean
@@ -5186,6 +5186,7 @@ import Mathlib.Order.UpperLower.LocallyFinite
 import Mathlib.Order.UpperLower.Principal
 import Mathlib.Order.UpperLower.Prod
 import Mathlib.Order.UpperLower.Relative
+import Mathlib.Order.UpperLower.WellFounded
 import Mathlib.Order.WellFounded
 import Mathlib.Order.WellFoundedSet
 import Mathlib.Order.WellQuasiOrder

--- a/Mathlib/Order/UpperLower/WellFounded.lean
+++ b/Mathlib/Order/UpperLower/WellFounded.lean
@@ -3,7 +3,7 @@ Copyright (c) 2025 Violeta Hernández Palacios. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Violeta Hernández Palacios
 -/
-import Mathlib.Order.UpperLower.Basic
+import Mathlib.Order.UpperLower.CompleteLattice
 import Mathlib.Order.WellQuasiOrder
 
 /-!
@@ -12,13 +12,13 @@ import Mathlib.Order.WellQuasiOrder
 We show that `LowerSet α` and `UpperSet α` are well-founded whenever `α` is a WQO.
 -/
 
-variable [Preorder α] [WellQuasiOrderedLE α]
+variable {α : Type*} [Preorder α] [WellQuasiOrderedLE α]
 
 instance : WellFoundedLT (LowerSet α) where
   wf := by
     rw [RelEmbedding.wellFounded_iff_isEmpty]
     refine ⟨fun f ↦ ?_⟩
-    have hf' (n) : ((f n).1 \ f (n + 1)).Nonempty := diff_nonempty.2 (f.2.2 n.lt_succ_self).not_ge
+    have hf' (n : ℕ) := Set.diff_nonempty.2 (f.2.2 n.lt_succ_self).not_ge
     choose g hg using hf'
     obtain ⟨m, n, h, h'⟩ := wellQuasiOrdered_le g
     apply not_not.2 <| (f n).lower' h' (hg n).1

--- a/Mathlib/Order/UpperLower/WellFounded.lean
+++ b/Mathlib/Order/UpperLower/WellFounded.lean
@@ -1,0 +1,30 @@
+/-
+Copyright (c) 2025 Violeta Hernández Palacios. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Violeta Hernández Palacios
+-/
+import Mathlib.Order.UpperLower.Basic
+import Mathlib.Order.WellQuasiOrder
+
+/-!
+# Well-founded instances
+
+We show that `LowerSet α` and `UpperSet α` are well-founded whenever `α` is a WQO.
+-/
+
+variable [Preorder α] [WellQuasiOrderedLE α]
+
+instance : WellFoundedLT (LowerSet α) where
+  wf := by
+    rw [RelEmbedding.wellFounded_iff_isEmpty]
+    refine ⟨fun f ↦ ?_⟩
+    have hf' (n) : ((f n).1 \ f (n + 1)).Nonempty := diff_nonempty.2 (f.2.2 n.lt_succ_self).not_ge
+    choose g hg using hf'
+    obtain ⟨m, n, h, h'⟩ := wellQuasiOrdered_le g
+    apply not_not.2 <| (f n).lower' h' (hg n).1
+    obtain rfl | h := h.nat_succ_le.eq_or_lt
+    · exact (hg _).2
+    · exact ((hg _).2 <| (f.map_rel_iff.2 h).le ·)
+
+instance : WellFoundedLT (UpperSet α) :=
+  upperSetIsoLowerSet.toRelIsoLT.toRelEmbedding.isWellFounded


### PR DESCRIPTION
We prove that `LowerSet α` is well-founded when `α` is a WQO.

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include at least one commit authored by each
co-author among the commits in the pull request. If necessary, you may 
create empty commits to indicate co-authorship, using commands like so:

git commit --author="Author Name <author@email.com>" --allow-empty -m "add Author Name as coauthor"

When merging, all the commits will be squashed into a single commit listing all co-authors.

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

This result is used in the CGT repository to construct the poset game!

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
