### PR TITLE
[Merged by Bors] - chore(Analysis/Normed/Completeness): Generalize extend to uniform groups

### DIFF
--- a/Mathlib/Analysis/Normed/Operator/Completeness.lean
+++ b/Mathlib/Analysis/Normed/Operator/Completeness.lean
@@ -159,7 +159,8 @@ section UniformlyExtend
 
 section NonField
 
-variable {R R₂ E F Fₗ : Type*} [NormedAddCommGroup E] [NormedAddCommGroup F] [NormedAddCommGroup Fₗ]
+variable {R R₂ E F Fₗ : Type*} [AddCommGroup E] [UniformSpace E] [IsUniformAddGroup E]
+  [NormedAddCommGroup F] [NormedAddCommGroup Fₗ]
   [NormedRing R] [NormedRing R₂] [Module R E] [Module R₂ F] [Module R Fₗ]
   [IsBoundedSMul R₂ F] [IsBoundedSMul R Fₗ]
   {σ₁₂ : R →+* R₂} (f g : E →SL[σ₁₂] F) [CompleteSpace F] (e : E →L[R] Fₗ) (h_dense : DenseRange e)

--- a/Mathlib/Analysis/Normed/Operator/Completeness.lean
+++ b/Mathlib/Analysis/Normed/Operator/Completeness.lean
@@ -160,9 +160,10 @@ section UniformlyExtend
 section NonField
 
 variable {R R₂ E F Fₗ : Type*} [AddCommGroup E] [UniformSpace E] [IsUniformAddGroup E]
-  [NormedAddCommGroup F] [NormedAddCommGroup Fₗ]
-  [NormedRing R] [NormedRing R₂] [Module R E] [Module R₂ F] [Module R Fₗ]
-  [IsBoundedSMul R₂ F] [IsBoundedSMul R Fₗ]
+  [AddCommGroup F] [UniformSpace F] [IsUniformAddGroup F] [T0Space F]
+  [AddCommMonoid Fₗ] [UniformSpace Fₗ] [ContinuousAdd Fₗ]
+  [Semiring R] [Semiring R₂] [Module R E] [Module R₂ F] [Module R Fₗ]
+  [ContinuousConstSMul R Fₗ] [ContinuousConstSMul R₂ F]
   {σ₁₂ : R →+* R₂} (f g : E →SL[σ₁₂] F) [CompleteSpace F] (e : E →L[R] Fₗ) (h_dense : DenseRange e)
 
 variable (h_e : IsUniformInducing e)


### PR DESCRIPTION
Since the continuous linear maps are defined for topological vector spaces, we can generalize `ContinuousLinearMap.extend` so that the dense subspace is not a normed space anymore.

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include at least one commit authored by each
co-author among the commits in the pull request. If necessary, you may 
create empty commits to indicate co-authorship, using commands like so:

git commit --author="Author Name <author@email.com>" --allow-empty -m "add Author Name as coauthor"

When merging, all the commits will be squashed into a single commit listing all co-authors.

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
