### PR TITLE
[Merged by Bors] - chore(Mathlib/AlgebraicGeometry/Restrict): change openCoverOfISupEqTop to openCoverOfIsOpenCover

### DIFF
--- a/Mathlib/AlgebraicGeometry/IdealSheaf/Subscheme.lean
+++ b/Mathlib/AlgebraicGeometry/IdealSheaf/Subscheme.lean
@@ -477,11 +477,11 @@ def subschemeCover : I.subscheme.AffineOpenCover where
   I₀ := X.affineOpens
   X U := .of <| Γ(X, U) ⧸ I.ideal U
   f U := I.glueData.ι U ≫ I.subschemeIso.inv
-  idx x := (X.openCoverOfISupEqTop _ (iSup_affineOpens_eq_top X)).idx x.1
+  idx x := (X.openCoverOfIsOpenCover _ (iSup_affineOpens_eq_top X)).idx x.1
   covers x := by
-    let U := (X.openCoverOfISupEqTop _ (iSup_affineOpens_eq_top X)).idx x.1
+    let U := (X.openCoverOfIsOpenCover _ (iSup_affineOpens_eq_top X)).idx x.1
     obtain ⟨⟨y, hy : y ∈ U.1⟩, rfl : y = x.1⟩ :=
-      (X.openCoverOfISupEqTop _ (iSup_affineOpens_eq_top X)).covers x.1
+      (X.openCoverOfIsOpenCover _ (iSup_affineOpens_eq_top X)).covers x.1
     exact (I.opensRange_glueData_ι_subschemeIso_inv U).ge hy
 
 @[simp]
@@ -639,7 +639,7 @@ lemma ideal_ker_le_ker_ΓSpecIso_inv_comp :
 
 private noncomputable
 def Hom.toImageAux : X ⟶ f.image :=
-  ((Y.openCoverOfISupEqTop _ (iSup_affineOpens_eq_top Y)).pullbackCover f).glueMorphisms
+  ((Y.openCoverOfIsOpenCover _ (iSup_affineOpens_eq_top Y)).pullbackCover f).glueMorphisms
     (fun U ↦ (pullback.snd f U.1.ι ≫ U.1.toSpecΓ).liftQuotient _
       (by exact ideal_ker_le_ker_ΓSpecIso_inv_comp f U) ≫ f.ker.subschemeCover.f U) (by
     intro U V
@@ -649,7 +649,7 @@ def Hom.toImageAux : X ⟶ f.image :=
 
 private lemma Hom.toImageAux_spec :
     f.toImageAux ≫ f.imageι = f := by
-  apply ((Y.openCoverOfISupEqTop _ (iSup_affineOpens_eq_top Y)).pullbackCover f).hom_ext
+  apply ((Y.openCoverOfIsOpenCover _ (iSup_affineOpens_eq_top Y)).pullbackCover f).hom_ext
   intro U
   simp only [Hom.toImageAux, Cover.ι_glueMorphisms_assoc]
   simp [IdealSheafData.glueDataObjι, Scheme.Hom.liftQuotient_comp_assoc, pullback.condition]

--- a/Mathlib/AlgebraicGeometry/Morphisms/Basic.lean
+++ b/Mathlib/AlgebraicGeometry/Morphisms/Basic.lean
@@ -155,7 +155,7 @@ theorem restrict (hf : P f) (U : Y.Opens) : P (f ∣_ U) :=
 lemma of_iSup_eq_top {ι} (U : ι → Y.Opens) (hU : iSup U = ⊤)
     (H : ∀ i, P (f ∣_ U i)) : P f := by
   refine (IsLocalAtTarget.iff_of_openCover' f
-    (Y.openCoverOfISupEqTop (s := Set.range U) Subtype.val (by ext; simp [← hU]))).mpr fun i ↦ ?_
+    (Y.openCoverOfIsOpenCover (s := Set.range U) Subtype.val (by ext; simp [← hU]))).mpr fun i ↦ ?_
   obtain ⟨_, i, rfl⟩ := i
   refine (P.arrow_mk_iso_iff (morphismRestrictOpensRange f _)).mp ?_
   change P (f ∣_ (U i).ι.opensRange)
