### PR TITLE
[Merged by Bors] - feat(GroupTheory): finitely generated groups are quotients of free groups on finite generators

### DIFF
--- a/Mathlib/GroupTheory/Finiteness.lean
+++ b/Mathlib/GroupTheory/Finiteness.lean
@@ -6,6 +6,7 @@ Authors: Riccardo Brasca
 import Mathlib.Algebra.Group.Pointwise.Set.Finite
 import Mathlib.Algebra.Group.Subgroup.Pointwise
 import Mathlib.Algebra.Group.Submonoid.BigOperators
+import Mathlib.GroupTheory.FreeGroup.Basic
 import Mathlib.GroupTheory.QuotientGroup.Defs
 
 /-!
@@ -165,6 +166,21 @@ theorem Monoid.fg_def : Monoid.FG M ↔ (⊤ : Submonoid M).FG :=
 theorem Monoid.fg_iff :
     Monoid.FG M ↔ ∃ S : Set M, Submonoid.closure S = (⊤ : Submonoid M) ∧ S.Finite :=
   ⟨fun _ => (Submonoid.fg_iff ⊤).1 FG.fg_top, fun h => ⟨(Submonoid.fg_iff ⊤).2 h⟩⟩
+
+/-- A monoid is finitely generated iff there exists a surjective homomorphism from a `FreeMonoid`
+on finite generators. -/
+@[to_additive /-- A additive monoid is finitely generated iff there exists a surjective homomorphism
+from a `FreeAddMonoid` on finite generators.-/]
+theorem Monoid.fg_iff_freeMonoid_hom_surjective {M} [Monoid M] :
+    Monoid.FG M ↔ ∃ (S : Set M) (_ : Finite S) (φ : FreeMonoid S →* M), Function.Surjective φ := by
+  constructor
+  · intro hfg
+    obtain ⟨S, hclosure, hfin⟩ := fg_iff.mp hfg
+    refine ⟨S, hfin, FreeMonoid.lift (·), ?_⟩
+    simp [← MonoidHom.mrange_eq_top, ← hclosure, ← Submonoid.closure_eq_mrange]
+  · rintro ⟨S, hfin, φ, hφ⟩
+    refine fg_iff.mpr ⟨φ '' Set.range FreeMonoid.of, ?_, Set.toFinite _⟩
+    simp [← MonoidHom.map_mclosure, hφ, FreeMonoid.closure_range_of, ← MonoidHom.mrange_eq_map]
 
 variable (M) in
 /-- A finitely generated monoid has a minimal generating set. -/
