### PR TITLE
[Merged by Bors] - docs: use `CoxeterMatrix.Group`  in doc-strings

### DIFF
--- a/Mathlib/GroupTheory/Coxeter/Basic.lean
+++ b/Mathlib/GroupTheory/Coxeter/Basic.lean
@@ -19,7 +19,7 @@ This file defines Coxeter groups and Coxeter systems.
 Let `B` be a (possibly infinite) type, and let $M = (M_{i,i'})_{i, i' \in B}$ be a matrix
 of natural numbers. Further assume that $M$ is a *Coxeter matrix* (`CoxeterMatrix`); that is, $M$ is
 symmetric and $M_{i,i'} = 1$ if and only if $i = i'$. The *Coxeter group* associated to $M$
-(`CoxeterMatrix.group`) has the presentation
+(`CoxeterMatrix.Group`) has the presentation
 $$\langle \{s_i\}_{i \in B} \vert \{(s_i s_{i'})^{M_{i, i'}}\}_{i, i' \in B} \rangle.$$
 The elements $s_i$ are called the *simple reflections* (`CoxeterMatrix.simple`) of the Coxeter
 group. Note that every simple reflection is an involution.
@@ -108,7 +108,7 @@ protected def Group : Type _ := PresentedGroup M.relationsSet
 
 instance : Group M.Group := QuotientGroup.Quotient.group _
 
-/-- The simple reflection of the Coxeter group `M.group` at the index `i`. -/
+/-- The simple reflection of the Coxeter group `M.Group` at the index `i`. -/
 def simple (i : B) : M.Group := PresentedGroup.of i
 
 theorem reindex_relationsSet :


### PR DESCRIPTION
I observed this looking at the docs and noticing that `CoxeterMatrix.group` was not linked (second paragraph of [file#Mathlib.GroupTheory.Coxeter.Basic](https://leanprover-community.github.io/mathlib4_docs/Mathlib/GroupTheory/Coxeter/Basic.html)).

Also note that [docs#CoxeterMatrix.Group](https://leanprover-community.github.io/mathlib4_docs/Mathlib/GroupTheory/Coxeter/Basic.html#CoxeterMatrix.Group) exists, while [docs#CoxeterMatrix.group](https://leanprover-community.github.io/mathlib4_docs/Mathlib/GroupTheory/Coxeter/Basic.html#CoxeterMatrix.group) does not!

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include at least one commit authored by each
co-author among the commits in the pull request. If necessary, you may 
create empty commits to indicate co-authorship, using commands like so:

git commit --author="Author Name <author@email.com>" --allow-empty -m "add Author Name as coauthor"

When merging, all the commits will be squashed into a single commit listing all co-authors.

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
