### PR TITLE
[Merged by Bors] - feat(RingTheory/PowerSeries): Multipliable (1 + f i) for when the order tends to infinity

### DIFF
--- a/Mathlib/RingTheory/MvPowerSeries/PiTopology.lean
+++ b/Mathlib/RingTheory/MvPowerSeries/PiTopology.lean
@@ -12,6 +12,7 @@ import Mathlib.Topology.Algebra.Ring.Basic
 import Mathlib.Topology.Algebra.IsUniformGroup.Basic
 import Mathlib.Topology.Instances.ENat
 import Mathlib.Topology.UniformSpace.Pi
+import Mathlib.Topology.Algebra.InfiniteSum.Ring
 import Mathlib.Topology.Algebra.TopologicallyNilpotent
 
 /-! # Product topology on multivariate power series
@@ -292,6 +293,48 @@ theorem summable_of_tendsto_order_atTop_nhds_top
   summable_of_tendsto_weightedOrder_atTop_nhds_top h
 
 end Sum
+
+section Prod
+variable {σ R : Type*} [TopologicalSpace R] [CommSemiring R]
+variable {ι : Type*} {f : ι → MvPowerSeries σ R} [LinearOrder ι] [LocallyFiniteOrderBot ι]
+
+/-- If the weighted order of a family of `MvPowerSeries` tends to infinity, the collection of all
+possible products over `Finset` is summable. -/
+theorem summable_prod_of_tendsto_weightedOrder_atTop_nhds_top {w : σ → ℕ}
+    (h : Tendsto (fun i ↦ weightedOrder w (f i)) atTop (𝓝 ⊤)) : Summable (∏ i ∈ ·, f i) := by
+  rcases isEmpty_or_nonempty ι with hempty | hempty
+  · apply Summable.of_finite
+  refine summable_iff_summable_coeff.mpr fun d ↦ (summable_of_finite_support ?_)
+  simp_rw [ENat.tendsto_nhds_top_iff_natCast_lt, eventually_atTop] at h
+  obtain ⟨i, hi⟩ := h (Finsupp.weight w d)
+  apply (Finset.Iio i).powerset.finite_toSet.subset
+  suffices ∀ s : Finset ι, coeff d (∏ i ∈ s, f i) ≠ 0 → ↑s ⊆ Set.Iio i by simpa
+  intro s hs
+  contrapose! hs
+  obtain ⟨x, hxs, hxi⟩ := Set.not_subset.mp hs
+  rw [Set.mem_Iio, not_lt] at hxi
+  refine coeff_eq_zero_of_lt_weightedOrder w <| (hi x hxi).trans_le <| ?_
+  apply le_trans (Finset.single_le_sum (by simp) hxs) (le_weightedOrder_prod w _ _)
+
+/-- If the order of a family of `MvPowerSeries` tends to infinity, the collection of all
+possible products over `Finset` is summable. -/
+theorem summable_prod_of_tendsto_order_atTop_nhds_top
+    (h : Tendsto (fun i ↦ (f i).order) atTop (𝓝 ⊤)) : Summable (∏ i ∈ ·, f i) :=
+  summable_prod_of_tendsto_weightedOrder_atTop_nhds_top h
+
+/-- A family of `MvPowerSeries` in the form `1 + f i` is multipliable if the weighted order of `f i`
+tends to infinity. -/
+theorem multipliable_one_add_oft_tendsto_weightedOrder_atTop_nhds_top {w : σ → ℕ}
+    (h : Tendsto (fun i ↦ weightedOrder w (f i)) atTop (nhds ⊤)) : Multipliable (1 + f ·) :=
+  multipliable_one_add_of_summable_prod <| summable_prod_of_tendsto_weightedOrder_atTop_nhds_top h
+
+/-- A family of `MvPowerSeries` in the form `1 + f i` is multipliable if the order of `f i`
+tends to infinity. -/
+theorem multipliable_one_add_oft_tendsto_order_atTop_nhds_top
+    (h : Tendsto (fun i ↦ (f i).order) atTop (nhds ⊤)) : Multipliable (1 + f ·) :=
+  multipliable_one_add_of_summable_prod <| summable_prod_of_tendsto_order_atTop_nhds_top h
+
+end Prod
 
 end Topology
 

--- a/Mathlib/RingTheory/MvPowerSeries/PiTopology.lean
+++ b/Mathlib/RingTheory/MvPowerSeries/PiTopology.lean
@@ -304,7 +304,7 @@ theorem summable_prod_of_tendsto_weightedOrder_atTop_nhds_top {w : σ → ℕ}
     (h : Tendsto (fun i ↦ weightedOrder w (f i)) atTop (𝓝 ⊤)) : Summable (∏ i ∈ ·, f i) := by
   rcases isEmpty_or_nonempty ι with hempty | hempty
   · apply Summable.of_finite
