### PR TITLE
[Merged by Bors] - feat(CategoryTheory/CopyDiscardCategory): add Copy-Discard categories

### DIFF
--- a/Mathlib.lean
+++ b/Mathlib.lean
@@ -2197,6 +2197,9 @@ import Mathlib.CategoryTheory.ConcreteCategory.ReflectsIso
 import Mathlib.CategoryTheory.ConcreteCategory.UnbundledHom
 import Mathlib.CategoryTheory.Conj
 import Mathlib.CategoryTheory.ConnectedComponents
+import Mathlib.CategoryTheory.CopyDiscardCategory.Basic
+import Mathlib.CategoryTheory.CopyDiscardCategory.Cartesian
+import Mathlib.CategoryTheory.CopyDiscardCategory.Deterministic
 import Mathlib.CategoryTheory.Core
 import Mathlib.CategoryTheory.Countable
 import Mathlib.CategoryTheory.Dialectica.Basic

--- a/Mathlib/CategoryTheory/CopyDiscardCategory/Basic.lean
+++ b/Mathlib/CategoryTheory/CopyDiscardCategory/Basic.lean
@@ -1,0 +1,65 @@
+/-
+Copyright (c) 2025 Jacob Reinhold. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Jacob Reinhold
+-/
+import Mathlib.CategoryTheory.Monoidal.Comon_
+
+/-!
+# Copy-Discard Categories
+
+Symmetric monoidal categories where every object has a commutative
+comonoid structure compatible with tensor products.
+
+## Main definitions
+
+* `CopyDiscardCategory` - Category with coherent copy and delete
+
+## Notations
+
+* `Δ[X]` - Copy morphism for X (from `ComonObj`)
+* `ε[X]` - Delete morphism for X (from `ComonObj`)
+
+## Implementation notes
+
+We use `ComonObj` instances to provide the comonoid structure.
+The key axioms ensure tensor products respect the comonoid structure.
+
+## References
+
+* [Cho and Jacobs, *Disintegration and Bayesian inversion via string diagrams*][cho_jacobs_2019]
+* [Fritz, *A synthetic approach to Markov kernels, conditional independence
+  and theorems on sufficient statistics*][fritz2020]
+
+## Tags
+
+copy-discard, comonoid, symmetric monoidal
+-/
+
+universe v u
+
+namespace CategoryTheory
+
+open MonoidalCategory ComonObj
+
+variable {C : Type u} [Category.{v} C] [MonoidalCategory.{v} C]
+
+/-- Category where objects have compatible copy and discard operations. -/
+class CopyDiscardCategory (C : Type u) [Category.{v} C] [MonoidalCategory.{v} C]
+    extends SymmetricCategory C where
+  /-- Every object has commutative comonoid structure. -/
+  [comonObj : (X : C) → ComonObj X]
+  /-- Every object's comonoid structure is commutative. -/
+  [isCommComonObj : (X : C) → IsCommComonObj X]
+  /-- Tensor products of copies equal copies of tensor products. -/
+  copy_tensor (X Y : C) : Δ[X ⊗ Y] = (Δ[X] ⊗ₘ Δ[Y]) ≫ tensorμ X X Y Y := by cat_disch
+  /-- Discard distributes over tensor. -/
+  discard_tensor (X Y : C) : ε[X ⊗ Y] = (ε[X] ⊗ₘ ε[Y]) ≫ (λ_ (𝟙_ C)).hom := by cat_disch
+    /-- Copy on the unit object. -/
+  copy_unit : Δ[𝟙_ C] = (λ_ (𝟙_ C)).inv := by cat_disch
+    /-- Discard on the unit object. -/
+  discard_unit : ε[𝟙_ C] = 𝟙 (𝟙_ C) := by cat_disch
+
+attribute [instance] CopyDiscardCategory.comonObj CopyDiscardCategory.isCommComonObj
+
+end CategoryTheory

--- a/Mathlib/CategoryTheory/CopyDiscardCategory/Cartesian.lean
+++ b/Mathlib/CategoryTheory/CopyDiscardCategory/Cartesian.lean
@@ -1,0 +1,59 @@
+/-
+Copyright (c) 2025 Jacob Reinhold. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Jacob Reinhold
+-/
+import Mathlib.CategoryTheory.CopyDiscardCategory.Basic
+import Mathlib.CategoryTheory.CopyDiscardCategory.Deterministic
+import Mathlib.CategoryTheory.Monoidal.Cartesian.Comon_
+import Mathlib.CategoryTheory.Monoidal.Cartesian.Basic
+
+/-!
+# Cartesian Categories as Copy-Discard Categories
+
+Every cartesian monoidal category is a copy-discard category where:
+- Copy is the diagonal map
+- Discard is the unique map to terminal
+
+## Main results
+
+* `CopyDiscardCategory` instance for cartesian monoidal categories
+* All morphisms in cartesian categories are deterministic
+
+## Tags
+
+cartesian, copy-discard, comonoid, symmetric monoidal
+-/
+
+universe v u
+
+namespace CategoryTheory
+
+open MonoidalCategory CartesianMonoidalCategory ComonObj
+
+variable {C : Type u} [Category.{v} C] [CartesianMonoidalCategory.{v} C]
+
+namespace CartesianCopyDiscard
+
+/-- Provide `ComonObj` instances using the canonical cartesian comonoid structure. -/
+abbrev instComonObjOfCartesian (X : C) : ComonObj X :=
+  ((cartesianComon C).obj X).comon
+
+attribute [local instance] instComonObjOfCartesian
+
+variable [BraidedCategory C]
+
+/-- Every object in a cartesian category has commutative comonoid structure. -/
+instance instIsCommComonObjOfCartesian (X : C) : IsCommComonObj X where
+
+/-- Cartesian categories have copy-discard structure. -/
+abbrev ofCartesianMonoidalCategory : CopyDiscardCategory C where
+
+attribute [local instance] ofCartesianMonoidalCategory
+
+/-- In cartesian categories, every morphism is deterministic (preserves the comonoid structure). -/
+instance instDeterministic {X Y : C} (f : X ⟶ Y) : Deterministic f where
+
+end CartesianCopyDiscard
+
+end CategoryTheory

