### PR TITLE
[Merged by Bors] - refactor: rename covarianceBilin to covarianceBilinDual

### DIFF
--- a/Mathlib.lean
+++ b/Mathlib.lean
@@ -5367,7 +5367,7 @@ import Mathlib.Probability.Martingale.Upcrossing
 import Mathlib.Probability.Moments.Basic
 import Mathlib.Probability.Moments.ComplexMGF
 import Mathlib.Probability.Moments.Covariance
-import Mathlib.Probability.Moments.CovarianceBilin
+import Mathlib.Probability.Moments.CovarianceBilinDual
 import Mathlib.Probability.Moments.IntegrableExpMul
 import Mathlib.Probability.Moments.MGFAnalytic
 import Mathlib.Probability.Moments.SubGaussian

--- a/Mathlib/Probability/Moments/CovarianceBilinDual.lean
+++ b/Mathlib/Probability/Moments/CovarianceBilinDual.lean
@@ -162,16 +162,16 @@ variable [NormedSpace ℝ E] [OpensMeasurableSpace E]
 /-- Continuous bilinear form with value `∫ x, L₁ x * L₂ x ∂μ` on `(L₁, L₂)`.
 This is equal to the covariance only if `μ` is centered. -/
 noncomputable
-def uncenteredcovarianceBilinDual (μ : Measure E) : StrongDual ℝ E →L[ℝ] StrongDual ℝ E →L[ℝ] ℝ :=
+def uncenteredCovarianceBilinDual (μ : Measure E) : StrongDual ℝ E →L[ℝ] StrongDual ℝ E →L[ℝ] ℝ :=
   ContinuousLinearMap.bilinearComp (isBoundedBilinearMap_inner (𝕜 := ℝ)).toContinuousLinearMap
     (StrongDual.toLp μ 2) (StrongDual.toLp μ 2)
 
-@[deprecated (since := "2025-10-10")] alias uncenteredcovarianceBilin :=
-  uncenteredcovarianceBilinDual
+@[deprecated (since := "2025-10-10")] alias uncenteredCovarianceBilin :=
+  uncenteredCovarianceBilinDual
 
