### PR TITLE
[Merged by Bors] - feat: add piCongrSigmaFiber and piCongrFiberwise equivalences

### DIFF
--- a/Mathlib/Logic/Equiv/Basic.lean
+++ b/Mathlib/Logic/Equiv/Basic.lean
@@ -945,22 +945,21 @@ theorem piCongr'_symm_apply_symm_apply (f : ∀ b, Z b) (b : β) :
 
 end
 
+variable {α : Type*} {β : Type*} {f : α → β}
+
 /-- A family of equivalences `∀ a, γ₁ a ≃ γ₂ a` generates an equivalence between the product
 over the fibers of a function `f : α → β` on index types. -/
-def piCongrSigmaFiber {α β : Type*} {f : α → β} {γ₁ γ₂ : α → Sort*}
-    (e : (a : α) → γ₁ a ≃ γ₂ a) :
+def piCongrSigmaFiber {γ₁ γ₂ : α → Sort*} (e : (a : α) → γ₁ a ≃ γ₂ a) :
     ((σ : (y : β) × { x : α // f x = y }) → γ₁ σ.2.1) ≃ ((a : α) → γ₂ a) :=
   piCongrLeft γ₁ (sigmaFiberEquiv f) |>.trans (piCongrRight e)
 
 @[simp]
-theorem piCongrSigmaFiber_apply {α β : Type*} {f : α → β} {γ₁ γ₂ : α → Sort*}
-    (e : (a : α) → γ₁ a ≃ γ₂ a)
+theorem piCongrSigmaFiber_apply {γ₁ γ₂ : α → Sort*} (e : (a : α) → γ₁ a ≃ γ₂ a)
     (g : (σ : (y : β) × { x : α // f x = y }) → γ₁ σ.2.1) (a : α) :
     piCongrSigmaFiber e g a = e a (g ⟨f a, ⟨a, rfl⟩⟩) := rfl
 
 @[simp]
-theorem piCongrSigmaFiber_symm_apply {α β : Type*} {f : α → β} {γ₁ γ₂ : α → Sort*}
-    (e : (a : α) → γ₁ a ≃ γ₂ a)
+theorem piCongrSigmaFiber_symm_apply {γ₁ γ₂ : α → Sort*} (e : (a : α) → γ₁ a ≃ γ₂ a)
     (g : (a : α) → γ₂ a) (σ : (y : β) × { x : α // f x = y }) :
     (piCongrSigmaFiber e).symm g σ = (e σ.2.1).symm (g σ.2.1) := rfl
 
@@ -968,7 +967,7 @@ theorem piCongrSigmaFiber_symm_apply {α β : Type*} {f : α → β} {γ₁ γ�
 between the product over the fiber of `b` under `f` given as
 `∀ (σ : { a : α // f a = b }) → γ₁ σ.1) ≃ γ₂ b` lifts to an equivalence over the products
 `∀ a, γ₁ a ≃ ∀ b, γ₂ b`. -/
-def piCongrFiberwise {α β : Type*} {γ₁ : α → Type*} {γ₂ : β → Type*} {f : α → β}
+def piCongrFiberwise {γ₁ : α → Type*} {γ₂ : β → Type*} {f : α → β}
     (e : (b : β) → ((σ : { a : α // f a = b }) → γ₁ σ.1) ≃ γ₂ b) :
     ((a : α) → γ₁ a) ≃ ((b : β) → γ₂ b) :=
   ((piCongrSigmaFiber (fun _ => Equiv.refl _)).symm.trans
@@ -976,12 +975,12 @@ def piCongrFiberwise {α β : Type*} {γ₁ : α → Type*} {γ₂ : β → Type
       (piCongrRight e)
 
 @[simp]
-theorem piCongrFiberwise_apply {α β : Type*} {γ₁ : α → Type*} {γ₂ : β → Type*} {f : α → β}
+theorem piCongrFiberwise_apply {γ₁ : α → Type*} {γ₂ : β → Type*} {f : α → β}
     (e : (b : β) → ((σ : { a : α // f a = b }) → γ₁ σ.1) ≃ γ₂ b) (g : (a : α) → γ₁ a) (b : β) :
     piCongrFiberwise e g b = e b fun σ => g σ.1 := rfl
 
 @[simp]
-theorem piCongrFiberwise_symm_apply {α β : Type*} {γ₁ : α → Type*} {γ₂ : β → Type*} {f : α → β}
+theorem piCongrFiberwise_symm_apply {γ₁ : α → Type*} {γ₂ : β → Type*} {f : α → β}
     (e : (b : β) → ((σ : { a : α // f a = b }) → γ₁ σ.1) ≃ γ₂ b) (g : (b : β) → γ₂ b) (a : α) :
     (piCongrFiberwise e).symm g a = (e (f a)).symm (g (f a)) ⟨a, rfl⟩ := rfl
 

--- a/Mathlib/Logic/Equiv/Basic.lean
+++ b/Mathlib/Logic/Equiv/Basic.lean
@@ -945,6 +945,46 @@ theorem piCongr'_symm_apply_symm_apply (f : ∀ b, Z b) (b : β) :
 
 end
 
+/-- A family of equivalences `∀ a, γ₁ a ≃ γ₂ a` generates an equivalence between the product
+over the fibers of a function `f : α → β` on index types. -/
+def piCongrSigmaFiber {α β : Type*} {f : α → β} {γ₁ γ₂ : α → Sort*}
+    (e : (a : α) → γ₁ a ≃ γ₂ a) :
+    ((σ : (y : β) × { x : α // f x = y }) → γ₁ σ.2.1) ≃ ((a : α) → γ₂ a) :=
+  piCongrLeft γ₁ (sigmaFiberEquiv f) |>.trans (piCongrRight e)
+
+@[simp]
+theorem piCongrSigmaFiber_apply {α β : Type*} {f : α → β} {γ₁ γ₂ : α → Sort*}
+    (e : (a : α) → γ₁ a ≃ γ₂ a)
+    (g : (σ : (y : β) × { x : α // f x = y }) → γ₁ σ.2.1) (a : α) :
+    piCongrSigmaFiber e g a = e a (g ⟨f a, ⟨a, rfl⟩⟩) := rfl
+
+@[simp]
+theorem piCongrSigmaFiber_symm_apply {α β : Type*} {f : α → β} {γ₁ γ₂ : α → Sort*}
+    (e : (a : α) → γ₁ a ≃ γ₂ a)
+    (g : (a : α) → γ₂ a) (σ : (y : β) × { x : α // f x = y }) :
+    (piCongrSigmaFiber e).symm g σ = (e σ.2.1).symm (g σ.2.1) := rfl
+
+/-- Let `f : α → β` be a function on index types. A family of equivalences, indexed by `b : β`,
+between the product over the fiber of `b` under `f` given as
+`∀ (σ : { a : α // f a = b }) → γ₁ σ.1) ≃ γ₂ b` lifts to an equivalence over the products
+`∀ a, γ₁ a ≃ ∀ b, γ₂ b`. -/
+def piCongrFiberwise {α β : Type*} {γ₁ : α → Type*} {γ₂ : β → Type*} {f : α → β}
+    (e : (b : β) → ((σ : { a : α // f a = b }) → γ₁ σ.1) ≃ γ₂ b) :
+    ((a : α) → γ₁ a) ≃ ((b : β) → γ₂ b) :=
+  ((piCongrSigmaFiber (fun _ => Equiv.refl _)).symm.trans
+    (piCurry fun b (x : { x : α // f x = b }) => γ₁ x.1)).trans
+      (piCongrRight e)
+
+@[simp]
+theorem piCongrFiberwise_apply {α β : Type*} {γ₁ : α → Type*} {γ₂ : β → Type*} {f : α → β}
+    (e : (b : β) → ((σ : { a : α // f a = b }) → γ₁ σ.1) ≃ γ₂ b) (g : (a : α) → γ₁ a) (b : β) :
+    piCongrFiberwise e g b = e b fun σ => g σ.1 := rfl
+
+@[simp]
+theorem piCongrFiberwise_symm_apply {α β : Type*} {γ₁ : α → Type*} {γ₂ : β → Type*} {f : α → β}
+    (e : (b : β) → ((σ : { a : α // f a = b }) → γ₁ σ.1) ≃ γ₂ b) (g : (b : β) → γ₂ b) (a : α) :
+    (piCongrFiberwise e).symm g a = (e (f a)).symm (g (f a)) ⟨a, rfl⟩ := rfl
+
 /-- Transport dependent functions through an equality of sets. -/
 @[simps!] def piCongrSet {α} {W : α → Sort w} {s t : Set α} (h : s = t) :
     (∀ i : {i // i ∈ s}, W i) ≃ (∀ i : {i // i ∈ t}, W i) where


### PR DESCRIPTION
## Summary

Add two new equivalence functions for working with fibers and sigma types:
- `Equiv.piCongrSigmaFiber`: transforms between functions on sigma fibers and regular pi types
- `Equiv.piCongrFiberwise`: lifts fiber-wise equivalences to product equivalences

These functions are from the FLT (Fermat's Last Theorem) project and are useful for manipulating dependent function types indexed by fibers of a function.

## Details

The new definitions allow for elegant transformations between:
1. Functions defined on sigma types representing fibers of a function
2. Regular dependent functions

These are particularly useful in algebraic contexts where one needs to work with products indexed by fibers.

## Context

This PR was prepared by Claude (Claude Code) based on the following prompt:
> "Please read FLT/Mathlib/Logic/Equiv/Basic.lean, and also the corresponding file in the Mathlib repository. Please prepare a PR to Mathlib containing this content, putting it at an appropriate point in the corresponding Mathlib file. Make sure the PR is label FLT, and write in the PR comment an explanation that the PR was prepared by Claude, including quoting the prompting."

The content is sourced from `/Users/kim/projects/lean/FLT/FLT/Mathlib/Logic/Equiv/Basic.lean` in the FLT project repository.

🤖 Generated with [Claude Code](https://claude.ai/code)