### PR TITLE
[Merged by Bors] - feat(InfinitePlace/Embeddings): remove dependency of `IsMixed`/`IsUnmixed` on `Extension`.

### DIFF
--- a/Mathlib/NumberTheory/NumberField/InfinitePlace/Embeddings.lean
+++ b/Mathlib/NumberTheory/NumberField/InfinitePlace/Embeddings.lean
@@ -315,7 +315,7 @@ if and only if it's restriction to `K` is.
 This is the complex embedding analogue of `InfinitePlace.IsUnramified K w`, where
 `w : InfinitePlace L`. In this case there is an isomorphism between unmixed embeddings and
 unramified infinite places. -/
-abbrev IsUnmixed (φ : L →+* ℂ) := ¬IsMixed K φ
+abbrev IsUnmixed (φ : L →+* ℂ) := IsReal (φ.comp (algebraMap K L)) → IsReal φ
 
 theorem IsUnmixed.isReal_iff_isReal {φ : L →+* ℂ} (h : IsUnmixed K φ) :
     IsReal (φ.comp (algebraMap K L)) ↔ IsReal φ := by

--- a/Mathlib/NumberTheory/NumberField/InfinitePlace/Embeddings.lean
+++ b/Mathlib/NumberTheory/NumberField/InfinitePlace/Embeddings.lean
@@ -277,11 +277,9 @@ section Extension
 
 variable {K : Type*} (L : Type*) [Field K] [Field L] (ψ : K →+* ℂ) [Algebra K L]
 
