### PR TITLE
[Merged by Bors] - feat(RingTheory): {Mv}PowerSeries.{le_}{weighted}Order_prod

### DIFF
--- a/Mathlib/RingTheory/MvPowerSeries/NoZeroDivisors.lean
+++ b/Mathlib/RingTheory/MvPowerSeries/NoZeroDivisors.lean
@@ -174,9 +174,20 @@ theorem weightedOrder_mul (w : σ → ℕ) (f g : MvPowerSeries σ R) :
   · rw [not_lt_top_iff] at hf
     simp [hf]
 
+theorem weightedOrder_prod {R : Type*} [CommSemiring R] [NoZeroDivisors R] [Nontrivial R]
+    {ι : Type*} (w : σ → ℕ) (f : ι → MvPowerSeries σ R) (s : Finset ι) :
+    ∑ i ∈ s, (f i).weightedOrder w = (∏ i ∈ s, f i).weightedOrder w := by
+  induction s using Finset.cons_induction with
+  | empty => simp
+  | cons a s ha ih => rw [Finset.sum_cons ha, Finset.prod_cons ha, weightedOrder_mul, ih]
+
 theorem order_mul (f g : MvPowerSeries σ R) :
     (f * g).order = f.order + g.order :=
   weightedOrder_mul _ f g
+
+theorem order_prod {R : Type*} [CommSemiring R] [NoZeroDivisors R] [Nontrivial R]
+    {ι : Type*} (f : ι → MvPowerSeries σ R) (s : Finset ι) :
+    ∑ i ∈ s, (f i).order = (∏ i ∈ s, f i).order := weightedOrder_prod _ _ _
 
 end MvPowerSeries
 

--- a/Mathlib/RingTheory/MvPowerSeries/NoZeroDivisors.lean
+++ b/Mathlib/RingTheory/MvPowerSeries/NoZeroDivisors.lean
@@ -176,7 +176,7 @@ theorem weightedOrder_mul (w : σ → ℕ) (f g : MvPowerSeries σ R) :
 
 theorem weightedOrder_prod {R : Type*} [CommSemiring R] [NoZeroDivisors R] [Nontrivial R]
     {ι : Type*} (w : σ → ℕ) (f : ι → MvPowerSeries σ R) (s : Finset ι) :
-    ∑ i ∈ s, (f i).weightedOrder w = (∏ i ∈ s, f i).weightedOrder w := by
+    (∏ i ∈ s, f i).weightedOrder w = ∑ i ∈ s, (f i).weightedOrder w:= by
   induction s using Finset.cons_induction with
   | empty => simp
   | cons a s ha ih => rw [Finset.sum_cons ha, Finset.prod_cons ha, weightedOrder_mul, ih]
@@ -187,7 +187,7 @@ theorem order_mul (f g : MvPowerSeries σ R) :
 
 theorem order_prod {R : Type*} [CommSemiring R] [NoZeroDivisors R] [Nontrivial R]
     {ι : Type*} (f : ι → MvPowerSeries σ R) (s : Finset ι) :
-    ∑ i ∈ s, (f i).order = (∏ i ∈ s, f i).order := weightedOrder_prod _ _ _
+    (∏ i ∈ s, f i).order = ∑ i ∈ s, (f i).order := weightedOrder_prod _ _ _
 
 end MvPowerSeries
 

