### PR TITLE
[Merged by Bors] - feat(RingTheory/Valuation/ValuativeRel): strict valuative relation

### DIFF
--- a/Mathlib/RingTheory/Valuation/ValuativeRel/Basic.lean
+++ b/Mathlib/RingTheory/Valuation/ValuativeRel/Basic.lean
@@ -101,6 +101,15 @@ namespace ValuativeRel
 
 variable {R : Type*} [CommRing R] [ValuativeRel R]
 
+/-- The strict version of the valuative relation. -/
+def rel_lt (x y : R) : Prop := x ≤ᵥ y ∧ ¬ y ≤ᵥ x
+
+@[inherit_doc] infix:50 " <ᵥ " => ValuativeRel.rel_lt
+
+macro_rules | `($a <ᵥ $b) => `(binrel% ValuativeRel.rel_lt $a $b)
+
+lemma rel_lt_iff (x y : R) : x <ᵥ y ↔ x ≤ᵥ y ∧ ¬ y ≤ᵥ x := Iff.rfl
+
 @[simp]
 lemma rel_refl (x : R) : x ≤ᵥ x := by
   cases rel_total x x <;> assumption
@@ -421,8 +430,7 @@ instance : LinearOrder (ValueGroupWithZero R) where
 
 @[simp]
 theorem ValueGroupWithZero.mk_lt_mk (x y : R) (t s : posSubmonoid R) :
-    ValueGroupWithZero.mk x t < ValueGroupWithZero.mk y s ↔
-      x * s ≤ᵥ y * t ∧ ¬ y * t ≤ᵥ x * s :=
+    ValueGroupWithZero.mk x t < ValueGroupWithZero.mk y s ↔ x * s <ᵥ y * t :=
   Iff.rfl
 
 instance : Bot (ValueGroupWithZero R) where
@@ -551,6 +559,11 @@ lemma isEquiv {Γ₁ Γ₂ : Type*}
     v₁.IsEquiv v₂ := by
   intro x y
   simp_rw [← Valuation.Compatible.rel_iff_le]
+
+lemma _root_.Valuation.Compatible.rel_lt_iff_lt {Γ₀ : Type*}
+    [LinearOrderedCommMonoidWithZero Γ₀] {v : Valuation R Γ₀} [v.Compatible] {x y : R} :
+    x <ᵥ y ↔ v x < v y := by
+  simp [lt_iff_le_not_ge, ← Valuation.Compatible.rel_iff_le, rel_lt_iff]
 
 @[simp]
 lemma _root_.Valuation.apply_posSubmonoid_ne_zero {Γ : Type*} [LinearOrderedCommMonoidWithZero Γ]

