### PR TITLE
[Merged by Bors] - CI: run a weekly linter workflow

### DIFF
--- a/.github/workflows/weekly-lints.yml
+++ b/.github/workflows/weekly-lints.yml
@@ -1,0 +1,94 @@
+name: Weekly linting report
+
+on:
+  schedule:
+    - cron: '0 5 * * 1'  # Run at 05:00 UTC every Monday
+  workflow_dispatch:
+
+env:
+  TOP_MODULE: Mathlib
+
+jobs:
+  weekly-lints:
+    name: Build
+    runs-on: pr
+    if: github.repository == 'leanprover-community/mathlib4'
+    steps:
+    - name: cleanup
+      run: |
+        find . -name . -o -prune -exec rm -rf -- {} +
+        # Delete all but the 5 most recent toolchains.
+        # Make sure to delete both the `~/.elan/toolchains/X` directory and the `~/.elan/update-hashes/X` file.
+        # Skip symbolic links (`-type d`), the current directory (`! -name .`), and `nightly` and `stable`.
+        if cd ~/.elan/toolchains && find . -maxdepth 1 -type d ! -name . -print0 | xargs -0 ls -1td | grep -v 'nightly$' | grep -v 'stable$' | tail -n +6 | xargs -I {} sh -c 'echo {} && rm -rf "{}" && rm "../update-hashes/{}"'; then
+            : # Do nothing on success
+        else
+            : # Do nothing on failure, but suppress errors
+        fi
+
+    - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+      with:
+        ref: master
+
+    - name: Configure Lean
+      uses: leanprover/lean-action@f807b338d95de7813c5c50d018f1c23c9b93b4ec # 2025-04-24
+      with:
+        auto-config: false
+        use-github-cache: false
+        use-mathlib-cache: false
+        reinstall-transient-toolchain: true
+
+    - name: add weekly linting option
+      run: |
+        # Reset contents of the lakefile, so we don't leave the wrong options enabled.
+        git checkout HEAD -- lakefile.lean
+
+        # we disable checking for backticks inside single quotes with the next line
+        # shellcheck disable=SC2016
+        # Enable the linter
+        sed -i -- '/^  -- '\`'latest_import.yml'\`' uses this comment/{s=^=  ⟨`linter.weeklyLintSet, true⟩,\n=}' lakefile.lean
+
+        # stage the changes in git so that `git diff` can confirm what changed
+        git add -u
+        git diff HEAD #lakefile.lean
+
+        printf $'\n\nRunning a test %slake build` to verify, for instance, the absence of import loops\n' $'`'
+        lake build Mathlib.Init
+
+    - name: Add GitHub problem matcher wrapper
+      uses: leanprover-community/gh-problem-matcher-wrap@20007cb926a46aa324653a387363b52f07709845 # 2025-04-23
+      with:
+        action: add
+        linters: lean
+
+    - name: build mathlib
+      id: build
+      continue-on-error: true
+      run: |
+        # Use a temporary file to ensure we don't overflow max variable size.
+        lean_outfile=$(mktemp)
+        # Show the stdout in the GitHub build logs, while we process it from the file.
+        (lake build || true) | tee "${lean_outfile}"
+
+        # Process output for posting to Zulip
+        SHA=${{ github.sha }} \
+        REPO=${{ github.repository }} \
+        RUN_ID=${{ github.run_id }} \
+          ./scripts/zulip_build_report.sh "${lean_outfile}" > "${GITHUB_OUTPUT}"
+
+    - name: Remove GitHub problem matcher wrapper
+      uses: leanprover-community/gh-problem-matcher-wrap@20007cb926a46aa324653a387363b52f07709845 # 2025-04-23
+      with:
+        action: remove
+        linters: lean
+
+    - name: Post output to Zulip
+      uses: zulip/github-actions-zulip/send-message@e4c8f27c732ba9bd98ac6be0583096dea82feea5 # v1.0.2
+      with:
+        api-key: ${{ secrets.ZULIP_API_KEY }}
+        email: 'github-mathlib4-bot@leanprover.zulipchat.com'
+        organization-url: 'https://leanprover.zulipchat.com'
+        to: 'mathlib4'
+        type: 'stream'
+        topic: Weekly linting log
+        content: ${{ steps.build.outputs.zulip-message }}

--- a/Mathlib/Init.lean
+++ b/Mathlib/Init.lean
@@ -91,6 +91,11 @@ register_linter_set linter.nightlyRegressionSet :=
   linter.tacticAnalysis.regressions.omegaToCutsat
   linter.tacticAnalysis.regressions.ringToGrind
 
+/-- Define a set of linters that run once a week and get posted to Zulip.
+-/
+register_linter_set linter.weeklyLintSet :=
+  linter.tacticAnalysis.mergeWithGrind
+
 -- Check that all linter options mentioned in the mathlib standard linter set exist.
 open Lean Elab.Command Linter Mathlib.Linter Mathlib.Linter.Style
 
@@ -103,7 +108,9 @@ run_cmd liftTermElabM do
     throwError m!"'linter.mathlibStandardSet' is not defined."
   let some (_, nrLinters) := ls.find? (·.1 == ``linter.nightlyRegressionSet) |
     throwError m!"'linter.nightlyRegressionSet is not defined."
-  for mll in mlLinters ∪ nrLinters do
+  let some (_, wlLinters) := ls.find? (·.1 == ``linter.weeklyLintSet) |
+    throwError m!"'linter.weeklyLintSet is not defined."
+  for mll in mlLinters ∪ nrLinters ∪ wlLinters do
     let [(mlRes, _)] ← realizeGlobalName mll |
       if !DefinedInScripts.contains mll then
         throwError "Unknown option '{mll}'!"


### PR DESCRIPTION
This PR adds a workflow analogous to the nightly regression lints, that reports possible refactors using the tactic analysis framework. Those would be too noisy or take too much time to run in regular CI.

As a first linter, we have the `mergeWithGrind` linter that reports when a sequence of tactics followed by `grind` can become just `grind`.

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include at least one commit authored by each
co-author among the commits in the pull request. If necessary, you may 
create empty commits to indicate co-authorship, using commands like so:

git commit --author="Author Name <author@email.com>" --allow-empty -m "add Author Name as coauthor"

When merging, all the commits will be squashed into a single commit listing all co-authors.

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