@@ -264,7 +264,7 @@ instance respectsLeft_isOpenImmersion {P : MorphismProperty Scheme}
 lemma of_iSup_eq_top {ι} (U : ι → X.Opens) (hU : iSup U = ⊤)
     (H : ∀ i, P ((U i).ι ≫ f)) : P f := by
   refine (iff_of_openCover' f
-    (X.openCoverOfISupEqTop (s := Set.range U) Subtype.val (by ext; simp [← hU]))).mpr fun i ↦ ?_
+    (X.openCoverOfIsOpenCover (s := Set.range U) Subtype.val (by ext; simp [← hU]))).mpr fun i ↦ ?_
   obtain ⟨_, i, rfl⟩ := i
   exact H i
 
@@ -587,7 +587,7 @@ instance (priority := 900) : IsLocalAtTarget P := by
     rw [Q.arrow_mk_iso_iff (morphismRestrictRestrict f _ _)]
     exact H ⟨_, V.2.image_of_isOpenImmersion (Y.ofRestrict _)⟩
   · rintro X Y f ι U hU H
-    let 𝒰 := Y.openCoverOfISupEqTop U hU
+    let 𝒰 := Y.openCoverOfIsOpenCover U hU
     apply of_openCover 𝒰.affineRefinement.openCover
     rintro ⟨i, j⟩
     have : P (𝒰.pullbackHom f i) := by

--- a/Mathlib/AlgebraicGeometry/Morphisms/Constructors.lean
+++ b/Mathlib/AlgebraicGeometry/Morphisms/Constructors.lean
@@ -129,7 +129,8 @@ instance HasAffineProperty.diagonal_affineProperty_isLocal
       ((diagonal_iff (targetAffineLocally Q)).mp hf)
   of_basicOpenCover {X Y} _ f s hs hs' := by
     refine (diagonal_iff (targetAffineLocally Q)).mpr ?_
-    let 𝒰 := Y.openCoverOfISupEqTop _ (((isAffineOpen_top Y).basicOpen_union_eq_self_iff _).mpr hs)
+    let 𝒰 := Y.openCoverOfIsOpenCover _
+      (((isAffineOpen_top Y).basicOpen_union_eq_self_iff _).mpr hs)
     have (i : _) : IsAffine (𝒰.X i) := (isAffineOpen_top Y).basicOpen i.1
     refine diagonal_of_openCover_diagonal (targetAffineLocally Q) f 𝒰 ?_
     intro i

--- a/Mathlib/AlgebraicGeometry/Morphisms/RingHomProperties.lean
+++ b/Mathlib/AlgebraicGeometry/Morphisms/RingHomProperties.lean
@@ -348,8 +348,8 @@ theorem of_iSup_eq_top [IsAffine Y] {ι : Type*}
     (U : ι → X.affineOpens) (hU : ⨆ i, (U i : Opens X) = ⊤)
     (H : ∀ i, Q (f.appLE ⊤ (U i).1 le_top).hom) :
     P f := by
-  have (i : _) : IsAffine ((X.openCoverOfISupEqTop _ hU).X i) := (U i).2
-  refine of_source_openCover (X.openCoverOfISupEqTop _ hU) fun i ↦ ?_
+  have (i : _) : IsAffine ((X.openCoverOfIsOpenCover _ hU).X i) := (U i).2
+  refine of_source_openCover (X.openCoverOfIsOpenCover _ hU) fun i ↦ ?_
   simpa [Scheme.Hom.app_eq_appLE] using (f.appLE_congr _ rfl (by simp) (fun f => Q f.hom)).mp (H i)
 
 theorem iff_of_iSup_eq_top [IsAffine Y] {ι : Type*}

--- a/Mathlib/AlgebraicGeometry/ProjectiveSpectrum/Basic.lean
+++ b/Mathlib/AlgebraicGeometry/ProjectiveSpectrum/Basic.lean
@@ -316,7 +316,7 @@ open TopologicalSpace.Opens in
 /-- Given a family of homogeneous elements `f` of positive degree that spans the irrelevant ideal,
 `Spec (A_f)₀ ⟶ Proj A` forms an affine open cover of `Proj A`. -/
 noncomputable
