### PR TITLE
[Merged by Bors] - feat(gcongr): `@[gcongr]` for `gcd` and `IsCoprime`

### DIFF
--- a/Mathlib/Algebra/GCDMonoid/Basic.lean
+++ b/Mathlib/Algebra/GCDMonoid/Basic.lean
@@ -381,6 +381,7 @@ theorem isUnit_gcd_one_right [GCDMonoid α] (a : α) : IsUnit (gcd a 1) :=
 
 theorem gcd_one_right' [GCDMonoid α] (a : α) : Associated (gcd a 1) 1 := by simp
 
+@[gcongr]
 theorem gcd_dvd_gcd [GCDMonoid α] {a b c d : α} (hab : a ∣ b) (hcd : c ∣ d) : gcd a c ∣ gcd b d :=
   dvd_gcd ((gcd_dvd_left _ _).trans hab) ((gcd_dvd_right _ _).trans hcd)
 
@@ -437,17 +438,17 @@ theorem gcd_eq_left_iff [NormalizedGCDMonoid α] (a b : α) (h : normalize a = a
 theorem gcd_eq_right_iff [NormalizedGCDMonoid α] (a b : α) (h : normalize b = b) :
     gcd a b = b ↔ b ∣ a := by simpa only [gcd_comm a b] using gcd_eq_left_iff b a h
 
-theorem gcd_dvd_gcd_mul_left [GCDMonoid α] (m n k : α) : gcd m n ∣ gcd (k * m) n :=
-  gcd_dvd_gcd (dvd_mul_left _ _) dvd_rfl
+theorem gcd_dvd_gcd_mul_left [GCDMonoid α] (m n k : α) : gcd m n ∣ gcd (k * m) n := by
+  grw [← dvd_mul_left]
 
-theorem gcd_dvd_gcd_mul_right [GCDMonoid α] (m n k : α) : gcd m n ∣ gcd (m * k) n :=
-  gcd_dvd_gcd (dvd_mul_right _ _) dvd_rfl
+theorem gcd_dvd_gcd_mul_right [GCDMonoid α] (m n k : α) : gcd m n ∣ gcd (m * k) n := by
+  grw [← dvd_mul_right]
 
-theorem gcd_dvd_gcd_mul_left_right [GCDMonoid α] (m n k : α) : gcd m n ∣ gcd m (k * n) :=
-  gcd_dvd_gcd dvd_rfl (dvd_mul_left _ _)
+theorem gcd_dvd_gcd_mul_left_right [GCDMonoid α] (m n k : α) : gcd m n ∣ gcd m (k * n) := by
+  grw [← dvd_mul_left]
 
-theorem gcd_dvd_gcd_mul_right_right [GCDMonoid α] (m n k : α) : gcd m n ∣ gcd m (n * k) :=
-  gcd_dvd_gcd dvd_rfl (dvd_mul_right _ _)
+theorem gcd_dvd_gcd_mul_right_right [GCDMonoid α] (m n k : α) : gcd m n ∣ gcd m (n * k) := by
+  grw [← dvd_mul_right]
 
 theorem Associated.gcd_eq_left [NormalizedGCDMonoid α] {m n : α} (h : Associated m n) (k : α) :
     gcd m k = gcd n k :=
@@ -531,8 +532,7 @@ theorem pow_dvd_of_mul_eq_pow [GCDMonoid α] {a b c d₁ d₂ : α} (ha : a ≠ 
     · apply IsUnit.dvd
       apply IsUnit.pow
       apply isUnit_of_dvd_one
-      apply dvd_trans _ hab.dvd
-      apply gcd_dvd_gcd hd₁ (dvd_refl b)
+      grw [hd₁, hab.dvd]
   have h2 : d₁ ^ k ∣ a * b := by
     use d₂ ^ k
     rw [h, hc]

--- a/Mathlib/RingTheory/Coprime/Basic.lean
+++ b/Mathlib/RingTheory/Coprime/Basic.lean
@@ -150,7 +150,7 @@ theorem IsCoprime.of_isCoprime_of_dvd_right (h : IsCoprime z y) (hdvd : x ∣ y)
   (h.symm.of_isCoprime_of_dvd_left hdvd).symm
 
 @[gcongr]
-theorem isCoprime_mono (h₁ : x ∣ y) (h₂ : z ∣ w) (h : IsCoprime y w) : IsCoprime x z :=
+theorem IsCoprime.mono (h₁ : x ∣ y) (h₂ : z ∣ w) (h : IsCoprime y w) : IsCoprime x z :=
   h.of_isCoprime_of_dvd_left h₁ |>.of_isCoprime_of_dvd_right h₂
 
 theorem IsCoprime.isUnit_of_dvd (H : IsCoprime x y) (d : x ∣ y) : IsUnit x :=

--- a/Mathlib/RingTheory/Coprime/Basic.lean
+++ b/Mathlib/RingTheory/Coprime/Basic.lean
@@ -31,7 +31,7 @@ universe u v
 
 section CommSemiring
 
-variable {R : Type u} [CommSemiring R] (x y z : R)
+variable {R : Type u} [CommSemiring R] (x y z w : R)
 
 /-- The proposition that `x` and `y` are coprime, defined to be the existence of `a` and `b` such
 that `a * x + b * y = 1`. Note that elements with no common divisors are not necessarily coprime,
@@ -39,7 +39,7 @@ e.g., the multivariate polynomials `x₁` and `x₂` are not coprime. -/
 def IsCoprime : Prop :=
   ∃ a b, a * x + b * y = 1
 
-variable {x y z}
+variable {x y z w}
 
 @[symm]
 theorem IsCoprime.symm (H : IsCoprime x y) : IsCoprime y x :=
@@ -148,6 +148,10 @@ theorem IsCoprime.of_isCoprime_of_dvd_left (h : IsCoprime y z) (hdvd : x ∣ y) 
 
 theorem IsCoprime.of_isCoprime_of_dvd_right (h : IsCoprime z y) (hdvd : x ∣ y) : IsCoprime z x :=
   (h.symm.of_isCoprime_of_dvd_left hdvd).symm
+
+@[gcongr]
+theorem isCoprime_mono (h₁ : x ∣ y) (h₂ : z ∣ w) (h : IsCoprime y w) : IsCoprime x z :=
+  h.of_isCoprime_of_dvd_left h₁ |>.of_isCoprime_of_dvd_right h₂
 
 theorem IsCoprime.isUnit_of_dvd (H : IsCoprime x y) (d : x ∣ y) : IsUnit x :=
   let ⟨k, hk⟩ := d


### PR DESCRIPTION
This PR adds `gcongr` tags for `gcd` and `IsCoprime`.

Although I don't expect it to be used very much, it is nice that we can use `grw` with the divisibility relation.

Is the name `isCoprime_mono` allowed even if the relation is divisibity?

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include at least one commit authored by each
co-author among the commits in the pull request. If necessary, you may 
create empty commits to indicate co-authorship, using commands like so:

git commit --author="Author Name <author@email.com>" --allow-empty -m "add Author Name as coauthor"

When merging, all the commits will be squashed into a single commit listing all co-authors.

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
