### PR TITLE
[Merged by Bors] - feat: first main theorem of value distribution theory

### DIFF
--- a/Mathlib/Analysis/Complex/ValueDistribution/FirstMainTheorem.lean
+++ b/Mathlib/Analysis/Complex/ValueDistribution/FirstMainTheorem.lean
@@ -59,7 +59,7 @@ First part of the First Main Theorem: Away from zero, the difference between the
 functions of `f` and `f⁻¹` equals `log ‖leadCoefficient f 0‖`.
 -/
 @[simp]
-theorem characteristic_sub_characteristic_inv_at_zero (hf : MeromorphicOn f ⊤) (hR : R ≠ 0) :
+theorem characteristic_sub_characteristic_inv_at_zero (hf : MeromorphicOn f Set.univ) (hR : R ≠ 0) :
     characteristic f ⊤ R - characteristic f⁻¹ ⊤ R = log ‖meromorphicTrailingCoeffAt f 0‖ := by
   calc characteristic f ⊤ R - characteristic f⁻¹ ⊤ R
   _ = (characteristic f ⊤ - characteristic f⁻¹ ⊤) R  := by simp
@@ -78,7 +78,7 @@ Complement to the first part of the First Main Theorem: At 0, the difference bet
 characteristic functions of `f`  and `f⁻¹` equals `log ‖f 0‖`.
 -/
 @[simp]
-theorem characteristic_sub_characteristic_inv_off_zero (h : MeromorphicOn f ⊤) :
+theorem characteristic_sub_characteristic_inv_off_zero (h : MeromorphicOn f Set.univ) :
     characteristic f ⊤ 0 - characteristic f⁻¹ ⊤ 0 = log ‖f 0‖ := by
   calc characteristic f ⊤ 0 - characteristic f⁻¹ ⊤ 0
   _ = (characteristic f ⊤ - characteristic f⁻¹ ⊤) 0 := by simp

--- a/Mathlib/Analysis/Complex/ValueDistribution/FirstMainTheorem.lean
+++ b/Mathlib/Analysis/Complex/ValueDistribution/FirstMainTheorem.lean
@@ -3,6 +3,7 @@ Copyright (c) 2025 Stefan Kebekus. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Stefan Kebekus
 -/
+import Mathlib.Analysis.Complex.JensenFormula
 import Mathlib.Analysis.Complex.ValueDistribution.CharacteristicFunction
 
 /-!
@@ -22,19 +23,78 @@ of the characteristic function `characteristic f ⊤` under modifications of `f`
 See Section~VI.2 of [Lang, *Introduction to Complex Hyperbolic Spaces*][MR886677] or Section~1.1 of
 [Noguchi-Winkelmann, *Nevanlinna Theory in Several Complex Variables and Diophantine
 Approximation*][MR3156076] for a detailed discussion.
-
-### TODO
-
-- Formalize the first part of the First Main Theorem, which is the more substantial part of the
-  statement.
 -/
 namespace ValueDistribution
 
