### PR TITLE
[Merged by Bors] - chore(MeasureTheory): remove unnecessary argument in `CountableOrCountablyGenerated`

### DIFF
--- a/Mathlib/MeasureTheory/MeasurableSpace/CountablyGenerated.lean
+++ b/Mathlib/MeasureTheory/MeasurableSpace/CountablyGenerated.lean
@@ -512,18 +512,19 @@ lemma measurableSet_countablePartitionSet (n : ℕ) (a : α) :
 
 section CountableOrCountablyGenerated
 
-variable {α γ : Type*} [MeasurableSpace α] [MeasurableSpace β] [MeasurableSpace γ]
+variable {α γ : Type*} [MeasurableSpace γ]
 
 /-- A class registering that either `α` is countable or `β` is a countably generated
 measurable space. -/
-class CountableOrCountablyGenerated (α β : Type*) [MeasurableSpace α] [MeasurableSpace β] :
+class CountableOrCountablyGenerated (α β : Type*) [MeasurableSpace β] :
     Prop where
   countableOrCountablyGenerated : Countable α ∨ MeasurableSpace.CountablyGenerated β
 
-instance instCountableOrCountablyGeneratedOfCountable [h1 : Countable α] :
+instance instCountableOrCountablyGeneratedOfCountable [h1 : Countable α] [MeasurableSpace β] :
     CountableOrCountablyGenerated α β := ⟨Or.inl h1⟩
 
-instance instCountableOrCountablyGeneratedOfCountablyGenerated [h : CountablyGenerated β] :
+instance instCountableOrCountablyGeneratedOfCountablyGenerated [MeasurableSpace β]
+    [h : CountablyGenerated β] :
     CountableOrCountablyGenerated α β := ⟨Or.inr h⟩
 
 instance [hα : CountableOrCountablyGenerated α γ] [hβ : CountableOrCountablyGenerated β γ] :


### PR DESCRIPTION
This PR changes the definition of `CountableOrCountablyGenerated` to
```lean
class CountableOrCountablyGenerated (α β : Type*) [MeasurableSpace β] :
    Prop where
  countableOrCountablyGenerated : Countable α ∨ MeasurableSpace.CountablyGenerated β
```
That is, it removes a `[MeasurableSpace α]` argument from the definition. That argument is not necessary to state the property and I saw an example in which Lean could not infer it.

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include at least one commit authored by each
co-author among the commits in the pull request. If necessary, you may 
create empty commits to indicate co-authorship, using commands like so:

git commit --author="Author Name <author@email.com>" --allow-empty -m "add Author Name as coauthor"

When merging, all the commits will be squashed into a single commit listing all co-authors.

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
