### PR TITLE
[Merged by Bors] - refactor(RingTheory/AdjoinRoot): generalise `algEquivOfAssociated`

### DIFF
--- a/Mathlib/FieldTheory/IntermediateField/Adjoin/Basic.lean
+++ b/Mathlib/FieldTheory/IntermediateField/Adjoin/Basic.lean
@@ -649,64 +649,10 @@ end AdjoinIntegralElement
 
 end IntermediateField
 
-section Minpoly
-
-open AlgEquiv
-
-variable {K L : Type _} [Field K] [Field L] [Algebra K L]
-namespace AdjoinRoot
-
-/-- The canonical algebraic homomorphism from `AdjoinRoot p` to `AdjoinRoot q`, where
-  the polynomial `q : K[X]` divides `p`. -/
-noncomputable def algHomOfDvd {p q : K[X]} (hpq : q ∣ p) :
-    AdjoinRoot p →ₐ[K] AdjoinRoot q :=
-  (liftHom p (root q) (by simp only [aeval_eq, mk_eq_zero, hpq]))
-
-theorem coe_algHomOfDvd {p q : K[X]} (hpq : q ∣ p) :
-    (algHomOfDvd hpq).toFun = liftHom p (root q) (by simp only [aeval_eq, mk_eq_zero, hpq]) :=
-  rfl
-
-/-- `algHomOfDvd` sends `AdjoinRoot.root p` to `AdjoinRoot.root q`. -/
-theorem algHomOfDvd_apply_root {p q : K[X]} (hpq : q ∣ p) :
-    algHomOfDvd hpq (root p) = root q := by
-  rw [algHomOfDvd, liftHom_root]
-
-@[deprecated (since := "2025-09-19")]
-alias algEquivOfEq_apply_root := algEquivOfEq_root
-
-/-- The canonical algebraic equivalence between `AdjoinRoot p` and `AdjoinRoot q`,
-where the two polynomials `p q : K[X]` are associated. -/
-noncomputable def algEquivOfAssociated {p q : K[X]} (hp : p ≠ 0) (hpq : Associated p q) :
-    AdjoinRoot p ≃ₐ[K] AdjoinRoot q :=
-  ofAlgHom (liftHom p (root q) (by simp only [aeval_eq, mk_eq_zero, hpq.symm.dvd] ))
-    (liftHom q (root p) (by simp only [aeval_eq, mk_eq_zero, hpq.dvd]))
-    ( PowerBasis.algHom_ext (powerBasis (hpq.ne_zero_iff.mp hp))
-        (by rw [powerBasis_gen (hpq.ne_zero_iff.mp hp), AlgHom.coe_comp, Function.comp_apply,
-          liftHom_root, liftHom_root, AlgHom.coe_id, id_eq]))
-    (PowerBasis.algHom_ext (powerBasis hp)
-      (by rw [powerBasis_gen hp, AlgHom.coe_comp, Function.comp_apply, liftHom_root, liftHom_root,
-          AlgHom.coe_id, id_eq]))
-
-theorem coe_algEquivOfAssociated {p q : K[X]} (hp : p ≠ 0) (hpq : Associated p q) :
-    (algEquivOfAssociated hp hpq).toFun =
-      liftHom p (root q) (by simp only [aeval_eq, mk_eq_zero, hpq.symm.dvd]) :=
-  rfl
-
-theorem algEquivOfAssociated_toAlgHom {p q : K[X]} (hp : p ≠ 0) (hpq : Associated p q) :
-    (algEquivOfAssociated hp hpq).toAlgHom =
-      liftHom p (root q) (by simp only [aeval_eq, mk_eq_zero, hpq.symm.dvd]) :=
-  rfl
-
-/-- `algEquivOfAssociated` sends `AdjoinRoot.root p` to `AdjoinRoot.root q`. -/
-theorem algEquivOfAssociated_apply_root {p q : K[X]} (hp : p ≠ 0) (hpq : Associated p q) :
-    algEquivOfAssociated hp hpq (root p) = root q := by
-  rw [← coe_algHom, algEquivOfAssociated_toAlgHom, liftHom_root]
-
-end AdjoinRoot
-
 namespace minpoly
