### PR TITLE
[Merged by Bors] - chore: new file for constructions of uniform groups

### DIFF
--- a/Mathlib.lean
+++ b/Mathlib.lean
@@ -6354,6 +6354,7 @@ import Mathlib.Topology.Algebra.InfiniteSum.UniformOn
 import Mathlib.Topology.Algebra.IntermediateField
 import Mathlib.Topology.Algebra.IsOpenUnits
 import Mathlib.Topology.Algebra.IsUniformGroup.Basic
+import Mathlib.Topology.Algebra.IsUniformGroup.Constructions
 import Mathlib.Topology.Algebra.IsUniformGroup.Defs
 import Mathlib.Topology.Algebra.IsUniformGroup.Order
 import Mathlib.Topology.Algebra.LinearTopology

--- a/Mathlib/Analysis/CStarAlgebra/Module/Synonym.lean
+++ b/Mathlib/Analysis/CStarAlgebra/Module/Synonym.lean
@@ -7,7 +7,7 @@ import Mathlib.RingTheory.Finiteness.Defs
 import Mathlib.Topology.Bornology.Constructions
 import Mathlib.Topology.UniformSpace.Equiv
 import Mathlib.Topology.Algebra.Module.Equiv
-import Mathlib.Topology.Algebra.IsUniformGroup.Basic
+import Mathlib.Topology.Algebra.IsUniformGroup.Constructions
 
 /-! # Type synonym for types with a `CStarModule` structure
 

--- a/Mathlib/RingTheory/MvPowerSeries/PiTopology.lean
+++ b/Mathlib/RingTheory/MvPowerSeries/PiTopology.lean
@@ -9,10 +9,10 @@ import Mathlib.RingTheory.MvPowerSeries.Trunc
 import Mathlib.RingTheory.Nilpotent.Defs
 import Mathlib.Topology.Algebra.InfiniteSum.Constructions
 import Mathlib.Topology.Algebra.Ring.Basic
-import Mathlib.Topology.Algebra.IsUniformGroup.Basic
 import Mathlib.Topology.Instances.ENat
 import Mathlib.Topology.UniformSpace.Pi
 import Mathlib.Topology.Algebra.TopologicallyNilpotent
+import Mathlib.Topology.Algebra.IsUniformGroup.Constructions
 
 /-! # Product topology on multivariate power series
 

--- a/Mathlib/Topology/Algebra/IsUniformGroup/Basic.lean
+++ b/Mathlib/Topology/Algebra/IsUniformGroup/Basic.lean
@@ -4,11 +4,10 @@ Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Patrick Massot, Johannes Hölzl
 -/
 import Mathlib.Topology.UniformSpace.UniformConvergence
-import Mathlib.Topology.UniformSpace.UniformEmbedding
 import Mathlib.Topology.UniformSpace.CompleteSeparated
 import Mathlib.Topology.UniformSpace.Compact
 import Mathlib.Topology.UniformSpace.HeineCantor
-import Mathlib.Topology.Algebra.IsUniformGroup.Defs
+import Mathlib.Topology.Algebra.IsUniformGroup.Constructions
 import Mathlib.Topology.Algebra.Group.Quotient
 import Mathlib.Topology.DiscreteSubset
 import Mathlib.Tactic.Abel
@@ -36,13 +35,6 @@ open Filter Set
 variable {α : Type*} {β : Type*}
 
 variable [UniformSpace α] [Group α] [IsUniformGroup α]
-
-@[to_additive]
-instance Pi.instIsUniformGroup {ι : Type*} {G : ι → Type*} [∀ i, UniformSpace (G i)]
-    [∀ i, Group (G i)] [∀ i, IsUniformGroup (G i)] : IsUniformGroup (∀ i, G i) where
-  uniformContinuous_div := uniformContinuous_pi.mpr fun i ↦
-    (uniformContinuous_proj G i).comp uniformContinuous_fst |>.div <|
-      (uniformContinuous_proj G i).comp uniformContinuous_snd
 
 @[to_additive]
 theorem isUniformEmbedding_translate_mul (a : α) : IsUniformEmbedding fun x : α => x * a :=
@@ -81,31 +73,6 @@ lemma cauchy_map_iff_tendsto_swapped (𝓕 : Filter ι) (f : ι → G) :
 end IsUniformGroup
 
 end Cauchy
