### PR TITLE
[Merged by Bors] - feat(CategoryTheory/Monoidal): Add commutative comonoid objects

### DIFF
--- a/Mathlib.lean
+++ b/Mathlib.lean
@@ -2564,6 +2564,7 @@ import Mathlib.CategoryTheory.Monoidal.Cartesian.Over
 import Mathlib.CategoryTheory.Monoidal.Category
 import Mathlib.CategoryTheory.Monoidal.Center
 import Mathlib.CategoryTheory.Monoidal.CoherenceLemmas
+import Mathlib.CategoryTheory.Monoidal.CommComon_
 import Mathlib.CategoryTheory.Monoidal.CommGrp_
 import Mathlib.CategoryTheory.Monoidal.CommMon_
 import Mathlib.CategoryTheory.Monoidal.Comon_

--- a/Mathlib/CategoryTheory/Bicategory/Monad/Basic.lean
+++ b/Mathlib/CategoryTheory/Bicategory/Monad/Basic.lean
@@ -70,7 +70,7 @@ end
 
 @[simps! counit]
 instance {a : B} : Comonad (𝟙 a) :=
-  inferInstanceAs <| ComonObj (MonoidalCategory.tensorUnit (a ⟶ a))
+  ComonObj.instTensorUnit (a ⟶ a)
 
 /-- An oplax functor from the trivial bicategory to `B` defines a comonad in `B`. -/
 def ofOplaxFromUnit (F : OplaxFunctor (LocallyDiscrete (Discrete Unit)) B) :

--- a/Mathlib/CategoryTheory/Monoidal/Bimon_.lean
+++ b/Mathlib/CategoryTheory/Monoidal/Bimon_.lean
@@ -142,9 +142,7 @@ theorem ofMonComonObjX_mul (M : Mon (Comon C)) :
 
 @[deprecated (since := "2025-09-15")] alias ofMon_Comon_ObjX_mul := ofMonComonObjX_mul
 
-/-- Local instance for the comonoid structure on the tensor unit. -/
-local instance instComonObjTensorUnit : ComonObj (𝟙_ C) := ComonObj.instTensorUnit C
-
+attribute [local instance] ComonObj.instTensorUnit in
 attribute [local simp] MonObj.tensorObj.one_def MonObj.tensorObj.mul_def tensorμ in
 /-- The object level part of the backward direction of `Comon (Mon C) ≌ Mon (Comon C)` -/
 @[simps]

--- a/Mathlib/CategoryTheory/Monoidal/Bimon_.lean
+++ b/Mathlib/CategoryTheory/Monoidal/Bimon_.lean
@@ -142,6 +142,9 @@ theorem ofMonComonObjX_mul (M : Mon (Comon C)) :
 
 @[deprecated (since := "2025-09-15")] alias ofMon_Comon_ObjX_mul := ofMonComonObjX_mul
 
+/-- Local instance for the comonoid structure on the tensor unit. -/
+local instance instComonObjTensorUnit : ComonObj (𝟙_ C) := ComonObj.instTensorUnit C
+
 attribute [local simp] MonObj.tensorObj.one_def MonObj.tensorObj.mul_def tensorμ in
 /-- The object level part of the backward direction of `Comon (Mon C) ≌ Mon (Comon C)` -/
 @[simps]

--- a/Mathlib/CategoryTheory/Monoidal/CommComon_.lean
+++ b/Mathlib/CategoryTheory/Monoidal/CommComon_.lean
@@ -47,9 +47,7 @@ def toComon (A : CommComon C) : Comon C := ⟨A.X⟩
 
 section
 
-/-- Local instance for the comonoid structure on the tensor unit. -/
-local instance instComonObjTensorUnit : ComonObj (𝟙_ C) := ComonObj.instTensorUnit C
-
+attribute [local instance] ComonObj.instTensorUnit in
 /-- The trivial comonoid on the unit object is commutative. -/
 instance instCommComonObjUnit : IsCommComonObj (𝟙_ C) where
   comul_comm := by
