### PR TITLE
feat(CategoryTheory/MarkovCategory): add basic finite stochastic matrices definitions to Markov category

### DIFF
--- a/Mathlib.lean
+++ b/Mathlib.lean
@@ -2531,6 +2531,8 @@ import Mathlib.CategoryTheory.Localization.StructuredArrow
 import Mathlib.CategoryTheory.Localization.Triangulated
 import Mathlib.CategoryTheory.Localization.Trifunctor
 import Mathlib.CategoryTheory.LocallyDirected
+import Mathlib.CategoryTheory.MarkovCategory.Basic
+import Mathlib.CategoryTheory.MarkovCategory.Cartesian
 import Mathlib.CategoryTheory.Monad.Adjunction
 import Mathlib.CategoryTheory.Monad.Algebra
 import Mathlib.CategoryTheory.Monad.Basic

--- a/Mathlib.lean
+++ b/Mathlib.lean
@@ -2184,6 +2184,8 @@ import Mathlib.CategoryTheory.ConcreteCategory.ReflectsIso
 import Mathlib.CategoryTheory.ConcreteCategory.UnbundledHom
 import Mathlib.CategoryTheory.Conj
 import Mathlib.CategoryTheory.ConnectedComponents
+import Mathlib.CategoryTheory.CopyDiscardCategory.Basic
+import Mathlib.CategoryTheory.CopyDiscardCategory.Deterministic
 import Mathlib.CategoryTheory.Core
 import Mathlib.CategoryTheory.Countable
 import Mathlib.CategoryTheory.Dialectica.Basic

--- a/Mathlib/CategoryTheory/CopyDiscardCategory/Basic.lean
+++ b/Mathlib/CategoryTheory/CopyDiscardCategory/Basic.lean
@@ -1,0 +1,65 @@
+/-
+Copyright (c) 2025 Jacob Reinhold. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Jacob Reinhold
+-/
+import Mathlib.CategoryTheory.Monoidal.Comon_
+
+/-!
+# Copy-Discard Categories
+
+Symmetric monoidal categories where every object has commutative
+comonoid structure compatible with tensor products.
+
+## Main definitions
+
+* `CopyDiscardCategory` - Category with coherent copy and delete
+
+## Notations
+
+* `Δ[X]` - Copy morphism for X (from ComonObj)
+* `ε[X]` - Delete morphism for X (from ComonObj)
+
+## Implementation notes
+
+We use CommComonObj instances to provide the comonoid structure.
+The key axioms ensure tensor products respect the comonoid structure.
+
+## References
+
+* [Cho and Jacobs, *Disintegration and Bayesian inversion via string diagrams*][cho_jacobs_2019]
+* [Fritz, *A synthetic approach to Markov kernels, conditional independence
+  and theorems on sufficient statistics*][fritz2020]
+
+## Tags
+
+copy-discard, comonoid, symmetric monoidal
+-/
+
+universe v u
+
+namespace CategoryTheory
+
+open MonoidalCategory ComonObj
+
+variable {C : Type u} [Category.{v} C] [MonoidalCategory.{v} C]
+
+/-- Category where objects have compatible copy and discard operations. -/
+class CopyDiscardCategory (C : Type u) [Category.{v} C] [MonoidalCategory.{v} C]
+    extends SymmetricCategory C where
+  /-- Every object has commutative comonoid structure. -/
+  [comon_obj : (X : C) → ComonObj X]
+  /-- Every object's comonoid structure is commutative. -/
+  [comm_obj : (X : C) → IsCommComonObj X]
+  /-- Tensor products of copies equal copies of tensor products. -/
+  copy_tensor (X Y : C) : Δ[X ⊗ Y] = (Δ[X] ⊗ₘ Δ[Y]) ≫ tensorμ X X Y Y := by cat_disch
+  /-- Discard distributes over tensor. -/
+  discard_tensor (X Y : C) : ε[X ⊗ Y] = (ε[X] ⊗ₘ ε[Y]) ≫ (λ_ (𝟙_ C)).hom := by cat_disch
+    /-- Copy on the unit object. -/
+  copy_unit : Δ[𝟙_ C] = (λ_ (𝟙_ C)).inv := by cat_disch
+    /-- Discard on the unit object. -/
+  discard_unit : ε[𝟙_ C] = 𝟙 (𝟙_ C) := by cat_disch
+
+attribute [instance] CopyDiscardCategory.comon_obj CopyDiscardCategory.comm_obj
+
+end CategoryTheory

--- a/Mathlib/CategoryTheory/CopyDiscardCategory/Deterministic.lean
+++ b/Mathlib/CategoryTheory/CopyDiscardCategory/Deterministic.lean
@@ -1,0 +1,60 @@
+/-
+Copyright (c) 2025 Jacob Reinhold. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Jacob Reinhold
+-/
+import Mathlib.CategoryTheory.CopyDiscardCategory.Basic
+
+/-!
+# Deterministic Morphisms in Copy-Discard Categories
+
+Morphisms that preserve the copy operation perfectly.
+
+A morphism `f : X → Y` is deterministic if copying then applying `f` to both copies equals applying
+`f` then copying: `f ≫ Δ[Y] = Δ[X] ≫ (f ⊗ f)`.
+
+In probabilistic settings, these are morphisms without randomness. In cartesian categories, all
+morphisms are deterministic.
+
+## Main definitions
+
+* `Deterministic` - Type class for morphisms that preserve copying
+
+## Main results
+
+* Identity morphisms are deterministic
+* Composition of deterministic morphisms is deterministic
+
+## Tags
+
+deterministic, copy-discard category, comonoid morphism
+-/
+
+universe v u
+
+namespace CategoryTheory
+
+open MonoidalCategory ComonObj
+
+variable {C : Type u} [Category.{v} C] [MonoidalCategory.{v} C] [CopyDiscardCategory.{v} C]
+
+/-- A morphism is deterministic if it preserves the comonoid structure.
+
+In probabilistic contexts, these are morphisms without randomness. -/
+abbrev Deterministic {X Y : C} (f : X ⟶ Y) := IsComonHom f
+
+namespace Deterministic
+
+variable {X Y Z : C}
+
+/-- Deterministic morphisms commute with copying. -/
+lemma copy_natural {f : X ⟶ Y} [Deterministic f] : f ≫ Δ[Y] = Δ[X] ≫ (f ⊗ₘ f) :=
+  IsComonHom.hom_comul f
+
+/-- Deterministic morphisms commute with discarding. -/
+lemma discard_natural {f : X ⟶ Y} [Deterministic f] : f ≫ ε[Y] = ε[X] :=
+  IsComonHom.hom_counit f
+
+end Deterministic
+
+end CategoryTheory

--- a/Mathlib/CategoryTheory/MarkovCategory/Basic.lean
+++ b/Mathlib/CategoryTheory/MarkovCategory/Basic.lean
@@ -1,0 +1,77 @@
+/-
+Copyright (c) 2025 Jacob Reinhold. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Jacob Reinhold
+-/
+import Mathlib.CategoryTheory.CopyDiscardCategory.Basic
+import Mathlib.CategoryTheory.Limits.Shapes.IsTerminal
+
+/-!
+# Markov Categories
+
+Copy-discard categories where deletion is natural for all morphisms.
+
+## Main definitions
+
+* `MarkovCategory` - Copy-discard category with natural deletion
+
+## Main results
+
+* `unit_terminal` - The monoidal unit is terminal
+
+## Implementation notes
+
+Natural deletion forces probabilistic interpretation: morphisms preserve normalization. The unit
+being terminal follows from naturality of deletion.
+
+## References
+
+* [Cho and Jacobs, *Disintegration and Bayesian inversion via string diagrams*][cho_jacobs_2019]
+* [Fritz, *A synthetic approach to Markov kernels, conditional independence
+  and theorems on sufficient statistics*][fritz2020]
+
+## Tags
+
+Markov category, probability, categorical probability
+-/
+
+namespace CategoryTheory
+
+open MonoidalCategory CopyDiscardCategory ComonObj Limits
+
+variable {C : Type*} [Category C] [MonoidalCategory C]
+
+/-- Copy-discard category where discard is natural. -/
+class MarkovCategory (C : Type*) [Category C] [MonoidalCategory C]
+    extends CopyDiscardCategory C where
+  /-- Process then discard equals delete directly. -/
+  discard_natural {X Y : C} (f : X ⟶ Y) : f ≫ ε[Y] = ε[X]
+
+namespace MarkovCategory
+
+variable [MarkovCategory C]
+
+/-- Natural discard as simp lemma. -/
+@[simp]
+lemma discard_natural_simp {X Y : C} (f : X ⟶ Y) : f ≫ ε[Y] = ε[X] :=
+  discard_natural f
+
+/-- The monoidal unit is terminal. -/
+theorem unit_terminal (X : C) (f : X ⟶ 𝟙_ C) : f = ε[X] := by
+  calc f = f ≫ 𝟙 (𝟙_ C) := (Category.comp_id _).symm
+       _ = f ≫ ε[𝟙_ C] := by rw [← CopyDiscardCategory.discard_unit]
+       _ = ε[X] := discard_natural f
+
+/-- The monoidal unit is a terminal object. -/
+def unit_isTerminal : IsTerminal (𝟙_ C : C) where
+  lift := fun s => ε[s.pt] -- The unique morphism to 𝟙_ C is the counit
+  fac := fun _ j => PEmpty.elim j.as -- Vacuous: no objects in empty diagram
+  uniq := fun s m _ => (unit_terminal s.pt m) -- Uniqueness by unit_terminal
+
+/-- Morphisms between terminal objects are unique. -/
+lemma terminal_unique (f : (𝟙_ C) ⟶ (𝟙_ C)) : f = 𝟙 (𝟙_ C) := by
+  rw [unit_terminal (𝟙_ C) f, CopyDiscardCategory.discard_unit]
+
+end MarkovCategory
+
+end CategoryTheory

