### PR TITLE
[Merged by Bors] - feat(CategoryTheory/Limits): sections of functors and precomposition with initial functors

### DIFF
--- a/Mathlib.lean
+++ b/Mathlib.lean
@@ -2387,6 +2387,7 @@ import Mathlib.CategoryTheory.Limits.FilteredColimitCommutesFiniteLimit
 import Mathlib.CategoryTheory.Limits.FilteredColimitCommutesProduct
 import Mathlib.CategoryTheory.Limits.Final
 import Mathlib.CategoryTheory.Limits.Final.ParallelPair
+import Mathlib.CategoryTheory.Limits.Final.Type
 import Mathlib.CategoryTheory.Limits.FinallySmall
 import Mathlib.CategoryTheory.Limits.FintypeCat
 import Mathlib.CategoryTheory.Limits.FormalCoproducts

--- a/Mathlib/CategoryTheory/Limits/Final/Type.lean
+++ b/Mathlib/CategoryTheory/Limits/Final/Type.lean
@@ -13,7 +13,7 @@ Given `F : C ⥤ D` and `P : D ⥤ Type w`, we define a map
 show that it is a bijection when `F` is initial.
 As `Functor.sections` identify to limits of functors to types
 (at least under suitable universe assumptions), this could
-be deduce from general results about limits and
+be deduced from general results about limits and
 initial functors, but we provide a more down to earth proof.
 
 -/

--- a/Mathlib/CategoryTheory/Limits/Final/Type.lean
+++ b/Mathlib/CategoryTheory/Limits/Final/Type.lean
@@ -1,0 +1,66 @@
+/-
+Copyright (c) 2025 Joël Riou. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Joël Riou
+-/
+import Mathlib.CategoryTheory.Limits.Final
+
+/-!
+# Action of an initial functor on sections
+
+Given `F : C ⥤ D` and `P : D ⥤ Type w`, we define a map
+`sectionsPrecomp F : P.sections → (F ⋙ P).sections` and
+show that it is a bijection when `F` is initial.
+As `Functor.sections` identify to limits of functors to types
+(at least under suitable universe assumptions), this could
+be deduce from general results about limits and
+initial functors, but we provide a more down to earth proof.
+
+-/
+
+universe w v₁ v₂ u₁ u₂
+
+namespace CategoryTheory
+
+namespace Functor
+
+variable {C : Type u₁} {D : Type u₂} [Category.{v₁} C] [Category.{v₂} D]
+
+/-- When `F : C ⥤ D` and `P : D ⥤ Type _`, this is the obvious map
+`P.section → (F ⋙ P).sections`. -/
+@[simps]
+def sectionsPrecomp (F : C ⥤ D) {P : D ⥤ Type w} (x : P.sections) :
+    (F ⋙ P).sections where
+  val _ := x.val _
+  property _ := x.property _
+
+lemma bijective_sectionsPrecomp (F : C ⥤ D) (P : D ⥤ Type w) [F.Initial] :
+    Function.Bijective (F.sectionsPrecomp (P := P)) := by
+  refine ⟨fun s₁ s₂ h ↦ ?_, fun t ↦ ?_⟩
+  · ext Y
+    let X : CostructuredArrow F Y := Classical.arbitrary _
+    have := congr_fun (congr_arg Subtype.val h) X.left
+    have h₁ := s₁.property X.hom
+    have h₂ := s₂.property X.hom
+    dsimp at this h₁ h₂
+    rw [← h₁, this, h₂]
+  · let X (Y : D) : CostructuredArrow F Y := Classical.arbitrary _
+    let val (Y : D) : P.obj Y := P.map (X Y).hom (t.val (X Y).left)
+    have h (Y : D) (Z : CostructuredArrow F Y) :
+        val Y = P.map Z.hom (t.val Z.left) :=
+      constant_of_preserves_morphisms (α := P.obj Y)
+        (fun (Z : CostructuredArrow F Y) ↦ P.map Z.hom (t.val Z.left)) (by
+          intro Z₁ Z₂ φ
+          dsimp
+          rw [← t.property φ.left]
+          dsimp
+          rw [← FunctorToTypes.map_comp_apply, CostructuredArrow.w]) _ _
+    refine ⟨⟨val, fun {Y₁ Y₂} f ↦ ?_⟩, ?_⟩
+    · rw [h Y₁ (X Y₁), h Y₂ ((CostructuredArrow.map f).obj (X Y₁))]
+      simp
+    · ext X : 2
+      simpa using h (F.obj X) (CostructuredArrow.mk (𝟙 _))
+
+end Functor
+
+end CategoryTheory


### PR DESCRIPTION
Given `F : C ⥤ D` and `P : D ⥤ Type w`, we define a map `sectionsPrecomp F : P.sections → (F ⋙ P).sections` and show that it is a bijection when `F` is initial.

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include at least one commit authored by each
co-author among the commits in the pull request. If necessary, you may 
create empty commits to indicate co-authorship, using commands like so:

git commit --author="Author Name <author@email.com>" --allow-empty -m "add Author Name as coauthor"

When merging, all the commits will be squashed into a single commit listing all co-authors.

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
