### PR TITLE
feat(Mathlib/AlgebraicGeometry/AffineScheme): add preservation of pullbacks of affine schemes and certain cover

### DIFF
--- a/Mathlib/AlgebraicGeometry/AffineScheme.lean
+++ b/Mathlib/AlgebraicGeometry/AffineScheme.lean
@@ -211,6 +211,17 @@ noncomputable instance forgetToScheme_preservesLimits : PreservesLimits forgetTo
   change PreservesLimits (equivCommRingCat.functor ⋙ Scheme.Spec)
   infer_instance
 
+/-- `AffineScheme.forgetToScheme` creates limits for cospans. -/
+noncomputable def forgetToScheme_createsLimits {X Y Z : AffineScheme.{u}}
+    (f : X ⟶ Z) (g : Y ⟶ Z) : CreatesLimit (cospan f g) AffineScheme.forgetToScheme.{u} :=
+  createsLimitOfReflectsIsomorphismsOfPreserves
+
+/-- `AffineScheme.forgetToScheme.op` creates colimits for spans. -/
+noncomputable def forgetToScheme_op_createsColimits {X Y Z : AffineScheme.{u}}
+    (f : X ⟶ Z) (g : Y ⟶ Z) : CreatesColimit (span f.op g.op) AffineScheme.forgetToScheme.{u}.op :=
+  let : PreservesColimits AffineScheme.forgetToScheme.{u}.op := preservesColimits_op _
+  createsColimitOfReflectsIsomorphismsOfPreserves
+
 end AffineScheme
 
 /-- An open subset of a scheme is affine if the open subscheme is affine. -/
@@ -239,6 +250,14 @@ theorem exists_isAffineOpen_mem_and_subset {X : Scheme.{u}} {x : X}
   obtain ⟨R, f, hf⟩ := AlgebraicGeometry.Scheme.exists_affine_mem_range_and_range_subset hxU
   exact ⟨Scheme.Hom.opensRange f (H := hf.1),
     ⟨AlgebraicGeometry.isAffineOpen_opensRange f (H := hf.1), hf.2.1, hf.2.2⟩⟩
+
+instance Scheme.isAffine_local_affine {X : Scheme.{u}} {x : X} :
+    IsAffine (Scheme.Opens.toScheme (X.local_affine x).choose.obj) := by
+  let f : Scheme.Opens.toScheme (X.local_affine x).choose.obj ≅
+      AlgebraicGeometry.Spec (X.local_affine x).choose_spec.choose :=
+    Scheme.fullyFaithfulForgetToLocallyRingedSpace.preimageIso
+      (X.local_affine x).choose_spec.choose_spec.some
+  exact IsAffine.of_isIso f.hom
 
 instance Scheme.isAffine_affineCover (X : Scheme) (i : X.affineCover.I₀) :
     IsAffine (X.affineCover.X i) :=
