### PR TITLE
[Merged by Bors] - feat(Topology/KrullDimension): add subspace dimension inequality

### DIFF
--- a/Mathlib/Topology/KrullDimension.lean
+++ b/Mathlib/Topology/KrullDimension.lean
@@ -44,7 +44,7 @@ to the Krull dimension of `Y`.
 -/
 theorem IsClosedEmbedding.topologicalKrullDim_le (f : X → Y) (hf : IsClosedEmbedding f) :
     topologicalKrullDim X ≤ topologicalKrullDim Y :=
-  krullDim_le_of_strictMono _ (IrreducibleCloseds.map_strictMono hf)
+  krullDim_le_of_strictMono _ (map_strictMono_of_embedding hf.toIsEmbedding)
 
 /-- The topological Krull dimension is invariant under homeomorphisms -/
 theorem IsHomeomorph.topologicalKrullDim_eq (f : X → Y) (h : IsHomeomorph f) :
@@ -63,7 +63,7 @@ theorem IsHomeomorph.topologicalKrullDim_eq (f : X → Y) (h : IsHomeomorph f) :
 This generalizes `IsClosedEmbedding.topologicalKrullDim_le`. -/
 theorem IsEmbedding.topologicalKrullDim_le {f : Y → X} (hf : IsEmbedding f) :
     topologicalKrullDim Y ≤ topologicalKrullDim X :=
-  krullDim_le_of_strictMono _ (IrreducibleCloseds.mapOfEmbedding_strictMono hf)
+  krullDim_le_of_strictMono _ (map_strictMono_of_embedding hf)
 
 /-- The topological Krull dimension of any subspace is at most the dimension of the
 ambient space. -/

--- a/Mathlib/Topology/KrullDimension.lean
+++ b/Mathlib/Topology/KrullDimension.lean
@@ -39,8 +39,7 @@ variable {X Y : Type*} [TopologicalSpace X] [TopologicalSpace Y]
 /-!
 ### Main dimension theorems -/
 
-/-- If `f : Y → X` is an embedding, then `dim(Y) ≤ dim(X)`.
-This generalizes `IsClosedEmbedding.topologicalKrullDim_le`. -/
+/-- If `f : Y → X` is inducing, then `dim(Y) ≤ dim(X)`. -/
 theorem IsInducing.topologicalKrullDim_le {f : Y → X} (hf : IsInducing f) :
     topologicalKrullDim Y ≤ topologicalKrullDim X :=
   krullDim_le_of_strictMono _ (map_strictMono_of_isInducing hf)

--- a/Mathlib/Topology/KrullDimension.lean
+++ b/Mathlib/Topology/KrullDimension.lean
@@ -36,35 +36,29 @@ noncomputable def topologicalKrullDim (T : Type*) [TopologicalSpace T] : WithBot
 
 variable {X Y : Type*} [TopologicalSpace X] [TopologicalSpace Y]
 
-/--
-If `f : X → Y` is a closed embedding, then the Krull dimension of `X` is less than or equal
-to the Krull dimension of `Y`.
--/
-theorem IsClosedEmbedding.topologicalKrullDim_le (f : X → Y) (hf : IsClosedEmbedding f) :
-    topologicalKrullDim X ≤ topologicalKrullDim Y :=
-  krullDim_le_of_strictMono _ (map_strictMono_of_isEmbedding hf.toIsEmbedding)
-
-/-- The topological Krull dimension is invariant under homeomorphisms -/
-theorem IsHomeomorph.topologicalKrullDim_eq (f : X → Y) (h : IsHomeomorph f) :
-    topologicalKrullDim X = topologicalKrullDim Y :=
-  have fwd : topologicalKrullDim X ≤ topologicalKrullDim Y :=
-    IsClosedEmbedding.topologicalKrullDim_le f h.isClosedEmbedding
-  have bwd : topologicalKrullDim Y ≤ topologicalKrullDim X :=
-    IsClosedEmbedding.topologicalKrullDim_le (h.homeomorph f).symm
-    (h.homeomorph f).symm.isClosedEmbedding
-  le_antisymm fwd bwd
-
 /-!
 ### Main dimension theorems -/
 
 /-- If `f : Y → X` is an embedding, then `dim(Y) ≤ dim(X)`.
 This generalizes `IsClosedEmbedding.topologicalKrullDim_le`. -/
-theorem IsEmbedding.topologicalKrullDim_le {f : Y → X} (hf : IsEmbedding f) :
+theorem IsInducing.topologicalKrullDim_le {f : Y → X} (hf : IsInducing f) :
     topologicalKrullDim Y ≤ topologicalKrullDim X :=
-  krullDim_le_of_strictMono _ (map_strictMono_of_isEmbedding hf)
+  krullDim_le_of_strictMono _ (map_strictMono_of_isInducing hf)
+
+@[deprecated (since := "2025-10-19")]
+alias IsClosedEmbedding.topologicalKrullDim_le := IsInducing.topologicalKrullDim_le
+
+/-- The topological Krull dimension is invariant under homeomorphisms -/
+theorem IsHomeomorph.topologicalKrullDim_eq (f : X → Y) (h : IsHomeomorph f) :
+    topologicalKrullDim X = topologicalKrullDim Y :=
+  have fwd : topologicalKrullDim X ≤ topologicalKrullDim Y :=
+    IsInducing.topologicalKrullDim_le h.isClosedEmbedding.toIsInducing
+  have bwd : topologicalKrullDim Y ≤ topologicalKrullDim X :=
+    IsInducing.topologicalKrullDim_le (h.homeomorph f).symm.isClosedEmbedding.toIsInducing
+  le_antisymm fwd bwd
 
 /-- The topological Krull dimension of any subspace is at most the dimension of the
 ambient space. -/
 theorem topologicalKrullDim_subspace_le (X : Type*) [TopologicalSpace X] (Y : Set X) :
     topologicalKrullDim Y ≤ topologicalKrullDim X :=
-  IsEmbedding.topologicalKrullDim_le IsEmbedding.subtypeVal
+  IsInducing.topologicalKrullDim_le IsInducing.subtypeVal

