### PR TITLE
[Merged by Bors] - chore(RingTheory/Spectrum/Prime/Module): golf `stableUnderSpecialization_support` using `mem_support_mono`

### DIFF
--- a/Mathlib/RingTheory/Spectrum/Prime/Module.lean
+++ b/Mathlib/RingTheory/Spectrum/Prime/Module.lean
@@ -36,12 +36,8 @@ lemma LocalizedModule.subsingleton_iff_disjoint {f : R} :
   rw [subsingleton_iff_support_subset, PrimeSpectrum.basicOpen_eq_zeroLocus_compl,
     disjoint_compl_left_iff, Set.le_iff_subset]
 
-lemma Module.stableUnderSpecialization_support :
-    StableUnderSpecialization (Module.support R M) := by
-  intro x y e H
-  rw [mem_support_iff_exists_annihilator] at H ⊢
-  obtain ⟨m, hm⟩ := H
-  exact ⟨m, hm.trans ((PrimeSpectrum.le_iff_specializes _ _).mpr e)⟩
+lemma Module.stableUnderSpecialization_support : StableUnderSpecialization (Module.support R M) :=
+  fun x y e ↦ mem_support_mono <| (PrimeSpectrum.le_iff_specializes x y).mpr e
 
 lemma Module.isClosed_support [Module.Finite R M] :
     IsClosed (Module.support R M) := by


### PR DESCRIPTION
Golf [Module.stableUnderSpecialization_support](https://leanprover-community.github.io/mathlib4_docs/Mathlib/RingTheory/Spectrum/Prime/Module.html#Module.stableUnderSpecialization_support) using [Module.mem_support_mono](https://leanprover-community.github.io/mathlib4_docs/Mathlib/RingTheory/Support.html#Module.mem_support_mono).

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include at least one commit authored by each
co-author among the commits in the pull request. If necessary, you may 
create empty commits to indicate co-authorship, using commands like so:

git commit --author="Author Name <author@email.com>" --allow-empty -m "add Author Name as coauthor"

When merging, all the commits will be squashed into a single commit listing all co-authors.

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
