### PR TITLE
[Merged by Bors] - feat(CategoryTheory): extremal epimorphisms

### DIFF
--- a/Mathlib.lean
+++ b/Mathlib.lean
@@ -2205,6 +2205,7 @@ import Mathlib.CategoryTheory.Equivalence.Symmetry
 import Mathlib.CategoryTheory.EssentialImage
 import Mathlib.CategoryTheory.EssentiallySmall
 import Mathlib.CategoryTheory.Extensive
+import Mathlib.CategoryTheory.ExtremalEpi
 import Mathlib.CategoryTheory.FiberedCategory.BasedCategory
 import Mathlib.CategoryTheory.FiberedCategory.Cartesian
 import Mathlib.CategoryTheory.FiberedCategory.Cocartesian

--- a/Mathlib/CategoryTheory/ExtremalEpi.lean
+++ b/Mathlib/CategoryTheory/ExtremalEpi.lean
@@ -62,7 +62,7 @@ lemma extremalEpi_iff_strongEpi_of_hasPullbacks [HasPullbacks C] :
     fun _ ↦ inferInstance⟩
   have := ExtremalEpi.isIso f (pullback.lift _ _ sq.w)
     (pullback.snd _ _) (by simp)
-  refine
+  exact
     { l := inv (pullback.snd i b) ≫ pullback.fst _ _
       fac_left := by
         rw [← cancel_mono i, sq.w, Category.assoc, Category.assoc]

--- a/Mathlib/CategoryTheory/ExtremalEpi.lean
+++ b/Mathlib/CategoryTheory/ExtremalEpi.lean
@@ -1,0 +1,74 @@
+/-
+Copyright (c) 2025 Joël Riou. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Joël Riou
+-/
+import Mathlib.CategoryTheory.Subobject.Lattice
+import Mathlib.CategoryTheory.Limits.Shapes.StrongEpi
+
+/-!
+# Extremal epimorphisms
+
+An extremal epimorphism `p : X ⟶ Y` is an epimorphism which does not factor
+through any proper subobject of `Y`. In case the category has equalizers,
+we show that a morphism `p : X ⟶ Y` which does not factor through
+any proper subobject of `Y` is automatically an epimorphism, and also
+an extremal epimorphism. We also show that a strong epimorphism
+is an extremal epimorphism, and the both notions coincide when
+the category has pullbacks.
+
+## References
+
+* https://ncatlab.org/nlab/show/extremal+epimorphism
+
+-/
+
+universe v u
+
+namespace CategoryTheory
+
+open Limits
+
+variable {C : Type u} [Category.{v} C] {X Y : C}
+
+/-- An extremal epimorphism `f : X ⟶ Y` is an epimorphism which does not
+factor through any proper subobject of `Y`. -/
+class ExtremalEpi (f : X ⟶ Y) : Prop extends Epi f where
+  isIso (f) {Z : C} (p : X ⟶ Z) (i : Z ⟶ Y) (fac : p ≫ i = f) [Mono i] : IsIso i
+
+variable (f : X ⟶ Y)
+
+lemma ExtremalEpi.subobject_eq_top [ExtremalEpi f]
+    {A : Subobject Y} (hA : Subobject.Factors A f) : A = ⊤ := by
+  rw [← Subobject.isIso_arrow_iff_eq_top]
+  exact isIso f (Subobject.factorThru A f hA) _ (by simp)
+
+lemma ExtremalEpi.mk_of_hasEqualizers [HasEqualizers C]
+    (hf : ∀ ⦃Z : C⦄ (p : X ⟶ Z) (i : Z ⟶ Y) (_ : p ≫ i = f) [Mono i], IsIso i) :
+    ExtremalEpi f where
+  left_cancellation {Z} p q h := by
+    have := hf (equalizer.lift f h) (equalizer.ι p q) (by simp)
+    rw [← cancel_epi (equalizer.ι p q), equalizer.condition]
+  isIso := by tauto
+
+instance [StrongEpi f] : ExtremalEpi f where
+  isIso {Z} p i fac _ := by
+    have sq : CommSq p f i (𝟙 Y) := { }
+    exact ⟨sq.lift, by simp [← cancel_mono i], by simp⟩
+
+lemma extremalEpi_iff_strongEpi_of_hasPullbacks [HasPullbacks C] :
+    ExtremalEpi f ↔ StrongEpi f := by
+  refine ⟨fun _ ↦ ⟨inferInstance, fun A B i _ ↦ ⟨fun {t b} sq ↦ ⟨⟨?_⟩⟩⟩⟩,
+    fun _ ↦ inferInstance⟩
+  have := ExtremalEpi.isIso f (pullback.lift _ _ sq.w)
+    (pullback.snd _ _) (by simp)
+  refine
+    { l := inv (pullback.snd i b) ≫ pullback.fst _ _
+      fac_left := by
+        rw [← cancel_mono i, sq.w, Category.assoc, Category.assoc]
+        congr 1
+        rw [← cancel_epi (pullback.snd i b), IsIso.hom_inv_id_assoc,
+          pullback.condition]
+      fac_right := by simp [pullback.condition] }
+
+end CategoryTheory

--- a/Mathlib/CategoryTheory/ExtremalEpi.lean
+++ b/Mathlib/CategoryTheory/ExtremalEpi.lean
@@ -14,7 +14,7 @@ through any proper subobject of `Y`. In case the category has equalizers,
 we show that a morphism `p : X ⟶ Y` which does not factor through
 any proper subobject of `Y` is automatically an epimorphism, and also
 an extremal epimorphism. We also show that a strong epimorphism
-is an extremal epimorphism, and the both notions coincide when
+is an extremal epimorphism, and that both notions coincide when
 the category has pullbacks.
 
 ## References


### PR DESCRIPTION
An extremal epimorphism `p : X ⟶ Y` is an epimorphism which does not factor through any proper subobject of `Y`. In case the category has equalizers, we show that a morphism `p : X ⟶ Y` which does not factor through any proper subobject of `Y` is automatically an epimorphism, and also an extremal epimorphism. We also show that a strong epimorphism is an extremal epimorphism, and that both notions coincide when the category has pullbacks.

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include at least one commit authored by each
co-author among the commits in the pull request. If necessary, you may 
create empty commits to indicate co-authorship, using commands like so:

git commit --author="Author Name <author@email.com>" --allow-empty -m "add Author Name as coauthor"

When merging, all the commits will be squashed into a single commit listing all co-authors.

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
