### PR TITLE
[Merged by Bors] - chore(Convex/Extreme): redefine `IsExtreme` and `extremePoints`

### DIFF
--- a/Mathlib/Analysis/Convex/Exposed.lean
+++ b/Mathlib/Analysis/Convex/Exposed.lean
@@ -87,6 +87,7 @@ protected theorem antisymm (hB : IsExposed 𝕜 A B) (hA : IsExposed 𝕜 B A) :
 `A₀₀₀, ..., A₁₁₁` and add to it the triangle `A₀₀₀A₀₀₁A₀₁₀`. Then `A₀₀₁A₀₁₀` is an exposed subset
 of `A₀₀₀A₀₀₁A₀₁₀` which is an exposed subset of the cube, but `A₀₀₁A₀₁₀` is not itself an exposed
 subset of the cube. -/
+
 protected theorem mono (hC : IsExposed 𝕜 A C) (hBA : B ⊆ A) (hCB : C ⊆ B) : IsExposed 𝕜 B C := by
   rintro ⟨w, hw⟩
   obtain ⟨l, rfl⟩ := hC ⟨w, hw⟩
@@ -102,6 +103,7 @@ theorem eq_inter_halfSpace' {A B : Set E} (hAB : IsExposed 𝕜 A B) (hB : B.Non
   obtain ⟨w, hw⟩ := hB
   exact ⟨l, l w, Subset.antisymm (fun x hx => ⟨hx.1, hx.2 w hw.1⟩) fun x hx =>
     ⟨hx.1, fun y hy => (hw.2 y hy).trans hx.2⟩⟩
+
 /-- For nontrivial `𝕜`, if `B` is an exposed subset of `A`, then `B` is the intersection of `A` with
 some closed half-space. The converse is *not* true. It would require that the corresponding open
 half-space doesn't intersect `A`. -/
@@ -115,6 +117,7 @@ theorem eq_inter_halfSpace [IsOrderedRing 𝕜] [Nontrivial 𝕜] {A B : Set E} 
     have : ¬(1 : 𝕜) ≤ 0 := not_le_of_gt zero_lt_one
     contradiction
   exact hAB.eq_inter_halfSpace' hB
+
 protected theorem inter [IsOrderedRing 𝕜] [ContinuousAdd 𝕜] {A B C : Set E} (hB : IsExposed 𝕜 A B)
     (hC : IsExposed 𝕜 A C) : IsExposed 𝕜 A (B ∩ C) := by
   rintro ⟨w, hwB, hwC⟩
@@ -221,11 +224,9 @@ protected theorem isExtreme (hAB : IsExposed 𝕜 A B) : IsExtreme 𝕜 A B := b
   have hl : ConvexOn 𝕜 univ l := l.toLinearMap.convexOn convex_univ
   have hlx₁ := hxB.2 x₁ hx₁A
   have hlx₂ := hxB.2 x₂ hx₂A
-  refine ⟨⟨hx₁A, fun y hy => ?_⟩, ⟨hx₂A, fun y hy => ?_⟩⟩
-  · rw [hlx₁.antisymm (hl.le_left_of_right_le (mem_univ _) (mem_univ _) hx hlx₂)]
-    exact hxB.2 y hy
-  · rw [hlx₂.antisymm (hl.le_right_of_left_le (mem_univ _) (mem_univ _) hx hlx₁)]
-    exact hxB.2 y hy
+  refine ⟨hx₁A, fun y hy => ?_⟩
+  rw [hlx₁.antisymm (hl.le_left_of_right_le (mem_univ _) (mem_univ _) hx hlx₂)]
+  exact hxB.2 y hy
 
 end IsExposed
 

