### PR TITLE
[Merged by Bors] - chore: Rename Proj.openCoverOfIsOpenCover to Proj.affineOpenCoverOfIrrelevantLESpan

### DIFF
--- a/Mathlib/AlgebraicGeometry/ProjectiveSpectrum/Basic.lean
+++ b/Mathlib/AlgebraicGeometry/ProjectiveSpectrum/Basic.lean
@@ -316,7 +316,7 @@ open TopologicalSpace.Opens in
 /-- Given a family of homogeneous elements `f` of positive degree that spans the irrelevant ideal,
 `Spec (A_f)₀ ⟶ Proj A` forms an affine open cover of `Proj A`. -/
 noncomputable
-def openCoverOfIsOpenCover {ι : Type*} (f : ι → A) {m : ι → ℕ}
+def affineOpenCoverOfIrrelevantLESpan {ι : Type*} (f : ι → A) {m : ι → ℕ}
     (f_deg : ∀ i, f i ∈ 𝒜 (m i)) (hm : ∀ i, 0 < m i)
     (hf : (HomogeneousIdeal.irrelevant 𝒜).toIdeal ≤ Ideal.span (Set.range f)) :
     (Proj 𝒜).AffineOpenCover where
@@ -328,6 +328,9 @@ def openCoverOfIsOpenCover {ι : Type*} (f : ι → A) {m : ι → ℕ}
     change x ∈ (awayι 𝒜 _ _ _).opensRange
     rw [opensRange_awayι]
     exact (mem_iSup.mp ((iSup_basicOpen_eq_top 𝒜 f hf).ge (Set.mem_univ x))).choose_spec
+
+@[deprecated (since := "2025-10-07")]
+noncomputable alias openCoverOfISupEqTop := affineOpenCoverOfIrrelevantLESpan
 
 /-- `Proj A` is covered by `Spec (A_f)₀` for all homogeneous elements of positive degree. -/
 noncomputable

--- a/Mathlib/AlgebraicGeometry/ProjectiveSpectrum/Basic.lean
+++ b/Mathlib/AlgebraicGeometry/ProjectiveSpectrum/Basic.lean
@@ -335,8 +335,8 @@ noncomputable alias openCoverOfISupEqTop := affineOpenCoverOfIrrelevantLESpan
 /-- `Proj A` is covered by `Spec (A_f)₀` for all homogeneous elements of positive degree. -/
 noncomputable
 def affineOpenCover : (Proj 𝒜).AffineOpenCover :=
-  openCoverOfIsOpenCover 𝒜 (ι := Σ i : PNat, 𝒜 i) (m := fun i ↦ i.1) (fun i ↦ i.2) (fun i ↦ i.2.2)
-    (fun i ↦ i.1.2) <| by
+  affineOpenCoverOfIrrelevantLESpan 𝒜
+    (ι := Σ i : PNat, 𝒜 i) (m := fun i ↦ i.1) (fun i ↦ i.2) (fun i ↦ i.2.2) (fun i ↦ i.1.2) <| by
   classical
   intro z hz
   rw [← DirectSum.sum_support_decompose 𝒜 z]

--- a/Mathlib/AlgebraicGeometry/ProjectiveSpectrum/Proper.lean
+++ b/Mathlib/AlgebraicGeometry/ProjectiveSpectrum/Proper.lean
@@ -85,8 +85,8 @@ instance isSeparated : IsSeparated (toSpecZero 𝒜) := by
         ((affineOpenCover 𝒜).f j ≫ toSpecZero 𝒜) ≅
         Spec (.of <| TensorProduct (𝒜 0) (Away 𝒜 i.2) (Away 𝒜 j.2)) := by
     refine pullback.congrHom ?_ ?_ ≪≫ pullbackSpecIso (𝒜 0) (Away 𝒜 i.2) (Away 𝒜 j.2)
-    · simp [affineOpenCover, openCoverOfIsOpenCover, awayι_toSpecZero]; rfl
-    · simp [affineOpenCover, openCoverOfIsOpenCover, awayι_toSpecZero]; rfl
+    · simp [affineOpenCover, affineOpenCoverOfIrrelevantLESpan, awayι_toSpecZero]; rfl
+    · simp [affineOpenCover, affineOpenCoverOfIrrelevantLESpan, awayι_toSpecZero]; rfl
   let e₂ : pullback ((affineOpenCover 𝒜).f i) ((affineOpenCover 𝒜).f j) ≅
         Spec (.of <| Away 𝒜 (i.2 * j.2)) :=
     pullbackAwayιIso 𝒜 _ _ _ _ rfl


### PR DESCRIPTION
#30072 renamed `AlgebraicGeometry.Scheme.openCoverOfISupEqTop` to `AlgebraicGeometry.Scheme.openCoverOfIsOpenCover` with deprecation, but it also moved `AlgebraicGeometry.Proj.openCoverOfISupEqTop` to `AlgebraicGeometry.Proj.openCoverOfIsOpenCover` by [accident](https://leanprover.zulipchat.com/#narrow/channel/287929-mathlib4/topic/Proj.2EopenCoverOfISupEqTop/near/543421929), and without deprecation.

This PR is a partial revert of that Proj renaming, but also renames it to the [more sensible](https://leanprover.zulipchat.com/#narrow/channel/287929-mathlib4/topic/Proj.2EopenCoverOfISupEqTop/near/543422249) `Proj.affineOpenCoverOfIrrelevantLESpan`.

Deprecation is added for the old name `Proj.openCoverOfISupEqTop`, but not for the current `Proj.openCoverOfIsOpenCover`, because this current erroneous `Proj.openCoverOfIsOpenCover` has only existed for 4 days.


---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include at least one commit authored by each
co-author among the commits in the pull request. If necessary, you may 
create empty commits to indicate co-authorship, using commands like so:

git commit --author="Author Name <author@email.com>" --allow-empty -m "add Author Name as coauthor"

When merging, all the commits will be squashed into a single commit listing all co-authors.

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