-/--
-If `L/K` and `ψ : K →+* ℂ`, `φ : L →+* ℂ`, then we say `φ` is an extension of `ψ` if
-`φ` restricted to `K` is `ψ`.
--/
-abbrev Extension := { φ : L →+* ℂ // φ.comp (algebraMap K L) = ψ }
+/-- If `L/K` and `ψ : K →+* ℂ`, then the type of `ComplexEmbedding.Extension L ψ` consists of all
+`φ : L →+* ℂ` such that `φ.comp (algebraMap K L) = ψ`. -/
+protected abbrev Extension := { φ : L →+* ℂ // φ.comp (algebraMap K L) = ψ }
 
 namespace Extension
 

--- a/Mathlib/NumberTheory/NumberField/InfinitePlace/Embeddings.lean
+++ b/Mathlib/NumberTheory/NumberField/InfinitePlace/Embeddings.lean
@@ -273,11 +273,15 @@ lemma orderOf_isConj_two_of_ne_one (hσ : IsConj φ σ) (hσ' : σ ≠ 1) :
     orderOf σ = 2 :=
   orderOf_eq_prime_iff.mpr ⟨by ext; simpa using isConj_apply_apply hσ _, hσ'⟩
 
+section Extension
+
 variable {K : Type*} (L : Type*) [Field K] [Field L] (ψ : K →+* ℂ) [Algebra K L]
 
-/-- If `L/K` and `ψ : K →+* ℂ`, then the type of `ComplexExtension L ψ` consists of all
-`φ : L →+* ℂ` such that `φ.comp (algebraMap K L) = ψ`. -/
-protected abbrev Extension := { φ : L →+* ℂ // φ.comp (algebraMap K L) = ψ }
+/--
+If `L/K` and `ψ : K →+* ℂ`, `φ : L →+* ℂ`, then we say `φ` is an extension of `ψ` if
+`φ` restricted to `K` is `ψ`.
+-/
+abbrev Extension := { φ : L →+* ℂ // φ.comp (algebraMap K L) = ψ }
 
 namespace Extension
 
@@ -285,34 +289,38 @@ variable (φ : ComplexEmbedding.Extension L ψ) {L ψ}
 
 theorem comp_eq : φ.1.comp (algebraMap K L) = ψ := φ.2
 
-variable {φ}
-
 theorem conjugate_comp_ne (h : ¬IsReal ψ) : (conjugate φ).comp (algebraMap K L) ≠ ψ := by
   simp_all [ComplexEmbedding.isReal_iff, comp_eq]
 
 theorem not_isReal_of_not_isReal (h : ¬IsReal ψ) : ¬IsReal φ.1 :=
   mt (IsReal.comp _) (comp_eq φ ▸ h)
 
-variable (φ)
+end Extension
 
-/-- If `L/K`, `ψ : K →+* ℂ` and `φ : ComplexExtension L ψ` is an extension of `ψ`, then
-`φ.IsMixed` if the image of `ψ` is real while the image of `φ` is complex.
+variable (K) {L ψ}
 
-This is the complex embedding analogue of ramified extensions of infinite places. It is not the
-same concept because conjugation of `φ` in this case leads to a non-extension of `ψ` but
-preserves extensions of associated infinite places, leading to a two-to-one isomorphism. -/
-abbrev IsMixed := IsReal ψ ∧ ¬IsReal φ.1
+/-- If `L/K` and `φ : L →+* ℂ`, then `IsMixed K φ` if the image of `φ` is complex while the image
+of `φ` restricted to `K` is real.
 
-/-- If `L/K`, `ψ : K →+* ℂ`, and `φ : ComplexExtension L ψ` is an extension of `ψ`, then
-`φ.IsUnmixed` if it is not mixed, i.e., the image of `ψ` is real if and only if the image of
-`φ` is real.
+This is the complex embedding analogue of `InfinitePlace.IsRamified K w`, where
+`w : InfinitePlace L`. It is not the same concept because conjugation of `φ` in this case
+leads to two distinct mixed embeddings but only a single ramified place `w`, leading to a
+two-to-one isomorphism between them. -/
+abbrev IsMixed (φ : L →+* ℂ) :=
+  ComplexEmbedding.IsReal (φ.comp (algebraMap K L)) ∧ ¬ComplexEmbedding.IsReal φ
 
-This is the complex embedding analogue of `InfinitePlace.UnramifiedExtension`. In this case
-there is an isomorphism between complex extensions of `ψ` and unramified extensions of
-associated infinite places. -/
-abbrev IsUnmixed := ¬φ.IsMixed
+/-- If `L/K` and `φ : L →+* ℂ`, then `IsMixed K φ` if `φ` is not mixed in `K`, i.e., `φ` is real
+if and only if it's restriction to `K` is.
 
-theorem IsUnmixed.isReal_iff_isReal (h : φ.IsUnmixed) : IsReal ψ ↔ IsReal φ.1 := by
+This is the complex embedding analogue of `InfinitePlace.IsUnramified K w`, where
+`w : InfinitePlace L`. In this case there is an isomorphism between unmixed embeddings and
+unramified infinite places. -/
+abbrev IsUnmixed (φ : L →+* ℂ) := ¬IsMixed K φ
+
+theorem IsUnmixed.isReal_iff_isReal {φ : L →+* ℂ} (h : IsUnmixed K φ) :
+    IsReal (φ.comp (algebraMap K L)) ↔ IsReal φ := by
   aesop (add simp [IsReal.comp])
 
-end NumberField.ComplexEmbedding.Extension
+end Extension
+
+end NumberField.ComplexEmbedding


### PR DESCRIPTION
- Remove the unnecessary dependency of `ComplexEmbedding.IsUnmixed` on the subtype `ComplexEmbedding.Extension`, which makes it easier to use as it does not require the construction of a term of `ComplexEmbedding.Extension`. This also aligns it more closely with [`InfinitePlace.IsUnramified`](https://github.com/leanprover-community/mathlib4/blob/f4506f7151c9057fd9f8714b2a1f13a647fe2352/Mathlib/NumberTheory/NumberField/InfinitePlace/Ramification.lean#L162-L165), of which it is intended to be an analogue.
- Ditto for `ComplexEmbedding.IsMixed`. 
- The definition of `IsUnmixed` is now given in simp-normal form.

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include at least one commit authored by each
co-author among the commits in the pull request. If necessary, you may 
create empty commits to indicate co-authorship, using commands like so:

git commit --author="Author Name <author@email.com>" --allow-empty -m "add Author Name as coauthor"

When merging, all the commits will be squashed into a single commit listing all co-authors.

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
