### PR TITLE
[Merged by Bors] - feat(Algebra): index of posSubgroup

### DIFF
--- a/Mathlib.lean
+++ b/Mathlib.lean
@@ -977,6 +977,7 @@ import Mathlib.Algebra.Order.Ring.Star
 import Mathlib.Algebra.Order.Ring.Synonym
 import Mathlib.Algebra.Order.Ring.Unbundled.Basic
 import Mathlib.Algebra.Order.Ring.Unbundled.Rat
+import Mathlib.Algebra.Order.Ring.Units
 import Mathlib.Algebra.Order.Ring.WithTop
 import Mathlib.Algebra.Order.Round
 import Mathlib.Algebra.Order.Star.Basic

--- a/Mathlib/Algebra/Order/Ring/Units.lean
+++ b/Mathlib/Algebra/Order/Ring/Units.lean
@@ -1,0 +1,17 @@
+/-
+Copyright (c) 2025 Andrew Yang. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Andrew Yang
+-/
+import Mathlib.Algebra.Ring.Subring.Units
+import Mathlib.GroupTheory.Index
+
+/-! # Lemmas about units of ordered rings -/
+
+lemma Units.index_posSubgroup (R : Type*) [Ring R] [LinearOrder R] [IsStrictOrderedRing R] :
+    (posSubgroup R).index = 2 := by
+  rw [Subgroup.index_eq_two_iff]
+  refine ⟨-1, fun a ↦ ?_⟩
+  obtain h | h := lt_or_gt_of_ne a.ne_zero
+  · simp [h, h.le]
+  · simp [h, xor_comm, h.le]

--- a/Mathlib/Algebra/Ring/Subring/Units.lean
+++ b/Mathlib/Algebra/Ring/Subring/Units.lean
@@ -7,7 +7,6 @@ import Mathlib.Algebra.Group.Subgroup.Defs
 import Mathlib.Algebra.Group.Submonoid.Operations
 import Mathlib.Algebra.Order.GroupWithZero.Submonoid
 import Mathlib.Algebra.Order.Ring.Defs
-import Mathlib.GroupTheory.Index
 
 /-!
 
@@ -26,11 +25,3 @@ def Units.posSubgroup (R : Type*) [Semiring R] [LinearOrder R] [IsStrictOrderedR
 theorem Units.mem_posSubgroup {R : Type*} [Semiring R] [LinearOrder R] [IsStrictOrderedRing R]
     (u : Rˣ) : u ∈ Units.posSubgroup R ↔ (0 : R) < u :=
   Iff.rfl
-
-lemma Units.index_posSubgroup (R : Type*) [Ring R] [LinearOrder R] [IsStrictOrderedRing R] :
-    (posSubgroup R).index = 2 := by
-  rw [Subgroup.index_eq_two_iff]
-  refine ⟨-1, fun a ↦ ?_⟩
-  obtain h | h := lt_or_gt_of_ne a.ne_zero
-  · simp [h, h.le]
-  · simp [h, xor_comm, h.le]

--- a/Mathlib/Algebra/Ring/Subring/Units.lean
+++ b/Mathlib/Algebra/Ring/Subring/Units.lean
@@ -7,6 +7,7 @@ import Mathlib.Algebra.Group.Subgroup.Defs
 import Mathlib.Algebra.Group.Submonoid.Operations
 import Mathlib.Algebra.Order.GroupWithZero.Submonoid
 import Mathlib.Algebra.Order.Ring.Defs
+import Mathlib.GroupTheory.Index
 
 /-!
 
@@ -25,3 +26,11 @@ def Units.posSubgroup (R : Type*) [Semiring R] [LinearOrder R] [IsStrictOrderedR
 theorem Units.mem_posSubgroup {R : Type*} [Semiring R] [LinearOrder R] [IsStrictOrderedRing R]
     (u : Rˣ) : u ∈ Units.posSubgroup R ↔ (0 : R) < u :=
   Iff.rfl
+
+lemma Units.index_posSubgroup (R : Type*) [Ring R] [LinearOrder R] [IsStrictOrderedRing R] :
+    (posSubgroup R).index = 2 := by
+  rw [Subgroup.index_eq_two_iff]
+  refine ⟨-1, fun a ↦ ?_⟩
+  obtain h | h := lt_or_gt_of_ne a.ne_zero
+  · simp [h, h.le]
+  · simp [h, xor_comm, h.le]


### PR DESCRIPTION

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include at least one commit authored by each
co-author among the commits in the pull request. If necessary, you may 
create empty commits to indicate co-authorship, using commands like so:

git commit --author="Author Name <author@email.com>" --allow-empty -m "add Author Name as coauthor"

When merging, all the commits will be squashed into a single commit listing all co-authors.

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
