### PR TITLE
[Merged by Bors] - feat: the complete graph is connected iff nonempty

### DIFF
--- a/Mathlib/Combinatorics/SimpleGraph/Connectivity/Connected.lean
+++ b/Mathlib/Combinatorics/SimpleGraph/Connectivity/Connected.lean
@@ -71,7 +71,7 @@ protected theorem Adj.reachable {u v : V} (h : G.Adj u v) : G.Reachable u v :=
 @[refl]
 protected theorem Reachable.refl (u : V) : G.Reachable u u := ⟨Walk.nil⟩
 
-protected theorem Reachable.rfl {u : V} : G.Reachable u u := Reachable.refl _
+@[simp] protected theorem Reachable.rfl {u : V} : G.Reachable u u := Reachable.refl _
 
 @[symm]
 protected theorem Reachable.symm {u v : V} (huv : G.Reachable u v) : G.Reachable v u :=
@@ -142,6 +142,11 @@ theorem reachable_is_equivalence : Equivalence G.Reachable :=
 lemma reachable_bot {u v : V} : (⊥ : SimpleGraph V).Reachable u v ↔ u = v :=
   ⟨fun h ↦ h.elim fun p ↦ match p with | .nil => rfl, fun h ↦ h ▸ .rfl⟩
 
+@[simp] lemma reachable_top {u v : V} : (completeGraph V).Reachable u v := by
+  obtain rfl | huv := eq_or_ne u v
+  · simp
+  · exact ⟨.cons huv .nil⟩
+
 /-- The equivalence relation on vertices given by `SimpleGraph.Reachable`. -/
 def reachableSetoid : Setoid V := Setoid.mk _ G.reachable_is_equivalence
 
