### PR TITLE
[Merged by Bors] - feat(SimpleGraph): characterise when `SimpleGraph V` is a subsingleton/nontrivial

### DIFF
--- a/Mathlib/Combinatorics/SimpleGraph/Basic.lean
+++ b/Mathlib/Combinatorics/SimpleGraph/Basic.lean
@@ -820,11 +820,11 @@ protected theorem nontrivial_iff : Nontrivial (SimpleGraph V) ↔ Nontrivial V :
 
 theorem nontrivial_of_ne_bot {G : SimpleGraph V} (h : G ≠ ⊥) : Nontrivial V := by
   contrapose! h
-  exact subsingleton_iff.mpr h |>.allEq _ _
+  exact SimpleGraph.subsingleton_iff.mpr h |>.allEq _ _
 
 theorem nontrivial_of_ne_top {G : SimpleGraph V} (h : G ≠ ⊤) : Nontrivial V := by
   contrapose! h
-  exact subsingleton_iff.mpr h |>.allEq _ _
+  exact SimpleGraph.subsingleton_iff.mpr h |>.allEq _ _
 
 end Subsingleton
 

--- a/Mathlib/Combinatorics/SimpleGraph/Basic.lean
+++ b/Mathlib/Combinatorics/SimpleGraph/Basic.lean
@@ -808,23 +808,23 @@ end Incidence
 
 section Subsingleton
 
-theorem subsingleton_iff_subsingleton : Subsingleton V ↔ Subsingleton (SimpleGraph V) := by
-  refine ⟨fun _ ↦ Unique.instSubsingleton, fun h ↦ ?_⟩
+theorem subsingleton_iff : Subsingleton (SimpleGraph V) ↔ Subsingleton V := by
+  refine ⟨fun h ↦ ?_, fun _ ↦ Unique.instSubsingleton⟩
   contrapose! h
   exact instNontrivial
 
-theorem nontrivial_iff_nontrivial : Nontrivial V ↔ Nontrivial (SimpleGraph V) := by
-  refine ⟨fun _ ↦ instNontrivial, fun h ↦ ?_⟩
+theorem nontrivial_iff : Nontrivial (SimpleGraph V) ↔ Nontrivial V := by
+  refine ⟨fun h ↦ ?_, fun _ ↦ instNontrivial⟩
   contrapose! h
   exact Unique.instSubsingleton
 
 theorem nontrivial_of_ne_bot {G : SimpleGraph V} (h : G ≠ ⊥) : Nontrivial V := by
   contrapose! h
-  exact subsingleton_iff_subsingleton.mp h |>.allEq _ _
+  exact subsingleton_iff.mpr h |>.allEq _ _
 
 theorem nontrivial_of_ne_top {G : SimpleGraph V} (h : G ≠ ⊤) : Nontrivial V := by
   contrapose! h
-  exact subsingleton_iff_subsingleton.mp h |>.allEq _ _
+  exact subsingleton_iff.mpr h |>.allEq _ _
 
 end Subsingleton
 

--- a/Mathlib/Combinatorics/SimpleGraph/Basic.lean
+++ b/Mathlib/Combinatorics/SimpleGraph/Basic.lean
@@ -806,4 +806,28 @@ def incidenceSetEquivNeighborSet (v : V) : G.incidenceSet v ≃ G.neighborSet v 
 
 end Incidence
 
+section Subsingleton
+
+theorem subsingleton_iff_subsingleton : Subsingleton V ↔ Subsingleton (SimpleGraph V) := by
+  refine ⟨fun _ ↦ Unique.instSubsingleton, fun h ↦ ?_⟩
+  contrapose! h
+  rw [not_subsingleton_iff_nontrivial] at h ⊢
+  exact instNontrivial
+
+theorem nontrivial_iff_nontrivial : Nontrivial V ↔ Nontrivial (SimpleGraph V) := by
+  refine ⟨fun _ ↦ instNontrivial, fun h ↦ ?_⟩
+  contrapose! h
+  rw [not_nontrivial_iff_subsingleton] at h ⊢
+  exact Unique.instSubsingleton
+
+theorem nontrivial_of_ne_bot {G : SimpleGraph V} (h : G ≠ ⊥) : Nontrivial V := by
+  contrapose! h
+  exact subsingleton_iff_subsingleton.mp (not_nontrivial_iff_subsingleton.mp h) |>.allEq _ _
+
+theorem nontrivial_of_ne_top {G : SimpleGraph V} (h : G ≠ ⊤) : Nontrivial V := by
+  contrapose! h
+  exact subsingleton_iff_subsingleton.mp (not_nontrivial_iff_subsingleton.mp h) |>.allEq _ _
+
+end Subsingleton
+
 end SimpleGraph

