### PR TITLE
[Merged by Bors] - perf(Algebra/IsPrimePow): speed up decidability for Nat IsPrimePow

### DIFF
--- a/Mathlib/Algebra/IsPrimePow.lean
+++ b/Mathlib/Algebra/IsPrimePow.lean
@@ -97,8 +97,7 @@ theorem isPrimePow_nat_iff_bounded_log_minFac (n : ℕ) :
       ↔ ∃ k : ℕ, k ≤ Nat.log 2 n ∧ 0 < k ∧ n = n.minFac ^ k := by
   rw [isPrimePow_nat_iff_bounded_log]
   obtain rfl | h := eq_or_ne n 1
-  · subst h
-    simp
+  · simp
   constructor
   · rintro ⟨k, hkle, hk_pos, p, hle, heq, hprime⟩
     refine ⟨k, hkle, hk_pos, ?_⟩

--- a/Mathlib/Algebra/IsPrimePow.lean
+++ b/Mathlib/Algebra/IsPrimePow.lean
@@ -6,6 +6,7 @@ Authors: Bhavik Mehta
 import Mathlib.Algebra.Order.Ring.Nat
 import Mathlib.Order.Nat
 import Mathlib.Data.Nat.Prime.Basic
+import Mathlib.Data.Nat.Prime.Pow
 
 /-!
 # Prime powers
@@ -76,8 +77,45 @@ theorem isPrimePow_nat_iff_bounded (n : ℕ) :
   conv => { lhs; rw [← (pow_one p)] }
   exact Nat.pow_le_pow_right hp.one_lt.le hk
 
+theorem isPrimePow_nat_iff_minFac_pow (n : ℕ) :
+    IsPrimePow n ↔ 2 ≤ n ∧ ∃ k : ℕ, 0 < k ∧ n.minFac ^ k = n := by
+  rw [isPrimePow_nat_iff_bounded]
+  constructor
+  · rintro ⟨p, hp, k, hk, hp', hk', rfl⟩
+    refine ⟨le_trans (Nat.Prime.two_le hp') hp, ⟨k, hk', ?_⟩⟩
+    · congr
+      exact Nat.Prime.pow_minFac hp' (Nat.ne_zero_of_lt hk')
+  · rintro ⟨hn, ⟨k, hk, heq⟩⟩
+    refine ⟨n.minFac, Nat.minFac_le (by grind), ⟨k, ⟨?_, Nat.minFac_prime (by grind), hk, heq⟩⟩⟩
+    · have two_le_minFac : 2 ≤ n.minFac := by
+        apply Nat.Prime.two_le
+        grind [Nat.minFac_prime_iff]
+      rw [← heq]
+      calc
+        k ≤ 2 ^ k := by
+          apply le_of_lt
+          apply Nat.lt_two_pow_self
+        _ ≤ _ := by
+          exact Nat.pow_le_pow_left two_le_minFac k
+
+theorem isPrimePow_nat_iff_minFac_pow_bounded (n : ℕ) :
+    IsPrimePow n ↔ 2 ≤ n ∧ ∃ k : ℕ, k ≤ n ∧ 0 < k ∧ n.minFac ^ k = n := by
+  rw [isPrimePow_nat_iff_minFac_pow]
+  constructor
+  · rintro ⟨hn, ⟨k, hk, heq⟩⟩
+    refine ⟨hn, ⟨k, ?_, hk, heq⟩⟩
+    calc
+      k ≤ 2 ^ k := by
+        apply le_of_lt
+        apply Nat.lt_two_pow_self
+      _ ≤ _ := by
+        rw [←heq]
+        exact Nat.pow_le_pow_left (Nat.Prime.two_le (Nat.minFac_prime (by grind))) k
+  · rintro ⟨hn, ⟨k, hk, hk', heq⟩⟩
+    exact ⟨hn, ⟨k, hk', heq⟩⟩
+
 instance {n : ℕ} : Decidable (IsPrimePow n) :=
-  decidable_of_iff' _ (isPrimePow_nat_iff_bounded n)
+  decidable_of_iff' _ (isPrimePow_nat_iff_minFac_pow_bounded n)
 
 theorem IsPrimePow.dvd {n m : ℕ} (hn : IsPrimePow n) (hm : m ∣ n) (hm₁ : m ≠ 1) : IsPrimePow m := by
   grind [isPrimePow_nat_iff, Nat.dvd_prime_pow, Nat.pow_eq_one]

