### PR TITLE
[Merged by Bors] - feat(Mathlib/AlgebraicGeometry/Morphisms/Flat): add simple properties of flat maps

### DIFF
--- a/Mathlib/AlgebraicGeometry/Morphisms/Flat.lean
+++ b/Mathlib/AlgebraicGeometry/Morphisms/Flat.lean
@@ -116,6 +116,7 @@ lemma isQuotientMap_of_surjective {X Y : Scheme.{u}} (f : X ⟶ Y) [Flat f] [Qua
     rwa [← HasRingHomProperty.Spec_iff (P := @Flat)]
 
 /-- A flat surjective morphism of schemes is an epimorphism in the category of schemes. -/
+@[stacks 02VW]
 lemma epi_of_flat_surjective {X Y : Scheme.{u}} (f : X ⟶ Y) [Flat f] [Surjective f] : Epi f := by
   constructor
   intro _ g g' hg

--- a/Mathlib/AlgebraicGeometry/Morphisms/Flat.lean
+++ b/Mathlib/AlgebraicGeometry/Morphisms/Flat.lean
@@ -120,7 +120,7 @@ lemma isQuotientMap_of_surjective {X Y : Scheme.{u}} (f : X ⟶ Y) [Flat f] [Qua
 lemma epi_of_flat_surjective {X Y : Scheme.{u}} (f : X ⟶ Y) [Flat f] [Surjective f] : Epi f := by
   apply CategoryTheory.Functor.epi_of_epi_map (Scheme.forgetToLocallyRingedSpace)
   apply CategoryTheory.Functor.epi_of_epi_map (LocallyRingedSpace.forgetToSheafedSpace)
-  apply SheafedSpace.mono_of_base_surjective_of_stalk_mono _ ‹Surjective f›.surj
+  apply SheafedSpace.epi_of_base_surjective_of_stalk_mono _ ‹Surjective f›.surj
   intro x
   apply ConcreteCategory.mono_of_injective
   algebraize [(f.stalkMap x).hom]

--- a/Mathlib/AlgebraicGeometry/Morphisms/Flat.lean
+++ b/Mathlib/AlgebraicGeometry/Morphisms/Flat.lean
@@ -117,7 +117,7 @@ lemma isQuotientMap_of_surjective {X Y : Scheme.{u}} (f : X ⟶ Y) [Flat f] [Qua
 
 /-- A flat surjective morphism of schemes is an epimorphism in the category of schemes. -/
 @[stacks 02VW]
-lemma epi_of_flat_surjective {X Y : Scheme.{u}} (f : X ⟶ Y) [Flat f] [Surjective f] : Epi f := by
+lemma epi_of_flat_of_surjective {X Y : Scheme.{u}} (f : X ⟶ Y) [Flat f] [Surjective f] : Epi f := by
   apply CategoryTheory.Functor.epi_of_epi_map (Scheme.forgetToLocallyRingedSpace)
   apply CategoryTheory.Functor.epi_of_epi_map (LocallyRingedSpace.forgetToSheafedSpace)
   apply SheafedSpace.epi_of_base_surjective_of_stalk_mono _ ‹Surjective f›.surj

--- a/Mathlib/AlgebraicGeometry/Morphisms/Flat.lean
+++ b/Mathlib/AlgebraicGeometry/Morphisms/Flat.lean
@@ -7,7 +7,7 @@ import Mathlib.AlgebraicGeometry.Morphisms.RingHomProperties
 import Mathlib.AlgebraicGeometry.Morphisms.QuasiCompact
 import Mathlib.AlgebraicGeometry.Morphisms.Affine
 import Mathlib.AlgebraicGeometry.PullbackCarrier
-import Mathlib.RingTheory.RingHom.Flat
+import Mathlib.RingTheory.RingHom.FaithfullyFlat
 
 /-!
 # Flat morphisms
@@ -114,6 +114,27 @@ lemma isQuotientMap_of_surjective {X Y : Scheme.{u}} (f : X ⟶ Y) [Flat f] [Qua
   · exact (surjective_iff (Spec.map φ)).mp inferInstance
   · apply RingHom.Flat.generalizingMap_comap
     rwa [← HasRingHomProperty.Spec_iff (P := @Flat)]
+
+/-- A flat surjective morphism of schemes is an epimorphism in the category of schemes. -/
+lemma epi_of_flat_surjective {X Y : Scheme.{u}} (f : X ⟶ Y) [Flat f] [Surjective f] : Epi f := by
+  constructor
+  intro _ g g' hg
+  apply Scheme.Hom.ext'
+  apply LocallyRingedSpace.Hom.ext'
+  fapply SheafedSpace.hom_stalk_ext
+  · apply ((TopCat.epi_iff_surjective f.base).mpr Surjective.surj).left_cancellation g.base g'.base
+    rw [← Scheme.comp_coeBase, hg, Scheme.comp_coeBase]
+  · intro y
+    change g.stalkMap y = _ ≫ g'.stalkMap y
+    obtain ⟨x, hx⟩ := ‹Surjective f›.surj y
+    rw [← hx]
+    algebraize [(f.stalkMap x).hom]
+    haveI : Module.FaithfullyFlat (Y.presheaf.stalk (f.base.hom x)) (X.presheaf.stalk x) :=
+      @Module.FaithfullyFlat.of_flat_of_isLocalHom _ _ _ _ _ _ _
+        (Flat.stalkMap f x) (f.toLRSHom.prop x)
+    apply ConcreteCategory.mono_of_injective _ (‹RingHom.FaithfullyFlat _›.injective)
+      |>.right_cancellation _ _
+    simp only [← Scheme.stalkMap_comp, Category.assoc, Scheme.stalkMap_congr_hom _ _ hg x]
 
 end Flat
 

--- a/Mathlib/AlgebraicGeometry/Morphisms/Flat.lean
+++ b/Mathlib/AlgebraicGeometry/Morphisms/Flat.lean
@@ -118,24 +118,16 @@ lemma isQuotientMap_of_surjective {X Y : Scheme.{u}} (f : X ⟶ Y) [Flat f] [Qua
 /-- A flat surjective morphism of schemes is an epimorphism in the category of schemes. -/
 @[stacks 02VW]
 lemma epi_of_flat_surjective {X Y : Scheme.{u}} (f : X ⟶ Y) [Flat f] [Surjective f] : Epi f := by
-  constructor
-  intro _ g g' hg
-  apply Scheme.Hom.ext'
-  apply LocallyRingedSpace.Hom.ext'
-  fapply SheafedSpace.hom_stalk_ext
-  · apply ((TopCat.epi_iff_surjective f.base).mpr Surjective.surj).left_cancellation g.base g'.base
-    rw [← Scheme.comp_coeBase, hg, Scheme.comp_coeBase]
-  · intro y
-    change g.stalkMap y = _ ≫ g'.stalkMap y
-    obtain ⟨x, hx⟩ := ‹Surjective f›.surj y
-    rw [← hx]
-    algebraize [(f.stalkMap x).hom]
-    haveI : Module.FaithfullyFlat (Y.presheaf.stalk (f.base.hom x)) (X.presheaf.stalk x) :=
-      @Module.FaithfullyFlat.of_flat_of_isLocalHom _ _ _ _ _ _ _
-        (Flat.stalkMap f x) (f.toLRSHom.prop x)
-    apply ConcreteCategory.mono_of_injective _ (‹RingHom.FaithfullyFlat _›.injective)
-      |>.right_cancellation _ _
-    simp only [← Scheme.stalkMap_comp, Category.assoc, Scheme.stalkMap_congr_hom _ _ hg x]
+  apply CategoryTheory.Functor.epi_of_epi_map (Scheme.forgetToLocallyRingedSpace)
+  apply CategoryTheory.Functor.epi_of_epi_map (LocallyRingedSpace.forgetToSheafedSpace)
+  apply SheafedSpace.mono_of_base_surjective_of_stalk_mono _ ‹Surjective f›.surj
+  intro x
+  apply ConcreteCategory.mono_of_injective
+  algebraize [(f.stalkMap x).hom]
+  have : Module.FaithfullyFlat (Y.presheaf.stalk (f.base.hom x)) (X.presheaf.stalk x) :=
+    @Module.FaithfullyFlat.of_flat_of_isLocalHom _ _ _ _ _ _ _
+      (Flat.stalkMap f x) (f.toLRSHom.prop x)
+  exact ‹RingHom.FaithfullyFlat _›.injective
 
 end Flat
 

--- a/Mathlib/Geometry/RingedSpace/SheafedSpace.lean
+++ b/Mathlib/Geometry/RingedSpace/SheafedSpace.lean
@@ -244,6 +244,22 @@ lemma mono_of_base_injective_of_stalk_epi {X Y : SheafedSpace C} (f : X ⟶ Y)
     ← PresheafedSpace.stalkMap.comp ⟨g, gc⟩ f, ← PresheafedSpace.stalkMap.comp ⟨g, hc⟩ f]
   congr 1
 
+attribute [local ext] DFunLike.ext in
+include instCC in
+lemma epi_of_base_surjective_of_stalk_mono {X Y : SheafedSpace C} (f : X ⟶ Y)
+    (h₁ : Function.Surjective f.base)
+    (h₂ : ∀ x, Mono (f.stalkMap x)) : Epi f := by
+  constructor
+  intro Z ⟨g, gc⟩ ⟨h, hc⟩ e
+  obtain rfl : g = h := ConcreteCategory.hom_ext _ _ fun y ↦ by
+    rw [← (h₁ y).choose_spec]
+    simpa using congr(($e).base.hom (h₁ y).choose)
+  refine SheafedSpace.hom_stalk_ext ⟨g, gc⟩ ⟨g, hc⟩ rfl fun y ↦ ?_
+  rw [← (h₁ y).choose_spec, ← cancel_mono (f.stalkMap (h₁ y).choose), stalkCongr_hom,
+    stalkSpecializes_refl, Category.id_comp, ← PresheafedSpace.stalkMap.comp f ⟨g, gc⟩,
+    ← PresheafedSpace.stalkMap.comp f ⟨g, hc⟩]
+  congr 1
+
 end ConcreteCategory
 
 end SheafedSpace

--- a/Mathlib/RingTheory/Flat/FaithfullyFlat/Algebra.lean
+++ b/Mathlib/RingTheory/Flat/FaithfullyFlat/Algebra.lean
@@ -81,6 +81,14 @@ lemma Module.FaithfullyFlat.tensorProduct_mk_injective (M : Type*) [AddCommGroup
   rw [this, coe_comp, LinearEquiv.coe_coe, EmbeddingLike.comp_injective]
   exact Algebra.TensorProduct.mk_one_injective_of_isScalarTower _
 
+instance : FaithfulSMul A B := by
+  constructor
+  intro a₁ a₂ ha
+  apply Module.FaithfullyFlat.tensorProduct_mk_injective (A := A) (B := B) A
+  simp only [TensorProduct.mk_apply]
+  rw [← mul_one a₁, ← mul_one a₂]
+  simp only [← smul_eq_mul, ← TensorProduct.smul_tmul, ha (1 : B)]
+
 open Algebra.TensorProduct in
 /-- If `B` is a faithfully flat `A`-algebra, the preimage of the pushforward of any
 ideal `I` is again `I`. -/

--- a/Mathlib/RingTheory/Flat/FaithfullyFlat/Algebra.lean
+++ b/Mathlib/RingTheory/Flat/FaithfullyFlat/Algebra.lean
@@ -81,7 +81,7 @@ lemma Module.FaithfullyFlat.tensorProduct_mk_injective (M : Type*) [AddCommGroup
   rw [this, coe_comp, LinearEquiv.coe_coe, EmbeddingLike.comp_injective]
   exact Algebra.TensorProduct.mk_one_injective_of_isScalarTower _
 
-instance : FaithfulSMul A B := by
+instance Module.FaithfullyFlat.faithfulSMul : FaithfulSMul A B := by
   constructor
   intro a₁ a₂ ha
   apply Module.FaithfullyFlat.tensorProduct_mk_injective (A := A) (B := B) A

--- a/Mathlib/RingTheory/RingHom/FaithfullyFlat.lean
+++ b/Mathlib/RingTheory/RingHom/FaithfullyFlat.lean
@@ -63,12 +63,9 @@ lemma of_bijective (hf : Function.Bijective f) : f.FaithfullyFlat := by
 
 lemma injective (hf : f.FaithfullyFlat) : Function.Injective ⇑f := by
   algebraize [f]
-  intro r r' hrr'
-  apply Module.FaithfullyFlat.tensorProduct_mk_injective (A := R) (B := S) R
-  simp only [TensorProduct.mk_apply]
-  rw [← mul_one r, ← mul_one r']
-  simp only [← smul_eq_mul, ← TensorProduct.smul_tmul]
-  simp only [Algebra.smul_def, mul_one, RingHom.algebraMap_toAlgebra, hrr']
+  intro _ _ h
+  apply (smul_left_injective' : Function.Injective (· • · : R → S → S))
+  simp only [Algebra.smul_def, RingHom.algebraMap_toAlgebra, h]
 
 lemma respectsIso : RespectsIso FaithfullyFlat :=
   stableUnderComposition.respectsIso (fun e ↦ .of_bijective e.bijective)

--- a/Mathlib/RingTheory/RingHom/FaithfullyFlat.lean
+++ b/Mathlib/RingTheory/RingHom/FaithfullyFlat.lean
@@ -63,9 +63,7 @@ lemma of_bijective (hf : Function.Bijective f) : f.FaithfullyFlat := by
 
 lemma injective (hf : f.FaithfullyFlat) : Function.Injective ⇑f := by
   algebraize [f]
-  intro _ _ h
-  apply (smul_left_injective' : Function.Injective (· • · : R → S → S))
-  simp only [Algebra.smul_def, RingHom.algebraMap_toAlgebra, h]
+  exact FaithfulSMul.algebraMap_injective R S
 
 lemma respectsIso : RespectsIso FaithfullyFlat :=
   stableUnderComposition.respectsIso (fun e ↦ .of_bijective e.bijective)

--- a/Mathlib/RingTheory/RingHom/FaithfullyFlat.lean
+++ b/Mathlib/RingTheory/RingHom/FaithfullyFlat.lean
@@ -61,6 +61,15 @@ lemma of_bijective (hf : Function.Bijective f) : f.FaithfullyFlat := by
     exact (RingEquiv.ofBijective f hf).injective (by simp)
   rw [← PrimeSpectrum.specComap_comp_apply, this, PrimeSpectrum.specComap_id]
 
+lemma injective (hf : f.FaithfullyFlat) : Function.Injective ⇑f := by
+  algebraize [f]
+  intro r r' hrr'
+  apply Module.FaithfullyFlat.tensorProduct_mk_injective (A := R) (B := S) R
+  simp only [TensorProduct.mk_apply]
+  rw [← mul_one r, ← mul_one r']
+  simp only [← smul_eq_mul, ← TensorProduct.smul_tmul]
+  simp only [Algebra.smul_def, mul_one, RingHom.algebraMap_toAlgebra, hrr']
+
 lemma respectsIso : RespectsIso FaithfullyFlat :=
   stableUnderComposition.respectsIso (fun e ↦ .of_bijective e.bijective)
 


### PR DESCRIPTION
This PR adds two lemmas for faithfully flat ring maps and flat surjective scheme morphisms.

- `RingHom.FaithfullyFlat.injective`: Proves that a faithfully flat ring map is injective. (This is built on the pre-existing lemma `Module.FaithfullyFlat.tensorProduct_mk_injective`, which states that ```If `B` is a faithfully flat `A`-module and `M` is any `A`-module, the canonical map `M →ₗ[A] B ⊗[A] M` is injective.```)

- `AlgebraicGeometry.Flat.epi_of_flat_surjective`: Proves that a flat surjective morphism of schemes is an epimorphism in the category of schemes. For this, `Mathlib/AlgebraicGeometry/Morphisms/Flat.lean` now imports `Mathlib.RingTheory.RingHom.FaithfullyFlat` to use the former.


