### PR TITLE
[Merged by Bors] - feat(Tactic/Ring): handle `ℤ`-scalar multiplication in the ring tactic

### DIFF
--- a/Mathlib/Tactic/Ring/Basic.lean
+++ b/Mathlib/Tactic/Ring/Basic.lean
@@ -88,11 +88,20 @@ open Lean (MetaM Expr mkRawNatLit)
 /-- A shortcut instance for `CommSemiring ℕ` used by ring. -/
 def instCommSemiringNat : CommSemiring ℕ := inferInstance
 
+/-- A shortcut instance for `CommSemiring ℤ` used by ring. -/
+def instCommSemiringInt : CommSemiring ℤ := inferInstance
+
 /--
 A typed expression of type `CommSemiring ℕ` used when we are working on
 ring subexpressions of type `ℕ`.
 -/
 def sℕ : Q(CommSemiring ℕ) := q(instCommSemiringNat)
+
+/--
+A typed expression of type `CommSemiring ℤ` used when we are working on
+ring subexpressions of type `ℤ`.
+-/
+def sℤ : Q(CommSemiring ℤ) := q(instCommSemiringInt)
 
 mutual
 
@@ -312,6 +321,8 @@ inductive Overlap (e : Q($α)) where
 
 variable {a a' a₁ a₂ a₃ b b' b₁ b₂ b₃ c c₁ c₂ : R}
 
+/-! ### Addition -/
+
 theorem add_overlap_pf (x : R) (e) (pq_pf : a + b = c) :
     x ^ e * a + x ^ e * b = x ^ e * c := by subst_vars; simp [mul_add]
 
@@ -397,6 +408,8 @@ partial def evalAdd {a b : Q($α)} (va : ExSum sα a) (vb : ExSum sα b) :
       else
         let ⟨_c, vc, (pc : Q($a₁ + $_a₂ + $_b₂ = $_c))⟩ ← evalAdd va vb₂
         return ⟨_, .add vb₁ vc, q(add_pf_add_gt $b₁ $pc)⟩
+
+/-! ### Multiplication -/
 
 theorem one_mul (a : R) : (nat_lit 1).rawCast * a = a := by simp [Nat.rawCast]
 
@@ -498,6 +511,8 @@ def evalMul {a b : Q($α)} (va : ExSum sα a) (vb : ExSum sα b) :
     let ⟨_, vd, pd⟩ ← evalAdd sα vc₁ vc₂
     return ⟨_, vd, q(add_mul $pc₁ $pc₂ $pd)⟩
 
+/-! ### Scalar multiplication by `ℕ` -/
+
 theorem natCast_nat (n) : ((Nat.rawCast n : ℕ) : R) = Nat.rawCast n := by simp
 
 theorem natCast_mul {a₁ a₃ : ℕ} (a₂) (_ : ((a₁ : ℕ) : R) = b₁)
