### PR TITLE
[Merged by Bors] - feat(CategoryTheory): define internally projective objects

### DIFF
--- a/Mathlib.lean
+++ b/Mathlib.lean
@@ -2637,6 +2637,7 @@ import Mathlib.CategoryTheory.ObjectProperty.EpiMono
 import Mathlib.CategoryTheory.ObjectProperty.Extensions
 import Mathlib.CategoryTheory.ObjectProperty.FullSubcategory
 import Mathlib.CategoryTheory.ObjectProperty.Ind
+import Mathlib.CategoryTheory.ObjectProperty.Retract
 import Mathlib.CategoryTheory.ObjectProperty.Shift
 import Mathlib.CategoryTheory.Opposites
 import Mathlib.CategoryTheory.PEmpty
@@ -2663,6 +2664,7 @@ import Mathlib.CategoryTheory.Preadditive.Mat
 import Mathlib.CategoryTheory.Preadditive.OfBiproducts
 import Mathlib.CategoryTheory.Preadditive.Opposite
 import Mathlib.CategoryTheory.Preadditive.Projective.Basic
+import Mathlib.CategoryTheory.Preadditive.Projective.Internal
 import Mathlib.CategoryTheory.Preadditive.Projective.LiftingProperties
 import Mathlib.CategoryTheory.Preadditive.Projective.Preserves
 import Mathlib.CategoryTheory.Preadditive.Projective.Resolution

