### PR TITLE
feat: add simp lemmas for Nat.card and ENat.card of sets

### DIFF
--- a/Mathlib/Data/Set/Card.lean
+++ b/Mathlib/Data/Set/Card.lean
@@ -79,6 +79,8 @@ theorem encard_eq_coe_toFinset_card (s : Set α) [Fintype s] : encard s = s.toFi
 
 @[simp] theorem toENat_cardinalMk (s : Set α) : (Cardinal.mk s).toENat = s.encard := rfl
 
+@[simp] lemma _root_.ENat.card_set_eq_encard {α : Type*} (s : Set α) : ENat.card s = s.encard := rfl
+
 theorem toENat_cardinalMk_subtype (P : α → Prop) :
     (Cardinal.mk {x // P x}).toENat = {x | P x}.encard :=
   rfl
@@ -552,6 +554,8 @@ lemma ncard_le_encard (s : Set α) : s.ncard ≤ s.encard := ENat.coe_toNat_le_s
 @[simp] theorem _root_.Nat.card_coe_set_eq (s : Set α) : Nat.card s = s.ncard := rfl
 
 @[deprecated (since := "2025-07-05")] alias Nat.card_coe_set_eq := _root_.Nat.card_coe_set_eq
+
+@[simp] lemma _root_.Nat.card_set_eq_ncard {α : Type*} (s : Set α) : Nat.card s = s.ncard := rfl
 
 theorem ncard_eq_toFinset_card (s : Set α) (hs : s.Finite := by toFinite_tac) :
     s.ncard = hs.toFinset.card := by

--- a/Mathlib/Data/Set/Card.lean
+++ b/Mathlib/Data/Set/Card.lean
@@ -118,7 +118,8 @@ protected alias ⟨_, Nonempty.encard_pos⟩ := encard_pos
 
 theorem encard_union_eq (h : Disjoint s t) : (s ∪ t).encard = s.encard + t.encard := by
   classical
-  simp [encard, ENat.card_congr (Equiv.Set.union h)]
+  unfold encard
+  simp [ENat.card_congr (Equiv.Set.union h), ENat.card_sum]
 
 theorem encard_ne_add_one (a : α) :
     ({x | x ≠ a}).encard + 1 = ENat.card α := by
@@ -168,7 +169,8 @@ theorem encard_le_coe_iff {k : ℕ} : s.encard ≤ k ↔ s.Finite ∧ ∃ (n₀ 
 
 @[simp]
 theorem encard_prod : (s ×ˢ t).encard = s.encard * t.encard := by
-  simp [Set.encard, ENat.card_congr (Equiv.Set.prod ..)]
+  unfold encard
+  simp [ENat.card_congr (Equiv.Set.prod ..)]
 
 section Lattice
 


### PR DESCRIPTION
## Summary

Adds two simp lemmas from the FLT project:
- `Nat.card_set_eq_ncard`: shows that `Nat.card s = s.ncard` for a set `s`
- `ENat.card_set_eq_encard`: shows that `ENat.card s = s.encard` for a set `s`

These lemmas provide convenient simp rules for converting between the generic `Nat.card`/`ENat.card` functions applied to sets and the specialized `ncard`/`encard` functions.

## Source

This PR was prepared by Claude from the FLT project file:
`FLT/Mathlib/Data/Set/Card.lean`

Link to source: https://github.com/ImperialCollegeLondon/FLT/blob/main/FLT/Mathlib/Data/Set/Card.lean

🤖 Generated with [Claude Code](https://claude.ai/code)