### PR TITLE
[Merged by Bors] - feat(CategoryTheory/Limits/Creates): add preservesLimit_comp_of_createsLimit

### DIFF
--- a/Mathlib/CategoryTheory/Limits/Creates.lean
+++ b/Mathlib/CategoryTheory/Limits/Creates.lean
@@ -633,6 +633,12 @@ instance compCreatesLimitsOfShape [CreatesLimitsOfShape J F] [CreatesLimitsOfSha
 instance compCreatesLimits [CreatesLimitsOfSize.{w, w'} F] [CreatesLimitsOfSize.{w, w'} G] :
     CreatesLimitsOfSize.{w, w'} (F ⋙ G) where CreatesLimitsOfShape := inferInstance
 
+instance compPreservesLimitOfCreates [CreatesLimit K F] [PreservesLimit K (F ⋙ G)] :
+    PreservesLimit (K ⋙ F) G where
+  preserves hc := ⟨IsLimit.ofIsoLimit (isLimitOfPreserves (F ⋙ G) (liftedLimitIsLimit hc))
+    ((Functor.mapConeMapCone (liftLimit hc)).symm ≪≫
+      (Cones.functoriality _ _).mapIso (liftedLimitMapsToOriginal hc))⟩
+
 instance compCreatesColimit [CreatesColimit K F] [CreatesColimit (K ⋙ F) G] :
     CreatesColimit K (F ⋙ G) where
   lifts c t :=
@@ -649,6 +655,12 @@ instance compCreatesColimitsOfShape [CreatesColimitsOfShape J F] [CreatesColimit
 
 instance compCreatesColimits [CreatesColimitsOfSize.{w, w'} F] [CreatesColimitsOfSize.{w, w'} G] :
     CreatesColimitsOfSize.{w, w'} (F ⋙ G) where CreatesColimitsOfShape := inferInstance
+
+instance compPreservesColimitOfCreates [CreatesColimit K F] [PreservesColimit K (F ⋙ G)] :
+    PreservesColimit (K ⋙ F) G where
+  preserves hc := ⟨IsColimit.ofIsoColimit (isColimitOfPreserves (F ⋙ G) (liftedColimitIsColimit hc))
+    ((Functor.mapCoconeMapCocone (liftColimit hc)).symm ≪≫
+      (Cocones.functoriality _ _).mapIso (liftedColimitMapsToOriginal hc))⟩
 
 end Comp
 

--- a/Mathlib/CategoryTheory/Limits/Creates.lean
+++ b/Mathlib/CategoryTheory/Limits/Creates.lean
@@ -656,7 +656,7 @@ instance compCreatesColimitsOfShape [CreatesColimitsOfShape J F] [CreatesColimit
 instance compCreatesColimits [CreatesColimitsOfSize.{w, w'} F] [CreatesColimitsOfSize.{w, w'} G] :
     CreatesColimitsOfSize.{w, w'} (F ⋙ G) where CreatesColimitsOfShape := inferInstance
 
-instance compPreservesColimitOfCreates [CreatesColimit K F] [PreservesColimit K (F ⋙ G)] :
+instance preservesColimit_comp_of_createsColimit [CreatesColimit K F] [PreservesColimit K (F ⋙ G)] :
     PreservesColimit (K ⋙ F) G where
   preserves hc := ⟨IsColimit.ofIsoColimit (isColimitOfPreserves (F ⋙ G) (liftedColimitIsColimit hc))
     ((Functor.mapCoconeMapCocone (liftColimit hc)).symm ≪≫

--- a/Mathlib/CategoryTheory/Limits/Creates.lean
+++ b/Mathlib/CategoryTheory/Limits/Creates.lean
@@ -633,7 +633,7 @@ instance compCreatesLimitsOfShape [CreatesLimitsOfShape J F] [CreatesLimitsOfSha
 instance compCreatesLimits [CreatesLimitsOfSize.{w, w'} F] [CreatesLimitsOfSize.{w, w'} G] :
     CreatesLimitsOfSize.{w, w'} (F ⋙ G) where CreatesLimitsOfShape := inferInstance
 
-instance compPreservesLimitOfCreates [CreatesLimit K F] [PreservesLimit K (F ⋙ G)] :
+instance preservesLimit_comp_of_createsLimit [CreatesLimit K F] [PreservesLimit K (F ⋙ G)] :
     PreservesLimit (K ⋙ F) G where
   preserves hc := ⟨IsLimit.ofIsoLimit (isLimitOfPreserves (F ⋙ G) (liftedLimitIsLimit hc))
     ((Functor.mapConeMapCone (liftLimit hc)).symm ≪≫


### PR DESCRIPTION
This PR introduces two instances regarding the interaction between functors that create (co)limits and preservation of (co)limits under composition.

`preservesLimit_comp_of_createsLimit `: Given a diagram `K : J => C` and composable functors of categories `C ==F==> D ==G==> E`, if 
-`F` creates limits for `K` and 
-`F ⋙ G` preserves limits for `K`
then `G` preserves limits for the diagram `J ==K==> C ==F==>D`.

`preservesColimit_comp_of_createsColimit `: the dual statement.