### PR TITLE
[Merged by Bors] - feat(FractionRing): add `algHom_commutes`

### DIFF
--- a/Mathlib/RingTheory/DedekindDomain/Different.lean
+++ b/Mathlib/RingTheory/DedekindDomain/Different.lean
@@ -144,11 +144,8 @@ lemma map_equiv_traceDual [IsDomain A] [IsFractionRing B L] [IsDomain B]
   rw [Algebra.trace_eq_of_equiv_equiv (FractionRing.algEquiv A K).toRingEquiv
     (FractionRing.algEquiv B L).toRingEquiv]
   swap
-  · apply IsLocalization.ringHom_ext (M := A⁰); ext
-    simp only [AlgEquiv.toRingEquiv_eq_coe, AlgEquiv.toRingEquiv_toRingHom, RingHom.coe_comp,
-      RingHom.coe_coe, Function.comp_apply, AlgEquiv.commutes, ← IsScalarTower.algebraMap_apply]
-    rw [IsScalarTower.algebraMap_apply A B (FractionRing B), AlgEquiv.commutes,
-      ← IsScalarTower.algebraMap_apply]
+  · ext
+    exact FractionRing.algebraMap_algEquiv_commutes _ _ _ _ _
   simp only [AlgEquiv.toRingEquiv_eq_coe, map_mul, AlgEquiv.coe_ringEquiv,
     AlgEquiv.apply_symm_apply, ← AlgEquiv.symm_toRingEquiv, AlgEquiv.algebraMap_eq_apply]
 

--- a/Mathlib/RingTheory/DedekindDomain/Different.lean
+++ b/Mathlib/RingTheory/DedekindDomain/Different.lean
@@ -145,8 +145,7 @@ lemma map_equiv_traceDual [IsDomain A] [IsFractionRing B L] [IsDomain B]
     (FractionRing.algEquiv B L).toRingEquiv]
   swap
   · ext
-    exact IsFractionRing.algebraMap_algHom_commute (FractionRing.algEquiv A K).toAlgHom
-      (FractionRing.algEquiv B L).toAlgHom _
+    exact IsFractionRing.algEquiv_commutes (FractionRing.algEquiv A K) (FractionRing.algEquiv B L) _
   simp only [AlgEquiv.toRingEquiv_eq_coe, map_mul, AlgEquiv.coe_ringEquiv,
     AlgEquiv.apply_symm_apply, ← AlgEquiv.symm_toRingEquiv, AlgEquiv.algebraMap_eq_apply]
 

--- a/Mathlib/RingTheory/DedekindDomain/Different.lean
+++ b/Mathlib/RingTheory/DedekindDomain/Different.lean
@@ -145,7 +145,8 @@ lemma map_equiv_traceDual [IsDomain A] [IsFractionRing B L] [IsDomain B]
     (FractionRing.algEquiv B L).toRingEquiv]
   swap
   · ext
-    exact FractionRing.algebraMap_algEquiv_commutes _ _ _ _ _
+    exact IsFractionRing.algebraMap_algHom_commute (FractionRing.algEquiv A K).toAlgHom
+      (FractionRing.algEquiv B L).toAlgHom _
   simp only [AlgEquiv.toRingEquiv_eq_coe, map_mul, AlgEquiv.coe_ringEquiv,
     AlgEquiv.apply_symm_apply, ← AlgEquiv.symm_toRingEquiv, AlgEquiv.algebraMap_eq_apply]
 

--- a/Mathlib/RingTheory/IntegralClosure/IntegralRestrict.lean
+++ b/Mathlib/RingTheory/IntegralClosure/IntegralRestrict.lean
@@ -273,8 +273,7 @@ lemma Algebra.algebraMap_intTrace (x : B) :
   apply Algebra.trace_eq_of_equiv_equiv (FractionRing.algEquiv A K).toRingEquiv
     (FractionRing.algEquiv B L).toRingEquiv
   ext
