### PR TITLE
[Merged by Bors] - feat(Data/Set/Subsingleton): added new lemma `Subsingleton.union_subsingleton` along with some trivial code cleanup

### DIFF
--- a/Mathlib/Data/Set/Subsingleton.lean
+++ b/Mathlib/Data/Set/Subsingleton.lean
@@ -80,13 +80,19 @@ lemma Subsingleton.inter_singleton : (s ∩ {a}).Subsingleton :=
 lemma Subsingleton.singleton_inter : ({a} ∩ s).Subsingleton :=
   Set.subsingleton_of_subset_singleton Set.inter_subset_left
 
-theorem subsingleton_of_subsingleton [Subsingleton α] {s : Set α} : Set.Subsingleton s :=
+lemma Subsingleton.union_subsingleton (h : (s ∪ t).Subsingleton) :
+    s.Subsingleton ∧ t.Subsingleton := by
+  constructor <;> intro _ h₁ _ h₂
+  · exact h (.inl h₁) (.inl h₂)
+  · exact h (.inr h₁) (.inr h₂)
+
+theorem subsingleton_of_subsingleton [Subsingleton α] {s : Set α} : s.Subsingleton :=
   subsingleton_univ.anti (subset_univ s)
 
-theorem subsingleton_isTop (α : Type*) [PartialOrder α] : Set.Subsingleton { x : α | IsTop x } :=
+theorem subsingleton_isTop (α : Type*) [PartialOrder α] : { x : α | IsTop x }.Subsingleton :=
   fun x hx _ hy => hx.isMax.eq_of_le (hy x)
 
-theorem subsingleton_isBot (α : Type*) [PartialOrder α] : Set.Subsingleton { x : α | IsBot x } :=
+theorem subsingleton_isBot (α : Type*) [PartialOrder α] : { x : α | IsBot x }.Subsingleton :=
   fun x hx _ hy => hx.isMin.eq_of_ge (hy x)
 
 theorem exists_eq_singleton_iff_nonempty_subsingleton :

--- a/Mathlib/Data/Set/Subsingleton.lean
+++ b/Mathlib/Data/Set/Subsingleton.lean
@@ -80,11 +80,11 @@ lemma Subsingleton.inter_singleton : (s ∩ {a}).Subsingleton :=
 lemma Subsingleton.singleton_inter : ({a} ∩ s).Subsingleton :=
   Set.subsingleton_of_subset_singleton Set.inter_subset_left
 
-lemma Subsingleton.union_subsingleton_left (h : (s ∪ t).Subsingleton) :
+lemma subsingleton_of_subsingleton_inter_left (h : (s ∪ t).Subsingleton) :
     s.Subsingleton :=
   fun _ h₁ _ h₂ ↦ h (.inl h₁) (.inl h₂)
 
-lemma Subsingleton.union_subsingleton_right (h : (s ∪ t).Subsingleton) :
+lemma subsingleton_of_subsingleton_inter_right (h : (s ∪ t).Subsingleton) :
     t.Subsingleton :=
   fun _ h₁ _ h₂ ↦ h (.inr h₁) (.inr h₂)
 

--- a/Mathlib/Data/Set/Subsingleton.lean
+++ b/Mathlib/Data/Set/Subsingleton.lean
@@ -80,11 +80,13 @@ lemma Subsingleton.inter_singleton : (s ∩ {a}).Subsingleton :=
 lemma Subsingleton.singleton_inter : ({a} ∩ s).Subsingleton :=
   Set.subsingleton_of_subset_singleton Set.inter_subset_left
 
-lemma Subsingleton.union_subsingleton (h : (s ∪ t).Subsingleton) :
-    s.Subsingleton ∧ t.Subsingleton := by
-  constructor <;> intro _ h₁ _ h₂
-  · exact h (.inl h₁) (.inl h₂)
-  · exact h (.inr h₁) (.inr h₂)
+lemma Subsingleton.union_subsingleton_left (h : (s ∪ t).Subsingleton) :
+    s.Subsingleton :=
+  fun _ h₁ _ h₂ ↦ h (.inl h₁) (.inl h₂)
+
+lemma Subsingleton.union_subsingleton_right (h : (s ∪ t).Subsingleton) :
+    t.Subsingleton :=
+  fun _ h₁ _ h₂ ↦ h (.inr h₁) (.inr h₂)
 
 theorem subsingleton_of_subsingleton [Subsingleton α] {s : Set α} : s.Subsingleton :=
   subsingleton_univ.anti (subset_univ s)


### PR DESCRIPTION
---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include at least one commit authored by each
co-author among the commits in the pull request. If necessary, you may 
create empty commits to indicate co-authorship, using commands like so:

git commit --author="Author Name <author@email.com>" --allow-empty -m "add Author Name as coauthor"

When merging, all the commits will be squashed into a single commit listing all co-authors.

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

Added a lemma which implies both sets are subsingleton if their union is subsingleton.

```lean
lemma Subsingleton.union_subsingleton (h : (s ∪ t).Subsingleton) :
    s.Subsingleton ∧ t.Subsingleton
```

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
