### PR TITLE
[Merged by Bors] - ci(label_new_contributor.yml): only trigger when PR is opened

### DIFF
--- a/.github/workflows/label_new_contributor.yml
+++ b/.github/workflows/label_new_contributor.yml
@@ -2,7 +2,10 @@ name: Label New Contributors
 
 # Written with ChatGPT: https://chat.openai.com/share/3777ceb1-d722-4705-bacd-ba3f04b387be
 
-on: pull_request_target
+on: 
+  pull_request_target:
+    types:
+      - opened
 
 # Limit permissions for GITHUB_TOKEN for the entire workflow
 permissions:

--- a/.github/workflows/label_new_contributor.yml
+++ b/.github/workflows/label_new_contributor.yml
@@ -39,6 +39,10 @@ jobs:
             const issues = await github.paginate(opts)
             const pullRequestCount = issues.length;
 
+            // We could filter out bot users here, with:
+            // const isBot = (github.rest.users.getByUsername(creator).type === "Bot");
+            // But we choose to label PRs by new bot contributors as well.
+
             // Determine if the creator has 5 or fewer pull requests
             if (pullRequestCount <= 5) {
               // Add the "new-contributor" label to the current pull request


### PR DESCRIPTION
Currently, this is triggered even when new bots push a commit to a PR (e.g. the pre-commit.ci bot); adding the `types` filter will prevent the `new-contributor` label being added in such cases.


---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include at least one commit authored by each
co-author among the commits in the pull request. If necessary, you may 
create empty commits to indicate co-authorship, using commands like so:

git commit --author="Author Name <author@email.com>" --allow-empty -m "add Author Name as coauthor"

When merging, all the commits will be squashed into a single commit listing all co-authors.

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
