### PR TITLE
[Merged by Bors] - feat(SimpleGraph): lemmas characterizing graphs that are not complete/empty

### DIFF
--- a/Mathlib/Combinatorics/SimpleGraph/Basic.lean
+++ b/Mathlib/Combinatorics/SimpleGraph/Basic.lean
@@ -201,6 +201,8 @@ def IsSubgraph (x y : SimpleGraph V) : Prop :=
 instance : LE (SimpleGraph V) :=
   ⟨IsSubgraph⟩
 
+lemma le_iff_adj {G H : SimpleGraph V} : G ≤ H ↔ ∀ v w, G.Adj v w → H.Adj v w := .rfl
+
 @[simp]
 theorem isSubgraph_eq_le : (IsSubgraph : SimpleGraph V → SimpleGraph V → Prop) = (· ≤ ·) :=
   rfl
@@ -519,16 +521,10 @@ theorem adj_iff_exists_edge_coe : G.Adj a b ↔ ∃ e : G.edgeSet, e.val = s(a, 
   simp only [mem_edgeSet, exists_prop, SetCoe.exists, exists_eq_right]
 
 theorem ne_bot_iff_exists_adj : G ≠ ⊥ ↔ ∃ a b : V, G.Adj a b := by
-  refine ⟨fun h ↦ ?_, fun ⟨a, b, hab⟩ ↦ ?_⟩
-  · contrapose! h
-    exact le_bot_iff.mp h
-  · grind [SimpleGraph.bot_adj]
+  simp [← le_bot_iff, le_iff_adj]
 
 theorem ne_top_iff_exists_not_adj : G ≠ ⊤ ↔ ∃ a b : V, a ≠ b ∧ ¬G.Adj a b := by
-  refine ⟨fun h ↦ ?_, fun ⟨a, b, hne, hab⟩ ↦ ?_⟩
-  · contrapose! h
-    exact eq_top_iff.mpr h
-  · grind [SimpleGraph.top_adj]
+  simp [← top_le_iff, le_iff_adj]
 
 variable (G G₁ G₂)
 

--- a/Mathlib/Combinatorics/SimpleGraph/Basic.lean
+++ b/Mathlib/Combinatorics/SimpleGraph/Basic.lean
@@ -518,13 +518,17 @@ theorem adj_iff_exists_edge {v w : V} : G.Adj v w ↔ v ≠ w ∧ ∃ e ∈ G.ed
 theorem adj_iff_exists_edge_coe : G.Adj a b ↔ ∃ e : G.edgeSet, e.val = s(a, b) := by
   simp only [mem_edgeSet, exists_prop, SetCoe.exists, exists_eq_right]
 
-theorem exists_adj_of_ne_bot (h : G ≠ ⊥) : ∃ a b : V, G.Adj a b := by
-  contrapose! h
-  exact le_bot_iff.mp h
+theorem ne_bot_iff_exists_adj : G ≠ ⊥ ↔ ∃ a b : V, G.Adj a b := by
+  refine ⟨fun h ↦ ?_, fun ⟨a, b, hab⟩ ↦ ?_⟩
+  · contrapose! h
+    exact le_bot_iff.mp h
+  · grind [SimpleGraph.bot_adj]
 
-theorem exists_adj_of_ne_top (h : G ≠ ⊤) : ∃ a b : V, a ≠ b ∧ ¬G.Adj a b := by
-  contrapose! h
-  exact eq_top_iff.mpr h
+theorem ne_top_iff_exists_not_adj : G ≠ ⊤ ↔ ∃ a b : V, a ≠ b ∧ ¬G.Adj a b := by
+  refine ⟨fun h ↦ ?_, fun ⟨a, b, hne, hab⟩ ↦ ?_⟩
+  · contrapose! h
+    exact eq_top_iff.mpr h
+  · grind [SimpleGraph.top_adj]
 
 variable (G G₁ G₂)
 

--- a/Mathlib/Combinatorics/SimpleGraph/Basic.lean
+++ b/Mathlib/Combinatorics/SimpleGraph/Basic.lean
@@ -520,7 +520,7 @@ theorem adj_iff_exists_edge_coe : G.Adj a b ↔ ∃ e : G.edgeSet, e.val = s(a, 
 
 theorem exists_adj_of_ne_bot (h : G ≠ ⊥) : ∃ a b : V, G.Adj a b := by
   obtain ⟨x, hx⟩ := edgeSet_nonempty.mpr h
-  exact ⟨x.out.1, x.out.2, adj_iff_exists_edge_coe.mpr ⟨⟨x, hx⟩ , by simp⟩⟩
+  exact ⟨x.out.1, x.out.2, adj_iff_exists_edge_coe.mpr ⟨⟨x, hx⟩, by simp⟩⟩
 
 theorem exists_adj_of_ne_top (h : G ≠ ⊤) : ∃ a b : V, a ≠ b ∧ ¬G.Adj a b := by
   contrapose! h

--- a/Mathlib/Combinatorics/SimpleGraph/Basic.lean
+++ b/Mathlib/Combinatorics/SimpleGraph/Basic.lean
@@ -519,8 +519,8 @@ theorem adj_iff_exists_edge_coe : G.Adj a b ↔ ∃ e : G.edgeSet, e.val = s(a, 
   simp only [mem_edgeSet, exists_prop, SetCoe.exists, exists_eq_right]
 
 theorem exists_adj_of_ne_bot (h : G ≠ ⊥) : ∃ a b : V, G.Adj a b := by
-  obtain ⟨x, hx⟩ := edgeSet_nonempty.mpr h
-  exact ⟨x.out.1, x.out.2, adj_iff_exists_edge_coe.mpr ⟨⟨x, hx⟩, by simp⟩⟩
+  contrapose! h
+  exact le_bot_iff.mp h
 
 theorem exists_adj_of_ne_top (h : G ≠ ⊤) : ∃ a b : V, a ≠ b ∧ ¬G.Adj a b := by
   contrapose! h

--- a/Mathlib/Combinatorics/SimpleGraph/Basic.lean
+++ b/Mathlib/Combinatorics/SimpleGraph/Basic.lean
@@ -518,6 +518,14 @@ theorem adj_iff_exists_edge {v w : V} : G.Adj v w ↔ v ≠ w ∧ ∃ e ∈ G.ed
 theorem adj_iff_exists_edge_coe : G.Adj a b ↔ ∃ e : G.edgeSet, e.val = s(a, b) := by
   simp only [mem_edgeSet, exists_prop, SetCoe.exists, exists_eq_right]
 
+theorem exists_adj_of_ne_bot (h : G ≠ ⊥) : ∃ a b : V, G.Adj a b := by
+  obtain ⟨x, hx⟩ := edgeSet_nonempty.mpr h
+  exact ⟨x.out.1, x.out.2, adj_iff_exists_edge_coe.mpr ⟨⟨x, hx⟩ , by simp⟩⟩
+
+theorem exists_adj_of_ne_top (h : G ≠ ⊤) : ∃ a b : V, a ≠ b ∧ ¬G.Adj a b := by
+  contrapose! h
+  exact eq_top_iff.mpr h
+
 variable (G G₁ G₂)
 
 theorem edge_other_ne {e : Sym2 V} (he : e ∈ G.edgeSet) {v : V} (h : v ∈ e) :


### PR DESCRIPTION
Two helper lemmas that I've found useful in several other PRs that characterize graphs that are neither complete nor empty.


---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include at least one commit authored by each
co-author among the commits in the pull request. If necessary, you may 
create empty commits to indicate co-authorship, using commands like so:

git commit --author="Author Name <author@email.com>" --allow-empty -m "add Author Name as coauthor"

When merging, all the commits will be squashed into a single commit listing all co-authors.

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