-
-section LatticeOps
-
-variable [Group β]
-
-@[to_additive]
-lemma IsUniformInducing.isUniformGroup {γ : Type*} [Group γ] [UniformSpace γ] [IsUniformGroup γ]
-    [UniformSpace β] {F : Type*} [FunLike F β γ] [MonoidHomClass F β γ]
-    (f : F) (hf : IsUniformInducing f) :
-    IsUniformGroup β where
-  uniformContinuous_div := by
-    simp_rw [hf.uniformContinuous_iff, Function.comp_def, map_div]
-    exact uniformContinuous_div.comp (hf.uniformContinuous.prodMap hf.uniformContinuous)
-
-@[deprecated (since := "2025-03-30")]
-alias IsUniformInducing.uniformAddGroup := IsUniformInducing.isUniformAddGroup
-@[to_additive existing, deprecated (since := "2025-03-30")]
-alias IsUniformInducing.uniformGroup := IsUniformInducing.isUniformGroup
-
-@[to_additive]
-protected theorem IsUniformGroup.comap {γ : Type*} [Group γ] {u : UniformSpace γ} [IsUniformGroup γ]
-    {F : Type*} [FunLike F β γ] [MonoidHomClass F β γ] (f : F) : @IsUniformGroup β (u.comap f) _ :=
-  letI : UniformSpace β := u.comap f; IsUniformInducing.isUniformGroup f ⟨rfl⟩
-
-end LatticeOps
 
 namespace Subgroup
 

