### PR TITLE
[Merged by Bors] - chore: add module deprecations for removed files

### DIFF
--- a/Mathlib.lean
+++ b/Mathlib.lean
@@ -44,6 +44,7 @@ import Mathlib.Algebra.Algebra.TransferInstance
 import Mathlib.Algebra.Algebra.Unitization
 import Mathlib.Algebra.Algebra.ZMod
 import Mathlib.Algebra.AlgebraicCard
+import Mathlib.Algebra.ArithmeticGeometric
 import Mathlib.Algebra.Azumaya.Basic
 import Mathlib.Algebra.Azumaya.Defs
 import Mathlib.Algebra.Azumaya.Matrix
@@ -1710,6 +1711,7 @@ import Mathlib.Analysis.InnerProductSpace.Dual
 import Mathlib.Analysis.InnerProductSpace.EuclideanDist
 import Mathlib.Analysis.InnerProductSpace.GramMatrix
 import Mathlib.Analysis.InnerProductSpace.GramSchmidtOrtho
+import Mathlib.Analysis.InnerProductSpace.Harmonic.Analytic
 import Mathlib.Analysis.InnerProductSpace.Harmonic.Basic
 import Mathlib.Analysis.InnerProductSpace.Harmonic.Constructions
 import Mathlib.Analysis.InnerProductSpace.JointEigenspace
@@ -1893,6 +1895,7 @@ import Mathlib.Analysis.NormedSpace.Alternating.Basic
 import Mathlib.Analysis.NormedSpace.Alternating.Curry
 import Mathlib.Analysis.NormedSpace.Alternating.Uncurry.Fin
 import Mathlib.Analysis.NormedSpace.BallAction
+import Mathlib.Analysis.NormedSpace.ConformalLinearMap
 import Mathlib.Analysis.NormedSpace.Connected
 import Mathlib.Analysis.NormedSpace.DualNumber
 import Mathlib.Analysis.NormedSpace.ENormedSpace
@@ -2129,6 +2132,7 @@ import Mathlib.CategoryTheory.Bicategory.Functor.LocallyDiscrete
 import Mathlib.CategoryTheory.Bicategory.Functor.Oplax
 import Mathlib.CategoryTheory.Bicategory.Functor.Prelax
 import Mathlib.CategoryTheory.Bicategory.Functor.Pseudofunctor
+import Mathlib.CategoryTheory.Bicategory.Functor.Strict
 import Mathlib.CategoryTheory.Bicategory.Functor.StrictlyUnitary
 import Mathlib.CategoryTheory.Bicategory.FunctorBicategory.Oplax
 import Mathlib.CategoryTheory.Bicategory.Grothendieck
@@ -2142,6 +2146,7 @@ import Mathlib.CategoryTheory.Bicategory.NaturalTransformation.Oplax
 import Mathlib.CategoryTheory.Bicategory.NaturalTransformation.Pseudo
 import Mathlib.CategoryTheory.Bicategory.NaturalTransformation.Strong
 import Mathlib.CategoryTheory.Bicategory.SingleObj
+import Mathlib.CategoryTheory.Bicategory.Strict
 import Mathlib.CategoryTheory.Bicategory.Strict.Basic
 import Mathlib.CategoryTheory.Bicategory.Strict.Pseudofunctor
 import Mathlib.CategoryTheory.CatCommSq
@@ -3550,6 +3555,7 @@ import Mathlib.Data.Nat.PSub
 import Mathlib.Data.Nat.Pairing
 import Mathlib.Data.Nat.PartENat
 import Mathlib.Data.Nat.Periodic
+import Mathlib.Data.Nat.PowModTotient
 import Mathlib.Data.Nat.Prime.Basic
 import Mathlib.Data.Nat.Prime.Defs
 import Mathlib.Data.Nat.Prime.Factorial
@@ -3639,6 +3645,7 @@ import Mathlib.Data.Real.EReal
 import Mathlib.Data.Real.Embedding
 import Mathlib.Data.Real.GoldenRatio
 import Mathlib.Data.Real.Hyperreal
+import Mathlib.Data.Real.Irrational
 import Mathlib.Data.Real.Pi.Bounds
 import Mathlib.Data.Real.Pi.Irrational
 import Mathlib.Data.Real.Pi.Leibniz
@@ -4165,6 +4172,7 @@ import Mathlib.LinearAlgebra.AffineSpace.AffineSubspace.Defs
 import Mathlib.LinearAlgebra.AffineSpace.Basis
 import Mathlib.LinearAlgebra.AffineSpace.Centroid
 import Mathlib.LinearAlgebra.AffineSpace.Combination