--- a/Mathlib/Topology/KrullDimension.lean
+++ b/Mathlib/Topology/KrullDimension.lean
@@ -17,9 +17,7 @@ the length of longest series of closed irreducible subsets ordered by inclusion.
 
 ## Main results
 
-- `topKrullDim_subspace_le`: For any subspace Y ⊆ X, we have dim(Y) ≤ dim(X)
-- Basic properties of maps between irreducible closed sets
-- Partial order structure on irreducible closed sets
+- `topologicalKrullDim_subspace_le`: For any subspace Y ⊆ X, we have dim(Y) ≤ dim(X)
 
 ## Implementation notes
 

--- a/Mathlib/Topology/KrullDimension.lean
+++ b/Mathlib/Topology/KrullDimension.lean
@@ -44,7 +44,7 @@ to the Krull dimension of `Y`.
 -/
 theorem IsClosedEmbedding.topologicalKrullDim_le (f : X → Y) (hf : IsClosedEmbedding f) :
     topologicalKrullDim X ≤ topologicalKrullDim Y :=
-  krullDim_le_of_strictMono _ (map_strictMono_of_embedding hf.toIsEmbedding)
+  krullDim_le_of_strictMono _ (map_strictMono_of_isEmbedding hf.toIsEmbedding)
 
 /-- The topological Krull dimension is invariant under homeomorphisms -/
 theorem IsHomeomorph.topologicalKrullDim_eq (f : X → Y) (h : IsHomeomorph f) :
@@ -63,7 +63,7 @@ theorem IsHomeomorph.topologicalKrullDim_eq (f : X → Y) (h : IsHomeomorph f) :
 This generalizes `IsClosedEmbedding.topologicalKrullDim_le`. -/
 theorem IsEmbedding.topologicalKrullDim_le {f : Y → X} (hf : IsEmbedding f) :
     topologicalKrullDim Y ≤ topologicalKrullDim X :=
-  krullDim_le_of_strictMono _ (map_strictMono_of_embedding hf)
+  krullDim_le_of_strictMono _ (map_strictMono_of_isEmbedding hf)
 
 /-- The topological Krull dimension of any subspace is at most the dimension of the
 ambient space. -/

--- a/Mathlib/Topology/KrullDimension.lean
+++ b/Mathlib/Topology/KrullDimension.lean
@@ -56,12 +56,6 @@ theorem IsHomeomorph.topologicalKrullDim_eq (f : X → Y) (h : IsHomeomorph f) :
     (h.homeomorph f).symm.isClosedEmbedding
   le_antisymm fwd bwd
 
-
-
-
-
-
-
 /-!
 ### Main dimension theorems -/
 

--- a/Mathlib/Topology/KrullDimension.lean
+++ b/Mathlib/Topology/KrullDimension.lean
@@ -1,9 +1,10 @@
 /-
 Copyright (c) 2024 Jujian Zhang. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
-Authors: Jujian Zhang, Fangming Li
+Authors: Jujian Zhang, Fangming Li, Alessandro D'Angelo
 -/
 import Mathlib.Order.KrullDimension
+import Mathlib.Topology.Irreducible
 import Mathlib.Topology.Homeomorph.Lemmas
 import Mathlib.Topology.Sets.Closeds
 
@@ -13,9 +14,20 @@ import Mathlib.Topology.Sets.Closeds
 The Krull dimension of a topological space is the order-theoretic Krull dimension applied to the
 collection of all its subsets that are closed and irreducible. Unfolding this definition, it is
 the length of longest series of closed irreducible subsets ordered by inclusion.
+
+## Main results
+
+- `topKrullDim_subspace_le`: For any subspace Y ⊆ X, we have dim(Y) ≤ dim(X)
+- Basic properties of maps between irreducible closed sets
+- Partial order structure on irreducible closed sets
+
+## Implementation notes
+
+The proofs use order-preserving maps between posets of irreducible closed sets to establish
+dimension inequalities.
 -/
 
-open Order TopologicalSpace Topology
+open Set Function Order TopologicalSpace Topology
 
 /--
 The Krull dimension of a topological space is the supremum of lengths of chains of
@@ -62,3 +74,123 @@ theorem IsHomeomorph.topologicalKrullDim_eq (f : X → Y) (h : IsHomeomorph f) :
     IsClosedEmbedding.topologicalKrullDim_le (h.homeomorph f).symm
     (h.homeomorph f).symm.isClosedEmbedding
   le_antisymm fwd bwd
