### PR TITLE
[Merged by Bors] - feat: remove separability assumption from Algebra.norm_eq_norm_adjoin and Algebra.norm_eq_prod_roots

### DIFF
--- a/Mathlib/FieldTheory/Finite/GaloisField.lean
+++ b/Mathlib/FieldTheory/Finite/GaloisField.lean
@@ -6,7 +6,7 @@ Authors: Aaron Anderson, Alex J. Best, Johan Commelin, Eric Rodriguez, Ruben Van
 import Mathlib.Algebra.Algebra.ZMod
 import Mathlib.FieldTheory.Finite.Basic
 import Mathlib.FieldTheory.Galois.Basic
-import Mathlib.RingTheory.Norm.Basic
+import Mathlib.RingTheory.Norm.Transitivity
 
 /-!
 # Galois fields

--- a/Mathlib/NumberTheory/Cyclotomic/PrimitiveRoots.lean
+++ b/Mathlib/NumberTheory/Cyclotomic/PrimitiveRoots.lean
@@ -8,7 +8,7 @@ import Mathlib.Data.Nat.Factorization.PrimePow
 import Mathlib.Data.PNat.Prime
 import Mathlib.NumberTheory.Cyclotomic.Basic
 import Mathlib.RingTheory.Adjoin.PowerBasis
-import Mathlib.RingTheory.Norm.Basic
+import Mathlib.RingTheory.Norm.Transitivity
 import Mathlib.RingTheory.Polynomial.Cyclotomic.Eval
 import Mathlib.RingTheory.Polynomial.Cyclotomic.Expand
 import Mathlib.RingTheory.SimpleModule.Basic

--- a/Mathlib/NumberTheory/NumberField/InfinitePlace/Basic.lean
+++ b/Mathlib/NumberTheory/NumberField/InfinitePlace/Basic.lean
@@ -330,7 +330,7 @@ variable [NumberField K]
 theorem prod_eq_abs_norm (x : K) :
     ∏ w : InfinitePlace K, w x ^ mult w = abs (Algebra.norm ℚ x) := by
   classical
-  convert (congr_arg (‖·‖) (@Algebra.norm_eq_prod_embeddings ℚ _ _ _ _ ℂ _ _ _ _ _ x)).symm
+  convert (congr_arg (‖·‖) (Algebra.norm_eq_prod_embeddings ℚ ℂ x)).symm
   · rw [norm_prod, ← Fintype.prod_equiv RingHom.equivRatAlgHom (fun f => ‖f x‖)
       (fun φ => ‖φ x‖) fun _ => by simp [RingHom.equivRatAlgHom_apply]]
     rw [← Finset.prod_fiberwise Finset.univ mk (fun φ => ‖φ x‖)]

--- a/Mathlib/NumberTheory/NumberField/Norm.lean
+++ b/Mathlib/NumberTheory/NumberField/Norm.lean
@@ -39,7 +39,7 @@ end Rat
 
 namespace RingOfIntegers
 
-variable {L : Type*} (K : Type*) [Field K] [Field L] [Algebra K L] [FiniteDimensional K L]
+variable {L : Type*} (K : Type*) [Field K] [Field L] [Algebra K L]
 
 /-- `Algebra.norm` as a morphism between the rings of integers. -/
 noncomputable def norm : 𝓞 L →* 𝓞 K :=
@@ -62,7 +62,8 @@ theorem norm_algebraMap (x : 𝓞 K) : norm K (algebraMap (𝓞 K) (𝓞 L) x) =
     RingOfIntegers.algebraMap_norm_algebraMap, Algebra.norm_algebraMap,
     RingOfIntegers.coe_eq_algebraMap, map_pow]
 
-theorem isUnit_norm_of_isGalois [IsGalois K L] {x : 𝓞 L} : IsUnit (norm K x) ↔ IsUnit x := by
+theorem isUnit_norm_of_isGalois [FiniteDimensional K L] [IsGalois K L] {x : 𝓞 L} :
+    IsUnit (norm K x) ↔ IsUnit x := by
   classical
   refine ⟨fun hx => ?_, IsUnit.map _⟩
   replace hx : IsUnit (algebraMap (𝓞 K) (𝓞 L) <| norm K x) := hx.map (algebraMap (𝓞 K) <| 𝓞 L)
