### PR TITLE
[Merged by Bors] - chore: fix formatting for deprecation dates

### DIFF
--- a/Mathlib/Analysis/LocallyConvex/Polar.lean
+++ b/Mathlib/Analysis/LocallyConvex/Polar.lean
@@ -186,7 +186,7 @@ theorem dualPairing_separatingLeft : (topDualPairing R M).SeparatingLeft := by
   rw [LinearMap.separatingLeft_iff_ker_eq_bot, LinearMap.ker_eq_bot]
   exact ContinuousLinearMap.coe_injective
 
-@[deprecated (since := "2025-08-3")] alias NormedSpace.dualPairing_separatingLeft :=
+@[deprecated (since := "2025-08-12")] alias NormedSpace.dualPairing_separatingLeft :=
   dualPairing_separatingLeft
 
 end
@@ -200,7 +200,7 @@ def polar (R : Type*) [NormedCommRing R] {M : Type*} [AddCommMonoid M]
     [TopologicalSpace M] [Module R M] : Set M → Set (StrongDual R M) :=
   (topDualPairing R M).flip.polar
 
-@[deprecated (since := "2025-08-3")] alias _root_.NormedSpace.polar := polar
+@[deprecated (since := "2025-08-12")] alias _root_.NormedSpace.polar := polar
 
 /-- Given a subset `s` in a monoid `M` (over a field `𝕜`) closed under scalar multiplication,
 the polar `polarSubmodule 𝕜 s` is the submodule of `StrongDual 𝕜 M` consisting of those functionals
