### PR TITLE
feat(RepresentationTheory/Commutative): simple representations of commutative monoids are 1-dimensional

### DIFF
--- a/Mathlib.lean
+++ b/Mathlib.lean
@@ -5301,6 +5301,7 @@ import Mathlib.RepresentationTheory.Basic
 import Mathlib.RepresentationTheory.Character
 import Mathlib.RepresentationTheory.Coinduced
 import Mathlib.RepresentationTheory.Coinvariants
+import Mathlib.RepresentationTheory.Commutative
 import Mathlib.RepresentationTheory.FDRep
 import Mathlib.RepresentationTheory.FiniteIndex
 import Mathlib.RepresentationTheory.GroupCohomology.Basic

--- a/Mathlib/RepresentationTheory/Commutative.lean
+++ b/Mathlib/RepresentationTheory/Commutative.lean
@@ -29,8 +29,7 @@ noncomputable def smul_hom {V : Rep R G} (g : G) : V ⟶ V :=
     change (V.ρ g * V.ρ h) a = (V.ρ h * V.ρ g) a
     rw[← map_mul, ← map_mul, mul_comm]⟩
 
-@[simp] theorem smul_hom_apply {V : Rep R G} {v : V} {g : G} :
-    smul_hom g v = V.ρ g v := rfl
+theorem smul_hom_apply {V : Rep R G} {v : V} {g : G} : smul_hom g v = V.ρ g v := rfl
 
 end Rep
 namespace FDRep
@@ -39,8 +38,7 @@ namespace FDRep
 noncomputable def smul_hom {V : FDRep R G} (g : G) : V ⟶ V :=
   forget₂HomLinearEquiv V V <| Rep.smul_hom g
 
-@[simp] theorem smul_hom_apply {V : FDRep R G} {v : V} {g : G} :
-    smul_hom g v = V.ρ g v := rfl
+theorem smul_hom_apply {V : FDRep R G} {v : V} {g : G} : smul_hom g v = V.ρ g v := rfl
 
 /-- If `G` is a commutative monoid and `k` is algebraically closed, any finite dimensional
 simple representation of `G` has dimension 1. -/

--- a/Mathlib/RepresentationTheory/Commutative.lean
+++ b/Mathlib/RepresentationTheory/Commutative.lean
@@ -18,8 +18,29 @@ simple finite dimensional representations over algebraically closed fields are a
 universe u
 open CategoryTheory LinearMap Representation Module
 
+variable {R k G : Type u} [CommRing R] [Field k] [CommMonoid G]
+namespace Rep
+/-- For commutative monoids `G`, `g : G` and a representation `V` of `G`, `smul_hom g` is the
+endomorphism of `V` defined by left multiplication with `g`. -/
+noncomputable def smul_hom {V : Rep R G} (g : G) : V ⟶ V :=
+  ⟨ModuleCat.ofHom <| V.ρ g, by
+    intro h
+    ext a
+    change (V.ρ g * V.ρ h) a = (V.ρ h * V.ρ g) a
+    rw[← map_mul, ← map_mul, mul_comm]⟩
+
+@[simp] theorem smul_hom_apply {V : Rep R G} {v : V} {g : G} :
+    smul_hom g v = V.ρ g v := rfl
+
+end Rep
 namespace FDRep
-variable {k G : Type u} [Field k] [CommMonoid G]
+/-- For commutative monoids `G`, `g : G` and a finite-dimensional representation `V` of `G`,
+`smul_hom g` is the endomorphism of `V` defined by left multiplication with `g`. -/
+noncomputable def smul_hom {V : FDRep R G} (g : G) : V ⟶ V :=
+  forget₂HomLinearEquiv V V <| Rep.smul_hom g
+
+@[simp] theorem smul_hom_apply {V : FDRep R G} {v : V} {g : G} :
+    smul_hom g v = V.ρ g v := rfl
 
 /-- If `G` is a commutative monoid and `k` is algebraically closed, any finite dimensional
 simple representation of `G` has dimension 1. -/
@@ -35,15 +56,10 @@ theorem finrank_eq_one_simple_of_commMonoid [IsAlgClosed k]
   -- TODO: fix this when made possible
   let W := Submodule.span k {x}
   -- This is true since `G` is abelian, such that each `V.ρ g` is a representation morphism, ...
