### PR TITLE
[Merged by Bors] - feat(CategoryTheory): the opposite of a property of objects

### DIFF
--- a/Mathlib.lean
+++ b/Mathlib.lean
@@ -2668,6 +2668,7 @@ import Mathlib.CategoryTheory.ObjectProperty.Extensions
 import Mathlib.CategoryTheory.ObjectProperty.FullSubcategory
 import Mathlib.CategoryTheory.ObjectProperty.Ind
 import Mathlib.CategoryTheory.ObjectProperty.LimitsOfShape
+import Mathlib.CategoryTheory.ObjectProperty.Opposite
 import Mathlib.CategoryTheory.ObjectProperty.Retract
 import Mathlib.CategoryTheory.ObjectProperty.Shift
 import Mathlib.CategoryTheory.ObjectProperty.Small

--- a/Mathlib/CategoryTheory/ObjectProperty/Basic.lean
+++ b/Mathlib/CategoryTheory/ObjectProperty/Basic.lean
@@ -57,6 +57,18 @@ lemma prop_map_obj (P : ObjectProperty C) (F : C ⥤ D) {X : C} (hX : P X) :
     P.map F (F.obj X) :=
   ⟨X, hX, ⟨Iso.refl _⟩⟩
 
+/-- The strict image of a property of objects by a functor. -/
+inductive strictMap (P : ObjectProperty C) (F : C ⥤ D) : ObjectProperty D
+  | mk (X : C) (hX : P X) : strictMap P F (F.obj X)
+
+lemma prop_strictMap_iff (P : ObjectProperty C) (F : C ⥤ D) (Y : D) :
+    P.strictMap F Y ↔ ∃ (X : C), P X ∧ F.obj X = Y :=
+  ⟨by rintro ⟨X, hX⟩; exact ⟨X, hX, rfl⟩, by rintro ⟨X, hX, rfl⟩; exact ⟨X, hX⟩⟩
+
+lemma prop_strictMap_obj (P : ObjectProperty C) (F : C ⥤ D) {X : C} (hX : P X) :
+    P.strictMap F (F.obj X) :=
+  ⟨X, hX⟩
+
 /-- The typeclass associated to `P : ObjectProperty C`. -/
 @[mk_iff]
 class Is (P : ObjectProperty C) (X : C) : Prop where
@@ -65,6 +77,65 @@ class Is (P : ObjectProperty C) (X : C) : Prop where
 lemma prop_of_is (P : ObjectProperty C) (X : C) [P.Is X] : P X := by rwa [← P.is_iff]
 
 lemma is_of_prop (P : ObjectProperty C) {X : C} (hX : P X) : P.Is X := by rwa [P.is_iff]
