### PR TITLE
[Merged by Bors] - chore(CategoryTheory/ObjectProperty): tag `ObjectProperty.Small` with pp_with_univ

### DIFF
--- a/Mathlib/CategoryTheory/ObjectProperty/Small.lean
+++ b/Mathlib/CategoryTheory/ObjectProperty/Small.lean
@@ -22,6 +22,7 @@ variable {C : Type u} [Category.{v} C]
 
 /-- A property of objects is small relative to a universe `w`
 if the corresponding subtype is. -/
+@[pp_with_univ]
 protected abbrev Small (P : ObjectProperty C) : Prop := _root_.Small.{w} (Subtype P)
 
 instance (P : ObjectProperty C) [ObjectProperty.Small.{w} P] :


### PR DESCRIPTION
The declaration `CategoryTheory.ObjectProperty.Small` introduced in #29843 depends on an extra universe level `w`, so should be tagged `pp_with_univ` to avoid confusion.

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include at least one commit authored by each
co-author among the commits in the pull request. If necessary, you may 
create empty commits to indicate co-authorship, using commands like so:

git commit --author="Author Name <author@email.com>" --allow-empty -m "add Author Name as coauthor"

When merging, all the commits will be squashed into a single commit listing all co-authors.

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
