### PR TITLE
[Merged by Bors] - chore(*): drop some `Decidable`/`Fintype` assumptions

### DIFF
--- a/Mathlib/Algebra/GroupWithZero/ProdHom.lean
+++ b/Mathlib/Algebra/GroupWithZero/ProdHom.lean
@@ -142,12 +142,12 @@ lemma inl_injective [DecidablePred fun x : G₀ ↦ x = 0] :
 lemma inr_injective [DecidablePred fun x : H₀ ↦ x = 0] :
     Function.Injective (inr G₀ H₀) :=
   Function.HasLeftInverse.injective ⟨snd .., fun _ ↦ by simp⟩
-lemma fst_surjective [DecidablePred fun x : G₀ ↦ x = 0] :
-    Function.Surjective (fst G₀ H₀) :=
-  Function.HasRightInverse.surjective ⟨inl .., fun _ ↦ by simp⟩
-lemma snd_surjective [DecidablePred fun x : H₀ ↦ x = 0] :
-    Function.Surjective (snd G₀ H₀) :=
-  Function.HasRightInverse.surjective ⟨inr .., fun _ ↦ by simp⟩
+lemma fst_surjective : Function.Surjective (fst G₀ H₀) := by
+  classical
+  exact Function.HasRightInverse.surjective ⟨inl .., fun _ ↦ by simp⟩
+lemma snd_surjective : Function.Surjective (snd G₀ H₀) := by
+  classical
+  exact Function.HasRightInverse.surjective ⟨inr .., fun _ ↦ by simp⟩
 
 variable [DecidablePred fun x : G₀ ↦ x = 0] [DecidablePred fun x : H₀ ↦ x = 0]
 

--- a/Mathlib/Algebra/MvPolynomial/Eval.lean
+++ b/Mathlib/Algebra/MvPolynomial/Eval.lean
@@ -481,9 +481,10 @@ lemma coeffs_map (f : R →+* S₁) (p : MvPolynomial σ R) [DecidableEq S₁] :
           disjoint_support_monomial ha hs
 
 @[simp]
-lemma coe_coeffs_map (f : R →+* S₁) (p : MvPolynomial σ R) [DecidableEq S₁] :
-    ((map f p).coeffs : Set S₁) ⊆ f '' p.coeffs :=
-  subset_trans (coeffs_map f p) (Finset.coe_image (f := f) ▸ .rfl)
+lemma coe_coeffs_map (f : R →+* S₁) (p : MvPolynomial σ R) :
+    ((map f p).coeffs : Set S₁) ⊆ f '' p.coeffs := by
+  classical
+  exact mod_cast coeffs_map f p
 
 lemma mem_range_map_iff_coeffs_subset {f : R →+* S₁} {x : MvPolynomial σ S₁} :
     x ∈ Set.range (MvPolynomial.map f) ↔ (x.coeffs : Set _) ⊆ .range f := by

--- a/Mathlib/Algebra/SkewMonoidAlgebra/Single.lean
+++ b/Mathlib/Algebra/SkewMonoidAlgebra/Single.lean
@@ -109,20 +109,22 @@ theorem coeff_update_apply [DecidableEq α] :
   rw [coeff_update, Function.update_apply]
 
 @[simp]
