### PR TITLE
[Merged by Bors] - feat: `finsum` and locally finite sums of differentiable sections are differentiable

### DIFF
--- a/Mathlib/Geometry/Manifold/MFDeriv/Basic.lean
+++ b/Mathlib/Geometry/Manifold/MFDeriv/Basic.lean
@@ -1067,6 +1067,12 @@ theorem MDifferentiableWithinAt.congr (h : MDifferentiableWithinAt I I' f s x)
     (ht : ∀ x ∈ s, f₁ x = f x) (hx : f₁ x = f x) : MDifferentiableWithinAt I I' f₁ s x :=
   (HasMFDerivWithinAt.congr_mono h.hasMFDerivWithinAt ht hx (Subset.refl _)).mdifferentiableWithinAt
 
+/-- Version of `MDifferentiableWithinAt.congr` where `x` need not be contained in `s`,
+but `f` and `f₁` are equal on a set containing both. -/
+theorem MDifferentiableWithinAt.congr' (h : MDifferentiableWithinAt I I' f s x)
+    (ht : ∀ x ∈ t, f₁ x = f x) (hst : s ⊆ t) (hxt : x ∈ t) : MDifferentiableWithinAt I I' f₁ s x :=
+  h.congr (fun _y hy ↦ ht _y (hst hy)) (ht x hxt)
+
 theorem Filter.EventuallyEq.mdifferentiableAt_iff (h₁ : f₁ =ᶠ[𝓝 x] f) :
     MDifferentiableAt I I' f₁ x ↔ MDifferentiableAt I I' f x :=
   differentiableWithinAt_localInvariantProp.liftPropAt_congr_iff_of_eventuallyEq h₁

--- a/Mathlib/Geometry/Manifold/VectorBundle/MDifferentiable.lean
+++ b/Mathlib/Geometry/Manifold/VectorBundle/MDifferentiable.lean
@@ -524,7 +524,7 @@ variable {ι : Type*} {t : ι → (x : B) → E x}
 
 open Function
 
-/-- The sum of a locally finite collection of sections is differentiable iff each section is.
+/-- The sum of a locally finite collection of sections is differentiable if each section is.
 Version at a point within a set. -/
 lemma MDifferentiableWithinAt.sum_section_of_locallyFinite
     (ht : LocallyFinite fun i ↦ {x : B | t i x ≠ 0})
@@ -561,7 +561,7 @@ lemma MDifferentiableWithinAt.sum_section_of_locallyFinite
     simpa using ⟨h, Set.mem_of_mem_inter_right hy⟩
   exact hi this
 
-/-- The sum of a locally finite collection of sections is `C^k` at `x` iff each section is. -/
+/-- The sum of a locally finite collection of sections is differentiable at `x` if each section is. -/
 lemma MDifferentiableAt.sum_section_of_locallyFinite
     (ht : LocallyFinite fun i ↦ {x : B | t i x ≠ 0})
     (ht' : ∀ i, MDifferentiableAt I (I.prod 𝓘(𝕜, F)) (fun x ↦ TotalSpace.mk' F x (t i x)) x₀) :

