### PR TITLE
[Merged by Bors] - doc: fix minor docstring errors

### DIFF
--- a/Mathlib/Analysis/Complex/JensenFormula.lean
+++ b/Mathlib/Analysis/Complex/JensenFormula.lean
@@ -17,8 +17,8 @@ precise statement.
 
 Jensen's Formula, formulated in `MeromorphicOn.circleAverage_log_norm` below, generalizes this to
 the setting where `g` is merely meromorphic. In that case, the `circleAverage (log ‖g ·‖) c R`
-equals `log `‖meromorphicTrailingCoeffAt g c‖` plus a correction term that accounts for the zeros
-and poles of `g` within the ball.
+equals `log ‖meromorphicTrailingCoeffAt g c‖` plus a correction term that accounts for the zeros and
+poles of `g` within the ball.
 -/
 
 open Filter MeromorphicAt MeromorphicOn Metric Real

--- a/Mathlib/Analysis/Complex/ValueDistribution/CharacteristicFunction.lean
+++ b/Mathlib/Analysis/Complex/ValueDistribution/CharacteristicFunction.lean
@@ -18,7 +18,7 @@ measure the "complexity" of objects. For rational functions, the characteristic 
 the degree times the logarithm, much like the logarithmic height in number theory reflects the
 degree of an algebraic number.
 
-See Section~VI.2 of [Lang, *Introduction to Complex Hyperbolic Spaces*][MR886677] or Section~1.1 of
+See Section VI.2 of [Lang, *Introduction to Complex Hyperbolic Spaces*][MR886677] or Section 1.1 of
 [Noguchi-Winkelmann, *Nevanlinna Theory in Several Complex Variables and Diophantine
 Approximation*][MR3156076] for a detailed discussion.
 

--- a/Mathlib/Analysis/Complex/ValueDistribution/CountingFunction.lean
+++ b/Mathlib/Analysis/Complex/ValueDistribution/CountingFunction.lean
@@ -15,9 +15,11 @@ of the three main functions used in Value Distribution Theory.
 
 The counting function of a meromorphic function `f` is a logarithmically weighted measure of the
 number of times the function `f` takes a given value `a` within the disk `∣z∣ ≤ r`, counting
-multiplicities.  See Section~VI.1 of [Lang, *Introduction to Complex Hyperbolic Spaces*][MR886677]
-or Section~1.1 of [Noguchi-Winkelmann, *Nevanlinna Theory in Several Complex Variables and
-Diophantine Approximation*][MR3156076] for a detailed discussion.
+multiplicities.
+
+See Section VI.1 of [Lang, *Introduction to Complex Hyperbolic Spaces*][MR886677] or Section 1.1 of
+[Noguchi-Winkelmann, *Nevanlinna Theory in Several Complex Variables and Diophantine
+Approximation*][MR3156076] for a detailed discussion.
 
 ## Implementation Notes
 

--- a/Mathlib/Analysis/Complex/ValueDistribution/FirstMainTheorem.lean
+++ b/Mathlib/Analysis/Complex/ValueDistribution/FirstMainTheorem.lean
@@ -19,7 +19,7 @@ of the characteristic function `characteristic f ⊤` under modifications of `f`
   the function `f` and `f - const` agree up to a constant, see Proposition 2.2 on p. 168 of [Lang,
   *Introduction to Complex Hyperbolic Spaces*][MR886677]
 
-See Section~VI.2 of [Lang, *Introduction to Complex Hyperbolic Spaces*][MR886677] or Section~1.1 of
+See Section VI.2 of [Lang, *Introduction to Complex Hyperbolic Spaces*][MR886677] or Section 1.1 of
 [Noguchi-Winkelmann, *Nevanlinna Theory in Several Complex Variables and Diophantine
 Approximation*][MR3156076] for a detailed discussion.
 

--- a/Mathlib/Analysis/Complex/ValueDistribution/ProximityFunction.lean
+++ b/Mathlib/Analysis/Complex/ValueDistribution/ProximityFunction.lean
@@ -19,7 +19,7 @@ The proximity function is a logarithmically weighted measure quantifying how wel
 function `f` approximates the constant function `a` on the circle of radius `R` in the complex
 plane.  The definition ensures that large values correspond to good approximation.
 
-See Section~VI.2 of [Lang, *Introduction to Complex Hyperbolic Spaces*][MR886677] or Section~1.1 of
+See Section VI.2 of [Lang, *Introduction to Complex Hyperbolic Spaces*][MR886677] or Section 1.1 of
 [Noguchi-Winkelmann, *Nevanlinna Theory in Several Complex Variables and Diophantine
 Approximation*][MR3156076] for a detailed discussion.
 -/
@@ -74,7 +74,7 @@ lemma proximity_top : proximity f ⊤ = circleAverage (log⁺ ‖f ·‖) 0 := b
   simp [proximity]
 
 /-!
-## Elementary Properties of the Counting Function
+## Elementary Properties of the Proximity Function
 -/
 
 /--


### PR DESCRIPTION
Fix a few typos and errors in the docstrings of files I added recently.

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include at least one commit authored by each
co-author among the commits in the pull request. If necessary, you may 
create empty commits to indicate co-authorship, using commands like so:

git commit --author="Author Name <author@email.com>" --allow-empty -m "add Author Name as coauthor"

When merging, all the commits will be squashed into a single commit listing all co-authors.

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
