### PR TITLE
[Merged by Bors] - feat(push_neg): `push_neg` for type size classes

### DIFF
--- a/Mathlib/Algebra/Category/Grp/Adjunctions.lean
+++ b/Mathlib/Algebra/Category/Grp/Adjunctions.lean
@@ -93,7 +93,7 @@ instance : (free.{u}).PreservesMonomorphisms where
       intros
       apply (IsInitial.isInitialObj free _
         ((Types.initial_iff_empty X).2 hX).some).isZero.eq_of_tgt
-    · simp only [not_isEmpty_iff] at hX
+    · push_neg at hX
       have hf : Function.Injective f := by rwa [← mono_iff_injective]
       obtain ⟨g, hg⟩ := hf.hasLeftInverse
       have : IsSplitMono f := IsSplitMono.mk' { retraction := g }

--- a/Mathlib/Algebra/CharP/MixedCharZero.lean
+++ b/Mathlib/Algebra/CharP/MixedCharZero.lean
@@ -282,7 +282,7 @@ theorem isEmpty_algebraRat_iff_mixedCharZero [CharZero R] :
     IsEmpty (Algebra ℚ R) ↔ ∃ p > 0, MixedCharZero R p := by
   rw [← not_iff_not]
   push_neg
-  rw [not_isEmpty_iff, ← EqualCharZero.iff_not_mixedCharZero]
+  rw [← EqualCharZero.iff_not_mixedCharZero]
   apply EqualCharZero.nonempty_algebraRat_iff
 
 /-!

--- a/Mathlib/Algebra/Lie/Submodule.lean
+++ b/Mathlib/Algebra/Lie/Submodule.lean
@@ -549,9 +549,10 @@ instance [Nontrivial M] : Nontrivial (LieSubmodule R L M) :=
 theorem nontrivial_iff_ne_bot {N : LieSubmodule R L M} : Nontrivial N ↔ N ≠ ⊥ := by
   constructor <;> contrapose!
   · rintro rfl
+    by_contra! h; rcases h with
       ⟨⟨m₁, h₁ : m₁ ∈ (⊥ : LieSubmodule R L M)⟩, ⟨m₂, h₂ : m₂ ∈ (⊥ : LieSubmodule R L M)⟩, h₁₂⟩
     simp [(LieSubmodule.mem_bot _).mp h₁, (LieSubmodule.mem_bot _).mp h₂] at h₁₂
-  · rw [not_nontrivial_iff_subsingleton, LieSubmodule.eq_bot_iff]
+  · rw [LieSubmodule.eq_bot_iff]
     rintro ⟨h⟩ m hm
     simpa using h ⟨m, hm⟩ ⟨_, N.zero_mem⟩
 

