### PR TITLE
[Merged by Bors] - chore(LinearAlgebra/TensorProduct/Finiteness): rename `_of_finite` lemmas to `_of_setFinite`

### DIFF
--- a/Mathlib/LinearAlgebra/FiniteDimensional/Basic.lean
+++ b/Mathlib/LinearAlgebra/FiniteDimensional/Basic.lean
@@ -601,15 +601,6 @@ theorem ker_pow_constant {f : End K V} {k : ℕ}
 
 end End
 
-lemma mem_finiteDimensional_submodule (K : Type*) {V : Type*}
-    [DivisionRing K] [AddCommGroup V] [Module K V] (e : V) :
-    ∃ (E' : Submodule K V) (_ : FiniteDimensional K E'), e ∈ E' := by
-  classical
-  let b := Basis.ofVectorSpace K V
-  refine ⟨Submodule.span K (Finset.image b (b.repr e).support),
-    FiniteDimensional.span_finset _ _, ?_⟩
-  simp [Basis.mem_span_repr_support]
-
 end Module
 
 open TensorProduct in
@@ -621,9 +612,8 @@ lemma TensorProduct.mem_finiteDimensional_range_mapIncl {K V V' : Type*} [Field 
   z.induction_on
   ⟨⊥, ⊥, finiteDimensional_bot K V, finiteDimensional_bot K V', Submodule.zero_mem _⟩
   fun e f => by
-    rcases Module.mem_finiteDimensional_submodule K e with ⟨E', iE', he⟩
-    rcases Module.mem_finiteDimensional_submodule K f with ⟨F', iF', hf⟩
-    exact ⟨E', F', iE', iF', ⟨⟨e, he⟩ ⊗ₜ ⟨f, hf⟩, rfl⟩⟩
+    exact ⟨span K {e}, span K {f}, Finite.span_singleton K e, Finite.span_singleton K f,
+      ⟨e, mem_span_singleton_self e⟩ ⊗ₜ ⟨f, mem_span_singleton_self f⟩, rfl⟩
   fun _ _ ih₁ ih₂ => by
     rcases ih₁ with ⟨E1, F1, _, _, ⟨z1, rfl⟩⟩
     rcases ih₂ with ⟨E2, F2, _, _, ⟨z2, rfl⟩⟩

--- a/Mathlib/LinearAlgebra/FiniteDimensional/Basic.lean
+++ b/Mathlib/LinearAlgebra/FiniteDimensional/Basic.lean
@@ -601,4 +601,35 @@ theorem ker_pow_constant {f : End K V} {k : ℕ}
 
 end End
 
+lemma mem_finiteDimensional_submodule (K : Type*) {V : Type*}
+    [DivisionRing K] [AddCommGroup V] [Module K V] (e : V) :
+    ∃ (E' : Submodule K V) (_ : FiniteDimensional K E'), e ∈ E' := by
+  classical
+  let b := Basis.ofVectorSpace K V
+  refine ⟨Submodule.span K (Finset.image b (b.repr e).support),
+    FiniteDimensional.span_finset _ _, ?_⟩
+  simp [Basis.mem_span_repr_support]
+
 end Module
+
+open TensorProduct in
+lemma TensorProduct.mem_finiteDimensional_range_mapIncl {K V V' : Type*} [Field K] [AddCommGroup V]
+    [AddCommGroup V'] [Module K V] [Module K V'] (z : V ⊗[K] V') :
+    ∃ (E' : Submodule K V) (F' : Submodule K V')
+    (_ : FiniteDimensional K E') (_ : FiniteDimensional K F'),
+    z ∈ LinearMap.range (mapIncl E' F') :=
+  z.induction_on
+  ⟨⊥, ⊥, finiteDimensional_bot K V, finiteDimensional_bot K V', Submodule.zero_mem _⟩
+  fun e f => by
+    rcases Module.mem_finiteDimensional_submodule K e with ⟨E', iE', he⟩
+    rcases Module.mem_finiteDimensional_submodule K f with ⟨F', iF', hf⟩
+    exact ⟨E', F', iE', iF', ⟨⟨e, he⟩ ⊗ₜ ⟨f, hf⟩, rfl⟩⟩
+  fun _ _ ih₁ ih₂ => by
+    rcases ih₁ with ⟨E1, F1, _, _, ⟨z1, rfl⟩⟩
+    rcases ih₂ with ⟨E2, F2, _, _, ⟨z2, rfl⟩⟩
+    exact ⟨E1 ⊔ E2, F1 ⊔ F2, E1.finiteDimensional_sup _, F1.finiteDimensional_sup _,
+      Submodule.add_mem _
+      ((range_mapIncl_mono le_sup_left (le_refl _)).trans
+        (range_mapIncl_mono (le_refl _) le_sup_left) ⟨z1, rfl⟩)
+      ((range_mapIncl_mono le_sup_right (le_refl _)).trans
+        (range_mapIncl_mono (le_refl _) le_sup_right) ⟨z2, rfl⟩)⟩

--- a/Mathlib/LinearAlgebra/FiniteDimensional/Basic.lean
+++ b/Mathlib/LinearAlgebra/FiniteDimensional/Basic.lean
@@ -604,7 +604,7 @@ end End
 end Module
 
 open TensorProduct in
-/-- Given an element `z : E ⊗ F'`, there exists finite subspaces `E'` and `F'`
+/-- Given an element `z : E ⊗ F`, there exists finite subspaces `E'` and `F'`
 such that `z ∈ range (mapIncl E' F')`. -/
 lemma TensorProduct.exists_finite_mem_range_mapIncl {R E F : Type*} [CommRing R]
     [AddCommGroup E] [AddCommGroup F] [Module R E] [Module R F] (z : E ⊗[R] F) :

--- a/Mathlib/LinearAlgebra/FiniteDimensional/Basic.lean
+++ b/Mathlib/LinearAlgebra/FiniteDimensional/Basic.lean
@@ -604,20 +604,21 @@ end End
 end Module
 
 open TensorProduct in
-lemma TensorProduct.mem_finiteDimensional_range_mapIncl {K V V' : Type*} [Field K] [AddCommGroup V]
-    [AddCommGroup V'] [Module K V] [Module K V'] (z : V ⊗[K] V') :
-    ∃ (E' : Submodule K V) (F' : Submodule K V')
-    (_ : FiniteDimensional K E') (_ : FiniteDimensional K F'),
+/-- Given an element `z : V ⊗ V'`, there exists finite subspaces `E'` and `F'`
+such that `z ∈ range (mapIncl E' F')`. -/
+lemma TensorProduct.exists_finite_mem_range_mapIncl {R V V' : Type*} [CommRing R]
+    [AddCommGroup V] [AddCommGroup V'] [Module R V] [Module R V'] (z : V ⊗[R] V') :
+    ∃ (E' : Submodule R V) (F' : Submodule R V') (_ : Module.Finite R E') (_ : Module.Finite R F'),
     z ∈ LinearMap.range (mapIncl E' F') :=
   z.induction_on
-  ⟨⊥, ⊥, finiteDimensional_bot K V, finiteDimensional_bot K V', Submodule.zero_mem _⟩
+  ⟨⊥, ⊥, Finite.bot R V, Finite.bot R V', Submodule.zero_mem _⟩
   fun e f => by
-    exact ⟨span K {e}, span K {f}, Finite.span_singleton K e, Finite.span_singleton K f,
+    exact ⟨span R {e}, span R {f}, Finite.span_singleton R e, Finite.span_singleton R f,
       ⟨e, mem_span_singleton_self e⟩ ⊗ₜ ⟨f, mem_span_singleton_self f⟩, rfl⟩
   fun _ _ ih₁ ih₂ => by
     rcases ih₁ with ⟨E1, F1, _, _, ⟨z1, rfl⟩⟩
     rcases ih₂ with ⟨E2, F2, _, _, ⟨z2, rfl⟩⟩
-    exact ⟨E1 ⊔ E2, F1 ⊔ F2, E1.finiteDimensional_sup _, F1.finiteDimensional_sup _,
+    exact ⟨E1 ⊔ E2, F1 ⊔ F2, E1.finite_sup _, F1.finite_sup _,
       Submodule.add_mem _
       ((range_mapIncl_mono le_sup_left (le_refl _)).trans
         (range_mapIncl_mono (le_refl _) le_sup_left) ⟨z1, rfl⟩)

--- a/Mathlib/LinearAlgebra/FiniteDimensional/Basic.lean
+++ b/Mathlib/LinearAlgebra/FiniteDimensional/Basic.lean
@@ -604,14 +604,14 @@ end End
 end Module
 
 open TensorProduct in
-/-- Given an element `z : V ⊗ V'`, there exists finite subspaces `E'` and `F'`
+/-- Given an element `z : E ⊗ F'`, there exists finite subspaces `E'` and `F'`
 such that `z ∈ range (mapIncl E' F')`. -/
-lemma TensorProduct.exists_finite_mem_range_mapIncl {R V V' : Type*} [CommRing R]
-    [AddCommGroup V] [AddCommGroup V'] [Module R V] [Module R V'] (z : V ⊗[R] V') :
-    ∃ (E' : Submodule R V) (F' : Submodule R V') (_ : Module.Finite R E') (_ : Module.Finite R F'),
+lemma TensorProduct.exists_finite_mem_range_mapIncl {R E F : Type*} [CommRing R]
+    [AddCommGroup E] [AddCommGroup F] [Module R E] [Module R F] (z : E ⊗[R] F) :
+    ∃ (E' : Submodule R E) (F' : Submodule R F) (_ : Module.Finite R E') (_ : Module.Finite R F'),
     z ∈ LinearMap.range (mapIncl E' F') :=
   z.induction_on
-  ⟨⊥, ⊥, Finite.bot R V, Finite.bot R V', Submodule.zero_mem _⟩
+  ⟨⊥, ⊥, Finite.bot R E, Finite.bot R F, Submodule.zero_mem _⟩
   fun e f => by
     exact ⟨span R {e}, span R {f}, Finite.span_singleton R e, Finite.span_singleton R f,
       ⟨e, mem_span_singleton_self e⟩ ⊗ₜ ⟨f, mem_span_singleton_self f⟩, rfl⟩

--- a/Mathlib/LinearAlgebra/FiniteDimensional/Basic.lean
+++ b/Mathlib/LinearAlgebra/FiniteDimensional/Basic.lean
@@ -602,25 +602,3 @@ theorem ker_pow_constant {f : End K V} {k : ℕ}
 end End
 
 end Module
-
-open TensorProduct in
-/-- Given an element `z : E ⊗ F`, there exists finite subspaces `E'` and `F'`
-such that `z ∈ range (mapIncl E' F')`. -/
-lemma TensorProduct.exists_finite_mem_range_mapIncl {R E F : Type*} [CommRing R]
-    [AddCommGroup E] [AddCommGroup F] [Module R E] [Module R F] (z : E ⊗[R] F) :
-    ∃ (E' : Submodule R E) (F' : Submodule R F) (_ : Module.Finite R E') (_ : Module.Finite R F'),
-    z ∈ LinearMap.range (mapIncl E' F') :=
-  z.induction_on
-  ⟨⊥, ⊥, Finite.bot R E, Finite.bot R F, Submodule.zero_mem _⟩
-  fun e f => by
-    exact ⟨span R {e}, span R {f}, Finite.span_singleton R e, Finite.span_singleton R f,
-      ⟨e, mem_span_singleton_self e⟩ ⊗ₜ ⟨f, mem_span_singleton_self f⟩, rfl⟩
-  fun _ _ ih₁ ih₂ => by
-    rcases ih₁ with ⟨E1, F1, _, _, ⟨z1, rfl⟩⟩
-    rcases ih₂ with ⟨E2, F2, _, _, ⟨z2, rfl⟩⟩
-    exact ⟨E1 ⊔ E2, F1 ⊔ F2, E1.finite_sup _, F1.finite_sup _,
-      Submodule.add_mem _
-      ((range_mapIncl_mono le_sup_left (le_refl _)).trans
-        (range_mapIncl_mono (le_refl _) le_sup_left) ⟨z1, rfl⟩)
-      ((range_mapIncl_mono le_sup_right (le_refl _)).trans
-        (range_mapIncl_mono (le_refl _) le_sup_right) ⟨z2, rfl⟩)⟩

--- a/Mathlib/LinearAlgebra/LinearDisjoint.lean
+++ b/Mathlib/LinearAlgebra/LinearDisjoint.lean
@@ -265,7 +265,7 @@ theorem of_linearDisjoint_fg_left
     (H : ∀ M' : Submodule R S, M' ≤ M → M'.FG → M'.LinearDisjoint N) :
     M.LinearDisjoint N := (linearDisjoint_iff _ _).2 fun x y hxy ↦ by
   obtain ⟨M', hM, hFG, h⟩ :=
-    TensorProduct.exists_finite_submodule_left_of_finite' {x, y} (Set.toFinite _)
+    TensorProduct.exists_finite_submodule_left_of_setFinite' {x, y} (Set.toFinite _)
   rw [Module.Finite.iff_fg] at hFG
   obtain ⟨x', hx'⟩ := h (show x ∈ {x, y} by simp)
   obtain ⟨y', hy'⟩ := h (show y ∈ {x, y} by simp)
@@ -278,7 +278,7 @@ theorem of_linearDisjoint_fg_right
     (H : ∀ N' : Submodule R S, N' ≤ N → N'.FG → M.LinearDisjoint N') :
     M.LinearDisjoint N := (linearDisjoint_iff _ _).2 fun x y hxy ↦ by
   obtain ⟨N', hN, hFG, h⟩ :=
-    TensorProduct.exists_finite_submodule_right_of_finite' {x, y} (Set.toFinite _)
+    TensorProduct.exists_finite_submodule_right_of_setFinite' {x, y} (Set.toFinite _)
   rw [Module.Finite.iff_fg] at hFG
   obtain ⟨x', hx'⟩ := h (show x ∈ {x, y} by simp)
   obtain ⟨y', hy'⟩ := h (show y ∈ {x, y} by simp)

--- a/Mathlib/LinearAlgebra/TensorProduct/Finiteness.lean
+++ b/Mathlib/LinearAlgebra/TensorProduct/Finiteness.lean
@@ -178,7 +178,7 @@ theorem exists_finite_submodule_right_of_finite' (s : Set (M₁ ⊗[R] N₁)) (h
 lemma exists_finite_mem_map₂ {R E F : Type*} [CommRing R]
     [AddCommGroup E] [AddCommGroup F] [Module R E] [Module R F] (z : E ⊗[R] F) :
     ∃ (E' : Submodule R E) (F' : Submodule R F) (_ : Module.Finite R E') (_ : Module.Finite R F'),
-    z ∈ Submodule.map₂ (mk R E F) E' F' :=
+      z ∈ Submodule.map₂ (mk R E F) E' F' :=
   z.induction_on
   ⟨⊥, ⊥, .bot R E, .bot R F, Submodule.zero_mem _⟩
   (fun e f => ⟨span R {e}, span R {f}, .span_singleton R e, .span_singleton R f,

--- a/Mathlib/LinearAlgebra/TensorProduct/Finiteness.lean
+++ b/Mathlib/LinearAlgebra/TensorProduct/Finiteness.lean
@@ -95,8 +95,11 @@ theorem exists_finset (x : M ⊗[R] N) :
 
 /-- For a finite subset `s` of `M ⊗[R] N`, there are finitely generated
 submodules `M'` and `N'` of `M` and `N`, respectively, such that `s` is contained in the image
-of `M' ⊗[R] N'` in `M ⊗[R] N`. -/
-theorem exists_finite_submodule_of_finite (s : Set (M ⊗[R] N)) (hs : s.Finite) :
+of `M' ⊗[R] N'` in `M ⊗[R] N`.
+
+This means that every element of a tensor product lies in the tensor product of some finite
+submodules. -/
+theorem exists_finite_submodule_of_finiteSet (s : Set (M ⊗[R] N)) (hs : s.Finite) :
     ∃ (M' : Submodule R M) (N' : Submodule R N), Module.Finite R M' ∧ Module.Finite R N' ∧
       s ⊆ LinearMap.range (mapIncl M' N') := by
   simp_rw [Module.Finite.iff_fg]
@@ -118,33 +121,42 @@ theorem exists_finite_submodule_of_finite (s : Set (M ⊗[R] N)) (hs : s.Finite)
     · exact range_mapIncl_mono le_sup_right le_sup_right (h₂ (Set.mem_insert y s))
     · exact range_mapIncl_mono le_sup_left le_sup_left (h₁ (Set.subset_insert x s hz))
 
+@[deprecated (since := "2025-10-11")] alias exists_finite_submodule_of_finite :=
+  exists_finite_submodule_of_finiteSet
+
 /-- For a finite subset `s` of `M ⊗[R] N`, there exists a finitely generated
 submodule `M'` of `M`, such that `s` is contained in the image
 of `M' ⊗[R] N` in `M ⊗[R] N`. -/
-theorem exists_finite_submodule_left_of_finite (s : Set (M ⊗[R] N)) (hs : s.Finite) :
+theorem exists_finite_submodule_left_of_finiteSet (s : Set (M ⊗[R] N)) (hs : s.Finite) :
     ∃ M' : Submodule R M, Module.Finite R M' ∧ s ⊆ LinearMap.range (M'.subtype.rTensor N) := by
-  obtain ⟨M', _, hfin, _, h⟩ := exists_finite_submodule_of_finite s hs
+  obtain ⟨M', _, hfin, _, h⟩ := exists_finite_submodule_of_finiteSet s hs
   refine ⟨M', hfin, ?_⟩
   rw [mapIncl, ← LinearMap.rTensor_comp_lTensor] at h
   exact h.trans (LinearMap.range_comp_le_range _ _)
 
+@[deprecated (since := "2025-10-11")] alias exists_finite_submodule_left_of_finite :=
+  exists_finite_submodule_left_of_finiteSet
+
 /-- For a finite subset `s` of `M ⊗[R] N`, there exists a finitely generated
 submodule `N'` of `N`, such that `s` is contained in the image
 of `M ⊗[R] N'` in `M ⊗[R] N`. -/
-theorem exists_finite_submodule_right_of_finite (s : Set (M ⊗[R] N)) (hs : s.Finite) :
+theorem exists_finite_submodule_right_of_finiteSet (s : Set (M ⊗[R] N)) (hs : s.Finite) :
     ∃ N' : Submodule R N, Module.Finite R N' ∧ s ⊆ LinearMap.range (N'.subtype.lTensor M) := by
-  obtain ⟨_, N', _, hfin, h⟩ := exists_finite_submodule_of_finite s hs
+  obtain ⟨_, N', _, hfin, h⟩ := exists_finite_submodule_of_finiteSet s hs
   refine ⟨N', hfin, ?_⟩
   rw [mapIncl, ← LinearMap.lTensor_comp_rTensor] at h
   exact h.trans (LinearMap.range_comp_le_range _ _)
 
+@[deprecated (since := "2025-10-11")] alias exists_finite_submodule_right_of_finite :=
+  exists_finite_submodule_right_of_finiteSet
+
 /-- Variation of `TensorProduct.exists_finite_submodule_of_finite` where `M` and `N` are
 already submodules. -/
-theorem exists_finite_submodule_of_finite' (s : Set (M₁ ⊗[R] N₁)) (hs : s.Finite) :
+theorem exists_finite_submodule_of_finiteSet' (s : Set (M₁ ⊗[R] N₁)) (hs : s.Finite) :
     ∃ (M' : Submodule R M) (N' : Submodule R N) (hM : M' ≤ M₁) (hN : N' ≤ N₁),
       Module.Finite R M' ∧ Module.Finite R N' ∧
         s ⊆ LinearMap.range (TensorProduct.map (inclusion hM) (inclusion hN)) := by
-  obtain ⟨M', N', _, _, h⟩ := exists_finite_submodule_of_finite s hs
+  obtain ⟨M', N', _, _, h⟩ := exists_finite_submodule_of_finiteSet s hs
   have hM := map_subtype_le M₁ M'
   have hN := map_subtype_le N₁ N'
   refine ⟨_, _, hM, hN, .map _ _, .map _ _, ?_⟩
@@ -154,31 +166,33 @@ theorem exists_finite_submodule_of_finite' (s : Set (M₁ ⊗[R] N₁)) (hs : s.
     map_comp] at h
   exact h.trans (LinearMap.range_comp_le_range _ _)
 
+@[deprecated (since := "2025-10-11")] alias exists_finite_submodule_of_finite' :=
+  exists_finite_submodule_of_finiteSet'
+
 /-- Variation of `TensorProduct.exists_finite_submodule_left_of_finite` where `M` and `N` are
 already submodules. -/
-theorem exists_finite_submodule_left_of_finite' (s : Set (M₁ ⊗[R] N₁)) (hs : s.Finite) :
+theorem exists_finite_submodule_left_of_finiteSet' (s : Set (M₁ ⊗[R] N₁)) (hs : s.Finite) :
     ∃ (M' : Submodule R M) (hM : M' ≤ M₁), Module.Finite R M' ∧
       s ⊆ LinearMap.range ((inclusion hM).rTensor N₁) := by
-  obtain ⟨M', _, hM, _, hfin, _, h⟩ := exists_finite_submodule_of_finite' s hs
+  obtain ⟨M', _, hM, _, hfin, _, h⟩ := exists_finite_submodule_of_finiteSet' s hs
   refine ⟨M', hM, hfin, ?_⟩
   rw [← LinearMap.rTensor_comp_lTensor] at h
   exact h.trans (LinearMap.range_comp_le_range _ _)
 
+@[deprecated (since := "2025-10-11")] alias exists_finite_submodule_left_of_finite' :=
+  exists_finite_submodule_left_of_finiteSet'
+
 /-- Variation of `TensorProduct.exists_finite_submodule_right_of_finite` where `M` and `N` are
 already submodules. -/
-theorem exists_finite_submodule_right_of_finite' (s : Set (M₁ ⊗[R] N₁)) (hs : s.Finite) :
+theorem exists_finite_submodule_right_of_finiteSet' (s : Set (M₁ ⊗[R] N₁)) (hs : s.Finite) :
     ∃ (N' : Submodule R N) (hN : N' ≤ N₁), Module.Finite R N' ∧
       s ⊆ LinearMap.range ((inclusion hN).lTensor M₁) := by
-  obtain ⟨_, N', _, hN, _, hfin, h⟩ := exists_finite_submodule_of_finite' s hs
+  obtain ⟨_, N', _, hN, _, hfin, h⟩ := exists_finite_submodule_of_finiteSet' s hs
   refine ⟨N', hN, hfin, ?_⟩
   rw [← LinearMap.lTensor_comp_rTensor] at h
   exact h.trans (LinearMap.range_comp_le_range _ _)
 
-/-- Every element of a tensor product lies in the tensor product of some finite submodules. -/
-lemma exists_finite_mem_map₂ (z : M ⊗[R] N) :
-    ∃ (M' : Submodule R M) (N' : Submodule R N) (_ : Module.Finite R M') (_ : Module.Finite R N'),
-      z ∈ Submodule.map₂ (mk R M N) M' N' := by
-  obtain ⟨M', N', hM', hN', h⟩ := exists_finite_submodule_of_finite {z} (Set.finite_singleton z)
-  exact ⟨M', N', hM', hN', range_mapIncl M' N' ▸ Set.singleton_subset_iff.mp h⟩
+@[deprecated (since := "2025-10-11")] alias exists_finite_submodule_right_of_finite' :=
+  exists_finite_submodule_right_of_finiteSet'
 
 end TensorProduct

--- a/Mathlib/LinearAlgebra/TensorProduct/Finiteness.lean
+++ b/Mathlib/LinearAlgebra/TensorProduct/Finiteness.lean
@@ -174,7 +174,6 @@ theorem exists_finite_submodule_right_of_finite' (s : Set (M₁ ⊗[R] N₁)) (h
   rw [← LinearMap.lTensor_comp_rTensor] at h
   exact h.trans (LinearMap.range_comp_le_range _ _)
 
-open Module in
 /-- Given an element `z : E ⊗ F`, there exists finite subspaces `E'` and `F'`
 whose tensor product contains `z`. -/
 lemma exists_finite_mem_map₂ {R E F : Type*} [CommRing R]

--- a/Mathlib/LinearAlgebra/TensorProduct/Finiteness.lean
+++ b/Mathlib/LinearAlgebra/TensorProduct/Finiteness.lean
@@ -176,21 +176,22 @@ theorem exists_finite_submodule_right_of_finite' (s : Set (M₁ ⊗[R] N₁)) (h
 
 open Module in
 /-- Given an element `z : E ⊗ F`, there exists finite subspaces `E'` and `F'`
-such that `z ∈ range (mapIncl E' F')`. -/
-lemma exists_finite_mem_range_mapIncl {R E F : Type*} [CommRing R]
+such that `z ∈ map₂ (mk R E F) E' F'`. -/
+lemma exists_finite_mem_map₂ {R E F : Type*} [CommRing R]
     [AddCommGroup E] [AddCommGroup F] [Module R E] [Module R F] (z : E ⊗[R] F) :
     ∃ (E' : Submodule R E) (F' : Submodule R F) (_ : Module.Finite R E') (_ : Module.Finite R F'),
-    z ∈ LinearMap.range (mapIncl E' F') :=
-  z.induction_on
-  ⟨⊥, ⊥, .bot R E, .bot R F, Submodule.zero_mem _⟩
-  (fun e f => ⟨span R {e}, span R {f}, Finite.span_singleton R e, Finite.span_singleton R f,
-    ⟨e, mem_span_singleton_self e⟩ ⊗ₜ ⟨f, mem_span_singleton_self f⟩, rfl⟩)
-  (fun _ _ ⟨E1, F1, _, _, ⟨z1, hz1⟩⟩ ⟨E2, F2, _, _, ⟨z2, hz2⟩⟩ =>
-    ⟨E1 ⊔ E2, F1 ⊔ F2, E1.finite_sup _, F1.finite_sup _,
-      Submodule.add_mem _
-      ((range_mapIncl_mono le_sup_left (le_refl _)).trans
-        (range_mapIncl_mono (le_refl _) le_sup_left) ⟨z1, hz1⟩)
-      ((range_mapIncl_mono le_sup_right (le_refl _)).trans
-        (range_mapIncl_mono (le_refl _) le_sup_right) ⟨z2, hz2⟩)⟩)
+    z ∈ Submodule.map₂ (mk R E F) E' F' := by
+  simp_rw [← range_mapIncl]
+  exact z.induction_on
+    ⟨⊥, ⊥, .bot R E, .bot R F, Submodule.zero_mem _⟩
+    (fun e f => ⟨span R {e}, span R {f}, Finite.span_singleton R e, Finite.span_singleton R f,
+      ⟨e, mem_span_singleton_self e⟩ ⊗ₜ ⟨f, mem_span_singleton_self f⟩, rfl⟩)
+    (fun _ _ ⟨E1, F1, _, _, ⟨z1, hz1⟩⟩ ⟨E2, F2, _, _, ⟨z2, hz2⟩⟩ =>
+      ⟨E1 ⊔ E2, F1 ⊔ F2, E1.finite_sup _, F1.finite_sup _,
+        Submodule.add_mem _
+        ((range_mapIncl_mono le_sup_left (le_refl _)).trans
+          (range_mapIncl_mono (le_refl _) le_sup_left) ⟨z1, hz1⟩)
+        ((range_mapIncl_mono le_sup_right (le_refl _)).trans
+          (range_mapIncl_mono (le_refl _) le_sup_right) ⟨z2, hz2⟩)⟩)
 
 end TensorProduct

--- a/Mathlib/LinearAlgebra/TensorProduct/Finiteness.lean
+++ b/Mathlib/LinearAlgebra/TensorProduct/Finiteness.lean
@@ -176,7 +176,7 @@ theorem exists_finite_submodule_right_of_finite' (s : Set (M₁ ⊗[R] N₁)) (h
 
 open Module in
 /-- Given an element `z : E ⊗ F`, there exists finite subspaces `E'` and `F'`
-such that `z ∈ map₂ (mk R E F) E' F'`. -/
+whose tensor product contains `z`. -/
 lemma exists_finite_mem_map₂ {R E F : Type*} [CommRing R]
     [AddCommGroup E] [AddCommGroup F] [Module R E] [Module R F] (z : E ⊗[R] F) :
     ∃ (E' : Submodule R E) (F' : Submodule R F) (_ : Module.Finite R E') (_ : Module.Finite R F'),

--- a/Mathlib/LinearAlgebra/TensorProduct/Finiteness.lean
+++ b/Mathlib/LinearAlgebra/TensorProduct/Finiteness.lean
@@ -97,7 +97,7 @@ theorem exists_finset (x : M ⊗[R] N) :
 submodules `M'` and `N'` of `M` and `N`, respectively, such that `s` is contained in the image
 of `M' ⊗[R] N'` in `M ⊗[R] N`.
 
-This means that every element of a tensor product lies in the tensor product of some finite
+In particular, every element of a tensor product lies in the tensor product of some finite
 submodules. -/
 theorem exists_finite_submodule_of_setFinite (s : Set (M ⊗[R] N)) (hs : s.Finite) :
     ∃ (M' : Submodule R M) (N' : Submodule R N), Module.Finite R M' ∧ Module.Finite R N' ∧

--- a/Mathlib/LinearAlgebra/TensorProduct/Finiteness.lean
+++ b/Mathlib/LinearAlgebra/TensorProduct/Finiteness.lean
@@ -175,18 +175,10 @@ theorem exists_finite_submodule_right_of_finite' (s : Set (M₁ ⊗[R] N₁)) (h
   exact h.trans (LinearMap.range_comp_le_range _ _)
 
 /-- Every element of a tensor product lies in the tensor product of some finite submodules. -/
-lemma exists_finite_mem_map₂ {R E F : Type*} [CommRing R]
-    [AddCommGroup E] [AddCommGroup F] [Module R E] [Module R F] (z : E ⊗[R] F) :
-    ∃ (E' : Submodule R E) (F' : Submodule R F) (_ : Module.Finite R E') (_ : Module.Finite R F'),
-      z ∈ Submodule.map₂ (mk R E F) E' F' :=
-  z.induction_on
-  ⟨⊥, ⊥, .bot R E, .bot R F, zero_mem _⟩
-  (fun e f => ⟨span R {e}, span R {f}, .span_singleton R e, .span_singleton R f,
-    apply_mem_map₂ _ (mem_span_singleton_self e) (mem_span_singleton_self f)⟩)
-  (fun _ _ ⟨E1, F1, _, _, hz1⟩ ⟨E2, F2, _, _, hz2⟩ =>
-    ⟨E1 ⊔ E2, F1 ⊔ F2, E1.finite_sup _, F1.finite_sup _,
-      (Submodule.add_mem _
-        (map₂_le_map₂ le_sup_left le_sup_left hz1))
-        (map₂_le_map₂ le_sup_right le_sup_right hz2)⟩)
+lemma exists_finite_mem_map₂ (z : M ⊗[R] N) :
+    ∃ (E' : Submodule R M) (F' : Submodule R N) (_ : Module.Finite R E') (_ : Module.Finite R F'),
+      z ∈ Submodule.map₂ (mk R M N) E' F' := by
+  obtain ⟨E', F', hE', hF', h⟩ := exists_finite_submodule_of_finite {z} (Set.finite_singleton z)
+  exact ⟨E', F', hE', hF', range_mapIncl E' F' ▸ Set.singleton_subset_iff.mp h⟩
 
 end TensorProduct

--- a/Mathlib/LinearAlgebra/TensorProduct/Finiteness.lean
+++ b/Mathlib/LinearAlgebra/TensorProduct/Finiteness.lean
@@ -183,15 +183,14 @@ lemma exists_finite_mem_range_mapIncl {R E F : Type*} [CommRing R]
     z ∈ LinearMap.range (mapIncl E' F') :=
   z.induction_on
   ⟨⊥, ⊥, .bot R E, .bot R F, Submodule.zero_mem _⟩
-  fun e f => by
-    exact ⟨span R {e}, span R {f}, Finite.span_singleton R e, Finite.span_singleton R f,
-      ⟨e, mem_span_singleton_self e⟩ ⊗ₜ ⟨f, mem_span_singleton_self f⟩, rfl⟩
-  fun _ _ ⟨E1, F1, _, _, ⟨z1, hz1⟩⟩ ⟨E2, F2, _, _, ⟨z2, hz2⟩⟩ =>
+  (fun e f => ⟨span R {e}, span R {f}, Finite.span_singleton R e, Finite.span_singleton R f,
+    ⟨e, mem_span_singleton_self e⟩ ⊗ₜ ⟨f, mem_span_singleton_self f⟩, rfl⟩)
+  (fun _ _ ⟨E1, F1, _, _, ⟨z1, hz1⟩⟩ ⟨E2, F2, _, _, ⟨z2, hz2⟩⟩ =>
     ⟨E1 ⊔ E2, F1 ⊔ F2, E1.finite_sup _, F1.finite_sup _,
       Submodule.add_mem _
       ((range_mapIncl_mono le_sup_left (le_refl _)).trans
         (range_mapIncl_mono (le_refl _) le_sup_left) ⟨z1, hz1⟩)
       ((range_mapIncl_mono le_sup_right (le_refl _)).trans
-        (range_mapIncl_mono (le_refl _) le_sup_right) ⟨z2, hz2⟩)⟩
+        (range_mapIncl_mono (le_refl _) le_sup_right) ⟨z2, hz2⟩)⟩)
 
 end TensorProduct

--- a/Mathlib/LinearAlgebra/TensorProduct/Finiteness.lean
+++ b/Mathlib/LinearAlgebra/TensorProduct/Finiteness.lean
@@ -180,18 +180,15 @@ whose tensor product contains `z`. -/
 lemma exists_finite_mem_map₂ {R E F : Type*} [CommRing R]
     [AddCommGroup E] [AddCommGroup F] [Module R E] [Module R F] (z : E ⊗[R] F) :
     ∃ (E' : Submodule R E) (F' : Submodule R F) (_ : Module.Finite R E') (_ : Module.Finite R F'),
-    z ∈ Submodule.map₂ (mk R E F) E' F' := by
-  simp_rw [← range_mapIncl]
-  exact z.induction_on
-    ⟨⊥, ⊥, .bot R E, .bot R F, Submodule.zero_mem _⟩
-    (fun e f => ⟨span R {e}, span R {f}, Finite.span_singleton R e, Finite.span_singleton R f,
-      ⟨e, mem_span_singleton_self e⟩ ⊗ₜ ⟨f, mem_span_singleton_self f⟩, rfl⟩)
-    (fun _ _ ⟨E1, F1, _, _, ⟨z1, hz1⟩⟩ ⟨E2, F2, _, _, ⟨z2, hz2⟩⟩ =>
-      ⟨E1 ⊔ E2, F1 ⊔ F2, E1.finite_sup _, F1.finite_sup _,
-        Submodule.add_mem _
-        ((range_mapIncl_mono le_sup_left (le_refl _)).trans
-          (range_mapIncl_mono (le_refl _) le_sup_left) ⟨z1, hz1⟩)
-        ((range_mapIncl_mono le_sup_right (le_refl _)).trans
-          (range_mapIncl_mono (le_refl _) le_sup_right) ⟨z2, hz2⟩)⟩)
+    z ∈ Submodule.map₂ (mk R E F) E' F' :=
+  z.induction_on
+  ⟨⊥, ⊥, .bot R E, .bot R F, Submodule.zero_mem _⟩
+  (fun e f => ⟨span R {e}, span R {f}, .span_singleton R e, .span_singleton R f,
+    apply_mem_map₂ _ (mem_span_singleton_self e) (mem_span_singleton_self f)⟩)
+  (fun _ _ ⟨E1, F1, _, _, hz1⟩ ⟨E2, F2, _, _, hz2⟩ =>
+    ⟨E1 ⊔ E2, F1 ⊔ F2, E1.finite_sup _, F1.finite_sup _,
+      (Submodule.add_mem _
+        (map₂_le_map₂ le_sup_left le_sup_left hz1))
+        (map₂_le_map₂ le_sup_right le_sup_right hz2)⟩)
 
 end TensorProduct

--- a/Mathlib/LinearAlgebra/TensorProduct/Finiteness.lean
+++ b/Mathlib/LinearAlgebra/TensorProduct/Finiteness.lean
@@ -174,8 +174,7 @@ theorem exists_finite_submodule_right_of_finite' (s : Set (M₁ ⊗[R] N₁)) (h
   rw [← LinearMap.lTensor_comp_rTensor] at h
   exact h.trans (LinearMap.range_comp_le_range _ _)
 
-/-- Given an element `z : E ⊗ F`, there exists finite subspaces `E'` and `F'`
-whose tensor product contains `z`. -/
+/-- Every element of a tensor product lies in the tensor product of some finite submodules. -/
 lemma exists_finite_mem_map₂ {R E F : Type*} [CommRing R]
     [AddCommGroup E] [AddCommGroup F] [Module R E] [Module R F] (z : E ⊗[R] F) :
     ∃ (E' : Submodule R E) (F' : Submodule R F) (_ : Module.Finite R E') (_ : Module.Finite R F'),

--- a/Mathlib/LinearAlgebra/TensorProduct/Finiteness.lean
+++ b/Mathlib/LinearAlgebra/TensorProduct/Finiteness.lean
@@ -176,9 +176,9 @@ theorem exists_finite_submodule_right_of_finite' (s : Set (M₁ ⊗[R] N₁)) (h
 
 /-- Every element of a tensor product lies in the tensor product of some finite submodules. -/
 lemma exists_finite_mem_map₂ (z : M ⊗[R] N) :
-    ∃ (E' : Submodule R M) (F' : Submodule R N) (_ : Module.Finite R E') (_ : Module.Finite R F'),
-      z ∈ Submodule.map₂ (mk R M N) E' F' := by
-  obtain ⟨E', F', hE', hF', h⟩ := exists_finite_submodule_of_finite {z} (Set.finite_singleton z)
-  exact ⟨E', F', hE', hF', range_mapIncl E' F' ▸ Set.singleton_subset_iff.mp h⟩
+    ∃ (M' : Submodule R M) (N' : Submodule R N) (_ : Module.Finite R M') (_ : Module.Finite R N'),
+      z ∈ Submodule.map₂ (mk R M N) M' N' := by
+  obtain ⟨M', N', hM', hN', h⟩ := exists_finite_submodule_of_finite {z} (Set.finite_singleton z)
+  exact ⟨M', N', hM', hN', range_mapIncl M' N' ▸ Set.singleton_subset_iff.mp h⟩
 
 end TensorProduct

--- a/Mathlib/LinearAlgebra/TensorProduct/Finiteness.lean
+++ b/Mathlib/LinearAlgebra/TensorProduct/Finiteness.lean
@@ -174,4 +174,26 @@ theorem exists_finite_submodule_right_of_finite' (s : Set (M₁ ⊗[R] N₁)) (h
   rw [← LinearMap.lTensor_comp_rTensor] at h
   exact h.trans (LinearMap.range_comp_le_range _ _)
 
+open Module in
+/-- Given an element `z : E ⊗ F`, there exists finite subspaces `E'` and `F'`
+such that `z ∈ range (mapIncl E' F')`. -/
+lemma exists_finite_mem_range_mapIncl {R E F : Type*} [CommRing R]
+    [AddCommGroup E] [AddCommGroup F] [Module R E] [Module R F] (z : E ⊗[R] F) :
+    ∃ (E' : Submodule R E) (F' : Submodule R F) (_ : Module.Finite R E') (_ : Module.Finite R F'),
+    z ∈ LinearMap.range (mapIncl E' F') :=
+  z.induction_on
+  ⟨⊥, ⊥, Finite.bot R E, Finite.bot R F, Submodule.zero_mem _⟩
+  fun e f => by
+    exact ⟨span R {e}, span R {f}, Finite.span_singleton R e, Finite.span_singleton R f,
+      ⟨e, mem_span_singleton_self e⟩ ⊗ₜ ⟨f, mem_span_singleton_self f⟩, rfl⟩
+  fun _ _ ih₁ ih₂ => by
+    rcases ih₁ with ⟨E1, F1, _, _, ⟨z1, rfl⟩⟩
+    rcases ih₂ with ⟨E2, F2, _, _, ⟨z2, rfl⟩⟩
+    exact ⟨E1 ⊔ E2, F1 ⊔ F2, E1.finite_sup _, F1.finite_sup _,
+      Submodule.add_mem _
+      ((range_mapIncl_mono le_sup_left (le_refl _)).trans
+        (range_mapIncl_mono (le_refl _) le_sup_left) ⟨z1, rfl⟩)
+      ((range_mapIncl_mono le_sup_right (le_refl _)).trans
+        (range_mapIncl_mono (le_refl _) le_sup_right) ⟨z2, rfl⟩)⟩
+
 end TensorProduct

--- a/Mathlib/LinearAlgebra/TensorProduct/Finiteness.lean
+++ b/Mathlib/LinearAlgebra/TensorProduct/Finiteness.lean
@@ -180,7 +180,7 @@ lemma exists_finite_mem_map₂ {R E F : Type*} [CommRing R]
     ∃ (E' : Submodule R E) (F' : Submodule R F) (_ : Module.Finite R E') (_ : Module.Finite R F'),
       z ∈ Submodule.map₂ (mk R E F) E' F' :=
   z.induction_on
-  ⟨⊥, ⊥, .bot R E, .bot R F, Submodule.zero_mem _⟩
+  ⟨⊥, ⊥, .bot R E, .bot R F, zero_mem _⟩
   (fun e f => ⟨span R {e}, span R {f}, .span_singleton R e, .span_singleton R f,
     apply_mem_map₂ _ (mem_span_singleton_self e) (mem_span_singleton_self f)⟩)
   (fun _ _ ⟨E1, F1, _, _, hz1⟩ ⟨E2, F2, _, _, hz2⟩ =>

--- a/Mathlib/LinearAlgebra/TensorProduct/Finiteness.lean
+++ b/Mathlib/LinearAlgebra/TensorProduct/Finiteness.lean
@@ -186,14 +186,12 @@ lemma exists_finite_mem_range_mapIncl {R E F : Type*} [CommRing R]
   fun e f => by
     exact ⟨span R {e}, span R {f}, Finite.span_singleton R e, Finite.span_singleton R f,
       ⟨e, mem_span_singleton_self e⟩ ⊗ₜ ⟨f, mem_span_singleton_self f⟩, rfl⟩
-  fun _ _ ih₁ ih₂ => by
-    rcases ih₁ with ⟨E1, F1, _, _, ⟨z1, rfl⟩⟩
-    rcases ih₂ with ⟨E2, F2, _, _, ⟨z2, rfl⟩⟩
-    exact ⟨E1 ⊔ E2, F1 ⊔ F2, E1.finite_sup _, F1.finite_sup _,
+  fun _ _ ⟨E1, F1, _, _, ⟨z1, hz1⟩⟩ ⟨E2, F2, _, _, ⟨z2, hz2⟩⟩ =>
+    ⟨E1 ⊔ E2, F1 ⊔ F2, E1.finite_sup _, F1.finite_sup _,
       Submodule.add_mem _
       ((range_mapIncl_mono le_sup_left (le_refl _)).trans
-        (range_mapIncl_mono (le_refl _) le_sup_left) ⟨z1, rfl⟩)
+        (range_mapIncl_mono (le_refl _) le_sup_left) ⟨z1, hz1⟩)
       ((range_mapIncl_mono le_sup_right (le_refl _)).trans
-        (range_mapIncl_mono (le_refl _) le_sup_right) ⟨z2, rfl⟩)⟩
+        (range_mapIncl_mono (le_refl _) le_sup_right) ⟨z2, hz2⟩)⟩
 
 end TensorProduct

--- a/Mathlib/LinearAlgebra/TensorProduct/Finiteness.lean
+++ b/Mathlib/LinearAlgebra/TensorProduct/Finiteness.lean
@@ -18,16 +18,16 @@ This file contains some finiteness results of tensor product.
   any element of `M ⊗[R] N` can be written as a finite sum of pure tensors.
   See also `TensorProduct.span_tmul_eq_top`.
 
-- `TensorProduct.exists_finite_submodule_left_of_finite`,
-  `TensorProduct.exists_finite_submodule_right_of_finite`,
-  `TensorProduct.exists_finite_submodule_of_finite`:
+- `TensorProduct.exists_finite_submodule_left_of_setFinite`,
+  `TensorProduct.exists_finite_submodule_right_of_setFinite`,
+  `TensorProduct.exists_finite_submodule_of_setFinite`:
   any finite subset of `M ⊗[R] N` is contained in `M' ⊗[R] N`,
   resp. `M ⊗[R] N'`, resp. `M' ⊗[R] N'`,
   for some finitely generated submodules `M'` and `N'` of `M` and `N`, respectively.
 
-- `TensorProduct.exists_finite_submodule_left_of_finite'`,
-  `TensorProduct.exists_finite_submodule_right_of_finite'`,
-  `TensorProduct.exists_finite_submodule_of_finite'`:
+- `TensorProduct.exists_finite_submodule_left_of_setFinite'`,
+  `TensorProduct.exists_finite_submodule_right_of_setFinite'`,
+  `TensorProduct.exists_finite_submodule_of_setFinite'`:
   variation of the above results where `M` and `N` are already submodules.
 
 ## Tags
@@ -99,7 +99,7 @@ of `M' ⊗[R] N'` in `M ⊗[R] N`.
 
 This means that every element of a tensor product lies in the tensor product of some finite
 submodules. -/
-theorem exists_finite_submodule_of_finiteSet (s : Set (M ⊗[R] N)) (hs : s.Finite) :
+theorem exists_finite_submodule_of_setFinite (s : Set (M ⊗[R] N)) (hs : s.Finite) :
     ∃ (M' : Submodule R M) (N' : Submodule R N), Module.Finite R M' ∧ Module.Finite R N' ∧
       s ⊆ LinearMap.range (mapIncl M' N') := by
   simp_rw [Module.Finite.iff_fg]
@@ -122,41 +122,41 @@ theorem exists_finite_submodule_of_finiteSet (s : Set (M ⊗[R] N)) (hs : s.Fini
     · exact range_mapIncl_mono le_sup_left le_sup_left (h₁ (Set.subset_insert x s hz))
 
 @[deprecated (since := "2025-10-11")] alias exists_finite_submodule_of_finite :=
-  exists_finite_submodule_of_finiteSet
+  exists_finite_submodule_of_setFinite
 
 /-- For a finite subset `s` of `M ⊗[R] N`, there exists a finitely generated
 submodule `M'` of `M`, such that `s` is contained in the image
 of `M' ⊗[R] N` in `M ⊗[R] N`. -/
-theorem exists_finite_submodule_left_of_finiteSet (s : Set (M ⊗[R] N)) (hs : s.Finite) :
+theorem exists_finite_submodule_left_of_setFinite (s : Set (M ⊗[R] N)) (hs : s.Finite) :
     ∃ M' : Submodule R M, Module.Finite R M' ∧ s ⊆ LinearMap.range (M'.subtype.rTensor N) := by
-  obtain ⟨M', _, hfin, _, h⟩ := exists_finite_submodule_of_finiteSet s hs
+  obtain ⟨M', _, hfin, _, h⟩ := exists_finite_submodule_of_setFinite s hs
   refine ⟨M', hfin, ?_⟩
   rw [mapIncl, ← LinearMap.rTensor_comp_lTensor] at h
   exact h.trans (LinearMap.range_comp_le_range _ _)
 
 @[deprecated (since := "2025-10-11")] alias exists_finite_submodule_left_of_finite :=
-  exists_finite_submodule_left_of_finiteSet
+  exists_finite_submodule_left_of_setFinite
 
 /-- For a finite subset `s` of `M ⊗[R] N`, there exists a finitely generated
 submodule `N'` of `N`, such that `s` is contained in the image
 of `M ⊗[R] N'` in `M ⊗[R] N`. -/
-theorem exists_finite_submodule_right_of_finiteSet (s : Set (M ⊗[R] N)) (hs : s.Finite) :
+theorem exists_finite_submodule_right_of_setFinite (s : Set (M ⊗[R] N)) (hs : s.Finite) :
     ∃ N' : Submodule R N, Module.Finite R N' ∧ s ⊆ LinearMap.range (N'.subtype.lTensor M) := by
-  obtain ⟨_, N', _, hfin, h⟩ := exists_finite_submodule_of_finiteSet s hs
+  obtain ⟨_, N', _, hfin, h⟩ := exists_finite_submodule_of_setFinite s hs
   refine ⟨N', hfin, ?_⟩
   rw [mapIncl, ← LinearMap.lTensor_comp_rTensor] at h
   exact h.trans (LinearMap.range_comp_le_range _ _)
 
 @[deprecated (since := "2025-10-11")] alias exists_finite_submodule_right_of_finite :=
-  exists_finite_submodule_right_of_finiteSet
+  exists_finite_submodule_right_of_setFinite
 
-/-- Variation of `TensorProduct.exists_finite_submodule_of_finite` where `M` and `N` are
+/-- Variation of `TensorProduct.exists_finite_submodule_of_setFinite` where `M` and `N` are
 already submodules. -/
-theorem exists_finite_submodule_of_finiteSet' (s : Set (M₁ ⊗[R] N₁)) (hs : s.Finite) :
+theorem exists_finite_submodule_of_setFinite' (s : Set (M₁ ⊗[R] N₁)) (hs : s.Finite) :
     ∃ (M' : Submodule R M) (N' : Submodule R N) (hM : M' ≤ M₁) (hN : N' ≤ N₁),
       Module.Finite R M' ∧ Module.Finite R N' ∧
         s ⊆ LinearMap.range (TensorProduct.map (inclusion hM) (inclusion hN)) := by
-  obtain ⟨M', N', _, _, h⟩ := exists_finite_submodule_of_finiteSet s hs
+  obtain ⟨M', N', _, _, h⟩ := exists_finite_submodule_of_setFinite s hs
   have hM := map_subtype_le M₁ M'
   have hN := map_subtype_le N₁ N'
   refine ⟨_, _, hM, hN, .map _ _, .map _ _, ?_⟩
@@ -167,32 +167,32 @@ theorem exists_finite_submodule_of_finiteSet' (s : Set (M₁ ⊗[R] N₁)) (hs :
   exact h.trans (LinearMap.range_comp_le_range _ _)
 
 @[deprecated (since := "2025-10-11")] alias exists_finite_submodule_of_finite' :=
-  exists_finite_submodule_of_finiteSet'
+  exists_finite_submodule_of_setFinite'
 
-/-- Variation of `TensorProduct.exists_finite_submodule_left_of_finite` where `M` and `N` are
+/-- Variation of `TensorProduct.exists_finite_submodule_left_of_setFinite` where `M` and `N` are
 already submodules. -/
-theorem exists_finite_submodule_left_of_finiteSet' (s : Set (M₁ ⊗[R] N₁)) (hs : s.Finite) :
+theorem exists_finite_submodule_left_of_setFinite' (s : Set (M₁ ⊗[R] N₁)) (hs : s.Finite) :
     ∃ (M' : Submodule R M) (hM : M' ≤ M₁), Module.Finite R M' ∧
       s ⊆ LinearMap.range ((inclusion hM).rTensor N₁) := by
-  obtain ⟨M', _, hM, _, hfin, _, h⟩ := exists_finite_submodule_of_finiteSet' s hs
+  obtain ⟨M', _, hM, _, hfin, _, h⟩ := exists_finite_submodule_of_setFinite' s hs
   refine ⟨M', hM, hfin, ?_⟩
   rw [← LinearMap.rTensor_comp_lTensor] at h
   exact h.trans (LinearMap.range_comp_le_range _ _)
 
 @[deprecated (since := "2025-10-11")] alias exists_finite_submodule_left_of_finite' :=
-  exists_finite_submodule_left_of_finiteSet'
+  exists_finite_submodule_left_of_setFinite'
 
-/-- Variation of `TensorProduct.exists_finite_submodule_right_of_finite` where `M` and `N` are
+/-- Variation of `TensorProduct.exists_finite_submodule_right_of_setFinite` where `M` and `N` are
 already submodules. -/
-theorem exists_finite_submodule_right_of_finiteSet' (s : Set (M₁ ⊗[R] N₁)) (hs : s.Finite) :
+theorem exists_finite_submodule_right_of_setFinite' (s : Set (M₁ ⊗[R] N₁)) (hs : s.Finite) :
     ∃ (N' : Submodule R N) (hN : N' ≤ N₁), Module.Finite R N' ∧
       s ⊆ LinearMap.range ((inclusion hN).lTensor M₁) := by
-  obtain ⟨_, N', _, hN, _, hfin, h⟩ := exists_finite_submodule_of_finiteSet' s hs
+  obtain ⟨_, N', _, hN, _, hfin, h⟩ := exists_finite_submodule_of_setFinite' s hs
   refine ⟨N', hN, hfin, ?_⟩
   rw [← LinearMap.lTensor_comp_rTensor] at h
   exact h.trans (LinearMap.range_comp_le_range _ _)
 
 @[deprecated (since := "2025-10-11")] alias exists_finite_submodule_right_of_finite' :=
-  exists_finite_submodule_right_of_finiteSet'
+  exists_finite_submodule_right_of_setFinite'
 
 end TensorProduct

--- a/Mathlib/LinearAlgebra/TensorProduct/Finiteness.lean
+++ b/Mathlib/LinearAlgebra/TensorProduct/Finiteness.lean
@@ -182,7 +182,7 @@ lemma exists_finite_mem_range_mapIncl {R E F : Type*} [CommRing R]
     ∃ (E' : Submodule R E) (F' : Submodule R F) (_ : Module.Finite R E') (_ : Module.Finite R F'),
     z ∈ LinearMap.range (mapIncl E' F') :=
   z.induction_on
-  ⟨⊥, ⊥, Finite.bot R E, Finite.bot R F, Submodule.zero_mem _⟩
+  ⟨⊥, ⊥, .bot R E, .bot R F, Submodule.zero_mem _⟩
   fun e f => by
     exact ⟨span R {e}, span R {f}, Finite.span_singleton R e, Finite.span_singleton R f,
       ⟨e, mem_span_singleton_self e⟩ ⊗ₜ ⟨f, mem_span_singleton_self f⟩, rfl⟩

--- a/Mathlib/RingTheory/LinearDisjoint.lean
+++ b/Mathlib/RingTheory/LinearDisjoint.lean
@@ -777,7 +777,7 @@ theorem of_linearDisjoint_finite_left [Algebra.IsIntegral R A]
   rw [linearDisjoint_iff, Submodule.linearDisjoint_iff]
   intro x y hxy
   obtain ⟨M', hM, hf, h⟩ :=
-    TensorProduct.exists_finite_submodule_left_of_finite' {x, y} (Set.toFinite _)
+    TensorProduct.exists_finite_submodule_left_of_setFinite' {x, y} (Set.toFinite _)
   obtain ⟨s, hs⟩ := Module.Finite.iff_fg.1 hf
   have hs' : (s : Set S) ⊆ A := by rwa [← hs, Submodule.span_le] at hM
   let A' := Algebra.adjoin R (s : Set S)


### PR DESCRIPTION
`TensorProduct.exists_finite_submodule_of_finite` and its variants are confusing since the `finite` in the name refers to different things, so we change it to `_of_setFinite`.

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include at least one commit authored by each
co-author among the commits in the pull request. If necessary, you may 
create empty commits to indicate co-authorship, using commands like so:

git commit --author="Author Name <author@email.com>" --allow-empty -m "add Author Name as coauthor"

When merging, all the commits will be squashed into a single commit listing all co-authors.

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
