### PR TITLE
[Merged by Bors] - chore(Topology/Constructions): avoid some defeq abuse

### DIFF
--- a/Mathlib/Topology/Constructions.lean
+++ b/Mathlib/Topology/Constructions.lean
@@ -403,11 +403,11 @@ theorem Continuous.subtype_map {f : X → Y} (h : Continuous f) {q : Y → Prop}
   (h.comp continuous_subtype_val).subtype_mk _
 
 theorem IsOpenMap.subtype_map {f : X → Y} (hf : IsOpenMap f) {s : Set X} {t : Set Y} (hs : IsOpen s)
-    (hst : ∀ x, s x → t (f x)) : IsOpenMap (Subtype.map f hst) :=
+    (hst : ∀ x, x ∈ s → f x ∈ t) : IsOpenMap (Subtype.map f hst) :=
   (hf.comp hs.isOpenMap_subtype_val).subtype_mk _
 
 theorem IsClosedMap.subtype_map {f : X → Y} (hf : IsClosedMap f) {s : Set X} {t : Set Y}
-    (hs : IsClosed s) (hst : ∀ x, s x → t (f x)) : IsClosedMap (Subtype.map f hst) :=
+    (hs : IsClosed s) (hst : ∀ x, x ∈ s → f x ∈ t) : IsClosedMap (Subtype.map f hst) :=
   (hf.comp hs.isClosedMap_subtype_val).subtype_mk _
 
 theorem continuous_inclusion {s t : Set X} (h : s ⊆ t) : Continuous (inclusion h) :=

--- a/Mathlib/Topology/Constructions.lean
+++ b/Mathlib/Topology/Constructions.lean
@@ -403,11 +403,11 @@ theorem Continuous.subtype_map {f : X → Y} (h : Continuous f) {q : Y → Prop}
   (h.comp continuous_subtype_val).subtype_mk _
 
 theorem IsOpenMap.subtype_map {f : X → Y} (hf : IsOpenMap f) {s : Set X} {t : Set Y} (hs : IsOpen s)
-    (hst : ∀ x, x ∈ s → f x ∈ t) : IsOpenMap (Subtype.map f hst) :=
+    (hst : ∀ x ∈ s, f x ∈ t) : IsOpenMap (Subtype.map f hst) :=
   (hf.comp hs.isOpenMap_subtype_val).subtype_mk _
 
 theorem IsClosedMap.subtype_map {f : X → Y} (hf : IsClosedMap f) {s : Set X} {t : Set Y}
-    (hs : IsClosed s) (hst : ∀ x, x ∈ s → f x ∈ t) : IsClosedMap (Subtype.map f hst) :=
+    (hs : IsClosed s) (hst : ∀ x ∈ s, f x ∈ t) : IsClosedMap (Subtype.map f hst) :=
   (hf.comp hs.isClosedMap_subtype_val).subtype_mk _
 
 theorem continuous_inclusion {s t : Set X} (h : s ⊆ t) : Continuous (inclusion h) :=


### PR DESCRIPTION
Uses `x ∈ s` instead of `s x` for `s : Set X`.

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include at least one commit authored by each
co-author among the commits in the pull request. If necessary, you may 
create empty commits to indicate co-authorship, using commands like so:

git commit --author="Author Name <author@email.com>" --allow-empty -m "add Author Name as coauthor"

When merging, all the commits will be squashed into a single commit listing all co-authors.

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
