### PR TITLE
[Merged by Bors] - feat(CategoryTheory/MorphismProperty): locality conditions

### DIFF
--- a/Mathlib.lean
+++ b/Mathlib.lean
@@ -2642,6 +2642,7 @@ import Mathlib.CategoryTheory.MorphismProperty.IsInvertedBy
 import Mathlib.CategoryTheory.MorphismProperty.IsSmall
 import Mathlib.CategoryTheory.MorphismProperty.LiftingProperty
 import Mathlib.CategoryTheory.MorphismProperty.Limits
+import Mathlib.CategoryTheory.MorphismProperty.Local
 import Mathlib.CategoryTheory.MorphismProperty.OverAdjunction
 import Mathlib.CategoryTheory.MorphismProperty.Representable
 import Mathlib.CategoryTheory.MorphismProperty.Retract

--- a/Mathlib/CategoryTheory/MorphismProperty/Basic.lean
+++ b/Mathlib/CategoryTheory/MorphismProperty/Basic.lean
@@ -222,6 +222,8 @@ variable {C}
 it is stable under pre- and postcomposition with isomorphisms. -/
 abbrev RespectsIso (P : MorphismProperty C) : Prop := P.Respects (isomorphisms C)
 
+instance inf (P Q : MorphismProperty C) [P.RespectsIso] [Q.RespectsIso] : (P ⊓ Q).RespectsIso where
+
 lemma RespectsIso.mk (P : MorphismProperty C)
     (hprecomp : ∀ {X Y Z : C} (e : X ≅ Y) (f : Y ⟶ Z) (_ : P f), P (e.hom ≫ f))
     (hpostcomp : ∀ {X Y Z : C} (e : Y ≅ Z) (f : X ⟶ Y) (_ : P f), P (f ≫ e.hom)) :