@@ -156,19 +161,25 @@ theorem Preconnected.map {G : SimpleGraph V} {H : SimpleGraph V'} (f : G →g H)
 protected lemma Preconnected.mono {G G' : SimpleGraph V} (h : G ≤ G') (hG : G.Preconnected) :
     G'.Preconnected := fun u v => (hG u v).mono h
 
-lemma bot_preconnected_iff_subsingleton : (⊥ : SimpleGraph V).Preconnected ↔ Subsingleton V := by
+lemma preconnected_bot_iff_subsingleton : (⊥ : SimpleGraph V).Preconnected ↔ Subsingleton V := by
   refine ⟨fun h ↦ ?_, fun h ↦ by simpa [subsingleton_iff, ← reachable_bot] using h⟩
   contrapose h
   simp [nontrivial_iff.mp <| not_subsingleton_iff_nontrivial.mp h, Preconnected, reachable_bot]
 
-lemma bot_preconnected [Subsingleton V] : (⊥ : SimpleGraph V).Preconnected :=
-  bot_preconnected_iff_subsingleton.mpr ‹_›
+lemma preconnected_bot [Subsingleton V] : (⊥ : SimpleGraph V).Preconnected :=
+  preconnected_bot_iff_subsingleton.mpr ‹_›
 
-lemma bot_not_preconnected [Nontrivial V] : ¬(⊥ : SimpleGraph V).Preconnected :=
-  bot_preconnected_iff_subsingleton.not.mpr <| not_subsingleton_iff_nontrivial.mpr ‹_›
+lemma not_preconnected_bot [Nontrivial V] : ¬(⊥ : SimpleGraph V).Preconnected :=
+  preconnected_bot_iff_subsingleton.not.mpr <| not_subsingleton_iff_nontrivial.mpr ‹_›
 
-lemma top_preconnected : (⊤ : SimpleGraph V).Preconnected := fun x y => by
+@[simp] lemma preconnected_top : (⊤ : SimpleGraph V).Preconnected := fun x y => by
   if h : x = y then rw [h] else exact Adj.reachable h
+
+@[deprecated (since := "2025-09-23")] alias bot_preconnected := preconnected_bot
+@[deprecated (since := "2025-09-23")]
+alias bot_preconnected_iff_subsingleton := preconnected_bot_iff_subsingleton
+@[deprecated (since := "2025-09-23")] alias bot_not_preconnected := not_preconnected_bot
+@[deprecated (since := "2025-09-23")] alias top_preconnected := preconnected_top
 
 theorem Iso.preconnected_iff {G : SimpleGraph V} {H : SimpleGraph V'} (e : G ≃g H) :
     G.Preconnected ↔ H.Preconnected :=
@@ -268,11 +279,18 @@ theorem Connected.exists_isPath {G : SimpleGraph V} (h : G.Connected) (u v : V) 
     ∃ p : G.Walk u v, p.IsPath :=
   (h u v).exists_isPath
 
-lemma bot_not_connected [Nontrivial V] : ¬(⊥ : SimpleGraph V).Connected := by
-  simp [bot_not_preconnected, connected_iff]
+lemma connected_bot_iff : (⊥ : SimpleGraph V).Connected ↔ Subsingleton V ∧ Nonempty V := by
+  simp [preconnected_bot_iff_subsingleton, connected_iff]
 
-lemma top_connected [Nonempty V] : (⊤ : SimpleGraph V).Connected where
-  preconnected := top_preconnected
+lemma not_connected_bot [Nontrivial V] : ¬(⊥ : SimpleGraph V).Connected := by
+  simp [not_preconnected_bot, connected_iff]
+
+lemma connected_top_iff : (completeGraph V).Connected ↔ Nonempty V := by simp [connected_iff]
+
+@[simp] lemma connected_top [Nonempty V] : (completeGraph V).Connected := by rwa [connected_top_iff]
+
+@[deprecated (since := "2025-09-23")] alias bot_not_connected := not_connected_bot
+@[deprecated (since := "2025-09-23")] alias top_connected := connected_top
 
 theorem Iso.connected_iff {G : SimpleGraph V} {H : SimpleGraph V'} (e : G ≃g H) :
     G.Connected ↔ H.Connected :=
@@ -512,11 +530,9 @@ lemma biUnion_supp_eq_supp {G G' : SimpleGraph V} (h : G ≤ G') (c' : Connected
 
 lemma top_supp_eq_univ (c : ConnectedComponent (⊤ : SimpleGraph V)) :
     c.supp = (Set.univ : Set V) := by
-  have ⟨w, hw⟩ := c.exists_rep
+  obtain ⟨w, rfl⟩ := c.exists_rep
   ext v
-  simp only [Set.mem_univ, iff_true, mem_supp_iff, ← hw]
-  apply ConnectedComponent.sound
-  exact (@top_connected V (Nonempty.intro v)).preconnected v w
+  simpa [-ConnectedComponent.eq] using ConnectedComponent.sound (G := ⊤)
 
 lemma reachable_of_mem_supp {G : SimpleGraph V} (C : G.ConnectedComponent) {u v : V}
     (hu : u ∈ C.supp) (hv : v ∈ C.supp) : G.Reachable u v := by

--- a/Mathlib/Combinatorics/SimpleGraph/Diam.lean
+++ b/Mathlib/Combinatorics/SimpleGraph/Diam.lean
@@ -75,7 +75,7 @@ lemma eccent_pos_iff (u : α) : 0 < G.eccent u ↔ Nontrivial α := by
 
 @[simp]
 lemma eccent_bot [Nontrivial α] (u : α) : (⊥ : SimpleGraph α).eccent u = ⊤ :=
-  eccent_eq_top_of_not_connected bot_not_connected u
+  eccent_eq_top_of_not_connected not_connected_bot u
 
 @[simp]
 lemma eccent_top [Nontrivial α] (u : α) : (⊤ : SimpleGraph α).eccent u = 1 := by
@@ -209,7 +209,7 @@ lemma ediam_anti (h : G ≤ G') : G'.ediam ≤ G.ediam :=
 
 @[simp]
 lemma ediam_bot [Nontrivial α] : (⊥ : SimpleGraph α).ediam = ⊤ :=
-  ediam_eq_top_of_not_connected bot_not_connected
+  ediam_eq_top_of_not_connected not_connected_bot
 
 @[simp]
 lemma ediam_top [Nontrivial α] : (⊤ : SimpleGraph α).ediam = 1 := by
@@ -383,7 +383,7 @@ lemma radius_eq_ediam_iff [Nonempty α] :
 
 @[simp]
 lemma radius_bot [Nontrivial α] : (⊥ : SimpleGraph α).radius = ⊤ :=
-  radius_eq_top_of_not_connected bot_not_connected
+  radius_eq_top_of_not_connected not_connected_bot
 
 @[simp]
 lemma radius_top [Nontrivial α] : (⊤ : SimpleGraph α).radius = 1 := by

--- a/Mathlib/Combinatorics/SimpleGraph/Maps.lean
+++ b/Mathlib/Combinatorics/SimpleGraph/Maps.lean
@@ -129,6 +129,11 @@ theorem comap_monotone (f : V ↪ W) : Monotone (SimpleGraph.comap f) := by
   intro G G' h _ _ ha
   exact h ha
 
+@[simp] lemma comap_bot (f : V → W) : (emptyGraph W).comap f = emptyGraph V := rfl
+
+lemma comap_top {f : V → W} (hf : f.Injective) : (completeGraph W).comap f = completeGraph V := by
+  ext; simp [hf.eq_iff]
+
 @[simp]
 theorem comap_map_eq (f : V ↪ W) (G : SimpleGraph V) : (G.map f).comap f = G := by
   ext
@@ -193,6 +198,9 @@ There is also a notion of induced subgraphs (see `SimpleGraph.subgraph.induce`).
 outside the set. This is a wrapper around `SimpleGraph.comap`. -/
 abbrev induce (s : Set V) (G : SimpleGraph V) : SimpleGraph s :=
   G.comap (Function.Embedding.subtype _)
+
+@[simp] lemma induce_top (s : Set V) : (completeGraph V).induce s = completeGraph s :=
+  comap_top Subtype.val_injective
 
 @[simp] lemma induce_singleton_eq_top (v : V) : G.induce {v} = ⊤ := by
   rw [eq_top_iff]; apply le_comap_of_subsingleton


### PR DESCRIPTION
Also fix the names of a bunch of lemmas.

From the ProofBench workshop


---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include at least one commit authored by each
co-author among the commits in the pull request. If necessary, you may 
create empty commits to indicate co-authorship, using commands like so:

git commit --author="Author Name <author@email.com>" --allow-empty -m "add Author Name as coauthor"

When merging, all the commits will be squashed into a single commit listing all co-authors.

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