@@ -579,6 +594,111 @@ def evalNSMul {a : Q(ℕ)} {b : Q($α)} (va : ExSum sℕ a) (vb : ExSum sα b) :
     let ⟨_, vc, pc⟩ ← evalMul sα va' vb
     pure ⟨_, vc, (q(smul_eq_cast $pa' $pc) : Expr)⟩
 
+/-! ### Scalar multiplication by `ℤ` -/
+
+theorem natCast_int {R} [Ring R] (n) : ((Nat.rawCast n : ℤ) : R) = Nat.rawCast n := by simp
+
+theorem intCast_negOfNat_Int {R} [Ring R] (n) :
+    ((Int.rawCast (Int.negOfNat n) : ℤ) : R) = Int.rawCast (Int.negOfNat n) := by simp
+
+theorem intCast_mul {R} [Ring R] {b₁ b₃ : R} {a₁ a₃ : ℤ} (a₂) (_ : ((a₁ : ℤ) : R) = b₁)
+    (_ : ((a₃ : ℤ) : R) = b₃) : ((a₁ ^ a₂ * a₃ : ℤ) : R) = b₁ ^ a₂ * b₃ := by
+  subst_vars; simp
+
+theorem intCast_zero {R} [Ring R] : ((0 : ℤ) : R) = 0 := Int.cast_zero
+
+theorem intCast_add {R} [Ring R] {b₁ b₂ : R} {a₁ a₂ : ℤ}
+    (_ : ((a₁ : ℤ) : R) = b₁) (_ : ((a₂ : ℤ) : R) = b₂) : ((a₁ + a₂ : ℤ) : R) = b₁ + b₂ := by
+  subst_vars; simp
+
+mutual
+
+/-- Applies `Int.cast` to an int polynomial to produce a polynomial in `α`.
+
+* An atom `e` causes `↑e` to be allocated as a new atom.
+* A sum delegates to `ExSum.evalIntCast`.
+-/
+partial def ExBase.evalIntCast {a : Q(ℤ)} (rα : Q(Ring $α)) (va : ExBase sℤ a) :
+    AtomM (Result (ExBase sα) q($a)) :=
+  match va with
+  | .atom _ => do
+    let (i, ⟨b', _⟩) ← addAtomQ q($a)
+    pure ⟨b', ExBase.atom i, q(Eq.refl $b')⟩
+  | .sum va => do
+    let ⟨_, vc, p⟩ ← va.evalIntCast rα
+    pure ⟨_, .sum vc, p⟩
+
+
+/-- Applies `Int.cast` to an int monomial to produce a monomial in `α`.
+
+* `↑c = c` if `c` is a numeric literal
+* `↑(a ^ n * b) = ↑a ^ n * ↑b`
+-/
+partial def ExProd.evalIntCast {a : Q(ℤ)} (rα : Q(Ring $α)) (va : ExProd sℤ a) :
+    AtomM (Result (ExProd sα) q($a)) :=
+  match va with
+  | .const c hc => do
+    match a with
+    | ~q(Nat.rawCast $m) =>
+      pure ⟨q(Nat.rawCast $m), .const c hc, q(natCast_int (R := $α) $m)⟩
+    | ~q(Int.rawCast (Int.negOfNat $m)) =>
+      pure ⟨q(Int.rawCast (Int.negOfNat $m)), .const c hc, q(intCast_negOfNat_Int (R := $α) $m)⟩
+  | .mul (e := a₂) va₁ va₂ va₃ => do
+    let ⟨_, vb₁, pb₁⟩ ← va₁.evalIntCast rα
+    let ⟨_, vb₃, pb₃⟩ ← va₃.evalIntCast rα
+    -- Qq is probably unhappy about `Ring` and `CommSemiring` at the same time.
+    let pf ← mkAppM ``intCast_mul #[a₂, pb₁, pb₃]
+    pure ⟨_, .mul vb₁ va₂ vb₃, pf⟩
+
+/-- Applies `Int.cast` to an int polynomial to produce a polynomial in `α`.
+
+* `↑0 = 0`
+* `↑(a + b) = ↑a + ↑b`
+-/
+partial def ExSum.evalIntCast {a : Q(ℤ)} (rα : Q(Ring $α)) (va : ExSum sℤ a) :
+    AtomM (Result (ExSum sα) q($a)) :=
+  match va with
+  | .zero => do
+    -- Qq is probably unhappy about `Ring` and `CommSemiring` at the same time.
+    let pf ← mkAppOptM ``intCast_zero #[α, none]
+    pure ⟨_, .zero, pf⟩
+  | .add va₁ va₂ => do
+    let ⟨_, vb₁, pb₁⟩ ← va₁.evalIntCast rα
+    let ⟨_, vb₂, pb₂⟩ ← va₂.evalIntCast rα
+    -- Qq is probably unhappy about `Ring` and `CommSemiring` at the same time.
+    let pf ← mkAppM ``intCast_add #[pb₁, pb₂]
+    pure ⟨_, .add vb₁ vb₂, pf⟩
+
+end
+
+theorem smul_int {a b c : ℤ} (_ : (a * b : ℤ) = c) : a • b = c := by subst_vars; simp
+
+theorem smul_eq_intCast {R} [Ring R] {a' b c : R} {a : ℤ} (_ : ((a : ℤ) : R) = a')
+    (_ : a' * b = c) : a • b = c := by
+  subst_vars; simp
+
+/-- Constructs the scalar multiplication `n • a`, where both `n : ℤ` and `a : α` are normalized
+polynomial expressions.
+
+* `a • b = a * b` if `α = ℤ`
+* `a • b = ↑a * b` otherwise
+-/
+def evalZSMul {a : Q(ℤ)} {b : Q($α)} (rα : Q(Ring $α)) (va : ExSum sℤ a) (vb : ExSum sα b) :
+    AtomM (Result (ExSum sα) q($a • $b)) := do
+  if ← isDefEq sα sℤ then
+    let ⟨_, va'⟩ := va.cast
+    have _b : Q(ℤ) := b
+    let ⟨(_c : Q(ℤ)), vc, (pc : Q($a * $_b = $_c))⟩ ← evalMul sα va' vb
+    pure ⟨_, vc, (q(smul_int $pc) : Expr)⟩
+  else
+    let ⟨_, va', pa'⟩ ← va.evalIntCast sα rα
+    let ⟨_, vc, pc⟩ ← evalMul sα va' vb
+    -- Qq is probably unhappy about `Ring` and `CommSemiring` at the same time.
+    let pf ← mkAppM ``smul_eq_intCast #[pa', pc]
+    pure ⟨_, vc, pf⟩
+
+/-! ### Negation -/
+
 theorem neg_one_mul {R} [Ring R] {a b : R} (_ : (Int.negOfNat (nat_lit 1)).rawCast * a = b) :
     -a = b := by subst_vars; simp [Int.negOfNat]
 
@@ -628,6 +748,8 @@ def evalNeg {a : Q($α)} (rα : Q(Ring $α)) (va : ExSum sα a) :
     let ⟨_, vb₂, pb₂⟩ ← evalNeg rα va₂
     return ⟨_, .add vb₁ vb₂, (q(neg_add $pb₁ $pb₂) : Expr)⟩
 
+/-! ### Subtraction -/
+
 theorem sub_pf {R} [Ring R] {a b c d : R}
     (_ : -b = c) (_ : a + c = d) : a - b = d := by subst_vars; simp [sub_eq_add_neg]
 
@@ -641,6 +763,8 @@ def evalSub {α : Q(Type u)} (sα : Q(CommSemiring $α)) {a b : Q($α)}
   let ⟨_c, vc, pc⟩ ← evalNeg sα rα vb
   let ⟨d, vd, (pd : Q($a + $_c = $d))⟩ ← evalAdd sα va vc
   return ⟨d, vd, (q(sub_pf $pc $pd) : Expr)⟩
+
+/-! ### Exponentiation -/
 
 theorem pow_prod_atom (a : R) (b) : a ^ b = (a + 0) ^ b * (nat_lit 1).rawCast := by simp
 
@@ -1064,6 +1188,11 @@ theorem nsmul_congr {a a' : ℕ} (_ : (a : ℕ) = a') (_ : b = b') (_ : a' • b
     (a • (b : R)) = c := by
   subst_vars; rfl
 
+theorem zsmul_congr {R} [Ring R] {b b' c : R} {a a' : ℤ} (_ : (a : ℤ) = a') (_ : b = b')
+    (_ : a' • b' = c) :
+    (a • (b : R)) = c := by
+  subst_vars; rfl
+
 theorem pow_congr {b b' : ℕ} (_ : a = a') (_ : b = b')
     (_ : a' ^ b' = c) : (a ^ b : R) = c := by subst_vars; rfl
 
@@ -1081,6 +1210,10 @@ theorem div_congr {R} [DivisionSemiring R] {a a' b b' c : R} (_ : a = a') (_ : b
 
 /-- A precomputed `Cache` for `ℕ`. -/
 def Cache.nat : Cache sℕ := { rα := none, dsα := none, czα := some q(inferInstance) }
+
+/-- A precomputed `Cache` for `ℤ`. -/
+def Cache.int : Cache sℤ :=
+  { rα := some q(inferInstance), dsα := none, czα := some q(inferInstance) }
 
 /-- Checks whether `e` would be processed by `eval` as a ring expression,
 or otherwise if it is an atom or something simplifiable via `norm_num`.
@@ -1136,13 +1269,21 @@ partial def eval {u : Lean.Level} {α : Q(Type u)} (sα : Q(CommSemiring $α))
       let ⟨c, vc, p⟩ ← evalMul sα va vb
       pure ⟨c, vc, q(mul_congr $pa $pb $p)⟩
     | _ => els
-  | ``HSMul.hSMul, _, _ => match e with
-    | ~q(($a : ℕ) • ($b : «$α»)) =>
+  | ``HSMul.hSMul, rα, _ => match e, rα with
+    | ~q(($a : ℕ) • ($b : «$α»)), _ =>
       let ⟨_, va, pa⟩ ← eval sℕ .nat a
       let ⟨_, vb, pb⟩ ← eval sα c b
       let ⟨c, vc, p⟩ ← evalNSMul sα va vb
       pure ⟨c, vc, q(nsmul_congr $pa $pb $p)⟩
-    | _ => els
+    | ~q(@HSMul.hSMul ℤ _ _ $i $a $b), some rα =>
+      let b : Q($α) := b
+      let ⟨_, va, pa⟩ ← eval sℤ .int a
+      let ⟨_, vb, pb⟩ ← eval sα c b
+      let ⟨c, vc, p⟩ ← evalZSMul sα rα va vb
+      -- Qq is probably unhappy about `Ring` and `CommSemiring` at the same time.
+      let pf ← mkAppM ``zsmul_congr #[pa, pb, p]
+      pure ⟨c, vc, pf⟩
+    | _, _ => els
   | ``HPow.hPow, _, _ | ``Pow.pow, _, _ => match e with
     | ~q($a ^ $b) =>
       let ⟨_, va, pa⟩ ← eval sα c a

--- a/Mathlib/Tactic/Ring/Basic.lean
+++ b/Mathlib/Tactic/Ring/Basic.lean
@@ -681,7 +681,7 @@ theorem smul_eq_intCast {R} [Ring R] {a' b c : R} {a : ℤ} (_ : ((a : ℤ) : R)
 polynomial expressions.
 
 * `a • b = a * b` if `α = ℤ`
-* `a • b = ↑a * b` otherwise
+* `a • b = a' * b` otherwise, where `a'` is `↑a` with the coercion pushed as deep as possible.
 -/
 def evalZSMul {a : Q(ℤ)} {b : Q($α)} (rα : Q(Ring $α)) (va : ExSum sℤ a) (vb : ExSum sα b) :
     AtomM (Result (ExSum sα) q($a • $b)) := do

--- a/Mathlib/Topology/Category/Profinite/Nobeling/Span.lean
+++ b/Mathlib/Topology/Category/Profinite/Nobeling/Span.lean
@@ -4,6 +4,7 @@ Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Dagur Asgeirsson
 -/
 import Mathlib.Data.Finset.Sort
+import Mathlib.Tactic.NoncommRing
 import Mathlib.Topology.Category.Profinite.CofilteredLimit
 import Mathlib.Topology.Category.Profinite.Nobeling.Basic
 
@@ -197,11 +198,11 @@ theorem GoodProducts.spanFin [WellFoundedLT I] :
     split_ifs
     · rw [hmap]
       exact finsuppSum_mem_span_eval _ _ ha hc
-    · ring_nf
+    · noncomm_ring
+      -- we use `noncomm_ring` even though this is a commutative ring, because we want a weaker
+      -- normalization which preserves multiplication order (i.e. doesn't use commutativity rules)
       rw [hmap]
       apply Submodule.add_mem
-      · apply Submodule.neg_mem
-        exact finsuppSum_mem_span_eval _ _ ha hc
       · apply Submodule.finsuppSum_mem
         intro m hm
         apply Submodule.smul_mem
@@ -217,6 +218,8 @@ theorem GoodProducts.spanFin [WellFoundedLT I] :
           apply le_of_lt
           rw [List.chain'_cons_cons] at ha
           exact (List.lt_iff_lex_lt _ _).mp (List.Lex.rel ha.1)
+      · apply Submodule.smul_mem
+        exact finsuppSum_mem_span_eval _ _ ha hc
 
 end Fin
 

--- a/MathlibTest/ring.lean
+++ b/MathlibTest/ring.lean
@@ -50,9 +50,9 @@ example {α} [CommRing α] (a b c d e : α) :
   (-(a * b) + c + d) * e = (c + (d + -a * b)) * e := by ring
 example (a n s : ℕ) : a * (n - s) = (n - s) * a := by ring
 
-example {α} [CommRing α] (x : α) : (2:ℕ) • x = x + x := by ring
-example {α} [CommRing α] (x : α) : (2:ℤ) • x = x + x := by ring
-example {α} [CommRing α] (x : α) : (-2:ℤ) • x = -x - x := by ring
+example {α} [CommRing α] (x : α) : (2 : ℕ) • x = x + x := by ring
+example {α} [CommRing α] (x : α) : (2 : ℤ) • x = x + x := by ring
+example {α} [CommRing α] (x : α) : (-2 : ℤ) • x = -x - x := by ring
 
 section Rat
 

--- a/MathlibTest/ring.lean
+++ b/MathlibTest/ring.lean
@@ -50,6 +50,10 @@ example {α} [CommRing α] (a b c d e : α) :
   (-(a * b) + c + d) * e = (c + (d + -a * b)) * e := by ring
 example (a n s : ℕ) : a * (n - s) = (n - s) * a := by ring
 
+example {α} [CommRing α] (x : α) : (2:ℕ) • x = x + x := by ring
+example {α} [CommRing α] (x : α) : (2:ℤ) • x = x + x := by ring
+example {α} [CommRing α] (x : α) : (-2:ℤ) • x = -x - x := by ring
+
 section Rat
 
 variable [Field α]


### PR DESCRIPTION
`ring` handles ℕ-scalar multiplication; it seems like an accidental omission that it doesn't handle ℤ-scalar multiplication. This PR adds that feature. Everything is directly adapted from the ℕ case.

A notable use case for this feature: often `abel_nf` output contains ℤ-scalar multiplication, so it's important that this can be handled if needed in subsequent `ring` calls.

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include at least one commit authored by each
co-author among the commits in the pull request. If necessary, you may 
create empty commits to indicate co-authorship, using commands like so:

git commit --author="Author Name <author@email.com>" --allow-empty -m "add Author Name as coauthor"

When merging, all the commits will be squashed into a single commit listing all co-authors.

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
