### PR TITLE
[Merged by Bors] -  feat: the set of points where IsImmersionAt(OfComplement) holds is open 

### DIFF
--- a/Mathlib/Geometry/Manifold/Immersion.lean
+++ b/Mathlib/Geometry/Manifold/Immersion.lean
@@ -45,7 +45,7 @@ This shortens the overall argument, as the definition of submersions has the sam
 * `IsImmersionAtOfComplement.congr_F`, `IsImmersionOfComplement.congr_F`:
   being an immersion (at `x`) w.r.t. `F` is stable under
   replacing the complement `F` by an isomorphic copy
-* `isOpen_isImmersionAtOfComplement` and `isOpen_isImmersionAt`:
+* `IsOpen.isImmersionAtOfComplement` and `IsOpen.isImmersionAt`:
   the set of points where `IsImmersionAt(OfComplement)` holds is open.
 
 ## Implementation notes
@@ -358,10 +358,10 @@ lemma congr_F (e : F ≃L[𝕜] F') :
   ⟨fun h ↦ trans_F (e := e) h, fun h ↦ trans_F (e := e.symm) h⟩
 
 /- The set of points where `IsImmersionAtOfComplement` holds is open. -/
-lemma _root_.isOpen_isImmersionAtOfComplement :
+lemma isOpen :
     IsOpen {x | IsImmersionAtOfComplement F I J n f x} := by
   simp_rw [IsImmersionAtOfComplement_def]
-  exact isOpen_liftSourceTargetPropertyAt
+  exact LiftSourceTargetPropertyAt.isOpen
 
 /-- If `f` is an immersion at `x` w.r.t. some complement `F`, it is an immersion at `x`.
 
@@ -523,12 +523,12 @@ lemma congr_iff (hfg : f =ᶠ[𝓝 x] g) :
   ⟨fun h ↦ h.congr_of_eventuallyEq hfg, fun h ↦ h.congr_of_eventuallyEq hfg.symm⟩
 
 /- The set of points where `IsImmersionAt` holds is open. -/
-lemma _root_.isOpen_isImmersionAt :
+lemma isOpen :
     IsOpen {x | IsImmersionAt I J n f x} := by
   rw [isOpen_iff_forall_mem_open]
   exact fun x hx ↦ ⟨{x | IsImmersionAtOfComplement hx.complement I J n f x },
     fun y hy ↦ hy.isImmersionAt,
-    isOpen_isImmersionAtOfComplement, by simp [hx.isImmersionAtOfComplement_complement]⟩
+    IsImmersionAtOfComplement.isOpen, by simp [hx.isImmersionAtOfComplement_complement]⟩
 
 end IsImmersionAt
 

--- a/Mathlib/Geometry/Manifold/Immersion.lean
+++ b/Mathlib/Geometry/Manifold/Immersion.lean
@@ -360,18 +360,8 @@ lemma congr_F (e : F ≃L[𝕜] F') :
 /- The set of points where `IsImmersionAtOfComplement` holds is open. -/
 lemma _root_.isOpen_isImmersionAtOfComplement :
     IsOpen {x | IsImmersionAtOfComplement F I J n f x} := by
-  rw [isOpen_iff_forall_mem_open]
-  intro x hx
-  -- Suppose `f` is an immersion at `x`: choose slice charts φ near x and ψ near f x s.t.
-  -- `f` looks like `u ↦ (u, 0)` in these charts. Then the same charts witness that `f` is an
-  -- immersion at any `y ∈ φ.source`.
-  simp only [mem_setOf_eq, IsImmersionAtOfComplement_def] at hx
-  refine ⟨hx.domChart.source, ?_, hx.domChart.open_source, hx.mem_domChart_source⟩
-  intro x' hx'
-  rw [mem_setOf_eq, IsImmersionAtOfComplement_def]
-  exact ⟨hx.domChart, hx.codChart, hx', hx.source_subset_preimage_source hx',
-    hx.domChart_mem_maximalAtlas, hx.codChart_mem_maximalAtlas, hx.source_subset_preimage_source,
-    hx.property⟩
+  simp_rw [IsImmersionAtOfComplement_def]
+  exact isOpen_liftSourceTargetPropertyAt
 
 /-- If `f` is an immersion at `x` w.r.t. some complement `F`, it is an immersion at `x`.
 

--- a/Mathlib/Geometry/Manifold/Immersion.lean
+++ b/Mathlib/Geometry/Manifold/Immersion.lean
@@ -358,10 +358,10 @@ lemma congr_F (e : F ≃L[𝕜] F') :
   ⟨fun h ↦ trans_F (e := e) h, fun h ↦ trans_F (e := e.symm) h⟩
 
 /- The set of points where `IsImmersionAtOfComplement` holds is open. -/
-lemma isOpen :
+lemma _root_.IsOpen.isImmersionAtOfComplement :
     IsOpen {x | IsImmersionAtOfComplement F I J n f x} := by
   simp_rw [IsImmersionAtOfComplement_def]
-  exact LiftSourceTargetPropertyAt.isOpen
+  exact .liftSourceTargetPropertyAt
 
 /-- If `f` is an immersion at `x` w.r.t. some complement `F`, it is an immersion at `x`.
 
@@ -523,12 +523,12 @@ lemma congr_iff (hfg : f =ᶠ[𝓝 x] g) :
   ⟨fun h ↦ h.congr_of_eventuallyEq hfg, fun h ↦ h.congr_of_eventuallyEq hfg.symm⟩
 
 /- The set of points where `IsImmersionAt` holds is open. -/
-lemma isOpen :
+lemma _root_.IsOpen.isImmersionAt :
     IsOpen {x | IsImmersionAt I J n f x} := by
   rw [isOpen_iff_forall_mem_open]
   exact fun x hx ↦ ⟨{x | IsImmersionAtOfComplement hx.complement I J n f x },
-    fun y hy ↦ hy.isImmersionAt,
-    IsImmersionAtOfComplement.isOpen, by simp [hx.isImmersionAtOfComplement_complement]⟩
+    fun y hy ↦ hy.isImmersionAt, .isImmersionAtOfComplement,
+    by simp [hx.isImmersionAtOfComplement_complement]⟩
 
 end IsImmersionAt
 

--- a/Mathlib/Geometry/Manifold/Immersion.lean
+++ b/Mathlib/Geometry/Manifold/Immersion.lean
@@ -45,6 +45,8 @@ This shortens the overall argument, as the definition of submersions has the sam
 * `IsImmersionAtOfComplement.congr_F`, `IsImmersionOfComplement.congr_F`:
   being an immersion (at `x`) w.r.t. `F` is stable under
   replacing the complement `F` by an isomorphic copy
+* `isOpen_isImmersionAtOfComplement` and `isOpen_isImmersionAt`:
+  the set of points where `IsImmersionAt(OfComplement)` holds is open.
 
 ## Implementation notes
 
@@ -64,7 +66,6 @@ This shortens the overall argument, as the definition of submersions has the sam
 ## TODO
 * The converse to `IsImmersionAtOfComplement.congr_F` also holds: any two complements are
   isomorphic, as they are isomorphic to the cokernel of the differential `mfderiv I J f x`.
-* The set where `IsImmersionAt(OfComplement)` holds is open.
 * `IsImmersionAt.contMDiffAt`: if f is an immersion at `x`, it is `C^n` at `x`.
 * `IsImmersion.contMDiff`: if f is an immersion, it is `C^n`.
 * `IsImmersionAt.prodMap`: the product of two immersions is an immersion.
@@ -356,6 +357,22 @@ lemma congr_F (e : F ≃L[𝕜] F') :
     IsImmersionAtOfComplement F I J n f x ↔ IsImmersionAtOfComplement F' I J n f x :=
   ⟨fun h ↦ trans_F (e := e) h, fun h ↦ trans_F (e := e.symm) h⟩
 
+/- The set of points where `IsImmersionAtOfComplement` holds is open. -/
+lemma _root_.isOpen_isImmersionAtOfComplement :
+    IsOpen {x | IsImmersionAtOfComplement F I J n f x} := by
+  rw [isOpen_iff_forall_mem_open]
+  intro x hx
+  -- Suppose `f` is an immersion at `x`: choose slice charts φ near x and ψ near f x s.t.
+  -- `f` looks like `u ↦ (u, 0)` in these charts. Then the same charts witness that `f` is an
+  -- immersion at any `y ∈ φ.source`.
+  simp only [mem_setOf_eq, IsImmersionAtOfComplement_def] at hx
+  refine ⟨hx.domChart.source, ?_, hx.domChart.open_source, hx.mem_domChart_source⟩
+  intro x' hx'
+  rw [mem_setOf_eq, IsImmersionAtOfComplement_def]
+  exact ⟨hx.domChart, hx.codChart, hx', hx.source_subset_preimage_source hx',
+    hx.domChart_mem_maximalAtlas, hx.codChart_mem_maximalAtlas, hx.source_subset_preimage_source,
+    hx.property⟩
+
 /-- If `f` is an immersion at `x` w.r.t. some complement `F`, it is an immersion at `x`.
 
 Note that the proof contains a small formalisation-related subtlety: `F` can live in any universe,
@@ -514,6 +531,14 @@ then `f` is an immersion at `x` if and only if `g` is an immersion at `x`. -/
 lemma congr_iff (hfg : f =ᶠ[𝓝 x] g) :
     IsImmersionAt I J n f x ↔ IsImmersionAt I J n g x :=
   ⟨fun h ↦ h.congr_of_eventuallyEq hfg, fun h ↦ h.congr_of_eventuallyEq hfg.symm⟩
+
+/- The set of points where `IsImmersionAt` holds is open. -/
+lemma _root_.isOpen_isImmersionAt :
+    IsOpen {x | IsImmersionAt I J n f x} := by
+  rw [isOpen_iff_forall_mem_open]
+  exact fun x hx ↦ ⟨{x | IsImmersionAtOfComplement hx.complement I J n f x },
+    fun y hy ↦ hy.isImmersionAt,
+    isOpen_isImmersionAtOfComplement, by simp [hx.isImmersionAtOfComplement_complement]⟩
 
 end IsImmersionAt
 

--- a/Mathlib/Geometry/Manifold/LocalSourceTargetProperty.lean
+++ b/Mathlib/Geometry/Manifold/LocalSourceTargetProperty.lean
@@ -33,6 +33,8 @@ local property of this form.
   `f` has this property at `x` if there exist charts `φ` and `ψ` such that `P f φ ψ` holds.
 * `Manifold.LiftSourceTargetPropertyAt.congr_of_eventuallyEq`: if `f` has property `P` at `x`
   and `g` equals `f` near `x`, then `g` also has property `P` at `x`.
+* `isOpen_liftSourceTargetPropertyAt`: the set of points at which `LiftSourceTargetPropertyAt`
+  holds is open
 
 -/
 
@@ -193,6 +195,19 @@ then `f` has property `P` at `x` if and only if `g` has property `P` at `x`. -/
 lemma congr_iff_of_eventuallyEq (hP : IsLocalSourceTargetProperty P) (h' : f =ᶠ[nhds x] g) :
     LiftSourceTargetPropertyAt I I' n f x P ↔ LiftSourceTargetPropertyAt I I' n g x P :=
   ⟨fun hf ↦ hf.congr_of_eventuallyEq hP h', fun hg ↦ hg.congr_of_eventuallyEq hP h'.symm⟩
+
+/- The set of points where `LiftSourceTargetPropertyAt` holds is open. -/
+lemma _root_.isOpen_liftSourceTargetPropertyAt :
+    IsOpen {x | LiftSourceTargetPropertyAt I I' n g x P} := by
+  rw [isOpen_iff_forall_mem_open]
+  intro x hx
+  -- Suppose the lifted property `P` holds at `x`:
+  -- choose slice charts `φ` near `x` and `ψ` near `f x` s.t. `P f φ ψ` holds.
+  -- Then the same charts witness that `P f φ ψ` holds at any `y ∈ φ.source`.
+  refine ⟨hx.domChart.source, fun y hy ↦ ?_, hx.domChart.open_source, hx.mem_domChart_source⟩
+  exact ⟨hx.domChart, hx.codChart, hy, hx.source_subset_preimage_source hy,
+    hx.domChart_mem_maximalAtlas, hx.codChart_mem_maximalAtlas, hx.source_subset_preimage_source,
+    hx.property⟩
 
 end LiftSourceTargetPropertyAt
 

--- a/Mathlib/Geometry/Manifold/LocalSourceTargetProperty.lean
+++ b/Mathlib/Geometry/Manifold/LocalSourceTargetProperty.lean
@@ -33,7 +33,7 @@ local property of this form.
   `f` has this property at `x` if there exist charts `φ` and `ψ` such that `P f φ ψ` holds.
 * `Manifold.LiftSourceTargetPropertyAt.congr_of_eventuallyEq`: if `f` has property `P` at `x`
   and `g` equals `f` near `x`, then `g` also has property `P` at `x`.
-* `LiftSourceTargetPropertyAt.isOpen`: the set of points at which `LiftSourceTargetPropertyAt`
+* `IsOpen.liftSourceTargetPropertyAt`: the set of points at which `LiftSourceTargetPropertyAt`
   holds is open
 
 -/
@@ -197,7 +197,7 @@ lemma congr_iff_of_eventuallyEq (hP : IsLocalSourceTargetProperty P) (h' : f =�
   ⟨fun hf ↦ hf.congr_of_eventuallyEq hP h', fun hg ↦ hg.congr_of_eventuallyEq hP h'.symm⟩
 
 /- The set of points where `LiftSourceTargetPropertyAt` holds is open. -/
-lemma isOpen :
+lemma _root_.IsOpen.liftSourceTargetPropertyAt :
     IsOpen {x | LiftSourceTargetPropertyAt I I' n g x P} := by
   rw [isOpen_iff_forall_mem_open]
   intro x hx

--- a/Mathlib/Geometry/Manifold/LocalSourceTargetProperty.lean
+++ b/Mathlib/Geometry/Manifold/LocalSourceTargetProperty.lean
@@ -33,7 +33,7 @@ local property of this form.
   `f` has this property at `x` if there exist charts `φ` and `ψ` such that `P f φ ψ` holds.
 * `Manifold.LiftSourceTargetPropertyAt.congr_of_eventuallyEq`: if `f` has property `P` at `x`
   and `g` equals `f` near `x`, then `g` also has property `P` at `x`.
-* `isOpen_liftSourceTargetPropertyAt`: the set of points at which `LiftSourceTargetPropertyAt`
+* `LiftSourceTargetPropertyAt.isOpen`: the set of points at which `LiftSourceTargetPropertyAt`
   holds is open
 
 -/
@@ -197,7 +197,7 @@ lemma congr_iff_of_eventuallyEq (hP : IsLocalSourceTargetProperty P) (h' : f =�
   ⟨fun hf ↦ hf.congr_of_eventuallyEq hP h', fun hg ↦ hg.congr_of_eventuallyEq hP h'.symm⟩
 
 /- The set of points where `LiftSourceTargetPropertyAt` holds is open. -/
-lemma _root_.isOpen_liftSourceTargetPropertyAt :
+lemma isOpen :
     IsOpen {x | LiftSourceTargetPropertyAt I I' n g x P} := by
   rw [isOpen_iff_forall_mem_open]
   intro x hx


### PR DESCRIPTION
Prove an API lemma which `chrisflav` requested in #28793, which was split from that PR to keep the diff smaller.

---

- [x] depends on: #28793

<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include at least one commit authored by each
co-author among the commits in the pull request. If necessary, you may 
create empty commits to indicate co-authorship, using commands like so:

git commit --author="Author Name <author@email.com>" --allow-empty -m "add Author Name as coauthor"

When merging, all the commits will be squashed into a single commit listing all co-authors.

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
