### PR TITLE
[Merged by Bors] - feat: add group/field versions of Filter.map_*_atTop_eq_nat

### DIFF
--- a/Mathlib/Order/Filter/AtTopBot/Archimedean.lean
+++ b/Mathlib/Order/Filter/AtTopBot/Archimedean.lean
@@ -146,6 +146,15 @@ namespace Filter
 
 variable {l : Filter α} {f : α → R} {r : R}
 
+theorem map_add_atTop_eq [AddCommGroup α] [PartialOrder α] [IsOrderedAddMonoid α]
+    [IsDirected α (· ≤ ·)] (k : α) : map (fun a => a + k) atTop = atTop :=
+  map_atTop_eq_of_gc (fun a => a - k) 0 add_left_mono (by simp [le_sub_iff_add_le]) (by simp)
+
+theorem map_sub_atTop_eq [AddCommGroup α] [PartialOrder α] [IsOrderedAddMonoid α]
+    [IsDirected α (· ≤ ·)] (k : α) : map (fun a => a - k) atTop = atTop := by
+  simp_rw [sub_eq_add_neg]
+  apply map_add_atTop_eq
+
 section LinearOrderedSemiring
 
 variable [Semiring R] [LinearOrder R] [IsStrictOrderedRing R] [Archimedean R]

--- a/Mathlib/Order/Filter/AtTopBot/Basic.lean
+++ b/Mathlib/Order/Filter/AtTopBot/Basic.lean
@@ -3,10 +3,11 @@ Copyright (c) 2017 Johannes Hölzl. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Johannes Hölzl, Jeremy Avigad, Yury Kudryashov, Patrick Massot
 -/
-import Mathlib.Order.Filter.Bases.Basic
+import Mathlib.Algebra.Field.Defs
+import Mathlib.Algebra.Order.Ring.Defs
 import Mathlib.Order.Filter.AtTopBot.Tendsto
+import Mathlib.Order.Filter.Bases.Basic
 import Mathlib.Order.Nat
-import Mathlib.Tactic.Subsingleton
 
 /-!
 # Basic results on `Filter.atTop` and `Filter.atBot` filters
@@ -428,6 +429,15 @@ theorem map_sub_atTop_eq_nat (k : ℕ) : map (fun a => a - k) atTop = atTop :=
   map_atTop_eq_of_gc (· + k) 0 (fun _ _ h => Nat.sub_le_sub_right h _)
     (fun _ _ _ => Nat.sub_le_iff_le_add) fun b _ => by rw [Nat.add_sub_cancel_right]
 
+theorem map_add_atTop_eq [AddCommGroup α] [PartialOrder α] [IsOrderedAddMonoid α]
+    [IsDirected α (· ≤ ·)] (k : α) : map (fun a => a + k) atTop = atTop :=
+  map_atTop_eq_of_gc (fun a => a - k) 0 add_left_mono (by simp [le_sub_iff_add_le]) (by simp)
+
+theorem map_sub_atTop_eq [AddCommGroup α] [PartialOrder α] [IsOrderedAddMonoid α]
+    [IsDirected α (· ≤ ·)] (k : α) : map (fun a => a - k) atTop = atTop := by
+  simp_rw [sub_eq_add_neg]
+  apply map_add_atTop_eq
+
 theorem tendsto_add_atTop_nat (k : ℕ) : Tendsto (fun a => a + k) atTop atTop :=
   le_of_eq (map_add_atTop_eq_nat k)
 
@@ -443,6 +453,12 @@ theorem map_div_atTop_eq_nat (k : ℕ) (hk : 0 < k) : map (fun a => a / k) atTop
   map_atTop_eq_of_gc (fun b => k * b + (k - 1)) 1 (fun _ _ h => Nat.div_le_div_right h)
     (fun a b _ => by rw [Nat.div_le_iff_le_mul_add_pred hk])
     fun b _ => by rw [Nat.mul_add_div hk, Nat.div_eq_of_lt, Nat.add_zero]; omega
