### PR TITLE
[Merged by Bors] - fix: make 'says' more robust to whitespace

### DIFF
--- a/Mathlib/Tactic/Says.lean
+++ b/Mathlib/Tactic/Says.lean
@@ -93,7 +93,7 @@ def evalTacticCapturingTryThis (tac : TSyntax `tactic) : TacticM (TSyntax ``tact
   let tryThis ← match msg.dropPrefix? "Try this:" with
   | none => throwError m!"Tactic output did not begin with 'Try this:': {msg}"
   | some S => pure S.toString.removeLeadingSpaces
-  match parseAsTacticSeq (← getEnv) tryThis with
+  match parseAsTacticSeq (← getEnv) tryThis.trim with
   | .ok stx => return stx
   | .error err => throwError m!"Failed to parse tactic output: {tryThis}\n{err}"
 

--- a/MathlibTest/says_whitespace.lean
+++ b/MathlibTest/says_whitespace.lean
@@ -1,0 +1,14 @@
+import Mathlib.Tactic.Common
+
+set_option says.verify true
+
+variable {X Y Z : Type}
+
+open Function
+
+example {f : X → Y} {g : Y → Z} (hgfinj : Injective (g ∘ f)) : Injective f := by
+  rw [Injective]
+  aesop? says
+    intro a₁ a₂ a
+    apply hgfinj
+    simp_all only [comp_apply]


### PR DESCRIPTION
See [#general > says tactic does not work in v4.24.0-rc1 @ 💬](https://leanprover.zulipchat.com/#narrow/channel/113488-general/topic/says.20tactic.20does.20not.20work.20in.20v4.2E24.2E0-rc1/near/540658297).
