### PR TITLE
[Merged by Bors] - feat(Data/List): relate destutter and dedup

### DIFF
--- a/Mathlib/Data/List/Dedup.lean
+++ b/Mathlib/Data/List/Dedup.lean
@@ -37,6 +37,10 @@ theorem dedup_cons_of_notMem' {a : α} {l : List α} (h : a ∉ dedup l) :
     dedup (a :: l) = a :: dedup l :=
   pwFilter_cons_of_pos <| by simpa only [forall_mem_ne] using h
 
+theorem dedup_cons' (a : α) (l : List α) :
+    dedup (a :: l) = if a ∈ dedup l then dedup l else a :: dedup l := by
+  split <;> simp [dedup_cons_of_mem', dedup_cons_of_notMem', *]
+
 @[deprecated (since := "2025-05-23")] alias dedup_cons_of_not_mem' := dedup_cons_of_notMem'
 
 @[simp]
@@ -55,6 +59,10 @@ theorem dedup_cons_of_notMem {a : α} {l : List α} (h : a ∉ l) : dedup (a :: 
   dedup_cons_of_notMem' <| mt mem_dedup.1 h
 
 @[deprecated (since := "2025-05-23")] alias dedup_cons_of_not_mem := dedup_cons_of_notMem
+
+theorem dedup_cons (a : α) (l : List α) :
+    dedup (a :: l) = if a ∈ l then dedup l else a :: dedup l := by
+  simpa using dedup_cons' a l
 
 theorem dedup_sublist : ∀ l : List α, dedup l <+ l :=
   pwFilter_sublist
@@ -171,5 +179,11 @@ theorem Perm.dedup {l₁ l₂ : List α} (p : l₁ ~ l₂) : dedup l₁ ~ dedup 
       simp [h, nodup_dedup, p.subset h]
     else by
       simp [h, count_eq_zero_of_not_mem, mt p.mem_iff.2]
+
+theorem Pairwise.dedup {r : α → α → Prop} {l : List α} (hl : l.Pairwise r) :
+    l.dedup.Pairwise r := by
+  induction l with
+  | nil => simp
+  | cons x xs ih => grind [dedup_cons, pairwise_cons, mem_dedup]
 
 end List

--- a/Mathlib/Data/List/Dedup.lean
+++ b/Mathlib/Data/List/Dedup.lean
@@ -180,10 +180,4 @@ theorem Perm.dedup {l₁ l₂ : List α} (p : l₁ ~ l₂) : dedup l₁ ~ dedup 
     else by
       simp [h, count_eq_zero_of_not_mem, mt p.mem_iff.2]
 
-theorem Pairwise.dedup {r : α → α → Prop} {l : List α} (hl : l.Pairwise r) :
-    l.dedup.Pairwise r := by
-  induction l with
-  | nil => simp
-  | cons x xs ih => grind [dedup_cons, pairwise_cons, mem_dedup]
-
 end List

--- a/Mathlib/Data/List/Destutter.lean
+++ b/Mathlib/Data/List/Destutter.lean
@@ -4,6 +4,7 @@ Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Eric Rodriguez, Eric Wieser
 -/
 import Mathlib.Data.List.Chain
+import Mathlib.Data.List.Dedup
 
 /-!
 # Destuttering of Lists
@@ -270,5 +271,23 @@ other `≠`-chain sublist. -/
 lemma IsChain.length_le_length_destutter_ne [DecidableEq α] (hl : l₁ <+ l₂)
     (hl₁ : l₁.IsChain (· ≠ ·)) : l₁.length ≤ (l₂.destutter (· ≠ ·)).length :=
   hl₁.length_le_length_destutter hl
+
+/--
+If the elements of a list `l` are related pairwise by an antisymmetric relation `r`, then
+destuttering `l` by disequality produces the same result as deduplicating `l`.
+This is most useful when `r` is a strict or weak ordering.
+-/
+lemma Pairwise.destutter_eq_dedup [DecidableEq α] {r : α → α → Prop} [IsAntisymm α r] :
+    ∀ {l : List α}, l.Pairwise r → l.destutter (· ≠ ·) = l.dedup
+  | [], h => by simp
+  | [x], h => by simp
+  | x :: y :: xs, h => by
+    rw [pairwise_cons] at h
+    rw [destutter_cons_cons, ← destutter_cons', ← destutter_cons', h.2.destutter_eq_dedup]
+    obtain rfl | hxy := eq_or_ne x y
+    · simpa using h.2.destutter_eq_dedup
+    · simp only [mem_cons, forall_eq_or_imp, pairwise_cons] at h
+      have : x ∉ xs := fun hx ↦ hxy (antisymm h.1.1 (h.2.1 x hx))
+      rw [if_pos hxy, dedup_cons_of_notMem (a := x) (by simp [*])]
 
 end List


### PR DESCRIPTION
---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include at least one commit authored by each
co-author among the commits in the pull request. If necessary, you may 
create empty commits to indicate co-authorship, using commands like so:

git commit --author="Author Name <author@email.com>" --allow-empty -m "add Author Name as coauthor"

When merging, all the commits will be squashed into a single commit listing all co-authors.

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
