### PR TITLE
[Merged by Bors] - feat(Analysis/SpecialFunctions/CFC/Rpow/Basic): add `isStrictlyPositive_TFAE`

### DIFF
--- a/Mathlib/Analysis/SpecialFunctions/ContinuousFunctionalCalculus/Rpow/Basic.lean
+++ b/Mathlib/Analysis/SpecialFunctions/ContinuousFunctionalCalculus/Rpow/Basic.lean
@@ -671,6 +671,61 @@ omit [T2Space A] [IsTopologicalRing A] in
 lemma _root_.IsStrictlyPositive.rpow {a : A} {y : ℝ} (ha : IsStrictlyPositive a) :
     IsStrictlyPositive (a ^ y) := by grind
 
+/-- For an element `a` in a C⋆-algebra, TFAE:
+* `a` is strictly positive,
+* `sqrt a` is strictly positive and `a = sqrt a * sqrt a`,
+* `sqrt a` is invertible and `a = sqrt a * sqrt a`,
+* `a = b * b` for some strictly positive `b`,
+* `a = b * b` for some self-adjoint and invertible `b`,
+* `a = star b * b` for some invertible `b`,
+* `a = b * star b` for some invertible `b`,
+* `0 ≤ b` and `a` is invertible,
+* `a` is self-adjoint and has positive spectrum. -/
+theorem _root_.CStarAlgebra.isStrictlyPositive_TFAE {a : A} :
+    [IsStrictlyPositive a,
+     IsStrictlyPositive (sqrt a) ∧ a = sqrt a * sqrt a,
+     IsUnit (sqrt a) ∧ a = sqrt a * sqrt a,
+     ∃ b, IsStrictlyPositive b ∧ a = b * b,
+     ∃ b, IsUnit b ∧ IsSelfAdjoint b ∧ a = b * b,
+     ∃ b, IsUnit b ∧ a = star b * b,
+     ∃ b, IsUnit b ∧ a = b * star b,
+     0 ≤ a ∧ IsUnit a,
+     IsSelfAdjoint a ∧ ∀ x ∈ spectrum ℝ a, 0 < x].TFAE := by
+  tfae_have 1 ↔ 8 := IsStrictlyPositive.iff_of_unital
+  tfae_have 1 ↔ 9 := ⟨fun h => ⟨h.isSelfAdjoint,
+      StarOrderedRing.isStrictlyPositive_iff_spectrum_pos a |>.mp h⟩,
+    fun h => (StarOrderedRing.isStrictlyPositive_iff_spectrum_pos a).mpr h.2⟩
+  tfae_have 1 → 2 := fun h => ⟨h.sqrt, sqrt_mul_sqrt_self a |>.symm⟩
+  tfae_have 2 → 3 := fun h => ⟨h.1.isUnit, h.2⟩
+  tfae_have 3 → 4 := fun h => ⟨sqrt a, h.1.isStrictlyPositive (sqrt_nonneg _), h.2⟩
+  tfae_have 4 → 5 := fun ⟨b, hb, hab⟩ => ⟨b, hb.isUnit, hb.isSelfAdjoint, hab⟩
+  tfae_have 5 → 6 := fun ⟨b, hb, hbsa, hab⟩ => ⟨b, hb, hbsa.symm ▸ hab⟩
+  tfae_have 6 → 7 := fun ⟨b, hb, hab⟩ => ⟨star b, hb.star, star_star b |>.symm ▸ hab⟩
+  tfae_have 7 → 8 := fun ⟨b, hb, hab⟩ => ⟨hab ▸ mul_star_self_nonneg _, hab ▸ hb.mul hb.star⟩
+  tfae_finish
+
+theorem _root_.CStarAlgebra.isStrictlyPositive_iff_isStrictlyPositive_sqrt_and_eq_sqrt_mul_sqrt
+    {a : A} : IsStrictlyPositive a ↔ IsStrictlyPositive (sqrt a) ∧ a = sqrt a * sqrt a :=
+  CStarAlgebra.isStrictlyPositive_TFAE.out 0 1
+theorem _root_.CStarAlgebra.isStrictlyPositive_iff_isUnit_sqrt_and_eq_sqrt_mul_sqrt
+    {a : A} : IsStrictlyPositive a ↔ IsUnit (sqrt a) ∧ a = sqrt a * sqrt a :=
+  CStarAlgebra.isStrictlyPositive_TFAE.out 0 2
+theorem _root_.CStarAlgebra.isStrictlyPositive_iff_eq_isStrictlyPositive_mul_self
+    {a : A} : IsStrictlyPositive a ↔ ∃ b, IsStrictlyPositive b ∧ a = b * b :=
+  CStarAlgebra.isStrictlyPositive_TFAE.out 0 3
+theorem _root_.CStarAlgebra.isStrictlyPositive_iff_eq_isUnit_and_isSelfAdjoint_mul_self
+    {a : A} : IsStrictlyPositive a ↔ ∃ b, IsUnit b ∧ IsSelfAdjoint b ∧ a = b * b :=
+  CStarAlgebra.isStrictlyPositive_TFAE.out 0 4
+theorem _root_.CStarAlgebra.isStrictlyPositive_iff_eq_star_mul_self
+    {a : A} : IsStrictlyPositive a ↔ ∃ b, IsUnit b ∧ a = star b * b :=
+  CStarAlgebra.isStrictlyPositive_TFAE.out 0 5
+theorem _root_.CStarAlgebra.isStrictlyPositive_iff_eq_mul_star_self
+    {a : A} : IsStrictlyPositive a ↔ ∃ b, IsUnit b ∧ a = b * star b :=
+  CStarAlgebra.isStrictlyPositive_TFAE.out 0 6
+theorem _root_.CStarAlgebra.isStrictlyPositive_iff_isSelfAdjoint_and_spectrum_pos
+    {a : A} : IsStrictlyPositive a ↔ IsSelfAdjoint a ∧ ∀ x ∈ spectrum ℝ a, 0 < x :=
+  CStarAlgebra.isStrictlyPositive_TFAE.out 0 8
+
 end unital_vs_nonunital
 
 end Unital

