### PR TITLE
[Merged by Bors] - chore: fix type confusion in LatticeHom.withTop/withBot/withTopWithBot

### DIFF
--- a/Mathlib/Order/Hom/WithTopBot.lean
+++ b/Mathlib/Order/Hom/WithTopBot.lean
@@ -393,12 +393,12 @@ lemma withTop_apply (f : LatticeHom α β) (a : WithTop α) : f.withTop a = a.ma
 
 @[simp]
 theorem withTop_id : (LatticeHom.id α).withTop = LatticeHom.id _ :=
-  DFunLike.coe_injective Option.map_id
+  DFunLike.coe_injective WithTop.map_id
 
 @[simp]
 theorem withTop_comp (f : LatticeHom β γ) (g : LatticeHom α β) :
     (f.comp g).withTop = f.withTop.comp g.withTop :=
-  DFunLike.coe_injective <| Eq.symm <| Option.map_comp_map _ _
+  DFunLike.coe_injective <| Eq.symm <| WithTop.map_comp_map _ _
 
 /-- Adjoins a `⊥` to the domain and codomain of a `LatticeHom`. -/
 @[simps]
@@ -407,18 +407,18 @@ protected def withBot (f : LatticeHom α β) : LatticeHom (WithBot α) (WithBot 
 
 -- Porting note: `simps` doesn't generate those
 @[simp, norm_cast]
-lemma coe_withBot (f : LatticeHom α β) : ⇑f.withBot = Option.map f := rfl
+lemma coe_withBot (f : LatticeHom α β) : ⇑f.withBot = WithBot.map f := rfl
 
 lemma withBot_apply (f : LatticeHom α β) (a : WithBot α) : f.withBot a = a.map f := rfl
 
 @[simp]
 theorem withBot_id : (LatticeHom.id α).withBot = LatticeHom.id _ :=
-  DFunLike.coe_injective Option.map_id
+  DFunLike.coe_injective WithBot.map_id
 
 @[simp]
 theorem withBot_comp (f : LatticeHom β γ) (g : LatticeHom α β) :
     (f.comp g).withBot = f.withBot.comp g.withBot :=
-  DFunLike.coe_injective <| Eq.symm <| Option.map_comp_map _ _
+  DFunLike.coe_injective <| Eq.symm <| WithBot.map_comp_map _ _
 
 /-- Adjoins a `⊤` and `⊥` to the domain and codomain of a `LatticeHom`. -/
 @[simps]
@@ -428,17 +428,17 @@ def withTopWithBot (f : LatticeHom α β) :
 
 -- Porting note: `simps` doesn't generate those
 @[simp, norm_cast]
-lemma coe_withTopWithBot (f : LatticeHom α β) : ⇑f.withTopWithBot = Option.map (Option.map f) := rfl
+lemma coe_withTopWithBot (f : LatticeHom α β) :
+    ⇑f.withTopWithBot = WithTop.map (WithBot.map f) :=
+  rfl
 
 lemma withTopWithBot_apply (f : LatticeHom α β) (a : WithTop <| WithBot α) :
-    f.withTopWithBot a = a.map (Option.map f) := rfl
+    f.withTopWithBot a = a.map (WithBot.map f) :=
+  rfl
 
 @[simp]
 theorem withTopWithBot_id : (LatticeHom.id α).withTopWithBot = BoundedLatticeHom.id _ :=
-  DFunLike.coe_injective <| by
-    refine (congr_arg Option.map ?_).trans Option.map_id
-    rw [withBot_id]
-    rfl
+  DFunLike.coe_injective <| by simp [WithTop.map_id, WithBot.map_id]
 
 @[simp]
 theorem withTopWithBot_comp (f : LatticeHom β γ) (g : LatticeHom α β) :


### PR DESCRIPTION
Based on #27918.

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include at least one commit authored by each
co-author among the commits in the pull request. If necessary, you may 
create empty commits to indicate co-authorship, using commands like so:

git commit --author="Author Name <author@email.com>" --allow-empty -m "add Author Name as coauthor"

When merging, all the commits will be squashed into a single commit listing all co-authors.

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
