### PR TITLE
[Merged by Bors] - chore(CategoryTheory/Limits): generalise from `Over` to `CostructuredArrow`

### DIFF
--- a/Mathlib/CategoryTheory/Limits/Constructions/Over/Connected.lean
+++ b/Mathlib/CategoryTheory/Limits/Constructions/Over/Connected.lean
@@ -11,11 +11,12 @@ import Mathlib.CategoryTheory.Filtered.Final
 /-!
 # Connected limits in the over category
 
-Shows that the forgetful functor `Over B ⥤ C` creates and preserves connected limits,
-the latter without assuming that `C` has any limits.
-In particular, `Over B` has any connected limit which `C` has.
--/
+We show that the projection `CostructuredArrow K B ⥤ C` creates and preserves
+connected limits, without assuming that `C` has any limits.
+In particular, `CostructuredArrow K B` has any connected limit which `C` has.
 
+From this we deduce the corresponding results for the over category.
+-/
 
 universe v' u' v u
 
@@ -25,45 +26,51 @@ noncomputable section
 open CategoryTheory CategoryTheory.Limits
 
 variable {J : Type u'} [Category.{v'} J]
-variable {C : Type u} [Category.{v} C]
+variable {C : Type u} [Category.{v} C] {D : Type*} [Category D] {K : C ⥤ D}
 variable {X : C}
 
-namespace CategoryTheory.Over
+namespace CategoryTheory.CostructuredArrow
 
 namespace CreatesConnected
 
-/-- (Impl) Given a diagram in the over category, produce a natural transformation from the
-diagram legs to the specific object.
--/
-def natTransInOver {B : C} (F : J ⥤ Over B) :
-    F ⋙ forget B ⟶ (CategoryTheory.Functor.const J).obj B where
-  app j := (F.obj j).hom
-
-/-- (Impl) Given a cone in the base category, raise it to a cone in the over category. Note this is
-where the connected assumption is used.
+/-- (Implementation) Given a diagram in `CostructuredArrow K B`, produce a natural transformation
+from the diagram legs to the specific object.
 -/
 @[simps]
-def raiseCone [IsConnected J] {B : C} {F : J ⥤ Over B} (c : Cone (F ⋙ forget B)) :
+def natTransInCostructuredArrow {B : D} (F : J ⥤ CostructuredArrow K B) :
+    F ⋙ CostructuredArrow.proj K B ⋙ K ⟶ (CategoryTheory.Functor.const J).obj B where
+  app j := (F.obj j).hom
+
+/-- (Implementation) Given a cone in the base category, raise it to a cone in
+`CostructuredArrow K B`. Note this is where the connected assumption is used.
+-/
+@[simps]
+def raiseCone [IsConnected J] {B : D} {F : J ⥤ CostructuredArrow K B}
+    (c : Cone (F ⋙ CostructuredArrow.proj K B)) :
     Cone F where
-  pt := Over.mk (c.π.app (Classical.arbitrary J) ≫ (F.obj (Classical.arbitrary J)).hom)
-  π :=
-    { app := fun j =>
-        Over.homMk (c.π.app j) (nat_trans_from_is_connected (c.π ≫ natTransInOver F) j _)
-      naturality := by
-        intro X Y f
-        apply CommaMorphism.ext
-        · simpa using (c.w f).symm
-        · simp }
+  pt := CostructuredArrow.mk
+    (K.map (c.π.app (Classical.arbitrary J)) ≫ (F.obj (Classical.arbitrary J)).hom)
+  π.app j := CostructuredArrow.homMk (c.π.app j) <| by
+    let z : (Functor.const J).obj (K.obj c.pt) ⟶ _ :=
+      (CategoryTheory.Functor.constComp J c.pt K).inv ≫ Functor.whiskerRight c.π K ≫
+        natTransInCostructuredArrow F
+    convert (nat_trans_from_is_connected z j (Classical.arbitrary J)) <;> simp [z]
+  π.naturality X Y f := by
+    apply CommaMorphism.ext
+    · simpa using (c.w f).symm
+    · simp
 
-theorem raised_cone_lowers_to_original [IsConnected J] {B : C} {F : J ⥤ Over B}
-    (c : Cone (F ⋙ forget B)) :
-    (forget B).mapCone (raiseCone c) = c := by cat_disch
+theorem mapCone_raiseCone [IsConnected J] {B : D} {F : J ⥤ CostructuredArrow K B}
+    (c : Cone (F ⋙ CostructuredArrow.proj K B)) :
+    (CostructuredArrow.proj K B).mapCone (raiseCone c) = c := by cat_disch
 
-/-- (Impl) Show that the raised cone is a limit. -/
-def raisedConeIsLimit [IsConnected J] {B : C} {F : J ⥤ Over B} {c : Cone (F ⋙ forget B)}
+/-- (Implementation) Show that the raised cone is a limit. -/
+def isLimitRaiseCone [IsConnected J] {B : D} {F : J ⥤ CostructuredArrow K B}
+    {c : Cone (F ⋙ CostructuredArrow.proj K B)}
     (t : IsLimit c) : IsLimit (raiseCone c) where
   lift s :=