--- a/Mathlib/Geometry/Manifold/VectorBundle/MDifferentiable.lean
+++ b/Mathlib/Geometry/Manifold/VectorBundle/MDifferentiable.lean
@@ -504,6 +504,122 @@ lemma MDifferentiable.sum_section {ι : Type*} {s : Finset ι} {t : ι → (x : 
     MDifferentiable I (I.prod 𝓘(𝕜, F)) (fun x ↦ TotalSpace.mk' F x (∑ i ∈ s, (t i x))) :=
   fun x₀ ↦ .sum_section fun i ↦ (hs i) x₀
 
+/-- The scalar product `ψ • s` of a differentiable function `ψ : M → 𝕜` and a section `s` of a
+vector bundle `V → M` is differentiable once `s` is differentiable on an open set containing
+`tsupport ψ`.
+
+See `ContMDiffOn.smul_section_of_tsupport` for the analogous result about `C^n` sections. -/
+lemma MDifferentiableOn.smul_section_of_tsupport {s : Π (x : B), E x} {ψ : B → 𝕜}
+    (hψ : MDifferentiableOn I 𝓘(𝕜) ψ u) (ht : IsOpen u) (ht' : tsupport ψ ⊆ u)
+    (hs : MDifferentiableOn I (I.prod 𝓘(𝕜, F)) (fun x ↦ TotalSpace.mk' F x (s x)) u) :
+    MDifferentiable I (I.prod 𝓘(𝕜, F)) (fun x ↦ TotalSpace.mk' F x (ψ x • s x)) := by
+  apply mdifferentiable_of_mdifferentiableOn_union_of_isOpen (hψ.smul_section hs) ?_ ?_ ht
+      (isOpen_compl_iff.mpr <| isClosed_tsupport ψ)
+  · apply ((mdifferentiable_zeroSection _ _).mdifferentiableOn (s := (tsupport ψ)ᶜ)).congr
+    intro y hy
+    simp [image_eq_zero_of_notMem_tsupport hy, zeroSection]
+  · exact Set.compl_subset_iff_union.mp <| Set.compl_subset_compl.mpr ht'
+
+variable {ι : Type*} {t : ι → (x : B) → E x}
+
+open Function
+
+/-- The sum of a locally finite collection of sections is differentiable iff each section is.
+Version at a point within a set. -/
+lemma MDifferentiableWithinAt.sum_section_of_locallyFinite
+    (ht : LocallyFinite fun i ↦ {x : B | t i x ≠ 0})
+    (ht' : ∀ i, MDifferentiableWithinAt I (I.prod 𝓘(𝕜, F))
+      (fun x ↦ TotalSpace.mk' F x (t i x)) u x₀) :
+    MDifferentiableWithinAt I (I.prod 𝓘(𝕜, F))
+      (fun x ↦ TotalSpace.mk' F x (∑' i, (t i x))) u x₀ := by
+  obtain ⟨u', hu', hfin⟩ := ht x₀
+  -- All sections `t i` but a finite set `s` vanish near `x₀`: choose a neighbourhood `u` of `x₀`
+  -- and a finite set `s` of sections which don't vanish.
+  let s := {i | ((fun i ↦ {x | t i x ≠ 0}) i ∩ u').Nonempty}
+  have := hfin.fintype
+  have : MDifferentiableWithinAt I (I.prod 𝓘(𝕜, F))
+      (fun x ↦ TotalSpace.mk' F x (∑ i ∈ s, (t i x))) (u ∩ u') x₀ :=
+     MDifferentiableWithinAt.sum_section fun i ↦ ((ht' i).mono inter_subset_left)
+  apply (mdifferentiableWithinAt_inter hu').mp
+  apply this.congr fun y hy ↦ ?_
+  · rw [TotalSpace.mk_inj, tsum_eq_sum']
+    refine support_subset_iff'.mpr fun i hi ↦ ?_
+    by_contra! h
+    have : i ∈ s.toFinset := by
+      refine Set.mem_toFinset.mpr ?_
+      simp only [s, ne_eq, Set.mem_setOf_eq]
+      use x₀
+      simpa using ⟨h, mem_of_mem_nhds hu'⟩
+    exact hi this
+  rw [TotalSpace.mk_inj, tsum_eq_sum']
+  refine support_subset_iff'.mpr fun i hi ↦ ?_
+  by_contra! h
+  have : i ∈ s.toFinset := by
+    refine Set.mem_toFinset.mpr ?_
+    simp only [s, ne_eq, Set.mem_setOf_eq]
+    use y
+    simpa using ⟨h, Set.mem_of_mem_inter_right hy⟩
+  exact hi this
+
+/-- The sum of a locally finite collection of sections is `C^k` at `x` iff each section is. -/
+lemma MDifferentiableAt.sum_section_of_locallyFinite
+    (ht : LocallyFinite fun i ↦ {x : B | t i x ≠ 0})
+    (ht' : ∀ i, MDifferentiableAt I (I.prod 𝓘(𝕜, F)) (fun x ↦ TotalSpace.mk' F x (t i x)) x₀) :
+    MDifferentiableAt I (I.prod 𝓘(𝕜, F)) (fun x ↦ TotalSpace.mk' F x (∑' i, (t i x))) x₀ := by
+  simp_rw [← mdifferentiableWithinAt_univ] at ht' ⊢
+  exact .sum_section_of_locallyFinite ht ht'
+
+/-- The sum of a locally finite collection of sections is `C^k` on a set `u` iff each section is. -/
+lemma MDifferentiableOn.sum_section_of_locallyFinite
+    (ht : LocallyFinite fun i ↦ {x : B | t i x ≠ 0})
+    (ht' : ∀ i, MDifferentiableOn I (I.prod 𝓘(𝕜, F)) (fun x ↦ TotalSpace.mk' F x (t i x)) u) :
+    MDifferentiableOn I (I.prod 𝓘(𝕜, F)) (fun x ↦ TotalSpace.mk' F x (∑' i, (t i x))) u :=
+  fun x hx ↦ .sum_section_of_locallyFinite ht (ht' · x hx)
+
+/-- The sum of a locally finite collection of sections is `C^k` iff each section is. -/
+lemma MDifferentiable.sum_section_of_locallyFinite (ht : LocallyFinite fun i ↦ {x : B | t i x ≠ 0})
+    (ht' : ∀ i, MDifferentiable I (I.prod 𝓘(𝕜, F)) (fun x ↦ TotalSpace.mk' F x (t i x))) :
+    MDifferentiable I (I.prod 𝓘(𝕜, F)) (fun x ↦ TotalSpace.mk' F x (∑' i, (t i x))) :=
+  fun x ↦ .sum_section_of_locallyFinite ht fun i ↦ ht' i x
+
+-- Future: the next four lemmas can presumably be generalised, but some hypotheses on the supports
+-- of the sections `t i` are necessary.
+lemma MDifferentiableWithinAt.finsum_section_of_locallyFinite
+    (ht : LocallyFinite fun i ↦ {x : B | t i x ≠ 0})
+    (ht' : ∀ i, MDifferentiableWithinAt I (I.prod 𝓘(𝕜, F))
+      (fun x ↦ TotalSpace.mk' F x (t i x)) u x₀) :
+    MDifferentiableWithinAt I (I.prod 𝓘(𝕜, F))
+      (fun x ↦ TotalSpace.mk' F x (∑ᶠ i, t i x)) u x₀ := by
+  apply (MDifferentiableWithinAt.sum_section_of_locallyFinite ht ht').congr' (t := Set.univ)
+      (fun y hy ↦ ?_) (by grind) trivial
+  rw [← tsum_eq_finsum]
+  choose U hu hfin using ht y
+  have : {x | t x y ≠ 0} ⊆ {i | ((fun i ↦ {x | t i x ≠ 0}) i ∩ U).Nonempty} := by
+    intro x hx
+    rw [Set.mem_setOf] at hx ⊢
+    use y
+    simpa using ⟨hx, mem_of_mem_nhds hu⟩
+  exact Set.Finite.subset hfin this
+
+lemma MDifferentiableAt.finsum_section_of_locallyFinite
+    (ht : LocallyFinite fun i ↦ {x : B | t i x ≠ 0})
+    (ht' : ∀ i, MDifferentiableAt I (I.prod 𝓘(𝕜, F)) (fun x ↦ TotalSpace.mk' F x (t i x)) x₀) :
+    MDifferentiableAt I (I.prod 𝓘(𝕜, F)) (fun x ↦ TotalSpace.mk' F x (∑ᶠ i, t i x)) x₀ := by
+  simp_rw [← mdifferentiableWithinAt_univ] at ht' ⊢
+  exact .finsum_section_of_locallyFinite ht ht'
+
+lemma MDifferentiableOn.finsum_section_of_locallyFinite
+    (ht : LocallyFinite fun i ↦ {x : B | t i x ≠ 0})
+    (ht' : ∀ i, MDifferentiableOn I (I.prod 𝓘(𝕜, F)) (fun x ↦ TotalSpace.mk' F x (t i x)) u) :
+    MDifferentiableOn I (I.prod 𝓘(𝕜, F)) (fun x ↦ TotalSpace.mk' F x (∑ᶠ i, t i x)) u :=
+  fun x hx ↦ .finsum_section_of_locallyFinite ht fun i ↦ ht' i x hx
+
+lemma MDifferentiable.finsum_section_of_locallyFinite
+    (ht : LocallyFinite fun i ↦ {x : B | t i x ≠ 0})
+    (ht' : ∀ i, MDifferentiable I (I.prod 𝓘(𝕜, F)) (fun x ↦ TotalSpace.mk' F x (t i x))) :
+    MDifferentiable I (I.prod 𝓘(𝕜, F)) (fun x ↦ TotalSpace.mk' F x (∑ᶠ i, t i x)) :=
+  fun x ↦ .finsum_section_of_locallyFinite ht fun i ↦ ht' i x
+
 end operations
 
 section

--- a/Mathlib/Geometry/Manifold/VectorBundle/MDifferentiable.lean
+++ b/Mathlib/Geometry/Manifold/VectorBundle/MDifferentiable.lean
@@ -561,7 +561,8 @@ lemma MDifferentiableWithinAt.sum_section_of_locallyFinite
     simpa using ⟨h, Set.mem_of_mem_inter_right hy⟩
   exact hi this
 
-/-- The sum of a locally finite collection of sections is differentiable at `x` if each section is. -/
+/-- The sum of a locally finite collection of sections is differentiable at `x`
+if each section is. -/
 lemma MDifferentiableAt.sum_section_of_locallyFinite
     (ht : LocallyFinite fun i ↦ {x : B | t i x ≠ 0})
     (ht' : ∀ i, MDifferentiableAt I (I.prod 𝓘(𝕜, F)) (fun x ↦ TotalSpace.mk' F x (t i x)) x₀) :
@@ -569,21 +570,20 @@ lemma MDifferentiableAt.sum_section_of_locallyFinite
   simp_rw [← mdifferentiableWithinAt_univ] at ht' ⊢
   exact .sum_section_of_locallyFinite ht ht'
 
-/-- The sum of a locally finite collection of sections is `C^k` on a set `u` iff each section is. -/
+/-- The sum of a locally finite collection of sections is differentiable on a set `u`
+if each section is. -/
 lemma MDifferentiableOn.sum_section_of_locallyFinite
     (ht : LocallyFinite fun i ↦ {x : B | t i x ≠ 0})
     (ht' : ∀ i, MDifferentiableOn I (I.prod 𝓘(𝕜, F)) (fun x ↦ TotalSpace.mk' F x (t i x)) u) :
     MDifferentiableOn I (I.prod 𝓘(𝕜, F)) (fun x ↦ TotalSpace.mk' F x (∑' i, (t i x))) u :=
   fun x hx ↦ .sum_section_of_locallyFinite ht (ht' · x hx)
 
-/-- The sum of a locally finite collection of sections is `C^k` iff each section is. -/
+/-- The sum of a locally finite collection of sections is differentiable if each section is. -/
 lemma MDifferentiable.sum_section_of_locallyFinite (ht : LocallyFinite fun i ↦ {x : B | t i x ≠ 0})
     (ht' : ∀ i, MDifferentiable I (I.prod 𝓘(𝕜, F)) (fun x ↦ TotalSpace.mk' F x (t i x))) :
     MDifferentiable I (I.prod 𝓘(𝕜, F)) (fun x ↦ TotalSpace.mk' F x (∑' i, (t i x))) :=
   fun x ↦ .sum_section_of_locallyFinite ht fun i ↦ ht' i x
 
--- Future: the next four lemmas can presumably be generalised, but some hypotheses on the supports
--- of the sections `t i` are necessary.
 lemma MDifferentiableWithinAt.finsum_section_of_locallyFinite
     (ht : LocallyFinite fun i ↦ {x : B | t i x ≠ 0})
     (ht' : ∀ i, MDifferentiableWithinAt I (I.prod 𝓘(𝕜, F))

--- a/Mathlib/Geometry/Manifold/VectorBundle/MDifferentiable.lean
+++ b/Mathlib/Geometry/Manifold/VectorBundle/MDifferentiable.lean
@@ -541,16 +541,7 @@ lemma MDifferentiableWithinAt.sum_section_of_locallyFinite
       (fun x ↦ TotalSpace.mk' F x (∑ i ∈ s, (t i x))) (u ∩ u') x₀ :=
      MDifferentiableWithinAt.sum_section fun i ↦ ((ht' i).mono inter_subset_left)
   apply (mdifferentiableWithinAt_inter hu').mp
-  apply this.congr fun y hy ↦ ?_
-  · rw [TotalSpace.mk_inj, tsum_eq_sum']
-    refine support_subset_iff'.mpr fun i hi ↦ ?_
-    by_contra! h
-    have : i ∈ s.toFinset := by
-      refine Set.mem_toFinset.mpr ?_
-      simp only [s, ne_eq, Set.mem_setOf_eq]
-      use x₀
-      simpa using ⟨h, mem_of_mem_nhds hu'⟩
-    exact hi this
+  apply this.congr' (fun y hy ↦ ?_) inter_subset_right (mem_of_mem_nhds hu')
   rw [TotalSpace.mk_inj, tsum_eq_sum']
   refine support_subset_iff'.mpr fun i hi ↦ ?_
   by_contra! h
@@ -558,7 +549,7 @@ lemma MDifferentiableWithinAt.sum_section_of_locallyFinite
     refine Set.mem_toFinset.mpr ?_
     simp only [s, ne_eq, Set.mem_setOf_eq]
     use y
-    simpa using ⟨h, Set.mem_of_mem_inter_right hy⟩
+    simp [h, hy]
   exact hi this
 
 /-- The sum of a locally finite collection of sections is differentiable at `x`


### PR DESCRIPTION
Mirrors analogous API for C^n sections; this is added mostly for completeness.
Follow-up to #26871.

Hence, this also originated from our work towards the path towards geodesics and the Levi-Civita connection.

---

- [x] depends on: #26871

<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include at least one commit authored by each
co-author among the commits in the pull request. If necessary, you may 
create empty commits to indicate co-authorship, using commands like so:

git commit --author="Author Name <author@email.com>" --allow-empty -m "add Author Name as coauthor"

When merging, all the commits will be squashed into a single commit listing all co-authors.

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