@@ -60,13 +58,11 @@ instance instCommComonObjUnit : IsCommComonObj (𝟙_ C) where
 
 end
 
+attribute [local instance] ComonObj.instTensorUnit in
 variable (C) in
 /-- The trivial commutative comonoid object. We later show this is initial in `CommComon C`. -/
 @[simps!]
-def trivial : CommComon C where
-  X := 𝟙_ C
-  comon := ComonObj.instTensorUnit C
-  comm := instCommComonObjUnit
+def trivial : CommComon C := mk (𝟙_ C)
 
 instance : Inhabited (CommComon C) :=
   ⟨trivial C⟩

--- a/Mathlib/CategoryTheory/Monoidal/CommComon_.lean
+++ b/Mathlib/CategoryTheory/Monoidal/CommComon_.lean
@@ -50,11 +50,7 @@ section
 attribute [local instance] ComonObj.instTensorUnit in
 /-- The trivial comonoid on the unit object is commutative. -/
 instance instCommComonObjUnit : IsCommComonObj (𝟙_ C) where
-  comul_comm := by
-    simp only [instTensorUnit_comul, braiding_tensorUnit_right]
-    rw [← Category.assoc]
-    rw [← unitors_equal]
-    simp only [Iso.inv_hom_id, Category.id_comp]
+  comul_comm := by simp [← unitors_equal]
 
 end
 

--- a/Mathlib/CategoryTheory/Monoidal/CommComon_.lean
+++ b/Mathlib/CategoryTheory/Monoidal/CommComon_.lean
@@ -1,0 +1,60 @@
+/-
+Copyright (c) 2025 Jacob Reinhold. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Jacob Reinhold
+-/
+import Mathlib.CategoryTheory.Monoidal.Comon_
+import Mathlib.CategoryTheory.Monoidal.Braided.Basic
+
+/-!
+# Commutative Comonoid Objects
+
+Comonoids where comultiplication is symmetric: swapping outputs gives the same result.
+
+## Main definitions
+
+* `CommComonObj X` - Commutative comonoid structure on X
+
+## Main results
+
+* `swap_comul` - Swapping the two copies does nothing
+
+## Implementation notes
+
+We extend ComonObj and add the commutativity axiom. This requires a braided monoidal category for
+the braiding isomorphism.
+
+Unlike the specific `ComonObj (𝟙_ C)` instance which was removed from mathlib to avoid conflicts,
+`CommComonObj` remains a type class because it describes a property of comonoid structures rather
+than providing a specific comonoid structure that could conflict with others.
+
+In cartesian monoidal categories, every object has a unique commutative comonoid structure
+(diagonal and terminal morphisms).
+
+## Tags
+
+comonoid, commutative, braided
+-/
+
+namespace CategoryTheory
+
+open MonoidalCategory ComonObj
+
+variable {C : Type*} [Category C] [MonoidalCategory C] [BraidedCategory C]
+
+/-- A comonoid where swapping outputs gives the same result: Δ ≫ σ = Δ. -/
+class CommComonObj (X : C) extends ComonObj X where
+  /-- Comultiplication commutes with braiding. -/
+  isComm : comul ≫ (β_ X X).hom = comul
+
+namespace CommComonObj
+
+variable {X : C} [CommComonObj X]
+
+/-- Swapping the two copies does nothing. -/
+@[simp]
+lemma swap_comul : Δ[X] ≫ (β_ X X).hom = Δ[X] := isComm
+
+end CommComonObj
+
+end CategoryTheory

--- a/Mathlib/CategoryTheory/Monoidal/Comon_.lean
+++ b/Mathlib/CategoryTheory/Monoidal/Comon_.lean
@@ -104,15 +104,12 @@ attribute [instance] Comon.comon
 
 namespace Comon
 
+attribute [local instance] ComonObj.instTensorUnit in
 variable (C) in
 /-- The trivial comonoid object. We later show this is terminal in `Comon C`.
