### PR TITLE
[Merged by Bors] - feat(MeasureTheory/ProbabilityTheory): `Is(Probability/Finite)Measure` iff map `Is(Probability/Finite)Measure`

### DIFF
--- a/Mathlib/MeasureTheory/Group/Convolution.lean
+++ b/Mathlib/MeasureTheory/Group/Convolution.lean
@@ -156,7 +156,7 @@ theorem mconv_assoc [MeasurableMul₂ M] (μ ν ρ : Measure M)
 instance probabilitymeasure_of_probabilitymeasures_mconv (μ : Measure M) (ν : Measure M)
     [MeasurableMul₂ M] [IsProbabilityMeasure μ] [IsProbabilityMeasure ν] :
     IsProbabilityMeasure (μ ∗ₘ ν) :=
-  MeasureTheory.isProbabilityMeasure_map (by fun_prop)
+  isProbabilityMeasure_map (by fun_prop)
 
 @[to_additive]
 theorem mconv_absolutelyContinuous [MeasurableMul₂ M] {μ ν ρ : Measure M}

--- a/Mathlib/MeasureTheory/Measure/IntegralCharFun.lean
+++ b/Mathlib/MeasureTheory/Measure/IntegralCharFun.lean
@@ -148,7 +148,7 @@ lemma measureReal_abs_dual_gt_le_integral_charFunDual {E : Type*} [NormedAddComm
     [NormedSpace ℝ E] {mE : MeasurableSpace E} [OpensMeasurableSpace E]
     {μ : Measure E} [IsProbabilityMeasure μ] (L : StrongDual ℝ E) {r : ℝ} (hr : 0 < r) :
     μ.real {x | r < |L x|} ≤ 2⁻¹ * r * ‖∫ t in -2 * r⁻¹..2 * r⁻¹, 1 - charFunDual μ (t • L)‖ := by
-  have : IsProbabilityMeasure (μ.map L) := isProbabilityMeasure_map (by fun_prop)
+  have : IsProbabilityMeasure (μ.map L) := Measure.isProbabilityMeasure_map (by fun_prop)
   convert measureReal_abs_gt_le_integral_charFun (μ := μ.map L) hr with x
   · rw [map_measureReal_apply (by fun_prop)]
     · simp
@@ -161,7 +161,8 @@ lemma measureReal_abs_inner_gt_le_integral_charFun {E : Type*} [SeminormedAddCom
     [InnerProductSpace ℝ E] {mE : MeasurableSpace E} [OpensMeasurableSpace E]
     {μ : Measure E} [IsProbabilityMeasure μ] {a : E} {r : ℝ} (hr : 0 < r) :
     μ.real {x | r < |⟪a, x⟫|} ≤ 2⁻¹ * r * ‖∫ t in -2 * r⁻¹..2 * r⁻¹, 1 - charFun μ (t • a)‖ := by
-  have : IsProbabilityMeasure (μ.map (fun x ↦ ⟪a, x⟫)) := isProbabilityMeasure_map (by fun_prop)
+  have : IsProbabilityMeasure (μ.map (fun x ↦ ⟪a, x⟫)) :=
+    Measure.isProbabilityMeasure_map (by fun_prop)
   convert measureReal_abs_gt_le_integral_charFun (μ := μ.map (fun x ↦ ⟪a, x⟫)) hr with x
   · rw [map_measureReal_apply (by fun_prop)]
     · simp

--- a/Mathlib/MeasureTheory/Measure/Typeclasses/Finite.lean
+++ b/Mathlib/MeasureTheory/Measure/Typeclasses/Finite.lean
@@ -124,7 +124,7 @@ theorem Measure.isFiniteMeasure_of_isFiniteMeasure_map {μ : Measure α} {f : α
 
 theorem Measure.isFiniteMeasure_iff_isFiniteMeasure_map {μ : Measure α} {f : α → β}
     (hf : AEMeasurable f μ) : IsFiniteMeasure μ ↔ IsFiniteMeasure (μ.map f) :=
-  ⟨fun _ ↦ isFiniteMeasure_map μ f, fun _ ↦ isFiniteMeasure_of_map_isFiniteMeasure hf⟩
+  ⟨fun _ ↦ isFiniteMeasure_map μ f, fun _ ↦ isFiniteMeasure_of_isFiniteMeasure_map hf⟩
 
 instance IsFiniteMeasure_comap (f : β → α) [IsFiniteMeasure μ] : IsFiniteMeasure (μ.comap f) where
   measure_univ_lt_top := by

--- a/Mathlib/MeasureTheory/Measure/Typeclasses/Finite.lean
+++ b/Mathlib/MeasureTheory/Measure/Typeclasses/Finite.lean
@@ -116,6 +116,16 @@ theorem Measure.isFiniteMeasure_map {m : MeasurableSpace α} (μ : Measure α) [
   · rw [map_of_not_aemeasurable hf]
     exact MeasureTheory.isFiniteMeasureZero
 
+theorem Measure.isFiniteMeasure_of_map_isFiniteMeasure {μ : Measure α} {f : α → β}
+    (hf : AEMeasurable f μ) [IsFiniteMeasure (μ.map f)] : IsFiniteMeasure μ where
+  measure_univ_lt_top := by
+    rw [← Set.preimage_univ (f := f), ← map_apply_of_aemeasurable hf .univ]
+    exact IsFiniteMeasure.measure_univ_lt_top
+
+theorem Measure.isFiniteMeasure_iff_map_isFiniteMeasure {μ : Measure α} {f : α → β}
+    (hf : AEMeasurable f μ) : IsFiniteMeasure μ ↔ IsFiniteMeasure (μ.map f) :=
+  ⟨fun _ ↦ isFiniteMeasure_map μ f, fun _ ↦ isFiniteMeasure_of_map_isFiniteMeasure hf⟩
+
 instance IsFiniteMeasure_comap (f : β → α) [IsFiniteMeasure μ] : IsFiniteMeasure (μ.comap f) where
   measure_univ_lt_top := by
     by_cases hf : Injective f ∧ ∀ s, MeasurableSet s → NullMeasurableSet (f '' s) μ

--- a/Mathlib/MeasureTheory/Measure/Typeclasses/Finite.lean
+++ b/Mathlib/MeasureTheory/Measure/Typeclasses/Finite.lean
@@ -122,9 +122,9 @@ theorem Measure.isFiniteMeasure_of_map {μ : Measure α} {f : α → β}
     rw [← Set.preimage_univ (f := f), ← map_apply_of_aemeasurable hf .univ]
     exact IsFiniteMeasure.measure_univ_lt_top
 
-theorem Measure.isFiniteMeasure_iff_isFiniteMeasure_map {μ : Measure α} {f : α → β}
-    (hf : AEMeasurable f μ) : IsFiniteMeasure μ ↔ IsFiniteMeasure (μ.map f) :=
-  ⟨fun _ ↦ isFiniteMeasure_map μ f, fun _ ↦ isFiniteMeasure_of_isFiniteMeasure_map hf⟩
+theorem Measure.isFiniteMeasure_map_iff {μ : Measure α} {f : α → β}
+    (hf : AEMeasurable f μ) : IsFiniteMeasure (μ.map f) ↔ IsFiniteMeasure μ :=
+  ⟨fun _ ↦ isFiniteMeasure_of_isFiniteMeasure_map hf, fun _ ↦ isFiniteMeasure_map μ f⟩
 
 instance IsFiniteMeasure_comap (f : β → α) [IsFiniteMeasure μ] : IsFiniteMeasure (μ.comap f) where
   measure_univ_lt_top := by

--- a/Mathlib/MeasureTheory/Measure/Typeclasses/Finite.lean
+++ b/Mathlib/MeasureTheory/Measure/Typeclasses/Finite.lean
@@ -122,7 +122,7 @@ theorem Measure.isFiniteMeasure_of_isFiniteMeasure_map {μ : Measure α} {f : α
     rw [← Set.preimage_univ (f := f), ← map_apply_of_aemeasurable hf .univ]
     exact IsFiniteMeasure.measure_univ_lt_top
 
-theorem Measure.isFiniteMeasure_iff_map_isFiniteMeasure {μ : Measure α} {f : α → β}
+theorem Measure.isFiniteMeasure_iff_isFiniteMeasure_map {μ : Measure α} {f : α → β}
     (hf : AEMeasurable f μ) : IsFiniteMeasure μ ↔ IsFiniteMeasure (μ.map f) :=
   ⟨fun _ ↦ isFiniteMeasure_map μ f, fun _ ↦ isFiniteMeasure_of_map_isFiniteMeasure hf⟩
 

--- a/Mathlib/MeasureTheory/Measure/Typeclasses/Finite.lean
+++ b/Mathlib/MeasureTheory/Measure/Typeclasses/Finite.lean
@@ -116,7 +116,7 @@ theorem Measure.isFiniteMeasure_map {m : MeasurableSpace α} (μ : Measure α) [
   · rw [map_of_not_aemeasurable hf]
     exact MeasureTheory.isFiniteMeasureZero
 
-theorem Measure.isFiniteMeasure_of_isFiniteMeasure_map {μ : Measure α} {f : α → β}
+theorem Measure.isFiniteMeasure_of_map {μ : Measure α} {f : α → β}
     (hf : AEMeasurable f μ) [IsFiniteMeasure (μ.map f)] : IsFiniteMeasure μ where
   measure_univ_lt_top := by
     rw [← Set.preimage_univ (f := f), ← map_apply_of_aemeasurable hf .univ]

--- a/Mathlib/MeasureTheory/Measure/Typeclasses/Finite.lean
+++ b/Mathlib/MeasureTheory/Measure/Typeclasses/Finite.lean
@@ -124,7 +124,7 @@ theorem Measure.isFiniteMeasure_of_map {μ : Measure α} {f : α → β}
 
 theorem Measure.isFiniteMeasure_map_iff {μ : Measure α} {f : α → β}
     (hf : AEMeasurable f μ) : IsFiniteMeasure (μ.map f) ↔ IsFiniteMeasure μ :=
-  ⟨fun _ ↦ isFiniteMeasure_of_isFiniteMeasure_map hf, fun _ ↦ isFiniteMeasure_map μ f⟩
+  ⟨fun _ ↦ isFiniteMeasure_of_map hf, fun _ ↦ isFiniteMeasure_map μ f⟩
 
 instance IsFiniteMeasure_comap (f : β → α) [IsFiniteMeasure μ] : IsFiniteMeasure (μ.comap f) where
   measure_univ_lt_top := by

--- a/Mathlib/MeasureTheory/Measure/Typeclasses/Finite.lean
+++ b/Mathlib/MeasureTheory/Measure/Typeclasses/Finite.lean
@@ -116,7 +116,7 @@ theorem Measure.isFiniteMeasure_map {m : MeasurableSpace α} (μ : Measure α) [
   · rw [map_of_not_aemeasurable hf]
     exact MeasureTheory.isFiniteMeasureZero
 
-theorem Measure.isFiniteMeasure_of_map_isFiniteMeasure {μ : Measure α} {f : α → β}
+theorem Measure.isFiniteMeasure_of_isFiniteMeasure_map {μ : Measure α} {f : α → β}
     (hf : AEMeasurable f μ) [IsFiniteMeasure (μ.map f)] : IsFiniteMeasure μ where
   measure_univ_lt_top := by
     rw [← Set.preimage_univ (f := f), ← map_apply_of_aemeasurable hf .univ]

--- a/Mathlib/MeasureTheory/Measure/Typeclasses/Probability.lean
+++ b/Mathlib/MeasureTheory/Measure/Typeclasses/Probability.lean
@@ -88,9 +88,20 @@ instance isProbabilityMeasureSMul [IsFiniteMeasure μ] [NeZero μ] :
 
 variable [IsProbabilityMeasure μ] {p : α → Prop} {f : β → α}
 
-theorem isProbabilityMeasure_map {f : α → β} (hf : AEMeasurable f μ) :
+theorem Measure.isProbabilityMeasure_map {f : α → β} (hf : AEMeasurable f μ) :
     IsProbabilityMeasure (map f μ) :=
   ⟨by simp [map_apply_of_aemeasurable, hf]⟩
+
+theorem Measure.isProbabilityMeasure_of_map_isProbabilityMeasure {μ : Measure α} {f : α → β}
+    (hf : AEMeasurable f μ) [IsProbabilityMeasure (μ.map f)] : IsProbabilityMeasure μ where
+  measure_univ := by
+    rw [← Set.preimage_univ (f := f), ← map_apply_of_aemeasurable hf .univ]
+    exact IsProbabilityMeasure.measure_univ
+
+theorem Measure.isProbabilityMeasure_iff_map_isProbabilityMeasure {μ : Measure α} {f : α → β}
+    (hf : AEMeasurable f μ) : IsProbabilityMeasure μ ↔ IsProbabilityMeasure (μ.map f) :=
+  ⟨fun _ ↦ isProbabilityMeasure_map hf,
+    fun _ ↦ isProbabilityMeasure_of_map_isProbabilityMeasure hf⟩
 
 instance IsProbabilityMeasure_comap_equiv (f : β ≃ᵐ α) : IsProbabilityMeasure (μ.comap f) := by
   rw [← MeasurableEquiv.map_symm]; exact isProbabilityMeasure_map f.symm.measurable.aemeasurable

--- a/Mathlib/MeasureTheory/Measure/Typeclasses/Probability.lean
+++ b/Mathlib/MeasureTheory/Measure/Typeclasses/Probability.lean
@@ -92,16 +92,16 @@ theorem Measure.isProbabilityMeasure_map {f : α → β} (hf : AEMeasurable f μ
     IsProbabilityMeasure (map f μ) :=
   ⟨by simp [map_apply_of_aemeasurable, hf]⟩
 
-theorem Measure.isProbabilityMeasure_of_map_isProbabilityMeasure {μ : Measure α} {f : α → β}
+theorem Measure.isProbabilityMeasure_of_isProbabilityMeasure_map {μ : Measure α} {f : α → β}
     (hf : AEMeasurable f μ) [IsProbabilityMeasure (μ.map f)] : IsProbabilityMeasure μ where
   measure_univ := by
     rw [← Set.preimage_univ (f := f), ← map_apply_of_aemeasurable hf .univ]
     exact IsProbabilityMeasure.measure_univ
 
-theorem Measure.isProbabilityMeasure_iff_map_isProbabilityMeasure {μ : Measure α} {f : α → β}
+theorem Measure.isProbabilityMeasure_iff_isProbabilityMeasure_map {μ : Measure α} {f : α → β}
     (hf : AEMeasurable f μ) : IsProbabilityMeasure μ ↔ IsProbabilityMeasure (μ.map f) :=
   ⟨fun _ ↦ isProbabilityMeasure_map hf,
-    fun _ ↦ isProbabilityMeasure_of_map_isProbabilityMeasure hf⟩
+    fun _ ↦ isProbabilityMeasure_of_isProbabilityMeasure_map hf⟩
 
 instance IsProbabilityMeasure_comap_equiv (f : β ≃ᵐ α) : IsProbabilityMeasure (μ.comap f) := by
   rw [← MeasurableEquiv.map_symm]; exact isProbabilityMeasure_map f.symm.measurable.aemeasurable

--- a/Mathlib/MeasureTheory/Measure/Typeclasses/Probability.lean
+++ b/Mathlib/MeasureTheory/Measure/Typeclasses/Probability.lean
@@ -100,8 +100,7 @@ theorem Measure.isProbabilityMeasure_of_map {μ : Measure α} {f : α → β}
 
 theorem Measure.isProbabilityMeasure_map_iff {μ : Measure α} {f : α → β}
     (hf : AEMeasurable f μ) : IsProbabilityMeasure (μ.map f) ↔ IsProbabilityMeasure μ :=
-  ⟨fun _ ↦ isProbabilityMeasure_of_isProbabilityMeasure_map hf,
-    fun _ ↦ isProbabilityMeasure_map hf⟩
+  ⟨fun _ ↦ isProbabilityMeasure_of_map hf, fun _ ↦ isProbabilityMeasure_map hf⟩
 
 instance IsProbabilityMeasure_comap_equiv (f : β ≃ᵐ α) : IsProbabilityMeasure (μ.comap f) := by
   rw [← MeasurableEquiv.map_symm]; exact isProbabilityMeasure_map f.symm.measurable.aemeasurable

--- a/Mathlib/MeasureTheory/Measure/Typeclasses/Probability.lean
+++ b/Mathlib/MeasureTheory/Measure/Typeclasses/Probability.lean
@@ -98,10 +98,10 @@ theorem Measure.isProbabilityMeasure_of_map {μ : Measure α} {f : α → β}
     rw [← Set.preimage_univ (f := f), ← map_apply_of_aemeasurable hf .univ]
     exact IsProbabilityMeasure.measure_univ
 
-theorem Measure.isProbabilityMeasure_iff_isProbabilityMeasure_map {μ : Measure α} {f : α → β}
-    (hf : AEMeasurable f μ) : IsProbabilityMeasure μ ↔ IsProbabilityMeasure (μ.map f) :=
-  ⟨fun _ ↦ isProbabilityMeasure_map hf,
-    fun _ ↦ isProbabilityMeasure_of_isProbabilityMeasure_map hf⟩
+theorem Measure.isProbabilityMeasure_map_iff {μ : Measure α} {f : α → β}
+    (hf : AEMeasurable f μ) : IsProbabilityMeasure (μ.map f) ↔ IsProbabilityMeasure μ :=
+  ⟨fun _ ↦ isProbabilityMeasure_of_isProbabilityMeasure_map hf,
+    fun _ ↦ isProbabilityMeasure_map hf⟩
 
 instance IsProbabilityMeasure_comap_equiv (f : β ≃ᵐ α) : IsProbabilityMeasure (μ.comap f) := by
   rw [← MeasurableEquiv.map_symm]; exact isProbabilityMeasure_map f.symm.measurable.aemeasurable

--- a/Mathlib/MeasureTheory/Measure/Typeclasses/Probability.lean
+++ b/Mathlib/MeasureTheory/Measure/Typeclasses/Probability.lean
@@ -92,7 +92,7 @@ theorem Measure.isProbabilityMeasure_map {f : α → β} (hf : AEMeasurable f μ
     IsProbabilityMeasure (map f μ) :=
   ⟨by simp [map_apply_of_aemeasurable, hf]⟩
 
-theorem Measure.isProbabilityMeasure_of_isProbabilityMeasure_map {μ : Measure α} {f : α → β}
+theorem Measure.isProbabilityMeasure_of_map {μ : Measure α} {f : α → β}
     (hf : AEMeasurable f μ) [IsProbabilityMeasure (μ.map f)] : IsProbabilityMeasure μ where
   measure_univ := by
     rw [← Set.preimage_univ (f := f), ← map_apply_of_aemeasurable hf .univ]

--- a/Mathlib/Probability/CDF.lean
+++ b/Mathlib/Probability/CDF.lean
@@ -38,7 +38,7 @@ The definition could be extended to `ℝⁿ`, either by extending the definition
 using another construction here.
 -/
 
-open MeasureTheory Set Filter
+open MeasureTheory Measure Set Filter
 
 open scoped Topology
 
@@ -49,7 +49,7 @@ for probability measures. In that case, it satisfies `cdf μ x = μ.real (Iic x)
 `ProbabilityTheory.cdf_eq_real`). -/
 noncomputable
 def cdf (μ : Measure ℝ) : StieltjesFunction :=
-  condCDF ((Measure.dirac Unit.unit).prod μ) Unit.unit
+  condCDF ((dirac Unit.unit).prod μ) Unit.unit
 
 section ExplicitMeasureArg
 variable (μ : Measure ℝ)
@@ -70,9 +70,8 @@ lemma tendsto_cdf_atBot : Tendsto (cdf μ) atBot (𝓝 0) := tendsto_condCDF_atB
 lemma tendsto_cdf_atTop : Tendsto (cdf μ) atTop (𝓝 1) := tendsto_condCDF_atTop _ _
 
 lemma ofReal_cdf [IsProbabilityMeasure μ] (x : ℝ) : ENNReal.ofReal (cdf μ x) = μ (Iic x) := by
-  have h := lintegral_condCDF ((Measure.dirac Unit.unit).prod μ) x
-  simpa only [MeasureTheory.Measure.fst_prod, Measure.prod_prod, measure_univ, one_mul,
-    lintegral_dirac] using h
+  have h := lintegral_condCDF ((dirac Unit.unit).prod μ) x
+  simpa only [fst_prod, prod_prod, measure_univ, one_mul, lintegral_dirac] using h
 
 lemma cdf_eq_real [IsProbabilityMeasure μ] (x : ℝ) : cdf μ x = μ.real (Iic x) := by
   rw [measureReal_def, ← ofReal_cdf μ x, ENNReal.toReal_ofReal (cdf_nonneg μ x)]
@@ -86,7 +85,7 @@ instance instIsProbabilityMeasurecdf : IsProbabilityMeasure (cdf μ).measure := 
 
 /-- The measure associated to the cdf of a probability measure is the same probability measure. -/
 lemma measure_cdf [IsProbabilityMeasure μ] : (cdf μ).measure = μ := by
-  refine Measure.ext_of_Iic (cdf μ).measure μ (fun a ↦ ?_)
+  refine ext_of_Iic (cdf μ).measure μ (fun a ↦ ?_)
   rw [StieltjesFunction.measure_Iic _ (tendsto_cdf_atBot μ), sub_zero, ofReal_cdf]
 
 end ExplicitMeasureArg
@@ -118,4 +117,4 @@ lemma MeasureTheory.Measure.eq_of_cdf (μ ν : Measure ℝ) [IsProbabilityMeasur
 @[simp] lemma MeasureTheory.Measure.cdf_eq_iff (μ ν : Measure ℝ) [IsProbabilityMeasure μ]
     [IsProbabilityMeasure ν] :
     cdf μ = cdf ν ↔ μ = ν :=
-⟨MeasureTheory.Measure.eq_of_cdf μ ν, fun h ↦ by rw [h]⟩
+⟨eq_of_cdf μ ν, fun h ↦ by rw [h]⟩

--- a/Mathlib/Probability/HasLaw.lean
+++ b/Mathlib/Probability/HasLaw.lean
@@ -54,11 +54,11 @@ lemma HasLaw.measurePreserving (h₁ : HasLaw X μ P) (h₂ : Measurable X) :
   map_eq := h₁.map_eq
 
 theorem HasLaw.isFiniteMeasure_iff (hX : HasLaw X μ P) :
-    IsFiniteMeasure P ↔ IsFiniteMeasure μ := by
+    IsFiniteMeasure μ ↔ IsFiniteMeasure P := by
   rw [← hX.map_eq, isFiniteMeasure_map_iff hX.aemeasurable]
 
 theorem HasLaw.isProbabilityMeasure_iff (hX : HasLaw X μ P) :
-    IsProbabilityMeasure P ↔ IsProbabilityMeasure μ := by
+    IsProbabilityMeasure μ ↔ IsProbabilityMeasure P := by
   rw [← hX.map_eq, isProbabilityMeasure_map_iff hX.aemeasurable]
 
 @[fun_prop]

--- a/Mathlib/Probability/HasLaw.lean
+++ b/Mathlib/Probability/HasLaw.lean
@@ -55,11 +55,11 @@ lemma HasLaw.measurePreserving (h₁ : HasLaw X μ P) (h₂ : Measurable X) :
 
 theorem HasLaw.isFiniteMeasure_iff (hX : HasLaw X μ P) :
     IsFiniteMeasure P ↔ IsFiniteMeasure μ := by
-  rw [← hX.map_eq, isFiniteMeasure_iff_isFiniteMeasure_map hX.aemeasurable]
+  rw [← hX.map_eq, isFiniteMeasure_map_iff hX.aemeasurable]
 
 theorem HasLaw.isProbabilityMeasure_iff (hX : HasLaw X μ P) :
     IsProbabilityMeasure P ↔ IsProbabilityMeasure μ := by
-  rw [← hX.map_eq, isProbabilityMeasure_iff_isProbabilityMeasure_map hX.aemeasurable]
+  rw [← hX.map_eq, isProbabilityMeasure_map_iff hX.aemeasurable]
 
 @[fun_prop]
 lemma HasLaw.comp {𝒴 : Type*} {m𝒴 : MeasurableSpace 𝒴} {ν : Measure 𝒴} {Y : 𝓧 → 𝒴}

--- a/Mathlib/Probability/HasLaw.lean
+++ b/Mathlib/Probability/HasLaw.lean
@@ -17,7 +17,7 @@ operations on the codomain of `X`.
 See for instance `HasLaw.comp`, `IndepFun.hasLaw_mul` and `IndepFun.hasLaw_add`.
 -/
 
-open MeasureTheory
+open MeasureTheory Measure
 
 open scoped ENNReal
 
@@ -121,5 +121,13 @@ lemma HasLaw.variance_eq {μ : Measure ℝ} {X : Ω → ℝ} (hX : HasLaw X μ P
 lemma HasPDF.hasLaw [h : HasPDF X P μ] : HasLaw X (μ.withDensity (pdf X P μ)) P where
   aemeasurable := h.aemeasurable
   map_eq := map_eq_withDensity_pdf X P μ
+
+theorem HasLaw.isFiniteMeasure_iff_law_isFiniteMeasure (hX : HasLaw X μ P) :
+    IsFiniteMeasure P ↔ IsFiniteMeasure μ := by
+  rw [← hX.map_eq, isFiniteMeasure_iff_map_isFiniteMeasure hX.aemeasurable]
+
+theorem HasLaw.isProbabilityMeasure_iff_law_isProbabilityMeasure (hX : HasLaw X μ P) :
+    IsProbabilityMeasure P ↔ IsProbabilityMeasure μ := by
+  rw [← hX.map_eq, isProbabilityMeasure_iff_map_isProbabilityMeasure hX.aemeasurable]
 
 end ProbabilityTheory

--- a/Mathlib/Probability/HasLaw.lean
+++ b/Mathlib/Probability/HasLaw.lean
@@ -53,11 +53,11 @@ lemma HasLaw.measurePreserving (h₁ : HasLaw X μ P) (h₂ : Measurable X) :
   measurable := h₂
   map_eq := h₁.map_eq
 
-theorem HasLaw.isFiniteMeasure_iff (hX : HasLaw X μ P) :
+protected theorem HasLaw.isFiniteMeasure_iff (hX : HasLaw X μ P) :
     IsFiniteMeasure μ ↔ IsFiniteMeasure P := by
   rw [← hX.map_eq, isFiniteMeasure_map_iff hX.aemeasurable]
 
-theorem HasLaw.isProbabilityMeasure_iff (hX : HasLaw X μ P) :
+protected theorem HasLaw.isProbabilityMeasure_iff (hX : HasLaw X μ P) :
     IsProbabilityMeasure μ ↔ IsProbabilityMeasure P := by
   rw [← hX.map_eq, isProbabilityMeasure_map_iff hX.aemeasurable]
 

--- a/Mathlib/Probability/HasLaw.lean
+++ b/Mathlib/Probability/HasLaw.lean
@@ -53,11 +53,11 @@ lemma HasLaw.measurePreserving (h₁ : HasLaw X μ P) (h₂ : Measurable X) :
   measurable := h₂
   map_eq := h₁.map_eq
 
-theorem HasLaw.isFiniteMeasure_iff_isFiniteMeasure_law (hX : HasLaw X μ P) :
+theorem HasLaw.isFiniteMeasure_iff (hX : HasLaw X μ P) :
     IsFiniteMeasure P ↔ IsFiniteMeasure μ := by
   rw [← hX.map_eq, isFiniteMeasure_iff_isFiniteMeasure_map hX.aemeasurable]
 
-theorem HasLaw.isProbabilityMeasure_iff_isProbabilityMeasure_law (hX : HasLaw X μ P) :
+theorem HasLaw.isProbabilityMeasure_iff (hX : HasLaw X μ P) :
     IsProbabilityMeasure P ↔ IsProbabilityMeasure μ := by
   rw [← hX.map_eq, isProbabilityMeasure_iff_isProbabilityMeasure_map hX.aemeasurable]
 

--- a/Mathlib/Probability/HasLaw.lean
+++ b/Mathlib/Probability/HasLaw.lean
@@ -53,6 +53,14 @@ lemma HasLaw.measurePreserving (h₁ : HasLaw X μ P) (h₂ : Measurable X) :
   measurable := h₂
   map_eq := h₁.map_eq
 
+theorem HasLaw.isFiniteMeasure_iff_isFiniteMeasure_law (hX : HasLaw X μ P) :
+    IsFiniteMeasure P ↔ IsFiniteMeasure μ := by
+  rw [← hX.map_eq, isFiniteMeasure_iff_isFiniteMeasure_map hX.aemeasurable]
+
+theorem HasLaw.isProbabilityMeasure_iff_isProbabilityMeasure_law (hX : HasLaw X μ P) :
+    IsProbabilityMeasure P ↔ IsProbabilityMeasure μ := by
+  rw [← hX.map_eq, isProbabilityMeasure_iff_isProbabilityMeasure_map hX.aemeasurable]
+
 @[fun_prop]
 lemma HasLaw.comp {𝒴 : Type*} {m𝒴 : MeasurableSpace 𝒴} {ν : Measure 𝒴} {Y : 𝓧 → 𝒴}
     (hY : HasLaw Y ν μ) (hX : HasLaw X μ P) : HasLaw (Y ∘ X) ν P where
@@ -121,13 +129,5 @@ lemma HasLaw.variance_eq {μ : Measure ℝ} {X : Ω → ℝ} (hX : HasLaw X μ P
 lemma HasPDF.hasLaw [h : HasPDF X P μ] : HasLaw X (μ.withDensity (pdf X P μ)) P where
   aemeasurable := h.aemeasurable
   map_eq := map_eq_withDensity_pdf X P μ
-
-theorem HasLaw.isFiniteMeasure_iff_law_isFiniteMeasure (hX : HasLaw X μ P) :
-    IsFiniteMeasure P ↔ IsFiniteMeasure μ := by
-  rw [← hX.map_eq, isFiniteMeasure_iff_map_isFiniteMeasure hX.aemeasurable]
-
-theorem HasLaw.isProbabilityMeasure_iff_law_isProbabilityMeasure (hX : HasLaw X μ P) :
-    IsProbabilityMeasure P ↔ IsProbabilityMeasure μ := by
-  rw [← hX.map_eq, isProbabilityMeasure_iff_map_isProbabilityMeasure hX.aemeasurable]
 
 end ProbabilityTheory

--- a/Mathlib/Probability/Kernel/IonescuTulcea/Traj.lean
+++ b/Mathlib/Probability/Kernel/IonescuTulcea/Traj.lean
@@ -171,7 +171,7 @@ instance [∀ n, IsZeroOrProbabilityMeasure (μ n)] (I : Finset ℕ) :
 instance [∀ n, IsProbabilityMeasure (μ n)] (I : Finset ℕ) :
     IsProbabilityMeasure (inducedFamily μ I) := by
   rw [inducedFamily]
-  exact isProbabilityMeasure_map (measurable_restrict₂ _).aemeasurable
+  exact Measure.isProbabilityMeasure_map (measurable_restrict₂ _).aemeasurable
 
 /-- Given a family of measures `μ : (n : ℕ) → Measure (Π i : Iic n, X i)`, the induced family
 equals `μ` over the intervals `Iic n`. -/

--- a/Mathlib/Probability/StrongLaw.lean
+++ b/Mathlib/Probability/StrongLaw.lean
@@ -215,7 +215,7 @@ theorem sum_prob_mem_Ioc_le {X : Ω → ℝ} (hint : Integrable X) (hnonneg : 0 
     (hKN : K ≤ N) :
     ∑ j ∈ range K, ℙ {ω | X ω ∈ Set.Ioc (j : ℝ) N} ≤ ENNReal.ofReal (𝔼[X] + 1) := by
   let ρ : Measure ℝ := Measure.map X ℙ
-  haveI : IsProbabilityMeasure ρ := isProbabilityMeasure_map hint.aemeasurable
+  haveI : IsProbabilityMeasure ρ := Measure.isProbabilityMeasure_map hint.aemeasurable
   have A : ∑ j ∈ range K, ∫ _ in j..N, (1 : ℝ) ∂ρ ≤ 𝔼[X] + 1 :=
     calc
       ∑ j ∈ range K, ∫ _ in j..N, (1 : ℝ) ∂ρ =


### PR DESCRIPTION
Adds theorems stating that if the pushforward of a measure is a probability/finite measure than the original measure is a probability/finite measure. Add the corresponding iff theorems and `HasLaw` versions. I also thought that these theorems should be under the same namespace whereas currently `isFiniteMeasure_map` is under `MeasureTheory.Measure` but `isProbabilityMeasure_map` is under `MeasureTheory`. I felt it more appropriate that they be in the `MeasureTheory.Measure` namespace so I made that change and updated downstream accordingly but I could change both to `MeasureTheory` (no `Measure`) instead if preferred. 