### PR TITLE
[Merged by Bors] - chore(CategoryTheory/Monoidal/Mon): reorder

### DIFF
--- a/Mathlib/CategoryTheory/Monoidal/Mon_.lean
+++ b/Mathlib/CategoryTheory/Monoidal/Mon_.lean
@@ -734,9 +734,6 @@ def mapMonNatTrans (f : F ⟶ F') [NatTrans.IsMonoidal f] : F.mapMon ⟶ F'.mapM
 def mapMonNatIso (e : F ≅ F') [NatTrans.IsMonoidal e.hom] : F.mapMon ≅ F'.mapMon :=
   NatIso.ofComponents fun X ↦ Mon.mkIso (e.app _)
 
-attribute [local simp] ε_tensorHom_comp_μ_assoc in
-instance [F.LaxMonoidal] : IsMonHom (ε F) where
-
 end LaxMonoidal
 
 section OplaxMonoidal

--- a/Mathlib/CategoryTheory/Monoidal/Mon_.lean
+++ b/Mathlib/CategoryTheory/Monoidal/Mon_.lean
@@ -222,6 +222,198 @@ theorem mul_assoc_flip : M ◁ μ ≫ μ = (α_ M M M).inv ≫ μ ▷ M ≫ μ :
 
 end MonObj
 
+namespace MonObj
+
+/-!
+In this section, we prove that the category of monoids in a braided monoidal category is monoidal.
+
+Given two monoids `M` and `N` in a braided monoidal category `C`,
+the multiplication on the tensor product `M.X ⊗ N.X` is defined in the obvious way:
+it is the tensor product of the multiplications on `M` and `N`,
+except that the tensor factors in the source come in the wrong order,
+which we fix by pre-composing with a permutation isomorphism constructed from the braiding.
+
+(There is a subtlety here: in fact there are two ways to do these,
+using either the positive or negative crossing.)
+
+A more conceptual way of understanding this definition is the following:
+The braiding on `C` gives rise to a monoidal structure on
+the tensor product functor from `C × C` to `C`.
+A pair of monoids in `C` gives rise to a monoid in `C × C`,
+which the tensor product functor by being monoidal takes to a monoid in `C`.
+The permutation isomorphism appearing in the definition of
+the multiplication on the tensor product of two monoids is
+an instance of a more general family of isomorphisms
+which together form a strength that equips the tensor product functor with a monoidal structure,
+and the monoid axioms for the tensor product follow from the monoid axioms for the tensor factors
+plus the properties of the strength (i.e., monoidal functor axioms).
+The strength `tensorμ` of the tensor product functor has been defined in
+`Mathlib/CategoryTheory/Monoidal/Braided.lean`.
+Its properties, stated as independent lemmas in that module,
+are used extensively in the proofs below.
+Notice that we could have followed the above plan not only conceptually
+but also as a possible implementation and
+could have constructed the tensor product of monoids via `mapMon`,
+but we chose to give a more explicit definition directly in terms of `tensorμ`.
+
+To complete the definition of the monoidal category structure on the category of monoids,
+we need to provide definitions of associator and unitors.
+The obvious candidates are the associator and unitors from `C`,
+but we need to prove that they are monoid morphisms, i.e., compatible with unit and multiplication.
+These properties translate to the monoidality of the associator and unitors
+(with respect to the monoidal structures on the functors they relate),
+which have also been proved in `Mathlib/CategoryTheory/Monoidal/Braided.lean`.
+
+-/
+
+-- The proofs that associators and unitors preserve monoid units don't require braiding.
+lemma one_associator {M N P : C} [MonObj M] [MonObj N] [MonObj P] :
+    ((λ_ (𝟙_ C)).inv ≫ ((λ_ (𝟙_ C)).inv ≫ (η[M] ⊗ₘ η[N]) ⊗ₘ η[P])) ≫ (α_ M N P).hom =
+      (λ_ (𝟙_ C)).inv ≫ (η[M] ⊗ₘ (λ_ (𝟙_ C)).inv ≫ (η[N] ⊗ₘ η[P])) := by
+  simp only [Category.assoc, Iso.cancel_iso_inv_left]
+  slice_lhs 1 3 => rw [← Category.id_comp (η : 𝟙_ C ⟶ P), ← tensorHom_comp_tensorHom]
+  slice_lhs 2 3 => rw [associator_naturality]
+  slice_rhs 1 2 => rw [← Category.id_comp η, ← tensorHom_comp_tensorHom]
+  slice_lhs 1 2 => rw [tensorHom_id, ← leftUnitor_tensor_inv]
+  rw [← cancel_epi (λ_ (𝟙_ C)).inv]
+  slice_lhs 1 2 => rw [leftUnitor_inv_naturality]
+  simp
+
+lemma one_leftUnitor {M : C} [MonObj M] :
+    ((λ_ (𝟙_ C)).inv ≫ (𝟙 (𝟙_ C) ⊗ₘ η[M])) ≫ (λ_ M).hom = η := by
+  simp
+
+lemma one_rightUnitor {M : C} [MonObj M] :
+    ((λ_ (𝟙_ C)).inv ≫ (η[M] ⊗ₘ 𝟙 (𝟙_ C))) ≫ (ρ_ M).hom = η := by
+  simp [← unitors_equal]
+
+section BraidedCategory
+
+variable [BraidedCategory C]
+
+lemma Mon_tensor_one_mul (M N : C) [MonObj M] [MonObj N] :
+    (((λ_ (𝟙_ C)).inv ≫ (η[M] ⊗ₘ η[N])) ▷ (M ⊗ N)) ≫
+        tensorμ M N M N ≫ (μ ⊗ₘ μ) =
+      (λ_ (M ⊗ N)).hom := by
+  simp only [comp_whiskerRight_assoc]
+  slice_lhs 2 3 => rw [tensorμ_natural_left]
+  slice_lhs 3 4 => rw [tensorHom_comp_tensorHom, one_mul, one_mul]
+  symm
+  exact tensor_left_unitality M N
+
+lemma Mon_tensor_mul_one (M N : C) [MonObj M] [MonObj N] :
+    (M ⊗ N) ◁ ((λ_ (𝟙_ C)).inv ≫ (η[M] ⊗ₘ η[N])) ≫
+        tensorμ M N M N ≫ (μ[M] ⊗ₘ μ[N]) =
+      (ρ_ (M ⊗ N)).hom := by
+  simp only [whiskerLeft_comp_assoc]
+  slice_lhs 2 3 => rw [tensorμ_natural_right]
+  slice_lhs 3 4 => rw [tensorHom_comp_tensorHom, mul_one, mul_one]
+  symm
+  exact tensor_right_unitality M N
+
+lemma Mon_tensor_mul_assoc (M N : C) [MonObj M] [MonObj N] :
+    ((tensorμ M N M N ≫ (μ ⊗ₘ μ)) ▷ (M ⊗ N)) ≫
+        tensorμ M N M N ≫ (μ ⊗ₘ μ) =
+      (α_ (M ⊗ N : C) (M ⊗ N) (M ⊗ N)).hom ≫
+        ((M ⊗ N : C) ◁ (tensorμ M N M N ≫ (μ ⊗ₘ μ))) ≫
+          tensorμ M N M N ≫ (μ ⊗ₘ μ) := by
+  simp only [comp_whiskerRight_assoc, whiskerLeft_comp_assoc]
+  slice_lhs 2 3 => rw [tensorμ_natural_left]
+  slice_lhs 3 4 => rw [tensorHom_comp_tensorHom, mul_assoc, mul_assoc, ← tensorHom_comp_tensorHom,
+    ← tensorHom_comp_tensorHom]
+  slice_lhs 1 3 => rw [tensor_associativity]
+  slice_lhs 3 4 => rw [← tensorμ_natural_right]
+  simp
+
+lemma mul_associator {M N P : C} [MonObj M] [MonObj N] [MonObj P] :
+    (tensorμ (M ⊗ N) P (M ⊗ N) P ≫
+          (tensorμ M N M N ≫ (μ ⊗ₘ μ) ⊗ₘ μ)) ≫
+        (α_ M N P).hom =
+      ((α_ M N P).hom ⊗ₘ (α_ M N P).hom) ≫
+        tensorμ M (N ⊗ P) M (N ⊗ P) ≫
+          (μ ⊗ₘ tensorμ N P N P ≫ (μ ⊗ₘ μ)) := by
+  simp only [Category.assoc]
+  slice_lhs 2 3 => rw [← Category.id_comp μ[P], ← tensorHom_comp_tensorHom]
+  slice_lhs 3 4 => rw [associator_naturality]
+  slice_rhs 3 4 => rw [← Category.id_comp μ, ← tensorHom_comp_tensorHom]
+  simp only [tensorHom_id, id_tensorHom]
+  slice_lhs 1 3 => rw [associator_monoidal]
+  simp only [Category.assoc]
+
+lemma mul_leftUnitor {M : C} [MonObj M] :
+    (tensorμ (𝟙_ C) M (𝟙_ C) M ≫ ((λ_ (𝟙_ C)).hom ⊗ₘ μ)) ≫ (λ_ M).hom =
+      ((λ_ M).hom ⊗ₘ (λ_ M).hom) ≫ μ := by
+  rw [← Category.comp_id (λ_ (𝟙_ C)).hom, ← Category.id_comp μ, ← tensorHom_comp_tensorHom]
+  simp only [tensorHom_id, id_tensorHom]
+  slice_lhs 3 4 => rw [leftUnitor_naturality]
+  slice_lhs 1 3 => rw [← leftUnitor_monoidal]
+  simp only [Category.id_comp]
+
+lemma mul_rightUnitor {M : C} [MonObj M] :
+    (tensorμ M (𝟙_ C) M (𝟙_ C) ≫ (μ ⊗ₘ (λ_ (𝟙_ C)).hom)) ≫ (ρ_ M).hom =
+      ((ρ_ M).hom ⊗ₘ (ρ_ M).hom) ≫ μ := by
+  rw [← Category.id_comp μ, ← Category.comp_id (λ_ (𝟙_ C)).hom, ← tensorHom_comp_tensorHom]
+  simp only [tensorHom_id, id_tensorHom]
+  slice_lhs 3 4 => rw [rightUnitor_naturality]
+  slice_lhs 1 3 => rw [← rightUnitor_monoidal]
+  simp only [Category.id_comp]
+
+namespace tensorObj
+
+-- We don't want `tensorObj.one_def` to be simp as it would loop with `IsMonHom.one_hom` applied
+-- to `(λ_ N.X).inv`.
+@[simps -isSimp]
+instance {M N : C} [MonObj M] [MonObj N] : MonObj (M ⊗ N) where
+  one := (λ_ (𝟙_ C)).inv ≫ (η ⊗ₘ η)
+  mul := tensorμ M N M N ≫ (μ ⊗ₘ μ)
+  one_mul := Mon_tensor_one_mul M N
+  mul_one := Mon_tensor_mul_one M N
+  mul_assoc := Mon_tensor_mul_assoc M N
+
+end tensorObj
+
+open IsMonHom
+
+variable {X Y Z W : C} [MonObj X] [MonObj Y] [MonObj Z] [MonObj W]
+
+instance {f : X ⟶ Y} {g : Z ⟶ W} [IsMonHom f] [IsMonHom g] : IsMonHom (f ⊗ₘ g) where
+  one_hom := by
+    dsimp [tensorObj.one_def]
+    slice_lhs 2 3 => rw [tensorHom_comp_tensorHom, one_hom, one_hom]
+  mul_hom := by
+    dsimp [tensorObj.mul_def]
+    slice_rhs 1 2 => rw [tensorμ_natural]
+    slice_lhs 2 3 => rw [tensorHom_comp_tensorHom, mul_hom, mul_hom, ← tensorHom_comp_tensorHom]
+    simp only [Category.assoc]
+
+instance : IsMonHom (𝟙 X) where
+
+instance {f : Y ⟶ Z} [IsMonHom f] : IsMonHom (X ◁ f) where
+  one_hom := by simpa using (inferInstanceAs <| IsMonHom (𝟙 X ⊗ₘ f)).one_hom
+  mul_hom := by simpa using (inferInstanceAs <| IsMonHom (𝟙 X ⊗ₘ f)).mul_hom
+
+instance {f : X ⟶ Y} [IsMonHom f] : IsMonHom (f ▷ Z) where
+  one_hom := by simpa using (inferInstanceAs <| IsMonHom (f ⊗ₘ (𝟙 Z))).one_hom
+  mul_hom := by simpa using (inferInstanceAs <| IsMonHom (f ⊗ₘ (𝟙 Z))).mul_hom
+
+instance : IsMonHom (α_ X Y Z).hom :=
+  ⟨one_associator, mul_associator⟩
+
+instance : IsMonHom (λ_ X).hom :=
+  ⟨one_leftUnitor, mul_leftUnitor⟩
+
+instance : IsMonHom (ρ_ X).hom :=
+  ⟨one_rightUnitor, mul_rightUnitor⟩
+
+lemma one_braiding (X Y : C) [MonObj X] [MonObj Y] : η ≫ (β_ X Y).hom = η := by
+  simp only [tensorObj.one_def, Category.assoc, BraidedCategory.braiding_naturality,
+    braiding_tensorUnit_right, Iso.cancel_iso_inv_left]
+  monoidal
+
+end BraidedCategory
+
+end MonObj
+
 namespace Mon
 
 /-- A morphism of monoid objects. -/
@@ -329,7 +521,128 @@ open CategoryTheory.Limits
 instance : HasInitial (Mon C) :=
   hasInitial_of_unique (Mon.trivial C)
 
+section BraidedCategory
+variable [BraidedCategory C]
+
+@[simps! tensorObj_X tensorHom_hom]
+instance monMonoidalStruct : MonoidalCategoryStruct (Mon C) where
+  tensorObj M N := ⟨M.X ⊗ N.X⟩
+  tensorHom f g := Hom.mk (f.hom ⊗ₘ g.hom)
+  whiskerRight f Y := Hom.mk (f.hom ▷ Y.X)
+  whiskerLeft X _ _ g := Hom.mk (X.X ◁ g.hom)
+  tensorUnit := ⟨𝟙_ C⟩
+  associator M N P := mkIso' <| associator M.X N.X P.X
+  leftUnitor M := mkIso' <| leftUnitor M.X
+  rightUnitor M := mkIso' <| rightUnitor M.X
+
+@[simp] lemma tensorUnit_X : (𝟙_ (Mon C)).X = 𝟙_ C := rfl
+@[simp] lemma tensorUnit_one : η[(𝟙_ (Mon C)).X] = 𝟙 (𝟙_ C) := rfl
+@[simp] lemma tensorUnit_mul : μ[(𝟙_ (Mon C)).X] = (λ_ (𝟙_ C)).hom := rfl
+
+@[simp]
+lemma tensorObj_one (X Y : Mon C) : η[(X ⊗ Y).X] = (λ_ (𝟙_ C)).inv ≫ (η[X.X] ⊗ₘ η[Y.X]) := rfl
+
+@[simp] lemma tensorObj_mul (X Y : Mon C) :
+    μ[(X ⊗ Y).X] = tensorμ X.X Y.X X.X Y.X ≫ (μ[X.X] ⊗ₘ μ[Y.X]) := rfl
+
+@[simp]
+lemma whiskerLeft_hom {X Y : Mon C} (f : X ⟶ Y) (Z : Mon C) : (f ▷ Z).hom = f.hom ▷ Z.X := rfl
+
+@[simp]
+lemma whiskerRight_hom (X : Mon C) {Y Z : Mon C} (f : Y ⟶ Z) : (X ◁ f).hom = X.X ◁ f.hom := rfl
+
+@[simp] lemma leftUnitor_hom_hom (X : Mon C) : (λ_ X).hom.hom = (λ_ X.X).hom := rfl
+@[simp] lemma leftUnitor_inv_hom (X : Mon C) : (λ_ X).inv.hom = (λ_ X.X).inv := rfl
+@[simp] lemma rightUnitor_hom_hom (X : Mon C) : (ρ_ X).hom.hom = (ρ_ X.X).hom := rfl
+@[simp] lemma rightUnitor_inv_hom (X : Mon C) : (ρ_ X).inv.hom = (ρ_ X.X).inv := rfl
+
+@[simp] lemma associator_hom_hom (X Y Z : Mon C) : (α_ X Y Z).hom.hom = (α_ X.X Y.X Z.X).hom := rfl
+@[simp] lemma associator_inv_hom (X Y Z : Mon C) : (α_ X Y Z).inv.hom = (α_ X.X Y.X Z.X).inv := rfl
+
+@[simp] lemma tensor_one (M N : Mon C) : η[(M ⊗ N).X] = (λ_ (𝟙_ C)).inv ≫ (η[M.X] ⊗ₘ η[N.X]) := rfl
+
+@[simp]
+lemma tensor_mul (M N : Mon C) : μ[(M ⊗ N).X] = tensorμ M.X N.X M.X N.X ≫ (μ[M.X] ⊗ₘ μ[N.X]) := rfl
+
+instance monMonoidal : MonoidalCategory (Mon C) where
+  tensorHom_def := by intros; ext; simp [tensorHom_def]
+
+-- We don't want `tensorObj.one_def` to be simp as it would loop with `IsMonHom.one_hom` applied
+-- to `(λ_ N.X).inv`.
+@[simps! -isSimp]
+instance {M N : C} [MonObj M] [MonObj N] : MonObj (M ⊗ N) :=
+  inferInstanceAs <| MonObj (Mon.mk M ⊗ Mon.mk N).X
+
+variable (C)
+
+/-- The forgetful functor from `Mon C` to `C` is monoidal when `C` is monoidal. -/
+instance : (forget C).Monoidal :=
+  Functor.CoreMonoidal.toMonoidal
+    { εIso := Iso.refl _
+      μIso _ _ := Iso.refl _ }
+
+@[simp] lemma forget_ε : ε (forget C) = 𝟙 (𝟙_ C) := rfl
+@[simp] lemma forget_η : «η» (forget C) = 𝟙 (𝟙_ C) := rfl
+@[simp] lemma forget_μ (X Y : Mon C) : «μ» (forget C) X Y = 𝟙 (X.X ⊗ Y.X) := rfl
+@[simp] lemma forget_δ (X Y : Mon C) : δ (forget C) X Y = 𝟙 (X.X ⊗ Y.X) := rfl
+
+end BraidedCategory
 end Mon
+
+/-!
+We next show that if `C` is symmetric, then `Mon C` is braided, and indeed symmetric.
+
+Note that `Mon C` is *not* braided in general when `C` is only braided.
+
+The more interesting construction is the 2-category of monoids in `C`,
+bimodules between the monoids, and intertwiners between the bimodules.
+
+When `C` is braided, that is a monoidal 2-category.
+-/
+section SymmetricCategory
+
+variable [SymmetricCategory C]
+
+namespace MonObj
+
+lemma mul_braiding (X Y : C) [MonObj X] [MonObj Y] :
+    μ ≫ (β_ X Y).hom = ((β_ X Y).hom ⊗ₘ (β_ X Y).hom) ≫ μ := by
+  dsimp [tensorObj.mul_def]
+  simp only [tensorμ, Category.assoc, BraidedCategory.braiding_naturality,
+    BraidedCategory.braiding_tensor_right_hom, BraidedCategory.braiding_tensor_left_hom,
+    comp_whiskerRight, whisker_assoc, whiskerLeft_comp, pentagon_assoc,
+    pentagon_inv_hom_hom_hom_inv_assoc, Iso.inv_hom_id_assoc, whiskerLeft_hom_inv_assoc]
+  slice_lhs 3 4 =>
+    -- We use symmetry here:
+    rw [← whiskerLeft_comp, ← comp_whiskerRight, SymmetricCategory.symmetry]
+  simp only [id_whiskerRight, whiskerLeft_id, Category.id_comp, Category.assoc, pentagon_inv_assoc,
+    Iso.hom_inv_id_assoc]
+  slice_lhs 1 2 =>
+    rw [← associator_inv_naturality_left]
+  slice_lhs 2 3 =>
+    rw [Iso.inv_hom_id]
+  rw [Category.id_comp]
+  slice_lhs 2 3 =>
+    rw [← associator_naturality_right]
+  slice_lhs 1 2 =>
+    rw [← tensorHom_def]
+  simp only [Category.assoc]
+
+instance {X Y : C} [MonObj X] [MonObj Y] : IsMonHom (β_ X Y).hom :=
+  ⟨one_braiding X Y, mul_braiding X Y⟩
+
+end MonObj
+
+namespace Mon
+
+instance : SymmetricCategory (Mon C) where
+  braiding X Y := mkIso' (β_ X.X Y.X)
+
+@[simp] lemma braiding_hom_hom (M N : Mon C) : (β_ M N).hom.hom = (β_ M.X N.X).hom := rfl
+@[simp] lemma braiding_inv_hom (M N : Mon C) : (β_ M N).inv.hom = (β_ M.X N.X).inv := rfl
+
+end Mon
+end SymmetricCategory
 
 namespace CategoryTheory
 variable
@@ -420,6 +733,9 @@ def mapMonNatTrans (f : F ⟶ F') [NatTrans.IsMonoidal f] : F.mapMon ⟶ F'.mapM
 @[simps!]
 def mapMonNatIso (e : F ≅ F') [NatTrans.IsMonoidal e.hom] : F.mapMon ≅ F'.mapMon :=
   NatIso.ofComponents fun X ↦ Mon.mkIso (e.app _)
+
+attribute [local simp] ε_tensorHom_comp_μ_assoc in
+instance [F.LaxMonoidal] : IsMonHom (ε F) where
 
 end LaxMonoidal
 
@@ -611,352 +927,6 @@ def equivLaxMonoidalFunctorPUnit : LaxMonoidalFunctor (Discrete PUnit.{w + 1}) C
   counitIso := counitIso C
 
 end Mon
-
-namespace MonObj
-
-/-!
-In this section, we prove that the category of monoids in a braided monoidal category is monoidal.
-
-Given two monoids `M` and `N` in a braided monoidal category `C`,
-the multiplication on the tensor product `M.X ⊗ N.X` is defined in the obvious way:
-it is the tensor product of the multiplications on `M` and `N`,
-except that the tensor factors in the source come in the wrong order,
-which we fix by pre-composing with a permutation isomorphism constructed from the braiding.
-
-(There is a subtlety here: in fact there are two ways to do these,
-using either the positive or negative crossing.)
-
-A more conceptual way of understanding this definition is the following:
-The braiding on `C` gives rise to a monoidal structure on
-the tensor product functor from `C × C` to `C`.
-A pair of monoids in `C` gives rise to a monoid in `C × C`,
-which the tensor product functor by being monoidal takes to a monoid in `C`.
-The permutation isomorphism appearing in the definition of
-the multiplication on the tensor product of two monoids is
-an instance of a more general family of isomorphisms
-which together form a strength that equips the tensor product functor with a monoidal structure,
-and the monoid axioms for the tensor product follow from the monoid axioms for the tensor factors
-plus the properties of the strength (i.e., monoidal functor axioms).
-The strength `tensorμ` of the tensor product functor has been defined in
-`Mathlib/CategoryTheory/Monoidal/Braided.lean`.
-Its properties, stated as independent lemmas in that module,
-are used extensively in the proofs below.
-Notice that we could have followed the above plan not only conceptually
-but also as a possible implementation and
-could have constructed the tensor product of monoids via `mapMon`,
-but we chose to give a more explicit definition directly in terms of `tensorμ`.
-
-To complete the definition of the monoidal category structure on the category of monoids,
-we need to provide definitions of associator and unitors.
-The obvious candidates are the associator and unitors from `C`,
-but we need to prove that they are monoid morphisms, i.e., compatible with unit and multiplication.
-These properties translate to the monoidality of the associator and unitors
-(with respect to the monoidal structures on the functors they relate),
-which have also been proved in `Mathlib/CategoryTheory/Monoidal/Braided.lean`.
-
--/
-
--- The proofs that associators and unitors preserve monoid units don't require braiding.
-theorem one_associator {M N P : C} [MonObj M] [MonObj N] [MonObj P] :
-    ((λ_ (𝟙_ C)).inv ≫ ((λ_ (𝟙_ C)).inv ≫ (η[M] ⊗ₘ η[N]) ⊗ₘ η[P])) ≫ (α_ M N P).hom =
-      (λ_ (𝟙_ C)).inv ≫ (η[M] ⊗ₘ (λ_ (𝟙_ C)).inv ≫ (η[N] ⊗ₘ η[P])) := by
-  simp only [Category.assoc, Iso.cancel_iso_inv_left]
-  slice_lhs 1 3 => rw [← Category.id_comp (η : 𝟙_ C ⟶ P), ← tensorHom_comp_tensorHom]
-  slice_lhs 2 3 => rw [associator_naturality]
-  slice_rhs 1 2 => rw [← Category.id_comp η, ← tensorHom_comp_tensorHom]
-  slice_lhs 1 2 => rw [tensorHom_id, ← leftUnitor_tensor_inv]
-  rw [← cancel_epi (λ_ (𝟙_ C)).inv]
-  slice_lhs 1 2 => rw [leftUnitor_inv_naturality]
-  simp
-
-theorem one_leftUnitor {M : C} [MonObj M] :
-    ((λ_ (𝟙_ C)).inv ≫ (𝟙 (𝟙_ C) ⊗ₘ η[M])) ≫ (λ_ M).hom = η := by
-  simp
-
-theorem one_rightUnitor {M : C} [MonObj M] :
-    ((λ_ (𝟙_ C)).inv ≫ (η[M] ⊗ₘ 𝟙 (𝟙_ C))) ≫ (ρ_ M).hom = η := by
-  simp [← unitors_equal]
-
-section BraidedCategory
-
-variable [BraidedCategory C]
-
-theorem Mon_tensor_one_mul (M N : C) [MonObj M] [MonObj N] :
-    (((λ_ (𝟙_ C)).inv ≫ (η[M] ⊗ₘ η[N])) ▷ (M ⊗ N)) ≫
-        tensorμ M N M N ≫ (μ ⊗ₘ μ) =
-      (λ_ (M ⊗ N)).hom := by
-  simp only [comp_whiskerRight_assoc]
-  slice_lhs 2 3 => rw [tensorμ_natural_left]
-  slice_lhs 3 4 => rw [tensorHom_comp_tensorHom, one_mul, one_mul]
-  symm
-  exact tensor_left_unitality M N
-
-theorem Mon_tensor_mul_one (M N : C) [MonObj M] [MonObj N] :
-    (M ⊗ N) ◁ ((λ_ (𝟙_ C)).inv ≫ (η[M] ⊗ₘ η[N])) ≫
-        tensorμ M N M N ≫ (μ[M] ⊗ₘ μ[N]) =
-      (ρ_ (M ⊗ N)).hom := by
-  simp only [whiskerLeft_comp_assoc]
-  slice_lhs 2 3 => rw [tensorμ_natural_right]
-  slice_lhs 3 4 => rw [tensorHom_comp_tensorHom, mul_one, mul_one]
-  symm
-  exact tensor_right_unitality M N
-
-theorem Mon_tensor_mul_assoc (M N : C) [MonObj M] [MonObj N] :
-    ((tensorμ M N M N ≫ (μ ⊗ₘ μ)) ▷ (M ⊗ N)) ≫
-        tensorμ M N M N ≫ (μ ⊗ₘ μ) =
-      (α_ (M ⊗ N : C) (M ⊗ N) (M ⊗ N)).hom ≫
-        ((M ⊗ N : C) ◁ (tensorμ M N M N ≫ (μ ⊗ₘ μ))) ≫
-          tensorμ M N M N ≫ (μ ⊗ₘ μ) := by
-  simp only [comp_whiskerRight_assoc, whiskerLeft_comp_assoc]
-  slice_lhs 2 3 => rw [tensorμ_natural_left]
-  slice_lhs 3 4 =>
-    rw [tensorHom_comp_tensorHom, mul_assoc, mul_assoc, ← tensorHom_comp_tensorHom,
-      ← tensorHom_comp_tensorHom]
-  slice_lhs 1 3 => rw [tensor_associativity]
-  slice_lhs 3 4 => rw [← tensorμ_natural_right]
-  simp
-
-theorem mul_associator {M N P : C} [MonObj M] [MonObj N] [MonObj P] :
-    (tensorμ (M ⊗ N) P (M ⊗ N) P ≫
-          (tensorμ M N M N ≫ (μ ⊗ₘ μ) ⊗ₘ μ)) ≫
-        (α_ M N P).hom =
-      ((α_ M N P).hom ⊗ₘ (α_ M N P).hom) ≫
-        tensorμ M (N ⊗ P) M (N ⊗ P) ≫
-          (μ ⊗ₘ tensorμ N P N P ≫ (μ ⊗ₘ μ)) := by
-  simp only [Category.assoc]
-  slice_lhs 2 3 => rw [← Category.id_comp μ[P], ← tensorHom_comp_tensorHom]
-  slice_lhs 3 4 => rw [associator_naturality]
-  slice_rhs 3 4 => rw [← Category.id_comp μ, ← tensorHom_comp_tensorHom]
-  simp only [tensorHom_id, id_tensorHom]
-  slice_lhs 1 3 => rw [associator_monoidal]
-  simp only [Category.assoc]
-
-theorem mul_leftUnitor {M : C} [MonObj M] :
-    (tensorμ (𝟙_ C) M (𝟙_ C) M ≫ ((λ_ (𝟙_ C)).hom ⊗ₘ μ)) ≫ (λ_ M).hom =
-      ((λ_ M).hom ⊗ₘ (λ_ M).hom) ≫ μ := by
-  rw [← Category.comp_id (λ_ (𝟙_ C)).hom, ← Category.id_comp μ, ← tensorHom_comp_tensorHom]
-  simp only [tensorHom_id, id_tensorHom]
-  slice_lhs 3 4 => rw [leftUnitor_naturality]
-  slice_lhs 1 3 => rw [← leftUnitor_monoidal]
-  simp only [Category.id_comp]
-
-theorem mul_rightUnitor {M : C} [MonObj M] :
-    (tensorμ M (𝟙_ C) M (𝟙_ C) ≫ (μ ⊗ₘ (λ_ (𝟙_ C)).hom)) ≫ (ρ_ M).hom =
-      ((ρ_ M).hom ⊗ₘ (ρ_ M).hom) ≫ μ := by
-  rw [← Category.id_comp μ, ← Category.comp_id (λ_ (𝟙_ C)).hom, ← tensorHom_comp_tensorHom]
-  simp only [tensorHom_id, id_tensorHom]
-  slice_lhs 3 4 => rw [rightUnitor_naturality]
-  slice_lhs 1 3 => rw [← rightUnitor_monoidal]
-  simp only [Category.id_comp]
-
-namespace tensorObj
-
--- We don't want `tensorObj.one_def` to be simp as it would loop with `IsMonHom.one_hom` applied
--- to `(λ_ N.X).inv`.
-@[simps -isSimp]
-instance {M N : C} [MonObj M] [MonObj N] : MonObj (M ⊗ N) where
-  one := (λ_ (𝟙_ C)).inv ≫ (η ⊗ₘ η)
-  mul := tensorμ M N M N ≫ (μ ⊗ₘ μ)
-  one_mul := Mon_tensor_one_mul M N
-  mul_one := Mon_tensor_mul_one M N
-  mul_assoc := Mon_tensor_mul_assoc M N
-
-end tensorObj
-
-open IsMonHom
-
-variable {X Y Z W : C} [MonObj X] [MonObj Y] [MonObj Z] [MonObj W]
-
-instance {f : X ⟶ Y} {g : Z ⟶ W} [IsMonHom f] [IsMonHom g] : IsMonHom (f ⊗ₘ g) where
-  one_hom := by
-    dsimp [tensorObj.one_def]
-    slice_lhs 2 3 => rw [tensorHom_comp_tensorHom, one_hom, one_hom]
-  mul_hom := by
-    dsimp [tensorObj.mul_def]
-    slice_rhs 1 2 => rw [tensorμ_natural]
-    slice_lhs 2 3 => rw [tensorHom_comp_tensorHom, mul_hom, mul_hom, ← tensorHom_comp_tensorHom]
-    simp only [Category.assoc]
-
-instance : IsMonHom (𝟙 X) where
-
-instance {f : Y ⟶ Z} [IsMonHom f] : IsMonHom (X ◁ f) where
-  one_hom := by simpa using (inferInstanceAs <| IsMonHom (𝟙 X ⊗ₘ f)).one_hom
-  mul_hom := by simpa using (inferInstanceAs <| IsMonHom (𝟙 X ⊗ₘ f)).mul_hom
-
-instance {f : X ⟶ Y} [IsMonHom f] : IsMonHom (f ▷ Z) where
-  one_hom := by simpa using (inferInstanceAs <| IsMonHom (f ⊗ₘ (𝟙 Z))).one_hom
-  mul_hom := by simpa using (inferInstanceAs <| IsMonHom (f ⊗ₘ (𝟙 Z))).mul_hom
-
-instance : IsMonHom (α_ X Y Z).hom :=
-  ⟨one_associator, mul_associator⟩
-
-instance : IsMonHom (λ_ X).hom :=
-  ⟨one_leftUnitor, mul_leftUnitor⟩
-
-instance : IsMonHom (ρ_ X).hom :=
-  ⟨one_rightUnitor, mul_rightUnitor⟩
-
-theorem one_braiding (X Y : C) [MonObj X] [MonObj Y] : η ≫ (β_ X Y).hom = η := by
-  simp only [tensorObj.one_def, Category.assoc, BraidedCategory.braiding_naturality,
-    braiding_tensorUnit_right, Iso.cancel_iso_inv_left]
-  monoidal
-
-end BraidedCategory
-
-end MonObj
-
-namespace Mon
-
-section BraidedCategory
-
-variable [BraidedCategory C]
-
-@[simps! tensorObj_X tensorHom_hom]
-instance monMonoidalStruct : MonoidalCategoryStruct (Mon C) where
-  tensorObj M N := ⟨M.X ⊗ N.X⟩
-  tensorHom f g := Hom.mk (f.hom ⊗ₘ g.hom)
-  whiskerRight f Y := Hom.mk (f.hom ▷ Y.X)
-  whiskerLeft X _ _ g := Hom.mk (X.X ◁ g.hom)
-  tensorUnit := ⟨𝟙_ C⟩
-  associator M N P := mkIso' <| associator M.X N.X P.X
-  leftUnitor M := mkIso' <| leftUnitor M.X
-  rightUnitor M := mkIso' <| rightUnitor M.X
-
-@[simp]
-theorem tensorUnit_X : (𝟙_ (Mon C)).X = 𝟙_ C := rfl
-
-@[simp]
-theorem tensorUnit_one : η[(𝟙_ (Mon C)).X] = 𝟙 (𝟙_ C) := rfl
-
-@[simp]
-theorem tensorUnit_mul : μ[(𝟙_ (Mon C)).X] = (λ_ (𝟙_ C)).hom := rfl
-
-@[simp]
-theorem tensorObj_one (X Y : Mon C) : η[(X ⊗ Y).X] = (λ_ (𝟙_ C)).inv ≫ (η[X.X] ⊗ₘ η[Y.X]) := rfl
-
-@[simp]
-theorem tensorObj_mul (X Y : Mon C) :
-    μ[(X ⊗ Y).X] = tensorμ X.X Y.X X.X Y.X ≫ (μ[X.X] ⊗ₘ μ[Y.X]) := rfl
-
-@[simp]
-theorem whiskerLeft_hom {X Y : Mon C} (f : X ⟶ Y) (Z : Mon C) :
-    (f ▷ Z).hom = f.hom ▷ Z.X := by
-  rfl
-
-@[simp]
-theorem whiskerRight_hom (X : Mon C) {Y Z : Mon C} (f : Y ⟶ Z) :
-    (X ◁ f).hom = X.X ◁ f.hom := by
-  rfl
-
-@[simp]
-theorem leftUnitor_hom_hom (X : Mon C) : (λ_ X).hom.hom = (λ_ X.X).hom := rfl
-
-@[simp]
-theorem leftUnitor_inv_hom (X : Mon C) : (λ_ X).inv.hom = (λ_ X.X).inv := rfl
-
-@[simp]
-theorem rightUnitor_hom_hom (X : Mon C) : (ρ_ X).hom.hom = (ρ_ X.X).hom := rfl
-
-@[simp]
-theorem rightUnitor_inv_hom (X : Mon C) : (ρ_ X).inv.hom = (ρ_ X.X).inv := rfl
-
-@[simp]
-theorem associator_hom_hom (X Y Z : Mon C) : (α_ X Y Z).hom.hom = (α_ X.X Y.X Z.X).hom := rfl
-
-@[simp]
-theorem associator_inv_hom (X Y Z : Mon C) : (α_ X Y Z).inv.hom = (α_ X.X Y.X Z.X).inv := rfl
-
-@[simp]
-theorem tensor_one (M N : Mon C) : η[(M ⊗ N).X] = (λ_ (𝟙_ C)).inv ≫ (η[M.X] ⊗ₘ η[N.X]) := rfl
-
-@[simp]
-theorem tensor_mul (M N : Mon C) : μ[(M ⊗ N).X] =
-    tensorμ M.X N.X M.X N.X ≫ (μ[M.X] ⊗ₘ μ[N.X]) := rfl
-
-instance monMonoidal : MonoidalCategory (Mon C) where
-  tensorHom_def := by intros; ext; simp [tensorHom_def]
-
--- We don't want `tensorObj.one_def` to be simp as it would loop with `IsMonHom.one_hom` applied
--- to `(λ_ N.X).inv`.
-@[simps! -isSimp]
-instance {M N : C} [MonObj M] [MonObj N] : MonObj (M ⊗ N) :=
-  inferInstanceAs <| MonObj (Mon.mk M ⊗ Mon.mk N).X
-
-variable (C)
-
-/-- The forgetful functor from `Mon C` to `C` is monoidal when `C` is monoidal. -/
-instance : (forget C).Monoidal :=
-  Functor.CoreMonoidal.toMonoidal
-    { εIso := Iso.refl _
-      μIso _ _ := Iso.refl _ }
-
-@[simp] theorem forget_ε : ε (forget C) = 𝟙 (𝟙_ C) := rfl
-@[simp] theorem forget_η : «η» (forget C) = 𝟙 (𝟙_ C) := rfl
-@[simp] theorem forget_μ (X Y : Mon C) : «μ» (forget C) X Y = 𝟙 (X.X ⊗ Y.X) := rfl
-@[simp] theorem forget_δ (X Y : Mon C) : δ (forget C) X Y = 𝟙 (X.X ⊗ Y.X) := rfl
-
-end BraidedCategory
-
-end Mon
-
-/-!
-We next show that if `C` is symmetric, then `Mon C` is braided, and indeed symmetric.
-
-Note that `Mon C` is *not* braided in general when `C` is only braided.
-
-The more interesting construction is the 2-category of monoids in `C`,
-bimodules between the monoids, and intertwiners between the bimodules.
-
-When `C` is braided, that is a monoidal 2-category.
--/
-section SymmetricCategory
-
-variable [SymmetricCategory C]
-
-namespace MonObj
-
-theorem mul_braiding (X Y : C) [MonObj X] [MonObj Y] :
-    μ ≫ (β_ X Y).hom = ((β_ X Y).hom ⊗ₘ (β_ X Y).hom) ≫ μ := by
-  dsimp [tensorObj.mul_def]
-  simp only [tensorμ, Category.assoc, BraidedCategory.braiding_naturality,
-    BraidedCategory.braiding_tensor_right_hom, BraidedCategory.braiding_tensor_left_hom,
-    comp_whiskerRight, whisker_assoc, whiskerLeft_comp, pentagon_assoc,
-    pentagon_inv_hom_hom_hom_inv_assoc, Iso.inv_hom_id_assoc, whiskerLeft_hom_inv_assoc]
-  slice_lhs 3 4 =>
-    -- We use symmetry here:
-    rw [← whiskerLeft_comp, ← comp_whiskerRight, SymmetricCategory.symmetry]
-  simp only [id_whiskerRight, whiskerLeft_id, Category.id_comp, Category.assoc, pentagon_inv_assoc,
-    Iso.hom_inv_id_assoc]
-  slice_lhs 1 2 =>
-    rw [← associator_inv_naturality_left]
-  slice_lhs 2 3 =>
-    rw [Iso.inv_hom_id]
-  rw [Category.id_comp]
-  slice_lhs 2 3 =>
-    rw [← associator_naturality_right]
-  slice_lhs 1 2 =>
-    rw [← tensorHom_def]
-  simp only [Category.assoc]
-
-instance {X Y : C} [MonObj X] [MonObj Y] : IsMonHom (β_ X Y).hom :=
-  ⟨one_braiding X Y, mul_braiding X Y⟩
-
-end MonObj
-
-namespace Mon
-
-instance : SymmetricCategory (Mon C) where
-  braiding X Y := mkIso' (β_ X.X Y.X)
-  symmetry X Y := by
-    ext
-    simp
-
-@[simp] lemma braiding_hom_hom (M N : Mon C) : (β_ M N).hom.hom = (β_ M.X N.X).hom := rfl
-@[simp] lemma braiding_inv_hom (M N : Mon C) : (β_ M N).inv.hom = (β_ M.X N.X).inv := rfl
-
-end Mon
-
-end SymmetricCategory
 
 section
 


### PR DESCRIPTION
Move the `BraidedCategory (Mon_ C)` instance earlier in the file. Indeed I think it makes more sense like this (defining `MonClass`, then `Mon`, then `Functor.mapMon`).

This is necessary for the material in #29136 to be placed in a relatively non-silly order within the file.


---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include at least one commit authored by each
co-author among the commits in the pull request. If necessary, you may 
create empty commits to indicate co-authorship, using commands like so:

git commit --author="Author Name <author@email.com>" --allow-empty -m "add Author Name as coauthor"

When merging, all the commits will be squashed into a single commit listing all co-authors.

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
