### PR TITLE
fix: substitute infotrees in linters

### DIFF
--- a/Mathlib/Tactic/Linter/Style.lean
+++ b/Mathlib/Tactic/Linter/Style.lean
@@ -551,7 +551,7 @@ def showLinter : Linter where run := withSetOptionIn fun stx => do
       return
     if (← get).messages.hasErrors then
       return
-    for tree in (← getInfoTrees) do
+    for tree in (← getInfoState).substituteLazy.get.trees do
       tree.foldInfoM (init := ()) fun ci i _ => do
         let .ofTacticInfo tac := i | return
         unless tac.stx.isOfKind ``Lean.Parser.Tactic.show do return

--- a/Mathlib/Tactic/TacticAnalysis.lean
+++ b/Mathlib/Tactic/TacticAnalysis.lean
@@ -216,7 +216,7 @@ def tacticAnalysis : Linter where run := withSetOptionIn fun stx => do
     return
   let env ← getEnv
   let configs := (tacticAnalysisExt.getState env).2
-  let trees ← getInfoTrees
+  let trees := (← getInfoState).substituteLazy.get.trees
   runPasses configs stx trees
 
 initialize addLinter tacticAnalysis


### PR DESCRIPTION
I don't know whether this is necessary in these particular cases, but I've seen places where it is.

There are a handful more of these cases in Batteries.

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include at least one commit authored by each
co-author among the commits in the pull request. If necessary, you may 
create empty commits to indicate co-authorship, using commands like so:

git commit --author="Author Name <author@email.com>" --allow-empty -m "add Author Name as coauthor"

When merging, all the commits will be squashed into a single commit listing all co-authors.

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
