### PR TITLE
[Merged by Bors] - feat(Data/Matrix): add `vecMul_fromRows` and `fromCols_mulVec`

### DIFF
--- a/Mathlib/Data/Matrix/ColumnRowPartitioned.lean
+++ b/Mathlib/Data/Matrix/ColumnRowPartitioned.lean
@@ -196,8 +196,7 @@ lemma sumElim_vecMul_fromRows [Fintype m₁] [Fintype m₂] (B₁ : Matrix m₁ 
 lemma vecMul_fromRows [Fintype m₁] [Fintype m₂]
     (B₁ : Matrix m₁ n R) (B₂ : Matrix m₂ n R) (v : m₁ ⊕ m₂ → R) :
     v ᵥ* fromRows B₁ B₂ = v ∘ Sum.inl ᵥ* B₁ + v ∘ Sum.inr ᵥ* B₂ := by
-  rw [← Sum.elim_comp_inl_inr v, sumElim_vecMul_fromRows]
-  simp
+  simp [← sumElim_vecMul_fromRows]
 
 @[simp]
 lemma fromCols_mulVec_sumElim [Fintype n₁] [Fintype n₂]
@@ -209,8 +208,7 @@ lemma fromCols_mulVec_sumElim [Fintype n₁] [Fintype n₂]
 lemma fromCols_mulVec [Fintype n₁] [Fintype n₂]
     (A₁ : Matrix m n₁ R) (A₂ : Matrix m n₂ R) (v : n₁ ⊕ n₂ → R) :
     fromCols A₁ A₂ *ᵥ v = A₁ *ᵥ v ∘ Sum.inl + A₂ *ᵥ v ∘ Sum.inr := by
-  rw [← Sum.elim_comp_inl_inr v, fromCols_mulVec_sumElim]
-  simp
+  simp [← fromCols_mulVec_sumElim]
 
 @[simp]
 lemma fromRows_mul [Fintype n] (A₁ : Matrix m₁ n R) (A₂ : Matrix m₂ n R) (B : Matrix n m R) :

--- a/Mathlib/Data/Matrix/ColumnRowPartitioned.lean
+++ b/Mathlib/Data/Matrix/ColumnRowPartitioned.lean
@@ -193,12 +193,24 @@ lemma sumElim_vecMul_fromRows [Fintype m₁] [Fintype m₂] (B₁ : Matrix m₁ 
   ext
   simp [Matrix.vecMul, fromRows, dotProduct]
 
+lemma vecMul_fromRows [Fintype m₁] [Fintype m₂]
+    (B₁ : Matrix m₁ n R) (B₂ : Matrix m₂ n R) (v : m₁ ⊕ m₂ → R) :
+    v ᵥ* fromRows B₁ B₂ = v ∘ Sum.inl ᵥ* B₁ + v ∘ Sum.inr ᵥ* B₂ := by
+  rw [← Sum.elim_comp_inl_inr v, sumElim_vecMul_fromRows]
+  simp
+
 @[simp]
 lemma fromCols_mulVec_sumElim [Fintype n₁] [Fintype n₂]
     (A₁ : Matrix m n₁ R) (A₂ : Matrix m n₂ R) (v₁ : n₁ → R) (v₂ : n₂ → R) :
     fromCols A₁ A₂ *ᵥ Sum.elim v₁ v₂ = A₁ *ᵥ v₁ + A₂ *ᵥ v₂ := by
   ext
   simp [Matrix.mulVec, fromCols]
+
+lemma fromCols_mulVec [Fintype n₁] [Fintype n₂]
+    (A₁ : Matrix m n₁ R) (A₂ : Matrix m n₂ R) (v : n₁ ⊕ n₂ → R) :
+    fromCols A₁ A₂ *ᵥ v = A₁ *ᵥ v ∘ Sum.inl + A₂ *ᵥ v ∘ Sum.inr := by
+  rw [← Sum.elim_comp_inl_inr v, fromCols_mulVec_sumElim]
+  simp
 
 @[simp]
 lemma fromRows_mul [Fintype n] (A₁ : Matrix m₁ n R) (A₂ : Matrix m₂ n R) (B : Matrix n m R) :

--- a/Mathlib/Data/Matrix/ColumnRowPartitioned.lean
+++ b/Mathlib/Data/Matrix/ColumnRowPartitioned.lean
@@ -186,25 +186,25 @@ lemma vecMul_fromCols [Fintype m] (B₁ : Matrix m n₁ R) (B₂ : Matrix m n₂
     v ᵥ* fromCols B₁ B₂ = Sum.elim (v ᵥ* B₁) (v ᵥ* B₂) := by
   ext (_ | _) <;> rfl
 
-@[simp]
 lemma sumElim_vecMul_fromRows [Fintype m₁] [Fintype m₂] (B₁ : Matrix m₁ n R) (B₂ : Matrix m₂ n R)
     (v₁ : m₁ → R) (v₂ : m₂ → R) :
     Sum.elim v₁ v₂ ᵥ* fromRows B₁ B₂ = v₁ ᵥ* B₁ + v₂ ᵥ* B₂ := by
   ext
   simp [Matrix.vecMul, fromRows, dotProduct]
 
+@[simp]
 lemma vecMul_fromRows [Fintype m₁] [Fintype m₂]
     (B₁ : Matrix m₁ n R) (B₂ : Matrix m₂ n R) (v : m₁ ⊕ m₂ → R) :
     v ᵥ* fromRows B₁ B₂ = v ∘ Sum.inl ᵥ* B₁ + v ∘ Sum.inr ᵥ* B₂ := by
   simp [← sumElim_vecMul_fromRows]
 
-@[simp]
 lemma fromCols_mulVec_sumElim [Fintype n₁] [Fintype n₂]
     (A₁ : Matrix m n₁ R) (A₂ : Matrix m n₂ R) (v₁ : n₁ → R) (v₂ : n₂ → R) :
     fromCols A₁ A₂ *ᵥ Sum.elim v₁ v₂ = A₁ *ᵥ v₁ + A₂ *ᵥ v₂ := by
   ext
   simp [Matrix.mulVec, fromCols]
 
+@[simp]
 lemma fromCols_mulVec [Fintype n₁] [Fintype n₂]
     (A₁ : Matrix m n₁ R) (A₂ : Matrix m n₂ R) (v : n₁ ⊕ n₂ → R) :
     fromCols A₁ A₂ *ᵥ v = A₁ *ᵥ v ∘ Sum.inl + A₂ *ᵥ v ∘ Sum.inr := by


### PR DESCRIPTION
We have [`Matrix.fromBlocks_mulVec`](https://leanprover-community.github.io/mathlib4_docs/Mathlib/Data/Matrix/Block.html#Matrix.fromBlocks_mulVec) and [`Matrix.vecMul_fromBlocks`](https://leanprover-community.github.io/mathlib4_docs/Mathlib/Data/Matrix/Block.html#Matrix.vecMul_fromBlocks) but not the `fromRows`/`fromCols` version. I find those helpful in #27414.

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include at least one commit authored by each
co-author among the commits in the pull request. If necessary, you may 
create empty commits to indicate co-authorship, using commands like so:

git commit --author="Author Name <author@email.com>" --allow-empty -m "add Author Name as coauthor"

When merging, all the commits will be squashed into a single commit listing all co-authors.

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
