### PR TITLE
[Merged by Bors] - chore: convert all linkifiers to links

### DIFF
--- a/Cache/IO.lean
+++ b/Cache/IO.lean
@@ -484,7 +484,7 @@ def leanModulesFromSpec (sp : SearchPath) (argₛ : String) :
       IO.println s!"Searching directory {folder} for .lean files"
       if ← folder.pathExists then
         -- (2.) provided "module name" of an existing folder: walk dir
-        -- TODO: will be implemented in #21838
+        -- TODO: will be implemented in https://github.com/leanprover-community/mathlib4/issues/21838
         return .error "Entering a part of a module name \
           (i.e. `Mathlib.Data` when only the folder `Mathlib/Data/` but no \
           file `Mathlib/Data.lean` exists) is not supported yet!"

--- a/Counterexamples/AharoniKorman.lean
+++ b/Counterexamples/AharoniKorman.lean
@@ -153,7 +153,7 @@ instance : PartialOrder Hollom where
   le_trans := «forall₃».2 HollomOrder.trans
   le_antisymm := «forall₂».2 fun
   | _, _, .twice _, .twice _ => by omega
-  | _, (_, _, _), .twice _, .within _ _ => by omega -- see lean4#6416 about the `(_, _, _)`
+  | _, (_, _, _), .twice _, .within _ _ => by omega -- see https://github.com/leanprover/lean4/issues/6416 about the `(_, _, _)`
   | _, _, .twice _, .next_min _ => by omega
   | _, _, .twice _, .next_add _ => by omega
   | _, _, .within _ _, .twice _ => by omega