--- a/Mathlib/Topology/Algebra/IsUniformGroup/Constructions.lean
+++ b/Mathlib/Topology/Algebra/IsUniformGroup/Constructions.lean
@@ -1,0 +1,105 @@
+/-
+Copyright (c) 2025 Anatole Dedecker. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Anatole Dedecker, Patrick Massot, Johannes Hölzl
+-/
+import Mathlib.Topology.Algebra.IsUniformGroup.Defs
+import Mathlib.Topology.UniformSpace.Pi
+import Mathlib.Topology.UniformSpace.UniformEmbedding
+
+/-!
+# Constructions of new uniform groups from old ones
+-/
+
+variable {G H hom : Type*} [Group G] [Group H]
+
+section LatticeOps
+
+@[to_additive]
+theorem isUniformGroup_sInf {us : Set (UniformSpace G)} (h : ∀ u ∈ us, @IsUniformGroup G u _) :
+    @IsUniformGroup G (sInf us) _ :=
+  @IsUniformGroup.mk G (_) _ <|
+    uniformContinuous_sInf_rng.mpr fun u hu =>
+      uniformContinuous_sInf_dom₂ hu hu (@IsUniformGroup.uniformContinuous_div G u _ (h u hu))
+
+@[deprecated (since := "2025-03-31")] alias uniformAddGroup_sInf := isUniformAddGroup_sInf
+@[to_additive existing, deprecated
+  (since := "2025-03-31")] alias uniformGroup_sInf := isUniformGroup_sInf
+
+@[to_additive]
+theorem isUniformGroup_iInf {ι : Sort*} {us' : ι → UniformSpace G}
+    (h' : ∀ i, @IsUniformGroup G (us' i) _) : @IsUniformGroup G (⨅ i, us' i) _ := by
+  rw [← sInf_range]
+  exact isUniformGroup_sInf (Set.forall_mem_range.mpr h')
+
+@[deprecated (since := "2025-03-31")] alias uniformAddGroup_iInf := isUniformAddGroup_iInf
+@[to_additive existing, deprecated
+  (since := "2025-03-31")] alias uniformGroup_iInf := isUniformGroup_iInf
+
+@[to_additive]
+theorem isUniformGroup_inf {u₁ u₂ : UniformSpace G} (h₁ : @IsUniformGroup G u₁ _)
+    (h₂ : @IsUniformGroup G u₂ _) : @IsUniformGroup G (u₁ ⊓ u₂) _ := by
+  rw [inf_eq_iInf]
+  refine isUniformGroup_iInf fun b => ?_
+  cases b <;> assumption
+
+@[deprecated (since := "2025-03-31")] alias uniformAddGroup_inf := isUniformAddGroup_inf
+@[to_additive existing, deprecated
+  (since := "2025-03-31")] alias uniformGroup_inf := isUniformGroup_inf
+
+end LatticeOps
+
+section Comap
+
+@[to_additive]
+lemma IsUniformInducing.isUniformGroup [UniformSpace G] [UniformSpace H]
+    [IsUniformGroup H] [FunLike hom G H] [MonoidHomClass hom G H]
+    (f : hom) (hf : IsUniformInducing f) :
+    IsUniformGroup G where
+  uniformContinuous_div := by
+    simp_rw [hf.uniformContinuous_iff, Function.comp_def, map_div]
+    exact uniformContinuous_div.comp (hf.uniformContinuous.prodMap hf.uniformContinuous)
+
+@[deprecated (since := "2025-03-30")]
+alias IsUniformInducing.uniformAddGroup := IsUniformInducing.isUniformAddGroup
+@[to_additive existing, deprecated (since := "2025-03-30")]
+alias IsUniformInducing.uniformGroup := IsUniformInducing.isUniformGroup
+
+@[to_additive]
+protected theorem IsUniformGroup.comap {u : UniformSpace H} [IsUniformGroup H]
+    [FunLike hom G H] [MonoidHomClass hom G H] (f : hom) :
+    @IsUniformGroup G (u.comap f) _ :=
+  letI : UniformSpace G := u.comap f; IsUniformInducing.isUniformGroup f ⟨rfl⟩
+
+end Comap
+
+section PiProd
+
+@[to_additive]
+instance Prod.instIsUniformGroup [UniformSpace G] [hG : IsUniformGroup G]
+    [UniformSpace H] [hH : IsUniformGroup H] :
+    IsUniformGroup (G × H) := by
+  rw [instUniformSpaceProd]
+  exact isUniformGroup_inf (.comap <| MonoidHom.fst G H) (.comap <| MonoidHom.snd G H)
+
+@[deprecated (since := "2025-03-31")] alias Prod.instUniformAddGroup :=
+  Prod.instIsUniformAddGroup
+@[to_additive existing, deprecated
+  (since := "2025-03-31")] alias Prod.instUniformGroup := Prod.instIsUniformGroup
+
+@[to_additive]
+instance Pi.instIsUniformGroup {ι : Type*} {G : ι → Type*} [∀ i, UniformSpace (G i)]
+    [∀ i, Group (G i)] [∀ i, IsUniformGroup (G i)] : IsUniformGroup (∀ i, G i) := by
+  rw [Pi.uniformSpace_eq]
+  exact isUniformGroup_iInf fun i ↦ .comap (Pi.evalMonoidHom G i)
+
+end PiProd
+
+section DiscreteUniformity
+
+/-- The discrete uniformity makes a group a `IsUniformGroup. -/
+@[to_additive /-- The discrete uniformity makes an additive group a `IsUniformAddGroup`. -/]
+instance [UniformSpace G] [DiscreteUniformity G] : IsUniformGroup G where
+  uniformContinuous_div := DiscreteUniformity.uniformContinuous (G × G) fun p ↦ p.1 / p.2
+
+end DiscreteUniformity

--- a/Mathlib/Topology/Algebra/IsUniformGroup/Defs.lean
+++ b/Mathlib/Topology/Algebra/IsUniformGroup/Defs.lean
@@ -3,7 +3,7 @@ Copyright (c) 2018 Patrick Massot. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Patrick Massot, Johannes Hölzl
 -/
-import Mathlib.Topology.UniformSpace.DiscreteUniformity
+import Mathlib.Topology.UniformSpace.Basic
 import Mathlib.Topology.Algebra.Group.Basic
 
 /-!
@@ -165,19 +165,6 @@ instance (priority := 10) IsUniformGroup.to_topologicalGroup : IsTopologicalGrou
   UniformGroup.to_topologicalGroup := IsUniformGroup.to_topologicalGroup
 
 @[to_additive]
-instance Prod.instIsUniformGroup [UniformSpace β] [Group β] [IsUniformGroup β] :
-    IsUniformGroup (α × β) :=
-  ⟨((uniformContinuous_fst.comp uniformContinuous_fst).div
-          (uniformContinuous_fst.comp uniformContinuous_snd)).prodMk
-      ((uniformContinuous_snd.comp uniformContinuous_fst).div
-        (uniformContinuous_snd.comp uniformContinuous_snd))⟩
-
-@[deprecated (since := "2025-03-31")] alias Prod.instUniformAddGroup :=
-  Prod.instIsUniformAddGroup
-@[to_additive existing, deprecated
-  (since := "2025-03-31")] alias Prod.instUniformGroup := Prod.instIsUniformGroup
-
-@[to_additive]
 theorem uniformity_translate_mul (a : α) : ((𝓤 α).map fun x : α × α => (x.1 * a, x.2 * a)) = 𝓤 α :=
   le_antisymm (uniformContinuous_id.mul uniformContinuous_const)
     (calc
@@ -188,11 +175,6 @@ theorem uniformity_translate_mul (a : α) : ((𝓤 α).map fun x : α × α => (
         Filter.map_mono (uniformContinuous_id.mul uniformContinuous_const)
       )
 
-/-- The discrete uniformity makes a group a `IsUniformGroup. -/
-@[to_additive /-- The discrete uniformity makes an additive group a `IsUniformAddGroup`. -/]
-instance [UniformSpace β] [Group β] [DiscreteUniformity β] : IsUniformGroup β where
-  uniformContinuous_div := DiscreteUniformity.uniformContinuous (β × β) fun p ↦ p.1 / p.2
-
 namespace MulOpposite
 
 @[to_additive]
@@ -202,44 +184,6 @@ instance : IsUniformGroup αᵐᵒᵖ :=
         uniformContinuous_unop.comp uniformContinuous_fst)⟩
 
 end MulOpposite
-
-section LatticeOps
-
-variable [Group β]
-
-@[to_additive]
-theorem isUniformGroup_sInf {us : Set (UniformSpace β)} (h : ∀ u ∈ us, @IsUniformGroup β u _) :
-    @IsUniformGroup β (sInf us) _ :=
-  @IsUniformGroup.mk β (_) _ <|
-    uniformContinuous_sInf_rng.mpr fun u hu =>
-      uniformContinuous_sInf_dom₂ hu hu (@IsUniformGroup.uniformContinuous_div β u _ (h u hu))
-
-@[deprecated (since := "2025-03-31")] alias uniformAddGroup_sInf := isUniformAddGroup_sInf
-@[to_additive existing, deprecated
-  (since := "2025-03-31")] alias uniformGroup_sInf := isUniformGroup_sInf
-
-@[to_additive]
-theorem isUniformGroup_iInf {ι : Sort*} {us' : ι → UniformSpace β}
-    (h' : ∀ i, @IsUniformGroup β (us' i) _) : @IsUniformGroup β (⨅ i, us' i) _ := by
-  rw [← sInf_range]
-  exact isUniformGroup_sInf (Set.forall_mem_range.mpr h')
-
-@[deprecated (since := "2025-03-31")] alias uniformAddGroup_iInf := isUniformAddGroup_iInf
-@[to_additive existing, deprecated
-  (since := "2025-03-31")] alias uniformGroup_iInf := isUniformGroup_iInf
-
-@[to_additive]
-theorem isUniformGroup_inf {u₁ u₂ : UniformSpace β} (h₁ : @IsUniformGroup β u₁ _)
-    (h₂ : @IsUniformGroup β u₂ _) : @IsUniformGroup β (u₁ ⊓ u₂) _ := by
-  rw [inf_eq_iInf]
-  refine isUniformGroup_iInf fun b => ?_
-  cases b <;> assumption
-
-@[deprecated (since := "2025-03-31")] alias uniformAddGroup_inf := isUniformAddGroup_inf
-@[to_additive existing, deprecated
-  (since := "2025-03-31")] alias uniformGroup_inf := isUniformGroup_inf
-
-end LatticeOps
 
 section
 

--- a/Mathlib/Topology/Instances/TrivSqZeroExt.lean
+++ b/Mathlib/Topology/Instances/TrivSqZeroExt.lean
@@ -5,6 +5,7 @@ Authors: Eric Wieser
 -/
 import Mathlib.Algebra.TrivSqZeroExt
 import Mathlib.Topology.Algebra.InfiniteSum.Basic
+import Mathlib.Topology.Algebra.IsUniformGroup.Constructions
 import Mathlib.Topology.Algebra.Module.LinearMapPiProd
 
 /-!

--- a/Mathlib/Topology/UniformSpace/Matrix.lean
+++ b/Mathlib/Topology/UniformSpace/Matrix.lean
@@ -4,8 +4,8 @@ Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Eric Wieser, Heather Macbeth
 -/
 import Mathlib.LinearAlgebra.Matrix.Defs
-import Mathlib.Topology.Algebra.IsUniformGroup.Basic
 import Mathlib.Topology.UniformSpace.Pi
+import Mathlib.Topology.Algebra.IsUniformGroup.Constructions
 
 /-!
 # Uniform space structure on matrices


### PR DESCRIPTION
The split between `Defs` and `Basic` was a bit messy (e.g the `Prod` instance was in `Defs` but the `Pi` instance was in `Basic`), and I'm going to make these files longer when introducing left and right uniform groups, so I figured the best solution was to move everything in an intermediate `Constructions` file.

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include at least one commit authored by each
co-author among the commits in the pull request. If necessary, you may 
create empty commits to indicate co-authorship, using commands like so:

git commit --author="Author Name <author@email.com>" --allow-empty -m "add Author Name as coauthor"

When merging, all the commits will be squashed into a single commit listing all co-authors.

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
