### PR TITLE
[Merged by Bors] - chore(RingTheory/Flat): split CharacterModule results from `Flat/Basic.lean`

### DIFF
--- a/Mathlib.lean
+++ b/Mathlib.lean
@@ -5485,6 +5485,7 @@ import Mathlib.RingTheory.Flat.FaithfullyFlat.Algebra
 import Mathlib.RingTheory.Flat.FaithfullyFlat.Basic
 import Mathlib.RingTheory.Flat.Localization
 import Mathlib.RingTheory.Flat.Stability
+import Mathlib.RingTheory.Flat.Tensor
 import Mathlib.RingTheory.Flat.TorsionFree
 import Mathlib.RingTheory.FractionalIdeal.Basic
 import Mathlib.RingTheory.FractionalIdeal.Extended

--- a/Mathlib/Algebra/Category/Grp/EnoughInjectives.lean
+++ b/Mathlib/Algebra/Category/Grp/EnoughInjectives.lean
@@ -16,6 +16,13 @@ import Mathlib.Algebra.Category.Grp.Injective
 Given an abelian group `A`, then `i : A ⟶ ∏_{A⋆} ℚ ⧸ ℤ` defined by `i : a ↦ c ↦ c a` is an
 injective presentation for `A`, hence category of abelian groups has enough injectives.
 
+## Main results
+
+- `AddCommGrp.enoughInjectives` : the category of abelian groups (written additively) has
+  enough injectives.
+- `CommGrp.enoughInjectives` : the category of abelian groups (written multiplicatively) has
+  enough injectives.
+
 ## Implementation notes
 
 This file is split from `Mathlib/Algebra/Category/Grp/Injective.lean` to prevent import loops.

--- a/Mathlib/Algebra/Category/Grp/Injective.lean
+++ b/Mathlib/Algebra/Category/Grp/Injective.lean
@@ -3,36 +3,24 @@ Copyright (c) 2022 Jujian Zhang. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Jujian Zhang
 -/
-import Mathlib.Algebra.Category.ModuleCat.EpiMono
 import Mathlib.Algebra.Category.Grp.ZModuleEquivalence
-import Mathlib.Algebra.EuclideanDomain.Int
 import Mathlib.Algebra.Category.ModuleCat.Injective
-import Mathlib.CategoryTheory.Preadditive.Injective.Basic
+import Mathlib.Algebra.EuclideanDomain.Int
+import Mathlib.GroupTheory.Divisible
 import Mathlib.RingTheory.PrincipalIdealDomain
-import Mathlib.Topology.Instances.AddCircle.Defs
 
 /-!
 # Injective objects in the category of abelian groups
 
 In this file we prove that divisible groups are injective objects in category of (additive) abelian
-groups and that the category of abelian groups has enough injective objects.
+groups. The proof that the category of abelian groups has enough injective objects can be found
+in `Mathlib/Algebra/Category/Grp/EnoughInjectives.lean`.
 
 ## Main results
 
 - `AddCommGrp.injective_of_divisible` : a divisible group is also an injective object.
-- `AddCommGrp.enoughInjectives` : the category of abelian groups (written additively) has
-  enough injectives.
-- `CommGrp.enoughInjectives` : the category of abelian groups (written multiplicatively) has
-  enough injectives.
-
-## Implementation notes
-
-The details of the proof that the category of abelian groups has enough injectives is hidden
-inside the namespace `AddCommGroup.enough_injectives_aux_proofs`. These are not marked `private`,
-but are not supposed to be used directly.
 
 -/
-
 
 open CategoryTheory
 
@@ -65,8 +53,5 @@ instance injective_of_divisible [DivisibleBy A ℤ] :
     Injective (C := AddCommGrp) (AddCommGrp.of A) :=
   (injective_as_module_iff A).mp <|
     Module.injective_object_of_injective_module (inj := (Module.Baer.of_divisible A).injective)
-
-instance injective_ratCircle : Injective <| of <| ULift.{u} <| AddCircle (1 : ℚ) :=
-  injective_of_divisible _
 
 end AddCommGrp

--- a/Mathlib/Algebra/Lie/Weights/Chain.lean
+++ b/Mathlib/Algebra/Lie/Weights/Chain.lean
@@ -5,8 +5,10 @@ Authors: Oliver Nash
 -/
 import Mathlib.Algebra.DirectSum.LinearMap
 import Mathlib.Algebra.Lie.Weights.Cartan
+import Mathlib.Algebra.Order.Group.Pointwise.Interval
 import Mathlib.RingTheory.Finiteness.Nilpotent
 import Mathlib.Data.Int.Interval