-  let rho_endo (g : G) : V ⟶ V := ⟨FGModuleCat.ofHom <| V.ρ g, by
-    intro h
-    ext a
-    change (V.ρ g * V.ρ h) a = (V.ρ h * V.ρ g) a
-    rw[← map_mul, ← map_mul, mul_comm]⟩
   have invariant (g y) (hy : y ∈ Submodule.span k {x}) : (V.ρ g) y ∈ Submodule.span k {x} := by
-    change (rho_endo g) y ∈ Submodule.span k {x}
+    rw[← smul_hom_apply]
   -- ...hence by Schur's lemma, it acts as a scalar and every subspace is invariant.
-    obtain ⟨c, eq⟩ := endomorphism_simple_eq_smul_id k <| rho_endo g
+    obtain ⟨c, eq⟩ := endomorphism_simple_eq_smul_id k <| smul_hom (V := V) g
     rw[← eq]
     exact (Submodule.span k {x}).smul_mem c hy
   -- So the span of `x` can be turned into a representation with `V.ρ`.

--- a/Mathlib/RepresentationTheory/Commutative.lean
+++ b/Mathlib/RepresentationTheory/Commutative.lean
@@ -11,7 +11,7 @@ import Mathlib.RepresentationTheory.FDRep
 This file introduces facts on representations of monoids that only holds for commutative monoids.
 
 A key result shown in `finrank_eq_one_simple_of_commMonoid` is that for a commutative monoid, the
-simple finite dimensional representations over algebraically closed fields are all 1-dimensional.
+simple finite dimensional representations over algebraically closed fields are all one-dimensional.
 
 -/
 
@@ -25,23 +25,16 @@ variable {k G : Type u} [Field k] [CommMonoid G]
 simple representation of `G` has dimension 1. -/
 theorem finrank_eq_one_simple_of_commMonoid [IsAlgClosed k]
     {V : FDRep k G} [Simple V] : finrank k V = 1 := by
-  -- Appealing to the fact that simple objects are not zero objects would be more complicated here,
-  -- so instead, we use that `0 = 𝟙` holds for rank 0 spaces, since they are subsingletons,
-  -- but not for simple objects.
-  have finrank_pos : 0 < finrank k V := by
-    by_contra! h
-    rw[nonpos_iff_eq_zero, Module.finrank_zero_iff] at h
-    apply id_nonzero V
-    ext a
-    change Subsingleton ↑V.V.obj at h
-    apply Subsingleton.allEq
+  -- exclude the case of dim 0 representations
+  have finrank_pos : 0 < finrank k V := FDRep.finrank_pos_of_simple V
   rw[finrank_pos_iff_exists_ne_zero] at finrank_pos
   obtain ⟨x, x_nonzero⟩ := finrank_pos
   -- We show that for any nonzero `x : V`, the span of `x` is a subrepresentation.
   -- We have to explicitly show it is a representation since the relationship
   -- between `FDRep` and `Rep` is not developed well enough yet.
   -- TODO: fix this when made possible
-  let W := ↥ (Submodule.span k {x})
+  let W := Submodule.span k {x}
+  -- This is true since `G` is abelian, such that each `V.ρ g` is a representation morphism, ...
   let rho_endo (g : G) : V ⟶ V := ⟨FGModuleCat.ofHom <| V.ρ g, by
     intro h
     ext a
@@ -49,9 +42,11 @@ theorem finrank_eq_one_simple_of_commMonoid [IsAlgClosed k]
     rw[← map_mul, ← map_mul, mul_comm]⟩
   have invariant (g y) (hy : y ∈ Submodule.span k {x}) : (V.ρ g) y ∈ Submodule.span k {x} := by
     change (rho_endo g) y ∈ Submodule.span k {x}
+  -- ...hence by Schur's lemma, it acts as a scalar and every subspace is invariant.
     obtain ⟨c, eq⟩ := endomorphism_simple_eq_smul_id k <| rho_endo g
     rw[← eq]
     exact (Submodule.span k {x}).smul_mem c hy
+  -- So the span of `x` can be turned into a representation with `V.ρ`.
   let w_rho : G →* W →ₗ[k] W := ⟨⟨fun g => (V.ρ g).restrict <| invariant g,
       by ext a; simp⟩,
     by intro g h; ext a; aesop⟩
