### PR TITLE
[Merged by Bors] - refactor: make Nat.digits use well-founded recursion once again

### DIFF
--- a/Mathlib/Data/Nat/Digits/Defs.lean
+++ b/Mathlib/Data/Nat/Digits/Defs.lean
@@ -280,13 +280,8 @@ theorem digits_ne_nil_iff_ne_zero {b n : ℕ} : digits b n ≠ [] ↔ n ≠ 0 :=
   not_congr digits_eq_nil_iff_eq_zero
 
 theorem digits_eq_cons_digits_div {b n : ℕ} (h : 1 < b) (w : n ≠ 0) :
-    digits b n = (n % b) :: digits b (n / b) := by
-  rcases b with (_ | _ | b)
-  · rw [digits_zero_succ' w, Nat.mod_zero, Nat.div_zero, Nat.digits_zero_zero]
-  · norm_num at h
-  rcases n with (_ | n)
-  · norm_num at w
-  · simp only [digits_add_two_add_one]
+    digits b n = (n % b) :: digits b (n / b) :=
+  digits_def' h (Nat.pos_of_ne_zero w)
 
 theorem digits_getLast {b : ℕ} (m : ℕ) (h : 1 < b) (p q) :
     (digits b m).getLast p = (digits b (m / b)).getLast q := by

--- a/Mathlib/Data/Nat/Digits/Defs.lean
+++ b/Mathlib/Data/Nat/Digits/Defs.lean
@@ -41,58 +41,20 @@ def digitsAux1 (n : ℕ) : List ℕ :=
   List.replicate n 1
 
 /-- (Impl.) An auxiliary definition for `digits`, to help get the desired definitional unfolding. -/
-def digitsAux (b : ℕ) (h : 2 ≤ b) (n : ℕ) : List ℕ :=
-  go n (n + 2) init
-where
-  init : (if n = 0 then 0 else n + 1) < n + 2 := by
-    split_ifs <;> simp
-  decreasing (n f : ℕ) (hf : (if n + 1 = 0 then 0 else n + 2) < f + 1) :
-      (if (n + 1) / b = 0 then 0 else ((n + 1) / b) + 1) < f := by
-    rw [if_neg n.add_one_ne_zero] at hf
-    split_ifs with hn
-    · exact zero_lt_of_lt (lt_of_succ_lt_succ hf)
-    · rw [Nat.div_eq_zero_iff, or_iff_right (by omega), not_lt] at hn
-      refine Nat.lt_of_le_of_lt (succ_le_succ ?_) (succ_lt_succ_iff.1 hf)
-      refine Nat.div_le_of_le_mul (Nat.le_trans ?_ (Nat.mul_le_mul_right n h))
-      omega
-  /-- Auxiliary function performing recursion for `Nat.digitsAux`. -/
-  go (n fuel : ℕ) (hfuel : (if n = 0 then 0 else n + 1) < fuel) : List ℕ :=
-    match n, fuel, hfuel with
-    | 0, _, _ => []
-    | n + 1, f + 1, hf =>
-      ((n + 1) % b) :: go ((n + 1) / b) f (decreasing n f hf)
-
-theorem digitsAux.go_zero (b : ℕ) (h : 2 ≤ b) (fuel : ℕ)
-    (hfuel : (if 0 = 0 then 0 else n + 1) < fuel) :
-    digitsAux.go b h 0 fuel hfuel = [] := by
-  rw [digitsAux.go]
-
-theorem digitsAux.go_succ (b : ℕ) (h : 2 ≤ b) (n fuel : ℕ)
-    (hfuel : (if n + 1 = 0 then 0 else n + 2) < fuel + 1) :
-    digitsAux.go b h (n + 1) (fuel + 1) hfuel = ((n + 1) % b) ::
-      digitsAux.go b h ((n + 1) / b) fuel (decreasing b h n fuel hfuel) :=
-  rfl
-
-theorem digitsAux.go_fuel_irrel (b : ℕ) (h : 2 ≤ b) (n fuel fuel' : ℕ)
-    (hfuel : (if n = 0 then 0 else n + 1) < fuel)
-    (hfuel' : (if n = 0 then 0 else n + 1) < fuel') :
-    digitsAux.go b h n fuel hfuel = digitsAux.go b h n fuel' hfuel' := by
-  fun_induction go b h n fuel hfuel generalizing fuel'
-  · rw [go_zero]
-  · cases fuel'
-    · simp at hfuel'
-    · rw [go_succ]
-      solve_by_elim
+def digitsAux (b : ℕ) (h : 2 ≤ b) : ℕ → List ℕ
+  | 0 => []
+  | n + 1 =>
+    ((n + 1) % b) :: digitsAux b h ((n + 1) / b)
+decreasing_by exact Nat.div_lt_self (Nat.succ_pos _) h
 
 @[simp]
-theorem digitsAux_zero (b : ℕ) (h : 2 ≤ b) :
-    digitsAux b h 0 = [] := by rw [digitsAux, digitsAux.go]
+theorem digitsAux_zero (b : ℕ) (h : 2 ≤ b) : digitsAux b h 0 = [] := by rw [digitsAux]
 
 theorem digitsAux_def (b : ℕ) (h : 2 ≤ b) (n : ℕ) (w : 0 < n) :
     digitsAux b h n = (n % b) :: digitsAux b h (n / b) := by
   cases n
   · cases w
-  · rw [digitsAux, digitsAux.go, digitsAux, digitsAux.go_fuel_irrel]
+  · rw [digitsAux]
 
 /-- `digits b n` gives the digits, in little-endian order,
 of a natural number `n` in a specified base `b`.
@@ -318,8 +280,13 @@ theorem digits_ne_nil_iff_ne_zero {b n : ℕ} : digits b n ≠ [] ↔ n ≠ 0 :=
   not_congr digits_eq_nil_iff_eq_zero
 
 theorem digits_eq_cons_digits_div {b n : ℕ} (h : 1 < b) (w : n ≠ 0) :
-    digits b n = (n % b) :: digits b (n / b) :=
-  digits_def' h (Nat.pos_of_ne_zero w)
+    digits b n = (n % b) :: digits b (n / b) := by
+  rcases b with (_ | _ | b)
+  · rw [digits_zero_succ' w, Nat.mod_zero, Nat.div_zero, Nat.digits_zero_zero]
+  · norm_num at h
+  rcases n with (_ | n)
+  · norm_num at w
+  · simp only [digits_add_two_add_one]
 
 theorem digits_getLast {b : ℕ} (m : ℕ) (h : 1 < b) (p q) :
     (digits b m).getLast p = (digits b (m / b)).getLast q := by


### PR DESCRIPTION
#25864 made `Nat.digits` structurally recursive, which has some benefits. In doing so, however, it added significant complexity. As brought up in [this zulip thread](https://leanprover.zulipchat.com/#narrow/channel/287929-mathlib4/topic/structural.20recursion.20instead.20of.20well.20founded/near/543172385), on the balance that PR might not be considered an improvement.

The present PR reverts that change (but keeps a code golf that was bundled with it).

Note that recent improvements to core Lean mean that `simp` can handle the structurally recursive version without a problem:

```lean
example : digits 10 123456789 = [9,8,7,6,5,4,3,2,1] := by
  simp [digits, digitsAux]
```

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include at least one commit authored by each
co-author among the commits in the pull request. If necessary, you may 
create empty commits to indicate co-authorship, using commands like so:

git commit --author="Author Name <author@email.com>" --allow-empty -m "add Author Name as coauthor"

When merging, all the commits will be squashed into a single commit listing all co-authors.

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
