### PR TITLE
[Merged by Bors] - chore: use `grw`, `gcongr` more

### DIFF
--- a/Archive/Imo/Imo2001Q3.lean
+++ b/Archive/Imo/Imo2001Q3.lean
@@ -87,8 +87,7 @@ lemma card_not_easy_le_210 (hG : ∀ i, #(G i) ≤ 6) (hB : ∀ i j, ¬Disjoint 
       exact Nat.le_of_lt_succ mp.2
     _ ≤ ∑ i : Fin 21, 5 * 2 := by
       gcongr with i
-      rw [sum_const, smul_eq_mul]
-      exact mul_le_mul_right' (card_not_easy_le_five (hG _) (hB _)) _
+      grw [sum_const, smul_eq_mul, card_not_easy_le_five (hG _) (hB _)]
     _ = _ := by norm_num
 
 theorem result (h : Condition G B) : ∃ p, Easy G p ∧ Easy B p := by

--- a/Mathlib/Algebra/AddConstMap/Basic.lean
+++ b/Mathlib/Algebra/AddConstMap/Basic.lean
@@ -257,7 +257,7 @@ protected theorem rel_map_of_Icc [AddCommGroup G] [LinearOrder G] [IsOrderedAddM
       calc
         y ≤ l + a + n • a := sub_le_iff_le_add.1 hny.2
         _ = l + (n + 1) • a := by rw [add_comm n, add_smul, one_smul, add_assoc]
-        _ ≤ l + 0 • a := add_le_add_left (zsmul_le_zsmul_left ha.le (by cutsat)) _
+        _ ≤ l + (0 : ℤ) • a := by gcongr; cutsat
         _ ≤ x := by simpa using hx.1
     · -- If `n = 0`, then `l < y ≤ l + a`, hence we can apply the assumption
       exact hf x (Ico_subset_Icc_self hx) y (by simpa using Ioc_subset_Icc_self hny) hxy

--- a/Mathlib/Algebra/AlgebraicCard.lean
+++ b/Mathlib/Algebra/AlgebraicCard.lean
@@ -52,8 +52,7 @@ theorem cardinalMk_lift_le_mul :
 
 theorem cardinalMk_lift_le_max :
     Cardinal.lift.{u} #{ x : A // IsAlgebraic R x } ≤ max (Cardinal.lift.{v} #R) ℵ₀ :=
-  (cardinalMk_lift_le_mul R A).trans <|
-    (mul_le_mul_right' (lift_le.2 cardinalMk_le_max) _).trans <| by simp
+  (cardinalMk_lift_le_mul R A).trans <| by grw [lift_le.2 cardinalMk_le_max]; simp
 
 @[simp]
 theorem cardinalMk_lift_of_infinite [Infinite R] :

--- a/Mathlib/Algebra/MonoidAlgebra/Degree.lean
+++ b/Mathlib/Algebra/MonoidAlgebra/Degree.lean
@@ -97,14 +97,15 @@ section AddOnly
 variable [Add A] [Add B] [Add T] [AddLeftMono B] [AddRightMono B]
   [AddLeftMono T] [AddRightMono T]
 
-theorem sup_support_mul_le {degb : A → B} (degbm : ∀ {a b}, degb (a + b) ≤ degb a + degb b)
+theorem sup_support_mul_le {degb : A → B} (degbm : ∀ a b, degb (a + b) ≤ degb a + degb b)
     (f g : R[A]) :
     (f * g).support.sup degb ≤ f.support.sup degb + g.support.sup degb := by
   classical
-  exact (Finset.sup_mono <| support_mul _ _).trans <| Finset.sup_add_le.2 fun _fd fds _gd gds ↦
-    degbm.trans <| add_le_add (Finset.le_sup fds) (Finset.le_sup gds)
+  grw [support_mul, Finset.sup_add_le]
+  rintro _fd fds _gd gds
+  grw [degbm, ← Finset.le_sup fds, ← Finset.le_sup gds]
 
-theorem le_inf_support_mul {degt : A → T} (degtm : ∀ {a b}, degt a + degt b ≤ degt (a + b))
+theorem le_inf_support_mul {degt : A → T} (degtm : ∀ a b, degt a + degt b ≤ degt (a + b))
     (f g : R[A]) :
     f.support.inf degt + g.support.inf degt ≤ (f * g).support.inf degt :=
   sup_support_mul_le (B := Tᵒᵈ) degtm f g
@@ -126,8 +127,7 @@ theorem sup_support_list_prod_le (degb0 : degb 0 ≤ 0)
     exact fun a ha => by rwa [Finset.mem_singleton.mp (Finsupp.support_single_subset ha)]
   | f::fs => by
     rw [List.prod_cons, List.map_cons, List.sum_cons]
-    exact (sup_support_mul_le (@fun a b => degbm a b) _ _).trans
-        (add_le_add_left (sup_support_list_prod_le degb0 degbm fs) _)
+    grw [sup_support_mul_le degbm, sup_support_list_prod_le degb0 degbm]
 
 theorem le_inf_support_list_prod (degt0 : 0 ≤ degt 0)
     (degtm : ∀ a b, degt a + degt b ≤ degt (a + b)) (l : List R[A]) :

--- a/Mathlib/Algebra/MvPolynomial/Degrees.lean
+++ b/Mathlib/Algebra/MvPolynomial/Degrees.lean
@@ -402,7 +402,7 @@ theorem totalDegree_add_eq_right_of_totalDegree_lt {p q : MvPolynomial σ R}
 
 theorem totalDegree_mul (a b : MvPolynomial σ R) :
     (a * b).totalDegree ≤ a.totalDegree + b.totalDegree :=
-  sup_support_mul_le (by exact (Finsupp.sum_add_index' (fun _ => rfl) (fun _ _ _ => rfl)).le) _ _
+  sup_support_mul_le (fun _ _ ↦ (Finsupp.sum_add_index' (fun _ => rfl) (fun _ _ _ => rfl)).le) _ _
 
 theorem totalDegree_smul_le [CommSemiring S] [DistribMulAction R S] (a : R) (f : MvPolynomial σ S) :
     (a • f).totalDegree ≤ f.totalDegree :=
@@ -434,8 +434,7 @@ theorem totalDegree_list_prod :
     ∀ s : List (MvPolynomial σ R), s.prod.totalDegree ≤ (s.map MvPolynomial.totalDegree).sum
   | [] => by rw [List.prod_nil, totalDegree_one, List.map_nil, List.sum_nil]
   | p::ps => by
-    rw [List.prod_cons, List.map, List.sum_cons]
-    exact le_trans (totalDegree_mul _ _) (add_le_add_left (totalDegree_list_prod ps) _)
+    grw [List.prod_cons, List.map, List.sum_cons, totalDegree_mul, totalDegree_list_prod]
 
 theorem totalDegree_multiset_prod (s : Multiset (MvPolynomial σ R)) :
     s.prod.totalDegree ≤ (s.map MvPolynomial.totalDegree).sum := by

--- a/Mathlib/Algebra/MvPolynomial/SchwartzZippel.lean
+++ b/Mathlib/Algebra/MvPolynomial/SchwartzZippel.lean
@@ -100,7 +100,7 @@ lemma schwartz_zippel_sup_sum :
         calc
           #{x ∈ S ^^ (n + 1) | eval x p = 0 ∧ eval (tail x) pₖ = 0} / ∏ i, (#(S i) : ℚ≥0)
             ≤ #{x ∈ S ^^ (n + 1) | eval (tail x) pₖ = 0} / ∏ i, (#(S i) : ℚ≥0) := by
-            gcongr; exact fun x hx ↦ hx.2
+            gcongr with x; exact And.right
           _ = #(S 0) * #{xₜ ∈ tail S ^^ n | eval xₜ pₖ = 0}
               / (#(S 0) * (∏ i, #(S (.succ i)) : ℚ≥0)) := by
             rw [card_consEquiv_filter_piFinset S fun x ↦ eval x pₖ = 0, prod_univ_succ, tail_def]

--- a/Mathlib/Algebra/Order/BigOperators/Group/Finset.lean
+++ b/Mathlib/Algebra/Order/BigOperators/Group/Finset.lean
@@ -352,18 +352,13 @@ theorem card_le_card_biUnion {s : Finset ι} {f : ι → Finset α} (hs : (s : S
 theorem card_le_card_biUnion_add_card_fiber {s : Finset ι} {f : ι → Finset α}
     (hs : (s : Set ι).PairwiseDisjoint f) : #s ≤ #(s.biUnion f) + #{i ∈ s | f i = ∅} := by
   rw [← Finset.filter_card_add_filter_neg_card_eq_card fun i ↦ f i = ∅, add_comm]
-  exact
-    add_le_add_right
-      ((card_le_card_biUnion (hs.subset <| filter_subset _ _) fun i hi ↦
-            nonempty_of_ne_empty <| (mem_filter.1 hi).2).trans <|
-        card_le_card <| biUnion_subset_biUnion_of_subset_left _ <| filter_subset _ _)
-      _
+  grw [card_le_card_biUnion (hs.subset <| filter_subset _ _) fun i hi ↦
+    nonempty_of_ne_empty (mem_filter.1 hi).2, filter_subset]
 
 theorem card_le_card_biUnion_add_one {s : Finset ι} {f : ι → Finset α} (hf : Injective f)
-    (hs : (s : Set ι).PairwiseDisjoint f) : #s ≤ #(s.biUnion f) + 1 :=
-  (card_le_card_biUnion_add_card_fiber hs).trans <|
-    add_le_add_left
-      (card_le_one.2 fun _ hi _ hj ↦ hf <| (mem_filter.1 hi).2.trans (mem_filter.1 hj).2.symm) _
+    (hs : (s : Set ι).PairwiseDisjoint f) : #s ≤ #(s.biUnion f) + 1 := by
+  grw [card_le_card_biUnion_add_card_fiber hs,
+    card_le_one.2 fun _ hi _ hj ↦ hf <| (mem_filter.1 hi).2.trans (mem_filter.1 hj).2.symm]
 
 end DoubleCounting
 

--- a/Mathlib/Algebra/Order/BigOperators/Group/List.lean
+++ b/Mathlib/Algebra/Order/BigOperators/Group/List.lean
@@ -45,7 +45,7 @@ lemma Sublist.prod_le_prod' [Preorder M] [MulRightMono M]
     exact (ih' h₁.2).trans (le_mul_of_one_le_left' h₁.1)
   | cons₂ a _ ih' =>
     simp only [prod_cons, forall_mem_cons] at h₁ ⊢
-    exact mul_le_mul_left' (ih' h₁.2) _
+    grw [ih' h₁.2]
 
 @[to_additive sum_le_sum]
 lemma SublistForall₂.prod_le_prod' [Preorder M]

--- a/Mathlib/Algebra/Order/BigOperators/Group/Multiset.lean
+++ b/Mathlib/Algebra/Order/BigOperators/Group/Multiset.lean
@@ -89,8 +89,8 @@ lemma le_prod_of_submultiplicative_on_pred (f : α → β)
   intro a s hs hpsa
   have hps : ∀ x, x ∈ s → p x := fun x hx => hpsa x (mem_cons_of_mem hx)
   have hp_prod : p s.prod := prod_induction p s hp_mul hp_one hps
-  rw [prod_cons, map_cons, prod_cons]
-  exact (h_mul a s.prod (hpsa a (mem_cons_self a s)) hp_prod).trans (mul_le_mul_left' (hs hps) _)
+  grw [prod_cons, map_cons, prod_cons, h_mul a s.prod (hpsa a (mem_cons_self a s)) hp_prod,
+    hs hps]
 
 @[to_additive le_sum_of_subadditive]
 lemma le_prod_of_submultiplicative (f : α → β) (h_one : f 1 = 1)
@@ -112,7 +112,7 @@ lemma le_prod_nonempty_of_submultiplicative_on_pred (f : α → β) (p : α → 
   have hsa_restrict : ∀ x, x ∈ s → p x := fun x hx => hsa_prop x (mem_cons_of_mem hx)
   have hp_sup : p s.prod := prod_induction_nonempty p hp_mul hs_empty hsa_restrict
   have hp_a : p a := hsa_prop a (mem_cons_self a s)
-  exact (h_mul a _ hp_a hp_sup).trans (mul_le_mul_left' (hs hs_empty hsa_restrict) _)
+  grw [h_mul a _ hp_a hp_sup, ← hs hs_empty hsa_restrict]
 
 @[to_additive le_sum_nonempty_of_subadditive]
 lemma le_prod_nonempty_of_submultiplicative (f : α → β) (h_mul : ∀ a b, f (a * b) ≤ f a * f b)

--- a/Mathlib/Algebra/Order/BigOperators/Ring/Finset.lean
+++ b/Mathlib/Algebra/Order/BigOperators/Ring/Finset.lean
@@ -166,8 +166,7 @@ lemma prod_add_prod_le' (hi : i ∈ s) (h2i : g i + h i ≤ f i) (hgf : ∀ j �
     (hhf : ∀ j ∈ s, j ≠ i → h j ≤ f j) : ((∏ i ∈ s, g i) + ∏ i ∈ s, h i) ≤ ∏ i ∈ s, f i := by
   classical
   simp_rw [prod_eq_mul_prod_diff_singleton hi]
-  refine le_trans ?_ (mul_le_mul_right' h2i _)
-  rw [right_distrib]
+  grw [← h2i, right_distrib]
   gcongr with j hj j hj <;> simp_all
 
 end CanonicallyOrderedAdd

--- a/Mathlib/Algebra/Order/CauSeq/BigOperators.lean
+++ b/Mathlib/Algebra/Order/CauSeq/BigOperators.lean
@@ -170,7 +170,7 @@ lemma of_decreasing_bounded (f : ℕ → α) {a : α} {m : ℕ} (ham : ∀ n ≥
         rhs
         rw [← Nat.succ_pred_eq_of_pos (Nat.pos_of_ne_zero hl0), succ_nsmul, sub_add,
           add_sub_cancel_right]
-    _ < f j + ε := add_lt_add_right (hl j (le_trans hi.1 hj)) _
+    _ < f j + ε := by gcongr; exact hl _ <| hi.1.trans hj
 
 lemma of_mono_bounded (f : ℕ → α) {a : α} {m : ℕ} (ham : ∀ n ≥ m, |f n| ≤ a)
     (hnm : ∀ n ≥ m, f n ≤ f n.succ) : IsCauSeq abs f :=

--- a/Mathlib/Algebra/Order/Field/Canonical.lean
+++ b/Mathlib/Algebra/Order/Field/Canonical.lean
@@ -22,7 +22,7 @@ abbrev CanonicallyOrderedAdd.toLinearOrderedCommGroupWithZero :
   bot := 0
   bot_le := zero_le
   zero_le_one := zero_le_one
-  mul_le_mul_left := fun _ _ h _ ↦ mul_le_mul_of_nonneg_left h <| zero_le _
+  mul_le_mul_left _ _ h _ := by grw [h]
 
 variable [IsStrictOrderedRing α] [Sub α] [OrderedSub α]
 

--- a/Mathlib/Algebra/Order/Group/Abs.lean
+++ b/Mathlib/Algebra/Order/Group/Abs.lean
@@ -185,8 +185,8 @@ theorem mabs_div_le_max_div {a b c : G} (hac : a ≤ b) (hcd : b ≤ c) (d : G) 
     exact le_max_of_le_right <| div_le_div_left' hac _
 
 @[to_additive]
-theorem mabs_mul_three (a b c : G) : |a * b * c|ₘ ≤ |a|ₘ * |b|ₘ * |c|ₘ :=
-  (mabs_mul_le _ _).trans (mul_le_mul_right' (mabs_mul_le _ _) _)
+theorem mabs_mul_three (a b c : G) : |a * b * c|ₘ ≤ |a|ₘ * |b|ₘ * |c|ₘ := by
+  grw [mabs_mul_le, mabs_mul_le]
 
 @[to_additive]
 theorem mabs_div_le_of_le_of_le {a b lb ub : G} (hal : lb ≤ a) (hau : a ≤ ub) (hbl : lb ≤ b)

--- a/Mathlib/Algebra/Order/Group/Finset.lean
+++ b/Mathlib/Algebra/Order/Group/Finset.lean
@@ -91,7 +91,7 @@ lemma sup'_add' (s : Finset ι) (f : ι → M) (a : M) (hs : s.Nonempty) :
   · apply add_le_of_le_tsub_right_of_le
     · exact Finset.le_sup'_of_le _ hs.choose_spec le_add_self
     · exact Finset.sup'_le _ _ fun i hi ↦ le_tsub_of_add_le_right (Finset.le_sup' (f · + a) hi)
-  · exact Finset.sup'_le _ _ fun i hi ↦ add_le_add_right (Finset.le_sup' _ hi) _
+  · exact Finset.sup'_le _ _ fun i hi ↦ by grw [← Finset.le_sup' _ hi]
 
 /-- Also see `Finset.add_sup'` that works for ordered groups. -/
 lemma add_sup'' (hs : s.Nonempty) (f : ι → M) (a : M) :

--- a/Mathlib/Algebra/Order/Group/Int/Sum.lean
+++ b/Mathlib/Algebra/Order/Group/Int/Sum.lean
@@ -56,15 +56,13 @@ lemma sum_Ico_le_sum {s : Finset ℤ} {c : ℤ} (hs : ∀ x ∈ s, c ≤ x) :
   set r := Ico c (c + #s)
   calc
     _ ≤ ∑ x ∈ r ∩ s, x + #(r \ s) • (c + #s) := by
-      rw [← sum_inter_add_sum_diff r s _]
-      refine add_le_add_left (sum_le_card_nsmul _ _ _ fun x mx ↦ ?_) _
+      grw [← sum_inter_add_sum_diff r s, ← sum_le_card_nsmul _ _ _ fun x mx ↦ ?_]
       rw [mem_sdiff, mem_Ico] at mx; exact mx.1.2.le
     _ = ∑ x ∈ s ∩ r, x + #(s \ r) • (c + #s) := by
       rw [inter_comm, card_sdiff_comm]
       rw [Int.card_Ico, add_sub_cancel_left, Int.toNat_natCast]
     _ ≤ _ := by
-      rw [← sum_inter_add_sum_diff s r _]
-      refine add_le_add_left (card_nsmul_le_sum _ _ _ fun x mx ↦ ?_) _
+      grw [← sum_inter_add_sum_diff s r, card_nsmul_le_sum _ _ _ fun x mx ↦ ?_]
       rw [mem_sdiff, mem_Ico, not_and] at mx
       have := mx.2 (hs _ mx.1); omega
 

--- a/Mathlib/Algebra/Order/Group/Pointwise/Interval.lean
+++ b/Mathlib/Algebra/Order/Group/Pointwise/Interval.lean
@@ -127,7 +127,8 @@ lemma smul_Icc (a b c : α) : a • Icc b c = Icc (a * b) (a * c) := by
   ext x
   constructor
   · rintro ⟨y, ⟨hby, hyc⟩, rfl⟩
-    exact ⟨mul_le_mul_left' hby _, mul_le_mul_left' hyc _⟩
+    dsimp
+    constructor <;> gcongr
   · rintro ⟨habx, hxac⟩
     obtain ⟨y, hy, rfl⟩ := exists_one_le_mul_of_le habx
     refine ⟨b * y, ⟨le_mul_of_one_le_right' hy, ?_⟩, (mul_assoc ..).symm⟩

--- a/Mathlib/Algebra/Order/Group/Unbundled/Abs.lean
+++ b/Mathlib/Algebra/Order/Group/Unbundled/Abs.lean
@@ -239,7 +239,7 @@ variable [MulLeftMono α] {a b : α}
   · simp [mabs_of_le_one h]
 
 @[to_additive add_abs_nonneg] lemma one_le_mul_mabs (a : α) : 1 ≤ a * |a|ₘ := by
-  rw [← mul_inv_cancel a]; exact mul_le_mul_left' (inv_le_mabs a) _
+  grw [← mul_inv_cancel a, inv_le_mabs a]
 
 @[to_additive] lemma inv_mabs_le_inv (a : α) : |a|ₘ⁻¹ ≤ a⁻¹ := by simpa using inv_mabs_le a⁻¹
 

--- a/Mathlib/Algebra/Order/GroupWithZero/WithZero.lean
+++ b/Mathlib/Algebra/Order/GroupWithZero/WithZero.lean
@@ -36,7 +36,7 @@ instance {α : Type*} [Mul α] [Preorder α] [MulLeftStrictMono α] :
     | ⟨(x : α), hx⟩, (a : α), (b : α), h => by
         dsimp only at h ⊢
         norm_cast at h ⊢
-        exact mul_lt_mul_left' h x
+        gcongr
 
 open Function in
 instance {α : Type*} [Mul α] [Preorder α] [MulRightStrictMono α] :
@@ -47,7 +47,7 @@ instance {α : Type*} [Mul α] [Preorder α] [MulRightStrictMono α] :
     | ⟨(x : α), hx⟩, (a : α), (b : α), h => by
         dsimp only at h ⊢
         norm_cast at h ⊢
-        exact mul_lt_mul_right' h x
+        gcongr
 
 instance {α : Type*} [Mul α] [Preorder α] [MulLeftMono α] :
     PosMulMono (WithZero α) where
@@ -61,7 +61,7 @@ instance {α : Type*} [Mul α] [Preorder α] [MulLeftMono α] :
     | ⟨(x : α), hx⟩, (a : α), (b : α), h => by
         dsimp only at h ⊢
         norm_cast at h ⊢
-        exact mul_le_mul_left' h x
+        gcongr
 
 -- This makes `lt_mul_of_le_of_one_lt'` work on `ℤᵐ⁰`
 open Function in
@@ -77,7 +77,7 @@ instance {α : Type*} [Mul α] [Preorder α] [MulRightMono α] :
     | ⟨(x : α), hx⟩, (a : α), (b : α), h => by
         dsimp only at h ⊢
         norm_cast at h ⊢
-        exact mul_le_mul_right' h x
+        gcongr
 
 section Units
 

--- a/Mathlib/Algebra/Order/Interval/Set/Monoid.lean
+++ b/Mathlib/Algebra/Order/Interval/Set/Monoid.lean
@@ -25,43 +25,32 @@ variable {M : Type*} [AddCommMonoid M] [PartialOrder M] [IsOrderedCancelAddMonoi
   [ExistsAddOfLE M] (a b c d : M)
 
 theorem Ici_add_bij : BijOn (· + d) (Ici a) (Ici (a + d)) := by
-  refine
-    ⟨fun x h => add_le_add_right (mem_Ici.mp h) _, (add_left_injective d).injOn, fun _ h => ?_⟩
+  refine ⟨by simp [MapsTo], by simp, fun _ h => ?_⟩
   obtain ⟨c, rfl⟩ := exists_add_of_le (mem_Ici.mp h)
   rw [mem_Ici, add_right_comm, add_le_add_iff_right] at h
   exact ⟨a + c, h, by rw [add_right_comm]⟩
 
 theorem Ioi_add_bij : BijOn (· + d) (Ioi a) (Ioi (a + d)) := by
-  refine
-    ⟨fun x h => add_lt_add_right (mem_Ioi.mp h) _, fun _ _ _ _ h => add_right_cancel h, fun _ h =>
-      ?_⟩
+  refine ⟨by simp [MapsTo], by simp, fun _ h => ?_⟩
   obtain ⟨c, rfl⟩ := exists_add_of_le (mem_Ioi.mp h).le
   rw [mem_Ioi, add_right_comm, add_lt_add_iff_right] at h
   exact ⟨a + c, h, by rw [add_right_comm]⟩
 
 theorem Icc_add_bij : BijOn (· + d) (Icc a b) (Icc (a + d) (b + d)) := by
   rw [← Ici_inter_Iic, ← Ici_inter_Iic]
-  exact
-    (Ici_add_bij a d).inter_mapsTo (fun x hx => add_le_add_right hx _) fun x hx =>
-      le_of_add_le_add_right hx.2
+  exact (Ici_add_bij a d).inter_mapsTo (by simp [MapsTo]) fun x hx => le_of_add_le_add_right hx.2
 
 theorem Ioo_add_bij : BijOn (· + d) (Ioo a b) (Ioo (a + d) (b + d)) := by
   rw [← Ioi_inter_Iio, ← Ioi_inter_Iio]
-  exact
-    (Ioi_add_bij a d).inter_mapsTo (fun x hx => add_lt_add_right hx _) fun x hx =>
-      lt_of_add_lt_add_right hx.2
+  exact (Ioi_add_bij a d).inter_mapsTo (by simp [MapsTo]) fun x hx => lt_of_add_lt_add_right hx.2
 
 theorem Ioc_add_bij : BijOn (· + d) (Ioc a b) (Ioc (a + d) (b + d)) := by
   rw [← Ioi_inter_Iic, ← Ioi_inter_Iic]
-  exact
-    (Ioi_add_bij a d).inter_mapsTo (fun x hx => add_le_add_right hx _) fun x hx =>
-      le_of_add_le_add_right hx.2
+  exact (Ioi_add_bij a d).inter_mapsTo (by simp [MapsTo]) fun x hx => le_of_add_le_add_right hx.2
 
 theorem Ico_add_bij : BijOn (· + d) (Ico a b) (Ico (a + d) (b + d)) := by
   rw [← Ici_inter_Iio, ← Ici_inter_Iio]
-  exact
-    (Ici_add_bij a d).inter_mapsTo (fun x hx => add_lt_add_right hx _) fun x hx =>
-      lt_of_add_lt_add_right hx.2
+  exact (Ici_add_bij a d).inter_mapsTo (by simp [MapsTo]) fun x hx => lt_of_add_lt_add_right hx.2
 
 /-!
 ### Images under `x ↦ x + a`

--- a/Mathlib/Algebra/Order/Kleene.lean
+++ b/Mathlib/Algebra/Order/Kleene.lean
@@ -198,11 +198,9 @@ theorem mul_kstar_le_self : b * a ≤ b → b * a∗ ≤ b :=
 theorem kstar_mul_le_self : a * b ≤ b → a∗ * b ≤ b :=
   KleeneAlgebra.kstar_mul_le_self _ _
 
-theorem mul_kstar_le (hb : b ≤ c) (ha : c * a ≤ c) : b * a∗ ≤ c :=
-  (mul_le_mul_right' hb _).trans <| mul_kstar_le_self ha
+theorem mul_kstar_le (hb : b ≤ c) (ha : c * a ≤ c) : b * a∗ ≤ c := by grw [hb, mul_kstar_le_self ha]
 
-theorem kstar_mul_le (hb : b ≤ c) (ha : a * c ≤ c) : a∗ * b ≤ c :=
-  (mul_le_mul_left' hb _).trans <| kstar_mul_le_self ha
+theorem kstar_mul_le (hb : b ≤ c) (ha : a * c ≤ c) : a∗ * b ≤ c := by grw [hb, kstar_mul_le_self ha]
 
 theorem kstar_le_of_mul_le_left (hb : 1 ≤ b) : b * a ≤ b → a∗ ≤ b := by
   simpa using mul_kstar_le hb
@@ -246,9 +244,7 @@ theorem kstar_idem (a : α) : a∗∗ = a∗ :=
 @[simp]
 theorem pow_le_kstar : ∀ {n : ℕ}, a ^ n ≤ a∗
   | 0 => (pow_zero _).trans_le one_le_kstar
-  | n + 1 => by
-    rw [pow_succ']
-    exact (mul_le_mul_left' pow_le_kstar _).trans mul_kstar_le_kstar
+  | n + 1 => by grw [pow_succ', pow_le_kstar, mul_kstar_le_kstar]
 
 end KleeneAlgebra
 

--- a/Mathlib/Algebra/Order/Monoid/Basic.lean
+++ b/Mathlib/Algebra/Order/Monoid/Basic.lean
@@ -25,8 +25,7 @@ lemma Function.Injective.isOrderedMonoid [IsOrderedMonoid α] [CommMonoid β]
     [PartialOrder β] (f : β → α) (mul : ∀ x y, f (x * y) = f x * f y)
     (le : ∀ {x y}, f x ≤ f y ↔ x ≤ y) :
     IsOrderedMonoid β where
-  mul_le_mul_left a b ab c := le.1 <| by
-      rw [mul, mul]; apply mul_le_mul_left'; exact le.2 ab
+  mul_le_mul_left a b ab c := le.1 <| by rw [mul, mul]; grw [le.2 ab]
 
 /-- Pullback an `IsOrderedMonoid` under a strictly monotone map. -/
 @[to_additive /-- Pullback an `IsOrderedAddMonoid` under a strictly monotone map. -/]
@@ -89,7 +88,7 @@ See also `OrderIso.mulLeft` when working in an ordered group. -/
        See also `OrderIso.addLeft` when working in an additive ordered group. -/]
 def OrderEmbedding.mulLeft {α : Type*} [Mul α] [LinearOrder α]
     [MulLeftStrictMono α] (m : α) : α ↪o α :=
-  OrderEmbedding.ofStrictMono (fun n => m * n) fun _ _ w => mul_lt_mul_left' w m
+  OrderEmbedding.ofStrictMono (fun n => m * n) mul_right_strictMono
 
 /-- The order embedding sending `b` to `b * a`, for some fixed `a`.
 See also `OrderIso.mulRight` when working in an ordered group. -/
@@ -98,4 +97,4 @@ See also `OrderIso.mulRight` when working in an ordered group. -/
        See also `OrderIso.addRight` when working in an additive ordered group. -/]
 def OrderEmbedding.mulRight {α : Type*} [Mul α] [LinearOrder α]
     [MulRightStrictMono α] (m : α) : α ↪o α :=
-  OrderEmbedding.ofStrictMono (fun n => n * m) fun _ _ w => mul_lt_mul_right' w m
+  OrderEmbedding.ofStrictMono (fun n => n * m) mul_left_strictMono

--- a/Mathlib/Algebra/Order/Monoid/NatCast.lean
+++ b/Mathlib/Algebra/Order/Monoid/NatCast.lean
@@ -43,13 +43,13 @@ lemma zero_le_four [Preorder α] [ZeroLEOneClass α] [AddLeftMono α] :
 lemma one_le_two [LE α] [ZeroLEOneClass α] [AddLeftMono α] :
     (1 : α) ≤ 2 :=
   calc (1 : α) = 1 + 0 := (add_zero 1).symm
-     _ ≤ 1 + 1 := add_le_add_left zero_le_one _
+     _ ≤ 1 + 1 := by gcongr; exact zero_le_one
      _ = 2 := one_add_one_eq_two
 
 lemma one_le_two' [LE α] [ZeroLEOneClass α] [AddRightMono α] :
     (1 : α) ≤ 2 :=
   calc (1 : α) = 0 + 1 := (zero_add 1).symm
-     _ ≤ 1 + 1 := add_le_add_right zero_le_one _
+     _ ≤ 1 + 1 := by gcongr; exact zero_le_one
      _ = 2 := one_add_one_eq_two
 
 section

--- a/Mathlib/Algebra/Order/Monoid/Unbundled/Basic.lean
+++ b/Mathlib/Algebra/Order/Monoid/Unbundled/Basic.lean
@@ -208,8 +208,7 @@ theorem Right.mul_lt_mul [MulLeftMono α]
 @[to_additive (attr := gcongr high) add_le_add]
 theorem mul_le_mul' [MulLeftMono α] [MulRightMono α]
     {a b c d : α} (h₁ : a ≤ b) (h₂ : c ≤ d) :
-    a * c ≤ b * d :=
-  (mul_le_mul_left' h₂ _).trans (mul_le_mul_right' h₁ d)
+    a * c ≤ b * d := by grw [h₁, h₂]
 
 @[to_additive]
 theorem mul_le_mul_three [MulLeftMono α]

--- a/Mathlib/Algebra/Order/Monoid/Unbundled/Pow.lean
+++ b/Mathlib/Algebra/Order/Monoid/Unbundled/Pow.lean
@@ -120,9 +120,9 @@ lemma pow_le_pow_mul_of_sq_le_mul [MulLeftMono M] {a b : M} (hab : a ^ 2 ≤ b *
   | n + 2, _ => by
     calc
       a ^ (n + 2) = a ^ (n + 1) * a := by rw [pow_succ]
-      _ ≤ b ^ n * a * a := mul_le_mul_right' (pow_le_pow_mul_of_sq_le_mul hab (by cutsat)) _
+      _ ≤ b ^ n * a * a := by grw [pow_le_pow_mul_of_sq_le_mul hab (by cutsat)]; simp
       _ = b ^ n * a ^ 2 := by rw [mul_assoc, sq]
-      _ ≤ b ^ n * (b * a) := mul_le_mul_left' hab _
+      _ ≤ b ^ n * (b * a) := by grw [hab]
       _ = b ^ (n + 1) * a := by rw [← mul_assoc, ← pow_succ]
 
 end Right

--- a/Mathlib/Algebra/Order/Monoid/Unbundled/WithTop.lean
+++ b/Mathlib/Algebra/Order/Monoid/Unbundled/WithTop.lean
@@ -128,11 +128,11 @@ lemma add_left_cancel [IsLeftCancelAdd α] (hx : x ≠ ⊤) (h : x + y = x + z) 
 
 instance addLeftMono [LE α] [AddLeftMono α] : AddLeftMono (WithTop α) where
   elim x y z := by
-    cases x <;> cases y <;> cases z <;> simp [← coe_add]; simpa using (add_le_add_left · _)
+    cases x <;> cases y <;> cases z <;> simp [← coe_add]; simpa using fun _ ↦ by gcongr
 
 instance addRightMono [LE α] [AddRightMono α] : AddRightMono (WithTop α) where
   elim x y z := by
-    cases x <;> cases y <;> cases z <;> simp [← coe_add, swap]; simpa using (add_le_add_right · _)
+    cases x <;> cases y <;> cases z <;> simp [← coe_add, swap]; simpa using fun _ ↦ by gcongr
 
 instance addLeftReflectLT [LT α] [AddLeftReflectLT α] : AddLeftReflectLT (WithTop α) where
   elim x y z := by
@@ -152,17 +152,17 @@ protected lemma le_of_add_le_add_right [LE α] [AddRightReflectLE α] (hz : z �
 
 protected lemma add_lt_add_left [LT α] [AddLeftStrictMono α] (hx : x ≠ ⊤) :
     y < z → x + y < x + z := by
-  lift x to α using hx; cases y <;> cases z <;> simp [← coe_add]; simpa using (add_lt_add_left · _)
+  lift x to α using hx; cases y <;> cases z <;> simp [← coe_add]; simpa using fun _ ↦ by gcongr
 
 protected lemma add_lt_add_right [LT α] [AddRightStrictMono α] (hz : z ≠ ⊤) :
     x < y → x + z < y + z := by
-  lift z to α using hz; cases x <;> cases y <;> simp [← coe_add]; simpa using (add_lt_add_right · _)
+  lift z to α using hz; cases x <;> cases y <;> simp [← coe_add]; simpa using fun _ ↦ by gcongr
 
 protected lemma add_le_add_iff_left [LE α] [AddLeftMono α] [AddLeftReflectLE α] (hx : x ≠ ⊤) :
-    x + y ≤ x + z ↔ y ≤ z := ⟨WithTop.le_of_add_le_add_left hx, (add_le_add_left · _)⟩
+    x + y ≤ x + z ↔ y ≤ z := ⟨WithTop.le_of_add_le_add_left hx, fun _ ↦ by gcongr⟩
 
 protected lemma add_le_add_iff_right [LE α] [AddRightMono α] [AddRightReflectLE α] (hz : z ≠ ⊤) :
-    x + z ≤ y + z ↔ x ≤ y := ⟨WithTop.le_of_add_le_add_right hz, (add_le_add_right · _)⟩
+    x + z ≤ y + z ↔ x ≤ y := ⟨WithTop.le_of_add_le_add_right hz, fun _ ↦ by gcongr⟩
 
 protected lemma add_lt_add_iff_left [LT α] [AddLeftStrictMono α] [AddLeftReflectLT α] (hx : x ≠ ⊤) :
     x + y < x + z ↔ y < z := ⟨lt_of_add_lt_add_left, WithTop.add_lt_add_left hx⟩
@@ -173,12 +173,12 @@ protected lemma add_lt_add_iff_right [LT α] [AddRightStrictMono α] [AddRightRe
 protected theorem add_lt_add_of_le_of_lt [Preorder α] [AddLeftStrictMono α]
     [AddRightMono α] (hw : w ≠ ⊤) (hwy : w ≤ y) (hxz : x < z) :
     w + x < y + z :=
-  (WithTop.add_lt_add_left hw hxz).trans_le <| add_le_add_right hwy _
+  (WithTop.add_lt_add_left hw hxz).trans_le <| by gcongr
 
 protected theorem add_lt_add_of_lt_of_le [Preorder α] [AddLeftMono α]
     [AddRightStrictMono α] (hx : x ≠ ⊤) (hwy : w < y) (hxz : x ≤ z) :
     w + x < y + z :=
-  (WithTop.add_lt_add_right hx hwy).trans_le <| add_le_add_left hxz _
+  (WithTop.add_lt_add_right hx hwy).trans_le <| by gcongr
 
 lemma addLECancellable_of_ne_top [LE α] [AddLeftReflectLE α]
     (hx : x ≠ ⊤) : AddLECancellable x := fun _b _c ↦ WithTop.le_of_add_le_add_left hx
@@ -460,11 +460,11 @@ lemma add_left_cancel [IsLeftCancelAdd α] (hx : x ≠ ⊥) (h : x + y = x + z) 
 
 instance addLeftMono [LE α] [AddLeftMono α] : AddLeftMono (WithBot α) where
   elim x y z := by
-    cases x <;> cases y <;> cases z <;> simp [← coe_add]; simpa using (add_le_add_left · _)
+    cases x <;> cases y <;> cases z <;> simp [← coe_add]; simpa using fun _ ↦ by gcongr
 
 instance addRightMono [LE α] [AddRightMono α] : AddRightMono (WithBot α) where
   elim x y z := by
-    cases x <;> cases y <;> cases z <;> simp [← coe_add, swap]; simpa using (add_le_add_right · _)
+    cases x <;> cases y <;> cases z <;> simp [← coe_add, swap]; simpa using fun _ ↦ by gcongr
 
 instance addLeftReflectLT [LT α] [AddLeftReflectLT α] : AddLeftReflectLT (WithBot α) where
   elim x y z := by
@@ -484,17 +484,17 @@ protected lemma le_of_add_le_add_right [LE α] [AddRightReflectLE α] (hz : z �
 
 protected lemma add_lt_add_left [LT α] [AddLeftStrictMono α] (hx : x ≠ ⊥) :
     y < z → x + y < x + z := by
-  lift x to α using hx; cases y <;> cases z <;> simp [← coe_add]; simpa using (add_lt_add_left · _)
+  lift x to α using hx; cases y <;> cases z <;> simp [← coe_add]; simpa using fun _ ↦ by gcongr
 
 protected lemma add_lt_add_right [LT α] [AddRightStrictMono α] (hz : z ≠ ⊥) :
     x < y → x + z < y + z := by
-  lift z to α using hz; cases x <;> cases y <;> simp [← coe_add]; simpa using (add_lt_add_right · _)
+  lift z to α using hz; cases x <;> cases y <;> simp [← coe_add]; simpa using fun _ ↦ by gcongr
 
 protected lemma add_le_add_iff_left [LE α] [AddLeftMono α] [AddLeftReflectLE α] (hx : x ≠ ⊥) :
-    x + y ≤ x + z ↔ y ≤ z := ⟨WithBot.le_of_add_le_add_left hx, (add_le_add_left · _)⟩
+    x + y ≤ x + z ↔ y ≤ z := ⟨WithBot.le_of_add_le_add_left hx, fun _ ↦ by gcongr⟩
 
 protected lemma add_le_add_iff_right [LE α] [AddRightMono α] [AddRightReflectLE α] (hz : z ≠ ⊥) :
-    x + z ≤ y + z ↔ x ≤ y := ⟨WithBot.le_of_add_le_add_right hz, (add_le_add_right · _)⟩
+    x + z ≤ y + z ↔ x ≤ y := ⟨WithBot.le_of_add_le_add_right hz, fun _ ↦ by gcongr⟩
 
 protected lemma add_lt_add_iff_left [LT α] [AddLeftStrictMono α] [AddLeftReflectLT α] (hx : x ≠ ⊥) :
     x + y < x + z ↔ y < z := ⟨lt_of_add_lt_add_left, WithBot.add_lt_add_left hx⟩
@@ -505,12 +505,12 @@ protected lemma add_lt_add_iff_right [LT α] [AddRightStrictMono α] [AddRightRe
 protected theorem add_lt_add_of_le_of_lt [Preorder α] [AddLeftStrictMono α]
     [AddRightMono α] (hw : w ≠ ⊥) (hwy : w ≤ y) (hxz : x < z) :
     w + x < y + z :=
-  (WithBot.add_lt_add_left hw hxz).trans_le <| add_le_add_right hwy _
+  (WithBot.add_lt_add_left hw hxz).trans_le <| by gcongr
 
 protected theorem add_lt_add_of_lt_of_le [Preorder α] [AddLeftMono α]
     [AddRightStrictMono α] (hx : x ≠ ⊥) (hwy : w < y) (hxz : x ≤ z) :
     w + x < y + z :=
-  (WithBot.add_lt_add_right hx hwy).trans_le <| add_le_add_left hxz _
+  (WithBot.add_lt_add_right hx hwy).trans_le <| by gcongr
 
 lemma addLECancellable_of_ne_bot [LE α] [AddLeftReflectLE α]
     (hx : x ≠ ⊥) : AddLECancellable x := fun _b _c ↦ WithBot.le_of_add_le_add_left hx

--- a/Mathlib/Algebra/Order/Quantale.lean
+++ b/Mathlib/Algebra/Order/Quantale.lean
@@ -176,7 +176,7 @@ instance : MulRightMono α where
 @[to_additive]
 theorem leftMulResiduation_le_iff_mul_le : x ≤ y ⇨ₗ z ↔ x * y ≤ z where
   mp h1 := by
-    apply le_trans (mul_le_mul_right' h1 _)
+    grw [h1]
     simp_all only [leftMulResiduation, sSup_mul_distrib, Set.mem_setOf_eq,
       iSup_le_iff, implies_true]
   mpr h1 := le_sSup h1
@@ -184,7 +184,7 @@ theorem leftMulResiduation_le_iff_mul_le : x ≤ y ⇨ₗ z ↔ x * y ≤ z wher
 @[to_additive]
 theorem rightMulResiduation_le_iff_mul_le : x ≤ y ⇨ᵣ z ↔ y * x ≤ z where
   mp h1 := by
-    apply le_trans (mul_le_mul_left' h1 _)
+    grw [h1]
     simp_all only [rightMulResiduation, mul_sSup_distrib, Set.mem_setOf_eq,
       iSup_le_iff, implies_true]
   mpr h1 := le_sSup h1

--- a/Mathlib/Algebra/Order/Ring/Basic.lean
+++ b/Mathlib/Algebra/Order/Ring/Basic.lean
@@ -138,12 +138,13 @@ lemma add_pow_le (ha : 0 ≤ a) (hb : 0 ≤ b) : ∀ n, (a + b) ^ n ≤ 2 ^ (n -
       _ = 2 ^ n * (a ^ (n + 2) + b ^ (n + 2) + (a ^ (n + 1) * b + b ^ (n + 1) * a)) := by
           rw [mul_assoc, mul_add, add_mul, add_mul, ← pow_succ, ← pow_succ, add_comm _ (b ^ _),
             add_add_add_comm, add_comm (_ * a)]
-      _ ≤ 2 ^ n * (a ^ (n + 2) + b ^ (n + 2) + (a ^ (n + 1) * a + b ^ (n + 1) * b)) :=
-          mul_le_mul_of_nonneg_left (add_le_add_left ?_ _) <| pow_nonneg (zero_le_two (α := R)) _
+      _ ≤ 2 ^ n * (a ^ (n + 2) + b ^ (n + 2) + (a ^ (n + 1) * a + b ^ (n + 1) * b)) := by
+        gcongr _ * (_ + _ + ?_)
+        · exact pow_nonneg zero_le_two _
+        obtain hab | hba := le_total a b
+        · exact mul_add_mul_le_mul_add_mul (by gcongr; exact ha) hab
+        · exact mul_add_mul_le_mul_add_mul' (by gcongr; exact hb) hba
       _ = _ := by simp only [← pow_succ, ← two_mul, ← mul_assoc]; rfl
-    · obtain hab | hba := le_total a b
-      · exact mul_add_mul_le_mul_add_mul (pow_le_pow_left₀ ha hab _) hab
-      · exact mul_add_mul_le_mul_add_mul' (pow_le_pow_left₀ hb hba _) hba
 
 protected lemma Even.add_pow_le (hn : Even n) :
     (a + b) ^ n ≤ 2 ^ (n - 1) * (a ^ n + b ^ n) := by

--- a/Mathlib/Algebra/Order/Ring/GeomSum.lean
+++ b/Mathlib/Algebra/Order/Ring/GeomSum.lean
@@ -45,11 +45,11 @@ lemma geom_sum_alternating_of_le_neg_one (hx : x + 1 ≤ 0) (n : ℕ) :
   | zero => simp only [range_zero, sum_empty, le_refl, ite_true, Even.zero]
   | succ n ih =>
     simp only [Nat.even_add_one, geom_sum_succ]
-    split_ifs at ih with h
-    · rw [if_neg (not_not_intro h), le_add_iff_nonneg_left]
+    split_ifs at ih ⊢ with h
+    · rw [le_add_iff_nonneg_left]
       exact mul_nonneg_of_nonpos_of_nonpos hx0 ih
-    · rw [if_pos h]
-      refine (add_le_add_right ?_ _).trans hx
+    · grw [← hx]
+      gcongr
       simpa only [mul_one] using mul_le_mul_of_nonpos_left ih hx0
 
 end IsOrderedRing
@@ -77,18 +77,12 @@ lemma geom_sum_alternating_of_lt_neg_one (hx : x + 1 < 0) (hn : 1 < n) :
   clear hn
   intro n _ ihn
   simp only [Nat.even_add_one, geom_sum_succ]
-  by_cases hn' : Even n
-  · rw [if_pos hn'] at ihn
-    rw [if_neg, lt_add_iff_pos_left]
-    · exact mul_pos_of_neg_of_neg hx0 ihn
-    · exact not_not_intro hn'
-  · rw [if_neg hn'] at ihn
-    rw [if_pos]
-    swap
-    · exact hn'
-    have := add_lt_add_right (mul_lt_mul_of_neg_left ihn hx0) 1
-    rw [mul_one] at this
-    exact this.trans hx
+  split_ifs at ihn ⊢ with hn'
+  · rw [lt_add_iff_pos_left]
+    exact mul_pos_of_neg_of_neg hx0 ihn
+  · grw [← hx]
+    gcongr
+    simpa only [mul_one] using mul_lt_mul_of_neg_left ihn hx0
 
 end IsStrictOrderedRing
 end PartialOrder

--- a/Mathlib/Algebra/Order/Ring/Unbundled/Basic.lean
+++ b/Mathlib/Algebra/Order/Ring/Unbundled/Basic.lean
@@ -454,7 +454,7 @@ theorem add_le_mul_of_left_le_right [ZeroLEOneClass R] [NeZero (1 : R)]
       _ ≤ a := a2
       _ ≤ b := ab
   calc
-    a + b ≤ b + b := add_le_add_right ab b
+    a + b ≤ b + b := by gcongr
     _ = 2 * b := (two_mul b).symm
     _ ≤ a * b := (mul_le_mul_iff_left₀ this).mpr a2
 
@@ -467,7 +467,7 @@ theorem add_le_mul_of_right_le_left [ZeroLEOneClass R] [NeZero (1 : R)]
       _ ≤ b := b2
       _ ≤ a := ba
   calc
-    a + b ≤ a + a := add_le_add_left ba a
+    a + b ≤ a + a := by gcongr
     _ = a * 2 := (mul_two a).symm
     _ ≤ a * b := (mul_le_mul_iff_right₀ this).mpr b2
 
@@ -687,8 +687,7 @@ lemma sq_nonneg [ExistsAddOfLE R] [PosMulMono R] [AddLeftMono R]
   obtain ha | ha := le_or_gt 0 a
   · exact pow_succ_nonneg ha _
   obtain ⟨b, hab⟩ := exists_add_of_le ha.le
-  have hb : 0 < b := not_le.1 fun hb ↦
-    ((add_le_add_left hb a).trans_lt ((add_zero a).trans_lt ha)).ne' hab
+  have hb : 0 < b := not_le.1 fun hb ↦ (add_neg_of_neg_of_nonpos ha hb).ne' hab
   calc
     0 ≤ b ^ 2 := pow_succ_nonneg hb.le _
     _ = b ^ 2 + a * (a + b) := by rw [← hab, mul_zero, add_zero]

--- a/Mathlib/Algebra/Order/Star/Basic.lean
+++ b/Mathlib/Algebra/Order/Star/Basic.lean
@@ -213,7 +213,7 @@ theorem conjugate_nonneg {a : R} (ha : 0 ≤ a) (c : R) : 0 ≤ star c * a * c :
     rw [star_mul, ← mul_assoc, mul_assoc _ _ c]
   · calc
       0 ≤ star c * x * c + 0 := by rw [add_zero]; exact hx
-      _ ≤ star c * x * c + star c * y * c := add_le_add_left hy _
+      _ ≤ star c * x * c + star c * y * c := by gcongr
       _ ≤ _ := by rw [mul_add, add_mul]
 
 @[aesop safe apply]

--- a/Mathlib/Algebra/Order/Sub/Defs.lean
+++ b/Mathlib/Algebra/Order/Sub/Defs.lean
@@ -108,7 +108,7 @@ section Cov
 variable [AddLeftMono α]
 
 theorem tsub_le_tsub_left (h : a ≤ b) (c : α) : c - b ≤ c - a :=
-  tsub_le_iff_left.mpr <| le_add_tsub.trans <| add_le_add_right h _
+  tsub_le_iff_left.mpr <| le_add_tsub.trans <| by gcongr
 
 @[gcongr] theorem tsub_le_tsub (hab : a ≤ b) (hcd : c ≤ d) : a - d ≤ b - c :=
   (tsub_le_tsub_right hab _).trans <| tsub_le_tsub_left hcd _
@@ -117,35 +117,30 @@ theorem antitone_const_tsub : Antitone fun x => c - x := fun _ _ hxy => tsub_le_
 
 /-- See `add_tsub_assoc_of_le` for the equality. -/
 theorem add_tsub_le_assoc : a + b - c ≤ a + (b - c) := by
-  rw [tsub_le_iff_left, add_left_comm]
-  exact add_le_add_left le_add_tsub a
+  grw [tsub_le_iff_left, add_left_comm, ← le_add_tsub]
 
 /-- See `tsub_add_eq_add_tsub` for the equality. -/
 theorem add_tsub_le_tsub_add : a + b - c ≤ a - c + b := by
   rw [add_comm, add_comm _ b]
   exact add_tsub_le_assoc
 
-theorem add_le_add_add_tsub : a + b ≤ a + c + (b - c) := by
-  rw [add_assoc]
-  exact add_le_add_left le_add_tsub a
+theorem add_le_add_add_tsub : a + b ≤ a + c + (b - c) := by grw [add_assoc, ← le_add_tsub]
 
 theorem le_tsub_add_add : a + b ≤ a - c + (b + c) := by
   rw [add_comm a, add_comm (a - c)]
   exact add_le_add_add_tsub
 
 theorem tsub_le_tsub_add_tsub : a - c ≤ a - b + (b - c) := by
-  rw [tsub_le_iff_left, ← add_assoc, add_right_comm]
-  exact le_add_tsub.trans (add_le_add_right le_add_tsub _)
+  grw [tsub_le_iff_left, ← add_assoc, add_right_comm, ← le_add_tsub, ← le_add_tsub]
 
 theorem tsub_tsub_tsub_le_tsub : c - a - (c - b) ≤ b - a := by
-  rw [tsub_le_iff_left, tsub_le_iff_left, add_left_comm]
-  exact le_tsub_add.trans (add_le_add_left le_add_tsub _)
+  grw [tsub_le_iff_left, tsub_le_iff_left, add_left_comm, ← le_add_tsub, ← le_tsub_add]
 
 theorem tsub_tsub_le_tsub_add {a b c : α} : a - (b - c) ≤ a - b + c :=
   tsub_le_iff_right.2 <|
     calc
       a ≤ a - b + b := le_tsub_add
-      _ ≤ a - b + (c + (b - c)) := add_le_add_left le_add_tsub _
+      _ ≤ a - b + (c + (b - c)) := by grw [← le_add_tsub]
       _ = a - b + c + (b - c) := (add_assoc _ _ _).symm
 
 /-- See `tsub_add_tsub_comm` for the equality. -/
@@ -157,13 +152,11 @@ theorem add_tsub_add_le_tsub_add_tsub : a + b - (c + d) ≤ a - c + (b - d) := b
 
 /-- See `add_tsub_add_eq_tsub_left` for the equality. -/
 theorem add_tsub_add_le_tsub_left : a + b - (a + c) ≤ b - c := by
-  rw [tsub_le_iff_left, add_assoc]
-  exact add_le_add_left le_add_tsub _
+  grw [tsub_le_iff_left, add_assoc, ← le_add_tsub]
 
 /-- See `add_tsub_add_eq_tsub_right` for the equality. -/
 theorem add_tsub_add_le_tsub_right : a + c - (b + c) ≤ a - b := by
-  rw [tsub_le_iff_left, add_right_comm]
-  exact add_le_add_right le_add_tsub c
+  grw [tsub_le_iff_left, add_right_comm, ← le_add_tsub]
 
 end Cov
 

--- a/Mathlib/Algebra/Order/Sub/Unbundled/Basic.lean
+++ b/Mathlib/Algebra/Order/Sub/Unbundled/Basic.lean
@@ -24,17 +24,17 @@ variable [AddCommSemigroup α] [PartialOrder α] [ExistsAddOfLE α]
 theorem add_tsub_cancel_of_le (h : a ≤ b) : a + (b - a) = b := by
   refine le_antisymm ?_ le_add_tsub
   obtain ⟨c, rfl⟩ := exists_add_of_le h
-  exact add_le_add_left add_tsub_le_left a
+  grw [add_tsub_le_left]
 
 theorem tsub_add_cancel_of_le (h : a ≤ b) : b - a + a = b := by
   rw [add_comm]
   exact add_tsub_cancel_of_le h
 
-theorem add_le_of_le_tsub_right_of_le (h : b ≤ c) (h2 : a ≤ c - b) : a + b ≤ c :=
-  (add_le_add_right h2 b).trans_eq <| tsub_add_cancel_of_le h
+theorem add_le_of_le_tsub_right_of_le (h : b ≤ c) (h2 : a ≤ c - b) : a + b ≤ c := by
+  grw [h2, tsub_add_cancel_of_le h]
 
-theorem add_le_of_le_tsub_left_of_le (h : a ≤ c) (h2 : b ≤ c - a) : a + b ≤ c :=
-  (add_le_add_left h2 a).trans_eq <| add_tsub_cancel_of_le h
+theorem add_le_of_le_tsub_left_of_le (h : a ≤ c) (h2 : b ≤ c - a) : a + b ≤ c := by
+  grw [h2, add_tsub_cancel_of_le h]
 
 theorem tsub_le_tsub_iff_right (h : c ≤ b) : a - c ≤ b - c ↔ a ≤ b := by
   rw [tsub_le_iff_right, tsub_add_cancel_of_le h]

--- a/Mathlib/Algebra/Polynomial/AlgebraMap.lean
+++ b/Mathlib/Algebra/Polynomial/AlgebraMap.lean
@@ -574,7 +574,7 @@ theorem eval_mul_X_sub_C {p : R[X]} (r : R) : (p * (X - C r)).eval r = 0 := by
   have bound :=
     calc
       (p * (X - C r)).natDegree ≤ p.natDegree + (X - C r).natDegree := natDegree_mul_le
-      _ ≤ p.natDegree + 1 := add_le_add_left (natDegree_X_sub_C_le _) _
+      _ ≤ p.natDegree + 1 := by grw [natDegree_X_sub_C_le]
       _ < p.natDegree + 2 := lt_add_one _
   rw [sum_over_range' _ _ (p.natDegree + 2) bound]
   swap

--- a/Mathlib/Algebra/Polynomial/Degree/Definitions.lean
+++ b/Mathlib/Algebra/Polynomial/Degree/Definitions.lean
@@ -393,20 +393,14 @@ theorem degree_sum_le (s : Finset ι) (f : ι → R[X]) :
       _ ≤ _ := by rw [sup_cons]; exact max_le_max le_rfl ih
 
 theorem degree_mul_le (p q : R[X]) : degree (p * q) ≤ degree p + degree q := by
-  simpa only [degree, ← support_toFinsupp, toFinsupp_mul]
-    using AddMonoidAlgebra.sup_support_mul_le (WithBot.coe_add _ _).le _ _
+  simpa [degree, ← support_toFinsupp] using AddMonoidAlgebra.sup_support_mul_le (by simp) ..
 
 theorem degree_mul_le_of_le {a b : WithBot ℕ} (hp : degree p ≤ a) (hq : degree q ≤ b) :
-    degree (p * q) ≤ a + b :=
-  (p.degree_mul_le _).trans <| add_le_add ‹_› ‹_›
+    degree (p * q) ≤ a + b := by grw [degree_mul_le, hp, hq]
 
 theorem degree_pow_le (p : R[X]) : ∀ n : ℕ, degree (p ^ n) ≤ n • degree p
   | 0 => by rw [pow_zero, zero_nsmul]; exact degree_one_le
-  | n + 1 =>
-    calc
-      degree (p ^ (n + 1)) ≤ degree (p ^ n) + degree p := by
-        rw [pow_succ]; exact degree_mul_le _ _
-      _ ≤ _ := by rw [succ_nsmul]; exact add_le_add_right (degree_pow_le _ _) _
+  | n + 1 => by grw [pow_succ, succ_nsmul, degree_mul_le, degree_pow_le]
 
 theorem degree_pow_le_of_le {a : WithBot ℕ} (b : ℕ) (hp : degree p ≤ a) :
     degree (p ^ b) ≤ b * a := by

--- a/Mathlib/Algebra/Polynomial/Degree/Lemmas.lean
+++ b/Mathlib/Algebra/Polynomial/Degree/Lemmas.lean
@@ -49,8 +49,7 @@ theorem natDegree_comp_le : natDegree (p.comp q) ≤ natDegree p * natDegree q :
                 degree_mul_le _ _
               _ ≤ natDegree (C (coeff p n)) + n • degree q :=
                 (add_le_add degree_le_natDegree (degree_pow_le _ _))
-              _ ≤ natDegree (C (coeff p n)) + n • ↑(natDegree q) :=
-                (add_le_add_left (nsmul_le_nsmul_right (@degree_le_natDegree _ _ q) n) _)
+              _ ≤ natDegree (C (coeff p n)) + n • ↑(natDegree q) := by grw [degree_le_natDegree]
               _ = (n * natDegree q : ℕ) := by
                 rw [natDegree_C, Nat.cast_zero, zero_add, nsmul_eq_mul]
                 simp

--- a/Mathlib/Algebra/Polynomial/Degree/Operations.lean
+++ b/Mathlib/Algebra/Polynomial/Degree/Operations.lean
@@ -431,7 +431,7 @@ theorem coeff_pow_mul_natDegree (p : R[X]) (n : ℕ) :
           exact leadingCoeff_eq_zero.mp hi
         calc
           (p ^ i * p).natDegree ≤ (p ^ i).natDegree + p.natDegree := natDegree_mul_le
-          _ < i * p.natDegree + p.natDegree := add_lt_add_right h1 _
+          _ < i * p.natDegree + p.natDegree := by gcongr
     · rw [← natDegree_pow' hp1, ← leadingCoeff_pow' hp1]
       exact coeff_mul_degree_add_degree _ _
 

--- a/Mathlib/Algebra/Polynomial/Monic.lean
+++ b/Mathlib/Algebra/Polynomial/Monic.lean
@@ -315,8 +315,8 @@ lemma Monic.irreducible_iff_natDegree' (hp : p.Monic) : Irreducible p ↔ p ≠ 
   · simp_rw [hf.natDegree_mul hg, pos_iff_ne_zero] at h
     contrapose! h
     obtain hl | hl := le_total f.natDegree g.natDegree
-    · exact ⟨g, f, hg, hf, mul_comm g f, h.1, add_le_add_left hl _⟩
-    · exact ⟨f, g, hf, hg, rfl, h.2, add_le_add_right hl _⟩
+    · exact ⟨g, f, hg, hf, mul_comm g f, h.1, by gcongr⟩
+    · exact ⟨f, g, hf, hg, rfl, h.2, by gcongr⟩
 
 /-- Alternate phrasing of `Polynomial.Monic.irreducible_iff_natDegree'` where we only have to check
 one divisor at a time. -/

--- a/Mathlib/Algebra/Polynomial/UnitTrinomial.lean
+++ b/Mathlib/Algebra/Polynomial/UnitTrinomial.lean
@@ -215,10 +215,10 @@ theorem irreducible_aux1 {k m n : ℕ} (hkm : k < m) (hmn : m < n) (u v w : Unit
     simp only [ofFinsupp_single]
     rw [C_mul_monomial, C_mul_monomial, mul_comm (v : ℤ) w, add_comm (n - m + k) n]
   · exact fun h => h.2.ne rfl
-  · refine ⟨?_, add_lt_add_left key n⟩
+  · refine ⟨?_, by gcongr⟩
     rwa [add_comm, add_lt_add_iff_left, lt_add_iff_pos_left, tsub_pos_iff_lt]
   · exact fun h => h.1.ne (add_comm k n)
-  · exact ⟨add_lt_add_right hkm n, add_lt_add_right hmn n⟩
+  · constructor <;> gcongr
   · rw [← add_assoc, add_tsub_cancel_of_le hmn.le, add_comm]
     exact fun h => h.1.ne rfl
   · grind

--- a/Mathlib/AlgebraicGeometry/EllipticCurve/Affine/Point.lean
+++ b/Mathlib/AlgebraicGeometry/EllipticCurve/Affine/Point.lean
@@ -407,7 +407,7 @@ lemma degree_norm_smul_basis [IsDomain R] (p q : R[X]) :
     (Algebra.norm R[X] <| p • 1 + q • mk W' Y).degree = max (2 • p.degree) (2 • q.degree + 3) := by
   have hdp : (p ^ 2).degree = 2 • p.degree := degree_pow p 2
   have hdpq : (p * q * (C W'.a₁ * X + C W'.a₃)).degree ≤ p.degree + q.degree + 1 := by
-    simpa only [degree_mul] using add_le_add_left degree_linear_le (p.degree + q.degree)
+    grw [degree_mul, degree_mul, degree_linear_le]
   have hdq :
       (q ^ 2 * (X ^ 3 + C W'.a₂ * X ^ 2 + C W'.a₄ * X + C W'.a₆)).degree = 2 • q.degree + 3 := by
     rw [degree_mul, degree_pow, ← one_mul <| X ^ 3, ← C_1, degree_cubic <| one_ne_zero' R]

--- a/Mathlib/AlgebraicGeometry/ProjectiveSpectrum/Proper.lean
+++ b/Mathlib/AlgebraicGeometry/ProjectiveSpectrum/Proper.lean
@@ -287,8 +287,8 @@ theorem valuativeCriterion_existence_aux
             · simp; ring
           · ext i; congr 1; ring
           · ring
-      _ ≤ (∏ i : ι, ψ i₀ ^ (d i * ai i)) * ψ i₀ ^ (d i₀ * a * (d j - 1)) :=
-          mul_le_mul_right' (Finset.prod_le_prod' fun i a ↦ pow_le_pow_left₀ zero_le' (hi₀ i) _) _
+      _ ≤ (∏ i : ι, ψ i₀ ^ (d i * ai i)) * ψ i₀ ^ (d i₀ * a * (d j - 1)) := by
+          gcongr with i; exacts [fun i _ ↦ zero_le', zero_le', hi₀ i]
       _ = ψ i₀ ^ (d i₀ * a * d j) := by
           rw [Finset.prod_pow_eq_pow_sum, ← pow_add]
           simp_rw [mul_comm (d _) (ai _), hai]

--- a/Mathlib/Analysis/Analytic/CPolynomialDef.lean
+++ b/Mathlib/Analysis/Analytic/CPolynomialDef.lean
@@ -376,8 +376,7 @@ theorem hasFiniteFPowerSeriesOnBall_changeOrigin (p : FormalMultilinearSeries �
     (k : ℕ) (hn : ∀ (m : ℕ), n + k ≤ m → p m = 0) :
     HasFiniteFPowerSeriesOnBall (p.changeOrigin · k) (p.changeOriginSeries k) 0 n ⊤ :=
   (p.changeOriginSeries k).hasFiniteFPowerSeriesOnBall_of_finite
-    (fun _ hm => p.changeOriginSeries_finite_of_finite hn k
-    (by rw [add_comm n k]; apply add_le_add_left hm))
+    fun _ hm => p.changeOriginSeries_finite_of_finite hn k <| by grw [hm, add_comm]
 
 theorem changeOrigin_eval_of_finite (p : FormalMultilinearSeries 𝕜 E F) {n : ℕ}
     (hn : ∀ (m : ℕ), n ≤ m → p m = 0) (x y : E) :

--- a/Mathlib/Analysis/Asymptotics/TVS.lean
+++ b/Mathlib/Analysis/Asymptotics/TVS.lean
@@ -140,7 +140,7 @@ theorem IsLittleOTVS.exists_eventuallyLE_mul_ennreal (h : f =o[𝕜; l] g) {U : 
   obtain ⟨V, hV₀, hV⟩ := h.exists_eventuallyLE_mul U hU
   refine ⟨V, hV₀, fun ε hε ↦ ?_⟩
   cases ε with
-  | top => exact (hV 1 one_ne_zero).trans <| .of_forall fun _ ↦ mul_le_mul_right' le_top _
+  | top => exact (hV 1 one_ne_zero).trans <| .of_forall fun _ ↦ by dsimp; grw [← le_top]
   | coe ε => exact hV ε (mod_cast hε)
 
 theorem isLittleOTVS_congr (hf : f₁ =ᶠ[l] f₂) (hg : g₁ =ᶠ[l] g₂) :

--- a/Mathlib/Analysis/BoxIntegral/Box/Basic.lean
+++ b/Mathlib/Analysis/BoxIntegral/Box/Basic.lean
@@ -459,8 +459,7 @@ theorem nndist_le_distortion_mul (I : Box ι) (i : ι) :
         nndist I.lower I.upper / nndist (I.lower i) (I.upper i) * nndist (I.lower i) (I.upper i) :=
       (div_mul_cancel₀ _ <| mt nndist_eq_zero.1 (I.lower_lt_upper i).ne).symm
     _ ≤ I.distortion * nndist (I.lower i) (I.upper i) := by
-      apply mul_le_mul_right'
-      apply Finset.le_sup (Finset.mem_univ i)
+      grw [distortion, ← Finset.le_sup (Finset.mem_univ i)]
 
 theorem dist_le_distortion_mul (I : Box ι) (i : ι) :
     dist I.lower I.upper ≤ I.distortion * (I.upper i - I.lower i) := by

--- a/Mathlib/Analysis/BoxIntegral/Integrability.lean
+++ b/Mathlib/Analysis/BoxIntegral/Integrability.lean
@@ -146,9 +146,8 @@ theorem HasIntegral.of_aeEq_zero {l : IntegrationParams} {I : Box ι} {f : (ι �
     exact ⟨hrU _ (hπ.1 _ hJ (Box.coe_subset_Icc hx)), π.le_of_mem' J hJ hx⟩
   clear_value m
   lift m to ℝ≥0 using ne_top_of_lt this
-  rw [ENNReal.coe_toReal, ← NNReal.coe_natCast, ← NNReal.coe_mul, NNReal.coe_le_coe, ←
-    ENNReal.coe_le_coe, ENNReal.coe_mul, ENNReal.coe_natCast, mul_comm]
-  exact (mul_le_mul_left' this.le _).trans ENNReal.mul_div_le
+  grw [ENNReal.coe_toReal, ← NNReal.coe_natCast, ← NNReal.coe_mul, NNReal.coe_le_coe, ←
+    ENNReal.coe_le_coe, ENNReal.coe_mul, ENNReal.coe_natCast, mul_comm, this, ENNReal.mul_div_le]
 
 /-- If `f` has integral `y` on a box `I` with respect to a locally finite measure `μ` and `g` is
 a.e. equal to `f` on `I`, then `g` has the same integral on `I`. -/

--- a/Mathlib/Analysis/CStarAlgebra/Multiplier.lean
+++ b/Mathlib/Analysis/CStarAlgebra/Multiplier.lean
@@ -535,10 +535,7 @@ theorem norm_fst_eq_snd (a : 𝓜(𝕜, A)) : ‖a.fst‖ = ‖a.snd‖ := by
   -- a handy lemma for this proof
   have h0 : ∀ f : A →L[𝕜] A, ∀ C : ℝ≥0, (∀ b : A, ‖f b‖₊ ^ 2 ≤ C * ‖f b‖₊ * ‖b‖₊) → ‖f‖₊ ≤ C := by
     intro f C h
-    have h1 : ∀ b, C * ‖f b‖₊ * ‖b‖₊ ≤ C * ‖f‖₊ * ‖b‖₊ ^ 2 := by
-      intro b
-      convert mul_le_mul_right' (mul_le_mul_left' (f.le_opNNNorm b) C) ‖b‖₊ using 1
-      ring
+    have h1 b : C * ‖f b‖₊ * ‖b‖₊ ≤ C * ‖f‖₊ * ‖b‖₊ ^ 2 := by grw [f.le_opNNNorm b]; ring_nf; rfl
     have := NNReal.div_le_of_le_mul <| f.opNNNorm_le_bound _ <| by
       simpa only [sqrt_sq, sqrt_mul] using fun b ↦ sqrt_le_sqrt.2 <| (h b).trans (h1 b)
     convert NNReal.rpow_le_rpow this two_pos.le

--- a/Mathlib/Analysis/Calculus/ContDiff/Basic.lean
+++ b/Mathlib/Analysis/Calculus/ContDiff/Basic.lean
@@ -1183,8 +1183,7 @@ theorem ContDiffWithinAt.fderivWithin'' {f : E → F → G} {g : E → F} {t : S
   have : ∀ k : ℕ, k ≤ m → ContDiffWithinAt 𝕜 k (fun x => fderivWithin 𝕜 (f x) t (g x)) s x₀ := by
     intro k hkm
     obtain ⟨v, hv, -, f', hvf', hf'⟩ :=
-      (hf.of_le <| (add_le_add_right hkm 1).trans hmn).hasFDerivWithinAt_nhds (by simp)
-        (hg.of_le hkm) hgt
+      (hf.of_le <| by grw [hkm, hmn]).hasFDerivWithinAt_nhds (by simp) (hg.of_le hkm) hgt
     refine hf'.congr_of_eventuallyEq_insert ?_
     filter_upwards [hv, ht]
     exact fun y hy h2y => (hvf' y hy).fderivWithin h2y

--- a/Mathlib/Analysis/Calculus/ContDiff/Bounds.lean
+++ b/Mathlib/Analysis/Calculus/ContDiff/Bounds.lean
@@ -373,8 +373,7 @@ theorem norm_iteratedFDerivWithin_comp_le_aux {Fu Gu : Type u} [NormedAddCommGro
     simp only [Finset.mem_range_succ_iff] at hi
     apply IH i hi
     · apply hg.fderivWithin ht
-      simp only [Nat.cast_succ]
-      exact add_le_add_right (Nat.cast_le.2 hi) _
+      grw [Nat.cast_succ, hi]
     · apply hf.of_le (Nat.cast_le.2 (hi.trans n.le_succ))
     · intro j hj
       have : ‖iteratedFDerivWithin 𝕜 j (fderivWithin 𝕜 g t) t (f x)‖ =

--- a/Mathlib/Analysis/Calculus/ContDiff/Defs.lean
+++ b/Mathlib/Analysis/Calculus/ContDiff/Defs.lean
@@ -833,7 +833,7 @@ theorem contDiffOn_succ_iff_fderivWithin (hs : UniqueDiffOn 𝕜 s) :
     exact H.analyticOn
   have A (m : ℕ) (hm : m ≤ n) : ContDiffWithinAt 𝕜 m (fun y => fderivWithin 𝕜 f s y) s x := by
     rcases (contDiffWithinAt_succ_iff_hasFDerivWithinAt (n := m) (ne_of_beq_false rfl)).1
-      (H.of_le (add_le_add_right hm 1) x hx) with ⟨u, hu, -, f', hff', hf'⟩
+      (H.of_le (by gcongr) x hx) with ⟨u, hu, -, f', hff', hf'⟩
     rcases mem_nhdsWithin.1 hu with ⟨o, o_open, xo, ho⟩
     rw [inter_comm, insert_eq_of_mem hx] at ho
     have := hf'.mono ho

--- a/Mathlib/Analysis/Calculus/FDeriv/Measurable.lean
+++ b/Mathlib/Analysis/Calculus/FDeriv/Measurable.lean
@@ -587,8 +587,8 @@ theorem D_subset_differentiable_set {K : Set F} (hK : IsComplete K) :
       ‖L e p q - L e' p' q'‖ =
           ‖L e p q - L e p r + (L e p r - L e' p' r) + (L e' p' r - L e' p' q')‖ := by
         congr 1; abel
-      _ ≤ ‖L e p q - L e p r‖ + ‖L e p r - L e' p' r‖ + ‖L e' p' r - L e' p' q'‖ :=
-        (le_trans (norm_add_le _ _) (add_le_add_right (norm_add_le _ _) _))
+      _ ≤ ‖L e p q - L e p r‖ + ‖L e p r - L e' p' r‖ + ‖L e' p' r - L e' p' q'‖ := by
+        grw [norm_add_le, norm_add_le]
       _ ≤ 4 * (1 / 2) ^ e + 4 * (1 / 2) ^ e + 4 * (1 / 2) ^ e := by gcongr
       _ = 12 * (1 / 2) ^ e := by ring
   /- For definiteness, use `L0 e = L e (n e) (n e)`, to have a single sequence. We claim that this

--- a/Mathlib/Analysis/Calculus/LocalExtr/Polynomial.lean
+++ b/Mathlib/Analysis/Calculus/LocalExtr/Polynomial.lean
@@ -47,8 +47,8 @@ theorem card_roots_toFinset_le_card_roots_derivative_diff_roots_succ (p : ℝ[X]
 one. -/
 theorem card_roots_toFinset_le_derivative (p : ℝ[X]) :
     p.roots.toFinset.card ≤ p.derivative.roots.toFinset.card + 1 :=
-  p.card_roots_toFinset_le_card_roots_derivative_diff_roots_succ.trans <|
-    add_le_add_right (Finset.card_mono Finset.sdiff_subset) _
+  p.card_roots_toFinset_le_card_roots_derivative_diff_roots_succ.trans <| by
+    grw [Finset.sdiff_subset]
 
 /-- The number of roots of a real polynomial (counted with multiplicities) is at most the number of
 roots of its derivative (counted with multiplicities) plus one. -/
@@ -70,10 +70,9 @@ theorem card_roots_le_derivative (p : ℝ[X]) :
     _ ≤ (∑ x ∈ p.roots.toFinset, p.derivative.roots.count x) +
           ((∑ x ∈ p.derivative.roots.toFinset \ p.roots.toFinset,
             p.derivative.roots.count x) + 1) := by
-      simp only [← count_roots]
-      refine add_le_add_left (add_le_add_right ((Finset.card_eq_sum_ones _).trans_le ?_) _) _
-      refine Finset.sum_le_sum fun x hx => Nat.succ_le_iff.2 <| ?_
-      rw [Multiset.count_pos, ← Multiset.mem_toFinset]
+      simp only [← count_roots, Finset.card_eq_sum_ones]
+      gcongr with x hx
+      rw [Nat.succ_le_iff, Multiset.count_pos, ← Multiset.mem_toFinset]
       exact (Finset.mem_sdiff.1 hx).1
     _ = Multiset.card (derivative p).roots + 1 := by
       rw [← add_assoc, ← Finset.sum_union Finset.disjoint_sdiff, Finset.union_sdiff_self_eq_union, ←

--- a/Mathlib/Analysis/Complex/Exponential.lean
+++ b/Mathlib/Analysis/Complex/Exponential.lean
@@ -574,7 +574,7 @@ theorem exp_approx_succ {n} {x a₁ b₁ : ℝ} (m : ℕ) (e₁ : n + 1 = m) (a�
     (e : |1 + x / m * a₂ - a₁| ≤ b₁ - |x| / m * b₂)
     (h : |exp x - expNear m x a₂| ≤ |x| ^ m / m.factorial * b₂) :
     |exp x - expNear n x a₁| ≤ |x| ^ n / n.factorial * b₁ := by
-  refine (abs_sub_le _ _ _).trans ((add_le_add_right h _).trans ?_)
+  grw [abs_sub_le, h]
   subst e₁; rw [expNear_succ, expNear_sub, abs_mul]
   convert mul_le_mul_of_nonneg_left (a := |x| ^ n / ↑(Nat.factorial n))
       (le_sub_iff_add_le'.1 e) ?_ using 1

--- a/Mathlib/Analysis/Convex/Birkhoff.lean
+++ b/Mathlib/Analysis/Convex/Birkhoff.lean
@@ -120,12 +120,12 @@ private lemma doublyStochastic_sum_perm_aux (M : Matrix n n R)
     case isFalse h => exact hM.1 _ _
   have hd' : #{i : n × n | N i.1 i.2 ≠ 0} < d := by
     rw [← hd]
-    refine card_lt_card ?_
+    gcongr
     rw [ssubset_iff_of_subset (monotone_filter_right _ _)]
     · simp_rw [mem_filter_univ, not_not, Prod.exists]
       refine ⟨i, σ i, hMi'.ne', ?_⟩
       simp [N, Equiv.toPEquiv_apply]
-    · rintro ⟨i', j'⟩ hN' hM'
+    · rintro ⟨i', j'⟩ _ hN' hM'
       dsimp at hN' hM'
       simp only [sub_apply, hM', smul_apply, PEquiv.toMatrix_apply, Equiv.toPEquiv_apply,
         Option.mem_def, Option.some.injEq, smul_eq_mul, mul_ite, mul_one, mul_zero, zero_sub,

--- a/Mathlib/Analysis/Convex/Gauge.lean
+++ b/Mathlib/Analysis/Convex/Gauge.lean
@@ -142,9 +142,7 @@ theorem gauge_le_eq (hs₁ : Convex ℝ s) (hs₀ : (0 : E) ∈ s) (hs₂ : Abso
     refine hs₁.smul_mem_of_zero_mem hs₀ hδ ⟨by positivity, ?_⟩
     rw [inv_mul_le_iff₀ hr', mul_one]
     exact hδr.le
-  · have hε' := (lt_add_iff_pos_right a).2 (half_pos hε)
-    exact
-      (gauge_le_of_mem (ha.trans hε'.le) <| h _ hε').trans_lt (add_lt_add_left (half_lt_self hε) _)
+  · linarith [gauge_le_of_mem (by linarith) <| h (a + ε / 2) (by linarith)]
 
 theorem gauge_lt_eq' (absorbs : Absorbent ℝ s) (a : ℝ) :
     { x | gauge s x < a } = ⋃ (r : ℝ) (_ : 0 < r) (_ : r < a), r • s := by
@@ -439,10 +437,10 @@ theorem continuousAt_gauge (hc : Convex ℝ s) (hs₀ : s ∈ 𝓝 0) : Continuo
     calc
       gauge s x = gauge s (x + y + (-y)) := by simp
       _ ≤ gauge s (x + y) + gauge s (-y) := gauge_add_le hc ha _ _
-      _ ≤ gauge s (x + y) + ε := add_le_add_left (gauge_le_of_mem hε₀.le (mem_neg.1 hy.2)) _
+      _ ≤ gauge s (x + y) + ε := by grw [gauge_le_of_mem hε₀.le (mem_neg.1 hy.2)]
   · calc
       gauge s (x + y) ≤ gauge s x + gauge s y := gauge_add_le hc ha _ _
-      _ ≤ gauge s x + ε := add_le_add_left (gauge_le_of_mem hε₀.le hy.1) _
+      _ ≤ gauge s x + ε := by grw [gauge_le_of_mem hε₀.le hy.1]
 
 /-- If `s` is a convex neighborhood of the origin in a topological real vector space, then `gauge s`
 is continuous. If the ambient space is a normed space, then `gauge s` is Lipschitz continuous, see
@@ -581,8 +579,7 @@ theorem Convex.lipschitzWith_gauge {r : ℝ≥0} (hc : Convex ℝ s) (hr : 0 < r
     calc
       gauge s x = gauge s (y + (x - y)) := by simp
       _ ≤ gauge s y + gauge s (x - y) := gauge_add_le hc (this.mono hs) _ _
-      _ ≤ gauge s y + ‖x - y‖ / r :=
-        add_le_add_left ((gauge_mono this hs (x - y)).trans_eq (gauge_ball hr.le _)) _
+      _ ≤ gauge s y + ‖x - y‖ / r := by grw [gauge_mono this hs (x - y), gauge_ball]; positivity
       _ = gauge s y + r⁻¹ * dist x y := by rw [dist_eq_norm, div_eq_inv_mul, NNReal.coe_inv]
 
 theorem Convex.lipschitz_gauge (hc : Convex ℝ s) (h₀ : s ∈ 𝓝 (0 : E)) :

--- a/Mathlib/Analysis/Convex/SpecificFunctions/Basic.lean
+++ b/Mathlib/Analysis/Convex/SpecificFunctions/Basic.lean
@@ -109,12 +109,14 @@ theorem one_add_mul_self_lt_rpow_one_add {s : ℝ} (hs : -1 ≤ s) (hs' : s ≠ 
     convert strictConcaveOn_log_Ioi.secant_strict_mono (zero_lt_one' ℝ) hs2 hs1 hs4 hs3 _ using 1
     · rw [add_sub_cancel_left, log_one, sub_zero]
     · rw [add_sub_cancel_left, div_div, log_one, sub_zero]
-    · apply add_lt_add_left (mul_lt_of_one_lt_left hs' hp)
+    · gcongr
+      exact mul_lt_of_one_lt_left hs' hp
   · rw [← div_lt_iff₀ hp', ← div_lt_div_iff_of_pos_right hs']
     convert strictConcaveOn_log_Ioi.secant_strict_mono (zero_lt_one' ℝ) hs1 hs2 hs3 hs4 _ using 1
     · rw [add_sub_cancel_left, div_div, log_one, sub_zero]
     · rw [add_sub_cancel_left, log_one, sub_zero]
-    · apply add_lt_add_left (lt_mul_of_one_lt_left hs' hp)
+    · gcongr
+      exact lt_mul_of_one_lt_left hs' hp
 
 /-- **Bernoulli's inequality** for real exponents, non-strict version: for `1 ≤ p` and `-1 ≤ s`
 we have `1 + p * s ≤ (1 + s) ^ p`. -/
@@ -148,12 +150,14 @@ theorem rpow_one_add_lt_one_add_mul_self {s : ℝ} (hs : -1 ≤ s) (hs' : s ≠ 
     convert strictConcaveOn_log_Ioi.secant_strict_mono (zero_lt_one' ℝ) hs1 hs2 hs3 hs4 _ using 1
     · rw [add_sub_cancel_left, div_div, log_one, sub_zero]
     · rw [add_sub_cancel_left, log_one, sub_zero]
-    · apply add_lt_add_left (lt_mul_of_lt_one_left hs' hp2)
+    · gcongr
+      exact lt_mul_of_lt_one_left hs' hp2
   · rw [← lt_div_iff₀ hp1, ← div_lt_div_iff_of_pos_right hs']
     convert strictConcaveOn_log_Ioi.secant_strict_mono (zero_lt_one' ℝ) hs2 hs1 hs4 hs3 _ using 1
     · rw [add_sub_cancel_left, log_one, sub_zero]
     · rw [add_sub_cancel_left, div_div, log_one, sub_zero]
-    · apply add_lt_add_left (mul_lt_of_lt_one_left hs' hp2)
+    · gcongr
+      exact mul_lt_of_lt_one_left hs' hp2
 
 /-- **Bernoulli's inequality** for real exponents, non-strict version: for `0 ≤ p ≤ 1` and `-1 ≤ s`
 we have `(1 + s) ^ p ≤ 1 + p * s`. -/

--- a/Mathlib/Analysis/InnerProductSpace/Projection/Minimal.lean
+++ b/Mathlib/Analysis/InnerProductSpace/Projection/Minimal.lean
@@ -101,10 +101,8 @@ theorem exists_norm_eq_iInf_of_complete_convex {K : Set F} (ne : K.Nonempty) (h�
         repeat' exact Subtype.mem _
         repeat' exact le_of_lt one_half_pos
         exact add_halves 1
-      have eq₂ : ‖a‖ ≤ δ + div :=
-          le_trans (le_of_lt <| hw q) (add_le_add_left (Nat.one_div_le_one_div hq) _)
-      have eq₂' : ‖b‖ ≤ δ + div :=
-          le_trans (le_of_lt <| hw p) (add_le_add_left (Nat.one_div_le_one_div hp) _)
+      have eq₂ : ‖a‖ ≤ δ + div := by grw [hw, Nat.one_div_le_one_div hq]
+      have eq₂' : ‖b‖ ≤ δ + div := by grw [hw, Nat.one_div_le_one_div hp]
       rw [dist_eq_norm]
       apply nonneg_le_nonneg_of_sq_le_sq
       · exact sqrt_nonneg _

--- a/Mathlib/Analysis/Normed/Affine/ContinuousAffineMap.lean
+++ b/Mathlib/Analysis/Normed/Affine/ContinuousAffineMap.lean
@@ -100,16 +100,12 @@ theorem norm_comp_le (g : W₂ →ᴬ[𝕜] V) : ‖f.comp g‖ ≤ ‖f‖ * �
   · calc
       ‖f.comp g 0‖ = ‖f (g 0)‖ := by simp
       _ = ‖f.contLinear (g 0) + f 0‖ := by rw [f.decomp]; simp
-      _ ≤ ‖f.contLinear‖ * ‖g 0‖ + ‖f 0‖ :=
-        ((norm_add_le _ _).trans (add_le_add_right (f.contLinear.le_opNorm _) _))
-      _ ≤ ‖f‖ * ‖g‖ + ‖f 0‖ :=
-        add_le_add_right
-          (mul_le_mul f.norm_contLinear_le g.norm_image_zero_le (norm_nonneg _) (norm_nonneg _)) _
+      _ ≤ ‖f.contLinear‖ * ‖g 0‖ + ‖f 0‖ := by grw [norm_add_le, f.contLinear.le_opNorm]
+      _ ≤ ‖f‖ * ‖g‖ + ‖f 0‖ := by grw [f.norm_contLinear_le, g.norm_image_zero_le]
   · calc
       ‖(f.comp g).contLinear‖ ≤ ‖f.contLinear‖ * ‖g.contLinear‖ :=
         (g.comp_contLinear f).symm ▸ f.contLinear.opNorm_comp_le _
-      _ ≤ ‖f‖ * ‖g‖ :=
-        (mul_le_mul f.norm_contLinear_le g.norm_contLinear_le (norm_nonneg _) (norm_nonneg _))
+      _ ≤ ‖f‖ * ‖g‖ := by grw [f.norm_contLinear_le, g.norm_contLinear_le]
       _ ≤ ‖f‖ * ‖g‖ + ‖f 0‖ := by rw [le_add_iff_nonneg_right]; apply norm_nonneg
 
 variable (𝕜 V W)

--- a/Mathlib/Analysis/Normed/Algebra/Spectrum.lean
+++ b/Mathlib/Analysis/Normed/Algebra/Spectrum.lean
@@ -270,7 +270,7 @@ theorem spectralRadius_le_liminf_pow_nnnorm_pow_one_div (a : A) :
   simp only [← add_assoc]
   refine (spectralRadius_le_pow_nnnorm_pow_one_div 𝕜 a (n + N)).trans ?_
   norm_cast
-  exact mul_le_mul_left' (hN (n + N + 1) (by cutsat)) _
+  grw [hN (n + N + 1) (by cutsat)]
 
 end SpectrumCompact
 
@@ -326,9 +326,7 @@ theorem hasFPowerSeriesOnBall_inverse_one_sub_smul [HasSummableGeomSeries A] (a 
       rw [← norm_toNNReal, norm_mkPiRing, norm_toNNReal]
       rcases n with - | n
       · simp only [le_refl, mul_one, or_true, le_max_iff, pow_zero]
-      · refine
-          le_trans (le_trans (mul_le_mul_right' (nnnorm_pow_le' a n.succ_pos) (r ^ n.succ)) ?_)
-            (le_max_left _ _)
+      · grw [nnnorm_pow_le' a n.succ_pos, ← le_max_left]
         by_cases h : ‖a‖₊ = 0
         · simp only [h, zero_mul, zero_le', pow_succ']
         · rw [← coe_inv h, coe_lt_coe, NNReal.lt_inv_iff_mul_lt h] at hr

--- a/Mathlib/Analysis/Normed/Group/Uniform.lean
+++ b/Mathlib/Analysis/Normed/Group/Uniform.lean
@@ -407,7 +407,7 @@ theorem cauchySeq_prod_of_eventually_eq {u v : ℕ → E} {N : ℕ} (huv : ∀ n
   suffices ∀ n ≥ N, d n = d N from (tendsto_atTop_of_eventually_const this).cauchySeq.mul hv
   intro n hn
   dsimp [d]
-  rw [eventually_constant_prod _ (add_le_add_right hn 1)]
+  rw [eventually_constant_prod (N := N + 1) _ (by gcongr)]
   intro m hm
   simp [huv m (le_of_lt hm)]
 

--- a/Mathlib/Analysis/Normed/Order/UpperLower.lean
+++ b/Mathlib/Analysis/Normed/Order/UpperLower.lean
@@ -148,10 +148,9 @@ lemma dist_le_dist_of_le_pi (ha : a₂ ≤ a₁) (h₁ : a₁ ≤ b₁) (hb : b�
 theorem IsUpperSet.exists_subset_ball (hs : IsUpperSet s) (hx : x ∈ closure s) (hδ : 0 < δ) :
     ∃ y, closedBall y (δ / 4) ⊆ closedBall x δ ∧ closedBall y (δ / 4) ⊆ interior s := by
   refine ⟨x + const _ (3 / 4 * δ), closedBall_subset_closedBall' ?_, ?_⟩
-  · rw [dist_self_add_left]
-    refine (add_le_add_left (pi_norm_const_le <| 3 / 4 * δ) _).trans_eq ?_
-    simp only [norm_mul, norm_div, Real.norm_eq_abs]
-    simp only [zero_lt_three, abs_of_pos, zero_lt_four, abs_of_pos hδ]
+  · grw [dist_self_add_left, ← const_def, pi_norm_const_le]
+    apply le_of_eq
+    simp [abs_of_nonneg, hδ.le]
     ring
   obtain ⟨y, hy, hxy⟩ := Metric.mem_closure_iff.1 hx _ (div_pos hδ zero_lt_four)
   refine fun z hz => hs.mem_interior_of_forall_lt (subset_closure hy) fun i => ?_
@@ -166,10 +165,9 @@ theorem IsUpperSet.exists_subset_ball (hs : IsUpperSet s) (hx : x ∈ closure s)
 theorem IsLowerSet.exists_subset_ball (hs : IsLowerSet s) (hx : x ∈ closure s) (hδ : 0 < δ) :
     ∃ y, closedBall y (δ / 4) ⊆ closedBall x δ ∧ closedBall y (δ / 4) ⊆ interior s := by
   refine ⟨x - const _ (3 / 4 * δ), closedBall_subset_closedBall' ?_, ?_⟩
-  · rw [dist_self_sub_left]
-    refine (add_le_add_left (pi_norm_const_le <| 3 / 4 * δ) _).trans_eq ?_
-    simp only [norm_mul, norm_div, Real.norm_eq_abs, zero_lt_three, abs_of_pos,
-      zero_lt_four, abs_of_pos hδ]
+  · grw [dist_self_sub_left, ← const_def, pi_norm_const_le]
+    apply le_of_eq
+    simp [abs_of_nonneg, hδ.le]
     ring
   obtain ⟨y, hy, hxy⟩ := Metric.mem_closure_iff.1 hx _ (div_pos hδ zero_lt_four)
   refine fun z hz => hs.mem_interior_of_forall_lt (subset_closure hy) fun i => ?_

--- a/Mathlib/Analysis/Normed/Unbundled/SeminormFromConst.lean
+++ b/Mathlib/Analysis/Normed/Unbundled/SeminormFromConst.lean
@@ -247,7 +247,7 @@ theorem seminormFromConst_const_mul (x : R) :
   have hlim : Tendsto (fun n ↦ seminormFromConst_seq c f x (n + 1)) atTop
       (𝓝 (seminormFromConst' hf1 hc hpm x)) := by
     apply (seminormFromConst_isLimit hf1 hc hpm x).comp
-      (tendsto_atTop_atTop_of_monotone (fun _ _ hnm ↦ add_le_add_right hnm 1) _)
+      (tendsto_atTop_atTop_of_monotone add_left_mono _)
     rintro n; use n; omega
   rw [seminormFromConst_apply_c hf1 hc hpm]
   apply tendsto_nhds_unique (seminormFromConst_isLimit hf1 hc hpm (c * x))

--- a/Mathlib/Analysis/NormedSpace/ENormedSpace.lean
+++ b/Mathlib/Analysis/NormedSpace/ENormedSpace.lean
@@ -89,7 +89,7 @@ theorem map_smul (c : 𝕜) (x : V) : e (c • x) = ‖c‖₊ * e x := by
   · simp [hc]
   calc
     (‖c‖₊ : ℝ≥0∞) * e x = ‖c‖₊ * e (c⁻¹ • c • x) := by rw [inv_smul_smul₀ hc]
-    _ ≤ ‖c‖₊ * (‖c⁻¹‖₊ * e (c • x)) := mul_le_mul_left' (e.map_smul_le' _ _) _
+    _ ≤ ‖c‖₊ * (‖c⁻¹‖₊ * e (c • x)) := by grw [e.map_smul_le']
     _ = e (c • x) := by
       rw [← mul_assoc, nnnorm_inv, ENNReal.coe_inv, ENNReal.mul_inv_cancel _ ENNReal.coe_ne_top,
         one_mul]

--- a/Mathlib/Analysis/NormedSpace/Extr.lean
+++ b/Mathlib/Analysis/NormedSpace/Extr.lean
@@ -33,11 +33,7 @@ variable {f : α → E} {l : Filter α} {s : Set α} {c : α} {y : E}
 a maximum along `l` at `c`. -/
 theorem IsMaxFilter.norm_add_sameRay (h : IsMaxFilter (norm ∘ f) l c) (hy : SameRay ℝ (f c) y) :
     IsMaxFilter (fun x => ‖f x + y‖) l c :=
-  h.mono fun x hx =>
-    calc
-      ‖f x + y‖ ≤ ‖f x‖ + ‖y‖ := norm_add_le _ _
-      _ ≤ ‖f c‖ + ‖y‖ := add_le_add_right hx _
-      _ = ‖f c + y‖ := hy.norm_add.symm
+  h.mono fun x hx => by dsimp at hx ⊢; grw [hy.norm_add, norm_add_le, hx]
 
 /-- If `f : α → E` is a function such that `norm ∘ f` has a maximum along a filter `l` at a point
 `c`, then the function `fun x => ‖f x + f c‖` has a maximum along `l` at `c`. -/

--- a/Mathlib/Analysis/ODE/Gronwall.lean
+++ b/Mathlib/Analysis/ODE/Gronwall.lean
@@ -100,14 +100,13 @@ theorem le_gronwallBound_of_liminf_deriv_right_le {f f' : ℝ → ℝ} {δ K ε 
     (ha : f a ≤ δ) (bound : ∀ x ∈ Ico a b, f' x ≤ K * f x + ε) :
     ∀ x ∈ Icc a b, f x ≤ gronwallBound δ K ε (x - a) := by
   have H : ∀ x ∈ Icc a b, ∀ ε' ∈ Ioi ε, f x ≤ gronwallBound δ K ε' (x - a) := by
-    intro x hx ε' hε'
+    intro x hx ε' (hε' : ε < ε')
     apply image_le_of_liminf_slope_right_lt_deriv_boundary hf hf'
     · rwa [sub_self, gronwallBound_x0]
     · exact fun x => hasDerivAt_gronwallBound_shift δ K ε' x a
     · intro x hx hfB
-      rw [← hfB]
-      apply lt_of_le_of_lt (bound x hx)
-      exact add_lt_add_left (mem_Ioi.1 hε') _
+      grw [← hfB, bound x hx]
+      gcongr
     · exact hx
   intro x hx
   change f x ≤ (fun ε' => gronwallBound δ K ε' (x - a)) ε

--- a/Mathlib/Analysis/ODE/PicardLindelof.lean
+++ b/Mathlib/Analysis/ODE/PicardLindelof.lean
@@ -237,7 +237,7 @@ protected lemma mem_closedBall
     _ ≤ L * max (tmax - t₀) (t₀ - tmin) + r := by
       gcongr
       exact abs_sub_le_max_sub t.2.1 t.2.2 _
-    _ ≤ a - r + r := add_le_add_right h _
+    _ ≤ a - r + r := by gcongr
     _ = a := sub_add_cancel _ _
 
 lemma compProj_mem_closedBall

--- a/Mathlib/Analysis/PSeries.lean
+++ b/Mathlib/Analysis/PSeries.lean
@@ -71,13 +71,12 @@ theorem le_sum_schlomilch (hf : ∀ ⦃m n⦄, 0 < m → m ≤ n → f n ≤ f m
     (hu : Monotone u) (n : ℕ) :
     (∑ k ∈ range (u n), f k) ≤
       ∑ k ∈ range (u 0), f k + ∑ k ∈ range n, (u (k + 1) - u k) • f (u k) := by
-  convert add_le_add_left (le_sum_schlomilch' hf h_pos hu n) (∑ k ∈ range (u 0), f k)
-  rw [← sum_range_add_sum_Ico _ (hu n.zero_le)]
+  grw [← le_sum_schlomilch' hf h_pos hu n, ← sum_range_add_sum_Ico _ (hu n.zero_le)]
 
 theorem le_sum_condensed (hf : ∀ ⦃m n⦄, 0 < m → m ≤ n → f n ≤ f m) (n : ℕ) :
     (∑ k ∈ range (2 ^ n), f k) ≤ f 0 + ∑ k ∈ range n, 2 ^ k • f (2 ^ k) := by
-  convert add_le_add_left (le_sum_condensed' hf n) (f 0)
-  rw [← sum_range_add_sum_Ico _ n.one_le_two_pow, sum_range_succ, sum_range_zero, zero_add]
+  grw [← le_sum_condensed' hf n, ← sum_range_add_sum_Ico _ n.one_le_two_pow, sum_range_succ,
+    sum_range_zero, zero_add]
 
 theorem sum_schlomilch_le' (hf : ∀ ⦃m n⦄, 1 < m → m ≤ n → f n ≤ f m) (h_pos : ∀ n, 0 < u n)
     (hu : Monotone u) (n : ℕ) :
@@ -124,7 +123,7 @@ theorem sum_schlomilch_le {C : ℕ} (hf : ∀ ⦃m n⦄, 1 < m → m ≤ n → f
 
 theorem sum_condensed_le (hf : ∀ ⦃m n⦄, 1 < m → m ≤ n → f n ≤ f m) (n : ℕ) :
     (∑ k ∈ range (n + 1), 2 ^ k • f (2 ^ k)) ≤ f 1 + 2 • ∑ k ∈ Ico 2 (2 ^ n + 1), f k := by
-  convert add_le_add_left (nsmul_le_nsmul_right (sum_condensed_le' hf n) 2) (f 1)
+  grw [← sum_condensed_le' hf n]
   simp [sum_range_succ', add_comm, pow_succ', mul_nsmul', sum_nsmul]
 
 end Finset
@@ -140,40 +139,33 @@ theorem le_tsum_schlomilch (hf : ∀ ⦃m n⦄, 0 < m → m ≤ n → f n ≤ f 
     (hu : StrictMono u) :
     ∑' k, f k ≤ ∑ k ∈ range (u 0), f k + ∑' k : ℕ, (u (k + 1) - u k) * f (u k) := by
   rw [ENNReal.tsum_eq_iSup_nat' hu.tendsto_atTop]
-  refine iSup_le fun n =>
-    (Finset.le_sum_schlomilch hf h_pos hu.monotone n).trans (add_le_add_left ?_ _)
-  have (k : ℕ) : (u (k + 1) - u k : ℝ≥0∞) = (u (k + 1) - (u k : ℕ) : ℕ) := by
-    simp
+  refine iSup_le fun n => ?_
+  grw [Finset.le_sum_schlomilch hf h_pos hu.monotone n]
+  gcongr
+  have (k : ℕ) : (u (k + 1) - u k : ℝ≥0∞) = (u (k + 1) - (u k : ℕ) : ℕ) := by simp
   simp only [nsmul_eq_mul, this]
   apply ENNReal.sum_le_tsum
 
 theorem le_tsum_condensed (hf : ∀ ⦃m n⦄, 0 < m → m ≤ n → f n ≤ f m) :
     ∑' k, f k ≤ f 0 + ∑' k : ℕ, 2 ^ k * f (2 ^ k) := by
   rw [ENNReal.tsum_eq_iSup_nat' (Nat.tendsto_pow_atTop_atTop_of_one_lt _root_.one_lt_two)]
-  refine iSup_le fun n => (Finset.le_sum_condensed hf n).trans (add_le_add_left ?_ _)
+  refine iSup_le fun n => (Finset.le_sum_condensed hf n).trans ?_
   simp only [nsmul_eq_mul, Nat.cast_pow, Nat.cast_two]
-  apply ENNReal.sum_le_tsum
+  grw [ENNReal.sum_le_tsum]
 
 theorem tsum_schlomilch_le {C : ℕ} (hf : ∀ ⦃m n⦄, 1 < m → m ≤ n → f n ≤ f m) (h_pos : ∀ n, 0 < u n)
     (h_nonneg : ∀ n, 0 ≤ f n) (hu : Monotone u) (h_succ_diff : SuccDiffBounded C u) :
     ∑' k : ℕ, (u (k + 1) - u k) * f (u k) ≤ (u 1 - u 0) * f (u 0) + C * ∑' k, f k := by
   rw [ENNReal.tsum_eq_iSup_nat' (tendsto_atTop_mono Nat.le_succ tendsto_id)]
-  refine
-    iSup_le fun n =>
-      le_trans ?_
-        (add_le_add_left
-          (mul_le_mul_of_nonneg_left (ENNReal.sum_le_tsum <| Finset.Ico (u 0 + 1) (u n + 1)) ?_) _)
-  · simpa using Finset.sum_schlomilch_le hf h_pos h_nonneg hu h_succ_diff n
-  · exact zero_le _
+  refine iSup_le fun n => ?_
+  grw [← ENNReal.sum_le_tsum <| Finset.Ico (u 0 + 1) (u n + 1)]
+  simpa using Finset.sum_schlomilch_le hf h_pos h_nonneg hu h_succ_diff n
 
 theorem tsum_condensed_le (hf : ∀ ⦃m n⦄, 1 < m → m ≤ n → f n ≤ f m) :
     (∑' k : ℕ, 2 ^ k * f (2 ^ k)) ≤ f 1 + 2 * ∑' k, f k := by
   rw [ENNReal.tsum_eq_iSup_nat' (tendsto_atTop_mono Nat.le_succ tendsto_id), two_mul, ← two_nsmul]
-  refine
-    iSup_le fun n =>
-      le_trans ?_
-        (add_le_add_left
-          (nsmul_le_nsmul_right (ENNReal.sum_le_tsum <| Finset.Ico 2 (2 ^ n + 1)) _) _)
+  refine iSup_le fun n => ?_
+  grw [← ENNReal.sum_le_tsum <| Finset.Ico 2 (2 ^ n + 1)]
   simpa using Finset.sum_condensed_le hf n
 
 end ENNReal

--- a/Mathlib/Analysis/Real/Hyperreal.lean
+++ b/Mathlib/Analysis/Real/Hyperreal.lean
@@ -254,24 +254,20 @@ theorem not_infinite_of_exists_st {x : ℝ*} : (∃ r : ℝ, IsSt x r) → ¬Inf
 theorem Infinite.st_eq {x : ℝ*} (hi : Infinite x) : st x = 0 :=
   dif_neg fun ⟨_r, hr⟩ ↦ hr.not_infinite hi
 
-theorem isSt_sSup {x : ℝ*} (hni : ¬Infinite x) : IsSt x (sSup { y : ℝ | (y : ℝ*) < x }) :=
-  let S : Set ℝ := { y : ℝ | (y : ℝ*) < x }
-  let R : ℝ := sSup S
-  let ⟨r₁, hr₁⟩ := not_forall.mp (not_or.mp hni).2
-  let ⟨r₂, hr₂⟩ := not_forall.mp (not_or.mp hni).1
-  have HR₁ : S.Nonempty :=
-    ⟨r₁ - 1, lt_of_lt_of_le (coe_lt_coe.2 <| sub_one_lt _) (not_lt.mp hr₁)⟩
-  have HR₂ : BddAbove S :=
-    ⟨r₂, fun _y hy => le_of_lt (coe_lt_coe.1 (lt_of_lt_of_le hy (not_lt.mp hr₂)))⟩
-  fun δ hδ =>
-  ⟨lt_of_not_ge fun c =>
-      have hc : ∀ y ∈ S, y ≤ R - δ := fun _y hy =>
-        coe_le_coe.1 <| le_of_lt <| lt_of_lt_of_le hy c
-      not_lt_of_ge (csSup_le HR₁ hc) <| sub_lt_self R hδ,
-    lt_of_not_ge fun c =>
-      have hc : ↑(R + δ / 2) < x :=
-        lt_of_lt_of_le (add_lt_add_left (coe_lt_coe.2 (half_lt_self hδ)) R) c
-      not_lt_of_ge (le_csSup HR₂ hc) <| (lt_add_iff_pos_right _).mpr <| half_pos hδ⟩
+theorem isSt_sSup {x : ℝ*} (hni : ¬Infinite x) : IsSt x (sSup { y : ℝ | (y : ℝ*) < x }) := by
+  set S : Set ℝ := { y : ℝ | (y : ℝ*) < x }
+  set R : ℝ := sSup S
+  have hS₀ : S.Nonempty := by
+    obtain ⟨r₁, hr₁⟩ := not_forall.mp (not_or.mp hni).2
+    exact ⟨r₁ - 1, (coe_lt_coe.2 <| sub_one_lt _).trans_le (not_lt.mp hr₁)⟩
+  have hS : BddAbove S := by
+    obtain ⟨r₂, hr₂⟩ := not_forall.mp (not_or.mp hni).1
+    exact ⟨r₂, fun _y hy => coe_le_coe.1 <| hy.le.trans <| not_lt.mp hr₂⟩
+  intro δ hδ
+  constructor <;> refine lt_of_not_ge fun hx => ?_
+  · exact (sub_lt_self R hδ).not_ge <| csSup_le hS₀ fun _y hy => coe_le_coe.1 <| hy.le.trans hx
+  · replace hx : ↑(R + δ / 2) < x := by grw [← hx]; norm_cast; linarith
+    exact (le_csSup hS hx).not_gt <| by simpa [R]
 
 theorem exists_st_of_not_infinite {x : ℝ*} (hni : ¬Infinite x) : ∃ r : ℝ, IsSt x r :=
   ⟨sSup { y : ℝ | (y : ℝ*) < x }, isSt_sSup hni⟩

--- a/Mathlib/Analysis/SpecialFunctions/Exp.lean
+++ b/Mathlib/Analysis/SpecialFunctions/Exp.lean
@@ -54,8 +54,7 @@ theorem locally_lipschitz_exp {r : ℝ} (hr_nonneg : 0 ≤ r) (hr_le : r ≤ 1) 
   calc
     ‖exp y - exp x‖ = ‖exp (x + (y - x)) - exp x‖ := by nth_rw 1 [hy_eq]
     _ ≤ ‖y - x‖ * ‖exp x‖ + ‖exp x‖ * ‖y - x‖ ^ 2 := h_sq (y - x) (hyx.le.trans hr_le)
-    _ ≤ ‖y - x‖ * ‖exp x‖ + ‖exp x‖ * (r * ‖y - x‖) :=
-      (add_le_add_left (mul_le_mul le_rfl hyx_sq_le (sq_nonneg _) (norm_nonneg _)) _)
+    _ ≤ ‖y - x‖ * ‖exp x‖ + ‖exp x‖ * (r * ‖y - x‖) := by grw [hyx_sq_le]
     _ = (1 + r) * ‖exp x‖ * ‖y - x‖ := by ring
 
 -- Porting note: proof by term mode `locally_lipschitz_exp zero_le_one le_rfl x`

--- a/Mathlib/Analysis/SpecialFunctions/Log/Summable.lean
+++ b/Mathlib/Analysis/SpecialFunctions/Log/Summable.lean
@@ -127,10 +127,7 @@ lemma Finset.norm_prod_one_add_sub_one_le (t : Finset ι) (f : ι → R) :
     generalize h : Real.exp (∑ i ∈ t, ‖f i‖) = A at ⊢ IH
     rw [sub_add_eq_add_sub, sub_le_sub_iff_right]
     transitivity A + ‖f x‖ * A
-    · gcongr
-      rw [← sub_add_cancel (∏ x ∈ t, (1 + f x)) 1]
-      refine (norm_add_le _ _).trans <| (add_le_add_right IH _).trans ?_
-      rw [norm_one, sub_add_cancel]
+    · grw [norm_le_norm_sub_add (∏ x ∈ t, (1 + f x)) 1, IH, norm_one, sub_add_cancel]
     rw [← one_add_mul, add_comm]
     exact mul_le_mul_of_nonneg_right (Real.add_one_le_exp _) (h ▸ Real.exp_nonneg _)
 

--- a/Mathlib/Analysis/SpecialFunctions/Trigonometric/Basic.lean
+++ b/Mathlib/Analysis/SpecialFunctions/Trigonometric/Basic.lean
@@ -395,11 +395,7 @@ theorem cos_int_mul_two_pi_sub_pi (n : ℤ) : cos (n * (2 * π) - π) = -1 := by
 
 theorem sin_pos_of_pos_of_lt_pi {x : ℝ} (h0x : 0 < x) (hxp : x < π) : 0 < sin x :=
   if hx2 : x ≤ 2 then sin_pos_of_pos_of_le_two h0x hx2
-  else
-    have : (2 : ℝ) + 2 = 4 := by norm_num
-    have : π - x ≤ 2 :=
-      sub_le_iff_le_add.2 (le_trans pi_le_four (this ▸ add_le_add_left (le_of_not_ge hx2) _))
-    sin_pi_sub x ▸ sin_pos_of_pos_of_le_two (sub_pos.2 hxp) this
+  else sin_pi_sub x ▸ sin_pos_of_pos_of_le_two (sub_pos.2 hxp) (by linarith [pi_le_four])
 
 theorem sin_pos_of_mem_Ioo {x : ℝ} (hx : x ∈ Ioo 0 π) : 0 < sin x :=
   sin_pos_of_pos_of_lt_pi hx.1 hx.2
@@ -659,12 +655,12 @@ theorem sqrtTwoAddSeries_succ (x : ℝ) :
   | 0 => rfl
   | n + 1 => by rw [sqrtTwoAddSeries, sqrtTwoAddSeries_succ _ _, sqrtTwoAddSeries]
 
+@[gcongr]
 theorem sqrtTwoAddSeries_monotone_left {x y : ℝ} (h : x ≤ y) :
     ∀ n : ℕ, sqrtTwoAddSeries x n ≤ sqrtTwoAddSeries y n
   | 0 => h
   | n + 1 => by
-    rw [sqrtTwoAddSeries, sqrtTwoAddSeries]
-    exact sqrt_le_sqrt (add_le_add_left (sqrtTwoAddSeries_monotone_left h _) _)
+    rw [sqrtTwoAddSeries, sqrtTwoAddSeries]; gcongr; exact sqrtTwoAddSeries_monotone_left h _
 
 @[simp]
 theorem cos_pi_over_two_pow : ∀ n : ℕ, cos (π / 2 ^ (n + 1)) = sqrtTwoAddSeries 0 n / 2

--- a/Mathlib/Analysis/SpecificLimits/Basic.lean
+++ b/Mathlib/Analysis/SpecificLimits/Basic.lean
@@ -642,8 +642,8 @@ theorem exists_pos_tsum_mul_lt_of_countable {ε : ℝ≥0∞} (hε : ε ≠ 0) {
   refine ⟨fun i ↦ δ' i / max 1 (w i), fun i ↦ div_pos (Hpos _) (this i), ?_⟩
   refine lt_of_le_of_lt (ENNReal.tsum_le_tsum fun i ↦ ?_) Hsum
   rw [coe_div (this i).ne']
-  refine mul_le_of_le_div' (mul_le_mul_left' (ENNReal.inv_le_inv.2 ?_) _)
-  exact coe_le_coe.2 (le_max_right _ _)
+  refine mul_le_of_le_div' ?_
+  grw [← le_max_right]
 
 end ENNReal
 

--- a/Mathlib/Analysis/SpecificLimits/FloorPow.lean
+++ b/Mathlib/Analysis/SpecificLimits/FloorPow.lean
@@ -280,8 +280,7 @@ theorem sum_div_nat_floor_pow_sq_le_div_sq (N : ℕ) {j : ℝ} (hj : 0 < j) {c :
   calc
     (∑ i ∈ range N with j < ⌊c ^ i⌋₊, (1 : ℝ) / (⌊c ^ i⌋₊ : ℝ) ^ 2) ≤
         ∑ i ∈ range N with j < c ^ i, (1 : ℝ) / (⌊c ^ i⌋₊ : ℝ) ^ 2 := by
-      gcongr
-      exact fun k hk ↦ hk.trans_le <| Nat.floor_le (by positivity)
+      gcongr with k hk; exact Nat.floor_le (by positivity)
     _ ≤ ∑ i ∈ range N with j < c ^ i, (1 - c⁻¹)⁻¹ ^ 2 * ((1 : ℝ) / (c ^ i) ^ 2) := by
       gcongr with i
       rw [mul_div_assoc', mul_one, div_le_div_iff₀]; rotate_left

--- a/Mathlib/Analysis/Subadditive.lean
+++ b/Mathlib/Analysis/Subadditive.lean
@@ -53,7 +53,7 @@ theorem apply_mul_add_le (k n r) : u (k * n + r) ≤ k * u n + u r := by
     calc
       u ((k + 1) * n + r) = u (n + (k * n + r)) := by congr 1; ring
       _ ≤ u n + u (k * n + r) := h _ _
-      _ ≤ u n + (k * u n + u r) := add_le_add_left IH _
+      _ ≤ u n + (k * u n + u r) := by grw [IH]
       _ = (k + 1 : ℕ) * u n + u r := by simp; ring
 
 include h in

--- a/Mathlib/Combinatorics/Additive/CauchyDavenport.lean
+++ b/Mathlib/Combinatorics/Additive/CauchyDavenport.lean
@@ -163,8 +163,8 @@ lemma cauchy_davenport_minOrder_mul (hs : s.Nonempty) (ht : t.Nonempty) :
   -- If the left translate of `t` by `g⁻¹` is disjoint from `t`, then we're easily done.
   obtain hgt | hgt := disjoint_or_nonempty_inter t (g⁻¹ • t)
   · rw [← card_smul_finset g⁻¹ t]
-    refine Or.inr ((add_le_add_right hst _).trans ?_)
-    rw [← card_union_of_disjoint hgt]
+    right
+    grw [hst, ← card_union_of_disjoint hgt]
     exact (card_le_card_mul_left hgs).trans (le_add_of_le_left aux1)
   -- Else, we're done by induction on either `(s', t')` or `(s'', t'')` depending on whether
   -- `|s| + |t| ≤ |s'| + |t'|` or `|s| + |t| < |s''| + |t''|`. One of those two inequalities must

--- a/Mathlib/Combinatorics/Additive/VerySmallDoubling.lean
+++ b/Mathlib/Combinatorics/Additive/VerySmallDoubling.lean
@@ -82,12 +82,11 @@ lemma op_smul_stabilizer_of_no_doubling (hA : #(A * A) ≤ #A) (ha : a ∈ A) :
 private lemma big_intersection (ha : a ∈ B) (hb : b ∈ B) :
     2 * #A ≤ #((a • A) ∩ (b • A)) + #(B * A) := by
   have : #((a • A) ∪ (b • A)) ≤ #(B * A) := by
-    refine card_le_card ?_
+    gcongr
     rw [union_subset_iff]
     exact ⟨smul_finset_subset_mul ha, smul_finset_subset_mul hb⟩
-  refine (add_le_add_left this _).trans_eq' ?_
-  rw [card_inter_add_card_union]
-  simp only [card_smul_finset, two_mul]
+  grw [← this, card_inter_add_card_union]
+  simp [card_smul_finset, two_mul]
 
 private lemma le_card_smul_inter_smul (hA : #(B * A) ≤ K * #A) (ha : a ∈ B) (hb : b ∈ B) :
     (2 - K) * #A ≤ #((a • A) ∩ (b • A)) := by

--- a/Mathlib/Combinatorics/Enumerative/Composition.lean
+++ b/Mathlib/Combinatorics/Enumerative/Composition.lean
@@ -837,11 +837,7 @@ def compositionAsSetEquiv (n : ℕ) : CompositionAsSet n ≃ Finset (Fin (n - 1)
   right_inv := by
     intro s
     ext i
-    have : (i : ℕ) + 1 ≠ n := by
-      apply ne_of_lt
-      convert add_lt_add_right i.is_lt 1
-      apply (Nat.succ_pred_eq_of_pos _).symm
-      exact Nat.lt_of_lt_pred (Fin.pos i)
+    have : (i : ℕ) + 1 ≠ n := by cutsat
     simp_rw [add_comm, Fin.ext_iff, Fin.val_zero, Fin.val_last, exists_prop, Set.toFinset_setOf,
       Finset.mem_filter_univ, reduceCtorEq, this, false_or, add_left_inj, ← Fin.ext_iff,
       exists_eq_right']

--- a/Mathlib/Combinatorics/Extremal/RuzsaSzemeredi.lean
+++ b/Mathlib/Combinatorics/Extremal/RuzsaSzemeredi.lean
@@ -59,7 +59,7 @@ lemma ruzsaSzemerediNumber_spec :
       #(G.cliqueFinset 3) = m ∧ G.LocallyLinear) _ _ (Nat.zero_le _)
     ⟨⊥, inferInstance, by simp, locallyLinear_bot⟩
 
-variable {n : ℕ}
+variable {m n : ℕ}
 
 lemma SimpleGraph.LocallyLinear.le_ruzsaSzemerediNumber [DecidableRel G.Adj]
     (hG : G.LocallyLinear) : #(G.cliqueFinset 3) ≤ ruzsaSzemerediNumber α := by
@@ -88,8 +88,13 @@ noncomputable def ruzsaSzemerediNumberNat (n : ℕ) : ℕ := ruzsaSzemerediNumbe
 lemma ruzsaSzemerediNumberNat_card : ruzsaSzemerediNumberNat (card α) = ruzsaSzemerediNumber α :=
   ruzsaSzemerediNumber_congr (Fintype.equivFin _).symm
 
-lemma ruzsaSzemerediNumberNat_mono : Monotone ruzsaSzemerediNumberNat := fun _m _n h =>
-  ruzsaSzemerediNumber_mono (Fin.castLEEmb h)
+-- TODO: Remove once #28339 lands?
+@[gcongr] lemma ruzsaSzemerediNumberNat_le_ruzsaSzemerediNumberNat (hmn : m ≤ n) :
+    ruzsaSzemerediNumberNat m ≤ ruzsaSzemerediNumberNat n :=
+  ruzsaSzemerediNumber_mono (Fin.castLEEmb hmn)
+
+lemma ruzsaSzemerediNumberNat_mono : Monotone ruzsaSzemerediNumberNat :=
+  fun _m _n => ruzsaSzemerediNumberNat_le_ruzsaSzemerediNumberNat
 
 lemma ruzsaSzemerediNumberNat_le : ruzsaSzemerediNumberNat n ≤ n.choose 3 :=
   ruzsaSzemerediNumber_le.trans_eq <| by rw [Fintype.card_fin]
@@ -205,8 +210,7 @@ theorem rothNumberNat_le_ruzsaSzemerediNumberNat' :
       _ ≤ (↑(2 * (n / 6) + 1) : ℝ) * rothNumberNat (n / 6) :=
         mul_le_mul_of_nonneg_right ?_ (Nat.cast_nonneg _)
       _ ≤ (ruzsaSzemerediNumberNat (6 * (n / 6) + 3) : ℝ) := ?_
-      _ ≤ _ :=
-        Nat.cast_le.2 (ruzsaSzemerediNumberNat_mono <| add_le_add_right (Nat.mul_div_le _ _) _)
+      _ ≤ _ := by grw [Nat.mul_div_le]
     · norm_num
       rw [← div_add_one (three_ne_zero' ℝ), ← le_sub_iff_add_le, div_le_iff₀ (zero_lt_three' ℝ),
         add_assoc, add_sub_assoc, add_mul, mul_right_comm]

--- a/Mathlib/Combinatorics/Matroid/Basic.lean
+++ b/Mathlib/Combinatorics/Matroid/Basic.lean
@@ -291,7 +291,7 @@ theorem encard_diff_le_aux {B₁ B₂ : Set α}
   rw [insert_diff_of_mem _ hf.1, diff_diff_comm, ← union_singleton, ← diff_diff, diff_diff_right,
     inter_singleton_eq_empty.mpr he.2, union_empty] at hencard
   rw [← encard_diff_singleton_add_one he, ← encard_diff_singleton_add_one hf]
-  exact add_le_add_right hencard 1
+  gcongr
 termination_by (B₂ \ B₁).encard
 
 variable {B₁ B₂ : Set α}

--- a/Mathlib/Combinatorics/Matroid/Rank/ENat.lean
+++ b/Mathlib/Combinatorics/Matroid/Rank/ENat.lean
@@ -311,7 +311,7 @@ lemma eRk_union_le_eRk_add_eRk (M : Matroid α) (X Y : Set α) : M.eRk (X ∪ Y)
   le_add_self.trans (M.eRk_submod X Y)
 
 lemma eRk_eq_eRk_union_eRk_le_zero (X : Set α) (hY : M.eRk Y ≤ 0) : M.eRk (X ∪ Y) = M.eRk X :=
-  (((M.eRk_union_le_eRk_add_eRk X Y).trans (add_le_add_left hY _)).trans_eq (add_zero _)).antisymm
+  (((M.eRk_union_le_eRk_add_eRk X Y).trans (by gcongr)).trans_eq (add_zero _)).antisymm
     (M.eRk_mono subset_union_left)
 
 lemma eRk_eq_eRk_diff_eRk_le_zero (X : Set α) (hY : M.eRk Y ≤ 0) : M.eRk (X \ Y) = M.eRk X := by
@@ -327,11 +327,11 @@ lemma eRk_le_eRk_add_eRk_diff (M : Matroid α) (h : Y ⊆ X) :
 
 lemma eRk_union_le_encard_add_eRk (M : Matroid α) (X Y : Set α) :
     M.eRk (X ∪ Y) ≤ X.encard + M.eRk Y :=
-  (M.eRk_union_le_eRk_add_eRk X Y).trans <| add_le_add_right (M.eRk_le_encard _) _
+  (M.eRk_union_le_eRk_add_eRk X Y).trans <| by grw [M.eRk_le_encard]
 
 lemma eRk_union_le_eRk_add_encard (M : Matroid α) (X Y : Set α) :
     M.eRk (X ∪ Y) ≤ M.eRk X + Y.encard :=
-  (M.eRk_union_le_eRk_add_eRk X Y).trans <| add_le_add_left (M.eRk_le_encard _) _
+  (M.eRk_union_le_eRk_add_eRk X Y).trans <| by grw [← M.eRk_le_encard]
 
 lemma eRank_le_encard_add_eRk_compl (M : Matroid α) (X : Set α) :
     M.eRank ≤ X.encard + M.eRk (M.E \ X) :=
@@ -408,8 +408,8 @@ lemma IsRkFinite.closure_eq_closure_of_subset_of_eRk_ge_eRk (hX : M.IsRkFinite X
 
 lemma eRk_insert_le_add_one (M : Matroid α) (e : α) (X : Set α) :
     M.eRk (insert e X) ≤ M.eRk X + 1 :=
-  union_singleton ▸ (M.eRk_union_le_eRk_add_eRk _ _).trans <|
-    add_le_add_left (by simpa using M.eRk_le_encard {e}) _
+  union_singleton ▸ (M.eRk_union_le_eRk_add_eRk _ _).trans <| by
+    gcongr; simpa using M.eRk_le_encard {e}
 
 lemma eRk_insert_eq_add_one (he : e ∈ M.E \ M.closure X) : M.eRk (insert e X) = M.eRk X + 1 := by
   obtain ⟨I, hI⟩ := M.exists_isBasis' X

--- a/Mathlib/Combinatorics/Schnirelmann.lean
+++ b/Mathlib/Combinatorics/Schnirelmann.lean
@@ -113,8 +113,7 @@ alias schnirelmannDensity_eq_zero_of_one_not_mem := schnirelmannDensity_eq_zero_
 /-- The Schnirelmann density is increasing with the set. -/
 lemma schnirelmannDensity_le_of_subset {B : Set ℕ} [DecidablePred (· ∈ B)] (h : A ⊆ B) :
     schnirelmannDensity A ≤ schnirelmannDensity B :=
-  ciInf_mono ⟨0, fun _ ⟨_, hx⟩ ↦ hx ▸ by positivity⟩ fun _ ↦ by
-    gcongr; exact h
+  ciInf_mono ⟨0, fun _ ⟨_, hx⟩ ↦ hx ▸ by positivity⟩ fun _ ↦ by gcongr
 
 /-- The Schnirelmann density of `A` is `1` if and only if `A` contains all the positive naturals. -/
 lemma schnirelmannDensity_eq_one_iff : schnirelmannDensity A = 1 ↔ {0}ᶜ ⊆ A := by

--- a/Mathlib/Combinatorics/SetFamily/HarrisKleitman.lean
+++ b/Mathlib/Combinatorics/SetFamily/HarrisKleitman.lean
@@ -64,14 +64,9 @@ theorem IsLowerSet.le_card_inter_finset' (h𝒜 : IsLowerSet (𝒜 : Set (Finset
   rw [card_insert_of_notMem hs, ← card_memberSubfamily_add_card_nonMemberSubfamily a 𝒜, ←
     card_memberSubfamily_add_card_nonMemberSubfamily a ℬ, add_mul, mul_add, mul_add,
     add_comm (_ * _), add_add_add_comm]
-  refine
-    (add_le_add_right
-          (mul_add_mul_le_mul_add_mul
-              (card_le_card h𝒜.memberSubfamily_subset_nonMemberSubfamily) <|
-            card_le_card hℬ.memberSubfamily_subset_nonMemberSubfamily)
-          _).trans
-      ?_
-  rw [← two_mul, pow_succ', mul_assoc]
+  grw [mul_add_mul_le_mul_add_mul
+    (card_le_card h𝒜.memberSubfamily_subset_nonMemberSubfamily) <|
+      card_le_card hℬ.memberSubfamily_subset_nonMemberSubfamily, ← two_mul, pow_succ', mul_assoc]
   have h₀ : ∀ 𝒞 : Finset (Finset α), (∀ t ∈ 𝒞, t ⊆ insert a s) →
       ∀ t ∈ 𝒞.nonMemberSubfamily a, t ⊆ s := by
     rintro 𝒞 h𝒞 t ht
@@ -82,7 +77,7 @@ theorem IsLowerSet.le_card_inter_finset' (h𝒜 : IsLowerSet (𝒜 : Set (Finset
     rintro 𝒞 h𝒞 t ht
     rw [mem_memberSubfamily] at ht
     exact (subset_insert_iff_of_notMem ht.2).1 ((subset_insert _ _).trans <| h𝒞 _ ht.1)
-  refine mul_le_mul_left' ?_ _
+  gcongr
   refine (add_le_add (ih h𝒜.memberSubfamily hℬ.memberSubfamily (h₁ _ h𝒜s) <| h₁ _ hℬs) <|
     ih h𝒜.nonMemberSubfamily hℬ.nonMemberSubfamily (h₀ _ h𝒜s) <| h₀ _ hℬs).trans_eq ?_
   rw [← mul_add, ← memberSubfamily_inter, ← nonMemberSubfamily_inter,
@@ -121,6 +116,5 @@ theorem IsUpperSet.le_card_inter_finset (h𝒜 : IsUpperSet (𝒜 : Set (Finset 
   rwa [card_compl, Fintype.card_finset, tsub_mul, le_tsub_iff_le_tsub, ← mul_tsub, ←
     card_sdiff_of_subset inter_subset_right, sdiff_inter_self_right, sdiff_compl,
     _root_.inf_comm] at this
-  · exact mul_le_mul_left' (card_le_card inter_subset_right) _
-  · rw [← Fintype.card_finset]
-    exact mul_le_mul_right' (card_le_univ _) _
+  · grw [inter_subset_right]
+  · grw [← Fintype.card_finset, card_le_univ]

--- a/Mathlib/Combinatorics/SetFamily/Kleitman.lean
+++ b/Mathlib/Combinatorics/SetFamily/Kleitman.lean
@@ -75,7 +75,7 @@ theorem Finset.card_biUnion_le_of_intersecting (s : Finset ι) (f : ι → Finse
   rw [mul_tsub, card_compl, Fintype.card_finset, mul_left_comm, mul_tsub,
     (hf₁ _ <| mem_cons_self _ _).2.1, two_mul, add_tsub_cancel_left, ← mul_tsub, ← mul_two,
     mul_assoc, ← add_mul, mul_comm]
-  refine mul_le_mul_left' ?_ _
+  gcongr
   refine (add_le_add_left
     (ih _ (fun i hi ↦ (hf₁ _ <| subset_cons _ hi).2.2)
     ((card_le_card <| subset_cons _).trans hs)) _).trans ?_

--- a/Mathlib/Combinatorics/SetFamily/KruskalKatona.lean
+++ b/Mathlib/Combinatorics/SetFamily/KruskalKatona.lean
@@ -373,11 +373,11 @@ theorem erdos_ko_rado {𝒜 : Finset (Finset (Fin n))} {r : ℕ}
   have : n - r - (n - 2 * r) = r := by omega
   rw [this] at kk
   -- But this gives a contradiction: `n choose r < |𝒜| + |∂^[n-2k] 𝒜ᶜˢ|`
-  have : n.choose r < #(𝒜 ∪ ∂^[n - 2 * r] 𝒜ᶜˢ) := by
-    rw [card_union_of_disjoint ‹_›]
-    convert lt_of_le_of_lt (add_le_add_left kk _) (add_lt_add_right size _) using 1
-    convert Nat.choose_succ_succ _ _ using 3
-    all_goals rwa [Nat.sub_one, Nat.succ_pred_eq_of_pos]
+  have := calc
+    n.choose r = (n - 1).choose (r - 1) + (n - 1).choose r := by
+      convert Nat.choose_succ_succ _ _ using 3 <;> rwa [Nat.sub_one, Nat.succ_pred_eq_of_pos]
+    _ < #𝒜 + #(∂^[n - 2 * r] 𝒜ᶜˢ) := add_lt_add_of_lt_of_le size kk
+    _ = #(𝒜 ∪ ∂^[n - 2 * r] 𝒜ᶜˢ) := by rw [card_union_of_disjoint ‹_›]
   apply this.not_ge
   convert Set.Sized.card_le _
   · rw [Fintype.card_fin]

--- a/Mathlib/Combinatorics/SetFamily/LYM.lean
+++ b/Mathlib/Combinatorics/SetFamily/LYM.lean
@@ -184,9 +184,8 @@ theorem le_card_falling_div_choose [Fintype α] (hk : k ≤ Fintype.card α)
       card_union_of_disjoint (IsAntichain.disjoint_slice_shadow_falling h𝒜),
       cast_add, _root_.add_div, add_comm]
     rw [← tsub_tsub, tsub_add_cancel_of_le (le_tsub_of_add_le_left hk)]
-    exact add_le_add_left ((ih <| le_of_succ_le hk).trans <|
-      local_lubell_yamamoto_meshalkin_inequality_div
-        (tsub_pos_iff_lt.2 <| Nat.succ_le_iff.1 hk).ne' <| sized_falling _ _) _
+    grw [ih <| le_of_succ_le hk, local_lubell_yamamoto_meshalkin_inequality_div
+      (tsub_pos_iff_lt.2 <| Nat.succ_le_iff.1 hk).ne' <| sized_falling _ _]
 
 end Falling
 

--- a/Mathlib/Combinatorics/SimpleGraph/Clique.lean
+++ b/Mathlib/Combinatorics/SimpleGraph/Clique.lean
@@ -754,7 +754,7 @@ variable [DecidableRel H.Adj]
 
 @[gcongr, mono]
 theorem cliqueFinset_mono (h : G ≤ H) : G.cliqueFinset n ⊆ H.cliqueFinset n :=
-  monotone_filter_right _ fun _ ↦ IsNClique.mono h
+  monotone_filter_right _ fun _ _ ↦ IsNClique.mono h
 
 variable [Fintype β] [DecidableEq β] (G)
 

--- a/Mathlib/Combinatorics/SimpleGraph/Extremal/Turan.lean
+++ b/Mathlib/Combinatorics/SimpleGraph/Extremal/Turan.lean
@@ -391,14 +391,14 @@ theorem card_edgeFinset_turanGraph {n r : ℕ} :
 `turanGraph n r`. -/
 theorem mul_card_edgeFinset_turanGraph_le :
     2 * r * #(turanGraph n r).edgeFinset ≤ (r - 1) * n ^ 2 := by
-  rw [card_edgeFinset_turanGraph, mul_add]
-  apply (Nat.add_le_add_right (Nat.mul_div_le ..) _).trans
+  grw [card_edgeFinset_turanGraph, mul_add, Nat.mul_div_le]
   rw [tsub_mul, ← Nat.sub_add_comm]; swap
-  · exact mul_le_mul_right' (pow_le_pow_left' (Nat.mod_le ..) _) _
+  · grw [Nat.mod_le]
+    exact Nat.zero_le _
   rw [Nat.sub_le_iff_le_add, mul_comm, Nat.add_le_add_iff_left, Nat.choose_two_right,
     ← Nat.mul_div_assoc _ (Nat.even_mul_pred_self _).two_dvd, mul_assoc,
     mul_div_cancel_left₀ _ two_ne_zero, ← mul_assoc, ← mul_rotate, sq, ← mul_rotate (r - 1)]
-  refine mul_le_mul_right' ?_ _
+  gcongr ?_ * _
   rcases r.eq_zero_or_pos with rfl | hr; · cutsat
   rw [Nat.sub_one_mul, Nat.sub_one_mul, mul_comm]
   exact Nat.sub_le_sub_left (Nat.mod_lt _ hr).le _

--- a/Mathlib/Combinatorics/SimpleGraph/Regularity/Bound.lean
+++ b/Mathlib/Combinatorics/SimpleGraph/Regularity/Bound.lean
@@ -215,10 +215,10 @@ theorem add_div_le_sum_sq_div_card (hst : s ⊆ t) (f : ι → 𝕜) (d : 𝕜) 
   have h₂ : x ^ 2 ≤ ((∑ i ∈ s, (f i - (∑ j ∈ t, f j) / #t)) / #s) ^ 2 := by
     apply h₁.trans
     rw [sum_sub_distrib, sum_const, nsmul_eq_mul, sub_div, mul_div_cancel_left₀ _ hscard.ne']
-  apply (add_le_add_right ht _).trans
+  grw [ht]
   rw [← mul_div_right_comm, le_div_iff₀ htcard, add_mul, div_mul_cancel₀ _ htcard.ne']
   have h₃ := mul_sq_le_sum_sq hst (fun i => (f i - (∑ j ∈ t, f j) / #t)) h₂ hscard.ne'
-  apply (add_le_add_left h₃ _).trans
+  grw [h₃]
   simp only [sub_div' htcard.ne', div_pow, ← sum_div, ← mul_div_right_comm _ (#t : 𝕜), ← add_div,
     div_le_iff₀ (sq_pos_of_ne_zero htcard.ne'), sub_sq, sum_add_distrib, sum_const,
     sum_sub_distrib, mul_pow, ← sum_mul, nsmul_eq_mul, two_mul]

--- a/Mathlib/Combinatorics/SimpleGraph/Regularity/Chunk.lean
+++ b/Mathlib/Combinatorics/SimpleGraph/Regularity/Chunk.lean
@@ -110,11 +110,8 @@ private theorem card_nonuniformWitness_sdiff_biUnion_star (hV : V ∈ P.parts) (
     split_ifs with h₁
     · convert card_parts_equitabilise_subset_le _ (card_aux₁ h₁) hB
     · convert card_parts_equitabilise_subset_le _ (card_aux₂ hP hU h₁) hB
-  rw [sum_const]
-  refine mul_le_mul_right' ?_ _
-  have t := card_filter_atomise_le_two_pow (s := U) hX
-  refine t.trans (pow_right_mono₀ (by simp) <| tsub_le_tsub_right ?_ _)
-  exact card_image_le.trans (card_le_card <| filter_subset _ _)
+  grw [sum_const, smul_eq_mul, card_filter_atomise_le_two_pow (s := U) hX,
+    Finpartition.card_nonuniformWitnesses_le, filter_subset] <;> simp
 
 private theorem one_sub_eps_mul_card_nonuniformWitness_le_card_star (hV : V ∈ P.parts)
     (hUV : U ≠ V) (hunif : ¬G.IsUniform ε U V) (hPε : ↑100 ≤ ↑4 ^ #P.parts * ε ^ 5)
@@ -464,7 +461,7 @@ theorem edgeDensity_chunk_not_uniform [Nonempty α] (hPα : #P.parts * 16 ^ #P.p
     ↑(G.edgeDensity U V) ^ 2 - ε ^ 5 / 25 + ε ^ 4 / ↑3 ≤ ↑(G.edgeDensity U V) ^ 2 - ε ^ 5 / ↑25 +
         #(star hP G ε hU V) * #(star hP G ε hV U) / ↑16 ^ #P.parts *
           (↑9 / ↑16) * ε ^ 2 := by
-      apply add_le_add_left
+      gcongr
       have Ul : 4 / 5 * ε ≤ #(star hP G ε hU V) / _ :=
         eps_le_card_star_div hPα hPε hε₁ hU hV hUVne hUV
       have Vl : 4 / 5 * ε ≤ #(star hP G ε hV U) / _ :=

--- a/Mathlib/Combinatorics/SimpleGraph/Regularity/Increment.lean
+++ b/Mathlib/Combinatorics/SimpleGraph/Regularity/Increment.lean
@@ -61,8 +61,7 @@ variable {hP G ε}
 /-- The increment partition has a prescribed (very big) size in terms of the original partition. -/
 theorem card_increment (hPα : #P.parts * 16 ^ #P.parts ≤ card α) (hPG : ¬P.IsUniform G ε) :
     #(increment hP G ε).parts = stepBound #P.parts := by
-  have hPα' : stepBound #P.parts ≤ card α :=
-    (mul_le_mul_left' (pow_le_pow_left' (by simp) _) _).trans hPα
+  have hPα' : stepBound #P.parts ≤ card α := by grw [← hPα, stepBound]; gcongr; simp
   have hPpos : 0 < stepBound #P.parts := stepBound_pos (nonempty_of_not_uniform hPG).card_pos
   rw [increment, card_bind]
   simp_rw [chunk, apply_dite Finpartition.parts, apply_dite card, sum_dite]
@@ -153,8 +152,7 @@ theorem energy_increment (hP : P.IsEquipartition) (hP₇ : 7 ≤ #P.parts)
   rw [Finpartition.IsUniform, not_le, mul_tsub, mul_one, ← offDiag_card] at hPG
   calc
     _ ≤ ∑ x ∈ P.parts.offDiag, (edgeDensity G x.1 x.2 : ℝ) ^ 2 +
-        (#(nonUniforms P G ε) * (ε ^ 4 / 3) - #P.parts.offDiag * (ε ^ 5 / 25)) :=
-        add_le_add_left ?_ _
+        (#(nonUniforms P G ε) * (ε ^ 4 / 3) - #P.parts.offDiag * (ε ^ 5 / 25)) := ?_
     _ = ∑ x ∈ P.parts.offDiag, ((G.edgeDensity x.1 x.2 : ℝ) ^ 2 +
         ((if G.IsUniform ε x.1 x.2 then (0 : ℝ) else ε ^ 4 / 3) - ε ^ 5 / 25) : ℝ) := by
         rw [sum_add_distrib, sum_sub_distrib, sum_const, nsmul_eq_mul, sum_ite, sum_const_zero,
@@ -162,6 +160,7 @@ theorem energy_increment (hP : P.IsEquipartition) (hP₇ : 7 ≤ #P.parts)
           add_sub_right_comm]
     _ = _ := (sum_attach ..).symm
     _ ≤ _ := sum_le_sum fun i _ ↦ le_sum_distinctPairs_edgeDensity_sq i hε₁ hPα hPε
+  gcongr
   calc
     _ = (6/7 * #P.parts ^ 2) * ε ^ 5 * (7 / 24) := by ring
     _ ≤ #P.parts.offDiag * ε ^ 5 * (22 / 75) := by

--- a/Mathlib/Combinatorics/SimpleGraph/Regularity/Uniform.lean
+++ b/Mathlib/Combinatorics/SimpleGraph/Regularity/Uniform.lean
@@ -202,7 +202,7 @@ lemma mk_mem_sparsePairs (u v : Finset α) (ε : 𝕜) :
 
 omit [IsStrictOrderedRing 𝕜] in
 lemma sparsePairs_mono {ε ε' : 𝕜} (h : ε ≤ ε') : P.sparsePairs G ε ⊆ P.sparsePairs G ε' :=
-  monotone_filter_right _ fun _ ↦ h.trans_lt'
+  monotone_filter_right _ fun _ _ ↦ h.trans_lt'
 
 /-- The pairs of parts of a partition `P` which are not `ε`-uniform in a graph `G`. Note that we
 dismiss the diagonal. We do not care whether `s` is `ε`-uniform with itself. -/
@@ -215,7 +215,7 @@ omit [IsStrictOrderedRing 𝕜] in
   rw [nonUniforms, mem_filter, mem_offDiag, and_assoc, and_assoc]
 
 theorem nonUniforms_mono {ε ε' : 𝕜} (h : ε ≤ ε') : P.nonUniforms G ε' ⊆ P.nonUniforms G ε :=
-  monotone_filter_right _ fun _ => mt <| SimpleGraph.IsUniform.mono h
+  monotone_filter_right _ fun _ _ => mt <| SimpleGraph.IsUniform.mono h
 
 theorem nonUniforms_bot (hε : 0 < ε) : (⊥ : Finpartition A).nonUniforms G ε = ∅ := by
   rw [eq_empty_iff_forall_notMem]
@@ -261,6 +261,9 @@ noncomputable def nonuniformWitnesses : Finset (Finset α) :=
   {t ∈ P.parts | s ≠ t ∧ ¬G.IsUniform ε s t}.image (G.nonuniformWitness ε s)
 
 variable {P G ε s} {t : Finset α}
+
+lemma card_nonuniformWitnesses_le :
+    #(P.nonuniformWitnesses G ε s) ≤ #{t ∈ P.parts | s ≠ t ∧ ¬G.IsUniform ε s t} := card_image_le
 
 theorem nonuniformWitness_mem_nonuniformWitnesses (h : ¬G.IsUniform ε s t) (ht : t ∈ P.parts)
     (hst : s ≠ t) : G.nonuniformWitness ε s t ∈ P.nonuniformWitnesses G ε s :=

--- a/Mathlib/Combinatorics/SimpleGraph/Triangle/Removal.lean
+++ b/Mathlib/Combinatorics/SimpleGraph/Triangle/Removal.lean
@@ -114,7 +114,8 @@ lemma regularityReduced_edges_card_aux [Nonempty α] (hε : 0 < ε) (hP : P.IsEq
       rw [univ_product_univ, mul_sub, filter_and_not, cast_card_sdiff]
       · norm_cast
         rw [two_mul_card_edgeFinset, two_mul_card_edgeFinset]
-      · exact monotone_filter_right _ fun xy hxy ↦ regularityReduced_le hxy
+      · gcongr with xy _
+        exact fun hxy ↦ regularityReduced_le hxy
     _ ≤ #(A ∪ B ∪ C) := by gcongr; exact unreduced_edges_subset
     _ ≤ #(A ∪ B) + #C := mod_cast (card_union_le _ _)
     _ ≤ #A + #B + #C := by gcongr; exact mod_cast card_union_le _ _

--- a/Mathlib/Computability/Ackermann.lean
+++ b/Mathlib/Computability/Ackermann.lean
@@ -175,8 +175,10 @@ private theorem ack_strict_mono_left' : ∀ {m₁ m₂} (n), m₁ < m₂ → ack
   | 0, m + 1, 0 => fun _h => by simpa using one_lt_ack_succ_right m 0
   | 0, m + 1, n + 1 => fun h => by
     rw [ack_zero, ack_succ_succ]
-    apply lt_of_le_of_lt (le_trans _ <| add_le_add_left (add_add_one_le_ack _ _) m) (add_lt_ack _ _)
-    omega
+    calc
+      n + 1 + 1 ≤ m + (m + 1 + n + 1) := by omega
+      _ ≤ m + ack (m + 1) n := by gcongr; exact add_add_one_le_ack ..
+      _ < ack m (ack (m + 1) n) := add_lt_ack ..
   | m₁ + 1, m₂ + 1, 0 => fun h => by
     simpa using ack_strict_mono_left' 1 ((add_lt_add_iff_right 1).1 h)
   | m₁ + 1, m₂ + 1, n + 1 => fun h => by
@@ -285,15 +287,13 @@ theorem exists_lt_ack_of_nat_primrec {f : ℕ → ℕ} (hf : Nat.Primrec f) :
     refine ⟨0, fun n => ?_⟩
     rw [ack_zero, Nat.lt_succ_iff]
     exact unpair_right_le n
-  | pair hf hg IHf IHg =>
+  | @pair f g hf hg IHf IHg =>
     obtain ⟨a, ha⟩ := IHf; obtain ⟨b, hb⟩ := IHg
-    refine
-      ⟨max a b + 3, fun n =>
-        (pair_lt_max_add_one_sq _ _).trans_le <|
-          (Nat.pow_le_pow_left (add_le_add_right ?_ _) 2).trans <|
-            ack_add_one_sq_lt_ack_add_three _ _⟩
-    rw [max_ack_left]
-    exact max_le_max (ha n).le (hb n).le
+    refine ⟨max a b + 3, fun n => ?_⟩
+    calc
+      pair (f n) (g n) < (max (f n) (g n) + 1) ^ 2 := pair_lt_max_add_one_sq ..
+      _ ≤ (ack (max a b) n + 1) ^ 2 := by rw [max_ack_left]; gcongr; exacts [(ha n).le, (hb n).le]
+      _ ≤ ack (max a b + 3) n := ack_add_one_sq_lt_ack_add_three ..
   | comp hf hg IHf IHg =>
     obtain ⟨a, ha⟩ := IHf; obtain ⟨b, hb⟩ := IHg
     exact

--- a/Mathlib/Computability/Language.lean
+++ b/Mathlib/Computability/Language.lean
@@ -306,8 +306,8 @@ theorem self_eq_mul_add_iff {l m n : Language α} (hm : [] ∉ m) : l = m * l + 
         rw [pow_zero, one_mul, add_comm]
         exact le_self_add
       | succ _ ih =>
-        rw [add_comm, pow_add, pow_one, mul_assoc]
-        exact le_add_right (mul_le_mul_left' ih _)
+        grw [add_comm, pow_add, pow_one, mul_assoc, ih]
+        exact le_self_add
   mpr h := by rw [h, add_comm, ← mul_assoc, ← one_add_mul, one_add_self_mul_kstar_eq_kstar]
 
 /-- Language `l.reverse` is defined as the set of words from `l` backwards. -/

--- a/Mathlib/Data/DFinsupp/Lex.lean
+++ b/Mathlib/Data/DFinsupp/Lex.lean
@@ -138,7 +138,7 @@ section Left
 variable [∀ i, AddLeftStrictMono (α i)]
 
 instance Lex.addLeftStrictMono : AddLeftStrictMono (Lex (Π₀ i, α i)) :=
-  ⟨fun _ _ _ ⟨a, lta, ha⟩ ↦ ⟨a, fun j ja ↦ congr_arg _ (lta j ja), add_lt_add_left ha _⟩⟩
+  ⟨fun _ _ _ ⟨a, lta, ha⟩ ↦ ⟨a, fun j ja ↦ congr_arg _ (lta j ja), by dsimp; gcongr⟩⟩
 
 instance Lex.addLeftMono : AddLeftMono (Lex (Π₀ i, α i)) :=
   addLeftMono_of_addLeftStrictMono _
@@ -151,7 +151,7 @@ variable [∀ i, AddRightStrictMono (α i)]
 
 instance Lex.addRightStrictMono : AddRightStrictMono (Lex (Π₀ i, α i)) :=
   ⟨fun f _ _ ⟨a, lta, ha⟩ ↦
-    ⟨a, fun j ja ↦ congr_arg (· + ofLex f j) (lta j ja), add_lt_add_right ha _⟩⟩
+    ⟨a, fun j ja ↦ congr_arg (· + ofLex f j) (lta j ja), by dsimp; gcongr⟩⟩
 
 instance Lex.addRightMono : AddRightMono (Lex (Π₀ i, α i)) :=
   addRightMono_of_addRightStrictMono _

--- a/Mathlib/Data/ENNReal/Operations.lean
+++ b/Mathlib/Data/ENNReal/Operations.lean
@@ -644,7 +644,7 @@ lemma iSup_natCast : ⨆ n : ℕ, (n : ℝ≥0∞) = ∞ :=
 lemma add_iSup [Nonempty ι] (f : ι → ℝ≥0∞) : a + ⨆ i, f i = ⨆ i, a + f i := by
   obtain rfl | ha := eq_or_ne a ∞
   · simp
-  refine le_antisymm ?_ <| iSup_le fun i ↦ add_le_add_left (le_iSup ..) _
+  refine le_antisymm ?_ <| iSup_le fun i ↦ by grw [← le_iSup]
   refine add_le_of_le_tsub_left_of_le (le_iSup_of_le (Classical.arbitrary _) le_self_add) ?_
   exact iSup_le fun i ↦ ENNReal.le_sub_of_add_le_left ha <| le_iSup (a + f ·) i
 

--- a/Mathlib/Data/ENat/Lattice.lean
+++ b/Mathlib/Data/ENat/Lattice.lean
@@ -145,7 +145,7 @@ lemma sSup_mul : sSup s * a = ⨆ b ∈ s, b * a := by
   simp_rw [mul_comm, mul_sSup]
 
 lemma mul_iInf [Nonempty ι] : a * ⨅ i, f i = ⨅ i, a * f i := by
-  refine (le_iInf fun x ↦ (mul_le_mul_left' (iInf_le ..) a)).antisymm ?_
+  refine (le_iInf fun x ↦ by grw [iInf_le]).antisymm ?_
   obtain ⟨b, hb⟩ := ENat.exists_eq_iInf f
   rw [← hb, iInf_le_iff]
   exact fun x h ↦ h _
@@ -177,7 +177,7 @@ lemma iInf_mul_of_ne (ha₀ : a ≠ 0) : (⨅ i, f i) * a = ⨅ i, f i * a :=
 lemma add_iSup [Nonempty ι] (f : ι → ℕ∞) : a + ⨆ i, f i = ⨆ i, a + f i := by
   obtain rfl | ha := eq_or_ne a ⊤
   · simp
-  refine le_antisymm ?_ <| iSup_le fun i ↦ add_le_add_left (le_iSup ..) _
+  refine le_antisymm ?_ <| iSup_le fun i ↦ by grw [← le_iSup]
   refine add_le_of_le_tsub_left_of_le (le_iSup_of_le (Classical.arbitrary _) le_self_add) ?_
   exact iSup_le fun i ↦ ENat.le_sub_of_add_le_left ha <| le_iSup (a + f ·) i
 

--- a/Mathlib/Data/EReal/Operations.lean
+++ b/Mathlib/Data/EReal/Operations.lean
@@ -145,7 +145,7 @@ theorem add_lt_add {x y z t : EReal} (h1 : x < y) (h2 : z < t) : x + z < y + t :
   · simp [h1, bot_le.trans_lt h2]
   · lift x to ℝ using ⟨h1.ne_top, hx⟩
     calc (x : EReal) + z < x + t := add_lt_add_left_coe h2 _
-    _ ≤ y + t := add_le_add_right h1.le _
+    _ ≤ y + t := by gcongr
 
 theorem add_lt_add_of_lt_of_le' {x y z t : EReal} (h : x < y) (h' : z ≤ t) (hbot : t ≠ ⊥)
     (htop : t = ⊤ → z = ⊤ → x = ⊥) : x + z < y + t := by

--- a/Mathlib/Data/Finset/Filter.lean
+++ b/Mathlib/Data/Finset/Filter.lean
@@ -189,8 +189,7 @@ theorem monotone_filter_left : Monotone (filter p) := fun _ _ => filter_subset_f
 
 @[gcongr]
 theorem monotone_filter_right (s : Finset α) ⦃p q : α → Prop⦄ [DecidablePred p] [DecidablePred q]
-    (h : p ≤ q) : s.filter p ⊆ s.filter q :=
-  Multiset.subset_of_le (Multiset.monotone_filter_right s.val h)
+    (h : ∀ a ∈ s, p a → q a) : s.filter p ⊆ s.filter q := by simp +contextual [subset_iff, h]
 
 @[simp, norm_cast]
 theorem coe_filter (s : Finset α) : ↑(s.filter p) = ({ x ∈ ↑s | p x } : Set α) :=

--- a/Mathlib/Data/Finset/Union.lean
+++ b/Mathlib/Data/Finset/Union.lean
@@ -187,6 +187,7 @@ lemma bind_toFinset [DecidableEq α] (s : Multiset α) (t : α → Multiset β) 
 
 lemma biUnion_mono (h : ∀ a ∈ s, t₁ a ⊆ t₂ a) : s.biUnion t₁ ⊆ s.biUnion t₂ := by grind
 
+@[gcongr]
 lemma biUnion_subset_biUnion_of_subset_left (t : α → Finset β) (h : s₁ ⊆ s₂) :
     s₁.biUnion t ⊆ s₂.biUnion t := by grind
 

--- a/Mathlib/Data/Finsupp/MonomialOrder.lean
+++ b/Mathlib/Data/Finsupp/MonomialOrder.lean
@@ -125,7 +125,7 @@ noncomputable instance {α N : Type*} [LinearOrder α]
     [AddCommMonoid N] [PartialOrder N] [IsOrderedCancelAddMonoid N] :
     IsOrderedCancelAddMonoid (Lex (α →₀ N)) where
   le_of_add_le_add_left a b c h := by simpa only [add_le_add_iff_left] using h
-  add_le_add_left a b h c := by simpa only [add_le_add_iff_left] using h
+  add_le_add_left a b h c := by simpa using h
 
 /-- for the lexicographic ordering, X 0 * X 1 < X 0 ^ 2 -/
 example : toLex (Finsupp.single 0 2) > toLex (Finsupp.single 0 1 + Finsupp.single 1 1) := by

--- a/Mathlib/Data/Int/Basic.lean
+++ b/Mathlib/Data/Int/Basic.lean
@@ -25,6 +25,8 @@ variable {a b c d m n : ℤ}
 -- TODO: Tag in Lean
 attribute [simp] natAbs_pos
 
+@[gcongr] alias ⟨_, GCongr.ofNat_le_ofNat⟩ := ofNat_le
+
 instance instNontrivial : Nontrivial ℤ := ⟨⟨0, 1, Int.zero_ne_one⟩⟩
 
 @[simp] lemma ofNat_injective : Function.Injective ofNat := @Int.ofNat.inj

--- a/Mathlib/Data/Int/LeastGreatest.lean
+++ b/Mathlib/Data/Int/LeastGreatest.lean
@@ -49,9 +49,8 @@ def leastOfBdd {P : ℤ → Prop} [DecidablePred P] (b : ℤ) (Hb : ∀ z : ℤ,
     let ⟨elt, Helt⟩ := Hinh
     match elt, le.dest (Hb _ Helt), Helt with
     | _, ⟨n, rfl⟩, Hn => ⟨n, Hn⟩
-  ⟨b + (Nat.find EX : ℤ), Nat.find_spec EX, fun z h =>
-    match z, le.dest (Hb _ h), h with
-    | _, ⟨_, rfl⟩, h => add_le_add_left (Int.ofNat_le.2 <| Nat.find_min' _ h) _⟩
+  ⟨b + (Nat.find EX : ℤ), Nat.find_spec EX, fun z h => by
+    obtain ⟨n, rfl⟩ := le.dest (Hb _ h); grw [Int.ofNat_le.2 <| Nat.find_min' EX h]⟩
 
 /-- `Int.leastOfBdd` is the least integer satisfying a predicate which is false for all `z : ℤ` with
 `z < b` for some fixed `b : ℤ`. -/

--- a/Mathlib/Data/NNReal/Defs.lean
+++ b/Mathlib/Data/NNReal/Defs.lean
@@ -314,7 +314,8 @@ noncomputable example : LinearOrder ℝ≥0 := by infer_instance
 
 @[simp, norm_cast] lemma coe_lt_coe : (r₁ : ℝ) < r₂ ↔ r₁ < r₂ := Iff.rfl
 
-@[bound] private alias ⟨_, Bound.coe_lt_coe_of_lt⟩ := coe_lt_coe
+@[gcongr] private alias ⟨_, GCongr.coe_le_coe_of_le⟩ := coe_le_coe
+@[gcongr, bound] private alias ⟨_, Bound.coe_lt_coe_of_lt⟩ := coe_lt_coe
 
 @[simp, norm_cast] lemma coe_pos : (0 : ℝ) < r ↔ 0 < r := Iff.rfl
 

--- a/Mathlib/Data/Nat/Cast/Order/Ring.lean
+++ b/Mathlib/Data/Nat/Cast/Order/Ring.lean
@@ -125,9 +125,8 @@ lemma two_mul_sq_add_one_le_two_pow_two_mul (k : ℕ) : 2 * k ^ 2 + 1 ≤ 2 ^ (2
   induction k with
   | zero => simp
   | succ k hk =>
-    rw [add_pow_two, one_pow, mul_one, add_assoc, mul_add, add_right_comm]
-    refine (add_le_add_right hk _).trans ?_
-    rw [mul_add 2 k, pow_add, mul_one, pow_two, ← mul_assoc, mul_two, mul_two, add_assoc]
+    grw [add_pow_two, one_pow, mul_one, add_assoc, mul_add, add_right_comm, hk, mul_add 2 k,
+      pow_add, mul_one, pow_two, ← mul_assoc, mul_two, mul_two, add_assoc]
     gcongr
     rw [← two_mul, ← pow_succ']
     exact le_add_of_le_right (mul_le_pow (by simp) _)

--- a/Mathlib/Data/Nat/Choose/Factorization.lean
+++ b/Mathlib/Data/Nat/Choose/Factorization.lean
@@ -221,7 +221,7 @@ theorem factorization_choose_of_lt_three_mul (hp' : p ≠ 2) (hk : p ≤ k) (hk'
       have : 3 ≤ p := lt_of_le_of_ne hp.two_le hp'.symm
       calc
         n < 3 * p := hn
-        _ ≤ p * p := mul_le_mul_right' this p
+        _ ≤ p * p := by gcongr
         _ = p ^ 2 := (sq p).symm
         _ ≤ p ^ i := pow_right_mono₀ hp.one_lt.le hi
     rwa [mod_eq_of_lt (lt_of_le_of_lt hkn hn), mod_eq_of_lt (lt_of_le_of_lt tsub_le_self hn),

--- a/Mathlib/Data/Nat/Count.lean
+++ b/Mathlib/Data/Nat/Count.lean
@@ -145,9 +145,9 @@ lemma exists_of_count_lt_count {a b : ℕ} (h : a.count p < b.count p) : ∃ x �
 variable {q : ℕ → Prop}
 variable [DecidablePred q]
 
-theorem count_mono_left {n : ℕ} (hpq : ∀ k, p k → q k) : count p n ≤ count q n := by
-  simp only [count_eq_card_filter_range]
-  exact card_le_card ((range n).monotone_filter_right hpq)
+@[gcongr]
+theorem count_mono_left {n : ℕ} (hpq : ∀ k < n, p k → q k) : count p n ≤ count q n :=
+  List.countP_mono_left <| by simpa
 
 end Count
 

--- a/Mathlib/Data/Nat/Digits/Defs.lean
+++ b/Mathlib/Data/Nat/Digits/Defs.lean
@@ -601,8 +601,7 @@ theorem digits_succ (b n m r l) (e : r + b * m = n) (hr : r < b)
   subst h; exact Nat.digits_def' b2 n0
 
 theorem digits_one (b n) (n0 : 0 < n) (nb : n < b) : Nat.digits b n = [n] ∧ 1 < b ∧ 0 < n := by
-  have b2 : 1 < b :=
-    lt_iff_add_one_le.mpr (le_trans (add_le_add_right (lt_iff_add_one_le.mp n0) 1) nb)
+  have b2 : 1 < b := by cutsat
   refine ⟨?_, b2, n0⟩
   rw [Nat.digits_def' b2 n0, Nat.mod_eq_of_lt nb, Nat.div_eq_zero_iff.2 <| .inr nb, Nat.digits_zero]
 

--- a/Mathlib/Data/Nat/Dist.lean
+++ b/Mathlib/Data/Nat/Dist.lean
@@ -24,56 +24,34 @@ theorem dist_comm (n m : ℕ) : dist n m = dist m n := by simp [dist, add_comm]
 @[simp]
 theorem dist_self (n : ℕ) : dist n n = 0 := by simp [dist, tsub_self]
 
-theorem eq_of_dist_eq_zero {n m : ℕ} (h : dist n m = 0) : n = m :=
-  have : n - m = 0 := Nat.eq_zero_of_add_eq_zero_right h
-  have : n ≤ m := tsub_eq_zero_iff_le.mp this
-  have : m - n = 0 := Nat.eq_zero_of_add_eq_zero_left h
-  have : m ≤ n := tsub_eq_zero_iff_le.mp this
-  le_antisymm ‹n ≤ m› ‹m ≤ n›
+theorem eq_of_dist_eq_zero {n m : ℕ} (h : dist n m = 0) : n = m := by unfold Nat.dist at h; cutsat
 
-theorem dist_eq_zero {n m : ℕ} (h : n = m) : dist n m = 0 := by rw [h, dist_self]
+theorem dist_eq_zero {n m : ℕ} (h : n = m) : dist n m = 0 := by unfold Nat.dist; cutsat
 
-theorem dist_eq_sub_of_le {n m : ℕ} (h : n ≤ m) : dist n m = m - n := by
-  rw [dist, tsub_eq_zero_iff_le.mpr h, zero_add]
+theorem dist_eq_sub_of_le {n m : ℕ} (h : n ≤ m) : dist n m = m - n := by unfold Nat.dist; cutsat
 
 theorem dist_eq_sub_of_le_right {n m : ℕ} (h : m ≤ n) : dist n m = n - m := by
-  rw [dist_comm]; apply dist_eq_sub_of_le h
+  unfold Nat.dist; cutsat
 
-theorem dist_tri_left (n m : ℕ) : m ≤ dist n m + n :=
-  le_trans le_tsub_add (add_le_add_right (Nat.le_add_left _ _) _)
+theorem dist_tri_left (n m : ℕ) : m ≤ dist n m + n := by unfold Nat.dist; cutsat
+theorem dist_tri_right (n m : ℕ) : m ≤ n + dist n m := by unfold Nat.dist; cutsat
+theorem dist_tri_left' (n m : ℕ) : n ≤ dist n m + m := by unfold Nat.dist; cutsat
+theorem dist_tri_right' (n m : ℕ) : n ≤ m + dist n m := by unfold Nat.dist; cutsat
 
-theorem dist_tri_right (n m : ℕ) : m ≤ n + dist n m := by rw [add_comm]; apply dist_tri_left
+theorem dist_zero_right (n : ℕ) : dist n 0 = n := by unfold Nat.dist; cutsat
+theorem dist_zero_left (n : ℕ) : dist 0 n = n := by unfold Nat.dist; cutsat
 
-theorem dist_tri_left' (n m : ℕ) : n ≤ dist n m + m := by rw [dist_comm]; apply dist_tri_left
-
-theorem dist_tri_right' (n m : ℕ) : n ≤ m + dist n m := by rw [dist_comm]; apply dist_tri_right
-
-theorem dist_zero_right (n : ℕ) : dist n 0 = n :=
-  Eq.trans (dist_eq_sub_of_le_right (zero_le n)) (tsub_zero n)
-
-theorem dist_zero_left (n : ℕ) : dist 0 n = n :=
-  Eq.trans (dist_eq_sub_of_le (zero_le n)) (tsub_zero n)
-
-theorem dist_add_add_right (n k m : ℕ) : dist (n + k) (m + k) = dist n m :=
-  calc
-    dist (n + k) (m + k) = n + k - (m + k) + (m + k - (n + k)) := rfl
-    _ = n - m + (m + k - (n + k)) := by rw [@add_tsub_add_eq_tsub_right]
-    _ = n - m + (m - n) := by rw [@add_tsub_add_eq_tsub_right]
+theorem dist_add_add_right (n k m : ℕ) : dist (n + k) (m + k) = dist n m := by
+  unfold Nat.dist; cutsat
 
 theorem dist_add_add_left (k n m : ℕ) : dist (k + n) (k + m) = dist n m := by
-  rw [add_comm k n, add_comm k m]; apply dist_add_add_right
+  unfold Nat.dist; cutsat
 
-theorem dist_eq_intro {n m k l : ℕ} (h : n + m = k + l) : dist n k = dist l m :=
-  calc
-    dist n k = dist (n + m) (k + m) := by rw [dist_add_add_right]
-    _ = dist (k + l) (k + m) := by rw [h]
-    _ = dist l m := by rw [dist_add_add_left]
+theorem dist_eq_intro {n m k l : ℕ} (h : n + m = k + l) : dist n k = dist l m := by
+  unfold Nat.dist; cutsat
 
 theorem dist.triangle_inequality (n m k : ℕ) : dist n k ≤ dist n m + dist m k := by
-  have : dist n m + dist m k = n - m + (m - k) + (k - m + (m - n)) := by
-    simp [dist, add_comm, add_left_comm, add_assoc]
-  rw [this, dist]
-  exact add_le_add tsub_le_tsub_add_tsub tsub_le_tsub_add_tsub
+  unfold Nat.dist; cutsat
 
 theorem dist_mul_right (n k m : ℕ) : dist (n * k) (m * k) = dist n m * k := by
   rw [dist, dist, right_distrib, tsub_mul n, tsub_mul m]
@@ -81,17 +59,11 @@ theorem dist_mul_right (n k m : ℕ) : dist (n * k) (m * k) = dist n m * k := by
 theorem dist_mul_left (k n m : ℕ) : dist (k * n) (k * m) = k * dist n m := by
   rw [mul_comm k n, mul_comm k m, dist_mul_right, mul_comm]
 
-theorem dist_eq_max_sub_min {i j : ℕ} : dist i j = (max i j) - min i j :=
-  Or.elim (lt_or_ge i j)
-  (by intro h; rw [max_eq_right_of_lt h, min_eq_left_of_lt h, dist_eq_sub_of_le (Nat.le_of_lt h)])
-  (by intro h; rw [max_eq_left h, min_eq_right h, dist_eq_sub_of_le_right h])
+theorem dist_eq_max_sub_min {i j : ℕ} : dist i j = (max i j) - min i j := by
+  cases le_total i j <;> simp [Nat.dist, *]
 
-theorem dist_succ_succ {i j : Nat} : dist (succ i) (succ j) = dist i j := by
-  simp [dist, succ_sub_succ]
+theorem dist_succ_succ {i j : Nat} : dist (succ i) (succ j) = dist i j := by unfold Nat.dist; cutsat
 
-theorem dist_pos_of_ne {i j : Nat} (h : i ≠ j) : 0 < dist i j := by
-  cases h.lt_or_gt with
-  | inl h => rw [dist_eq_sub_of_le h.le]; apply tsub_pos_of_lt h
-  | inr h => rw [dist_eq_sub_of_le_right h.le]; apply tsub_pos_of_lt h
+theorem dist_pos_of_ne {i j : Nat} (h : i ≠ j) : 0 < dist i j := by unfold Nat.dist; cutsat
 
 end Nat

--- a/Mathlib/Data/Nat/Factorization/Basic.lean
+++ b/Mathlib/Data/Nat/Factorization/Basic.lean
@@ -455,12 +455,8 @@ theorem card_multiples (n p : ℕ) : #{e ∈ range n | p ∣ e + 1} = n / p := b
 
 /-- Exactly `n / p` naturals in `(0, n]` are multiples of `p`. -/
 theorem Ioc_filter_dvd_card_eq_div (n p : ℕ) : #{x ∈ Ioc 0 n | p ∣ x} = n / p := by
-  induction n with
-  | zero => simp
-  | succ n IH =>
-    simp [Nat.succ_div, add_ite, add_zero, filter_insert, apply_ite card, IH,
-      Finset.mem_filter, mem_Ioc, not_le.2 (lt_add_one n),
-      ← Finset.insert_Ioc_right_eq_Ioc_add_one (zero_le _)]
+  induction n <;> simp [Nat.succ_div, add_ite, ← insert_Ioc_right_eq_Ioc_add_one, filter_insert,
+    apply_ite card, *]
 
 /-- There are exactly `⌊N/n⌋` positive multiples of `n` that are `≤ N`.
 See `Nat.card_multiples` for a "shifted-by-one" version. -/

--- a/Mathlib/Data/Nat/Fib/Zeckendorf.lean
+++ b/Mathlib/Data/Nat/Fib/Zeckendorf.lean
@@ -76,11 +76,11 @@ lemma fib_greatestFib_le (n : ℕ) : fib (greatestFib n) ≤ n :=
   findGreatest_spec (P := (fun k ↦ fib k ≤ n)) (zero_le _) <| zero_le _
 
 lemma greatestFib_mono : Monotone greatestFib :=
-  fun _a _b hab ↦ findGreatest_mono (fun _k ↦ hab.trans') <| add_le_add_right hab _
+  fun _a _b hab ↦ findGreatest_mono (fun _k ↦ hab.trans') <| by gcongr
 
 @[simp] lemma le_greatestFib : m ≤ greatestFib n ↔ fib m ≤ n :=
   ⟨fun h ↦ (fib_mono h).trans <| fib_greatestFib_le _,
-    fun h ↦ le_findGreatest (m.le_fib_add_one.trans <| add_le_add_right h _) h⟩
+    fun h ↦ le_findGreatest (m.le_fib_add_one.trans <| by gcongr) h⟩
 
 @[simp] lemma greatestFib_lt : greatestFib m < n ↔ m < fib n :=
   lt_iff_lt_of_le_iff_le le_greatestFib

--- a/Mathlib/Data/Nat/Totient.lean
+++ b/Mathlib/Data/Nat/Totient.lean
@@ -95,7 +95,7 @@ theorem Ico_filter_coprime_le {a : ℕ} (k n : ℕ) (a_ne_zero : a ≠ 0) :
     _ ≤ #{x ∈ Ico k (k + n % a + a * i) | a.Coprime x} + a.totient := by
       rw [filter_union, ← filter_coprime_Ico_eq_totient a (k + n % a + a * i)]
       apply card_union_le
-    _ ≤ a.totient * i + a.totient + a.totient := add_le_add_right ih (totient a)
+    _ ≤ a.totient * i + a.totient + a.totient := by grw [← mul_add_one, ih]
 
 open ZMod
 
@@ -346,8 +346,7 @@ theorem totient_super_multiplicative (a b : ℕ) : φ a * φ b ≤ φ (a * b) :=
   · simp
   have hd0 : 0 < d := Nat.gcd_pos_of_pos_left _ ha0
   apply le_of_mul_le_mul_right _ hd0
-  rw [← totient_gcd_mul_totient_mul a b, mul_comm]
-  apply mul_le_mul_left' (Nat.totient_le d)
+  grw [← totient_gcd_mul_totient_mul a b, mul_comm, d.totient_le]
 
 @[gcongr]
 theorem totient_dvd_of_dvd {a b : ℕ} (h : a ∣ b) : φ a ∣ φ b := by

--- a/Mathlib/Data/Num/ZNum.lean
+++ b/Mathlib/Data/Num/ZNum.lean
@@ -623,12 +623,10 @@ theorem gcd_to_nat_aux :
     rw [pow_succ, ← Nat.mod_add_div b (pos a)] at h
     refine lt_of_mul_lt_mul_right (lt_of_le_of_lt ?_ h) (Nat.zero_le 2)
     rw [mul_two, mul_add]
-    refine
-      add_le_add_left
-        (Nat.mul_le_mul_left _ (le_trans (le_of_lt (Nat.mod_lt _ (PosNum.cast_pos _))) ?_)) _
-    suffices 1 ≤ _ by simpa using Nat.mul_le_mul_left (pos a) this
-    rw [Nat.le_div_iff_mul_le a.cast_pos, one_mul]
-    exact le_to_nat.2 ab
+    gcongr _ + _ * ?_
+    grw [Nat.mod_lt, ← le_to_nat.2 ab]
+    · simp
+    · exact PosNum.cast_pos _
 
 @[simp]
 theorem gcd_to_nat : ∀ a b, (gcd a b : ℕ) = Nat.gcd a b := by

--- a/Mathlib/Data/Set/Equitable.lean
+++ b/Mathlib/Data/Set/Equitable.lean
@@ -35,7 +35,7 @@ theorem equitableOn_empty [LE β] [Add β] [One β] (f : α → β) : EquitableO
 
 theorem equitableOn_iff_exists_le_le_add_one {s : Set α} {f : α → ℕ} :
     s.EquitableOn f ↔ ∃ b, ∀ a ∈ s, b ≤ f a ∧ f a ≤ b + 1 := by
-  refine ⟨?_, fun ⟨b, hb⟩ x y hx hy => (hb x hx).2.trans (add_le_add_right (hb y hy).1 _)⟩
+  refine ⟨?_, fun ⟨b, hb⟩ x y hx hy => by grw [(hb x hx).2, (hb y hy).1]⟩
   obtain rfl | ⟨x, hx⟩ := s.eq_empty_or_nonempty
   · simp
   intro hs

--- a/Mathlib/Dynamics/Circle/RotationNumber/TranslationNumber.lean
+++ b/Mathlib/Dynamics/Circle/RotationNumber/TranslationNumber.lean
@@ -251,11 +251,9 @@ theorem commute_iff_commute {f g : CircleDeg1Lift} : Commute f g ↔ Function.Co
 `Multiplicative ℝ` to `CircleDeg1Liftˣ`, so the translation by `x` is
 `translation (Multiplicative.ofAdd x)`. -/
 def translate : Multiplicative ℝ →* CircleDeg1Liftˣ := MonoidHom.toHomUnits <|
-  { toFun := fun x =>
-      ⟨⟨fun y => x.toAdd + y, fun _ _ h => add_le_add_left h _⟩, fun _ =>
-        (add_assoc _ _ _).symm⟩
-    map_one' := ext <| zero_add
-    map_mul' := fun _ _ => ext <| add_assoc _ _ }
+  { toFun x := ⟨⟨fun y => x.toAdd + y, add_right_mono⟩, fun _ => (add_assoc ..).symm⟩
+    map_one' := ext zero_add
+    map_mul' _ _ := ext <| add_assoc _ _ }
 
 @[simp]
 theorem translate_apply (x y : ℝ) : translate (Multiplicative.ofAdd x) y = x + y :=
@@ -417,7 +415,7 @@ theorem ceil_map_map_zero_le : ⌈f (g 0)⌉ ≤ ⌈f 0⌉ + ⌈g 0⌉ :=
 theorem map_map_zero_lt : f (g 0) < f 0 + g 0 + 1 :=
   calc
     f (g 0) ≤ f 0 + ⌈g 0⌉ := f.map_map_zero_le g
-    _ < f 0 + (g 0 + 1) := add_lt_add_left (ceil_lt_add_one _) _
+    _ < f 0 + (g 0 + 1) := by gcongr; exact ceil_lt_add_one _
     _ = f 0 + g 0 + 1 := (add_assoc _ _ _).symm
 
 theorem le_map_of_map_zero (x : ℝ) : f 0 + ⌊x⌋ ≤ f x :=
@@ -441,7 +439,7 @@ theorem le_ceil_map_map_zero : ⌈f 0⌉ + ⌊g 0⌋ ≤ ⌈(f * g) 0⌉ :=
 theorem lt_map_map_zero : f 0 + g 0 - 1 < f (g 0) :=
   calc
     f 0 + g 0 - 1 = f 0 + (g 0 - 1) := add_sub_assoc _ _ _
-    _ < f 0 + ⌊g 0⌋ := add_lt_add_left (sub_one_lt_floor _) _
+    _ < f 0 + ⌊g 0⌋ := by gcongr; exact sub_one_lt_floor _
     _ ≤ f (g 0) := f.le_map_map_zero g
 
 theorem dist_map_map_zero_lt : dist (f 0 + g 0) (f (g 0)) < 1 := by
@@ -842,8 +840,7 @@ theorem semiconj_of_group_action_of_forall_translationNumber_eq {G : Type*} [Gro
       f₂ g⁻¹ (f₁ g x) ≤ f₂ g⁻¹ (x + τ (f₁ g) + 1) :=
         mono _ (map_lt_add_translationNumber_add_one _ _).le
       _ = f₂ g⁻¹ (x + τ (f₂ g)) + 1 := by rw [h, map_add_one]
-      _ ≤ x + τ (f₂ g) + τ (f₂ g⁻¹) + 1 + 1 :=
-        add_le_add_right (map_lt_add_translationNumber_add_one _ _).le _
+      _ ≤ x + τ (f₂ g) + τ (f₂ g⁻¹) + 1 + 1 := by grw [map_lt_add_translationNumber_add_one]
       _ = x + 2 := by simp [this, add_assoc, one_add_one_eq_two]
   -- We have a theorem about actions by `OrderIso`, so we introduce auxiliary maps
   -- to `ℝ ≃o ℝ`.

--- a/Mathlib/Geometry/Manifold/VectorField/LieBracket.lean
+++ b/Mathlib/Geometry/Manifold/VectorField/LieBracket.lean
@@ -766,12 +766,11 @@ protected lemma _root_.ContMDiffWithinAt.mlieBracketWithin_vectorField
   locally a smooth function, which coincides with the initial Lie bracket by invariance
   under diffeos. -/
   have min2 : minSmoothness 𝕜 2 ≤ n + 1 := by
-    apply le_trans _ (add_le_add_right hmn 1)
-    rw [← minSmoothness_add, add_assoc]
+    grw [← hmn, ← minSmoothness_add, add_assoc]
     exact minSmoothness_monotone le_add_self
   apply contMDiffWithinAt_iff_le_ne_infty.2 (fun m' hm' h'm' ↦ ?_)
   have hn : 1 ≤ m' + 1 := le_add_self
-  have hm'n : m' + 1 ≤ n := le_trans (add_le_add_right hm' 1) (le_minSmoothness.trans hmn)
+  have hm'n : m' + 1 ≤ n := by grw [hm', ← hmn, ← le_minSmoothness]
   have pre_mem : (extChartAt I x) ⁻¹' ((extChartAt I x).target ∩ (extChartAt I x).symm ⁻¹' s)
       ∈ 𝓝[s] x := by
     filter_upwards [self_mem_nhdsWithin,
@@ -805,9 +804,9 @@ protected lemma _root_.ContMDiffWithinAt.mlieBracketWithin_vectorField
     eventually_eventually_nhdsWithin.2 (eventuallyEq_mpullback_mpullbackWithin_extChartAt U),
     eventually_eventually_nhdsWithin.2 (eventuallyEq_mpullback_mpullbackWithin_extChartAt V),
     eventually_contMDiffWithinAt_mpullbackWithin_extChartAt_symm (hU.of_le hm'n) hs hx
-      (add_le_add_right hm'n 1) (by simp [h'm']),
+      (by gcongr) (by simp [h'm']),
     eventually_contMDiffWithinAt_mpullbackWithin_extChartAt_symm (hV.of_le hm'n) hs hx
-      (add_le_add_right hm'n 1) (by simp [h'm']),
+      (by gcongr) (by simp [h'm']),
     nhdsWithin_le_nhds (chart_source_mem_nhds H x), self_mem_nhdsWithin]
     with y hy hyU hyV h'yU h'yV hy_chart hys
   simp only [Bundle.TotalSpace.mk_inj]

--- a/Mathlib/GroupTheory/Archimedean.lean
+++ b/Mathlib/GroupTheory/Archimedean.lean
@@ -83,14 +83,14 @@ theorem Subgroup.exists_isLeast_one_lt {H : Subgroup G} (hbot : H ≠ ⊥) {a : 
   simp only [IsLeast, not_and, mem_setOf_eq, mem_lowerBounds, not_exists, not_forall,
     not_le] at hxmin
   rcases hxmin x ⟨hxH, (one_le_pow_of_one_le'  h₀.le _).trans_lt hnx⟩ with ⟨y, ⟨hyH, hy₀⟩, hxy⟩
-  rcases hex y hy₀ with ⟨m, hm⟩
+  obtain ⟨m, hm, hya⟩ := hex y hy₀
   rcases lt_or_ge m n with hmn | hnm
-  · exact hmin m hmn ⟨y, hyH, hm⟩
+  · exact hmin m hmn ⟨y, hyH, hm, hya⟩
   · refine disjoint_left.1 hd (div_mem hxH hyH) ⟨one_lt_div'.2 hxy, div_lt_iff_lt_mul'.2 ?_⟩
     calc x ≤ a^ (n + 1) := hxn
-    _ ≤ a ^ (m + 1) := pow_le_pow_right' h₀.le (add_le_add_right hnm _)
+    _ ≤ a ^ (m + 1) := by grw [hnm]; exact h₀.le
     _ = a ^ m * a := pow_succ _ _
-    _ < y * a := mul_lt_mul_right' hm.1 _
+    _ < y * a := by gcongr
 
 /-- If a subgroup of a linear ordered commutative group is disjoint with the
 interval `Set.Ioo 1 a` for some `1 < a`, then this is a cyclic subgroup. -/

--- a/Mathlib/GroupTheory/Index.lean
+++ b/Mathlib/GroupTheory/Index.lean
@@ -441,7 +441,7 @@ theorem relIndex_inf_le : (H ⊓ K).relIndex L ≤ H.relIndex L * K.relIndex L :
   · exact (le_of_eq (relIndex_eq_zero_of_le_left inf_le_left h)).trans (zero_le _)
   rw [← inf_relIndex_right, inf_assoc, ← relIndex_mul_relIndex _ _ L inf_le_right inf_le_right,
     inf_relIndex_right, inf_relIndex_right]
-  exact mul_le_mul_right' (relIndex_le_of_le_right inf_le_right h) (K.relIndex L)
+  grw [relIndex_le_of_le_right inf_le_right h]
 
 @[deprecated (since := "2025-08-12")] alias relindex_inf_le := relIndex_inf_le
 

--- a/Mathlib/GroupTheory/MonoidLocalization/Order.lean
+++ b/Mathlib/GroupTheory/MonoidLocalization/Order.lean
@@ -67,8 +67,7 @@ instance partialOrder : PartialOrder (Localization s) where
       simp only [mk_le_mk] at hab hbc ⊢
       apply le_of_mul_le_mul_left' _
       · exact ↑b.2
-      rw [mul_left_comm]
-      refine (mul_le_mul_left' hab _).trans ?_
+      grw [mul_left_comm, hab]
       rwa [mul_left_comm, mul_left_comm (b.2 : α), mul_le_mul_iff_left]
   le_antisymm a b := by
     induction a using Localization.rec

--- a/Mathlib/GroupTheory/Perm/Cycle/Type.lean
+++ b/Mathlib/GroupTheory/Perm/Cycle/Type.lean
@@ -327,9 +327,7 @@ theorem cycleType_of_card_le_mem_cycleType_add_two {n : ℕ} {g : Perm α}
   suffices g'1 : g' = 1 by
     rw [hd.cycleType_mul, hc.cycleType, g'1, cycleType_one, add_zero]
   contrapose! hn2 with g'1
-  apply le_trans _ (c * g').support.card_le_univ
-  rw [hd.card_support_mul]
-  exact add_le_add_left (two_le_card_support_of_ne_one g'1) _
+  grw [← (c * g').support.card_le_univ, hd.card_support_mul, two_le_card_support_of_ne_one g'1]
 
 end CycleType
 

--- a/Mathlib/InformationTheory/Hamming.lean
+++ b/Mathlib/InformationTheory/Hamming.lean
@@ -57,7 +57,7 @@ theorem hammingDist_triangle (x y z : ∀ i, β i) :
     unfold hammingDist
     refine le_trans (card_mono ?_) (card_union_le _ _)
     rw [← filter_or]
-    exact monotone_filter_right _ fun i h ↦ (h.ne_or_ne _).imp_right Ne.symm
+    exact monotone_filter_right _ fun i _ h ↦ (h.ne_or_ne _).imp_right Ne.symm
 
 /-- Corresponds to `dist_triangle_left`. -/
 theorem hammingDist_triangle_left (x y z : ∀ i, β i) :
@@ -109,13 +109,12 @@ theorem hammingDist_le_card_fintype {x y : ∀ i, β i} : hammingDist x y ≤ Fi
   card_le_univ _
 
 theorem hammingDist_comp_le_hammingDist (f : ∀ i, γ i → β i) {x y : ∀ i, γ i} :
-    (hammingDist (fun i => f i (x i)) fun i => f i (y i)) ≤ hammingDist x y :=
-  card_mono (monotone_filter_right _ fun i H1 H2 => H1 <| congr_arg (f i) H2)
+    hammingDist (fun i => f i (x i)) (fun i => f i (y i)) ≤ hammingDist x y := by
+  dsimp [hammingDist]; gcongr; simp +contextual
 
 theorem hammingDist_comp (f : ∀ i, γ i → β i) {x y : ∀ i, γ i} (hf : ∀ i, Injective (f i)) :
-    (hammingDist (fun i => f i (x i)) fun i => f i (y i)) = hammingDist x y :=
-  le_antisymm (hammingDist_comp_le_hammingDist _) <|
-    card_mono (monotone_filter_right _ fun i H1 H2 => H1 <| hf i H2)
+    hammingDist (fun i => f i (x i)) (fun i => f i (y i)) = hammingDist x y :=
+  le_antisymm (hammingDist_comp_le_hammingDist _) <| by dsimp [hammingDist]; gcongr; exact @hf _ _ _
 
 theorem hammingDist_smul_le_hammingDist [∀ i, SMul α (β i)] {k : α} {x y : ∀ i, β i} :
     hammingDist (k • x) (k • y) ≤ hammingDist x y :=

--- a/Mathlib/LinearAlgebra/AffineSpace/FiniteDimensional.lean
+++ b/Mathlib/LinearAlgebra/AffineSpace/FiniteDimensional.lean
@@ -710,16 +710,15 @@ variable (k) in
 one. -/
 theorem finrank_vectorSpan_insert_le_set (s : Set P) (p : P) :
     finrank k (vectorSpan k (insert p s)) ≤ finrank k (vectorSpan k s) + 1 := by
-  rw [← direction_affineSpan, ← affineSpan_insert_affineSpan, direction_affineSpan]
-  refine (finrank_vectorSpan_insert_le _ _).trans (add_le_add_right ?_ _)
-  rw [direction_affineSpan]
+  rw [← direction_affineSpan, ← affineSpan_insert_affineSpan, direction_affineSpan,
+    ← direction_affineSpan _ s]
+  exact finrank_vectorSpan_insert_le ..
 
 /-- Adding a point to a collinear set produces a coplanar set. -/
 theorem Collinear.coplanar_insert {s : Set P} (h : Collinear k s) (p : P) :
     Coplanar k (insert p s) := by
   have : FiniteDimensional k { x // x ∈ vectorSpan k s } := h.finiteDimensional_vectorSpan
-  rw [coplanar_iff_finrank_le_two]
-  exact (finrank_vectorSpan_insert_le_set k s p).trans (add_le_add_right h.finrank_le_one _)
+  grw [coplanar_iff_finrank_le_two, finrank_vectorSpan_insert_le_set, h.finrank_le_one]
 
 /-- A set of points in a two-dimensional space is coplanar. -/
 theorem coplanar_of_finrank_eq_two (s : Set P) (h : finrank k V = 2) : Coplanar k s := by

--- a/Mathlib/LinearAlgebra/AffineSpace/Ordered.lean
+++ b/Mathlib/LinearAlgebra/AffineSpace/Ordered.lean
@@ -62,8 +62,7 @@ theorem lineMap_mono_right (hb : b ≤ b') (hr : 0 ≤ r) : lineMap a b r ≤ li
 
 omit [IsOrderedRing k] in
 theorem lineMap_strict_mono_right (hb : b < b') (hr : 0 < r) : lineMap a b r < lineMap a b' r := by
-  simp only [lineMap_apply_module]
-  exact add_lt_add_left (smul_lt_smul_of_pos_left hb hr) _
+  simp only [lineMap_apply_module]; gcongr
 
 theorem lineMap_mono_endpoints (ha : a ≤ a') (hb : b ≤ b') (h₀ : 0 ≤ r) (h₁ : r ≤ 1) :
     lineMap a b r ≤ lineMap a' b' r :=

--- a/Mathlib/LinearAlgebra/Dimension/LinearMap.lean
+++ b/Mathlib/LinearAlgebra/Dimension/LinearMap.lean
@@ -92,7 +92,7 @@ theorem rank_add_le (f g : V →ₗ[K] V') : rank (f + g) ≤ rank f + rank g :=
 theorem rank_finset_sum_le {η} (s : Finset η) (f : η → V →ₗ[K] V') :
     rank (∑ d ∈ s, f d) ≤ ∑ d ∈ s, rank (f d) :=
   @Finset.sum_hom_rel _ _ _ _ _ (fun a b => rank a ≤ b) f (fun d => rank (f d)) s
-    (le_of_eq rank_zero) fun _ _ _ h => le_trans (rank_add_le _ _) (add_le_add_left h _)
+    (le_of_eq rank_zero) fun _ _ _ h => le_trans (rank_add_le _ _) (by gcongr)
 
 theorem le_rank_iff_exists_linearIndependent {c : Cardinal} {f : V →ₗ[K] V'} :
     c ≤ rank f ↔ ∃ s : Set V,

--- a/Mathlib/MeasureTheory/Constructions/Polish/Basic.lean
+++ b/Mathlib/MeasureTheory/Constructions/Polish/Basic.lean
@@ -778,8 +778,7 @@ theorem MeasureTheory.measurableSet_range_of_continuous_injective {β : Type*} [
       intro a ha
       calc
         dist a z ≤ dist a (y n) + dist (y n) z := dist_triangle _ _ _
-        _ ≤ u n + dist (y n) z :=
-          (add_le_add_right ((dist_le_diam_of_mem (hs n).1 ha (hy n)).trans (hs n).2) _)
+        _ ≤ u n + dist (y n) z := by grw [dist_le_diam_of_mem (hs n).1 ha (hy n), (hs n).2]
         _ < δ := hn
     -- as `x` belongs to the closure of `f '' (s n)`, it belongs to the closure of `v`.
     have : x ∈ closure v := closure_mono fsnv (hxs n).1

--- a/Mathlib/MeasureTheory/Covering/Besicovitch.lean
+++ b/Mathlib/MeasureTheory/Covering/Besicovitch.lean
@@ -776,7 +776,7 @@ theorem exists_disjoint_closedBall_covering_ae_of_finiteMeasure_aux (μ : Measur
         calc
           _ ≤ N / (N + 1) * μ (s \ ⋃ (p : α × ℝ) (_ : p ∈ u n), closedBall p.fst p.snd) := by
             rw [u_succ]; exact (hF (u n) (Pu n)).2.2
-          _ ≤ _ := by rw [pow_succ', mul_assoc]; exact mul_le_mul_left' IH _
+          _ ≤ _ := by grw [pow_succ', mul_assoc, IH]
     have C : Tendsto (fun n : ℕ => ((N : ℝ≥0∞) / (N + 1)) ^ n * μ s) atTop (𝓝 (0 * μ s)) := by
       apply ENNReal.Tendsto.mul_const _ (Or.inr (measure_lt_top μ s).ne)
       apply ENNReal.tendsto_pow_atTop_nhds_zero_of_lt_one

--- a/Mathlib/MeasureTheory/Covering/BesicovitchVectorSpace.lean
+++ b/Mathlib/MeasureTheory/Covering/BesicovitchVectorSpace.lean
@@ -381,7 +381,7 @@ theorem exists_normalized_aux2 {N : ℕ} {τ : ℝ} (a : SatelliteConfig E N τ)
       a.r j - δ ≤ ‖a.c i - a.c j‖ := A
       _ ≤ ‖a.c i - d‖ + ‖d - a.c j‖ := by simp only [← dist_eq_norm, dist_triangle]
       _ ≤ ‖a.c i - d‖ + (a.r j - 1) := by
-        apply add_le_add_left
+        gcongr
         have A : 0 ≤ 1 - 2 / ‖a.c j‖ := by simpa [div_le_iff₀ (zero_le_two.trans_lt hj)] using hj.le
         rw [← one_smul ℝ (a.c j), hd, ← sub_smul, norm_smul, norm_sub_rev, Real.norm_eq_abs,
           abs_of_nonneg A, sub_mul]

--- a/Mathlib/MeasureTheory/Covering/Differentiation.lean
+++ b/Mathlib/MeasureTheory/Covering/Differentiation.lean
@@ -197,8 +197,9 @@ theorem ae_eventually_measure_zero_of_singular (hρ : ρ ⟂ₘ μ) :
   obtain ⟨n, hn⟩ : ∃ n, u n < w := ((tendsto_order.1 u_lim).2 w (ENNReal.coe_pos.1 w_pos)).exists
   filter_upwards [hx n, h'x, v.eventually_measure_lt_top x]
   intro a ha μa_pos μa_lt_top
-  rw [ENNReal.div_lt_iff (Or.inl μa_pos.ne') (Or.inl μa_lt_top.ne)]
-  exact ha.trans_le (mul_le_mul_right' ((ENNReal.coe_le_coe.2 hn.le).trans w_lt.le) _)
+  grw [ENNReal.div_lt_iff (.inl μa_pos.ne') (.inl μa_lt_top.ne), ha, hn]
+  gcongr
+  exact μa_lt_top.ne
 
 section AbsolutelyContinuous
 
@@ -625,8 +626,7 @@ theorem le_mul_withDensity {s : Set α} (hs : MeasurableSet s) {t : ℝ≥0} (ht
         simp only [lintegral_const, MeasurableSet.univ, Measure.restrict_apply, univ_inter]
       _ ≤ ∫⁻ x in s ∩ f ⁻¹' I, t * f x ∂μ := by
         apply lintegral_mono_ae ((ae_restrict_iff' M).2 (Eventually.of_forall fun x hx => ?_))
-        rw [add_comm, ENNReal.zpow_add t_ne_zero ENNReal.coe_ne_top, zpow_one]
-        exact mul_le_mul_left' hx.2.1 _
+        grw [add_comm, ENNReal.zpow_add t_ne_zero ENNReal.coe_ne_top, zpow_one, hx.2.1]
       _ = t * ∫⁻ x in s ∩ f ⁻¹' I, f x ∂μ := lintegral_const_mul _ f_meas
   calc
     ρ s =

--- a/Mathlib/MeasureTheory/Function/ConditionalExpectation/CondexpL2.lean
+++ b/Mathlib/MeasureTheory/Function/ConditionalExpectation/CondexpL2.lean
@@ -316,8 +316,7 @@ theorem setLIntegral_nnnorm_condExpL2_indicator_le (hm : m ≤ m0) (hs : Measura
       simp_rw [nnnorm_smul, ENNReal.coe_mul]
       rw [lintegral_mul_const]
       exact (Lp.stronglyMeasurable _).enorm (ε := ℝ)
-    _ ≤ μ (s ∩ t) * ‖x‖₊ :=
-      mul_le_mul_right' (lintegral_nnnorm_condExpL2_indicator_le_real hs hμs ht hμt) _
+    _ ≤ μ (s ∩ t) * ‖x‖₊ := by grw [lintegral_nnnorm_condExpL2_indicator_le_real hs hμs ht hμt]
 
 theorem lintegral_nnnorm_condExpL2_indicator_le (hm : m ≤ m0) (hs : MeasurableSet s) (hμs : μ s ≠ ∞)
     (x : E') [SigmaFinite (μ.trim hm)] :
@@ -387,8 +386,7 @@ theorem setLIntegral_nnnorm_condExpIndSMul_le (hm : m ≤ m0) (hs : MeasurableSe
       simp_rw [nnnorm_smul, ENNReal.coe_mul]
       rw [lintegral_mul_const]
       exact (Lp.stronglyMeasurable _).enorm (ε := ℝ)
-    _ ≤ μ (s ∩ t) * ‖x‖₊ :=
-      mul_le_mul_right' (lintegral_nnnorm_condExpL2_indicator_le_real hs hμs ht hμt) _
+    _ ≤ μ (s ∩ t) * ‖x‖₊ := by grw [lintegral_nnnorm_condExpL2_indicator_le_real hs hμs ht hμt]
 
 theorem lintegral_nnnorm_condExpIndSMul_le (hm : m ≤ m0) (hs : MeasurableSet s) (hμs : μ s ≠ ∞)
     (x : G) [SigmaFinite (μ.trim hm)] : ∫⁻ a, ‖condExpIndSMul hm hs hμs x a‖₊ ∂μ ≤ μ s * ‖x‖₊ := by

--- a/Mathlib/MeasureTheory/Function/Jacobian.lean
+++ b/Mathlib/MeasureTheory/Function/Jacobian.lean
@@ -514,7 +514,7 @@ theorem _root_.ApproximatesLinearOn.norm_fderiv_sub_le {A : E →L[ℝ] E} {δ :
     calc
       ‖a‖ = ‖z + (a - z)‖ := by simp only [add_sub_cancel]
       _ ≤ ‖z‖ + ‖a - z‖ := norm_add_le _ _
-      _ ≤ ‖z‖ + ε := add_le_add_left (mem_closedBall_iff_norm.1 az) _
+      _ ≤ ‖z‖ + ε := by grw [mem_closedBall_iff_norm.1 az]
   -- use the approximation properties to control `(f' x - A) a`, and then `(f' x - A) z` as `z` is
   -- close to `a`.
   have I : r * ‖(f' x - A) a‖ ≤ r * (δ + ε) * (‖z‖ + ε) :=
@@ -589,7 +589,7 @@ theorem addHaar_image_eq_zero_of_differentiableOn_of_addHaar_eq_zero (hf : Diffe
       apply (hδ (A n)).2
       exact ht n
     _ ≤ ∑' n, ((Real.toNNReal |(A n).det| + 1 : ℝ≥0) : ℝ≥0∞) * 0 := by
-      refine ENNReal.tsum_le_tsum fun n => mul_le_mul_left' ?_ _
+      gcongr with n
       exact le_trans (measure_mono inter_subset_left) (le_of_eq hs)
     _ = 0 := by simp only [tsum_zero, mul_zero]
 
@@ -640,9 +640,7 @@ theorem addHaar_image_eq_zero_of_det_fderivWithin_eq_zero_aux
       · exact pairwise_disjoint_mono t_disj fun n => inter_subset_right
       · intro n
         exact measurableSet_closedBall.inter (t_meas n)
-    _ ≤ ε * μ (closedBall 0 R) := by
-      rw [← inter_iUnion]
-      exact mul_le_mul_left' (measure_mono inter_subset_left) _
+    _ ≤ ε * μ (closedBall 0 R) := by grw [← inter_iUnion, inter_subset_left]
 
 /-- A version of Sard lemma in fixed dimension: given a differentiable function from `E` to `E` and
 a set where the differential is not invertible, then the image of this set has zero measure. -/

--- a/Mathlib/MeasureTheory/Function/L1Space/Integrable.lean
+++ b/Mathlib/MeasureTheory/Function/L1Space/Integrable.lean
@@ -613,7 +613,7 @@ theorem integrable_of_norm_sub_le {f₀ f₁ : α → β} {g : α → ℝ} (hf�
     intro a ha
     calc
       ‖f₁ a‖ ≤ ‖f₀ a‖ + ‖f₀ a - f₁ a‖ := norm_le_insert _ _
-      _ ≤ ‖f₀ a‖ + g a := add_le_add_left ha _
+      _ ≤ ‖f₀ a‖ + g a := by gcongr
   Integrable.mono' (hf₀_i.norm.add hg_i) hf₁_m this
 
 lemma integrable_of_le_of_le {f g₁ g₂ : α → ℝ} (hf : AEStronglyMeasurable f μ)

--- a/Mathlib/MeasureTheory/Function/LpSpace/Indicator.lean
+++ b/Mathlib/MeasureTheory/Function/LpSpace/Indicator.lean
@@ -52,8 +52,7 @@ theorem exists_eLpNorm_indicator_le (hp : p ≠ ∞) (c : E) {ε : ℝ≥0∞} (
     refine ⟨η, hη, ?_⟩
     simpa only [← ENNReal.coe_rpow_of_nonneg _ hp₀', enorm, ← ENNReal.coe_mul] using hδε' hηδ
   refine ⟨η, hη_pos, fun s hs => ?_⟩
-  refine (eLpNorm_indicator_const_le _ _).trans (le_trans ?_ hη_le)
-  gcongr
+  grw [eLpNorm_indicator_const_le, ← hη_le, hs]
 
 section Topology
 variable {X : Type*} [TopologicalSpace X] [MeasurableSpace X]

--- a/Mathlib/MeasureTheory/Function/SimpleFuncDense.lean
+++ b/Mathlib/MeasureTheory/Function/SimpleFuncDense.lean
@@ -176,7 +176,7 @@ theorem edist_approxOn_y0_le {f : β → α} (hf : Measurable f) {s : Set α} {y
     edist y₀ (approxOn f hf s y₀ h₀ n x) ≤
         edist y₀ (f x) + edist (approxOn f hf s y₀ h₀ n x) (f x) :=
       edist_triangle_right _ _ _
-    _ ≤ edist y₀ (f x) + edist y₀ (f x) := add_le_add_left (edist_approxOn_le hf h₀ x n) _
+    _ ≤ edist y₀ (f x) + edist y₀ (f x) := by grw [edist_approxOn_le hf h₀ x n]
 
 end SimpleFunc
 

--- a/Mathlib/MeasureTheory/Function/UniformIntegrable.lean
+++ b/Mathlib/MeasureTheory/Function/UniformIntegrable.lean
@@ -468,10 +468,8 @@ theorem eLpNorm_sub_le_of_dist_bdd (μ : Measure α)
         Real.norm_eq_abs, abs_of_nonneg hc]
       exact hf x hx
     · simp [Set.indicator_of_notMem hx]
-  refine le_trans (eLpNorm_mono this) ?_
-  rw [eLpNorm_indicator_const hs hp hp']
-  refine mul_le_mul_right' (le_of_eq ?_) _
-  rw [← ofReal_norm_eq_enorm, Real.norm_eq_abs, abs_of_nonneg hc]
+  grw [eLpNorm_mono this, eLpNorm_indicator_const hs hp hp', ← ofReal_norm_eq_enorm,
+    Real.norm_eq_abs, abs_of_nonneg hc]
 
 /-- A sequence of uniformly integrable functions which converges μ-a.e. converges in Lp. -/
 theorem tendsto_Lp_finite_of_tendsto_ae_of_meas [IsFiniteMeasure μ] (hp : 1 ≤ p) (hp' : p ≠ ∞)
@@ -499,11 +497,10 @@ theorem tendsto_Lp_finite_of_tendsto_ae_of_meas [IsFiniteMeasure μ] (hp : 1 ≤
   obtain ⟨N, hN⟩ := eventually_atTop.1 ht₂; clear ht₂
   refine ⟨N, fun n hn => ?_⟩
   rw [← t.indicator_self_add_compl (f n - g)]
-  refine le_trans (eLpNorm_add_le (((hf n).sub hg).indicator htm).aestronglyMeasurable
-    (((hf n).sub hg).indicator htm.compl).aestronglyMeasurable hp) ?_
-  rw [sub_eq_add_neg, Set.indicator_add' t, Set.indicator_neg']
-  refine le_trans (add_le_add_right (eLpNorm_add_le ((hf n).indicator htm).aestronglyMeasurable
-    (hg.indicator htm).neg.aestronglyMeasurable hp) _) ?_
+  grw [eLpNorm_add_le (((hf n).sub hg).indicator htm).aestronglyMeasurable
+    (((hf n).sub hg).indicator htm.compl).aestronglyMeasurable hp, sub_eq_add_neg,
+    Set.indicator_add' t, Set.indicator_neg', eLpNorm_add_le
+    ((hf n).indicator htm).aestronglyMeasurable (hg.indicator htm).neg.aestronglyMeasurable hp]
   have hnf : eLpNorm (t.indicator (f n)) p μ ≤ ENNReal.ofReal (ε.toReal / 3) := by
     refine heLpNorm₁ n t htm (le_trans ht₁ ?_)
     rw [ENNReal.ofReal_le_ofReal_iff hδ₁.le]
@@ -660,11 +657,12 @@ theorem unifIntegrable_of' (hp : 1 ≤ p) (hp' : p ≠ ∞) {f : ι → α → �
       refine le_trans (eLpNorm_le_of_ae_bound this) ?_
       rw [mul_comm, Measure.restrict_apply' hs, Set.univ_inter, ENNReal.ofReal_coe_nnreal, one_div]
     _ ≤ ENNReal.ofReal (ε / 2) + C * ENNReal.ofReal (ε / (2 * C)) := by
-      refine add_le_add (hC i) (mul_le_mul_left' ?_ _)
+      grw [hC i]
+      gcongr
       rwa [one_div, ENNReal.rpow_inv_le_iff (ENNReal.toReal_pos hpzero hp'),
         ENNReal.ofReal_rpow_of_pos (div_pos hε (mul_pos two_pos (NNReal.coe_pos.2 hCpos)))]
     _ ≤ ENNReal.ofReal (ε / 2) + ENNReal.ofReal (ε / 2) := by
-      refine add_le_add_left ?_ _
+      gcongr
       rw [← ENNReal.ofReal_coe_nnreal, ← ENNReal.ofReal_mul (NNReal.coe_nonneg _), ← div_div,
         mul_div_cancel₀ _ (NNReal.coe_pos.2 hCpos).ne.symm]
     _ ≤ ENNReal.ofReal ε := by

--- a/Mathlib/MeasureTheory/Integral/Bochner/Basic.lean
+++ b/Mathlib/MeasureTheory/Integral/Bochner/Basic.lean
@@ -1416,7 +1416,7 @@ theorem eLpNorm_one_le_of_le {r : ℝ≥0} (hfint : Integrable f μ) (hfint' : 0
   rw [integral_add hfint.real_toNNReal]
   · simp only [Real.coe_toNNReal', ENNReal.toReal_mul, ENNReal.coe_toReal,
       toReal_ofNat] at hfint' ⊢
-    refine (add_le_add_left hfint' _).trans ?_
+    grw [hfint']
     rwa [← two_mul, mul_assoc, mul_le_mul_iff_right₀ (two_pos : (0 : ℝ) < 2)]
   · exact hfint.neg.sup (integrable_zero _ _ μ)
 

--- a/Mathlib/MeasureTheory/Integral/Bochner/VitaliCaratheodory.lean
+++ b/Mathlib/MeasureTheory/Integral/Bochner/VitaliCaratheodory.lean
@@ -133,7 +133,7 @@ theorem SimpleFunc.exists_le_lowerSemicontinuous_lintegral_ge (f : α →ₛ ℝ
           lintegral_const, MeasurableSet.univ, Measure.restrict_apply, Set.univ_inter, const_zero,
           coe_piecewise, coe_const, coe_zero, Set.piecewise_eq_indicator, Function.const_apply, hs]
       calc
-        (c : ℝ≥0∞) * μ u ≤ c * (μ s + ε / c) := mul_le_mul_left' μu.le _
+        (c : ℝ≥0∞) * μ u ≤ c * (μ s + ε / c) := by grw [μu]
         _ = c * μ s + ε := by
           simp_rw [mul_add]
           rw [ENNReal.mul_div_cancel _ ENNReal.coe_ne_top]
@@ -291,7 +291,7 @@ theorem exists_lt_lowerSemicontinuous_integral_gt_nnreal [SigmaFinite μ] (f : �
           simpa using int_f_ne_top
         _ = ENNReal.toReal (∫⁻ a : α, f a ∂μ) + δ := by
           rw [ENNReal.toReal_add int_f_ne_top ENNReal.coe_ne_top, ENNReal.coe_toReal]
-        _ < ENNReal.toReal (∫⁻ a : α, f a ∂μ) + ε := add_lt_add_left hδε _
+        _ < ENNReal.toReal (∫⁻ a : α, f a ∂μ) + ε := by gcongr
         _ = (∫⁻ a : α, ENNReal.ofReal ↑(f a) ∂μ).toReal + ε := by simp
     · apply Filter.Eventually.of_forall fun x => _; simp
     · exact fmeas.coe_nnreal_real.aestronglyMeasurable
@@ -345,7 +345,7 @@ theorem SimpleFunc.exists_upperSemicontinuous_le_lintegral_le (f : α →ₛ ℝ
           SimpleFunc.const_zero, lintegral_indicator, SimpleFunc.coe_zero,
           Set.piecewise_eq_indicator, SimpleFunc.coe_piecewise, Measure.restrict_apply]
       calc
-        (c : ℝ≥0∞) * μ s ≤ c * (μ F + ε / c) := mul_le_mul_left' μF.le _
+        (c : ℝ≥0∞) * μ s ≤ c * (μ F + ε / c) := by grw [μF]
         _ = c * μ F + ε := by
           simp_rw [mul_add]
           rw [ENNReal.mul_div_cancel _ ENNReal.coe_ne_top]

--- a/Mathlib/MeasureTheory/Integral/Lebesgue/Add.lean
+++ b/Mathlib/MeasureTheory/Integral/Lebesgue/Add.lean
@@ -292,8 +292,7 @@ theorem lintegral_add_left {f : α → ℝ≥0∞} (hf : Measurable f) (g : α �
     ∫⁻ a, f a + g a ∂μ = ∫⁻ a, φ a ∂μ := hφ_eq
     _ ≤ ∫⁻ a, f a + (φ a - f a) ∂μ := lintegral_mono fun a => le_add_tsub
     _ = ∫⁻ a, f a ∂μ + ∫⁻ a, φ a - f a ∂μ := lintegral_add_aux hf (hφm.sub hf)
-    _ ≤ ∫⁻ a, f a ∂μ + ∫⁻ a, g a ∂μ :=
-      add_le_add_left (lintegral_mono fun a => tsub_le_iff_left.2 <| hφ_le a) _
+    _ ≤ ∫⁻ a, f a ∂μ + ∫⁻ a, g a ∂μ := by gcongr with a; exact tsub_le_iff_left.2 <| hφ_le _
 
 theorem lintegral_add_left' {f : α → ℝ≥0∞} (hf : AEMeasurable f μ) (g : α → ℝ≥0∞) :
     ∫⁻ a, f a + g a ∂μ = ∫⁻ a, f a ∂μ + ∫⁻ a, g a ∂μ := by
@@ -362,7 +361,9 @@ theorem lintegral_const_mul (r : ℝ≥0∞) {f : α → ℝ≥0∞} (hf : Measu
       · intro n
         exact SimpleFunc.measurable _
       · intro i j h a
-        exact mul_le_mul_left' (monotone_eapprox _ h _) _
+        dsimp
+        gcongr
+        exact eapprox_mono h _
     _ = r * ∫⁻ a, f a ∂μ := by rw [← ENNReal.mul_iSup, lintegral_eq_iSup_eapprox_lintegral hf]
 
 theorem lintegral_const_mul'' (r : ℝ≥0∞) {f : α → ℝ≥0∞} (hf : AEMeasurable f μ) :
@@ -380,7 +381,8 @@ theorem lintegral_const_mul_le (r : ℝ≥0∞) (f : α → ℝ≥0∞) :
   intro hs
   rw [← SimpleFunc.const_mul_lintegral, lintegral]
   refine le_iSup_of_le (const α r * s) (le_iSup_of_le (fun x => ?_) le_rfl)
-  exact mul_le_mul_left' (hs x) _
+  dsimp
+  grw [hs x]
 
 theorem lintegral_const_mul' (r : ℝ≥0∞) (f : α → ℝ≥0∞) (hr : r ≠ ∞) :
     ∫⁻ a, r * f a ∂μ = r * ∫⁻ a, f a ∂μ := by

--- a/Mathlib/MeasureTheory/Integral/SetToL1.lean
+++ b/Mathlib/MeasureTheory/Integral/SetToL1.lean
@@ -971,8 +971,7 @@ theorem setToFun_congr_measure_of_add_left {μ' : Measure α}
     setToFun (μ + μ') T hT_add f = setToFun μ' T hT f := by
   refine setToFun_congr_measure_of_integrable 1 one_ne_top ?_ hT_add hT f hf
   rw [one_smul]
-  nth_rw 1 [← zero_add μ']
-  exact add_le_add_right bot_le μ'
+  exact Measure.le_add_left le_rfl
 
 theorem setToFun_top_smul_measure (hT : DominatedFinMeasAdditive (∞ • μ) T C) (f : α → E) :
     setToFun (∞ • μ) T hT f = 0 := by

--- a/Mathlib/MeasureTheory/Measure/Content.lean
+++ b/Mathlib/MeasureTheory/Measure/Content.lean
@@ -163,8 +163,7 @@ theorem innerContent_iSup_nat [R1Space G] (U : ℕ → Opens G) :
     refine Finset.induction_on t ?_ ?_
     · simp only [μ.empty, nonpos_iff_eq_zero, Finset.sum_empty, Finset.sup_empty]
     · intro n s hn ih
-      rw [Finset.sup_insert, Finset.sum_insert hn]
-      exact le_trans (μ.sup_le _ _) (add_le_add_left ih _)
+      grw [Finset.sup_insert, Finset.sum_insert hn, μ.sup_le, ih]
   refine iSup₂_le fun K hK => ?_
   obtain ⟨t, ht⟩ :=
     K.isCompact.elim_finite_subcover _ (fun i => (U i).isOpen) (by rwa [← Opens.coe_iSup])
@@ -260,7 +259,7 @@ theorem outerMeasure_exists_compact {U : Opens G} (hU : μ.outerMeasure U ≠ �
     (hε : ε ≠ 0) : ∃ K : Compacts G, (K : Set G) ⊆ U ∧ μ.outerMeasure U ≤ μ.outerMeasure K + ε := by
   rw [μ.outerMeasure_opens] at hU ⊢
   rcases μ.innerContent_exists_compact hU hε with ⟨K, h1K, h2K⟩
-  exact ⟨K, h1K, le_trans h2K <| add_le_add_right (μ.le_outerMeasure_compacts K) _⟩
+  exact ⟨K, h1K, by grw [h2K, μ.le_outerMeasure_compacts K]⟩
 
 theorem outerMeasure_exists_open {A : Set G} (hA : μ.outerMeasure A ≠ ∞) {ε : ℝ≥0} (hε : ε ≠ 0) :
     ∃ U : Opens G, A ⊆ U ∧ μ.outerMeasure U ≤ μ.outerMeasure A + ε := by
@@ -324,9 +323,8 @@ theorem borel_le_caratheodory : S ≤ μ.outerMeasure.caratheodory := by
   refine iSup_le ?_
   rintro ⟨L, hL⟩
   let L' : Compacts G := ⟨closure L, L.isCompact.closure⟩
-  suffices μ L' + μ.outerMeasure (↑U' \ U) ≤ μ.outerMeasure U' by
-    have A : μ L ≤ μ L' := μ.mono _ _ subset_closure
-    exact (add_le_add_right A _).trans this
+  dsimp
+  grw [show μ L ≤ μ L' from μ.mono _ _ subset_closure]
   simp only [subset_inter_iff] at hL
   have hL'U : (L' : Set G) ⊆ U := IsCompact.closure_subset_of_isOpen L.2 hU hL.2
   have hL'U' : (L' : Set G) ⊆ (U' : Set G) := IsCompact.closure_subset_of_isOpen L.2 U'.2 hL.1
@@ -340,9 +338,8 @@ theorem borel_le_caratheodory : S ≤ μ.outerMeasure.caratheodory := by
   refine iSup_le ?_
   rintro ⟨M, hM⟩
   let M' : Compacts G := ⟨closure M, M.isCompact.closure⟩
-  suffices μ L' + μ M' ≤ μ.outerMeasure U' by
-    have A : μ M ≤ μ M' := μ.mono _ _ subset_closure
-    exact (add_le_add_left A _).trans this
+  dsimp
+  grw [show μ M ≤ μ M' from μ.mono _ _ subset_closure]
   have hM' : (M' : Set G) ⊆ U' \ L' :=
     IsCompact.closure_subset_of_isOpen M.2 (IsOpen.sdiff U'.2 isClosed_closure) hM
   have : (↑(L' ⊔ M') : Set G) ⊆ U' := by

--- a/Mathlib/MeasureTheory/Measure/Decomposition/Hahn.lean
+++ b/Mathlib/MeasureTheory/Measure/Decomposition/Hahn.lean
@@ -102,22 +102,21 @@ theorem hahn_decomposition (μ ν : Measure α) [IsFiniteMeasure μ] [IsFiniteMe
       simp_rw [f, Nat.Ico_succ_singleton, Finset.inf_singleton]
       linarith
     · intro n (hmn : m ≤ n) ih
-      have : γ + (γ - 2 * (1 / 2) ^ m + (1 / 2) ^ (n + 1)) ≤ γ + d (f m (n + 1)) := by
-        calc
-          γ + (γ - 2 * (1 / 2) ^ m + (1 / 2) ^ (n + 1)) =
-              γ + (γ - 2 * (1 / 2) ^ m + ((1 / 2) ^ n - (1 / 2) ^ (n + 1))) := by
-            rw [pow_succ, mul_one_div, _root_.sub_half]
-          _ = γ - (1 / 2) ^ (n + 1) + (γ - 2 * (1 / 2) ^ m + (1 / 2) ^ n) := by
-            simp only [sub_eq_add_neg]; abel
-          _ ≤ d (e (n + 1)) + d (f m n) := add_le_add (le_of_lt <| he₂ _) ih
-          _ ≤ d (e (n + 1)) + d (f m n \ e (n + 1)) + d (f m (n + 1)) := by
-            rw [f_succ _ _ hmn, d_split (f m n) (e (n + 1)) (he₁ _), add_assoc]
-          _ = d (e (n + 1) ∪ f m n) + d (f m (n + 1)) := by
-            rw [d_split (e (n + 1) ∪ f m n) (e (n + 1)), union_diff_left, union_inter_cancel_left]
-            · abel
-            · exact he₁ _
-          _ ≤ γ + d (f m (n + 1)) := add_le_add_right (d_le_γ _ <| (he₁ _).union (hf _ _)) _
-      exact (add_le_add_iff_left γ).1 this
+      refine le_of_add_le_add_left (a := γ) ?_
+      calc
+        γ + (γ - 2 * (1 / 2) ^ m + (1 / 2) ^ (n + 1)) =
+            γ + (γ - 2 * (1 / 2) ^ m + ((1 / 2) ^ n - (1 / 2) ^ (n + 1))) := by
+          rw [pow_succ, mul_one_div, _root_.sub_half]
+        _ = γ - (1 / 2) ^ (n + 1) + (γ - 2 * (1 / 2) ^ m + (1 / 2) ^ n) := by
+          simp only [sub_eq_add_neg]; abel
+        _ ≤ d (e (n + 1)) + d (f m n) := add_le_add (le_of_lt <| he₂ _) ih
+        _ ≤ d (e (n + 1)) + d (f m n \ e (n + 1)) + d (f m (n + 1)) := by
+          rw [f_succ _ _ hmn, d_split (f m n) (e (n + 1)) (he₁ _), add_assoc]
+        _ = d (e (n + 1) ∪ f m n) + d (f m (n + 1)) := by
+          rw [d_split (e (n + 1) ∪ f m n) (e (n + 1)), union_diff_left, union_inter_cancel_left]
+          · abel
+          · exact he₁ _
+        _ ≤ γ + d (f m (n + 1)) := by grw [d_le_γ _ <| (he₁ _).union (hf _ _)]
   let s := ⋃ m, ⋂ n, f m n
   have γ_le_d_s : γ ≤ d s := by
     have hγ : Tendsto (fun m : ℕ => γ - 2 * (1 / 2) ^ m) atTop (𝓝 γ) := by

--- a/Mathlib/MeasureTheory/Measure/Doubling.lean
+++ b/Mathlib/MeasureTheory/Measure/Doubling.lean
@@ -123,7 +123,7 @@ theorem eventually_measure_le_scaling_constant_mul (K : ℝ) :
     ∀ᶠ r in 𝓝[>] 0, ∀ x, μ (closedBall x (K * r)) ≤ scalingConstantOf μ K * μ (closedBall x r) := by
   filter_upwards [Classical.choose_spec
       (exists_eventually_forall_measure_closedBall_le_mul μ K)] with r hr x
-  exact (hr x K le_rfl).trans (mul_le_mul_right' (ENNReal.coe_le_coe.2 (le_max_left _ _)) _)
+  grw [hr x K le_rfl, scalingConstantOf, ← le_max_left]
 
 theorem eventually_measure_le_scaling_constant_mul' (K : ℝ) (hK : 0 < K) :
     ∀ᶠ r in 𝓝[>] 0, ∀ x,

--- a/Mathlib/MeasureTheory/Measure/LevyProkhorovMetric.lean
+++ b/Mathlib/MeasureTheory/Measure/LevyProkhorovMetric.lean
@@ -147,20 +147,16 @@ lemma levyProkhorovEDist_triangle [OpensMeasurableSpace Ω] (μ ν κ : Measure 
   refine ⟨?_, ?_⟩
   · calc μ B ≤ ν (thickening r.toReal B) + r :=
       left_measure_le_of_levyProkhorovEDist_lt lt_r B_mble
-    _ ≤ κ (thickening s.toReal (thickening r.toReal B)) + s + r :=
-      add_le_add_right
-        (left_measure_le_of_levyProkhorovEDist_lt lt_s isOpen_thickening.measurableSet) _
+    _ ≤ κ (thickening s.toReal (thickening r.toReal B)) + s + r := by
+      grw [left_measure_le_of_levyProkhorovEDist_lt lt_s isOpen_thickening.measurableSet]
     _ = κ (thickening s.toReal (thickening r.toReal B)) + (s + r) := add_assoc _ _ _
-    _ ≤ κ (thickening (s.toReal + r.toReal) B) + (s + r) :=
-      add_le_add_right (measure_mono (thickening_thickening_subset _ _ _)) _
+    _ ≤ κ (thickening (s.toReal + r.toReal) B) + (s + r) := by grw [thickening_thickening_subset]
   · calc κ B ≤ ν (thickening s.toReal B) + s :=
       right_measure_le_of_levyProkhorovEDist_lt lt_s B_mble
-    _ ≤ μ (thickening r.toReal (thickening s.toReal B)) + r + s :=
-      add_le_add_right
-        (right_measure_le_of_levyProkhorovEDist_lt lt_r isOpen_thickening.measurableSet) s
+    _ ≤ μ (thickening r.toReal (thickening s.toReal B)) + r + s := by
+      grw [right_measure_le_of_levyProkhorovEDist_lt lt_r isOpen_thickening.measurableSet]
     _ = μ (thickening r.toReal (thickening s.toReal B)) + (s + r) := by rw [add_assoc, add_comm r]
-    _ ≤ μ (thickening (r.toReal + s.toReal) B) + (s + r) :=
-      add_le_add_right (measure_mono (thickening_thickening_subset _ _ _)) _
+    _ ≤ μ (thickening (r.toReal + s.toReal) B) + (s + r) := by grw [thickening_thickening_subset]
     _ = μ (thickening (s.toReal + r.toReal) B) + (s + r) := by rw [add_comm r.toReal]
 
 /-- The Lévy-Prokhorov distance between finite measures:
@@ -421,7 +417,7 @@ lemma LevyProkhorov.continuous_equiv_probabilityMeasure :
   refine SeqContinuous.continuous ?_
   intro μs ν hμs
   set P := LevyProkhorov.equiv _ ν -- more palatable notation
-  set Ps := fun n ↦ LevyProkhorov.equiv _ (μs n) -- more palatable notation
+  set Ps := LevyProkhorov.equiv _ ∘ μs -- more palatable notation
   rw [ProbabilityMeasure.tendsto_iff_forall_integral_tendsto]
   refine fun f ↦ tendsto_integral_of_forall_limsup_integral_le_integral ?_ f
   intro f f_nn
@@ -432,7 +428,7 @@ lemma LevyProkhorov.continuous_equiv_probabilityMeasure :
   apply _root_.le_of_forall_pos_le_add
   intro δ δ_pos
   apply limsup_le_of_le ?_
-  · obtain ⟨εs, ⟨_, ⟨εs_pos, εs_lim⟩⟩⟩ := exists_seq_strictAnti_tendsto (0 : ℝ)
+  · obtain ⟨εs, _, εs_pos, εs_lim⟩ := exists_seq_strictAnti_tendsto (0 : ℝ)
     have ε_of_room := Tendsto.add (tendsto_iff_dist_tendsto_zero.mp hμs) εs_lim
     have ε_of_room' : Tendsto (fun n ↦ dist (μs n) ν + εs n) atTop (𝓝[>] 0) := by
       rw [tendsto_nhdsWithin_iff]
@@ -445,20 +441,17 @@ lemma LevyProkhorov.continuous_equiv_probabilityMeasure :
     filter_upwards [key (aux _), ε_of_room <| Iio_mem_nhds <| half_pos <|
                       mul_pos (inv_pos.mpr norm_f_pos) δ_pos]
       with n hn hn'
-    simp only [mem_preimage, mem_Iio] at *
+    simp only [mem_preimage, Function.comp_def, mem_Iio] at *
     specialize εs_pos n
     have bound := BoundedContinuousFunction.integral_le_of_levyProkhorovEDist_lt
                     (Ps n) P (ε := dist (μs n) ν + εs n) ?_ ?_ f ?_
-    · refine bound.trans ?_
-      apply (add_le_add_right hn.le _).trans
-      rw [BoundedContinuousFunction.integral_eq_integral_meas_le]
-      · rw [add_assoc, mul_comm]
-        gcongr
-        calc
-          δ / 2 + ‖f‖ * (dist (μs n) ν + εs n)
-          _ ≤ δ / 2 + ‖f‖ * (‖f‖⁻¹ * δ / 2) := by gcongr
-          _ = δ := by field_simp; ring
-      · exact Eventually.of_forall f_nn
+    · grw [bound, hn, BoundedContinuousFunction.integral_eq_integral_meas_le _ _ <| .of_forall f_nn,
+        add_assoc, mul_comm]
+      gcongr
+      calc
+        δ / 2 + ‖f‖ * (dist (μs n) ν + εs n)
+        _ ≤ δ / 2 + ‖f‖ * (‖f‖⁻¹ * δ / 2) := by gcongr
+        _ = δ := by field_simp; ring
     · positivity
     · rw [ENNReal.ofReal_add (by positivity) (by positivity), ← add_zero (levyProkhorovEDist _ _)]
       apply ENNReal.add_lt_add_of_le_of_lt (levyProkhorovEDist_ne_top _ _)

--- a/Mathlib/MeasureTheory/Measure/Regular.lean
+++ b/Mathlib/MeasureTheory/Measure/Regular.lean
@@ -565,7 +565,7 @@ theorem measurableSet_of_isOpen [OuterRegular μ] (H : InnerRegularWRT μ p IsOp
   calc
     μ s ≤ μ U := μ.mono hsU
     _ < μ K + ε := hKr
-    _ ≤ μ (K \ U') + μ U' + ε := add_le_add_right (tsub_le_iff_right.1 le_measure_diff) _
+    _ ≤ μ (K \ U') + μ U' + ε := by grw [tsub_le_iff_right.1 le_measure_diff]
     _ ≤ μ (K \ U') + ε + ε := by gcongr
     _ = μ (K \ U') + (ε + ε) := add_assoc _ _ _
 
@@ -634,7 +634,7 @@ theorem weaklyRegular_of_finite [BorelSpace α] (μ : Measure α) [IsFiniteMeasu
         μ (⋃ n, U n) ≤ ∑' n, μ (U n) := measure_iUnion_le _
         _ ≤ ∑' n, (μ (s n) + δ n) := ENNReal.tsum_le_tsum hU
         _ = μ (⋃ n, s n) + ∑' n, δ n := by rw [measure_iUnion hsd hsm, ENNReal.tsum_add]
-        _ ≤ μ (⋃ n, s n) + ε := add_le_add_left (hδε.le.trans ENNReal.half_le_self) _
+        _ ≤ μ (⋃ n, s n) + ε := by grw [hδε, ENNReal.half_le_self]
 
 /-- In a metrizable space (or even a pseudo metrizable space), an open set can be approximated from
 inside by closed sets. -/

--- a/Mathlib/MeasureTheory/Measure/Typeclasses/Finite.lean
+++ b/Mathlib/MeasureTheory/Measure/Typeclasses/Finite.lean
@@ -57,7 +57,7 @@ theorem measure_compl_le_add_of_le_add [IsFiniteMeasure μ] (hs : MeasurableSet 
     tsub_le_iff_right]
   calc
     μ univ = μ univ - μ s + μ s := (tsub_add_cancel_of_le <| measure_mono s.subset_univ).symm
-    _ ≤ μ univ - μ s + (μ t + ε) := add_le_add_left h _
+    _ ≤ μ univ - μ s + (μ t + ε) := by gcongr
     _ = _ := by rw [add_right_comm, add_assoc]
 
 theorem measure_compl_le_add_iff [IsFiniteMeasure μ] (hs : MeasurableSet s) (ht : MeasurableSet t)

--- a/Mathlib/MeasureTheory/Measure/WithDensity.lean
+++ b/Mathlib/MeasureTheory/Measure/WithDensity.lean
@@ -366,7 +366,7 @@ theorem lintegral_withDensity_eq_lintegral_mul (μ : Measure α) {f : α → ℝ
   · intro g h _ h_mea_g _ h_ind_g h_ind_h
     simp [mul_add, *, Measurable.mul]
   · intro g h_mea_g h_mono_g h_ind
-    have : Monotone fun n a => f a * g n a := fun m n hmn x => mul_le_mul_left' (h_mono_g hmn x) _
+    have : Monotone fun n a => f a * g n a := fun m n hmn x => by dsimp; grw [h_mono_g hmn x]
     simp [lintegral_iSup, ENNReal.mul_iSup, h_mf.mul (h_mea_g _), *]
 
 theorem setLIntegral_withDensity_eq_setLIntegral_mul (μ : Measure α) {f g : α → ℝ≥0∞}
@@ -433,9 +433,8 @@ theorem lintegral_withDensity_le_lintegral_mul (μ : Measure α) {f : α → ℝ
     (f_meas : Measurable f) (g : α → ℝ≥0∞) : (∫⁻ a, g a ∂μ.withDensity f) ≤ ∫⁻ a, (f * g) a ∂μ := by
   rw [← iSup_lintegral_measurable_le_eq_lintegral, ← iSup_lintegral_measurable_le_eq_lintegral]
   refine iSup₂_le fun i i_meas => iSup_le fun hi => ?_
-  have A : f * i ≤ f * g := fun x => mul_le_mul_left' (hi x) _
-  refine le_iSup₂_of_le (f * i) (f_meas.mul i_meas) ?_
-  exact le_iSup_of_le A (le_of_eq (lintegral_withDensity_eq_lintegral_mul _ f_meas i_meas))
+  rw [lintegral_withDensity_eq_lintegral_mul _ f_meas i_meas]
+  exact le_iSup₂_of_le (f * i) (f_meas.mul i_meas) <| le_iSup_of_le (by grw [hi]) le_rfl
 
 theorem lintegral_withDensity_eq_lintegral_mul_non_measurable (μ : Measure α) {f : α → ℝ≥0∞}
     (f_meas : Measurable f) (hf : ∀ᵐ x ∂μ, f x < ∞) (g : α → ℝ≥0∞) :

--- a/Mathlib/MeasureTheory/OuterMeasure/Caratheodory.lean
+++ b/Mathlib/MeasureTheory/OuterMeasure/Caratheodory.lean
@@ -129,18 +129,17 @@ theorem isCaratheodory_sum {s : ℕ → Set α} (h : ∀ i, IsCaratheodory m (s 
 /-- Use `isCaratheodory_iUnion` instead, which does not require the disjoint assumption. -/
 theorem isCaratheodory_iUnion_of_disjoint {s : ℕ → Set α} (h : ∀ i, IsCaratheodory m (s i))
     (hd : Pairwise (Disjoint on s)) : IsCaratheodory m (⋃ i, s i) := by
-      apply (isCaratheodory_iff_le' m).mpr
-      intro t
-      have hp : m (t ∩ ⋃ i, s i) ≤ ⨆ n, m (t ∩ ⋃ i < n, s i) := by
-        convert measure_iUnion_le (μ := m) fun i => t ∩ s i using 1
-        · simp [inter_iUnion]
-        · simp [ENNReal.tsum_eq_iSup_nat, isCaratheodory_sum m h hd]
-      grw [hp]
-      rw [ENNReal.iSup_add]
-      refine iSup_le fun n => le_trans (add_le_add_left ?_ _)
-        (ge_of_eq (isCaratheodory_iUnion_lt m (fun i _ => h i) _))
-      refine m.mono (diff_subset_diff_right ?_)
-      exact iUnion₂_subset fun i _ => subset_iUnion _ i
+  apply (isCaratheodory_iff_le' m).mpr
+  intro t
+  have hp : m (t ∩ ⋃ i, s i) ≤ ⨆ n, m (t ∩ ⋃ i < n, s i) := by
+    convert measure_iUnion_le (μ := m) fun i => t ∩ s i using 1
+    · simp [inter_iUnion]
+    · simp [ENNReal.tsum_eq_iSup_nat, isCaratheodory_sum m h hd]
+  grw [hp, ENNReal.iSup_add]
+  refine iSup_le fun n => ?_
+  rw [isCaratheodory_iUnion_lt _ (fun i _ => h i) t (n := n)]
+  gcongr with i
+  exact iUnion_subset fun _ => .rfl
 
 lemma isCaratheodory_iUnion {s : ℕ → Set α} (h : ∀ i, m.IsCaratheodory (s i)) :
     m.IsCaratheodory (⋃ i, s i) := by

--- a/Mathlib/MeasureTheory/VectorMeasure/Basic.lean
+++ b/Mathlib/MeasureTheory/VectorMeasure/Basic.lean
@@ -909,7 +909,7 @@ variable {M : Type*} [TopologicalSpace M] [AddCommMonoid M] [PartialOrder M]
   [AddLeftMono M] [ContinuousAdd M]
 
 instance instAddLeftMono : AddLeftMono (VectorMeasure α M) :=
-  ⟨fun _ _ _ h i hi => add_le_add_left (h i hi) _⟩
+  ⟨fun _ _ _ h i hi => by dsimp; grw [h i hi]⟩
 
 end
 

--- a/Mathlib/ModelTheory/Encoding.lean
+++ b/Mathlib/ModelTheory/Encoding.lean
@@ -114,9 +114,8 @@ theorem card_sigma : #(Σ n, L.Term (α ⊕ (Fin n))) = max ℵ₀ #(α ⊕ (Σ 
       ciSup_le_iff' (bddAbove_range _)]
     · refine ⟨le_max_left _ _, fun i => card_le.trans ?_⟩
       refine max_le (le_max_left _ _) ?_
-      rw [← add_eq_max le_rfl, mk_sum, mk_sum, mk_sum, add_comm (Cardinal.lift #α), lift_add,
-        add_assoc, lift_lift, lift_lift, mk_fin, lift_natCast]
-      exact add_le_add_right (nat_lt_aleph0 _).le _
+      grw [← add_eq_max le_rfl, mk_sum, mk_sum, mk_sum, add_comm (Cardinal.lift #α), lift_add,
+        add_assoc, lift_lift, lift_lift, mk_fin, lift_natCast, nat_lt_aleph0]
     · rw [← one_le_iff_ne_zero]
       refine _root_.trans ?_ (le_ciSup (bddAbove_range _) 1)
       rw [one_le_iff_ne_zero, mk_ne_zero_iff]

--- a/Mathlib/ModelTheory/Semantics.lean
+++ b/Mathlib/ModelTheory/Semantics.lean
@@ -402,7 +402,7 @@ theorem realize_liftAt_one {n m : ℕ} {φ : L.BoundedFormula α n} {v : α → 
     (hmn : m ≤ n) :
     (φ.liftAt 1 m).Realize v xs ↔
       φ.Realize v (xs ∘ fun i => if ↑i < m then castSucc i else i.succ) := by
-  simp [realize_liftAt (add_le_add_right hmn 1), castSucc]
+  simp [realize_liftAt, hmn, castSucc]
 
 @[simp]
 theorem realize_liftAt_one_self {n : ℕ} {φ : L.BoundedFormula α n} {v : α → M}

--- a/Mathlib/ModelTheory/Syntax.lean
+++ b/Mathlib/ModelTheory/Syntax.lean
@@ -413,7 +413,7 @@ def castLE : ∀ {m n : ℕ} (_h : m ≤ n), L.BoundedFormula α m → L.Bounded
     equal (t₁.relabel (Sum.map id (Fin.castLE h))) (t₂.relabel (Sum.map id (Fin.castLE h)))
   | _m, _n, h, rel R ts => rel R (Term.relabel (Sum.map id (Fin.castLE h)) ∘ ts)
   | _m, _n, h, imp f₁ f₂ => (f₁.castLE h).imp (f₂.castLE h)
-  | _m, _n, h, all f => (f.castLE (add_le_add_right h 1)).all
+  | _m, _n, h, all f => (f.castLE (by gcongr)).all
 
 @[simp]
 theorem castLE_rfl {n} (h : n ≤ n) (φ : L.BoundedFormula α n) : φ.castLE h = φ := by

--- a/Mathlib/NumberTheory/AbelSummation.lean
+++ b/Mathlib/NumberTheory/AbelSummation.lean
@@ -328,14 +328,15 @@ private theorem summable_mul_of_bigO_atTop_aux (m : ℕ)
       · exact hf _
       · refine tsub_le_tsub_right (le_of_eq_of_le (Real.norm_of_nonneg ?_).symm (hC₁ n)) _
         exact mul_nonneg (norm_nonneg _) (sum_nonneg fun _ _ ↦ norm_nonneg _)
-      · exact add_le_add_left
-          (le_trans (neg_le_abs _) (Real.norm_eq_abs _ ▸ norm_integral_le_integral_norm _)) _
-      · refine add_le_add_left (setIntegral_mono_set ?_ ?_ Set.Ioc_subset_Ioi_self.eventuallyLE) C₁
-        · exact Iff.mp integrableOn_Ici_iff_integrableOn_Ioi <|
-            (integrable_norm_iff h_mes.aestronglyMeasurable).mpr <|
-              (locallyIntegrableOn_mul_sum_Icc _ m.cast_nonneg hf_int).integrableOn_of_isBigO_atTop
-                hg₁ hg₂
-        · filter_upwards with t using norm_nonneg _
+      · grw [sub_eq_add_neg, neg_le_abs, abs_integral_le_integral_abs]
+        simp
+      · unfold C₂
+        grw [setIntegral_mono_set ?_ (.of_forall fun _ ↦ norm_nonneg _)
+          Set.Ioc_subset_Ioi_self.eventuallyLE]
+        rw [← integrableOn_Ici_iff_integrableOn_Ioi, IntegrableOn,
+          integrable_norm_iff h_mes.aestronglyMeasurable]
+        exact (locallyIntegrableOn_mul_sum_Icc _ m.cast_nonneg hf_int).integrableOn_of_isBigO_atTop
+          hg₁ hg₂
 
 theorem summable_mul_of_bigO_atTop
     (hf_diff : ∀ t ∈ Set.Ici 0, DifferentiableAt ℝ (fun x ↦ ‖f x‖) t)

--- a/Mathlib/NumberTheory/Bertrand.lean
+++ b/Mathlib/NumberTheory/Bertrand.lean
@@ -135,17 +135,15 @@ theorem bertrand_main_inequality {n : ℕ} (n_large : 512 ≤ n) :
 factorization of the central binomial coefficient only has factors at most `2 * n / 3 + 1`.
 -/
 theorem centralBinom_factorization_small (n : ℕ) (n_large : 2 < n)
-    (no_prime : ¬∃ p : ℕ, p.Prime ∧ n < p ∧ p ≤ 2 * n) :
+    (no_prime : ∀ p : ℕ, p.Prime → n < p → 2 * n < p) :
     centralBinom n = ∏ p ∈ Finset.range (2 * n / 3 + 1), p ^ (centralBinom n).factorization p := by
   refine (Eq.trans ?_ n.prod_pow_factorization_centralBinom).symm
   apply Finset.prod_subset
-  · exact Finset.range_subset_range.2 (add_le_add_right (Nat.div_le_self _ _) _)
+  · grw [Nat.div_le_self]
   intro x hx h2x
   rw [Finset.mem_range, Nat.lt_succ_iff] at hx h2x
   rw [not_le, div_lt_iff_lt_mul three_pos, mul_comm x] at h2x
-  replace no_prime := not_exists.mp no_prime x
-  rw [← and_assoc, not_and', not_and_or, not_lt] at no_prime
-  rcases no_prime hx with h | h
+  obtain h | h : ¬ x.Prime ∨ x ≤ n := by simpa [imp_iff_not_or, hx.not_gt] using no_prime x
   · rw [factorization_eq_zero_of_non_prime n.centralBinom h, Nat.pow_zero]
   · rw [factorization_centralBinom_of_two_mul_self_lt_three_mul n_large h h2x, Nat.pow_zero]
 
@@ -158,7 +156,7 @@ The bound splits the prime factors of `centralBinom n` into those
 5. Above `2 * n`, which do not exist.
 -/
 theorem centralBinom_le_of_no_bertrand_prime (n : ℕ) (n_large : 2 < n)
-    (no_prime : ¬∃ p : ℕ, Nat.Prime p ∧ n < p ∧ p ≤ 2 * n) :
+    (no_prime : ∀ p : ℕ, p.Prime → n < p → 2 * n < p) :
     centralBinom n ≤ (2 * n) ^ sqrt (2 * n) * 4 ^ (2 * n / 3) := by
   have n_pos : 0 < n := (Nat.zero_le _).trans_lt n_large
   have n2_pos : 1 ≤ 2 * n := mul_pos (zero_lt_two' ℕ) n_pos
@@ -192,17 +190,16 @@ namespace Nat
 -/
 theorem exists_prime_lt_and_le_two_mul_eventually (n : ℕ) (n_large : 512 ≤ n) :
     ∃ p : ℕ, p.Prime ∧ n < p ∧ p ≤ 2 * n := by
+  have no_prime : 4 ^ n < n * n.centralBinom :=
+    Nat.four_pow_lt_mul_centralBinom n (le_trans (by norm_num1) n_large)
   -- Assume there is no prime in the range.
-  by_contra no_prime
+  contrapose! no_prime
   -- Then we have the above sub-exponential bound on the size of this central binomial coefficient.
   -- We now couple this bound with an exponential lower bound on the central binomial coefficient,
   -- yielding an inequality which we have seen is false for large enough n.
-  have H1 : n * (2 * n) ^ sqrt (2 * n) * 4 ^ (2 * n / 3) ≤ 4 ^ n := bertrand_main_inequality n_large
-  have H2 : 4 ^ n < n * n.centralBinom :=
-    Nat.four_pow_lt_mul_centralBinom n (le_trans (by norm_num1) n_large)
-  have H3 : n.centralBinom ≤ (2 * n) ^ sqrt (2 * n) * 4 ^ (2 * n / 3) :=
+  have : n.centralBinom ≤ (2 * n) ^ sqrt (2 * n) * 4 ^ (2 * n / 3) :=
     centralBinom_le_of_no_bertrand_prime n (lt_of_lt_of_le (by norm_num1) n_large) no_prime
-  rw [mul_assoc] at H1; exact not_le.2 H2 ((mul_le_mul_left' H3 n).trans H1)
+  grw [this, ← mul_assoc, bertrand_main_inequality n_large]
 
 /-- Proves that Bertrand's postulate holds over all positive naturals less than n by identifying a
 descending list of primes, each no more than twice the next, such that the list contains a witness

--- a/Mathlib/NumberTheory/Dioph.lean
+++ b/Mathlib/NumberTheory/Dioph.lean
@@ -214,7 +214,7 @@ def sumsq : List (Poly α) → Poly α
   | [] => 0
   | p::ps => p * p + sumsq ps
 
-theorem sumsq_nonneg (x : α → ℕ) : ∀ l, 0 ≤ sumsq l x
+@[simp] theorem sumsq_nonneg (x : α → ℕ) : ∀ l, 0 ≤ sumsq l x
   | [] => le_refl 0
   | p::ps => by
     rw [sumsq]
@@ -222,20 +222,7 @@ theorem sumsq_nonneg (x : α → ℕ) : ∀ l, 0 ≤ sumsq l x
 
 theorem sumsq_eq_zero (x) : ∀ l, sumsq l x = 0 ↔ l.Forall fun a : Poly α => a x = 0
   | [] => eq_self_iff_true _
-  | p::ps => by
-    rw [List.forall_cons, ← sumsq_eq_zero _ ps]; rw [sumsq]
-    exact
-      ⟨fun h : p x * p x + sumsq ps x = 0 =>
-        have : p x = 0 :=
-          eq_zero_of_mul_self_eq_zero <|
-            le_antisymm
-              (by
-                rw [← h]
-                have t := add_le_add_left (sumsq_nonneg x ps) (p x * p x)
-                rwa [add_zero] at t)
-              (mul_self_nonneg _)
-        ⟨this, by simpa [this] using h⟩,
-      fun ⟨h1, h2⟩ => by rw [add_apply, mul_apply, h1, h2]; rfl⟩
+  | p::ps => by simp [sumsq, add_eq_zero_iff_of_nonneg, mul_self_nonneg, sumsq_eq_zero]
 
 end
 

--- a/Mathlib/NumberTheory/Divisors.lean
+++ b/Mathlib/NumberTheory/Divisors.lean
@@ -430,7 +430,7 @@ theorem eq_properDivisors_of_subset_of_sum_eq_sum {s : Finset ℕ} (hsub : s ⊆
     rw [← Ne, ← nonempty_iff_ne_empty] at h
     apply ne_of_lt
     rw [← zero_add (∑ x ∈ s, x), ← add_assoc, add_zero]
-    apply add_lt_add_right
+    gcongr
     have hlt :=
       sum_lt_sum_of_nonempty h fun x hx => pos_of_mem_properDivisors (sdiff_subset hx)
     simp only [sum_const_zero] at hlt

--- a/Mathlib/NumberTheory/EllipticDivisibilitySequence.lean
+++ b/Mathlib/NumberTheory/EllipticDivisibilitySequence.lean
@@ -127,8 +127,8 @@ def preNormEDS' : ℕ → R
       preNormEDS' (m + 4) * preNormEDS' (m + 2) ^ 3 * (if Even m then b else 1) -
         preNormEDS' (m + 1) * preNormEDS' (m + 3) ^ 3 * (if Even m then 1 else b)
     else
-      have : m + 5 < n + 5 :=
-        add_lt_add_right (Nat.div_lt_self (Nat.not_even_iff_odd.mp hn).pos one_lt_two) 5
+      have : m + 5 < n + 5 := by
+        gcongr; exact Nat.div_lt_self (Nat.not_even_iff_odd.mp hn).pos one_lt_two
       preNormEDS' (m + 2) ^ 2 * preNormEDS' (m + 3) * preNormEDS' (m + 5) -
         preNormEDS' (m + 1) * preNormEDS' (m + 3) * preNormEDS' (m + 4) ^ 2
 

--- a/Mathlib/NumberTheory/Harmonic/Bounds.lean
+++ b/Mathlib/NumberTheory/Harmonic/Bounds.lean
@@ -35,7 +35,7 @@ theorem harmonic_le_one_add_log (n : ℕ) :
   simp_rw [harmonic_eq_sum_Icc, Rat.cast_sum, Rat.cast_inv, Rat.cast_natCast]
   rw [← Finset.sum_erase_add (Finset.Icc 1 n) _ (Finset.left_mem_Icc.mpr hn), add_comm,
     Nat.cast_one, inv_one]
-  refine add_le_add_left ?_ 1
+  gcongr
   simp only [Finset.Icc_erase_left]
   calc ∑ d ∈ .Ico 2 (n + 1), (d : ℝ)⁻¹
     _ = ∑ d ∈ .Ico 2 (n + 1), (↑(d + 1) - 1)⁻¹ := ?_

--- a/Mathlib/NumberTheory/Padics/PadicVal/Basic.lean
+++ b/Mathlib/NumberTheory/Padics/PadicVal/Basic.lean
@@ -320,15 +320,11 @@ theorem le_padicValRat_add_of_le {q r : ℚ} (hqr : q + r ≠ 0)
       rw [← q.num_divInt_den, ← r.num_divInt_den, padicValRat_le_padicValRat_iff hqn hrn hqd hrd, ←
         emultiplicity_le_emultiplicity_iff] at h
       calc
-        _ ≤
-            min (emultiplicity (↑p) (q.num * r.den * q.den))
-              (emultiplicity (↑p) (↑q.den * r.num * ↑q.den)) :=
+        _ ≤ min (emultiplicity ↑p (q.num * r.den * q.den))
+                (emultiplicity ↑p (q.den * r.num * q.den)) :=
           le_min
             (by rw [emultiplicity_mul (a :=_ * _) (Nat.prime_iff_prime_int.1 hp.1), add_comm])
-            (by
-              rw [mul_assoc,
-                  emultiplicity_mul (b := _ * _) (Nat.prime_iff_prime_int.1 hp.1)]
-              exact add_le_add_left h _)
+            (by grw [mul_assoc, emultiplicity_mul (b := _ * _) (Nat.prime_iff_prime_int.1 hp.1), h])
         _ ≤ _ := min_le_emultiplicity_add
 
 /-- The minimum of the valuations of `q` and `r` is at most the valuation of `q + r`. -/

--- a/Mathlib/NumberTheory/PellMatiyasevic.lean
+++ b/Mathlib/NumberTheory/PellMatiyasevic.lean
@@ -581,13 +581,7 @@ theorem eq_of_xn_modEq_lem3 {i n} (npos : 0 < n) :
   | j + 1, ij, j2n, jnn, ntriv =>
     have lem2 : ∀ k > n, k ≤ 2 * n → (↑(xn a1 k % xn a1 n) : ℤ) =
         xn a1 n - xn a1 (2 * n - k) := fun k kn k2n => by
-      let k2nl :=
-        lt_of_add_lt_add_right <|
-          show 2 * n - k + k < n + k by
-            rw [tsub_add_cancel_of_le]
-            · rw [two_mul]
-              exact add_lt_add_left kn n
-            exact k2n
+      let k2nl : 2 * n - k < n := by cutsat
       have xle : xn a1 (2 * n - k) ≤ xn a1 n := le_of_lt <| strictMono_x a1 k2nl
       suffices xn a1 k % xn a1 n = xn a1 n - xn a1 (2 * n - k) by rw [this, Int.ofNat_sub xle]
       rw [← Nat.mod_eq_of_lt (Nat.sub_lt (x_pos a1 n) (x_pos a1 (2 * n - k)))]

--- a/Mathlib/NumberTheory/PrimeCounting.lean
+++ b/Mathlib/NumberTheory/PrimeCounting.lean
@@ -132,13 +132,9 @@ theorem primeCounting'_add_le {a k : ℕ} (h0 : a ≠ 0) (h1 : a < k) (n : ℕ) 
     _ ≤ π' k + #{p ∈ Ico k (k + n) | p.Prime} := by
       rw [primeCounting', count_eq_card_filter_range]
     _ ≤ π' k + #{b ∈ Ico k (k + n) | a.Coprime b} := by
-      refine add_le_add_left (card_le_card ?_) k.primeCounting'
-      simp only [subset_iff, and_imp, mem_filter, mem_Ico]
-      intro p succ_k_le_p p_lt_n p_prime
-      constructor
-      · exact ⟨succ_k_le_p, p_lt_n⟩
-      · rw [coprime_comm]
-        exact coprime_of_lt_prime h0 (lt_of_lt_of_le h1 succ_k_le_p) p_prime
+      gcongr with p hp
+      rw [coprime_comm]
+      exact coprime_of_lt_prime h0 <| h1.trans_le (mem_Ico.1 hp).1
     _ ≤ π' k + totient a * (n / a + 1) := by
       rw [add_le_add_iff_left]
       exact Ico_filter_coprime_le k n h0

--- a/Mathlib/NumberTheory/Primorial.lean
+++ b/Mathlib/NumberTheory/Primorial.lean
@@ -44,8 +44,7 @@ theorem primorial_succ {n : ℕ} (hn1 : n ≠ 1) (hn : Odd n) : (n + 1)# = n# :=
 theorem primorial_add (m n : ℕ) :
     (m + n)# = m# * ∏ p ∈ Ico (m + 1) (m + n + 1) with p.Prime, p := by
   rw [primorial, primorial, ← Ico_zero_eq_range, ← prod_union, ← filter_union, Ico_union_Ico_eq_Ico]
-  exacts [Nat.zero_le _, add_le_add_right (Nat.le_add_right _ _) _,
-    disjoint_filter_filter <| Ico_disjoint_Ico_consecutive _ _ _]
+  exacts [Nat.zero_le _, by cutsat, disjoint_filter_filter <| Ico_disjoint_Ico_consecutive _ _ _]
 
 theorem primorial_add_dvd {m n : ℕ} (h : n ≤ m) : (m + n)# ∣ m# * choose (m + n) m :=
   calc

--- a/Mathlib/NumberTheory/SmoothNumbers.lean
+++ b/Mathlib/NumberTheory/SmoothNumbers.lean
@@ -480,8 +480,9 @@ lemma smoothNumbersUpTo_subset_image (N k : ℕ) :
   · rw [lt_succ, le_sqrt']
     refine LE.le.trans ?_ (hm ▸ hn₁)
     nth_rw 1 [← mul_one (m ^ 2)]
-    exact mul_le_mul_left' (Finset.one_le_prod' fun p hp ↦
-      (prime_of_mem_primesBelow <| Finset.mem_powerset.mp hs hp).one_lt.le) _
+    gcongr
+    exact Finset.one_le_prod' fun p hp ↦
+      (prime_of_mem_primesBelow <| Finset.mem_powerset.mp hs hp).one_le
 
 /-- The cardinality of the set of `k`-smooth numbers `≤ N` is bounded by `2^π(k-1) * √N`. -/
 lemma smoothNumbersUpTo_card_le (N k : ℕ) :

--- a/Mathlib/NumberTheory/SumPrimeReciprocals.lean
+++ b/Mathlib/NumberTheory/SumPrimeReciprocals.lean
@@ -58,8 +58,7 @@ lemma one_half_le_sum_primes_ge_one_div (k : ℕ) :
         exact_mod_cast ((2 * N₀).smoothNumbersUpTo_card_add_roughNumbersUpTo_card k).symm
     _ ≤ m * (2 * N₀).sqrt + ((2 * N₀).roughNumbersUpTo k).card := by
         exact_mod_cast Nat.add_le_add_right ((2 * N₀).smoothNumbersUpTo_card_le k) _
-    _ ≤ m * (2 * N₀).sqrt + 2 * N₀ * S := add_le_add_left ?_ _
-  exact_mod_cast roughNumbersUpTo_card_le' (2 * N₀) k
+    _ ≤ m * (2 * N₀).sqrt + 2 * N₀ * S := by grw [roughNumbersUpTo_card_le']; norm_cast
 
 /-- The sum over the reciprocals of the primes diverges. -/
 theorem not_summable_one_div_on_primes :

--- a/Mathlib/NumberTheory/Zsqrtd/Basic.lean
+++ b/Mathlib/NumberTheory/Zsqrtd/Basic.lean
@@ -422,9 +422,8 @@ theorem sqLe_cancel {c d x y z w : ℕ} (zw : SqLe y d x c) (h : SqLe (x + z) c 
   simp only [mul_add, mul_comm, mul_left_comm, add_assoc]
   have hm := sqLe_add_mixed zw (le_of_lt l)
   simp only [SqLe, mul_assoc] at l zw
-  exact
-    lt_of_le_of_lt (add_le_add_right zw _)
-      (add_lt_add_left (add_lt_add_of_le_of_lt hm (add_lt_add_of_le_of_lt hm l)) _)
+  grw [zw, hm]
+  gcongr
 
 theorem sqLe_smul {c d x y : ℕ} (n : ℕ) (xy : SqLe x c y d) : SqLe (n * x) c (n * y) d := by
   simpa [SqLe, mul_left_comm, mul_assoc] using Nat.mul_le_mul_left (n * n) xy

--- a/Mathlib/NumberTheory/Zsqrtd/QuadraticReciprocity.lean
+++ b/Mathlib/NumberTheory/Zsqrtd/QuadraticReciprocity.lean
@@ -42,12 +42,9 @@ theorem mod_four_eq_three_of_nat_prime_of_prime (p : ℕ) [hp : Fact p.Prime]
         rw [pow_two, ← CharP.cast_eq_zero_iff (ZMod p) p, Nat.cast_add, Nat.cast_mul, Nat.cast_one,
           ← hk, neg_add_cancel]
       have hkmul : (k ^ 2 + 1 : ℤ[i]) = ⟨k, 1⟩ * ⟨k, -1⟩ := by ext <;> simp [sq]
-      have hkltp : 1 + k * k < p * p :=
-        calc
-          1 + k * k ≤ k + k * k := by
-            apply add_le_add_right
-            exact (Nat.pos_of_ne_zero fun (hk0 : k = 0) => by clear_aux_decl; simp_all)
-          _ = k * (k + 1) := by simp [add_comm, mul_add]
+      have hk₀ : k ≠ 0 := by rintro rfl; simp at hk
+      have hkltp := calc
+          1 + k * k ≤ k * (k + 1) := by cutsat
           _ < p * p := mul_lt_mul k_lt_p k_lt_p (Nat.succ_pos _) (Nat.zero_le _)
       have hpk₁ : ¬(p : ℤ[i]) ∣ ⟨k, -1⟩ := fun ⟨x, hx⟩ =>
         lt_irrefl (p * x : ℤ[i]).norm.natAbs <|

--- a/Mathlib/Order/Filter/AtTopBot/Monoid.lean
+++ b/Mathlib/Order/Filter/AtTopBot/Monoid.lean
@@ -126,7 +126,7 @@ theorem Tendsto.atTop_of_isBoundedUnder_le_mul (hf : IsBoundedUnder (· ≤ ·) 
     (hfg : Tendsto (fun x => f x * g x) l atTop) : Tendsto g l atTop := by
   obtain ⟨C, hC⟩ := hf
   refine .atTop_of_const_mul C <| tendsto_atTop_mono' l ?_ hfg
-  exact (eventually_map.mp hC).mono fun _ ↦ (mul_le_mul_right' · _)
+  exact (eventually_map.mp hC).mono fun _ _ ↦ by dsimp; gcongr
 
 @[to_additive]
 theorem Tendsto.atBot_of_isBoundedUnder_ge_mul (hf : IsBoundedUnder (· ≥ ·) l f)
@@ -148,7 +148,7 @@ theorem Tendsto.atTop_of_mul_isBoundedUnder_le (hg : IsBoundedUnder (· ≤ ·) 
     (h : Tendsto (fun x => f x * g x) l atTop) : Tendsto f l atTop := by
   obtain ⟨C, hC⟩ := hg
   refine .atTop_of_mul_const C <| tendsto_atTop_mono' l ?_ h
-  exact (eventually_map.mp hC).mono fun _ ↦ (mul_le_mul_left' · _)
+  exact (eventually_map.mp hC).mono fun _ _ ↦ by dsimp; gcongr
 
 @[to_additive]
 theorem Tendsto.atBot_of_mul_isBoundedUnder_ge (hg : IsBoundedUnder (· ≥ ·) l g)

--- a/Mathlib/Order/Filter/Germ/OrderedMonoid.lean
+++ b/Mathlib/Order/Filter/Germ/OrderedMonoid.lean
@@ -28,7 +28,7 @@ variable {α : Type*} {β : Type*} {l : Filter α}
 instance instIsOrderedMonoid [CommMonoid β] [PartialOrder β] [IsOrderedMonoid β] :
     IsOrderedMonoid (Germ l β) where
   mul_le_mul_left f g := inductionOn₂ f g fun _ _ H h ↦ inductionOn h fun _ ↦ H.mono
-    fun _ H ↦ mul_le_mul_left' H _
+    fun _ H ↦ by dsimp; gcongr
 
 @[to_additive]
 instance instIsOrderedCancelMonoid [CommMonoid β] [PartialOrder β] [IsOrderedCancelMonoid β] :

--- a/Mathlib/Order/Height.lean
+++ b/Mathlib/Order/Height.lean
@@ -145,27 +145,25 @@ theorem le_chainHeight_add_nat_iff {n m : ℕ} :
 
 theorem chainHeight_add_le_chainHeight_add (s : Set α) (t : Set β) (n m : ℕ) :
     s.chainHeight + n ≤ t.chainHeight + m ↔
-      ∀ l ∈ s.subchain, ∃ l' ∈ t.subchain, length l + n ≤ length l' + m := by
-  refine
-    ⟨fun e l h ↦
-      le_chainHeight_add_nat_iff.1
-        ((add_le_add_right (length_le_chainHeight_of_mem_subchain h) _).trans e),
-      fun H ↦ ?_⟩
-  by_cases h : s.chainHeight = ⊤
-  · suffices t.chainHeight = ⊤ by
-      rw [this, top_add]
-      exact le_top
-    rw [chainHeight_eq_top_iff] at h ⊢
-    intro k
-    have := (le_chainHeight_TFAE t k).out 1 2
-    rw [this]
-    obtain ⟨l, hs, hl⟩ := h (k + m)
-    obtain ⟨l', ht, hl'⟩ := H l hs
-    exact ⟨l', ht, (add_le_add_iff_right m).1 <| _root_.trans (hl.symm.trans_le le_self_add) hl'⟩
-  · obtain ⟨k, hk⟩ := WithTop.ne_top_iff_exists.1 h
-    obtain ⟨l, hs, hl⟩ := le_chainHeight_iff.1 hk.le
-    rw [← hk, ← hl]
-    exact le_chainHeight_add_nat_iff.2 (H l hs)
+      ∀ l ∈ s.subchain, ∃ l' ∈ t.subchain, length l + n ≤ length l' + m where
+  mp e l h := le_chainHeight_add_nat_iff.1 <| by
+    push_cast; grw [length_le_chainHeight_of_mem_subchain h, e]
+  mpr H := by
+    by_cases h : s.chainHeight = ⊤
+    · suffices t.chainHeight = ⊤ by
+        rw [this, top_add]
+        exact le_top
+      rw [chainHeight_eq_top_iff] at h ⊢
+      intro k
+      have := (le_chainHeight_TFAE t k).out 1 2
+      rw [this]
+      obtain ⟨l, hs, hl⟩ := h (k + m)
+      obtain ⟨l', ht, hl'⟩ := H l hs
+      exact ⟨l', ht, (add_le_add_iff_right m).1 <| _root_.trans (hl.symm.trans_le le_self_add) hl'⟩
+    · obtain ⟨k, hk⟩ := WithTop.ne_top_iff_exists.1 h
+      obtain ⟨l, hs, hl⟩ := le_chainHeight_iff.1 hk.le
+      rw [← hk, ← hl]
+      exact le_chainHeight_add_nat_iff.2 (H l hs)
 
 theorem chainHeight_le_chainHeight_TFAE (s : Set α) (t : Set β) :
     TFAE [s.chainHeight ≤ t.chainHeight, ∀ l ∈ s.subchain, ∃ l' ∈ t.subchain, length l = length l',

--- a/Mathlib/Order/KrullDimension.lean
+++ b/Mathlib/Order/KrullDimension.lean
@@ -1108,8 +1108,8 @@ lemma krullDim_le_of_krullDim_preimage_le :
   rw [Order.krullDim_eq_iSup_height, Order.krullDim_eq_iSup_height, iSup_le_iff]
   refine fun x ↦ (WithBot.coe_mono (height_le_of_krullDim_preimage_le f h x)).trans ?_
   push_cast
-  apply add_le_add_right <| mul_le_mul_of_nonneg_left ?_ (right_eq_inf.mp rfl)
-  exact le_iSup_iff.mpr fun b a ↦ a (f x)
+  gcongr
+  exacts [right_eq_inf.mp rfl, le_iSup_iff.mpr fun b a ↦ a (f x)]
 
 /-- Another version when the `OrderHom` is unbundled -/
 lemma krullDim_le_of_krullDim_preimage_le' (f : α → β) (h_mono : Monotone f)

--- a/Mathlib/Order/SuccPred/LinearLocallyFinite.lean
+++ b/Mathlib/Order/SuccPred/LinearLocallyFinite.lean
@@ -309,15 +309,14 @@ theorem toZ_mono {i j : ι} (h_le : i ≤ j) : toZ i0 i ≤ toZ i0 j := by
       rw [Function.iterate_add]
       rfl
     by_contra h
-    by_cases hm0 : m = 0
+    obtain hm0 | hm0 : m = 0 ∨ 1 ≤ m := by cutsat
     · rw [hm0, Function.iterate_zero, id] at hm
       rw [hm] at h
       exact h (le_of_eq rfl)
     refine hi_max (max_of_succ_le (le_trans ?_ (@le_of_toZ_le _ _ _ _ _ i0 j i ?_)))
     · have h_succ_le : succ^[(toZ i0 i).toNat + 1] i0 ≤ j := by
         rw [hj_eq]
-        refine Monotone.monotone_iterate_of_le_map succ_mono (le_succ i0) (add_le_add_left ?_ _)
-        exact Nat.one_le_iff_ne_zero.mpr hm0
+        exact Monotone.monotone_iterate_of_le_map succ_mono (le_succ i0) (by gcongr)
       rwa [Function.iterate_succ', Function.comp_apply, iterate_succ_toZ i hi] at h_succ_le
     · exact le_of_not_ge h
   · exact absurd h_le (not_le.mpr (hj.trans_le hi))
@@ -330,7 +329,7 @@ theorem toZ_mono {i j : ι} (h_le : i ≤ j) : toZ i0 i ≤ toZ i0 j := by
       rw [Function.iterate_add]
       rfl
     by_contra h
-    by_cases hm0 : m = 0
+    obtain hm0 | hm0 : m = 0 ∨ 1 ≤ m := by cutsat
     · rw [hm0, Function.iterate_zero, id] at hm
       rw [hm] at h
       exact h (le_of_eq rfl)
@@ -339,8 +338,7 @@ theorem toZ_mono {i j : ι} (h_le : i ≤ j) : toZ i0 i ≤ toZ i0 j := by
     · exact le_of_not_ge h
     · have h_le_pred : i ≤ pred^[(-toZ i0 j).toNat + 1] i0 := by
         rw [hj_eq]
-        refine Monotone.antitone_iterate_of_map_le pred_mono (pred_le i0) (add_le_add_left ?_ _)
-        exact Nat.one_le_iff_ne_zero.mpr hm0
+        exact Monotone.antitone_iterate_of_map_le pred_mono (pred_le i0) (by gcongr)
       rwa [Function.iterate_succ', Function.comp_apply, iterate_pred_toZ j hj] at h_le_pred
 
 theorem toZ_le_iff (i j : ι) : toZ i0 i ≤ toZ i0 j ↔ i ≤ j :=

--- a/Mathlib/Probability/Kernel/Disintegration/Basic.lean
+++ b/Mathlib/Probability/Kernel/Disintegration/Basic.lean
@@ -162,7 +162,8 @@ lemma IsCondKernel.isProbabilityMeasure_ae [IsFiniteKernel κ.fst] [κ.IsCondKer
     rw [lintegral_indicator_const hs] at this
     contrapose! this with h_ne_zero
     conv_lhs => rw [← one_mul (κ.fst a s)]
-    exact ENNReal.mul_lt_mul_right' h_ne_zero (measure_ne_top _ _) hr
+    gcongr
+    finiteness
   · rw [ae_const_le_iff_forall_lt_measure_zero]
     intro r hr
     let s := {b | κCond (a, b) Set.univ ≤ r}
@@ -177,7 +178,8 @@ lemma IsCondKernel.isProbabilityMeasure_ae [IsFiniteKernel κ.fst] [κ.IsCondKer
     rw [lintegral_indicator_const hs] at this
     contrapose! this with h_ne_zero
     conv_rhs => rw [← one_mul (κ.fst a s)]
-    exact ENNReal.mul_lt_mul_right' h_ne_zero (measure_ne_top _ _) hr
+    gcongr
+    finiteness
 
 
 /-! #### Existence of a disintegrating kernel in a countable space -/

--- a/Mathlib/Probability/Kernel/WithDensity.lean
+++ b/Mathlib/Probability/Kernel/WithDensity.lean
@@ -185,7 +185,7 @@ theorem isFiniteKernel_withDensity_of_bounded (κ : Kernel α β) [IsFiniteKerne
           ∫⁻ b in Set.univ, f a b ∂κ a ≤ ∫⁻ _ in Set.univ, B ∂κ a := lintegral_mono (hf_B a)
           _ = B * κ a Set.univ := by
             simp only [Measure.restrict_univ, MeasureTheory.lintegral_const]
-          _ ≤ B * κ.bound := mul_le_mul_left' (measure_le_bound κ a Set.univ) _⟩⟩
+          _ ≤ B * κ.bound := by grw [measure_le_bound]⟩⟩
   · rw [withDensity_of_not_measurable _ hf]
     infer_instance
 

--- a/Mathlib/Probability/StrongLaw.lean
+++ b/Mathlib/Probability/StrongLaw.lean
@@ -257,10 +257,10 @@ theorem sum_prob_mem_Ioc_le {X : Ω → ℝ} (hint : Integrable X) (hnonneg : 0 
         · exact continuous_const.intervalIntegrable _ _
       _ = 𝔼[truncation X N] + ∫ x in 0..N, 1 ∂ρ := by
         rw [integral_truncation_eq_intervalIntegral_of_nonneg hint.1 hnonneg]
-      _ ≤ 𝔼[X] + ∫ x in 0..N, 1 ∂ρ :=
-        (add_le_add_right (integral_truncation_le_integral_of_nonneg hint hnonneg) _)
+      _ ≤ 𝔼[X] + ∫ x in 0..N, 1 ∂ρ := by
+        grw [integral_truncation_le_integral_of_nonneg hint hnonneg]
       _ ≤ 𝔼[X] + 1 := by
-        refine add_le_add le_rfl ?_
+        gcongr
         rw [intervalIntegral.integral_of_le (Nat.cast_nonneg _)]
         simp only [integral_const, measureReal_restrict_apply', measurableSet_Ioc, Set.univ_inter,
           Algebra.id.smul_eq_mul, mul_one]

--- a/Mathlib/RingTheory/DedekindDomain/Factorization.lean
+++ b/Mathlib/RingTheory/DedekindDomain/Factorization.lean
@@ -657,8 +657,8 @@ lemma IsDedekindDomain.exists_add_spanSingleton_mul_eq
     {a b c : FractionalIdeal R⁰ K} (hac : a ≤ c) (ha : a ≠ 0) (hb : b ≠ 0) :
     ∃ x : K, a + FractionalIdeal.spanSingleton R⁰ x * b = c := by
   wlog hb' : b = 1
-  · obtain ⟨x, e⟩ := this (a := b⁻¹ * a) (b := 1) (c := b⁻¹ * c)
-      (mul_le_mul_left' hac _) (by simp [ha, hb]) one_ne_zero rfl
+  · obtain ⟨x, e⟩ := this (a := b⁻¹ * a) (b := 1) (c := b⁻¹ * c) (by gcongr) (by simp [ha, hb])
+      one_ne_zero rfl
     use x
     simpa [hb, ← mul_assoc, mul_add, mul_comm b (.spanSingleton _ _)] using congr(b * $e)
   subst hb'
@@ -667,7 +667,7 @@ lemma IsDedekindDomain.exists_add_spanSingleton_mul_eq
     simp only [FractionalIdeal.coeIdeal_mul, FractionalIdeal.coeIdeal_span_singleton, ←
       FractionalIdeal.den_mul_self_eq_num']
     ring_nf
-    exact mul_le_mul_left' hac _
+    gcongr
   obtain ⟨x, hx⟩ := exists_sup_span_eq H
     (by simpa using FractionalIdeal.num_eq_zero_iff.not.mpr ha)
   refine ⟨algebraMap R K x / algebraMap R K (a.den.1 * c.den.1), ?_⟩

--- a/Mathlib/RingTheory/DedekindDomain/Ideal/Lemmas.lean
+++ b/Mathlib/RingTheory/DedekindDomain/Ideal/Lemmas.lean
@@ -243,10 +243,7 @@ lemma Ideal.mul_iInf (I : Ideal A) {ι : Type*} [Nonempty ι] (J : ι → Ideal 
   refine (le_iInf fun i ↦ Ideal.mul_mono_right (iInf_le _ _)).antisymm ?_
   have H : ⨅ i, I * J i ≤ I := (iInf_le _ (Nonempty.some ‹_›)).trans Ideal.mul_le_right
   obtain ⟨K, hK⟩ := Ideal.dvd_iff_le.mpr H
-  rw [hK]
-  refine mul_le_mul_left' ?_ I
-  rw [le_iInf_iff]
-  intro i
+  grw [hK, le_iInf (a := K) fun i ↦ ?_]
   rw [← mul_le_mul_iff_of_pos_left (a := I), ← hK]
   · exact iInf_le _ _
   · exact bot_lt_iff_ne_bot.mpr hI

--- a/Mathlib/RingTheory/DedekindDomain/PID.lean
+++ b/Mathlib/RingTheory/DedekindDomain/PID.lean
@@ -81,8 +81,7 @@ theorem FractionalIdeal.isPrincipal_of_unit_of_comap_mul_span_singleton_eq_top {
   have hJ : IsLocalization.coeSubmodule A J = ↑I * Submodule.span R {v} := by
     rw [coe_ext_iff, coe_mul, coe_one] at hinv
     apply Submodule.map_comap_eq_self
-    rw [← Submodule.one_eq_range, ← hinv]
-    exact mul_le_mul_left' ((Submodule.span_singleton_le_iff_mem _ _).2 hv) _
+    grw [← Submodule.one_eq_range, ← hinv, (Submodule.span_singleton_le_iff_mem _ _).2 hv]
   have : (1 : A) ∈ ↑I * Submodule.span R {v} := by
     rw [← hJ, h, IsLocalization.coeSubmodule_top, Submodule.mem_one]
     exact ⟨1, (algebraMap R _).map_one⟩
@@ -91,7 +90,7 @@ theorem FractionalIdeal.isPrincipal_of_unit_of_comap_mul_span_singleton_eq_top {
   rw [← FractionalIdeal.coe_spanSingleton S, ← inv_inv I, eq_comm]
   refine congr_arg coeToSubmodule (Units.eq_inv_of_mul_eq_one_left (le_antisymm ?_ ?_))
   · conv_rhs => rw [← hinv, mul_comm]
-    apply mul_le_mul_left' (FractionalIdeal.spanSingleton_le_iff_mem.mpr hw)
+    grw [FractionalIdeal.spanSingleton_le_iff_mem.mpr hw]
   · rw [FractionalIdeal.one_le, ← hvw, mul_comm]
     exact FractionalIdeal.mul_mem_mul (FractionalIdeal.mem_spanSingleton_self _ _) hv
 

--- a/Mathlib/RingTheory/Finiteness/Subalgebra.lean
+++ b/Mathlib/RingTheory/Finiteness/Subalgebra.lean
@@ -36,8 +36,7 @@ theorem fg_unit {R A : Type*} [CommSemiring R] [Semiring A] [Algebra R A] (I : (
   refine ⟨T, span_eq_of_le _ hT ?_⟩
   rw [← one_mul I, ← mul_one (span R (T : Set A))]
   conv_rhs => rw [← I.inv_mul, ← mul_assoc]
-  refine mul_le_mul_right' (le_trans ?_ <| mul_le_mul_left' (span_le.mpr hT') _) _
-  rwa [Units.val_one, span_mul_span, one_le]
+  grw [← span_le.mpr hT', Units.val_mul, Units.val_one, span_mul_span, one_le.2 one_mem]
 
 theorem fg_of_isUnit {R A : Type*} [CommSemiring R] [Semiring A] [Algebra R A] {I : Submodule R A}
     (hI : IsUnit I) : I.FG :=

--- a/Mathlib/RingTheory/GradedAlgebra/Radical.lean
+++ b/Mathlib/RingTheory/GradedAlgebra/Radical.lean
@@ -101,13 +101,10 @@ theorem Ideal.IsHomogeneous.isPrime_of_homogeneous_mem_or_mem {I : Ideal A} (hI 
         simp only [antidiag, mem_erase, Prod.mk_inj, Ne, mem_filter, mem_product] at H
         rcases H with ⟨H₁, ⟨H₂, H₃⟩, H₄⟩
         have max_lt : max₁ < i ∨ max₂ < j := by
-          rcases lt_trichotomy max₁ i with (h | rfl | h)
-          · exact Or.inl h
-          · refine False.elim (H₁ ⟨rfl, add_left_cancel H₄⟩)
-          · apply Or.inr
-            have := add_lt_add_right h j
-            rw [H₄] at this
-            exact lt_of_add_lt_add_left this
+          convert le_or_lt_of_add_le_add H₄.ge using 1
+          rw [Ne.le_iff_lt]
+          rintro rfl
+          cases H₁ ⟨rfl, add_left_cancel H₄⟩
         rcases max_lt with max_lt | max_lt
         · -- in this case `max₁ < i`, then `xᵢ ∈ I`; for otherwise `i ∈ set₁` then `i ≤ max₁`.
           have notMem : i ∉ set₁ := fun h =>

--- a/Mathlib/RingTheory/HahnSeries/Multiplication.lean
+++ b/Mathlib/RingTheory/HahnSeries/Multiplication.lean
@@ -611,8 +611,7 @@ theorem orderTop_nsmul_le_orderTop_pow {Γ}
   | succ n ih =>
     rw [add_nsmul, pow_add]
     calc
-      n • x.orderTop + 1 • x.orderTop ≤ (x ^ n).orderTop + 1 • x.orderTop :=
-        add_le_add_right ih (1 • x.orderTop)
+      n • x.orderTop + 1 • x.orderTop ≤ (x ^ n).orderTop + 1 • x.orderTop := by gcongr
       (x ^ n).orderTop + 1 • x.orderTop = (x ^ n).orderTop + x.orderTop := by rw [one_nsmul]
       (x ^ n).orderTop + x.orderTop ≤ (x ^ n * x).orderTop := orderTop_add_le_mul
       (x ^ n * x).orderTop ≤ (x ^ n * x ^ 1).orderTop := by rw [pow_one]

--- a/Mathlib/RingTheory/KrullDimension/NonZeroDivisors.lean
+++ b/Mathlib/RingTheory/KrullDimension/NonZeroDivisors.lean
@@ -83,7 +83,7 @@ lemma ringKrullDim_add_natCard_le_ringKrullDim_mvPolynomial (σ : Type*) [Finite
   | h_option IH =>
     simp only [Nat.card_eq_fintype_card, Fintype.card_option, Nat.cast_add, Nat.cast_one,
       ← add_assoc] at IH ⊢
-    refine (add_le_add_right IH _).trans (ringKrullDim_succ_le_ringKrullDim_polynomial.trans ?_)
+    grw [IH, ringKrullDim_succ_le_ringKrullDim_polynomial]
     exact (ringKrullDim_eq_of_ringEquiv (MvPolynomial.optionEquivLeft _ _).toRingEquiv).ge
 
 open MvPolynomial in

--- a/Mathlib/RingTheory/MvPolynomial/Groebner.lean
+++ b/Mathlib/RingTheory/MvPolynomial/Groebner.lean
@@ -177,13 +177,8 @@ theorem div {ι : Type*} {b : ι → MvPolynomial σ R}
       · classical
         rw [Finsupp.single_apply]
         split_ifs with hc
-        · apply le_trans degree_mul_le
-          simp only [map_add]
-          apply le_of_le_of_eq (add_le_add_left (degree_monomial_le _) _)
-          simp only [← hc]
-          rw [← map_add, m.toSyn.injective.eq_iff]
-          rw [add_tsub_cancel_of_le]
-          exact hf
+        · subst j
+          grw [degree_mul_le, map_add, degree_monomial_le, ← map_add, add_tsub_cancel_of_le hf]
         · simp only [mul_zero, degree_zero, map_zero]
           exact bot_le
     · exact H'.2.2

--- a/Mathlib/RingTheory/MvPolynomial/MonomialOrder.lean
+++ b/Mathlib/RingTheory/MvPolynomial/MonomialOrder.lean
@@ -369,10 +369,8 @@ theorem degree_mul_le {f g : MvPolynomial σ R} :
       rw [m.coeff_eq_zero_of_lt this, mul_zero]
     simp only [not_lt] at hd
     apply lt_of_add_lt_add_left (a := m.toSyn d)
-    simp only [← map_add, hde]
-    apply lt_of_le_of_lt _ hc
-    simp only [map_add]
-    exact add_le_add_right hd _
+    grw [← map_add _ _ e, hd, ← map_add, hde]
+    exact hc
 
 /-- Multiplicativity of leading coefficients -/
 theorem coeff_mul_of_add_of_degree_le {f g : MvPolynomial σ R} {a b : σ →₀ ℕ}

--- a/Mathlib/RingTheory/MvPowerSeries/Inverse.lean
+++ b/Mathlib/RingTheory/MvPowerSeries/Inverse.lean
@@ -117,19 +117,11 @@ theorem mul_invOfUnit (φ : MvPowerSeries σ R) (u : Rˣ) (h : constantCoeff φ 
         sub_eq_add_neg, sub_eq_zero, Finset.sum_congr rfl]
       rintro ⟨i, j⟩ hij
       rw [Finset.mem_erase, mem_antidiagonal] at hij
-      obtain ⟨h₁, h₂⟩ := hij
-      subst n
+      obtain ⟨h₁, rfl⟩ := hij
       rw [if_pos]
-      suffices 0 + j < i + j by simpa
-      apply add_lt_add_right
-      constructor
-      · intro s
-        exact Nat.zero_le _
-      · intro H
-        apply h₁
-        suffices i = 0 by simp [this]
-        ext1 s
-        exact Nat.eq_zero_of_le_zero (H s)
+      refine lt_add_of_pos_left _ <| pos_iff_ne_zero.2 ?_
+      rintro rfl
+      simp at h₁
 
 -- TODO : can one prove equivalence?
 @[simp]

--- a/Mathlib/RingTheory/MvPowerSeries/Order.lean
+++ b/Mathlib/RingTheory/MvPowerSeries/Order.lean
@@ -297,9 +297,7 @@ theorem le_weightedOrder_prod {R : Type*} [CommSemiring R] {ι : Type*} (w : σ 
     ∑ i ∈ s, (f i).weightedOrder w ≤ (∏ i ∈ s, f i).weightedOrder w := by
   induction s using Finset.cons_induction with
   | empty => simp
-  | cons a s ha ih =>
-    rw [Finset.sum_cons ha, Finset.prod_cons ha]
-    exact le_trans (add_le_add_left ih _) (le_weightedOrder_mul _)
+  | cons a s ha ih => grw [Finset.sum_cons ha, Finset.prod_cons ha, ih, le_weightedOrder_mul]
 
 alias weightedOrder_mul_ge := le_weightedOrder_mul
 

--- a/Mathlib/RingTheory/PowerSeries/Order.lean
+++ b/Mathlib/RingTheory/PowerSeries/Order.lean
@@ -193,9 +193,7 @@ theorem le_order_prod {R : Type*} [CommSemiring R] {ι : Type*} (φ : ι → R�
     ∑ i ∈ s, (φ i).order ≤ (∏ i ∈ s, φ i).order := by
   induction s using Finset.cons_induction with
   | empty => simp
-  | cons a s ha ih =>
-    rw [Finset.sum_cons ha, Finset.prod_cons ha]
-    exact le_trans (add_le_add_left ih _) (le_order_mul _ _)
+  | cons a s ha ih => grw [Finset.sum_cons ha, Finset.prod_cons ha, ih, le_order_mul]
 
 alias order_mul_ge := le_order_mul
 

--- a/Mathlib/RingTheory/Valuation/Archimedean.lean
+++ b/Mathlib/RingTheory/Valuation/Archimedean.lean
@@ -27,7 +27,7 @@ instance MonoidWithZeroHom.instLinearOrderedCommGroupWithZeroMrange (v : F â†’*â
     simp only [Subtype.forall, MonoidHom.mem_mrange, forall_exists_index, Submonoid.mk_mul_mk,
       Subtype.mk_le_mk, forall_apply_eq_imp_iff]
     intro a b hab c
-    exact mul_le_mul_left' hab (v c)
+    gcongr
 
 instance Valuation.instLinearOrderedCommGroupWithZeroMrange :
     LinearOrderedCommGroupWithZero (MonoidHom.mrange v) :=

--- a/Mathlib/RingTheory/Valuation/ExtendToLocalization.lean
+++ b/Mathlib/RingTheory/Valuation/ExtendToLocalization.lean
@@ -43,8 +43,8 @@ noncomputable def Valuation.extendToLocalization : Valuation B Γ :=
           IsLocalization.toLocalizationMap_apply,
           IsLocalization.toLocalizationMap_apply]
       iterate 3 rw [f.lift_mk']
-      rw [max_mul_mul_right]
-      apply mul_le_mul_right' (v.map_add a b) }
+      dsimp
+      grw [max_mul_mul_right, v.map_add a b] }
 
 @[simp]
 theorem Valuation.extendToLocalization_mk' (x : A) (y : S) :

--- a/Mathlib/RingTheory/Valuation/Integers.lean
+++ b/Mathlib/RingTheory/Valuation/Integers.lean
@@ -67,9 +67,8 @@ theorem one_of_isUnit' {x : O} (hx : IsUnit x) (H : ∀ x, v (algebraMap O R x) 
     v (algebraMap O R x) = 1 :=
   let ⟨u, hu⟩ := hx
   le_antisymm (H _) <| by
-    rw [← v.map_one, ← (algebraMap O R).map_one, ← u.mul_inv, ← mul_one (v (algebraMap O R x)), hu,
-      (algebraMap O R).map_mul, v.map_mul]
-    exact mul_le_mul_left' (H (u⁻¹ : Units O)) _
+    grw [← v.map_one, ← (algebraMap O R).map_one, ← u.mul_inv, ← mul_one (v (algebraMap O R x)), hu,
+      (algebraMap O R).map_mul, v.map_mul, H (u⁻¹ : Units O)]
 
 theorem one_of_isUnit (hv : Integers v O) {x : O} (hx : IsUnit x) : v (algebraMap O R x) = 1 :=
   one_of_isUnit' hx hv.map_le_one
@@ -92,9 +91,8 @@ theorem isUnit_of_one (hv : Integers v O) {x : O} (hx : IsUnit (algebraMap O R x
 
 theorem le_of_dvd (hv : Integers v O) {x y : O} (h : x ∣ y) :
     v (algebraMap O R y) ≤ v (algebraMap O R x) := by
-  let ⟨z, hz⟩ := h
-  rw [← mul_one (v (algebraMap O R x)), hz, RingHom.map_mul, v.map_mul]
-  exact mul_le_mul_left' (hv.2 z) _
+  obtain ⟨z, rfl⟩ := h
+  grw [← mul_one (v (algebraMap O R x)), RingHom.map_mul, v.map_mul, hv.2 z]
 
 lemma nontrivial_iff (hv : v.Integers O) : Nontrivial O ↔ Nontrivial R := by
   constructor <;> intro h
@@ -130,8 +128,7 @@ theorem dvd_of_le (hv : Integers v O) {x y : O}
       hx.symm ▸ dvd_zero y)
     fun hy : algebraMap O F y ≠ 0 =>
     have : v ((algebraMap O F y)⁻¹ * algebraMap O F x) ≤ 1 := by
-      rw [← v.map_one, ← inv_mul_cancel₀ hy, v.map_mul, v.map_mul]
-      exact mul_le_mul_left' h _
+      grw [← v.map_one, ← inv_mul_cancel₀ hy, v.map_mul, v.map_mul, h]
     let ⟨z, hz⟩ := hv.3 this
     ⟨z, hv.1 <| ((algebraMap O F).map_mul y z).symm ▸ hz.symm ▸ (mul_inv_cancel_left₀ hy _).symm⟩
 

--- a/Mathlib/RingTheory/Valuation/ValuativeRel/Basic.lean
+++ b/Mathlib/RingTheory/Valuation/ValuativeRel/Basic.lean
@@ -460,8 +460,7 @@ instance : IsOrderedMonoid (ValueGroupWithZero R) where
     simp only [ValueGroupWithZero.mk_mul_mk, ValueGroupWithZero.mk_le_mk, Submonoid.coe_mul]
     conv_lhs => apply mul_mul_mul_comm
     conv_rhs => apply mul_mul_mul_comm
-    apply rel_mul_left
-    exact hab
+    exact rel_mul_left _ hab
 
 instance : Inv (ValueGroupWithZero R) where
   inv := ValueGroupWithZero.lift (fun x s => by
@@ -543,7 +542,7 @@ def ofValuation
   rel_total x y := le_total (v x) (v y)
   rel_trans := le_trans
   rel_add hab hbc := (map_add_le_max v _ _).trans (sup_le hab hbc)
-  rel_mul_right _ h := by simp only [map_mul, mul_le_mul_right' h]
+  rel_mul_right _ h := by simp [map_mul]; gcongr
   rel_mul_cancel h0 h := by
     rw [map_zero, le_zero_iff] at h0
     simp only [map_mul] at h

--- a/Mathlib/SetTheory/Cardinal/Aleph.lean
+++ b/Mathlib/SetTheory/Cardinal/Aleph.lean
@@ -603,7 +603,7 @@ theorem preBeth_le_beth (o : Ordinal) : preBeth o ≤ ℶ_ o :=
   preBeth_le_preBeth.2 (Ordinal.le_add_left _ _)
 
 theorem beth_strictMono : StrictMono beth :=
-  preBeth_strictMono.comp fun _ _ h ↦ add_lt_add_left h _
+  preBeth_strictMono.comp fun _ _ h ↦ by gcongr
 
 theorem beth_mono : Monotone beth :=
   beth_strictMono.monotone

--- a/Mathlib/SetTheory/Cardinal/Arithmetic.lean
+++ b/Mathlib/SetTheory/Cardinal/Arithmetic.lean
@@ -364,7 +364,7 @@ variable [Nonempty ι] [Nonempty ι']
 
 protected theorem ciSup_add (hf : BddAbove (range f)) (c : Cardinal.{v}) :
     (⨆ i, f i) + c = ⨆ i, f i + c := by
-  have : ∀ i, f i + c ≤ (⨆ i, f i) + c := fun i ↦ add_le_add_right (le_ciSup hf i) c
+  have (i : ι) : f i + c ≤ (⨆ i, f i) + c := by grw [le_ciSup hf i]
   refine le_antisymm ?_ (ciSup_le' this)
   have bdd : BddAbove (range (f · + c)) := ⟨_, forall_mem_range.mpr this⟩
   obtain hs | hs := lt_or_ge (⨆ i, f i) ℵ₀
@@ -393,7 +393,7 @@ protected theorem ciSup_mul (c : Cardinal.{v}) : (⨆ i, f i) * c = ⨆ i, f i *
   · have hfc : ¬ BddAbove (range (f · * c)) := fun bdd ↦ hf
       ⟨⨆ i, f i * c, forall_mem_range.mpr fun i ↦ (le_mul_right h0).trans (le_ciSup bdd i)⟩
     simp [iSup, csSup_of_not_bddAbove, hf, hfc]
-  have : ∀ i, f i * c ≤ (⨆ i, f i) * c := fun i ↦ mul_le_mul_right' (le_ciSup hf i) c
+  have (i : ι) : f i * c ≤ (⨆ i, f i) * c := by grw [← le_ciSup hf i]
   refine le_antisymm ?_ (ciSup_le' this)
   have bdd : BddAbove (range (f · * c)) := ⟨_, forall_mem_range.mpr this⟩
   obtain hs | hs := lt_or_ge (⨆ i, f i) ℵ₀
@@ -443,10 +443,10 @@ theorem add_one_inj {α β : Cardinal} : α + 1 = β + 1 ↔ α = β :=
 
 theorem add_le_add_iff_of_lt_aleph0 {α β γ : Cardinal} (γ₀ : γ < ℵ₀) :
     α + γ ≤ β + γ ↔ α ≤ β := by
-  refine ⟨fun h => ?_, fun h => add_le_add_right h γ⟩
+  refine ⟨fun h => ?_, fun h => by gcongr⟩
   contrapose h
   rw [not_le, lt_iff_le_and_ne, Ne] at h ⊢
-  exact ⟨add_le_add_right h.1 γ, mt (add_right_inj_of_lt_aleph0 γ₀).1 h.2⟩
+  exact ⟨by grw [h.1], mt (add_right_inj_of_lt_aleph0 γ₀).1 h.2⟩
 
 @[simp]
 theorem add_nat_le_add_nat_iff {α β : Cardinal} (n : ℕ) : α + n ≤ β + n ↔ α ≤ β :=
@@ -467,17 +467,8 @@ theorem pow_le {κ μ : Cardinal.{u}} (H1 : ℵ₀ ≤ κ) (H2 : μ < ℵ₀) : 
     Quotient.inductionOn κ
       (fun α H1 =>
         Nat.recOn n
-          (lt_of_lt_of_le
-              (by
-                rw [Nat.cast_zero, power_zero]
-                exact one_lt_aleph0)
-              H1).le
-          fun n ih =>
-          le_of_le_of_eq
-            (by
-              rw [Nat.cast_succ, power_add, power_one]
-              exact mul_le_mul_right' ih _)
-            (mul_eq_self H1))
+          (by grw [Nat.cast_zero, power_zero, one_lt_aleph0, H1])
+          fun n ih => by grw [Nat.cast_succ, power_add, power_one, ih, mul_eq_self H1])
       H1
 
 theorem pow_eq {κ μ : Cardinal.{u}} (H1 : ℵ₀ ≤ κ) (H2 : 1 ≤ μ) (H3 : μ < ℵ₀) : κ ^ μ = κ :=

--- a/Mathlib/SetTheory/Cardinal/CountableCover.lean
+++ b/Mathlib/SetTheory/Cardinal/CountableCover.lean
@@ -58,7 +58,7 @@ lemma mk_subtype_le_of_countable_eventually_mem_aux {α ι : Type u} {a : Cardin
       _     ≤ sum (fun i ↦ #(f i)) := mk_iUnion_le_sum_mk
       _     ≤ sum (fun _ ↦ a) := sum_le_sum _ _ h'f
       _     = #ι * a := by simp
-      _     ≤ ℵ₀ * a := mul_le_mul_right' mk_le_aleph0 a
+      _     ≤ ℵ₀ * a := by grw [mk_le_aleph0]
       _     = a := aleph0_mul_eq ha
 
 /-- If a set `t` is eventually covered by a countable family of sets, all with cardinality at

--- a/Mathlib/SetTheory/Cardinal/Order.lean
+++ b/Mathlib/SetTheory/Cardinal/Order.lean
@@ -292,8 +292,8 @@ instance canonicallyOrderedAdd : CanonicallyOrderedAdd Cardinal.{u} where
         exact (Equiv.sumCongr (Equiv.ofInjective f hf) (Equiv.refl _)).trans <|
           Equiv.Set.sumCompl (range f)
       ⟨#(↥(range f)ᶜ), mk_congr this.symm⟩
-  le_self_add a _ := (add_zero a).ge.trans <| add_le_add_left (Cardinal.zero_le _) _
-  le_add_self a _ := (zero_add a).ge.trans <| add_le_add_right (Cardinal.zero_le _) _
+  le_self_add a b := (add_zero a).ge.trans <| by grw [Cardinal.zero_le b]
+  le_add_self a _ := (zero_add a).ge.trans <| by grw [Cardinal.zero_le]
 
 instance isOrderedRing : IsOrderedRing Cardinal.{u} :=
   CanonicallyOrderedAdd.toIsOrderedRing

--- a/Mathlib/SetTheory/Ordinal/Arithmetic.lean
+++ b/Mathlib/SetTheory/Ordinal/Arithmetic.lean
@@ -456,7 +456,7 @@ theorem le_add_sub (a b : Ordinal) : a ≤ b + (a - b) := by
   · simpa [sub_eq_zero_of_lt h] using h.le
 
 theorem sub_le {a b c : Ordinal} : a - b ≤ c ↔ a ≤ b + c := by
-  refine ⟨fun h ↦ (le_add_sub a b).trans (add_le_add_left h _), fun h ↦ ?_⟩
+  refine ⟨fun h ↦ (le_add_sub a b).trans (by gcongr), fun h ↦ ?_⟩
   obtain h' | h' := le_or_gt b a
   · rwa [← add_le_add_iff_left b, Ordinal.add_sub_cancel_of_le h']
   · simp [sub_eq_zero_of_lt h']
@@ -511,7 +511,7 @@ theorem sub_lt_of_lt_add {a b c : Ordinal} (h : a < b + c) (hc : 0 < c) : a - b 
 theorem lt_add_iff {a b c : Ordinal} (hc : c ≠ 0) : a < b + c ↔ ∃ d < c, a ≤ b + d := by
   use fun h ↦ ⟨_, sub_lt_of_lt_add h hc.bot_lt, le_add_sub a b⟩
   rintro ⟨d, hd, ha⟩
-  exact ha.trans_lt (add_lt_add_left hd b)
+  exact ha.trans_lt (by gcongr)
 
 theorem add_le_iff {a b c : Ordinal} (hb : b ≠ 0) : a + b ≤ c ↔ ∀ d < b, a + d < c := by
   simpa using (lt_add_iff hb).not
@@ -785,14 +785,8 @@ private theorem add_mul_limit_aux {a b c : Ordinal} (ba : b + a = a) (l : IsSucc
     (IH : ∀ c' < c, (a + b) * succ c' = a * succ c' + b) : (a + b) * c = a * c :=
   le_antisymm
     ((mul_le_iff_of_isSuccLimit l).2 fun c' h => by
-      apply (mul_le_mul_left' (le_succ c') _).trans
-      rw [IH _ h]
-      apply (add_le_add_left _ _).trans
-      · rw [← mul_succ]
-        exact mul_le_mul_left' (succ_le_of_lt <| l.succ_lt h) _
-      · rw [← ba]
-        exact le_add_right _ _)
-    (mul_le_mul_right' (le_add_right _ _) _)
+      grw [le_succ c', IH _ h, le_add_right b a, ba, ← mul_succ, succ_le_of_lt <| l.succ_lt h])
+    (by grw [← le_add_right])
 
 theorem add_mul_succ {a b : Ordinal} (c) (ba : b + a = a) : (a + b) * succ c = a * succ c + b := by
   induction c using limitRecOn with
@@ -901,11 +895,10 @@ theorem mul_add_div_mul {a c : Ordinal} (hc : c < a) (b d : Ordinal) :
     · rw [← lt_succ_iff, div_lt H, mul_assoc]
       · apply (add_lt_add_left hc _).trans_le
         rw [← mul_succ]
-        apply mul_le_mul_left'
+        gcongr
         rw [succ_le_iff]
         exact lt_mul_succ_div b hd
-    · rw [le_div H, mul_assoc]
-      exact (mul_le_mul_left' (mul_div_le b d) a).trans (le_add_right _ c)
+    · grw [le_div H, mul_assoc, mul_div_le b d, ← le_add_right]
 
 theorem mul_div_mul_cancel {a : Ordinal} (ha : a ≠ 0) (b c) : a * b / (a * c) = b / c := by
   convert mul_add_div_mul (Ordinal.pos_iff_ne_zero.2 ha) b c using 1
@@ -1188,9 +1181,8 @@ theorem isSuccLimit_iff_omega0_dvd {a : Ordinal} : IsSuccLimit a ↔ a ≠ 0 ∧
       add_le_iff_of_isSuccLimit isSuccLimit_omega0]
     intro b hb
     rcases lt_omega0.1 hb with ⟨n, rfl⟩
-    exact
-      (add_le_add_right (mul_div_le _ _) _).trans
-        (lt_sub.1 <| natCast_lt_of_isSuccLimit (isSuccLimit_sub l hx) _).le
+    grw [mul_div_le]
+    exact (lt_sub.1 <| natCast_lt_of_isSuccLimit (isSuccLimit_sub l hx) _).le
   · rcases h with ⟨a0, b, rfl⟩
     refine isSuccLimit_mul_left isSuccLimit_omega0 (Ordinal.pos_iff_ne_zero.2 <| mt ?_ a0)
     intro e

--- a/Mathlib/SetTheory/Ordinal/Exponential.lean
+++ b/Mathlib/SetTheory/Ordinal/Exponential.lean
@@ -149,11 +149,13 @@ theorem isSuccLimit_opow_left {a b : Ordinal} (l : IsSuccLimit a) (hb : b ≠ 0)
 @[deprecated (since := "2025-07-08")]
 alias isLimit_opow_left := isSuccLimit_opow_left
 
+@[gcongr]
 theorem opow_le_opow_right {a b c : Ordinal} (h₁ : 0 < a) (h₂ : b ≤ c) : a ^ b ≤ a ^ c := by
   rcases (one_le_iff_pos.2 h₁).eq_or_lt' with h₁ | h₁
   · simp_all
   · exact (opow_le_opow_iff_right h₁).2 h₂
 
+@[gcongr]
 theorem opow_le_opow_left {a b : Ordinal} (c : Ordinal) (ab : a ≤ b) : a ^ c ≤ b ^ c := by
   by_cases ha : a = 0
   · by_cases c = 0 <;> simp_all
@@ -164,6 +166,7 @@ theorem opow_le_opow_left {a b : Ordinal} (c : Ordinal) (ab : a ≤ b) : a ^ c �
       exact (opow_le_of_isSuccLimit ha l).2 fun b' h ↦
         (IH _ h).trans (opow_le_opow_right ((Ordinal.pos_iff_ne_zero.2 ha).trans_le ab) h.le)
 
+@[gcongr]
 theorem opow_le_opow {a b c d : Ordinal} (hac : a ≤ c) (hbd : b ≤ d) (hc : 0 < c) : a ^ b ≤ c ^ d :=
   (opow_le_opow_left b hac).trans (opow_le_opow_right hc hbd)
 
@@ -186,8 +189,7 @@ theorem right_le_opow {a : Ordinal} (b : Ordinal) (a1 : 1 < a) : b ≤ a ^ b :=
 
 theorem opow_lt_opow_left_of_succ {a b c : Ordinal} (ab : a < b) : a ^ succ c < b ^ succ c := by
   rw [opow_succ, opow_succ]
-  exact (mul_le_mul_right' (opow_le_opow_left c ab.le) a).trans_lt <|
-    mul_lt_mul_of_pos_left ab <| opow_pos c <| (Ordinal.zero_le a).trans_lt ab
+  exact mul_lt_mul_of_le_of_lt_of_nonneg_of_pos (by gcongr) ab a.zero_le (opow_pos _ ab.bot_lt)
 
 theorem opow_add (a b c : Ordinal) : a ^ (b + c) = a ^ b * a ^ c := by
   rcases eq_or_ne a 0 with (rfl | a0)
@@ -257,7 +259,7 @@ theorem opow_mul_add_lt_opow_mul {b u w x : Ordinal} {v : Ordinal} (hw : w < b ^
     b ^ u * v + w < b ^ u * x := by
   apply lt_of_lt_of_le (b := b ^ u * (v + 1))
   · rwa [mul_add_one, add_lt_add_iff_left]
-  · exact mul_le_mul_left' (add_one_le_of_lt hv) _
+  · grw [add_one_le_of_lt hv]
 
 @[deprecated opow_mul_add_lt_opow_mul (since := "2025-08-27")]
 theorem opow_mul_add_lt_opow_mul_succ {b u w : Ordinal} (v : Ordinal) (hw : w < b ^ u) :
@@ -410,7 +412,7 @@ theorem log_eq_zero {b o : Ordinal} (hbo : o < b) : log b o = 0 := by
     · exact log_one_left o
   · rwa [← Ordinal.le_zero, ← lt_succ_iff, succ_zero, ← lt_opow_iff_log_lt hb ho, opow_one]
 
-@[mono]
+@[gcongr, mono]
 theorem log_mono_right (b : Ordinal) {x y : Ordinal} (xy : x ≤ y) : log b x ≤ log b y := by
   obtain rfl | hx := eq_or_ne x 0
   · simp_rw [log_zero_right, Ordinal.zero_le]
@@ -462,11 +464,10 @@ theorem log_opow_mul_add {b u v w : Ordinal} (hb : 1 < b) (hv : v ≠ 0) (hw : w
     log b (b ^ u * v + w) = u + log b v := by
   rw [log_eq_iff hb]
   · constructor
-    · rw [opow_add]
-      exact (mul_le_mul_left' (opow_log_le_self b hv) _).trans (le_add_right _ w)
+    · grw [opow_add, opow_log_le_self b hv, ← le_add_right]
     · apply (add_lt_add_left hw _).trans_le
       rw [← mul_succ, ← add_succ, opow_add]
-      apply mul_le_mul_left'
+      gcongr
       rw [succ_le_iff]
       exact lt_opow_succ_log_self hb _
   · exact fun h ↦ mul_ne_zero (opow_ne_zero u (bot_lt_of_lt hb).ne') hv <|
@@ -516,8 +517,9 @@ theorem lt_omega0_opow {a b : Ordinal} (hb : b ≠ 0) :
 theorem lt_omega0_opow_succ {a b : Ordinal} : a < ω ^ succ b ↔ ∃ n : ℕ, a < ω ^ b * n := by
   refine ⟨fun ha ↦ ?_, fun ⟨n, hn⟩ ↦ hn.trans (omega0_opow_mul_nat_lt (lt_succ b) n)⟩
   obtain ⟨c, hc, n, hn⟩ := (lt_omega0_opow (succ_ne_zero b)).1 ha
-  refine ⟨n, hn.trans_le (mul_le_mul_right' ?_ _)⟩
-  rwa [opow_le_opow_iff_right one_lt_omega0, ← lt_succ_iff]
+  refine ⟨n, hn.trans_le ?_⟩
+  grw [lt_succ_iff.1 hc]
+  exact omega0_pos
 
 /-! ### Interaction with `Nat.cast` -/
 

--- a/Mathlib/SetTheory/Ordinal/FixedPoint.lean
+++ b/Mathlib/SetTheory/Ordinal/FixedPoint.lean
@@ -492,7 +492,7 @@ theorem nfp_mul_opow_omega0_add {a c : Ordinal} (b) (ha : 0 < a) (hc : 0 < c)
   apply le_antisymm
   · apply nfp_le_fp (isNormal_mul_right ha).monotone
     · rw [mul_succ]
-      apply add_le_add_left hca
+      gcongr
     · dsimp only; rw [← mul_assoc, ← opow_one_add, one_add_omega0]
   · obtain ⟨d, hd⟩ :=
       mul_eq_right_iff_opow_omega0_dvd.1 ((isNormal_mul_right ha).nfp_fp ((a ^ ω) * b + c))

--- a/Mathlib/SetTheory/Ordinal/NaturalOps.lean
+++ b/Mathlib/SetTheory/Ordinal/NaturalOps.lean
@@ -339,9 +339,7 @@ instance : AddLeftMono NatOrdinal.{u} :=
   ⟨fun a _ _ h => nadd_le_nadd_left h a⟩
 
 instance : AddLeftReflectLE NatOrdinal.{u} :=
-  ⟨fun a b c h => by
-    by_contra! h'
-    exact h.not_gt (add_lt_add_left h' a)⟩
+  ⟨fun a b c h => by by_contra! h'; exact h.not_gt (by gcongr)⟩
 
 instance : AddCommMonoid NatOrdinal :=
   { add := (· + ·)

--- a/Mathlib/SetTheory/Ordinal/Notation.lean
+++ b/Mathlib/SetTheory/Ordinal/Notation.lean
@@ -109,6 +109,9 @@ theorem lt_def {x y : ONote} : x < y ↔ repr x < repr y :=
 theorem le_def {x y : ONote} : x ≤ y ↔ repr x ≤ repr y :=
   Iff.rfl
 
+@[gcongr] alias ⟨repr_le_repr, _⟩ := le_def
+@[gcongr] alias ⟨repr_lt_repr, _⟩ := lt_def
+
 instance : WellFoundedRelation ONote :=
   ⟨(· < ·), InvImage.wf repr Ordinal.lt_wf⟩
 
@@ -227,11 +230,9 @@ theorem NFBelow.repr_lt {o b} (h : NFBelow o b) : repr o < ω ^ b := by
   | zero => exact opow_pos _ omega0_pos
   | oadd' _ _ h₃ _ IH =>
     rw [repr]
-    apply ((add_lt_add_iff_left _).2 IH).trans_le
-    rw [← mul_succ]
-    apply (mul_le_mul_left' (succ_le_of_lt (nat_lt_omega0 _)) _).trans
-    rw [← opow_succ]
-    exact opow_le_opow_right omega0_pos (succ_le_of_lt h₃)
+    apply (add_lt_add_left IH _).trans_le
+    grw [← mul_succ, succ_le_of_lt (nat_lt_omega0 _), ← opow_succ, succ_le_of_lt h₃]
+    exact omega0_pos
 
 theorem NFBelow.mono {o b₁ b₂} (bb : b₁ ≤ b₂) (h : NFBelow o b₁) : NFBelow o b₂ := by
   induction h with
@@ -269,8 +270,7 @@ theorem oadd_lt_oadd_2 {e o₁ o₂ : ONote} {n₁ n₂ : ℕ+} (h₁ : NF (oadd
   rwa [← mul_succ, mul_le_mul_iff_right₀ (opow_pos _ omega0_pos), succ_le_iff, Nat.cast_lt]
 
 theorem oadd_lt_oadd_3 {e n a₁ a₂} (h : a₁ < a₂) : oadd e n a₁ < oadd e n a₂ := by
-  rw [lt_def]; unfold repr
-  exact @add_lt_add_left _ _ _ _ (repr a₁) _ h _
+  rw [lt_def]; unfold repr; gcongr
 
 theorem cmp_compares : ∀ (a b : ONote) [NF a] [NF b], (cmp a b).Compares a b
   | 0, 0, _, _ => rfl
@@ -775,14 +775,15 @@ theorem repr_opow_aux₁ {e a} [Ne : NF e] [Na : NF a] {a' : Ordinal} (e0 : repr
   rw [repr] at this
   apply (opow_le_opow_left b <| this.le).trans
   rw [← opow_mul, ← opow_mul]
-  apply opow_le_opow_right omega0_pos
   rcases le_or_gt ω (repr e) with h | h
-  · apply (mul_le_mul_left' (le_succ b) _).trans
-    rw [← add_one_eq_succ, add_mul_succ _ (one_add_of_omega0_le h), add_one_eq_succ, succ_le_iff]
-    gcongr
-    exact isSuccLimit_omega0.succ_lt l
-  · apply (principal_mul_omega0 (isSuccLimit_omega0.succ_lt h) l).le.trans
-    simpa using mul_le_mul_right' (one_le_iff_ne_zero.2 e0) ω
+  · grw [le_succ b, ← add_one_eq_succ, add_mul_succ _ (one_add_of_omega0_le h), add_one_eq_succ]
+    · gcongr
+      · exact omega0_pos
+      · exact succ_le_iff.2 <| by gcongr; exact isSuccLimit_omega0.succ_lt l
+    · exact omega0_pos
+  · grw [show _ * _ < _ from principal_mul_omega0 (isSuccLimit_omega0.succ_lt h) l]
+    · simpa using mul_le_mul_right' (one_le_iff_ne_zero.2 e0) ω
+    · exact omega0_pos
 
 section
 
@@ -863,7 +864,7 @@ theorem repr_opow_aux₂ {a0 a'} [N0 : NF a0] [Na' : NF a'] (m : ℕ) (d : ω �
     · rw [natCast_succ, add_mul_succ]
       apply add_absorp Rl
       rw [opow_mul, opow_succ]
-      apply mul_le_mul_left'
+      gcongr
       simpa [repr] using omega0_le_oadd a0 n a'
 
 end

--- a/Mathlib/SetTheory/Ordinal/Principal.lean
+++ b/Mathlib/SetTheory/Ordinal/Principal.lean
@@ -197,14 +197,12 @@ theorem add_omega0_opow (h : a < ω ^ b) : a + ω ^ b = ω ^ b := by
   | succ =>
     rw [opow_succ] at h
     rcases (lt_mul_iff_of_isSuccLimit isSuccLimit_omega0).1 h with ⟨x, xo, ax⟩
-    apply (add_le_add_right ax.le _).trans
-    rw [opow_succ, ← mul_add, add_omega0 xo]
+    grw [ax, opow_succ, ← mul_add, add_omega0 xo]
   | limit b l IH =>
     rcases (lt_opow_of_isSuccLimit omega0_ne_zero l).1 h with ⟨x, xb, ax⟩
     apply (((isNormal_add_right a).trans <| isNormal_opow one_lt_omega0).limit_le l).2
     intro y yb
-    calc a + ω ^ y ≤ a + ω ^ max x y :=
-      add_le_add_left (opow_le_opow_right omega0_pos (le_max_right x y)) _
+    calc a + ω ^ y ≤ a + ω ^ max x y := by gcongr; exacts [omega0_pos, le_max_right ..]
     _ ≤ ω ^ max x y :=
       IH _ (max_lt xb yb) <| ax.trans_le <| opow_le_opow_right omega0_pos <| le_max_left x y
     _ ≤ ω ^ b :=
@@ -341,8 +339,7 @@ theorem mul_lt_omega0_opow (c0 : 0 < c) (ha : a < ω ^ c) (hb : b < ω) : a * b 
   · rw [opow_succ] at ha
     obtain ⟨n, hn, an⟩ :=
       ((isNormal_mul_right <| opow_pos _ omega0_pos).limit_lt isSuccLimit_omega0).1 ha
-    apply (mul_le_mul_right' (le_of_lt an) _).trans_lt
-    rw [opow_succ, mul_assoc]
+    grw [an, opow_succ, mul_assoc]
     gcongr
     exacts [opow_pos _ omega0_pos, principal_mul_omega0 hn hb]
   · rcases ((isNormal_opow one_lt_omega0).limit_lt l).1 ha with ⟨x, hx, ax⟩
@@ -357,10 +354,9 @@ theorem mul_omega0_opow_opow (a0 : 0 < a) (h : a < ω ^ ω ^ b) : a * ω ^ ω ^ 
   · apply le_antisymm
     · obtain ⟨x, xb, ax⟩ :=
         (lt_opow_of_isSuccLimit omega0_ne_zero (isSuccLimit_opow_left isSuccLimit_omega0 b0)).1 h
-      apply (mul_le_mul_right' (le_of_lt ax) _).trans
-      rw [← opow_add, add_omega0_opow xb]
+      grw [ax, ← opow_add, add_omega0_opow xb]
     · conv_lhs => rw [← one_mul (ω ^ _)]
-      exact mul_le_mul_right' (one_le_iff_pos.2 a0) _
+      grw [one_le_iff_pos.2 a0]
 
 theorem principal_mul_omega0_opow_opow (o : Ordinal) : Principal (· * ·) (ω ^ ω ^ o) :=
   principal_mul_iff_mul_left_eq.2 fun _ => mul_omega0_opow_opow
@@ -403,11 +399,11 @@ theorem mul_eq_opow_log_succ (ha : a ≠ 0) (hb : Principal (· * ·) b) (hb₂ 
     have hbo₀ : b ^ log b a ≠ 0 := Ordinal.pos_iff_ne_zero.1 (opow_pos _ (zero_lt_one.trans hb₁))
     apply (mul_le_mul_right' (le_of_lt (lt_mul_succ_div a hbo₀)) c).trans
     rw [mul_assoc, opow_succ]
-    refine mul_le_mul_left' (hb (hbl.succ_lt ?_) hcb).le _
+    gcongr
+    refine (hb (hbl.succ_lt ?_) hcb).le
     rw [div_lt hbo₀, ← opow_succ]
     exact lt_opow_succ_log_self hb₁ _
-  · rw [opow_succ]
-    exact mul_le_mul_right' (opow_log_le_self b ha) b
+  · grw [opow_succ, opow_log_le_self b ha]
 
 /-! #### Exponential principal ordinals -/
 

--- a/Mathlib/SetTheory/PGame/Algebra.lean
+++ b/Mathlib/SetTheory/PGame/Algebra.lean
@@ -700,11 +700,11 @@ theorem add_lf_add_right {y z : PGame} (h : y ⧏ z) (x) : y + x ⧏ z + x :=
   fun w =>
   calc
     z ≤ z + 0 := (PGame.add_zero _).symm.le
-    _ ≤ z + (x + -x) := add_le_add_left (zero_le_add_neg_cancel x) _
+    _ ≤ z + (x + -x) := by grw [zero_le_add_neg_cancel]
     _ ≤ z + x + -x := (PGame.add_assoc _ _ _).symm.le
     _ ≤ y + x + -x := by gcongr
     _ ≤ y + (x + -x) := (PGame.add_assoc _ _ _).le
-    _ ≤ y + 0 := add_le_add_left (add_neg_cancel_le_zero x) _
+    _ ≤ y + 0 := by grw [add_neg_cancel_le_zero]
     _ ≤ y := (PGame.add_zero _).le
 
 theorem add_lf_add_left {y z : PGame} (h : y ⧏ z) (x) : x + y ⧏ x + z := by
@@ -724,8 +724,7 @@ theorem add_lf_add_of_le_of_lf {w x y z : PGame} (hwx : w ≤ x) (hyz : y ⧏ z)
   lf_of_le_of_lf (add_le_add_right hwx y) (add_lf_add_left hyz x)
 
 theorem add_congr {w x y z : PGame} (h₁ : w ≈ x) (h₂ : y ≈ z) : w + y ≈ x + z :=
-  ⟨(add_le_add_left h₂.1 w).trans (add_le_add_right h₁.1 z),
-    (add_le_add_left h₂.2 x).trans (add_le_add_right h₁.2 y)⟩
+  ⟨add_le_add h₁.1 h₂.1, add_le_add h₁.2 h₂.2⟩
 
 theorem add_congr_left {x y z : PGame} (h : x ≈ y) : x + z ≈ y + z :=
   add_congr h equiv_rfl

--- a/Mathlib/SetTheory/Surreal/Dyadic.lean
+++ b/Mathlib/SetTheory/Surreal/Dyadic.lean
@@ -126,22 +126,22 @@ theorem add_powHalf_succ_self_eq_powHalf (n) : powHalf (n + 1) + powHalf (n + 1)
     swap
     · exact Sum.inl default
     calc
-      powHalf n.succ + powHalf (n.succ + 1) ≤ powHalf n.succ + powHalf n.succ :=
-        add_le_add_left (powHalf_succ_le_powHalf _) _
+      powHalf n.succ + powHalf (n.succ + 1) ≤ powHalf n.succ + powHalf n.succ := by
+        grw [powHalf_succ_le_powHalf (n + 1)]
       _ ≈ powHalf n := hn _ (Nat.lt_succ_self n)
   · simp only [powHalf_moveLeft, forall_const]
     apply lf_of_lt
     calc
       0 ≈ 0 + 0 := Equiv.symm (add_zero_equiv 0)
-      _ ≤ powHalf n.succ + 0 := add_le_add_right (zero_le_powHalf _) _
-      _ < powHalf n.succ + powHalf n.succ := add_lt_add_left (powHalf_pos _) _
+      _ ≤ powHalf n.succ + 0 := by grw [← zero_le_powHalf]
+      _ < powHalf n.succ + powHalf n.succ := by gcongr; exact powHalf_pos _
   · rintro (⟨⟨⟩⟩ | ⟨⟨⟩⟩) <;> apply lf_of_lt
     · calc
         powHalf n ≈ powHalf n + 0 := Equiv.symm (add_zero_equiv _)
-        _ < powHalf n + powHalf n.succ := add_lt_add_left (powHalf_pos _) _
+        _ < powHalf n + powHalf n.succ := by gcongr; exact powHalf_pos _
     · calc
         powHalf n ≈ 0 + powHalf n := Equiv.symm (zero_add_equiv _)
-        _ < powHalf n.succ + powHalf n := add_lt_add_right (powHalf_pos _) _
+        _ < powHalf n.succ + powHalf n := by gcongr; exact powHalf_pos _
 
 theorem half_add_half_equiv_one : powHalf 1 + powHalf 1 ≈ 1 :=
   add_powHalf_succ_self_eq_powHalf 0

--- a/Mathlib/Tactic/LinearCombination/Lemmas.lean
+++ b/Mathlib/Tactic/LinearCombination/Lemmas.lean
@@ -145,9 +145,7 @@ theorem eq_of_eq [Add α] [IsRightCancelAdd α] (p : (a : α) = b) (H : a' + b =
 theorem le_of_le [AddCommMonoid α] [PartialOrder α] [IsOrderedCancelAddMonoid α]
     (p : (a : α) ≤ b) (H : a' + b ≤ b' + a) :
     a' ≤ b' := by
-  rw [← add_le_add_iff_right b]
-  apply H.trans
-  apply add_le_add_left p
+  grw [← add_le_add_iff_right b, H, p]
 
 theorem le_of_eq [AddCommMonoid α] [PartialOrder α] [IsOrderedCancelAddMonoid α]
     (p : (a : α) = b) (H : a' + b ≤ b' + a) :
@@ -162,9 +160,7 @@ theorem le_of_lt [AddCommMonoid α] [PartialOrder α] [IsOrderedCancelAddMonoid 
 theorem lt_of_le [AddCommMonoid α] [PartialOrder α] [IsOrderedCancelAddMonoid α]
     (p : (a : α) ≤ b) (H : a' + b < b' + a) :
     a' < b' := by
-  rw [← add_lt_add_iff_right b]
-  apply H.trans_le
-  apply add_le_add_left p
+  grw [p] at H; simpa using H
 
 theorem lt_of_eq [AddCommMonoid α] [PartialOrder α] [IsOrderedCancelAddMonoid α]
     (p : (a : α) = b) (H : a' + b < b' + a) :
@@ -174,9 +170,8 @@ theorem lt_of_eq [AddCommMonoid α] [PartialOrder α] [IsOrderedCancelAddMonoid 
 theorem lt_of_lt [AddCommMonoid α] [PartialOrder α] [IsOrderedCancelAddMonoid α]
     (p : (a : α) < b) (H : a' + b ≤ b' + a) :
     a' < b' := by
-  rw [← add_lt_add_iff_right b]
-  apply H.trans_lt
-  apply add_lt_add_left p
+  grw [← add_lt_add_iff_right b, H]
+  gcongr
 
 alias ⟨eq_rearrange, _⟩ := sub_eq_zero
 

--- a/Mathlib/Topology/Algebra/Order/LiminfLimsup.lean
+++ b/Mathlib/Topology/Algebra/Order/LiminfLimsup.lean
@@ -161,7 +161,7 @@ lemma limsup_const_add (F : Filter ι) [NeBot F] [Add R] [ContinuousAdd R]
     (bdd_above : F.IsBoundedUnder (· ≤ ·) f) (cobdd : F.IsCoboundedUnder (· ≤ ·) f) :
     Filter.limsup (fun i ↦ c + f i) F = c + Filter.limsup f F :=
   (Monotone.map_limsSup_of_continuousAt (F := F.map f) (f := fun (x : R) ↦ c + x)
-    (fun _ _ h ↦ add_le_add_left h c) (continuous_add_left c).continuousAt bdd_above cobdd).symm
+    (fun _ _ h ↦ by dsimp; gcongr) (continuous_add_left c).continuousAt bdd_above cobdd).symm
 
 /-- `limsup (xᵢ + c) = (limsup xᵢ) + c`. -/
 lemma limsup_add_const (F : Filter ι) [NeBot F] [Add R] [ContinuousAdd R]
@@ -169,7 +169,7 @@ lemma limsup_add_const (F : Filter ι) [NeBot F] [Add R] [ContinuousAdd R]
     (bdd_above : F.IsBoundedUnder (· ≤ ·) f) (cobdd : F.IsCoboundedUnder (· ≤ ·) f) :
     Filter.limsup (fun i ↦ f i + c) F = Filter.limsup f F + c :=
   (Monotone.map_limsSup_of_continuousAt (F := F.map f) (f := fun (x : R) ↦ x + c)
-    (fun _ _ h ↦ add_le_add_right h c) (continuous_add_right c).continuousAt bdd_above cobdd).symm
+    (fun _ _ h ↦ by dsimp; gcongr) (continuous_add_right c).continuousAt bdd_above cobdd).symm
 
 /-- `liminf (c + xᵢ) = c + liminf xᵢ`. -/
 lemma liminf_const_add (F : Filter ι) [NeBot F] [Add R] [ContinuousAdd R]
@@ -177,7 +177,7 @@ lemma liminf_const_add (F : Filter ι) [NeBot F] [Add R] [ContinuousAdd R]
     (cobdd : F.IsCoboundedUnder (· ≥ ·) f) (bdd_below : F.IsBoundedUnder (· ≥ ·) f) :
     Filter.liminf (fun i ↦ c + f i) F = c + Filter.liminf f F :=
   (Monotone.map_limsInf_of_continuousAt (F := F.map f) (f := fun (x : R) ↦ c + x)
-    (fun _ _ h ↦ add_le_add_left h c) (continuous_add_left c).continuousAt cobdd bdd_below).symm
+    (fun _ _ h ↦ by dsimp; gcongr) (continuous_add_left c).continuousAt cobdd bdd_below).symm
 
 /-- `liminf (xᵢ + c) = (liminf xᵢ) + c`. -/
 lemma liminf_add_const (F : Filter ι) [NeBot F] [Add R] [ContinuousAdd R]
@@ -185,7 +185,7 @@ lemma liminf_add_const (F : Filter ι) [NeBot F] [Add R] [ContinuousAdd R]
     (cobdd : F.IsCoboundedUnder (· ≥ ·) f) (bdd_below : F.IsBoundedUnder (· ≥ ·) f) :
     Filter.liminf (fun i ↦ f i + c) F = Filter.liminf f F + c :=
   (Monotone.map_limsInf_of_continuousAt (F := F.map f) (f := fun (x : R) ↦ x + c)
-    (fun _ _ h ↦ add_le_add_right h c) (continuous_add_right c).continuousAt cobdd bdd_below).symm
+    (fun _ _ h ↦ by dsimp; gcongr) (continuous_add_right c).continuousAt cobdd bdd_below).symm
 
 /-- `limsup (c - xᵢ) = c - liminf xᵢ`. -/
 lemma limsup_const_sub (F : Filter ι) [AddCommSemigroup R] [Sub R] [ContinuousSub R] [OrderedSub R]

--- a/Mathlib/Topology/Algebra/Valued/ValuedField.lean
+++ b/Mathlib/Topology/Algebra/Valued/ValuedField.lean
@@ -181,15 +181,7 @@ instance (priority := 100) completable : CompletableTopField K :=
             simp at x_in₀
           exact (Valuation.ne_zero_iff _).mp this
         · refine lt_of_lt_of_le H₁ ?_
-          rw [Units.min_val]
-          apply min_le_min _ x_in₀
-          rw [mul_assoc]
-          have : ((γ₀ * γ₀ : Γ₀ˣ) : Γ₀) ≤ v x * v x :=
-            calc
-              ↑γ₀ * ↑γ₀ ≤ ↑γ₀ * v x := mul_le_mul_left' x_in₀ ↑γ₀
-              _ ≤ _ := mul_le_mul_right' x_in₀ (v x)
-          rw [Units.val_mul]
-          exact mul_le_mul_left' this γ }
+          grw [Units.min_val, mul_assoc, Units.val_mul, Units.val_mul, x_in₀] }
 
 open WithZeroTopology
 

--- a/Mathlib/Topology/CWComplex/Classical/Basic.lean
+++ b/Mathlib/Topology/CWComplex/Classical/Basic.lean
@@ -774,7 +774,7 @@ lemma RelCWComplex.skeletonLT_monotone [RelCWComplex C D] : Monotone (skeletonLT
 
 lemma RelCWComplex.skeleton_mono [RelCWComplex C D] {n m : ℕ∞} (h : m ≤ n) :
     (skeleton C m : Set X) ⊆ skeleton C n :=
-  skeletonLT_mono (add_le_add_right h 1)
+  skeletonLT_mono (by gcongr)
 
 lemma RelCWComplex.skeleton_monotone [RelCWComplex C D] : Monotone (skeleton C) :=
   fun _ _ h ↦ skeleton_mono h

--- a/Mathlib/Topology/ContinuousMap/Bounded/Normed.lean
+++ b/Mathlib/Topology/ContinuousMap/Bounded/Normed.lean
@@ -545,12 +545,8 @@ instance instHasSolidNorm : HasSolidNorm (α →ᵇ β) :=
       rw [norm_le (norm_nonneg _)]
       exact fun t => (i1 t).trans (norm_coe_le_norm g t) }
 
-instance instIsOrderedAddMonoid : IsOrderedAddMonoid (α →ᵇ β) :=
-  { add_le_add_left := by
-      intro f g h₁ h t
-      simp only [ContinuousMap.toFun_eq_coe, coe_toContinuousMap, coe_add, Pi.add_apply,
-        add_le_add_iff_left]
-      exact h₁ _ }
+instance instIsOrderedAddMonoid : IsOrderedAddMonoid (α →ᵇ β) where
+  add_le_add_left f g h₁ h t := by simpa using h₁ _
 
 end NormedLatticeOrderedGroup
 

--- a/Mathlib/Topology/ContinuousMap/ZeroAtInfty.lean
+++ b/Mathlib/Topology/ContinuousMap/ZeroAtInfty.lean
@@ -419,7 +419,7 @@ theorem isClosed_range_toBCF : IsClosed (range (toBCF : C₀(α, β) → α →�
     calc
       dist (f x) 0 ≤ dist (g.toBCF x) (f x) + dist (g x) 0 := dist_triangle_left _ _ _
       _ < dist g.toBCF f + ε / 2 := add_lt_add_of_le_of_lt (dist_coe_le_dist x) hx
-      _ < ε := by simpa [add_halves ε] using add_lt_add_right (mem_ball.1 hg) (ε / 2)
+      _ ≤ ε := by grw [mem_ball.1 hg, add_halves ε]
   exact ⟨⟨f.toContinuousMap, this⟩, rfl⟩
 
 

--- a/Mathlib/Topology/EMetricSpace/BoundedVariation.lean
+++ b/Mathlib/Topology/EMetricSpace/BoundedVariation.lean
@@ -727,7 +727,7 @@ theorem LipschitzOnWith.comp_eVariationOn_le {f : E → F} {C : ℝ≥0} {t : Se
         ∑ i ∈ Finset.range n, C * edist (g (u (i + 1))) (g (u i)) :=
       Finset.sum_le_sum fun i _ => h (hg (us _)) (hg (us _))
     _ = C * ∑ i ∈ Finset.range n, edist (g (u (i + 1))) (g (u i)) := by rw [Finset.mul_sum]
-    _ ≤ C * eVariationOn g s := mul_le_mul_left' (eVariationOn.sum_le _ _ hu us) _
+    _ ≤ C * eVariationOn g s := by grw [eVariationOn.sum_le _ _ hu us]
 
 theorem LipschitzOnWith.comp_boundedVariationOn {f : E → F} {C : ℝ≥0} {t : Set E}
     (hf : LipschitzOnWith C f t) {g : α → E} {s : Set α} (hg : MapsTo g s t)

--- a/Mathlib/Topology/EMetricSpace/Defs.lean
+++ b/Mathlib/Topology/EMetricSpace/Defs.lean
@@ -141,10 +141,8 @@ theorem edist_congr {w x y z : α} (hl : edist w x = 0) (hr : edist y z = 0) :
     edist w y = edist x z :=
   (edist_congr_right hl).trans (edist_congr_left hr)
 
-theorem edist_triangle4 (x y z t : α) : edist x t ≤ edist x y + edist y z + edist z t :=
-  calc
-    edist x t ≤ edist x z + edist z t := edist_triangle x z t
-    _ ≤ edist x y + edist y z + edist z t := add_le_add_right (edist_triangle x y z) _
+theorem edist_triangle4 (x y z t : α) : edist x t ≤ edist x y + edist y z + edist z t := by
+  grw [edist_triangle _ z, edist_triangle]
 
 /-- Reformulation of the uniform structure in terms of the extended distance -/
 theorem uniformity_pseudoedist : 𝓤 α = ⨅ ε > 0, 𝓟 { p : α × α | edist p.1 p.2 < ε } :=

--- a/Mathlib/Topology/Instances/ENNReal/Lemmas.lean
+++ b/Mathlib/Topology/Instances/ENNReal/Lemmas.lean
@@ -201,7 +201,8 @@ theorem hasBasis_nhds_of_ne_top' (xt : x ≠ ∞) :
       rcases lt_iff_exists_add_pos_lt.1 hb with ⟨δ, δ0, hδ⟩
       refine ⟨min ε δ, (lt_min ε0 (coe_pos.2 δ0)).ne', Icc_subset_Ioo ?_ ?_⟩
       · exact lt_tsub_comm.2 ((min_le_left _ _).trans_lt hε)
-      · exact (add_le_add_left (min_le_right _ _) _).trans_lt hδ
+      · grw [min_le_right]
+        exact hδ
     · exact ⟨(x - ε, x + ε), ⟨ENNReal.sub_lt_self xt x0.ne' ε0,
         lt_add_right xt ε0⟩, Ioo_subset_Icc_self⟩
 
@@ -293,9 +294,8 @@ theorem tendsto_sub : ∀ {a b : ℝ≥0∞}, (a ≠ ∞ ∨ b ≠ ∞) →
     rw [top_sub_coe, tendsto_nhds_top_iff_nnreal]
     refine fun x => ((lt_mem_nhds <| @coe_lt_top (b + 1 + x)).prod_nhds
       (ge_mem_nhds <| coe_lt_coe.2 <| lt_add_one b)).mono fun y hy => ?_
-    rw [lt_tsub_iff_left]
-    calc y.2 + x ≤ ↑(b + 1) + x := add_le_add_right hy.2 _
-    _ < y.1 := hy.1
+    grw [lt_tsub_iff_left, hy.2]
+    exact hy.1
   | (a : ℝ≥0), ∞, _ => by
     rw [sub_top]
     refine (tendsto_pure.2 ?_).mono_right (pure_le_nhds _)
@@ -1130,8 +1130,7 @@ theorem continuous_of_le_add_edist {f : α → ℝ≥0∞} (C : ℝ≥0∞) (hC 
   rcases ENNReal.exists_nnreal_pos_mul_lt hC ε0.ne' with ⟨δ, δ0, hδ⟩
   rw [mul_comm] at hδ
   filter_upwards [EMetric.closedBall_mem_nhds x (ENNReal.coe_pos.2 δ0)] with y hy
-  refine ⟨tsub_le_iff_right.2 <| (h x y).trans ?_, (h y x).trans ?_⟩ <;>
-    refine add_le_add_left (le_trans (mul_le_mul_left' ?_ _) hδ.le) _
+  refine ⟨tsub_le_iff_right.2 <| (h x y).trans ?_, (h y x).trans ?_⟩ <;> grw [← hδ.le] <;> gcongr
   exacts [EMetric.mem_closedBall'.1 hy, EMetric.mem_closedBall.1 hy]
 
 theorem continuous_edist : Continuous fun p : α × α => edist p.1 p.2 := by

--- a/Mathlib/Topology/MetricSpace/Algebra.lean
+++ b/Mathlib/Topology/MetricSpace/Algebra.lean
@@ -145,9 +145,7 @@ instance (priority := 100) IsBoundedSMul.continuousSMul : ContinuousSMul α β w
         ≤ dist (a' • b') (a • b') + dist (a • b') (a • b) := dist_triangle ..
       _ ≤ dist a' a * dist b' 0 + dist a 0 * dist b' b :=
         add_le_add (dist_pair_smul _ _ _) (dist_smul_pair _ _ _)
-      _ ≤ δ * (δ + dist b 0) + dist a 0 * δ := by
-          have : dist b' 0 ≤ δ + dist b 0 := (dist_triangle _ _ _).trans <| add_le_add_right hb.le _
-          gcongr
+      _ ≤ δ * (δ + dist b 0) + dist a 0 * δ := by gcongr; grw [dist_triangle b' b 0, hb]
       _ < ε := hδε
 
 instance (priority := 100) IsBoundedSMul.toUniformContinuousConstSMul :

--- a/Mathlib/Topology/MetricSpace/Antilipschitz.lean
+++ b/Mathlib/Topology/MetricSpace/Antilipschitz.lean
@@ -96,8 +96,7 @@ theorem mul_le_edist (hf : AntilipschitzWith K f) (x y : α) :
   exact ENNReal.div_le_of_le_mul' (hf x y)
 
 theorem ediam_preimage_le (hf : AntilipschitzWith K f) (s : Set β) : diam (f ⁻¹' s) ≤ K * diam s :=
-  diam_le fun x hx y hy => (hf x y).trans <|
-    mul_le_mul_left' (edist_le_diam_of_mem (mem_preimage.1 hx) hy) K
+  diam_le fun x hx y hy => by grw [hf x y, edist_le_diam_of_mem (mem_preimage.1 hx) hy]
 
 theorem le_mul_ediam_image (hf : AntilipschitzWith K f) (s : Set α) : diam s ≤ K * diam (f '' s) :=
   (diam_mono (subset_preimage_image _ _)).trans (hf.ediam_preimage_le (f '' s))

--- a/Mathlib/Topology/MetricSpace/Bounded.lean
+++ b/Mathlib/Topology/MetricSpace/Bounded.lean
@@ -487,8 +487,7 @@ obviously true if `s ∪ t` is unbounded. -/
 theorem diam_union {t : Set α} (xs : x ∈ s) (yt : y ∈ t) :
     diam (s ∪ t) ≤ diam s + dist x y + diam t := by
   simp only [diam, dist_edist]
-  refine (ENNReal.toReal_le_add' (EMetric.diam_union xs yt) ?_ ?_).trans
-    (add_le_add_right ENNReal.toReal_add_le _)
+  grw [ENNReal.toReal_le_add' (EMetric.diam_union xs yt), ENNReal.toReal_add_le]
   · simp only [ENNReal.add_eq_top, edist_ne_top, or_false]
     exact fun h ↦ top_unique <| h ▸ EMetric.diam_mono subset_union_left
   · exact fun h ↦ top_unique <| h ▸ EMetric.diam_mono subset_union_right

--- a/Mathlib/Topology/MetricSpace/Contracting.lean
+++ b/Mathlib/Topology/MetricSpace/Contracting.lean
@@ -244,7 +244,7 @@ theorem dist_inequality (x y) : dist x y ≤ (dist x (f x) + dist y (f y)) / (1 
     rwa [le_div_iff₀ hf.one_sub_K_pos, mul_comm, _root_.sub_mul, one_mul, sub_le_iff_le_add]
   calc
     dist x y ≤ dist x (f x) + dist y (f y) + dist (f x) (f y) := dist_triangle4_right _ _ _ _
-    _ ≤ dist x (f x) + dist y (f y) + K * dist x y := add_le_add_left (hf.dist_le_mul _ _) _
+    _ ≤ dist x (f x) + dist y (f y) + K * dist x y := by grw [hf.dist_le_mul]
 
 theorem dist_le_of_fixedPoint (x) {y} (hy : IsFixedPt f y) : dist x y ≤ dist x (f x) / (1 - K) := by
   simpa only [hy.eq, dist_self, add_zero] using hf.dist_inequality x y

--- a/Mathlib/Topology/MetricSpace/Dilation.lean
+++ b/Mathlib/Topology/MetricSpace/Dilation.lean
@@ -400,7 +400,7 @@ theorem mapsTo_emetric_ball (x : α) (r : ℝ≥0∞) :
 /-- A dilation maps closed balls to closed balls and scales the radius by `ratio f`. -/
 theorem mapsTo_emetric_closedBall (x : α) (r' : ℝ≥0∞) :
     MapsTo (f : α → β) (EMetric.closedBall x r') (EMetric.closedBall (f x) (ratio f * r')) :=
-  fun y hy => (edist_eq f y x).trans_le <| mul_le_mul_left' hy _
+  fun y hy => (edist_eq f y x).trans_le <| by gcongr; exact hy
 
 theorem comp_continuousOn_iff {γ} [TopologicalSpace γ] {g : γ → α} {s : Set γ} :
     ContinuousOn ((f : α → β) ∘ g) s ↔ ContinuousOn g s :=

--- a/Mathlib/Topology/MetricSpace/Gluing.lean
+++ b/Mathlib/Topology/MetricSpace/Gluing.lean
@@ -223,9 +223,8 @@ theorem Sum.dist_eq_glueDist {p q : X ⊕ Y} (x : X) (y : Y) :
 private theorem Sum.dist_comm (x y : X ⊕ Y) : Sum.dist x y = Sum.dist y x := by
   cases x <;> cases y <;> simp [Sum.dist, _root_.dist_comm, add_comm, add_left_comm]
 
-theorem Sum.one_le_dist_inl_inr {x : X} {y : Y} : 1 ≤ Sum.dist (.inl x) (.inr y) :=
-  le_trans (le_add_of_nonneg_right dist_nonneg) <|
-    add_le_add_right (le_add_of_nonneg_left dist_nonneg) _
+theorem Sum.one_le_dist_inl_inr {x : X} {y : Y} : 1 ≤ Sum.dist (.inl x) (.inr y) := by
+  grw [Sum.dist, ← le_add_of_nonneg_right dist_nonneg, ← le_add_of_nonneg_left dist_nonneg]
 
 theorem Sum.one_le_dist_inr_inl {x : X} {y : Y} : 1 ≤ Sum.dist (.inr y) (.inl x) := by
   rw [Sum.dist_comm]; exact Sum.one_le_dist_inl_inr

--- a/Mathlib/Topology/MetricSpace/GromovHausdorffRealized.lean
+++ b/Mathlib/Topology/MetricSpace/GromovHausdorffRealized.lean
@@ -240,7 +240,7 @@ technical lemmas. -/
 theorem HD_below_aux1 {f : Cb X Y} (C : ℝ) {x : X} :
     BddBelow (range fun y : Y => f (inl x, inr y) + C) :=
   let ⟨cf, hcf⟩ := f.isBounded_range.bddBelow
-  ⟨cf + C, forall_mem_range.2 fun _ => add_le_add_right ((fun x => hcf (mem_range_self x)) _) _⟩
+  ⟨cf + C, forall_mem_range.2 fun _ => by grw [hcf (mem_range_self _)]⟩
 
 private theorem HD_bound_aux1 [Nonempty Y] (f : Cb X Y) (C : ℝ) :
     BddAbove (range fun x : X => ⨅ y, f (inl x, inr y) + C) := by
@@ -253,7 +253,7 @@ private theorem HD_bound_aux1 [Nonempty Y] (f : Cb X Y) (C : ℝ) :
 theorem HD_below_aux2 {f : Cb X Y} (C : ℝ) {y : Y} :
     BddBelow (range fun x : X => f (inl x, inr y) + C) :=
   let ⟨cf, hcf⟩ := f.isBounded_range.bddBelow
-  ⟨cf + C, forall_mem_range.2 fun _ => add_le_add_right ((fun x => hcf (mem_range_self x)) _) _⟩
+  ⟨cf + C, forall_mem_range.2 fun _ => by grw [hcf (mem_range_self _)]⟩
 
 private theorem HD_bound_aux2 [Nonempty X] (f : Cb X Y) (C : ℝ) :
     BddAbove (range fun y : Y => ⨅ x, f (inl x, inr y) + C) := by
@@ -326,8 +326,8 @@ private theorem HD_lipschitz_aux2 (f g : Cb X Y) :
 
 private theorem HD_lipschitz_aux3 (f g : Cb X Y) :
     HD f ≤ HD g + dist f g :=
-  max_le (le_trans (HD_lipschitz_aux1 f g) (add_le_add_right (le_max_left _ _) _))
-    (le_trans (HD_lipschitz_aux2 f g) (add_le_add_right (le_max_right _ _) _))
+  max_le (by grw [HD_lipschitz_aux1 f g, HD, ← le_max_left])
+    (by grw [HD_lipschitz_aux2 f g, HD, ← le_max_right])
 
 /-- Conclude that `HD`, being Lipschitz, is continuous -/
 private theorem HD_continuous : Continuous (HD : Cb X Y → ℝ) :=

--- a/Mathlib/Topology/MetricSpace/HausdorffDistance.lean
+++ b/Mathlib/Topology/MetricSpace/HausdorffDistance.lean
@@ -103,6 +103,7 @@ theorem infEdist_zero_of_mem (h : x ∈ s) : infEdist x s = 0 :=
   nonpos_iff_eq_zero.1 <| @edist_self _ _ x ▸ infEdist_le_edist_of_mem h
 
 /-- The edist is antitone with respect to inclusion. -/
+@[gcongr]
 theorem infEdist_anti (h : s ⊆ t) : infEdist x t ≤ infEdist x s :=
   iInf_le_iInf_of_subset h
 
@@ -350,15 +351,13 @@ theorem hausdorffEdist_triangle : hausdorffEdist s u ≤ hausdorffEdist s t + ha
       calc
         infEdist x u ≤ infEdist x t + hausdorffEdist t u :=
           infEdist_le_infEdist_add_hausdorffEdist
-        _ ≤ hausdorffEdist s t + hausdorffEdist t u :=
-          add_le_add_right (infEdist_le_hausdorffEdist_of_mem xs) _
+        _ ≤ hausdorffEdist s t + hausdorffEdist t u := by grw [infEdist_le_hausdorffEdist_of_mem xs]
   · change ∀ x ∈ u, infEdist x s ≤ hausdorffEdist s t + hausdorffEdist t u
     exact fun x xu =>
       calc
         infEdist x s ≤ infEdist x t + hausdorffEdist t s :=
           infEdist_le_infEdist_add_hausdorffEdist
-        _ ≤ hausdorffEdist u t + hausdorffEdist t s :=
-          add_le_add_right (infEdist_le_hausdorffEdist_of_mem xu) _
+        _ ≤ hausdorffEdist u t + hausdorffEdist t s := by grw [infEdist_le_hausdorffEdist_of_mem xu]
         _ = hausdorffEdist s t + hausdorffEdist t u := by simp [hausdorffEdist_comm, add_comm]
 
 /-- Two sets are at zero Hausdorff edistance if and only if they have the same closure. -/

--- a/Mathlib/Topology/MetricSpace/Pseudo/Defs.lean
+++ b/Mathlib/Topology/MetricSpace/Pseudo/Defs.lean
@@ -507,7 +507,7 @@ theorem closedBall_eq_bInter_ball : closedBall x ε = ⋂ δ > ε, ball x δ := 
 theorem ball_subset_ball' (h : ε₁ + dist x y ≤ ε₂) : ball x ε₁ ⊆ ball y ε₂ := fun z hz =>
   calc
     dist z y ≤ dist z x + dist x y := dist_triangle _ _ _
-    _ < ε₁ + dist x y := add_lt_add_right (mem_ball.1 hz) _
+    _ < ε₁ + dist x y := by gcongr; exact hz
     _ ≤ ε₂ := h
 
 @[gcongr]
@@ -518,7 +518,7 @@ theorem closedBall_subset_closedBall' (h : ε₁ + dist x y ≤ ε₂) :
     closedBall x ε₁ ⊆ closedBall y ε₂ := fun z hz =>
   calc
     dist z y ≤ dist z x + dist x y := dist_triangle _ _ _
-    _ ≤ ε₁ + dist x y := add_le_add_right (mem_closedBall.1 hz) _
+    _ ≤ ε₁ + dist x y := by gcongr; exact hz
     _ ≤ ε₂ := h
 
 theorem closedBall_subset_ball (h : ε₁ < ε₂) : closedBall x ε₁ ⊆ ball x ε₂ :=
@@ -528,7 +528,7 @@ theorem closedBall_subset_ball' (h : ε₁ + dist x y < ε₂) :
     closedBall x ε₁ ⊆ ball y ε₂ := fun z hz =>
   calc
     dist z y ≤ dist z x + dist x y := dist_triangle _ _ _
-    _ ≤ ε₁ + dist x y := add_le_add_right (mem_closedBall.1 hz) _
+    _ ≤ ε₁ + dist x y := by gcongr; exact hz
     _ < ε₂ := h
 
 theorem dist_le_add_of_nonempty_closedBall_inter_closedBall

--- a/Mathlib/Topology/MetricSpace/Thickening.lean
+++ b/Mathlib/Topology/MetricSpace/Thickening.lean
@@ -167,7 +167,7 @@ protected theorem _root_.Bornology.IsBounded.thickening {δ : ℝ} {E : Set X} (
   · refine (isBounded_iff_subset_closedBall x).2 ⟨δ + diam E, fun y hy ↦ ?_⟩
     calc
       dist y x ≤ infDist y E + diam E := dist_le_infDist_add_diam (x := y) h hx
-      _ ≤ δ + diam E := add_le_add_right ((mem_thickening_iff_infDist_lt ⟨x, hx⟩).1 hy).le _
+      _ ≤ δ + diam E := by grw [(mem_thickening_iff_infDist_lt ⟨x, hx⟩).1 hy]
 
 end Thickening
 
@@ -600,8 +600,7 @@ theorem infEdist_le_infEdist_cthickening_add :
 /-- For the equality, see `infEdist_thickening`. -/
 theorem infEdist_le_infEdist_thickening_add :
     infEdist x s ≤ infEdist x (thickening δ s) + ENNReal.ofReal δ :=
-  infEdist_le_infEdist_cthickening_add.trans <|
-    add_le_add_right (infEdist_anti <| thickening_subset_cthickening _ _) _
+  infEdist_le_infEdist_cthickening_add.trans <| by gcongr; exact thickening_subset_cthickening ..
 
 /-- For the equality, see `thickening_thickening`. -/
 @[simp]
@@ -637,7 +636,7 @@ theorem cthickening_thickening_subset (hε : 0 ≤ ε) (δ : ℝ) (s : Set α) :
   · simp only [thickening_of_nonpos hδ, cthickening_empty, empty_subset]
   intro x
   simp_rw [mem_cthickening_iff, ENNReal.ofReal_add hε hδ]
-  exact fun hx => infEdist_le_infEdist_thickening_add.trans (add_le_add_right hx _)
+  exact fun hx => infEdist_le_infEdist_thickening_add.trans (by grw [hx])
 
 /-- For the equality, see `cthickening_cthickening`. -/
 @[simp]
@@ -645,7 +644,7 @@ theorem cthickening_cthickening_subset (hε : 0 ≤ ε) (hδ : 0 ≤ δ) (s : Se
     cthickening ε (cthickening δ s) ⊆ cthickening (ε + δ) s := by
   intro x
   simp_rw [mem_cthickening_iff, ENNReal.ofReal_add hε hδ]
-  exact fun hx => infEdist_le_infEdist_cthickening_add.trans (add_le_add_right hx _)
+  exact fun hx => infEdist_le_infEdist_cthickening_add.trans (by grw [hx])
 
 open scoped Function in -- required for scoped `on` notation
 theorem frontier_cthickening_disjoint (A : Set α) :

--- a/Mathlib/Topology/Metrizable/Uniformity.lean
+++ b/Mathlib/Topology/Metrizable/Uniformity.lean
@@ -124,7 +124,7 @@ theorem le_two_mul_dist_ofPreNNDist (d : X → X → ℝ≥0) (dist_self : ∀ x
   rcases eq_or_ne (d x y) 0 with hd₀ | hd₀
   · simp only [hd₀, zero_le]
   rsuffices ⟨z, z', hxz, hzz', hz'y⟩ : ∃ z z' : X, d x z ≤ L.sum ∧ d z z' ≤ L.sum ∧ d z' y ≤ L.sum
-  · exact (hd x z z' y).trans (mul_le_mul_left' (max_le hxz (max_le hzz' hz'y)) _)
+  · grw [hd x z z' y, max_le hxz (max_le hzz' hz'y)]
   set s : Set ℕ := { m : ℕ | 2 * (take m L).sum ≤ L.sum }
   have hs₀ : 0 ∈ s := by simp [s]
   have hsne : s.Nonempty := ⟨0, hs₀⟩

--- a/Mathlib/Topology/UnitInterval.lean
+++ b/Mathlib/Topology/UnitInterval.lean
@@ -221,10 +221,7 @@ instance : LinearOrderedCommMonoidWithZero I where
   zero_mul i := zero_mul i
   mul_zero i := mul_zero i
   zero_le_one := nonneg'
-  mul_le_mul_left i j h_ij k := by
-    simp only [← Subtype.coe_le_coe, coe_mul]
-    apply mul_le_mul le_rfl ?_ (nonneg i) (nonneg k)
-    simp [h_ij]
+  mul_le_mul_left i j h_ij k := by simp only [← Subtype.coe_le_coe, coe_mul]; gcongr; exact nonneg k
 
 lemma subtype_Iic_eq_Icc (x : I) : Subtype.val⁻¹' (Iic ↑x) = Icc 0 x := by
   rw [preimage_subtype_val_Iic]

--- a/Mathlib/Topology/UrysohnsLemma.lean
+++ b/Mathlib/Topology/UrysohnsLemma.lean
@@ -300,10 +300,7 @@ theorem continuous_lim (c : CU P) : Continuous c.lim := by
         compl_subset_compl.2 c.left.left_U_subset_right_C hyl
       simp only [pow_succ, c.lim_eq_midpoint, c.left.lim_eq_midpoint,
         c.left.left.lim_of_notMem_U _ hxl, c.left.left.lim_of_notMem_U _ hyl]
-      refine (dist_midpoint_midpoint_le _ _ _ _).trans ?_
-      refine (div_le_div_of_nonneg_right (add_le_add_right (dist_midpoint_midpoint_le _ _ _ _) _)
-        zero_le_two).trans ?_
-      rw [dist_self, zero_add]
+      grw [dist_midpoint_midpoint_le, dist_midpoint_midpoint_le, dist_self, zero_add]
       set r := (3 / 4 : ℝ) ^ n
       calc _ ≤ (r / 2 + r) / 2 := by gcongr
         _ = _ := by field_simp; ring


### PR DESCRIPTION
Golf many proofs using `grw`, `gcongr`, `cutsat`, `linarith`... For this, tag a few more lemmas with `gcongr`, and make some existing ones stronger.

The goal here is not necessarily to golf (although it usually is the case), but instead to reduce the number of explicit mentions of lemmas, as these are a maintainability concern.

The precise golfs that are performed are motivated by #30242, where four pairs of very basic and widespread lemmas get swapped. The best way to reduce the number of swaps needed is to simply not mention the lemmas explicitly.

---
Annoyingly, `grw` is basically unusable with strict inequalities (it often leaves an unprovable goal since it doesn't know about `lt_of_le_of_lt` nor `lt_of_lt_of_le`, but only `lt_trans`). This means that I must fall back to `gcongr; exact strict_ineq` many times where I would instead have liked to do `grw [strict_ineq]`.

<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include at least one commit authored by each
co-author among the commits in the pull request. If necessary, you may 
create empty commits to indicate co-authorship, using commands like so:

git commit --author="Author Name <author@email.com>" --allow-empty -m "add Author Name as coauthor"

When merging, all the commits will be squashed into a single commit listing all co-authors.

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
