### PR TITLE
[Merged by Bors] - feat: support coercions in the differential geometry elaborators

### DIFF
--- a/Mathlib/Geometry/Manifold/Notation.lean
+++ b/Mathlib/Geometry/Manifold/Notation.lean
@@ -393,7 +393,9 @@ scoped elab:max "MDiff" ppSpace t:term:arg : term => do
   mkAppM ``MDifferentiable #[srcI, tgtI, e]
 
 -- We ensure the type of `n` before checking `f` is a function to provide better error messages
--- in case e.g. just `n` was forgotten.
+-- in case e.g. `f` and `n` are swapped.
+-- TODO: provide better error messages if just `n` is forgotten (say, by making `n` optional in
+-- the parser and erroring later in the elaborator); currently, this yields just a parser error.
 
 /-- `CMDiffAt[s] n f x` elaborates to `ContMDiffWithinAt I J n f s x`,
 trying to determine `I` and `J` from the local context.

--- a/Mathlib/Geometry/Manifold/Notation.lean
+++ b/Mathlib/Geometry/Manifold/Notation.lean
@@ -339,7 +339,7 @@ def findModels (e : Expr) (es : Option Expr) : TermElabM (Expr × Expr) := do
 
 end Elab
 
-open Elab Lean.Meta
+open Elab
 
 /-- `MDiffAt[s] f x` elaborates to `MDifferentiableWithinAt I J f s x`,
 trying to determine `I` and `J` from the local context.

