### PR TITLE
feat: define two (trivial) ContinuousMulEquivs

### DIFF
--- a/Mathlib/Topology/Algebra/ContinuousMonoidHom.lean
+++ b/Mathlib/Topology/Algebra/ContinuousMonoidHom.lean
@@ -545,7 +545,7 @@ end unique
 /-- A family indexed by a type with a unique element
 is `ContinuousMulEquiv` to the element at the single index.
 This is the topological version of `MulEquiv.piUnique`. -/
-@[to_additive 
+@[to_additive
 /-- A family indexed by a type with a unique element
 is `ContinuousAddEquiv` to the element at the single index.
 This is the topological equivalent of `AddEquiv.piUnique`. -/]

--- a/Mathlib/Topology/Algebra/ContinuousMonoidHom.lean
+++ b/Mathlib/Topology/Algebra/ContinuousMonoidHom.lean
@@ -5,6 +5,7 @@ Authors: Thomas Browning, Nailin Guan
 -/
 import Mathlib.Algebra.Group.Equiv.Basic
 import Mathlib.Topology.Algebra.Group.Defs
+import Mathlib.Topology.Homeomorph.Lemmas
 
 /-!
 
@@ -540,6 +541,30 @@ instance {M N} [Unique M] [Unique N] [Mul M] [Mul N]
   uniq _ := ext fun _ ↦ Subsingleton.elim _ _
 
 end unique
+
+/-- A family indexed by a type with a unique element
+is `ContinuousMulEquiv` to the element at the single index.
+This is the topological version of `MulEquiv.piUnique`. -/
+@[to_additive 
+/-- A family indexed by a type with a unique element
+is `ContinuousAddEquiv` to the element at the single index.
+This is the topological equivalent of `AddEquiv.piUnique`. -/]
+def piUnique {ι : Type*} (M : ι → Type*) [(j : ι) → Mul (M j)]
+    [(j : ι) → TopologicalSpace (M j)] [Unique ι] :
+    ((j : ι) → M j) ≃ₜ* M default where
+  __ := MulEquiv.piUnique M
+  continuous_toFun := continuous_apply default
+  continuous_invFun := by simpa [continuous_pi_iff, Unique.forall_iff] using continuous_id'
+
+/-- Splits the indices of `∀ (i : ι), Y i` along the predicate `p`.
+This is `Equiv.piEquivPiSubtypeProd` as a `ContinuousMulEquiv`. -/
+@[to_additive piEquivPiSubtypeProd
+/-- Splits the indices of `∀ (i : ι), Y i` along the predicate `p`.
+This is `Equiv.piEquivPiSubtypeProd` as a `ContinuousAddEquiv`. -/]
+def piEquivPiSubtypeProd {ι : Type*} (p : ι → Prop) (Y : ι → Type*)
+    [(i : ι) → TopologicalSpace (Y i)] [(i : ι) → Mul (Y i)] [DecidablePred p] :
+    ((i : ι) → Y i) ≃ₜ* ((i : { x : ι // p x }) → Y i) × ((i : { x : ι // ¬p x }) → Y i) :=
+  {Homeomorph.piEquivPiSubtypeProd p Y with map_mul' _ _ := rfl}
 
 end ContinuousMulEquiv
 


### PR DESCRIPTION
Define two trivial `ContinuousMulEquiv`s:

`ContinuousMulEquiv.piUnique` is the topological version of `MulEquiv.piUnique`.

`ContinuousMulEquiv.piEquivPiSubtypeProd` is the multiplicative version of `Homeomorph.piEquivPiSubtypeProd`.

Done for the FLT project.

Note that this is the same as #29827, but I switched to a new branch due to strange CI issues with the old branch.

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include at least one commit authored by each
co-author among the commits in the pull request. If necessary, you may 
create empty commits to indicate co-authorship, using commands like so:

git commit --author="Author Name <author@email.com>" --allow-empty -m "add Author Name as coauthor"

When merging, all the commits will be squashed into a single commit listing all co-authors.

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
