### PR TITLE
[Merged by Bors] - feat(Nat/Log): add lemma for `log b (n / b ^ k)`

### DIFF
--- a/Mathlib/Data/Nat/Log.lean
+++ b/Mathlib/Data/Nat/Log.lean
@@ -218,9 +218,7 @@ theorem log_div_base (b n : ℕ) : log b (n / b) = log b n - 1 := by
 lemma log_div_base_pow (b n k : ℕ) : log b (n / b ^ k) = log b n - k := by
   induction k with
   | zero => grind
-  | succ k hk =>
-    rw [Nat.pow_succ, ← Nat.div_div_eq_div_mul]
-    grind [= Nat.log_div_base]
+  | succ k hk => rw [Nat.pow_succ, ← Nat.div_div_eq_div_mul, log_div_base, hk, sub_add_eq]
 
 @[simp]
 theorem log_div_mul_self (b n : ℕ) : log b (n / b * b) = log b n := by

--- a/Mathlib/Data/Nat/Log.lean
+++ b/Mathlib/Data/Nat/Log.lean
@@ -215,6 +215,13 @@ theorem log_div_base (b n : ℕ) : log b (n / b) = log b n - 1 := by
   · rw [div_eq_of_lt h, log_of_lt h, log_zero_right]
   rw [log_of_one_lt_of_le hb h, Nat.add_sub_cancel_right]
 
+lemma log_div_base_pow (b n k : ℕ) : log b (n / b ^ k) = log b n - k := by
+  induction k with
+  | zero => grind
+  | succ k hk =>
+    rw [Nat.pow_succ, ← Nat.div_div_eq_div_mul]
+    grind [= Nat.log_div_base]
+
 @[simp]
 theorem log_div_mul_self (b n : ℕ) : log b (n / b * b) = log b n := by
   rcases le_or_gt b 1 with hb | hb


### PR DESCRIPTION
This lemma is a simple consequence of the previous by induction, but is often useful for calculation, especially since the natural number division and natural number subtraction play very nicely here.

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include at least one commit authored by each
co-author among the commits in the pull request. If necessary, you may 
create empty commits to indicate co-authorship, using commands like so:

git commit --author="Author Name <author@email.com>" --allow-empty -m "add Author Name as coauthor"

When merging, all the commits will be squashed into a single commit listing all co-authors.

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