+open Asymptotics Filter Function.locallyFinsuppWithin MeromorphicAt MeromorphicOn Metric Real
+
+section FirstPart
+
+variable {f : ℂ → ℂ} {R : ℝ}
+
+/-!
+## First Part of the First Main Theorem
+-/
+
+/--
+Helper lemma for the first part of the First Main Theorem: Given a meromorphic function `f`, compute
+difference between the characteristic functions of `f` and of its inverse.
+-/
+lemma characteristic_sub_characteristic_inv (h : MeromorphicOn f ⊤) :
+    characteristic f ⊤ - characteristic f⁻¹ ⊤ =
+      circleAverage (log ‖f ·‖) 0 - (divisor f Set.univ).logCounting := by
+  calc characteristic f ⊤ - characteristic f⁻¹ ⊤
+  _ = proximity f ⊤ - proximity f⁻¹ ⊤ - (logCounting f⁻¹ ⊤ - logCounting f ⊤) := by
+    unfold characteristic
+    ring
+  _ = circleAverage (log ‖f ·‖) 0 - (logCounting f⁻¹ ⊤ - logCounting f ⊤) := by
+    rw [proximity_sub_proximity_inv_eq_circleAverage h]
+  _ = circleAverage (log ‖f ·‖) 0 - (logCounting f 0 - logCounting f ⊤) := by
+    rw [logCounting_inv]
+  _ = circleAverage (log ‖f ·‖) 0 - (divisor f Set.univ).logCounting := by
+    rw [← ValueDistribution.log_counting_zero_sub_logCounting_top]
+
+/--
+First part of the First Main Theorem: Away from zero, the difference between the characteristic
+functions of `f` and `f⁻¹` equals `log ‖leadCoefficient f 0‖`.
+-/
+@[simp]
+theorem characteristic_sub_characteristic_inv_at_zero (hf : MeromorphicOn f ⊤) (hR : R ≠ 0) :
+    characteristic f ⊤ R - characteristic f⁻¹ ⊤ R = log ‖meromorphicTrailingCoeffAt f 0‖ := by
+  calc characteristic f ⊤ R - characteristic f⁻¹ ⊤ R
+  _ = (characteristic f ⊤ - characteristic f⁻¹ ⊤) R  := by simp
+  _ = circleAverage (log ‖f ·‖) 0 R - (divisor f Set.univ).logCounting R := by
+    rw [characteristic_sub_characteristic_inv hf]
+    rfl
+  _ = log ‖meromorphicTrailingCoeffAt f 0‖ := by
+    rw [MeromorphicOn.circleAverage_log_norm hR (hf.mono_set (by tauto))]
+    unfold Function.locallyFinsuppWithin.logCounting
+    have : (divisor f (closedBall 0 |R|)) = (divisor f Set.univ).toClosedBall R :=
+      (divisor_restrict hf (by tauto)).symm
+    simp [this, toClosedBall, restrictMonoidHom, restrict_apply]
+
+/--
+Complement to the first part of the First Main Theorem: At 0, the difference between the
+characteristic functions of `f`  and `f⁻¹` equals `log ‖f 0‖`.
+-/
+@[simp]
+theorem characteristic_sub_characteristic_inv_off_zero (h : MeromorphicOn f ⊤) :
+    characteristic f ⊤ 0 - characteristic f⁻¹ ⊤ 0 = log ‖f 0‖ := by
+  calc characteristic f ⊤ 0 - characteristic f⁻¹ ⊤ 0
+  _ = (characteristic f ⊤ - characteristic f⁻¹ ⊤) 0 := by simp
+  _ = circleAverage (log ‖f ·‖) 0 0 - (divisor f Set.univ).logCounting 0 := by
+    rw [ValueDistribution.characteristic_sub_characteristic_inv h]
+    rfl
+  _ = log ‖f 0‖ := by
+    simp
+
+end FirstPart
+
+section SecondPart
+
 variable
   {E : Type*} [NormedAddCommGroup E] [NormedSpace ℂ E]
-  {f : ℂ → E} {a₀ : E}
-
-open Asymptotics Filter Real
+  {a₀ : E} {f : ℂ → E}
 
 /-!
 ## Second Part of the First Main Theorem
