### PR TITLE
[Merged by Bors] - feat(CategoryTheory/Sites): jointly surjective precoverage

### DIFF
--- a/Mathlib.lean
+++ b/Mathlib.lean
@@ -2479,6 +2479,7 @@ import Mathlib.CategoryTheory.Limits.Types.Filtered
 import Mathlib.CategoryTheory.Limits.Types.Images
 import Mathlib.CategoryTheory.Limits.Types.Limits
 import Mathlib.CategoryTheory.Limits.Types.Multicoequalizer
+import Mathlib.CategoryTheory.Limits.Types.Pullbacks
 import Mathlib.CategoryTheory.Limits.Types.Shapes
 import Mathlib.CategoryTheory.Limits.Types.Yoneda
 import Mathlib.CategoryTheory.Limits.Unit
@@ -2750,6 +2751,7 @@ import Mathlib.CategoryTheory.Sites.Hypercover.IsSheaf
 import Mathlib.CategoryTheory.Sites.Hypercover.One
 import Mathlib.CategoryTheory.Sites.Hypercover.Zero
 import Mathlib.CategoryTheory.Sites.IsSheafFor
+import Mathlib.CategoryTheory.Sites.JointlySurjective
 import Mathlib.CategoryTheory.Sites.LeftExact
 import Mathlib.CategoryTheory.Sites.Limits
 import Mathlib.CategoryTheory.Sites.Localization

--- a/Mathlib/CategoryTheory/Limits/Types/Pullbacks.lean
+++ b/Mathlib/CategoryTheory/Limits/Types/Pullbacks.lean
@@ -1,0 +1,46 @@
+/-
+Copyright (c) 2025 Christian Merten. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Christian Merten
+-/
+import Mathlib.CategoryTheory.Limits.Shapes.Pullback.CommSq
+import Mathlib.CategoryTheory.Limits.Types.Shapes
+
+/-!
+# Lemmas on pullbacks in the category of types
+
+We show some additional lemmas for pullbacks in the category of types.
+-/
+
+universe u
+
+namespace CategoryTheory.Limits.Types
+
+variable {P X Y Z : Type u} {fst : P ⟶ X} {snd : P ⟶ Y} {f : X ⟶ Z} {g : Y ⟶ Z}
+
+lemma range_fst_of_isPullback (h : IsPullback fst snd f g) :
+    Set.range fst = f ⁻¹' Set.range g := by
+  let e := h.isoPullback ≪≫ Types.pullbackIsoPullback f g
+  have : fst = _root_.Prod.fst ∘ Subtype.val ∘ e.hom := by
+    ext p
+    suffices fst p = pullback.fst f g (h.isoPullback.hom p) by simpa
+    rw [← types_comp_apply h.isoPullback.hom (pullback.fst f g), IsPullback.isoPullback_hom_fst]
+  rw [this, Set.range_comp, Set.range_comp, Set.range_eq_univ.mpr (surjective_of_epi e.hom)]
+  ext
+  simp [eq_comm]
+
+lemma range_snd_of_isPullback (h : IsPullback fst snd f g) :
+    Set.range snd = g ⁻¹' Set.range f := by
+  rw [range_fst_of_isPullback (IsPullback.flip h)]
+
+variable (f g)
+
+@[simp]
+lemma range_pullbackFst : Set.range (pullback.fst f g) = f ⁻¹' Set.range g :=
+  range_fst_of_isPullback (.of_hasPullback f g)
+
+@[simp]
+lemma range_pullbackSnd : Set.range (pullback.snd f g) = g ⁻¹' Set.range f :=
+  range_snd_of_isPullback (.of_hasPullback f g)
+
+end CategoryTheory.Limits.Types

--- a/Mathlib/CategoryTheory/Limits/Types/Shapes.lean
+++ b/Mathlib/CategoryTheory/Limits/Types/Shapes.lean
@@ -5,7 +5,7 @@ Authors: Kim Morrison
 -/
 import Mathlib.CategoryTheory.Limits.Shapes.Multiequalizer
 import Mathlib.CategoryTheory.Limits.Shapes.BinaryProducts
-import Mathlib.CategoryTheory.Limits.Shapes.Pullback.HasPullback
+import Mathlib.CategoryTheory.Limits.Shapes.Pullback.CommSq
 import Mathlib.CategoryTheory.Limits.Types.Colimits
 import Mathlib.CategoryTheory.Limits.Types.Limits
 import Mathlib.Logic.Function.Coequalizer
@@ -690,6 +690,31 @@ theorem pullbackIsoPullback_inv_fst :
 @[simp]
 theorem pullbackIsoPullback_inv_snd :
     (pullbackIsoPullback f g).inv ≫ pullback.snd _ _ = fun p => (p.1 : X × Y).snd := by aesop
