### PR TITLE
[Merged by Bors] - chore: deprecate Real.add_lt_add_iff_left

### DIFF
--- a/Archive/Wiedijk100Theorems/CubingACube.lean
+++ b/Archive/Wiedijk100Theorems/CubingACube.lean
@@ -329,7 +329,7 @@ theorem mi_xm_ne_one : (cs <| mi h v).xm ≠ 1 := by
   · apply lt_of_lt_of_le _ h.b_add_w_le_one
     · exact i
     · exact 0
-    rw [xm, mi_mem_bcubes.1, hi.1, _root_.add_lt_add_iff_left]
+    rw [xm, mi_mem_bcubes.1, hi.1, add_lt_add_iff_left]
     exact mi_strict_minimal h2i.symm hi
 
 /-- If `mi` lies on the boundary of the valley in dimension j, then this lemma expresses that all

--- a/Mathlib/Data/Real/Basic.lean
+++ b/Mathlib/Data/Real/Basic.lean
@@ -302,13 +302,6 @@ protected theorem ind_mk {C : Real → Prop} (x : Real) (h : ∀ y, C (mk y)) : 
   induction x using Quot.induction_on
   exact h _
 
-theorem add_lt_add_iff_left {a b : ℝ} (c : ℝ) : c + a < c + b ↔ a < b := by
-  induction a using Real.ind_mk
-  induction b using Real.ind_mk
-  induction c using Real.ind_mk
-  simp only [mk_lt, ← mk_add]
-  change Pos _ ↔ Pos _; rw [add_sub_add_left_eq_sub]
-
 instance partialOrder : PartialOrder ℝ where
   le := (· ≤ ·)
   lt := (· < ·)
@@ -353,7 +346,16 @@ instance instIsOrderedAddMonoid : IsOrderedAddMonoid ℝ where
     simp only [le_iff_eq_or_lt]
     rintro a b ⟨rfl, h⟩
     · simp only [lt_self_iff_false, or_false, forall_const]
-    · exact fun c => Or.inr ((add_lt_add_iff_left c).2 ‹_›)
+    · refine fun c => Or.inr ?_
+      induction a using Real.ind_mk with | _ a =>
+      induction b using Real.ind_mk with | _ b =>
+      induction c using Real.ind_mk with | _ c =>
+      simp only [mk_lt, ← mk_add] at *
+      change Pos _ at *
+      rwa [add_sub_add_left_eq_sub]
+
+@[deprecated (since := "2025-09-15")]
+protected alias add_lt_add_iff_left := _root_.add_lt_add_iff_left
 
 instance instIsStrictOrderedRing : IsStrictOrderedRing ℝ :=
   .of_mul_pos fun a b ↦ by


### PR DESCRIPTION
`_root_.add_lt_add_iff_left` serves the same purpose, though the instance that provides it currently relies on the specialized theorem. By deprecating it, authors no longer need to make a meaningless choice between the two theorems. Making it `protected` should ensure no disambiguation is needed when the `Real` namespace is open, though I've not managed to reproduce a case where Lean errors rather than using the namespaced theorem silently.

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include at least one commit authored by each
co-author among the commits in the pull request. If necessary, you may 
create empty commits to indicate co-authorship, using commands like so:

git commit --author="Author Name <author@email.com>" --allow-empty -m "add Author Name as coauthor"

When merging, all the commits will be squashed into a single commit listing all co-authors.

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
