### PR TITLE
feat: WithTop/Bot.mapD

### DIFF
--- a/Mathlib/Order/Hom/WithTopBot.lean
+++ b/Mathlib/Order/Hom/WithTopBot.lean
@@ -286,7 +286,7 @@ theorem withBot_comp (f : SupHom β γ) (g : SupHom α β) :
 /-- Adjoins a `⊤` to the codomain of a `SupHom`. -/
 @[simps]
 def withTop' [OrderTop β] (f : SupHom α β) : SupHom (WithTop α) β where
-  toFun a := a.elim ⊤ f
+  toFun a := a.mapD ⊤ f
   map_sup' a b :=
     match a, b with
     | ⊤, ⊤ => (top_sup_eq _).symm
@@ -297,7 +297,7 @@ def withTop' [OrderTop β] (f : SupHom α β) : SupHom (WithTop α) β where
 /-- Adjoins a `⊥` to the domain of a `SupHom`. -/
 @[simps]
 def withBot' [OrderBot β] (f : SupHom α β) : SupBotHom (WithBot α) β where
-  toFun a := a.elim ⊥ f
+  toFun a := a.mapD ⊥ f
   map_sup' a b :=
     match a, b with
     | ⊥, ⊥ => (bot_sup_eq _).symm
@@ -354,7 +354,7 @@ theorem withBot_comp (f : InfHom β γ) (g : InfHom α β) :
 /-- Adjoins a `⊤` to the codomain of an `InfHom`. -/
 @[simps]
 def withTop' [OrderTop β] (f : InfHom α β) : InfTopHom (WithTop α) β where
-  toFun a := a.elim ⊤ f
+  toFun a := a.mapD ⊤ f
   map_inf' a b :=
     match a, b with
     | ⊤, ⊤ => (top_inf_eq _).symm
@@ -366,7 +366,7 @@ def withTop' [OrderTop β] (f : InfHom α β) : InfTopHom (WithTop α) β where
 /-- Adjoins a `⊥` to the codomain of an `InfHom`. -/
 @[simps]
 def withBot' [OrderBot β] (f : InfHom α β) : InfHom (WithBot α) β where
-  toFun a := a.elim ⊥ f
+  toFun a := a.mapD ⊥ f
   map_inf' a b :=
     match a, b with
     | ⊥, ⊥ => (bot_inf_eq _).symm

--- a/Mathlib/Order/WithBot.lean
+++ b/Mathlib/Order/WithBot.lean
@@ -87,6 +87,20 @@ theorem unbotD_eq_unbotD_iff {d : α} {x y : WithBot α} :
     unbotD d x = unbotD d y ↔ x = y ∨ x = d ∧ y = ⊥ ∨ x = ⊥ ∧ y = d := by
   induction y <;> simp [unbotD_eq_iff, or_comm]
 
+/-- Apply a function to non-`⊥` elements, and send `⊥` to `d`. -/
+-- (If you think `WithBot` is equivalent to `Option`, this is the equivalent of `Option.elim`.)
+def mapD (d : β) (f : α → β) : WithBot α → β
+| .none => d
+| .some a => f a
+
+@[simp, grind =]
+theorem mapD_bot (d : β) (f : α → β) : mapD d f ⊥ = d :=
+  rfl
+
+@[simp, grind =]
+theorem mapD_coe (d : β) (f : α → β) (a : α) : mapD d f a = f a :=
+  rfl
+
 /-- Lift a map `f : α → β` to `WithBot α → WithBot β`. Implemented using `Option.map`. -/
 def map (f : α → β) : WithBot α → WithBot β :=
   Option.map f
@@ -605,6 +619,20 @@ theorem untopD_eq_self_iff {d : α} {x : WithTop α} : untopD d x = d ↔ x = d 
 theorem untopD_eq_untopD_iff {d : α} {x y : WithTop α} :
     untopD d x = untopD d y ↔ x = y ∨ x = d ∧ y = ⊤ ∨ x = ⊤ ∧ y = d :=
   WithBot.unbotD_eq_unbotD_iff
+
+/-- Apply a function to non-`⊤` elements, and send `⊤` to `d`. -/
+-- (If you think `WithTop` is equivalent to `Option`, this is the equivalent of `Option.elim`.)
+def mapD (d : β) (f : α → β) : WithTop α → β
+| .none => d
+| .some a => f a
+
+@[simp, grind =]
+theorem mapD_bot (d : β) (f : α → β) : mapD d f ⊤ = d :=
+  rfl
+
+@[simp, grind =]
+theorem mapD_coe (d : β) (f : α → β) (a : α) : mapD d f a = f a :=
+  rfl
 
 /-- Lift a map `f : α → β` to `WithTop α → WithTop β`. Implemented using `Option.map`. -/
 def map (f : α → β) : WithTop α → WithTop β :=


### PR DESCRIPTION
To replace Option.elim; working towards #27918


---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include at least one commit authored by each
co-author among the commits in the pull request. If necessary, you may 
create empty commits to indicate co-authorship, using commands like so:

git commit --author="Author Name <author@email.com>" --allow-empty -m "add Author Name as coauthor"

When merging, all the commits will be squashed into a single commit listing all co-authors.

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