+import Mathlib.Order.Filter.Cofinite
 
 /-!
 # Chains of roots and weights

--- a/Mathlib/AlgebraicGeometry/ProjectiveSpectrum/Proper.lean
+++ b/Mathlib/AlgebraicGeometry/ProjectiveSpectrum/Proper.lean
@@ -4,6 +4,7 @@ Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Patience Ablett, Kevin Buzzard, Harald Carlens, Wayne Ng Kwing King, Michael Schlößer,
   Justus Springer, Andrew Yang, Jujian Zhang
 -/
+import Mathlib.Algebra.Order.BigOperators.Ring.Finset
 import Mathlib.AlgebraicGeometry.ProjectiveSpectrum.Basic
 import Mathlib.AlgebraicGeometry.ValuativeCriterion
 

--- a/Mathlib/RingTheory/AdicCompletion/AsTensorProduct.lean
+++ b/Mathlib/RingTheory/AdicCompletion/AsTensorProduct.lean
@@ -7,7 +7,7 @@ import Mathlib.Algebra.FiveLemma
 import Mathlib.LinearAlgebra.TensorProduct.Pi
 import Mathlib.LinearAlgebra.TensorProduct.RightExactness
 import Mathlib.RingTheory.AdicCompletion.Exactness
-import Mathlib.RingTheory.Flat.Basic
+import Mathlib.RingTheory.Flat.Tensor
 
 /-!
 

--- a/Mathlib/RingTheory/Flat/Basic.lean
+++ b/Mathlib/RingTheory/Flat/Basic.lean
@@ -4,7 +4,6 @@ Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Johan Commelin, Jujian Zhang, Yongle Hu
 -/
 import Mathlib.Algebra.Colimit.TensorProduct
-import Mathlib.Algebra.Module.CharacterModule
 import Mathlib.Algebra.Module.Projective
 import Mathlib.LinearAlgebra.TensorProduct.RightExactness
 import Mathlib.RingTheory.Finiteness.Small
@@ -57,6 +56,8 @@ the current `Module.Flat` to `Module.MonoFlat`.
 * Generalize flatness to noncommutative semirings.
 
 -/
+
+assert_not_exists AddCircle
 
 universe v' u v w
 
