### PR TITLE
[Merged by Bors] - feat(lint-style): also lint against module names containing whitespace

### DIFF
--- a/Mathlib/Tactic/Linter/TextBased.lean
+++ b/Mathlib/Tactic/Linter/TextBased.lean
@@ -23,9 +23,10 @@ Currently, this file contains linters checking
 - for lines with windows line endings,
 - for lines containing trailing whitespace,
 - for module names to be in upper camel case,
-- for module names to be valid Windows filenames.
+- for module names to be valid Windows filenames, and containing no forbidden characters such as
+  `!`, `.` or spaces.
 
-For historic reasons, some further such check checks are written in a Python script `lint-style.py`:
+For historic reasons, some further such checks are written in a Python script `lint-style.py`:
 these are gradually being rewritten in Lean.
 
 This linter has a file for style exceptions (to avoid false positives in the implementation),
@@ -405,7 +406,7 @@ def modulesOSForbidden (opts : LinterOptions) (modules : Array Lean.Name) : IO N
   ]
   -- We also check for the exclamation mark (which is not forbidden on Windows, but e.g. on Nix OS).
   let forbiddenCharacters := [
-    '<', '>', '"', '/', '\\', '|', '?', '*',
+    '<', '>', '"', '/', '\\', '|', '?', '*', ' ',
   ]
   let mut badNamesNum := 0
   for name in modules do

--- a/Mathlib/Tactic/Linter/TextBased.lean
+++ b/Mathlib/Tactic/Linter/TextBased.lean
@@ -404,9 +404,10 @@ def modulesOSForbidden (opts : LinterOptions) (modules : Array Lean.Name) : IO N
     "COM9", "COM¹", "COM²", "COM³", "LPT1", "LPT2", "LPT3", "LPT4", "LPT5", "LPT6", "LPT7", "LPT8",
     "LPT9", "LPT¹", "LPT²", "LPT³"
   ]
-  -- We also check for the exclamation mark (which is not forbidden on Windows, but e.g. on Nix OS).
+  -- We also check for the exclamation mark (which is not forbidden on Windows, but e.g. on Nix OS),
+  -- but do so below (with a custom error message).
   let forbiddenCharacters := [
-    '<', '>', '"', '/', '\\', '|', '?', '*', ' ',
+    '<', '>', '"', '/', '\\', '|', '?', '*',
   ]
   let mut badNamesNum := 0
   for name in modules do
@@ -424,6 +425,9 @@ def modulesOSForbidden (opts : LinterOptions) (modules : Array Lean.Name) : IO N
         else if s.contains '.' then
           isBad := true
           IO.eprintln s!"error: module name '{name}' contains forbidden character '.'"
+        else if s.contains ' ' || s.contains '\t' then
+          isBad := true
+          IO.eprintln s!"error: module name '{name}' contains a space"
         for c in forbiddenCharacters do
           if s.contains c then
             badChars := c.toString :: badChars

--- a/Mathlib/Tactic/Linter/TextBased.lean
+++ b/Mathlib/Tactic/Linter/TextBased.lean
@@ -425,9 +425,9 @@ def modulesOSForbidden (opts : LinterOptions) (modules : Array Lean.Name) : IO N
         else if s.contains '.' then
           isBad := true
           IO.eprintln s!"error: module name '{name}' contains forbidden character '.'"
-        else if s.contains ' ' || s.contains '\t' then
+        else if s.contains ' ' || s.contains '\t' || s.contains '\n' then
           isBad := true
-          IO.eprintln s!"error: module name '{name}' contains a space"
+          IO.eprintln s!"error: module name '{name}' contains a whitespace character"
         for c in forbiddenCharacters do
           if s.contains c then
             badChars := c.toString :: badChars