--- a/Mathlib/RingTheory/MvPowerSeries/Order.lean
+++ b/Mathlib/RingTheory/MvPowerSeries/Order.lean
@@ -232,6 +232,9 @@ theorem weightedOrder_monomial_of_ne_zero {d : σ →₀ ℕ} {a : R} (h : a ≠
   classical
   rw [weightedOrder_monomial, if_neg h]
 
+@[simp]
+theorem weightedOrder_one [Nontrivial R] : (1 : MvPowerSeries σ R).weightedOrder w = 0 :=
+  weightedOrder_monomial_of_ne_zero w one_ne_zero
 
 /-- The order of the sum of two formal power series is at least the minimum of their orders. -/
 theorem min_weightedOrder_le_add :
@@ -288,6 +291,15 @@ theorem le_weightedOrder_mul :
       exfalso
       apply ne_of_lt (lt_of_lt_of_le hd <| add_le_add hi hj)
       rw [← hij, map_add, Nat.cast_add]
+
+theorem le_weightedOrder_prod {R : Type*} [CommSemiring R] {ι : Type*} (w : σ → ℕ)
+    (f : ι → MvPowerSeries σ R) (s : Finset ι) :
+    ∑ i ∈ s, (f i).weightedOrder w ≤ (∏ i ∈ s, f i).weightedOrder w := by
+  induction s using Finset.cons_induction with
+  | empty => simp
+  | cons a s ha ih =>
+    rw [Finset.sum_cons ha, Finset.prod_cons ha]
+    exact le_trans (add_le_add_left ih _) (le_weightedOrder_mul _)
 
 alias weightedOrder_mul_ge := le_weightedOrder_mul
 
@@ -424,6 +436,10 @@ theorem le_order_mul : f.order + g.order ≤ order (f * g) :=
   le_weightedOrder_mul _
 
 alias order_mul_ge := le_order_mul
+
+theorem le_order_prod {R : Type*} [CommSemiring R] {ι : Type*}
+    (f : ι → MvPowerSeries σ R) (s : Finset ι) : ∑ i ∈ s, (f i).order ≤ (∏ i ∈ s, f i).order :=
+  le_weightedOrder_prod _ _ _
 
 section Ring
 

--- a/Mathlib/RingTheory/PowerSeries/Order.lean
+++ b/Mathlib/RingTheory/PowerSeries/Order.lean
@@ -187,6 +187,14 @@ theorem le_order_pow (φ : R⟦X⟧) (n : ℕ) : n • order φ ≤ order (φ ^ 
     apply le_trans _ (le_order_mul _ _)
     exact add_le_add_right hn φ.order
 
+theorem le_order_prod {R : Type*} [CommSemiring R] {ι : Type*} (φ : ι → R⟦X⟧) (s : Finset ι) :
+    ∑ i ∈ s, (φ i).order ≤ (∏ i ∈ s, φ i).order := by
+  induction s using Finset.cons_induction with
+  | empty => simp
+  | cons a s ha ih =>
+    rw [Finset.sum_cons ha, Finset.prod_cons ha]
+    exact le_trans (add_le_add_left ih _) (le_order_mul _ _)
+
 alias order_mul_ge := le_order_mul
 
 /-- The order of the monomial `a*X^n` is infinite if `a = 0` and `n` otherwise. -/
@@ -377,6 +385,12 @@ theorem order_pow [Nontrivial R] (φ : R⟦X⟧) (n : ℕ) :
   | zero => simp
   | succ n hn =>
     simp only [add_smul, one_smul, pow_succ, order_mul, hn]
+
+theorem order_prod {R : Type*} [CommSemiring R] [NoZeroDivisors R] [Nontrivial R] {ι : Type*}
+    (φ : ι → R⟦X⟧) (s : Finset ι) : ∑ i ∈ s, (φ i).order = (∏ i ∈ s, φ i).order := by
+  induction s using Finset.cons_induction with
+  | empty => simp
+  | cons a s ha ih => rw [Finset.sum_cons ha, Finset.prod_cons ha, order_mul, ih]
 
 /-- The operation of dividing a power series by the largest possible power of `X`
 preserves multiplication. -/

--- a/Mathlib/RingTheory/PowerSeries/Order.lean
+++ b/Mathlib/RingTheory/PowerSeries/Order.lean
@@ -387,7 +387,7 @@ theorem order_pow [Nontrivial R] (φ : R⟦X⟧) (n : ℕ) :
     simp only [add_smul, one_smul, pow_succ, order_mul, hn]
 
 theorem order_prod {R : Type*} [CommSemiring R] [NoZeroDivisors R] [Nontrivial R] {ι : Type*}
-    (φ : ι → R⟦X⟧) (s : Finset ι) : ∑ i ∈ s, (φ i).order = (∏ i ∈ s, φ i).order := by
+    (φ : ι → R⟦X⟧) (s : Finset ι) : (∏ i ∈ s, φ i).order = ∑ i ∈ s, (φ i).order := by
   induction s using Finset.cons_induction with
   | empty => simp
   | cons a s ha ih => rw [Finset.sum_cons ha, Finset.prod_cons ha, order_mul, ih]


### PR DESCRIPTION
The big operator version of `{le}_{weighted}Order_mul`

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include at least one commit authored by each
co-author among the commits in the pull request. If necessary, you may 
create empty commits to indicate co-authorship, using commands like so:

git commit --author="Author Name <author@email.com>" --allow-empty -m "add Author Name as coauthor"

When merging, all the commits will be squashed into a single commit listing all co-authors.

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