--- a/Mathlib/CategoryTheory/MorphismProperty/Local.lean
+++ b/Mathlib/CategoryTheory/MorphismProperty/Local.lean
@@ -1,0 +1,143 @@
+/-
+Copyright (c) 2025 Christian Merten. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Christian Merten, Andrew Yang
+-/
+import Mathlib.CategoryTheory.Sites.Hypercover.Zero
+import Mathlib.CategoryTheory.MorphismProperty.Limits
+
+/-!
+# Locality conditions on morphism properties
+
+In this file we define locality conditions on morphism properties in a category. Let `K` be a
+precoverage in a category `C` and `P` be a morphism property on `C` that respects isomorphisms.
+
+We say that
+
+- `P` is local at the target if for every `f : X ⟶ Y`, `P` holds for `f` if and only if it holds
+  for the restrictions of `f` to `Uᵢ` for a
+  `K`-cover `{Uᵢ}` of `Y`.
+- `P` is local at the source if for every `f : X ⟶ Y`, `P` holds for `f` if and only if it holds
+  for the restrictions of `f` to `Uᵢ` for a `K`-cover `{Uᵢ}` of `X`.
+
+## Implementation details
+
+The covers appearing in the definitions have index type in the morphism universe of `C`.
+-/
+
+universe w v u
+
+namespace CategoryTheory
+
+open Limits
+
+variable {C : Type u} [Category.{v} C]
+
+namespace MorphismProperty
+
+variable (K : Precoverage C)
+
+/--
+A property of morphisms `P` in `C` is local at the target with respect to the precoverage `K` if
+it respects ismorphisms, and:
+`P` holds for `f : X ⟶ Y` if and only if it holds for the restrictions of `f` to `Uᵢ` for a
+`0`-hypercover `{Uᵢ}` of `Y` in the precoverage `K`.
+-/
+class IsLocalAtTarget (P : MorphismProperty C) (K : Precoverage C) [K.HasPullbacks]
+    extends RespectsIso P where
+  /-- If `P` holds for `f : X ⟶ Y`, it also holds for `f` restricted to `Uᵢ` for any
+  `K`-cover `𝒰` of `Y`. -/
+  pullbackSnd {X Y : C} {f : X ⟶ Y} (𝒰 : Precoverage.ZeroHypercover.{v} K Y)
+    (i : 𝒰.I₀) (hf : P f) : P (pullback.snd f (𝒰.f i))
+  /-- If `P` holds for `f` restricted to `Uᵢ` for all `i`, it also holds for `f : X ⟶ Y` for any
+  `K`-cover `𝒰` of `Y`. -/
+  of_zeroHypercover {X Y : C} {f : X ⟶ Y} (𝒰 : Precoverage.ZeroHypercover.{v} K Y)
+    (h : ∀ i, P (pullback.snd f (𝒰.f i))) : P f
+
+namespace IsLocalAtTarget
+
+variable {P : MorphismProperty C} {K L : Precoverage C} [K.HasPullbacks]
+
+lemma mk_of_isStableUnderBaseChange [P.IsStableUnderBaseChange]
+    (H : ∀ {X Y : C} (f : X ⟶ Y) (𝒰 : Precoverage.ZeroHypercover.{v} K Y),
+      (∀ i, P (pullback.snd f (𝒰.f i))) → P f) :
+    P.IsLocalAtTarget K where
+  pullbackSnd _ _ hf := P.pullback_snd _ _ hf
+  of_zeroHypercover _ := H _ _
+
+lemma of_le [L.HasPullbacks] [IsLocalAtTarget P L] (hle : K ≤ L) : IsLocalAtTarget P K where
+  pullbackSnd 𝒰 i hf := pullbackSnd (𝒰.weaken hle) i hf
+  of_zeroHypercover 𝒰 := of_zeroHypercover (𝒰.weaken hle)
+
+instance top : IsLocalAtTarget (⊤ : MorphismProperty C) K where
+  pullbackSnd := by simp
+  of_zeroHypercover := by simp
+
+variable [IsLocalAtTarget P K] {X Y : C} {f : X ⟶ Y} (𝒰 : Precoverage.ZeroHypercover.{v} K Y)
+
+lemma of_isPullback {X' : C} (i : 𝒰.I₀) {fst : X' ⟶ X} {snd : X' ⟶ 𝒰.X i}
+    (h : IsPullback fst snd f (𝒰.f i)) (hf : P f) :
+    P snd := by
+  rw [← P.cancel_left_of_respectsIso h.isoPullback.inv, h.isoPullback_inv_snd]
+  exact pullbackSnd _ _ hf
+
+lemma iff_of_zeroHypercover : P f ↔ ∀ i, P (pullback.snd f (𝒰.f i)) :=
+  ⟨fun hf _ ↦ pullbackSnd _ _ hf, fun h ↦ of_zeroHypercover _ h⟩
+
+instance inf (P Q : MorphismProperty C) [IsLocalAtTarget P K] [IsLocalAtTarget Q K] :
+    IsLocalAtTarget (P ⊓ Q) K where
+  pullbackSnd _ i h := ⟨pullbackSnd _ i h.1, pullbackSnd _ i h.2⟩
+  of_zeroHypercover _ h :=
+    ⟨of_zeroHypercover _ fun i ↦ (h i).1, of_zeroHypercover _ fun i ↦ (h i).2⟩
+
+end IsLocalAtTarget
+
+alias of_zeroHypercover_target := IsLocalAtTarget.of_zeroHypercover
+alias iff_of_zeroHypercover_target := IsLocalAtTarget.iff_of_zeroHypercover
+
+/--
+A property of morphisms `P` in `C` is local at the source with respect to the precoverage `K` if
+it respects ismorphisms, and:
+`P` holds for `f : X ⟶ Y` if and only if it holds for the restrictions of `f` to `Uᵢ` for a
+`0`-hypercover `{Uᵢ}` of `X` in the precoverage `K`.
+-/
+class IsLocalAtSource (P : MorphismProperty C) (K : Precoverage C) extends RespectsIso P where
+  /-- If `P` holds for `f : X ⟶ Y`, it also holds for `𝒰.f i ≫ f` for any `K`-cover `𝒰` of `X`. -/
+  comp {X Y : C} {f : X ⟶ Y} (𝒰 : Precoverage.ZeroHypercover.{v} K X) (i : 𝒰.I₀)
+    (hf : P f) : P (𝒰.f i ≫ f)
+  /-- If `P` holds for `𝒰.f i ≫ f` for all `i`, it holds for `f : X ⟶ Y` for any `K`-cover
+  `𝒰` of X. -/
+  of_zeroHypercover {X Y : C} {f : X ⟶ Y} (𝒰 : Precoverage.ZeroHypercover.{v} K X) :
+    (∀ i, P (𝒰.f i ≫ f)) → P f
+
+namespace IsLocalAtSource
+
+variable {P : MorphismProperty C} {K L : Precoverage C}
+
+lemma of_le [IsLocalAtSource P L] (hle : K ≤ L) : IsLocalAtSource P K where
+  comp 𝒰 i hf := comp (𝒰.weaken hle) i hf
+  of_zeroHypercover 𝒰 h := of_zeroHypercover (𝒰.weaken hle) h
+
+instance top : IsLocalAtSource (⊤ : MorphismProperty C) K where
+  comp := by simp
+  of_zeroHypercover := by simp
+
+variable [IsLocalAtSource P K] {X Y : C} {f : X ⟶ Y} (𝒰 : Precoverage.ZeroHypercover.{v} K X)
+
+lemma iff_of_zeroHypercover : P f ↔ ∀ i, P (𝒰.f i ≫ f) :=
+  ⟨fun hf i ↦ comp _ i hf, fun h ↦ of_zeroHypercover _ h⟩
+
+instance inf (P Q : MorphismProperty C) [IsLocalAtSource P K] [IsLocalAtSource Q K] :
+    IsLocalAtSource (P ⊓ Q) K where
+  comp 𝒰 i hf := ⟨comp 𝒰 i hf.1, comp 𝒰 i hf.2⟩
+  of_zeroHypercover _ h :=
+    ⟨of_zeroHypercover _ fun i ↦ (h i).1, of_zeroHypercover _ fun i ↦ (h i).2⟩
+
+end IsLocalAtSource
+
+alias of_zeroHypercover_source := IsLocalAtSource.of_zeroHypercover
+alias iff_of_zeroHypercover_source := IsLocalAtSource.iff_of_zeroHypercover
+
+end MorphismProperty
+
+end CategoryTheory

--- a/Mathlib/CategoryTheory/MorphismProperty/Local.lean
+++ b/Mathlib/CategoryTheory/MorphismProperty/Local.lean
@@ -23,6 +23,10 @@ We say that
 ## Implementation details
 
 The covers appearing in the definitions have index type in the morphism universe of `C`.
+
+## TODOs
+
+- Define source and target local closure of a morphism property.
 -/
 
 universe w v u

--- a/Mathlib/CategoryTheory/Sites/Hypercover/Zero.lean
+++ b/Mathlib/CategoryTheory/Sites/Hypercover/Zero.lean
@@ -370,6 +370,26 @@ def add (E : ZeroHypercover.{w} J S) {T : C} (f : T ⟶ S)
   __ := E.toPreZeroHypercover.add f
   mem₀ := by rwa [PreZeroHypercover.presieve₀_add]
 
+/-- If `L` is a finer precoverage than `K`, any `0`-hypercover wrt. `K` is in particular
+a `0`-hypercover wrt. to `L`. -/
+@[simps toPreZeroHypercover]
+def weaken {K L : Precoverage C} {X : C} (E : Precoverage.ZeroHypercover K X) (h : K ≤ L) :
+    Precoverage.ZeroHypercover L X where
+  __ := E
+  mem₀ := h _ E.mem₀
+
+instance (K : Precoverage C) [K.HasPullbacks] {X Y : C} (E : K.ZeroHypercover X) (f : Y ⟶ X) :
+    E.presieve₀.HasPullbacks f :=
+  K.hasPullbacks_of_mem _ E.mem₀
+
+instance {X Y : C} (E : PreZeroHypercover X) (f : Y ⟶ X) [E.presieve₀.HasPullbacks f]
+    (i : E.I₀) : HasPullback (E.f i) f :=
+  E.presieve₀.hasPullback f ⟨i⟩
+
+instance {X Y : C} (E : PreZeroHypercover X) (f : Y ⟶ X) [E.presieve₀.HasPullbacks f]
+    (i : E.I₀) : HasPullback f (E.f i) :=
+  hasPullback_symmetry (E.f i) f
+
 variable (J) in
 /-- A morphism of `0`-hypercovers is a morphism of the underlying pre-`0`-hypercovers. -/
 abbrev Hom (E : ZeroHypercover.{w} J S) (F : ZeroHypercover.{w'} J S) :=


### PR DESCRIPTION
These are "upstreamed" from the corresponding definitions for morphism properties of schemes. The old definitions for schemes will be deprecated in a follow-up PR.

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include at least one commit authored by each
co-author among the commits in the pull request. If necessary, you may 
create empty commits to indicate co-authorship, using commands like so:

git commit --author="Author Name <author@email.com>" --allow-empty -m "add Author Name as coauthor"

When merging, all the commits will be squashed into a single commit listing all co-authors.

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