+
+lemma range_fst_of_isPullback {fst : W ⟶ X} {snd : W ⟶ Y} {f : X ⟶ Z} {g : Y ⟶ Z}
+    (h : IsPullback fst snd f g) :
+    Set.range fst = f ⁻¹' Set.range g := by
+  let e := h.isoPullback ≪≫ Types.pullbackIsoPullback f g
+  have : fst = _root_.Prod.fst ∘ Subtype.val ∘ e.hom := by
+    ext p
+    suffices fst p = pullback.fst f g (h.isoPullback.hom p) by simpa
+    rw [← types_comp_apply h.isoPullback.hom (pullback.fst f g), IsPullback.isoPullback_hom_fst]
+  rw [this, Set.range_comp, Set.range_comp, Set.range_eq_univ.mpr (surjective_of_epi e.hom)]
+  ext
+  simp [eq_comm]
+
+@[simp]
+lemma range_pullbackFst : Set.range (pullback.fst f g) = f ⁻¹' Set.range g :=
+  range_fst_of_isPullback (.of_hasPullback f g)
+
+lemma range_snd_of_isPullback {fst : W ⟶ X} {snd : W ⟶ Y} {f : X ⟶ Z} {g : Y ⟶ Z}
+    (h : IsPullback fst snd f g) :
+    Set.range snd = g ⁻¹' Set.range f := by
+  rw [range_fst_of_isPullback (IsPullback.flip h)]
+
+@[simp]
+lemma range_pullbackSnd : Set.range (pullback.snd f g) = g ⁻¹' Set.range f :=
+  range_snd_of_isPullback (.of_hasPullback f g)
 
 end Pullback
 

--- a/Mathlib/CategoryTheory/Limits/Types/Shapes.lean
+++ b/Mathlib/CategoryTheory/Limits/Types/Shapes.lean
@@ -5,7 +5,7 @@ Authors: Kim Morrison
 -/
 import Mathlib.CategoryTheory.Limits.Shapes.Multiequalizer
 import Mathlib.CategoryTheory.Limits.Shapes.BinaryProducts
-import Mathlib.CategoryTheory.Limits.Shapes.Pullback.CommSq
+import Mathlib.CategoryTheory.Limits.Shapes.Pullback.HasPullback
 import Mathlib.CategoryTheory.Limits.Types.Colimits
 import Mathlib.CategoryTheory.Limits.Types.Limits
 import Mathlib.Logic.Function.Coequalizer

--- a/Mathlib/CategoryTheory/Limits/Types/Shapes.lean
+++ b/Mathlib/CategoryTheory/Limits/Types/Shapes.lean
@@ -691,31 +691,6 @@ theorem pullbackIsoPullback_inv_fst :
 theorem pullbackIsoPullback_inv_snd :
     (pullbackIsoPullback f g).inv ≫ pullback.snd _ _ = fun p => (p.1 : X × Y).snd := by aesop
 
-lemma range_fst_of_isPullback {fst : W ⟶ X} {snd : W ⟶ Y} {f : X ⟶ Z} {g : Y ⟶ Z}
-    (h : IsPullback fst snd f g) :
-    Set.range fst = f ⁻¹' Set.range g := by
-  let e := h.isoPullback ≪≫ Types.pullbackIsoPullback f g
-  have : fst = _root_.Prod.fst ∘ Subtype.val ∘ e.hom := by
-    ext p
-    suffices fst p = pullback.fst f g (h.isoPullback.hom p) by simpa
-    rw [← types_comp_apply h.isoPullback.hom (pullback.fst f g), IsPullback.isoPullback_hom_fst]
-  rw [this, Set.range_comp, Set.range_comp, Set.range_eq_univ.mpr (surjective_of_epi e.hom)]
-  ext
-  simp [eq_comm]
-
-@[simp]
-lemma range_pullbackFst : Set.range (pullback.fst f g) = f ⁻¹' Set.range g :=
-  range_fst_of_isPullback (.of_hasPullback f g)
-
-lemma range_snd_of_isPullback {fst : W ⟶ X} {snd : W ⟶ Y} {f : X ⟶ Z} {g : Y ⟶ Z}
-    (h : IsPullback fst snd f g) :
-    Set.range snd = g ⁻¹' Set.range f := by
-  rw [range_fst_of_isPullback (IsPullback.flip h)]
-
-@[simp]
-lemma range_pullbackSnd : Set.range (pullback.snd f g) = g ⁻¹' Set.range f :=
-  range_snd_of_isPullback (.of_hasPullback f g)
-
 end Pullback
 
 section Pushout

