### PR TITLE
[Merged by Bors] - feat(Analysis/Polynomial/MahlerMeasure): add a couple of easy facts

### DIFF
--- a/Mathlib/Analysis/Polynomial/MahlerMeasure.lean
+++ b/Mathlib/Analysis/Polynomial/MahlerMeasure.lean
@@ -8,7 +8,6 @@ import Mathlib.Analysis.Analytic.Polynomial
 import Mathlib.Analysis.CStarAlgebra.Classes
 import Mathlib.Analysis.SpecialFunctions.Integrability.LogMeromorphic
 import Mathlib.MeasureTheory.Integral.CircleAverage
-import Mathlib.Tactic.Cases
 
 /-!
 # Mahler measure of complex polynomials

--- a/Mathlib/Analysis/Polynomial/MahlerMeasure.lean
+++ b/Mathlib/Analysis/Polynomial/MahlerMeasure.lean
@@ -130,6 +130,7 @@ theorem mahlerMeasure_mul (p q : ℂ[X]) :
   contrapose h
   simp_all [log_mul]
 
+@[simp]
 theorem prod_mahlerMeasure_eq_mahlerMeasure_prod (s : Multiset ℂ[X]) :
     (s.prod).mahlerMeasure = (s.map (fun p ↦ p.mahlerMeasure)).prod := by
   induction s using Multiset.induction_on with

--- a/Mathlib/Analysis/Polynomial/MahlerMeasure.lean
+++ b/Mathlib/Analysis/Polynomial/MahlerMeasure.lean
@@ -8,6 +8,7 @@ import Mathlib.Analysis.Analytic.Polynomial
 import Mathlib.Analysis.CStarAlgebra.Classes
 import Mathlib.Analysis.SpecialFunctions.Integrability.LogMeromorphic
 import Mathlib.MeasureTheory.Integral.CircleAverage
+import Mathlib.Tactic.Cases
 
 /-!
 # Mahler measure of complex polynomials
@@ -91,6 +92,10 @@ theorem mahlerMeasure_const (z : ℂ) : (C z).mahlerMeasure = ‖z‖ := by
 theorem mahlerMeasure_nonneg : 0 ≤ p.mahlerMeasure := by
   by_cases hp : p = 0 <;> simp [hp, mahlerMeasure_def_of_ne_zero, exp_nonneg]
 
+variable {p} in
+theorem mahlerMeasure_pos_of_ne_zero (hp : p ≠ 0) : 0 < p.mahlerMeasure := by
+  grind [exp_pos, mahlerMeasure_def_of_ne_zero]
+
 @[simp]
 theorem mahlerMeasure_eq_zero_iff : p.mahlerMeasure = 0 ↔ p = 0 := by
   refine ⟨?_, by simp_all [mahlerMeasure_zero]⟩
@@ -125,5 +130,15 @@ theorem mahlerMeasure_mul (p q : ℂ[X]) :
   rintro _ ⟨_, ⟨_, h⟩, _⟩
   contrapose h
   simp_all [log_mul]
+
+theorem prod_mahlerMeasure_eq_mahlerMeasure_prod (s : Multiset ℂ[X]) :
+    (s.prod).mahlerMeasure = (s.map (fun p ↦ p.mahlerMeasure)).prod := by
+  induction s using Multiset.induction_on with
+  | empty => simp
+  | cons _ _ ih => simp [mahlerMeasure_mul, ih]
+
+theorem logMahlerMeasure_mul_eq_add_logMahelerMeasure {p q : ℂ[X]} (hpq : p * q ≠ 0) :
+    (p * q).logMahlerMeasure = p.logMahlerMeasure + q.logMahlerMeasure := by
+  simp_all [logMahlerMeasure_eq_log_MahlerMeasure, mahlerMeasure_mul, log_mul]
 
 end Polynomial


### PR DESCRIPTION
We add a couple of easy facts about `mahlerMeasure`.

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include at least one commit authored by each
co-author among the commits in the pull request. If necessary, you may 
create empty commits to indicate co-authorship, using commands like so:

git commit --author="Author Name <author@email.com>" --allow-empty -m "add Author Name as coauthor"

When merging, all the commits will be squashed into a single commit listing all co-authors.

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