--- a/Mathlib/CategoryTheory/MarkovCategory/Cartesian.lean
+++ b/Mathlib/CategoryTheory/MarkovCategory/Cartesian.lean
@@ -1,0 +1,110 @@
+/-
+Copyright (c) 2025 Jacob Reinhold. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Jacob Reinhold
+-/
+import Mathlib.CategoryTheory.MarkovCategory.Basic
+import Mathlib.CategoryTheory.Monoidal.Cartesian.Basic
+import Mathlib.CategoryTheory.Monoidal.Braided.Basic
+
+/-!
+# Cartesian Categories as Markov Categories
+
+Every cartesian monoidal category is a Markov category where:
+- Copy is the diagonal map
+- Discard is the unique map to terminal
+
+## Main results
+
+* Cartesian categories satisfy CopyDiscardCategory
+* Cartesian categories satisfy MarkovCategory
+* All morphisms are deterministic in cartesian categories
+
+## Tags
+
+cartesian, Markov category, deterministic
+-/
+
+namespace CategoryTheory
+
+open MonoidalCategory CartesianMonoidalCategory ComonObj CommComonObj
+
+variable {C : Type*} [Category C] [CartesianMonoidalCategory C]
+
+namespace CartesianMarkov
+
+/-- The diagonal morphism as copy operation. -/
+def diag (X : C) : X ⟶ X ⊗ X := lift (𝟙 X) (𝟙 X)
+
+/-- The swap morphism for products. -/
+def swap (X Y : C) : X ⊗ Y ⟶ Y ⊗ X := lift (snd X Y) (fst X Y)
+
+end CartesianMarkov
+
+open CartesianMarkov
+
+/-- The braiding for cartesian categories. -/
+instance : BraidedCategory C where
+  braiding X Y := ⟨swap X Y, swap Y X, by ext <;> simp [swap], by ext <;> simp [swap]⟩
+  braiding_naturality_left := by intros; ext <;> simp [swap]
+  braiding_naturality_right := by intros; ext <;> simp [swap]
+  hexagon_forward := by intros; ext <;> simp [swap]
+  hexagon_reverse := by intros; ext <;> simp [swap]
+
+/-- Cartesian categories are symmetric. -/
+instance : SymmetricCategory C where
+  symmetry X Y := by ext <;> simp
+
+namespace CartesianMarkov
+
+/-- Cartesian categories have comonoid structure on every object. -/
+instance instComonObj (X : C) : ComonObj X where
+  comul := diag X
+  counit := toUnit X
+  counit_comul := by ext; simp [diag]
+  comul_counit := by ext; simp [diag]
+  comul_assoc := by ext <;> simp [diag]
+
+/-- The comonoid structure in cartesian categories is commutative. -/
+instance instCommComonObj (X : C) : CommComonObj X where
+  isComm := by ext <;> simp [ComonObj.comul, diag]
+
+/-- Tensor coherence for copy in cartesian categories. -/
+lemma diag_tensor (X Y : C) :
+    Δ[X ⊗ Y] = (Δ[X] ⊗ₘ Δ[Y]) ≫ tensorμ X X Y Y := by
+  ext <;> simp
+
+/-- Tensor coherence for discard in cartesian categories. -/
+lemma toUnit_tensor (X Y : C) : ε[X ⊗ Y] = (ε[X] ⊗ₘ ε[Y]) ≫ (λ_ (𝟙_ C)).hom := by ext
+
+/-- Copy on unit is the left unitor inverse. -/
+lemma diag_unit : Δ[𝟙_ C] = (λ_ (𝟙_ C)).inv := by ext
+
+/-- Discard on unit is the identity. -/
+lemma toUnit_unit : ε[𝟙_ C] = 𝟙 (𝟙_ C) := by ext
+
+end CartesianMarkov
+
+open scoped ComonObj
+
+/-- Cartesian categories have copy-discard structure. -/
+instance : CopyDiscardCategory C where
+  commComonObj := inferInstance  -- This should find instCommComonObj X
+  copy_tensor := CartesianMarkov.diag_tensor
+  discard_tensor := CartesianMarkov.toUnit_tensor
+  copy_unit := CartesianMarkov.diag_unit
+  discard_unit := CartesianMarkov.toUnit_unit
+
+/-- Cartesian categories are Markov. -/
+instance : MarkovCategory C where
+  discard_natural {X Y} (f : X ⟶ Y) := by simp [ComonObj.counit]
+
+namespace CartesianMarkov
+
+/-- In cartesian categories, all morphisms preserve copy. -/
+lemma deterministic {X Y : C} (f : X ⟶ Y) : f ≫ Δ[Y] = Δ[X] ≫ (f ⊗ₘ f) := by
+  ext <;> simp [ComonObj.comul, diag]
+
+end CartesianMarkov
+
+end CategoryTheory

