### PR TITLE
[Merged by Bors] - chore: golf `nondegenerate_of_det_ne_zero`, `num_zero` and `sum_to_range` using `simp_all`

### DIFF
--- a/Mathlib/LinearAlgebra/Matrix/Nondegenerate.lean
+++ b/Mathlib/LinearAlgebra/Matrix/Nondegenerate.lean
@@ -54,15 +54,7 @@ theorem nondegenerate_of_det_ne_zero [DecidableEq m] {M : Matrix m m A} (hM : M.
   refine nondegenerate_def.mpr fun v hv ↦ ?_
   ext i
   specialize hv (M.cramer (Pi.single i 1))
-  refine (mul_eq_zero.mp ?_).resolve_right hM
-  convert hv
-  simp only [mulVec_cramer M (Pi.single i 1), dotProduct, Pi.smul_apply, smul_eq_mul]
-  rw [Finset.sum_eq_single i, Pi.single_eq_same, mul_one]
-  · intro j _ hj
-    simp [hj]
-  · intros
-    have := Finset.mem_univ i
-    contradiction
+  simp_all
 
 theorem eq_zero_of_vecMul_eq_zero [DecidableEq m] {M : Matrix m m A} (hM : M.det ≠ 0) {v : m → A}
     (hv : v ᵥ* M = 0) : v = 0 :=

--- a/Mathlib/MeasureTheory/Integral/MeanInequalities.lean
+++ b/Mathlib/MeasureTheory/Integral/MeanInequalities.lean
@@ -192,10 +192,18 @@ theorem lintegral_prod_norm_pow_le {α ι : Type*} [MeasurableSpace α] {μ : Me
     simp at hp
   | insert i₀ s hi₀ ih =>
     rcases eq_or_ne (p i₀) 1 with h2i₀|h2i₀
-    · have : ∀ i ∈ s, p i = 0 := by
+    · simp only [hi₀, not_false_eq_true, prod_insert]
+      have h2p : ∀ i ∈ s, p i = 0 := by
         simpa [hi₀, h2i₀, sum_eq_zero_iff_of_nonneg (fun i hi ↦ h2p i <| mem_insert_of_mem hi)]
           using hp
-      simp_all
+      calc ∫⁻ a, f i₀ a ^ p i₀ * ∏ i ∈ s, f i a ^ p i ∂μ
+          = ∫⁻ a, f i₀ a ^ p i₀ * ∏ i ∈ s, 1 ∂μ := by
+            congr! 3 with x
+            apply prod_congr rfl fun i hi ↦ by rw [h2p i hi, ENNReal.rpow_zero]
+        _ ≤ (∫⁻ a, f i₀ a ∂μ) ^ p i₀ * ∏ i ∈ s, 1 := by simp [h2i₀]
+        _ = (∫⁻ a, f i₀ a ∂μ) ^ p i₀ * ∏ i ∈ s, (∫⁻ a, f i a ∂μ) ^ p i := by
+            congr 1
+            apply prod_congr rfl fun i hi ↦ by rw [h2p i hi, ENNReal.rpow_zero]
     · have hpi₀ : 0 ≤ 1 - p i₀ := by
         simp_rw [sub_nonneg, ← hp, single_le_sum h2p (mem_insert_self ..)]
       have h2pi₀ : 1 - p i₀ ≠ 0 := by

--- a/Mathlib/MeasureTheory/Integral/MeanInequalities.lean
+++ b/Mathlib/MeasureTheory/Integral/MeanInequalities.lean
@@ -192,18 +192,10 @@ theorem lintegral_prod_norm_pow_le {α ι : Type*} [MeasurableSpace α] {μ : Me
     simp at hp
   | insert i₀ s hi₀ ih =>
     rcases eq_or_ne (p i₀) 1 with h2i₀|h2i₀
-    · simp only [hi₀, not_false_eq_true, prod_insert]
-      have h2p : ∀ i ∈ s, p i = 0 := by
+    · have : ∀ i ∈ s, p i = 0 := by
         simpa [hi₀, h2i₀, sum_eq_zero_iff_of_nonneg (fun i hi ↦ h2p i <| mem_insert_of_mem hi)]
           using hp
-      calc ∫⁻ a, f i₀ a ^ p i₀ * ∏ i ∈ s, f i a ^ p i ∂μ
-          = ∫⁻ a, f i₀ a ^ p i₀ * ∏ i ∈ s, 1 ∂μ := by
-            congr! 3 with x
-            apply prod_congr rfl fun i hi ↦ by rw [h2p i hi, ENNReal.rpow_zero]
-        _ ≤ (∫⁻ a, f i₀ a ∂μ) ^ p i₀ * ∏ i ∈ s, 1 := by simp [h2i₀]
-        _ = (∫⁻ a, f i₀ a ∂μ) ^ p i₀ * ∏ i ∈ s, (∫⁻ a, f i a ∂μ) ^ p i := by
-            congr 1
-            apply prod_congr rfl fun i hi ↦ by rw [h2p i hi, ENNReal.rpow_zero]
+      simp_all
     · have hpi₀ : 0 ≤ 1 - p i₀ := by
         simp_rw [sub_nonneg, ← hp, single_le_sum h2p (mem_insert_self ..)]
       have h2pi₀ : 1 - p i₀ ≠ 0 := by

--- a/Mathlib/RingTheory/Localization/NumDen.lean
+++ b/Mathlib/RingTheory/Localization/NumDen.lean
@@ -84,11 +84,7 @@ theorem eq_zero_of_num_eq_zero {x : K} (h : num A x = 0) : x = 0 :=
 lemma num_zero : IsFractionRing.num A (0 : K) = 0 := by
   have := mk'_num_den' A (0 : K)
   simp only [div_eq_zero_iff] at this
-  rcases this with h | h
-  · exact FaithfulSMul.algebraMap_injective A K (by convert h; simp)
-  · replace h : algebraMap A K (den A (0 : K)) = algebraMap A K 0 := by convert h; simp
-    absurd FaithfulSMul.algebraMap_injective A K h
-    apply nonZeroDivisors.coe_ne_zero
+  simp_all
 
 @[simp]
 lemma num_eq_zero (x : K) : IsFractionRing.num A x = 0 ↔ x = 0 :=

--- a/Mathlib/Topology/Category/Profinite/Nobeling/Successor.lean
+++ b/Mathlib/Topology/Category/Profinite/Nobeling/Successor.lean
@@ -326,9 +326,8 @@ theorem injective_sum_to : Function.Injective (sum_to C ho) := by
 
 theorem sum_to_range :
     Set.range (sum_to C ho) = GoodProducts (π C (ord I · < o)) ∪ MaxProducts C ho := by
-  have h : Set.range (sum_to C ho) = _ ∪ _ := Set.Sum.elim_range _ _; rw [h]; congr <;> ext l
-  · exact ⟨fun ⟨m,hm⟩ ↦ by rw [← hm]; exact m.prop, fun hl ↦ ⟨⟨l,hl⟩, rfl⟩⟩
-  · exact ⟨fun ⟨m,hm⟩ ↦ by rw [← hm]; exact m.prop, fun hl ↦ ⟨⟨l,hl⟩, rfl⟩⟩
+  have : Set.range (sum_to C ho) = _ ∪ _ := Set.Sum.elim_range _ _
+  simp_all
 
 /-- The equivalence from the sum of `GoodProducts (π C (ord I · < o))` and
 `(MaxProducts C ho)` to `GoodProducts C`. -/


### PR DESCRIPTION
---
Trace profiling -- `nondegenerate_of_det_ne_zero`: 196 ms before, 184 ms after 🎉
Trace profiling -- `eq_zero_of_num_eq_zero`: <10 ms before, <10 ms after 🎉
Trace profiling -- `sum_to_range`: 39 ms before, 16 ms after 🎉

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include at least one commit authored by each
co-author among the commits in the pull request. If necessary, you may 
create empty commits to indicate co-authorship, using commands like so:

git commit --author="Author Name <author@email.com>" --allow-empty -m "add Author Name as coauthor"

When merging, all the commits will be squashed into a single commit listing all co-authors.

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
