### PR TITLE
[Merged by Bors] - chore: rely less on WithTop/Bot-Option defeq, add missing API

### DIFF
--- a/Mathlib/Algebra/Order/AddGroupWithTop.lean
+++ b/Mathlib/Algebra/Order/AddGroupWithTop.lean
@@ -64,7 +64,7 @@ open Function
 namespace LinearOrderedAddCommGroup
 
 instance instNeg [AddCommGroup α] : Neg (WithTop α) where
-  neg := Option.map fun a : α => -a
+  neg := WithTop.map fun a : α => -a
 
 /-- If `α` has subtraction, we can extend the subtraction to `WithTop α`, by
 setting `x - ⊤ = ⊤` and `⊤ - x = ⊤`. This definition is only registered as an instance on linearly
@@ -104,10 +104,10 @@ lemma sub_eq_top_iff {a b : WithTop α} : a - b = ⊤ ↔ (a = ⊤ ∨ b = ⊤) 
 
 instance [LinearOrder α] [IsOrderedAddMonoid α] : LinearOrderedAddCommGroupWithTop (WithTop α) where
   __ := WithTop.linearOrderedAddCommMonoidWithTop
-  __ := Option.nontrivial
+  __ := WithTop.nontrivial
   sub_eq_add_neg a b := by
     cases a <;> cases b <;> simp [← coe_sub, ← coe_neg, sub_eq_add_neg]
-  neg_top := Option.map_none _
+  neg_top := WithTop.map_top _
   zsmul := zsmulRec
   add_neg_cancel := by
     rintro (a | a) ha

--- a/Mathlib/Algebra/Order/Interval/Basic.lean
+++ b/Mathlib/Algebra/Order/Interval/Basic.lean
@@ -127,7 +127,7 @@ instance : Mul (NonemptyInterval α) :=
 
 @[to_additive]
 instance : Mul (Interval α) :=
-  ⟨Option.map₂ (· * ·)⟩
+  ⟨WithBot.map₂ (· * ·)⟩
 
 namespace NonemptyInterval
 
@@ -161,11 +161,11 @@ variable (s t : Interval α)
 
 @[to_additive (attr := simp)]
 theorem bot_mul : ⊥ * t = ⊥ :=
-  rfl
+  WithBot.map₂_bot_left _ _
 
 @[to_additive]
 theorem mul_bot : s * ⊥ = ⊥ :=
-  Option.map₂_none_right _ _
+  WithBot.map₂_bot_right _ _
 
 -- simp can already prove `add_bot`
 attribute [simp] mul_bot