--- a/Mathlib/Combinatorics/SimpleGraph/Basic.lean
+++ b/Mathlib/Combinatorics/SimpleGraph/Basic.lean
@@ -811,22 +811,20 @@ section Subsingleton
 theorem subsingleton_iff_subsingleton : Subsingleton V ↔ Subsingleton (SimpleGraph V) := by
   refine ⟨fun _ ↦ Unique.instSubsingleton, fun h ↦ ?_⟩
   contrapose! h
-  rw [not_subsingleton_iff_nontrivial] at h ⊢
   exact instNontrivial
 
 theorem nontrivial_iff_nontrivial : Nontrivial V ↔ Nontrivial (SimpleGraph V) := by
   refine ⟨fun _ ↦ instNontrivial, fun h ↦ ?_⟩
   contrapose! h
-  rw [not_nontrivial_iff_subsingleton] at h ⊢
   exact Unique.instSubsingleton
 
 theorem nontrivial_of_ne_bot {G : SimpleGraph V} (h : G ≠ ⊥) : Nontrivial V := by
   contrapose! h
-  exact subsingleton_iff_subsingleton.mp (not_nontrivial_iff_subsingleton.mp h) |>.allEq _ _
+  exact subsingleton_iff_subsingleton.mp h |>.allEq _ _
 
 theorem nontrivial_of_ne_top {G : SimpleGraph V} (h : G ≠ ⊤) : Nontrivial V := by
   contrapose! h
-  exact subsingleton_iff_subsingleton.mp (not_nontrivial_iff_subsingleton.mp h) |>.allEq _ _
+  exact subsingleton_iff_subsingleton.mp h |>.allEq _ _
 
 end Subsingleton
 

--- a/Mathlib/Combinatorics/SimpleGraph/Basic.lean
+++ b/Mathlib/Combinatorics/SimpleGraph/Basic.lean
@@ -808,12 +808,12 @@ end Incidence
 
 section Subsingleton
 
-theorem subsingleton_iff : Subsingleton (SimpleGraph V) ↔ Subsingleton V := by
+protected theorem subsingleton_iff : Subsingleton (SimpleGraph V) ↔ Subsingleton V := by
   refine ⟨fun h ↦ ?_, fun _ ↦ Unique.instSubsingleton⟩
   contrapose! h
   exact instNontrivial
 
-theorem nontrivial_iff : Nontrivial (SimpleGraph V) ↔ Nontrivial V := by
+protected theorem nontrivial_iff : Nontrivial (SimpleGraph V) ↔ Nontrivial V := by
   refine ⟨fun h ↦ ?_, fun _ ↦ instNontrivial⟩
   contrapose! h
   exact Unique.instSubsingleton

--- a/Mathlib/Combinatorics/SimpleGraph/Basic.lean
+++ b/Mathlib/Combinatorics/SimpleGraph/Basic.lean
@@ -818,14 +818,6 @@ protected theorem nontrivial_iff : Nontrivial (SimpleGraph V) ↔ Nontrivial V :
   contrapose! h
   exact Unique.instSubsingleton
 
-theorem nontrivial_of_ne_bot {G : SimpleGraph V} (h : G ≠ ⊥) : Nontrivial V := by
-  contrapose! h
-  exact SimpleGraph.subsingleton_iff.mpr h |>.allEq _ _
-
-theorem nontrivial_of_ne_top {G : SimpleGraph V} (h : G ≠ ⊤) : Nontrivial V := by
-  contrapose! h
-  exact SimpleGraph.subsingleton_iff.mpr h |>.allEq _ _
-
 end Subsingleton
 
 end SimpleGraph


### PR DESCRIPTION
Helper lemmas I found useful in mutliple PRs for dispatching trivial cases.


---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include at least one commit authored by each
co-author among the commits in the pull request. If necessary, you may 
create empty commits to indicate co-authorship, using commands like so:

git commit --author="Author Name <author@email.com>" --allow-empty -m "add Author Name as coauthor"

When merging, all the commits will be squashed into a single commit listing all co-authors.

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
