### PR TITLE
[Merged by Bors] - feat(AbsoluteValue/Equivalence): two absolute values `v` and `w` are equivalent if and only if `WithAbs v` and `WithAbs w` are homeomorphic

### DIFF
--- a/Mathlib/Analysis/AbsoluteValue/Equivalence.lean
+++ b/Mathlib/Analysis/AbsoluteValue/Equivalence.lean
@@ -4,6 +4,7 @@ Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Michael Stoll
 -/
 import Mathlib.Analysis.SpecialFunctions.Pow.Real
+import Mathlib.Analysis.Normed.Field.WithAbs
 
 /-!
 # Equivalence of real-valued absolute values
@@ -152,7 +153,7 @@ end LinearOrderedSemifield
 
 section Real
 
-open Real
+open Real Topology
 
 variable {F : Type*} [Field F] {v w : AbsoluteValue F ℝ}
 
@@ -211,6 +212,42 @@ theorem isEquiv_iff_exists_rpow_eq {v w : AbsoluteValue F ℝ} :
       rpow_inv_log (v.pos hb₀) (h.eq_one_iff.not.2 hb₁), exp_one_rpow, exp_log (w.pos hb₀)]
   · exact ⟨1, zero_lt_one, funext fun x ↦ by rcases eq_or_ne x 0 with rfl | h₀ <;>
       aesop (add simp [h.isNontrivial_congr])⟩
+
+theorem IsEquiv.equivWithAbs_image_mem_nhds_zero (h : v.IsEquiv w) {U : Set (WithAbs v)}
+    (hU : U ∈ 𝓝 0) : WithAbs.equivWithAbs v w '' U ∈ 𝓝 0 := by
+  rw [Metric.mem_nhds_iff] at hU ⊢
+  obtain ⟨ε, hε, hU⟩ := hU
+  obtain ⟨c, hc, hvw⟩ := isEquiv_iff_exists_rpow_eq.1 h
+  refine ⟨ε ^ c, rpow_pos_of_pos hε _, fun x hx ↦ ?_⟩
+  rw [← RingEquiv.apply_symm_apply (WithAbs.equivWithAbs v w) x]
+  refine Set.mem_image_of_mem _ (hU ?_)
+  rw [Metric.mem_ball, dist_zero_right, WithAbs.norm_eq_abv, ← funext_iff.1 hvw,
+    rpow_lt_rpow_iff (v.nonneg _) hε.le hc] at hx
+  simpa [WithAbs.norm_eq_abv]
+
+open Topology IsTopologicalAddGroup in
+theorem IsEquiv.isEmbedding_equivWithAbs (h : v.IsEquiv w) :
+    IsEmbedding (WithAbs.equivWithAbs v w) := by
+  refine IsInducing.isEmbedding <| isInducing_iff_nhds_zero.2 <| Filter.ext fun U ↦
+    ⟨fun hU ↦ ?_, fun hU ↦ ?_⟩
+  · exact ⟨WithAbs.equivWithAbs v w '' U, h.equivWithAbs_image_mem_nhds_zero hU,
+      by simp [RingEquiv.image_eq_preimage, Set.preimage_preimage]⟩
+  · rw [← RingEquiv.coe_toEquiv, ← Filter.map_equiv_symm] at hU
+    obtain ⟨s, hs, hss⟩ := Filter.mem_map_iff_exists_image.1 hU
+    rw [← RingEquiv.coe_toEquiv_symm, WithAbs.equivWithAbs_symm] at hss
+    exact Filter.mem_of_superset (h.symm.equivWithAbs_image_mem_nhds_zero hs) hss
+
+theorem isEquiv_iff_isHomeomorph (v w : AbsoluteValue F ℝ) :
+    v.IsEquiv w ↔ IsHomeomorph (WithAbs.equivWithAbs v w) := by
+  rw [isHomeomorph_iff_isEmbedding_surjective]
+  refine ⟨fun h ↦ ⟨h.isEmbedding_equivWithAbs, RingEquiv.surjective _⟩, fun ⟨hi, _⟩ ↦ ?_⟩
+  refine isEquiv_iff_lt_one_iff.2 fun x ↦ ?_
+  conv_lhs => rw [← (WithAbs.equiv v).apply_symm_apply x]
+  conv_rhs => rw [← (WithAbs.equiv w).apply_symm_apply x]
+  simp_rw [← WithAbs.norm_eq_abv, ← tendsto_pow_atTop_nhds_zero_iff_norm_lt_one]
+  exact ⟨fun h ↦ by simpa [Function.comp_def] using (hi.continuous.tendsto 0).comp h, fun h ↦ by
+    simpa [Function.comp_def] using (hi.continuous_iff (f := (WithAbs.equivWithAbs v w).symm)).2
+      continuous_id |>.tendsto 0 |>.comp h ⟩
 
 end Real
 

