### PR TITLE
[Merged by Bors] - chore(Analysis/SpecialFunctions): golf entire `mulExpNegMulSq_eq_sqrt_mul_mulExpNegMulSq_one` using `grind`

### DIFF
--- a/Mathlib/Analysis/SpecialFunctions/MulExpNegMulSq.lean
+++ b/Mathlib/Analysis/SpecialFunctions/MulExpNegMulSq.lean
@@ -118,15 +118,7 @@ theorem lipschitzWith_one_mulExpNegMulSq (hε : 0 < ε) :
 
 theorem mulExpNegMulSq_eq_sqrt_mul_mulExpNegMulSq_one (hε : 0 < ε) (x : ℝ) :
     mulExpNegMulSq ε x = (√ε)⁻¹ * mulExpNegMulSq 1 (sqrt ε * x) := by
-  simp only [mulExpNegMulSq, one_mul]
-  have h : √ε * x * (√ε * x) = ε * x * x := by
-    ring_nf
-    rw [sq_sqrt hε.le, mul_comm]
-  rw [h, eq_inv_mul_iff_mul_eq₀ _]
-  · ring_nf
-  · intro h
-    rw [← pow_eq_zero_iff (Ne.symm (Nat.zero_ne_add_one 1)), sq_sqrt hε.le] at h
-    linarith
+  grind [mulExpNegMulSq]
 
 /-- For fixed `ε > 0`, the mapping `x ↦ mulExpNegMulSq ε x` is bounded by `(√ε)⁻¹ -/
 theorem abs_mulExpNegMulSq_le (hε : 0 < ε) {x : ℝ} : |mulExpNegMulSq ε x| ≤ (√ε)⁻¹ := by


### PR DESCRIPTION
---
<details>
<summary>Show trace profiling of <code>mulExpNegMulSq_eq_sqrt_mul_mulExpNegMulSq_one</code>: 205 ms before, 110 ms after  🎉</summary>

### Trace profiling of `mulExpNegMulSq_eq_sqrt_mul_mulExpNegMulSq_one` before PR 30320
```diff
diff --git a/Mathlib/Analysis/SpecialFunctions/MulExpNegMulSq.lean b/Mathlib/Analysis/SpecialFunctions/MulExpNegMulSq.lean
index e8406d12e3..fd5286ea47 100644
--- a/Mathlib/Analysis/SpecialFunctions/MulExpNegMulSq.lean
+++ b/Mathlib/Analysis/SpecialFunctions/MulExpNegMulSq.lean
@@ -116,6 +116,7 @@ theorem lipschitzWith_one_mulExpNegMulSq (hε : 0 < ε) :
   apply lipschitzWith_of_nnnorm_deriv_le differentiable_mulExpNegMulSq
   exact nnnorm_deriv_mulExpNegMulSq_le_one hε
 
+set_option trace.profiler true in
 theorem mulExpNegMulSq_eq_sqrt_mul_mulExpNegMulSq_one (hε : 0 < ε) (x : ℝ) :
     mulExpNegMulSq ε x = (√ε)⁻¹ * mulExpNegMulSq 1 (sqrt ε * x) := by
   simp only [mulExpNegMulSq, one_mul]
