### PR TITLE
[Merged by Bors] - chore: deprecate duplicate `zeta_mul_kappa` lemma

### DIFF
--- a/Mathlib/Combinatorics/Enumerative/IncidenceAlgebra.lean
+++ b/Mathlib/Combinatorics/Enumerative/IncidenceAlgebra.lean
@@ -352,6 +352,8 @@ lemma zeta_mul_zeta [NonAssocSemiring 𝕜] [Preorder α] [LocallyFiniteOrder α
   rw [mem_Icc] at hx
   rw [zeta_of_le hx.1, zeta_of_le hx.2, one_mul]
 
+@[deprecated (since := "2025-09-28")] alias zeta_mul_kappa := zeta_mul_zeta
+
 section Mu
 variable (𝕜) [AddCommGroup 𝕜] [One 𝕜] [Preorder α] [LocallyFiniteOrder α] [DecidableEq α]
 

--- a/Mathlib/Combinatorics/Enumerative/IncidenceAlgebra.lean
+++ b/Mathlib/Combinatorics/Enumerative/IncidenceAlgebra.lean
@@ -352,13 +352,6 @@ lemma zeta_mul_zeta [NonAssocSemiring 𝕜] [Preorder α] [LocallyFiniteOrder α
   rw [mem_Icc] at hx
   rw [zeta_of_le hx.1, zeta_of_le hx.2, one_mul]
 
-lemma zeta_mul_kappa [NonAssocSemiring 𝕜] [Preorder α] [LocallyFiniteOrder α] [DecidableLE α]
-    (a b : α) : (zeta 𝕜 * zeta 𝕜 : IncidenceAlgebra 𝕜 α) a b = (Icc a b).card := by
-  rw [mul_apply, card_eq_sum_ones, Nat.cast_sum, Nat.cast_one]
-  refine sum_congr rfl fun x hx ↦ ?_
-  rw [mem_Icc] at hx
-  rw [zeta_of_le hx.1, zeta_of_le hx.2, one_mul]
-
 section Mu
 variable (𝕜) [AddCommGroup 𝕜] [One 𝕜] [Preorder α] [LocallyFiniteOrder α] [DecidableEq α]
 


### PR DESCRIPTION
This PR deprecates the duplicate lemma `zeta_mul_kappa` that was identical to `zeta_mul_zeta` but with a typo in the name. 

Closes #28440.