### PR TITLE
[Merged by Bors] - feat(Geometry/Euclidean/Incenter): touchpoints are not vertices

### DIFF
--- a/Mathlib/Geometry/Euclidean/Incenter.lean
+++ b/Mathlib/Geometry/Euclidean/Incenter.lean
@@ -719,6 +719,33 @@ lemma touchpointWeights_singleton_neg [Nat.AtLeastTwo n] {i j : Fin (n + 1)} (hn
     s.touchpointWeights {i} j i < 0 := by
   simpa [sign_eq_neg_one_iff] using s.sign_touchpointWeights_singleton_neg hne
 
+variable {s} in
+lemma ExcenterExists.touchpoint_ne_point [Nat.AtLeastTwo n] {signs : Finset (Fin (n + 1))}
+    (h : s.ExcenterExists signs) (i j : Fin (n + 1)) : s.touchpoint signs i ≠ s.points j := by
+  intro he
+  rw [eq_comm, ← Finset.univ.affineCombination_affineCombinationSingleWeights ℝ s.points
+    (Finset.mem_univ _), affineCombination_eq_touchpoint_iff
+    (Finset.univ.sum_affineCombinationSingleWeights ℝ (Finset.mem_univ _))] at he
+  have : 1 < n := Nat.AtLeastTwo.one_lt
+  obtain ⟨k, hki, hkj⟩ : ∃ k, k ≠ i ∧ k ≠ j := Fin.exists_ne_and_ne_of_two_lt i j (by cutsat)
+  have he' : Finset.affineCombinationSingleWeights ℝ j k = s.touchpointWeights signs i k := by
+    rw [he]
+  simp only [ne_eq, hkj, not_false_eq_true,
+    Finset.affineCombinationSingleWeights_apply_of_ne] at he'
+  rw [eq_comm] at he'
+  apply_fun SignType.sign at he'
+  rw [h.sign_touchpointWeights hki.symm, excenterWeights] at he'
+  have h' := h
+  rw [ExcenterExists] at h'
+  simp only [Pi.smul_apply, smul_eq_mul, sign_zero, sign_eq_zero_iff, mul_eq_zero, inv_eq_zero,
+    h', false_or] at he'
+  rw [excenterWeightsUnnorm] at he'
+  by_cases hk : k ∈ signs <;> simp [hk, (s.height_pos k).ne'] at he'
+
+lemma touchpoint_empty_ne_point [Nat.AtLeastTwo n] (i j : Fin (n + 1)) :
+    s.touchpoint ∅ i ≠ s.points j :=
+  s.excenterExists_empty.touchpoint_ne_point i j
+
 end Simplex
 
 namespace Triangle


### PR DESCRIPTION
Add lemmas that touchpoints of a simplex do not equal any of the vertices (in two or more dimensions, this isn't true for a 1-simplex).


---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include at least one commit authored by each
co-author among the commits in the pull request. If necessary, you may 
create empty commits to indicate co-authorship, using commands like so:

git commit --author="Author Name <author@email.com>" --allow-empty -m "add Author Name as coauthor"

When merging, all the commits will be squashed into a single commit listing all co-authors.

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
