### PR TITLE
[Merged by Bors] - chore: delete wrong docstring for irrelevant ideal

### DIFF
--- a/Mathlib/RingTheory/GradedAlgebra/Homogeneous/Ideal.lean
+++ b/Mathlib/RingTheory/GradedAlgebra/Homogeneous/Ideal.lean
@@ -562,11 +562,6 @@ open GradedRing SetLike.GradedMonoid DirectSum
 refers to `⨁_{i>0} 𝒜ᵢ`, or equivalently `{a | a₀ = 0}`. This definition is used in `Proj`
 construction where `ι` is always `ℕ` so the irrelevant ideal is simply elements with `0` as
 0-th coordinate.
-
-# Future work
-Here in the definition, `ι` is assumed to be `CanonicallyOrderedAddCommMonoid`. However, the notion
-of irrelevant ideal makes sense in a more general setting by defining it as the ideal of elements
-with `0` as i-th coordinate for all `i ≤ 0`, i.e. `{a | ∀ (i : ι), i ≤ 0 → aᵢ = 0}`.
 -/
 def HomogeneousIdeal.irrelevant : HomogeneousIdeal 𝒜 :=
   ⟨RingHom.ker (GradedRing.projZeroRingHom 𝒜), fun i r (hr : (decompose 𝒜 r 0 : A) = 0) => by


### PR DESCRIPTION
The expression given `{a | ∀ (i : ι), i ≤ 0 → aᵢ = 0}` does not define an ideal, because it is not closed under (external) multiplication. For example, if x has grade 1 and y has grade -2, then x will be in this "ideal", but xy will not.

Zulip discussion: [#mathlib4 > irrelevant ideal cannot be generalised](https://leanprover.zulipchat.com/#narrow/channel/287929-mathlib4/topic/irrelevant.20ideal.20cannot.20be.20generalised/near/543800961)

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include at least one commit authored by each
co-author among the commits in the pull request. If necessary, you may 
create empty commits to indicate co-authorship, using commands like so:

git commit --author="Author Name <author@email.com>" --allow-empty -m "add Author Name as coauthor"

When merging, all the commits will be squashed into a single commit listing all co-authors.

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
