### PR TITLE
[Merged by Bors] - chore: `abel_nf` bug

### DIFF
--- a/Mathlib/Tactic/Abel.lean
+++ b/Mathlib/Tactic/Abel.lean
@@ -398,6 +398,29 @@ partial def eval (e : Expr) : M (NormalExpr × Expr) := do
       evalAtom e
   | _ => evalAtom e
 
+/-- Determine whether `e` will be handled as an atom by the `abel` tactic. The `match` in this
+function should be preserved to be parallel in case-matching to that in the
+`Mathlib.Tactic.Abel.eval` metaprogram. -/
+def isAtom (e : Expr) : Bool :=
+  match e.getAppFnArgs with
+  | (``HAdd.hAdd, #[_, _, _, _, _, _])
+  | (``HSub.hSub, #[_, _, _, _, _, _])
+  | (``Neg.neg, #[_, _, _])
+  | (``AddMonoid.nsmul, #[_, _, _, _])
+  | (``SubNegMonoid.zsmul, #[_, _, _, _])
+  | (``SMul.smul, #[.const ``Int _, _, _, _, _])
+  | (``SMul.smul, #[.const ``Nat _, _, _, _, _])
+  | (``HSMul.hSMul, #[.const ``Int _, _, _, _, _, _])
+  | (``HSMul.hSMul, #[.const ``Nat _, _, _, _, _, _])
+  | (``smul, #[_, _, _, _])
+  | (``smulg, #[_, _, _, _]) => false
+  /- The `OfNat.ofNat` and `Zero.zero` cases are deliberately omitted here: these two cases are not
+  strictly atoms for `abel`, but they are atom-like in that their handling by
+  `Mathlib.Tactic.Abel.eval` contains no recursive call. -/
+  -- | (``OfNat.ofNat, #[_, .lit (.natVal 0), _])
+  -- | (``Zero.zero, #[_, _])
+  | _ => true
+
 @[tactic_alt abel]
 elab (name := abel1) "abel1" tk:"!"? : tactic => withMainContext do
   let tm := if tk.isSome then .default else .reducible
@@ -466,8 +489,8 @@ It differs in
 def evalExpr (e : Expr) : AtomM Simp.Result := do
   let e ← withReducible <| whnf e
   guard e.isApp -- all interesting group expressions are applications
+  guard !(isAtom e)
   let (a, pa) ← eval e (← mkContext e)
-  guard !a.isAtom
   return { expr := a, proof? := pa }
 
 open Parser.Tactic

--- a/Mathlib/Tactic/Abel.lean
+++ b/Mathlib/Tactic/Abel.lean
@@ -488,7 +488,6 @@ It differs in
 -/
 def evalExpr (e : Expr) : AtomM Simp.Result := do
   let e ← withReducible <| whnf e
-  guard e.isApp -- all interesting group expressions are applications
   guard !(isAtom e)
   let (a, pa) ← eval e (← mkContext e)
   return { expr := a, proof? := pa }

--- a/MathlibTest/abel.lean
+++ b/MathlibTest/abel.lean
@@ -110,6 +110,7 @@ example [AddCommGroup α] (x y z : α) (h : False) (w : x - x = y + z) : False :
   guard_hyp w : 0 = y + z
   assumption
 
+-- regression test for the issue fixed in PR #29778
 example [AddCommGroup α] {a b : α} {P : α → Prop} (h : P a) : P (a - b + b) := by
   abel_nf
   guard_target = P a

--- a/MathlibTest/abel.lean
+++ b/MathlibTest/abel.lean
@@ -110,6 +110,11 @@ example [AddCommGroup α] (x y z : α) (h : False) (w : x - x = y + z) : False :
   guard_hyp w : 0 = y + z
   assumption
 
+example [AddCommGroup α] {a b : α} {P : α → Prop} (h : P a) : P (a - b + b) := by
+  abel_nf
+  guard_target = P a
+  exact h
+
 /-
 Test that when `abel_nf` is run at multiple locations, it uses the same atom ordering in each
 location.


### PR DESCRIPTION
Fix the bug reported at https://leanprover.zulipchat.com/#narrow/channel/287929-mathlib4/topic/abel_nf.20bug/with/540086130.

Context: when `abel_nf` runs on a statement `e`, it is supposed to run abelian-group-normalization only on subexpressions of `e` which would not be treated as atoms by the normalization algorithm.  For example, in the statement `log (sin (x + y + y)) + log (sin (y + x + y)) = z` the normalization should be run
- on `x + y + y` => `x + 2y`
- on `y + x + y` => `x + 2y`
- on `log (sin (x + 2y)) + log (sin (x + 2y))` =>  `2 log (sin (x + 2y))`

but not on `x`, `y`, `z`, `sin (x + 2y)`, `log (sin (x + 2y))` or `2 log (sin (x + 2y)) = z`. This saves work, and also keeps the table of atoms smaller (e.g. in the above example `z`, `sin (x + 2y)` and `2 log (sin (x + 2y)) = z` never join the atoms table since they never appear as atomic subexpressions of abelian-group expressions).

The issue fixed in this PR was that the atoms check was logically incorrect: instead of testing whether a subexpression `t` was non-atomic *before* normalizing it, we tested -- *after* normalizing it! -- whether its normalized form `t'` was non-atomic.

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include at least one commit authored by each
co-author among the commits in the pull request. If necessary, you may 
create empty commits to indicate co-authorship, using commands like so:

git commit --author="Author Name <author@email.com>" --allow-empty -m "add Author Name as coauthor"

When merging, all the commits will be squashed into a single commit listing all co-authors.

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
