### PR TITLE
[Merged by Bors] - feat(Algebra): add `mem_closure_iff_of_fintype` and `mem_closure_finset'`

### DIFF
--- a/Mathlib/Algebra/Group/Subgroup/Finsupp.lean
+++ b/Mathlib/Algebra/Group/Subgroup/Finsupp.lean
@@ -61,10 +61,4 @@ theorem mem_closure_iff_of_fintype {s : Set M} [Fintype s] :
   conv_lhs => rw [← Subtype.range_coe (s := s)]
   exact mem_closure_range_iff_of_fintype
 
-/-- A variant of `Subgroup.mem_closure_finset` using `s` as the index type. -/
-@[to_additive /-- A variant of `AddSubgroup.mem_closure_finset` using `s` as the index type. -/]
-theorem mem_closure_finset' {s : Finset M} :
-    x ∈ closure s ↔ ∃ a : s → ℤ, x = ∏ i : s, i.1 ^ a i :=
-  mem_closure_iff_of_fintype
-
 end Subgroup

--- a/Mathlib/Algebra/Group/Subgroup/Finsupp.lean
+++ b/Mathlib/Algebra/Group/Subgroup/Finsupp.lean
@@ -34,7 +34,14 @@ theorem exists_finsupp_of_mem_closure_range (hx : x ∈ closure (Set.range f)) :
     · simp
     · simp
 
-variable {f x} in
+@[to_additive]
+theorem exists_of_mem_closure_range [Fintype ι] (hx : x ∈ closure (Set.range f)) :
+    ∃ a : ι → ℤ, x = ∏ i, f i ^ a i := by
+  obtain ⟨a, rfl⟩ := exists_finsupp_of_mem_closure_range f x hx
+  exact ⟨a, by simp⟩
+
+variable {f x}
+
 @[to_additive]
 theorem mem_closure_range_iff :
     x ∈ closure (Set.range f) ↔ ∃ a : ι →₀ ℤ, x = a.prod (f · ^ ·) := by
@@ -43,16 +50,21 @@ theorem mem_closure_range_iff :
   exact Submonoid.prod_mem _ fun i hi ↦ zpow_mem (subset_closure (Set.mem_range_self i)) _
 
 @[to_additive]
-theorem exists_of_mem_closure_range [Fintype ι] (hx : x ∈ closure (Set.range f)) :
-    ∃ a : ι → ℤ, x = ∏ i, f i ^ a i := by
-  obtain ⟨a, rfl⟩ := exists_finsupp_of_mem_closure_range f x hx
-  exact ⟨a, by simp⟩
-
-variable {f x} in
-@[to_additive]
 theorem mem_closure_range_iff_of_fintype [Fintype ι] :
     x ∈ closure (Set.range f) ↔ ∃ a : ι → ℤ, x = ∏ i, f i ^ a i := by
   rw [Finsupp.equivFunOnFinite.symm.exists_congr_left, mem_closure_range_iff]
   simp
+
+@[to_additive]
+theorem mem_closure_iff_of_fintype {s : Set M} [Fintype s] :
+    x ∈ closure s ↔ ∃ a : s → ℤ, x = ∏ i : s, i.1 ^ a i := by
+  conv_lhs => rw [← Subtype.range_coe (s := s)]
+  exact mem_closure_range_iff_of_fintype
+
+/-- A variant of `Subgroup.mem_closure_finset` using `s` as the index type. -/
+@[to_additive /-- A variant of `AddSubgroup.mem_closure_finset` using `s` as the index type. -/]
+theorem mem_closure_finset' {s : Finset M} :
+    x ∈ closure s ↔ ∃ a : s → ℤ, x = ∏ i : s, i.1 ^ a i :=
+  mem_closure_iff_of_fintype
 
 end Subgroup

