### PR TITLE
[Merged by Bors] - feat(GroupTheory/Commensurable): additivize

### DIFF
--- a/Mathlib/GroupTheory/Commensurable.lean
+++ b/Mathlib/GroupTheory/Commensurable.lean
@@ -64,7 +64,7 @@ theorem equivalence : Equivalence (@Commensurable G _) :=
   ⟨Commensurable.refl, fun h => Commensurable.symm h, fun h₁ h₂ => Commensurable.trans h₁ h₂⟩
 
 /-- Equivalence of `K/H ⊓ K` with `gKg⁻¹/gHg⁻¹ ⊓ gKg⁻¹` -/
-def quotConjEquiv (H K : Subgroup G) (g : ConjAct G) :
+def _root_.Subgroup.quotConjEquiv (H K : Subgroup G) (g : ConjAct G) :
     K ⧸ H.subgroupOf K ≃ (g • K : Subgroup G) ⧸ (g • H).subgroupOf (g • K) :=
   Quotient.congr (K.equivSMul g).toEquiv fun a b => by
     dsimp
@@ -115,3 +115,7 @@ theorem eq {H K : Subgroup G} (hk : Commensurable H K) : commensurator H = comme
     ⟨fun h => hx.symm.trans (h.trans hk), fun h => hx.trans (h.trans hk.symm)⟩
 
 end Subgroup.Commensurable
+
+@[deprecated (since := "2025-09-17")] alias Commensurable := Subgroup.Commensurable
+
+@[deprecated (since := "2025-09-17")] alias Commensurable.quotConjEquiv := Subgroup.quotConjEquiv

--- a/Mathlib/GroupTheory/Commensurable.lean
+++ b/Mathlib/GroupTheory/Commensurable.lean
@@ -26,32 +26,40 @@ commensurable with `H`.
 We define the commensurator of a subgroup `H` of `G` by first defining it as a subgroup of
 `(conjAct G)`, which we call `commensurator'` and then taking the pre-image under
 the map `G → (conjAct G)` to obtain our commensurator as a subgroup of `G`.
--/
 
+We define `Commensurable` both for additive and multiplicative groups (in the `AddSubgroup` and
+`Subgroup` namespaces respectively); but `Commensurator` is not additivized, since it is not an
+interesting concept for abelian groups, and it would be unusual to write a non-abelian group
+additively.
+-/
 
 variable {G : Type*} [Group G]
 
-/-- Two subgroups `H K` of `G` are commensurable if `H ⊓ K` has finite index in both `H` and `K` -/
-def Commensurable (H K : Subgroup G) : Prop :=
+/-- Two subgroups `H K` of `G` are commensurable if `H ⊓ K` has finite index in both `H` and `K`. -/
+@[to_additive /-- Two subgroups `H K` of `G` are commensurable if `H ⊓ K` has finite index in both
+`H` and `K`. -/]
+def Subgroup.Commensurable (H K : Subgroup G) : Prop :=
   H.relIndex K ≠ 0 ∧ K.relIndex H ≠ 0
 
-namespace Commensurable
+namespace Subgroup.Commensurable
 
 open Pointwise
 
-@[refl]
+@[to_additive (attr := refl)]
 protected theorem refl (H : Subgroup G) : Commensurable H H := by simp [Commensurable]
 
+@[to_additive]
 theorem comm {H K : Subgroup G} : Commensurable H K ↔ Commensurable K H := and_comm
 
-@[symm]
+@[to_additive (attr := symm)]
 theorem symm {H K : Subgroup G} : Commensurable H K → Commensurable K H := And.symm
 
-@[trans]
+@[to_additive (attr := trans)]
 theorem trans {H K L : Subgroup G} (hhk : Commensurable H K) (hkl : Commensurable K L) :
     Commensurable H L :=
   ⟨Subgroup.relIndex_ne_zero_trans hhk.1 hkl.1, Subgroup.relIndex_ne_zero_trans hkl.2 hhk.2⟩
 
+@[to_additive]
 theorem equivalence : Equivalence (@Commensurable G _) :=
   ⟨Commensurable.refl, fun h => Commensurable.symm h, fun h₁ h₂ => Commensurable.trans h₁ h₂⟩
 
@@ -69,6 +77,11 @@ theorem commensurable_conj {H K : Subgroup G} (g : ConjAct G) :
     Commensurable H K ↔ Commensurable (g • H) (g • K) :=
   and_congr (not_iff_not.mpr (Eq.congr_left (Cardinal.toNat_congr (quotConjEquiv H K g))))
     (not_iff_not.mpr (Eq.congr_left (Cardinal.toNat_congr (quotConjEquiv K H g))))
+
+/-- Alias for the forward direction of `commensurable_conj` to allow dot-notation -/
+theorem conj {H K : Subgroup G} (h : Commensurable H K) (g : ConjAct G) :
+    Commensurable (g • H) (g • K) :=
+  (commensurable_conj g).mp h
 
 theorem commensurable_inv (H : Subgroup G) (g : ConjAct G) :
     Commensurable (g • H) H ↔ Commensurable H (g⁻¹ • H) := by rw [commensurable_conj, inv_smul_smul]
