### PR TITLE
[Merged by Bors] - chore(Order/Defs): golf entire `le_min`, `max_le` and `min_eq_left` using `grind`

### DIFF
--- a/Mathlib/Order/Defs/LinearOrder.lean
+++ b/Mathlib/Order/Defs/LinearOrder.lean
@@ -147,9 +147,7 @@ lemma min_le_right (a b : α) : min a b ≤ b := by
   else simp [min_def, if_neg h, le_refl]
 
 lemma le_min (h₁ : c ≤ a) (h₂ : c ≤ b) : c ≤ min a b := by
-  if h : a ≤ b
-  then simpa [min_def, if_pos h] using h₁
-  else simpa [min_def, if_neg h] using h₂
+  grind
 
 lemma le_max_left (a b : α) : a ≤ max a b := by
   if h : a ≤ b
@@ -162,9 +160,7 @@ lemma le_max_right (a b : α) : b ≤ max a b := by
   else simpa [max_def, if_neg h] using le_of_not_ge h
 
 lemma max_le (h₁ : a ≤ c) (h₂ : b ≤ c) : max a b ≤ c := by
-  if h : a ≤ b
-  then simpa [max_def, if_pos h] using h₂
-  else simpa [max_def, if_neg h] using h₁
+  grind
 
 lemma eq_min (h₁ : c ≤ a) (h₂ : c ≤ b) (h₃ : ∀ {d}, d ≤ a → d ≤ b → d ≤ c) : c = min a b :=
   le_antisymm (le_min h₁ h₂) (h₃ (min_le_left a b) (min_le_right a b))
@@ -188,7 +184,7 @@ lemma min_left_comm (a b c : α) : min a (min b c) = min b (min a c) := by
 @[simp] lemma min_self (a : α) : min a a = a := by simp [min_def]
 
 lemma min_eq_left (h : a ≤ b) : min a b = a := by
-  apply Eq.symm; apply eq_min (le_refl _) h; intros; assumption
+  grind
 
 lemma min_eq_right (h : b ≤ a) : min a b = b := min_comm b a ▸ min_eq_left h
 


### PR DESCRIPTION
---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include at least one commit authored by each
co-author among the commits in the pull request. If necessary, you may 
create empty commits to indicate co-authorship, using commands like so:

git commit --author="Author Name <author@email.com>" --allow-empty -m "add Author Name as coauthor"

When merging, all the commits will be squashed into a single commit listing all co-authors.

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
