### PR TITLE
[Merged by Bors] - chore(Algebra/Category/Grp): don't import `AddCircle` in `Injective.lean`

### DIFF
--- a/Mathlib/Algebra/Category/Grp/EnoughInjectives.lean
+++ b/Mathlib/Algebra/Category/Grp/EnoughInjectives.lean
@@ -16,6 +16,13 @@ import Mathlib.Algebra.Category.Grp.Injective
 Given an abelian group `A`, then `i : A ⟶ ∏_{A⋆} ℚ ⧸ ℤ` defined by `i : a ↦ c ↦ c a` is an
 injective presentation for `A`, hence category of abelian groups has enough injectives.
 
+## Main results
+
+- `AddCommGrp.enoughInjectives` : the category of abelian groups (written additively) has
+  enough injectives.
+- `CommGrp.enoughInjectives` : the category of abelian groups (written multiplicatively) has
+  enough injectives.
+
 ## Implementation notes
 
 This file is split from `Mathlib/Algebra/Category/Grp/Injective.lean` to prevent import loops.

--- a/Mathlib/Algebra/Category/Grp/Injective.lean
+++ b/Mathlib/Algebra/Category/Grp/Injective.lean
@@ -3,36 +3,24 @@ Copyright (c) 2022 Jujian Zhang. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Jujian Zhang
 -/
-import Mathlib.Algebra.Category.ModuleCat.EpiMono
 import Mathlib.Algebra.Category.Grp.ZModuleEquivalence
-import Mathlib.Algebra.EuclideanDomain.Int
 import Mathlib.Algebra.Category.ModuleCat.Injective
-import Mathlib.CategoryTheory.Preadditive.Injective.Basic
+import Mathlib.Algebra.EuclideanDomain.Int
+import Mathlib.GroupTheory.Divisible
 import Mathlib.RingTheory.PrincipalIdealDomain
-import Mathlib.Topology.Instances.AddCircle.Defs
 
 /-!
 # Injective objects in the category of abelian groups
 
 In this file we prove that divisible groups are injective objects in category of (additive) abelian
-groups and that the category of abelian groups has enough injective objects.
+groups. The proof that the category of abelian groups has enough injective objects can be found
+in `Mathlib/Algebra/Category/Grp/EnoughInjectives.lean`.
 
 ## Main results
 
 - `AddCommGrp.injective_of_divisible` : a divisible group is also an injective object.
-- `AddCommGrp.enoughInjectives` : the category of abelian groups (written additively) has
-  enough injectives.
-- `CommGrp.enoughInjectives` : the category of abelian groups (written multiplicatively) has
-  enough injectives.
-
-## Implementation notes
-
-The details of the proof that the category of abelian groups has enough injectives is hidden
-inside the namespace `AddCommGroup.enough_injectives_aux_proofs`. These are not marked `private`,
-but are not supposed to be used directly.
 
 -/
-
 
 open CategoryTheory
 
@@ -65,8 +53,5 @@ instance injective_of_divisible [DivisibleBy A ℤ] :
     Injective (C := AddCommGrp) (AddCommGrp.of A) :=
   (injective_as_module_iff A).mp <|
     Module.injective_object_of_injective_module (inj := (Module.Baer.of_divisible A).injective)
-
-instance injective_ratCircle : Injective <| of <| ULift.{u} <| AddCircle (1 : ℚ) :=
-  injective_of_divisible _
 
 end AddCommGrp

--- a/MathlibTest/Algebra/Category/Grp/Injective.lean
+++ b/MathlibTest/Algebra/Category/Grp/Injective.lean
@@ -1,0 +1,10 @@
+import Mathlib.Algebra.Category.Grp.Injective
+import Mathlib.Topology.Instances.AddCircle.Defs
+
+open CategoryTheory
+
+-- This instance used to have a specialized proof, but we can now find it with typeclass synthesis.
+-- If this test fails, you should re-add this as a specialized instance.
+instance AddCommGrp.injective_ratCircle : Injective <| of <| ULift.{u} <| AddCircle (1 : ℚ) :=
+  inferInstance
+  -- Proof should be: injective_of_divisible _


### PR DESCRIPTION
The file `Grp/Injective.lean` contained an injectivity result for `AddCircle`, but this is immediately derived from existing instances. It used to have a much more complex proof. Since `AddCircle` brings with it a whole bunch of analysis and topology imports that we don't need for this algebraic theory, this saves us a couple hundred transitive imports.

Also, clean up the module docs to reflect the current situation.

I have moved the instance to a test file, to ensure it remains accessible even after future refactors.

This import was spotted in the same PR run as #29808, but does not change the top-level directory import structure in the same way.


---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include at least one commit authored by each
co-author among the commits in the pull request. If necessary, you may 
create empty commits to indicate co-authorship, using commands like so:

git commit --author="Author Name <author@email.com>" --allow-empty -m "add Author Name as coauthor"

When merging, all the commits will be squashed into a single commit listing all co-authors.

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
