### PR TITLE
test: remove deprecated declarations in Archive and Counterexamples

### DIFF
--- a/.github/workflows/remove_deprecated_decls.yml
+++ b/.github/workflows/remove_deprecated_decls.yml
@@ -1,22 +1,22 @@
 name: Remove outdated deprecated declarations
 
 on:
-  #push:
-  #  branches:
-  #  - remove_deprecations_linter_dev_upstream
-  schedule:
-  - cron: "5 4 * * 1" # At 04:05, on Monday
+  push:
+    branches:
+    - upstream/adomani/test_deprecated_removals
+  #schedule:
+  #- cron: "5 4 * * 1" # At 04:05, on Monday
   workflow_dispatch:
     inputs:
       raw_from_date:
         description: 'starting date for deprecations to remove: YYYY-MM-DD or valid input for date -d, like "3 months ago"'
         required: false
-        default: '2025-01-01'
+        default: '2025-05-23'
         type: string
       raw_to_date:
         description: 'ending date for deprecations to remove: YYYY-MM-DD or valid input for date -d, like "2 weeks ago"'
         required: false
-        default: ''
+        default: '2025-05-23'
         type: string
       dry_run:
         description: 'if true, only log the outdated declarations, do not remove them and open a PR'

--- a/.github/workflows/remove_deprecated_decls.yml
+++ b/.github/workflows/remove_deprecated_decls.yml
@@ -11,12 +11,12 @@ on:
       raw_from_date:
         description: 'starting date for deprecations to remove: YYYY-MM-DD or valid input for date -d, like "3 months ago"'
         required: false
-        default: '2025-05-23'
+        default: ''
         type: string
       raw_to_date:
         description: 'ending date for deprecations to remove: YYYY-MM-DD or valid input for date -d, like "2 weeks ago"'
         required: false
-        default: '2025-05-23'
+        default: ''
         type: string
       dry_run:
         description: 'if true, only log the outdated declarations, do not remove them and open a PR'
@@ -34,8 +34,8 @@ jobs:
       id: process_dates
       shell: bash
       env:
-        RAW_FROM_DATE: ${{ inputs.raw_from_date }}
-        RAW_TO_DATE: ${{ inputs.raw_to_date }}
+        RAW_FROM_DATE: 2025-05-23 #${{ inputs.raw_from_date }}
+        RAW_TO_DATE: 2025-05-23 #${{ inputs.raw_to_date }}
       run: |
         set -euo pipefail
 

--- a/.github/workflows/remove_deprecated_decls.yml
+++ b/.github/workflows/remove_deprecated_decls.yml
@@ -34,8 +34,8 @@ jobs:
       id: process_dates
       shell: bash
       env:
-        RAW_FROM_DATE: 2025-05-23 # ${{ inputs.raw_from_date }}
-        RAW_TO_DATE: 2025-05-23 # ${{ inputs.raw_to_date }}
+        RAW_FROM_DATE: '2025-05-23' # ${{ inputs.raw_from_date }}
+        RAW_TO_DATE: '2025-05-23' # ${{ inputs.raw_to_date }}
       run: |
         set -euo pipefail
 

