### PR TITLE
[Merged by Bors] - chore: deprime `induction` in all remaining places

### DIFF
--- a/Mathlib/Algebra/Order/Group/Action.lean
+++ b/Mathlib/Algebra/Order/Group/Action.lean
@@ -6,7 +6,6 @@ Authors: Eric Wieser
 import Mathlib.Algebra.Group.Action.Defs
 import Mathlib.Algebra.Order.Monoid.Unbundled.Defs
 import Mathlib.Order.ConditionallyCompleteLattice.Basic
-import Mathlib.Tactic.Cases
 
 /-!
 # Results about `CovariantClass G α HSMul.hSMul LE.le`

--- a/Mathlib/Combinatorics/Quiver/Path/Decomposition.lean
+++ b/Mathlib/Combinatorics/Quiver/Path/Decomposition.lean
@@ -3,10 +3,8 @@ Copyright (c) 2025 Matteo Cipollina. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Matteo Cipollina
 -/
-
 import Mathlib.Algebra.Order.Group.Nat
 import Mathlib.Combinatorics.Quiver.Path
-import Mathlib.Tactic.Cases
 
 /-!
 # Path Decomposition and Boundary Crossing

--- a/Mathlib/Data/Countable/Basic.lean
+++ b/Mathlib/Data/Countable/Basic.lean
@@ -140,11 +140,10 @@ instance [Countable α] [∀ a, Countable (π a)] : Countable (PSigma π) :=
   Countable.of_equiv (Σ a : PLift α, PLift (π a.down)) (Equiv.psigmaEquivSigmaPLift π).symm
 
 instance [Finite α] [∀ a, Countable (π a)] : Countable (∀ a, π a) := by
