### PR TITLE
[Merged by Bors] - chore(Data/Int): deprecate `ediv_ediv_eq_ediv_mul`

### DIFF
--- a/Mathlib/Data/Int/DivMod.lean
+++ b/Mathlib/Data/Int/DivMod.lean
@@ -4,6 +4,7 @@ Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Kim Morrison
 -/
 
+import Batteries.Tactic.Alias
 import Mathlib.Init
 
 /-!
@@ -22,36 +23,14 @@ theorem mul_ediv_le_mul_ediv_assoc {a : Int} (ha : 0 ≤ a) (b : Int) {c : Int} 
   · rw [Int.le_ediv_iff_mul_le hlt, Int.mul_assoc]
     exact Int.mul_le_mul_of_nonneg_left (Int.ediv_mul_le b (Int.ne_of_gt hlt)) ha
 
-theorem ediv_ediv_eq_ediv_mul (m : Int) {n k : Int} (hn : 0 ≤ n) :
-    m / n / k = m / (n * k) := by
-  have {k : Int} (hk : 0 < k) : m / n / k = m / (n * k) := by
-    obtain rfl | hn' : n = 0 ∨ 0 < n := by cutsat
-    · simp
-    · apply Int.le_antisymm
-      · apply Int.le_ediv_of_mul_le (Int.mul_pos hn' hk)
-        calc
-          m / n / k * (n * k) = m / n / k * k * n := by ac_rfl
-          _ ≤ m / n * n :=
-            Int.mul_le_mul_of_nonneg_right (Int.ediv_mul_le (m / n) (Int.ne_of_gt hk)) hn
-          _ ≤ m :=
-            Int.ediv_mul_le m (Int.ne_of_gt hn')
-      · apply Int.le_ediv_of_mul_le hk
-        rw [← Int.mul_ediv_mul_of_pos_left m n hk, Int.mul_comm m k, Int.mul_comm (_ / _) k]
-        apply Int.mul_ediv_le_mul_ediv_assoc
-        · exact Int.le_of_lt hk
-        · exact Int.le_of_lt <| Int.mul_pos hn' hk
-  · rcases Int.lt_trichotomy 0 k with hk | rfl | hk
-    · exact this hk
-    · simp
-    · rw [← Int.neg_neg (m / n / k), ← Int.ediv_neg, this (Int.neg_pos_of_neg hk), ← Int.ediv_neg,
-        Int.mul_neg, Int.neg_neg]
+@[deprecated (since := "2025-10-06")] alias ediv_ediv_eq_ediv_mul := ediv_ediv
 
 theorem fdiv_fdiv_eq_fdiv_mul (m : Int) {n k : Int} (hn : 0 ≤ n) (hk : 0 ≤ k) :
     (m.fdiv n).fdiv k = m.fdiv (n * k) := by
   rw [Int.fdiv_eq_ediv_of_nonneg _ hn,
     Int.fdiv_eq_ediv_of_nonneg _ hk,
     Int.fdiv_eq_ediv_of_nonneg _ (Int.mul_nonneg hn hk),
-    ediv_ediv_eq_ediv_mul _ hn]
+    ediv_ediv hn]
 
 /-! ### `emod` -/
 


### PR DESCRIPTION
---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include at least one commit authored by each
co-author among the commits in the pull request. If necessary, you may 
create empty commits to indicate co-authorship, using commands like so:

git commit --author="Author Name <author@email.com>" --allow-empty -m "add Author Name as coauthor"

When merging, all the commits will be squashed into a single commit listing all co-authors.

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
