### PR TITLE
[Merged by Bors] - feat(Algebra/Subgroup/Lattice): `mem_biSup_of_directedOn`

### DIFF
--- a/Mathlib/Algebra/Group/Subgroup/Lattice.lean
+++ b/Mathlib/Algebra/Group/Subgroup/Lattice.lean
@@ -515,18 +515,43 @@ theorem _root_.AddSubgroup.toSubgroup'_closure (S : Set (Additive G)) :
   congr_arg AddSubgroup.toSubgroup' (toAddSubgroup'_closure _).symm
 
 @[to_additive]
+theorem mem_biSup_of_directedOn {ι} {p : ι → Prop} {K : ι → Subgroup G} {i : ι} (hp : p i)
+    (hK : DirectedOn ((· ≤ ·) on K) {i | p i})
+    {x : G} : x ∈ (⨆ i, ⨆ (_h : p i), K i) ↔ ∃ i, p i ∧ x ∈ K i := by
+  refine ⟨?_, fun ⟨i, hi', hi⟩ ↦ ?_⟩
+  · suffices x ∈ closure (⋃ i, ⋃ (_ : p i), (K i : Set G)) → ∃ i, p i ∧ x ∈ K i by
+      simpa only [closure_iUnion, closure_eq (K _)] using this
+    refine fun hx ↦ closure_induction (fun _ ↦ ?_) ?_ ?_ ?_ hx
+    · simp
+    · exact ⟨i, hp, (K i).one_mem⟩
+    · rintro x y _ _ ⟨i, hip, hi⟩ ⟨j, hjp, hj⟩
+      rcases hK i hip j hjp with ⟨k, hk, hki, hkj⟩
+      exact ⟨k, hk, mul_mem (hki hi) (hkj hj)⟩
+    · rintro _ _ ⟨i, hi', hi⟩
+      exact ⟨i, hi', inv_mem hi⟩
+  · apply le_iSup (fun i ↦ ⨆ (_ : p i), K i) i
+    simp [hi, hi']
+
+@[to_additive]
 theorem mem_iSup_of_directed {ι} [hι : Nonempty ι] {K : ι → Subgroup G} (hK : Directed (· ≤ ·) K)
     {x : G} : x ∈ (iSup K : Subgroup G) ↔ ∃ i, x ∈ K i := by
-  refine ⟨?_, fun ⟨i, hi⟩ ↦ le_iSup K i hi⟩
-  suffices x ∈ closure (⋃ i, (K i : Set G)) → ∃ i, x ∈ K i by
-    simpa only [closure_iUnion, closure_eq (K _)] using this
-  refine fun hx ↦ closure_induction (fun _ ↦ mem_iUnion.1) ?_ ?_ ?_ hx
-  · exact hι.elim fun i ↦ ⟨i, (K i).one_mem⟩
-  · rintro x y _ _ ⟨i, hi⟩ ⟨j, hj⟩
-    rcases hK i j with ⟨k, hki, hkj⟩
-    exact ⟨k, mul_mem (hki hi) (hkj hj)⟩
-  · rintro _ _ ⟨i, hi⟩
-    exact ⟨i, inv_mem hi⟩
+  have : iSup K = ⨆ i : PLift ι, ⨆ (_ : True), K i.down := by simp [iSup_plift_down]
+  rw [this, mem_biSup_of_directedOn trivial]
+  · simp
+  · simp only [setOf_true]
+    -- API need for `Function.onFun` and `Function.comp` and with `PLift`
+    intro i
+    simp only [mem_univ, true_and, PLift.exists, forall_const]
+    intro j
+    refine (hK i.down j.down).imp ?_
+    simp
+  · exact PLift.up hι.some
+
+@[to_additive (attr := simp)]
+theorem mem_iSup_prop {p : Prop} {K : p → Subgroup G} {x : G} :
+    x ∈ ⨆ (h : p), K h ↔ x = 1 ∨ ∃ (h : p), x ∈ K h := by
+  by_cases h : p <;>
+  simp +contextual [h]
 
 @[to_additive]
 theorem coe_iSup_of_directed {ι} [Nonempty ι] {S : ι → Subgroup G} (hS : Directed (· ≤ ·) S) :

--- a/Mathlib/Algebra/Group/Subgroup/Lattice.lean
+++ b/Mathlib/Algebra/Group/Subgroup/Lattice.lean
@@ -518,6 +518,7 @@ theorem _root_.AddSubgroup.toSubgroup'_closure (S : Set (Additive G)) :
 theorem mem_biSup_of_directedOn {ι} {p : ι → Prop} {K : ι → Subgroup G} {i : ι} (hp : p i)
     (hK : DirectedOn ((· ≤ ·) on K) {i | p i})
     {x : G} : x ∈ (⨆ i, ⨆ (_h : p i), K i) ↔ ∃ i, p i ∧ x ∈ K i := by
+  -- Could use the `Submonoid` version, but we limit the imports here
   refine ⟨?_, fun ⟨i, hi', hi⟩ ↦ ?_⟩
   · suffices x ∈ closure (⋃ i, ⋃ (_ : p i), (K i : Set G)) → ∃ i, p i ∧ x ∈ K i by
       simpa only [closure_iUnion, closure_eq (K _)] using this
@@ -539,9 +540,10 @@ theorem mem_iSup_of_directed {ι} [hι : Nonempty ι] {K : ι → Subgroup G} (h
   rw [this, mem_biSup_of_directedOn trivial]
   · simp
   · simp only [setOf_true]
-    -- API need for `Function.onFun` and `Function.comp` and with `PLift`
+    rw [directedOn_onFun_iff, Set.image_univ, ← directedOn_range]
+    -- `Directed.mono_comp` and much of the Set API requires `Type u` instead of `Sort u`
     intro i
-    simp only [mem_univ, true_and, PLift.exists, forall_const]
+    simp only [PLift.exists]
     intro j
     refine (hK i.down j.down).imp ?_
     simp

--- a/Mathlib/Algebra/Group/Submonoid/Membership.lean
+++ b/Mathlib/Algebra/Group/Submonoid/Membership.lean
@@ -47,23 +47,43 @@ section NonAssoc
 
 variable [MulOneClass M]
 
-open Set
+open Function Set
 
 namespace Submonoid
+
+@[to_additive]
+theorem mem_biSup_of_directedOn {ι} {p : ι → Prop} {K : ι → Submonoid M} {i : ι} (hp : p i)
+    (hK : DirectedOn ((· ≤ ·) on K) {i | p i})
+    {x : M} : x ∈ (⨆ i, ⨆ (_h : p i), K i) ↔ ∃ i, p i ∧ x ∈ K i := by
+  refine ⟨?_, fun ⟨i, hi', hi⟩ ↦ ?_⟩
+  · suffices x ∈ closure (⋃ i, ⋃ (_ : p i), (K i : Set M)) → ∃ i, p i ∧ x ∈ K i by
+      simpa only [closure_iUnion, closure_eq (K _)] using this
+    refine fun hx ↦ closure_induction (fun _ ↦ ?_) ?_ ?_ hx
+    · simp
+    · exact ⟨i, hp, (K i).one_mem⟩
+    · rintro x y _ _ ⟨i, hip, hi⟩ ⟨j, hjp, hj⟩
+      rcases hK i hip j hjp with ⟨k, hk, hki, hkj⟩
+      exact ⟨k, hk, mul_mem (hki hi) (hkj hj)⟩
+  · apply le_iSup (fun i ↦ ⨆ (_ : p i), K i) i
+    simp [hi, hi']
 
 -- TODO: this section can be generalized to `[SubmonoidClass B M] [CompleteLattice B]`
 -- such that `CompleteLattice.LE` coincides with `SetLike.LE`
 @[to_additive]
 theorem mem_iSup_of_directed {ι} [hι : Nonempty ι] {S : ι → Submonoid M} (hS : Directed (· ≤ ·) S)
     {x : M} : (x ∈ ⨆ i, S i) ↔ ∃ i, x ∈ S i := by
-  refine ⟨?_, fun ⟨i, hi⟩ ↦ le_iSup S i hi⟩
-  suffices x ∈ closure (⋃ i, (S i : Set M)) → ∃ i, x ∈ S i by
-    simpa only [closure_iUnion, closure_eq (S _)] using this
-  refine closure_induction (fun _ ↦ mem_iUnion.1) ?_ ?_
-  · exact hι.elim fun i ↦ ⟨i, (S i).one_mem⟩
-  · rintro x y - - ⟨i, hi⟩ ⟨j, hj⟩
-    rcases hS i j with ⟨k, hki, hkj⟩
-    exact ⟨k, (S k).mul_mem (hki hi) (hkj hj)⟩
+  have : iSup S = ⨆ i : PLift ι, ⨆ (_ : True), S i.down := by simp [iSup_plift_down]
+  rw [this, mem_biSup_of_directedOn trivial]
+  · simp
+  · simp only [setOf_true]
+    rw [directedOn_onFun_iff, Set.image_univ, ← directedOn_range]
+    -- `Directed.mono_comp` and much of the Set API requires `Type u` instead of `Sort u`
+    intro i
+    simp only [PLift.exists]
+    intro j
+    refine (hS i.down j.down).imp ?_
+    simp
+  · exact PLift.up hι.some
 
 @[to_additive]
 theorem coe_iSup_of_directed {ι} [Nonempty ι] {S : ι → Submonoid M} (hS : Directed (· ≤ ·) S) :

--- a/Mathlib/Algebra/Group/Submonoid/Membership.lean
+++ b/Mathlib/Algebra/Group/Submonoid/Membership.lean
@@ -85,6 +85,12 @@ theorem mem_iSup_of_directed {ι} [hι : Nonempty ι] {S : ι → Submonoid M} (
     simp
   · exact PLift.up hι.some
 
+@[to_additive (attr := simp)]
+theorem mem_iSup_prop {p : Prop} {S : p → Submonoid M} {x : M} :
+    x ∈ ⨆ (h : p), S h ↔ x = 1 ∨ ∃ (h : p), x ∈ S h := by
+  by_cases h : p <;>
+  simp +contextual [h]
+
 @[to_additive]
 theorem coe_iSup_of_directed {ι} [Nonempty ι] {S : ι → Submonoid M} (hS : Directed (· ≤ ·) S) :
     ((⨆ i, S i : Submonoid M) : Set M) = ⋃ i, S i :=

--- a/Mathlib/Algebra/Group/Subsemigroup/Membership.lean
+++ b/Mathlib/Algebra/Group/Subsemigroup/Membership.lean
@@ -35,22 +35,41 @@ section NonAssoc
 
 variable [Mul M]
 
-open Set
+open Set Function
 
 namespace Subsemigroup
+
+@[to_additive]
+theorem mem_biSup_of_directedOn {ι} {p : ι → Prop} {K : ι → Subsemigroup M}
+    (hK : DirectedOn ((· ≤ ·) on K) {i | p i})
+    {x : M} : x ∈ (⨆ i, ⨆ (_h : p i), K i) ↔ ∃ i, p i ∧ x ∈ K i := by
+  refine ⟨?_, fun ⟨i, hi', hi⟩ ↦ ?_⟩
+  · suffices x ∈ closure (⋃ i, ⋃ (_ : p i), (K i : Set M)) → ∃ i, p i ∧ x ∈ K i by
+      simpa only [closure_iUnion, closure_eq (K _)] using this
+    refine fun hx ↦ closure_induction (fun _ ↦ ?_) ?_ hx
+    · simp
+    · rintro x y _ _ ⟨i, hip, hi⟩ ⟨j, hjp, hj⟩
+      rcases hK i hip j hjp with ⟨k, hk, hki, hkj⟩
+      exact ⟨k, hk, mul_mem (hki hi) (hkj hj)⟩
+  · apply le_iSup (fun i ↦ ⨆ (_ : p i), K i) i
+    simp [hi, hi']
 
 -- TODO: this section can be generalized to `[MulMemClass B M] [CompleteLattice B]`
 -- such that `complete_lattice.le` coincides with `set_like.le`
 @[to_additive]
 theorem mem_iSup_of_directed {S : ι → Subsemigroup M} (hS : Directed (· ≤ ·) S) {x : M} :
     (x ∈ ⨆ i, S i) ↔ ∃ i, x ∈ S i := by
-  refine ⟨?_, fun ⟨i, hi⟩ ↦ le_iSup S i hi⟩
-  suffices x ∈ closure (⋃ i, (S i : Set M)) → ∃ i, x ∈ S i by
-    simpa only [closure_iUnion, closure_eq (S _)] using this
-  refine fun hx ↦ closure_induction (fun y hy ↦ mem_iUnion.mp hy) ?_ hx
-  rintro x y - - ⟨i, hi⟩ ⟨j, hj⟩
-  rcases hS i j with ⟨k, hki, hkj⟩
-  exact ⟨k, (S k).mul_mem (hki hi) (hkj hj)⟩
+  have : iSup S = ⨆ i : PLift ι, ⨆ (_ : True), S i.down := by simp [iSup_plift_down]
+  rw [this, mem_biSup_of_directedOn]
+  · simp
+  · simp only [setOf_true]
+    rw [directedOn_onFun_iff, Set.image_univ, ← directedOn_range]
+    -- `Directed.mono_comp` and much of the Set API requires `Type u` instead of `Sort u`
+    intro i
+    simp only [PLift.exists]
+    intro j
+    refine (hS i.down j.down).imp ?_
+    simp
 
 @[to_additive]
 theorem coe_iSup_of_directed {S : ι → Subsemigroup M} (hS : Directed (· ≤ ·) S) :

--- a/Mathlib/Algebra/Group/Subsemigroup/Membership.lean
+++ b/Mathlib/Algebra/Group/Subsemigroup/Membership.lean
@@ -71,6 +71,13 @@ theorem mem_iSup_of_directed {S : ι → Subsemigroup M} (hS : Directed (· ≤ 
     refine (hS i.down j.down).imp ?_
     simp
 
+@[to_additive (attr := simp)]
+theorem mem_iSup_prop {p : Prop} {S : p → Subsemigroup M} {x : M} :
+    x ∈ ⨆ (h : p), S h ↔ ∃ (h : p), x ∈ S h := by
+  by_cases h : p
+  · simp +contextual [h]
+  · simpa [h] using id
+
 @[to_additive]
 theorem coe_iSup_of_directed {S : ι → Subsemigroup M} (hS : Directed (· ≤ ·) S) :
     ((⨆ i, S i : Subsemigroup M) : Set M) = ⋃ i, S i :=

--- a/Mathlib/Order/Directed.lean
+++ b/Mathlib/Order/Directed.lean
@@ -77,6 +77,9 @@ theorem DirectedOn.mono {s : Set α} (h : DirectedOn r s) (H : ∀ ⦃a b⦄, r 
 theorem directed_comp {ι} {f : ι → β} {g : β → α} : Directed r (g ∘ f) ↔ Directed (g ⁻¹'o r) f :=
   Iff.rfl
 
+theorem directed_comp' {ι} {f : ι → β} {g : β → α} : Directed r (g ∘ f) ↔ Directed (g ⁻¹'o r) f :=
+  Iff.rfl
+
 theorem Directed.mono {s : α → α → Prop} {ι} {f : ι → α} (H : ∀ a b, r a b → s a b)
     (h : Directed r f) : Directed s f := fun a b =>
   let ⟨c, h₁, h₂⟩ := h a b
@@ -89,6 +92,13 @@ theorem Directed.mono_comp (r : α → α → Prop) {ι} {rb : β → β → Pro
 theorem DirectedOn.mono_comp {r : α → α → Prop} {rb : β → β → Prop} {g : α → β} {s : Set α}
     (hg : ∀ ⦃x y⦄, r x y → rb (g x) (g y)) (hf : DirectedOn r s) : DirectedOn rb (g '' s) :=
   directedOn_image.mpr (hf.mono hg)
+
+lemma directedOn_onFun_iff {r : α → α → Prop} {f : β → α} {s : Set β} :
+    DirectedOn (r on f) s ↔ DirectedOn r (f '' s) := by
+  refine ⟨DirectedOn.mono_comp (by simp), fun h x hx y hy ↦ ?_⟩
+  obtain ⟨_, ⟨z, hz, rfl⟩, hz'⟩ := h (f x) (Set.mem_image_of_mem f hx) (f y)
+    (Set.mem_image_of_mem f hy)
+  grind
 
 /-- A set stable by supremum is `≤`-directed. -/
 theorem directedOn_of_sup_mem [SemilatticeSup α] {S : Set α}

--- a/Mathlib/Order/Directed.lean
+++ b/Mathlib/Order/Directed.lean
@@ -77,9 +77,6 @@ theorem DirectedOn.mono {s : Set α} (h : DirectedOn r s) (H : ∀ ⦃a b⦄, r 
 theorem directed_comp {ι} {f : ι → β} {g : β → α} : Directed r (g ∘ f) ↔ Directed (g ⁻¹'o r) f :=
   Iff.rfl
 
-theorem directed_comp' {ι} {f : ι → β} {g : β → α} : Directed r (g ∘ f) ↔ Directed (g ⁻¹'o r) f :=
-  Iff.rfl
-
 theorem Directed.mono {s : α → α → Prop} {ι} {f : ι → α} (H : ∀ a b, r a b → s a b)
     (h : Directed r f) : Directed s f := fun a b =>
   let ⟨c, h₁, h₂⟩ := h a b


### PR DESCRIPTION
Generalization of existing `mem_iSup_of_directed`

On the way to characterization of the torsion subgroup as the sup over all subgroups of roots of unity

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include at least one commit authored by each
co-author among the commits in the pull request. If necessary, you may 
create empty commits to indicate co-authorship, using commands like so:

git commit --author="Author Name <author@email.com>" --allow-empty -m "add Author Name as coauthor"

When merging, all the commits will be squashed into a single commit listing all co-authors.

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
