### PR TITLE
[Merged by Bors] - feat(CategoryTheory): Guitart exact squares and Kan extensions

### DIFF
--- a/Mathlib.lean
+++ b/Mathlib.lean
@@ -2332,6 +2332,7 @@ import Mathlib.CategoryTheory.Groupoid.FreeGroupoid
 import Mathlib.CategoryTheory.Groupoid.Subgroupoid
 import Mathlib.CategoryTheory.Groupoid.VertexGroup
 import Mathlib.CategoryTheory.GuitartExact.Basic
+import Mathlib.CategoryTheory.GuitartExact.KanExtension
 import Mathlib.CategoryTheory.GuitartExact.Opposite
 import Mathlib.CategoryTheory.GuitartExact.VerticalComposition
 import Mathlib.CategoryTheory.HomCongr

--- a/Mathlib/CategoryTheory/Functor/KanExtension/Pointwise.lean
+++ b/Mathlib/CategoryTheory/Functor/KanExtension/Pointwise.lean
@@ -191,6 +191,9 @@ def coconeAtFunctor (Y : D) :
 `E.coconeAt Y` is a colimit cocone. -/
 def IsPointwiseLeftKanExtensionAt (Y : D) := IsColimit (E.coconeAt Y)
 
+instance (Y : D) : Subsingleton (E.IsPointwiseLeftKanExtensionAt Y) :=
+  inferInstanceAs (Subsingleton (IsColimit _))
+
 variable {E} in
 lemma IsPointwiseLeftKanExtensionAt.hasPointwiseLeftKanExtensionAt
     {Y : D} (h : E.IsPointwiseLeftKanExtensionAt Y) :
