### PR TITLE
[Merged by Bors] - chore(Data): golf entire `tail_cons` using `rfl`. fix `coe_eq_image_val` theorem statement.

### DIFF
--- a/Mathlib/Data/Seq/Defs.lean
+++ b/Mathlib/Data/Seq/Defs.lean
@@ -230,10 +230,7 @@ theorem tail_nil : tail (nil : Seq α) = nil :=
   rfl
 
 @[simp]
-theorem tail_cons (a : α) (s) : tail (cons a s) = s := by
-  obtain ⟨f, al⟩ := s
-  apply Subtype.eq
-  dsimp [tail, cons]
+theorem tail_cons (a : α) (s) : tail (cons a s) = s := rfl
 
 theorem head_eq_some {s : Seq α} {x : α} (h : s.head = some x) :
     s = cons x s.tail := by

--- a/Mathlib/Data/Set/Functor.lean
+++ b/Mathlib/Data/Set/Functor.lean
@@ -139,7 +139,10 @@ as was defined in `Data.Set.Notation`. -/
 attribute [local instance] Set.monad in
 /-- The coercion from `Set.monad` as an instance is equal to the coercion in `Data.Set.Notation`. -/
 theorem coe_eq_image_val (t : Set s) :
-    @Lean.Internal.coeM Set s α _ _ t = (t : Set α) := rfl
+    @Lean.Internal.coeM Set s α _ _ t = Subtype.val '' t := by
+  change ⋃ (x ∈ t), {x.1} = _
+  ext
+  simp
 
 variable {β : Set α} {γ : Set β} {a : α}
 

--- a/Mathlib/Data/Set/Functor.lean
+++ b/Mathlib/Data/Set/Functor.lean
@@ -139,10 +139,7 @@ as was defined in `Data.Set.Notation`. -/
 attribute [local instance] Set.monad in
 /-- The coercion from `Set.monad` as an instance is equal to the coercion in `Data.Set.Notation`. -/
 theorem coe_eq_image_val (t : Set s) :
-    @Lean.Internal.coeM Set s α _ _ t = (t : Set α) := by
-  change ⋃ (x ∈ t), {x.1} = _
-  ext
-  simp
+    @Lean.Internal.coeM Set s α _ _ t = (t : Set α) := rfl
 
 variable {β : Set α} {γ : Set β} {a : α}
 


### PR DESCRIPTION
---
<details>
<summary>Show trace profiling of <code>tail_cons</code>: <10 ms before, <10 ms after  🎉</summary>

### Trace profiling of `tail_cons` before PR 29661
```diff
diff --git a/Mathlib/Data/Seq/Defs.lean b/Mathlib/Data/Seq/Defs.lean
index fc03ab5f49..aba7137487 100644
--- a/Mathlib/Data/Seq/Defs.lean
+++ b/Mathlib/Data/Seq/Defs.lean
@@ -229,6 +229,7 @@ theorem head_cons (a : α) (s) : head (cons a s) = some a := by
 theorem tail_nil : tail (nil : Seq α) = nil :=
   rfl
 
+set_option trace.profiler true in
 @[simp]
 theorem tail_cons (a : α) (s) : tail (cons a s) = s := by
   obtain ⟨f, al⟩ := s
```
```
✔ [428/428] Built Mathlib.Data.Seq.Defs (3.8s)
Build completed successfully (428 jobs).
```

### Trace profiling of `tail_cons` after PR 29661
```diff
diff --git a/Mathlib/Data/Seq/Defs.lean b/Mathlib/Data/Seq/Defs.lean
index fc03ab5f49..ad65ea7a8f 100644
--- a/Mathlib/Data/Seq/Defs.lean
+++ b/Mathlib/Data/Seq/Defs.lean
@@ -229,11 +229,9 @@ theorem head_cons (a : α) (s) : head (cons a s) = some a := by
 theorem tail_nil : tail (nil : Seq α) = nil :=
   rfl
 
+set_option trace.profiler true in
 @[simp]
-theorem tail_cons (a : α) (s) : tail (cons a s) = s := by
-  obtain ⟨f, al⟩ := s
-  apply Subtype.eq
-  dsimp [tail, cons]
+theorem tail_cons (a : α) (s) : tail (cons a s) = s := rfl
 
 theorem head_eq_some {s : Seq α} {x : α} (h : s.head = some x) :
     s = cons x s.tail := by
diff --git a/Mathlib/Data/Set/Functor.lean b/Mathlib/Data/Set/Functor.lean
index 35063a2feb..7b52b24536 100644
--- a/Mathlib/Data/Set/Functor.lean
+++ b/Mathlib/Data/Set/Functor.lean
@@ -139,10 +139,7 @@ as was defined in `Data.Set.Notation`. -/
 attribute [local instance] Set.monad in
 /-- The coercion from `Set.monad` as an instance is equal to the coercion in `Data.Set.Notation`. -/
 theorem coe_eq_image_val (t : Set s) :
-    @Lean.Internal.coeM Set s α _ _ t = (t : Set α) := by
-  change ⋃ (x ∈ t), {x.1} = _
-  ext
-  simp
+    @Lean.Internal.coeM Set s α _ _ t = (t : Set α) := rfl
 
 variable {β : Set α} {γ : Set β} {a : α}
 
```
```
✔ [428/428] Built Mathlib.Data.Seq.Defs (1.0s)
Build completed successfully (428 jobs).
```
</details>

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include at least one commit authored by each
co-author among the commits in the pull request. If necessary, you may 
create empty commits to indicate co-authorship, using commands like so:

git commit --author="Author Name <author@email.com>" --allow-empty -m "add Author Name as coauthor"

When merging, all the commits will be squashed into a single commit listing all co-authors.

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