-  exact IsFractionRing.algebraMap_algHom_commute (FractionRing.algEquiv A K).toAlgHom
-    (FractionRing.algEquiv B L).toAlgHom _
+  exact IsFractionRing.algEquiv_commutes (FractionRing.algEquiv A K) (FractionRing.algEquiv B L) _
 
 lemma Algebra.algebraMap_intTrace_fractionRing (x : B) :
     algebraMap A (FractionRing A) (Algebra.intTrace A B x) =
@@ -400,8 +399,7 @@ lemma Algebra.algebraMap_intNorm (x : B) :
   apply Algebra.norm_eq_of_equiv_equiv (FractionRing.algEquiv A K).toRingEquiv
     (FractionRing.algEquiv B L).toRingEquiv
   ext
-  exact IsFractionRing.algebraMap_algHom_commute (FractionRing.algEquiv A K).toAlgHom
-    (FractionRing.algEquiv B L).toAlgHom _
+  exact IsFractionRing.algEquiv_commutes (FractionRing.algEquiv A K) (FractionRing.algEquiv B L) _
 
 @[simp]
 lemma Algebra.algebraMap_intNorm_fractionRing (x : B) :

--- a/Mathlib/RingTheory/IntegralClosure/IntegralRestrict.lean
+++ b/Mathlib/RingTheory/IntegralClosure/IntegralRestrict.lean
@@ -272,9 +272,8 @@ lemma Algebra.algebraMap_intTrace (x : B) :
     ← AlgEquiv.commutes (FractionRing.algEquiv B L)]
   apply Algebra.trace_eq_of_equiv_equiv (FractionRing.algEquiv A K).toRingEquiv
     (FractionRing.algEquiv B L).toRingEquiv
-  apply IsLocalization.ringHom_ext A⁰
-  simp only [AlgEquiv.toRingEquiv_eq_coe, ← AlgEquiv.coe_ringHom_commutes, RingHom.comp_assoc,
-    AlgHom.comp_algebraMap_of_tower, ← IsScalarTower.algebraMap_eq, RingHom.comp_assoc]
+  ext
+  exact FractionRing.algebraMap_algEquiv_commutes _ _ _ _ _
 
 lemma Algebra.algebraMap_intTrace_fractionRing (x : B) :
     algebraMap A (FractionRing A) (Algebra.intTrace A B x) =
@@ -399,9 +398,8 @@ lemma Algebra.algebraMap_intNorm (x : B) :
     ← AlgEquiv.commutes (FractionRing.algEquiv B L)]
   apply Algebra.norm_eq_of_equiv_equiv (FractionRing.algEquiv A K).toRingEquiv
     (FractionRing.algEquiv B L).toRingEquiv
-  apply IsLocalization.ringHom_ext A⁰
-  simp only [AlgEquiv.toRingEquiv_eq_coe, ← AlgEquiv.coe_ringHom_commutes, RingHom.comp_assoc,
-    AlgHom.comp_algebraMap_of_tower, ← IsScalarTower.algebraMap_eq, RingHom.comp_assoc]
+  ext
+  exact FractionRing.algebraMap_algEquiv_commutes _ _ _ _ _
 
 @[simp]
 lemma Algebra.algebraMap_intNorm_fractionRing (x : B) :

--- a/Mathlib/RingTheory/IntegralClosure/IntegralRestrict.lean
+++ b/Mathlib/RingTheory/IntegralClosure/IntegralRestrict.lean
@@ -273,7 +273,8 @@ lemma Algebra.algebraMap_intTrace (x : B) :
   apply Algebra.trace_eq_of_equiv_equiv (FractionRing.algEquiv A K).toRingEquiv
     (FractionRing.algEquiv B L).toRingEquiv
   ext
-  exact FractionRing.algebraMap_algEquiv_commutes _ _ _ _ _
+  exact IsFractionRing.algebraMap_algHom_commute (FractionRing.algEquiv A K).toAlgHom
+    (FractionRing.algEquiv B L).toAlgHom _
 
 lemma Algebra.algebraMap_intTrace_fractionRing (x : B) :
     algebraMap A (FractionRing A) (Algebra.intTrace A B x) =
@@ -399,7 +400,8 @@ lemma Algebra.algebraMap_intNorm (x : B) :
   apply Algebra.norm_eq_of_equiv_equiv (FractionRing.algEquiv A K).toRingEquiv
     (FractionRing.algEquiv B L).toRingEquiv
   ext