-    Over.homMk (t.lift ((forget B).mapCone s))
+    CostructuredArrow.homMk (t.lift ((CostructuredArrow.proj K B).mapCone s)) <| by
+      simp [← Functor.map_comp_assoc]
   uniq s m K := by
     ext1
     apply t.hom_ext
@@ -72,32 +79,55 @@ def raisedConeIsLimit [IsConnected J] {B : C} {F : J ⥤ Over B} {c : Cone (F �
 
 end CreatesConnected
 
-/-- The forgetful functor from the over category creates any connected limit. -/
-instance forgetCreatesConnectedLimits [IsConnected J] {B : C} :
-    CreatesLimitsOfShape J (forget B) where
+/-- The projection from `CostructuredArrow K B` to `C` creates any connected limit. -/
+instance [IsConnected J] {B : D} : CreatesLimitsOfShape J (CostructuredArrow.proj K B) where
   CreatesLimit :=
     createsLimitOfReflectsIso fun c t =>
       { liftedCone := CreatesConnected.raiseCone c
-        validLift := eqToIso (CreatesConnected.raised_cone_lowers_to_original c)
-        makesLimit := CreatesConnected.raisedConeIsLimit t }
+        validLift := eqToIso (CreatesConnected.mapCone_raiseCone c)
+        makesLimit := CreatesConnected.isLimitRaiseCone t }
 
-/-- The forgetful functor from the over category preserves any connected limit. -/
-instance forgetPreservesConnectedLimits [IsConnected J] {B : C} :
-    PreservesLimitsOfShape J (forget B) where
-  preservesLimit := {
-    preserves hc := ⟨{
-      lift s := (forget B).map (hc.lift (CreatesConnected.raiseCone s))
-      fac _ _ := by
-        rw [Functor.mapCone_π_app, ← Functor.map_comp, hc.fac,
-          CreatesConnected.raiseCone_π_app, forget_map, homMk_left _ _]
-      uniq s m fac :=
-        congrArg (forget B).map (hc.uniq (CreatesConnected.raiseCone s)
-          (Over.homMk m (by simp [← fac])) fun j => (forget B).map_injective (fac j))
-    }⟩
-  }
+/-- The forgetful functor from `CostructuredArrow K B` preserves any connected limit. -/
+instance [IsConnected J] {B : D} : PreservesLimitsOfShape J (CostructuredArrow.proj K B) where
+  preservesLimit.preserves hc := ⟨{
+    lift s := (CostructuredArrow.proj K B).map (hc.lift (CreatesConnected.raiseCone s))
+    fac _ _ := by
+      rw [Functor.mapCone_π_app, ← Functor.map_comp, hc.fac,
+        CreatesConnected.raiseCone_π_app, CostructuredArrow.proj_map,
+        CostructuredArrow.homMk_left _ _]
+    uniq s m fac :=
+      congrArg (CostructuredArrow.proj K B).map (hc.uniq (CreatesConnected.raiseCone s)
+        (CostructuredArrow.homMk m (by simp [← fac])) fun j =>
+          (CostructuredArrow.proj K B).map_injective (fac j))
+  }⟩
 
 /-- The over category has any connected limit which the original category has. -/
-instance has_connected_limits {B : C} [IsConnected J] [HasLimitsOfShape J C] :
+instance hasLimitsOfShape_of_isConnected {B : D} [IsConnected J] [HasLimitsOfShape J C] :
+    HasLimitsOfShape J (CostructuredArrow K B) where
+  has_limit F := hasLimit_of_created F (CostructuredArrow.proj K B)
+
+end CostructuredArrow
+
+namespace Over
+
+/-- The forgetful functor from the over category creates any connected limit. -/
+instance createsLimitsOfShapeForgetOfIsConnected [IsConnected J] {B : C} :
+    CreatesLimitsOfShape J (forget B) :=
+  inferInstanceAs <| CreatesLimitsOfShape J (CostructuredArrow.proj _ _)
+
+@[deprecated (since := "2025-09-29")]
+noncomputable alias forgetCreatesConnectedLimits := createsLimitsOfShapeForgetOfIsConnected
+
+/-- The forgetful functor from the over category preserves any connected limit. -/
+instance preservesLimitsOfShape_forget_of_isConnected [IsConnected J] {B : C} :
+    PreservesLimitsOfShape J (forget B) :=
+  inferInstanceAs <| PreservesLimitsOfShape J (CostructuredArrow.proj _ _)
+
+@[deprecated (since := "2025-09-29")]
+alias forgetPreservesConnectedLimits := preservesLimitsOfShape_forget_of_isConnected
+
+/-- The over category has any connected limit which the original category has. -/
+instance hasLimitsOfShape_of_isConnected {B : C} [IsConnected J] [HasLimitsOfShape J C] :
     HasLimitsOfShape J (Over B) where
   has_limit F := hasLimit_of_created F (forget B)
 


### PR DESCRIPTION
We generalise the limit results for connected categories from `Over` to `CostructuredArrow`. Also the naming is adapted to the naming convention.

From Proetale.

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include at least one commit authored by each
co-author among the commits in the pull request. If necessary, you may 
create empty commits to indicate co-authorship, using commands like so:

git commit --author="Author Name <author@email.com>" --allow-empty -m "add Author Name as coauthor"

When merging, all the commits will be squashed into a single commit listing all co-authors.

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
