### PR TITLE
[Merged by Bors] - chore(Nat/Log): swap Nat.pow_le_iff_le_log lemmas

### DIFF
--- a/Mathlib/Data/Nat/Digits/Lemmas.lean
+++ b/Mathlib/Data/Nat/Digits/Lemmas.lean
@@ -63,7 +63,7 @@ theorem digits_length_le_iff {b k : ℕ} (hb : 1 < b) (n : ℕ) :
   by_cases h : n = 0
   · have : 0 < b ^ k := by positivity
     simpa [h]
-  rw [digits_len b n hb h, lt_pow_iff_log_lt hb h]
+  rw [digits_len b n hb h, log_lt_iff_lt_pow hb h]
   exact add_one_le_iff
 
 theorem lt_digits_length_iff {b k : ℕ} (hb : 1 < b) (n : ℕ) :

--- a/Mathlib/Data/Nat/Digits/Lemmas.lean
+++ b/Mathlib/Data/Nat/Digits/Lemmas.lean
@@ -63,7 +63,7 @@ theorem digits_length_le_iff {b k : ℕ} (hb : 1 < b) (n : ℕ) :
   by_cases h : n = 0
   · have : 0 < b ^ k := by positivity
     simpa [h]
-  rw [digits_len b n hb h, log_lt_iff_lt_pow hb h]
+  rw [digits_len b n hb h, ← log_lt_iff_lt_pow hb h]
   exact add_one_le_iff
 
 theorem lt_digits_length_iff {b k : ℕ} (hb : 1 < b) (n : ℕ) :

--- a/Mathlib/Data/Nat/Log.lean
+++ b/Mathlib/Data/Nat/Log.lean
@@ -77,31 +77,40 @@ theorem log_one_right (b : ℕ) : log b 1 = 0 :=
 
 /-- `pow b` and `log b` (almost) form a Galois connection. See also `Nat.pow_le_of_le_log` and
 `Nat.le_log_of_pow_le` for individual implications under weaker assumptions. -/
-theorem pow_le_iff_le_log {b : ℕ} (hb : 1 < b) {x y : ℕ} (hy : y ≠ 0) :
-    b ^ x ≤ y ↔ x ≤ log b y := by
+theorem le_log_iff_pow_le {b : ℕ} (hb : 1 < b) {x y : ℕ} (hy : y ≠ 0) :
+    x ≤ log b y ↔ b ^ x ≤ y := by
   induction y using Nat.strong_induction_on generalizing x with | h y ih => ?_
   cases x with
   | zero => dsimp; cutsat
   | succ x =>
     rw [log]; split_ifs with h
     · have b_pos : 0 < b := lt_of_succ_lt hb