```
```
ℹ [2024/2024] Built Mathlib.Analysis.SpecialFunctions.MulExpNegMulSq (6.0s)
info: Mathlib/Analysis/SpecialFunctions/MulExpNegMulSq.lean:120:0: [Elab.async] [0.208617] elaborating proof of Real.mulExpNegMulSq_eq_sqrt_mul_mulExpNegMulSq_one
  [Elab.definition.value] [0.204751] Real.mulExpNegMulSq_eq_sqrt_mul_mulExpNegMulSq_one
    [Elab.step] [0.202247] 
          simp only [mulExpNegMulSq, one_mul]
          have h : √ε * x * (√ε * x) = ε * x * x := by
            ring_nf
            rw [sq_sqrt hε.le, mul_comm]
          rw [h, eq_inv_mul_iff_mul_eq₀ _]
          · ring_nf
          · intro h
            rw [← pow_eq_zero_iff (Ne.symm (Nat.zero_ne_add_one 1)), sq_sqrt hε.le] at h
            linarith
      [Elab.step] [0.202228] 
            simp only [mulExpNegMulSq, one_mul]
            have h : √ε * x * (√ε * x) = ε * x * x := by
              ring_nf
              rw [sq_sqrt hε.le, mul_comm]
            rw [h, eq_inv_mul_iff_mul_eq₀ _]
            · ring_nf
            · intro h
              rw [← pow_eq_zero_iff (Ne.symm (Nat.zero_ne_add_one 1)), sq_sqrt hε.le] at h
              linarith
        [Elab.step] [0.014468] simp only [mulExpNegMulSq, one_mul]
        [Elab.step] [0.082657] have h : √ε * x * (√ε * x) = ε * x * x :=
              by
              ring_nf
              rw [sq_sqrt hε.le, mul_comm]
          [Elab.step] [0.082603] focus
                refine
                  no_implicit_lambda%
                    (have h : √ε * x * (√ε * x) = ε * x * x := ?body✝;
                    ?_)
                case body✝ =>
                  with_annotate_state"by"
                    ( ring_nf
                      rw [sq_sqrt hε.le, mul_comm])
            [Elab.step] [0.082594] 
                  refine
                    no_implicit_lambda%
                      (have h : √ε * x * (√ε * x) = ε * x * x := ?body✝;
                      ?_)
                  case body✝ =>
                    with_annotate_state"by"
                      ( ring_nf
                        rw [sq_sqrt hε.le, mul_comm])
              [Elab.step] [0.082589] 
                    refine
                      no_implicit_lambda%
                        (have h : √ε * x * (√ε * x) = ε * x * x := ?body✝;
                        ?_)
                    case body✝ =>
                      with_annotate_state"by"
                        ( ring_nf
                          rw [sq_sqrt hε.le, mul_comm])
                [Elab.step] [0.075925] case body✝ =>
                      with_annotate_state"by"
                        ( ring_nf
                          rw [sq_sqrt hε.le, mul_comm])
                  [Elab.step] [0.075887] with_annotate_state"by"
                          ( ring_nf
                            rw [sq_sqrt hε.le, mul_comm])
                    [Elab.step] [0.075884] with_annotate_state"by"
                            ( ring_nf
                              rw [sq_sqrt hε.le, mul_comm])
                      [Elab.step] [0.075879] with_annotate_state"by"
                            ( ring_nf
                              rw [sq_sqrt hε.le, mul_comm])
                        [Elab.step] [0.075874] (
                              ring_nf
                              rw [sq_sqrt hε.le, mul_comm])
                          [Elab.step] [0.075869] 
                                ring_nf
                                rw [sq_sqrt hε.le, mul_comm]
                            [Elab.step] [0.075862] 
                                  ring_nf
                                  rw [sq_sqrt hε.le, mul_comm]
                              [Elab.step] [0.066691] ring_nf
        [Elab.step] [0.064222] · ring_nf
          [Elab.step] [0.063656] ring_nf
            [Elab.step] [0.063562] ring_nf
              [Elab.step] [0.063508] ring_nf
        [Elab.step] [0.036518] ·
              intro h
              rw [← pow_eq_zero_iff (Ne.symm (Nat.zero_ne_add_one 1)), sq_sqrt hε.le] at h
              linarith
          [Elab.step] [0.036406] 
                intro h
                rw [← pow_eq_zero_iff (Ne.symm (Nat.zero_ne_add_one 1)), sq_sqrt hε.le] at h
                linarith
            [Elab.step] [0.036393] 
                  intro h
                  rw [← pow_eq_zero_iff (Ne.symm (Nat.zero_ne_add_one 1)), sq_sqrt hε.le] at h
                  linarith
              [Elab.step] [0.014552] rw [← pow_eq_zero_iff (Ne.symm (Nat.zero_ne_add_one 1)), sq_sqrt hε.le] at h
                [Elab.step] [0.014532] (rewrite [← pow_eq_zero_iff (Ne.symm (Nat.zero_ne_add_one 1)),
                        sq_sqrt hε.le] at h;
                      with_annotate_state"]" (try (with_reducible rfl)))
                  [Elab.step] [0.014522] rewrite [← pow_eq_zero_iff (Ne.symm (Nat.zero_ne_add_one 1)),
                          sq_sqrt hε.le] at h;
                        with_annotate_state"]" (try (with_reducible rfl))
                    [Elab.step] [0.014512] rewrite [← pow_eq_zero_iff (Ne.symm (Nat.zero_ne_add_one 1)),
                            sq_sqrt hε.le] at h;
                          with_annotate_state"]" (try (with_reducible rfl))
                      [Elab.step] [0.013675] rewrite [← pow_eq_zero_iff (Ne.symm (Nat.zero_ne_add_one 1)),
                            sq_sqrt hε.le] at h
              [Elab.step] [0.021695] linarith
                [linarith] [0.018289] ✅️ running on type ℝ
