### PR TITLE
feat: `norm_num` extension for `IsSquare` on `Nat`, `Int`, `Rat`

### DIFF
--- a/Mathlib.lean
+++ b/Mathlib.lean
@@ -6261,6 +6261,7 @@ import Mathlib.Tactic.NormNum.Ineq
 import Mathlib.Tactic.NormNum.Inv
 import Mathlib.Tactic.NormNum.Irrational
 import Mathlib.Tactic.NormNum.IsCoprime
+import Mathlib.Tactic.NormNum.IsSquare
 import Mathlib.Tactic.NormNum.LegendreSymbol
 import Mathlib.Tactic.NormNum.ModEq
 import Mathlib.Tactic.NormNum.NatFactorial

--- a/Mathlib/Tactic.lean
+++ b/Mathlib/Tactic.lean
@@ -196,6 +196,7 @@ import Mathlib.Tactic.NormNum.Ineq
 import Mathlib.Tactic.NormNum.Inv
 import Mathlib.Tactic.NormNum.Irrational
 import Mathlib.Tactic.NormNum.IsCoprime
+import Mathlib.Tactic.NormNum.IsSquare
 import Mathlib.Tactic.NormNum.LegendreSymbol
 import Mathlib.Tactic.NormNum.ModEq
 import Mathlib.Tactic.NormNum.NatFactorial