+
+section
+
+variable {ι : Type u'} (X : ι → C)
+
+/-- The property of objects that is satisfied by the `X i` for a family
+of objects `X : ι : C`. -/
+inductive ofObj : ObjectProperty C
+  | mk (i : ι) : ofObj (X i)
+
+@[simp]
+lemma prop_ofObj (i : ι) : ofObj X (X i) := ⟨i⟩
+
+lemma prop_ofObj_iff (Y : C) : ofObj X Y ↔ ∃ i, X i = Y := by
+  constructor
+  · rintro ⟨i⟩
+    exact ⟨i, rfl⟩
+  · rintro ⟨i, rfl⟩
+    exact ⟨i⟩
+
+lemma ofObj_le_iff (P : ObjectProperty C) :
+    ofObj X ≤ P ↔ ∀ i, P (X i) :=
+  ⟨fun h i ↦ h _ (by simp), fun h ↦ by rintro _ ⟨i⟩; exact h i⟩
+
+@[simp]
+lemma strictMap_ofObj (F : C ⥤ D) :
+    (ofObj X).strictMap F = ofObj (F.obj ∘ X) := by
+  ext Y
+  simp [prop_ofObj_iff, prop_strictMap_iff]
+
+end
+
+/-- The property of objects in a category that is satisfied by a single object `X : C`. -/
+abbrev singleton (X : C) : ObjectProperty C := ofObj (fun (_ : Unit) ↦ X)
+
+@[simp]
+lemma prop_singleton_iff (X Y : C) : singleton X Y ↔ X = Y := by simp [prop_ofObj_iff]
+
+@[simp]
+lemma singleton_le_iff {X : C} {P : ObjectProperty C} :
+    singleton X ≤ P ↔ P X := by
+  simp [ofObj_le_iff]
+
+@[simp high]
+lemma strictMap_singleton (X : C) (F : C ⥤ D) :
+    (singleton X).strictMap F = singleton (F.obj X) := by
+  ext
+  simp [prop_strictMap_iff]
+
+/-- The property of objects in a category that is satisfied by `X : C` and `Y : C`. -/
+def pair (X Y : C) : ObjectProperty C :=
+  ofObj (Sum.elim (fun (_ : Unit) ↦ X) (fun (_ : Unit) ↦ Y))
+
+@[simp]
+lemma prop_pair_iff (X Y Z : C) :
+    pair X Y Z ↔ X = Z ∨ Y = Z := by
+  constructor
+  · rintro ⟨_ | _⟩ <;> tauto
+  · rintro (rfl | rfl); exacts [⟨Sum.inl .unit⟩, ⟨Sum.inr .unit⟩]
 
 end ObjectProperty
 

--- a/Mathlib/CategoryTheory/ObjectProperty/Basic.lean
+++ b/Mathlib/CategoryTheory/ObjectProperty/Basic.lean
@@ -61,11 +61,11 @@ lemma prop_map_obj (P : ObjectProperty C) (F : C ⥤ D) {X : C} (hX : P X) :
 inductive strictMap (P : ObjectProperty C) (F : C ⥤ D) : ObjectProperty D
   | mk (X : C) (hX : P X) : strictMap P F (F.obj X)
 
-lemma prop_strictMap_iff (P : ObjectProperty C) (F : C ⥤ D) (Y : D) :
+lemma strictMap_iff (P : ObjectProperty C) (F : C ⥤ D) (Y : D) :
     P.strictMap F Y ↔ ∃ (X : C), P X ∧ F.obj X = Y :=
   ⟨by rintro ⟨X, hX⟩; exact ⟨X, hX, rfl⟩, by rintro ⟨X, hX, rfl⟩; exact ⟨X, hX⟩⟩
 
-lemma prop_strictMap_obj (P : ObjectProperty C) (F : C ⥤ D) {X : C} (hX : P X) :
+lemma strictMap_obj (P : ObjectProperty C) (F : C ⥤ D) {X : C} (hX : P X) :
     P.strictMap F (F.obj X) :=
   ⟨X, hX⟩
 
@@ -88,9 +88,9 @@ inductive ofObj : ObjectProperty C
   | mk (i : ι) : ofObj (X i)
 
 @[simp]
-lemma prop_ofObj (i : ι) : ofObj X (X i) := ⟨i⟩
+lemma ofObj_apply (i : ι) : ofObj X (X i) := ⟨i⟩
 
-lemma prop_ofObj_iff (Y : C) : ofObj X Y ↔ ∃ i, X i = Y := by
+lemma ofObj_iff (Y : C) : ofObj X Y ↔ ∃ i, X i = Y := by
   constructor
   · rintro ⟨i⟩
     exact ⟨i, rfl⟩
@@ -105,7 +105,7 @@ lemma ofObj_le_iff (P : ObjectProperty C) :
 lemma strictMap_ofObj (F : C ⥤ D) :
     (ofObj X).strictMap F = ofObj (F.obj ∘ X) := by
   ext Y
-  simp [prop_ofObj_iff, prop_strictMap_iff]
+  simp [ofObj_iff, strictMap_iff]
 
 end
 
@@ -113,7 +113,7 @@ end
 abbrev singleton (X : C) : ObjectProperty C := ofObj (fun (_ : Unit) ↦ X)
 
 @[simp]
-lemma prop_singleton_iff (X Y : C) : singleton X Y ↔ X = Y := by simp [prop_ofObj_iff]
+lemma singleton_iff (X Y : C) : singleton X Y ↔ X = Y := by simp [ofObj_iff]
 
 @[simp]
 lemma singleton_le_iff {X : C} {P : ObjectProperty C} :
@@ -124,14 +124,14 @@ lemma singleton_le_iff {X : C} {P : ObjectProperty C} :
 lemma strictMap_singleton (X : C) (F : C ⥤ D) :
     (singleton X).strictMap F = singleton (F.obj X) := by
   ext
-  simp [prop_strictMap_iff]
+  simp [strictMap_iff]
 
 /-- The property of objects in a category that is satisfied by `X : C` and `Y : C`. -/
 def pair (X Y : C) : ObjectProperty C :=
   ofObj (Sum.elim (fun (_ : Unit) ↦ X) (fun (_ : Unit) ↦ Y))
 
 @[simp]
-lemma prop_pair_iff (X Y Z : C) :
+lemma pair_iff (X Y Z : C) :
     pair X Y Z ↔ X = Z ∨ Y = Z := by
   constructor
   · rintro ⟨_ | _⟩ <;> tauto

--- a/Mathlib/CategoryTheory/ObjectProperty/Opposite.lean
+++ b/Mathlib/CategoryTheory/ObjectProperty/Opposite.lean
@@ -69,7 +69,7 @@ lemma isoClosure_op (P : ObjectProperty C) :
   exact ⟨fun ⟨Y, h, ⟨e⟩⟩ ↦ ⟨op Y, h, ⟨e.op.symm⟩⟩,
     fun ⟨Y, h, ⟨e⟩⟩ ↦ ⟨Y.unop, h, ⟨e.unop.symm⟩⟩⟩
 
-lemma isoClosure_unop (P : ObjectProperty Cᵒᵖ) :
+lemma unop_isoClosure (P : ObjectProperty Cᵒᵖ) :
     P.isoClosure.unop = P.unop.isoClosure := by
   rw [← op_injective_iff, P.unop.isoClosure_op, op_unop, op_unop]
 

--- a/Mathlib/CategoryTheory/ObjectProperty/Opposite.lean
+++ b/Mathlib/CategoryTheory/ObjectProperty/Opposite.lean
@@ -1,0 +1,106 @@
+/-
+Copyright (c) 2025 Joël Riou. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Joël Riou
+-/
+import Mathlib.CategoryTheory.ObjectProperty.ClosedUnderIsomorphisms
+import Mathlib.CategoryTheory.Opposites
+
+/-!
+# The opposite of a property of objects
+
+-/
+
+universe v u
+
+namespace CategoryTheory.ObjectProperty
+
+open Opposite
+
+variable {C : Type u} [Category.{v} C]
+
+/-- The property of objects of `Cᵒᵖ` corresponding to `P : ObjectProperty C`. -/
+protected def op (P : ObjectProperty C) : ObjectProperty Cᵒᵖ :=
+  fun X ↦ P X.unop
+
+/-- The property of objects of `C` corresponding to `P : ObjectProperty Cᵒᵖ`. -/
+protected def unop (P : ObjectProperty Cᵒᵖ) : ObjectProperty C :=
+  fun X ↦ P (op X)
+
+@[simp]
+lemma op_iff (P : ObjectProperty C) (X : Cᵒᵖ) :
+    P.op X ↔ P X.unop := Iff.rfl
+
+@[simp]
+lemma unop_iff (P : ObjectProperty Cᵒᵖ) (X : C) :
+    P.unop X ↔ P (op X) := Iff.rfl
+
+@[simp]
+lemma op_unop (P : ObjectProperty Cᵒᵖ) : P.unop.op = P := rfl
+
+@[simp]
+lemma unop_op (P : ObjectProperty C) : P.op.unop = P := rfl
+
+lemma op_injective {P Q : ObjectProperty C} (h : P.op = Q.op) : P = Q := by
+  rw [← P.unop_op, ← Q.unop_op, h]
+
+lemma unop_injective {P Q : ObjectProperty Cᵒᵖ} (h : P.unop = Q.unop) : P = Q := by
+  rw [← P.op_unop, ← Q.op_unop, h]
+
+lemma op_injective_iff {P Q : ObjectProperty C} :
+    P.op = Q.op ↔ P = Q :=
+  ⟨op_injective, by rintro rfl; rfl⟩
+
+lemma unop_injective_iff {P Q : ObjectProperty Cᵒᵖ} :
+    P.unop = Q.unop ↔ P = Q :=
+  ⟨unop_injective, by rintro rfl; rfl⟩
+
+instance (P : ObjectProperty C) [P.IsClosedUnderIsomorphisms] :
+    P.op.IsClosedUnderIsomorphisms where
+  of_iso e hX := P.prop_of_iso e.symm.unop hX
+
+instance (P : ObjectProperty Cᵒᵖ) [P.IsClosedUnderIsomorphisms] :
+    P.unop.IsClosedUnderIsomorphisms where
+  of_iso e hX := P.prop_of_iso e.symm.op hX
+
+lemma isoClosure_op (P : ObjectProperty C) :
+    P.isoClosure.op = P.op.isoClosure := by
+  ext ⟨X⟩
+  exact ⟨fun ⟨Y, h, ⟨e⟩⟩ ↦ ⟨op Y, h, ⟨e.op.symm⟩⟩,
+    fun ⟨Y, h, ⟨e⟩⟩ ↦ ⟨Y.unop, h, ⟨e.unop.symm⟩⟩⟩
+
+lemma isoClosure_unop (P : ObjectProperty Cᵒᵖ) :
+    P.isoClosure.unop = P.unop.isoClosure := by
+  rw [← op_injective_iff, P.unop.isoClosure_op, op_unop, op_unop]
+
+/-- The bijection `Subtype P.op ≃ Subtype P` for `P : ObjectProperty C`. -/
+def subtypeOpEquiv (P : ObjectProperty C) :
+    Subtype P.op ≃ Subtype P where
+  toFun x := ⟨x.1.unop, x.2⟩
+  invFun x := ⟨op x.1, x.2⟩
+
+@[simp]
+lemma op_ofObj {ι : Type*} (X : ι → C) : (ofObj X).op = ofObj (fun i ↦ op (X i)) := by
+  ext Z
+  simp only [op_iff, prop_ofObj_iff]
+  constructor
+  · rintro ⟨i, hi⟩
+    exact ⟨i, by rw [hi]⟩
+  · rintro ⟨i, hi⟩
+    exact ⟨i, by rw [← hi]⟩
+
+@[simp]
+lemma unop_ofObj {ι : Type*} (X : ι → Cᵒᵖ) : (ofObj X).unop = ofObj (fun i ↦ (X i).unop) :=
+  op_injective ((op_ofObj _).symm)
+
+@[simp high]
+lemma op_singleton (X : C) :
+    (singleton X).op = singleton (op X) := by
+  simp
+
+@[simp high]
+lemma unop_singleton (X : Cᵒᵖ) :
+    (singleton X).unop = singleton X.unop := by
+  simp
+
+end CategoryTheory.ObjectProperty

--- a/Mathlib/CategoryTheory/ObjectProperty/Opposite.lean
+++ b/Mathlib/CategoryTheory/ObjectProperty/Opposite.lean
@@ -55,6 +55,20 @@ lemma unop_injective_iff {P Q : ObjectProperty Cᵒᵖ} :
     P.unop = Q.unop ↔ P = Q :=
   ⟨unop_injective, by rintro rfl; rfl⟩
 
+lemma op_monotone {P Q : ObjectProperty C} (h : P ≤ Q) : P.op ≤ Q.op :=
+  fun _ hX ↦ h _ hX
+
+lemma unop_monotone {P Q : ObjectProperty Cᵒᵖ} (h : P ≤ Q) : P.unop ≤ Q.unop :=
+  fun _ hX ↦ h _ hX
+
+@[simp]
+lemma op_monotone_iff {P Q : ObjectProperty C} : P.op ≤ Q.op ↔ P ≤ Q :=
+  ⟨unop_monotone, op_monotone⟩
+
+@[simp]
+lemma unop_monotone_iff {P Q : ObjectProperty Cᵒᵖ} : P.unop ≤ Q.unop ↔ P ≤ Q :=
+  ⟨op_monotone, unop_monotone⟩
+
 instance (P : ObjectProperty C) [P.IsClosedUnderIsomorphisms] :
     P.op.IsClosedUnderIsomorphisms where
   of_iso e hX := P.prop_of_iso e.symm.unop hX
@@ -71,7 +85,7 @@ lemma op_isoClosure (P : ObjectProperty C) :
 
 lemma unop_isoClosure (P : ObjectProperty Cᵒᵖ) :
     P.isoClosure.unop = P.unop.isoClosure := by
-  rw [← op_injective_iff, P.unop.isoClosure_op, op_unop, op_unop]
+  rw [← op_injective_iff, P.unop.op_isoClosure, op_unop, op_unop]
 
 /-- The bijection `Subtype P.op ≃ Subtype P` for `P : ObjectProperty C`. -/
 def subtypeOpEquiv (P : ObjectProperty C) :

--- a/Mathlib/CategoryTheory/ObjectProperty/Opposite.lean
+++ b/Mathlib/CategoryTheory/ObjectProperty/Opposite.lean
@@ -96,7 +96,7 @@ def subtypeOpEquiv (P : ObjectProperty C) :
 @[simp]
 lemma op_ofObj {ι : Type*} (X : ι → C) : (ofObj X).op = ofObj (fun i ↦ op (X i)) := by
   ext Z
-  simp only [op_iff, prop_ofObj_iff]
+  simp only [op_iff, ofObj_iff]
   constructor
   · rintro ⟨i, hi⟩
     exact ⟨i, by rw [hi]⟩

--- a/Mathlib/CategoryTheory/ObjectProperty/Opposite.lean
+++ b/Mathlib/CategoryTheory/ObjectProperty/Opposite.lean
@@ -63,7 +63,7 @@ instance (P : ObjectProperty Cᵒᵖ) [P.IsClosedUnderIsomorphisms] :
     P.unop.IsClosedUnderIsomorphisms where
   of_iso e hX := P.prop_of_iso e.symm.op hX
 
-lemma isoClosure_op (P : ObjectProperty C) :
+lemma op_isoClosure (P : ObjectProperty C) :
     P.isoClosure.op = P.op.isoClosure := by
   ext ⟨X⟩
   exact ⟨fun ⟨Y, h, ⟨e⟩⟩ ↦ ⟨op Y, h, ⟨e.op.symm⟩⟩,

--- a/Mathlib/CategoryTheory/ObjectProperty/Small.lean
+++ b/Mathlib/CategoryTheory/ObjectProperty/Small.lean
@@ -4,6 +4,7 @@ Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Joël Riou
 -/
 import Mathlib.CategoryTheory.ObjectProperty.FullSubcategory
+import Mathlib.CategoryTheory.ObjectProperty.Opposite
 import Mathlib.Logic.Small.Basic
 
 /-!
@@ -32,5 +33,21 @@ instance (P : ObjectProperty C) [ObjectProperty.Small.{w} P] :
 lemma Small.of_le {P Q : ObjectProperty C} [ObjectProperty.Small.{w} Q] (h : P ≤ Q) :
     ObjectProperty.Small.{w} P :=
   small_of_injective (Subtype.map_injective h Function.injective_id)
+
+instance (P : ObjectProperty C) [ObjectProperty.Small.{w} P] :
+    ObjectProperty.Small.{w} P.op :=
+  small_of_injective P.subtypeOpEquiv.injective
+
+instance (P : ObjectProperty Cᵒᵖ) [ObjectProperty.Small.{w} P] :
+    ObjectProperty.Small.{w} P.unop := by
+  simpa only [← small_congr P.unop.subtypeOpEquiv]
+
+instance {ι : Type*} (X : ι → C) [Small.{w} ι] :
+    ObjectProperty.Small.{w} (ofObj X) :=
+  small_of_surjective (f := fun i ↦ ⟨X i, by simp⟩) (by rintro ⟨_, ⟨i⟩⟩;simp )
+
+instance (X Y : C) : ObjectProperty.Small.{w} (.pair X Y) := by
+  dsimp [pair]
+  infer_instance
 
 end CategoryTheory.ObjectProperty


### PR DESCRIPTION
This PR adds the prerequisites for the refactor PR #30269, mostly the addition of `ObjectProperty.op` and constructors for `ObjectProperty` given by families of objects.

---

<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include at least one commit authored by each
co-author among the commits in the pull request. If necessary, you may 
create empty commits to indicate co-authorship, using commands like so:

git commit --author="Author Name <author@email.com>" --allow-empty -m "add Author Name as coauthor"

When merging, all the commits will be squashed into a single commit listing all co-authors.

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
