### PR TITLE
feat(Topology/Baire): define IsNonMeagre

### DIFF
--- a/Mathlib/Topology/Baire/NonMeagre.lean
+++ b/Mathlib/Topology/Baire/NonMeagre.lean
@@ -1,0 +1,72 @@
+/-
+Copyright (c) 2025 Shaun Allison. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Shaun Allison
+-/
+import Mathlib.Topology.Baire.BaireMeasurable
+import Mathlib.Topology.Baire.Lemmas
+
+/-!
+# Non-Meagre Sets
+
+This file defines `IsNonMeagre` as `¬ IsMeagre A` and proves basic properties of these sets.
+Historically these are often called "of the second category" while meagre sets are "of the first
+category". These are of generally of interest in the context of a Baire Space.
+-/
+
+open Function Topology TopologicalSpace Set
+
+variable {α : Type*} [TopologicalSpace α]
+variable {s t : Set α}
+
+abbrev IsNonMeagre (A : Set α) : Prop := ¬ IsMeagre A
+
+theorem IsNonMeagre.nonempty [Nonempty α] (hs : IsNonMeagre s) : s.Nonempty := by
+  contrapose! hs
+  exact hs ▸ IsMeagre.empty
+
+lemma IsNonMeagre.mono (hs : IsNonMeagre s) (hst : s ⊆ t) : IsNonMeagre t :=
+  mt (IsMeagre.mono · hst) hs
+
+lemma IsNonMeagre.congr_residual (hst : s =ᵇ t) : IsNonMeagre s ↔ IsNonMeagre t := by
+  have : IsMeagre s ↔ IsMeagre t := by exact isMeagre_congr_residual hst
+  exact not_congr this
+
+lemma BaireMeasurableSet.IsNonMeagre_residualEq_isOpen_Nonempty (hBM : BaireMeasurableSet s)
+    (hNM : IsNonMeagre s) : ∃ u : Set α, (IsOpen u) ∧ u.Nonempty ∧ s =ᵇ u := by
+  rcases hBM.residualEq_isOpen with ⟨u, h_open, h_su⟩
+  refine ⟨u, h_open, ?_, h_su⟩
+  rw [IsNonMeagre.congr_residual h_su] at hNM
+  exact nonempty_of_not_isMeagre hNM
+
+theorem IsOpen.IsNonMeagre_of_Nonempty [BaireSpace α] (h_open : IsOpen s) (h_ne : s.Nonempty)
+     : IsNonMeagre s := by
+  by_contra h_meagre
+  apply dense_of_mem_residual at h_meagre
+  have : (s ∩ sᶜ).Nonempty := Dense.inter_open_nonempty h_meagre s h_open h_ne
+  simp only [inter_compl_self, Set.not_nonempty_empty] at this
+
+theorem IsNonMeagre.univ [Nonempty α] [BaireSpace α] : IsNonMeagre (univ : Set α) := by
+  simp [IsNonMeagre, IsMeagre]
+  by_contra h
+  have : False := Set.not_nonempty_empty (dense_of_mem_residual h).nonempty
+  contradiction
+
+theorem IsNonMeagre.of_nonempty_interior [BaireSpace α] (hs : (interior s).Nonempty)
+    : IsNonMeagre s :=
+  IsNonMeagre.mono (isOpen_interior.IsNonMeagre_of_Nonempty hs) interior_subset
+
+theorem IsNonMeagre.of_mem_nhds [BaireSpace α] {a : α} (hs : s ∈ 𝓝 a)
+    : IsNonMeagre s := by
+  obtain ⟨U, hUs, hU_open, h_aU⟩ := mem_nhds_iff.mp hs
+  exact IsNonMeagre.mono (hU_open.IsNonMeagre_of_Nonempty ⟨a, h_aU⟩) hUs
+
+/-- If a countable union of sets covers the space, then one of the sets is non meagre. -/
+theorem IsNonMeagre.of_iUnion_univ {ι : Sort*} [Nonempty α] [BaireSpace α] [Countable ι]
+  {f : ι → Set α} (hU : ⋃ i, f i = Set.univ) : ∃ i, IsNonMeagre (f i) := by
+  by_contra! h
+  have : IsMeagre (Set.univ : Set α) := by
+    rw [←hU]
+    exact isMeagre_iUnion h
+  have : False := IsNonMeagre.univ this
+  contradiction

--- a/Mathlib/Topology/GDelta/Basic.lean
+++ b/Mathlib/Topology/GDelta/Basic.lean
@@ -232,7 +232,7 @@ lemma IsMeagre.union {s t : Set X} (hs : IsMeagre s) (ht : IsMeagre t) : IsMeagr
   exact inter_mem hs ht
 
 /-- A countable union of meagre sets is meagre. -/
-lemma isMeagre_iUnion [Countable ι] {f : ι → Set X} (hs : ∀ i, IsMeagre (f i)) :
+lemma isMeagre_iUnion [Countable ι'] {f : ι' → Set X} (hs : ∀ i, IsMeagre (f i)) :
     IsMeagre (⋃ i, f i) := by
   rw [IsMeagre, compl_iUnion]
   exact countable_iInter_mem.mpr hs

--- a/Mathlib/Topology/GDelta/Basic.lean
+++ b/Mathlib/Topology/GDelta/Basic.lean
@@ -256,4 +256,14 @@ lemma nonempty_of_not_isMeagre {s : Set X} (hs : ¬IsMeagre s) : s.Nonempty := b
   contrapose! hs
   simpa [hs] using IsMeagre.empty
 
+lemma isMeagre_congr_residual {s t : Set X} (h : s =ᶠ[residual X] t) : IsMeagre s ↔ IsMeagre t := by
+  constructor <;> {
+    intro h_meagre
+    have : _ᶜ ∩ {x | s x = t x} ∈ residual X := inter_mem h_meagre h
+    refine mem_of_superset this ?_
+    intro x ⟨hs, hx⟩
+    simp only [mem_setOf_eq] at hx
+    tauto
+  }
+
 end IsMeagre


### PR DESCRIPTION
non-meagre sets (also known as "of the second category") are worthy of their own definition and API. This was useful to me for formalizing a result of "automatic continuity", that is, a Baire-measurable homomorphism between Polish groups must be continuous. Simply working with the negation of IsMeagre quickly became cumbersome, and non-meagre sets have an important role in the study of Polish (e.g. locally compact) groups.

From https://github.com/shalliso/automatic_continuity

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include at least one commit authored by each
co-author among the commits in the pull request. If necessary, you may 
create empty commits to indicate co-authorship, using commands like so:

git commit --author="Author Name <author@email.com>" --allow-empty -m "add Author Name as coauthor"

When merging, all the commits will be squashed into a single commit listing all co-authors.

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
