### PR TITLE
[Merged by Bors] - chore: remove unnecessary simp +singlePass

### DIFF
--- a/Mathlib/Topology/MetricSpace/GromovHausdorff.lean
+++ b/Mathlib/Topology/MetricSpace/GromovHausdorff.lean
@@ -408,11 +408,7 @@ instance : MetricSpace GHSpace where
       funext
       simp only [comp_apply, Prod.fst_swap, Prod.snd_swap]
       congr
-      -- The next line had `singlePass := true` before https://github.com/leanprover-community/mathlib4/pull/9928,
-      -- then was changed to be `simp only [hausdorffDist_comm]`,
-      -- then `singlePass := true` was readded in https://github.com/leanprover-community/mathlib4/pull/8386 because of timeouts.
-      -- TODO: figure out what causes the slowdown and make it a `simp only` again?
-      simp +singlePass only [hausdorffDist_comm]
+      simp only [hausdorffDist_comm]
     simp only [dist, A, image_comp, image_swap_prod]
   eq_of_dist_eq_zero {x} {y} hxy := by
     /- To show that two spaces at zero distance are isometric,


### PR DESCRIPTION
Clean up a comment and an unnecessary +singlePass. Apparently no longer slow.