### PR TITLE
chore(Algebra): generalize isSMulRegular_iff_torsionBy_eq_bot

### DIFF
--- a/Mathlib/Algebra/Module/Torsion.lean
+++ b/Mathlib/Algebra/Module/Torsion.lean
@@ -261,9 +261,13 @@ end Module
 end Defs
 
 lemma isSMulRegular_iff_torsionBy_eq_bot {R} (M : Type*)
-    [CommRing R] [AddCommGroup M] [Module R M] (r : R) :
-    IsSMulRegular M r ↔ Submodule.torsionBy R M r = ⊥ :=
-  Iff.symm (DistribMulAction.toLinearMap R M r).ker_eq_bot
+    [CommSemiring R] [AddCommGroup M] [Module R M] (r : R) :
+    IsSMulRegular M r ↔ Submodule.torsionBy R M r = ⊥ := by
+  have htorsion : Submodule.torsionBy R M r = ⊥ ↔
+      ∀ x : M, r • x = 0 → x = 0 := by
+    simp [Submodule.eq_bot_iff, Submodule.torsionBy]
+  exact (isSMulRegular_iff_right_eq_zero_of_smul (R := R) (M := M) (r := r)).trans
+    htorsion.symm
 
 variable {R M : Type*}
 

--- a/Mathlib/Algebra/Module/Torsion.lean
+++ b/Mathlib/Algebra/Module/Torsion.lean
@@ -263,7 +263,9 @@ end Defs
 lemma isSMulRegular_iff_torsionBy_eq_bot {R} (M : Type*)
     [CommSemiring R] [AddCommGroup M] [Module R M] (r : R) :
     IsSMulRegular M r ↔ Submodule.torsionBy R M r = ⊥ :=
-  isSMulRegular_iff_right_eq_zero_of_smul.trans (by simp [Submodule.eq_bot_iff, Submodule.torsionBy])
+  isSMulRegular_iff_right_eq_zero_of_smul.trans <|
+    by
+      simp [Submodule.eq_bot_iff, Submodule.torsionBy]
 
 variable {R M : Type*}
 

--- a/Mathlib/Algebra/Module/Torsion.lean
+++ b/Mathlib/Algebra/Module/Torsion.lean
@@ -262,12 +262,8 @@ end Defs
 
 lemma isSMulRegular_iff_torsionBy_eq_bot {R} (M : Type*)
     [CommSemiring R] [AddCommGroup M] [Module R M] (r : R) :
-    IsSMulRegular M r ↔ Submodule.torsionBy R M r = ⊥ := by
-  have htorsion : Submodule.torsionBy R M r = ⊥ ↔
-      ∀ x : M, r • x = 0 → x = 0 := by
-    simp [Submodule.eq_bot_iff, Submodule.torsionBy]
-  exact (isSMulRegular_iff_right_eq_zero_of_smul (R := R) (M := M) (r := r)).trans
-    htorsion.symm
+    IsSMulRegular M r ↔ Submodule.torsionBy R M r = ⊥ :=
+  isSMulRegular_iff_right_eq_zero_of_smul.trans (by simp [Submodule.eq_bot_iff, Submodule.torsionBy])
 
 variable {R M : Type*}
 


### PR DESCRIPTION
Relax an assumption.

---

Found by asking OpenAI Codex to search for low-hanging generalization opportunities. I don't have any usage in mind. Just wanted to explore what Codex would find.
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include at least one commit authored by each
co-author among the commits in the pull request. If necessary, you may 
create empty commits to indicate co-authorship, using commands like so:

git commit --author="Author Name <author@email.com>" --allow-empty -m "add Author Name as coauthor"

When merging, all the commits will be squashed into a single commit listing all co-authors.

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
