### PR TITLE
[Merged by Bors] - feat(RingTheory/Ideal/IsOka): Add a variant for `Ideal.IsOka.forall_of_forall_prime`

### DIFF
--- a/Mathlib/RingTheory/Ideal/Oka.lean
+++ b/Mathlib/RingTheory/Ideal/Oka.lean
@@ -52,16 +52,18 @@ theorem isPrime_of_maximal_not {I : Ideal R} (hI : Maximal (¬P ·) I) : I.IsPri
       (fun H ↦ hb <| H ▸ mem_colon_singleton.2 (mul_comm a b ▸ hab))
     exact hI.prop (hP.oka h₁ h₂)
 
-/-- If all prime ideals of a ring satisfy an Oka predicate, then all its ideals also satisfy the
-predicate. `hmax` is generally obtained using Zorn's lemma. -/
+/-- If a ring `R` verify:
+1. All prime ideals of `R` satisfy an Oka predicate `P`.
+2. One ideal not satisfying `P` implies that there is an ideal maximal for not satisfying `P`.
+
+Then all the ideals of `R` satisfy `P`. -/
 theorem forall_of_forall_prime (hmax : ∀ I, ¬P I → ∃ I, Maximal (¬P ·) I)
-    (hprime : ∀ I, I.IsPrime → P I) : ∀ I, P I := by
-  by_contra!
-  obtain ⟨I, hI⟩ := this
+    (hprime : ∀ I, I.IsPrime → P I) (I : Ideal R) : P I := by
+  by_contra! hI
   obtain ⟨I, hI⟩ := hmax I hI
   exact hI.prop <| hprime I (hP.isPrime_of_maximal_not hI)
 
-/-- A variant of `forall_of_forall_prime` using a common technique to obtain `hmax`. -/
+/-- A variant of `forall_of_forall_prime` with a different spelling of the condition `hmax`. -/
 theorem forall_of_forall_prime'
     (hchain : ∀ C ⊆ {I | ¬P I}, IsChain (· ≤ ·) C → ∀ _ ∈ C, P (sSup C) → ∃ I ∈ C, P I)
     (hprime : ∀ I, I.IsPrime → P I) : ∀ I, P I := by

--- a/docs/references.bib
+++ b/docs/references.bib
@@ -766,9 +766,10 @@
   mrclass       = {13D45 (13-01)}
 }
 
-@Article{brown-1973,
+@Article{         brown-1973,
   author        = {Brown, Kenneth S.},
-  title         = {Abstract homotopy theory and generalized sheaf cohomology},
+  title         = {Abstract homotopy theory and generalized sheaf
+                  cohomology},
   journal       = {Trans. Amer. Math. Soc.},
   fjournal      = {Transactions of the American Mathematical Society},
   volume        = {186},
@@ -1017,6 +1018,23 @@
   keywords      = {17A30,17B60,18D50,55P65,81T15},
   zbmath        = {1618753},
   zbl           = {1053.17001}
+}
+
+@Article{         Chen_Glebov_2018,
+  author        = {Chen, Imin and Glebov, Gleb},
+  title         = {On {C}hudnovsky--{R}amanujan type formulae},
+  journal       = {Ramanujan J.},
+  fjournal      = {The Ramanujan Journal. An International Journal Devoted to
+                  the Areas of Mathematics Influenced by Ramanujan},
+  volume        = {46},
+  year          = {2018},
+  number        = {3},
+  pages         = {677--712},
+  issn          = {1382-4090},
+  mrclass       = {11F03 (11Y60 14H52 33C75)},
+  mrnumber      = {3830044},
+  doi           = {10.1007/s11139-017-9948-8},
+  url           = {https://doi.org/10.1007/s11139-017-9948-8}
 }
 
 @Misc{            chintala2020,
@@ -2899,7 +2917,7 @@
   year          = {1999}
 }
 
-@article{         lam_reyes_2009,
+@Article{         lam_reyes_2009,
   title         = {Oka and Ako ideal families in commutative rings},
   author        = {T. Y. Lam and Manuel L. Reyes},
   year          = {2009},
@@ -3172,10 +3190,21 @@
   url           = {https://doi.org/10.1007/978-3-642-76724-1}
 }
 
-@article{         Miller_1976,
+@Article{         Milla_2018,
+  author        = {Milla, Lorenz},
+  title         = {A detailed proof of the {C}hudnovsky formula with means of
+                  basic complex analysis},
+  year          = {2021},
+  eprint        = {1809.00533},
+  archiveprefix = {arXiv},
+  primaryclass  = {math.NT},
+  url           = {https://arxiv.org/abs/1809.00533}
+}
+
+@Article{         Miller_1976,
   title         = {Normal functions and constructive ordinal notations},
   volume        = {41},
-  DOI           = {10.2307/2272243},
+  doi           = {10.2307/2272243},
   number        = {2},
   journal       = {The Journal of Symbolic Logic},
   author        = {Miller, Larry W.},
@@ -4136,7 +4165,7 @@
   title         = {Stacks Project},
   author        = {The {Stacks Project Authors}},
   year          = {2018},
-  url           = {https://stacks.math.columbia.edu},
+  url           = {https://stacks.math.columbia.edu}
 }
 
 @Book{            stanley2012,
@@ -4580,32 +4609,4 @@
   author        = {Zwillinger, Daniel},
   year          = {2003},
   edition       = {31st ed.}
-}
-
-@Article{         Chen_Glebov_2018,
-  author        = {Chen, Imin and Glebov, Gleb},
-  title         = {On {C}hudnovsky--{R}amanujan type formulae},
-  journal       = {Ramanujan J.},
-  fjournal      = {The Ramanujan Journal. An International Journal Devoted to
-                  the Areas of Mathematics Influenced by Ramanujan},
-  volume        = {46},
-  year          = {2018},
-  number        = {3},
-  pages         = {677--712},
-  issn          = {1382-4090},
-  mrclass       = {11F03 (11Y60 14H52 33C75)},
-  mrnumber      = {3830044},
-  doi           = {10.1007/s11139-017-9948-8},
-  url           = {https://doi.org/10.1007/s11139-017-9948-8}
-}
-
-@Article{         Milla_2018,
-  author        = {Milla, Lorenz},
-  title         = {A detailed proof of the {C}hudnovsky formula with means of
-                  basic complex analysis},
-  year          = {2021},
-  eprint        = {1809.00533},
-  archiveprefix = {arXiv},
-  primaryclass  = {math.NT},
-  url           = {https://arxiv.org/abs/1809.00533}
 }


### PR DESCRIPTION
When reviewing #28451 and #28477, @kckennylau noticed that a common pattern to create the argument `hmax` of `Ideal.IsOka.forall_of_forall_prime`.

This PR factors out this common pattern inside `Ideal.IsOka.forall_of_forall_prime'`.

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include at least one commit authored by each
co-author among the commits in the pull request. If necessary, you may 
create empty commits to indicate co-authorship, using commands like so:

git commit --author="Author Name <author@email.com>" --allow-empty -m "add Author Name as coauthor"

When merging, all the commits will be squashed into a single commit listing all co-authors.

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
