### PR TITLE
[Merged by Bors] - feat(Analysis/Fourier): Parseval for FourierCoeffOn

### DIFF
--- a/Mathlib/Analysis/Fourier/AddCircle.lean
+++ b/Mathlib/Analysis/Fourier/AddCircle.lean
@@ -397,53 +397,52 @@ theorem tsum_sq_fourierCoeff (f : Lp ℂ 2 <| @haarAddCircle T hT) :
     ∑' i : ℤ, ‖fourierCoeff f i‖ ^ 2 = ∫ t : AddCircle T, ‖f t‖ ^ 2 ∂haarAddCircle :=
   (hasSum_sq_fourierCoeff _).tsum_eq
 
-lemma integral_liftIoc_sq_eq {a b : ℝ} [hab : Fact (0 < b - a)] {f : ℝ → ℂ} :
-    ∫ (t : AddCircle (b - a)), ‖liftIoc (b - a) a f t‖^2 ∂haarAddCircle =
-    (b - a)⁻¹ • ∫ x in a..b, ‖f x‖ ^ 2 := by
-  have hab' : a < b := lt_add_neg_iff_lt.mp hab.out
+lemma integral_liftIoc_sq_eq {a : ℝ} {f : ℝ → ℂ} :
+    ∫ (t : AddCircle T), ‖liftIoc T a f t‖ ^ 2 ∂haarAddCircle = T⁻¹ • ∫ x in a..a + T, ‖f x‖ ^ 2
+    := by
+  have hab : a < a + T := (lt_add_iff_pos_right a).mpr hT.out
   rw [eq_inv_smul_iff₀ (by linarith)]
-  conv in (b-a) =>
-    rw [←ENNReal.toReal_ofReal (by linarith : 0 ≤ b-a)]
-  rw [←integral_smul_measure, ←volume_eq_smul_haarAddCircle, ←AddCircle.intervalIntegral_preimage,
-    add_sub_cancel]
+  conv in T =>
+    rw [←ENNReal.toReal_ofReal hT.out.le]
+  rw [←integral_smul_measure, ←volume_eq_smul_haarAddCircle, ←AddCircle.intervalIntegral_preimage]
   apply intervalIntegral.integral_congr_ae
   filter_upwards with _ hx
   congr
