### PR TITLE
[Merged by Bors] - ci(update_dependencies.yml): skip force pushing if lake-manifest.json was not modified

### DIFF
--- a/.github/workflows/update_dependencies.yml
+++ b/.github/workflows/update_dependencies.yml
@@ -29,7 +29,7 @@ jobs:
         id: get-branch-sha
         run: |
           # Check if the branch exists remotely
-          if git fetch origin "$BRANCH_NAME" then
+          if git fetch origin "$BRANCH_NAME"; then
             SHA=$(git rev-parse "origin/$BRANCH_NAME")
             echo "Branch '$BRANCH_NAME' exists with SHA: $SHA"
             echo "sha=$SHA" >> "${GITHUB_OUTPUT}"

--- a/.github/workflows/update_dependencies.yml
+++ b/.github/workflows/update_dependencies.yml
@@ -29,15 +29,13 @@ jobs:
         id: get-branch-sha
         run: |
           # Check if the branch exists remotely
-          if git ls-remote --heads origin "$BRANCH_NAME" | grep -q "$BRANCH_NAME"; then
-            # Fetch the branch and get its SHA
-            git fetch origin "$BRANCH_NAME"
+          if git fetch origin "$BRANCH_NAME" then
             SHA=$(git rev-parse "origin/$BRANCH_NAME")
             echo "Branch '$BRANCH_NAME' exists with SHA: $SHA"
-            echo "sha=$SHA" >> $GITHUB_OUTPUT
+            echo "sha=$SHA" >> "${GITHUB_OUTPUT}"
           else
             echo "Branch '$BRANCH_NAME' does not exist"
-            echo "sha=" >> $GITHUB_OUTPUT
+            echo "sha=" >>" ${GITHUB_OUTPUT}"
           fi
 
       - name: Get PR and labels
@@ -81,15 +79,15 @@ jobs:
           if [ -n "${{ steps.get-branch-sha.outputs.sha }}" ]; then
             # Branch exists, compare the file
             if git diff --quiet HEAD "origin/$BRANCH_NAME" -- lake-manifest.json; then
-              echo "has_diff=false" >> $GITHUB_OUTPUT
+              echo "has_diff=false" >> $"{GITHUB_OUTPUT}"
               echo "No differences in lake-manifest.json"
             else
-              echo "has_diff=true" >> $GITHUB_OUTPUT
+              echo "has_diff=true" >> $"{GITHUB_OUTPUT}"
               echo "Differences found in lake-manifest.json"
             fi
           else
             # Branch doesn't exist, consider it as different
-            echo "has_diff=true" >> $GITHUB_OUTPUT
+            echo "has_diff=true" >> $"{GITHUB_OUTPUT}"
             echo "Branch does not exist, treating as different"
           fi
 

--- a/.github/workflows/update_dependencies.yml
+++ b/.github/workflows/update_dependencies.yml
@@ -79,15 +79,15 @@ jobs:
           if [ -n "${{ steps.get-branch-sha.outputs.sha }}" ]; then
             # Branch exists, compare the file
             if git diff --quiet HEAD "origin/$BRANCH_NAME" -- lake-manifest.json; then
-              echo "has_diff=false" >> $"{GITHUB_OUTPUT}"
+              echo "has_diff=false" >> "${GITHUB_OUTPUT}"
               echo "No differences in lake-manifest.json"
             else
-              echo "has_diff=true" >> $"{GITHUB_OUTPUT}"
+              echo "has_diff=true" >> "${GITHUB_OUTPUT}"
               echo "Differences found in lake-manifest.json"
             fi
           else
             # Branch doesn't exist, consider it as different
-            echo "has_diff=true" >> $"{GITHUB_OUTPUT}"
+            echo "has_diff=true" >> "${GITHUB_OUTPUT}"
             echo "Branch does not exist, treating as different"
           fi
 

--- a/.github/workflows/update_dependencies.yml
+++ b/.github/workflows/update_dependencies.yml
@@ -110,5 +110,8 @@ jobs:
           branch: ${{ env.BRANCH_NAME }}
           base: master
           title: "${{ env.pr_title }}"
-          body: "This PR updates the Mathlib dependencies."
+          body: |
+            This PR updates the Mathlib dependencies.
+
+            [workflow run for this PR](${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }})
           labels: "auto-merge-after-CI"

--- a/.github/workflows/update_dependencies.yml
+++ b/.github/workflows/update_dependencies.yml
@@ -9,6 +9,8 @@ jobs:
   update-dependencies:
     runs-on: ubuntu-latest
     if: github.repository == 'leanprover-community/mathlib4'
+    env:
+      BRANCH_NAME: "update-dependencies-bot-use-only"
     steps:
       - name: Checkout repository
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
@@ -23,13 +25,30 @@ jobs:
           use-github-cache: false
           use-mathlib-cache: false
 