-def openCoverOfISupEqTop {ι : Type*} (f : ι → A) {m : ι → ℕ}
+def openCoverOfIsOpenCover {ι : Type*} (f : ι → A) {m : ι → ℕ}
     (f_deg : ∀ i, f i ∈ 𝒜 (m i)) (hm : ∀ i, 0 < m i)
     (hf : (HomogeneousIdeal.irrelevant 𝒜).toIdeal ≤ Ideal.span (Set.range f)) :
     (Proj 𝒜).AffineOpenCover where
@@ -332,7 +332,7 @@ def openCoverOfISupEqTop {ι : Type*} (f : ι → A) {m : ι → ℕ}
 /-- `Proj A` is covered by `Spec (A_f)₀` for all homogeneous elements of positive degree. -/
 noncomputable
 def affineOpenCover : (Proj 𝒜).AffineOpenCover :=
-  openCoverOfISupEqTop 𝒜 (ι := Σ i : PNat, 𝒜 i) (m := fun i ↦ i.1) (fun i ↦ i.2) (fun i ↦ i.2.2)
+  openCoverOfIsOpenCover 𝒜 (ι := Σ i : PNat, 𝒜 i) (m := fun i ↦ i.1) (fun i ↦ i.2) (fun i ↦ i.2.2)
     (fun i ↦ i.1.2) <| by
   classical
   intro z hz
