### PR TITLE
feat: missing instance `NonUnitalCommSemiring R → NonUnitalNonAssocCommSemiring R`

### DIFF
--- a/Mathlib/Algebra/Ring/Defs.lean
+++ b/Mathlib/Algebra/Ring/Defs.lean
@@ -212,6 +212,10 @@ class NonUnitalCommSemiring (α : Type u) extends NonUnitalSemiring α, CommSemi
 class CommSemiring (R : Type u) extends Semiring R, CommMonoid R
 
 -- see Note [lower instance priority]
+instance (priority := 100) NonUnitalCommSemiring.toNonUnitalNonAssocCommSemiring
+    [NonUnitalCommSemiring R] : NonUnitalNonAssocCommSemiring R where
+
+-- see Note [lower instance priority]
 instance (priority := 100) CommSemiring.toNonUnitalCommSemiring [CommSemiring α] :
     NonUnitalCommSemiring α :=
   { inferInstanceAs (CommMonoid α), inferInstanceAs (CommSemiring α) with }

--- a/Mathlib/RingTheory/Coalgebra/Basic.lean
+++ b/Mathlib/RingTheory/Coalgebra/Basic.lean
@@ -204,7 +204,7 @@ instance toCoalgebra : Coalgebra R R where
 theorem comul_apply (r : R) : comul r = 1 ⊗ₜ[R] r := rfl
 
 @[simp]
-theorem counit_apply (r : R) : counit r = r := rfl
+theorem counit_apply (r : R) : counit (R := R) r = r := rfl
 
 instance : IsCocomm R R where comm_comp_comul := by ext; simp
 
@@ -230,7 +230,8 @@ theorem comul_apply (r : A × B) :
       TensorProduct.map (.inr R A B) (.inr R A B) (comul r.2) := rfl
 
 @[simp]
-theorem counit_apply (r : A × B) : (counit r : R) = counit r.1 + counit r.2 := rfl
+theorem counit_apply (r : A × B) :
+    counit (R := R) r = counit (R := R) r.1 + counit (R := R) r.2 := rfl
 
 theorem comul_comp_inl :
     comul ∘ₗ inl R A B = TensorProduct.map (.inl R A B) (.inl R A B) ∘ₗ comul := by
@@ -309,7 +310,8 @@ theorem comul_single (i : ι) (a : A i) :
   lsum_single _ _ _ _
 
 @[simp]
-theorem counit_single (i : ι) (a : A i) : counit (DFinsupp.single i a) = counit (R := R) a :=
+theorem counit_single (i : ι) (a : A i) :
+    counit (R := R) (DFinsupp.single i a) = counit (R := R) a :=
   lsum_single _ _ _ _
 
 theorem comul_comp_lsingle (i : ι) :
@@ -378,7 +380,7 @@ theorem comul_single (i : ι) (a : A) :
   lsum_single _ _ _ _
 
 @[simp]
-theorem counit_single (i : ι) (a : A) : counit (Finsupp.single i a) = counit (R := R) a :=
+theorem counit_single (i : ι) (a : A) : counit (R := R) (Finsupp.single i a) = counit (R := R) a :=
   lsum_single _ _ _ _
 
 theorem comul_comp_lsingle (i : ι) :

--- a/Mathlib/RingTheory/Coalgebra/Hom.lean
+++ b/Mathlib/RingTheory/Coalgebra/Hom.lean
@@ -74,7 +74,7 @@ instance instCoeToCoalgHom : CoeHead F (A →ₗc[R] B) :=
   ⟨CoalgHomClass.toCoalgHom⟩
 
 @[simp]
-theorem counit_comp_apply (f : F) (x : A) : counit (f x) = counit (R := R) x :=
+theorem counit_comp_apply (f : F) (x : A) : counit (R := R) (f x) = counit (R := R) x :=
   LinearMap.congr_fun (counit_comp f) _
 
 @[simp]
@@ -275,8 +275,7 @@ noncomputable def counitCoalgHom : A →ₗc[R] R :=
         ← LinearMap.lTensor_comp_rTensor, rTensor_counit_comul, LinearMap.lTensor_tmul] }
 
 @[simp]
-theorem counitCoalgHom_apply (x : A) :
-    counitCoalgHom R A x = counit x := rfl
+theorem counitCoalgHom_apply (x : A) : counitCoalgHom R A x = counit (R := R) x := rfl
 
 @[simp]
 theorem counitCoalgHom_toLinearMap :

--- a/Mathlib/Tactic/Ring/Basic.lean
+++ b/Mathlib/Tactic/Ring/Basic.lean
@@ -705,6 +705,7 @@ theorem neg_one_mul {R} [Ring R] {a b : R} (_ : (Int.negOfNat (nat_lit 1)).rawCa
 theorem neg_mul {R} [Ring R] (a₁ : R) (a₂) {a₃ b : R}
     (_ : -a₃ = b) : -(a₁ ^ a₂ * a₃) = a₁ ^ a₂ * b := by subst_vars; simp
 
+attribute [-instance] NonUnitalCommSemiring.toNonUnitalNonAssocCommSemiring in
 /-- Negates a monomial `va` to get another monomial.
 
 * `-c = (-c)` (for `c` coefficient)
@@ -753,6 +754,7 @@ def evalNeg {a : Q($α)} (rα : Q(Ring $α)) (va : ExSum sα a) :
 theorem sub_pf {R} [Ring R] {a b c d : R}
     (_ : -b = c) (_ : a + c = d) : a - b = d := by subst_vars; simp [sub_eq_add_neg]
 
+attribute [-instance] NonUnitalCommSemiring.toNonUnitalNonAssocCommSemiring in
 /-- Subtracts two polynomials `va, vb` to get a normalized result polynomial.
 
 * `a - b = a + -b`
@@ -1120,6 +1122,7 @@ def evalInvAtom (a : Q($α)) : AtomM (Result (ExBase sα) q($a⁻¹)) := do
   let (i, ⟨b', _⟩) ← addAtomQ q($a⁻¹)
   pure ⟨b', ExBase.atom i, q(Eq.refl $b')⟩
 
+attribute [-instance] NonUnitalCommSemiring.toNonUnitalNonAssocCommSemiring in
 /-- Inverts a polynomial `va` to get a normalized result polynomial.
 
 * `c⁻¹ = (c⁻¹)` if `c` is a constant
@@ -1168,6 +1171,7 @@ theorem div_pf {R} [DivisionSemiring R] {a b c d : R}
     (_ : b⁻¹ = c) (_ : a * c = d) : a / b = d := by
   subst_vars; simp [div_eq_mul_inv]
 
+attribute [-instance] NonUnitalCommSemiring.toNonUnitalNonAssocCommSemiring in
 /-- Divides two polynomials `va, vb` to get a normalized result polynomial.
 
 * `a / b = a * b⁻¹`


### PR DESCRIPTION
For some reason, this causes elaboration issues.


---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include at least one commit authored by each
co-author among the commits in the pull request. If necessary, you may 
create empty commits to indicate co-authorship, using commands like so:

git commit --author="Author Name <author@email.com>" --allow-empty -m "add Author Name as coauthor"

When merging, all the commits will be squashed into a single commit listing all co-authors.

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
