### PR TITLE
[Merged by Bors] - chore: move `isProperMap_iff_isClosedMap_filter` next to the ultrafilter version

### DIFF
--- a/Mathlib/Topology/Maps/Proper/Basic.lean
+++ b/Mathlib/Topology/Maps/Proper/Basic.lean
@@ -4,7 +4,6 @@ Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Anatole Dedecker, Etienne Marion
 -/
 import Mathlib.Topology.Homeomorph.Lemmas
-import Mathlib.Topology.Filter
 
 /-!
 # Proper maps between topological spaces
@@ -66,8 +65,6 @@ open Prod (fst snd)
 
 variable {X Y Z W ι : Type*} [TopologicalSpace X] [TopologicalSpace Y] [TopologicalSpace Z]
   [TopologicalSpace W] {f : X → Y} {g : Y → Z}
-
-universe u v
 
 /-- A map `f : X → Y` between two topological spaces is said to be **proper** if it is continuous
 and, for all `ℱ : Filter X`, any cluster point of `map f ℱ` is the image by `f` of a cluster point
@@ -310,47 +307,3 @@ theorem IsProperMap.universally_closed (Z) [TopologicalSpace Z] (h : IsProperMap
     IsClosedMap (Prod.map f id : X × Z → Y × Z) :=
   -- `f × id` is proper as a product of proper maps, hence closed.
   (h.prodMap isProperMap_id).isClosedMap
-
-/-- A map `f : X → Y` is proper if and only if it is continuous and the map
-`(Prod.map f id : X × Filter X → Y × Filter X)` is closed. This is stronger than
-`isProperMap_iff_universally_closed` since it shows that there's only one space to check to get
-properness, but in most cases it doesn't matter. -/
-theorem isProperMap_iff_isClosedMap_filter {X : Type u} {Y : Type v} [TopologicalSpace X]
-    [TopologicalSpace Y] {f : X → Y} :
-    IsProperMap f ↔ Continuous f ∧ IsClosedMap
-      (Prod.map f id : X × Filter X → Y × Filter X) := by
-  constructor <;> intro H
-  -- The direct implication is clear.
-  · exact ⟨H.continuous, H.universally_closed _⟩
-  · rw [isProperMap_iff_ultrafilter]
-  -- Let `𝒰 : Ultrafilter X`, and assume that `f` tends to some `y` along `𝒰`.
-    refine ⟨H.1, fun 𝒰 y hy ↦ ?_⟩
-  -- In `X × Filter X`, consider the closed set `F := closure {(x, ℱ) | ℱ = pure x}`
-    let F : Set (X × Filter X) := closure {xℱ | xℱ.2 = pure xℱ.1}
-  -- Since `f × id` is closed, the set `(f × id) '' F` is also closed.
-    have := H.2 F isClosed_closure
-  -- Let us show that `(y, 𝒰) ∈ (f × id) '' F`.
-    have : (y, ↑𝒰) ∈ Prod.map f id '' F :=
-  -- Note that, by the properties of the topology on `Filter X`, the function `pure : X → Filter X`
-  -- tends to the point `𝒰` of `Filter X` along the filter `𝒰` on `X`. Since `f` tends to `y` along
-  -- `𝒰`, we get that the function `(f, pure) : X → (Y, Filter X)` tends to `(y, 𝒰)` along
-  -- `𝒰`. Furthermore, each `(f, pure)(x) = (f × id)(x, pure x)` is clearly an element of
-  -- the closed set `(f × id) '' F`, thus the limit `(y, 𝒰)` also belongs to that set.
-      this.mem_of_tendsto (hy.prodMk_nhds (Filter.tendsto_pure_self (𝒰 : Filter X)))
-        (Eventually.of_forall fun x ↦ ⟨⟨x, pure x⟩, subset_closure rfl, rfl⟩)
-  -- The above shows that `(y, 𝒰) = (f x, 𝒰)`, for some `x : X` such that `(x, 𝒰) ∈ F`.
-    rcases this with ⟨⟨x, _⟩, hx, ⟨_, _⟩⟩
-  -- We already know that `f x = y`, so to finish the proof we just have to check that `𝒰` tends
-  -- to `x`. So, for `U ∈ 𝓝 x` arbitrary, let's show that `U ∈ 𝒰`. Since `𝒰` is a ultrafilter,
-  -- it is enough to show that `Uᶜ` is not in `𝒰`.
-    refine ⟨x, rfl, fun U hU ↦ Ultrafilter.compl_notMem_iff.mp fun hUc ↦ ?_⟩
-    rw [mem_closure_iff_nhds] at hx
-  -- Indeed, if that was the case, the set `V := {𝒢 : Filter X | Uᶜ ∈ 𝒢}` would be a neighborhood
-  -- of `𝒰` in `Filter X`, hence `U ×ˢ V` would be a neighborhood of `(x, 𝒰) : X × Filter X`.
-  -- But recall that `(x, 𝒰) ∈ F = closure {(x, ℱ) | ℱ = pure x}`, so the neighborhood `U ×ˢ V`
-  -- must contain some element of the form `(z, pure z)`. In other words, we have `z ∈ U` and
-  -- `Uᶜ ∈ pure z`, which means `z ∈ Uᶜ` by the definition of pure.
-  -- This is a contradiction, which completes the proof.
-    rcases hx (U ×ˢ {𝒢 | Uᶜ ∈ 𝒢}) (prod_mem_nhds hU (isOpen_setOf_mem.mem_nhds hUc)) with
-      ⟨⟨z, 𝒢⟩, ⟨⟨hz : z ∈ U, hz' : Uᶜ ∈ 𝒢⟩, rfl : 𝒢 = pure z⟩⟩
-    exact hz' hz

--- a/Mathlib/Topology/Maps/Proper/UniversallyClosed.lean
+++ b/Mathlib/Topology/Maps/Proper/UniversallyClosed.lean
@@ -3,8 +3,9 @@ Copyright (c) 2023 Anatole Dedecker. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Anatole Dedecker, Etienne Marion
 -/
-import Mathlib.Topology.Maps.Proper.Basic
 import Mathlib.Topology.Compactification.StoneCech
+import Mathlib.Topology.Filter
+import Mathlib.Topology.Maps.Proper.Basic
 
 /-!
 # A map is proper iff it is continuous and universally closed
@@ -13,6 +14,50 @@ import Mathlib.Topology.Compactification.StoneCech
 open Filter
 
 universe u v
+
+/-- A map `f : X → Y` is proper if and only if it is continuous and the map
+`(Prod.map f id : X × Filter X → Y × Filter X)` is closed. This is stronger than
+`isProperMap_iff_universally_closed` since it shows that there's only one space to check to get
+properness, but in most cases it doesn't matter. -/
+theorem isProperMap_iff_isClosedMap_filter {X : Type u} {Y : Type v} [TopologicalSpace X]
+    [TopologicalSpace Y] {f : X → Y} :
+    IsProperMap f ↔ Continuous f ∧ IsClosedMap
+      (Prod.map f id : X × Filter X → Y × Filter X) := by
+  constructor <;> intro H
+  -- The direct implication is clear.
+  · exact ⟨H.continuous, H.universally_closed _⟩
+  · rw [isProperMap_iff_ultrafilter]
+  -- Let `𝒰 : Ultrafilter X`, and assume that `f` tends to some `y` along `𝒰`.
+    refine ⟨H.1, fun 𝒰 y hy ↦ ?_⟩
+  -- In `X × Filter X`, consider the closed set `F := closure {(x, ℱ) | ℱ = pure x}`
+    let F : Set (X × Filter X) := closure {xℱ | xℱ.2 = pure xℱ.1}
+  -- Since `f × id` is closed, the set `(f × id) '' F` is also closed.
+    have := H.2 F isClosed_closure
+  -- Let us show that `(y, 𝒰) ∈ (f × id) '' F`.
+    have : (y, ↑𝒰) ∈ Prod.map f id '' F :=
+  -- Note that, by the properties of the topology on `Filter X`, the function `pure : X → Filter X`
+  -- tends to the point `𝒰` of `Filter X` along the filter `𝒰` on `X`. Since `f` tends to `y` along
+  -- `𝒰`, we get that the function `(f, pure) : X → (Y, Filter X)` tends to `(y, 𝒰)` along
+  -- `𝒰`. Furthermore, each `(f, pure)(x) = (f × id)(x, pure x)` is clearly an element of
+  -- the closed set `(f × id) '' F`, thus the limit `(y, 𝒰)` also belongs to that set.
+      this.mem_of_tendsto (hy.prodMk_nhds (Filter.tendsto_pure_self (𝒰 : Filter X)))
+        (Eventually.of_forall fun x ↦ ⟨⟨x, pure x⟩, subset_closure rfl, rfl⟩)
+  -- The above shows that `(y, 𝒰) = (f x, 𝒰)`, for some `x : X` such that `(x, 𝒰) ∈ F`.
+    rcases this with ⟨⟨x, _⟩, hx, ⟨_, _⟩⟩
+  -- We already know that `f x = y`, so to finish the proof we just have to check that `𝒰` tends
+  -- to `x`. So, for `U ∈ 𝓝 x` arbitrary, let's show that `U ∈ 𝒰`. Since `𝒰` is a ultrafilter,
+  -- it is enough to show that `Uᶜ` is not in `𝒰`.
+    refine ⟨x, rfl, fun U hU ↦ Ultrafilter.compl_notMem_iff.mp fun hUc ↦ ?_⟩
+    rw [mem_closure_iff_nhds] at hx
+  -- Indeed, if that was the case, the set `V := {𝒢 : Filter X | Uᶜ ∈ 𝒢}` would be a neighborhood
+  -- of `𝒰` in `Filter X`, hence `U ×ˢ V` would be a neighborhood of `(x, 𝒰) : X × Filter X`.
+  -- But recall that `(x, 𝒰) ∈ F = closure {(x, ℱ) | ℱ = pure x}`, so the neighborhood `U ×ˢ V`
+  -- must contain some element of the form `(z, pure z)`. In other words, we have `z ∈ U` and
+  -- `Uᶜ ∈ pure z`, which means `z ∈ Uᶜ` by the definition of pure.
+  -- This is a contradiction, which completes the proof.
+    rcases hx (U ×ˢ {𝒢 | Uᶜ ∈ 𝒢}) (prod_mem_nhds hU (isOpen_setOf_mem.mem_nhds hUc)) with
+      ⟨⟨z, 𝒢⟩, ⟨⟨hz : z ∈ U, hz' : Uᶜ ∈ 𝒢⟩, rfl : 𝒢 = pure z⟩⟩
+    exact hz' hz
 
 /-- A map `f : X → Y` is proper if and only if it is continuous and the map
 `(Prod.map f id : X × Ultrafilter X → Y × Ultrafilter X)` is closed. This is stronger than


### PR DESCRIPTION
I don't quite know/remember what the motivation for having `Mathlib.Topology.Maps.Proper.UniversallyClosed` be a separate file, but certainly [isProperMap_iff_isClosedMap_filter](https://leanprover-community.github.io/mathlib4_docs/Mathlib/Topology/Maps/Proper/Basic.html#isProperMap_iff_isClosedMap_filter) and [isProperMap_iff_isClosedMap_ultrafilter](https://leanprover-community.github.io/mathlib4_docs/Mathlib/Topology/Maps/Proper/UniversallyClosed.html#isProperMap_iff_isClosedMap_ultrafilter) should be together.

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include at least one commit authored by each
co-author among the commits in the pull request. If necessary, you may 
create empty commits to indicate co-authorship, using commands like so:

git commit --author="Author Name <author@email.com>" --allow-empty -m "add Author Name as coauthor"

When merging, all the commits will be squashed into a single commit listing all co-authors.

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
