### PR TITLE
[Merged by Bors] - doc(Tactic/FieldSimp): update tactic docstring

### DIFF
--- a/Mathlib/Tactic/FieldSimp.lean
+++ b/Mathlib/Tactic/FieldSimp.lean
@@ -747,8 +747,9 @@ example {K : Type*} [Field K] {x : K} (hx0 : x ≠ 0) :
 ```
 
 The `field` simproc-set's functionality is a variant of the more general `field_simp` tactic, which
-clears denominators in field (in)equalities as well as bringing isolated field expressions into the
-normal form `n / d` (where neither `n` nor `d` contains any division symbol).
+not only clears denominators in field (in)equalities but also brings isolated field expressions into
+the normal form `n / d` (where neither `n` nor `d` contains any division symbol). (For confluence
+reasons, the `field` simprocs also have a slightly different normal form from `field_simp`'s.)
 
 Cancelling and combining denominators will generally require checking "nonzeroness"/"positivity"
 side conditions. The `field` simproc-set attempts to discharge these, and will omit such steps if it

--- a/Mathlib/Tactic/FieldSimp.lean
+++ b/Mathlib/Tactic/FieldSimp.lean
@@ -687,8 +687,8 @@ example {K : Type*} [Field K] {x : K} (hx0 : x ≠ 0) :
 Cancelling and combining denominators will generally require checking "nonzeroness"/"positivity"
 side conditions. The `field_simp` tactic attempts to discharge these, and will omit such steps if it
 cannot discharge the corresponding side conditions. The discharger will try, among other things,
-`positivity` and `norm_num`, and will also use any nonzeroness proofs included explicitly (e.g.
-`field_simp [hx]`). If your expression is not completely reduced by `field_simp`, check the
+`positivity` and `norm_num`, and will also use any nonzeroness/positivity proofs included explicitly
+(e.g. `field_simp [hx]`). If your expression is not completely reduced by `field_simp`, check the
 denominators of the resulting expression and provide proofs that they are nonzero/positive to enable
 further progress.
 -/
@@ -753,10 +753,10 @@ normal form `n / d` (where neither `n` nor `d` contains any division symbol).
 Cancelling and combining denominators will generally require checking "nonzeroness"/"positivity"
 side conditions. The `field` simproc-set attempts to discharge these, and will omit such steps if it
 cannot discharge the corresponding side conditions. The discharger will try, among other things,
-`positivity` and `norm_num`, and will also use any nonzeroness proofs included explicitly in the
-simp call (e.g. `simp [field, hx]`). If your (in)equality is not completely reduced by the `field`
-simproc-set, check the denominators of the resulting (in)equality and provide proofs that they are
-nonzero/positive to enable further progress.
+`positivity` and `norm_num`, and will also use any nonzeroness/positivity proofs included explicitly
+in the simp call (e.g. `simp [field, hx]`). If your (in)equality is not completely reduced by the
+`field` simproc-set, check the denominators of the resulting (in)equality and provide proofs that
+they are nonzero/positive to enable further progress.
 -/
 def proc : Simp.Simproc := fun (t : Expr) ↦ do
   let ctx ← Simp.getContext

--- a/Mathlib/Tactic/FieldSimp.lean
+++ b/Mathlib/Tactic/FieldSimp.lean
@@ -684,10 +684,6 @@ example {K : Type*} [Field K] {x : K} (hx0 : x ≠ 0) :
   -- new goal: `⊢ (x ^ 2 + 1) * (x ^ 2 + 1 + x) = x ^ 2`
 ```
 
-A very common pattern is `field_simp; ring` (clear denominators, then the resulting goal is
-solvable by the axioms of a commutative ring). The finishing tactic `field` is a shorthand for this
-pattern.
-
 Cancelling and combining denominators will generally require checking "nonzeroness"/"positivity"
 side conditions. The `field_simp` tactic attempts to discharge these, and will omit such steps if it
 cannot discharge the corresponding side conditions. The discharger will try, among other things,

