### PR TITLE
feat(RingTheory/Valuation/Discrete/Basic): add exists_zpow_Uniformizer

### DIFF
--- a/Mathlib/RingTheory/Valuation/Discrete/Basic.lean
+++ b/Mathlib/RingTheory/Valuation/Discrete/Basic.lean
@@ -324,6 +324,21 @@ theorem exists_pow_Uniformizer {r : K₀} (hr : r ≠ 0) (π : Uniformizer v) :
   rw [IsUnit.unit_spec, Subring.coe_pow, ha, ← mul_assoc, zpow_neg, hn, zpow_natCast,
     mul_inv_cancel₀ (pow_ne_zero _ π.ne_zero), one_mul]
 
+theorem exists_zpow_Uniformizer {r : K} (hr : r ≠ 0) (x : Uniformizer v) :
+    ∃ n : ℤ, ∃ u : (v.valuationSubring)ˣ, r = (x.1 ^ n) * u.1 := by
+  obtain ⟨num, den, hd, rfl⟩ := IsFractionRing.div_surjective (A := v.valuationSubring) r
+  have hnum : num ≠ 0 := fun h ↦ by simp [h] at hr
+  have hden : den ≠ 0 := fun h ↦ by simp [h] at hr
+  obtain ⟨n1, u1, h1⟩ := exists_pow_Uniformizer hnum x
+  obtain ⟨n2, u2, h2⟩ := exists_pow_Uniformizer hden x
+  have hu2 : ((u2 : v.valuationSubring) : K)⁻¹ = u2⁻¹ :=
+    inv_eq_of_mul_eq_one_left (by norm_cast; simp)
+  use ((n1 : ℤ) - n2), u1 * u2⁻¹
+  simp only [ValuationSubring.algebraMap_apply, h1, SubmonoidClass.coe_pow, h2, div_eq_mul_inv,
+    mul_inv_rev, hu2, zpow_sub₀ (Uniformizer.ne_zero x), zpow_natCast, Units.val_mul,
+    MulMemClass.coe_mul]
+  ring
+
 theorem Uniformizer.is_generator (π : Uniformizer v) :
     maximalIdeal v.valuationSubring = Ideal.span {π.1} := by
   apply (maximalIdeal.isMaximal _).eq_of_le


### PR DESCRIPTION
Co-authored-by: @Louddy

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include at least one commit authored by each
co-author among the commits in the pull request. If necessary, you may 
create empty commits to indicate co-authorship, using commands like so:

git commit --author="Author Name <author@email.com>" --allow-empty -m "add Author Name as coauthor"

When merging, all the commits will be squashed into a single commit listing all co-authors.

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