-  rw [uIoc_of_le (le_of_lt hab'), ←add_sub_cancel a b] at hx
+  rw [uIoc_of_le hab.le] at hx
   exact liftIoc_coe_apply hx
 
-lemma memLp_liftIoc_of_memLp {a b : ℝ} [hab : Fact (0 < b - a)] {f : ℝ → ℂ} {p : ℝ≥0∞}
-    (hLp : MemLp f p (volume.restrict (Ioc a b))) : MemLp (liftIoc (b - a) a f) p
-    := by
-  rw [←add_sub_cancel a b] at hLp
-  rw [←(AddCircle.measurePreserving_mk (b-a) a).map_eq]
-  apply (memLp_map_measure_iff _ _).mpr
-  · apply hLp.ae_eq
-    rw [Filter.EventuallyEq, ae_restrict_iff' measurableSet_Ioc]
-    filter_upwards with _ h
-    rw [←liftIoc_coe_apply (f:=f) h]
-    rfl
-  · rw [aestronglyMeasurable_iff_aemeasurable, ←map_comap_subtype_coe measurableSet_Ioc,
-      map_map (by exact fun ⦃t⦄ a ↦ a) measurable_subtype_coe, liftIoc]
-    apply AEMeasurable.comp_measurable _ (measurableEquivIoc (b-a) a).measurable
-    rw [map_map (measurableEquivIoc _ _).measurable]
-    · have : ⇑(measurableEquivIoc (b - a) a) ∘ QuotientAddGroup.mk ∘ Subtype.val = _root_.id :=
-        Function.RightInverse.id (measurableEquivIoc _ _).right_inv
-      rw [this, Measure.map_id]
-      apply AEMeasurable.comp_measurable _ measurable_subtype_coe
-      rw [map_comap_subtype_coe measurableSet_Ioc]
-      exact hLp.aemeasurable
-    · exact (measurableEquivIoc _ _).measurable_invFun
-  · exact Measurable.aemeasurable fun t a ↦ a
+lemma measurePreserving_equivIoc {a : ℝ} :
+    MeasurePreserving (equivIoc T a) volume (Measure.comap Subtype.val volume) := by
+  have h := (measurableEquivIoc T a).measurable
+  refine ⟨h, ?_⟩
+  ext s hs
+  rw [comap_apply _ Subtype.val_injective (fun _ ↦ measurableSet_Ioc.subtype_image) _ hs,
+    map_apply (by measurability) hs, add_projection_respects_measure T a (by exact h hs)]
+  congr!
+  ext x
+  simp only [mem_inter_iff, mem_preimage, mem_image, Subtype.exists, exists_and_right,
+    exists_eq_right]
+  rw [and_comm, ← exists_prop]
+  congr! with hx
+  rw [equivIoc_coe_eq hx]
 
-lemma memLp_liftIoc_of_memLp' {a b : ℝ} [hab : Fact (0 < b - a)] {f : ℝ → ℂ} {p : ℝ≥0∞}
-    (hLp : MemLp f p (volume.restrict (Ioc a b))) : MemLp (liftIoc (b - a) a f) p haarAddCircle
-    := by
+lemma memLp_liftIoc_of_memLp
+    {a : ℝ} {f : ℝ → ℂ} {p : ℝ≥0∞} (hLp : MemLp f p (volume.restrict (Ioc a (a + T)))) :
+    MemLp (liftIoc T a f) p := by
+  simp only [liftIoc, Set.restrict_def, Function.comp_def]
+  apply hLp.comp_measurePreserving
+  refine .comp (measurePreserving_subtype_coe measurableSet_Ioc) ?_
+  exact measurePreserving_equivIoc
+
+
+lemma memLp_liftIoc_of_memLp'
+    {a : ℝ} {f : ℝ → ℂ} {p : ℝ≥0∞} (hLp : MemLp f p (volume.restrict (Ioc a (a + T)))) :
+    MemLp (liftIoc T a f) p haarAddCircle := by
   have h := memLp_liftIoc_of_memLp hLp
   rw [volume_eq_smul_haarAddCircle] at h
-  have h' := MemLp.smul_measure h (ENNReal.inv_ne_top.mpr (ENNReal.ofReal_ne_zero_iff.mpr hab.out))
+  have h' := MemLp.smul_measure h (ENNReal.inv_ne_top.mpr (ENNReal.ofReal_ne_zero_iff.mpr hT.out))
   simpa [smul_smul,
-    ENNReal.inv_mul_cancel (ENNReal.ofReal_ne_zero_iff.mpr hab.out) ENNReal.ofReal_ne_top] using h'
+    ENNReal.inv_mul_cancel (ENNReal.ofReal_ne_zero_iff.mpr hT.out) ENNReal.ofReal_ne_top] using h'
 
 /-- **Parseval's identity**: for a function `f` which is square integrable on (a,b],
 the sum of the squared norms of the Fourier coefficients equals the `L²` norm of `f`. -/
@@ -451,7 +450,9 @@ theorem hasSum_sq_fourierCoeffOn
     {a b : ℝ} {f : ℝ → ℂ} (hab : a < b) (hL2 : MemLp f 2 (volume.restrict (Ioc a b))) :
     HasSum (fun i => ‖fourierCoeffOn hab f i‖ ^ 2) ((b - a)⁻¹ • ∫ x in a..b, ‖f x‖ ^ 2) := by
   haveI := Fact.mk (by linarith : 0 < b - a)
+  rw [←add_sub_cancel a b] at hL2
   have h := (memLp_liftIoc_of_memLp' hL2).coeFn_toLp
+  conv in intervalIntegral _ _ _ => rw [←add_sub_cancel a b]
   rw [←integral_liftIoc_sq_eq,
       ←integral_congr_ae (h.mono (fun x hx => congrArg (fun x => ‖x‖^2) hx))]
   conv in fourierCoeffOn _ _ _ =>

--- a/Mathlib/Analysis/Fourier/AddCircle.lean
+++ b/Mathlib/Analysis/Fourier/AddCircle.lean
@@ -96,6 +96,20 @@ lemma integral_haarAddCircle {E : Type*} [NormedAddCommGroup E] [NormedSpace ℝ
 
 end AddCircle
 
+namespace MeasureTheory
+
+lemma memLp_haarAddCircle_iff [hT : Fact (0 < T)] {f : AddCircle T → ℂ} {p : ℝ≥0∞} :
+    MemLp f p AddCircle.haarAddCircle ↔ MemLp f p := by
+  rw [AddCircle.volume_eq_smul_haarAddCircle]
+  have hT' := hT.out
+  refine ⟨fun h ↦ h.smul_measure (by finiteness), fun h ↦ ?_⟩
+  have := h.smul_measure (c := (ENNReal.ofReal T)⁻¹) (by finiteness)
+  rwa [smul_smul, ENNReal.inv_mul_cancel (by positivity) (by finiteness), one_smul] at this
+
+alias ⟨MemLp.of_haarAddCircle, MemLp.haarAddCircle⟩ := memLp_haarAddCircle_iff
+
+end MeasureTheory
+
 open AddCircle
 
 section Monomials
@@ -414,20 +428,6 @@ theorem hasSum_sq_fourierCoeff (f : Lp ℂ 2 <| @haarAddCircle T hT) :
 theorem tsum_sq_fourierCoeff (f : Lp ℂ 2 <| @haarAddCircle T hT) :
     ∑' i : ℤ, ‖fourierCoeff f i‖ ^ 2 = ∫ t : AddCircle T, ‖f t‖ ^ 2 ∂haarAddCircle :=
   (hasSum_sq_fourierCoeff _).tsum_eq
-
-namespace MeasureTheory
-
-lemma memLp_haarAddCircle_iff {f : AddCircle T → ℂ} {p : ℝ≥0∞} :
-    MemLp f p haarAddCircle ↔ MemLp f p := by
-  rw [volume_eq_smul_haarAddCircle]
-  have hT' := hT.out
-  refine ⟨fun h ↦ h.smul_measure (by finiteness), fun h ↦ ?_⟩
-  have := h.smul_measure (c := (ENNReal.ofReal T)⁻¹) (by finiteness)
-  rwa [smul_smul, ENNReal.inv_mul_cancel (by positivity) (by finiteness), one_smul] at this
-
-alias ⟨MemLp.of_haarAddCircle, MemLp.haarAddCircle⟩ := memLp_haarAddCircle_iff
-
-end MeasureTheory
 
 /-- **Parseval's identity**: for a function `f` which is square integrable on (a,b],
 the sum of the squared norms of the Fourier coefficients equals the `L²` norm of `f`. -/

--- a/Mathlib/Analysis/Fourier/AddCircle.lean
+++ b/Mathlib/Analysis/Fourier/AddCircle.lean
@@ -415,30 +415,7 @@ theorem tsum_sq_fourierCoeff (f : Lp ℂ 2 <| @haarAddCircle T hT) :
     ∑' i : ℤ, ‖fourierCoeff f i‖ ^ 2 = ∫ t : AddCircle T, ‖f t‖ ^ 2 ∂haarAddCircle :=
   (hasSum_sq_fourierCoeff _).tsum_eq
 
-lemma AddCircle.measurePreserving_equivIoc {a : ℝ} :
-    MeasurePreserving (equivIoc T a) volume (Measure.comap Subtype.val volume) := by
-  have h := (measurableEquivIoc T a).measurable
-  refine ⟨h, ?_⟩
-  ext s hs
-  rw [comap_apply _ Subtype.val_injective (fun _ ↦ measurableSet_Ioc.subtype_image) _ hs,
-    map_apply (by measurability) hs, add_projection_respects_measure T a (by exact h hs)]
-  congr!
-  ext x
-  simp only [mem_inter_iff, mem_preimage, mem_image, Subtype.exists, exists_and_right,
-    exists_eq_right]
-  rw [and_comm, ← exists_prop]
-  congr! with hx
-  rw [equivIoc_coe_eq hx]
-
 namespace MeasureTheory
-
-lemma MemLp.memLp_liftIoc {a : ℝ} {f : ℝ → ℂ} {p : ℝ≥0∞}
-    (hLp : MemLp f p (volume.restrict (Ioc a (a + T)))) :
-      MemLp (liftIoc T a f) p := by
-  simp only [liftIoc, Set.restrict_def, Function.comp_def]
-  apply hLp.comp_measurePreserving
-  refine .comp (measurePreserving_subtype_coe measurableSet_Ioc) ?_
-  exact measurePreserving_equivIoc
 
 lemma memLp_haarAddCircle_iff {f : AddCircle T → ℂ} {p : ℝ≥0∞} :
     MemLp f p haarAddCircle ↔ MemLp f p := by

--- a/Mathlib/MeasureTheory/Integral/IntervalIntegral/Periodic.lean
+++ b/Mathlib/MeasureTheory/Integral/IntervalIntegral/Periodic.lean
@@ -187,6 +187,14 @@ protected theorem intervalIntegral_preimage (t : ℝ) (f : AddCircle T → E) :
   rw [integral_of_le, AddCircle.integral_preimage T t f]
   linarith [hT.out]
 
+lemma integral_liftIoc_eq_intervalIntegral {a : ℝ} {f : ℝ → E} :
+    ∫ t, liftIoc T a f t = ∫ x in a..a + T, f x := by
+  rw [← AddCircle.intervalIntegral_preimage T a]
+  apply intervalIntegral.integral_congr_ae
+  refine .of_forall fun x hx ↦ ?_
+  rw [uIoc_of_le (by linarith [hT.out])] at hx
+  rw [liftIoc_coe_apply hx]
+
 end AddCircle
 
 namespace UnitAddCircle

--- a/Mathlib/MeasureTheory/Integral/IntervalIntegral/Periodic.lean
+++ b/Mathlib/MeasureTheory/Integral/IntervalIntegral/Periodic.lean
@@ -215,8 +215,8 @@ lemma integral_liftIoc_eq_intervalIntegral {t : ℝ} {f : ℝ → E} :
 
 end AddCircle
 
-/-- If a function is MemLp on the interval `(t, t + T]`, then its lift to the AddCircle is also
-MemLp with respect to the Haar measure. -/
+/-- If a function satisfies `MemLp` on the interval `(t, t + T]`, then its lift to the AddCircle
+also satisfies `MemLp` with respect to the Haar measure. -/
 lemma MeasureTheory.MemLp.memLp_liftIoc {T : ℝ} [hT : Fact (0 < T)] {t : ℝ} {f : ℝ → ℂ} {p : ℝ≥0∞}
     (hLp : MemLp f p (volume.restrict (Ioc t (t + T)))) :
       MemLp (AddCircle.liftIoc T t f) p := by

--- a/Mathlib/MeasureTheory/Integral/IntervalIntegral/Periodic.lean
+++ b/Mathlib/MeasureTheory/Integral/IntervalIntegral/Periodic.lean
@@ -142,6 +142,22 @@ noncomputable def measurableEquivIco (a : ℝ) : AddCircle T ≃ᵐ Ico a (a + T
       continuousAt_equivIco T a hx).measurable
   measurable_invFun := AddCircle.measurable_mk'.comp measurable_subtype_coe
 
+/-- The equivalence `equivIoc` is measure preserving with respect to the natural volume measures. -/
+lemma measurePreserving_equivIoc {a : ℝ} :
+    MeasurePreserving (equivIoc T a) volume (Measure.comap Subtype.val volume) := by
+  have h := (measurableEquivIoc T a).measurable
+  refine ⟨h, ?_⟩
+  ext s hs
+  rw [comap_apply _ Subtype.val_injective (fun _ ↦ measurableSet_Ioc.subtype_image) _ hs,
+    map_apply (by measurability) hs, add_projection_respects_measure T a (by exact h hs)]
+  congr!
+  ext x
+  simp only [mem_inter_iff, mem_preimage, mem_image, Subtype.exists, exists_and_right,
+    exists_eq_right]
+  rw [and_comm, ← exists_prop]
+  congr! with hx
+  rw [equivIoc_coe_eq hx]
+
 attribute [local instance] Subtype.measureSpace in
 /-- The lower integral of a function over `AddCircle T` is equal to the lower integral over an
 interval (t, t + T] in `ℝ` of its lift to `ℝ`. -/
@@ -187,15 +203,27 @@ protected theorem intervalIntegral_preimage (t : ℝ) (f : AddCircle T → E) :
   rw [integral_of_le, AddCircle.integral_preimage T t f]
   linarith [hT.out]
 
-lemma integral_liftIoc_eq_intervalIntegral {a : ℝ} {f : ℝ → E} :
-    ∫ t, liftIoc T a f t = ∫ x in a..a + T, f x := by
-  rw [← AddCircle.intervalIntegral_preimage T a]
+/-- The integral of a function lifted to AddCircle from an interval `(t, t + T]` to `AddCircle T`
+is equal the the intervalIntegral over the interval. -/
+lemma integral_liftIoc_eq_intervalIntegral {t : ℝ} {f : ℝ → E} :
+    ∫ a, liftIoc T t f a = ∫ a in t..t + T, f a := by
+  rw [← AddCircle.intervalIntegral_preimage T t]
   apply intervalIntegral.integral_congr_ae
   refine .of_forall fun x hx ↦ ?_
   rw [uIoc_of_le (by linarith [hT.out])] at hx
   rw [liftIoc_coe_apply hx]
 
 end AddCircle
+
+/-- If a function is MemLp on the interval `(t, t + T]`, then its lift to the AddCircle is also
+MemLp with respect to the Haar measure. -/
+lemma MeasureTheory.MemLp.memLp_liftIoc {T : ℝ} [hT : Fact (0 < T)] {t : ℝ} {f : ℝ → ℂ} {p : ℝ≥0∞}
+    (hLp : MemLp f p (volume.restrict (Ioc t (t + T)))) :
+      MemLp (AddCircle.liftIoc T t f) p := by
+  simp only [AddCircle.liftIoc, Set.restrict_def, Function.comp_def]
+  apply hLp.comp_measurePreserving
+  refine .comp (measurePreserving_subtype_coe measurableSet_Ioc) ?_
+  exact AddCircle.measurePreserving_equivIoc T
 
 namespace UnitAddCircle
 

--- a/Mathlib/Topology/Instances/AddCircle/Defs.lean
+++ b/Mathlib/Topology/Instances/AddCircle/Defs.lean
@@ -192,6 +192,14 @@ def liftIoc (f : 𝕜 → B) : AddCircle p → B :=
 
 variable {p a}
 
+theorem equivIco_coe_eq {x : 𝕜} (hx : x ∈ Ico a (a + p)) : (equivIco p a) x = ⟨x, hx⟩ := by
+  rw [Equiv.apply_eq_iff_eq_symm_apply]
+  rfl
+
+theorem equivIoc_coe_eq {x : 𝕜} (hx : x ∈ Ioc a (a + p)) : (equivIoc p a) x = ⟨x, hx⟩ := by
+  rw [Equiv.apply_eq_iff_eq_symm_apply]
+  rfl
+
 theorem coe_eq_coe_iff_of_mem_Ico {x y : 𝕜} (hx : x ∈ Ico a (a + p)) (hy : y ∈ Ico a (a + p)) :
     (x : AddCircle p) = y ↔ x = y := by
   refine ⟨fun h => ?_, by tauto⟩
@@ -202,18 +210,12 @@ theorem coe_eq_coe_iff_of_mem_Ico {x y : 𝕜} (hx : x ∈ Ico a (a + p)) (hy : 
 
 theorem liftIco_coe_apply {f : 𝕜 → B} {x : 𝕜} (hx : x ∈ Ico a (a + p)) :
     liftIco p a f ↑x = f x := by
-  have : (equivIco p a) x = ⟨x, hx⟩ := by
-    rw [Equiv.apply_eq_iff_eq_symm_apply]
-    rfl
-  rw [liftIco, comp_apply, this]
+  rw [liftIco, comp_apply, equivIco_coe_eq hx]
   rfl
 
 theorem liftIoc_coe_apply {f : 𝕜 → B} {x : 𝕜} (hx : x ∈ Ioc a (a + p)) :
     liftIoc p a f ↑x = f x := by
-  have : (equivIoc p a) x = ⟨x, hx⟩ := by
-    rw [Equiv.apply_eq_iff_eq_symm_apply]
-    rfl
-  rw [liftIoc, comp_apply, this]
+  rw [liftIoc, comp_apply, equivIoc_coe_eq hx]
   rfl
 
 lemma eq_coe_Ico (a : AddCircle p) : ∃ b, b ∈ Ico 0 p ∧ ↑b = a := by

--- a/Mathlib/Topology/Instances/AddCircle/Defs.lean
+++ b/Mathlib/Topology/Instances/AddCircle/Defs.lean
@@ -315,6 +315,20 @@ entire space. -/
 theorem coe_image_Icc_eq : ((↑) : 𝕜 → AddCircle p) '' Icc a (a + p) = univ :=
   eq_top_mono (image_mono Ico_subset_Icc_self) <| coe_image_Ico_eq _ _
 
+/-- If functions on AddCircle agree on the image of the interval `[a, a + p)` then they are equal -/
+lemma Ico_ext {α : Type*} {f g : AddCircle p → α} (a : 𝕜)
+    (h : ∀ x ∈ Ico a (a + p), f x = g x) : f = g := by
+  rw [← Set.eqOn_univ, ← coe_image_Ico_eq p a]
+  rintro - ⟨x, hx, rfl⟩
+  exact h x hx
+
+/-- If functions on AddCircle agree on the image of the interval `(a, a + p]` then they are equal -/
+lemma Ioc_ext {α : Type*} {f g : AddCircle p → α} (a : 𝕜)
+    (h : ∀ x ∈ Ioc a (a + p), f x = g x) : f = g := by
+  rw [← Set.eqOn_univ, ← coe_image_Ioc_eq p a]
+  rintro - ⟨x, hx, rfl⟩
+  exact h x hx
+
 end LinearOrderedAddCommGroup
 
 section LinearOrderedField

--- a/Mathlib/Topology/Instances/AddCircle/Defs.lean
+++ b/Mathlib/Topology/Instances/AddCircle/Defs.lean
@@ -210,13 +210,17 @@ theorem coe_eq_coe_iff_of_mem_Ico {x y : 𝕜} (hx : x ∈ Ico a (a + p)) (hy : 
 
 theorem liftIco_coe_apply {f : 𝕜 → B} {x : 𝕜} (hx : x ∈ Ico a (a + p)) :
     liftIco p a f ↑x = f x := by
-  rw [liftIco, comp_apply, equivIco_coe_eq hx]
-  rfl
+  simp [liftIco, equivIco_coe_eq hx]
 
 theorem liftIoc_coe_apply {f : 𝕜 → B} {x : 𝕜} (hx : x ∈ Ioc a (a + p)) :
     liftIoc p a f ↑x = f x := by
-  rw [liftIoc, comp_apply, equivIoc_coe_eq hx]
-  rfl
+  simp [liftIoc, equivIoc_coe_eq hx]
+
+lemma liftIco_comp_apply {α β : Type*} {f : 𝕜 → α} {g : α → β} {a : 𝕜} {x : AddCircle p} :
+    liftIco p a (g ∘ f) x = g (liftIco p a f x) := rfl
+
+lemma liftIoc_comp_apply {α β : Type*} {f : 𝕜 → α} {g : α → β} {a : 𝕜} {x : AddCircle p} :
+    liftIoc p a (g ∘ f) x = g (liftIoc p a f x) := rfl
 
 lemma eq_coe_Ico (a : AddCircle p) : ∃ b, b ∈ Ico 0 p ∧ ↑b = a := by
   let b := QuotientAddGroup.equivIcoMod hp.out 0 a


### PR DESCRIPTION
`tsum_sq_fourierCoeffOn` proved via the existing `tsum_sq_fourierCoeff`. The lemmas I needed, particularly `memLp_liftIoc_of_memLp` which shows that the lift of an Lp function on the interval is Lp on AddCircle, turned out to be much messier than I anticipated. Hopefully someone can suggest improvements.

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include at least one commit authored by each
co-author among the commits in the pull request. If necessary, you may 
create empty commits to indicate co-authorship, using commands like so:

git commit --author="Author Name <author@email.com>" --allow-empty -m "add Author Name as coauthor"

When merging, all the commits will be squashed into a single commit listing all co-authors.

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
