### PR TITLE
feat(Topology/Instances): Cantor set

### DIFF
--- a/Mathlib.lean
+++ b/Mathlib.lean
@@ -6680,7 +6680,9 @@ import Mathlib.Topology.Inseparable
 import Mathlib.Topology.Instances.AddCircle.Defs
 import Mathlib.Topology.Instances.AddCircle.DenseSubgroup
 import Mathlib.Topology.Instances.AddCircle.Real
-import Mathlib.Topology.Instances.CantorSet
+import Mathlib.Topology.Instances.CantorSet.Basic
+import Mathlib.Topology.Instances.CantorSet.Cardinality
+import Mathlib.Topology.Instances.CantorSet.Lemmas
 import Mathlib.Topology.Instances.Complex
 import Mathlib.Topology.Instances.Discrete
 import Mathlib.Topology.Instances.ENNReal.Lemmas

--- a/Mathlib/Topology/Instances/CantorSet/Basic.lean
+++ b/Mathlib/Topology/Instances/CantorSet/Basic.lean
@@ -3,7 +3,7 @@ Copyright (c) 2024 Jana Göken. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Artur Szafarczyk, Suraj Krishna M S, Jean-Baptiste Stiegler, Isabelle Dubois,
 Tomáš Jakl, Lorenzo Zanichelli, Alina Yan, Emilie Uthaiwat, Jana Göken,
-Filippo A. E. Nuccio
+Filippo A. E. Nuccio, Francesco Vercellesi
 -/
 import Mathlib.Topology.Algebra.GroupWithZero
 import Mathlib.Topology.Algebra.Ring.Real
@@ -108,6 +108,38 @@ theorem cantorSet_eq_union_halves :
     Function.comp_def, ← preCantorSet_succ]
   exact (preCantorSet_antitone.iInter_nat_add _).symm
 
