### PR TITLE
[Merged by Bors] - chore(Probability): rename IsFiniteKernel.bound to Kernel.bound

### DIFF
--- a/Mathlib/Probability/Kernel/Basic.lean
+++ b/Mathlib/Probability/Kernel/Basic.lean
@@ -272,7 +272,7 @@ theorem setLIntegral_restrict (κ : Kernel α β) (hs : MeasurableSet s) (a : α
 
 instance IsFiniteKernel.restrict (κ : Kernel α β) [IsFiniteKernel κ] (hs : MeasurableSet s) :
     IsFiniteKernel (κ.restrict hs) := by
-  refine ⟨⟨IsFiniteKernel.bound κ, IsFiniteKernel.bound_lt_top κ, fun a => ?_⟩⟩
+  refine ⟨⟨κ.bound, κ.bound_lt_top, fun a => ?_⟩⟩
   rw [restrict_apply' κ hs a MeasurableSet.univ]
   exact measure_le_bound κ a _
 
@@ -323,7 +323,7 @@ theorem IsMarkovKernel.comapRight (κ : Kernel α β) (hf : MeasurableEmbedding 
 
 instance IsFiniteKernel.comapRight (κ : Kernel α β) [IsFiniteKernel κ]
     (hf : MeasurableEmbedding f) : IsFiniteKernel (comapRight κ hf) := by
-  refine ⟨⟨IsFiniteKernel.bound κ, IsFiniteKernel.bound_lt_top κ, fun a => ?_⟩⟩
+  refine ⟨⟨κ.bound, κ.bound_lt_top, fun a => ?_⟩⟩
   rw [comapRight_apply' κ hf a .univ]
   exact measure_le_bound κ a _
 
@@ -369,8 +369,7 @@ instance IsMarkovKernel.piecewise [IsMarkovKernel κ] [IsMarkovKernel η] :
 
 instance IsFiniteKernel.piecewise [IsFiniteKernel κ] [IsFiniteKernel η] :
     IsFiniteKernel (piecewise hs κ η) := by
-  refine ⟨⟨max (IsFiniteKernel.bound κ) (IsFiniteKernel.bound η), ?_, fun a => ?_⟩⟩
-  · exact max_lt (IsFiniteKernel.bound_lt_top κ) (IsFiniteKernel.bound_lt_top η)
+  refine ⟨⟨max κ.bound η.bound, max_lt κ.bound_lt_top η.bound_lt_top, fun a => ?_⟩⟩
   rw [piecewise_apply']
   exact (ite_le_sup _ _ _).trans (sup_le_sup (measure_le_bound _ _ _) (measure_le_bound _ _ _))
 

--- a/Mathlib/Probability/Kernel/Composition/Comp.lean
+++ b/Mathlib/Probability/Kernel/Composition/Comp.lean
@@ -56,9 +56,9 @@ theorem comp_apply' (η : Kernel β γ) (κ : Kernel α β) (a : α) {s : Set γ
   rw [comp_apply, Measure.bind_apply hs (Kernel.aemeasurable _)]
 
 theorem comp_apply_univ_le (κ : Kernel α β) (η : Kernel β γ) (a : α) :
-    (η ∘ₖ κ) a Set.univ ≤ κ a Set.univ * IsFiniteKernel.bound η := by
+    (η ∘ₖ κ) a Set.univ ≤ κ a Set.univ * η.bound := by
   rw [comp_apply' _ _ _ .univ]
-  let Cη := IsFiniteKernel.bound η
+  let Cη := η.bound
   calc
     ∫⁻ b, η b Set.univ ∂κ a ≤ ∫⁻ _, Cη ∂κ a :=
       lintegral_mono fun b => measure_le_bound η b Set.univ
@@ -196,13 +196,10 @@ instance IsZeroOrMarkovKernel.comp (κ : Kernel α β) [IsZeroOrMarkovKernel κ]
 
 instance IsFiniteKernel.comp (η : Kernel β γ) [IsFiniteKernel η] (κ : Kernel α β)
     [IsFiniteKernel κ] : IsFiniteKernel (η ∘ₖ κ) := by
-  refine ⟨⟨IsFiniteKernel.bound κ * IsFiniteKernel.bound η,
-    ENNReal.mul_lt_top (IsFiniteKernel.bound_lt_top κ) (IsFiniteKernel.bound_lt_top η),
-    fun a ↦ ?_⟩⟩
+  refine ⟨⟨κ.bound * η.bound, ENNReal.mul_lt_top κ.bound_lt_top η.bound_lt_top, fun a ↦ ?_⟩⟩
   calc (η ∘ₖ κ) a Set.univ
-  _ ≤ κ a Set.univ * IsFiniteKernel.bound η := comp_apply_univ_le κ η a
-  _ ≤ IsFiniteKernel.bound κ * IsFiniteKernel.bound η :=
-    mul_le_mul (measure_le_bound κ a Set.univ) le_rfl (zero_le _) (zero_le _)
+  _ ≤ κ a Set.univ * η.bound := comp_apply_univ_le κ η a
+  _ ≤ κ.bound * η.bound := mul_le_mul (measure_le_bound κ a Set.univ) le_rfl zero_le' zero_le'
 
 instance IsSFiniteKernel.comp (η : Kernel β γ) [IsSFiniteKernel η] (κ : Kernel α β)
     [IsSFiniteKernel κ] : IsSFiniteKernel (η ∘ₖ κ) := by

--- a/Mathlib/Probability/Kernel/Composition/CompProd.lean
+++ b/Mathlib/Probability/Kernel/Composition/CompProd.lean
@@ -524,13 +524,13 @@ instance IsZeroOrMarkovKernel.compProd (κ : Kernel α β) [IsZeroOrMarkovKernel
   all_goals simpa using by infer_instance
 
 theorem compProd_apply_univ_le (κ : Kernel α β) (η : Kernel (α × β) γ) [IsFiniteKernel η] (a : α) :
-    (κ ⊗ₖ η) a Set.univ ≤ κ a Set.univ * IsFiniteKernel.bound η := by
+    (κ ⊗ₖ η) a Set.univ ≤ κ a Set.univ * η.bound := by
   by_cases hκ : IsSFiniteKernel κ
   swap
   · rw [compProd_of_not_isSFiniteKernel_left _ _ hκ]
     simp
   rw [compProd_apply .univ]
-  let Cη := IsFiniteKernel.bound η
+  let Cη := η.bound
   calc
     ∫⁻ b, η (a, b) Set.univ ∂κ a ≤ ∫⁻ _, Cη ∂κ a :=
       lintegral_mono fun b => measure_le_bound η (a, b) Set.univ
@@ -539,12 +539,9 @@ theorem compProd_apply_univ_le (κ : Kernel α β) (η : Kernel (α × β) γ) [
 
 instance IsFiniteKernel.compProd (κ : Kernel α β) [IsFiniteKernel κ] (η : Kernel (α × β) γ)
     [IsFiniteKernel η] : IsFiniteKernel (κ ⊗ₖ η) :=
-  ⟨⟨IsFiniteKernel.bound κ * IsFiniteKernel.bound η,
-      ENNReal.mul_lt_top (IsFiniteKernel.bound_lt_top κ) (IsFiniteKernel.bound_lt_top η), fun a =>
-      calc
-        (κ ⊗ₖ η) a Set.univ ≤ κ a Set.univ * IsFiniteKernel.bound η := compProd_apply_univ_le κ η a
-        _ ≤ IsFiniteKernel.bound κ * IsFiniteKernel.bound η :=
-          mul_le_mul (measure_le_bound κ a Set.univ) le_rfl (zero_le _) (zero_le _)⟩⟩
+  ⟨⟨κ.bound * η.bound, ENNReal.mul_lt_top κ.bound_lt_top η.bound_lt_top, fun a =>
+      calc (κ ⊗ₖ η) a Set.univ ≤ κ a Set.univ * η.bound := compProd_apply_univ_le κ η a
+      _ ≤ κ.bound * η.bound := mul_le_mul (measure_le_bound κ a Set.univ) le_rfl zero_le' zero_le'⟩⟩
 
 instance IsSFiniteKernel.compProd (κ : Kernel α β) (η : Kernel (α × β) γ) :
     IsSFiniteKernel (κ ⊗ₖ η) := by

--- a/Mathlib/Probability/Kernel/Composition/MapComap.lean
+++ b/Mathlib/Probability/Kernel/Composition/MapComap.lean
@@ -125,7 +125,7 @@ instance IsZeroOrMarkovKernel.map (κ : Kernel α β) [IsZeroOrMarkovKernel κ] 
 
 instance IsFiniteKernel.map (κ : Kernel α β) [IsFiniteKernel κ] (f : β → γ) :
     IsFiniteKernel (map κ f) := by
-  refine ⟨⟨IsFiniteKernel.bound κ, IsFiniteKernel.bound_lt_top κ, fun a => ?_⟩⟩
+  refine ⟨⟨κ.bound, κ.bound_lt_top, fun a => ?_⟩⟩
   by_cases hf : Measurable f
   · rw [map_apply' κ hf a MeasurableSet.univ]
     exact measure_le_bound κ a _
@@ -192,7 +192,7 @@ instance IsZeroOrMarkovKernel.comap (κ : Kernel α β) [IsZeroOrMarkovKernel κ
 
 instance IsFiniteKernel.comap (κ : Kernel α β) [IsFiniteKernel κ] (hg : Measurable g) :
     IsFiniteKernel (comap κ g hg) := by
-  refine ⟨⟨IsFiniteKernel.bound κ, IsFiniteKernel.bound_lt_top κ, fun a => ?_⟩⟩
+  refine ⟨⟨κ.bound, κ.bound_lt_top, fun a => ?_⟩⟩
   rw [comap_apply' κ hg a Set.univ]
   exact measure_le_bound κ _ _
 
@@ -437,7 +437,7 @@ instance IsSFiniteKernel.fst (κ : Kernel α (β × γ)) [IsSFiniteKernel κ] :
 instance (priority := 100) isFiniteKernel_of_isFiniteKernel_fst {κ : Kernel α (β × γ)}
     [h : IsFiniteKernel (fst κ)] :
     IsFiniteKernel κ := by
-  refine ⟨IsFiniteKernel.bound (fst κ), h.bound_lt_top,
+  refine ⟨(fst κ).bound, (fst κ).bound_lt_top,
     fun a ↦ le_trans ?_ (measure_le_bound (fst κ) a Set.univ)⟩
   rw [fst_apply' _ _ MeasurableSet.univ]
   simp
@@ -499,7 +499,7 @@ instance IsSFiniteKernel.snd (κ : Kernel α (β × γ)) [IsSFiniteKernel κ] :
 instance (priority := 100) isFiniteKernel_of_isFiniteKernel_snd {κ : Kernel α (β × γ)}
     [h : IsFiniteKernel (snd κ)] :
     IsFiniteKernel κ := by
-  refine ⟨IsFiniteKernel.bound (snd κ), h.bound_lt_top,
+  refine ⟨(snd κ).bound, (snd κ).bound_lt_top,
     fun a ↦ le_trans ?_ (measure_le_bound (snd κ) a Set.univ)⟩
   rw [snd_apply' _ _ MeasurableSet.univ]
   simp

--- a/Mathlib/Probability/Kernel/Composition/ParallelComp.lean
+++ b/Mathlib/Probability/Kernel/Composition/ParallelComp.lean
@@ -130,12 +130,10 @@ instance [IsZeroOrMarkovKernel κ] [IsZeroOrMarkovKernel η] : IsZeroOrMarkovKer
   all_goals simpa using by infer_instance
 
 instance [IsFiniteKernel κ] [IsFiniteKernel η] : IsFiniteKernel (κ ∥ₖ η) := by
-  refine ⟨⟨IsFiniteKernel.bound κ * IsFiniteKernel.bound η,
-    ENNReal.mul_lt_top (IsFiniteKernel.bound_lt_top κ) (IsFiniteKernel.bound_lt_top η),
-    fun a ↦ ?_⟩⟩
+  refine ⟨⟨κ.bound * η.bound, ENNReal.mul_lt_top κ.bound_lt_top η.bound_lt_top, fun a ↦ ?_⟩⟩
   calc (κ ∥ₖ η) a Set.univ
   _ = κ a.1 Set.univ * η a.2 Set.univ := parallelComp_apply_univ
-  _ ≤ IsFiniteKernel.bound κ * IsFiniteKernel.bound η := by
+  _ ≤ κ.bound * η.bound := by
     gcongr
     · exact measure_le_bound κ a.1 Set.univ
     · exact measure_le_bound η a.2 Set.univ

--- a/Mathlib/Probability/Kernel/Defs.lean
+++ b/Mathlib/Probability/Kernel/Defs.lean
@@ -153,34 +153,53 @@ theorem eq_zero_or_isMarkovKernel
 /-- A constant `C : ℝ≥0∞` such that `C < ∞` for a finite kernel
 (`ProbabilityTheory.IsFiniteKernel.bound_lt_top κ`) and for all `a : α` and `s : Set β`,
 `κ a s ≤ C` (`ProbabilityTheory.Kernel.measure_le_bound κ a s`). -/
-noncomputable def IsFiniteKernel.bound (κ : Kernel α β) : ℝ≥0∞ :=
+noncomputable def Kernel.bound (κ : Kernel α β) : ℝ≥0∞ :=
   ⨆ a, κ a Set.univ
 
-theorem IsFiniteKernel.bound_lt_top (κ : Kernel α β) [h : IsFiniteKernel κ] :
-    IsFiniteKernel.bound κ < ∞ := by
+@[deprecated (since := "2025-09-13")] alias IsFiniteKernel.bound := Kernel.bound
+
+namespace Kernel
+
+theorem bound_lt_top (κ : Kernel α β) [h : IsFiniteKernel κ] : κ.bound < ∞ := by
   obtain ⟨C, hC, hle⟩ := h.exists_univ_le
   refine lt_of_le_of_lt ?_ hC
   simp [bound, hle]
 
-theorem IsFiniteKernel.bound_ne_top (κ : Kernel α β) [IsFiniteKernel κ] :
-    IsFiniteKernel.bound κ ≠ ∞ :=
-  (IsFiniteKernel.bound_lt_top κ).ne
+@[deprecated (since := "2025-09-13")] alias _root_.ProbabilityTheory.IsFiniteKernel.bound_lt_top :=
+  bound_lt_top
 
-theorem Kernel.measure_le_bound (κ : Kernel α β) (a : α) (s : Set β) :
-    κ a s ≤ IsFiniteKernel.bound κ :=
+theorem bound_ne_top (κ : Kernel α β) [IsFiniteKernel κ] :
+    κ.bound ≠ ∞ := κ.bound_lt_top.ne
+
+@[deprecated (since := "2025-09-13")] alias _root_.ProbabilityTheory.IsFiniteKernel.bound_ne_top :=
+  bound_ne_top
+
+theorem measure_le_bound (κ : Kernel α β) (a : α) (s : Set β) :
+    κ a s ≤ κ.bound :=
   (measure_mono (Set.subset_univ s)).trans <| le_iSup (f := fun a ↦ κ a .univ) a
 
 @[simp]
-lemma IsFiniteKernel.bound_eq_zero_of_isEmpty [IsEmpty α] (κ : Kernel α β) :
-    IsFiniteKernel.bound κ = 0 := by simp [IsFiniteKernel.bound]
+lemma bound_eq_zero_of_isEmpty [IsEmpty α] (κ : Kernel α β) :
+    κ.bound = 0 := by simp [bound]
+
+@[deprecated (since := "2025-09-13")] alias
+  _root_.ProbabilityTheory.IsFiniteKernel.bound_eq_zero_of_isEmpty := bound_eq_zero_of_isEmpty
 
 @[simp]
-lemma IsFiniteKernel.bound_eq_zero_of_isEmpty' [IsEmpty β] (κ : Kernel α β) :
-    IsFiniteKernel.bound κ = 0 := by simp [bound, Subsingleton.elim _ (0 : Measure β)]
+lemma bound_eq_zero_of_isEmpty' [IsEmpty β] (κ : Kernel α β) :
+    κ.bound = 0 := by simp [bound, Subsingleton.elim _ (0 : Measure β)]
+
+@[deprecated (since := "2025-09-13")] alias
+  _root_.ProbabilityTheory.IsFiniteKernel.bound_eq_zero_of_isEmpty' := bound_eq_zero_of_isEmpty'
 
 @[simp]
-lemma IsFiniteKernel.bound_zero : IsFiniteKernel.bound (0 : Kernel α β) = 0 := by
-  simp [IsFiniteKernel.bound]
+lemma bound_zero : bound (0 : Kernel α β) = 0 := by
+  simp [bound]
+
+@[deprecated (since := "2025-09-13")] alias
+  _root_.ProbabilityTheory.IsFiniteKernel.bound_zero := bound_zero
+
+end Kernel
 
 instance isFiniteKernel_zero (α β : Type*) {_ : MeasurableSpace α} {_ : MeasurableSpace β} :
     IsFiniteKernel (0 : Kernel α β) :=
@@ -189,15 +208,12 @@ instance isFiniteKernel_zero (α β : Type*) {_ : MeasurableSpace α} {_ : Measu
 
 instance IsFiniteKernel.add (κ η : Kernel α β) [IsFiniteKernel κ] [IsFiniteKernel η] :
     IsFiniteKernel (κ + η) := by
-  refine ⟨⟨IsFiniteKernel.bound κ + IsFiniteKernel.bound η,
-    ENNReal.add_lt_top.mpr ⟨IsFiniteKernel.bound_lt_top κ, IsFiniteKernel.bound_lt_top η⟩,
-    fun a => ?_⟩⟩
+  refine ⟨⟨κ.bound + η.bound, ENNReal.add_lt_top.mpr ⟨κ.bound_lt_top, η.bound_lt_top⟩, fun a => ?_⟩⟩
   exact add_le_add (Kernel.measure_le_bound _ _ _) (Kernel.measure_le_bound _ _ _)
 
 lemma isFiniteKernel_of_le {κ ν : Kernel α β} [hν : IsFiniteKernel ν] (hκν : κ ≤ ν) :
-    IsFiniteKernel κ := by
-  refine ⟨IsFiniteKernel.bound ν, hν.bound_lt_top,
-    fun a ↦ (hκν _ _).trans (Kernel.measure_le_bound ν a Set.univ)⟩
+    IsFiniteKernel κ :=
+  ⟨ν.bound, ν.bound_lt_top, fun a ↦ (hκν _ _).trans (ν.measure_le_bound a Set.univ)⟩
 
 variable {κ η : Kernel α β}
 
@@ -218,7 +234,7 @@ instance (priority := 100) IsZeroOrMarkovKernel.isZeroOrProbabilityMeasure
   · infer_instance
 
 instance IsFiniteKernel.isFiniteMeasure [IsFiniteKernel κ] (a : α) : IsFiniteMeasure (κ a) :=
-  ⟨(Kernel.measure_le_bound κ a Set.univ).trans_lt (IsFiniteKernel.bound_lt_top κ)⟩
+  ⟨(κ.measure_le_bound a Set.univ).trans_lt κ.bound_lt_top⟩
 
 instance (priority := 100) IsZeroOrMarkovKernel.isFiniteKernel [h : IsZeroOrMarkovKernel κ] :
     IsFiniteKernel κ := by
@@ -226,18 +242,24 @@ instance (priority := 100) IsZeroOrMarkovKernel.isFiniteKernel [h : IsZeroOrMark
   · infer_instance
   · exact ⟨⟨1, ENNReal.one_lt_top, fun _ => prob_le_one⟩⟩
 
-@[simp]
-lemma IsMarkovKernel.bound_eq_one [Nonempty α] (κ : Kernel α β) [IsMarkovKernel κ] :
-    IsFiniteKernel.bound κ = 1 := by simp [IsFiniteKernel.bound]
+namespace Kernel
 
 @[simp]
-lemma IsZeroOrMarkovKernel.bound_le_one (κ : Kernel α β) [IsZeroOrMarkovKernel κ] :
-    IsFiniteKernel.bound κ ≤ 1 := by
+lemma bound_eq_one [Nonempty α] (κ : Kernel α β) [IsMarkovKernel κ] :
+    κ.bound = 1 := by simp [bound]
+
+@[deprecated (since := "2025-09-13")] alias _root_.ProbabilityTheory.IsMarkovKernel.bound_eq_one :=
+  bound_eq_one
+
+@[simp]
+lemma bound_le_one (κ : Kernel α β) [IsZeroOrMarkovKernel κ] :
+    κ.bound ≤ 1 := by
   rcases isEmpty_or_nonempty α
   · simp
   · rcases eq_zero_or_isMarkovKernel κ with rfl | _ <;> simp
 
-namespace Kernel
+@[deprecated (since := "2025-09-13")] alias
+  _root_.ProbabilityTheory.IsZeroOrMarkovKernel.bound_le_one := bound_le_one
 
 @[ext]
 theorem ext (h : ∀ a, κ a = η a) : κ = η := DFunLike.ext _ _ h

--- a/Mathlib/Probability/Kernel/Integral.lean
+++ b/Mathlib/Probability/Kernel/Integral.lean
@@ -23,11 +23,11 @@ namespace Kernel
 lemma IsFiniteKernel.integrable (μ : Measure α) [IsFiniteMeasure μ]
     (κ : Kernel α β) [IsFiniteKernel κ] {s : Set β} (hs : MeasurableSet s) :
     Integrable (fun x ↦ (κ x).real s) μ := by
-  refine Integrable.mono' (integrable_const (IsFiniteKernel.bound κ).toReal)
+  refine Integrable.mono' (integrable_const κ.bound.toReal)
     ((κ.measurable_coe hs).ennreal_toReal.aestronglyMeasurable)
     (ae_of_all μ fun x ↦ ?_)
   rw [Real.norm_eq_abs, abs_of_nonneg measureReal_nonneg]
-  exact ENNReal.toReal_mono (IsFiniteKernel.bound_ne_top _) (Kernel.measure_le_bound _ _ _)
+  exact ENNReal.toReal_mono (Kernel.bound_ne_top _) (Kernel.measure_le_bound _ _ _)
 
 lemma IsMarkovKernel.integrable (μ : Measure α) [IsFiniteMeasure μ]
     (κ : Kernel α β) [IsMarkovKernel κ] {s : Set β} (hs : MeasurableSet s) :

--- a/Mathlib/Probability/Kernel/RadonNikodym.lean
+++ b/Mathlib/Probability/Kernel/RadonNikodym.lean
@@ -524,14 +524,14 @@ end Unique
 
 instance [hκ : IsFiniteKernel κ] [IsFiniteKernel η] :
     IsFiniteKernel (withDensity η (rnDeriv κ η)) := by
-  refine ⟨IsFiniteKernel.bound κ, hκ.bound_lt_top, fun a ↦ ?_⟩
+  refine ⟨κ.bound, κ.bound_lt_top, fun a ↦ ?_⟩
   rw [Kernel.withDensity_apply', setLIntegral_univ]
   swap; · exact measurable_rnDeriv κ η
   rw [lintegral_congr_ae rnDeriv_eq_rnDeriv_measure]
   exact Measure.lintegral_rnDeriv_le.trans (measure_le_bound _ _ _)
 
 instance [hκ : IsFiniteKernel κ] [IsFiniteKernel η] : IsFiniteKernel (singularPart κ η) := by
-  refine ⟨IsFiniteKernel.bound κ, hκ.bound_lt_top, fun a ↦ ?_⟩
+  refine ⟨κ.bound, κ.bound_lt_top, fun a ↦ ?_⟩
   have h : withDensity η (rnDeriv κ η) a univ + singularPart κ η a univ = κ a univ := by
     conv_rhs => rw [← rnDeriv_add_singularPart κ η]
     simp

--- a/Mathlib/Probability/Kernel/WithDensity.lean
+++ b/Mathlib/Probability/Kernel/WithDensity.lean
@@ -179,14 +179,13 @@ is finite. -/
 theorem isFiniteKernel_withDensity_of_bounded (κ : Kernel α β) [IsFiniteKernel κ] {B : ℝ≥0∞}
     (hB_top : B ≠ ∞) (hf_B : ∀ a b, f a b ≤ B) : IsFiniteKernel (withDensity κ f) := by
   by_cases hf : Measurable (Function.uncurry f)
-  · exact ⟨⟨B * IsFiniteKernel.bound κ, ENNReal.mul_lt_top hB_top.lt_top
-      (IsFiniteKernel.bound_lt_top κ), fun a => by
+  · exact ⟨⟨B * κ.bound, ENNReal.mul_lt_top hB_top.lt_top κ.bound_lt_top, fun a => by
         rw [Kernel.withDensity_apply' κ hf a Set.univ]
         calc
           ∫⁻ b in Set.univ, f a b ∂κ a ≤ ∫⁻ _ in Set.univ, B ∂κ a := lintegral_mono (hf_B a)
           _ = B * κ a Set.univ := by
             simp only [Measure.restrict_univ, MeasureTheory.lintegral_const]
-          _ ≤ B * IsFiniteKernel.bound κ := mul_le_mul_left' (measure_le_bound κ a Set.univ) _⟩⟩
+          _ ≤ B * κ.bound := mul_le_mul_left' (measure_le_bound κ a Set.univ) _⟩⟩
   · rw [withDensity_of_not_measurable _ hf]
     infer_instance
 


### PR DESCRIPTION
That definition was specific to finite kernels before #29137, but not anymore. Also the new name allows dot notation.

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include at least one commit authored by each
co-author among the commits in the pull request. If necessary, you may 
create empty commits to indicate co-authorship, using commands like so:

git commit --author="Author Name <author@email.com>" --allow-empty -m "add Author Name as coauthor"

When merging, all the commits will be squashed into a single commit listing all co-authors.

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