-theorem coeff_update_same [DecidableEq α] : (f.update a b).coeff a = b := by
+theorem coeff_update_same : (f.update a b).coeff a = b := by
+  classical
   rw [f.coeff_update_apply, if_pos rfl]
 
 variable {a a'} in
 @[simp]
-theorem coeff_update_ne [DecidableEq α] (h : a' ≠ a) : (f.update a b).coeff a' = f.coeff a' := by
+theorem coeff_update_ne (h : a' ≠ a) : (f.update a b).coeff a' = f.coeff a' := by
+  classical
   rw [f.coeff_update_apply, if_neg h]
 
-theorem update_eq_erase_add_single [DecidableEq α] : f.update a b = f.erase a + single a b := by
-  ext x; by_cases hx : x = a <;> aesop (add norm coeff_single_apply)
+theorem update_eq_erase_add_single : f.update a b = f.erase a + single a b := by
+  classical ext x; by_cases hx : x = a <;> aesop (add norm coeff_single_apply)
 
 @[simp]
-theorem update_zero_eq_erase [DecidableEq α] : f.update a 0 = f.erase a := by
-  ext; simp [coeff_update_apply, coeff_erase_apply]
+theorem update_zero_eq_erase : f.update a 0 = f.erase a := by
+  classical ext; simp [coeff_update_apply, coeff_erase_apply]
 
 end update
 

--- a/Mathlib/Algebra/SkewMonoidAlgebra/Support.lean
+++ b/Mathlib/Algebra/SkewMonoidAlgebra/Support.lean
@@ -101,19 +101,21 @@ theorem support_mul_single_eq_image {r : k} {x : G} (rx : IsRightRegular x)
   simp [coeff_mul, mem_support_iff.mp yf, hrx, mem_support_iff, sum_single_index, mul_zero,
     ite_self, rx.eq_iff]
 
+end DecidableEq
+
 theorem support_mul_single [IsRightCancelMul G] (r : k) (x : G)
    (hrx : ∀ g : G, ∀ y, y * g • r = 0 ↔ y = 0) :
     (f * single x r).support = f.support.map (mulRightEmbedding x) := by
+  classical
   ext a
   simp [support_mul_single_eq_image f (IsRightRegular.all x) hrx]
 
 theorem support_single_mul [IsLeftCancelMul G] (r : k) (x : G)
     (hrx : ∀ y, r * x • y = 0 ↔ y = 0) :
     (single x r * f : SkewMonoidAlgebra k G).support = f.support.map (mulLeftEmbedding x) := by
+  classical
   ext a
   simp [support_single_mul_eq_image f (IsLeftRegular.all x) hrx]
-
-end DecidableEq
 
 section Span
 

--- a/Mathlib/Algebra/Squarefree/Basic.lean
+++ b/Mathlib/Algebra/Squarefree/Basic.lean
@@ -212,17 +212,17 @@ theorem squarefree_mul_iff : Squarefree (x * y) ↔ IsRelPrime x y ∧ Squarefre
       (sqx.dvd_of_squarefree_of_mul_dvd_mul_right dvd)⟩
 
 open scoped Function in
-theorem Finset.squarefree_prod_of_pairwise_isCoprime {ι : Type*} [DecidableEq ι] {s : Finset ι}
+theorem Finset.squarefree_prod_of_pairwise_isCoprime {ι : Type*} {s : Finset ι}
     {f : ι → R} (hs : Set.Pairwise s.toSet (IsRelPrime on f)) (hs' : ∀ i ∈ s, Squarefree (f i)) :
     Squarefree (∏ i ∈ s, f i) := by
-  induction s using Finset.induction with
+  induction s using Finset.cons_induction with
   | empty => simp
-  | @insert a s ha ih =>
-    rw [Finset.prod_insert ha, squarefree_mul_iff]
-    rw [Finset.coe_insert, Set.pairwise_insert] at hs
+  | cons a s ha ih =>
+    rw [Finset.prod_cons, squarefree_mul_iff]
+    rw [Finset.coe_cons, Set.pairwise_insert] at hs
     refine ⟨.prod_right fun i hi ↦ ?_, hs' a (by simp), ?_⟩
     · exact (hs.right i (by simp [hi]) fun h ↦ ha (h ▸ hi)).left
-    · exact ih hs.left fun i hi ↦ hs' i <| Finset.mem_insert_of_mem hi
+    · exact ih hs.left fun i hi ↦ hs' i <| Finset.mem_cons_of_mem hi
 
 theorem isRadical_iff_squarefree_or_zero : IsRadical x ↔ Squarefree x ∨ x = 0 :=
   ⟨fun hx ↦ (em <| x = 0).elim .inr fun h ↦ .inl <| hx.squarefree h,

--- a/Mathlib/AlgebraicGeometry/EllipticCurve/Jacobian/Point.lean
+++ b/Mathlib/AlgebraicGeometry/EllipticCurve/Jacobian/Point.lean
@@ -580,17 +580,29 @@ noncomputable def toAffineAddEquiv [DecidableEq F] : W.Point ≃+ W.toAffine.Poi
     · rw [fromAffine_some, toAffineLift_some]
   map_add' := toAffineLift_add
 
-noncomputable instance [DecidableEq F] : AddCommGroup W.Point where
+noncomputable instance : AddCommGroup W.Point where
   nsmul := nsmulRec
   zsmul := zsmulRec
-  zero_add _ := (toAffineAddEquiv W).injective <| by
+  zero_add _ := by
+    classical
+    apply (toAffineAddEquiv W).injective
     simp only [map_add, toAffineAddEquiv_apply, toAffineLift_zero, zero_add]
-  add_zero _ := (toAffineAddEquiv W).injective <| by
+  add_zero _ := by
+    classical
+    apply (toAffineAddEquiv W).injective
     simp only [map_add, toAffineAddEquiv_apply, toAffineLift_zero, add_zero]
-  neg_add_cancel P := (toAffineAddEquiv W).injective <| by
+  neg_add_cancel P := by
+    classical
+    apply (toAffineAddEquiv W).injective
     simp only [map_add, toAffineAddEquiv_apply, toAffineLift_neg, neg_add_cancel, toAffineLift_zero]
-  add_comm _ _ := (toAffineAddEquiv W).injective <| by simp only [map_add, add_comm]
-  add_assoc _ _ _ := (toAffineAddEquiv W).injective <| by simp only [map_add, add_assoc]
+  add_comm _ _ := by
+    classical
+    apply (toAffineAddEquiv W).injective
+    simp only [map_add, add_comm]
+  add_assoc _ _ _ := by
+    classical
+    apply (toAffineAddEquiv W).injective
+    simp only [map_add, add_assoc]
 
 end Point
 

--- a/Mathlib/AlgebraicGeometry/EllipticCurve/Projective/Point.lean
+++ b/Mathlib/AlgebraicGeometry/EllipticCurve/Projective/Point.lean
@@ -567,17 +567,29 @@ noncomputable def toAffineAddEquiv [DecidableEq F] : W.Point ≃+ W.toAffine.Poi
     · rw [fromAffine_some, toAffineLift_some]
   map_add' := toAffineLift_add
 
-noncomputable instance [DecidableEq F] : AddCommGroup W.Point where
+noncomputable instance : AddCommGroup W.Point where
   nsmul := nsmulRec
   zsmul := zsmulRec
-  zero_add _ := (toAffineAddEquiv W).injective <| by
+  zero_add _ := by
+    classical
+    apply (toAffineAddEquiv W).injective
     simp only [map_add, toAffineAddEquiv_apply, toAffineLift_zero, zero_add]
-  add_zero _ := (toAffineAddEquiv W).injective <| by
+  add_zero _ := by
+    classical
+    apply (toAffineAddEquiv W).injective
     simp only [map_add, toAffineAddEquiv_apply, toAffineLift_zero, add_zero]
-  neg_add_cancel P := (toAffineAddEquiv W).injective <| by
+  neg_add_cancel P := by
+    classical
+    apply (toAffineAddEquiv W).injective
     simp only [map_add, toAffineAddEquiv_apply, toAffineLift_neg, neg_add_cancel, toAffineLift_zero]
-  add_comm _ _ := (toAffineAddEquiv W).injective <| by simp only [map_add, add_comm]
-  add_assoc _ _ _ := (toAffineAddEquiv W).injective <| by simp only [map_add, add_assoc]
+  add_comm _ _ := by
+    classical
+    apply (toAffineAddEquiv W).injective
+    simp only [map_add, add_comm]
+  add_assoc _ _ _ := by
+    classical
+    apply (toAffineAddEquiv W).injective
+    simp only [map_add, add_assoc]
 
 end Point
 

--- a/Mathlib/Analysis/InnerProductSpace/Trace.lean
+++ b/Mathlib/Analysis/InnerProductSpace/Trace.lean
@@ -15,15 +15,15 @@ This file contains various results about traces of linear operators in inner pro
 
 namespace LinearMap
 
-variable {𝕜 E ι : Type*} [RCLike 𝕜] [Fintype ι] [DecidableEq ι]
+variable {𝕜 E ι : Type*} [RCLike 𝕜] [Fintype ι]
 variable [NormedAddCommGroup E] [InnerProductSpace 𝕜 E]
 
 open scoped InnerProductSpace
 
 lemma trace_eq_sum_inner (T : E →ₗ[𝕜] E) (b : OrthonormalBasis ι 𝕜 E) :
     T.trace 𝕜 E = ∑ i, ⟪b i, T (b i)⟫_𝕜 := by
-  let b' := b.toBasis
-  rw [LinearMap.trace_eq_matrix_trace 𝕜 b' T]
+  classical
+  rw [LinearMap.trace_eq_matrix_trace 𝕜 b.toBasis T]
   apply Fintype.sum_congr
   intro i
   rw [Matrix.diag_apply, T.toMatrix_apply, b.coe_toBasis, b.coe_toBasis_repr_apply,

--- a/Mathlib/Combinatorics/SimpleGraph/Finite.lean
+++ b/Mathlib/Combinatorics/SimpleGraph/Finite.lean
@@ -243,8 +243,9 @@ theorem incidenceFinset_subset [DecidableEq V] [Fintype G.edgeSet] :
   Set.toFinset_subset_toFinset.mpr (G.incidenceSet_subset v)
 
 /-- The degree of a vertex is at most the number of edges. -/
-theorem degree_le_card_edgeFinset [DecidableEq V] [Fintype G.edgeSet] :
+theorem degree_le_card_edgeFinset [Fintype G.edgeSet] :
     G.degree v ≤ #G.edgeFinset := by
+  classical
   rw [← card_incidenceFinset_eq_degree]
   exact card_le_card (G.incidenceFinset_subset v)
 

--- a/Mathlib/LinearAlgebra/Matrix/PosDef.lean
+++ b/Mathlib/LinearAlgebra/Matrix/PosDef.lean
@@ -404,9 +404,9 @@ theorem posSemidef_iff_isHermitian_and_spectrum_nonneg [DecidableEq n] {A : Matr
     intro i
     simpa [h1.spectrum_eq_image_range] using @h2 (h1.eigenvalues i)
 
-theorem PosSemidef.commute_iff [DecidableEq n] {A B : Matrix n n 𝕜}
-    (hA : A.PosSemidef) (hB : B.PosSemidef) :
+theorem PosSemidef.commute_iff {A B : Matrix n n 𝕜} (hA : A.PosSemidef) (hB : B.PosSemidef) :
     Commute A B ↔ (A * B).PosSemidef := by
+  classical
   rw [hA.isHermitian.commute_iff hB.isHermitian]
   refine ⟨fun hAB => posSemidef_iff_isHermitian_and_spectrum_nonneg.mpr ⟨hAB, ?_⟩,
     fun h => h.isHermitian⟩
@@ -661,8 +661,9 @@ theorem _root_.Matrix.PosSemidef.posDef_iff_isUnit [DecidableEq n] {x : Matrix n
   rw [← map_eq_zero_iff (f := (yᴴ * y).mulVecLin) (mulVec_injective_iff_isUnit.mpr h),
     mulVecLin_apply, ← mulVec_mulVec, hv, mulVec_zero]
 
-theorem commute_iff [DecidableEq n] {A B : Matrix n n 𝕜} (hA : A.PosDef) (hB : B.PosDef) :
+theorem commute_iff {A B : Matrix n n 𝕜} (hA : A.PosDef) (hB : B.PosDef) :
     Commute A B ↔ (A * B).PosDef := by
+  classical
   rw [hA.posSemidef.commute_iff hB.posSemidef]
   exact ⟨fun h => h.posDef_iff_isUnit.mpr <| hA.isUnit.mul hB.isUnit, fun h => h.posSemidef⟩
 

--- a/Mathlib/RepresentationTheory/Homological/Resolution.lean
+++ b/Mathlib/RepresentationTheory/Homological/Resolution.lean
@@ -271,9 +271,9 @@ equipped with the representation induced by the diagonal action of `G`. -/
 def xIso (n : ℕ) : (standardComplex k G).X n ≅ Rep.ofMulAction k G (Fin (n + 1) → G) :=
   Iso.refl _
 
-instance x_projective (G : Type u) [Group G] [DecidableEq G] (n : ℕ) :
-    Projective ((standardComplex k G).X n) :=
-  inferInstanceAs <| Projective (Rep.diagonal k G (n + 1))
+instance x_projective (G : Type u) [Group G] (n : ℕ) :
+    Projective ((standardComplex k G).X n) := by
+  classical exact inferInstanceAs <| Projective (Rep.diagonal k G (n + 1))
 
 /-- Simpler expression for the differential in the standard resolution of `k` as a
 `G`-representation. It sends `(g₀, ..., gₙ₊₁) ↦ ∑ (-1)ⁱ • (g₀, ..., ĝᵢ, ..., gₙ₊₁)`. -/
@@ -370,7 +370,7 @@ end standardComplex
 
 open HomologicalComplex.Hom standardComplex
 
-variable [Group G] [DecidableEq G]
+variable [Group G]
 
 /-- The standard projective resolution of `k` as a trivial `k`-linear `G`-representation. -/
 def standardResolution : ProjectiveResolution (Rep.trivial k G k) where
@@ -395,6 +395,7 @@ namespace barComplex
 
 open Rep Finsupp
 
+variable [DecidableEq G]
 variable (n)
 
 /-- The differential from `Gⁿ⁺¹ →₀ k[G]` to `Gⁿ →₀ k[G]` in the bar resolution of `k` as a trivial
@@ -425,6 +426,8 @@ lemma d_comp_diagonalSuccIsoFree_inv_eq :
 end barComplex
 
 open barComplex
+
+variable [DecidableEq G]
 
 /-- The projective resolution of `k` as a trivial `k`-linear `G`-representation with `n`th
 differential `(Gⁿ⁺¹ →₀ k[G]) → (Gⁿ →₀ k[G])` sending `(g₀, ..., gₙ)` to

--- a/Mathlib/RepresentationTheory/Rep.lean
+++ b/Mathlib/RepresentationTheory/Rep.lean
@@ -469,10 +469,11 @@ def freeLiftLEquiv :
 
 variable {A}
 
+omit [DecidableEq α] in
 @[ext]
 lemma free_ext (f g : free k G α ⟶ A)
-    (h : ∀ i : α, f.hom (single i (single 1 1)) = g.hom (single i (single 1 1))) : f = g :=
-  (freeLiftLEquiv α A).injective (funext_iff.2 h)
+    (h : ∀ i : α, f.hom (single i (single 1 1)) = g.hom (single i (single 1 1))) : f = g := by
+  classical exact (freeLiftLEquiv α A).injective (funext_iff.2 h)
 
 section
 
@@ -945,11 +946,12 @@ instance free_projective {G α : Type u} [Group G] :
 
 section
 
-variable {G : Type u} [Group G] {n : ℕ} [DecidableEq (Fin n → G)]
+variable {G : Type u} [Group G] {n : ℕ}
 
 instance diagonal_succ_projective :
-    Projective (diagonal k G (n + 1)) :=
-  Projective.of_iso (diagonalSuccIsoFree k G n).symm inferInstance
+    Projective (diagonal k G (n + 1)) := by
+  classical
+  exact Projective.of_iso (diagonalSuccIsoFree k G n).symm inferInstance
 
 instance leftRegular_projective :
     Projective (leftRegular k G) :=

--- a/Mathlib/RingTheory/MvPowerSeries/Basic.lean
+++ b/Mathlib/RingTheory/MvPowerSeries/Basic.lean
@@ -625,10 +625,10 @@ section CommSemiring
 
 open Finset.HasAntidiagonal Finset
 
-variable {R : Type*} [CommSemiring R] {ι : Type*} [DecidableEq ι]
+variable {R : Type*} [CommSemiring R] {ι : Type*}
 
 /-- Coefficients of a product of power series -/
-theorem coeff_prod [DecidableEq σ]
+theorem coeff_prod [DecidableEq ι] [DecidableEq σ]
     (f : ι → MvPowerSeries σ R) (d : σ →₀ ℕ) (s : Finset ι) :
     coeff d (∏ j ∈ s, f j) =
       ∑ l ∈ finsuppAntidiag s d,
@@ -665,9 +665,9 @@ theorem coeff_prod [DecidableEq σ]
 
 theorem prod_monomial (f : ι → σ →₀ ℕ) (g : ι → R) (s : Finset ι) :
     ∏ i ∈ s, monomial (f i) (g i) = monomial (∑ i ∈ s, f i) (∏ i ∈ s, g i) := by
-  induction s using Finset.induction with
+  induction s using Finset.cons_induction with
   | empty => simp
-  | insert a s ha h => simp [ha, h, monomial_mul_monomial]
+  | cons a s ha h => simp [h, monomial_mul_monomial]
 
 /-- The `d`th coefficient of a power of a multivariate power series
 is the sum, indexed by `finsuppAntidiag (Finset.range n) d`, of products of coefficients -/

--- a/Mathlib/RingTheory/PowerSeries/Basic.lean
+++ b/Mathlib/RingTheory/PowerSeries/Basic.lean
@@ -630,10 +630,10 @@ section CommSemiring
 
 open Finset.HasAntidiagonal Finset
 
-variable {R : Type*} [CommSemiring R] {ι : Type*} [DecidableEq ι]
+variable {R : Type*} [CommSemiring R] {ι : Type*}
 
 /-- Coefficients of a product of power series -/
-theorem coeff_prod (f : ι → PowerSeries R) (d : ℕ) (s : Finset ι) :
+theorem coeff_prod [DecidableEq ι] (f : ι → PowerSeries R) (d : ℕ) (s : Finset ι) :
     coeff d (∏ j ∈ s, f j) = ∑ l ∈ finsuppAntidiag s d, ∏ i ∈ s, coeff (l i) (f i) := by
   simp only [coeff]
   rw [MvPowerSeries.coeff_prod, ← AddEquiv.finsuppUnique_symm d, ← mapRange_finsuppAntidiag_eq,

--- a/Mathlib/RingTheory/TensorProduct/DirectLimitFG.lean
+++ b/Mathlib/RingTheory/TensorProduct/DirectLimitFG.lean
@@ -192,8 +192,9 @@ variable {R M N} (u : M ⊗[R] N)
     {P : Submodule R M} (hP : Submodule.FG P) {t : P ⊗[R] N}
     {P' : Submodule R M} (hP' : Submodule.FG P') {t' : P' ⊗[R] N}
 
-theorem TensorProduct.exists_of_fg [DecidableEq {P : Submodule R M // P.FG}] :
+theorem TensorProduct.exists_of_fg :
     ∃ (P : Submodule R M), P.FG ∧ u ∈ range (rTensor N P.subtype) := by
+  classical
   let ⟨P, t, ht⟩ := Module.DirectLimit.exists_of ((Submodule.FG.rTensor.directLimit R M N).symm u)
   use P.val, P.property, t
   rw [← Submodule.FG.rTensor.directLimit_apply, ht, LinearEquiv.apply_symm_apply]
@@ -239,7 +240,7 @@ variable {R S M N : Type*} [CommSemiring R] [Semiring S] [Algebra R S]
   {A : Subalgebra R S} (hA : A.FG) {t t' : A ⊗[R] N}
   {A' : Subalgebra R S} (hA' : A'.FG)
 
-theorem TensorProduct.Algebra.exists_of_fg [DecidableEq {P : Submodule R S // P.FG}] :
+theorem TensorProduct.Algebra.exists_of_fg :
     ∃ (A : Subalgebra R S), Subalgebra.FG A ∧ u ∈ range (rTensor N A.val.toLinearMap) := by
   obtain ⟨P, ⟨s, hs⟩, hu⟩ := TensorProduct.exists_of_fg u
   use Algebra.adjoin R s, Subalgebra.fg_adjoin_finset _

--- a/Mathlib/RingTheory/UniqueFactorizationDomain/NormalizedFactors.lean
+++ b/Mathlib/RingTheory/UniqueFactorizationDomain/NormalizedFactors.lean
@@ -343,22 +343,22 @@ variable {β : Type*} [CancelCommMonoidWithZero β] [NormalizationMonoid β]
 If the monoid equiv `f : α ≃* β` commutes with `normalize` then, for `a : α`, it yields a
 bijection between the `normalizedFactors` of `a` and of `f a`.
 -/
-def normalizedFactorsEquiv [DecidableEq α] (he : ∀ x, normalize (f x) = f (normalize x)) (a : α) :
+def normalizedFactorsEquiv (he : ∀ x, normalize (f x) = f (normalize x)) (a : α) :
     {x // x ∈ normalizedFactors a} ≃ {y // y ∈ normalizedFactors (f a)} :=
-  Equiv.subtypeEquiv f fun x ↦
-    if ha : a = 0 then by simp [ha] else by
-      simp [mem_normalizedFactors_iff' ha,
+  Equiv.subtypeEquiv f fun x ↦ by
+    rcases eq_or_ne a 0 with rfl | ha
+    · simp
+    · simp [mem_normalizedFactors_iff' ha,
         mem_normalizedFactors_iff' (EmbeddingLike.map_ne_zero_iff.mpr ha), map_dvd_iff_dvd_symm,
         MulEquiv.irreducible_iff, he]
 
 @[simp]
-theorem normalizedFactorsEquiv_apply [DecidableEq α] (he : ∀ x, normalize (f x) = f (normalize x))
+theorem normalizedFactorsEquiv_apply (he : ∀ x, normalize (f x) = f (normalize x))
     {a p : α} (hp : p ∈ normalizedFactors a) :
     normalizedFactorsEquiv he a ⟨p, hp⟩ = f p := rfl
 
 @[simp]
-theorem normalizedFactorsEquiv_symm_apply [DecidableEq α]
-    (he : ∀ x, normalize (f x) = f (normalize x))
+theorem normalizedFactorsEquiv_symm_apply (he : ∀ x, normalize (f x) = f (normalize x))
     {a : α} {q : β} (hq : q ∈ normalizedFactors (f a)) :
     (normalizedFactorsEquiv he a).symm ⟨q, hq⟩ = (MulEquivClass.toMulEquiv f).symm q := rfl
 

--- a/Mathlib/Topology/Algebra/RestrictedProduct/TopologicalSpace.lean
+++ b/Mathlib/Topology/Algebra/RestrictedProduct/TopologicalSpace.lean
@@ -478,7 +478,7 @@ theorem continuous_dom_prod {R' : ι → Type*} {A' : (i : ι) → Set (R' i)}
   exact (H U hU).comp ((continuous_inclusion hSU).prodMap (continuous_inclusion hTU))
 
 /-- A finitary (instead of binary) version of `continuous_dom_prod`. -/
-theorem continuous_dom_pi {n : Type*} [Fintype n] {X : Type*}
+theorem continuous_dom_pi {n : Type*} [Finite n] {X : Type*}
     [TopologicalSpace X] {A : n → ι → Type*}
     [∀ j i, TopologicalSpace (A j i)]
     {C : (j : n) → (i : ι) → Set (A j i)}

--- a/Mathlib/Topology/Instances/Matrix.lean
+++ b/Mathlib/Topology/Instances/Matrix.lean
@@ -55,7 +55,7 @@ instance [TopologicalSpace R] [DecidableEq n] [Fintype n] [CommRing R] :
 
 section Set
 
-theorem IsOpen.matrix [Fintype m] [Fintype n]
+theorem IsOpen.matrix [Finite m] [Finite n]
     [TopologicalSpace R] {S : Set R} (hS : IsOpen S) :
     IsOpen (S.matrix : Set (Matrix m n R)) :=
   Set.matrix_eq_pi ▸

--- a/Mathlib/Topology/Order/HullKernel.lean
+++ b/Mathlib/Topology/Order/HullKernel.lean
@@ -80,7 +80,7 @@ lemma hull_inf (hT : ∀ p ∈ T, InfPrime p) (a b : α) :
     · exact inf_le_of_left_le h1
     · exact inf_le_of_right_le h3
 
-variable [DecidableEq α] [OrderTop α]
+variable [OrderTop α]
 
 /- Every relative-closed set of the form `T ↓∩ (↑(upperClosure F))` for `F` finite is a
 relative-closed set of the form `hull T a` where `a = ⨅ F`. -/
@@ -88,7 +88,7 @@ open Finset in
 lemma hull_finsetInf (hT : ∀ p ∈ T, InfPrime p) (F : Finset α) :
     hull T (inf F id) = T ↓∩ upperClosure F.toSet := by
   rw [coe_upperClosure]
-  induction F using Finset.induction_on with
+  induction F using Finset.cons_induction with
   | empty =>
     simp only [coe_empty, mem_empty_iff_false, iUnion_of_empty, iUnion_empty, Set.preimage_empty,
       inf_empty]
@@ -96,9 +96,7 @@ lemma hull_finsetInf (hT : ∀ p ∈ T, InfPrime p) (F : Finset α) :
     rw [← Set.not_nonempty_iff_eq_empty, not_not] at hf
     obtain ⟨x, hx⟩ := hf
     exact (hT x (Subtype.coe_prop x)).1 (isMax_iff_eq_top.mpr (eq_top_iff.mpr hx))
-  | insert a F' _ I4 =>
-    simp only [coe_insert, mem_insert_iff, mem_coe, iUnion_iUnion_eq_or_left, Set.preimage_union,
-      preimage_iUnion, inf_insert, id_eq, hull_inf hT, I4]
+  | cons a F' _ I4 => simp [hull_inf hT, I4]
 
 /- Every relative-open set of the form `T ↓∩ (↑(upperClosure F))ᶜ` for `F` finite is a relative-open
 set of the form `(hull T a)ᶜ` where `a = ⨅ F`. -/
@@ -147,7 +145,7 @@ lemma hull_sSup (S : Set α) : hull T (sSup S) = ⋂₀ { hull T a | a ∈ S } :
 
 /- When `α` is complete, a set is Lower topology relative-open if and only if it is of the form
 `(hull T a)ᶜ` for some `a` in `α`.-/
-lemma isOpen_iff [TopologicalSpace α] [IsLower α] [DecidableEq α] (hT : ∀ p ∈ T, InfPrime p)
+lemma isOpen_iff [TopologicalSpace α] [IsLower α] (hT : ∀ p ∈ T, InfPrime p)
     (S : Set T) : IsOpen S ↔ ∃ (a : α), S = (hull T a)ᶜ := by
   constructor <;> intro h
   · let R := {a : α | (hull T a)ᶜ ⊆ S}
@@ -159,7 +157,7 @@ lemma isOpen_iff [TopologicalSpace α] [IsLower α] [DecidableEq α] (hT : ∀ p
 
 /- When `α` is complete, a set is closed in the relative lower topology if and only if it is of the
 form `hull T a` for some `a` in `α`.-/
-lemma isClosed_iff [TopologicalSpace α] [IsLower α] [DecidableEq α] (hT : ∀ p ∈ T, InfPrime p)
+lemma isClosed_iff [TopologicalSpace α] [IsLower α] (hT : ∀ p ∈ T, InfPrime p)
     {S : Set T} : IsClosed S ↔ ∃ (a : α), S = hull T a := by
   simp only [← isOpen_compl_iff, isOpen_iff hT, compl_inj_iff]
 
@@ -193,24 +191,24 @@ When `T` is order generating, the `kernel` and the `hull` form a Galois insertio
 def gi (hG : OrderGenerates T) : GaloisInsertion (α := Set T) (β := αᵒᵈ)
     (OrderDual.toDual ∘ kernel)
     (hull T ∘ OrderDual.ofDual) :=
-  gc.toGaloisInsertion fun a ↦ (by
+  gc.toGaloisInsertion fun a ↦ by
     rw [OrderDual.le_toDual]
     obtain ⟨S, hS⟩ := hG a
     exact le_of_le_of_eq (sInf_le_sInf (image_val_mono (fun c hcS => mem_preimage.mpr (mem_Ici.mpr
       (by rw [hS]; exact CompleteSemilatticeInf.sInf_le _ _ (mem_image_of_mem Subtype.val hcS))))))
-      hS.symm)
+      hS.symm
 
 lemma kernel_hull (hG : OrderGenerates T) (a : α) : kernel (hull T a) = a := by
   conv_rhs => rw [← OrderDual.ofDual_toDual a, ← (gi hG).l_u_eq a]
   rfl
 
-lemma hull_kernel_of_isClosed [TopologicalSpace α] [IsLower α] [DecidableEq α]
+lemma hull_kernel_of_isClosed [TopologicalSpace α] [IsLower α]
     (hT : ∀ p ∈ T, InfPrime p) (hG : OrderGenerates T) {C : Set T} (h : IsClosed C) :
-     hull T (kernel C) = C := by
+    hull T (kernel C) = C := by
   obtain ⟨a, ha⟩ := (isClosed_iff hT).mp h
   rw [ha, kernel_hull hG]
 
-lemma closedsGC_closureOperator [TopologicalSpace α] [IsLower α] [DecidableEq α]
+lemma closedsGC_closureOperator [TopologicalSpace α] [IsLower α]
     (hT : ∀ p ∈ T, InfPrime p) (hG : OrderGenerates T) (S : Set T) :
     (TopologicalSpace.Closeds.gc (α := T)).closureOperator S = hull T (kernel S) := by
   simp only [GaloisConnection.closureOperator_apply, Closeds.coe_closure, closure, le_antisymm_iff]


### PR DESCRIPTION
Found by the linter in #10235

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include at least one commit authored by each
co-author among the commits in the pull request. If necessary, you may 
create empty commits to indicate co-authorship, using commands like so:

git commit --author="Author Name <author@email.com>" --allow-empty -m "add Author Name as coauthor"

When merging, all the commits will be squashed into a single commit listing all co-authors.

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
