### PR TITLE
[Merged by Bors] - feat(Tactic/Common): add `fun_prop` tactic to `hint`

### DIFF
--- a/Mathlib/Tactic/Common.lean
+++ b/Mathlib/Tactic/Common.lean
@@ -41,6 +41,7 @@ import Mathlib.Tactic.Coe
 import Mathlib.Tactic.CongrExclamation
 import Mathlib.Tactic.CongrM
 import Mathlib.Tactic.Constructor
+import Mathlib.Tactic.Continuity
 import Mathlib.Tactic.Contrapose
 import Mathlib.Tactic.Conv
 import Mathlib.Tactic.Convert
@@ -52,6 +53,7 @@ import Mathlib.Tactic.ExistsI
 import Mathlib.Tactic.ExtractGoal
 import Mathlib.Tactic.FailIfNoProgress
 import Mathlib.Tactic.Find
+import Mathlib.Tactic.FunProp
 import Mathlib.Tactic.GCongr
 import Mathlib.Tactic.GRewrite
 import Mathlib.Tactic.GeneralizeProofs
@@ -142,5 +144,7 @@ register_hint (priority := 800) simp_all?
 register_hint (priority := 600) exact?
 register_hint (priority := 1000) decide
 register_hint (priority := 200) omega
+register_hint (priority := 300) continuity
+register_hint (priority := 200) fun_prop
 
 end Hint

--- a/Mathlib/Tactic/Common.lean
+++ b/Mathlib/Tactic/Common.lean
@@ -41,7 +41,6 @@ import Mathlib.Tactic.Coe
 import Mathlib.Tactic.CongrExclamation
 import Mathlib.Tactic.CongrM
 import Mathlib.Tactic.Constructor
-import Mathlib.Tactic.Continuity
 import Mathlib.Tactic.Contrapose
 import Mathlib.Tactic.Conv
 import Mathlib.Tactic.Convert
@@ -144,7 +143,6 @@ register_hint (priority := 800) simp_all?
 register_hint (priority := 600) exact?
 register_hint (priority := 1000) decide
 register_hint (priority := 200) omega
-register_hint (priority := 300) continuity
 register_hint (priority := 200) fun_prop
 
 end Hint

--- a/MathlibTest/MinImports.lean
+++ b/MathlibTest/MinImports.lean
@@ -1,4 +1,5 @@
 import Mathlib.Tactic.NormNum.Basic
+import Mathlib.Tactic.FunProp.Attr
 
 open Lean.Elab.Command Mathlib.Command.MinImports in
 run_cmd liftTermElabM do
@@ -166,9 +167,9 @@ Note: This linter can be disabled with `set_option linter.minImports false`
 
 /--
 warning: Imports increased to
-[Mathlib.Tactic.FunProp.Attr, Mathlib.Tactic.NormNum.Basic]
+[Mathlib.Tactic.NormNum.Basic]
 
-New imports: [Mathlib.Tactic.FunProp.Attr, Mathlib.Tactic.NormNum.Basic]
+New imports: [Mathlib.Tactic.NormNum.Basic]
 
 Now redundant: [Mathlib.Tactic.Linter.MinImports]
 
@@ -211,6 +212,11 @@ def propose_to_move_this_def : ℕ := 0
 theorem theorem_with_local_def : propose_to_move_this_def = 0 := rfl
 
 -- This definition depends on definitions in two different files, so should not be moved.
+/--
+warning: Consider moving this declaration to the module Mathlib.Tactic.NormNum.Basic.
+
+Note: This linter can be disabled with `set_option linter.upstreamableDecl false`
+-/
 #guard_msgs in
 theorem theorem_with_multiple_dependencies : True :=
   let _ := Mathlib.Meta.FunProp.funPropAttr

--- a/MathlibTest/MinImports.lean
+++ b/MathlibTest/MinImports.lean
@@ -1,5 +1,4 @@
 import Mathlib.Tactic.NormNum.Basic
-import Mathlib.Tactic.FunProp.Attr
 
 open Lean.Elab.Command Mathlib.Command.MinImports in
 run_cmd liftTermElabM do


### PR DESCRIPTION
This registers `fun_prop` with `hint`, so that `hint` users will find it.

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include at least one commit authored by each
co-author among the commits in the pull request. If necessary, you may 
create empty commits to indicate co-authorship, using commands like so:

git commit --author="Author Name <author@email.com>" --allow-empty -m "add Author Name as coauthor"

When merging, all the commits will be squashed into a single commit listing all co-authors.

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