--- a/Mathlib/Analysis/SpecialFunctions/ContinuousFunctionalCalculus/Rpow/Basic.lean
+++ b/Mathlib/Analysis/SpecialFunctions/ContinuousFunctionalCalculus/Rpow/Basic.lean
@@ -672,15 +672,15 @@ lemma _root_.IsStrictlyPositive.rpow {a : A} {y : ℝ} (ha : IsStrictlyPositive 
     IsStrictlyPositive (a ^ y) := by grind
 
 /-- For an element `a` in a C⋆-algebra, TFAE:
-* `a` is strictly positive,
-* `sqrt a` is strictly positive and `a = sqrt a * sqrt a`,
-* `sqrt a` is invertible and `a = sqrt a * sqrt a`,
-* `a = b * b` for some strictly positive `b`,
-* `a = b * b` for some self-adjoint and invertible `b`,
-* `a = star b * b` for some invertible `b`,
-* `a = b * star b` for some invertible `b`,
-* `0 ≤ b` and `a` is invertible,
-* `a` is self-adjoint and has positive spectrum. -/
+1. `a` is strictly positive,
+2. `sqrt a` is strictly positive and `a = sqrt a * sqrt a`,
+3. `sqrt a` is invertible and `a = sqrt a * sqrt a`,
+4. `a = b * b` for some strictly positive `b`,
+5. `a = b * b` for some self-adjoint and invertible `b`,
+6. `a = star b * b` for some invertible `b`,
+7. `a = b * star b` for some invertible `b`,
+8. `0 ≤ a` and `a` is invertible,
+9. `a` is self-adjoint and has positive spectrum. -/
 theorem _root_.CStarAlgebra.isStrictlyPositive_TFAE {a : A} :
     [IsStrictlyPositive a,
      IsStrictlyPositive (sqrt a) ∧ a = sqrt a * sqrt a,
@@ -710,10 +710,10 @@ theorem _root_.CStarAlgebra.isStrictlyPositive_iff_isStrictlyPositive_sqrt_and_e
 theorem _root_.CStarAlgebra.isStrictlyPositive_iff_isUnit_sqrt_and_eq_sqrt_mul_sqrt
     {a : A} : IsStrictlyPositive a ↔ IsUnit (sqrt a) ∧ a = sqrt a * sqrt a :=
   CStarAlgebra.isStrictlyPositive_TFAE.out 0 2
-theorem _root_.CStarAlgebra.isStrictlyPositive_iff_eq_isStrictlyPositive_mul_self
+theorem _root_.CStarAlgebra.isStrictlyPositive_iff_exists_isStrictlyPositive_and_eq_mul_self
     {a : A} : IsStrictlyPositive a ↔ ∃ b, IsStrictlyPositive b ∧ a = b * b :=
   CStarAlgebra.isStrictlyPositive_TFAE.out 0 3
-theorem _root_.CStarAlgebra.isStrictlyPositive_iff_eq_isUnit_and_isSelfAdjoint_mul_self
+theorem _root_.CStarAlgebra.isStrictlyPositive_iff_exists_isUnit_and_isSelfAdjoint_and_eq_mul_self
     {a : A} : IsStrictlyPositive a ↔ ∃ b, IsUnit b ∧ IsSelfAdjoint b ∧ a = b * b :=
   CStarAlgebra.isStrictlyPositive_TFAE.out 0 4
 theorem _root_.CStarAlgebra.isStrictlyPositive_iff_eq_star_mul_self


### PR DESCRIPTION
Some equivalent lemmas for strict positivity in a C⋆-algebra.

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include at least one commit authored by each
co-author among the commits in the pull request. If necessary, you may 
create empty commits to indicate co-authorship, using commands like so:

git commit --author="Author Name <author@email.com>" --allow-empty -m "add Author Name as coauthor"

When merging, all the commits will be squashed into a single commit listing all co-authors.

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
