### PR TITLE
[Merged by Bors] - feat: commutativity of `mul` and `finprod`

### DIFF
--- a/Mathlib/Algebra/BigOperators/Finprod.lean
+++ b/Mathlib/Algebra/BigOperators/Finprod.lean
@@ -1132,8 +1132,7 @@ theorem finsum_mem_mul {R : Type*} [NonUnitalNonAssocSemiring R] [NoZeroDivisors
   rw [finsum_mul]
   congr
   ext a
-  by_cases h : a ∈ s
-  <;> simp_all
+  by_cases h : a ∈ s <;> simp_all
 
 @[to_additive (attr := simp)]
 lemma finprod_apply {α ι : Type*} {f : ι → α → N} (hf : (mulSupport f).Finite) (a : α) :

--- a/Mathlib/Algebra/BigOperators/Finprod.lean
+++ b/Mathlib/Algebra/BigOperators/Finprod.lean
@@ -1106,8 +1106,7 @@ theorem mul_finsum_mem {R : Type*} [NonUnitalNonAssocSemiring R] [NoZeroDivisors
   rw [mul_finsum]
   congr
   ext a
-  by_cases h : a ∈ s
-  <;> simp_all
+  by_cases h : a ∈ s <;> simp_all
 
 open Classical in
 /--

--- a/Mathlib/Algebra/BigOperators/Finprod.lean
+++ b/Mathlib/Algebra/BigOperators/Finprod.lean
@@ -1050,21 +1050,57 @@ theorem prod_finprod_comm (s : Finset α) (f : α → β → M) (h : ∀ a ∈ s
     (∏ a ∈ s, ∏ᶠ b : β, f a b) = ∏ᶠ b : β, ∏ a ∈ s, f a b :=
   (finprod_prod_comm s (fun b a => f a b) h).symm
 
-theorem mul_finsum {R : Type*} [NonUnitalNonAssocSemiring R] (f : α → R) (r : R)
+/--
+For functions with finite support, multiplication commutes with finsums. See `mul_finsum` for a
+statement assuming that `R` has no zero divisors.
+-/
+theorem mul_finsum' {R : Type*} [NonUnitalNonAssocSemiring R] (f : α → R) (r : R)
     (h : (support f).Finite) : (r * ∑ᶠ a : α, f a) = ∑ᶠ a : α, r * f a :=
   (AddMonoidHom.mulLeft r).map_finsum h
 
-theorem mul_finsum_mem {R : Type*} [NonUnitalNonAssocSemiring R] {s : Set α} (f : α → R) (r : R)
+theorem mul_finsum_mem' {R : Type*} [NonUnitalNonAssocSemiring R] {s : Set α} (f : α → R) (r : R)
     (hs : s.Finite) : (r * ∑ᶠ a ∈ s, f a) = ∑ᶠ a ∈ s, r * f a :=
   (AddMonoidHom.mulLeft r).map_finsum_mem f hs
 
-theorem finsum_mul {R : Type*} [NonUnitalNonAssocSemiring R] (f : α → R) (r : R)
+/--
+For functions with finite support, multiplication commutes with finsums. See `finsum_mul` for a
+statement assuming that `R` has no zero divisors.
+-/
+theorem finsum_mul' {R : Type*} [NonUnitalNonAssocSemiring R] (f : α → R) (r : R)
     (h : (support f).Finite) : (∑ᶠ a : α, f a) * r = ∑ᶠ a : α, f a * r :=
   (AddMonoidHom.mulRight r).map_finsum h
 
-theorem finsum_mem_mul {R : Type*} [NonUnitalNonAssocSemiring R] {s : Set α} (f : α → R) (r : R)
+theorem finsum_mem_mul' {R : Type*} [NonUnitalNonAssocSemiring R] {s : Set α} (f : α → R) (r : R)
     (hs : s.Finite) : (∑ᶠ a ∈ s, f a) * r = ∑ᶠ a ∈ s, f a * r :=
   (AddMonoidHom.mulRight r).map_finsum_mem f hs
+
+open Classical in
+/--
+If `R` has no zero divisors, then multiplication commutes with finsums. See `mul_finsum'` for a
+statement assuming finiteness of support.
+-/
+theorem mul_finsum {R : Type*} [NonUnitalNonAssocSemiring R] [NoZeroDivisors R] (f : α → R)
+    (r : R) :
+    (r * ∑ᶠ a : α, f a) = ∑ᶠ a : α, r * f a := by
+  by_cases hr : r = 0
+  · simp_all
+  by_cases h : f.support.Finite
+  · exact mul_finsum' f r h
+  simp [finsum_def, h, (by aesop : (r * f ·).support = f.support)]
+
+open Classical in
+/--
+If `R` has no zero divisors, then multiplication commutes with finsums. See `finsum_mul'` for a
+statement assuming finiteness of support.
+-/
+theorem finsum_mul {R : Type*} [NonUnitalNonAssocSemiring R] [NoZeroDivisors R] (f : α → R)
+    (r : R) :
+    (∑ᶠ a : α, f a) * r = ∑ᶠ a : α, f a * r := by
+  by_cases hr : r = 0
+  · simp_all
+  by_cases h : f.support.Finite
+  · exact finsum_mul' f r h
+  simp [finsum_def, h, (by aesop : (f · * r).support = f.support)]
 
 @[to_additive (attr := simp)]
 lemma finprod_apply {α ι : Type*} {f : ι → α → N} (hf : (mulSupport f).Finite) (a : α) :

--- a/Mathlib/Algebra/BigOperators/Finprod.lean
+++ b/Mathlib/Algebra/BigOperators/Finprod.lean
@@ -1058,6 +1058,10 @@ theorem mul_finsum' {R : Type*} [NonUnitalNonAssocSemiring R] (f : α → R) (r 
     (h : (support f).Finite) : (r * ∑ᶠ a : α, f a) = ∑ᶠ a : α, r * f a :=
   (AddMonoidHom.mulLeft r).map_finsum h
 
+/--
+For finite sets, multiplication commutes with `finsum_mem`. See `mul_finsum_mem'` for a statement
+assuming finiteness of support.
+-/
 theorem mul_finsum_mem' {R : Type*} [NonUnitalNonAssocSemiring R] {s : Set α} (f : α → R) (r : R)
     (hs : s.Finite) : (r * ∑ᶠ a ∈ s, f a) = ∑ᶠ a ∈ s, r * f a :=
   (AddMonoidHom.mulLeft r).map_finsum_mem f hs
@@ -1070,6 +1074,10 @@ theorem finsum_mul' {R : Type*} [NonUnitalNonAssocSemiring R] (f : α → R) (r 
     (h : (support f).Finite) : (∑ᶠ a : α, f a) * r = ∑ᶠ a : α, f a * r :=
   (AddMonoidHom.mulRight r).map_finsum h
 
+/--
+For finite sets, multiplication commutes with `finsum_mem`. See `finsum_mem_mul'` for a statement
+assuming finiteness of support.
+-/
 theorem finsum_mem_mul' {R : Type*} [NonUnitalNonAssocSemiring R] {s : Set α} (f : α → R) (r : R)
     (hs : s.Finite) : (∑ᶠ a ∈ s, f a) * r = ∑ᶠ a ∈ s, f a * r :=
   (AddMonoidHom.mulRight r).map_finsum_mem f hs
@@ -1088,6 +1096,19 @@ theorem mul_finsum {R : Type*} [NonUnitalNonAssocSemiring R] [NoZeroDivisors R] 
   · exact mul_finsum' f r h
   simp [finsum_def, h, (by aesop : (r * f ·).support = f.support)]
 
+/--
+If `R` has no zero divisors, then multiplication commutes with `finsum_mem`. See `mul_finsum_mem'`
+for a statement assuming finiteness of support.
+-/
+theorem mul_finsum_mem {R : Type*} [NonUnitalNonAssocSemiring R] [NoZeroDivisors R] {s : Set α}
+    (f : α → R) (r : R) :
+    (r * ∑ᶠ a ∈ s, f a) = ∑ᶠ a ∈ s, r * f a := by
+  rw [mul_finsum]
+  congr
+  ext a
+  by_cases h : a ∈ s
+  <;> simp_all
+
 open Classical in
 /--
 If `R` has no zero divisors, then multiplication commutes with finsums. See `finsum_mul'` for a
@@ -1101,6 +1122,19 @@ theorem finsum_mul {R : Type*} [NonUnitalNonAssocSemiring R] [NoZeroDivisors R] 
   by_cases h : f.support.Finite
   · exact finsum_mul' f r h
   simp [finsum_def, h, (by aesop : (f · * r).support = f.support)]
+
+/--
+If `R` has no zero divisors, then multiplication commutes with `finsum_mem`. See `finsum_mem_mul'`
+for a statement assuming finiteness of support.
+-/
+theorem finsum_mem_mul {R : Type*} [NonUnitalNonAssocSemiring R] [NoZeroDivisors R] {s : Set α}
+    (f : α → R) (r : R) :
+    (∑ᶠ a ∈ s, f a) * r = ∑ᶠ a ∈ s, f a * r := by
+  rw [finsum_mul]
+  congr
+  ext a
+  by_cases h : a ∈ s
+  <;> simp_all
 
 @[to_additive (attr := simp)]
 lemma finprod_apply {α ι : Type*} {f : ι → α → N} (hf : (mulSupport f).Finite) (a : α) :


### PR DESCRIPTION
For (semi-)rings without zero divisors, show that multiplication commutes with `finprod`. Following a [brief discussion of Zulip](https://leanprover.zulipchat.com/#narrow/channel/287929-mathlib4/topic/Naming.20inconstency.2C.20finsum.20and.20multiplication/with/543461589), unify naming between theorems about multiplication and theorems about scalar multiplication.

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include at least one commit authored by each
co-author among the commits in the pull request. If necessary, you may 
create empty commits to indicate co-authorship, using commands like so:

git commit --author="Author Name <author@email.com>" --allow-empty -m "add Author Name as coauthor"

When merging, all the commits will be squashed into a single commit listing all co-authors.

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
