### PR TITLE
perf(CategoryTheory/Limits/Shapes): reorder more instance arguments

### DIFF
--- a/Mathlib/CategoryTheory/Limits/Shapes/Countable.lean
+++ b/Mathlib/CategoryTheory/Limits/Shapes/Countable.lean
@@ -26,7 +26,7 @@ limits, see `sequentialFunctor_initial`.
 
 open CategoryTheory Opposite CountableCategory
 
-variable (C : Type*) [Category C] (J : Type*) [Countable J]
+variable (C : Type*) [Category C] (J : Type*)
 
 namespace CategoryTheory.Limits
 
@@ -56,7 +56,7 @@ instance [HasCountableLimits C] [Category.{v} J] [CountableCategory J] : HasLimi
 class HasCountableProducts where
   out (J : Type) [Countable J] : HasProductsOfShape J C
 
-instance [HasCountableProducts C] (J : Type*) [Countable J] : HasProductsOfShape J C :=
+instance [HasCountableProducts C] [Countable J] : HasProductsOfShape J C :=
   have : Countable (Shrink.{0} J) := Countable.of_equiv _ (equivShrink.{0} J)
   have : HasLimitsOfShape (Discrete (Shrink.{0} J)) C := HasCountableProducts.out _
   hasLimitsOfShape_of_equivalence (Discrete.equivalence (equivShrink.{0} J)).symm
@@ -110,7 +110,7 @@ instance (priority := 100) hasCountableCoproducts_of_hasCoproducts [HasCoproduct
     inferInstance
 
 -- See note [instance argument order]
-instance [HasCountableCoproducts C] (J : Type*) [Countable J] : HasCoproductsOfShape J C :=
+instance [HasCountableCoproducts C] [Countable J] : HasCoproductsOfShape J C :=
   have : Countable (Shrink.{0} J) := Countable.of_equiv _ (equivShrink.{0} J)
   have : HasColimitsOfShape (Discrete (Shrink.{0} J)) C := HasCountableCoproducts.out _
   hasColimitsOfShape_of_equivalence (Discrete.equivalence (equivShrink.{0} J)).symm
@@ -129,7 +129,7 @@ namespace IsFiltered
 
 attribute [local instance] IsFiltered.nonempty
 
-variable {C} [Preorder J] [IsFiltered J]
+variable {C} [Countable J] [Preorder J] [IsFiltered J]
 
 /-- The object part of the initial functor `ℕᵒᵖ ⥤ J` -/
 noncomputable def sequentialFunctor_obj : ℕ → J := fun
@@ -177,7 +177,7 @@ namespace IsCofiltered
 
 attribute [local instance] IsCofiltered.nonempty
 
-variable {C} [Preorder J] [IsCofiltered J]
+variable {C} [Countable J] [Preorder J] [IsCofiltered J]
 
 /-- The object part of the initial functor `ℕᵒᵖ ⥤ J` -/
 noncomputable def sequentialFunctor_obj : ℕ → J := fun

--- a/Mathlib/CategoryTheory/Limits/Shapes/FiniteLimits.lean
+++ b/Mathlib/CategoryTheory/Limits/Shapes/FiniteLimits.lean
@@ -218,7 +218,7 @@ class HasFiniteWidePullbacks : Prop where
   /-- `C` has all wide pullbacks for any Finite `J` -/
   out (J : Type) [Finite J] : HasLimitsOfShape (WidePullbackShape J) C
 
-instance hasLimitsOfShape_widePullbackShape (J : Type) [Finite J] [HasFiniteWidePullbacks C] :
+instance hasLimitsOfShape_widePullbackShape [HasFiniteWidePullbacks C] (J : Type) [Finite J] :
     HasLimitsOfShape (WidePullbackShape J) C := by
   haveI := @HasFiniteWidePullbacks.out C _ _ J
   infer_instance
@@ -230,7 +230,7 @@ class HasFiniteWidePushouts : Prop where
   /-- `C` has all wide pushouts for any Finite `J` -/
   out (J : Type) [Finite J] : HasColimitsOfShape (WidePushoutShape J) C
 
-instance hasColimitsOfShape_widePushoutShape (J : Type) [Finite J] [HasFiniteWidePushouts C] :
+instance hasColimitsOfShape_widePushoutShape [HasFiniteWidePushouts C] (J : Type) [Finite J] :
     HasColimitsOfShape (WidePushoutShape J) C := by
   haveI := @HasFiniteWidePushouts.out C _ _ J
   infer_instance


### PR DESCRIPTION
This PR continues from #22968

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include at least one commit authored by each
co-author among the commits in the pull request. If necessary, you may 
create empty commits to indicate co-authorship, using commands like so:

git commit --author="Author Name <author@email.com>" --allow-empty -m "add Author Name as coauthor"

When merging, all the commits will be squashed into a single commit listing all co-authors.

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
