### PR TITLE
[Merged by Bors] - feat(CategoryTheory): limit presentations

### DIFF
--- a/Mathlib/CategoryTheory/Limits/Presentation.lean
+++ b/Mathlib/CategoryTheory/Limits/Presentation.lean
@@ -274,7 +274,7 @@ def map (P : LimitPresentation J X) {D : Type*} [Category D] (F : C ⥤ D)
 /-- If `P` is a limit presentation of `X`, it is possible to define another
 limit presentation of `X` where `P.diag` is replaced by an isomorphic functor. -/
 @[simps]
-def chgDiag (P : LimitPresentation J X) {F : J ⥤ C} (e : F ≅ P.diag) :
+def changeDiag (P : LimitPresentation J X) {F : J ⥤ C} (e : F ≅ P.diag) :
     LimitPresentation J X where
   diag := F
   π := P.π ≫ e.inv

--- a/Mathlib/CategoryTheory/Limits/Presentation.lean
+++ b/Mathlib/CategoryTheory/Limits/Presentation.lean
@@ -19,10 +19,11 @@ the data of objects `Dⱼ` and natural maps `sⱼ : Dⱼ ⟶ X` that make `X` th
   `{Dᵢ}` in `C` and natural maps `sᵢ : Dᵢ ⟶ X` making `X` into the colimit of the `Dᵢ`.
 - `CategoryTheory.Limits.ColimitPresentation.bind`: Given a colimit presentation of `X` and
   colimit presentations of the components, this is the colimit presentation over the sigma type.
+- `CategoryTheory.Limits.LimitPresentation`: A limit presentation of `X` over `J` is a diagram
+  `{Dᵢ}` in `C` and natural maps `sᵢ : X ⟶ Dᵢ` making `X` into the limit of the `Dᵢ`.
 
 ## TODOs:
 
-- Dualise to obtain `LimitPresentation`.
 - Refactor `TransfiniteCompositionOfShape` so that it extends `ColimitPresentation`.
 -/
 
@@ -52,6 +53,9 @@ initialize_simps_projections ColimitPresentation (-isColimit)
 abbrev cocone (pres : ColimitPresentation J X) : Cocone pres.diag :=
   Cocone.mk _ pres.ι
 
+lemma hasColimit (pres : ColimitPresentation J X) : HasColimit pres.diag :=
+  ⟨_, pres.isColimit⟩
+
 /-- The canonical colimit presentation of any object over a point. -/
 @[simps]
 noncomputable
@@ -69,6 +73,15 @@ def map (P : ColimitPresentation J X) {D : Type*} [Category D] (F : C ⥤ D)
   diag := P.diag ⋙ F
   ι := Functor.whiskerRight P.ι F ≫ (F.constComp _ _).hom
   isColimit := (isColimitOfPreserves F P.isColimit).ofIsoColimit (Cocones.ext (.refl _) (by simp))
+
+/-- If `P` is a colimit presentation of `X`, it is possible to define another
+colimit presentation of `X` where `P.diag` is replaced by an isomorphic functor. -/
+@[simps]
+def chgDiag (P : ColimitPresentation J X) {F : J ⥤ C} (e : F ≅ P.diag) :
+    ColimitPresentation J X where
+  diag := F
+  ι := e.hom ≫ P.ι
+  isColimit := (IsColimit.precomposeHomEquiv e _).2 P.isColimit
 
 /-- Map a colimit presentation under an isomorphism. -/
 @[simps]
@@ -215,4 +228,74 @@ end Small
 
 end
 
