### PR TITLE
[Merged by Bors] - feat(Topology/InfiniteSum): tprod_one_{add/sub}_ordered

### DIFF
--- a/Mathlib/Algebra/BigOperators/Ring/Finset.lean
+++ b/Mathlib/Algebra/BigOperators/Ring/Finset.lean
@@ -220,6 +220,11 @@ theorem prod_add_ordered [LinearOrder ι] (s : Finset ι) (f g : ι → R) :
       mul_left_comm]
     exact mt (fun ha => (mem_filter.1 ha).1) ha'
 
+theorem prod_one_add_ordered [LinearOrder ι] (s : Finset ι) (f : ι → R) :
+    ∏ i ∈ s, (1 + f i) = 1 + ∑ i ∈ s, f i * ∏ j ∈ s with j < i, (1 + f j) := by
+  rw [prod_add_ordered]
+  simp
+
 /-- Summing `a ^ #t * b ^ (n - #t)` over all finite subsets `t` of a finset `s`
 gives `(a + b) ^ #s`. -/
 theorem sum_pow_mul_eq_add_pow (a b : R) (s : Finset ι) :

--- a/Mathlib/Topology/Algebra/InfiniteSum/Ring.lean
+++ b/Mathlib/Topology/Algebra/InfiniteSum/Ring.lean
@@ -307,4 +307,43 @@ theorem tprod_one_add [T2Space α] (h : Summable (∏ i ∈ ·, f i)) :
     ∏' i, (1 + f i) = ∑' s, ∏ i ∈ s, f i :=
   HasProd.tprod_eq <| hasProd_one_add_of_hasSum_prod h.hasSum
 
+section Ordered
+variable [LinearOrder ι] [LocallyFiniteOrderBot ι] [T2Space α]
+
+/-- The infinite version of `Finset.prod_one_add_ordered`. -/
+theorem tprod_one_add_ordered [ContinuousAdd α]
+    (hsum : Summable fun i ↦ f i * ∏ j ∈ Iio i, (1 + f j))
+    (hprod : Multipliable (1 + f ·)) :
+    ∏' i, (1 + f i) = 1 + ∑' i, f i * ∏ j ∈ Iio i, (1 + f j) := by
+  rcases isEmpty_or_nonempty ι with _ | _
+  · simp
+  obtain ⟨x, hx⟩ := hprod
+  obtain ⟨a, ha⟩ := hsum
+  convert hx.tprod_eq
+  unfold HasProd at hx
+  conv at hx in fun _ ↦ _ => ext _; rw [prod_one_add_ordered] -- simp_rw would cause loop
+  rw [ha.tsum_eq]
+  refine (tendsto_nhds_unique (hx.comp tendsto_finset_Iic_atTop_atTop) ?_).symm
+  apply Tendsto.const_add
+  convert ha.comp tendsto_finset_Iic_atTop_atTop using 2 with s
+  refine sum_congr rfl (fun i hi ↦ ?_)
+  congr
+  ext j
+  suffices j < i → j ≤ s by simpa
+  exact fun hj ↦ (hj.trans_le (by simpa using hi)).le
+
+omit [CommSemiring α] in
+/-- The infinite version of `Finset.prod_one_sub_ordered`. -/
+theorem tprod_one_sub_ordered [CommRing α] [IsTopologicalAddGroup α]
+    (hsum : Summable fun i ↦ f i * ∏ j ∈ Iio i, (1 - f j))
+    (hprod : Multipliable (1 - f ·)) :
+    ∏' i, (1 - f i) = 1 - ∑' i, f i * ∏ j ∈ Iio i, (1 - f j) := by
+  simp_rw [sub_eq_add_neg] at hsum hprod ⊢
+  obtain hsum' := hsum.neg
+  simp_rw [← neg_mul] at hsum'
+  simp_rw [← tsum_neg, ← neg_mul]
+  exact tprod_one_add_ordered hsum' hprod
+
+end Ordered
+
 end ProdOneSum

--- a/Mathlib/Topology/Algebra/InfiniteSum/Ring.lean
+++ b/Mathlib/Topology/Algebra/InfiniteSum/Ring.lean
@@ -328,9 +328,7 @@ theorem tprod_one_add_ordered [ContinuousAdd α]
   convert ha.comp tendsto_finset_Iic_atTop_atTop using 2 with s
   refine sum_congr rfl (fun i hi ↦ ?_)
   congr
-  ext j
-  suffices j < i → j ≤ s by simpa
-  exact fun hj ↦ (hj.trans_le (by simpa using hi)).le
+  grind
 
 omit [CommSemiring α] in
 /-- The infinite version of `Finset.prod_one_sub_ordered`. -/


### PR DESCRIPTION
This extends the existing `Finset.prod_one_sub_ordered` to infinite sum/product, and also adds the more natural `add` version.

Together with some previous PRs about infinite sum/prod and powerseries, this is part of my effort of upstreaming useful stuff from https://github.com/wwylele/PentagonalNumberTheorem. It starts getting into niche lemma, so suggestions such that not wanting this in mathlib, or it should be stated in a different form, are all welcomed.

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include at least one commit authored by each
co-author among the commits in the pull request. If necessary, you may 
create empty commits to indicate co-authorship, using commands like so:

git commit --author="Author Name <author@email.com>" --allow-empty -m "add Author Name as coauthor"

When merging, all the commits will be squashed into a single commit listing all co-authors.

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