--- a/Mathlib/Tactic/NormNum/IsSquare.lean
+++ b/Mathlib/Tactic/NormNum/IsSquare.lean
@@ -1,0 +1,123 @@
+/-
+Copyright (c) 2025 Aaron Liu. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Aaron Liu
+-/
+import Mathlib.Data.Nat.Sqrt
+import Mathlib.Data.Rat.Lemmas
+import Mathlib.Tactic.NormNum.NatSqrt
+import Mathlib.Tactic.NormNum.GCD
+
+/-! # `norm_num` extension for `IsSquare`
+
+This module defines a `norm_num` extension for `IsSquare x` for `x` a `Nat`, `Int`, or `Rat`.
+Depends on the `Nat.sqrt` extension.
+
+-/
+
+namespace Tactic
+
+namespace NormNum
+
+open Qq Lean Elab.Tactic Mathlib.Meta.NormNum
+
+section lemmas
+
+theorem nat_isSquare_helper {x y : ℕ} (hy : x.sqrt = y)
+    (hxz : Nat.beq x (y * y) = false) : ¬IsSquare x := by
+  intro h
+  apply Nat.ne_of_beq_eq_false hxz
+  rw [← hy, eq_comm, ← Nat.exists_mul_self]
+  obtain ⟨r, hr⟩ := h
+  exact ⟨r, hr.symm⟩
+
+theorem isSquare_of_isNat_nat : {x nx : ℕ} → IsNat x nx → IsSquare nx → IsSquare x
+  | _, _, ⟨rfl⟩, h => h
+
+theorem not_isSquare_of_isNat_nat : {x nx : ℕ} → IsNat x nx → ¬IsSquare nx → ¬IsSquare x
+  | _, _, ⟨rfl⟩, h => h
+
+theorem isSquare_of_isNat_int {x : ℤ} {nx : ℕ}
+    (hx : IsNat x nx) (hnx : IsSquare nx) : IsSquare x := by
+  rcases hx with ⟨rfl⟩
+  obtain ⟨y, hy⟩ := hnx
+  exact ⟨y, by simp [hy]⟩
+
+theorem not_isSquare_of_isNat_int {x : ℤ} {nx : ℕ}
+    (hx : IsNat x nx) (hnx : ¬IsSquare nx) : ¬IsSquare x := by
+  rcases hx with ⟨rfl⟩
+  rintro ⟨y, hy⟩
+  apply hnx
+  exact ⟨y.natAbs, (Int.natAbs_mul_natAbs_eq hy.symm).symm⟩
+
+theorem not_isSquare_of_isNegOfNat {x : ℤ} {nx : ℕ}
+    (hx : IsInt x (Int.negOfNat nx.succ)) : ¬IsSquare x := by
+  rcases hx with ⟨rfl⟩
+  rintro ⟨y, hy⟩
+  rw [← Int.natAbs_mul_self] at hy
+  cases hy
+
+theorem isSquare_rat_eq {x : ℚ} : IsSquare x = (IsSquare x.num ∧ IsSquare x.den) :=
+  propext Rat.isSquare_iff
+
+end lemmas
+
+/-- Given the natural number literal `ex`, returns a proof that it's a square
+or a proof that it's not. Panics if `ex` isn't a natural number literal. -/
+def proveIsSquareNat (ex : Q(ℕ)) : Q(IsSquare $ex) ⊕ Q(¬IsSquare $ex) :=
+  let ⟨ey, pfy⟩ := proveNatSqrt ex
+  let x := ex.natLit!
+  let y := ey.natLit!
+  if x = y * y then
+    have : ($ey * $ey) =Q $ex := ⟨⟩
+    .inl q(⟨$ey, Eq.refl $ex⟩)
+  else
+    have ne : Q(Nat.beq $ex ($ey * $ey) = false) := reflBoolFalse
+    .inr q(nat_isSquare_helper $pfy $ne)
+
+/-- `norm_num` extension that proves `IsSquare x` for `x : ℕ`. -/
+@[norm_num IsSquare (_ : ℕ)]
+def evalIsSquareNat : NormNumExt where eval {u α} e := do
+  let 0 := u | failure
+  let ~q(Prop) := α | failure
+  let ~q(IsSquare ($x : ℕ)) := e | failure
+  let ⟨ex, px⟩ ← deriveNat x q(instAddMonoidWithOneNat)
+  match proveIsSquareNat ex with
+  | .inl pf => return .isTrue q(isSquare_of_isNat_nat $px $pf)
+  | .inr pf => return .isFalse q(not_isSquare_of_isNat_nat $px $pf)
+
+/-- `norm_num` extension that proves `IsSquare x` for `x : ℤ`. -/
+@[norm_num IsSquare (_ : ℤ)]
+def evalIsSquareInt : NormNumExt where eval {u α} e := do
+  let 0 := u | failure
+  let ~q(Prop) := α | failure
+  let ~q(IsSquare ($x : ℤ)) := e | failure
+  match ← derive (α := q(ℤ)) x with
+  | .isNat _ nx px =>
+    assumeInstancesCommute
+    match proveIsSquareNat nx with
+    | .inl pf => return .isTrue q(isSquare_of_isNat_int $px $pf)
+    | .inr pf => return .isFalse q(not_isSquare_of_isNat_int $px $pf)
+  | .isNegNat _ nx px =>
+    assumeInstancesCommute
+    match nx.natLit! with
+    | 0 => failure
+    | .succ m =>
+      have m : Q(Nat) := mkRawNatLit m
+      have : Nat.succ $m =Q $nx := ⟨⟩
+      return .isFalse q(not_isSquare_of_isNegOfNat $px)
+  | _ => failure
+
+/-- `norm_num` extension that proves `IsSquare x` for `x : ℚ`.
+Depends on the extensions for `Rat.num` and `Rat.den`. -/
+@[norm_num IsSquare (_ : ℚ)]
+def evalIsSquareRat : NormNumExt where eval {u α} e := do
+  let 0 := u | failure
+  let ~q(Prop) := α | failure
+  let ~q(IsSquare ($x : ℚ)) := e | failure
+  let r ← derive q(IsSquare ($x).num ∧ IsSquare ($x).den)
+  return r.eqTrans q(isSquare_rat_eq)
+
+end NormNum
+
+end Tactic

--- a/Mathlib/Tactic/NormNum/IsSquare.lean
+++ b/Mathlib/Tactic/NormNum/IsSquare.lean
@@ -57,8 +57,14 @@ theorem not_isSquare_of_isNegOfNat {x : ℤ} {nx : ℕ}
   rw [← Int.natAbs_mul_self] at hy
   cases hy
 
-theorem isSquare_rat_eq {x : ℚ} : IsSquare x = (IsSquare x.num ∧ IsSquare x.den) :=
-  propext Rat.isSquare_iff
+theorem isSquare_rat_of_num_den {x : ℚ} (hn : IsSquare x.num) (hd : IsSquare x.den) :
+    IsSquare x := Rat.isSquare_iff.2 ⟨hn, hd⟩
+
+theorem not_isSquare_rat_of_num {x : ℚ} (hn : ¬IsSquare x.num) :
+    ¬IsSquare x := fun h => hn (Rat.isSquare_iff.1 h).1
+
+theorem not_isSquare_rat_of_den {x : ℚ} (hd : ¬IsSquare x.den) :
+    ¬IsSquare x := fun h => hd (Rat.isSquare_iff.1 h).2
 
 end lemmas
 