--- a/MathlibTest/ForbiddenModuleNames.lean
+++ b/MathlibTest/ForbiddenModuleNames.lean
@@ -24,6 +24,8 @@ def testModulesOSForbidden : IO Unit := do
   assert!((← modulesOSForbidden opts #[`Mathlib.«Qu<x!!»]) == 1)
   assert!((← modulesOSForbidden opts #[`Mathlib.«Ba dname»]) == 1)
   assert!((← modulesOSForbidden opts #[`Mathlib.«Bar dname»]) == 1)
+  assert!((← modulesOSForbidden opts #[`Mathlib.«Bar
+dname»]) == 1)
 
 /--
 info: error: module name 'Mathlib.Aux.Foo' contains component '[Aux]', which is forbidden in Windows filenames.
@@ -36,8 +38,10 @@ error: module name 'Mathlib.«B>ar<»' contains characters '[>, <]', which are f
 error: module name 'Mathlib.Bar!' contains forbidden character '!'
 error: module name 'Mathlib.«Qu<x!!»' contains forbidden character '!'
 error: module name 'Mathlib.«Qu<x!!»' contains character '[<]', which is forbidden in Windows filenames.
-error: module name 'Mathlib.«Ba dname»' contains a space
-error: module name 'Mathlib.«Bar dname»' contains a space
+error: module name 'Mathlib.«Ba dname»' contains a whitespace character
+error: module name 'Mathlib.«Bar dname»' contains a whitespace character
+error: module name 'Mathlib.«Bar
+dname»' contains a whitespace character
 -/
 #guard_msgs in
 #eval testModulesOSForbidden

--- a/MathlibTest/ForbiddenModuleNames.lean
+++ b/MathlibTest/ForbiddenModuleNames.lean
@@ -22,6 +22,7 @@ def testModulesOSForbidden : IO Unit := do
   assert!((← modulesOSForbidden opts #[`Mathlib.«B>ar<»]) == 1)
   assert!((← modulesOSForbidden opts #[`Mathlib.«Bar!»]) == 1)
   assert!((← modulesOSForbidden opts #[`Mathlib.«Qu<x!!»]) == 1)
+  assert!((← modulesOSForbidden opts #[`Mathlib.«Ba dname»]) == 1)
 
 /--
 info: error: module name 'Mathlib.Aux.Foo' contains component '[Aux]', which is forbidden in Windows filenames.
@@ -34,6 +35,7 @@ error: module name 'Mathlib.«B>ar<»' contains characters '[>, <]', which are f
 error: module name 'Mathlib.Bar!' contains forbidden character '!'
 error: module name 'Mathlib.«Qu<x!!»' contains forbidden character '!'
 error: module name 'Mathlib.«Qu<x!!»' contains character '[<]', which is forbidden in Windows filenames.
+error: module name 'Mathlib.«Ba dname»' contains character '[ ]', which is forbidden in Windows filenames.
 -/
 #guard_msgs in
 #eval testModulesOSForbidden

--- a/MathlibTest/ForbiddenModuleNames.lean
+++ b/MathlibTest/ForbiddenModuleNames.lean
@@ -23,6 +23,7 @@ def testModulesOSForbidden : IO Unit := do
   assert!((← modulesOSForbidden opts #[`Mathlib.«Bar!»]) == 1)
   assert!((← modulesOSForbidden opts #[`Mathlib.«Qu<x!!»]) == 1)
   assert!((← modulesOSForbidden opts #[`Mathlib.«Ba dname»]) == 1)
+  assert!((← modulesOSForbidden opts #[`Mathlib.«Bar dname»]) == 1)
 
 /--
 info: error: module name 'Mathlib.Aux.Foo' contains component '[Aux]', which is forbidden in Windows filenames.
@@ -35,7 +36,8 @@ error: module name 'Mathlib.«B>ar<»' contains characters '[>, <]', which are f
 error: module name 'Mathlib.Bar!' contains forbidden character '!'
 error: module name 'Mathlib.«Qu<x!!»' contains forbidden character '!'
 error: module name 'Mathlib.«Qu<x!!»' contains character '[<]', which is forbidden in Windows filenames.
-error: module name 'Mathlib.«Ba dname»' contains character '[ ]', which is forbidden in Windows filenames.
+error: module name 'Mathlib.«Ba dname»' contains a space
+error: module name 'Mathlib.«Bar dname»' contains a space
 -/
 #guard_msgs in
 #eval testModulesOSForbidden


### PR DESCRIPTION
This makes iterating over all file names much easier, particularly in bash and `xargs`.

And update the module doc-string, while at it. Follow-up to #27965.

---

For the same reason, we may want to disallow single quotes in the filename --- but given that these also have legitimate uses, I'm less convinced by these. (Particularly so since the shell issues can be solved using better quoting.

<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include at least one commit authored by each
co-author among the commits in the pull request. If necessary, you may 
create empty commits to indicate co-authorship, using commands like so:

git commit --author="Author Name <author@email.com>" --allow-empty -m "add Author Name as coauthor"

When merging, all the commits will be squashed into a single commit listing all co-authors.

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