-
-Uses the explicit comonoid structure to avoid instance conflicts.
 -/
 @[simps!]
-def trivial : Comon C :=
-  { X := 𝟙_ C
-    comon := ComonObj.instTensorUnit C }
+def trivial : Comon C := mk (𝟙_ C)
 
 instance : Inhabited (Comon C) :=
   ⟨trivial C⟩

--- a/Mathlib/CategoryTheory/Monoidal/Comon_.lean
+++ b/Mathlib/CategoryTheory/Monoidal/Comon_.lean
@@ -448,3 +448,16 @@ def mapComon (F : C ⥤ D) [F.OplaxMonoidal] : Comon C ⥤ Comon D where
 -- and so can't state `mapComonFunctor : OplaxMonoidalFunctor C D ⥤ Comon C ⥤ Comon D`.
 
 end CategoryTheory.Functor
+
+section
+variable [BraidedCategory.{v₁} C]
+
+/-- Predicate for a comonoid object to be commutative. -/
+class IsCommComonObj (X : C) [ComonObj X] where
+  comul_comm (X) : Δ ≫ (β_ X X).hom = Δ := by cat_disch
+
+open scoped ComonObj
+
+attribute [reassoc (attr := simp)] IsCommComonObj.comul_comm
+
+end

--- a/Mathlib/CategoryTheory/Monoidal/Comon_.lean
+++ b/Mathlib/CategoryTheory/Monoidal/Comon_.lean
@@ -53,8 +53,10 @@ namespace ComonObj
 
 attribute [reassoc (attr := simp)] counit_comul comul_counit comul_assoc
 
+/-- The canonical comonoid structure on the monoidal unit.
+This is not a global instance to avoid conflicts with other comonoid structures. -/
 @[simps]
-instance (C : Type u₁) [Category.{v₁} C] [MonoidalCategory.{v₁} C] : ComonObj (𝟙_ C) where
+def instTensorUnit (C : Type u₁) [Category.{v₁} C] [MonoidalCategory.{v₁} C] : ComonObj (𝟙_ C) where
   counit := 𝟙 _
   comul := (λ_ _).inv
   counit_comul := by simp
@@ -104,9 +106,13 @@ namespace Comon
 
 variable (C) in
 /-- The trivial comonoid object. We later show this is terminal in `Comon C`.
+
+Uses the explicit comonoid structure to avoid instance conflicts.
 -/
 @[simps!]
-def trivial : Comon C := mk (𝟙_ C)
+def trivial : Comon C :=
+  { X := 𝟙_ C
+    comon := ComonObj.instTensorUnit C }
 
 instance : Inhabited (Comon C) :=
   ⟨trivial C⟩


### PR DESCRIPTION
This PR adds commutative comonoid objects and removes the problematic global comonoid instance (see #29657).

## Main changes

### 1. Add `CommComonObj` class

Added `Mathlib/CategoryTheory/Monoidal/CommComon_.lean` defining commutative comonoids.

This captures the mathematical notion that swapping the two copies produced by comultiplication gives the same result. In cartesian categories, all comonoids are automatically commutative (copying data has no preferred order).

### 2. Remove global `ComonObj` instance for unit object

The global `ComonObj (𝟙_ C)` instance interfered in [related proofs](https://github.com/leanprover-community/mathlib4/pull/29657#discussion_r2352151327). This PR removes it and updates affected code:

- `Bicategory/Monad/Basic.lean`: Now uses `ComonObj.instTensorUnit` for the identity monad's comonad structure
- `Monoidal/Bimon_.lean`: Added explicit proofs the global instance previously resolved, verifying unit morphisms preserve comonoid structure

## Design notes

- `CommComonObj` extends `ComonObj` and requires `BraidedCategory` for the braiding
- Unlike the removed global instance, `CommComonObj` stays a class (it describes a property, not a structure)
- The explicit `instTensorUnit` lets users control when to use the trivial comonoid structure

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)