@@ -101,4 +114,4 @@ theorem eq {H K : Subgroup G} (hk : Commensurable H K) : commensurator H = comme
     let hx := (commensurable_conj x).1 hk
     ⟨fun h => hx.symm.trans (h.trans hk), fun h => hx.trans (h.trans hk.symm)⟩
 
-end Commensurable
+end Subgroup.Commensurable

--- a/Mathlib/GroupTheory/Commensurable.lean
+++ b/Mathlib/GroupTheory/Commensurable.lean
@@ -33,7 +33,20 @@ interesting concept for abelian groups, and it would be unusual to write a non-a
 additively.
 -/
 
+open Pointwise
+
 variable {G : Type*} [Group G]
+
+/-- Equivalence of `K / (H ⊓ K)` with `gKg⁻¹/ (gHg⁻¹ ⊓ gKg⁻¹)` -/
+def Subgroup.quotConjEquiv (H K : Subgroup G) (g : ConjAct G) :
+    K ⧸ H.subgroupOf K ≃ (g • K : Subgroup G) ⧸ (g • H).subgroupOf (g • K) :=
+  Quotient.congr (K.equivSMul g).toEquiv fun a b ↦ by
+    dsimp
+    rw [← Quotient.eq'', ← Quotient.eq'', QuotientGroup.eq, QuotientGroup.eq,
+      mem_subgroupOf, mem_subgroupOf, ← map_inv, ← map_mul, equivSMul_apply_coe]
+    exact smul_mem_pointwise_smul_iff.symm
+
+@[deprecated (since := "2025-09-17")] alias Commensurable.quotConjEquiv := Subgroup.quotConjEquiv
 
 /-- Two subgroups `H K` of `G` are commensurable if `H ⊓ K` has finite index in both `H` and `K`. -/
 @[to_additive /-- Two subgroups `H K` of `G` are commensurable if `H ⊓ K` has finite index in both
@@ -41,9 +54,9 @@ variable {G : Type*} [Group G]
 def Subgroup.Commensurable (H K : Subgroup G) : Prop :=
   H.relIndex K ≠ 0 ∧ K.relIndex H ≠ 0
 
-namespace Subgroup.Commensurable
+@[deprecated (since := "2025-09-17")] alias Commensurable := Subgroup.Commensurable
 
-open Pointwise
+namespace Subgroup.Commensurable
 
 @[to_additive (attr := refl)]
 protected theorem refl (H : Subgroup G) : Commensurable H H := by simp [Commensurable]
@@ -62,16 +75,6 @@ theorem trans {H K L : Subgroup G} (hhk : Commensurable H K) (hkl : Commensurabl
 @[to_additive]
 theorem equivalence : Equivalence (@Commensurable G _) :=
   ⟨Commensurable.refl, fun h => Commensurable.symm h, fun h₁ h₂ => Commensurable.trans h₁ h₂⟩
-
-/-- Equivalence of `K/H ⊓ K` with `gKg⁻¹/gHg⁻¹ ⊓ gKg⁻¹` -/
-def _root_.Subgroup.quotConjEquiv (H K : Subgroup G) (g : ConjAct G) :
-    K ⧸ H.subgroupOf K ≃ (g • K : Subgroup G) ⧸ (g • H).subgroupOf (g • K) :=
-  Quotient.congr (K.equivSMul g).toEquiv fun a b => by
-    dsimp
-    rw [← Quotient.eq'', ← Quotient.eq'', QuotientGroup.eq, QuotientGroup.eq,
-      Subgroup.mem_subgroupOf, Subgroup.mem_subgroupOf, ← map_inv, ← map_mul,
-      Subgroup.equivSMul_apply_coe]
-    exact Subgroup.smul_mem_pointwise_smul_iff.symm
 
 theorem commensurable_conj {H K : Subgroup G} (g : ConjAct G) :
     Commensurable H K ↔ Commensurable (g • H) (g • K) :=
@@ -115,7 +118,3 @@ theorem eq {H K : Subgroup G} (hk : Commensurable H K) : commensurator H = comme
     ⟨fun h => hx.symm.trans (h.trans hk), fun h => hx.trans (h.trans hk.symm)⟩
 
 end Subgroup.Commensurable
-
-@[deprecated (since := "2025-09-17")] alias Commensurable := Subgroup.Commensurable
-
-@[deprecated (since := "2025-09-17")] alias Commensurable.quotConjEquiv := Subgroup.quotConjEquiv

--- a/Mathlib/NumberTheory/ModularForms/CongruenceSubgroups.lean
+++ b/Mathlib/NumberTheory/ModularForms/CongruenceSubgroups.lean
@@ -340,9 +340,10 @@ lemma isArithmetic_conj_SL2Z (g : GL (Fin 2) ℚ) :
     exact (finiteIndex_conjGL g).index_ne_zero
 
 /-- Conjugation by `GL(2, ℚ)` preserves arithmetic subgroups. -/
-lemma IsArithmetic.conj (𝒢 : Subgroup (GL (Fin 2) ℝ)) [𝒢.IsArithmetic] (g : GL (Fin 2) ℚ) :
+lemma _root_.Subgroup.IsArithmetic.conj (𝒢 : Subgroup (GL (Fin 2) ℝ)) [𝒢.IsArithmetic]
+    (g : GL (Fin 2) ℚ) :
     (toConjAct (g.map (Rat.castHom ℝ)) • 𝒢).IsArithmetic :=
-  ⟨((Commensurable.commensurable_conj _).mp Subgroup.IsArithmetic.is_commensurable).trans
+  ⟨(Subgroup.IsArithmetic.is_commensurable.conj _).trans
     (isArithmetic_conj_SL2Z g).is_commensurable⟩
 
 /-- If `Γ` is a congruence subgroup, then so is `g⁻¹ Γ g ∩ SL(2, ℤ)` for any `g ∈ GL(2, ℚ)`. -/

--- a/Mathlib/NumberTheory/ModularForms/CongruenceSubgroups.lean
+++ b/Mathlib/NumberTheory/ModularForms/CongruenceSubgroups.lean
@@ -346,6 +346,8 @@ lemma _root_.Subgroup.IsArithmetic.conj (𝒢 : Subgroup (GL (Fin 2) ℝ)) [𝒢
   ⟨(Subgroup.IsArithmetic.is_commensurable.conj _).trans
     (isArithmetic_conj_SL2Z g).is_commensurable⟩
 
+@[deprecated (since := "2025-09-17")] alias IsArithmetic.conj := _root_.Subgroup.IsArithmetic.conj
+
 /-- If `Γ` is a congruence subgroup, then so is `g⁻¹ Γ g ∩ SL(2, ℤ)` for any `g ∈ GL(2, ℚ)`. -/
 lemma IsCongruenceSubgroup.conjGL {Γ : Subgroup SL(2, ℤ)} (hΓ : IsCongruenceSubgroup Γ)
     (g : GL (Fin 2) ℚ) :

--- a/Mathlib/NumberTheory/ModularForms/Cusps.lean
+++ b/Mathlib/NumberTheory/ModularForms/Cusps.lean
@@ -71,7 +71,7 @@ lemma isCusp_iff_of_relIndex_ne_zero {𝒢 𝒢' : Subgroup (GL (Fin 2) ℝ)}
 @[deprecated (since := "2025-09-13")]
 alias isCusp_iff_of_relindex_ne_zero := isCusp_iff_of_relIndex_ne_zero
 
-lemma Commensurable.isCusp_iff {𝒢 𝒢' : Subgroup (GL (Fin 2) ℝ)}
+lemma Subgroup.Commensurable.isCusp_iff {𝒢 𝒢' : Subgroup (GL (Fin 2) ℝ)}
     (h𝒢 : Commensurable 𝒢 𝒢') {c : OnePoint ℝ} :
     IsCusp c 𝒢 ↔ IsCusp c 𝒢' := by
   rw [← isCusp_iff_of_relIndex_ne_zero inf_le_left, isCusp_iff_of_relIndex_ne_zero inf_le_right]

--- a/Mathlib/NumberTheory/ModularForms/Cusps.lean
+++ b/Mathlib/NumberTheory/ModularForms/Cusps.lean
@@ -78,6 +78,9 @@ lemma Subgroup.Commensurable.isCusp_iff {𝒢 𝒢' : Subgroup (GL (Fin 2) ℝ)}
   · simpa [Subgroup.inf_relIndex_right] using h𝒢.1
   · simpa [Subgroup.inf_relIndex_left] using h𝒢.2
 
+@[deprecated (since := "2025-09-17")]
+alias Commensurable.isCusp_iff := Subgroup.Commensurable.isCusp_iff
+
 /-- The cusps of `SL(2, ℤ)` are precisely the elements of `ℙ¹(ℚ)`. -/
 lemma isCusp_SL2Z_iff {c : OnePoint ℝ} : IsCusp c 𝒮ℒ ↔ c ∈ Set.range (OnePoint.map Rat.cast) := by
   constructor


### PR DESCRIPTION
Move `Commensurable` into the `Subgroup` namespace, and add `to_additive` flags (hence auto-creating a parallel def `AddSubgroup.commensurable`)

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include at least one commit authored by each
co-author among the commits in the pull request. If necessary, you may 
create empty commits to indicate co-authorship, using commands like so:

git commit --author="Author Name <author@email.com>" --allow-empty -m "add Author Name as coauthor"

When merging, all the commits will be squashed into a single commit listing all co-authors.

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
