### PR TITLE
[Merged by Bors] - feat: representation of log⁺ as a circle average

### DIFF
--- a/Mathlib/Analysis/SpecialFunctions/Integrals/PosLogEqCircleAverage.lean
+++ b/Mathlib/Analysis/SpecialFunctions/Integrals/PosLogEqCircleAverage.lean
@@ -12,7 +12,7 @@ import Mathlib.MeasureTheory.Integral.CircleAverage
 /-!
 # Representation of `log⁺` as a Circle Average
 
-If `a` is any complex number, `circleAverage_log_norm_sub_const_eq_posLog` represents of `log⁺` as
+If `a` is any complex number, `circleAverage_log_norm_sub_const_eq_posLog` represents `log⁺ a` as
 the circle average of `log ‖· - a‖` over the unit circle.
 -/
 

--- a/Mathlib/Analysis/SpecialFunctions/Integrals/PosLogEqCircleAverage.lean
+++ b/Mathlib/Analysis/SpecialFunctions/Integrals/PosLogEqCircleAverage.lean
@@ -45,18 +45,10 @@ theorem circleAverage_log_norm_sub_const₀ (h : ‖a‖ < 1) : circleAverage (l
     intro z hz
     simp_all only [abs_one, mem_sphere_iff_norm, sub_zero]
     congr 1
+    have : z ≠ 0 := fun h ↦ by simp [h] at hz
     calc ‖z - a‖
-    _ = 1 * ‖z - a‖ :=
-      (one_mul ‖z - a‖).symm
-    _ = ‖z⁻¹‖ * ‖z - a‖ := by
-      simp_all
-    _ = ‖z⁻¹ * (z - a)‖ :=
-      (Complex.norm_mul z⁻¹ (z - a)).symm
-    _ = ‖z⁻¹ * z - z⁻¹ * a‖ := by
-      rw [mul_sub]
-    _ = ‖1 - z⁻¹ * a‖ := by
-      rw [inv_mul_cancel₀]
-      aesop
+    _ = ‖z⁻¹ * (z - a)‖ := by simp [hz]
+    _ = ‖1 - z⁻¹ * a‖ := by field_simp
   _ = 0 := by
     rw [circleAverage_zero_one_congr_inv (f := fun x ↦ log ‖1 - x * a‖),
       HarmonicOnNhd.circleAverage_eq, zero_mul, sub_zero,

--- a/Mathlib/Analysis/SpecialFunctions/Integrals/PosLogEqCircleAverage.lean
+++ b/Mathlib/Analysis/SpecialFunctions/Integrals/PosLogEqCircleAverage.lean
@@ -112,7 +112,7 @@ If `a : ℂ` has norm one, then the circle average `circleAverage (log ‖· - a
 theorem circleAverage_log_norm_sub_const₁ (h : ‖a‖ = 1) :
     circleAverage (log ‖· - a‖) 0 1 = 0 := by
   -- Observing that the problem is rotation invariant, we rotate by an angle of `ζ = - arg a` and
-  -- reduce the problem to the case where `a = 1`. The integral can then be evalutated by a direct
+  -- reduce the problem to the case where `a = 1`. The integral can then be evaluated by a direct
   -- computation.
   simp only [circleAverage, mul_inv_rev, smul_eq_mul, mul_eq_zero, inv_eq_zero, OfNat.ofNat_ne_zero,
     or_false]

--- a/Mathlib/Analysis/SpecialFunctions/Integrals/PosLogEqCircleAverage.lean
+++ b/Mathlib/Analysis/SpecialFunctions/Integrals/PosLogEqCircleAverage.lean
@@ -252,8 +252,7 @@ Trivial corollary of
 with center `c` and radius `R`, then the circle average
 `circleAverage (log ‖· - u‖) c R` equals `log R`.
 -/
-@[simp]
-lemma circleAverage_logAbs_affine (hu : a ∈ closedBall c |R|) :
+lemma circleAverage_log_norm_sub_const_of_mem_closedBall (hu : a ∈ closedBall c |R|) :
     circleAverage (log ‖· - a‖) c R = log R := by
   by_cases hR : R = 0
   · simp_all

--- a/Mathlib/Analysis/SpecialFunctions/Integrals/PosLogEqCircleAverage.lean
+++ b/Mathlib/Analysis/SpecialFunctions/Integrals/PosLogEqCircleAverage.lean
@@ -12,8 +12,8 @@ import Mathlib.MeasureTheory.Integral.CircleAverage
 /-!
 # Representation of `log⁺` as a Circle Average
 
-If `a` is any complex number, the circle average of `log ‖· - a‖` over the unit circle equals the
-positive part of the logarithm, `circleAverage (log ‖· - a‖) 0 1 = log⁺ ‖a‖`.
+If `a` is any complex number, `circleAverage_log_norm_sub_const_eq_posLog` represents of `log⁺` as
+the circle average of `log ‖· - a‖` over the unit circle.
 -/
 
 open Filter Interval intervalIntegral MeasureTheory Metric Real

--- a/Mathlib/Analysis/SpecialFunctions/Integrals/PosLogEqCircleAverage.lean
+++ b/Mathlib/Analysis/SpecialFunctions/Integrals/PosLogEqCircleAverage.lean
@@ -3,6 +3,8 @@ Copyright (c) 2025 Stefan Kebekus. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Stefan Kebekus
 -/
+import Mathlib.Analysis.Complex.Harmonic.MeanValue
+import Mathlib.Analysis.InnerProductSpace.Harmonic.Constructions
 import Mathlib.Analysis.SpecialFunctions.Integrals.Basic
 import Mathlib.Analysis.SpecialFunctions.Integrals.LogTrigonometric
 import Mathlib.MeasureTheory.Integral.CircleAverage
@@ -10,23 +12,13 @@ import Mathlib.MeasureTheory.Integral.CircleAverage
 /-!
 # Representation of `log⁺` as a Circle Average
 
-If `a` is any complex number of norm one, then `log ‖· - a‖` is circle integrable over every circle
-in the complex plane, and the circle average `circleAverage (log ‖· - a‖) 0 1` vanishes.
-
-- Integrability is recalled in `circleIntegrability_log_norm_id_sub_const`, as a consequence of the
-  general fact that functions of the form `log ‖meromorphic‖` are circle integrable.
-
-- The value of the integral is computed in `circleAverage_log_norm_id_sub_const₁`.
-
-TODO: As soon as the mean value theorem for harmonic functions becomes available, extend this result
-to arbitrary complex numbers `a`, showing that the circle average equals the positive part of the
-logarithm, `circleAverage (log ‖· - a‖) 0 1 = = log⁺ ‖a‖`. This result, in turn, is a major
-ingredient in the proof of Jensen's formula in complex analysis.
+If `a` is any complex number, the circle average of `log ‖· - a‖` over the unit circle equals the
+positive part of the logarithm, `circleAverage (log ‖· - a‖) 0 1 = log⁺ ‖a‖`.
 -/
 
-open Filter Interval intervalIntegral MeasureTheory Real
+open Filter Interval intervalIntegral MeasureTheory Metric Real
 
-variable {a : ℂ}
+variable {a c : ℂ} {R : ℝ}
 
 /-!
 ## Circle Integrability
@@ -35,9 +27,52 @@ variable {a : ℂ}
 /--
 If `a` is any complex number, the function `(log ‖· - a‖)` is circle integrable over every circle.
 -/
-lemma circleIntegrable_log_norm_sub_const {c : ℂ} (r : ℝ) :
-    CircleIntegrable (log ‖· - a‖) c r :=
+lemma circleIntegrable_log_norm_sub_const (r : ℝ) : CircleIntegrable (log ‖· - a‖) c r :=
   circleIntegrable_log_norm_meromorphicOn (fun z hz ↦ by fun_prop)
+
+/-!
+## Computing `circleAverage (log ‖· - a‖) 0 1` in case where `‖a‖ < 1`.
+-/
+
+/--
+If `a : ℂ` has norm smaller than one, then `circleAverage (log ‖· - a‖) 0 1` vanishes.
+-/
+@[simp]
+theorem circleAverage_log_norm_sub_const₀ (h : ‖a‖ < 1) : circleAverage (log ‖· - a‖) 0 1 = 0 := by
+  calc circleAverage (log ‖· - a‖) 0 1
+  _ = circleAverage (log ‖1 - ·⁻¹ * a‖) 0 1 := by
+    apply circleAverage_congr_sphere
+    intro z hz
+    simp_all only [abs_one, mem_sphere_iff_norm, sub_zero]
+    congr 1
+    calc ‖z - a‖
+    _ = 1 * ‖z - a‖ :=
+      (one_mul ‖z - a‖).symm
+    _ = ‖z⁻¹‖ * ‖z - a‖ := by
+      simp_all
+    _ = ‖z⁻¹ * (z - a)‖ :=
+      (Complex.norm_mul z⁻¹ (z - a)).symm
+    _ = ‖z⁻¹ * z - z⁻¹ * a‖ := by
+      rw [mul_sub]
+    _ = ‖1 - z⁻¹ * a‖ := by
+      rw [inv_mul_cancel₀]
+      aesop
+  _ = 0 := by
+    rw [circleAverage_zero_one_congr_inv (f := fun x ↦ log ‖1 - x * a‖),
+      HarmonicOnNhd.circleAverage_eq, zero_mul, sub_zero,
+      CStarRing.norm_of_mem_unitary (unitary ℂ).one_mem, log_one]
+    intro x hx
+    have : ‖x * a‖ < 1 := by
+      calc ‖x * a‖
+      _ = ‖x‖ * ‖a‖ := by simp
+      _ ≤ ‖a‖ := by
+        by_cases ‖a‖ = 0
+        <;> aesop
+      _ < 1 := h
+    apply AnalyticAt.harmonicAt_log_norm (by fun_prop)
+    rw [sub_ne_zero]
+    by_contra! hCon
+    rwa [← hCon, CStarRing.norm_of_mem_unitary (unitary ℂ).one_mem, lt_self_iff_false] at this
 
 /-!
 ## Computing `circleAverage (log ‖· - a‖) 0 1` in case where `‖a‖ = 1`.
@@ -78,7 +113,7 @@ If `a : ℂ` has norm one, then the circle average `circleAverage (log ‖· - a
 theorem circleAverage_log_norm_sub_const₁ (h : ‖a‖ = 1) :
     circleAverage (log ‖· - a‖) 0 1 = 0 := by
   -- Observing that the problem is rotation invariant, we rotate by an angle of `ζ = - arg a` and
-  -- reduce the problem to the case where `a = 1`. The integral can then be evaluated by a direct
+  -- reduce the problem to the case where `a = 1`. The integral can then be evalutated by a direct
   -- computation.
   simp only [circleAverage, mul_inv_rev, smul_eq_mul, mul_eq_zero, inv_eq_zero, OfNat.ofNat_ne_zero,
     or_false]
@@ -120,3 +155,110 @@ theorem circleAverage_log_norm_sub_const₁ (h : ‖a‖ = 1) :
       nth_rw 1 [← mul_one 4, ← sin_sq_add_cos_sq (x / 2)]
       ring
   _ = 0 := circleAverage_log_norm_sub_const₁_integral
+
+/-!
+## Computing `circleAverage (log ‖· - a‖) 0 1` in case where `1 < ‖a‖`.
+-/
+
+/--
+If `a : ℂ` has norm greater than one, then `circleAverage (log ‖· - a‖) 0 1` equals `log ‖a‖`.
+-/
+@[simp]
+theorem circleAverage_log_norm_sub_const₂ (h : 1 < ‖a‖) :
+    circleAverage (log ‖· - a‖) 0 1 = log ‖a‖ := by
+  rw [HarmonicOnNhd.circleAverage_eq, zero_sub, norm_neg]
+  intro x hx
+  apply AnalyticAt.harmonicAt_log_norm (by fun_prop)
+  rw [sub_ne_zero]
+  by_contra!
+  simp_all only [abs_one, Metric.mem_closedBall, dist_zero_right]
+  linarith
+
+/-!
+## Presentation of `log⁺` in Terms of Circle Averages
+-/
+
+/--
+The `circleAverage (log ‖· - a‖) 0 1` equals `log⁺ ‖a‖`.
+-/
+@[simp]
+theorem circleAverage_log_norm_sub_const_eq_posLog :
+    circleAverage (log ‖· - a‖) 0 1 = log⁺ ‖a‖ := by
+  rcases lt_trichotomy 1 ‖a‖ with h | h | h
+  · rw [circleAverage_log_norm_sub_const₂ h]
+    apply (posLog_eq_log _).symm
+    simp_all [le_of_lt h]
+  · rw [eq_comm, circleAverage_log_norm_sub_const₁ h.symm, posLog_eq_zero_iff]
+    simp_all
+  · rw [eq_comm, circleAverage_log_norm_sub_const₀ h, posLog_eq_zero_iff]
+    simp_all [le_of_lt h]
+
+/--
+The `circleAverage (log ‖· + a‖) 0 1` equals `log⁺ ‖a‖`.
+-/
+@[simp]
+theorem circleAverage_log_norm_add_const_eq_posLog :
+    circleAverage (log ‖· + a‖) 0 1 = log⁺ ‖a‖ := by
+  have : (log ‖· + a‖) = (log ‖· - -a‖) := by simp
+  simp [this]
+
+/--
+Generalization of `circleAverage_log_norm_sub_const_eq_posLog`: The
+`circleAverage (log ‖· - a‖) c R` equals `log R + log⁺ (|R|⁻¹ * ‖c - a‖)`.
+-/
+theorem circleAverage_log_norm_sub_const_eq_log_radius_add_posLog (hR : R ≠ 0) :
+    circleAverage (log ‖· - a‖) c R = log R + log⁺ (R⁻¹ * ‖c - a‖) := by
+  calc circleAverage (log ‖· - a‖) c R
+  _ = circleAverage (fun z ↦ log ‖R * (z + R⁻¹ * (c - a))‖) 0 1 := by
+    rw [circleAverage_eq_circleAverage_zero_one]
+    congr
+    ext z
+    congr
+    rw [Complex.ofReal_inv R]
+    field_simp [Complex.ofReal_ne_zero.mpr hR]
+    ring
+  _ = circleAverage (fun z ↦ log ‖R‖ + log ‖z + R⁻¹ * (c - a)‖) 0 1 := by
+    apply circleAverage_congr_codiscreteWithin _ (zero_ne_one' ℝ).symm
+    have : {z | ‖z + ↑R⁻¹ * (c - a)‖ ≠ 0} ∈ codiscreteWithin (Metric.sphere (0 : ℂ) |1|) := by
+      apply codiscreteWithin_iff_locallyFiniteComplementWithin.2
+      intro z hz
+      use Set.univ
+      simp only [univ_mem, abs_one, Complex.ofReal_inv, ne_eq, norm_eq_zero, Set.univ_inter,
+        true_and]
+      apply Set.Subsingleton.finite
+      intro z₁ hz₁ z₂ hz₂
+      simp_all only [ne_eq, abs_one, mem_sphere_iff_norm, sub_zero, Set.mem_diff, Set.mem_setOf_eq,
+        Decidable.not_not]
+      rw [add_eq_zero_iff_eq_neg.1 hz₁.2, add_eq_zero_iff_eq_neg.1 hz₂.2]
+    filter_upwards [this] with z hz
+    rw [norm_mul, log_mul (norm_ne_zero_iff.2 (Complex.ofReal_ne_zero.mpr hR)) hz]
+    simp
+  _ = log R + log⁺ (|R|⁻¹ * ‖c - a‖) := by
+    have : (fun z ↦ log ‖R‖ + log ‖z + ↑R⁻¹ * (c - a)‖) =
+        (fun z ↦ log ‖R‖) + (fun z ↦ log ‖z + ↑R⁻¹ * (c - a)‖) := by
+      rfl
+    rw [this, circleAverage_add (circleIntegrable_const (log ‖R‖) 0 1)
+      (circleIntegrable_log_norm_meromorphicOn (fun _ _ ↦ by fun_prop)), circleAverage_const]
+    simp
+  _ = log R + log⁺ (R⁻¹ * ‖c - a‖) := by
+    congr 1
+    rcases lt_trichotomy 0 R with h | h | h
+    · rw [abs_of_pos h]
+    · tauto
+    · simp [abs_of_neg h]
+
+/--
+Trivial corollary of
+`circleAverage_log_norm_sub_const_eq_log_radius_add_posLog`: If `u : ℂ` lies within the closed ball
+with center `c` and radius `R`, then the circle average
+`circleAverage (log ‖· - u‖) c R` equals `log R`.
+-/
+@[simp]
+lemma circleAverage_logAbs_affine (hu : a ∈ closedBall c |R|) :
+    circleAverage (log ‖· - a‖) c R = log R := by
+  by_cases hR : R = 0
+  · simp_all
+  rw [circleAverage_log_norm_sub_const_eq_log_radius_add_posLog hR, add_eq_left,
+    posLog_eq_zero_iff, abs_mul, abs_inv, abs_of_nonneg (norm_nonneg (c - a))]
+  rw [mem_closedBall, dist_eq_norm'] at hu
+  apply inv_mul_le_one_of_le₀ hu (abs_nonneg R)

--- a/Mathlib/Analysis/SpecialFunctions/Integrals/PosLogEqCircleAverage.lean
+++ b/Mathlib/Analysis/SpecialFunctions/Integrals/PosLogEqCircleAverage.lean
@@ -109,7 +109,6 @@ private lemma circleAverage_log_norm_sub_const₁_integral :
 /--
 If `a : ℂ` has norm one, then the circle average `circleAverage (log ‖· - a‖) 0 1` vanishes.
 -/
-@[simp]
 theorem circleAverage_log_norm_sub_const₁ (h : ‖a‖ = 1) :
     circleAverage (log ‖· - a‖) 0 1 = 0 := by
   -- Observing that the problem is rotation invariant, we rotate by an angle of `ζ = - arg a` and


### PR DESCRIPTION
If `a` is any complex number, show that the circle average of `log ‖· - a‖` over the unit circle equals the positive part of the logarithm, `log⁺ ‖a‖`.

This material is used in [Project VD](https://github.com/kebekus/ProjectVD), which aims to formalize Value Distribution Theory for meromorphic functions on the complex plane. The formula established here is a key ingredient in Jensen's formula of complex analysis.

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include at least one commit authored by each
co-author among the commits in the pull request. If necessary, you may 
create empty commits to indicate co-authorship, using commands like so:

git commit --author="Author Name <author@email.com>" --allow-empty -m "add Author Name as coauthor"

When merging, all the commits will be squashed into a single commit listing all co-authors.

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