@@ -231,11 +231,11 @@ instance Interval.mulOneClass [CommMonoid α] [PartialOrder α] [IsOrderedMonoid
   mul := (· * ·)
   one := 1
   one_mul s :=
-    (Option.map₂_coe_left _ _ _).trans <| by
-      simp_rw [one_mul, ← Function.id_def, Option.map_id, id]
+    (WithBot.map₂_coe_left _ _ _).trans <| by
+      simp_rw [one_mul, ← Function.id_def, WithBot.map_id, id]
   mul_one s :=
-    (Option.map₂_coe_right _ _ _).trans <| by
-      simp_rw [mul_one, ← Function.id_def, Option.map_id, id]
+    (WithBot.map₂_coe_right _ _ _).trans <| by
+      simp_rw [mul_one, ← Function.id_def, WithBot.map_id, id]
 
 @[to_additive]
 instance Interval.commMonoid [CommMonoid α] [PartialOrder α] [IsOrderedMonoid α] :
@@ -321,7 +321,7 @@ instance : Sub (NonemptyInterval α) :=
   ⟨fun s t => ⟨(s.fst - t.snd, s.snd - t.fst), tsub_le_tsub s.fst_le_snd t.fst_le_snd⟩⟩
 
 instance : Sub (Interval α) :=
-  ⟨Option.map₂ Sub.sub⟩
+  ⟨WithBot.map₂ Sub.sub⟩
 
 namespace NonemptyInterval
 
@@ -354,11 +354,11 @@ variable (s t : Interval α)
 
 @[simp]
 theorem bot_sub : ⊥ - t = ⊥ :=
-  rfl
+  WithBot.map₂_bot_left _ _
 
 @[simp]
 theorem sub_bot : s - ⊥ = ⊥ :=
-  Option.map₂_none_right _ _
+  WithBot.map₂_bot_right _ _
 
 end Interval
 
@@ -379,7 +379,7 @@ instance : Div (NonemptyInterval α) :=
   ⟨fun s t => ⟨(s.fst / t.snd, s.snd / t.fst), div_le_div'' s.fst_le_snd t.fst_le_snd⟩⟩
 
 instance : Div (Interval α) :=
-  ⟨Option.map₂ (· / ·)⟩
+  ⟨WithBot.map₂ (· / ·)⟩
 
 namespace NonemptyInterval
 
@@ -412,11 +412,11 @@ variable (s t : Interval α)
 
 @[simp]
 theorem bot_div : ⊥ / t = ⊥ :=
-  rfl
+  WithBot.map₂_bot_left _ _
 
 @[simp]
 theorem div_bot : s / ⊥ = ⊥ :=
-  Option.map₂_none_right _ _
+  WithBot.map₂_bot_right _ _
 
 end Interval
 
@@ -435,7 +435,7 @@ instance : Inv (NonemptyInterval α) :=
 
 @[to_additive]
 instance : Inv (Interval α) :=
-  ⟨Option.map Inv.inv⟩
+  ⟨WithBot.map Inv.inv⟩
 
 namespace NonemptyInterval
 
@@ -542,14 +542,15 @@ instance subtractionCommMonoid {α : Type u}
     neg := Neg.neg
     sub := Sub.sub
     sub_eq_add_neg := by
-      rintro (_ | s) (_ | t) <;> first |rfl|exact congr_arg some (sub_eq_add_neg _ _)
-    neg_neg := by rintro (_ | s) <;> first |rfl|exact congr_arg some (neg_neg _)
-    neg_add_rev := by rintro (_ | s) (_ | t) <;> first |rfl|exact congr_arg some (neg_add_rev _ _)
+      rintro (_ | s) (_ | t) <;> first |rfl|exact congr_arg WithBot.some (sub_eq_add_neg _ _)
+    neg_neg := by rintro (_ | s) <;> first |rfl|exact congr_arg WithBot.some (neg_neg _)
+    neg_add_rev := by
+      rintro (_ | s) (_ | t) <;> first |rfl|exact congr_arg WithBot.some (neg_add_rev _ _)
     neg_eq_of_add := by
       rintro (_ | s) (_ | t) h <;>
         first
           | cases h
-          | exact congr_arg some (neg_eq_of_add_eq_zero_right <| Option.some_injective _ h)
+          | exact congr_arg WithBot.some (neg_eq_of_add_eq_zero_right <| WithBot.coe_injective h)
     -- TODO: use a better defeq
     zsmul := zsmulRec }
 
@@ -559,14 +560,15 @@ instance divisionCommMonoid : DivisionCommMonoid (Interval α) :=
     inv := Inv.inv
     div := (· / ·)
     div_eq_mul_inv := by
-      rintro (_ | s) (_ | t) <;> first |rfl|exact congr_arg some (div_eq_mul_inv _ _)
-    inv_inv := by rintro (_ | s) <;> first |rfl|exact congr_arg some (inv_inv _)
-    mul_inv_rev := by rintro (_ | s) (_ | t) <;> first |rfl|exact congr_arg some (mul_inv_rev _ _)
+      rintro (_ | s) (_ | t) <;> first |rfl|exact congr_arg WithBot.some (div_eq_mul_inv _ _)
+    inv_inv := by rintro (_ | s) <;> first |rfl|exact congr_arg WithBot.some (inv_inv _)
+    mul_inv_rev := by
+      rintro (_ | s) (_ | t) <;> first |rfl|exact congr_arg WithBot.some (mul_inv_rev _ _)
     inv_eq_of_mul := by
       rintro (_ | s) (_ | t) h <;>
         first
           | cases h
-          | exact congr_arg some (inv_eq_of_mul_eq_one_right <| Option.some_injective _ h) }
+          | exact congr_arg WithBot.some (inv_eq_of_mul_eq_one_right <| WithBot.coe_injective h) }
 
 end Interval
 