+/-- If `x` is in the ternary Cantor set then either `3 * x` or `3 * x - 2` also is. -/
+theorem cantorSet_scaled_mem {x : ℝ} (h : x ∈ cantorSet) :
+    x * 3 ∈ cantorSet ∨ x * 3 - 2 ∈ cantorSet := by
+  rw [cantorSet_eq_union_halves, Set.mem_union, Set.mem_image] at h
+  apply h.elim
+  · intro ⟨x', ⟨hx'₀, hx'₁⟩⟩
+    apply Or.inl
+    rwa [(by linarith : x' = x * 3)] at hx'₀
+  · intro ⟨x', ⟨hx'₀, hx'₁⟩⟩
+    apply Or.inr
+    rwa [(by linarith : x' = x * 3 - 2)] at hx'₀
+
+/-- If `x` is in the ternary Cantor set then so is `x / 3` -/
+theorem third_in_cantorSet {x : ℝ} (h : x ∈ cantorSet) :
+    x * (1 / 3) ∈ cantorSet := by
+  rw [(by field_simp : x * (1 / 3) = x / 3)]
+  have mem_left_half := Set.mem_image_of_mem (· / 3) h
+  have left_half_subset : (· / 3) '' cantorSet ⊆ cantorSet := by
+    conv_rhs => rw [cantorSet_eq_union_halves]
+    simp
+  exact left_half_subset mem_left_half
+
+/-- If `x` is in the ternary Cantor set then so is `2 / 3 + x / 3` -/
+theorem third_plus_two_thirds_in_cantorSet {x : ℝ} (h : x ∈ cantorSet) :
+    2 / 3 + x * (1 / 3) ∈ cantorSet := by
+  rw [(by field_simp : 2 / 3 + x * (1 / 3) = (2 + x) / 3)]
+  have mem_right_half := Set.mem_image_of_mem (fun x => (2 + x) / 3) h
+  have right_half_subset : ((2 + ·) / 3) '' cantorSet ⊆ cantorSet := by
+    conv_rhs => rw [cantorSet_eq_union_halves]
+    simp
+  exact right_half_subset mem_right_half
+
 /-- The preCantor sets are closed. -/
 lemma isClosed_preCantorSet (n : ℕ) : IsClosed (preCantorSet n) := by
   let f := Homeomorph.mulLeft₀ (1 / 3 : ℝ) (by simp)
@@ -126,3 +158,7 @@ lemma isClosed_cantorSet : IsClosed cantorSet :=
 /-- The ternary Cantor set is compact. -/
 lemma isCompact_cantorSet : IsCompact cantorSet :=
   isCompact_Icc.of_isClosed_subset isClosed_cantorSet cantorSet_subset_unitInterval
+
+/-- The ternary Cantor set is complete -/
+lemma isComplete_cantorSet : IsComplete cantorSet :=
+  isClosed_cantorSet.isComplete

--- a/Mathlib/Topology/Instances/CantorSet/Cardinality.lean
+++ b/Mathlib/Topology/Instances/CantorSet/Cardinality.lean
@@ -1,0 +1,178 @@
+/-
+Copyright (c) 2025 Francesco Vercellesi. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Francesco Vercellesi
+-/
+import Mathlib.Analysis.Normed.Group.InfiniteSum
+import Mathlib.Analysis.RCLike.Basic
+import Mathlib.Analysis.Real.Cardinality
+import Mathlib.Topology.Instances.CantorSet.Basic
+
+/-!
+# Cardinality of the Ternary Cantor Set
+
+This file proves that the ternary Cantor set has the cardinality of the continuum.
+
+## Main results
+
+* `cantor_set_continuum_card`: The ternary Cantor set has the cardinality of the continuum.
+-/
+
+open Cardinal
+
+variable (χ : ℕ → ({0, 2} : Set ℤ))
+
+/-- The infinite series which maps bijectively binary sequences
+to elements of the ternary Cantor set -/
+noncomputable def cantorSet_series :=
+  fun i ↦ χ i * (1 / 3 : ℝ) ^ i * (1 / 3)
+
+lemma partial_sums_cantorSet_series_in_cantorSet (n : ℕ) :
+    ∑ i ∈ Finset.range n, cantorSet_series χ i ∈ cantorSet := by
+  revert χ
+  induction n with
+  | zero =>
+    simp [zero_mem_cantorSet]
+  | succ n ih =>
+    intro χ
+    apply (Subtype.coe_prop (χ 0)).elim
+    all_goals
+      intro
+      simp_all only [Finset.sum_range_succ', cantorSet_series, Int.cast_zero,
+        zero_mul, add_zero, Set.mem_singleton_iff,
+        Finset.sum_range_succ', Int.cast_ofNat, pow_zero, mul_one]
+      rw [←Finset.sum_mul]
+      ring_nf
+      first | apply third_in_cantorSet | apply third_plus_two_thirds_in_cantorSet
+      exact ih (fun i ↦ χ (1 + i))
+
+lemma cantorSet_series_summable : Summable (cantorSet_series χ) := by
+  have summable_geo : Summable (fun i ↦ 2 / 3 * (1 / 3 : ℝ) ^ i) := by
+    apply Summable.mul_left
+    exact summable_geometric_of_lt_one (by simp) (by norm_num)
+  refine Summable.of_nonneg_of_le ?_ ?_ summable_geo
+  all_goals
+    intro i
+    apply (Subtype.coe_prop (χ i)).elim <;>
+      (simp_all [cantorSet_series]; try ring_nf; try field_simp; try (intros; rfl))
+
+/-- For any given binary sequence, its series converges to an element of the ternary Cantor set -/
+lemma cantorSet_series_in_cantorSet : tsum (cantorSet_series χ) ∈ cantorSet := by
+  have ⟨l, hl⟩ := cantorSet_series_summable χ
+  have partial_sums_cauchy : CauchySeq (fun n ↦ ∑ i ∈ Finset.range n, cantorSet_series χ i) := by
+    apply Filter.Tendsto.cauchySeq (x := l)
+    exact (Summable.hasSum_iff_tendsto_nat (cantorSet_series_summable χ)).mp hl
+  have ⟨l', ⟨_, hl'⟩⟩ := cauchySeq_tendsto_of_isComplete
+    isComplete_cantorSet
+    (partial_sums_cantorSet_series_in_cantorSet χ)
+    partial_sums_cauchy
+  rw [HasSum.tsum_eq hl]
+  rw [Summable.hasSum_iff_tendsto_nat (cantorSet_series_summable χ)] at hl
+  rwa [tendsto_nhds_unique hl hl']
+
+/-- For any given binary sequence, the sum of its series as an element of the ternary Cantor set -/
+@[simp]
+noncomputable def cantorSet_series_sum :=
+  Subtype.mk (tsum (cantorSet_series χ)) (cantorSet_series_in_cantorSet χ)
+
+/-- `cantorSet_series_sum` is an injective function -/
+lemma sum_of_cantorSet_series_injective : Function.Injective cantorSet_series_sum := by
+  have diff (χ₁ χ₂ : _) : χ₁ ≠ χ₂ → cantorSet_series_sum χ₁ ≠ cantorSet_series_sum χ₂ := by
+    intro h
+    let n := Nat.find (Function.ne_iff.mp h)
+    have hn := Nat.find_spec (Function.ne_iff.mp h)
+    simp only [cantorSet_series_sum, ne_eq, Subtype.mk.injEq]
+    rw [←Summable.sum_add_tsum_nat_add (n + 1) (cantorSet_series_summable χ₁)]
+    rw [←Summable.sum_add_tsum_nat_add (n + 1) (cantorSet_series_summable χ₂)]
+    rw [Finset.sum_range_succ, Finset.sum_range_succ]
+    have first_eq :
+        ∑ x ∈ Finset.range n, cantorSet_series χ₁ x =
+        ∑ x ∈ Finset.range n, cantorSet_series χ₂ x := by
+      refine Finset.sum_congr rfl ?_
+      have (x : ℕ) (hx : x < n) :=
+        Subtype.ext_iff.mp (not_ne_iff.mp (Nat.find_min (Function.ne_iff.mp h) hx))
+      simp_all [cantorSet_series]
+    rw [add_assoc, add_assoc, first_eq, add_right_inj _]
+    rw [←sub_eq_zero, sub_add_eq_sub_sub, add_sub_right_comm, add_sub_assoc]
+    rw [←eq_neg_iff_add_eq_zero]
+    apply (fun h x ↦ h (congrArg abs x) : |_| ≠ |_| → _ ≠ _)
+    have first_ge_two_thirds :
+        |cantorSet_series χ₁ n - cantorSet_series χ₂ n| ≥ 2 / 3 * (1 / 3) ^ n := by
+      simp only [cantorSet_series, one_div, inv_pow]
+      rw [←mul_sub_right_distrib, abs_mul, ←mul_sub_right_distrib, abs_mul]
+      rw [(by aesop : |(3 : ℝ)⁻¹| = 3⁻¹), (by aesop : |((3 : ℝ) ^ n)⁻¹| = ((3 : ℝ) ^ n)⁻¹)]
+      have eq : |(χ₁ n : ℝ) - ↑↑(χ₂ n)| = 2 := by
+        match (Subtype.coe_prop (χ₁ n)), (Subtype.coe_prop (χ₂ n)) with
+        | Or.inl hχ₁, Or.inl hχ₂ | Or.inr hχ₁, Or.inr hχ₂ =>
+          exact False.elim (hn (Subtype.ext (Eq.trans hχ₁ hχ₂.symm)))
+        | Or.inr hχ₁, Or.inl hχ₂ | Or.inl hχ₁, Or.inr hχ₂ =>
+          simp_all
+      rw [eq]
+      linarith
+    have tail_le_third :
+        |∑' (i : ℕ), cantorSet_series χ₂ (i + (n + 1))
+        - ∑' (i : ℕ), cantorSet_series χ₁ (i + (n + 1))| ≤ 1 / 3 * (1 / 3) ^ n := by
+      simp only [cantorSet_series]
+      rw [tsum_mul_right, tsum_mul_right]
+      ring_nf
+      conv in (occs := 1) (_ * _ * _) => rw [mul_right_comm]
+      conv in (occs := 3) (_ * _ * _) => rw [mul_assoc, mul_right_comm, ←mul_assoc]
+      conv in (occs := 1) (∑' _, _) => rw [tsum_mul_right]
+      conv in (occs := 2) (∑' _, _) => rw [tsum_mul_right]
+      rw [(by ring : ((-1 : ℝ) / 3) = -(1 / 3))]
+      rw [mul_neg, ←sub_eq_add_neg, ←sub_mul, ←sub_mul, abs_mul, abs_mul]
+      rw [(by aesop : |(1 : ℝ) / 3| = (1 : ℝ) / 3),
+        (by aesop : |(((1 : ℝ) / 3) ^ n)| = (((1 : ℝ) / 3) ^ n))]
+      simp only [one_div, inv_pow, inv_pos, Nat.ofNat_pos, mul_le_mul_iff_left₀, pow_pos,
+        mul_le_iff_le_one_left]
+      have merge_sums := Summable.tsum_sub
+        (cantorSet_series_summable (fun i ↦ χ₂ (1 + i + n)))
+        (cantorSet_series_summable (fun i ↦ χ₁ (1 + n + i)))
+      simp only [cantorSet_series, one_div, inv_pow] at merge_sums
+      rw [←merge_sums]
+      simp only [←sub_mul]
+      let χ₃ : ℕ → ({0, 2} : Set ℤ) := fun i ↦ Subtype.mk |χ₂ (1 + i + n) - χ₁ (1 + n + i)| <| by
+        apply (Subtype.coe_prop (χ₁ (1 + n + i))).elim <;>
+          apply (Subtype.coe_prop (χ₂ (1 + i + n))).elim <;>
+            simp_all
+      have eq₃ :
+            (fun i ↦ |(χ₂ (1 + i + n) : ℝ) - χ₁ (1 + n + i)| * (1 / 3) ^ i * (1 / 3)) =
+            (fun i ↦ cantorSet_series χ₃ i) := by
+          simp [χ₃, cantorSet_series]
+      have norm_diff_summable :
+          Summable
+          fun i ↦ ‖((χ₂ (1 + i + n) : ℝ) - (χ₁ (1 + n + i)))  * (1 / 3 : ℝ) ^ i * (1 / 3)‖ := by
+        simp only [Real.norm_eq_abs, abs_mul]
+        conv =>
+          arg 1; intro n
+          rw [(by aesop : |(1 : ℝ) / 3| = (1 : ℝ) / 3),
+            (by aesop : |(((1 : ℝ) / 3) ^ n)| = (((1 : ℝ) / 3) ^ n))]
+        rw [eq₃]
+        exact cantorSet_series_summable χ₃
+      have le_abs := norm_tsum_le_tsum_norm norm_diff_summable
+      simp only [one_div, inv_pow, Real.norm_eq_abs, norm_mul, norm_inv, norm_pow] at le_abs
+      calc
+        _ ≤ _ := le_abs
+        _ ≤ _ := by
+          conv in (_ * _ * _) =>
+            rw [(by aesop : |(3 : ℝ)|⁻¹ = 1 / 3), (by aesop : (|(3 : ℝ)| ^ i)⁻¹ = (1 / 3) ^ i)]
+          rw [eq₃]
+          exact (cantorSet_subset_unitInterval (cantorSet_series_in_cantorSet χ₃)).right
+    have diseq : (1 : ℝ) / 3 * (1 / 3) ^ n < 2 / 3 * (1 / 3) ^ n := by
+      simp
+      linarith
+    simp only [neg_sub]
+    apply ne_of_gt
+    calc
+      _ ≤ _ := tail_le_third
+      _ < _ := diseq
+      _ ≤ _ := first_ge_two_thirds
+  exact Function.injective_iff_pairwise_ne.mpr diff
+
+/-- The ternary Cantor set has the cardinality of the continuum -/
+theorem cantor_set_continuum_card : #cantorSet = continuum := by
+  apply le_antisymm
+  · rw [←Cardinal.mk_real]
+    exact Cardinal.mk_set_le cantorSet
+  · have := Cardinal.mk_le_of_injective sum_of_cantorSet_series_injective
+    simp_all

--- a/Mathlib/Topology/Instances/CantorSet/Lemmas.lean
+++ b/Mathlib/Topology/Instances/CantorSet/Lemmas.lean
@@ -1,0 +1,137 @@
+/-
+Copyright (c) 2025 Francesco Vercellesi. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Francesco Vercellesi
+-/
+import Mathlib.Analysis.RCLike.Basic
+import Mathlib.Data.Int.Log
+import Mathlib.Tactic.Rify
+import Mathlib.Topology.Instances.CantorSet.Basic
+
+/-!
+# Lemmas about the Ternary Cantor Set
+
+This file proves a few properties of the ternary Cantor set.
+
+## Main results
+
+* `empty_interior_cantorSet`: The ternary Cantor has empty interior.
+-/
+
+/-- Numbers of the form `n / (2 * 3 ^ k)` with odd `n`.
+These are dense over the reals and never in the ternary Cantor set -/
+def HalfTriadic (x : ℝ) :=
+  ∃ n : ℤ, ∃ k : ℕ, x = n / (2 * 3 ^ k) ∧ Int.gcd n 2 = 1
+
+/-- Half Triadics are not in the ternary Cantor set -/
+lemma half_triadic_not_in_cantorSet (x : ℝ) (h : HalfTriadic x) : x ∉ cantorSet := by
+  have ⟨n, k, ⟨h₁, h₂⟩⟩ := h
+  rw [h₁]
+  revert n x
+  induction k with
+  | zero =>
+    intro _ _ n h₁ h₂
+    simp only [pow_zero, mul_one]
+    rcases lt_trichotomy n 1 with _ | h | _
+    · apply (LE.le.eq_or_lt' (by omega : n ≤ 0)).elim
+      · intro a
+        simp [←a] at h₂
+      · intro h abs
+        have : (n : ℝ) / 2 < 0 := by rify at h; linarith
+        have := (cantorSet_subset_unitInterval abs).left
+        linarith
+    · simp [cantorSet, h]
+      use 1
+      simp
+      exact ⟨fun _ _ _ ↦ by linarith, fun _ _ _ ↦ by linarith⟩
+    · apply (LE.le.eq_or_lt' (by omega : n ≥ 2)).elim
+      · intro
+        simp_all
+      · intro h abs
+        have : (n : ℝ) / 2 > 1 := by rify at h; linarith
+        have := (cantorSet_subset_unitInterval abs).right
+        linarith
+  | succ k ih =>
+    conv at ih =>
+      intro _ _ _ h
+      rw [←h]
+    intro x hx n h₁ h₂
+    rw [←h₁]
+    let p₀ := x * 3
+    let p₁ := x * 3 - 2
+    have abs₀ := by
+      refine ih p₀ ?_ n ?g1 ?g2
+      use n, k
+      refine ⟨?g3, ?g4⟩
+      case g1 | g3 =>
+        simp only [p₀, h₁]
+        ring_nf
+      case g2 | g4 =>
+        assumption
+    have abs₁ := by
+      refine ih p₁ ?_ (n - 4 * (3 ^ k)) ?g1 ?g2
+      use (n - 4 * (3 ^ k)), k
+      refine ⟨?g3, ?g4⟩
+      case g1 | g3 =>
+        simp [p₁, h₁]
+        field_simp
+        ring_nf
+      case g2 | g4 =>
+        rw [←h₂]
+        apply Int.gcd_sub_right_left_of_dvd
+        omega
+    intro abs
+    exact (cantorSet_scaled_mem abs).elim abs₀ abs₁
+
+/-- Half Triadics are dense over the reals -/
+lemma triadic_dense : Dense HalfTriadic := by
+  apply dense_of_exists_between
+  intro a b h
+  rw [←sub_pos] at h
+  have big_k {x : ℝ} : x > 0 → ∃ k : ℕ, 1 / (3 ^ k) < x := by
+    intro h
+    use (Int.log 3 (1 / x) + 1).toNat
+    calc
+      _ = 1 / (3 : ℝ) ^ ((Int.log 3 (1 / x) + 1).toNat : ℤ) := by rfl
+      _ ≤ 1 / (3 : ℝ) ^ (Int.log 3 (1 / x) + 1) := by
+        rw [←one_div_zpow, ←one_div_zpow]
+        apply (zpow_le_zpow_iff_right_of_lt_one₀ (by linarith) (by linarith)).mpr
+        exact Int.self_le_toNat _
+      _ < 1 / (1 / x) := by
+        apply one_div_lt_one_div_of_lt
+        · exact one_div_pos.mpr h
+        · apply Int.lt_zpow_succ_log_self (by norm_cast)
+      _ = _ := by simp
+  have ⟨k, hk⟩ := big_k h
+  let n := ⌊(a * (2 * 3 ^ k) - 1) / 2⌋ + 1
+  use (2 * n + 1) / (2 * 3 ^ k)
+  refine ⟨?_, ?_, ?_⟩
+  · exact ⟨2 * n + 1, k, by simp⟩
+  · simp only [Int.cast_add, Int.cast_one, n]
+    apply (lt_div_iff₀ (by norm_cast; simp : ((2 : ℝ) * 3 ^ k) > 0)).mpr
+    ring_nf
+    calc
+      _ > (3 : ℝ) + (-1 / 2 + a * 3 ^ k - 1) * 2 := by simp
+      _ ≥ _ := by ring_nf; simp
+  · have : (2 * n + 1) / (2 * 3 ^ k) - a < b - a := calc
+      _ ≤ 1 / (3 ^ k) := by
+        simp only [Int.cast_add, Int.cast_one, n]
+        rw [OrderedSub.tsub_le_iff_right]
+        apply (div_le_iff₀ (by norm_cast; simp : ((2 : ℝ) * 3 ^ k) > 0)).mpr
+        ring_nf
+        calc
+          _ ≤ 3 + (-1 / 2 + a * 3 ^ k) * 2 := by
+            simp
+            exact Int.floor_le _
+          _ ≤ _ := by simp; ring_nf; simp
+      _ < _ := hk
+    simp_all
+
+/-- The ternary Cantor has empty interior -/
+theorem empty_interior_cantorSet : interior cantorSet = ∅ := by
+  apply interior_eq_empty_iff_dense_compl.mpr
+  rw [dense_iff_closure_eq]
+  apply Set.eq_univ_of_univ_subset
+  calc
+    _ ⊇ _ := closure_mono half_triadic_not_in_cantorSet
+    _ = _ := dense_iff_closure_eq.mp triadic_dense


### PR DESCRIPTION
Prove that the Cantor set has empty interior and the cardinality of the continuum as discussed on [Zulip](https://leanprover.zulipchat.com/#narrow/channel/287929-mathlib4/topic/A.20few.20results.20about.20the.20Cantor.20set/with/543560670)

Moves:
- Mathlib.Topology.Instances.CantorSet -> Mathlib.Topology.Instances.CantorSet.Basic

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include at least one commit authored by each
co-author among the commits in the pull request. If necessary, you may 
create empty commits to indicate co-authorship, using commands like so:

git commit --author="Author Name <author@email.com>" --allow-empty -m "add Author Name as coauthor"

When merging, all the commits will be squashed into a single commit listing all co-authors.

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Mathlib.Topology.Instances.CantorSet ->
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