--- a/Mathlib/Tactic/FieldSimp.lean
+++ b/Mathlib/Tactic/FieldSimp.lean
@@ -664,26 +664,37 @@ def parseDischarger (d : Option (TSyntax ``discharger)) (args : Option (TSyntax 
     | _ => throwError "could not parse the provided discharger {d}"
 
 /--
-The goal of `field_simp` is to reduce an expression in a field to an expression of the form `n / d`
-where neither `n` nor `d` contains any division symbol.
-
-If the goal is an (in)equality, this tactic will also clear the denominators, so that the proof
-can normally be concluded by an application of `ring`.
-
-For example,
-```lean
-example (a b c d x y : ℂ) (hx : x ≠ 0) (hy : y ≠ 0) :
-    a + b / x + c / x ^ 2 + d / x ^ 3 = a + x⁻¹ * (y * b / y + (d / x + c) / x) := by
+The goal of `field_simp` is to bring expressions in (semi-)fields over a common denominator, i.e. to
+reduce them to expressions of the form `n / d` where neither `n` nor `d` contains any division
+symbol. For example, `x / (1 - y) / (1 + y / (1 - y))` is reduced to `x / (1 - y + y)`:
+```
+example (x y z : ℚ) (hy : 1 - y ≠ 0) :
+    ⌊x / (1 - y) / (1 + y / (1 - y))⌋ < 3 := by
   field_simp
-  ring
+  -- new goal: `⊢ ⌊x / (1 - y + y)⌋ < 3`
 ```
 
-Cancelling and combining denominators often requires "nonzeroness" side conditions. The `field_simp`
-tactic attempts to discharge these, and will omit such steps if it cannot discharge the
-corresponding side conditions. The discharger will try, among other things, `positivity` and
-`norm_num`, and will also use any nonzeroness proofs included explicitly (e.g. `field_simp [hx]`).
-If your expression is not completely reduced by `field_simp`, check the denominators of the
-resulting expression and provide proofs that they are nonzero to enable further progress.
+The `field_simp` tactic will also clear denominators in field *(in)equalities*, by
+cross-multiplying. For example, `field_simp` will clear the `x` denominators in the following
+equation:
+```
+example {K : Type*} [Field K] {x : K} (hx0 : x ≠ 0) :
+    (x + 1 / x) ^ 2 + (x + 1 / x) = 1 := by
+  field_simp
+  -- new goal: `⊢ (x ^ 2 + 1) * (x ^ 2 + 1 + x) = x ^ 2`
+```
+
+A very common pattern is `field_simp; ring` (clear denominators, then the resulting goal is
+solvable by the axioms of a commutative ring). The finishing tactic `field` is a shorthand for this
+pattern.
+
+Cancelling and combining denominators will generally require checking "nonzeroness"/"positivity"
+side conditions. The `field_simp` tactic attempts to discharge these, and will omit such steps if it
+cannot discharge the corresponding side conditions. The discharger will try, among other things,
+`positivity` and `norm_num`, and will also use any nonzeroness proofs included explicitly (e.g.
+`field_simp [hx]`). If your expression is not completely reduced by `field_simp`, check the
+denominators of the resulting expression and provide proofs that they are nonzero/positive to enable
+further progress.
 -/
 elab (name := fieldSimp) "field_simp" d:(discharger)? args:(simpArgs)? loc:(location)? :
     tactic => withMainContext do
@@ -694,7 +705,30 @@ elab (name := fieldSimp) "field_simp" d:(discharger)? args:(simpArgs)? loc:(loca
   let loc := (loc.map expandLocation).getD (.targets #[] true)
   transformAtLocation (m ·) "field_simp" (failIfUnchanged := true) (mayCloseGoalFromHyp := true) loc
 
-@[inherit_doc fieldSimp]
+/--
+The goal of the `field_simp` conv tactic is to bring an expression in a (semi-)field over a common
+denominator, i.e. to reduce it to an expression of the form `n / d` where neither `n` nor `d`
+contains any division symbol. For example, `x / (1 - y) / (1 + y / (1 - y))` is reduced to
+`x / (1 - y + y)`:
+```
+example (x y z : ℚ) (hy : 1 - y ≠ 0) :
+    ⌊x / (1 - y) / (1 + y / (1 - y))⌋ < 3 := by
+  conv => enter [1, 1]; field_simp
+  -- new goal: `⊢ ⌊x / (1 - y + y)⌋ < 3`
+```
+
+As in this example, cancelling and combining denominators will generally require checking
+"nonzeroness" side conditions. The `field_simp` tactic attempts to discharge these, and will omit
+such steps if it cannot discharge the corresponding side conditions. The discharger will try, among
+other things, `positivity` and `norm_num`, and will also use any nonzeroness proofs included
+explicitly (e.g. `field_simp [hx]`). If your expression is not completely reduced by `field_simp`,
+check the denominators of the resulting expression and provide proofs that they are nonzero to
+enable further progress.
+
+The `field_simp` conv tactic is a variant of the main (i.e., not conv) `field_simp` tactic. The
+latter operates recursively on subexpressions, bringing *every* field-expression encountered to the
+form `n / d`.
+-/
 elab "field_simp" d:(discharger)? args:(simpArgs)? : conv => do
   -- find the expression `x` to `conv` on
   let x ← Conv.getLhs
@@ -704,7 +738,30 @@ elab "field_simp" d:(discharger)? args:(simpArgs)? : conv => do
   -- convert `x` to the output of the normalization
   Conv.applySimpResult r
 
-@[inherit_doc fieldSimp]
+/--
+The goal of the simprocs grouped under the `field` attribute is to clear denominators in
+(semi-)field (in)equalities, by bringing LHS and RHS each over a common denominator and then
+cross-multiplying. For example, the `field` simproc will clear the `x` denominators in the following
+equation:
+```
+example {K : Type*} [Field K] {x : K} (hx0 : x ≠ 0) :
+    (x + 1 / x) ^ 2 + (x + 1 / x) = 1 := by
+  simp only [field]
+  -- new goal: `⊢ (x ^ 2 + 1) * (x ^ 2 + 1 + x) = x ^ 2`
+```
+
+The `field` simproc-set's functionality is a variant of the more general `field_simp` tactic, which
+clears denominators in field (in)equalities as well as bringing isolated field expressions into the
+normal form `n / d` (where neither `n` nor `d` contains any division symbol).
+
+Cancelling and combining denominators will generally require checking "nonzeroness"/"positivity"
+side conditions. The `field` simproc-set attempts to discharge these, and will omit such steps if it
+cannot discharge the corresponding side conditions. The discharger will try, among other things,
+`positivity` and `norm_num`, and will also use any nonzeroness proofs included explicitly in the
+simp call (e.g. `simp [field, hx]`). If your (in)equality is not completely reduced by the `field`
+simproc-set, check the denominators of the resulting (in)equality and provide proofs that they are
+nonzero/positive to enable further progress.
+-/
 def proc : Simp.Simproc := fun (t : Expr) ↦ do
   let ctx ← Simp.getContext
   let disch e : MetaM Expr := Prod.fst <$> (FieldSimp.discharge e).run ctx >>= Option.getM
@@ -724,7 +781,7 @@ simproc_decl fieldEq (Eq _ _) := FieldSimp.proc
 simproc_decl fieldLe (LE.le _ _) := FieldSimp.proc
 simproc_decl fieldLt (LT.lt _ _) := FieldSimp.proc
 
-attribute [field, inherit_doc FieldSimp.fieldSimp] fieldEq fieldLe fieldLt
+attribute [field, inherit_doc FieldSimp.proc] fieldEq fieldLe fieldLt
 
 /-!
  We register `field_simp` with the `hint` tactic.

--- a/MathlibTest/FieldSimp.lean
+++ b/MathlibTest/FieldSimp.lean
@@ -497,7 +497,7 @@ example {K : Type*} [Field K] {x : K} (hx : x ^ 5 = 1) (hx0 : x ≠ 0) (hx1 : x 
     (x ^ 2 + 1) * (x ^ 2 + 1 + x) = (x ^ 5 - 1) / (x - 1) + x ^ 2 := by field
     _ = x ^ 2 := by simp [hx]
 
--- used in `field` simproc docstring
+-- used in `field` simproc-set docstring
 example {K : Type*} [Field K] {x : K} (hx : x ^ 5 = 1) (hx0 : x ≠ 0) (hx1 : x - 1 ≠ 0) :
     (x + 1 / x) ^ 2 + (x + 1 / x) = 1 := by
   simp only [field]

--- a/MathlibTest/FieldSimp.lean
+++ b/MathlibTest/FieldSimp.lean
@@ -273,6 +273,16 @@ example (hx : x ≠ 0) (hy : y ≠ 0) : P ((x * y) * (y * x)⁻¹) := by test_fi
 #guard_msgs in
 example (hy : y ≠ 0) : P (x ^ 1 * y * x ^ 2 * y⁻¹) := by test_field_simp
 
+/-- info: P (x / (1 - y + y)) -/
+#guard_msgs in
+example (hy : 1 - y ≠ 0): P (x / (1 - y) / (1 + y / (1 - y))) := by test_field_simp
+
+-- test `conv` tactic
+example (hy : 1 - y ≠ 0) : P (x / (1 - y) / (1 + y / (1 - y))) := by
+  conv => enter [1]; field_simp
+  guard_target = P (x / (1 - y + y))
+  exact test_sorry
+
 /-! ### Three atoms -/
 
 /-- info: P (x * y * z) -/
@@ -372,17 +382,23 @@ example {x : ℚ} (hx : x ≠ 0) : x * x⁻¹ = 1 := by field
 example {a b : ℚ} (h : b ≠ 0) : a / b + 2 * a / b + (-a) / b + (- (2 * a)) / b = 0 := by field
 example {x y : ℚ} (hx : x + y ≠ 0) : x / (x + y) + y / (x + y) = 1 := by field
 
+example {x : ℚ} : x ^ 2 / (x ^ 2 + 1) + 1 / (x ^ 2 + 1) = 1 := by field
+
 example {x y : ℚ} (hx : 0 < x) :
     ((x ^ 2 - y ^ 2) / (x ^ 2 + y ^ 2)) ^ 2 + (2 * x * y / (x ^ 2 + y ^ 2)) ^ 2 = 1 := by
   field
 
--- example from the `field_simp` docstring
 example {K : Type*} [Field K] (a b c d x y : K) (hx : x ≠ 0) (hy : y ≠ 0) :
     a + b / x + c / x ^ 2 + d / x ^ 3 = a + x⁻¹ * (y * b / y + (d / x + c) / x) := by
   field
 
 example {a b : ℚ} (ha : a ≠ 0) : a / (a * b) - 1 / b = 0 := by field
 example {x : ℚ} : x ^ 2 * x⁻¹ = x := by field
+
+-- testing that mdata is cleared before parsing goal
+example {x : ℚ} (hx : x ≠ 0) : x * x⁻¹ = 1 := by
+  have : 1 = 1 := rfl
+  field
 
 /-! ### Mid-proof use -/
 
@@ -471,6 +487,24 @@ example {x y : ℚ} (hx : 0 < x) :
   simp only [field]
   guard_target = (x ^ 2 - y ^ 2) ^ 2 + x ^ 2 * y ^ 2 * 2 ^ 2 < (x ^ 2 + y ^ 2) ^ 2
   exact test_sorry
+
+-- used in `field_simp` docstring
+example {K : Type*} [Field K] {x : K} (hx : x ^ 5 = 1) (hx0 : x ≠ 0) (hx1 : x - 1 ≠ 0) :
+    (x + 1 / x) ^ 2 + (x + 1 / x) = 1 := by
+  field_simp
+  guard_target = (x ^ 2 + 1) * (x ^ 2 + 1 + x) = x ^ 2
+  calc
+    (x ^ 2 + 1) * (x ^ 2 + 1 + x) = (x ^ 5 - 1) / (x - 1) + x ^ 2 := by field
+    _ = x ^ 2 := by simp [hx]
+
+-- used in `field` simproc docstring
+example {K : Type*} [Field K] {x : K} (hx : x ^ 5 = 1) (hx0 : x ≠ 0) (hx1 : x - 1 ≠ 0) :
+    (x + 1 / x) ^ 2 + (x + 1 / x) = 1 := by
+  simp only [field]
+  guard_target = (x ^ 2 + 1) * (x ^ 2 + 1 + x) = x ^ 2
+  calc
+    (x ^ 2 + 1) * (x ^ 2 + 1 + x) = (x ^ 5 - 1) / (x - 1) + x ^ 2 := by field
+    _ = x ^ 2 := by simp [hx]
 
 section
 
@@ -574,6 +608,12 @@ example {x y : ℚ} (hx : y ≠ 0) {f : ℚ → ℚ} (hf : ∀ t, f t ≠ 0) :
 example {x y z : ℚ} (hx : y ≠ 0) {f : ℚ → ℚ} (hf : ∀ t, f t ≠ 0) :
     f (y * x / (y ^ 2 / z)) / f (z / (y / x)) = 1 := by
   field_simp [hf]
+
+open Finset in
+example (n : ℕ) : ∏ i ∈ range n, (1 - (i + 2 : ℚ)⁻¹) < 1 := by
+  field_simp
+  guard_target = ∏ x ∈ range n, ((x:ℚ) + 2 - 1) / (x + 2) < 1
+  exact test_sorry
 
 /-! ## Performance -/
 


### PR DESCRIPTION
The `field_simp` tactic has changed a lot recently. We update the examples mentioned in the tactic docstring, and also write customised docstrings for the new variants (conv tactic, simproc set) -- previously they inherited the docstring of the main tactic.  We also add the tactic docstring examples to the main `field_simp` tests.

Extracted from #29089.

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include at least one commit authored by each
co-author among the commits in the pull request. If necessary, you may 
create empty commits to indicate co-authorship, using commands like so:

git commit --author="Author Name <author@email.com>" --allow-empty -m "add Author Name as coauthor"

When merging, all the commits will be squashed into a single commit listing all co-authors.

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