--- a/Mathlib/CategoryTheory/MarkovCategory/FinStoch/Basic.lean
+++ b/Mathlib/CategoryTheory/MarkovCategory/FinStoch/Basic.lean
@@ -1,0 +1,595 @@
+/-
+Copyright (c) 2025 Jacob Reinhold. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Jacob Reinhold
+-/
+import Mathlib.CategoryTheory.Category.Basic
+import Mathlib.Data.Fintype.Basic
+import Mathlib.Logic.Equiv.Basic
+import Mathlib.Data.Fintype.Prod
+import Mathlib.Data.NNReal.Defs
+import Mathlib.LinearAlgebra.Matrix.Defs
+import Mathlib.Algebra.BigOperators.Ring.Finset
+import Mathlib.Algebra.Order.BigOperators.Group.Finset
+
+/-!
+# Finite Stochastic Matrices
+
+FinStoch: finite types with stochastic matrices.
+
+## Main definitions
+
+* `StochasticMatrix m n` - Matrix where rows sum to 1
+* `FinStoch` - Category of finite types and stochastic matrices
+* `DetMorphism m n` - Deterministic matrix with underlying function
+* `isDeterministic` - Matrix has exactly one 1 per row
+
+## Design
+
+Rows sum to 1. Entry (i,j) gives P(j|i).
+Uses NNReal to avoid negativity.
+
+## References
+
+* [Fritz, *A synthetic approach to Markov kernels, conditional independence
+  and theorems on sufficient statistics*][fritz2020]
+
+## Tags
+
+Markov category, stochastic matrix
+-/
+
+namespace CategoryTheory.MarkovCategory
+
+universe u
+
+/-- Stochastic matrix where rows sum to 1. Entry (i,j) is P(j|i). -/
+structure StochasticMatrix (m n : Type u) [Fintype m] [Fintype n] where
+  /-- The matrix of non-negative reals -/
+  toMatrix : Matrix m n NNReal
+  /-- Each row sums to 1 -/
+  row_sum : ∀ i : m, ∑ j : n, toMatrix i j = 1
+
+namespace StochasticMatrix
+
+variable {m n p : Type u} [Fintype m] [Fintype n] [Fintype p]
+
+/-- Identity matrix. -/
+def id (m : Type u) [Fintype m] [DecidableEq m] : StochasticMatrix m m where
+  toMatrix := fun i j => if i = j then (1 : NNReal) else 0
+  row_sum := fun i => by
+    -- Exactly one 1 in row i (at position i), all others are 0
+    rw [Finset.sum_eq_single i]
+    · simp
+    · intro j _ hj
+      simp only [if_neg (Ne.symm hj)]
+    · intro h
+      exfalso
+      exact h (Finset.mem_univ _)
+
+/-- Composition: P(Z|X) = ∑_Y P(Y|X) * P(Z|Y). -/
+def comp (f : StochasticMatrix m n) (g : StochasticMatrix n p) : StochasticMatrix m p where
+  toMatrix := fun i k => ∑ j : n, f.toMatrix i j * g.toMatrix j k
+  row_sum := fun i => by
+    -- ∑_k ∑_j f(i,j)*g(j,k) = ∑_j f(i,j) * ∑_k g(j,k) = ∑_j f(i,j) * 1 = 1
+    rw [Finset.sum_comm]
+    simp [← Finset.mul_sum, g.row_sum, f.row_sum]
+
+/-- Tensor product for independent processes. -/
+def tensor {m₁ n₁ m₂ n₂ : Type u} [Fintype m₁] [Fintype n₁] [Fintype m₂] [Fintype n₂]
+    (f : StochasticMatrix m₁ n₁) (g : StochasticMatrix m₂ n₂) :
+    StochasticMatrix (m₁ × m₂) (n₁ × n₂) where
+  toMatrix := fun ij kl => f.toMatrix ij.1 kl.1 * g.toMatrix ij.2 kl.2
+  row_sum := fun ij => by
+    obtain ⟨i₁, i₂⟩ := ij
+    -- Independence: P(k₁,k₂|i₁,i₂) = P(k₁|i₁) * P(k₂|i₂)
+    -- So ∑_(k₁,k₂) P(k₁|i₁)*P(k₂|i₂) = (∑_k₁ P(k₁|i₁)) * (∑_k₂ P(k₂|i₂)) = 1 * 1
+    rw [← Finset.univ_product_univ, Finset.sum_product, ← Finset.sum_mul_sum]
+    simp [f.row_sum i₁, g.row_sum i₂]
+
+@[ext]
+theorem ext {f g : StochasticMatrix m n} (h : f.toMatrix = g.toMatrix) : f = g := by
+  cases f
+  cases g
+  congr
+
+/-! ### Deterministic matrices -/
+
+/-- Each row has exactly one 1. -/
+def isDeterministic (f : StochasticMatrix m n) : Prop :=
+  ∀ i : m, ∃! j : n, f.toMatrix i j = 1
+
+/-- Extract function from deterministic matrix. -/
+noncomputable def apply (f : StochasticMatrix m n)
+    (h : f.isDeterministic) (i : m) : n :=
+  (h i).choose
+
+/-- Apply gives the unique 1. -/
+lemma apply_spec (f : StochasticMatrix m n) (h : f.isDeterministic) (i : m) :
+    f.toMatrix i (f.apply h i) = 1 :=
+  (h i).choose_spec.1
+
+/-- Non-chosen outputs are 0. -/
+lemma apply_spec_ne (f : StochasticMatrix m n) [DecidableEq n] (h : f.isDeterministic) (i : m)
+    (j : n) (hj : j ≠ f.apply h i) : f.toMatrix i j = 0 := by
+  by_contra h_nonzero
+  push_neg at h_nonzero
+  have h_sum := f.row_sum i
+  have h_unique := (h i).choose_spec.2
+  by_cases h_one : f.toMatrix i j = 1
+  · -- If f(i,j) = 1, then j must be the unique choice
+    exact hj (h_unique j h_one)
+  · -- Key insight: row has exactly one 1, everything else is 0
+    have h_apply_one := apply_spec f h i
+    have h_sum_eq : ∑ k : n, f.toMatrix i k = 1 := f.row_sum i
+    -- Split sum into the chosen entry plus all others
+    have h_split : ∑ k : n, f.toMatrix i k =
+        f.toMatrix i (f.apply h i) + ∑ k ∈ Finset.univ.erase (f.apply h i), f.toMatrix i k := by
+      rw [← Finset.sum_erase_add _ _ (Finset.mem_univ (f.apply h i))]
+      ring
+    rw [h_split] at h_sum_eq
+    rw [h_apply_one] at h_sum_eq
+    -- Since 1 + rest = 1, we get rest = 0
+    have h_others_zero : ∑ k ∈ Finset.univ.erase (f.apply h i), f.toMatrix i k = 0 := by
+      grind only
+    -- Non-negative reals summing to 0 means each is 0
+    have h_all_zero : ∀ k ∈ Finset.univ.erase (f.apply h i), f.toMatrix i k = 0 := by
+      have h_nonneg : ∀ k ∈ Finset.univ.erase (f.apply h i), 0 ≤ f.toMatrix i k := by
+        intro k _
+        exact (f.toMatrix i k).2
+      exact Finset.sum_eq_zero_iff_of_nonneg h_nonneg |>.mp h_others_zero
+    have h_j_in : j ∈ Finset.univ.erase (f.apply h i) := by
+      simp [hj]
+    exact h_nonzero (h_all_zero j h_j_in)
+
+/-- Matrix entry is 1 iff it's the unique output. -/
+@[simp]
+lemma det_matrix_eq_one_iff (f : StochasticMatrix m n) (h : f.isDeterministic)
+    (i : m) (j : n) : f.toMatrix i j = 1 ↔ j = f.apply h i := by
+  constructor
+  · intro hj
+    exact (h i).choose_spec.2 j hj
+  · intro hj
+    rw [hj]
+    exact apply_spec f h i
+
+/-- All other entries are 0. -/
+@[simp]
+lemma det_matrix_eq_zero_of_ne (f : StochasticMatrix m n) [DecidableEq n] (h : f.isDeterministic)
+    (i : m) (j : n) (hne : j ≠ f.apply h i) : f.toMatrix i j = 0 :=
+  apply_spec_ne f h i j hne
+
+/-- Identity matrix is deterministic. -/
+lemma id_isDeterministic (m : Type u) [Fintype m] [DecidableEq m] :
+    (id m).isDeterministic := by
+  intro i
+  use i
+  constructor
+  · simp [id]
+  · intro j hj
+    simp [id] at hj
+    exact hj.symm
+
+/-- Deterministic matrices compose to deterministic matrices. -/
+theorem det_comp_det (f : StochasticMatrix m n) (g : StochasticMatrix n p)
+    [DecidableEq n] (hf : f.isDeterministic) (hg : g.isDeterministic) :
+    (comp f g).isDeterministic := by
+  intro i
+  -- The composition follows the unique path i → f(i) → g(f(i))
+  use g.apply hg (f.apply hf i)
+  constructor
+  · simp only [comp]
+    -- Only the j = f(i) term is non-zero in the sum
+    rw [Finset.sum_eq_single (f.apply hf i)]
+    · simp [apply_spec f hf i, apply_spec g hg (f.apply hf i)]
+    · intro j _ hj
+      simp [apply_spec_ne f hf i j hj]
+    · intro h; exfalso; exact h (Finset.mem_univ _)
+  · intro k hk
+    simp only [comp] at hk
+    -- Product f(i,j) * g(j,k) equals 1 only when both are 1
+    have h_exist : ∃ j : n, f.toMatrix i j = 1 ∧ g.toMatrix j k = 1 := by
+      by_contra h_none
+      push_neg at h_none
+      -- Since f is deterministic, the sum collapses to g(f(i), k)
+      have h_sum_simp : ∑ j : n, f.toMatrix i j * g.toMatrix j k = g.toMatrix (f.apply hf i) k := by
+        rw [Finset.sum_eq_single (f.apply hf i)]
+        · simp [apply_spec f hf i]
+        · intro j _ hj
+          simp [apply_spec_ne f hf i j hj]
+        · intro h; exfalso; exact h (Finset.mem_univ _)
+      rw [h_sum_simp] at hk
+      have : g.toMatrix (f.apply hf i) k ≠ 1 := h_none _ (apply_spec f hf i)
+      exact this hk
+    obtain ⟨j, hf_j, hg_j⟩ := h_exist
+    -- Since f is deterministic, j must be f(i)
+    have h_j_unique : j = f.apply hf i := (hf i).choose_spec.2 j hf_j
+    rw [h_j_unique] at hg_j
+    -- Since g is deterministic, k must be g(f(i))
+    exact (hg (f.apply hf i)).choose_spec.2 k hg_j
+
+/-- Composition of deterministic matrices equals function composition. -/
+theorem det_comp_eq_fun_comp (f : StochasticMatrix m n) (g : StochasticMatrix n p)
+    [DecidableEq n] (hf : f.isDeterministic) (hg : g.isDeterministic) (i : m) :
+    (comp f g).apply (det_comp_det f g hf hg) i = g.apply hg (f.apply hf i) := by
+  -- By det_comp_det, the unique 1 in row i of comp f g is at column g.apply hg (f.apply hf i)
+  -- The apply function returns this unique column
+  have h_unique := (det_comp_det f g hf hg i).choose_spec
+  -- We know comp f g has value 1 at g.apply hg (f.apply hf i)
+  have h_one : (comp f g).toMatrix i (g.apply hg (f.apply hf i)) = 1 := by
+    simp only [comp]
+    rw [Finset.sum_eq_single (f.apply hf i)]
+    · simp [apply_spec f hf i, apply_spec g hg (f.apply hf i)]
+    · intro j _ hj
+      simp [apply_spec_ne f hf i j hj]
+    · intro h; exfalso; exact h (Finset.mem_univ _)
+  -- By uniqueness, apply must return this value
+  have h_eq := h_unique.2 _ h_one
+  exact h_eq.symm
+
+/-! ### Helper lemmas for sums -/
+
+/-- Sum of delta function equals 1 at unique point. -/
+lemma sum_delta {α : Type*} [Fintype α] [DecidableEq α] (a : α) :
+    ∑ x : α, (if x = a then (1 : NNReal) else 0) = 1 := by
+  -- Only the x = a term contributes 1, all others are 0
+  rw [Finset.sum_eq_single a]
+  · simp
+  · intro b _ hb; simp [hb]
+  · intro h; exfalso; exact h (Finset.mem_univ _)
+
+/-- Product of delta functions. -/
+lemma delta_mul_delta {α β : Type*} [DecidableEq α] [DecidableEq β]
+    (a a' : α) (b b' : β) :
+    (if a = a' then (1 : NNReal) else 0) * (if b = b' then 1 else 0) =
+    if a = a' ∧ b = b' then 1 else 0 := by
+  by_cases ha : a = a'
+  · by_cases hb : b = b'
+    · simp [ha, hb]
+    · simp [ha, hb]
+  · simp [ha]
+
+/-! ### Extensionality lemmas for deterministic matrices -/
+
+/-- Tensor product of deterministic matrices is deterministic. -/
+theorem det_tensor_det {m₁ n₁ m₂ n₂ : Type u} [Fintype m₁] [Fintype n₁] [Fintype m₂] [Fintype n₂]
+    (f : StochasticMatrix m₁ n₁) (g : StochasticMatrix m₂ n₂)
+    [DecidableEq n₁]
+    (hf : f.isDeterministic) (hg : g.isDeterministic) :
+    (tensor f g).isDeterministic := by
+  intro ⟨i₁, i₂⟩
+  -- Tensor acts independently on each component
+  use (f.apply hf i₁, g.apply hg i₂)
+  constructor
+  · simp only [tensor]
+    rw [apply_spec f hf i₁, apply_spec g hg i₂]
+    simp
+  · intro ⟨j₁, j₂⟩ hj
+    simp only [tensor] at hj
+    have h_prod : f.toMatrix i₁ j₁ * g.toMatrix i₂ j₂ = 1 := hj
+    -- In NNReal, product = 1 iff both factors = 1
+    have h₁ : f.toMatrix i₁ j₁ = 1 := by
+      by_contra h_not_one
+      by_cases h_zero : f.toMatrix i₁ j₁ = 0
+      · rw [h_zero, zero_mul] at h_prod
+        simp at h_prod
+      · -- Deterministic means each entry is 0 or 1
+        by_cases h_eq : j₁ = f.apply hf i₁
+        · subst h_eq
+          exact absurd (apply_spec f hf i₁) h_not_one
+        · have := apply_spec_ne f hf i₁ j₁ h_eq
+          exact absurd this h_zero
+    have h₂ : g.toMatrix i₂ j₂ = 1 := by
+      rw [h₁, one_mul] at h_prod
+      exact h_prod
+    -- Uniqueness forces j₁ = f(i₁) and j₂ = g(i₂)
+    have hj₁ : j₁ = f.apply hf i₁ := (hf i₁).choose_spec.2 j₁ h₁
+    have hj₂ : j₂ = g.apply hg i₂ := (hg i₂).choose_spec.2 j₂ h₂
+    simp [hj₁, hj₂]
+
+/-- Apply function for tensor products of deterministic matrices. -/
+theorem apply_tensor {m₁ n₁ m₂ n₂ : Type u} [Fintype m₁] [Fintype n₁] [Fintype m₂] [Fintype n₂]
+    (f : StochasticMatrix m₁ n₁) (g : StochasticMatrix m₂ n₂)
+    [DecidableEq n₁]
+    (hf : f.isDeterministic) (hg : g.isDeterministic) (i₁ : m₁) (i₂ : m₂) :
+    (tensor f g).apply (det_tensor_det f g hf hg) (i₁, i₂) =
+    (f.apply hf i₁, g.apply hg i₂) := by
+  -- By uniqueness in the proof of det_tensor_det
+  have h := (det_tensor_det f g hf hg (i₁, i₂)).choose_spec
+  have h_val : (tensor f g).toMatrix (i₁, i₂) (f.apply hf i₁, g.apply hg i₂) = 1 := by
+    simp only [tensor]
+    rw [apply_spec f hf i₁, apply_spec g hg i₂]
+    simp
+  exact h.2 _ h_val |>.symm
+
+/-- Two deterministic matrices are equal if their apply functions agree. -/
+theorem ext_deterministic {m n : Type u} [Fintype m] [Fintype n] [DecidableEq n]
+    {f g : StochasticMatrix m n} (hf : f.isDeterministic) (hg : g.isDeterministic) :
+    f = g ↔ ∀ i, f.apply hf i = g.apply hg i := by
+  constructor
+  · intro h i
+    subst h
+    rfl
+  · intro h
+    ext i j
+    by_cases hj : j = f.apply hf i
+    · rw [hj, apply_spec f hf i]
+      have : g.apply hg i = f.apply hf i := (h i).symm
+      rw [← this, apply_spec g hg i]
+    · rw [apply_spec_ne f hf i j hj]
+      have : j ≠ g.apply hg i := by
+        rw [← h i]
+        exact hj
+      rw [apply_spec_ne g hg i j this]
+
+end StochasticMatrix
+
+/-! ### Deterministic morphisms as functions -/
+
+/-- Bundle for deterministic stochastic matrices with their underlying function. -/
+structure DetMorphism (m n : Type u) [Fintype m] [Fintype n] [DecidableEq n] where
+  /-- The underlying function -/
+  func : m → n
+  /-- The stochastic matrix representation -/
+  toStochastic : StochasticMatrix m n
+  /-- Proof that the matrix is deterministic -/
+  is_det : toStochastic.isDeterministic
+  /-- The function agrees with the matrix -/
+  spec : ∀ i, toStochastic.apply is_det i = func i
+
+namespace DetMorphism
+
+variable {m n p : Type u} [Fintype m] [Fintype n] [Fintype p] [DecidableEq n] [DecidableEq p]
+
+/-- Create deterministic morphism from function. -/
+def ofFunc (f : m → n) : DetMorphism m n :=
+  let mat : StochasticMatrix m n := {
+    toMatrix := fun i j => if f i = j then 1 else 0
+    row_sum := fun i => by
+      -- Only f(i) gets 1, all others get 0
+      rw [Finset.sum_eq_single (f i)]
+      · simp
+      · intro j _ hj
+        simp only [if_neg (Ne.symm hj)]
+      · intro h; exfalso; exact h (Finset.mem_univ _)
+  }
+  let det : mat.isDeterministic := fun i => by
+    use f i
+    constructor
+    · simp [mat]
+    · intro j hj
+      simp [mat] at hj
+      exact hj.symm
+  { func := f
+    toStochastic := mat
+    is_det := det
+    spec := fun i => by
+      unfold StochasticMatrix.apply
+      -- apply returns the unique j where the matrix is 1
+      have h_det := det i
+      have h_spec := h_det.choose_spec
+      have h_one : mat.toMatrix i (f i) = 1 := by simp [mat]
+      exact h_spec.2 (f i) h_one |>.symm }
+
+/-- Identity as deterministic morphism. -/
+def id (m : Type u) [Fintype m] [DecidableEq m] : DetMorphism m m :=
+  ofFunc _root_.id
+
+/-- Composition of deterministic morphisms. -/
+def comp (f : DetMorphism m n) (g : DetMorphism n p) : DetMorphism m p where
+  func := g.func ∘ f.func
+  toStochastic := StochasticMatrix.comp f.toStochastic g.toStochastic
+  is_det := StochasticMatrix.det_comp_det f.toStochastic g.toStochastic f.is_det g.is_det
+  spec := fun i => by
+    rw [StochasticMatrix.det_comp_eq_fun_comp _ _ f.is_det g.is_det]
+    simp [f.spec, g.spec]
+
+/-- Tensor product of deterministic morphisms. -/
+def tensor {m₁ n₁ m₂ n₂ : Type u} [Fintype m₁] [Fintype n₁] [Fintype m₂] [Fintype n₂]
+    [DecidableEq n₁] [DecidableEq n₂] [DecidableEq (n₁ × n₂)]
+    (f : DetMorphism m₁ n₁) (g : DetMorphism m₂ n₂) : DetMorphism (m₁ × m₂) (n₁ × n₂) where
+  func := fun ⟨i₁, i₂⟩ => (f.func i₁, g.func i₂)
+  toStochastic := StochasticMatrix.tensor f.toStochastic g.toStochastic
+  is_det := StochasticMatrix.det_tensor_det f.toStochastic g.toStochastic f.is_det g.is_det
+  spec := fun ⟨i₁, i₂⟩ => by
+    rw [StochasticMatrix.apply_tensor _ _ f.is_det g.is_det]
+    simp [f.spec, g.spec]
+
+/-- Extensionality for deterministic morphisms. -/
+@[ext]
+theorem ext (f g : DetMorphism m n) (h : f.func = g.func) : f = g := by
+  -- Two deterministic morphisms with the same function are equal
+  have h_apply : ∀ i, f.toStochastic.apply f.is_det i = g.toStochastic.apply g.is_det i := by
+    intro i
+    rw [f.spec, g.spec, h]
+  have h_mat := (StochasticMatrix.ext_deterministic f.is_det g.is_det).mpr h_apply
+  cases f; cases g
+  simp at h ⊢
+  exact ⟨h, h_mat⟩
+
+/-! ### Helper lemmas for reasoning about DetMorphisms -/
+
+/-- Matrix entry of a DetMorphism. -/
+@[simp]
+lemma toMatrix_apply (f : DetMorphism m n) (i : m) (j : n) :
+    f.toStochastic.toMatrix i j = if f.func i = j then 1 else 0 := by
+  by_cases h : f.func i = j
+  · rw [if_pos h]
+    have hj : j = f.toStochastic.apply f.is_det i := by
+      rw [f.spec i]
+      exact h.symm
+    rw [hj]
+    exact StochasticMatrix.apply_spec f.toStochastic f.is_det i
+  · rw [if_neg h]
+    have hne : j ≠ f.toStochastic.apply f.is_det i := by
+      rw [f.spec i]
+      exact Ne.symm h
+    exact StochasticMatrix.apply_spec_ne f.toStochastic f.is_det i j hne
+
+/-- Composition of DetMorphisms as matrices. -/
+lemma comp_toMatrix (f : DetMorphism m n) (g : DetMorphism n p)
+    (i : m) (k : p) :
+    (comp f g).toStochastic.toMatrix i k = if g.func (f.func i) = k then 1 else 0 := by
+  simp only [comp]
+  exact toMatrix_apply (comp f g) i k
+
+/-- Tensor product of DetMorphisms as matrices. -/
+lemma tensor_toMatrix {m₁ n₁ m₂ n₂ : Type u} [Fintype m₁] [Fintype n₁]
+    [Fintype m₂] [Fintype n₂] [DecidableEq n₁] [DecidableEq n₂] [DecidableEq (n₁ × n₂)]
+    (f : DetMorphism m₁ n₁) (g : DetMorphism m₂ n₂)
+    (i : m₁ × m₂) (j : n₁ × n₂) :
+    (tensor f g).toStochastic.toMatrix i j =
+    if (f.func i.1, g.func i.2) = j then 1 else 0 := by
+  simp only [tensor]
+  exact toMatrix_apply (tensor f g) i j
+
+/-- Identity composition left. -/
+@[simp]
+lemma id_comp [DecidableEq m] (f : DetMorphism m n) :
+    comp (id m) f = f := by
+  ext i
+  simp [comp, id, ofFunc]
+
+omit [DecidableEq n] in
+/-- Identity composition right. -/
+@[simp]
+lemma comp_id [DecidableEq n] (f : DetMorphism m n) :
+    comp f (id n) = f := by
+  ext i
+  simp [comp, id, ofFunc]
+
+/-- Composition is associative. -/
+lemma comp_assoc {q : Type u} [Fintype q] [DecidableEq q]
+    (f : DetMorphism m n) (g : DetMorphism n p) (h : DetMorphism p q) :
+    comp (comp f g) h = comp f (comp g h) := by
+  ext i
+  simp [comp]
+
+end DetMorphism
+
+/-- FinStoch: finite types with stochastic matrices. -/
+structure FinStoch : Type (u+1) where
+  /-- The underlying finite type. -/
+  carrier : Type u
+  /-- Proof that the carrier is finite. -/
+  [fintype : Fintype carrier]
+  /-- Decidable equality for the carrier type. -/
+  [decidableEq : DecidableEq carrier]
+
+namespace FinStoch
+
+instance (X : FinStoch) : Fintype X.carrier := X.fintype
+
+instance (X : FinStoch) : DecidableEq X.carrier := X.decidableEq
+
+/-- Morphisms are stochastic matrices. -/
+abbrev Hom (X Y : FinStoch) := StochasticMatrix X.carrier Y.carrier
+
+instance : CategoryStruct FinStoch where
+  Hom := Hom
+  id X := StochasticMatrix.id X.carrier
+  comp f g := StochasticMatrix.comp f g
+
+instance : Category FinStoch where
+  id_comp f := by
+    apply StochasticMatrix.ext
+    ext i j
+    simp only [CategoryStruct.comp, StochasticMatrix.comp, CategoryStruct.id]
+    -- id(i,k) * f(k,j) is non-zero only when k = i
+    rw [Finset.sum_eq_single i]
+    · simp [StochasticMatrix.id]
+    · intro k _ hk
+      simp [StochasticMatrix.id]
+      intro h
+      exact absurd h (Ne.symm hk)
+    · intro h
+      exfalso
+      exact h (Finset.mem_univ _)
+  comp_id f := by
+    apply StochasticMatrix.ext
+    ext i j
+    simp only [CategoryStruct.comp, StochasticMatrix.comp, CategoryStruct.id]
+    -- f(i,k) * id(k,j) is non-zero only when k = j
+    rw [Finset.sum_eq_single j]
+    · simp [StochasticMatrix.id]
+    · intro k _ hk
+      simp [StochasticMatrix.id]
+      intro h
+      exact absurd h.symm (Ne.symm hk)
+    · intro h
+      exfalso
+      exact h (Finset.mem_univ _)
+  assoc f g h := by
+    apply StochasticMatrix.ext
+    ext i k
+    simp only [CategoryStruct.comp, StochasticMatrix.comp]
+    -- Both (f;g);h and f;(g;h) equal ∑_j,k f(i,j)*g(j,k)*h(k,l)
+    simp only [Finset.sum_mul, Finset.mul_sum, mul_assoc]
+    rw [Finset.sum_comm]
+
+/-- Singleton type as tensor unit. -/
+def tensorUnit : FinStoch where
+  carrier := Unit
+
+/-- Tensor product of objects. -/
+def tensorObj (X Y : FinStoch) : FinStoch where
+  carrier := X.carrier × Y.carrier
+
+/-! ### Structural morphisms as deterministic morphisms -/
+
+section Structural
+
+/-- Associator as deterministic morphism. -/
+def associatorDet (X Y Z : FinStoch) :
+    DetMorphism ((X.tensorObj Y).tensorObj Z).carrier (X.tensorObj (Y.tensorObj Z)).carrier :=
+  DetMorphism.ofFunc fun ⟨⟨x, y⟩, z⟩ => (x, (y, z))
+
+/-- Inverse associator as deterministic morphism. -/
+def associatorInvDet (X Y Z : FinStoch) :
+    DetMorphism (X.tensorObj (Y.tensorObj Z)).carrier ((X.tensorObj Y).tensorObj Z).carrier :=
+  DetMorphism.ofFunc fun ⟨x, ⟨y, z⟩⟩ => ((x, y), z)
+
+/-- Left unitor as deterministic morphism. -/
+def leftUnitorDet (X : FinStoch) :
+    DetMorphism (tensorUnit.tensorObj X).carrier X.carrier :=
+  DetMorphism.ofFunc fun ⟨_, x⟩ => x
+
+/-- Inverse left unitor as deterministic morphism. -/
+def leftUnitorInvDet (X : FinStoch) :
+    DetMorphism X.carrier (tensorUnit.tensorObj X).carrier :=
+  DetMorphism.ofFunc fun x => ((), x)
+
+/-- Right unitor as deterministic morphism. -/
+def rightUnitorDet (X : FinStoch) :
+    DetMorphism (X.tensorObj tensorUnit).carrier X.carrier :=
+  DetMorphism.ofFunc fun ⟨x, _⟩ => x
+
+/-- Inverse right unitor as deterministic morphism. -/
+def rightUnitorInvDet (X : FinStoch) :
+    DetMorphism X.carrier (X.tensorObj tensorUnit).carrier :=
+  DetMorphism.ofFunc fun x => (x, ())
+
+/-- Swap/braiding as deterministic morphism. -/
+def swapDet (X Y : FinStoch) :
+    DetMorphism (X.tensorObj Y).carrier (Y.tensorObj X).carrier :=
+  DetMorphism.ofFunc fun ⟨x, y⟩ => (y, x)
+
+/-! ### Properties of structural morphisms -/
+
+/-- Associator and its inverse compose to identity. -/
+theorem associatorDet_comp_inv (X Y Z : FinStoch) :
+    (associatorDet X Y Z).func ∘ (associatorInvDet X Y Z).func = _root_.id := by
+  ext ⟨x, ⟨y, z⟩⟩
+  rfl
+
+/-- Swap is involutive. -/
+theorem swapDet_involutive (X Y : FinStoch) :
+    (swapDet X Y).func ∘ (swapDet Y X).func = _root_.id := by
+  ext ⟨x, y⟩
+  rfl
+
+end Structural
+
+end FinStoch
+
+end CategoryTheory.MarkovCategory

