### PR TITLE
[Merged by Bors] - feat(Algebra): add `mem_eqLocus` simp lemmas

### DIFF
--- a/Mathlib/Algebra/Field/Subfield/Basic.lean
+++ b/Mathlib/Algebra/Field/Subfield/Basic.lean
@@ -465,6 +465,9 @@ def eqLocusField (f g : K →+* L) : Subfield K where
   inv_mem' _ := eq_on_inv₀ f g
   carrier := { x | f x = g x }
 
+@[simp]
+theorem mem_eqLocusField {f g : K →+* L} {x} : x ∈ f.eqLocusField g ↔ f x = g x := Iff.rfl
+
 /-- If two ring homomorphisms are equal on a set, then they are equal on its subfield closure. -/
 theorem eqOn_field_closure {f g : K →+* L} {s : Set K} (h : Set.EqOn f g s) :
     Set.EqOn f g (closure s) :=

--- a/Mathlib/Algebra/Field/Subfield/Basic.lean
+++ b/Mathlib/Algebra/Field/Subfield/Basic.lean
@@ -466,7 +466,7 @@ def eqLocusField (f g : K →+* L) : Subfield K where
   carrier := { x | f x = g x }
 
 @[simp]
-theorem mem_eqLocusField {f g : K →+* L} {x} : x ∈ f.eqLocusField g ↔ f x = g x := Iff.rfl
+theorem mem_eqLocusField {f g : K →+* L} {x : K} : x ∈ f.eqLocusField g ↔ f x = g x := Iff.rfl
 
 /-- If two ring homomorphisms are equal on a set, then they are equal on its subfield closure. -/
 theorem eqOn_field_closure {f g : K →+* L} {s : Set K} (h : Set.EqOn f g s) :

--- a/Mathlib/Algebra/Group/Submonoid/Defs.lean
+++ b/Mathlib/Algebra/Group/Submonoid/Defs.lean
@@ -292,7 +292,7 @@ def eqLocusM (f g : M →* N) : Submonoid M where
   mul_mem' (hx : _ = _) (hy : _ = _) := by simp [*]
 
 @[to_additive (attr := simp)]
-theorem mem_eqLocusM {f g : M →* N} {x} : x ∈ f.eqLocusM g ↔ f x = g x := Iff.rfl
+theorem mem_eqLocusM {f g : M →* N} {x : M} : x ∈ f.eqLocusM g ↔ f x = g x := Iff.rfl
 
 @[to_additive (attr := simp)]
 theorem eqLocusM_same (f : M →* N) : f.eqLocusM f = ⊤ :=

--- a/Mathlib/Algebra/Group/Submonoid/Defs.lean
+++ b/Mathlib/Algebra/Group/Submonoid/Defs.lean
@@ -292,6 +292,9 @@ def eqLocusM (f g : M →* N) : Submonoid M where
   mul_mem' (hx : _ = _) (hy : _ = _) := by simp [*]
 
 @[to_additive (attr := simp)]
+theorem mem_eqLocusM {f g : M →* N} {x} : x ∈ f.eqLocusM g ↔ f x = g x := Iff.rfl
+
+@[to_additive (attr := simp)]
 theorem eqLocusM_same (f : M →* N) : f.eqLocusM f = ⊤ :=
   SetLike.ext fun _ => eq_self_iff_true _
 

--- a/Mathlib/Algebra/Group/Subsemigroup/Defs.lean
+++ b/Mathlib/Algebra/Group/Subsemigroup/Defs.lean
@@ -237,7 +237,7 @@ def eqLocus (f g : M →ₙ* N) : Subsemigroup M where
   mul_mem' (hx : _ = _) (hy : _ = _) := by simp [*]
 
 @[to_additive (attr := simp)]
