### PR TITLE
[Merged by Bors] - feat(Data/Nat/BinaryRec): equational lemmas for variants of binary recursion

### DIFF
--- a/Mathlib/Data/Nat/BinaryRec.lean
+++ b/Mathlib/Data/Nat/BinaryRec.lean
@@ -149,4 +149,37 @@ theorem binaryRec_eq {zero : motive 0} {bit : ∀ b n, motive n → motive (bit 
     rw [testBit_bit_zero, bit_shiftRight_one]
     intros; rfl
 
+@[simp] theorem binaryRec'_zero (zero : motive 0)
+    (bit : (b : Bool) → (n : Nat) → (n = 0 → b = true) → motive n → motive (n.bit b)) :
+    binaryRec' zero bit 0 = zero := by
+  rw [binaryRec', Nat.binaryRec_zero]
+
+@[simp] theorem binaryRec'_one (zero : motive 0)
+    (bit : (b : Bool) → (n : Nat) → (n = 0 → b = true) → motive n → motive (n.bit b)) :
+    binaryRec' (motive := motive) zero bit 1 = bit true 0 (by simp) zero := by
+  rw [binaryRec', Nat.binaryRec_one, dif_pos]
+
+theorem binaryRec'_eq {zero : motive 0}
+    {bit : (b : Bool) → (n : Nat) → (n = 0 → b = true) → motive n → motive (n.bit b)}
+    (b n) (h : n = 0 → b = true) :
+    binaryRec' zero bit (n.bit b) = bit b n h (binaryRec' zero bit n) := by
+  rw [binaryRec', binaryRec_eq _ _ (by simp), dif_pos h, binaryRec']
+
+@[simp] theorem binaryRecFromOne_zero (zero : motive 0) (one : motive 1)
+    (bit : (b : Bool) → (n : Nat) → n ≠ 0 → motive n → motive (n.bit b)) :
+    binaryRecFromOne zero one bit 0 = zero :=
+  binaryRec'_zero _ _
+
+@[simp] theorem binaryRecFromOne_one {zero : motive 0} {one : motive 1}
+    (bit : (b : Bool) → (n : Nat) → n ≠ 0 → motive n → motive (n.bit b)) :
+    binaryRecFromOne zero one bit 1 = one := by
+  rw [binaryRecFromOne, binaryRec'_one, dif_pos rfl]
+
+theorem binaryRecFromOne_eq {zero : motive 0} {one : motive 1}
+    {bit : (b : Bool) → (n : Nat) → n ≠ 0 → motive n → motive (n.bit b)}
+    (b n) (h) :
+    binaryRecFromOne zero one bit (Nat.bit b n) =
+      bit b n h (binaryRecFromOne zero one bit n) := by
+  rw [binaryRecFromOne, binaryRec'_eq _ _ (by simp [h]), dif_neg h, binaryRecFromOne]
+
 end Nat


### PR DESCRIPTION
Adds the missing equational lemmas for `binaryRec'` and `binaryRecFromOne`. The statements and implicitness are chosen to match the existing ones for `binaryRec`, which seem to work quite well.


---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include at least one commit authored by each
co-author among the commits in the pull request. If necessary, you may 
create empty commits to indicate co-authorship, using commands like so:

git commit --author="Author Name <author@email.com>" --allow-empty -m "add Author Name as coauthor"

When merging, all the commits will be squashed into a single commit listing all co-authors.

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
