### PR TITLE
feat(CategoryTheory/Monoidal): added CocartesianMonoidalCategory

### DIFF
--- a/Mathlib.lean
+++ b/Mathlib.lean
@@ -2585,6 +2585,7 @@ import Mathlib.CategoryTheory.Monoidal.Cartesian.Mon_
 import Mathlib.CategoryTheory.Monoidal.Cartesian.Over
 import Mathlib.CategoryTheory.Monoidal.Category
 import Mathlib.CategoryTheory.Monoidal.Center
+import Mathlib.CategoryTheory.Monoidal.Cocartesian.Basic
 import Mathlib.CategoryTheory.Monoidal.CoherenceLemmas
 import Mathlib.CategoryTheory.Monoidal.CommComon_
 import Mathlib.CategoryTheory.Monoidal.CommGrp_

--- a/Mathlib/CategoryTheory/Monoidal/Category.lean
+++ b/Mathlib/CategoryTheory/Monoidal/Category.lean
@@ -64,7 +64,7 @@ Currently, the simp lemmas don't rewrite `𝟙 X ⊗ₘ f` and `f ⊗ₘ 𝟙 Y`
 respectively, since it requires a huge refactoring. We hope to add these simp lemmas soon.
 
 ## References
-* Tensor categories, Etingof, Gelaki, Nikshych, Ostrik,\
+* Tensor categories, Etingof, Gelaki, Nikshych, Ostrik,
   http://www-math.mit.edu/~etingof/egnobookfinal.pdf
 * <https://stacks.math.columbia.edu/tag/0FFK>.
 -/

--- a/Mathlib/CategoryTheory/Monoidal/Category.lean
+++ b/Mathlib/CategoryTheory/Monoidal/Category.lean
@@ -121,7 +121,7 @@ class AddMonoidalCategoryStruct (C : Type u) [𝒞 : Category.{v} C] where
   /-- The right unitor: `X ⊕ₒ 𝟘_ C ≃ X` -/
   rightAddUnitor : ∀ X : C, addObj X addUnit ≅ X
 
-attribute [to_additive AddMonoidalCategoryStruct] MonoidalCategoryStruct
+attribute [to_additive] MonoidalCategoryStruct
 
 namespace MonoidalCategory
 
@@ -342,7 +342,7 @@ attribute [reassoc] AddMonoidalCategory.rightAddUnitor_naturality
 attribute [reassoc (attr := simp)] AddMonoidalCategory.addPentagon
 attribute [reassoc (attr := simp)] AddMonoidalCategory.addTriangle
 
-attribute [to_additive AddMonoidalCategory] MonoidalCategory
+attribute [to_additive] MonoidalCategory
 
 -- NOTE: we disable this warning, which would otherwise fire since some of these are already marked
 -- as `simp` lemmas.

--- a/Mathlib/CategoryTheory/Monoidal/Category.lean
+++ b/Mathlib/CategoryTheory/Monoidal/Category.lean
@@ -354,7 +354,14 @@ attribute [to_additive existing]
   MonoidalCategory.associator_naturality_assoc
   MonoidalCategory.leftUnitor_naturality_assoc
   MonoidalCategory.rightUnitor_naturality_assoc
+
+set_option linter.existingAttributeWarning false in
+attribute [to_additive existing AddMonoidalCategory.addPentagon_assoc]
   MonoidalCategory.pentagon_assoc
+
+set_option linter.existingAttributeWarning false in
+attribute [to_additive existing AddMonoidalCategory.addTriangle_assoc]
+  MonoidalCategory.triangle_assoc
 
 namespace MonoidalCategory
 

--- a/Mathlib/CategoryTheory/Monoidal/Category.lean
+++ b/Mathlib/CategoryTheory/Monoidal/Category.lean
@@ -163,7 +163,9 @@ scoped notation "ρ_" => MonoidalCategoryStruct.rightUnitor
 
 /-- The property that the pentagon relation is satisfied by four objects
 in a category equipped with a `MonoidalCategoryStruct`. -/
-@[to_additive AddMonoidalCategory.AddPentagon]
+@[to_additive AddMonoidalCategory.AddPentagon
+/-- The property that the pentagon relation is satisfied by four objects
+in a category equipped with an `AddMonoidalCategoryStruct`. -/]
 def Pentagon {C : Type u} [Category.{v} C] [MonoidalCategoryStruct C]
     (Y₁ Y₂ Y₃ Y₄ : C) : Prop :=
   (α_ Y₁ Y₂ Y₃).hom ▷ Y₄ ≫ (α_ Y₁ (Y₂ ⊗ Y₃) Y₄).hom ≫ Y₁ ◁ (α_ Y₂ Y₃ Y₄).hom =
@@ -495,7 +497,7 @@ theorem inv_hom_whiskerRight' {X Y : C} (f : X ⟶ Y) [IsIso f] (Z : C) :
   rw [← comp_whiskerRight, IsIso.inv_hom_id, id_whiskerRight]
 
 /-- The left whiskering of an isomorphism is an isomorphism. -/
-@[to_additive (attr := simps)]
+@[to_additive (attr := simps) /-- The left whiskering of an isomorphism is an isomorphism. -/]
 def whiskerLeftIso (X : C) {Y Z : C} (f : Y ≅ Z) : X ⊗ Y ≅ X ⊗ Z where
   hom := X ◁ f.hom
   inv := X ◁ f.inv
@@ -524,7 +526,7 @@ lemma whiskerLeftIso_symm (W : C) {X Y : C} (f : X ≅ Y) :
     (whiskerLeftIso W f).symm = whiskerLeftIso W f.symm := rfl
 
 /-- The right whiskering of an isomorphism is an isomorphism. -/
-@[to_additive (attr := simps!)]
+@[to_additive (attr := simps!) /-- The right whiskering of an isomorphism is an isomorphism. -/]
 def whiskerRightIso {X Y : C} (f : X ≅ Y) (Z : C) : X ⊗ Z ≅ Y ⊗ Z where
   hom := f.hom ▷ Z
   inv := f.inv ▷ Z
@@ -553,7 +555,7 @@ lemma whiskerRightIso_symm {X Y : C} (f : X ≅ Y) (W : C) :
     (whiskerRightIso f W).symm = whiskerRightIso f.symm W := rfl
 
 /-- The tensor product of two isomorphisms is an isomorphism. -/
-@[to_additive (attr := simps)]
+@[to_additive (attr := simps) /-- The tensor product of two isomorphisms is an isomorphism. -/]
 def tensorIso {X Y X' Y' : C} (f : X ≅ Y)
     (g : X' ≅ Y') : X ⊗ X' ≅ Y ⊗ Y' where
   hom := f.hom ⊗ₘ g.hom
@@ -954,13 +956,13 @@ variable (C)
 attribute [local simp] whisker_exchange
 
 /-- The tensor product expressed as a functor. -/
-@[to_additive (attr := simps)]
+@[to_additive (attr := simps) /-- The sum of objects expressed as a functor. -/]
 def tensor : C × C ⥤ C where
   obj X := X.1 ⊗ X.2
   map {X Y : C × C} (f : X ⟶ Y) := f.1 ⊗ₘ f.2
 
 /-- The left-associated triple tensor product as a functor. -/
-@[to_additive]
+@[to_additive /-- The left-associated triple sum of objects as a functor. -/]
 def leftAssocTensor : C × C × C ⥤ C where
   obj X := (X.1 ⊗ X.2.1) ⊗ X.2.2
   map {X Y : C × C × C} (f : X ⟶ Y) := (f.1 ⊗ₘ f.2.1) ⊗ₘ f.2.2
@@ -975,7 +977,7 @@ theorem leftAssocTensor_map {X Y} (f : X ⟶ Y) :
   rfl
 
 /-- The right-associated triple tensor product as a functor. -/
-@[to_additive]
+@[to_additive /-- The right-associated triple sum of objects as a functor. -/]
 def rightAssocTensor : C × C × C ⥤ C where
   obj X := X.1 ⊗ X.2.1 ⊗ X.2.2
   map {X Y : C × C × C} (f : X ⟶ Y) := f.1 ⊗ₘ f.2.1 ⊗ₘ f.2.2
@@ -990,7 +992,7 @@ theorem rightAssocTensor_map {X Y} (f : X ⟶ Y) :
   rfl
 
 /-- The tensor product bifunctor `C ⥤ C ⥤ C` of a monoidal category. -/
