### PR TITLE
[Merged by Bors] - chore(Algebra): generalize subalgebra operations to semirings

### DIFF
--- a/Mathlib/Algebra/Algebra/Subalgebra/Operations.lean
+++ b/Mathlib/Algebra/Algebra/Subalgebra/Operations.lean
@@ -31,7 +31,7 @@ namespace Subalgebra
 
 open Algebra
 
-variable {R S : Type*} [CommSemiring R] [CommRing S] [Algebra R S]
+variable {R S : Type*} [CommSemiring R] [CommSemiring S] [Algebra R S]
 variable (S' : Subalgebra R S)
 
 /-- Suppose we are given `∑ i, lᵢ * sᵢ = 1` ∈ `S`, and `S'` a subalgebra of `S` that contains
@@ -75,7 +75,7 @@ end Subalgebra
 
 section MulSemiringAction
 
-variable (A B : Type*) [CommRing A] [CommRing B] [Algebra A B]
+variable (A B : Type*) [CommSemiring A] [Ring B] [Algebra A B]
 variable (G : Type*) [Monoid G] [MulSemiringAction G B] [SMulCommClass G A B]
 
 /-- The set of fixed points under a group action, as a subring. -/


### PR DESCRIPTION
Relax Subalgebra operations to work over `CommSemiring` structures instead of demanding commutative rings.

---

Found by asking OpenAI Codex to search for low-hanging generalization opportunities. I don't have any usage in mind. Just wanted to explore what Codex would find.

<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include at least one commit authored by each
co-author among the commits in the pull request. If necessary, you may 
create empty commits to indicate co-authorship, using commands like so:

git commit --author="Author Name <author@email.com>" --allow-empty -m "add Author Name as coauthor"

When merging, all the commits will be squashed into a single commit listing all co-authors.

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
