### PR TITLE
[Merged by Bors] - chore(Order): untangle imports by moving `IsAntichain` lemmas

### DIFF
--- a/Mathlib/Order/Antichain.lean
+++ b/Mathlib/Order/Antichain.lean
@@ -228,6 +228,28 @@ theorem IsAntichain.bot_mem_iff [OrderBot α] (hs : IsAntichain (· ≤ ·) s) :
 theorem IsAntichain.top_mem_iff [OrderTop α] (hs : IsAntichain (· ≤ ·) s) : ⊤ ∈ s ↔ s = {⊤} :=
   isGreatest_top_iff.symm.trans hs.greatest_iff
 
+theorem IsAntichain.minimal_mem_iff (hs : IsAntichain (· ≤ ·) s) : Minimal (· ∈ s) a ↔ a ∈ s :=
+  ⟨fun h ↦ h.prop, fun h ↦ ⟨h, fun _ hys hyx ↦ (hs.eq hys h hyx).symm.le⟩⟩
+
+theorem IsAntichain.maximal_mem_iff (hs : IsAntichain (· ≤ ·) s) : Maximal (· ∈ s) a ↔ a ∈ s :=
+  hs.to_dual.minimal_mem_iff
+
+/-- If `t` is an antichain shadowing and including the set of maximal elements of `s`,
+then `t` *is* the set of maximal elements of `s`. -/
+theorem IsAntichain.eq_setOf_maximal (ht : IsAntichain (· ≤ ·) t)
+    (h : ∀ x, Maximal (· ∈ s) x → x ∈ t) (hs : ∀ a ∈ t, ∃ b, b ≤ a ∧ Maximal (· ∈ s) b) :
+    {x | Maximal (· ∈ s) x} = t := by
+  refine Set.ext fun x ↦ ⟨h _, fun hx ↦ ?_⟩
+  obtain ⟨y, hyx, hy⟩ := hs x hx
+  rwa [← ht.eq (h y hy) hx hyx]
+
+/-- If `t` is an antichain shadowed by and including the set of minimal elements of `s`,
+then `t` *is* the set of minimal elements of `s`. -/
+theorem IsAntichain.eq_setOf_minimal (ht : IsAntichain (· ≤ ·) t)
+    (h : ∀ x, Minimal (· ∈ s) x → x ∈ t) (hs : ∀ a ∈ t, ∃ b, a ≤ b ∧ Minimal (· ∈ s) b) :
+    {x | Minimal (· ∈ s) x} = t :=
+  ht.to_dual.eq_setOf_maximal h hs
+
 end Preorder
 
 section PartialOrder
@@ -237,6 +259,12 @@ variable [PartialOrder α]
 theorem isAntichain_iff_forall_not_lt :
     IsAntichain (· ≤ ·) s ↔ ∀ ⦃a⦄, a ∈ s → ∀ ⦃b⦄, b ∈ s → ¬a < b :=
   ⟨fun hs _ ha _ => hs.not_lt ha, fun hs _ ha _ hb h h' => hs ha hb <| h'.lt_of_ne h⟩
+
+theorem setOf_maximal_antichain (P : α → Prop) : IsAntichain (· ≤ ·) {x | Maximal P x} :=
+  fun _ hx _ ⟨hy, _⟩ hne hle ↦ hne (hle.antisymm <| hx.2 hy hle)
+
+theorem setOf_minimal_antichain (P : α → Prop) : IsAntichain (· ≤ ·) {x | Minimal P x} :=
+  (setOf_maximal_antichain (α := αᵒᵈ) P).swap
 
 end PartialOrder
 

--- a/Mathlib/Order/Minimal.lean
+++ b/Mathlib/Order/Minimal.lean
@@ -3,7 +3,9 @@ Copyright (c) 2022 Yaël Dillies. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Yaël Dillies, Peter Nelson
 -/
