### PR TITLE
[Merged by Bors] - feat(RingTheory): local properties of semilocal rings

### DIFF
--- a/Mathlib.lean
+++ b/Mathlib.lean
@@ -5605,6 +5605,7 @@ import Mathlib.RingTheory.LocalProperties.IntegrallyClosed
 import Mathlib.RingTheory.LocalProperties.Projective
 import Mathlib.RingTheory.LocalProperties.Reduced
 import Mathlib.RingTheory.LocalProperties.Submodule
+import Mathlib.RingTheory.LocalProperties.Semilocal
 import Mathlib.RingTheory.LocalRing.Basic
 import Mathlib.RingTheory.LocalRing.Defs
 import Mathlib.RingTheory.LocalRing.LocalSubring

--- a/Mathlib.lean
+++ b/Mathlib.lean
@@ -5604,8 +5604,8 @@ import Mathlib.RingTheory.LocalProperties.Exactness
 import Mathlib.RingTheory.LocalProperties.IntegrallyClosed
 import Mathlib.RingTheory.LocalProperties.Projective
 import Mathlib.RingTheory.LocalProperties.Reduced
-import Mathlib.RingTheory.LocalProperties.Submodule
 import Mathlib.RingTheory.LocalProperties.Semilocal
+import Mathlib.RingTheory.LocalProperties.Submodule
 import Mathlib.RingTheory.LocalRing.Basic
 import Mathlib.RingTheory.LocalRing.Defs
 import Mathlib.RingTheory.LocalRing.LocalSubring