-@[to_additive (attr := simps)]
+@[to_additive (attr := simps) /-- The sum bifunctor `C ⥤ C ⥤ C` of an additive category. -/]
 def curriedTensor : C ⥤ C ⥤ C where
   obj X :=
     { obj := fun Y => X ⊗ Y
@@ -1001,42 +1003,43 @@ def curriedTensor : C ⥤ C ⥤ C where
 variable {C}
 
 /-- Tensoring on the left with a fixed object, as a functor. -/
-@[to_additive]
+@[to_additive /-- Adding on the left with a fixed object, as a functor. -/]
 abbrev tensorLeft (X : C) : C ⥤ C := (curriedTensor C).obj X
 
 /-- Tensoring on the right with a fixed object, as a functor. -/
-@[to_additive]
+@[to_additive /-- Adding on the right with a fixed object, as a functor. -/]
 abbrev tensorRight (X : C) : C ⥤ C := (curriedTensor C).flip.obj X
 
 variable (C)
 
 /-- The functor `fun X ↦ 𝟙_ C ⊗ X`. -/
-@[to_additive]
+@[to_additive /-- The functor `fun X ↦ 0 + X`. -/]
 abbrev tensorUnitLeft : C ⥤ C := tensorLeft (𝟙_ C)
 
 /-- The functor `fun X ↦ X ⊗ 𝟙_ C`. -/
-@[to_additive]
+@[to_additive /-- The functor `fun X ↦ X + 0`. -/]
 abbrev tensorUnitRight : C ⥤ C := tensorRight (𝟙_ C)
 
 -- We can express the associator and the unitors, given componentwise above,
 -- as natural isomorphisms.
 /-- The associator as a natural isomorphism. -/
-@[to_additive (attr := simps!)]
+@[to_additive (attr := simps!) /-- The associator for sums as a natural isomorphism. -/]
 def associatorNatIso : leftAssocTensor C ≅ rightAssocTensor C :=
   NatIso.ofComponents (fun _ => MonoidalCategory.associator _ _ _)
 
 /-- The left unitor as a natural isomorphism. -/
-@[to_additive (attr := simps!)]
+@[to_additive (attr := simps!) /-- The left unitor for sums as a natural isomorphism. -/]
 def leftUnitorNatIso : tensorUnitLeft C ≅ 𝟭 C :=
   NatIso.ofComponents MonoidalCategory.leftUnitor
 
 /-- The right unitor as a natural isomorphism. -/
-@[to_additive (attr := simps!)]
+@[to_additive (attr := simps!) /-- The right unitor for sums as a natural isomorphism. -/]
 def rightUnitorNatIso : tensorUnitRight C ≅ 𝟭 C :=
   NatIso.ofComponents MonoidalCategory.rightUnitor
 
 /-- The associator as a natural isomorphism between trifunctors `C ⥤ C ⥤ C ⥤ C`. -/
-@[to_additive (attr := simps!)]
+@[to_additive (attr := simps!)
+/-- The associator for sums as a natural isomorphism between trifunctors `C ⥤ C ⥤ C ⥤ C`. -/]
 def curriedAssociatorNatIso :
     bifunctorComp₁₂ (curriedTensor C) (curriedTensor C) ≅
       bifunctorComp₂₃ (curriedTensor C) (curriedTensor C) :=
@@ -1050,7 +1053,10 @@ variable {C}
 /-- Tensoring on the left with `X ⊗ Y` is naturally isomorphic to
 tensoring on the left with `Y`, and then again with `X`.
 -/
-@[to_additive]
+@[to_additive
+/-- Adding on the left with `X ⊕ Y` is naturally isomorphic to
+adding on the left with `Y`, and then again with `X`.
+-/]
 def tensorLeftTensor (X Y : C) : tensorLeft (X ⊗ Y) ≅ tensorLeft Y ⋙ tensorLeft X :=
   NatIso.ofComponents (associator _ _) fun {Z} {Z'} f => by simp
 
@@ -1069,7 +1075,7 @@ variable (C)
 
 TODO: show this is an op-monoidal functor.
 -/
-@[to_additive]
+@[to_additive /-- Adding on the left, as a functor from `C` into endofunctors of `C`. -/]
 abbrev tensoringLeft : C ⥤ C ⥤ C := curriedTensor C
 
 @[to_additive]
@@ -1083,7 +1089,7 @@ instance : (tensoringLeft C).Faithful where
 
 We later show this is a monoidal functor.
 -/
-@[to_additive]
+@[to_additive /-- Adding on the right, as a functor from `C` into endofunctors of `C`. -/]
 abbrev tensoringRight : C ⥤ C ⥤ C := (curriedTensor C).flip
 
 @[to_additive]
@@ -1098,7 +1104,10 @@ variable {C}
 /-- Tensoring on the right with `X ⊗ Y` is naturally isomorphic to
 tensoring on the right with `X`, and then again with `Y`.
 -/
-@[to_additive]
+@[to_additive
+/-- Adding on the right with `X ⊕ Y` is naturally isomorphic to
+adding on the right with `X`, and then again with `Y`.
+-/]
 def tensorRightTensor (X Y : C) : tensorRight (X ⊗ Y) ≅ tensorRight X ⋙ tensorRight Y :=
   NatIso.ofComponents (fun Z => (associator Z X Y).symm) fun {Z} {Z'} f => by simp
 
@@ -1217,7 +1226,10 @@ section ObjectProperty
 /-- The restriction of a monoidal category along an object property
 that's closed under the monoidal structure. -/
 -- See note [reducible non-instances]
-@[to_additive]
+@[to_additive
+/-- The restriction of an additive category along an object property
+that's closed under the additive structure.
+-/]
 abbrev MonoidalCategory.fullSubcategory
     {C : Type u} [Category.{v} C] [MonoidalCategory C] (P : ObjectProperty C)
     (tensorUnit : P (𝟙_ C))

--- a/Mathlib/CategoryTheory/Monoidal/Category.lean
+++ b/Mathlib/CategoryTheory/Monoidal/Category.lean
@@ -279,7 +279,7 @@ specified associator, `α⁺ X Y Z : (X ⊕ₒ Y) ⊕ₒ Z ≅ X ⊕ₒ (Y ⊕�
 with specified left and right unitor isomorphisms `λ⁺ X : 𝟘_ C ⊕ₒ X ≅ X` and `ρ⁺ X : X ⊕ₒ 𝟘_ C ≅ X`.
 These associators and unitors satisfy the pentagon and triangle equations. -/
 class AddMonoidalCategory (C : Type u) [𝒞 : Category.{v} C]
-  extends AddMonoidalCategoryStruct C where
+    extends AddMonoidalCategoryStruct C where
   addHom_def {X₁ Y₁ X₂ Y₂ : C} (f : X₁ ⟶ Y₁) (g : X₂ ⟶ Y₂) :
     f ⊕ₘ g = (f ▷⁺ X₂) ≫ (Y₁ ◁⁺ g) := by
       cat_disch

--- a/Mathlib/CategoryTheory/Monoidal/Category.lean
+++ b/Mathlib/CategoryTheory/Monoidal/Category.lean
@@ -358,191 +358,202 @@ namespace MonoidalCategory
 
 variable {C : Type u} [𝒞 : Category.{v} C] [MonoidalCategory C]
 
-@[simp]
+@[to_additive (attr := simp)]
 theorem id_tensorHom (X : C) {Y₁ Y₂ : C} (f : Y₁ ⟶ Y₂) :
     𝟙 X ⊗ₘ f = X ◁ f := by
   simp [tensorHom_def]
 
-@[simp]
+@[to_additive (attr := simp)]
 theorem tensorHom_id {X₁ X₂ : C} (f : X₁ ⟶ X₂) (Y : C) :
     f ⊗ₘ 𝟙 Y = f ▷ Y := by
   simp [tensorHom_def]
 
-@[reassoc, simp]
+@[reassoc]
 theorem whiskerLeft_comp (W : C) {X Y Z : C} (f : X ⟶ Y) (g : Y ⟶ Z) :
     W ◁ (f ≫ g) = W ◁ f ≫ W ◁ g := by
   simp [← id_tensorHom]
 
-@[reassoc, simp]
+@[reassoc]
 theorem id_whiskerLeft {X Y : C} (f : X ⟶ Y) :
     𝟙_ C ◁ f = (λ_ X).hom ≫ f ≫ (λ_ Y).inv := by
   rw [← assoc, ← leftUnitor_naturality]; simp
 
-@[reassoc, simp]
+@[reassoc]
 theorem tensor_whiskerLeft (X Y : C) {Z Z' : C} (f : Z ⟶ Z') :
     (X ⊗ Y) ◁ f = (α_ X Y Z).hom ≫ X ◁ Y ◁ f ≫ (α_ X Y Z').inv := by
   simp only [← id_tensorHom]
   rw [← assoc, ← associator_naturality]
   simp
 
-@[reassoc, simp]
+@[reassoc]
 theorem comp_whiskerRight {W X Y : C} (f : W ⟶ X) (g : X ⟶ Y) (Z : C) :
     (f ≫ g) ▷ Z = f ▷ Z ≫ g ▷ Z := by
   simp [← tensorHom_id]
 
-@[reassoc, simp]
+@[reassoc]
 theorem whiskerRight_id {X Y : C} (f : X ⟶ Y) :
     f ▷ 𝟙_ C = (ρ_ X).hom ≫ f ≫ (ρ_ Y).inv := by
   rw [← assoc, ← rightUnitor_naturality]; simp
 
-@[reassoc, simp]
+@[reassoc]
 theorem whiskerRight_tensor {X X' : C} (f : X ⟶ X') (Y Z : C) :
     f ▷ (Y ⊗ Z) = (α_ X Y Z).inv ≫ f ▷ Y ▷ Z ≫ (α_ X' Y Z).hom := by
   simp only [← tensorHom_id]
   rw [associator_naturality]
   simp
 
-@[reassoc, simp]
+@[reassoc]
 theorem whisker_assoc (X : C) {Y Y' : C} (f : Y ⟶ Y') (Z : C) :
     (X ◁ f) ▷ Z = (α_ X Y Z).hom ≫ X ◁ f ▷ Z ≫ (α_ X Y' Z).inv := by
   simp only [← id_tensorHom, ← tensorHom_id]
   rw [← assoc, ← associator_naturality]
   simp
 
-@[reassoc]
+attribute [to_additive (attr := simp)]
+  whiskerLeft_comp id_whiskerLeft tensor_whiskerLeft comp_whiskerRight whiskerRight_id
+  whiskerRight_tensor whisker_assoc
+attribute [to_additive]
+  whiskerLeft_comp_assoc id_whiskerLeft_assoc tensor_whiskerLeft_assoc comp_whiskerRight_assoc
+  whiskerRight_id_assoc whiskerRight_tensor_assoc whisker_assoc_assoc
+
+@[reassoc (attr := to_additive)]
 theorem whisker_exchange {W X Y Z : C} (f : W ⟶ X) (g : Y ⟶ Z) :
     W ◁ g ≫ f ▷ Z = f ▷ Y ≫ X ◁ g := by
   simp [← id_tensorHom, ← tensorHom_id]
 
-@[reassoc]
+@[reassoc (attr := to_additive)]
 theorem tensorHom_def' {X₁ Y₁ X₂ Y₂ : C} (f : X₁ ⟶ Y₁) (g : X₂ ⟶ Y₂) :
     f ⊗ₘ g = X₁ ◁ g ≫ f ▷ Y₂ :=
   whisker_exchange f g ▸ tensorHom_def f g
 
-@[reassoc]
+@[reassoc (attr := to_additive)]
 theorem whiskerLeft_comp_tensorHom {V W X Y Z : C} (f : V ⟶ W) (g : X ⟶ Y) (h : Y ⟶ Z) :
     (V ◁ g) ≫ (f ⊗ₘ h) = f ⊗ₘ (g ≫ h) := by
   simp [tensorHom_def']
 
-@[reassoc]
+@[reassoc (attr := to_additive)]
 theorem whiskerRight_comp_tensorHom {V W X Y Z : C} (f : X ⟶ Y) (g : Y ⟶ Z) (h : V ⟶ W) :
     (f ▷ V) ≫ (g ⊗ₘ h) = (f ≫ g) ⊗ₘ h := by
   simp [tensorHom_def]
 
-@[reassoc]
+@[reassoc (attr := to_additive)]
 theorem tensorHom_comp_whiskerLeft {V W X Y Z : C} (f : V ⟶ W) (g : X ⟶ Y) (h : Y ⟶ Z) :
     (f ⊗ₘ g) ≫ (W ◁ h) = f ⊗ₘ (g ≫ h) := by
   simp [tensorHom_def]
 
-@[reassoc]
+@[reassoc (attr := to_additive)]
 theorem tensorHom_comp_whiskerRight {V W X Y Z : C} (f : X ⟶ Y) (g : Y ⟶ Z) (h : V ⟶ W) :
     (f ⊗ₘ h) ≫ (g ▷ W) = (f ≫ g) ⊗ₘ h := by
   simp [tensorHom_def, whisker_exchange]
 
-@[reassoc] lemma leftUnitor_inv_comp_tensorHom {X Y Z : C} (f : 𝟙_ C ⟶ Y) (g : X ⟶ Z) :
+@[reassoc (attr := to_additive)]
+lemma leftUnitor_inv_comp_tensorHom {X Y Z : C} (f : 𝟙_ C ⟶ Y) (g : X ⟶ Z) :
     (λ_ X).inv ≫ (f ⊗ₘ g) = g ≫ (λ_ Z).inv ≫ f ▷ Z := by simp [tensorHom_def']
 
-@[reassoc] lemma rightUnitor_inv_comp_tensorHom {X Y Z : C} (f : X ⟶ Y) (g : 𝟙_ C ⟶ Z) :
+@[reassoc (attr := to_additive)]
+lemma rightUnitor_inv_comp_tensorHom {X Y Z : C} (f : X ⟶ Y) (g : 𝟙_ C ⟶ Z) :
     (ρ_ X).inv ≫ (f ⊗ₘ g) = f ≫ (ρ_ Y).inv ≫ Y ◁ g := by simp [tensorHom_def]
 
-@[reassoc (attr := simp)]
+@[reassoc (attr := to_additive (attr := simp))]
 theorem whiskerLeft_hom_inv (X : C) {Y Z : C} (f : Y ≅ Z) :
     X ◁ f.hom ≫ X ◁ f.inv = 𝟙 (X ⊗ Y) := by
   rw [← whiskerLeft_comp, hom_inv_id, whiskerLeft_id]
 
-@[reassoc (attr := simp)]
+@[reassoc (attr := to_additive (attr := simp))]
 theorem hom_inv_whiskerRight {X Y : C} (f : X ≅ Y) (Z : C) :
     f.hom ▷ Z ≫ f.inv ▷ Z = 𝟙 (X ⊗ Z) := by
   rw [← comp_whiskerRight, hom_inv_id, id_whiskerRight]
 
-@[reassoc (attr := simp)]
+@[reassoc (attr := to_additive (attr := simp))]
 theorem whiskerLeft_inv_hom (X : C) {Y Z : C} (f : Y ≅ Z) :
     X ◁ f.inv ≫ X ◁ f.hom = 𝟙 (X ⊗ Z) := by
   rw [← whiskerLeft_comp, inv_hom_id, whiskerLeft_id]
 
-@[reassoc (attr := simp)]
+@[reassoc (attr := to_additive (attr := simp))]
 theorem inv_hom_whiskerRight {X Y : C} (f : X ≅ Y) (Z : C) :
     f.inv ▷ Z ≫ f.hom ▷ Z = 𝟙 (Y ⊗ Z) := by
   rw [← comp_whiskerRight, inv_hom_id, id_whiskerRight]
 
-@[reassoc (attr := simp)]
+@[reassoc (attr := to_additive (attr := simp))]
 theorem whiskerLeft_hom_inv' (X : C) {Y Z : C} (f : Y ⟶ Z) [IsIso f] :
     X ◁ f ≫ X ◁ inv f = 𝟙 (X ⊗ Y) := by
   rw [← whiskerLeft_comp, IsIso.hom_inv_id, whiskerLeft_id]
 
-@[reassoc (attr := simp)]
+@[reassoc (attr := to_additive (attr := simp))]
 theorem hom_inv_whiskerRight' {X Y : C} (f : X ⟶ Y) [IsIso f] (Z : C) :
     f ▷ Z ≫ inv f ▷ Z = 𝟙 (X ⊗ Z) := by
   rw [← comp_whiskerRight, IsIso.hom_inv_id, id_whiskerRight]
 
-@[reassoc (attr := simp)]
+@[reassoc (attr := to_additive (attr := simp))]
 theorem whiskerLeft_inv_hom' (X : C) {Y Z : C} (f : Y ⟶ Z) [IsIso f] :
     X ◁ inv f ≫ X ◁ f = 𝟙 (X ⊗ Z) := by
   rw [← whiskerLeft_comp, IsIso.inv_hom_id, whiskerLeft_id]
 
-@[reassoc (attr := simp)]
+@[reassoc (attr := to_additive (attr := simp))]
 theorem inv_hom_whiskerRight' {X Y : C} (f : X ⟶ Y) [IsIso f] (Z : C) :
     inv f ▷ Z ≫ f ▷ Z = 𝟙 (Y ⊗ Z) := by
   rw [← comp_whiskerRight, IsIso.inv_hom_id, id_whiskerRight]
 
 /-- The left whiskering of an isomorphism is an isomorphism. -/
-@[simps]
+@[to_additive (attr := simps)]
 def whiskerLeftIso (X : C) {Y Z : C} (f : Y ≅ Z) : X ⊗ Y ≅ X ⊗ Z where
   hom := X ◁ f.hom
   inv := X ◁ f.inv
 
+@[to_additive]
 instance whiskerLeft_isIso (X : C) {Y Z : C} (f : Y ⟶ Z) [IsIso f] : IsIso (X ◁ f) :=
   (whiskerLeftIso X (asIso f)).isIso_hom
 
-@[simp]
+@[to_additive (attr := simp)]
 theorem inv_whiskerLeft (X : C) {Y Z : C} (f : Y ⟶ Z) [IsIso f] :
     inv (X ◁ f) = X ◁ inv f := by
   cat_disch
 
-@[simp]
+@[to_additive (attr := simp)]
 lemma whiskerLeftIso_refl (W X : C) :
     whiskerLeftIso W (Iso.refl X) = Iso.refl (W ⊗ X) :=
   Iso.ext (whiskerLeft_id W X)
 
-@[simp]
+@[to_additive (attr := simp)]
 lemma whiskerLeftIso_trans (W : C) {X Y Z : C} (f : X ≅ Y) (g : Y ≅ Z) :
     whiskerLeftIso W (f ≪≫ g) = whiskerLeftIso W f ≪≫ whiskerLeftIso W g :=
   Iso.ext (whiskerLeft_comp W f.hom g.hom)
 
-@[simp]
+@[to_additive (attr := simp)]
 lemma whiskerLeftIso_symm (W : C) {X Y : C} (f : X ≅ Y) :
     (whiskerLeftIso W f).symm = whiskerLeftIso W f.symm := rfl
 
 /-- The right whiskering of an isomorphism is an isomorphism. -/
-@[simps!]
+@[to_additive (attr := simps!)]
 def whiskerRightIso {X Y : C} (f : X ≅ Y) (Z : C) : X ⊗ Z ≅ Y ⊗ Z where
   hom := f.hom ▷ Z
   inv := f.inv ▷ Z
 
+@[to_additive]
 instance whiskerRight_isIso {X Y : C} (f : X ⟶ Y) (Z : C) [IsIso f] : IsIso (f ▷ Z) :=
   (whiskerRightIso (asIso f) Z).isIso_hom
 
-@[simp]
+@[to_additive (attr := simp)]
 theorem inv_whiskerRight {X Y : C} (f : X ⟶ Y) (Z : C) [IsIso f] :
     inv (f ▷ Z) = inv f ▷ Z := by
   cat_disch
 
-@[simp]
+@[to_additive (attr := simp)]
 lemma whiskerRightIso_refl (X W : C) :
     whiskerRightIso (Iso.refl X) W = Iso.refl (X ⊗ W) :=
   Iso.ext (id_whiskerRight X W)
 
-@[simp]
+@[to_additive (attr := simp)]
 lemma whiskerRightIso_trans {X Y Z : C} (f : X ≅ Y) (g : Y ≅ Z) (W : C) :
     whiskerRightIso (f ≪≫ g) W = whiskerRightIso f W ≪≫ whiskerRightIso g W :=
   Iso.ext (comp_whiskerRight f.hom g.hom W)
 
-@[simp]
+@[to_additive (attr := simp)]
 lemma whiskerRightIso_symm {X Y : C} (f : X ≅ Y) (W : C) :
     (whiskerRightIso f W).symm = whiskerRightIso f.symm W := rfl
 
 /-- The tensor product of two isomorphisms is an isomorphism. -/
-@[simps]
+@[to_additive (attr := simps)]
 def tensorIso {X Y X' Y' : C} (f : X ≅ Y)
     (g : X' ≅ Y') : X ⊗ X' ≅ Y ⊗ Y' where
   hom := f.hom ⊗ₘ g.hom
@@ -555,110 +566,119 @@ scoped infixr:70 " ⊗ᵢ " => tensorIso
 -- TODO: Try setting this notation to `⊗` if the elaborator is improved and performs
 -- better than currently on overloaded notations.
 
+@[to_additive]
 theorem tensorIso_def {X Y X' Y' : C} (f : X ≅ Y) (g : X' ≅ Y') :
     f ⊗ᵢ g = whiskerRightIso f X' ≪≫ whiskerLeftIso Y g :=
   Iso.ext (tensorHom_def f.hom g.hom)
 
+@[to_additive]
 theorem tensorIso_def' {X Y X' Y' : C} (f : X ≅ Y) (g : X' ≅ Y') :
     f ⊗ᵢ g = whiskerLeftIso X g ≪≫ whiskerRightIso f Y' :=
   Iso.ext (tensorHom_def' f.hom g.hom)
 
+@[to_additive]
 instance tensor_isIso {W X Y Z : C} (f : W ⟶ X) [IsIso f] (g : Y ⟶ Z) [IsIso g] : IsIso (f ⊗ₘ g) :=
   (asIso f ⊗ᵢ asIso g).isIso_hom
 
-@[simp]
+@[to_additive (attr := simp)]
 theorem inv_tensor {W X Y Z : C} (f : W ⟶ X) [IsIso f] (g : Y ⟶ Z) [IsIso g] :
     inv (f ⊗ₘ g) = inv f ⊗ₘ inv g := by
   simp [tensorHom_def, whisker_exchange]
 
 variable {W X Y Z : C}
 
+@[to_additive]
 theorem whiskerLeft_dite {P : Prop} [Decidable P]
     (X : C) {Y Z : C} (f : P → (Y ⟶ Z)) (f' : ¬P → (Y ⟶ Z)) :
       X ◁ (if h : P then f h else f' h) = if h : P then X ◁ f h else X ◁ f' h := by
   split_ifs <;> rfl
 
+@[to_additive]
 theorem dite_whiskerRight {P : Prop} [Decidable P]
     {X Y : C} (f : P → (X ⟶ Y)) (f' : ¬P → (X ⟶ Y)) (Z : C) :
       (if h : P then f h else f' h) ▷ Z = if h : P then f h ▷ Z else f' h ▷ Z := by
   split_ifs <;> rfl
 
+@[to_additive]
 theorem tensor_dite {P : Prop} [Decidable P] {W X Y Z : C} (f : W ⟶ X) (g : P → (Y ⟶ Z))
     (g' : ¬P → (Y ⟶ Z)) : (f ⊗ₘ if h : P then g h else g' h) =
     if h : P then f ⊗ₘ g h else f ⊗ₘ g' h := by split_ifs <;> rfl
 
+@[to_additive]
 theorem dite_tensor {P : Prop} [Decidable P] {W X Y Z : C} (f : W ⟶ X) (g : P → (Y ⟶ Z))
     (g' : ¬P → (Y ⟶ Z)) : (if h : P then g h else g' h) ⊗ₘ f =
     if h : P then g h ⊗ₘ f else g' h ⊗ₘ f := by split_ifs <;> rfl
 
-@[simp]
+@[to_additive (attr := simp)]
 theorem whiskerLeft_eqToHom (X : C) {Y Z : C} (f : Y = Z) :
     X ◁ eqToHom f = eqToHom (congr_arg₂ tensorObj rfl f) := by
   cases f
   simp only [whiskerLeft_id, eqToHom_refl]
 
-@[simp]
+@[to_additive (attr := simp)]
 theorem eqToHom_whiskerRight {X Y : C} (f : X = Y) (Z : C) :
     eqToHom f ▷ Z = eqToHom (congr_arg₂ tensorObj f rfl) := by
   cases f
   simp only [id_whiskerRight, eqToHom_refl]
 
-@[reassoc]
+@[reassoc (attr := to_additive)]
 theorem associator_naturality_left {X X' : C} (f : X ⟶ X') (Y Z : C) :
     f ▷ Y ▷ Z ≫ (α_ X' Y Z).hom = (α_ X Y Z).hom ≫ f ▷ (Y ⊗ Z) := by simp
 
-@[reassoc]
+@[reassoc (attr := to_additive)]
 theorem associator_inv_naturality_left {X X' : C} (f : X ⟶ X') (Y Z : C) :
     f ▷ (Y ⊗ Z) ≫ (α_ X' Y Z).inv = (α_ X Y Z).inv ≫ f ▷ Y ▷ Z := by simp
 
-@[reassoc]
+@[reassoc (attr := to_additive)]
 theorem whiskerRight_tensor_symm {X X' : C} (f : X ⟶ X') (Y Z : C) :
     f ▷ Y ▷ Z = (α_ X Y Z).hom ≫ f ▷ (Y ⊗ Z) ≫ (α_ X' Y Z).inv := by simp
 
-@[reassoc]
+@[reassoc (attr := to_additive)]
 theorem associator_naturality_middle (X : C) {Y Y' : C} (f : Y ⟶ Y') (Z : C) :
     (X ◁ f) ▷ Z ≫ (α_ X Y' Z).hom = (α_ X Y Z).hom ≫ X ◁ f ▷ Z := by simp
 
-@[reassoc]
+@[reassoc (attr := to_additive)]
 theorem associator_inv_naturality_middle (X : C) {Y Y' : C} (f : Y ⟶ Y') (Z : C) :
     X ◁ f ▷ Z ≫ (α_ X Y' Z).inv = (α_ X Y Z).inv ≫ (X ◁ f) ▷ Z := by simp
 
-@[reassoc]
+@[reassoc (attr := to_additive)]
 theorem whisker_assoc_symm (X : C) {Y Y' : C} (f : Y ⟶ Y') (Z : C) :
     X ◁ f ▷ Z = (α_ X Y Z).inv ≫ (X ◁ f) ▷ Z ≫ (α_ X Y' Z).hom := by simp
 
-@[reassoc]
+@[reassoc (attr := to_additive)]
 theorem associator_naturality_right (X Y : C) {Z Z' : C} (f : Z ⟶ Z') :
     (X ⊗ Y) ◁ f ≫ (α_ X Y Z').hom = (α_ X Y Z).hom ≫ X ◁ Y ◁ f := by simp
 
-@[reassoc]
+@[reassoc (attr := to_additive)]
 theorem associator_inv_naturality_right (X Y : C) {Z Z' : C} (f : Z ⟶ Z') :
     X ◁ Y ◁ f ≫ (α_ X Y Z').inv = (α_ X Y Z).inv ≫ (X ⊗ Y) ◁ f := by simp
 
-@[reassoc]
+@[reassoc (attr := to_additive)]
 theorem tensor_whiskerLeft_symm (X Y : C) {Z Z' : C} (f : Z ⟶ Z') :
     X ◁ Y ◁ f = (α_ X Y Z).inv ≫ (X ⊗ Y) ◁ f ≫ (α_ X Y Z').hom := by simp
 
-@[reassoc]
+@[reassoc (attr := to_additive)]
 theorem leftUnitor_inv_naturality {X Y : C} (f : X ⟶ Y) :
     f ≫ (λ_ Y).inv = (λ_ X).inv ≫ _ ◁ f := by simp
 
-@[reassoc]
+@[reassoc (attr := to_additive)]
 theorem id_whiskerLeft_symm {X X' : C} (f : X ⟶ X') :
     f = (λ_ X).inv ≫ 𝟙_ C ◁ f ≫ (λ_ X').hom := by
   simp only [id_whiskerLeft, assoc, inv_hom_id, comp_id, inv_hom_id_assoc]
 
-@[reassoc]
+@[reassoc (attr := to_additive)]
 theorem rightUnitor_inv_naturality {X X' : C} (f : X ⟶ X') :
     f ≫ (ρ_ X').inv = (ρ_ X).inv ≫ f ▷ _ := by simp
 
-@[reassoc]
+@[reassoc (attr := to_additive)]
 theorem whiskerRight_id_symm {X Y : C} (f : X ⟶ Y) :
     f = (ρ_ X).inv ≫ f ▷ 𝟙_ C ≫ (ρ_ Y).hom := by
   simp
 
+@[to_additive]
 theorem whiskerLeft_iff {X Y : C} (f g : X ⟶ Y) : 𝟙_ C ◁ f = 𝟙_ C ◁ g ↔ f = g := by simp
 
+@[to_additive]
 theorem whiskerRight_iff {X Y : C} (f g : X ⟶ Y) : f ▷ 𝟙_ C = g ▷ 𝟙_ C ↔ f = g := by simp
 
 /-! The lemmas in the next section are true by coherence,
@@ -666,73 +686,73 @@ but we prove them directly as they are used in proving the coherence theorem. -/
 
 section
 
-@[reassoc (attr := simp)]
+@[reassoc (attr := to_additive (attr := simp))]
 theorem pentagon_inv :
     W ◁ (α_ X Y Z).inv ≫ (α_ W (X ⊗ Y) Z).inv ≫ (α_ W X Y).inv ▷ Z =
       (α_ W X (Y ⊗ Z)).inv ≫ (α_ (W ⊗ X) Y Z).inv :=
   eq_of_inv_eq_inv (by simp)
 
-@[reassoc (attr := simp)]
+@[reassoc (attr := to_additive (attr := simp))]
 theorem pentagon_inv_inv_hom_hom_inv :
     (α_ W (X ⊗ Y) Z).inv ≫ (α_ W X Y).inv ▷ Z ≫ (α_ (W ⊗ X) Y Z).hom =
       W ◁ (α_ X Y Z).hom ≫ (α_ W X (Y ⊗ Z)).inv := by
   rw [← cancel_epi (W ◁ (α_ X Y Z).inv), ← cancel_mono (α_ (W ⊗ X) Y Z).inv]
   simp
 
-@[reassoc (attr := simp)]
+@[reassoc (attr := to_additive (attr := simp))]
 theorem pentagon_inv_hom_hom_hom_inv :
     (α_ (W ⊗ X) Y Z).inv ≫ (α_ W X Y).hom ▷ Z ≫ (α_ W (X ⊗ Y) Z).hom =
       (α_ W X (Y ⊗ Z)).hom ≫ W ◁ (α_ X Y Z).inv :=
   eq_of_inv_eq_inv (by simp)
 
-@[reassoc (attr := simp)]
+@[reassoc (attr := to_additive (attr := simp))]
 theorem pentagon_hom_inv_inv_inv_inv :
     W ◁ (α_ X Y Z).hom ≫ (α_ W X (Y ⊗ Z)).inv ≫ (α_ (W ⊗ X) Y Z).inv =
       (α_ W (X ⊗ Y) Z).inv ≫ (α_ W X Y).inv ▷ Z := by
   simp [← cancel_epi (W ◁ (α_ X Y Z).inv)]
 
-@[reassoc (attr := simp)]
+@[reassoc (attr := to_additive (attr := simp))]
 theorem pentagon_hom_hom_inv_hom_hom :
     (α_ (W ⊗ X) Y Z).hom ≫ (α_ W X (Y ⊗ Z)).hom ≫ W ◁ (α_ X Y Z).inv =
       (α_ W X Y).hom ▷ Z ≫ (α_ W (X ⊗ Y) Z).hom :=
   eq_of_inv_eq_inv (by simp)
 
-@[reassoc (attr := simp)]
+@[reassoc (attr := to_additive (attr := simp))]
 theorem pentagon_hom_inv_inv_inv_hom :
     (α_ W X (Y ⊗ Z)).hom ≫ W ◁ (α_ X Y Z).inv ≫ (α_ W (X ⊗ Y) Z).inv =
       (α_ (W ⊗ X) Y Z).inv ≫ (α_ W X Y).hom ▷ Z := by
   rw [← cancel_epi (α_ W X (Y ⊗ Z)).inv, ← cancel_mono ((α_ W X Y).inv ▷ Z)]
   simp
 
-@[reassoc (attr := simp)]
+@[reassoc (attr := to_additive (attr := simp))]
 theorem pentagon_hom_hom_inv_inv_hom :
     (α_ W (X ⊗ Y) Z).hom ≫ W ◁ (α_ X Y Z).hom ≫ (α_ W X (Y ⊗ Z)).inv =
       (α_ W X Y).inv ▷ Z ≫ (α_ (W ⊗ X) Y Z).hom :=
   eq_of_inv_eq_inv (by simp)
 
-@[reassoc (attr := simp)]
+@[reassoc (attr := to_additive (attr := simp))]
 theorem pentagon_inv_hom_hom_hom_hom :
     (α_ W X Y).inv ▷ Z ≫ (α_ (W ⊗ X) Y Z).hom ≫ (α_ W X (Y ⊗ Z)).hom =
       (α_ W (X ⊗ Y) Z).hom ≫ W ◁ (α_ X Y Z).hom := by
   simp [← cancel_epi ((α_ W X Y).hom ▷ Z)]
 
-@[reassoc (attr := simp)]
+@[reassoc (attr := to_additive (attr := simp))]
 theorem pentagon_inv_inv_hom_inv_inv :
     (α_ W X (Y ⊗ Z)).inv ≫ (α_ (W ⊗ X) Y Z).inv ≫ (α_ W X Y).hom ▷ Z =
       W ◁ (α_ X Y Z).inv ≫ (α_ W (X ⊗ Y) Z).inv :=
   eq_of_inv_eq_inv (by simp)
 
-@[reassoc (attr := simp)]
+@[reassoc (attr := to_additive (attr := simp))]
 theorem triangle_assoc_comp_right (X Y : C) :
     (α_ X (𝟙_ C) Y).inv ≫ ((ρ_ X).hom ▷ Y) = X ◁ (λ_ Y).hom := by
   rw [← triangle, Iso.inv_hom_id_assoc]
 
-@[reassoc (attr := simp)]
+@[reassoc (attr := to_additive (attr := simp))]
 theorem triangle_assoc_comp_right_inv (X Y : C) :
     (ρ_ X).inv ▷ Y ≫ (α_ X (𝟙_ C) Y).hom = X ◁ (λ_ Y).inv := by
   simp [← cancel_mono (X ◁ (λ_ Y).hom)]
 
-@[reassoc (attr := simp)]
+@[reassoc (attr := to_additive (attr := simp))]
 theorem triangle_assoc_comp_left_inv (X Y : C) :
     (X ◁ (λ_ Y).inv) ≫ (α_ X (𝟙_ C) Y).inv = (ρ_ X).inv ▷ Y := by
   simp [← cancel_mono ((ρ_ X).hom ▷ Y)]
@@ -740,19 +760,25 @@ theorem triangle_assoc_comp_left_inv (X Y : C) :
 /-- We state it as a simp lemma, which is regarded as an involved version of
 `id_whiskerRight X Y : 𝟙 X ▷ Y = 𝟙 (X ⊗ Y)`.
 -/
-@[reassoc, simp]
+@[reassoc]
 theorem leftUnitor_whiskerRight (X Y : C) :
     (λ_ X).hom ▷ Y = (α_ (𝟙_ C) X Y).hom ≫ (λ_ (X ⊗ Y)).hom := by
   rw [← whiskerLeft_iff, whiskerLeft_comp, ← cancel_epi (α_ _ _ _).hom, ←
       cancel_epi ((α_ _ _ _).hom ▷ _), pentagon_assoc, triangle, ← associator_naturality_middle, ←
       comp_whiskerRight_assoc, triangle, associator_naturality_left]
 
-@[reassoc, simp]
+attribute [to_additive (attr := simp)] leftUnitor_whiskerRight
+attribute [to_additive] leftUnitor_whiskerRight_assoc
+
+@[reassoc]
 theorem leftUnitor_inv_whiskerRight (X Y : C) :
     (λ_ X).inv ▷ Y = (λ_ (X ⊗ Y)).inv ≫ (α_ (𝟙_ C) X Y).inv :=
   eq_of_inv_eq_inv (by simp)
 
-@[reassoc, simp]
+attribute [to_additive (attr := simp)] leftUnitor_inv_whiskerRight
+attribute [to_additive] leftUnitor_inv_whiskerRight_assoc
+
+@[reassoc]
 theorem whiskerLeft_rightUnitor (X Y : C) :
     X ◁ (ρ_ Y).hom = (α_ X Y (𝟙_ C)).inv ≫ (ρ_ (X ⊗ Y)).hom := by
   rw [← whiskerRight_iff, comp_whiskerRight, ← cancel_epi (α_ _ _ _).inv, ←
@@ -760,89 +786,98 @@ theorem whiskerLeft_rightUnitor (X Y : C) :
       associator_inv_naturality_middle, ← whiskerLeft_comp_assoc, triangle_assoc_comp_right,
       associator_inv_naturality_right]
 
-@[reassoc, simp]
+attribute [to_additive (attr := simp)] whiskerLeft_rightUnitor
+attribute [to_additive] whiskerLeft_rightUnitor_assoc
+
+@[reassoc]
 theorem whiskerLeft_rightUnitor_inv (X Y : C) :
     X ◁ (ρ_ Y).inv = (ρ_ (X ⊗ Y)).inv ≫ (α_ X Y (𝟙_ C)).hom :=
   eq_of_inv_eq_inv (by simp)
 
-@[reassoc]
+attribute [to_additive (attr := simp)] whiskerLeft_rightUnitor_inv
+attribute [to_additive] whiskerLeft_rightUnitor_inv_assoc
+
+@[reassoc (attr := to_additive)]
 theorem leftUnitor_tensor_hom (X Y : C) :
     (λ_ (X ⊗ Y)).hom = (α_ (𝟙_ C) X Y).inv ≫ (λ_ X).hom ▷ Y := by simp
 
 @[deprecated (since := "2025-06-24")] alias leftUnitor_tensor := leftUnitor_tensor_hom
 
-@[reassoc]
+@[reassoc (attr := to_additive)]
 theorem leftUnitor_tensor_inv (X Y : C) :
     (λ_ (X ⊗ Y)).inv = (λ_ X).inv ▷ Y ≫ (α_ (𝟙_ C) X Y).hom := by simp
 
-@[reassoc]
+@[reassoc (attr := to_additive)]
 theorem rightUnitor_tensor_hom (X Y : C) :
     (ρ_ (X ⊗ Y)).hom = (α_ X Y (𝟙_ C)).hom ≫ X ◁ (ρ_ Y).hom := by simp
 
 @[deprecated (since := "2025-06-24")] alias rightUnitor_tensor := rightUnitor_tensor_hom
 
-@[reassoc]
+@[reassoc (attr := to_additive)]
 theorem rightUnitor_tensor_inv (X Y : C) :
     (ρ_ (X ⊗ Y)).inv = X ◁ (ρ_ Y).inv ≫ (α_ X Y (𝟙_ C)).inv := by simp
 
 end
 
-@[reassoc]
+@[reassoc (attr := to_additive)]
 theorem associator_inv_naturality {X Y Z X' Y' Z' : C} (f : X ⟶ X') (g : Y ⟶ Y') (h : Z ⟶ Z') :
     (f ⊗ₘ g ⊗ₘ h) ≫ (α_ X' Y' Z').inv = (α_ X Y Z).inv ≫ ((f ⊗ₘ g) ⊗ₘ h) := by
   simp [tensorHom_def]
 
-@[reassoc, simp]
+@[reassoc]
 theorem associator_conjugation {X X' Y Y' Z Z' : C} (f : X ⟶ X') (g : Y ⟶ Y') (h : Z ⟶ Z') :
     (f ⊗ₘ g) ⊗ₘ h = (α_ X Y Z).hom ≫ (f ⊗ₘ g ⊗ₘ h) ≫ (α_ X' Y' Z').inv := by
   rw [associator_inv_naturality, hom_inv_id_assoc]
 
-@[reassoc]
+attribute [to_additive (attr := simp)] associator_conjugation
+attribute [to_additive] associator_conjugation_assoc
+
+@[reassoc (attr := to_additive)]
 theorem associator_inv_conjugation {X X' Y Y' Z Z' : C} (f : X ⟶ X') (g : Y ⟶ Y') (h : Z ⟶ Z') :
     f ⊗ₘ g ⊗ₘ h = (α_ X Y Z).inv ≫ ((f ⊗ₘ g) ⊗ₘ h) ≫ (α_ X' Y' Z').hom := by
   rw [associator_naturality, inv_hom_id_assoc]
 
 -- TODO these next two lemmas aren't so fundamental, and perhaps could be removed
 -- (replacing their usages by their proofs).
-@[reassoc]
+@[reassoc (attr := to_additive)]
 theorem id_tensor_associator_naturality {X Y Z Z' : C} (h : Z ⟶ Z') :
     (𝟙 (X ⊗ Y) ⊗ₘ h) ≫ (α_ X Y Z').hom = (α_ X Y Z).hom ≫ (𝟙 X ⊗ₘ 𝟙 Y ⊗ₘ h) := by
   rw [← id_tensorHom_id, associator_naturality]
 
-@[reassoc]
+@[reassoc (attr := to_additive)]
 theorem id_tensor_associator_inv_naturality {X Y Z X' : C} (f : X ⟶ X') :
     (f ⊗ₘ 𝟙 (Y ⊗ Z)) ≫ (α_ X' Y Z).inv = (α_ X Y Z).inv ≫ ((f ⊗ₘ 𝟙 Y) ⊗ₘ 𝟙 Z) := by
   rw [← id_tensorHom_id, associator_inv_naturality]
 
-@[reassoc]
+@[reassoc (attr := to_additive)]
 theorem hom_inv_id_tensor {V W X Y Z : C} (f : V ≅ W) (g : X ⟶ Y) (h : Y ⟶ Z) :
     (f.hom ⊗ₘ g) ≫ (f.inv ⊗ₘ h) = (𝟙 V ⊗ₘ g) ≫ (𝟙 V ⊗ₘ h) := by simp
 
-@[reassoc]
+@[reassoc (attr := to_additive)]
 theorem inv_hom_id_tensor {V W X Y Z : C} (f : V ≅ W) (g : X ⟶ Y) (h : Y ⟶ Z) :
     (f.inv ⊗ₘ g) ≫ (f.hom ⊗ₘ h) = (𝟙 W ⊗ₘ g) ≫ (𝟙 W ⊗ₘ h) := by simp
 
-@[reassoc]
+@[reassoc (attr := to_additive)]
 theorem tensor_hom_inv_id {V W X Y Z : C} (f : V ≅ W) (g : X ⟶ Y) (h : Y ⟶ Z) :
     (g ⊗ₘ f.hom) ≫ (h ⊗ₘ f.inv) = (g ⊗ₘ 𝟙 V) ≫ (h ⊗ₘ 𝟙 V) := by simp
 
-@[reassoc]
+@[reassoc (attr := to_additive)]
 theorem tensor_inv_hom_id {V W X Y Z : C} (f : V ≅ W) (g : X ⟶ Y) (h : Y ⟶ Z) :
     (g ⊗ₘ f.inv) ≫ (h ⊗ₘ f.hom) = (g ⊗ₘ 𝟙 W) ≫ (h ⊗ₘ 𝟙 W) := by simp
 
-@[reassoc]
+@[reassoc (attr := to_additive)]
 theorem hom_inv_id_tensor' {V W X Y Z : C} (f : V ⟶ W) [IsIso f] (g : X ⟶ Y) (h : Y ⟶ Z) :
     (f ⊗ₘ g) ≫ (inv f ⊗ₘ h) = (𝟙 V ⊗ₘ g) ≫ (𝟙 V ⊗ₘ h) := by simp
 
-@[reassoc]
+@[reassoc (attr := to_additive)]
 theorem inv_hom_id_tensor' {V W X Y Z : C} (f : V ⟶ W) [IsIso f] (g : X ⟶ Y) (h : Y ⟶ Z) :
     (inv f ⊗ₘ g) ≫ (f ⊗ₘ h) = (𝟙 W ⊗ₘ g) ≫ (𝟙 W ⊗ₘ h) := by simp
 
-@[reassoc]
+@[reassoc (attr := to_additive)]
 theorem tensor_hom_inv_id' {V W X Y Z : C} (f : V ⟶ W) [IsIso f] (g : X ⟶ Y) (h : Y ⟶ Z) :
     (g ⊗ₘ f) ≫ (h ⊗ₘ inv f) = (g ⊗ₘ 𝟙 V) ≫ (h ⊗ₘ 𝟙 V) := by simp
 
-@[reassoc]
+@[reassoc (attr := to_additive)]
 theorem tensor_inv_hom_id' {V W X Y Z : C} (f : V ⟶ W) [IsIso f] (g : X ⟶ Y) (h : Y ⟶ Z) :
     (g ⊗ₘ inv f) ≫ (h ⊗ₘ f) = (g ⊗ₘ 𝟙 W) ≫ (h ⊗ₘ 𝟙 W) := by simp
 
@@ -892,19 +927,19 @@ abbrev ofTensorHom [MonoidalCategoryStruct C]
   pentagon := by intros; simp [← id_tensorHom, ← tensorHom_id, pentagon]
   triangle := by intros; simp [← id_tensorHom, ← tensorHom_id, triangle]
 
-@[reassoc]
+@[reassoc (attr := to_additive)]
 theorem comp_tensor_id (f : W ⟶ X) (g : X ⟶ Y) : f ≫ g ⊗ₘ 𝟙 Z = (f ⊗ₘ 𝟙 Z) ≫ (g ⊗ₘ 𝟙 Z) := by
   simp
 
-@[reassoc]
+@[reassoc (attr := to_additive)]
 theorem id_tensor_comp (f : W ⟶ X) (g : X ⟶ Y) : 𝟙 Z ⊗ₘ f ≫ g = (𝟙 Z ⊗ₘ f) ≫ (𝟙 Z ⊗ₘ g) := by
   simp
 
-@[reassoc]
+@[reassoc (attr := to_additive)]
 theorem id_tensor_comp_tensor_id (f : W ⟶ X) (g : Y ⟶ Z) : (𝟙 Y ⊗ₘ f) ≫ (g ⊗ₘ 𝟙 X) = g ⊗ₘ f := by
   simp [tensorHom_def']
 
-@[reassoc]
+@[reassoc (attr := to_additive)]
 theorem tensor_id_comp_id_tensor (f : W ⟶ X) (g : Y ⟶ Z) : (g ⊗ₘ 𝟙 W) ≫ (𝟙 Z ⊗ₘ f) = g ⊗ₘ f := by
   simp [tensorHom_def]
 
@@ -919,41 +954,43 @@ variable (C)
 attribute [local simp] whisker_exchange
 
 /-- The tensor product expressed as a functor. -/
-@[simps]
+@[to_additive (attr := simps)]
 def tensor : C × C ⥤ C where
   obj X := X.1 ⊗ X.2
   map {X Y : C × C} (f : X ⟶ Y) := f.1 ⊗ₘ f.2
 
 /-- The left-associated triple tensor product as a functor. -/
+@[to_additive]
 def leftAssocTensor : C × C × C ⥤ C where
   obj X := (X.1 ⊗ X.2.1) ⊗ X.2.2
   map {X Y : C × C × C} (f : X ⟶ Y) := (f.1 ⊗ₘ f.2.1) ⊗ₘ f.2.2
 
-@[simp]
+@[to_additive (attr := simp)]
 theorem leftAssocTensor_obj (X) : (leftAssocTensor C).obj X = (X.1 ⊗ X.2.1) ⊗ X.2.2 :=
   rfl
 
-@[simp]
+@[to_additive (attr := simp)]
 theorem leftAssocTensor_map {X Y} (f : X ⟶ Y) :
     (leftAssocTensor C).map f = (f.1 ⊗ₘ f.2.1) ⊗ₘ f.2.2 :=
   rfl
 
 /-- The right-associated triple tensor product as a functor. -/
+@[to_additive]
 def rightAssocTensor : C × C × C ⥤ C where
   obj X := X.1 ⊗ X.2.1 ⊗ X.2.2
   map {X Y : C × C × C} (f : X ⟶ Y) := f.1 ⊗ₘ f.2.1 ⊗ₘ f.2.2
 
-@[simp]
+@[to_additive (attr := simp)]
 theorem rightAssocTensor_obj (X) : (rightAssocTensor C).obj X = X.1 ⊗ X.2.1 ⊗ X.2.2 :=
   rfl
 
-@[simp]
+@[to_additive (attr := simp)]
 theorem rightAssocTensor_map {X Y} (f : X ⟶ Y) :
     (rightAssocTensor C).map f = f.1 ⊗ₘ f.2.1 ⊗ₘ f.2.2 :=
   rfl
 
 /-- The tensor product bifunctor `C ⥤ C ⥤ C` of a monoidal category. -/
-@[simps]
+@[to_additive (attr := simps)]
 def curriedTensor : C ⥤ C ⥤ C where
   obj X :=
     { obj := fun Y => X ⊗ Y
@@ -964,38 +1001,42 @@ def curriedTensor : C ⥤ C ⥤ C where
 variable {C}
 
 /-- Tensoring on the left with a fixed object, as a functor. -/
+@[to_additive]
 abbrev tensorLeft (X : C) : C ⥤ C := (curriedTensor C).obj X
 
 /-- Tensoring on the right with a fixed object, as a functor. -/
+@[to_additive]
 abbrev tensorRight (X : C) : C ⥤ C := (curriedTensor C).flip.obj X
 
 variable (C)
 
 /-- The functor `fun X ↦ 𝟙_ C ⊗ X`. -/
+@[to_additive]
 abbrev tensorUnitLeft : C ⥤ C := tensorLeft (𝟙_ C)
 
 /-- The functor `fun X ↦ X ⊗ 𝟙_ C`. -/
+@[to_additive]
 abbrev tensorUnitRight : C ⥤ C := tensorRight (𝟙_ C)
 
 -- We can express the associator and the unitors, given componentwise above,
 -- as natural isomorphisms.
 /-- The associator as a natural isomorphism. -/
-@[simps!]
+@[to_additive (attr := simps!)]
 def associatorNatIso : leftAssocTensor C ≅ rightAssocTensor C :=
   NatIso.ofComponents (fun _ => MonoidalCategory.associator _ _ _)
 
 /-- The left unitor as a natural isomorphism. -/
-@[simps!]
+@[to_additive (attr := simps!)]
 def leftUnitorNatIso : tensorUnitLeft C ≅ 𝟭 C :=
   NatIso.ofComponents MonoidalCategory.leftUnitor
 
 /-- The right unitor as a natural isomorphism. -/
-@[simps!]
+@[to_additive (attr := simps!)]
 def rightUnitorNatIso : tensorUnitRight C ≅ 𝟭 C :=
   NatIso.ofComponents MonoidalCategory.rightUnitor
 
 /-- The associator as a natural isomorphism between trifunctors `C ⥤ C ⥤ C ⥤ C`. -/
-@[simps!]
+@[to_additive (attr := simps!)]
 def curriedAssociatorNatIso :
     bifunctorComp₁₂ (curriedTensor C) (curriedTensor C) ≅
       bifunctorComp₂₃ (curriedTensor C) (curriedTensor C) :=
@@ -1009,15 +1050,16 @@ variable {C}
 /-- Tensoring on the left with `X ⊗ Y` is naturally isomorphic to
 tensoring on the left with `Y`, and then again with `X`.
 -/
+@[to_additive]
 def tensorLeftTensor (X Y : C) : tensorLeft (X ⊗ Y) ≅ tensorLeft Y ⋙ tensorLeft X :=
   NatIso.ofComponents (associator _ _) fun {Z} {Z'} f => by simp
 
-@[simp]
+@[to_additive (attr := simp)]
 theorem tensorLeftTensor_hom_app (X Y Z : C) :
     (tensorLeftTensor X Y).hom.app Z = (associator X Y Z).hom :=
   rfl
 
-@[simp]
+@[to_additive (attr := simp)]
 theorem tensorLeftTensor_inv_app (X Y Z : C) :
     (tensorLeftTensor X Y).inv.app Z = (associator X Y Z).inv := by simp [tensorLeftTensor]
 
@@ -1027,8 +1069,10 @@ variable (C)
 
 TODO: show this is an op-monoidal functor.
 -/
+@[to_additive]
 abbrev tensoringLeft : C ⥤ C ⥤ C := curriedTensor C
 
+@[to_additive]
 instance : (tensoringLeft C).Faithful where
   map_injective {X} {Y} f g h := by
     injections h
@@ -1039,8 +1083,10 @@ instance : (tensoringLeft C).Faithful where
 
 We later show this is a monoidal functor.
 -/
+@[to_additive]
 abbrev tensoringRight : C ⥤ C ⥤ C := (curriedTensor C).flip
 
+@[to_additive]
 instance : (tensoringRight C).Faithful where
   map_injective {X} {Y} f g h := by
     injections h
@@ -1052,15 +1098,16 @@ variable {C}
 /-- Tensoring on the right with `X ⊗ Y` is naturally isomorphic to
 tensoring on the right with `X`, and then again with `Y`.
 -/
+@[to_additive]
 def tensorRightTensor (X Y : C) : tensorRight (X ⊗ Y) ≅ tensorRight X ⋙ tensorRight Y :=
   NatIso.ofComponents (fun Z => (associator Z X Y).symm) fun {Z} {Z'} f => by simp
 
-@[simp]
+@[to_additive (attr := simp)]
 theorem tensorRightTensor_hom_app (X Y Z : C) :
     (tensorRightTensor X Y).hom.app Z = (associator Z X Y).inv :=
   rfl
 
-@[simp]
+@[to_additive (attr := simp)]
 theorem tensorRightTensor_inv_app (X Y Z : C) :
     (tensorRightTensor X Y).inv.app Z = (associator Z X Y).hom := by simp [tensorRightTensor]
 
@@ -1146,18 +1193,18 @@ namespace NatTrans
 variable {J : Type*} [Category J] {C : Type*} [Category C] [MonoidalCategory C]
   {F G F' G' : J ⥤ C} (α : F ⟶ F') (β : G ⟶ G')
 
-@[reassoc]
+@[reassoc (attr := to_additive)]
 lemma tensor_naturality {X Y X' Y' : J} (f : X ⟶ Y) (g : X' ⟶ Y') :
     (F.map f ⊗ₘ G.map g) ≫ (α.app Y ⊗ₘ β.app Y') =
       (α.app X ⊗ₘ β.app X') ≫ (F'.map f ⊗ₘ G'.map g) := by simp
 
-@[reassoc]
+@[reassoc (attr := to_additive)]
 lemma whiskerRight_app_tensor_app {X Y : J} (f : X ⟶ Y) (X' : J) :
     F.map f ▷ G.obj X' ≫ (α.app Y ⊗ₘ β.app X') =
       (α.app X ⊗ₘ β.app X') ≫ F'.map f ▷ (G'.obj X') := by
   simpa using tensor_naturality α β f (𝟙 X')
 
-@[reassoc]
+@[reassoc (attr := to_additive)]
 lemma whiskerLeft_app_tensor_app {X' Y' : J} (f : X' ⟶ Y') (X : J) :
     F.obj X ◁ G.map f ≫ (α.app X ⊗ₘ β.app Y') =
       (α.app X ⊗ₘ β.app X') ≫ F'.obj X ◁ G'.map f := by
@@ -1170,6 +1217,7 @@ section ObjectProperty
 /-- The restriction of a monoidal category along an object property
 that's closed under the monoidal structure. -/
 -- See note [reducible non-instances]
+@[to_additive]
 abbrev MonoidalCategory.fullSubcategory
     {C : Type u} [Category.{v} C] [MonoidalCategory C] (P : ObjectProperty C)
     (tensorUnit : P (𝟙_ C))

--- a/Mathlib/CategoryTheory/Monoidal/Category.lean
+++ b/Mathlib/CategoryTheory/Monoidal/Category.lean
@@ -152,9 +152,6 @@ scoped notation "𝟙_ " C:arg => MonoidalCategoryStruct.tensorUnit C
 /-- Notation for the monoidal `associator`: `(X ⊗ Y) ⊗ Z ≃ X ⊗ (Y ⊗ Z)` -/
 scoped notation "α_" => MonoidalCategoryStruct.associator
 
-/-- Notation for the additive monoidal `addAssociator`: `(X ⊕ₒ Y) ⊕ₒ Z ≃ X ⊕ₒ (Y ⊕ₒ Z)` -/
-scoped notation "α⁺" => AddMonoidalCategoryStruct.addAssociator
-
 /-- Notation for the `leftUnitor`: `𝟙_C ⊗ X ≃ X` -/
 scoped notation "λ_" => MonoidalCategoryStruct.leftUnitor
 
@@ -189,6 +186,9 @@ scoped infixr:70 " ⊕ₘ " => AddMonoidalCategoryStruct.addHom
 
 /-- Notation for `addUnit`, the two-sided identity of `⊕ₒ` -/
 scoped notation "𝟘_ " C:arg => AddMonoidalCategoryStruct.addUnit C
+
+/-- Notation for the additive monoidal `addAssociator`: `(X ⊕ₒ Y) ⊕ₒ Z ≃ X ⊕ₒ (Y ⊕ₒ Z)` -/
+scoped notation "α⁺" => AddMonoidalCategoryStruct.addAssociator
 
 /-- Notation for the `leftAddUnitor`: `𝟘_C ⊕ₒ X ≃ X` -/
 scoped notation "λ⁺" => AddMonoidalCategoryStruct.leftAddUnitor

--- a/Mathlib/CategoryTheory/Monoidal/Category.lean
+++ b/Mathlib/CategoryTheory/Monoidal/Category.lean
@@ -589,7 +589,7 @@ theorem tensorIso_def' {X Y X' Y' : C} (f : X ≅ Y) (g : X' ≅ Y') :
 instance tensor_isIso {W X Y Z : C} (f : W ⟶ X) [IsIso f] (g : Y ⟶ Z) [IsIso g] : IsIso (f ⊗ₘ g) :=
   (asIso f ⊗ᵢ asIso g).isIso_hom
 
-@[to_additive (attr := simp)]
+@[to_additive (attr := simp) inv_add]
 theorem inv_tensor {W X Y Z : C} (f : W ⟶ X) [IsIso f] (g : Y ⟶ Z) [IsIso g] :
     inv (f ⊗ₘ g) = inv f ⊗ₘ inv g := by
   simp [tensorHom_def, whisker_exchange]
@@ -1123,7 +1123,7 @@ theorem tensorRightTensor_hom_app (X Y Z : C) :
     (tensorRightTensor X Y).hom.app Z = (associator Z X Y).inv :=
   rfl
 
-@[to_additive (attr := simp)]
+@[to_additive (attr := simp) addRightAdd_inv_app]
 theorem tensorRightTensor_inv_app (X Y Z : C) :
     (tensorRightTensor X Y).inv.app Z = (associator Z X Y).hom := by simp [tensorRightTensor]
 

--- a/Mathlib/CategoryTheory/Monoidal/Cocartesian/Basic.lean
+++ b/Mathlib/CategoryTheory/Monoidal/Cocartesian/Basic.lean
@@ -1,0 +1,394 @@
+/-
+Copyright (c) 2019 Kim Morrison, Adam Topaz. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Kim Morrison, Simon Hudon, Adam Topaz, Robin Carlier
+-/
+import Mathlib.CategoryTheory.Limits.Constructions.FiniteProductsOfBinaryProducts
+import Mathlib.CategoryTheory.Limits.FullSubcategory
+import Mathlib.CategoryTheory.Limits.Preserves.Shapes.Terminal
+import Mathlib.CategoryTheory.Monoidal.Braided.Basic
+
+/-!
+# Categories with chosen finite products
+
+We introduce a class, `CocartesianMonoidalCategory`, which bundles explicit choices
+for an initial object and binary coproducts in a category `C`.
+This is primarily useful for categories which have finite coproducts with good
+definitional properties, such as the category of types.
+
+For better defeqs, we also extend `AddMonoidalCategory`.
+
+-/
+
+namespace CategoryTheory
+
+universe v v₁ v₂ v₃ u u₁ u₂ u₃
+
+open AddMonoidalCategory Limits
+
+variable (C) in
+/--
+An instance of `CocartesianMonoidalCategory C` bundles an explicit choice of a binary
+coproduct of two objects of `C`, and an initial object in `C`.
+
+Users should use the additive monoidal notation: `X ⊕ₒ Y` for the coproduct and `𝟘_ C` for
+the initial object.
+-/
+class CocartesianMonoidalCategory (C : Type u) [Category.{v} C] extends AddMonoidalCategory C where
+  /-- The additive unit is an initial object. -/
+  isInitialAddUnit : IsInitial (𝟘_ C)
+  /-- The first injection into the coproduct. -/
+  inl (X Y : C) : X ⟶ X ⊕ₒ Y
+  /-- The second injection into the coproduct. -/
+  inr (X Y : C) : Y ⟶ X ⊕ₒ Y
+  /-- The monoidal product is the categorical product. -/
+  addHomIsBinaryCoproduct (X Y : C) : IsColimit <| BinaryCofan.mk (inl X Y) (inr X Y)
+  inl_def (X Y : C) : inl X Y = (ρ⁺ X).inv ≫ X ◁⁺ isInitialAddUnit.to Y := by cat_disch
+  inr_def (X Y : C) : inr X Y = (λ⁺ Y).inv ≫ isInitialAddUnit.to X ▷⁺ Y := by cat_disch
+
+namespace CocartesianMonoidalCategory
+
+variable {C : Type u} [Category.{v} C]
+
+section OfChosenFiniteCoproducts
+variable (𝒯 : ColimitCocone (Functor.empty.{0} C)) (ℬ : ∀ X Y : C, ColimitCocone (pair X Y))
+  {X₁ X₂ X₃ Y₁ Y₂ Y₃ Z₁ Z₂ : C}
+
+namespace ofChosenFiniteCoproducts
+
+/-- Implementation of addition for `CocartesianMonoidalCategory.ofChosenFiniteCoproducts`. -/
+abbrev addObj (X Y : C) : C := (ℬ X Y).cocone.pt
+
+/-- Implementation of the addition of morphisms for
+`CocartesianMonoidalCategory.ofChosenFiniteCoproducts`. -/
+abbrev addHom (f : X₁ ⟶ Y₁) (g : X₂ ⟶ Y₂) : addObj ℬ X₁ X₂ ⟶ addObj ℬ Y₁ Y₂ :=
+  (BinaryCofan.IsColimit.desc' (ℬ X₁ X₂).isColimit
+      (f ≫ (ℬ Y₁ Y₂).cocone.ι.app ⟨.left⟩)
+      (g ≫ ((ℬ Y₁ Y₂).cocone.ι.app ⟨.right⟩ : Y₂ ⟶ (ℬ Y₁ Y₂).cocone.pt))).val
+
+lemma id_addHom_id (X Y : C) : addHom ℬ (𝟙 X) (𝟙 Y) = 𝟙 (addObj ℬ X Y) :=
+  (ℬ _ _).isColimit.hom_ext <| by rintro ⟨_ | _⟩ <;> simp [addHom]
+
+lemma addHom_comp_addHom (f₁ : X₁ ⟶ Y₁) (f₂ : X₂ ⟶ Y₂) (g₁ : Y₁ ⟶ Z₁) (g₂ : Y₂ ⟶ Z₂) :
+    addHom ℬ f₁ f₂ ≫ addHom ℬ g₁ g₂ = addHom ℬ (f₁ ≫ g₁) (f₂ ≫ g₂) :=
+  (ℬ _ _).isColimit.hom_ext <| by rintro ⟨_ | _⟩ <;> simp [addHom]
+
+-- TODO: BinaryCofan.{associatorOfColimitCocone, leftUnitor, rightUnitor}
+-- lemma pentagon (W X Y Z : C) :
+--     tensorHom ℬ (BinaryFan.associatorOfLimitCone ℬ W X Y).hom (𝟙 Z) ≫
+--         (BinaryFan.associatorOfLimitCone ℬ W (tensorObj ℬ X Y) Z).hom ≫
+--           tensorHom ℬ (𝟙 W) (BinaryFan.associatorOfLimitCone ℬ X Y Z).hom =
+--       (BinaryFan.associatorOfLimitCone ℬ (tensorObj ℬ W X) Y Z).hom ≫
+--         (BinaryFan.associatorOfLimitCone ℬ W X (tensorObj ℬ Y Z)).hom := by
+--   dsimp [tensorHom]
+--   apply (ℬ _ _).isLimit.hom_ext
+--   rintro ⟨_ | _⟩
+--   · simp
+--   apply (ℬ _ _).isLimit.hom_ext
+--   rintro ⟨_ | _⟩
+--   · simp
+--   apply (ℬ _ _).isLimit.hom_ext
+--   rintro ⟨_ | _⟩ <;> simp
+
+-- lemma triangle (X Y : C) :
+--     (BinaryFan.associatorOfLimitCone ℬ X 𝒯.cone.pt Y).hom ≫
+--         tensorHom ℬ (𝟙 X) (BinaryFan.leftUnitor 𝒯.isLimit (ℬ 𝒯.cone.pt Y).isLimit).hom =
+--       tensorHom ℬ (BinaryFan.rightUnitor 𝒯.isLimit (ℬ X 𝒯.cone.pt).isLimit).hom (𝟙 Y) :=
+--   (ℬ _ _).isLimit.hom_ext <| by rintro ⟨_ | _⟩ <;> simp
+
+-- lemma leftUnitor_naturality (f : X₁ ⟶ X₂) :
+--     tensorHom ℬ (𝟙 𝒯.cone.pt) f ≫ (BinaryFan.leftUnitor 𝒯.isLimit (ℬ 𝒯.cone.pt X₂).isLimit).hom =
+--       (BinaryFan.leftUnitor 𝒯.isLimit (ℬ 𝒯.cone.pt X₁).isLimit).hom ≫ f := by
+--   simp [tensorHom]
+
+-- lemma rightUnitor_naturality (f : X₁ ⟶ X₂) :
+--     tensorHom ℬ f (𝟙 𝒯.cone.pt) ≫ (BinaryFan.rightUnitor 𝒯.isLimit
+--       (ℬ X₂ 𝒯.cone.pt).isLimit).hom =
+--       (BinaryFan.rightUnitor 𝒯.isLimit (ℬ X₁ 𝒯.cone.pt).isLimit).hom ≫ f := by
+--   simp [tensorHom]
+
+-- lemma associator_naturality (f₁ : X₁ ⟶ Y₁) (f₂ : X₂ ⟶ Y₂) (f₃ : X₃ ⟶ Y₃) :
+--     tensorHom ℬ (tensorHom ℬ f₁ f₂) f₃ ≫ (BinaryFan.associatorOfLimitCone ℬ Y₁ Y₂ Y₃).hom =
+--       (BinaryFan.associatorOfLimitCone ℬ X₁ X₂ X₃).hom ≫ tensorHom ℬ f₁ (tensorHom ℬ f₂ f₃) := by
+--   dsimp [tensorHom]
+--   apply (ℬ _ _).isLimit.hom_ext
+--   rintro ⟨_ | _⟩
+--   · simp
+--   apply (ℬ _ _).isLimit.hom_ext
+--   rintro ⟨_ | _⟩ <;> simp
+
+end ofChosenFiniteCoproducts
+
+-- open ofChosenFiniteCoproducts
+
+-- /-- Construct an instance of `CocartesianMonoidalCategory C` given a terminal object and colimit
+-- cocones over arbitrary pairs of objects. -/
+-- abbrev ofChosenFiniteProducts : CocartesianMonoidalCategory C :=
+--   letI : MonoidalCategoryStruct C := {
+--     tensorUnit := 𝒯.cocone.pt
+--     tensorObj := addObj ℬ
+--     tensorHom := addHom ℬ
+--     whiskerLeft X {_ _} g := addHom ℬ (𝟙 X) g
+--     whiskerRight {_ _} f Y := addHom ℬ f (𝟙 Y)
+--     associator := BinaryFan.associatorOfLimitCone ℬ
+--     leftUnitor X := BinaryFan.leftUnitor 𝒯.isLimit (ℬ 𝒯.cone.pt X).isLimit
+--     rightUnitor X := BinaryFan.rightUnitor 𝒯.isLimit (ℬ X 𝒯.cone.pt).isLimit
+--   }
+--   {
+--   toAddMonoidalCategory := .ofTensorHom
+--     (id_tensorHom_id := id_tensorHom_id ℬ)
+--     (tensorHom_comp_tensorHom := tensorHom_comp_tensorHom ℬ)
+--     (pentagon := pentagon ℬ)
+--     (triangle := triangle 𝒯 ℬ)
+--     (leftUnitor_naturality := leftUnitor_naturality 𝒯 ℬ)
+--     (rightUnitor_naturality := rightUnitor_naturality 𝒯 ℬ)
+--     (associator_naturality := associator_naturality ℬ)
+--   isTerminalTensorUnit :=
+--     .ofUniqueHom (𝒯.isLimit.lift <| asEmptyCone ·) fun _ _ ↦ 𝒯.isLimit.hom_ext (by simp)
+--   fst X Y := BinaryFan.fst (ℬ X Y).cone
+--   snd X Y := BinaryFan.snd (ℬ X Y).cone
+--   tensorProductIsBinaryProduct X Y := BinaryFan.IsLimit.mk _
+--     (fun f g ↦ (BinaryFan.IsLimit.lift' (ℬ X Y).isLimit f g).1)
+--     (fun f g ↦ (BinaryFan.IsLimit.lift' (ℬ X Y).isLimit f g).2.1)
+--     (fun f g ↦ (BinaryFan.IsLimit.lift' (ℬ X Y).isLimit f g).2.2)
+--     (fun f g m hf hg ↦
+--       BinaryFan.IsLimit.hom_ext (ℬ X Y).isLimit (by simpa using hf) (by simpa using hg))
+--   fst_def X Y := (((ℬ X 𝒯.cone.pt).isLimit.fac
+--     (BinaryFan.mk _ _) ⟨.left⟩).trans (Category.comp_id _)).symm
+--   snd_def X Y := (((ℬ 𝒯.cone.pt Y).isLimit.fac
+--     (BinaryFan.mk _ _) ⟨.right⟩).trans (Category.comp_id _)).symm
+--   }
+
+-- omit 𝒯 in
+-- /-- Construct an instance of `CartesianMonoidalCategory C` given the existence of finite products
+-- in `C`. -/
+-- noncomputable abbrev ofHasFiniteCoproducts [HasFiniteCoproducts C]
+--   : CocartesianMonoidalCategory C
+--   := .ofChosenFiniteCoproducts (getLimitCone (.empty C)) (getLimitCone <| pair · ·)
+
+end OfChosenFiniteCoproducts
+
+variable {C : Type u} [Category.{v} C] [CocartesianMonoidalCategory C]
+
+open AddMonoidalCategory
+
+/--
+The unique map from the initial object.
+-/
+def fromUnit (X : C) : 𝟘_ C ⟶ X := isInitialAddUnit.to _
+
+instance (X : C) : Unique (𝟘_ C ⟶ X) := isInitialEquivUnique _ _ isInitialAddUnit _
+
+lemma default_eq_fromUnit (X : C) : default = fromUnit X := rfl
+
+/--
+This lemma follows from the preexisting `Unique` instance, but
+it is often convenient to use it directly as `apply fromUnit_unique` forcing
+lean to do the necessary elaboration.
+-/
+@[ext]
+lemma fromUnit_unique {X : C} (f g : 𝟘_ _ ⟶ X) : f = g :=
+  Subsingleton.elim _ _
+
+@[simp] lemma fromUnit_unit : fromUnit (𝟘_ C) = 𝟙 (𝟘_ C) := fromUnit_unique ..
+
+@[reassoc (attr := simp)]
+theorem fromUnit_comp {X Y : C} (f : X ⟶ Y) : fromUnit X ≫ f = fromUnit Y :=
+  fromUnit_unique _ _
+
+/--
+Construct a morphism from the coproduct given its two components.
+-/
+def desc {T X Y : C} (f : X ⟶ T) (g : Y ⟶ T) : X ⊕ₒ Y ⟶ T :=
+  (BinaryCofan.IsColimit.desc' (addHomIsBinaryCoproduct X Y) f g).1
+
+@[reassoc (attr := simp)]
+lemma inl_desc {T X Y : C} (f : X ⟶ T) (g : Y ⟶ T) : inl _ _ ≫ desc f g = f :=
+  (BinaryCofan.IsColimit.desc' (addHomIsBinaryCoproduct X Y) f g).2.1
+
+@[reassoc (attr := simp)]
+lemma inr_desc {T X Y : C} (f : X ⟶ T) (g : Y ⟶ T) : inr _ _ ≫ desc f g = g :=
+  (BinaryCofan.IsColimit.desc' (addHomIsBinaryCoproduct X Y) f g).2.2
+
+instance epi_desc_of_epi_left {W X Y : C} (f : X ⟶ W) (g : Y ⟶ W)
+    [Epi f] : Epi (desc f g) :=
+  epi_of_epi_fac <| inl_desc _ _
+
+instance epi_desc_of_epi_right {W X Y : C} (f : X ⟶ W) (g : Y ⟶ W)
+    [Epi g] : Epi (desc f g) :=
+  epi_of_epi_fac <| inr_desc _ _
+
+@[ext 1050]
+lemma hom_ext {T X Y : C} (f g : X ⊕ₒ Y ⟶ T)
+    (h_fst : inl _ _ ≫ f = inl _ _ ≫ g)
+    (h_snd : inr _ _ ≫ f = inr _ _ ≫ g) :
+    f = g :=
+  BinaryCofan.IsColimit.hom_ext (addHomIsBinaryCoproduct X Y) h_fst h_snd
+
+@[reassoc, simp]
+lemma comp_lift {V W X Y : C} (f : X ⟶ W) (g : Y ⟶ W) (h : W ⟶ V) :
+    desc f g ≫ h = desc (f ≫ h) (g ≫ h) := by ext <;> simp
+
+@[simp]
+lemma desc_inl_inr {X Y : C} : desc (inl X Y) (inr X Y) = 𝟙 (X ⊕ₒ Y) := by ext <;> simp
+
+@[simp]
+lemma desc_inl_inr_comp {X Y Z : C} (f : X ⊕ₒ Y ⟶ Z) :
+    desc (inl _ _ ≫ f) (inr _ _ ≫ f) = f := by
+  cat_disch
+
+@[reassoc (attr := simp)]
+lemma inl_addWhiskerLeft (X : C) {Y Z : C} (f : Y ⟶ Z) : inl _ _ ≫ X ◁⁺ f = inl _ _ := by
+  simp [inl_def, <-addWhiskerLeft_comp]
+
+@[reassoc (attr := simp)]
+lemma inr_addWhiskerLeft (X : C) {Y Z : C} (f : Y ⟶ Z) : inr _ _ ≫ X ◁⁺ f = f ≫ inr _ _ := by
+  simp [inr_def, <-addWhisker_exchange]
+
+@[reassoc (attr := simp)]
+lemma inl_addWhiskerRight {X Y : C} (f : X ⟶ Y) (Z : C) : inl _ _ ≫ f ▷⁺ Z = f ≫ inl _ _ := by
+  simp [inl_def, addWhisker_exchange]
+
+@[reassoc (attr := simp)]
+lemma inr_whiskerRight {X Y : C} (f : X ⟶ Y) (Z : C) : inr _ _ ≫ f ▷⁺ Z = inr _ _ := by
+  simp [inr_def, ←comp_addWhiskerRight]
+
+@[reassoc (attr := simp)]
+lemma inl_addHom {X₁ X₂ Y₁ Y₂ : C} (f : X₁ ⟶ X₂) (g : Y₁ ⟶ Y₂) :
+    inl _ _ ≫ (f ⊕ₘ g) = f ≫ inl _ _ := by simp [addHom_def]
+
+@[reassoc (attr := simp)]
+lemma inr_addHom {X₁ X₂ Y₁ Y₂ : C} (f : X₁ ⟶ X₂) (g : Y₁ ⟶ Y₂) :
+    inr _ _ ≫ (f ⊕ₘ g) = g ≫ inr _ _ := by simp [addHom_def]
+
+@[reassoc (attr := simp)]
+lemma map_desc {V W X Y Z : C} (f : W ⟶ Y) (g : X ⟶ Z) (h : Y ⟶ V) (k : Z ⟶ V) :
+    (f ⊕ₘ g) ≫ desc h k = desc (f ≫ h) (g ≫ k) := by ext <;> simp
+
+@[simp]
+lemma desc_comp_inl_comp_inr {W X Y Z : C} (g : X ⟶ W) (g' : Z ⟶ Y) :
+    desc (g ≫ inl _ _) (g' ≫ inr _ _) = g ⊕ₘ g' := by ext <;> simp
+
+@[reassoc (attr := simp)]
+lemma whiskerRight_desc {X Y Z W : C} (f : Y ⟶ W) (g : W ⟶ X) (h : Z ⟶ X) :
+    (f ▷⁺ Z) ≫ desc g h = desc (f ≫ g) h := by
+  cat_disch
+
+-- @[reassoc (attr := simp)]
+-- lemma whiskerLeft_desc {X Y Z W : C} (f : Z ⟶ W) (g : Y ⟶ X) (h : W ⟶ X) :
+--     (Y ◁⁺ f) ≫ desc g h = desc g (f ≫ h) := by
+--   cat_disch
+
+-- @[reassoc (attr := simp)]
+-- lemma inr_addAssociator_hom (X Y Z : C) :
+--     inr _ _ ≫ (α⁺ X Y Z).hom = inr _ _ ≫ inr _ _ := by sorry
+
+-- @[reassoc (attr := simp)]
+-- lemma inr_inl_addAssociator_hom (X Y Z : C) :
+--     inr _ _ ≫ inl _ _ ≫ (α⁺ X Y Z).hom = inl _ _ ≫ inr _ _ := by sorry
+
+-- @[reassoc (attr := simp)]
+-- lemma inl_inl_addAssociator_hom (X Y Z : C) :
+--     inl _ _ ≫ inl _ _ ≫ (α⁺ X Y Z).hom = inl _ _ := by sorry
+
+-- @[reassoc (attr := simp)]
+-- lemma inl_addAssociator_inv (X Y Z : C) :
+--     inl _ _ ≫ (α⁺ X Y Z).inv = inl _ _ ≫ inl _ _ := by sorry
+
+-- @[reassoc (attr := simp)]
+-- lemma inl_inr_addAssociator_inv (X Y Z : C) :
+--     inl _ _ ≫ inr _ _ ≫ (α⁺ X Y Z).inv = inr _ _ ≫ inl _ _ := by sorry
+
+-- @[reassoc (attr := simp)]
+-- lemma inr_inr_addAssociator_inv (X Y Z : C) :
+--     inr _ _ ≫ inr _ _ ≫ (α⁺ X Y Z).inv = inr _ _ := by sorry
+
+-- @[reassoc (attr := simp)]
+-- lemma addAssociator_hom_desc_desc {X Y Z W : C} (f : Y ⟶ X) (g : Z ⟶ X) (h : W ⟶ X) :
+--     (α⁺ Y Z W).hom ≫ desc f (desc g h) = desc (desc f g) h := by
+--   cat_disch
+
+-- @[reassoc (attr := simp)]
+-- lemma addAssociator_inv_desc_desc {X Y Z W : C} (f : Y ⟶ X) (g : Z ⟶ X) (h : W ⟶ X) :
+--     (α⁺ Y Z W).inv ≫ desc (desc f g) h = desc f (desc g h) := by
+--   cat_disch
+
+lemma addLeftUnitor_inv (X : C) : (λ⁺ X).inv = inr _ _ := by simp [inr_def]
+lemma addRightUnitor_inv (X : C) : (ρ⁺ X).inv = inl _ _ := by simp [inl_def]
+
+@[reassoc (attr := simp)]
+lemma inl_leftUnitor_hom (X : C) :
+    inl _ _ ≫ (λ⁺ X).hom = fromUnit _ := fromUnit_unique _ _
+
+@[reassoc (attr := simp)]
+lemma inr_leftUnitor_hom (X : C) :
+    inr _ _ ≫ (λ⁺ X).hom = 𝟙 X := by simp [inr_def]
+
+@[reassoc (attr := simp)]
+lemma inl_rightUnitor_hom (X : C) :
+    inl _ _ ≫ (ρ⁺ X).hom = 𝟙 X := by simp [inl_def]
+
+@[reassoc (attr := simp)]
+lemma inr_rightUnitor_hom (X : C) :
+    inr _ _ ≫ (ρ⁺ X).hom = fromUnit _ := fromUnit_unique _ _
+
+-- @[reassoc]
+-- lemma whiskerLeft_toUnit_comp_rightUnitor_hom (X Y : C) : X ◁ toUnit Y ≫ (ρ_ X).hom
+-- = fst X Y := by
+--   rw [← cancel_mono (ρ_ X).inv]; aesop
+
+-- @[reassoc]
+-- lemma whiskerRight_toUnit_comp_leftUnitor_hom (X Y : C) : toUnit X ▷ Y ≫ (λ_ Y).hom
+-- = snd X Y := by
+--   rw [← cancel_mono (λ_ Y).inv]; aesop
+
+-- @[reassoc (attr := simp)]
+-- lemma lift_leftUnitor_hom {X Y : C} (f : X ⟶ 𝟙_ C) (g : X ⟶ Y) :
+--     lift f g ≫ (λ_ Y).hom = g := by
+--   rw [← Iso.eq_comp_inv]
+--   cat_disch
+
+-- @[reassoc (attr := simp)]
+-- lemma lift_rightUnitor_hom {X Y : C} (f : X ⟶ Y) (g : X ⟶ 𝟙_ C) :
+--     lift f g ≫ (ρ_ Y).hom = f := by
+--   rw [← Iso.eq_comp_inv]
+--   cat_disch
+
+/-- Universal property of the coproduct: Maps from `X ⊕ Y` correspond to pairs of maps from `X`
+and from `Y`. -/
+@[simps]
+def homEquivToProd {X Y Z : C} : (X ⊕ₒ Y ⟶ Z) ≃ (X ⟶ Z) × (Y ⟶ Z) where
+  toFun f := ⟨inl _ _ ≫ f, inr _ _ ≫ f⟩
+  invFun f := desc f.1 f.2
+  left_inv _ := by simp
+  right_inv _ := by simp
+
+instance (priority := 100) : Limits.HasFiniteCoproducts C :=
+  letI : ∀ (X Y : C), Limits.HasColimit (Limits.pair X Y) := fun _ _ =>
+    .mk ⟨_, addHomIsBinaryCoproduct _ _⟩
+  letI : Limits.HasBinaryCoproducts C := Limits.hasBinaryCoproducts_of_hasColimit_pair _
+  letI : Limits.HasInitial C := Limits.hasInitial_of_unique (𝟘_ C)
+  hasFiniteCoproducts_of_has_binary_and_initial
+
+variable {P : ObjectProperty C}
+
+-- TODO: Introduce `ClosedUnderFiniteProducts`?
+/-- The restriction of a Cartesian-monoidal category along an object property that's closed under
+finite products is Cartesian-monoidal. -/
+noncomputable def fullSubcategory (hP₀ : ClosedUnderColimitsOfShape (Discrete PEmpty) P)
+    (hP₂ : ClosedUnderColimitsOfShape (Discrete WalkingPair) P) :
+    CocartesianMonoidalCategory P.FullSubcategory where
+  __ := AddMonoidalCategory.fullSubcategory P (hP₀ isInitialAddUnit <| by simp)
+    fun X Y hX hY ↦ hP₂ (addHomIsBinaryCoproduct X Y) (by rintro ⟨_ | _⟩ <;> simp [hX, hY])
+  isInitialAddUnit := .ofUniqueHom (fun X ↦ fromUnit X.1) fun _ _ ↦ by ext
+  inl X Y := inl X.1 Y.1
+  inr X Y := inr X.1 Y.1
+  addHomIsBinaryCoproduct X Y :=
+    BinaryCofan.IsColimit.mk _ (desc (C := C)) (inl_desc (C := C)) (inr_desc (C := C))
+      (by rintro T f g m rfl rfl; symm; exact desc_inl_inr_comp _)
+  inl_def X Y := inl_def X.1 Y.1
+  inr_def X Y := inr_def X.1 Y.1
+
+end CocartesianMonoidalCategory
+
+end CategoryTheory

--- a/Mathlib/CategoryTheory/Monoidal/Discrete.lean
+++ b/Mathlib/CategoryTheory/Monoidal/Discrete.lean
@@ -23,9 +23,8 @@ variable (M : Type u)
 
 namespace CategoryTheory
 
-abbrev DiscreteMonoidalCategory := MonoidalCategory (Discrete M)
-
-instance Discrete.monoidal [Monoid M] : DiscreteMonoidalCategory M where
+@[simps tensorObj_as leftUnitor rightUnitor associator]
+instance Discrete.monoidal [Monoid M] : MonoidalCategory (Discrete M) where
   tensorUnit := Discrete.mk 1
   tensorObj X Y := Discrete.mk (X.as * Y.as)
   whiskerLeft X _ _ f := eqToHom (by rw [eq_of_hom f])
@@ -35,7 +34,8 @@ instance Discrete.monoidal [Monoid M] : DiscreteMonoidalCategory M where
   rightUnitor X := Discrete.eqToIso (mul_one X.as)
   associator _ _ _ := Discrete.eqToIso (mul_assoc _ _ _)
 
-instance Discrete.addMonoidal [AddMonoid M] : DiscreteMonoidalCategory M where
+@[simps tensorObj_as leftUnitor rightUnitor associator]
+instance Discrete.addMonoidal [AddMonoid M] : MonoidalCategory (Discrete M) where
   tensorUnit := Discrete.mk 0
   tensorObj X Y := Discrete.mk (X.as + Y.as)
   whiskerLeft X _ _ f := eqToHom (by rw [eq_of_hom f])
@@ -51,11 +51,6 @@ lemma Discrete.monoidal_tensorUnit_as [Monoid M] : (𝟙_ (Discrete M)).as = 1 :
 @[simp]
 lemma Discrete.addMonoidal_tensorUnit_as [AddMonoid M] : (𝟙_ (Discrete M)).as = 0 := rfl
 
-attribute [
-  to_additive existing (attr := simps tensorObj_as leftUnitor rightUnitor associator)
-  Discrete.addMonoidal
-] Discrete.monoidal
-
 section Monoid
 
 variable [Monoid M]
@@ -65,11 +60,10 @@ variable {M} {N : Type u'} [Monoid N]
 /-- A multiplicative morphism between monoids gives a monoidal functor between the corresponding
 discrete monoidal categories.
 -/
-@[to_additive Discrete.addMonoidalFunctor]
 def Discrete.monoidalFunctor (F : M →* N) : Discrete M ⥤ Discrete N :=
   Discrete.functor (fun X ↦ Discrete.mk (F X))
 
-@[to_additive (attr := simp) Discrete.addMonoidalFunctor_obj]
+@[simp]
 lemma Discrete.monoidalFunctor_obj (F : M →* N) (m : M) :
     (Discrete.monoidalFunctor F).obj (Discrete.mk m) = Discrete.mk (F m) := rfl
 
@@ -104,9 +98,6 @@ variable {K : Type u} [Monoid K]
 
 /-- The monoidal natural isomorphism corresponding to composing two multiplicative morphisms.
 -/
-@[to_additive Discrete.addMonoidalFunctorComp
-      /-- The monoidal natural isomorphism corresponding to
-composing two additive morphisms. -/]
 def Discrete.monoidalFunctorComp (F : M →* N) (G : N →* K) :
     Discrete.monoidalFunctor F ⋙ Discrete.monoidalFunctor G ≅
       Discrete.monoidalFunctor (G.comp F) := Iso.refl _
@@ -129,42 +120,40 @@ variable [AddMonoid M]
 
 variable {M} {N : Type u'} [AddMonoid N]
 
+def Discrete.addMonoidalFunctor (F : M →+ N) : Discrete M ⥤ Discrete N :=
+  Discrete.functor (fun X ↦ Discrete.mk (F X))
+
+@[simp]
+lemma Discrete.addMonoidalFunctor_obj (F : M →+ N) (m : M) :
+    (Discrete.addMonoidalFunctor F).obj (Discrete.mk m) = Discrete.mk (F m) := rfl
+
 instance Discrete.addMonoidalFunctorMonoidal (F : M →+ N) :
     (Discrete.addMonoidalFunctor F).Monoidal :=
     Functor.CoreMonoidal.toMonoidal
       { εIso := Discrete.eqToIso F.map_zero.symm
         μIso := fun m₁ m₂ ↦ Discrete.eqToIso (F.map_add _ _).symm }
 
-attribute
-  [to_additive existing Discrete.addMonoidalFunctorMonoidal] Discrete.monoidalFunctorMonoidal
-
 open Functor.LaxMonoidal Functor.OplaxMonoidal
 
 lemma Discrete.addMonoidalFunctor_ε (F : M →+ N) :
     ε (addMonoidalFunctor F) = Discrete.eqToHom F.map_zero.symm := rfl
 
-attribute [to_additive existing Discrete.addMonoidalFunctor_ε] Discrete.monoidalFunctor_ε
-
 lemma Discrete.addMonoidalFunctor_η (F : M →+ N) :
     η (addMonoidalFunctor F) = Discrete.eqToHom F.map_zero := rfl
-
-attribute [to_additive existing Discrete.addMonoidalFunctor_η] Discrete.monoidalFunctor_η
 
 lemma Discrete.addMonoidalFunctor_μ (F : M →+ N) (m₁ m₂ : Discrete M) :
     μ (addMonoidalFunctor F) m₁ m₂ = Discrete.eqToHom (F.map_add _ _).symm := rfl
 
-attribute [to_additive existing Discrete.addMonoidalFunctor_μ] Discrete.monoidalFunctor_μ
-
 lemma Discrete.addMonoidalFunctor_δ (F : M →+ N) (m₁ m₂ : Discrete M) :
     δ (addMonoidalFunctor F) m₁ m₂ = Discrete.eqToHom (F.map_add _ _) := rfl
 
-attribute [to_additive existing Discrete.addMonoidalFunctor_δ] Discrete.monoidalFunctor_δ
+variable {K : Type u} [AddMonoid K]
 
 /-- An additive morphism between add_monoids gives a
 monoidal functor between the corresponding discrete monoidal categories. -/
-add_decl_doc Discrete.addMonoidalFunctor
-
-variable {K : Type u} [AddMonoid K]
+def Discrete.addMonoidalFunctorComp (F : M →+ N) (G : N →+ K) :
+    Discrete.addMonoidalFunctor F ⋙ Discrete.addMonoidalFunctor G ≅
+      Discrete.addMonoidalFunctor (G.comp F) := Iso.refl _
 
 instance Discrete.addMonoidalFunctorComp_isMonoidal (F : M →+ N) (G : N →+ K) :
     NatTrans.IsMonoidal (Discrete.addMonoidalFunctorComp F G).hom where

--- a/Mathlib/CategoryTheory/Monoidal/Discrete.lean
+++ b/Mathlib/CategoryTheory/Monoidal/Discrete.lean
@@ -102,7 +102,6 @@ def Discrete.monoidalFunctorComp (F : M →* N) (G : N →* K) :
     Discrete.monoidalFunctor F ⋙ Discrete.monoidalFunctor G ≅
       Discrete.monoidalFunctor (G.comp F) := Iso.refl _
 
---@[to_additive Discrete.addMonoidalFunctorComp_isMonoidal]
 instance Discrete.monoidalFunctorComp_isMonoidal (F : M →* N) (G : N →* K) :
     NatTrans.IsMonoidal (Discrete.monoidalFunctorComp F G).hom where
   unit := by

--- a/Mathlib/CategoryTheory/Monoidal/Discrete.lean
+++ b/Mathlib/CategoryTheory/Monoidal/Discrete.lean
@@ -78,15 +78,12 @@ open Functor.LaxMonoidal Functor.OplaxMonoidal
 lemma Discrete.monoidalFunctor_ε (F : M →* N) :
     ε (monoidalFunctor F) = Discrete.eqToHom F.map_one.symm := rfl
 
--- @[to_additive Discrete.addMonoidalFunctor_η]
 lemma Discrete.monoidalFunctor_η (F : M →* N) :
     η (monoidalFunctor F) = Discrete.eqToHom F.map_one := rfl
 
--- @[to_additive Discrete.addMonoidalFunctor_μ]
 lemma Discrete.monoidalFunctor_μ (F : M →* N) (m₁ m₂ : Discrete M) :
     μ (monoidalFunctor F) m₁ m₂ = Discrete.eqToHom (F.map_mul _ _).symm := rfl
 
--- @[to_additive Discrete.addMonoidalFunctor_δ]
 lemma Discrete.monoidalFunctor_δ (F : M →* N) (m₁ m₂ : Discrete M) :
     δ (monoidalFunctor F) m₁ m₂ = Discrete.eqToHom (F.map_mul _ _) := rfl
 

--- a/Mathlib/CategoryTheory/Monoidal/Discrete.lean
+++ b/Mathlib/CategoryTheory/Monoidal/Discrete.lean
@@ -120,6 +120,9 @@ variable [AddMonoid M]
 
 variable {M} {N : Type u'} [AddMonoid N]
 
+/-- An additive morphism between monoids gives a monoidal functor between the corresponding
+discrete monoidal categories.
+-/
 def Discrete.addMonoidalFunctor (F : M →+ N) : Discrete M ⥤ Discrete N :=
   Discrete.functor (fun X ↦ Discrete.mk (F X))
 

--- a/Mathlib/CategoryTheory/Monoidal/Discrete.lean
+++ b/Mathlib/CategoryTheory/Monoidal/Discrete.lean
@@ -19,12 +19,13 @@ universe u u'
 
 open CategoryTheory Discrete MonoidalCategory
 
-variable (M : Type u) [Monoid M]
+variable (M : Type u)
 
 namespace CategoryTheory
 
-@[to_additive (attr := simps tensorObj_as leftUnitor rightUnitor associator) Discrete.addMonoidal]
-instance Discrete.monoidal : MonoidalCategory (Discrete M) where
+abbrev DiscreteMonoidalCategory := MonoidalCategory (Discrete M)
+
+instance Discrete.monoidal [Monoid M] : DiscreteMonoidalCategory M where
   tensorUnit := Discrete.mk 1
   tensorObj X Y := Discrete.mk (X.as * Y.as)
   whiskerLeft X _ _ f := eqToHom (by rw [eq_of_hom f])
@@ -34,8 +35,30 @@ instance Discrete.monoidal : MonoidalCategory (Discrete M) where
   rightUnitor X := Discrete.eqToIso (mul_one X.as)
   associator _ _ _ := Discrete.eqToIso (mul_assoc _ _ _)
 
-@[to_additive (attr := simp) Discrete.addMonoidal_tensorUnit_as]
-lemma Discrete.monoidal_tensorUnit_as : (𝟙_ (Discrete M)).as = 1 := rfl
+instance Discrete.addMonoidal [AddMonoid M] : DiscreteMonoidalCategory M where
+  tensorUnit := Discrete.mk 0
+  tensorObj X Y := Discrete.mk (X.as + Y.as)
+  whiskerLeft X _ _ f := eqToHom (by rw [eq_of_hom f])
+  whiskerRight f X := eqToHom (by rw [eq_of_hom f])
+  tensorHom f g := eqToHom (by rw [eq_of_hom f, eq_of_hom g])
+  leftUnitor X := Discrete.eqToIso (zero_add X.as)
+  rightUnitor X := Discrete.eqToIso (add_zero X.as)
+  associator _ _ _ := Discrete.eqToIso (add_assoc _ _ _)
+
+@[simp]
+lemma Discrete.monoidal_tensorUnit_as [Monoid M] : (𝟙_ (Discrete M)).as = 1 := rfl
+
+@[simp]
+lemma Discrete.addMonoidal_tensorUnit_as [AddMonoid M] : (𝟙_ (Discrete M)).as = 0 := rfl
+
+attribute [
+  to_additive existing (attr := simps tensorObj_as leftUnitor rightUnitor associator)
+  Discrete.addMonoidal
+] Discrete.monoidal
+
+section Monoid
+
+variable [Monoid M]
 
 variable {M} {N : Type u'} [Monoid N]
 
@@ -50,7 +73,6 @@ def Discrete.monoidalFunctor (F : M →* N) : Discrete M ⥤ Discrete N :=
 lemma Discrete.monoidalFunctor_obj (F : M →* N) (m : M) :
     (Discrete.monoidalFunctor F).obj (Discrete.mk m) = Discrete.mk (F m) := rfl
 
-@[to_additive Discrete.addMonoidalFunctorMonoidal]
 instance Discrete.monoidalFunctorMonoidal (F : M →* N) :
     (Discrete.monoidalFunctor F).Monoidal :=
     Functor.CoreMonoidal.toMonoidal
@@ -59,25 +81,24 @@ instance Discrete.monoidalFunctorMonoidal (F : M →* N) :
 
 open Functor.LaxMonoidal Functor.OplaxMonoidal
 
-@[to_additive Discrete.addMonoidalFunctor_ε]
 lemma Discrete.monoidalFunctor_ε (F : M →* N) :
     ε (monoidalFunctor F) = Discrete.eqToHom F.map_one.symm := rfl
 
-@[to_additive Discrete.addMonoidalFunctor_η]
+-- @[to_additive Discrete.addMonoidalFunctor_η]
 lemma Discrete.monoidalFunctor_η (F : M →* N) :
     η (monoidalFunctor F) = Discrete.eqToHom F.map_one := rfl
 
-@[to_additive Discrete.addMonoidalFunctor_μ]
+-- @[to_additive Discrete.addMonoidalFunctor_μ]
 lemma Discrete.monoidalFunctor_μ (F : M →* N) (m₁ m₂ : Discrete M) :
     μ (monoidalFunctor F) m₁ m₂ = Discrete.eqToHom (F.map_mul _ _).symm := rfl
 
-@[to_additive Discrete.addMonoidalFunctor_δ]
+-- @[to_additive Discrete.addMonoidalFunctor_δ]
 lemma Discrete.monoidalFunctor_δ (F : M →* N) (m₁ m₂ : Discrete M) :
     δ (monoidalFunctor F) m₁ m₂ = Discrete.eqToHom (F.map_mul _ _) := rfl
 
-/-- An additive morphism between add_monoids gives a
-monoidal functor between the corresponding discrete monoidal categories. -/
-add_decl_doc Discrete.addMonoidalFunctor
+-- /-- An additive morphism between add_monoids gives a
+-- monoidal functor between the corresponding discrete monoidal categories. -/
+-- add_decl_doc Discrete.addMonoidalFunctor
 
 variable {K : Type u} [Monoid K]
 
@@ -90,7 +111,7 @@ def Discrete.monoidalFunctorComp (F : M →* N) (G : N →* K) :
     Discrete.monoidalFunctor F ⋙ Discrete.monoidalFunctor G ≅
       Discrete.monoidalFunctor (G.comp F) := Iso.refl _
 
-@[to_additive Discrete.addMonoidalFunctorComp_isMonoidal]
+--@[to_additive Discrete.addMonoidalFunctorComp_isMonoidal]
 instance Discrete.monoidalFunctorComp_isMonoidal (F : M →* N) (G : N →* K) :
     NatTrans.IsMonoidal (Discrete.monoidalFunctorComp F G).hom where
   unit := by
@@ -99,5 +120,61 @@ instance Discrete.monoidalFunctorComp_isMonoidal (F : M →* N) (G : N →* K) :
   tensor _ _ := by
     dsimp only [comp_μ, monoidalFunctorComp, Iso.refl, Discrete.monoidalFunctor_μ]
     simp [eqToHom_map]
+
+end Monoid
+
+section AddMonoid
+
+variable [AddMonoid M]
+
+variable {M} {N : Type u'} [AddMonoid N]
+
+instance Discrete.addMonoidalFunctorMonoidal (F : M →+ N) :
+    (Discrete.addMonoidalFunctor F).Monoidal :=
+    Functor.CoreMonoidal.toMonoidal
+      { εIso := Discrete.eqToIso F.map_zero.symm
+        μIso := fun m₁ m₂ ↦ Discrete.eqToIso (F.map_add _ _).symm }
+
+attribute
+  [to_additive existing Discrete.addMonoidalFunctorMonoidal] Discrete.monoidalFunctorMonoidal
+
+open Functor.LaxMonoidal Functor.OplaxMonoidal
+
+lemma Discrete.addMonoidalFunctor_ε (F : M →+ N) :
+    ε (addMonoidalFunctor F) = Discrete.eqToHom F.map_zero.symm := rfl
+
+attribute [to_additive existing Discrete.addMonoidalFunctor_ε] Discrete.monoidalFunctor_ε
+
+lemma Discrete.addMonoidalFunctor_η (F : M →+ N) :
+    η (addMonoidalFunctor F) = Discrete.eqToHom F.map_zero := rfl
+
+attribute [to_additive existing Discrete.addMonoidalFunctor_η] Discrete.monoidalFunctor_η
+
+lemma Discrete.addMonoidalFunctor_μ (F : M →+ N) (m₁ m₂ : Discrete M) :
+    μ (addMonoidalFunctor F) m₁ m₂ = Discrete.eqToHom (F.map_add _ _).symm := rfl
+
+attribute [to_additive existing Discrete.addMonoidalFunctor_μ] Discrete.monoidalFunctor_μ
+
+lemma Discrete.addMonoidalFunctor_δ (F : M →+ N) (m₁ m₂ : Discrete M) :
+    δ (addMonoidalFunctor F) m₁ m₂ = Discrete.eqToHom (F.map_add _ _) := rfl
+
+attribute [to_additive existing Discrete.addMonoidalFunctor_δ] Discrete.monoidalFunctor_δ
+
+/-- An additive morphism between add_monoids gives a
+monoidal functor between the corresponding discrete monoidal categories. -/
+add_decl_doc Discrete.addMonoidalFunctor
+
+variable {K : Type u} [AddMonoid K]
+
+instance Discrete.addMonoidalFunctorComp_isMonoidal (F : M →+ N) (G : N →+ K) :
+    NatTrans.IsMonoidal (Discrete.addMonoidalFunctorComp F G).hom where
+  unit := by
+    dsimp only [comp_ε, addMonoidalFunctorComp, Iso.refl, Discrete.addMonoidalFunctor_ε]
+    simp [eqToHom_map]
+  tensor _ _ := by
+    dsimp only [comp_μ, addMonoidalFunctorComp, Iso.refl, Discrete.addMonoidalFunctor_μ]
+    simp [eqToHom_map]
+
+end AddMonoid
 
 end CategoryTheory

--- a/Mathlib/Tactic/ToAdditive/GuessName.lean
+++ b/Mathlib/Tactic/ToAdditive/GuessName.lean
@@ -239,6 +239,46 @@ def fixAbbreviation : List String → List String
   | "sub" :: "Neg" :: "Zero" :: "Add" :: "Monoid" :: s => "subNegZeroMonoid" :: fixAbbreviation s
   | "modular" :: "Character" :: s => "addModularCharacter" :: fixAbbreviation s
   | "Modular" :: "Character" :: s => "AddModularCharacter" :: fixAbbreviation s
+  /-
+  This is a bit aggressive, but
+  - `hom_neg` doesn't appear in any `to_additive` context
+  - Changing `neg_hom` to `inv_hom` actually _fixes_ the naming of a few lemmas, e.g.
+     `AddGrp.neg_hom_apply`, without breaking anything else.
+  - We don't need to add any special cases for e.g. `pentagon_hom_hom_inv_hom_hom`
+
+  If desired, can just replace these with the special cases
+
+  Note that to deal with e.g. `pentagon_hom_inv_inv_inv_inv` I just special case `hom` followed by
+  up to four `neg`s, as well as `neg_hom_neg` and `neg_hom_neg_neg`. More robust handling would
+  just transform a string of negs before and after a `hom` into invs.
+  -/
+  | "neg" :: "_" :: "hom" :: "_" :: "neg" :: "_" :: "neg" :: s
+    => "inv" :: "_" :: "hom" :: "_" :: "inv" :: "_" :: "inv" :: fixAbbreviation s
+  -- | "neg" :: "_" :: "hom" :: "_" :: "neg" :: s
+  --   => "inv" :: "_" :: "hom" :: "_" :: "inv" :: fixAbbreviation s
+  | "hom" :: "_" :: "neg" :: "_" :: "neg" :: "_" :: "neg" :: "_" :: "neg" :: s
+    => "hom" :: "_" :: "inv" :: "_" :: "inv" :: "_" :: "inv" :: "_" :: "inv" :: fixAbbreviation s
+  | "hom" :: "_" :: "neg" :: "_" :: "neg" :: "_" :: "neg" :: s
+    => "hom" :: "_" :: "inv" :: "_" :: "inv" :: "_" :: "inv" :: fixAbbreviation s
+  | "hom" :: "_" :: "neg" :: "_" :: "neg" :: s
+     => "hom" :: "_" :: "inv" :: "_" :: "inv" :: fixAbbreviation s
+  | "hom" :: "_" :: "neg" :: s          => "hom" :: "_" :: "inv" :: fixAbbreviation s
+  | "neg" :: "_" :: "hom" :: s          => "inv" :: "_" :: "hom" :: fixAbbreviation s
+  -- Fixes both `leftAddUnitor_neg` and `rightAddUnitor_neg`
+  | "Add" :: "Unitor" :: "_" :: "neg" :: s => "AddUnitor" :: "_" :: "inv" :: fixAbbreviation s
+  -- Fixes both `neg_addWhiskerLeft` and `neg_addWhiskerRight`
+  | "neg" :: "_" :: "add" :: "Whisker" :: s => "inv" :: "_" :: "addWhisker" :: fixAbbreviation s
+  -- Fixes both `leftAddUnitor_add_neg` and `rightAddUnitor_add_neg`
+  | "Add" :: "Unitor" :: "_" :: "add" :: "_" :: "neg" :: s
+    => "AddUnitor" :: "_" :: "add" :: "_" :: "inv" :: fixAbbreviation s
+  | "add" :: "Whisker" :: "Left" :: "_" :: "neg" :: s => "addWhiskerLeft_inv" :: fixAbbreviation s
+  | "add" :: "Whisker" :: "Right" :: "_" :: "neg" :: s => "addWhiskerRight_inv" :: fixAbbreviation s
+  | "add" :: "Associator" :: "_" :: "neg" :: s => "addAssociator_inv" :: fixAbbreviation s
+  | "pentagon" :: "_" :: "neg" :: s => "pentagon_inv" :: fixAbbreviation s
+  | "triangle" :: "_" :: "assoc" :: "_" :: "comp" :: "_" :: "left" :: "_" :: "neg" :: s
+    => "triangle_assoc_comp_left_inv" :: fixAbbreviation s
+  | "triangle" :: "_" :: "assoc" :: "_" :: "comp" :: "_" :: "right" :: "_" :: "neg" :: s
+    => "triangle_assoc_comp_right_inv" :: fixAbbreviation s
   | x :: s                            => x :: fixAbbreviation s
   | []                                => []
 

--- a/Mathlib/Tactic/ToAdditive/GuessName.lean
+++ b/Mathlib/Tactic/ToAdditive/GuessName.lean
@@ -132,6 +132,13 @@ def nameDict : String → List String
   | "mconv"         => ["conv"]
   | "irreducible"   => ["add", "Irreducible"]
   | "mlconvolution" => ["lconvolution"]
+  | "tensor"        => ["add"]
+  | "tensoring"     => ["adding"]
+  | "whisker"       => ["add", "Whisker"]
+  | "associator"    => ["add", "Associator"]
+  | "unitor"        => ["add", "Unitor"]
+  | "pentagon"      => ["add", "Pentagon"]
+  | "triangle"      => ["add", "Triangle"]
   | x               => [x]
 
 /--

--- a/Mathlib/Tactic/ToAdditive/GuessName.lean
+++ b/Mathlib/Tactic/ToAdditive/GuessName.lean
@@ -137,8 +137,6 @@ def nameDict : String → List String
   | "whisker"       => ["add", "Whisker"]
   | "associator"    => ["add", "Associator"]
   | "unitor"        => ["add", "Unitor"]
-  | "pentagon"      => ["add", "Pentagon"]
-  | "triangle"      => ["add", "Triangle"]
   | x               => [x]
 
 /--

--- a/Mathlib/Tactic/ToAdditive/GuessName.lean
+++ b/Mathlib/Tactic/ToAdditive/GuessName.lean
@@ -137,6 +137,7 @@ def nameDict : String → List String
   | "whisker"       => ["add", "Whisker"]
   | "associator"    => ["add", "Associator"]
   | "unitor"        => ["add", "Unitor"]
+  | "monoidal"      => ["add", "Monoidal"]
   | x               => [x]
 
 /--


### PR DESCRIPTION
As discussed in #21603 and #28718; this implements chosen finite coproducts on top of `AddMonoidalCategory` as defined in #30150
---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include at least one commit authored by each
co-author among the commits in the pull request. If necessary, you may 
create empty commits to indicate co-authorship, using commands like so:

git commit --author="Author Name <author@email.com>" --allow-empty -m "add Author Name as coauthor"

When merging, all the commits will be squashed into a single commit listing all co-authors.

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->
- [ ] depends on: #30150 
[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