@@ -209,7 +209,7 @@ def polarSubmodule (𝕜 : Type*) [NontriviallyNormedField 𝕜] {M : Type*} [Ad
     [TopologicalSpace M] [Module 𝕜 M] {S : Type*} [SetLike S M] [SMulMemClass S 𝕜 M] (m : S) :
     Submodule 𝕜 (StrongDual 𝕜 M) := (topDualPairing 𝕜 M).flip.polarSubmodule m
 
-@[deprecated (since := "2025-08-3")] alias _root_.NormedSpace.polarSubmodule := polarSubmodule
+@[deprecated (since := "2025-08-12")] alias _root_.NormedSpace.polarSubmodule := polarSubmodule
 
 variable (𝕜 : Type*) [NontriviallyNormedField 𝕜]
 variable {E : Type*} [AddCommMonoid E] [TopologicalSpace E] [Module 𝕜 E]
@@ -217,38 +217,38 @@ variable {E : Type*} [AddCommMonoid E] [TopologicalSpace E] [Module 𝕜 E]
 lemma polarSubmodule_eq_polar (m : SubMulAction 𝕜 E) :
     (polarSubmodule 𝕜 m : Set (StrongDual 𝕜 E)) = polar 𝕜 m := rfl
 
-@[deprecated (since := "2025-08-3")] alias _root_.NormedSpace.polarSubmodule_eq_polar :=
+@[deprecated (since := "2025-08-12")] alias _root_.NormedSpace.polarSubmodule_eq_polar :=
   polarSubmodule_eq_polar
 
 theorem mem_polar_iff {x' : StrongDual 𝕜 E} (s : Set E) : x' ∈ polar 𝕜 s ↔ ∀ z ∈ s, ‖x' z‖ ≤ 1 :=
   Iff.rfl
 
-@[deprecated (since := "2025-08-3")] alias _root_.NormedSpace.mem_polar_iff := mem_polar_iff
+@[deprecated (since := "2025-08-12")] alias _root_.NormedSpace.mem_polar_iff := mem_polar_iff
 
 lemma polarSubmodule_eq_setOf {S : Type*} [SetLike S E] [SMulMemClass S 𝕜 E] (m : S) :
     polarSubmodule 𝕜 m = { y : StrongDual 𝕜 E | ∀ x ∈ m, y x = 0 } :=
   (topDualPairing 𝕜 E).flip.polar_subMulAction _
 
-@[deprecated (since := "2025-08-3")] alias _root_.NormedSpace.polarSubmodule_eq_setOf :=
+@[deprecated (since := "2025-08-12")] alias _root_.NormedSpace.polarSubmodule_eq_setOf :=
   polarSubmodule_eq_setOf
 
 lemma mem_polarSubmodule {S : Type*} [SetLike S E] [SMulMemClass S 𝕜 E] (m : S)
     (y : StrongDual 𝕜 E) : y ∈ polarSubmodule 𝕜 m ↔ ∀ x ∈ m, y x = 0 :=
   propext_iff.mp congr($(polarSubmodule_eq_setOf 𝕜 m) y)
 
-@[deprecated (since := "2025-08-3")] alias _root_.NormedSpace.mem_polarSubmodule :=
+@[deprecated (since := "2025-08-12")] alias _root_.NormedSpace.mem_polarSubmodule :=
   mem_polarSubmodule
 
 @[simp]
 theorem zero_mem_polar (s : Set E) : (0 : StrongDual 𝕜 E) ∈ polar 𝕜 s :=
   LinearMap.zero_mem_polar _ s
 
-@[deprecated (since := "2025-08-3")] alias _root_.NormedSpace.zero_mem_polar := zero_mem_polar
+@[deprecated (since := "2025-08-12")] alias _root_.NormedSpace.zero_mem_polar := zero_mem_polar
 
 theorem polar_nonempty (s : Set E) : Set.Nonempty (polar 𝕜 s) :=
   LinearMap.polar_nonempty _ _
 
-@[deprecated (since := "2025-08-3")] alias _root_.NormedSpace.polar_nonempty := polar_nonempty
+@[deprecated (since := "2025-08-12")] alias _root_.NormedSpace.polar_nonempty := polar_nonempty
 
 open Set
 
@@ -256,24 +256,24 @@ open Set
 theorem polar_empty : polar 𝕜 (∅ : Set E) = Set.univ :=
   LinearMap.polar_empty _
 
-@[deprecated (since := "2025-08-3")] alias _root_.NormedSpace.polar_empty := polar_empty
+@[deprecated (since := "2025-08-12")] alias _root_.NormedSpace.polar_empty := polar_empty
 
 @[simp]
 theorem polar_singleton {a : E} : polar 𝕜 {a} = { x | ‖x a‖ ≤ 1 } := by
   simp only [polar, LinearMap.polar_singleton, LinearMap.flip_apply, topDualPairing_apply]
 
-@[deprecated (since := "2025-08-3")] alias _root_.NormedSpace.polar_singleton := polar_singleton
+@[deprecated (since := "2025-08-12")] alias _root_.NormedSpace.polar_singleton := polar_singleton
 
 theorem mem_polar_singleton {a : E} (y : StrongDual 𝕜 E) : y ∈ polar 𝕜 {a} ↔ ‖y a‖ ≤ 1 := by
   simp only [polar_singleton, mem_setOf_eq]
 
-@[deprecated (since := "2025-08-3")] alias _root_.NormedSpace.mem_polar_singleton :=
+@[deprecated (since := "2025-08-12")] alias _root_.NormedSpace.mem_polar_singleton :=
   mem_polar_singleton
 
 theorem polar_zero : polar 𝕜 ({0} : Set E) = Set.univ :=
   LinearMap.polar_zero _
 
-@[deprecated (since := "2025-08-3")] alias _root_.NormedSpace.polar_zero := polar_zero
+@[deprecated (since := "2025-08-12")] alias _root_.NormedSpace.polar_zero := polar_zero
 
 end
 
@@ -289,7 +289,7 @@ theorem polar_univ : polar 𝕜 (univ : Set E) = {(0 : StrongDual 𝕜 E)} :=
   (topDualPairing 𝕜 E).flip.polar_univ
     (LinearMap.flip_separatingRight.mpr (dualPairing_separatingLeft 𝕜 E))
 
-@[deprecated (since := "2025-08-3")] alias _root_.NormedSpace.polar_univ := polar_univ
+@[deprecated (since := "2025-08-12")] alias _root_.NormedSpace.polar_univ := polar_univ
 
 end
 

--- a/Mathlib/Topology/Algebra/Module/LinearMap.lean
+++ b/Mathlib/Topology/Algebra/Module/LinearMap.lean
@@ -1250,7 +1250,7 @@ variable (𝕜 E) in
 def topDualPairing : (E →L[𝕜] 𝕜) →ₗ[𝕜] E →ₗ[𝕜] 𝕜 :=
   ContinuousLinearMap.coeLM 𝕜
 
-@[deprecated (since := "2025-08-3")] alias NormedSpace.dualPairing := topDualPairing
+@[deprecated (since := "2025-08-12")] alias NormedSpace.dualPairing := topDualPairing
 
 @[deprecated (since := "2025-09-03")] alias strongDualPairing := topDualPairing
 
@@ -1259,7 +1259,7 @@ theorem topDualPairing_apply (v : E →L[𝕜] 𝕜)
     (x : E) : topDualPairing 𝕜 E v x = v x :=
   rfl
 
-@[deprecated (since := "2025-08-3")] alias NormedSpace.dualPairing_apply := topDualPairing_apply
+@[deprecated (since := "2025-08-12")] alias NormedSpace.dualPairing_apply := topDualPairing_apply
 
 @[deprecated (since := "2025-09-03")] alias StrongDual.dualPairing_apply := topDualPairing_apply
 


### PR DESCRIPTION
Also update the date to when the PR (#27699) was actually landed.


---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include at least one commit authored by each
co-author among the commits in the pull request. If necessary, you may 
create empty commits to indicate co-authorship, using commands like so:

git commit --author="Author Name <author@email.com>" --allow-empty -m "add Author Name as coauthor"

When merging, all the commits will be squashed into a single commit listing all co-authors.

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