--- a/Mathlib/RingTheory/Valuation/ValuativeRel/Basic.lean
+++ b/Mathlib/RingTheory/Valuation/ValuativeRel/Basic.lean
@@ -153,7 +153,7 @@ lemma rel_mul {x x' y y' : R} (h1 : x ≤ᵥ y) (h2 : x' ≤ᵥ y') : (x * x') �
 theorem rel_add_cases (x y : R) : x + y ≤ᵥ x ∨ x + y ≤ᵥ y :=
   (rel_total y x).imp (fun h => rel_add .rfl h) (fun h => rel_add h .rfl)
 
-lemma zero_srel_mul_of_zero_srel {x y : R} (hx : 0 <ᵥ x) (hy : 0 <ᵥ y) : 0 <ᵥ x * y := by
+lemma zero_srel_mul {x y : R} (hx : 0 <ᵥ x) (hy : 0 <ᵥ y) : 0 <ᵥ x * y := by
   contrapose! hy
   rw [not_srel_iff] at hy ⊢
   rw [show (0 : R) = x * 0 by simp, mul_comm x y, mul_comm x 0] at hy
@@ -163,7 +163,7 @@ variable (R) in
 /-- The submonoid of elements `x : R` whose valuation is positive. -/
 def posSubmonoid : Submonoid R where
   carrier := { x | 0 <ᵥ x }
-  mul_mem' := zero_srel_mul_of_zero_srel
+  mul_mem' := zero_srel_mul
   one_mem' := zero_srel_one
 
 @[simp]
@@ -440,9 +440,7 @@ instance : LinearOrder (ValueGroupWithZero R) where
 @[simp]
 theorem ValueGroupWithZero.mk_lt_mk (x y : R) (t s : posSubmonoid R) :
     ValueGroupWithZero.mk x t < ValueGroupWithZero.mk y s ↔ x * s <ᵥ y * t := by
-  rw [lt_iff_le_not_ge, srel_iff]
-  refine and_iff_right_iff_imp.mpr ?_
-  exact (rel_total _ _).resolve_right
+  rw [lt_iff_not_ge, srel_iff, mk_le_mk]
 
 instance : Bot (ValueGroupWithZero R) where
   bot := 0
@@ -574,8 +572,7 @@ lemma isEquiv {Γ₁ Γ₂ : Type*}
 lemma _root_.Valuation.Compatible.srel_iff_lt {Γ₀ : Type*}
     [LinearOrderedCommMonoidWithZero Γ₀] {v : Valuation R Γ₀} [v.Compatible] {x y : R} :
     x <ᵥ y ↔ v x < v y := by
-  simpa [lt_iff_le_not_ge, ← Valuation.Compatible.rel_iff_le, srel_iff] using
-    (rel_total _ _).resolve_right
+  simp [lt_iff_not_ge, ← Valuation.Compatible.rel_iff_le, srel_iff]
 
 @[simp]
 lemma _root_.Valuation.apply_posSubmonoid_ne_zero {Γ : Type*} [LinearOrderedCommMonoidWithZero Γ]

--- a/Mathlib/RingTheory/Valuation/ValuativeRel/Basic.lean
+++ b/Mathlib/RingTheory/Valuation/ValuativeRel/Basic.lean
@@ -102,16 +102,16 @@ namespace ValuativeRel
 variable {R : Type*} [CommRing R] [ValuativeRel R]
 
 /-- The strict version of the valuative relation. -/
-def rel_lt (x y : R) : Prop := ¬ y ≤ᵥ x
+def srel (x y : R) : Prop := ¬ y ≤ᵥ x
 
-@[inherit_doc] infix:50 " <ᵥ " => ValuativeRel.rel_lt
+@[inherit_doc] infix:50 " <ᵥ " => ValuativeRel.srel
 
-macro_rules | `($a <ᵥ $b) => `(binrel% ValuativeRel.rel_lt $a $b)
+macro_rules | `($a <ᵥ $b) => `(binrel% ValuativeRel.srel $a $b)
 
-lemma rel_lt_iff (x y : R) : x <ᵥ y ↔ ¬ y ≤ᵥ x := Iff.rfl
+lemma srel_iff (x y : R) : x <ᵥ y ↔ ¬ y ≤ᵥ x := Iff.rfl
 
 @[simp]
-lemma not_rel_lt_iff {x y : R} : ¬ (x <ᵥ y) ↔ y ≤ᵥ x := Iff.rfl.not_left
+lemma not_srel_iff {x y : R} : ¬ x <ᵥ y ↔ y ≤ᵥ x := Iff.rfl.not_left
 
 @[simp]
 lemma rel_refl (x : R) : x ≤ᵥ x := by
@@ -129,7 +129,7 @@ theorem zero_rel (x : R) : 0 ≤ᵥ x := by
   simpa using rel_mul_right x ((rel_total 0 1).resolve_right not_rel_one_zero)
 
 @[simp]
-lemma zero_rel_lt_one : (0 : R) <ᵥ 1 :=
+lemma zero_srel_one : (0 : R) <ᵥ 1 :=
   not_rel_one_zero
 
 lemma rel_mul_left {x y : R} (z) : x ≤ᵥ y → (z * x) ≤ᵥ (z * y) := by
@@ -153,21 +153,21 @@ lemma rel_mul {x x' y y' : R} (h1 : x ≤ᵥ y) (h2 : x' ≤ᵥ y') : (x * x') �
 theorem rel_add_cases (x y : R) : x + y ≤ᵥ x ∨ x + y ≤ᵥ y :=
   (rel_total y x).imp (fun h => rel_add .rfl h) (fun h => rel_add h .rfl)
 
-lemma zero_rel_lt_mul_of_zero_rel_lt {x y : R} (hx : 0 <ᵥ x) (hy : 0 <ᵥ y) : 0 <ᵥ x * y := by
+lemma zero_srel_mul_of_zero_srel {x y : R} (hx : 0 <ᵥ x) (hy : 0 <ᵥ y) : 0 <ᵥ x * y := by
   contrapose! hy
-  rw [not_rel_lt_iff] at hy ⊢
+  rw [not_srel_iff] at hy ⊢
   rw [show (0 : R) = x * 0 by simp, mul_comm x y, mul_comm x 0] at hy
   exact rel_mul_cancel hx hy
 
 variable (R) in
 /-- The submonoid of elements `x : R` whose valuation is positive. -/
 def posSubmonoid : Submonoid R where
-  carrier := { x | 0 <ᵥ x}
-  mul_mem' := zero_rel_lt_mul_of_zero_rel_lt
-  one_mem' := zero_rel_lt_one
+  carrier := { x | 0 <ᵥ x }
+  mul_mem' := zero_srel_mul_of_zero_srel
+  one_mem' := zero_srel_one
 
 @[simp]
-lemma posSubmonoid_def (x : R) : x ∈ posSubmonoid R ↔ ¬ x ≤ᵥ 0 := Iff.refl _
+lemma posSubmonoid_def (x : R) : x ∈ posSubmonoid R ↔ 0 <ᵥ x := Iff.rfl
 
 @[simp]
 lemma right_cancel_posSubmonoid (x y : R) (u : posSubmonoid R) :
@@ -440,7 +440,7 @@ instance : LinearOrder (ValueGroupWithZero R) where
 @[simp]
 theorem ValueGroupWithZero.mk_lt_mk (x y : R) (t s : posSubmonoid R) :
     ValueGroupWithZero.mk x t < ValueGroupWithZero.mk y s ↔ x * s <ᵥ y * t := by
-  rw [lt_iff_le_not_ge, rel_lt_iff]
+  rw [lt_iff_le_not_ge, srel_iff]
   refine and_iff_right_iff_imp.mpr ?_
   exact (rel_total _ _).resolve_right
 
@@ -571,10 +571,10 @@ lemma isEquiv {Γ₁ Γ₂ : Type*}
   intro x y
   simp_rw [← Valuation.Compatible.rel_iff_le]
 
-lemma _root_.Valuation.Compatible.rel_lt_iff_lt {Γ₀ : Type*}
+lemma _root_.Valuation.Compatible.srel_iff_lt {Γ₀ : Type*}
     [LinearOrderedCommMonoidWithZero Γ₀] {v : Valuation R Γ₀} [v.Compatible] {x y : R} :
     x <ᵥ y ↔ v x < v y := by
-  simpa [lt_iff_le_not_ge, ← Valuation.Compatible.rel_iff_le, rel_lt_iff] using
+  simpa [lt_iff_le_not_ge, ← Valuation.Compatible.rel_iff_le, srel_iff] using
     (rel_total _ _).resolve_right
 
 @[simp]
@@ -714,9 +714,9 @@ lemma exists_valuation_posSubmonoid_div_valuation_posSubmonoid_eq (γ : (ValueGr
     ∃ (a b : posSubmonoid R), valuation R a / valuation _ (b : R) = γ := by
   obtain ⟨a, b, hab⟩ := exists_valuation_div_valuation_eq γ.val
   lift a to posSubmonoid R using by
-    rw [posSubmonoid_def, ← valuation_eq_zero_iff]
-    intro H
-    simp [H, eq_comm] at hab
+    contrapose! hab
+    rw [posSubmonoid_def, not_srel_iff, ← valuation_eq_zero_iff] at hab
+    simp [hab, eq_comm]
   use a, b
 
 -- See `exists_valuation_div_valuation_eq` for the version that works for all rings.
@@ -809,13 +809,17 @@ variable {A B : Type*} [CommRing A] [CommRing B]
   [ValuativeRel A] [ValuativeRel B] [Algebra A B]
   [ValuativeExtension A B]
 
+lemma srel_iff_srel (a b : A) :
+    algebraMap A B a <ᵥ algebraMap A B b ↔ a <ᵥ b := by
+  rw [srel_iff, rel_iff_rel, srel_iff]
+
 variable (A B) in
 /-- The morphism of `posSubmonoid`s associated to an algebra map.
   This is used in constructing `ValuativeExtension.mapValueGroupWithZero`. -/
 @[simps]
 def mapPosSubmonoid : posSubmonoid A →* posSubmonoid B where
   toFun := fun ⟨a,ha⟩ => ⟨algebraMap _ _ a,
-    by simpa only [posSubmonoid_def, ← (algebraMap A B).map_zero, rel_iff_rel] using ha⟩
+    by simpa only [posSubmonoid_def, ← (algebraMap A B).map_zero, srel_iff_srel] using ha⟩
   map_one' := by simp
   map_mul' := by simp
 


### PR DESCRIPTION
extracted out of #27163

a way of discussing unbundled `posSubmonoid`


---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include at least one commit authored by each
co-author among the commits in the pull request. If necessary, you may 
create empty commits to indicate co-authorship, using commands like so:

git commit --author="Author Name <author@email.com>" --allow-empty -m "add Author Name as coauthor"

When merging, all the commits will be squashed into a single commit listing all co-authors.

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
