### PR TITLE
[Merged by Bors] - feat(CategoryTheory/Limits/Cones): add Co(co)neMorphism.map_w

### DIFF
--- a/Mathlib/CategoryTheory/Limits/Cones.lean
+++ b/Mathlib/CategoryTheory/Limits/Cones.lean
@@ -400,6 +400,17 @@ def whiskeringEquivalence (e : K ≌ J) : Cone F ≌ Cone (e.functor ⋙ F) wher
 def equivalenceOfReindexing {G : K ⥤ C} (e : K ≌ J) (α : e.functor ⋙ F ≅ G) : Cone F ≌ Cone G :=
   (whiskeringEquivalence e).trans (postcomposeEquivalence α)
 
+
+/-- Given a cone isomorphism, produce an isomorphism of the object parts. -/
+@[simps!]
+def IsoPt {c c' : Cone F} (e : c ≅ c') : c.pt ≅ c'.pt where
+  hom := e.hom.hom
+  inv := e.inv.hom
+
+/-- `Cones.IsoPt` is compatible with `π`. -/
+lemma isoPt_π {c c' : Cone F} (e : c ≅ c') (j : J) : (IsoPt e).hom ≫ c'.π.app j = c.π.app j :=
+  e.hom.w j
+
 section
 
 variable (F)
@@ -614,6 +625,16 @@ The categories of cocones over `F` and `G` are equivalent if `F` and `G` are nat
 @[simps! functor_obj]
 def equivalenceOfReindexing {G : K ⥤ C} (e : K ≌ J) (α : e.functor ⋙ F ≅ G) : Cocone F ≌ Cocone G :=
   (whiskeringEquivalence e).trans (precomposeEquivalence α.symm)
+
+/-- Given a cocone isomorphism, produce an isomorphism of the object parts. -/
+@[simps!]
+def IsoPt {c c' : Cocone F} (e : c ≅ c') : c.pt ≅ c'.pt where
+  hom := e.hom.hom
+  inv := e.inv.hom
+
+/-- `Cocones.IsoPt` is compatible with `ι`. -/
+lemma isoPt_ι {c c' : Cocone F} (e : c ≅ c') (j : J) : c.ι.app j ≫ (IsoPt e).hom = c'.ι.app j :=
+  e.hom.w j
 
 section
 