@@ -1182,4 +1201,46 @@ def Scheme.arrowStalkMapSpecIso {R S : CommRingCat.{u}} (f : R ⟶ S) (p : Prime
     simp
 
 end Stalks
+
+section AffinePreimageCover
+
+variable {X Y : Scheme.{u}} [IsAffine X] (f : X.carrier ⟶ Y.carrier)
+
+/-- For a continuous map `f : X.carrier ⟶ Y.carrier` between schemes with `X` affine,
+each point `x : X` has a basic open neighborhood contained in the preimage of an affine open
+of `Y` containing `f x`. This version returns an element of `X.Opens`. -/
+lemma exists_basicOpen_to_affineOpens' (x : X) : ∃ (U' : X.Opens),
+    U' ∈ Set.range (X.basicOpen : Γ(X, ⊤).carrier → X.Opens) ∧ x ∈ U' ∧
+      U' ≤ (Y.local_affine (f x)).choose.obj.comap f.hom :=
+  TopologicalSpace.Opens.isBasis_iff_nbhd.mp (isBasis_basicOpen X)
+    ((Y.local_affine (f x)).choose.obj.mem_comap.mpr
+      (TopologicalSpace.Opens.mem_mk.mpr (Y.local_affine (f x)).choose.property))
+
+/-- For a continuous map `f : X.carrier ⟶ Y.carrier` between schemes with `X` affine,
+each point `x : X` has a basic open neighborhood contained in the preimage of an affine open
+of `Y` containing `f x`. This version returns a global section `r : Γ(X, ⊤)`. -/
+lemma exists_basicOpen_to_affineOpens (x : X) : ∃ (r : Γ(X, ⊤)), x ∈ X.basicOpen r ∧
+    X.basicOpen r ≤ ⇑f ⁻¹' (Y.local_affine (f x)).choose.obj.carrier := by
+  fconstructor
+  · exact (exists_basicOpen_to_affineOpens' f x).choose_spec.left.choose
+  · constructor
+    · rw [(exists_basicOpen_to_affineOpens' f x).choose_spec.left.choose_spec]
+      exact (exists_basicOpen_to_affineOpens' f x).choose_spec.right.left
+    · rw [(exists_basicOpen_to_affineOpens' f x).choose_spec.left.choose_spec]
+      exact (exists_basicOpen_to_affineOpens' f x).choose_spec.right.right
+
+/-- Open cover of an affine scheme by basic opens that map into affine opens under a given
+continuous map into another scheme. -/
+noncomputable def affinePreimageCover : X.OpenCover where
+  I₀ := X.carrier
+  X x := (X.basicOpen (exists_basicOpen_to_affineOpens f x).choose).toScheme
+  f x := (X.basicOpen (exists_basicOpen_to_affineOpens f x).choose).ι
+  idx x := x
+  covers _ := by
+    rw [Scheme.Opens.range_ι]
+    exact (exists_basicOpen_to_affineOpens _ _).choose_spec.left
+  map_prop := by infer_instance
+
+end AffinePreimageCover
+
 end AlgebraicGeometry

--- a/Mathlib/AlgebraicGeometry/Pullbacks.lean
+++ b/Mathlib/AlgebraicGeometry/Pullbacks.lean
@@ -598,6 +598,37 @@ def diagonalRestrictIsoDiagonal (i j) :
     simp only [← Category.assoc, IsIso.comp_inv_eq]
     apply pullback.hom_ext <;> simp [H]
 
+section IsAffine
+
+lemma preservesColimit_affineScheme_Γ_span {X Y Z : AffineScheme} (f : X ⟶ Z) (g : Y ⟶ Z) :
+    PreservesColimit (span f.op g.op ⋙ AffineScheme.forgetToScheme.op) Scheme.Γ :=
+  @CategoryTheory.compPreservesColimitOfCreates _ _ _ _ _ _ _ _ _
+    AffineScheme.forgetToScheme.op Scheme.Γ (AffineScheme.forgetToScheme_op_createsColimits _ _)
+      (by rw [← AffineScheme.Γ]; infer_instance)
+
+lemma preservesLimit_affineScheme_Γ_cospan {X Y Z : AffineScheme} (f : X ⟶ Z) (g : Y ⟶ Z) :
+    PreservesLimit (cospan f g ⋙ AffineScheme.forgetToScheme) Scheme.Γ.rightOp := by
+  apply @CategoryTheory.compPreservesLimitOfCreates _ _ _ _ _ _ _ _ _
+    AffineScheme.forgetToScheme Scheme.Γ.rightOp (AffineScheme.forgetToScheme_createsLimits _ _) ?_
+  have : PreservesColimit (cospan f g).op (AffineScheme.forgetToScheme.op ⋙ Γ) := by
+    rw [← AffineScheme.Γ]
+    infer_instance
+  exact preservesLimit_rightOp (cospan f g) (AffineScheme.forgetToScheme.op ⋙ Γ)
+
+instance {X Y Z : Scheme} [IsAffine X] [IsAffine Y] [IsAffine Z]
+    (f : X ⟶ Z) (g : Y ⟶ Z) : PreservesColimit (span f.op g.op) Scheme.Γ :=
+  have := preservesColimit_affineScheme_Γ_span (AffineScheme.ofHom f) (AffineScheme.ofHom g)
+  preservesColimit_of_iso_diagram Scheme.Γ
+    (spanCompIso AffineScheme.forgetToScheme.op (AffineScheme.ofHom f).op (AffineScheme.ofHom g).op)
+
+instance {X Y Z : Scheme} [IsAffine X] [IsAffine Y] [IsAffine Z]
+    (f : X ⟶ Z) (g : Y ⟶ Z) : PreservesLimit (cospan f g) Scheme.Γ.rightOp :=
+  have := preservesLimit_affineScheme_Γ_cospan (AffineScheme.ofHom f) (AffineScheme.ofHom g)
+  preservesLimit_of_iso_diagram Scheme.Γ.rightOp
+    (cospanCompIso AffineScheme.forgetToScheme (AffineScheme.ofHom f) (AffineScheme.ofHom g))
+
+end IsAffine
+
 end Pullback
 
 end AlgebraicGeometry.Scheme

--- a/Mathlib/CategoryTheory/Limits/Creates.lean
+++ b/Mathlib/CategoryTheory/Limits/Creates.lean
@@ -633,6 +633,12 @@ instance compCreatesLimitsOfShape [CreatesLimitsOfShape J F] [CreatesLimitsOfSha
 instance compCreatesLimits [CreatesLimitsOfSize.{w, w'} F] [CreatesLimitsOfSize.{w, w'} G] :
     CreatesLimitsOfSize.{w, w'} (F ⋙ G) where CreatesLimitsOfShape := inferInstance
 
+instance compPreservesLimitOfCreates [CreatesLimit K F] [PreservesLimit K (F ⋙ G)] :
+    PreservesLimit (K ⋙ F) G where
+  preserves hc := ⟨IsLimit.ofIsoLimit (isLimitOfPreserves (F ⋙ G) (liftedLimitIsLimit hc))
+    ((Functor.mapConeMapCone (liftLimit hc)).symm ≪≫
+      (Cones.functoriality _ _).mapIso (liftedLimitMapsToOriginal hc))⟩
+
 instance compCreatesColimit [CreatesColimit K F] [CreatesColimit (K ⋙ F) G] :
     CreatesColimit K (F ⋙ G) where
   lifts c t :=
@@ -649,6 +655,12 @@ instance compCreatesColimitsOfShape [CreatesColimitsOfShape J F] [CreatesColimit
 
 instance compCreatesColimits [CreatesColimitsOfSize.{w, w'} F] [CreatesColimitsOfSize.{w, w'} G] :
     CreatesColimitsOfSize.{w, w'} (F ⋙ G) where CreatesColimitsOfShape := inferInstance
+
+instance compPreservesColimitOfCreates [CreatesColimit K F] [PreservesColimit K (F ⋙ G)] :
+    PreservesColimit (K ⋙ F) G where
+  preserves hc := ⟨IsColimit.ofIsoColimit (isColimitOfPreserves (F ⋙ G) (liftedColimitIsColimit hc))
+    ((Functor.mapCoconeMapCocone (liftColimit hc)).symm ≪≫
+      (Cocones.functoriality _ _).mapIso (liftedColimitMapsToOriginal hc))⟩
 
 end Comp
 


### PR DESCRIPTION
This PR adds simple results about affine scheme.

Main changes:

* `forgetToScheme_createsLimits`: Shows that the `AffineScheme.forgetToScheme` creates limits for cospans
* `forgetToScheme_op_createsColimits` : the dual statement for `AffineScheme.forgetToScheme.op`

* instance `Scheme.isAffine_local_affine`: the scheme associated to a local affine neighborhood is affine

* `exists_basicOpen_to_affineOpens`: For a *continuous* map from an affine scheme `X` to a scheme `Y`, every point in `X` has a basic open neighborhood that maps into an affine open of `Y`
* `affinePreimageCover`: Constructs an open cover of an affine scheme by basic opens that map into affine opens under a given continuous map to another scheme

* instances : `Scheme.Γ` (or `Scheme.Γ.rightOp`) preserves pullbacks of affine schemes.

This PR supersedes #29961 (closed) and has been reopened following #30014.

These results will be used in a forthcoming PR on a proof that `Spec` of a faithfully flat ring map is an effective epimorphism in the category of schemes.

---

- [ ] depends on: #30014