### PR TITLE
[Merged by Bors] - ci(update_dependencies.yml): use lake-manifest.json in working directory rather than HEAD

### DIFF
--- a/.github/workflows/update_dependencies.yml
+++ b/.github/workflows/update_dependencies.yml
@@ -78,7 +78,7 @@ jobs:
         run: |
           if [ -n "${{ steps.get-branch-sha.outputs.sha }}" ]; then
             # Branch exists, compare the file
-            if git diff --quiet HEAD "origin/$BRANCH_NAME" -- lake-manifest.json; then
+            if git diff --quiet "origin/$BRANCH_NAME" -- lake-manifest.json; then
               echo "has_diff=false" >> "${GITHUB_OUTPUT}"
               echo "No differences in lake-manifest.json"
             else


### PR DESCRIPTION
This fixes an embarrassing mistake in #30095: the script currently compares `lake-manifest.json` in the `update-dependencies-bot-use-only` branch to itself rather than to the changes made in the working directory. This has caused the update workflow to fail to push changes for about a week or so.


---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include at least one commit authored by each
co-author among the commits in the pull request. If necessary, you may 
create empty commits to indicate co-authorship, using commands like so:

git commit --author="Author Name <author@email.com>" --allow-empty -m "add Author Name as coauthor"

When merging, all the commits will be squashed into a single commit listing all co-authors.

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