--- a/Mathlib/Geometry/Manifold/Notation.lean
+++ b/Mathlib/Geometry/Manifold/Notation.lean
@@ -100,7 +100,7 @@ private def findSomeLocalInstanceOf? (c : Name) {α} (p : Expr → Expr → Meta
     MetaM (Option α) := do
   (← getLocalInstances).findSomeM? fun inst ↦ do
     if inst.className == c then
-      let type ← whnfR <|← instantiateMVars <|← inferType inst.fvar
+      let type ← whnfR <| ← instantiateMVars <| ← inferType inst.fvar
       p inst.fvar type
     else return none
 
@@ -110,7 +110,7 @@ to `p`. -/
 private def findSomeLocalHyp? {α} (p : Expr → Expr → MetaM (Option α)) : MetaM (Option α) := do
   (← getLCtx).findDeclRevM? fun decl ↦ do
     if decl.isImplementationDetail then return none
-    let type ← whnfR <|← instantiateMVars decl.type
+    let type ← whnfR <| ← instantiateMVars decl.type
     p decl.toExpr type
 
 end Elab
@@ -132,7 +132,7 @@ run.
 -- TODO: factor out `MetaM` component for reuse
 scoped elab:max "T% " t:term:arg : term => do
   let e ← Term.elabTerm t none
-  let etype ← whnf <|← instantiateMVars <|← inferType e
+  let etype ← whnf <| ← instantiateMVars <| ← inferType e
   match etype with
   | .forallE x base tgt _ => withLocalDeclD x base fun x ↦ do
     let tgtHasLooseBVars := tgt.hasLooseBVars
@@ -317,7 +317,7 @@ We pass `e` instead of just its type for better diagnostics.
 
 If `es` is `some`, we verify that `src` and the type of `es` are definitionally equal. -/
 def findModels (e : Expr) (es : Option Expr) : TermElabM (Expr × Expr) := do
-  let etype ← whnf <|← instantiateMVars <|← inferType e
+  let etype ← whnf <| ← instantiateMVars <| ← inferType e
   match etype with
   | .forallE _ src tgt _ =>
     if tgt.hasLooseBVars then
@@ -330,7 +330,7 @@ def findModels (e : Expr) (es : Option Expr) : TermElabM (Expr × Expr) := do
       /- Note: we use `isDefEq` here since persistent metavariable assignments in `src` and
       `estype` are acceptable.
       TODO: consider attempting to coerce `es` to a `Set`. -/
-      if !(← isDefEq estype <|← mkAppM ``Set #[src]) then
+      if !(← isDefEq estype <| ← mkAppM ``Set #[src]) then
         throwError "The domain {src} of {e} is not definitionally equal to the carrier type of \
           the set {es} : {estype}"
     let tgtI ← findModel tgt (src, srcI)
@@ -346,7 +346,7 @@ trying to determine `I` and `J` from the local context.
 The argument `x` can be omitted. -/
 scoped elab:max "MDiffAt[" s:term "]" ppSpace f:term:arg : term => do
   let es ← Term.elabTerm s none
-  let ef ← ensureIsFunction <|← Term.elabTerm f none
+  let ef ← ensureIsFunction <| ← Term.elabTerm f none
   let (srcI, tgtI) ← findModels ef es
   mkAppM ``MDifferentiableWithinAt #[srcI, tgtI, ef, es]
 
@@ -354,7 +354,7 @@ scoped elab:max "MDiffAt[" s:term "]" ppSpace f:term:arg : term => do
 trying to determine `I` and `J` from the local context.
 The argument `x` can be omitted. -/
 scoped elab:max "MDiffAt" ppSpace t:term:arg : term => do
-  let e ← ensureIsFunction <|← Term.elabTerm t none
+  let e ← ensureIsFunction <| ← Term.elabTerm t none
   let (srcI, tgtI) ← findModels e none
   mkAppM ``MDifferentiableAt #[srcI, tgtI, e]
 
@@ -364,7 +364,7 @@ scoped elab:max "MDiffAt" ppSpace t:term:arg : term => do
 -- The argument `x` can be omitted. -/
 -- scoped elab:max "MDiffAt2" ppSpace t:term:arg : term => do
 --   let e ← Term.elabTerm t none
---   let etype ← whnfR <|← instantiateMVars <|← inferType e
+--   let etype ← whnfR <| ← instantiateMVars <| ← inferType e
 --   forallBoundedTelescope etype (some 1) fun src tgt ↦ do
 --     if let some src := src[0]? then
 --       let srcI ← findModel (← inferType src)
@@ -381,14 +381,14 @@ scoped elab:max "MDiffAt" ppSpace t:term:arg : term => do
 trying to determine `I` and `J` from the local context. -/
 scoped elab:max "MDiff[" s:term "]" ppSpace t:term:arg : term => do
   let es ← Term.elabTerm s none
-  let et ← ensureIsFunction <|← Term.elabTerm t none
+  let et ← ensureIsFunction <| ← Term.elabTerm t none
   let (srcI, tgtI) ← findModels et es
   mkAppM ``MDifferentiableOn #[srcI, tgtI, et, es]
 
 /-- `MDiff f` elaborates to `MDifferentiable I J f`,
 trying to determine `I` and `J` from the local context. -/
 scoped elab:max "MDiff" ppSpace t:term:arg : term => do
-  let e ← ensureIsFunction <|← Term.elabTerm t none
+  let e ← ensureIsFunction <| ← Term.elabTerm t none
   let (srcI, tgtI) ← findModels e none
   mkAppM ``MDifferentiable #[srcI, tgtI, e]
 
@@ -404,7 +404,7 @@ The argument `x` can be omitted. -/
 scoped elab:max "CMDiffAt[" s:term "]" ppSpace nt:term:arg ppSpace f:term:arg : term => do
   let es ← Term.elabTerm s none
   let ne ← Term.elabTermEnsuringType nt q(WithTop ℕ∞)
-  let ef ← ensureIsFunction <|← Term.elabTerm f none
+  let ef ← ensureIsFunction <| ← Term.elabTerm f none
   let (srcI, tgtI) ← findModels ef es
   mkAppM ``ContMDiffWithinAt #[srcI, tgtI, ne, ef, es]
 
@@ -413,7 +413,7 @@ trying to determine `I` and `J` from the local context.
 `n` is coerced to `WithTop ℕ∞` if necessary (so passing a `ℕ`, `∞` or `ω` are all supported).
 The argument `x` can be omitted. -/
 scoped elab:max "CMDiffAt" ppSpace nt:term:arg ppSpace t:term:arg : term => do
-  let e ← ensureIsFunction <|← Term.elabTerm t none
+  let e ← ensureIsFunction <| ← Term.elabTerm t none
   let ne ← Term.elabTermEnsuringType nt q(WithTop ℕ∞)
   let (srcI, tgtI) ← findModels e none
   mkAppM ``ContMDiffAt #[srcI, tgtI, ne, e]
@@ -424,7 +424,7 @@ trying to determine `I` and `J` from the local context.
 scoped elab:max "CMDiff[" s:term "]" ppSpace nt:term:arg ppSpace f:term:arg : term => do
   let es ← Term.elabTerm s none
   let ne ← Term.elabTermEnsuringType nt q(WithTop ℕ∞)
-  let ef ← ensureIsFunction <|← Term.elabTerm f none
+  let ef ← ensureIsFunction <| ← Term.elabTerm f none
   let (srcI, tgtI) ← findModels ef es
   mkAppM ``ContMDiffOn #[srcI, tgtI, ne, ef, es]
 
@@ -433,7 +433,7 @@ trying to determine `I` and `J` from the local context.
 `n` is coerced to `WithTop ℕ∞` if necessary (so passing a `ℕ`, `∞` or `ω` are all supported). -/
 scoped elab:max "CMDiff" ppSpace nt:term:arg ppSpace f:term:arg : term => do
   let ne ← Term.elabTermEnsuringType nt q(WithTop ℕ∞)
-  let e ← ensureIsFunction <|← Term.elabTerm f none
+  let e ← ensureIsFunction <| ← Term.elabTerm f none
   let (srcI, tgtI) ← findModels e none
   mkAppM ``ContMDiff #[srcI, tgtI, ne, e]
 
@@ -441,14 +441,14 @@ scoped elab:max "CMDiff" ppSpace nt:term:arg ppSpace f:term:arg : term => do
 trying to determine `I` and `J` from the local context. -/
 scoped elab:max "mfderiv[" s:term "]" ppSpace t:term:arg : term => do
   let es ← Term.elabTerm s none
-  let e ← ensureIsFunction <|← Term.elabTerm t none
+  let e ← ensureIsFunction <| ← Term.elabTerm t none
   let (srcI, tgtI) ← findModels e es
   mkAppM ``mfderivWithin #[srcI, tgtI, e, es]
 
 /-- `mfderiv% f x` elaborates to `mfderiv I J f x`,
 trying to determine `I` and `J` from the local context. -/
 scoped elab:max "mfderiv%" ppSpace t:term:arg : term => do
-  let e ← ensureIsFunction <|← Term.elabTerm t none
+  let e ← ensureIsFunction <| ← Term.elabTerm t none
   let (srcI, tgtI) ← findModels e none
   mkAppM ``mfderiv #[srcI, tgtI, e]
 

--- a/Mathlib/Geometry/Manifold/Notation.lean
+++ b/Mathlib/Geometry/Manifold/Notation.lean
@@ -337,6 +337,12 @@ def findModels (e : Expr) (es : Option Expr) : TermElabM (Expr × Expr) := do
           the set {es} : {estype}"
     let tgtI ← findModel tgt (src, srcI)
     return (srcI, tgtI)
+  | mkApp4 (.const ``OpenPartialHomeomorph [_uX, _uY]) X Y _ _ =>
+    trace[Elab.DiffGeo.MDiff] m!"found a partial homeomorphism from {X} to {Y}"
+    return (X, Y)
+  | mkApp4 (.const ``PartialEquiv [_uX, _uY]) X Y _ _ =>
+    trace[Elab.DiffGeo.MDiff] m!"found a partial equivalence from {X} to {Y}"
+    return (X, Y)
   | _ => throwError "Expected{indentD e}\nof type{indentD etype}\nto be a function"
 
 end Elab

--- a/Mathlib/Geometry/Manifold/Notation.lean
+++ b/Mathlib/Geometry/Manifold/Notation.lean
@@ -407,8 +407,8 @@ trying to determine `I` and `J` from the local context.
 The argument `x` can be omitted. -/
 scoped elab:max "CMDiffAt[" s:term "]" ppSpace nt:term:arg ppSpace f:term:arg : term => do
   let es ← Term.elabTerm s none
-  let ef ← ensureIsFunction <|← Term.elabTerm f none
   let ne ← Term.elabTermEnsuringType nt q(WithTop ℕ∞)
+  let ef ← ensureIsFunction <|← Term.elabTerm f none
   let (srcI, tgtI) ← findModels ef es
   mkAppM ``ContMDiffWithinAt #[srcI, tgtI, ne, ef, es]
 
@@ -427,8 +427,8 @@ trying to determine `I` and `J` from the local context.
 `n` is coerced to `WithTop ℕ∞` if necessary (so passing a `ℕ`, `∞` or `ω` are all supported). -/
 scoped elab:max "CMDiff[" s:term "]" ppSpace nt:term:arg ppSpace f:term:arg : term => do
   let es ← Term.elabTerm s none
-  let ef ← ensureIsFunction <|← Term.elabTerm f none
   let ne ← Term.elabTermEnsuringType nt q(WithTop ℕ∞)
+  let ef ← ensureIsFunction <|← Term.elabTerm f none
   let (srcI, tgtI) ← findModels ef es
   mkAppM ``ContMDiffOn #[srcI, tgtI, ne, ef, es]
 
@@ -436,8 +436,8 @@ scoped elab:max "CMDiff[" s:term "]" ppSpace nt:term:arg ppSpace f:term:arg : te
 trying to determine `I` and `J` from the local context.
 `n` is coerced to `WithTop ℕ∞` if necessary (so passing a `ℕ`, `∞` or `ω` are all supported). -/
 scoped elab:max "CMDiff" ppSpace nt:term:arg ppSpace f:term:arg : term => do
-  let e ← ensureIsFunction <|← Term.elabTerm f none
   let ne ← Term.elabTermEnsuringType nt q(WithTop ℕ∞)
+  let e ← ensureIsFunction <|← Term.elabTerm f none
   let (srcI, tgtI) ← findModels e none
   mkAppM ``ContMDiff #[srcI, tgtI, ne, e]
 

--- a/Mathlib/Geometry/Manifold/Notation.lean
+++ b/Mathlib/Geometry/Manifold/Notation.lean
@@ -401,6 +401,9 @@ scoped elab:max "MDiff" ppSpace t:term:arg : term => do
   let (srcI, tgtI) ← findModels e none
   mkAppM ``MDifferentiable #[srcI, tgtI, e]
 
+-- We ensure the type of `n` before checking `f` is a function to provide better error messages
+-- in case e.g. just `n` was forgotten.
+
 /-- `CMDiffAt[s] n f x` elaborates to `ContMDiffWithinAt I J n f s x`,
 trying to determine `I` and `J` from the local context.
 `n` is coerced to `WithTop ℕ∞` if necessary (so passing a `ℕ`, `∞` or `ω` are all supported).

--- a/Mathlib/Geometry/Manifold/Notation.lean
+++ b/Mathlib/Geometry/Manifold/Notation.lean
@@ -337,13 +337,15 @@ def findModels (e : Expr) (es : Option Expr) : TermElabM (Expr × Expr) := do
           the set {es} : {estype}"
     let tgtI ← findModel tgt (src, srcI)
     return (srcI, tgtI)
-  | mkApp4 (.const ``OpenPartialHomeomorph [_uX, _uY]) X Y _ _ =>
-    trace[Elab.DiffGeo.MDiff] m!"found a partial homeomorphism from {X} to {Y}"
-    return (X, Y)
-  | mkApp4 (.const ``PartialEquiv [_uX, _uY]) X Y _ _ =>
-    trace[Elab.DiffGeo.MDiff] m!"found a partial equivalence from {X} to {Y}"
-    return (X, Y)
-  | _ => throwError "Expected{indentD e}\nof type{indentD etype}\nto be a function"
+  | _ =>
+    match_expr etype with
+    | OpenPartialHomeomorph X Y _ _ =>
+      trace[Elab.DiffGeo.MDiff] m!"found a partial homeomorphism from {X} to {Y}"
+      return (X, Y)
+    | PartialEquiv X Y =>
+      trace[Elab.DiffGeo.MDiff] m!"found a partial equivalence from {X} to {Y}"
+      return (X, Y)
+    | _ => throwError "Expected{indentD e}\nof type{indentD etype}\nto be a function"
 
 end Elab
 

--- a/Mathlib/Geometry/Manifold/Notation.lean
+++ b/Mathlib/Geometry/Manifold/Notation.lean
@@ -67,7 +67,7 @@ variable {s : E → E'} in
 These elaborators can be combined: `CMDiffAt[u] n (T% s) x`
 
 **Warning.** These elaborators are a proof of concept; the implementation should be considered a
-prototype. Don't rewrite all of mathlib to use it just yet. Notable bugs and limitations include
+prototype. Don't rewrite all of mathlib to use it just yet. Notable limitations include
 the following.
 
 ## TODO
@@ -76,10 +76,8 @@ the following.
   is correct 90% of the time).
   For products of vector spaces `E × F`, this could print a warning about making a choice between
   the model in `E × F` and the product of the models on `E` and `F`.
-- extend the elaborators to support `OpenPartialHomeomorph`s and `PartialEquiv`s
-- better error messages (as needed)
-- further testing and fixing of edge cases
-- add tests for all of the above
+- better error messages (as needed), with tests
+- further testing and fixing of edge cases (with tests)
 - add delaborators for these elaborators
 
 -/

--- a/Mathlib/Geometry/Manifold/Notation.lean
+++ b/Mathlib/Geometry/Manifold/Notation.lean
@@ -310,13 +310,6 @@ where
     let iTerm : Term ← ``(𝓘($eT, $eT))
     Term.elabTerm iTerm none
 
-/-- Ensures that `e` is a function. Attempts to coerce `e` to a function if necessary. -/
-def ensureIsFunction (e : Expr) : MetaM Expr := do
-  let ty ← whnf <|← instantiateMVars <|← inferType e
-  if ty.isForall then return e else (← coerceToFunction? e).getDM <|
-    throwError "Expected{indentD e}\nof type{indentD ty}\nto be a function, or to be coercible to \
-      a function"
-
 /-- If the type of `e` is a non-dependent function between spaces `src` and `tgt`, try to find a
 model with corners on both `src` and `tgt`. If successful, return both models.
 
@@ -346,7 +339,7 @@ def findModels (e : Expr) (es : Option Expr) : TermElabM (Expr × Expr) := do
 
 end Elab
 
-open Elab
+open Elab Lean.Meta
 
 /-- `MDiffAt[s] f x` elaborates to `MDifferentiableWithinAt I J f s x`,
 trying to determine `I` and `J` from the local context.

--- a/Mathlib/Lean/Meta/Basic.lean
+++ b/Mathlib/Lean/Meta/Basic.lean
@@ -100,10 +100,10 @@ def Lean.Meta.withEnsuringLocalInstance {α : Type} (inst : MVarId) (k : MetaM (
 or fails with a descriptive error. -/
 def Lean.Meta.ensureHasType (e expectedType : Expr) : MetaM Expr := do
   let ty ← whnf <| ← instantiateMVars <| ← inferType e
-  let some name := expectedType.constName?
-    | throwError "expected type {expectedType} is not a constant"
-  if ty.isConstOf name then return e else (← coerceSimple? e expectedType).toOption.getDM <|
-    throwError "Expected{indentD e}\nto have type{indentD ty}\n or to be coercible to it"
+  let ty ← inferType e
+  if ← withNewMCtxDepth (isDefEq ty expectedType) then return e else
+    (← coerceSimple? e expectedType).toOption.getDM <|
+      throwError "Expected{indentD e}\nto have type{indentD ty}\n or to be coercible to it"
 
 /-- Checks that `e` is a function (i.e. that its type is a `.forallE` after `instantiateMVars` and
 `whnf`). If not, coerces `e` to a function or fails with a descriptive error. -/

--- a/Mathlib/Lean/Meta/Basic.lean
+++ b/Mathlib/Lean/Meta/Basic.lean
@@ -94,3 +94,10 @@ def Lean.Meta.withEnsuringLocalInstance {α : Type} (inst : MVarId) (k : MetaM (
       let (e, v) ← k
       let e' := (← e.abstractM #[inst']).instantiate1 instE
       return (e', v)
+
+/-- Ensures that `e` is a function. Attempts to coerce `e` to a function if necessary. -/
+def Lean.Meta.ensureIsFunction (e : Expr) : MetaM Expr := do
+  let ty ← whnf <|← instantiateMVars <|← inferType e
+  if ty.isForall then return e else (← coerceToFunction? e).getDM <|
+    throwError "Expected{indentD e}\nof type{indentD ty}\nto be a function, or to be coercible to \
+      a function"

--- a/Mathlib/Lean/Meta/Basic.lean
+++ b/Mathlib/Lean/Meta/Basic.lean
@@ -95,8 +95,8 @@ def Lean.Meta.withEnsuringLocalInstance {α : Type} (inst : MVarId) (k : MetaM (
       let e' := (← e.abstractM #[inst']).instantiate1 instE
       return (e', v)
 
-/-- Checks that `e` has type `expectedType` (i.e. that its type is `expectedType` after
-`instantiateMVars` and `whnf`). If not, coerces `e` to this type
+/-- Checks that `e` has type `expectedType` (i.e. that its type is defeq to `expectedType`
+at the current transparency). If not, coerces `e` to this type
 or fails with a descriptive error. -/
 def Lean.Meta.ensureHasType (e expectedType : Expr) : MetaM Expr := do
   let ty ← whnf <| ← instantiateMVars <| ← inferType e

--- a/Mathlib/Lean/Meta/Basic.lean
+++ b/Mathlib/Lean/Meta/Basic.lean
@@ -95,7 +95,8 @@ def Lean.Meta.withEnsuringLocalInstance {α : Type} (inst : MVarId) (k : MetaM (
       let e' := (← e.abstractM #[inst']).instantiate1 instE
       return (e', v)
 
-/-- Ensures that `e` is a function. Attempts to coerce `e` to a function if necessary. -/
+/-- Checks that `e` is a function (i.e. that its type is a `.forallE` after `instantiateMVars` and 
+`whnf`). If not, coerces `e` to a function or fails with a descriptive error. -/
 def Lean.Meta.ensureIsFunction (e : Expr) : MetaM Expr := do
   let ty ← whnf <|← instantiateMVars <|← inferType e
   if ty.isForall then return e else (← coerceToFunction? e).getDM <|

--- a/Mathlib/Lean/Meta/Basic.lean
+++ b/Mathlib/Lean/Meta/Basic.lean
@@ -95,10 +95,28 @@ def Lean.Meta.withEnsuringLocalInstance {α : Type} (inst : MVarId) (k : MetaM (
       let e' := (← e.abstractM #[inst']).instantiate1 instE
       return (e', v)
 
+/-- Checks that `e` has type `expectedType` (i.e. that its type is `expectedType` after
+`instantiateMVars` and `whnf`). If not, coerces `e` to this type
+or fails with a descriptive error. -/
+def Lean.Meta.ensureHasType (e expectedType : Expr) : MetaM Expr := do
+  let ty ← whnf <| ← instantiateMVars <| ← inferType e
+  let some name := expectedType.constName?
+    | throwError "expected type {expectedType} is not a constant"
+  if ty.isConstOf name then return e else (← coerceSimple? e expectedType).toOption.getDM <|
+    throwError "Expected{indentD e}\nto have type{indentD ty}\n or to be coercible to it"
+
 /-- Checks that `e` is a function (i.e. that its type is a `.forallE` after `instantiateMVars` and
 `whnf`). If not, coerces `e` to a function or fails with a descriptive error. -/
 def Lean.Meta.ensureIsFunction (e : Expr) : MetaM Expr := do
-  let ty ← whnf <|← instantiateMVars <|← inferType e
+  let ty ← whnf <| ← instantiateMVars <| ← inferType e
   if ty.isForall then return e else (← coerceToFunction? e).getDM <|
     throwError "Expected{indentD e}\nof type{indentD ty}\nto be a function, or to be coercible to \
       a function"
+
+/-- Checks that `e` is a type (i.e. that its type is a `Sort` after `instantiateMVars` and
+`whnf`). If not, coerces `e` to a Sort or fails with a descriptive error. -/
+def Lean.Meta.ensureIsSort (e : Expr) : MetaM Expr := do
+  let ty ← whnf <| ← instantiateMVars <| ← inferType e
+  if ty.isSort then return e else (← coerceToSort? e).getDM <|
+    throwError "Expected{indentD e}\nof type{indentD ty}\nto be a Sort, or to be coercible to \
+      a Sort"

--- a/Mathlib/Lean/Meta/Basic.lean
+++ b/Mathlib/Lean/Meta/Basic.lean
@@ -95,7 +95,7 @@ def Lean.Meta.withEnsuringLocalInstance {α : Type} (inst : MVarId) (k : MetaM (
       let e' := (← e.abstractM #[inst']).instantiate1 instE
       return (e', v)
 
-/-- Checks that `e` is a function (i.e. that its type is a `.forallE` after `instantiateMVars` and 
+/-- Checks that `e` is a function (i.e. that its type is a `.forallE` after `instantiateMVars` and
 `whnf`). If not, coerces `e` to a function or fails with a descriptive error. -/
 def Lean.Meta.ensureIsFunction (e : Expr) : MetaM Expr := do
   let ty ← whnf <|← instantiateMVars <|← inferType e

--- a/Mathlib/Lean/Meta/Basic.lean
+++ b/Mathlib/Lean/Meta/Basic.lean
@@ -99,7 +99,6 @@ def Lean.Meta.withEnsuringLocalInstance {α : Type} (inst : MVarId) (k : MetaM (
 at the current transparency). If not, coerces `e` to this type
 or fails with a descriptive error. -/
 def Lean.Meta.ensureHasType (e expectedType : Expr) : MetaM Expr := do
-  let ty ← whnf <| ← instantiateMVars <| ← inferType e
   let ty ← inferType e
   if ← withNewMCtxDepth (isDefEq ty expectedType) then return e else
     (← coerceSimple? e expectedType).toOption.getDM <|

--- a/MathlibTest/DifferentialGeometry/Notation.lean
+++ b/MathlibTest/DifferentialGeometry/Notation.lean
@@ -372,6 +372,24 @@ info: mfderivWithin I 𝓘(𝕜, E) (↑ψ) s : (x : M) → TangentSpace I x →
 #guard_msgs in
 #check mfderiv[s] ψ
 
+/--
+info: mfderivWithin I 𝓘(𝕜, E) (↑ψ) s : (x : M) → TangentSpace I x →L[𝕜] TangentSpace 𝓘(𝕜, E) (↑ψ x)
+-/
+#guard_msgs in
+variable {f : ContMDiffSection I F n V} in
+#check mfderiv[s] ψ
+
+/-- info: mfderiv I I' ⇑g : (x : M) → TangentSpace I x →L[𝕜] TangentSpace I' (g x) -/
+#guard_msgs in
+variable {g : ContMDiffMap I I' M M' n} in
+#check mfderiv% g
+
+-- An example of "any type" which coerces to functions.
+/-- info: mfderiv I I' ⇑g : (x : M) → TangentSpace I x →L[𝕜] TangentSpace I' (g x) -/
+#guard_msgs in
+variable {g : Equiv M M'} in
+#check mfderiv% g
+
 end coercion
 
 variable {σ : Π x : M, V x} {σ' : (x : E) → Trivial E E' x} {s : E → E'}

--- a/MathlibTest/DifferentialGeometry/Notation.lean
+++ b/MathlibTest/DifferentialGeometry/Notation.lean
@@ -573,6 +573,7 @@ variable [IsManifold I 1 M] [IsManifold I' 1 M']
 section error
 
 -- yields a parse error, "unexpected token '/--'; expected term"
+-- TODO: make this parse, but error in the elaborator
 -- #check CMDiffAt[s] f
 
 /--

--- a/MathlibTest/DifferentialGeometry/Notation.lean
+++ b/MathlibTest/DifferentialGeometry/Notation.lean
@@ -92,10 +92,12 @@ end TotalSpace
 /-! Tests for the elaborators for `MDifferentiable{WithinAt,At,On}`. -/
 section differentiability
 
--- Start with some basic tests: a simple function, both in applied and unapplied form.
 variable {EM' : Type*} [NormedAddCommGroup EM']
   [NormedSpace 𝕜 EM'] {H' : Type*} [TopologicalSpace H'] (I' : ModelWithCorners 𝕜 EM' H')
   {M' : Type*} [TopologicalSpace M'] [ChartedSpace H' M']
+
+/-! Some basic tests: a simple function, both in applied and unapplied form -/
+section basic
 
 -- General case: a function between two manifolds.
 variable {f : M → M'} {s : Set M} {m : M}
@@ -368,11 +370,15 @@ variable {f : 𝕜 → 𝕜} {u : Set 𝕜} {a : 𝕜}
 #guard_msgs in
 #check MDiff[u] f
 
--- This elaborator can be combined with the total space elaborator.
--- XXX: these tests might be incomplete; extend as needed!
+end basic
 
 variable {σ : Π x : M, V x} {σ' : (x : E) → Trivial E E' x} {s : E → E'}
 variable (X : (m : M) → TangentSpace I m) [IsManifold I 1 M]
+
+/-! These elaborators can be combined with the total space elaborator. -/
+section interaction
+
+-- XXX: these tests might be incomplete; extend as needed!
 
 /-- info: MDifferentiableAt I (I.prod 𝓘(𝕜, E)) fun m ↦ TotalSpace.mk' E m (X m) : M → Prop -/
 #guard_msgs in
@@ -387,6 +393,8 @@ info: MDifferentiableAt 𝓘(𝕜, E) (𝓘(𝕜, E).prod 𝓘(𝕜, E')) fun x 
 -/
 #guard_msgs in
 #check MDiffAt (T% σ')
+
+end interaction
 
 section
 

--- a/MathlibTest/DifferentialGeometry/Notation.lean
+++ b/MathlibTest/DifferentialGeometry/Notation.lean
@@ -398,7 +398,7 @@ variable (X : (m : M) → TangentSpace I m) [IsManifold I 1 M]
 /-! These elaborators can be combined with the total space elaborator. -/
 section interaction
 
--- XXX: these tests might be incomplete; extend as needed!
+-- Note: these tests might be incomplete; extend as needed!
 
 /-- info: MDifferentiableAt I (I.prod 𝓘(𝕜, E)) fun m ↦ TotalSpace.mk' E m (X m) : M → Prop -/
 #guard_msgs in

--- a/MathlibTest/DifferentialGeometry/Notation.lean
+++ b/MathlibTest/DifferentialGeometry/Notation.lean
@@ -125,30 +125,35 @@ variable {φ : OpenPartialHomeomorph M E} {ψ : PartialEquiv M E}
 
 #check MDifferentiableWithinAt I 𝓘(𝕜, E) ψ
 #check MDifferentiableWithinAt I 𝓘(𝕜, E) ψ s
+
+
 /--
 error: Application type mismatch: The argument
-  M
+  φ
 has type
-  Type u_4
+  OpenPartialHomeomorph M E
 but is expected to have type
-  ModelWithCorners ?𝕜 ?E ?H
+  ?M → ?M'
 in the application
-  @MDifferentiableWithinAt ?𝕜 ?inst✝ ?E ?inst✝¹ ?inst✝² ?H ?inst✝³ M
+  MDifferentiableWithinAt I 𝓘(𝕜, E) φ
 -/
 #guard_msgs in
 #check MDiffAt[s] φ
+
 /--
 error: Application type mismatch: The argument
-  M
+  ψ
 has type
-  Type u_4
+  PartialEquiv M E
 but is expected to have type
-  ModelWithCorners ?𝕜 ?E ?H
+  ?M → ?M'
 in the application
-  @MDifferentiableWithinAt ?𝕜 ?inst✝ ?E ?inst✝¹ ?inst✝² ?H ?inst✝³ M
+  MDifferentiableWithinAt I 𝓘(𝕜, E) ψ
 -/
 #guard_msgs in
 #check MDiffAt[s] ψ
+
+#exit
 
 -- Testing an error message.
 section

--- a/MathlibTest/DifferentialGeometry/Notation.lean
+++ b/MathlibTest/DifferentialGeometry/Notation.lean
@@ -544,7 +544,7 @@ variable [IsManifold I 1 M] [IsManifold I' 1 M']
 -- TODO: can there be better error messages when forgetting the smoothness exponent?
 section error
 
--- yields a parse error, "unexpected toekn '/--'; expected term"
+-- yields a parse error, "unexpected token '/--'; expected term"
 -- #check CMDiffAt[s] f
 
 /--

--- a/MathlibTest/DifferentialGeometry/Notation.lean
+++ b/MathlibTest/DifferentialGeometry/Notation.lean
@@ -581,10 +581,28 @@ of type
 to be a function, or to be coercible to a function
 -/
 #guard_msgs in
-#check CMDiffAt[s] f m
+#check CMDiff[s] f m
 
--- yields a parse error, "unexpected toekn '/--'; expected term"
+-- yields a parse error, "unexpected token '/--'; expected term"
 -- #check CMDiffAt f
+
+/--
+error: Type mismatch
+  f
+has type
+  M → M'
+of sort `Type (max u_10 u_4)` but is expected to have type
+  WithTop ℕ∞
+of sort `Type`
+---
+error: Expected
+  n
+of type
+  Option ℕ∞
+to be a function, or to be coercible to a function
+-/
+#guard_msgs in
+#check CMDiff f n
 
 end error
 

--- a/MathlibTest/DifferentialGeometry/Notation.lean
+++ b/MathlibTest/DifferentialGeometry/Notation.lean
@@ -138,11 +138,14 @@ in the application
 #guard_msgs in
 #check MDiffAt[s] φ
 /--
-error: Expected
-  ψ
-of type
-  PartialEquiv M E
-to be a function
+error: Application type mismatch: The argument
+  M
+has type
+  Type u_4
+but is expected to have type
+  ModelWithCorners ?𝕜 ?E ?H
+in the application
+  @MDifferentiableWithinAt ?𝕜 ?inst✝ ?E ?inst✝¹ ?inst✝² ?H ?inst✝³ M
 -/
 #guard_msgs in
 #check MDiffAt[s] ψ

--- a/MathlibTest/DifferentialGeometry/Notation.lean
+++ b/MathlibTest/DifferentialGeometry/Notation.lean
@@ -122,68 +122,6 @@ variable {f : M → M'} {s : Set M} {m : M}
 #guard_msgs in
 #check MDiff[s] f
 
-/-! A partial homeomorphism or partial equivalence. More generally, this works for any type
-with a coercion to (possibly dependent) functions. -/
-section coercion
-
-variable {φ : OpenPartialHomeomorph M E} {ψ : PartialEquiv M E}
-
-/-- info: MDifferentiableWithinAt I 𝓘(𝕜, E) (↑φ) s : M → Prop -/
-#guard_msgs in
-#check MDiffAt[s] φ
-
-/-- info: MDifferentiableWithinAt I 𝓘(𝕜, E) (↑ψ) s : M → Prop -/
-#guard_msgs in
-#check MDiffAt[s] ψ
-
-/-- info: MDifferentiableAt I 𝓘(𝕜, E) ↑φ : M → Prop -/
-#guard_msgs in
-#check MDiffAt φ
-
-/-- info: MDifferentiableAt I 𝓘(𝕜, E) ↑ψ : M → Prop -/
-#guard_msgs in
-#check MDiffAt ψ
-
-/-- info: MDifferentiableOn I 𝓘(𝕜, E) (↑φ) s : Prop -/
-#guard_msgs in
-#check MDiff[s] φ
-
-/-- info: MDifferentiableOn I 𝓘(𝕜, E) (↑ψ) s : Prop -/
-#guard_msgs in
-#check MDiff[s] ψ
-
-/-- info: MDifferentiable I 𝓘(𝕜, E) ↑φ : Prop -/
-#guard_msgs in
-#check MDiff φ
-
-/-- info: ContMDiffWithinAt I 𝓘(𝕜, E) 2 (↑ψ) s : M → Prop -/
-#guard_msgs in
-#check CMDiffAt[s] 2 ψ
-
-/-- info: ContMDiffOn I 𝓘(𝕜, E) 2 (↑φ) s : Prop -/
-#guard_msgs in
-#check CMDiff[s] 2 φ
-
-/-- info: ContMDiffAt I 𝓘(𝕜, E) 2 ↑φ : M → Prop -/
-#guard_msgs in
-#check CMDiffAt 2 φ
-
-/-- info: ContMDiff I 𝓘(𝕜, E) 2 ↑ψ : Prop -/
-#guard_msgs in
-#check CMDiff 2 ψ
-
-/-- info: mfderiv I 𝓘(𝕜, E) ↑φ : (x : M) → TangentSpace I x →L[𝕜] TangentSpace 𝓘(𝕜, E) (↑φ x) -/
-#guard_msgs in
-#check mfderiv% φ
-
-/--
-info: mfderivWithin I 𝓘(𝕜, E) (↑ψ) s : (x : M) → TangentSpace I x →L[𝕜] TangentSpace 𝓘(𝕜, E) (↑ψ x)
--/
-#guard_msgs in
-#check mfderiv[s] ψ
-
-end coercion
-
 -- Testing an error message.
 section
 
@@ -371,6 +309,70 @@ variable {f : 𝕜 → 𝕜} {u : Set 𝕜} {a : 𝕜}
 #check MDiff[u] f
 
 end basic
+
+/-! A partial homeomorphism or partial equivalence. More generally, this works for any type
+with a coercion to (possibly dependent) functions. -/
+section coercion
+
+variable {s : Set M} {m : M}
+
+variable {φ : OpenPartialHomeomorph M E} {ψ : PartialEquiv M E}
+
+/-- info: MDifferentiableWithinAt I 𝓘(𝕜, E) (↑φ) s : M → Prop -/
+#guard_msgs in
+#check MDiffAt[s] φ
+
+/-- info: MDifferentiableWithinAt I 𝓘(𝕜, E) (↑ψ) s : M → Prop -/
+#guard_msgs in
+#check MDiffAt[s] ψ
+
+/-- info: MDifferentiableAt I 𝓘(𝕜, E) ↑φ : M → Prop -/
+#guard_msgs in
+#check MDiffAt φ
+
+/-- info: MDifferentiableAt I 𝓘(𝕜, E) ↑ψ : M → Prop -/
+#guard_msgs in
+#check MDiffAt ψ
+
+/-- info: MDifferentiableOn I 𝓘(𝕜, E) (↑φ) s : Prop -/
+#guard_msgs in
+#check MDiff[s] φ
+
+/-- info: MDifferentiableOn I 𝓘(𝕜, E) (↑ψ) s : Prop -/
+#guard_msgs in
+#check MDiff[s] ψ
+
+/-- info: MDifferentiable I 𝓘(𝕜, E) ↑φ : Prop -/
+#guard_msgs in
+#check MDiff φ
+
+/-- info: ContMDiffWithinAt I 𝓘(𝕜, E) 2 (↑ψ) s : M → Prop -/
+#guard_msgs in
+#check CMDiffAt[s] 2 ψ
+
+/-- info: ContMDiffOn I 𝓘(𝕜, E) 2 (↑φ) s : Prop -/
+#guard_msgs in
+#check CMDiff[s] 2 φ
+
+/-- info: ContMDiffAt I 𝓘(𝕜, E) 2 ↑φ : M → Prop -/
+#guard_msgs in
+#check CMDiffAt 2 φ
+
+/-- info: ContMDiff I 𝓘(𝕜, E) 2 ↑ψ : Prop -/
+#guard_msgs in
+#check CMDiff 2 ψ
+
+/-- info: mfderiv I 𝓘(𝕜, E) ↑φ : (x : M) → TangentSpace I x →L[𝕜] TangentSpace 𝓘(𝕜, E) (↑φ x) -/
+#guard_msgs in
+#check mfderiv% φ
+
+/--
+info: mfderivWithin I 𝓘(𝕜, E) (↑ψ) s : (x : M) → TangentSpace I x →L[𝕜] TangentSpace 𝓘(𝕜, E) (↑ψ x)
+-/
+#guard_msgs in
+#check mfderiv[s] ψ
+
+end coercion
 
 variable {σ : Π x : M, V x} {σ' : (x : E) → Trivial E E' x} {s : E → E'}
 variable (X : (m : M) → TangentSpace I m) [IsManifold I 1 M]

--- a/MathlibTest/DifferentialGeometry/Notation.lean
+++ b/MathlibTest/DifferentialGeometry/Notation.lean
@@ -120,6 +120,33 @@ variable {f : M → M'} {s : Set M} {m : M}
 #guard_msgs in
 #check MDiff[s] f
 
+-- A partial homeomorphism or partial equivalence.
+variable {φ : OpenPartialHomeomorph M E} {ψ : PartialEquiv M E}
+
+#check MDifferentiableWithinAt I 𝓘(𝕜, E) ψ
+#check MDifferentiableWithinAt I 𝓘(𝕜, E) ψ s
+/--
+error: Application type mismatch: The argument
+  M
+has type
+  Type u_4
+but is expected to have type
+  ModelWithCorners ?𝕜 ?E ?H
+in the application
+  @MDifferentiableWithinAt ?𝕜 ?inst✝ ?E ?inst✝¹ ?inst✝² ?H ?inst✝³ M
+-/
+#guard_msgs in
+#check MDiffAt[s] φ
+/--
+error: Expected
+  ψ
+of type
+  PartialEquiv M E
+to be a function
+-/
+#guard_msgs in
+#check MDiffAt[s] ψ
+
 -- Testing an error message.
 section
 

--- a/MathlibTest/DifferentialGeometry/Notation.lean
+++ b/MathlibTest/DifferentialGeometry/Notation.lean
@@ -541,14 +541,13 @@ variable {f : M → M'} {s : Set M} {m : M}
 
 variable [IsManifold I 1 M] [IsManifold I' 1 M']
 
--- TODO: can there be better error messages when forgetting the smoothness exponent?
+-- Testing error messages when forgetting the smoothness exponent or swapping arguments.
 section error
 
 -- yields a parse error, "unexpected token '/--'; expected term"
 -- #check CMDiffAt[s] f
 
--- TODO: the old error message here was better; somehow restore it!
-/-
+/--
 error: Type mismatch
   f
 has type
@@ -556,9 +555,7 @@ has type
 of sort `Type (max u_10 u_4)` but is expected to have type
   WithTop ℕ∞
 of sort `Type`
--/
-
-/--
+---
 error: Expected
   m
 of type
@@ -569,6 +566,14 @@ to be a function, or to be coercible to a function
 #check CMDiffAt[s] f m
 
 /--
+error: Type mismatch
+  f
+has type
+  M → M'
+of sort `Type (max u_10 u_4)` but is expected to have type
+  WithTop ℕ∞
+of sort `Type`
+---
 error: Expected
   m
 of type

--- a/MathlibTest/DifferentialGeometry/Notation.lean
+++ b/MathlibTest/DifferentialGeometry/Notation.lean
@@ -120,40 +120,67 @@ variable {f : M → M'} {s : Set M} {m : M}
 #guard_msgs in
 #check MDiff[s] f
 
--- A partial homeomorphism or partial equivalence.
+/-! A partial homeomorphism or partial equivalence. More generally, this works for any type
+with a coercion to (possibly dependent) functions. -/
+section coercion
+
 variable {φ : OpenPartialHomeomorph M E} {ψ : PartialEquiv M E}
 
-#check MDifferentiableWithinAt I 𝓘(𝕜, E) ψ
-#check MDifferentiableWithinAt I 𝓘(𝕜, E) ψ s
-
-
-/--
-error: Application type mismatch: The argument
-  φ
-has type
-  OpenPartialHomeomorph M E
-but is expected to have type
-  ?M → ?M'
-in the application
-  MDifferentiableWithinAt I 𝓘(𝕜, E) φ
--/
+/-- info: MDifferentiableWithinAt I 𝓘(𝕜, E) (↑φ) s : M → Prop -/
 #guard_msgs in
 #check MDiffAt[s] φ
 
-/--
-error: Application type mismatch: The argument
-  ψ
-has type
-  PartialEquiv M E
-but is expected to have type
-  ?M → ?M'
-in the application
-  MDifferentiableWithinAt I 𝓘(𝕜, E) ψ
--/
+/-- info: MDifferentiableWithinAt I 𝓘(𝕜, E) (↑ψ) s : M → Prop -/
 #guard_msgs in
 #check MDiffAt[s] ψ
 
-#exit
+/-- info: MDifferentiableAt I 𝓘(𝕜, E) ↑φ : M → Prop -/
+#guard_msgs in
+#check MDiffAt φ
+
+/-- info: MDifferentiableAt I 𝓘(𝕜, E) ↑ψ : M → Prop -/
+#guard_msgs in
+#check MDiffAt ψ
+
+/-- info: MDifferentiableOn I 𝓘(𝕜, E) (↑φ) s : Prop -/
+#guard_msgs in
+#check MDiff[s] φ
+
+/-- info: MDifferentiableOn I 𝓘(𝕜, E) (↑ψ) s : Prop -/
+#guard_msgs in
+#check MDiff[s] ψ
+
+/-- info: MDifferentiable I 𝓘(𝕜, E) ↑φ : Prop -/
+#guard_msgs in
+#check MDiff φ
+
+/-- info: ContMDiffWithinAt I 𝓘(𝕜, E) 2 (↑ψ) s : M → Prop -/
+#guard_msgs in
+#check CMDiffAt[s] 2 ψ
+
+/-- info: ContMDiffOn I 𝓘(𝕜, E) 2 (↑φ) s : Prop -/
+#guard_msgs in
+#check CMDiff[s] 2 φ
+
+/-- info: ContMDiffAt I 𝓘(𝕜, E) 2 ↑φ : M → Prop -/
+#guard_msgs in
+#check CMDiffAt 2 φ
+
+/-- info: ContMDiff I 𝓘(𝕜, E) 2 ↑ψ : Prop -/
+#guard_msgs in
+#check CMDiff 2 ψ
+
+/-- info: mfderiv I 𝓘(𝕜, E) ↑φ : (x : M) → TangentSpace I x →L[𝕜] TangentSpace 𝓘(𝕜, E) (↑φ x) -/
+#guard_msgs in
+#check mfderiv% φ
+
+/--
+info: mfderivWithin I 𝓘(𝕜, E) (↑ψ) s : (x : M) → TangentSpace I x →L[𝕜] TangentSpace 𝓘(𝕜, E) (↑ψ x)
+-/
+#guard_msgs in
+#check mfderiv[s] ψ
+
+end coercion
 
 -- Testing an error message.
 section

--- a/MathlibTest/DifferentialGeometry/Notation.lean
+++ b/MathlibTest/DifferentialGeometry/Notation.lean
@@ -547,7 +547,8 @@ section error
 -- yields a parse error, "unexpected token '/--'; expected term"
 -- #check CMDiffAt[s] f
 
-/--
+-- TODO: the old error message here was better; somehow restore it!
+/-
 error: Type mismatch
   f
 has type
@@ -555,30 +556,24 @@ has type
 of sort `Type (max u_10 u_4)` but is expected to have type
   WithTop ℕ∞
 of sort `Type`
----
+-/
+
+/--
 error: Expected
   m
 of type
   M
-to be a function
+to be a function, or to be coercible to a function
 -/
 #guard_msgs in
 #check CMDiffAt[s] f m
 
 /--
-error: Type mismatch
-  f
-has type
-  M → M'
-of sort `Type (max u_10 u_4)` but is expected to have type
-  WithTop ℕ∞
-of sort `Type`
----
 error: Expected
   m
 of type
   M
-to be a function
+to be a function, or to be coercible to a function
 -/
 #guard_msgs in
 #check CMDiffAt[s] f m


### PR DESCRIPTION
Generalise the `CMDiff`, `MDiff` and `mfderiv` elaborators (and its friends) to apply to any object which coerces to a function. We can such speak about the smoothness of a `PartialEquiv`, `OpenPartialHomeomorph` (or the future `ClosedPartialHomeomorph` and `PartialHomeomorph`), smooth section or bundled smooth map without the need for a coercion.

As a by-product, add new functions `Lean.Meta.ensure{HasType,IsFunction,IsSort}` which apply the respective coercion if necessary.

While at it, add more sections (and section headers) to the test file for the elaborators.

---

I have forward-ported this PR to #26221 and not noticed any issues yet.

- [x] depends on: #27021

<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include at least one commit authored by each
co-author among the commits in the pull request. If necessary, you may 
create empty commits to indicate co-authorship, using commands like so:

git commit --author="Author Name <author@email.com>" --allow-empty -m "add Author Name as coauthor"

When merging, all the commits will be squashed into a single commit listing all co-authors.

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
