### PR TITLE
[Merged by Bors] - chore: document Spec(R) notation in docstring of Spec

### DIFF
--- a/Mathlib/AlgebraicGeometry/Scheme.lean
+++ b/Mathlib/AlgebraicGeometry/Scheme.lean
@@ -413,6 +413,19 @@ lemma Hom.copyBase_eq {X Y : Scheme} (f : X.Hom Y) (g : X → Y) (h : f.base = g
 end Scheme
 
 /-- The spectrum of a commutative ring, as a scheme.
+
+The notation `Spec(R)` for `(R : Type*) [CommRing R]` to mean `Spec (CommRingCat.of R)` is
+enabled in the scope `SpecOfNotation`. Please do not use it within Mathlib, but it can be
+used in downstream projects if desired. To use this, do:
+```lean
+import Mathlib.AlgebraicGeometry.Scheme
+
+variable (R : Type*) [CommRing R]
+
+open scoped SpecOfNotation
+
+#check Spec(R)
+```
 -/
 def Spec (R : CommRingCat) : Scheme where
   local_affine _ := ⟨⟨⊤, trivial⟩, R, ⟨(Spec.toLocallyRingedSpace.obj (op R)).restrictTopIso⟩⟩


### PR DESCRIPTION
#30272 changed the `Spec(R)` notation to scoped, so I am including this new information in the docstring of `AlgebraicGeometry.Spec`.

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include at least one commit authored by each
co-author among the commits in the pull request. If necessary, you may 
create empty commits to indicate co-authorship, using commands like so:

git commit --author="Author Name <author@email.com>" --allow-empty -m "add Author Name as coauthor"

When merging, all the commits will be squashed into a single commit listing all co-authors.

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