@@ -215,12 +218,8 @@ def isPointwiseLeftKanExtensionAtEquivOfIso' {Y Y' : D} (e : Y ≅ Y') :
     E.IsPointwiseLeftKanExtensionAt Y ≃ E.IsPointwiseLeftKanExtensionAt Y' where
   toFun h := E.isPointwiseLeftKanExtensionAtOfIso' h e
   invFun h := E.isPointwiseLeftKanExtensionAtOfIso' h e.symm
-  left_inv h := by
-    dsimp only [IsPointwiseLeftKanExtensionAt]
-    apply Subsingleton.elim
-  right_inv h := by
-    dsimp only [IsPointwiseLeftKanExtensionAt]
-    apply Subsingleton.elim
+  left_inv h := by subsingleton
+  right_inv h := by subsingleton
 
 namespace IsPointwiseLeftKanExtensionAt
 
@@ -357,6 +356,9 @@ def coneAtFunctor (Y : D) :
 `E.coneAt Y` is a limit cone. -/
 def IsPointwiseRightKanExtensionAt (Y : D) := IsLimit (E.coneAt Y)
 
+instance (Y : D) : Subsingleton (E.IsPointwiseRightKanExtensionAt Y) :=
+  inferInstanceAs (Subsingleton (IsLimit _))
+
 variable {E} in
 lemma IsPointwiseRightKanExtensionAt.hasPointwiseRightKanExtensionAt
     {Y : D} (h : E.IsPointwiseRightKanExtensionAt Y) :
@@ -381,12 +383,8 @@ def isPointwiseRightKanExtensionAtEquivOfIso' {Y Y' : D} (e : Y ≅ Y') :
     E.IsPointwiseRightKanExtensionAt Y ≃ E.IsPointwiseRightKanExtensionAt Y' where
   toFun h := E.isPointwiseRightKanExtensionAtOfIso' h e
   invFun h := E.isPointwiseRightKanExtensionAtOfIso' h e.symm
-  left_inv h := by
-    dsimp only [IsPointwiseRightKanExtensionAt]
-    apply Subsingleton.elim
-  right_inv h := by
-    dsimp only [IsPointwiseRightKanExtensionAt]
-    apply Subsingleton.elim
+  left_inv h := by subsingleton
+  right_inv h := by subsingleton
 
 namespace IsPointwiseRightKanExtensionAt
 

--- a/Mathlib/CategoryTheory/GuitartExact/KanExtension.lean
+++ b/Mathlib/CategoryTheory/GuitartExact/KanExtension.lean
@@ -1,0 +1,142 @@
+/-
+Copyright (c) 2025 Joël Riou. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Joël Riou
+-/
+import Mathlib.CategoryTheory.GuitartExact.Basic
+import Mathlib.CategoryTheory.Functor.KanExtension.Pointwise
+
+/-!
+# Guitart exact squares and Kan extensions
+
+Given a Guitart exact square `w : T ⋙ R ⟶ L ⋙ B`,
+```
+     T
+  C₁ ⥤ C₂
+L |     | R
+  v     v
+  C₃ ⥤ C₄
+     B
+```
+we show that an extension `F' : C₄ ⥤ D` of `F : C₂ ⥤ D` along `R`
+is a pointwise left Kan extension at `B.obj X₃` iff
+the composition `T ⋙ F'` is a pointwise left Kan extension at `X₃`
+of `B ⋙ F'`.
+
+-/
+
+universe v₁ v₂ v₃ v₄ v₅ u₁ u₂ u₃ u₄ u₅
+
+namespace CategoryTheory
+
+open Limits
+
+variable {C₁ : Type u₁} {C₂ : Type u₂} {C₃ : Type u₃} {C₄ : Type u₄} {D : Type u₅}
+  [Category.{v₁} C₁] [Category.{v₂} C₂] [Category.{v₃} C₃] [Category.{v₄} C₄]
+  [Category.{v₅} D]
+
+namespace Functor.LeftExtension
+
+variable {T : C₁ ⥤ C₂} {L : C₁ ⥤ C₃} {R : C₂ ⥤ C₄} {B : C₃ ⥤ C₄}
+  {F : C₂ ⥤ D} (E : R.LeftExtension F)
+
+/-- Given a square `w : TwoSquare T L R B` (consisting of a natural transformation
+`T ⋙ R ⟶ L ⋙ B`), this is the obvious map `R.LeftExtension F → L.LeftExtension (T ⋙ F)`
+obtained by the precomposition with `B` and the postcomposition with `w`. -/
+abbrev compTwoSquare (w : TwoSquare T L R B) : L.LeftExtension (T ⋙ F) :=
+  LeftExtension.mk (B ⋙ E.right)
+    (whiskerLeft _ E.hom ≫ (associator _ _ _).inv ≫
+      whiskerRight w.natTrans _ ≫ (associator _ _ _).hom)
+
+/-- If `w : TwoSquare T L R B` is a Guitart exact square, and `E` is a left extension
+of `F` along `R`, then `E` is a pointwise left Kan extension of `F` along `R` at
+`B.obj X₃` iff `E.compTwoSquare w` is a pointwise left Kan extension
+of `T ⋙ F` along `L` at `X₃`. -/
+noncomputable def isPointwiseLeftKanExtensionAtCompTwoSquareEquiv
+    (w : TwoSquare T L R B) (X₃ : C₃) [Final (w.costructuredArrowRightwards X₃)] :
+    (E.compTwoSquare w).IsPointwiseLeftKanExtensionAt X₃ ≃
+      E.IsPointwiseLeftKanExtensionAt (B.obj X₃) := by
+  refine Equiv.trans ?_ (Final.isColimitWhiskerEquiv (w.costructuredArrowRightwards X₃) _)
+  exact IsColimit.equivIsoColimit (Cocones.ext (Iso.refl _))
+
+lemma nonempty_isPointwiseLeftKanExtensionAt_compTwoSquare_iff
+    (w : TwoSquare T L R B) (X₃ : C₃) [Final (w.costructuredArrowRightwards X₃)] :
+    Nonempty ((E.compTwoSquare w).IsPointwiseLeftKanExtensionAt X₃) ↔
+      Nonempty (E.IsPointwiseLeftKanExtensionAt (B.obj X₃)) :=
+  (E.isPointwiseLeftKanExtensionAtCompTwoSquareEquiv w _).nonempty_congr
+
+variable {E} in
+/-- If `w : TwoSquare T L R B` is a Guitart exact square, and `E` is a pointwise
+left Kan extension of `F` along `R`, then `E.compTwoSquare w` is a pointwise left
+Kan extension of `T ⋙ F` along `L`. -/
+noncomputable def IsPointwiseLeftKanExtension.compTwoSquare
+    (h : E.IsPointwiseLeftKanExtension) (w : TwoSquare T L R B) [w.GuitartExact] :
+    (E.compTwoSquare w).IsPointwiseLeftKanExtension :=
+  fun X₃ ↦ (E.isPointwiseLeftKanExtensionAtCompTwoSquareEquiv w X₃).symm (h _)
+
+/-- If `w : TwoSquare T L R B` is a Guitart exact square, with `B` essentially surjective,
+and `E` is a left extension of `F` along `R`, then `E` is a pointwise
+left Kan extension of `F` along `R` provided `E.compTwoSquare w` is a pointwise left
+Kan extension of `T ⋙ F` along `L`. -/
+noncomputable def isPointwiseLeftKanExtensionOfCompTwoSquare
+    (w : TwoSquare T L R B) [w.GuitartExact] [B.EssSurj]
+    (h : (E.compTwoSquare w).IsPointwiseLeftKanExtension) :
+    E.IsPointwiseLeftKanExtension :=
+  fun X₄ ↦ E.isPointwiseLeftKanExtensionAtOfIso'
+    (E.isPointwiseLeftKanExtensionAtCompTwoSquareEquiv w _ (h (B.objPreimage X₄)))
+    (B.objObjPreimageIso X₄)
+
+/-- If `w : TwoSquare T L R B` is a Guitart exact square, with `B` essentially surjective,
+and `E` is a left extension of `F` along `R`, then `E` is a pointwise left Kan extension
+of `F` along `R` iff `E.compTwoSquare w` is a pointwise left Kan extension
+of `T ⋙ F` along `L`. -/
+noncomputable def isPointwiseLeftKanExtensionEquivOfGuitartExact
+    (w : TwoSquare T L R B) [w.GuitartExact] [B.EssSurj] :
+    (E.compTwoSquare w).IsPointwiseLeftKanExtension ≃
+      E.IsPointwiseLeftKanExtension where
+  toFun h := E.isPointwiseLeftKanExtensionOfCompTwoSquare w h
+  invFun h := h.compTwoSquare w
+  left_inv _ := by subsingleton
+  right_inv _ := by subsingleton
+
+end Functor.LeftExtension
+
+namespace TwoSquare
+
+variable {T : C₁ ⥤ C₂} {L : C₁ ⥤ C₃} {R : C₂ ⥤ C₄} {B : C₃ ⥤ C₄}
+   (w : TwoSquare T L R B)
+
+include w
+
+lemma hasPointwiseLeftKanExtensionAt_iff
+    (F : C₂ ⥤ D) (X₃ : C₃) [(w.costructuredArrowRightwards X₃).Final] :
+    L.HasPointwiseLeftKanExtensionAt (T ⋙ F) X₃ ↔
+      R.HasPointwiseLeftKanExtensionAt F (B.obj X₃) := by
+  dsimp [Functor.HasPointwiseLeftKanExtensionAt]
+  rw [← Functor.Final.hasColimit_comp_iff (w.costructuredArrowRightwards X₃)]
+  rfl
+
+lemma hasPointwiseLeftKanExtension_iff [w.GuitartExact] [B.EssSurj] (F : C₂ ⥤ D) :
+    L.HasPointwiseLeftKanExtension (T ⋙ F) ↔
+      R.HasPointwiseLeftKanExtension F := by
+  dsimp [Functor.HasPointwiseLeftKanExtension]
+  simp only [hasPointwiseLeftKanExtensionAt_iff w]
+  refine ⟨fun h X₄ ↦ ?_, fun h _ ↦ h _⟩
+  rw [← Functor.hasPointwiseLeftKanExtensionAt_iff_of_iso _ _ (B.objObjPreimageIso X₄)]
+  apply h
+
+lemma hasPointwiseLeftKanExtension [w.GuitartExact]
+    (F : C₂ ⥤ D) [R.HasPointwiseLeftKanExtension F] :
+    L.HasPointwiseLeftKanExtension (T ⋙ F) :=
+  ((R.pointwiseLeftKanExtensionIsPointwiseLeftKanExtension
+    F).compTwoSquare w).hasPointwiseLeftKanExtension
+
+lemma hasLeftKanExtension [w.GuitartExact]
+    (F : C₂ ⥤ D) [R.HasPointwiseLeftKanExtension F] :
+    L.HasLeftKanExtension (T ⋙ F) := by
+  have := w.hasPointwiseLeftKanExtension F
+  infer_instance
+
+end TwoSquare
+
+end CategoryTheory

--- a/Mathlib/CategoryTheory/Limits/Final.lean
+++ b/Mathlib/CategoryTheory/Limits/Final.lean
@@ -380,6 +380,10 @@ We can't make this an instance, because `F` is not determined by the goal.
 theorem hasColimit_of_comp [HasColimit (F ⋙ G)] : HasColimit G :=
   HasColimit.mk (colimitCoconeOfComp F (getColimitCocone (F ⋙ G)))
 
+lemma hasColimit_comp_iff :
+    HasColimit (F ⋙ G) ↔ HasColimit G :=
+  ⟨fun _ ↦ Functor.Final.hasColimit_of_comp F, fun _ ↦ inferInstance⟩
+
 theorem preservesColimit_of_comp {B : Type u₄} [Category.{v₄} B] {H : E ⥤ B}
     [PreservesColimit (F ⋙ G) H] : PreservesColimit G H where
   preserves {c} hc := by
@@ -715,6 +719,10 @@ We can't make this an instance, because `F` is not determined by the goal.
 -/
 theorem hasLimit_of_comp [HasLimit (F ⋙ G)] : HasLimit G :=
   HasLimit.mk (limitConeOfComp F (getLimitCone (F ⋙ G)))
+
+lemma hasLimit_comp_iff :
+    HasLimit (F ⋙ G) ↔ HasLimit G :=
+  ⟨fun _ ↦ Functor.Initial.hasLimit_of_comp F, fun _ ↦ inferInstance⟩
 
 theorem preservesLimit_of_comp {B : Type u₄} [Category.{v₄} B] {H : E ⥤ B}
     [PreservesLimit (F ⋙ G) H] : PreservesLimit G H where


### PR DESCRIPTION
Given a Guitart exact square `w : T ⋙ R ⟶ L ⋙ B`, we show that pointwise left Kan extensions along `R` give, by composition, pointwise left Kan extensions along `L`.

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include at least one commit authored by each
co-author among the commits in the pull request. If necessary, you may 
create empty commits to indicate co-authorship, using commands like so:

git commit --author="Author Name <author@email.com>" --allow-empty -m "add Author Name as coauthor"

When merging, all the commits will be squashed into a single commit listing all co-authors.

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