-  exact FractionRing.algebraMap_algEquiv_commutes _ _ _ _ _
+  exact IsFractionRing.algebraMap_algHom_commute (FractionRing.algEquiv A K).toAlgHom
+    (FractionRing.algEquiv B L).toAlgHom _
 
 @[simp]
 lemma Algebra.algebraMap_intNorm_fractionRing (x : B) :

--- a/Mathlib/RingTheory/Localization/FractionRing.lean
+++ b/Mathlib/RingTheory/Localization/FractionRing.lean
@@ -222,7 +222,7 @@ theorem mk'_eq_one_iff_eq {x : A} {y : nonZeroDivisors A} : mk' K x y = 1 ↔ x 
   exact IsFractionRing.injective A K hxy
 
 omit [IsDomain B] in
-theorem algebraMap_algHom_commute [Algebra A B] {K₁ K₂ : Type*} [Field K₁] [Field K₂]
+theorem algHom_commutes [Algebra A B] {K₁ K₂ : Type*} [Field K₁] [Field K₂]
     [Algebra A K₁] [Algebra A K₂] [IsFractionRing A K₁] {L₁ L₂ : Type*} [Field L₁] [Field L₂]
     [Algebra B L₁] [Algebra B L₂] [Algebra K₁ L₁] [Algebra K₂ L₂] [Algebra A L₁] [Algebra A L₂]
     [IsScalarTower A K₁ L₁] [IsScalarTower A K₂ L₂] [IsScalarTower A B L₁] [IsScalarTower A B L₂]
@@ -231,6 +231,15 @@ theorem algebraMap_algHom_commute [Algebra A B] {K₁ K₂ : Type*} [Field K₁]
   obtain ⟨r, s, hs, rfl⟩ := IsFractionRing.div_surjective (A := A) x
   simp_rw [map_div₀, AlgHom.commutes, ← IsScalarTower.algebraMap_apply,
     IsScalarTower.algebraMap_apply A B L₁, AlgHom.commutes, ← IsScalarTower.algebraMap_apply]
+
+omit [IsDomain B] in
+theorem algEquiv_commutes [Algebra A B] {K₁ K₂ : Type*} [Field K₁] [Field K₂]
+    [Algebra A K₁] [Algebra A K₂] [IsFractionRing A K₁] {L₁ L₂ : Type*} [Field L₁] [Field L₂]
+    [Algebra B L₁] [Algebra B L₂] [Algebra K₁ L₁] [Algebra K₂ L₂] [Algebra A L₁] [Algebra A L₂]
+    [IsScalarTower A K₁ L₁] [IsScalarTower A K₂ L₂] [IsScalarTower A B L₁] [IsScalarTower A B L₂]
+    (e : K₁ ≃ₐ[A] K₂) (f : L₁ ≃ₐ[B] L₂) (x : K₁) :
+    algebraMap K₂ L₂ (e x) = f (algebraMap K₁ L₁ x) := by
+  exact algHom_commutes e.toAlgHom f.toAlgHom _
 
 section Subfield
 