--- a/.github/workflows/remove_deprecated_decls.yml
+++ b/.github/workflows/remove_deprecated_decls.yml
@@ -1,0 +1,213 @@
+name: Remove outdated deprecated declarations
+
+on:
+  #push:
+  #  branches:
+  #  - remove_deprecations_linter_dev_upstream
+  schedule:
+  - cron: "5 4 * * 1" # At 04:05, on Monday
+  workflow_dispatch:
+    inputs:
+      raw_from_date:
+        description: 'starting date for deprecations to remove: YYYY-MM-DD or valid input for date -d, like "3 months ago"'
+        required: false
+        default: '2025-01-01'
+        type: string
+      raw_to_date:
+        description: 'ending date for deprecations to remove: YYYY-MM-DD or valid input for date -d, like "2 weeks ago"'
+        required: false
+        default: ''
+        type: string
+      dry_run:
+        description: 'if true, only log the outdated declarations, do not remove them and open a PR'
+        required: false
+        default: false
+        type: boolean
+
+jobs:
+  build:
+    name: Remove outdated deprecated declarations
+    runs-on: ubuntu-latest
+    if: github.repository == 'leanprover-community/mathlib4'
+    steps:
+    - name: Process dates
+      id: process_dates
+      shell: bash
+      env:
+        RAW_FROM_DATE: ${{ inputs.raw_from_date }}
+        RAW_TO_DATE: ${{ inputs.raw_to_date }}
+      run: |
+        set -euo pipefail
+
+        # Function to validate YYYY-MM-DD format
+        validate_iso_date() {
+          local date_str="$1"
+          if [[ "$date_str" =~ ^[0-9]{4}-[0-9]{2}-[0-9]{2}$ ]]; then
+            # Validate it's a real date by parsing it
+            if date -d "$date_str" >/dev/null 2>&1; then
+              echo "$date_str"
+              return 0
+            fi
+          fi
+          return 1
+        }
+
+        # Function to safely parse date using `date -d`
+        parse_date_safely() {
+          local input="$1"
+
+          # Basic shell injection protection - reject inputs with dangerous characters
+          if [[ "$input" =~ [\;\&\|\`\$\(\)] ]]; then
+            echo "Error: Invalid characters in date input: $input" >&2
+            return 1
+          fi
+
+          # Try to parse with date -d and extract YYYY-MM-DD format
+          local parsed_date
+          if parsed_date=$(date -d "$input" +%Y-%m-%d 2>/dev/null); then
+            echo "$parsed_date"
+            return 0
+          else
+            echo "Error: Unable to parse date: $input" >&2
+            return 1
+          fi
+        }
+
+        # Process from_date
+        if [[ -n "${RAW_FROM_DATE:-}" ]]; then
+          echo "Processing raw_from_date: '${RAW_FROM_DATE}'"
+
+          if from_date=$(validate_iso_date "${RAW_FROM_DATE}"); then
+            echo "Valid ISO date format detected"
+          else
+            echo "Not a valid ISO date, trying date parser..."
+            from_date=$(parse_date_safely "${RAW_FROM_DATE}")
+          fi
+        else
+          echo "No raw_from_date provided, using 5 years ago"
+          from_date=$(date -d '5 years ago' +%Y-%m-%d)
+        fi
+
+        # Process to_date
+        if [[ -n "${RAW_TO_DATE:-}" ]]; then
+          echo "Processing raw_to_date: '${RAW_TO_DATE}'"
+
+          if to_date=$(validate_iso_date "${RAW_TO_DATE}"); then
+            echo "Valid ISO date format detected"
+          else
+            echo "Not a valid ISO date, trying date parser..."
+            to_date=$(parse_date_safely "${RAW_TO_DATE}")
+          fi
+        else
+          echo "No raw_to_date provided, using 6 months ago"
+          to_date=$(date -d '6 months ago' +%Y-%m-%d)
+        fi
+
+        echo "Parsed dates - from: $from_date, to: $to_date"
+
+        # Validate date range - from_date should not be after to_date
+        if [[ "$from_date" > "$to_date" ]]; then
+          echo "Error: from_date ($from_date) cannot be after to_date ($to_date)" >&2
+          exit 1
+        fi
+
+        # Set outputs
+        echo "from_date=$from_date" >> "$GITHUB_OUTPUT"
+        echo "to_date=$to_date" >> "$GITHUB_OUTPUT"
+
+    - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+
+    - name: Configure Lean
+      uses: leanprover/lean-action@f807b338d95de7813c5c50d018f1c23c9b93b4ec # 2025-04-24
+      with:
+        auto-config: false
+        use-github-cache: false
+        use-mathlib-cache: false
+
+    - name: Retrieve caches for unmodified repositories
+      run: |
+        # Retrieve the cache for the unmodified repository
+        # show the current pwd:
+        printf $'Current directory is: %s\n' "$(pwd)"
+        printf $'::group::Running lake env\n'
+        lake env | tr ':' '\n'
+        echo "::endgroup::"
+        for repo in Mathlib Archive Counterexamples; do
+          echo "::group::Retrieving the cache for ${repo}"
+          lake exe cache get "$repo" || true
+          echo "::endgroup::"
+        done
+
+    - name: set up deprecated doubles
+      env:
+        OLD_DATE: "${{ steps.process_dates.outputs.from_date }}"
+        NEW_DATE: "${{ steps.process_dates.outputs.to_date }}"
+        DRY_RUN: "${{ toJson(inputs.dry_run) }}"
+      run: |
+        # We create a temporary file importing `Mathlib`, `Archive` and `Counterexamples`
+        # and running `#clear_deprecations` with the expected date-range.
+        tmplean="$(mktemp -p Mathlib --suffix=.lean RMDXXX)"
+        echo "::group::Creating ${tmplean} file"
+        {
+          for repo in Mathlib Archive Counterexamples; do
+            printf $'import %s\n' "$repo"
+          done
+          REALLY=$([ "$DRY_RUN" = "true" ] && echo "" || echo "really")
+          printf $'#clear_deprecations "%s" "%s" %s\n' "$OLD_DATE" "$NEW_DATE" "$REALLY"
+        } | tee -a "${tmplean}"
+        echo "::endgroup::"
+
+        # This will add the new files, whose names end in `_with_option.lean` and with the
+        # `commandRanges` linter on.  Building these files gives access to the ranges of all
+        # the commands in the files with deprecations to be removed.
+        # These files ending in `_with_option.lean` get erased after they have been build.
+        # If the `really` flag is passed, then the deprecations are removed from the appropriate
+        # files.  Otherwise, they are only logged as an output, but the original files are left
+        # untouched.
+        echo "::group::Building ${tmplean} file -- this may take a while"
+        lake build "${tmplean}"
+        echo "::endgroup::"
+
+        ## We then add the new files to `Mathlib.lean`
+        #if lake exe mk_all; then
+        #  echo "Successfully updated Mathlib.lean"
+        #  # TODO: exit more gracefully, but there is nothing to do, since no files contain
+        #  # deprecated declarations in the specified date range
+        #  exit 1
+        #else
+        #  echo "There are files with deprecated declarations in the specified date range"
+        #  tmpMod="${tmplean%.lean}"
+        #  printf $'Removing line containing %s from Mathlib.lean\n' "${tmpMod/\//.}"
+        #  sed -i "/${tmpMod/\//.}/d" Mathlib.lean
+        #fi
+
+    - name: configure git setup
+      run: |
+        git remote add origin-bot "https://leanprover-community-bot:${{ secrets.UPDATE_NOLINTS_TOKEN }}@github.com/leanprover-community/mathlib4.git"
+        git config user.email "leanprover.community@gmail.com"
+        git config user.name "leanprover-community-bot"
+
+        # By default, github actions overrides the credentials used to access any
+        # github url so that it uses the github-actions[bot] user.  We want to access
+        # github using a different username.
+        git config --unset http.https://github.com/.extraheader
+
+    - name: file a new PR to remove outdated deprecated declarations
+      id: pr
+      run: ./scripts/remove_deprecated_decls_CI.sh "${DEPRECATION_DATE_FROM}" "${DEPRECATION_DATE_TO}"
+      env:
+        DEPLOY_GITHUB_TOKEN: ${{ secrets.UPDATE_NOLINTS_TOKEN }}
+        DEPRECATION_DATE_FROM: ${{ steps.process_dates.outputs.from_date }}
+        DEPRECATION_DATE_TO: ${{ steps.process_dates.outputs.to_date }}
+
+    - name: Send Zulip message
+      #if: false # TODO: change to "steps.pr.outcome == 'success'" once everything is working
+      uses: zulip/github-actions-zulip/send-message@e4c8f27c732ba9bd98ac6be0583096dea82feea5 # v1.0.2
+      with:
+        api-key: ${{ secrets.ZULIP_API_KEY }}
+        email: 'github-mathlib4-bot@leanprover.zulipchat.com'
+        organization-url: 'https://leanprover.zulipchat.com'
+        to: 'nightly-testing'
+        type: 'stream'
+        topic: 'Mathlib `remove outdated deprecated declarations`'
+        content: '${{ steps.pr.outputs.message }}'

--- a/.github/workflows/remove_deprecated_decls.yml
+++ b/.github/workflows/remove_deprecated_decls.yml
@@ -34,8 +34,8 @@ jobs:
       id: process_dates
       shell: bash
       env:
-        RAW_FROM_DATE: 2025-05-23 #${{ inputs.raw_from_date }}
-        RAW_TO_DATE: 2025-05-23 #${{ inputs.raw_to_date }}
+        RAW_FROM_DATE: 2025-05-23 # ${{ inputs.raw_from_date }}
+        RAW_TO_DATE: 2025-05-23 # ${{ inputs.raw_to_date }}
       run: |
         set -euo pipefail
 

--- a/Mathlib.lean
+++ b/Mathlib.lean
@@ -6158,12 +6158,14 @@ import Mathlib.Tactic.LinearCombination
 import Mathlib.Tactic.LinearCombination'
 import Mathlib.Tactic.LinearCombination.Lemmas
 import Mathlib.Tactic.Linter
+import Mathlib.Tactic.Linter.CommandRanges
 import Mathlib.Tactic.Linter.CommandStart
 import Mathlib.Tactic.Linter.DeprecatedModule
 import Mathlib.Tactic.Linter.DeprecatedSyntaxLinter
 import Mathlib.Tactic.Linter.DirectoryDependency
 import Mathlib.Tactic.Linter.DocPrime
 import Mathlib.Tactic.Linter.DocString
+import Mathlib.Tactic.Linter.FindDeprecations
 import Mathlib.Tactic.Linter.FlexibleLinter
 import Mathlib.Tactic.Linter.GlobalAttributeIn
 import Mathlib.Tactic.Linter.HashCommandLinter

--- a/Mathlib/Tactic.lean
+++ b/Mathlib/Tactic.lean
@@ -148,12 +148,14 @@ import Mathlib.Tactic.LinearCombination
 import Mathlib.Tactic.LinearCombination'
 import Mathlib.Tactic.LinearCombination.Lemmas
 import Mathlib.Tactic.Linter
+import Mathlib.Tactic.Linter.CommandRanges
 import Mathlib.Tactic.Linter.CommandStart
 import Mathlib.Tactic.Linter.DeprecatedModule
 import Mathlib.Tactic.Linter.DeprecatedSyntaxLinter
 import Mathlib.Tactic.Linter.DirectoryDependency
 import Mathlib.Tactic.Linter.DocPrime
 import Mathlib.Tactic.Linter.DocString
+import Mathlib.Tactic.Linter.FindDeprecations
 import Mathlib.Tactic.Linter.FlexibleLinter
 import Mathlib.Tactic.Linter.GlobalAttributeIn
 import Mathlib.Tactic.Linter.HashCommandLinter

--- a/Mathlib/Tactic/Linter/CommandRanges.lean
+++ b/Mathlib/Tactic/Linter/CommandRanges.lean
@@ -1,0 +1,61 @@
+/-
+Copyright (c) 2025 Damiano Testa. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Damiano Testa
+-/
+
+import Lean.Elab.Command
+
+/-!
+#  The "commandRanges" linter
+
+The "commandRanges" linter simply logs the `getRange?` and the `getRangeWithTrailing?`
+for each command.
+
+This is useful for the "removeDeprecations" automation, since it helps identifying the exact range
+of each declaration that should be removed.
+
+This linter is strictly tied to the `#clear_deprecations` command in
+`Mathlib/Tactic/Linter/FindDeprecations.lean`.
+-/
+
+open Lean Elab Linter
+
+namespace Mathlib.Linter
+
+/--
+The "commandRanges" linter logs the `getRange?` and the `getRangeWithTrailing?` for each command.
+The format is `[start, end, trailing]`, where
+* `start` is the start of the command,
+* `end` is the end of the command, not including trailing whitespace and comments,
+* `trailing` is the "syntactic end" of the command, so it contains all trailing whitespace and
+  comments.
+
+Thus, assuming that there has been no tampering with positions/synthetic syntax,
+if the current command is followed by another command, then `trailing` for the previous command
+coincides with `start` of the following.
+-/
+register_option linter.commandRanges : Bool := {
+  defValue := false
+  descr := "enable the commandRanges linter"
+}
+
+namespace CommandRanges
+
+@[inherit_doc Mathlib.Linter.linter.commandRanges]
+def commandRangesLinter : Linter where run stx := do
+  unless Linter.getLinterValue linter.commandRanges (← getLinterOptions) do
+    return
+  if Parser.isTerminalCommand stx then
+    return
+  let ranges :=
+    if let some rg := stx.getRange? then #[rg.start, rg.stop] else #[]
+  let ranges : Array String.Pos :=
+    if let some rg := stx.getRangeWithTrailing? then ranges.push rg.stop else ranges
+  logInfo m!"{ranges}"
+
+initialize addLinter commandRangesLinter
+
+end CommandRanges
+
+end Mathlib.Linter

--- a/Mathlib/Tactic/Linter/FindDeprecations.lean
+++ b/Mathlib/Tactic/Linter/FindDeprecations.lean
@@ -32,7 +32,7 @@ For reporting, the script assumes there is no sub-dir of the `repo` dir that con
 `repo` as a substring.
 However, the script should still remove old deprecations correctly even if that happens.
 -/
-def repos : NameSet := .ofArray #[`Mathlib, `Archive, `Counterexamples]
+def repos : NameSet := .ofArray #[`Archive, `Counterexamples]
 
 /--
 The main structure containing the information a deprecated declaration.

--- a/Mathlib/Tactic/Linter/FindDeprecations.lean
+++ b/Mathlib/Tactic/Linter/FindDeprecations.lean
@@ -95,6 +95,8 @@ def getDeprecatedInfo (nm : Name) (verbose? : Bool) :
       -- retrieve the module where the declaration is located
       if let some mod ← findModuleOf? nm
       then
+        unless repos.contains mod.getRoot do
+          return none
         if verbose? then
           logInfo
             s!"In the module '{mod}', the declaration {nm} at {rg.pos}--{rg.endPos} \
@@ -121,6 +123,7 @@ def deprecatedHashMap (oldDate newDate : String) :
   for (nm, _) in (← getEnv).constants.map₁ do
     if let some ⟨modName, decl, rgStart, rgStop, since⟩ ← getDeprecatedInfo nm false
     then
+      dbg_trace modName
       unless repos.contains modName.getRoot do continue
       if !(oldDate ≤ since && since ≤ newDate) then
         continue

--- a/Mathlib/Tactic/Linter/FindDeprecations.lean
+++ b/Mathlib/Tactic/Linter/FindDeprecations.lean
@@ -1,0 +1,297 @@
+/-
+Copyright (c) 2025 Damiano Testa. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Damiano Testa
+-/
+
+import ImportGraph.Imports
+
+/-!
+# The `#clear_deprecations` command
+
+This file defines the `#clear_deprecations date₁ date₂ really` command.
+
+This function is intended for automated use by the `remove_deprecations` automation.
+It removes declarations that have been deprecated in the time range starting from `date₁` and
+ending with `date₂`.
+
+See the doc-string for the command for more information.
+-/
+
+open Lean Elab Command
+
+namespace Mathlib.Tactic
+
+/-- A convenience instance to print a `String.Range` as the corresponding pair of `String.Pos`. -/
+local instance : ToString String.Range where
+  toString | ⟨s, e⟩ => s!"({s}, {e})"
+
+/--
+These are the names of the directories containing all the files that should be inspected.
+For reporting, the script assumes there is no sub-dir of the `repo` dir that contains
+`repo` as a substring.
+However, the script should still remove old deprecations correctly even if that happens.
+-/
+def repos : NameSet := .ofArray #[`Mathlib, `Archive, `Counterexamples]
+
+/--
+The main structure containing the information a deprecated declaration.
+* `module` is the name of the module containing the deprecated declaration;
+* `decl` is the name of the deprecated declaration;
+* `rgStart` is the `Position` where the deprecated declaration starts;
+* `rgStop` is the `Position` where the deprecated declaration ends;
+* `since` is the date when the declaration was deprecated.
+-/
+structure DeprecationInfo where
+  /-- `module` is the name of the module containing the deprecated declaration. -/
+  module : Name
+  /-- `decl` is the name of the deprecated declaration. -/
+  decl : Name
+  /-- `rgStart` is the `Position` where the deprecated declaration starts. -/
+  rgStart : Position
+  /-- `rgStop` is the `Position` where the deprecated declaration ends. -/
+  rgStop : Position
+  /-- `since` is the date when the declaration was deprecated. -/
+  since : String
+
+/--
+`getPosAfterImports fname` parses the imports of `fname` and returns the position just after them.
+
+This position is after all trailing whitespace and comments that may follow the imports of `fname`.
+-/
+def getPosAfterImports (fname : String) : CommandElabM String.Pos := do
+  let file ← IO.FS.readFile fname
+  let fm := file.toFileMap
+  let (_, fileStartPos, _) ← parseImports fm.source (← getFileName)
+  return fm.ofPosition fileStartPos
+
+/--
+`addAfterImports fname s` returns the content of the file `fname`, with the string `s` added
+after the imports of `fname`.
+-/
+def addAfterImports (fname s : String) : CommandElabM String := do
+  let pos ← getPosAfterImports fname
+  let file ← IO.FS.readFile fname
+  let fileSubstring := file.toSubstring
+  return {fileSubstring with stopPos := pos}.toString ++ s ++
+    {fileSubstring with startPos := pos}.toString
+
+/--
+If `nm` is the name of a declaration, then `getDeprecatedInfo nm` returns the
+`DeprecationInfo` data for `nm`.
+Otherwise, it returns `none`.
+
+If the `verbose?` input is `true`, then the command also summarizes what the data is.
+-/
+def getDeprecatedInfo (nm : Name) (verbose? : Bool) :
+    CommandElabM (Option DeprecationInfo) := do
+  let env ← getEnv
+  -- if there is a `since` in the deprecation
+  if let some {since? := some since, ..} := Linter.deprecatedAttr.getParam? env nm
+  then
+    -- retrieve the `range` for the declaration
+    if let some {range := rg, ..} ← findDeclarationRanges? nm
+    then
+      -- retrieve the module where the declaration is located
+      if let some mod ← findModuleOf? nm
+      then
+        if verbose? then
+          logInfo
+            s!"In the module '{mod}', the declaration {nm} at {rg.pos}--{rg.endPos} \
+              is deprecated since {since}"
+        return some { module := mod
+                      decl := nm
+                      rgStart := rg.pos
+                      rgStop := rg.endPos
+                      since := since }
+  return none
+
+/--
+The output is the `HashMap` whose keys are the names of the files containing
+deprecated declarations, and whose values are the arrays of ranges
+corresponding to the deprecated declarations in that file.
+The input `oldDate` and `newDate` are strings of the form "YYYY-MM-DD".
+The output contains all the declarations that were deprecated after `oldDate`
+and before `newDate`.
+-/
+def deprecatedHashMap (oldDate newDate : String) :
+    CommandElabM (Std.HashMap (Name × String) (Array (Name × String.Range))) := do
+  let mut fin := ∅
+  --let searchPath ← getSrcSearchPath
+  for (nm, _) in (← getEnv).constants.map₁ do
+    if let some ⟨modName, decl, rgStart, rgStop, since⟩ ← getDeprecatedInfo nm false
+    then
+      unless repos.contains modName.getRoot do continue
+      if !(oldDate ≤ since && since ≤ newDate) then
+        continue
+      -- Ideally, `lean` would be computed by `← findLean (← getSrcSearchPath) modName`
+      -- However, while this works locally, CI throws the error ` unknown module prefix 'Mathlib'`
+      let lean := (modName.components.foldl (init := "")
+        fun a b => (a.push System.FilePath.pathSeparator) ++ b.toString) ++ ".lean" |>.drop 1
+      --let lean ← findLean searchPath modName
+      let file ← IO.FS.readFile lean
+      let fm := FileMap.ofString file
+      let rg : String.Range := ⟨fm.ofPosition rgStart, fm.ofPosition rgStop⟩
+      fin := fin.alter (modName, lean) fun a =>
+        (a.getD #[]).binInsert (·.2.1 < ·.2.1) (decl, rg)
+  return fin
+
+/--
+`removeRanges file rgs` removes from the string `file` the substrings whose ranges are in the array
+`rgs`.
+
+*Notes*.
+* The command makes the assumption that `rgs` is *sorted*.
+* The command removes all consecutive whitespace following the end of each range.
+-/
+def removeRanges (file : String) (rgs : Array String.Range) : String := Id.run do
+  let mut curr : String.Pos := 0
+  let mut fileSubstring := file.toSubstring
+  let mut tot := ""
+  let last := fileSubstring.stopPos
+  for next in rgs.push ⟨last, last⟩ do
+    if next.start < curr then continue
+    let part := {fileSubstring with stopPos := next.start}.toString
+    tot := tot ++ part
+    curr := next.start
+    fileSubstring := {fileSubstring with startPos := next.stop}.trimLeft
+  return tot
+
+/--
+`removeDeprecations fname rgs` reads the content of `fname` and removes from it the substrings
+whose ranges are in the array `rgs`.
+
+The command makes the assumption that `rgs` is *sorted*.
+-/
+def removeDeprecations (fname : String) (rgs : Array String.Range) : IO String :=
+  return removeRanges (← IO.FS.readFile fname) rgs
+
+/--
+`parseLine line` assumes that the input string is of the form
+```
+info: File/Path.lean:12:0: [362, 398, 399]
+```
+and extracts `[362, 398, 399]`.
+It makes the assumption that there is a unique `: [` substring and then retrieves the numbers.
+
+Note that this is the output of `Mathlib.Linter.CommandRanges.commandRangesLinter`
+that the script here is parsing.
+-/
+def parseLine (line : String) : Option (List String.Pos) :=
+  match (line.dropRight 1).splitOn ": [" with
+  | [_, rest] =>
+    let nums := rest.splitOn ", "
+    if nums == [""] then some [] else
+    some <| nums.map fun s => ⟨s.toNat?.getD 0⟩
+  | _ => none
+
+/--
+Takes as input a file path `fname` and an array of pairs `(declName, range of declaration)`.
+The `declName` is mostly for printing information, but is not used essentially by the function.
+
+It returns the pair `(temp file name, file without the commands that generated the declarations)`.
+
+In the course of doing so, the function creates a temporary file from `fname`, by
+* adding the import `Mathlib.Tactic.Linter.CommandRanges` and
+* setting the `linter.commandRanges` option to `true`.
+
+It parses the temporary file, capturing the output and uses the command ranges to remove the
+ranges of the *commands* that generated the passed declaration ranges.
+-/
+def rewriteOneFile (fname : String) (rgs : Array (Name × String.Range)) :
+    CommandElabM (String × String) := do
+  -- `option` is the extra text that we add to the files that contain deprecations.
+  -- We save these modified files with a different name then their originals, so that all their
+  -- dependencies still have valid `olean`s and we build them to collect the ranges of the commands
+  -- in each one of them.
+  let option :=
+    s!"\nimport Mathlib.Tactic.Linter.CommandRanges\n\
+      set_option linter.commandRanges true\n"
+  -- `offset` represents the difference between a position in the modified file and the
+  -- corresponding position in the original file.
+  -- Since we added the modification right after the imports, the command positions of the old file
+  -- are always smaller than the command positions of the new file.
+  let offset := option.toSubstring.stopPos
+  let fileWithOptionAdded ← addAfterImports fname option
+  let fname_with_option := fname.dropRight ".lean".length ++ "_with_option.lean"
+  let file ← IO.FS.readFile fname
+  let fm := file.toFileMap
+  let rgsPos := rgs.map fun (decl, ⟨s, e⟩) =>
+    m!"* {.ofConstName decl} {(fm.toPosition s, fm.toPosition e)}"
+  let rgsStringPos := rgs.map (m!"{·.2}")
+  let combinedRanges := rgsPos.zipWith (· ++ m!" " ++ ·) rgsStringPos |>.toList
+  logInfo m!"Adding '{option}' to '{fname}'\nWriting to {indentD fname_with_option}\n\
+          Removing the following declarations\n{m!"\n".joinSep combinedRanges}"
+  IO.FS.writeFile fname_with_option fileWithOptionAdded
+  let ranges := rgs.map (·.2)
+
+  logInfo m!"Retrieving command positions from '{fname_with_option}'"
+  let commandPositions ←
+    IO.Process.output {cmd := "lake", args := #["build", fname_with_option]}
+  -- `stringPositions` consists of lists of the form `[p₁, p₂, p₃]`, where
+  -- * `p₁` is the start of a command;
+  -- * `p₂` is the end of the command, excluding trailing whitespace and comments;
+  -- * `p₁` is the end of the command, including trailing whitespace and comments.
+  let stringPositions := (commandPositions.stdout.splitOn "\n").map parseLine |>.reduceOption
+  let mut removals : Std.HashSet (List String.Pos) := ∅
+  -- For each range `rg` in `ranges`, we isolate the unique entry of `stringPositions` that
+  -- entirely contains `rg`.  This helps catching the full range of `open Nat in @[deprecated] ...`,
+  -- rather than just the `@[deprecated] ...` range.
+  for rg in ranges do
+    let candidate := stringPositions.filterMap (fun arr ↦
+      let a := arr.head! - offset
+      let b := arr[arr.length - 1]! - offset
+      if a ≤ rg.start ∧ rg.stop ≤ b then some (arr.map (· - offset)) else none)
+    match candidate with
+    | [d@([_, _, _])] => removals := removals.insert d
+    | _ => logInfo "Something went wrong!"
+  -- We only remember the `start` and `end` of each command, ignoring trailing whitespace and
+  -- comments.  This means that we may err on the side of preserving comments that may have to be
+  -- manually removed, instead of having to manually add them back later on.
+  let rems : Std.HashSet _ := removals.fold (init := ∅) fun tot ↦ fun
+    | [a, b, _c] => tot.insert (⟨a, b⟩ : String.Range)
+    | _ => tot
+  return (fname_with_option, ← removeDeprecations fname (rems.toArray.qsort (·.1 < ·.1)))
+
+/-- The `<` partial order on modules: `importLT env mod₁ mod₂` means that `mod₂` imports `mod₁`. -/
+def importLT (env : Environment) (f1 f2 : Name) : Bool :=
+  (env.findRedundantImports #[f1, f2]).contains f1
+
+/--
+`#clear_deprecations "YYYY₁-MM₁-DD₁" "YYYY₂-MM₂-DD₂" really` computes the declarations that have
+the `@[deprecated]` attribute and the `since` field satisfies
+`YYYY₁-MM₁-DD₁ ≤ since ≤ YYYY₂-MM₂-DD₂`.
+For each one of them, it retrieves the command that generated it and removes it.
+It also verbosely logs various steps of the computation.
+
+Running `#clear_deprecations "YYYY₁-MM₁-DD₁" "YYYY₂-MM₂-DD₂"`, without the trailing `really` skips
+the removal, but still emits the same verbose output.
+
+This function is intended for automated use by the `remove_deprecations` automation.
+-/
+elab "#clear_deprecations " oldDate:str ppSpace newDate:str really?:(&" really")? : command => do
+  let oldDate := oldDate.getString
+  let newDate := newDate.getString
+  let fmap ← deprecatedHashMap oldDate newDate
+  let mut filesToRemove := #[]
+  let env ← getEnv
+  let sortedFMap := fmap.toArray.qsort fun ((a, _), _) ((b, _), _) => importLT env b a
+  if sortedFMap.isEmpty then
+    logInfo m!"No deprecations in the range from {oldDate} to {newDate}"
+    return
+  for ((modName, fname), noDeprs) in sortedFMap do
+    let (toRemove, fileWithoutDeprecations) ← rewriteOneFile fname noDeprs
+    let message :=
+      m!"Click to see the file with the deprecations in the date range \
+        {oldDate} to {newDate} removed"
+    let collapsibleMessage := .trace {cls := modName} message #[fileWithoutDeprecations]
+    logInfo collapsibleMessage
+    if really?.isSome then
+      IO.FS.writeFile fname fileWithoutDeprecations
+    filesToRemove := filesToRemove.push toRemove
+  logInfo
+    m!"Removing the temporary files\n* {m!"\n* ".joinSep (filesToRemove.map (m!"{·}")).toList}"
+  for tmp in filesToRemove do
+    IO.FS.removeFile tmp
+
+end Mathlib.Tactic

--- a/MathlibTest/FindDeprecations.lean
+++ b/MathlibTest/FindDeprecations.lean
@@ -1,0 +1,36 @@
+import Mathlib.Tactic.Linter.FindDeprecations
+import Mathlib.Tactic.Linter.CommandRanges
+
+/-- info: [134, 170, 171] -/
+#guard_msgs in
+set_option linter.commandRanges true
+/-- info: [215, 223, 224] -/
+#guard_msgs in
+open Nat
+set_option linter.commandRanges false
+
+open Mathlib.Tactic
+
+#guard parseLine "" == none
+#guard parseLine "a: []" == some []
+#guard parseLine "a: [1, 2, 3]" == some [⟨1⟩, ⟨2⟩, ⟨3⟩]
+#guard parseLine "info: File/Path.lean:12:0: [362, 398, 399]" == some [⟨362⟩, ⟨398⟩, ⟨399⟩]
+
+/--
+info:
+01234567   9
+0134567   9
+0134569
+-/
+#guard_msgs in
+#eval show Lean.Elab.Term.TermElabM _ from do
+  let file := "01234567   9"
+  IO.println s!"\n{file}"
+  guard <| -- An empty array of changes leaves `file` unchanged
+    removeRanges file #[] == file
+  IO.println <| removeRanges file #[⟨⟨2⟩, ⟨3⟩⟩]
+  guard <| -- Removing a single character not followed by whitespace, removes that character only
+    removeRanges file #[⟨⟨2⟩, ⟨3⟩⟩] == file.replace "2" ""
+  IO.println <| removeRanges file #[⟨⟨2⟩, ⟨3⟩⟩, ⟨⟨7⟩, ⟨8⟩⟩]
+  guard <| -- Also removing a range followed by whitespace, removes the trailing whitespace as well
+    removeRanges file #[⟨⟨2⟩, ⟨3⟩⟩, ⟨⟨7⟩, ⟨8⟩⟩] == ((file.replace "2" "").replace "7   " "")

--- a/scripts/README.md
+++ b/scripts/README.md
@@ -97,6 +97,7 @@ to learn about it as well!
   `*-pr-testing-NNNN` branch.
 - `update_nolints_CI.sh`
   Update the `nolints.json` file to remove unneeded entries. Automatically run once a week.
+- `remove_deprecated_decls_CI.sh` Create a PR after running the deprecations linter in CI.
 - `assign_reviewers.py` is used to automatically assign a reviewer to each stale github PR on the review queue.
   This script downloads a .json file with proposed assignments and makes the
   corresponding github API calls.

--- a/scripts/remove_deprecated_decls_CI.sh
+++ b/scripts/remove_deprecated_decls_CI.sh
@@ -1,0 +1,52 @@
+#!/usr/bin/env bash
+
+# Check if there are changes in the working directory
+# (which should come from the linter removing deprecated declarations)
+# and file a PR if necessary.
+# Also set an output parameter 'message' containing a Zulip message
+# DO NOT run this as a human; this is meant only for usage in automation!
+
+# Make this script robust against unintentional errors.
+# See e.g. http://redsymbol.net/articles/unofficial-bash-strict-mode/ for explanation.
+set -euo pipefail
+IFS=$'\n\t'
+
+set -x
+
+remote_name=origin-bot
+branch_name=deprecated-decls
+owner_name=leanprover-community
+from_date="${1:-from date not set}"
+to_date="${2:-to date not set}"
+
+# Exit if the branch already exists (a PR is already open)
+git fetch --quiet "$remote_name"
+git rev-parse --verify --quiet "refs/remotes/${remote_name}/${branch_name}" && exit 0
+
+pr_title="chore: remove declarations deprecated between $from_date and $to_date"
+pr_body='I am happy to remove some deprecated declarations for you! Please check if there are any remaining stray comments or other issues before merging.'
+
+git checkout -b "$branch_name"
+git add -u
+git commit -m "$pr_title" || { echo "No changes to commit" && exit 0; }
+
+gh_api() {
+  local url="$1"
+  shift
+  curl -s -H "Authorization: token $DEPLOY_GITHUB_TOKEN" \
+    "https://api.github.com/$url" "$@"
+}
+
+git push "${remote_name}" "HEAD:$branch_name"
+
+pr_id="$(gh_api "repos/${owner_name}/mathlib4/pulls" -X POST -d @- <<EOF | jq -r .number
+{
+  "title": "$pr_title",
+  "head": "$branch_name",
+  "base": "master",
+  "body": "$pr_body"
+}
+EOF
+)"
+
+printf $'message<<EOF\nPlease review #%s, which removes deprecated declarations between %s and %s. Pay special attention to whether there are stray comments that can also be deleted.\nEOF\n' "${pr_id}" "${from_date}" "${to_date}" | tee -a "${GITHUB_OUTPUT}"


### PR DESCRIPTION
Checks that the latest modifications in #30070 still work and allow the removal of deprecated declarations in `Archive` and `Counterexamples`.

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include at least one commit authored by each
co-author among the commits in the pull request. If necessary, you may 
create empty commits to indicate co-authorship, using commands like so:

git commit --author="Author Name <author@email.com>" --allow-empty -m "add Author Name as coauthor"

When merging, all the commits will be squashed into a single commit listing all co-authors.

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
