### PR TITLE
[Merged by Bors] - fix(TacticAnalysis): include more `CommandElabM` state calling `runTactic`

### DIFF
--- a/Mathlib/Lean/ContextInfo.lean
+++ b/Mathlib/Lean/ContextInfo.lean
@@ -4,6 +4,7 @@ Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Anne Baanen
 -/
 
+import Mathlib.Lean.Elab.Tactic.Meta
 -- Import this linter explicitly to ensure that
 -- this file has a valid copyright header and module docstring.
 import Mathlib.Tactic.Linter.Header
@@ -76,5 +77,13 @@ def runTactic (ctx : ContextInfo) (i : TacticInfo) (goal : MVarId) (x : MVarId �
     let type ← goal.getType
     let goal ← Meta.mkFreshExprSyntheticOpaqueMVar type
     x goal.mvarId!
+
+/-- Run tactic code, given by a piece of syntax, in the context of an infotree node. -/
+def runTacticCode (ctx : ContextInfo) (i : TacticInfo) (goal : MVarId) (code : Syntax) :
+    CommandElabM (List MVarId) := do
+  let termCtx ← liftTermElabM read
+  let termState ← liftTermElabM get
+  ctx.runTactic i goal fun goal =>
+    Lean.Elab.runTactic' (ctx := termCtx) (s := termState) goal code
 
 end Lean.Elab.ContextInfo

--- a/Mathlib/Tactic/TacticAnalysis.lean
+++ b/Mathlib/Tactic/TacticAnalysis.lean
@@ -285,9 +285,9 @@ def testTacticSeq (config : ComplexConfig) (tacticSeq : Array (TSyntax `tactic))
   let stx ← `(tactic| $(tacticSeq);*)
   -- TODO: support more than 1 goal. Probably by requiring all tests to succeed in a row
   if let [goal] := i.goalsBefore then
-    let (oldGoals, oldHeartbeats) ← withHeartbeats <| ctxI.runTactic i goal fun goal => do
+    let (oldGoals, oldHeartbeats) ← withHeartbeats <|
       try
-        Lean.Elab.runTactic' goal stx
+        ctxI.runTacticCode i goal stx
       catch e =>
         logWarningAt stx m!"original tactic '{stx}' failed: {e.toMessageData}"
         return [goal]

--- a/MathlibTest/TacticAnalysis.lean
+++ b/MathlibTest/TacticAnalysis.lean
@@ -58,4 +58,19 @@ example : 1 + 1 = 2 := by
   have : 1 + 1 < 4 := by omega
   rfl
 
+universe u v
+
+-- This next example used to fail with `unknown universe level 'v'`.
+
+/--
+warning: replace the proof with 'grind': let T : Type max u v := Sigma f;
+  have : 1 + 1 = 2 := rfl;
+  rfl
+-/
+#guard_msgs in
+example {α : Type u} (f : α → Type max u v) : 1 = 1 := by
+  let T : Type max u v := Sigma f
+  have : 1 + 1 = 2 := rfl -- Extra line to ensure the linter picks it up.
+  rfl
+
 end replaceWithGrind


### PR DESCRIPTION
This PR fixes a few "unknown universe `v`" errors when running the tactic analysis framework on Mathlib. We need to move more state from the CommandElabM to the TermElabM that ends up running tactic code. Since we do essentially the same in a few places, bundle up all the state manipulation into a new function `runTacticCode`.


---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include at least one commit authored by each
co-author among the commits in the pull request. If necessary, you may 
create empty commits to indicate co-authorship, using commands like so:

git commit --author="Author Name <author@email.com>" --allow-empty -m "add Author Name as coauthor"

When merging, all the commits will be squashed into a single commit listing all co-authors.

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