--- a/Mathlib/CategoryTheory/MarkovCategory/FinStoch/Monoidal.lean
+++ b/Mathlib/CategoryTheory/MarkovCategory/FinStoch/Monoidal.lean
@@ -1,0 +1,433 @@
+/-
+Copyright (c) 2025 Jacob Reinhold. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Jacob Reinhold
+-/
+import Mathlib.CategoryTheory.MarkovCategory.FinStoch.Basic
+import Mathlib.CategoryTheory.Monoidal.Category
+import Mathlib.Data.NNReal.Basic
+
+/-!
+# Monoidal Structure on FinStoch
+
+Tensor products model independent parallel processes.
+
+## Main definitions
+
+* `associator` - Isomorphism `(X ⊗ Y) ⊗ Z ≅ X ⊗ (Y ⊗ Z)`
+* `leftUnitor` - Isomorphism `I ⊗ X ≅ X`
+* `rightUnitor` - Isomorphism `X ⊗ I ≅ X`
+
+## Implementation notes
+
+Structural morphisms use deterministic functions.
+Proofs use functional reasoning instead of matrix calculations.
+
+## References
+
+* [Fritz, *A synthetic approach to Markov kernels, conditional independence
+  and theorems on sufficient statistics*][fritz2020]
+
+## Tags
+
+Markov category, monoidal category, stochastic matrix
+-/
+
+namespace CategoryTheory.MarkovCategory
+
+open FinStoch MonoidalCategory
+
+universe u
+
+open FinStoch
+
+
+
+/-! ### Structural isomorphisms using DetMorphism -/
+
+/-- Rearranges `((X ⊗ Y) ⊗ Z)` to `(X ⊗ (Y ⊗ Z))`. -/
+def associator (X Y Z : FinStoch) :
+    (tensorObj (tensorObj X Y) Z) ≅ (tensorObj X (tensorObj Y Z)) where
+  hom := (associatorDet X Y Z).toStochastic
+  inv := (associatorInvDet X Y Z).toStochastic
+  hom_inv_id := by
+    apply StochasticMatrix.ext
+    ext ⟨⟨x, y⟩, z⟩ ⟨⟨x', y'⟩, z'⟩
+    simp only [CategoryStruct.comp, StochasticMatrix.comp]
+    -- Associator is deterministic: ((x,y),z) → (x,(y,z)) → ((x,y),z)
+    -- The only non-zero path is through the intermediate (x,(y,z))
+    rw [Finset.sum_eq_single ⟨x, ⟨y, z⟩⟩]
+    · simp only [associatorDet, associatorInvDet, DetMorphism.ofFunc]; cat_disch
+    · intro b _ hb; simp only [associatorDet, associatorInvDet, DetMorphism.ofFunc]; cat_disch
+    · intro h; exfalso; exact h (Finset.mem_univ _)
+  inv_hom_id := by
+    apply StochasticMatrix.ext
+    ext ⟨x, ⟨y, z⟩⟩ ⟨x', ⟨y', z'⟩⟩
+    simp only [CategoryStruct.comp, StochasticMatrix.comp]
+    -- Inverse path: (x,(y,z)) → ((x,y),z) → (x,(y,z))
+    rw [Finset.sum_eq_single ⟨⟨x, y⟩, z⟩]
+    · simp only [associatorInvDet, associatorDet, DetMorphism.ofFunc]; cat_disch
+    · intro b _ hb; simp only [associatorInvDet, associatorDet, DetMorphism.ofFunc]; cat_disch
+    · intro h; exfalso; exact h (Finset.mem_univ _)
+
+/-- Removes trivial left factor from `I ⊗ X` to get `X`. -/
+def leftUnitor (X : FinStoch) : (tensorObj tensorUnit X) ≅ X where
+  hom := (leftUnitorDet X).toStochastic
+  inv := (leftUnitorInvDet X).toStochastic
+  hom_inv_id := by
+    apply StochasticMatrix.ext
+    ext ⟨⟨⟩, x⟩ ⟨⟨⟩, x'⟩
+    simp only [CategoryStruct.comp, StochasticMatrix.comp]
+    -- ((),x) → x → ((),x) is identity
+    rw [Finset.sum_eq_single x]
+    · simp only [leftUnitorDet, leftUnitorInvDet, DetMorphism.ofFunc]; cat_disch
+    · intro b _ hb; simp only [leftUnitorDet, leftUnitorInvDet, DetMorphism.ofFunc]; cat_disch
+    · intro h; exfalso; exact h (Finset.mem_univ _)
+  inv_hom_id := by
+    apply StochasticMatrix.ext
+    ext x x'
+    simp only [CategoryStruct.comp, StochasticMatrix.comp]
+    -- x → ((),x) → x is identity
+    rw [Finset.sum_eq_single ⟨⟨⟩, x⟩]
+    · simp only [leftUnitorInvDet, leftUnitorDet, DetMorphism.ofFunc]; cat_disch
+    · intro b _ hb; simp only [leftUnitorInvDet, leftUnitorDet, DetMorphism.ofFunc]; cat_disch
+    · intro h; exfalso; exact h (Finset.mem_univ _)
+
+/-- Removes trivial right factor from `X ⊗ I` to get `X`. -/
+def rightUnitor (X : FinStoch) : (tensorObj X tensorUnit) ≅ X where
+  hom := (rightUnitorDet X).toStochastic
+  inv := (rightUnitorInvDet X).toStochastic
+  hom_inv_id := by
+    apply StochasticMatrix.ext
+    ext ⟨x, ⟨⟩⟩ ⟨x', ⟨⟩⟩
+    simp only [CategoryStruct.comp, StochasticMatrix.comp]
+    rw [Finset.sum_eq_single x]
+    · simp only [rightUnitorDet, rightUnitorInvDet, DetMorphism.ofFunc]; cat_disch
+    · intro b _ hb; simp only [rightUnitorDet, rightUnitorInvDet, DetMorphism.ofFunc]; cat_disch
+    · intro h; exfalso; exact h (Finset.mem_univ _)
+  inv_hom_id := by
+    apply StochasticMatrix.ext
+    ext x x'
+    simp only [CategoryStruct.comp, StochasticMatrix.comp]
+    rw [Finset.sum_eq_single ⟨x, ⟨⟩⟩]
+    · simp only [rightUnitorInvDet, rightUnitorDet, DetMorphism.ofFunc]; cat_disch
+    · intro b _ hb; simp only [rightUnitorInvDet, rightUnitorDet, DetMorphism.ofFunc]; cat_disch
+    · intro h; exfalso; exact h (Finset.mem_univ _)
+
+/-- Basic monoidal structure on FinStoch using tensor products. -/
+instance : MonoidalCategoryStruct FinStoch where
+  tensorObj := tensorObj
+  tensorUnit := tensorUnit
+  tensorHom f g := StochasticMatrix.tensor f g
+  whiskerLeft := fun X {_ _} f => StochasticMatrix.tensor (𝟙 X) f
+  whiskerRight := fun {_ _} f Y => StochasticMatrix.tensor f (𝟙 Y)
+  associator := associator
+  leftUnitor := leftUnitor
+  rightUnitor := rightUnitor
+
+/-! ### Simp lemmas for structural morphisms -/
+
+/-- Matrix entry for associator. -/
+@[simp]
+lemma associator_matrix (X Y Z : FinStoch) (xyz : ((X ⊗ Y) ⊗ Z).carrier)
+    (xyz' : (X ⊗ (Y ⊗ Z)).carrier) :
+    (MonoidalCategoryStruct.associator X Y Z).hom.toMatrix xyz xyz' =
+    if xyz.1.1 = xyz'.1 ∧ xyz.1.2 = xyz'.2.1 ∧ xyz.2 = xyz'.2.2 then 1 else 0 := by
+  simp only [MonoidalCategoryStruct.associator, associator, DetMorphism.toMatrix_apply]
+  simp only [associatorDet, DetMorphism.ofFunc]
+  -- The associator permutation: ((x,y),z) ↦ (x,(y,z))
+  aesop
+
+/-- Matrix entry for left unitor. -/
+@[simp]
+lemma leftUnitor_matrix (X : FinStoch) (ux : (FinStoch.tensorUnit ⊗ X).carrier)
+    (x : X.carrier) :
+    (MonoidalCategoryStruct.leftUnitor X).hom.toMatrix ux x =
+    if ux.2 = x then 1 else 0 := by
+  simp only [MonoidalCategoryStruct.leftUnitor, leftUnitor, DetMorphism.toMatrix_apply]
+  simp only [leftUnitorDet, DetMorphism.ofFunc]
+  obtain ⟨⟨⟩, x'⟩ := ux
+  simp only
+
+/-- Matrix entry for right unitor. -/
+@[simp]
+lemma rightUnitor_matrix (X : FinStoch) (xu : (X ⊗ FinStoch.tensorUnit).carrier)
+    (x : X.carrier) :
+    (MonoidalCategoryStruct.rightUnitor X).hom.toMatrix xu x =
+    if xu.1 = x then 1 else 0 := by
+  simp only [MonoidalCategoryStruct.rightUnitor, rightUnitor]
+  simp only [rightUnitorDet, DetMorphism.ofFunc]
+  obtain ⟨x', ⟨⟩⟩ := xu
+  simp only
+
+
+/-- FinStoch forms a monoidal category. -/
+instance : MonoidalCategory FinStoch where
+  tensorHom_def := by
+    intros X₁ Y₁ X₂ Y₂ f g
+    apply StochasticMatrix.ext
+    ext ⟨x₁, x₂⟩ ⟨y₁, y₂⟩
+    simp only [MonoidalCategoryStruct.tensorHom, StochasticMatrix.tensor,
+               MonoidalCategoryStruct.whiskerRight, MonoidalCategoryStruct.whiskerLeft,
+               CategoryStruct.comp, StochasticMatrix.comp]
+    -- f ⊗ g = (f ⊗ id) ∘ (id ⊗ g) = f(x₁,y₁) * g(x₂,y₂)
+    rw [Finset.sum_eq_single ⟨y₁, x₂⟩]
+    · simp only [StochasticMatrix.id, CategoryStruct.id]
+      cat_disch
+    · simp only [StochasticMatrix.id, CategoryStruct.id]
+      cat_disch
+    · intro h; exfalso; exact h (Finset.mem_univ _)
+  id_tensorHom_id := by
+    intros X Y
+    apply StochasticMatrix.ext
+    ext ⟨x, y⟩ ⟨x', y'⟩
+    simp only [MonoidalCategoryStruct.tensorHom, StochasticMatrix.tensor]
+    simp only [CategoryStruct.id, StochasticMatrix.id]
+    by_cases hx : x = x'
+    · by_cases hy : y = y'
+      · simp [hx, hy]
+      · simp [hx, hy]
+        split_ifs with h
+        · exfalso
+          obtain ⟨_, h2⟩ := h
+          exact hy rfl
+        · rfl
+    · simp [hx]
+      split_ifs with h
+      · exfalso
+        obtain ⟨h1, _⟩ := h
+        exact hx rfl
+      · rfl
+  tensorHom_comp_tensorHom := by
+    intros X₁ Y₁ Z₁ X₂ Y₂ Z₂ f₁ f₂ g₁ g₂
+    apply StochasticMatrix.ext
+    ext ⟨x₁, x₂⟩ ⟨z₁, z₂⟩
+    simp only [CategoryStruct.comp, StochasticMatrix.comp,
+               MonoidalCategoryStruct.tensorHom, StochasticMatrix.tensor]
+    rw [Finset.sum_mul_sum]
+    simp_rw [← Finset.sum_product']
+    ac_rfl
+  whiskerLeft_id := by
+    intros X Y
+    apply StochasticMatrix.ext
+    ext ⟨x, y⟩ ⟨x', y'⟩
+    simp only [MonoidalCategoryStruct.whiskerLeft, StochasticMatrix.tensor]
+    simp only [CategoryStruct.id, StochasticMatrix.id]
+    by_cases hx : x = x'
+    · by_cases hy : y = y'
+      · subst hx hy; simp
+      · subst hx
+        simp [hy]
+        by_cases h : (x, y) = (x, y')
+        · exfalso
+          simp only [Prod.mk.injEq] at h
+          obtain ⟨_, h2⟩ := h
+          exact hy h2
+        · simp [h]
+    · simp [hx]
+      by_cases h : (x, y) = (x', y')
+      · exfalso
+        simp only [Prod.mk.injEq] at h
+        obtain ⟨h1, _⟩ := h
+        exact hx h1
+      · simp [h]
+  id_whiskerRight := by
+    intros X Y
+    apply StochasticMatrix.ext
+    ext ⟨x, y⟩ ⟨x', y'⟩
+    simp only [MonoidalCategoryStruct.whiskerRight, StochasticMatrix.tensor]
+    simp only [CategoryStruct.id, StochasticMatrix.id]
+    by_cases hx : x = x'
+    · by_cases hy : y = y'
+      · subst hx hy
+        simp
+      · subst hx
+        simp [hy]
+        by_cases h : (x, y) = (x, y')
+        · exfalso
+          simp only [Prod.mk.injEq] at h
+          obtain ⟨_, h2⟩ := h
+          exact hy h2
+        · simp [h]
+    · simp [hx]
+      by_cases h : (x, y) = (x', y')
+      · exfalso
+        simp only [Prod.mk.injEq] at h
+        obtain ⟨h1, _⟩ := h
+        exact hx h1
+      · simp [h]
+  associator_naturality := by
+    intros X₁ X₂ X₃ Y₁ Y₂ Y₃ f₁ f₂ f₃
+    apply StochasticMatrix.ext
+    ext ⟨⟨x₁, x₂⟩, x₃⟩ ⟨y₁, ⟨y₂, y₃⟩⟩
+    simp only [CategoryStruct.comp, StochasticMatrix.comp,
+               MonoidalCategoryStruct.tensorHom, StochasticMatrix.tensor]
+    -- Naturality: α ∘ (f₁⊗f₂⊗f₃) = (f₁⊗(f₂⊗f₃)) ∘ α
+    -- Both paths factor through the same intermediate states
+    rw [Finset.sum_eq_single ⟨⟨y₁, y₂⟩, y₃⟩]
+    · simp [associator_matrix]
+      rw [Finset.sum_eq_single ⟨x₁, ⟨x₂, x₃⟩⟩]
+      · norm_num; ring
+      · intro ⟨x₁', ⟨x₂', x₃'⟩⟩ _ h_ne
+        by_cases h : x₁' = x₁ ∧ x₂' = x₂ ∧ x₃' = x₃
+        · exfalso
+          apply h_ne
+          simp [h]
+        · aesop
+      · intro; exfalso; apply ‹_›; exact Finset.mem_univ _
+    · intro ⟨⟨y₁', y₂'⟩, y₃'⟩ _ h_ne
+      by_cases h : y₁' = y₁ ∧ y₂' = y₂ ∧ y₃' = y₃
+      · exfalso
+        apply h_ne
+        simp only [h]
+      · -- Associator is deterministic, gives 0 for non-matching indices
+        have h_assoc_zero : (MonoidalCategoryStruct.associator Y₁ Y₂ Y₃).hom.toMatrix
+                              ((y₁', y₂'), y₃') (y₁, y₂, y₃) = 0 := by
+          simp [associator_matrix, h]
+        rw [h_assoc_zero, mul_zero]
+    · intro; exfalso; apply ‹_›; exact Finset.mem_univ _
+  leftUnitor_naturality := by
+    intros X Y f
+    apply StochasticMatrix.ext
+    ext ⟨⟨⟩, x⟩ y
+    simp only [CategoryStruct.comp, StochasticMatrix.comp]
+    rw [Finset.sum_eq_single ⟨⟨⟩, y⟩]
+    · simp [MonoidalCategoryStruct.whiskerLeft, StochasticMatrix.tensor,
+            CategoryStruct.id, StochasticMatrix.id]
+    · intro ⟨⟨⟩, y'⟩ _ h_ne
+      have h_neq : y' ≠ y := by
+        intro h_eq
+        apply h_ne
+        simp only [h_eq]
+      simp only [MonoidalCategoryStruct.whiskerLeft, StochasticMatrix.tensor,
+                 CategoryStruct.id, StochasticMatrix.id]
+      have h_unitor_zero : (MonoidalCategoryStruct.leftUnitor Y).hom.toMatrix (⟨⟩, y') y = 0 := by
+        simp [leftUnitor_matrix, h_neq]
+      simp [h_unitor_zero]
+    · intro h; exfalso; exact h (Finset.mem_univ _)
+  rightUnitor_naturality := by
+    intros X Y f
+    apply StochasticMatrix.ext
+    ext ⟨x, ⟨⟩⟩ y
+    simp only [CategoryStruct.comp, StochasticMatrix.comp]
+    rw [Finset.sum_eq_single ⟨y, ⟨⟩⟩]
+    · simp only [MonoidalCategoryStruct.whiskerRight, StochasticMatrix.tensor,
+                 CategoryStruct.id, StochasticMatrix.id]
+      have h_right_unitor : (MonoidalCategoryStruct.rightUnitor Y).hom.toMatrix (y,⟨⟩) y = 1 := by
+        simp [rightUnitor_matrix]
+      simp only [h_right_unitor, mul_one]
+      rw [Finset.sum_eq_single x]
+      · have h_right_unitor :
+          (MonoidalCategoryStruct.rightUnitor X).hom.toMatrix (x, ⟨⟩) x = 1 := by
+          simp [rightUnitor_matrix]
+        simp [h_right_unitor]
+      · intro x' _ h_ne
+        have h_unitor_zero :
+          (MonoidalCategoryStruct.rightUnitor X).hom.toMatrix (x, ⟨⟩) x' = 0 := by
+          simp only [rightUnitor_matrix]
+          rw [if_neg h_ne.symm]
+        simp [h_unitor_zero]
+      · intro h; exfalso; exact h (Finset.mem_univ _)
+    · intro ⟨y', ⟨⟩⟩ _ h_ne
+      have h_neq : y' ≠ y := by
+        intro h_eq
+        apply h_ne
+        simp only [h_eq]
+      simp only [MonoidalCategoryStruct.whiskerRight, StochasticMatrix.tensor,
+                 CategoryStruct.id, StochasticMatrix.id]
+      have h_unitor_zero : (MonoidalCategoryStruct.rightUnitor Y).hom.toMatrix (y', ⟨⟩) y = 0 := by
+        simp [rightUnitor_matrix, h_neq]
+      simp [h_unitor_zero]
+    · intro h; exfalso; exact h (Finset.mem_univ _)
+  pentagon := by
+    intros W X Y Z
+    apply StochasticMatrix.ext
+    ext ⟨⟨⟨w, x⟩, y⟩, z⟩ ⟨w', ⟨x', ⟨y', z'⟩⟩⟩
+    -- Pentagon coherence: both paths from ((w,x),y,z) to (w,(x,(y,z))) are equal
+    simp only [CategoryStruct.comp, StochasticMatrix.comp]
+    -- Left path: ((w,x),y,z) → (w,(x,y),z) → (w,((x,y),z)) → (w,(x,(y,z)))
+    rw [Finset.sum_eq_single ⟨⟨w, ⟨x, y⟩⟩, z⟩]
+    · rw [Finset.sum_eq_single ⟨w, ⟨⟨x, y⟩, z⟩⟩]
+      · -- Right path: ((w,x),y,z) → ((w,x),(y,z)) → (w,(x,(y,z)))
+        rw [Finset.sum_eq_single ⟨⟨w, x⟩, ⟨y, z⟩⟩]
+        · -- Both paths use deterministic permutations
+          simp only [MonoidalCategoryStruct.whiskerRight, MonoidalCategoryStruct.whiskerLeft,
+                     StochasticMatrix.tensor, associator_matrix,
+                     CategoryStruct.id, StochasticMatrix.id]
+          -- All components must match for non-zero contribution
+          by_cases hw : w = w'
+          · by_cases hx : x = x'
+            · by_cases hy : y = y'
+              · by_cases hz : z = z'
+                · subst hw hx hy hz; simp
+                · simp [hw, hx, hy, hz]
+                  subst hw hx hy
+                  split
+                  · grind only
+                  · rfl
+              · simp [hw, hx, hy]
+                subst hw hx
+                split
+                · grind only
+                · rfl
+            · simp [hw, hx]
+          · simp [hw]
+        · intro b _ hb
+          simp only [associator_matrix, mul_eq_zero]
+          left
+          split_ifs with h
+          · exfalso
+            obtain ⟨h1, h2, h3⟩ := h
+            have : b = ⟨⟨w, x⟩, ⟨y, z⟩⟩ := by
+              cases b; simp [h1, h2, h3]
+            exact hb this
+          · rfl
+        · intro h; exfalso; exact h (Finset.mem_univ _)
+      · intro a _ ha
+        simp only [associator_matrix, mul_eq_zero]
+        left
+        split_ifs with h
+        · exfalso
+          obtain ⟨h1, h2, h3⟩ := h
+          have : a = ⟨w, ⟨⟨x, y⟩, z⟩⟩ := by
+            cases a; simp [h1, h2, h3]
+          exact ha this
+        · rfl
+      · intro h; exfalso; exact h (Finset.mem_univ _)
+    · intro b _ hb
+      simp only [MonoidalCategoryStruct.whiskerRight, StochasticMatrix.tensor,
+                 associator_matrix, CategoryStruct.id, StochasticMatrix.id, mul_eq_zero]
+      left
+      split_ifs with h
+      · exfalso
+        obtain ⟨hw, hx, hy⟩ := h
+        have : b = ⟨⟨w, ⟨x, y⟩⟩, z⟩ := by
+          cases b; simp_all only [Finset.mem_univ, Prod.mk.eta, ne_eq, not_true_eq_false]
+        exact hb this
+      · right; rfl
+      · left; rfl
+      · left; rfl
+    · intro h; exfalso; exact h (Finset.mem_univ _)
+  triangle := by
+    intros X Y
+    apply StochasticMatrix.ext
+    ext ⟨⟨x, ⟨⟩⟩, y⟩ ⟨x', y'⟩
+    -- Triangle coherence: associator and unitors interact correctly
+    -- Both paths: ((x,()),y) → (x,y) via different unit eliminations
+    simp only [CategoryStruct.comp, StochasticMatrix.comp]
+    -- Unique intermediate state is (x,((),y))
+    rw [Finset.sum_eq_single ⟨x, ⟨⟨⟩, y⟩⟩]
+    · simp only [associator_matrix, MonoidalCategoryStruct.whiskerLeft,
+                 MonoidalCategoryStruct.whiskerRight, StochasticMatrix.tensor,
+                 leftUnitor_matrix, rightUnitor_matrix, CategoryStruct.id, StochasticMatrix.id]
+      by_cases hx : x = x'
+      · by_cases hy : y = y'
+        · subst hx hy; simp
+        · simp [hx, hy]
+      · simp [hx]
+    · intro a _ ha
+      obtain ⟨x₁, ⟨⟨⟩, y₁⟩⟩ := a
+      cat_disch
+    · intro h; exfalso; exact h (Finset.mem_univ _)
+
+end CategoryTheory.MarkovCategory

--- a/MathlibTest/CategoryTheory/MarkovCategory.lean
+++ b/MathlibTest/CategoryTheory/MarkovCategory.lean
@@ -1,0 +1,80 @@
+/-
+Copyright (c) 2025 Jacob Reinhold. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Jacob Reinhold
+-/
+import Mathlib.CategoryTheory.MarkovCategory.Basic
+import Mathlib.CategoryTheory.MarkovCategory.Cartesian
+import Mathlib.CategoryTheory.Monoidal.Types.Basic
+import Mathlib.CategoryTheory.CopyDiscardCategory.Basic
+import Mathlib.LinearAlgebra.Matrix.Notation
+import Mathlib.Tactic.FinCases
+
+/-!
+# Tests for Markov Categories
+
+This file contains tests and examples for the Markov category implementation.
+
+## Tests included
+
+* Basic axiom verification for Type*
+* Examples of deterministic morphisms
+* Verification of comonoid laws
+
+-/
+
+universe u
+
+open CategoryTheory MarkovCategory CopyDiscardCategory ComonObj
+
+section BasicTests
+
+/-- Type* forms a Markov category via its cartesian structure -/
+example : MarkovCategory (Type u) := inferInstance
+
+/-- CartesianMonoidalCategory instance exists for Type* -/
+example : CartesianMonoidalCategory (Type u) := inferInstance
+
+end BasicTests
+
+section ComonoidLaws
+
+variable {C : Type u} [Category.{u} C] [MonoidalCategory.{u} C] [MarkovCategory C]
+
+open MonoidalCategory CopyDiscardCategory
+
+/-- The copy operation is commutative -/
+example (X : C) : Δ[X] ≫ (β_ X X).hom = Δ[X] := CommComonObj.swap_comul
+
+/-- Left counit law -/
+example (X : C) : Δ[X] ≫ (ε[X] ▷ X) = (λ_ X).inv := ComonObj.counit_comul X
+
+/-- Right counit law -/
+example (X : C) : Δ[X] ≫ (X ◁ ε[X]) = (ρ_ X).inv := ComonObj.comul_counit X
+
+/-- Coassociativity -/
+example (X : C) :
+    Δ[X] ≫ (X ◁ Δ[X]) = Δ[X] ≫ (Δ[X] ▷ X) ≫ (α_ X X X).hom :=
+  ComonObj.comul_assoc X
+
+/-- Delete is natural -/
+example {X Y : C} (f : X ⟶ Y) : f ≫ ε[Y] = ε[X] := MarkovCategory.discard_natural f
+
+end ComonoidLaws
+
+section SimpLemmas
+
+variable {C : Type u} [Category.{u} C] [MonoidalCategory C] [MarkovCategory C]
+
+open MonoidalCategory CopyDiscardCategory
+
+/-- Test that simp lemmas work for counit laws -/
+example (X : C) : Δ[X] ≫ (ε[X] ▷ X) = (λ_ X).inv := by simp
+
+/-- Test that simp lemmas work for naturality of delete -/
+example {X Y : C} (f : X ⟶ Y) : f ≫ ε[Y] = ε[X] := by simp
+
+/-- Test that simp lemmas work for copy commutativity -/
+example (X : C) : Δ[X] ≫ (β_ X X).hom = Δ[X] := by simp
+
+end SimpLemmas

--- a/docs/references.bib
+++ b/docs/references.bib
@@ -1052,6 +1052,19 @@
   keywords      = {{16P10, 16U99},Mathematics - Rings and Algebras}
 }
 
+@Article{         cho_jacobs_2019,
+  title         = {Disintegration and Bayesian inversion via string
+                  diagrams},
+  author        = {Cho, Kenta and Jacobs, Bart},
+  journal       = {Mathematical Structures in Computer Science},
+  volume        = {29},
+  number        = {7},
+  pages         = {938--971},
+  year          = {2019},
+  publisher     = {Cambridge University Press},
+  doi           = {10.1017/S0960129518000488}
+}
+
 @InProceedings{   Chou1994,
   author        = {Chou, Ching-Tsun},
   booktitle     = {Higher Order Logic Theorem Proving and Its Applications},


### PR DESCRIPTION
This PR introduces FinStoch, the category of finite stochastic matrices, as a concrete example of a Markov category.

This PR builds on #29925, #29939, and #29919 and was split up from #29657.

## Main additions

### 1. Core definitions (`FinStoch/Basic.lean`)

- `StochasticMatrix m n`: Matrices where rows sum to 1, representing conditional probabilities P(j|i)
- `FinStoch`: The category with finite types as objects and stochastic matrices as morphisms
- `DetMorphism`: Deterministic matrices (exactly one 1 per row) with their underlying functions
- Composition: Matrix multiplication preserves row-stochasticity via the Chapman-Kolmogorov equation

Key design choices:
- Row-stochastic convention: entry (i,j) is P(output=j | input=i)
- Deterministic morphisms tracked separately for structural isomorphisms

### 2. Monoidal structure (`FinStoch/Monoidal.lean`)

Implements tensor products modeling independent parallel processes:
- Tensor on objects: Cartesian product of finite types
- Tensor on morphisms: Kronecker product P((j₁,j₂)|(i₁,i₂)) = P(j₁|i₁) × P(j₂|i₂)
- Structural morphisms: Associator, unitors use deterministic permutations
- Coherence**: Pentagon and triangle identities verified computationally

## Mathematical significance

FinStoch provides the canonical example of a Markov category:
- Morphisms: Stochastic matrices/Markov chains
- Composition: Chapman-Kolmogorov equation for multi-step transitions
- Tensor: Independent parallel processes

This models finite probability spaces categorically, where:
- Objects represent sample spaces
- Morphisms represent probabilistic transitions
- Tensor products model independence

## References

Fritz (2020)

- [ ] depends on: #29925 