--- a/Mathlib/RingTheory/Localization/FractionRing.lean
+++ b/Mathlib/RingTheory/Localization/FractionRing.lean
@@ -221,25 +221,26 @@ theorem mk'_eq_one_iff_eq {x : A} {y : nonZeroDivisors A} : mk' K x y = 1 ↔ x 
   rw [IsFractionRing.mk'_eq_div, div_eq_one_iff_eq hy] at hxy
   exact IsFractionRing.injective A K hxy
 
-omit [IsDomain B] in
-theorem algHom_commutes [Algebra A B] {K₁ K₂ : Type*} [Field K₁] [Field K₂]
-    [Algebra A K₁] [Algebra A K₂] [IsFractionRing A K₁] {L₁ L₂ : Type*} [Field L₁] [Field L₂]
-    [Algebra B L₁] [Algebra B L₂] [Algebra K₁ L₁] [Algebra K₂ L₂] [Algebra A L₁] [Algebra A L₂]
-    [IsScalarTower A K₁ L₁] [IsScalarTower A K₂ L₂] [IsScalarTower A B L₁] [IsScalarTower A B L₂]
-    (e : K₁ →ₐ[A] K₂) (f : L₁ →ₐ[B] L₂) (x : K₁) :
+section commutes
+
+variable [Algebra A B] {K₁ K₂ : Type*} [Field K₁] [Field K₂] [Algebra A K₁] [Algebra A K₂]
+  [IsFractionRing A K₁] {L₁ L₂ : Type*} [Field L₁] [Field L₂] [Algebra B L₁] [Algebra B L₂]
+  [Algebra K₁ L₁] [Algebra K₂ L₂] [Algebra A L₁] [Algebra A L₂] [IsScalarTower A K₁ L₁]
+  [IsScalarTower A K₂ L₂] [IsScalarTower A B L₁] [IsScalarTower A B L₂]
+
+omit [IsDomain B]
+
+theorem algHom_commutes (e : K₁ →ₐ[A] K₂) (f : L₁ →ₐ[B] L₂) (x : K₁) :
     algebraMap K₂ L₂ (e x) = f (algebraMap K₁ L₁ x) := by
   obtain ⟨r, s, hs, rfl⟩ := IsFractionRing.div_surjective (A := A) x
   simp_rw [map_div₀, AlgHom.commutes, ← IsScalarTower.algebraMap_apply,
     IsScalarTower.algebraMap_apply A B L₁, AlgHom.commutes, ← IsScalarTower.algebraMap_apply]
 
-omit [IsDomain B] in
-theorem algEquiv_commutes [Algebra A B] {K₁ K₂ : Type*} [Field K₁] [Field K₂]
-    [Algebra A K₁] [Algebra A K₂] [IsFractionRing A K₁] {L₁ L₂ : Type*} [Field L₁] [Field L₂]
-    [Algebra B L₁] [Algebra B L₂] [Algebra K₁ L₁] [Algebra K₂ L₂] [Algebra A L₁] [Algebra A L₂]
-    [IsScalarTower A K₁ L₁] [IsScalarTower A K₂ L₂] [IsScalarTower A B L₁] [IsScalarTower A B L₂]
-    (e : K₁ ≃ₐ[A] K₂) (f : L₁ ≃ₐ[B] L₂) (x : K₁) :
+theorem algEquiv_commutes (e : K₁ ≃ₐ[A] K₂) (f : L₁ ≃ₐ[B] L₂) (x : K₁) :
     algebraMap K₂ L₂ (e x) = f (algebraMap K₁ L₁ x) := by
   exact algHom_commutes e.toAlgHom f.toAlgHom _
+
+end commutes
 
 section Subfield
 

--- a/Mathlib/RingTheory/Localization/FractionRing.lean
+++ b/Mathlib/RingTheory/Localization/FractionRing.lean
@@ -562,10 +562,46 @@ noncomputable def algEquiv (K : Type*) [CommRing K] [Algebra A K] [IsFractionRin
     FractionRing A ≃ₐ[A] K :=
   Localization.algEquiv (nonZeroDivisors A) K
 
+
 instance [Algebra R A] [FaithfulSMul R A] : FaithfulSMul R (FractionRing A) := by
   rw [faithfulSMul_iff_algebraMap_injective, IsScalarTower.algebraMap_eq R A]
   exact (FaithfulSMul.algebraMap_injective A (FractionRing A)).comp
     (FaithfulSMul.algebraMap_injective R A)
+
+/--
+To apply results that prove that certain properties of the extension `Frac B /Frac A` are shared by
+the extension `K/L` where `IsFractionRing A K` and `IsFractionRing B L` such as
+`Algebra.finrank_eq_of_equiv_equiv`, `Algebra.IsSeparable.of_equiv_equiv`, etc., it is necessary
+to prove a compatibility between `algEquiv` and `algebraMap`. This is what this result proves.
+See also `FractionRing.algebraMap_algEquiv_symm_commutes` for the result in the other direction.
+-/
+theorem algebraMap_algEquiv_commutes (B : Type*) [CommRing B] [IsDomain B] (L : Type*) [Field K]
+    [Field L] [Algebra A K] [IsFractionRing A K] [Algebra B L] [IsFractionRing B L] [Algebra A B]
+    [Algebra K L] [Algebra A L] [IsScalarTower A B L] [IsScalarTower A K L]
+    [Algebra (FractionRing A) (FractionRing B)] [IsScalarTower A (FractionRing A) (FractionRing B)]
+    (x : FractionRing A) :
+    algebraMap K L (algEquiv A K x) =
+      algEquiv B L (algebraMap (FractionRing A) (FractionRing B) x) := by
+  obtain ⟨r, s, -, rfl⟩ := IsFractionRing.div_surjective (A := A) x
+  simp_rw [map_div₀, ← IsScalarTower.algebraMap_apply, IsScalarTower.algebraMap_apply A B
+    (FractionRing B), AlgEquiv.commutes, ← IsScalarTower.algebraMap_apply]
+
+/--
+To apply results that prove that certain properties of the extension `Frac B /Frac A` are shared by
+the extension `K/L` where `IsFractionRing A K` and `IsFractionRing B L` such as
+`Algebra.finrank_eq_of_equiv_equiv`, `Algebra.IsSeparable.of_equiv_equiv`, etc., it is necessary
+to prove a compatibility between `algEquiv` and the corresponding `algebraMap`. This is what this
+result proves.
+See also `FractionRing.algebraMap_algEquiv_commutes` for the result in the other direction.
+-/
+theorem algebraMap_algEquiv_symm_commutes (B : Type*) [CommRing B] [IsDomain B] (L : Type*)
+    [Field K] [Field L] [Algebra A K] [IsFractionRing A K] [Algebra B L] [IsFractionRing B L]
+    [Algebra A B] [Algebra K L] [Algebra A L] [IsScalarTower A B L] [IsScalarTower A K L]
+    [Algebra (FractionRing A) (FractionRing B)] [IsScalarTower A (FractionRing A) (FractionRing B)]
+    (x : K) :
+    algebraMap (FractionRing A) (FractionRing B) ((FractionRing.algEquiv A K).symm x) =
+      (FractionRing.algEquiv B L).symm (algebraMap K L x) := by
+  rw [AlgEquiv.eq_symm_apply, ← algebraMap_algEquiv_commutes A K B L, AlgEquiv.apply_symm_apply]
 
 section IsScalarTower
 

--- a/Mathlib/RingTheory/Localization/FractionRing.lean
+++ b/Mathlib/RingTheory/Localization/FractionRing.lean
@@ -221,6 +221,17 @@ theorem mk'_eq_one_iff_eq {x : A} {y : nonZeroDivisors A} : mk' K x y = 1 ↔ x 
   rw [IsFractionRing.mk'_eq_div, div_eq_one_iff_eq hy] at hxy
   exact IsFractionRing.injective A K hxy
 
+omit [IsDomain B] in
+theorem algebraMap_algHom_commute [Algebra A B] {K₁ K₂ : Type*} [Field K₁] [Field K₂]
+    [Algebra A K₁] [Algebra A K₂] [IsFractionRing A K₁] {L₁ L₂ : Type*} [Field L₁] [Field L₂]
+    [Algebra B L₁] [Algebra B L₂] [Algebra K₁ L₁] [Algebra K₂ L₂] [Algebra A L₁] [Algebra A L₂]
+    [IsScalarTower A K₁ L₁] [IsScalarTower A K₂ L₂] [IsScalarTower A B L₁] [IsScalarTower A B L₂]
+    (e : K₁ →ₐ[A] K₂) (f : L₁ →ₐ[B] L₂) (x : K₁) :
+    algebraMap K₂ L₂ (e x) = f (algebraMap K₁ L₁ x) := by
+  obtain ⟨r, s, hs, rfl⟩ := IsFractionRing.div_surjective (A := A) x
+  simp_rw [map_div₀, AlgHom.commutes, ← IsScalarTower.algebraMap_apply,
+    IsScalarTower.algebraMap_apply A B L₁, AlgHom.commutes, ← IsScalarTower.algebraMap_apply]
+
 section Subfield
 
 variable (A K) in
@@ -562,46 +573,10 @@ noncomputable def algEquiv (K : Type*) [CommRing K] [Algebra A K] [IsFractionRin
     FractionRing A ≃ₐ[A] K :=
   Localization.algEquiv (nonZeroDivisors A) K
 
-
 instance [Algebra R A] [FaithfulSMul R A] : FaithfulSMul R (FractionRing A) := by
   rw [faithfulSMul_iff_algebraMap_injective, IsScalarTower.algebraMap_eq R A]
   exact (FaithfulSMul.algebraMap_injective A (FractionRing A)).comp
     (FaithfulSMul.algebraMap_injective R A)
-
-/--
-To apply results that prove that certain properties of the extension `Frac B /Frac A` are shared by
-the extension `K/L` where `IsFractionRing A K` and `IsFractionRing B L` such as
-`Algebra.finrank_eq_of_equiv_equiv`, `Algebra.IsSeparable.of_equiv_equiv`, etc., it is necessary
-to prove a compatibility between `algEquiv` and `algebraMap`. This is what this result proves.
-See also `FractionRing.algebraMap_algEquiv_symm_commutes` for the result in the other direction.
--/
-theorem algebraMap_algEquiv_commutes (B : Type*) [CommRing B] [IsDomain B] (L : Type*) [Field K]
-    [Field L] [Algebra A K] [IsFractionRing A K] [Algebra B L] [IsFractionRing B L] [Algebra A B]
-    [Algebra K L] [Algebra A L] [IsScalarTower A B L] [IsScalarTower A K L]
-    [Algebra (FractionRing A) (FractionRing B)] [IsScalarTower A (FractionRing A) (FractionRing B)]
-    (x : FractionRing A) :
-    algebraMap K L (algEquiv A K x) =
-      algEquiv B L (algebraMap (FractionRing A) (FractionRing B) x) := by
-  obtain ⟨r, s, -, rfl⟩ := IsFractionRing.div_surjective (A := A) x
-  simp_rw [map_div₀, ← IsScalarTower.algebraMap_apply, IsScalarTower.algebraMap_apply A B
-    (FractionRing B), AlgEquiv.commutes, ← IsScalarTower.algebraMap_apply]
-
-/--
-To apply results that prove that certain properties of the extension `Frac B /Frac A` are shared by
-the extension `K/L` where `IsFractionRing A K` and `IsFractionRing B L` such as
-`Algebra.finrank_eq_of_equiv_equiv`, `Algebra.IsSeparable.of_equiv_equiv`, etc., it is necessary
-to prove a compatibility between `algEquiv` and the corresponding `algebraMap`. This is what this
-result proves.
-See also `FractionRing.algebraMap_algEquiv_commutes` for the result in the other direction.
--/
-theorem algebraMap_algEquiv_symm_commutes (B : Type*) [CommRing B] [IsDomain B] (L : Type*)
-    [Field K] [Field L] [Algebra A K] [IsFractionRing A K] [Algebra B L] [IsFractionRing B L]
-    [Algebra A B] [Algebra K L] [Algebra A L] [IsScalarTower A B L] [IsScalarTower A K L]
-    [Algebra (FractionRing A) (FractionRing B)] [IsScalarTower A (FractionRing A) (FractionRing B)]
-    (x : K) :
-    algebraMap (FractionRing A) (FractionRing B) ((FractionRing.algEquiv A K).symm x) =
-      (FractionRing.algEquiv B L).symm (algebraMap K L x) := by
-  rw [AlgEquiv.eq_symm_apply, ← algebraMap_algEquiv_commutes A K B L, AlgEquiv.apply_symm_apply]
 
 section IsScalarTower
 


### PR DESCRIPTION
Add a version of `algHom.commutes` and `algEquiv.commutes` for fraction fields and use them to simplify some proofs.


---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include at least one commit authored by each
co-author among the commits in the pull request. If necessary, you may 
create empty commits to indicate co-authorship, using commands like so:

git commit --author="Author Name <author@email.com>" --allow-empty -m "add Author Name as coauthor"

When merging, all the commits will be squashed into a single commit listing all co-authors.

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->
