### PR TITLE
[Merged by Bors] - chore: Deprecate IsAdjoinRoot.subsingleton

### DIFF
--- a/Mathlib/Algebra/Algebra/Defs.lean
+++ b/Mathlib/Algebra/Algebra/Defs.lean
@@ -103,6 +103,10 @@ end Prio
 def algebraMap (R : Type u) (A : Type v) [CommSemiring R] [Semiring A] [Algebra R A] : R →+* A :=
   Algebra.algebraMap
 
+theorem Algebra.subsingleton (R : Type u) (A : Type v) [CommSemiring R] [Semiring A] [Algebra R A]
+    [Subsingleton R] : Subsingleton A :=
+  (algebraMap R A).codomain_trivial
+
 /-- Coercion from a commutative semiring to an algebra over this semiring. -/
 @[coe, reducible]
 def Algebra.cast {R A : Type*} [CommSemiring R] [Semiring A] [Algebra R A] : R → A :=

--- a/Mathlib/RingTheory/IsAdjoinRoot.lean
+++ b/Mathlib/RingTheory/IsAdjoinRoot.lean
@@ -109,7 +109,8 @@ def root : S := h.map X
 set_option linter.unusedSectionVars false in
 include h in
 @[deprecated "use Algebra.subsingleton" (since := "2025-09-10")]
-theorem subsingleton [Subsingleton R] : Subsingleton S := Algebra.subsingleton R S
+theorem subsingleton [Subsingleton R] : Subsingleton S := by
+  have := h; exact Algebra.subsingleton R S
 
 theorem algebraMap_apply (x : R) :
     algebraMap R S x = h.map (Polynomial.C x) := AlgHom.algebraMap_eq_apply h.map rfl

--- a/Mathlib/RingTheory/IsAdjoinRoot.lean
+++ b/Mathlib/RingTheory/IsAdjoinRoot.lean
@@ -106,8 +106,10 @@ variable (h : IsAdjoinRoot S f)
 /-- `(h : IsAdjoinRoot S f).root` is the root of `f` that can be adjoined to generate `S`. -/
 def root : S := h.map X
 
+set_option linter.unusedSectionVars false in
 include h in
-theorem subsingleton [Subsingleton R] : Subsingleton S := h.map_surjective.subsingleton
+@[deprecated "use Algebra.subsingleton" (since := "2025-09-10")]
+theorem subsingleton [Subsingleton R] : Subsingleton S := Algebra.subsingleton R S
 
 theorem algebraMap_apply (x : R) :
     algebraMap R S x = h.map (Polynomial.C x) := AlgHom.algebraMap_eq_apply h.map rfl
@@ -457,8 +459,7 @@ def basis : Basis (Fin (natDegree f)) R S :=
     { toFun x := (h.modByMonicHom x).toFinsupp.comapDomain _ Fin.val_injective.injOn
       invFun g := h.map (ofFinsupp (g.mapDomain Fin.val))
       left_inv x := by
-        cases subsingleton_or_nontrivial R
-        · subsingleton [h.subsingleton]
+        nontriviality R using Algebra.subsingleton R S
         simp only
         rw [Finsupp.mapDomain_comapDomain, Polynomial.eta, h.map_modByMonicHom x]
         · exact Fin.val_injective


### PR DESCRIPTION
This PR deprecates `IsAdjoinRoot.subsingleton` in favour of the new `Algebra.subsingleton`:
```lean
theorem IsAdjoinRoot.subsingleton {R : Type u} {S : Type v} [CommRing R] [Ring S] {f : Polynomial R}
    [Algebra R S] (h : IsAdjoinRoot S f) [Subsingleton R] :
  Subsingleton S

theorem Algebra.subsingleton (R : Type u) (A : Type v) [CommSemiring R] [Semiring A] [Algebra R A]
    [Subsingleton R] : Subsingleton A
```

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include at least one commit authored by each
co-author among the commits in the pull request. If necessary, you may 
create empty commits to indicate co-authorship, using commands like so:

git commit --author="Author Name <author@email.com>" --allow-empty -m "add Author Name as coauthor"

When merging, all the commits will be squashed into a single commit listing all co-authors.

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

Zulip: https://leanprover.zulipchat.com/#narrow/channel/287929-mathlib4/topic/IsAdjoinRoot.2Esubsingleton/with/538731602

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
