### PR TITLE
[Merged by Bors] - feat(RingTheory): summability lemma for (Mv)PowerSeries

### DIFF
--- a/Mathlib/RingTheory/MvPowerSeries/PiTopology.lean
+++ b/Mathlib/RingTheory/MvPowerSeries/PiTopology.lean
@@ -274,7 +274,7 @@ variable [LinearOrder ι] [LocallyFiniteOrderBot ι]
 /-- A family of `MvPowerSeries` is summable if their weighted order tends to infinity. -/
 theorem summable_of_tendsto_weightedOrder_atTop_nhds_top {w : σ → ℕ}
     (h : Tendsto (fun i ↦ weightedOrder w (f i)) atTop (𝓝 ⊤)) : Summable f := by
-  obtain hempty | hempty := isEmpty_or_nonempty ι
+  rcases isEmpty_or_nonempty ι with hempty | hempty
   · apply summable_empty
   rw [summable_iff_summable_coeff]
   simp_rw [ENat.tendsto_nhds_top_iff_natCast_lt, Filter.eventually_atTop] at h

--- a/Mathlib/RingTheory/MvPowerSeries/PiTopology.lean
+++ b/Mathlib/RingTheory/MvPowerSeries/PiTopology.lean
@@ -4,11 +4,13 @@ Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Antoine Chambert-Loir, María Inés de Frutos-Fernández
 -/
 import Mathlib.RingTheory.MvPowerSeries.Basic
+import Mathlib.RingTheory.MvPowerSeries.Order
 import Mathlib.RingTheory.MvPowerSeries.Trunc
 import Mathlib.RingTheory.Nilpotent.Defs
 import Mathlib.Topology.Algebra.InfiniteSum.Constructions
 import Mathlib.Topology.Algebra.Ring.Basic
 import Mathlib.Topology.Algebra.IsUniformGroup.Basic
+import Mathlib.Topology.Instances.ENat
 import Mathlib.Topology.UniformSpace.Pi
 import Mathlib.Topology.Algebra.TopologicallyNilpotent
 
@@ -248,6 +250,48 @@ theorem hasSum_of_monomials_self (f : MvPowerSeries σ R) :
 theorem as_tsum [T2Space R] (f : MvPowerSeries σ R) :
     f = tsum fun d : σ →₀ ℕ => monomial d (coeff d f) :=
   (HasSum.tsum_eq (hasSum_of_monomials_self _)).symm
+
+section Sum
+variable {ι : Type*} {f : ι → MvPowerSeries σ R}
+
+theorem hasSum_iff_hasSum_coeff {g : MvPowerSeries σ R} :
+    HasSum f g ↔ ∀ d : σ →₀ ℕ, HasSum (fun i ↦ coeff d (f i)) (coeff d g) := by
+  simp_rw [HasSum, ← map_sum]
+  apply tendsto_iff_coeff_tendsto
+
+theorem summable_iff_summable_coeff :
+    Summable f ↔ ∀ d : σ →₀ ℕ, Summable (fun i ↦ coeff d (f i)) := by
+  simp_rw [Summable, hasSum_iff_hasSum_coeff]
+  constructor
+  · rintro ⟨a, h⟩ n
+    exact ⟨coeff n a, h n⟩
+  · intro h
+    choose a h using h
+    exact ⟨a, by simpa using h⟩
+
+variable [LinearOrder ι] [LocallyFiniteOrderBot ι]
+
+/-- A family of `MvPowerSeries` is summable if their weighted order tends to infinity. -/
+theorem summable_of_tendsto_weightedOrder_atTop_nhds_top {w : σ → ℕ}
+    (h : Tendsto (fun i ↦ weightedOrder w (f i)) atTop (𝓝 ⊤)) : Summable f := by
+  obtain hempty | hempty := isEmpty_or_nonempty ι
+  · apply summable_empty
+  rw [summable_iff_summable_coeff]
+  simp_rw [ENat.tendsto_nhds_top_iff_natCast_lt, Filter.eventually_atTop] at h
+  intro d
+  obtain ⟨i, hi⟩ := h (Finsupp.weight w d)
+  refine summable_of_finite_support <| (Set.finite_Iic i).subset ?_
+  simp_rw [Function.support_subset_iff, Set.mem_Iic]
+  intro k hk
+  contrapose! hk
+  exact coeff_eq_zero_of_lt_weightedOrder w <| hi k hk.le
+
+/-- A family of `MvPowerSeries` is summable if their order tends to infinity. -/
+theorem summable_of_tendsto_order_atTop_nhds_top
+    (h : Tendsto (fun i ↦ (f i).order) atTop (𝓝 ⊤)) : Summable f :=
+  summable_of_tendsto_weightedOrder_atTop_nhds_top h
+
+end Sum
 
 end Topology
 

