### PR TITLE
[Merged by Bors] - chore(Data/Nat): golf `findGreatest_eq_iff` using `grind`

### DIFF
--- a/Mathlib/Data/Nat/Find.lean
+++ b/Mathlib/Data/Nat/Find.lean
@@ -194,16 +194,7 @@ lemma findGreatest_eq_iff :
         rcases Decidable.lt_or_eq_of_le hle with hlt | rfl
         exacts [(hm hlt (le_refl _) hk).elim, rfl]
     · rw [findGreatest_of_not hk, ihk]
-      constructor
-      · rintro ⟨hle, hP, hm⟩
-        refine ⟨le_trans hle k.le_succ, hP, fun n hlt hle ↦ ?_⟩
-        rcases Decidable.lt_or_eq_of_le hle with hlt' | rfl
-        exacts [hm hlt <| Nat.lt_succ_iff.1 hlt', hk]
-      · rintro ⟨hle, hP, hm⟩
-        refine ⟨Nat.lt_succ_iff.1 (lt_of_le_of_ne hle ?_), hP,
-          fun n hlt hle ↦ hm hlt (le_trans hle k.le_succ)⟩
-        rintro rfl
-        exact hk (hP k.succ_ne_zero)
+      grind
 
 lemma findGreatest_eq_zero_iff : Nat.findGreatest P k = 0 ↔ ∀ ⦃n⦄, 0 < n → n ≤ k → ¬P n := by
   simp [findGreatest_eq_iff]


### PR DESCRIPTION
---
<details>
<summary>Show trace profiling of <code>findGreatest_eq_iff</code>: 21 ms before, 39 ms after </summary>

### Trace profiling of `findGreatest_eq_iff` before PR 30515
```diff
diff --git a/Mathlib/Data/Nat/Find.lean b/Mathlib/Data/Nat/Find.lean
index 4ac5779f75..8e95d6e030 100644
--- a/Mathlib/Data/Nat/Find.lean
+++ b/Mathlib/Data/Nat/Find.lean
@@ -176,6 +176,7 @@ lemma findGreatest_succ (n : ℕ) :
 lemma findGreatest_of_not (h : ¬ P (n + 1)) : findGreatest P (n + 1) = findGreatest P n := by
   simp [Nat.findGreatest, h]
 
+set_option trace.profiler true in
 lemma findGreatest_eq_iff :
     Nat.findGreatest P k = m ↔ m ≤ k ∧ (m ≠ 0 → P m) ∧ ∀ ⦃n⦄, m < n → n ≤ k → ¬P n := by
   induction k generalizing m with
```
```
ℹ [103/103] Built Mathlib.Data.Nat.Find (710ms)
info: Mathlib/Data/Nat/Find.lean:180:0: [Elab.async] [0.021505] elaborating proof of Nat.findGreatest_eq_iff
  [Elab.definition.value] [0.020637] Nat.findGreatest_eq_iff
    [Elab.step] [0.020109] induction k generalizing m with
          | zero =>
            rw [eq_comm, Iff.comm]
            simp only [Nat.le_zero, ne_eq, findGreatest_zero, and_iff_left_iff_imp]
            rintro rfl
            exact ⟨fun h ↦ (h rfl).elim, fun n hlt heq ↦ by cutsat⟩
          | succ k ihk =>
            by_cases hk : P (k + 1)
            · rw [findGreatest_eq hk]
              constructor
              · rintro rfl
                exact ⟨le_refl _, fun _ ↦ hk, fun n hlt hle ↦ by cutsat⟩
              · rintro ⟨hle, h0, hm⟩
                rcases Decidable.lt_or_eq_of_le hle with hlt | rfl
                exacts [(hm hlt (le_refl _) hk).elim, rfl]
            · rw [findGreatest_of_not hk, ihk]
              constructor
              · rintro ⟨hle, hP, hm⟩
                refine ⟨le_trans hle k.le_succ, hP, fun n hlt hle ↦ ?_⟩
                rcases Decidable.lt_or_eq_of_le hle with hlt' | rfl
                exacts [hm hlt <| Nat.lt_succ_iff.1 hlt', hk]
              · rintro ⟨hle, hP, hm⟩
                refine ⟨Nat.lt_succ_iff.1 (lt_of_le_of_ne hle ?_), hP, fun n hlt hle ↦ hm hlt (le_trans hle k.le_succ)⟩
                rintro rfl
                exact hk (hP k.succ_ne_zero)
      [Elab.step] [0.020104] induction k generalizing m with
            | zero =>
              rw [eq_comm, Iff.comm]
              simp only [Nat.le_zero, ne_eq, findGreatest_zero, and_iff_left_iff_imp]
              rintro rfl
              exact ⟨fun h ↦ (h rfl).elim, fun n hlt heq ↦ by cutsat⟩
            | succ k ihk =>
              by_cases hk : P (k + 1)
              · rw [findGreatest_eq hk]
                constructor
                · rintro rfl
                  exact ⟨le_refl _, fun _ ↦ hk, fun n hlt hle ↦ by cutsat⟩
                · rintro ⟨hle, h0, hm⟩
                  rcases Decidable.lt_or_eq_of_le hle with hlt | rfl
                  exacts [(hm hlt (le_refl _) hk).elim, rfl]
              · rw [findGreatest_of_not hk, ihk]
                constructor
                · rintro ⟨hle, hP, hm⟩
                  refine ⟨le_trans hle k.le_succ, hP, fun n hlt hle ↦ ?_⟩
                  rcases Decidable.lt_or_eq_of_le hle with hlt' | rfl
                  exacts [hm hlt <| Nat.lt_succ_iff.1 hlt', hk]
                · rintro ⟨hle, hP, hm⟩
                  refine
                    ⟨Nat.lt_succ_iff.1 (lt_of_le_of_ne hle ?_), hP, fun n hlt hle ↦ hm hlt (le_trans hle k.le_succ)⟩
                  rintro rfl
                  exact hk (hP k.succ_ne_zero)
        [Elab.step] [0.020100] induction k generalizing m with
            | zero =>
              rw [eq_comm, Iff.comm]
              simp only [Nat.le_zero, ne_eq, findGreatest_zero, and_iff_left_iff_imp]
              rintro rfl
              exact ⟨fun h ↦ (h rfl).elim, fun n hlt heq ↦ by cutsat⟩
            | succ k ihk =>
              by_cases hk : P (k + 1)
              · rw [findGreatest_eq hk]
                constructor
                · rintro rfl
                  exact ⟨le_refl _, fun _ ↦ hk, fun n hlt hle ↦ by cutsat⟩
                · rintro ⟨hle, h0, hm⟩
                  rcases Decidable.lt_or_eq_of_le hle with hlt | rfl
                  exacts [(hm hlt (le_refl _) hk).elim, rfl]
              · rw [findGreatest_of_not hk, ihk]
                constructor
                · rintro ⟨hle, hP, hm⟩
                  refine ⟨le_trans hle k.le_succ, hP, fun n hlt hle ↦ ?_⟩
                  rcases Decidable.lt_or_eq_of_le hle with hlt' | rfl
                  exacts [hm hlt <| Nat.lt_succ_iff.1 hlt', hk]
                · rintro ⟨hle, hP, hm⟩
                  refine
                    ⟨Nat.lt_succ_iff.1 (lt_of_le_of_ne hle ?_), hP, fun n hlt hle ↦ hm hlt (le_trans hle k.le_succ)⟩
                  rintro rfl
                  exact hk (hP k.succ_ne_zero)
          [Elab.step] [0.014891] 
                by_cases hk : P (k + 1)
                · rw [findGreatest_eq hk]
                  constructor
                  · rintro rfl
                    exact ⟨le_refl _, fun _ ↦ hk, fun n hlt hle ↦ by cutsat⟩
                  · rintro ⟨hle, h0, hm⟩
                    rcases Decidable.lt_or_eq_of_le hle with hlt | rfl
                    exacts [(hm hlt (le_refl _) hk).elim, rfl]
                · rw [findGreatest_of_not hk, ihk]
                  constructor
                  · rintro ⟨hle, hP, hm⟩
                    refine ⟨le_trans hle k.le_succ, hP, fun n hlt hle ↦ ?_⟩
                    rcases Decidable.lt_or_eq_of_le hle with hlt' | rfl
                    exacts [hm hlt <| Nat.lt_succ_iff.1 hlt', hk]
                  · rintro ⟨hle, hP, hm⟩
                    refine
                      ⟨Nat.lt_succ_iff.1 (lt_of_le_of_ne hle ?_), hP, fun n hlt hle ↦ hm hlt (le_trans hle k.le_succ)⟩
                    rintro rfl
                    exact hk (hP k.succ_ne_zero)
            [Elab.step] [0.014884] 
                  by_cases hk : P (k + 1)
                  · rw [findGreatest_eq hk]
                    constructor
                    · rintro rfl
                      exact ⟨le_refl _, fun _ ↦ hk, fun n hlt hle ↦ by cutsat⟩
                    · rintro ⟨hle, h0, hm⟩
                      rcases Decidable.lt_or_eq_of_le hle with hlt | rfl
                      exacts [(hm hlt (le_refl _) hk).elim, rfl]
                  · rw [findGreatest_of_not hk, ihk]
                    constructor
                    · rintro ⟨hle, hP, hm⟩
                      refine ⟨le_trans hle k.le_succ, hP, fun n hlt hle ↦ ?_⟩
                      rcases Decidable.lt_or_eq_of_le hle with hlt' | rfl
                      exacts [hm hlt <| Nat.lt_succ_iff.1 hlt', hk]
                    · rintro ⟨hle, hP, hm⟩
                      refine
                        ⟨Nat.lt_succ_iff.1 (lt_of_le_of_ne hle ?_), hP, fun n hlt hle ↦ hm hlt (le_trans hle k.le_succ)⟩
                      rintro rfl
                      exact hk (hP k.succ_ne_zero)
Build completed successfully (103 jobs).
```

### Trace profiling of `findGreatest_eq_iff` after PR 30515
```diff
diff --git a/Mathlib/Data/Nat/Find.lean b/Mathlib/Data/Nat/Find.lean
index 4ac5779f75..091200bd46 100644
--- a/Mathlib/Data/Nat/Find.lean
+++ b/Mathlib/Data/Nat/Find.lean
@@ -176,6 +176,7 @@ lemma findGreatest_succ (n : ℕ) :
 lemma findGreatest_of_not (h : ¬ P (n + 1)) : findGreatest P (n + 1) = findGreatest P n := by
   simp [Nat.findGreatest, h]
 
+set_option trace.profiler true in
 lemma findGreatest_eq_iff :
     Nat.findGreatest P k = m ↔ m ≤ k ∧ (m ≠ 0 → P m) ∧ ∀ ⦃n⦄, m < n → n ≤ k → ¬P n := by
   induction k generalizing m with
@@ -194,16 +195,7 @@ lemma findGreatest_eq_iff :
         rcases Decidable.lt_or_eq_of_le hle with hlt | rfl
         exacts [(hm hlt (le_refl _) hk).elim, rfl]
     · rw [findGreatest_of_not hk, ihk]
-      constructor
-      · rintro ⟨hle, hP, hm⟩
-        refine ⟨le_trans hle k.le_succ, hP, fun n hlt hle ↦ ?_⟩
-        rcases Decidable.lt_or_eq_of_le hle with hlt' | rfl
-        exacts [hm hlt <| Nat.lt_succ_iff.1 hlt', hk]
-      · rintro ⟨hle, hP, hm⟩
-        refine ⟨Nat.lt_succ_iff.1 (lt_of_le_of_ne hle ?_), hP,
-          fun n hlt hle ↦ hm hlt (le_trans hle k.le_succ)⟩
-        rintro rfl
-        exact hk (hP k.succ_ne_zero)
+      grind
 
 lemma findGreatest_eq_zero_iff : Nat.findGreatest P k = 0 ↔ ∀ ⦃n⦄, 0 < n → n ≤ k → ¬P n := by
   simp [findGreatest_eq_iff]
```
```
ℹ [103/103] Built Mathlib.Data.Nat.Find (704ms)
info: Mathlib/Data/Nat/Find.lean:180:0: [Elab.async] [0.040019] elaborating proof of Nat.findGreatest_eq_iff
  [Elab.definition.value] [0.039235] Nat.findGreatest_eq_iff
    [Elab.step] [0.038893] induction k generalizing m with
          | zero =>
            rw [eq_comm, Iff.comm]
            simp only [Nat.le_zero, ne_eq, findGreatest_zero, and_iff_left_iff_imp]
            rintro rfl
            exact ⟨fun h ↦ (h rfl).elim, fun n hlt heq ↦ by cutsat⟩
          | succ k ihk =>
            by_cases hk : P (k + 1)
            · rw [findGreatest_eq hk]
              constructor
              · rintro rfl
                exact ⟨le_refl _, fun _ ↦ hk, fun n hlt hle ↦ by cutsat⟩
              · rintro ⟨hle, h0, hm⟩
                rcases Decidable.lt_or_eq_of_le hle with hlt | rfl
                exacts [(hm hlt (le_refl _) hk).elim, rfl]
            · rw [findGreatest_of_not hk, ihk]
              grind
      [Elab.step] [0.038886] induction k generalizing m with
            | zero =>
              rw [eq_comm, Iff.comm]
              simp only [Nat.le_zero, ne_eq, findGreatest_zero, and_iff_left_iff_imp]
              rintro rfl
              exact ⟨fun h ↦ (h rfl).elim, fun n hlt heq ↦ by cutsat⟩
            | succ k ihk =>
              by_cases hk : P (k + 1)
              · rw [findGreatest_eq hk]
                constructor
                · rintro rfl
                  exact ⟨le_refl _, fun _ ↦ hk, fun n hlt hle ↦ by cutsat⟩
                · rintro ⟨hle, h0, hm⟩
                  rcases Decidable.lt_or_eq_of_le hle with hlt | rfl
                  exacts [(hm hlt (le_refl _) hk).elim, rfl]
              · rw [findGreatest_of_not hk, ihk]
                grind
        [Elab.step] [0.038881] induction k generalizing m with
            | zero =>
              rw [eq_comm, Iff.comm]
              simp only [Nat.le_zero, ne_eq, findGreatest_zero, and_iff_left_iff_imp]
              rintro rfl
              exact ⟨fun h ↦ (h rfl).elim, fun n hlt heq ↦ by cutsat⟩
            | succ k ihk =>
              by_cases hk : P (k + 1)
              · rw [findGreatest_eq hk]
                constructor
                · rintro rfl
                  exact ⟨le_refl _, fun _ ↦ hk, fun n hlt hle ↦ by cutsat⟩
                · rintro ⟨hle, h0, hm⟩
                  rcases Decidable.lt_or_eq_of_le hle with hlt | rfl
                  exacts [(hm hlt (le_refl _) hk).elim, rfl]
              · rw [findGreatest_of_not hk, ihk]
                grind
          [Elab.step] [0.033287] 
                by_cases hk : P (k + 1)
                · rw [findGreatest_eq hk]
                  constructor
                  · rintro rfl
                    exact ⟨le_refl _, fun _ ↦ hk, fun n hlt hle ↦ by cutsat⟩
                  · rintro ⟨hle, h0, hm⟩
                    rcases Decidable.lt_or_eq_of_le hle with hlt | rfl
                    exacts [(hm hlt (le_refl _) hk).elim, rfl]
                · rw [findGreatest_of_not hk, ihk]
                  grind
            [Elab.step] [0.033279] 
                  by_cases hk : P (k + 1)
                  · rw [findGreatest_eq hk]
                    constructor
                    · rintro rfl
                      exact ⟨le_refl _, fun _ ↦ hk, fun n hlt hle ↦ by cutsat⟩
                    · rintro ⟨hle, h0, hm⟩
                      rcases Decidable.lt_or_eq_of_le hle with hlt | rfl
                      exacts [(hm hlt (le_refl _) hk).elim, rfl]
                  · rw [findGreatest_of_not hk, ihk]
                    grind
              [Elab.step] [0.022776] ·
                    rw [findGreatest_of_not hk, ihk]
                    grind
                [Elab.step] [0.022745] 
                      rw [findGreatest_of_not hk, ihk]
                      grind
                  [Elab.step] [0.022740] 
                        rw [findGreatest_of_not hk, ihk]
                        grind
                    [Elab.step] [0.021688] grind
Build completed successfully (103 jobs).
```
</details>

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include at least one commit authored by each
co-author among the commits in the pull request. If necessary, you may 
create empty commits to indicate co-authorship, using commands like so:

git commit --author="Author Name <author@email.com>" --allow-empty -m "add Author Name as coauthor"

When merging, all the commits will be squashed into a single commit listing all co-authors.

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
