### PR TITLE
[Merged by Bors] - feat(CharP/*): generalize a lemma, add `ringChar_eq_one`

### DIFF
--- a/Mathlib/Algebra/CharP/Defs.lean
+++ b/Mathlib/Algebra/CharP/Defs.lean
@@ -180,7 +180,15 @@ lemma dvd {x : ℕ} (hx : (x : R) = 0) : ringChar R ∣ x :=
 lemma eq_zero [CharZero R] : ringChar R = 0 :=
   eq R 0
 
+@[simp]
 lemma Nat.cast_ringChar : (ringChar R : R) = 0 := by rw [ringChar.spec]
+
+@[simp]
+lemma ringChar_eq_one : ringChar R = 1 ↔ Subsingleton R := by
+  rw [← Nat.dvd_one, ← spec, eq_comm, Nat.cast_one, subsingleton_iff_zero_eq_one]
+
+@[nontriviality]
+lemma ringChar_subsingleton [Subsingleton R] : ringChar R = 1 := by simpa
 
 end ringChar
 

--- a/Mathlib/Algebra/CharP/Defs.lean
+++ b/Mathlib/Algebra/CharP/Defs.lean
@@ -180,7 +180,6 @@ lemma dvd {x : ℕ} (hx : (x : R) = 0) : ringChar R ∣ x :=
 lemma eq_zero [CharZero R] : ringChar R = 0 :=
   eq R 0
 
-@[simp]
 lemma Nat.cast_ringChar : (ringChar R : R) = 0 := by rw [ringChar.spec]
 
 @[simp]

--- a/Mathlib/Algebra/CharP/Invertible.lean
+++ b/Mathlib/Algebra/CharP/Invertible.lean
@@ -36,6 +36,11 @@ theorem Odd.all [Ring R] [Invertible (2 : R)] (a : R) : Odd a :=
 section Ring
 variable [Ring R] {p : ℕ} [CharP R p]
 
+theorem not_ringChar_dvd_of_invertible {t : ℕ} [Invertible (t : R)] [Nontrivial R] :
+    ¬ringChar R ∣ t := by
+  rw [← ringChar.spec, ← Ne]
+  exact Invertible.ne_zero (t : R)
+
 theorem CharP.intCast_mul_natCast_gcdA_eq_gcd (n : ℕ) :
     (n * n.gcdA p : R) = n.gcd p := by
   suffices ↑(n * n.gcdA p + p * n.gcdB p : ℤ) = ((n.gcd p : ℤ) : R) by simpa using this
@@ -85,10 +90,6 @@ variable [Semifield K]
 divide `t`. -/
 def invertibleOfRingCharNotDvd {t : ℕ} (not_dvd : ¬ringChar K ∣ t) : Invertible (t : K) :=
   invertibleOfNonzero fun h => not_dvd ((ringChar.spec K t).mp h)
-
-theorem not_ringChar_dvd_of_invertible {t : ℕ} [Invertible (t : K)] : ¬ringChar K ∣ t := by
-  rw [← ringChar.spec, ← Ne]
-  exact Invertible.ne_zero (t : K)
 
 /-- A natural number `t` is invertible in a semifield `K` of characteristic `p` if `p` does not
 divide `t`. -/


### PR DESCRIPTION
---
I have no specific plans for these lemmas, just noticed a lemma that can be generalized and a missing `nontriviality` lemma.

<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include at least one commit authored by each
co-author among the commits in the pull request. If necessary, you may 
create empty commits to indicate co-authorship, using commands like so:

git commit --author="Author Name <author@email.com>" --allow-empty -m "add Author Name as coauthor"

When merging, all the commits will be squashed into a single commit listing all co-authors.

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