+
+/-! ### Maps between irreducible closed sets -/
+
+/-- The canonical map from irreducible closed sets of a subspace `Y` to irreducible
+closed sets of the ambient space `X`, defined by taking the closure of the image
+under the inclusion map. This map is crucial for comparing Krull dimensions. -/
+def mapIrreducibleClosed (Y : Set X) (c : IrreducibleCloseds Y) : IrreducibleCloseds X where
+  carrier := closure (Subtype.val '' c.carrier)
+  is_irreducible' := c.is_irreducible'.image Subtype.val
+    (continuous_subtype_val.continuousOn) |>.closure
+  is_closed' := isClosed_closure
+
+/-- The map `mapIrreducibleClosed` is injective, meaning distinct irreducible
+closed sets in a subspace map to distinct irreducible closed sets in the ambient space.
+This ensures that the dimension-preserving properties hold. -/
+lemma mapIrreducibleClosed_injective (Y : Set X) :
+    Function.Injective (mapIrreducibleClosed Y) := by
+  intro A B h_images_eq
+  ext x
+  have h_closures_eq : closure (Subtype.val '' A.carrier) =
+      closure (Subtype.val '' B.carrier) :=
+    congrArg IrreducibleCloseds.carrier h_images_eq
+  constructor
+  · -- Forward direction: x ∈ A → x ∈ B
+    intro hx_in_A
+    change x ∈ B.carrier
+    rw [← B.is_closed'.closure_eq]
+    -- Use the mathlib lemma for embeddings
+    rw [Topology.IsEmbedding.subtypeVal.closure_eq_preimage_closure_image]
+    rw [← h_closures_eq]
+    simp_rw [mem_preimage]
+    apply subset_closure
+    exact mem_image_of_mem Subtype.val hx_in_A
+  · -- Backward direction: x ∈ B → x ∈ A
+    intro hx_in_B
+    change x ∈ A.carrier
+    rw [← A.is_closed'.closure_eq]
+    -- Use the mathlib lemma for embeddings
+    rw [Topology.IsEmbedding.subtypeVal.closure_eq_preimage_closure_image]
+    rw [h_closures_eq]
+    simp_rw [mem_preimage]
+    apply subset_closure
+    exact mem_image_of_mem Subtype.val hx_in_B
+
+
+/-! ### Partial order structure on irreducible closed sets -/
+
+instance : PartialOrder (IrreducibleCloseds X) where
+  le s t := s.carrier ⊆ t.carrier
+  le_refl s := Set.Subset.refl _
+  le_trans s t u hst htu := Set.Subset.trans hst htu
+  le_antisymm s t hst hts := by
+    apply IrreducibleCloseds.ext
+    exact Set.Subset.antisymm hst hts
+
+/-- The partial order on `IrreducibleCloseds X` is given by subset inclusion
+of the underlying sets. -/
+lemma IrreducibleCloseds.le_iff_subset {s t : IrreducibleCloseds X} :
+    s ≤ t ↔ s.carrier ⊆ t.carrier := by rfl
+
+/-- The strict partial order on `IrreducibleCloseds X` corresponds to strict
+subset inclusion of the underlying sets. -/
+lemma IrreducibleCloseds.lt_iff_subset {s t : IrreducibleCloseds X} :
+    s < t ↔ s.carrier ⊂ t.carrier := by
+  constructor
+  · intro h_lt
+    have h_le := le_of_lt h_lt
+    have h_ne := ne_of_lt h_lt
+    rw [ssubset_iff_subset_ne]
+    constructor
+    · rw [← IrreducibleCloseds.le_iff_subset]
+      exact h_le
+    · apply mt IrreducibleCloseds.ext
+      exact h_ne
+  · intro h_ssubset
+    rw [lt_iff_le_and_ne]
+    rcases h_ssubset with ⟨h_subset, h_ne_carrier⟩
+    constructor
+    · rw [IrreducibleCloseds.le_iff_subset]
+      exact h_subset
+    · intro h_s_eq_t
+      apply h_ne_carrier
+      rw [h_s_eq_t]
+
+/-- The canonical map `mapIrreducibleClosed` is strictly monotone, preserving
+the order structure when comparing irreducible closed sets between subspaces
+and ambient spaces. This is essential for the dimension inequality theorem. -/
+lemma mapIrreducibleClosed_strictMono (Y : Set X) :
+    StrictMono (mapIrreducibleClosed Y) := by
+  intro A B h_less_AB
+  constructor
+  · -- Part 1: Prove map A ≤ map B
+    apply closure_mono
+    apply image_mono
+    exact le_of_lt h_less_AB
+  · -- Part 2: Prove ¬(map B ≤ map A)
+    intro h_contra_le
+    have h_forward_subset : (mapIrreducibleClosed Y A).carrier ⊆
+        (mapIrreducibleClosed Y B).carrier := by
+      apply closure_mono
+      apply image_mono
+      exact le_of_lt h_less_AB
+    have h_carrier_eq : (mapIrreducibleClosed Y A).carrier = (mapIrreducibleClosed Y B).carrier :=
+      Subset.antisymm h_forward_subset h_contra_le
+    have h_A_eq_B : A = B := by
+      apply mapIrreducibleClosed_injective Y
+      apply IrreducibleCloseds.ext
+      exact h_carrier_eq
+    exact (ne_of_lt h_less_AB) h_A_eq_B
+
+/-! ### Main dimension theorems -/
+
+/-- **Subspace Dimension Inequality**: The topological Krull dimension of any subspace
+is at most the dimension of the ambient space. This fundamental result shows that
+subspaces cannot have larger dimension than their ambient space. -/
+theorem topKrullDim_subspace_le (X : Type*) [TopologicalSpace X] (Y : Set X) :
+    topologicalKrullDim Y ≤ topologicalKrullDim X := by
+  unfold topologicalKrullDim
+  apply krullDim_le_of_strictMono (mapIrreducibleClosed Y)
+  exact mapIrreducibleClosed_strictMono Y

--- a/Mathlib/Topology/KrullDimension.lean
+++ b/Mathlib/Topology/KrullDimension.lean
@@ -27,7 +27,7 @@ The proofs use order-preserving maps between posets of irreducible closed sets t
 dimension inequalities.
 -/
 
-open Set Function Order TopologicalSpace Topology
+open Set Function Order TopologicalSpace Topology TopologicalSpace.IrreducibleCloseds
 
 /--
 The Krull dimension of a topological space is the supremum of lengths of chains of
@@ -37,25 +37,6 @@ noncomputable def topologicalKrullDim (T : Type*) [TopologicalSpace T] : WithBot
   krullDim (IrreducibleCloseds T)
 
 variable {X Y : Type*} [TopologicalSpace X] [TopologicalSpace Y]
-
-/--
-Map induced on irreducible closed subsets by a closed continuous map `f`.
-This is just a wrapper around the image of `f` together with proofs that it
-preserves irreducibility (by continuity) and closedness (since `f` is closed).
--/
-def IrreducibleCloseds.map {f : X → Y} (hf1 : Continuous f) (hf2 : IsClosedMap f)
-    (c : IrreducibleCloseds X) :
-    IrreducibleCloseds Y where
-  carrier := f '' c
-  isIrreducible' := c.isIrreducible.image f hf1.continuousOn
-  isClosed' := hf2 c c.isClosed
-
-/--
-Taking images under a closed embedding is strictly monotone on the preorder of irreducible closeds.
--/
-lemma IrreducibleCloseds.map_strictMono {f : X → Y} (hf : IsClosedEmbedding f) :
-    StrictMono (IrreducibleCloseds.map hf.continuous hf.isClosedMap) :=
-  fun ⦃_ _⦄ UltV ↦ hf.injective.image_strictMono UltV
 
 /--
 If `f : X → Y` is a closed embedding, then the Krull dimension of `X` is less than or equal
@@ -75,122 +56,23 @@ theorem IsHomeomorph.topologicalKrullDim_eq (f : X → Y) (h : IsHomeomorph f) :
     (h.homeomorph f).symm.isClosedEmbedding
   le_antisymm fwd bwd
 
-/-! ### Maps between irreducible closed sets -/
-
-/-- The canonical map from irreducible closed sets of a subspace `Y` to irreducible
-closed sets of the ambient space `X`, defined by taking the closure of the image
-under the inclusion map. This map is crucial for comparing Krull dimensions. -/
-def mapIrreducibleClosed (Y : Set X) (c : IrreducibleCloseds Y) : IrreducibleCloseds X where
-  carrier := closure (Subtype.val '' c.carrier)
-  is_irreducible' := c.is_irreducible'.image Subtype.val
-    (continuous_subtype_val.continuousOn) |>.closure
-  is_closed' := isClosed_closure
-
-/-- The map `mapIrreducibleClosed` is injective, meaning distinct irreducible
-closed sets in a subspace map to distinct irreducible closed sets in the ambient space.
-This ensures that the dimension-preserving properties hold. -/
-lemma mapIrreducibleClosed_injective (Y : Set X) :
-    Function.Injective (mapIrreducibleClosed Y) := by
-  intro A B h_images_eq
-  ext x
-  have h_closures_eq : closure (Subtype.val '' A.carrier) =
-      closure (Subtype.val '' B.carrier) :=
-    congrArg IrreducibleCloseds.carrier h_images_eq
-  constructor
-  · -- Forward direction: x ∈ A → x ∈ B
-    intro hx_in_A
-    change x ∈ B.carrier
-    rw [← B.is_closed'.closure_eq]
-    -- Use the mathlib lemma for embeddings
-    rw [Topology.IsEmbedding.subtypeVal.closure_eq_preimage_closure_image]
-    rw [← h_closures_eq]
-    simp_rw [mem_preimage]
-    apply subset_closure
-    exact mem_image_of_mem Subtype.val hx_in_A
-  · -- Backward direction: x ∈ B → x ∈ A
-    intro hx_in_B
-    change x ∈ A.carrier
-    rw [← A.is_closed'.closure_eq]
-    -- Use the mathlib lemma for embeddings
-    rw [Topology.IsEmbedding.subtypeVal.closure_eq_preimage_closure_image]
-    rw [h_closures_eq]
-    simp_rw [mem_preimage]
-    apply subset_closure
-    exact mem_image_of_mem Subtype.val hx_in_B
 
 
-/-! ### Partial order structure on irreducible closed sets -/
 
-instance : PartialOrder (IrreducibleCloseds X) where
-  le s t := s.carrier ⊆ t.carrier
-  le_refl s := Set.Subset.refl _
-  le_trans s t u hst htu := Set.Subset.trans hst htu
-  le_antisymm s t hst hts := by
-    apply IrreducibleCloseds.ext
-    exact Set.Subset.antisymm hst hts
 
-/-- The partial order on `IrreducibleCloseds X` is given by subset inclusion
-of the underlying sets. -/
-lemma IrreducibleCloseds.le_iff_subset {s t : IrreducibleCloseds X} :
-    s ≤ t ↔ s.carrier ⊆ t.carrier := by rfl
 
-/-- The strict partial order on `IrreducibleCloseds X` corresponds to strict
-subset inclusion of the underlying sets. -/
-lemma IrreducibleCloseds.lt_iff_subset {s t : IrreducibleCloseds X} :
-    s < t ↔ s.carrier ⊂ t.carrier := by
-  constructor
-  · intro h_lt
-    have h_le := le_of_lt h_lt
-    have h_ne := ne_of_lt h_lt
-    rw [ssubset_iff_subset_ne]
-    constructor
-    · rw [← IrreducibleCloseds.le_iff_subset]
-      exact h_le
-    · apply mt IrreducibleCloseds.ext
-      exact h_ne
-  · intro h_ssubset
-    rw [lt_iff_le_and_ne]
-    rcases h_ssubset with ⟨h_subset, h_ne_carrier⟩
-    constructor
-    · rw [IrreducibleCloseds.le_iff_subset]
-      exact h_subset
-    · intro h_s_eq_t
-      apply h_ne_carrier
-      rw [h_s_eq_t]
 
-/-- The canonical map `mapIrreducibleClosed` is strictly monotone, preserving
-the order structure when comparing irreducible closed sets between subspaces
-and ambient spaces. This is essential for the dimension inequality theorem. -/
-lemma mapIrreducibleClosed_strictMono (Y : Set X) :
-    StrictMono (mapIrreducibleClosed Y) := by
-  intro A B h_less_AB
-  constructor
-  · -- Part 1: Prove map A ≤ map B
-    apply closure_mono
-    apply image_mono
-    exact le_of_lt h_less_AB
-  · -- Part 2: Prove ¬(map B ≤ map A)
-    intro h_contra_le
-    have h_forward_subset : (mapIrreducibleClosed Y A).carrier ⊆
-        (mapIrreducibleClosed Y B).carrier := by
-      apply closure_mono
-      apply image_mono
-      exact le_of_lt h_less_AB
-    have h_carrier_eq : (mapIrreducibleClosed Y A).carrier = (mapIrreducibleClosed Y B).carrier :=
-      Subset.antisymm h_forward_subset h_contra_le
-    have h_A_eq_B : A = B := by
-      apply mapIrreducibleClosed_injective Y
-      apply IrreducibleCloseds.ext
-      exact h_carrier_eq
-    exact (ne_of_lt h_less_AB) h_A_eq_B
+/-!
+### Main dimension theorems -/
 
-/-! ### Main dimension theorems -/
+/-- If `f : Y → X` is an embedding, then `dim(Y) ≤ dim(X)`.
+This generalizes `IsClosedEmbedding.topologicalKrullDim_le`. -/
+theorem IsEmbedding.topologicalKrullDim_le {f : Y → X} (hf : IsEmbedding f) :
+    topologicalKrullDim Y ≤ topologicalKrullDim X :=
+  krullDim_le_of_strictMono _ (IrreducibleCloseds.mapOfEmbedding_strictMono hf)
 
-/-- **Subspace Dimension Inequality**: The topological Krull dimension of any subspace
-is at most the dimension of the ambient space. This fundamental result shows that
-subspaces cannot have larger dimension than their ambient space. -/
-theorem topKrullDim_subspace_le (X : Type*) [TopologicalSpace X] (Y : Set X) :
-    topologicalKrullDim Y ≤ topologicalKrullDim X := by
-  unfold topologicalKrullDim
-  apply krullDim_le_of_strictMono (mapIrreducibleClosed Y)
-  exact mapIrreducibleClosed_strictMono Y
+/-- The topological Krull dimension of any subspace is at most the dimension of the
+ambient space. -/
+theorem topologicalKrullDim_subspace_le (X : Type*) [TopologicalSpace X] (Y : Set X) :
+    topologicalKrullDim Y ≤ topologicalKrullDim X :=
+  IsEmbedding.topologicalKrullDim_le IsEmbedding.subtypeVal

--- a/Mathlib/Topology/Sets/Closeds.lean
+++ b/Mathlib/Topology/Sets/Closeds.lean
@@ -460,9 +460,9 @@ lemma map_injective_of_isInducing {f : β → α} (hf : Topology.IsInducing f) :
 
 /-- The map `IrreducibleCloseds.map` is strictly monotone when `f` is an embedding. -/
 lemma map_strictMono_of_isInducing {f : β → α} (hf : Topology.IsInducing f) :
-    StrictMono (map f hf.continuous) := by
-  exact Monotone.strictMono_of_injective
-    (fun A B h_le => closure_mono <| Set.image_mono h_le)
+    StrictMono (map f hf.continuous) :=
+  Monotone.strictMono_of_injective
+    (fun _ _ h_le => closure_mono <| Set.image_mono h_le)
     (map_injective_of_isInducing hf)
 
 end IrreducibleCloseds

--- a/Mathlib/Topology/Sets/Closeds.lean
+++ b/Mathlib/Topology/Sets/Closeds.lean
@@ -5,7 +5,6 @@ Authors: Floris van Doorn, Yaël Dillies
 -/
 import Mathlib.Topology.Sets.Opens
 import Mathlib.Topology.Clopen
-import Mathlib.Topology.Homeomorph.Lemmas
 import Mathlib.Topology.Constructions
 
 /-!

--- a/Mathlib/Topology/Sets/Closeds.lean
+++ b/Mathlib/Topology/Sets/Closeds.lean
@@ -438,17 +438,22 @@ def orderIsoSubtype' : IrreducibleCloseds α ≃o { x : Set α // IsClosed x ∧
 instance : PartialOrder (IrreducibleCloseds α) := inferInstance
 
 /-- The map on irreducible closed sets induced by a continuous map `f`. -/
-def map {f : β → α} (hf : Continuous f)
+def map (f : β → α) (hf : Continuous f)
     (c : IrreducibleCloseds β) : IrreducibleCloseds α where
-  carrier := closure (f '' c.carrier)
+  carrier := closure (f '' c)
   isIrreducible' := c.isIrreducible.image f hf.continuousOn |>.closure
   isClosed' := isClosed_closure
+
+@[simp]
+lemma coe_map (f : β → α) (hf : Continuous f) (s : IrreducibleCloseds β) :
+    (map f hf s : Set α) = closure (f '' s) :=
+  rfl
 
 /-- The map `IrreducibleCloseds.map` is injective when `f` is an embedding.
 This relies on the property of embeddings that a closed set in the domain is the preimage
 of the closure of its image. -/
-lemma map_injective_of_embedding {f : β → α} (hf : Topology.IsEmbedding f) :
-    Function.Injective (map hf.continuous) := by
+lemma map_injective_of_isEmbedding {f : β → α} (hf : Topology.IsEmbedding f) :
+    Function.Injective (map f hf.continuous) := by
   intro A B h_images_eq
   ext x
   have h_closures_eq : closure (f '' A.carrier) = closure (f '' B.carrier) :=
@@ -467,33 +472,15 @@ lemma map_injective_of_embedding {f : β → α} (hf : Topology.IsEmbedding f) :
     exact subset_closure (mem_image_of_mem f hx_in_B)⟩
 
 /-- The map `IrreducibleCloseds.map` is strictly monotone when `f` is an embedding. -/
-lemma map_strictMono_of_embedding {f : β → α} (hf : Topology.IsEmbedding f) :
-    StrictMono (map hf.continuous) := by
+lemma map_strictMono_of_isEmbedding {f : β → α} (hf : Topology.IsEmbedding f) :
+    StrictMono (map f hf.continuous) := by
   intro A B h_less_AB
   rw [← SetLike.coe_ssubset_coe] at h_less_AB ⊢
   exact ⟨closure_mono (Set.image_mono (subset_of_ssubset h_less_AB)), fun h_contra_subset =>
     (ne_of_lt (SetLike.coe_ssubset_coe.mp h_less_AB))
-    (map_injective_of_embedding hf (IrreducibleCloseds.ext
+    (map_injective_of_isEmbedding hf (IrreducibleCloseds.ext
       (Subset.antisymm (closure_mono (Set.image_mono (subset_of_ssubset h_less_AB)))
         h_contra_subset)))⟩
-
-/-! ### Maps for subspace embeddings -/
-
-/-- The canonical map from irreducible closed sets of a subspace `β` to irreducible
-closed sets of the ambient space `α`, defined by taking the closure of the image
-under the inclusion map. This is an instance of `IrreducibleCloseds.mapOfContinuous`. -/
-def mapIrreducibleClosed (β : Set α) : IrreducibleCloseds β → IrreducibleCloseds α :=
-  map continuous_subtype_val
-
-/-- The map `mapIrreducibleClosed` is injective, as it's induced by an embedding. -/
-lemma mapIrreducibleClosed_injective (β : Set α) :
-    Function.Injective (mapIrreducibleClosed β) :=
-  map_injective_of_embedding Topology.IsEmbedding.subtypeVal
-
-/-- The canonical map `mapIrreducibleClosed` is strictly monotone. -/
-lemma mapIrreducibleClosed_strictMono (β : Set α) :
-    StrictMono (mapIrreducibleClosed β) :=
-  map_strictMono_of_embedding Topology.IsEmbedding.subtypeVal
 
 end IrreducibleCloseds
 

--- a/Mathlib/Topology/Sets/Closeds.lean
+++ b/Mathlib/Topology/Sets/Closeds.lean
@@ -5,8 +5,6 @@ Authors: Floris van Doorn, Yaël Dillies
 -/
 import Mathlib.Topology.Sets.Opens
 import Mathlib.Topology.Clopen
-import Mathlib.Topology.Constructions
-import Mathlib.Topology.Defs.Induced
 
 /-!
 # Closed sets

--- a/Mathlib/Topology/Sets/Closeds.lean
+++ b/Mathlib/Topology/Sets/Closeds.lean
@@ -21,8 +21,8 @@ For a topological space `α`,
 -/
 
 
-open Order OrderDual Set
-open scoped Topology
+open Order OrderDual Set Topology
+
 
 variable {ι α β : Type*} [TopologicalSpace α] [TopologicalSpace β]
 
@@ -447,10 +447,13 @@ lemma coe_map (f : β → α) (hf : Continuous f) (s : IrreducibleCloseds β) :
     (map f hf s : Set α) = closure (f '' s) :=
   rfl
 
-/-- The map `IrreducibleCloseds.map` is injective when `f` is an embedding.
+lemma map_mono {f : β → α} (hf : Continuous f) : Monotone (map f hf) :=
+  fun _ _ h_le => closure_mono <| Set.image_mono h_le
+
+/-- The map `IrreducibleCloseds.map` is injective when `f` is inducing.
 This relies on the property of embeddings that a closed set in the domain is the preimage
 of the closure of its image. -/
-lemma map_injective_of_isInducing {f : β → α} (hf : Topology.IsInducing f) :
+lemma map_injective_of_isInducing {f : β → α} (hf : IsInducing f) :
     Function.Injective (map f hf.continuous) := by
   intro A B h_images_eq
   apply SetLike.coe_injective
@@ -458,12 +461,10 @@ lemma map_injective_of_isInducing {f : β → α} (hf : Topology.IsInducing f) :
   rw [← A.isClosed.closure_eq, hf.closure_eq_preimage_closure_image, h_images_eq,
     ← hf.closure_eq_preimage_closure_image, B.isClosed.closure_eq]
 
-/-- The map `IrreducibleCloseds.map` is strictly monotone when `f` is an embedding. -/
-lemma map_strictMono_of_isInducing {f : β → α} (hf : Topology.IsInducing f) :
+/-- The map `IrreducibleCloseds.map` is strictly monotone when `f` is inducing. -/
+lemma map_strictMono_of_isInducing {f : β → α} (hf : IsInducing f) :
     StrictMono (map f hf.continuous) :=
-  Monotone.strictMono_of_injective
-    (fun _ _ h_le => closure_mono <| Set.image_mono h_le)
-    (map_injective_of_isInducing hf)
+  Monotone.strictMono_of_injective (map_mono hf.continuous) (map_injective_of_isInducing hf)
 
 end IrreducibleCloseds
 

--- a/Mathlib/Topology/Sets/Closeds.lean
+++ b/Mathlib/Topology/Sets/Closeds.lean
@@ -6,6 +6,7 @@ Authors: Floris van Doorn, Yaël Dillies
 import Mathlib.Topology.Sets.Opens
 import Mathlib.Topology.Clopen
 import Mathlib.Topology.Constructions
+import Mathlib.Topology.Defs.Induced
 
 /-!
 # Closed sets
@@ -21,6 +22,7 @@ For a topological space `α`,
 
 
 open Order OrderDual Set
+open scoped Topology
 
 variable {ι α β : Type*} [TopologicalSpace α] [TopologicalSpace β]
 
@@ -431,115 +433,67 @@ order isomorphism. -/
 def orderIsoSubtype' : IrreducibleCloseds α ≃o { x : Set α // IsClosed x ∧ IsIrreducible x } :=
   equivSubtype'.toOrderIso (fun _ _ h ↦ h) (fun _ _ h ↦ h)
 
-/-! ### Partial order structure on irreducible closed sets -/
+/-! ### Partial order structure on irreducible closed sets and maps thereof-/
 
-instance : PartialOrder (IrreducibleCloseds α) where
-  le s t := s.carrier ⊆ t.carrier
-  le_refl s := Set.Subset.refl _
-  le_trans s t u hst htu := Set.Subset.trans hst htu
-  le_antisymm s t hst hts := IrreducibleCloseds.ext (Set.Subset.antisymm hst hts)
+instance : PartialOrder (IrreducibleCloseds α) := inferInstance
 
-/-- The partial order on `IrreducibleCloseds α` is given by subset inclusion
-of the underlying sets. -/
-lemma le_iff_subset {s t : IrreducibleCloseds α} :
-    s ≤ t ↔ s.carrier ⊆ t.carrier := by rfl
-
-/-- The strict partial order on `IrreducibleCloseds α` corresponds to strict
-subset inclusion of the underlying sets. -/
-lemma lt_iff_subset {s t : IrreducibleCloseds α} :
-    s < t ↔ s.carrier ⊂ t.carrier := by
-  constructor
-  · intro h_lt
-    have h_le := le_of_lt h_lt
-    have h_ne := ne_of_lt h_lt
-    rw [ssubset_iff_subset_ne]
-    exact ⟨by rwa [← le_iff_subset], mt IrreducibleCloseds.ext h_ne⟩
-  · intro h_ssubset
-    rw [lt_iff_le_and_ne]
-    rcases h_ssubset with ⟨h_subset, h_ne_carrier⟩
-    exact ⟨by rwa [le_iff_subset],
-      fun h_s_eq_t => h_ne_carrier (by rw [h_s_eq_t])⟩
-
-/-! ### Maps between irreducible closed sets -/
-
-variable {Y : Type*} [TopologicalSpace Y]
-
-/--
-Map induced on irreducible closed subsets by a closed continuous map `f`.
-This is just a wrapper around the image of `f` together with proofs that it
-preserves irreducibility (by continuity) and closedness (since `f` is closed).
--/
-def map {f : α → Y} (hf1 : Continuous f) (hf2 : IsClosedMap f)
-    (c : IrreducibleCloseds α) :
-    IrreducibleCloseds Y where
-  carrier := f '' c
-  isIrreducible' := c.isIrreducible.image f hf1.continuousOn
-  isClosed' := hf2 c c.isClosed
-
-/--
-Taking images under a closed embedding is strictly monotone on the preorder of irreducible closeds.
--/
-lemma map_strictMono {f : α → Y} (hf : Topology.IsClosedEmbedding f) :
-    StrictMono (map hf.continuous hf.isClosedMap) :=
-  fun ⦃_ _⦄ UltV ↦ hf.injective.image_strictMono UltV
-
-/-- The map on irreducible closed sets induced by an embedding `f`.
-This is a generalization of `IrreducibleCloseds.map` for embeddings that are not necessarily
-closed. We take the closure of the image to ensure the result is a closed set. -/
-def mapOfEmbedding {f : Y → α} (hf : Topology.IsEmbedding f)
-    (c : IrreducibleCloseds Y) : IrreducibleCloseds α where
+/-- The map on irreducible closed sets induced by a continuous map `f`. -/
+def map {f : β → α} (hf : Continuous f)
+    (c : IrreducibleCloseds β) : IrreducibleCloseds α where
   carrier := closure (f '' c.carrier)
-  isIrreducible' := c.isIrreducible.image f (hf.continuous.continuousOn) |>.closure
+  isIrreducible' := c.isIrreducible.image f hf.continuousOn |>.closure
   isClosed' := isClosed_closure
 
-/-- The map `IrreducibleCloseds.mapOfEmbedding` is injective.
+/-- The map `IrreducibleCloseds.map` is injective when `f` is an embedding.
 This relies on the property of embeddings that a closed set in the domain is the preimage
 of the closure of its image. -/
-lemma mapOfEmbedding_injective {f : Y → α} (hf : Topology.IsEmbedding f) :
-    Function.Injective (mapOfEmbedding hf) := by
+lemma map_injective_of_embedding {f : β → α} (hf : Topology.IsEmbedding f) :
+    Function.Injective (map hf.continuous) := by
   intro A B h_images_eq
   ext x
   have h_closures_eq : closure (f '' A.carrier) = closure (f '' B.carrier) :=
-    congrArg carrier h_images_eq
+    congrArg IrreducibleCloseds.carrier h_images_eq
   exact ⟨fun hx_in_A => by
-    change x ∈ B.carrier
-    rw [← B.isClosed.closure_eq, hf.closure_eq_preimage_closure_image, ← h_closures_eq]
+    rw [← B.isClosed.closure_eq, hf.closure_eq_preimage_closure_image]
     simp_rw [mem_preimage]
+    change f x ∈ closure (f '' B.carrier)
+    rw [← h_closures_eq]
     exact subset_closure (mem_image_of_mem f hx_in_A),
   fun hx_in_B => by
-    change x ∈ A.carrier
-    rw [← A.isClosed.closure_eq, hf.closure_eq_preimage_closure_image, h_closures_eq]
+    rw [← A.isClosed.closure_eq, hf.closure_eq_preimage_closure_image]
     simp_rw [mem_preimage]
+    change f x ∈ closure (f '' A.carrier)
+    rw [h_closures_eq]
     exact subset_closure (mem_image_of_mem f hx_in_B)⟩
 
-/-- The map `IrreducibleCloseds.mapOfEmbedding` is strictly monotone. -/
-lemma mapOfEmbedding_strictMono {f : Y → α} (hf : Topology.IsEmbedding f) :
-    StrictMono (mapOfEmbedding hf) := by
+/-- The map `IrreducibleCloseds.map` is strictly monotone when `f` is an embedding. -/
+lemma map_strictMono_of_embedding {f : β → α} (hf : Topology.IsEmbedding f) :
+    StrictMono (map hf.continuous) := by
   intro A B h_less_AB
-  rw [lt_iff_subset] at h_less_AB ⊢
-  exact ⟨closure_mono (image_mono (subset_of_ssubset h_less_AB)), fun h_contra_subset =>
-    (ne_of_lt (lt_iff_subset.mpr h_less_AB))
-    (mapOfEmbedding_injective hf (IrreducibleCloseds.ext
-      (Subset.antisymm (closure_mono (image_mono (subset_of_ssubset h_less_AB)))
+  rw [← SetLike.coe_ssubset_coe] at h_less_AB ⊢
+  exact ⟨closure_mono (Set.image_mono (subset_of_ssubset h_less_AB)), fun h_contra_subset =>
+    (ne_of_lt (SetLike.coe_ssubset_coe.mp h_less_AB))
+    (map_injective_of_embedding hf (IrreducibleCloseds.ext
+      (Subset.antisymm (closure_mono (Set.image_mono (subset_of_ssubset h_less_AB)))
         h_contra_subset)))⟩
 
 /-! ### Maps for subspace embeddings -/
 
-/-- The canonical map from irreducible closed sets of a subspace `Y` to irreducible
+/-- The canonical map from irreducible closed sets of a subspace `β` to irreducible
 closed sets of the ambient space `α`, defined by taking the closure of the image
-under the inclusion map. This is an instance of `IrreducibleCloseds.mapOfEmbedding`. -/
-def mapIrreducibleClosed (Y : Set α) : IrreducibleCloseds Y → IrreducibleCloseds α :=
-  mapOfEmbedding Topology.IsEmbedding.subtypeVal
+under the inclusion map. This is an instance of `IrreducibleCloseds.mapOfContinuous`. -/
+def mapIrreducibleClosed (β : Set α) : IrreducibleCloseds β → IrreducibleCloseds α :=
+  map continuous_subtype_val
 
 /-- The map `mapIrreducibleClosed` is injective, as it's induced by an embedding. -/
-lemma mapIrreducibleClosed_injective (Y : Set α) :
-    Function.Injective (mapIrreducibleClosed Y) :=
-  mapOfEmbedding_injective Topology.IsEmbedding.subtypeVal
+lemma mapIrreducibleClosed_injective (β : Set α) :
+    Function.Injective (mapIrreducibleClosed β) :=
+  map_injective_of_embedding Topology.IsEmbedding.subtypeVal
 
 /-- The canonical map `mapIrreducibleClosed` is strictly monotone. -/
-lemma mapIrreducibleClosed_strictMono (Y : Set α) :
-    StrictMono (mapIrreducibleClosed Y) :=
-  mapOfEmbedding_strictMono Topology.IsEmbedding.subtypeVal
+lemma mapIrreducibleClosed_strictMono (β : Set α) :
+    StrictMono (mapIrreducibleClosed β) :=
+  map_strictMono_of_embedding Topology.IsEmbedding.subtypeVal
 
 end IrreducibleCloseds
 

--- a/Mathlib/Topology/Sets/Closeds.lean
+++ b/Mathlib/Topology/Sets/Closeds.lean
@@ -433,9 +433,7 @@ order isomorphism. -/
 def orderIsoSubtype' : IrreducibleCloseds α ≃o { x : Set α // IsClosed x ∧ IsIrreducible x } :=
   equivSubtype'.toOrderIso (fun _ _ h ↦ h) (fun _ _ h ↦ h)
 
-/-! ### Partial order structure on irreducible closed sets and maps thereof-/
-
-instance : PartialOrder (IrreducibleCloseds α) := inferInstance
+/-! ### Partial order structure on irreducible closed sets and maps thereof.-/
 
 /-- The map on irreducible closed sets induced by a continuous map `f`. -/
 def map (f : β → α) (hf : Continuous f)
@@ -452,35 +450,20 @@ lemma coe_map (f : β → α) (hf : Continuous f) (s : IrreducibleCloseds β) :
 /-- The map `IrreducibleCloseds.map` is injective when `f` is an embedding.
 This relies on the property of embeddings that a closed set in the domain is the preimage
 of the closure of its image. -/
-lemma map_injective_of_isEmbedding {f : β → α} (hf : Topology.IsEmbedding f) :
+lemma map_injective_of_isInducing {f : β → α} (hf : Topology.IsInducing f) :
     Function.Injective (map f hf.continuous) := by
   intro A B h_images_eq
-  ext x
-  have h_closures_eq : closure (f '' A.carrier) = closure (f '' B.carrier) :=
-    congrArg IrreducibleCloseds.carrier h_images_eq
-  exact ⟨fun hx_in_A => by
-    rw [← B.isClosed.closure_eq, hf.closure_eq_preimage_closure_image]
-    simp_rw [mem_preimage]
-    change f x ∈ closure (f '' B.carrier)
-    rw [← h_closures_eq]
-    exact subset_closure (mem_image_of_mem f hx_in_A),
-  fun hx_in_B => by
-    rw [← A.isClosed.closure_eq, hf.closure_eq_preimage_closure_image]
-    simp_rw [mem_preimage]
-    change f x ∈ closure (f '' A.carrier)
-    rw [h_closures_eq]
-    exact subset_closure (mem_image_of_mem f hx_in_B)⟩
+  apply SetLike.coe_injective
+  replace h_images_eq : closure (f '' A) = closure (f '' B) := congr($h_images_eq)
+  rw [← A.isClosed.closure_eq, hf.closure_eq_preimage_closure_image, h_images_eq,
+    ← hf.closure_eq_preimage_closure_image, B.isClosed.closure_eq]
 
 /-- The map `IrreducibleCloseds.map` is strictly monotone when `f` is an embedding. -/
-lemma map_strictMono_of_isEmbedding {f : β → α} (hf : Topology.IsEmbedding f) :
+lemma map_strictMono_of_isInducing {f : β → α} (hf : Topology.IsInducing f) :
     StrictMono (map f hf.continuous) := by
-  intro A B h_less_AB
-  rw [← SetLike.coe_ssubset_coe] at h_less_AB ⊢
-  exact ⟨closure_mono (Set.image_mono (subset_of_ssubset h_less_AB)), fun h_contra_subset =>
-    (ne_of_lt (SetLike.coe_ssubset_coe.mp h_less_AB))
-    (map_injective_of_isEmbedding hf (IrreducibleCloseds.ext
-      (Subset.antisymm (closure_mono (Set.image_mono (subset_of_ssubset h_less_AB)))
-        h_contra_subset)))⟩
+  exact Monotone.strictMono_of_injective
+    (fun A B h_le => closure_mono <| Set.image_mono h_le)
+    (map_injective_of_isInducing hf)
 
 end IrreducibleCloseds
 


### PR DESCRIPTION
This PR proves that subspaces have Krull dimension at most that of the ambient space: dim(Y) ≤ dim(X) for Y ⊆ X (theorem topologicalKrullDim_subspace_le).

Supporting results about IrreducibleCloseds were refactored and moved from KrullDimension.lean to Closeds.lean for better modularity.
Note: Some code/documentation generated with AI assistance (Gemini).

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include at least one commit authored by each
co-author among the commits in the pull request. If necessary, you may 
create empty commits to indicate co-authorship, using commands like so:

git commit --author="Author Name <author@email.com>" --allow-empty -m "add Author Name as coauthor"

When merging, all the commits will be squashed into a single commit listing all co-authors.

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