+variable {K L : Type*} [Field K] [Field L] [Algebra K L]
 
-open IntermediateField
+open AlgEquiv IntermediateField
 
 /-- If `y : L` is a root of `minpoly K x`, then `minpoly K y = minpoly K x`. -/
 theorem eq_of_root {x y : L} (hx : IsAlgebraic K x)
@@ -731,8 +677,6 @@ theorem algEquiv_apply {x y : L} (hx : IsAlgebraic K x) (h_mp : minpoly K x = mi
     adjoinRootEquivAdjoin_apply_root K hy.isIntegral]
 
 end minpoly
-
-end Minpoly
 
 namespace PowerBasis
 

--- a/Mathlib/FieldTheory/IntermediateField/Adjoin/Basic.lean
+++ b/Mathlib/FieldTheory/IntermediateField/Adjoin/Basic.lean
@@ -665,7 +665,7 @@ noncomputable def algEquiv {x y : L} (hx : IsAlgebraic K x)
     (h_mp : minpoly K x = minpoly K y) : K⟮x⟯ ≃ₐ[K] K⟮y⟯ := by
   have hy : IsAlgebraic K y := ⟨minpoly K x, ne_zero hx.isIntegral, (h_mp ▸ aeval _ _)⟩
   exact AlgEquiv.trans (adjoinRootEquivAdjoin K hx.isIntegral).symm
