### PR TITLE
[Merged by Bors] - chore(Topology/Algebra/Affine): generalize `eventually_homothety_*` to `IsTopologicalAddTorsor`

### DIFF
--- a/Mathlib/Analysis/Normed/Affine/AddTorsor.lean
+++ b/Mathlib/Analysis/Normed/Affine/AddTorsor.lean
@@ -207,29 +207,6 @@ theorem antilipschitzWith_lineMap {p₁ p₂ : Q} (h : p₁ ≠ p₂) :
     rw [dist_lineMap_lineMap, NNReal.coe_inv, ← dist_nndist, mul_left_comm,
       inv_mul_cancel₀ (dist_ne_zero.2 h), mul_one]
 
-variable (𝕜)
-
-theorem eventually_homothety_mem_of_mem_interior (x : Q) {s : Set Q} {y : Q} (hy : y ∈ interior s) :
-    ∀ᶠ δ in 𝓝 (1 : 𝕜), homothety x δ y ∈ s := by
-  rw [(NormedAddCommGroup.nhds_basis_norm_lt (1 : 𝕜)).eventually_iff]
-  rcases eq_or_ne y x with h | h
-  · use 1
-    simp [h.symm, interior_subset hy]
-  have hxy : 0 < ‖y -ᵥ x‖ := by rwa [norm_pos_iff, vsub_ne_zero]
-  obtain ⟨u, hu₁, hu₂, hu₃⟩ := mem_interior.mp hy
-  obtain ⟨ε, hε, hyε⟩ := Metric.isOpen_iff.mp hu₂ y hu₃
-  refine ⟨ε / ‖y -ᵥ x‖, div_pos hε hxy, fun δ (hδ : ‖δ - 1‖ < ε / ‖y -ᵥ x‖) => hu₁ (hyε ?_)⟩
-  rw [lt_div_iff₀ hxy, ← norm_smul, sub_smul, one_smul] at hδ
-  rwa [homothety_apply, Metric.mem_ball, dist_eq_norm_vsub W, vadd_vsub_eq_sub_vsub]
-
-theorem eventually_homothety_image_subset_of_finite_subset_interior (x : Q) {s : Set Q} {t : Set Q}
-    (ht : t.Finite) (h : t ⊆ interior s) : ∀ᶠ δ in 𝓝 (1 : 𝕜), homothety x δ '' t ⊆ s := by
-  suffices ∀ y ∈ t, ∀ᶠ δ in 𝓝 (1 : 𝕜), homothety x δ y ∈ s by
-    simp_rw [Set.image_subset_iff]
-    exact (Filter.eventually_all_finite ht).mpr this
-  intro y hy
-  exact eventually_homothety_mem_of_mem_interior 𝕜 x (h hy)
-
 end NormedSpace
 
 variable [NormedSpace ℝ V] [NormedSpace ℝ W]

--- a/Mathlib/Topology/Algebra/Affine.lean
+++ b/Mathlib/Topology/Algebra/Affine.lean
@@ -1,7 +1,7 @@
 /-
 Copyright (c) 2020 Frédéric Dupuis. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
-Authors: Frédéric Dupuis
+Authors: Frédéric Dupuis, Attila Gáspár
 -/
 import Mathlib.LinearAlgebra.AffineSpace.AffineMap
 import Mathlib.Topology.Algebra.Group.AddTorsor
@@ -87,7 +87,7 @@ theorem _root_.eventually_homothety_mem_of_mem_interior {y : Q} (hy : y ∈ inte
 theorem _root_.eventually_homothety_image_subset_of_finite_subset_interior {t : Set Q}
     (ht : t.Finite) (h : t ⊆ interior s) : ∀ᶠ δ in 𝓝 (1 : R), homothety x δ '' t ⊆ s := by
   suffices ∀ y ∈ t, ∀ᶠ δ in 𝓝 (1 : R), homothety x δ y ∈ s by
-    simp only [Set.image_subset_iff]
+    simp_rw [Set.image_subset_iff]
     exact (Filter.eventually_all_finite ht).mpr this
   intro y hy
   exact eventually_homothety_mem_of_mem_interior R x (h hy)

--- a/Mathlib/Topology/Algebra/Affine.lean
+++ b/Mathlib/Topology/Algebra/Affine.lean
@@ -74,6 +74,24 @@ theorem homothety_continuous (x : P) (t : R) : Continuous <| homothety x t := by
   rw [coe_homothety]
   fun_prop
 
+variable (R) [TopologicalSpace R] [Module R W] [ContinuousSMul R W] (x : Q) {s : Set Q}
+
+open Topology
+
+theorem _root_.eventually_homothety_mem_of_mem_interior {y : Q} (hy : y ∈ interior s) :
+    ∀ᶠ δ in 𝓝 (1 : R), homothety x δ y ∈ s := by
+  have cont : Continuous (fun δ : R => homothety x δ y) := lineMap_continuous
+  filter_upwards [cont.tendsto' 1 y (by simp) |>.eventually (isOpen_interior.eventually_mem hy)]
+    with _ h using interior_subset h
+
+theorem _root_.eventually_homothety_image_subset_of_finite_subset_interior {t : Set Q}
+    (ht : t.Finite) (h : t ⊆ interior s) : ∀ᶠ δ in 𝓝 (1 : R), homothety x δ '' t ⊆ s := by
+  suffices ∀ y ∈ t, ∀ᶠ δ in 𝓝 (1 : R), homothety x δ y ∈ s by
+    simp only [Set.image_subset_iff]
+    exact (Filter.eventually_all_finite ht).mpr this
+  intro y hy
+  exact eventually_homothety_mem_of_mem_interior R x (h hy)
+
 end CommRing
 
 section Field


### PR DESCRIPTION
---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include at least one commit authored by each
co-author among the commits in the pull request. If necessary, you may 
create empty commits to indicate co-authorship, using commands like so:

git commit --author="Author Name <author@email.com>" --allow-empty -m "add Author Name as coauthor"

When merging, all the commits will be squashed into a single commit listing all co-authors.

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->
- [x] depends on: #29616 

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
