### PR TITLE
[Merged by Bors] - feat: add lemmata about selfadjoint elements

### DIFF
--- a/Mathlib/Analysis/CStarAlgebra/Basic.lean
+++ b/Mathlib/Analysis/CStarAlgebra/Basic.lean
@@ -266,7 +266,7 @@ theorem IsSelfAdjoint.nnnorm_pow_two_pow {x : E} (hx : IsSelfAdjoint x) (n : ℕ
     rw [pow_succ', pow_mul', sq, (hx.pow (2 ^ k)).nnnorm_mul_self, hk, pow_mul']
 
 @[deprecated (since := "2025-10-07")]
-alias selfAdjoint.nnnorm_pow_two_pow :=IsSelfAdjoint.nnnorm_pow_two_pow
+alias selfAdjoint.nnnorm_pow_two_pow := IsSelfAdjoint.nnnorm_pow_two_pow
 
 theorem IsSelfAdjoint.norm_pow_two_pow {x : E} (hx : IsSelfAdjoint x) (n : ℕ) :
     ‖x ^ 2 ^ n‖ = ‖x‖ ^ 2 ^ n :=

--- a/Mathlib/Analysis/CStarAlgebra/Basic.lean
+++ b/Mathlib/Analysis/CStarAlgebra/Basic.lean
@@ -130,6 +130,14 @@ theorem nnnorm_self_mul_star {x : E} : ‖x * x⋆‖₊ = ‖x‖₊ * ‖x‖�
 theorem nnnorm_star_mul_self {x : E} : ‖x⋆ * x‖₊ = ‖x‖₊ * ‖x‖₊ :=
   Subtype.ext norm_star_mul_self
 
+lemma _root_.IsSelfAdjoint.norm_mul_self {x : E} (hx : IsSelfAdjoint x) :
+    ‖x * x‖ = ‖x‖ ^ 2 := by
+  simpa [sq, hx.star_eq] using  CStarRing.norm_star_mul_self (x := x)
+
+lemma _root_.IsSelfAdjoint.nnnorm_mul_self {x : E} (hx : IsSelfAdjoint x) :
+    ‖x * x‖₊ = ‖x‖₊ ^ 2 :=
+  Subtype.ext hx.norm_mul_self
+
 @[simp]
 theorem star_mul_self_eq_zero_iff (x : E) : x⋆ * x = 0 ↔ x = 0 := by
   rw [← norm_eq_zero, norm_star_mul_self]
@@ -246,19 +254,25 @@ end Unital
 
 end CStarRing
 
-theorem IsSelfAdjoint.nnnorm_pow_two_pow [NormedRing E] [StarRing E] [CStarRing E] {x : E}
-    (hx : IsSelfAdjoint x) (n : ℕ) : ‖x ^ 2 ^ n‖₊ = ‖x‖₊ ^ 2 ^ n := by
+section SelfAdjoint
+
+variable [NormedRing E] [StarRing E] [CStarRing E]
+
+theorem IsSelfAdjoint.nnnorm_pow_two_pow {x : E} (hx : IsSelfAdjoint x) (n : ℕ) :
+    ‖x ^ 2 ^ n‖₊ = ‖x‖₊ ^ 2 ^ n := by
   induction n with
   | zero => simp only [pow_zero, pow_one]
   | succ k hk =>
-    rw [pow_succ', pow_mul', sq]
-    nth_rw 1 [← selfAdjoint.mem_iff.mp hx]
-    rw [← star_pow, CStarRing.nnnorm_star_mul_self, ← sq, hk, pow_mul']
+    rw [pow_succ', pow_mul', sq, (hx.pow (2 ^ k)).nnnorm_mul_self, hk, pow_mul']
 
-theorem selfAdjoint.nnnorm_pow_two_pow [NormedRing E] [StarRing E] [CStarRing E] (x : selfAdjoint E)
-    (n : ℕ) : ‖x ^ 2 ^ n‖₊ = ‖x‖₊ ^ 2 ^ n :=
-  x.prop.nnnorm_pow_two_pow _
+@[deprecated (since := "2025-10-07")]
+alias selfAdjoint.nnnorm_pow_two_pow :=IsSelfAdjoint.nnnorm_pow_two_pow
 
+theorem IsSelfAdjoint.norm_pow_two_pow {x : E} (hx : IsSelfAdjoint x) (n : ℕ) :
+    ‖x ^ 2 ^ n‖ = ‖x‖ ^ 2 ^ n :=
+  congr($(hx.nnnorm_pow_two_pow n))
+
+end SelfAdjoint
 section starₗᵢ
 
 variable [CommSemiring 𝕜] [StarRing 𝕜]

--- a/Mathlib/Analysis/CStarAlgebra/Basic.lean
+++ b/Mathlib/Analysis/CStarAlgebra/Basic.lean
@@ -68,6 +68,11 @@ theorem star_isometry : Isometry (star : E → E) :=
 instance (priority := 100) NormedStarGroup.to_continuousStar : ContinuousStar E :=
   ⟨star_isometry.continuous⟩
 
+noncomputable
+instance [NormedField 𝕜] [NormedSpace 𝕜 E] [Star 𝕜] [TrivialStar 𝕜] [StarModule 𝕜 E] :
+    NormedSpace 𝕜 (selfAdjoint E) where
+  norm_smul_le _ _ := norm_smul_le _ (_ : E)
+
 end NormedStarGroup
 
 instance RingHomIsometric.starRingEnd [NormedCommRing E] [StarRing E] [NormedStarGroup E] :

--- a/Mathlib/LinearAlgebra/Complex/Module.lean
+++ b/Mathlib/LinearAlgebra/Complex/Module.lean
@@ -439,18 +439,22 @@ lemma imaginaryPart_comp_subtype_selfAdjoint :
     LinearMap.comp_zero]
 
 @[simp]
+lemma selfAdjoint.realPart_coe {x : selfAdjoint A} : ℜ (x : A) = x :=
+  Subtype.ext x.property.coe_realPart
+
+@[simp]
+lemma selfAdjoint.imaginaryPart_coe {x : selfAdjoint A} : ℑ (x : A) = 0 :=
+  x.property.imaginaryPart
+
 lemma imaginaryPart_realPart {x : A} : ℑ (ℜ x : A) = 0 :=
   (ℜ x).property.imaginaryPart
 
-@[simp]
 lemma imaginaryPart_imaginaryPart {x : A} : ℑ (ℑ x : A) = 0 :=
   (ℑ x).property.imaginaryPart
 
-@[simp]
 lemma realPart_idem {x : A} : ℜ (ℜ x : A) = ℜ x :=
   Subtype.ext <| (ℜ x).property.coe_realPart
 
-@[simp]
 lemma realPart_imaginaryPart {x : A} : ℜ (ℑ x : A) = ℑ x :=
   Subtype.ext <| (ℑ x).property.coe_realPart
 


### PR DESCRIPTION
This contains:

- a `NormedSpace 𝕜 (selfAdjoint E)` instance.
- `‖x * x‖ = ‖x‖ ^ 2` for selfadjoint `x` in a non-unital C⋆-ring.
- some improved `simp` lemmas for `realPart` and `imaginaryPart` which supersede existing ones.

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include at least one commit authored by each
co-author among the commits in the pull request. If necessary, you may 
create empty commits to indicate co-authorship, using commands like so:

git commit --author="Author Name <author@email.com>" --allow-empty -m "add Author Name as coauthor"

When merging, all the commits will be squashed into a single commit listing all co-authors.

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
