### PR TITLE
[Merged by Bors] - chore (Topology/UniformSpace/Ultra): deprecate `IsTransitiveRel.mem_filter_prod_comm`

### DIFF
--- a/Mathlib/Topology/UniformSpace/Ultra/Basic.lean
+++ b/Mathlib/Topology/UniformSpace/Ultra/Basic.lean
@@ -119,20 +119,8 @@ lemma IsTransitiveRel.mem_filter_prod_trans {s : Set (X × X)} {f g h : Filter X
     s ∈ f ×ˢ h :=
   Eventually.trans_prod (by simpa using hfg) (by simpa using hgh) hs
 
-lemma IsTransitiveRel.mem_filter_prod_comm {s : Set (X × X)} {f g h : Filter X} [g.NeBot]
-    (hs : IsTransitiveRel s) (hfg : s ∈ f ×ˢ g) (hgh : s ∈ g ×ˢ h) :
-    s ∈ f ×ˢ h := by
-  rw [mem_prod_iff] at hfg hgh ⊢
-  obtain ⟨t, ht, u, hu, htu⟩ := hfg
-  obtain ⟨v, hv, w, hw, hvw⟩ := hgh
-  replace htu : t ×ˢ (u ∩ v) ⊆ s := by
-    rw [Set.prod_inter]
-    refine inter_subset_left.trans htu
-  replace hvw : (u ∩ v) ×ˢ w ⊆ s := by
-    rw [Set.inter_prod]
-    refine inter_subset_right.trans hvw
-  refine ⟨_, ht, _, hw, hs.prod_subset_trans htu hvw <| g.nonempty_of_mem ?_⟩
-  simp [hu, hv]
+@[deprecated (since := "2025-10-08")]
+alias IsTransitiveRel.mem_filter_prod_comm := IsTransitiveRel.mem_filter_prod_trans
 
 open UniformSpace in
 lemma IsTransitiveRel.ball_subset_of_mem {V : Set (X × X)} (h : IsTransitiveRel V)

--- a/Mathlib/Topology/UniformSpace/Ultra/Completion.lean
+++ b/Mathlib/Topology/UniformSpace/Ultra/Completion.lean
@@ -33,7 +33,7 @@ lemma IsTransitiveRel.cauchyFilter_gen {s : Set (X × X)} (hs : IsTransitiveRel 
     IsTransitiveRel (CauchyFilter.gen s) := by
   simp only [IsTransitiveRel, CauchyFilter.gen, mem_setOf_eq]
   intro f g h hfg hgh
-  exact hs.mem_filter_prod_comm hfg hgh
+  exact hs.mem_filter_prod_trans hfg hgh
 
 instance IsUltraUniformity.cauchyFilter [IsUltraUniformity X] :
     IsUltraUniformity (CauchyFilter X) := by


### PR DESCRIPTION
---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include at least one commit authored by each
co-author among the commits in the pull request. If necessary, you may 
create empty commits to indicate co-authorship, using commands like so:

git commit --author="Author Name <author@email.com>" --allow-empty -m "add Author Name as coauthor"

When merging, all the commits will be squashed into a single commit listing all co-authors.

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