@@ -71,7 +66,7 @@ theorem finrank_eq_one_simple_of_commMonoid [IsAlgClosed k]
   have := isIso_of_mono_of_nonzero incl_nz
   let incl' := (forget₂ (FGModuleCat k) (ModuleCat k)).mapIso <|
     (forget₂ _ (FGModuleCat k)).mapIso <| asIso incl
-  -- So `V` must be equal to the span of `x`, hence 1-dimensional.
+  -- Hence `V` must be equal to the span of `x`, hence 1-dimensional.
   let incl_equiv : WMod ≃ₗ[k] V.V := CategoryTheory.Iso.toLinearEquiv <| incl'
   rw[← LinearEquiv.finrank_eq incl_equiv]
   apply finrank_span_singleton x_nonzero

--- a/Mathlib/RepresentationTheory/Commutative.lean
+++ b/Mathlib/RepresentationTheory/Commutative.lean
@@ -36,10 +36,11 @@ theorem finrank_eq_one_simple_of_commMonoid [IsAlgClosed k]
     change Subsingleton ↑V.V.obj at h
     apply Subsingleton.allEq
   rw[finrank_pos_iff_exists_ne_zero] at finrank_pos
-  obtain ⟨x, ne⟩ := finrank_pos
+  obtain ⟨x, x_nonzero⟩ := finrank_pos
   -- We show that for any nonzero `x : V`, the span of `x` is a subrepresentation.
   -- We have to explicitly show it is a representation since the relationship
   -- between `FDRep` and `Rep` is not developed well enough yet.
+  -- TODO: fix this when made possible by
   let W := ↥ (Submodule.span k {x})
   let rho_endo (g : G) : V ⟶ V := ⟨FGModuleCat.ofHom <| V.ρ g, by
     intro h
@@ -60,15 +61,16 @@ theorem finrank_eq_one_simple_of_commMonoid [IsAlgClosed k]
   let WMod := FDRep.of w_rho
   -- This subrepresentation induces a monomorphism into `V`, which must be iso since `V` is simple.
   let incl : WMod ⟶ V := ⟨FGModuleCat.ofHom <| Submodule.subtype _, fun _ => rfl⟩
-  have mono_incl := (forget (FDRep k G)).reflectsMonomorphisms_of_faithful.reflects incl (by
-    rw[CategoryTheory.mono_iff_injective]
-    rintro ⟨a,ha⟩ ⟨b,hb⟩ rfl
-    rfl)
+  have mono_incl : Mono incl :=
+    (forget (FDRep k G)).reflectsMonomorphisms_of_faithful.reflects incl (by
+      rw[CategoryTheory.mono_iff_injective]
+      rintro ⟨a,ha⟩ ⟨b,hb⟩ rfl
+      rfl)
   have incl_nz : incl ≠ 0 := by
     intro h
     have mem : x ∈ Submodule.span k {x} := by simp
     have wrong : incl ⟨x,mem⟩ = (0 : WMod ⟶ V) ⟨x,mem⟩ := by rw[h]
-    exact ne wrong
+    exact x_nonzero wrong
   have incl_isIso := isIso_of_mono_of_nonzero incl_nz
   let incl_iso := asIso incl
   let incl' := (forget₂ (FGModuleCat k) (ModuleCat k)).mapIso <|
@@ -76,6 +78,6 @@ theorem finrank_eq_one_simple_of_commMonoid [IsAlgClosed k]
   -- So `V` must be equal to the span of `x`, hence 1-dimensional.
   let incl_equiv : WMod ≃ₗ[k] V.V := CategoryTheory.Iso.toLinearEquiv <| incl'
   rw[← LinearEquiv.finrank_eq incl_equiv]
-  apply finrank_span_singleton ne
+  apply finrank_span_singleton x_nonzero
 
 end FDRep

--- a/Mathlib/RepresentationTheory/Commutative.lean
+++ b/Mathlib/RepresentationTheory/Commutative.lean
@@ -3,7 +3,7 @@ Copyright (c) 2025 Uni Marx. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Uni Marx
 -/
-import Mathlib.RepresentationTheory.Character
+import Mathlib.RepresentationTheory.FDRep
 
 /-!
 # Representations of commutative monoids