@@ -383,6 +399,21 @@ theorem Group.fg_iff : Group.FG G ↔ ∃ S : Set G, Subgroup.closure S = (⊤ :
 theorem Group.fg_iff' :
     Group.FG G ↔ ∃ (n : _) (S : Finset G), S.card = n ∧ Subgroup.closure (S : Set G) = ⊤ :=
   Group.fg_def.trans ⟨fun ⟨S, hS⟩ => ⟨S.card, S, rfl, hS⟩, fun ⟨_n, S, _hn, hS⟩ => ⟨S, hS⟩⟩
+
+/-- A group is finitely generated iff there exists a surjective homomorphism from a `FreeGroup`
+on finite generators. -/
+@[to_additive /-- An additive group is finitely generated iff there exists a surjective homomorphism
+from a `FreeAddGroup` on finite generators. -/]
+theorem Group.fg_iff_freeGroup_hom_surjective {G} [Group G] :
+    Group.FG G ↔ ∃ (S : Set G) (_ : Finite S) (φ : FreeGroup S →* G), Function.Surjective φ := by
+  constructor
+  · intro hfg
+    obtain ⟨S, hclosure, hfin⟩ := fg_iff.mp hfg
+    refine ⟨S, hfin, FreeGroup.lift (·), ?_⟩
+    simp [← MonoidHom.range_eq_top, ← hclosure, FreeGroup.range_lift_eq_closure]
+  · rintro ⟨S, hfin, φ, hφ⟩
+    refine fg_iff.mpr ⟨φ '' Set.range FreeGroup.of, ?_, Set.toFinite _⟩
+    simp [← MonoidHom.map_closure, Subgroup.map_top_of_surjective, hφ]
 
 /-- A group is finitely generated if and only if it is finitely generated as a monoid. -/
 @[to_additive /-- An additive group is finitely generated if and only

--- a/Mathlib/GroupTheory/Finiteness.lean
+++ b/Mathlib/GroupTheory/Finiteness.lean
@@ -171,14 +171,11 @@ theorem Monoid.fg_iff :
 on finite generators. -/
 @[to_additive /-- A additive monoid is finitely generated iff there exists a surjective homomorphism
 from a `FreeAddMonoid` on finite generators.-/]
-theorem Monoid.fg_iff_freeMonoid_hom_surjective {M} [Monoid M] :
-    Monoid.FG M ↔ ∃ (S : Set M) (_ : Finite S) (φ : FreeMonoid S →* M), Function.Surjective φ := by
-  constructor
-  · intro hfg
-    obtain ⟨S, hclosure, hfin⟩ := fg_iff.mp hfg
-    refine ⟨S, hfin, FreeMonoid.lift (·), ?_⟩
-    simp [← MonoidHom.mrange_eq_top, ← hclosure, ← Submonoid.closure_eq_mrange]
-  · rintro ⟨S, hfin, φ, hφ⟩
+theorem Monoid.fg_iff_exists_freeMonoid_hom_surjective :
+    Monoid.FG M ↔ ∃ (S : Set M) (_ : S.Finite) (φ : FreeMonoid S →* M), Function.Surjective φ := by
+  refine ⟨fun ⟨S, hS⟩ ↦ ⟨S, S.finite_toSet, FreeMonoid.lift Subtype.val, ?_⟩, ?_⟩
+  · rwa [← MonoidHom.mrange_eq_top, ← Submonoid.closure_eq_mrange]
+  · rintro ⟨S, hfin : Finite S, φ, hφ⟩
     refine fg_iff.mpr ⟨φ '' Set.range FreeMonoid.of, ?_, Set.toFinite _⟩
     simp [← MonoidHom.map_mclosure, hφ, FreeMonoid.closure_range_of, ← MonoidHom.mrange_eq_map]
 
@@ -404,14 +401,11 @@ theorem Group.fg_iff' :
 on finite generators. -/
 @[to_additive /-- An additive group is finitely generated iff there exists a surjective homomorphism
 from a `FreeAddGroup` on finite generators. -/]
-theorem Group.fg_iff_freeGroup_hom_surjective {G} [Group G] :
-    Group.FG G ↔ ∃ (S : Set G) (_ : Finite S) (φ : FreeGroup S →* G), Function.Surjective φ := by
-  constructor
-  · intro hfg
-    obtain ⟨S, hclosure, hfin⟩ := fg_iff.mp hfg
-    refine ⟨S, hfin, FreeGroup.lift (·), ?_⟩
-    simp [← MonoidHom.range_eq_top, ← hclosure, FreeGroup.range_lift_eq_closure]
-  · rintro ⟨S, hfin, φ, hφ⟩
+theorem Group.fg_iff_exists_freeGroup_hom_surjective :
+    Group.FG G ↔ ∃ (S : Set G) (_ : S.Finite) (φ : FreeGroup S →* G), Function.Surjective φ := by
+  refine ⟨fun ⟨S, hS⟩ ↦ ⟨S, S.finite_toSet, FreeGroup.lift Subtype.val, ?_⟩, ?_⟩
+  · rwa [← MonoidHom.range_eq_top, ← FreeGroup.closure_eq_range]
+  · rintro ⟨S, hfin : Finite S, φ, hφ⟩
     refine fg_iff.mpr ⟨φ '' Set.range FreeGroup.of, ?_, Set.toFinite _⟩
     simp [← MonoidHom.map_closure, Subgroup.map_top_of_surjective, hφ]
 

--- a/Mathlib/GroupTheory/Finiteness.lean
+++ b/Mathlib/GroupTheory/Finiteness.lean
@@ -168,9 +168,9 @@ theorem Monoid.fg_iff :
   ⟨fun _ => (Submonoid.fg_iff ⊤).1 FG.fg_top, fun h => ⟨(Submonoid.fg_iff ⊤).2 h⟩⟩
 
 /-- A monoid is finitely generated iff there exists a surjective homomorphism from a `FreeMonoid`
-on finite generators. -/
+on finitely many generators. -/
 @[to_additive /-- A additive monoid is finitely generated iff there exists a surjective homomorphism
-from a `FreeAddMonoid` on finite generators.-/]
+from a `FreeAddMonoid` on finitely many generators.-/]
 theorem Monoid.fg_iff_exists_freeMonoid_hom_surjective :
     Monoid.FG M ↔ ∃ (S : Set M) (_ : S.Finite) (φ : FreeMonoid S →* M), Function.Surjective φ := by
   refine ⟨fun ⟨S, hS⟩ ↦ ⟨S, S.finite_toSet, FreeMonoid.lift Subtype.val, ?_⟩, ?_⟩
@@ -398,9 +398,9 @@ theorem Group.fg_iff' :
   Group.fg_def.trans ⟨fun ⟨S, hS⟩ => ⟨S.card, S, rfl, hS⟩, fun ⟨_n, S, _hn, hS⟩ => ⟨S, hS⟩⟩
 
 /-- A group is finitely generated iff there exists a surjective homomorphism from a `FreeGroup`
-on finite generators. -/
+on finitely many generators. -/
 @[to_additive /-- An additive group is finitely generated iff there exists a surjective homomorphism
-from a `FreeAddGroup` on finite generators. -/]
+from a `FreeAddGroup` on finitely many generators. -/]
 theorem Group.fg_iff_exists_freeGroup_hom_surjective :
     Group.FG G ↔ ∃ (S : Set G) (_ : S.Finite) (φ : FreeGroup S →* G), Function.Surjective φ := by
   refine ⟨fun ⟨S, hS⟩ ↦ ⟨S, S.finite_toSet, FreeGroup.lift Subtype.val, ?_⟩, ?_⟩