+import Mathlib.LinearAlgebra.AffineSpace.ContinuousAffineEquiv
 import Mathlib.LinearAlgebra.AffineSpace.Defs
 import Mathlib.LinearAlgebra.AffineSpace.FiniteDimensional
 import Mathlib.LinearAlgebra.AffineSpace.Independent
@@ -5384,6 +5392,7 @@ import Mathlib.Probability.Martingale.Upcrossing
 import Mathlib.Probability.Moments.Basic
 import Mathlib.Probability.Moments.ComplexMGF
 import Mathlib.Probability.Moments.Covariance
+import Mathlib.Probability.Moments.CovarianceBilin
 import Mathlib.Probability.Moments.CovarianceBilinDual
 import Mathlib.Probability.Moments.IntegrableExpMul
 import Mathlib.Probability.Moments.MGFAnalytic

--- a/Mathlib/Algebra/ArithmeticGeometric.lean
+++ b/Mathlib/Algebra/ArithmeticGeometric.lean
@@ -1,0 +1,3 @@
+import Mathlib.Analysis.SpecificLimits.ArithmeticGeometric
+
+deprecated_module (since := "2025-09-17")

--- a/Mathlib/Analysis/InnerProductSpace/Harmonic/Analytic.lean
+++ b/Mathlib/Analysis/InnerProductSpace/Harmonic/Analytic.lean
@@ -1,0 +1,3 @@
+import Mathlib.Analysis.Complex.Harmonic.Analytic
+
+deprecated_module (since := "2025-09-16")

--- a/Mathlib/Analysis/NormedSpace/ConformalLinearMap.lean
+++ b/Mathlib/Analysis/NormedSpace/ConformalLinearMap.lean
@@ -1,0 +1,3 @@
+import Mathlib.Analysis.Normed.Operator.Conformal
+
+deprecated_module (since := "2025-09-16")

--- a/Mathlib/CategoryTheory/Bicategory/Functor/Strict.lean
+++ b/Mathlib/CategoryTheory/Bicategory/Functor/Strict.lean
@@ -1,0 +1,3 @@
+import Mathlib.CategoryTheory.Bicategory.Strict.Pseudofunctor
+
+deprecated_module (since := "2025-10-02")

--- a/Mathlib/CategoryTheory/Bicategory/Strict.lean
+++ b/Mathlib/CategoryTheory/Bicategory/Strict.lean
@@ -1,0 +1,3 @@
+import Mathlib.CategoryTheory.Bicategory.Strict.Basic
+
+deprecated_module (since := "2025-10-02")

--- a/Mathlib/Data/Nat/PowModTotient.lean
+++ b/Mathlib/Data/Nat/PowModTotient.lean
@@ -1,0 +1,3 @@
+import Mathlib.NumberTheory.PowModTotient
+
+deprecated_module (since := "2025-09-19")

--- a/Mathlib/Data/Real/Irrational.lean
+++ b/Mathlib/Data/Real/Irrational.lean
@@ -1,0 +1,3 @@
+import Mathlib.RingTheory.Real.Irrational
+
+deprecated_module (since := "2025-10-13")

--- a/Mathlib/LinearAlgebra/AffineSpace/ContinuousAffineEquiv.lean
+++ b/Mathlib/LinearAlgebra/AffineSpace/ContinuousAffineEquiv.lean
@@ -1,0 +1,3 @@
+import Mathlib.Topology.Algebra.ContinuousAffineEquiv
+
+deprecated_module (since := "2025-09-20")

--- a/Mathlib/Probability/Moments/CovarianceBilin.lean
+++ b/Mathlib/Probability/Moments/CovarianceBilin.lean
@@ -1,0 +1,3 @@
+import Mathlib.Probability.Moments.CovarianceBilinDual
+
+deprecated_module (since := "2025-10-13")


### PR DESCRIPTION
The files were moved in:

- 50229ae534b8cbd5ed798d38dbb2b3f27d20d20b
- 1a3e03e5d2f2be462a184a221fc72456f992987a
- fefa0fbec28fb2dfc1b78741499d9d177ee75c94
- 27e8b12514da477e4b681ba3134b0c42ac19bc5d (two files)
- c3104a0a6e21b2926b505f47ac9c96eacf24aa3a
- a778305ec3a679802f7dcfa64e2b903d4679ee21
- 1b18558289ee0c58c43f196a3d628f9be728f5d7
- eaa1502e407c6ce4bb367d12df0f15ff3f14e25a

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include at least one commit authored by each
co-author among the commits in the pull request. If necessary, you may 
create empty commits to indicate co-authorship, using commands like so:

git commit --author="Author Name <author@email.com>" --allow-empty -m "add Author Name as coauthor"

When merging, all the commits will be squashed into a single commit listing all co-authors.

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