info: Mathlib/Analysis/SpecialFunctions/MulExpNegMulSq.lean:120:8: [Elab.async] [0.019239] Lean.addDecl
  [Kernel] [0.019189] ✅️ typechecking declarations [Real.mulExpNegMulSq_eq_sqrt_mul_mulExpNegMulSq_one]
Build completed successfully (2024 jobs).
```

### Trace profiling of `mulExpNegMulSq_eq_sqrt_mul_mulExpNegMulSq_one` after PR 30320
```diff
diff --git a/Mathlib/Analysis/SpecialFunctions/MulExpNegMulSq.lean b/Mathlib/Analysis/SpecialFunctions/MulExpNegMulSq.lean
index e8406d12e3..fda5d48c67 100644
--- a/Mathlib/Analysis/SpecialFunctions/MulExpNegMulSq.lean
+++ b/Mathlib/Analysis/SpecialFunctions/MulExpNegMulSq.lean
@@ -116,17 +116,10 @@ theorem lipschitzWith_one_mulExpNegMulSq (hε : 0 < ε) :
   apply lipschitzWith_of_nnnorm_deriv_le differentiable_mulExpNegMulSq
   exact nnnorm_deriv_mulExpNegMulSq_le_one hε
 
+set_option trace.profiler true in
 theorem mulExpNegMulSq_eq_sqrt_mul_mulExpNegMulSq_one (hε : 0 < ε) (x : ℝ) :
     mulExpNegMulSq ε x = (√ε)⁻¹ * mulExpNegMulSq 1 (sqrt ε * x) := by
-  simp only [mulExpNegMulSq, one_mul]
-  have h : √ε * x * (√ε * x) = ε * x * x := by
-    ring_nf
-    rw [sq_sqrt hε.le, mul_comm]
-  rw [h, eq_inv_mul_iff_mul_eq₀ _]
-  · ring_nf
-  · intro h
-    rw [← pow_eq_zero_iff (Ne.symm (Nat.zero_ne_add_one 1)), sq_sqrt hε.le] at h
-    linarith
+  grind [mulExpNegMulSq]
 
 /-- For fixed `ε > 0`, the mapping `x ↦ mulExpNegMulSq ε x` is bounded by `(√ε)⁻¹ -/
 theorem abs_mulExpNegMulSq_le (hε : 0 < ε) {x : ℝ} : |mulExpNegMulSq ε x| ≤ (√ε)⁻¹ := by
```
```
ℹ [2024/2024] Built Mathlib.Analysis.SpecialFunctions.MulExpNegMulSq (2.8s)
info: Mathlib/Analysis/SpecialFunctions/MulExpNegMulSq.lean:120:0: [Elab.async] [0.110171] elaborating proof of Real.mulExpNegMulSq_eq_sqrt_mul_mulExpNegMulSq_one
  [Elab.definition.value] [0.109780] Real.mulExpNegMulSq_eq_sqrt_mul_mulExpNegMulSq_one
    [Elab.step] [0.109650] grind [mulExpNegMulSq]
      [Elab.step] [0.109642] grind [mulExpNegMulSq]
        [Elab.step] [0.109630] grind [mulExpNegMulSq]
          [Meta.synthInstance] [0.012377] ✅️ Lean.Grind.IsCharP ℝ 0
          [Meta.synthInstance] [0.012187] ✅️ Lean.Grind.NoNatZeroDivisors ℝ
          [Meta.synthInstance] [0.010630] ✅️ Lean.Grind.OrderedAdd ℝ
info: Mathlib/Analysis/SpecialFunctions/MulExpNegMulSq.lean:122:2: [Elab.async] [0.030979] Lean.addDecl
  [Kernel] [0.030956] ✅️ typechecking declarations [Real.mulExpNegMulSq_eq_sqrt_mul_mulExpNegMulSq_one._proof_1_2]
Build completed successfully (2024 jobs).
```
</details>

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include at least one commit authored by each
co-author among the commits in the pull request. If necessary, you may 
create empty commits to indicate co-authorship, using commands like so:

git commit --author="Author Name <author@email.com>" --allow-empty -m "add Author Name as coauthor"

When merging, all the commits will be squashed into a single commit listing all co-authors.

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
