### PR TITLE
[Merged by Bors] - feat(MeasureTheory): add formula for Radon-Nikodym derivative of a convolution of measures

### DIFF
--- a/Mathlib/MeasureTheory/Group/Convolution.lean
+++ b/Mathlib/MeasureTheory/Group/Convolution.lean
@@ -3,9 +3,8 @@ Copyright (c) 2023 Josha Dekker. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Josha Dekker
 -/
-import Mathlib.MeasureTheory.Measure.MeasureSpace
-import Mathlib.MeasureTheory.Measure.Prod
 import Mathlib.MeasureTheory.Group.Defs
+import Mathlib.MeasureTheory.Measure.Prod
 
 /-!
 # The multiplicative and additive convolution of measures

--- a/Mathlib/MeasureTheory/Group/Convolution.lean
+++ b/Mathlib/MeasureTheory/Group/Convolution.lean
@@ -151,7 +151,7 @@ theorem mconv_absolutelyContinuous [MeasurableMul₂ M] {μ ν ρ : Measure M}
   refine AbsolutelyContinuous.mk (fun s hs h ↦ ?_)
   rw [← lintegral_indicator_one hs, lintegral_mconv (by measurability)]
   conv in s.indicator 1 (_ * _) => change s.indicator 1 ((fun y ↦ x * y) y)