--- a/Mathlib/Algebra/Group/Submonoid/BigOperators.lean
+++ b/Mathlib/Algebra/Group/Submonoid/BigOperators.lean
@@ -176,5 +176,30 @@ lemma mem_closure_finset {s : Finset M} :
     simp +contextual [Function.support_subset_iff'.1 hf]
   mpr := by rintro ⟨n, -, rfl⟩; exact prod_mem _ fun x hx ↦ pow_mem (subset_closure hx) _
 
+/-- A variant of `Submonoid.mem_closure_finset` using `s` as the index type. -/
+@[to_additive /-- A variant of `AddSubmonoid.mem_closure_finset` using `s` as the index type. -/]
+theorem mem_closure_finset' {s : Finset M} :
+    x ∈ closure s ↔ ∃ f : s → ℕ, ∏ a : s, a.1 ^ f a = x := by
+  conv_lhs => rw [mem_closure_finset]
+  constructor
+  · rintro ⟨f, _, rfl⟩
+    exact ⟨f ∘ Subtype.val, Finset.prod_coe_sort s (f := fun a => a ^ f a)⟩
+  · intro ⟨f, hx⟩
+    classical
+    refine ⟨fun a => if h : a ∈ s then f ⟨a, h⟩ else 0, ?_, ?_⟩
+    · aesop
+    · rw [← Finset.prod_attach]
+      simpa
+
+@[to_additive]
+theorem mem_closure_fintype {s : Set M} [Fintype s] :
+    x ∈ closure s ↔ ∃ f : s → ℕ, ∏ a : s, a.1 ^ f a = x := by
+  conv_lhs =>
+    rw [← s.coe_toFinset, mem_closure_finset',
+      Equiv.subtypeEquivRight (fun _ => Set.mem_toFinset) |>.piCongrLeft (fun _ => ℕ)
+        |>.exists_congr_left]
+  congr! 3
+  apply Finset.prod_equiv <| Equiv.subtypeEquivRight fun _ => Set.mem_toFinset <;> simp
+
 end CommMonoid
 end Submonoid

--- a/Mathlib/Algebra/Group/Submonoid/BigOperators.lean
+++ b/Mathlib/Algebra/Group/Submonoid/BigOperators.lean
@@ -176,30 +176,5 @@ lemma mem_closure_finset {s : Finset M} :
     simp +contextual [Function.support_subset_iff'.1 hf]
   mpr := by rintro ⟨n, -, rfl⟩; exact prod_mem _ fun x hx ↦ pow_mem (subset_closure hx) _
 
-/-- A variant of `Submonoid.mem_closure_finset` using `s` as the index type. -/
-@[to_additive /-- A variant of `AddSubmonoid.mem_closure_finset` using `s` as the index type. -/]
-theorem mem_closure_finset' {s : Finset M} :
-    x ∈ closure s ↔ ∃ f : s → ℕ, ∏ a : s, a.1 ^ f a = x := by
-  conv_lhs => rw [mem_closure_finset]
-  constructor
-  · rintro ⟨f, _, rfl⟩
-    exact ⟨f ∘ Subtype.val, Finset.prod_coe_sort s (f := fun a => a ^ f a)⟩
-  · intro ⟨f, hx⟩
-    classical
-    refine ⟨fun a => if h : a ∈ s then f ⟨a, h⟩ else 0, ?_, ?_⟩
-    · aesop
-    · rw [← Finset.prod_attach]
-      simpa
-
-@[to_additive]
-theorem mem_closure_fintype {s : Set M} [Fintype s] :
-    x ∈ closure s ↔ ∃ f : s → ℕ, ∏ a : s, a.1 ^ f a = x := by
-  conv_lhs =>
-    rw [← s.coe_toFinset, mem_closure_finset',
-      Equiv.subtypeEquivRight (fun _ => Set.mem_toFinset) |>.piCongrLeft (fun _ => ℕ)
-        |>.exists_congr_left]
-  congr! 3
-  apply Finset.prod_equiv <| Equiv.subtypeEquivRight fun _ => Set.mem_toFinset <;> simp
-
 end CommMonoid
 end Submonoid

--- a/Mathlib/Algebra/Group/Submonoid/Finsupp.lean
+++ b/Mathlib/Algebra/Group/Submonoid/Finsupp.lean
@@ -27,7 +27,14 @@ theorem exists_finsupp_of_mem_closure_range (hx : x ∈ closure (Set.range f)) :
     · simp
     · simp [pow_add]
 
-variable {f x} in
+@[to_additive]
+theorem exists_of_mem_closure_range [Fintype ι] (hx : x ∈ closure (Set.range f)) :
+    ∃ a : ι → ℕ, x = ∏ i, f i ^ a i := by
+  obtain ⟨a, rfl⟩ := exists_finsupp_of_mem_closure_range f x hx
+  exact ⟨a, by simp⟩
+
+variable {f x}
+
 @[to_additive]
 theorem mem_closure_range_iff :
     x ∈ closure (Set.range f) ↔ ∃ a : ι →₀ ℕ, x = a.prod (f · ^ ·) := by
@@ -36,16 +43,21 @@ theorem mem_closure_range_iff :
   exact prod_mem _ fun i hi ↦ pow_mem (subset_closure (Set.mem_range_self i)) _
 
 @[to_additive]
-theorem exists_of_mem_closure_range [Fintype ι] (hx : x ∈ closure (Set.range f)) :
-    ∃ a : ι → ℕ, x = ∏ i, f i ^ a i := by
-  obtain ⟨a, rfl⟩ := exists_finsupp_of_mem_closure_range f x hx
-  exact ⟨a, by simp⟩
-
-variable {f x} in
-@[to_additive]
 theorem mem_closure_range_iff_of_fintype [Fintype ι] :
     x ∈ closure (Set.range f) ↔ ∃ a : ι → ℕ, x = ∏ i, f i ^ a i := by
   rw [Finsupp.equivFunOnFinite.symm.exists_congr_left, mem_closure_range_iff]
   simp
+
+@[to_additive]
+theorem mem_closure_iff_of_fintype {s : Set M} [Fintype s] :
+    x ∈ closure s ↔ ∃ a : s → ℕ, x = ∏ i : s, i.1 ^ a i := by
+  conv_lhs => rw [← Subtype.range_coe (s := s)]
+  exact mem_closure_range_iff_of_fintype
+
+/-- A variant of `Submonoid.mem_closure_finset` using `s` as the index type. -/
+@[to_additive /-- A variant of `AddSubmonoid.mem_closure_finset` using `s` as the index type. -/]
+theorem mem_closure_finset' {s : Finset M} :
+    x ∈ closure s ↔ ∃ a : s → ℕ, x = ∏ i : s, i.1 ^ a i :=
+  mem_closure_iff_of_fintype
 
 end Submonoid

--- a/Mathlib/LinearAlgebra/Finsupp/LinearCombination.lean
+++ b/Mathlib/LinearAlgebra/Finsupp/LinearCombination.lean
@@ -445,11 +445,15 @@ lemma Submodule.mem_span_finset {s : Finset M} {x : M} :
     simp +contextual [Function.support_subset_iff'.1 hf]
   mpr := by rintro ⟨f, -, rfl⟩; exact sum_mem fun x hx ↦ smul_mem _ _ <| subset_span <| hx
 
+lemma Submodule.mem_span_iff_of_fintype {s : Set M} [Fintype s] {x : M} :
+    x ∈ span R s ↔ ∃ f : s → R, ∑ a : s, f a • a.1 = x := by
+  conv_lhs => rw [← Subtype.range_val (s := s)]
+  exact mem_span_range_iff_exists_fun _
+
 /-- A variant of `Submodule.mem_span_finset` using `s` as the index type. -/
 lemma Submodule.mem_span_finset' {s : Finset M} {x : M} :
-    x ∈ span R s ↔ ∃ f : s → R, ∑ a : s, f a • a.1 = x := by
-  rw [← Subtype.range_val (s := s.toSet), ← Fintype.range_linearCombination]
-  simp [Fintype.linearCombination]
+    x ∈ span R s ↔ ∃ f : s → R, ∑ a : s, f a • a.1 = x :=
+  mem_span_iff_of_fintype
 
 /-- An element `m ∈ M` is contained in the `R`-submodule spanned by a set `s ⊆ M`, if and only if
 `m` can be written as a finite `R`-linear combination of elements of `s`.


### PR DESCRIPTION
`mem_closure_iff_of_fintype` is a corollary of `mem_closure_range_iff_of_fintype`, when we have a `s : Set M` with a `Fintype s` instance on it. `mem_closure_finset'` is a special case of `mem_closure_iff_of_fintype` when we have a `Finset`.

Also add `mem_span_iff_of_fintype` for `Submodule`.

Thanks for the [discussion in Zulip](https://leanprover.zulipchat.com/#narrow/channel/217875-Is-there-code-for-X.3F/topic/.60Finset.2Euniv_eq_attach.60.20for.20.60Set.2EtoFinset.60).

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include at least one commit authored by each
co-author among the commits in the pull request. If necessary, you may 
create empty commits to indicate co-authorship, using commands like so:

git commit --author="Author Name <author@email.com>" --allow-empty -m "add Author Name as coauthor"

When merging, all the commits will be squashed into a single commit listing all co-authors.

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
