### PR TITLE
[Merged by Bors] - chore(NumberTheory/ArithmeticFunction): remove notation scope

### DIFF
--- a/Archive/Wiedijk100Theorems/PerfectNumbers.lean
+++ b/Archive/Wiedijk100Theorems/PerfectNumbers.lean
@@ -31,6 +31,9 @@ namespace Nat
 
 open ArithmeticFunction Finset
 
+-- access notation `σ`
+open scoped sigma
+
 theorem sigma_two_pow_eq_mersenne_succ (k : ℕ) : σ 1 (2 ^ k) = mersenne (k + 1) := by
   simp_rw [sigma_one_apply, mersenne, ← one_add_one_eq_two, ← geom_sum_mul_add 1 (k + 1)]
   norm_num

--- a/Mathlib/Algebra/Order/Antidiag/Nat.lean
+++ b/Mathlib/Algebra/Order/Antidiag/Nat.lean
@@ -224,6 +224,7 @@ private theorem card_finMulAntidiag_pi (d n : ℕ) (hn : Squarefree n) :
   apply Finset.card_bij (Nat.primeFactorsPiBij d n) (primeFactorsPiBij_img d n hn)
     (primeFactorsPiBij_inj d n) (primeFactorsPiBij_surj d n hn)
 
+open scoped ArithmeticFunction.omega in -- access notation `ω`
 theorem card_finMulAntidiag_of_squarefree {d n : ℕ} (hn : Squarefree n) :
     #(finMulAntidiag d n) = d ^ ω n := by
   rw [← card_finMulAntidiag_pi d n hn, Finset.card_pi, Finset.prod_const,
@@ -296,6 +297,7 @@ private theorem f_surj {n : ℕ} (hn : n ≠ 0) (b : ℕ × ℕ)
 end card_pair_lcm_eq
 
 open card_pair_lcm_eq in
+open scoped ArithmeticFunction.omega in -- access notation `ω`
 theorem card_pair_lcm_eq {n : ℕ} (hn : Squarefree n) :
     #{p ∈ (n.divisors ×ˢ n.divisors) | p.1.lcm p.2 = n} = 3 ^ ω n := by
   rw [← card_finMulAntidiag_of_squarefree hn, eq_comm]

--- a/Mathlib/NumberTheory/ArithmeticFunction.lean
+++ b/Mathlib/NumberTheory/ArithmeticFunction.lean
@@ -49,14 +49,11 @@ to form the Dirichlet ring.
 
 ## Notation
 
-All notation is localized in the namespace `ArithmeticFunction`.
-
 The arithmetic functions `ζ`, `σ`, `ω`, `Ω` and `μ` have Greek letter names.
-
-In addition, there are separate locales `ArithmeticFunction.zeta` for `ζ`,
+This notation is scpoed to the separate locales `ArithmeticFunction.zeta` for `ζ`,
 `ArithmeticFunction.sigma` for `σ`, `ArithmeticFunction.omega` for `ω`,
 `ArithmeticFunction.Omega` for `Ω`, and `ArithmeticFunction.Moebius` for `μ`,
-to allow for selective access to these notations.
+to allow for selective access.
 
 The arithmetic function $$n \mapsto \prod_{p \mid n} f(p)$$ is given custom notation
 `∏ᵖ p ∣ n, f p` when applied to `n`.
@@ -381,10 +378,9 @@ def zeta : ArithmeticFunction ℕ :=
   ⟨fun x => ite (x = 0) 0 1, rfl⟩
 
 @[inherit_doc]
-scoped[ArithmeticFunction] notation "ζ" => ArithmeticFunction.zeta
-
-@[inherit_doc]
 scoped[ArithmeticFunction.zeta] notation "ζ" => ArithmeticFunction.zeta
+
+open scoped zeta
 
 @[simp]
 theorem zeta_apply {x : ℕ} : ζ x = if x = 0 then 0 else 1 :=
@@ -469,6 +465,8 @@ section NonAssocSemiring
 
 variable [NonAssocSemiring R]
 
+open scoped zeta
+
 @[simp]
 theorem pmul_zeta (f : ArithmeticFunction R) : f.pmul ↑ζ = f := by
   ext x
@@ -482,6 +480,8 @@ theorem zeta_pmul (f : ArithmeticFunction R) : (ζ : ArithmeticFunction R).pmul 
 end NonAssocSemiring
 
 variable [Semiring R]
+
+open scoped zeta
 
 /-- This is the pointwise power of `ArithmeticFunction`s. -/
 def ppow (f : ArithmeticFunction R) (k : ℕ) : ArithmeticFunction R :=
@@ -803,6 +803,8 @@ end IsMultiplicative
 
 section SpecialFunctions
 
+open scoped zeta
+
 /-- The identity on `ℕ` as an `ArithmeticFunction`. -/
 def id : ArithmeticFunction ℕ :=
   ⟨_root_.id, rfl⟩
@@ -832,10 +834,9 @@ def sigma (k : ℕ) : ArithmeticFunction ℕ :=
   ⟨fun n => ∑ d ∈ divisors n, d ^ k, by simp⟩
 
 @[inherit_doc]
-scoped[ArithmeticFunction] notation "σ" => ArithmeticFunction.sigma
-
-@[inherit_doc]
 scoped[ArithmeticFunction.sigma] notation "σ" => ArithmeticFunction.sigma
+
+open scoped sigma
 
 theorem sigma_apply {k n : ℕ} : σ k n = ∑ d ∈ divisors n, d ^ k :=
   rfl
@@ -975,10 +976,9 @@ def cardFactors : ArithmeticFunction ℕ :=
   ⟨fun n => n.primeFactorsList.length, by simp⟩
 
 @[inherit_doc]
-scoped[ArithmeticFunction] notation "Ω" => ArithmeticFunction.cardFactors
-
-@[inherit_doc]
 scoped[ArithmeticFunction.Omega] notation "Ω" => ArithmeticFunction.cardFactors
+
+open scoped Omega
 
 theorem cardFactors_apply {n : ℕ} : Ω n = n.primeFactorsList.length :=
   rfl
@@ -1042,10 +1042,9 @@ def cardDistinctFactors : ArithmeticFunction ℕ :=
   ⟨fun n => n.primeFactorsList.dedup.length, by simp⟩
 
 @[inherit_doc]
-scoped[ArithmeticFunction] notation "ω" => ArithmeticFunction.cardDistinctFactors
-
-@[inherit_doc]
 scoped[ArithmeticFunction.omega] notation "ω" => ArithmeticFunction.cardDistinctFactors
+
+open scoped omega
 
 theorem cardDistinctFactors_zero : ω 0 = 0 := by simp
 
@@ -1087,10 +1086,9 @@ def moebius : ArithmeticFunction ℤ :=
   ⟨fun n => if Squarefree n then (-1) ^ cardFactors n else 0, by simp⟩
 
 @[inherit_doc]
-scoped[ArithmeticFunction] notation "μ" => ArithmeticFunction.moebius
-
-@[inherit_doc]
 scoped[ArithmeticFunction.Moebius] notation "μ" => ArithmeticFunction.moebius
+
+open scoped Moebius
 
 @[simp]
 theorem moebius_apply_of_squarefree {n : ℕ} (h : Squarefree n) : μ n = (-1) ^ cardFactors n :=

--- a/Mathlib/NumberTheory/LSeries/Dirichlet.lean
+++ b/Mathlib/NumberTheory/LSeries/Dirichlet.lean
@@ -49,6 +49,9 @@ We show that `L μ s` converges absolutely if and only if `re s > 1`.
 
 namespace ArithmeticFunction
 
+-- access notation `μ`
+open scoped Moebius
+
 open LSeries Nat Complex
 
 lemma not_LSeriesSummable_moebius_at_one : ¬ LSeriesSummable ↗μ 1 := by
@@ -133,6 +136,7 @@ lemma delta_mul {n : ℕ} (χ : DirichletCharacter ℂ n) : δ * ↗χ = δ :=
   mul_comm δ _ ▸ mul_delta ..
 
 open ArithmeticFunction in
+open scoped Moebius in -- access notation `μ`
 /-- The convolution of a Dirichlet character `χ` with the twist `χ * μ` is `δ`,
 the indicator function of `{1}`. -/
 lemma convolution_mul_moebius {n : ℕ} (χ : DirichletCharacter ℂ n) : ↗χ ⍟ (↗χ * ↗μ) = δ := by
@@ -246,6 +250,9 @@ theorem LSeriesSummable_one_iff {s : ℂ} : LSeriesSummable 1 s ↔ 1 < s.re :=
 
 namespace ArithmeticFunction
 
+-- access notation `ζ` and `μ`
+open scoped zeta Moebius
+
 /-- The `LSeries` of the arithmetic function `ζ` is the same as the `LSeries` associated
 to the constant sequence `1`. -/
 lemma LSeries_zeta_eq : L ↗ζ = L 1 := by
@@ -300,6 +307,7 @@ domain of convergence `1 < re s`. -/
 lemma LSeriesHasSum_one {s : ℂ} (hs : 1 < s.re) : LSeriesHasSum 1 s (riemannZeta s) :=
   LSeries_one_eq_riemannZeta hs ▸ (LSeriesSummable_one_iff.mpr hs).LSeriesHasSum
 
+open scoped Moebius in -- access notation `μ`
 /-- The L-series of the constant sequence `1` and of the Möbius function are inverses. -/
 lemma LSeries_one_mul_Lseries_moebius {s : ℂ} (hs : 1 < s.re) : L 1 s * L ↗μ s = 1 :=
   LSeries_zeta_eq ▸ LSeries_zeta_mul_Lseries_moebius hs
@@ -325,6 +333,9 @@ section vonMangoldt
 open LSeries Nat Complex ArithmeticFunction
 
 namespace ArithmeticFunction
+
+-- access notation `ζ`
+open scoped zeta
 
 /-- A translation of the relation `Λ * ↑ζ = log` of (real-valued) arithmetic functions
 to an equality of complex sequences. -/

--- a/Mathlib/NumberTheory/TsumDivsorsAntidiagonal.lean
+++ b/Mathlib/NumberTheory/TsumDivsorsAntidiagonal.lean
@@ -95,6 +95,9 @@ theorem summable_prod_mul_pow (k : ℕ) {r : 𝕜} (hr : ‖r‖ < 1) :
     Summable fun c : (ℕ+ × ℕ+) ↦ c.2 ^ k * (r ^ (c.1 * c.2 : ℕ)) := by
   simpa [sigmaAntidiagonalEquivProd.summable_iff.symm] using summable_divisorsAntidiagonal_aux k hr
 
+-- access notation `σ`
+open scoped sigma
+
 theorem tsum_prod_pow_eq_tsum_sigma (k : ℕ) {r : 𝕜} (hr : ‖r‖ < 1) :
     ∑' d : ℕ+, ∑' c : ℕ+, c ^ k * r ^ (d * c : ℕ) = ∑' e : ℕ+, σ k e * r ^ (e : ℕ) := by
   suffices ∑' c : ℕ+ × ℕ+, c.2 ^ k * r ^ (c.1 * c.2 : ℕ) =

--- a/Mathlib/NumberTheory/VonMangoldt.lean
+++ b/Mathlib/NumberTheory/VonMangoldt.lean
@@ -109,6 +109,9 @@ theorem vonMangoldt_sum {n : ℕ} : ∑ i ∈ n.divisors, Λ i = Real.log n := b
     sum_union (disjoint_divisors_filter_isPrimePow hab), ha, hb, Nat.cast_mul,
     Real.log_mul (cast_ne_zero.2 (pos_of_gt ha').ne') (cast_ne_zero.2 (pos_of_gt hb').ne')]
 
+-- access notation `ζ` and `μ`
+open scoped zeta Moebius
+
 @[simp]
 theorem vonMangoldt_mul_zeta : Λ * ζ = log := by
   ext n; rw [coe_mul_zeta_apply, vonMangoldt_sum]; rfl

--- a/Mathlib/RingTheory/Polynomial/Cyclotomic/Basic.lean
+++ b/Mathlib/RingTheory/Polynomial/Cyclotomic/Basic.lean
@@ -413,7 +413,8 @@ section ArithmeticFunction
 
 open ArithmeticFunction
 
-open scoped ArithmeticFunction
+-- access notation `μ`
+open scoped ArithmeticFunction.Moebius
 
 /-- `cyclotomic n R` can be expressed as a product in a fraction field of `R[X]`
   using Möbius inversion. -/

--- a/MathlibTest/ArithMult.lean
+++ b/MathlibTest/ArithMult.lean
@@ -9,6 +9,9 @@ import Mathlib.NumberTheory.ArithmeticFunction
 
 open ArithmeticFunction
 
+-- access notation `ζ`, `μ` and `σ`
+open scoped zeta Moebius sigma
+
 variable {R : Type*} [Field R]
 
 set_option linter.unusedVariables false


### PR DESCRIPTION
Right now, the notations `ζ`, `σ`, `ω`, `Ω` and `μ` for arithmetic functions exist in the scope `ArithmeticFunction` and in additional scopes `ArithmeticFunction.zeta` etc. This leads to an "ambiguous notation" error when both are open (even though both interpretations result in exactly the same term).

We fix this by removing the notations from `ArithmeticFunction`, only leaving the fine-grained per-function access.

(Cleaning up after myself here; I had introduced the duplication at some point. A better solution would be for Lean to check whether conflicting notations actually lead to the same result and in this case not give an error.)

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include at least one commit authored by each
co-author among the commits in the pull request. If necessary, you may 
create empty commits to indicate co-authorship, using commands like so:

git commit --author="Author Name <author@email.com>" --allow-empty -m "add Author Name as coauthor"

When merging, all the commits will be squashed into a single commit listing all co-authors.

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
