### PR TITLE
[Merged by Bors] - chore: deprecate unused prereqs of the rw_search tactic

### DIFF
--- a/Mathlib.lean
+++ b/Mathlib.lean
@@ -3345,7 +3345,6 @@ import Mathlib.Data.List.TakeWhile
 import Mathlib.Data.List.ToFinsupp
 import Mathlib.Data.List.Triplewise
 import Mathlib.Data.List.Zip
-import Mathlib.Data.MLList.BestFirst
 import Mathlib.Data.Matrix.Action
 import Mathlib.Data.Matrix.Auto
 import Mathlib.Data.Matrix.Basic
@@ -4990,7 +4989,6 @@ import Mathlib.Order.Directed
 import Mathlib.Order.DirectedInverseSystem
 import Mathlib.Order.Disjoint
 import Mathlib.Order.Disjointed
-import Mathlib.Order.Estimator
 import Mathlib.Order.Extension.Linear
 import Mathlib.Order.Extension.Well
 import Mathlib.Order.Filter.AtTopBot.Archimedean

--- a/Mathlib.lean
+++ b/Mathlib.lean
@@ -3686,6 +3686,8 @@ import Mathlib.Data.ZMod.Units
 import Mathlib.Data.ZMod.ValMinAbs
 import Mathlib.Deprecated.Aliases
 import Mathlib.Deprecated.AnalyticManifold
+import Mathlib.Deprecated.Estimator
+import Mathlib.Deprecated.MLList.BestFirst
 import Mathlib.Deprecated.Order
 import Mathlib.Deprecated.RingHom
 import Mathlib.Dynamics.BirkhoffSum.Average

--- a/Mathlib/Deprecated/Estimator.lean
+++ b/Mathlib/Deprecated/Estimator.lean
@@ -12,6 +12,8 @@ import Mathlib.Lean.Thunk
 /-!
 # Improvable lower bounds.
 
+Note: this entire file is deprecated.
+
 The typeclass `Estimator a ε`, where `a : Thunk α` and `ε : Type`,
 states that `e : ε` carries the data of a lower bound for `a.get`,
 in the form `bound_le : bound a e ≤ a.get`,
@@ -53,6 +55,8 @@ Given `[Estimator a ε]`
 * `improve a e` returns none iff `bound a e = a.get`,
   and otherwise it returns a strictly better bound.
 -/
+@[deprecated "No replacement: this was only used \
+  in the implementation of the removed `rw_search` tactic." (since := "2025-09-11")]
 class Estimator [Preorder α] (a : Thunk α) (ε : Type*) extends EstimatorData a ε where
   /-- The calculated bounds are always lower bounds. -/
   bound_le e : bound e ≤ a.get
@@ -61,6 +65,10 @@ class Estimator [Preorder α] (a : Thunk α) (ε : Type*) extends EstimatorData 
   improve_spec e : match improve e with
     | none => bound e = a.get
     | some e' => bound e < bound e'
+
+-- Everything in this file is deprecated,
+-- but we'll just add the deprecation attribute to the main class.
+set_option linter.deprecated false
 
 open EstimatorData Set
 

--- a/Mathlib/Deprecated/MLList/BestFirst.lean
+++ b/Mathlib/Deprecated/MLList/BestFirst.lean
@@ -6,10 +6,12 @@ Authors: Kim Morrison
 import Batteries.Data.MLList.Basic
 import Mathlib.Data.Prod.Lex
 import Mathlib.Data.Set.Finite.Range
-import Mathlib.Order.Estimator
+import Mathlib.Deprecated.Estimator
 
 /-!
 # Best first search
+
+Note: this entire file is deprecated.
 
 We perform best first search of a tree or graph,
 where the neighbours of a vertex are provided by a lazy list `α → MLList m α`.
@@ -77,6 +79,8 @@ With this design, it is okay if we visit nodes with very large edit distances:
 while these would be expensive to compute, we never actually finish the computation
 except in cases where the node arrives at the front of the queue.
 -/
+
+set_option linter.deprecated false
 
 open Std (TreeMap TreeSet)
 
@@ -332,6 +336,8 @@ amongst unvisited neighbours of visited nodes.
 -/
 -- Although the core implementation lazily computes estimates of priorities,
 -- this version does not take advantage of those features.
+@[deprecated "No replacement: this was only used \
+  in the implementation of the removed `rw_search` tactic." (since := "2025-09-11")]
 def bestFirstSearch (f : α → MLList m α) (a : α)
     (maxQueued : Option Nat := none) (maxDepth : Option Nat := none) (removeDuplicates := true) :
     MLList m α :=

--- a/MathlibTest/search/BestFirst.lean
+++ b/MathlibTest/search/BestFirst.lean
@@ -1,4 +1,4 @@
-import Mathlib.Data.MLList.BestFirst
+import Mathlib.Deprecated.MLList.BestFirst
 import Mathlib.Data.Nat.Basic
 
 /-!
@@ -6,6 +6,8 @@ import Mathlib.Data.Nat.Basic
 
 We check that `bestFirstSearch` can find its way around a wall.
 -/
+
+set_option linter.deprecated false
 
 open Lean MLList Function
 


### PR DESCRIPTION
These probably should have been deprecated at the same time as #29196.