### PR TITLE
[Merged by Bors] - feat(Algebra/HahnEmbedding): ArchimedeanStrata is non-empty

### DIFF
--- a/Mathlib/Algebra/Order/Module/HahnEmbedding.lean
+++ b/Mathlib/Algebra/Order/Module/HahnEmbedding.lean
@@ -8,6 +8,7 @@ import Mathlib.Algebra.DirectSum.Module
 import Mathlib.Algebra.Module.Submodule.Order
 import Mathlib.Algebra.Order.Module.Archimedean
 import Mathlib.Algebra.Order.Module.Equiv
+import Mathlib.LinearAlgebra.Basis.VectorSpace
 import Mathlib.LinearAlgebra.LinearPMap
 import Mathlib.RingTheory.HahnSeries.Lex
 
@@ -76,6 +77,13 @@ structure ArchimedeanStrata where
 
 namespace ArchimedeanStrata
 variable (u : ArchimedeanStrata K M) {c : ArchimedeanClass M}
+
+instance : Nonempty (ArchimedeanStrata K M) := by
+  have hstratum (c : ArchimedeanClass M) :
+      ∃ G : Submodule K M, Disjoint (ball K c) G ∧ ball K c ⊔ G = closedBall K c :=
+    IsModularLattice.exists_disjoint_and_sup_eq <| ball_le_closedBall _
+  choose g h1 h2 using hstratum
+  exact ⟨g, h1, h2⟩
 
 @[simp] lemma ball_eq_closedBall : ball K c = closedBall K c ↔ c = ⊤ where
   mp h := by


### PR DESCRIPTION
This is a small part of #27268 (Hahn embedding theorem). Separated out for easy review while waiting for the other dependency.

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include at least one commit authored by each
co-author among the commits in the pull request. If necessary, you may 
create empty commits to indicate co-authorship, using commands like so:

git commit --author="Author Name <author@email.com>" --allow-empty -m "add Author Name as coauthor"

When merging, all the commits will be squashed into a single commit listing all co-authors.

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