--- a/Mathlib/Algebra/Lie/Weights/Linear.lean
+++ b/Mathlib/Algebra/Lie/Weights/Linear.lean
@@ -236,8 +236,7 @@ lemma exists_nontrivial_weightSpace_of_isNilpotent [Field k] [LieAlgebra k L] [M
     [IsTriangularizable k L M] [Nontrivial M] :
     ∃ χ : Module.Dual k L, Nontrivial (weightSpace M χ) := by
   obtain ⟨χ⟩ : Nonempty (Weight k L M) := by
-    by_contra contra
-    rw [not_nonempty_iff] at contra
+    by_contra! contra
     simpa only [iSup_of_empty, bot_ne_top] using LieModule.iSup_genWeightSpace_eq_top' k L M
   obtain ⟨m, hm₀, hm⟩ := exists_forall_lie_eq_smul k L M χ
   simp only [LieSubmodule.nontrivial_iff_ne_bot, LieSubmodule.eq_bot_iff, ne_eq, not_forall]

--- a/Mathlib/AlgebraicGeometry/AffineTransitionLimit.lean
+++ b/Mathlib/AlgebraicGeometry/AffineTransitionLimit.lean
@@ -50,7 +50,6 @@ lemma Scheme.nonempty_of_isLimit [IsCofilteredOrEmpty I]
     have (i' : _) : IsAffine (𝒰.X i') := inferInstanceAs (IsAffine (Spec _))
     obtain ⟨j, H⟩ :
         ∃ j : 𝒰.I₀, ∀ {i'} (f : i' ⟶ i), Nonempty ((𝒰.pullbackCover (D.map f)).X j) := by
-      simp_rw [← not_isEmpty_iff]
       by_contra! H
       choose i' f hf using H
       let g (j) := IsCofiltered.infTo (insert i (Finset.univ.image i'))

--- a/Mathlib/AlgebraicGeometry/PullbackCarrier.lean
+++ b/Mathlib/AlgebraicGeometry/PullbackCarrier.lean
@@ -310,7 +310,7 @@ lemma forget_comparison_surjective {X Y S : Scheme.{u}} (f : X ⟶ S) (g : Y ⟶
 lemma _root_.AlgebraicGeometry.Scheme.isEmpty_pullback_iff {f : X ⟶ S} {g : Y ⟶ S} :
     IsEmpty ↑(Limits.pullback f g) ↔ Disjoint (Set.range f.base) (Set.range g.base) := by
   refine ⟨?_, Scheme.isEmpty_pullback f g⟩
-  rw [← not_nonempty_iff, Set.disjoint_iff_forall_ne]
+  rw [Set.disjoint_iff_forall_ne]
   contrapose!
   rintro ⟨_, ⟨x, rfl⟩, _, ⟨y, rfl⟩, e⟩
   obtain ⟨z, -⟩ := exists_preimage_pullback x y e

--- a/Mathlib/Analysis/CStarAlgebra/ContinuousFunctionalCalculus/Order.lean
+++ b/Mathlib/Analysis/CStarAlgebra/ContinuousFunctionalCalculus/Order.lean
@@ -155,7 +155,7 @@ lemma IsSelfAdjoint.le_algebraMap_norm_self {a : A} (ha : IsSelfAdjoint a := by 
   · refine le_algebraMap_of_spectrum_le fun r hr => ?_
     calc r ≤ ‖r‖ := Real.le_norm_self r
       _ ≤ ‖a‖ := spectrum.norm_le_norm_of_mem hr
-  · rw [not_nontrivial_iff_subsingleton] at nontriv
+  · push_neg at nontriv
     simp
 
 lemma IsSelfAdjoint.neg_algebraMap_norm_le_self {a : A} (ha : IsSelfAdjoint a := by cfc_tac) :

--- a/Mathlib/Analysis/Calculus/FDeriv/Norm.lean
+++ b/Mathlib/Analysis/Calculus/FDeriv/Norm.lean
@@ -81,7 +81,7 @@ theorem ContDiffAt.contDiffAt_norm_of_smul (h : ContDiffAt ℝ n (‖·‖) (t �
     · rw [zero_smul] at h
       exact (mt (ContDiffAt.differentiableAt · (mod_cast hn)))
         (not_differentiableAt_norm_zero E) h |>.elim
-    · rw [not_nontrivial_iff_subsingleton] at hE
+    · push_neg at hE
       rw [eq_const_of_subsingleton (‖·‖) 0]
       exact contDiffAt_const
   · exact contDiffAt_norm_smul_iff ht |>.2 h
@@ -148,7 +148,7 @@ theorem DifferentiableAt.differentiableAt_norm_of_smul (h : DifferentiableAt ℝ
   · by_cases hE : Nontrivial E
     · rw [zero_smul] at h
       exact not_differentiableAt_norm_zero E h |>.elim
-    · rw [not_nontrivial_iff_subsingleton] at hE
+    · push_neg at hE
       exact (hasFDerivAt_of_subsingleton _ _).differentiableAt
   · exact differentiableAt_norm_smul ht |>.2 h
 
@@ -178,7 +178,7 @@ theorem fderiv_norm_smul :
     · rw [fderiv_zero_of_not_differentiableAt hd, fderiv_zero_of_not_differentiableAt]
       · simp
       · exact mt DifferentiableAt.differentiableAt_norm_of_smul hd
-  · rw [not_nontrivial_iff_subsingleton] at hE
+  · push_neg at hE
     simp_rw [(hasFDerivAt_of_subsingleton _ _).fderiv, smul_zero]
 
 theorem fderiv_norm_smul_pos (ht : 0 < t) :

--- a/Mathlib/Combinatorics/SimpleGraph/Clique.lean
+++ b/Mathlib/Combinatorics/SimpleGraph/Clique.lean
@@ -804,10 +804,10 @@ lemma IsIndepSet.nonempty_mem_compl_mem_edge
     [Fintype α] [DecidableEq α] {s : Finset α} (indA : G.IsIndepSet s) {e} (he : e ∈ G.edgeSet) :
     { b ∈ sᶜ | b ∈ e }.Nonempty := by
   obtain ⟨v, w⟩ := e
-  by_contra! c
+  by_contra c
   rw [IsIndepSet] at indA
   rw [mem_edgeSet] at he
-  rw [filter_eq_empty_iff] at c
+  rw [not_nonempty_iff_eq_empty, filter_eq_empty_iff] at c
   simp_rw [mem_compl, Sym2.mem_iff, not_or] at c
   by_cases vins : v ∈ s
   · have wins : w ∈ s := by by_contra wnins; exact (c wnins).right rfl

--- a/Mathlib/Combinatorics/SimpleGraph/Clique.lean
+++ b/Mathlib/Combinatorics/SimpleGraph/Clique.lean
@@ -414,7 +414,7 @@ theorem CliqueFree.comap {H : SimpleGraph β} (f : H ↪g G) : G.CliqueFree n �
 theorem cliqueFree_of_card_lt [Fintype α] (hc : card α < n) : G.CliqueFree n := by
   by_contra h
   refine Nat.lt_le_asymm hc ?_
-  rw [cliqueFree_iff, not_isEmpty_iff] at h
+  rw [not_cliqueFree_iff] at h
   simpa only [Fintype.card_fin] using Fintype.card_le_of_embedding h.some.toEmbedding
 
 /-- A complete `r`-partite graph has no `n`-cliques for `r < n`. -/
@@ -804,10 +804,10 @@ lemma IsIndepSet.nonempty_mem_compl_mem_edge
     [Fintype α] [DecidableEq α] {s : Finset α} (indA : G.IsIndepSet s) {e} (he : e ∈ G.edgeSet) :
     { b ∈ sᶜ | b ∈ e }.Nonempty := by
   obtain ⟨v, w⟩ := e
-  by_contra c
+  by_contra! c
   rw [IsIndepSet] at indA
   rw [mem_edgeSet] at he
-  rw [not_nonempty_iff_eq_empty, filter_eq_empty_iff] at c
+  rw [filter_eq_empty_iff] at c
   simp_rw [mem_compl, Sym2.mem_iff, not_or] at c
   by_cases vins : v ∈ s
   · have wins : w ∈ s := by by_contra wnins; exact (c wnins).right rfl

--- a/Mathlib/Combinatorics/SimpleGraph/Connectivity/Connected.lean
+++ b/Mathlib/Combinatorics/SimpleGraph/Connectivity/Connected.lean
@@ -163,8 +163,8 @@ protected lemma Preconnected.mono {G G' : SimpleGraph V} (h : G ≤ G') (hG : G.
 
 lemma preconnected_bot_iff_subsingleton : (⊥ : SimpleGraph V).Preconnected ↔ Subsingleton V := by
   refine ⟨fun h ↦ ?_, fun h ↦ by simpa [subsingleton_iff, ← reachable_bot] using h⟩
-  contrapose h
-  simp [nontrivial_iff.mp <| not_subsingleton_iff_nontrivial.mp h, Preconnected, reachable_bot]
+  contrapose! h
+  simp [nontrivial_iff.mp h, Preconnected, reachable_bot]
 
 lemma preconnected_bot [Subsingleton V] : (⊥ : SimpleGraph V).Preconnected :=
   preconnected_bot_iff_subsingleton.mpr ‹_›
@@ -313,7 +313,6 @@ instance inhabited [Inhabited V] : Inhabited G.ConnectedComponent :=
 
 instance isEmpty [IsEmpty V] : IsEmpty (ConnectedComponent G) := by
   by_contra! hc
-  rw [@not_isEmpty_iff] at hc
   obtain ⟨v, _⟩ := (Classical.inhabited_of_nonempty hc).default.exists_rep
   exact IsEmpty.false v
 

--- a/Mathlib/Combinatorics/SimpleGraph/Diam.lean
+++ b/Mathlib/Combinatorics/SimpleGraph/Diam.lean
@@ -67,7 +67,6 @@ lemma eccent_ne_zero [Nontrivial α] (u : α) : G.eccent u ≠ 0 := by
 lemma eccent_eq_zero_iff (u : α) : G.eccent u = 0 ↔ Subsingleton α := by
   refine ⟨fun h ↦ ?_, fun _ ↦ eccent_eq_zero_of_subsingleton u⟩
   contrapose! h
-  rw [not_subsingleton_iff_nontrivial] at h
   exact eccent_ne_zero u
 
 lemma eccent_pos_iff (u : α) : 0 < G.eccent u ↔ Nontrivial α := by
@@ -132,7 +131,6 @@ lemma ediam_eq_zero_of_subsingleton [Subsingleton α] : G.ediam = 0 := by
 
 lemma nontrivial_of_ediam_ne_zero (h : G.ediam ≠ 0) : Nontrivial α := by
   contrapose! h
-  rw [not_nontrivial_iff_subsingleton] at h
   exact ediam_eq_zero_of_subsingleton
 
 lemma ediam_ne_zero [Nontrivial α] : G.ediam ≠ 0 := by
@@ -143,7 +141,6 @@ lemma ediam_ne_zero [Nontrivial α] : G.ediam ≠ 0 := by
 
 lemma subsingleton_of_ediam_eq_zero (h : G.ediam = 0) : Subsingleton α := by
   contrapose! h
-  apply not_subsingleton_iff_nontrivial.mp at h
   exact ediam_ne_zero
 
 lemma ediam_ne_zero_iff_nontrivial :
@@ -346,9 +343,9 @@ lemma radius_ne_zero_of_nontrivial [Nontrivial α] : G.radius ≠ 0 := by
 lemma radius_eq_zero_iff : G.radius = 0 ↔ Nonempty α ∧ Subsingleton α := by
   refine ⟨fun h ↦ ⟨?_, ?_⟩, fun ⟨_, _⟩ ↦ ?_⟩
   · contrapose! h
-    simp [radius, not_nonempty_iff.mp h]
+    simp [radius]
   · contrapose! h
-    simp [not_subsingleton_iff_nontrivial.mp h, radius_ne_zero_of_nontrivial]
+    simp [radius_ne_zero_of_nontrivial]
   · rw [radius, ENat.iInf_eq_zero]
     use Classical.ofNonempty
     simpa [eccent] using Subsingleton.elim _

--- a/Mathlib/Combinatorics/SimpleGraph/Extremal/Basic.lean
+++ b/Mathlib/Combinatorics/SimpleGraph/Extremal/Basic.lean
@@ -98,7 +98,7 @@ theorem card_edgeFinset_le_extremalNumber (h : H.Free G) :
 /-- If `G` has more than `extremalNumber (card V) H` edges, then `G` contains a copy of `H`. -/
 theorem IsContained.of_extremalNumber_lt_card_edgeFinset
     (h : extremalNumber (card V) H < #G.edgeFinset) : H ⊑ G := by
-  contrapose! h
+  contrapose h; push_neg
   exact card_edgeFinset_le_extremalNumber h
 
 /-- `extremalNumber (card V) H` is at most `x` if and only if every `H`-free simple graph `G` has

--- a/Mathlib/Combinatorics/SimpleGraph/Extremal/Turan.lean
+++ b/Mathlib/Combinatorics/SimpleGraph/Extremal/Turan.lean
@@ -87,8 +87,7 @@ theorem turanGraph_eq_top : turanGraph n r = ⊤ ↔ r = 0 ∨ n ≤ r := by
 
 theorem turanGraph_cliqueFree (hr : 0 < r) : (turanGraph n r).CliqueFree (r + 1) := by
   rw [cliqueFree_iff]
-  by_contra h
-  rw [not_isEmpty_iff] at h
+  by_contra! h
   obtain ⟨f, ha⟩ := h
   simp only [turanGraph, top_adj] at ha
   obtain ⟨x, y, d, c⟩ := Fintype.exists_ne_map_eq_of_card_lt (fun x ↦

--- a/Mathlib/Combinatorics/SimpleGraph/Finite.lean
+++ b/Mathlib/Combinatorics/SimpleGraph/Finite.lean
@@ -360,7 +360,7 @@ lemma minDegree_le_minDegree {H : SimpleGraph V} [DecidableRel G.Adj] [Decidable
   by_cases hne : Nonempty V
   · apply le_minDegree_of_forall_le_degree
     exact fun v ↦ (G.minDegree_le_degree v).trans (G.degree_le_of_le hle)
-  · rw [not_nonempty_iff] at hne
+  · push_neg at hne
     simp
 
 /-- In a nonempty graph, the minimal degree is less than the number of vertices. -/
@@ -409,7 +409,7 @@ theorem maxDegree_le_of_forall_degree_le [DecidableRel G.Adj] (k : ℕ) (h : ∀
     G.maxDegree ≤ k := by
   by_cases hV : IsEmpty V
   · simp
-  · have := not_isEmpty_iff.1 hV
+  · push_neg at hV
     obtain ⟨_, hv⟩ := G.exists_maximal_degree_vertex
     exact hv ▸ h _
 
@@ -421,7 +421,7 @@ lemma maxDegree_bot_eq_zero : (⊥ : SimpleGraph V).maxDegree = 0 :=
 lemma minDegree_le_maxDegree [DecidableRel G.Adj] : G.minDegree ≤ G.maxDegree := by
   by_cases he : IsEmpty V
   · simp
-  · rw [not_isEmpty_iff] at he
+  · push_neg at he
     exact he.elim fun v ↦ (minDegree_le_degree _ v).trans (degree_le_maxDegree _ v)
 
 @[simp]

--- a/Mathlib/Data/Countable/Basic.lean
+++ b/Mathlib/Data/Countable/Basic.lean
@@ -94,13 +94,11 @@ instance [Nonempty α] [Uncountable β] : Uncountable (α × β) := by
   exact (Prod.mk_right_injective default).uncountable
 
 lemma countable_left_of_prod_of_nonempty [Nonempty β] (h : Countable (α × β)) : Countable α := by
-  contrapose h
-  rw [not_countable_iff] at *
+  contrapose! h
   infer_instance
 
 lemma countable_right_of_prod_of_nonempty [Nonempty α] (h : Countable (α × β)) : Countable β := by
-  contrapose h
-  rw [not_countable_iff] at *
+  contrapose! h
   infer_instance
 
 lemma countable_prod_swap [Countable (α × β)] : Countable (β × α) :=

--- a/Mathlib/Data/Countable/Defs.lean
+++ b/Mathlib/Data/Countable/Defs.lean
@@ -121,9 +121,11 @@ class Uncountable (α : Sort*) : Prop where
   /-- A type `α` is uncountable if it is not countable. -/
   not_countable : ¬Countable α
 
+@[push]
 lemma not_uncountable_iff : ¬Uncountable α ↔ Countable α := by
   rw [uncountable_iff_not_countable, not_not]
 
+@[push]
 lemma not_countable_iff : ¬Countable α ↔ Uncountable α := (uncountable_iff_not_countable α).symm
 
 @[simp]

--- a/Mathlib/Data/Finite/Defs.lean
+++ b/Mathlib/Data/Finite/Defs.lean
@@ -132,11 +132,11 @@ class Infinite (α : Sort*) : Prop where
   /-- assertion that `α` is `¬Finite` -/
   not_finite : ¬Finite α
 
-@[simp]
+@[simp, push]
 theorem not_finite_iff_infinite : ¬Finite α ↔ Infinite α :=
   ⟨Infinite.mk, fun h => h.1⟩
 
-@[simp]
+@[simp, push]
 theorem not_infinite_iff_finite : ¬Infinite α ↔ Finite α :=
   not_finite_iff_infinite.not_right.symm
 

--- a/Mathlib/Data/Fintype/Pigeonhole.lean
+++ b/Mathlib/Data/Fintype/Pigeonhole.lean
@@ -71,6 +71,7 @@ theorem Finite.exists_ne_map_eq_of_infinite {α β} [Infinite α] [Finite β] (f
     ∃ x y : α, x ≠ y ∧ f x = f y := by
   simpa [Injective, and_comm] using not_injective_infinite_finite f
 
+attribute [local instance] Fintype.ofFinite in
 /-- The strong pigeonhole principle for infinitely many pigeons in
 finitely many pigeonholes.  If there are infinitely many pigeons in
 finitely many pigeonholes, then there is a pigeonhole with infinitely
@@ -83,7 +84,6 @@ theorem Finite.exists_infinite_fiber [Infinite α] [Finite β] (f : α → β) :
   classical
     by_contra! hf
     cases nonempty_fintype β
-    haveI := fun y => fintypeOfNotInfinite <| hf y
     let key : Fintype α :=
       { elems := univ.biUnion fun y : β => (f ⁻¹' {y}).toFinset
         complete := by simp }

--- a/Mathlib/Data/Fintype/Prod.lean
+++ b/Mathlib/Data/Fintype/Prod.lean
@@ -55,15 +55,16 @@ theorem Fintype.card_prod (α β : Type*) [Fintype α] [Fintype β] :
 
 section
 
+attribute [local instance] Fintype.ofFinite in
 @[simp]
 theorem infinite_prod : Infinite (α × β) ↔ Infinite α ∧ Nonempty β ∨ Nonempty α ∧ Infinite β := by
   refine
     ⟨fun H => ?_, fun H =>
       H.elim (and_imp.2 <| @Prod.infinite_of_left α β) (and_imp.2 <| @Prod.infinite_of_right α β)⟩
-  rw [and_comm]; contrapose! H; intro H'
+  rw [and_comm]
   rcases Infinite.nonempty (α × β) with ⟨a, b⟩
-  haveI := fintypeOfNotInfinite (H.1 ⟨b⟩); haveI := fintypeOfNotInfinite (H.2 ⟨a⟩)
-  exact H'.false
+  contrapose! H; haveI := H.1 ⟨b⟩; haveI := H.2 ⟨a⟩
+  infer_instance
 
 instance Pi.infinite_of_left {ι : Sort*} {π : ι → Type*} [∀ i, Nontrivial <| π i] [Infinite ι] :
     Infinite (∀ i : ι, π i) := by

--- a/Mathlib/Data/Fintype/Sum.lean
+++ b/Mathlib/Data/Fintype/Sum.lean
@@ -137,13 +137,9 @@ theorem Fintype.card_subtype_or_disjoint (p q : α → Prop) (h : Disjoint p q) 
     convert Fintype.card_congr (subtypeOrEquiv p q h)
     simp
 
-section
-
 attribute [local instance] Fintype.ofFinite in
 @[simp]
 theorem infinite_sum : Infinite (α ⊕ β) ↔ Infinite α ∨ Infinite β := by
   refine ⟨fun H => ?_, fun H => H.elim (@Sum.infinite_of_left α β) (@Sum.infinite_of_right α β)⟩
-  contrapose! H; haveI := H.1; haveI := H.2
+  contrapose! H; cases H
   infer_instance
-
-end

--- a/Mathlib/Data/Fintype/Sum.lean
+++ b/Mathlib/Data/Fintype/Sum.lean
@@ -139,10 +139,11 @@ theorem Fintype.card_subtype_or_disjoint (p q : α → Prop) (h : Disjoint p q) 
 
 section
 
+attribute [local instance] Fintype.ofFinite in
 @[simp]
 theorem infinite_sum : Infinite (α ⊕ β) ↔ Infinite α ∨ Infinite β := by
   refine ⟨fun H => ?_, fun H => H.elim (@Sum.infinite_of_left α β) (@Sum.infinite_of_right α β)⟩
-  contrapose! H; haveI := fintypeOfNotInfinite H.1; haveI := fintypeOfNotInfinite H.2
-  exact Infinite.false
+  contrapose! H; haveI := H.1; haveI := H.2
+  infer_instance
 
 end

--- a/Mathlib/Data/Real/Embedding.lean
+++ b/Mathlib/Data/Real/Embedding.lean
@@ -229,7 +229,7 @@ theorem exists_orderAddMonoidHom_real_injective :
     ∃ f : M →+o ℝ, Function.Injective f := by
   by_cases h : Subsingleton M
   · exact ⟨0, Function.injective_of_subsingleton _⟩
-  · have : Nontrivial M := not_subsingleton_iff_nontrivial.mp h
+  · push_neg at h
     obtain ⟨a, ha⟩ := exists_ne (0 : M)
     let one : One M := ⟨|a|⟩
     have : ZeroLEOneClass M := ⟨abs_nonneg a⟩

--- a/Mathlib/Data/Set/Subsingleton.lean
+++ b/Mathlib/Data/Set/Subsingleton.lean
@@ -263,11 +263,11 @@ theorem nontrivial_mono {α : Type*} {s t : Set α} (hst : s ⊆ t) (hs : Nontri
     Nontrivial t :=
   Nontrivial.coe_sort <| (nontrivial_coe_sort.1 hs).mono hst
 
-@[simp]
+@[simp, push]
 theorem not_subsingleton_iff : ¬s.Subsingleton ↔ s.Nontrivial := by
   simp_rw [Set.Subsingleton, Set.Nontrivial, not_forall, exists_prop]
 
-@[simp]
+@[simp, push]
 theorem not_nontrivial_iff : ¬s.Nontrivial ↔ s.Subsingleton :=
   Iff.not_left not_subsingleton_iff.symm
 

--- a/Mathlib/FieldTheory/Galois/IsGaloisGroup.lean
+++ b/Mathlib/FieldTheory/Galois/IsGaloisGroup.lean
@@ -51,7 +51,6 @@ theorem card_eq_finrank [IsGaloisGroup G K L] : Nat.card G = Module.finrank K L 
     exact (FixedPoints.finrank_eq_card G L).symm
   · rw [Nat.card_eq_zero_of_infinite, eq_comm]
     contrapose! hG
-    rw [not_infinite_iff_finite]
     have : FiniteDimensional K L := FiniteDimensional.of_finrank_pos (Nat.zero_lt_of_ne_zero hG)
     exact Finite.of_injective (MulSemiringAction.toAlgAut G K L)
       (fun _ _ ↦ (faithful K).eq_of_smul_eq_smul ∘ DFunLike.ext_iff.mp)

--- a/Mathlib/Geometry/Manifold/ChartedSpace.lean
+++ b/Mathlib/Geometry/Manifold/ChartedSpace.lean
@@ -915,7 +915,7 @@ def ChartedSpace.sum_of_nonempty [Nonempty H] : ChartedSpace H (M ⊕ M') where
 open scoped Classical in
 instance ChartedSpace.sum : ChartedSpace H (M ⊕ M') :=
   if h : Nonempty H then ChartedSpace.sum_of_nonempty else by
-  simp only [not_nonempty_iff] at h
+  push_neg at h
   have : IsEmpty M := isEmpty_of_chartedSpace H
   have : IsEmpty M' := isEmpty_of_chartedSpace H
   exact empty H (M ⊕ M')
@@ -1488,9 +1488,9 @@ def PartialHomeomorph.toStructomorph {e : PartialHomeomorph M H} (he : e ∈ atl
         -- with `c'` yields a chart in the maximal atlas of `s`.
         fun c c' hc hc' ↦ G.compatible_of_mem_maximalAtlas (G.subset_maximalAtlas hc)
           (G.restriction_mem_maximalAtlas_subtype he h c' hc') }
-  · have : IsEmpty s := not_nonempty_iff.mp h
+  · push_neg at h
     have : IsEmpty t := isEmpty_coe_sort.mpr
-      (by convert e.image_source_eq_target ▸ image_eq_empty.mpr (isEmpty_coe_sort.mp this))
+      (by convert e.image_source_eq_target ▸ image_eq_empty.mpr (isEmpty_coe_sort.mp h))
     exact { Homeomorph.empty with
       -- `c'` cannot exist: it would be the restriction of `chartAt H x` at some `x ∈ t`.
       mem_groupoid := fun _ c' _ ⟨_, ⟨x, _⟩, _⟩ ↦ (this.false x).elim }

--- a/Mathlib/GroupTheory/SpecificGroups/Cyclic.lean
+++ b/Mathlib/GroupTheory/SpecificGroups/Cyclic.lean
@@ -108,7 +108,7 @@ variable [Group α] [Group G] [Group G']
 @[to_additive /-- A non-cyclic additive group is non-trivial. -/]
 theorem Nontrivial.of_not_isCyclic (nc : ¬IsCyclic α) : Nontrivial α := by
   contrapose! nc
-  exact @isCyclic_of_subsingleton _ _ (not_nontrivial_iff_subsingleton.mp nc)
+  exact @isCyclic_of_subsingleton _ _ nc
 
 @[to_additive]
 theorem MonoidHom.map_cyclic [h : IsCyclic G] (σ : G →* G) :

--- a/Mathlib/LinearAlgebra/Basis/Defs.lean
+++ b/Mathlib/LinearAlgebra/Basis/Defs.lean
@@ -418,7 +418,7 @@ def reindexRange : Basis (range b) R M :=
 theorem reindexRange_self (i : ι) (h := Set.mem_range_self i) : b.reindexRange ⟨b i, h⟩ = b i := by
   by_cases htr : Nontrivial R
   · simp [htr, reindexRange, reindex_apply]
-  · letI : Subsingleton R := not_nontrivial_iff_subsingleton.mp htr
+  · push_neg at htr
     letI := Module.subsingleton R M
     simp [reindexRange, eq_iff_true_of_subsingleton]
 

--- a/Mathlib/LinearAlgebra/Dimension/Localization.lean
+++ b/Mathlib/LinearAlgebra/Dimension/Localization.lean
@@ -218,8 +218,8 @@ lemma aleph0_le_rank_of_isEmpty_oreSet (hS : IsEmpty (OreLocalization.OreSet R‚Å
 -- TODO: Upgrade this to an iff. See [lam_1999] Exercise 10.21
 lemma nonempty_oreSet_of_strongRankCondition [StrongRankCondition R] :
     Nonempty (OreLocalization.OreSet R‚Å∞) := by
-  by_contra h
-  have := aleph0_le_rank_of_isEmpty_oreSet (not_nonempty_iff.mp h)
+  by_contra! h
+  have := aleph0_le_rank_of_isEmpty_oreSet h
   rw [rank_self] at this
   exact this.not_gt one_lt_aleph0
 

--- a/Mathlib/LinearAlgebra/InvariantBasisNumber.lean
+++ b/Mathlib/LinearAlgebra/InvariantBasisNumber.lean
@@ -235,9 +235,8 @@ theorem card_eq_of_linearEquiv {α β : Type*} [Fintype α] [Fintype β] (f : (�
       (LinearEquiv.funCongrLeft R R (Fintype.equivFin β)).symm)
 
 theorem nontrivial_of_invariantBasisNumber : Nontrivial R := by
-  by_contra h
+  by_contra! h
   refine zero_ne_one (eq_of_fin_equiv R ?_)
-  haveI := not_nontrivial_iff_subsingleton.1 h
   haveI : Subsingleton (Fin 1 → R) :=
     Subsingleton.intro fun a b => funext fun x => Subsingleton.elim _ _
   exact

--- a/Mathlib/LinearAlgebra/Projectivization/Cardinality.lean
+++ b/Mathlib/LinearAlgebra/Projectivization/Cardinality.lean
@@ -60,13 +60,12 @@ See `Projectivization.card'` and `Projectivization.card''` for other spellings o
 lemma card : Nat.card V - 1 = Nat.card (ℙ k V) * (Nat.card k - 1) := by
   nontriviality V
   wlog h : Finite k
-  · simp only [not_finite_iff_infinite] at h
+  · push_neg at h
     have : Infinite V := Module.Free.infinite k V
     simp
   wlog h : Finite V
-  · simp only [not_finite_iff_infinite] at h
-    have := not_iff_not.mpr (finite_iff_of_finite k V)
-    simp only [not_finite_iff_infinite] at this
+  · have := not_iff_not.mpr (finite_iff_of_finite k V)
+    push_neg at h this
     have : Infinite (ℙ k V) := by rwa [this]
     simp
   classical
@@ -98,10 +97,9 @@ lemma card'' [Finite k] : Nat.card (ℙ k V) = (Nat.card V - 1) / (Nat.card k - 
 lemma card_of_finrank [Finite k] {n : ℕ} (h : Module.finrank k V = n) :
     Nat.card (ℙ k V) = ∑ i ∈ Finset.range n, Nat.card k ^ i := by
   wlog hf : Finite V
-  · simp only [not_finite_iff_infinite] at hf
-    have : Infinite (ℙ k V) := by
-      rw [← not_finite_iff_infinite, not_iff_not.mpr (finite_iff_of_finite k V)]
-      simpa
+  · have : Infinite (ℙ k V) := by
+      contrapose! hf
+      rwa [finite_iff_of_finite] at hf
     have : n = 0 := by
       rw [← h]
       apply Module.finrank_of_not_finite

--- a/Mathlib/Logic/IsEmpty.lean
+++ b/Mathlib/Logic/IsEmpty.lean
@@ -130,11 +130,11 @@ instance (priority := 100) : Subsingleton α :=
 
 end IsEmpty
 
-@[simp]
+@[simp, push]
 theorem not_nonempty_iff : ¬Nonempty α ↔ IsEmpty α :=
   ⟨fun h ↦ ⟨fun x ↦ h ⟨x⟩⟩, fun h1 h2 ↦ h2.elim h1.elim⟩
 
-@[simp]
+@[simp, push]
 theorem not_isEmpty_iff : ¬IsEmpty α ↔ Nonempty α :=
   not_iff_comm.mp not_nonempty_iff
 

--- a/Mathlib/Logic/Nontrivial/Defs.lean
+++ b/Mathlib/Logic/Nontrivial/Defs.lean
@@ -5,6 +5,7 @@ Authors: Sébastien Gouëzel
 -/
 import Mathlib.Tactic.TypeStar
 import Mathlib.Tactic.Lemma
+import Mathlib.Tactic.Push.Attr
 
 /-!
 # Nontrivial types
@@ -67,6 +68,7 @@ theorem subsingleton_iff : Subsingleton α ↔ ∀ x y : α, x = y :=
     intro h
     exact Subsingleton.elim, fun h ↦ ⟨h⟩⟩
 
+@[push]
 theorem not_nontrivial_iff_subsingleton : ¬Nontrivial α ↔ Subsingleton α := by
   simp only [nontrivial_iff, subsingleton_iff, not_exists, Classical.not_not]
 
@@ -76,6 +78,7 @@ theorem not_nontrivial (α) [Subsingleton α] : ¬Nontrivial α :=
 theorem not_subsingleton (α) [Nontrivial α] : ¬Subsingleton α :=
   fun _ => not_nontrivial _ ‹_›
 
+@[push]
 lemma not_subsingleton_iff_nontrivial : ¬Subsingleton α ↔ Nontrivial α := by
   rw [← not_nontrivial_iff_subsingleton, Classical.not_not]
 

--- a/Mathlib/MeasureTheory/Measure/LevyProkhorovMetric.lean
+++ b/Mathlib/MeasureTheory/Measure/LevyProkhorovMetric.lean
@@ -522,7 +522,7 @@ lemma SeparableSpace.exists_measurable_partition_diam_le {ε : ℝ} (ε_pos : 0 
     · intro n
       simpa only [diam_empty] using LT.lt.le ε_pos
     · subsingleton
-  rw [not_isEmpty_iff] at X_emp
+  push_neg at X_emp
   obtain ⟨xs, xs_dense⟩ := exists_dense_seq Ω
   have half_ε_pos : 0 < ε / 2 := half_pos ε_pos
   set Bs := fun n ↦ Metric.ball (xs n) (ε / 2)
@@ -614,7 +614,8 @@ lemma LevyProkhorov.continuous_equiv_symm_probabilityMeasure :
     by_cases i_small : i ∈ Iio N
     · refine Or.inl ⟨i, ?_, self_subset_thickening third_ε_pos _ hi⟩
       simp only [mem_Iio, mem_setOf_eq, JB]
-      refine ⟨nonempty_iff_ne_empty.mp <| Set.nonempty_of_mem <| mem_inter ω_in_B hi, i_small⟩
+      push_neg
+      exact ⟨Set.nonempty_of_mem <| mem_inter ω_in_B hi, i_small⟩
     · exact Or.inr ⟨i, by simpa only [mem_Iio, not_lt] using i_small, hi⟩
   have subset_thickB : ⋃ i ∈ JB, thickening (ε / 3) (Es i) ⊆ thickening δ B := by
     intro ω ω_in_U

--- a/Mathlib/Order/Birkhoff.lean
+++ b/Mathlib/Order/Birkhoff.lean
@@ -209,7 +209,7 @@ powerset lattice. -/
 noncomputable def birkhoffSet : α ↪o Set {a : α // SupIrred a} := by
   by_cases h : IsEmpty α
   · exact OrderEmbedding.ofIsEmpty
-  rw [not_isEmpty_iff] at h
+  push_neg at h
   have := Fintype.toOrderBot α
   exact OrderIso.lowerSetSupIrred.toOrderEmbedding.trans ⟨⟨_, SetLike.coe_injective⟩, Iff.rfl⟩
 

--- a/Mathlib/Order/Interval/Set/Basic.lean
+++ b/Mathlib/Order/Interval/Set/Basic.lean
@@ -681,7 +681,6 @@ lemma subsingleton_Icc_of_ge (hba : b ≤ a) : Set.Subsingleton (Icc a b) :=
     Set.Subsingleton (Icc a b) ↔ b ≤ a := by
   refine ⟨fun h ↦ ?_, subsingleton_Icc_of_ge⟩
   contrapose! h
-  simp only [not_subsingleton_iff]
   exact ⟨a, ⟨le_refl _, h.le⟩, b, ⟨h.le, le_refl _⟩, h.ne⟩
 
 @[simp]

--- a/Mathlib/RepresentationTheory/Submodule.lean
+++ b/Mathlib/RepresentationTheory/Submodule.lean
@@ -44,7 +44,6 @@ instance : BoundedOrder ρ.invtSubmodule where
 protected lemma nontrivial_iff : Nontrivial ρ.invtSubmodule ↔ Nontrivial V := by
   refine ⟨fun h ↦ ?_, fun h ↦ ?_⟩
   · contrapose! h
-    rw [not_nontrivial_iff_subsingleton] at h ⊢
     infer_instance
   · refine ⟨⊥, ⊤, ?_⟩
     rw [← Subtype.coe_ne_coe, invtSubmodule.coe_top, invtSubmodule.coe_bot]

--- a/Mathlib/RingTheory/Algebraic/Basic.lean
+++ b/Mathlib/RingTheory/Algebraic/Basic.lean
@@ -34,7 +34,6 @@ variable {R}
 
 theorem IsAlgebraic.nontrivial {a : A} (h : IsAlgebraic R a) : Nontrivial R := by
   contrapose! h
-  rw [not_nontrivial_iff_subsingleton] at h
   apply is_transcendental_of_subsingleton
 
 variable (R A)

--- a/Mathlib/RingTheory/AlgebraicIndependent/Basic.lean
+++ b/Mathlib/RingTheory/AlgebraicIndependent/Basic.lean
@@ -149,7 +149,7 @@ theorem isTranscendenceBasis_iff_of_subsingleton [Subsingleton R] (x : ι → A)
   have := Module.subsingleton R A
   refine ⟨fun h ↦ ?_, fun h ↦ ⟨.of_subsingleton, fun s hs hx ↦
     hx.antisymm fun a _ ↦ ⟨Classical.arbitrary _, Subsingleton.elim ..⟩⟩⟩
-  by_contra hι; rw [not_nonempty_iff] at hι
+  by_contra! hι
   have := h.2 {0} .of_subsingleton
   simp [range_eq_empty, eq_comm (a := ∅)] at this
 

--- a/Mathlib/RingTheory/AlgebraicIndependent/TranscendenceBasis.lean
+++ b/Mathlib/RingTheory/AlgebraicIndependent/TranscendenceBasis.lean
@@ -262,7 +262,7 @@ private def indepMatroid : IndepMatroid A where
     rw [← isTranscendenceBasis_iff_maximal] at B_base ⊢
     cases subsingleton_or_nontrivial R
     · rw [isTranscendenceBasis_iff_of_subsingleton] at B_base ⊢
-      by_contra!
+      by_contra this
       have ⟨b, hb⟩ := B_base
       exact h b ⟨hb, fun hbI ↦ this ⟨b, hbI⟩⟩ .of_subsingleton
     apply I_ind.isTranscendenceBasis_iff_isAlgebraic.mpr

--- a/Mathlib/RingTheory/DividedPowers/SubDPIdeal.lean
+++ b/Mathlib/RingTheory/DividedPowers/SubDPIdeal.lean
@@ -190,7 +190,7 @@ theorem isSubDPIdeal_iInf {ι : Type*} {J : ι → Ideal A} (hJ : ∀ i, IsSubDP
     intro n hn x hx
     simp only [Ideal.mem_inf, mem_iInf] at hx ⊢
     exact ⟨hI.dpow_mem hn hx.1, fun i ↦  IsSubDPIdeal.dpow_mem (hJ i) n hn (hx.2 i)⟩
-  · simp only [not_nonempty_iff] at hι
+  · push_neg at hι
     simp only [iInf_of_empty, le_top, inf_of_le_left]
     exact IsSubDPIdeal.self hI
 

--- a/Mathlib/RingTheory/Flat/FaithfullyFlat/Basic.lean
+++ b/Mathlib/RingTheory/Flat/FaithfullyFlat/Basic.lean
@@ -115,8 +115,7 @@ instance lTensor_nontrivial
 lemma rTensor_reflects_triviality
     [FaithfullyFlat R M] (N : Type*) [AddCommGroup N] [Module R N]
     [h : Subsingleton (N ⊗[R] M)] : Subsingleton N := by
-  revert h; change _ → _; contrapose
-  simp only [not_subsingleton_iff_nontrivial]
+  revert h; change _ → _; contrapose!
   intro h
   infer_instance
 

--- a/Mathlib/RingTheory/Frobenius.lean
+++ b/Mathlib/RingTheory/Frobenius.lean
@@ -61,8 +61,7 @@ lemma mk_apply (x) : Ideal.Quotient.mk Q (φ x) = x ^ Nat.card (R ⧸ Q.under R)
   exact H x
 
 lemma finite_quotient : _root_.Finite (R ⧸ Q.under R) := by
-  rw [← not_infinite_iff_finite]
-  intro h
+  by_contra! h
   obtain rfl : Q = ⊤ := by simpa [Nat.card_eq_zero_of_infinite, ← Ideal.eq_top_iff_one] using H 0
   simp only [Ideal.comap_top] at h
   exact not_finite (R ⧸ (⊤ : Ideal R))

--- a/Mathlib/RingTheory/Ideal/Int.lean
+++ b/Mathlib/RingTheory/Ideal/Int.lean
@@ -87,8 +87,8 @@ theorem absNorm_under_dvd_absNorm {S : Type*} [CommRing S] [IsDedekindDomain S] 
     rw [Ideal.absNorm_apply I, Submodule.cardQuot_apply, Nat.card_eq_fintype_card]
     simp_rw [absNorm_under_eq_sInf, h_main, ← AddMonoid.exponent_eq_sInf]
     exact AddGroup.exponent_dvd_card (G := S ⧸ I)
-  · rw [show absNorm I = 0 by
-      exact AddSubgroup.index_eq_zero_iff_infinite.mpr <| not_finite_iff_infinite.mp h]
+  · push_neg at h
+    rw [show absNorm I = 0 by exact AddSubgroup.index_eq_zero_iff_infinite.mpr h]
     exact Nat.dvd_zero _
 
 end Ring

--- a/Mathlib/RingTheory/Regular/Depth.lean
+++ b/Mathlib/RingTheory/Regular/Depth.lean
@@ -45,7 +45,7 @@ lemma subsingleton_linearMap_iff [IsNoetherianRing R] [Module.Finite R M] [Modul
     linearMap_subsingleton_of_mem_annihilator reg mem_ann⟩
   by_cases htrivial : Subsingleton M
   · exact ⟨0, ⟨Submodule.zero_mem (Module.annihilator R N), IsSMulRegular.zero⟩⟩
-  · let _ : Nontrivial M := not_subsingleton_iff_nontrivial.mp htrivial
+  · push_neg at htrivial
     by_contra! h
     have hexist : ∃ p ∈ associatedPrimes R M, Module.annihilator R N ≤ p := by
       rcases associatedPrimes.nonempty R M with ⟨Ia, hIa⟩

--- a/Mathlib/RingTheory/Spectrum/Maximal/Localization.lean
+++ b/Mathlib/RingTheory/Spectrum/Maximal/Localization.lean
@@ -138,7 +138,7 @@ variable {R}
 theorem finite_of_toPiLocalization_pi_surjective
     (h : Function.Surjective (toPiLocalization (Π i, R i))) :
     Finite ι := by
-  contrapose h; rw [not_finite_iff_infinite] at h
+  contrapose! h
   exact toPiLocalization_not_surjective_of_infinite _
 
 end Pi
@@ -251,7 +251,7 @@ variable {R}
 theorem finite_of_toPiLocalization_pi_surjective
     (h : Function.Surjective (toPiLocalization (Π i, R i))) :
     Finite ι := by
-  contrapose h; rw [not_finite_iff_infinite] at h
+  contrapose! h
   exact toPiLocalization_not_surjective_of_infinite _
 
 end Pi

--- a/Mathlib/RingTheory/Spectrum/Prime/FreeLocus.lean
+++ b/Mathlib/RingTheory/Spectrum/Prime/FreeLocus.lean
@@ -235,7 +235,6 @@ lemma rankAtStalk_eq_zero_of_subsingleton [Subsingleton M] :
 lemma nontrivial_of_rankAtStalk_pos (h : 0 < rankAtStalk (R := R) M) :
     Nontrivial M := by
   by_contra! hn
-  have : Subsingleton M := not_nontrivial_iff_subsingleton.mp hn
   simp at h
 
 lemma rankAtStalk_eq_of_equiv {N : Type*} [AddCommGroup N] [Module R N] (e : M ≃ₗ[R] N) :

--- a/Mathlib/RingTheory/Unramified/Basic.lean
+++ b/Mathlib/RingTheory/Unramified/Basic.lean
@@ -81,8 +81,7 @@ theorem iff_comp_injective :
   · intros; exact comp_injective _ ‹_›
   · intro H
     constructor
-    rw [← not_nontrivial_iff_subsingleton]
-    intro h
+    by_contra! h
     obtain ⟨f₁, f₂, e⟩ := (KaehlerDifferential.endEquiv R A).injective.nontrivial
     apply e
     ext1

--- a/Mathlib/RingTheory/Valuation/Discrete/Basic.lean
+++ b/Mathlib/RingTheory/Valuation/Discrete/Basic.lean
@@ -127,10 +127,10 @@ instance : Nontrivial (valueGroup v) :=
   ⟨1, ⟨generator v, by simp [← generator_zpowers_eq_valueGroup]⟩, ne_of_gt <| generator_lt_one v⟩
 
 instance [IsRankOneDiscrete v] : Nontrivial (valueMonoid v) := by
-  by_contra H
+  by_contra! H
   apply ((valueGroup v).nontrivial_iff_ne_bot).mp (by infer_instance)
   apply closure_eq_bot_iff.mpr
-  rw [not_nontrivial_iff_subsingleton, subsingleton_iff] at H
+  rw [subsingleton_iff] at H
   intro x hx
   specialize H ⟨x, hx⟩ ⟨1, one_mem_valueMonoid v⟩
   simpa using H

--- a/Mathlib/RingTheory/Valuation/DiscreteValuativeRel.lean
+++ b/Mathlib/RingTheory/Valuation/DiscreteValuativeRel.lean
@@ -61,7 +61,7 @@ lemma IsDiscrete.of_compatible_withZeroMulInt (v : Valuation R ℤᵐ⁰) [v.Com
       rw [← LinearOrderedCommGroupWithZero.discrete_iff_not_denselyOrdered] at H
       rw [nonempty_orderIso_withZeroMul_int_iff] at H
       exact H.left
-  · rw [isNontrivial_iff_nontrivial_units, not_nontrivial_iff_subsingleton] at h
+  · rw [isNontrivial_iff_nontrivial_units] at h; push_neg at h
     refine ⟨⟨0, zero_lt_one, fun y hy ↦ ?_⟩⟩
     contrapose! hy
     have : 1 = Units.mk0 y hy.ne' := Subsingleton.elim _ _

--- a/Mathlib/Topology/CWComplex/Classical/Finite.lean
+++ b/Mathlib/Topology/CWComplex/Classical/Finite.lean
@@ -310,16 +310,16 @@ lemma RelCWComplex.finite_of_finite_cells (finite : _root_.Finite (Σ n, cell C 
     · exact ⟨0, by simp_all⟩
     -- We take the greatest `n` such that there is a `j : cell C n` and show that this fulfills
     -- the necessary conditions.
-    rw [not_isEmpty_iff] at h
+    push_neg at h
     have _ := Fintype.ofFinite (Σ n, cell C n)
     classical
     let A := (Finset.univ : Finset (Σ n, cell C n)).image Sigma.fst
     use A.max' (Finset.image_nonempty.2 Finset.univ_nonempty) + 1
     intro m _
-    by_contra h'
+    by_contra! h'
     have hmA : m ∈ A := by
       simp only [Finset.mem_image, Finset.mem_univ, true_and, A]
-      simp only [not_isEmpty_iff, ← exists_true_iff_nonempty] at h'
+      simp only [← exists_true_iff_nonempty] at h'
       obtain ⟨j, _⟩ := h'
       use ⟨m, j⟩
     linarith [A.le_max' m hmA]

--- a/Mathlib/Topology/Category/Profinite/CofilteredLimit.lean
+++ b/Mathlib/Topology/Category/Profinite/CofilteredLimit.lean
@@ -191,8 +191,7 @@ theorem exists_locallyConstant {α : Type*} (hC : IsLimit C) (f : LocallyConstan
         exact @Set.eq_empty_of_isEmpty _ hj _
       · ext x
         exact hj.elim' (C.π.app j x)
-    simp only [← not_nonempty_iff, ← not_forall]
-    intro h
+    by_contra! h
     haveI : ∀ j : J, Nonempty ((F ⋙ Profinite.toTopCat).obj j) := h
     haveI : ∀ j : J, T2Space ((F ⋙ Profinite.toTopCat).obj j) := fun j =>
       (inferInstance : T2Space (F.obj j))

--- a/Mathlib/Topology/MetricSpace/Infsep.lean
+++ b/Mathlib/Topology/MetricSpace/Infsep.lean
@@ -217,7 +217,6 @@ theorem einfsep_eq_top_iff : s.einfsep = ∞ ↔ s.Subsingleton :=
 
 theorem Nontrivial.einfsep_ne_top (hs : s.Nontrivial) : s.einfsep ≠ ∞ := by
   contrapose! hs
-  rw [not_nontrivial_iff]
   exact subsingleton_of_einfsep_eq_top hs
 
 theorem Nontrivial.einfsep_lt_top (hs : s.Nontrivial) : s.einfsep < ∞ := by

--- a/Mathlib/Topology/Separation/Connected.lean
+++ b/Mathlib/Topology/Separation/Connected.lean
@@ -25,8 +25,8 @@ instance (priority := 100) TotallyDisconnectedSpace.t1Space [h : TotallyDisconne
 
 theorem PreconnectedSpace.trivial_of_discrete [PreconnectedSpace X] [DiscreteTopology X] :
     Subsingleton X := by
-  rw [← not_nontrivial_iff_subsingleton]
-  rintro ⟨x, y, hxy⟩
+  by_contra! h
+  rcases h with ⟨x, y, hxy⟩
   rw [Ne, ← mem_singleton_iff, (isClopen_discrete _).eq_univ <| singleton_nonempty y] at hxy
   exact hxy (mem_univ x)
 


### PR DESCRIPTION
This PR adds `push_neg` attributes for the size classes
- IsEmpty/Nonempty
- Subsingleton/Nontrivial
- Finite/Infinite
- Countable/Uncoutable

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include at least one commit authored by each
co-author among the commits in the pull request. If necessary, you may 
create empty commits to indicate co-authorship, using commands like so:

git commit --author="Author Name <author@email.com>" --allow-empty -m "add Author Name as coauthor"

When merging, all the commits will be squashed into a single commit listing all co-authors.

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