--- a/Mathlib/Algebra/IsPrimePow.lean
+++ b/Mathlib/Algebra/IsPrimePow.lean
@@ -6,7 +6,7 @@ Authors: Bhavik Mehta
 import Mathlib.Algebra.Order.Ring.Nat
 import Mathlib.Order.Nat
 import Mathlib.Data.Nat.Prime.Basic
-import Mathlib.Data.Nat.Prime.Pow
+import Mathlib.Data.Nat.Log
 
 /-!
 # Prime powers
@@ -77,45 +77,31 @@ theorem isPrimePow_nat_iff_bounded (n : ℕ) :
   conv => { lhs; rw [← (pow_one p)] }
   exact Nat.pow_le_pow_right hp.one_lt.le hk
 
-theorem isPrimePow_nat_iff_minFac_pow (n : ℕ) :
-    IsPrimePow n ↔ 2 ≤ n ∧ ∃ k : ℕ, 0 < k ∧ n.minFac ^ k = n := by
+theorem isPrimePow_nat_iff_bounded' (n : ℕ) :
+    IsPrimePow n ↔ ∃ k : ℕ, k ≤ n ∧ ∃ p : ℕ, p ≤ n ∧ p.Prime ∧ 0 < k ∧ p ^ k = n := by
   rw [isPrimePow_nat_iff_bounded]
   constructor
   · rintro ⟨p, hp, k, hk, hp', hk', rfl⟩
-    refine ⟨le_trans (Nat.Prime.two_le hp') hp, ⟨k, hk', ?_⟩⟩
-    · congr
-      exact Nat.Prime.pow_minFac hp' (Nat.ne_zero_of_lt hk')
-  · rintro ⟨hn, ⟨k, hk, heq⟩⟩
-    refine ⟨n.minFac, Nat.minFac_le (by grind), ⟨k, ⟨?_, Nat.minFac_prime (by grind), hk, heq⟩⟩⟩
-    · have two_le_minFac : 2 ≤ n.minFac := by
-        apply Nat.Prime.two_le
-        grind [Nat.minFac_prime_iff]
-      rw [← heq]
-      calc
-        k ≤ 2 ^ k := by
-          apply le_of_lt
-          apply Nat.lt_two_pow_self
-        _ ≤ _ := by
-          exact Nat.pow_le_pow_left two_le_minFac k
+    exact ⟨k, hk, ⟨p, hp, hp', hk', rfl⟩⟩
+  · rintro ⟨k, hk, ⟨p, hp, hp', hk', rfl⟩⟩
+    exact ⟨p, hp, k, hk, hp', hk', rfl⟩
 
-theorem isPrimePow_nat_iff_minFac_pow_bounded (n : ℕ) :
-    IsPrimePow n ↔ 2 ≤ n ∧ ∃ k : ℕ, k ≤ n ∧ 0 < k ∧ n.minFac ^ k = n := by
-  rw [isPrimePow_nat_iff_minFac_pow]
+theorem isPrimePow_nat_iff_bounded_log (n : ℕ) :
+    IsPrimePow n
+      ↔ ∃ k : ℕ, k ≤ Nat.log 2 n ∧ 0 < k ∧ ∃ p : ℕ, p ≤ n ∧ p ^ k = n ∧ p.Prime := by
+  rw [isPrimePow_nat_iff]
   constructor