-lemma uncenteredcovarianceBilinDual_apply (h : MemLp id 2 μ) (L₁ L₂ : StrongDual ℝ E) :
-    uncenteredcovarianceBilinDual μ L₁ L₂ = ∫ x, L₁ x * L₂ x ∂μ := by
-  simp only [uncenteredcovarianceBilinDual, ContinuousLinearMap.bilinearComp_apply,
+lemma uncenteredCovarianceBilinDual_apply (h : MemLp id 2 μ) (L₁ L₂ : StrongDual ℝ E) :
+    uncenteredCovarianceBilinDual μ L₁ L₂ = ∫ x, L₁ x * L₂ x ∂μ := by
+  simp only [uncenteredCovarianceBilinDual, ContinuousLinearMap.bilinearComp_apply,
     StrongDual.toLp_apply h, L2.inner_def, RCLike.inner_apply, conj_trivial]
   refine integral_congr_ae ?_
   filter_upwards [MemLp.coeFn_toLp (h.continuousLinearMap_comp L₁),
@@ -179,30 +179,30 @@ lemma uncenteredcovarianceBilinDual_apply (h : MemLp id 2 μ) (L₁ L₂ : Stron
   simp only [id_eq] at hxL₁ hxL₂
   rw [hxL₁, hxL₂, mul_comm]
 
-@[deprecated (since := "2025-10-10")] alias uncenteredcovarianceBilin_apply :=
-  uncenteredcovarianceBilinDual_apply
+@[deprecated (since := "2025-10-10")] alias uncenteredCovarianceBilin_apply :=
+  uncenteredCovarianceBilinDual_apply
 
-lemma uncenteredcovarianceBilinDual_of_not_memLp (h : ¬ MemLp id 2 μ) (L₁ L₂ : StrongDual ℝ E) :
-    uncenteredcovarianceBilinDual μ L₁ L₂ = 0 := by
-  simp [uncenteredcovarianceBilinDual, StrongDual.toLp_of_not_memLp h]
+lemma uncenteredCovarianceBilinDual_of_not_memLp (h : ¬ MemLp id 2 μ) (L₁ L₂ : StrongDual ℝ E) :
+    uncenteredCovarianceBilinDual μ L₁ L₂ = 0 := by
+  simp [uncenteredCovarianceBilinDual, StrongDual.toLp_of_not_memLp h]
 
-@[deprecated (since := "2025-10-10")] alias uncenteredcovarianceBilin_of_not_memLp :=
-  uncenteredcovarianceBilinDual_of_not_memLp
+@[deprecated (since := "2025-10-10")] alias uncenteredCovarianceBilin_of_not_memLp :=
+  uncenteredCovarianceBilinDual_of_not_memLp
 
-lemma uncenteredcovarianceBilinDual_zero : uncenteredcovarianceBilinDual (0 : Measure E) = 0 := by
+lemma uncenteredCovarianceBilinDual_zero : uncenteredCovarianceBilinDual (0 : Measure E) = 0 := by
   ext
   have : Subsingleton (Lp ℝ 2 (0 : Measure E)) := ⟨fun x y ↦ Lp.ext_iff.2 rfl⟩
-  simp [uncenteredcovarianceBilinDual, Subsingleton.eq_zero (StrongDual.toLp 0 2)]
+  simp [uncenteredCovarianceBilinDual, Subsingleton.eq_zero (StrongDual.toLp 0 2)]
 
-@[deprecated (since := "2025-10-10")] alias uncenteredcovarianceBilin_zero :=
-  uncenteredcovarianceBilinDual_zero
+@[deprecated (since := "2025-10-10")] alias uncenteredCovarianceBilin_zero :=
+  uncenteredCovarianceBilinDual_zero
 
-lemma norm_uncenteredcovarianceBilinDual_le (L₁ L₂ : StrongDual ℝ E) :
-    ‖uncenteredcovarianceBilinDual μ L₁ L₂‖ ≤ ‖L₁‖ * ‖L₂‖ * ∫ x, ‖x‖ ^ 2 ∂μ := by
+lemma norm_uncenteredCovarianceBilinDual_le (L₁ L₂ : StrongDual ℝ E) :
+    ‖uncenteredCovarianceBilinDual μ L₁ L₂‖ ≤ ‖L₁‖ * ‖L₂‖ * ∫ x, ‖x‖ ^ 2 ∂μ := by
   by_cases h : MemLp id 2 μ
-  swap; · simp only [uncenteredcovarianceBilinDual_of_not_memLp h, norm_zero]; positivity
-  calc ‖uncenteredcovarianceBilinDual μ L₁ L₂‖
-  _ = ‖∫ x, L₁ x * L₂ x ∂μ‖ := by rw [uncenteredcovarianceBilinDual_apply h]
+  swap; · simp only [uncenteredCovarianceBilinDual_of_not_memLp h, norm_zero]; positivity
+  calc ‖uncenteredCovarianceBilinDual μ L₁ L₂‖
+  _ = ‖∫ x, L₁ x * L₂ x ∂μ‖ := by rw [uncenteredCovarianceBilinDual_apply h]
   _ ≤ ∫ x, ‖L₁ x‖ * ‖L₂ x‖ ∂μ := (norm_integral_le_integral_norm _).trans (by simp)
   _ ≤ ∫ x, ‖L₁‖ * ‖x‖ * ‖L₂‖ * ‖x‖ ∂μ := by
     refine integral_mono_ae ?_ ?_ (ae_of_all _ fun x ↦ ?_)
@@ -224,8 +224,8 @@ lemma norm_uncenteredcovarianceBilinDual_le (L₁ L₂ : StrongDual ℝ E) :
     congr with x
     ring
 
-@[deprecated (since := "2025-10-10")] alias norm_uncenteredcovarianceBilin_le :=
-  norm_uncenteredcovarianceBilinDual_le
+@[deprecated (since := "2025-10-10")] alias norm_uncenteredCovarianceBilin_le :=
+  norm_uncenteredCovarianceBilinDual_le
 
 end Centered
 
@@ -238,12 +238,12 @@ open Classical in
 if `MemLp id 2 μ`. If not, we set it to zero. -/
 noncomputable
 def covarianceBilinDual (μ : Measure E) : StrongDual ℝ E →L[ℝ] StrongDual ℝ E →L[ℝ] ℝ :=
-  uncenteredcovarianceBilinDual (μ.map (fun x ↦ x - ∫ x, x ∂μ))
+  uncenteredCovarianceBilinDual (μ.map (fun x ↦ x - ∫ x, x ∂μ))
 
 @[simp]
 lemma covarianceBilinDual_of_not_memLp (h : ¬ MemLp id 2 μ) (L₁ L₂ : StrongDual ℝ E) :
     covarianceBilinDual μ L₁ L₂ = 0 := by
-  rw [covarianceBilinDual, uncenteredcovarianceBilinDual_of_not_memLp]
+  rw [covarianceBilinDual, uncenteredCovarianceBilinDual_of_not_memLp]
   rw [(measurableEmbedding_subRight _).memLp_map_measure_iff]
   refine fun h_Lp ↦ h ?_
   have : (id : E → E) = fun x ↦ x - ∫ x, x ∂μ + ∫ x, x ∂μ := by ext; simp
@@ -252,21 +252,21 @@ lemma covarianceBilinDual_of_not_memLp (h : ¬ MemLp id 2 μ) (L₁ L₂ : Stron
 
 @[simp]
 lemma covarianceBilinDual_zero : covarianceBilinDual (0 : Measure E) = 0 := by
-  rw [covarianceBilinDual, Measure.map_zero, uncenteredcovarianceBilinDual_zero]
+  rw [covarianceBilinDual, Measure.map_zero, uncenteredCovarianceBilinDual_zero]
 
 lemma covarianceBilinDual_comm (L₁ L₂ : StrongDual ℝ E) :
     covarianceBilinDual μ L₁ L₂ = covarianceBilinDual μ L₂ L₁ := by
   by_cases h : MemLp id 2 μ
   · have h' : MemLp id 2 (Measure.map (fun x ↦ x - ∫ (x : E), x ∂μ) μ) :=
       (measurableEmbedding_subRight _).memLp_map_measure_iff.mpr <| h.sub (memLp_const _)
-    simp_rw [covarianceBilinDual, uncenteredcovarianceBilinDual_apply h', mul_comm (L₁ _)]
+    simp_rw [covarianceBilinDual, uncenteredCovarianceBilinDual_apply h', mul_comm (L₁ _)]
   · simp [h]
 
 variable [CompleteSpace E]
 
 lemma covarianceBilinDual_apply (h : MemLp id 2 μ) (L₁ L₂ : StrongDual ℝ E) :
     covarianceBilinDual μ L₁ L₂ = ∫ x, (L₁ x - μ[L₁]) * (L₂ x - μ[L₂]) ∂μ := by
-  rw [covarianceBilinDual, uncenteredcovarianceBilinDual_apply,
+  rw [covarianceBilinDual, uncenteredCovarianceBilinDual_apply,
     integral_map (by fun_prop) (by fun_prop)]
   · have hL (L : StrongDual ℝ E) : μ[L] = L (∫ x, x ∂μ) :=
       L.integral_comp_comm (h.integrable (by simp))

--- a/Mathlib/Probability/Moments/CovarianceBilinDual.lean
+++ b/Mathlib/Probability/Moments/CovarianceBilinDual.lean
@@ -20,15 +20,15 @@ Let `μ` be a finite measure on a normed space `E` with the Borel σ-algebra. We
 * `Dual.toLp`: the function `MemLp.toLp` as a continuous linear map from `Dual 𝕜 E` (for `RCLike 𝕜`)
   into the space `Lp 𝕜 p μ` for `p ≥ 1`. This needs a hypothesis `MemLp id p μ` (we set it to the
   junk value 0 if that's not the case).
-* `covarianceBilin` : covariance of a measure `μ` with `∫ x, ‖x‖^2 ∂μ < ∞` on a Banach space,
+* `covarianceBilinDual` : covariance of a measure `μ` with `∫ x, ‖x‖^2 ∂μ < ∞` on a Banach space,
   as a continuous bilinear form `Dual ℝ E →L[ℝ] Dual ℝ E →L[ℝ] ℝ`.
-  If the second moment of `μ` is not finite, we set `covarianceBilin μ = 0`.
+  If the second moment of `μ` is not finite, we set `covarianceBilinDual μ = 0`.
 
 ## Main statements
 
-* `covarianceBilin_apply` : the covariance of `μ` on `L₁, L₂ : Dual ℝ E` is equal to
+* `covarianceBilinDual_apply` : the covariance of `μ` on `L₁, L₂ : Dual ℝ E` is equal to
   `∫ x, (L₁ x - μ[L₁]) * (L₂ x - μ[L₂]) ∂μ`.
-* `covarianceBilin_same_eq_variance`: `covarianceBilin μ L L = Var[L; μ]`.
+* `covarianceBilinDual_same_eq_variance`: `covarianceBilinDual μ L L = Var[L; μ]`.
 
 ## Implementation notes
 
@@ -162,13 +162,13 @@ variable [NormedSpace ℝ E] [OpensMeasurableSpace E]
 /-- Continuous bilinear form with value `∫ x, L₁ x * L₂ x ∂μ` on `(L₁, L₂)`.
 This is equal to the covariance only if `μ` is centered. -/
 noncomputable
-def uncenteredCovarianceBilin (μ : Measure E) : StrongDual ℝ E →L[ℝ] StrongDual ℝ E →L[ℝ] ℝ :=
+def uncenteredcovarianceBilinDual (μ : Measure E) : StrongDual ℝ E →L[ℝ] StrongDual ℝ E →L[ℝ] ℝ :=
   ContinuousLinearMap.bilinearComp (isBoundedBilinearMap_inner (𝕜 := ℝ)).toContinuousLinearMap
     (StrongDual.toLp μ 2) (StrongDual.toLp μ 2)
 
-lemma uncenteredCovarianceBilin_apply (h : MemLp id 2 μ) (L₁ L₂ : StrongDual ℝ E) :
-    uncenteredCovarianceBilin μ L₁ L₂ = ∫ x, L₁ x * L₂ x ∂μ := by
-  simp only [uncenteredCovarianceBilin, ContinuousLinearMap.bilinearComp_apply,
+lemma uncenteredcovarianceBilinDual_apply (h : MemLp id 2 μ) (L₁ L₂ : StrongDual ℝ E) :
+    uncenteredcovarianceBilinDual μ L₁ L₂ = ∫ x, L₁ x * L₂ x ∂μ := by
+  simp only [uncenteredcovarianceBilinDual, ContinuousLinearMap.bilinearComp_apply,
     StrongDual.toLp_apply h, L2.inner_def, RCLike.inner_apply, conj_trivial]
   refine integral_congr_ae ?_
   filter_upwards [MemLp.coeFn_toLp (h.continuousLinearMap_comp L₁),
@@ -176,21 +176,21 @@ lemma uncenteredCovarianceBilin_apply (h : MemLp id 2 μ) (L₁ L₂ : StrongDua
   simp only [id_eq] at hxL₁ hxL₂
   rw [hxL₁, hxL₂, mul_comm]
 
-lemma uncenteredCovarianceBilin_of_not_memLp (h : ¬ MemLp id 2 μ) (L₁ L₂ : StrongDual ℝ E) :
-    uncenteredCovarianceBilin μ L₁ L₂ = 0 := by
-  simp [uncenteredCovarianceBilin, StrongDual.toLp_of_not_memLp h]
+lemma uncenteredcovarianceBilinDual_of_not_memLp (h : ¬ MemLp id 2 μ) (L₁ L₂ : StrongDual ℝ E) :
+    uncenteredcovarianceBilinDual μ L₁ L₂ = 0 := by
+  simp [uncenteredcovarianceBilinDual, StrongDual.toLp_of_not_memLp h]
 
-lemma uncenteredCovarianceBilin_zero : uncenteredCovarianceBilin (0 : Measure E) = 0 := by
+lemma uncenteredcovarianceBilinDual_zero : uncenteredcovarianceBilinDual (0 : Measure E) = 0 := by
   ext
   have : Subsingleton (Lp ℝ 2 (0 : Measure E)) := ⟨fun x y ↦ Lp.ext_iff.2 rfl⟩
-  simp [uncenteredCovarianceBilin, Subsingleton.eq_zero (StrongDual.toLp 0 2)]
+  simp [uncenteredcovarianceBilinDual, Subsingleton.eq_zero (StrongDual.toLp 0 2)]
 
-lemma norm_uncenteredCovarianceBilin_le (L₁ L₂ : StrongDual ℝ E) :
-    ‖uncenteredCovarianceBilin μ L₁ L₂‖ ≤ ‖L₁‖ * ‖L₂‖ * ∫ x, ‖x‖ ^ 2 ∂μ := by
+lemma norm_uncenteredcovarianceBilinDual_le (L₁ L₂ : StrongDual ℝ E) :
+    ‖uncenteredcovarianceBilinDual μ L₁ L₂‖ ≤ ‖L₁‖ * ‖L₂‖ * ∫ x, ‖x‖ ^ 2 ∂μ := by
   by_cases h : MemLp id 2 μ
-  swap; · simp only [uncenteredCovarianceBilin_of_not_memLp h, norm_zero]; positivity
-  calc ‖uncenteredCovarianceBilin μ L₁ L₂‖
-  _ = ‖∫ x, L₁ x * L₂ x ∂μ‖ := by rw [uncenteredCovarianceBilin_apply h]
+  swap; · simp only [uncenteredcovarianceBilinDual_of_not_memLp h, norm_zero]; positivity
+  calc ‖uncenteredcovarianceBilinDual μ L₁ L₂‖
+  _ = ‖∫ x, L₁ x * L₂ x ∂μ‖ := by rw [uncenteredcovarianceBilinDual_apply h]
   _ ≤ ∫ x, ‖L₁ x‖ * ‖L₂ x‖ ∂μ := (norm_integral_le_integral_norm _).trans (by simp)
   _ ≤ ∫ x, ‖L₁‖ * ‖x‖ * ‖L₂‖ * ‖x‖ ∂μ := by
     refine integral_mono_ae ?_ ?_ (ae_of_all _ fun x ↦ ?_)
@@ -222,13 +222,13 @@ open Classical in
 /-- Continuous bilinear form with value `∫ x, (L₁ x - μ[L₁]) * (L₂ x - μ[L₂]) ∂μ` on `(L₁, L₂)`
 if `MemLp id 2 μ`. If not, we set it to zero. -/
 noncomputable
-def covarianceBilin (μ : Measure E) : StrongDual ℝ E →L[ℝ] StrongDual ℝ E →L[ℝ] ℝ :=
-  uncenteredCovarianceBilin (μ.map (fun x ↦ x - ∫ x, x ∂μ))
+def covarianceBilinDual (μ : Measure E) : StrongDual ℝ E →L[ℝ] StrongDual ℝ E →L[ℝ] ℝ :=
+  uncenteredcovarianceBilinDual (μ.map (fun x ↦ x - ∫ x, x ∂μ))
 
 @[simp]
-lemma covarianceBilin_of_not_memLp (h : ¬ MemLp id 2 μ) (L₁ L₂ : StrongDual ℝ E) :
-    covarianceBilin μ L₁ L₂ = 0 := by
-  rw [covarianceBilin, uncenteredCovarianceBilin_of_not_memLp]
+lemma covarianceBilinDual_of_not_memLp (h : ¬ MemLp id 2 μ) (L₁ L₂ : StrongDual ℝ E) :
+    covarianceBilinDual μ L₁ L₂ = 0 := by
+  rw [covarianceBilinDual, uncenteredcovarianceBilinDual_of_not_memLp]
   rw [(measurableEmbedding_subRight _).memLp_map_measure_iff]
   refine fun h_Lp ↦ h ?_
   have : (id : E → E) = fun x ↦ x - ∫ x, x ∂μ + ∫ x, x ∂μ := by ext; simp
@@ -236,45 +236,45 @@ lemma covarianceBilin_of_not_memLp (h : ¬ MemLp id 2 μ) (L₁ L₂ : StrongDua
   exact h_Lp.add (memLp_const _)
 
 @[simp]
-lemma covarianceBilin_zero : covarianceBilin (0 : Measure E) = 0 := by
-  rw [covarianceBilin, Measure.map_zero, uncenteredCovarianceBilin_zero]
+lemma covarianceBilinDual_zero : covarianceBilinDual (0 : Measure E) = 0 := by
+  rw [covarianceBilinDual, Measure.map_zero, uncenteredcovarianceBilinDual_zero]
 
-lemma covarianceBilin_comm (L₁ L₂ : StrongDual ℝ E) :
-    covarianceBilin μ L₁ L₂ = covarianceBilin μ L₂ L₁ := by
+lemma covarianceBilinDual_comm (L₁ L₂ : StrongDual ℝ E) :
+    covarianceBilinDual μ L₁ L₂ = covarianceBilinDual μ L₂ L₁ := by
   by_cases h : MemLp id 2 μ
   · have h' : MemLp id 2 (Measure.map (fun x ↦ x - ∫ (x : E), x ∂μ) μ) :=
       (measurableEmbedding_subRight _).memLp_map_measure_iff.mpr <| h.sub (memLp_const _)
-    simp_rw [covarianceBilin, uncenteredCovarianceBilin_apply h', mul_comm (L₁ _)]
+    simp_rw [covarianceBilinDual, uncenteredcovarianceBilinDual_apply h', mul_comm (L₁ _)]
   · simp [h]
 
 variable [CompleteSpace E]
 
-lemma covarianceBilin_apply (h : MemLp id 2 μ) (L₁ L₂ : StrongDual ℝ E) :
-    covarianceBilin μ L₁ L₂ = ∫ x, (L₁ x - μ[L₁]) * (L₂ x - μ[L₂]) ∂μ := by
-  rw [covarianceBilin, uncenteredCovarianceBilin_apply,
+lemma covarianceBilinDual_apply (h : MemLp id 2 μ) (L₁ L₂ : StrongDual ℝ E) :
+    covarianceBilinDual μ L₁ L₂ = ∫ x, (L₁ x - μ[L₁]) * (L₂ x - μ[L₂]) ∂μ := by
+  rw [covarianceBilinDual, uncenteredcovarianceBilinDual_apply,
     integral_map (by fun_prop) (by fun_prop)]
   · have hL (L : StrongDual ℝ E) : μ[L] = L (∫ x, x ∂μ) :=
       L.integral_comp_comm (h.integrable (by simp))
     simp [← hL]
   · exact (measurableEmbedding_subRight _).memLp_map_measure_iff.mpr <| h.sub (memLp_const _)
 
-lemma covarianceBilin_apply' (h : MemLp id 2 μ) (L₁ L₂ : StrongDual ℝ E) :
-    covarianceBilin μ L₁ L₂ = ∫ x, L₁ (x - μ[id]) * L₂ (x - μ[id]) ∂μ := by
-  rw [covarianceBilin_apply h]
+lemma covarianceBilinDual_apply' (h : MemLp id 2 μ) (L₁ L₂ : StrongDual ℝ E) :
+    covarianceBilinDual μ L₁ L₂ = ∫ x, L₁ (x - μ[id]) * L₂ (x - μ[id]) ∂μ := by
+  rw [covarianceBilinDual_apply h]
   have hL (L : StrongDual ℝ E) : μ[L] = L (∫ x, x ∂μ) :=
     L.integral_comp_comm (h.integrable (by simp))
   simp [← hL]
 
-lemma covarianceBilin_eq_covariance (h : MemLp id 2 μ) (L₁ L₂ : StrongDual ℝ E) :
-    covarianceBilin μ L₁ L₂ = cov[L₁, L₂; μ] := by
-  rw [covarianceBilin_apply h, covariance]
+lemma covarianceBilinDual_eq_covariance (h : MemLp id 2 μ) (L₁ L₂ : StrongDual ℝ E) :
+    covarianceBilinDual μ L₁ L₂ = cov[L₁, L₂; μ] := by
+  rw [covarianceBilinDual_apply h, covariance]
 
-lemma covarianceBilin_self_eq_variance (h : MemLp id 2 μ) (L : StrongDual ℝ E) :
-    covarianceBilin μ L L = Var[L; μ] := by
-  rw [covarianceBilin_eq_covariance h, covariance_self (by fun_prop)]
+lemma covarianceBilinDual_self_eq_variance (h : MemLp id 2 μ) (L : StrongDual ℝ E) :
+    covarianceBilinDual μ L L = Var[L; μ] := by
+  rw [covarianceBilinDual_eq_covariance h, covariance_self (by fun_prop)]
 
-@[deprecated (since := "2025-07-16")] alias covarianceBilin_same_eq_variance :=
-  covarianceBilin_self_eq_variance
+@[deprecated (since := "2025-07-16")] alias covarianceBilinDual_same_eq_variance :=
+  covarianceBilinDual_self_eq_variance
 
 end Covariance
 

--- a/Mathlib/Probability/Moments/CovarianceBilinDual.lean
+++ b/Mathlib/Probability/Moments/CovarianceBilinDual.lean
@@ -273,7 +273,7 @@ lemma covarianceBilinDual_self_eq_variance (h : MemLp id 2 μ) (L : StrongDual �
     covarianceBilinDual μ L L = Var[L; μ] := by
   rw [covarianceBilinDual_eq_covariance h, covariance_self (by fun_prop)]
 
-@[deprecated (since := "2025-07-16")] alias covarianceBilinDual_same_eq_variance :=
+@[deprecated (since := "2025-07-16")] alias covarianceBilin_same_eq_variance :=
   covarianceBilinDual_self_eq_variance
 
 end Covariance

--- a/Mathlib/Probability/Moments/CovarianceBilinDual.lean
+++ b/Mathlib/Probability/Moments/CovarianceBilinDual.lean
@@ -166,6 +166,9 @@ def uncenteredcovarianceBilinDual (μ : Measure E) : StrongDual ℝ E →L[ℝ] 
   ContinuousLinearMap.bilinearComp (isBoundedBilinearMap_inner (𝕜 := ℝ)).toContinuousLinearMap
     (StrongDual.toLp μ 2) (StrongDual.toLp μ 2)
 
+@[deprecated (since := "2025-10-10")] alias uncenteredcovarianceBilin :=
+  uncenteredcovarianceBilinDual
+
 lemma uncenteredcovarianceBilinDual_apply (h : MemLp id 2 μ) (L₁ L₂ : StrongDual ℝ E) :
     uncenteredcovarianceBilinDual μ L₁ L₂ = ∫ x, L₁ x * L₂ x ∂μ := by
   simp only [uncenteredcovarianceBilinDual, ContinuousLinearMap.bilinearComp_apply,
@@ -176,14 +179,23 @@ lemma uncenteredcovarianceBilinDual_apply (h : MemLp id 2 μ) (L₁ L₂ : Stron
   simp only [id_eq] at hxL₁ hxL₂
   rw [hxL₁, hxL₂, mul_comm]
 
+@[deprecated (since := "2025-10-10")] alias uncenteredcovarianceBilin_apply :=
+  uncenteredcovarianceBilinDual_apply
+
 lemma uncenteredcovarianceBilinDual_of_not_memLp (h : ¬ MemLp id 2 μ) (L₁ L₂ : StrongDual ℝ E) :
     uncenteredcovarianceBilinDual μ L₁ L₂ = 0 := by
   simp [uncenteredcovarianceBilinDual, StrongDual.toLp_of_not_memLp h]
+
+@[deprecated (since := "2025-10-10")] alias uncenteredcovarianceBilin_of_not_memLp :=
+  uncenteredcovarianceBilinDual_of_not_memLp
 
 lemma uncenteredcovarianceBilinDual_zero : uncenteredcovarianceBilinDual (0 : Measure E) = 0 := by
   ext
   have : Subsingleton (Lp ℝ 2 (0 : Measure E)) := ⟨fun x y ↦ Lp.ext_iff.2 rfl⟩
   simp [uncenteredcovarianceBilinDual, Subsingleton.eq_zero (StrongDual.toLp 0 2)]
+
+@[deprecated (since := "2025-10-10")] alias uncenteredcovarianceBilin_zero :=
+  uncenteredcovarianceBilinDual_zero
 
 lemma norm_uncenteredcovarianceBilinDual_le (L₁ L₂ : StrongDual ℝ E) :
     ‖uncenteredcovarianceBilinDual μ L₁ L₂‖ ≤ ‖L₁‖ * ‖L₂‖ * ∫ x, ‖x‖ ^ 2 ∂μ := by
@@ -211,6 +223,9 @@ lemma norm_uncenteredcovarianceBilinDual_le (L₁ L₂ : StrongDual ℝ E) :
     rw [← integral_const_mul]
     congr with x
     ring
+
+@[deprecated (since := "2025-10-10")] alias norm_uncenteredcovarianceBilin_le :=
+  norm_uncenteredcovarianceBilinDual_le
 
 end Centered
 


### PR DESCRIPTION
This allows to define `covarianceBilin` on a Hilbert space in #30324, following the naming scheme `charFunDual/charFun`.

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include at least one commit authored by each
co-author among the commits in the pull request. If necessary, you may 
create empty commits to indicate co-authorship, using commands like so:

git commit --author="Author Name <author@email.com>" --allow-empty -m "add Author Name as coauthor"

When merging, all the commits will be squashed into a single commit listing all co-authors.

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

I did not put deprecations because the name will be reused instantly in #30324.

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