-import Mathlib.Order.Antichain
+import Mathlib.Order.Hom.Basic
+import Mathlib.Order.Interval.Set.Defs
+import Mathlib.Order.WellFounded
 
 /-!
 # Minimality and Maximality
@@ -419,39 +421,11 @@ theorem IsLeast.minimal (h : IsLeast s x) : Minimal (· ∈ s) x :=
 theorem IsGreatest.maximal (h : IsGreatest s x) : Maximal (· ∈ s) x :=
   ⟨h.1, fun _b hb _ ↦ h.2 hb⟩
 
-theorem IsAntichain.minimal_mem_iff (hs : IsAntichain (· ≤ ·) s) : Minimal (· ∈ s) x ↔ x ∈ s :=
-  ⟨fun h ↦ h.prop, fun h ↦ ⟨h, fun _ hys hyx ↦ (hs.eq hys h hyx).symm.le⟩⟩
-
-theorem IsAntichain.maximal_mem_iff (hs : IsAntichain (· ≤ ·) s) : Maximal (· ∈ s) x ↔ x ∈ s :=
-  hs.to_dual.minimal_mem_iff
-
-/-- If `t` is an antichain shadowing and including the set of maximal elements of `s`,
-then `t` *is* the set of maximal elements of `s`. -/
-theorem IsAntichain.eq_setOf_maximal (ht : IsAntichain (· ≤ ·) t)
-    (h : ∀ x, Maximal (· ∈ s) x → x ∈ t) (hs : ∀ a ∈ t, ∃ b, b ≤ a ∧ Maximal (· ∈ s) b) :
-    {x | Maximal (· ∈ s) x} = t := by
-  refine Set.ext fun x ↦ ⟨h _, fun hx ↦ ?_⟩
-  obtain ⟨y, hyx, hy⟩ := hs x hx
-  rwa [← ht.eq (h y hy) hx hyx]
-
-/-- If `t` is an antichain shadowed by and including the set of minimal elements of `s`,
-then `t` *is* the set of minimal elements of `s`. -/
-theorem IsAntichain.eq_setOf_minimal (ht : IsAntichain (· ≤ ·) t)
-    (h : ∀ x, Minimal (· ∈ s) x → x ∈ t) (hs : ∀ a ∈ t, ∃ b, a ≤ b ∧ Minimal (· ∈ s) b) :
-    {x | Minimal (· ∈ s) x} = t :=
-  ht.to_dual.eq_setOf_maximal h hs
-
 end Preorder
 
 section PartialOrder
 
 variable [PartialOrder α]
-
-theorem setOf_maximal_antichain (P : α → Prop) : IsAntichain (· ≤ ·) {x | Maximal P x} :=
-  fun _ hx _ ⟨hy, _⟩ hne hle ↦ hne (hle.antisymm <| hx.2 hy hle)
-
-theorem setOf_minimal_antichain (P : α → Prop) : IsAntichain (· ≤ ·) {x | Minimal P x} :=
-  (setOf_maximal_antichain (α := αᵒᵈ) P).swap
 
 theorem IsLeast.minimal_iff (h : IsLeast s a) : Minimal (· ∈ s) x ↔ x = a :=
   ⟨fun h' ↦ h'.eq_of_ge h.1 (h.2 h'.prop), fun h' ↦ h' ▸ h.minimal⟩


### PR DESCRIPTION
Right now Minimal.lean imports Antichain.lean to prove some lemmas about antichains. This is an unnecessary import, since those lemmas can live in Antichain.lean with no additional imports, and thereby reduce the imports in Minimal.lean (and this helps prevent circular includes for another PR of mine.)


---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include at least one commit authored by each
co-author among the commits in the pull request. If necessary, you may 
create empty commits to indicate co-authorship, using commands like so:

git commit --author="Author Name <author@email.com>" --allow-empty -m "add Author Name as coauthor"

When merging, all the commits will be squashed into a single commit listing all co-authors.

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