+      - name: Get branch SHA if it exists
+        id: get-branch-sha
+        run: |
+          # Check if the branch exists remotely
+          if git ls-remote --heads origin "$BRANCH_NAME" | grep -q "$BRANCH_NAME"; then
+            # Fetch the branch and get its SHA
+            git fetch origin "$BRANCH_NAME"
+            SHA=$(git rev-parse "origin/$BRANCH_NAME")
+            echo "Branch '$BRANCH_NAME' exists with SHA: $SHA"
+            echo "sha=$SHA" >> $GITHUB_OUTPUT
+          else
+            echo "Branch '$BRANCH_NAME' does not exist"
+            echo "sha=" >> $GITHUB_OUTPUT
+          fi
+
       - name: Get PR and labels
+        if: ${{ steps.get-branch-sha.outputs.sha != '' }}
         id: PR # all the steps below are skipped if 'ready-to-merge' is in the list of labels found here
         uses: 8BitJonny/gh-get-current-pr@4056877062a1f3b624d5d4c2bedefa9cf51435c9 # 4.0.0
         # TODO: this may not work properly if the same commit is pushed to multiple branches:
         # https://github.com/8BitJonny/gh-get-current-pr/issues/8
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
+          sha: ${{ steps.get-branch-sha.outputs.sha }}
           # Only return if PR is still open
           filterOutClosed: true
 
@@ -39,12 +58,6 @@ jobs:
         env:
           prNumber: ${{ steps.PR.outputs.number }}
           prUrl: ${{ steps.PR.outputs.pr_url }}
-
-      - name: Configure Git User
-        if: ${{ !contains(steps.PR.outputs.pr_labels, 'ready-to-merge') }}
-        run: |
-          git config user.name "leanprover-community-mathlib4-bot"
-          git config user.email "leanprover-community-mathlib4-bot@users.noreply.github.com"
 
       - name: Update dependencies
         if: ${{ !contains(steps.PR.outputs.pr_labels, 'ready-to-merge') }}
@@ -61,21 +74,40 @@ jobs:
             echo "toolchain_modified=false" >> "$GITHUB_OUTPUT"
           fi
 
-      - name: Generate PR title
+      - name: Check if lake-manifest.json was modified
         if: ${{ !contains(steps.PR.outputs.pr_labels, 'ready-to-merge') && steps.check_toolchain.outputs.toolchain_modified != 'true' }}
+        id: check_manifest
+        run: |
+          if [ -n "${{ steps.get-branch-sha.outputs.sha }}" ]; then
+            # Branch exists, compare the file
+            if git diff --quiet HEAD "origin/$BRANCH_NAME" -- lake-manifest.json; then
+              echo "has_diff=false" >> $GITHUB_OUTPUT
+              echo "No differences in lake-manifest.json"
+            else
+              echo "has_diff=true" >> $GITHUB_OUTPUT
+              echo "Differences found in lake-manifest.json"
+            fi
+          else
+            # Branch doesn't exist, consider it as different
+            echo "has_diff=true" >> $GITHUB_OUTPUT
+            echo "Branch does not exist, treating as different"
+          fi
+
+      - name: Generate PR title
+        if: ${{ !contains(steps.PR.outputs.pr_labels, 'ready-to-merge') && steps.check_manifest.outputs.has_diff == 'true' }}
         run: |
           echo "timestamp=$(date -u +"%Y-%m-%d-%H-%M")" >> "$GITHUB_ENV"
           echo "pr_title=chore: update Mathlib dependencies $(date -u +"%Y-%m-%d")" >> "$GITHUB_ENV"
 
       - name: Create Pull Request
-        if: ${{ !contains(steps.PR.outputs.pr_labels, 'ready-to-merge') && steps.check_toolchain.outputs.toolchain_modified != 'true' }}
+        if: ${{ !contains(steps.PR.outputs.pr_labels, 'ready-to-merge') && steps.check_manifest.outputs.has_diff == 'true' }}
         uses: peter-evans/create-pull-request@271a8d0340265f705b14b6d32b9829c1cb33d45e # v7.0.8
         with:
           token: "${{ secrets.UPDATE_DEPENDENCIES_TOKEN }}"
           author: "leanprover-community-mathlib4-bot <leanprover-community-mathlib4-bot@users.noreply.github.com>"
           commit-message: "chore: update Mathlib dependencies ${{ env.timestamp }}"
           # this branch is referenced in update_dependencies_zulip.yml
-          branch: "update-dependencies-bot-use-only"
+          branch: ${{ env.BRANCH_NAME }}
           base: master
           title: "${{ env.pr_title }}"
           body: "This PR updates the Mathlib dependencies."


### PR DESCRIPTION
This PR fixes a few things with the current `update_dependencies.yml`:
- In #29726, I incorrectly removed some code that was necessary for the workflow to be able to detect whether `ready-to-merge` was already on the PR.
- If the branch used by this workflow is already present, we check whether there are any differences between `lake-manifest.json` on that branch and in the working directory (`master` after running `lake update`) before running any later steps. This should prevent some unnecessary force-pushing.

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include at least one commit authored by each
co-author among the commits in the pull request. If necessary, you may 
create empty commits to indicate co-authorship, using commands like so:

git commit --author="Author Name <author@email.com>" --allow-empty -m "add Author Name as coauthor"

When merging, all the commits will be squashed into a single commit listing all co-authors.

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
