### PR TITLE
[Merged by Bors] - chore: import-only tactic files

### DIFF
--- a/Mathlib/Tactic/NormNum.lean
+++ b/Mathlib/Tactic/NormNum.lean
@@ -1,9 +1,3 @@
-/-
-Copyright (c) 2025. All rights reserved.
-Released under Apache 2.0 license as described in the file LICENSE.
-Authors: euprunin
--/
-
 import Mathlib.Tactic.NormNum.Basic
 import Mathlib.Tactic.NormNum.OfScientific
 import Mathlib.Tactic.NormNum.Eq
@@ -12,9 +6,3 @@ import Mathlib.Tactic.NormNum.Pow
 import Mathlib.Tactic.NormNum.Inv
 import Mathlib.Tactic.NormNum.DivMod
 import Mathlib.Data.Rat.Cast.Order
-
-/-!
-We register `norm_num` with the `hint` tactic.
--/
-
-register_hint norm_num

--- a/Mathlib/Tactic/NormNum/Core.lean
+++ b/Mathlib/Tactic/NormNum/Core.lean
@@ -4,6 +4,7 @@ Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Mario Carneiro
 -/
 import Mathlib.Lean.Expr.Rat
+import Mathlib.Tactic.Hint
 import Mathlib.Tactic.NormNum.Result
 import Mathlib.Util.AtLocation
 import Mathlib.Util.Qq
@@ -301,3 +302,9 @@ macro (name := normNumCmd) "#norm_num" cfg:optConfig o:(&" only")?
   `(command| #conv norm_num $cfg:optConfig $[only%$o]? $(args)? => $e)
 
 end Mathlib.Tactic
+
+/-!
+We register `norm_num` with the `hint` tactic.
+-/
+
+register_hint norm_num

--- a/Mathlib/Tactic/Ring.lean
+++ b/Mathlib/Tactic/Ring.lean
@@ -1,15 +1,3 @@
-/-
-Copyright (c) 2025. All rights reserved.
-Released under Apache 2.0 license as described in the file LICENSE.
-Authors: euprunin
--/
-
 import Mathlib.Tactic.Ring.Basic
 import Mathlib.Tactic.Ring.RingNF
 import Mathlib.Tactic.Ring.PNat
-
-/-!
-We register `ring` with the `hint` tactic.
--/
-
-register_hint ring

--- a/Mathlib/Tactic/Ring/RingNF.lean
+++ b/Mathlib/Tactic/Ring/RingNF.lean
@@ -238,3 +238,9 @@ macro (name := ringConv) "ring" : conv =>
 end RingNF
 
 end Mathlib.Tactic
+
+/-!
+We register `ring` with the `hint` tactic.
+-/
+
+register_hint ring


### PR DESCRIPTION
#22365 inadvertently broke the convention that the `ring` and `norm_num` main files should be import-only. This fixes that.

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include at least one commit authored by each
co-author among the commits in the pull request. If necessary, you may 
create empty commits to indicate co-authorship, using commands like so:

git commit --author="Author Name <author@email.com>" --allow-empty -m "add Author Name as coauthor"

When merging, all the commits will be squashed into a single commit listing all co-authors.

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