@@ -115,8 +121,14 @@ def evalIsSquareRat : NormNumExt where eval {u α} e := do
   let 0 := u | failure
   let ~q(Prop) := α | failure
   let ~q(IsSquare ($x : ℚ)) := e | failure
-  let r ← derive q(IsSquare ($x).num ∧ IsSquare ($x).den)
-  return r.eqTrans q(isSquare_rat_eq)
+  let ⟨rn, pfn⟩ ← deriveBool q(IsSquare ($x).num)
+  match rn with
+  | true =>
+    let ⟨rd, pfd⟩ ← deriveBool q(IsSquare ($x).den)
+    match rd with
+    | true => return .isTrue q(isSquare_rat_of_num_den $pfn $pfd)
+    | false => return .isFalse q(not_isSquare_rat_of_den $pfd)
+  | false => return .isFalse q(not_isSquare_rat_of_num $pfn)
 
 end NormNum
 

--- a/Mathlib/Tactic/NormNum/IsSquare.lean
+++ b/Mathlib/Tactic/NormNum/IsSquare.lean
@@ -6,12 +6,12 @@ Authors: Aaron Liu
 import Mathlib.Data.Nat.Sqrt
 import Mathlib.Data.Rat.Lemmas
 import Mathlib.Tactic.NormNum.NatSqrt
-import Mathlib.Tactic.NormNum.GCD
 
 /-! # `norm_num` extension for `IsSquare`
 
 This module defines a `norm_num` extension for `IsSquare x` for `x` a `Nat`, `Int`, or `Rat`.
-Depends on the `Nat.sqrt` extension.
+The extension for `Rat` depends on the `Rat.num` and `Rat.den` extensions,
+and will not work without them imported (from `Mathlib.Tactic.NormNum.GCD`).
 
 -/
 
@@ -115,7 +115,8 @@ def evalIsSquareInt : NormNumExt where eval {u α} e := do
   | _ => failure
 
 /-- `norm_num` extension that proves `IsSquare x` for `x : ℚ`.
-Depends on the extensions for `Rat.num` and `Rat.den`. -/
+Depends on the extensions for `Rat.num` and `Rat.den`,
+which are in `Mathlib.Tactic.NormNum.GCD`. -/
 @[norm_num IsSquare (_ : ℚ)]
 def evalIsSquareRat : NormNumExt where eval {u α} e := do
   let 0 := u | failure

--- a/MathlibTest/norm_num_ext.lean
+++ b/MathlibTest/norm_num_ext.lean
@@ -20,6 +20,7 @@ import Mathlib.Tactic.NormNum.Pow
 import Mathlib.Tactic.NormNum.RealSqrt
 import Mathlib.Tactic.NormNum.Irrational
 import Mathlib.Tactic.Simproc.Factors
+import Mathlib.Tactic.NormNum.IsSquare
 
 /-!
 # Tests for `norm_num` extensions
@@ -583,5 +584,17 @@ example : Irrational
 -- We only need to check that it is coprime with the denominator.
 example : Irrational (100 ^ ((10^1000 + 10^500) / 3 : ℝ)) := by norm_num1
 
-
 end irrational
+
+section IsSquare
+
+example : IsSquare (243089725342304986 ^ 2 : ℕ) := by norm_num1
+example : ¬IsSquare (243089725342304986 ^ 2 + 1 : ℤ) := by norm_num1
+example : ¬IsSquare (10^101 : ℕ) := by norm_num1
+example : IsSquare (100^100 : ℤ) := by norm_num1
+example : ¬IsSquare (-256 : ℤ) := by norm_num1
+example : IsSquare ((15553 * 256) / (15553 * 289) : ℚ) := by norm_num1
+example : ¬IsSquare (21/8 : ℚ) := by norm_num1
+example : ¬IsSquare (-21/8 : ℚ) := by norm_num1
+
+end IsSquare


### PR DESCRIPTION
Write a `norm_num` extension to evaluate `IsSquare` for `Nat`, `Int`, `Rat`.

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include at least one commit authored by each
co-author among the commits in the pull request. If necessary, you may 
create empty commits to indicate co-authorship, using commands like so:

git commit --author="Author Name <author@email.com>" --allow-empty -m "add Author Name as coauthor"

When merging, all the commits will be squashed into a single commit listing all co-authors.

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
