### PR TITLE
[Merged by Bors] - refactor(Data/Set/Finite): redo proof to reduce imports

### DIFF
--- a/Mathlib/CategoryTheory/Sites/Coherent/CoherentTopology.lean
+++ b/Mathlib/CategoryTheory/Sites/Coherent/CoherentTopology.lean
@@ -4,8 +4,9 @@ Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Adam Topaz, Nikolas Kuhn
 -/
 import Mathlib.CategoryTheory.Sites.Coherent.CoherentSheaves
-/-!
+import Mathlib.Data.Finite.Sigma
 
+/-!
 # Description of the covering sieves of the coherent topology
 
 This file characterises the covering sieves of the coherent topology.

--- a/Mathlib/CategoryTheory/Sites/Coherent/ExtensiveTopology.lean
+++ b/Mathlib/CategoryTheory/Sites/Coherent/ExtensiveTopology.lean
@@ -4,8 +4,9 @@ Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Dagur Asgeirsson
 -/
 import Mathlib.CategoryTheory.Sites.Coherent.Basic
-/-!
+import Mathlib.Data.Finite.Sigma
 
+/-!
 # Description of the covering sieves of the extensive topology
 
 This file characterises the covering sieves of the extensive topology.

--- a/Mathlib/Data/Set/Finite/Lattice.lean
+++ b/Mathlib/Data/Set/Finite/Lattice.lean
@@ -3,9 +3,9 @@ Copyright (c) 2017 Johannes Hölzl. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Johannes Hölzl, Mario Carneiro, Kyle Miller
 -/
-import Mathlib.Data.Finite.Sigma
 import Mathlib.Data.Set.Finite.Powerset
 import Mathlib.Data.Set.Finite.Range
+import Mathlib.Data.Set.Lattice.Image
 
 /-!
 # Finiteness of unions and intersections
@@ -83,8 +83,9 @@ Some set instances do not appear here since they are consequences of others, for
 namespace Finite.Set
 
 instance finite_iUnion [Finite ι] (f : ι → Set α) [∀ i, Finite (f i)] : Finite (⋃ i, f i) := by
-  rw [iUnion_eq_range_psigma]
-  apply Set.finite_range
+  have : Fintype (PLift ι) := Fintype.ofFinite _
+  have : ∀ i, Fintype (f i) := fun i => Fintype.ofFinite _
+  classical apply (fintypeiUnion _).finite
 
 instance finite_sUnion {s : Set (Set α)} [Finite s] [H : ∀ t : s, Finite (t : Set α)] :
     Finite (⋃₀ s) := by

--- a/Mathlib/Data/Set/Finite/List.lean
+++ b/Mathlib/Data/Set/Finite/List.lean
@@ -7,7 +7,6 @@ import Mathlib.Data.Set.Finite.Basic
 import Mathlib.Data.Set.Finite.Lattice
 import Mathlib.Data.Set.Finite.Range
 import Mathlib.Data.Set.Lattice
-import Mathlib.Data.Finite.Sigma
 import Mathlib.Data.Finite.Vector
 
 /-!

--- a/Mathlib/Order/Filter/Finite.lean
+++ b/Mathlib/Order/Filter/Finite.lean
@@ -4,6 +4,7 @@ Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Johannes Hölzl, Jeremy Avigad
 -/
 import Mathlib.Data.Set.Finite.Lattice
+import Mathlib.Order.CompleteLattice.Finset
 import Mathlib.Order.Filter.Basic
 
 /-!

--- a/Mathlib/Order/RelSeries.lean
+++ b/Mathlib/Order/RelSeries.lean
@@ -7,6 +7,7 @@ import Mathlib.Algebra.Order.Ring.Nat
 import Mathlib.Data.Fin.VecNotation
 import Mathlib.Data.Fintype.Pi
 import Mathlib.Data.Fintype.Pigeonhole
+import Mathlib.Data.Fintype.Sigma
 import Mathlib.Data.Rel
 import Mathlib.Order.OrderIsoNat
 

--- a/Mathlib/Topology/Sets/CompactOpenCovered.lean
+++ b/Mathlib/Topology/Sets/CompactOpenCovered.lean
@@ -3,6 +3,7 @@ Copyright (c) 2025 Christian Merten. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Christian Merten
 -/
+import Mathlib.Data.Finite.Sigma
 import Mathlib.Topology.Spectral.Prespectral
 
 /-!


### PR DESCRIPTION
This PR changes the construction of a `finite_iUnion` instance so that we do not need finiteness of sigma types. I noticed this import on the [long pole](https://speed.lean-lang.org/mathlib4-out/b16bc96c8fa8c9b828fd6b48607becccee06d77f/) and figured it can be reduced somewhat.


---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include at least one commit authored by each
co-author among the commits in the pull request. If necessary, you may 
create empty commits to indicate co-authorship, using commands like so:

git commit --author="Author Name <author@email.com>" --allow-empty -m "add Author Name as coauthor"

When merging, all the commits will be squashed into a single commit listing all co-authors.

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