--- a/Mathlib/RingTheory/DedekindDomain/PID.lean
+++ b/Mathlib/RingTheory/DedekindDomain/PID.lean
@@ -170,6 +170,15 @@ theorem Ideal.IsPrincipal.of_finite_maximals_of_isUnit (hf : {I : Ideal R | I.Is
       (↑hI.unit⁻¹ : FractionalIdeal R⁰ (FractionRing R)) hI.unit.mul_inv)
 
 /-- A Dedekind domain is a PID if its set of primes is finite. -/
+theorem IsPrincipalIdealRing.of_finite_maximals [IsDedekindDomain R]
+    (h : {I : Ideal R | I.IsMaximal}.Finite) : IsPrincipalIdealRing R :=
+  ⟨fun I => by
+    obtain rfl | hI := eq_or_ne I ⊥
+    · exact bot_isPrincipal
+    apply Ideal.IsPrincipal.of_finite_maximals_of_isUnit h
+    exact isUnit_of_mul_eq_one _ _ (FractionalIdeal.coe_ideal_mul_inv I hI)⟩
+
+/-- A Dedekind domain is a PID if its set of primes is finite. -/
 theorem IsPrincipalIdealRing.of_finite_primes [IsDedekindDomain R]
     (h : {I : Ideal R | I.IsPrime}.Finite) : IsPrincipalIdealRing R :=
   ⟨fun I => by

--- a/Mathlib/RingTheory/DedekindDomain/PID.lean
+++ b/Mathlib/RingTheory/DedekindDomain/PID.lean
@@ -181,12 +181,7 @@ theorem IsPrincipalIdealRing.of_finite_maximals [IsDedekindDomain R]
 /-- A Dedekind domain is a PID if its set of primes is finite. -/
 theorem IsPrincipalIdealRing.of_finite_primes [IsDedekindDomain R]
     (h : {I : Ideal R | I.IsPrime}.Finite) : IsPrincipalIdealRing R :=
-  ⟨fun I => by
-    obtain rfl | hI := eq_or_ne I ⊥
-    · exact bot_isPrincipal
-    apply Ideal.IsPrincipal.of_finite_maximals_of_isUnit
-    · apply h.subset; exact @Ideal.IsMaximal.isPrime _ _
-    · exact isUnit_of_mul_eq_one _ _ (FractionalIdeal.coe_ideal_mul_inv I hI)⟩
+  IsPrincipalIdealRing.of_finite_maximals <| h.subset fun _ hi ↦ hi.isPrime
 
 variable [IsDedekindDomain R]
 variable (S : Type*) [CommRing S]

--- a/Mathlib/RingTheory/DedekindDomain/PID.lean
+++ b/Mathlib/RingTheory/DedekindDomain/PID.lean
@@ -169,7 +169,7 @@ theorem Ideal.IsPrincipal.of_finite_maximals_of_isUnit (hf : {I : Ideal R | I.Is
     (FractionalIdeal.isPrincipal.of_finite_maximals_of_inv le_rfl hf I
       (↑hI.unit⁻¹ : FractionalIdeal R⁰ (FractionRing R)) hI.unit.mul_inv)
 
-/-- A Dedekind domain is a PID if its set of primes is finite. -/
+/-- A Dedekind domain is a PID if its set of maximal ideals is finite. -/
 theorem IsPrincipalIdealRing.of_finite_maximals [IsDedekindDomain R]
     (h : {I : Ideal R | I.IsMaximal}.Finite) : IsPrincipalIdealRing R :=
   ⟨fun I => by

--- a/Mathlib/RingTheory/Ideal/Height.lean
+++ b/Mathlib/RingTheory/Ideal/Height.lean
@@ -430,3 +430,24 @@ lemma Ideal.sup_primeHeight_of_maximal_eq_ringKrullDim [Nontrivial R] :
     · exact ⟨⊥, by grind [iSup_le_iff, Ideal.IsPrime.ne_top]⟩
     · obtain ⟨M, hM, hIM⟩ := exists_le_maximal I I_top
       exact ⟨M, iSup_mono' (fun hI ↦ ⟨hM, primeHeight_mono hIM⟩)⟩
+
+section isLocalization
+
+variable
+  (Rₚ : ∀ (P : Ideal R) [P.IsMaximal], Type*)
+  [∀ (P : Ideal R) [P.IsMaximal], CommRing (Rₚ P)]
+  [∀ (P : Ideal R) [P.IsMaximal], Algebra R (Rₚ P)]
+  [∀ (P : Ideal R) [P.IsMaximal], IsLocalization.AtPrime (Rₚ P) P]
+
+lemma Ring.krullDimLE_of_isLocalization_maximal {n : ℕ}
+    (h : ∀ (P : Ideal R) [P.IsMaximal], Ring.KrullDimLE n (Rₚ P)) :
+    Ring.KrullDimLE n R := by
+  simp_rw [Ring.krullDimLE_iff] at h ⊢
+  nontriviality R
+  rw [← Ideal.sup_primeHeight_of_maximal_eq_ringKrullDim]
+  refine (WithBot.coe_le_coe).mpr (iSup₂_le_iff.mpr fun P hP ↦ ?_)
+  rw [← Ideal.height_eq_primeHeight, ← WithBot.coe_le_coe]
+  rw [← IsLocalization.AtPrime.ringKrullDim_eq_height P (Rₚ P)]
+  exact h P
+
+end isLocalization

--- a/Mathlib/RingTheory/LocalProperties/IntegrallyClosed.lean
+++ b/Mathlib/RingTheory/LocalProperties/IntegrallyClosed.lean
@@ -77,3 +77,14 @@ theorem IsIntegrallyClosed.of_localization_maximal [IsDomain R]
 theorem isIntegrallyClosed_ofLocalizationMaximal :
     OfLocalizationMaximal fun R _ => ([IsDomain R] → IsIntegrallyClosed R) :=
   fun _ _ h _ ↦ IsIntegrallyClosed.of_localization_maximal fun p _ hpm ↦ h p hpm
+
+variable
+  (Rₚ : ∀ (P : Ideal R) [P.IsMaximal], Type*)
+  [∀ (P : Ideal R) [P.IsMaximal], CommRing (Rₚ P)]
+  [∀ (P : Ideal R) [P.IsMaximal], Algebra R (Rₚ P)]
+  [∀ (P : Ideal R) [P.IsMaximal], IsLocalization.AtPrime (Rₚ P) P]
+
+theorem IsIntegrallyClosed.of_isLocalization_maximal [IsDomain R]
+    (h : ∀ (P : Ideal R) [P.IsMaximal], IsIntegrallyClosed (Rₚ P)) :
+    IsIntegrallyClosed R := .of_localization_maximal
+  (fun P _ _ ↦ .of_equiv <| ringEquivOfRingEquiv (Rₚ P) _ (RingEquiv.refl R) P.primeCompl.map_id)

--- a/Mathlib/RingTheory/LocalProperties/Semilocal.lean
+++ b/Mathlib/RingTheory/LocalProperties/Semilocal.lean
@@ -66,10 +66,7 @@ theorem Submodule.fg_of_isLocalized_maximal (N : Submodule R M)
     (H : ∀ (P : Ideal R) [P.IsMaximal], (Submodule.localized' (Rₚ P) P.primeCompl (f P) N).FG) :
     N.FG := by
   simp_rw [← Module.Finite.iff_fg] at ⊢ H
-  let fN : ∀ (P : Ideal R) [P.IsMaximal], ↥N →ₗ[R]
-    Submodule.localized' (Rₚ P) P.primeCompl (f P) N :=
-    fun P _ => N.toLocalized' (Rₚ P) P.primeCompl (f P)
-  exact Module.Finite.of_isLocalized_maximal  _ _ _ fN H
+  exact .of_isLocalized_maximal  _ _ _ (fun P ↦ N.toLocalized' (Rₚ P) P.primeCompl (f P)) H
 
 end isLocalized_maximal
 

--- a/Mathlib/RingTheory/LocalProperties/Semilocal.lean
+++ b/Mathlib/RingTheory/LocalProperties/Semilocal.lean
@@ -120,8 +120,8 @@ theorem isPrincipalIdealRing_of_isPrincipalIdealRing_isLocalization [IsDomain R]
     IsNoetherianRing.of_isLocalization_maximal Rₚ (fun P _ => inferInstance)
   have : IsIntegrallyClosed R := by
     refine IsIntegrallyClosed.of_isLocalization_maximal Rₚ (fun P hP => ?_)
-
-    sorry
+    have : IsDomain (Rₚ P) := IsLocalization.isDomain_of_isLocalization_atPrime (Rₚ P) P
+    infer_instance
   have : Ring.KrullDimLE 1 R :=
     Ring.krullDimLE_of_isLocalization_maximal Rₚ (fun P _ => inferInstance)
   rw [Ring.krullDimLE_one_iff_of_noZeroDivisors] at this

--- a/Mathlib/RingTheory/LocalProperties/Semilocal.lean
+++ b/Mathlib/RingTheory/LocalProperties/Semilocal.lean
@@ -81,7 +81,7 @@ theorem Module.Finite.of_localized_maximal
 
 variable {M} in
 theorem Submodule.fg_of_localized_maximal (N : Submodule R M)
-    (H : ∀ (P : Ideal R) [P.IsMaximal], (N.localized (P.primeCompl)).FG) :
+    (H : ∀ (P : Ideal R) [P.IsMaximal], (N.localized P.primeCompl).FG) :
     N.FG := N.fg_of_isLocalized_maximal _ _ _ H
 
 end localized_maximal
@@ -117,13 +117,13 @@ theorem isPrincipalIdealRing_of_isPrincipalIdealRing_isLocalization [IsDomain R]
     (hpid : ∀ (P : Ideal R) [P.IsMaximal], IsPrincipalIdealRing (Rₚ P)) :
     IsPrincipalIdealRing R := by
   have : IsNoetherianRing R :=
-    IsNoetherianRing.of_isLocalization_maximal Rₚ (fun P _ => inferInstance)
+    IsNoetherianRing.of_isLocalization_maximal Rₚ fun P _ => inferInstance
   have : IsIntegrallyClosed R := by
-    refine IsIntegrallyClosed.of_isLocalization_maximal Rₚ (fun P hP => ?_)
+    refine IsIntegrallyClosed.of_isLocalization_maximal Rₚ fun P hP => ?_
     have : IsDomain (Rₚ P) := IsLocalization.isDomain_of_isLocalization_atPrime (Rₚ P) P
     infer_instance
   have : Ring.KrullDimLE 1 R :=
-    Ring.krullDimLE_of_isLocalization_maximal Rₚ (fun P _ => inferInstance)
+    Ring.krullDimLE_of_isLocalization_maximal Rₚ fun P _ => inferInstance
   rw [Ring.krullDimLE_one_iff_of_noZeroDivisors] at this
   have dedekind : IsDedekindDomain R := { maximalOfPrime := this _ }
   have hp_finite : {P : Ideal R | P.IsPrime}.Finite :=

--- a/Mathlib/RingTheory/LocalProperties/Semilocal.lean
+++ b/Mathlib/RingTheory/LocalProperties/Semilocal.lean
@@ -17,8 +17,8 @@ finitely many maximal ideals).
 
 * `Module.finite.of_isLocalized_maximal`: A module `M` over a semilocal ring `R` is finite if it is
   locally finite at every maximal ideal.
-* `IsNoetherianRing.of_isLocalized_maximal`: A semilocal ring `R` is Noetherian if it is locally
-  Noetherian at every maximal ideal.
+* `IsNoetherianRing.of_isLocalization_maximal`: A semilocal ring `R` is Noetherian if it is
+  locally Noetherian at every maximal ideal.
 * `isPrincipalIdealRing_of_isPrincipalIdealRing_localization`: A semilocal integral domain `A` is a
   PID if its localization at every maximal ideal is a PID.
 -/
@@ -90,7 +90,7 @@ end localized_maximal
 section IsLocalization
 
 /-- A semilocal ring `R` is Noetherian if it is locally Noetherian at every maximal ideal. -/
-theorem IsNoetherianRing.of_isLocalized_maximal
+theorem IsNoetherianRing.of_isLocalization_maximal
     (H : ∀ (P : Ideal R) [P.IsMaximal], IsNoetherianRing (Rₚ P)) :
     IsNoetherianRing R where
   noetherian N := Submodule.fg_of_isLocalized_maximal
@@ -116,7 +116,8 @@ This is the `IsLocalization` version. -/
 theorem isPrincipalIdealRing_of_isPrincipalIdealRing_isLocalization [IsDomain R]
     (hpid : ∀ (P : Ideal R) [P.IsMaximal], IsPrincipalIdealRing (Rₚ P)) :
     IsPrincipalIdealRing R := by
-  have : IsNoetherianRing R := IsNoetherianRing.of_isLocalized_maximal Rₚ (fun P _ => inferInstance)
+  have : IsNoetherianRing R :=
+    IsNoetherianRing.of_isLocalization_maximal Rₚ (fun P _ => inferInstance)
   have : IsIntegrallyClosed R := by
     refine IsIntegrallyClosed.of_isLocalization_maximal Rₚ (fun P _ => ?_)
     have := hpid P

--- a/Mathlib/RingTheory/LocalProperties/Semilocal.lean
+++ b/Mathlib/RingTheory/LocalProperties/Semilocal.lean
@@ -40,6 +40,8 @@ variable
   [∀ (P : Ideal R) [P.IsMaximal], IsLocalizedModule P.primeCompl (f P)]
 
 include f in
+/-- A module `M` over a semilocal ring `R` is finite if it is
+locally finite at every maximal ideal. -/
 theorem Module.finite.of_isLocalized_maximal
     (H : ∀ (P : Ideal R) [P.IsMaximal], Module.Finite (Rₚ P) (Mₚ P)) :
     Module.Finite R M := by

--- a/Mathlib/RingTheory/LocalProperties/Semilocal.lean
+++ b/Mathlib/RingTheory/LocalProperties/Semilocal.lean
@@ -126,11 +126,10 @@ theorem isPrincipalIdealRing_of_isPrincipalIdealRing_isLocalization [IsDomain R]
     Ring.krullDimLE_of_isLocalization_maximal Rₚ fun P _ => inferInstance
   rw [Ring.krullDimLE_one_iff_of_noZeroDivisors] at this
   have dedekind : IsDedekindDomain R := { maximalOfPrime := this _ }
-  have hp_finite : {P : Ideal R | P.IsPrime}.Finite :=
-    ((Set.finite_range MaximalSpectrum.asIdeal).insert ⊥).subset fun P hP ↦
-      or_iff_not_imp_left.mpr (⟨⟨_, this _ · hP⟩, rfl⟩)
-  exact IsPrincipalIdealRing.of_finite_primes hp_finite
-
+  have hp_finite : {P : Ideal R | P.IsMaximal}.Finite := by
+    rw [← MaximalSpectrum.range_asIdeal]
+    exact Set.finite_range MaximalSpectrum.asIdeal
+  exact IsPrincipalIdealRing.of_finite_maximals hp_finite
 end IsLocalization
 
 end CommRing

--- a/Mathlib/RingTheory/LocalProperties/Semilocal.lean
+++ b/Mathlib/RingTheory/LocalProperties/Semilocal.lean
@@ -5,7 +5,7 @@ Authors: Yiming Fu
 -/
 import Mathlib.RingTheory.DedekindDomain.PID
 import Mathlib.RingTheory.KrullDimension.PID
-import Mathlib.RingTheory.Localization.Finiteness
+
 /-!
 # Local properties for semilocal rings
 

--- a/Mathlib/RingTheory/LocalProperties/Semilocal.lean
+++ b/Mathlib/RingTheory/LocalProperties/Semilocal.lean
@@ -1,0 +1,143 @@
+/-
+Copyright (c) 2025 Yiming Fu. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Yiming Fu
+-/
+import Mathlib.RingTheory.DedekindDomain.PID
+import Mathlib.RingTheory.KrullDimension.PID
+import Mathlib.RingTheory.Localization.Finiteness
+
+/-!
+# Local properties for semilocal rings
+
+This file proves some local properties for a semilocal ring `R` (a ring with
+finitely many maximal ideals).
+
+## Main results
+
+* `Module.finite.of_isLocalized_maximal`: A module `M` over a semilocal ring `R` is finite if it is
+  locally finite at every maximal ideal.
+* `isPrincipalIdealRing_of_isPrincipalIdealRing_localization`: A semilocal integral domain `A` is a
+  PID if its localization at every maximal ideal is a PID.
+-/
+
+variable {R : Type*} [CommSemiring R] [Finite (MaximalSpectrum R)]
+variable (M : Type*) [AddCommMonoid M] [Module R M]
+
+section isLocalized_maximal
+
+variable
+  (Rₚ : ∀ (P : Ideal R) [P.IsMaximal], Type*)
+  [∀ (P : Ideal R) [P.IsMaximal], CommSemiring (Rₚ P)]
+  [∀ (P : Ideal R) [P.IsMaximal], Algebra R (Rₚ P)]
+  [∀ (P : Ideal R) [P.IsMaximal], IsLocalization.AtPrime (Rₚ P) P]
+  (Mₚ : ∀ (P : Ideal R) [P.IsMaximal], Type*)
+  [∀ (P : Ideal R) [P.IsMaximal], AddCommMonoid (Mₚ P)]
+  [∀ (P : Ideal R) [P.IsMaximal], Module R (Mₚ P)]
+  [∀ (P : Ideal R) [P.IsMaximal], Module (Rₚ P) (Mₚ P)]
+  [∀ (P : Ideal R) [P.IsMaximal], IsScalarTower R (Rₚ P) (Mₚ P)]
+  (f : ∀ (P : Ideal R) [P.IsMaximal], M →ₗ[R] Mₚ P)
+  [∀ (P : Ideal R) [P.IsMaximal], IsLocalizedModule P.primeCompl (f P)]
+
+include f in
+theorem Module.finite.of_isLocalized_maximal
+    (H : ∀ (P : Ideal R) [P.IsMaximal], Module.Finite (Rₚ P) (Mₚ P)) :
+    Module.Finite R M := by
+  classical
+  let _ : Fintype ({ P : Ideal R | P.IsMaximal }) := by
+    rw [← MaximalSpectrum.range_asIdeal]
+    exact Fintype.ofFinite (Set.range MaximalSpectrum.asIdeal)
+  constructor
+  let {P : { P : Ideal R | P.IsMaximal }} : P.1.IsMaximal := P.2
+  choose s₁ s₂ using (fun P : { P : Ideal R | P.IsMaximal } ↦ (H P.1).1)
+  let getNum (P : { P : Ideal R | P.IsMaximal }) (x : Mₚ P) :=
+    (IsLocalizedModule.surj P.1.primeCompl (f P.1) x).choose.1
+  let sf := fun P : { P : Ideal R | P.IsMaximal } ↦ Finset.image (getNum P) (s₁ P)
+  use Finset.biUnion (Finset.univ) sf
+  let N : Submodule R M := Submodule.span R (Finset.univ.biUnion sf)
+  refine Submodule.eq_top_of_localization_maximal Rₚ Mₚ f _ (fun P hP ↦ ?_)
+  rw [← top_le_iff, ← s₂ ⟨P, hP⟩, Submodule.localized'_span]
+  refine Submodule.span_le.2 fun x hx ↦ ?_
+  lift x to s₁ ⟨P, hP⟩ using hx
+  rw [SetLike.mem_coe]
+  let Num := getNum ⟨P, hP⟩ x
+  let denom := (IsLocalizedModule.surj P.primeCompl (f P) x).choose.2
+  have h : denom • x = f P Num := (IsLocalizedModule.surj P.primeCompl (f P) x).choose_spec
+  rw [← IsLocalization.smul_mem_iff (s := denom), h]
+  refine Submodule.mem_span.mpr fun p a => a ?_
+  simp only [Finset.coe_biUnion, Finset.coe_univ, Set.mem_univ, Set.iUnion_true, Set.mem_image,
+    Set.mem_iUnion, Finset.mem_coe, Finset.mem_image, sf]
+  exact ⟨Num, ⟨⟨P, hP⟩, ⟨x, ⟨x.2, rfl⟩⟩⟩, rfl⟩
+
+variable {M} in
+theorem Submodule.fg_of_isLocalized_maximal (N : Submodule R M)
+    (H : ∀ (P : Ideal R) [P.IsMaximal], (Submodule.localized' (Rₚ P) P.primeCompl (f P) N).FG) :
+    N.FG := by
+  simp_rw [← Module.Finite.iff_fg] at ⊢ H
+  let fN : ∀ (P : Ideal R) [P.IsMaximal], ↥N →ₗ[R]
+    Submodule.localized' (Rₚ P) P.primeCompl (f P) N :=
+    fun P _ => N.toLocalized' (Rₚ P) P.primeCompl (f P)
+  exact Module.finite.of_isLocalized_maximal _ _ _ fN H
+
+end isLocalized_maximal
+
+section localized_maximal
+
+theorem finite_of_finite_localized_maximal
+    (H : ∀ (P : Ideal R) [P.IsMaximal],
+      Module.Finite (Localization P.primeCompl) (LocalizedModule P.primeCompl M)) :
+    Module.Finite R M :=
+  Module.finite.of_isLocalized_maximal M _ _ (fun _ _ ↦ LocalizedModule.mkLinearMap _ _) H
+
+variable {M} in
+theorem Submodule.fg_of_localized_maximal (N : Submodule R M)
+    (H : ∀ (P : Ideal R) [P.IsMaximal], (Submodule.localized (P.primeCompl) N).FG) :
+    N.FG := Submodule.fg_of_isLocalized_maximal _ _ _ N H
+
+end localized_maximal
+
+lemma Ring.krullDimLE_one_of_localization_maximal {A : Type*} [CommRing A] {n : ℕ}
+    (h : ∀ (P : Ideal A) [P.IsMaximal], Ring.KrullDimLE n (Localization P.primeCompl)) :
+    Ring.KrullDimLE n A := by
+  by_cases hA : Nontrivial A
+  · simp_rw [Ring.krullDimLE_iff] at h ⊢
+    rw [← Ideal.sup_primeHeight_of_maximal_eq_ringKrullDim]
+    refine (WithBot.coe_le_coe).2 (iSup₂_le_iff.mpr fun P hP ↦ ?_)
+    rw [← Ideal.height_eq_primeHeight, ← WithBot.coe_le_coe]
+    rw [← IsLocalization.AtPrime.ringKrullDim_eq_height P (Localization P.primeCompl)]
+    exact h P
+  · rw [not_nontrivial_iff_subsingleton] at hA
+    simp only [Ring.krullDimLE_iff, ringKrullDim_eq_bot_of_subsingleton, bot_le]
+
+/-- If a semilocal integral domain satisfies that it localized at all
+maximal ideals is a PID, then itself is a PID. -/
+theorem isPrincipalIdealRing_of_isPrincipalIdealRing_localization
+    (A : Type*) [CommRing A] [IsDomain A] [Finite (MaximalSpectrum A)]
+    (hpid : ∀ (P : Ideal A) [P.IsMaximal], IsPrincipalIdealRing (Localization P.primeCompl)) :
+    IsPrincipalIdealRing A := by
+  have : IsNoetherianRing A := by
+    constructor
+    intro N
+    refine Submodule.fg_of_localized_maximal N (fun P hP => ?_)
+    exact IsNoetherian.noetherian (Submodule.localized P.primeCompl N)
+  have : IsIntegrallyClosed A := by
+    refine IsIntegrallyClosed.of_localization_maximal (fun P _ hP => ?_)
+    let p : MaximalSpectrum A := ⟨P, hP⟩
+    change IsIntegrallyClosed (Localization p.1.primeCompl)
+    infer_instance
+  have : Ring.KrullDimLE 1 A :=
+    Ring.krullDimLE_one_of_localization_maximal (fun _ _ => by infer_instance)
+  rw [Ring.krullDimLE_one_iff_of_noZeroDivisors] at this
+  have : IsDedekindDomain A := {maximalOfPrime := this _}
+  have hp_sub : {P : Ideal A | P.IsPrime} ⊆ {P : Ideal A | P.IsMaximal} ∪ {⊥} := by
+    simp only [Set.union_singleton]
+    intro P hP
+    obtain rfl | hbot := eq_or_ne P ⊥
+    · simp
+    · simp only [Set.mem_insert_iff, hbot, Set.mem_setOf_eq, false_or]
+      exact this.maximalOfPrime hbot hP
+  have hp_finite : {P : Ideal A | P.IsPrime}.Finite := by
+    refine Set.Finite.subset (Set.Finite.union ?_ (Set.finite_singleton ⊥)) hp_sub
+    rw [← MaximalSpectrum.range_asIdeal]
+    exact Set.finite_range MaximalSpectrum.asIdeal
+  exact IsPrincipalIdealRing.of_finite_primes hp_finite

--- a/Mathlib/RingTheory/LocalProperties/Semilocal.lean
+++ b/Mathlib/RingTheory/LocalProperties/Semilocal.lean
@@ -130,6 +130,7 @@ theorem isPrincipalIdealRing_of_isPrincipalIdealRing_isLocalization [IsDomain R]
     rw [← MaximalSpectrum.range_asIdeal]
     exact Set.finite_range MaximalSpectrum.asIdeal
   exact IsPrincipalIdealRing.of_finite_maximals hp_finite
+
 end IsLocalization
 
 end CommRing

--- a/Mathlib/RingTheory/LocalProperties/Semilocal.lean
+++ b/Mathlib/RingTheory/LocalProperties/Semilocal.lean
@@ -72,6 +72,8 @@ theorem Module.finite.of_isLocalized_maximal
   exact ⟨Num, ⟨⟨P, hP⟩, ⟨x, ⟨x.2, rfl⟩⟩⟩, rfl⟩
 
 variable {M} in
+/-- A submodule `N` of a module `M` over a semilocal ring `R` is finitely generated if it is
+locally finitely generated at every maximal ideal. -/
 theorem Submodule.fg_of_isLocalized_maximal (N : Submodule R M)
     (H : ∀ (P : Ideal R) [P.IsMaximal], (Submodule.localized' (Rₚ P) P.primeCompl (f P) N).FG) :
     N.FG := by
@@ -79,22 +81,23 @@ theorem Submodule.fg_of_isLocalized_maximal (N : Submodule R M)
   let fN : ∀ (P : Ideal R) [P.IsMaximal], ↥N →ₗ[R]
     Submodule.localized' (Rₚ P) P.primeCompl (f P) N :=
     fun P _ => N.toLocalized' (Rₚ P) P.primeCompl (f P)
-  exact Module.finite.of_isLocalized_maximal _ _ _ fN H
+  exact Module.finite.of_isLocalized_maximal  _ _ _ fN H
 
 end isLocalized_maximal
 
 section localized_maximal
 
-theorem finite_of_finite_localized_maximal
+theorem Module.finite.of_localized_maximal
     (H : ∀ (P : Ideal R) [P.IsMaximal],
       Module.Finite (Localization P.primeCompl) (LocalizedModule P.primeCompl M)) :
     Module.Finite R M :=
-  Module.finite.of_isLocalized_maximal M _ _ (fun _ _ ↦ LocalizedModule.mkLinearMap _ _) H
+  Module.finite.of_isLocalized_maximal  M _ _
+    (fun _ _ ↦ LocalizedModule.mkLinearMap _ _) H
 
 variable {M} in
 theorem Submodule.fg_of_localized_maximal (N : Submodule R M)
     (H : ∀ (P : Ideal R) [P.IsMaximal], (Submodule.localized (P.primeCompl) N).FG) :
-    N.FG := Submodule.fg_of_isLocalized_maximal _ _ _ N H
+    N.FG := Submodule.fg_of_isLocalized_maximal  _ _ _ N H
 
 end localized_maximal
 
@@ -120,7 +123,7 @@ theorem isPrincipalIdealRing_of_isPrincipalIdealRing_localization
   have : IsNoetherianRing A := by
     constructor
     intro N
-    refine Submodule.fg_of_localized_maximal N (fun P hP => ?_)
+    refine Submodule.fg_of_localized_maximal  N (fun P hP => ?_)
     exact IsNoetherian.noetherian (Submodule.localized P.primeCompl N)
   have : IsIntegrallyClosed A := by
     refine IsIntegrallyClosed.of_localization_maximal (fun P _ hP => ?_)

--- a/Mathlib/RingTheory/LocalProperties/Semilocal.lean
+++ b/Mathlib/RingTheory/LocalProperties/Semilocal.lean
@@ -17,6 +17,8 @@ finitely many maximal ideals).
 
 * `Module.finite.of_isLocalized_maximal`: A module `M` over a semilocal ring `R` is finite if it is
   locally finite at every maximal ideal.
+* `IsNoetherianRing.of_isLocalized_maximal`: A semilocal ring `R` is Noetherian if it is locally
+  Noetherian at every maximal ideal.
 * `isPrincipalIdealRing_of_isPrincipalIdealRing_localization`: A semilocal integral domain `A` is a
   PID if its localization at every maximal ideal is a PID.
 -/
@@ -87,6 +89,7 @@ end localized_maximal
 
 section IsLocalization
 
+/-- A semilocal ring `R` is Noetherian if it is locally Noetherian at every maximal ideal. -/
 theorem IsNoetherianRing.of_isLocalized_maximal
     (H : ∀ (P : Ideal R) [P.IsMaximal], IsNoetherianRing (Rₚ P)) :
     IsNoetherianRing R where

--- a/Mathlib/RingTheory/LocalProperties/Semilocal.lean
+++ b/Mathlib/RingTheory/LocalProperties/Semilocal.lean
@@ -46,7 +46,7 @@ theorem Module.finite.of_isLocalized_maximal
     (H : ∀ (P : Ideal R) [P.IsMaximal], Module.Finite (Rₚ P) (Mₚ P)) :
     Module.Finite R M := by
   classical
-  let _ : Fintype ({ P : Ideal R | P.IsMaximal }) := by
+  let : Fintype ({ P : Ideal R | P.IsMaximal }) := by
     rw [← MaximalSpectrum.range_asIdeal]
     exact Fintype.ofFinite (Set.range MaximalSpectrum.asIdeal)
   constructor
@@ -123,7 +123,7 @@ theorem isPrincipalIdealRing_of_isPrincipalIdealRing_localization
   have : IsNoetherianRing A := by
     constructor
     intro N
-    refine Submodule.fg_of_localized_maximal  N (fun P hP => ?_)
+    refine Submodule.fg_of_localized_maximal N (fun P hP => ?_)
     exact IsNoetherian.noetherian (Submodule.localized P.primeCompl N)
   have : IsIntegrallyClosed A := by
     refine IsIntegrallyClosed.of_localization_maximal (fun P _ hP => ?_)

--- a/Mathlib/RingTheory/LocalProperties/Semilocal.lean
+++ b/Mathlib/RingTheory/LocalProperties/Semilocal.lean
@@ -100,11 +100,6 @@ theorem Submodule.fg_of_localized_maximal (N : Submodule R M)
 
 end localized_maximal
 
-variable
-  (Rₚ : ∀ (P : Ideal R) [P.IsMaximal], Type*)
-  [∀ (P : Ideal R) [P.IsMaximal], CommSemiring (Rₚ P)]
-  [∀ (P : Ideal R) [P.IsMaximal], Algebra R (Rₚ P)]
-  [∀ (P : Ideal R) [P.IsMaximal], IsLocalization.AtPrime (Rₚ P) P]
 /-- If a semilocal integral domain satisfies that it localized at all
 maximal ideals is a PID, then itself is a PID. -/
 theorem isPrincipalIdealRing_of_isPrincipalIdealRing_localization

--- a/Mathlib/RingTheory/LocalProperties/Semilocal.lean
+++ b/Mathlib/RingTheory/LocalProperties/Semilocal.lean
@@ -18,8 +18,8 @@ finitely many maximal ideals).
   localization at every maximal ideal is finite.
 * `IsNoetherianRing.of_isLocalization_maximal`: A semilocal ring `R` is Noetherian if its
   localization at every maximal ideal is a Noetherian ring.
-* `isPrincipalIdealRing_of_isPrincipalIdealRing_isLocalization`: A semilocal integral domain `A` is
-  a PID if its localization at every maximal ideal is a PID.
+* `isPrincipalIdealRing_of_isPrincipalIdealRing_isLocalization_maximal`: A semilocal
+  integral domain `A` is a PID if its localization at every maximal ideal is a PID.
 -/
 
 section CommSemiring
@@ -40,7 +40,7 @@ variable
   (f : ∀ (P : Ideal R) [P.IsMaximal], M →ₗ[R] Mₚ P)
   [∀ (P : Ideal R) [P.IsMaximal], IsLocalizedModule P.primeCompl (f P)]
 
-section isLocalized_maximal
+section IsLocalized
 
 include f in
 /-- A module `M` over a semilocal ring `R` is finite if
@@ -69,9 +69,9 @@ theorem Submodule.fg_of_isLocalized_maximal (N : Submodule R M)
   simp_rw [← Module.Finite.iff_fg] at ⊢ H
   exact .of_isLocalized_maximal _ _ _ (fun P ↦ N.toLocalized' (Rₚ P) P.primeCompl (f P)) H
 
-end isLocalized_maximal
+end IsLocalized
 
-section localized_maximal
+section Localized
 
 theorem Module.Finite.of_localized_maximal
     (H : ∀ (P : Ideal R) [P.IsMaximal],
@@ -84,7 +84,7 @@ theorem Submodule.fg_of_localized_maximal (N : Submodule R M)
     (H : ∀ (P : Ideal R) [P.IsMaximal], (N.localized P.primeCompl).FG) :
     N.FG := N.fg_of_isLocalized_maximal _ _ _ H
 
-end localized_maximal
+end Localized
 
 section IsLocalization
 
@@ -112,7 +112,7 @@ variable
   [∀ (P : Ideal R) [P.IsMaximal], IsLocalization.AtPrime (Rₚ P) P]
 
 /-- A semilocal integral domain `A` is a PID if its localization at every maximal ideal is a PID. -/
-theorem isPrincipalIdealRing_of_isPrincipalIdealRing_isLocalization [IsDomain R]
+theorem isPrincipalIdealRing_of_isPrincipalIdealRing_isLocalization_maximal [IsDomain R]
     (hpid : ∀ (P : Ideal R) [P.IsMaximal], IsPrincipalIdealRing (Rₚ P)) :
     IsPrincipalIdealRing R := by
   have : IsNoetherianRing R :=

--- a/Mathlib/RingTheory/LocalProperties/Semilocal.lean
+++ b/Mathlib/RingTheory/LocalProperties/Semilocal.lean
@@ -18,8 +18,8 @@ finitely many maximal ideals).
   localization at every maximal ideal is finite.
 * `IsNoetherianRing.of_isLocalization_maximal`: A semilocal ring `R` is Noetherian if its
   localization at every maximal ideal is a Noetherian ring.
-* `isPrincipalIdealRing_of_isPrincipalIdealRing_isLocalization`: A semilocal integral domain `A` is a
-  PID if its localization at every maximal ideal is a PID.
+* `isPrincipalIdealRing_of_isPrincipalIdealRing_isLocalization`: A semilocal integral domain `A` is
+  a PID if its localization at every maximal ideal is a PID.
 -/
 
 section CommSemiring
@@ -94,7 +94,7 @@ theorem IsNoetherianRing.of_isLocalization_maximal
     (H : ∀ (P : Ideal R) [P.IsMaximal], IsNoetherianRing (Rₚ P)) :
     IsNoetherianRing R where
   noetherian N := Submodule.fg_of_isLocalized_maximal
-    Rₚ Rₚ (fun P _ => Algebra.linearMap R (Rₚ P)) N fun _ _ => IsNoetherian.noetherian _
+    Rₚ Rₚ (fun P _ => Algebra.linearMap R (Rₚ P)) N fun _ _ ↦ IsNoetherian.noetherian _
 
 end IsLocalization
 

--- a/Mathlib/RingTheory/LocalProperties/Semilocal.lean
+++ b/Mathlib/RingTheory/LocalProperties/Semilocal.lean
@@ -6,7 +6,6 @@ Authors: Yiming Fu
 import Mathlib.RingTheory.DedekindDomain.PID
 import Mathlib.RingTheory.KrullDimension.PID
 import Mathlib.RingTheory.Localization.Finiteness
-
 /-!
 # Local properties for semilocal rings
 
@@ -15,10 +14,10 @@ finitely many maximal ideals).
 
 ## Main results
 
-* `Module.finite.of_isLocalized_maximal`: A module `M` over a semilocal ring `R` is finite if it is
-  locally finite at every maximal ideal.
-* `IsNoetherianRing.of_isLocalization_maximal`: A semilocal ring `R` is Noetherian if it is
-  locally Noetherian at every maximal ideal.
+* `Module.Finite.of_isLocalized_maximal`: A module `M` over a semilocal ring `R` is finite if its
+  localization at every maximal ideal is finite.
+* `IsNoetherianRing.of_isLocalization_maximal`: A semilocal ring `R` is Noetherian if its
+  localization at every maximal ideal is a Noetherian ring.
 * `isPrincipalIdealRing_of_isPrincipalIdealRing_localization`: A semilocal integral domain `A` is a
   PID if its localization at every maximal ideal is a PID.
 -/
@@ -44,8 +43,8 @@ variable
 section isLocalized_maximal
 
 include f in
-/-- A module `M` over a semilocal ring `R` is finite if it is
-locally finite at every maximal ideal. -/
+/-- A module `M` over a semilocal ring `R` is finite if its
+  localization at every maximal ideal is finite. -/
 theorem Module.Finite.of_isLocalized_maximal
     (H : ∀ (P : Ideal R) [P.IsMaximal], Module.Finite (Rₚ P) (Mₚ P)) :
     Module.Finite R M := by
@@ -62,13 +61,13 @@ theorem Module.Finite.of_isLocalized_maximal
   exact Submodule.subset_span ⟨_, by simpa using ⟨_, _, x.2, rfl⟩, rfl⟩
 
 variable {M} in
-/-- A submodule `N` of a module `M` over a semilocal ring `R` is finitely generated if it is
-locally finitely generated at every maximal ideal. -/
+/-- A submodule `N` of a module `M` over a semilocal ring `R` is finitely generated if its
+localization at every maximal ideal is finitely generated. -/
 theorem Submodule.fg_of_isLocalized_maximal (N : Submodule R M)
     (H : ∀ (P : Ideal R) [P.IsMaximal], (Submodule.localized' (Rₚ P) P.primeCompl (f P) N).FG) :
     N.FG := by
   simp_rw [← Module.Finite.iff_fg] at ⊢ H
-  exact .of_isLocalized_maximal  _ _ _ (fun P ↦ N.toLocalized' (Rₚ P) P.primeCompl (f P)) H
+  exact .of_isLocalized_maximal _ _ _ (fun P ↦ N.toLocalized' (Rₚ P) P.primeCompl (f P)) H
 
 end isLocalized_maximal
 
@@ -82,19 +81,20 @@ theorem Module.Finite.of_localized_maximal
 
 variable {M} in
 theorem Submodule.fg_of_localized_maximal (N : Submodule R M)
-    (H : ∀ (P : Ideal R) [P.IsMaximal], (Submodule.localized (P.primeCompl) N).FG) :
+    (H : ∀ (P : Ideal R) [P.IsMaximal], (N.localized (P.primeCompl)).FG) :
     N.FG := N.fg_of_isLocalized_maximal _ _ _ H
 
 end localized_maximal
 
 section IsLocalization
 
-/-- A semilocal ring `R` is Noetherian if it is locally Noetherian at every maximal ideal. -/
+/-- A semilocal ring `R` is Noetherian if its
+localization at every maximal ideal is a Noetherian ring. -/
 theorem IsNoetherianRing.of_isLocalization_maximal
     (H : ∀ (P : Ideal R) [P.IsMaximal], IsNoetherianRing (Rₚ P)) :
     IsNoetherianRing R where
   noetherian N := Submodule.fg_of_isLocalized_maximal
-    Rₚ Rₚ (fun P _ => Algebra.linearMap R (Rₚ P)) N (fun _ _ => IsNoetherian.noetherian _)
+    Rₚ Rₚ (fun P _ => Algebra.linearMap R (Rₚ P)) N fun _ _ => IsNoetherian.noetherian _
 
 end IsLocalization
 
@@ -119,8 +119,8 @@ theorem isPrincipalIdealRing_of_isPrincipalIdealRing_isLocalization [IsDomain R]
   have : IsNoetherianRing R :=
     IsNoetherianRing.of_isLocalization_maximal Rₚ (fun P _ => inferInstance)
   have : IsIntegrallyClosed R := by
-    refine IsIntegrallyClosed.of_isLocalization_maximal Rₚ (fun P _ => ?_)
-    have := hpid P
+    refine IsIntegrallyClosed.of_isLocalization_maximal Rₚ (fun P hP => ?_)
+
     sorry
   have : Ring.KrullDimLE 1 R :=
     Ring.krullDimLE_of_isLocalization_maximal Rₚ (fun P _ => inferInstance)
@@ -134,3 +134,5 @@ theorem isPrincipalIdealRing_of_isPrincipalIdealRing_isLocalization [IsDomain R]
 end IsLocalization
 
 end CommRing
+
+#min_imports

--- a/Mathlib/RingTheory/LocalProperties/Semilocal.lean
+++ b/Mathlib/RingTheory/LocalProperties/Semilocal.lean
@@ -18,7 +18,7 @@ finitely many maximal ideals).
   localization at every maximal ideal is finite.
 * `IsNoetherianRing.of_isLocalization_maximal`: A semilocal ring `R` is Noetherian if its
   localization at every maximal ideal is a Noetherian ring.
-* `isPrincipalIdealRing_of_isPrincipalIdealRing_localization`: A semilocal integral domain `A` is a
+* `isPrincipalIdealRing_of_isPrincipalIdealRing_isLocalization`: A semilocal integral domain `A` is a
   PID if its localization at every maximal ideal is a PID.
 -/
 

--- a/Mathlib/RingTheory/LocalProperties/Semilocal.lean
+++ b/Mathlib/RingTheory/LocalProperties/Semilocal.lean
@@ -43,8 +43,8 @@ variable
 section isLocalized_maximal
 
 include f in
-/-- A module `M` over a semilocal ring `R` is finite if its
-  localization at every maximal ideal is finite. -/
+/-- A module `M` over a semilocal ring `R` is finite if
+its localization at every maximal ideal is finite. -/
 theorem Module.Finite.of_isLocalized_maximal
     (H : ∀ (P : Ideal R) [P.IsMaximal], Module.Finite (Rₚ P) (Mₚ P)) :
     Module.Finite R M := by
@@ -61,8 +61,8 @@ theorem Module.Finite.of_isLocalized_maximal
   exact Submodule.subset_span ⟨_, by simpa using ⟨_, _, x.2, rfl⟩, rfl⟩
 
 variable {M} in
-/-- A submodule `N` of a module `M` over a semilocal ring `R` is finitely generated if its
-localization at every maximal ideal is finitely generated. -/
+/-- A submodule `N` of a module `M` over a semilocal ring `R` is finitely generated if
+its localization at every maximal ideal is finitely generated. -/
 theorem Submodule.fg_of_isLocalized_maximal (N : Submodule R M)
     (H : ∀ (P : Ideal R) [P.IsMaximal], (Submodule.localized' (Rₚ P) P.primeCompl (f P) N).FG) :
     N.FG := by
@@ -88,8 +88,8 @@ end localized_maximal
 
 section IsLocalization
 
-/-- A semilocal ring `R` is Noetherian if its
-localization at every maximal ideal is a Noetherian ring. -/
+/-- A semilocal ring `R` is Noetherian if
+its localization at every maximal ideal is a Noetherian ring. -/
 theorem IsNoetherianRing.of_isLocalization_maximal
     (H : ∀ (P : Ideal R) [P.IsMaximal], IsNoetherianRing (Rₚ P)) :
     IsNoetherianRing R where
@@ -111,8 +111,7 @@ variable
   [∀ (P : Ideal R) [P.IsMaximal], Algebra R (Rₚ P)]
   [∀ (P : Ideal R) [P.IsMaximal], IsLocalization.AtPrime (Rₚ P) P]
 
-/-- If a semilocal integral domain `R` is a PID at all of its maximal ideals, then it is a PID.
-This is the `IsLocalization` version. -/
+/-- A semilocal integral domain `A` is a PID if its localization at every maximal ideal is a PID. -/
 theorem isPrincipalIdealRing_of_isPrincipalIdealRing_isLocalization [IsDomain R]
     (hpid : ∀ (P : Ideal R) [P.IsMaximal], IsPrincipalIdealRing (Rₚ P)) :
     IsPrincipalIdealRing R := by

--- a/Mathlib/RingTheory/LocalProperties/Semilocal.lean
+++ b/Mathlib/RingTheory/LocalProperties/Semilocal.lean
@@ -134,5 +134,3 @@ theorem isPrincipalIdealRing_of_isPrincipalIdealRing_isLocalization [IsDomain R]
 end IsLocalization
 
 end CommRing
-
-#min_imports

--- a/Mathlib/RingTheory/LocalProperties/Semilocal.lean
+++ b/Mathlib/RingTheory/LocalProperties/Semilocal.lean
@@ -119,7 +119,7 @@ theorem isPrincipalIdealRing_of_isPrincipalIdealRing_isLocalization_maximal [IsD
     IsNoetherianRing.of_isLocalization_maximal Rₚ fun P _ => inferInstance
   have : IsIntegrallyClosed R := by
     refine IsIntegrallyClosed.of_isLocalization_maximal Rₚ fun P hP => ?_
-    have : IsDomain (Rₚ P) := IsLocalization.isDomain_of_isLocalization_atPrime (Rₚ P) P
+    have : IsDomain (Rₚ P) := IsLocalization.isDomain_of_atPrime (Rₚ P) P
     infer_instance
   have : Ring.KrullDimLE 1 R :=
     Ring.krullDimLE_of_isLocalization_maximal Rₚ fun P _ => inferInstance

--- a/Mathlib/RingTheory/Localization/AtPrime/Basic.lean
+++ b/Mathlib/RingTheory/Localization/AtPrime/Basic.lean
@@ -123,6 +123,11 @@ instance isDomain_of_local_atPrime {P : Ideal A} (_ : P.IsPrime) :
     IsDomain (Localization.AtPrime P) :=
   isDomain_localization P.primeCompl_le_nonZeroDivisors
 
+/-- This is a `IsLocalization.AtPrime` version for `IsLocalization.isDomain_of_local_atPrime`. -/
+theorem isDomain_of_isLocalization_atPrime (S : Type*) [CommSemiring S] [Algebra A S]
+    (P : Ideal A) [P.IsPrime] [IsLocalization.AtPrime S P] : IsDomain S :=
+  isDomain_of_le_nonZeroDivisors S P.primeCompl_le_nonZeroDivisors
+
 namespace AtPrime
 
 variable (I : Ideal R) [hI : I.IsPrime] [IsLocalization.AtPrime S I]

--- a/Mathlib/RingTheory/Localization/AtPrime/Basic.lean
+++ b/Mathlib/RingTheory/Localization/AtPrime/Basic.lean
@@ -123,7 +123,7 @@ instance isDomain_of_local_atPrime {P : Ideal A} (_ : P.IsPrime) :
     IsDomain (Localization.AtPrime P) :=
   isDomain_localization P.primeCompl_le_nonZeroDivisors
 
-/-- This is a `IsLocalization.AtPrime` version for `IsLocalization.isDomain_of_local_atPrime`. -/
+/-- This is an `IsLocalization.AtPrime` version for `IsLocalization.isDomain_of_local_atPrime`. -/
 theorem isDomain_of_isLocalization_atPrime (S : Type*) [CommSemiring S] [Algebra A S]
     (P : Ideal A) [P.IsPrime] [IsLocalization.AtPrime S P] : IsDomain S :=
   isDomain_of_le_nonZeroDivisors S P.primeCompl_le_nonZeroDivisors

--- a/Mathlib/RingTheory/Localization/AtPrime/Basic.lean
+++ b/Mathlib/RingTheory/Localization/AtPrime/Basic.lean
@@ -124,7 +124,7 @@ instance isDomain_of_local_atPrime {P : Ideal A} (_ : P.IsPrime) :
   isDomain_localization P.primeCompl_le_nonZeroDivisors
 
 /-- This is an `IsLocalization.AtPrime` version for `IsLocalization.isDomain_of_local_atPrime`. -/
-theorem isDomain_of_isLocalization_atPrime (S : Type*) [CommSemiring S] [Algebra A S]
+theorem isDomain_of_atPrime (S : Type*) [CommSemiring S] [Algebra A S]
     (P : Ideal A) [P.IsPrime] [IsLocalization.AtPrime S P] : IsDomain S :=
   isDomain_of_le_nonZeroDivisors S P.primeCompl_le_nonZeroDivisors
 


### PR DESCRIPTION
Proves local properties of semilocal rings, which wiil be used in Iwasawa theory. For a natural language proof, see [lean-iwasawa](https://acmepjz.github.io/lean-iwasawa/blueprint/sect0002.html#a0000000013) (slightly different from this PR).
> 
> > 
> [![Open in Gitpod](https://camo.githubusercontent.com/b04f5659467d23b5109ba935a40c00decd264eea25c22d50a118021349eea94f/68747470733a2f2f676974706f642e696f2f627574746f6e2f6f70656e2d696e2d676974706f642e737667)](https://gitpod.io/from-referrer/)
