### PR TITLE
[Merged by Bors] - refactor: Category.Filtered.Small: avoid reducing wfrec

### DIFF
--- a/Mathlib/CategoryTheory/Filtered/Small.lean
+++ b/Mathlib/CategoryTheory/Filtered/Small.lean
@@ -79,10 +79,7 @@ private noncomputable def inductiveStepRealization (n : ℕ)
 
 /--
 All steps of building the abstract filtered closure together with the realization function,
-as a function of `ℕ`.
-
-The function is defined by well-founded recursion, but we really want to use its
-definitional equalities in the proofs below, so lets make it semireducible. -/
+as a function of `ℕ`.  -/
 private noncomputable def bundledAbstractFilteredClosure :
     ℕ → Σ t : Type (max v w), t → C
   | 0 => ⟨ULift.{v} α, f ∘ ULift.down⟩
@@ -230,11 +227,8 @@ private noncomputable def inductiveStepRealization (n : ℕ)
   | (InductiveStep.eq _ _ _ _ f g) => eq f g
 
 /-- Implementation detail for the instance
-`EssentiallySmall.{max v w} (FullSubcategory (cofilteredClosure f))`.
-
-The function is defined by well-founded recursion, but we really want to use its
-definitional equalities in the proofs below, so lets make it semireducible. -/
-@[semireducible] private noncomputable def bundledAbstractCofilteredClosure :
+`EssentiallySmall.{max v w} (FullSubcategory (cofilteredClosure f))`. -/
+private noncomputable def bundledAbstractCofilteredClosure :
     ℕ → Σ t : Type (max v w), t → C
   | 0 => ⟨ULift.{v} α, f ∘ ULift.down⟩
   | (n + 1) => ⟨_, inductiveStepRealization (n + 1) (fun m _ => bundledAbstractCofilteredClosure m)⟩
@@ -258,20 +252,35 @@ theorem small_fullSubcategory_cofilteredClosure :
     (fun _ _ => ObjectProperty.FullSubcategory.ext) ?_
   rintro ⟨j, h⟩
   induction h with
-  | base x => exact ⟨⟨0, ⟨x⟩⟩, rfl⟩
+  | base x =>
+    refine ⟨⟨0, ?_⟩,?_⟩
+    · simp only [CofilteredClosureSmall.bundledAbstractCofilteredClosure]
+      exact ULift.up x
+    · simp only [CofilteredClosureSmall.abstractCofilteredClosureRealization]
+      rw! [CofilteredClosureSmall.bundledAbstractCofilteredClosure]
+      rfl
   | min hj₁ hj₂ ih ih' =>
     rcases ih with ⟨⟨n, x⟩, rfl⟩
     rcases ih' with ⟨⟨m, y⟩, rfl⟩
-    refine ⟨⟨(Max.max n m).succ, CofilteredClosureSmall.InductiveStep.min ?_ ?_ x y⟩, rfl⟩
-    all_goals apply Nat.lt_succ_of_le
-    exacts [Nat.le_max_left _ _, Nat.le_max_right _ _]
+    refine ⟨⟨(Max.max n m).succ, ?_⟩, ?_⟩
+    · simp only [CofilteredClosureSmall.bundledAbstractCofilteredClosure]
+      refine CofilteredClosureSmall.InductiveStep.min ?_ ?_ x y
+      all_goals apply Nat.lt_succ_of_le
+      exacts [Nat.le_max_left _ _, Nat.le_max_right _ _]
+    · simp only [CofilteredClosureSmall.abstractCofilteredClosureRealization]
+      rw! [CofilteredClosureSmall.bundledAbstractCofilteredClosure]
+      rfl
   | eq hj₁ hj₂ g g' ih ih' =>
     rcases ih with ⟨⟨n, x⟩, rfl⟩
     rcases ih' with ⟨⟨m, y⟩, rfl⟩
-    refine ⟨⟨(Max.max n m).succ, CofilteredClosureSmall.InductiveStep.eq ?_ ?_ x y g g'⟩, rfl⟩
-    all_goals apply Nat.lt_succ_of_le
-    exacts [Nat.le_max_left _ _, Nat.le_max_right _ _]
-
+    refine ⟨⟨(Max.max n m).succ, ?_⟩, ?_⟩
+    · simp only [CofilteredClosureSmall.bundledAbstractCofilteredClosure]
+      refine CofilteredClosureSmall.InductiveStep.eq ?_ ?_ x y g g'
+      all_goals apply Nat.lt_succ_of_le
+      exacts [Nat.le_max_left _ _, Nat.le_max_right _ _]
+    · simp only [CofilteredClosureSmall.abstractCofilteredClosureRealization]
+      rw! [CofilteredClosureSmall.bundledAbstractCofilteredClosure]
+      rfl
 instance : EssentiallySmall.{max v w} (cofilteredClosure f).FullSubcategory :=
   have : LocallySmall.{max v w} (cofilteredClosure f).FullSubcategory :=
     locallySmall_max.{w, v, u}