--- a/Mathlib/CategoryTheory/Preadditive/Injective/Basic.lean
+++ b/Mathlib/CategoryTheory/Preadditive/Injective/Basic.lean
@@ -112,10 +112,10 @@ instance Type.enoughInjectives : EnoughInjectives (Type u₁) where
     Nonempty.intro
       { J := WithBot X
         injective := inferInstance
-        f := Option.some
+        f := WithBot.some
         mono := by
           rw [mono_iff_injective]
-          exact Option.some_injective X }
+          exact WithBot.coe_injective }
 
 instance {P Q : C} [HasBinaryProduct P Q] [Injective P] [Injective Q] : Injective (P ⨯ Q) where
   factors g f mono := by

--- a/Mathlib/Data/ENNReal/Basic.lean
+++ b/Mathlib/Data/ENNReal/Basic.lean
@@ -294,7 +294,7 @@ theorem ofReal_toReal_le {a : ℝ≥0∞} : ENNReal.ofReal a.toReal ≤ a :=
   if ha : a = ∞ then ha.symm ▸ le_top else le_of_eq (ofReal_toReal ha)
 
 theorem forall_ennreal {p : ℝ≥0∞ → Prop} : (∀ a, p a) ↔ (∀ r : ℝ≥0, p r) ∧ p ∞ :=
-  Option.forall.trans and_comm
+  WithTop.forall.trans and_comm
 
 theorem forall_ne_top {p : ℝ≥0∞ → Prop} : (∀ a, a ≠ ∞ → p a) ↔ ∀ r : ℝ≥0, p r :=
   Option.forall_ne_none
@@ -467,13 +467,13 @@ theorem iSup_ennreal {α : Type*} [CompleteLattice α] {f : ℝ≥0∞ → α} :
 
 /-- Coercion `ℝ≥0 → ℝ≥0∞` as a `RingHom`. -/
 def ofNNRealHom : ℝ≥0 →+* ℝ≥0∞ where
-  toFun := some
+  toFun := WithTop.some
   map_one' := coe_one
   map_mul' _ _ := coe_mul _ _
   map_zero' := coe_zero
   map_add' _ _ := coe_add _ _
 
-@[simp] theorem coe_ofNNRealHom : ⇑ofNNRealHom = some := rfl
+@[simp] theorem coe_ofNNRealHom : ⇑ofNNRealHom = WithTop.some := rfl
 
 section Order
 

