### PR TITLE
[Merged by Bors] - feat: add `LaxMonoidal` instance for `Applicative` functors

### DIFF
--- a/Mathlib.lean
+++ b/Mathlib.lean
@@ -2615,6 +2615,7 @@ import Mathlib.CategoryTheory.Monoidal.ExternalProduct.KanExtension
 import Mathlib.CategoryTheory.Monoidal.Free.Basic
 import Mathlib.CategoryTheory.Monoidal.Free.Coherence
 import Mathlib.CategoryTheory.Monoidal.Functor
+import Mathlib.CategoryTheory.Monoidal.Functor.Types
 import Mathlib.CategoryTheory.Monoidal.FunctorCategory
 import Mathlib.CategoryTheory.Monoidal.Grp_
 import Mathlib.CategoryTheory.Monoidal.Hopf_

--- a/Mathlib/CategoryTheory/Monoidal/Functor/Types.lean
+++ b/Mathlib/CategoryTheory/Monoidal/Functor/Types.lean
@@ -1,0 +1,70 @@
+/-
+Copyright (c) 2025 Vilim Lendvaj. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Vilim Lendvaj
+-/
+import Mathlib.CategoryTheory.Monoidal.Functor
+import Mathlib.CategoryTheory.Monoidal.Types.Basic
+import Mathlib.CategoryTheory.Types.Basic
+import Mathlib.Tactic.Simps.Basic
+
+/-!
+
+# Convert from `Applicative` to `CategoryTheory.Functor.LaxMonoidal`
+
+This allows us to use Lean's `Type`-based applicative functors in category theory.
+
+-/
+
+namespace CategoryTheory
+
+section
+
+universe u v
+
+variable (F : Type u → Type v) [Applicative F] [LawfulApplicative F]
+
+/-- A lawful `Applicative` gives a category theory `LaxMonoidal` functor
+between categories of types. -/
+@[simps!]
+instance : (ofTypeFunctor F).LaxMonoidal where
+  ε := by
+    intro
+    simp only [ofTypeFunctor_obj]
+    apply pure PUnit.unit
+  μ := by
+    intro _ _ ⟨x, y⟩
+    simp only [ofTypeFunctor_obj]
+    exact Prod.mk <$> x <*> y
+  μ_natural_left := by
+    repeat intro
+    funext x
+    cases x
+    simp [map_seq]
+    rfl
+  μ_natural_right := by
+    repeat intro
+    funext x
+    cases x
+    simp [map_seq, seq_map_assoc]
+    rfl
+  associativity := by
+    repeat intro
+    funext x
+    rcases x with ⟨⟨_, _⟩, _⟩
+    simp [map_seq, seq_map_assoc, LawfulApplicative.seq_assoc]
+    rfl
+  left_unitality := by
+    repeat intro
+    funext x
+    cases x
+    simp [LawfulApplicative.pure_seq]
+  right_unitality := by
+    repeat intro
+    funext x
+    cases x
+    simp
+
+end
+
+end CategoryTheory

--- a/Mathlib/CategoryTheory/Monoidal/Functor/Types.lean
+++ b/Mathlib/CategoryTheory/Monoidal/Functor/Types.lean
@@ -8,9 +8,7 @@ import Mathlib.CategoryTheory.Monoidal.Types.Basic
 import Mathlib.CategoryTheory.Types.Basic
 import Mathlib.Tactic.Simps.Basic
 
-/-!
-
-# Convert from `Applicative` to `CategoryTheory.Functor.LaxMonoidal`
+/-! # Convert from `Applicative` to `CategoryTheory.Functor.LaxMonoidal`
 
 This allows us to use Lean's `Type`-based applicative functors in category theory.
 
@@ -20,9 +18,7 @@ namespace CategoryTheory
 
 section
 
-universe u v
-
-variable (F : Type u → Type v) [Applicative F] [LawfulApplicative F]
+variable (F : Type* → Type*) [Applicative F] [LawfulApplicative F]
 
 /-- A lawful `Applicative` gives a category theory `LaxMonoidal` functor
 between categories of types. -/

--- a/Mathlib/CategoryTheory/Monoidal/Functor/Types.lean
+++ b/Mathlib/CategoryTheory/Monoidal/Functor/Types.lean
@@ -8,7 +8,8 @@ import Mathlib.CategoryTheory.Monoidal.Types.Basic
 import Mathlib.CategoryTheory.Types.Basic
 import Mathlib.Tactic.Simps.Basic
 
-/-! # Convert from `Applicative` to `CategoryTheory.Functor.LaxMonoidal`
+/-!
+# Convert from `Applicative` to `CategoryTheory.Functor.LaxMonoidal`
 
 This allows us to use Lean's `Type`-based applicative functors in category theory.
 

--- a/Mathlib/CategoryTheory/Monoidal/Functor/Types.lean
+++ b/Mathlib/CategoryTheory/Monoidal/Functor/Types.lean
@@ -20,46 +20,14 @@ section
 
 variable (F : Type* → Type*) [Applicative F] [LawfulApplicative F]
 
+attribute [local simp] map_seq seq_map_assoc
+  LawfulApplicative.pure_seq LawfulApplicative.seq_assoc in
 /-- A lawful `Applicative` gives a category theory `LaxMonoidal` functor
 between categories of types. -/
-@[simps!]
+@[simps]
 instance : (ofTypeFunctor F).LaxMonoidal where
-  ε := by
-    intro
-    simp only [ofTypeFunctor_obj]
-    apply pure PUnit.unit
-  μ := by
-    intro _ _ ⟨x, y⟩
-    simp only [ofTypeFunctor_obj]
-    exact Prod.mk <$> x <*> y
-  μ_natural_left := by
-    repeat intro
-    funext x
-    cases x
-    simp [map_seq]
-    rfl
-  μ_natural_right := by
-    repeat intro
-    funext x
-    cases x
-    simp [map_seq, seq_map_assoc]
-    rfl
-  associativity := by
-    repeat intro
-    funext x
-    rcases x with ⟨⟨_, _⟩, _⟩
-    simp [map_seq, seq_map_assoc, LawfulApplicative.seq_assoc]
-    rfl
-  left_unitality := by
-    repeat intro
-    funext x
-    cases x
-    simp [LawfulApplicative.pure_seq]
-  right_unitality := by
-    repeat intro
-    funext x
-    cases x
-    simp
+  ε _ : F _ := pure PUnit.unit
+  μ _ _ p : F _ := Prod.mk <$> p.1 <*> p.2
 
 end
 


### PR DESCRIPTION
Since similar conversions exist for `Functor`s and `Monad`s.


---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include at least one commit authored by each
co-author among the commits in the pull request. If necessary, you may 
create empty commits to indicate co-authorship, using commands like so:

git commit --author="Author Name <author@email.com>" --allow-empty -m "add Author Name as coauthor"

When merging, all the commits will be squashed into a single commit listing all co-authors.

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