--- a/Mathlib/CategoryTheory/Filtered/Small.lean
+++ b/Mathlib/CategoryTheory/Filtered/Small.lean
@@ -79,7 +79,7 @@ private noncomputable def inductiveStepRealization (n : ℕ)
 
 /--
 All steps of building the abstract filtered closure together with the realization function,
-as a function of `ℕ`.  -/
+as a function of `ℕ`. -/
 private noncomputable def bundledAbstractFilteredClosure :
     ℕ → Σ t : Type (max v w), t → C
   | 0 => ⟨ULift.{v} α, f ∘ ULift.down⟩

--- a/Mathlib/CategoryTheory/Filtered/Small.lean
+++ b/Mathlib/CategoryTheory/Filtered/Small.lean
@@ -5,6 +5,7 @@ Authors: Markus Himmel
 -/
 import Mathlib.CategoryTheory.EssentiallySmall
 import Mathlib.CategoryTheory.Filtered.Basic
+import Mathlib.Tactic.DepRewrite
 
 /-!
 # A functor from a small category to a filtered category factors through a small filtered category
@@ -82,7 +83,7 @@ as a function of `ℕ`.
 
 The function is defined by well-founded recursion, but we really want to use its
 definitional equalities in the proofs below, so lets make it semireducible. -/
-@[semireducible] private noncomputable def bundledAbstractFilteredClosure :
+private noncomputable def bundledAbstractFilteredClosure :
     ℕ → Σ t : Type (max v w), t → C
   | 0 => ⟨ULift.{v} α, f ∘ ULift.down⟩
   | (n + 1) => ⟨_, inductiveStepRealization (n + 1) (fun m _ => bundledAbstractFilteredClosure m)⟩
@@ -103,19 +104,35 @@ theorem small_fullSubcategory_filteredClosure :
     (fun _ _ => ObjectProperty.FullSubcategory.ext) ?_
   rintro ⟨j, h⟩
   induction h with
-  | base x => exact ⟨⟨0, ⟨x⟩⟩, rfl⟩
+  | base x =>
+      refine ⟨⟨0, ?_⟩, ?_⟩
+      · simp only [FilteredClosureSmall.bundledAbstractFilteredClosure]
+        exact ULift.up x
+      · simp only [FilteredClosureSmall.abstractFilteredClosureRealization]
+        rw! [FilteredClosureSmall.bundledAbstractFilteredClosure]
+        rfl
   | max hj₁ hj₂ ih ih' =>
     rcases ih with ⟨⟨n, x⟩, rfl⟩
     rcases ih' with ⟨⟨m, y⟩, rfl⟩
-    refine ⟨⟨(Max.max n m).succ, FilteredClosureSmall.InductiveStep.max ?_ ?_ x y⟩, rfl⟩
-    all_goals apply Nat.lt_succ_of_le
-    exacts [Nat.le_max_left _ _, Nat.le_max_right _ _]
+    refine ⟨⟨(Max.max n m).succ, ?_⟩, ?_⟩
+    · simp only [FilteredClosureSmall.bundledAbstractFilteredClosure]
+      refine FilteredClosureSmall.InductiveStep.max ?_ ?_ x y
+      all_goals apply Nat.lt_succ_of_le
+      exacts [Nat.le_max_left _ _, Nat.le_max_right _ _]
+    · simp only [FilteredClosureSmall.abstractFilteredClosureRealization]
+      rw! [FilteredClosureSmall.bundledAbstractFilteredClosure]
+      rfl
   | coeq hj₁ hj₂ g g' ih ih' =>
     rcases ih with ⟨⟨n, x⟩, rfl⟩
     rcases ih' with ⟨⟨m, y⟩, rfl⟩
-    refine ⟨⟨(Max.max n m).succ, FilteredClosureSmall.InductiveStep.coeq ?_ ?_ x y g g'⟩, rfl⟩
-    all_goals apply Nat.lt_succ_of_le
-    exacts [Nat.le_max_left _ _, Nat.le_max_right _ _]
+    refine ⟨⟨(Max.max n m).succ, ?_⟩, ?_⟩
+    · simp only [FilteredClosureSmall.bundledAbstractFilteredClosure]
+      refine FilteredClosureSmall.InductiveStep.coeq ?_ ?_ x y g g'
+      all_goals apply Nat.lt_succ_of_le
+      exacts [Nat.le_max_left _ _, Nat.le_max_right _ _]
+    · simp only [FilteredClosureSmall.abstractFilteredClosureRealization]
+      rw! [FilteredClosureSmall.bundledAbstractFilteredClosure]
+      rfl
 
 instance : EssentiallySmall.{max v w} (filteredClosure f).FullSubcategory :=
   have : LocallySmall.{max v w} (filteredClosure f).FullSubcategory := locallySmall_max.{w, v, u}


### PR DESCRIPTION
Using `rw!` this isn’t too bad.


---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include at least one commit authored by each
co-author among the commits in the pull request. If necessary, you may 
create empty commits to indicate co-authorship, using commands like so:

git commit --author="Author Name <author@email.com>" --allow-empty -m "add Author Name as coauthor"

When merging, all the commits will be squashed into a single commit listing all co-authors.

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