@@ -79,7 +80,8 @@ theorem isUnit_norm_of_isGalois [IsGalois K L] {x : 𝓞 L} : IsUnit (norm K x) 
 
 /-- If `L/K` is a finite Galois extension of fields, then, for all `(x : 𝓞 L)` we have that
 `x ∣ algebraMap (𝓞 K) (𝓞 L) (norm K x)`. -/
-theorem dvd_norm [IsGalois K L] (x : 𝓞 L) : x ∣ algebraMap (𝓞 K) (𝓞 L) (norm K x) := by
+theorem dvd_norm [FiniteDimensional K L] [IsGalois K L] (x : 𝓞 L) :
+    x ∣ algebraMap (𝓞 K) (𝓞 L) (norm K x) := by
   classical
   have hint :
     IsIntegral ℤ (∏ σ ∈ univ.erase (AlgEquiv.refl : L ≃ₐ[K] L), σ x) :=

--- a/Mathlib/RingTheory/Discriminant.lean
+++ b/Mathlib/RingTheory/Discriminant.lean
@@ -4,7 +4,7 @@ Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Riccardo Brasca
 -/
 import Mathlib.Algebra.Order.BigOperators.Group.LocallyFinite
-import Mathlib.RingTheory.Norm.Basic
+import Mathlib.RingTheory.Norm.Transitivity
 import Mathlib.RingTheory.Trace.Basic
 
 /-!

--- a/Mathlib/RingTheory/IntegralClosure/IntegralRestrict.lean
+++ b/Mathlib/RingTheory/IntegralClosure/IntegralRestrict.lean
@@ -362,6 +362,7 @@ def Algebra.intNormAux :
 
 variable {A K L B}
 
+omit [FiniteDimensional K L] in
 lemma Algebra.map_intNormAux (x : B) :
     algebraMap A K (Algebra.intNormAux A K L B x) = Algebra.norm K (algebraMap B L x) := by
   dsimp [Algebra.intNormAux]

--- a/Mathlib/RingTheory/Norm/Basic.lean
+++ b/Mathlib/RingTheory/Norm/Basic.lean
@@ -129,19 +129,6 @@ end EqZeroIff
 
 open IntermediateField
 
-variable (K) in
-theorem norm_eq_norm_adjoin [FiniteDimensional K L] [Algebra.IsSeparable K L] (x : L) :
-    norm K x = norm K (AdjoinSimple.gen K x) ^ finrank K⟮x⟯ L := by
-  letI := Algebra.isSeparable_tower_top_of_isSeparable K K⟮x⟯ L
-  let pbL := Field.powerBasisOfFiniteOfSeparable K⟮x⟯ L
-  let pbx := IntermediateField.adjoin.powerBasis (Algebra.IsSeparable.isIntegral K x)
-  rw [← AdjoinSimple.algebraMap_gen K x, norm_eq_matrix_det (pbx.basis.smulTower pbL.basis) _,
-    smulTower_leftMulMatrix_algebraMap, det_blockDiagonal, AdjoinSimple.algebraMap_gen,
-    norm_eq_matrix_det pbx.basis]
-  simp only [Finset.card_fin, Finset.prod_const]
-  congr
-  rw [← PowerBasis.finrank]
-
 section IntermediateField
 
 theorem _root_.IntermediateField.AdjoinSimple.norm_gen_eq_one {x : L} (hx : ¬IsIntegral K x) :