-end CategoryTheory.Limits.ColimitPresentation
+end ColimitPresentation
+
+/-- A limit presentation of `X` over `J` is a diagram `{Dᵢ}` in `C` and natural maps
+`sᵢ : X ⟶ Dᵢ` making `X` into the limit of the `Dᵢ`. -/
+structure LimitPresentation (J : Type w) [Category.{t} J] (X : C) where
+  /-- The diagram `{Dᵢ}`. -/
+  diag : J ⥤ C
+  /-- The natural maps `sᵢ : X ⟶ Dᵢ`. -/
+  π : (Functor.const J).obj X ⟶ diag
+  /-- `X` is the colimit of the `Dᵢ` via `sᵢ`. -/
+  isLimit : IsLimit (Cone.mk _ π)
+
+variable {J : Type w} [Category.{t} J] {X : C}
+
+namespace LimitPresentation
+
+initialize_simps_projections LimitPresentation (-isLimit)
+
+/-- The cone associated to a limit presentation. -/
+abbrev cone (pres : LimitPresentation J X) : Cone pres.diag :=
+  Cone.mk _ pres.π
+
+lemma hasLimit (pres : LimitPresentation J X) : HasLimit pres.diag :=
+  ⟨_, pres.isLimit⟩
+
+/-- The canonical limit presentation of any object over a point. -/
+@[simps]
+noncomputable
+def self (X : C) : LimitPresentation PUnit.{s + 1} X where
+  diag := (Functor.const _).obj X
+  π := 𝟙 _
+  isLimit := isLimitConstCone _ _
+
+/-- If `F` preserves limits of shape `J`, it maps limit presentations of `X` to
+limit presentations of `F(X)`. -/
+@[simps]
+noncomputable
+def map (P : LimitPresentation J X) {D : Type*} [Category D] (F : C ⥤ D)
+    [PreservesLimitsOfShape J F] : LimitPresentation J (F.obj X) where
+  diag := P.diag ⋙ F
+  π := (F.constComp _ _).inv ≫ Functor.whiskerRight P.π F
+  isLimit := (isLimitOfPreserves F P.isLimit).ofIsoLimit (Cones.ext (.refl _) (by simp))
+
+/-- If `P` is a limit presentation of `X`, it is possible to define another
+limit presentation of `X` where `P.diag` is replaced by an isomorphic functor. -/
+@[simps]
+def chgDiag (P : LimitPresentation J X) {F : J ⥤ C} (e : F ≅ P.diag) :
+    LimitPresentation J X where
+  diag := F
+  π := P.π ≫ e.inv
+  isLimit := (IsLimit.postcomposeHomEquiv e.symm _).2 P.isLimit
+
+/-- Map a limit presentation under an isomorphism. -/
+@[simps]
+def ofIso (P : LimitPresentation J X) {Y : C} (e : X ≅ Y) : LimitPresentation J Y where
+  diag := P.diag
+  π := (Functor.const J).map e.inv ≫ P.π
+  isLimit := P.isLimit.ofIsoLimit (Cones.ext e)
+
+/-- Change the index category of a limit presentation. -/
+@[simps]
+noncomputable
+def reindex (P : LimitPresentation J X) {J' : Type*} [Category J'] (F : J' ⥤ J) [F.Initial] :
+    LimitPresentation J' X where
+  diag := F ⋙ P.diag
+  π := F.whiskerLeft P.π
+  isLimit := (Functor.Initial.isLimitWhiskerEquiv F _).symm P.isLimit
+
+end LimitPresentation
+
+end CategoryTheory.Limits

--- a/Mathlib/CategoryTheory/Limits/Presentation.lean
+++ b/Mathlib/CategoryTheory/Limits/Presentation.lean
@@ -237,7 +237,7 @@ structure LimitPresentation (J : Type w) [Category.{t} J] (X : C) where
   diag : J ⥤ C
   /-- The natural maps `sᵢ : X ⟶ Dᵢ`. -/
   π : (Functor.const J).obj X ⟶ diag
-  /-- `X` is the colimit of the `Dᵢ` via `sᵢ`. -/
+  /-- `X` is the limit of the `Dᵢ` via `sᵢ`. -/
   isLimit : IsLimit (Cone.mk _ π)
 
 variable {J : Type w} [Category.{t} J] {X : C}

--- a/Mathlib/CategoryTheory/Limits/Presentation.lean
+++ b/Mathlib/CategoryTheory/Limits/Presentation.lean
@@ -77,7 +77,7 @@ def map (P : ColimitPresentation J X) {D : Type*} [Category D] (F : C ⥤ D)
 /-- If `P` is a colimit presentation of `X`, it is possible to define another
 colimit presentation of `X` where `P.diag` is replaced by an isomorphic functor. -/
 @[simps]
-def chgDiag (P : ColimitPresentation J X) {F : J ⥤ C} (e : F ≅ P.diag) :
+def changeDiag (P : ColimitPresentation J X) {F : J ⥤ C} (e : F ≅ P.diag) :
     ColimitPresentation J X where
   diag := F
   ι := e.hom ≫ P.ι


### PR DESCRIPTION
This PR introduces `LimitPresentation` which is the dual notion to `ColimitPresentation` introduced in #29382.

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include at least one commit authored by each
co-author among the commits in the pull request. If necessary, you may 
create empty commits to indicate co-authorship, using commands like so:

git commit --author="Author Name <author@email.com>" --allow-empty -m "add Author Name as coauthor"

When merging, all the commits will be squashed into a single commit listing all co-authors.

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
