### PR TITLE
[Merged by Bors] - feat(Mathlib/AlgebraicGeometry/PullbackCarrier): pullbackComparison for Scheme.forget is surjective

### DIFF
--- a/Mathlib/AlgebraicGeometry/PullbackCarrier.lean
+++ b/Mathlib/AlgebraicGeometry/PullbackCarrier.lean
@@ -295,6 +295,18 @@ lemma exists_preimage_pullback (x : X) (y : Y) (h : f.base x = g.base y) :
     (pullback.fst f g).base z = x ∧ (pullback.snd f g).base z = y :=
   (Pullback.Triplet.mk' x y h).exists_preimage
 
+/-- The comparison map for pullbacks under the forgetful functor `Scheme ⥤ Type u` is surjective. -/
+lemma forget_comparison_surjective {X Y S : Scheme.{u}} (f : X ⟶ S) (g : Y ⟶ S) :
+    Function.Surjective (pullbackComparison forget f g) := by
+  apply (Function.Surjective.of_comp_iff' ((PullbackCone.IsLimit.equivPullbackObj
+    (pullbackIsPullback _ _)).bijective) (pullbackComparison forget f g)).mp
+  intro ⟨⟨x, y⟩, hb⟩
+  obtain ⟨z, ⟨hz, hz'⟩⟩ := exists_preimage_pullback x y hb
+  use z
+  ext
+  · exact hz.symm ▸ congr_fun (pullbackComparison_comp_fst forget f g) z
+  · exact hz'.symm ▸ congr_fun (pullbackComparison_comp_snd forget f g) z
+
 lemma _root_.AlgebraicGeometry.Scheme.isEmpty_pullback_iff {f : X ⟶ S} {g : Y ⟶ S} :
     IsEmpty ↑(Limits.pullback f g) ↔ Disjoint (Set.range f.base) (Set.range g.base) := by
   refine ⟨?_, Scheme.isEmpty_pullback f g⟩

--- a/Mathlib/AlgebraicGeometry/PullbackCarrier.lean
+++ b/Mathlib/AlgebraicGeometry/PullbackCarrier.lean
@@ -298,14 +298,14 @@ lemma exists_preimage_pullback (x : X) (y : Y) (h : f.base x = g.base y) :
 /-- The comparison map for pullbacks under the forgetful functor `Scheme ⥤ Type u` is surjective. -/
 lemma forget_comparison_surjective {X Y S : Scheme.{u}} (f : X ⟶ S) (g : Y ⟶ S) :
     Function.Surjective (pullbackComparison forget f g) := by
-  apply (Function.Surjective.of_comp_iff' ((PullbackCone.IsLimit.equivPullbackObj
-    (pullbackIsPullback _ _)).bijective) (pullbackComparison forget f g)).mp
+  apply (Function.Surjective.of_comp_iff'
+    ((PullbackCone.IsLimit.equivPullbackObj (pullbackIsPullback _ _)).bijective) _).mp
   intro ⟨⟨x, y⟩, hb⟩
   obtain ⟨z, ⟨hz, hz'⟩⟩ := exists_preimage_pullback x y hb
   use z
   ext
-  · exact hz.symm ▸ congr_fun (pullbackComparison_comp_fst forget f g) z
-  · exact hz'.symm ▸ congr_fun (pullbackComparison_comp_snd forget f g) z
+  · exact hz.symm ▸ congrFun (pullbackComparison_comp_fst forget f g) z
+  · exact hz'.symm ▸ congrFun (pullbackComparison_comp_snd forget f g) z
 
 lemma _root_.AlgebraicGeometry.Scheme.isEmpty_pullback_iff {f : X ⟶ S} {g : Y ⟶ S} :
     IsEmpty ↑(Limits.pullback f g) ↔ Disjoint (Set.range f.base) (Set.range g.base) := by


### PR DESCRIPTION
This PR adds a simple lemma `forget_comparison_surjective` which states that:

The pullback comparison map for the forgetful functor `Scheme ⥤ Type*` is surjective.

The proof builds on the existing `exists_preimage_pullback`, which was already available.