@@ -408,7 +408,7 @@ variable (f : A →+* Γ(X, ⊤)) (hf : (HomogeneousIdeal.irrelevant 𝒜).toIde
 irrelevant ideal under `f` generates the whole ring, the set of `D(f(r))` for homogeneous `r`
 of positive degree forms an open cover on `X`. -/
 def openCoverOfMapIrrelevantEqTop : X.OpenCover :=
-  X.openCoverOfISupEqTop (fun ir : Σ' i r, 0 < i ∧ r ∈ 𝒜 i ↦
+  X.openCoverOfIsOpenCover (fun ir : Σ' i r, 0 < i ∧ r ∈ 𝒜 i ↦
     X.basicOpen (f ir.2.1)) (by
     classical
     have H : Ideal.span (Set.range fun x : Σ' i r, 0 < i ∧ r ∈ 𝒜 i ↦ x.2.1) =
@@ -458,7 +458,7 @@ lemma fromOfGlobalSections_preimage_basicOpen {r : A} {n : ℕ} (hn : 0 < n) (hr
     obtain ⟨i, x, rfl⟩ := (openCoverOfMapIrrelevantEqTop 𝒜 f hf).exists_eq x
     simp only [TopologicalSpace.Opens.map_coe, Set.mem_preimage, SetLike.mem_coe,
       ← Scheme.comp_base_apply, fromOfGlobalSections, Scheme.Cover.ι_glueMorphisms] at hx
-    simp only [openCoverOfMapIrrelevantEqTop, Scheme.openCoverOfISupEqTop_X,
+    simp only [openCoverOfMapIrrelevantEqTop, Scheme.openCoverOfIsOpenCover_X,
       toBasicOpenOfGlobalSections, Scheme.isoOfEq_inv, Category.assoc, basicOpenIsoSpec_inv_ι] at hx
     simp only [Scheme.comp_coeBase, Scheme.homOfLE_base, homOfLE_leOfHom, TopCat.hom_comp,
       ContinuousMap.comp_assoc, ContinuousMap.comp_apply, morphismRestrict_base,
@@ -510,8 +510,8 @@ lemma fromOfGlobalSections_toSpecZero
   simp only [fromOfGlobalSections, toBasicOpenOfGlobalSections, CommRingCat.ofHom_comp,
     Category.assoc, Scheme.Cover.ι_glueMorphisms_assoc, basicOpenIsoSpec_inv_ι_assoc,
     awayι_toSpecZero, Iso.inv_comp_eq]
-  simp only [openCoverOfMapIrrelevantEqTop, Scheme.openCoverOfISupEqTop_X,
-    Scheme.openCoverOfISupEqTop_f, Scheme.isoOfEq_hom_ι_assoc, ← morphismRestrict_ι_assoc]
+  simp only [openCoverOfMapIrrelevantEqTop, Scheme.openCoverOfIsOpenCover_X,
+    Scheme.openCoverOfIsOpenCover_f, Scheme.isoOfEq_hom_ι_assoc, ← morphismRestrict_ι_assoc]
   congr 1
   simp only [basicOpenIsoSpecAway, ← CommRingCat.ofHom_comp, ← Spec.map_comp, ← Iso.eq_inv_comp,
     IsOpenImmersion.isoOfRangeEq_inv_fac_assoc, ← HomogeneousLocalization.algebraMap_eq]

--- a/Mathlib/AlgebraicGeometry/ProjectiveSpectrum/Proper.lean
+++ b/Mathlib/AlgebraicGeometry/ProjectiveSpectrum/Proper.lean
@@ -85,8 +85,8 @@ instance isSeparated : IsSeparated (toSpecZero 𝒜) := by
         ((affineOpenCover 𝒜).f j ≫ toSpecZero 𝒜) ≅
         Spec(TensorProduct (𝒜 0) (Away 𝒜 i.2) (Away 𝒜 j.2)) := by
     refine pullback.congrHom ?_ ?_ ≪≫ pullbackSpecIso (𝒜 0) (Away 𝒜 i.2) (Away 𝒜 j.2)
-    · simp [affineOpenCover, openCoverOfISupEqTop, awayι_toSpecZero]; rfl
-    · simp [affineOpenCover, openCoverOfISupEqTop, awayι_toSpecZero]; rfl
+    · simp [affineOpenCover, openCoverOfIsOpenCover, awayι_toSpecZero]; rfl
+    · simp [affineOpenCover, openCoverOfIsOpenCover, awayι_toSpecZero]; rfl
   let e₂ : pullback ((affineOpenCover 𝒜).f i) ((affineOpenCover 𝒜).f j) ≅
         Spec(Away 𝒜 (i.2 * j.2)) :=
     pullbackAwayιIso 𝒜 _ _ _ _ rfl

--- a/Mathlib/AlgebraicGeometry/Restrict.lean
+++ b/Mathlib/AlgebraicGeometry/Restrict.lean
@@ -163,7 +163,7 @@ end Scheme.Opens
 
 /-- If `U` is a family of open sets that covers `X`, then `X.restrict U` forms an `X.open_cover`. -/
 @[simps! I₀ X f]
-def Scheme.openCoverOfIsOpenCover {s : Type*} (X : Scheme.{u}) (U : s → X.Opens)
+noncomputable def Scheme.openCoverOfIsOpenCover {s : Type*} (X : Scheme.{u}) (U : s → X.Opens)
     (hU : TopologicalSpace.IsOpenCover U) : X.OpenCover where
   I₀ := s
   X i := U i
@@ -175,6 +175,9 @@ def Scheme.openCoverOfIsOpenCover {s : Type*} (X : Scheme.{u}) (U : s → X.Open
     erw [Subtype.range_coe]
     have : x ∈ ⨆ i, U i := hU.symm ▸ show x ∈ (⊤ : X.Opens) by trivial
     exact (Opens.mem_iSup.mp this).choose_spec
+
+@[deprecated (since := "2025-09-30")]
+alias Scheme.openCoverOfISupEqTop := Scheme.openCoverOfIsOpenCover
 
 /-- The open sets of an open subscheme corresponds to the open sets containing in the subset. -/
 @[simps!]

--- a/Mathlib/AlgebraicGeometry/Restrict.lean
+++ b/Mathlib/AlgebraicGeometry/Restrict.lean
@@ -163,7 +163,7 @@ end Scheme.Opens
 
 /-- If `U` is a family of open sets that covers `X`, then `X.restrict U` forms an `X.open_cover`. -/
 @[simps! I₀ X f]
-noncomputable def Scheme.openCoverOfIsOpenCover {s : Type*} (X : Scheme.{u}) (U : s → X.Opens)
+def Scheme.openCoverOfIsOpenCover {s : Type*} (X : Scheme.{u}) (U : s → X.Opens)
     (hU : TopologicalSpace.IsOpenCover U) : X.OpenCover where
   I₀ := s
   X i := U i
@@ -177,7 +177,7 @@ noncomputable def Scheme.openCoverOfIsOpenCover {s : Type*} (X : Scheme.{u}) (U 
     exact (Opens.mem_iSup.mp this).choose_spec
 
 @[deprecated (since := "2025-09-30")]
-alias Scheme.openCoverOfISupEqTop := Scheme.openCoverOfIsOpenCover
+noncomputable alias Scheme.openCoverOfISupEqTop := Scheme.openCoverOfIsOpenCover
 
 /-- The open sets of an open subscheme corresponds to the open sets containing in the subset. -/
 @[simps!]

--- a/Mathlib/AlgebraicGeometry/Restrict.lean
+++ b/Mathlib/AlgebraicGeometry/Restrict.lean
@@ -163,7 +163,7 @@ end Scheme.Opens
 
 /-- If `U` is a family of open sets that covers `X`, then `X.restrict U` forms an `X.open_cover`. -/
 @[simps! I₀ X f]
-def Scheme.openCoverOfISupEqTop {s : Type*} (X : Scheme.{u}) (U : s → X.Opens)
+def Scheme.openCoverOfIsOpenCover {s : Type*} (X : Scheme.{u}) (U : s → X.Opens)
     (hU : TopologicalSpace.IsOpenCover U) : X.OpenCover where
   I₀ := s
   X i := U i

--- a/Mathlib/AlgebraicGeometry/Restrict.lean
+++ b/Mathlib/AlgebraicGeometry/Restrict.lean
@@ -164,7 +164,7 @@ end Scheme.Opens
 /-- If `U` is a family of open sets that covers `X`, then `X.restrict U` forms an `X.open_cover`. -/
 @[simps! I₀ X f]
 def Scheme.openCoverOfISupEqTop {s : Type*} (X : Scheme.{u}) (U : s → X.Opens)
-    (hU : ⨆ i, U i = ⊤) : X.OpenCover where
+    (hU : TopologicalSpace.IsOpenCover U) : X.OpenCover where
   I₀ := s
   X i := U i
   f i := (U i).ι
@@ -759,16 +759,6 @@ noncomputable def arrowResLEAppIso (f : X ⟶ Y) (U : Y.Opens) (V : X.Opens) (e 
   rw [Scheme.Hom.appTop, ← Scheme.Hom.appLE_eq_app, Scheme.Hom.resLE_appLE, Scheme.Hom.appLE_map]
 
 end MorphismRestrict
-
-/-- The open cover of a scheme `X` from an open cover of the underlying topological space. -/
-def openCoverOfIsOpenCover {X : Scheme.{u}} {ι : Type v} (U : ι → X.Opens)
-    (hU : TopologicalSpace.IsOpenCover U) : X.OpenCover where
-  I₀ := ι
-  X x := (U x).toScheme
-  f x := (U x).ι
-  idx x := (hU.exists_mem x).choose
-  covers x := Scheme.Opens.range_ι _ ▸ (hU.exists_mem x).choose_spec
-  map_prop := inferInstance
 
 /-- The restriction of an open cover to an open subset. -/
 @[simps! I₀ X f]

--- a/Mathlib/AlgebraicGeometry/Restrict.lean
+++ b/Mathlib/AlgebraicGeometry/Restrict.lean
@@ -760,6 +760,16 @@ noncomputable def arrowResLEAppIso (f : X ⟶ Y) (U : Y.Opens) (V : X.Opens) (e 
 
 end MorphismRestrict
 
+/-- The open cover of a scheme `X` from an open cover of the underlying topological space. -/
+def openCoverOfIsOpenCover {X : Scheme.{u}} {ι : Type v} (U : ι → X.Opens)
+    (hU : TopologicalSpace.IsOpenCover U) : X.OpenCover where
+  I₀ := ι
+  X x := (U x).toScheme
+  f x := (U x).ι
+  idx x := (hU.exists_mem x).choose
+  covers x := Scheme.Opens.range_ι _ ▸ (hU.exists_mem x).choose_spec
+  map_prop := inferInstance
+
 /-- The restriction of an open cover to an open subset. -/
 @[simps! I₀ X f]
 noncomputable


### PR DESCRIPTION
This PR changes [AlgebraicGeometry.Scheme.openCoverOfISupEqTop](https://leanprover-community.github.io/mathlib4_docs/Mathlib/AlgebraicGeometry/Restrict.html#AlgebraicGeometry.Scheme.openCoverOfISupEqTop) into `AlgebraicGeometry.Scheme.openCoverOfISupEqTop`, which now takes `TopologicalSpace.IsOpenCover`.