@@ -78,5 +138,7 @@ theorem abs_characteristic_sub_characteristic_shift_eqO (h : MeromorphicOn f ⊤
   simp_rw [isBigO_iff', eventually_atTop]
   use log⁺ ‖a₀‖ + log 2, add_pos_of_nonneg_of_pos posLog_nonneg (log_pos one_lt_two), 0
   simp [abs_characteristic_sub_characteristic_shift_le h]
+
+end SecondPart
 
 end ValueDistribution

--- a/Mathlib/Analysis/Complex/ValueDistribution/FirstMainTheorem.lean
+++ b/Mathlib/Analysis/Complex/ValueDistribution/FirstMainTheorem.lean
@@ -59,7 +59,8 @@ First part of the First Main Theorem: Away from zero, the difference between the
 functions of `f` and `f⁻¹` equals `log ‖leadCoefficient f 0‖`.
 -/
 @[simp]
-theorem characteristic_sub_characteristic_inv_at_zero (hf : MeromorphicOn f Set.univ) (hR : R ≠ 0) :
+theorem characteristic_sub_characteristic_inv_off_zero
+    (hf : MeromorphicOn f Set.univ) (hR : R ≠ 0) :
     characteristic f ⊤ R - characteristic f⁻¹ ⊤ R = log ‖meromorphicTrailingCoeffAt f 0‖ := by
   calc characteristic f ⊤ R - characteristic f⁻¹ ⊤ R
   _ = (characteristic f ⊤ - characteristic f⁻¹ ⊤) R  := by simp
@@ -78,7 +79,7 @@ Complement to the first part of the First Main Theorem: At 0, the difference bet
 characteristic functions of `f`  and `f⁻¹` equals `log ‖f 0‖`.
 -/
 @[simp]
-theorem characteristic_sub_characteristic_inv_off_zero (h : MeromorphicOn f Set.univ) :
+theorem characteristic_sub_characteristic_inv_at_zero (h : MeromorphicOn f Set.univ) :
     characteristic f ⊤ 0 - characteristic f⁻¹ ⊤ 0 = log ‖f 0‖ := by
   calc characteristic f ⊤ 0 - characteristic f⁻¹ ⊤ 0
   _ = (characteristic f ⊤ - characteristic f⁻¹ ⊤) 0 := by simp

--- a/Mathlib/Analysis/Complex/ValueDistribution/FirstMainTheorem.lean
+++ b/Mathlib/Analysis/Complex/ValueDistribution/FirstMainTheorem.lean
@@ -56,7 +56,7 @@ lemma characteristic_sub_characteristic_inv (h : MeromorphicOn f ⊤) :
 
 /--
 First part of the First Main Theorem: Away from zero, the difference between the characteristic
-functions of `f` and `f⁻¹` equals `log ‖leadCoefficient f 0‖`.
+functions of `f` and `f⁻¹` equals `log ‖meromorphicTrailingCoeffAt f 0‖`.
 -/
 @[simp]
 theorem characteristic_sub_characteristic_inv_off_zero

--- a/Mathlib/Analysis/Complex/ValueDistribution/FirstMainTheorem.lean
+++ b/Mathlib/Analysis/Complex/ValueDistribution/FirstMainTheorem.lean
@@ -105,7 +105,7 @@ plane, then the characteristic functions of `f` and `f⁻¹` agree asymptoticall
 function.
 -/
 theorem isBigO_characteristic_sub_characteristic_inv (h : MeromorphicOn f ⊤) :
-    |characteristic f ⊤ - characteristic f⁻¹ ⊤| =O[atTop] (1 : ℝ → ℝ) :=
+    (characteristic f ⊤ - characteristic f⁻¹ ⊤) =O[atTop] (1 : ℝ → ℝ) :=
   isBigO_of_le' (c := max |log ‖f 0‖| |log ‖meromorphicTrailingCoeffAt f 0‖|) _
     (fun R ↦ by simpa using characteristic_sub_characteristic_inv_le h (R := R))
 
@@ -154,14 +154,14 @@ Second part of the First Main Theorem of Value Distribution Theory, qualitative 
 meromorphic on the complex plane, then the characteristic functions for the value `⊤` of the
 function `f` and `f - a₀` agree asymptotically up to a bounded function.
 -/
-theorem isBigO_abs_characteristic_sub_characteristic_shift (h : MeromorphicOn f ⊤) :
-    |characteristic f ⊤ - characteristic (f · - a₀) ⊤| =O[atTop] (1 : ℝ → ℝ) :=
+theorem isBigO_characteristic_sub_characteristic_shift (h : MeromorphicOn f ⊤) :
+    (characteristic f ⊤ - characteristic (f · - a₀) ⊤) =O[atTop] (1 : ℝ → ℝ) :=
   isBigO_of_le' (c := log⁺ ‖a₀‖ + log 2) _
     (fun R ↦ by simpa using abs_characteristic_sub_characteristic_shift_le h)
 
 @[deprecated (since := "2025-10-06")]
 alias abs_characteristic_sub_characteristic_shift_eqO :=
-  isBigO_abs_characteristic_sub_characteristic_shift
+  isBigO_characteristic_sub_characteristic_shift
 
 end SecondPart
 

--- a/Mathlib/Analysis/Complex/ValueDistribution/FirstMainTheorem.lean
+++ b/Mathlib/Analysis/Complex/ValueDistribution/FirstMainTheorem.lean
@@ -97,7 +97,7 @@ theorem characteristic_sub_characteristic_inv_le (hf : MeromorphicOn f Set.univ)
       ≤ max |log ‖f 0‖| |log ‖meromorphicTrailingCoeffAt f 0‖| := by
   by_cases h : R = 0
   · simp [h, characteristic_sub_characteristic_inv_at_zero hf]
-  · simp [characteristic_sub_characteristic_inv_off_zero hf h]
+  · simp [characteristic_sub_characteristic_inv_of_ne_zero hf h]
 
 /--
 First part of the First Main Theorem, qualitative version: If `f` is meromorphic on the complex
@@ -106,7 +106,7 @@ function.
 -/
 theorem isBigO_characteristic_sub_characteristic_inv (h : MeromorphicOn f ⊤) :
     |characteristic f ⊤ - characteristic f⁻¹ ⊤| =O[atTop] (1 : ℝ → ℝ) :=
-  isBigO_of_le' (c := max |log ‖f 0‖| |log ‖meromorphicTrailingCoeffAt f 0‖|) _ 
+  isBigO_of_le' (c := max |log ‖f 0‖| |log ‖meromorphicTrailingCoeffAt f 0‖|) _
     (fun R ↦ by simpa using characteristic_sub_characteristic_inv_le h (R := R))
 
 end FirstPart
@@ -154,11 +154,14 @@ Second part of the First Main Theorem of Value Distribution Theory, qualitative 
 meromorphic on the complex plane, then the characteristic functions for the value `⊤` of the
 function `f` and `f - a₀` agree asymptotically up to a bounded function.
 -/
-theorem abs_characteristic_sub_characteristic_shift_eqO (h : MeromorphicOn f ⊤) :
-    |characteristic f ⊤ - characteristic (f · - a₀) ⊤| =O[atTop] (1 : ℝ → ℝ) := by
-  simp_rw [isBigO_iff', eventually_atTop]
-  use log⁺ ‖a₀‖ + log 2, add_pos_of_nonneg_of_pos posLog_nonneg (log_pos one_lt_two), 0
-  simp [abs_characteristic_sub_characteristic_shift_le h]
+theorem isBigO_abs_characteristic_sub_characteristic_shift (h : MeromorphicOn f ⊤) :
+    |characteristic f ⊤ - characteristic (f · - a₀) ⊤| =O[atTop] (1 : ℝ → ℝ) :=
+  isBigO_of_le' (c := log⁺ ‖a₀‖ + log 2) _
+    (fun R ↦ by simpa using abs_characteristic_sub_characteristic_shift_le h)
+
+@[deprecated (since := "2025-10-06")]
+alias abs_characteristic_sub_characteristic_shift_eqO :=
+  isBigO_abs_characteristic_sub_characteristic_shift
 
 end SecondPart
 

--- a/Mathlib/Analysis/Complex/ValueDistribution/FirstMainTheorem.lean
+++ b/Mathlib/Analysis/Complex/ValueDistribution/FirstMainTheorem.lean
@@ -58,7 +58,6 @@ lemma characteristic_sub_characteristic_inv (h : MeromorphicOn f ⊤) :
 First part of the First Main Theorem: Away from zero, the difference between the characteristic
 functions of `f` and `f⁻¹` equals `log ‖meromorphicTrailingCoeffAt f 0‖`.
 -/
-@[simp]
 theorem characteristic_sub_characteristic_inv_off_zero
     (hf : MeromorphicOn f Set.univ) (hR : R ≠ 0) :
     characteristic f ⊤ R - characteristic f⁻¹ ⊤ R = log ‖meromorphicTrailingCoeffAt f 0‖ := by
@@ -78,7 +77,6 @@ theorem characteristic_sub_characteristic_inv_off_zero
 Complement to the first part of the First Main Theorem: At 0, the difference between the
 characteristic functions of `f`  and `f⁻¹` equals `log ‖f 0‖`.
 -/
-@[simp]
 theorem characteristic_sub_characteristic_inv_at_zero (h : MeromorphicOn f Set.univ) :
     characteristic f ⊤ 0 - characteristic f⁻¹ ⊤ 0 = log ‖f 0‖ := by
   calc characteristic f ⊤ 0 - characteristic f⁻¹ ⊤ 0
@@ -88,6 +86,36 @@ theorem characteristic_sub_characteristic_inv_at_zero (h : MeromorphicOn f Set.u
     rfl
   _ = log ‖f 0‖ := by
     simp
+
+/--
+First part of the First Main Theorem: Away from zero, the difference between the characteristic
+functions of `f` and `f⁻¹` equals `log ‖meromorphicTrailingCoeffAt f 0‖`.
+-/
+@[simp]
+theorem characteristic_sub_characteristic_inv_le (hf : MeromorphicOn f Set.univ) :
+    ‖characteristic f ⊤ R - characteristic f⁻¹ ⊤ R‖
+      ≤ max ‖log ‖f 0‖‖ ‖log ‖meromorphicTrailingCoeffAt f 0‖‖ := by
+  by_cases h : R = 0
+  · simp [h, characteristic_sub_characteristic_inv_at_zero hf]
+  · simp [characteristic_sub_characteristic_inv_off_zero hf h]
+
+theorem characteristic_sub_characteristic_inv_eqO (h : MeromorphicOn f ⊤) :
+    (characteristic f ⊤ - characteristic f⁻¹ ⊤) =O[atTop] (1 : ℝ → ℝ) := by
+  simp_rw [isBigO_iff', eventually_atTop]
+  use 1 + max |log ‖f 0‖| |log ‖meromorphicTrailingCoeffAt f 0‖|
+  constructor
+  · rw [gt_iff_lt, add_comm]
+    apply lt_add_of_le_of_pos (by aesop) Real.zero_lt_one
+  · simp only [ge_iff_le, Pi.sub_apply, norm_eq_abs, Pi.one_apply, one_mem,
+      CStarRing.norm_of_mem_unitary, mul_one]
+    use 1
+    intro b hb
+    calc ‖(characteristic f ⊤ - characteristic f⁻¹ ⊤) b‖
+    _ ≤ max ‖log ‖f 0‖‖ ‖log ‖meromorphicTrailingCoeffAt f 0‖‖ := by
+      simp [characteristic_sub_characteristic_inv_off_zero h (by linarith)]
+    _ ≤ 1 + max ‖log ‖f 0‖‖ ‖log ‖meromorphicTrailingCoeffAt f 0‖‖ := by
+      simp
+
 
 end FirstPart
 

--- a/Mathlib/Analysis/Complex/ValueDistribution/FirstMainTheorem.lean
+++ b/Mathlib/Analysis/Complex/ValueDistribution/FirstMainTheorem.lean
@@ -58,7 +58,7 @@ lemma characteristic_sub_characteristic_inv (h : MeromorphicOn f ⊤) :
 Helper lemma for the first part of the First Main Theorem: Away from zero, the difference between
 the characteristic functions of `f` and `f⁻¹` equals `log ‖meromorphicTrailingCoeffAt f 0‖`.
 -/
-lemma characteristic_sub_characteristic_inv_off_zero
+lemma characteristic_sub_characteristic_inv_of_ne_zero
     (hf : MeromorphicOn f Set.univ) (hR : R ≠ 0) :
     characteristic f ⊤ R - characteristic f⁻¹ ⊤ R = log ‖meromorphicTrailingCoeffAt f 0‖ := by
   calc characteristic f ⊤ R - characteristic f⁻¹ ⊤ R
@@ -75,7 +75,7 @@ lemma characteristic_sub_characteristic_inv_off_zero
 
 /--
 Helper lemma for the first part of the First Main Theorem: At 0, the difference between the
-characteristic functions of `f`  and `f⁻¹` equals `log ‖f 0‖`.
+characteristic functions of `f` and `f⁻¹` equals `log ‖f 0‖`.
 -/
 lemma characteristic_sub_characteristic_inv_at_zero (h : MeromorphicOn f Set.univ) :
     characteristic f ⊤ 0 - characteristic f⁻¹ ⊤ 0 = log ‖f 0‖ := by
@@ -104,21 +104,10 @@ First part of the First Main Theorem, qualitative version: If `f` is meromorphic
 plane, then the characteristic functions of `f` and `f⁻¹` agree asymptotically up to a bounded
 function.
 -/
-theorem characteristic_sub_characteristic_inv_eqO (h : MeromorphicOn f ⊤) :
-    |characteristic f ⊤ - characteristic f⁻¹ ⊤| =O[atTop] (1 : ℝ → ℝ) := by
-  simp_rw [isBigO_iff', eventually_atTop]
-  use 1 + max |log ‖f 0‖| |log ‖meromorphicTrailingCoeffAt f 0‖|
-  constructor
-  · rw [gt_iff_lt, add_comm]
-    apply lt_add_of_le_of_pos (by aesop) Real.zero_lt_one
-  · simp only [ge_iff_le, norm_eq_abs, Pi.abs_apply, Pi.sub_apply, abs_abs, Pi.one_apply, one_mem,
-      CStarRing.norm_of_mem_unitary, mul_one]
-    use 1
-    intro b _
-    calc |(characteristic f ⊤ - characteristic f⁻¹ ⊤) b|
-    _ ≤ max |log ‖f 0‖| |log ‖meromorphicTrailingCoeffAt f 0‖| := by
-      simp [characteristic_sub_characteristic_inv_off_zero h (by linarith)]
-    _ ≤ 1 + max |log ‖f 0‖| |log ‖meromorphicTrailingCoeffAt f 0‖| := by simp
+theorem isBigO_characteristic_sub_characteristic_inv (h : MeromorphicOn f ⊤) :
+    |characteristic f ⊤ - characteristic f⁻¹ ⊤| =O[atTop] (1 : ℝ → ℝ) :=
+  isBigO_of_le' (c := max |log ‖f 0‖| |log ‖meromorphicTrailingCoeffAt f 0‖|) _ 
+    (fun R ↦ by simpa using characteristic_sub_characteristic_inv_le h (R := R))
 
 end FirstPart
 

--- a/Mathlib/Analysis/Complex/ValueDistribution/FirstMainTheorem.lean
+++ b/Mathlib/Analysis/Complex/ValueDistribution/FirstMainTheorem.lean
@@ -100,7 +100,7 @@ theorem characteristic_sub_characteristic_inv_le (hf : MeromorphicOn f Set.univ)
   · simp [characteristic_sub_characteristic_inv_off_zero hf h]
 
 /--
-First part of the First Main Theorem, quantitative version: If `f` is meromorphic on the complex
+First part of the First Main Theorem, qualitative version: If `f` is meromorphic on the complex
 plane, then the characteristic functions of `f` and `f⁻¹` agree asymptotically up to a bounded
 function.
 -/

--- a/Mathlib/Analysis/Complex/ValueDistribution/FirstMainTheorem.lean
+++ b/Mathlib/Analysis/Complex/ValueDistribution/FirstMainTheorem.lean
@@ -106,7 +106,7 @@ function.
 -/
 theorem isBigO_characteristic_sub_characteristic_inv (h : MeromorphicOn f ⊤) :
     |characteristic f ⊤ - characteristic f⁻¹ ⊤| =O[atTop] (1 : ℝ → ℝ) :=
-  isBigO_of_le' (c := max |log ‖f 0‖| |log ‖meromorphicTrailingCoeffAt f 0‖|) _ 
+  isBigO_of_le' (c := max |log ‖f 0‖| |log ‖meromorphicTrailingCoeffAt f 0‖|) _
     (fun R ↦ by simpa using characteristic_sub_characteristic_inv_le h (R := R))
 
 end FirstPart

--- a/Mathlib/Analysis/Complex/ValueDistribution/FirstMainTheorem.lean
+++ b/Mathlib/Analysis/Complex/ValueDistribution/FirstMainTheorem.lean
@@ -55,10 +55,10 @@ lemma characteristic_sub_characteristic_inv (h : MeromorphicOn f ⊤) :
     rw [← ValueDistribution.log_counting_zero_sub_logCounting_top]
 
 /--
-First part of the First Main Theorem: Away from zero, the difference between the characteristic
-functions of `f` and `f⁻¹` equals `log ‖meromorphicTrailingCoeffAt f 0‖`.
+Helper lemma for the first part of the First Main Theorem: Away from zero, the difference between
+the characteristic functions of `f` and `f⁻¹` equals `log ‖meromorphicTrailingCoeffAt f 0‖`.
 -/
-theorem characteristic_sub_characteristic_inv_off_zero
+lemma characteristic_sub_characteristic_inv_off_zero
     (hf : MeromorphicOn f Set.univ) (hR : R ≠ 0) :
     characteristic f ⊤ R - characteristic f⁻¹ ⊤ R = log ‖meromorphicTrailingCoeffAt f 0‖ := by
   calc characteristic f ⊤ R - characteristic f⁻¹ ⊤ R
@@ -74,10 +74,10 @@ theorem characteristic_sub_characteristic_inv_off_zero
     simp [this, toClosedBall, restrictMonoidHom, restrict_apply]
 
 /--
-Complement to the first part of the First Main Theorem: At 0, the difference between the
+Helper lemma for the first part of the First Main Theorem: At 0, the difference between the
 characteristic functions of `f`  and `f⁻¹` equals `log ‖f 0‖`.
 -/
-theorem characteristic_sub_characteristic_inv_at_zero (h : MeromorphicOn f Set.univ) :
+lemma characteristic_sub_characteristic_inv_at_zero (h : MeromorphicOn f Set.univ) :
     characteristic f ⊤ 0 - characteristic f⁻¹ ⊤ 0 = log ‖f 0‖ := by
   calc characteristic f ⊤ 0 - characteristic f⁻¹ ⊤ 0
   _ = (characteristic f ⊤ - characteristic f⁻¹ ⊤) 0 := by simp
@@ -88,34 +88,37 @@ theorem characteristic_sub_characteristic_inv_at_zero (h : MeromorphicOn f Set.u
     simp
 
 /--
-First part of the First Main Theorem: Away from zero, the difference between the characteristic
-functions of `f` and `f⁻¹` equals `log ‖meromorphicTrailingCoeffAt f 0‖`.
+First part of the First Main Theorem, quantitative version: If `f` is meromorphic on the complex
+plane, then the difference between the characteristic functions of `f` and `f⁻¹` is bounded by an
+explicit constant.
 -/
-@[simp]
 theorem characteristic_sub_characteristic_inv_le (hf : MeromorphicOn f Set.univ) :
-    ‖characteristic f ⊤ R - characteristic f⁻¹ ⊤ R‖
-      ≤ max ‖log ‖f 0‖‖ ‖log ‖meromorphicTrailingCoeffAt f 0‖‖ := by
+    |characteristic f ⊤ R - characteristic f⁻¹ ⊤ R|
+      ≤ max |log ‖f 0‖| |log ‖meromorphicTrailingCoeffAt f 0‖| := by
   by_cases h : R = 0
   · simp [h, characteristic_sub_characteristic_inv_at_zero hf]
   · simp [characteristic_sub_characteristic_inv_off_zero hf h]
 
+/--
+First part of the First Main Theorem, quantitative version: If `f` is meromorphic on the complex
+plane, then the characteristic functions of `f` and `f⁻¹` agree asymptotically up to a bounded
+function.
+-/
 theorem characteristic_sub_characteristic_inv_eqO (h : MeromorphicOn f ⊤) :
-    (characteristic f ⊤ - characteristic f⁻¹ ⊤) =O[atTop] (1 : ℝ → ℝ) := by
+    |characteristic f ⊤ - characteristic f⁻¹ ⊤| =O[atTop] (1 : ℝ → ℝ) := by
   simp_rw [isBigO_iff', eventually_atTop]
   use 1 + max |log ‖f 0‖| |log ‖meromorphicTrailingCoeffAt f 0‖|
   constructor
   · rw [gt_iff_lt, add_comm]
     apply lt_add_of_le_of_pos (by aesop) Real.zero_lt_one
-  · simp only [ge_iff_le, Pi.sub_apply, norm_eq_abs, Pi.one_apply, one_mem,
+  · simp only [ge_iff_le, norm_eq_abs, Pi.abs_apply, Pi.sub_apply, abs_abs, Pi.one_apply, one_mem,
       CStarRing.norm_of_mem_unitary, mul_one]
     use 1
-    intro b hb
-    calc ‖(characteristic f ⊤ - characteristic f⁻¹ ⊤) b‖
-    _ ≤ max ‖log ‖f 0‖‖ ‖log ‖meromorphicTrailingCoeffAt f 0‖‖ := by
+    intro b _
+    calc |(characteristic f ⊤ - characteristic f⁻¹ ⊤) b|
+    _ ≤ max |log ‖f 0‖| |log ‖meromorphicTrailingCoeffAt f 0‖| := by
       simp [characteristic_sub_characteristic_inv_off_zero h (by linarith)]
-    _ ≤ 1 + max ‖log ‖f 0‖‖ ‖log ‖meromorphicTrailingCoeffAt f 0‖‖ := by
-      simp
-
+    _ ≤ 1 + max |log ‖f 0‖| |log ‖meromorphicTrailingCoeffAt f 0‖| := by simp
 
 end FirstPart
 

--- a/docs/overview.yaml
+++ b/docs/overview.yaml
@@ -362,6 +362,7 @@ Analysis:
     removable singularity: 'Complex.differentiableOn_update_limUnder_insert_of_isLittleO'
     Phragmen-Lindelöf principle: 'PhragmenLindelof.horizontal_strip'
     fundamental theorem of algebra: 'Complex.isAlgClosed'
+    First Main Theorem of Value Distribution Theory: 'ValueDistribution.characteristic_sub_characteristic_inv_off_zero'
 
   Distribution theory:
     Schwartz space: 'SchwartzMap'

--- a/docs/overview.yaml
+++ b/docs/overview.yaml
@@ -362,7 +362,7 @@ Analysis:
     removable singularity: 'Complex.differentiableOn_update_limUnder_insert_of_isLittleO'
     Phragmen-Lindelöf principle: 'PhragmenLindelof.horizontal_strip'
     fundamental theorem of algebra: 'Complex.isAlgClosed'
-    First Main Theorem of Value Distribution Theory: 'ValueDistribution.characteristic_sub_characteristic_inv_off_zero'
+    First Main Theorem of Value Distribution Theory: 'ValueDistribution.characteristic_sub_characteristic_inv_le'
 
   Distribution theory:
     Schwartz space: 'SchwartzMap'


### PR DESCRIPTION
Establish the first main theorem of value distribution theory in full.

This PR completes a major milestone in [Project VD](https://github.com/kebekus/ProjectVD), which aims to formalize Value Distribution Theory for meromorphic functions on the complex plane.

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include at least one commit authored by each
co-author among the commits in the pull request. If necessary, you may 
create empty commits to indicate co-authorship, using commands like so:

git commit --author="Author Name <author@email.com>" --allow-empty -m "add Author Name as coauthor"

When merging, all the commits will be squashed into a single commit listing all co-authors.

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