--- a/Mathlib/CategoryTheory/Sites/JointlySurjective.lean
+++ b/Mathlib/CategoryTheory/Sites/JointlySurjective.lean
@@ -4,7 +4,7 @@ Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Christian Merten
 -/
 import Mathlib.CategoryTheory.Sites.Precoverage
-import Mathlib.CategoryTheory.Limits.Types.Shapes
+import Mathlib.CategoryTheory.Limits.Types.Pullbacks
 
 /-!
 # The jointly surjective precoverage

--- a/Mathlib/CategoryTheory/Sites/JointlySurjective.lean
+++ b/Mathlib/CategoryTheory/Sites/JointlySurjective.lean
@@ -1,0 +1,115 @@
+/-
+Copyright (c) 2025 Christian Merten. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Christian Merten
+-/
+import Mathlib.CategoryTheory.Sites.Precoverage
+import Mathlib.CategoryTheory.Limits.Types.Shapes
+
+/-!
+# The jointly surjective precoverage
+
+In the category of types, the jointly surjective precoverage has the jointly surjective
+families as coverings. We show that this precoverage is stable under the standard constructions.
+
+## Notes
+
+See `CategoryTheory.Sites.Types` for the Grothendieck topology of jointly surjective covers.
+-/
+
+universe u
+
+namespace CategoryTheory
+
+open Limits
+
+namespace Types
+
+/-- The jointly surjective precoverage in the category of types has the jointly surjective
+families as coverings. -/
+def jointlySurjectivePrecoverage : Precoverage (Type u) where
+  coverings X R := ∀ x : X, ∃ (Y : Type u) (g : Y ⟶ X), R g ∧ x ∈ Set.range g
+
+lemma mem_jointlySurjectivePrecoverage_iff {X : Type u} {R : Presieve X} :
+    R ∈ jointlySurjectivePrecoverage X ↔
+      ∀ x : X, ∃ (Y : Type u) (g : Y ⟶ X), R g ∧ x ∈ Set.range g :=
+  .rfl
+
+lemma singleton_mem_jointlySurjectivePrecoverage_iff {X Y : Type u} {f : X ⟶ Y} :
+    Presieve.singleton f ∈ jointlySurjectivePrecoverage Y ↔ Function.Surjective f := by
+  rw [mem_jointlySurjectivePrecoverage_iff]
+  refine ⟨fun hf x ↦ ?_, fun hf x ↦ ⟨X, f, ⟨⟩, by simp [hf.range_eq]⟩⟩
+  obtain ⟨_, _, ⟨⟩, hx⟩ := hf x
+  exact hx
+
+@[simp]
+lemma ofArrows_mem_jointlySurjectivePrecoverage_iff {X : Type u} {ι : Type*} {Y : ι → Type u}
+    {f : ∀ i, Y i ⟶ X} :
+    Presieve.ofArrows Y f ∈ jointlySurjectivePrecoverage X ↔
+      ∀ x, ∃ (i : ι), x ∈ Set.range (f i) := by
+  refine ⟨fun h x ↦ ?_, fun h x ↦ ?_⟩
+  · obtain ⟨Y, g, ⟨i⟩, hx⟩ := h x
+    use i
+  · obtain ⟨i, hx⟩ := h x
+    use Y i, f i, ⟨i⟩
+
+instance : jointlySurjectivePrecoverage.HasIsos where
+  mem_coverings_of_isIso {S T} f hf x := by
+    use S, f, ⟨⟩
+    exact surjective_of_epi f x
+
+instance : jointlySurjectivePrecoverage.IsStableUnderComposition where
+  comp_mem_coverings {ι} S X f hf σ Y g hg := by
+    simp_rw [ofArrows_mem_jointlySurjectivePrecoverage_iff] at hf hg ⊢
+    intro x
+    obtain ⟨i, y, rfl⟩ := hf x
+    obtain ⟨j, z, rfl⟩ := hg i y
+    use ⟨i, j⟩, z
+    simp
+
+instance : jointlySurjectivePrecoverage.IsStableUnderSup where
+  sup_mem_coverings {X} R S hR _ x := by
+    obtain ⟨Y, f, hf, hx⟩ := hR x
+    use Y, f, .inl hf
+
+end Types
+
+variable {C : Type*} [Category C] (F : C ⥤ Type u)
+
+lemma Presieve.mem_comap_jointlySurjectivePrecoverage_iff {X : C} {R : Presieve X} :
+    R ∈ Types.jointlySurjectivePrecoverage.comap F X ↔
+      ∀ x : F.obj X, ∃ (Y : C) (f : Y ⟶ X), R f ∧ x ∈ Set.range (F.map f) := by
+  rw [Precoverage.mem_comap_iff]
+  refine ⟨fun h x ↦ ?_, fun h x ↦ ?_⟩
+  · obtain ⟨-, -, ⟨hf⟩, hi⟩ := h x
+    exact ⟨_, _, hf, hi⟩
+  · obtain ⟨Y, g, hg, hi⟩ := h x
+    exact ⟨_, _, ⟨hg⟩, hi⟩
+
+/-- The pullback of the jointly surjective precoverage of types to any category `C` via a
+(forgetful) functor `C ⥤ Type u` is stable under base change if the canonical map
+`F (X ×[Y] Z) ⟶ F(X) ×[F(Y)] F(Z)` is surjective. -/
+lemma isStableUnderBaseChange_comap_jointlySurjectivePrecoverage
+    (H : ∀ {X Y S : C} (f : X ⟶ S) (g : Y ⟶ S) [HasPullback f g],
+      Function.Surjective (pullbackComparison F f g)) :
+    (Types.jointlySurjectivePrecoverage.comap F).IsStableUnderBaseChange where
+  mem_coverings_of_isPullback {ι} S X f hf Y g P p₁ p₂ h := by
+    rw [Precoverage.mem_comap_iff, Presieve.map_ofArrows,
+      Types.ofArrows_mem_jointlySurjectivePrecoverage_iff] at hf ⊢
+    intro x
+    obtain ⟨i, hi⟩ := hf (F.map g x)
+    have : HasPullback g (f i) := (h i).hasPullback
+    use i
+    have : F.map (p₁ i) = F.map ((h i).isoPullback.hom) ≫ pullbackComparison F g (f i) ≫
+        pullback.fst _ _ := by simp [← Functor.map_comp]
+    rwa [this, types_comp, types_comp, Function.comp_assoc, Set.range_comp,
+      Function.Surjective.range_eq <| (H _ _).comp (surjective_of_epi _), Set.image_univ,
+      Types.range_pullbackFst]
+
+instance : Types.jointlySurjectivePrecoverage.IsStableUnderBaseChange := by
+  rw [← Precoverage.comap_id Types.jointlySurjectivePrecoverage]
+  apply isStableUnderBaseChange_comap_jointlySurjectivePrecoverage
+  intro X Y S f g _
+  exact surjective_of_epi _
+
+end CategoryTheory

