### PR TITLE
[Merged by Bors] - feat(Set): finite cardinality iff `[Finite]`

### DIFF
--- a/Mathlib/SetTheory/Cardinal/Finite.lean
+++ b/Mathlib/SetTheory/Cardinal/Finite.lean
@@ -284,7 +284,9 @@ theorem card_eq_top_of_infinite [Infinite α] : card α = ⊤ := by
 
 @[simp] lemma card_eq_top : card α = ⊤ ↔ Infinite α := by simp [card, aleph0_le_mk_iff]
 
-@[simp] theorem card_lt_top_of_finite [Finite α] : card α < ⊤ := by simp [card]
+@[simp high] theorem card_lt_top_of_finite [Finite α] : card α < ⊤ := by simp [card]
+
+@[simp] theorem card_lt_top : card α < ⊤ ↔ Finite α := by simp [card, lt_aleph0_iff_finite]
 
 @[simp]
 theorem card_sum (α β : Type*) :


### PR DESCRIPTION
Add a lemma making it easy to derive `Finite α` from `ENat.card α < ⊤`. Note that immediately above, the following three lemmas are defined:

```lean
@[simp high]
theorem card_eq_top_of_infinite [Infinite α] : card α = ⊤ := by ...

@[simp] lemma card_eq_top : card α = ⊤ ↔ Infinite α := by ...

@[simp] theorem card_lt_top_of_finite [Finite α] : card α < ⊤ := by ...
```

`card_lt_top` is the analog of `card_eq_top`, so symmetry implies that `card_lt_top_of_finite` should be marked `@[simp high]` and `card_lt_top` should be marked `@[simp]`. I find this use of `@[simp]` a bit surprising so I wanted to highlight this to reviewers.


---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include at least one commit authored by each
co-author among the commits in the pull request. If necessary, you may 
create empty commits to indicate co-authorship, using commands like so:

git commit --author="Author Name <author@email.com>" --allow-empty -m "add Author Name as coauthor"

When merging, all the commits will be squashed into a single commit listing all co-authors.

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
