### PR TITLE
[Merged by Bors] - feat(CategoryTheory/Closed): variant of `cartesianClosedOfReflective` with better definitional equalities

### DIFF
--- a/Mathlib/CategoryTheory/Closed/Ideal.lean
+++ b/Mathlib/CategoryTheory/Closed/Ideal.lean
@@ -218,8 +218,10 @@ exponential objects in `D` by applying the reflector to them, even though they a
 essential image of `i`; if you need better control over definitional equality, use
 `cartesianClosedOfReflective'` instead. -/
 def cartesianClosedOfReflective : CartesianClosed D :=
-  cartesianClosedOfReflective' i (i.essImage.ι ⋙ reflector i) <| NatIso.ofComponents
-    (fun X ↦ (@asIso _ _ _ _ _ <| Functor.essImage.unit_isIso X.2).symm) (by simp)
+  cartesianClosedOfReflective' i (i.essImage.ι ⋙ reflector i)
+    (NatIso.ofComponents (fun X ↦
+      have := Functor.essImage.unit_isIso X.2
+      (asIso ((reflectorAdjunction i).unit.app X.obj)).symm))
 
 variable [BraidedCategory C]
 

--- a/Mathlib/CategoryTheory/Closed/Ideal.lean
+++ b/Mathlib/CategoryTheory/Closed/Ideal.lean
@@ -186,10 +186,17 @@ variable [ExponentialIdeal i]
 
 /-- If `i` witnesses that `D` is a reflective subcategory and an exponential ideal, then `D` is
 itself Cartesian closed.
--/
-def cartesianClosedOfReflective : CartesianClosed D where
+
+To allow for better control of definitional equality, this construction
+takes in an explicit choice of lift of the essential image of `i` to `D`, in the form of a functor
+`l : i.EssImageSubcategory ⥤ D` and natural isomorphism `φ : l ⋙ i ≅ i.essImage.ι`. When
+`l ⋙ i` is defeq to `i.essImage.ι`, images of exponential objects in `D` under `i` will be defeq
+to the respective exponential objects in `C`. -/
+def cartesianClosedOfReflective' (l : i.EssImageSubcategory ⥤ D) (φ : l ⋙ i ≅ i.essImage.ι) :
+    CartesianClosed D where
   closed := fun B =>
-    { rightAdj := i ⋙ exp (i.obj B) ⋙ reflector i
+    { rightAdj := i.essImage.lift (i ⋙ exp (i.obj B))
+        (fun X ↦ ExponentialIdeal.exp_closed (i.obj_mem_essImage X) _) ⋙ l
       adj := by
         apply (exp.adjunction (i.obj B)).restrictFullyFaithful i.fullyFaithfulOfReflective
           i.fullyFaithfulOfReflective
@@ -200,7 +207,19 @@ def cartesianClosedOfReflective : CartesianClosed D where
             apply asIso (prodComparison i B X)
           · dsimp [asIso]
             rw [prodComparison_natural_whiskerLeft]
-        · apply (exponentialIdealReflective i _).symm }
+        · exact (i.essImage.liftCompιIso _ _).symm.trans <|
+            (Functor.isoWhiskerLeft _ φ.symm).trans (Functor.associator _ _ _).symm }
+
+/-- If `i` witnesses that `D` is a reflective subcategory and an exponential ideal, then `D` is
+itself Cartesian closed.
+
+Unlike `cartesianClosedOfReflective'` this construction lifts exponential objects in `C` to
+exponential objects in `D` by applying the reflector to them, even though they already lie in the
+essential image of `i`; if you need better control over definitional equality, use
+`cartesianClosedOfReflective'` instead. -/
+def cartesianClosedOfReflective : CartesianClosed D :=
+  cartesianClosedOfReflective' i (i.essImage.ι ⋙ reflector i) <| NatIso.ofComponents
+    (fun X ↦ (@asIso _ _ _ _ _ <| Functor.essImage.unit_isIso X.2).symm) (by simp)
 
 variable [BraidedCategory C]
 

--- a/Mathlib/CategoryTheory/Sites/CartesianClosed.lean
+++ b/Mathlib/CategoryTheory/Sites/CartesianClosed.lean
@@ -24,6 +24,6 @@ variable {C : Type*} [Category C] (J : GrothendieckTopology C) (A : Type*) [Cate
 instance [HasSheafify J A] [CartesianMonoidalCategory A] [CartesianClosed (Cᵒᵖ ⥤ A)] :
     CartesianClosed (Sheaf J A) :=
   cartesianClosedOfReflective' (sheafToPresheaf _ _) {
-    obj F := ⟨F.1, (isSheaf_of_iso_iff <| Classical.choice <| F.2.choose_spec).1 (Sheaf.cond _)⟩
+    obj F := ⟨F.obj, (isSheaf_of_iso_iff F.2.choose_spec.some).1 (Sheaf.cond _)⟩
     map f := ⟨f⟩
   } (Iso.refl _)

--- a/Mathlib/CategoryTheory/Sites/CartesianClosed.lean
+++ b/Mathlib/CategoryTheory/Sites/CartesianClosed.lean
@@ -17,10 +17,13 @@ import Mathlib.CategoryTheory.Sites.Sheafification
 
 noncomputable section
 
-open CategoryTheory Limits
+open CategoryTheory Presheaf
 
 variable {C : Type*} [Category C] (J : GrothendieckTopology C) (A : Type*) [Category A]
 
 instance [HasSheafify J A] [CartesianMonoidalCategory A] [CartesianClosed (Cᵒᵖ ⥤ A)] :
     CartesianClosed (Sheaf J A) :=
-  cartesianClosedOfReflective (sheafToPresheaf _ _)
+  cartesianClosedOfReflective' (sheafToPresheaf _ _) {
+    obj F := ⟨F.1, (isSheaf_of_iso_iff <| Classical.choice <| F.2.choose_spec).1 (Sheaf.cond _)⟩
+    map f := ⟨f⟩
+  } (Iso.refl _)


### PR DESCRIPTION
A variant of `cartesianClosedOfReflective` that allows for better control over the resulting exponentials. The main application of this is that exponentials of sheaves are now computed as exponentials of presheaves up to definitional equality.

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include at least one commit authored by each
co-author among the commits in the pull request. If necessary, you may 
create empty commits to indicate co-authorship, using commands like so:

git commit --author="Author Name <author@email.com>" --allow-empty -m "add Author Name as coauthor"

When merging, all the commits will be squashed into a single commit listing all co-authors.

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