--- a/Mathlib/RepresentationTheory/Commutative.lean
+++ b/Mathlib/RepresentationTheory/Commutative.lean
@@ -1,0 +1,38 @@
+import Mathlib.RepresentationTheory.Character
+
+namespace FDRep
+variable {k G : Type u} [Field k] [CommMonoid G]
+
+
+theorem existsUnique_smul_id_eq_of_simple [IsAlgClosed k] {V : FDRep k G} [Simple V] (f : V ⟶ V) :
+    f.1.1.tr • 𝟙 V = f := by
+  apply existsUnique_of_exists_of_uniq  ue
+  · have : finrank k (V ⟶ V) = 1 := by
+      rw[finrank_hom_simple_simple]; simp
+    apply exists_smul_eq_of_finrank_eq_one this <| id_nonzero _
+  · intro x y hx hy
+    rw[← hy] at hx
+    refine smul_left_injective k (x := 𝟙 V) ?_ hx
+    exact id_nonzero V
+
+
+open Module
+
+
+def end_hom_of_commMonoid (g : G) {V : FDRep k G} : V ⟶ V := _ -- does this exist already
+
+theorem finrank_eq_one_simple_of_commMonoid [IsAlgClosed k]
+    {V : FDRep k G} [Simple V] : finrank k V = 1 := by
+  have finrank_pos : 0 < finrank k V := by
+    sorry
+  rw[finrank_pos_iff_exists_ne_zero] at finrank_pos
+  obtain ⟨x, ne⟩ := finrank_pos
+  let W := ↥ (Submodule.span k {x})
+
+  let rho : G →* W →ₗ[k] W := ⟨⟨fun g => (end_scalar_simple (V.ρ g)) • 𝟙 W, _⟩, _⟩
+
+
+
+
+
+end FDRep

--- a/Mathlib/RepresentationTheory/Commutative.lean
+++ b/Mathlib/RepresentationTheory/Commutative.lean
@@ -1,44 +1,45 @@
+/-
+Copyright (c) 2025 Uni Marx. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Uni Marx
+-/
 import Mathlib.RepresentationTheory.Character
+
+/-!
+# Representations of commutative monoids
+
+This file introduces facts on representations of monoids that only holds for commutative monoids.
+
+A key result shown in `finrank_eq_one_simple_of_commMonoid` is that for a commutative monoid, the
+simple finite dimensional representations over algebraically closed fields are all 1-dimensional.
+
+-/
 
 universe u
 open CategoryTheory LinearMap Representation Module
 
-
 namespace FDRep
 variable {k G : Type u} [Field k] [CommMonoid G]
 
-
-theorem existsUnique_smul_id_eq_of_simple [IsAlgClosed k] {V : FDRep k G} [Simple V] (f : V ⟶ V) :
-    LinearMap.trace k V f.hom.hom • 𝟙 V = finrank k V • f := by
-  have : finrank k (V ⟶ V) = 1 := by
-    rw[finrank_hom_simple_simple]; simp
-  obtain ⟨c,rfl⟩ := endomorphism_simple_eq_smul_id k f
-  congr
-  rw[Action.smul_hom, Action.id_hom, ModuleCat.hom_smul]
-  simp
-  sorry
-
-
-
-
-open Module
-
-
-def end_hom_of_commMonoid (g : G) {V : FDRep k G} : V ⟶ V := _ -- does this exist already
-
+/-- If `G` is a commutative monoid and `k` is algebraically closed, any finite dimensional
+simple representation of `G` has dimension 1. -/
 theorem finrank_eq_one_simple_of_commMonoid [IsAlgClosed k]
     {V : FDRep k G} [Simple V] : finrank k V = 1 := by
+  -- Appealing to the fact that simple objects are not zero objects would be more complicated here,
+  -- so instead, we use that `0 = 𝟙` holds for rank 0 spaces, since they are subsingletons,
+  -- but not for simple objects.
   have finrank_pos : 0 < finrank k V := by
     by_contra! h
     rw[nonpos_iff_eq_zero, Module.finrank_zero_iff] at h
-    have := id_nonzero V
-    apply this
+    apply id_nonzero V
     ext a
     change Subsingleton ↑V.V.obj at h
     apply Subsingleton.allEq
-
   rw[finrank_pos_iff_exists_ne_zero] at finrank_pos
   obtain ⟨x, ne⟩ := finrank_pos
+  -- We show that for any nonzero `x : V`, the span of `x` is a subrepresentation.
+  -- We have to explicitly show it is a representation since the relationship
+  -- between `FDRep` and `Rep` is not developed well enough yet.
   let W := ↥ (Submodule.span k {x})
   let rho_endo (g : G) : V ⟶ V := ⟨FGModuleCat.ofHom <| V.ρ g, by
     intro h
