### PR TITLE
[Merged by Bors] - chore: add a space before "with" in finset sum notation

### DIFF
--- a/Mathlib/Algebra/BigOperators/Group/Finset/Defs.lean
+++ b/Mathlib/Algebra/BigOperators/Group/Finset/Defs.lean
@@ -170,9 +170,9 @@ def bigOpBindersProd (processed : Array (Term × Term)) : MacroM Term := do
 
 These support destructuring, for example `∑ ⟨x, y⟩ ∈ s ×ˢ t, f x y`.
 
-Notation: `"∑" bigOpBinders* ("with" (ident ":")? term)? "," term` -/
+Notation: `"∑" bigOpBinders* (" with" (ident ":")? term)? "," term` -/
 syntax (name := bigsum)
-  "∑ " bigOpBinders ("with " atomic(binderIdent " : ")? term)? ", " term:67 : term
+  "∑ " bigOpBinders (" with " atomic(binderIdent " : ")? term)? ", " term:67 : term
 
 /--
 - `∏ x, f x` is notation for `Finset.prod Finset.univ f`. It is the product of `f x`,


### PR DESCRIPTION
Currently, `∑ i ∈ Finset.range 10 with Even i, i ^ i` prints as `∑ i ∈ Finset.range 10with Even i, i ^ i`. This PR fixes that.

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include at least one commit authored by each
co-author among the commits in the pull request. If necessary, you may 
create empty commits to indicate co-authorship, using commands like so:

git commit --author="Author Name <author@email.com>" --allow-empty -m "add Author Name as coauthor"

When merging, all the commits will be squashed into a single commit listing all co-authors.

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

```lean
import Mathlib

def foo : ℕ :=
  ∑ i ∈ Finset.range 10 with Even i, i ^ i

#print foo -- ∑ i ∈ Finset.range 10with Even i, i ^ i
```
[Live editor](https://live.lean-lang.org/#codez=JYWwDg9gTgLgBAWQIYwBYBtgCMBQOAmApgGZzEQRwBccgqITUC8OccgiERzByAQRHAGLAA7AM6EYAOihIBAc0JwAjAAY4Ad2Bo4AUQBuhARwA0HOAD0OeAMRgog+OUoBaB22M9+w0RKmyFitRp09Q2MzYBwgA).

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
