### PR TITLE
fix: improve keyword handling in add_deprecations script

### DIFF
--- a/scripts/add_deprecations.sh
+++ b/scripts/add_deprecations.sh
@@ -84,6 +84,13 @@ mkDeclAndDepr () {
             reps++
             # reset the "old name counter", since the deprecation happened
             old=""
+            perr(NR " plus " i ": " $i "\n")
+            break
+          } else {
+            # we found a keyword corresponding to a declaration the following word was not
+            # different from the line prior to the change so we do not need to deprecate
+            # reset the "old name counter", since the deprecation should not happen
+            old=""
             break
           }
         }


### PR DESCRIPTION
The script had a bug where it would try to interpret a word ending in a keyword such as `def` as an actual `def`inition.  This caused problems when a declaration *name* was `start_mul_def`, since the script would guess that the word following `start_mul_def` could be a declaration name.

This patch makes the script a little more robust: it should now match a *full word* with a keyword, not just one that *ends* with a keyword.

The bug was reported in #28406.

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include at least one commit authored by each
co-author among the commits in the pull request. If necessary, you may 
create empty commits to indicate co-authorship, using commands like so:

git commit --author="Author Name <author@email.com>" --allow-empty -m "add Author Name as coauthor"

When merging, all the commits will be squashed into a single commit listing all co-authors.

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