-theorem mem_eqLocus {f g : M →ₙ* N} {x} : x ∈ f.eqLocus g ↔ f x = g x := Iff.rfl
+theorem mem_eqLocus {f g : M →ₙ* N} {x : M} : x ∈ f.eqLocus g ↔ f x = g x := Iff.rfl
 
 @[to_additive]
 theorem eq_of_eqOn_top {f g : M →ₙ* N} (h : Set.EqOn f g (⊤ : Subsemigroup M)) : f = g :=

--- a/Mathlib/Algebra/Group/Subsemigroup/Defs.lean
+++ b/Mathlib/Algebra/Group/Subsemigroup/Defs.lean
@@ -236,6 +236,9 @@ def eqLocus (f g : M →ₙ* N) : Subsemigroup M where
   carrier := { x | f x = g x }
   mul_mem' (hx : _ = _) (hy : _ = _) := by simp [*]
 
+@[to_additive (attr := simp)]
+theorem mem_eqLocus {f g : M →ₙ* N} {x} : x ∈ f.eqLocus g ↔ f x = g x := Iff.rfl
+
 @[to_additive]
 theorem eq_of_eqOn_top {f g : M →ₙ* N} (h : Set.EqOn f g (⊤ : Subsemigroup M)) : f = g :=
   ext fun _ => h trivial

--- a/Mathlib/Algebra/Ring/Subring/Basic.lean
+++ b/Mathlib/Algebra/Ring/Subring/Basic.lean
@@ -814,6 +814,9 @@ def eqLocus (f g : R →+* S) : Subring R :=
   { (f : R →* S).eqLocusM g, (f : R →+ S).eqLocus g with carrier := { x | f x = g x } }
 
 @[simp]
+theorem mem_eqLocus {f g : R →+* S} {x} : x ∈ f.eqLocus g ↔ f x = g x := Iff.rfl
+
+@[simp]
 theorem eqLocus_same (f : R →+* S) : f.eqLocus f = ⊤ :=
   SetLike.ext fun _ => eq_self_iff_true _
 

--- a/Mathlib/Algebra/Ring/Subring/Basic.lean
+++ b/Mathlib/Algebra/Ring/Subring/Basic.lean
@@ -814,7 +814,7 @@ def eqLocus (f g : R →+* S) : Subring R :=
   { (f : R →* S).eqLocusM g, (f : R →+ S).eqLocus g with carrier := { x | f x = g x } }
 
 @[simp]
-theorem mem_eqLocus {f g : R →+* S} {x} : x ∈ f.eqLocus g ↔ f x = g x := Iff.rfl
+theorem mem_eqLocus {f g : R →+* S} {x : R} : x ∈ f.eqLocus g ↔ f x = g x := Iff.rfl
 
 @[simp]
 theorem eqLocus_same (f : R →+* S) : f.eqLocus f = ⊤ :=

--- a/Mathlib/Algebra/Ring/Subsemiring/Defs.lean
+++ b/Mathlib/Algebra/Ring/Subsemiring/Defs.lean
@@ -398,7 +398,7 @@ def eqLocusS (f g : R →+* S) : Subsemiring R :=
   { (f : R →* S).eqLocusM g, (f : R →+ S).eqLocusM g with carrier := { x | f x = g x } }
 
 @[simp]
-theorem mem_eqLocusS {f g : R →+* S} {x} : x ∈ f.eqLocusS g ↔ f x = g x := Iff.rfl
+theorem mem_eqLocusS {f g : R →+* S} {x : R} : x ∈ f.eqLocusS g ↔ f x = g x := Iff.rfl
 
 @[simp]
 theorem eqLocusS_same (f : R →+* S) : f.eqLocusS f = ⊤ :=

--- a/Mathlib/Algebra/Ring/Subsemiring/Defs.lean
+++ b/Mathlib/Algebra/Ring/Subsemiring/Defs.lean
@@ -398,6 +398,9 @@ def eqLocusS (f g : R →+* S) : Subsemiring R :=
   { (f : R →* S).eqLocusM g, (f : R →+ S).eqLocusM g with carrier := { x | f x = g x } }
 
 @[simp]
