### PR TITLE
[Merged by Bors] - chore(Data): golf entire `getElem_insertIdx_add_succ` and `inv_sqrt_two_sub_one` using `grind`

### DIFF
--- a/Mathlib/Data/List/InsertIdx.lean
+++ b/Mathlib/Data/List/InsertIdx.lean
@@ -101,8 +101,7 @@ theorem getElem_insertIdx_add_succ (l : List α) (x : α) (n k : ℕ) (hk' : n +
     (hk : n + k + 1 < (l.insertIdx n x).length := (by
       rwa [length_insertIdx_of_le_length (by cutsat), Nat.succ_lt_succ_iff])) :
     (l.insertIdx n x)[n + k + 1] = l[n + k] := by
-  rw [getElem_insertIdx_of_gt (by cutsat)]
-  simp only [Nat.add_one_sub_one]
+  grind
 
 theorem get_insertIdx_add_succ (l : List α) (x : α) (n k : ℕ) (hk' : n + k < l.length)
     (hk : n + k + 1 < (l.insertIdx n x).length := (by

--- a/Mathlib/Data/Real/Sqrt.lean
+++ b/Mathlib/Data/Real/Sqrt.lean
@@ -322,9 +322,7 @@ lemma sqrt_two_lt_three_halves : √2 < 3 / 2 := by
   norm_num
 
 lemma inv_sqrt_two_sub_one : (√2 - 1)⁻¹ = √2 + 1 := by
-  rw [← one_div, div_eq_iff (sub_ne_zero_of_ne (by simp))]
-  ring_nf
-  norm_num
+  grind
 
 @[simp]
 theorem sqrt_mul {x : ℝ} (hx : 0 ≤ x) (y : ℝ) : √(x * y) = √x * √y := by


### PR DESCRIPTION
---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include at least one commit authored by each
co-author among the commits in the pull request. If necessary, you may 
create empty commits to indicate co-authorship, using commands like so:

git commit --author="Author Name <author@email.com>" --allow-empty -m "add Author Name as coauthor"

When merging, all the commits will be squashed into a single commit listing all co-authors.

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
