### PR TITLE
[Merged by Bors] - test(TacticAnalysis): ensure `classical`'s effects are picked up

### DIFF
--- a/MathlibTest/TacticAnalysis.lean
+++ b/MathlibTest/TacticAnalysis.lean
@@ -88,6 +88,16 @@ example {α : Type u} (f : α → Type max u v) : 1 = 1 := by
   have : 1 + 1 = 2 := rfl -- Extra line to ensure the linter picks it up.
   rfl
 
+-- Ensure the effects of `classical` are picked up. Otherwise we get an error like:
+-- failed to synthesize
+--   Decidable b
+theorem forall_imp_iff_exists_imp {α : Type} {p : α → Prop} {b : Prop} [ha : Nonempty α] :
+    (∀ x, p x) → b ↔ ∃ x, p x → b := by
+  classical
+  let ⟨a⟩ := ha
+  refine ⟨fun h ↦ Decidable.not_forall_not.1 fun h' ↦ ?_, fun ⟨x, hx⟩ h ↦ hx (h x)⟩
+  exact if hb : b then h' a fun _ ↦ hb else hb <| h fun x ↦ (Decidable.not_imp_iff_and_not.1 (h' x)).1
+
 end replaceWithGrind
 
 section introMerge


### PR DESCRIPTION
This test case used to fail, and needed a fix to the `classical` tactic in the standard library:

- [x] depends on: https://github.com/leanprover/lean4/pull/10332


---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include at least one commit authored by each
co-author among the commits in the pull request. If necessary, you may 
create empty commits to indicate co-authorship, using commands like so:

git commit --author="Author Name <author@email.com>" --allow-empty -m "add Author Name as coauthor"

When merging, all the commits will be squashed into a single commit listing all co-authors.

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