+
+theorem map_div_atTop_eq [Semifield α] [LinearOrder α] [IsStrictOrderedRing α]
+    (k : α) (hk : 0 < k) : map (fun a => a / k) atTop = atTop :=
+  map_atTop_eq_of_gc (fun b => k * b) 1 (fun _ _ h => div_le_div_of_nonneg_right h (le_of_lt hk))
+    (fun a b _ => (by rw [div_le_iff₀' hk]))
+    fun b _ => (by rw [mul_div_assoc, mul_div_cancel₀]; exact ne_of_gt hk)
 
 section NeBot
 variable [Preorder β] {l : Filter α} [NeBot l] {f : α → β}

--- a/Mathlib/Order/Filter/AtTopBot/Basic.lean
+++ b/Mathlib/Order/Filter/AtTopBot/Basic.lean
@@ -3,11 +3,10 @@ Copyright (c) 2017 Johannes Hölzl. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Johannes Hölzl, Jeremy Avigad, Yury Kudryashov, Patrick Massot
 -/
-import Mathlib.Algebra.Field.Defs
-import Mathlib.Algebra.Order.Ring.Defs
-import Mathlib.Order.Filter.AtTopBot.Tendsto
 import Mathlib.Order.Filter.Bases.Basic
+import Mathlib.Order.Filter.AtTopBot.Tendsto
 import Mathlib.Order.Nat
+import Mathlib.Tactic.Subsingleton
 
 /-!
 # Basic results on `Filter.atTop` and `Filter.atBot` filters
@@ -429,15 +428,6 @@ theorem map_sub_atTop_eq_nat (k : ℕ) : map (fun a => a - k) atTop = atTop :=
   map_atTop_eq_of_gc (· + k) 0 (fun _ _ h => Nat.sub_le_sub_right h _)
     (fun _ _ _ => Nat.sub_le_iff_le_add) fun b _ => by rw [Nat.add_sub_cancel_right]
 
-theorem map_add_atTop_eq [AddCommGroup α] [PartialOrder α] [IsOrderedAddMonoid α]
-    [IsDirected α (· ≤ ·)] (k : α) : map (fun a => a + k) atTop = atTop :=
-  map_atTop_eq_of_gc (fun a => a - k) 0 add_left_mono (by simp [le_sub_iff_add_le]) (by simp)
-
-theorem map_sub_atTop_eq [AddCommGroup α] [PartialOrder α] [IsOrderedAddMonoid α]
-    [IsDirected α (· ≤ ·)] (k : α) : map (fun a => a - k) atTop = atTop := by
-  simp_rw [sub_eq_add_neg]
-  apply map_add_atTop_eq
-
 theorem tendsto_add_atTop_nat (k : ℕ) : Tendsto (fun a => a + k) atTop atTop :=
   le_of_eq (map_add_atTop_eq_nat k)
 
@@ -453,12 +443,6 @@ theorem map_div_atTop_eq_nat (k : ℕ) (hk : 0 < k) : map (fun a => a / k) atTop
   map_atTop_eq_of_gc (fun b => k * b + (k - 1)) 1 (fun _ _ h => Nat.div_le_div_right h)
     (fun a b _ => by rw [Nat.div_le_iff_le_mul_add_pred hk])
     fun b _ => by rw [Nat.mul_add_div hk, Nat.div_eq_of_lt, Nat.add_zero]; omega
-
-theorem map_div_atTop_eq [Semifield α] [LinearOrder α] [IsStrictOrderedRing α]
-    (k : α) (hk : 0 < k) : map (fun a => a / k) atTop = atTop :=
-  map_atTop_eq_of_gc (fun b => k * b) 1 (fun _ _ h => div_le_div_of_nonneg_right h (le_of_lt hk))
-    (fun a b _ => (by rw [div_le_iff₀' hk]))
-    fun b _ => (by rw [mul_div_assoc, mul_div_cancel₀]; exact ne_of_gt hk)
 
 section NeBot
 variable [Preorder β] {l : Filter α} [NeBot l] {f : α → β}

--- a/Mathlib/Order/Filter/AtTopBot/Field.lean
+++ b/Mathlib/Order/Filter/AtTopBot/Field.lean
@@ -97,6 +97,11 @@ theorem tendsto_const_mul_pow_atTop_iff :
 lemma tendsto_zpow_atTop_atTop {n : ℤ} (hn : 0 < n) : Tendsto (fun x : α ↦ x ^ n) atTop atTop := by
   lift n to ℕ using hn.le; simp [(Int.natCast_pos.mp hn).ne']
 
+theorem map_div_atTop_eq (k : α) (hk : 0 < k) : map (fun a => a / k) atTop = atTop :=
+  map_atTop_eq_of_gc (fun b => k * b) 1 (fun _ _ h => div_le_div_of_nonneg_right h (le_of_lt hk))
+    (fun a b _ => (by rw [div_le_iff₀' hk]))
+    fun b _ => (by rw [mul_div_assoc, mul_div_cancel₀]; exact ne_of_gt hk)
+
 end LinearOrderedSemifield
 
 


### PR DESCRIPTION
Add Filter.map_add_atTop_eq, Filter.map_sub_atTop_eq, and Filter.map_div_atTop_eq, which correspond to
Filter.map_add_atTop_eq_nat, Filter.map_sub_atTop_eq_nat, and Filter.map_div_atTop_eq_nat respectively.
These theorems apply to ordered groups/fields


---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include at least one commit authored by each
co-author among the commits in the pull request. If necessary, you may 
create empty commits to indicate co-authorship, using commands like so:

git commit --author="Author Name <author@email.com>" --allow-empty -m "add Author Name as coauthor"

When merging, all the commits will be squashed into a single commit listing all co-authors.

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