@@ -831,6 +852,16 @@ def mapConeWhisker {E : K ⥤ J} {c : Cone F} : mapCone H (c.whisker E) ≅ (map
 def mapCoconeWhisker {E : K ⥤ J} {c : Cocone F} :
     mapCocone H (c.whisker E) ≅ (mapCocone H c).whisker E :=
   Cocones.ext (Iso.refl _)
+
+/-- `mapCone` is compatible with `Cones.IsoPt`. -/
+lemma mapCone_π_isoPt {c c' : Cone F} (e : c ≅ c') (j : J) :
+    (H.mapIso (Cones.IsoPt e)).hom ≫ (H.mapCone c').π.app j = (H.mapCone c).π.app j :=
+  ((Cones.functoriality F H).mapIso e).hom.w j
+
+/-- `mapCocone` is compatible with `Cocones.IsoPt`. -/
+lemma mapCocone_ι_isoPt {c c' : Cocone F} (e : c ≅ c') (j : J) :
+    (H.mapCocone c).ι.app j ≫ (H.mapIso (Cocones.IsoPt e)).hom = (H.mapCocone c').ι.app j :=
+  ((Cocones.functoriality F H).mapIso e).hom.w j
 
 end Functor
 

--- a/Mathlib/CategoryTheory/Limits/Cones.lean
+++ b/Mathlib/CategoryTheory/Limits/Cones.lean
@@ -410,12 +410,6 @@ def forget : Cone F ⥤ C where
   obj t := t.pt
   map f := f.hom
 
-variable {F} in
-/-- Given a cone isomorphism, produce an isomorphism of the object parts. -/
-@[simps!]
-def _root_.CategoryTheory.Iso.conePt {c c' : Cone F} (e : c ≅ c') : c.pt ≅ c'.pt :=
-  (Cones.forget F).mapIso e
-
 variable (G : C ⥤ D)
 
 /-- A functor `G : C ⥤ D` sends cones over `F` to cones over `F ⋙ G` functorially. -/
@@ -631,12 +625,6 @@ def forget : Cocone F ⥤ C where
   obj t := t.pt
   map f := f.hom
 
-variable {F} in
-/-- Given a cocone isomorphism, produce an isomorphism of the object parts. -/
-@[simps!]
-def _root_.CategoryTheory.Iso.coconePt {c c' : Cocone F} (e : c ≅ c') : c.pt ≅ c'.pt :=
-  (Cocones.forget F).mapIso e
-
 variable (G : C ⥤ D)
 
 /-- A functor `G : C ⥤ D` sends cocones over `F` to cocones over `F ⋙ G` functorially. -/
@@ -844,14 +832,14 @@ def mapCoconeWhisker {E : K ⥤ J} {c : Cocone F} :
     mapCocone H (c.whisker E) ≅ (mapCocone H c).whisker E :=
   Cocones.ext (Iso.refl _)
 
-/-- `mapCone` is compatible with `Cones.IsoPt`. -/
-lemma mapCone_π_isoPt {c c' : Cone F} (e : c ≅ c') (j : J) :
-    (H.mapIso e.conePt).hom ≫ (H.mapCone c').π.app j = (H.mapCone c).π.app j := by
+/-- `mapCone` is compatible with `Cones.forget`. -/
+lemma mapCone_π_forget {c c' : Cone F} (e : c ⟶ c') (j : J) :
+    H.map ((Cones.forget F).map e) ≫ (H.mapCone c').π.app j = (H.mapCone c).π.app j := by
   simp [← map_comp]
 
-/-- `mapCocone` is compatible with `Cocones.IsoPt`. -/
-lemma mapCocone_ι_isoPt {c c' : Cocone F} (e : c ≅ c') (j : J) :
-    (H.mapCocone c).ι.app j ≫ (H.mapIso e.coconePt).hom = (H.mapCocone c').ι.app j := by
+/-- `mapCocone` is compatible with `Cocones.forget`. -/
+lemma mapCocone_ι_forget {c c' : Cocone F} (e : c ⟶ c') (j : J) :
+    (H.mapCocone c).ι.app j ≫ H.map ((Cocones.forget F).map e) = (H.mapCocone c').ι.app j := by
   simp [← map_comp]
 
 end Functor

--- a/Mathlib/CategoryTheory/Limits/Cones.lean
+++ b/Mathlib/CategoryTheory/Limits/Cones.lean
@@ -417,7 +417,6 @@ def forget : Cone F ⥤ C where
 
 variable (G : C ⥤ D)
 
-set_option diagnostics true in
 /-- A functor `G : C ⥤ D` sends cones over `F` to cones over `F ⋙ G` functorially. -/
 @[simps]
 def functoriality : Cone F ⥤ Cone (F ⋙ G) where
@@ -428,7 +427,7 @@ def functoriality : Cone F ⥤ Cone (F ⋙ G) where
           naturality := by intros; erw [← G.map_comp]; simp } }
   map f :=
     { hom := G.map f.hom
-      w := fun j => by simp [-ConeMorphism.w, ← f.w j] }
+      w := ConeMorphism.map_w f G }
 
 /-- Functoriality is functorial. -/
 def functorialityCompFunctoriality (H : D ⥤ E) :
@@ -648,7 +647,7 @@ def functoriality : Cocone F ⥤ Cocone (F ⋙ G) where
           naturality := by intros; erw [← G.map_comp]; simp } }
   map f :=
     { hom := G.map f.hom
-      w := by intros; rw [← Functor.map_comp, CoconeMorphism.w] }
+      w := CoconeMorphism.map_w f G }
 
 /-- Functoriality is functorial. -/
 def functorialityCompFunctoriality (H : D ⥤ E) :

--- a/Mathlib/CategoryTheory/Limits/Cones.lean
+++ b/Mathlib/CategoryTheory/Limits/Cones.lean
@@ -400,17 +400,6 @@ def whiskeringEquivalence (e : K ≌ J) : Cone F ≌ Cone (e.functor ⋙ F) wher
 def equivalenceOfReindexing {G : K ⥤ C} (e : K ≌ J) (α : e.functor ⋙ F ≅ G) : Cone F ≌ Cone G :=
   (whiskeringEquivalence e).trans (postcomposeEquivalence α)
 
-
-/-- Given a cone isomorphism, produce an isomorphism of the object parts. -/
-@[simps!]
-def IsoPt {c c' : Cone F} (e : c ≅ c') : c.pt ≅ c'.pt where
-  hom := e.hom.hom
-  inv := e.inv.hom
-
-/-- `Cones.IsoPt` is compatible with `π`. -/
-lemma isoPt_π {c c' : Cone F} (e : c ≅ c') (j : J) : (IsoPt e).hom ≫ c'.π.app j = c.π.app j :=
-  e.hom.w j
-
 section
 
 variable (F)
@@ -420,6 +409,12 @@ variable (F)
 def forget : Cone F ⥤ C where
   obj t := t.pt
   map f := f.hom
+
+variable {F} in
+/-- Given a cone isomorphism, produce an isomorphism of the object parts. -/
+@[simps!]
+def _root_.CategoryTheory.Iso.conePt {c c' : Cone F} (e : c ≅ c') : c.pt ≅ c'.pt :=
+  (Cones.forget F).mapIso e
 
 variable (G : C ⥤ D)
 
@@ -626,16 +621,6 @@ The categories of cocones over `F` and `G` are equivalent if `F` and `G` are nat
 def equivalenceOfReindexing {G : K ⥤ C} (e : K ≌ J) (α : e.functor ⋙ F ≅ G) : Cocone F ≌ Cocone G :=
   (whiskeringEquivalence e).trans (precomposeEquivalence α.symm)
 
-/-- Given a cocone isomorphism, produce an isomorphism of the object parts. -/
-@[simps!]
-def IsoPt {c c' : Cocone F} (e : c ≅ c') : c.pt ≅ c'.pt where
-  hom := e.hom.hom
-  inv := e.inv.hom
-
-/-- `Cocones.IsoPt` is compatible with `ι`. -/
-lemma isoPt_ι {c c' : Cocone F} (e : c ≅ c') (j : J) : c.ι.app j ≫ (IsoPt e).hom = c'.ι.app j :=
-  e.hom.w j
-
 section
 
 variable (F)
@@ -645,6 +630,12 @@ variable (F)
 def forget : Cocone F ⥤ C where
   obj t := t.pt
   map f := f.hom
+
+variable {F} in
+/-- Given a cocone isomorphism, produce an isomorphism of the object parts. -/
+@[simps!]
+def _root_.CategoryTheory.Iso.coconePt {c c' : Cocone F} (e : c ≅ c') : c.pt ≅ c'.pt :=
+  (Cocones.forget F).mapIso e
 
 variable (G : C ⥤ D)
 
@@ -855,13 +846,13 @@ def mapCoconeWhisker {E : K ⥤ J} {c : Cocone F} :
 
 /-- `mapCone` is compatible with `Cones.IsoPt`. -/
 lemma mapCone_π_isoPt {c c' : Cone F} (e : c ≅ c') (j : J) :
-    (H.mapIso (Cones.IsoPt e)).hom ≫ (H.mapCone c').π.app j = (H.mapCone c).π.app j :=
-  ((Cones.functoriality F H).mapIso e).hom.w j
+    (H.mapIso e.conePt).hom ≫ (H.mapCone c').π.app j = (H.mapCone c).π.app j := by
+  simp [← map_comp]
 
 /-- `mapCocone` is compatible with `Cocones.IsoPt`. -/
 lemma mapCocone_ι_isoPt {c c' : Cocone F} (e : c ≅ c') (j : J) :
-    (H.mapCocone c).ι.app j ≫ (H.mapIso (Cocones.IsoPt e)).hom = (H.mapCocone c').ι.app j :=
-  ((Cocones.functoriality F H).mapIso e).hom.w j
+    (H.mapCocone c).ι.app j ≫ (H.mapIso e.coconePt).hom = (H.mapCocone c').ι.app j := by
+  simp [← map_comp]
 
 end Functor
 

--- a/Mathlib/CategoryTheory/Limits/Cones.lean
+++ b/Mathlib/CategoryTheory/Limits/Cones.lean
@@ -832,15 +832,15 @@ def mapCoconeWhisker {E : K ⥤ J} {c : Cocone F} :
     mapCocone H (c.whisker E) ≅ (mapCocone H c).whisker E :=
   Cocones.ext (Iso.refl _)
 
-/-- `mapCone` is compatible with `Cones.forget`. -/
-lemma mapCone_π_forget {c c' : Cone F} (e : c ⟶ c') (j : J) :
-    H.map ((Cones.forget F).map e) ≫ (H.mapCone c').π.app j = (H.mapCone c).π.app j := by
-  simp [← map_comp]
+@[reassoc (attr := simp)]
+lemma map_coneMorphism {c c' : Cone F} (e : c ⟶ c') (j : J) :
+    H.map e.hom ≫ H.map (c'.π.app j) = H.map (c.π.app j) := by
+  simp only [← map_comp, ConeMorphism.w]
 
-/-- `mapCocone` is compatible with `Cocones.forget`. -/
-lemma mapCocone_ι_forget {c c' : Cocone F} (e : c ⟶ c') (j : J) :
-    (H.mapCocone c).ι.app j ≫ H.map ((Cocones.forget F).map e) = (H.mapCocone c').ι.app j := by
-  simp [← map_comp]
+@[reassoc (attr := simp)]
+lemma map_coconeMorphism {c c' : Cocone F} (e : c ⟶ c') (j : J) :
+    H.map (c.ι.app j) ≫ H.map e.hom = H.map (c'.ι.app j) := by
+  simp only [← map_comp, CoconeMorphism.w]
 
 end Functor
 

--- a/Mathlib/CategoryTheory/Limits/Cones.lean
+++ b/Mathlib/CategoryTheory/Limits/Cones.lean
@@ -289,6 +289,11 @@ instance {c d : Cone F} (f : c ≅ d) : IsIso f.hom.hom := ⟨f.inv.hom, by simp
 
 instance {c d : Cone F} (f : c ≅ d) : IsIso f.inv.hom := ⟨f.hom.hom, by simp⟩
 
+@[reassoc (attr := simp)]
+lemma ConeMorphism.map_w {c c' : Cone F} (f : c ⟶ c') (G : C ⥤ D) (j : J) :
+    G.map f.hom ≫ G.map (c'.π.app j) = G.map (c.π.app j) := by
+  simp only [← map_comp, ConeMorphism.w]
+
 namespace Cones
 
 /-- To give an isomorphism between cones, it suffices to give an
@@ -412,6 +417,7 @@ def forget : Cone F ⥤ C where
 
 variable (G : C ⥤ D)
 
+set_option diagnostics true in
 /-- A functor `G : C ⥤ D` sends cones over `F` to cones over `F ⋙ G` functorially. -/
 @[simps]
 def functoriality : Cone F ⥤ Cone (F ⋙ G) where
@@ -505,6 +511,11 @@ lemma CoconeMorphism.inv_hom_id {c d : Cocone F} (f : c ≅ d) : f.inv.hom ≫ f
 instance {c d : Cocone F} (f : c ≅ d) : IsIso f.hom.hom := ⟨f.inv.hom, by simp⟩
 
 instance {c d : Cocone F} (f : c ≅ d) : IsIso f.inv.hom := ⟨f.hom.hom, by simp⟩
+
+@[reassoc (attr := simp)]
+lemma CoconeMorphism.map_w {c c' : Cocone F} (f : c ⟶ c') (G : C ⥤ D) (j : J) :
+    G.map (c.ι.app j) ≫ G.map f.hom = G.map (c'.ι.app j) := by
+  simp only [← map_comp, CoconeMorphism.w]
 
 namespace Cocones
 
@@ -831,16 +842,6 @@ def mapConeWhisker {E : K ⥤ J} {c : Cone F} : mapCone H (c.whisker E) ≅ (map
 def mapCoconeWhisker {E : K ⥤ J} {c : Cocone F} :
     mapCocone H (c.whisker E) ≅ (mapCocone H c).whisker E :=
   Cocones.ext (Iso.refl _)
-
-@[reassoc (attr := simp)]
-lemma map_coneMorphism {c c' : Cone F} (e : c ⟶ c') (j : J) :
-    H.map e.hom ≫ H.map (c'.π.app j) = H.map (c.π.app j) := by
-  simp only [← map_comp, ConeMorphism.w]
-
-@[reassoc (attr := simp)]
-lemma map_coconeMorphism {c c' : Cocone F} (e : c ⟶ c') (j : J) :
-    H.map (c.ι.app j) ≫ H.map e.hom = H.map (c'.ι.app j) := by
-  simp only [← map_comp, CoconeMorphism.w]
 
 end Functor
 


### PR DESCRIPTION
This PR introduces `ConeMorphism.map_w` and `CoconeMorphism.map_w`, which assert that functors preserve the commutativity of (co)cone morphisms.

Thanks to @chrisflav for the review and suggestions on the earlier version of this PR.