-  have : ∀ n, Countable (Fin n → ℕ) := by
-    intro n
-    induction' n with n ihn
-    · infer_instance
-    · exact Countable.of_equiv (ℕ × (Fin n → ℕ)) (Fin.consEquiv fun _ ↦ ℕ)
+  have (n : ℕ) : Countable (Fin n → ℕ) := by
+    induction n with
+    | zero => infer_instance
+    | succ n ihn => exact Countable.of_equiv (ℕ × (Fin n → ℕ)) (Fin.consEquiv fun _ ↦ ℕ)
   rcases Finite.exists_equiv_fin α with ⟨n, ⟨e⟩⟩
   have f := fun a => (nonempty_embedding_nat (π a)).some
   exact ((Embedding.piCongrRight f).trans (Equiv.piCongrLeft' _ e).toEmbedding).countable

--- a/Mathlib/Data/Multiset/Antidiagonal.lean
+++ b/Mathlib/Data/Multiset/Antidiagonal.lean
@@ -77,9 +77,10 @@ theorem antidiagonal_cons (a : α) (s) :
 
 theorem antidiagonal_eq_map_powerset [DecidableEq α] (s : Multiset α) :
     s.antidiagonal = s.powerset.map fun t ↦ (s - t, t) := by
-  induction' s using Multiset.induction_on with a s hs
-  · simp only [antidiagonal_zero, powerset_zero, Multiset.zero_sub, map_singleton]
-  · simp_rw [antidiagonal_cons, powerset_cons, map_add, hs, map_map, Function.comp, Prod.map_apply,
+  induction s using Multiset.induction_on with
+  | empty => simp only [antidiagonal_zero, powerset_zero, Multiset.zero_sub, map_singleton]
+  | cons a s hs =>
+    simp_rw [antidiagonal_cons, powerset_cons, map_add, hs, map_map, Function.comp, Prod.map_apply,
       id, sub_cons, erase_cons_head]
     rw [add_comm]
     congr 1

--- a/Mathlib/Data/Multiset/Bind.lean
+++ b/Mathlib/Data/Multiset/Bind.lean
@@ -225,9 +225,9 @@ variable (op : α → α → α) [hc : Std.Commutative op] [ha : Std.Associative
 theorem fold_bind {ι : Type*} (s : Multiset ι) (t : ι → Multiset α) (b : ι → α) (b₀ : α) :
     (s.bind t).fold op ((s.map b).fold op b₀) =
     (s.map fun i => (t i).fold op (b i)).fold op b₀ := by
-  induction' s using Multiset.induction_on with a ha ih
-  · rw [zero_bind, map_zero, map_zero, fold_zero]
-  · rw [cons_bind, map_cons, map_cons, fold_cons_left, fold_cons_left, fold_add, ih]
+  induction s using Multiset.induction_on with
+  | empty => rw [zero_bind, map_zero, map_zero, fold_zero]
+  | cons a ha ih => rw [cons_bind, map_cons, map_cons, fold_cons_left, fold_cons_left, fold_add, ih]
 
 end Bind
 

--- a/Mathlib/Data/Multiset/DershowitzManna.lean
+++ b/Mathlib/Data/Multiset/DershowitzManna.lean
@@ -99,9 +99,9 @@ private lemma isDershowitzMannaLT_singleton_insert (h : OneStep N (a ::ₘ M)) :
 
 private lemma acc_oneStep_cons_of_acc_lt (ha : Acc LT.lt a) :
     ∀ {M}, Acc OneStep M → Acc OneStep (a ::ₘ M) := by
-  induction' ha with a _ ha
+  induction ha with | _ a _ ha
   rintro M hM
-  induction' hM with M hM ihM
+  induction hM with | _ M hM ihM
   refine .intro _ fun N hNM ↦ ?_
   obtain ⟨N, ⟨rfl, hNM'⟩ | ⟨rfl, hN⟩⟩ := isDershowitzMannaLT_singleton_insert hNM
   · exact ihM _ hNM'
@@ -134,8 +134,9 @@ private lemma transGen_oneStep_of_isDershowitzMannaLT :
     IsDershowitzMannaLT M N → TransGen OneStep M N := by
   classical
   rintro ⟨X, Y, Z, hZ, hM, hN, hYZ⟩
-  induction' Z using Multiset.induction_on with z Z ih generalizing X Y M N
-  · simp at hZ
+  induction Z using Multiset.induction_on generalizing X Y M N with
+  | empty => simp at hZ
+  | cons z Z ih => ?_
   obtain rfl | hZ := eq_or_ne Z 0
   · exact .single ⟨X, Y, z, hM, hN, by simpa using hYZ⟩
   let Y' : Multiset α := Y.filter (· < z)

--- a/Mathlib/Data/Multiset/Pi.lean
+++ b/Mathlib/Data/Multiset/Pi.lean
@@ -151,13 +151,14 @@ protected theorem Nodup.pi {s : Multiset α} {t : ∀ a, Multiset (β a)} :
             by rw [eq]
           neb <| show b₁ = b₂ by rwa [Pi.cons_same, Pi.cons_same] at this)
 
-theorem mem_pi (m : Multiset α) (t : ∀ a, Multiset (β a)) :
-    ∀ f : ∀ a ∈ m, β a, f ∈ pi m t ↔ ∀ (a) (h : a ∈ m), f a h ∈ t a := by
-  intro f
-  induction' m using Multiset.induction_on with a m ih
-  · have : f = Pi.empty β := funext (fun _ => funext fun h => (notMem_zero _ h).elim)
+theorem mem_pi (m : Multiset α) (t : ∀ a, Multiset (β a)) (f : ∀ a ∈ m, β a) :
+    f ∈ pi m t ↔ ∀ (a) (h : a ∈ m), f a h ∈ t a := by
+  induction m using Multiset.induction_on with
+  | empty =>
+    have : f = Pi.empty β := funext (fun _ => funext fun h => (notMem_zero _ h).elim)
     simp only [this, pi_zero, mem_singleton, true_iff]
     intro _ h; exact (notMem_zero _ h).elim
+  | cons a m ih => ?_
   simp_rw [pi_cons, mem_bind, mem_map, ih]
   constructor
   · rintro ⟨b, hb, f', hf', rfl⟩ a' ha'

--- a/Mathlib/Data/Multiset/Powerset.lean
+++ b/Mathlib/Data/Multiset/Powerset.lean
@@ -179,8 +179,7 @@ theorem powersetCardAux_cons (n : ℕ) (a : α) (l : List α) :
 
 theorem powersetCardAux_perm {n} {l₁ l₂ : List α} (p : l₁ ~ l₂) :
     powersetCardAux n l₁ ~ powersetCardAux n l₂ := by
-  induction' n with n IHn generalizing l₁ l₂
-  · simp
+  induction n generalizing l₁ l₂ with | zero => simp | succ n IHn => ?_
   induction p with
   | nil => rfl
   | cons _ p IH =>
@@ -256,9 +255,9 @@ theorem powersetCard_card_add (s : Multiset α) {i : ℕ} (hi : 0 < i) :
 
 theorem powersetCard_map {β : Type*} (f : α → β) (n : ℕ) (s : Multiset α) :
     powersetCard n (s.map f) = (powersetCard n s).map (map f) := by
-  induction' s using Multiset.induction with t s ih generalizing n
-  · cases n <;> simp [powersetCard_zero_left]
-  · cases n <;> simp [ih]
+  induction s using Multiset.induction generalizing n with
+  | empty => cases n <;> simp [powersetCard_zero_left]
+  | cons t s ih => cases n <;> simp [ih]
 
 theorem pairwise_disjoint_powersetCard (s : Multiset α) :
     _root_.Pairwise fun i j => Disjoint (s.powersetCard i) (s.powersetCard j) :=

--- a/Mathlib/Data/Num/Lemmas.lean
+++ b/Mathlib/Data/Num/Lemmas.lean
@@ -116,8 +116,9 @@ theorem cmp_to_nat_lemma {m n : PosNum} : (m : ℕ) < n → (bit1 m : ℕ) < bit
     intro h; rw [Nat.add_right_comm m m 1, add_assoc]; exact Nat.add_le_add h h
 
 theorem cmp_swap (m) : ∀ n, (cmp m n).swap = cmp n m := by
-  induction' m with m IH m IH <;> intro n <;> obtain - | n | n := n <;> unfold cmp <;>
-    try { rfl } <;> rw [← IH] <;> cases cmp m n <;> rfl
+  induction m with | one => ?_ | bit1 m IH => ?_ | bit0 m IH => ?_ <;>
+    intro n <;> obtain - | n | n := n <;> unfold cmp <;>
+      try { rfl } <;> rw [← IH] <;> cases cmp m n <;> rfl
 
 theorem cmp_to_nat : ∀ m n, (Ordering.casesOn (cmp m n) ((m : ℕ) < n) (m = n) ((n : ℕ) < m) : Prop)
   | 1, 1 => rfl
@@ -779,7 +780,8 @@ theorem castNum_eq_bitwise {f : Num → Num → Num} {g : Bool → Bool → Bool
       cases b <;> rfl
     have this' b (n : PosNum) : ↑ (pos (PosNum.bit b n)) = Nat.bit b ↑n := by
       cases b <;> simp
-    induction' m with m IH m IH generalizing n <;> obtain - | n | n := n
+    induction m generalizing n with | one => ?_ | bit1 m IH => ?_ | bit0 m IH => ?_ <;>
+    obtain - | n | n := n
     any_goals simp only [show one = 1 from rfl, show pos 1 = 1 from rfl,
       show PosNum.bit0 = PosNum.bit false from rfl, show PosNum.bit1 = PosNum.bit true from rfl,
       show ((1 : Num) : ℕ) = Nat.bit true 0 from rfl]
@@ -816,18 +818,20 @@ theorem castNum_shiftLeft (m : Num) (n : Nat) : ↑(m <<< n) = (m : ℕ) <<< (n 
   · symm
     apply Nat.zero_shiftLeft
   simp only [cast_pos]
-  induction' n with n IH
-  · rfl
-  simp [PosNum.shiftl_succ_eq_bit0_shiftl, Nat.shiftLeft_succ, IH, mul_comm,
-        -shiftl_eq_shiftLeft, -PosNum.shiftl_eq_shiftLeft, mul_two]
+  induction n with
+  | zero => rfl
+  | succ n IH =>
+    simp [PosNum.shiftl_succ_eq_bit0_shiftl, Nat.shiftLeft_succ, IH, mul_comm,
+      -shiftl_eq_shiftLeft, -PosNum.shiftl_eq_shiftLeft, mul_two]
 
 @[simp, norm_cast]
 theorem castNum_shiftRight (m : Num) (n : Nat) : ↑(m >>> n) = (m : ℕ) >>> (n : ℕ) := by
   obtain - | m := m <;> dsimp only [← shiftr_eq_shiftRight, shiftr]
   · symm
     apply Nat.zero_shiftRight
-  induction' n with n IH generalizing m
-  · cases m <;> rfl
+  induction n generalizing m with
+  | zero => cases m <;> rfl
+  | succ n IH => ?_
   have hdiv2 : ∀ m, Nat.div2 (m + m) = m := by intro; rw [Nat.div2_val]; omega
   obtain - | m | m := m <;> dsimp only [PosNum.shiftr, ← PosNum.shiftr_eq_shiftRight]
   · rw [Nat.shiftRight_eq_div_pow]
@@ -854,14 +858,16 @@ theorem castNum_testBit (m n) : testBit m n = Nat.testBit m n := by
     rw [show (Num.zero : Nat) = 0 from rfl, Nat.zero_testBit]
   | pos m =>
     rw [cast_pos]
-    induction' n with n IH generalizing m <;> obtain - | m | m := m
+    induction n generalizing m <;> obtain - | m | m := m
         <;> simp only [PosNum.testBit]
     · rfl
     · rw [PosNum.cast_bit1, ← two_mul, ← congr_fun Nat.bit_true, Nat.testBit_bit_zero]
     · rw [PosNum.cast_bit0, ← two_mul, ← congr_fun Nat.bit_false, Nat.testBit_bit_zero]
     · simp [Nat.testBit_add_one]
-    · rw [PosNum.cast_bit1, ← two_mul, ← congr_fun Nat.bit_true, Nat.testBit_bit_succ, IH]
-    · rw [PosNum.cast_bit0, ← two_mul, ← congr_fun Nat.bit_false, Nat.testBit_bit_succ, IH]
+    case succ.bit1 n IH =>
+      rw [PosNum.cast_bit1, ← two_mul, ← congr_fun Nat.bit_true, Nat.testBit_bit_succ, IH]
+    case succ.bit0 n IH =>
+      rw [PosNum.cast_bit0, ← two_mul, ← congr_fun Nat.bit_false, Nat.testBit_bit_succ, IH]
 
 end Num
 

--- a/Mathlib/Data/Num/Prime.lean
+++ b/Mathlib/Data/Num/Prime.lean
@@ -39,15 +39,17 @@ def minFacAux (n : PosNum) : ℕ → PosNum → PosNum
 
 theorem minFacAux_to_nat {fuel : ℕ} {n k : PosNum} (h : Nat.sqrt n < fuel + k.bit1) :
     (minFacAux n fuel k : ℕ) = Nat.minFacAux n k.bit1 := by
-  induction' fuel with fuel ih generalizing k <;> rw [minFacAux, Nat.minFacAux]
-  · rw [Nat.zero_add, Nat.sqrt_lt] at h
+  induction fuel generalizing k <;> rw [minFacAux, Nat.minFacAux]
+  case zero =>
+    rw [Nat.zero_add, Nat.sqrt_lt] at h
     simp only [h, ite_true]
-  simp_rw [← mul_to_nat]
-  simp only [cast_lt, dvd_to_nat]
-  split_ifs <;> try rfl
-  rw [ih] <;> [congr; convert Nat.lt_succ_of_lt h using 1] <;>
-    simp only [cast_bit1, cast_succ, Nat.succ_eq_add_one, add_assoc,
-      add_left_comm, ← one_add_one_eq_two]
+  case succ fuel ih =>
+    simp_rw [← mul_to_nat]
+    simp only [cast_lt, dvd_to_nat]
+    split_ifs <;> try rfl
+    rw [ih] <;> [congr; convert Nat.lt_succ_of_lt h using 1] <;>
+      simp only [cast_bit1, cast_succ, Nat.succ_eq_add_one, add_assoc,
+        add_left_comm, ← one_add_one_eq_two]
 
 /-- Returns the smallest prime factor of `n ≠ 1`. -/
 def minFac : PosNum → PosNum

--- a/Mathlib/Data/Num/ZNum.lean
+++ b/Mathlib/Data/Num/ZNum.lean
@@ -545,17 +545,19 @@ theorem divMod_to_nat_aux {n d : PosNum} {q r : Num} (h₁ : (r : ℕ) + d * ((q
 theorem divMod_to_nat (d n : PosNum) :
     (n / d : ℕ) = (divMod d n).1 ∧ (n % d : ℕ) = (divMod d n).2 := by
   rw [Nat.div_mod_unique (PosNum.cast_pos _)]
-  induction' n with n IH n IH
-  · exact
-      divMod_to_nat_aux (by simp) (Nat.mul_le_mul_left 2 (PosNum.cast_pos d : (0 : ℕ) < d))
-  · unfold divMod
+  induction n with
+  | one =>
+    exact divMod_to_nat_aux (by simp) (Nat.mul_le_mul_left 2 (PosNum.cast_pos d : (0 : ℕ) < d))
+  | bit1 n IH =>
+    unfold divMod
     -- Porting note: `cases'` didn't rewrite at `this`, so `revert` & `intro` are required.
     revert IH; obtain ⟨q, r⟩ := divMod d n; intro IH
     simp only at IH ⊢
     apply divMod_to_nat_aux <;> simp only [Num.cast_bit1, cast_bit1]
     · rw [← two_mul, ← two_mul, add_right_comm, mul_left_comm, ← mul_add, IH.1]
     · omega
-  · unfold divMod
+  | bit0 n IH =>
+    unfold divMod
     -- Porting note: `cases'` didn't rewrite at `this`, so `revert` & `intro` are required.
     revert IH; obtain ⟨q, r⟩ := divMod d n; intro IH
     simp only at IH ⊢

--- a/Mathlib/Data/QPF/Univariate/Basic.lean
+++ b/Mathlib/Data/QPF/Univariate/Basic.lean
@@ -202,7 +202,7 @@ def Wrepr : q.P.W → q.P.W :=
   recF (PFunctor.W.mk ∘ repr)
 
 theorem Wrepr_equiv (x : q.P.W) : Wequiv (Wrepr x) x := by
-  induction' x with a f ih
+  induction x with | _ a f ih
   apply Wequiv.trans
   · change Wequiv (Wrepr ⟨a, f⟩) (PFunctor.W.mk (q.P.map Wrepr ⟨a, f⟩))
     apply Wequiv.abs'
@@ -269,7 +269,7 @@ theorem Fix.ind_rec {α : Type u} (g₁ g₂ : Fix F → α)
     (h : ∀ x : F (Fix F), g₁ <$> x = g₂ <$> x → g₁ (Fix.mk x) = g₂ (Fix.mk x)) :
     ∀ x, g₁ x = g₂ x := by
   rintro ⟨x⟩
-  induction' x with a f ih
+  induction x with | _ a f ih
   change g₁ ⟦⟨a, f⟩⟧ = g₂ ⟦⟨a, f⟩⟧
   rw [← Fix.ind_aux a f]; apply h
   rw [← abs_map, ← abs_map, PFunctor.map_eq, PFunctor.map_eq]
@@ -301,7 +301,7 @@ theorem Fix.dest_mk (x : F (Fix F)) : Fix.dest (Fix.mk x) = x := by
 
 theorem Fix.ind (p : Fix F → Prop) (h : ∀ x : F (Fix F), Liftp p x → p (Fix.mk x)) : ∀ x, p x := by
   rintro ⟨x⟩
-  induction' x with a f ih
+  induction x with | _ a f ih
   change p ⟦⟨a, f⟩⟧
   rw [← Fix.ind_aux a f]
   apply h

--- a/Mathlib/Data/Seq/Basic.lean
+++ b/Mathlib/Data/Seq/Basic.lean
@@ -393,8 +393,9 @@ theorem dropn_tail (s : Seq α) (n) : drop (tail s) n = drop s (n + 1) := by
 
 @[simp]
 theorem head_dropn (s : Seq α) (n) : head (drop s n) = get? s n := by
-  induction' n with n IH generalizing s; · rfl
-  rw [← get?_tail, ← dropn_tail]; apply IH
+  induction n generalizing s with
+  | zero => rfl
+  | succ n IH => rw [← get?_tail, ← dropn_tail]; apply IH
 
 @[simp]
 theorem drop_succ_cons {x : α} {s : Seq α} {n : ℕ} :
@@ -735,7 +736,8 @@ theorem bind_assoc (s : Seq1 α) (f : α → Seq1 β) (g : β → Seq1 γ) :
   rw [map_comp _ join]
   generalize Seq.map (map g ∘ f) s = SS
   rcases map g (f a) with ⟨⟨a, s⟩, S⟩
-  induction' s using recOn with x s_1 <;> induction' S using recOn with x_1 s_2 <;> simp
+  induction s using recOn with | nil => ?_ | cons x s_1 => ?_ <;>
+  induction S using recOn with | nil => simp | cons x_1 s_2 => ?_
   · obtain ⟨x, t⟩ := x_1
     cases t <;> simp
   · obtain ⟨y, t⟩ := x_1; simp

--- a/Mathlib/Data/Seq/Computation.lean
+++ b/Mathlib/Data/Seq/Computation.lean
@@ -98,18 +98,17 @@ unsafe def run : Computation α → α
 
 theorem destruct_eq_pure {s : Computation α} {a : α} : destruct s = Sum.inl a → s = pure a := by
   dsimp [destruct]
-  induction' f0 : s.1 0 with _ <;> intro h
+  cases f0 : s.1 0 <;> intro h
   · contradiction
   · apply Subtype.eq
     funext n
-    induction' n with n IH
-    · injection h with h'
-      rwa [h'] at f0
-    · exact s.2 IH
+    induction n with
+    | zero => injection h with h'; rwa [h'] at f0
+    | succ n IH => exact s.2 IH
 
 theorem destruct_eq_think {s : Computation α} {s'} : destruct s = Sum.inr s' → s = think s' := by
   dsimp [destruct]
-  induction' f0 : s.1 0 with a' <;> intro h
+  rcases f0 : s.1 0 with - | a' <;> intro h
   · injection h with h'
     rw [← h']
     obtain ⟨f, al⟩ := s
@@ -187,13 +186,15 @@ def corec (f : β → α ⊕ β) (b : β) : Computation α := by
   refine ⟨Stream'.corec' (Corec.f f) (Sum.inr b), fun n a' h => ?_⟩
   rw [Stream'.corec'_eq]
   change Stream'.corec' (Corec.f f) (Corec.f f (Sum.inr b)).2 n = some a'
-  revert h; generalize Sum.inr b = o; revert o
-  induction' n with n IH <;> intro o
-  · change (Corec.f f o).1 = some a' → (Corec.f f (Corec.f f o).2).1 = some a'
+  revert h; generalize Sum.inr b = o
+  induction n generalizing o with
+  | zero =>
+    change (Corec.f f o).1 = some a' → (Corec.f f (Corec.f f o).2).1 = some a'
     rcases o with _ | b <;> intro h
     · exact h
     unfold Corec.f at *; split <;> simp_all
-  · rw [Stream'.corec'_eq (Corec.f f) (Corec.f f o).2, Stream'.corec'_eq (Corec.f f) o]
+  | succ n IH =>
+    rw [Stream'.corec'_eq (Corec.f f) (Corec.f f o).2, Stream'.corec'_eq (Corec.f f) o]
     exact IH (Corec.f f o).2
 
 /-- left map of `⊕` -/
@@ -218,7 +219,7 @@ theorem corec_eq (f : β → α ⊕ β) (b : β) : destruct (corec f b) = rmap (
     | Sum.inl x => rfl
     | Sum.inr x => rfl
     ]
-  induction' h : f b with a b'; · rfl
+  rcases h : f b with a | b'; · rfl
   dsimp [Corec.f, destruct]
   apply congr_arg; apply Subtype.eq
   dsimp [corec, tail]
@@ -282,8 +283,9 @@ instance : Membership α (Computation α) :=
 
 theorem le_stable (s : Computation α) {a m n} (h : m ≤ n) : s.1 m = some a → s.1 n = some a := by
   obtain ⟨f, al⟩ := s
-  induction' h with n _ IH
-  exacts [id, fun h2 => al (IH h2)]
+  induction h with
+  | refl => exact id
+  | step _ IH => exact fun h2 ↦ al (IH h2)
 
 theorem mem_unique {s : Computation α} {a b : α} : a ∈ s → b ∈ s → a = b
   | ⟨m, ha⟩, ⟨n, hb⟩ => by
@@ -348,7 +350,7 @@ theorem not_terminates_empty : ¬Terminates (empty α) := fun ⟨⟨a, h⟩⟩ =
 
 theorem eq_empty_of_not_terminates {s} (H : ¬Terminates s) : s = empty α := by
   apply Subtype.eq; funext n
-  induction' h : s.val n with _; · rfl
+  rcases h : s.val n; · rfl
   refine absurd ?_ H; exact ⟨⟨_, _, h.symm⟩⟩
 
 theorem thinkN_mem {s : Computation α} {a} : ∀ n, a ∈ thinkN s n ↔ a ∈ s
@@ -525,7 +527,7 @@ def memRecOn {C : Computation α → Sort v} {a s} (M : a ∈ s) (h1 : C (pure a
   haveI T := terminates_of_mem M
   rw [eq_thinkN' s, get_eq_of_mem s M]
   generalize length s = n
-  induction' n with n IH; exacts [h1, h2 _ IH]
+  induction n with | zero => exact h1 | succ n IH => exact h2 _ IH
 
 /-- Recursor based on assertion of `Terminates` -/
 def terminatesRecOn
@@ -540,7 +542,7 @@ def map (f : α → β) : Computation α → Computation β
   | ⟨s, al⟩ =>
     ⟨s.map fun o => Option.casesOn o none (some ∘ f), fun n b => by
       dsimp [Stream'.map, Stream'.get]
-      induction' e : s n with a <;> intro h
+      rcases e : s n with - | a <;> intro h
       · contradiction
       · rw [al e]; exact h⟩
 

--- a/Mathlib/Data/Seq/Parallel.lean
+++ b/Mathlib/Data/Seq/Parallel.lean
@@ -66,8 +66,7 @@ theorem terminates_parallel.aux :
   apply @terminatesRecOn _ _ c T _ _
   · intro a l S m
     apply lem1
-    induction' l with c l IH
-    · simp at m
+    induction l with | nil => simp at m | cons c l IH => ?_
     simp only [List.mem_cons] at m
     rcases m with e | m
     · rw [← e]
@@ -79,9 +78,8 @@ theorem terminates_parallel.aux :
       rw [e]
       exact ⟨a', rfl⟩
   · intro s IH l S m
-    have H1 : ∀ l', parallel.aux2 l = Sum.inr l' → s ∈ l' := by
-      induction' l with c l IH' <;> intro l' e'
-      · simp at m
+    have H1 (l') (e' : parallel.aux2 l = Sum.inr l') : s ∈ l' := by
+      induction l generalizing l' with | nil => simp at m | cons c l IH' => ?_
       simp only [List.mem_cons] at m
       rcases m with e | m <;> simp only [parallel.aux2, rmap, List.foldr_cons] at e'
       · rw [← e] at e'
@@ -92,11 +90,11 @@ theorem terminates_parallel.aux :
         · simp only [destruct_think, Sum.inr.injEq]
           rintro rfl
           simp
-      · induction' e : List.foldr (fun c o =>
+      · rcases e : List.foldr (fun c o =>
             match o with
             | Sum.inl a => Sum.inl a
             | Sum.inr ls => rmap (fun c' => c' :: ls) (destruct c))
-          (Sum.inr List.nil) l with a' ls <;> erw [e] at e'
+          (Sum.inr List.nil) l with a' | ls <;> erw [e] at e'
         · contradiction
         have := IH' m _ e
         -- Porting note: `revert e'` & `intro e'` are required.
@@ -104,7 +102,7 @@ theorem terminates_parallel.aux :
         cases destruct c <;> intro e' <;> [injection e'; injection e' with h']
         rw [← h']
         simp [this]
-    induction' h : parallel.aux2 l with a l'
+    rcases h : parallel.aux2 l with a | l'
     · exact lem1 _ _ ⟨a, h⟩
     · have H2 : corec parallel.aux1 (l, S) = think _ := destruct_eq_think (by
         simp only [parallel.aux1, rmap, corec_eq]
@@ -122,11 +120,12 @@ theorem terminates_parallel {S : WSeq (Computation α)} {c} (h : c ∈ S) [T : T
     from
     let ⟨n, h⟩ := h
     this n [] S c (Or.inr h) T
-  intro n; induction' n with n IH <;> intro l S c o T
-  · rcases o with a | a
+  intro n; induction n <;> intro l S c o T
+  case zero =>
+    rcases o with a | a
     · exact terminates_parallel.aux a T
     have H : Seq.destruct S = some (some c, Seq.tail S) := by simp [Seq.destruct, (· <$> ·), ← a]
-    induction' h : parallel.aux2 l with a l'
+    rcases h : parallel.aux2 l with a | l'
     · have C : corec parallel.aux1 (l, S) = pure a := by
         apply destruct_eq_pure
         rw [corec_eq, parallel.aux1]
@@ -141,9 +140,10 @@ theorem terminates_parallel {S : WSeq (Computation α)} {c} (h : c ∈ S) [T : T
       refine @Computation.think_terminates _ _ ?_
       apply terminates_parallel.aux _ T
       simp
-  · rcases o with a | a
+  case succ n IH =>
+    rcases o with a | a
     · exact terminates_parallel.aux a T
-    induction' h : parallel.aux2 l with a l'
+    rcases h : parallel.aux2 l with a | l'
     · have C : corec parallel.aux1 (l, S) = pure a := by
         apply destruct_eq_pure
         rw [corec_eq, parallel.aux1]
@@ -160,7 +160,7 @@ theorem terminates_parallel {S : WSeq (Computation α)} {c} (h : c ∈ S) [T : T
         intro
         apply IH _ _ _ (Or.inr _) T
         rw [a, Seq.get?_tail]
-      induction' e : Seq.get? S 0 with o
+      rcases e : Seq.get? S 0 with - | o
       · have D : Seq.destruct S = none := by
           dsimp [Seq.destruct]
           rw [e]
@@ -188,12 +188,13 @@ theorem exists_of_mem_parallel {S : WSeq (Computation α)} {a} (h : a ∈ parall
     rcases a with a | l'
     · exact ∃ c ∈ l, a ∈ c
     · exact ∀ a', (∃ c ∈ l', a' ∈ c) → ∃ c ∈ l, a' ∈ c
-  have lem1 : ∀ l : List (Computation α), F l (parallel.aux2 l) := by
-    intro l
-    induction' l with c l IH <;> simp only [parallel.aux2, List.foldr]
-    · intro a h
+  have lem1 (l) : F l (parallel.aux2 l) := by
+    induction l <;> simp only [parallel.aux2, List.foldr]
+    case nil =>
+      intro a h
       assumption
-    · simp only [parallel.aux2] at IH
+    case cons c l IH =>
+      simp only [parallel.aux2] at IH
       -- Porting note: `revert IH` & `intro IH` are required.
       revert IH
       cases List.foldr (fun c o =>
@@ -203,7 +204,7 @@ theorem exists_of_mem_parallel {S : WSeq (Computation α)} {a} (h : a ∈ parall
         intro IH <;> simp only
       · rcases IH with ⟨c', cl, ac⟩
         exact ⟨c', List.Mem.tail _ cl, ac⟩
-      · induction' h : destruct c with a c' <;> simp only [rmap]
+      · rcases h : destruct c with a | c' <;> simp only [rmap]
         · refine ⟨c, List.mem_cons_self, ?_⟩
           rw [destruct_eq_pure h]
           apply ret_mem
@@ -226,7 +227,7 @@ theorem exists_of_mem_parallel {S : WSeq (Computation α)} {a} (h : a ∈ parall
   · rw [h'] at this
     rcases this with ⟨c, cl, ac⟩
     exact ⟨c, Or.inl cl, ac⟩
-  · induction' e : Seq.destruct S with a <;> rw [e] at h'
+  · rcases e : Seq.destruct S with - | a <;> rw [e] at h'
     · exact
         let ⟨d, o, ad⟩ := IH _ _ h'
         let ⟨c, cl, ac⟩ := this a ⟨d, o.resolve_right (WSeq.notMem_nil _), ad⟩
@@ -267,19 +268,20 @@ theorem map_parallel (f : α → β) (S) : map f (parallel S) = parallel (S.map 
       have : parallel.aux2 (l.map (map f))
           = lmap f (rmap (List.map (map f)) (parallel.aux2 l)) := by
         simp only [parallel.aux2, rmap, lmap]
-        induction' l with c l IH
-        · simp
-        simp only [List.map_cons, List.foldr_cons, destruct_map, lmap, rmap]
-        rw [IH]
-        cases List.foldr _ _ _
-        · simp
-        · cases destruct c <;> simp
+        induction l with
+        | nil => simp
+        | cons c l IH =>
+          simp only [List.map_cons, List.foldr_cons, destruct_map, lmap, rmap]
+          rw [IH]
+          cases List.foldr _ _ _
+          · simp
+          · cases destruct c <;> simp
       simp only [BisimO, destruct_map, lmap, rmap, corec_eq, parallel.aux1.eq_1]
       rw [this]
       rcases parallel.aux2 l with a | l'
       · simp
       simp only [lmap, rmap]
-      induction' S using WSeq.recOn with c S S <;> simpa using ⟨_, _, rfl, rfl⟩
+      induction S using WSeq.recOn <;> simpa using ⟨_, _, rfl, rfl⟩
 
 theorem parallel_empty (S : WSeq (Computation α)) (h : S.head ~> none) : parallel S = empty _ :=
   eq_empty_of_not_terminates fun ⟨⟨a, m⟩⟩ => by
@@ -305,7 +307,7 @@ def parallelRec {S : WSeq (Computation α)} (C : α → Sort v) (H : ∀ s ∈ S
   have h' := h
   rw [pe] at h'
   haveI : Terminates (parallel T) := (terminates_map_iff _ _).1 ⟨⟨_, h'⟩⟩
-  induction' e : get (parallel T) with a' c
+  rcases e : get (parallel T) with ⟨a', c⟩
   have : a ∈ c ∧ c ∈ S := by
     rcases exists_of_mem_map h' with ⟨d, dT, cd⟩
     rw [get_eq_of_mem _ dT] at e

--- a/Mathlib/Data/Set/Finite/Basic.lean
+++ b/Mathlib/Data/Set/Finite/Basic.lean
@@ -685,9 +685,9 @@ theorem Finite.induction_on {motive : ∀ s : Set α, s.Finite → Prop} (s : Se
       ∀ hs : Set.Finite s, motive s hs → motive (insert a s) (hs.insert a)) :
     motive s hs := by
   lift s to Finset α using id hs
-  induction' s using Finset.cons_induction_on with a s ha ih
-  · simpa
-  · simpa using @insert a s ha (Set.toFinite _) (ih _)
+  induction s using Finset.cons_induction_on with
+  | empty => simpa
+  | cons a s ha ih => simpa using @insert a s ha (Set.toFinite _) (ih _)
 
 /-- Induction principle for finite sets: To prove a property `C` of a finite set `s`, it's enough
 to prove for the empty set and to prove that `C t → C ({a} ∪ t)` for all `t ⊆ s`.

--- a/Mathlib/Data/Setoid/Partition.lean
+++ b/Mathlib/Data/Setoid/Partition.lean
@@ -167,8 +167,8 @@ noncomputable def quotientEquivClasses (r : Setoid α) : Quotient r ≃ Setoid.c
   apply Equiv.ofBijective (Quot.lift f f_respects_relation)
   constructor
   · intro (q_a : Quotient r) (q_b : Quotient r) h_eq
-    induction' q_a using Quotient.ind with a
-    induction' q_b using Quotient.ind with b
+    induction q_a using Quotient.ind with | _ a
+    induction q_b using Quotient.ind with | _ b
     simp only [f, Quotient.lift_mk, Subtype.ext_iff] at h_eq
     apply Quotient.sound
     change a ∈ { x | r x b }

--- a/Mathlib/Data/Stream/Init.lean
+++ b/Mathlib/Data/Stream/Init.lean
@@ -231,9 +231,9 @@ theorem get_succ_iterate' (n : ℕ) (f : α → α) (a : α) :
 theorem tail_iterate (f : α → α) (a : α) : tail (iterate f a) = iterate f (f a) := by
   ext n
   rw [get_tail]
-  induction' n with n' ih
-  · rfl
-  · rw [get_succ_iterate', ih, get_succ_iterate']
+  induction n with
+  | zero => rfl
+  | succ n ih => rw [get_succ_iterate', ih, get_succ_iterate']
 
 theorem iterate_eq (f : α → α) (a : α) : iterate f a = a::iterate f (f a) := by
   rw [← Stream'.eta (iterate f a)]
@@ -307,9 +307,10 @@ theorem iterate_id (a : α) : iterate id a = const a :=
 
 theorem map_iterate (f : α → α) (a : α) : iterate f (f a) = map f (iterate f a) := by
   funext n
-  induction' n with n' ih
-  · rfl
-  · unfold map iterate get
+  induction n with
+  | zero => rfl
+  | succ n ih =>
+    unfold map iterate get
     rw [map, get] at ih
     rw [iterate]
     exact congrArg f ih
@@ -340,13 +341,10 @@ end Corec'
 theorem unfolds_eq (g : α → β) (f : α → α) (a : α) : unfolds g f a = g a :: unfolds g f (f a) := by
   unfold unfolds; rw [corec_eq]
 
-theorem get_unfolds_head_tail : ∀ (n : ℕ) (s : Stream' α),
-    get (unfolds head tail s) n = get s n := by
-  intro n; induction' n with n' ih
-  · intro s
-    rfl
-  · intro s
-    rw [get_succ, get_succ, unfolds_eq, tail_cons, ih]
+theorem get_unfolds_head_tail (n : ℕ) (s : Stream' α) : get (unfolds head tail s) n = get s n := by
+  induction n generalizing s with
+  | zero => rfl
+  | succ n ih => rw [get_succ, get_succ, unfolds_eq, tail_cons, ih]
 
 theorem unfolds_head_eq : ∀ s : Stream' α, unfolds head tail s = s := fun s =>
   Stream'.ext fun n => get_unfolds_head_tail n s
@@ -451,14 +449,15 @@ theorem cons_append_stream (a : α) (l : List α) (s : Stream' α) :
     rw [List.cons_append, cons_append_stream, cons_append_stream, append_append_stream l₁]
 
 lemma get_append_left (h : n < x.length) : (x ++ₛ a).get n = x[n] := by
-  induction' x with b x ih generalizing n
-  · simp at h
-  · rcases n with (_ | n)
+  induction x generalizing n with
+  | nil => simp at h
+  | cons b x ih =>
+    rcases n with (_ | n)
     · simp
     · simp [ih n (by simpa using h), cons_append_stream]
 
 @[simp] lemma get_append_right : (x ++ₛ a).get (x.length + n) = a.get n := by
-  induction' x <;> simp [Nat.succ_add, *, cons_append_stream]
+  induction x <;> simp [Nat.succ_add, *, cons_append_stream]
 
 @[simp] lemma get_append_length : (x ++ₛ a).get x.length = a.get 0 := get_append_right 0 x a
 
@@ -545,17 +544,13 @@ theorem getElem?_take_succ (n : ℕ) (s : Stream' α) :
   | succ n => rw [take_succ', List.dropLast_concat, Nat.add_one_sub_one]
 
 @[simp]
-theorem append_take_drop : ∀ (n : ℕ) (s : Stream' α),
-    appendStream' (take n s) (drop n s) = s := by
-  intro n
-  induction' n with n' ih
-  · intro s
-    rfl
-  · intro s
-    rw [take_succ, drop_succ, cons_append_stream, ih (tail s), Stream'.eta]
+theorem append_take_drop (n : ℕ) (s : Stream' α) : appendStream' (take n s) (drop n s) = s := by
+  induction n generalizing s with
+  | zero => rfl
+  | succ n ih =>rw [take_succ, drop_succ, cons_append_stream, ih (tail s), Stream'.eta]
 
 lemma append_take : x ++ (a.take n) = (x ++ₛ a).take (x.length + n) := by
-  induction' x <;> simp [take, Nat.add_comm, cons_append_stream, *]
+  induction x <;> simp [take, Nat.add_comm, cons_append_stream, *]
 
 @[simp] lemma take_get (h : m < (a.take n).length) : (a.take n)[m] = a.get m := by
   nth_rw 2 [← append_take_drop n a]; rw [get_append_left]
@@ -593,11 +588,12 @@ lemma drop_append_of_le_length (h : n ≤ x.length) :
 
 -- Take theorem reduces a proof of equality of infinite streams to an
 -- induction over all their finite approximations.
-theorem take_theorem (s₁ s₂ : Stream' α) : (∀ n : ℕ, take n s₁ = take n s₂) → s₁ = s₂ := by
-  intro h; apply Stream'.ext; intro n
-  induction' n with n _
-  · simpa [take] using h 1
-  · have h₁ : some (get s₁ (succ n)) = some (get s₂ (succ n)) := by
+theorem take_theorem (s₁ s₂ : Stream' α) (h : ∀ n : ℕ, take n s₁ = take n s₂) : s₁ = s₂ := by
+  ext n
+  induction n with
+  | zero => simpa [take] using h 1
+  | succ n =>
+    have h₁ : some (get s₁ (succ n)) = some (get s₂ (succ n)) := by
       rw [← getElem?_take_succ, ← getElem?_take_succ, h (succ (succ n))]
     injection h₁
 
@@ -608,16 +604,11 @@ protected theorem cycle_g_cons (a : α) (a₁ : α) (l₁ : List α) (a₀ : α)
 theorem cycle_eq : ∀ (l : List α) (h : l ≠ []), cycle l h = l ++ₛ cycle l h
   | [], h => absurd rfl h
   | List.cons a l, _ =>
-    have gen : ∀ l' a', corec Stream'.cycleF Stream'.cycleG (a', l', a, l) =
+    have gen (l' a') : corec Stream'.cycleF Stream'.cycleG (a', l', a, l) =
         (a'::l') ++ₛ corec Stream'.cycleF Stream'.cycleG (a, l, a, l) := by
-      intro l'
-      induction' l' with a₁ l₁ ih
-      · intros
-        rw [corec_eq]
-        rfl
-      · intros
-        rw [corec_eq, Stream'.cycle_g_cons, ih a₁]
-        rfl
+      induction l' generalizing a' with
+      | nil => rw [corec_eq]; rfl
+      | cons a₁ l₁ ih => rw [corec_eq, Stream'.cycle_g_cons, ih a₁]; rfl
     gen l a
 
 theorem mem_cycle {a : α} {l : List α} : ∀ h : l ≠ [], a ∈ l → a ∈ cycle l h := fun h ainl => by
@@ -631,12 +622,10 @@ theorem tails_eq (s : Stream' α) : tails s = tail s::tails (tail s) := by
   unfold tails; rw [corec_eq]; rfl
 
 @[simp]
-theorem get_tails : ∀ (n : ℕ) (s : Stream' α), get (tails s) n = drop n (tail s) := by
-  intro n; induction' n with n' ih
-  · intros
-    rfl
-  · intro s
-    rw [get_succ, drop_succ, tails_eq, tail_cons, ih]
+theorem get_tails (n : ℕ) (s : Stream' α) : get (tails s) n = drop n (tail s) := by
+  induction n generalizing s with
+  | zero => rfl
+  | succ n ih => rw [get_succ, drop_succ, tails_eq, tail_cons, ih]
 
 theorem tails_eq_iterate (s : Stream' α) : tails s = iterate tail (tail s) :=
   rfl
@@ -654,24 +643,19 @@ theorem tail_inits (s : Stream' α) :
 theorem inits_tail (s : Stream' α) : inits (tail s) = initsCore [head (tail s)] (tail (tail s)) :=
   rfl
 
-theorem cons_get_inits_core :
-    ∀ (a : α) (n : ℕ) (l : List α) (s : Stream' α),
-      (a::get (initsCore l s) n) = get (initsCore (a::l) s) n := by
-  intro a n
-  induction' n with n' ih
-  · intros
-    rfl
-  · intro l s
-    rw [get_succ, inits_core_eq, tail_cons, ih, inits_core_eq (a::l) s]
+theorem cons_get_inits_core (a : α) (n : ℕ) (l : List α) (s : Stream' α) :
+    (a :: get (initsCore l s) n) = get (initsCore (a :: l) s) n := by
+  induction n generalizing l s with
+  | zero => rfl
+  | succ n ih =>
+    rw [get_succ, inits_core_eq, tail_cons, ih, inits_core_eq (a :: l) s]
     rfl
 
 @[simp]
-theorem get_inits : ∀ (n : ℕ) (s : Stream' α), get (inits s) n = take (succ n) s := by
-  intro n; induction' n with n' ih
-  · intros
-    rfl
-  · intros
-    rw [get_succ, take_succ, ← ih, tail_inits, inits_tail, cons_get_inits_core]
+theorem get_inits (n : ℕ) (s : Stream' α) : get (inits s) n = take (succ n) s := by
+  induction n generalizing s with
+  | zero => rfl
+  | succ n ih => rw [get_succ, take_succ, ← ih, tail_inits, inits_tail, cons_get_inits_core]
 
 theorem inits_eq (s : Stream' α) :
     inits s = [head s]::map (List.cons (head s)) (inits (tail s)) := by

--- a/Mathlib/Data/Sym/Sym2/Order.lean
+++ b/Mathlib/Data/Sym/Sym2/Order.lean
@@ -46,8 +46,8 @@ def sortEquiv [LinearOrder α] : Sym2 α ≃ { p : α × α // p.1 ≤ p.2 } whe
 they have the same infimum and supremum. -/
 theorem inf_eq_inf_and_sup_eq_sup [LinearOrder α] {s t : Sym2 α} :
     s.inf = t.inf ∧ s.sup = t.sup ↔ s = t := by
-  induction' s with a b
-  induction' t with c d
+  induction s with | _ a b
+  induction t with | _ c d
   obtain hab | hba := le_total a b <;> obtain hcd | hdc := le_total c d <;>
     aesop (add unsafe le_antisymm)
 

--- a/Mathlib/Data/Vector/Basic.lean
+++ b/Mathlib/Data/Vector/Basic.lean
@@ -361,10 +361,12 @@ theorem scanl_get (i : Fin n) :
     (scanl f b v).get i.succ = f ((scanl f b v).get (Fin.castSucc i)) (v.get i) := by
   rcases n with - | n
   · exact i.elim0
-  induction' n with n hn generalizing b
-  · have i0 : i = 0 := Fin.eq_zero _
+  induction n generalizing b with
+  | zero =>
+    have i0 : i = 0 := Fin.eq_zero _
     simp [scanl_singleton, i0, get_zero]; simp [get_eq_get_toList]
-  · rw [← cons_head_tail v, scanl_cons, get_cons_succ]
+  | succ n hn =>
+    rw [← cons_head_tail v, scanl_cons, get_cons_succ]
     refine Fin.cases ?_ ?_ i
     · simp only [get_zero, scanl_head, Fin.castSucc_zero, head_cons]
     · intro i'
@@ -421,10 +423,12 @@ It is used as the default induction principle for the `induction` tactic.
 @[elab_as_elim, induction_eliminator]
 def inductionOn {C : ∀ {n : ℕ}, Vector α n → Sort*} {n : ℕ} (v : Vector α n)
     (nil : C nil) (cons : ∀ {n : ℕ} {x : α} {w : Vector α n}, C w → C (x ::ᵥ w)) : C v := by
-  induction' n with n ih
-  · rcases v with ⟨_ | ⟨-, -⟩, - | -⟩
+  induction n with
+  | zero =>
+    rcases v with ⟨_ | ⟨-, -⟩, - | -⟩
     exact nil
-  · rcases v with ⟨_ | ⟨a, v⟩, v_property⟩
+  | succ n ih =>
+    rcases v with ⟨_ | ⟨a, v⟩, v_property⟩
     cases v_property
     exact cons (ih ⟨v, (add_left_inj 1).mp v_property⟩)
 
@@ -448,11 +452,13 @@ def inductionOn₂ {C : ∀ {n}, Vector α n → Vector β n → Sort*}
     (v : Vector α n) (w : Vector β n)
     (nil : C nil nil) (cons : ∀ {n a b} {x : Vector α n} {y}, C x y → C (a ::ᵥ x) (b ::ᵥ y)) :
     C v w := by
-  induction' n with n ih
-  · rcases v with ⟨_ | ⟨-, -⟩, - | -⟩
+  induction n with
+  | zero =>
+    rcases v with ⟨_ | ⟨-, -⟩, - | -⟩
     rcases w with ⟨_ | ⟨-, -⟩, - | -⟩
     exact nil
-  · rcases v with ⟨_ | ⟨a, v⟩, v_property⟩
+  | succ n ih =>
+    rcases v with ⟨_ | ⟨a, v⟩, v_property⟩
     cases v_property
     rcases w with ⟨_ | ⟨b, w⟩, w_property⟩
     cases w_property
@@ -466,12 +472,14 @@ def inductionOn₃ {C : ∀ {n}, Vector α n → Vector β n → Vector γ n →
     (u : Vector α n) (v : Vector β n) (w : Vector γ n) (nil : C nil nil nil)
     (cons : ∀ {n a b c} {x : Vector α n} {y z}, C x y z → C (a ::ᵥ x) (b ::ᵥ y) (c ::ᵥ z)) :
     C u v w := by
-  induction' n with n ih
-  · rcases u with ⟨_ | ⟨-, -⟩, - | -⟩
+  induction n with
+  | zero =>
+    rcases u with ⟨_ | ⟨-, -⟩, - | -⟩
     rcases v with ⟨_ | ⟨-, -⟩, - | -⟩
     rcases w with ⟨_ | ⟨-, -⟩, - | -⟩
     exact nil
-  · rcases u with ⟨_ | ⟨a, u⟩, u_property⟩
+  | succ n ih =>
+    rcases u with ⟨_ | ⟨a, u⟩, u_property⟩
     cases u_property
     rcases v with ⟨_ | ⟨b, v⟩, v_property⟩
     cases v_property
@@ -646,8 +654,7 @@ protected theorem traverse_def (f : α → F β) (x : α) :
 
 protected theorem id_traverse : ∀ x : Vector α n, x.traverse (pure : _ → Id _) = pure x := by
   rintro ⟨x, rfl⟩; dsimp [Vector.traverse, cast]
-  induction' x with x xs IH; · rfl
-  simp! [IH]
+  induction x with | nil => rfl | cons x xs IH => simp! [IH]
 
 end
 
@@ -662,10 +669,12 @@ variable {α β γ : Type u}
 protected theorem comp_traverse (f : β → F γ) (g : α → G β) (x : Vector α n) :
     Vector.traverse (Comp.mk ∘ Functor.map f ∘ g) x =
       Comp.mk (Vector.traverse f <$> Vector.traverse g x) := by
-  induction' x with n x xs ih
-  · simp! [cast, *, functor_norm]
+  induction x with
+  | nil =>
+    simp! [cast, *, functor_norm]
     rfl
-  · rw [Vector.traverse_def, ih]
+  | cons ih =>
+    rw [Vector.traverse_def, ih]
     simp [functor_norm, Function.comp_def]
 
 protected theorem traverse_eq_map_id {α β} (f : α → β) :
@@ -676,9 +685,10 @@ variable [LawfulApplicative F] (η : ApplicativeTransformation F G)
 
 protected theorem naturality {α β : Type u} (f : α → F β) (x : Vector α n) :
     η (x.traverse f) = x.traverse (@η _ ∘ f) := by
-  induction' x with n x xs ih
-  · simp! [functor_norm, cast, η.preserves_pure]
-  · rw [Vector.traverse_def, Vector.traverse_def, ← ih, η.preserves_seq, η.preserves_map]
+  induction x with
+  | nil => simp! [functor_norm, cast, η.preserves_pure]
+  | cons ih =>
+    rw [Vector.traverse_def, Vector.traverse_def, ← ih, η.preserves_seq, η.preserves_map]
     rfl
 
 end Traverse

--- a/Mathlib/Data/W/Basic.lean
+++ b/Mathlib/Data/W/Basic.lean
@@ -95,9 +95,10 @@ theorem infinite_of_nonempty_of_isEmpty (a b : α) [ha : Nonempty (β a)] [he : 
           show WType β from Nat.recOn n ⟨b, IsEmpty.elim' he⟩ fun _ ih => ⟨a, fun _ => ih⟩)
         ?_
     intro n m h
-    induction' n with n ih generalizing m
-    · rcases m with - | m <;> simp_all
-    · rcases m with - | m
+    induction n generalizing m with
+    | zero => rcases m with - | m <;> simp_all
+    | succ n ih =>
+      rcases m with - | m
       · simp_all
       · refine congr_arg Nat.succ (ih ?_)
         simp_all [funext_iff]⟩

--- a/Mathlib/Data/W/Cardinal.lean
+++ b/Mathlib/Data/W/Cardinal.lean
@@ -42,7 +42,7 @@ theorem cardinalMk_eq_sum_lift : #(WType β) = sum fun a ↦ #(WType β) ^ lift.
 theorem cardinalMk_le_of_le' {κ : Cardinal.{max u v}}
     (hκ : (sum fun a : α => κ ^ lift.{u} #(β a)) ≤ κ) :
     #(WType β) ≤ κ := by
-  induction' κ using Cardinal.inductionOn with γ
+  induction κ using Cardinal.inductionOn with | _ γ
   simp_rw [← lift_umax.{v, u}] at hκ
   nth_rewrite 1 [← lift_id'.{v, u} #γ] at hκ
   simp_rw [← mk_arrow, ← mk_sigma, le_def] at hκ

--- a/Mathlib/Data/WSeq/Basic.lean
+++ b/Mathlib/Data/WSeq/Basic.lean
@@ -239,9 +239,9 @@ theorem destruct_flatten (c : Computation (WSeq α)) : destruct (flatten c) = c 
     match c1, c2, h with
     | c, _, Or.inl rfl => by cases c.destruct <;> simp
     | _, _, Or.inr ⟨c, rfl, rfl⟩ => by
-      induction' c using Computation.recOn with a c'
-      · simp; cases (destruct a).destruct <;> simp
-      · simpa using Or.inr ⟨c', rfl, rfl⟩
+      induction c using Computation.recOn with
+      | pure a => simp; cases (destruct a).destruct <;> simp
+      | think c' => simpa using Or.inr ⟨c', rfl, rfl⟩
 
 theorem head_terminates_iff (s : WSeq α) : Terminates (head s) ↔ Terminates (destruct s) :=
   terminates_map_iff _ (destruct s)
@@ -384,8 +384,9 @@ theorem head_some_of_get?_some {s : WSeq α} {a n} (h : some a ∈ get? s n) :
 
 theorem get?_terminates_le {s : WSeq α} {m n} (h : m ≤ n) :
     Terminates (get? s n) → Terminates (get? s m) := by
-  induction' h with m' _ IH
-  exacts [id, fun T => IH (@head_terminates_of_head_tail_terminates _ _ T)]
+  induction h with
+  | refl => exact id
+  | step _ IH => exact fun T ↦ IH (@head_terminates_of_head_tail_terminates _ _ T)
 
 theorem head_terminates_of_get?_terminates {s : WSeq α} {n} :
     Terminates (get? s n) → Terminates (head s) :=
@@ -423,7 +424,7 @@ theorem eq_or_mem_iff_mem {s : WSeq α} {a a' s'} :
   generalize e : destruct s = c; intro h
   revert s
   apply Computation.memRecOn h <;> [skip; intro c IH] <;> intro s <;>
-    induction' s using WSeq.recOn with x s s <;>
+    induction s using WSeq.recOn <;>
     intro m <;>
     have := congr_arg Computation.destruct m <;>
     simp at this
@@ -452,12 +453,12 @@ theorem mem_cons (s : WSeq α) (a) : a ∈ cons a s :=
 
 theorem mem_of_mem_tail {s : WSeq α} {a} : a ∈ tail s → a ∈ s := by
   intro h; have := h; obtain ⟨n, e⟩ := h; revert s; simp only [Stream'.get]
-  induction' n with n IH <;> intro s <;> induction' s using WSeq.recOn with x s s <;>
-    simp <;> intro m e <;>
-    injections
+  induction n <;> intro s <;> induction s using WSeq.recOn <;>
+    simp <;> intro m e <;> injections
   · exact Or.inr m
   · exact Or.inr m
-  · apply IH m
+  case succ.think n IH s =>
+    apply IH m
     rw [e]
     cases tail s
     rfl
@@ -467,14 +468,16 @@ theorem mem_of_mem_dropn {s : WSeq α} {a} : ∀ {n}, a ∈ drop s n → a ∈ s
   | n + 1, h => @mem_of_mem_dropn s a n (mem_of_mem_tail h)
 
 theorem get?_mem {s : WSeq α} {a n} : some a ∈ get? s n → a ∈ s := by
-  revert s; induction' n with n IH <;> intro s h
-  · rcases Computation.exists_of_mem_map h with ⟨o, h1, h2⟩
+  induction n generalizing s <;> intro h
+  case zero =>
+    rcases Computation.exists_of_mem_map h with ⟨o, h1, h2⟩
     rcases o with - | o
     · injection h2
     injection h2 with h'
     obtain ⟨a', s'⟩ := o
     exact (eq_or_mem_iff_mem h1).2 (Or.inl h'.symm)
-  · have := @IH (tail s)
+  case succ n IH =>
+    have := @IH (tail s)
     rw [get?_tail] at this
     exact mem_of_mem_tail (this h)
 
@@ -594,9 +597,9 @@ theorem toList'_map (l : List α) (s : WSeq α) :
               | some (some a, s') => Sum.inr (a::l, s')) (l', s)))
       ?_ ⟨[], s, rfl, rfl⟩
   intro s1 s2 h; rcases h with ⟨l', s, h⟩; rw [h.left, h.right]
-  induction' s using WSeq.recOn with a s s <;> simp [nil, cons, think]
-  · refine ⟨a::l', s, ?_, ?_⟩ <;> simp
-  · refine ⟨l', s, ?_, ?_⟩ <;> simp
+  induction s using WSeq.recOn <;> simp [nil, cons, think]
+  case cons a s => refine ⟨a :: l', s, ?_, ?_⟩ <;> simp
+  case think s => refine ⟨l', s, ?_, ?_⟩ <;> simp
 
 @[simp]
 theorem toList_cons (a : α) (s) : toList (cons a s) = (List.cons a <$> toList s).think :=
@@ -612,9 +615,9 @@ theorem toList_nil : toList (nil : WSeq α) = Computation.pure [] :=
   destruct_eq_pure rfl
 
 theorem toList_ofList (l : List α) : l ∈ toList (ofList l) := by
-  induction' l with a l IH
-  · simp
-  · simpa [ret_mem] using think_mem (Computation.mem_map _ IH)
+  induction l with
+  | nil => simp
+  | cons a l IH => simpa [ret_mem] using think_mem (Computation.mem_map _ IH)
 
 @[simp]
 theorem destruct_ofSeq (s : Seq α) :
@@ -636,7 +639,7 @@ theorem head_ofSeq (s : Seq α) : head (ofSeq s) = Computation.pure s.head := by
 @[simp]
 theorem tail_ofSeq (s : Seq α) : tail (ofSeq s) = ofSeq s.tail := by
   simp only [tail, destruct_ofSeq, map_pure', flatten_pure]
-  induction' s using Seq.recOn with x s <;> simp only [ofSeq, Seq.tail_nil, Seq.head_nil,
+  induction s using Seq.recOn <;> simp only [ofSeq, Seq.tail_nil, Seq.head_nil,
     Option.map_none, Seq.tail_cons, Seq.head_cons, Option.map_some]
   · rfl
 
@@ -687,25 +690,28 @@ theorem exists_of_mem_join {a : α} : ∀ {S : WSeq (WSeq α)}, a ∈ join S →
       a ∈ ss → ∀ s S, append s (join S) = ss → a ∈ append s (join S) → a ∈ s ∨ ∃ s, s ∈ S ∧ a ∈ s
     from fun S h => (this _ h nil S (by simp) (by simp [h])).resolve_left (notMem_nil _)
   intro ss h; apply mem_rec_on h <;> [intro b ss o; intro ss IH] <;> intro s S
-  · induction' s using WSeq.recOn with b' s s <;>
-      [induction' S using WSeq.recOn with s S S; skip; skip] <;>
+  · induction s using WSeq.recOn <;>
+      [induction S using WSeq.recOn; skip; skip] <;>
       intro ej m <;> simp at ej <;> have := congr_arg Seq.destruct ej <;>
       simp at this; cases this
-    substs b' ss
-    simp? at m ⊢ says simp only [cons_append, mem_cons_iff] at m ⊢
-    rcases o with e | IH
-    · simp [e]
-    rcases m with e | m
-    · simp [e]
-    exact Or.imp_left Or.inr (IH _ _ rfl m)
-  · induction' s using WSeq.recOn with b' s s <;>
-      [induction' S using WSeq.recOn with s S S; skip; skip] <;>
+    case cons.intro b' s =>
+      substs b' ss
+      simp? at m ⊢ says simp only [cons_append, mem_cons_iff] at m ⊢
+      rcases o with e | IH
+      · simp [e]
+      rcases m with e | m
+      · simp [e]
+      exact Or.imp_left Or.inr (IH _ _ rfl m)
+  · induction s using WSeq.recOn <;>
+      [induction S using WSeq.recOn; skip; skip] <;>
       intro ej m <;> simp at ej <;> have := congr_arg Seq.destruct ej <;> simp at this <;>
       subst ss
-    · apply Or.inr
+    case cons s S =>
+      apply Or.inr
       simp only [join_cons, nil_append, mem_think, mem_cons_iff, exists_eq_or_imp] at m ⊢
       exact IH s S rfl m
-    · apply Or.inr
+    case think S =>
+      apply Or.inr
       replace m : a ∈ S.join := by simpa using m
       rcases (IH nil S (by simp) (by simp [m])).resolve_left (notMem_nil _) with ⟨s, sS, as⟩
       exact ⟨s, by simp [sS], as⟩
@@ -728,8 +734,8 @@ theorem destruct_map (f : α → β) (s : WSeq α) :
   · intro c1 c2 h
     obtain ⟨s, h⟩ := h
     rw [h.left, h.right]
-    induction' s using WSeq.recOn with a s s <;> simp
-    exact ⟨s, rfl, rfl⟩
+    induction s using WSeq.recOn <;> simp
+    case think s => exact ⟨s, rfl, rfl⟩
   · exact ⟨s, rfl, rfl⟩
 
 /-- auxiliary definition of `destruct_append` over weak sequences -/
@@ -746,10 +752,11 @@ theorem destruct_append (s t : WSeq α) :
         ∃ s t, c1 = destruct (append s t) ∧ c2 = (destruct s).bind (destruct_append.aux t))
       _ ⟨s, t, rfl, rfl⟩
   intro c1 c2 h; rcases h with ⟨s, t, h⟩; rw [h.left, h.right]
-  induction' s using WSeq.recOn with a s s <;> simp
-  · induction' t using WSeq.recOn with b t t <;> simp
-    · refine ⟨nil, t, ?_, ?_⟩ <;> simp
-  · exact ⟨s, t, rfl, rfl⟩
+  induction s using WSeq.recOn <;> simp
+  case nil =>
+    induction t using WSeq.recOn <;> simp
+    case think t => refine ⟨nil, t, ?_, ?_⟩ <;> simp
+  case think s => exact ⟨s, t, rfl, rfl⟩
 
 /-- auxiliary definition of `destruct_join` over weak sequences -/
 @[simp]
@@ -769,8 +776,8 @@ theorem destruct_join (S : WSeq (WSeq α)) :
     match c1, c2, h with
     | c, _, Or.inl <| rfl => by cases c.destruct <;> simp
     | _, _, Or.inr ⟨S, rfl, rfl⟩ => by
-      induction' S using WSeq.recOn with s S S <;> simp
-      · refine Or.inr ⟨S, rfl, rfl⟩
+      induction S using WSeq.recOn <;> simp
+      case think S => refine Or.inr ⟨S, rfl, rfl⟩
 
 @[simp]
 theorem map_join (f : α → β) (S) : map f (join S) = join (map (map f) S) := by
@@ -781,10 +788,10 @@ theorem map_join (f : α → β) (S) : map f (join S) = join (map (map f) S) := 
     exact
       match s1, s2, h with
       | _, _, ⟨s, S, rfl, rfl⟩ => by
-        induction' s using WSeq.recOn with a s s <;> simp
-        · induction' S using WSeq.recOn with s S S <;> simp
-          · exact ⟨map f s, S, rfl, rfl⟩
-          · refine ⟨nil, S, ?_, ?_⟩ <;> simp
+        induction s using WSeq.recOn <;> simp
+        · induction S using WSeq.recOn <;> simp
+          case cons s S => exact ⟨map f s, S, rfl, rfl⟩
+          case think S => refine ⟨nil, S, ?_, ?_⟩ <;> simp
         · exact ⟨_, _, rfl, rfl⟩
         · exact ⟨_, _, rfl, rfl⟩
   · refine ⟨nil, S, ?_, ?_⟩ <;> simp

--- a/Mathlib/Data/WSeq/Defs.lean
+++ b/Mathlib/Data/WSeq/Defs.lean
@@ -234,9 +234,9 @@ theorem length_eq_map (s : WSeq α) : length s = Computation.map List.length (to
               | some (some a, s') => Sum.inr (a::l, s')) (l, s)))
       ?_ ⟨[], s, rfl, rfl⟩
   intro s1 s2 h; rcases h with ⟨l, s, h⟩; rw [h.left, h.right]
-  induction' s using WSeq.recOn with a s s
-  · simp [nil]
-  · simpa using ⟨a::l, s, by simp, by simp⟩
-  · simpa using ⟨l, s, by simp, by simp⟩
+  induction s using WSeq.recOn with
+  | nil => simp [nil]
+  | cons a s => simpa using ⟨a::l, s, by simp, by simp⟩
+  | think s => simpa using ⟨l, s, by simp, by simp⟩
 
 end Stream'.WSeq

--- a/Mathlib/Tactic.lean
+++ b/Mathlib/Tactic.lean
@@ -21,6 +21,7 @@ import Mathlib.Tactic.CC.Lemmas
 import Mathlib.Tactic.CC.MkProof
 import Mathlib.Tactic.CancelDenoms
 import Mathlib.Tactic.CancelDenoms.Core
+import Mathlib.Tactic.Cases
 import Mathlib.Tactic.CasesM
 import Mathlib.Tactic.CategoryTheory.BicategoricalComp
 import Mathlib.Tactic.CategoryTheory.Bicategory.Basic

--- a/Mathlib/Tactic.lean
+++ b/Mathlib/Tactic.lean
@@ -21,7 +21,6 @@ import Mathlib.Tactic.CC.Lemmas
 import Mathlib.Tactic.CC.MkProof
 import Mathlib.Tactic.CancelDenoms
 import Mathlib.Tactic.CancelDenoms.Core
-import Mathlib.Tactic.Cases
 import Mathlib.Tactic.CasesM
 import Mathlib.Tactic.CategoryTheory.BicategoricalComp
 import Mathlib.Tactic.CategoryTheory.Bicategory.Basic

--- a/Mathlib/Tactic/Common.lean
+++ b/Mathlib/Tactic/Common.lean
@@ -31,7 +31,6 @@ import Mathlib.Tactic.ApplyAt
 import Mathlib.Tactic.ApplyWith
 import Mathlib.Tactic.Basic
 import Mathlib.Tactic.ByContra
-import Mathlib.Tactic.Cases
 import Mathlib.Tactic.CasesM
 import Mathlib.Tactic.Check
 import Mathlib.Tactic.Choose

--- a/scripts/noshake.json
+++ b/scripts/noshake.json
@@ -69,7 +69,6 @@
   "Mathlib.Tactic.ByContra",
   "Mathlib.Tactic.CC",
   "Mathlib.Tactic.CancelDenoms",
-  "Mathlib.Tactic.Cases",
   "Mathlib.Tactic.CasesM",
   "Mathlib.Tactic.CategoryTheory.Coherence",
   "Mathlib.Tactic.CategoryTheory.Elementwise",


### PR DESCRIPTION
The second commit removes the `Mathlib.Tactic.Cases` imports from all mathlib files (except `Mathlib.Tactic`) to prove that `induction'` has been completely removed from the main body of mathlib.