### PR TITLE
[Merged by Bors] - feat: add Stirling-style global bounds on factorial

### DIFF
--- a/Mathlib/Analysis/SpecialFunctions/Stirling.lean
+++ b/Mathlib/Analysis/SpecialFunctions/Stirling.lean
@@ -263,11 +263,9 @@ Sharper bounds due to Robbins are available, but are not yet formalised.
 theorem le_factorial_stirling (n : ℕ) : √(2 * π * n) * (n / exp 1) ^ n ≤ n ! := by
   obtain rfl | hn := eq_or_ne n 0
   · simp
-  calc
-    _ = (√(π * (2 * n)) * (n / exp 1) ^ n) := by congr! 2; ring
-    _ = (√π * √(2 * n) * (n / exp 1) ^ n) := by congr! 1; simp [sqrt_mul']
-    _ = √π * (√(2 * n) * (n / exp 1) ^ n) := by ring
-  rw [← le_div_iff₀ (by positivity)]
+  have : √(2 * π * n) * (n / exp 1) ^ n = √π * (√(2 * n) * (n / exp 1) ^ n) := by
+    simp [sqrt_mul']; ring
+  rw [this, ← le_div_iff₀ (by positivity)]
   exact sqrt_pi_le_stirlingSeq hn
 
 /--

--- a/Mathlib/Analysis/SpecialFunctions/Stirling.lean
+++ b/Mathlib/Analysis/SpecialFunctions/Stirling.lean
@@ -13,6 +13,8 @@ import Mathlib.Tactic.AdaptationNote
 This file proves Stirling's formula for the factorial.
 It states that $n!$ grows asymptotically like $\sqrt{2\pi n}(\frac{n}{e})^n$.
 
+Also some _global_ bounds on the factorial function and the Stirling sequence are proved.
+
 ## Proof outline
 
 The proof follows: <https://proofwiki.org/wiki/Stirling%27s_Formula>.
@@ -33,7 +35,8 @@ formula for `π`.
 
 open scoped Topology Real Nat Asymptotics
 
-open Finset Filter Nat Real
+open Nat hiding log log_pow
+open Finset Filter Real
 
 namespace Stirling
 
@@ -236,5 +239,54 @@ lemma factorial_isEquivalent_stirling :
     convert tendsto_stirlingSeq_sqrt_pi.div tendsto_const_nhds this using 1
     ext n
     simp [field, stirlingSeq, mul_right_comm]
+
+/-! ### Global bounds -/
+
+/--
+The Stirling sequence is bounded below by `√π`, for all positive naturals. Note that this bound
+holds for all `n > 0`, rather than for sufficiently large `n`: it is effective.
+-/
+theorem sqrt_pi_le_stirlingSeq {n : ℕ} (hn : n ≠ 0) : √π ≤ stirlingSeq n :=
+  match n, hn with
+  | n + 1, _ =>
+    stirlingSeq'_antitone.le_of_tendsto (b := n) <|
+      tendsto_stirlingSeq_sqrt_pi.comp (tendsto_add_atTop_nat 1)
+
+/--
+Stirling's approximation gives a lower bound for `n!` for all `n`.
+The left hand side is formulated to mimic the usual informal description of the approxmation.
+See also `factorial_isEquivalent_stirling` which says these are asymptotically equivalent. That
+statement gives an upper bound also, but requires sufficiently large `n`. In contrast, this one is
+only a lower bound, but holds for all `n`.
+Sharper bounds due to Robbins are available, but are not yet formalised.
+-/
+theorem le_factorial_stirling (n : ℕ) : √(2 * π * n) * (n / exp 1) ^ n ≤ n ! := by
+  obtain rfl | hn := eq_or_ne n 0
+  · simp
+  calc
+    _ = (√(π * (2 * n)) * (n / exp 1) ^ n) := by congr! 2; ring
+    _ = (√π * √(2 * n) * (n / exp 1) ^ n) := by congr! 1; simp [sqrt_mul']
+    _ = √π * (√(2 * n) * (n / exp 1) ^ n) := by ring
+  rw [← le_div_iff₀ (by positivity)]
+  exact sqrt_pi_le_stirlingSeq hn
+
+/--
+Stirling's approximation gives a lower bound for `log n!` for all positive `n`.
+The left hand side is formulated in decreasing order in `n`: the higher order terms are first.
+This is a consequence of `le_factorial_stirling`, but is stated separately since the logarithmic
+version is sometimes more practical, and having this version eases algebraic calculations for
+applications.
+Sharper bounds due to Robbins are available, but are not yet formalised. These would add
+lower order terms (beginning with `(12 * n)⁻¹`) to the left hand side.
+-/
+theorem le_log_factorial_stirling (n : ℕ) (hn : n ≠ 0) :
+    n * log n - n + log n / 2 + log (2 * π) / 2 ≤ log n ! := by
+  calc
+    _ ≥ log (√(2 * π * n) * (n / rexp 1) ^ n) :=
+        log_le_log (by positivity) (le_factorial_stirling n)
+    _ ≥ (log (2 * π) + log n) / 2 + n * (log n - 1) := by
+        rw [log_mul, log_sqrt, log_mul, log_pow, log_div, log_exp]
+        all_goals positivity
+    _ = _ := by ring
 
 end Stirling

--- a/Mathlib/Analysis/SpecialFunctions/Stirling.lean
+++ b/Mathlib/Analysis/SpecialFunctions/Stirling.lean
@@ -279,14 +279,13 @@ applications.
 Sharper bounds due to Robbins are available, but are not yet formalised. These would add
 lower order terms (beginning with `(12 * n)⁻¹`) to the left hand side.
 -/
-theorem le_log_factorial_stirling (n : ℕ) (hn : n ≠ 0) :
+theorem le_log_factorial_stirling {n : ℕ} (hn : n ≠ 0) :
     n * log n - n + log n / 2 + log (2 * π) / 2 ≤ log n ! := by
   calc
-    _ ≥ log (√(2 * π * n) * (n / rexp 1) ^ n) :=
-        log_le_log (by positivity) (le_factorial_stirling n)
-    _ ≥ (log (2 * π) + log n) / 2 + n * (log n - 1) := by
-        rw [log_mul, log_sqrt, log_mul, log_pow, log_div, log_exp]
-        all_goals positivity
-    _ = _ := by ring
+    _ = (log (2 * π) + log n) / 2 + n * (log n - 1) := by ring
+    _ = log (√(2 * π * n) * (n / rexp 1) ^ n) := by
+      rw [log_mul (x := √_), log_sqrt, log_mul (x := 2 * π), log_pow, log_div, log_exp] <;>
+      positivity
+    _ ≤ _ := log_le_log (by positivity) (le_factorial_stirling n)
 
 end Stirling


### PR DESCRIPTION
---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include at least one commit authored by each
co-author among the commits in the pull request. If necessary, you may 
create empty commits to indicate co-authorship, using commands like so:

git commit --author="Author Name <author@email.com>" --allow-empty -m "add Author Name as coauthor"

When merging, all the commits will be squashed into a single commit listing all co-authors.

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
