### PR TITLE
[Merged by Bors] - chore: make Opposite.small an instance

### DIFF
--- a/Mathlib/Data/Opposite.lean
+++ b/Mathlib/Data/Opposite.lean
@@ -107,7 +107,7 @@ protected def rec' {F : αᵒᵖ → Sort v} (h : ∀ X, F (op X)) : ∀ X, F X 
 
 /-- If `X` is `u`-small, also `Xᵒᵖ` is `u`-small.
 Note: This is not an instance, because it tends to mislead typeclass search. -/
-lemma small {X : Type v} [Small.{u} X] : Small.{u} Xᵒᵖ := by
+instance small {X : Type v} [Small.{u} X] : Small.{u} Xᵒᵖ := by
   obtain ⟨S, ⟨e⟩⟩ := Small.equiv_small (α := X)
   exact ⟨S, ⟨equivToOpposite.symm.trans e⟩⟩
 

--- a/Mathlib/Data/Opposite.lean
+++ b/Mathlib/Data/Opposite.lean
@@ -105,8 +105,7 @@ instance [Subsingleton α] : Subsingleton αᵒᵖ := unop_injective.subsingleto
 @[deprecated Opposite.rec (since := "2025-04-04")]
 protected def rec' {F : αᵒᵖ → Sort v} (h : ∀ X, F (op X)) : ∀ X, F X := fun X => h (unop X)
 
-/-- If `X` is `u`-small, also `Xᵒᵖ` is `u`-small.
-Note: This is not an instance, because it tends to mislead typeclass search. -/
+/-- If `X` is `u`-small, also `Xᵒᵖ` is `u`-small. -/
 instance small {X : Type v} [Small.{u} X] : Small.{u} Xᵒᵖ := by
   obtain ⟨S, ⟨e⟩⟩ := Small.equiv_small (α := X)
   exact ⟨S, ⟨equivToOpposite.symm.trans e⟩⟩


### PR DESCRIPTION
If `X` is small, so is `Xᵒᵖ`. It no longer seems to be dangerous to have such an instance. (Which shall be convenient for #30160.)

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include at least one commit authored by each
co-author among the commits in the pull request. If necessary, you may 
create empty commits to indicate co-authorship, using commands like so:

git commit --author="Author Name <author@email.com>" --allow-empty -m "add Author Name as coauthor"

When merging, all the commits will be squashed into a single commit listing all co-authors.

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
