### PR TITLE
[Merged by Bors] - feat(ProbabilityTheory): Add `moment_def` and `moment_one`

### DIFF
--- a/Mathlib/Probability/Moments/Basic.lean
+++ b/Mathlib/Probability/Moments/Basic.lean
@@ -50,6 +50,9 @@ variable {Ω ι : Type*} {m : MeasurableSpace Ω} {X : Ω → ℝ} {p : ℕ} {μ
 def moment (X : Ω → ℝ) (p : ℕ) (μ : Measure Ω) : ℝ :=
   μ[X ^ p]
 
+lemma moment_def (X : Ω → ℝ) (p : ℕ) (μ : Measure Ω) :
+    moment X p μ = μ[X ^ p] := rfl
+
 /-- Central moment of a real random variable, `μ[(X - μ[X]) ^ p]`. -/
 def centralMoment (X : Ω → ℝ) (p : ℕ) (μ : Measure Ω) : ℝ :=
   μ[(X - fun (_ : Ω) => μ[X]) ^ p]
@@ -66,6 +69,9 @@ lemma moment_zero_measure : moment X p (0 : Measure Ω) = 0 := by simp [moment]
 theorem centralMoment_zero (hp : p ≠ 0) : centralMoment 0 p μ = 0 := by
   simp only [centralMoment, hp, Pi.zero_apply, integral_const, smul_eq_mul,
     mul_zero, zero_sub, Pi.pow_apply, Pi.neg_apply, neg_zero, zero_pow, Ne, not_false_iff]
+
+lemma moment_one (X : Ω → ℝ) (μ : Measure Ω) :
+    moment X 1 μ = μ[X] := by simp [moment]
 
 @[simp]
 lemma centralMoment_zero_measure : centralMoment X p (0 : Measure Ω) = 0 := by


### PR DESCRIPTION
Add `moment_def` to make it easier to go from `μ[X ^ p]` to `moment X p μ`. Also added `moment_one` as a special case.
This is useful for stating a lemma for the mean and variance of a random variable as a corollary of the moments if all of the moments can be proved at once (but one could use `moment_def` instead if this lemma is deemed unnecessary). 