### PR TITLE
[Merged by Bors] - chore(CategoryTheory/Sites): move `PreOneHypercover.Homotopy` in new file

### DIFF
--- a/Mathlib.lean
+++ b/Mathlib.lean
@@ -2725,6 +2725,7 @@ import Mathlib.CategoryTheory.Sites.EqualizerSheafCondition
 import Mathlib.CategoryTheory.Sites.Equivalence
 import Mathlib.CategoryTheory.Sites.GlobalSections
 import Mathlib.CategoryTheory.Sites.Grothendieck
+import Mathlib.CategoryTheory.Sites.Hypercover.Homotopy
 import Mathlib.CategoryTheory.Sites.Hypercover.IsSheaf
 import Mathlib.CategoryTheory.Sites.Hypercover.One
 import Mathlib.CategoryTheory.Sites.Hypercover.Zero

--- a/Mathlib/CategoryTheory/Sites/Hypercover/Homotopy.lean
+++ b/Mathlib/CategoryTheory/Sites/Hypercover/Homotopy.lean
@@ -3,7 +3,6 @@ Copyright (c) 2025 Christian Merten. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Christian Merten
 -/
-import Mathlib.CategoryTheory.Quotient
 import Mathlib.CategoryTheory.Sites.Hypercover.One
 
 /-!