@@ -50,23 +51,18 @@ theorem finrank_eq_one_simple_of_commMonoid [IsAlgClosed k]
     change (rho_endo g) y ∈ Submodule.span k {x}
     obtain ⟨c, eq⟩ := endomorphism_simple_eq_smul_id k <| rho_endo g
     rw[← eq]
-    change (c • 𝟙 V).hom.hom y ∈ Submodule.span k {x}
-    rw[Action.smul_hom, Action.id_hom, ModuleCat.hom_smul]
-    simp only [FGModuleCat.obj_carrier, FGModuleCat.hom_id, smul_apply, id_coe, id_eq]
     exact Submodule.smul_mem (Submodule.span k {x}) c hy
   let w_rho : G →* W →ₗ[k] W := ⟨⟨fun g => (V.ρ g).restrict <| invariant g,
-    by ext a; simp⟩,
+      by ext a; simp⟩,
     by intro g h
        ext a
        aesop⟩
   let WMod := FDRep.of w_rho
-  let incl : WMod ⟶ V := ⟨FGModuleCat.ofHom <| Submodule.subtype _, by
-    intro g
-    norm_cast⟩
+  -- This subrepresentation induces a monomorphism into `V`, which must be iso since `V` is simple.
+  let incl : WMod ⟶ V := ⟨FGModuleCat.ofHom <| Submodule.subtype _, fun _ => rfl⟩
   have mono_incl := (forget (FDRep k G)).reflectsMonomorphisms_of_faithful.reflects incl (by
     rw[CategoryTheory.mono_iff_injective]
-    rintro ⟨a,ha⟩ ⟨b,hb⟩ eq
-    rcases eq
+    rintro ⟨a,ha⟩ ⟨b,hb⟩ rfl
     rfl)
   have incl_nz : incl ≠ 0 := by
     intro h
@@ -77,10 +73,9 @@ theorem finrank_eq_one_simple_of_commMonoid [IsAlgClosed k]
   let incl_iso := asIso incl
   let incl' := (forget₂ (FGModuleCat k) (ModuleCat k)).mapIso <|
     (forget₂ _ (FGModuleCat k)).mapIso incl_iso
+  -- So `V` must be equal to the span of `x`, hence 1-dimensional.
   let incl_equiv : WMod ≃ₗ[k] V.V := CategoryTheory.Iso.toLinearEquiv <| incl'
   rw[← LinearEquiv.finrank_eq incl_equiv]
   apply finrank_span_singleton ne
-
-
 
 end FDRep

--- a/Mathlib/RepresentationTheory/Commutative.lean
+++ b/Mathlib/RepresentationTheory/Commutative.lean
@@ -40,24 +40,21 @@ theorem finrank_eq_one_simple_of_commMonoid [IsAlgClosed k]
   -- We show that for any nonzero `x : V`, the span of `x` is a subrepresentation.
   -- We have to explicitly show it is a representation since the relationship
   -- between `FDRep` and `Rep` is not developed well enough yet.
-  -- TODO: fix this when made possible by
+  -- TODO: fix this when made possible
   let W := ↥ (Submodule.span k {x})
   let rho_endo (g : G) : V ⟶ V := ⟨FGModuleCat.ofHom <| V.ρ g, by
     intro h
     ext a
-    simp only [FGModuleCat.obj_carrier, FGModuleCat.hom_comp, ModuleCat.hom_ofHom, hom_action_ρ,
-      LinearMap.coe_comp, Function.comp_apply]
-    rw[← Module.End.mul_apply, ← Module.End.mul_apply, ← map_mul, ← map_mul, mul_comm]⟩
+    change (V.ρ g * V.ρ h) a = (V.ρ h * V.ρ g) a
+    rw[← map_mul, ← map_mul, mul_comm]⟩
   have invariant (g y) (hy : y ∈ Submodule.span k {x}) : (V.ρ g) y ∈ Submodule.span k {x} := by
     change (rho_endo g) y ∈ Submodule.span k {x}
     obtain ⟨c, eq⟩ := endomorphism_simple_eq_smul_id k <| rho_endo g
     rw[← eq]
