### PR TITLE
[Merged by Bors] - chore(Algebra/AddTorsor/Basic): import existing `Pi.vadd'` instance

### DIFF
--- a/Mathlib/Algebra/AddTorsor/Basic.lean
+++ b/Mathlib/Algebra/AddTorsor/Basic.lean
@@ -5,6 +5,7 @@ Authors: Joseph Myers, Yury Kudryashov
 -/
 import Mathlib.Algebra.AddTorsor.Defs
 import Mathlib.Algebra.Group.Action.Basic
+import Mathlib.Algebra.Group.Action.Pi
 import Mathlib.Algebra.Group.End
 import Mathlib.Algebra.Group.Pointwise.Set.Scalar
 
@@ -154,9 +155,6 @@ open AddAction AddTorsor
 
 /-- A product of `AddTorsor`s is an `AddTorsor`. -/
 instance instAddTorsor : AddTorsor (∀ i, fg i) (∀ i, fp i) where
-  vadd g p i := g i +ᵥ p i
-  zero_vadd p := funext fun i => zero_vadd (fg i) (p i)
-  add_vadd g₁ g₂ p := funext fun i => add_vadd (g₁ i) (g₂ i) (p i)
   vsub p₁ p₂ i := p₁ i -ᵥ p₂ i
   vsub_vadd' p₁ p₂ := funext fun i => vsub_vadd (p₁ i) (p₂ i)
   vadd_vsub' g p := funext fun i => vadd_vsub (g i) (p i)


### PR DESCRIPTION
Removes a duplicate definition of `+ᵥ` in `Pi.instAddTorsor`.


---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include at least one commit authored by each
co-author among the commits in the pull request. If necessary, you may 
create empty commits to indicate co-authorship, using commands like so:

git commit --author="Author Name <author@email.com>" --allow-empty -m "add Author Name as coauthor"

When merging, all the commits will be squashed into a single commit listing all co-authors.

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