--- a/Mathlib/Analysis/Normed/Ring/WithAbs.lean
+++ b/Mathlib/Analysis/Normed/Ring/WithAbs.lean
@@ -51,6 +51,23 @@ instance instInhabited : Inhabited (WithAbs v) := ⟨0⟩
 /-- The canonical (semiring) equivalence between `WithAbs v` and `R`. -/
 def equiv : WithAbs v ≃+* R := RingEquiv.refl _
 
+def equivWithAbs (v w : AbsoluteValue R S) : WithAbs v ≃+* WithAbs w :=
+    (WithAbs.equiv v).trans <| (WithAbs.equiv w).symm
+
+def equivWithAbs_symm (v w : AbsoluteValue R S) : (equivWithAbs v w).symm = equivWithAbs w v := rfl
+
+@[simp]
+theorem equiv_equivWithAbs_symm_apply {v w : AbsoluteValue R S} {x : WithAbs w} :
+    equiv v ((equivWithAbs v w).symm x) = equiv w x := rfl
+
+@[simp]
+theorem equivWithAbs_equiv_symm_apply {v w : AbsoluteValue R S} {x : R} :
+    equivWithAbs v w ((equiv v).symm x) = (equiv w).symm x := rfl
+
+@[simp]
+theorem equivWithAbs_symm_equiv_symm_apply {v w : AbsoluteValue R S} {x : R} :
+    (equivWithAbs v w).symm ((equiv w).symm x) = (equiv v).symm x := rfl
+
 end semiring
 
 section more_instances

--- a/Mathlib/Analysis/Normed/Ring/WithAbs.lean
+++ b/Mathlib/Analysis/Normed/Ring/WithAbs.lean
@@ -51,10 +51,13 @@ instance instInhabited : Inhabited (WithAbs v) := ⟨0⟩
 /-- The canonical (semiring) equivalence between `WithAbs v` and `R`. -/
 def equiv : WithAbs v ≃+* R := RingEquiv.refl _
 
+/-- The canonical (semiring) equivalence between `WithAbs v` and `WithAbs w`, for any two
+absolute values `v` and `w` on `R`. -/
 def equivWithAbs (v w : AbsoluteValue R S) : WithAbs v ≃+* WithAbs w :=
     (WithAbs.equiv v).trans <| (WithAbs.equiv w).symm
 
-def equivWithAbs_symm (v w : AbsoluteValue R S) : (equivWithAbs v w).symm = equivWithAbs w v := rfl
+theorem equivWithAbs_symm (v w : AbsoluteValue R S) :
+    (equivWithAbs v w).symm = equivWithAbs w v := rfl
 
 @[simp]
 theorem equiv_equivWithAbs_symm_apply {v w : AbsoluteValue R S} {x : WithAbs w} :


### PR DESCRIPTION
---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include at least one commit authored by each
co-author among the commits in the pull request. If necessary, you may 
create empty commits to indicate co-authorship, using commands like so:

git commit --author="Author Name <author@email.com>" --allow-empty -m "add Author Name as coauthor"

When merging, all the commits will be squashed into a single commit listing all co-authors.

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
