### PR TITLE
[Merged by Bors] - fix(CI): use `sed` instead of Bash string manipulation

### DIFF
--- a/scripts/zulip_build_report.sh
+++ b/scripts/zulip_build_report.sh
@@ -16,22 +16,26 @@ counts=()
 # Panics are reported as an info message.
 # They should be very prominent when debugging, so treat them differently.
 if panic_lines=$(grep '^info: .*PANIC at ' <<<"${filtered_out}"); then
-  panic_descriptions=${panic_lines//info: *([^:]):*([0-9]):*([0-9]): }
+  # shellcheck disable=SC2001 # The sed version is (hours!) faster than native Bash string manipulation.
+  panic_descriptions=$(sed 's/^info: [^:]*:[0-9]*:[0-9]*: //' <<<"${panic_lines}")
   counts+=( "$(printf 'Panics: %d' "$(wc -l <<<"${panic_lines}")")" )
   echo "$(wc -l <<<"${panic_lines}") lines of panic" >&2
 fi
 if error_lines=$(grep '^error: ' <<<"${filtered_out}"); then
-  error_descriptions=${error_lines//error: *([^:]):*([0-9]):*([0-9]): }
+  # shellcheck disable=SC2001 # The sed version is (hours!) faster than native Bash string manipulation.
+  error_descriptions=$(sed 's/^error: [^:]*:[0-9]*:[0-9]*: //' <<<"${error_lines}")
   counts+=( "$(printf 'Errors: %d' "$(wc -l <<<"${error_lines}")")" )
   echo "$(wc -l <<<"${error_lines}") lines of errors" >&2
 fi
 if warning_lines=$(grep '^warning: ' <<<"${filtered_out}"); then
-  warning_descriptions=${warning_lines//warning: *([^:]):*([0-9]):*([0-9]): }
+  # shellcheck disable=SC2001 # The sed version is (hours!) faster than native Bash string manipulation.
+  warning_descriptions=$(sed 's/^warning: [^:]*:[0-9]*:[0-9]*: //' <<<"${warning_lines}")
   counts+=( "$(printf 'Warnings: %d' "$(wc -l <<<"${warning_lines}")")" )
   echo "$(wc -l <<<"${warning_lines}") lines of warnings" >&2
 fi
 if info_lines=$(grep '^info: ' <<<"${filtered_out}" | grep -v 'PANIC at '); then
-  info_descriptions=${info_lines//info: *([^:]):*([0-9]):*([0-9]): }
+  # shellcheck disable=SC2001 # The sed version is (hours!) faster than native Bash string manipulation.
+  info_descriptions=$(sed 's/^info: [^:]*:[0-9]*:[0-9]*: //' <<<"${info_lines}")
   counts+=( "$(printf 'Info messages: %d' "$(wc -l <<<"${info_lines}")")" )
   echo "$(wc -l <<<"${info_lines}") lines of info" >&2
 fi


### PR DESCRIPTION
Processing these log lines through `sed` seems to go much faster (minutes rather than hours). Verified on my own machine by running `lake build > build_log.txt; ./scripts/zulip_build_report.sh build-log.txt`. Shellcheck prefers Bash string manipulation, so we silence those lints.

Timing differences on an example build log:
* on `master`: 33s
* on this branch: 0.01s


---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include at least one commit authored by each
co-author among the commits in the pull request. If necessary, you may 
create empty commits to indicate co-authorship, using commands like so:

git commit --author="Author Name <author@email.com>" --allow-empty -m "add Author Name as coauthor"

When merging, all the commits will be squashed into a single commit listing all co-authors.

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