--- a/Mathlib/RingTheory/PowerSeries/PiTopology.lean
+++ b/Mathlib/RingTheory/PowerSeries/PiTopology.lean
@@ -143,7 +143,7 @@ theorem summable_iff_summable_coeff :
 /-- A family of `PowerSeries` is summable if their order tends to infinity. -/
 theorem summable_of_tendsto_order_atTop_nhds_top [LinearOrder ι] [LocallyFiniteOrderBot ι]
     (h : Tendsto (fun i ↦ (f i).order) atTop (𝓝 ⊤)) : Summable f := by
-  obtain hempty | hempty := isEmpty_or_nonempty ι
+  rcases isEmpty_or_nonempty ι with hempty | hempty
   · apply summable_empty
   rw [summable_iff_summable_coeff]
   intro n

--- a/Mathlib/RingTheory/PowerSeries/PiTopology.lean
+++ b/Mathlib/RingTheory/PowerSeries/PiTopology.lean
@@ -5,6 +5,7 @@ Authors: Antoine Chambert-Loir, María Inés de Frutos-Fernández
 -/
 import Mathlib.RingTheory.MvPowerSeries.PiTopology
 import Mathlib.RingTheory.PowerSeries.Basic
+import Mathlib.RingTheory.PowerSeries.Order
 import Mathlib.RingTheory.PowerSeries.Trunc
 import Mathlib.LinearAlgebra.Finsupp.Pi
 
@@ -120,6 +121,41 @@ theorem instIsTopologicalSemiring [Semiring R] [IsTopologicalSemiring R] :
 theorem instIsTopologicalRing [Ring R] [IsTopologicalRing R] :
     IsTopologicalRing (PowerSeries R) :=
   MvPowerSeries.WithPiTopology.instIsTopologicalRing Unit R
+
+section Sum
+variable [Semiring R] {ι : Type*} {f : ι → R⟦X⟧}
+
+theorem hasSum_iff_hasSum_coeff {g : R⟦X⟧} :
+    HasSum f g ↔ ∀ d, HasSum (fun i ↦ coeff d (f i)) (coeff d g) := by
+  simp_rw [HasSum, ← map_sum]
+  apply tendsto_iff_coeff_tendsto
+
+theorem summable_iff_summable_coeff :
+    Summable f ↔ ∀ d : ℕ, Summable (fun i ↦ coeff d (f i)) := by
+  simp_rw [Summable, hasSum_iff_hasSum_coeff]
+  constructor
+  · rintro ⟨a, h⟩ n
+    exact ⟨coeff n a, h n⟩
+  · intro h
+    choose a h using h
+    exact ⟨mk a, by simpa using h⟩
+
+/-- A family of `PowerSeries` is summable if their order tends to infinity. -/
+theorem summable_of_tendsto_order_atTop_nhds_top [LinearOrder ι] [LocallyFiniteOrderBot ι]
+    (h : Tendsto (fun i ↦ (f i).order) atTop (𝓝 ⊤)) : Summable f := by
+  obtain hempty | hempty := isEmpty_or_nonempty ι
+  · apply summable_empty
+  rw [summable_iff_summable_coeff]
+  intro n
+  simp_rw [ENat.tendsto_nhds_top_iff_natCast_lt, Filter.eventually_atTop] at h
+  obtain ⟨i, hi⟩ := h n
+  refine summable_of_finite_support <| (Set.finite_Iic i).subset ?_
+  simp_rw [Function.support_subset_iff, Set.mem_Iic]
+  intro k hk
+  contrapose! hk
+  exact coeff_of_lt_order _ <| by simpa using (hi k hk.le)
+
+end Sum
 
 end WithPiTopology
 


### PR DESCRIPTION
About `PowerSeries.summable_of_tendsto_weightedOrder_atTop_nhds_top`, it surprised me that `PowerSeries.order` isn't implemented using `MvPowerSeries.order`, so I had to duplicate the proof for `MvPowerSeries` and `PowerSeries`. The other lemmas are also duplication instead of reusing the same proof, because it turned out piercing through defeq actually makes the code longer.

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include at least one commit authored by each
co-author among the commits in the pull request. If necessary, you may 
create empty commits to indicate co-authorship, using commands like so:

git commit --author="Author Name <author@email.com>" --allow-empty -m "add Author Name as coauthor"

When merging, all the commits will be squashed into a single commit listing all co-authors.

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