-    (AlgEquiv.trans (AdjoinRoot.algEquivOfEq h_mp)
+    (AlgEquiv.trans (AdjoinRoot.algEquivOfEq _ _ h_mp)
       (adjoinRootEquivAdjoin K hy.isIntegral))
 
 /-- `minpoly.algEquiv` sends the generator of `K⟮x⟯` to the generator of `K⟮y⟯`. -/

--- a/Mathlib/RingTheory/AdjoinRoot.lean
+++ b/Mathlib/RingTheory/AdjoinRoot.lean
@@ -340,52 +340,53 @@ end Prime
 
 /-- The canonical algebraic homomorphism from `AdjoinRoot f` to `AdjoinRoot g`, where
 the polynomial `g : K[X]` divides `f`. -/
-noncomputable def algHomOfDvd (hgf : g ∣ f) : AdjoinRoot f →ₐ[R] AdjoinRoot g :=
-  liftAlgHom f (Algebra.ofId _ _) (root g) <| (aeval_eq _).trans <| by simp [mk_eq_zero, hgf]
+noncomputable def algHomOfDvd (f g : R[X]) (hgf : g ∣ f) : AdjoinRoot f →ₐ[R] AdjoinRoot g :=
+  liftHom f (root g) <| (aeval_eq _).trans <| by simp [mk_eq_zero, hgf]
 
-lemma coe_algHomOfDvd (hgf : g ∣ f) :
-    ⇑(algHomOfDvd hgf) =
-      liftAlgHom f (Algebra.ofId _ _) (root g) ((aeval_eq _).trans <| by simp [mk_eq_zero, hgf]) :=
+lemma coe_algHomOfDvd (f g : R[X]) (hgf) :
+    ⇑(algHomOfDvd f g hgf) = liftHom f (root g) ((aeval_eq _).trans <| by simp [mk_eq_zero, hgf]) :=
   rfl
 
 /-- `algHomOfDvd` sends `AdjoinRoot.root f` to `AdjoinRoot.root q`. -/
-@[simp] lemma algHomOfDvd_root (hgf : g ∣ f) : algHomOfDvd hgf (root f) = root g := by
-  rw [algHomOfDvd, liftAlgHom_root]
+@[simp] lemma algHomOfDvd_root (f g : R[X]) (hgf) : algHomOfDvd f g hgf (root f) = root g := by
+  rw [algHomOfDvd, liftHom_root]
 
 /-- The canonical algebraic equivalence between `AdjoinRoot p` and `AdjoinRoot g`,
 where the two polynomials `f g : R[X]` are associated. -/
-noncomputable def algEquivOfAssociated (hfg : Associated f g) : AdjoinRoot f ≃ₐ[R] AdjoinRoot g :=
-  .ofAlgHom (algHomOfDvd hfg.symm.dvd) (algHomOfDvd hfg.dvd) (by ext; simp) (by ext; simp)
+noncomputable def algEquivOfAssociated (f g : R[X]) (hfg : Associated f g) :
+    AdjoinRoot f ≃ₐ[R] AdjoinRoot g :=
+  .ofAlgHom (algHomOfDvd f g hfg.symm.dvd) (algHomOfDvd g f hfg.dvd) (by ext; simp) (by ext; simp)
 
-lemma coe_algEquivOfAssociated (hfg : Associated f g) :
-    ⇑(algEquivOfAssociated hfg) = algHomOfDvd hfg.symm.dvd := rfl
+lemma coe_algEquivOfAssociated (f g : R[X]) (hfg) :
+    ⇑(algEquivOfAssociated f g hfg) = algHomOfDvd f g hfg.symm.dvd := rfl
 
-@[simp] lemma algEquivOfAssociated_symm (hfg : Associated f g) :
-    (algEquivOfAssociated hfg).symm = algEquivOfAssociated hfg.symm := rfl
+@[simp] lemma algEquivOfAssociated_symm (f g : R[X]) (hfg) :
+    (algEquivOfAssociated f g hfg).symm = algEquivOfAssociated g f hfg.symm := rfl
 
-lemma algEquivOfAssociated_toAlgHom (hfg : Associated f g) :
-    (algEquivOfAssociated hfg).toAlgHom = algHomOfDvd hfg.symm.dvd := rfl
+lemma algEquivOfAssociated_toAlgHom (f g : R[X]) (hfg) :
+    (algEquivOfAssociated f g hfg).toAlgHom = algHomOfDvd f g hfg.symm.dvd := rfl
 
 /-- `algEquivOfAssociated` sends `AdjoinRoot.root f` to `AdjoinRoot.root g`. -/
-@[simp] lemma algEquivOfAssociated_root (hfg : Associated f g) :
-    algEquivOfAssociated hfg (root f) = root g := by
+@[simp] lemma algEquivOfAssociated_root (f g : R[X]) (hfg) :
+    algEquivOfAssociated f g hfg (root f) = root g := by
   rw [coe_algEquivOfAssociated, algHomOfDvd_root]
 
 /-- The canonical algebraic equivalence between `AdjoinRoot f` and `AdjoinRoot g`, where
 the two polynomials `f g : R[X]` are equal. -/
-noncomputable def algEquivOfEq (hfg : f = g) : AdjoinRoot f ≃ₐ[R] AdjoinRoot g :=
-  algEquivOfAssociated (by rw [hfg])
+noncomputable def algEquivOfEq (f g : R[X]) (hfg : f = g) : AdjoinRoot f ≃ₐ[R] AdjoinRoot g :=
+  algEquivOfAssociated f g (by rw [hfg])
 
-lemma coe_algEquivOfEq (hfg : f = g) : ⇑(algEquivOfEq hfg) = algHomOfDvd hfg.symm.dvd := rfl
+lemma coe_algEquivOfEq (f g : R[X]) (hfg) :
+    ⇑(algEquivOfEq f g hfg) = algHomOfDvd f g hfg.symm.dvd := rfl
 
-@[simp] lemma algEquivOfEq_symm (hfg : f = g) : (algEquivOfEq hfg).symm = algEquivOfEq hfg.symm :=
-  rfl
+@[simp] lemma algEquivOfEq_symm (f g : R[X]) (hfg) :
+    (algEquivOfEq f g hfg).symm = algEquivOfEq g f hfg.symm := rfl
 
-lemma algEquivOfEq_toAlgHom (hfg : f = g) :
-    (algEquivOfEq hfg).toAlgHom = algHomOfDvd hfg.symm.dvd := rfl
+lemma algEquivOfEq_toAlgHom (f g : R[X]) (hfg) :
+    (algEquivOfEq f g hfg).toAlgHom = algHomOfDvd f g hfg.symm.dvd := rfl
 
 /-- `algEquivOfEq` sends `AdjoinRoot.root f` to `AdjoinRoot.root g`. -/
-lemma algEquivOfEq_root (hfg : f = g) : algEquivOfEq hfg (root f) = root g := by
+lemma algEquivOfEq_root (f g : R[X]) (hfg) : algEquivOfEq f g hfg (root f) = root g := by
   rw [coe_algEquivOfEq, algHomOfDvd_root]
 
 @[deprecated (since := "2025-10-10")] alias algHomOfDvd_apply_root := algHomOfDvd_root

--- a/Mathlib/RingTheory/AdjoinRoot.lean
+++ b/Mathlib/RingTheory/AdjoinRoot.lean
@@ -63,7 +63,7 @@ namespace AdjoinRoot
 
 section CommRing
 
-variable [CommRing R] (f : R[X])
+variable [CommRing R] (f g : R[X])
 
 instance instCommRing : CommRing (AdjoinRoot f) :=
   Ideal.Quotient.commRing _
@@ -159,7 +159,7 @@ theorem finitePresentation : Algebra.FinitePresentation R (AdjoinRoot f) :=
 def root : AdjoinRoot f :=
   mk f X
 
-variable {f}
+variable {f g}
 
 instance hasCoeT : CoeTC R (AdjoinRoot f) :=
   ⟨of f⟩
@@ -338,26 +338,60 @@ theorem noZeroSMulDivisors_of_prime_of_degree_ne_zero [IsDomain R] (hf : Prime f
 
 end Prime
 
-section
+/-- The canonical algebraic homomorphism from `AdjoinRoot f` to `AdjoinRoot g`, where
+the polynomial `g : K[X]` divides `f`. -/
+noncomputable def algHomOfDvd (hgf : g ∣ f) : AdjoinRoot f →ₐ[R] AdjoinRoot g :=
+  liftAlgHom f (Algebra.ofId _ _) (root g) <| (aeval_eq _).trans <| by simp [mk_eq_zero, hgf]
 
-/-- If `f = g`, `R` adjoin a root of `f` is isomorphic to `R` adjoin a root of `g`. -/
-def algEquivOfEq {f g : R[X]} (hfg : f = g) : AdjoinRoot f ≃ₐ[R] AdjoinRoot g :=
-  .ofAlgHom
-    (liftHom f (root g) (by simp [hfg]))
-    (liftHom g (root f) (by simp [hfg]))
-    (by ext; simp)
-    (by ext; simp)
+lemma coe_algHomOfDvd (hgf : g ∣ f) :
+    ⇑(algHomOfDvd hgf) =
+      liftAlgHom f (Algebra.ofId _ _) (root g) ((aeval_eq _).trans <| by simp [mk_eq_zero, hgf]) :=
+  rfl
 
-variable {f g : R[X]} (hfg : f = g)
+/-- `algHomOfDvd` sends `AdjoinRoot.root f` to `AdjoinRoot.root q`. -/
+@[simp] lemma algHomOfDvd_root (hgf : g ∣ f) : algHomOfDvd hgf (root f) = root g := by
+  rw [algHomOfDvd, liftAlgHom_root]
 
-@[simp] lemma algEquivOfEq_root : algEquivOfEq hfg (root f) = root g := by
-  simp [algEquivOfEq]
+/-- The canonical algebraic equivalence between `AdjoinRoot p` and `AdjoinRoot g`,
+where the two polynomials `f g : R[X]` are associated. -/
+noncomputable def algEquivOfAssociated (hfg : Associated f g) : AdjoinRoot f ≃ₐ[R] AdjoinRoot g :=
+  .ofAlgHom (algHomOfDvd hfg.symm.dvd) (algHomOfDvd hfg.dvd) (by ext; simp) (by ext; simp)
 
-@[simp] lemma algEquivOfEq_symm : (algEquivOfEq hfg).symm = algEquivOfEq hfg.symm := by
-  ext
-  simp [algEquivOfEq]
+lemma coe_algEquivOfAssociated (hfg : Associated f g) :
+    ⇑(algEquivOfAssociated hfg) = algHomOfDvd hfg.symm.dvd := rfl
 
-end
+@[simp] lemma algEquivOfAssociated_symm (hfg : Associated f g) :
+    (algEquivOfAssociated hfg).symm = algEquivOfAssociated hfg.symm := rfl
+
+lemma algEquivOfAssociated_toAlgHom (hfg : Associated f g) :
+    (algEquivOfAssociated hfg).toAlgHom = algHomOfDvd hfg.symm.dvd := rfl
+
+/-- `algEquivOfAssociated` sends `AdjoinRoot.root f` to `AdjoinRoot.root g`. -/
+@[simp] lemma algEquivOfAssociated_root (hfg : Associated f g) :
+    algEquivOfAssociated hfg (root f) = root g := by
+  rw [coe_algEquivOfAssociated, algHomOfDvd_root]
+
+/-- The canonical algebraic equivalence between `AdjoinRoot f` and `AdjoinRoot g`, where
+the two polynomials `f g : R[X]` are equal. -/
+noncomputable def algEquivOfEq (hfg : f = g) : AdjoinRoot f ≃ₐ[R] AdjoinRoot g :=
+  algEquivOfAssociated (by rw [hfg])
+
+lemma coe_algEquivOfEq (hfg : f = g) : ⇑(algEquivOfEq hfg) = algHomOfDvd hfg.symm.dvd := rfl
+
+@[simp] lemma algEquivOfEq_symm (hfg : f = g) : (algEquivOfEq hfg).symm = algEquivOfEq hfg.symm :=
+  rfl
+
+lemma algEquivOfEq_toAlgHom (hfg : f = g) :
+    (algEquivOfEq hfg).toAlgHom = algHomOfDvd hfg.symm.dvd := rfl
+
+/-- `algEquivOfEq` sends `AdjoinRoot.root f` to `AdjoinRoot.root g`. -/
+lemma algEquivOfEq_root (hfg : f = g) : algEquivOfEq hfg (root f) = root g := by
+  rw [coe_algEquivOfEq, algHomOfDvd_root]
+
+@[deprecated (since := "2025-10-10")] alias algHomOfDvd_apply_root := algHomOfDvd_root
+@[deprecated (since := "2025-10-10")] alias algEquivOfEq_apply_root := algEquivOfEq_root
+@[deprecated (since := "2025-10-10")]
+alias algEquivOfAssociated_apply_root := algEquivOfAssociated_root
 
 end CommRing
 


### PR DESCRIPTION
Generalise `algEquivOfAssociated` from fields to commutative rings, and use it to define `algEquivOfEq`. Also make the `f` and `g` arguments explicit to avoid there only being Prop arguments to the defs.


---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include at least one commit authored by each
co-author among the commits in the pull request. If necessary, you may 
create empty commits to indicate co-authorship, using commands like so:

git commit --author="Author Name <author@email.com>" --allow-empty -m "add Author Name as coauthor"

When merging, all the commits will be squashed into a single commit listing all co-authors.

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
