### PR TITLE
[Merged by Bors] - ci: remove "CI Success" job

### DIFF
--- a/.github/build.in.yml
+++ b/.github/build.in.yml
@@ -671,16 +671,6 @@ jobs:
           lint-bib-file: true
           ref: ${{ PR_BRANCH_REF }}
 
-  build_and_lint:
-    name: CI Success
-    if: FORK_CONDITION
-    needs: [style_lint, post_steps]
-    runs-on: ubuntu-latest
-    steps:
-      - name: succeed
-        run: |
-          echo "Success: Required build and lint checks completed!"
-
   final:
     name: Post-CI jobJOB_NAME
     if: FORK_CONDITION

--- a/.github/workflows/bors.yml
+++ b/.github/workflows/bors.yml
@@ -681,16 +681,6 @@ jobs:
           lint-bib-file: true
           ref: ${{ github.sha }}
 
-  build_and_lint:
-    name: CI Success
-    if: github.repository == 'leanprover-community/mathlib4' || github.repository == 'leanprover-community/mathlib4-nightly-testing'
-    needs: [style_lint, post_steps]
-    runs-on: ubuntu-latest
-    steps:
-      - name: succeed
-        run: |
-          echo "Success: Required build and lint checks completed!"
-
   final:
     name: Post-CI job
     if: github.repository == 'leanprover-community/mathlib4' || github.repository == 'leanprover-community/mathlib4-nightly-testing'

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -688,16 +688,6 @@ jobs:
           lint-bib-file: true
           ref: ${{ github.sha }}
 
-  build_and_lint:
-    name: CI Success
-    if: github.repository == 'leanprover-community/mathlib4' || github.repository == 'leanprover-community/mathlib4-nightly-testing'
-    needs: [style_lint, post_steps]
-    runs-on: ubuntu-latest
-    steps:
-      - name: succeed
-        run: |
-          echo "Success: Required build and lint checks completed!"
-
   final:
     name: Post-CI job
     if: github.repository == 'leanprover-community/mathlib4' || github.repository == 'leanprover-community/mathlib4-nightly-testing'

--- a/.github/workflows/build_fork.yml
+++ b/.github/workflows/build_fork.yml
@@ -685,16 +685,6 @@ jobs:
           lint-bib-file: true
           ref: ${{ github.event.pull_request.head.sha }}
 
-  build_and_lint:
-    name: CI Success
-    if: github.event.pull_request.head.repo.fork
-    needs: [style_lint, post_steps]
-    runs-on: ubuntu-latest
-    steps:
-      - name: succeed
-        run: |
-          echo "Success: Required build and lint checks completed!"
-
   final:
     name: Post-CI job (fork)
     if: github.event.pull_request.head.repo.fork

--- a/bors.toml
+++ b/bors.toml
@@ -1,4 +1,4 @@
-status = ["CI Success"]
+status = ["Build", "Lint style", "Post-Build Step"]
 use_squash_merge = true
 timeout_sec = 28800
 block_labels = ["WIP", "blocked-by-other-PR", "merge-conflict", "awaiting-CI", "bench-after-CI"]


### PR DESCRIPTION
Currently we have a job named "CI Success" which passes if and only if the "Lint style" and the "Post-Build Step" succeed. This was added in #25614 when we moved to a fork-based contribution model because I thought that bors would have trouble recognizing CI jobs on PRs from forks, since those job names end with "(fork)".

However, this was wrong: in fact, the `status` field in `bors.toml` only checks that the required status checks pass on the `staging` branch and doesn't apply to the PR branches at all. (There is a separate config field named `pr_status`, which checks that commits on PR branches have passed certain CI checks before `bors r+` works on them, but we haven't been using this.) 

The downside of only having "CI Success" in the `status` field is that when an earlier job fails, bors won't be able to link to the logs of that run in the comments it posts on GitHub and Zulip. We could just add all of the earlier jobs to `status` and keep "CI Success", but since my original concern was unfounded, I've opted to just remove the unnecessary job completely and replace the `status` field with all "Build", "Lint style" and "Post-Build Step" so that all of the logs are easily available again.

Thanks to @kckennylau for bringing this up in [#mathlib4 > Build failed: CI Success](https://leanprover.zulipchat.com/#narrow/channel/287929-mathlib4/topic/Build.20failed.3A.20CI.20Success/with/543367124).

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include at least one commit authored by each
co-author among the commits in the pull request. If necessary, you may 
create empty commits to indicate co-authorship, using commands like so:

git commit --author="Author Name <author@email.com>" --allow-empty -m "add Author Name as coauthor"

When merging, all the commits will be squashed into a single commit listing all co-authors.

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