--- a/Mathlib/Data/ENat/Basic.lean
+++ b/Mathlib/Data/ENat/Basic.lean
@@ -521,7 +521,7 @@ protected def _root_.MonoidWithZeroHom.ENatMap {S : Type*} [MulZeroOneClass S] [
     toFun := ENat.map f
     map_mul' := fun x y => by
       have : ∀ z, map f z = 0 ↔ z = 0 := fun z =>
-        (Option.map_injective hf).eq_iff' f.toZeroHom.ENatMap.map_zero
+        (WithTop.map_injective hf).eq_iff' f.toZeroHom.ENatMap.map_zero
       rcases Decidable.eq_or_ne x 0 with (rfl | hx)
       · simp
       rcases Decidable.eq_or_ne y 0 with (rfl | hy)

--- a/Mathlib/Data/Finset/Max.lean
+++ b/Mathlib/Data/Finset/Max.lean
@@ -282,19 +282,19 @@ theorem min'_union {s₁ s₂ : Finset α} (h₁ : s₁.Nonempty) (h₂ : s₂.N
 
 theorem map_ofDual_min (s : Finset αᵒᵈ) : s.min.map ofDual = (s.image ofDual).max := by
   rw [max_eq_sup_withBot, sup_image]
-  exact congr_fun Option.map_id _
+  exact congr_fun WithBot.map_id _
 
 theorem map_ofDual_max (s : Finset αᵒᵈ) : s.max.map ofDual = (s.image ofDual).min := by
   rw [min_eq_inf_withTop, inf_image]
-  exact congr_fun Option.map_id _
+  exact congr_fun WithTop.map_id _
 
 theorem map_toDual_min (s : Finset α) : s.min.map toDual = (s.image toDual).max := by
   rw [max_eq_sup_withBot, sup_image]
-  exact congr_fun Option.map_id _
+  exact congr_fun WithBot.map_id _
 
 theorem map_toDual_max (s : Finset α) : s.max.map toDual = (s.image toDual).min := by
   rw [min_eq_inf_withTop, inf_image]
-  exact congr_fun Option.map_id _
+  exact congr_fun WithTop.map_id _
 
 theorem ofDual_min' {s : Finset αᵒᵈ} (hs : s.Nonempty) :
     ofDual (min' s hs) = max' (s.image ofDual) (hs.image _) := by

--- a/Mathlib/Order/Hom/WithTopBot.lean
+++ b/Mathlib/Order/Hom/WithTopBot.lean
@@ -256,17 +256,17 @@ protected def withTop (f : SupHom α β) : SupHom (WithTop α) (WithTop β) wher
     | (a : α), (b : α) => congr_arg _ (f.map_sup' _ _)
 
 @[simp]
-theorem withTop_id : (SupHom.id α).withTop = SupHom.id _ := DFunLike.coe_injective Option.map_id
+theorem withTop_id : (SupHom.id α).withTop = SupHom.id _ := DFunLike.coe_injective WithTop.map_id
 
 @[simp]
 theorem withTop_comp (f : SupHom β γ) (g : SupHom α β) :
     (f.comp g).withTop = f.withTop.comp g.withTop :=
-  DFunLike.coe_injective <| Eq.symm <| Option.map_comp_map _ _
+  DFunLike.coe_injective <| Eq.symm <| WithTop.map_comp_map _ _
 
 /-- Adjoins a `⊥` to the domain and codomain of a `SupHom`. -/
 @[simps]
 protected def withBot (f : SupHom α β) : SupBotHom (WithBot α) (WithBot β) where
-  toFun := Option.map f
+  toFun := WithBot.map f
   map_sup' a b :=
     match a, b with
     | ⊥, ⊥ => rfl
@@ -276,12 +276,12 @@ protected def withBot (f : SupHom α β) : SupBotHom (WithBot α) (WithBot β) w
   map_bot' := rfl
 
 @[simp]
-theorem withBot_id : (SupHom.id α).withBot = SupBotHom.id _ := DFunLike.coe_injective Option.map_id
+theorem withBot_id : (SupHom.id α).withBot = SupBotHom.id _ := DFunLike.coe_injective WithBot.map_id
 
 @[simp]
 theorem withBot_comp (f : SupHom β γ) (g : SupHom α β) :
     (f.comp g).withBot = f.withBot.comp g.withBot :=
-  DFunLike.coe_injective <| Eq.symm <| Option.map_comp_map _ _
+  DFunLike.coe_injective <| Eq.symm <| WithBot.map_comp_map _ _
 
 /-- Adjoins a `⊤` to the codomain of a `SupHom`. -/
 @[simps]
@@ -315,7 +315,7 @@ variable [SemilatticeInf α] [SemilatticeInf β] [SemilatticeInf γ]
 /-- Adjoins a `⊤` to the domain and codomain of an `InfHom`. -/
 @[simps]
 protected def withTop (f : InfHom α β) : InfTopHom (WithTop α) (WithTop β) where
-  toFun := Option.map f
+  toFun := WithTop.map f
   map_inf' a b :=
     match a, b with
     | ⊤, ⊤ => rfl
@@ -325,17 +325,17 @@ protected def withTop (f : InfHom α β) : InfTopHom (WithTop α) (WithTop β) w
   map_top' := rfl
 
 @[simp]
-theorem withTop_id : (InfHom.id α).withTop = InfTopHom.id _ := DFunLike.coe_injective Option.map_id
+theorem withTop_id : (InfHom.id α).withTop = InfTopHom.id _ := DFunLike.coe_injective WithTop.map_id
 
 @[simp]
 theorem withTop_comp (f : InfHom β γ) (g : InfHom α β) :
     (f.comp g).withTop = f.withTop.comp g.withTop :=
-  DFunLike.coe_injective <| Eq.symm <| Option.map_comp_map _ _
+  DFunLike.coe_injective <| Eq.symm <| WithTop.map_comp_map _ _
 
 /-- Adjoins a `⊥` to the domain and codomain of an `InfHom`. -/
 @[simps]
 protected def withBot (f : InfHom α β) : InfHom (WithBot α) (WithBot β) where
-  toFun := Option.map f
+  toFun := WithBot.map f
   map_inf' a b :=
     match a, b with
     | ⊥, ⊥ => rfl
@@ -344,12 +344,12 @@ protected def withBot (f : InfHom α β) : InfHom (WithBot α) (WithBot β) wher
     | (a : α), (b : α) => congr_arg _ (f.map_inf' _ _)
 
 @[simp]
-theorem withBot_id : (InfHom.id α).withBot = InfHom.id _ := DFunLike.coe_injective Option.map_id
+theorem withBot_id : (InfHom.id α).withBot = InfHom.id _ := DFunLike.coe_injective WithBot.map_id
 
 @[simp]
 theorem withBot_comp (f : InfHom β γ) (g : InfHom α β) :
     (f.comp g).withBot = f.withBot.comp g.withBot :=
-  DFunLike.coe_injective <| Eq.symm <| Option.map_comp_map _ _
+  DFunLike.coe_injective <| Eq.symm <| WithBot.map_comp_map _ _
 
 /-- Adjoins a `⊤` to the codomain of an `InfHom`. -/
 @[simps]

--- a/Mathlib/Order/WithBot.lean
+++ b/Mathlib/Order/WithBot.lean
@@ -110,6 +110,20 @@ theorem some_eq_map_iff {f : α → β} {y : β} {v : WithBot α} :
     .some y = WithBot.map f v ↔ ∃ x, v = .some x ∧ f x = y := by
   cases v <;> simp [eq_comm]
 
+theorem map_id : map (id : α → α) = id :=
+  Option.map_id
+
+@[simp]
+theorem map_map (h : β → γ) (g : α → β) (a : WithBot α) : map h (map g a) = map (h ∘ g) a :=
+  Option.map_map h g a
+
+theorem comp_map (h : β → γ) (g : α → β) (x : WithBot α) : x.map (h ∘ g) = (x.map g).map h :=
+  (map_map ..).symm
+
+@[simp] theorem map_comp_map (f : α → β) (g : β → γ) :
+    WithBot.map g ∘ WithBot.map f = WithBot.map (g ∘ f) :=
+  Option.map_comp_map f g
+
 theorem map_comm {f₁ : α → β} {f₂ : α → γ} {g₁ : β → δ} {g₂ : γ → δ}
     (h : g₁ ∘ f₁ = g₂ ∘ f₂) (a : α) :
     map g₁ (map f₁ a) = map g₂ (map f₂ a) :=
@@ -580,6 +594,20 @@ theorem map_eq_some_iff {f : α → β} {y : β} {v : WithTop α} :
 theorem some_eq_map_iff {f : α → β} {y : β} {v : WithTop α} :
     .some y = WithTop.map f v ↔ ∃ x, v = .some x ∧ f x = y := by
   cases v <;> simp [eq_comm]
+
+theorem map_id : map (id : α → α) = id :=
+  Option.map_id
+
+@[simp]
+theorem map_map (h : β → γ) (g : α → β) (a : WithTop α) : map h (map g a) = map (h ∘ g) a :=
+  Option.map_map h g a
+
+theorem comp_map (h : β → γ) (g : α → β) (x : WithTop α) : x.map (h ∘ g) = (x.map g).map h :=
+  (map_map ..).symm
+
+@[simp] theorem map_comp_map (f : α → β) (g : β → γ) :
+    WithTop.map g ∘ WithTop.map f = WithTop.map (g ∘ f) :=
+  Option.map_comp_map f g
 
 theorem map_comm {f₁ : α → β} {f₂ : α → γ} {g₁ : β → δ} {g₂ : γ → δ}
     (h : g₁ ∘ f₁ = g₂ ∘ f₂) (a : α) : map g₁ (map f₁ a) = map g₂ (map f₂ a) :=


### PR DESCRIPTION
Nowhere near comprehensive; inspired by #27918.

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include at least one commit authored by each
co-author among the commits in the pull request. If necessary, you may 
create empty commits to indicate co-authorship, using commands like so:

git commit --author="Author Name <author@email.com>" --allow-empty -m "add Author Name as coauthor"

When merging, all the commits will be squashed into a single commit listing all co-authors.

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