--- a/Mathlib/Algebra/Homology/ExactSequence.lean
+++ b/Mathlib/Algebra/Homology/ExactSequence.lean
@@ -209,7 +209,7 @@ lemma isComplex₂_mk (S : ComposableArrows C 2) (w : S.map' 0 1 ≫ S.map' 1 2 
 
 lemma _root_.CategoryTheory.ShortComplex.isComplex_toComposableArrows (S : ShortComplex C) :
     S.toComposableArrows.IsComplex :=
-  -- Disable `Fin.reduceFinMk` because otherwise `Precompose.map_one_succ` does not apply. (#27382)
+  -- Disable `Fin.reduceFinMk` because otherwise `Precompose.map_one_succ` does not apply. (https://github.com/leanprover-community/mathlib4/issues/27382)
   isComplex₂_mk _ (by simp [-Fin.reduceFinMk])
 
 lemma exact₂_iff (S : ComposableArrows C 2) (hS : S.IsComplex) :

--- a/Mathlib/Algebra/Homology/HomologySequence.lean
+++ b/Mathlib/Algebra/Homology/HomologySequence.lean
@@ -112,7 +112,7 @@ instance [K.HasHomology i] [K.HasHomology j] :
 
 instance [K.HasHomology i] [K.HasHomology j] :
     Epi ((composableArrows₃ K i j).map' 2 3) := by
-  -- Disable `Fin.reduceFinMk`, otherwise `Precomp.obj_succ` does not fire. (#27382)
+  -- Disable `Fin.reduceFinMk`, otherwise `Precomp.obj_succ` does not fire. (https://github.com/leanprover-community/mathlib4/issues/27382)
   dsimp [-Fin.reduceFinMk]
   infer_instance
 
@@ -154,7 +154,7 @@ noncomputable def composableArrows₃Functor [CategoryWithHomology C] :
     HomologicalComplex C c ⥤ ComposableArrows C 3 where
   obj K := composableArrows₃ K i j
   map {K L} φ := ComposableArrows.homMk₃ (homologyMap φ i) (opcyclesMap φ i) (cyclesMap φ j)
-    -- Disable `Fin.reduceFinMk`, otherwise `Precomp.obj_succ` does not fire. (#27382)
+    -- Disable `Fin.reduceFinMk`, otherwise `Precomp.obj_succ` does not fire. (https://github.com/leanprover-community/mathlib4/issues/27382)
     (homologyMap φ j) (by simp) (by simp [-Fin.reduceFinMk]) (by simp [-Fin.reduceFinMk])
 
 end HomologySequence

--- a/Mathlib/Algebra/Homology/HomotopyCategory/DegreewiseSplit.lean
+++ b/Mathlib/Algebra/Homology/HomotopyCategory/DegreewiseSplit.lean
@@ -20,7 +20,7 @@ assert_not_exists TwoSidedIdeal
 
 open CategoryTheory Category Limits Pretriangulated Preadditive
 
--- Explicit universe annotations were used in this file to improve performance #12737
+-- Explicit universe annotations were used in this file to improve performance https://github.com/leanprover-community/mathlib4/issues/12737
 
 universe v
 

--- a/Mathlib/Algebra/Homology/HomotopyCategory/MappingCone.lean
+++ b/Mathlib/Algebra/Homology/HomotopyCategory/MappingCone.lean
@@ -22,7 +22,7 @@ assert_not_exists TwoSidedIdeal
 
 open CategoryTheory Limits
 
--- Explicit universe annotations were used in this file to improve performance #12737
+-- Explicit universe annotations were used in this file to improve performance https://github.com/leanprover-community/mathlib4/issues/12737
 
 universe v v'
 

--- a/Mathlib/Algebra/Homology/HomotopyCategory/ShortExact.lean
+++ b/Mathlib/Algebra/Homology/HomotopyCategory/ShortExact.lean
@@ -125,11 +125,11 @@ lemma quasiIso_descShortComplex : QuasiIso (descShortComplex S) where
         ((homologyFunctorFactors C (up ℤ) _).hom.naturality S.f)
         (by
           erw [(homologyFunctorFactors C (up ℤ) n).hom.naturality_assoc]
-          -- Disable `Fin.reduceFinMk`, otherwise `Precomp.obj_succ` does not fire. (#27382)
+          -- Disable `Fin.reduceFinMk`, otherwise `Precomp.obj_succ` does not fire. (https://github.com/leanprover-community/mathlib4/issues/27382)
           dsimp [-Fin.reduceFinMk]
           rw [← HomologicalComplex.homologyMap_comp, inr_descShortComplex])
         (by
-          -- Disable `Fin.reduceFinMk`, otherwise `Precomp.obj_succ` does not fire. (#27382)
+          -- Disable `Fin.reduceFinMk`, otherwise `Precomp.obj_succ` does not fire. (https://github.com/leanprover-community/mathlib4/issues/27382)
           dsimp [-Fin.reduceFinMk]
           erw [homologySequenceδ_triangleh hS]
           simp only [Functor.comp_obj, HomologicalComplex.homologyFunctor_obj, assoc,

--- a/Mathlib/Algebra/Homology/HomotopyCategory/Triangulated.lean
+++ b/Mathlib/Algebra/Homology/HomotopyCategory/Triangulated.lean
@@ -18,7 +18,7 @@ assert_not_exists TwoSidedIdeal
 
 open CategoryTheory Category Limits Pretriangulated ComposableArrows
 
--- Explicit universe annotations were used in this file to improve performance #12737
+-- Explicit universe annotations were used in this file to improve performance https://github.com/leanprover-community/mathlib4/issues/12737
 
 universe v
 

--- a/Mathlib/Algebra/Lie/Weights/Chain.lean
+++ b/Mathlib/Algebra/Lie/Weights/Chain.lean
@@ -228,7 +228,7 @@ lemma exists_forall_mem_corootSpace_smul_add_eq_zero
     ← LieSubmodule.toEnd_restrict_eq_toEnd]
   -- The lines below illustrate the cost of treating `LieSubmodule` as both a
   -- `Submodule` and a `LieSubmodule` simultaneously.
-  #adaptation_note /-- 2025-06-18 (lean4#8804).
+  #adaptation_note /-- 2025-06-18 (https://github.com/leanprover/lean4/issues/8804).
     The `erw` causes a kernel timeout if there is no `subst`. -/
   subst a b N
   erw [LinearMap.trace_eq_sum_trace_restrict_of_eq_biSup _ h₁ h₂ (genWeightSpaceChain M α χ p q) h₃]

--- a/Mathlib/Algebra/Lie/Weights/RootSystem.lean
+++ b/Mathlib/Algebra/Lie/Weights/RootSystem.lean
@@ -423,7 +423,7 @@ instance : (rootSystem H).IsReduced where
 
 section IsSimple
 
--- Note that after #10068 (Cartan's criterion) is complete we can omit `[IsKilling K L]`
+-- Note that after https://github.com/leanprover-community/mathlib4/issues/10068 (Cartan's criterion) is complete we can omit `[IsKilling K L]`
 variable [IsSimple K L]
 
 open Weight in

--- a/Mathlib/Algebra/Order/BigOperators/Ring/Finset.lean
+++ b/Mathlib/Algebra/Order/BigOperators/Ring/Finset.lean
@@ -282,7 +282,8 @@ def evalFinsetProd : PositivityExt where eval {u α} zα pα e := do
     -- Try to show that the product is positive
     let p_pos : Option Q(0 < $e) := ← do
       let .positive pbody := rbody | pure none -- Fail if the body is not provably positive
-      -- TODO(quote4#38): We must name the following, else `assertInstancesCommute` loops.
+      -- TODO(https://github.com/leanprover-community/quote4/issues/38):
+      -- We must name the following, else `assertInstancesCommute` loops.
       let .some _instαzeroone ← trySynthInstanceQ q(ZeroLEOneClass $α) | pure none
       let .some _instαposmul ← trySynthInstanceQ q(PosMulStrictMono $α) | pure none
       let .some _instαnontriv ← trySynthInstanceQ q(Nontrivial $α) | pure none
@@ -295,7 +296,8 @@ def evalFinsetProd : PositivityExt where eval {u α} zα pα e := do
       let some pbody := rbody.toNonneg
         | return none -- Fail if the body is not provably nonnegative
       let pr : Q(∀ i, 0 ≤ $f i) ← mkLambdaFVars #[i] pbody (binderInfoForMVars := .default)
-      -- TODO(quote4#38): We must name the following, else `assertInstancesCommute` loops.
+      -- TODO(https://github.com/leanprover-community/quote4/issues/38):
+      -- We must name the following, else `assertInstancesCommute` loops.
       let .some _instαzeroone ← trySynthInstanceQ q(ZeroLEOneClass $α) | pure none
       let .some _instαposmul ← trySynthInstanceQ q(PosMulMono $α) | pure none
       assertInstancesCommute
@@ -304,7 +306,8 @@ def evalFinsetProd : PositivityExt where eval {u α} zα pα e := do
     -- Fall back to showing that the product is nonzero
     let pbody ← rbody.toNonzero
     let pr : Q(∀ i, $f i ≠ 0) ← mkLambdaFVars #[i] pbody (binderInfoForMVars := .default)
-    -- TODO(quote4#38): We must name the following, else `assertInstancesCommute` loops.
+    -- TODO(https://github.com/leanprover-community/quote4/issues/38):
+    -- We must name the following, else `assertInstancesCommute` loops.
     let _instαnontriv ← synthInstanceQ q(Nontrivial $α)
     let _instαnozerodiv ← synthInstanceQ q(NoZeroDivisors $α)
     assertInstancesCommute

--- a/Mathlib/Algebra/Order/GroupWithZero/Canonical.lean
+++ b/Mathlib/Algebra/Order/GroupWithZero/Canonical.lean
@@ -131,13 +131,13 @@ instance (priority := 100) LinearOrderedCommGroupWithZero.toMulPosReflectLE :
 instance (priority := 100) LinearOrderedCommGroupWithZero.toPosMulReflectLT :
     PosMulReflectLT α where elim _a _b _c := lt_of_mul_lt_mul_left'
 
-#adaptation_note /-- 2025-03-29 lean4#7717 Needed to add `dsimp only` -/
+#adaptation_note /-- 2025-03-29 https://github.com/leanprover/lean4/issues/7717 Needed to add `dsimp only` -/
 -- See note [lower instance priority]
 instance (priority := 100) LinearOrderedCommGroupWithZero.toPosMulStrictMono :
     PosMulStrictMono α where
   elim a b c hbc := by dsimp only; by_contra! h; exact hbc.not_ge <| (mul_le_mul_iff_right₀ a.2).1 h
 
-#adaptation_note /-- 2025-03-29 lean4#7717 Needed to add `dsimp only` -/
+#adaptation_note /-- 2025-03-29 https://github.com/leanprover/lean4/issues/7717 Needed to add `dsimp only` -/
 -- See note [lower instance priority]
 instance (priority := 100) LinearOrderedCommGroupWithZero.toMulPosStrictMono :
     MulPosStrictMono α where

--- a/Mathlib/Algebra/SkewMonoidAlgebra/Basic.lean
+++ b/Mathlib/Algebra/SkewMonoidAlgebra/Basic.lean
@@ -26,8 +26,8 @@ yields a not-necessarily-unital, not-necessarily-associative algebra.
 `k`-linear combinations of terms of `G`, endowed with a skewed convolution product.
 
 ## TODO
-- the algebra instance (see #10541)
-- lifting lemmas (see #10541)
+- the algebra instance (see https://github.com/leanprover-community/mathlib4/issues/10541)
+- lifting lemmas (see https://github.com/leanprover-community/mathlib4/issues/10541)
 -/
 
 

--- a/Mathlib/AlgebraicGeometry/EllipticCurve/ModelsWithJ.lean
+++ b/Mathlib/AlgebraicGeometry/EllipticCurve/ModelsWithJ.lean
@@ -78,7 +78,7 @@ lemma ofJNe0Or1728_Δ : (ofJNe0Or1728 j).Δ = j ^ 2 * (j - 1728) ^ 9 := by
 
 variable (R) [W.IsElliptic]
 
--- TODO: change to `[IsUnit ...]` once #17458 is merged
+-- TODO: change to `[IsUnit ...]` once https://github.com/leanprover-community/mathlib4/issues/17458 is merged
 /-- When 3 is a unit, `Y² + Y = X³` is an elliptic curve.
 It is of j-invariant 0 (see `WeierstrassCurve.ofJ0_j`). -/
 instance [hu : Fact (IsUnit (3 : R))] : (ofJ0 R).IsElliptic := by
@@ -86,12 +86,12 @@ instance [hu : Fact (IsUnit (3 : R))] : (ofJ0 R).IsElliptic := by
   convert (hu.out.pow 3).neg
   norm_num1
 
--- TODO: change to `[IsUnit ...]` once #17458 is merged
+-- TODO: change to `[IsUnit ...]` once https://github.com/leanprover-community/mathlib4/issues/17458 is merged
 lemma ofJ0_j [Fact (IsUnit (3 : R))] : (ofJ0 R).j = 0 := by
   rw [j, ofJ0_c₄]
   ring1
 
--- TODO: change to `[IsUnit ...]` once #17458 is merged
+-- TODO: change to `[IsUnit ...]` once https://github.com/leanprover-community/mathlib4/issues/17458 is merged
 /-- When 2 is a unit, `Y² = X³ + X` is an elliptic curve.
 It is of j-invariant 1728 (see `WeierstrassCurve.ofJ1728_j`). -/
 instance [hu : Fact (IsUnit (2 : R))] : (ofJ1728 R).IsElliptic := by
@@ -99,14 +99,14 @@ instance [hu : Fact (IsUnit (2 : R))] : (ofJ1728 R).IsElliptic := by
   convert (hu.out.pow 6).neg
   norm_num1
 
--- TODO: change to `[IsUnit ...]` once #17458 is merged
+-- TODO: change to `[IsUnit ...]` once https://github.com/leanprover-community/mathlib4/issues/17458 is merged
 lemma ofJ1728_j [Fact (IsUnit (2 : R))] : (ofJ1728 R).j = 1728 := by
   rw [j, Units.inv_mul_eq_iff_eq_mul, ofJ1728_c₄, coe_Δ', ofJ1728_Δ]
   norm_num1
 
 variable {R}
 
--- TODO: change to `[IsUnit ...]` once #17458 is merged
+-- TODO: change to `[IsUnit ...]` once https://github.com/leanprover-community/mathlib4/issues/17458 is merged
 /-- When j and j - 1728 are both units,
 `Y² + (j - 1728)XY = X³ - 36(j - 1728)³X - (j - 1728)⁵` is an elliptic curve.
 It is of j-invariant j (see `WeierstrassCurve.ofJNe0Or1728_j`). -/
@@ -115,7 +115,7 @@ instance (j : R) [h1 : Fact (IsUnit j)] [h2 : Fact (IsUnit (j - 1728))] :
   rw [isElliptic_iff, ofJNe0Or1728_Δ]
   exact (h1.out.pow 2).mul (h2.out.pow 9)
 
--- TODO: change to `[IsUnit ...]` once #17458 is merged
+-- TODO: change to `[IsUnit ...]` once https://github.com/leanprover-community/mathlib4/issues/17458 is merged
 lemma ofJNe0Or1728_j (j : R) [Fact (IsUnit j)] [Fact (IsUnit (j - 1728))] :
     (ofJNe0Or1728 j).j = j := by
   rw [WeierstrassCurve.j, Units.inv_mul_eq_iff_eq_mul, ofJNe0Or1728_c₄, coe_Δ', ofJNe0Or1728_Δ]

--- a/Mathlib/AlgebraicGeometry/EllipticCurve/Weierstrass.lean
+++ b/Mathlib/AlgebraicGeometry/EllipticCurve/Weierstrass.lean
@@ -332,13 +332,13 @@ lemma twoTorsionPolynomial_disc_of_char_three : W.twoTorsionPolynomial.disc = W.
 
 end CharThree
 
--- TODO: change to `[IsUnit ...]` once #17458 is merged
+-- TODO: change to `[IsUnit ...]` once https://github.com/leanprover-community/mathlib4/issues/17458 is merged
 lemma twoTorsionPolynomial_disc_isUnit (hu : IsUnit (2 : R)) :
     IsUnit W.twoTorsionPolynomial.disc ↔ IsUnit W.Δ := by
   rw [twoTorsionPolynomial_disc, IsUnit.mul_iff, show (16 : R) = 2 ^ 4 by norm_num1]
   exact and_iff_right <| hu.pow 4
 
--- TODO: change to `[IsUnit ...]` once #17458 is merged
+-- TODO: change to `[IsUnit ...]` once https://github.com/leanprover-community/mathlib4/issues/17458 is merged
 -- TODO: In this case `IsUnit W.Δ` is just `W.IsElliptic`, consider removing/rephrasing this result
 lemma twoTorsionPolynomial_disc_ne_zero [Nontrivial R] (hu : IsUnit (2 : R)) (hΔ : IsUnit W.Δ) :
     W.twoTorsionPolynomial.disc ≠ 0 :=
@@ -348,7 +348,7 @@ end TorsionPolynomial
 
 /-! ## Elliptic curves -/
 
--- TODO: change to `protected abbrev IsElliptic := IsUnit W.Δ` once #17458 is merged
+-- TODO: change to `protected abbrev IsElliptic := IsUnit W.Δ` once https://github.com/leanprover-community/mathlib4/issues/17458 is merged
 /-- `WeierstrassCurve.IsElliptic` is a typeclass which asserts that a Weierstrass curve is an
 elliptic curve: that its discriminant is a unit. Note that this definition is only mathematically
 accurate for certain rings whose Picard group has trivial 12-torsion, such as a field or a PID. -/
@@ -426,7 +426,7 @@ lemma j_eq_zero_iff_of_char_three [IsReduced R] : W.j = 0 ↔ W.b₂ = 0 := by
 
 end CharThree
 
--- TODO: this is defeq to `twoTorsionPolynomial_disc_ne_zero` once #17458 is merged,
+-- TODO: this is defeq to `twoTorsionPolynomial_disc_ne_zero` once https://github.com/leanprover-community/mathlib4/issues/17458 is merged,
 -- TODO: consider removing/rephrasing this result
 lemma twoTorsionPolynomial_disc_ne_zero_of_isElliptic [Nontrivial R] (hu : IsUnit (2 : R)) :
     W.twoTorsionPolynomial.disc ≠ 0 :=

--- a/Mathlib/Analysis/Calculus/FDeriv/Mul.lean
+++ b/Mathlib/Analysis/Calculus/FDeriv/Mul.lean
@@ -753,7 +753,7 @@ theorem HasStrictFDerivAt.list_prod' {l : List ι} {x : E}
       (∑ i : Fin l.length, ((l.take i).map (f · x)).prod •
         f' l[i] <• ((l.drop (.succ i)).map (f · x)).prod) x := by
   simp_rw [Fin.getElem_fin, ← l.get_eq_getElem, ← List.finRange_map_get l, List.map_map]
-  -- After #19108, we have to be optimistic with `:)`s; otherwise Lean decides it need to find
+  -- After https://github.com/leanprover-community/mathlib4/issues/19108, we have to be optimistic with `:)`s; otherwise Lean decides it need to find
   -- `NormedAddCommGroup (List 𝔸)` which is nonsense.
   refine .congr_fderiv (hasStrictFDerivAt_list_prod_finRange'.comp x
     (hasStrictFDerivAt_pi.mpr fun i ↦ h (l.get i) (List.getElem_mem ..)) :) ?_

--- a/Mathlib/Analysis/InnerProductSpace/Harmonic/Analytic.lean
+++ b/Mathlib/Analysis/InnerProductSpace/Harmonic/Analytic.lean
@@ -13,7 +13,7 @@ import Mathlib.Analysis.InnerProductSpace.Harmonic.Basic
 
 If `f : ℂ → ℝ` is harmonic at `x`, we show that `∂f/∂1 - I • ∂f/∂I` is complex-analytic at `x`.
 
-TODO: As soon as PR #9598 (feat(Analysis/Complex): HasPrimitives on disc) is merged, extend this to
+TODO: As soon as PR https://github.com/leanprover-community/mathlib4/issues/9598 (feat(Analysis/Complex): HasPrimitives on disc) is merged, extend this to
 show that `f` itself is locally the real part of a holomorphic function, and hence real-analytic.
 -/
 

--- a/Mathlib/Analysis/LocallyConvex/WeakOperatorTopology.lean
+++ b/Mathlib/Analysis/LocallyConvex/WeakOperatorTopology.lean
@@ -223,7 +223,7 @@ instance instContinuousAdd : ContinuousAdd (E →WOT[𝕜] F) := .induced (induc
 instance instContinuousNeg : ContinuousNeg (E →WOT[𝕜] F) := .induced (inducingFn 𝕜 E F)
 instance instContinuousSMul : ContinuousSMul 𝕜 (E →WOT[𝕜] F) := .induced (inducingFn 𝕜 E F)
 
-#adaptation_note /-- 2025-03-29 lean4#7717 Needed to add this instance explicitly to avoid a
+#adaptation_note /-- 2025-03-29 https://github.com/leanprover/lean4/issues/7717 Needed to add this instance explicitly to avoid a
 limitation with parent instance inference. TODO(kmill): fix this. -/
 instance instIsTopologicalAddGroup : IsTopologicalAddGroup (E →WOT[𝕜] F) where
   toContinuousAdd := inferInstance

--- a/Mathlib/Analysis/RCLike/Basic.lean
+++ b/Mathlib/Analysis/RCLike/Basic.lean
@@ -949,7 +949,7 @@ lemma instPosMulReflectLE : PosMulReflectLE K where
   elim a b c h := by
     obtain ⟨a', ha1, ha2⟩ := pos_iff_exists_ofReal.mp a.2
     rw [← sub_nonneg]
-    #adaptation_note /-- 2025-03-29 need beta reduce for lean4#7717 -/
+    #adaptation_note /-- 2025-03-29 need beta reduce for https://github.com/leanprover/lean4/issues/7717 -/
     beta_reduce at h
     rw [← ha2, ← sub_nonneg, ← mul_sub, le_iff_lt_or_eq] at h
     rcases h with h | h

--- a/Mathlib/CategoryTheory/ComposableArrows.lean
+++ b/Mathlib/CategoryTheory/ComposableArrows.lean
@@ -49,7 +49,7 @@ For now, we just turn off the offending simprocs in this file.
 *However*, hopefully it is possible to refactor the material here so that no disabling of
 simprocs is needed.
 
-See issue #27382.
+See issue https://github.com/leanprover-community/mathlib4/issues/27382.
 -/
 attribute [-simp] Fin.reduceFinMk
 

--- a/Mathlib/CategoryTheory/Monoidal/DayConvolution/Closed.lean
+++ b/Mathlib/CategoryTheory/Monoidal/DayConvolution/Closed.lean
@@ -18,7 +18,7 @@ ends can be organised as data that exhibit `F` as monoidal closed in `C ⥤ V` f
 the Day convolution monoidal structure.
 
 ## TODOs
-* When `LawfulDayConvolutionMonoidalStruct` (#26820) lands, transport the
+* When `LawfulDayConvolutionMonoidalStruct` (https://github.com/leanprover-community/mathlib4/issues/26820) lands, transport the
   constructions here to produce actual `CategoryTheory.MonoidalClosed` instances.
 -/
 

--- a/Mathlib/LinearAlgebra/RootSystem/Finite/Lemmas.lean
+++ b/Mathlib/LinearAlgebra/RootSystem/Finite/Lemmas.lean
@@ -108,7 +108,7 @@ lemma pairingIn_pairingIn_mem_set_of_isCrystal_of_isRed [P.IsReduced] :
   rcases eq_or_ne (α i) (-α j) with h₂ | h₂; · simp_all
   have aux₁ := P.pairingIn_pairingIn_mem_set_of_isCrystallographic i j
   have aux₂ : P.pairingIn ℤ i j * P.pairingIn ℤ j i ≠ 4 := P.coxeterWeightIn_ne_four ℤ h₁ h₂
-  aesop -- #24551 (this should be faster)
+  aesop -- https://github.com/leanprover-community/mathlib4/issues/24551 (this should be faster)
 
 lemma pairingIn_pairingIn_mem_set_of_isCrystal_of_isRed' [P.IsReduced]
     (hij : α i ≠ α j) (hij' : α i ≠ -α j) :
@@ -126,7 +126,7 @@ lemma RootPositiveForm.rootLength_le_of_pairingIn_eq (B : P.RootPositiveForm ℤ
   have h : (P.pairingIn ℤ i j, P.pairingIn ℤ j i) ∈
       ({(1, 1), (1, 2), (1, 3), (1, 4), (-1, -1), (-1, -2), (-1, -3), (-1, -4)} : Set (ℤ × ℤ)) := by
     have := P.pairingIn_pairingIn_mem_set_of_isCrystallographic i j
-    aesop -- #24551 (this should be faster)
+    aesop -- https://github.com/leanprover-community/mathlib4/issues/24551 (this should be faster)
   simp only [mem_insert_iff, mem_singleton_iff, Prod.mk_one_one, Prod.mk_eq_one, Prod.mk.injEq] at h
   have h' := B.pairingIn_mul_eq_pairingIn_mul_swap i j
   have hi := B.rootLength_pos i
@@ -142,11 +142,11 @@ lemma RootPositiveForm.rootLength_lt_of_pairingIn_notMem
   have hij' : P.pairingIn ℤ i j = -3 ∨ P.pairingIn ℤ i j = -2 ∨ P.pairingIn ℤ i j = 2 ∨
       P.pairingIn ℤ i j = 3 ∨ P.pairingIn ℤ i j = -4 ∨ P.pairingIn ℤ i j = 4 := by
     have := P.pairingIn_pairingIn_mem_set_of_isCrystallographic i j
-    aesop -- #24551 (this should be faster)
+    aesop -- https://github.com/leanprover-community/mathlib4/issues/24551 (this should be faster)
   have aux₁ : P.pairingIn ℤ j i = -1 ∨ P.pairingIn ℤ j i = 1 := by
     have : Module.IsReflexive R M := .of_isPerfPair P.toLinearMap
     have := P.pairingIn_pairingIn_mem_set_of_isCrystallographic i j
-    aesop -- #24551 (this should be faster)
+    aesop -- https://github.com/leanprover-community/mathlib4/issues/24551 (this should be faster)
   have aux₂ := B.pairingIn_mul_eq_pairingIn_mul_swap i j
   have hi := B.rootLength_pos i
   rcases aux₁ with hji | hji <;> rcases hij' with hij' | hij' | hij' | hij' | hij' | hij' <;>
@@ -165,7 +165,7 @@ lemma pairingIn_pairingIn_mem_set_of_length_eq {B : P.InvariantForm}
     simp only [← (FaithfulSMul.algebraMap_injective ℤ R).eq_iff, algebraMap_pairingIn]
     exact mul_right_cancel₀ (B.ne_zero j) (len_eq ▸ B.pairing_mul_eq_pairing_mul_swap j i)
   have := P.pairingIn_pairingIn_mem_set_of_isCrystallographic i j
-  aesop -- #24551 (this should be faster)
+  aesop -- https://github.com/leanprover-community/mathlib4/issues/24551 (this should be faster)
 
 variable {i j} in
 lemma pairingIn_pairingIn_mem_set_of_length_eq_of_ne {B : P.InvariantForm}
@@ -214,7 +214,7 @@ lemma root_sub_root_mem_of_pairingIn_pos (h : 0 < P.pairingIn ℤ i j) (h' : i �
       have := P.pairingIn_pairingIn_mem_set_of_isCrystallographic i j
       replace hli : P.pairingIn ℤ i j * P.pairingIn ℤ j i = 4 :=
         (P.coxeterWeightIn_eq_four_iff_not_linearIndependent ℤ).mpr hli
-      aesop -- #24551 (this should be faster)
+      aesop -- https://github.com/leanprover-community/mathlib4/issues/24551 (this should be faster)
     simp only [mem_insert_iff, mem_singleton_iff, Prod.mk.injEq] at this
     rcases this with hij | hij | hij
     · rw [(P.pairingIn_one_four_iff ℤ i j).mp hij, two_smul, sub_add_cancel_right]
@@ -272,7 +272,7 @@ lemma apply_eq_or_aux (i j : ι) (h : P.pairingIn ℤ i j ≠ 0) :
   have h₂ : algebraMap ℤ R (P.pairingIn ℤ j i) * B.form (α i) (α i) =
             algebraMap ℤ R (P.pairingIn ℤ i j) * B.form (α j) (α j) := by
     simpa only [algebraMap_pairingIn] using B.pairing_mul_eq_pairing_mul_swap i j
-  aesop -- #24551 (this should be faster)
+  aesop -- https://github.com/leanprover-community/mathlib4/issues/24551 (this should be faster)
 
 variable [P.IsIrreducible]
 
@@ -346,12 +346,12 @@ lemma forall_pairing_eq_swap_or [P.IsReduced] [P.IsIrreducible] :
     have hk := B.pairing_mul_eq_pairing_mul_swap k₁ k₂
     rcases this with h₀ | h₀ <;> rcases key k₁ with h₁ | h₁ <;> rcases key k₂ with h₂ | h₂ <;>
     simp only [h₁, h₂, h₀, ← mul_assoc, mul_comm, mul_eq_mul_right_iff] at hk <;>
-    aesop -- #24551 (this should be faster)
+    aesop -- https://github.com/leanprover-community/mathlib4/issues/24551 (this should be faster)
   · refine Or.inr fun k₁ k₂ ↦ ?_
     have hk := B.pairing_mul_eq_pairing_mul_swap k₁ k₂
     rcases this with h₀ | h₀ <;> rcases key k₁ with h₁ | h₁ <;> rcases key k₂ with h₂ | h₂ <;>
     simp only [h₁, h₂, h₀, ← mul_assoc, mul_comm, mul_eq_mul_right_iff] at hk <;>
-    aesop -- #24551 (this should be faster)
+    aesop -- https://github.com/leanprover-community/mathlib4/issues/24551 (this should be faster)
 
 lemma forall_pairingIn_eq_swap_or [P.IsReduced] [P.IsIrreducible] :
     (∀ i j, P.pairingIn ℤ i j = P.pairingIn ℤ j i ∨

--- a/Mathlib/LinearAlgebra/RootSystem/GeckConstruction/Lemmas.lean
+++ b/Mathlib/LinearAlgebra/RootSystem/GeckConstruction/Lemmas.lean
@@ -65,7 +65,7 @@ lemma root_sub_root_mem_of_mem_of_mem (hk : α k + α i - α j ∈ Φ)
       have : Module.IsReflexive R M := .of_isPerfPair P.toLinearMap
       contrapose! hk'; exact (P.pairingIn_neg_two_neg_two_iff ℤ i k).mp ⟨h, hk'⟩
     have := P.pairingIn_pairingIn_mem_set_of_isCrystallographic i k
-    aesop -- #24551 (this should be faster)
+    aesop -- https://github.com/leanprover-community/mathlib4/issues/24551 (this should be faster)
   replace hki : P.pairing k i = -1 := by rw [← P.algebraMap_pairingIn ℤ, hki]; simp
   have : P.pairingIn ℤ l i = 1 - P.pairingIn ℤ j i := by
     apply algebraMap_injective ℤ R

--- a/Mathlib/Order/Atoms.lean
+++ b/Mathlib/Order/Atoms.lean
@@ -754,7 +754,7 @@ This is not an instance to prevent loops. -/
 protected def IsSimpleOrder.linearOrder [DecidableEq α] : LinearOrder α :=
   { (inferInstance : PartialOrder α) with
     le_total := fun a b => by rcases eq_bot_or_eq_top a with (rfl | rfl) <;> simp
-    -- Note from #23976: do we want this inlined or should this be a separate definition?
+    -- Note from https://github.com/leanprover-community/mathlib4/issues/23976: do we want this inlined or should this be a separate definition?
     toDecidableLE := fun a b =>
       if ha : a = ⊥ then isTrue (ha.le.trans bot_le)
       else

--- a/Mathlib/RepresentationTheory/Rep.lean
+++ b/Mathlib/RepresentationTheory/Rep.lean
@@ -482,7 +482,7 @@ variable (A B : Rep k G) (α : Type u) [DecidableEq α]
 
 open ModuleCat.MonoidalCategory
 
--- the proof below can be simplified after #24823 is merged
+-- the proof below can be simplified after https://github.com/leanprover-community/mathlib4/issues/24823 is merged
 /-- Given representations `A, B` and a type `α`, this is the natural representation isomorphism
 `(α →₀ A) ⊗ B ≅ (A ⊗ B) →₀ α` sending `single x a ⊗ₜ b ↦ single x (a ⊗ₜ b)`. -/
 @[simps! hom_hom inv_hom]

--- a/Mathlib/RingTheory/DedekindDomain/Ideal/Basic.lean
+++ b/Mathlib/RingTheory/DedekindDomain/Ideal/Basic.lean
@@ -402,7 +402,7 @@ noncomputable instance FractionalIdeal.semifield : Semifield (FractionalIdeal Aâ
   nnqsmul := _
   nnqsmul_def := fun _ _ => rfl
 
-#adaptation_note /-- 2025-03-29 for lean4#7717 had to add `mul_left_cancel_of_ne_zero` field.
+#adaptation_note /-- 2025-03-29 for https://github.com/leanprover/lean4/issues/7717 had to add `mul_left_cancel_of_ne_zero` field.
 TODO(kmill) There is trouble calculating the type of the `IsLeftCancelMulZero` parent. -/
 /-- Fractional ideals have cancellative multiplication in a Dedekind domain.
 

--- a/Mathlib/Tactic/DepRewrite.lean
+++ b/Mathlib/Tactic/DepRewrite.lean
@@ -527,7 +527,7 @@ def depRewriteTarget (stx : Syntax) (symm : Bool) (config : DepRewrite.Config :=
 def depRewriteLocalDecl (stx : Syntax) (symm : Bool) (fvarId : FVarId)
     (config : DepRewrite.Config := {}) : TacticM Unit := withMainContext do
   -- Note: we cannot execute `replaceLocalDecl` inside `Term.withSynthesize`.
-  -- See issues #2711 and #2727.
+  -- See issues https://github.com/leanprover-community/mathlib4/issues/2711 and https://github.com/leanprover-community/mathlib4/issues/2727.
   let rwResult ← Term.withSynthesize <| withMainContext do
     let e ← elabTerm stx none true
     let localDecl ← fvarId.getDecl
@@ -592,7 +592,7 @@ def depRwTarget (stx : Syntax) (symm : Bool) (config : DepRewrite.Config := {}) 
 def depRwLocalDecl (stx : Syntax) (symm : Bool) (fvarId : FVarId)
     (config : DepRewrite.Config := {}) : TacticM Unit := withMainContext do
   -- Note: we cannot execute `replaceLocalDecl` inside `Term.withSynthesize`.
-  -- See issues #2711 and #2727.
+  -- See issues https://github.com/leanprover-community/mathlib4/issues/2711 and https://github.com/leanprover-community/mathlib4/issues/2727.
   let rwResult ← Term.withSynthesize <| withMainContext do
     let e ← elabTerm stx none true
     let localDecl ← fvarId.getDecl

--- a/Mathlib/Tactic/Eqns.lean
+++ b/Mathlib/Tactic/Eqns.lean
@@ -40,7 +40,7 @@ initialize eqnsAttribute : NameMapExtension (Array Name) ←
     add   := fun
     | declName, `(attr| eqns $[$names]*) => do
       -- We used to be able to check here if equational lemmas have already been registered in
-      -- Leans `eqsnExt`, but that has been removed in #8519, so no warning in that case.
+      -- Leans `eqsnExt`, but that has been removed in https://github.com/leanprover-community/mathlib4/issues/8519, so no warning in that case.
       -- Now we just hope that the `GetEqnsFn` registered below will always run before
       -- Lean’s.
       names.mapM realizeGlobalConstNoOverloadWithInfo

--- a/Mathlib/Tactic/GRewrite/Elab.lean
+++ b/Mathlib/Tactic/GRewrite/Elab.lean
@@ -40,7 +40,7 @@ def grewriteTarget (stx : Syntax) (symm : Bool) (config : GRewrite.Config) : Tac
 def grewriteLocalDecl (stx : Syntax) (symm : Bool) (fvarId : FVarId) (config : GRewrite.Config) :
     TacticM Unit := withMainContext do
   -- Note: we cannot execute `replace` inside `Term.withSynthesize`.
-  -- See issues #2711 and #2727.
+  -- See issues https://github.com/leanprover-community/mathlib4/issues/2711 and https://github.com/leanprover-community/mathlib4/issues/2727.
   let goal ← getMainGoal
   let r ← Term.withSynthesize <| withMainContext do
     let e ← elabTerm stx none true

--- a/Mathlib/Topology/Algebra/LinearTopology.lean
+++ b/Mathlib/Topology/Algebra/LinearTopology.lean
@@ -58,10 +58,10 @@ hence our definition agrees with [N. Bourbaki, *Algebra II*, chapter 4, §2, n°
   (invariance by translation) would be enough. In fact, in presence of `IsLinearTopology R M`,
   invariance by translation implies that `M` is a topological additive group on which `R` acts
   by homeomorphisms. Similarly, `IsLinearTopology R R` and `ContinuousConstVAdd R R` imply that
-  `R` is a topological ring. All of this will follow from PR#18437.
+  `R` is a topological ring. All of this will follow from https://github.com/leanprover-community/mathlib4/issues/18437.
 
   Nevertheless, we don't plan on adding those facts as instances: one should use directly
-  results from PR#18437 to get `IsTopologicalAddGroup` and `IsTopologicalRing` instances.
+  results from https://github.com/leanprover-community/mathlib4/issues/18437 to get `IsTopologicalAddGroup` and `IsTopologicalRing` instances.
 
 * The main constructor for `IsLinearTopology`, `IsLinearTopology.mk_of_hasBasis`
   is formulated in terms of the subobject classes `AddSubmonoidClass` and `SMulMemClass`

--- a/Mathlib/Topology/Algebra/Valued/WithZeroMulInt.lean
+++ b/Mathlib/Topology/Algebra/Valued/WithZeroMulInt.lean
@@ -21,7 +21,7 @@ open scoped Topology
 namespace Valued
 variable {R Γ₀ : Type*} [Ring R] [LinearOrderedCommGroupWithZero Γ₀]
 
--- TODO: use ValuativeRel after #26833
+-- TODO: use ValuativeRel after https://github.com/leanprover-community/mathlib4/issues/26833
 lemma tendsto_zero_pow_of_v_lt_one [MulArchimedean Γ₀] [Valued R Γ₀] {x : R} (hx : v x < 1) :
     Tendsto (fun n : ℕ ↦ x ^ n) atTop (𝓝 0) := by
   simp only [(hasBasis_nhds_zero _ _).tendsto_right_iff, mem_setOf_eq, map_pow, eventually_atTop,

--- a/Mathlib/Topology/Sheaves/CommRingCat.lean
+++ b/Mathlib/Topology/Sheaves/CommRingCat.lean
@@ -65,7 +65,7 @@ open scoped nonZeroDivisors
 
 variable {X : TopCat.{w}} {C : Type u} [Category.{v} C]
 
--- note: this was specialized to `CommRingCat` in #19757
+-- note: this was specialized to `CommRingCat` in https://github.com/leanprover-community/mathlib4/issues/19757
 /-- A subpresheaf with a submonoid structure on each of the components. -/
 structure SubmonoidPresheaf (F : X.Presheaf CommRingCat) where
   /-- The submonoid structure for each component -/

--- a/Mathlib/Topology/UniformSpace/Dini.lean
+++ b/Mathlib/Topology/UniformSpace/Dini.lean
@@ -18,7 +18,7 @@ This theorem is true in a different generality as well: when `G` is a linearly o
 group with the order topology. This weakens the norm assumption, in exchange for strengthening to
 a linear order. This separate generality is not included in this file, but that generality was
 included in initial drafts of the original
-[PR #19068](https://github.com/leanprover-community/mathlib4/pull/19068) and can be recovered if
+https://github.com/leanprover-community/mathlib4/pull/19068 and can be recovered if
 necessary.
 
 The key idea of the proof is to use a particular basis of `𝓝 0` which consists of open sets that

--- a/MathlibTest/ApplyAt.lean
+++ b/MathlibTest/ApplyAt.lean
@@ -106,14 +106,14 @@ example (a b : ℝ) (h : -a * b = 0) : a = 0 ∨ b = 0 := by
   simp at h
   assumption
 
-/-- `apply H at h` when type of `H h` depends on proof of `h` (#20623) -/
+/-- `apply H at h` when type of `H h` depends on proof of `h` (https://github.com/leanprover-community/mathlib4/issues/20623) -/
 example (h : True) : True := by
   have H (h : True) : h = h := rfl
   apply H at h
   simp at h
   exact h
 
-/-- `apply H at h` when type of `H h` depends on proof of `h` (#20623) -/
+/-- `apply H at h` when type of `H h` depends on proof of `h` (https://github.com/leanprover-community/mathlib4/issues/20623) -/
 example (a : List Nat) (k : Nat) (hk : k < a.length) : True := by
   have H (k : Nat) {xs ys : List Nat} (hk: k < xs.length)
     (h : xs = ys) : xs[k] = ys[k]'(h ▸ hk) := h ▸ rfl

--- a/MathlibTest/CalcQuestionMark.lean
+++ b/MathlibTest/CalcQuestionMark.lean
@@ -2,7 +2,7 @@ import Mathlib.Tactic.Widget.Calc
 
 /-!
 Note that while the suggestions look incorrectly indented here,
-this is an artifact of the rendering to a string for `guard_msgs` (leanprover/lean4#7191).
+this is an artifact of the rendering to a string for `guard_msgs` (https://github.com/leanprover/lean4/issues/7191).
 
 When used from the widget that appears in VSCode, they insert correctly-indented code.
 -/

--- a/MathlibTest/TermCongr.lean
+++ b/MathlibTest/TermCongr.lean
@@ -183,7 +183,7 @@ lemma test (n n' : Nat) (h : n = n') (hn : n = n) (hn' : n' = n') :
   exact congr(f $h _) -- with expected type
 
 /-!
-Regression test for #25851. Make sure hcongr doesn't force the final result to be an equality.
+Regression test for https://github.com/leanprover-community/mathlib4/issues/25851. Make sure hcongr doesn't force the final result to be an equality.
 -/
 example (a a' : Nat) (h : a = a') (n : Fin a) (n' : Fin a') (hn : HEq n n') :
     HEq (f n rfl) (f n' rfl) :=

--- a/MathlibTest/push_neg.lean
+++ b/MathlibTest/push_neg.lean
@@ -136,12 +136,12 @@ example (h : p ∧ q) : ¬¬(p ∧ q) := by
   guard_target =ₛ r
   exact h
 
--- new error message as of #27562
+-- new error message as of https://github.com/leanprover-community/mathlib4/issues/27562
 /-- error: push_neg made no progress anywhere -/
 #guard_msgs in
 example {P : Prop} (h : P) : P := by push_neg at *
 
--- new behaviour as of #27562
+-- new behaviour as of https://github.com/leanprover-community/mathlib4/issues/27562
 -- (Previously, because of a metavariable instantiation issue, the tactic succeeded as a no-op.)
 /-- error: push_neg made no progress at h -/
 #guard_msgs in
@@ -149,7 +149,7 @@ example {x y : ℕ} : True := by
   have h : x ≤ y := test_sorry
   push_neg at h
 
--- new behaviour as of #27562 (previously the tactic succeeded as a no-op)
+-- new behaviour as of https://github.com/leanprover-community/mathlib4/issues/27562 (previously the tactic succeeded as a no-op)
 /-- error: cannot run push_neg at inductive_proof, it is an implementation detail -/
 #guard_msgs in
 def inductive_proof : True := by

--- a/MathlibTest/ring.lean
+++ b/MathlibTest/ring.lean
@@ -209,7 +209,7 @@ example (x : ℤ) (R : ℤ → ℤ → Prop) : True := by
 
 end
 
--- new behaviour as of #27562
+-- new behaviour as of https://github.com/leanprover-community/mathlib4/issues/27562
 -- (Previously, because of a metavariable instantiation issue, the tactic succeeded as a no-op.)
 /-- error: ring_nf made no progress at h -/
 #guard_msgs in

--- a/scripts/zulip_emoji_reactions.py
+++ b/scripts/zulip_emoji_reactions.py
@@ -152,7 +152,7 @@ for message in messages:
 
         # Otherwise, remove all previous mutually exclusive emoji reactions (unless
         # LABELS_TO_KEEP contains the corresponding label). This is because otherwise this script
-        # may end up removing reactions that are still relevant. See PR #27570
+        # may end up removing reactions that are still relevant. See PR https://github.com/leanprover-community/mathlib4/issues/27570
         # Note that the 'merge' and 'closed-pr' reactions do not have a corresponding label,
         # so we pass the empty string (which will never be in LABELS_TO_KEEP) so that they are
         # always removed.


### PR DESCRIPTION
This helps disambiguate, and also opens the possibility of a script which checks such links to see if the issue has been closed, for follow-up. (Prototype at #29527.)

We've done this before at https://github.com/leanprover-community/mathlib4/pull/11036.