--- a/Mathlib/CategoryTheory/CopyDiscardCategory/Deterministic.lean
+++ b/Mathlib/CategoryTheory/CopyDiscardCategory/Deterministic.lean
@@ -1,0 +1,60 @@
+/-
+Copyright (c) 2025 Jacob Reinhold. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Jacob Reinhold
+-/
+import Mathlib.CategoryTheory.CopyDiscardCategory.Basic
+
+/-!
+# Deterministic Morphisms in Copy-Discard Categories
+
+Morphisms that preserve the copy operation perfectly.
+
+A morphism `f : X → Y` is deterministic if copying then applying `f` to both copies equals applying
+`f` then copying: `f ≫ Δ[Y] = Δ[X] ≫ (f ⊗ f)`.
+
+In probabilistic settings, these are morphisms without randomness. In cartesian categories, all
+morphisms are deterministic.
+
+## Main definitions
+
+* `Deterministic` - Type class for morphisms that preserve copying
+
+## Main results
+
+* Identity morphisms are deterministic
+* Composition of deterministic morphisms is deterministic
+
+## Tags
+
+deterministic, copy-discard category, comonoid morphism
+-/
+
+universe v u
+
+namespace CategoryTheory
+
+open MonoidalCategory ComonObj
+
+variable {C : Type u} [Category.{v} C] [MonoidalCategory.{v} C] [CopyDiscardCategory.{v} C]
+
+/-- A morphism is deterministic if it preserves the comonoid structure.
+
+In probabilistic contexts, these are morphisms without randomness. -/
+abbrev Deterministic {X Y : C} (f : X ⟶ Y) := IsComonHom f
+
+namespace Deterministic
+
+variable {X Y Z : C}
+
+/-- Deterministic morphisms commute with copying. -/
+lemma copy_natural (f : X ⟶ Y) [Deterministic f] : f ≫ Δ[Y] = Δ[X] ≫ (f ⊗ₘ f) :=
+  IsComonHom.hom_comul f
+
+/-- Deterministic morphisms commute with discarding. -/
+lemma discard_natural (f : X ⟶ Y) [Deterministic f] : f ≫ ε[Y] = ε[X] :=
+  IsComonHom.hom_counit f
+
+end Deterministic
+
+end CategoryTheory

--- a/docs/references.bib
+++ b/docs/references.bib
@@ -1052,6 +1052,19 @@
   keywords      = {{16P10, 16U99},Mathematics - Rings and Algebras}
 }
 
+@Article{         cho_jacobs_2019,
+  title         = {Disintegration and Bayesian inversion via string
+                  diagrams},
+  author        = {Cho, Kenta and Jacobs, Bart},
+  journal       = {Mathematical Structures in Computer Science},
+  volume        = {29},
+  number        = {7},
+  pages         = {938--971},
+  year          = {2019},
+  publisher     = {Cambridge University Press},
+  doi           = {10.1017/S0960129518000488}
+}
+
 @InProceedings{   Chou1994,
   author        = {Chou, Ching-Tsun},
   booktitle     = {Higher Order Logic Theorem Proving and Its Applications},


### PR DESCRIPTION
This PR introduces copy-discard categories for categorical probability theory (see #29657 for future work).

This PR builds on #29919.

## Main additions

### 1. Copy-discard categories (`CopyDiscardCategory`)

A symmetric monoidal category where every object has commutative comonoid structure (copy and discard operations) compatible with the tensor product.

### 2. Deterministic morphisms

Morphisms that preserve copy-discard structure. In probabilistic interpretations, these lack randomness. In Cartesian categories, all morphisms are deterministic.

## Mathematical significance

Copy-discard categories provide the base for categorical probability (a later PR will build Markov categories from this); morphisms model stochastic processes, copy creates perfect correlation, discard marginalizes.

## Implementation notes

- Builds on the `CommComonObj` class in #29919
- Uses type class instances to provide copy/discard for all objects
- The `Deterministic` type class abbreviates `IsComonHom` for readability

## References

Added citations to:
- Cho & Jacobs (2019) on disintegration and Bayesian inversion with string diagrams
- Fritz (2020) on categorical approaches to statistics and conditional independence

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)