-    exact Submodule.smul_mem (Submodule.span k {x}) c hy
+    exact (Submodule.span k {x}).smul_mem c hy
   let w_rho : G →* W →ₗ[k] W := ⟨⟨fun g => (V.ρ g).restrict <| invariant g,
       by ext a; simp⟩,
-    by intro g h
-       ext a
-       aesop⟩
+    by intro g h; ext a; aesop⟩
   let WMod := FDRep.of w_rho
   -- This subrepresentation induces a monomorphism into `V`, which must be iso since `V` is simple.
   let incl : WMod ⟶ V := ⟨FGModuleCat.ofHom <| Submodule.subtype _, fun _ => rfl⟩
@@ -68,13 +65,12 @@ theorem finrank_eq_one_simple_of_commMonoid [IsAlgClosed k]
       rfl)
   have incl_nz : incl ≠ 0 := by
     intro h
-    have mem : x ∈ Submodule.span k {x} := by simp
+    have mem : x ∈ Submodule.span k {x} := Submodule.mem_span_singleton_self x
     have wrong : incl ⟨x,mem⟩ = (0 : WMod ⟶ V) ⟨x,mem⟩ := by rw[h]
     exact x_nonzero wrong
-  have incl_isIso := isIso_of_mono_of_nonzero incl_nz
-  let incl_iso := asIso incl
+  have := isIso_of_mono_of_nonzero incl_nz
   let incl' := (forget₂ (FGModuleCat k) (ModuleCat k)).mapIso <|
-    (forget₂ _ (FGModuleCat k)).mapIso incl_iso
+    (forget₂ _ (FGModuleCat k)).mapIso <| asIso incl
   -- So `V` must be equal to the span of `x`, hence 1-dimensional.
   let incl_equiv : WMod ≃ₗ[k] V.V := CategoryTheory.Iso.toLinearEquiv <| incl'
   rw[← LinearEquiv.finrank_eq incl_equiv]

--- a/Mathlib/RepresentationTheory/FDRep.lean
+++ b/Mathlib/RepresentationTheory/FDRep.lean
@@ -192,8 +192,18 @@ instance : (forget₂ (FDRep R G) (Rep R G)).Faithful := by
   dsimp [forget₂, HasForget₂.forget₂]
   infer_instance
 
-end FDRep
+-- Appealing to the fact that simple objects are not zero objects would be more complicated here,
+-- so instead, we use that `0 = 𝟙` holds for rank 0 spaces, since they are subsingletons,
+-- but not for simple objects.
+theorem finrank_pos_of_simple (V : FDRep R G) [Simple V] [StrongRankCondition R]
+    [NoZeroSMulDivisors R V] : 0 < finrank R V := by
+  by_contra! h
+  rw[nonpos_iff_eq_zero, Module.finrank_zero_iff] at h
+  apply id_nonzero V
+  ext a
+  simpa using Subsingleton.allEq _ _
 
+end FDRep
 namespace FDRep
 
 variable {k G : Type u} [Field k] [Group G]

--- a/docs/undergrad.yaml
+++ b/docs/undergrad.yaml
@@ -109,7 +109,7 @@ Group Theory:
     unitary group: 'Matrix.unitaryGroup'
     special unitary group: 'https://en.wikipedia.org/wiki/Special_unitary_group'
   Representation theory of finite groups:
-    representations of abelian groups: 'https://proofwiki.org/wiki/Irreducible_Representations_of_Abelian_Group'
+    representations of abelian groups: 'FDRep.finrank_eq_one_simple_of_commMonoid'
     dual groups: 'https://kconrad.math.uconn.edu/blurbs/grouptheory/charthy.pdf'
     Maschke theorem: 'MonoidAlgebra.Submodule.exists_isCompl'
     orthogonality of irreducible characters: 'FDRep.char_orthonormal'


### PR DESCRIPTION
Shows that for a commutative monoid, the simple finite dimensional representations over algebraically closed fields are all 1-dimensional.

---

<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include at least one commit authored by each
co-author among the commits in the pull request. If necessary, you may 
create empty commits to indicate co-authorship, using commands like so:

git commit --author="Author Name <author@email.com>" --allow-empty -m "add Author Name as coauthor"

When merging, all the commits will be squashed into a single commit listing all co-authors.

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->
Some things in here I am a bit uncomfortable with. `FDRep` seems to be not particularly fleshed out yet, so I had to explicitly construct embeddings and so on instead of using `Rep.subrepresentation`.
[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