--- a/Mathlib/CategoryTheory/Sites/Hypercover/Homotopy.lean
+++ b/Mathlib/CategoryTheory/Sites/Hypercover/Homotopy.lean
@@ -1,0 +1,210 @@
+/-
+Copyright (c) 2025 Christian Merten. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Christian Merten
+-/
+import Mathlib.CategoryTheory.Quotient
+import Mathlib.CategoryTheory.Sites.Hypercover.One
+
+/-!
+# The category of `1`-hypercovers up to homotopy
+
+In this file we define the category of `1`-hypercovers up to homotopy. This is the category of
+`1`-hypercovers, but where morphisms are considered up to existence of a homotopy (TODO, Christian).
+
+## Main definitions
+
+- `CategoryTheory.PreOneHypercover.Homotopy`: A homotopy of refinements `E ⟶ F` is a family of
+  morphisms `Xᵢ ⟶ Yₐ` where `Yₐ` is a component of the cover of `X_{f(i)} ×[S] X_{g(i)}`.
+-/
+
+universe w'' w' w v u
+
+namespace CategoryTheory
+
+open Limits
+
+variable {C : Type u} [Category.{v} C]
+
+namespace PreOneHypercover
+
+variable {S : C} {E : PreOneHypercover.{w} S} {F : PreOneHypercover.{w'} S}
+
+/-- A homotopy of refinements `E ⟶ F` is a family of morphisms `Xᵢ ⟶ Yₐ` where
+`Yₐ` is a component of the cover of `X_{f(i)} ×[S] X_{g(i)}`. -/
+structure Homotopy (f g : E.Hom F) where
+  /-- The index map sending `i : E.I₀` to `a` above `(f(i), g(i))`. -/
+  H (i : E.I₀) : F.I₁ (f.s₀ i) (g.s₀ i)
+  /-- The morphism `Xᵢ ⟶ Yₐ`. -/
+  a (i : E.I₀) : E.X i ⟶ F.Y (H i)
+  wl (i : E.I₀) : a i ≫ F.p₁ (H i) = f.h₀ i
+  wr (i : E.I₀) : a i ≫ F.p₂ (H i) = g.h₀ i
+
+attribute [reassoc (attr := simp)] Homotopy.wl Homotopy.wr
+
+/-- Homotopic refinements induce the same map on multiequalizers. -/
+lemma Homotopy.mapMultiforkOfIsLimit_eq {A : Type*} [Category A]
+    {E F : PreOneHypercover.{w} S} {f g : E.Hom F} (H : Homotopy f g)
+    (P : Cᵒᵖ ⥤ A) {c : Multifork (E.multicospanIndex P)} (hc : IsLimit c)
+    (d : Multifork (F.multicospanIndex P)) :
+    f.mapMultiforkOfIsLimit P hc d = g.mapMultiforkOfIsLimit P hc d := by
+  refine Multifork.IsLimit.hom_ext hc fun a ↦ ?_
+  have heq := d.condition ⟨⟨(f.s₀ a), (g.s₀ a)⟩, H.H a⟩
+  simp only [multicospanIndex_right, multicospanShape_fst, multicospanIndex_left,
+    multicospanIndex_fst, multicospanShape_snd, multicospanIndex_snd] at heq
+  simp [-Homotopy.wl, -Homotopy.wr, ← H.wl, ← H.wr, reassoc_of% heq]
+
+variable [Limits.HasPullbacks C] (f g : E.Hom F)
+
+/-- (Implementation): The covering object of `cylinder f g`. -/
+noncomputable
+abbrev cylinderX {i : E.I₀} (k : F.I₁ (f.s₀ i) (g.s₀ i)) : C :=
+  pullback (pullback.lift (f.h₀ i) (g.h₀ i) (by simp)) (F.toPullback k)
+
+/-- (Implementation): The structure morphisms of the covering objects of `cylinder f g`. -/
+noncomputable
+abbrev cylinderf {i : E.I₀} (k : F.I₁ (f.s₀ i) (g.s₀ i)) : cylinderX f g k ⟶ S :=
+  pullback.fst _ _ ≫ E.f _
+
+/-- Given two refinement morphisms `f, g : E ⟶ F`, this is a (pre-)`1`-hypercover `W` that
+admits a morphism `h : W ⟶ E` such that `h ≫ f` and `h ≫ g` are homotopic. Hence
+they become equal after quotienting out by homotopy.
+This is a `1`-hypercover, if `E` and `F` are (see `OneHypercover.cylinder`). -/
+@[simps]
+noncomputable def cylinder (f g : E.Hom F) : PreOneHypercover.{max w w'} S where
+  I₀ := Σ (i : E.I₀), F.I₁ (f.s₀ i) (g.s₀ i)
+  X p := cylinderX f g p.2
+  f p := cylinderf f g p.2
+  I₁ p q := ULift.{max w w'} (E.I₁ p.1 q.1)
+  Y {p q} k :=
+    pullback
+      (pullback.map (cylinderf f g p.2)
+        (cylinderf f g q.2) _ _ (pullback.fst _ _) (pullback.fst _ _) (𝟙 S) (by simp)
+        (by simp))
+      (pullback.lift _ _ (E.w k.down))
+  p₁ {p q} k := pullback.fst _ _ ≫ pullback.fst _ _
+  p₂ {p q} k := pullback.fst _ _ ≫ pullback.snd _ _
+  w {_ _} k := by simp [pullback.condition]
+
+lemma toPullback_cylinder {i j : (cylinder f g).I₀} (k : (cylinder f g).I₁ i j) :
+    (cylinder f g).toPullback k = pullback.fst _ _ := by
+  apply pullback.hom_ext <;> simp [toPullback]
+
+lemma sieve₀_cylinder :
+    (cylinder f g).sieve₀ =
+      Sieve.generate
+        (Presieve.bindOfArrows _ E.f <| fun i ↦
+          (Sieve.pullback (pullback.lift (f.h₀ _) (g.h₀ _) (by simp))
+            (F.sieve₁' _ _)).arrows) := by
+  refine le_antisymm ?_ ?_
+  · rw [PreZeroHypercover.sieve₀, Sieve.generate_le_iff]
+    rintro - - ⟨i⟩
+    refine ⟨_, 𝟙 _, (cylinder f g).f _, ⟨_, _, ?_⟩, by simp⟩
+    simp only [Sieve.pullback_apply, pullback.condition]
+    exact Sieve.downward_closed _ (Sieve.ofArrows_mk _ _ _) _
+  · rw [Sieve.generate_le_iff, PreZeroHypercover.sieve₀]
+    rintro Z u ⟨i, v, ⟨W, o, o', ⟨j⟩, hoo'⟩⟩
+    exact ⟨_, pullback.lift v o hoo'.symm, (cylinder f g).f ⟨i, j⟩, Presieve.ofArrows.mk _,
+      by simp⟩
+
+lemma sieve₁'_cylinder (i j : Σ (i : E.I₀), F.I₁ (f.s₀ i) (g.s₀ i)) :
+    (cylinder f g).sieve₁' i j =
+      Sieve.pullback
+        (pullback.map _ _ _ _ (pullback.fst _ _) (pullback.fst _ _) (𝟙 S) (by simp) (by simp))
+        (E.sieve₁' i.1 j.1) := by
+  refine le_antisymm ?_ ?_
+  · rw [sieve₁', Sieve.ofArrows, Sieve.generate_le_iff]
+    rintro - - ⟨k⟩
+    refine ⟨E.Y k.down, pullback.snd _ _, E.toPullback k.down, Presieve.ofArrows.mk k.down, ?_⟩
+    simp only [cylinder_Y, cylinder_f, toPullback_cylinder, pullback.condition]
+  · rw [sieve₁', Sieve.ofArrows, ← Sieve.pullbackArrows_comm, Sieve.generate_le_iff]
+    rintro Z u ⟨W, v, ⟨k⟩⟩
+    simp_rw [← pullbackSymmetry_inv_comp_fst]
+    apply (((cylinder f g).sieve₁' i j)).downward_closed
+    rw [sieve₁']
+    convert Sieve.ofArrows_mk _ _ (ULift.up k)
+    simp [toPullback_cylinder f g ⟨k⟩]
+
+/-- (Implementation): The refinement morphism `cylinder f g ⟶ E`. -/
+@[simps]
+noncomputable def cylinderHom : (cylinder f g).Hom E where
+  s₀ p := p.1
+  s₁ k := k.down
+  h₀ p := pullback.fst _ _
+  h₁ {p q} k := pullback.snd _ _
+  w₁₁ k := by
+    have : E.p₁ k.down = pullback.lift _ _ (E.w k.down) ≫ pullback.fst _ _ := by simp
+    nth_rw 2 [this]
+    rw [← pullback.condition_assoc]
+    simp
+  w₁₂ {p q} k := by
+    have : E.p₂ k.down = pullback.lift _ _ (E.w k.down) ≫ pullback.snd _ _ := by simp
+    nth_rw 2 [this]
+    rw [← pullback.condition_assoc]
+    simp
+  w₀ := by simp
+
+/-- (Implementation): The homotopy of the morphisms `cylinder f g ⟶ E ⟶ F`. -/
+noncomputable def cylinderHomotopy :
+    Homotopy ((cylinderHom f g).comp f) ((cylinderHom f g).comp g) where
+  H p := p.2
+  a p := pullback.snd _ _
+  wl p := by
+    have : F.p₁ p.snd = pullback.lift _ _ (F.w p.2) ≫ pullback.fst _ _ := by simp
+    nth_rw 1 [this]
+    rw [← pullback.condition_assoc]
+    simp
+  wr p := by
+    have : g.h₀ p.fst = pullback.lift (f.h₀ p.fst) (g.h₀ p.fst) (by simp) ≫
+        pullback.snd (F.f _) (F.f _) := by simp
+    dsimp only [cylinder_X, Hom.comp_s₀, cylinder_I₀, Function.comp_apply, cylinderHom_s₀,
+      Hom.comp_h₀, cylinderHom_h₀]
+    nth_rw 3 [this]
+    rw [pullback.condition_assoc]
+    simp
+
+/-- Up to homotopy, the category of (pre-)`1`-hypercovers is cofiltered. -/
+lemma exists_nonempty_homotopy (f g : E.Hom F) :
+    ∃ (W : PreOneHypercover.{max w w'} S) (h : W.Hom E),
+      Nonempty (Homotopy (h.comp f) (h.comp g)) :=
+  ⟨cylinder f g, PreOneHypercover.cylinderHom f g, ⟨cylinderHomotopy f g⟩⟩
+
+end PreOneHypercover
+
+namespace GrothendieckTopology
+
+open PreOneHypercover OneHypercover
+
+variable {J : GrothendieckTopology C}
+
+namespace OneHypercover
+
+variable {S : C} {E : OneHypercover.{w} J S} {F : OneHypercover.{w'} J S}
+variable [HasPullbacks C]
+
+/-- Given two refinement morphism `f, g : E ⟶ F`, this is a `1`-hypercover `W` that
+admits a morphism `h : W ⟶ E` such that `h ≫ f` and `h ≫ g` are homotopic. Hence
+they become equal after quotienting out by homotopy. -/
+@[simps! toPreOneHypercover]
+noncomputable def cylinder (f g : E.Hom F) : J.OneHypercover S :=
+  mk' (PreOneHypercover.cylinder f g)
+    (by
+      rw [PreOneHypercover.sieve₀_cylinder]
+      refine J.bindOfArrows E.mem₀ fun i ↦ ?_
+      rw [Sieve.generate_sieve]
+      exact J.pullback_stable _ (mem_sieve₁' F _ _))
+    (fun i j ↦ by
+      rw [PreOneHypercover.sieve₁'_cylinder]
+      exact J.pullback_stable _ (mem_sieve₁' E _ _))
+
+/-- Up to homotopy, the category of `1`-hypercovers is cofiltered. -/
+lemma exists_nonempty_homotopy (f g : E.Hom F) :
+    ∃ (W : OneHypercover.{max w w'} J S) (h : W.Hom E),
+      Nonempty (PreOneHypercover.Homotopy (h.comp f) (h.comp g)) :=
+  ⟨cylinder f g, PreOneHypercover.cylinderHom f g, ⟨PreOneHypercover.cylinderHomotopy f g⟩⟩
+
+end OneHypercover
+
+end GrothendieckTopology
+
+end CategoryTheory

--- a/Mathlib/CategoryTheory/Sites/Hypercover/One.lean
+++ b/Mathlib/CategoryTheory/Sites/Hypercover/One.lean
@@ -179,18 +179,6 @@ def oneToZero : PreOneHypercover.{w} S ⥤ PreZeroHypercover.{w} S where
   obj f := f.1
   map f := f.1
 
-/-- A homotopy of refinements `E ⟶ F` is a family of morphisms `Xᵢ ⟶ Yₐ` where
-`Yₐ` is a component of the cover of `X_{f(i)} ×[S] X_{g(i)}`. -/
-structure Homotopy (f g : E.Hom F) where
-  /-- The index map sending `i : E.I₀` to `a` above `(f(i), g(i))`. -/
-  H (i : E.I₀) : F.I₁ (f.s₀ i) (g.s₀ i)
-  /-- The morphism `Xᵢ ⟶ Yₐ`. -/
-  a (i : E.I₀) : E.X i ⟶ F.Y (H i)
-  wl (i : E.I₀) : a i ≫ F.p₁ (H i) = f.h₀ i
-  wr (i : E.I₀) : a i ≫ F.p₂ (H i) = g.h₀ i
-
-attribute [reassoc (attr := simp)] Homotopy.wl Homotopy.wr
-
 /-- A refinement morphism `E ⟶ F` induces a morphism on associated multiequalizers. -/
 def Hom.mapMultiforkOfIsLimit (f : E.Hom F) (P : Cᵒᵖ ⥤ A) {c : Multifork (E.multicospanIndex P)}
     (hc : IsLimit c) (d : Multifork (F.multicospanIndex P)) :
@@ -211,133 +199,6 @@ lemma Hom.mapMultiforkOfIsLimit_ι {E F : PreOneHypercover.{w} S}
     (d : Multifork (F.multicospanIndex P)) (a : E.I₀) :
     f.mapMultiforkOfIsLimit P hc d ≫ c.ι a = d.ι (f.s₀ a) ≫ P.map (f.h₀ a).op := by
   simp [mapMultiforkOfIsLimit]
-
-/-- Homotopic refinements induce the same map on multiequalizers. -/
-lemma Homotopy.mapMultiforkOfIsLimit_eq {E F : PreOneHypercover.{w} S}
-    {f g : E.Hom F} (H : Homotopy f g)
-    (P : Cᵒᵖ ⥤ A) {c : Multifork (E.multicospanIndex P)} (hc : IsLimit c)
-    (d : Multifork (F.multicospanIndex P)) :
-    f.mapMultiforkOfIsLimit P hc d = g.mapMultiforkOfIsLimit P hc d := by
-  refine Multifork.IsLimit.hom_ext hc fun a ↦ ?_
-  have heq := d.condition ⟨⟨(f.s₀ a), (g.s₀ a)⟩, H.H a⟩
-  simp only [multicospanIndex_right, multicospanShape_fst, multicospanIndex_left,
-    multicospanIndex_fst, multicospanShape_snd, multicospanIndex_snd] at heq
-  simp [-Homotopy.wl, -Homotopy.wr, ← H.wl, ← H.wr, reassoc_of% heq]
-
-variable [Limits.HasPullbacks C] (f g : E.Hom F)
-
-/-- (Implementation): The covering object of `cylinder f g`. -/
-noncomputable
-abbrev cylinderX {i : E.I₀} (k : F.I₁ (f.s₀ i) (g.s₀ i)) : C :=
-  pullback (pullback.lift (f.h₀ i) (g.h₀ i) (by simp)) (F.toPullback k)
-
-/-- (Implementation): The structure morphisms of the covering objects of `cylinder f g`. -/
-noncomputable
-abbrev cylinderf {i : E.I₀} (k : F.I₁ (f.s₀ i) (g.s₀ i)) : cylinderX f g k ⟶ S :=
-  pullback.fst _ _ ≫ E.f _
-
-/-- Given two refinement morphisms `f, g : E ⟶ F`, this is a (pre-)`1`-hypercover `W` that
-admits a morphism `h : W ⟶ E` such that `h ≫ f` and `h ≫ g` are homotopic. Hence
-they become equal after quotienting out by homotopy.
-This is a `1`-hypercover, if `E` and `F` are (see `OneHypercover.cylinder`). -/
-@[simps]
-noncomputable def cylinder (f g : E.Hom F) : PreOneHypercover.{max w w'} S where
-  I₀ := Σ (i : E.I₀), F.I₁ (f.s₀ i) (g.s₀ i)
-  X p := cylinderX f g p.2
-  f p := cylinderf f g p.2
-  I₁ p q := ULift.{max w w'} (E.I₁ p.1 q.1)
-  Y {p q} k :=
-    pullback
-      (pullback.map (cylinderf f g p.2)
-        (cylinderf f g q.2) _ _ (pullback.fst _ _) (pullback.fst _ _) (𝟙 S) (by simp)
-        (by simp))
-      (pullback.lift _ _ (E.w k.down))
-  p₁ {p q} k := pullback.fst _ _ ≫ pullback.fst _ _
-  p₂ {p q} k := pullback.fst _ _ ≫ pullback.snd _ _
-  w {_ _} k := by simp [pullback.condition]
-
-lemma toPullback_cylinder {i j : (cylinder f g).I₀} (k : (cylinder f g).I₁ i j) :
-    (cylinder f g).toPullback k = pullback.fst _ _ := by
-  apply pullback.hom_ext <;> simp [toPullback]
-
-lemma sieve₀_cylinder :
-    (cylinder f g).sieve₀ =
-      Sieve.generate
-        (Presieve.bindOfArrows _ E.f <| fun i ↦
-          (Sieve.pullback (pullback.lift (f.h₀ _) (g.h₀ _) (by simp))
-            (F.sieve₁' _ _)).arrows) := by
-  refine le_antisymm ?_ ?_
-  · rw [PreZeroHypercover.sieve₀, Sieve.generate_le_iff]
-    rintro - - ⟨i⟩
-    refine ⟨_, 𝟙 _, (cylinder f g).f _, ⟨_, _, ?_⟩, by simp⟩
-    simp only [Sieve.pullback_apply, pullback.condition]
-    exact Sieve.downward_closed _ (Sieve.ofArrows_mk _ _ _) _
-  · rw [Sieve.generate_le_iff, PreZeroHypercover.sieve₀]
-    rintro Z u ⟨i, v, ⟨W, o, o', ⟨j⟩, hoo'⟩⟩
-    exact ⟨_, pullback.lift v o hoo'.symm, (cylinder f g).f ⟨i, j⟩, Presieve.ofArrows.mk _,
-      by simp⟩
-
-lemma sieve₁'_cylinder (i j : Σ (i : E.I₀), F.I₁ (f.s₀ i) (g.s₀ i)) :
-    (cylinder f g).sieve₁' i j =
-      Sieve.pullback
-        (pullback.map _ _ _ _ (pullback.fst _ _) (pullback.fst _ _) (𝟙 S) (by simp) (by simp))
-        (E.sieve₁' i.1 j.1) := by
-  refine le_antisymm ?_ ?_
-  · rw [sieve₁', Sieve.ofArrows, Sieve.generate_le_iff]
-    rintro - - ⟨k⟩
-    refine ⟨E.Y k.down, pullback.snd _ _, E.toPullback k.down, Presieve.ofArrows.mk k.down, ?_⟩
-    simp only [cylinder_Y, cylinder_f, toPullback_cylinder, pullback.condition]
-  · rw [sieve₁', Sieve.ofArrows, ← Sieve.pullbackArrows_comm, Sieve.generate_le_iff]
-    rintro Z u ⟨W, v, ⟨k⟩⟩
-    simp_rw [← pullbackSymmetry_inv_comp_fst]
-    apply (((cylinder f g).sieve₁' i j)).downward_closed
-    rw [sieve₁']
-    convert Sieve.ofArrows_mk _ _ (ULift.up k)
-    simp [toPullback_cylinder f g ⟨k⟩]
-
-/-- (Implementation): The refinement morphism `cylinder f g ⟶ E`. -/
-@[simps]
-noncomputable def cylinderHom : (cylinder f g).Hom E where
-  s₀ p := p.1
-  s₁ k := k.down
-  h₀ p := pullback.fst _ _
-  h₁ {p q} k := pullback.snd _ _
-  w₁₁ k := by
-    have : E.p₁ k.down = pullback.lift _ _ (E.w k.down) ≫ pullback.fst _ _ := by simp
-    nth_rw 2 [this]
-    rw [← pullback.condition_assoc]
-    simp
-  w₁₂ {p q} k := by
-    have : E.p₂ k.down = pullback.lift _ _ (E.w k.down) ≫ pullback.snd _ _ := by simp
-    nth_rw 2 [this]
-    rw [← pullback.condition_assoc]
-    simp
-  w₀ := by simp
-
-/-- (Implementation): The homotopy of the morphisms `cylinder f g ⟶ E ⟶ F`. -/
-noncomputable def cylinderHomotopy :
-    Homotopy ((cylinderHom f g).comp f) ((cylinderHom f g).comp g) where
-  H p := p.2
-  a p := pullback.snd _ _
-  wl p := by
-    have : F.p₁ p.snd = pullback.lift _ _ (F.w p.2) ≫ pullback.fst _ _ := by simp
-    nth_rw 1 [this]
-    rw [← pullback.condition_assoc]
-    simp
-  wr p := by
-    have : g.h₀ p.fst = pullback.lift (f.h₀ p.fst) (g.h₀ p.fst) (by simp) ≫
-        pullback.snd (F.f _) (F.f _) := by simp
-    dsimp only [cylinder_X, Hom.comp_s₀, cylinder_I₀, Function.comp_apply, cylinderHom_s₀,
-      Hom.comp_h₀, cylinderHom_h₀]
-    nth_rw 3 [this]
-    rw [pullback.condition_assoc]
-    simp
-
-/-- Up to homotopy, the category of (pre-)`1`-hypercovers is cofiltered. -/
-lemma exists_nonempty_homotopy (f g : E.Hom F) :
-    ∃ (W : PreOneHypercover.{max w w'} S) (h : W.Hom E),
-      Nonempty (Homotopy (h.comp f) (h.comp g)) :=
-  ⟨cylinder f g, PreOneHypercover.cylinderHom f g, ⟨cylinderHomotopy f g⟩⟩
 
 end Category
 
@@ -423,29 +284,6 @@ variable {S : C} {E : OneHypercover.{w} J S} {F : OneHypercover.{w'} J S}
 /-- A morphism of `1`-hypercovers is a morphism of the underlying pre-`1`-hypercovers. -/
 abbrev Hom (E : OneHypercover.{w} J S) (F : OneHypercover.{w'} J S) :=
   E.toPreOneHypercover.Hom F.toPreOneHypercover
-
-variable [HasPullbacks C]
-
-/-- Given two refinement morphism `f, g : E ⟶ F`, this is a `1`-hypercover `W` that
-admits a morphism `h : W ⟶ E` such that `h ≫ f` and `h ≫ g` are homotopic. Hence
-they become equal after quotienting out by homotopy. -/
-@[simps! toPreOneHypercover]
-noncomputable def cylinder (f g : E.Hom F) : J.OneHypercover S :=
-  mk' (PreOneHypercover.cylinder f g)
-    (by
-      rw [PreOneHypercover.sieve₀_cylinder]
-      refine J.bindOfArrows E.mem₀ fun i ↦ ?_
-      rw [Sieve.generate_sieve]
-      exact J.pullback_stable _ (mem_sieve₁' F _ _))
-    (fun i j ↦ by
-      rw [PreOneHypercover.sieve₁'_cylinder]
-      exact J.pullback_stable _ (mem_sieve₁' E _ _))
-
-/-- Up to homotopy, the category of `1`-hypercovers is cofiltered. -/
-lemma exists_nonempty_homotopy (f g : E.Hom F) :
-    ∃ (W : OneHypercover.{max w w'} J S) (h : W.Hom E),
-      Nonempty (PreOneHypercover.Homotopy (h.comp f) (h.comp g)) :=
-  ⟨cylinder f g, PreOneHypercover.cylinderHom f g, ⟨PreOneHypercover.cylinderHomotopy f g⟩⟩
 
 end Category
 


### PR DESCRIPTION
In preparation for more material. The module docstring is written in anticipation of #29551.

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include at least one commit authored by each
co-author among the commits in the pull request. If necessary, you may 
create empty commits to indicate co-authorship, using commands like so:

git commit --author="Author Name <author@email.com>" --allow-empty -m "add Author Name as coauthor"

When merging, all the commits will be squashed into a single commit listing all co-authors.

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
