### PR TITLE
feat(GroupTheory/Finiteness): define finitely generated semigroups

### DIFF
--- a/Mathlib/Algebra/Group/Submonoid/Defs.lean
+++ b/Mathlib/Algebra/Group/Submonoid/Defs.lean
@@ -150,6 +150,9 @@ instance : SubmonoidClass (Submonoid M) M where
 theorem mem_toSubsemigroup {s : Submonoid M} {x : M} : x ∈ s.toSubsemigroup ↔ x ∈ s :=
   Iff.rfl
 
+@[to_additive (attr := simp)]
+theorem coe_toSubsemigroup {s : Submonoid M} : (s.toSubsemigroup : Set M) = s := rfl
+
 @[to_additive]
 theorem mem_carrier {s : Submonoid M} {x : M} : x ∈ s.carrier ↔ x ∈ s :=
   Iff.rfl
@@ -164,6 +167,10 @@ theorem coe_set_mk {s : Subsemigroup M} (h_one) : (mk s h_one : Set M) = s :=
 
 @[to_additive (attr := simp)]
 theorem mk_le_mk {s t : Subsemigroup M} (h_one) (h_one') : mk s h_one ≤ mk t h_one' ↔ s ≤ t :=
+  Iff.rfl
+
+@[to_additive (attr := simp)]
+theorem toSubsemigroup_le {s t : Submonoid M} : s.toSubsemigroup ≤ t.toSubsemigroup ↔ s ≤ t :=
   Iff.rfl
 
 /-- Two submonoids are equal if they have the same elements. -/

--- a/Mathlib/GroupTheory/Finiteness.lean
+++ b/Mathlib/GroupTheory/Finiteness.lean
@@ -108,7 +108,7 @@ section Semigroup
 variable [Semigroup M]
 
 /-- An additive semigroup is finitely generated if it is finitely generated as an additive
-semigroup of itself. -/
+subsemigroup of itself. -/
 @[mk_iff]
 class AddSemigroup.FG (M : Type*) [AddSemigroup M] : Prop where
   fg_top : (⊤ : AddSubsemigroup M).FG

--- a/Mathlib/GroupTheory/Finiteness.lean
+++ b/Mathlib/GroupTheory/Finiteness.lean
@@ -10,13 +10,16 @@ import Mathlib.Algebra.Group.Subsemigroup.Operations
 import Mathlib.GroupTheory.QuotientGroup.Defs
 
 /-!
-# Finitely generated monoids and groups
+# Finitely generated semigroups, monoids and groups
 
-We define finitely generated monoids and groups. See also `Submodule.FG` and `Module.Finite` for
-finitely-generated modules.
+We define finitely generated semigroups, monoids and groups. See also `Submodule.FG`
+and `Module.Finite` for finitely-generated modules.
 
 ## Main definition
 
+* `Subsemigroup.FG S`, `AddSubsemigroup.FG S` : A subsemigroup `S` is finitely generated.
+* `Semigroup.FG M`, `AddSemigroup.FG M` : A typeclass indicating a type `M` is finitely generated
+  as a semigroup.
 * `Submonoid.FG S`, `AddSubmonoid.FG S` : A submonoid `S` is finitely generated.
 * `Monoid.FG M`, `AddMonoid.FG M` : A typeclass indicating a type `M` is finitely generated as a
   monoid.
@@ -104,14 +107,14 @@ section Semigroup
 
 variable [Semigroup M]
 
-/-- An additive monoid is finitely generated if it is finitely generated as an additive submonoid of
-itself. -/
+/-- An additive semigroup is finitely generated if it is finitely generated as an additive
+semigroup of itself. -/
 @[mk_iff]
 class AddSemigroup.FG (M : Type*) [AddSemigroup M] : Prop where
   fg_top : (⊤ : AddSubsemigroup M).FG
 
 variable (M) in
-/-- A monoid is finitely generated if it is finitely generated as a submonoid of itself. -/
+/-- A semigroup is finitely generated if it is finitely generated as a subsemigroup of itself. -/
 @[to_additive]
 class Semigroup.FG : Prop where
   fg_top : (⊤ : Subsemigroup M).FG
@@ -128,8 +131,8 @@ theorem Semigroup.fg_iff :
   ⟨fun _ => (Subsemigroup.fg_iff ⊤).1 FG.fg_top, fun h => ⟨(Subsemigroup.fg_iff ⊤).2 h⟩⟩
 
 variable (M) in
-/-- A finitely generated monoid has a minimal generating set. -/
-@[to_additive /-- A finitely generated monoid has a minimal generating set. -/]
+/-- A finitely generated semigroup has a minimal generating set. -/
+@[to_additive /-- A finitely generated semigroup has a minimal generating set. -/]
 lemma Subsemigroup.exists_minimal_closure_eq_top [Semigroup.FG M] :
     ∃ S : Finset M, Minimal (Subsemigroup.closure ·.toSet = ⊤) S :=
   Semigroup.FG.fg_top.exists_minimal_closure_eq
@@ -150,8 +153,6 @@ instance Semigroup.fg_of_addSemigroup_fg {M : Type*} [AddSemigroup M] [AddSemigr
     Semigroup.FG (Multiplicative M) :=
   AddSemigroup.fg_iff_mul_fg.1 ‹_›
 
--- This was previously a global instance,
--- but it doesn't appear to be used and has been implicated in slow typeclass resolutions.
 @[to_additive]
 lemma Semigroup.fg_of_finite [Finite M] : Semigroup.FG M := by
   cases nonempty_fintype M
@@ -242,8 +243,8 @@ theorem Submonoid.fg_iff_subsemigroup_fg (P : Submonoid M) : P.FG ↔ P.toSubsem
   constructor
   · rintro ⟨S, rfl⟩
     rw [Subsemigroup.fg_iff]
-    let Q : Submonoid M := ⟨Subsemigroup.closure (S ∪ {1}),
-      Subsemigroup.mem_closure_of_mem <| Set.mem_union_right _ rfl⟩
+    let Q : Submonoid M :=
+      ⟨Subsemigroup.closure (S ∪ {1}), Subsemigroup.mem_closure_of_mem <| Set.mem_union_right _ rfl⟩
     refine ⟨S ∪ {1}, le_antisymm ?_ ?_, S.finite_toSet.union (Set.finite_singleton 1)⟩
     · apply Subsemigroup.closure_le.mpr <| Set.union_subset subset_closure (by simp)
     · change Submonoid.closure S ≤ Q
@@ -662,17 +663,17 @@ end Group
 section Quotient
 
 @[to_additive]
-instance Con.semigroup_fg {M : Type*} [Semigroup M] [Semigroup.FG M] {c : Con M}
-    : Semigroup.FG c.Quotient :=
+instance Con.semigroup_fg {M : Type*} [Semigroup M] [Semigroup.FG M] {c : Con M} :
+    Semigroup.FG c.Quotient :=
   Semigroup.fg_of_surjective c.mkMulHom Quotient.mk''_surjective
 
 @[to_additive]
-instance Con.monoid_fg {M : Type*} [Monoid M] [Monoid.FG M] {c : Con M}
-    : Monoid.FG c.Quotient :=
+instance Con.monoid_fg {M : Type*} [Monoid M] [Monoid.FG M] {c : Con M} : Monoid.FG c.Quotient :=
   Monoid.fg_of_surjective c.mk' c.mk'_surjective
 
 @[to_additive]
-instance QuotientGroup.fg {G : Type*} [Group G] [Group.FG G] (N : Subgroup G) [Subgroup.Normal N] : Group.FG <| G ⧸ N :=
+instance QuotientGroup.fg {G : Type*} [Group G] [Group.FG G] (N : Subgroup G)
+    [Subgroup.Normal N] : Group.FG <| G ⧸ N :=
   Group.fg_of_surjective <| QuotientGroup.mk'_surjective N
 
 end Quotient


### PR DESCRIPTION
We define finitely generated semigroups and basics similarly to monoids and groups and prove that semigroups and monoids remain finitely generated when a congruence is quotiented out. This will be important when further developing semigroup theory.

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include at least one commit authored by each
co-author among the commits in the pull request. If necessary, you may 
create empty commits to indicate co-authorship, using commands like so:

git commit --author="Author Name <author@email.com>" --allow-empty -m "add Author Name as coauthor"

When merging, all the commits will be squashed into a single commit listing all co-authors.

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
