### PR TITLE
[Merged by Bors] - chore: remove non-terminal simps

### DIFF
--- a/Mathlib/AlgebraicTopology/SimplicialSet/NerveAdjunction.lean
+++ b/Mathlib/AlgebraicTopology/SimplicialSet/NerveAdjunction.lean
@@ -109,7 +109,7 @@ noncomputable def nerve₂.seagull (C : Type u) [Category C] :
 instance (C : Type u) [Category C] : Mono (nerve₂.seagull C) where
   right_cancellation {X} (f g : X → ComposableArrows C 2) eq := by
     ext x
-    simp [nerve₂.seagull] at eq
+    simp only [nerve₂.seagull, prod.comp_lift] at eq
     have eq1 := congr($eq ≫ prod.fst)
     have eq2 := congr($eq ≫ prod.snd)
     simp only [limit.lift_π, BinaryFan.mk_fst, BinaryFan.mk_snd] at eq1 eq2

--- a/Mathlib/Analysis/Analytic/Binomial.lean
+++ b/Mathlib/Analysis/Analytic/Binomial.lean
@@ -63,6 +63,7 @@ theorem binomialSeries_radius_eq_top_of_nat {𝕂 : Type v} [RCLike 𝕂] {𝔸 
 /-- The radius of convergence of `binomialSeries 𝔸 a` is `1`, when `a` is not natural. -/
 theorem binomialSeries_radius_eq_one {𝕂 : Type v} [RCLike 𝕂] {𝔸 : Type u} [NormedDivisionRing 𝔸]
     [NormedAlgebra 𝕂 𝔸] {a : 𝕂} (ha : ∀ (k : ℕ), a ≠ k) : (binomialSeries 𝔸 a).radius = 1 := by
-  simp [binomialSeries_eq_ordinaryHypergeometricSeries (b := (1 : 𝕂)) (by norm_cast; simp)]
+  simp only [binomialSeries_eq_ordinaryHypergeometricSeries (b := (1 : 𝕂)) (by norm_cast; simp),
+    FormalMultilinearSeries.radius_compNeg]
   conv at ha => ext; rw [ne_comm]
   exact ordinaryHypergeometricSeries_radius_eq_one _ _ _ _ (by norm_cast; grind)

--- a/Mathlib/Analysis/Calculus/FDeriv/Pow.lean
+++ b/Mathlib/Analysis/Calculus/FDeriv/Pow.lean
@@ -38,7 +38,7 @@ private theorem aux (f : E → 𝔸) (f' : E →L[𝕜] 𝔸) (x : E) (n : ℕ) 
   simp only [Nat.pred_eq_sub_one, add_tsub_cancel_right, tsub_self, pow_zero, one_smul]
   simp_rw [smul_comm (_ : 𝔸) (_ : 𝔸ᵐᵒᵖ), smul_smul, ← pow_succ']
   congr! 5 with x hx
-  simp [Nat.lt_succ_iff] at hx
+  simp only [Finset.mem_range, Nat.lt_succ_iff] at hx
   rw [tsub_add_eq_add_tsub hx]
 
 theorem HasStrictFDerivAt.fun_pow' (h : HasStrictFDerivAt f f' x) (n : ℕ) :

--- a/Mathlib/Analysis/Calculus/FormalMultilinearSeries.lean
+++ b/Mathlib/Analysis/Calculus/FormalMultilinearSeries.lean
@@ -196,7 +196,7 @@ def unshift (q : FormalMultilinearSeries 𝕜 E (E →L[𝕜] F)) (z : F) : Form
 theorem unshift_shift {p : FormalMultilinearSeries 𝕜 E (E →L[𝕜] F)} {z : F} :
     (p.unshift z).shift = p := by
   ext1 n
-  simp [shift, unshift]
+  simp only [shift, Nat.succ_eq_add_one, unshift]
   exact LinearIsometryEquiv.apply_symm_apply (continuousMultilinearCurryRightEquiv' 𝕜 n E F) (p n)
 
 end FormalMultilinearSeries

--- a/Mathlib/Analysis/Complex/ValueDistribution/FirstMainTheorem.lean
+++ b/Mathlib/Analysis/Complex/ValueDistribution/FirstMainTheorem.lean
@@ -62,7 +62,8 @@ theorem abs_characteristic_sub_characteristic_shift_le {r : ℝ} (h : Meromorphi
     by_cases h : 0 ≤ log⁺ ‖f θ‖ - log⁺ ‖f θ - a₀‖
     · simpa [abs_of_nonneg h, sub_le_iff_le_add, add_comm (log⁺ ‖a₀‖ + log 2), ← add_assoc]
         using (posLog_norm_add_le (f θ - a₀) a₀)
-    · simp [abs_of_nonpos (le_of_not_ge h), neg_sub, add_comm (log⁺ ‖a₀‖ + log 2), ← add_assoc]
+    · simp only [abs_of_nonpos (le_of_not_ge h), neg_sub, tsub_le_iff_right,
+        add_comm (log⁺ ‖a₀‖ + log 2), ← add_assoc]
       convert posLog_norm_add_le (-f θ) (a₀) using 2
       · rw [← norm_neg]
         abel_nf

--- a/Mathlib/Analysis/Meromorphic/TrailingCoefficient.lean
+++ b/Mathlib/Analysis/Meromorphic/TrailingCoefficient.lean
@@ -207,9 +207,8 @@ lemma MeromorphicAt.meromorphicTrailingCoeffAt_smul {f₁ : 𝕜 → 𝕜} {f₂
   have : f₁ • f₂ =ᶠ[𝓝[≠] x]
       fun z ↦ (z - x) ^ (meromorphicOrderAt (f₁ • f₂) x).untop₀ • (g₁ • g₂) z := by
     filter_upwards [h₃g₁, h₃g₂, self_mem_nhdsWithin] with y h₁y h₂y h₃y
-    simp_all [meromorphicOrderAt_smul hf₁ hf₂, ← smul_assoc, ← smul_assoc, smul_eq_mul,
-      smul_eq_mul, zpow_add₀ (sub_ne_zero.2 h₃y)]
-    ring_nf
+    simp_all [meromorphicOrderAt_smul hf₁ hf₂, zpow_add₀ (sub_ne_zero.2 h₃y)]
+    module
   rw [h₁g₁.meromorphicTrailingCoeffAt_of_ne_zero_of_eq_nhdsNE h₂g₁ h₃g₁,
     h₁g₂.meromorphicTrailingCoeffAt_of_ne_zero_of_eq_nhdsNE h₂g₂ h₃g₂,
     (h₁g₁.smul h₁g₂).meromorphicTrailingCoeffAt_of_eq_nhdsNE this]

--- a/Mathlib/Analysis/Meromorphic/TrailingCoefficient.lean
+++ b/Mathlib/Analysis/Meromorphic/TrailingCoefficient.lean
@@ -207,8 +207,8 @@ lemma MeromorphicAt.meromorphicTrailingCoeffAt_smul {f₁ : 𝕜 → 𝕜} {f₂
   have : f₁ • f₂ =ᶠ[𝓝[≠] x]
       fun z ↦ (z - x) ^ (meromorphicOrderAt (f₁ • f₂) x).untop₀ • (g₁ • g₂) z := by
     filter_upwards [h₃g₁, h₃g₂, self_mem_nhdsWithin] with y h₁y h₂y h₃y
-    simp_all [meromorphicOrderAt_smul hf₁ hf₂]
-    rw [← smul_assoc, ← smul_assoc, smul_eq_mul, smul_eq_mul, zpow_add₀ (sub_ne_zero.2 h₃y)]
+    simp_all [meromorphicOrderAt_smul hf₁ hf₂, ← smul_assoc, ← smul_assoc, smul_eq_mul,
+      smul_eq_mul, zpow_add₀ (sub_ne_zero.2 h₃y)]
     ring_nf
   rw [h₁g₁.meromorphicTrailingCoeffAt_of_ne_zero_of_eq_nhdsNE h₂g₁ h₃g₁,
     h₁g₂.meromorphicTrailingCoeffAt_of_ne_zero_of_eq_nhdsNE h₂g₂ h₃g₂,

--- a/Mathlib/CategoryTheory/SmallObject/Construction.lean
+++ b/Mathlib/CategoryTheory/SmallObject/Construction.lean
@@ -316,7 +316,7 @@ noncomputable def functor : Arrow C ⥤ Arrow C where
   map_comp {π₁ π₂ π₃} τ τ' := by
     ext
     · dsimp
-      simp [functorMap]
+      simp only [functorMap, Arrow.comp_left, Arrow.mk_left]
       ext ⟨i, t, b, w⟩
       · simp
       · simp [ι_functorMapTgt_assoc f τ i t b w _ rfl _ rfl,

--- a/Mathlib/Combinatorics/SetFamily/FourFunctions.lean
+++ b/Mathlib/Combinatorics/SetFamily/FourFunctions.lean
@@ -282,11 +282,11 @@ lemma four_functions_theorem [DecidableEq α] (h₁ : 0 ≤ f₁) (h₂ : 0 ≤ 
   set s' : Finset L := s.preimage (↑) Subtype.coe_injective.injOn
   set t' : Finset L := t.preimage (↑) Subtype.coe_injective.injOn
   have hs' : s'.map ⟨L.subtype, Subtype.coe_injective⟩ = s := by
-    simp [s', map_eq_image, image_preimage, filter_eq_self]
-    exact fun a ha ↦ subset_latticeClosure <| Set.subset_union_left ha
+    simpa [s', map_eq_image, image_preimage, filter_eq_self] using
+      fun a ha ↦ subset_latticeClosure <| Set.subset_union_left ha
   have ht' : t'.map ⟨L.subtype, Subtype.coe_injective⟩ = t := by
-    simp [t', map_eq_image, image_preimage, filter_eq_self]
-    exact fun a ha ↦ subset_latticeClosure <| Set.subset_union_right ha
+    simpa [t', map_eq_image, image_preimage, filter_eq_self] using
+      fun a ha ↦ subset_latticeClosure <| Set.subset_union_right ha
   clear_value s' t'
   obtain ⟨β, _, _, g, hg⟩ := exists_birkhoff_representation L
   have := four_functions_theorem_aux (extend g (f₁ ∘ (↑)) 0) (extend g (f₂ ∘ (↑)) 0)

--- a/Mathlib/Data/ENNReal/BigOperators.lean
+++ b/Mathlib/Data/ENNReal/BigOperators.lean
@@ -128,7 +128,7 @@ lemma prod_inv_distrib {ι : Type*} {f : ι → ℝ≥0∞} {s : Finset ι}
   induction s using Finset.cons_induction with
   | empty => simp
   | cons i s hi ih => ?_
-  simp [← ih (hf.mono <| by simp)]
+  simp only [Finset.prod_cons, ← ih (hf.mono <| by simp)]
   refine ENNReal.mul_inv (not_or_of_imp fun hi₀ ↦ prod_ne_top fun j hj ↦ ?_)
     (not_or_of_imp fun hi₀ ↦ Finset.prod_ne_zero_iff.2 fun j hj ↦ ?_)
   · exact imp_iff_not_or.2 (hf (by simp) (by simp [hj]) <| .symm <| ne_of_mem_of_not_mem hj hi) hi₀

--- a/Mathlib/Data/Nat/Digits/Lemmas.lean
+++ b/Mathlib/Data/Nat/Digits/Lemmas.lean
@@ -61,8 +61,8 @@ theorem digits_len (b n : ℕ) (hb : 1 < b) (hn : n ≠ 0) : (b.digits n).length
 theorem digits_length_le_iff {b k : ℕ} (hb : 1 < b) (n : ℕ) :
     (b.digits n).length ≤ k ↔ n < b ^ k  := by
   by_cases h : n = 0
-  · simp [h]
-    positivity
+  · have : 0 < b ^ k := by positivity
+    simpa [h]
   rw [digits_len b n hb h, lt_pow_iff_log_lt hb h]
   exact add_one_le_iff
 

--- a/Mathlib/Probability/Kernel/IonescuTulcea/PartialTraj.lean
+++ b/Mathlib/Probability/Kernel/IonescuTulcea/PartialTraj.lean
@@ -345,7 +345,7 @@ lemma measurable_lmarginalPartialTraj (a b : ℕ) {f : (Π n, X n) → ℝ≥0�
   refine Measurable.lintegral_kernel_prod_left' <| hf.comp ?_
   simp only [updateFinset, measurable_pi_iff]
   intro i
-  by_cases h : i ∈ Iic b <;> simp [h] <;> fun_prop
+  by_cases h : i ∈ Iic b <;> simp only [h, ↓reduceDIte] <;> fun_prop
 
 /-- Integrating `f` against `partialTraj κ a b` and then against `partialTraj κ b c` is the same
 as integrating `f` against `partialTraj κ a c`. -/

--- a/Mathlib/Probability/ProbabilityMassFunction/Constructions.lean
+++ b/Mathlib/Probability/ProbabilityMassFunction/Constructions.lean
@@ -313,7 +313,7 @@ theorem support_bernoulli : (bernoulli p h).support = { b | cond b (p ≠ 0) (p 
       ENNReal.coe_one, Bool.cond_prop, Set.mem_setOf_eq, Bool.false_eq_true, ite_false, not_iff_not]
     constructor
     · intro h'
-      simp [tsub_eq_zero_iff_le] at h'
+      simp only [tsub_eq_zero_iff_le, one_le_coe_iff] at h'
       exact eq_of_le_of_ge h h'
     · intro h'
       simp only [h', ENNReal.coe_one, tsub_self]

--- a/Mathlib/Topology/DiscreteSubset.lean
+++ b/Mathlib/Topology/DiscreteSubset.lean
@@ -225,7 +225,7 @@ lemma mem_codiscrete' {S : Set X} :
 
 lemma mem_codiscrete_subtype_iff_mem_codiscreteWithin {S : Set X} {U : Set S} :
     U ∈ codiscrete S ↔ (↑) '' U ∈ codiscreteWithin S := by
-  simp [mem_codiscrete, disjoint_principal_right, compl_compl, Subtype.forall,
+  simp only [mem_codiscrete, disjoint_principal_right, compl_compl, Subtype.forall,
     mem_codiscreteWithin]
   congr! with x hx
   constructor

--- a/Mathlib/Topology/Instances/EReal/Lemmas.lean
+++ b/Mathlib/Topology/Instances/EReal/Lemmas.lean
@@ -201,8 +201,8 @@ lemma continuous_toENNReal : Continuous EReal.toENNReal := by
   by_cases h_bot : x = ⊥
   · refine tendsto_nhds_of_eventually_eq ?_
     rw [h_bot, nhds_bot_basis.eventually_iff]
-    simp [toReal_bot, ENNReal.ofReal_zero, ENNReal.ofReal_eq_zero, true_and]
-    exact ⟨0, fun _ hx ↦ toReal_nonpos hx.le⟩
+    simpa [toReal_bot, ENNReal.ofReal_zero, ENNReal.ofReal_eq_zero, true_and] using
+      ⟨0, fun _ hx ↦ toReal_nonpos hx.le⟩
   refine ENNReal.continuous_ofReal.continuousAt.comp' <| continuousOn_toReal.continuousAt
     <| (toFinite _).isClosed.compl_mem_nhds ?_
   simp_all only [mem_compl_iff, mem_singleton_iff, mem_insert_iff, or_self, not_false_eq_true]


### PR DESCRIPTION
Found by the flexible linter; extracted from https://github.com/leanprover-community/mathlib4/pull/28962.

I consider these changes improvements as well, given they improve robustness.

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include at least one commit authored by each
co-author among the commits in the pull request. If necessary, you may 
create empty commits to indicate co-authorship, using commands like so:

git commit --author="Author Name <author@email.com>" --allow-empty -m "add Author Name as coauthor"

When merging, all the commits will be squashed into a single commit listing all co-authors.

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