@@ -287,65 +288,6 @@ lemma iff_lTensor_preserves_injective_linearMap : Flat R M ↔
     ∀ ⦃N N' : Type (max u v)⦄ [AddCommGroup N] [AddCommGroup N'] [Module R N] [Module R N']
       (f : N →ₗ[R] N'), Function.Injective f → Function.Injective (f.lTensor M) :=
   iff_lTensor_preserves_injective_linearMap'
-
-/--
-Define the character module of `M` to be `M →+ ℚ ⧸ ℤ`.
-The character module of `M` is an injective module if and only if
-`f ⊗ 𝟙 M` is injective for any linear map `f` in the same universe as `M`.
--/
-lemma injective_characterModule_iff_rTensor_preserves_injective_linearMap :
-    Module.Injective R (CharacterModule M) ↔
-    ∀ ⦃N N' : Type v⦄ [AddCommGroup N] [AddCommGroup N'] [Module R N] [Module R N']
-      (f : N →ₗ[R] N'), Function.Injective f → Function.Injective (f.rTensor M) := by
-  simp_rw [injective_iff, rTensor_injective_iff_lcomp_surjective, Surjective, DFunLike.ext_iff]; rfl
-
-/-- `CharacterModule M` is an injective module iff `M` is flat.
-See [Lambek_1964] for a self-contained proof. -/
-theorem iff_characterModule_injective [Small.{v} R] :
-    Flat R M ↔ Module.Injective R (CharacterModule M) := by
-  rw [injective_characterModule_iff_rTensor_preserves_injective_linearMap,
-    iff_rTensor_preserves_injective_linearMap']
-
-/-- `CharacterModule M` is Baer iff `M` is flat. -/
-theorem iff_characterModule_baer : Flat R M ↔ Baer R (CharacterModule M) := by
-  rw [equiv_iff (N := ULift.{u} M) ULift.moduleEquiv.symm, iff_characterModule_injective,
-    ← Baer.iff_injective, Baer.congr (CharacterModule.congr ULift.moduleEquiv)]
-
-/-- An `R`-module `M` is flat iff for all ideals `I` of `R`, the tensor product of the
-inclusion `I → R` and the identity `M → M` is injective. See `iff_rTensor_injective` to
-restrict to finitely generated ideals `I`. -/
-theorem iff_rTensor_injective' :
-    Flat R M ↔ ∀ I : Ideal R, Function.Injective (rTensor M I.subtype) := by
-  simp_rw [iff_characterModule_baer, Baer, rTensor_injective_iff_lcomp_surjective,
-    Surjective, DFunLike.ext_iff, Subtype.forall]
-  rfl
-
-/-- The `lTensor`-variant of `iff_rTensor_injective'`. . -/
-theorem iff_lTensor_injective' :
-    Flat R M ↔ ∀ (I : Ideal R), Function.Injective (lTensor M I.subtype) := by
-  simpa [← comm_comp_rTensor_comp_comm_eq] using iff_rTensor_injective'
-
-/-- A module `M` over a ring `R` is flat iff for all finitely generated ideals `I` of `R`, the
-tensor product of the inclusion `I → R` and the identity `M → M` is injective. See
-`iff_rTensor_injective'` to extend to all ideals `I`. -/
-lemma iff_rTensor_injective :
-    Flat R M ↔ ∀ ⦃I : Ideal R⦄, I.FG → Function.Injective (I.subtype.rTensor M) := by
-  refine iff_rTensor_injective'.trans ⟨fun h I _ ↦ h I,
-    fun h I ↦ (injective_iff_map_eq_zero _).mpr fun x hx ↦ ?_⟩
-  obtain ⟨J, hfg, hle, y, rfl⟩ := Submodule.exists_fg_le_eq_rTensor_inclusion x
-  rw [← rTensor_comp_apply] at hx
-  rw [(injective_iff_map_eq_zero _).mp (h hfg) y hx, map_zero]
-
-/-- The `lTensor`-variant of `iff_rTensor_injective`. -/
-theorem iff_lTensor_injective :
-    Flat R M ↔ ∀ ⦃I : Ideal R⦄, I.FG → Function.Injective (I.subtype.lTensor M) := by
-  simpa [← comm_comp_rTensor_comp_comm_eq] using iff_rTensor_injective
-
-/-- An `R`-module `M` is flat if for all finitely generated ideals `I` of `R`,
-the canonical map `I ⊗ M →ₗ M` is injective. -/
-lemma iff_lift_lsmul_comp_subtype_injective : Flat R M ↔ ∀ ⦃I : Ideal R⦄, I.FG →
-    Function.Injective (TensorProduct.lift ((lsmul R M).comp I.subtype)) := by
-  simp [iff_rTensor_injective, ← lid_comp_rTensor]
 
 variable (M) in
 /-- If `M` is flat then `M ⊗ -` is an exact functor. -/

--- a/Mathlib/RingTheory/Flat/EquationalCriterion.lean
+++ b/Mathlib/RingTheory/Flat/EquationalCriterion.lean
@@ -3,9 +3,9 @@ Copyright (c) 2024 Mitchell Lee. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Mitchell Lee, Junyan Xu
 -/
-import Mathlib.RingTheory.Flat.Basic
-import Mathlib.LinearAlgebra.TensorProduct.Vanishing
 import Mathlib.Algebra.Module.FinitePresentation
+import Mathlib.LinearAlgebra.TensorProduct.Vanishing
+import Mathlib.RingTheory.Flat.Tensor
 
 /-! # The equational criterion for flatness
 

--- a/Mathlib/RingTheory/Flat/Tensor.lean
+++ b/Mathlib/RingTheory/Flat/Tensor.lean
@@ -1,0 +1,96 @@
+/-
+Copyright (c) 2020 Johan Commelin. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Johan Commelin, Jujian Zhang
+-/
+import Mathlib.Algebra.Module.CharacterModule
+import Mathlib.RingTheory.Flat.Basic
+
+/-!
+# Flat modules
+
+`M` is flat if `· ⊗ M` preserves finite limits (equivalently, pullbacks, or equalizers).
+If `R` is a ring, an `R`-module `M` is flat if and only if it is mono-flat, and to show
+a module is flat, it suffices to check inclusions of finitely generated ideals into `R`.
+See <https://stacks.math.columbia.edu/tag/00HD>.
+
+## Main theorems
+
+* `Module.Flat.iff_characterModule_injective`: `CharacterModule M` is an injective module iff
+  `M` is flat.
+* `Module.Flat.iff_lTensor_injective`, `Module.Flat.iff_rTensor_injective`,
+  `Module.Flat.iff_lTensor_injective'`, `Module.Flat.iff_rTensor_injective'`:
+  A module `M` over a ring `R` is flat iff for all (finitely generated) ideals `I` of `R`, the
+  tensor product of the inclusion `I → R` and the identity `M → M` is injective.
+-/
+
+universe u v
+
+namespace Module.Flat
+
+open Function (Surjective)
+
+open LinearMap
+
+variable {R : Type u} {M : Type v} [CommRing R] [AddCommGroup M] [Module R M]
+
+/--
+Define the character module of `M` to be `M →+ ℚ ⧸ ℤ`.
+The character module of `M` is an injective module if and only if
+`f ⊗ 𝟙 M` is injective for any linear map `f` in the same universe as `M`.
+-/
+lemma injective_characterModule_iff_rTensor_preserves_injective_linearMap :
+    Module.Injective R (CharacterModule M) ↔
+    ∀ ⦃N N' : Type v⦄ [AddCommGroup N] [AddCommGroup N'] [Module R N] [Module R N']
+      (f : N →ₗ[R] N'), Function.Injective f → Function.Injective (f.rTensor M) := by
+  simp_rw [injective_iff, rTensor_injective_iff_lcomp_surjective, Surjective, DFunLike.ext_iff]; rfl
+
+/-- `CharacterModule M` is an injective module iff `M` is flat.
+See [Lambek_1964] for a self-contained proof. -/
+theorem iff_characterModule_injective [Small.{v} R] :
+    Flat R M ↔ Module.Injective R (CharacterModule M) := by
+  rw [injective_characterModule_iff_rTensor_preserves_injective_linearMap,
+    iff_rTensor_preserves_injective_linearMap']
+
+/-- `CharacterModule M` is Baer iff `M` is flat. -/
+theorem iff_characterModule_baer : Flat R M ↔ Baer R (CharacterModule M) := by
+  rw [equiv_iff (N := ULift.{u} M) ULift.moduleEquiv.symm, iff_characterModule_injective,
+    ← Baer.iff_injective, Baer.congr (CharacterModule.congr ULift.moduleEquiv)]
+
+/-- An `R`-module `M` is flat iff for all ideals `I` of `R`, the tensor product of the
+inclusion `I → R` and the identity `M → M` is injective. See `iff_rTensor_injective` to
+restrict to finitely generated ideals `I`. -/
+theorem iff_rTensor_injective' :
+    Flat R M ↔ ∀ I : Ideal R, Function.Injective (rTensor M I.subtype) := by
+  simp_rw [iff_characterModule_baer, Baer, rTensor_injective_iff_lcomp_surjective,
+    Surjective, DFunLike.ext_iff, Subtype.forall]
+  rfl
+
+/-- The `lTensor`-variant of `iff_rTensor_injective'`. . -/
+theorem iff_lTensor_injective' :
+    Flat R M ↔ ∀ (I : Ideal R), Function.Injective (lTensor M I.subtype) := by
+  simpa [← comm_comp_rTensor_comp_comm_eq] using iff_rTensor_injective'
+
+/-- A module `M` over a ring `R` is flat iff for all finitely generated ideals `I` of `R`, the
+tensor product of the inclusion `I → R` and the identity `M → M` is injective. See
+`iff_rTensor_injective'` to extend to all ideals `I`. -/
+lemma iff_rTensor_injective :
+    Flat R M ↔ ∀ ⦃I : Ideal R⦄, I.FG → Function.Injective (I.subtype.rTensor M) := by
+  refine iff_rTensor_injective'.trans ⟨fun h I _ ↦ h I,
+    fun h I ↦ (injective_iff_map_eq_zero _).mpr fun x hx ↦ ?_⟩
+  obtain ⟨J, hfg, hle, y, rfl⟩ := Submodule.exists_fg_le_eq_rTensor_inclusion x
+  rw [← rTensor_comp_apply] at hx
+  rw [(injective_iff_map_eq_zero _).mp (h hfg) y hx, map_zero]
+
+/-- The `lTensor`-variant of `iff_rTensor_injective`. -/
+theorem iff_lTensor_injective :
+    Flat R M ↔ ∀ ⦃I : Ideal R⦄, I.FG → Function.Injective (I.subtype.lTensor M) := by
+  simpa [← comm_comp_rTensor_comp_comm_eq] using iff_rTensor_injective
+
+/-- An `R`-module `M` is flat if for all finitely generated ideals `I` of `R`,
+the canonical map `I ⊗ M →ₗ M` is injective. -/
+lemma iff_lift_lsmul_comp_subtype_injective : Flat R M ↔ ∀ ⦃I : Ideal R⦄, I.FG →
+    Function.Injective (TensorProduct.lift ((lsmul R M).comp I.subtype)) := by
+  simp [iff_rTensor_injective, ← lid_comp_rTensor]
+
+end Module.Flat

--- a/Mathlib/RingTheory/Flat/TorsionFree.lean
+++ b/Mathlib/RingTheory/Flat/TorsionFree.lean
@@ -7,6 +7,7 @@ Authors: Matthew Jasper, Kevin Buzzard
 import Mathlib.Algebra.Module.Torsion
 import Mathlib.RingTheory.DedekindDomain.Dvr
 import Mathlib.RingTheory.Flat.Localization
+import Mathlib.RingTheory.Flat.Tensor
 import Mathlib.RingTheory.Ideal.IsPrincipal
 
 /-!

--- a/Mathlib/Tactic/Linter/DirectoryDependency.lean
+++ b/Mathlib/Tactic/Linter/DirectoryDependency.lean
@@ -588,6 +588,7 @@ def overrideAllowedImportDirs : NamePrefixRel := .ofArray #[
   (`Mathlib.Algebra.Module.ZLattice, `Mathlib.Analysis),
   (`Mathlib.Algebra.Notation, `Mathlib.Algebra.Notation),
   (`Mathlib.Deprecated, `Mathlib.Deprecated),
+  (`Mathlib.LinearAlgebra.Complex, `Mathlib.Topology), -- Complex numbers are analysis/topology.
   (`Mathlib.LinearAlgebra.Matrix, `Mathlib.Topology), -- For e.g. spectra.
   (`Mathlib.LinearAlgebra.QuadraticForm, `Mathlib.Topology), -- For real/complex quadratic forms.
   (`Mathlib.Topology.Algebra, `Mathlib.Algebra),

--- a/Mathlib/Tactic/Linter/DirectoryDependency.lean
+++ b/Mathlib/Tactic/Linter/DirectoryDependency.lean
@@ -467,6 +467,7 @@ def forbiddenImportDirs : NamePrefixRel := .ofArray #[
   (`Mathlib.LinearAlgebra, `Mathlib.ModelTheory),
   (`Mathlib.LinearAlgebra, `Mathlib.Probability),
   (`Mathlib.LinearAlgebra, `Mathlib.Testing),
+  (`Mathlib.LinearAlgebra, `Mathlib.Topology),
   (`Mathlib.MeasureTheory, `Mathlib.AlgebraicGeometry),
   (`Mathlib.MeasureTheory, `Mathlib.AlgebraicTopology),
   (`Mathlib.MeasureTheory, `Mathlib.Computability),
@@ -587,6 +588,8 @@ def overrideAllowedImportDirs : NamePrefixRel := .ofArray #[
   (`Mathlib.Algebra.Module.ZLattice, `Mathlib.Analysis),
   (`Mathlib.Algebra.Notation, `Mathlib.Algebra.Notation),
   (`Mathlib.Deprecated, `Mathlib.Deprecated),
+  (`Mathlib.LinearAlgebra.Matrix, `Mathlib.Topology), -- For e.g. spectra.
+  (`Mathlib.LinearAlgebra.QuadraticForm, `Mathlib.Topology), -- For real/complex quadratic forms.
   (`Mathlib.Topology.Algebra, `Mathlib.Algebra),
   (`Mathlib.Topology.Compactification, `Mathlib.Geometry.Manifold)
 ]

--- a/MathlibTest/Algebra/Category/Grp/Injective.lean
+++ b/MathlibTest/Algebra/Category/Grp/Injective.lean
@@ -1,0 +1,10 @@
+import Mathlib.Algebra.Category.Grp.Injective
+import Mathlib.Topology.Instances.AddCircle.Defs
+
+open CategoryTheory
+
+-- This instance used to have a specialized proof, but we can now find it with typeclass synthesis.
+-- If this test fails, you should re-add this as a specialized instance.
+instance AddCommGrp.injective_ratCircle : Injective <| of <| ULift.{u} <| AddCircle (1 : ℚ) :=
+  inferInstance
+  -- Proof should be: injective_of_divisible _


### PR DESCRIPTION
The results requiring character modules require importing a whole set of topological definitions, via `AddCircle`. This creates a big topological dependency tree for theory that otherwise lives neatly in algebra. As we can see by looking at the 50 or so files losing hundreds of dependencies each!

I spotted this as I tried to reduce the amount of analysis and topology imported into the LinearAlgebra folder.

---

Not sure about the naming of the file, other suggestions are welcome!

- [x] depends on: #29779 (allows us to add a DirectoryDependency lint)
- [x] depends on: #29811

<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include at least one commit authored by each
co-author among the commits in the pull request. If necessary, you may 
create empty commits to indicate co-authorship, using commands like so:

git commit --author="Author Name <author@email.com>" --allow-empty -m "add Author Name as coauthor"

When merging, all the commits will be squashed into a single commit listing all co-authors.

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