--- a/Mathlib/Analysis/Convex/Extreme.lean
+++ b/Mathlib/Analysis/Convex/Extreme.lean
@@ -49,32 +49,37 @@ variable (𝕜) [Semiring 𝕜] [PartialOrder 𝕜] [AddCommMonoid E] [SMul 𝕜
 
 /-- A set `B` is an extreme subset of `A` if `B ⊆ A` and all points of `B` only belong to open
 segments whose ends are in `B`. -/
-def IsExtreme (A B : Set E) : Prop :=
-  B ⊆ A ∧ ∀ ⦃x₁⦄, x₁ ∈ A → ∀ ⦃x₂⦄, x₂ ∈ A → ∀ ⦃x⦄, x ∈ B → x ∈ openSegment 𝕜 x₁ x₂ → x₁ ∈ B ∧ x₂ ∈ B
+@[mk_iff]
+structure IsExtreme (A B : Set E) : Prop where
+  subset : B ⊆ A
+  left_mem_of_mem_openSegment : ∀ ⦃x⦄, x ∈ A → ∀ ⦃y⦄, y ∈ A →
+    ∀ ⦃z⦄, z ∈ B → z ∈ openSegment 𝕜 x y → x ∈ B
 
 /-- A point `x` is an extreme point of a set `A` if `x` belongs to no open segment with ends in
-`A`, except for the obvious `openSegment x x`.
-
-In order to prove that `x` is an extreme point of `A`,
-it is convenient to use `mem_extremePoints_iff_left` to avoid repeating arguments twice. -/
+`A`, except for the obvious `openSegment x x`. -/
 def Set.extremePoints (A : Set E) : Set E :=
-  { x ∈ A | ∀ ⦃x₁⦄, x₁ ∈ A → ∀ ⦃x₂⦄, x₂ ∈ A → x ∈ openSegment 𝕜 x₁ x₂ → x₁ = x ∧ x₂ = x }
+  {x ∈ A | ∀ ⦃x₁⦄, x₁ ∈ A → ∀ ⦃x₂⦄, x₂ ∈ A → x ∈ openSegment 𝕜 x₁ x₂ → x₁ = x}
 
 @[refl]
 protected theorem IsExtreme.refl (A : Set E) : IsExtreme 𝕜 A A :=
-  ⟨Subset.rfl, fun _ hx₁A _ hx₂A _ _ _ ↦ ⟨hx₁A, hx₂A⟩⟩
+  ⟨Subset.rfl, fun _ hx₁A _ _ _ _ _ ↦ hx₁A⟩
 
 variable {𝕜} {A B C : Set E} {x : E}
 
 protected theorem IsExtreme.rfl : IsExtreme 𝕜 A A :=
   IsExtreme.refl 𝕜 A
 
+theorem IsExtreme.right_mem_of_mem_openSegment (h : IsExtreme 𝕜 A B) {y z : E} (hx : x ∈ A)
+    (hy : y ∈ A) (hz : z ∈ B) (hzxy : z ∈ openSegment 𝕜 x y) : y ∈ B :=
+  h.left_mem_of_mem_openSegment hy hx hz <| by rwa [openSegment_symm]
+
 @[trans]
 protected theorem IsExtreme.trans (hAB : IsExtreme 𝕜 A B) (hBC : IsExtreme 𝕜 B C) :
     IsExtreme 𝕜 A C := by
-  refine ⟨Subset.trans hBC.1 hAB.1, fun x₁ hx₁A x₂ hx₂A x hxC hx ↦ ?_⟩
-  obtain ⟨hx₁B, hx₂B⟩ := hAB.2 hx₁A hx₂A (hBC.1 hxC) hx
-  exact hBC.2 hx₁B hx₂B hxC hx
+  refine ⟨hBC.subset.trans hAB.subset, fun x₁ hx₁A x₂ hx₂A x hxC hx ↦ ?_⟩
+  exact hBC.left_mem_of_mem_openSegment
+    (hAB.left_mem_of_mem_openSegment hx₁A hx₂A (hBC.subset hxC) hx)
+    (hAB.right_mem_of_mem_openSegment hx₁A hx₂A (hBC.subset hxC) hx) hxC hx
 
 protected theorem IsExtreme.antisymm : AntiSymmetric (IsExtreme 𝕜 : Set E → Set E → Prop) :=
   fun _ _ hAB hBA ↦ Subset.antisymm hBA.1 hAB.1
@@ -88,9 +93,8 @@ theorem IsExtreme.inter (hAB : IsExtreme 𝕜 A B) (hAC : IsExtreme 𝕜 A C) :
     IsExtreme 𝕜 A (B ∩ C) := by
   use Subset.trans inter_subset_left hAB.1
   rintro x₁ hx₁A x₂ hx₂A x ⟨hxB, hxC⟩ hx
-  obtain ⟨hx₁B, hx₂B⟩ := hAB.2 hx₁A hx₂A hxB hx
-  obtain ⟨hx₁C, hx₂C⟩ := hAC.2 hx₁A hx₂A hxC hx
-  exact ⟨⟨hx₁B, hx₁C⟩, hx₂B, hx₂C⟩
+  exact ⟨hAB.left_mem_of_mem_openSegment hx₁A hx₂A hxB hx,
+    hAC.left_mem_of_mem_openSegment hx₁A hx₂A hxC hx⟩
 
 protected theorem IsExtreme.mono (hAC : IsExtreme 𝕜 A C) (hBA : B ⊆ A) (hCB : C ⊆ B) :
     IsExtreme 𝕜 B C :=
@@ -98,11 +102,10 @@ protected theorem IsExtreme.mono (hAC : IsExtreme 𝕜 A C) (hBA : B ⊆ A) (hCB
 
 theorem isExtreme_iInter {ι : Sort*} [Nonempty ι] {F : ι → Set E}
     (hAF : ∀ i : ι, IsExtreme 𝕜 A (F i)) : IsExtreme 𝕜 A (⋂ i : ι, F i) := by
-  obtain i := Classical.arbitrary ι
-  refine ⟨iInter_subset_of_subset i (hAF i).1, fun x₁ hx₁A x₂ hx₂A x hxF hx ↦ ?_⟩
-  simp_rw [mem_iInter] at hxF ⊢
-  have h := fun i ↦ (hAF i).2 hx₁A hx₂A (hxF i) hx
-  exact ⟨fun i ↦ (h i).1, fun i ↦ (h i).2⟩
+  inhabit ι
+  refine ⟨iInter_subset_of_subset default (hAF default).1, fun x₁ hx₁A x₂ hx₂A x hxF hx ↦ ?_⟩
+  rw [mem_iInter] at hxF ⊢
+  exact fun i ↦ (hAF i).2 hx₁A hx₂A (hxF i) hx
 
 theorem isExtreme_biInter {F : Set (Set E)} (hF : F.Nonempty) (hA : ∀ B ∈ F, IsExtreme 𝕜 A B) :
     IsExtreme 𝕜 A (⋂ B ∈ F, B) := by
@@ -112,30 +115,30 @@ theorem isExtreme_biInter {F : Set (Set E)} (hF : F.Nonempty) (hA : ∀ B ∈ F,
 theorem isExtreme_sInter {F : Set (Set E)} (hF : F.Nonempty) (hAF : ∀ B ∈ F, IsExtreme 𝕜 A B) :
     IsExtreme 𝕜 A (⋂₀ F) := by simpa [sInter_eq_biInter] using isExtreme_biInter hF hAF
 
+/-- A point `x` is an extreme point of a set `A`
+iff `x ∈ A` and for any `x₁`, `x₂` such that `x` belongs to the open segment `(x₁, x₂)`,
+we have `x₁ = x` and `x₂ = x`.
+
+We used to use the RHS as the definition of `extremePoints`.
+However, the conclusion `x₂ = x` is redundant,
+so we changed the definition to the RHS of `mem_extremePoints_iff_left`. -/
 theorem mem_extremePoints : x ∈ A.extremePoints 𝕜 ↔
-    x ∈ A ∧ ∀ᵉ (x₁ ∈ A) (x₂ ∈ A), x ∈ openSegment 𝕜 x₁ x₂ → x₁ = x ∧ x₂ = x :=
-  Iff.rfl
-
-/-- In order to prove that a point `x` is an extreme point of a set `A`,
-it suffices to show that `x ∈ A`
-and for any `x₁`, `x₂` such that `x` belongs to the open segment `(x₁, x₂)`, we have `x₁ = x`.
-
-The definition of `extremePoints` also requires `x₂ = x`, but this condition is redundant. -/
-theorem mem_extremePoints_iff_left : x ∈ A.extremePoints 𝕜 ↔
-    x ∈ A ∧ ∀ x₁ ∈ A, ∀ x₂ ∈ A, x ∈ openSegment 𝕜 x₁ x₂ → x₁ = x := by
-  refine ⟨fun h ↦ ⟨h.1, fun x₁ hx₁ x₂ hx₂ hx ↦ (h.2 hx₁ hx₂ hx).1⟩, ?_⟩
-  rintro ⟨hxA, Hx⟩
-  use hxA
-  refine fun x₁ hx₁ x₂ hx₂ hx ↦ ⟨Hx x₁ hx₁ x₂ hx₂ hx, Hx x₂ hx₂ x₁ hx₁ ?_⟩
+    x ∈ A ∧ ∀ᵉ (x₁ ∈ A) (x₂ ∈ A), x ∈ openSegment 𝕜 x₁ x₂ → x₁ = x ∧ x₂ = x := by
+  refine ⟨fun h ↦ ⟨h.1, fun x₁ hx₁ x₂ hx₂ hx ↦ ⟨h.2 hx₁ hx₂ hx, ?_⟩⟩,
+    fun h ↦ ⟨h.1, fun x₁ hx₁ x₂ hx₂ hx ↦ (h.2 x₁ hx₁ x₂ hx₂ hx).1⟩⟩
+  apply h.2 hx₂ hx₁
   rwa [openSegment_symm]
+
+/-- A point `x` is an extreme point of a set `A`
+iff `x ∈ A` and for any `x₁`, `x₂` such that `x` belongs to the open segment `(x₁, x₂)`,
+we have `x₁ = x`. -/
+theorem mem_extremePoints_iff_left : x ∈ A.extremePoints 𝕜 ↔
+    x ∈ A ∧ ∀ x₁ ∈ A, ∀ x₂ ∈ A, x ∈ openSegment 𝕜 x₁ x₂ → x₁ = x :=
+  .rfl
 
 /-- x is an extreme point to A iff {x} is an extreme set of A. -/
 @[simp] lemma isExtreme_singleton : IsExtreme 𝕜 A {x} ↔ x ∈ A.extremePoints 𝕜 := by
-  refine ⟨fun hx ↦ ⟨singleton_subset_iff.1 hx.1, fun x₁ hx₁ x₂ hx₂ ↦ hx.2 hx₁ hx₂ rfl⟩, ?_⟩
-  rintro ⟨hxA, hAx⟩
-  use singleton_subset_iff.2 hxA
-  rintro x₁ hx₁A x₂ hx₂A y (rfl : y = x)
-  exact hAx hx₁A hx₂A
+  simp [isExtreme_iff, extremePoints]
 
 alias ⟨IsExtreme.mem_extremePoints, _⟩ := isExtreme_singleton
 
@@ -148,8 +151,7 @@ theorem extremePoints_empty : (∅ : Set E).extremePoints 𝕜 = ∅ :=
 
 @[simp]
 theorem extremePoints_singleton : ({x} : Set E).extremePoints 𝕜 = {x} :=
-  extremePoints_subset.antisymm <|
-    singleton_subset_iff.2 ⟨mem_singleton x, fun _ hx₁ _ hx₂ _ ↦ ⟨hx₁, hx₂⟩⟩
+  extremePoints_subset.antisymm <| singleton_subset_iff.2 ⟨mem_singleton x, fun _ hx₁ _ _ _ ↦ hx₁⟩
 
 theorem inter_extremePoints_subset_extremePoints_of_subset (hBA : B ⊆ A) :
     B ∩ A.extremePoints 𝕜 ⊆ B.extremePoints 𝕜 :=
@@ -174,51 +176,44 @@ variable [Semiring 𝕜] [PartialOrder 𝕜] [AddCommGroup E] [AddCommGroup F] [
 theorem IsExtreme.convex_diff [IsOrderedRing 𝕜] (hA : Convex 𝕜 A) (hAB : IsExtreme 𝕜 A B) :
     Convex 𝕜 (A \ B) :=
   convex_iff_openSegment_subset.2 fun _ ⟨hx₁A, hx₁B⟩ _ ⟨hx₂A, _⟩ _ hx ↦
-    ⟨hA.openSegment_subset hx₁A hx₂A hx, fun hxB ↦ hx₁B (hAB.2 hx₁A hx₂A hxB hx).1⟩
+    ⟨hA.openSegment_subset hx₁A hx₂A hx, fun hxB ↦ hx₁B (hAB.2 hx₁A hx₂A hxB hx)⟩
 
 @[simp]
 theorem extremePoints_prod (s : Set E) (t : Set F) :
     (s ×ˢ t).extremePoints 𝕜 = s.extremePoints 𝕜 ×ˢ t.extremePoints 𝕜 := by
-  ext
-  refine (and_congr_right fun hx ↦ ⟨fun h ↦ ?_, fun h ↦ ?_⟩).trans and_and_and_comm
-  constructor
-  · rintro x₁ hx₁ x₂ hx₂ hx_fst
-    refine (h (mk_mem_prod hx₁ hx.2) (mk_mem_prod hx₂ hx.2) ?_).imp (congr_arg Prod.fst)
-        (congr_arg Prod.fst)
-    rw [← Prod.image_mk_openSegment_left]
-    exact ⟨_, hx_fst, rfl⟩
-  · rintro x₁ hx₁ x₂ hx₂ hx_snd
-    refine (h (mk_mem_prod hx.1 hx₁) (mk_mem_prod hx.1 hx₂) ?_).imp (congr_arg Prod.snd)
-        (congr_arg Prod.snd)
-    rw [← Prod.image_mk_openSegment_right]
-    exact ⟨_, hx_snd, rfl⟩
+  ext ⟨x, y⟩
+  refine (and_congr_right fun hx ↦ ⟨fun h ↦ ⟨?_, ?_⟩, fun h ↦ ?_⟩).trans and_and_and_comm
   · rintro x₁ hx₁ x₂ hx₂ ⟨a, b, ha, hb, hab, hx'⟩
-    simp_rw [Prod.ext_iff]
-    exact and_and_and_comm.1
-        ⟨h.1 hx₁.1 hx₂.1 ⟨a, b, ha, hb, hab, congr_arg Prod.fst hx'⟩,
-          h.2 hx₁.2 hx₂.2 ⟨a, b, ha, hb, hab, congr_arg Prod.snd hx'⟩⟩
+    ext
+    · exact h.1 hx₁.1 hx₂.1 ⟨a, b, ha, hb, hab, congrArg Prod.fst hx'⟩
+    · exact h.2 hx₁.2 hx₂.2 ⟨a, b, ha, hb, hab, congrArg Prod.snd hx'⟩
+  · rintro x₁ hx₁ x₂ hx₂ hx_fst
+    refine congrArg Prod.fst (h (mk_mem_prod hx₁ hx.2) (mk_mem_prod hx₂ hx.2) ?_)
+    rw [← Prod.image_mk_openSegment_left]
+    exact mem_image_of_mem _ hx_fst
+  · rintro x₁ hx₁ x₂ hx₂ hx_snd
+    refine congrArg Prod.snd (h (mk_mem_prod hx.1 hx₁) (mk_mem_prod hx.1 hx₂) ?_)
+    rw [← Prod.image_mk_openSegment_right]
+    exact mem_image_of_mem _ hx_snd
 
 @[simp]
 theorem extremePoints_pi (s : ∀ i, Set (M i)) :
     (univ.pi s).extremePoints 𝕜 = univ.pi fun i ↦ (s i).extremePoints 𝕜 := by
   classical
   ext x
-  simp only [mem_extremePoints, mem_pi, mem_univ, true_imp_iff, @forall_and ι]
+  simp only [mem_extremePoints_iff_left, mem_univ_pi, @forall_and ι]
   refine and_congr_right fun hx ↦ ⟨fun h i ↦ ?_, fun h ↦ ?_⟩
   · rintro x₁ hx₁ x₂ hx₂ hi
-    refine (h (update x i x₁) ?_ (update x i x₂) ?_ ?_).imp (fun h₁ ↦ by rw [← h₁, update_self])
-        fun h₂ ↦ by rw [← h₂, update_self]
-    iterate 2
-      rintro j
-      obtain rfl | hji := eq_or_ne j i
-      · rwa [update_self]
-      · rw [update_of_ne hji]
-        exact hx _
-    rw [← Pi.image_update_openSegment]
-    exact ⟨_, hi, update_eq_self _ _⟩
-  · rintro x₁ hx₁ x₂ hx₂ ⟨a, b, ha, hb, hab, hx'⟩
-    simp_rw [funext_iff, ← forall_and]
-    exact fun i ↦ h _ _ (hx₁ _) _ (hx₂ _) ⟨a, b, ha, hb, hab, congr_fun hx' _⟩
+    rw [← update_self i x₁ x, h (update x i x₁) _ (update x i x₂)]
+    · rintro j
+      obtain rfl | hji := eq_or_ne j i <;> simp [*]
+    · rw [← Pi.image_update_openSegment]
+      exact ⟨_, hi, update_eq_self _ _⟩
+    · rintro j
+      obtain rfl | hji := eq_or_ne j i <;> simp [*]
+  · rintro x₁ hx₁ x₂ hx₂ ⟨a, b, ha, hb, hab, rfl⟩
+    ext i
+    exact h _ _ (hx₁ _) _ (hx₂ _) ⟨a, b, ha, hb, hab, rfl⟩
 
 end OrderedSemiring
 
@@ -247,6 +242,7 @@ variable [DenselyOrdered 𝕜] [NoZeroSMulDivisors 𝕜 E] {A : Set E} {x : E}
 that contain it are those with `x` as one of their endpoints. -/
 theorem mem_extremePoints_iff_forall_segment : x ∈ A.extremePoints 𝕜 ↔
     x ∈ A ∧ ∀ᵉ (x₁ ∈ A) (x₂ ∈ A), x ∈ segment 𝕜 x₁ x₂ → x₁ = x ∨ x₂ = x := by
+  rw [mem_extremePoints]
   refine and_congr_right fun hxA ↦ forall₄_congr fun x₁ h₁ x₂ h₂ ↦ ?_
   constructor
   · rw [← insert_endpoints_openSegment]

--- a/Mathlib/Analysis/Convex/Extreme.lean
+++ b/Mathlib/Analysis/Convex/Extreme.lean
@@ -48,7 +48,11 @@ section SMul
 variable (𝕜) [Semiring 𝕜] [PartialOrder 𝕜] [AddCommMonoid E] [SMul 𝕜 E]
 
 /-- A set `B` is an extreme subset of `A` if `B ⊆ A` and all points of `B` only belong to open
-segments whose ends are in `B`. -/
+segments whose ends are in `B`.
+
+Our definition only requires that the left endpoint of the segment lies in `B`,
+but by symmetry of open segments, the right endpoint must also lie in `B`.
+See `IsExtreme.right_mem_of_mem_openSegment`. -/
 @[mk_iff]
 structure IsExtreme (A B : Set E) : Prop where
   subset : B ⊆ A

--- a/Mathlib/Analysis/Convex/KreinMilman.lean
+++ b/Mathlib/Analysis/Convex/KreinMilman.lean
@@ -116,6 +116,7 @@ lemma surjOn_extremePoints_image (f : E →ᴬ[ℝ] F) (hs : IsCompact s) :
   -- `f x = w` and `x` is an extreme point of `s`, so we're done
   refine mem_image_of_mem _ ⟨hx, fun y hy z hz hxyz ↦ ?_⟩
   have := by simpa using image_openSegment _ f.toAffineMap y z
-  have := hw.2 (mem_image_of_mem _ hy) (mem_image_of_mem _ hz) <| by
+  rw [mem_extremePoints] at hw
+  have := hw.2 _ (mem_image_of_mem _ hy) _ (mem_image_of_mem _ hz) <| by
     rw [← this]; exact mem_image_of_mem _ hxyz
   exact hyt ⟨hy, this.1⟩ ⟨hz, this.2⟩ hxyz

--- a/Mathlib/Dynamics/Ergodic/Extreme.lean
+++ b/Mathlib/Dynamics/Ergodic/Extreme.lean
@@ -46,7 +46,7 @@ theorem of_mem_extremePoints_measure_univ_eq {c : ℝ≥0∞} (hc : c ≠ ∞)
     by_contra H
     obtain ⟨hs, hs'⟩ : μ s ≠ 0 ∧ μ sᶜ ≠ 0 := by
       simpa [eventuallyConst_set, ae_iff, and_comm] using H
-    obtain ⟨hcond, -⟩ : c • μ[|s] = μ ∧ c • μ[|sᶜ] = μ := by
+    have hcond : c • μ[|s] = μ := by
       apply h.2 (this hsm hfs hs) (this hsm.compl (by rw [preimage_compl, hfs]) hs')
       refine ⟨μ s / c, μ sᶜ / c, ENNReal.div_pos hs hc, ENNReal.div_pos hs' hc, ?_, ?_⟩
       · rw [← ENNReal.add_div, measure_add_measure_compl hsm, h.1.2, ENNReal.div_self hc₀ hc]


### PR DESCRIPTION
Remove a redundant conclusion from the definitions, so that it's easier to prove these statements now.

As suggested by @YaelDillies  in a comment to #23458

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include at least one commit authored by each
co-author among the commits in the pull request. If necessary, you may 
create empty commits to indicate co-authorship, using commands like so:

git commit --author="Author Name <author@email.com>" --allow-empty -m "add Author Name as coauthor"

When merging, all the commits will be squashed into a single commit listing all co-authors.

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
