### PR TITLE
[Merged by Bors] - feat(Order): generalize `Finset.exists_maximalFor` to transitive orders

### DIFF
--- a/Mathlib/Order/Basic.lean
+++ b/Mathlib/Order/Basic.lean
@@ -741,6 +741,9 @@ instance instSup (α : Type*) [Min α] : Max αᵒᵈ :=
 instance instInf (α : Type*) [Max α] : Min αᵒᵈ :=
   ⟨((· ⊔ ·) : α → α → α)⟩
 
+instance instIsTransLE [LE α] [T : IsTrans α LE.le] : IsTrans αᵒᵈ LE.le where
+  trans := fun _ _ _ hab hbc ↦ T.trans _ _ _ hbc hab
+
 instance instPreorder (α : Type*) [Preorder α] : Preorder αᵒᵈ where
   le_refl := fun _ ↦ le_refl _
   le_trans := fun _ _ _ hab hbc ↦ hbc.trans hab

--- a/Mathlib/Order/Basic.lean
+++ b/Mathlib/Order/Basic.lean
@@ -744,6 +744,9 @@ instance instInf (α : Type*) [Max α] : Min αᵒᵈ :=
 instance instIsTransLE [LE α] [T : IsTrans α LE.le] : IsTrans αᵒᵈ LE.le where
   trans := fun _ _ _ hab hbc ↦ T.trans _ _ _ hbc hab
 
+instance instIsTransLT [LT α] [T : IsTrans α LT.lt] : IsTrans αᵒᵈ LT.lt where
+  trans := fun _ _ _ hab hbc ↦ T.trans _ _ _ hbc hab
+
 instance instPreorder (α : Type*) [Preorder α] : Preorder αᵒᵈ where
   le_refl := fun _ ↦ le_refl _
   le_trans := fun _ _ _ hab hbc ↦ hbc.trans hab

--- a/Mathlib/Order/Preorder/Finite.lean
+++ b/Mathlib/Order/Preorder/Finite.lean
@@ -16,7 +16,8 @@ contrapositively that non-empty sets without minimal or maximal elements are inf
 variable {ι α β : Type*}
 
 namespace Finset
-variable [Preorder α] {s : Finset α} {a : α}
+section IsTrans
+variable [LE α] [IsTrans α LE.le] {s : Finset α} {a : α}
 
 lemma exists_maximalFor (f : ι → α) (s : Finset ι) (hs : s.Nonempty) :
     ∃ i, MaximalFor (· ∈ s) f i := by
@@ -26,8 +27,8 @@ lemma exists_maximalFor (f : ι → α) (s : Finset ι) (hs : s.Nonempty) :
     obtain ⟨j, hj⟩ := ih
     by_cases hji : f j ≤ f i
     · refine ⟨i, mem_cons_self .., ?_⟩
-      simp only [mem_cons, forall_eq_or_imp, le_refl, imp_self, true_and]
-      exact fun k hk hik ↦ (hj.2 hk <| hji.trans hik).trans hji
+      simp only [mem_cons, forall_eq_or_imp, imp_self, true_and]
+      exact fun k hk hik ↦ _root_.trans (hj.2 hk <| _root_.trans hji hik) hji
     · exact ⟨j, mem_cons_of_mem hj.1, by simpa [hji] using hj.2⟩
 
 lemma exists_minimalFor (f : ι → α) (s : Finset ι) (hs : s.Nonempty) :
@@ -35,6 +36,11 @@ lemma exists_minimalFor (f : ι → α) (s : Finset ι) (hs : s.Nonempty) :
 
 lemma exists_maximal (hs : s.Nonempty) : ∃ i, Maximal (· ∈ s) i := s.exists_maximalFor id hs
 lemma exists_minimal (hs : s.Nonempty) : ∃ i, Minimal (· ∈ s) i := s.exists_minimalFor id hs
+
+end IsTrans
+
+section Preorder
+variable [Preorder α] {s : Finset α} {a : α}
 
 lemma exists_le_maximal (s : Finset α) (ha : a ∈ s) : ∃ b, a ≤ b ∧ Maximal (· ∈ s) b := by
   classical
@@ -47,11 +53,12 @@ lemma exists_le_minimal (s : Finset α) (ha : a ∈ s) : ∃ b ≤ a, Minimal (�
 
 @[deprecated (since := "2025-05-04")] alias exists_minimal_le := exists_le_minimal
 
+end Preorder
 end Finset
 
 namespace Set
-section Preorder
-variable [Preorder α] {s : Set α} {a : α}
+section IsTrans
+variable [LE α] [IsTrans α (@LE.le α _)] {s : Set α} {a : α}
 
 lemma Finite.exists_maximalFor (f : ι → α) (s : Set ι) (h : s.Finite) (hs : s.Nonempty) :
     ∃ i, MaximalFor (· ∈ s) f i := by
@@ -82,6 +89,11 @@ lemma Finite.exists_minimalFor' (f : ι → α) (s : Set ι) (h : (f '' s).Finit
 @[deprecated (since := "2025-05-04")] alias Finite.exists_minimal_wrt := Finite.exists_minimalFor
 @[deprecated (since := "2025-05-04")] alias Finite.exists_maximal_wrt' := Finite.exists_maximalFor'
 @[deprecated (since := "2025-05-04")] alias Finite.exists_minimal_wrt' := Finite.exists_minimalFor'
+
+end IsTrans
+
+section Preorder
+variable [Preorder α] {s : Set α} {a : α}
 
 lemma Finite.exists_le_maximal (hs : s.Finite) (ha : a ∈ s) : ∃ b, a ≤ b ∧ Maximal (· ∈ s) b := by
   lift s to Finset α using hs; exact s.exists_le_maximal ha

--- a/Mathlib/Order/Preorder/Finite.lean
+++ b/Mathlib/Order/Preorder/Finite.lean
@@ -58,7 +58,7 @@ end Finset
 
 namespace Set
 section IsTrans
-variable [LE α] [IsTrans α (@LE.le α _)] {s : Set α} {a : α}
+variable [LE α] [IsTrans α LE.le] {s : Set α} {a : α}
 
 lemma Finite.exists_maximalFor (f : ι → α) (s : Set ι) (h : s.Finite) (hs : s.Nonempty) :
     ∃ i, MaximalFor (· ∈ s) f i := by


### PR DESCRIPTION
Currently `exists_maximalFor` and it's related analogs are only defined for Preorders. I generalize the results where it is possible to do so to transitive relations without requiring reflexivity. This was necessary for work where I needed to work with < and find maximums.


---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include at least one commit authored by each
co-author among the commits in the pull request. If necessary, you may 
create empty commits to indicate co-authorship, using commands like so:

git commit --author="Author Name <author@email.com>" --allow-empty -m "add Author Name as coauthor"

When merging, all the commits will be squashed into a single commit listing all co-authors.

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
