### PR TITLE
[Merged by Bors] - refactor(Algebra/Polynomial/Splits): generalize `Polynomial.splits_map_iff` from `Field` to `CommRing`

### DIFF
--- a/Mathlib/Algebra/Polynomial/Splits.lean
+++ b/Mathlib/Algebra/Polynomial/Splits.lean
@@ -105,7 +105,8 @@ theorem splits_of_splits_mul' {f g : K[X]} (hfg : (f * g).map i ≠ 0) (h : Spli
     Or.inr @fun g hgi hg =>
       Or.resolve_left h hfg hgi (by rw [Polynomial.map_mul]; exact hg.trans (dvd_mul_left _ _))⟩
 
-theorem splits_map_iff (j : L →+* F) {f : K[X]} : Splits j (f.map i) ↔ Splits (j.comp i) f := by
+theorem splits_map_iff {L : Type*} [CommRing L] (i : K →+* L) (j : L →+* F) {f : K[X]} :
+    Splits j (f.map i) ↔ Splits (j.comp i) f := by
   simp [Splits, Polynomial.map_map]
 
 theorem splits_one : Splits i 1 :=

--- a/Mathlib/RingTheory/Invariant/Basic.lean
+++ b/Mathlib/RingTheory/Invariant/Basic.lean
@@ -482,10 +482,8 @@ lemma Ideal.Quotient.normal [P.IsMaximal] [Q.IsMaximal] :
     (by rw [Polynomial.aeval_map_algebraMap, Polynomial.aeval_algebraMap_apply, H, map_zero])
   refine Polynomial.splits_of_splits_of_dvd (algebraMap (A ⧸ P) (B ⧸ Q)) ?_ ?_ this
   · exact (h₂.map (algebraMap A (A ⧸ P))).ne_zero
-  · rw [Polynomial.splits_map_iff, ← IsScalarTower.algebraMap_eq]
-    convert_to (p.map (algebraMap A B)).Splits (algebraMap B (B ⧸ Q))
-    · simp [Polynomial.Splits, Polynomial.map_map]
-    rw [hp, MulSemiringAction.charpoly_eq]
+  · rw [Polynomial.splits_map_iff, ← IsScalarTower.algebraMap_eq, IsScalarTower.algebraMap_eq A B,
+      ← Polynomial.splits_map_iff, hp, MulSemiringAction.charpoly_eq]
     exact Polynomial.splits_prod _ (fun _ _ ↦ Polynomial.splits_X_sub_C _)
 
 attribute [local instance] Ideal.Quotient.field in


### PR DESCRIPTION
`Polynomial.splits_map_iff` currently assumes `K →+* L →+* F` with `K` a `CommRing`, `L` a `Field`, and `F` a `Field`. But `L` can be generalized to a `CommRing`. This also allows for a golf in `RingTheory/Invariant/Basic.lean`.

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include at least one commit authored by each
co-author among the commits in the pull request. If necessary, you may 
create empty commits to indicate co-authorship, using commands like so:

git commit --author="Author Name <author@email.com>" --allow-empty -m "add Author Name as coauthor"

When merging, all the commits will be squashed into a single commit listing all co-authors.

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
