### PR TITLE
[Merged by Bors] - feat(Algebra/Homology): define projective dimension as a number

### DIFF
--- a/Mathlib/CategoryTheory/Abelian/Projective/Dimension.lean
+++ b/Mathlib/CategoryTheory/Abelian/Projective/Dimension.lean
@@ -286,7 +286,7 @@ lemma projectiveDimension_eq_find (X : C) (h : ∃ n, HasProjectiveDimensionLE X
 
 lemma projectiveDimension_ne_top_iff (X : C) :
     projectiveDimension X ≠ ⊤ ↔ ∃ n, HasProjectiveDimensionLE X n := by
-  generalize hd : projectiveDimension X = d 
+  generalize hd : projectiveDimension X = d
   induction d with
   | bot =>
     simp only [ne_eq, bot_ne_top, not_false_eq_true, true_iff]

--- a/Mathlib/CategoryTheory/Abelian/Projective/Dimension.lean
+++ b/Mathlib/CategoryTheory/Abelian/Projective/Dimension.lean
@@ -101,6 +101,9 @@ lemma isZero_of_hasProjectiveDimensionLT_zero [HasProjectiveDimensionLT X 0] : I
   simpa only [Ext.homEquiv₀_symm_apply, Ext.mk₀_zero]
     using Abelian.Ext.eq_zero_of_hasProjectiveDimensionLT _ 0 (by rfl)
 
+lemma hasProjectiveDimensionLT_zero_iff_isZero : HasProjectiveDimensionLT X 0 ↔ IsZero X :=
+  ⟨fun _ ↦ isZero_of_hasProjectiveDimensionLT_zero X, fun h ↦ h.hasProjectiveDimensionLT_zero⟩
+
 lemma hasProjectiveDimensionLT_of_ge (m : ℕ) (h : n ≤ m)
     [HasProjectiveDimensionLT X n] :
     HasProjectiveDimensionLT X m := by
@@ -128,6 +131,28 @@ instance [Projective X] : HasProjectiveDimensionLT X 1 := by
   obtain _ | i := i
   · simp at hi
   · exact e.eq_zero_of_projective
+
+lemma hasProjectiveDimensionLT_one_iff (X : C) :
+    Projective X ↔ HasProjectiveDimensionLT X 1 := by
+  letI := HasExt.standard C
+  refine ⟨fun h ↦ inferInstance, fun ⟨h⟩ ↦ ⟨?_⟩⟩
+  intro Z Y f g epi
+  let S := ShortComplex.mk (kernel.ι g) g (kernel.condition g)
+  have S_exact : S.ShortExact := {
+    exact := ShortComplex.exact_kernel g
+    mono_f := equalizer.ι_mono
+    epi_g := epi}
+  have : IsZero (AddCommGrp.of (Ext X S.X₁ 1)) := by
+    let _ := h 1 (le_refl 1) (Y := S.X₁)
+    exact AddCommGrp.isZero_of_subsingleton _
+  have exac := Ext.covariant_sequence_exact₃' X S_exact 0 1 (zero_add 1)
+  have surj: Function.Surjective ((Ext.mk₀ S.g).postcomp X (add_zero 0)) :=
+    (AddCommGrp.epi_iff_surjective _).mp (exac.epi_f (this.eq_zero_of_tgt _))
+  rcases surj (Ext.mk₀ f) with ⟨f', hf'⟩
+  use Ext.addEquiv₀ f'
+  simp only [AddMonoidHom.flip_apply, Ext.bilinearComp_apply_apply] at hf'
+  rw [← Ext.mk₀_addEquiv₀_apply f', Ext.mk₀_comp_mk₀] at hf'
+  exact (Ext.mk₀_bijective X Y).1 hf'
 
 end
 
@@ -306,28 +331,5 @@ lemma projectiveDimension_ne_top_iff (X : C) : projectiveDimension X ≠ ⊤ ↔
   · use n
     simpa using ⟨fun i hi ↦ hasProjectiveDimensionLT_of_ge X (n + 1) i hi,
       WithBot.coe_inj.not.mpr (ENat.coe_ne_top n)⟩
-
-open Limits Abelian in
-lemma hasProjectiveDimensionLT_one_iff (X : C) :
-    Projective X ↔ HasProjectiveDimensionLT X 1 := by
-  letI := HasExt.standard C
-  refine ⟨fun h ↦ inferInstance, fun ⟨h⟩ ↦ ⟨?_⟩⟩
-  intro Z Y f g epi
-  let S := ShortComplex.mk (kernel.ι g) g (kernel.condition g)
-  have S_exact : S.ShortExact := {
-    exact := ShortComplex.exact_kernel g
-    mono_f := equalizer.ι_mono
-    epi_g := epi}
-  have : IsZero (AddCommGrp.of (Ext X S.X₁ 1)) := by
-    let _ := h 1 (le_refl 1) (Y := S.X₁)
-    exact AddCommGrp.isZero_of_subsingleton _
-  have exac := Ext.covariant_sequence_exact₃' X S_exact 0 1 (zero_add 1)
-  have surj: Function.Surjective ((Ext.mk₀ S.g).postcomp X (add_zero 0)) :=
-    (AddCommGrp.epi_iff_surjective _).mp (exac.epi_f (this.eq_zero_of_tgt _))
-  rcases surj (Ext.mk₀ f) with ⟨f', hf'⟩
-  use Ext.addEquiv₀ f'
-  simp only [AddMonoidHom.flip_apply, Ext.bilinearComp_apply_apply] at hf'
-  rw [← Ext.mk₀_addEquiv₀_apply f', Ext.mk₀_comp_mk₀] at hf'
-  exact (Ext.mk₀_bijective X Y).1 hf'
 
 end ProjectiveDimension

--- a/Mathlib/CategoryTheory/Abelian/Projective/Dimension.lean
+++ b/Mathlib/CategoryTheory/Abelian/Projective/Dimension.lean
@@ -265,18 +265,6 @@ lemma projectiveDimension_eq_bot_iff (X : C) : projectiveDimension X = ⊥ ↔
   rw [← hasProjectiveDimensionLT_zero_iff_isZero, ← projectiveDimension_lt_iff,
     Nat.cast_zero, ← WithBot.lt_coe_bot, bot_eq_zero', WithBot.coe_zero]
 
-lemma projectiveDimension_eq_find (X : C) (h : ∃ n, HasProjectiveDimensionLE X n)
-    (nzero : ¬ Limits.IsZero X) [DecidablePred (HasProjectiveDimensionLE X)] :
-    projectiveDimension X = Nat.find h := by
-  apply le_antisymm ((projectiveDimension_le_iff _ _).mpr (Nat.find_spec h))
-  apply (projectiveDimension_ge_iff _ _).mpr
-  by_cases eq0 : Nat.find h = 0
-  · simp only [eq0]
-    by_contra
-    exact nzero (isZero_of_hasProjectiveDimensionLT_zero X)
-  · rw [← Nat.succ_pred_eq_of_ne_zero eq0]
-    exact (Nat.find_min h (Nat.sub_one_lt eq0))
-
 lemma projectiveDimension_ne_top_iff (X : C) :
     projectiveDimension X ≠ ⊤ ↔ ∃ n, HasProjectiveDimensionLE X n := by
   generalize hd : projectiveDimension X = d

--- a/Mathlib/CategoryTheory/Abelian/Projective/Dimension.lean
+++ b/Mathlib/CategoryTheory/Abelian/Projective/Dimension.lean
@@ -4,9 +4,8 @@ Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Joël Riou, Nailin Guan
 -/
 import Mathlib.Algebra.Homology.DerivedCategory.Ext.EnoughProjectives
-import Mathlib.Data.ENat.Lattice
 import Mathlib.CategoryTheory.Abelian.Exact
-import Mathlib.Algebra.Category.Grp.Zero
+import Mathlib.Data.ENat.Lattice
 
 /-!
 # Projective dimension

--- a/Mathlib/CategoryTheory/Abelian/Projective/Dimension.lean
+++ b/Mathlib/CategoryTheory/Abelian/Projective/Dimension.lean
@@ -286,15 +286,13 @@ lemma projectiveDimension_ge_iff (X : C) (n : ℕ) : n ≤ projectiveDimension X
 
 lemma projectiveDimension_eq_bot_iff (X : C) : projectiveDimension X = ⊥ ↔
     Limits.IsZero X := by
+  rw [← hasProjectiveDimensionLT_zero_iff_isZero]
   refine ⟨fun h ↦ ?_, fun h ↦ ?_⟩
-  · have : HasProjectiveDimensionLT X 0 := by
-      apply hasProjectiveDimensionLT_of_projectiveDimension_lt X 0
-      simp [h, bot_lt_iff_ne_bot]
-    exact isZero_of_hasProjectiveDimensionLT_zero X
+  · apply hasProjectiveDimensionLT_of_projectiveDimension_lt X 0
+    simp [h, bot_lt_iff_ne_bot]
   · rw [eq_bot_iff]
     apply sInf_le
     intro i _
-    have := h.hasProjectiveDimensionLT_zero
     apply hasProjectiveDimensionLT_of_ge X 0 i (Nat.zero_le i)
 
 lemma projectiveDimension_eq_find (X : C) (h : ∃ n, HasProjectiveDimensionLE X n)

--- a/Mathlib/CategoryTheory/Abelian/Projective/Dimension.lean
+++ b/Mathlib/CategoryTheory/Abelian/Projective/Dimension.lean
@@ -141,7 +141,7 @@ lemma projective_iff_subsingleton_ext_one [HasExt.{w} C] {X : C} :
   obtain ⟨φ, rfl⟩ := Ext.homEquiv₀.symm.surjective φ
   exact ⟨φ, Ext.homEquiv₀.symm.injective (by simpa using hφ)⟩
 
-lemma hasProjectiveDimensionLT_one_iff (X : C) :
+lemma projective_iff_hasProjectiveDimensionLT_one (X : C) :
     Projective X ↔ HasProjectiveDimensionLT X 1 := by
   letI := HasExt.standard C
   exact ⟨fun _ ↦ inferInstance, fun _ ↦ projective_iff_subsingleton_ext_one.2

--- a/Mathlib/CategoryTheory/Abelian/Projective/Dimension.lean
+++ b/Mathlib/CategoryTheory/Abelian/Projective/Dimension.lean
@@ -19,7 +19,7 @@ if all `Ext X Y i` vanish when `n ≤ i`. This defines a type class
 `HasProjectiveDimensionLT X 0`, but this cannot be expressed in terms of
 `HasProjectiveDimensionLE`.)
 
-We also defined the projective dimension as `WithBot ℕ∞` as `projectiveDimension`,
+We also define the projective dimension in `WithBot ℕ∞` as `projectiveDimension`,
 `projectiveDimension X = ⊥` iff `X` is zero and acts in common sense in the non-negative values.
 
 -/
@@ -226,7 +226,7 @@ end CategoryTheory
 
 section ProjectiveDimension
 
-open CategoryTheory
+namespace CategoryTheory
 
 variable {C : Type u} [Category.{v, u} C] [Abelian C]
 
@@ -241,9 +241,18 @@ lemma projectiveDimension_eq_of_iso {X Y : C} (e : X ≅ Y) :
   exact ⟨fun h ↦ hasProjectiveDimensionLT_of_iso e _,
     fun h ↦ hasProjectiveDimensionLT_of_iso e.symm _⟩
 
+lemma Retract.projectiveDimension_le {X Y : C} (h : Retract X Y) :
+    projectiveDimension X ≤ projectiveDimension Y :=
+  sInf_le_sInf_of_subset_insert_top (fun n hn ↦ by
+    simp only [Set.mem_setOf_eq, not_top_lt, IsEmpty.forall_iff, implies_true,
+      Set.insert_eq_of_mem] at hn ⊢
+    intro i hi
+    have := hn i hi
+    exact h.hasProjectiveDimensionLT i)
+
 lemma projectiveDimension_lt_iff {X : C} {n : ℕ} :
     projectiveDimension X < n ↔ HasProjectiveDimensionLT X n := by
-  refine ⟨fun h ↦ ?_, fun h ↦ (sInf_lt_iff ..).2 ?_⟩
+  refine ⟨fun h ↦ ?_, fun h ↦ sInf_lt_iff.2 ?_⟩
   · have : projectiveDimension X ∈ _ := csInf_mem ⟨⊤, by simp⟩
     simp only [Set.mem_setOf_eq] at this
     exact this _ h
@@ -252,16 +261,16 @@ lemma projectiveDimension_lt_iff {X : C} {n : ℕ} :
     · exact ⟨n, fun i hi ↦ hasProjectiveDimensionLT_of_ge _ (n + 1) _ (by simpa using hi),
         by simp [WithBot.lt_add_one_iff]⟩
 
-lemma projectiveDimension_le_iff (X : C) (n : ℕ) : projectiveDimension X ≤ n ↔
-    HasProjectiveDimensionLE X n := by
+lemma projectiveDimension_le_iff (X : C) (n : ℕ) :
+    projectiveDimension X ≤ n ↔ HasProjectiveDimensionLE X n := by
   simp [← projectiveDimension_lt_iff, ← WithBot.lt_add_one_iff]
 
-lemma projectiveDimension_ge_iff (X : C) (n : ℕ) : n ≤ projectiveDimension X  ↔
-    ¬ HasProjectiveDimensionLT X n := by
+lemma projectiveDimension_ge_iff (X : C) (n : ℕ) :
+    n ≤ projectiveDimension X ↔ ¬ HasProjectiveDimensionLT X n := by
   rw [← not_iff_not, not_le, not_not, projectiveDimension_lt_iff]
 
-lemma projectiveDimension_eq_bot_iff (X : C) : projectiveDimension X = ⊥ ↔
-    Limits.IsZero X := by
+lemma projectiveDimension_eq_bot_iff (X : C) :
+    projectiveDimension X = ⊥ ↔ Limits.IsZero X := by
   rw [← hasProjectiveDimensionLT_zero_iff_isZero, ← projectiveDimension_lt_iff,
     Nat.cast_zero, ← WithBot.lt_coe_bot, bot_eq_zero', WithBot.coe_zero]
 
@@ -283,5 +292,7 @@ lemma projectiveDimension_ne_top_iff (X : C) :
     | coe d =>
       simp only [ne_eq, WithBot.coe_eq_top, ENat.coe_ne_top, not_false_eq_true, true_iff]
       exact ⟨d, by simpa only [← projectiveDimension_le_iff] using hd.le⟩
+
+end CategoryTheory
 
 end ProjectiveDimension

--- a/Mathlib/CategoryTheory/Abelian/Projective/Dimension.lean
+++ b/Mathlib/CategoryTheory/Abelian/Projective/Dimension.lean
@@ -237,7 +237,7 @@ open CategoryTheory
 
 variable {C : Type u} [Category.{v, u} C] [Abelian C]
 
-/-- The projective dimension of object of abelian category. -/
+/-- The projective dimension of an object in an abelian category. -/
 noncomputable def projectiveDimension (X : C) : WithBot ℕ∞ :=
   sInf {n : WithBot ℕ∞ | ∀ (i : ℕ), n < i → HasProjectiveDimensionLT X i}
 

--- a/Mathlib/CategoryTheory/Abelian/Projective/Dimension.lean
+++ b/Mathlib/CategoryTheory/Abelian/Projective/Dimension.lean
@@ -1,9 +1,12 @@
 /-
 Copyright (c) 2024 Joël Riou. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
-Authors: Joël Riou
+Authors: Joël Riou, Nailin Guan
 -/
 import Mathlib.Algebra.Homology.DerivedCategory.Ext.EnoughProjectives
+import Mathlib.Data.ENat.Lattice
+import Mathlib.CategoryTheory.Abelian.Exact
+import Mathlib.Algebra.Category.Grp.Zero
 
 /-!
 # Projective dimension
@@ -16,6 +19,9 @@ if all `Ext X Y i` vanish when `n ≤ i`. This defines a type class
 (Note that the fact that `X` is a zero object is equivalent to the condition
 `HasProjectiveDimensionLT X 0`, but this cannot be expressed in terms of
 `HasProjectiveDimensionLE`.)
+
+We also defined the projective dimension as `WithBot ℕ∞` as `projectiveDimension`,
+`projectiveDimension X = ⊥` iff `X` is zero and acts in common sense in the non-negative values.
 
 -/
 
@@ -199,3 +205,129 @@ instance (X Y : C) (n : ℕ) [HasProjectiveDimensionLT X n]
     (by assumption) (by assumption)
 
 end CategoryTheory
+
+section ProjectiveDimension
+
+open CategoryTheory
+
+variable {C : Type u} [Category.{v, u} C] [Abelian C]
+
+/-- The projective dimension of object of abelian category. -/
+noncomputable def projectiveDimension (X : C) : WithBot ℕ∞ :=
+  sInf {n : WithBot ℕ∞ | ∀ (i : ℕ), n < i → HasProjectiveDimensionLT X i}
+
+lemma projectiveDimension_eq_of_iso {X Y : C} (e : X ≅ Y) :
+    projectiveDimension X = projectiveDimension Y := by
+  simp only [projectiveDimension]
+  congr! 5
+  exact ⟨fun h ↦ hasProjectiveDimensionLT_of_iso e _,
+    fun h ↦ hasProjectiveDimensionLT_of_iso e.symm _⟩
+
+lemma hasProjectiveDimensionLT_of_projectiveDimension_lt (X : C) (n : ℕ)
+    (h : projectiveDimension X < n) : HasProjectiveDimensionLT X n := by
+  have : projectiveDimension X ∈ _ := csInf_mem (by
+    use ⊤
+    simp)
+  simp only [Set.mem_setOf_eq] at this
+  exact this n h
+
+lemma projectiveDimension_le_iff (X : C) (n : ℕ) : projectiveDimension X ≤ n ↔
+    HasProjectiveDimensionLE X n := by
+  refine ⟨fun h ↦ ?_, fun h ↦ ?_⟩
+  · apply hasProjectiveDimensionLT_of_projectiveDimension_lt X (n + 1)
+    exact lt_of_le_of_lt h (Nat.cast_lt.mpr (lt_add_one n))
+  · apply sInf_le
+    simp only [Set.mem_setOf_eq, Nat.cast_lt]
+    intro i hi
+    exact hasProjectiveDimensionLT_of_ge X (n + 1) i hi
+
+lemma projectiveDimension_ge_iff (X : C) (n : ℕ) : n ≤ projectiveDimension X  ↔
+    ¬ HasProjectiveDimensionLT X n := by
+  refine ⟨fun h ↦ ?_, fun h ↦ ?_⟩
+  · simp only [projectiveDimension, le_sInf_iff, Set.mem_setOf_eq] at h
+    by_contra lt
+    by_cases eq0 : n = 0
+    · have := h ⊥ (fun i _ ↦ (hasProjectiveDimensionLT_of_ge X n i (by simp [eq0])))
+      simp [eq0] at this
+    · have : ∀ (i : ℕ), (n - 1 : ℕ) < (i : WithBot ℕ∞) → HasProjectiveDimensionLT X i := by
+        intro i hi
+        exact hasProjectiveDimensionLT_of_ge X n i (Nat.le_of_pred_lt (Nat.cast_lt.mp hi))
+      have not := Nat.cast_le.mp (h (n - 1 : ℕ) this)
+      omega
+  · simp only [projectiveDimension, le_sInf_iff, Set.mem_setOf_eq]
+    intro m hm
+    by_contra nle
+    exact h (hm _ (lt_of_not_ge nle))
+
+lemma projectiveDimension_eq_bot_iff (X : C) : projectiveDimension X = ⊥ ↔
+    Limits.IsZero X := by
+  refine ⟨fun h ↦ ?_, fun h ↦ ?_⟩
+  · have : HasProjectiveDimensionLT X 0 := by
+      apply hasProjectiveDimensionLT_of_projectiveDimension_lt X 0
+      simp [h, bot_lt_iff_ne_bot]
+    exact isZero_of_hasProjectiveDimensionLT_zero X
+  · rw [eq_bot_iff]
+    apply sInf_le
+    intro i _
+    have := h.hasProjectiveDimensionLT_zero
+    apply hasProjectiveDimensionLT_of_ge X 0 i (Nat.zero_le i)
+
+lemma projectiveDimension_eq_find (X : C) (h : ∃ n, HasProjectiveDimensionLE X n)
+    (nzero : ¬ Limits.IsZero X) [DecidablePred (HasProjectiveDimensionLE X)] :
+    projectiveDimension X = Nat.find h := by
+  apply le_antisymm ((projectiveDimension_le_iff _ _).mpr (Nat.find_spec h))
+  apply (projectiveDimension_ge_iff _ _).mpr
+  by_cases eq0 : Nat.find h = 0
+  · simp only [eq0]
+    by_contra
+    exact nzero (isZero_of_hasProjectiveDimensionLT_zero X)
+  · rw [← Nat.succ_pred_eq_of_ne_zero eq0]
+    exact (Nat.find_min h (Nat.sub_one_lt eq0))
+
+lemma projectiveDimension_ne_top_iff (X : C) : projectiveDimension X ≠ ⊤ ↔
+    ∃ n, HasProjectiveDimensionLE X n := by
+  simp only [projectiveDimension, ne_eq, sInf_eq_top, Set.mem_setOf_eq, not_forall]
+  refine ⟨fun ⟨x, hx, ne⟩ ↦ ?_, fun ⟨n, hn⟩ ↦ ?_⟩
+  · by_cases eqbot : x = ⊥
+    · use 0
+      have := hx 0 (by simp [eqbot, bot_lt_iff_ne_bot])
+      exact instHasProjectiveDimensionLTSucc X 0
+    · have : x.unbot eqbot ≠ ⊤ := by
+        by_contra eq
+        rw [← WithBot.coe_inj, WithBot.coe_unbot, WithBot.coe_top] at eq
+        exact ne eq
+      use (x.unbot eqbot).toNat
+      have eq : x = (x.unbot eqbot).toNat := (WithBot.coe_unbot x eqbot).symm.trans
+        (WithBot.coe_inj.mpr (ENat.coe_toNat this).symm)
+      have : x < ((x.unbot eqbot).toNat + 1 : ℕ) := by
+        nth_rw 1 [eq]
+        exact Nat.cast_lt.mpr (lt_add_one _)
+      exact hx ((x.unbot eqbot).toNat + 1 : ℕ) this
+  · use n
+    simpa using ⟨fun i hi ↦ hasProjectiveDimensionLT_of_ge X (n + 1) i hi,
+      WithBot.coe_inj.not.mpr (ENat.coe_ne_top n)⟩
+
+open Limits Abelian in
+lemma hasProjectiveDimensionLT_one_iff (X : C) :
+    Projective X ↔ HasProjectiveDimensionLT X 1 := by
+  letI := HasExt.standard C
+  refine ⟨fun h ↦ inferInstance, fun ⟨h⟩ ↦ ⟨?_⟩⟩
+  intro Z Y f g epi
+  let S := ShortComplex.mk (kernel.ι g) g (kernel.condition g)
+  have S_exact : S.ShortExact := {
+    exact := ShortComplex.exact_kernel g
+    mono_f := equalizer.ι_mono
+    epi_g := epi}
+  have : IsZero (AddCommGrp.of (Ext X S.X₁ 1)) := by
+    let _ := h 1 (le_refl 1) (Y := S.X₁)
+    exact AddCommGrp.isZero_of_subsingleton _
+  have exac := Ext.covariant_sequence_exact₃' X S_exact 0 1 (zero_add 1)
+  have surj: Function.Surjective ((Ext.mk₀ S.g).postcomp X (add_zero 0)) :=
+    (AddCommGrp.epi_iff_surjective _).mp (exac.epi_f (this.eq_zero_of_tgt _))
+  rcases surj (Ext.mk₀ f) with ⟨f', hf'⟩
+  use Ext.addEquiv₀ f'
+  simp only [AddMonoidHom.flip_apply, Ext.bilinearComp_apply_apply] at hf'
+  rw [← Ext.mk₀_addEquiv₀_apply f', Ext.mk₀_comp_mk₀] at hf'
+  exact (Ext.mk₀_bijective X Y).1 hf'
+
+end ProjectiveDimension

--- a/Mathlib/CategoryTheory/Abelian/Projective/Dimension.lean
+++ b/Mathlib/CategoryTheory/Abelian/Projective/Dimension.lean
@@ -284,27 +284,23 @@ lemma projectiveDimension_eq_find (X : C) (h : ∃ n, HasProjectiveDimensionLE X
   · rw [← Nat.succ_pred_eq_of_ne_zero eq0]
     exact (Nat.find_min h (Nat.sub_one_lt eq0))
 
-lemma projectiveDimension_ne_top_iff (X : C) : projectiveDimension X ≠ ⊤ ↔
-    ∃ n, HasProjectiveDimensionLE X n := by
-  simp only [projectiveDimension, ne_eq, sInf_eq_top, Set.mem_setOf_eq, not_forall]
-  refine ⟨fun ⟨x, hx, ne⟩ ↦ ?_, fun ⟨n, hn⟩ ↦ ?_⟩
-  · by_cases eqbot : x = ⊥
-    · use 0
-      have := hx 0 (by simp [eqbot, bot_lt_iff_ne_bot])
-      exact instHasProjectiveDimensionLTSucc X 0
-    · have : x.unbot eqbot ≠ ⊤ := by
-        by_contra eq
-        rw [← WithBot.coe_inj, WithBot.coe_unbot, WithBot.coe_top] at eq
-        exact ne eq
-      use (x.unbot eqbot).toNat
-      have eq : x = (x.unbot eqbot).toNat := (WithBot.coe_unbot x eqbot).symm.trans
-        (WithBot.coe_inj.mpr (ENat.coe_toNat this).symm)
-      have : x < ((x.unbot eqbot).toNat + 1 : ℕ) := by
-        nth_rw 1 [eq]
-        exact Nat.cast_lt.mpr (lt_add_one _)
-      exact hx ((x.unbot eqbot).toNat + 1 : ℕ) this
-  · use n
-    simpa using ⟨fun i hi ↦ hasProjectiveDimensionLT_of_ge X (n + 1) i hi,
-      WithBot.coe_inj.not.mpr (ENat.coe_ne_top n)⟩
+lemma projectiveDimension_ne_top_iff (X : C) :
+    projectiveDimension X ≠ ⊤ ↔ ∃ n, HasProjectiveDimensionLE X n := by
+  generalize hd : projectiveDimension X = d 
+  induction d with
+  | bot =>
+    simp only [ne_eq, bot_ne_top, not_false_eq_true, true_iff]
+    exact ⟨0, by simp [← projectiveDimension_le_iff, hd]⟩
+  | coe d =>
+    induction d with
+    | top =>
+      by_contra!
+      simp only [WithBot.coe_top, ne_eq, not_true_eq_false, false_and, true_and, false_or] at this
+      obtain ⟨n, hn⟩ := this
+      rw [← projectiveDimension_le_iff, hd, WithBot.coe_top, top_le_iff] at hn
+      exact ENat.coe_ne_top _ ((WithBot.coe_eq_coe).1 hn)
+    | coe d =>
+      simp only [ne_eq, WithBot.coe_eq_top, ENat.coe_ne_top, not_false_eq_true, true_iff]
+      exact ⟨d, by simpa only [← projectiveDimension_le_iff] using hd.le⟩
 
 end ProjectiveDimension

--- a/Mathlib/CategoryTheory/Abelian/Projective/Dimension.lean
+++ b/Mathlib/CategoryTheory/Abelian/Projective/Dimension.lean
@@ -248,52 +248,29 @@ lemma projectiveDimension_eq_of_iso {X Y : C} (e : X ≅ Y) :
   exact ⟨fun h ↦ hasProjectiveDimensionLT_of_iso e _,
     fun h ↦ hasProjectiveDimensionLT_of_iso e.symm _⟩
 
-lemma hasProjectiveDimensionLT_of_projectiveDimension_lt (X : C) (n : ℕ)
-    (h : projectiveDimension X < n) : HasProjectiveDimensionLT X n := by
-  have : projectiveDimension X ∈ _ := csInf_mem (by
-    use ⊤
-    simp)
-  simp only [Set.mem_setOf_eq] at this
-  exact this n h
+lemma projectiveDimension_lt_iff {X : C} {n : ℕ} :
+    projectiveDimension X < n ↔ HasProjectiveDimensionLT X n := by
+  refine ⟨fun h ↦ ?_, fun h ↦ (sInf_lt_iff ..).2 ?_⟩
+  · have : projectiveDimension X ∈ _ := csInf_mem ⟨⊤, by simp⟩
+    simp only [Set.mem_setOf_eq] at this
+    exact this _ h
+  · obtain _ | n := n
+    · exact ⟨⊥, fun _ _ ↦ hasProjectiveDimensionLT_of_ge _ 0 _ (by simp), by decide⟩
+    · exact ⟨n, fun i hi ↦ hasProjectiveDimensionLT_of_ge _ (n + 1) _ (by simpa using hi),
+        by simp [WithBot.lt_add_one_iff]⟩
 
 lemma projectiveDimension_le_iff (X : C) (n : ℕ) : projectiveDimension X ≤ n ↔
     HasProjectiveDimensionLE X n := by
-  refine ⟨fun h ↦ ?_, fun h ↦ ?_⟩
-  · apply hasProjectiveDimensionLT_of_projectiveDimension_lt X (n + 1)
-    exact lt_of_le_of_lt h (Nat.cast_lt.mpr (lt_add_one n))
-  · apply sInf_le
-    simp only [Set.mem_setOf_eq, Nat.cast_lt]
-    intro i hi
-    exact hasProjectiveDimensionLT_of_ge X (n + 1) i hi
+  simp [← projectiveDimension_lt_iff, ← WithBot.lt_add_one_iff]
 
 lemma projectiveDimension_ge_iff (X : C) (n : ℕ) : n ≤ projectiveDimension X  ↔
     ¬ HasProjectiveDimensionLT X n := by
-  refine ⟨fun h ↦ ?_, fun h ↦ ?_⟩
-  · simp only [projectiveDimension, le_sInf_iff, Set.mem_setOf_eq] at h
-    by_contra lt
-    by_cases eq0 : n = 0
-    · have := h ⊥ (fun i _ ↦ (hasProjectiveDimensionLT_of_ge X n i (by simp [eq0])))
-      simp [eq0] at this
-    · have : ∀ (i : ℕ), (n - 1 : ℕ) < (i : WithBot ℕ∞) → HasProjectiveDimensionLT X i := by
-        intro i hi
-        exact hasProjectiveDimensionLT_of_ge X n i (Nat.le_of_pred_lt (Nat.cast_lt.mp hi))
-      have not := Nat.cast_le.mp (h (n - 1 : ℕ) this)
-      omega
-  · simp only [projectiveDimension, le_sInf_iff, Set.mem_setOf_eq]
-    intro m hm
-    by_contra nle
-    exact h (hm _ (lt_of_not_ge nle))
+  rw [← not_iff_not, not_le, not_not, projectiveDimension_lt_iff]
 
 lemma projectiveDimension_eq_bot_iff (X : C) : projectiveDimension X = ⊥ ↔
     Limits.IsZero X := by
-  rw [← hasProjectiveDimensionLT_zero_iff_isZero]
-  refine ⟨fun h ↦ ?_, fun h ↦ ?_⟩
-  · apply hasProjectiveDimensionLT_of_projectiveDimension_lt X 0
-    simp [h, bot_lt_iff_ne_bot]
-  · rw [eq_bot_iff]
-    apply sInf_le
-    intro i _
-    apply hasProjectiveDimensionLT_of_ge X 0 i (Nat.zero_le i)
+  rw [← hasProjectiveDimensionLT_zero_iff_isZero, ← projectiveDimension_lt_iff,
+    Nat.cast_zero, ← WithBot.lt_coe_bot, bot_eq_zero', WithBot.coe_zero]
 
 lemma projectiveDimension_eq_find (X : C) (h : ∃ n, HasProjectiveDimensionLE X n)
     (nzero : ¬ Limits.IsZero X) [DecidablePred (HasProjectiveDimensionLE X)] :

--- a/Mathlib/CategoryTheory/Abelian/Projective/Dimension.lean
+++ b/Mathlib/CategoryTheory/Abelian/Projective/Dimension.lean
@@ -132,27 +132,21 @@ instance [Projective X] : HasProjectiveDimensionLT X 1 := by
   · simp at hi
   · exact e.eq_zero_of_projective
 
+lemma projective_iff_subsingleton_ext_one [HasExt.{w} C] {X : C} :
+    Projective X ↔ ∀ ⦃Y : C⦄, Subsingleton (Ext X Y 1) := by
+  refine ⟨fun h ↦ HasProjectiveDimensionLT.subsingleton X 1 1 (by rfl),
+    fun h ↦ ⟨fun f g _ ↦ ?_⟩⟩
+  obtain ⟨φ, hφ⟩ :=
+    Ext.covariant_sequence_exact₃ _ { exact := ShortComplex.exact_kernel g }
+      (Ext.mk₀ f) (zero_add 1) (by subsingleton)
+  obtain ⟨φ, rfl⟩ := Ext.homEquiv₀.symm.surjective φ
+  exact ⟨φ, Ext.homEquiv₀.symm.injective (by simpa using hφ)⟩
+
 lemma hasProjectiveDimensionLT_one_iff (X : C) :
     Projective X ↔ HasProjectiveDimensionLT X 1 := by
   letI := HasExt.standard C
-  refine ⟨fun h ↦ inferInstance, fun ⟨h⟩ ↦ ⟨?_⟩⟩
-  intro Z Y f g epi
-  let S := ShortComplex.mk (kernel.ι g) g (kernel.condition g)
-  have S_exact : S.ShortExact := {
-    exact := ShortComplex.exact_kernel g
-    mono_f := equalizer.ι_mono
-    epi_g := epi}
-  have : IsZero (AddCommGrp.of (Ext X S.X₁ 1)) := by
-    let _ := h 1 (le_refl 1) (Y := S.X₁)
-    exact AddCommGrp.isZero_of_subsingleton _
-  have exac := Ext.covariant_sequence_exact₃' X S_exact 0 1 (zero_add 1)
-  have surj: Function.Surjective ((Ext.mk₀ S.g).postcomp X (add_zero 0)) :=
-    (AddCommGrp.epi_iff_surjective _).mp (exac.epi_f (this.eq_zero_of_tgt _))
-  rcases surj (Ext.mk₀ f) with ⟨f', hf'⟩
-  use Ext.addEquiv₀ f'
-  simp only [AddMonoidHom.flip_apply, Ext.bilinearComp_apply_apply] at hf'
-  rw [← Ext.mk₀_addEquiv₀_apply f', Ext.mk₀_comp_mk₀] at hf'
-  exact (Ext.mk₀_bijective X Y).1 hf'
+  exact ⟨fun _ ↦ inferInstance, fun _ ↦ projective_iff_subsingleton_ext_one.2
+    (HasProjectiveDimensionLT.subsingleton X 1 1 (by rfl))⟩
 
 end
 


### PR DESCRIPTION
In this PR, we gave the definition of projective dimension in `WithBot ℕ∞` as `projectiveDimension`, 
`projectiveDimension X = ⊥` iff `X` is zero and acts in common sense in the non-negative values.

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include at least one commit authored by each
co-author among the commits in the pull request. If necessary, you may 
create empty commits to indicate co-authorship, using commands like so:

git commit --author="Author Name <author@email.com>" --allow-empty -m "add Author Name as coauthor"

When merging, all the commits will be squashed into a single commit listing all co-authors.

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