--- a/Mathlib/GroupTheory/Finiteness.lean
+++ b/Mathlib/GroupTheory/Finiteness.lean
@@ -407,7 +407,7 @@ theorem Group.fg_iff_exists_freeGroup_hom_surjective :
   · rwa [← MonoidHom.range_eq_top, ← FreeGroup.closure_eq_range]
   · rintro ⟨S, hfin : Finite S, φ, hφ⟩
     refine fg_iff.mpr ⟨φ '' Set.range FreeGroup.of, ?_, Set.toFinite _⟩
-    simp [← MonoidHom.map_closure, Subgroup.map_top_of_surjective, hφ]
+    simp [← MonoidHom.map_closure, hφ, FreeGroup.closure_range_of, ← MonoidHom.range_eq_map]
 
 /-- A group is finitely generated if and only if it is finitely generated as a monoid. -/
 @[to_additive /-- An additive group is finitely generated if and only

--- a/Mathlib/GroupTheory/FreeGroup/Basic.lean
+++ b/Mathlib/GroupTheory/FreeGroup/Basic.lean
@@ -717,6 +717,10 @@ theorem range_lift_eq_closure : (lift f).range = Subgroup.closure (Set.range f) 
   rintro _ ⟨a, rfl⟩
   exact ⟨FreeGroup.of a, by simp only [lift_apply_of]⟩
 
+@[to_additive]
+theorem closure_eq_range (s : Set β) : Subgroup.closure s = (lift ((↑) : s → β)).range := by
+  rw [FreeGroup.range_lift_eq_closure, Subtype.range_coe]
+
 /-- The generators of `FreeGroup α` generate `FreeGroup α`. That is, the subgroup closure of the
 set of generators equals `⊤`. -/
 @[to_additive (attr := simp)]


### PR DESCRIPTION
This is equivalent to the formulation that finitely generated groups/monoids are quotients of FreeGroups/Monoids over the same generators, though I think the phrasing as a surjective homomorphism is more useful.


---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include at least one commit authored by each
co-author among the commits in the pull request. If necessary, you may 
create empty commits to indicate co-authorship, using commands like so:

git commit --author="Author Name <author@email.com>" --allow-empty -m "add Author Name as coauthor"

When merging, all the commits will be squashed into a single commit listing all co-authors.

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