-  · rintro ⟨hn, ⟨k, hk, heq⟩⟩
-    refine ⟨hn, ⟨k, ?_, hk, heq⟩⟩
-    calc
-      k ≤ 2 ^ k := by
-        apply le_of_lt
-        apply Nat.lt_two_pow_self
-      _ ≤ _ := by
-        rw [←heq]
-        exact Nat.pow_le_pow_left (Nat.Prime.two_le (Nat.minFac_prime (by grind))) k
-  · rintro ⟨hn, ⟨k, hk, hk', heq⟩⟩
-    exact ⟨hn, ⟨k, hk', heq⟩⟩
+  · rintro ⟨p, k, hp', hk', rfl⟩
+    refine ⟨k, ?_, hk', ⟨p, Nat.le_pow hk', rfl, hp'⟩⟩
+    · calc
+        k = Nat.log 2 (2 ^ k) := by simp
+        _ ≤ Nat.log 2 (p ^ k) := Nat.log_mono Nat.one_lt_two Nat.AtLeastTwo.prop
+                                   (Nat.pow_le_pow_left (Nat.Prime.two_le hp') k)
+  · rintro ⟨k, hk, hk', ⟨p, hp, rfl, hp'⟩⟩
+    exact ⟨p, k, hp', hk', rfl⟩
 
 instance {n : ℕ} : Decidable (IsPrimePow n) :=
-  decidable_of_iff' _ (isPrimePow_nat_iff_minFac_pow_bounded n)
+  decidable_of_iff' _ (isPrimePow_nat_iff_bounded_log n)
 
 theorem IsPrimePow.dvd {n m : ℕ} (hn : IsPrimePow n) (hm : m ∣ n) (hm₁ : m ≠ 1) : IsPrimePow m := by
   grind [isPrimePow_nat_iff, Nat.dvd_prime_pow, Nat.pow_eq_one]

--- a/Mathlib/Algebra/IsPrimePow.lean
+++ b/Mathlib/Algebra/IsPrimePow.lean
@@ -77,15 +77,6 @@ theorem isPrimePow_nat_iff_bounded (n : ℕ) :
   conv => { lhs; rw [← (pow_one p)] }
   exact Nat.pow_le_pow_right hp.one_lt.le hk
 
-theorem isPrimePow_nat_iff_bounded' (n : ℕ) :
-    IsPrimePow n ↔ ∃ k : ℕ, k ≤ n ∧ ∃ p : ℕ, p ≤ n ∧ p.Prime ∧ 0 < k ∧ p ^ k = n := by
-  rw [isPrimePow_nat_iff_bounded]
-  constructor
-  · rintro ⟨p, hp, k, hk, hp', hk', rfl⟩
-    exact ⟨k, hk, ⟨p, hp, hp', hk', rfl⟩⟩
-  · rintro ⟨k, hk, ⟨p, hp, hp', hk', rfl⟩⟩
-    exact ⟨p, hp, k, hk, hp', hk', rfl⟩
-
 theorem isPrimePow_nat_iff_bounded_log (n : ℕ) :
     IsPrimePow n
       ↔ ∃ k : ℕ, k ≤ Nat.log 2 n ∧ 0 < k ∧ ∃ p : ℕ, p ≤ n ∧ p ^ k = n ∧ p.Prime := by

--- a/Mathlib/Algebra/IsPrimePow.lean
+++ b/Mathlib/Algebra/IsPrimePow.lean
@@ -80,7 +80,7 @@ theorem isPrimePow_nat_iff_bounded (n : ℕ) :
 
 theorem isPrimePow_nat_iff_bounded_log (n : ℕ) :
     IsPrimePow n
-      ↔ ∃ k : ℕ, k ≤ Nat.log 2 n ∧ 0 < k ∧ ∃ p : ℕ, p ≤ n ∧ p ^ k = n ∧ p.Prime := by
+      ↔ ∃ k : ℕ, k ≤ Nat.log 2 n ∧ 0 < k ∧ ∃ p : ℕ, p ≤ n ∧ n = p ^ k ∧ p.Prime := by
   rw [isPrimePow_nat_iff]
   constructor
   · rintro ⟨p, k, hp', hk', rfl⟩
@@ -102,12 +102,11 @@ theorem isPrimePow_nat_iff_bounded_log_minFac (n : ℕ) :
   constructor
   · rintro ⟨k, hkle, hk_pos, p, hle, heq, hprime⟩
     refine ⟨k, hkle, hk_pos, ?_⟩
-    · rw [← heq, Nat.Prime.pow_minFac hprime hk_pos.ne']
+    · rw [heq, Nat.Prime.pow_minFac hprime hk_pos.ne']
   · rintro ⟨k, hkle, hk_pos, heq⟩
-    refine ⟨k, hkle, hk_pos, n.minFac, Nat.minFac_le ?_, ?_, ?_⟩
+    refine ⟨k, hkle, hk_pos, n.minFac, Nat.minFac_le ?_, heq, ?_⟩
     · grind [Nat.minFac_prime_iff, nonpos_iff_eq_zero, Nat.log_zero_right, lt_self_iff_false]
-    · exact id (Eq.symm heq)
-    · refine Nat.minFac_prime_iff.mpr (by grind)
+    · grind [Nat.minFac_prime_iff]
 
 instance {n : ℕ} : Decidable (IsPrimePow n) :=
   decidable_of_iff' _ (isPrimePow_nat_iff_bounded_log_minFac n)

--- a/Mathlib/Algebra/IsPrimePow.lean
+++ b/Mathlib/Algebra/IsPrimePow.lean
@@ -96,7 +96,7 @@ theorem isPrimePow_nat_iff_bounded_log_minFac (n : ℕ) :
     IsPrimePow n
       ↔ ∃ k : ℕ, k ≤ Nat.log 2 n ∧ 0 < k ∧ n = n.minFac ^ k := by
   rw [isPrimePow_nat_iff_bounded_log]
-  by_cases h : n = 1
+  obtain rfl | h := eq_or_ne n 1
   · subst h
     simp
   constructor

--- a/Mathlib/Algebra/IsPrimePow.lean
+++ b/Mathlib/Algebra/IsPrimePow.lean
@@ -102,7 +102,7 @@ theorem isPrimePow_nat_iff_bounded_log_minFac (n : ℕ) :
   constructor
   · rintro ⟨k, hkle, hk_pos, p, hle, heq, hprime⟩
     refine ⟨k, hkle, hk_pos, ?_⟩
-    · rw [heq, Nat.Prime.pow_minFac hprime hk_pos.ne']
+    rw [heq, hprime.pow_minFac hk_pos.ne']
   · rintro ⟨k, hkle, hk_pos, heq⟩
     refine ⟨k, hkle, hk_pos, n.minFac, Nat.minFac_le ?_, heq, ?_⟩
     · grind [Nat.minFac_prime_iff, nonpos_iff_eq_zero, Nat.log_zero_right, lt_self_iff_false]

--- a/Mathlib/Algebra/IsPrimePow.lean
+++ b/Mathlib/Algebra/IsPrimePow.lean
@@ -7,6 +7,7 @@ import Mathlib.Algebra.Order.Ring.Nat
 import Mathlib.Order.Nat
 import Mathlib.Data.Nat.Prime.Basic
 import Mathlib.Data.Nat.Log
+import Mathlib.Data.Nat.Prime.Pow
 
 /-!
 # Prime powers
@@ -91,8 +92,25 @@ theorem isPrimePow_nat_iff_bounded_log (n : ℕ) :
   · rintro ⟨k, hk, hk', ⟨p, hp, rfl, hp'⟩⟩
     exact ⟨p, k, hp', hk', rfl⟩
 
+theorem isPrimePow_nat_iff_bounded_log_minFac (n : ℕ) :
+    IsPrimePow n
+      ↔ ∃ k : ℕ, k ≤ Nat.log 2 n ∧ 0 < k ∧ n = n.minFac ^ k := by
+  rw [isPrimePow_nat_iff_bounded_log]
+  by_cases h : n = 1
+  · subst h
+    simp
+  constructor
+  · rintro ⟨k, hkle, hk_pos, p, hle, heq, hprime⟩
+    refine ⟨k, hkle, hk_pos, ?_⟩
+    · rw [← heq, Nat.Prime.pow_minFac hprime hk_pos.ne']
+  · rintro ⟨k, hkle, hk_pos, heq⟩
+    refine ⟨k, hkle, hk_pos, n.minFac, Nat.minFac_le ?_, ?_, ?_⟩
+    · grind [Nat.minFac_prime_iff, nonpos_iff_eq_zero, Nat.log_zero_right, lt_self_iff_false]
+    · exact id (Eq.symm heq)
+    · refine Nat.minFac_prime_iff.mpr (by grind)
+
 instance {n : ℕ} : Decidable (IsPrimePow n) :=
-  decidable_of_iff' _ (isPrimePow_nat_iff_bounded_log n)
+  decidable_of_iff' _ (isPrimePow_nat_iff_bounded_log_minFac n)
 
 theorem IsPrimePow.dvd {n m : ℕ} (hn : IsPrimePow n) (hm : m ∣ n) (hm₁ : m ≠ 1) : IsPrimePow m := by
   grind [isPrimePow_nat_iff, Nat.dvd_prime_pow, Nat.pow_eq_one]


### PR DESCRIPTION
Previously, this decidability instance was defined using `isPrimePow_nat_iff_bounded`, which (as I understand it) means that it undertook a search over all pairs `p, k` of numbers below `n` until it finds one where `p` is prime, and `p^k = n`, or else loops through all possibilities.

This PR creates a new theorem which instead searches over possible values of the exponent first, bounding the search at the binary logarithm of `n`, and then a further theorem which uses `n.minFac` for `p`. This massively reduces the time for large `n`.

In principle this could be made polynomial time, if we were to compute the putative prime factor for each `k` by taking the `k`th root and checking primality with AKS. But until that is implemented, this seems like a fine improvement.

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include at least one commit authored by each
co-author among the commits in the pull request. If necessary, you may 
create empty commits to indicate co-authorship, using commands like so:

git commit --author="Author Name <author@email.com>" --allow-empty -m "add Author Name as coauthor"

When merging, all the commits will be squashed into a single commit listing all co-authors.

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
