### PR TITLE
[Merged by Bors] - chore: remove redundant `haveI`/`letI`

### DIFF
--- a/Mathlib/Algebra/Group/Pointwise/Set/Finite.lean
+++ b/Mathlib/Algebra/Group/Pointwise/Set/Finite.lean
@@ -58,7 +58,6 @@ instance decidableMemPow [Fintype α] [DecidableEq α] [DecidablePred (· ∈ s)
     simp only [pow_zero, mem_one]
     infer_instance
   | succ n ih =>
-    letI := ih
     rw [pow_succ]
     infer_instance
 

--- a/Mathlib/AlgebraicGeometry/Morphisms/AffineAnd.lean
+++ b/Mathlib/AlgebraicGeometry/Morphisms/AffineAnd.lean
@@ -191,7 +191,7 @@ lemma HasAffineProperty.affineAnd_isStableUnderComposition {P : MorphismProperty
     · rw [IsLocalAtTarget.iff_of_iSup_eq_top (P := P) _ (iSup_affineOpens_eq_top _)]
       intro U
       rw [morphismRestrict_comp]
-      exact this hA hQ _ _ (IsLocalAtTarget.restrict hf _) (IsLocalAtTarget.restrict hg _) hA U.2
+      exact this hA hQ _ _ (IsLocalAtTarget.restrict hf _) (IsLocalAtTarget.restrict hg _) U.2
     rw [HasAffineProperty.iff_of_isAffine (P := P) (Q := (affineAnd Q))] at hg
     obtain ⟨hY, hg⟩ := hg
     rw [HasAffineProperty.iff_of_isAffine (P := P) (Q := (affineAnd Q))] at hf

--- a/Mathlib/AlgebraicGeometry/Morphisms/AffineAnd.lean
+++ b/Mathlib/AlgebraicGeometry/Morphisms/AffineAnd.lean
@@ -187,7 +187,6 @@ lemma HasAffineProperty.affineAnd_isStableUnderComposition {P : MorphismProperty
     (hA : HasAffineProperty P (affineAnd Q)) (hQ : RingHom.StableUnderComposition Q) :
     P.IsStableUnderComposition where
   comp_mem {X Y Z} f g hf hg := by
-    haveI := hA
     wlog hZ : IsAffine Z
     · rw [IsLocalAtTarget.iff_of_iSup_eq_top (P := P) _ (iSup_affineOpens_eq_top _)]
       intro U

--- a/Mathlib/FieldTheory/Finite/Basic.lean
+++ b/Mathlib/FieldTheory/Finite/Basic.lean
@@ -470,7 +470,6 @@ open Polynomial
 
 theorem expand_card (f : K[X]) : expand K q f = f ^ q := by
   obtain ⟨p, hp⟩ := CharP.exists K
-  letI := hp
   rcases FiniteField.card K p with ⟨⟨n, npos⟩, ⟨hp, hn⟩⟩
   haveI : Fact p.Prime := ⟨hp⟩
   dsimp at hn

--- a/Mathlib/LinearAlgebra/Basis/Defs.lean
+++ b/Mathlib/LinearAlgebra/Basis/Defs.lean
@@ -410,7 +410,6 @@ section ReindexRange
 def reindexRange : Basis (range b) R M :=
   haveI := Classical.dec (Nontrivial R)
   if h : Nontrivial R then
-    letI := h
     b.reindex (Equiv.ofInjective b (Basis.injective b))
   else
     letI : Subsingleton R := not_nontrivial_iff_subsingleton.mp h
@@ -418,8 +417,7 @@ def reindexRange : Basis (range b) R M :=
 
 theorem reindexRange_self (i : ι) (h := Set.mem_range_self i) : b.reindexRange ⟨b i, h⟩ = b i := by
   by_cases htr : Nontrivial R
-  · letI := htr
-    simp [htr, reindexRange, reindex_apply]
+  · simp [htr, reindexRange, reindex_apply]
   · letI : Subsingleton R := not_nontrivial_iff_subsingleton.mp htr
     letI := Module.subsingleton R M
     simp [reindexRange, eq_iff_true_of_subsingleton]

--- a/Mathlib/LinearAlgebra/Matrix/Charpoly/FiniteField.lean
+++ b/Mathlib/LinearAlgebra/Matrix/Charpoly/FiniteField.lean
@@ -24,7 +24,7 @@ variable {n : Type*} [DecidableEq n] [Fintype n]
 theorem FiniteField.Matrix.charpoly_pow_card {K : Type*} [Field K] [Fintype K] (M : Matrix n n K) :
     (M ^ Fintype.card K).charpoly = M.charpoly := by
   cases (isEmpty_or_nonempty n).symm
-  · obtain ⟨p, hp⟩ := CharP.exists K; letI := hp
+  · obtain ⟨p, hp⟩ := CharP.exists K
     rcases FiniteField.card K p with ⟨⟨k, kpos⟩, ⟨hp, hk⟩⟩
     haveI : Fact p.Prime := ⟨hp⟩
     dsimp at hk; rw [hk]

--- a/Mathlib/Probability/Kernel/WithDensity.lean
+++ b/Mathlib/Probability/Kernel/WithDensity.lean
@@ -239,7 +239,7 @@ theorem isSFiniteKernel_withDensity_of_isFiniteKernel (κ : Kernel α β) [IsFin
   rw [hf_eq_tsum, withDensity_tsum _ fun n : ℕ => _]
   swap; · fun_prop
   refine isSFiniteKernel_sum (hκs := fun n => ?_)
-  suffices IsFiniteKernel (withDensity κ (fs n)) by haveI := this; infer_instance
+  suffices IsFiniteKernel (withDensity κ (fs n)) by infer_instance
   refine isFiniteKernel_withDensity_of_bounded _ (ENNReal.coe_ne_top : ↑n + 1 ≠ ∞) fun a b => ?_
   -- After https://github.com/leanprover/lean4/pull/2734, we need to do beta reduction before `norm_cast`
   beta_reduce

--- a/Mathlib/SetTheory/Cardinal/Cofinality.lean
+++ b/Mathlib/SetTheory/Cardinal/Cofinality.lean
@@ -684,7 +684,6 @@ theorem mk_subset_mk_lt_cof {α : Type*} (h : ∀ x < #α, 2 ^ x < #α) :
   · simp [ha]
   have h' : IsStrongLimit #α := ⟨ha, @h⟩
   rcases ord_eq α with ⟨r, wo, hr⟩
-  haveI := wo
   apply le_antisymm
   · conv_rhs => rw [← mk_bounded_subset h hr]
     apply mk_le_mk_of_subset


### PR DESCRIPTION
These `haveI` and `letI` invocations seem to be remnants of lean3, when local variables weren't automatically added as instances.

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include at least one commit authored by each
co-author among the commits in the pull request. If necessary, you may 
create empty commits to indicate co-authorship, using commands like so:

git commit --author="Author Name <author@email.com>" --allow-empty -m "add Author Name as coauthor"

When merging, all the commits will be squashed into a single commit listing all co-authors.

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
