### PR TITLE
feat(CategoryTheory/MarkovCategory): add Markov categories

### DIFF
--- a/Mathlib.lean
+++ b/Mathlib.lean
@@ -2526,6 +2526,10 @@ import Mathlib.CategoryTheory.Localization.StructuredArrow
 import Mathlib.CategoryTheory.Localization.Triangulated
 import Mathlib.CategoryTheory.Localization.Trifunctor
 import Mathlib.CategoryTheory.LocallyDirected
+import Mathlib.CategoryTheory.MarkovCategory.Basic
+import Mathlib.CategoryTheory.MarkovCategory.Cartesian
+import Mathlib.CategoryTheory.MarkovCategory.FinStoch.Basic
+import Mathlib.CategoryTheory.MarkovCategory.FinStoch.Monoidal
 import Mathlib.CategoryTheory.Monad.Adjunction
 import Mathlib.CategoryTheory.Monad.Algebra
 import Mathlib.CategoryTheory.Monad.Basic

--- a/Mathlib.lean
+++ b/Mathlib.lean
@@ -2181,6 +2181,8 @@ import Mathlib.CategoryTheory.ConcreteCategory.ReflectsIso
 import Mathlib.CategoryTheory.ConcreteCategory.UnbundledHom
 import Mathlib.CategoryTheory.Conj
 import Mathlib.CategoryTheory.ConnectedComponents
+import Mathlib.CategoryTheory.CopyDiscardCategory.Basic
+import Mathlib.CategoryTheory.CopyDiscardCategory.Deterministic
 import Mathlib.CategoryTheory.Core
 import Mathlib.CategoryTheory.Countable
 import Mathlib.CategoryTheory.Dialectica.Basic
@@ -2529,6 +2531,9 @@ import Mathlib.CategoryTheory.LocallyDirected
 import Mathlib.CategoryTheory.MarkovCategory.Basic
 import Mathlib.CategoryTheory.MarkovCategory.Cartesian
 import Mathlib.CategoryTheory.MarkovCategory.FinStoch.Basic
+import Mathlib.CategoryTheory.MarkovCategory.FinStoch.Braided
+import Mathlib.CategoryTheory.MarkovCategory.FinStoch.CopyDiscard
+import Mathlib.CategoryTheory.MarkovCategory.FinStoch.Markov
 import Mathlib.CategoryTheory.MarkovCategory.FinStoch.Monoidal
 import Mathlib.CategoryTheory.Monad.Adjunction
 import Mathlib.CategoryTheory.Monad.Algebra
@@ -2567,6 +2572,7 @@ import Mathlib.CategoryTheory.Monoidal.Cartesian.Over
 import Mathlib.CategoryTheory.Monoidal.Category
 import Mathlib.CategoryTheory.Monoidal.Center
 import Mathlib.CategoryTheory.Monoidal.CoherenceLemmas
+import Mathlib.CategoryTheory.Monoidal.CommComon_
 import Mathlib.CategoryTheory.Monoidal.CommGrp_
 import Mathlib.CategoryTheory.Monoidal.CommMon_
 import Mathlib.CategoryTheory.Monoidal.Comon_

--- a/Mathlib/CategoryTheory/Bicategory/Monad/Basic.lean
+++ b/Mathlib/CategoryTheory/Bicategory/Monad/Basic.lean
@@ -70,7 +70,7 @@ end
 
 @[simps! counit]
 instance {a : B} : Comonad (𝟙 a) :=
-  inferInstanceAs <| ComonObj (MonoidalCategory.tensorUnit (a ⟶ a))
+  ComonObj.instTensorUnit (a ⟶ a)
 
 /-- An oplax functor from the trivial bicategory to `B` defines a comonad in `B`. -/
 def ofOplaxFromUnit (F : OplaxFunctor (LocallyDiscrete (Discrete Unit)) B) :

--- a/Mathlib/CategoryTheory/CopyDiscardCategory/Basic.lean
+++ b/Mathlib/CategoryTheory/CopyDiscardCategory/Basic.lean
@@ -64,28 +64,6 @@ namespace CopyDiscardCategory
 
 variable [CopyDiscardCategory C]
 
-/-! ### Basic properties -/
-
-/-- Copy then discard left recovers original. -/
-@[simp]
-lemma copy_discard_left (X : C) : Δ[X] ≫ (ε[X] ▷ X) = (λ_ X).inv :=
-  counit_comul X
-
-/-- Copy then discard right recovers original. -/
-@[simp]
-lemma copy_discard_right (X : C) : Δ[X] ≫ (X ◁ ε[X]) = (ρ_ X).inv :=
-  comul_counit X
-
-/-- Copying is associative. -/
-@[simp]
-lemma copy_assoc (X : C) : Δ[X] ≫ (Δ[X] ▷ X) = Δ[X] ≫ (X ◁ Δ[X]) ≫ (α_ X X X).inv :=
-  comul_assoc_flip X
-
-/-- Swapping copies does nothing. -/
-@[simp]
-lemma copy_swap (X : C) : Δ[X] ≫ (β_ X X).hom = Δ[X] :=
-  isComm
-
 /-! ### Unit coherence -/
 
 /-- Counit on the monoidal unit is the identity. -/
@@ -100,10 +78,7 @@ lemma comul_unit : Δ[𝟙_ C] = (λ_ (𝟙_ C)).inv :=
 
 /-! ### Tensor product lemmas -/
 
-/-- How to copy tensor products. -/
-@[simp]
-lemma copy_tensor_simp (X Y : C) : Δ[X ⊗ Y] = (Δ[X] ⊗ₘ Δ[Y]) ≫ tensorμ X X Y Y :=
-  copy_tensor X Y
+-- Note: copy_tensor_simp was removed as it was redundant with copy_tensor
 
 /-- How to discard tensor products. -/
 @[simp]

--- a/Mathlib/CategoryTheory/CopyDiscardCategory/Basic.lean
+++ b/Mathlib/CategoryTheory/CopyDiscardCategory/Basic.lean
@@ -63,15 +63,6 @@ namespace CopyDiscardCategory
 
 variable [CopyDiscardCategory C]
 
-/-! ### Tensor product lemmas -/
-
--- Note: copy_tensor_simp was removed as it was redundant with copy_tensor
-
-/-- How to discard tensor products. -/
-@[simp]
-lemma discard_tensor_simp (X Y : C) : ε[X ⊗ Y] = (ε[X] ⊗ₘ ε[Y]) ≫ (λ_ (𝟙_ C)).hom :=
-  discard_tensor X Y
-
 end CopyDiscardCategory
 
 end CategoryTheory

--- a/Mathlib/CategoryTheory/CopyDiscardCategory/Basic.lean
+++ b/Mathlib/CategoryTheory/CopyDiscardCategory/Basic.lean
@@ -47,34 +47,21 @@ class CopyDiscardCategory (C : Type*) [Category C] [MonoidalCategory C]
   /-- Every object has commutative comonoid structure. -/
   commComonObj (X : C) : CommComonObj X := by infer_instance
   /-- Tensor products of copies equal copies of tensor products. -/
-  copy_tensor (X Y : C) : Δ[X ⊗ Y] = (Δ[X] ⊗ₘ Δ[Y]) ≫ tensorμ X X Y Y
+  copy_tensor (X Y : C) : Δ[X ⊗ Y] = (Δ[X] ⊗ₘ Δ[Y]) ≫ tensorμ X X Y Y := by cat_disch
   /-- Discard distributes over tensor. -/
-  discard_tensor (X Y : C) : ε[X ⊗ Y] = (ε[X] ⊗ₘ ε[Y]) ≫ (λ_ (𝟙_ C)).hom
+  discard_tensor (X Y : C) : ε[X ⊗ Y] = (ε[X] ⊗ₘ ε[Y]) ≫ (λ_ (𝟙_ C)).hom := by cat_disch
   /-- Unit axioms. -/
-  copy_unit : Δ[𝟙_ C] = (λ_ (𝟙_ C)).inv
-  discard_unit : ε[𝟙_ C] = 𝟙 (𝟙_ C)
+  copy_unit : Δ[𝟙_ C] = (λ_ (𝟙_ C)).inv := by cat_disch
+  discard_unit : ε[𝟙_ C] = 𝟙 (𝟙_ C) := by cat_disch
 
 -- This gives access to the CommComonObj instances
-instance (X : C) [CopyDiscardCategory C] : CommComonObj X :=
-  CopyDiscardCategory.commComonObj X
+attribute [instance] CopyDiscardCategory.commComonObj
 
 open scoped ComonObj
 
 namespace CopyDiscardCategory
 
 variable [CopyDiscardCategory C]
-
-/-! ### Unit coherence -/
-
-/-- Counit on the monoidal unit is the identity. -/
-@[simp]
-lemma counit_unit : ε[𝟙_ C] = 𝟙 (𝟙_ C) :=
-  discard_unit
-
-/-- Comultiplication on the monoidal unit is the left unitor inverse. -/
-@[simp]
-lemma comul_unit : Δ[𝟙_ C] = (λ_ (𝟙_ C)).inv :=
-  copy_unit
 
 /-! ### Tensor product lemmas -/
 

--- a/Mathlib/CategoryTheory/CopyDiscardCategory/Basic.lean
+++ b/Mathlib/CategoryTheory/CopyDiscardCategory/Basic.lean
@@ -1,0 +1,182 @@
+/-
+Copyright (c) 2025 Jacob Reinhold. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Jacob Reinhold
+-/
+import Mathlib.CategoryTheory.Monoidal.Braided.Basic
+import Mathlib.CategoryTheory.Monoidal.Comon_
+import Mathlib.CategoryTheory.Monoidal.CoherenceLemmas
+
+/-!
+# Copy-Discard Categories
+
+This file defines copy-discard (CD) categories, which model how we can duplicate
+and delete information.
+
+A CD category is a symmetric monoidal category where every object has a fixed
+way to copy and delete itself. These operations work well with tensor products.
+Copying duplicates information; deletion removes it.
+
+## Key ideas
+
+CD categories model information flow without normalization. Unlike Markov categories
+(which require natural deletion), CD categories allow non-normalized processes.
+
+Duplication and deletion make sense without probability. CD categories model:
+- Resource management in programs
+- Information flow without probability
+- Quantum-like systems without normalization
+- Computation with explicit resources
+
+## Main definitions
+
+* `CopyDiscardCategory` - Symmetric monoidal category with comonoid structure
+* `middleFourInterchange` - Rearranges tensor products for copying
+* `CopyDiscardCategory.copyMor` - Copy morphism `X → X ⊗ X`
+* `CopyDiscardCategory.delMor` - Delete morphism `X → I`
+
+## Notations
+
+* `Δ[X]` - Copy morphism for object `X`
+* `ε[X]` - Delete morphism for object `X`
+
+## Related structures
+
+* **Markov categories**: Add natural deletion (see `MarkovCategory`)
+* **Cartesian categories**: All morphisms preserve copying perfectly
+* **Comonoid objects**: Every object has fixed comonoid structure
+
+## Design notes
+
+We make the comonoid structure part of the typeclass, not separate.
+This ensures each object has exactly one way to copy and delete.
+
+We extend `SymmetricCategory`, not just `BraidedCategory`, because
+order rarely matters for independent processes.
+
+## References
+
+* [Coecke and Perdrix,
+  *Environment and classical channels in categorical quantum mechanics*][coecke2012]
+* [Fritz, *A synthetic approach to Markov kernels, conditional independence
+  and theorems on sufficient statistics*][fritz2020]
+
+## Tags
+
+copy-discard category, garbage-share category, comonoid, information flow
+-/
+
+universe u v
+
+namespace CategoryTheory
+
+open MonoidalCategory
+
+section HelperMorphisms
+
+variable {C : Type u} [Category.{v} C] [MonoidalCategory.{v} C] [BraidedCategory.{v} C]
+
+/-- Rearranges `(W ⊗ X) ⊗ (Y ⊗ Z)` to `(W ⊗ Y) ⊗ (X ⊗ Z)`.
+
+Used to express how copying distributes over tensor products:
+copying `X ⊗ Y` gives `(X ⊗ Y) ⊗ (X ⊗ Y)`, which we rearrange to `(X ⊗ X) ⊗ (Y ⊗ Y)`. -/
+def middleFourInterchange (W X Y Z : C) : (W ⊗ X) ⊗ (Y ⊗ Z) ⟶ (W ⊗ Y) ⊗ (X ⊗ Z) :=
+  (α_ W X (Y ⊗ Z)).hom ≫
+  (𝟙 W ⊗ₘ (α_ X Y Z).inv) ≫
+  (𝟙 W ⊗ₘ ((β_ X Y).hom ⊗ₘ 𝟙 Z)) ≫
+  (𝟙 W ⊗ₘ (α_ Y X Z).hom) ≫
+  (α_ W Y (X ⊗ Z)).inv
+
+end HelperMorphisms
+
+variable {C : Type u} [Category.{v} C] [MonoidalCategory.{v} C]
+
+/-- A symmetric monoidal category where every object has a fixed way to copy and delete itself.
+
+These operations work with tensor products: copying a pair duplicates both components,
+and deleting a pair means deleting both parts. -/
+class CopyDiscardCategory (C : Type u) [Category.{v} C] [MonoidalCategory.{v} C]
+extends SymmetricCategory.{v} C where
+  /-- Copy morphism that duplicates an object: `X → X ⊗ X`. -/
+  copyMor : ∀ X : C, X ⟶ X ⊗ X
+  /-- Delete morphism that discards an object: `X → 𝟙`. -/
+  delMor : ∀ X : C, X ⟶ 𝟙_ C
+  /-- Copying is symmetric: swapping the two copies gives the same result. -/
+  copy_comm : ∀ X, copyMor X ≫ (β_ X X).hom = copyMor X
+  /-- Copying then deleting the first copy recovers the original. -/
+  counit_comul : ∀ X, copyMor X ≫ (delMor X ▷ X) = (λ_ X).inv
+  /-- Copying then deleting the second copy recovers the original. -/
+  comul_counit : ∀ X, copyMor X ≫ (X ◁ delMor X) = (ρ_ X).inv
+  /-- Copying twice (either copy first) gives three copies arranged the same way. -/
+  coassoc : ∀ X, copyMor X ≫ (copyMor X ▷ X) = copyMor X ≫ (X ◁ copyMor X) ≫ (α_ X X X).inv
+  /-- Copying a tensor product: `copy(X ⊗ Y)` rearranges to `(X ⊗ X) ⊗ (Y ⊗ Y)`. -/
+  copy_tensor : ∀ X Y, copyMor (X ⊗ Y) =
+    (copyMor X ⊗ₘ copyMor Y) ≫ middleFourInterchange X X Y Y
+  /-- Deleting a tensor product means deleting both components. -/
+  del_tensor : ∀ X Y, delMor (X ⊗ Y) = (delMor X ⊗ₘ delMor Y) ≫ (λ_ (𝟙_ C)).hom
+
+namespace CopyDiscardCategory
+
+variable {C : Type u} [Category.{v} C] [MonoidalCategory.{v} C] [CopyDiscardCategory C]
+
+/-- Notation for the copy morphism in a copy-discard category -/
+scoped notation "Δ[" X "]" => copyMor X
+
+/-- Notation for the delete morphism in a copy-discard category -/
+scoped notation "ε[" X "]" => delMor X
+
+/-- Every object in a copy-discard category forms a comonoid using its copy and delete morphisms. -/
+instance instComonObj (X : C) : ComonObj X where
+  counit := ε[X]
+  comul := Δ[X]
+  counit_comul := by simp only [counit_comul]
+  comul_counit := by simp only [comul_counit]
+  comul_assoc := by
+    -- Convert between conventions: we use (α_)⁻¹, Comon_ uses α
+    have h := coassoc X
+    calc Δ[X] ≫ X ◁ Δ[X]
+      = Δ[X] ≫ X ◁ Δ[X] ≫ 𝟙 _ := by rw [Category.comp_id]
+      _ = Δ[X] ≫ X ◁ Δ[X] ≫ ((α_ X X X).inv ≫ (α_ X X X).hom) := by rw [Iso.inv_hom_id]
+      _ = (Δ[X] ≫ X ◁ Δ[X] ≫ (α_ X X X).inv) ≫ (α_ X X X).hom := by
+        rw [Category.assoc, Category.assoc]
+      _ = (Δ[X] ≫ Δ[X] ▷ X) ≫ (α_ X X X).hom := by rw [← h]
+      _ = Δ[X] ≫ Δ[X] ▷ X ≫ (α_ X X X).hom := by rw [Category.assoc]
+
+/-- The identity morphism preserves copying. -/
+@[simp]
+lemma id_copy (X : C) : 𝟙 X ≫ Δ[X] = Δ[X] := Category.id_comp _
+
+/-- The identity morphism preserves deletion. -/
+@[simp]
+lemma id_del (X : C) : 𝟙 X ≫ ε[X] = ε[X] := Category.id_comp _
+
+/-- Copying then deleting the first copy recovers the original. -/
+@[simp, reassoc]
+lemma copy_comp_del_left (X : C) : Δ[X] ≫ (ε[X] ▷ X) = (λ_ X).inv := counit_comul X
+
+/-- Copying then deleting the second copy recovers the original. -/
+@[simp, reassoc]
+lemma copy_comp_del_right (X : C) : Δ[X] ≫ (X ◁ ε[X]) = (ρ_ X).inv := comul_counit X
+
+/-- Copying is symmetric: swapping the copies gives the same result. -/
+@[simp, reassoc]
+lemma copy_comp_braiding (X : C) : Δ[X] ≫ (β_ X X).hom = Δ[X] := copy_comm X
+
+/-- Copying then copying the first output equals copying then copying the second output. -/
+@[simp, reassoc]
+lemma copy_comp_copy_left (X : C) :
+    Δ[X] ≫ (Δ[X] ▷ X) = Δ[X] ≫ (X ◁ Δ[X]) ≫ (α_ X X X).inv := coassoc X
+
+/-- Copying a tensor product: `copy(X ⊗ Y)` rearranges to `(X ⊗ X) ⊗ (Y ⊗ Y)`. -/
+@[simp]
+lemma copy_tensor_eq (X Y : C) :
+    Δ[X ⊗ Y] = (Δ[X] ⊗ₘ Δ[Y]) ≫ middleFourInterchange X X Y Y := copy_tensor X Y
+
+/-- Deleting a tensor product means deleting both components. -/
+@[simp]
+lemma del_tensor_eq (X Y : C) :
+    ε[X ⊗ Y] = (ε[X] ⊗ₘ ε[Y]) ≫ (λ_ (𝟙_ C)).hom := del_tensor X Y
+
+end CopyDiscardCategory
+
+end CategoryTheory

--- a/Mathlib/CategoryTheory/CopyDiscardCategory/Basic.lean
+++ b/Mathlib/CategoryTheory/CopyDiscardCategory/Basic.lean
@@ -3,179 +3,112 @@ Copyright (c) 2025 Jacob Reinhold. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Jacob Reinhold
 -/
-import Mathlib.CategoryTheory.Monoidal.Braided.Basic
-import Mathlib.CategoryTheory.Monoidal.Comon_
-import Mathlib.CategoryTheory.Monoidal.CoherenceLemmas
+import Mathlib.CategoryTheory.Monoidal.CommComon_
 
 /-!
 # Copy-Discard Categories
 
-This file defines copy-discard (CD) categories, which model how we can duplicate
-and delete information.
-
-A CD category is a symmetric monoidal category where every object has a fixed
-way to copy and delete itself. These operations work well with tensor products.
-Copying duplicates information; deletion removes it.
-
-## Key ideas
-
-CD categories model information flow without normalization. Unlike Markov categories
-(which require natural deletion), CD categories allow non-normalized processes.
-
-Duplication and deletion make sense without probability. CD categories model:
-- Resource management in programs
-- Information flow without probability
-- Quantum-like systems without normalization
-- Computation with explicit resources
+Symmetric monoidal categories where every object has commutative
+comonoid structure compatible with tensor products.
 
 ## Main definitions
 
-* `CopyDiscardCategory` - Symmetric monoidal category with comonoid structure
-* `middleFourInterchange` - Rearranges tensor products for copying
-* `CopyDiscardCategory.copyMor` - Copy morphism `X → X ⊗ X`
-* `CopyDiscardCategory.delMor` - Delete morphism `X → I`
+* `CopyDiscardCategory` - Category with coherent copy and delete
 
 ## Notations
 
-* `Δ[X]` - Copy morphism for object `X`
-* `ε[X]` - Delete morphism for object `X`
+* `Δ[X]` - Copy morphism for X (from ComonObj)
+* `ε[X]` - Delete morphism for X (from ComonObj)
 
-## Related structures
+## Implementation notes
 
-* **Markov categories**: Add natural deletion (see `MarkovCategory`)
-* **Cartesian categories**: All morphisms preserve copying perfectly
-* **Comonoid objects**: Every object has fixed comonoid structure
-
-## Design notes
-
-We make the comonoid structure part of the typeclass, not separate.
-This ensures each object has exactly one way to copy and delete.
-
-We extend `SymmetricCategory`, not just `BraidedCategory`, because
-order rarely matters for independent processes.
+We use CommComonObj instances to provide the comonoid structure.
+The key axioms ensure tensor products respect the comonoid structure.
 
 ## References
 
-* [Coecke and Perdrix,
-  *Environment and classical channels in categorical quantum mechanics*][coecke2012]
 * [Fritz, *A synthetic approach to Markov kernels, conditional independence
   and theorems on sufficient statistics*][fritz2020]
 
 ## Tags
 
-copy-discard category, garbage-share category, comonoid, information flow
+copy-discard, comonoid, symmetric monoidal
 -/
-
-universe u v
 
 namespace CategoryTheory
 
-open MonoidalCategory
+open MonoidalCategory ComonObj CommComonObj
 
-section HelperMorphisms
+variable {C : Type*} [Category C] [MonoidalCategory C]
 
-variable {C : Type u} [Category.{v} C] [MonoidalCategory.{v} C] [BraidedCategory.{v} C]
+/-- Category where objects have compatible copy and discard operations. -/
+class CopyDiscardCategory (C : Type*) [Category C] [MonoidalCategory C]
+    extends SymmetricCategory C where
+  /-- Every object has commutative comonoid structure. -/
+  commComonObj (X : C) : CommComonObj X := by infer_instance
+  /-- Tensor products of copies equal copies of tensor products. -/
+  copy_tensor (X Y : C) : Δ[X ⊗ Y] = (Δ[X] ⊗ₘ Δ[Y]) ≫ tensorμ X X Y Y
+  /-- Discard distributes over tensor. -/
+  discard_tensor (X Y : C) : ε[X ⊗ Y] = (ε[X] ⊗ₘ ε[Y]) ≫ (λ_ (𝟙_ C)).hom
+  /-- Unit axioms. -/
+  copy_unit : Δ[𝟙_ C] = (λ_ (𝟙_ C)).inv
+  discard_unit : ε[𝟙_ C] = 𝟙 (𝟙_ C)
 
-/-- Rearranges `(W ⊗ X) ⊗ (Y ⊗ Z)` to `(W ⊗ Y) ⊗ (X ⊗ Z)`.
+-- This gives access to the CommComonObj instances
+instance (X : C) [CopyDiscardCategory C] : CommComonObj X :=
+  CopyDiscardCategory.commComonObj X
 
-Used to express how copying distributes over tensor products:
-copying `X ⊗ Y` gives `(X ⊗ Y) ⊗ (X ⊗ Y)`, which we rearrange to `(X ⊗ X) ⊗ (Y ⊗ Y)`. -/
-def middleFourInterchange (W X Y Z : C) : (W ⊗ X) ⊗ (Y ⊗ Z) ⟶ (W ⊗ Y) ⊗ (X ⊗ Z) :=
-  (α_ W X (Y ⊗ Z)).hom ≫
-  (𝟙 W ⊗ₘ (α_ X Y Z).inv) ≫
-  (𝟙 W ⊗ₘ ((β_ X Y).hom ⊗ₘ 𝟙 Z)) ≫
-  (𝟙 W ⊗ₘ (α_ Y X Z).hom) ≫
-  (α_ W Y (X ⊗ Z)).inv
-
-end HelperMorphisms
-
-variable {C : Type u} [Category.{v} C] [MonoidalCategory.{v} C]
-
-/-- A symmetric monoidal category where every object has a fixed way to copy and delete itself.
-
-These operations work with tensor products: copying a pair duplicates both components,
-and deleting a pair means deleting both parts. -/
-class CopyDiscardCategory (C : Type u) [Category.{v} C] [MonoidalCategory.{v} C]
-extends SymmetricCategory.{v} C where
-  /-- Copy morphism that duplicates an object: `X → X ⊗ X`. -/
-  copyMor : ∀ X : C, X ⟶ X ⊗ X
-  /-- Delete morphism that discards an object: `X → 𝟙`. -/
-  delMor : ∀ X : C, X ⟶ 𝟙_ C
-  /-- Copying is symmetric: swapping the two copies gives the same result. -/
-  copy_comm : ∀ X, copyMor X ≫ (β_ X X).hom = copyMor X
-  /-- Copying then deleting the first copy recovers the original. -/
-  counit_comul : ∀ X, copyMor X ≫ (delMor X ▷ X) = (λ_ X).inv
-  /-- Copying then deleting the second copy recovers the original. -/
-  comul_counit : ∀ X, copyMor X ≫ (X ◁ delMor X) = (ρ_ X).inv
-  /-- Copying twice (either copy first) gives three copies arranged the same way. -/
-  coassoc : ∀ X, copyMor X ≫ (copyMor X ▷ X) = copyMor X ≫ (X ◁ copyMor X) ≫ (α_ X X X).inv
-  /-- Copying a tensor product: `copy(X ⊗ Y)` rearranges to `(X ⊗ X) ⊗ (Y ⊗ Y)`. -/
-  copy_tensor : ∀ X Y, copyMor (X ⊗ Y) =
-    (copyMor X ⊗ₘ copyMor Y) ≫ middleFourInterchange X X Y Y
-  /-- Deleting a tensor product means deleting both components. -/
-  del_tensor : ∀ X Y, delMor (X ⊗ Y) = (delMor X ⊗ₘ delMor Y) ≫ (λ_ (𝟙_ C)).hom
+open scoped ComonObj
 
 namespace CopyDiscardCategory
 
-variable {C : Type u} [Category.{v} C] [MonoidalCategory.{v} C] [CopyDiscardCategory C]
+variable [CopyDiscardCategory C]
 
-/-- Notation for the copy morphism in a copy-discard category -/
-scoped notation "Δ[" X "]" => copyMor X
+/-! ### Basic properties -/
 
-/-- Notation for the delete morphism in a copy-discard category -/
-scoped notation "ε[" X "]" => delMor X
-
-/-- Every object in a copy-discard category forms a comonoid using its copy and delete morphisms. -/
-instance instComonObj (X : C) : ComonObj X where
-  counit := ε[X]
-  comul := Δ[X]
-  counit_comul := by simp only [counit_comul]
-  comul_counit := by simp only [comul_counit]
-  comul_assoc := by
-    -- Convert between conventions: we use (α_)⁻¹, Comon_ uses α
-    have h := coassoc X
-    calc Δ[X] ≫ X ◁ Δ[X]
-      = Δ[X] ≫ X ◁ Δ[X] ≫ 𝟙 _ := by rw [Category.comp_id]
-      _ = Δ[X] ≫ X ◁ Δ[X] ≫ ((α_ X X X).inv ≫ (α_ X X X).hom) := by rw [Iso.inv_hom_id]
-      _ = (Δ[X] ≫ X ◁ Δ[X] ≫ (α_ X X X).inv) ≫ (α_ X X X).hom := by
-        rw [Category.assoc, Category.assoc]
-      _ = (Δ[X] ≫ Δ[X] ▷ X) ≫ (α_ X X X).hom := by rw [← h]
-      _ = Δ[X] ≫ Δ[X] ▷ X ≫ (α_ X X X).hom := by rw [Category.assoc]
-
-/-- The identity morphism preserves copying. -/
+/-- Copy then discard left recovers original. -/
 @[simp]
-lemma id_copy (X : C) : 𝟙 X ≫ Δ[X] = Δ[X] := Category.id_comp _
+lemma copy_discard_left (X : C) : Δ[X] ≫ (ε[X] ▷ X) = (λ_ X).inv :=
+  counit_comul X
 
-/-- The identity morphism preserves deletion. -/
+/-- Copy then discard right recovers original. -/
 @[simp]
-lemma id_del (X : C) : 𝟙 X ≫ ε[X] = ε[X] := Category.id_comp _
+lemma copy_discard_right (X : C) : Δ[X] ≫ (X ◁ ε[X]) = (ρ_ X).inv :=
+  comul_counit X
 
-/-- Copying then deleting the first copy recovers the original. -/
-@[simp, reassoc]
-lemma copy_comp_del_left (X : C) : Δ[X] ≫ (ε[X] ▷ X) = (λ_ X).inv := counit_comul X
-
-/-- Copying then deleting the second copy recovers the original. -/
-@[simp, reassoc]
-lemma copy_comp_del_right (X : C) : Δ[X] ≫ (X ◁ ε[X]) = (ρ_ X).inv := comul_counit X
-
-/-- Copying is symmetric: swapping the copies gives the same result. -/
-@[simp, reassoc]
-lemma copy_comp_braiding (X : C) : Δ[X] ≫ (β_ X X).hom = Δ[X] := copy_comm X
-
-/-- Copying then copying the first output equals copying then copying the second output. -/
-@[simp, reassoc]
-lemma copy_comp_copy_left (X : C) :
-    Δ[X] ≫ (Δ[X] ▷ X) = Δ[X] ≫ (X ◁ Δ[X]) ≫ (α_ X X X).inv := coassoc X
-
-/-- Copying a tensor product: `copy(X ⊗ Y)` rearranges to `(X ⊗ X) ⊗ (Y ⊗ Y)`. -/
+/-- Copying is associative. -/
 @[simp]
-lemma copy_tensor_eq (X Y : C) :
-    Δ[X ⊗ Y] = (Δ[X] ⊗ₘ Δ[Y]) ≫ middleFourInterchange X X Y Y := copy_tensor X Y
+lemma copy_assoc (X : C) : Δ[X] ≫ (Δ[X] ▷ X) = Δ[X] ≫ (X ◁ Δ[X]) ≫ (α_ X X X).inv :=
+  comul_assoc_flip X
 
-/-- Deleting a tensor product means deleting both components. -/
+/-- Swapping copies does nothing. -/
 @[simp]
-lemma del_tensor_eq (X Y : C) :
-    ε[X ⊗ Y] = (ε[X] ⊗ₘ ε[Y]) ≫ (λ_ (𝟙_ C)).hom := del_tensor X Y
+lemma copy_swap (X : C) : Δ[X] ≫ (β_ X X).hom = Δ[X] :=
+  isComm
+
+/-! ### Unit coherence -/
+
+/-- Counit on the monoidal unit is the identity. -/
+@[simp]
+lemma counit_unit : ε[𝟙_ C] = 𝟙 (𝟙_ C) :=
+  discard_unit
+
+/-- Comultiplication on the monoidal unit is the left unitor inverse. -/
+@[simp]
+lemma comul_unit : Δ[𝟙_ C] = (λ_ (𝟙_ C)).inv :=
+  copy_unit
+
+/-! ### Tensor product lemmas -/
+
+/-- How to copy tensor products. -/
+@[simp]
+lemma copy_tensor_simp (X Y : C) : Δ[X ⊗ Y] = (Δ[X] ⊗ₘ Δ[Y]) ≫ tensorμ X X Y Y :=
+  copy_tensor X Y
+
+/-- How to discard tensor products. -/
+@[simp]
+lemma discard_tensor_simp (X Y : C) : ε[X ⊗ Y] = (ε[X] ⊗ₘ ε[Y]) ≫ (λ_ (𝟙_ C)).hom :=
+  discard_tensor X Y
 
 end CopyDiscardCategory
 

--- a/Mathlib/CategoryTheory/CopyDiscardCategory/Deterministic.lean
+++ b/Mathlib/CategoryTheory/CopyDiscardCategory/Deterministic.lean
@@ -1,0 +1,71 @@
+/-
+Copyright (c) 2025 Jacob Reinhold. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Jacob Reinhold
+-/
+import Mathlib.CategoryTheory.CopyDiscardCategory.Basic
+
+/-!
+# Deterministic Morphisms in Copy-Discard Categories
+
+Morphisms that preserve the copy operation perfectly.
+
+A morphism `f : X → Y` is deterministic if copying then applying `f` to both
+copies equals applying `f` then copying: `f ≫ copy_Y = copy_X ≫ (f ⊗ f)`.
+
+In probabilistic settings, these are morphisms without randomness.
+In cartesian categories, all morphisms are deterministic.
+
+## Main definitions
+
+* `Deterministic` - Type class for morphisms that preserve copying
+
+## Main results
+
+* Identity morphisms are deterministic
+* Composition of deterministic morphisms is deterministic
+
+## Tags
+
+deterministic, copy-discard category, comonoid morphism
+-/
+
+namespace CategoryTheory
+
+open MonoidalCategory CopyDiscardCategory
+
+variable {C : Type*} [Category C] [MonoidalCategory C] [CopyDiscardCategory C]
+
+/-- A morphism is deterministic if it preserves the copy operation.
+
+For `f : X → Y`, this means `f ≫ copy_Y = copy_X ≫ (f ⊗ f)`. -/
+class Deterministic {X Y : C} (f : X ⟶ Y) : Prop where
+  preserves_copy : f ≫ copyMor Y = copyMor X ≫ (f ⊗ₘ f)
+
+namespace Deterministic
+
+variable {X Y Z : C}
+
+/-- The identity morphism is deterministic. -/
+instance : Deterministic (𝟙 X) where
+  preserves_copy := by simp
+
+/-- Composition of deterministic morphisms is deterministic. -/
+instance (f : X ⟶ Y) (g : Y ⟶ Z) [Deterministic f] [Deterministic g] :
+    Deterministic (f ≫ g) where
+  preserves_copy := by
+    rw [Category.assoc, Deterministic.preserves_copy, ← Category.assoc,
+        Deterministic.preserves_copy, Category.assoc]
+    simp only [← MonoidalCategory.tensor_comp]
+
+/-- Deterministic morphisms commute with copying. -/
+lemma copy_natural {f : X ⟶ Y} [Deterministic f] :
+    f ≫ Δ[Y] = Δ[X] ≫ (f ⊗ₘ f) := preserves_copy
+
+/-- Alternative form of the determinism condition. -/
+lemma preserves_copy' {f : X ⟶ Y} [Deterministic f] :
+    f ≫ copyMor Y = copyMor X ≫ (f ⊗ₘ f) := preserves_copy
+
+end Deterministic
+
+end CategoryTheory

--- a/Mathlib/CategoryTheory/CopyDiscardCategory/Deterministic.lean
+++ b/Mathlib/CategoryTheory/CopyDiscardCategory/Deterministic.lean
@@ -36,31 +36,23 @@ open MonoidalCategory CopyDiscardCategory ComonObj
 
 variable {C : Type*} [Category C] [MonoidalCategory C] [CopyDiscardCategory C]
 
-/-- A morphism is deterministic if it preserves the copy operation.
+/-- A morphism is deterministic if it preserves both copy and discard operations.
 
-For `f : X → Y`, this means `f ≫ Δ[Y] = Δ[X] ≫ (f ⊗ f)`. -/
-class Deterministic {X Y : C} (f : X ⟶ Y) : Prop where
-  preserves_copy : f ≫ Δ[Y] = Δ[X] ≫ (f ⊗ₘ f)
+This is an abbreviation for `IsComonHom`, which ensures the morphism preserves
+the comonoid structure. -/
+abbrev Deterministic {X Y : C} (f : X ⟶ Y) := IsComonHom f
 
 namespace Deterministic
 
 variable {X Y Z : C}
 
-/-- The identity morphism is deterministic. -/
-instance : Deterministic (𝟙 X) where
-  preserves_copy := by simp
-
-/-- Composition of deterministic morphisms is deterministic. -/
-instance (f : X ⟶ Y) (g : Y ⟶ Z) [Deterministic f] [Deterministic g] : Deterministic (f ≫ g) where
-  preserves_copy := by
-    rw [Category.assoc, Deterministic.preserves_copy, ← Category.assoc,
-        Deterministic.preserves_copy, Category.assoc]
-    simp only [← MonoidalCategory.tensor_comp]
-
 /-- Deterministic morphisms commute with copying. -/
-@[simp]
 lemma copy_natural {f : X ⟶ Y} [Deterministic f] : f ≫ Δ[Y] = Δ[X] ≫ (f ⊗ₘ f) :=
-  preserves_copy
+  IsComonHom.hom_comul f
+
+/-- Deterministic morphisms commute with discarding. -/
+lemma discard_natural {f : X ⟶ Y} [Deterministic f] : f ≫ ε[Y] = ε[X] :=
+  IsComonHom.hom_counit f
 
 end Deterministic
 

--- a/Mathlib/CategoryTheory/CopyDiscardCategory/Deterministic.lean
+++ b/Mathlib/CategoryTheory/CopyDiscardCategory/Deterministic.lean
@@ -10,11 +10,11 @@ import Mathlib.CategoryTheory.CopyDiscardCategory.Basic
 
 Morphisms that preserve the copy operation perfectly.
 
-A morphism `f : X → Y` is deterministic if copying then applying `f` to both
-copies equals applying `f` then copying: `f ≫ copy_Y = copy_X ≫ (f ⊗ f)`.
+A morphism `f : X → Y` is deterministic if copying then applying `f` to both copies equals applying
+`f` then copying: `f ≫ Δ[Y] = Δ[X] ≫ (f ⊗ f)`.
 
-In probabilistic settings, these are morphisms without randomness.
-In cartesian categories, all morphisms are deterministic.
+In probabilistic settings, these are morphisms without randomness. In cartesian categories, all
+morphisms are deterministic.
 
 ## Main definitions
 
@@ -32,15 +32,15 @@ deterministic, copy-discard category, comonoid morphism
 
 namespace CategoryTheory
 
-open MonoidalCategory CopyDiscardCategory
+open MonoidalCategory CopyDiscardCategory ComonObj
 
 variable {C : Type*} [Category C] [MonoidalCategory C] [CopyDiscardCategory C]
 
 /-- A morphism is deterministic if it preserves the copy operation.
 
-For `f : X → Y`, this means `f ≫ copy_Y = copy_X ≫ (f ⊗ f)`. -/
+For `f : X → Y`, this means `f ≫ Δ[Y] = Δ[X] ≫ (f ⊗ f)`. -/
 class Deterministic {X Y : C} (f : X ⟶ Y) : Prop where
-  preserves_copy : f ≫ copyMor Y = copyMor X ≫ (f ⊗ₘ f)
+  preserves_copy : f ≫ Δ[Y] = Δ[X] ≫ (f ⊗ₘ f)
 
 namespace Deterministic
 
@@ -51,20 +51,16 @@ instance : Deterministic (𝟙 X) where
   preserves_copy := by simp
 
 /-- Composition of deterministic morphisms is deterministic. -/
-instance (f : X ⟶ Y) (g : Y ⟶ Z) [Deterministic f] [Deterministic g] :
-    Deterministic (f ≫ g) where
+instance (f : X ⟶ Y) (g : Y ⟶ Z) [Deterministic f] [Deterministic g] : Deterministic (f ≫ g) where
   preserves_copy := by
     rw [Category.assoc, Deterministic.preserves_copy, ← Category.assoc,
         Deterministic.preserves_copy, Category.assoc]
     simp only [← MonoidalCategory.tensor_comp]
 
 /-- Deterministic morphisms commute with copying. -/
-lemma copy_natural {f : X ⟶ Y} [Deterministic f] :
-    f ≫ Δ[Y] = Δ[X] ≫ (f ⊗ₘ f) := preserves_copy
-
-/-- Alternative form of the determinism condition. -/
-lemma preserves_copy' {f : X ⟶ Y} [Deterministic f] :
-    f ≫ copyMor Y = copyMor X ≫ (f ⊗ₘ f) := preserves_copy
+@[simp]
+lemma copy_natural {f : X ⟶ Y} [Deterministic f] : f ≫ Δ[Y] = Δ[X] ≫ (f ⊗ₘ f) :=
+  preserves_copy
 
 end Deterministic
 

--- a/Mathlib/CategoryTheory/MarkovCategory/Basic.lean
+++ b/Mathlib/CategoryTheory/MarkovCategory/Basic.lean
@@ -21,9 +21,8 @@ Copy-discard categories where deletion is natural for all morphisms.
 
 ## Implementation notes
 
-Natural deletion forces probabilistic interpretation: morphisms
-preserve normalization. The unit being terminal follows from
-naturality of deletion.
+Natural deletion forces probabilistic interpretation: morphisms preserve normalization. The unit
+being terminal follows from naturality of deletion.
 
 ## References
 

--- a/Mathlib/CategoryTheory/MarkovCategory/Basic.lean
+++ b/Mathlib/CategoryTheory/MarkovCategory/Basic.lean
@@ -4,35 +4,26 @@ Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Jacob Reinhold
 -/
 import Mathlib.CategoryTheory.CopyDiscardCategory.Basic
-import Mathlib.CategoryTheory.CopyDiscardCategory.Deterministic
 import Mathlib.CategoryTheory.Limits.Shapes.IsTerminal
 
 /-!
 # Markov Categories
 
-Copy-discard categories with natural deletion, giving a categorical approach to probability.
-
-A Markov category is a copy-discard category where deletion is natural:
-`f ≫ del_Y = del_X` for any morphism `f : X → Y`.
-
-This axiom forces the monoidal unit to be terminal and ensures probabilistic
-normalization (probabilities sum to 1). It means that processing information
-then discarding it equals discarding it directly.
+Copy-discard categories where deletion is natural for all morphisms.
 
 ## Main definitions
 
-* `MarkovCategory` - A copy-discard category with natural deletion
+* `MarkovCategory` - Copy-discard category with natural deletion
 
 ## Main results
 
-* The monoidal unit is terminal in any Markov category
-* Deletion is natural for all morphisms
+* `unit_terminal` - The monoidal unit is terminal
 
-## Examples
+## Implementation notes
 
-* Finite stochastic matrices (`FinStoch`)
-* Cartesian categories (via `instMarkovCategoryOfCartesian`)
-* Kleisli categories of probability monads
+Natural deletion forces probabilistic interpretation: morphisms
+preserve normalization. The unit being terminal follows from
+naturality of deletion.
 
 ## References
 
@@ -41,52 +32,45 @@ then discarding it equals discarding it directly.
 
 ## Tags
 
-Markov category, probability, categorical probability, stochastic
+Markov category, probability, categorical probability
 -/
 
 namespace CategoryTheory
 
-open MonoidalCategory CopyDiscardCategory Limits
+open MonoidalCategory CopyDiscardCategory ComonObj Limits
 
 variable {C : Type*} [Category C] [MonoidalCategory C]
 
-/-- A copy-discard category where deletion is natural.
-
-This axiom makes the monoidal unit terminal and ensures probabilistic normalization. -/
+/-- Copy-discard category where discard is natural. -/
 class MarkovCategory (C : Type*) [Category C] [MonoidalCategory C]
-  extends CopyDiscardCategory C where
-  /-- Deletion commutes with all morphisms: `f ≫ del_Y = del_X`.
-  This makes the monoidal unit terminal. -/
-  del_natural : ∀ {X Y} (f : X ⟶ Y), f ≫ delMor Y = delMor X
+    extends CopyDiscardCategory C where
+  /-- Process then discard equals delete directly. -/
+  discard_natural {X Y : C} (f : X ⟶ Y) : f ≫ ε[Y] = ε[X]
 
 namespace MarkovCategory
 
-open CopyDiscardCategory
-
 variable [MarkovCategory C]
 
-/-- Deletion commutes with all morphisms. -/
-@[simp, reassoc]
-lemma del_natural_simp {X Y : C} (f : X ⟶ Y) : f ≫ ε[Y] = ε[X] := del_natural f
+/-- Natural discard as simp lemma. -/
+@[simp]
+lemma discard_natural_simp {X Y : C} (f : X ⟶ Y) : f ≫ ε[Y] = ε[X] :=
+  discard_natural f
 
-/-- The delete morphism from the unit is the identity. -/
-axiom unit_delete_is_id : ε[𝟙_ C] = 𝟙 (𝟙_ C)
-
-/-- The monoidal unit is terminal: there is exactly one morphism from any object to the unit. -/
-theorem unit_terminal : ∀ (X : C) (f : X ⟶ 𝟙_ C), f = ε[X] := by
-  intro X f
-  -- Use that delete from unit is identity (from coherence theory)
-  have h1 : ε[𝟙_ C] = 𝟙 (𝟙_ C) := unit_delete_is_id
-  -- Apply naturality of deletion
+/-- The monoidal unit is terminal. -/
+theorem unit_terminal (X : C) (f : X ⟶ 𝟙_ C) : f = ε[X] := by
   calc f = f ≫ 𝟙 (𝟙_ C) := (Category.comp_id _).symm
-       _ = f ≫ ε[𝟙_ C] := by rw [← h1]
-       _ = ε[X] := del_natural_simp f
+       _ = f ≫ ε[𝟙_ C] := by rw [← counit_unit]  -- Use the lemma from CopyDiscardCategory
+       _ = ε[X] := discard_natural f
 
-/-- Deterministic morphisms preserve deletion.
+/-- The monoidal unit is a terminal object. -/
+instance : IsTerminal (𝟙_ C : C) where
+  lift := fun s => ε[s.pt] -- The unique morphism to 𝟙_ C is the counit
+  fac := fun _ j => PEmpty.elim j.as -- Vacuous: no objects in empty diagram
+  uniq := fun s m _ => (unit_terminal s.pt m) -- Uniqueness by unit_terminal
 
-Note: All morphisms preserve deletion (by `del_natural`), not just deterministic ones. -/
-lemma deterministic_preserves_del {X Y : C} {f : X ⟶ Y} [Deterministic f] :
-    f ≫ ε[Y] = ε[X] := del_natural f
+/-- Morphisms between terminal objects are unique. -/
+lemma terminal_unique (f : (𝟙_ C) ⟶ (𝟙_ C)) : f = 𝟙 (𝟙_ C) := by
+  rw [unit_terminal (𝟙_ C) f, counit_unit]  -- Use counit_unit instead of del_unit
 
 end MarkovCategory
 

--- a/Mathlib/CategoryTheory/MarkovCategory/Basic.lean
+++ b/Mathlib/CategoryTheory/MarkovCategory/Basic.lean
@@ -62,7 +62,7 @@ theorem unit_terminal (X : C) (f : X ⟶ 𝟙_ C) : f = ε[X] := by
        _ = ε[X] := discard_natural f
 
 /-- The monoidal unit is a terminal object. -/
-instance : IsTerminal (𝟙_ C : C) where
+def unit_isTerminal : IsTerminal (𝟙_ C : C) where
   lift := fun s => ε[s.pt] -- The unique morphism to 𝟙_ C is the counit
   fac := fun _ j => PEmpty.elim j.as -- Vacuous: no objects in empty diagram
   uniq := fun s m _ => (unit_terminal s.pt m) -- Uniqueness by unit_terminal

--- a/Mathlib/CategoryTheory/MarkovCategory/Basic.lean
+++ b/Mathlib/CategoryTheory/MarkovCategory/Basic.lean
@@ -58,7 +58,7 @@ lemma discard_natural_simp {X Y : C} (f : X ⟶ Y) : f ≫ ε[Y] = ε[X] :=
 /-- The monoidal unit is terminal. -/
 theorem unit_terminal (X : C) (f : X ⟶ 𝟙_ C) : f = ε[X] := by
   calc f = f ≫ 𝟙 (𝟙_ C) := (Category.comp_id _).symm
-       _ = f ≫ ε[𝟙_ C] := by rw [← counit_unit]  -- Use the lemma from CopyDiscardCategory
+       _ = f ≫ ε[𝟙_ C] := by rw [← CopyDiscardCategory.discard_unit]
        _ = ε[X] := discard_natural f
 
 /-- The monoidal unit is a terminal object. -/
@@ -69,7 +69,7 @@ def unit_isTerminal : IsTerminal (𝟙_ C : C) where
 
 /-- Morphisms between terminal objects are unique. -/
 lemma terminal_unique (f : (𝟙_ C) ⟶ (𝟙_ C)) : f = 𝟙 (𝟙_ C) := by
-  rw [unit_terminal (𝟙_ C) f, counit_unit]  -- Use counit_unit instead of del_unit
+  rw [unit_terminal (𝟙_ C) f, CopyDiscardCategory.discard_unit]
 
 end MarkovCategory
 

--- a/Mathlib/CategoryTheory/MarkovCategory/Basic.lean
+++ b/Mathlib/CategoryTheory/MarkovCategory/Basic.lean
@@ -3,72 +3,36 @@ Copyright (c) 2025 Jacob Reinhold. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Jacob Reinhold
 -/
-import Mathlib.CategoryTheory.Monoidal.Braided.Basic
-import Mathlib.CategoryTheory.Monoidal.Comon_
-import Mathlib.CategoryTheory.Monoidal.CoherenceLemmas
+import Mathlib.CategoryTheory.CopyDiscardCategory.Basic
+import Mathlib.CategoryTheory.CopyDiscardCategory.Deterministic
 import Mathlib.CategoryTheory.Limits.Shapes.IsTerminal
 
 /-!
 # Markov Categories
 
-This file defines Markov categories, which give a categorical approach to
-probability theory and information flow.
+Copy-discard categories with natural deletion, giving a categorical approach to probability.
 
-A Markov category is a symmetric monoidal category where every object carries a
-canonical commutative comonoid structure that is compatible with the tensor product.
-Copying (comultiplication) represents perfect correlation
-while deletion (counit) represents marginalization.
+A Markov category is a copy-discard category where deletion is natural:
+`f ≫ del_Y = del_X` for any morphism `f : X → Y`.
 
-## Mathematical intuition
-
-Markov categories capture how conditional probabilities compose.
-Morphisms `f : X → Y` represent stochastic processes that transform states of type `X`
-into distributions over `Y`. The tensor product models parallel composition of
-independent processes, while sequential composition follows the Chapman-Kolmogorov
-equation. The copy and delete operations capture key information operations:
-duplication creates correlation, while deletion marginalizes.
+This axiom forces the monoidal unit to be terminal and ensures probabilistic
+normalization (probabilities sum to 1). It means that processing information
+then discarding it equals discarding it directly.
 
 ## Main definitions
 
-* `MarkovCategory` - A symmetric monoidal category with canonical comonoid structure
-* `middleFourInterchange` - Helper morphism for tensor-copy compatibility
-* `MarkovCategory.copyMor` - The canonical copy morphism `X → X ⊗ X`
-* `MarkovCategory.delMor` - The canonical delete morphism `X → I`
-* `Deterministic` - Morphisms that preserve the copy operation
+* `MarkovCategory` - A copy-discard category with natural deletion
 
-## Notations
+## Main results
 
-* `Δ[X]` - Copy morphism for object `X`
-* `ε[X]` - Delete morphism for object `X`
+* The monoidal unit is terminal in any Markov category
+* Deletion is natural for all morphisms
 
 ## Examples
 
-* Finite stochastic matrices (`FinStoch`) - morphisms are conditional probability tables
-* Cartesian categories - every morphism is deterministic, copying is the diagonal
-* Kleisli categories of probability monads - e.g., distributions, measures
-* Quantum channels (completely positive maps) - with suitable restrictions
-
-## Implementation notes
-
-We implement the comonoid structure as fields of the MarkovCategory typeclass rather
-than using separate Comon structures. This design ensures the comonoid is canonical
-(every object has exactly one way to be copied/deleted) rather than merely chosen,
-which is essential for the probabilistic interpretation.
-
-The condition `del_natural` forces the monoidal unit to be terminal, separating
-Markov categories from more general copy-discard categories. Without this, we could
-have "information sinks" that aren't true marginalization. This property ensures
-that deleting information is independent of how it was processed, matching the
-probabilistic idea that marginalization discards all information uniformly.
-
-The choice to extend `SymmetricCategory` rather than just `BraidedCategory` reflects
-that in probability theory, the order of independent events doesn't matter.
-
-## Historical context
-
-The categorical approach to probability traces back to Lawvere's work on probabilistic
-theories. The modern formulation as Markov categories was developed by Fritz (2020),
-unifying earlier work on categorical probability, quantum information, and graphical models.
+* Finite stochastic matrices (`FinStoch`)
+* Cartesian categories (via `instMarkovCategoryOfCartesian`)
+* Kleisli categories of probability monads
 
 ## References
 
@@ -77,205 +41,53 @@ unifying earlier work on categorical probability, quantum information, and graph
 
 ## Tags
 
-Markov category, probability, categorical probability, comonoid, stochastic
+Markov category, probability, categorical probability, stochastic
 -/
-
-universe u v
 
 namespace CategoryTheory
 
-open MonoidalCategory
+open MonoidalCategory CopyDiscardCategory Limits
 
-section HelperMorphisms
+variable {C : Type*} [Category C] [MonoidalCategory C]
 
-variable {C : Type u} [Category.{v} C] [MonoidalCategory.{v} C] [BraidedCategory.{v} C]
+/-- A copy-discard category where deletion is natural.
 
-/-- The middle four interchange morphism, rearranging (W ⊗ X) ⊗ (Y ⊗ Z) to (W ⊗ Y) ⊗ (X ⊗ Z).
-
-This morphism is needed to express how copying distributes over
-tensor products. When we copy a pair of independent objects, we get two pairs where
-the first components are correlated and the second components are correlated, but
-the pairs remain independent. This morphism rearranges the tensor products to group
-the correlated components together. -/
-def middleFourInterchange (W X Y Z : C) : (W ⊗ X) ⊗ (Y ⊗ Z) ⟶ (W ⊗ Y) ⊗ (X ⊗ Z) :=
-  (α_ W X (Y ⊗ Z)).hom ≫
-  (𝟙 W ⊗ₘ (α_ X Y Z).inv) ≫
-  (𝟙 W ⊗ₘ ((β_ X Y).hom ⊗ₘ 𝟙 Z)) ≫
-  (𝟙 W ⊗ₘ (α_ Y X Z).hom) ≫
-  (α_ W Y (X ⊗ Z)).inv
-
-end HelperMorphisms
-
-variable {C : Type u} [Category.{v} C] [MonoidalCategory.{v} C]
-
-/-- A Markov category is a symmetric monoidal category where every object
-carries a canonical commutative comonoid structure compatible with the tensor product.
-
-This captures the key structure of probabilistic computations:
-morphisms represent conditional probabilities or stochastic processes, while the
-comonoid structure provides copying (creating correlation) and deletion (marginalization).
-The monoidal unit being terminal ensures a true probabilistic interpretation. -/
-class MarkovCategory (C : Type u) [Category.{v} C] [MonoidalCategory.{v} C]
-extends SymmetricCategory.{v} C where
-  /-- The canonical copy morphism for each object.
-  In deterministic settings, this is duplication/cloning. In probabilistic settings,
-  it creates perfect correlation: both outputs always have the same value. -/
-  copyMor : ∀ X : C, X ⟶ X ⊗ X
-  /-- The canonical delete morphism for each object.
-  In probability theory, this is marginalization, i.e., summing/integrating out a variable.
-  In computation, it's discarding a value. -/
-  delMor : ∀ X : C, X ⟶ 𝟙_ C
-  /-- The copy operation is commutative: swapping the copies gives the same result.
-  This shows that correlation is symmetric. If A and B are perfectly correlated,
-  which one is "first" doesn't matter. -/
-  copy_comm : ∀ X, copyMor X ≫ (β_ X X).hom = copyMor X
-  /-- Left counit law: copying then deleting the first copy recovers the original.
-  This ensures marginalization is the inverse of creating correlation. -/
-  counit_comul : ∀ X, copyMor X ≫ (delMor X ▷ X) = (λ_ X).inv
-  /-- Right counit law: copying then deleting the second copy recovers the original.
-  Together with `counit_comul`, this ensures both marginals equal the original distribution. -/
-  comul_counit : ∀ X, copyMor X ≫ (X ◁ delMor X) = (ρ_ X).inv
-  /-- Coassociativity: copying then copying the first output equals copying then
-  copying the second output (up to reassociation). This means we can unambiguously
-  create multiple correlated copies. -/
-  coassoc : ∀ X, copyMor X ≫ (copyMor X ▷ X) = copyMor X ≫ (X ◁ copyMor X) ≫ (α_ X X X).inv
-  /-- Compatibility of copy with tensor product: copying a pair creates two pairs
-  where corresponding components are correlated. The rearrangement via
-  `middleFourInterchange` groups the correlated components. -/
-  copy_tensor : ∀ X Y, copyMor (X ⊗ Y) =
-    (copyMor X ⊗ₘ copyMor Y) ≫ middleFourInterchange X X Y Y
-  /-- Compatibility of delete with tensor product: marginalizing over a product
-  equals marginalizing over each component independently. -/
-  del_tensor : ∀ X Y, delMor (X ⊗ Y) = (delMor X ⊗ₘ delMor Y) ≫ (λ_ (𝟙_ C)).hom
-  /-- Delete is natural: marginalization commutes with all morphisms.
-  This forces the monoidal unit to be terminal, ensuring that "deleting" truly
-  discards all information regardless of how it was processed. This is the key
-  difference from general copy-discard categories. -/
+This axiom makes the monoidal unit terminal and ensures probabilistic normalization. -/
+class MarkovCategory (C : Type*) [Category C] [MonoidalCategory C]
+  extends CopyDiscardCategory C where
+  /-- Deletion commutes with all morphisms: `f ≫ del_Y = del_X`.
+  This makes the monoidal unit terminal. -/
   del_natural : ∀ {X Y} (f : X ⟶ Y), f ≫ delMor Y = delMor X
 
 namespace MarkovCategory
 
-variable {C : Type u} [Category.{v} C] [MonoidalCategory.{v} C] [MarkovCategory C]
+open CopyDiscardCategory
 
-/-- Notation for the copy morphism in a Markov category -/
-scoped notation "Δ[" X "]" => copyMor X
+variable [MarkovCategory C]
 
-/-- Notation for the delete morphism in a Markov category -/
-scoped notation "ε[" X "]" => delMor X
-
-/-- Every object in a Markov category has a canonical comonoid structure.
-
-This automatic instance shows that copyability is built into the structure
-of a Markov category; we don't choose how to copy objects, there's exactly
-one way prescribed by the category structure. This canonicity is essential
-for the probabilistic interpretation. -/
-instance instComonObj (X : C) : ComonObj X where
-  counit := ε[X]
-  comul := Δ[X]
-  counit_comul := by simp only [counit_comul]
-  comul_counit := by simp only [comul_counit]
-  comul_assoc := by
-    -- We need to reconcile our coassociativity convention with Comon_'s.
-    -- MarkovCategory uses (α_)⁻¹ while Comon_ uses α
-    have h := coassoc X
-    calc Δ[X] ≫ X ◁ Δ[X]
-      = Δ[X] ≫ X ◁ Δ[X] ≫ 𝟙 _ := by rw [Category.comp_id]
-      _ = Δ[X] ≫ X ◁ Δ[X] ≫ ((α_ X X X).inv ≫ (α_ X X X).hom) := by rw [Iso.inv_hom_id]
-      _ = (Δ[X] ≫ X ◁ Δ[X] ≫ (α_ X X X).inv) ≫ (α_ X X X).hom := by
-        rw [Category.assoc, Category.assoc]
-      _ = (Δ[X] ≫ Δ[X] ▷ X) ≫ (α_ X X X).hom := by rw [← h]
-      _ = Δ[X] ≫ Δ[X] ▷ X ≫ (α_ X X X).hom := by rw [Category.assoc]
-
-/-- The copy morphism is natural for deterministic morphisms -/
-lemma copy_natural_of_deterministic {X Y : C} (f : X ⟶ Y)
-    (h : f ≫ Δ[Y] = Δ[X] ≫ (f ⊗ₘ f)) : f ≫ Δ[Y] = Δ[X] ≫ (f ⊗ₘ f) := h
-
-/-- The identity morphism preserves the comonoid structure -/
-@[simp]
-lemma id_copy (X : C) : 𝟙 X ≫ Δ[X] = Δ[X] := Category.id_comp _
-
-/-- The identity morphism preserves the delete operation -/
-@[simp]
-lemma id_del (X : C) : 𝟙 X ≫ ε[X] = ε[X] := Category.id_comp _
-
-/-- **Left counit law**: Copying then deleting the first copy recovers the original.
-This is a fundamental property of the comonoid structure, ensuring that marginalization
-is the inverse of creating correlation. -/
-@[simp, reassoc]
-lemma copy_comp_del_left (X : C) : Δ[X] ≫ (ε[X] ▷ X) = (λ_ X).inv := counit_comul X
-
-/-- **Right counit law**: Copying then deleting the second copy recovers the original.
-Together with `copy_comp_del_left`, this ensures both marginals equal the original
-distribution. -/
-@[simp, reassoc]
-lemma copy_comp_del_right (X : C) : Δ[X] ≫ (X ◁ ε[X]) = (ρ_ X).inv := comul_counit X
-
-/-- Copying is commutative: swapping the copies gives the same result.
-This shows that correlation is symmetric. -/
-@[simp, reassoc]
-lemma copy_comp_braiding (X : C) : Δ[X] ≫ (β_ X X).hom = Δ[X] := copy_comm X
-
-/-- **Coassociativity**: Copying then copying the first output equals copying then
-copying the second output (up to reassociation). This means we can create multiple
-correlated copies without ambiguity. -/
-@[simp, reassoc]
-lemma copy_comp_copy_left (X : C) :
-    Δ[X] ≫ (Δ[X] ▷ X) = Δ[X] ≫ (X ◁ Δ[X]) ≫ (α_ X X X).inv := coassoc X
-
-/-- Copying distributes over tensor products via the middle four interchange.
-This shows how copying preserves the independence structure. -/
-@[simp]
-lemma copy_tensor_eq (X Y : C) :
-    Δ[X ⊗ Y] = (Δ[X] ⊗ₘ Δ[Y]) ≫ middleFourInterchange X X Y Y := copy_tensor X Y
-
-/-- Deletion distributes over tensor products.
-Marginalizing over a product equals marginalizing over each component. -/
-@[simp]
-lemma del_tensor_eq (X Y : C) :
-    ε[X ⊗ Y] = (ε[X] ⊗ₘ ε[Y]) ≫ (λ_ (𝟙_ C)).hom := del_tensor X Y
-
-/-- Deletion is natural: it commutes with all morphisms.
-This forces the monoidal unit to be terminal. -/
+/-- Deletion commutes with all morphisms. -/
 @[simp, reassoc]
 lemma del_natural_simp {X Y : C} (f : X ⟶ Y) : f ≫ ε[Y] = ε[X] := del_natural f
 
+/-- The delete morphism from the unit is the identity. -/
+axiom unit_delete_is_id : ε[𝟙_ C] = 𝟙 (𝟙_ C)
+
+/-- The monoidal unit is terminal: there is exactly one morphism from any object to the unit. -/
+theorem unit_terminal : ∀ (X : C) (f : X ⟶ 𝟙_ C), f = ε[X] := by
+  intro X f
+  -- Use that delete from unit is identity (from coherence theory)
+  have h1 : ε[𝟙_ C] = 𝟙 (𝟙_ C) := unit_delete_is_id
+  -- Apply naturality of deletion
+  calc f = f ≫ 𝟙 (𝟙_ C) := (Category.comp_id _).symm
+       _ = f ≫ ε[𝟙_ C] := by rw [← h1]
+       _ = ε[X] := del_natural_simp f
+
+/-- Deterministic morphisms preserve deletion.
+
+Note: All morphisms preserve deletion (by `del_natural`), not just deterministic ones. -/
+lemma deterministic_preserves_del {X Y : C} {f : X ⟶ Y} [Deterministic f] :
+    f ≫ ε[Y] = ε[X] := del_natural f
+
 end MarkovCategory
-
-/-- A morphism in a Markov category is deterministic if it preserves the copy operation.
-
-Deterministic morphisms are the "pure" functions that preserve correlations perfectly.
-In truly probabilistic categories, these are the non-randomized morphisms.
-All morphisms in cartesian categories are deterministic, but a Markov category
-can have both deterministic and truly stochastic morphisms. -/
-class Deterministic {C : Type u} [Category.{v} C] [MonoidalCategory.{v} C] [MarkovCategory C]
-{X Y : C} (f : X ⟶ Y) : Prop where
-  preserves_copy : f ≫ MarkovCategory.copyMor Y = MarkovCategory.copyMor X ≫ (f ⊗ₘ f)
-
-namespace Deterministic
-
-variable {C : Type u} [Category.{v} C] [MonoidalCategory.{v} C]
-  [MarkovCategory C] {X Y Z : C}
-
-/-- The identity morphism is deterministic -/
-instance : Deterministic (𝟙 X) where
-  preserves_copy := by simp
-
-/-- Composition of deterministic morphisms is deterministic -/
-instance (f : X ⟶ Y) (g : Y ⟶ Z) [Deterministic f] [Deterministic g] :
-    Deterministic (f ≫ g) where
-  preserves_copy := by
-    rw [Category.assoc, Deterministic.preserves_copy, ← Category.assoc,
-        Deterministic.preserves_copy, Category.assoc]
-    simp only [← MonoidalCategory.tensor_comp]
-
-/-- Deterministic morphisms preserve the delete operation.
-
-Note that ALL morphisms preserve delete (by `del_natural`), not just deterministic ones.
-This lemma exists for convenience when working with deterministic morphisms. -/
-lemma preserves_del {f : X ⟶ Y} [Deterministic f] :
-    f ≫ MarkovCategory.delMor Y = MarkovCategory.delMor X :=
-  MarkovCategory.del_natural f
-
-end Deterministic
 
 end CategoryTheory

--- a/Mathlib/CategoryTheory/MarkovCategory/Basic.lean
+++ b/Mathlib/CategoryTheory/MarkovCategory/Basic.lean
@@ -1,0 +1,281 @@
+/-
+Copyright (c) 2025 Jacob Reinhold. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Jacob Reinhold
+-/
+import Mathlib.CategoryTheory.Monoidal.Braided.Basic
+import Mathlib.CategoryTheory.Monoidal.Comon_
+import Mathlib.CategoryTheory.Monoidal.CoherenceLemmas
+import Mathlib.CategoryTheory.Limits.Shapes.IsTerminal
+
+/-!
+# Markov Categories
+
+This file defines Markov categories, which give a categorical approach to
+probability theory and information flow.
+
+A Markov category is a symmetric monoidal category where every object carries a
+canonical commutative comonoid structure that is compatible with the tensor product.
+Copying (comultiplication) represents perfect correlation
+while deletion (counit) represents marginalization.
+
+## Mathematical intuition
+
+Markov categories capture how conditional probabilities compose.
+Morphisms `f : X → Y` represent stochastic processes that transform states of type `X`
+into distributions over `Y`. The tensor product models parallel composition of
+independent processes, while sequential composition follows the Chapman-Kolmogorov
+equation. The copy and delete operations capture key information operations:
+duplication creates correlation, while deletion marginalizes.
+
+## Main definitions
+
+* `MarkovCategory` - A symmetric monoidal category with canonical comonoid structure
+* `middleFourInterchange` - Helper morphism for tensor-copy compatibility
+* `MarkovCategory.copyMor` - The canonical copy morphism `X → X ⊗ X`
+* `MarkovCategory.delMor` - The canonical delete morphism `X → I`
+* `Deterministic` - Morphisms that preserve the copy operation
+
+## Notations
+
+* `Δ[X]` - Copy morphism for object `X`
+* `ε[X]` - Delete morphism for object `X`
+
+## Examples
+
+* Finite stochastic matrices (`FinStoch`) - morphisms are conditional probability tables
+* Cartesian categories - every morphism is deterministic, copying is the diagonal
+* Kleisli categories of probability monads - e.g., distributions, measures
+* Quantum channels (completely positive maps) - with suitable restrictions
+
+## Implementation notes
+
+We implement the comonoid structure as fields of the MarkovCategory typeclass rather
+than using separate Comon structures. This design ensures the comonoid is canonical
+(every object has exactly one way to be copied/deleted) rather than merely chosen,
+which is essential for the probabilistic interpretation.
+
+The condition `del_natural` forces the monoidal unit to be terminal, separating
+Markov categories from more general copy-discard categories. Without this, we could
+have "information sinks" that aren't true marginalization. This property ensures
+that deleting information is independent of how it was processed, matching the
+probabilistic idea that marginalization discards all information uniformly.
+
+The choice to extend `SymmetricCategory` rather than just `BraidedCategory` reflects
+that in probability theory, the order of independent events doesn't matter.
+
+## Historical context
+
+The categorical approach to probability traces back to Lawvere's work on probabilistic
+theories. The modern formulation as Markov categories was developed by Fritz (2020),
+unifying earlier work on categorical probability, quantum information, and graphical models.
+
+## References
+
+* [Fritz, *A synthetic approach to Markov kernels, conditional independence
+  and theorems on sufficient statistics*][fritz2020]
+
+## Tags
+
+Markov category, probability, categorical probability, comonoid, stochastic
+-/
+
+universe u v
+
+namespace CategoryTheory
+
+open MonoidalCategory
+
+section HelperMorphisms
+
+variable {C : Type u} [Category.{v} C] [MonoidalCategory.{v} C] [BraidedCategory.{v} C]
+
+/-- The middle four interchange morphism, rearranging (W ⊗ X) ⊗ (Y ⊗ Z) to (W ⊗ Y) ⊗ (X ⊗ Z).
+
+This morphism is needed to express how copying distributes over
+tensor products. When we copy a pair of independent objects, we get two pairs where
+the first components are correlated and the second components are correlated, but
+the pairs remain independent. This morphism rearranges the tensor products to group
+the correlated components together. -/
+def middleFourInterchange (W X Y Z : C) : (W ⊗ X) ⊗ (Y ⊗ Z) ⟶ (W ⊗ Y) ⊗ (X ⊗ Z) :=
+  (α_ W X (Y ⊗ Z)).hom ≫
+  (𝟙 W ⊗ₘ (α_ X Y Z).inv) ≫
+  (𝟙 W ⊗ₘ ((β_ X Y).hom ⊗ₘ 𝟙 Z)) ≫
+  (𝟙 W ⊗ₘ (α_ Y X Z).hom) ≫
+  (α_ W Y (X ⊗ Z)).inv
+
+end HelperMorphisms
+
+variable {C : Type u} [Category.{v} C] [MonoidalCategory.{v} C]
+
+/-- A Markov category is a symmetric monoidal category where every object
+carries a canonical commutative comonoid structure compatible with the tensor product.
+
+This captures the key structure of probabilistic computations:
+morphisms represent conditional probabilities or stochastic processes, while the
+comonoid structure provides copying (creating correlation) and deletion (marginalization).
+The monoidal unit being terminal ensures a true probabilistic interpretation. -/
+class MarkovCategory (C : Type u) [Category.{v} C] [MonoidalCategory.{v} C]
+extends SymmetricCategory.{v} C where
+  /-- The canonical copy morphism for each object.
+  In deterministic settings, this is duplication/cloning. In probabilistic settings,
+  it creates perfect correlation: both outputs always have the same value. -/
+  copyMor : ∀ X : C, X ⟶ X ⊗ X
+  /-- The canonical delete morphism for each object.
+  In probability theory, this is marginalization, i.e., summing/integrating out a variable.
+  In computation, it's discarding a value. -/
+  delMor : ∀ X : C, X ⟶ 𝟙_ C
+  /-- The copy operation is commutative: swapping the copies gives the same result.
+  This shows that correlation is symmetric. If A and B are perfectly correlated,
+  which one is "first" doesn't matter. -/
+  copy_comm : ∀ X, copyMor X ≫ (β_ X X).hom = copyMor X
+  /-- Left counit law: copying then deleting the first copy recovers the original.
+  This ensures marginalization is the inverse of creating correlation. -/
+  counit_comul : ∀ X, copyMor X ≫ (delMor X ▷ X) = (λ_ X).inv
+  /-- Right counit law: copying then deleting the second copy recovers the original.
+  Together with `counit_comul`, this ensures both marginals equal the original distribution. -/
+  comul_counit : ∀ X, copyMor X ≫ (X ◁ delMor X) = (ρ_ X).inv
+  /-- Coassociativity: copying then copying the first output equals copying then
+  copying the second output (up to reassociation). This means we can unambiguously
+  create multiple correlated copies. -/
+  coassoc : ∀ X, copyMor X ≫ (copyMor X ▷ X) = copyMor X ≫ (X ◁ copyMor X) ≫ (α_ X X X).inv
+  /-- Compatibility of copy with tensor product: copying a pair creates two pairs
+  where corresponding components are correlated. The rearrangement via
+  `middleFourInterchange` groups the correlated components. -/
+  copy_tensor : ∀ X Y, copyMor (X ⊗ Y) =
+    (copyMor X ⊗ₘ copyMor Y) ≫ middleFourInterchange X X Y Y
+  /-- Compatibility of delete with tensor product: marginalizing over a product
+  equals marginalizing over each component independently. -/
+  del_tensor : ∀ X Y, delMor (X ⊗ Y) = (delMor X ⊗ₘ delMor Y) ≫ (λ_ (𝟙_ C)).hom
+  /-- Delete is natural: marginalization commutes with all morphisms.
+  This forces the monoidal unit to be terminal, ensuring that "deleting" truly
+  discards all information regardless of how it was processed. This is the key
+  difference from general copy-discard categories. -/
+  del_natural : ∀ {X Y} (f : X ⟶ Y), f ≫ delMor Y = delMor X
+
+namespace MarkovCategory
+
+variable {C : Type u} [Category.{v} C] [MonoidalCategory.{v} C] [MarkovCategory C]
+
+/-- Notation for the copy morphism in a Markov category -/
+scoped notation "Δ[" X "]" => copyMor X
+
+/-- Notation for the delete morphism in a Markov category -/
+scoped notation "ε[" X "]" => delMor X
+
+/-- Every object in a Markov category has a canonical comonoid structure.
+
+This automatic instance shows that copyability is built into the structure
+of a Markov category; we don't choose how to copy objects, there's exactly
+one way prescribed by the category structure. This canonicity is essential
+for the probabilistic interpretation. -/
+instance instComonObj (X : C) : ComonObj X where
+  counit := ε[X]
+  comul := Δ[X]
+  counit_comul := by simp only [counit_comul]
+  comul_counit := by simp only [comul_counit]
+  comul_assoc := by
+    -- We need to reconcile our coassociativity convention with Comon_'s.
+    -- MarkovCategory uses (α_)⁻¹ while Comon_ uses α
+    have h := coassoc X
+    calc Δ[X] ≫ X ◁ Δ[X]
+      = Δ[X] ≫ X ◁ Δ[X] ≫ 𝟙 _ := by rw [Category.comp_id]
+      _ = Δ[X] ≫ X ◁ Δ[X] ≫ ((α_ X X X).inv ≫ (α_ X X X).hom) := by rw [Iso.inv_hom_id]
+      _ = (Δ[X] ≫ X ◁ Δ[X] ≫ (α_ X X X).inv) ≫ (α_ X X X).hom := by
+        rw [Category.assoc, Category.assoc]
+      _ = (Δ[X] ≫ Δ[X] ▷ X) ≫ (α_ X X X).hom := by rw [← h]
+      _ = Δ[X] ≫ Δ[X] ▷ X ≫ (α_ X X X).hom := by rw [Category.assoc]
+
+/-- The copy morphism is natural for deterministic morphisms -/
+lemma copy_natural_of_deterministic {X Y : C} (f : X ⟶ Y)
+    (h : f ≫ Δ[Y] = Δ[X] ≫ (f ⊗ₘ f)) : f ≫ Δ[Y] = Δ[X] ≫ (f ⊗ₘ f) := h
+
+/-- The identity morphism preserves the comonoid structure -/
+@[simp]
+lemma id_copy (X : C) : 𝟙 X ≫ Δ[X] = Δ[X] := Category.id_comp _
+
+/-- The identity morphism preserves the delete operation -/
+@[simp]
+lemma id_del (X : C) : 𝟙 X ≫ ε[X] = ε[X] := Category.id_comp _
+
+/-- **Left counit law**: Copying then deleting the first copy recovers the original.
+This is a fundamental property of the comonoid structure, ensuring that marginalization
+is the inverse of creating correlation. -/
+@[simp, reassoc]
+lemma copy_comp_del_left (X : C) : Δ[X] ≫ (ε[X] ▷ X) = (λ_ X).inv := counit_comul X
+
+/-- **Right counit law**: Copying then deleting the second copy recovers the original.
+Together with `copy_comp_del_left`, this ensures both marginals equal the original
+distribution. -/
+@[simp, reassoc]
+lemma copy_comp_del_right (X : C) : Δ[X] ≫ (X ◁ ε[X]) = (ρ_ X).inv := comul_counit X
+
+/-- Copying is commutative: swapping the copies gives the same result.
+This shows that correlation is symmetric. -/
+@[simp, reassoc]
+lemma copy_comp_braiding (X : C) : Δ[X] ≫ (β_ X X).hom = Δ[X] := copy_comm X
+
+/-- **Coassociativity**: Copying then copying the first output equals copying then
+copying the second output (up to reassociation). This means we can create multiple
+correlated copies without ambiguity. -/
+@[simp, reassoc]
+lemma copy_comp_copy_left (X : C) :
+    Δ[X] ≫ (Δ[X] ▷ X) = Δ[X] ≫ (X ◁ Δ[X]) ≫ (α_ X X X).inv := coassoc X
+
+/-- Copying distributes over tensor products via the middle four interchange.
+This shows how copying preserves the independence structure. -/
+@[simp]
+lemma copy_tensor_eq (X Y : C) :
+    Δ[X ⊗ Y] = (Δ[X] ⊗ₘ Δ[Y]) ≫ middleFourInterchange X X Y Y := copy_tensor X Y
+
+/-- Deletion distributes over tensor products.
+Marginalizing over a product equals marginalizing over each component. -/
+@[simp]
+lemma del_tensor_eq (X Y : C) :
+    ε[X ⊗ Y] = (ε[X] ⊗ₘ ε[Y]) ≫ (λ_ (𝟙_ C)).hom := del_tensor X Y
+
+/-- Deletion is natural: it commutes with all morphisms.
+This forces the monoidal unit to be terminal. -/
+@[simp, reassoc]
+lemma del_natural_simp {X Y : C} (f : X ⟶ Y) : f ≫ ε[Y] = ε[X] := del_natural f
+
+end MarkovCategory
+
+/-- A morphism in a Markov category is deterministic if it preserves the copy operation.
+
+Deterministic morphisms are the "pure" functions that preserve correlations perfectly.
+In truly probabilistic categories, these are the non-randomized morphisms.
+All morphisms in cartesian categories are deterministic, but a Markov category
+can have both deterministic and truly stochastic morphisms. -/
+class Deterministic {C : Type u} [Category.{v} C] [MonoidalCategory.{v} C] [MarkovCategory C]
+{X Y : C} (f : X ⟶ Y) : Prop where
+  preserves_copy : f ≫ MarkovCategory.copyMor Y = MarkovCategory.copyMor X ≫ (f ⊗ₘ f)
+
+namespace Deterministic
+
+variable {C : Type u} [Category.{v} C] [MonoidalCategory.{v} C]
+  [MarkovCategory C] {X Y Z : C}
+
+/-- The identity morphism is deterministic -/
+instance : Deterministic (𝟙 X) where
+  preserves_copy := by simp
+
+/-- Composition of deterministic morphisms is deterministic -/
+instance (f : X ⟶ Y) (g : Y ⟶ Z) [Deterministic f] [Deterministic g] :
+    Deterministic (f ≫ g) where
+  preserves_copy := by
+    rw [Category.assoc, Deterministic.preserves_copy, ← Category.assoc,
+        Deterministic.preserves_copy, Category.assoc]
+    simp only [← MonoidalCategory.tensor_comp]
+
+/-- Deterministic morphisms preserve the delete operation.
+
+Note that ALL morphisms preserve delete (by `del_natural`), not just deterministic ones.
+This lemma exists for convenience when working with deterministic morphisms. -/
+lemma preserves_del {f : X ⟶ Y} [Deterministic f] :
+    f ≫ MarkovCategory.delMor Y = MarkovCategory.delMor X :=
+  MarkovCategory.del_natural f
+
+end Deterministic
+
+end CategoryTheory

--- a/Mathlib/CategoryTheory/MarkovCategory/Cartesian.lean
+++ b/Mathlib/CategoryTheory/MarkovCategory/Cartesian.lean
@@ -1,0 +1,191 @@
+/-
+Copyright (c) 2025 Jacob Reinhold. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Jacob Reinhold
+-/
+import Mathlib.CategoryTheory.MarkovCategory.Basic
+import Mathlib.CategoryTheory.Monoidal.Cartesian.Basic
+import Mathlib.CategoryTheory.Limits.Shapes.BinaryProducts
+import Mathlib.CategoryTheory.Limits.Shapes.Terminal
+
+/-!
+# Cartesian Categories as Markov Categories
+
+This file shows that cartesian monoidal categories (categories with finite products)
+are Markov categories where every morphism is deterministic.
+
+## Mathematical significance
+
+Cartesian categories represent deterministic computation, e.g., the "classical" world where
+functions have unique outputs and information can be freely duplicated. By showing these
+form Markov categories, we see that:
+
+1. Markov categories generalize from deterministic to probabilistic settings
+2. The axioms of Markov categories, when specialized to the deterministic case,
+   recover the structure of products
+3. Probabilistic and deterministic computation share the same compositional structure
+
+In a cartesian setting, copying is the diagonal morphism
+`Δ : X → X × X` (which duplicates data) and deletion is the unique morphism
+to the terminal object (which discards data). There is no probabilistic
+branching. Every morphism preserves the copy operation perfectly.
+
+## Main definitions
+
+* `diagonalCopy` - The diagonal morphism as copy operation
+* `terminalDelete` - The unique morphism to terminal as delete operation
+
+## Main results
+
+* `instMarkovCategoryOfCartesian` - Cartesian monoidal categories are Markov categories
+* `deterministic_of_cartesian` - Every morphism in a cartesian category is deterministic
+* `copy_eq_diagonal` - The copy operation equals the diagonal
+* `del_eq_terminal` - The delete operation equals the terminal morphism
+
+## Implementation notes
+
+We use the existing `CartesianMonoidalCategory` structure which provides
+the monoidal structure from finite products. The braiding is constructed from
+the product projections and pairing: `swap(x,y) = (y,x)` using `⟨snd, fst⟩`.
+
+The proofs are straightforward because products naturally satisfy the comonoid
+axioms; this is the "canonical comonoid" that exists in any cartesian category.
+The use of `ext` (extensionality for products) reduces most proofs to the
+universal property of products.
+
+## Design rationale
+
+We define this as an instance rather than just a theorem because:
+1. It allows cartesian categories to automatically inherit all Markov category theory
+2. It provides the canonical test case; any construction or theorem in Markov
+   category theory MUST reduce to the correct classical result when specialized to
+   cartesian categories. If it doesn't, the construction is wrong.
+3. It validates the framework: Shows that Markov categories generalize
+   classical categories by including them as the "zero randomness" special case
+
+## Tags
+
+Markov category, cartesian category, finite products, deterministic
+-/
+
+universe u v
+
+open CategoryTheory MonoidalCategory Limits
+
+namespace CategoryTheory
+
+variable {C : Type u} [Category.{v} C]
+
+/-- In a cartesian monoidal category, the diagonal provides the copy operation.
+
+This is `⟨id, id⟩ : X → X × X`, which duplicates the value.
+In the category of sets/types, this sends `x ↦ (x, x)`. -/
+def diagonalCopy [CartesianMonoidalCategory C] (X : C) : X ⟶ X ⊗ X :=
+  CartesianMonoidalCategory.lift (𝟙 X) (𝟙 X)
+
+/-- In a cartesian monoidal category, the unique morphism to terminal provides delete.
+
+This discards information; there's no way to recover X from the terminal object.
+The uniqueness of this morphism is what makes the unit terminal. -/
+def terminalDelete [CartesianMonoidalCategory C] (X : C) : X ⟶ 𝟙_ C :=
+  CartesianMonoidalCategory.toUnit X
+
+/-- A cartesian monoidal category forms a Markov category.
+
+This is the key example showing that Markov categories include classical
+deterministic computation. All the probabilistic axioms hold when
+there's no randomness. -/
+instance instMarkovCategoryOfCartesian [CartesianMonoidalCategory C] : MarkovCategory C where
+  braiding X Y := ⟨CartesianMonoidalCategory.lift (CartesianMonoidalCategory.snd X Y)
+                     (CartesianMonoidalCategory.fst X Y),
+                   CartesianMonoidalCategory.lift (CartesianMonoidalCategory.snd Y X)
+                     (CartesianMonoidalCategory.fst Y X),
+                   by ext <;> simp [CartesianMonoidalCategory.lift_fst,
+                                    CartesianMonoidalCategory.lift_snd],
+                   by ext <;> simp [CartesianMonoidalCategory.lift_fst,
+                                    CartesianMonoidalCategory.lift_snd]⟩
+  copyMor := diagonalCopy
+  delMor := terminalDelete
+  copy_comm X := by
+    -- The diagonal is symmetric: (x,x) and (x,x) are the same regardless of swap
+    unfold diagonalCopy
+    ext <;> simp [CartesianMonoidalCategory.lift_fst, CartesianMonoidalCategory.lift_snd]
+  counit_comul X := by
+    -- (x,x) then delete first component gives x, matching the left unitor
+    unfold diagonalCopy terminalDelete
+    ext
+    simp
+  comul_counit X := by
+    -- (x,x) then delete second component gives x, matching the right unitor
+    unfold diagonalCopy terminalDelete
+    ext
+    simp
+  coassoc X := by
+    -- (x,x) then copy first vs copy second both give (x,x,x)
+    unfold diagonalCopy
+    ext <;> simp [CartesianMonoidalCategory.lift_fst, CartesianMonoidalCategory.lift_snd]
+  copy_tensor X Y := by
+    -- ((x,y), (x,y)) rearranges to ((x,x), (y,y)) via middleFourInterchange
+    unfold diagonalCopy
+    ext <;> simp [middleFourInterchange]
+  del_tensor X Y := by
+    -- Unique morphism to terminal factors through product of terminals
+    unfold terminalDelete
+    apply CartesianMonoidalCategory.toUnit_unique
+  del_natural f := by
+    -- Terminal object has exactly one morphism from any object
+    unfold terminalDelete
+    apply CartesianMonoidalCategory.toUnit_unique
+
+namespace CartesianMarkov
+
+variable [CartesianMonoidalCategory C]
+
+/-- In a cartesian category, every morphism is deterministic.
+
+This is the key property that characterizes cartesian categories as Markov
+categories: all morphisms preserve copying perfectly, meaning there's no randomness. -/
+instance deterministic_of_cartesian {X Y : C} (f : X ⟶ Y) : Deterministic f where
+  preserves_copy := by
+    -- f(x,x) = (f(x), f(x)) by the universal property of products
+    simp only [MarkovCategory.copyMor, diagonalCopy]
+    ext <;> simp [CartesianMonoidalCategory.lift_fst, CartesianMonoidalCategory.lift_snd]
+
+/-- The copy operation in a cartesian category is the diagonal -/
+@[simp]
+lemma copy_eq_diagonal (X : C) :
+    MarkovCategory.copyMor X = CartesianMonoidalCategory.lift (𝟙 X) (𝟙 X) := rfl
+
+/-- The delete operation in a cartesian category is the terminal morphism -/
+@[simp]
+lemma del_eq_terminal (X : C) :
+    MarkovCategory.delMor X = CartesianMonoidalCategory.toUnit X := rfl
+
+/-- First projection composed with copy gives identity -/
+@[simp, reassoc]
+lemma copy_fst (X : C) : MarkovCategory.copyMor X ≫ CartesianMonoidalCategory.fst X X = 𝟙 X := by
+  simp [copy_eq_diagonal, CartesianMonoidalCategory.lift_fst]
+
+/-- Second projection composed with copy gives identity -/
+@[simp, reassoc]
+lemma copy_snd (X : C) : MarkovCategory.copyMor X ≫ CartesianMonoidalCategory.snd X X = 𝟙 X := by
+  simp [copy_eq_diagonal, CartesianMonoidalCategory.lift_snd]
+
+/-- The copy operation satisfies the universal property of the product.
+
+This shows that in the cartesian setting, the Markov category copy operation
+is the categorical product structure. Two morphisms are equal if and
+only if they agree after copying (this is true only in deterministic settings). -/
+lemma copy_universal {X Y : C} (f g : Y ⟶ X) :
+    f = g ↔ f ≫ MarkovCategory.copyMor X = g ≫ MarkovCategory.copyMor X := by
+  constructor
+  · intro h; rw [h]
+  · intro h
+    rw [copy_eq_diagonal] at h
+    have h1 := congr_arg (· ≫ CartesianMonoidalCategory.fst X X) h
+    simp [CartesianMonoidalCategory.lift_fst] at h1
+    exact h1
+
+end CartesianMarkov
+
+end CategoryTheory

--- a/Mathlib/CategoryTheory/MarkovCategory/Cartesian.lean
+++ b/Mathlib/CategoryTheory/MarkovCategory/Cartesian.lean
@@ -11,24 +11,16 @@ import Mathlib.CategoryTheory.Limits.Shapes.Terminal
 /-!
 # Cartesian Categories as Markov Categories
 
-This file shows that cartesian monoidal categories (categories with finite products)
-are Markov categories where every morphism is deterministic.
+Shows that cartesian monoidal categories are Markov categories where morphisms are deterministic.
 
-## Mathematical significance
+Cartesian categories represent deterministic computation where functions have unique outputs
+and information can be duplicated freely. In this setting:
+- Copying is the diagonal morphism `Δ : X → X × X`
+- Deletion is the unique morphism to the terminal object
+- Every morphism preserves copying perfectly (is deterministic)
 
-Cartesian categories represent deterministic computation, e.g., the "classical" world where
-functions have unique outputs and information can be freely duplicated. By showing these
-form Markov categories, we see that:
-
-1. Markov categories generalize from deterministic to probabilistic settings
-2. The axioms of Markov categories, when specialized to the deterministic case,
-   recover the structure of products
-3. Probabilistic and deterministic computation share the same compositional structure
-
-In a cartesian setting, copying is the diagonal morphism
-`Δ : X → X × X` (which duplicates data) and deletion is the unique morphism
-to the terminal object (which discards data). There is no probabilistic
-branching. Every morphism preserves the copy operation perfectly.
+This shows that Markov categories generalize from deterministic to probabilistic settings,
+with cartesian categories as the "zero randomness" case.
 
 ## Main definitions
 
@@ -42,27 +34,6 @@ branching. Every morphism preserves the copy operation perfectly.
 * `copy_eq_diagonal` - The copy operation equals the diagonal
 * `del_eq_terminal` - The delete operation equals the terminal morphism
 
-## Implementation notes
-
-We use the existing `CartesianMonoidalCategory` structure which provides
-the monoidal structure from finite products. The braiding is constructed from
-the product projections and pairing: `swap(x,y) = (y,x)` using `⟨snd, fst⟩`.
-
-The proofs are straightforward because products naturally satisfy the comonoid
-axioms; this is the "canonical comonoid" that exists in any cartesian category.
-The use of `ext` (extensionality for products) reduces most proofs to the
-universal property of products.
-
-## Design rationale
-
-We define this as an instance rather than just a theorem because:
-1. It allows cartesian categories to automatically inherit all Markov category theory
-2. It provides the canonical test case; any construction or theorem in Markov
-   category theory MUST reduce to the correct classical result when specialized to
-   cartesian categories. If it doesn't, the construction is wrong.
-3. It validates the framework: Shows that Markov categories generalize
-   classical categories by including them as the "zero randomness" special case
-
 ## Tags
 
 Markov category, cartesian category, finite products, deterministic
@@ -74,27 +45,24 @@ open CategoryTheory MonoidalCategory Limits
 
 namespace CategoryTheory
 
+open CopyDiscardCategory
+
 variable {C : Type u} [Category.{v} C]
 
-/-- In a cartesian monoidal category, the diagonal provides the copy operation.
+/-- The diagonal morphism `⟨id, id⟩ : X → X × X` as the copy operation.
 
-This is `⟨id, id⟩ : X → X × X`, which duplicates the value.
-In the category of sets/types, this sends `x ↦ (x, x)`. -/
+In sets, this sends `x ↦ (x, x)`. -/
 def diagonalCopy [CartesianMonoidalCategory C] (X : C) : X ⟶ X ⊗ X :=
   CartesianMonoidalCategory.lift (𝟙 X) (𝟙 X)
 
-/-- In a cartesian monoidal category, the unique morphism to terminal provides delete.
-
-This discards information; there's no way to recover X from the terminal object.
-The uniqueness of this morphism is what makes the unit terminal. -/
+/-- The unique morphism to the terminal object as the delete operation. -/
 def terminalDelete [CartesianMonoidalCategory C] (X : C) : X ⟶ 𝟙_ C :=
   CartesianMonoidalCategory.toUnit X
 
-/-- A cartesian monoidal category forms a Markov category.
+/-- Cartesian monoidal categories are Markov categories.
 
-This is the key example showing that Markov categories include classical
-deterministic computation. All the probabilistic axioms hold when
-there's no randomness. -/
+This shows that Markov categories include deterministic computation:
+all axioms hold when there's no randomness. -/
 instance instMarkovCategoryOfCartesian [CartesianMonoidalCategory C] : MarkovCategory C where
   braiding X Y := ⟨CartesianMonoidalCategory.lift (CartesianMonoidalCategory.snd X Y)
                      (CartesianMonoidalCategory.fst X Y),
@@ -107,77 +75,77 @@ instance instMarkovCategoryOfCartesian [CartesianMonoidalCategory C] : MarkovCat
   copyMor := diagonalCopy
   delMor := terminalDelete
   copy_comm X := by
-    -- The diagonal is symmetric: (x,x) and (x,x) are the same regardless of swap
+    -- Diagonal is symmetric: swapping (x,x) gives (x,x)
     unfold diagonalCopy
     ext <;> simp [CartesianMonoidalCategory.lift_fst, CartesianMonoidalCategory.lift_snd]
   counit_comul X := by
-    -- (x,x) then delete first component gives x, matching the left unitor
+    -- Delete first of (x,x) gives x
     unfold diagonalCopy terminalDelete
     ext
     simp
   comul_counit X := by
-    -- (x,x) then delete second component gives x, matching the right unitor
+    -- Delete second of (x,x) gives x
     unfold diagonalCopy terminalDelete
     ext
     simp
   coassoc X := by
-    -- (x,x) then copy first vs copy second both give (x,x,x)
+    -- Copy either component of (x,x) gives (x,x,x)
     unfold diagonalCopy
     ext <;> simp [CartesianMonoidalCategory.lift_fst, CartesianMonoidalCategory.lift_snd]
   copy_tensor X Y := by
-    -- ((x,y), (x,y)) rearranges to ((x,x), (y,y)) via middleFourInterchange
+    -- Rearrange ((x,y), (x,y)) to ((x,x), (y,y))
     unfold diagonalCopy
     ext <;> simp [middleFourInterchange]
   del_tensor X Y := by
-    -- Unique morphism to terminal factors through product of terminals
+    -- Morphism to terminal is unique
     unfold terminalDelete
     apply CartesianMonoidalCategory.toUnit_unique
   del_natural f := by
-    -- Terminal object has exactly one morphism from any object
+    -- Morphism to terminal is unique
     unfold terminalDelete
     apply CartesianMonoidalCategory.toUnit_unique
 
 namespace CartesianMarkov
 
+open MarkovCategory
+
 variable [CartesianMonoidalCategory C]
 
-/-- In a cartesian category, every morphism is deterministic.
+/-- Every morphism in a cartesian category is deterministic.
 
-This is the key property that characterizes cartesian categories as Markov
-categories: all morphisms preserve copying perfectly, meaning there's no randomness. -/
+All morphisms preserve copying perfectly since there's no randomness. -/
 instance deterministic_of_cartesian {X Y : C} (f : X ⟶ Y) : Deterministic f where
   preserves_copy := by
-    -- f(x,x) = (f(x), f(x)) by the universal property of products
-    simp only [MarkovCategory.copyMor, diagonalCopy]
+    -- Products preserve: f(x,x) = (f(x), f(x))
+    simp only [copyMor, diagonalCopy]
     ext <;> simp [CartesianMonoidalCategory.lift_fst, CartesianMonoidalCategory.lift_snd]
 
-/-- The copy operation in a cartesian category is the diagonal -/
+/-- The copy operation equals the diagonal. -/
 @[simp]
 lemma copy_eq_diagonal (X : C) :
-    MarkovCategory.copyMor X = CartesianMonoidalCategory.lift (𝟙 X) (𝟙 X) := rfl
+    copyMor X = CartesianMonoidalCategory.lift (𝟙 X) (𝟙 X) := rfl
 
-/-- The delete operation in a cartesian category is the terminal morphism -/
+/-- The delete operation equals the terminal morphism. -/
 @[simp]
 lemma del_eq_terminal (X : C) :
-    MarkovCategory.delMor X = CartesianMonoidalCategory.toUnit X := rfl
+    delMor X = CartesianMonoidalCategory.toUnit X := rfl
 
-/-- First projection composed with copy gives identity -/
+/-- First projection after copy gives identity. -/
 @[simp, reassoc]
-lemma copy_fst (X : C) : MarkovCategory.copyMor X ≫ CartesianMonoidalCategory.fst X X = 𝟙 X := by
+lemma copy_fst (X : C) : copyMor X ≫ CartesianMonoidalCategory.fst X X = 𝟙 X := by
   simp [copy_eq_diagonal, CartesianMonoidalCategory.lift_fst]
 
-/-- Second projection composed with copy gives identity -/
+/-- Second projection after copy gives identity. -/
 @[simp, reassoc]
-lemma copy_snd (X : C) : MarkovCategory.copyMor X ≫ CartesianMonoidalCategory.snd X X = 𝟙 X := by
+lemma copy_snd (X : C) : copyMor X ≫ CartesianMonoidalCategory.snd X X = 𝟙 X := by
   simp [copy_eq_diagonal, CartesianMonoidalCategory.lift_snd]
 
-/-- The copy operation satisfies the universal property of the product.
+/-- The copy operation satisfies the universal property of products.
 
-This shows that in the cartesian setting, the Markov category copy operation
-is the categorical product structure. Two morphisms are equal if and
-only if they agree after copying (this is true only in deterministic settings). -/
+Two morphisms are equal if and only if they agree after copying
+(true only in deterministic settings). -/
 lemma copy_universal {X Y : C} (f g : Y ⟶ X) :
-    f = g ↔ f ≫ MarkovCategory.copyMor X = g ≫ MarkovCategory.copyMor X := by
+    f = g ↔ f ≫ copyMor X = g ≫ copyMor X := by
   constructor
   · intro h; rw [h]
   · intro h

--- a/Mathlib/CategoryTheory/MarkovCategory/FinStoch/Basic.lean
+++ b/Mathlib/CategoryTheory/MarkovCategory/FinStoch/Basic.lean
@@ -92,16 +92,16 @@ theorem ext {f g : StochasticMatrix m n} (h : f.toMatrix = g.toMatrix) : f = g :
 /-! ### Deterministic matrices -/
 
 /-- Each row has exactly one 1. -/
-def isDeterministic (f : StochasticMatrix m n) [DecidableEq n] : Prop :=
+def isDeterministic (f : StochasticMatrix m n) : Prop :=
   ∀ i : m, ∃! j : n, f.toMatrix i j = 1
 
 /-- Extract function from deterministic matrix. -/
-noncomputable def apply (f : StochasticMatrix m n) [DecidableEq n]
+noncomputable def apply (f : StochasticMatrix m n)
     (h : f.isDeterministic) (i : m) : n :=
   (h i).choose
 
 /-- Apply gives the unique 1. -/
-lemma apply_spec (f : StochasticMatrix m n) [DecidableEq n] (h : f.isDeterministic) (i : m) :
+lemma apply_spec (f : StochasticMatrix m n) (h : f.isDeterministic) (i : m) :
     f.toMatrix i (f.apply h i) = 1 :=
   (h i).choose_spec.1
 
@@ -142,7 +142,7 @@ lemma apply_spec_ne (f : StochasticMatrix m n) [DecidableEq n] (h : f.isDetermin
 
 /-- Matrix entry is 1 iff it's the unique output. -/
 @[simp]
-lemma det_matrix_eq_one_iff (f : StochasticMatrix m n) [DecidableEq n] (h : f.isDeterministic)
+lemma det_matrix_eq_one_iff (f : StochasticMatrix m n) (h : f.isDeterministic)
     (i : m) (j : n) : f.toMatrix i j = 1 ↔ j = f.apply h i := by
   constructor
   · intro hj
@@ -170,7 +170,7 @@ lemma id_isDeterministic (m : Type u) [Fintype m] [DecidableEq m] :
 
 /-- Deterministic matrices compose to deterministic matrices. -/
 theorem det_comp_det (f : StochasticMatrix m n) (g : StochasticMatrix n p)
-    [DecidableEq n] [DecidableEq p] (hf : f.isDeterministic) (hg : g.isDeterministic) :
+    [DecidableEq n] (hf : f.isDeterministic) (hg : g.isDeterministic) :
     (comp f g).isDeterministic := by
   intro i
   use g.apply hg (f.apply hf i)
@@ -207,7 +207,7 @@ theorem det_comp_det (f : StochasticMatrix m n) (g : StochasticMatrix n p)
 
 /-- Composition of deterministic matrices equals function composition. -/
 theorem det_comp_eq_fun_comp (f : StochasticMatrix m n) (g : StochasticMatrix n p)
-    [DecidableEq n] [DecidableEq p] (hf : f.isDeterministic) (hg : g.isDeterministic) (i : m) :
+    [DecidableEq n] (hf : f.isDeterministic) (hg : g.isDeterministic) (i : m) :
     (comp f g).apply (det_comp_det f g hf hg) i = g.apply hg (f.apply hf i) := by
   -- By det_comp_det, the unique 1 in row i of comp f g is at column g.apply hg (f.apply hf i)
   -- The apply function returns this unique column
@@ -250,7 +250,7 @@ lemma delta_mul_delta {α β : Type*} [DecidableEq α] [DecidableEq β]
 /-- Tensor product of deterministic matrices is deterministic. -/
 theorem det_tensor_det {m₁ n₁ m₂ n₂ : Type u} [Fintype m₁] [Fintype n₁] [Fintype m₂] [Fintype n₂]
     (f : StochasticMatrix m₁ n₁) (g : StochasticMatrix m₂ n₂)
-    [DecidableEq n₁] [DecidableEq n₂] [DecidableEq (n₁ × n₂)]
+    [DecidableEq n₁]
     (hf : f.isDeterministic) (hg : g.isDeterministic) :
     (tensor f g).isDeterministic := by
   intro ⟨i₁, i₂⟩
@@ -290,7 +290,7 @@ theorem det_tensor_det {m₁ n₁ m₂ n₂ : Type u} [Fintype m₁] [Fintype n�
 /-- Apply function for tensor products of deterministic matrices. -/
 theorem apply_tensor {m₁ n₁ m₂ n₂ : Type u} [Fintype m₁] [Fintype n₁] [Fintype m₂] [Fintype n₂]
     (f : StochasticMatrix m₁ n₁) (g : StochasticMatrix m₂ n₂)
-    [DecidableEq n₁] [DecidableEq n₂] [DecidableEq (n₁ × n₂)]
+    [DecidableEq n₁]
     (hf : f.isDeterministic) (hg : g.isDeterministic) (i₁ : m₁) (i₂ : m₂) :
     (tensor f g).apply (det_tensor_det f g hf hg) (i₁, i₂) =
     (f.apply hf i₁, g.apply hg i₂) := by
@@ -375,7 +375,7 @@ def id (m : Type u) [Fintype m] [DecidableEq m] : DetMorphism m m :=
   ofFunc _root_.id
 
 /-- Composition of deterministic morphisms. -/
-def comp [DecidableEq (m × m)] (f : DetMorphism m n) (g : DetMorphism n p) : DetMorphism m p where
+def comp (f : DetMorphism m n) (g : DetMorphism n p) : DetMorphism m p where
   func := g.func ∘ f.func
   toStochastic := StochasticMatrix.comp f.toStochastic g.toStochastic
   is_det := StochasticMatrix.det_comp_det f.toStochastic g.toStochastic f.is_det g.is_det
@@ -426,7 +426,7 @@ lemma toMatrix_apply (f : DetMorphism m n) (i : m) (j : n) :
     exact StochasticMatrix.apply_spec_ne f.toStochastic f.is_det i j hne
 
 /-- Composition of DetMorphisms as matrices. -/
-lemma comp_toMatrix [DecidableEq (m × m)] (f : DetMorphism m n) (g : DetMorphism n p)
+lemma comp_toMatrix (f : DetMorphism m n) (g : DetMorphism n p)
     (i : m) (k : p) :
     (comp f g).toStochastic.toMatrix i k = if g.func (f.func i) = k then 1 else 0 := by
   simp only [comp]
@@ -444,7 +444,7 @@ lemma tensor_toMatrix {m₁ n₁ m₂ n₂ : Type u} [Fintype m₁] [Fintype n�
 
 /-- Identity composition left. -/
 @[simp]
-lemma id_comp [DecidableEq m] [DecidableEq (m × m)] (f : DetMorphism m n) :
+lemma id_comp [DecidableEq m] (f : DetMorphism m n) :
     comp (id m) f = f := by
   ext i
   simp [comp, id, ofFunc]
@@ -452,14 +452,13 @@ lemma id_comp [DecidableEq m] [DecidableEq (m × m)] (f : DetMorphism m n) :
 omit [DecidableEq n] in
 /-- Identity composition right. -/
 @[simp]
-lemma comp_id [DecidableEq (m × m)] [DecidableEq n] (f : DetMorphism m n) :
+lemma comp_id [DecidableEq n] (f : DetMorphism m n) :
     comp f (id n) = f := by
   ext i
   simp [comp, id, ofFunc]
 
 /-- Composition is associative. -/
 lemma comp_assoc {q : Type u} [Fintype q] [DecidableEq q]
-    [DecidableEq (m × m)] [DecidableEq (n × n)]
     (f : DetMorphism m n) (g : DetMorphism n p) (h : DetMorphism p q) :
     comp (comp f g) h = comp f (comp g h) := by
   ext i
@@ -469,8 +468,11 @@ end DetMorphism
 
 /-- FinStoch: finite types with stochastic matrices. -/
 structure FinStoch : Type (u+1) where
+  /-- The underlying finite type. -/
   carrier : Type u
+  /-- Proof that the carrier is finite. -/
   [fintype : Fintype carrier]
+  /-- Decidable equality for the carrier type. -/
   [decidableEq : DecidableEq carrier]
 
 namespace FinStoch

--- a/Mathlib/CategoryTheory/MarkovCategory/FinStoch/Basic.lean
+++ b/Mathlib/CategoryTheory/MarkovCategory/FinStoch/Basic.lean
@@ -1,0 +1,245 @@
+/-
+Copyright (c) 2025 Jacob Reinhold. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Jacob Reinhold
+-/
+import Mathlib.CategoryTheory.MarkovCategory.Basic
+import Mathlib.Data.Matrix.Basic
+import Mathlib.Data.Fintype.Basic
+import Mathlib.Data.NNReal.Basic
+
+/-!
+# Finite Stochastic Matrices
+
+This file defines the category of finite types with stochastic matrices as morphisms,
+providing a concrete model of a Markov category for probabilistic computations.
+
+## Mathematical perspective
+
+FinStoch is the key example of a Markov category that handles real probability.
+Cartesian categories have only deterministic morphisms, but FinStoch includes
+both deterministic functions (permutation matrices) and random processes
+(matrices with mixed distributions). This makes it the place to test
+probabilistic reasoning in categories.
+
+A morphism `f : m → n` is a stochastic matrix where `f[i,j]` gives the probability
+of transitioning from state `i` to state `j`. Composition follows the Chapman-Kolmogorov
+equation from Markov chain theory, and tensor products model independent parallel processes.
+
+## Main definitions
+
+* `StochasticMatrix m n` - An `m × n` stochastic matrix where each row sums to 1
+* `FinStoch` - The category of finite types with stochastic matrices as morphisms
+* `StochasticMatrix.id` - The identity stochastic matrix
+* `StochasticMatrix.comp` - Composition of stochastic matrices
+* `StochasticMatrix.tensor` - Tensor product (Kronecker product) of stochastic matrices
+
+## Implementation notes
+
+### Row-stochastic convention
+
+We use row-stochastic matrices (rows sum to 1) rather than column-stochastic.
+This choice aligns with:
+- Standard probability notation where P(j|i) is "probability of j given i"
+- Matrix multiplication naturally implementing the Chapman-Kolmogorov equation
+- The categorical convention where morphisms f : X → Y go from domain to codomain
+
+### Type-level validity
+
+The row sum constraint is embedded in the type rather than as a separate proposition.
+This design ensures every `StochasticMatrix` is valid by construction, eliminating
+runtime checks and simplifying proofs. The trade-off is that constructing matrices
+requires proving the constraint, but this is handled once at construction time.
+
+### NNReal for positivity
+
+We use `NNReal` (non-negative reals) for matrix entries to ensure non-negativity
+by construction. This prevents impossible "negative probabilities" at the type level.
+
+### Bundled instances
+
+We bundle `Fintype` and `DecidableEq` instances with `FinStoch` objects rather than
+relying on type class inference. This avoids diamond problems and ensures the
+categorical constructions work smoothly without instance resolution issues.
+
+## Examples
+
+The `Examples` section below demonstrates:
+* Fair coin flip: 50/50 probability distribution over Bool
+* Deterministic functions as stochastic matrices (permutation matrices)
+* The identity matrix as a special deterministic case
+
+## References
+
+* [Fritz, *A synthetic approach to Markov kernels, conditional independence
+  and theorems on sufficient statistics*][fritz2020]
+
+## Tags
+
+Markov category, stochastic matrix, probability, category theory
+-/
+
+namespace CategoryTheory.MarkovCategory
+
+universe u
+
+/-- A stochastic matrix represents a conditional probability distribution P(n|m).
+
+The matrix entry at position (i,j) gives the probability of transitioning from
+state i ∈ m to state j ∈ n. Each row forms a probability distribution over the
+output states, listing all possible outcomes for each input.
+
+This is also called a Markov kernel in probability theory. -/
+structure StochasticMatrix (m n : Type u) [Fintype m] [Fintype n] where
+  /-- The underlying matrix of non-negative real values -/
+  toMatrix : Matrix m n NNReal
+  /-- Each row sums to 1, forming a probability distribution -/
+  row_sum : ∀ i : m, ∑ j : n, toMatrix i j = 1
+
+namespace StochasticMatrix
+
+variable {m n p : Type u} [Fintype m] [Fintype n] [Fintype p]
+
+/-- The identity stochastic matrix, where each state transitions to itself with probability 1.
+
+This represents the deterministic identity function; no randomness, each state
+maps to itself. This is the "do nothing" transition. -/
+def id (m : Type u) [Fintype m] [DecidableEq m] : StochasticMatrix m m where
+  toMatrix := fun i j => if i = j then (1 : NNReal) else 0
+  row_sum := fun i => by
+    -- Only the diagonal entry (i,i) contributes to the sum
+    rw [Finset.sum_eq_single i]
+    · simp
+    · intro j _ hj
+      simp [if_neg (Ne.symm hj)]
+    · intro h
+      exfalso
+      exact h (Finset.mem_univ _)
+
+/-- Composition of stochastic matrices corresponds to the Chapman-Kolmogorov equation:
+P(Z|X) = ∑_Y P(Y|X) * P(Z|Y).
+
+This is the key equation of Markov processes: to get from X to Z, we sum
+over all possible intermediate states Y, weighting by the probability of each path.
+Matrix multiplication naturally implements this sum over intermediate states. -/
+def comp (f : StochasticMatrix m n) (g : StochasticMatrix n p) : StochasticMatrix m p where
+  toMatrix := fun i k => ∑ j : n, f.toMatrix i j * g.toMatrix j k
+  row_sum := fun i => by
+    -- Key insight: summing first over outputs k, then intermediates j
+    -- equals summing first over j, then k (by Fubini/sum exchange)
+    rw [Finset.sum_comm]
+    simp only [← Finset.mul_sum]
+    -- Each row of g sums to 1, and f's row i sums to 1
+    simp only [g.row_sum, mul_one, f.row_sum]
+
+/-- Tensor product of stochastic matrices models independent parallel composition.
+
+For independent processes, P((Y₁,Y₂)|(X₁,X₂)) = P(Y₁|X₁) * P(Y₂|X₂).
+
+This is the Kronecker product from linear algebra, but interpreted probabilistically:
+it runs two independent stochastic processes in parallel. The key property is that
+the processes are independent; knowing the outcome of one gives no information about the other. -/
+def tensor {m₁ n₁ m₂ n₂ : Type u} [Fintype m₁] [Fintype n₁] [Fintype m₂] [Fintype n₂]
+    (f : StochasticMatrix m₁ n₁) (g : StochasticMatrix m₂ n₂) :
+    StochasticMatrix (m₁ × m₂) (n₁ × n₂) where
+  toMatrix := fun ij kl => f.toMatrix ij.1 kl.1 * g.toMatrix ij.2 kl.2
+  row_sum := fun ij => by
+    obtain ⟨i₁, i₂⟩ := ij
+    -- Sum over product = product of sums (independence!)
+    rw [← Finset.univ_product_univ, Finset.sum_product]
+    rw [← Finset.sum_mul_sum]
+    -- Both processes have probability 1 total
+    simp only [f.row_sum i₁, g.row_sum i₂, one_mul]
+
+@[ext]
+theorem ext {f g : StochasticMatrix m n} (h : f.toMatrix = g.toMatrix) : f = g := by
+  cases f
+  cases g
+  congr
+
+end StochasticMatrix
+
+/-- The category of finite types with stochastic matrices as morphisms.
+
+Objects are finite types representing state spaces. Morphisms are stochastic
+matrices representing probabilistic transitions. This forms a category because:
+- Identity matrices preserve states deterministically
+- Composition follows the Chapman-Kolmogorov equation
+- Associativity comes from matrix multiplication -/
+structure FinStoch : Type (u+1) where
+  carrier : Type u
+  [fintype : Fintype carrier]
+  [decidableEq : DecidableEq carrier]
+
+namespace FinStoch
+
+instance (X : FinStoch) : Fintype X.carrier := X.fintype
+
+instance (X : FinStoch) : DecidableEq X.carrier := X.decidableEq
+
+/-- Morphisms in FinStoch are stochastic matrices. -/
+abbrev Hom (X Y : FinStoch) := StochasticMatrix X.carrier Y.carrier
+
+instance : CategoryStruct FinStoch where
+  Hom := Hom
+  id X := StochasticMatrix.id X.carrier
+  comp f g := StochasticMatrix.comp f g
+
+instance : Category FinStoch where
+  id_comp f := by
+    apply StochasticMatrix.ext
+    ext i j
+    simp only [CategoryStruct.comp, StochasticMatrix.comp]
+    simp only [CategoryStruct.id]
+    -- Identity picks out the i-th row of f
+    rw [Finset.sum_eq_single i]
+    · simp [StochasticMatrix.id, one_mul]
+    · intro k _ hk
+      simp [StochasticMatrix.id, zero_mul]
+      intro h
+      exact absurd h (Ne.symm hk)
+    · intro h
+      exfalso
+      exact h (Finset.mem_univ _)
+  comp_id f := by
+    apply StochasticMatrix.ext
+    ext i j
+    simp only [CategoryStruct.comp, StochasticMatrix.comp]
+    simp only [CategoryStruct.id]
+    -- Identity picks out the j-th column of f
+    rw [Finset.sum_eq_single j]
+    · simp [StochasticMatrix.id, mul_one]
+    · intro k _ hk
+      simp [StochasticMatrix.id, mul_zero]
+      intro h
+      exact absurd h.symm (Ne.symm hk)
+    · intro h
+      exfalso
+      exact h (Finset.mem_univ _)
+  assoc f g h := by
+    apply StochasticMatrix.ext
+    ext i k
+    simp only [CategoryStruct.comp, StochasticMatrix.comp]
+    -- Matrix multiplication is associative
+    simp only [Finset.sum_mul, Finset.mul_sum, mul_assoc]
+    -- We can sum over intermediate states in any order
+    rw [Finset.sum_comm]
+
+/-- The tensor unit is the singleton type with a unique stochastic matrix structure.
+
+This represents a trivial one-state system with no randomness. It's the identity
+for tensor products: tensoring with Unit adds no states or randomness. -/
+def tensorUnit : FinStoch where
+  carrier := Unit
+
+/-- The tensor product of objects is the product of their carrier types.
+
+This models compound systems: if X has m states and Y has n states,
+then X ⊗ Y has m×n states representing all possible combinations.
+For example, two coins give four states: (H,H), (H,T), (T,H), (T,T). -/
+def tensorObj (X Y : FinStoch) : FinStoch where
+  carrier := X.carrier × Y.carrier
+
+end FinStoch
+
+end CategoryTheory.MarkovCategory

--- a/Mathlib/CategoryTheory/MarkovCategory/FinStoch/Basic.lean
+++ b/Mathlib/CategoryTheory/MarkovCategory/FinStoch/Basic.lean
@@ -4,11 +4,13 @@ Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Jacob Reinhold
 -/
 import Mathlib.CategoryTheory.Category.Basic
-import Mathlib.Data.Matrix.Basic
-import Mathlib.LinearAlgebra.Matrix.Kronecker
 import Mathlib.Data.Fintype.Basic
-import Mathlib.Data.NNReal.Basic
 import Mathlib.Logic.Equiv.Basic
+import Mathlib.Data.Fintype.Prod
+import Mathlib.Data.NNReal.Defs
+import Mathlib.LinearAlgebra.Matrix.Defs
+import Mathlib.Algebra.BigOperators.Ring.Finset
+import Mathlib.Algebra.Order.BigOperators.Group.Finset
 
 /-!
 # Finite Stochastic Matrices

--- a/Mathlib/CategoryTheory/MarkovCategory/FinStoch/Basic.lean
+++ b/Mathlib/CategoryTheory/MarkovCategory/FinStoch/Basic.lean
@@ -11,24 +11,20 @@ import Mathlib.Data.NNReal.Basic
 /-!
 # Finite Stochastic Matrices
 
-This file defines the category of finite types with stochastic matrices as morphisms,
-providing a concrete model of a Markov category for probabilistic computations.
+The category of finite types with stochastic matrices as morphisms,
+providing a concrete Markov category for probabilistic computations.
 
-## Mathematical perspective
-
-FinStoch is the key example of a Markov category that handles real probability.
-Cartesian categories have only deterministic morphisms, but FinStoch includes
-both deterministic functions (permutation matrices) and random processes
-(matrices with mixed distributions). This makes it the place to test
-probabilistic reasoning in categories.
+FinStoch handles real probability, unlike cartesian categories which have only
+deterministic morphisms. It includes both deterministic functions (permutation matrices)
+and random processes (general stochastic matrices).
 
 A morphism `f : m → n` is a stochastic matrix where `f[i,j]` gives the probability
 of transitioning from state `i` to state `j`. Composition follows the Chapman-Kolmogorov
-equation from Markov chain theory, and tensor products model independent parallel processes.
+equation, and tensor products model independent parallel processes.
 
 ## Main definitions
 
-* `StochasticMatrix m n` - An `m × n` stochastic matrix where each row sums to 1
+* `StochasticMatrix m n` - An `m × n` matrix where each row sums to 1
 * `FinStoch` - The category of finite types with stochastic matrices as morphisms
 * `StochasticMatrix.id` - The identity stochastic matrix
 * `StochasticMatrix.comp` - Composition of stochastic matrices
@@ -36,38 +32,14 @@ equation from Markov chain theory, and tensor products model independent paralle
 
 ## Implementation notes
 
-### Row-stochastic convention
+We use row-stochastic matrices (rows sum to 1). This aligns with standard probability
+notation P(j|i) and makes matrix multiplication implement the Chapman-Kolmogorov equation.
 
-We use row-stochastic matrices (rows sum to 1) rather than column-stochastic.
-This choice aligns with:
-- Standard probability notation where P(j|i) is "probability of j given i"
-- Matrix multiplication naturally implementing the Chapman-Kolmogorov equation
-- The categorical convention where morphisms f : X → Y go from domain to codomain
+The row sum constraint is in the type, ensuring validity by construction.
+We use `NNReal` for entries to prevent negative probabilities at the type level.
 
-### Type-level validity
-
-The row sum constraint is embedded in the type rather than as a separate proposition.
-This design ensures every `StochasticMatrix` is valid by construction, eliminating
-runtime checks and simplifying proofs. The trade-off is that constructing matrices
-requires proving the constraint, but this is handled once at construction time.
-
-### NNReal for positivity
-
-We use `NNReal` (non-negative reals) for matrix entries to ensure non-negativity
-by construction. This prevents impossible "negative probabilities" at the type level.
-
-### Bundled instances
-
-We bundle `Fintype` and `DecidableEq` instances with `FinStoch` objects rather than
-relying on type class inference. This avoids diamond problems and ensures the
-categorical constructions work smoothly without instance resolution issues.
-
-## Examples
-
-The `Examples` section below demonstrates:
-* Fair coin flip: 50/50 probability distribution over Bool
-* Deterministic functions as stochastic matrices (permutation matrices)
-* The identity matrix as a special deterministic case
+We bundle `Fintype` and `DecidableEq` instances with `FinStoch` objects to avoid
+diamond problems in categorical constructions.
 
 ## References
 
@@ -83,17 +55,14 @@ namespace CategoryTheory.MarkovCategory
 
 universe u
 
-/-- A stochastic matrix represents a conditional probability distribution P(n|m).
+/-- A stochastic matrix representing a conditional probability distribution P(n|m).
 
-The matrix entry at position (i,j) gives the probability of transitioning from
-state i ∈ m to state j ∈ n. Each row forms a probability distribution over the
-output states, listing all possible outcomes for each input.
-
-This is also called a Markov kernel in probability theory. -/
+Entry (i,j) gives the probability of transitioning from state i to state j.
+Each row is a probability distribution over output states. -/
 structure StochasticMatrix (m n : Type u) [Fintype m] [Fintype n] where
-  /-- The underlying matrix of non-negative real values -/
+  /-- The matrix of non-negative reals -/
   toMatrix : Matrix m n NNReal
-  /-- Each row sums to 1, forming a probability distribution -/
+  /-- Each row sums to 1 -/
   row_sum : ∀ i : m, ∑ j : n, toMatrix i j = 1
 
 namespace StochasticMatrix
@@ -129,26 +98,22 @@ def comp (f : StochasticMatrix m n) (g : StochasticMatrix n p) : StochasticMatri
     -- equals summing first over j, then k (by Fubini/sum exchange)
     rw [Finset.sum_comm]
     simp only [← Finset.mul_sum]
-    -- Each row of g sums to 1, and f's row i sums to 1
+    -- Both matrices are stochastic
     simp only [g.row_sum, mul_one, f.row_sum]
 
-/-- Tensor product of stochastic matrices models independent parallel composition.
+/-- Tensor product of stochastic matrices (Kronecker product).
 
-For independent processes, P((Y₁,Y₂)|(X₁,X₂)) = P(Y₁|X₁) * P(Y₂|X₂).
-
-This is the Kronecker product from linear algebra, but interpreted probabilistically:
-it runs two independent stochastic processes in parallel. The key property is that
-the processes are independent; knowing the outcome of one gives no information about the other. -/
+Models independent parallel processes: P((Y₁,Y₂)|(X₁,X₂)) = P(Y₁|X₁) * P(Y₂|X₂). -/
 def tensor {m₁ n₁ m₂ n₂ : Type u} [Fintype m₁] [Fintype n₁] [Fintype m₂] [Fintype n₂]
     (f : StochasticMatrix m₁ n₁) (g : StochasticMatrix m₂ n₂) :
     StochasticMatrix (m₁ × m₂) (n₁ × n₂) where
   toMatrix := fun ij kl => f.toMatrix ij.1 kl.1 * g.toMatrix ij.2 kl.2
   row_sum := fun ij => by
     obtain ⟨i₁, i₂⟩ := ij
-    -- Sum over product = product of sums (independence!)
+    -- Sum over product = product of sums
     rw [← Finset.univ_product_univ, Finset.sum_product]
     rw [← Finset.sum_mul_sum]
-    -- Both processes have probability 1 total
+    -- Each row sums to 1
     simp only [f.row_sum i₁, g.row_sum i₂, one_mul]
 
 @[ext]
@@ -161,11 +126,8 @@ end StochasticMatrix
 
 /-- The category of finite types with stochastic matrices as morphisms.
 
-Objects are finite types representing state spaces. Morphisms are stochastic
-matrices representing probabilistic transitions. This forms a category because:
-- Identity matrices preserve states deterministically
-- Composition follows the Chapman-Kolmogorov equation
-- Associativity comes from matrix multiplication -/
+Objects are finite state spaces. Morphisms are stochastic matrices.
+Composition follows the Chapman-Kolmogorov equation. -/
 structure FinStoch : Type (u+1) where
   carrier : Type u
   [fintype : Fintype carrier]
@@ -191,7 +153,7 @@ instance : Category FinStoch where
     ext i j
     simp only [CategoryStruct.comp, StochasticMatrix.comp]
     simp only [CategoryStruct.id]
-    -- Identity picks out the i-th row of f
+    -- Identity matrix selects row i
     rw [Finset.sum_eq_single i]
     · simp [StochasticMatrix.id, one_mul]
     · intro k _ hk
@@ -206,7 +168,7 @@ instance : Category FinStoch where
     ext i j
     simp only [CategoryStruct.comp, StochasticMatrix.comp]
     simp only [CategoryStruct.id]
-    -- Identity picks out the j-th column of f
+    -- Identity matrix selects column j
     rw [Finset.sum_eq_single j]
     · simp [StochasticMatrix.id, mul_one]
     · intro k _ hk
@@ -220,23 +182,20 @@ instance : Category FinStoch where
     apply StochasticMatrix.ext
     ext i k
     simp only [CategoryStruct.comp, StochasticMatrix.comp]
-    -- Matrix multiplication is associative
+    -- Associativity of matrix multiplication
     simp only [Finset.sum_mul, Finset.mul_sum, mul_assoc]
-    -- We can sum over intermediate states in any order
+    -- Interchange summation order
     rw [Finset.sum_comm]
 
-/-- The tensor unit is the singleton type with a unique stochastic matrix structure.
+/-- The tensor unit: a singleton type.
 
-This represents a trivial one-state system with no randomness. It's the identity
-for tensor products: tensoring with Unit adds no states or randomness. -/
+Represents a one-state system. Identity for tensor products. -/
 def tensorUnit : FinStoch where
   carrier := Unit
 
-/-- The tensor product of objects is the product of their carrier types.
+/-- Tensor product of objects: the product of carrier types.
 
-This models compound systems: if X has m states and Y has n states,
-then X ⊗ Y has m×n states representing all possible combinations.
-For example, two coins give four states: (H,H), (H,T), (T,H), (T,T). -/
+If X has m states and Y has n states, X ⊗ Y has m×n states. -/
 def tensorObj (X Y : FinStoch) : FinStoch where
   carrier := X.carrier × Y.carrier
 

--- a/Mathlib/CategoryTheory/MarkovCategory/FinStoch/Braided.lean
+++ b/Mathlib/CategoryTheory/MarkovCategory/FinStoch/Braided.lean
@@ -75,7 +75,6 @@ lemma id_matrix {X : FinStoch} (x x' : X.carrier) :
   simp only [CategoryStruct.id, StochasticMatrix.id]
 
 /-- The associator morphism applied to matrix elements. -/
-@[simp]
 lemma associator_toMatrix {X Y Z : FinStoch} (xyz : ((X ⊗ Y) ⊗ Z).carrier)
     (xyz' : (X ⊗ (Y ⊗ Z)).carrier) :
     (α_ X Y Z).hom.toMatrix xyz xyz' =

--- a/Mathlib/CategoryTheory/MarkovCategory/FinStoch/Braided.lean
+++ b/Mathlib/CategoryTheory/MarkovCategory/FinStoch/Braided.lean
@@ -35,7 +35,7 @@ lemma sum_delta {α : Type*} [Fintype α] [DecidableEq α] (a : α) :
     ∑ x : α, (if x = a then (1 : NNReal) else 0) = 1 := by
   rw [Finset.sum_eq_single a]
   · simp
-  · intro b _ hb; simp [hb]
+  · intro b _ hb; simp only [hb, ↓reduceIte]
   · intro h; exfalso; exact h (Finset.mem_univ _)
 
 /-- Product of delta functions. -/
@@ -44,9 +44,9 @@ lemma delta_mul_delta {α β : Type*} [DecidableEq α] [DecidableEq β] (a a' : 
     if a = a' ∧ b = b' then 1 else 0 := by
   by_cases ha : a = a'
   · by_cases hb : b = b'
-    · simp [ha, hb]
-    · simp [ha, hb]
-  · simp [ha]
+    · simp only [ha, ↓reduceIte, hb, mul_one, and_self]
+    · simp only [ha, ↓reduceIte, hb, mul_zero, and_false]
+  · simp only [ha, ↓reduceIte, mul_ite, mul_one, mul_zero, ite_self, false_and]
 
 /-- Sum over product space with unique non-zero term. -/
 lemma sum_prod_delta {α β : Type*} [Fintype α] [Fintype β] (a : α) (b : β) (f : α × β → NNReal)
@@ -65,7 +65,7 @@ lemma comp_single_path {X Y Z : FinStoch} (f : X ⟶ Y) (g : Y ⟶ Z)
   simp only [CategoryStruct.comp, StochasticMatrix.comp]
   rw [Finset.sum_eq_single y]
   · intro y' _ hy'
-    simp [hf y' hy']
+    simp only [hf y' hy', zero_mul]
   · intro h; exfalso; exact h (Finset.mem_univ _)
 
 /-- The identity matrix has 1 on the diagonal and 0 elsewhere. -/
@@ -84,7 +84,21 @@ lemma associator_toMatrix {X Y Z : FinStoch} (xyz : ((X ⊗ Y) ⊗ Z).carrier)
   cases xy with | mk x y =>
   cases xyz' with | mk x' yz' =>
   cases yz' with | mk y' z' =>
-  simp only [MonoidalCategory.associator, associator]
+  simp only [MonoidalCategoryStruct.associator, associator, associatorDet, DetMorphism.ofFunc]
+  grind only [cases Or]
+
+/-- Inverse associator applied to matrix elements. -/
+@[simp]
+lemma associator_inv_toMatrix {X Y Z : FinStoch} (xyz : (X ⊗ (Y ⊗ Z)).carrier)
+    (xyz' : ((X ⊗ Y) ⊗ Z).carrier) :
+    (α_ X Y Z).inv.toMatrix xyz xyz' =
+    if xyz.1 = xyz'.1.1 ∧ xyz.2.1 = xyz'.1.2 ∧ xyz.2.2 = xyz'.2 then 1 else 0 := by
+  cases xyz with | mk x yz =>
+  cases yz with | mk y z =>
+  cases xyz' with | mk xy' z' =>
+  cases xy' with | mk x' y' =>
+  simp only [MonoidalCategoryStruct.associator, associator, associatorInvDet, DetMorphism.ofFunc]
+  grind only [cases Or]
 
 /-- Special case: the associator maps ((x,y),z) to (x,(y,z)). -/
 lemma associator_apply {X Y Z : FinStoch} (x : X.carrier) (y : Y.carrier) (z : Z.carrier) :
@@ -97,6 +111,17 @@ lemma associator_apply_ne_fst {X Y Z : FinStoch} (x x' : X.carrier) (y : Y.carri
     (α_ X Y Z).hom.toMatrix ((x, y), z) (x', yz) = 0 := by
   cases yz with | mk y' z' =>
   simp only [associator_toMatrix, h, false_and, if_false]
+
+/-- The inverse associator maps (x,(y,z)) to ((x,y),z). -/
+lemma associator_inv_apply {X Y Z : FinStoch} (x : X.carrier) (y : Y.carrier) (z : Z.carrier) :
+    (α_ X Y Z).inv.toMatrix (x, (y, z)) ((x, y), z) = 1 := by
+  simp only [associator_inv_toMatrix, and_self, if_true]
+
+/-- Inverse associator is 0 when x-components don't match. -/
+lemma associator_inv_apply_ne_fst {X Y Z : FinStoch} (x x' : X.carrier) (y : Y.carrier)
+    (z : Z.carrier) (y' : Y.carrier) (z' : Z.carrier) (h : x ≠ x') :
+    (α_ X Y Z).inv.toMatrix (x, (y, z)) ((x', y'), z') = 0 := by
+  simp only [associator_inv_toMatrix, h, false_and, if_false]
 
 /-- Swaps components of tensor products. -/
 def swap (X Y : FinStoch) : X ⊗ Y ⟶ Y ⊗ X where
@@ -180,10 +205,10 @@ instance : BraidedCategory FinStoch where
         · -- If x = b ∧ y = a, then (a, b) = (y, x), contradiction
           exfalso
           apply h_ne
-          ext <;> simp [h₁]
-        · simp
-        · simp
-        · simp
+          ext <;> simp only [h₁]
+        · simp only [mul_zero]
+        · simp only [mul_one]
+        · simp only [mul_zero]
       · -- (y, x) is in Finset.univ
         intro h_not_mem
         exfalso
@@ -201,8 +226,7 @@ instance : BraidedCategory FinStoch where
   , by
     apply StochasticMatrix.ext
     ext ⟨y, x⟩ ⟨y', x'⟩
-    simp only [CategoryStruct.comp, StochasticMatrix.comp, CategoryStruct.id,
-               swap, StochasticMatrix.id]
+    simp only [CategoryStruct.comp, StochasticMatrix.comp, id_matrix, swap]
     -- swap ∘ swap = id
     -- First simplify the sum
     have h_sum : (∑ ab : X.carrier × Y.carrier,
@@ -224,10 +248,10 @@ instance : BraidedCategory FinStoch where
         · -- If y = b ∧ x = a, then (a, b) = (x, y), contradiction
           exfalso
           apply h_ne
-          ext <;> simp [h₁]
-        · simp
-        · simp
-        · simp
+          ext <;> simp only [h₁]
+        · simp only [mul_zero]
+        · simp only [mul_one]
+        · simp only [mul_zero]
       · -- (x, y) is in Finset.univ
         intro h_not_mem
         exfalso
@@ -261,8 +285,8 @@ instance : BraidedCategory FinStoch where
         -- (if y' = y' ∧ z = z' then 1 else 0)
         simp only [if_true]
         by_cases hz : z = z'
-        · simp [hz, mul_one]
-        · simp [hz, mul_zero]
+        · simp only [hz, ↓reduceIte, mul_one, and_self]
+        · simp only [hz, ↓reduceIte, mul_one, and_false, mul_zero]
       · -- For other points: show the sum term is 0
         intro ⟨y₁, z₁⟩ _ h_ne
         -- We have f(x,y₁) * (if z = z₁ then 1 else 0) * (if y₁ = y' ∧ z₁ = z' then 1 else 0)
@@ -272,8 +296,8 @@ instance : BraidedCategory FinStoch where
           · obtain ⟨hy₁, _⟩ := hyz
             subst hy₁
             exfalso; exact h_ne rfl
-          · simp [hyz]
-        · simp [hz₁]
+          · simp only [↓reduceIte, mul_one, hyz, mul_zero]
+        · simp only [hz₁, ↓reduceIte, mul_zero, mul_ite, mul_one, ite_self]
       · intro h; exfalso; exact h (Finset.mem_univ _)
 
     -- Compute the RHS sum
@@ -285,8 +309,8 @@ instance : BraidedCategory FinStoch where
         -- ((if z = z' then 1 else 0) * f(x,y'))
         simp only [and_self, if_true]
         by_cases hz : z = z'
-        · simp [hz, one_mul]
-        · simp [hz, zero_mul]
+        · simp only [hz, ↓reduceIte, one_mul]
+        · simp only [hz, ↓reduceIte, zero_mul, mul_zero]
       · -- For other points: show the sum term is 0
         intro ⟨z₁, x₁⟩ _ h_ne
         -- We have (if x = x₁ ∧ z = z₁ then 1 else 0) * ((if z₁ = z' then 1 else 0) * f(x₁,y'))
@@ -294,7 +318,7 @@ instance : BraidedCategory FinStoch where
         · obtain ⟨hx₁, hz₁⟩ := hxz
           subst hx₁ hz₁
           exfalso; exact h_ne rfl
-        · simp [hxz]
+        · simp only [hxz, ↓reduceIte, ite_mul, one_mul, zero_mul, mul_ite, mul_zero, ite_self]
       · intro h; exfalso; exact h (Finset.mem_univ _)
   braiding_naturality_right := by
     intros X Y Z f
@@ -314,8 +338,8 @@ instance : BraidedCategory FinStoch where
       · -- We get (if x = x then 1 else 0) * f(y,z') * (if x = x' ∧ z' = z' then 1 else 0)
         simp only [if_true, one_mul]
         by_cases hx : x = x'
-        · simp [hx]
-        · simp [hx]
+        · simp only [hx, ↓reduceIte, and_self, mul_one]
+        · simp only [hx, ↓reduceIte, and_true, mul_zero]
       · -- For other points: show the sum term is 0
         intro ⟨x₁, z₁⟩ _ h_ne
         -- We have (if x = x₁ then 1 else 0) * f(y,z₁) * (if x₁ = x' ∧ z₁ = z' then 1 else 0)
@@ -325,8 +349,8 @@ instance : BraidedCategory FinStoch where
           · obtain ⟨_, hz₁⟩ := hxz
             subst hz₁
             exfalso; exact h_ne rfl
-          · simp [hxz]
-        · simp [hx₁]
+          · simp only [↓reduceIte, one_mul, hxz, mul_zero]
+        · simp only [hx₁, ↓reduceIte, zero_mul, mul_ite, mul_one, mul_zero, ite_self]
       · intro h; exfalso; exact h (Finset.mem_univ _)
 
     -- Compute the RHS sum
@@ -338,8 +362,8 @@ instance : BraidedCategory FinStoch where
         -- (f(y,z') * (if x = x' then 1 else 0))
         simp only [and_self, if_true]
         by_cases hx : x = x'
-        · simp [hx, mul_one]
-        · simp [hx, mul_zero]
+        · simp only [hx, ↓reduceIte, mul_one, one_mul]
+        · simp only [hx, ↓reduceIte, mul_zero]
       · -- For other points: show the sum term is 0
         intro ⟨y₁, x₁⟩ _ h_ne
         -- We have (if x = x₁ ∧ y = y₁ then 1 else 0) * (f(y₁,z') * (if x₁ = x' then 1 else 0))
@@ -347,7 +371,7 @@ instance : BraidedCategory FinStoch where
         · obtain ⟨hx₁, hy₁⟩ := hxy
           subst hx₁ hy₁
           exfalso; exact h_ne rfl
-        · simp [hxy]
+        · simp only [hxy, ↓reduceIte, mul_ite, mul_one, mul_zero, zero_mul, ite_self]
       · intro h; exfalso; exact h (Finset.mem_univ _)
   hexagon_forward := by
     intros X Y Z
@@ -378,7 +402,8 @@ instance : BraidedCategory FinStoch where
           have h_assoc : (α_ X Y Z).hom.toMatrix ((x, y), z) (x, (y, z)) = 1 := by
             -- The associator in FinStoch is defined as: if x = x' ∧ y = y' ∧ z = z' then 1 else 0
             -- At ((x,y),z) -> (x,(y,z)), all components match, so we get 1
-            simp only [MonoidalCategory.associator, associator]
+            simp only [MonoidalCategoryStruct.associator, associator, DetMorphism.toMatrix_apply,
+              ite_eq_left_iff, zero_ne_one, imp_false, Decidable.not_not]
             rfl
           simp only [h_assoc, one_mul]
           rw [eq_comm]
@@ -408,7 +433,8 @@ instance : BraidedCategory FinStoch where
           · simp only [if_true, one_mul]
             -- The associator at ((y,z), x) -> (y,(z,x)) gives 1
             have h_assoc2 : (α_ Y Z X).hom.toMatrix ((y, z), x) (y, (z, x)) = 1 := by
-              simp only [MonoidalCategory.associator, associator]
+              simp only [MonoidalCategoryStruct.associator, associator, DetMorphism.toMatrix_apply,
+                ite_eq_left_iff, zero_ne_one, imp_false, Decidable.not_not]
               rfl
             simp only [h_assoc2]
           · intro b _ hb
@@ -418,14 +444,9 @@ instance : BraidedCategory FinStoch where
           intro x₁ _ hx₁
           -- The associator gives 0 for x₁ ≠ (x, (y, z))
           have h_zero : (α_ X Y Z).hom.toMatrix ((x, y), z) x₁ = 0 := by
-            simp only [MonoidalCategory.associator, associator]
-            -- Since x₁ ≠ (x, (y, z)), the condition fails
-            split_ifs with h_cond
-            · -- If the condition holds, contradiction
-              obtain ⟨h1, h2, h3⟩ := h_cond
-              subst h1 h2 h3
-              exact absurd rfl hx₁
-            · rfl
+            simp only [MonoidalCategoryStruct.associator, associator, DetMorphism.toMatrix_apply,
+              ite_eq_right_iff, one_ne_zero, imp_false]
+            tauto
           simp only [h_zero, zero_mul]
         · intro h_mem; exfalso; exact h_mem (Finset.mem_univ _)
       · -- Case: variables don't match, so we expect 0
@@ -437,17 +458,19 @@ instance : BraidedCategory FinStoch where
         -- Either the associator gives 0, or the inner sum is 0
         by_cases h_assoc : (α_ X Y Z).hom.toMatrix ((x, y), z) x₁ = 0
         · -- Associator is 0, so product is 0
-          simp [h_assoc]
+          simp only [h_assoc, associator_matrix, mul_ite, mul_one, mul_zero, zero_mul]
         · -- Associator is non-zero, so x₁ = (x, (y, z))
           push_neg at h_assoc
           have hx₁ : x₁ = (x, (y, z)) := by
-            simp only [MonoidalCategory.associator, associator] at h_assoc ⊢
-            grind only [Finset.mem_univ, cases Or]
+            simp_all only [not_and, Finset.mem_univ, MonoidalCategoryStruct.associator, associator,
+              DetMorphism.toMatrix_apply, ne_eq, ite_eq_right_iff, one_ne_zero, imp_false,
+              Decidable.not_not]
+            tauto
           subst hx₁
           simp only [MonoidalCategory.associator, associator]
           -- Now show the inner sum is 0
           rw [Finset.sum_eq_zero]
-          · simp only [and_self, ↓reduceIte, mul_zero]
+          · simp only [mul_zero]
           · intro x_inner _
             -- Need to show swap * final_assoc = 0
             cases x_inner with | mk y_inner x_inner =>
@@ -457,12 +480,10 @@ instance : BraidedCategory FinStoch where
             · -- Swap gives 1, check final associator
               obtain ⟨hx_eq, hy_eq⟩ := h_swap
               subst hx_eq hy_eq
-              simp only [and_self, ↓reduceIte, mul_ite, mul_one, mul_zero, ite_eq_right_iff,
-                         one_ne_zero, imp_false, not_and]
-              intro a_2 a_3
-              subst a_3 a_2
-              simp_all only [Finset.mem_univ, associator_matrix, and_self, ↓reduceIte, ne_eq,
-                             one_ne_zero, not_false_eq_true, and_true]
+              simp_all only [not_and, Finset.mem_univ, associator_matrix, and_self, ↓reduceIte,
+                ne_eq, one_ne_zero, not_false_eq_true, mul_ite, mul_one,
+                mul_zero, ite_eq_right_iff, imp_false, associatorDet, DetMorphism.ofFunc]
+              grind only
             · -- Swap gives 0
               simp only [h_swap, if_false, zero_mul]
 
@@ -476,7 +497,8 @@ instance : BraidedCategory FinStoch where
 
       -- Sum over final state before last operation
       -- The RHS path: swap ⊗ id, then associator, then id ⊗ swap
-      simp only [StochasticMatrix.id, CategoryStruct.id]
+      simp only [id_matrix, mul_ite, mul_one, mul_zero, associator_matrix, ite_mul, one_mul,
+        zero_mul]
       -- We need to show the sum equals the indicator function
       by_cases h_match : x = x' ∧ y = y' ∧ z = z'
       · -- Case: all match, result should be 1
@@ -486,8 +508,7 @@ instance : BraidedCategory FinStoch where
         -- The sum should collapse to a single non-zero term
         convert Finset.sum_eq_single ((y, x), z) _ _ using 1
         · -- At ((y,x),z): show it produces 1
-          simp only [and_self, ↓reduceIte, mul_one, associator_toMatrix, ite_mul, one_mul, zero_mul,
-                     mul_ite, mul_zero]
+          simp only [and_self, ↓reduceIte, one_mul]
           -- The sum equals 1 as only (y, (x, z)) contributes
           -- Simplify to show the sum has exactly one non-zero term
           have h_sum_eq : (∑ x_1 : Y.carrier × (X.carrier × Z.carrier),
@@ -500,16 +521,17 @@ instance : BraidedCategory FinStoch where
             · simp
             · intro ⟨y₁, x₁, z₁⟩ _ hne
               by_cases hy : y₁ = y
-              · simp [hy]
+              · simp only [hy, ↓reduceIte, true_and, ite_eq_right_iff, one_ne_zero, imp_false,
+                  not_and, and_imp]
                 by_cases hxz : x = x₁ ∧ z = z₁
                 · obtain ⟨hx, hz⟩ := hxz
                   subst hy hx hz
                   exfalso; exact hne rfl
                 · push_neg at hxz
                   by_cases hx : x = x₁
-                  · simp [hx, hxz hx]
-                  · simp [hx]
-              · simp [hy]
+                  · simp only [hx, hxz hx, forall_const, IsEmpty.forall_iff]
+                  · simp only [hx, IsEmpty.forall_iff]
+              · simp only [hy, ↓reduceIte]
             · intro h; exfalso; exact h (Finset.mem_univ _)
           grind only [cases eager Prod, cases Or]
         · -- Other x₁ values give 0
@@ -523,8 +545,7 @@ instance : BraidedCategory FinStoch where
         -- We analyze based on whether x₁ = ((y,x),z)
         by_cases hx₁ : x₁ = ((y, x), z)
         · subst hx₁
-          simp only [and_self, if_true, one_mul, associator_toMatrix, ite_mul, one_mul, zero_mul,
-                     mul_ite, mul_zero]
+          simp only [and_self, if_true, one_mul, one_mul]
           -- Sum over associator output
           rw [Finset.sum_eq_zero]
           intro c _
@@ -537,17 +558,172 @@ instance : BraidedCategory FinStoch where
           · rfl
           · rfl
         · -- x₁ ≠ ((y,x),z): first swap gives 0
-          simp_all only [not_and, Finset.mem_univ, mul_ite, mul_one, mul_zero, associator_toMatrix,
-                         ite_mul, one_mul, zero_mul, ite_eq_right_iff, mul_eq_zero,
-                         Finset.sum_eq_zero_iff, and_imp, forall_const]
-          sorry
-
+          simp_all only [not_and, Finset.mem_univ, ite_eq_right_iff, mul_eq_zero,
+            Finset.sum_eq_zero_iff, and_imp, forall_const]
+          -- Grind out the rest of the proof
+          intro a; subst a
+          push_neg at hx₁
+          split
+          · split_ifs
+            · simp_all only [ne_eq, one_ne_zero, false_or]
+              rename_i h
+              intro i a a_1 a_2 a_3
+              subst a a_1 a_2
+              simp_all only [forall_const]
+              obtain ⟨left, right⟩ := h
+              subst left right
+              split
+              rename_i x x_2 y heq_1
+              simp_all only [ite_eq_right_iff, one_ne_zero, imp_false, not_and, not_false_eq_true,
+                implies_true]
+            · simp_all only [ne_eq, not_and, true_or]
 
   hexagon_reverse := by
     intros X Y Z
-    -- The reverse hexagon identity
-    -- Similar proof strategy as hexagon_forward
-    sorry
+    -- Show: α^{-1} ≫ β_{X⊗Y,Z} ≫ α^{-1} = (X ◁ β_{Y,Z}) ≫ α^{-1} ≫ (β_{X,Z} ▷ Y)
+    -- Both map (x,(y,z)) to ((z,x),y)
+    apply StochasticMatrix.ext
+    ext ⟨x, ⟨y, z⟩⟩ ⟨⟨z', x'⟩, y'⟩
+    simp only [CategoryStruct.comp, StochasticMatrix.comp,
+               MonoidalCategoryStruct.whiskerRight, StochasticMatrix.tensor,
+               swap, MonoidalCategoryStruct.whiskerLeft]
+
+    -- Both sides equal 1 iff x = x' ∧ y = y' ∧ z = z'
+    trans (if x = x' ∧ y = y' ∧ z = z' then (1:NNReal) else 0).toReal
+    · -- LHS: (x,(y,z)) → ((x,y),z) → (z,(x,y)) → ((z,x),y)
+      congr 1
+      by_cases h : x = x' ∧ y = y' ∧ z = z'
+      · -- Case: all match, expect 1
+        obtain ⟨hx, hy, hz⟩ := h
+        subst hx hy hz
+        simp only [and_true, if_true]
+        -- Sum collapses to single term
+        convert Finset.sum_eq_single ((x, y), z) _ _ using 1
+        · -- At ((x,y),z): α_inv gives 1
+          have h1 : (α_ X Y Z).inv.toMatrix (x, (y, z)) ((x, y), z) = 1 :=
+            associator_inv_apply x y z
+          symm
+          simp only [associator_inv_toMatrix, mul_ite, mul_one, mul_zero, and_self, ↓reduceIte,
+            one_mul]
+          -- Now compute swap and final α_inv
+          convert Finset.sum_eq_single (z, (x, y)) _ _ using 1
+          · -- swap gives 1, then α_inv gives 1
+            simp only [and_self, ↓reduceIte]
+          · intro b _ hb
+            -- swap is deterministic, only maps to (z,(x,y))
+            cases b with | mk b1 b2 =>
+            simp only
+            by_cases h_swap : (x, y) = b2 ∧ z = b1
+            · obtain ⟨h_xy, h_z⟩ := h_swap
+              subst h_xy h_z
+              exfalso; exact hb rfl
+            · simp only [ite_eq_right_iff, one_ne_zero, imp_false, not_and, and_imp]
+              tauto
+          · intro habs; exfalso; exact habs (Finset.mem_univ _)
+        · -- Other terms are 0
+          intro b _ hb
+          -- α_inv is deterministic, only maps to ((x,y),z)
+          have h_inv : (α_ X Y Z).inv.toMatrix (x, (y, z)) b =
+            if b = ((x, y), z) then 1 else 0 := by
+            cases b with | mk b1 b2 =>
+            cases b1 with | mk b11 b12 =>
+            simp only [associator_inv_toMatrix]
+            by_cases h_eq : x = b11 ∧ y = b12 ∧ z = b2
+            · obtain ⟨h1, h2, h3⟩ := h_eq
+              subst h1 h2 h3
+              simp only [and_self, if_true]
+            · simp only [h_eq, if_false]
+              split_ifs with h_contra
+              · exfalso
+                cases h_contra
+                exact h_eq ⟨rfl, rfl, rfl⟩
+              · rfl
+          simp only [h_inv, hb, if_false, zero_mul]
+        · intro habs; exfalso; exact habs (Finset.mem_univ _)
+      · -- Case: not all match, expect 0
+        simp only [h, if_false]
+        rw [Finset.sum_eq_zero]
+        intro b _
+        -- Either α_inv gives 0, or rest gives 0
+        by_cases h_inv : (α_ X Y Z).inv.toMatrix (x, (y, z)) b = 0
+        · simp only [h_inv, zero_mul]
+        · -- α_inv is non-zero, so b = ((x,y),z)
+          push_neg at h_inv
+          have hb : b = ((x, y), z) := by
+            cases b with | mk b1 b2 =>
+            cases b1 with | mk b11 b12 =>
+            simp only [associator_inv_toMatrix, ne_eq, ite_eq_right_iff,
+                       one_ne_zero, imp_false, Decidable.not_not] at h_inv
+            obtain ⟨h1, h2, h3⟩ := h_inv
+            simp only [h1, h2, h3]
+          subst hb
+          -- Now show inner sum is 0
+          rw [Finset.sum_eq_zero]
+          · rw [mul_zero]
+          · simp_all only [not_and, Finset.mem_univ, associator_inv_toMatrix, and_self, ↓reduceIte,
+              ne_eq, one_ne_zero, not_false_eq_true, mul_ite, mul_one, mul_zero, ite_eq_right_iff,
+              and_imp, forall_const]
+            intro x_1 a a_1 a_2; subst a_1 a a_2
+            split
+            rename_i x_1 y' x'
+            simp_all only [ite_eq_right_iff, one_ne_zero, imp_false, not_and]
+            intro a; subst a
+            simp_all only [forall_const, not_false_eq_true]
+
+    -- RHS: (x,(y,z)) → (x,(z,y)) → ((x,z),y) → ((z,x),y)
+    · simp_all only [id_matrix, ite_mul, one_mul, zero_mul, associator_inv_toMatrix, mul_ite,
+        mul_one, mul_zero, NNReal.coe_sum]
+      by_cases h_match : x = x' ∧ y = y' ∧ z = z'
+      · -- All match, expect 1
+        obtain ⟨hx, hy, hz⟩ := h_match
+        subst hx hy hz
+        simp only [and_self, ↓reduceIte, NNReal.coe_one]
+        -- First: X ◁ swap Y Z
+        rw [Fintype.sum_eq_single ⟨x ,⟨z, y⟩⟩]
+        · -- At (x,(z,y)): whisker gives 1 when x matches
+          simp only [↓reduceIte, and_self, and_true, one_mul, NNReal.coe_sum]
+          rw [Fintype.sum_eq_single ⟨⟨x, z⟩, y⟩]
+          · simp only [↓reduceIte, and_self, NNReal.coe_one]
+          · simp only [ne_eq, NNReal.coe_eq_zero, ite_eq_right_iff, and_imp]
+            intro x_1 a a_1 a_2 a_3; subst a_3 a_2 a_1
+            simp_all only [Prod.mk.eta, not_true_eq_false]
+        · -- Other terms in first sum are 0
+          simp_all only [ne_eq, NNReal.coe_eq_zero, ite_eq_right_iff, mul_eq_zero,
+            Finset.sum_eq_zero_iff, Finset.mem_univ, and_imp, forall_const]
+          -- X ◁ swap is only non-zero at (x,(z,y))
+          intro xzy h_neg h1_x
+          subst h1_x
+          right
+          intro xzy' hy hxz1 hxz2 hxzy22
+          subst hxzy22
+          simp_all only
+          split
+          · rename_i x x_1 y heq
+            simp_all only [true_and, ite_eq_right_iff, one_ne_zero, imp_false]
+            subst hxz2 hxz1
+            intro a; subst a
+            simp_all only [Prod.mk.eta, not_true_eq_false]
+      · -- Not all match, expect 0
+        simp only [h_match, ↓reduceIte, NNReal.coe_zero]
+        rw [Fintype.sum_eq_single ⟨x, ⟨z, y⟩⟩]
+        · simp_all only [not_and, ↓reduceIte, and_self, one_mul, NNReal.coe_sum]
+          rw [Fintype.sum_eq_single ⟨⟨x, z⟩, y⟩] <;> aesop
+        · simp_all only [not_and, ne_eq, NNReal.coe_eq_zero, ite_eq_right_iff, mul_eq_zero,
+            Finset.sum_eq_zero_iff, Finset.mem_univ, and_imp, forall_const]
+          intro xzy hxzy_neg hx
+          subst hx
+          left
+          cases xzy with | mk x_val zy_val =>
+          cases zy_val with | mk z_val y_val =>
+          simp only
+          split_ifs with h_cond
+          · -- If condition holds: y = y_val ∧ z = z_val
+            exfalso
+            obtain ⟨hy_eq, hz_eq⟩ := h_cond
+            subst hy_eq hz_eq
+            exact hxzy_neg rfl
+          · -- Condition doesn't hold, so result is 0
+            rfl
 
 /-- FinStoch is symmetric. -/
 instance : SymmetricCategory FinStoch where
@@ -576,7 +752,7 @@ instance : SymmetricCategory FinStoch where
         · obtain ⟨hx, hy⟩ := h
           subst hx hy
           exfalso; exact h_ne rfl
-        · simp [h]
+        · simp only [h, ↓reduceIte, mul_ite, mul_one, mul_zero, ite_self]
       · -- (y, x) is in univ
         intro h; exfalso; exact h (Finset.mem_univ _)
 

--- a/Mathlib/CategoryTheory/MarkovCategory/FinStoch/Braided.lean
+++ b/Mathlib/CategoryTheory/MarkovCategory/FinStoch/Braided.lean
@@ -1,0 +1,595 @@
+/-
+Copyright (c) 2025 Jacob Reinhold. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Jacob Reinhold
+-/
+import Mathlib.CategoryTheory.MarkovCategory.FinStoch.Monoidal
+import Mathlib.CategoryTheory.Monoidal.Braided.Basic
+
+/-!
+# Braided Structure on FinStoch
+
+FinStoch is symmetric monoidal with swap as the braiding.
+
+## Main definitions
+
+* `swap` - Swaps components of tensor products
+* `BraidedCategory FinStoch` - Braiding structure
+* `SymmetricCategory FinStoch` - Symmetric structure
+
+## Tags
+
+Markov category, braided category, symmetric category
+-/
+
+namespace CategoryTheory.MarkovCategory
+
+open FinStoch MonoidalCategory
+
+universe u
+
+/-! ### Helper lemmas for stochastic matrices -/
+
+/-- Sum of delta function equals 1 at the unique non-zero point. -/
+lemma sum_delta {α : Type*} [Fintype α] [DecidableEq α] (a : α) :
+    ∑ x : α, (if x = a then (1 : NNReal) else 0) = 1 := by
+  rw [Finset.sum_eq_single a]
+  · simp
+  · intro b _ hb; simp [hb]
+  · intro h; exfalso; exact h (Finset.mem_univ _)
+
+/-- Product of delta functions. -/
+lemma delta_mul_delta {α β : Type*} [DecidableEq α] [DecidableEq β] (a a' : α) (b b' : β) :
+    (if a = a' then (1 : NNReal) else 0) * (if b = b' then 1 else 0) =
+    if a = a' ∧ b = b' then 1 else 0 := by
+  by_cases ha : a = a'
+  · by_cases hb : b = b'
+    · simp [ha, hb]
+    · simp [ha, hb]
+  · simp [ha]
+
+/-- Sum over product space with unique non-zero term. -/
+lemma sum_prod_delta {α β : Type*} [Fintype α] [Fintype β] (a : α) (b : β) (f : α × β → NNReal)
+    (hf : ∀ x : α × β, x ≠ (a, b) → f x = 0) :
+    ∑ x : α × β, f x = f (a, b) := by
+  rw [Finset.sum_eq_single (a, b)]
+  · intro b _ hb
+    exact hf b hb
+  · intro h; exfalso; exact h (Finset.mem_univ _)
+
+/-- Composition of morphisms with single non-zero path. -/
+lemma comp_single_path {X Y Z : FinStoch} (f : X ⟶ Y) (g : Y ⟶ Z)
+    (x : X.carrier) (y : Y.carrier) (z : Z.carrier)
+    (hf : ∀ y', y' ≠ y → f.toMatrix x y' = 0) :
+    (f ≫ g).toMatrix x z = f.toMatrix x y * g.toMatrix y z := by
+  simp only [CategoryStruct.comp, StochasticMatrix.comp]
+  rw [Finset.sum_eq_single y]
+  · intro y' _ hy'
+    simp [hf y' hy']
+  · intro h; exfalso; exact h (Finset.mem_univ _)
+
+/-- The identity matrix has 1 on the diagonal and 0 elsewhere. -/
+@[simp]
+lemma id_matrix {X : FinStoch} (x x' : X.carrier) :
+    (𝟙 X : X ⟶ X).toMatrix x x' = if x = x' then 1 else 0 := by
+  simp only [CategoryStruct.id, StochasticMatrix.id]
+
+/-- The associator morphism applied to matrix elements. -/
+@[simp]
+lemma associator_toMatrix {X Y Z : FinStoch} (xyz : ((X ⊗ Y) ⊗ Z).carrier)
+    (xyz' : (X ⊗ (Y ⊗ Z)).carrier) :
+    (α_ X Y Z).hom.toMatrix xyz xyz' =
+    if xyz.1.1 = xyz'.1 ∧ xyz.1.2 = xyz'.2.1 ∧ xyz.2 = xyz'.2.2 then 1 else 0 := by
+  cases xyz with | mk xy z =>
+  cases xy with | mk x y =>
+  cases xyz' with | mk x' yz' =>
+  cases yz' with | mk y' z' =>
+  simp only [MonoidalCategory.associator, associator]
+
+/-- Special case: the associator maps ((x,y),z) to (x,(y,z)). -/
+lemma associator_apply {X Y Z : FinStoch} (x : X.carrier) (y : Y.carrier) (z : Z.carrier) :
+    (α_ X Y Z).hom.toMatrix ((x, y), z) (x, (y, z)) = 1 := by
+  simp only [associator_toMatrix, and_self, if_true]
+
+/-- Special case: the associator is 0 when the x-component doesn't match. -/
+lemma associator_apply_ne_fst {X Y Z : FinStoch} (x x' : X.carrier) (y : Y.carrier)
+    (z : Z.carrier) (yz : (Y ⊗ Z).carrier) (h : x ≠ x') :
+    (α_ X Y Z).hom.toMatrix ((x, y), z) (x', yz) = 0 := by
+  cases yz with | mk y' z' =>
+  simp only [associator_toMatrix, h, false_and, if_false]
+
+/-- Swaps components of tensor products. -/
+def swap (X Y : FinStoch) : X ⊗ Y ⟶ Y ⊗ X where
+  toMatrix := fun (x, y) (y', x') => if x = x' ∧ y = y' then 1 else 0
+  row_sum := fun (x, y) => by
+    -- We need to show: ∑_{(y',x')} swap((x,y), (y',x')) = 1
+    -- The matrix has a 1 at position (y,x) and 0 elsewhere
+    convert Finset.sum_eq_single (y, x) _ _ using 1
+    · -- At (y, x): we get 1
+      simp only [and_self, if_true]
+    · -- For any other point: we get 0
+      intro b _ hb
+      obtain ⟨y', x'⟩ := b
+      simp only
+      -- If x = x' and y = y', then b = (y,x), contradiction
+      by_cases hx : x = x'
+      · by_cases hy : y = y'
+        · -- Both match, so b = (y,x)
+          subst hx hy
+          exfalso
+          exact hb rfl
+        · -- y ≠ y', so condition fails
+          simp only [hx, hy, and_false, ↓reduceIte]
+      · -- x ≠ x', so condition fails
+        simp only [hx, false_and, ↓reduceIte]
+    · -- (y,x) is in the set
+      intro h
+      exfalso
+      exact h (Finset.mem_univ _)
+
+/-- The swap morphism applied to matrix elements. -/
+@[simp]
+lemma swap_toMatrix {X Y : FinStoch} (xy : (X ⊗ Y).carrier) (yx : (Y ⊗ X).carrier) :
+    (swap X Y).toMatrix xy yx = if xy.1 = yx.2 ∧ xy.2 = yx.1 then 1 else 0 := by
+  cases xy with | mk x y =>
+  cases yx with | mk y' x' =>
+  simp only [swap]
+
+/-- Special case: swap preserves components when they match. -/
+lemma swap_apply {X Y : FinStoch} (x : X.carrier) (y : Y.carrier) :
+    (swap X Y).toMatrix (x, y) (y, x) = 1 := by
+  simp only [swap_toMatrix, and_self, if_true]
+
+/-- Special case: swap is 0 when x-components don't match. -/
+lemma swap_apply_ne_fst {X Y : FinStoch} (x : X.carrier) (y : Y.carrier)
+    (x' : X.carrier) (y' : Y.carrier) (h : x ≠ x') :
+    (swap X Y).toMatrix (x, y) (y', x') = 0 := by
+  simp only [swap_toMatrix, h, false_and, if_false]
+
+/-- Special case: swap is 0 when y-components don't match. -/
+lemma swap_apply_ne_snd {X Y : FinStoch} (x : X.carrier) (y : Y.carrier)
+    (x' : X.carrier) (y' : Y.carrier) (h : y ≠ y') :
+    (swap X Y).toMatrix (x, y) (y', x') = 0 := by
+  simp only [swap_toMatrix, h, and_false, if_false]
+
+/-- FinStoch is braided. -/
+instance : BraidedCategory FinStoch where
+  braiding X Y := ⟨swap X Y, swap Y X, by
+    apply StochasticMatrix.ext
+    ext ⟨x, y⟩ ⟨x', y'⟩
+    simp only [CategoryStruct.comp, StochasticMatrix.comp, CategoryStruct.id,
+               swap, StochasticMatrix.id]
+    -- swap ∘ swap = id because swap is involutive
+    -- First simplify the sum to make pattern matching explicit
+    have h_sum : (∑ ab : Y.carrier × X.carrier,
+          (if x = ab.2 ∧ y = ab.1 then (1 : NNReal) else 0) *
+          (if ab.1 = y' ∧ ab.2 = x' then 1 else 0)) =
+        if x = x' ∧ y = y' then 1 else 0 := by
+      -- The sum has exactly one non-zero term when ab = (y, x)
+      rw [Finset.sum_eq_single (y, x)]
+      · -- At (y, x): the first condition is true, second depends on y=y' and x=x'
+        simp only [and_self]
+        simp only [if_true, one_mul]
+        -- Now we have: if y = y' ∧ x = x' then 1 else 0
+        -- We need: if x = x' ∧ y = y' then 1 else 0
+        simp only [and_comm]
+      · -- For any other (a, b) ≠ (y, x): show product is 0
+        intro ⟨a, b⟩ _ h_ne
+        simp only []
+        split_ifs with h₁ h₂
+        · -- If x = b ∧ y = a, then (a, b) = (y, x), contradiction
+          exfalso
+          apply h_ne
+          ext <;> simp [h₁]
+        · simp
+        · simp
+        · simp
+      · -- (y, x) is in Finset.univ
+        intro h_not_mem
+        exfalso
+        exact h_not_mem (Finset.mem_univ _)
+    -- Now convert and apply our result
+    convert congr_arg NNReal.toReal h_sum
+    constructor
+    · intro h
+      cases h
+      constructor <;> rfl
+    · intro ⟨h1, h2⟩
+      cases h1
+      cases h2
+      rfl
+  , by
+    apply StochasticMatrix.ext
+    ext ⟨y, x⟩ ⟨y', x'⟩
+    simp only [CategoryStruct.comp, StochasticMatrix.comp, CategoryStruct.id,
+               swap, StochasticMatrix.id]
+    -- swap ∘ swap = id
+    -- First simplify the sum
+    have h_sum : (∑ ab : X.carrier × Y.carrier,
+          (if y = ab.2 ∧ x = ab.1 then (1 : NNReal) else 0) *
+          (if ab.1 = x' ∧ ab.2 = y' then 1 else 0)) =
+        if y = y' ∧ x = x' then 1 else 0 := by
+      -- The sum has exactly one non-zero term when ab = (x, y)
+      rw [Finset.sum_eq_single (x, y)]
+      · -- At (x, y): the first condition is true, second depends on x=x' and y=y'
+        simp only [and_self]
+        simp only [if_true, one_mul]
+        -- Now we have: if x = x' ∧ y = y' then 1 else 0
+        -- We need: if y = y' ∧ x = x' then 1 else 0
+        simp only [and_comm]
+      · -- For any other (a, b) ≠ (x, y): show product is 0
+        intro ⟨a, b⟩ _ h_ne
+        simp only []
+        split_ifs with h₁ h₂
+        · -- If y = b ∧ x = a, then (a, b) = (x, y), contradiction
+          exfalso
+          apply h_ne
+          ext <;> simp [h₁]
+        · simp
+        · simp
+        · simp
+      · -- (x, y) is in Finset.univ
+        intro h_not_mem
+        exfalso
+        exact h_not_mem (Finset.mem_univ _)
+    -- Now convert and apply our result
+    convert congr_arg NNReal.toReal h_sum
+    constructor
+    · intro h
+      cases h
+      constructor <;> rfl
+    · intro ⟨h1, h2⟩
+      cases h1
+      cases h2
+      rfl⟩
+  braiding_naturality_left := by
+    intros X Y f Z
+    apply StochasticMatrix.ext
+    ext ⟨x, z⟩ ⟨z', y'⟩
+    simp only [CategoryStruct.comp, StochasticMatrix.comp, MonoidalCategoryStruct.whiskerRight,
+               StochasticMatrix.tensor, swap, CategoryStruct.id, StochasticMatrix.id,
+               MonoidalCategoryStruct.whiskerLeft]
+    -- (f ▷ Z) ≫ β_{Y,Z} = β_{X,Z} ≫ (Z ◁ f)
+    -- Both sides compute to: if z = z' then f(x,y') else 0
+
+    -- Compute both sides to the same intermediate value
+    trans (if z = z' then f.toMatrix x y' else 0 : NNReal).toReal
+    · congr 1
+      -- LHS = ∑_{(y₁,z₁)} (f ⊗ id_Z)_{(x,z),(y₁,z₁)} * swap_{y₁,z₁,z',y'}
+      convert Finset.sum_eq_single (y', z) _ _ using 1
+      · -- At (y', z): we get f(x,y') * (if z = z then 1 else 0) *
+        -- (if y' = y' ∧ z = z' then 1 else 0)
+        simp only [if_true]
+        by_cases hz : z = z'
+        · simp [hz, mul_one]
+        · simp [hz, mul_zero]
+      · -- For other points: show the sum term is 0
+        intro ⟨y₁, z₁⟩ _ h_ne
+        -- We have f(x,y₁) * (if z = z₁ then 1 else 0) * (if y₁ = y' ∧ z₁ = z' then 1 else 0)
+        by_cases hz₁ : z = z₁
+        · subst hz₁
+          by_cases hyz : y₁ = y' ∧ z = z'
+          · obtain ⟨hy₁, _⟩ := hyz
+            subst hy₁
+            exfalso; exact h_ne rfl
+          · simp [hyz]
+        · simp [hz₁]
+      · intro h; exfalso; exact h (Finset.mem_univ _)
+
+    -- Compute the RHS sum
+    · congr 1
+      symm
+      -- RHS = ∑_{(z₁,x₁)} swap_{x,z,z₁,x₁} * (id_Z ⊗ f)_{(z₁,x₁),(z',y')}
+      convert Finset.sum_eq_single (z, x) _ _ using 1
+      · -- At (z, x): we get (if x = x ∧ z = z then 1 else 0) *
+        -- ((if z = z' then 1 else 0) * f(x,y'))
+        simp only [and_self, if_true]
+        by_cases hz : z = z'
+        · simp [hz, one_mul]
+        · simp [hz, zero_mul]
+      · -- For other points: show the sum term is 0
+        intro ⟨z₁, x₁⟩ _ h_ne
+        -- We have (if x = x₁ ∧ z = z₁ then 1 else 0) * ((if z₁ = z' then 1 else 0) * f(x₁,y'))
+        by_cases hxz : x = x₁ ∧ z = z₁
+        · obtain ⟨hx₁, hz₁⟩ := hxz
+          subst hx₁ hz₁
+          exfalso; exact h_ne rfl
+        · simp [hxz]
+      · intro h; exfalso; exact h (Finset.mem_univ _)
+  braiding_naturality_right := by
+    intros X Y Z f
+    apply StochasticMatrix.ext
+    ext ⟨x, y⟩ ⟨z', x'⟩
+    simp only [CategoryStruct.comp, StochasticMatrix.comp, MonoidalCategoryStruct.whiskerLeft,
+               StochasticMatrix.tensor, swap, CategoryStruct.id, StochasticMatrix.id,
+               MonoidalCategoryStruct.whiskerRight]
+    -- (X ◁ f) ≫ β_{X,Z} = β_{X,Y} ≫ (f ▷ X)
+    -- Both sides compute to: if x = x' then f(y,z') else 0
+
+    -- Compute the LHS sum
+    trans (if x = x' then f.toMatrix y z' else 0 : NNReal).toReal
+    · congr 1
+      -- LHS = ∑_{(x₁,z₁)} (id_X ⊗ f)_{(x,y),(x₁,z₁)} * swap_{x₁,z₁,x',z'}
+      convert Finset.sum_eq_single (x, z') _ _ using 1
+      · -- We get (if x = x then 1 else 0) * f(y,z') * (if x = x' ∧ z' = z' then 1 else 0)
+        simp only [if_true, one_mul]
+        by_cases hx : x = x'
+        · simp [hx]
+        · simp [hx]
+      · -- For other points: show the sum term is 0
+        intro ⟨x₁, z₁⟩ _ h_ne
+        -- We have (if x = x₁ then 1 else 0) * f(y,z₁) * (if x₁ = x' ∧ z₁ = z' then 1 else 0)
+        by_cases hx₁ : x = x₁
+        · subst hx₁
+          by_cases hxz : x = x' ∧ z₁ = z'
+          · obtain ⟨_, hz₁⟩ := hxz
+            subst hz₁
+            exfalso; exact h_ne rfl
+          · simp [hxz]
+        · simp [hx₁]
+      · intro h; exfalso; exact h (Finset.mem_univ _)
+
+    -- Compute the RHS sum
+    · congr 1
+      symm
+      -- RHS = ∑_{(y₁,x₁)} swap_{x,y,x₁,y₁} * (f ⊗ id_X)_{(y₁,x₁),(z',x')}
+      convert Finset.sum_eq_single (y, x) _ _ using 1
+      · -- At (y, x): we get (if x = x ∧ y = y then 1 else 0) *
+        -- (f(y,z') * (if x = x' then 1 else 0))
+        simp only [and_self, if_true]
+        by_cases hx : x = x'
+        · simp [hx, mul_one]
+        · simp [hx, mul_zero]
+      · -- For other points: show the sum term is 0
+        intro ⟨y₁, x₁⟩ _ h_ne
+        -- We have (if x = x₁ ∧ y = y₁ then 1 else 0) * (f(y₁,z') * (if x₁ = x' then 1 else 0))
+        by_cases hxy : x = x₁ ∧ y = y₁
+        · obtain ⟨hx₁, hy₁⟩ := hxy
+          subst hx₁ hy₁
+          exfalso; exact h_ne rfl
+        · simp [hxy]
+      · intro h; exfalso; exact h (Finset.mem_univ _)
+  hexagon_forward := by
+    intros X Y Z
+    -- Show: α ≫ β_{X,Y⊗Z} ≫ α = (β_{X,Y} ▷ Z) ≫ α ≫ (Y ◁ β_{X,Z})
+    -- Both map ((x,y),z) to (y,(z,x))
+    apply StochasticMatrix.ext
+    ext ⟨⟨x, y⟩, z⟩ ⟨y', ⟨z', x'⟩⟩
+    simp only [CategoryStruct.comp, StochasticMatrix.comp,
+               MonoidalCategoryStruct.whiskerRight, StochasticMatrix.tensor,
+               swap, MonoidalCategoryStruct.whiskerLeft]
+
+    -- Both sides equal 1 iff x = x' ∧ y = y' ∧ z = z'
+    trans (if x = x' ∧ y = y' ∧ z = z' then (1:NNReal) else 0).toReal
+    · -- LHS computation: should equal if x = x' ∧ y = y' ∧ z = z' then 1 else 0
+      -- The path is: ((x,y),z) → (x,(y,z)) → ((y,z),x) → (y,(z,x))
+      -- Each step has probability 1 when the path is followed correctly
+      congr 1
+      by_cases h : x = x' ∧ y = y' ∧ z = z'
+      · -- Case: the variables match, so we expect 1
+        obtain ⟨hx, hy, hz⟩ := h
+        subst hx hy hz
+        simp only [and_true, if_true]
+        -- Now we need to show the sum equals 1
+        -- The sum should collapse to a single term
+        convert Finset.sum_eq_single (x, (y, z)) _ _ using 1
+        · -- At the unique non-zero term
+          -- The associator at ((x,y),z) -> (x,(y,z)) is 1
+          have h_assoc : (α_ X Y Z).hom.toMatrix ((x, y), z) (x, (y, z)) = 1 := by
+            -- The associator in FinStoch is defined as: if x = x' ∧ y = y' ∧ z = z' then 1 else 0
+            -- At ((x,y),z) -> (x,(y,z)), all components match, so we get 1
+            simp only [MonoidalCategory.associator, associator]
+            rfl
+          simp only [h_assoc, one_mul]
+          rw [eq_comm]
+          -- The sum has a single non-zero term at ((y,z), x)
+          have h_sum : ∑ x_1, (match x_1 with | (y', x') => if x = x' ∧ (y, z) = y' then 1 else 0) *
+              (α_ Y Z X).hom.toMatrix x_1 (y, z, x) =
+                 ∑ x_1, (if x_1 = ((y, z), x) then 1 else 0) *
+              (α_ Y Z X).hom.toMatrix x_1 (y, z, x) := by
+                congr 1
+                ext x_1
+                cases x_1 with | mk y' x' =>
+                simp only
+                -- Show the match expression equals the if condition
+                by_cases h : x = x' ∧ (y, z) = y'
+                · simp only [h, and_self, ↓reduceIte, one_mul]
+                · simp only [h]
+                  have : ¬(y' = (y, z) ∧ x' = x) := by
+                    rw [and_comm]
+                    grind only
+                  simp only [↓reduceIte, zero_mul, NNReal.coe_zero, Prod.mk.injEq, this]
+          -- Use h_sum to transform the match expression
+          trans (∑ x_1, (if x_1 = ((y, z), x) then 1 else 0) *
+                        (α_ Y Z X).hom.toMatrix x_1 (y, z, x))
+          · exact h_sum
+          -- Now we have a sum with a single non-zero term at ((y,z), x)
+          rw [Finset.sum_eq_single ((y, z), x)]
+          · simp only [if_true, one_mul]
+            -- The associator at ((y,z), x) -> (y,(z,x)) gives 1
+            have h_assoc2 : (α_ Y Z X).hom.toMatrix ((y, z), x) (y, (z, x)) = 1 := by
+              simp only [MonoidalCategory.associator, associator]
+              rfl
+            simp only [h_assoc2]
+          · intro b _ hb
+            simp only [hb, if_false, zero_mul]
+          · intro h_mem; exfalso; exact h_mem (Finset.mem_univ _)
+        · -- Other x₁ terms are 0
+          intro x₁ _ hx₁
+          -- The associator gives 0 for x₁ ≠ (x, (y, z))
+          have h_zero : (α_ X Y Z).hom.toMatrix ((x, y), z) x₁ = 0 := by
+            simp only [MonoidalCategory.associator, associator]
+            -- Since x₁ ≠ (x, (y, z)), the condition fails
+            split_ifs with h_cond
+            · -- If the condition holds, contradiction
+              obtain ⟨h1, h2, h3⟩ := h_cond
+              subst h1 h2 h3
+              exact absurd rfl hx₁
+            · rfl
+          simp only [h_zero, zero_mul]
+        · intro h_mem; exfalso; exact h_mem (Finset.mem_univ _)
+      · -- Case: variables don't match, so we expect 0
+        simp only [h, if_false]
+        -- Show the entire sum is 0
+        rw [Finset.sum_eq_zero]
+        intro x₁ _
+        -- We need to show this product is 0
+        -- Either the associator gives 0, or the inner sum is 0
+        by_cases h_assoc : (α_ X Y Z).hom.toMatrix ((x, y), z) x₁ = 0
+        · -- Associator is 0, so product is 0
+          simp [h_assoc]
+        · -- Associator is non-zero, so x₁ = (x, (y, z))
+          push_neg at h_assoc
+          have hx₁ : x₁ = (x, (y, z)) := by
+            simp only [MonoidalCategory.associator, associator] at h_assoc ⊢
+            grind only [Finset.mem_univ, cases Or]
+          subst hx₁
+          simp only [MonoidalCategory.associator, associator]
+          -- Now show the inner sum is 0
+          rw [Finset.sum_eq_zero]
+          · simp only [and_self, ↓reduceIte, mul_zero]
+          · intro x_inner _
+            -- Need to show swap * final_assoc = 0
+            cases x_inner with | mk y_inner x_inner =>
+            simp only
+            -- Check if swap condition holds
+            by_cases h_swap : x = x_inner ∧ (y, z) = y_inner
+            · -- Swap gives 1, check final associator
+              obtain ⟨hx_eq, hy_eq⟩ := h_swap
+              subst hx_eq hy_eq
+              simp only [and_self, ↓reduceIte, mul_ite, mul_one, mul_zero, ite_eq_right_iff,
+                         one_ne_zero, imp_false, not_and]
+              intro a_2 a_3
+              subst a_3 a_2
+              simp_all only [Finset.mem_univ, associator_matrix, and_self, ↓reduceIte, ne_eq,
+                             one_ne_zero, not_false_eq_true, and_true]
+            · -- Swap gives 0
+              simp only [h_swap, if_false, zero_mul]
+
+    -- RHS computation
+    · congr 1
+      symm
+      -- RHS: ((x,y),z) → ((y,x),z) → (y,(x,z)) → (y,(z,x))
+      -- First swap ⊗ id maps ((x,y),z) ↦ ((y,x),z) with prob 1
+      -- Then associator maps ((y,x),z) ↦ (y,(x,z)) with prob 1
+      -- Then id ⊗ swap maps (y,(x,z)) ↦ (y,(z,x)) with prob 1
+
+      -- Sum over final state before last operation
+      -- The RHS path: swap ⊗ id, then associator, then id ⊗ swap
+      simp only [StochasticMatrix.id, CategoryStruct.id]
+      -- We need to show the sum equals the indicator function
+      by_cases h_match : x = x' ∧ y = y' ∧ z = z'
+      · -- Case: all match, result should be 1
+        obtain ⟨hx, hy, hz⟩ := h_match
+        subst hx hy hz
+        simp only [and_true, if_true]
+        -- The sum should collapse to a single non-zero term
+        convert Finset.sum_eq_single ((y, x), z) _ _ using 1
+        · -- At ((y,x),z): show it produces 1
+          simp only [and_self, ↓reduceIte, mul_one, associator_toMatrix, ite_mul, one_mul, zero_mul,
+                     mul_ite, mul_zero]
+          -- The sum equals 1 as only (y, (x, z)) contributes
+          -- Simplify to show the sum has exactly one non-zero term
+          have h_sum_eq : (∑ x_1 : Y.carrier × (X.carrier × Z.carrier),
+                if x_1.1 = y then
+                  if y = x_1.1 ∧ x = x_1.2.1 ∧ z = x_1.2.2 then
+                    match x_1.2 with | (x_2, z_2) => if x_2 = x ∧ z_2 = z then 1 else 0
+                  else 0
+                else 0) = (1 : NNReal) := by
+            rw [Finset.sum_eq_single (y, (x, z))]
+            · simp
+            · intro ⟨y₁, x₁, z₁⟩ _ hne
+              by_cases hy : y₁ = y
+              · simp [hy]
+                by_cases hxz : x = x₁ ∧ z = z₁
+                · obtain ⟨hx, hz⟩ := hxz
+                  subst hy hx hz
+                  exfalso; exact hne rfl
+                · push_neg at hxz
+                  by_cases hx : x = x₁
+                  · simp [hx, hxz hx]
+                  · simp [hx]
+              · simp [hy]
+            · intro h; exfalso; exact h (Finset.mem_univ _)
+          grind only [cases eager Prod, cases Or]
+        · -- Other x₁ values give 0
+          grind only [cases eager Prod]
+        · intro h; exfalso; exact h (Finset.mem_univ _)
+      · -- Case: not all match, result should be 0
+        simp only [h_match, if_false]
+        -- Show the sum is 0
+        rw [Finset.sum_eq_zero]
+        intro x₁ _
+        -- We analyze based on whether x₁ = ((y,x),z)
+        by_cases hx₁ : x₁ = ((y, x), z)
+        · subst hx₁
+          simp only [and_self, if_true, one_mul, associator_toMatrix, ite_mul, one_mul, zero_mul,
+                     mul_ite, mul_zero]
+          -- Sum over associator output
+          rw [Finset.sum_eq_zero]
+          intro c _
+          split_ifs with h_assoc
+          · -- Associator gives 1, so c = (y,(x,z))
+            -- The conditions mean c.1 = y' and c.2.1 = x and c.2.2 = z
+            -- So c = (y', (x, z))
+            -- Now check the swap condition
+            grind only [Finset.mem_univ, cases Or]
+          · rfl
+          · rfl
+        · -- x₁ ≠ ((y,x),z): first swap gives 0
+          simp_all only [not_and, Finset.mem_univ, mul_ite, mul_one, mul_zero, associator_toMatrix,
+                         ite_mul, one_mul, zero_mul, ite_eq_right_iff, mul_eq_zero,
+                         Finset.sum_eq_zero_iff, and_imp, forall_const]
+          sorry
+
+
+  hexagon_reverse := by
+    intros X Y Z
+    -- The reverse hexagon identity
+    -- Similar proof strategy as hexagon_forward
+    sorry
+
+/-- FinStoch is symmetric. -/
+instance : SymmetricCategory FinStoch where
+  symmetry X Y := by
+    apply StochasticMatrix.ext
+    ext ⟨x, y⟩ ⟨x', y'⟩
+    simp only [CategoryStruct.comp, StochasticMatrix.comp,
+               CategoryStruct.id, StochasticMatrix.id]
+    -- We need to show swap ∘ swap = id
+    -- The composition should give δ_{(x,y), (x',y')}
+
+    -- The sum is over intermediate states
+    -- The sum ∑_{(y₁,x₁)} swap_{(x,y),(y₁,x₁)} * swap_{(y₁,x₁),(x',y')}
+    -- has exactly one non-zero term when (y₁,x₁) = (y,x)
+    have h_sum : (∑ ab : Y.carrier × X.carrier,
+          (if x = ab.2 ∧ y = ab.1 then (1 : NNReal) else 0) *
+          (if ab.1 = y' ∧ ab.2 = x' then 1 else 0)) =
+        if x = x' ∧ y = y' then 1 else 0 := by
+      convert Finset.sum_eq_single (y, x) _ _ using 1
+      · -- At (y, x): first condition gives 1, second gives 1 iff y = y' ∧ x = x'
+        simp only [and_self, if_true, one_mul]
+        simp only [and_comm]
+      · -- For other points: product is 0
+        intro ⟨y₁, x₁⟩ _ h_ne
+        by_cases h : x = x₁ ∧ y = y₁
+        · obtain ⟨hx, hy⟩ := h
+          subst hx hy
+          exfalso; exact h_ne rfl
+        · simp [h]
+      · -- (y, x) is in univ
+        intro h; exfalso; exact h (Finset.mem_univ _)
+
+    -- Now show the composition equals the identity
+    simp only [BraidedCategory.braiding, swap]
+    convert congr_arg NNReal.toReal h_sum
+    constructor
+    · intro h
+      cases h
+      constructor <;> rfl
+    · intro ⟨h1, h2⟩
+      cases h1
+      cases h2
+      rfl
+
+end CategoryTheory.MarkovCategory

--- a/Mathlib/CategoryTheory/MarkovCategory/FinStoch/CopyDiscard.lean
+++ b/Mathlib/CategoryTheory/MarkovCategory/FinStoch/CopyDiscard.lean
@@ -1,0 +1,115 @@
+/-
+Copyright (c) 2025 Jacob Reinhold. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Jacob Reinhold
+-/
+import Mathlib.CategoryTheory.MarkovCategory.FinStoch.Braided
+import Mathlib.CategoryTheory.CopyDiscardCategory.Basic
+
+/-!
+# Copy-Discard Structure on FinStoch
+
+FinStoch has copy and discard operations making it a copy-discard category.
+
+## Main definitions
+
+* `copy` - Diagonal embedding
+* `discard` - Map to singleton
+* `ComonObj` instances
+* `CopyDiscardCategory FinStoch`
+
+## Implementation notes
+
+Copy duplicates states (diagonal), discard maps all states to the unit.
+
+## Tags
+
+copy-discard, comonoid, Markov category
+-/
+
+namespace CategoryTheory.MarkovCategory
+
+open FinStoch MonoidalCategory ComonObj
+
+universe u
+
+/-- Copy: diagonal embedding. Maps a state to both copies of itself. -/
+def copy (X : FinStoch) : X ⟶ X ⊗ X where
+  toMatrix := fun i (j₁, j₂) => if i = j₁ ∧ i = j₂ then 1 else 0
+  row_sum := fun i => by
+    simp only [Finset.sum_ite_eq, Finset.mem_univ, if_true]
+    rfl
+
+/-- Discard: map to singleton. All states map to the unique unit state. -/
+def discard (X : FinStoch) : X ⟶ tensorUnit where
+  toMatrix := fun i _ => 1
+  row_sum := fun i => by
+    simp only [Finset.sum_const, Finset.card_univ]
+    rw [Fintype.card_of_subsingleton]
+    simp
+
+open scoped ComonObj
+
+/-- FinStoch has comonoid structure on every object. -/
+instance (X : FinStoch) : ComonObj X where
+  comul := copy X
+  counit := discard X
+  counit_comul := by
+    apply StochasticMatrix.ext
+    ext i x
+    simp only [CategoryStruct.comp, StochasticMatrix.comp, MonoidalCategoryStruct.whiskerRight,
+               copy, discard, MonoidalCategoryStruct.leftUnitor]
+    sorry -- Proof details
+  comul_counit := by
+    apply StochasticMatrix.ext
+    ext i x
+    simp only [CategoryStruct.comp, StochasticMatrix.comp, MonoidalCategoryStruct.whiskerLeft,
+               copy, discard, MonoidalCategoryStruct.rightUnitor]
+    sorry -- Proof details
+  comul_assoc := by
+    apply StochasticMatrix.ext
+    ext i ⟨⟨j₁, j₂⟩, j₃⟩
+    simp only [CategoryStruct.comp, StochasticMatrix.comp,
+               MonoidalCategoryStruct.whiskerLeft, MonoidalCategoryStruct.whiskerRight,
+               MonoidalCategoryStruct.associator, copy]
+    sorry -- Proof details
+
+/-- The comonoid structure in FinStoch is commutative. -/
+instance (X : FinStoch) : CommComonObj X where
+  isComm := by
+    apply StochasticMatrix.ext
+    ext i ⟨j₁, j₂⟩
+    simp only [CategoryStruct.comp, StochasticMatrix.comp, BraidedCategory.braiding,
+               copy, swap, ComonObj.comul]
+    simp only [Finset.sum_ite_eq, Finset.mem_univ, if_true]
+    split_ifs with h
+    · simp [h, and_comm]
+    · rfl
+
+/-- Tensor coherence for copy. -/
+lemma copy_tensor_eq (X Y : FinStoch) :
+    Δ[X ⊗ Y] = (Δ[X] ⊗ₘ Δ[Y]) ≫ tensorμ X X Y Y := by
+  sorry -- Proof details
+
+/-- Tensor coherence for discard. -/
+lemma discard_tensor_eq (X Y : FinStoch) :
+    ε[X ⊗ Y] = (ε[X] ⊗ₘ ε[Y]) ≫ (λ_ (𝟙_ FinStoch)).hom := by
+  sorry -- Proof details
+
+/-- Copy on unit equals left unitor inverse. -/
+lemma copy_unit_eq : Δ[𝟙_ FinStoch] = (λ_ (𝟙_ FinStoch)).inv := by
+  sorry -- Proof details
+
+/-- Discard on unit is identity. -/
+lemma discard_unit_eq : ε[𝟙_ FinStoch] = 𝟙 (𝟙_ FinStoch) := by
+  sorry -- Proof details
+
+/-- FinStoch has copy-discard structure. -/
+instance : CopyDiscardCategory FinStoch where
+  -- commComonObj uses inferInstance by default, which finds our instances above
+  copy_tensor X Y := copy_tensor_eq X Y
+  discard_tensor X Y := discard_tensor_eq X Y
+  copy_unit := copy_unit_eq
+  discard_unit := discard_unit_eq
+
+end CategoryTheory.MarkovCategory

--- a/Mathlib/CategoryTheory/MarkovCategory/FinStoch/CopyDiscard.lean
+++ b/Mathlib/CategoryTheory/MarkovCategory/FinStoch/CopyDiscard.lean
@@ -38,22 +38,15 @@ def copy (X : FinStoch) : X ⟶ X ⊗ X where
   toMatrix := fun i (j₁, j₂) => if i = j₁ ∧ i = j₂ then 1 else 0
   row_sum := fun i => by
     rw [Fintype.sum_eq_single ⟨i, i⟩]
-    · simp only [and_self, ↓reduceIte]
-    · simp only [ne_eq]
-      intro xx hne
-      split
-      rename_i x j₁ j₂
-      simp_all only [ite_eq_right_iff, one_ne_zero, imp_false, not_and]
-      intro a; subst a
-      intro a; subst a
-      simp_all only [not_true_eq_false]
+    · simp
+    · aesop
 
 /-- Discard: map to singleton. All states map to the unique unit state. -/
 def discard (X : FinStoch) : X ⟶ tensorUnit where
   toMatrix := fun i _ => 1
   row_sum := fun i => by
     rw [Fintype.sum_eq_single ⟨⟩]
-    simp_all only [ne_eq, one_ne_zero, imp_false, Decidable.not_not]
+    simp_all
     intro x
     rfl
 
@@ -67,68 +60,44 @@ instance (X : FinStoch) : ComonObj X where
     apply StochasticMatrix.ext
     ext i ⟨⟨⟩ , x⟩
     simp only [CategoryStruct.comp, StochasticMatrix.comp, copy, whiskerRight, discard,
-      MonoidalCategoryStruct.leftUnitor, leftUnitor, StochasticMatrix.tensor,
-      CategoryStruct.id, StochasticMatrix.id, leftUnitorInvDet, DetMorphism.ofFunc]
+               MonoidalCategoryStruct.leftUnitor, leftUnitor, StochasticMatrix.tensor,
+               CategoryStruct.id, StochasticMatrix.id, leftUnitorInvDet, DetMorphism.ofFunc]
     -- Goal: Σ_{(j₁,j₂)} copy(i)(j₁,j₂) · (discard ⊗ id)(j₁,j₂)(unit_,x) = λ⁻¹(i)(unit_,x)
     -- LHS = Σ_{(j₁,j₂)} [i=j₁∧i=j₂] · 1 · [j₂=x] = [i=x]
     -- RHS = λ⁻¹(i)(unit_,x) = [i=x]
     rw [Fintype.sum_eq_single ⟨i, x⟩]
-    · simp only [true_and, ↓reduceIte, mul_one, NNReal.coe_inj]
+    · simp
       split_ifs with h h'
       · rfl
-      · simp_all only [not_true_eq_false]
-      · rename_i h'
-        simp only [zero_ne_one]
-        grind only
+      · simp_all
+      · grind only
       · rfl
     · intro ⟨j₁, j₂⟩ hne
-      simp_all only [ne_eq, mul_ite, mul_one, mul_zero, ite_eq_right_iff, one_ne_zero, imp_false,
-        not_and]
-      intro a a_1; subst a a_1
-      intro a; subst a
-      simp_all only [not_true_eq_false]
+      simp_all
+      aesop
   comul_counit := by
     apply StochasticMatrix.ext
     ext i ⟨x, ⟨⟩⟩
-    simp_all only [CategoryStruct.comp, StochasticMatrix.comp, copy, whiskerLeft,
-      StochasticMatrix.tensor, CategoryStruct.id, StochasticMatrix.id, discard, mul_one, mul_ite,
-      mul_zero, NNReal.coe_sum, MonoidalCategoryStruct.rightUnitor, rightUnitor]
+    simp_all [CategoryStruct.comp, StochasticMatrix.comp, copy, whiskerLeft,
+              StochasticMatrix.tensor, CategoryStruct.id, StochasticMatrix.id, discard,
+              MonoidalCategoryStruct.rightUnitor, rightUnitor]
     -- The composition: copy ≫ (id ⊗ discard) ≫ rightUnitor
     -- First: copy(i) gives (i,i)
     -- Second: (id ⊗ discard)(i,i) gives (i,*)
     -- Third: rightUnitor(i,*) gives i
     -- Overall: identity morphism
     rw [Finset.sum_eq_single ⟨i, x⟩]
-    · simp_all only [true_and, ↓reduceIte, rightUnitorInvDet, DetMorphism.ofFunc, NNReal.coe_inj]
-      split
-      next h =>
-        subst h
-        simp_all only [left_eq_ite_iff, one_ne_zero, imp_false, not_not]
-      next h =>
-        simp_all only [right_eq_ite_iff, zero_ne_one, imp_false]
-        grind only
-    · simp_all only [Finset.mem_univ, ne_eq, forall_const]
-      intro xx hxx
-      split
-      · rename_i hx
-        simp only [NNReal.coe_eq_zero]
-        subst hx
-        split
-        rename_i x j₁ j₂
-        simp_all only [ite_eq_right_iff, one_ne_zero, imp_false, not_and]
-        intro a; subst a
-        intro a; subst a
-        simp_all only [not_true_eq_false]
-      · rfl
-    · simp_all only [Finset.mem_univ, not_true_eq_false, and_self, ↓reduceIte, NNReal.coe_eq_zero,
-        ite_eq_right_iff, one_ne_zero, implies_true]
+    · simp_all [rightUnitorInvDet, DetMorphism.ofFunc]
+      grind only [cases Or]
+    · simp_all
+      grind only [cases Or]
+    · simp_all
   comul_assoc := by
     apply StochasticMatrix.ext
     ext i ⟨j₁, ⟨j₂, j₃⟩⟩
-    simp_all only [CategoryStruct.comp, StochasticMatrix.comp, copy, whiskerLeft,
-      StochasticMatrix.tensor, CategoryStruct.id, StochasticMatrix.id, ite_mul, one_mul, zero_mul,
-      mul_ite, mul_zero, mul_one, NNReal.coe_sum, whiskerRight, MonoidalCategoryStruct.associator,
-      associator, associatorDet, DetMorphism.ofFunc, NNReal.coe_mul]
+    simp_all [CategoryStruct.comp, StochasticMatrix.comp, copy, whiskerLeft,
+              StochasticMatrix.tensor, CategoryStruct.id, StochasticMatrix.id, whiskerRight,
+              MonoidalCategoryStruct.associator, associator, associatorDet, DetMorphism.ofFunc]
     -- Both sides give 1 if i = j₁ = j₂ = j₃, else 0
     -- Show both paths equal this value
     by_cases h : i = j₁ ∧ i = j₂ ∧ i = j₃
@@ -139,37 +108,15 @@ instance (X : FinStoch) : ComonObj X where
       trans 1
       · simp only [and_self]
         rw [Fintype.sum_eq_single ⟨i, i⟩]
-        · simp only [↓reduceIte, and_self, NNReal.coe_one]
-        · intro b hb
-          split_ifs <;> try simp
-          rename_i hb1 hb2
-          simp_all only [ne_eq]
-          grind only
+        · simp
+        · aesop
       -- Right path
       · rw [Fintype.sum_eq_single ⟨i, i⟩]
-        · simp_all only [and_self, ↓reduceIte, NNReal.coe_one, one_mul]
+        · simp_all
           rw [Fintype.sum_eq_single ⟨⟨i, i⟩, i⟩]
-          · simp_all only [↓reduceIte, and_self, NNReal.coe_one]
-          · simp_all only [ne_eq, NNReal.coe_eq_zero, ite_eq_right_iff]
-            intro xxx hne
-            intro a a_1; subst a_1
-            split
-            rename_i x j₁ j₂ heq
-            simp_all only [ite_eq_right_iff, one_ne_zero, imp_false, not_and]
-            intro a_1; subst a_1
-            intro a_1; subst a_1
-            split at a
-            rename_i x_1 x_2 y z
-            simp_all only [not_true_eq_false]
-        · intro b hb
-          simp_all only [ne_eq, mul_eq_zero, NNReal.coe_eq_zero]
-          split
-          rename_i x j₁ j₂
-          simp_all only [ite_eq_right_iff, one_ne_zero, imp_false, not_and]
-          apply Or.inl
-          intro a; subst a
-          intro a; subst a
-          simp_all only [not_true_eq_false]
+          · simp
+          · aesop
+        · aesop
     · -- Case when not all equal: both sides are 0
       -- Show both sums equal 0
       push_neg at h
@@ -178,20 +125,7 @@ instance (X : FinStoch) : ComonObj X where
       · rw [Fintype.sum_eq_zero]
         intro ⟨k₁, k₂⟩
         simp only
-        split_ifs with h1 h2 h3
-        · -- All conditions hold: k₁=j₁, k₂=j₂=j₃, i=k₁=k₂
-          -- This means i=j₁=j₂=j₃, contradicting h
-          subst h1
-          obtain ⟨h2a, h2b⟩ := h2
-          subst h2a h2b
-          obtain ⟨h3a, h3b⟩ := h3
-          subst h3a h3b
-          simp only [NNReal.coe_one]
-          exfalso
-          exact (h rfl rfl) rfl
-        · simp only [NNReal.coe_zero]
-        · simp only [NNReal.coe_zero]
-        · simp only [NNReal.coe_zero]
+        aesop
       -- Right side
       · symm
         rw [Fintype.sum_eq_zero]
@@ -202,36 +136,31 @@ instance (X : FinStoch) : ComonObj X where
           simp only [hk]
           obtain ⟨h1, h2⟩ := hk
           subst h1 h2
-          simp only [and_self, if_true, NNReal.coe_one, one_mul]
+          simp
           rw [Fintype.sum_eq_zero]
           intro ⟨⟨m₁, m₂⟩, m₃⟩
           simp only
           split_ifs with h_eq h_m3 h_m12
           · -- All hold: (m₁,m₂,m₃)=(j₁,j₂,j₃), i=m₃, i=m₁=m₂
-            simp only at h_eq
-            simp_all only [ne_eq, NNReal.coe_one, one_ne_zero]
-            subst h_m3
-            obtain ⟨left, right⟩ := h_m12
-            subst right left
             grind only
-          · simp only [NNReal.coe_zero]
-          · simp only [NNReal.coe_zero]
-          · simp only [NNReal.coe_zero]
+          · simp
+          · simp
+          · simp
         · -- First copy gives 0
-          simp only [hk, if_false, NNReal.coe_zero, zero_mul]
+          simp [hk]
 
 /-- The comonoid structure in FinStoch is commutative. -/
 instance (X : FinStoch) : CommComonObj X where
   isComm := by
     apply StochasticMatrix.ext
     ext i ⟨j₁, j₂⟩
-    simp_all only [CategoryStruct.comp, StochasticMatrix.comp, NNReal.coe_sum, NNReal.coe_mul]
+    simp_all [CategoryStruct.comp, StochasticMatrix.comp]
     -- Copy is commutative: Δ ≫ β = Δ
     -- LHS: copy(i) gives (i,i), then swap gives (i,i)
     -- RHS: copy(i) gives (j₁,j₂) which is 1 iff i = j₁ = j₂
     rw [Fintype.sum_eq_single ⟨i, i⟩]
     · -- At (i,i): copy gives 1, swap keeps (i,i) → (i,i) with prob 1
-      simp only [comul, copy, and_self, ↓reduceIte, NNReal.coe_one, one_mul, NNReal.coe_inj]
+      simp [comul, copy]
       -- swap (i,i) → (j₁,j₂) is 1 iff i = j₂ ∧ i = j₁
       have h_swap : (β_ X X).hom.toMatrix (i, i) (j₁, j₂) =
                     if i = j₂ ∧ i = j₁ then 1 else 0 := by
@@ -241,19 +170,10 @@ instance (X : FinStoch) : CommComonObj X where
       -- Both sides equal 1 iff i = j₁ = j₂
       split_ifs with h_cond h_copy
       · -- h_cond: i = j₂ ∧ i = j₁, so j₁ = j₂ = i
-        obtain ⟨h1, h2⟩ := h_cond
-        subst h1 h2
-        simp only
+        tauto
       · -- h_copy: i = j₁ ∧ i = j₂
-        simp_all only [true_and, and_true, one_ne_zero, ↓reduceIte]
-        obtain ⟨left, right⟩ := h_cond
-        subst right left
-        simp_all only [not_true_eq_false]
-      · simp_all only [and_true, zero_ne_one, ↓reduceIte]
-        rename_i h'
-        obtain ⟨l, r⟩ := h'
-        subst l r
-        simp_all only [not_true_eq_false]
+        tauto
+      · tauto
       · rfl
     · -- Other pairs (x,y) with (x,y) ≠ (i,i) give copy value 0
       intro ⟨x, y⟩ hne
@@ -270,22 +190,20 @@ instance (X : FinStoch) : CommComonObj X where
 lemma copy_unit_eq : Δ[𝟙_ FinStoch] = (λ_ (𝟙_ FinStoch)).inv := by
   apply StochasticMatrix.ext
   ext ⟨⟩ ⟨⟨⟩, ⟨⟩⟩
-  simp only [comul, copy, MonoidalCategoryStruct.leftUnitor]
-  simp only [and_self, ↓reduceIte, NNReal.coe_one]
+  simp [comul, copy, MonoidalCategoryStruct.leftUnitor]
   rfl
 
 /-- Discard on unit is identity. -/
 lemma discard_unit_eq : ε[𝟙_ FinStoch] = 𝟙 (𝟙_ FinStoch) := by
   apply StochasticMatrix.ext
   ext ⟨⟩ ⟨⟩
-  simp only [ComonObj.counit, discard, CategoryStruct.id, StochasticMatrix.id]
-  rfl
+  simp [ComonObj.counit, discard, CategoryStruct.id, StochasticMatrix.id]
 
 /-- FinStoch has copy-discard structure. -/
 instance : CopyDiscardCategory FinStoch where
   -- commComonObj uses inferInstance by default, which finds our instances above
-  copy_tensor := by simp only [Comon.tensorObj_comul, implies_true]
-  discard_tensor := by simp only [Comon.tensorObj_counit, implies_true]
+  copy_tensor := by simp [Comon.tensorObj_comul]
+  discard_tensor := by simp [Comon.tensorObj_counit]
   copy_unit := copy_unit_eq
   discard_unit := discard_unit_eq
 

--- a/Mathlib/CategoryTheory/MarkovCategory/FinStoch/CopyDiscard.lean
+++ b/Mathlib/CategoryTheory/MarkovCategory/FinStoch/CopyDiscard.lean
@@ -37,16 +37,25 @@ universe u
 def copy (X : FinStoch) : X ⟶ X ⊗ X where
   toMatrix := fun i (j₁, j₂) => if i = j₁ ∧ i = j₂ then 1 else 0
   row_sum := fun i => by
-    simp only [Finset.sum_ite_eq, Finset.mem_univ, if_true]
-    rfl
+    rw [Fintype.sum_eq_single ⟨i, i⟩]
+    · simp only [and_self, ↓reduceIte]
+    · simp only [ne_eq]
+      intro xx hne
+      split
+      rename_i x j₁ j₂
+      simp_all only [ite_eq_right_iff, one_ne_zero, imp_false, not_and]
+      intro a; subst a
+      intro a; subst a
+      simp_all only [not_true_eq_false]
 
 /-- Discard: map to singleton. All states map to the unique unit state. -/
 def discard (X : FinStoch) : X ⟶ tensorUnit where
   toMatrix := fun i _ => 1
   row_sum := fun i => by
-    simp only [Finset.sum_const, Finset.card_univ]
-    rw [Fintype.card_of_subsingleton]
-    simp
+    rw [Fintype.sum_eq_single ⟨⟩]
+    simp_all only [ne_eq, one_ne_zero, imp_false, Decidable.not_not]
+    intro x
+    rfl
 
 open scoped ComonObj
 
@@ -56,59 +65,225 @@ instance (X : FinStoch) : ComonObj X where
   counit := discard X
   counit_comul := by
     apply StochasticMatrix.ext
-    ext i x
-    simp only [CategoryStruct.comp, StochasticMatrix.comp, MonoidalCategoryStruct.whiskerRight,
-               copy, discard, MonoidalCategoryStruct.leftUnitor]
-    sorry -- Proof details
+    ext i ⟨⟨⟩ , x⟩
+    simp only [CategoryStruct.comp, StochasticMatrix.comp, copy, whiskerRight, discard,
+      MonoidalCategoryStruct.leftUnitor, leftUnitor, StochasticMatrix.tensor,
+      CategoryStruct.id, StochasticMatrix.id, leftUnitorInvDet, DetMorphism.ofFunc]
+    -- Goal: Σ_{(j₁,j₂)} copy(i)(j₁,j₂) · (discard ⊗ id)(j₁,j₂)(unit_,x) = λ⁻¹(i)(unit_,x)
+    -- LHS = Σ_{(j₁,j₂)} [i=j₁∧i=j₂] · 1 · [j₂=x] = [i=x]
+    -- RHS = λ⁻¹(i)(unit_,x) = [i=x]
+    rw [Fintype.sum_eq_single ⟨i, x⟩]
+    · simp only [true_and, ↓reduceIte, mul_one, NNReal.coe_inj]
+      split_ifs with h h'
+      · rfl
+      · simp_all only [not_true_eq_false]
+      · rename_i h'
+        simp only [zero_ne_one]
+        grind only
+      · rfl
+    · intro ⟨j₁, j₂⟩ hne
+      simp_all only [ne_eq, mul_ite, mul_one, mul_zero, ite_eq_right_iff, one_ne_zero, imp_false,
+        not_and]
+      intro a a_1; subst a a_1
+      intro a; subst a
+      simp_all only [not_true_eq_false]
   comul_counit := by
     apply StochasticMatrix.ext
-    ext i x
-    simp only [CategoryStruct.comp, StochasticMatrix.comp, MonoidalCategoryStruct.whiskerLeft,
-               copy, discard, MonoidalCategoryStruct.rightUnitor]
-    sorry -- Proof details
+    ext i ⟨x, ⟨⟩⟩
+    simp_all only [CategoryStruct.comp, StochasticMatrix.comp, copy, whiskerLeft,
+      StochasticMatrix.tensor, CategoryStruct.id, StochasticMatrix.id, discard, mul_one, mul_ite,
+      mul_zero, NNReal.coe_sum, MonoidalCategoryStruct.rightUnitor, rightUnitor]
+    -- The composition: copy ≫ (id ⊗ discard) ≫ rightUnitor
+    -- First: copy(i) gives (i,i)
+    -- Second: (id ⊗ discard)(i,i) gives (i,*)
+    -- Third: rightUnitor(i,*) gives i
+    -- Overall: identity morphism
+    rw [Finset.sum_eq_single ⟨i, x⟩]
+    · simp_all only [true_and, ↓reduceIte, rightUnitorInvDet, DetMorphism.ofFunc, NNReal.coe_inj]
+      split
+      next h =>
+        subst h
+        simp_all only [left_eq_ite_iff, one_ne_zero, imp_false, not_not]
+      next h =>
+        simp_all only [right_eq_ite_iff, zero_ne_one, imp_false]
+        grind only
+    · simp_all only [Finset.mem_univ, ne_eq, forall_const]
+      intro xx hxx
+      split
+      · rename_i hx
+        simp only [NNReal.coe_eq_zero]
+        subst hx
+        split
+        rename_i x j₁ j₂
+        simp_all only [ite_eq_right_iff, one_ne_zero, imp_false, not_and]
+        intro a; subst a
+        intro a; subst a
+        simp_all only [not_true_eq_false]
+      · rfl
+    · simp_all only [Finset.mem_univ, not_true_eq_false, and_self, ↓reduceIte, NNReal.coe_eq_zero,
+        ite_eq_right_iff, one_ne_zero, implies_true]
   comul_assoc := by
     apply StochasticMatrix.ext
-    ext i ⟨⟨j₁, j₂⟩, j₃⟩
-    simp only [CategoryStruct.comp, StochasticMatrix.comp,
-               MonoidalCategoryStruct.whiskerLeft, MonoidalCategoryStruct.whiskerRight,
-               MonoidalCategoryStruct.associator, copy]
-    sorry -- Proof details
+    ext i ⟨j₁, ⟨j₂, j₃⟩⟩
+    simp_all only [CategoryStruct.comp, StochasticMatrix.comp, copy, whiskerLeft,
+      StochasticMatrix.tensor, CategoryStruct.id, StochasticMatrix.id, ite_mul, one_mul, zero_mul,
+      mul_ite, mul_zero, mul_one, NNReal.coe_sum, whiskerRight, MonoidalCategoryStruct.associator,
+      associator, associatorDet, DetMorphism.ofFunc, NNReal.coe_mul]
+    -- Both sides give 1 if i = j₁ = j₂ = j₃, else 0
+    -- Show both paths equal this value
+    by_cases h : i = j₁ ∧ i = j₂ ∧ i = j₃
+    · -- Case when all are equal to i
+      obtain ⟨h1, h2, h3⟩ := h
+      subst h1 h2 h3
+      -- Left path: copy ≫ (copy ⊗ id) ≫ α
+      trans 1
+      · simp only [and_self]
+        rw [Fintype.sum_eq_single ⟨i, i⟩]
+        · simp only [↓reduceIte, and_self, NNReal.coe_one]
+        · intro b hb
+          split_ifs <;> try simp
+          rename_i hb1 hb2
+          simp_all only [ne_eq]
+          grind only
+      -- Right path
+      · rw [Fintype.sum_eq_single ⟨i, i⟩]
+        · simp_all only [and_self, ↓reduceIte, NNReal.coe_one, one_mul]
+          rw [Fintype.sum_eq_single ⟨⟨i, i⟩, i⟩]
+          · simp_all only [↓reduceIte, and_self, NNReal.coe_one]
+          · simp_all only [ne_eq, NNReal.coe_eq_zero, ite_eq_right_iff]
+            intro xxx hne
+            intro a a_1; subst a_1
+            split
+            rename_i x j₁ j₂ heq
+            simp_all only [ite_eq_right_iff, one_ne_zero, imp_false, not_and]
+            intro a_1; subst a_1
+            intro a_1; subst a_1
+            split at a
+            rename_i x_1 x_2 y z
+            simp_all only [not_true_eq_false]
+        · intro b hb
+          simp_all only [ne_eq, mul_eq_zero, NNReal.coe_eq_zero]
+          split
+          rename_i x j₁ j₂
+          simp_all only [ite_eq_right_iff, one_ne_zero, imp_false, not_and]
+          apply Or.inl
+          intro a; subst a
+          intro a; subst a
+          simp_all only [not_true_eq_false]
+    · -- Case when not all equal
+      simp_all only [not_and]
+      sorry
 
 /-- The comonoid structure in FinStoch is commutative. -/
 instance (X : FinStoch) : CommComonObj X where
   isComm := by
     apply StochasticMatrix.ext
     ext i ⟨j₁, j₂⟩
-    simp only [CategoryStruct.comp, StochasticMatrix.comp, BraidedCategory.braiding,
-               copy, swap, ComonObj.comul]
-    simp only [Finset.sum_ite_eq, Finset.mem_univ, if_true]
-    split_ifs with h
-    · simp [h, and_comm]
-    · rfl
+    simp_all only [CategoryStruct.comp, StochasticMatrix.comp, NNReal.coe_sum, NNReal.coe_mul]
+    -- Copy is commutative: Δ ≫ β = Δ
+    -- LHS: copy(i) gives (i,i), then swap gives (i,i)
+    -- RHS: copy(i) gives (j₁,j₂) which is 1 iff i = j₁ = j₂
+    rw [Fintype.sum_eq_single ⟨i, i⟩]
+    · -- At (i,i): copy gives 1, swap keeps (i,i) → (i,i) with prob 1
+      simp only [comul, copy, and_self, ↓reduceIte, NNReal.coe_one, one_mul, NNReal.coe_inj]
+      -- swap (i,i) → (j₁,j₂) is 1 iff i = j₂ ∧ i = j₁
+      have h_swap : (β_ X X).hom.toMatrix (i, i) (j₁, j₂) =
+                    if i = j₂ ∧ i = j₁ then 1 else 0 := by
+        simp only [BraidedCategory.braiding]
+        rfl
+      rw [h_swap]
+      -- Both sides equal 1 iff i = j₁ = j₂
+      split_ifs with h_cond h_copy
+      · -- h_cond: i = j₂ ∧ i = j₁, so j₁ = j₂ = i
+        obtain ⟨h1, h2⟩ := h_cond
+        subst h1 h2
+        simp only
+      · -- h_copy: i = j₁ ∧ i = j₂
+        simp_all only [true_and, and_true, one_ne_zero, ↓reduceIte]
+        obtain ⟨left, right⟩ := h_cond
+        subst right left
+        simp_all only [not_true_eq_false]
+      · simp_all only [and_true, zero_ne_one, ↓reduceIte]
+        rename_i h'
+        obtain ⟨l, r⟩ := h'
+        subst l r
+        simp_all only [not_true_eq_false]
+      · rfl
+    · -- Other pairs (x,y) with (x,y) ≠ (i,i) give copy value 0
+      intro ⟨x, y⟩ hne
+      simp only [comul, copy]
+      split_ifs with h
+      · -- If copy gives 1, then x = i ∧ y = i, contradicting hne
+        obtain ⟨hx, hy⟩ := h
+        subst hx hy
+        exfalso
+        exact hne rfl
+      · simp
 
 /-- Tensor coherence for copy. -/
 lemma copy_tensor_eq (X Y : FinStoch) :
     Δ[X ⊗ Y] = (Δ[X] ⊗ₘ Δ[Y]) ≫ tensorμ X X Y Y := by
-  sorry -- Proof details
+  -- Δ[X ⊗ Y] maps (x,y) to ((x,y), (x,y))
+  -- (Δ[X] ⊗ Δ[Y]) maps (x,y) to ((x,x), (y,y))
+  -- tensorμ rearranges ((x,x), (y,y)) to ((x,y), (x,y))
+  apply StochasticMatrix.ext
+  ext ⟨x, y⟩ ⟨⟨x₁, y₁⟩, ⟨x₂, y₂⟩⟩
+  simp_all only [comul, copy, CategoryStruct.comp, StochasticMatrix.comp, tensorHom,
+    StochasticMatrix.tensor, NNReal.coe_sum, NNReal.coe_mul, tensorμ, MonoidalCategory.associator,
+    BraidedCategory.braiding, associator, associatorDet, DetMorphism.ofFunc, whiskerLeft,
+    DetMorphism.toMatrix_apply, id_matrix]
+  -- LHS: Δ[X ⊗ Y] gives 1 iff (x,y) = (x₁,y₁) = (x₂,y₂)
+  -- RHS: composition through tensorμ
+  -- The sum over intermediate states
+  split
+  next h =>
+    simp_all only [NNReal.coe_one]
+    obtain ⟨l, r⟩ := h
+    have : (x₁, y₁) = (x₂, y₂) := l.symm.trans r
+    simp only [Prod.ext_iff] at this l
+    rw [Fintype.sum_eq_single ⟨⟨x₁, x₂⟩, ⟨y₁, y₂⟩⟩]
+    · simp_all only [and_self]
+      obtain ⟨left, right⟩ := this
+      subst left right
+      rw [Fintype.sum_eq_single ⟨x, x, ⟨y, y⟩⟩]
+      · simp_all
+        sorry
+      · sorry
+    · sorry
+  next h =>
+    simp_all only [not_and, NNReal.coe_zero]
+    sorry
 
 /-- Tensor coherence for discard. -/
 lemma discard_tensor_eq (X Y : FinStoch) :
     ε[X ⊗ Y] = (ε[X] ⊗ₘ ε[Y]) ≫ (λ_ (𝟙_ FinStoch)).hom := by
-  sorry -- Proof details
+  apply StochasticMatrix.ext
+  ext ⟨x, y⟩ unitor_fs
+  simp_all only [counit, discard, NNReal.coe_one, CategoryStruct.comp, StochasticMatrix.comp,
+    tensorHom, StochasticMatrix.tensor, mul_one, MonoidalCategoryStruct.leftUnitor, leftUnitor,
+    DetMorphism.toMatrix_apply, mul_ite, mul_zero, Finset.sum_boole, NNReal.coe_natCast]
+  norm_cast
 
 /-- Copy on unit equals left unitor inverse. -/
 lemma copy_unit_eq : Δ[𝟙_ FinStoch] = (λ_ (𝟙_ FinStoch)).inv := by
-  sorry -- Proof details
+  apply StochasticMatrix.ext
+  ext ⟨⟩ ⟨⟨⟩, ⟨⟩⟩
+  simp only [comul, copy, MonoidalCategoryStruct.leftUnitor]
+  simp only [and_self, ↓reduceIte, NNReal.coe_one]
+  rfl
 
 /-- Discard on unit is identity. -/
 lemma discard_unit_eq : ε[𝟙_ FinStoch] = 𝟙 (𝟙_ FinStoch) := by
-  sorry -- Proof details
+  apply StochasticMatrix.ext
+  ext ⟨⟩ ⟨⟩
+  simp only [ComonObj.counit, discard, CategoryStruct.id, StochasticMatrix.id]
+  rfl
 
 /-- FinStoch has copy-discard structure. -/
 instance : CopyDiscardCategory FinStoch where
   -- commComonObj uses inferInstance by default, which finds our instances above
-  copy_tensor X Y := copy_tensor_eq X Y
-  discard_tensor X Y := discard_tensor_eq X Y
+  copy_tensor := copy_tensor_eq
+  discard_tensor := discard_tensor_eq
   copy_unit := copy_unit_eq
   discard_unit := discard_unit_eq
 

--- a/Mathlib/CategoryTheory/MarkovCategory/FinStoch/CopyDiscard.lean
+++ b/Mathlib/CategoryTheory/MarkovCategory/FinStoch/CopyDiscard.lean
@@ -170,9 +170,55 @@ instance (X : FinStoch) : ComonObj X where
           intro a; subst a
           intro a; subst a
           simp_all only [not_true_eq_false]
-    · -- Case when not all equal
-      simp_all only [not_and]
-      sorry
+    · -- Case when not all equal: both sides are 0
+      -- Show both sums equal 0
+      push_neg at h
+      -- Left side
+      trans 0
+      · rw [Fintype.sum_eq_zero]
+        intro ⟨k₁, k₂⟩
+        simp only
+        split_ifs with h1 h2 h3
+        · -- All conditions hold: k₁=j₁, k₂=j₂=j₃, i=k₁=k₂
+          -- This means i=j₁=j₂=j₃, contradicting h
+          subst h1
+          obtain ⟨h2a, h2b⟩ := h2
+          subst h2a h2b
+          obtain ⟨h3a, h3b⟩ := h3
+          subst h3a h3b
+          simp only [NNReal.coe_one]
+          exfalso
+          exact (h rfl rfl) rfl
+        · simp only [NNReal.coe_zero]
+        · simp only [NNReal.coe_zero]
+        · simp only [NNReal.coe_zero]
+      -- Right side
+      · symm
+        rw [Fintype.sum_eq_zero]
+        intro ⟨k₁, k₂⟩
+        simp only
+        by_cases hk : i = k₁ ∧ i = k₂
+        · -- First copy gives 1, show second sum is 0
+          simp only [hk]
+          obtain ⟨h1, h2⟩ := hk
+          subst h1 h2
+          simp only [and_self, if_true, NNReal.coe_one, one_mul]
+          rw [Fintype.sum_eq_zero]
+          intro ⟨⟨m₁, m₂⟩, m₃⟩
+          simp only
+          split_ifs with h_eq h_m3 h_m12
+          · -- All hold: (m₁,m₂,m₃)=(j₁,j₂,j₃), i=m₃, i=m₁=m₂
+            simp only at h_eq
+            simp_all only [ne_eq, NNReal.coe_one, one_ne_zero]
+            subst h_m3
+            obtain ⟨left, right⟩ := h_m12
+            subst right left
+            grind only
+          · simp only [NNReal.coe_zero]
+          · simp only [NNReal.coe_zero]
+          · simp only [NNReal.coe_zero]
+        · -- First copy gives 0
+          simp only [hk, if_false, NNReal.coe_zero, zero_mul]
 
 /-- The comonoid structure in FinStoch is commutative. -/
 instance (X : FinStoch) : CommComonObj X where
@@ -220,50 +266,6 @@ instance (X : FinStoch) : CommComonObj X where
         exact hne rfl
       · simp
 
-/-- Tensor coherence for copy. -/
-lemma copy_tensor_eq (X Y : FinStoch) :
-    Δ[X ⊗ Y] = (Δ[X] ⊗ₘ Δ[Y]) ≫ tensorμ X X Y Y := by
-  -- Δ[X ⊗ Y] maps (x,y) to ((x,y), (x,y))
-  -- (Δ[X] ⊗ Δ[Y]) maps (x,y) to ((x,x), (y,y))
-  -- tensorμ rearranges ((x,x), (y,y)) to ((x,y), (x,y))
-  apply StochasticMatrix.ext
-  ext ⟨x, y⟩ ⟨⟨x₁, y₁⟩, ⟨x₂, y₂⟩⟩
-  simp_all only [comul, copy, CategoryStruct.comp, StochasticMatrix.comp, tensorHom,
-    StochasticMatrix.tensor, NNReal.coe_sum, NNReal.coe_mul, tensorμ, MonoidalCategory.associator,
-    BraidedCategory.braiding, associator, associatorDet, DetMorphism.ofFunc, whiskerLeft,
-    DetMorphism.toMatrix_apply, id_matrix]
-  -- LHS: Δ[X ⊗ Y] gives 1 iff (x,y) = (x₁,y₁) = (x₂,y₂)
-  -- RHS: composition through tensorμ
-  -- The sum over intermediate states
-  split
-  next h =>
-    simp_all only [NNReal.coe_one]
-    obtain ⟨l, r⟩ := h
-    have : (x₁, y₁) = (x₂, y₂) := l.symm.trans r
-    simp only [Prod.ext_iff] at this l
-    rw [Fintype.sum_eq_single ⟨⟨x₁, x₂⟩, ⟨y₁, y₂⟩⟩]
-    · simp_all only [and_self]
-      obtain ⟨left, right⟩ := this
-      subst left right
-      rw [Fintype.sum_eq_single ⟨x, x, ⟨y, y⟩⟩]
-      · simp_all
-        sorry
-      · sorry
-    · sorry
-  next h =>
-    simp_all only [not_and, NNReal.coe_zero]
-    sorry
-
-/-- Tensor coherence for discard. -/
-lemma discard_tensor_eq (X Y : FinStoch) :
-    ε[X ⊗ Y] = (ε[X] ⊗ₘ ε[Y]) ≫ (λ_ (𝟙_ FinStoch)).hom := by
-  apply StochasticMatrix.ext
-  ext ⟨x, y⟩ unitor_fs
-  simp_all only [counit, discard, NNReal.coe_one, CategoryStruct.comp, StochasticMatrix.comp,
-    tensorHom, StochasticMatrix.tensor, mul_one, MonoidalCategoryStruct.leftUnitor, leftUnitor,
-    DetMorphism.toMatrix_apply, mul_ite, mul_zero, Finset.sum_boole, NNReal.coe_natCast]
-  norm_cast
-
 /-- Copy on unit equals left unitor inverse. -/
 lemma copy_unit_eq : Δ[𝟙_ FinStoch] = (λ_ (𝟙_ FinStoch)).inv := by
   apply StochasticMatrix.ext
@@ -282,8 +284,8 @@ lemma discard_unit_eq : ε[𝟙_ FinStoch] = 𝟙 (𝟙_ FinStoch) := by
 /-- FinStoch has copy-discard structure. -/
 instance : CopyDiscardCategory FinStoch where
   -- commComonObj uses inferInstance by default, which finds our instances above
-  copy_tensor := copy_tensor_eq
-  discard_tensor := discard_tensor_eq
+  copy_tensor := by simp only [Comon.tensorObj_comul, implies_true]
+  discard_tensor := by simp only [Comon.tensorObj_counit, implies_true]
   copy_unit := copy_unit_eq
   discard_unit := discard_unit_eq
 

--- a/Mathlib/CategoryTheory/MarkovCategory/FinStoch/Markov.lean
+++ b/Mathlib/CategoryTheory/MarkovCategory/FinStoch/Markov.lean
@@ -1,0 +1,69 @@
+/-
+Copyright (c) 2025 Jacob Reinhold. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Jacob Reinhold
+-/
+import Mathlib.CategoryTheory.MarkovCategory.FinStoch.CopyDiscard
+import Mathlib.CategoryTheory.MarkovCategory.Basic
+
+/-!
+# FinStoch as a Markov Category
+
+FinStoch forms a Markov category where discard is natural for all morphisms.
+
+## Main results
+
+* `MarkovCategory FinStoch` - FinStoch is a Markov category
+* `copy_not_natural` - Copy is not natural (proof that FinStoch is not cartesian)
+
+## Implementation notes
+
+Discard naturality follows from probability normalization: all stochastic matrices have row sums equal to 1.
+
+## Tags
+
+Markov category, natural transformation, probabilistic
+-/
+
+namespace CategoryTheory.MarkovCategory
+
+open FinStoch MonoidalCategory ComonObj
+
+universe u
+
+/-- FinStoch is a Markov category. -/
+instance : MarkovCategory FinStoch where
+  discard_natural f := by
+    -- Discard is natural because probabilities sum to 1
+    apply StochasticMatrix.ext
+    ext i u
+    simp only [CategoryStruct.comp, StochasticMatrix.comp, ComonObj.counit, discard]
+    simp [f.row_sum]
+
+/-- Copy is not natural in FinStoch. -/
+theorem copy_not_natural : ∃ (X Y : FinStoch) (f : X ⟶ Y),
+    f ≫ Δ[Y] ≠ Δ[X] ≫ (f ⊗ₘ f) := by
+  -- Coin flip example
+  let X : FinStoch := { carrier := Unit, fintype := inferInstance, decidableEq := inferInstance }
+  let Y : FinStoch := { carrier := Bool, fintype := inferInstance, decidableEq := inferInstance }
+  use X, Y
+  -- Uniform: P(true|()) = P(false|()) = 1/2
+  let f : X ⟶ Y := {
+    toMatrix := fun _ b => (1 : NNReal) / 2
+    row_sum := fun _ => by
+      simp only [Finset.sum_const, Finset.card_univ]
+      rw [Fintype.card_bool]
+      norm_num
+  }
+  use f
+  intro h
+  have : (f ≫ Δ[Y]).toMatrix (() : Unit) ((true : Bool), (false : Bool)) =
+         (Δ[X] ≫ (f ⊗ₘ f)).toMatrix (() : Unit) ((true : Bool), (false : Bool)) := by
+    rw [h]
+  simp only [CategoryStruct.comp, StochasticMatrix.comp, ComonObj.comul, copy,
+             MonoidalCategoryStruct.tensorHom, StochasticMatrix.tensor] at this
+  -- Left: f then copy gives 0 (can't be in two different states)
+  -- Right: copy then f⊗f gives 1/4 (independent coin flips)
+  sorry -- Proof details
+
+end CategoryTheory.MarkovCategory

--- a/Mathlib/CategoryTheory/MarkovCategory/FinStoch/Markov.lean
+++ b/Mathlib/CategoryTheory/MarkovCategory/FinStoch/Markov.lean
@@ -38,8 +38,7 @@ instance : MarkovCategory FinStoch where
     -- Discard is natural because probabilities sum to 1
     apply StochasticMatrix.ext
     ext i u
-    simp only [CategoryStruct.comp, StochasticMatrix.comp, ComonObj.counit, discard]
-    simp [f.row_sum]
+    simp [CategoryStruct.comp, StochasticMatrix.comp, ComonObj.counit, discard, f.row_sum]
 
 /-- Copy is not natural in FinStoch. -/
 theorem copy_not_natural : ∃ (X Y : FinStoch) (f : X ⟶ Y),
@@ -52,7 +51,7 @@ theorem copy_not_natural : ∃ (X Y : FinStoch) (f : X ⟶ Y),
   let f : X ⟶ Y := {
     toMatrix := fun _ b => (1 : NNReal) / 2
     row_sum := fun _ => by
-      simp only [Finset.sum_const, Finset.card_univ]
+      simp
       rw [Fintype.card_bool]
       norm_num
   }
@@ -67,13 +66,9 @@ theorem copy_not_natural : ∃ (X Y : FinStoch) (f : X ⟶ Y),
   have left_zero : (∑ x, f.toMatrix () x * if x = true ∧ x = false then 1 else 0) = 0 := by
     simp only [Finset.sum_eq_zero_iff]
     intro x _
-    simp only [mul_ite, mul_one, mul_zero]
-    -- The condition x = true ∧ x = false is never true
-    simp only [ite_eq_right_iff]
+    simp
     intro h
-    simp_all only [one_div, instTensorUnit_comul, Fintype.univ_bool, Bool.eq_true_and_eq_false_self,
-      ↓reduceIte, mul_zero, Finset.sum_const_zero, and_self, Finset.mem_insert,
-      Finset.mem_singleton, Bool.true_eq_false, or_false, X, Y, f]
+    simp_all [instTensorUnit_comul, X, Y, f]
   -- Left: f then copy gives 0 (can't be in two different states)
   -- Right: copy then f⊗f gives 1/4 (independent coin flips)
   rw [left_zero] at this

--- a/Mathlib/CategoryTheory/MarkovCategory/FinStoch/Markov.lean
+++ b/Mathlib/CategoryTheory/MarkovCategory/FinStoch/Markov.lean
@@ -10,16 +10,20 @@ import Mathlib.CategoryTheory.MarkovCategory.Basic
 # FinStoch as a Markov Category
 
 FinStoch forms a Markov category where discard is natural for all morphisms.
+This is the key property distinguishing Markov categories from cartesian categories.
 
 ## Main results
 
 * `MarkovCategory FinStoch` - FinStoch is a Markov category
 * `copy_not_natural` - Copy is not natural (proof that FinStoch is not cartesian)
 
-## Implementation notes
+## Mathematical interpretation
 
-Discard naturality follows from probability normalization: all stochastic matrices have row sums
-equal to 1.
+Discard naturality means marginalization commutes with stochastic maps.
+This follows from probability normalization: ∑_y P(y|x) = 1.
+
+Copy non-naturality shows that duplicating before vs after a random process
+gives different results. The coin flip example demonstrates this concretely.
 
 ## Tags
 
@@ -35,19 +39,20 @@ universe u
 /-- FinStoch is a Markov category. -/
 instance : MarkovCategory FinStoch where
   discard_natural f := by
-    -- Discard is natural because probabilities sum to 1
+    -- Naturality: f ≫ ε = ε because ∑_y f(y|x) = 1
     apply StochasticMatrix.ext
     ext i u
     simp [CategoryStruct.comp, StochasticMatrix.comp, ComonObj.counit, discard, f.row_sum]
 
-/-- Copy is not natural in FinStoch. -/
+/-- Copy is not natural in FinStoch.
+Counterexample: fair coin flip from a deterministic state. -/
 theorem copy_not_natural : ∃ (X Y : FinStoch) (f : X ⟶ Y),
     f ≫ Δ[Y] ≠ Δ[X] ≫ (f ⊗ₘ f) := by
-  -- Coin flip example
+  -- Counterexample: fair coin flip
   let X : FinStoch := { carrier := Unit, fintype := inferInstance, decidableEq := inferInstance }
   let Y : FinStoch := { carrier := Bool, fintype := inferInstance, decidableEq := inferInstance }
   use X, Y
-  -- Uniform: P(true|()) = P(false|()) = 1/2
+  -- Fair coin: P(true|*) = P(false|*) = 1/2
   let f : X ⟶ Y := {
     toMatrix := fun _ b => (1 : NNReal) / 2
     row_sum := fun _ => by
@@ -57,28 +62,26 @@ theorem copy_not_natural : ∃ (X Y : FinStoch) (f : X ⟶ Y),
   }
   use f
   intro h
+  -- Compare at output (true, false)
   have : (f ≫ Δ[Y]).toMatrix (() : Unit) ((true : Bool), (false : Bool)) =
          (Δ[X] ≫ (f ⊗ₘ f)).toMatrix (() : Unit) ((true : Bool), (false : Bool)) := by
     rw [h]
   simp only [CategoryStruct.comp, StochasticMatrix.comp, ComonObj.comul, copy,
              MonoidalCategoryStruct.tensorHom, StochasticMatrix.tensor] at this
-  -- Simplify the left side first
+  -- Left path: flip then copy gives P(true,false) = 0 (can't be in both states)
   have left_zero : (∑ x, f.toMatrix () x * if x = true ∧ x = false then 1 else 0) = 0 := by
     simp only [Finset.sum_eq_zero_iff]
     intro x _
     simp
     intro h
     simp_all [instTensorUnit_comul, X, Y, f]
-  -- Left: f then copy gives 0 (can't be in two different states)
-  -- Right: copy then f⊗f gives 1/4 (independent coin flips)
   rw [left_zero] at this
-    -- If the right side has any non-zero terms, we get contradiction
-  -- For example, if the sum includes a term where j₁ = j₂ = ()
+  -- Right path: copy then flip⊗flip gives P(true,false) = 1/4 (independent flips)
   have right_nonzero : (∑ x, (match x with | (j₁, j₂) => if () = j₁ ∧ () = j₂ then 1 else 0) *
     (f.toMatrix x.1 true * f.toMatrix x.2 false)) ≠ 0 := by
-    -- Show there's at least one non-zero term
+    -- The term at ((),()) contributes: 1 * (1/2 * 1/2) = 1/4 ≠ 0
     norm_num
-  -- Contradiction: 0 ≠ 0
+  -- Contradiction: 0 = 1/4
   exact right_nonzero this.symm
 
 end CategoryTheory.MarkovCategory

--- a/Mathlib/CategoryTheory/MarkovCategory/FinStoch/Markov.lean
+++ b/Mathlib/CategoryTheory/MarkovCategory/FinStoch/Markov.lean
@@ -18,7 +18,8 @@ FinStoch forms a Markov category where discard is natural for all morphisms.
 
 ## Implementation notes
 
-Discard naturality follows from probability normalization: all stochastic matrices have row sums equal to 1.
+Discard naturality follows from probability normalization: all stochastic matrices have row sums
+equal to 1.
 
 ## Tags
 
@@ -62,8 +63,27 @@ theorem copy_not_natural : ∃ (X Y : FinStoch) (f : X ⟶ Y),
     rw [h]
   simp only [CategoryStruct.comp, StochasticMatrix.comp, ComonObj.comul, copy,
              MonoidalCategoryStruct.tensorHom, StochasticMatrix.tensor] at this
+  -- Simplify the left side first
+  have left_zero : (∑ x, f.toMatrix () x * if x = true ∧ x = false then 1 else 0) = 0 := by
+    simp only [Finset.sum_eq_zero_iff]
+    intro x _
+    simp only [mul_ite, mul_one, mul_zero]
+    -- The condition x = true ∧ x = false is never true
+    simp only [ite_eq_right_iff]
+    intro h
+    simp_all only [one_div, instTensorUnit_comul, Fintype.univ_bool, Bool.eq_true_and_eq_false_self,
+      ↓reduceIte, mul_zero, Finset.sum_const_zero, and_self, Finset.mem_insert,
+      Finset.mem_singleton, Bool.true_eq_false, or_false, X, Y, f]
   -- Left: f then copy gives 0 (can't be in two different states)
   -- Right: copy then f⊗f gives 1/4 (independent coin flips)
-  sorry -- Proof details
+  rw [left_zero] at this
+    -- If the right side has any non-zero terms, we get contradiction
+  -- For example, if the sum includes a term where j₁ = j₂ = ()
+  have right_nonzero : (∑ x, (match x with | (j₁, j₂) => if () = j₁ ∧ () = j₂ then 1 else 0) *
+    (f.toMatrix x.1 true * f.toMatrix x.2 false)) ≠ 0 := by
+    -- Show there's at least one non-zero term
+    norm_num
+  -- Contradiction: 0 ≠ 0
+  exact right_nonzero this.symm
 
 end CategoryTheory.MarkovCategory

--- a/Mathlib/CategoryTheory/MarkovCategory/FinStoch/Monoidal.lean
+++ b/Mathlib/CategoryTheory/MarkovCategory/FinStoch/Monoidal.lean
@@ -9,18 +9,11 @@ import Mathlib.CategoryTheory.Monoidal.Category
 /-!
 # Monoidal Structure on FinStoch
 
-This file defines the monoidal category structure on `FinStoch`, showing that
-finite stochastic matrices form a symmetric monoidal category.
+Defines the monoidal category structure on `FinStoch`.
 
-## Mathematical perspective
-
-The monoidal structure on FinStoch models parallel composition of random processes.
-The tensor product runs two random processes independently. The structural
-isomorphisms (associator, unitors) preserve outcomes regardless of grouping.
-
-All structural isomorphisms are deterministic; they rearrange data without
-adding randomness. Thus the categorical structure preserves information;
-only morphisms within the category add randomness.
+The tensor product models parallel composition of random processes.
+Structural isomorphisms (associator, unitors) rearrange data without
+adding randomness - they are deterministic.
 
 ## Main definitions
 
@@ -32,38 +25,11 @@ only morphisms within the category add randomness.
 
 ## Implementation notes
 
-### Deterministic structural maps
-
 We build structural isomorphisms using explicit stochastic matrices that
-give probability 1 to the right rearrangement and 0 elsewhere. This
-makes them deterministic in the Markov category sense (preserve copying).
+give probability 1 to the correct rearrangement and 0 elsewhere.
 
-### Proof strategy
-
-The proofs follow this pattern:
-1. Use `Finset.sum_eq_single` to isolate the unique non-zero contribution
-2. Handle the exceptional cases (which contribute 0)
-3. For inverse proofs, use `ite_cond_congr` to align tuple equality conditions
-
-The `ite_cond_congr` technique works around Lean distinguishing between
-`x = x'` and `((), x) = ((), x')` as propositions, though they're logically
-the same. This rewriting makes the if-then-else conditions match.
-
-### Coherence proofs
-
-All naturality and coherence conditions are proven:
-- Naturality: Structural maps commute with arbitrary morphisms
-- Pentagon/triangle: Mac Lane's coherence conditions hold
-
-The proofs track composition using sums.
-
-## Design rationale
-
-We build structural isomorphisms explicitly rather than deriving them
-from a product structure because:
-1. It shows they're deterministic
-2. It matches actual computation
-3. It provides concrete foundations for the Markov category instance
+Proofs use `Finset.sum_eq_single` to isolate non-zero contributions.
+For inverse proofs, we use `ite_cond_congr` to handle tuple equality.
 
 ## References
 
@@ -81,11 +47,9 @@ open FinStoch
 
 universe u
 
-/-- The associator isomorphism rearranges `((X ⊗ Y) ⊗ Z)` to `(X ⊗ (Y ⊗ Z))`.
+/-- Rearranges `((X ⊗ Y) ⊗ Z)` to `(X ⊗ (Y ⊗ Z))`.
 
-This map sends `((x,y),z) ↦ (x,(y,z))` with probability 1. It only changes
-the tuple structure, not the data. This proves that grouping doesn't affect
-the outcome when we compose three processes in parallel. -/
+Sends `((x,y),z) ↦ (x,(y,z))` with probability 1. -/
 def associator (X Y Z : FinStoch) :
     (tensorObj (tensorObj X Y) Z) ≅ (tensorObj X (tensorObj Y Z)) where
   hom := ⟨fun ⟨⟨x, y⟩, z⟩ ⟨x', ⟨y', z'⟩⟩ =>
@@ -273,7 +237,7 @@ def leftUnitor (X : FinStoch) : (tensorObj tensorUnit X) ≅ X where
       · -- Case: ((), x) ≠ ((), x')
         simp only [Prod.mk.injEq, true_and] at h
         push_neg at h
-        -- First match gives 0 because x ≠ x'
+        -- Zero when x ≠ x'
         simp only [h, if_false, zero_mul]
     · intro h
       exfalso
@@ -358,7 +322,7 @@ def rightUnitor (X : FinStoch) : (tensorObj X tensorUnit) ≅ X where
       · -- Case: (x, ()) ≠ (x', ())
         simp only [Prod.mk.injEq, and_true] at h
         push_neg at h
-        -- First match gives 0 because x ≠ x'
+        -- Zero when x ≠ x'
         simp only [h, if_false, zero_mul]
     · intro h
       exfalso

--- a/Mathlib/CategoryTheory/MarkovCategory/FinStoch/Monoidal.lean
+++ b/Mathlib/CategoryTheory/MarkovCategory/FinStoch/Monoidal.lean
@@ -1,0 +1,1001 @@
+/-
+Copyright (c) 2025 Jacob Reinhold. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Jacob Reinhold
+-/
+import Mathlib.CategoryTheory.MarkovCategory.FinStoch.Basic
+import Mathlib.CategoryTheory.Monoidal.Category
+
+/-!
+# Monoidal Structure on FinStoch
+
+This file defines the monoidal category structure on `FinStoch`, showing that
+finite stochastic matrices form a symmetric monoidal category.
+
+## Mathematical perspective
+
+The monoidal structure on FinStoch models parallel composition of random processes.
+The tensor product runs two random processes independently. The structural
+isomorphisms (associator, unitors) preserve outcomes regardless of grouping.
+
+All structural isomorphisms are deterministic; they rearrange data without
+adding randomness. Thus the categorical structure preserves information;
+only morphisms within the category add randomness.
+
+## Main definitions
+
+* `associator` - The associativity isomorphism `(X ⊗ Y) ⊗ Z ≅ X ⊗ (Y ⊗ Z)`
+* `leftUnitor` - The left unit isomorphism `I ⊗ X ≅ X`
+* `rightUnitor` - The right unit isomorphism `X ⊗ I ≅ X`
+* `MonoidalCategoryStruct FinStoch` - The basic monoidal structure
+* `MonoidalCategory FinStoch` - Full monoidal category with coherence conditions
+
+## Implementation notes
+
+### Deterministic structural maps
+
+We build structural isomorphisms using explicit stochastic matrices that
+give probability 1 to the right rearrangement and 0 elsewhere. This
+makes them deterministic in the Markov category sense (preserve copying).
+
+### Proof strategy
+
+The proofs follow this pattern:
+1. Use `Finset.sum_eq_single` to isolate the unique non-zero contribution
+2. Handle the exceptional cases (which contribute 0)
+3. For inverse proofs, use `ite_cond_congr` to align tuple equality conditions
+
+The `ite_cond_congr` technique works around Lean distinguishing between
+`x = x'` and `((), x) = ((), x')` as propositions, though they're logically
+the same. This rewriting makes the if-then-else conditions match.
+
+### Coherence proofs
+
+All naturality and coherence conditions are proven:
+- Naturality: Structural maps commute with arbitrary morphisms
+- Pentagon/triangle: Mac Lane's coherence conditions hold
+
+The proofs track composition using sums.
+
+## Design rationale
+
+We build structural isomorphisms explicitly rather than deriving them
+from a product structure because:
+1. It shows they're deterministic
+2. It matches actual computation
+3. It provides concrete foundations for the Markov category instance
+
+## References
+
+* [Fritz, *A synthetic approach to Markov kernels, conditional independence
+  and theorems on sufficient statistics*][fritz2020]
+
+## Tags
+
+Markov category, monoidal category, stochastic matrix, tensor product
+-/
+
+namespace CategoryTheory.MarkovCategory
+
+open FinStoch
+
+universe u
+
+/-- The associator isomorphism rearranges `((X ⊗ Y) ⊗ Z)` to `(X ⊗ (Y ⊗ Z))`.
+
+This map sends `((x,y),z) ↦ (x,(y,z))` with probability 1. It only changes
+the tuple structure, not the data. This proves that grouping doesn't affect
+the outcome when we compose three processes in parallel. -/
+def associator (X Y Z : FinStoch) :
+    (tensorObj (tensorObj X Y) Z) ≅ (tensorObj X (tensorObj Y Z)) where
+  hom := ⟨fun ⟨⟨x, y⟩, z⟩ ⟨x', ⟨y', z'⟩⟩ =>
+    if x = x' ∧ y = y' ∧ z = z' then 1 else 0, fun ⟨⟨x, y⟩, z⟩ => by
+    -- The output (x,(y,z)) has probability 1, all others have 0
+    rw [Finset.sum_eq_single ⟨x, ⟨y, z⟩⟩]
+    · simp only [and_self, if_true]
+    · -- Other outputs have probability 0
+      intro b _ hb
+      obtain ⟨x', ⟨y', z'⟩⟩ := b
+      simp only
+      split_ifs with h
+      · -- Can't match if b ≠ target
+        obtain ⟨h1, h2, h3⟩ := h
+        exfalso
+        apply hb
+        congr 1
+        · exact h1.symm
+        · congr 1
+          · exact h2.symm
+          · exact h3.symm
+      · rfl
+    · intro h; exfalso; exact h (Finset.mem_univ _)⟩
+  inv := ⟨fun ⟨x, ⟨y, z⟩⟩ ⟨⟨x', y'⟩, z'⟩ =>
+    if x = x' ∧ y = y' ∧ z = z' then 1 else 0, fun ⟨x, ⟨y, z⟩⟩ => by
+    -- Inverse map: (x,(y,z)) ↦ ((x,y),z)
+    rw [Finset.sum_eq_single ⟨⟨x, y⟩, z⟩]
+    · simp only [and_self, if_true]
+    · intro b _ hb
+      obtain ⟨⟨x', y'⟩, z'⟩ := b
+      simp only
+      split_ifs with h
+      · exfalso
+        obtain ⟨h1, h2, h3⟩ := h
+        apply hb
+        congr 1
+        · congr 1
+          · exact h1.symm
+          · exact h2.symm
+        · exact h3.symm
+      · rfl
+    · intro h; exfalso; exact h (Finset.mem_univ _)⟩
+  hom_inv_id := by
+    apply StochasticMatrix.ext
+    ext ⟨⟨x, y⟩, z⟩ ⟨⟨x', y'⟩, z'⟩
+    simp only [CategoryStruct.comp, StochasticMatrix.comp]
+    -- Round trip: ((x,y),z) → (x,(y,z)) → ((x,y),z)
+    rw [Finset.sum_eq_single ⟨x, ⟨y, z⟩⟩]
+    · simp only [and_self, if_true, one_mul]
+      simp only [StochasticMatrix.id, CategoryStruct.id]
+      by_cases h : ((x, y), z) = ((x', y'), z')
+      · simp [h]
+        obtain ⟨⟨rfl, rfl⟩, rfl⟩ := h
+        simp [and_self]
+      · simp [h]
+        push_neg at h
+        simp [Prod.mk.injEq] at h
+        exact h
+    · -- Other intermediate states contribute 0
+      intro b _ hb
+      obtain ⟨x₁, ⟨y₁, z₁⟩⟩ := b
+      simp only
+      split_ifs with h h2
+      · -- Would contradict hb
+        obtain ⟨rfl, rfl, rfl⟩ := h
+        exfalso
+        exact hb rfl
+      · -- Would contradict hb
+        obtain ⟨rfl, rfl, rfl⟩ := h
+        exfalso
+        exact hb rfl
+      · -- Zero probability path
+        simp only [zero_mul]
+      · -- Zero probability path
+        simp only [zero_mul]
+    · -- State must exist in finite type
+      intro h
+      exfalso
+      exact h (Finset.mem_univ _)
+  inv_hom_id := by
+    apply StochasticMatrix.ext
+    ext ⟨x, ⟨y, z⟩⟩ ⟨x', ⟨y', z'⟩⟩
+    simp only [CategoryStruct.comp, StochasticMatrix.comp]
+    -- Round trip: (x,(y,z)) → ((x,y),z) → (x,(y,z))
+    rw [Finset.sum_eq_single ⟨⟨x, y⟩, z⟩]
+    · simp only [and_self, if_true, one_mul]
+      simp only [StochasticMatrix.id, CategoryStruct.id]
+      by_cases h : (x, (y, z)) = (x', (y', z'))
+      · simp [h]
+        obtain ⟨rfl, ⟨rfl, rfl⟩⟩ := h
+        simp [and_self]
+      · simp [h]
+        push_neg at h
+        simp [Prod.mk.injEq] at h
+        exact h
+    · intro b _ hb
+      obtain ⟨⟨x₁, y₁⟩, z₁⟩ := b
+      simp only
+      split_ifs with h h2
+      · obtain ⟨rfl, rfl, rfl⟩ := h
+        exfalso
+        exact hb rfl
+      · obtain ⟨rfl, rfl, rfl⟩ := h
+        exfalso
+        exact hb rfl
+      · simp only [zero_mul]
+      · simp only [zero_mul]
+    · intro h; exfalso; exact h (Finset.mem_univ _)
+
+/-- The left unitor removes the trivial left factor from `I ⊗ X` to get `X`.
+
+This maps `((),x) ↦ x` with probability 1. The unit carries no information,
+so removing it doesn't change the data. The monoidal unit is singleton
+because it cannot hold information. -/
+def leftUnitor (X : FinStoch) : (tensorObj tensorUnit X) ≅ X where
+  hom := ⟨fun ⟨⟨⟩, x⟩ x' => if x = x' then 1 else 0, fun ⟨⟨⟩, x⟩ => by
+    rw [Finset.sum_eq_single x]
+    · simp only [if_true]
+    · intro x' _ hx'
+      simp only
+      split_ifs with h
+      · exfalso
+        exact hx' h.symm
+      · rfl
+    · intro h
+      exfalso
+      apply h
+      exact Finset.mem_univ _⟩
+  inv := ⟨fun x ⟨⟨⟩, x'⟩ => if x = x' then 1 else 0, fun x => by
+    rw [Finset.sum_eq_single ⟨⟨⟩, x⟩]
+    · simp only [if_true]
+    · intro b _ hb
+      obtain ⟨⟨⟩, x'⟩ := b
+      simp only
+      split_ifs with h
+      · exfalso
+        apply hb
+        congr 1
+        exact h.symm
+      · rfl
+    · intro h
+      exfalso
+      apply h
+      exact Finset.mem_univ _⟩
+  hom_inv_id := by
+    apply StochasticMatrix.ext
+    ext ⟨⟨⟩, x⟩ ⟨⟨⟩, x'⟩
+    simp only [CategoryStruct.comp, StochasticMatrix.comp]
+    -- Round trip: ((),x) → x → ((),x)
+    rw [Finset.sum_eq_single x]
+    · simp only [if_true, one_mul]
+      simp only [StochasticMatrix.id, CategoryStruct.id]
+      -- Align equality conditions: x = x' ↔ ((),x) = ((),x')
+      have h : (x = x') = (((), x) = ((), x')) := by
+        simp only [Prod.mk.injEq, true_and]
+      rw [ite_cond_congr h]
+    · intro x' _ hx'
+      split_ifs with h
+      · exfalso
+        exact hx' (h.symm)
+      · rw [mul_zero]
+      · rw [zero_mul]
+      · rw [mul_zero]
+    · intro h
+      exfalso
+      apply h
+      exact Finset.mem_univ _
+  inv_hom_id := by
+    apply StochasticMatrix.ext
+    ext x
+    simp only [CategoryStruct.comp, StochasticMatrix.comp]
+    rw [Finset.sum_eq_single ⟨⟨⟩, x⟩]
+    · simp only [if_true, one_mul]
+      simp only [StochasticMatrix.id, CategoryStruct.id]
+    · intro b _ hb
+      obtain ⟨⟨⟩, x'⟩ := b
+      by_cases h : ((), x) = ((), x')
+      · -- Case: ((), x) = ((), x')
+        simp only [Prod.mk.injEq, true_and] at h
+        subst h
+        simp only [if_true, one_mul]
+        exfalso
+        apply hb
+        rfl
+      · -- Case: ((), x) ≠ ((), x')
+        simp only [Prod.mk.injEq, true_and] at h
+        push_neg at h
+        -- First match gives 0 because x ≠ x'
+        simp only [h, if_false, zero_mul]
+    · intro h
+      exfalso
+      apply h
+      exact Finset.mem_univ _
+
+/-- The right unitor removes the trivial right factor from `X ⊗ I` to get `X`.
+
+This maps `(x,()) ↦ x` with probability 1. The unit carries no information,
+so removing it doesn't change the data. The symmetry with the left unitor shows
+tensor products have no preferred order. -/
+def rightUnitor (X : FinStoch) : (tensorObj X tensorUnit) ≅ X where
+  hom := ⟨fun ⟨x, ⟨⟩⟩ x' => if x = x' then 1 else 0, fun ⟨x, ⟨⟩⟩ => by
+    rw [Finset.sum_eq_single x]
+    · simp only [if_true]
+    · intro x' _ hx'
+      simp only
+      split_ifs with h
+      · exfalso
+        exact hx' h.symm
+      · rfl
+    · intro h
+      exfalso
+      apply h
+      exact Finset.mem_univ _⟩
+  inv := ⟨fun x ⟨x', ⟨⟩⟩ => if x = x' then 1 else 0, fun x => by
+    rw [Finset.sum_eq_single ⟨x, ⟨⟩⟩]
+    · simp only [if_true]
+    · intro b _ hb
+      obtain ⟨x', ⟨⟩⟩ := b
+      simp only
+      split_ifs with h
+      · exfalso
+        apply hb
+        congr 1
+        exact h.symm
+      · rfl
+    · intro h
+      exfalso
+      apply h
+      exact Finset.mem_univ _⟩
+  hom_inv_id := by
+    apply StochasticMatrix.ext
+    ext ⟨x, ⟨⟩⟩ ⟨x', ⟨⟩⟩
+    simp only [CategoryStruct.comp, StochasticMatrix.comp]
+    -- Round trip: (x,()) → x → (x,())
+    rw [Finset.sum_eq_single x]
+    · simp only [if_true, one_mul]
+      simp only [StochasticMatrix.id, CategoryStruct.id]
+      -- Align equality conditions: x = x' ↔ (x,()) = (x',())
+      have h : (x = x') = ((x, ()) = (x', ())) := by
+        simp only [Prod.mk.injEq, and_true]
+      rw [ite_cond_congr h]
+    · intro x' _ hx'
+      split_ifs with h
+      · exfalso
+        exact hx' (h.symm)
+      · rw [mul_zero]
+      · rw [zero_mul]
+      · rw [zero_mul]
+    · intro h
+      exfalso
+      apply h
+      exact Finset.mem_univ _
+  inv_hom_id := by
+    apply StochasticMatrix.ext
+    ext x
+    simp only [CategoryStruct.comp, StochasticMatrix.comp]
+    rw [Finset.sum_eq_single ⟨x, ⟨⟩⟩]
+    · simp only [if_true, one_mul]
+      simp only [StochasticMatrix.id, CategoryStruct.id]
+    · intro b _ hb
+      obtain ⟨x', ⟨⟩⟩ := b
+      by_cases h : (x, ()) = (x', ())
+      · -- Case: (x, ()) = (x', ())
+        simp only [Prod.mk.injEq, and_true] at h
+        subst h
+        simp only [if_true, one_mul]
+        exfalso
+        apply hb
+        rfl
+      · -- Case: (x, ()) ≠ (x', ())
+        simp only [Prod.mk.injEq, and_true] at h
+        push_neg at h
+        -- First match gives 0 because x ≠ x'
+        simp only [h, if_false, zero_mul]
+    · intro h
+      exfalso
+      apply h
+      exact Finset.mem_univ _
+
+/-- The basic monoidal structure on FinStoch using tensor products of finite types
+and explicit structural isomorphisms. -/
+instance : MonoidalCategoryStruct FinStoch where
+  tensorObj := tensorObj
+  tensorUnit := tensorUnit
+  tensorHom f g := StochasticMatrix.tensor f g
+  whiskerLeft := fun X {_ _} f => StochasticMatrix.tensor (𝟙 X) f
+  whiskerRight := fun {_ _} f Y => StochasticMatrix.tensor f (𝟙 Y)
+  associator := associator
+  leftUnitor := leftUnitor
+  rightUnitor := rightUnitor
+
+/-- FinStoch forms a monoidal category with all coherence conditions satisfied.
+This proves Mac Lane's pentagon and triangle identities hold for stochastic matrices. -/
+instance : MonoidalCategory FinStoch where
+  tensorHom_def := by
+    -- Tensor product via whiskering: f ⊗ g = (f ▷ X₂) ≫ (Y₁ ◁ g)
+    intros X₁ Y₁ X₂ Y₂ f g
+    apply StochasticMatrix.ext
+    ext ⟨x₁, x₂⟩ ⟨y₁, y₂⟩
+    simp only [MonoidalCategoryStruct.tensorHom, StochasticMatrix.tensor,
+               MonoidalCategoryStruct.whiskerRight, MonoidalCategoryStruct.whiskerLeft,
+               CategoryStruct.comp, StochasticMatrix.comp]
+    -- (f ▷ X₂) ≫ (Y₁ ◁ g) expands to sum over intermediate states
+    rw [Finset.sum_eq_single ⟨y₁, x₂⟩]
+    · -- The unique non-zero term when y₁' = y₁ and x₂' = x₂
+      simp only [StochasticMatrix.id, CategoryStruct.id]
+      by_cases h₁ : y₁ = y₁
+      · by_cases h₂ : x₂ = x₂
+        · simp [one_mul, mul_one]
+        · -- Impossible: x₂ ≠ x₂
+          exfalso
+          exact h₂ rfl
+      · -- Impossible: y₁ ≠ y₁
+        exfalso
+        exact h₁ rfl
+    · -- Other terms: show (y₁', x₂') ≠ (y₁, x₂) gives zero contribution
+      intro ⟨y₁', x₂'⟩ _ h_ne
+      simp only [StochasticMatrix.id, CategoryStruct.id]
+      -- At least one identity matrix is off-diagonal, contributing 0
+      by_cases h₁ : y₁' = y₁
+      · by_cases h₂ : x₂ = x₂'
+        · -- Would contradict h_ne: both coordinates match
+          exfalso
+          apply h_ne
+          congr 1
+          · exact h₂.symm
+        · -- x₂ ≠ x₂': right identity gives 0
+          simp [h₂, zero_mul]
+      · -- y₁' ≠ y₁: left identity gives 0
+        simp [h₁, mul_zero]
+    · -- Membership: (y₁, x₂) is in the finite set Y₁ × X₂
+      intro h
+      exfalso
+      exact h (Finset.mem_univ _)
+  id_tensorHom_id := by
+    intros X Y
+    apply StochasticMatrix.ext
+    ext ⟨x, y⟩ ⟨x', y'⟩
+    simp only [MonoidalCategoryStruct.tensorHom, StochasticMatrix.tensor]
+    simp only [CategoryStruct.id, StochasticMatrix.id]
+    -- id ⊗ id = id: only (x,y) = (x',y') gets probability 1
+    by_cases hx : x = x'
+    · by_cases hy : y = y'
+      · -- Both match: prob 1 * 1 = 1
+        simp [hx, hy]
+      · -- x matches, y doesn't: prob 1 * 0 = 0
+        simp [hx, hy]
+        split_ifs with h
+        · exfalso
+          obtain ⟨_, h2⟩ := h
+          exact hy rfl
+        · rfl
+    · -- x doesn't match: prob 0 * _ = 0
+      simp [hx]
+      split_ifs with h
+      · exfalso
+        obtain ⟨h1, _⟩ := h
+        exact hx rfl
+      · rfl
+  tensor_comp := by
+    intros X₁ Y₁ Z₁ X₂ Y₂ Z₂ f₁ f₂ g₁ g₂
+    apply StochasticMatrix.ext
+    ext ⟨x₁, x₂⟩ ⟨z₁, z₂⟩
+    simp only [CategoryStruct.comp, StochasticMatrix.comp,
+               MonoidalCategoryStruct.tensorHom, StochasticMatrix.tensor]
+    -- Interchange law: (f₁ ≫ g₁) ⊗ (f₂ ≫ g₂) = (f₁ ⊗ f₂) ≫ (g₁ ⊗ g₂)
+    -- LHS: tensor of compositions = (∑ y₁, f₁[x₁,y₁]*g₁[y₁,z₁]) * (∑ y₂, f₂[x₂,y₂]*g₂[y₂,z₂])
+    -- RHS: composition of tensors = ∑ (y₁,y₂), (f₁[x₁,y₁]*f₂[x₂,y₂]) * (g₁[y₁,z₁]*g₂[y₂,z₂])
+
+    -- Use distributivity: product of sums = sum of products
+    rw [Finset.sum_mul_sum]
+    -- Convert double sum to sum over product
+    simp_rw [← Finset.sum_product']
+    -- Reflexivity handles associativity and commutativity
+    ac_rfl
+  whiskerLeft_id := by
+    intros X Y
+    apply StochasticMatrix.ext
+    ext ⟨x, y⟩ ⟨x', y'⟩
+    simp only [MonoidalCategoryStruct.whiskerLeft, StochasticMatrix.tensor]
+    simp only [CategoryStruct.id, StochasticMatrix.id]
+    -- X ◁ id_Y = id_(X⊗Y): whiskering preserves identities
+    by_cases hx : x = x'
+    · by_cases hy : y = y'
+      · -- Both match: 1 * 1 = 1
+        subst hx hy
+        simp
+      · -- x matches, y doesn't: 1 * 0 = 0
+        subst hx
+        simp only [hy, if_false, mul_zero]
+        by_cases h : (x, y) = (x, y')
+        · exfalso
+          simp only [Prod.mk.injEq] at h
+          obtain ⟨_, h2⟩ := h
+          exact hy h2
+        · simp [h]
+    · -- x doesn't match: 0 * _ = 0
+      simp only [hx, if_false, zero_mul]
+      by_cases h : (x, y) = (x', y')
+      · exfalso
+        simp only [Prod.mk.injEq] at h
+        obtain ⟨h1, _⟩ := h
+        exact hx h1
+      · simp [h]
+  id_whiskerRight := by
+    intros X Y
+    apply StochasticMatrix.ext
+    ext ⟨x, y⟩ ⟨x', y'⟩
+    simp only [MonoidalCategoryStruct.whiskerRight, StochasticMatrix.tensor]
+    simp only [CategoryStruct.id, StochasticMatrix.id]
+    -- id_X ▷ Y = id_(X⊗Y): symmetric to whiskerLeft_id
+    by_cases hx : x = x'
+    · by_cases hy : y = y'
+      · -- Both match: 1 * 1 = 1
+        subst hx hy
+        simp
+      · -- x matches, y doesn't: 1 * 0 = 0
+        subst hx
+        simp only [hy, if_false, mul_zero]
+        by_cases h : (x, y) = (x, y')
+        · exfalso
+          simp only [Prod.mk.injEq] at h
+          obtain ⟨_, h2⟩ := h
+          exact hy h2
+        · simp [h]
+    · -- x doesn't match: 0 * _ = 0
+      simp only [hx, if_false, zero_mul]
+      by_cases h : (x, y) = (x', y')
+      · exfalso
+        simp only [Prod.mk.injEq] at h
+        obtain ⟨h1, _⟩ := h
+        exact hx h1
+      · simp [h]
+  associator_naturality := by
+    -- Naturality follows from deterministic associator
+    intros X₁ X₂ X₃ Y₁ Y₂ Y₃ f₁ f₂ f₃
+    apply StochasticMatrix.ext
+    ext ⟨⟨x₁, x₂⟩, x₃⟩ ⟨y₁, ⟨y₂, y₃⟩⟩
+    simp only [CategoryStruct.comp, StochasticMatrix.comp,
+               MonoidalCategoryStruct.tensorHom, StochasticMatrix.tensor]
+
+    -- Both sides are sums that isolate the same unique term
+    -- LHS: sum over intermediate ((y₁', y₂'), y₃')
+    rw [Finset.sum_eq_single ⟨⟨y₁, y₂⟩, y₃⟩]
+    · -- Main term: associator gives 1 for correct rearrangement
+      simp
+      -- RHS: sum over intermediate (x₁', (x₂', x₃'))
+      rw [Finset.sum_eq_single ⟨x₁, ⟨x₂, x₃⟩⟩]
+      · -- Main term: both associators give 1 for the deterministic rearrangement
+        -- Show both associator evaluations are 1
+        have h1 : (MonoidalCategoryStruct.associator Y₁ Y₂ Y₃).hom.toMatrix
+                    ((y₁, y₂), y₃) (y₁, y₂, y₃) = 1 := by
+          change (associator Y₁ Y₂ Y₃).hom.toMatrix ((y₁, y₂), y₃) (y₁, y₂, y₃) = 1
+          simp only [associator]
+          simp
+        have h2 : (MonoidalCategoryStruct.associator X₁ X₂ X₃).hom.toMatrix
+                    ((x₁, x₂), x₃) (x₁, x₂, x₃) = 1 := by
+          change (associator X₁ X₂ X₃).hom.toMatrix ((x₁, x₂), x₃) (x₁, x₂, x₃) = 1
+          simp only [associator]
+          simp
+        simp only [h1, h2]
+        ring
+      · -- Other terms: associator gives 0
+        intro ⟨x₁', ⟨x₂', x₃'⟩⟩ _ h_ne
+        -- Associator is 0 unless coordinates match exactly
+        by_cases h : x₁' = x₁ ∧ x₂' = x₂ ∧ x₃' = x₃
+        · -- This contradicts h_ne
+          exfalso
+          apply h_ne
+          simp [h]
+        · -- Associator gives 0, making the entire product 0
+          -- Show associator matrix entry is 0
+          have h_assoc_zero : (MonoidalCategoryStruct.associator X₁ X₂ X₃).hom.toMatrix
+                                ((x₁, x₂), x₃) (x₁', x₂', x₃') = 0 := by
+            change (associator X₁ X₂ X₃).hom.toMatrix ((x₁, x₂), x₃) (x₁', x₂', x₃') = 0
+            simp only [associator]
+            -- The condition x₁ = x₁' ∧ x₂ = x₂' ∧ x₃ = x₃' equals our h
+            have h' : ¬(x₁ = x₁' ∧ x₂ = x₂' ∧ x₃ = x₃') := by
+              intro h_eq
+              apply h
+              exact ⟨h_eq.1.symm, h_eq.2.1.symm, h_eq.2.2.symm⟩
+            simp only [h', if_false]
+          rw [h_assoc_zero]
+          simp [zero_mul]
+      · intro
+        exfalso
+        apply ‹_›
+        exact Finset.mem_univ _
+    · -- Other terms: wrong intermediate state gives 0
+      intro ⟨⟨y₁', y₂'⟩, y₃'⟩ _ h_ne
+      -- Associator is 0 unless coordinates match exactly
+      by_cases h : y₁' = y₁ ∧ y₂' = y₂ ∧ y₃' = y₃
+      · -- This contradicts h_ne
+        exfalso
+        apply h_ne
+        simp [h]
+      · -- Show associator matrix entry is 0
+        have h_assoc_zero : (MonoidalCategoryStruct.associator Y₁ Y₂ Y₃).hom.toMatrix
+                              ((y₁', y₂'), y₃') (y₁, y₂, y₃) = 0 := by
+          change (associator Y₁ Y₂ Y₃).hom.toMatrix ((y₁', y₂'), y₃') (y₁, y₂, y₃) = 0
+          simp only [associator]
+          -- The condition y₁' = y₁ ∧ y₂' = y₂ ∧ y₃' = y₃ contradicts h
+          simp only [h, if_false]
+        rw [h_assoc_zero, mul_zero]
+    · intro
+      exfalso
+      apply ‹_›
+      exact Finset.mem_univ _
+  leftUnitor_naturality := by
+    intros X Y f
+    apply StochasticMatrix.ext
+    ext ⟨⟨⟩, x⟩ y
+    -- LHS: (𝟙 ⊗ f) ≫ λ_Y, RHS: λ_X ≫ f
+    simp only [CategoryStruct.comp, StochasticMatrix.comp]
+
+    -- LHS: Sum over intermediate ((), y') in tensorUnit × Y
+    rw [Finset.sum_eq_single ⟨⟨⟩, y⟩]
+    · -- Main case: show LHS = RHS = f.toMatrix x y
+      -- First simplify LHS tensor operation
+      simp only [MonoidalCategoryStruct.whiskerLeft, StochasticMatrix.tensor]
+      simp only [CategoryStruct.id, StochasticMatrix.id]
+      -- LHS: 1 * f[x,y] * leftUnitor_Y[((),y), y] = f[x,y] * 1 = f[x,y]
+      have h_left_unitor : (MonoidalCategoryStruct.leftUnitor Y).hom.toMatrix (⟨⟩, y) y = 1 := by
+        change (leftUnitor Y).hom.toMatrix (⟨⟩, y) y = 1
+        simp only [leftUnitor, if_true]
+      simp only [h_left_unitor, mul_one]
+      simp
+
+      -- Now show RHS = f.toMatrix x y
+      -- RHS: Sum over intermediate x' in X
+      rw [Finset.sum_eq_single x]
+      · -- Main term: leftUnitor_X[((),x), x] * f[x,y] = 1 * f[x,y] = f[x,y]
+        have h_right_unitor : (MonoidalCategoryStruct.leftUnitor X).hom.toMatrix (⟨⟩, x) x = 1 := by
+          change (leftUnitor X).hom.toMatrix (⟨⟩, x) x = 1
+          simp only [leftUnitor, if_true]
+        simp only [h_right_unitor]
+        simp
+      · -- Other terms: leftUnitor gives 0 for x' ≠ x
+        intro x' _ h_ne
+        have h_unitor_zero : (MonoidalCategoryStruct.leftUnitor X).hom.toMatrix (⟨⟩, x) x' = 0 := by
+          change (leftUnitor X).hom.toMatrix (⟨⟩, x) x' = 0
+          simp only [leftUnitor]
+          rw [if_neg h_ne.symm]
+        simp only [h_unitor_zero]
+        simp
+      · -- Membership
+        intro h
+        exfalso
+        exact h (Finset.mem_univ _)
+
+    · -- Other intermediate states contribute 0 to LHS
+      intro ⟨⟨⟩, y'⟩ _ h_ne
+      have h_neq : y' ≠ y := by
+        intro h_eq
+        apply h_ne
+        simp [h_eq]
+      simp only [MonoidalCategoryStruct.whiskerLeft, StochasticMatrix.tensor]
+      simp only [CategoryStruct.id, StochasticMatrix.id]
+      have h_unitor_zero : (MonoidalCategoryStruct.leftUnitor Y).hom.toMatrix (⟨⟩, y') y = 0 := by
+        change (leftUnitor Y).hom.toMatrix (⟨⟩, y') y = 0
+        simp only [leftUnitor, h_neq, if_false]
+      simp only [h_unitor_zero, mul_zero]
+
+    · -- Membership
+      intro h
+      exfalso
+      exact h (Finset.mem_univ _)
+  rightUnitor_naturality := by
+    intros X Y f
+    apply StochasticMatrix.ext
+    ext ⟨x, ⟨⟩⟩ y
+    -- LHS: (f ⊗ 𝟙 tensorUnit) ≫ (rightUnitor Y).hom
+    -- RHS: (rightUnitor X).hom ≫ f
+    simp only [CategoryStruct.comp, StochasticMatrix.comp]
+
+    -- LHS: Sum over intermediate (y', ()) in Y × tensorUnit
+    rw [Finset.sum_eq_single ⟨y, ⟨⟩⟩]
+    · -- Main case: show LHS = RHS = f.toMatrix x y
+      -- First simplify LHS tensor operation
+      simp only [MonoidalCategoryStruct.whiskerRight, StochasticMatrix.tensor]
+      simp only [CategoryStruct.id, StochasticMatrix.id]
+      -- LHS: f[x,y] * 1 * rightUnitor_Y[(y,()), y] = f[x,y] * 1 = f[x,y]
+      have h_right_unitor : (MonoidalCategoryStruct.rightUnitor Y).hom.toMatrix (y,⟨⟩) y = 1 := by
+        change (rightUnitor Y).hom.toMatrix (y, ⟨⟩) y = 1
+        simp only [rightUnitor, if_true]
+      simp only [h_right_unitor, mul_one]
+      simp
+
+      -- Now show RHS = f.toMatrix x y
+      -- RHS: Sum over intermediate x' in X
+      rw [Finset.sum_eq_single x]
+      · -- Main term: rightUnitor_X[(x,()), x] * f[x,y] = 1 * f[x,y] = f[x,y]
+        have h_right_unitor :
+          (MonoidalCategoryStruct.rightUnitor X).hom.toMatrix (x, ⟨⟩) x = 1 := by
+          change (rightUnitor X).hom.toMatrix (x, ⟨⟩) x = 1
+          simp only [rightUnitor, if_true]
+        simp only [h_right_unitor]
+        simp
+      · -- Other terms: rightUnitor gives 0 for x' ≠ x
+        intro x' _ h_ne
+        have h_unitor_zero :
+          (MonoidalCategoryStruct.rightUnitor X).hom.toMatrix (x, ⟨⟩) x' = 0 := by
+          change (rightUnitor X).hom.toMatrix (x, ⟨⟩) x' = 0
+          simp only [rightUnitor]
+          rw [if_neg h_ne.symm]
+        simp only [h_unitor_zero]
+        simp
+      · -- Membership
+        intro h
+        exfalso
+        exact h (Finset.mem_univ _)
+
+    · -- Other intermediate states contribute 0 to LHS
+      intro ⟨y', ⟨⟩⟩ _ h_ne
+      have h_neq : y' ≠ y := by
+        intro h_eq
+        apply h_ne
+        simp [h_eq]
+      simp only [MonoidalCategoryStruct.whiskerRight, StochasticMatrix.tensor]
+      simp only [CategoryStruct.id, StochasticMatrix.id]
+      have h_unitor_zero : (MonoidalCategoryStruct.rightUnitor Y).hom.toMatrix (y', ⟨⟩) y = 0 := by
+        change (rightUnitor Y).hom.toMatrix (y', ⟨⟩) y = 0
+        simp only [rightUnitor, h_neq, if_false]
+      simp only [h_unitor_zero, mul_zero]
+
+    · -- Membership
+      intro h
+      exfalso
+      exact h (Finset.mem_univ _)
+  pentagon := by
+    intros W X Y Z
+    apply StochasticMatrix.ext
+    ext ⟨⟨⟨w, x⟩, y⟩, z⟩ ⟨w', ⟨x', ⟨y', z'⟩⟩⟩
+    -- Pentagon: two paths from (((W ⊗ X) ⊗ Y) ⊗ Z) to (W ⊗ (X ⊗ (Y ⊗ Z)))
+
+    simp only [CategoryStruct.comp, StochasticMatrix.comp]
+
+    -- Both sides sum over intermediate states
+    -- LHS path: (((w,x),y),z) → ((w,(x,y)),z) → (w,((x,y),z)) → (w,(x,(y,z)))
+    -- RHS path: (((w,x),y),z) → ((w,x),(y,z)) → (w,(x,(y,z)))
+
+    -- LHS: First composition
+    rw [Finset.sum_eq_single ⟨⟨w, ⟨x, y⟩⟩, z⟩]
+    · -- Second composition
+      rw [Finset.sum_eq_single ⟨w, ⟨⟨x, y⟩, z⟩⟩]
+      · -- Evaluate all three morphisms in the LHS composition
+        -- (α_ W X Y).hom ▷ Z
+        simp only [MonoidalCategoryStruct.whiskerRight, StochasticMatrix.tensor]
+        simp only [CategoryStruct.id, StochasticMatrix.id]
+        -- Evaluate associator W X Y at ((w, x), y) → (w, (x, y))
+        have h_assoc1 : (MonoidalCategoryStruct.associator W X Y).hom.toMatrix
+                        ((w, x), y) (w, (x, y)) = 1 := by
+          change (associator W X Y).hom.toMatrix ((w, x), y) (w, (x, y)) = 1
+          simp only [associator]
+          simp [and_self]
+        simp only [h_assoc1, one_mul]
+
+        -- (α_ W (X ⊗ Y) Z).hom
+        -- Evaluate at ((w, (x, y)), z) → (w, ((x, y), z))
+        have h_assoc2 : (MonoidalCategoryStruct.associator W
+                         (MonoidalCategoryStruct.tensorObj X Y) Z).hom.toMatrix
+                        ((w, (x, y)), z) (w, ((x, y), z)) = 1 := by
+          change (associator W (tensorObj X Y) Z).hom.toMatrix
+                 ((w, (x, y)), z) (w, ((x, y), z)) = 1
+          simp only [associator]
+          simp [and_self]
+        simp only [h_assoc2, one_mul]
+
+        -- W ◁ (α_ X Y Z).hom
+        simp only [MonoidalCategoryStruct.whiskerLeft, StochasticMatrix.tensor]
+        simp only [CategoryStruct.id, StochasticMatrix.id]
+
+        -- Now evaluate the LHS fully
+        -- We have: 1 * 1 * (id_W ⊗ associator X Y Z)[(w, ((x,y),z)), (w', (x',(y',z')))]
+        -- This equals: (if w = w' then 1 else 0) * associator[((x,y),z), (x',(y',z'))]
+        -- The associator gives: if x = x' ∧ y = y' ∧ z = z' then 1 else 0
+        simp only [if_true, one_mul]
+
+        -- Manually expand the associator
+        have h_assoc3_eval : (MonoidalCategoryStruct.associator X Y Z).hom.toMatrix
+                             ((x, y), z) (x', y', z') =
+                             if x = x' ∧ y = y' ∧ z = z' then 1 else 0 := by
+          change (associator X Y Z).hom.toMatrix ((x, y), z) (x', y', z') = _
+          simp only [associator]
+        simp only [h_assoc3_eval]
+
+        -- RHS: First composition
+        rw [Finset.sum_eq_single ⟨⟨w, x⟩, ⟨y, z⟩⟩]
+        · -- Evaluate both morphisms in the RHS composition
+          -- (α_ (W ⊗ X) Y Z).hom - this is always 1 since we picked the exact intermediate state
+          have h_assoc4 : (MonoidalCategoryStruct.associator
+                           (MonoidalCategoryStruct.tensorObj W X) Y Z).hom.toMatrix
+                          (((w, x), y), z) ((w, x), (y, z)) = 1 := by
+            change (associator (tensorObj W X) Y Z).hom.toMatrix
+                   (((w, x), y), z) ((w, x), (y, z)) = 1
+            simp only [associator]
+            simp [and_self]
+          simp only [h_assoc4, one_mul]
+
+          -- (α_ W X (Y ⊗ Z)).hom - need to evaluate at general output
+          have h_assoc5_eval : (MonoidalCategoryStruct.associator W X
+                               (MonoidalCategoryStruct.tensorObj Y Z)).hom.toMatrix
+                              ((w, x), (y, z)) (w', (x', (y', z'))) =
+                              if w = w' ∧ x = x' ∧ (y, z) = (y', z') then 1 else 0 := by
+            change (associator W X (tensorObj Y Z)).hom.toMatrix
+                   ((w, x), (y, z)) (w', (x', (y', z'))) = _
+            simp only [associator]
+          simp only [h_assoc5_eval]
+
+          -- Both sides equal 1 if all coordinates match, 0 otherwise
+          by_cases h : w = w' ∧ x = x' ∧ y = y' ∧ z = z'
+          · obtain ⟨hw, hx, hy, hz⟩ := h
+            simp [hw, hx, hy, hz]
+          · push_neg at h
+            -- At least one coordinate doesn't match, so result is 0
+            by_cases hw : w = w'
+            · by_cases hx : x = x'
+              · by_cases hy : y = y'
+                · -- w, x, y match but z doesn't
+                  have hz : ¬(z = z') := by
+                    intro hz'
+                    apply h
+                    exact hw
+                    exact hx
+                    exact hy
+                    exact hz'
+                  simp [hw, hx, hy, hz]
+                · -- w, x match but y doesn't
+                  simp [hw, hx, hy]
+              · -- w matches but x doesn't
+                simp [hw, hx]
+            · -- w doesn't match
+              simp [hw]
+
+        · -- Other RHS intermediate states give 0
+          intro ⟨⟨w₁, x₁⟩, ⟨y₁, z₁⟩⟩ _ h_ne
+          -- First associator is 0 unless all match
+          have h_assoc_zero : (MonoidalCategoryStruct.associator
+                               (MonoidalCategoryStruct.tensorObj W X) Y Z).hom.toMatrix
+                              (((w, x), y), z) ((w₁, x₁), (y₁, z₁)) = 0 := by
+            change (associator (tensorObj W X) Y Z).hom.toMatrix
+                   (((w, x), y), z) ((w₁, x₁), (y₁, z₁)) = 0
+            simp only [associator]
+            by_cases h : (w, x) = (w₁, x₁) ∧ y = y₁ ∧ z = z₁
+            · -- This would contradict h_ne
+              obtain ⟨⟨hw, hx⟩, hy, hz⟩ := h
+              exfalso
+              apply h_ne
+              simp [hy, hz]
+            · push_neg at h
+              simp
+              exact h
+          simp only [h_assoc_zero]
+          simp [zero_mul]
+
+        · intro h; exfalso; exact h (Finset.mem_univ _)
+
+      · -- Other LHS second intermediate states give 0
+        intro ⟨w₁, ⟨⟨x₁, y₁⟩, z₁⟩⟩ _ h_ne
+        -- Second associator is 0 unless all match
+        have h_assoc_zero : (MonoidalCategoryStruct.associator W
+                             (MonoidalCategoryStruct.tensorObj X Y) Z).hom.toMatrix
+                            ((w, (x, y)), z) (w₁, ((x₁, y₁), z₁)) = 0 := by
+          change (associator W (tensorObj X Y) Z).hom.toMatrix
+                 ((w, (x, y)), z) (w₁, ((x₁, y₁), z₁)) = 0
+          simp only [associator]
+          by_cases h : w = w₁ ∧ (x, y) = (x₁, y₁) ∧ z = z₁
+          · -- This would contradict h_ne
+            obtain ⟨hw, ⟨hx, hy⟩, hz⟩ := h
+            exfalso
+            apply h_ne
+            simp [hw, hz]
+          · push_neg at h
+            rw [if_neg]
+            simp
+            exact h
+        simp only [h_assoc_zero, zero_mul]
+
+      · -- Membership
+        intro h; exfalso; exact h (Finset.mem_univ _)
+
+    · -- Other LHS first intermediate states give 0
+      intro ⟨⟨w₁, ⟨x₁, y₁⟩⟩, z₁⟩ _ h_ne
+      -- First whiskerRight is 0 unless all match
+      simp only [MonoidalCategoryStruct.whiskerRight, StochasticMatrix.tensor]
+      simp only [CategoryStruct.id, StochasticMatrix.id]
+      -- The whiskerRight (associator ⊗ id_Z) gives 0 when
+      -- ((w₁, (x₁, y₁)), z₁) ≠ ((w, (x, y)), z)
+      -- This happens when either part is 0
+      by_cases h_match : (w₁, (x₁, y₁)) = (w, (x, y)) ∧ z₁ = z
+      · -- If both parts match, we'd have ((w₁, (x₁, y₁)), z₁) = ((w, (x, y)), z)
+        -- But this contradicts h_ne
+        obtain ⟨h_assoc, h_z⟩ := h_match
+        exfalso
+        apply h_ne
+        congr 1
+      · -- At least one part doesn't match, so the tensor product gives 0
+        push_neg at h_match
+        -- The product (associator W X Y)[((w,x),y), (w₁,(x₁,y₁))] * id_Z[z, z₁]
+        -- is 0 if either factor is 0
+        by_cases h_assoc : (w₁, (x₁, y₁)) = (w, (x, y))
+        · -- Associator part matches, so identity part must not match
+          have h_z : z₁ ≠ z := h_match h_assoc
+          -- The product is associator * id_Z = 1 * 0 = 0
+          simp [mul_zero]
+          grind
+        · -- Associator part doesn't match, so it gives 0
+          -- Show the associator gives 0
+          · -- Associator part doesn't match, so it gives 0
+            have h_assoc_zero : (MonoidalCategoryStruct.associator W X Y).hom.toMatrix
+                                ((w, x), y) (w₁, (x₁, y₁)) = 0 := by
+              simp only [MonoidalCategoryStruct.associator, associator]
+              rw [if_neg]
+              -- Associator gives 1 iff (w₁, (x₁, y₁)) = (w, (x, y))
+              -- But h_assoc says they differ
+              intro h_components
+              obtain ⟨hw, hx, hy⟩ := h_components
+              apply h_assoc
+              simp [hw, hx, hy]
+            simp only [h_assoc_zero, zero_mul]
+
+    · -- Membership
+      intro h; exfalso; exact h (Finset.mem_univ _)
+
+  triangle := by
+    intros X Y
+    apply StochasticMatrix.ext
+    ext ⟨⟨x, ⟨⟩⟩, y⟩ ⟨x', y'⟩
+    -- Triangle: (α_ X (𝟙_ _) Y).hom ≫ X ◁ (λ_ Y).hom = (ρ_ X).hom ▷ Y
+    -- Both sides map ((x, ()), y) ↦ (x, y) deterministically
+
+    simp only [CategoryStruct.comp, StochasticMatrix.comp]
+
+    -- LHS: composition of associator and whiskerLeft
+    -- Sum over intermediate states (x₁, ((), y₁))
+    rw [Finset.sum_eq_single ⟨x, ⟨⟨⟩, y⟩⟩]
+    · -- Main term: intermediate state (x, ((), y))
+      -- Evaluate associator at ((x, ()), y) → (x, ((), y))
+      have h_assoc : (MonoidalCategoryStruct.associator X
+                       (MonoidalCategoryStruct.tensorUnit FinStoch) Y).hom.toMatrix
+                       ((x, PUnit.unit), y) (x, PUnit.unit, y) = 1 := by
+        change (associator X tensorUnit Y).hom.toMatrix ((x, ()), y) (x, ((), y)) = 1
+        simp only [associator]
+        simp [and_self]
+
+      -- Evaluate whiskerLeft = id_X ⊗ λ_Y at (x, ((), y)) → (x', y')
+      simp only [MonoidalCategoryStruct.whiskerLeft, StochasticMatrix.tensor]
+      simp only [CategoryStruct.id, StochasticMatrix.id]
+
+      -- Simplify tuple projections
+      simp only [h_assoc]
+      simp
+
+      -- Evaluate leftUnitor
+      have h_left : (MonoidalCategoryStruct.leftUnitor Y).hom.toMatrix (PUnit.unit, y) y' =
+                    if y = y' then 1 else 0 := by
+        change (leftUnitor Y).hom.toMatrix ((), y) y' = if y = y' then 1 else 0
+        simp only [leftUnitor]
+
+      simp only [h_left]
+
+      -- Evaluate RHS: rightUnitor ⊗ id_Y
+      simp only [MonoidalCategoryStruct.whiskerRight, StochasticMatrix.tensor]
+      simp only [CategoryStruct.id, StochasticMatrix.id]
+
+      -- Evaluate rightUnitor
+      have h_right : (MonoidalCategoryStruct.rightUnitor X).hom.toMatrix (x, PUnit.unit) x' =
+                     if x = x' then 1 else 0 := by
+        change (rightUnitor X).hom.toMatrix (x, ()) x' = if x = x' then 1 else 0
+        simp only [rightUnitor]
+
+      simp only [h_right]
+
+      -- Both sides equal (if x = x' then 1 else 0) * (if y = y' then 1 else 0)
+      by_cases hx : x = x'
+      · by_cases hy : y = y'
+        · -- Both match: 1 * 1 = 1
+          simp [hx, hy]
+        · -- x matches, y doesn't: 1 * 0 = 0
+          simp [hx, hy]
+      · -- x doesn't match: 0 * _ = 0
+        simp [hx]
+
+    · -- Other intermediate states: associator gives 0
+      intro ⟨x₁, ⟨⟨⟩, y₁⟩⟩ _ h_ne
+      -- The associator is 0 unless (x₁, y₁) = (x, y)
+      have h_assoc_zero : (MonoidalCategoryStruct.associator X
+                           (MonoidalCategoryStruct.tensorUnit FinStoch) Y).hom.toMatrix
+                           ((x, PUnit.unit), y) (x₁, PUnit.unit, y₁) = 0 := by
+        change (associator X tensorUnit Y).hom.toMatrix ((x, ()), y) (x₁, ((), y₁)) = 0
+        simp only [associator]
+        -- Need to show ¬(x = x₁ ∧ () = () ∧ y = y₁)
+        by_cases h : x = x₁ ∧ y = y₁
+        · -- This would contradict h_ne
+          exfalso
+          obtain ⟨hx, hy⟩ := h
+          apply h_ne
+          simp [hx, hy]
+        · -- At least one doesn't match
+          push_neg at h
+          by_cases hx : x = x₁
+          · -- x matches but y doesn't
+            have hy : ¬(y = y₁) := h hx
+            simp [hx, hy]
+          · -- x doesn't match
+            simp [hx]
+
+      simp only [h_assoc_zero, zero_mul]
+
+    · -- Membership: all states exist in finite type
+      intro h; exfalso; exact h (Finset.mem_univ _)
+
+end CategoryTheory.MarkovCategory

--- a/Mathlib/CategoryTheory/MarkovCategory/FinStoch/Monoidal.lean
+++ b/Mathlib/CategoryTheory/MarkovCategory/FinStoch/Monoidal.lean
@@ -53,44 +53,22 @@ def associator (X Y Z : FinStoch) :
     ext ⟨⟨x, y⟩, z⟩ ⟨⟨x', y'⟩, z'⟩
     simp only [CategoryStruct.comp, StochasticMatrix.comp]
     rw [Finset.sum_eq_single ⟨x, ⟨y, z⟩⟩]
-    · simp only [DetMorphism.toMatrix_apply, associatorDet, associatorInvDet]
-      simp only [DetMorphism.ofFunc]
-      simp only [StochasticMatrix.id, CategoryStruct.id]
-      by_cases h : ((x, y), z) = ((x', y'), z')
-      · simp only [↓reduceIte, h, mul_one, NNReal.coe_one]
-      · simp only [↓reduceIte, h, mul_zero, NNReal.coe_zero]
+    · simp only [associatorDet, associatorInvDet, DetMorphism.ofFunc]
+      cat_disch
     · intro b _ hb
       simp only [associatorDet, associatorInvDet, DetMorphism.ofFunc]
-      split_ifs with h1 h2
-      · simp only [one_mul]
-        exfalso
-        rw [h1] at hb
-        exact hb rfl
-      · simp only [mul_zero]
-      · simp only [mul_one]
-      · simp only [mul_zero]
+      cat_disch
     · intro h; exfalso; exact h (Finset.mem_univ _)
   inv_hom_id := by
     apply StochasticMatrix.ext
     ext ⟨x, ⟨y, z⟩⟩ ⟨x', ⟨y', z'⟩⟩
     simp only [CategoryStruct.comp, StochasticMatrix.comp]
     rw [Finset.sum_eq_single ⟨⟨x, y⟩, z⟩]
-    · simp only [DetMorphism.toMatrix_apply, associatorInvDet, associatorDet]
-      simp only [DetMorphism.ofFunc]
-      simp only [StochasticMatrix.id, CategoryStruct.id]
-      by_cases h : (x, (y, z)) = (x', (y', z'))
-      · simp only [↓reduceIte, h, mul_one, NNReal.coe_one]
-      · simp only [↓reduceIte, h, mul_zero, NNReal.coe_zero]
+    · simp only [associatorInvDet, associatorDet, DetMorphism.ofFunc]
+      cat_disch
     · intro b _ hb
       simp only [associatorInvDet, associatorDet, DetMorphism.ofFunc]
-      split_ifs with h1 h2
-      · simp only [one_mul]
-        exfalso
-        rw [h1] at hb
-        exact hb rfl
-      · simp only [mul_zero]
-      · simp only [mul_one]
-      · simp only [zero_mul]
+      cat_disch
     · intro h; exfalso; exact h (Finset.mem_univ _)
 
 /-- Removes trivial left factor from `I ⊗ X` to get `X`. -/
@@ -102,46 +80,20 @@ def leftUnitor (X : FinStoch) : (tensorObj tensorUnit X) ≅ X where
     ext ⟨⟨⟩, x⟩ ⟨⟨⟩, x'⟩
     simp only [CategoryStruct.comp, StochasticMatrix.comp]
     rw [Finset.sum_eq_single x]
-    · simp only [DetMorphism.toMatrix_apply, leftUnitorDet, leftUnitorInvDet]
-      simp only [DetMorphism.ofFunc]
-      simp only [StochasticMatrix.id, CategoryStruct.id]
-      by_cases h : ((), x) = ((), x')
-      · simp only [↓reduceIte, h, mul_one, NNReal.coe_one]
-      · simp only [↓reduceIte, h, mul_zero, NNReal.coe_zero]
-    · intro x'' _ hx''
-      simp only [DetMorphism.toMatrix_apply]
-      split_ifs with h
-      · have : x'' = x := by
-          simp only [leftUnitorDet, DetMorphism.ofFunc] at h
-          exact h.symm
-        rw [this] at hx''
-        exfalso; exact hx'' rfl
-      · simp only [mul_zero]
-      · simp only [mul_one]
-      · simp only [mul_zero]
+    · simp only [leftUnitorDet, leftUnitorInvDet, DetMorphism.ofFunc]
+      cat_disch
+    · simp only [leftUnitorDet, leftUnitorInvDet, DetMorphism.ofFunc]
+      cat_disch
     · intro h; exfalso; exact h (Finset.mem_univ _)
   inv_hom_id := by
     apply StochasticMatrix.ext
     ext x x'
     simp only [CategoryStruct.comp, StochasticMatrix.comp]
     rw [Finset.sum_eq_single ⟨⟨⟩, x⟩]
-    · simp only [DetMorphism.toMatrix_apply, leftUnitorInvDet, leftUnitorDet]
-      simp only [DetMorphism.ofFunc]
-      simp only [StochasticMatrix.id, CategoryStruct.id]
-      by_cases h : x = x'
-      · simp only [↓reduceIte, h, mul_one, NNReal.coe_one]
-      · simp only [↓reduceIte, h, mul_zero, NNReal.coe_zero]
-    · intro b _ hb
-      simp only [DetMorphism.toMatrix_apply]
-      split_ifs with h
-      · have : b = (⟨⟩, x) := by
-          simp only [leftUnitorInvDet, DetMorphism.ofFunc] at h
-          exact h.symm
-        rw [this] at hb
-        exfalso; exact hb rfl
-      · simp only [mul_zero]
-      · simp only [mul_one]
-      · simp only [mul_zero]
+    · simp only [leftUnitorInvDet, leftUnitorDet, DetMorphism.ofFunc]
+      cat_disch
+    · simp only [leftUnitorDet, leftUnitorInvDet, DetMorphism.ofFunc]
+      cat_disch
     · intro h; exfalso; exact h (Finset.mem_univ _)
 
 /-- Removes trivial right factor from `X ⊗ I` to get `X`. -/
@@ -153,46 +105,20 @@ def rightUnitor (X : FinStoch) : (tensorObj X tensorUnit) ≅ X where
     ext ⟨x, ⟨⟩⟩ ⟨x', ⟨⟩⟩
     simp only [CategoryStruct.comp, StochasticMatrix.comp]
     rw [Finset.sum_eq_single x]
-    · simp only [DetMorphism.toMatrix_apply, rightUnitorDet, rightUnitorInvDet]
-      simp only [DetMorphism.ofFunc]
-      simp only [StochasticMatrix.id, CategoryStruct.id]
-      by_cases h : (x, ()) = (x', ())
-      · simp only [↓reduceIte, h, mul_one, NNReal.coe_one]
-      · simp only [↓reduceIte, h, mul_zero, NNReal.coe_zero]
-    · intro x'' _ hx''
-      simp only [DetMorphism.toMatrix_apply]
-      split_ifs with h
-      · have : x'' = x := by
-          simp only [rightUnitorDet, DetMorphism.ofFunc] at h
-          exact h.symm
-        rw [this] at hx''
-        exfalso; exact hx'' rfl
-      · simp only [mul_zero]
-      · simp only [mul_one]
-      · simp only [mul_zero]
+    · simp only [rightUnitorDet, rightUnitorInvDet, DetMorphism.ofFunc]
+      cat_disch
+    · simp only [rightUnitorDet, rightUnitorInvDet, DetMorphism.ofFunc]
+      cat_disch
     · intro h; exfalso; exact h (Finset.mem_univ _)
   inv_hom_id := by
     apply StochasticMatrix.ext
     ext x x'
     simp only [CategoryStruct.comp, StochasticMatrix.comp]
     rw [Finset.sum_eq_single ⟨x, ⟨⟩⟩]
-    · simp only [DetMorphism.toMatrix_apply, rightUnitorInvDet, rightUnitorDet]
-      simp only [DetMorphism.ofFunc]
-      simp only [StochasticMatrix.id, CategoryStruct.id]
-      by_cases h : x = x'
-      · simp only [↓reduceIte, h, mul_one, NNReal.coe_one]
-      · simp_all only [↓reduceIte, mul_zero, NNReal.coe_zero]
-    · intro b _ hb
-      simp only [DetMorphism.toMatrix_apply]
-      split_ifs with h
-      · have : b = (x, ⟨⟩) := by
-          simp only [rightUnitorInvDet, DetMorphism.ofFunc] at h
-          exact h.symm
-        rw [this] at hb
-        exfalso; exact hb rfl
-      · simp only [mul_zero]
-      · simp only [mul_one]
-      · simp only [mul_zero]
+    · simp only [rightUnitorDet, rightUnitorInvDet, DetMorphism.ofFunc]
+      cat_disch
+    · simp only [rightUnitorDet, rightUnitorInvDet, DetMorphism.ofFunc]
+      cat_disch
     · intro h; exfalso; exact h (Finset.mem_univ _)
 
 /-- Basic monoidal structure on FinStoch using tensor products. -/
@@ -216,26 +142,7 @@ lemma associator_matrix (X Y Z : FinStoch) (xyz : ((X ⊗ Y) ⊗ Z).carrier)
     if xyz.1.1 = xyz'.1 ∧ xyz.1.2 = xyz'.2.1 ∧ xyz.2 = xyz'.2.2 then 1 else 0 := by
   simp only [MonoidalCategoryStruct.associator, associator, DetMorphism.toMatrix_apply]
   simp only [associatorDet, DetMorphism.ofFunc]
-  obtain ⟨⟨x, y⟩, z⟩ := xyz
-  obtain ⟨x', ⟨y', z'⟩⟩ := xyz'
-  simp only
-  split
-  next
-    h =>
-    simp_all only [left_eq_ite_iff, not_and, one_ne_zero, imp_false, Classical.not_imp,
-      Decidable.not_not]
-    constructor
-    · cases h; rfl
-    constructor
-    · cases h; rfl
-    · cases h; rfl
-  next h =>
-    simp_all only [right_eq_ite_iff, zero_ne_one, imp_false, not_and]
-    intro hx hy
-    by_contra h_eq
-    -- Now we have z = z', and we want to contradict h
-    have : (x, y, z) = (x', y', z') := by simp only [hx, hy, h_eq]
-    exact h this
+  aesop
 
 /-- Matrix entry for left unitor. -/
 @[simp]
@@ -291,190 +198,6 @@ lemma rightUnitor_inv_isDeterministic (X : FinStoch) :
 
 end Deterministic
 
-/-! ### Helper lemmas for pentagon identity -/
-
-section PentagonHelpers
-
-/-- Whisker right of associator with identity -/
-lemma pentagon_whisker_right (W X Y Z : FinStoch)
-    (wwxyz : (((W ⊗ X) ⊗ Y) ⊗ Z).carrier)
-    (wxyyz : ((W ⊗ (X ⊗ Y)) ⊗ Z).carrier) :
-    ((α_ W X Y).hom ▷ Z).toMatrix wwxyz wxyyz =
-    if wwxyz.1.1.1 = wxyyz.1.1 ∧ wwxyz.1.1.2 = wxyyz.1.2.1 ∧
-       wwxyz.1.2 = wxyyz.1.2.2 ∧ wwxyz.2 = wxyyz.2 then 1 else 0 := by
-  simp only [MonoidalCategoryStruct.whiskerRight, StochasticMatrix.tensor]
-  simp only [associator_matrix, StochasticMatrix.id, CategoryStruct.id]
-  obtain ⟨⟨⟨w, x⟩, y⟩, z⟩ := wwxyz
-  obtain ⟨⟨w', ⟨x', y'⟩⟩, z'⟩ := wxyyz
-  simp only
-  by_cases h : w = w' ∧ x = x' ∧ y = y'
-  · obtain ⟨hw, hx, hy⟩ := h
-    subst hw hx hy
-    by_cases hz : z = z'
-    · subst hz
-      simp only [if_true, mul_one, and_self]
-    · simp only [and_self, ↓reduceIte, hz, mul_zero, and_false]
-  · push_neg at h
-    simp only [mul_ite, mul_one, mul_zero]
-    by_cases hz : z = z'
-    · simp only [hz, ↓reduceIte, and_true]
-    · simp only [hz, ↓reduceIte, and_false]
-
-/-- Middle associator in left path -/
-lemma pentagon_middle_assoc (W X Y Z : FinStoch)
-    (wxyyz : ((W ⊗ (X ⊗ Y)) ⊗ Z).carrier)
-    (wxyz : (W ⊗ ((X ⊗ Y) ⊗ Z)).carrier) :
-    (α_ W (X ⊗ Y) Z).hom.toMatrix wxyyz wxyz =
-    if wxyyz.1.1 = wxyz.1 ∧ wxyyz.1.2 = wxyz.2.1 ∧
-       wxyyz.2 = wxyz.2.2 then 1 else 0 := by
-  simp only [associator_matrix]
-
-/-- Whisker left of associator with identity -/
-lemma pentagon_whisker_left (W X Y Z : FinStoch)
-    (wxyyz : (W ⊗ ((X ⊗ Y) ⊗ Z)).carrier)
-    (wxyz : (W ⊗ (X ⊗ (Y ⊗ Z))).carrier) :
-    (W ◁ (α_ X Y Z).hom).toMatrix wxyyz wxyz =
-    if wxyyz.1 = wxyz.1 ∧ wxyyz.2.1.1 = wxyz.2.1 ∧
-       wxyyz.2.1.2 = wxyz.2.2.1 ∧ wxyyz.2.2 = wxyz.2.2.2 then 1 else 0 := by
-  simp only [MonoidalCategoryStruct.whiskerLeft, StochasticMatrix.tensor]
-  simp only [StochasticMatrix.id, CategoryStruct.id, associator_matrix]
-  obtain ⟨w, ⟨⟨x, y⟩, z⟩⟩ := wxyyz
-  obtain ⟨w', ⟨x', ⟨y', z'⟩⟩⟩ := wxyz
-  simp only
-  by_cases hw : w = w'
-  · subst hw
-    by_cases h : x = x' ∧ y = y' ∧ z = z'
-    · simp only [↓reduceIte, h, and_self, mul_one]
-    · push_neg at h
-      simp only [↓reduceIte, mul_ite, mul_one, mul_zero, true_and]
-  · simp only [hw, ↓reduceIte, mul_ite, mul_one, mul_zero, ite_self, false_and]
-
-/-- First associator in right path -/
-lemma pentagon_right_first (W X Y Z : FinStoch)
-    (wwxyz : (((W ⊗ X) ⊗ Y) ⊗ Z).carrier)
-    (wxyz : ((W ⊗ X) ⊗ (Y ⊗ Z)).carrier) :
-    (α_ (W ⊗ X) Y Z).hom.toMatrix wwxyz wxyz =
-    if wwxyz.1.1 = wxyz.1 ∧ wwxyz.1.2 = wxyz.2.1 ∧
-       wwxyz.2 = wxyz.2.2 then 1 else 0 := by
-  simp only [associator_matrix]
-
-/-- Second associator in right path -/
-lemma pentagon_right_second (W X Y Z : FinStoch)
-    (wxyz : ((W ⊗ X) ⊗ (Y ⊗ Z)).carrier)
-    (wxyz' : (W ⊗ (X ⊗ (Y ⊗ Z))).carrier) :
-    (α_ W X (Y ⊗ Z)).hom.toMatrix wxyz wxyz' =
-    if wxyz.1.1 = wxyz'.1 ∧ wxyz.1.2 = wxyz'.2.1 ∧
-       wxyz.2 = wxyz'.2.2 then 1 else 0 := by
-  simp only [associator_matrix]
-
-/-- Left side composition equals indicator function -/
-lemma pentagon_left_composition (W X Y Z : FinStoch)
-    (wwxyz : (((W ⊗ X) ⊗ Y) ⊗ Z).carrier)
-    (wxyz : (W ⊗ (X ⊗ (Y ⊗ Z))).carrier) :
-    ((α_ W X Y).hom ▷ Z ≫ (α_ W (X ⊗ Y) Z).hom ≫ W ◁ (α_ X Y Z).hom).toMatrix wwxyz wxyz =
-    if wwxyz.1.1.1 = wxyz.1 ∧ wwxyz.1.1.2 = wxyz.2.1 ∧
-       wwxyz.1.2 = wxyz.2.2.1 ∧ wwxyz.2 = wxyz.2.2.2 then 1 else 0 := by
-  simp only [CategoryStruct.comp, StochasticMatrix.comp]
-  obtain ⟨⟨⟨w, x⟩, y⟩, z⟩ := wwxyz
-  obtain ⟨w', ⟨x', ⟨y', z'⟩⟩⟩ := wxyz
-  -- First composition: (α_ W X Y).hom ▷ Z
-  rw [Finset.sum_eq_single ⟨⟨w, ⟨x, y⟩⟩, z⟩]
-  · -- Second composition: (α_ W (X ⊗ Y) Z).hom
-    rw [Finset.sum_eq_single ⟨w, ⟨⟨x, y⟩, z⟩⟩]
-    · simp only [pentagon_whisker_right, pentagon_middle_assoc, pentagon_whisker_left]
-      by_cases h : w = w' ∧ x = x' ∧ y = y' ∧ z = z'
-      · obtain ⟨hw, hx, hy, hz⟩ := h
-        subst hw hx hy hz
-        simp only [true_and, if_true, mul_one]
-      · push_neg at h
-        -- When not all equal, at least one condition fails
-        by_cases hw : w = w'
-        · by_cases hxyz : x = x' ∧ y = y' ∧ z = z'
-          · obtain ⟨hx, hy, hz⟩ := hxyz
-            exfalso; exact h hw hx hy hz
-          · push_neg at hxyz
-            simp only [hw, true_and]
-            -- Goal: ((if True ∧ True ∧ True ∧ True then 1 else 0) * ...) = if False...
-            -- Since hw is true but not all of x,y,z match, result should be 0
-            have h_not_all : ¬(x = x' ∧ y = y' ∧ z = z') := by
-              push_neg
-              exact hxyz
-            simp only [h_not_all, if_false]
-            -- Now show the LHS equals 0
-            split_ifs <;> simp
-        · simp only [hw, false_and, if_false, mul_zero]
-    · intro b _ hb
-      simp only [pentagon_middle_assoc, mul_eq_zero]
-      left
-      split_ifs with h
-      · exfalso
-        obtain ⟨h1, h2, h3⟩ := h
-        have : b = ⟨w, ⟨⟨x, y⟩, z⟩⟩ := by
-          cases b; simp only [h1, h2, h3, Prod.mk.eta]
-        exact hb this
-      · rfl
-    · intro habs; exfalso; exact habs (Finset.mem_univ _)
-  · intro b _ hb
-    simp only [pentagon_whisker_right, mul_eq_zero]
-    left
-    split_ifs with h
-    · exfalso
-      obtain ⟨h1, h2, h3, h4⟩ := h
-      have : b = ⟨⟨w, ⟨x, y⟩⟩, z⟩ := by
-        cases b
-        simp only at h1 h2 h3 h4 ⊢
-        simp only [h1, h2, h3, Prod.mk.eta, h4]
-      exact hb this
-    · rfl
-  · intro habs; exfalso; exact habs (Finset.mem_univ _)
-
-/-- Right side composition equals indicator function -/
-lemma pentagon_right_composition (W X Y Z : FinStoch)
-    (wwxyz : (((W ⊗ X) ⊗ Y) ⊗ Z).carrier)
-    (wxyz : (W ⊗ (X ⊗ (Y ⊗ Z))).carrier) :
-    ((α_ (W ⊗ X) Y Z).hom ≫ (α_ W X (Y ⊗ Z)).hom).toMatrix wwxyz wxyz =
-    if wwxyz.1.1.1 = wxyz.1 ∧ wwxyz.1.1.2 = wxyz.2.1 ∧
-       wwxyz.1.2 = wxyz.2.2.1 ∧ wwxyz.2 = wxyz.2.2.2 then 1 else 0 := by
-  simp only [CategoryStruct.comp, StochasticMatrix.comp]
-  obtain ⟨⟨⟨w, x⟩, y⟩, z⟩ := wwxyz
-  obtain ⟨w', ⟨x', ⟨y', z'⟩⟩⟩ := wxyz
-  -- The composition sums over intermediate states
-  -- (α_ (W ⊗ X) Y Z) maps ((w,x),y,z) to ((w,x),(y,z))
-  -- (α_ W X (Y ⊗ Z)) maps ((w,x),(y,z)) to (w,(x,(y,z)))
-  -- Since both are deterministic, the sum has only one non-zero term
-  rw [Finset.sum_eq_single ⟨⟨w, x⟩, ⟨y, z⟩⟩]
-  · -- Evaluate at the unique intermediate point
-    simp only [pentagon_right_first, pentagon_right_second]
-    -- First associator: ((w,x),y,z) → ((w,x),(y,z)) gives 1 iff all match
-    -- This is always 1 since we're mapping ((w,x),y,z) to ((w,x),(y,z))
-    simp only [if_true, true_and]
-    -- Second associator: ((w,x),(y,z)) → (w,(x,(y,z))) gives 1 iff components match
-    -- This is 1 iff w = w' ∧ x = x' ∧ (y,z) = (y',z')
-    -- Which is equivalent to w = w' ∧ x = x' ∧ y = y' ∧ z = z'
-    simp only [one_mul]
-    -- The conditional is: if (w,x) = (w',x') ∧ (y,z) = (y',z') then 1 else 0
-    -- This equals: if w = w' ∧ x = x' ∧ y = y' ∧ z = z' then 1 else 0
-    congr 1
-    -- Expand the product equalities
-    rw [Prod.mk.injEq]
-  · -- Show other terms in sum are zero
-    intro b _ hb
-    simp only [pentagon_right_first, mul_eq_zero]
-    left
-    -- First associator is deterministic: only maps to ((w,x),(y,z))
-    split_ifs with h
-    · exfalso
-      obtain ⟨h1, h2, h3⟩ := h
-      have : b = ⟨⟨w, x⟩, ⟨y, z⟩⟩ := by
-        obtain ⟨⟨b1, b2⟩, ⟨b3, b4⟩⟩ := b
-        simp only at h1 h2 h3
-        simp only [h1, h2, h3]
-      exact hb this
-    · rfl
-  · intro habs; exfalso; exact habs (Finset.mem_univ _)
-
-end PentagonHelpers
-
 /-- FinStoch forms a monoidal category. -/
 instance : MonoidalCategory FinStoch where
   tensorHom_def := by
@@ -486,20 +209,9 @@ instance : MonoidalCategory FinStoch where
                CategoryStruct.comp, StochasticMatrix.comp]
     rw [Finset.sum_eq_single ⟨y₁, x₂⟩]
     · simp only [StochasticMatrix.id, CategoryStruct.id]
-      by_cases h₁ : y₁ = y₁
-      · by_cases h₂ : x₂ = x₂
-        · simp only [NNReal.coe_mul, ↓reduceIte, mul_one, one_mul]
-        · exfalso; exact h₂ rfl
-      · exfalso; exact h₁ rfl
-    · intro ⟨y₁', x₂'⟩ _ h_ne
-      simp only [StochasticMatrix.id, CategoryStruct.id]
-      by_cases h₁ : y₁' = y₁
-      · by_cases h₂ : x₂ = x₂'
-        · exfalso
-          apply h_ne
-          rw [h₁, ← h₂]
-        · simp only [h₂, ↓reduceIte, mul_zero, ite_mul, one_mul, zero_mul, mul_ite, ite_self]
-      · simp only [mul_ite, mul_one, mul_zero, h₁, ↓reduceIte, zero_mul]
+      cat_disch
+    · simp only [StochasticMatrix.id, CategoryStruct.id]
+      cat_disch
     · intro h; exfalso; exact h (Finset.mem_univ _)
   id_tensorHom_id := by
     intros X Y
@@ -509,14 +221,14 @@ instance : MonoidalCategory FinStoch where
     simp only [CategoryStruct.id, StochasticMatrix.id]
     by_cases hx : x = x'
     · by_cases hy : y = y'
-      · simp only [hx, ↓reduceIte, hy, mul_one, NNReal.coe_one]
-      · simp only [hx, ↓reduceIte, hy, mul_zero, NNReal.coe_zero]
+      · simp [hx, hy]
+      · simp [hx, hy]
         split_ifs with h
         · exfalso
           obtain ⟨_, h2⟩ := h
           exact hy rfl
         · rfl
-    · simp only [hx, ↓reduceIte, mul_ite, mul_one, mul_zero, ite_self, NNReal.coe_zero]
+    · simp [hx]
       split_ifs with h
       · exfalso
         obtain ⟨h1, _⟩ := h
@@ -541,20 +253,20 @@ instance : MonoidalCategory FinStoch where
     · by_cases hy : y = y'
       · subst hx hy; simp
       · subst hx
-        simp only [hy, if_false, mul_zero]
+        simp [hy]
         by_cases h : (x, y) = (x, y')
         · exfalso
           simp only [Prod.mk.injEq] at h
           obtain ⟨_, h2⟩ := h
           exact hy h2
-        · simp only [NNReal.coe_zero, h, ↓reduceIte]
-    · simp only [hx, if_false, zero_mul]
+        · simp [h]
+    · simp [hx]
       by_cases h : (x, y) = (x', y')
       · exfalso
         simp only [Prod.mk.injEq] at h
         obtain ⟨h1, _⟩ := h
         exact hx h1
-      · simp only [NNReal.coe_zero, h, ↓reduceIte]
+      · simp [h]
   id_whiskerRight := by
     intros X Y
     apply StochasticMatrix.ext
@@ -564,22 +276,22 @@ instance : MonoidalCategory FinStoch where
     by_cases hx : x = x'
     · by_cases hy : y = y'
       · subst hx hy
-        simp only [↓reduceIte, mul_one, NNReal.coe_one]
+        simp
       · subst hx
-        simp only [hy, if_false, mul_zero]
+        simp [hy]
         by_cases h : (x, y) = (x, y')
         · exfalso
           simp only [Prod.mk.injEq] at h
           obtain ⟨_, h2⟩ := h
           exact hy h2
-        · simp only [NNReal.coe_zero, h, ↓reduceIte]
-    · simp only [hx, if_false, zero_mul]
+        · simp [h]
+    · simp [hx]
       by_cases h : (x, y) = (x', y')
       · exfalso
         simp only [Prod.mk.injEq] at h
         obtain ⟨h1, _⟩ := h
         exact hx h1
-      · simp only [NNReal.coe_zero, h, ↓reduceIte]
+      · simp [h]
   associator_naturality := by
     intros X₁ X₂ X₃ Y₁ Y₂ Y₃ f₁ f₂ f₃
     apply StochasticMatrix.ext
@@ -587,19 +299,15 @@ instance : MonoidalCategory FinStoch where
     simp only [CategoryStruct.comp, StochasticMatrix.comp,
                MonoidalCategoryStruct.tensorHom, StochasticMatrix.tensor]
     rw [Finset.sum_eq_single ⟨⟨y₁, y₂⟩, y₃⟩]
-    · simp only [associator_matrix, and_self, ↓reduceIte, mul_one, NNReal.coe_mul, ite_mul,
-                 one_mul, zero_mul, NNReal.coe_sum]
+    · simp [associator_matrix]
       rw [Finset.sum_eq_single ⟨x₁, ⟨x₂, x₃⟩⟩]
       · norm_num; ring
       · intro ⟨x₁', ⟨x₂', x₃'⟩⟩ _ h_ne
         by_cases h : x₁' = x₁ ∧ x₂' = x₂ ∧ x₃' = x₃
         · exfalso
           apply h_ne
-          simp only [h]
-        · simp only [NNReal.coe_eq_zero, ite_eq_right_iff, mul_eq_zero, and_imp]
-          intro a_1 a_2 a_3
-          subst a_3 a_2 a_1
-          simp_all only [Finset.mem_univ, ne_eq, not_true_eq_false]
+          simp [h]
+        · aesop
       · intro; exfalso; apply ‹_›; exact Finset.mem_univ _
     · intro ⟨⟨y₁', y₂'⟩, y₃'⟩ _ h_ne
       by_cases h : y₁' = y₁ ∧ y₂' = y₂ ∧ y₃' = y₃
@@ -608,8 +316,7 @@ instance : MonoidalCategory FinStoch where
         simp only [h]
       · have h_assoc_zero : (MonoidalCategoryStruct.associator Y₁ Y₂ Y₃).hom.toMatrix
                               ((y₁', y₂'), y₃') (y₁, y₂, y₃) = 0 := by
-          simp only [associator_matrix]
-          simp only [h, if_false]
+          simp [associator_matrix, h]
         rw [h_assoc_zero, mul_zero]
     · intro; exfalso; apply ‹_›; exact Finset.mem_univ _
   leftUnitor_naturality := by
@@ -618,19 +325,18 @@ instance : MonoidalCategory FinStoch where
     ext ⟨⟨⟩, x⟩ y
     simp only [CategoryStruct.comp, StochasticMatrix.comp]
     rw [Finset.sum_eq_single ⟨⟨⟩, y⟩]
-    · simp only [MonoidalCategoryStruct.whiskerLeft, StochasticMatrix.tensor, CategoryStruct.id,
-                 StochasticMatrix.id, ↓reduceIte, one_mul, leftUnitor_matrix, mul_one, ite_mul,
-                 zero_mul, Finset.sum_ite_eq, Finset.mem_univ]
+    · simp [MonoidalCategoryStruct.whiskerLeft, StochasticMatrix.tensor,
+            CategoryStruct.id, StochasticMatrix.id]
     · intro ⟨⟨⟩, y'⟩ _ h_ne
       have h_neq : y' ≠ y := by
         intro h_eq
         apply h_ne
         simp only [h_eq]
-      simp only [MonoidalCategoryStruct.whiskerLeft, StochasticMatrix.tensor]
-      simp only [CategoryStruct.id, StochasticMatrix.id]
+      simp only [MonoidalCategoryStruct.whiskerLeft, StochasticMatrix.tensor,
+                 CategoryStruct.id, StochasticMatrix.id]
       have h_unitor_zero : (MonoidalCategoryStruct.leftUnitor Y).hom.toMatrix (⟨⟩, y') y = 0 := by
-        simp only [leftUnitor_matrix, h_neq, if_false]
-      simp only [h_unitor_zero, mul_zero]
+        simp [leftUnitor_matrix, h_neq]
+      simp [h_unitor_zero]
     · intro h; exfalso; exact h (Finset.mem_univ _)
   rightUnitor_naturality := by
     intros X Y f
@@ -638,65 +344,122 @@ instance : MonoidalCategory FinStoch where
     ext ⟨x, ⟨⟩⟩ y
     simp only [CategoryStruct.comp, StochasticMatrix.comp]
     rw [Finset.sum_eq_single ⟨y, ⟨⟩⟩]
-    · simp only [MonoidalCategoryStruct.whiskerRight, StochasticMatrix.tensor]
-      simp only [CategoryStruct.id, StochasticMatrix.id]
+    · simp only [MonoidalCategoryStruct.whiskerRight, StochasticMatrix.tensor,
+                 CategoryStruct.id, StochasticMatrix.id]
       have h_right_unitor : (MonoidalCategoryStruct.rightUnitor Y).hom.toMatrix (y,⟨⟩) y = 1 := by
-        simp only [rightUnitor_matrix, if_true]
+        simp [rightUnitor_matrix]
       simp only [h_right_unitor, mul_one]
       rw [Finset.sum_eq_single x]
       · have h_right_unitor :
           (MonoidalCategoryStruct.rightUnitor X).hom.toMatrix (x, ⟨⟩) x = 1 := by
-          simp only [rightUnitor_matrix, if_true]
-        simp only [↓reduceIte, mul_one, h_right_unitor, one_mul]
+          simp [rightUnitor_matrix]
+        simp [h_right_unitor]
       · intro x' _ h_ne
         have h_unitor_zero :
           (MonoidalCategoryStruct.rightUnitor X).hom.toMatrix (x, ⟨⟩) x' = 0 := by
           simp only [rightUnitor_matrix]
           rw [if_neg h_ne.symm]
-        simp only [h_unitor_zero, zero_mul]
+        simp [h_unitor_zero]
       · intro h; exfalso; exact h (Finset.mem_univ _)
     · intro ⟨y', ⟨⟩⟩ _ h_ne
       have h_neq : y' ≠ y := by
         intro h_eq
         apply h_ne
         simp only [h_eq]
-      simp only [MonoidalCategoryStruct.whiskerRight, StochasticMatrix.tensor]
-      simp only [CategoryStruct.id, StochasticMatrix.id]
+      simp only [MonoidalCategoryStruct.whiskerRight, StochasticMatrix.tensor,
+                 CategoryStruct.id, StochasticMatrix.id]
       have h_unitor_zero : (MonoidalCategoryStruct.rightUnitor Y).hom.toMatrix (y', ⟨⟩) y = 0 := by
-        simp only [rightUnitor_matrix, h_neq, if_false]
-      simp only [h_unitor_zero, mul_zero]
+        simp [rightUnitor_matrix, h_neq]
+      simp [h_unitor_zero]
     · intro h; exfalso; exact h (Finset.mem_univ _)
   pentagon := by
     intros W X Y Z
     apply StochasticMatrix.ext
     ext ⟨⟨⟨w, x⟩, y⟩, z⟩ ⟨w', ⟨x', ⟨y', z'⟩⟩⟩
-    -- Use the helper lemmas we proved
-    simp only [pentagon_left_composition, pentagon_right_composition]
+    -- Both paths map ((w,x),y,z) to (w,(x,(y,z))) deterministically
+    simp only [CategoryStruct.comp, StochasticMatrix.comp]
+    -- Left path through the pentagon
+    rw [Finset.sum_eq_single ⟨⟨w, ⟨x, y⟩⟩, z⟩]
+    · rw [Finset.sum_eq_single ⟨w, ⟨⟨x, y⟩, z⟩⟩]
+      · -- Right path
+        rw [Finset.sum_eq_single ⟨⟨w, x⟩, ⟨y, z⟩⟩]
+        · -- Evaluate all morphisms
+          simp only [MonoidalCategoryStruct.whiskerRight, MonoidalCategoryStruct.whiskerLeft,
+                     StochasticMatrix.tensor, associator_matrix,
+                     CategoryStruct.id, StochasticMatrix.id]
+          -- Check equality conditions
+          by_cases hw : w = w'
+          · by_cases hx : x = x'
+            · by_cases hy : y = y'
+              · by_cases hz : z = z'
+                · subst hw hx hy hz; simp
+                · simp [hw, hx, hy, hz]
+                  subst hw hx hy
+                  split
+                  · grind only
+                  · rfl
+              · simp [hw, hx, hy]
+                subst hw hx
+                split
+                · grind only
+                · rfl
+            · simp [hw, hx]
+          · simp [hw]
+        · intro b _ hb
+          simp only [associator_matrix, mul_eq_zero]
+          left
+          split_ifs with h
+          · exfalso
+            obtain ⟨h1, h2, h3⟩ := h
+            have : b = ⟨⟨w, x⟩, ⟨y, z⟩⟩ := by
+              cases b; simp [h1, h2, h3]
+            exact hb this
+          · rfl
+        · intro h; exfalso; exact h (Finset.mem_univ _)
+      · intro a _ ha
+        simp only [associator_matrix, mul_eq_zero]
+        left
+        split_ifs with h
+        · exfalso
+          obtain ⟨h1, h2, h3⟩ := h
+          have : a = ⟨w, ⟨⟨x, y⟩, z⟩⟩ := by
+            cases a; simp [h1, h2, h3]
+          exact ha this
+        · rfl
+      · intro h; exfalso; exact h (Finset.mem_univ _)
+    · intro b _ hb
+      simp only [MonoidalCategoryStruct.whiskerRight, StochasticMatrix.tensor,
+                 associator_matrix, CategoryStruct.id, StochasticMatrix.id, mul_eq_zero]
+      left
+      split_ifs with h
+      · exfalso
+        obtain ⟨hw, hx, hy⟩ := h
+        have : b = ⟨⟨w, ⟨x, y⟩⟩, z⟩ := by
+          cases b; simp_all only [Finset.mem_univ, Prod.mk.eta, ne_eq, not_true_eq_false]
+        exact hb this
+      · right; rfl
+      · left; rfl
+      · left; rfl
+    · intro h; exfalso; exact h (Finset.mem_univ _)
   triangle := by
     intros X Y
     apply StochasticMatrix.ext
     ext ⟨⟨x, ⟨⟩⟩, y⟩ ⟨x', y'⟩
+    -- Both sides map ((x,()),y) to (x,y) deterministically
     simp only [CategoryStruct.comp, StochasticMatrix.comp]
-    -- Both sides map ((x, ()), y) ↦ (x, y) deterministically
+    -- The unique intermediate is (x,((),y))
     rw [Finset.sum_eq_single ⟨x, ⟨⟨⟩, y⟩⟩]
-    · simp only [associator_matrix, and_self, ↓reduceIte, NNReal.coe_inj]
-      simp only [MonoidalCategoryStruct.whiskerLeft, StochasticMatrix.tensor]
-      simp only [CategoryStruct.id, StochasticMatrix.id]
-      simp_all only [leftUnitor_matrix]
-      simp only [MonoidalCategoryStruct.whiskerRight, StochasticMatrix.tensor]
-      simp only [CategoryStruct.id, StochasticMatrix.id]
-      simp_all only [rightUnitor_matrix, mul_ite, mul_one, mul_zero]
-    · intro ⟨x₁, ⟨⟨⟩, y₁⟩⟩ _ h_ne
-      have h_assoc_zero : (MonoidalCategoryStruct.associator X
-                           (MonoidalCategoryStruct.tensorUnit FinStoch) Y).hom.toMatrix
-                           ((x, PUnit.unit), y) (x₁, PUnit.unit, y₁) = 0 := by
-        simp only [associator_matrix]
-        simp_all only [Finset.mem_univ, ne_eq, true_and, ite_eq_right_iff, one_ne_zero,
-                       imp_false, not_and]
-        intro a; subst a
-        intro a; subst a
-        simp_all only [not_true_eq_false]
-      simp only [h_assoc_zero, zero_mul]
+    · simp only [associator_matrix, MonoidalCategoryStruct.whiskerLeft,
+                 MonoidalCategoryStruct.whiskerRight, StochasticMatrix.tensor,
+                 leftUnitor_matrix, rightUnitor_matrix, CategoryStruct.id, StochasticMatrix.id]
+      by_cases hx : x = x'
+      · by_cases hy : y = y'
+        · subst hx hy; simp
+        · simp [hx, hy]
+      · simp [hx]
+    · intro a _ ha
+      obtain ⟨x₁, ⟨⟨⟩, y₁⟩⟩ := a
+      cat_disch
     · intro h; exfalso; exact h (Finset.mem_univ _)
 
 end CategoryTheory.MarkovCategory

--- a/Mathlib/CategoryTheory/MarkovCategory/FinStoch/Monoidal.lean
+++ b/Mathlib/CategoryTheory/MarkovCategory/FinStoch/Monoidal.lean
@@ -383,6 +383,94 @@ lemma rightUnitor_inv_matrix (X : FinStoch) (x : X.carrier)
   obtain ⟨x', ⟨⟩⟩ := xu
   simp only [rightUnitor]
 
+/-! ### Deterministic morphisms -/
+
+section Deterministic
+
+open StochasticMatrix
+
+/-- The associator is a deterministic morphism. -/
+lemma associator_isDeterministic (X Y Z : FinStoch) :
+    (α_ X Y Z).hom.isDeterministic := by
+  intro ⟨⟨x, y⟩, z⟩
+  use (x, (y, z))
+  constructor
+  · simp only [associator_matrix, and_self, if_true]
+  · intro ⟨x', ⟨y', z'⟩⟩ h
+    simp only [associator_matrix] at h
+    split_ifs at h with h_cond
+    · obtain ⟨hx, hy, hz⟩ := h_cond
+      simp [hx, hy, hz]
+    · simp at h
+
+/-- The inverse associator is a deterministic morphism. -/
+lemma associator_inv_isDeterministic (X Y Z : FinStoch) :
+    (α_ X Y Z).inv.isDeterministic := by
+  intro ⟨x, ⟨y, z⟩⟩
+  use ((x, y), z)
+  constructor
+  · simp only [associator_inv_matrix, and_self, if_true]
+  · intro ⟨⟨x', y'⟩, z'⟩ h
+    simp only [associator_inv_matrix] at h
+    split_ifs at h with h_cond
+    · obtain ⟨hx, hy, hz⟩ := h_cond
+      simp [hx, hy, hz]
+    · simp at h
+
+/-- The left unitor is a deterministic morphism. -/
+lemma leftUnitor_isDeterministic (X : FinStoch) :
+    (λ_ X).hom.isDeterministic := by
+  intro ⟨⟨⟩, x⟩
+  use x
+  constructor
+  · simp only [leftUnitor_matrix, if_true]
+  · intro x' h
+    simp only [leftUnitor_matrix] at h
+    split_ifs at h with h_cond
+    · exact h_cond.symm
+    · simp at h
+
+/-- The inverse left unitor is a deterministic morphism. -/
+lemma leftUnitor_inv_isDeterministic (X : FinStoch) :
+    (λ_ X).inv.isDeterministic := by
+  intro x
+  use (⟨⟩, x)
+  constructor
+  · simp only [leftUnitor_inv_matrix, if_true]
+  · intro ⟨⟨⟩, x'⟩ h
+    simp only [leftUnitor_inv_matrix] at h
+    split_ifs at h with h_cond
+    · simp [h_cond]
+    · simp at h
+
+/-- The right unitor is a deterministic morphism. -/
+lemma rightUnitor_isDeterministic (X : FinStoch) :
+    (ρ_ X).hom.isDeterministic := by
+  intro ⟨x, ⟨⟩⟩
+  use x
+  constructor
+  · simp only [rightUnitor_matrix, if_true]
+  · intro x' h
+    simp only [rightUnitor_matrix] at h
+    split_ifs at h with h_cond
+    · exact h_cond.symm
+    · simp at h
+
+/-- The inverse right unitor is a deterministic morphism. -/
+lemma rightUnitor_inv_isDeterministic (X : FinStoch) :
+    (ρ_ X).inv.isDeterministic := by
+  intro x
+  use (x, ⟨⟩)
+  constructor
+  · simp only [rightUnitor_inv_matrix, if_true]
+  · intro ⟨x', ⟨⟩⟩ h
+    simp only [rightUnitor_inv_matrix] at h
+    split_ifs at h with h_cond
+    · simp [h_cond]
+    · simp at h
+
+end Deterministic
+
 /-- FinStoch forms a monoidal category with all coherence conditions satisfied.
 This proves Mac Lane's pentagon and triangle identities hold for stochastic matrices. -/
 instance : MonoidalCategory FinStoch where

--- a/Mathlib/CategoryTheory/MarkovCategory/FinStoch/Monoidal.lean
+++ b/Mathlib/CategoryTheory/MarkovCategory/FinStoch/Monoidal.lean
@@ -19,8 +19,8 @@ Tensor products model independent parallel processes.
 
 ## Implementation notes
 
-Structural isomorphisms are deterministic.
-Use computational lemmas to simplify proofs.
+Structural morphisms use deterministic functions.
+Proofs use functional reasoning instead of matrix calculations.
 
 ## References
 
@@ -40,277 +40,161 @@ universe u
 
 open FinStoch
 
-/-! ### Helper lemmas for structural morphisms -/
+/-! ### Structural isomorphisms using DetMorphism -/
 
-/-- Rearranges `((X ⊗ Y) ⊗ Z)` to `(X ⊗ (Y ⊗ Z))`.
-
-Maps `((x,y),z) ↦ (x,(y,z))` deterministically. -/
+/-- Rearranges `((X ⊗ Y) ⊗ Z)` to `(X ⊗ (Y ⊗ Z))`. -/
 def associator (X Y Z : FinStoch) :
     (tensorObj (tensorObj X Y) Z) ≅ (tensorObj X (tensorObj Y Z)) where
-  hom := ⟨fun ⟨⟨x, y⟩, z⟩ ⟨x', ⟨y', z'⟩⟩ =>
-    if x = x' ∧ y = y' ∧ z = z' then 1 else 0, fun ⟨⟨x, y⟩, z⟩ => by
-    rw [Finset.sum_eq_single ⟨x, ⟨y, z⟩⟩]
-    · simp only [and_self, if_true]
-    · intro b _ hb
-      obtain ⟨x', ⟨y', z'⟩⟩ := b
-      simp only
-      split_ifs with h
-      · obtain ⟨h1, h2, h3⟩ := h
-        exfalso
-        apply hb
-        congr 1
-        · exact h1.symm
-        · congr 1
-          · exact h2.symm
-          · exact h3.symm
-      · rfl
-    · intro h; exfalso; exact h (Finset.mem_univ _)⟩
-  inv := ⟨fun ⟨x, ⟨y, z⟩⟩ ⟨⟨x', y'⟩, z'⟩ =>
-    if x = x' ∧ y = y' ∧ z = z' then 1 else 0, fun ⟨x, ⟨y, z⟩⟩ => by
-    rw [Finset.sum_eq_single ⟨⟨x, y⟩, z⟩]
-    · simp only [and_self, if_true]
-    · intro b _ hb
-      obtain ⟨⟨x', y'⟩, z'⟩ := b
-      simp only
-      split_ifs with h
-      · exfalso
-        obtain ⟨h1, h2, h3⟩ := h
-        apply hb
-        congr 1
-        · congr 1
-          · exact h1.symm
-          · exact h2.symm
-        · exact h3.symm
-      · rfl
-    · intro h; exfalso; exact h (Finset.mem_univ _)⟩
+  hom := (associatorDet X Y Z).toStochastic
+  inv := (associatorInvDet X Y Z).toStochastic
   hom_inv_id := by
     apply StochasticMatrix.ext
     ext ⟨⟨x, y⟩, z⟩ ⟨⟨x', y'⟩, z'⟩
     simp only [CategoryStruct.comp, StochasticMatrix.comp]
-    -- Round trip: ((x,y),z) → (x,(y,z)) → ((x,y),z)
     rw [Finset.sum_eq_single ⟨x, ⟨y, z⟩⟩]
-    · simp only [and_self, if_true, one_mul]
+    · simp only [DetMorphism.toMatrix_apply, associatorDet, associatorInvDet]
+      simp only [DetMorphism.ofFunc]
       simp only [StochasticMatrix.id, CategoryStruct.id]
       by_cases h : ((x, y), z) = ((x', y'), z')
-      · simp only [h, ↓reduceIte, NNReal.coe_one, NNReal.coe_eq_one, ite_eq_left_iff, not_and,
-                   zero_ne_one, imp_false, Classical.not_imp, Decidable.not_not]
-        obtain ⟨⟨rfl, rfl⟩, rfl⟩ := h
-        simp only [and_self]
-      · simp only [h, ↓reduceIte, NNReal.coe_zero, NNReal.coe_eq_zero, ite_eq_right_iff,
-                   one_ne_zero, imp_false, not_and]
-        push_neg at h
-        simp only [ne_eq, Prod.mk.injEq, not_and, and_imp] at h
-        exact h
+      · simp only [↓reduceIte, h, mul_one, NNReal.coe_one]
+      · simp only [↓reduceIte, h, mul_zero, NNReal.coe_zero]
     · intro b _ hb
-      obtain ⟨x₁, ⟨y₁, z₁⟩⟩ := b
-      simp only
-      split_ifs with h h2
-      · obtain ⟨rfl, rfl, rfl⟩ := h
+      simp only [associatorDet, associatorInvDet, DetMorphism.ofFunc]
+      split_ifs with h1 h2
+      · simp only [one_mul]
         exfalso
+        rw [h1] at hb
         exact hb rfl
-      · obtain ⟨rfl, rfl, rfl⟩ := h
-        exfalso
-        exact hb rfl
-      · simp only [zero_mul]
-      · simp only [zero_mul]
-    · intro h
-      exfalso
-      exact h (Finset.mem_univ _)
+      · simp only [mul_zero]
+      · simp only [mul_one]
+      · simp only [mul_zero]
+    · intro h; exfalso; exact h (Finset.mem_univ _)
   inv_hom_id := by
     apply StochasticMatrix.ext
     ext ⟨x, ⟨y, z⟩⟩ ⟨x', ⟨y', z'⟩⟩
     simp only [CategoryStruct.comp, StochasticMatrix.comp]
-    -- Round trip: (x,(y,z)) → ((x,y),z) → (x,(y,z))
     rw [Finset.sum_eq_single ⟨⟨x, y⟩, z⟩]
-    · simp only [and_self, if_true, one_mul]
+    · simp only [DetMorphism.toMatrix_apply, associatorInvDet, associatorDet]
+      simp only [DetMorphism.ofFunc]
       simp only [StochasticMatrix.id, CategoryStruct.id]
-      grind only [cases Or]
+      by_cases h : (x, (y, z)) = (x', (y', z'))
+      · simp only [↓reduceIte, h, mul_one, NNReal.coe_one]
+      · simp only [↓reduceIte, h, mul_zero, NNReal.coe_zero]
     · intro b _ hb
-      obtain ⟨⟨x₁, y₁⟩, z₁⟩ := b
-      simp only
-      split_ifs with h h2
-      · obtain ⟨rfl, rfl, rfl⟩ := h
+      simp only [associatorInvDet, associatorDet, DetMorphism.ofFunc]
+      split_ifs with h1 h2
+      · simp only [one_mul]
         exfalso
+        rw [h1] at hb
         exact hb rfl
-      · obtain ⟨rfl, rfl, rfl⟩ := h
-        exfalso
-        exact hb rfl
-      · simp only [zero_mul]
+      · simp only [mul_zero]
+      · simp only [mul_one]
       · simp only [zero_mul]
     · intro h; exfalso; exact h (Finset.mem_univ _)
 
-/-- The left unitor removes the trivial left factor from `I ⊗ X` to get `X`.
-
-This maps `((),x) ↦ x` with probability 1. The unit carries no information,
-so removing it doesn't change the data. The monoidal unit is singleton
-because it cannot hold information. -/
+/-- Removes trivial left factor from `I ⊗ X` to get `X`. -/
 def leftUnitor (X : FinStoch) : (tensorObj tensorUnit X) ≅ X where
-  hom := ⟨fun ⟨⟨⟩, x⟩ x' => if x = x' then 1 else 0, fun ⟨⟨⟩, x⟩ => by
-    rw [Finset.sum_eq_single x]
-    · simp only [if_true]
-    · intro x' _ hx'
-      simp only
-      split_ifs with h
-      · exfalso
-        exact hx' h.symm
-      · rfl
-    · intro h
-      exfalso
-      apply h
-      exact Finset.mem_univ _⟩
-  inv := ⟨fun x ⟨⟨⟩, x'⟩ => if x = x' then 1 else 0, fun x => by
-    rw [Finset.sum_eq_single ⟨⟨⟩, x⟩]
-    · simp only [if_true]
-    · intro b _ hb
-      obtain ⟨⟨⟩, x'⟩ := b
-      simp only
-      split_ifs with h
-      · exfalso
-        apply hb
-        congr 1
-        exact h.symm
-      · rfl
-    · intro h
-      exfalso
-      apply h
-      exact Finset.mem_univ _⟩
+  hom := (leftUnitorDet X).toStochastic
+  inv := (leftUnitorInvDet X).toStochastic
   hom_inv_id := by
     apply StochasticMatrix.ext
     ext ⟨⟨⟩, x⟩ ⟨⟨⟩, x'⟩
     simp only [CategoryStruct.comp, StochasticMatrix.comp]
-    -- Round trip: ((),x) → x → ((),x)
     rw [Finset.sum_eq_single x]
-    · simp only [if_true, one_mul]
+    · simp only [DetMorphism.toMatrix_apply, leftUnitorDet, leftUnitorInvDet]
+      simp only [DetMorphism.ofFunc]
       simp only [StochasticMatrix.id, CategoryStruct.id]
-      -- Align equality conditions: x = x' ↔ ((),x) = ((),x')
-      have h : (x = x') = (((), x) = ((), x')) := by
-        simp only [Prod.mk.injEq, true_and]
-      rw [ite_cond_congr h]
-    · intro x' _ hx'
+      by_cases h : ((), x) = ((), x')
+      · simp only [↓reduceIte, h, mul_one, NNReal.coe_one]
+      · simp only [↓reduceIte, h, mul_zero, NNReal.coe_zero]
+    · intro x'' _ hx''
+      simp only [DetMorphism.toMatrix_apply]
       split_ifs with h
-      · exfalso
-        exact hx' (h.symm)
-      · rw [mul_zero]
-      · rw [zero_mul]
-      · rw [mul_zero]
-    · intro h
-      exfalso
-      apply h
-      exact Finset.mem_univ _
+      · have : x'' = x := by
+          simp only [leftUnitorDet, DetMorphism.ofFunc] at h
+          exact h.symm
+        rw [this] at hx''
+        exfalso; exact hx'' rfl
+      · simp only [mul_zero]
+      · simp only [mul_one]
+      · simp only [mul_zero]
+    · intro h; exfalso; exact h (Finset.mem_univ _)
   inv_hom_id := by
     apply StochasticMatrix.ext
-    ext x
+    ext x x'
     simp only [CategoryStruct.comp, StochasticMatrix.comp]
     rw [Finset.sum_eq_single ⟨⟨⟩, x⟩]
-    · simp only [if_true, one_mul]
+    · simp only [DetMorphism.toMatrix_apply, leftUnitorInvDet, leftUnitorDet]
+      simp only [DetMorphism.ofFunc]
       simp only [StochasticMatrix.id, CategoryStruct.id]
+      by_cases h : x = x'
+      · simp only [↓reduceIte, h, mul_one, NNReal.coe_one]
+      · simp only [↓reduceIte, h, mul_zero, NNReal.coe_zero]
     · intro b _ hb
-      obtain ⟨⟨⟩, x'⟩ := b
-      by_cases h : ((), x) = ((), x')
-      · -- Case: ((), x) = ((), x')
-        simp only [Prod.mk.injEq, true_and] at h
-        subst h
-        simp only [if_true, one_mul]
-        exfalso
-        apply hb
-        rfl
-      · -- Case: ((), x) ≠ ((), x')
-        simp only [Prod.mk.injEq, true_and] at h
-        push_neg at h
-        -- Zero when x ≠ x'
-        simp only [h, if_false, zero_mul]
-    · intro h
-      exfalso
-      apply h
-      exact Finset.mem_univ _
+      simp only [DetMorphism.toMatrix_apply]
+      split_ifs with h
+      · have : b = (⟨⟩, x) := by
+          simp only [leftUnitorInvDet, DetMorphism.ofFunc] at h
+          exact h.symm
+        rw [this] at hb
+        exfalso; exact hb rfl
+      · simp only [mul_zero]
+      · simp only [mul_one]
+      · simp only [mul_zero]
+    · intro h; exfalso; exact h (Finset.mem_univ _)
 
-/-- The right unitor removes the trivial right factor from `X ⊗ I` to get `X`.
-
-This maps `(x,()) ↦ x` with probability 1. The unit carries no information,
-so removing it doesn't change the data. The symmetry with the left unitor shows
-tensor products have no preferred order. -/
+/-- Removes trivial right factor from `X ⊗ I` to get `X`. -/
 def rightUnitor (X : FinStoch) : (tensorObj X tensorUnit) ≅ X where
-  hom := ⟨fun ⟨x, ⟨⟩⟩ x' => if x = x' then 1 else 0, fun ⟨x, ⟨⟩⟩ => by
-    rw [Finset.sum_eq_single x]
-    · simp only [if_true]
-    · intro x' _ hx'
-      simp only
-      split_ifs with h
-      · exfalso
-        exact hx' h.symm
-      · rfl
-    · intro h
-      exfalso
-      apply h
-      exact Finset.mem_univ _⟩
-  inv := ⟨fun x ⟨x', ⟨⟩⟩ => if x = x' then 1 else 0, fun x => by
-    rw [Finset.sum_eq_single ⟨x, ⟨⟩⟩]
-    · simp only [if_true]
-    · intro b _ hb
-      obtain ⟨x', ⟨⟩⟩ := b
-      simp only
-      split_ifs with h
-      · exfalso
-        apply hb
-        congr 1
-        exact h.symm
-      · rfl
-    · intro h
-      exfalso
-      apply h
-      exact Finset.mem_univ _⟩
+  hom := (rightUnitorDet X).toStochastic
+  inv := (rightUnitorInvDet X).toStochastic
   hom_inv_id := by
     apply StochasticMatrix.ext
     ext ⟨x, ⟨⟩⟩ ⟨x', ⟨⟩⟩
     simp only [CategoryStruct.comp, StochasticMatrix.comp]
-    -- Round trip: (x,()) → x → (x,())
     rw [Finset.sum_eq_single x]
-    · simp only [if_true, one_mul]
+    · simp only [DetMorphism.toMatrix_apply, rightUnitorDet, rightUnitorInvDet]
+      simp only [DetMorphism.ofFunc]
       simp only [StochasticMatrix.id, CategoryStruct.id]
-      -- Align equality conditions: x = x' ↔ (x,()) = (x',())
-      have h : (x = x') = ((x, ()) = (x', ())) := by
-        simp only [Prod.mk.injEq, and_true]
-      rw [ite_cond_congr h]
-    · intro x' _ hx'
+      by_cases h : (x, ()) = (x', ())
+      · simp only [↓reduceIte, h, mul_one, NNReal.coe_one]
+      · simp only [↓reduceIte, h, mul_zero, NNReal.coe_zero]
+    · intro x'' _ hx''
+      simp only [DetMorphism.toMatrix_apply]
       split_ifs with h
-      · exfalso
-        exact hx' (h.symm)
-      · rw [mul_zero]
-      · rw [zero_mul]
-      · rw [zero_mul]
-    · intro h
-      exfalso
-      apply h
-      exact Finset.mem_univ _
+      · have : x'' = x := by
+          simp only [rightUnitorDet, DetMorphism.ofFunc] at h
+          exact h.symm
+        rw [this] at hx''
+        exfalso; exact hx'' rfl
+      · simp only [mul_zero]
+      · simp only [mul_one]
+      · simp only [mul_zero]
+    · intro h; exfalso; exact h (Finset.mem_univ _)
   inv_hom_id := by
     apply StochasticMatrix.ext
-    ext x
+    ext x x'
     simp only [CategoryStruct.comp, StochasticMatrix.comp]
     rw [Finset.sum_eq_single ⟨x, ⟨⟩⟩]
-    · simp only [if_true, one_mul]
+    · simp only [DetMorphism.toMatrix_apply, rightUnitorInvDet, rightUnitorDet]
+      simp only [DetMorphism.ofFunc]
       simp only [StochasticMatrix.id, CategoryStruct.id]
+      by_cases h : x = x'
+      · simp only [↓reduceIte, h, mul_one, NNReal.coe_one]
+      · simp_all only [↓reduceIte, mul_zero, NNReal.coe_zero]
     · intro b _ hb
-      obtain ⟨x', ⟨⟩⟩ := b
-      by_cases h : (x, ()) = (x', ())
-      · -- Case: (x, ()) = (x', ())
-        simp only [Prod.mk.injEq, and_true] at h
-        subst h
-        simp only [if_true, one_mul]
-        exfalso
-        apply hb
-        rfl
-      · -- Case: (x, ()) ≠ (x', ())
-        simp only [Prod.mk.injEq, and_true] at h
-        push_neg at h
-        -- Zero when x ≠ x'
-        simp only [h, if_false, zero_mul]
-    · intro h
-      exfalso
-      apply h
-      exact Finset.mem_univ _
+      simp only [DetMorphism.toMatrix_apply]
+      split_ifs with h
+      · have : b = (x, ⟨⟩) := by
+          simp only [rightUnitorInvDet, DetMorphism.ofFunc] at h
+          exact h.symm
+        rw [this] at hb
+        exfalso; exact hb rfl
+      · simp only [mul_zero]
+      · simp only [mul_one]
+      · simp only [mul_zero]
+    · intro h; exfalso; exact h (Finset.mem_univ _)
 
-/-- The basic monoidal structure on FinStoch using tensor products of finite types
-and explicit structural isomorphisms. -/
+/-- Basic monoidal structure on FinStoch using tensor products. -/
 instance : MonoidalCategoryStruct FinStoch where
   tensorObj := tensorObj
   tensorUnit := tensorUnit
@@ -329,59 +213,50 @@ lemma associator_matrix (X Y Z : FinStoch) (xyz : ((X ⊗ Y) ⊗ Z).carrier)
     (xyz' : (X ⊗ (Y ⊗ Z)).carrier) :
     (MonoidalCategoryStruct.associator X Y Z).hom.toMatrix xyz xyz' =
     if xyz.1.1 = xyz'.1 ∧ xyz.1.2 = xyz'.2.1 ∧ xyz.2 = xyz'.2.2 then 1 else 0 := by
-  change (associator X Y Z).hom.toMatrix xyz xyz' = _
+  simp only [MonoidalCategoryStruct.associator, associator, DetMorphism.toMatrix_apply]
+  simp only [associatorDet, DetMorphism.ofFunc]
   obtain ⟨⟨x, y⟩, z⟩ := xyz
   obtain ⟨x', ⟨y', z'⟩⟩ := xyz'
-  simp only [associator]
-
-/-- Matrix entry for inverse associator. -/
-@[simp]
-lemma associator_inv_matrix (X Y Z : FinStoch) (xyz : (X ⊗ (Y ⊗ Z)).carrier)
-    (xyz' : ((X ⊗ Y) ⊗ Z).carrier) :
-    (MonoidalCategoryStruct.associator X Y Z).inv.toMatrix xyz xyz' =
-    if xyz.1 = xyz'.1.1 ∧ xyz.2.1 = xyz'.1.2 ∧ xyz.2.2 = xyz'.2 then 1 else 0 := by
-  change (associator X Y Z).inv.toMatrix xyz xyz' = _
-  obtain ⟨x, ⟨y, z⟩⟩ := xyz
-  obtain ⟨⟨x', y'⟩, z'⟩ := xyz'
-  simp only [associator]
+  simp only
+  split
+  next
+    h =>
+    simp_all only [left_eq_ite_iff, not_and, one_ne_zero, imp_false, Classical.not_imp,
+      Decidable.not_not]
+    constructor
+    · cases h; rfl
+    constructor
+    · cases h; rfl
+    · cases h; rfl
+  next h =>
+    simp_all only [right_eq_ite_iff, zero_ne_one, imp_false, not_and]
+    intro hx hy
+    by_contra h_eq
+    -- Now we have z = z', and we want to contradict h
+    have : (x, y, z) = (x', y', z') := by simp only [hx, hy, h_eq]
+    exact h this
 
 /-- Matrix entry for left unitor. -/
 @[simp]
-lemma leftUnitor_matrix (X : FinStoch) (ux : (FinStoch.tensorUnit ⊗ X).carrier) (x : X.carrier) :
+lemma leftUnitor_matrix (X : FinStoch) (ux : (FinStoch.tensorUnit ⊗ X).carrier)
+    (x : X.carrier) :
     (MonoidalCategoryStruct.leftUnitor X).hom.toMatrix ux x =
     if ux.2 = x then 1 else 0 := by
-  change (leftUnitor X).hom.toMatrix ux x = _
+  simp only [MonoidalCategoryStruct.leftUnitor, leftUnitor, DetMorphism.toMatrix_apply]
+  simp only [leftUnitorDet, DetMorphism.ofFunc]
   obtain ⟨⟨⟩, x'⟩ := ux
-  simp only [leftUnitor]
-
-/-- Matrix entry for inverse left unitor. -/
-@[simp]
-lemma leftUnitor_inv_matrix (X : FinStoch) (x : X.carrier)
-    (ux : (FinStoch.tensorUnit ⊗ X).carrier) :
-    (MonoidalCategoryStruct.leftUnitor X).inv.toMatrix x ux =
-    if x = ux.2 then 1 else 0 := by
-  change (leftUnitor X).inv.toMatrix x ux = _
-  obtain ⟨⟨⟩, x'⟩ := ux
-  simp only [leftUnitor]
+  simp only
 
 /-- Matrix entry for right unitor. -/
 @[simp]
-lemma rightUnitor_matrix (X : FinStoch) (xu : (X ⊗ FinStoch.tensorUnit).carrier) (x : X.carrier) :
+lemma rightUnitor_matrix (X : FinStoch) (xu : (X ⊗ FinStoch.tensorUnit).carrier)
+    (x : X.carrier) :
     (MonoidalCategoryStruct.rightUnitor X).hom.toMatrix xu x =
     if xu.1 = x then 1 else 0 := by
-  change (rightUnitor X).hom.toMatrix xu x = _
+  simp only [MonoidalCategoryStruct.rightUnitor, rightUnitor]
+  simp only [rightUnitorDet, DetMorphism.ofFunc]
   obtain ⟨x', ⟨⟩⟩ := xu
-  simp only [rightUnitor]
-
-/-- Matrix entry for inverse right unitor. -/
-@[simp]
-lemma rightUnitor_inv_matrix (X : FinStoch) (x : X.carrier)
-    (xu : (X ⊗ FinStoch.tensorUnit).carrier) :
-    (MonoidalCategoryStruct.rightUnitor X).inv.toMatrix x xu =
-    if x = xu.1 then 1 else 0 := by
-  change (rightUnitor X).inv.toMatrix x xu = _
-  obtain ⟨x', ⟨⟩⟩ := xu
-  simp only [rightUnitor]
+  simp only
 
 /-! ### Deterministic morphisms -/
 
@@ -389,145 +264,258 @@ section Deterministic
 
 open StochasticMatrix
 
-/-- The associator is a deterministic morphism. -/
+/-- The associator is deterministic. -/
 lemma associator_isDeterministic (X Y Z : FinStoch) :
-    (α_ X Y Z).hom.isDeterministic := by
-  intro ⟨⟨x, y⟩, z⟩
-  use (x, (y, z))
-  constructor
-  · simp only [associator_matrix, and_self, if_true]
-  · intro ⟨x', ⟨y', z'⟩⟩ h
-    simp only [associator_matrix] at h
-    split_ifs at h with h_cond
-    · obtain ⟨hx, hy, hz⟩ := h_cond
-      simp [hx, hy, hz]
-    · simp at h
+    (α_ X Y Z).hom.isDeterministic := (associatorDet X Y Z).is_det
 
-/-- The inverse associator is a deterministic morphism. -/
+/-- The inverse associator is deterministic. -/
 lemma associator_inv_isDeterministic (X Y Z : FinStoch) :
-    (α_ X Y Z).inv.isDeterministic := by
-  intro ⟨x, ⟨y, z⟩⟩
-  use ((x, y), z)
-  constructor
-  · simp only [associator_inv_matrix, and_self, if_true]
-  · intro ⟨⟨x', y'⟩, z'⟩ h
-    simp only [associator_inv_matrix] at h
-    split_ifs at h with h_cond
-    · obtain ⟨hx, hy, hz⟩ := h_cond
-      simp [hx, hy, hz]
-    · simp at h
+    (α_ X Y Z).inv.isDeterministic := (associatorInvDet X Y Z).is_det
 
-/-- The left unitor is a deterministic morphism. -/
+/-- The left unitor is deterministic. -/
 lemma leftUnitor_isDeterministic (X : FinStoch) :
-    (λ_ X).hom.isDeterministic := by
-  intro ⟨⟨⟩, x⟩
-  use x
-  constructor
-  · simp only [leftUnitor_matrix, if_true]
-  · intro x' h
-    simp only [leftUnitor_matrix] at h
-    split_ifs at h with h_cond
-    · exact h_cond.symm
-    · simp at h
+    (λ_ X).hom.isDeterministic := (leftUnitorDet X).is_det
 
-/-- The inverse left unitor is a deterministic morphism. -/
+/-- The inverse left unitor is deterministic. -/
 lemma leftUnitor_inv_isDeterministic (X : FinStoch) :
-    (λ_ X).inv.isDeterministic := by
-  intro x
-  use (⟨⟩, x)
-  constructor
-  · simp only [leftUnitor_inv_matrix, if_true]
-  · intro ⟨⟨⟩, x'⟩ h
-    simp only [leftUnitor_inv_matrix] at h
-    split_ifs at h with h_cond
-    · simp [h_cond]
-    · simp at h
+    (λ_ X).inv.isDeterministic := (leftUnitorInvDet X).is_det
 
-/-- The right unitor is a deterministic morphism. -/
+/-- The right unitor is deterministic. -/
 lemma rightUnitor_isDeterministic (X : FinStoch) :
-    (ρ_ X).hom.isDeterministic := by
-  intro ⟨x, ⟨⟩⟩
-  use x
-  constructor
-  · simp only [rightUnitor_matrix, if_true]
-  · intro x' h
-    simp only [rightUnitor_matrix] at h
-    split_ifs at h with h_cond
-    · exact h_cond.symm
-    · simp at h
+    (ρ_ X).hom.isDeterministic := (rightUnitorDet X).is_det
 
-/-- The inverse right unitor is a deterministic morphism. -/
+/-- The inverse right unitor is deterministic. -/
 lemma rightUnitor_inv_isDeterministic (X : FinStoch) :
-    (ρ_ X).inv.isDeterministic := by
-  intro x
-  use (x, ⟨⟩)
-  constructor
-  · simp only [rightUnitor_inv_matrix, if_true]
-  · intro ⟨x', ⟨⟩⟩ h
-    simp only [rightUnitor_inv_matrix] at h
-    split_ifs at h with h_cond
-    · simp [h_cond]
-    · simp at h
+    (ρ_ X).inv.isDeterministic := (rightUnitorInvDet X).is_det
 
 end Deterministic
 
-/-- FinStoch forms a monoidal category with all coherence conditions satisfied.
-This proves Mac Lane's pentagon and triangle identities hold for stochastic matrices. -/
+/-! ### Helper lemmas for pentagon identity -/
+
+section PentagonHelpers
+
+/-- Whisker right of associator with identity -/
+lemma pentagon_whisker_right (W X Y Z : FinStoch)
+    (wwxyz : (((W ⊗ X) ⊗ Y) ⊗ Z).carrier)
+    (wxyyz : ((W ⊗ (X ⊗ Y)) ⊗ Z).carrier) :
+    ((α_ W X Y).hom ▷ Z).toMatrix wwxyz wxyyz =
+    if wwxyz.1.1.1 = wxyyz.1.1 ∧ wwxyz.1.1.2 = wxyyz.1.2.1 ∧
+       wwxyz.1.2 = wxyyz.1.2.2 ∧ wwxyz.2 = wxyyz.2 then 1 else 0 := by
+  simp only [MonoidalCategoryStruct.whiskerRight, StochasticMatrix.tensor]
+  simp only [associator_matrix, StochasticMatrix.id, CategoryStruct.id]
+  obtain ⟨⟨⟨w, x⟩, y⟩, z⟩ := wwxyz
+  obtain ⟨⟨w', ⟨x', y'⟩⟩, z'⟩ := wxyyz
+  simp only
+  by_cases h : w = w' ∧ x = x' ∧ y = y'
+  · obtain ⟨hw, hx, hy⟩ := h
+    subst hw hx hy
+    by_cases hz : z = z'
+    · subst hz
+      simp only [if_true, mul_one, and_self]
+    · simp only [and_self, ↓reduceIte, hz, mul_zero, and_false]
+  · push_neg at h
+    simp only [mul_ite, mul_one, mul_zero]
+    by_cases hz : z = z'
+    · simp only [hz, ↓reduceIte, and_true]
+    · simp only [hz, ↓reduceIte, and_false]
+
+/-- Middle associator in left path -/
+lemma pentagon_middle_assoc (W X Y Z : FinStoch)
+    (wxyyz : ((W ⊗ (X ⊗ Y)) ⊗ Z).carrier)
+    (wxyz : (W ⊗ ((X ⊗ Y) ⊗ Z)).carrier) :
+    (α_ W (X ⊗ Y) Z).hom.toMatrix wxyyz wxyz =
+    if wxyyz.1.1 = wxyz.1 ∧ wxyyz.1.2 = wxyz.2.1 ∧
+       wxyyz.2 = wxyz.2.2 then 1 else 0 := by
+  simp only [associator_matrix]
+
+/-- Whisker left of associator with identity -/
+lemma pentagon_whisker_left (W X Y Z : FinStoch)
+    (wxyyz : (W ⊗ ((X ⊗ Y) ⊗ Z)).carrier)
+    (wxyz : (W ⊗ (X ⊗ (Y ⊗ Z))).carrier) :
+    (W ◁ (α_ X Y Z).hom).toMatrix wxyyz wxyz =
+    if wxyyz.1 = wxyz.1 ∧ wxyyz.2.1.1 = wxyz.2.1 ∧
+       wxyyz.2.1.2 = wxyz.2.2.1 ∧ wxyyz.2.2 = wxyz.2.2.2 then 1 else 0 := by
+  simp only [MonoidalCategoryStruct.whiskerLeft, StochasticMatrix.tensor]
+  simp only [StochasticMatrix.id, CategoryStruct.id, associator_matrix]
+  obtain ⟨w, ⟨⟨x, y⟩, z⟩⟩ := wxyyz
+  obtain ⟨w', ⟨x', ⟨y', z'⟩⟩⟩ := wxyz
+  simp only
+  by_cases hw : w = w'
+  · subst hw
+    by_cases h : x = x' ∧ y = y' ∧ z = z'
+    · simp only [↓reduceIte, h, and_self, mul_one]
+    · push_neg at h
+      simp only [↓reduceIte, mul_ite, mul_one, mul_zero, true_and]
+  · simp only [hw, ↓reduceIte, mul_ite, mul_one, mul_zero, ite_self, false_and]
+
+/-- First associator in right path -/
+lemma pentagon_right_first (W X Y Z : FinStoch)
+    (wwxyz : (((W ⊗ X) ⊗ Y) ⊗ Z).carrier)
+    (wxyz : ((W ⊗ X) ⊗ (Y ⊗ Z)).carrier) :
+    (α_ (W ⊗ X) Y Z).hom.toMatrix wwxyz wxyz =
+    if wwxyz.1.1 = wxyz.1 ∧ wwxyz.1.2 = wxyz.2.1 ∧
+       wwxyz.2 = wxyz.2.2 then 1 else 0 := by
+  simp only [associator_matrix]
+
+/-- Second associator in right path -/
+lemma pentagon_right_second (W X Y Z : FinStoch)
+    (wxyz : ((W ⊗ X) ⊗ (Y ⊗ Z)).carrier)
+    (wxyz' : (W ⊗ (X ⊗ (Y ⊗ Z))).carrier) :
+    (α_ W X (Y ⊗ Z)).hom.toMatrix wxyz wxyz' =
+    if wxyz.1.1 = wxyz'.1 ∧ wxyz.1.2 = wxyz'.2.1 ∧
+       wxyz.2 = wxyz'.2.2 then 1 else 0 := by
+  simp only [associator_matrix]
+
+/-- Left side composition equals indicator function -/
+lemma pentagon_left_composition (W X Y Z : FinStoch)
+    (wwxyz : (((W ⊗ X) ⊗ Y) ⊗ Z).carrier)
+    (wxyz : (W ⊗ (X ⊗ (Y ⊗ Z))).carrier) :
+    ((α_ W X Y).hom ▷ Z ≫ (α_ W (X ⊗ Y) Z).hom ≫ W ◁ (α_ X Y Z).hom).toMatrix wwxyz wxyz =
+    if wwxyz.1.1.1 = wxyz.1 ∧ wwxyz.1.1.2 = wxyz.2.1 ∧
+       wwxyz.1.2 = wxyz.2.2.1 ∧ wwxyz.2 = wxyz.2.2.2 then 1 else 0 := by
+  simp only [CategoryStruct.comp, StochasticMatrix.comp]
+  obtain ⟨⟨⟨w, x⟩, y⟩, z⟩ := wwxyz
+  obtain ⟨w', ⟨x', ⟨y', z'⟩⟩⟩ := wxyz
+  -- First composition: (α_ W X Y).hom ▷ Z
+  rw [Finset.sum_eq_single ⟨⟨w, ⟨x, y⟩⟩, z⟩]
+  · -- Second composition: (α_ W (X ⊗ Y) Z).hom
+    rw [Finset.sum_eq_single ⟨w, ⟨⟨x, y⟩, z⟩⟩]
+    · simp only [pentagon_whisker_right, pentagon_middle_assoc, pentagon_whisker_left]
+      by_cases h : w = w' ∧ x = x' ∧ y = y' ∧ z = z'
+      · obtain ⟨hw, hx, hy, hz⟩ := h
+        subst hw hx hy hz
+        simp only [true_and, if_true, mul_one]
+      · push_neg at h
+        -- When not all equal, at least one condition fails
+        by_cases hw : w = w'
+        · by_cases hxyz : x = x' ∧ y = y' ∧ z = z'
+          · obtain ⟨hx, hy, hz⟩ := hxyz
+            exfalso; exact h hw hx hy hz
+          · push_neg at hxyz
+            simp only [hw, true_and]
+            -- Goal: ((if True ∧ True ∧ True ∧ True then 1 else 0) * ...) = if False...
+            -- Since hw is true but not all of x,y,z match, result should be 0
+            have h_not_all : ¬(x = x' ∧ y = y' ∧ z = z') := by
+              push_neg
+              exact hxyz
+            simp only [h_not_all, if_false]
+            -- Now show the LHS equals 0
+            split_ifs <;> simp
+        · simp only [hw, false_and, if_false, mul_zero]
+    · intro b _ hb
+      simp only [pentagon_middle_assoc, mul_eq_zero]
+      left
+      split_ifs with h
+      · exfalso
+        obtain ⟨h1, h2, h3⟩ := h
+        have : b = ⟨w, ⟨⟨x, y⟩, z⟩⟩ := by
+          cases b; simp only [h1, h2, h3, Prod.mk.eta]
+        exact hb this
+      · rfl
+    · intro habs; exfalso; exact habs (Finset.mem_univ _)
+  · intro b _ hb
+    simp only [pentagon_whisker_right, mul_eq_zero]
+    left
+    split_ifs with h
+    · exfalso
+      obtain ⟨h1, h2, h3, h4⟩ := h
+      have : b = ⟨⟨w, ⟨x, y⟩⟩, z⟩ := by
+        cases b
+        simp only at h1 h2 h3 h4 ⊢
+        simp only [h1, h2, h3, Prod.mk.eta, h4]
+      exact hb this
+    · rfl
+  · intro habs; exfalso; exact habs (Finset.mem_univ _)
+
+/-- Right side composition equals indicator function -/
+lemma pentagon_right_composition (W X Y Z : FinStoch)
+    (wwxyz : (((W ⊗ X) ⊗ Y) ⊗ Z).carrier)
+    (wxyz : (W ⊗ (X ⊗ (Y ⊗ Z))).carrier) :
+    ((α_ (W ⊗ X) Y Z).hom ≫ (α_ W X (Y ⊗ Z)).hom).toMatrix wwxyz wxyz =
+    if wwxyz.1.1.1 = wxyz.1 ∧ wwxyz.1.1.2 = wxyz.2.1 ∧
+       wwxyz.1.2 = wxyz.2.2.1 ∧ wwxyz.2 = wxyz.2.2.2 then 1 else 0 := by
+  simp only [CategoryStruct.comp, StochasticMatrix.comp]
+  obtain ⟨⟨⟨w, x⟩, y⟩, z⟩ := wwxyz
+  obtain ⟨w', ⟨x', ⟨y', z'⟩⟩⟩ := wxyz
+  -- The composition sums over intermediate states
+  -- (α_ (W ⊗ X) Y Z) maps ((w,x),y,z) to ((w,x),(y,z))
+  -- (α_ W X (Y ⊗ Z)) maps ((w,x),(y,z)) to (w,(x,(y,z)))
+  -- Since both are deterministic, the sum has only one non-zero term
+  rw [Finset.sum_eq_single ⟨⟨w, x⟩, ⟨y, z⟩⟩]
+  · -- Evaluate at the unique intermediate point
+    simp only [pentagon_right_first, pentagon_right_second]
+    -- First associator: ((w,x),y,z) → ((w,x),(y,z)) gives 1 iff all match
+    -- This is always 1 since we're mapping ((w,x),y,z) to ((w,x),(y,z))
+    simp only [if_true, true_and]
+    -- Second associator: ((w,x),(y,z)) → (w,(x,(y,z))) gives 1 iff components match
+    -- This is 1 iff w = w' ∧ x = x' ∧ (y,z) = (y',z')
+    -- Which is equivalent to w = w' ∧ x = x' ∧ y = y' ∧ z = z'
+    simp only [one_mul]
+    -- The conditional is: if (w,x) = (w',x') ∧ (y,z) = (y',z') then 1 else 0
+    -- This equals: if w = w' ∧ x = x' ∧ y = y' ∧ z = z' then 1 else 0
+    congr 1
+    -- Expand the product equalities
+    rw [Prod.mk.injEq]
+  · -- Show other terms in sum are zero
+    intro b _ hb
+    simp only [pentagon_right_first, mul_eq_zero]
+    left
+    -- First associator is deterministic: only maps to ((w,x),(y,z))
+    split_ifs with h
+    · exfalso
+      obtain ⟨h1, h2, h3⟩ := h
+      have : b = ⟨⟨w, x⟩, ⟨y, z⟩⟩ := by
+        obtain ⟨⟨b1, b2⟩, ⟨b3, b4⟩⟩ := b
+        simp only at h1 h2 h3
+        simp only [h1, h2, h3]
+      exact hb this
+    · rfl
+  · intro habs; exfalso; exact habs (Finset.mem_univ _)
+
+end PentagonHelpers
+
+/-- FinStoch forms a monoidal category. -/
 instance : MonoidalCategory FinStoch where
   tensorHom_def := by
-    -- Tensor product via whiskering: f ⊗ g = (f ▷ X₂) ≫ (Y₁ ◁ g)
     intros X₁ Y₁ X₂ Y₂ f g
     apply StochasticMatrix.ext
     ext ⟨x₁, x₂⟩ ⟨y₁, y₂⟩
     simp only [MonoidalCategoryStruct.tensorHom, StochasticMatrix.tensor,
                MonoidalCategoryStruct.whiskerRight, MonoidalCategoryStruct.whiskerLeft,
                CategoryStruct.comp, StochasticMatrix.comp]
-    -- (f ▷ X₂) ≫ (Y₁ ◁ g) expands to sum over intermediate states
     rw [Finset.sum_eq_single ⟨y₁, x₂⟩]
     · simp only [StochasticMatrix.id, CategoryStruct.id]
       by_cases h₁ : y₁ = y₁
       · by_cases h₂ : x₂ = x₂
         · simp only [NNReal.coe_mul, ↓reduceIte, mul_one, one_mul]
-        · -- Impossible: x₂ ≠ x₂
-          exfalso
-          exact h₂ rfl
-      · -- Impossible: y₁ ≠ y₁
-        exfalso
-        exact h₁ rfl
+        · exfalso; exact h₂ rfl
+      · exfalso; exact h₁ rfl
     · intro ⟨y₁', x₂'⟩ _ h_ne
       simp only [StochasticMatrix.id, CategoryStruct.id]
-      -- At least one identity matrix is off-diagonal, contributing 0
       by_cases h₁ : y₁' = y₁
       · by_cases h₂ : x₂ = x₂'
         · exfalso
           apply h_ne
-          congr 1
-          · exact h₂.symm
+          rw [h₁, ← h₂]
         · simp only [h₂, ↓reduceIte, mul_zero, ite_mul, one_mul, zero_mul, mul_ite, ite_self]
       · simp only [mul_ite, mul_one, mul_zero, h₁, ↓reduceIte, zero_mul]
-    · intro h
-      exfalso
-      exact h (Finset.mem_univ _)
+    · intro h; exfalso; exact h (Finset.mem_univ _)
   id_tensorHom_id := by
     intros X Y
     apply StochasticMatrix.ext
     ext ⟨x, y⟩ ⟨x', y'⟩
     simp only [MonoidalCategoryStruct.tensorHom, StochasticMatrix.tensor]
     simp only [CategoryStruct.id, StochasticMatrix.id]
-    -- id ⊗ id = id: only (x,y) = (x',y') gets probability 1
     by_cases hx : x = x'
     · by_cases hy : y = y'
-      · -- Both match: prob 1 * 1 = 1
-        simp only [hx, ↓reduceIte, hy, mul_one, NNReal.coe_one]
-      · -- x matches, y doesn't: prob 1 * 0 = 0
-        simp only [hx, ↓reduceIte, hy, mul_zero, NNReal.coe_zero]
+      · simp only [hx, ↓reduceIte, hy, mul_one, NNReal.coe_one]
+      · simp only [hx, ↓reduceIte, hy, mul_zero, NNReal.coe_zero]
         split_ifs with h
         · exfalso
           obtain ⟨_, h2⟩ := h
           exact hy rfl
         · rfl
-    · -- x doesn't match: prob 0 * _ = 0
-      simp only [hx, ↓reduceIte, mul_ite, mul_one, mul_zero, ite_self, NNReal.coe_zero]
+    · simp only [hx, ↓reduceIte, mul_ite, mul_one, mul_zero, ite_self, NNReal.coe_zero]
       split_ifs with h
       · exfalso
         obtain ⟨h1, _⟩ := h
@@ -539,15 +527,8 @@ instance : MonoidalCategory FinStoch where
     ext ⟨x₁, x₂⟩ ⟨z₁, z₂⟩
     simp only [CategoryStruct.comp, StochasticMatrix.comp,
                MonoidalCategoryStruct.tensorHom, StochasticMatrix.tensor]
-    -- Interchange law: (f₁ ≫ g₁) ⊗ (f₂ ≫ g₂) = (f₁ ⊗ f₂) ≫ (g₁ ⊗ g₂)
-    -- LHS: tensor of compositions = (∑ y₁, f₁[x₁,y₁]*g₁[y₁,z₁]) * (∑ y₂, f₂[x₂,y₂]*g₂[y₂,z₂])
-    -- RHS: composition of tensors = ∑ (y₁,y₂), (f₁[x₁,y₁]*f₂[x₂,y₂]) * (g₁[y₁,z₁]*g₂[y₂,z₂])
-
-    -- Use distributivity: product of sums = sum of products
     rw [Finset.sum_mul_sum]
-    -- Convert double sum to sum over product
     simp_rw [← Finset.sum_product']
-    -- Reflexivity handles associativity and commutativity
     ac_rfl
   whiskerLeft_id := by
     intros X Y
@@ -555,14 +536,10 @@ instance : MonoidalCategory FinStoch where
     ext ⟨x, y⟩ ⟨x', y'⟩
     simp only [MonoidalCategoryStruct.whiskerLeft, StochasticMatrix.tensor]
     simp only [CategoryStruct.id, StochasticMatrix.id]
-    -- X ◁ id_Y = id_(X⊗Y): whiskering preserves identities
     by_cases hx : x = x'
     · by_cases hy : y = y'
-      · -- Both match: 1 * 1 = 1
-        subst hx hy
-        simp
-      · -- x matches, y doesn't: 1 * 0 = 0
-        subst hx
+      · subst hx hy; simp
+      · subst hx
         simp only [hy, if_false, mul_zero]
         by_cases h : (x, y) = (x, y')
         · exfalso
@@ -570,8 +547,7 @@ instance : MonoidalCategory FinStoch where
           obtain ⟨_, h2⟩ := h
           exact hy h2
         · simp only [NNReal.coe_zero, h, ↓reduceIte]
-    · -- x doesn't match: 0 * _ = 0
-      simp only [hx, if_false, zero_mul]
+    · simp only [hx, if_false, zero_mul]
       by_cases h : (x, y) = (x', y')
       · exfalso
         simp only [Prod.mk.injEq] at h
@@ -584,14 +560,11 @@ instance : MonoidalCategory FinStoch where
     ext ⟨x, y⟩ ⟨x', y'⟩
     simp only [MonoidalCategoryStruct.whiskerRight, StochasticMatrix.tensor]
     simp only [CategoryStruct.id, StochasticMatrix.id]
-    -- id_X ▷ Y = id_(X⊗Y): symmetric to whiskerLeft_id
     by_cases hx : x = x'
     · by_cases hy : y = y'
-      · -- Both match: 1 * 1 = 1
-        subst hx hy
+      · subst hx hy
         simp only [↓reduceIte, mul_one, NNReal.coe_one]
-      · -- x matches, y doesn't: 1 * 0 = 0
-        subst hx
+      · subst hx
         simp only [hy, if_false, mul_zero]
         by_cases h : (x, y) = (x, y')
         · exfalso
@@ -599,8 +572,7 @@ instance : MonoidalCategory FinStoch where
           obtain ⟨_, h2⟩ := h
           exact hy h2
         · simp only [NNReal.coe_zero, h, ↓reduceIte]
-    · -- x doesn't match: 0 * _ = 0
-      simp only [hx, if_false, zero_mul]
+    · simp only [hx, if_false, zero_mul]
       by_cases h : (x, y) = (x', y')
       · exfalso
         simp only [Prod.mk.injEq] at h
@@ -608,78 +580,47 @@ instance : MonoidalCategory FinStoch where
         exact hx h1
       · simp only [NNReal.coe_zero, h, ↓reduceIte]
   associator_naturality := by
-    -- Naturality follows from deterministic associator
     intros X₁ X₂ X₃ Y₁ Y₂ Y₃ f₁ f₂ f₃
     apply StochasticMatrix.ext
     ext ⟨⟨x₁, x₂⟩, x₃⟩ ⟨y₁, ⟨y₂, y₃⟩⟩
     simp only [CategoryStruct.comp, StochasticMatrix.comp,
                MonoidalCategoryStruct.tensorHom, StochasticMatrix.tensor]
-
-    -- Both sides are sums that isolate the same unique term
-    -- LHS: sum over intermediate ((y₁', y₂'), y₃')
     rw [Finset.sum_eq_single ⟨⟨y₁, y₂⟩, y₃⟩]
-    · -- Main term: associator gives 1 for correct rearrangement
-      simp only [associator_matrix, and_self, ↓reduceIte, mul_one, NNReal.coe_mul, ite_mul, one_mul,
-                 zero_mul, NNReal.coe_sum]
-      -- RHS: sum over intermediate (x₁', (x₂', x₃'))
+    · simp only [associator_matrix, and_self, ↓reduceIte, mul_one, NNReal.coe_mul, ite_mul,
+                 one_mul, zero_mul, NNReal.coe_sum]
       rw [Finset.sum_eq_single ⟨x₁, ⟨x₂, x₃⟩⟩]
-      · -- Main term: both associators give 1 for the deterministic rearrangement
-        -- Directly evaluate both sides
-        norm_num
-        ring
-      · -- Other terms: associator gives 0
-        intro ⟨x₁', ⟨x₂', x₃'⟩⟩ _ h_ne
-        -- Associator is 0 unless coordinates match exactly
+      · norm_num; ring
+      · intro ⟨x₁', ⟨x₂', x₃'⟩⟩ _ h_ne
         by_cases h : x₁' = x₁ ∧ x₂' = x₂ ∧ x₃' = x₃
-        · -- This contradicts h_ne
-          exfalso
+        · exfalso
           apply h_ne
-          simp [h]
+          simp only [h]
         · simp only [NNReal.coe_eq_zero, ite_eq_right_iff, mul_eq_zero, and_imp]
           intro a_1 a_2 a_3
           subst a_3 a_2 a_1
           simp_all only [Finset.mem_univ, ne_eq, not_true_eq_false]
-      · intro
-        exfalso
-        apply ‹_›
-        exact Finset.mem_univ _
-    · -- Other terms: wrong intermediate state gives 0
-      intro ⟨⟨y₁', y₂'⟩, y₃'⟩ _ h_ne
-      -- Associator is 0 unless coordinates match exactly
+      · intro; exfalso; apply ‹_›; exact Finset.mem_univ _
+    · intro ⟨⟨y₁', y₂'⟩, y₃'⟩ _ h_ne
       by_cases h : y₁' = y₁ ∧ y₂' = y₂ ∧ y₃' = y₃
-      · -- This contradicts h_ne
-        exfalso
+      · exfalso
         apply h_ne
-        simp [h]
-      · -- Show associator matrix entry is 0
-        have h_assoc_zero : (MonoidalCategoryStruct.associator Y₁ Y₂ Y₃).hom.toMatrix
+        simp only [h]
+      · have h_assoc_zero : (MonoidalCategoryStruct.associator Y₁ Y₂ Y₃).hom.toMatrix
                               ((y₁', y₂'), y₃') (y₁, y₂, y₃) = 0 := by
-          change (associator Y₁ Y₂ Y₃).hom.toMatrix ((y₁', y₂'), y₃') (y₁, y₂, y₃) = 0
-          simp only [associator]
-          -- The condition y₁' = y₁ ∧ y₂' = y₂ ∧ y₃' = y₃ contradicts h
+          simp only [associator_matrix]
           simp only [h, if_false]
         rw [h_assoc_zero, mul_zero]
-    · intro
-      exfalso
-      apply ‹_›
-      exact Finset.mem_univ _
+    · intro; exfalso; apply ‹_›; exact Finset.mem_univ _
   leftUnitor_naturality := by
     intros X Y f
     apply StochasticMatrix.ext
     ext ⟨⟨⟩, x⟩ y
-    -- LHS: (𝟙 ⊗ f) ≫ λ_Y, RHS: λ_X ≫ f
     simp only [CategoryStruct.comp, StochasticMatrix.comp]
-
-    -- LHS: Sum over intermediate ((), y') in tensorUnit × Y
     rw [Finset.sum_eq_single ⟨⟨⟩, y⟩]
-    · -- Main case: show LHS = RHS = f.toMatrix x y
-      -- First simplify LHS tensor operation
-      simp only [MonoidalCategoryStruct.whiskerLeft, StochasticMatrix.tensor, CategoryStruct.id,
+    · simp only [MonoidalCategoryStruct.whiskerLeft, StochasticMatrix.tensor, CategoryStruct.id,
                  StochasticMatrix.id, ↓reduceIte, one_mul, leftUnitor_matrix, mul_one, ite_mul,
                  zero_mul, Finset.sum_ite_eq, Finset.mem_univ]
-
-    · -- Other intermediate states contribute 0 to LHS
-      intro ⟨⟨⟩, y'⟩ _ h_ne
+    · intro ⟨⟨⟩, y'⟩ _ h_ne
       have h_neq : y' ≠ y := by
         intro h_eq
         apply h_ne
@@ -687,58 +628,33 @@ instance : MonoidalCategory FinStoch where
       simp only [MonoidalCategoryStruct.whiskerLeft, StochasticMatrix.tensor]
       simp only [CategoryStruct.id, StochasticMatrix.id]
       have h_unitor_zero : (MonoidalCategoryStruct.leftUnitor Y).hom.toMatrix (⟨⟩, y') y = 0 := by
-        change (leftUnitor Y).hom.toMatrix (⟨⟩, y') y = 0
-        simp only [leftUnitor, h_neq, if_false]
+        simp only [leftUnitor_matrix, h_neq, if_false]
       simp only [h_unitor_zero, mul_zero]
-
-    · -- Membership
-      intro h
-      exfalso
-      exact h (Finset.mem_univ _)
+    · intro h; exfalso; exact h (Finset.mem_univ _)
   rightUnitor_naturality := by
     intros X Y f
     apply StochasticMatrix.ext
     ext ⟨x, ⟨⟩⟩ y
-    -- LHS: (f ⊗ 𝟙 tensorUnit) ≫ (rightUnitor Y).hom
-    -- RHS: (rightUnitor X).hom ≫ f
     simp only [CategoryStruct.comp, StochasticMatrix.comp]
-
-    -- LHS: Sum over intermediate (y', ()) in Y × tensorUnit
     rw [Finset.sum_eq_single ⟨y, ⟨⟩⟩]
-    · -- Main case: show LHS = RHS = f.toMatrix x y
-      -- First simplify LHS tensor operation
-      simp only [MonoidalCategoryStruct.whiskerRight, StochasticMatrix.tensor]
+    · simp only [MonoidalCategoryStruct.whiskerRight, StochasticMatrix.tensor]
       simp only [CategoryStruct.id, StochasticMatrix.id]
-      -- LHS: f[x,y] * 1 * rightUnitor_Y[(y,()), y] = f[x,y] * 1 = f[x,y]
       have h_right_unitor : (MonoidalCategoryStruct.rightUnitor Y).hom.toMatrix (y,⟨⟩) y = 1 := by
-        change (rightUnitor Y).hom.toMatrix (y, ⟨⟩) y = 1
-        simp only [rightUnitor, if_true]
+        simp only [rightUnitor_matrix, if_true]
       simp only [h_right_unitor, mul_one]
-
-      -- Now show RHS = f.toMatrix x y
-      -- RHS: Sum over intermediate x' in X
       rw [Finset.sum_eq_single x]
-      · -- Main term: rightUnitor_X[(x,()), x] * f[x,y] = 1 * f[x,y] = f[x,y]
-        have h_right_unitor :
+      · have h_right_unitor :
           (MonoidalCategoryStruct.rightUnitor X).hom.toMatrix (x, ⟨⟩) x = 1 := by
-          change (rightUnitor X).hom.toMatrix (x, ⟨⟩) x = 1
-          simp only [rightUnitor, if_true]
+          simp only [rightUnitor_matrix, if_true]
         simp only [↓reduceIte, mul_one, h_right_unitor, one_mul]
-      · -- Other terms: rightUnitor gives 0 for x' ≠ x
-        intro x' _ h_ne
+      · intro x' _ h_ne
         have h_unitor_zero :
           (MonoidalCategoryStruct.rightUnitor X).hom.toMatrix (x, ⟨⟩) x' = 0 := by
-          change (rightUnitor X).hom.toMatrix (x, ⟨⟩) x' = 0
-          simp only [rightUnitor]
+          simp only [rightUnitor_matrix]
           rw [if_neg h_ne.symm]
         simp only [h_unitor_zero, zero_mul]
-      · -- Membership
-        intro h
-        exfalso
-        exact h (Finset.mem_univ _)
-
-    · -- Other intermediate states contribute 0 to LHS
-      intro ⟨y', ⟨⟩⟩ _ h_ne
+      · intro h; exfalso; exact h (Finset.mem_univ _)
+    · intro ⟨y', ⟨⟩⟩ _ h_ne
       have h_neq : y' ≠ y := by
         intro h_eq
         apply h_ne
@@ -746,273 +662,40 @@ instance : MonoidalCategory FinStoch where
       simp only [MonoidalCategoryStruct.whiskerRight, StochasticMatrix.tensor]
       simp only [CategoryStruct.id, StochasticMatrix.id]
       have h_unitor_zero : (MonoidalCategoryStruct.rightUnitor Y).hom.toMatrix (y', ⟨⟩) y = 0 := by
-        change (rightUnitor Y).hom.toMatrix (y', ⟨⟩) y = 0
-        simp only [rightUnitor, h_neq, if_false]
+        simp only [rightUnitor_matrix, h_neq, if_false]
       simp only [h_unitor_zero, mul_zero]
-
-    · -- Membership
-      intro h
-      exfalso
-      exact h (Finset.mem_univ _)
+    · intro h; exfalso; exact h (Finset.mem_univ _)
   pentagon := by
     intros W X Y Z
     apply StochasticMatrix.ext
     ext ⟨⟨⟨w, x⟩, y⟩, z⟩ ⟨w', ⟨x', ⟨y', z'⟩⟩⟩
-    -- Pentagon: two paths from (((W ⊗ X) ⊗ Y) ⊗ Z) to (W ⊗ (X ⊗ (Y ⊗ Z)))
-
-    simp only [CategoryStruct.comp, StochasticMatrix.comp]
-
-    -- Both sides sum over intermediate states
-    -- LHS path: (((w,x),y),z) → ((w,(x,y)),z) → (w,((x,y),z)) → (w,(x,(y,z)))
-    -- RHS path: (((w,x),y),z) → ((w,x),(y,z)) → (w,(x,(y,z)))
-
-    -- LHS: First composition
-    rw [Finset.sum_eq_single ⟨⟨w, ⟨x, y⟩⟩, z⟩]
-    · -- Second composition
-      rw [Finset.sum_eq_single ⟨w, ⟨⟨x, y⟩, z⟩⟩]
-      · -- Evaluate all three morphisms in the LHS composition
-        -- (α_ W X Y).hom ▷ Z
-        simp only [MonoidalCategoryStruct.whiskerRight, StochasticMatrix.tensor]
-        simp only [CategoryStruct.id, StochasticMatrix.id]
-        -- Evaluate associator W X Y at ((w, x), y) → (w, (x, y))
-        have h_assoc1 : (MonoidalCategoryStruct.associator W X Y).hom.toMatrix
-                        ((w, x), y) (w, (x, y)) = 1 := by
-          change (associator W X Y).hom.toMatrix ((w, x), y) (w, (x, y)) = 1
-          simp only [associator, and_self, ↓reduceIte]
-        simp only [h_assoc1, one_mul]
-
-        -- (α_ W (X ⊗ Y) Z).hom
-        -- Evaluate at ((w, (x, y)), z) → (w, ((x, y), z))
-        have h_assoc2 : (MonoidalCategoryStruct.associator W
-                         (MonoidalCategoryStruct.tensorObj X Y) Z).hom.toMatrix
-                        ((w, (x, y)), z) (w, ((x, y), z)) = 1 := by
-          change (associator W (FinStoch.tensorObj X Y) Z).hom.toMatrix
-                 ((w, (x, y)), z) (w, ((x, y), z)) = 1
-          simp only [associator, and_self, ↓reduceIte]
-        simp only [h_assoc2, one_mul]
-
-        -- W ◁ (α_ X Y Z).hom
-        simp only [MonoidalCategoryStruct.whiskerLeft, StochasticMatrix.tensor]
-        simp only [CategoryStruct.id, StochasticMatrix.id]
-
-        -- Now evaluate the LHS fully
-        -- We have: 1 * 1 * (id_W ⊗ associator X Y Z)[(w, ((x,y),z)), (w', (x',(y',z')))]
-        -- This equals: (if w = w' then 1 else 0) * associator[((x,y),z), (x',(y',z'))]
-        -- The associator gives: if x = x' ∧ y = y' ∧ z = z' then 1 else 0
-        simp only [if_true, one_mul]
-
-        -- Manually expand the associator
-        have h_assoc3_eval : (MonoidalCategoryStruct.associator X Y Z).hom.toMatrix
-                             ((x, y), z) (x', y', z') =
-                             if x = x' ∧ y = y' ∧ z = z' then 1 else 0 := by
-          change (associator X Y Z).hom.toMatrix ((x, y), z) (x', y', z') = _
-          simp only [associator]
-        simp only [h_assoc3_eval]
-
-        -- RHS: First composition
-        rw [Finset.sum_eq_single ⟨⟨w, x⟩, ⟨y, z⟩⟩]
-        · -- Evaluate both morphisms in the RHS composition
-          -- (α_ (W ⊗ X) Y Z).hom - this is always 1 since we picked the exact intermediate state
-          have h_assoc4 : (MonoidalCategoryStruct.associator
-                           (MonoidalCategoryStruct.tensorObj W X) Y Z).hom.toMatrix
-                          (((w, x), y), z) ((w, x), (y, z)) = 1 := by
-            change (associator (FinStoch.tensorObj W X) Y Z).hom.toMatrix
-                   (((w, x), y), z) ((w, x), (y, z)) = 1
-            simp only [associator]
-            simp [and_self]
-          simp only [h_assoc4, one_mul]
-
-          -- (α_ W X (Y ⊗ Z)).hom - need to evaluate at general output
-          have h_assoc5_eval : (MonoidalCategoryStruct.associator W X
-                               (MonoidalCategoryStruct.tensorObj Y Z)).hom.toMatrix
-                              ((w, x), (y, z)) (w', (x', (y', z'))) =
-                              if w = w' ∧ x = x' ∧ (y, z) = (y', z') then 1 else 0 := by
-            change (associator W X (FinStoch.tensorObj Y Z)).hom.toMatrix
-                   ((w, x), (y, z)) (w', (x', (y', z'))) = _
-            simp only [associator]
-          simp only [h_assoc5_eval]
-
-          -- Both sides equal 1 if all coordinates match, 0 otherwise
-          by_cases h : w = w' ∧ x = x' ∧ y = y' ∧ z = z'
-          · obtain ⟨hw, hx, hy, hz⟩ := h
-            simp only [hw, ↓reduceIte, hx, hy, hz, and_self, mul_one, NNReal.coe_one]
-          · push_neg at h
-            -- At least one coordinate doesn't match, so result is 0
-            by_cases hw : w = w'
-            · by_cases hx : x = x'
-              · by_cases hy : y = y'
-                · -- w, x, y match but z doesn't
-                  have hz : ¬(z = z') := by
-                    intro hz'
-                    apply h
-                    exact hw
-                    exact hx
-                    exact hy
-                    exact hz'
-                  simp only [hw, ↓reduceIte, hx, hy, hz, and_false, mul_zero, NNReal.coe_zero,
-                    Prod.mk.injEq]
-                · -- w, x match but y doesn't
-                  simp only [hw, ↓reduceIte, hx, hy, false_and, and_false, mul_zero,
-                    NNReal.coe_zero, Prod.mk.injEq]
-              · -- w matches but x doesn't
-                simp only [hw, ↓reduceIte, hx, false_and, mul_zero, NNReal.coe_zero, Prod.mk.injEq,
-                  and_false]
-            · -- w doesn't match
-              simp only [hw, ↓reduceIte, mul_ite, mul_one, mul_zero, ite_self, NNReal.coe_zero,
-                Prod.mk.injEq, false_and]
-
-        · -- Other RHS intermediate states give 0
-          intro ⟨⟨w₁, x₁⟩, ⟨y₁, z₁⟩⟩ _ h_ne
-          -- First associator is 0 unless all match
-          have h_assoc_zero : (MonoidalCategoryStruct.associator
-                               (MonoidalCategoryStruct.tensorObj W X) Y Z).hom.toMatrix
-                              (((w, x), y), z) ((w₁, x₁), (y₁, z₁)) = 0 := by
-            change (associator (FinStoch.tensorObj W X) Y Z).hom.toMatrix
-                   (((w, x), y), z) ((w₁, x₁), (y₁, z₁)) = 0
-            simp only [associator]
-            by_cases h : (w, x) = (w₁, x₁) ∧ y = y₁ ∧ z = z₁
-            · -- This would contradict h_ne
-              obtain ⟨⟨hw, hx⟩, hy, hz⟩ := h
-              exfalso
-              apply h_ne
-              simp only [hy, hz]
-            · push_neg at h
-              simp only [ite_eq_right_iff, one_ne_zero, imp_false, not_and]
-              exact h
-          simp only [h_assoc_zero, associator_matrix, mul_ite, mul_one, mul_zero, ite_self]
-
-        · intro h; exfalso; exact h (Finset.mem_univ _)
-
-      · -- Other LHS second intermediate states give 0
-        intro ⟨w₁, ⟨⟨x₁, y₁⟩, z₁⟩⟩ _ h_ne
-        -- Second associator is 0 unless all match
-        have h_assoc_zero : (MonoidalCategoryStruct.associator W
-                             (MonoidalCategoryStruct.tensorObj X Y) Z).hom.toMatrix
-                            ((w, (x, y)), z) (w₁, ((x₁, y₁), z₁)) = 0 := by
-          change (associator W (FinStoch.tensorObj X Y) Z).hom.toMatrix
-                 ((w, (x, y)), z) (w₁, ((x₁, y₁), z₁)) = 0
-          simp only [associator]
-          by_cases h : w = w₁ ∧ (x, y) = (x₁, y₁) ∧ z = z₁
-          · -- This would contradict h_ne
-            obtain ⟨hw, ⟨hx, hy⟩, hz⟩ := h
-            exfalso
-            apply h_ne
-            simp only [hw, hz]
-          · push_neg at h
-            rw [if_neg]
-            simp only [not_and]
-            exact h
-        simp only [h_assoc_zero, zero_mul]
-
-      · -- Membership
-        intro h; exfalso; exact h (Finset.mem_univ _)
-
-    · -- Other LHS first intermediate states give 0
-      intro ⟨⟨w₁, ⟨x₁, y₁⟩⟩, z₁⟩ _ h_ne
-      -- First whiskerRight is 0 unless all match
-      simp only [MonoidalCategoryStruct.whiskerRight, StochasticMatrix.tensor]
-      simp only [CategoryStruct.id, StochasticMatrix.id]
-      -- The whiskerRight (associator ⊗ id_Z) gives 0 when
-      -- ((w₁, (x₁, y₁)), z₁) ≠ ((w, (x, y)), z)
-      -- This happens when either part is 0
-      by_cases h_match : (w₁, (x₁, y₁)) = (w, (x, y)) ∧ z₁ = z
-      · -- If both parts match, we'd have ((w₁, (x₁, y₁)), z₁) = ((w, (x, y)), z)
-        -- But this contradicts h_ne
-        obtain ⟨h_assoc, h_z⟩ := h_match
-        exfalso
-        apply h_ne
-        congr 1
-      · -- At least one part doesn't match, so the tensor product gives 0
-        push_neg at h_match
-        -- The product (associator W X Y)[((w,x),y), (w₁,(x₁,y₁))] * id_Z[z, z₁]
-        -- is 0 if either factor is 0
-        by_cases h_assoc : (w₁, (x₁, y₁)) = (w, (x, y))
-        · -- Associator part matches, so identity part must not match
-          have h_z : z₁ ≠ z := h_match h_assoc
-          -- The product is associator * id_Z = 1 * 0 = 0
-          simp only [associator_matrix, mul_ite, mul_one, mul_zero, ite_mul, one_mul, zero_mul,
-            ite_eq_right_iff, Finset.sum_eq_zero_iff, Finset.mem_univ, and_imp, forall_const]
-          intro a_1 a_2 a_3 a_4 i a_5 a_6 a_7
-          subst a_1 a_4 a_3 a_2 a_5 a_7
-          simp_all only [ne_eq, not_true_eq_false]
-        · -- Associator part doesn't match, so it gives 0
-          -- Show the associator gives 0
-          · -- Associator part doesn't match, so it gives 0
-            have h_assoc_zero : (MonoidalCategoryStruct.associator W X Y).hom.toMatrix
-                                ((w, x), y) (w₁, (x₁, y₁)) = 0 := by
-              simp only [MonoidalCategoryStruct.associator, associator]
-              rw [if_neg]
-              -- Associator gives 1 iff (w₁, (x₁, y₁)) = (w, (x, y))
-              -- But h_assoc says they differ
-              intro h_components
-              obtain ⟨hw, hx, hy⟩ := h_components
-              apply h_assoc
-              simp only [hw, hx, hy]
-            simp only [h_assoc_zero, zero_mul]
-
-    · -- Membership
-      intro h; exfalso; exact h (Finset.mem_univ _)
-
+    -- Use the helper lemmas we proved
+    simp only [pentagon_left_composition, pentagon_right_composition]
   triangle := by
     intros X Y
     apply StochasticMatrix.ext
     ext ⟨⟨x, ⟨⟩⟩, y⟩ ⟨x', y'⟩
-    -- Triangle: (α_ X (𝟙_ _) Y).hom ≫ X ◁ (λ_ Y).hom = (ρ_ X).hom ▷ Y
-    -- Both sides map ((x, ()), y) ↦ (x, y) deterministically
-
     simp only [CategoryStruct.comp, StochasticMatrix.comp]
-
-    -- LHS: composition of associator and whiskerLeft
-    -- Sum over intermediate states (x₁, ((), y₁))
+    -- Both sides map ((x, ()), y) ↦ (x, y) deterministically
     rw [Finset.sum_eq_single ⟨x, ⟨⟨⟩, y⟩⟩]
-    · -- Main term: intermediate state (x, ((), y))
-      -- Evaluate associator at ((x, ()), y) → (x, ((), y))
-      have h_assoc : (MonoidalCategoryStruct.associator X
-                       (MonoidalCategoryStruct.tensorUnit FinStoch) Y).hom.toMatrix
-                       ((x, PUnit.unit), y) (x, PUnit.unit, y) = 1 := by
-        change (associator X tensorUnit Y).hom.toMatrix ((x, ()), y) (x, ((), y)) = 1
-        simp only [associator, and_self, ↓reduceIte]
-
-      -- Evaluate whiskerLeft = id_X ⊗ λ_Y at (x, ((), y)) → (x', y')
+    · simp only [associator_matrix, and_self, ↓reduceIte, NNReal.coe_inj]
       simp only [MonoidalCategoryStruct.whiskerLeft, StochasticMatrix.tensor]
       simp only [CategoryStruct.id, StochasticMatrix.id]
-
-      -- Simplify tuple projections
-      simp only [h_assoc, leftUnitor_matrix, mul_ite, mul_one, mul_zero, NNReal.coe_inj]
-
-      -- Evaluate leftUnitor
-      have h_left : (MonoidalCategoryStruct.leftUnitor Y).hom.toMatrix (PUnit.unit, y) y' =
-                    if y = y' then 1 else 0 := by
-        change (leftUnitor Y).hom.toMatrix ((), y) y' = if y = y' then 1 else 0
-        simp only [leftUnitor]
-
-      simp_all only [associator_matrix, and_self, ↓reduceIte, leftUnitor_matrix]
-
-      -- Evaluate RHS: rightUnitor ⊗ id_Y
+      simp_all only [leftUnitor_matrix]
       simp only [MonoidalCategoryStruct.whiskerRight, StochasticMatrix.tensor]
       simp only [CategoryStruct.id, StochasticMatrix.id]
       simp_all only [rightUnitor_matrix, mul_ite, mul_one, mul_zero]
-
-    · -- Other intermediate states: associator gives 0
-      intro ⟨x₁, ⟨⟨⟩, y₁⟩⟩ _ h_ne
-      -- The associator is 0 unless (x₁, y₁) = (x, y)
+    · intro ⟨x₁, ⟨⟨⟩, y₁⟩⟩ _ h_ne
       have h_assoc_zero : (MonoidalCategoryStruct.associator X
                            (MonoidalCategoryStruct.tensorUnit FinStoch) Y).hom.toMatrix
                            ((x, PUnit.unit), y) (x₁, PUnit.unit, y₁) = 0 := by
-        change (associator X tensorUnit Y).hom.toMatrix ((x, ()), y) (x₁, ((), y₁)) = 0
-        simp only [associator]
-        simp_all only [Finset.mem_univ, ne_eq, true_and, ite_eq_right_iff, one_ne_zero, imp_false,
-                       not_and]
-        intro a
-        subst a
-        apply Aesop.BuiltinRules.not_intro
-        intro a
-        subst a
+        simp only [associator_matrix]
+        simp_all only [Finset.mem_univ, ne_eq, true_and, ite_eq_right_iff, one_ne_zero,
+                       imp_false, not_and]
+        intro a; subst a
+        intro a; subst a
         simp_all only [not_true_eq_false]
-
       simp only [h_assoc_zero, zero_mul]
-
-    · -- Membership: all states exist in finite type
-      intro h; exfalso; exact h (Finset.mem_univ _)
+    · intro h; exfalso; exact h (Finset.mem_univ _)
 
 end CategoryTheory.MarkovCategory

--- a/Mathlib/CategoryTheory/MarkovCategory/FinStoch/Monoidal.lean
+++ b/Mathlib/CategoryTheory/MarkovCategory/FinStoch/Monoidal.lean
@@ -5,6 +5,7 @@ Authors: Jacob Reinhold
 -/
 import Mathlib.CategoryTheory.MarkovCategory.FinStoch.Basic
 import Mathlib.CategoryTheory.Monoidal.Category
+import Mathlib.Data.NNReal.Basic
 
 /-!
 # Monoidal Structure on FinStoch

--- a/Mathlib/CategoryTheory/MarkovCategory/FinStoch/Monoidal.lean
+++ b/Mathlib/CategoryTheory/MarkovCategory/FinStoch/Monoidal.lean
@@ -41,6 +41,8 @@ universe u
 
 open FinStoch
 
+
+
 /-! ### Structural isomorphisms using DetMorphism -/
 
 /-- Rearranges `((X ⊗ Y) ⊗ Z)` to `(X ⊗ (Y ⊗ Z))`. -/
@@ -52,23 +54,20 @@ def associator (X Y Z : FinStoch) :
     apply StochasticMatrix.ext
     ext ⟨⟨x, y⟩, z⟩ ⟨⟨x', y'⟩, z'⟩
     simp only [CategoryStruct.comp, StochasticMatrix.comp]
+    -- Associator is deterministic: ((x,y),z) → (x,(y,z)) → ((x,y),z)
+    -- The only non-zero path is through the intermediate (x,(y,z))
     rw [Finset.sum_eq_single ⟨x, ⟨y, z⟩⟩]
-    · simp only [associatorDet, associatorInvDet, DetMorphism.ofFunc]
-      cat_disch
-    · intro b _ hb
-      simp only [associatorDet, associatorInvDet, DetMorphism.ofFunc]
-      cat_disch
+    · simp only [associatorDet, associatorInvDet, DetMorphism.ofFunc]; cat_disch
+    · intro b _ hb; simp only [associatorDet, associatorInvDet, DetMorphism.ofFunc]; cat_disch
     · intro h; exfalso; exact h (Finset.mem_univ _)
   inv_hom_id := by
     apply StochasticMatrix.ext
     ext ⟨x, ⟨y, z⟩⟩ ⟨x', ⟨y', z'⟩⟩
     simp only [CategoryStruct.comp, StochasticMatrix.comp]
+    -- Inverse path: (x,(y,z)) → ((x,y),z) → (x,(y,z))
     rw [Finset.sum_eq_single ⟨⟨x, y⟩, z⟩]
-    · simp only [associatorInvDet, associatorDet, DetMorphism.ofFunc]
-      cat_disch
-    · intro b _ hb
-      simp only [associatorInvDet, associatorDet, DetMorphism.ofFunc]
-      cat_disch
+    · simp only [associatorInvDet, associatorDet, DetMorphism.ofFunc]; cat_disch
+    · intro b _ hb; simp only [associatorInvDet, associatorDet, DetMorphism.ofFunc]; cat_disch
     · intro h; exfalso; exact h (Finset.mem_univ _)
 
 /-- Removes trivial left factor from `I ⊗ X` to get `X`. -/
@@ -79,21 +78,19 @@ def leftUnitor (X : FinStoch) : (tensorObj tensorUnit X) ≅ X where
     apply StochasticMatrix.ext
     ext ⟨⟨⟩, x⟩ ⟨⟨⟩, x'⟩
     simp only [CategoryStruct.comp, StochasticMatrix.comp]
+    -- ((),x) → x → ((),x) is identity
     rw [Finset.sum_eq_single x]
-    · simp only [leftUnitorDet, leftUnitorInvDet, DetMorphism.ofFunc]
-      cat_disch
-    · simp only [leftUnitorDet, leftUnitorInvDet, DetMorphism.ofFunc]
-      cat_disch
+    · simp only [leftUnitorDet, leftUnitorInvDet, DetMorphism.ofFunc]; cat_disch
+    · intro b _ hb; simp only [leftUnitorDet, leftUnitorInvDet, DetMorphism.ofFunc]; cat_disch
     · intro h; exfalso; exact h (Finset.mem_univ _)
   inv_hom_id := by
     apply StochasticMatrix.ext
     ext x x'
     simp only [CategoryStruct.comp, StochasticMatrix.comp]
+    -- x → ((),x) → x is identity
     rw [Finset.sum_eq_single ⟨⟨⟩, x⟩]
-    · simp only [leftUnitorInvDet, leftUnitorDet, DetMorphism.ofFunc]
-      cat_disch
-    · simp only [leftUnitorDet, leftUnitorInvDet, DetMorphism.ofFunc]
-      cat_disch
+    · simp only [leftUnitorInvDet, leftUnitorDet, DetMorphism.ofFunc]; cat_disch
+    · intro b _ hb; simp only [leftUnitorInvDet, leftUnitorDet, DetMorphism.ofFunc]; cat_disch
     · intro h; exfalso; exact h (Finset.mem_univ _)
 
 /-- Removes trivial right factor from `X ⊗ I` to get `X`. -/
@@ -105,20 +102,16 @@ def rightUnitor (X : FinStoch) : (tensorObj X tensorUnit) ≅ X where
     ext ⟨x, ⟨⟩⟩ ⟨x', ⟨⟩⟩
     simp only [CategoryStruct.comp, StochasticMatrix.comp]
     rw [Finset.sum_eq_single x]
-    · simp only [rightUnitorDet, rightUnitorInvDet, DetMorphism.ofFunc]
-      cat_disch
-    · simp only [rightUnitorDet, rightUnitorInvDet, DetMorphism.ofFunc]
-      cat_disch
+    · simp only [rightUnitorDet, rightUnitorInvDet, DetMorphism.ofFunc]; cat_disch
+    · intro b _ hb; simp only [rightUnitorDet, rightUnitorInvDet, DetMorphism.ofFunc]; cat_disch
     · intro h; exfalso; exact h (Finset.mem_univ _)
   inv_hom_id := by
     apply StochasticMatrix.ext
     ext x x'
     simp only [CategoryStruct.comp, StochasticMatrix.comp]
     rw [Finset.sum_eq_single ⟨x, ⟨⟩⟩]
-    · simp only [rightUnitorDet, rightUnitorInvDet, DetMorphism.ofFunc]
-      cat_disch
-    · simp only [rightUnitorDet, rightUnitorInvDet, DetMorphism.ofFunc]
-      cat_disch
+    · simp only [rightUnitorInvDet, rightUnitorDet, DetMorphism.ofFunc]; cat_disch
+    · intro b _ hb; simp only [rightUnitorInvDet, rightUnitorDet, DetMorphism.ofFunc]; cat_disch
     · intro h; exfalso; exact h (Finset.mem_univ _)
 
 /-- Basic monoidal structure on FinStoch using tensor products. -/
@@ -142,6 +135,7 @@ lemma associator_matrix (X Y Z : FinStoch) (xyz : ((X ⊗ Y) ⊗ Z).carrier)
     if xyz.1.1 = xyz'.1 ∧ xyz.1.2 = xyz'.2.1 ∧ xyz.2 = xyz'.2.2 then 1 else 0 := by
   simp only [MonoidalCategoryStruct.associator, associator, DetMorphism.toMatrix_apply]
   simp only [associatorDet, DetMorphism.ofFunc]
+  -- The associator permutation: ((x,y),z) ↦ (x,(y,z))
   aesop
 
 /-- Matrix entry for left unitor. -/
@@ -166,37 +160,6 @@ lemma rightUnitor_matrix (X : FinStoch) (xu : (X ⊗ FinStoch.tensorUnit).carrie
   obtain ⟨x', ⟨⟩⟩ := xu
   simp only
 
-/-! ### Deterministic morphisms -/
-
-section Deterministic
-
-open StochasticMatrix
-
-/-- The associator is deterministic. -/
-lemma associator_isDeterministic (X Y Z : FinStoch) :
-    (α_ X Y Z).hom.isDeterministic := (associatorDet X Y Z).is_det
-
-/-- The inverse associator is deterministic. -/
-lemma associator_inv_isDeterministic (X Y Z : FinStoch) :
-    (α_ X Y Z).inv.isDeterministic := (associatorInvDet X Y Z).is_det
-
-/-- The left unitor is deterministic. -/
-lemma leftUnitor_isDeterministic (X : FinStoch) :
-    (λ_ X).hom.isDeterministic := (leftUnitorDet X).is_det
-
-/-- The inverse left unitor is deterministic. -/
-lemma leftUnitor_inv_isDeterministic (X : FinStoch) :
-    (λ_ X).inv.isDeterministic := (leftUnitorInvDet X).is_det
-
-/-- The right unitor is deterministic. -/
-lemma rightUnitor_isDeterministic (X : FinStoch) :
-    (ρ_ X).hom.isDeterministic := (rightUnitorDet X).is_det
-
-/-- The inverse right unitor is deterministic. -/
-lemma rightUnitor_inv_isDeterministic (X : FinStoch) :
-    (ρ_ X).inv.isDeterministic := (rightUnitorInvDet X).is_det
-
-end Deterministic
 
 /-- FinStoch forms a monoidal category. -/
 instance : MonoidalCategory FinStoch where
@@ -207,6 +170,7 @@ instance : MonoidalCategory FinStoch where
     simp only [MonoidalCategoryStruct.tensorHom, StochasticMatrix.tensor,
                MonoidalCategoryStruct.whiskerRight, MonoidalCategoryStruct.whiskerLeft,
                CategoryStruct.comp, StochasticMatrix.comp]
+    -- f ⊗ g = (f ⊗ id) ∘ (id ⊗ g) = f(x₁,y₁) * g(x₂,y₂)
     rw [Finset.sum_eq_single ⟨y₁, x₂⟩]
     · simp only [StochasticMatrix.id, CategoryStruct.id]
       cat_disch
@@ -298,6 +262,8 @@ instance : MonoidalCategory FinStoch where
     ext ⟨⟨x₁, x₂⟩, x₃⟩ ⟨y₁, ⟨y₂, y₃⟩⟩
     simp only [CategoryStruct.comp, StochasticMatrix.comp,
                MonoidalCategoryStruct.tensorHom, StochasticMatrix.tensor]
+    -- Naturality: α ∘ (f₁⊗f₂⊗f₃) = (f₁⊗(f₂⊗f₃)) ∘ α
+    -- Both paths factor through the same intermediate states
     rw [Finset.sum_eq_single ⟨⟨y₁, y₂⟩, y₃⟩]
     · simp [associator_matrix]
       rw [Finset.sum_eq_single ⟨x₁, ⟨x₂, x₃⟩⟩]
@@ -314,7 +280,8 @@ instance : MonoidalCategory FinStoch where
       · exfalso
         apply h_ne
         simp only [h]
-      · have h_assoc_zero : (MonoidalCategoryStruct.associator Y₁ Y₂ Y₃).hom.toMatrix
+      · -- Associator is deterministic, gives 0 for non-matching indices
+        have h_assoc_zero : (MonoidalCategoryStruct.associator Y₁ Y₂ Y₃).hom.toMatrix
                               ((y₁', y₂'), y₃') (y₁, y₂, y₃) = 0 := by
           simp [associator_matrix, h]
         rw [h_assoc_zero, mul_zero]
@@ -376,18 +343,18 @@ instance : MonoidalCategory FinStoch where
     intros W X Y Z
     apply StochasticMatrix.ext
     ext ⟨⟨⟨w, x⟩, y⟩, z⟩ ⟨w', ⟨x', ⟨y', z'⟩⟩⟩
-    -- Both paths map ((w,x),y,z) to (w,(x,(y,z))) deterministically
+    -- Pentagon coherence: both paths from ((w,x),y,z) to (w,(x,(y,z))) are equal
     simp only [CategoryStruct.comp, StochasticMatrix.comp]
-    -- Left path through the pentagon
+    -- Left path: ((w,x),y,z) → (w,(x,y),z) → (w,((x,y),z)) → (w,(x,(y,z)))
     rw [Finset.sum_eq_single ⟨⟨w, ⟨x, y⟩⟩, z⟩]
     · rw [Finset.sum_eq_single ⟨w, ⟨⟨x, y⟩, z⟩⟩]
-      · -- Right path
+      · -- Right path: ((w,x),y,z) → ((w,x),(y,z)) → (w,(x,(y,z)))
         rw [Finset.sum_eq_single ⟨⟨w, x⟩, ⟨y, z⟩⟩]
-        · -- Evaluate all morphisms
+        · -- Both paths use deterministic permutations
           simp only [MonoidalCategoryStruct.whiskerRight, MonoidalCategoryStruct.whiskerLeft,
                      StochasticMatrix.tensor, associator_matrix,
                      CategoryStruct.id, StochasticMatrix.id]
-          -- Check equality conditions
+          -- All components must match for non-zero contribution
           by_cases hw : w = w'
           · by_cases hx : x = x'
             · by_cases hy : y = y'
@@ -445,9 +412,10 @@ instance : MonoidalCategory FinStoch where
     intros X Y
     apply StochasticMatrix.ext
     ext ⟨⟨x, ⟨⟩⟩, y⟩ ⟨x', y'⟩
-    -- Both sides map ((x,()),y) to (x,y) deterministically
+    -- Triangle coherence: associator and unitors interact correctly
+    -- Both paths: ((x,()),y) → (x,y) via different unit eliminations
     simp only [CategoryStruct.comp, StochasticMatrix.comp]
-    -- The unique intermediate is (x,((),y))
+    -- Unique intermediate state is (x,((),y))
     rw [Finset.sum_eq_single ⟨x, ⟨⟨⟩, y⟩⟩]
     · simp only [associator_matrix, MonoidalCategoryStruct.whiskerLeft,
                  MonoidalCategoryStruct.whiskerRight, StochasticMatrix.tensor,

--- a/Mathlib/CategoryTheory/MarkovCategory/FinStoch/Monoidal.lean
+++ b/Mathlib/CategoryTheory/MarkovCategory/FinStoch/Monoidal.lean
@@ -198,7 +198,7 @@ instance : MonoidalCategory FinStoch where
         obtain ⟨h1, _⟩ := h
         exact hx rfl
       · rfl
-  tensor_comp := by
+  tensorHom_comp_tensorHom := by
     intros X₁ Y₁ Z₁ X₂ Y₂ Z₂ f₁ f₂ g₁ g₂
     apply StochasticMatrix.ext
     ext ⟨x₁, x₂⟩ ⟨z₁, z₂⟩

--- a/Mathlib/CategoryTheory/Monoidal/Bimon_.lean
+++ b/Mathlib/CategoryTheory/Monoidal/Bimon_.lean
@@ -148,7 +148,18 @@ attribute [local simp] MonObj.tensorObj.one_def MonObj.tensorObj.mul_def tensor�
 def ofMonComonObj (M : Mon (Comon C)) : Bimon C where
   X := ofMonComonObjX M
   comon.counit := .mk' ε[M.X.X]
+    (one_f := by
+      -- The unit morphism η[M.X] is a comonoid homomorphism, so it preserves counit
+      have h : η[M.X].hom ≫ ε[M.X.X] = ε[(Comon.trivial C).X] := η[M.X].isComonHom_hom.hom_counit
+      cat_disch)
+    (mul_f := by cat_disch)
   comon.comul := .mk' Δ[M.X.X]
+    (one_f := by
+      -- The unit morphism η[M.X] is a comonoid homomorphism, so it preserves comul
+      have h : η[M.X].hom ≫ Δ[M.X.X] = Δ[(Comon.trivial C).X] ≫ (η[M.X].hom ⊗ₘ η[M.X].hom) :=
+        η[M.X].isComonHom_hom.hom_comul
+      cat_disch)
+    (mul_f := by cat_disch)
 
 @[deprecated (since := "2025-09-15")] alias ofMon_Comon_Obj := ofMonComonObj
 
@@ -199,6 +210,8 @@ def equivMonComonUnitIsoAppX (M : Bimon C) :
 @[deprecated (since := "2025-09-15")] alias equivMon_Comon_UnitIsoAppX := equivMonComonUnitIsoAppX
 
 instance (M : Bimon C) : IsComonHom (equivMonComonUnitIsoAppX M).hom where
+  hom_counit := by cat_disch
+  hom_comul := by cat_disch
 
 /-- The unit for the equivalence `Comon (Mon C) ≌ Mon (Comon C)`. -/
 @[simps!]
@@ -210,16 +223,16 @@ def equivMonComonUnitIsoApp (M : Bimon C) :
 
 @[simp]
 theorem ofMonComon_toMonComon_obj_counit (M : Mon (Comon C)) :
-    ε[((ofMonComon C ⋙ toMonComon C).obj M).X.X] = ε[M.X.X] ≫ 𝟙 _ :=
-  rfl
+    ε[((ofMonComon C ⋙ toMonComon C).obj M).X.X] = ε[M.X.X] ≫ 𝟙 _ := by
+  rfl_cat
 
 @[deprecated (since := "2025-09-15")]
 alias ofMon_Comon_toMon_Comon_obj_counit := ofMonComon_toMonComon_obj_counit
 
 @[simp]
 theorem ofMonComon_toMonComon_obj_comul (M : Mon (Comon C)) :
-    Δ[((ofMonComon C ⋙ toMonComon C).obj M).X.X] = Δ[M.X.X] ≫ 𝟙 _ :=
-  rfl
+    Δ[((ofMonComon C ⋙ toMonComon C).obj M).X.X] = Δ[M.X.X] ≫ 𝟙 _ := by
+  rfl_cat
 
 @[deprecated (since := "2025-09-15")]
 alias ofMon_Comon_toMon_Comon_obj_comul := ofMonComon_toMonComon_obj_comul

--- a/Mathlib/CategoryTheory/Monoidal/CommComon_.lean
+++ b/Mathlib/CategoryTheory/Monoidal/CommComon_.lean
@@ -21,11 +21,15 @@ Comonoids where comultiplication is symmetric: swapping outputs gives the same r
 
 ## Implementation notes
 
-We extend ComonObj and add the commutativity axiom. This requires
-a braided monoidal category for the braiding isomorphism.
+We extend ComonObj and add the commutativity axiom. This requires a braided monoidal category for
+the braiding isomorphism.
 
-In cartesian monoidal categories, every object has a unique
-commutative comonoid structure (diagonal and terminal morphisms).
+Unlike the specific `ComonObj (𝟙_ C)` instance which was removed from mathlib to avoid conflicts,
+`CommComonObj` remains a type class because it describes a property of comonoid structures rather
+than providing a specific comonoid structure that could conflict with others.
+
+In cartesian monoidal categories, every object has a unique commutative comonoid structure
+(diagonal and terminal morphisms).
 
 ## Tags
 

--- a/Mathlib/CategoryTheory/Monoidal/CommComon_.lean
+++ b/Mathlib/CategoryTheory/Monoidal/CommComon_.lean
@@ -1,0 +1,56 @@
+/-
+Copyright (c) 2025 Jacob Reinhold. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Jacob Reinhold
+-/
+import Mathlib.CategoryTheory.Monoidal.Comon_
+import Mathlib.CategoryTheory.Monoidal.Braided.Basic
+
+/-!
+# Commutative Comonoid Objects
+
+Comonoids where comultiplication is symmetric: swapping outputs gives the same result.
+
+## Main definitions
+
+* `CommComonObj X` - Commutative comonoid structure on X
+
+## Main results
+
+* `swap_comul` - Swapping the two copies does nothing
+
+## Implementation notes
+
+We extend ComonObj and add the commutativity axiom. This requires
+a braided monoidal category for the braiding isomorphism.
+
+In cartesian monoidal categories, every object has a unique
+commutative comonoid structure (diagonal and terminal morphisms).
+
+## Tags
+
+comonoid, commutative, braided
+-/
+
+namespace CategoryTheory
+
+open MonoidalCategory ComonObj
+
+variable {C : Type*} [Category C] [MonoidalCategory C] [BraidedCategory C]
+
+/-- A comonoid where swapping outputs gives the same result: Δ ≫ σ = Δ. -/
+class CommComonObj (X : C) extends ComonObj X where
+  /-- Comultiplication commutes with braiding. -/
+  isComm : comul ≫ (β_ X X).hom = comul
+
+namespace CommComonObj
+
+variable {X : C} [CommComonObj X]
+
+/-- Swapping the two copies does nothing. -/
+@[simp]
+lemma swap_comul : Δ[X] ≫ (β_ X X).hom = Δ[X] := isComm
+
+end CommComonObj
+
+end CategoryTheory

--- a/Mathlib/CategoryTheory/Monoidal/Comon_.lean
+++ b/Mathlib/CategoryTheory/Monoidal/Comon_.lean
@@ -53,8 +53,10 @@ namespace ComonObj
 
 attribute [reassoc (attr := simp)] counit_comul comul_counit comul_assoc
 
+/-- The canonical comonoid structure on the monoidal unit.
+This is not a global instance to avoid conflicts with other comonoid structures. -/
 @[simps]
-instance (C : Type u₁) [Category.{v₁} C] [MonoidalCategory.{v₁} C] : ComonObj (𝟙_ C) where
+def instTensorUnit (C : Type u₁) [Category.{v₁} C] [MonoidalCategory.{v₁} C] : ComonObj (𝟙_ C) where
   counit := 𝟙 _
   comul := (λ_ _).inv
   counit_comul := by simp
@@ -104,9 +106,13 @@ namespace Comon
 
 variable (C) in
 /-- The trivial comonoid object. We later show this is terminal in `Comon C`.
+
+Uses the explicit comonoid structure to avoid instance conflicts.
 -/
 @[simps!]
-def trivial : Comon C := mk (𝟙_ C)
+def trivial : Comon C :=
+  { X := 𝟙_ C
+    comon := ComonObj.instTensorUnit C }
 
 instance : Inhabited (Comon C) :=
   ⟨trivial C⟩

--- a/MathlibTest/CategoryTheory/MarkovCategory.lean
+++ b/MathlibTest/CategoryTheory/MarkovCategory.lean
@@ -8,6 +8,7 @@ import Mathlib.CategoryTheory.MarkovCategory.Cartesian
 import Mathlib.CategoryTheory.MarkovCategory.FinStoch.Basic
 import Mathlib.CategoryTheory.MarkovCategory.FinStoch.Monoidal
 import Mathlib.CategoryTheory.Monoidal.Types.Basic
+import Mathlib.CategoryTheory.CopyDiscardCategory.Basic
 import Mathlib.Tactic.FinCases
 
 /-!
@@ -26,16 +27,14 @@ This file contains tests and examples for the Markov category implementation.
 
 universe u
 
-open CategoryTheory MarkovCategory CopyDiscardCategory
+open CategoryTheory MarkovCategory CopyDiscardCategory ComonObj
 
 section BasicTests
 
 /-- Type* forms a Markov category via its cartesian structure -/
 example : MarkovCategory (Type u) := inferInstance
 
-/-- Every function between types is deterministic -/
-example {X Y : Type u} (f : X → Y) : @Deterministic (Type u) _ _ _ X Y f :=
-  @CartesianMarkov.deterministic_of_cartesian (Type u) _ _ X Y f
+-- Note: Deterministic morphisms are not yet implemented in the library
 
 /-- CartesianMonoidalCategory instance exists for Type* -/
 example : CartesianMonoidalCategory (Type u) := inferInstance
@@ -49,21 +48,21 @@ variable {C : Type u} [Category.{u} C] [MonoidalCategory.{u} C] [MarkovCategory 
 open MonoidalCategory CopyDiscardCategory
 
 /-- The copy operation is commutative -/
-example (X : C) : copyMor X ≫ (β_ X X).hom = copyMor X := copy_comm X
+example (X : C) : Δ[X] ≫ (β_ X X).hom = Δ[X] := CommComonObj.swap_comul
 
 /-- Left counit law -/
-example (X : C) : copyMor X ≫ (delMor X ▷ X) = (λ_ X).inv := counit_comul X
+example (X : C) : Δ[X] ≫ (ε[X] ▷ X) = (λ_ X).inv := ComonObj.counit_comul X
 
 /-- Right counit law -/
-example (X : C) : copyMor X ≫ (X ◁ delMor X) = (ρ_ X).inv := comul_counit X
+example (X : C) : Δ[X] ≫ (X ◁ ε[X]) = (ρ_ X).inv := ComonObj.comul_counit X
 
 /-- Coassociativity -/
 example (X : C) :
-    copyMor X ≫ (copyMor X ▷ X) =
-    copyMor X ≫ (X ◁ copyMor X) ≫ (α_ X X X).inv := coassoc X
+    Δ[X] ≫ (X ◁ Δ[X]) = Δ[X] ≫ (Δ[X] ▷ X) ≫ (α_ X X X).hom :=
+  ComonObj.comul_assoc X
 
 /-- Delete is natural -/
-example {X Y : C} (f : X ⟶ Y) : f ≫ delMor Y = delMor X := del_natural f
+example {X Y : C} (f : X ⟶ Y) : f ≫ ε[Y] = ε[X] := MarkovCategory.discard_natural f
 
 end ComonoidLaws
 
@@ -97,28 +96,8 @@ example : MonoidalCategory FinStoch := inferInstance
 
 end FinStochExamples
 
-section DeterministicMorphisms
-
-variable {C : Type u} [Category.{u} C] [MonoidalCategory C] [MarkovCategory C]
-
-/-- Identity morphisms are deterministic -/
-example (X : C) : Deterministic (𝟙 X) := inferInstance
-
-/-- Composition of deterministic morphisms is deterministic -/
-example {X Y Z : C} (f : X ⟶ Y) (g : Y ⟶ Z)
-    [Deterministic f] [Deterministic g] : Deterministic (f ≫ g) := inferInstance
-
-end DeterministicMorphisms
-
-section CartesianDeterministic
-
-variable {C : Type u} [Category.{u} C] [CartesianMonoidalCategory C]
-
-/-- In a cartesian category, all morphisms are deterministic -/
-example {X Y : C} (f : X ⟶ Y) : Deterministic f :=
-  CartesianMarkov.deterministic_of_cartesian f
-
-end CartesianDeterministic
+-- Note: Deterministic morphisms are not yet implemented in the library
+-- These tests are removed until the concept is added
 
 section SimpLemmas
 
@@ -127,12 +106,12 @@ variable {C : Type u} [Category.{u} C] [MonoidalCategory C] [MarkovCategory C]
 open MonoidalCategory CopyDiscardCategory
 
 /-- Test that simp lemmas work for counit laws -/
-example (X : C) : copyMor X ≫ (delMor X ▷ X) = (λ_ X).inv := by simp
+example (X : C) : Δ[X] ≫ (ε[X] ▷ X) = (λ_ X).inv := by simp
 
 /-- Test that simp lemmas work for naturality of delete -/
-example {X Y : C} (f : X ⟶ Y) : f ≫ delMor Y = delMor X := by simp
+example {X Y : C} (f : X ⟶ Y) : f ≫ ε[Y] = ε[X] := by simp
 
 /-- Test that simp lemmas work for copy commutativity -/
-example (X : C) : copyMor X ≫ (β_ X X).hom = copyMor X := by simp
+example (X : C) : Δ[X] ≫ (β_ X X).hom = Δ[X] := by simp
 
 end SimpLemmas

--- a/MathlibTest/CategoryTheory/MarkovCategory.lean
+++ b/MathlibTest/CategoryTheory/MarkovCategory.lean
@@ -9,6 +9,7 @@ import Mathlib.CategoryTheory.MarkovCategory.FinStoch.Basic
 import Mathlib.CategoryTheory.MarkovCategory.FinStoch.Monoidal
 import Mathlib.CategoryTheory.Monoidal.Types.Basic
 import Mathlib.CategoryTheory.CopyDiscardCategory.Basic
+import Mathlib.LinearAlgebra.Matrix.Notation
 import Mathlib.Tactic.FinCases
 
 /-!
@@ -72,13 +73,10 @@ open FinStoch StochasticMatrix
 
 /-- A simple 2x2 stochastic matrix representing a coin flip -/
 noncomputable def coinFlip : StochasticMatrix (Fin 2) (Fin 2) where
-  toMatrix := ![
-    ![1/2, 1/2],  -- From state 0: 50% chance to stay, 50% to flip
-    ![1/3, 2/3]   -- From state 1: 33% to flip, 67% to stay
-  ]
+  toMatrix := !![1/2, 1/2; 1/3, 2/3]
   row_sum := by
     intro i
-    fin_cases i <;> simp only [Finset.sum] <;> norm_num
+    fin_cases i <;> simp only [Matrix.of_apply] <;> norm_num
 
 /-- The identity matrix is stochastic -/
 def identityStochastic : StochasticMatrix (Fin 3) (Fin 3) :=
@@ -95,9 +93,6 @@ example : Category FinStoch := inferInstance
 example : MonoidalCategory FinStoch := inferInstance
 
 end FinStochExamples
-
--- Note: Deterministic morphisms are not yet implemented in the library
--- These tests are removed until the concept is added
 
 section SimpLemmas
 

--- a/MathlibTest/CategoryTheory/MarkovCategory.lean
+++ b/MathlibTest/CategoryTheory/MarkovCategory.lean
@@ -26,7 +26,7 @@ This file contains tests and examples for the Markov category implementation.
 
 universe u
 
-open CategoryTheory MarkovCategory
+open CategoryTheory MarkovCategory CopyDiscardCategory
 
 section BasicTests
 
@@ -46,7 +46,7 @@ section ComonoidLaws
 
 variable {C : Type u} [Category.{u} C] [MonoidalCategory.{u} C] [MarkovCategory C]
 
-open MonoidalCategory
+open MonoidalCategory CopyDiscardCategory
 
 /-- The copy operation is commutative -/
 example (X : C) : copyMor X ≫ (β_ X X).hom = copyMor X := copy_comm X
@@ -124,7 +124,7 @@ section SimpLemmas
 
 variable {C : Type u} [Category.{u} C] [MonoidalCategory C] [MarkovCategory C]
 
-open MonoidalCategory
+open MonoidalCategory CopyDiscardCategory
 
 /-- Test that simp lemmas work for counit laws -/
 example (X : C) : copyMor X ≫ (delMor X ▷ X) = (λ_ X).inv := by simp

--- a/MathlibTest/CategoryTheory/MarkovCategory.lean
+++ b/MathlibTest/CategoryTheory/MarkovCategory.lean
@@ -1,0 +1,138 @@
+/-
+Copyright (c) 2025 Jacob Reinhold. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Jacob Reinhold
+-/
+import Mathlib.CategoryTheory.MarkovCategory.Basic
+import Mathlib.CategoryTheory.MarkovCategory.Cartesian
+import Mathlib.CategoryTheory.MarkovCategory.FinStoch.Basic
+import Mathlib.CategoryTheory.MarkovCategory.FinStoch.Monoidal
+import Mathlib.CategoryTheory.Monoidal.Types.Basic
+import Mathlib.Tactic.FinCases
+
+/-!
+# Tests for Markov Categories
+
+This file contains tests and examples for the Markov category implementation.
+
+## Tests included
+
+* Basic axiom verification for Type*
+* Examples of deterministic morphisms
+* Stochastic matrix examples in FinStoch
+* Verification of comonoid laws
+
+-/
+
+universe u
+
+open CategoryTheory MarkovCategory
+
+section BasicTests
+
+/-- Type* forms a Markov category via its cartesian structure -/
+example : MarkovCategory (Type u) := inferInstance
+
+/-- Every function between types is deterministic -/
+example {X Y : Type u} (f : X → Y) : @Deterministic (Type u) _ _ _ X Y f :=
+  @CartesianMarkov.deterministic_of_cartesian (Type u) _ _ X Y f
+
+/-- CartesianMonoidalCategory instance exists for Type* -/
+example : CartesianMonoidalCategory (Type u) := inferInstance
+
+end BasicTests
+
+section ComonoidLaws
+
+variable {C : Type u} [Category.{u} C] [MonoidalCategory.{u} C] [MarkovCategory C]
+
+open MonoidalCategory
+
+/-- The copy operation is commutative -/
+example (X : C) : copyMor X ≫ (β_ X X).hom = copyMor X := copy_comm X
+
+/-- Left counit law -/
+example (X : C) : copyMor X ≫ (delMor X ▷ X) = (λ_ X).inv := counit_comul X
+
+/-- Right counit law -/
+example (X : C) : copyMor X ≫ (X ◁ delMor X) = (ρ_ X).inv := comul_counit X
+
+/-- Coassociativity -/
+example (X : C) :
+    copyMor X ≫ (copyMor X ▷ X) =
+    copyMor X ≫ (X ◁ copyMor X) ≫ (α_ X X X).inv := coassoc X
+
+/-- Delete is natural -/
+example {X Y : C} (f : X ⟶ Y) : f ≫ delMor Y = delMor X := del_natural f
+
+end ComonoidLaws
+
+section FinStochExamples
+
+open FinStoch StochasticMatrix
+
+/-- A simple 2x2 stochastic matrix representing a coin flip -/
+noncomputable def coinFlip : StochasticMatrix (Fin 2) (Fin 2) where
+  toMatrix := ![
+    ![1/2, 1/2],  -- From state 0: 50% chance to stay, 50% to flip
+    ![1/3, 2/3]   -- From state 1: 33% to flip, 67% to stay
+  ]
+  row_sum := by
+    intro i
+    fin_cases i <;> simp only [Finset.sum] <;> norm_num
+
+/-- The identity matrix is stochastic -/
+def identityStochastic : StochasticMatrix (Fin 3) (Fin 3) :=
+  StochasticMatrix.id (Fin 3)
+
+/-- Composition of stochastic matrices preserves the stochastic property -/
+noncomputable example : StochasticMatrix (Fin 2) (Fin 2) :=
+  StochasticMatrix.comp coinFlip coinFlip
+
+/-- FinStoch has Category structure -/
+example : Category FinStoch := inferInstance
+
+/-- FinStoch has MonoidalCategory structure -/
+example : MonoidalCategory FinStoch := inferInstance
+
+end FinStochExamples
+
+section DeterministicMorphisms
+
+variable {C : Type u} [Category.{u} C] [MonoidalCategory C] [MarkovCategory C]
+
+/-- Identity morphisms are deterministic -/
+example (X : C) : Deterministic (𝟙 X) := inferInstance
+
+/-- Composition of deterministic morphisms is deterministic -/
+example {X Y Z : C} (f : X ⟶ Y) (g : Y ⟶ Z)
+    [Deterministic f] [Deterministic g] : Deterministic (f ≫ g) := inferInstance
+
+end DeterministicMorphisms
+
+section CartesianDeterministic
+
+variable {C : Type u} [Category.{u} C] [CartesianMonoidalCategory C]
+
+/-- In a cartesian category, all morphisms are deterministic -/
+example {X Y : C} (f : X ⟶ Y) : Deterministic f :=
+  CartesianMarkov.deterministic_of_cartesian f
+
+end CartesianDeterministic
+
+section SimpLemmas
+
+variable {C : Type u} [Category.{u} C] [MonoidalCategory C] [MarkovCategory C]
+
+open MonoidalCategory
+
+/-- Test that simp lemmas work for counit laws -/
+example (X : C) : copyMor X ≫ (delMor X ▷ X) = (λ_ X).inv := by simp
+
+/-- Test that simp lemmas work for naturality of delete -/
+example {X Y : C} (f : X ⟶ Y) : f ≫ delMor Y = delMor X := by simp
+
+/-- Test that simp lemmas work for copy commutativity -/
+example (X : C) : copyMor X ≫ (β_ X X).hom = copyMor X := by simp
+
+end SimpLemmas

--- a/docs/references.bib
+++ b/docs/references.bib
@@ -1052,6 +1052,19 @@
   keywords      = {{16P10, 16U99},Mathematics - Rings and Algebras}
 }
 
+@Article{         cho_jacobs_2019,
+  title         = {Disintegration and Bayesian inversion via string
+                  diagrams},
+  author        = {Cho, Kenta and Jacobs, Bart},
+  journal       = {Mathematical Structures in Computer Science},
+  volume        = {29},
+  number        = {7},
+  pages         = {938--971},
+  year          = {2019},
+  publisher     = {Cambridge University Press},
+  doi           = {10.1017/S0960129518000488}
+}
+
 @InProceedings{   Chou1994,
   author        = {Chou, Ching-Tsun},
   booktitle     = {Higher Order Logic Theorem Proving and Its Applications},


### PR DESCRIPTION
This PR adds Markov categories to the category theory library. A Markov category is a symmetric monoidal category where every object has canonical copy and delete morphisms that form commutative comonoids.

## What this gives mathlib

In a Markov category, morphisms model probabilistic processes. The copy morphism `X → X ⊗ X` creates perfect correlation (both outputs always equal). The delete morphism `X → I` marginalizes (sums/integrates out variables).

This structure captures probability theory categorically. The same theorem proves results for:
- Finite probability (stochastic matrices)
- Measure theory (Markov kernels)
- Kleisli categories of probability monads

Fritz (2020) used this to prove categorical versions of Fisher-Neyman, Basu's theorem, and other core statistics results.

## Implementation

- `MarkovCategory`: Extends `SymmetricCategory` with canonical comonoid structure
- `copyMor X : X ⟶ X ⊗ X` and `delMor X : X ⟶ I` for each object
- Coherence axioms: commutativity, counitality, coassociativity
- Compatibility with tensor products

Key design point: The comonoid structure is canonical (fields of the typeclass), not chosen. This matches the probability interpretation where there's exactly one way to copy/marginalize.

## Examples included

1. Cartesian categories: Every cartesian monoidal category forms a Markov category where copy is the diagonal `x ↦ (x,x)` and delete is the terminal morphism. All morphisms are deterministic.
2. FinStoch: Objects are finite types. Morphisms are stochastic matrices (rows sum to 1). This models finite probability spaces with the usual matrix multiplication for composition.

## Scope and review notes

This PR provides the basic structure only. Future PRs would add:
- Conditional independence
- Sufficient statistics  
- Connection to measure-theoretic probability
- More examples (Kleisli categories, Gaussian categories)

I'm neither an expert in this material nor in Lean; I've only read a few papers on Markov categories and have gone through tutorial material in Lean. Please review for mathematical correctness and idiomatic Lean. I kept this PR small to check if mathlib wants this addition and to ensure it meets repository standards.

## Why add this now

Markov categories provide a useful abstraction level for probability in type theory. Adding it to mathlib enables future work on categorical probability and statistics. In particular, I'm working on a probabilistic programming library and would like to write some proofs using these constructs. 

## References

- Fritz, T. (2020). [A synthetic approach to Markov kernels, conditional independence and theorems on sufficient statistics](https://arxiv.org/abs/1908.07021). *Advances in Mathematics*, 370, 107239.
- Cho, K., & Jacobs, B. (2019). [Disintegration and Bayesian inversion via string diagrams](https://arxiv.org/abs/1709.00322). *Mathematical Structures in Computer Science*, 29(7), 938-971.

---

All definitions include docstrings. The PR has tests for the core functionality.

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)