### PR TITLE
[Merged by Bors] - feat(Topology/Connected): locally (path-)connected compact spaces have finitely many (path-)connected components

### DIFF
--- a/Mathlib/Topology/Connected/Clopen.lean
+++ b/Mathlib/Topology/Connected/Clopen.lean
@@ -5,6 +5,7 @@ Authors: Johannes Hölzl, Mario Carneiro, Yury Kudryashov
 -/
 import Mathlib.Data.Set.Subset
 import Mathlib.Topology.Clopen
+import Mathlib.Topology.Compactness.Compact
 import Mathlib.Topology.Connected.Basic
 
 /-!
@@ -567,3 +568,5 @@ theorem connectedSpace_iff_clopen :
     ConnectedSpace α ↔ Nonempty α ∧ ∀ s : Set α, IsClopen s → s = ∅ ∨ s = Set.univ := by
   rw [connectedSpace_iff_univ, IsConnected, ← preconnectedSpace_iff_univ,
     preconnectedSpace_iff_clopen, Set.nonempty_iff_univ_nonempty]
+
+instance [CompactSpace α] : CompactSpace <| ConnectedComponents α := Quotient.compactSpace

--- a/Mathlib/Topology/Connected/LocPathConnected.lean
+++ b/Mathlib/Topology/Connected/LocPathConnected.lean
@@ -236,4 +236,8 @@ instance : DiscreteTopology <| ZerothHomotopy X := by
   rw [← isQuotientMap_quotient_mk'.isOpen_preimage]
   grind [ZerothHomotopy.preimage_singleton_eq_pathComponent, IsOpen.pathComponent]
 
+/-- A locally path-connected compact space has finitely many path components. -/
+instance [CompactSpace X] : Finite <| ZerothHomotopy X :=
+  finite_of_compact_of_discrete
+
 end LocPathConnectedSpace

--- a/Mathlib/Topology/Connected/LocPathConnected.lean
+++ b/Mathlib/Topology/Connected/LocPathConnected.lean
@@ -229,4 +229,11 @@ instance AlexandrovDiscrete.locPathConnectedSpace [AlexandrovDiscrete X] :
   symm
   apply hy.joinedIn <;> rewrite [mem_nhdsKer_singleton] <;> [assumption; rfl]
 
+/-- If a space is locally path-connected, the topology of its path components is discrete. -/
+instance : DiscreteTopology <| ZerothHomotopy X := by
+  refine discreteTopology_iff_isOpen_singleton.mpr fun c ↦ ?_
+  obtain ⟨x, rfl⟩ := Quotient.mk_surjective c
+  rw [← isQuotientMap_quotient_mk'.isOpen_preimage]
+  grind [ZerothHomotopy.preimage_singleton_eq_pathComponent, IsOpen.pathComponent]
+
 end LocPathConnectedSpace

--- a/Mathlib/Topology/Connected/LocallyConnected.lean
+++ b/Mathlib/Topology/Connected/LocallyConnected.lean
@@ -4,6 +4,7 @@ Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Anatole Dedecker
 -/
 import Mathlib.Topology.Connected.Basic
+import Mathlib.Topology.Connected.Clopen
 
 /-!
 # Locally connected topological spaces
@@ -132,5 +133,12 @@ lemma Topology.IsOpenEmbedding.locallyConnectedSpace [LocallyConnectedSpace α] 
 theorem IsOpen.locallyConnectedSpace [LocallyConnectedSpace α] {U : Set α} (hU : IsOpen U) :
     LocallyConnectedSpace U :=
   hU.isOpenEmbedding_subtypeVal.locallyConnectedSpace
+
+/-- If a space is locally connected, the topology of its connected components is discrete. -/
+instance [LocallyConnectedSpace α] : DiscreteTopology <| ConnectedComponents α := by
+  refine discreteTopology_iff_isOpen_singleton.mpr fun c ↦ ?_
+  obtain ⟨x, rfl⟩ := ConnectedComponents.surjective_coe c
+  simp [← ConnectedComponents.isQuotientMap_coe.isOpen_preimage,
+    connectedComponents_preimage_singleton, isOpen_connectedComponent]
 
 end LocallyConnectedSpace

--- a/Mathlib/Topology/Connected/LocallyConnected.lean
+++ b/Mathlib/Topology/Connected/LocallyConnected.lean
@@ -141,4 +141,8 @@ instance [LocallyConnectedSpace α] : DiscreteTopology <| ConnectedComponents α
   simp [← ConnectedComponents.isQuotientMap_coe.isOpen_preimage,
     connectedComponents_preimage_singleton, isOpen_connectedComponent]
 
+/-- A locally connected compact space has finitely many connected components. -/
+instance [LocallyConnectedSpace α] [CompactSpace α] : Finite <| ConnectedComponents α :=
+  finite_of_compact_of_discrete
+
 end LocallyConnectedSpace

--- a/Mathlib/Topology/Connected/PathConnected.lean
+++ b/Mathlib/Topology/Connected/PathConnected.lean
@@ -565,4 +565,12 @@ theorem exists_path_through_family' {n : ℕ} (p : Fin (n + 1) → X) :
 
 end PathConnectedSpace
 
+/-- The preimage of a singleton in `ZerothHomotopy` is the path component of an element in the
+equivalence class. -/
+theorem ZerothHomotopy.preimage_singleton_eq_pathComponent (x : X) :
+    Quotient.mk' (s := pathSetoid X) ⁻¹' {⟦x⟧} = pathComponent x := by
+  ext y
+  rw [mem_preimage, mem_singleton_iff, eq_comm, mem_pathComponent_iff]
+  exact Quotient.eq
+
 instance [CompactSpace X] : CompactSpace <| ZerothHomotopy X := Quotient.compactSpace

--- a/Mathlib/Topology/Connected/PathConnected.lean
+++ b/Mathlib/Topology/Connected/PathConnected.lean
@@ -564,3 +564,5 @@ theorem exists_path_through_family' {n : ℕ} (p : Fin (n + 1) → X) :
   exact ⟨γ, t, h⟩
 
 end PathConnectedSpace
+
+instance [CompactSpace X] : CompactSpace <| ZerothHomotopy X := Quotient.compactSpace

--- a/Mathlib/Topology/Connected/PathConnected.lean
+++ b/Mathlib/Topology/Connected/PathConnected.lean
@@ -103,6 +103,10 @@ def pathSetoid : Setoid X where
 def ZerothHomotopy :=
   Quotient (pathSetoid X)
 
+/-- The quotient topology on path components. -/
+instance : TopologicalSpace <| ZerothHomotopy X :=
+  inferInstanceAs <| TopologicalSpace <| Quotient _
+
 instance ZerothHomotopy.inhabited : Inhabited (ZerothHomotopy ℝ) :=
   ⟨@Quotient.mk' ℝ (pathSetoid ℝ) 0⟩
 


### PR DESCRIPTION
feat(Topology/Connected): locally (path-)connected compact spaces have finitely many (path-)connected components

Locally (path-)connectedness implies all (path-)connected components are open, so they form an open cover. Compactness implies there's a finite subcover. Since the components are disjoint, the subcover must equal the cover.

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include at least one commit authored by each
co-author among the commits in the pull request. If necessary, you may 
create empty commits to indicate co-authorship, using commands like so:

git commit --author="Author Name <author@email.com>" --allow-empty -m "add Author Name as coauthor"

When merging, all the commits will be squashed into a single commit listing all co-authors.

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