@@ -186,12 +173,6 @@ theorem norm_eq_prod_embeddings_gen [Algebra R F] (pb : PowerBasis R S)
     · intro x; rfl
   · intro σ; simp only [PowerBasis.liftEquiv'_apply_coe]
 
-theorem norm_eq_prod_roots [Algebra.IsSeparable K L] [FiniteDimensional K L] {x : L}
-    (hF : (minpoly K x).Splits (algebraMap K F)) :
-    algebraMap K F (norm K x) =
-      ((minpoly K x).aroots F).prod ^ finrank K⟮x⟯ L := by
-  rw [norm_eq_norm_adjoin K x, map_pow, IntermediateField.AdjoinSimple.norm_gen_eq_prod_roots _ hF]
-
 theorem prod_embeddings_eq_finrank_pow [Algebra L F] [IsScalarTower K L F] [IsAlgClosed E]
     [Algebra.IsSeparable K F] [FiniteDimensional K F] (pb : PowerBasis K L) :
     ∏ σ : F →ₐ[K] E, σ (algebraMap L F pb.gen) =
@@ -210,30 +191,6 @@ theorem prod_embeddings_eq_finrank_pow [Algebra L F] [IsScalarTower K L F] [IsAl
   · intro σ
     simp only [algHomEquivSigma, Equiv.coe_fn_mk, AlgHom.restrictDomain, AlgHom.comp_apply,
       IsScalarTower.coe_toAlgHom']
-
-variable (K)
-
-/-- For `L/K` a finite separable extension of fields and `E` an algebraically closed extension
-of `K`, the norm (down to `K`) of an element `x` of `L` is equal to the product of the images
-of `x` over all the `K`-embeddings `σ` of `L` into `E`. -/
-theorem norm_eq_prod_embeddings [FiniteDimensional K L] [Algebra.IsSeparable K L] [IsAlgClosed E]
-    (x : L) : algebraMap K E (norm K x) = ∏ σ : L →ₐ[K] E, σ x := by
-  have hx := Algebra.IsSeparable.isIntegral K x
-  rw [norm_eq_norm_adjoin K x, RingHom.map_pow, ← adjoin.powerBasis_gen hx,
-    norm_eq_prod_embeddings_gen E (adjoin.powerBasis hx) (IsAlgClosed.splits_codomain _)]
-  · exact (prod_embeddings_eq_finrank_pow L (L := K⟮x⟯) E (adjoin.powerBasis hx)).symm
-  · haveI := Algebra.isSeparable_tower_bot_of_isSeparable K K⟮x⟯ L
-    exact Algebra.IsSeparable.isSeparable K _
-
-theorem norm_eq_prod_automorphisms [FiniteDimensional K L] [IsGalois K L] (x : L) :
-    algebraMap K L (norm K x) = ∏ σ : L ≃ₐ[K] L, σ x := by
-  apply FaithfulSMul.algebraMap_injective L (AlgebraicClosure L)
-  rw [map_prod (algebraMap L (AlgebraicClosure L))]
-  rw [← Fintype.prod_equiv (Normal.algHomEquivAut K (AlgebraicClosure L) L)]
-  · rw [← norm_eq_prod_embeddings _ _ x, ← IsScalarTower.algebraMap_apply]
-  · intro σ
-    simp only [Normal.algHomEquivAut, AlgHom.restrictNormal', Equiv.coe_fn_mk,
-      AlgEquiv.coe_ofBijective, AlgHom.restrictNormal_commutes, algebraMap_self, RingHom.id_apply]
 
 lemma norm_eq_of_algEquiv [Ring T] [Algebra R T] (e : S ≃ₐ[R] T) (x) :
     Algebra.norm R (e x) = Algebra.norm R x := by

--- a/Mathlib/RingTheory/Norm/Basic.lean
+++ b/Mathlib/RingTheory/Norm/Basic.lean
@@ -7,8 +7,6 @@ import Mathlib.RingTheory.Norm.Defs
 import Mathlib.FieldTheory.PrimitiveElement
 import Mathlib.LinearAlgebra.Matrix.Charpoly.Minpoly
 import Mathlib.LinearAlgebra.Matrix.ToLinearEquiv
-import Mathlib.FieldTheory.IsAlgClosed.AlgebraicClosure
-import Mathlib.FieldTheory.Galois.Basic
 
 /-!
 # Norm for (finite) ring extensions

--- a/Mathlib/RingTheory/Norm/Transitivity.lean
+++ b/Mathlib/RingTheory/Norm/Transitivity.lean
@@ -11,6 +11,7 @@ import Mathlib.FieldTheory.IntermediateField.Adjoin.Defs
 import Mathlib.FieldTheory.IntermediateField.Algebraic
 import Mathlib.FieldTheory.IsAlgClosed.AlgebraicClosure
 import Mathlib.RingTheory.Norm.Basic
+import Mathlib.FieldTheory.Galois.Basic
 
 /-!
 # Transitivity of algebra norm

--- a/Mathlib/RingTheory/Norm/Transitivity.lean
+++ b/Mathlib/RingTheory/Norm/Transitivity.lean
@@ -200,7 +200,7 @@ theorem Algebra.norm_norm {A} [Ring A] [Algebra R A] [Algebra S A]
     norm R (norm S a) = norm R a := by
   rw [norm_apply S, norm_apply R a, ← LinearMap.det_restrictScalars]; rfl
 
-variable {L : Type*} (K : Type*) [Field K] [Field L] [Algebra K L] [FiniteDimensional K L]
+variable {L : Type*} (K : Type*) [Field K] [Field L] [Algebra K L]
 
 open Module IntermediateField AdjoinSimple
 
@@ -208,6 +208,9 @@ namespace Algebra
 
 theorem isIntegral_norm [Algebra R L] [Algebra R K] [IsScalarTower R K L] {x : L}
     (hx : IsIntegral R x) : IsIntegral R (norm K x) := by
+  by_cases h : FiniteDimensional K L
+  swap
+  · simpa [norm_eq_one_of_not_module_finite h] using isIntegral_one
   let F := K⟮x⟯
   rw [← norm_norm (S := F), ← coe_gen K x, ← IntermediateField.algebraMap_apply,
     norm_algebraMap_of_basis (Module.Free.chooseBasis F L) (gen K x), map_pow]
@@ -221,6 +224,19 @@ theorem isIntegral_norm [Algebra R L] [Algebra R K] [IsScalarTower R K L] {x : L
 
 theorem norm_eq_norm_adjoin (x : L) :
     norm K x = norm K (AdjoinSimple.gen K x) ^ finrank K⟮x⟯ L := by
+  by_cases h : FiniteDimensional K L
+  swap
+  · rw [norm_eq_one_of_not_module_finite h]
+    by_cases hx : IsIntegral K x
+    · have h₁ : ¬ FiniteDimensional K⟮x⟯ L := fun H ↦ h <| by
+        have : FiniteDimensional K K⟮x⟯ := adjoin.finiteDimensional hx
+        exact Finite.trans K⟮x⟯ L
+      simp [finrank_of_not_finite h₁]
+    · rw [norm_eq_one_of_not_module_finite]
+      · simp
+      · refine fun H ↦ hx ?_
+        rw [← isIntegral_gen]
+        exact IsIntegral.isIntegral (gen K x)
   let F := K⟮x⟯
   nth_rw 1 [← coe_gen K x]
   rw [← norm_norm (S := F), ← IntermediateField.algebraMap_apply,
@@ -234,6 +250,8 @@ theorem norm_eq_prod_roots {x : L} (hF : (minpoly K x).Splits (algebraMap K F)) 
     algebraMap K F (norm K x) =
       ((minpoly K x).aroots F).prod ^ finrank K⟮x⟯ L := by
   rw [norm_eq_norm_adjoin K x, map_pow, IntermediateField.AdjoinSimple.norm_gen_eq_prod_roots _ hF]
+
+variable [FiniteDimensional K L]
 
 /-- For `L/K` a finite separable extension of fields and `E` an algebraically closed extension
 of `K`, the norm (down to `K`) of an element `x` of `L` is equal to the product of the images


### PR DESCRIPTION
Continuing the work of #30323  we remove the separability assumption from `Algebra.norm_eq_norm_adjoin` and `Algebra.norm_eq_prod_roots`.

---

Removing every `IsSeparable` assumption is not completely easy, as some statements need to be changed, so I think it's better to do so in various steps, starting with the obvious ones.

<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include at least one commit authored by each
co-author among the commits in the pull request. If necessary, you may 
create empty commits to indicate co-authorship, using commands like so:

git commit --author="Author Name <author@email.com>" --allow-empty -m "add Author Name as coauthor"

When merging, all the commits will be squashed into a single commit listing all co-authors.

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
