### PR TITLE
[Merged by Bors] - chore(VectorBundle/Riemannian): use `grw`

### DIFF
--- a/Mathlib/Topology/VectorBundle/Riemannian.lean
+++ b/Mathlib/Topology/VectorBundle/Riemannian.lean
@@ -197,14 +197,12 @@ lemma eventually_norm_symmL_trivializationAt_self_comp_lt (x : B) {r : ℝ} (hr 
         g' x w w
     _ = (g' x - g' y) w w + g' y w w := by simp
     _ ≤ ‖g' x - g' y‖ * ‖w‖ * ‖w‖ + g' y w w := by
-      gcongr; exact (Real.le_norm_self _).trans (le_opNorm₂ (g' x - g' y) w w)
+      grw [← le_opNorm₂, ← Real.le_norm_self]
     _ ≤ δ * ‖w‖ ^ 2 + g' y w w := by
       rw [pow_two, mul_assoc]; gcongr
     _ ≤ δ * (‖(G : E x →L[ℝ] F)‖ * ‖G.symm w‖) ^ 2 + g' y w w := by
-      gcongr
-      have : w = G (G.symm w) := by simp
-      conv_lhs => rw [this]
-      exact le_opNorm (G : E x →L[ℝ] F) (G.symm w)
+      grw [← le_opNorm]
+      simp
     _ = δ * C * ‖G.symm w‖^2 + g' y w w := by ring
     _ = δ * C * g x (G.symm w) (G.symm w) + g' y w w := by
       simp [← real_inner_self_eq_norm_sq, hg]
@@ -212,7 +210,7 @@ lemma eventually_norm_symmL_trivializationAt_self_comp_lt (x : B) {r : ℝ} (hr 
       rw [← hgx]; rfl
   have : (1 - δ * C) * g' x w w ≤ g' y w w := by linarith
   rw [← (le_div_iff₀' (lt_of_le_of_lt (by positivity) hδ )), div_eq_inv_mul] at this
-  apply this.trans
+  grw [this]
   gcongr
   · rw [← hgy, ← hg,real_inner_self_eq_norm_sq]
     positivity
@@ -234,9 +232,7 @@ lemma eventually_norm_trivializationAt_lt (x : B) :
     rfl
   have : (trivializationAt F E x).continuousLinearMapAt ℝ y =
     (ContinuousLinearMap.id _ _) ∘L ((trivializationAt F E x).continuousLinearMapAt ℝ y) := by simp
-  rw [← A, comp_assoc] at this
-  rw [this]
-  apply (opNorm_comp_le _ _).trans_lt
+  grw [this, ← A, comp_assoc, opNorm_comp_le]
   gcongr
   linarith
 
@@ -306,14 +302,12 @@ lemma eventually_norm_symmL_trivializationAt_comp_self_lt (x : B) {r : ℝ} (hr 
   calc g' y w w
     _ = (g' y - g' x) w w + g' x w w := by simp
     _ ≤ ‖g' y - g' x‖ * ‖w‖ * ‖w‖ + g' x w w := by
-      gcongr; exact (Real.le_norm_self _).trans (le_opNorm₂ (g' y - g' x) w w)
+      grw [← le_opNorm₂, ← Real.le_norm_self]
     _ ≤ δ * ‖w‖ ^ 2 + g' x w w := by
       rw [pow_two, mul_assoc]; gcongr
     _ ≤ δ * (‖(G : E x →L[ℝ] F)‖ * ‖G.symm w‖) ^ 2 + g' x w w := by
-      gcongr
-      have : w = G (G.symm w) := by simp
-      conv_lhs => rw [this]
-      exact le_opNorm (G : E x →L[ℝ] F) (G.symm w)
+      grw [← le_opNorm]
+      simp
     _ = δ * C * ‖G.symm w‖^2 + g' x w w := by ring
     _ = δ * C * g x (G.symm w) (G.symm w) + g' x w w := by
       simp [← real_inner_self_eq_norm_sq, hg]
@@ -346,9 +340,7 @@ lemma eventually_norm_symmL_trivializationAt_lt (x : B) :
     rfl
   have : (trivializationAt F E x).symmL ℝ y =
      ((trivializationAt F E x).symmL ℝ y) ∘L (ContinuousLinearMap.id _ _) := by simp
-  rw [← A, ← comp_assoc] at this
-  rw [this]
-  apply (opNorm_comp_le _ _).trans_lt
+  grw [this, ← A, ← comp_assoc, opNorm_comp_le]
   gcongr
   linarith
 


### PR DESCRIPTION

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include at least one commit authored by each
co-author among the commits in the pull request. If necessary, you may 
create empty commits to indicate co-authorship, using commands like so:

git commit --author="Author Name <author@email.com>" --allow-empty -m "add Author Name as coauthor"

When merging, all the commits will be squashed into a single commit listing all co-authors.

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)

This is an experiment to see what kinds of argument styles `grw` supports, feel free to close the PR if you prefer the old way!