-  refine summable_iff_summable_coeff.mpr fun d ↦ (summable_of_finite_support ?_)
+  refine summable_iff_summable_coeff.mpr fun d ↦ summable_of_finite_support ?_
   simp_rw [ENat.tendsto_nhds_top_iff_natCast_lt, eventually_atTop] at h
   obtain ⟨i, hi⟩ := h (Finsupp.weight w d)
   apply (Finset.Iio i).powerset.finite_toSet.subset

--- a/Mathlib/RingTheory/MvPowerSeries/PiTopology.lean
+++ b/Mathlib/RingTheory/MvPowerSeries/PiTopology.lean
@@ -324,13 +324,13 @@ theorem summable_prod_of_tendsto_order_atTop_nhds_top
 
 /-- A family of `MvPowerSeries` in the form `1 + f i` is multipliable if the weighted order of `f i`
 tends to infinity. -/
-theorem multipliable_one_add_oft_tendsto_weightedOrder_atTop_nhds_top {w : σ → ℕ}
+theorem multipliable_one_add_of_tendsto_weightedOrder_atTop_nhds_top {w : σ → ℕ}
     (h : Tendsto (fun i ↦ weightedOrder w (f i)) atTop (nhds ⊤)) : Multipliable (1 + f ·) :=
   multipliable_one_add_of_summable_prod <| summable_prod_of_tendsto_weightedOrder_atTop_nhds_top h
 
 /-- A family of `MvPowerSeries` in the form `1 + f i` is multipliable if the order of `f i`
 tends to infinity. -/
-theorem multipliable_one_add_oft_tendsto_order_atTop_nhds_top
+theorem multipliable_one_add_of_tendsto_order_atTop_nhds_top
     (h : Tendsto (fun i ↦ (f i).order) atTop (nhds ⊤)) : Multipliable (1 + f ·) :=
   multipliable_one_add_of_summable_prod <| summable_prod_of_tendsto_order_atTop_nhds_top h
 

--- a/Mathlib/RingTheory/PowerSeries/PiTopology.lean
+++ b/Mathlib/RingTheory/PowerSeries/PiTopology.lean
@@ -167,7 +167,7 @@ theorem summable_prod_of_tendsto_order_atTop_nhds_top
     (h : Tendsto (fun i ↦ (f i).order) atTop (𝓝 ⊤)) : Summable (∏ i ∈ ·, f i) := by
   rcases isEmpty_or_nonempty ι with hempty | hempty
   · apply Summable.of_finite
-  refine (summable_iff_summable_coeff _).mpr fun n ↦ (summable_of_finite_support ?_)
+  refine (summable_iff_summable_coeff _).mpr fun n ↦ summable_of_finite_support ?_
   simp_rw [ENat.tendsto_nhds_top_iff_natCast_lt, eventually_atTop] at h
   obtain ⟨i, hi⟩ := h n
   apply (Finset.Iio i).powerset.finite_toSet.subset

--- a/Mathlib/RingTheory/PowerSeries/PiTopology.lean
+++ b/Mathlib/RingTheory/PowerSeries/PiTopology.lean
@@ -8,6 +8,7 @@ import Mathlib.RingTheory.PowerSeries.Basic
 import Mathlib.RingTheory.PowerSeries.Order
 import Mathlib.RingTheory.PowerSeries.Trunc
 import Mathlib.LinearAlgebra.Finsupp.Pi
+import Mathlib.Topology.Algebra.InfiniteSum.Ring
 
 /-! # Product topology on power series
 