--- a/Mathlib/CategoryTheory/Functor/EpiMono.lean
+++ b/Mathlib/CategoryTheory/Functor/EpiMono.lean
@@ -100,21 +100,33 @@ theorem reflectsMonomorphisms_of_preserves_of_reflects (F : C ⥤ D) (G : D ⥤ 
     [PreservesMonomorphisms G] [ReflectsMonomorphisms (F ⋙ G)] : ReflectsMonomorphisms F :=
   ⟨fun f _ => (F ⋙ G).mono_of_mono_map <| show Mono (G.map (F.map f)) from inferInstance⟩
 
+lemma preservesMonomorphisms.of_natTrans {F G : C ⥤ D} [PreservesMonomorphisms F]
+    (f : G ⟶ F) [∀ X, Mono (f.app X)] :
+    PreservesMonomorphisms G where
+  preserves {X Y} π hπ := by
+    suffices Mono (G.map π ≫ f.app Y) from mono_of_mono (G.map π) (f.app Y)
+    rw [f.naturality π]
+    infer_instance
+
 theorem preservesMonomorphisms.of_iso {F G : C ⥤ D} [PreservesMonomorphisms F] (α : F ≅ G) :
     PreservesMonomorphisms G :=
-  { preserves := fun {X} {Y} f h => by
-      suffices G.map f = (α.app X).inv ≫ F.map f ≫ (α.app Y).hom from this ▸ mono_comp _ _
-      rw [Iso.eq_inv_comp, Iso.app_hom, Iso.app_hom, NatTrans.naturality] }
+  of_natTrans α.inv
 
 theorem preservesMonomorphisms.iso_iff {F G : C ⥤ D} (α : F ≅ G) :
     PreservesMonomorphisms F ↔ PreservesMonomorphisms G :=
   ⟨fun _ => preservesMonomorphisms.of_iso α, fun _ => preservesMonomorphisms.of_iso α.symm⟩
 
+lemma preservesEpimorphisms.of_natTrans {F G : C ⥤ D} [PreservesEpimorphisms F]
+    (f : F ⟶ G) [∀ X, Epi (f.app X)] :
+    PreservesEpimorphisms G where
+  preserves {X Y} π hπ := by
+    suffices Epi (f.app X ≫ G.map π) from epi_of_epi (f.app X) (G.map π)
+    rw [← f.naturality π]
+    infer_instance
+
 theorem preservesEpimorphisms.of_iso {F G : C ⥤ D} [PreservesEpimorphisms F] (α : F ≅ G) :
     PreservesEpimorphisms G :=
-  { preserves := fun {X} {Y} f h => by
-      suffices G.map f = (α.app X).inv ≫ F.map f ≫ (α.app Y).hom from this ▸ epi_comp _ _
-      rw [Iso.eq_inv_comp, Iso.app_hom, Iso.app_hom, NatTrans.naturality] }
+  of_natTrans α.hom
 
 theorem preservesEpimorphisms.iso_iff {F G : C ⥤ D} (α : F ≅ G) :
     PreservesEpimorphisms F ↔ PreservesEpimorphisms G :=
@@ -182,6 +194,20 @@ instance (priority := 100) reflectsEpimorphisms_of_faithful (F : C ⥤ D) [Faith
   reflects {X} {Y} f _ :=
     ⟨fun {Z} g h hgh =>
       F.map_injective ((cancel_epi (F.map f)).1 (by rw [← F.map_comp, hgh, F.map_comp]))⟩
+
+instance {F G : C ⥤ D} (f : F ⟶ G) [IsSplitEpi f] (X : C) : IsSplitEpi (f.app X) :=
+  inferInstanceAs (IsSplitEpi (((evaluation C D).obj X).map f))
+
+instance {F G : C ⥤ D} (f : F ⟶ G) [IsSplitMono f] (X : C) : IsSplitMono (f.app X) :=
+  inferInstanceAs (IsSplitMono (((evaluation C D).obj X).map f))
+
+lemma preservesEpimorphisms.ofRetract {F G : C ⥤ D} (r : Retract G F) [F.PreservesEpimorphisms] :
+    G.PreservesEpimorphisms where
+  preserves := (preservesEpimorphisms.of_natTrans r.r).preserves
+
+lemma preservesMonomorphisms.ofRetract {F G : C ⥤ D} (r : Retract G F) [F.PreservesMonomorphisms] :
+    G.PreservesMonomorphisms where
+  preserves := (preservesMonomorphisms.of_natTrans r.i).preserves
 
 section
 

--- a/Mathlib/CategoryTheory/ObjectProperty/Retract.lean
+++ b/Mathlib/CategoryTheory/ObjectProperty/Retract.lean
@@ -1,0 +1,61 @@
+/-
+Copyright (c) 2025 Dagur Asgeirsson. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Dagur Asgeirsson
+-/
+import Mathlib.CategoryTheory.ObjectProperty.Basic
+import Mathlib.CategoryTheory.Retract
+
+/-! # Properties of objects which are stable under retracts
+
+Given a category `C` and `P : ObjectProperty C` (i.e. `P : C → Prop`),
+this file introduces the type class `P.IsStableUnderRetracts`.
+-/
+
+namespace CategoryTheory.ObjectProperty
+
+variable {C : Type*} [Category C] (P : ObjectProperty C)
+
+/-- A predicate `C → Prop` on the objects of a category is stable under retracts
+if whenever `P Y`, then all the objects `X` that are retracts of `X` also satisfy `P X`. -/
+class IsStableUnderRetracts where
+  of_retract {X Y : C} (_ : Retract X Y) (_ : P Y) : P X
+
+lemma prop_of_retract [IsStableUnderRetracts P] {X Y : C} (h : Retract X Y) (hY : P Y) : P X :=
+  IsStableUnderRetracts.of_retract h hY
+
+/-- The closure by retracts of a predicate on objects in a category. -/
+def retractClosure : ObjectProperty C := fun X => ∃ (Y : C) (_ : P Y), Nonempty (Retract X Y)
+
+lemma prop_retractClosure_iff (X : C) :
+    retractClosure P X ↔ ∃ (Y : C) (_ : P Y), Nonempty (Retract X Y) := by rfl
+
+variable {P} in
+lemma prop_retractClosure {X Y : C} (h : P Y) (r : Retract X Y) : retractClosure P X :=
+  ⟨Y, h, ⟨r⟩⟩
+
+lemma le_retractClosure : P ≤ retractClosure P :=
+  fun X hX => ⟨X, hX, ⟨Retract.refl X⟩⟩
+
+variable {P Q} in
+lemma monotone_retractClosure (h : P ≤ Q) : retractClosure P ≤ retractClosure Q := by
+  rintro X ⟨X', hX', ⟨e⟩⟩
+  exact ⟨X', h _ hX', ⟨e⟩⟩
+
+lemma retractClosure_eq_self [IsStableUnderRetracts P] : retractClosure P = P := by
+  apply le_antisymm
+  · intro X ⟨Y, hY, ⟨e⟩⟩
+    exact prop_of_retract P e hY
+  · exact le_retractClosure P
+
+lemma retractClosure_le_iff (Q : ObjectProperty C) [IsStableUnderRetracts Q] :
+    retractClosure P ≤ Q ↔ P ≤ Q :=
+  ⟨(le_retractClosure P).trans,
+    fun h => (monotone_retractClosure h).trans (by rw [retractClosure_eq_self])⟩
+
+instance : IsStableUnderRetracts (retractClosure P) where
+  of_retract := by
+    rintro X Y r₁ ⟨Z, hZ, ⟨r₂⟩⟩
+    refine ⟨Z, hZ, ⟨r₁.trans r₂⟩⟩
+
+end CategoryTheory.ObjectProperty

--- a/Mathlib/CategoryTheory/Preadditive/Projective/Internal.lean
+++ b/Mathlib/CategoryTheory/Preadditive/Projective/Internal.lean
@@ -6,13 +6,15 @@ Authors: Dagur Asgeirsson, Jonas van der Schaaf
 import Mathlib.CategoryTheory.Retract
 import Mathlib.CategoryTheory.Closed.Monoidal
 import Mathlib.CategoryTheory.Limits.FunctorCategory.EpiMono
+
 /-!
 
 # Internal projectivity
 
-This file defines internal projectivity and provides explicit characterizations of
-internal projectivity in the category of light condensed modules over a commutative ring.
-
+This file defines internal projectivity of objects `P` in a category `C` as a class
+`InternallyProjective P`. This means that the functor taking internal homs out of `P`
+preserves epimorphisms. It also proves that a retract of an internally projective object
+is internally projective (see `InternallyProjective.ofRetract`).
 -/
 
 noncomputable section

--- a/Mathlib/CategoryTheory/Preadditive/Projective/Internal.lean
+++ b/Mathlib/CategoryTheory/Preadditive/Projective/Internal.lean
@@ -3,9 +3,7 @@ Copyright (c) 2025 Dagur Asgeirsson. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Dagur Asgeirsson, Jonas van der Schaaf
 -/
-import Mathlib.CategoryTheory.Retract
 import Mathlib.CategoryTheory.Closed.Monoidal
-import Mathlib.CategoryTheory.Limits.FunctorCategory.EpiMono
 
 /-!
 

--- a/Mathlib/CategoryTheory/Preadditive/Projective/Internal.lean
+++ b/Mathlib/CategoryTheory/Preadditive/Projective/Internal.lean
@@ -1,0 +1,45 @@
+/-
+Copyright (c) 2025 Dagur Asgeirsson. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Dagur Asgeirsson, Jonas van der Schaaf
+-/
+import Mathlib.CategoryTheory.Retract
+import Mathlib.CategoryTheory.Closed.Monoidal
+import Mathlib.CategoryTheory.Limits.FunctorCategory.EpiMono
+/-!
+
+# Internal projectivity
+
+This file defines internal projectivity and provides explicit characterizations of
+internal projectivity in the category of light condensed modules over a commutative ring.
+
+-/
+
+noncomputable section
+
+universe u
+
+open CategoryTheory MonoidalCategory MonoidalClosed Limits Functor
+
+namespace CategoryTheory
+
+variable {C : Type*} [Category C] [MonoidalCategory C] [MonoidalClosed C]
+
+/--
+An object `P : C` is *internally projective* if the functor `P ⟶[C] -` taking internal homs
+out of `P` preserves epimorphisms.
+-/
+class InternallyProjective (P : C) : Prop where
+  /-- The functor `P ⟶[C] -` preserves epimorphisms. -/
+  preserves_epi : (ihom P).PreservesEpimorphisms
+
+attribute [instance] InternallyProjective.preserves_epi
+
+namespace InternallyProjective
+
+lemma ofRetract {X Y : C} (r : Retract Y X) [InternallyProjective X] : InternallyProjective Y where
+  preserves_epi :=
+    have : Retract (ihom Y) (ihom X) := r.op.map internalHom
+    preservesEpimorphisms.ofRetract this
+
+end CategoryTheory.InternallyProjective

--- a/Mathlib/CategoryTheory/Preadditive/Projective/Internal.lean
+++ b/Mathlib/CategoryTheory/Preadditive/Projective/Internal.lean
@@ -4,6 +4,7 @@ Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Dagur Asgeirsson, Jonas van der Schaaf
 -/
 import Mathlib.CategoryTheory.Closed.Monoidal
+import Mathlib.CategoryTheory.ObjectProperty.Retract
 
 /-!
 
@@ -13,6 +14,10 @@ This file defines internal projectivity of objects `P` in a category `C` as a cl
 `InternallyProjective P`. This means that the functor taking internal homs out of `P`
 preserves epimorphisms. It also proves that a retract of an internally projective object
 is internally projective (see `InternallyProjective.ofRetract`).
+
+This property is important in the setting of light condensed abelian groups, when establishing
+the solid theory (see the lecture series on analytic stacks:
+https://www.youtube.com/playlist?list=PLx5f8IelFRgGmu6gmL-Kf_Rl_6Mm7juZO).
 -/
 
 noncomputable section
@@ -29,17 +34,27 @@ variable {C : Type*} [Category C] [MonoidalCategory C] [MonoidalClosed C]
 An object `P : C` is *internally projective* if the functor `P ⟶[C] -` taking internal homs
 out of `P` preserves epimorphisms.
 -/
-class InternallyProjective (P : C) : Prop where
-  /-- The functor `P ⟶[C] -` preserves epimorphisms. -/
-  preserves_epi : (ihom P).PreservesEpimorphisms
+def isInternallyProjective : ObjectProperty C := fun P ↦ (ihom P).PreservesEpimorphisms
 
-attribute [instance] InternallyProjective.preserves_epi
+/--
+An object `P : C` is *internally projective* if the functor `P ⟶[C] -` taking internal homs
+out of `P` preserves epimorphisms.
+-/
+abbrev InternallyProjective (P : C) := isInternallyProjective.Is P
+
+instance InternallyProjective.preserves_epi (P : C) [InternallyProjective P] :
+    (ihom P).PreservesEpimorphisms :=
+  isInternallyProjective.prop_of_is P
+
+instance : (isInternallyProjective (C := C)).IsStableUnderRetracts where
+  of_retract {Y X} r h :=
+    have : InternallyProjective X := ⟨h⟩
+    have : Retract (ihom Y) (ihom X) := r.op.map internalHom
+    preservesEpimorphisms.ofRetract this
 
 namespace InternallyProjective
 
-lemma ofRetract {X Y : C} (r : Retract Y X) [InternallyProjective X] : InternallyProjective Y where
-  preserves_epi :=
-    have : Retract (ihom Y) (ihom X) := r.op.map internalHom
-    preservesEpimorphisms.ofRetract this
+lemma ofRetract {X Y : C} (r : Retract Y X) [InternallyProjective X] : InternallyProjective Y :=
+  ⟨isInternallyProjective.prop_of_retract r (isInternallyProjective.prop_of_is _)⟩
 
 end CategoryTheory.InternallyProjective

--- a/Mathlib/CategoryTheory/Retract.lean
+++ b/Mathlib/CategoryTheory/Retract.lean
@@ -34,6 +34,15 @@ attribute [reassoc (attr := simp)] retract
 
 variable {X Y : C} (h : Retract X Y)
 
+open Opposite
+
+/-- Retracts are preserved when passing to the opposite category. -/
+@[simps]
+def op : Retract (op X) (op Y) where
+  i := h.r.op
+  r := h.i.op
+  retract := by simp [← op_comp, h.retract]
+
 /-- If `X` is a retract of `Y`, then `F.obj X` is a retract of `F.obj Y`. -/
 @[simps]
 def map (F : C ⥤ D) : Retract (F.obj X) (F.obj Y) where


### PR DESCRIPTION
This PR defines internal projectivity and proves that a retract of an internally projective object is internally projective

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include at least one commit authored by each
co-author among the commits in the pull request. If necessary, you may 
create empty commits to indicate co-authorship, using commands like so:

git commit --author="Author Name <author@email.com>" --allow-empty -m "add Author Name as coauthor"

When merging, all the commits will be squashed into a single commit listing all co-authors.

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