-  simp [← Set.indicator_comp_right]
+  simp only [← Set.indicator_comp_right, Pi.one_comp]
   conv in ∫⁻ _, _ ∂ν =>
     rw [lintegral_indicator_one (by apply MeasurableSet.preimage hs (by fun_prop))]
   have h0 (x : M) : ν (HMul.hMul x ⁻¹' s) = 0 := by

--- a/Mathlib/MeasureTheory/Group/Convolution.lean
+++ b/Mathlib/MeasureTheory/Group/Convolution.lean
@@ -146,24 +146,19 @@ instance probabilitymeasure_of_probabilitymeasures_mconv (μ : Measure M) (ν : 
     IsProbabilityMeasure (μ ∗ₘ ν) :=
   MeasureTheory.isProbabilityMeasure_map (by fun_prop)
 
--- TODO: Clean Proof!
 @[to_additive]
 theorem mconv_absolutelyContinuous [MeasurableMul₂ M] {μ ν ρ : Measure M}
     [IsMulLeftInvariant ρ] [SFinite ν] (hν : ν ≪ ρ) : μ ∗ₘ ν ≪ ρ := by
   refine AbsolutelyContinuous.mk (fun s hs h ↦ ?_)
   rw [← lintegral_indicator_one hs, lintegral_mconv (by measurability)]
-  conv =>
-    enter [1, 2, x, 2, y]
-    change s.indicator 1 ((fun y ↦ x * y) y)
-    simp [← Set.indicator_comp_right]
-  conv =>
-    enter [1, 2, x]
+  conv in s.indicator 1 (_ * _) => change s.indicator 1 ((fun y ↦ x * y) y)
+  simp [← Set.indicator_comp_right]
+  conv in ∫⁻ _, _ ∂ν =>
     rw [lintegral_indicator_one (by apply MeasurableSet.preimage hs (by fun_prop))]
-  have : ∀ x : M, ν (HMul.hMul x ⁻¹' s) = 0 := by
-    intro x
+  have h0 (x : M) : ν (HMul.hMul x ⁻¹' s) = 0 := by
     apply hν
     rw [← map_apply (by fun_prop) hs, IsMulLeftInvariant.map_mul_left_eq_self, h]
-  simp [this]
+  simp [h0]
 
 @[to_additive]
 lemma map_mconv_monoidHom {M M' : Type*} {mM : MeasurableSpace M} [Monoid M] [MeasurableMul₂ M]

--- a/Mathlib/MeasureTheory/Group/Convolution.lean
+++ b/Mathlib/MeasureTheory/Group/Convolution.lean
@@ -5,6 +5,7 @@ Authors: Josha Dekker
 -/
 import Mathlib.MeasureTheory.Measure.MeasureSpace
 import Mathlib.MeasureTheory.Measure.Prod
+import Mathlib.MeasureTheory.Group.Defs
 
 /-!
 # The multiplicative and additive convolution of measures
@@ -144,6 +145,25 @@ instance probabilitymeasure_of_probabilitymeasures_mconv (μ : Measure M) (ν : 
     [MeasurableMul₂ M] [IsProbabilityMeasure μ] [IsProbabilityMeasure ν] :
     IsProbabilityMeasure (μ ∗ₘ ν) :=
   MeasureTheory.isProbabilityMeasure_map (by fun_prop)
+
+-- TODO: Clean Proof!
+@[to_additive]
+theorem mconv_absolutelyContinuous [MeasurableMul₂ M] {μ ν ρ : Measure M}
+    [IsMulLeftInvariant ρ] [SFinite ν] (hν : ν ≪ ρ) : μ ∗ₘ ν ≪ ρ := by
+  refine AbsolutelyContinuous.mk (fun s hs h ↦ ?_)
+  rw [← lintegral_indicator_one hs, lintegral_mconv (by measurability)]
+  conv =>
+    enter [1, 2, x, 2, y]
+    change s.indicator 1 ((fun y ↦ x * y) y)
+    simp [← Set.indicator_comp_right]
+  conv =>
+    enter [1, 2, x]
+    rw [lintegral_indicator_one (by apply MeasurableSet.preimage hs (by fun_prop))]
+  have : ∀ x : M, ν (HMul.hMul x ⁻¹' s) = 0 := by
+    intro x
+    apply hν
+    rw [← map_apply (by fun_prop) hs, IsMulLeftInvariant.map_mul_left_eq_self, h]
+  simp [this]
 
 @[to_additive]
 lemma map_mconv_monoidHom {M M' : Type*} {mM : MeasurableSpace M} [Monoid M] [MeasurableMul₂ M]

--- a/Mathlib/MeasureTheory/Measure/Decomposition/Lebesgue.lean
+++ b/Mathlib/MeasureTheory/Measure/Decomposition/Lebesgue.lean
@@ -6,7 +6,6 @@ Authors: Kexing Ying
 import Mathlib.MeasureTheory.Measure.Decomposition.Hahn
 import Mathlib.MeasureTheory.Function.AEEqOfLIntegral
 import Mathlib.MeasureTheory.Measure.Sub
-import Mathlib.Analysis.LConvolution
 
 /-!
 # Lebesgue decomposition

--- a/Mathlib/MeasureTheory/Measure/Decomposition/Lebesgue.lean
+++ b/Mathlib/MeasureTheory/Measure/Decomposition/Lebesgue.lean
@@ -6,6 +6,7 @@ Authors: Kexing Ying
 import Mathlib.MeasureTheory.Measure.Decomposition.Hahn
 import Mathlib.MeasureTheory.Function.AEEqOfLIntegral
 import Mathlib.MeasureTheory.Measure.Sub
+import Mathlib.Analysis.LConvolution
 
 /-!
 # Lebesgue decomposition

--- a/Mathlib/MeasureTheory/Measure/Decomposition/RadonNikodym.lean
+++ b/Mathlib/MeasureTheory/Measure/Decomposition/RadonNikodym.lean
@@ -542,7 +542,7 @@ theorem rnDeriv_mconv [SFinite μ] {ν₁ ν₂ : Measure G} [IsFiniteMeasure ν
   exact (lintegral_rnDeriv_lt_top (ν₁ ∗ₘ ν₂) μ).ne
 
 @[to_additive]
-theorem rnDeriv_mconv' [SigmaFinite μ] (ν₁ ν₂ : Measure G) [SigmaFinite ν₁] [SigmaFinite ν₂]
+theorem rnDeriv_mconv' [SigmaFinite μ] {ν₁ ν₂ : Measure G} [SigmaFinite ν₁] [SigmaFinite ν₂]
     (hν₁ : ν₁ ≪ μ) (hν₂ : ν₂ ≪ μ) :
     (ν₁ ∗ₘ ν₂).rnDeriv μ =ᵐ[μ] (ν₁.rnDeriv μ) ⋆ₘₗ[μ] (ν₂.rnDeriv μ) := by
   rw [← withDensity_eq_iff_of_sigmaFinite (by fun_prop) (by fun_prop),

--- a/Mathlib/MeasureTheory/Measure/Decomposition/RadonNikodym.lean
+++ b/Mathlib/MeasureTheory/Measure/Decomposition/RadonNikodym.lean
@@ -520,4 +520,22 @@ lemma setIntegral_rnDeriv_smul' [SigmaFinite ν] (hμν : μ ≪ ν) (s : Set α
 
 end IntegralRNDerivMul
 
+section Conv
+
+open Measure
+
+variable {G : Type*} [Group G] [MeasureSpace G] [MeasurableMul₂ G] [MeasurableInv G]
+  {μ : Measure G} [SFinite μ] [IsMulLeftInvariant μ]
+
+-- I guess I should give a proof for monoids...
+@[to_additive]
+theorem mconv_absolutelyContinuous (ν₁ ν₂ : Measure G)
+    [ν₁.HaveLebesgueDecomposition μ] [ν₂.HaveLebesgueDecomposition μ]
+    (hν₁ : ν₁ ≪ μ) (hν₂ : ν₂ ≪ μ) : ν₁ ∗ₘ ν₂ ≪ μ := by
+  rw [← withDensity_rnDeriv_eq _ _  hν₁, ← withDensity_rnDeriv_eq _ _  hν₂,
+    mconv_withDensity_eq_mlconvolution (by fun_prop) (by fun_prop)]
+  exact withDensity_absolutelyContinuous _ _
+
+end Conv
+
 end MeasureTheory

--- a/Mathlib/MeasureTheory/Measure/Decomposition/RadonNikodym.lean
+++ b/Mathlib/MeasureTheory/Measure/Decomposition/RadonNikodym.lean
@@ -525,16 +525,27 @@ section Conv
 open Measure
 
 variable {G : Type*} [Group G] [MeasureSpace G] [MeasurableMul₂ G] [MeasurableInv G]
-  {μ : Measure G} [SFinite μ] [IsMulLeftInvariant μ]
+  {μ : Measure G} [IsMulLeftInvariant μ]
 
--- I guess I should give a proof for monoids...
 @[to_additive]
-theorem mconv_absolutelyContinuous (ν₁ ν₂ : Measure G)
+theorem rnDeriv_mconv [SFinite μ] (ν₁ ν₂ : Measure G) [IsFiniteMeasure ν₁] [IsFiniteMeasure ν₂]
     [ν₁.HaveLebesgueDecomposition μ] [ν₂.HaveLebesgueDecomposition μ]
-    (hν₁ : ν₁ ≪ μ) (hν₂ : ν₂ ≪ μ) : ν₁ ∗ₘ ν₂ ≪ μ := by
-  rw [← withDensity_rnDeriv_eq _ _  hν₁, ← withDensity_rnDeriv_eq _ _  hν₂,
-    mconv_withDensity_eq_mlconvolution (by fun_prop) (by fun_prop)]
-  exact withDensity_absolutelyContinuous _ _
+    [(ν₁ ∗ₘ ν₂).HaveLebesgueDecomposition μ] (hν₁ : ν₁ ≪ μ) (hν₂ : ν₂ ≪ μ) :
+    (ν₁ ∗ₘ ν₂).rnDeriv μ =ᵐ[μ] (ν₁.rnDeriv μ) ⋆ₘₗ[μ] (ν₂.rnDeriv μ) := by
+  rw [← withDensity_eq_iff (by fun_prop) (by fun_prop),
+    withDensity_rnDeriv_eq _ _ (mconv_absolutelyContinuous hν₂),
+    ← mconv_withDensity_eq_mlconvolution (by fun_prop) (by fun_prop),
+    withDensity_rnDeriv_eq _ _ hν₁, withDensity_rnDeriv_eq _ _ hν₂]
+  exact (lintegral_rnDeriv_lt_top (ν₁ ∗ₘ ν₂) μ).ne
+
+@[to_additive]
+theorem rnDeriv_mconv' [SigmaFinite μ] (ν₁ ν₂ : Measure G) [SigmaFinite ν₁] [SigmaFinite ν₂]
+    (hν₁ : ν₁ ≪ μ) (hν₂ : ν₂ ≪ μ) :
+    (ν₁ ∗ₘ ν₂).rnDeriv μ =ᵐ[μ] (ν₁.rnDeriv μ) ⋆ₘₗ[μ] (ν₂.rnDeriv μ) := by
+  rw [← withDensity_eq_iff_of_sigmaFinite (by fun_prop) (by fun_prop),
+    withDensity_rnDeriv_eq _ _ (mconv_absolutelyContinuous hν₂),
+    ← mconv_withDensity_eq_mlconvolution (by fun_prop) (by fun_prop),
+    withDensity_rnDeriv_eq _ _ hν₁, withDensity_rnDeriv_eq _ _ hν₂]
 
 end Conv
 

--- a/Mathlib/MeasureTheory/Measure/Decomposition/RadonNikodym.lean
+++ b/Mathlib/MeasureTheory/Measure/Decomposition/RadonNikodym.lean
@@ -528,14 +528,17 @@ variable {G : Type*} [Group G] [MeasureSpace G] [MeasurableMul₂ G] [Measurable
   {μ : Measure G} [IsMulLeftInvariant μ]
 
 @[to_additive]
-theorem rnDeriv_mconv [SFinite μ] (ν₁ ν₂ : Measure G) [IsFiniteMeasure ν₁] [IsFiniteMeasure ν₂]
+theorem rnDeriv_mconv [SFinite μ] {ν₁ ν₂ : Measure G} [IsFiniteMeasure ν₁] [IsFiniteMeasure ν₂]
     [ν₁.HaveLebesgueDecomposition μ] [ν₂.HaveLebesgueDecomposition μ]
-    [(ν₁ ∗ₘ ν₂).HaveLebesgueDecomposition μ] (hν₁ : ν₁ ≪ μ) (hν₂ : ν₂ ≪ μ) :
+    (hν₁ : ν₁ ≪ μ) (hν₂ : ν₂ ≪ μ) :
     (ν₁ ∗ₘ ν₂).rnDeriv μ =ᵐ[μ] (ν₁.rnDeriv μ) ⋆ₘₗ[μ] (ν₂.rnDeriv μ) := by
+  have h_eq : ν₁ ∗ₘ ν₂ = μ.withDensity (ν₁.rnDeriv μ ⋆ₘₗ[μ] ν₂.rnDeriv μ) := by
+    rw [← mconv_withDensity_eq_mlconvolution (by fun_prop) (by fun_prop),
+      withDensity_rnDeriv_eq _ _ hν₁, withDensity_rnDeriv_eq _ _ hν₂]
+  have : (ν₁ ∗ₘ ν₂).HaveLebesgueDecomposition μ :=
+    ⟨⟨0, (ν₁.rnDeriv μ) ⋆ₘₗ[μ] (ν₂.rnDeriv μ)⟩, by fun_prop, by simp, by simpa⟩
   rw [← withDensity_eq_iff (by fun_prop) (by fun_prop),
-    withDensity_rnDeriv_eq _ _ (mconv_absolutelyContinuous hν₂),
-    ← mconv_withDensity_eq_mlconvolution (by fun_prop) (by fun_prop),
-    withDensity_rnDeriv_eq _ _ hν₁, withDensity_rnDeriv_eq _ _ hν₂]
+    withDensity_rnDeriv_eq _ _ (mconv_absolutelyContinuous hν₂), h_eq]
   exact (lintegral_rnDeriv_lt_top (ν₁ ∗ₘ ν₂) μ).ne
 
 @[to_additive]


### PR DESCRIPTION
Add `rnDeriv_mconv` and `rnDeriv_mconv'` which give formulas (up to almost everywhere equality) for the Radon-Nikodym derivative of a convolution of measures in terms of the Radon-Nikodym derivatives of the individual measures. The theorems have different assumptions on the measures (which match the difference in the assumptions of `withDensity_eq_iff` and `withDensity_eq_iff_of_SigmaFinite`). 

Also add `mconv_absolutelyContinuous` which shows that absolute continuity is preserved under convolution of measures (with sufficient assumptions). 