-      rw [Nat.add_le_add_iff_right, ← ih (y / b) (div_lt_self
+      rw [Nat.add_le_add_iff_right, ih (y / b) (div_lt_self
         (Nat.pos_iff_ne_zero.2 hy) hb) (Nat.div_pos h.1 b_pos).ne', le_div_iff_mul_le b_pos,
         pow_succ', Nat.mul_comm]
-    · exact iff_of_false (fun hby => h ⟨(le_self_pow x.succ_ne_zero _).trans hby, hb⟩)
-        (not_succ_le_zero _)
+    · exact iff_of_false (not_succ_le_zero _)
+        (fun hby => h ⟨(le_self_pow x.succ_ne_zero _).trans hby, hb⟩)
 
+@[deprecated le_log_iff_pow_le (since := "2025-10-05")]
+theorem pow_le_iff_le_log {b : ℕ} (hb : 1 < b) {x y : ℕ} (hy : y ≠ 0) :
+    b ^ x ≤ y ↔ x ≤ log b y :=
+  (le_log_iff_pow_le hb hy).symm
+
+theorem log_lt_iff_lt_pow {b : ℕ} (hb : 1 < b) {x y : ℕ} (hy : y ≠ 0) : log b y < x ↔ y < b ^ x :=
+  lt_iff_lt_of_le_iff_le (le_log_iff_pow_le hb hy)
+
+@[deprecated log_lt_iff_lt_pow (since := "2025-10-05")]
 theorem lt_pow_iff_log_lt {b : ℕ} (hb : 1 < b) {x y : ℕ} (hy : y ≠ 0) : y < b ^ x ↔ log b y < x :=
-  lt_iff_lt_of_le_iff_le (pow_le_iff_le_log hb hy)
+  (log_lt_iff_lt_pow hb hy).symm
 
 theorem pow_le_of_le_log {b x y : ℕ} (hy : y ≠ 0) (h : x ≤ log b y) : b ^ x ≤ y := by
-  refine (le_or_gt b 1).elim (fun hb => ?_) fun hb => (pow_le_iff_le_log hb hy).2 h
+  refine (le_or_gt b 1).elim (fun hb => ?_) fun hb => (le_log_iff_pow_le hb hy).1 h
   rw [log_of_left_le_one hb, Nat.le_zero] at h
   rwa [h, Nat.pow_zero, one_le_iff_ne_zero]
 
 theorem le_log_of_pow_le {b x y : ℕ} (hb : 1 < b) (h : b ^ x ≤ y) : x ≤ log b y := by
   rcases ne_or_eq y 0 with (hy | rfl)
-  exacts [(pow_le_iff_le_log hb hy).1 h, (h.not_gt (Nat.pow_pos (Nat.zero_lt_one.trans hb))).elim]
+  exacts [(le_log_iff_pow_le hb hy).2 h, (h.not_gt (Nat.pow_pos (Nat.zero_lt_one.trans hb))).elim]
 
 theorem pow_log_le_self (b : ℕ) {x : ℕ} (hx : x ≠ 0) : b ^ log b x ≤ x :=
   pow_le_of_le_log hx le_rfl
@@ -127,7 +136,7 @@ theorem lt_pow_succ_log_self {b : ℕ} (hb : 1 < b) (x : ℕ) : x < b ^ (log b x
 theorem log_eq_iff {b m n : ℕ} (h : m ≠ 0 ∨ 1 < b ∧ n ≠ 0) :
     log b n = m ↔ b ^ m ≤ n ∧ n < b ^ (m + 1) := by
   rcases em (1 < b ∧ n ≠ 0) with (⟨hb, hn⟩ | hbn)
-  · rw [le_antisymm_iff, ← Nat.lt_succ_iff, ← pow_le_iff_le_log, ← lt_pow_iff_log_lt,
+  · rw [le_antisymm_iff, ← Nat.lt_succ_iff, le_log_iff_pow_le, log_lt_iff_lt_pow,
       and_comm] <;> assumption
   have hm : m ≠ 0 := h.resolve_right hbn
   rw [not_and_or, not_lt, Ne, not_not] at hbn
@@ -234,7 +243,7 @@ lemma log2_eq_log_two {n : ℕ} : Nat.log2 n = Nat.log 2 n := by
   · rw [log2_zero, log_zero_right]
   apply eq_of_forall_le_iff
   intro m
-  rw [Nat.le_log2 hn, ← Nat.pow_le_iff_le_log Nat.one_lt_two hn]
+  rw [Nat.le_log2 hn, Nat.le_log_iff_pow_le Nat.one_lt_two hn]
 
 /-! ### Ceil logarithm -/
 
@@ -280,47 +289,55 @@ theorem clog_eq_one {b n : ℕ} (hn : 2 ≤ n) (h : n ≤ b) : clog b n = 1 := b
   rw [← Nat.lt_succ_iff, Nat.div_lt_iff_lt_mul] <;> omega
 
 /-- `clog b` and `pow b` form a Galois connection. -/
-theorem le_pow_iff_clog_le {b : ℕ} (hb : 1 < b) {x y : ℕ} : x ≤ b ^ y ↔ clog b x ≤ y := by
+theorem clog_le_iff_le_pow {b : ℕ} (hb : 1 < b) {x y : ℕ} : clog b x ≤ y ↔ x ≤ b ^ y := by
   induction x using Nat.strong_induction_on generalizing y with | h x ih => ?_
   cases y
   · rw [Nat.pow_zero]
-    refine ⟨fun h => (clog_of_right_le_one h b).le, ?_⟩
+    refine ⟨?_, fun h => (clog_of_right_le_one h b).le⟩
     simp_rw [← not_lt]
     contrapose!
     exact clog_pos hb
   have b_pos : 0 < b := zero_lt_of_lt hb
   rw [clog]; split_ifs with h
-  · rw [Nat.add_le_add_iff_right, ← ih ((x + b - 1) / b) (add_pred_div_lt hb h.2),
+  · rw [Nat.add_le_add_iff_right, ih ((x + b - 1) / b) (add_pred_div_lt hb h.2),
       Nat.div_le_iff_le_mul_add_pred b_pos, Nat.mul_comm b, ← Nat.pow_succ,
       Nat.add_sub_assoc (Nat.succ_le_of_lt b_pos), Nat.add_le_add_iff_right]
-  · exact iff_of_true ((not_lt.1 (not_and.1 h hb)).trans <| succ_le_of_lt <| Nat.pow_pos b_pos)
-      (zero_le _)
+  · exact iff_of_true (zero_le _)
+      ((not_lt.1 (not_and.1 h hb)).trans <| succ_le_of_lt <| Nat.pow_pos b_pos)
 
+@[deprecated clog_le_iff_le_pow (since := "2025-10-05")]
+theorem le_pow_iff_clog_le {b : ℕ} (hb : 1 < b) {x y : ℕ} : x ≤ b ^ y ↔ clog b x ≤ y :=
+  (clog_le_iff_le_pow hb).symm
+
+theorem lt_clog_iff_pow_lt {b : ℕ} (hb : 1 < b) {x y : ℕ} : y < clog b x ↔ b ^ y < x :=
+  lt_iff_lt_of_le_iff_le (clog_le_iff_le_pow hb)
+
+@[deprecated lt_clog_iff_pow_lt (since := "2025-10-05")]
 theorem pow_lt_iff_lt_clog {b : ℕ} (hb : 1 < b) {x y : ℕ} : b ^ y < x ↔ y < clog b x :=
-  lt_iff_lt_of_le_iff_le (le_pow_iff_clog_le hb)
+  (lt_clog_iff_pow_lt hb).symm
 
 @[simp]
 theorem clog_pow (b x : ℕ) (hb : 1 < b) : clog b (b ^ x) = x :=
-  eq_of_forall_ge_iff fun z ↦ by rw [← le_pow_iff_clog_le hb, Nat.pow_le_pow_iff_right hb]
+  eq_of_forall_ge_iff fun z ↦ by rw [clog_le_iff_le_pow hb, Nat.pow_le_pow_iff_right hb]
 
 theorem pow_pred_clog_lt_self {b : ℕ} (hb : 1 < b) {x : ℕ} (hx : 1 < x) :
     b ^ (clog b x).pred < x := by
-  rw [← not_le, le_pow_iff_clog_le hb, not_le]
+  rw [← lt_clog_iff_pow_lt hb]
   exact pred_lt (clog_pos hb hx).ne'
 
 theorem le_pow_clog {b : ℕ} (hb : 1 < b) (x : ℕ) : x ≤ b ^ clog b x :=
-  (le_pow_iff_clog_le hb).2 le_rfl
+  (clog_le_iff_le_pow hb).1 le_rfl
 
 @[mono, gcongr]
 theorem clog_mono_right (b : ℕ) {n m : ℕ} (h : n ≤ m) : clog b n ≤ clog b m := by
   rcases le_or_gt b 1 with hb | hb
   · rw [clog_of_left_le_one hb]
     exact zero_le _
-  · rw [← le_pow_iff_clog_le hb]
+  · rw [clog_le_iff_le_pow hb]
     exact h.trans (le_pow_clog hb _)
 
 theorem clog_anti_left {b c n : ℕ} (hc : 1 < c) (hb : c ≤ b) : clog b n ≤ clog c n := by
-  rw [← le_pow_iff_clog_le (lt_of_lt_of_le hc hb)]
+  rw [clog_le_iff_le_pow (lt_of_lt_of_le hc hb)]
   calc
     n ≤ c ^ clog c n := le_pow_clog hc _
     _ ≤ b ^ clog c n := Nat.pow_le_pow_left hb _
@@ -353,8 +370,8 @@ theorem clog_lt_clog_succ_iff {b n : ℕ} (hb : 1 < b) :
   refine ⟨fun H ↦ ?_, fun H ↦ ?_⟩
   · apply le_antisymm _ (le_pow_clog hb n)
     apply le_of_lt_succ
-    exact (pow_lt_iff_lt_clog hb).mpr H
-  · rw [← pow_lt_iff_lt_clog hb, H]
+    exact (lt_clog_iff_pow_lt hb).mp H
+  · rw [lt_clog_iff_pow_lt hb, H]
     exact n.lt_add_one
 
 theorem clog_eq_clog_succ_iff {b n : ℕ} (hb : 1 < b) :

--- a/Mathlib/Tactic/NormNum/NatLog.lean
+++ b/Mathlib/Tactic/NormNum/NatLog.lean
@@ -74,8 +74,8 @@ theorem nat_clog_helper {b m n : ℕ} (hb : Nat.blt 1 b = true)
     (h₁ : Nat.blt (b ^ m) n = true) (h₂ : Nat.ble n (b ^ (m + 1)) = true) :
     Nat.clog b n = m + 1 := by
   rw [Nat.blt_eq] at hb
-  rw [Nat.blt_eq, Nat.pow_lt_iff_lt_clog hb] at h₁
-  rw [Nat.ble_eq, Nat.le_pow_iff_clog_le hb] at h₂
+  rw [Nat.blt_eq, ← Nat.lt_clog_iff_pow_lt hb] at h₁
+  rw [Nat.ble_eq, ← Nat.clog_le_iff_le_pow hb] at h₂
   cutsat
 
 private theorem isNat_clog : {b nb n nn k : ℕ} → IsNat b nb → IsNat n nn →


### PR DESCRIPTION
Swap the order of the following four lemmas:
- `Nat.pow_le_iff_le_log`
- `Nat.lt_pow_iff_log_lt`
- `Nat.le_pow_iff_clog_le`
- `Nat.pow_lt_iff_lt_clog`

This is to match the pattern used everywhere else in mathlib, eg for Real.log, and the pattern used in core, eg for Nat.log2.

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include at least one commit authored by each
co-author among the commits in the pull request. If necessary, you may 
create empty commits to indicate co-authorship, using commands like so:

git commit --author="Author Name <author@email.com>" --allow-empty -m "add Author Name as coauthor"

When merging, all the commits will be squashed into a single commit listing all co-authors.

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
