### PR TITLE
[Merged by Bors] - fix(lint-style): recognise a few more transitive imports of `Mathlib.Init` as such

### DIFF
--- a/Mathlib/Lean/Elab/Tactic/Meta.lean
+++ b/Mathlib/Lean/Elab/Tactic/Meta.lean
@@ -4,6 +4,9 @@ Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Kim Morrison
 -/
 import Lean.Elab.SyntheticMVars
+-- Import this linter explicitly to ensure that
+-- this file has a valid copyright header and module docstring.
+import Mathlib.Tactic.Linter.Header
 
 /-!
 # Additions to `Lean.Elab.Tactic.Meta`

--- a/Mathlib/Tactic/Linter/DirectoryDependency.lean
+++ b/Mathlib/Tactic/Linter/DirectoryDependency.lean
@@ -5,6 +5,7 @@ Authors: Anne Baanen
 -/
 import Lean.Elab.Command
 import Lean.Elab.ParseImportsFast
+-- This file is imported by the Header linter, hence has no mathlib imports.
 
 /-! # The `directoryDependency` linter
 

--- a/scripts/lint-style.lean
+++ b/scripts/lint-style.lean
@@ -104,6 +104,7 @@ def missingInitImports (opts : LinterOptions) : IO Nat := do
     -- These files are transitively imported by `Mathlib.Init`.
     |>.erase `Mathlib.Tactic.DeclarationNames
     |>.erase `Mathlib.Lean.ContextInfo
+    |>.erase `Mathlib.Tactic.Linter.DirectoryDependency
   if mismatch.size > 0 then
     IO.eprintln s!"error: the following {mismatch.size} module(s) import the `header` linter \
       directly, but should import Mathlib.Init instead: {mismatch}\n\

--- a/scripts/lint-style.lean
+++ b/scripts/lint-style.lean
@@ -101,8 +101,9 @@ def missingInitImports (opts : LinterOptions) : IO Nat := do
   let initImports ← findImports ("Mathlib" / "Init.lean")
   let mismatch := importsHeaderLinter.filter (fun mod ↦
     ![`Mathlib, `Mathlib.Tactic, `Mathlib.Init].contains mod && !initImports.contains mod)
-    -- This file is transitively imported by `Mathlib.Init`.
+    -- These files are transitively imported by `Mathlib.Init`.
     |>.erase `Mathlib.Tactic.DeclarationNames
+    |>.erase `Mathlib.Lean.ContextInfo
   if mismatch.size > 0 then
     IO.eprintln s!"error: the following {mismatch.size} module(s) import the `header` linter \
       directly, but should import Mathlib.Init instead: {mismatch}\n\

--- a/scripts/lint-style.lean
+++ b/scripts/lint-style.lean
@@ -103,6 +103,7 @@ def missingInitImports (opts : LinterOptions) : IO Nat := do
     ![`Mathlib, `Mathlib.Tactic, `Mathlib.Init].contains mod && !initImports.contains mod)
     -- These files are transitively imported by `Mathlib.Init`.
     |>.erase `Mathlib.Tactic.DeclarationNames
+    |>.erase `Mathlib.Lean.Elab.Tactic.Meta
     |>.erase `Mathlib.Lean.ContextInfo
     |>.erase `Mathlib.Tactic.Linter.DirectoryDependency
   if mismatch.size > 0 then


### PR DESCRIPTION
Uncovered by the fix of CI in #29513.

---

Commits can be reviewed independently.

<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include at least one commit authored by each
co-author among the commits in the pull request. If necessary, you may 
create empty commits to indicate co-authorship, using commands like so:

git commit --author="Author Name <author@email.com>" --allow-empty -m "add Author Name as coauthor"

When merging, all the commits will be squashed into a single commit listing all co-authors.

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