+theorem mem_eqLocusS {f g : R →+* S} {x} : x ∈ f.eqLocusS g ↔ f x = g x := Iff.rfl
+
+@[simp]
 theorem eqLocusS_same (f : R →+* S) : f.eqLocusS f = ⊤ :=
   SetLike.ext fun _ => eq_self_iff_true _
 

--- a/Mathlib/ModelTheory/Substructures.lean
+++ b/Mathlib/ModelTheory/Substructures.lean
@@ -828,7 +828,7 @@ def eqLocus (f g : M →[L] N) : Substructure L M where
     simp [h]
 
 @[simp]
-theorem mem_eqLocus {f g : M →[L] N} {x} : x ∈ f.eqLocus g ↔ f x = g x := Iff.rfl
+theorem mem_eqLocus {f g : M →[L] N} {x : M} : x ∈ f.eqLocus g ↔ f x = g x := Iff.rfl
 
 /-- If two `L.Hom`s are equal on a set, then they are equal on its substructure closure. -/
 theorem eqOn_closure {f g : M →[L] N} {s : Set M} (h : Set.EqOn f g s) :

--- a/Mathlib/ModelTheory/Substructures.lean
+++ b/Mathlib/ModelTheory/Substructures.lean
@@ -827,6 +827,9 @@ def eqLocus (f g : M →[L] N) : Substructure L M where
       apply hx
     simp [h]
 
+@[simp]
+theorem mem_eqLocus {f g : M →[L] N} {x} : x ∈ f.eqLocus g ↔ f x = g x := Iff.rfl
+
 /-- If two `L.Hom`s are equal on a set, then they are equal on its substructure closure. -/
 theorem eqOn_closure {f g : M →[L] N} {s : Set M} (h : Set.EqOn f g s) :
     Set.EqOn f g (closure L s) :=

--- a/Mathlib/RingTheory/NonUnitalSubring/Basic.lean
+++ b/Mathlib/RingTheory/NonUnitalSubring/Basic.lean
@@ -687,7 +687,7 @@ def eqLocus (f g : R →ₙ+* S) : NonUnitalSubring R :=
   { (f : R →ₙ* S).eqLocus g, (f : R →+ S).eqLocus g with carrier := {x | f x = g x} }
 
 @[simp]
-theorem mem_eqLocus {f g : R →ₙ+* S} {x} : x ∈ f.eqLocus g ↔ f x = g x := Iff.rfl
+theorem mem_eqLocus {f g : R →ₙ+* S} {x : R} : x ∈ f.eqLocus g ↔ f x = g x := Iff.rfl
 
 @[simp]
 theorem eqLocus_same (f : R →ₙ+* S) : f.eqLocus f = ⊤ :=

--- a/Mathlib/RingTheory/NonUnitalSubring/Basic.lean
+++ b/Mathlib/RingTheory/NonUnitalSubring/Basic.lean
@@ -687,6 +687,9 @@ def eqLocus (f g : R →ₙ+* S) : NonUnitalSubring R :=
   { (f : R →ₙ* S).eqLocus g, (f : R →+ S).eqLocus g with carrier := {x | f x = g x} }
 
 @[simp]
+theorem mem_eqLocus {f g : R →ₙ+* S} {x} : x ∈ f.eqLocus g ↔ f x = g x := Iff.rfl
+
+@[simp]
 theorem eqLocus_same (f : R →ₙ+* S) : f.eqLocus f = ⊤ :=
   SetLike.ext fun _ => eq_self_iff_true _
 


### PR DESCRIPTION
Currently only `LinearMap.mem_eqLocus` exists.

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include at least one commit authored by each
co-author among the commits in the pull request. If necessary, you may 
create empty commits to indicate co-authorship, using commands like so:

git commit --author="Author Name <author@email.com>" --allow-empty -m "add Author Name as coauthor"

When merging, all the commits will be squashed into a single commit listing all co-authors.

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
