### PR TITLE
[Merged by Bors] - feat(Topology): Units of nonnegative elements

### DIFF
--- a/Mathlib/Algebra/Order/Nonneg/Field.lean
+++ b/Mathlib/Algebra/Order/Nonneg/Field.lean
@@ -6,6 +6,7 @@ Authors: Floris van Doorn
 import Mathlib.Algebra.Field.Basic
 import Mathlib.Algebra.Order.Field.Canonical
 import Mathlib.Algebra.Order.Nonneg.Ring
+import Mathlib.Algebra.Order.Positive.Ring
 import Mathlib.Data.Nat.Cast.Order.Ring
 
 /-!
@@ -39,6 +40,18 @@ lemma nnqsmul_nonneg (q : ℚ≥0) (ha : 0 ≤ a) : 0 ≤ q • a := by
 end NNRat
 
 namespace Nonneg
+
+/-- In an ordered field, the units of the nonnegative elements are the positive elements. -/
+@[simps]
+def unitsEquivPos (R : Type*) [DivisionSemiring R] [PartialOrder R]
+    [IsStrictOrderedRing R] [PosMulReflectLT R] :
+    { r : R // 0 ≤ r }ˣ ≃* { r : R // 0 < r } where
+  toFun r := ⟨r, lt_of_le_of_ne r.1.2 (Subtype.val_injective.ne r.ne_zero.symm)⟩
+  invFun r := ⟨⟨r.1, r.2.le⟩, ⟨r.1⁻¹, inv_nonneg.mpr r.2.le⟩,
+    by ext; simp [r.2.ne'], by ext; simp [r.2.ne']⟩
+  left_inv r := by ext; rfl
+  right_inv r := by ext; rfl
+  map_mul' _ _ := rfl
 
 section LinearOrderedSemifield
 

--- a/Mathlib/Topology/Algebra/Field.lean
+++ b/Mathlib/Topology/Algebra/Field.lean
@@ -77,6 +77,28 @@ theorem Subfield.topologicalClosure_minimal (s : Subfield α) {t : Subfield α} 
 
 end Subfield
 
+section Units
+
+/-- In an ordered field, the units of the nonnegative elements are the positive elements. -/
+@[simps!]
+def Nonneg.unitsHomeomorphPos (R : Type*) [DivisionSemiring R] [PartialOrder R]
+    [IsStrictOrderedRing R] [PosMulReflectLT R]
+    [TopologicalSpace R] [ContinuousInv₀ R] :
+    { r : R // 0 ≤ r }ˣ ≃ₜ { r : R // 0 < r } where
+  __ := Nonneg.unitsEquivPos R
+  continuous_toFun := by
+    rw [Topology.IsEmbedding.subtypeVal.continuous_iff]
+    exact Continuous.subtype_val (p := (0 ≤ ·)) Units.continuous_val
+  continuous_invFun := by
+    rw [Units.continuous_iff]
+    refine ⟨by fun_prop, ?_⟩
+    suffices Continuous fun (x : { r : R // 0 < r }) ↦ (x⁻¹ : R) by
+      simpa [Topology.IsEmbedding.subtypeVal.continuous_iff, Function.comp_def]
+    rw [continuous_iff_continuousAt]
+    exact fun x ↦ ContinuousAt.inv₀ (by fun_prop) x.2.ne'
+
+end Units
+
 section affineHomeomorph
 
 /-!


### PR DESCRIPTION
---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include at least one commit authored by each
co-author among the commits in the pull request. If necessary, you may 
create empty commits to indicate co-authorship, using commands like so:

git commit --author="Author Name <author@email.com>" --allow-empty -m "add Author Name as coauthor"

When merging, all the commits will be squashed into a single commit listing all co-authors.

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