@@ -156,6 +157,31 @@ theorem summable_of_tendsto_order_atTop_nhds_top [LinearOrder ι] [LocallyFinite
   exact coeff_of_lt_order _ <| by simpa using (hi k hk.le)
 
 end Sum
+
+section Prod
+
+/-- A family of `PowerSeries` in the form `1 + f i` is multipliable if order of `f i` tends to
+infinity. -/
+theorem multipliable_one_add_of_tendsto_order_atTop_nhds_top [CommSemiring R]
+    {ι : Type*} [LinearOrder ι] [LocallyFiniteOrderBot ι] {f : ι → R⟦X⟧}
+    (h : Tendsto (fun i ↦ (f i).order) atTop (nhds ⊤)) :
+    Multipliable (1 + f ·) := by
+  rcases isEmpty_or_nonempty ι with hempty | hempty
+  · apply multipliable_empty
+  apply multipliable_one_add_of_summable_prod
+  refine (summable_iff_summable_coeff _).mpr fun n ↦ (summable_of_finite_support ?_)
+  simp_rw [ENat.tendsto_nhds_top_iff_natCast_lt, eventually_atTop] at h
+  obtain ⟨i, hi⟩ := h n
+  apply (Finset.Iio i).powerset.finite_toSet.subset
+  suffices ∀ s : Finset ι, coeff n (∏ i ∈ s, f i) ≠ 0 → ↑s ⊆ Set.Iio i by simpa
+  intro s hs
+  contrapose! hs
+  obtain ⟨x, hxs, hxi⟩ := Set.not_subset.mp hs
+  rw [Set.mem_Iio, not_lt] at hxi
+  refine coeff_of_lt_order _<| (hi x hxi).trans_le <| le_trans ?_ (le_order_prod _ _)
+  apply Finset.single_le_sum (by simp) hxs
+
+end Prod
 
 end WithPiTopology
 

--- a/Mathlib/RingTheory/PowerSeries/PiTopology.lean
+++ b/Mathlib/RingTheory/PowerSeries/PiTopology.lean
@@ -159,16 +159,14 @@ theorem summable_of_tendsto_order_atTop_nhds_top [LinearOrder ι] [LocallyFinite
 end Sum
 
 section Prod
+variable [CommSemiring R] {ι : Type*} [LinearOrder ι] [LocallyFiniteOrderBot ι] {f : ι → R⟦X⟧}
 
-/-- A family of `PowerSeries` in the form `1 + f i` is multipliable if order of `f i` tends to
-infinity. -/
-theorem multipliable_one_add_of_tendsto_order_atTop_nhds_top [CommSemiring R]
-    {ι : Type*} [LinearOrder ι] [LocallyFiniteOrderBot ι] {f : ι → R⟦X⟧}
-    (h : Tendsto (fun i ↦ (f i).order) atTop (nhds ⊤)) :
-    Multipliable (1 + f ·) := by
+/-- If the order of a family of `PowerSeries` tends to infinity, the collection of all
+possible products over `Finset` is summable. -/
+theorem summable_prod_of_tendsto_order_atTop_nhds_top
+    (h : Tendsto (fun i ↦ (f i).order) atTop (𝓝 ⊤)) : Summable (∏ i ∈ ·, f i) := by
   rcases isEmpty_or_nonempty ι with hempty | hempty
-  · apply multipliable_empty
-  apply multipliable_one_add_of_summable_prod
+  · apply Summable.of_finite
   refine (summable_iff_summable_coeff _).mpr fun n ↦ (summable_of_finite_support ?_)
   simp_rw [ENat.tendsto_nhds_top_iff_natCast_lt, eventually_atTop] at h
   obtain ⟨i, hi⟩ := h n
@@ -178,8 +176,14 @@ theorem multipliable_one_add_of_tendsto_order_atTop_nhds_top [CommSemiring R]
   contrapose! hs
   obtain ⟨x, hxs, hxi⟩ := Set.not_subset.mp hs
   rw [Set.mem_Iio, not_lt] at hxi
-  refine coeff_of_lt_order _<| (hi x hxi).trans_le <| le_trans ?_ (le_order_prod _ _)
+  refine coeff_of_lt_order _ <| (hi x hxi).trans_le <| le_trans ?_ (le_order_prod _ _)
   apply Finset.single_le_sum (by simp) hxs
+
+/-- A family of `PowerSeries` in the form `1 + f i` is multipliable if the order of `f i` tends to
+infinity. -/
+theorem multipliable_one_add_of_tendsto_order_atTop_nhds_top
+    (h : Tendsto (fun i ↦ (f i).order) atTop (nhds ⊤)) : Multipliable (1 + f ·) :=
+  multipliable_one_add_of_summable_prod <| summable_prod_of_tendsto_order_atTop_nhds_top _ h
 
 end Prod
 


### PR DESCRIPTION
As `Summable f` and `Multipliable (1 + f ·)` are often related, this shares the same condition as `summable_of_tendsto_order_atTop_nhds_top`

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include at least one commit authored by each
co-author among the commits in the pull request. If necessary, you may 
create empty commits to indicate co-authorship, using commands like so:

git commit --author="Author Name <author@email.com>" --allow-empty -m "add Author Name as coauthor"

When merging, all the commits will be squashed into a single commit listing all co-authors.

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