--- a/Mathlib/CategoryTheory/Sites/Precoverage.lean
+++ b/Mathlib/CategoryTheory/Sites/Precoverage.lean
@@ -166,6 +166,11 @@ lemma mem_comap_iff {X : C} {R : Presieve X} :
 
 lemma comap_inf : (J ⊓ K).comap F = J.comap F ⊓ K.comap F := rfl
 
+@[simp]
+lemma comap_id (K : Precoverage C) : K.comap (𝟭 C) = K := by
+  ext
+  simp
+
 instance [HasIsos J] : HasIsos (J.comap F) where
   mem_coverings_of_isIso {S T} f hf := by simpa using mem_coverings_of_isIso (F.map f)
 

--- a/Mathlib/CategoryTheory/Sites/Sieves.lean
+++ b/Mathlib/CategoryTheory/Sites/Sieves.lean
@@ -334,6 +334,10 @@ lemma map_singleton {X Y : C} (f : X ⟶ Y) : (singleton f).map F = singleton (F
 lemma map_functorPullback {X : C} (R : Presieve (F.obj X)) : (R.functorPullback F).map F ≤ R :=
   fun _ _ ⟨hu⟩ ↦ hu
 
+@[simp]
+lemma map_id {X : C} (R : Presieve X) : R.map (𝟭 C) = R :=
+  le_antisymm (fun _ _ ⟨hg⟩ ↦ hg) fun _ _ hg ↦ ⟨hg⟩
+
 end
 
 end FunctorPushforward


### PR DESCRIPTION
We define the precoverage on `Type u` of jointly surjective families. This precoverage can be pulled-back along a (forgetful) functor from `C` to `Type u` to obtain a precoverage on `C`. We show that the obtained precoverage is stable under base change if the pullback comparison map is surjective.

This will be used to define the jointly surjective precoverage on the category of schemes.

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include at least one commit authored by each
co-author among the commits in the pull request. If necessary, you may 
create empty commits to indicate co-authorship, using commands like so:

git commit --author="Author Name <author@email.com>" --allow-empty -m "add Author Name as coauthor"

When merging, all the commits will be squashed into a single commit listing all co-authors.

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
