### PR TITLE
feat(RingTheory): make FormallySmooth, FormallyEtale, and FormallyUnramified universe-polymorphic

### DIFF
--- a/Mathlib/RingTheory/Etale/Basic.lean
+++ b/Mathlib/RingTheory/Etale/Basic.lean
@@ -26,21 +26,21 @@ localization at an element.
 
 open scoped TensorProduct
 
-universe u
+universe u v
 
 namespace Algebra
 
 section
 
 variable (R : Type u) [CommRing R]
-variable (A : Type u) [CommRing A] [Algebra R A]
+variable (A : Type v) [CommRing A] [Algebra R A]
 
 /-- An `R` algebra `A` is formally étale if for every `R`-algebra, every square-zero ideal
 `I : Ideal B` and `f : A →ₐ[R] B ⧸ I`, there exists exactly one lift `A →ₐ[R] B`. -/
 @[mk_iff, stacks 00UQ]
 class FormallyEtale : Prop where
-  comp_bijective :
-    ∀ ⦃B : Type u⦄ [CommRing B],
+  comp_bijective' :
+    ∀ ⦃B : Type (max u v)⦄ [CommRing B],
       ∀ [Algebra R B] (I : Ideal B) (_ : I ^ 2 = ⊥),
         Function.Bijective ((Ideal.Quotient.mkₐ R I).comp : (A →ₐ[R] B) → A →ₐ[R] B ⧸ I)
 
@@ -50,13 +50,14 @@ namespace FormallyEtale
 
 section
 
-variable {R : Type u} [CommRing R]
-variable {A : Type u} [CommRing A] [Algebra R A]
+variable {R : Type*} [CommRing R]
+variable {A : Type*} [CommRing A] [Algebra R A]
 
 theorem iff_unramified_and_smooth :
-    FormallyEtale R A ↔ FormallyUnramified R A ∧ FormallySmooth R A := by
-  rw [FormallyUnramified.iff_comp_injective, formallySmooth_iff, formallyEtale_iff]
-  simp_rw [← forall_and, Function.Bijective]
+    FormallyEtale R A ↔ FormallyUnramified R A ∧ FormallySmooth R A :=
+  ⟨fun et ↦ ⟨.of_comp_injective fun _ _ _ _ h ↦ (et.1 _ h).injective,
+    ⟨fun _ _ _ _ h ↦ (et.1 _ h).surjective⟩⟩,
+  fun ⟨unr, sm⟩ ↦ ⟨fun _ _ _ _ h ↦ ⟨unr.comp_injective _ h, sm.comp_surjective _ h⟩⟩⟩
 
 instance (priority := 100) to_unramified [h : FormallyEtale R A] :
     FormallyUnramified R A :=
@@ -69,12 +70,17 @@ theorem of_unramified_and_smooth [h₁ : FormallyUnramified R A]
     [h₂ : FormallySmooth R A] : FormallyEtale R A :=
   FormallyEtale.iff_unramified_and_smooth.mpr ⟨h₁, h₂⟩
 
+theorem comp_bijective [FormallyEtale R A] ⦃B : Type*⦄ [CommRing B] [Algebra R B]
+    (I : Ideal B) (hI : I ^ 2 = ⊥) :
+    Function.Bijective ((Ideal.Quotient.mkₐ R I).comp : (A →ₐ[R] B) → A →ₐ[R] B ⧸ I) :=
+  ⟨FormallyUnramified.comp_injective _ hI, FormallySmooth.comp_surjective _ hI⟩
+
 end
 
 section OfEquiv
 
-variable {R : Type u} [CommRing R]
-variable {A B : Type u} [CommRing A] [Algebra R A] [CommRing B] [Algebra R B]
+variable {R : Type*} [CommRing R]
+variable {A B : Type*} [CommRing A] [Algebra R A] [CommRing B] [Algebra R B]
 
 theorem of_equiv [FormallyEtale R A] (e : A ≃ₐ[R] B) : FormallyEtale R B :=
   FormallyEtale.iff_unramified_and_smooth.mpr
@@ -87,9 +93,9 @@ end OfEquiv
 
 section Comp
 
-variable (R : Type u) [CommRing R]
-variable (A : Type u) [CommRing A] [Algebra R A]
-variable (B : Type u) [CommRing B] [Algebra R B] [Algebra A B] [IsScalarTower R A B]
+variable (R : Type*) [CommRing R]
+variable (A : Type*) [CommRing A] [Algebra R A]
+variable (B : Type*) [CommRing B] [Algebra R B] [Algebra A B] [IsScalarTower R A B]
 
 theorem comp [FormallyEtale R A] [FormallyEtale A B] : FormallyEtale R B :=
   FormallyEtale.iff_unramified_and_smooth.mpr
@@ -101,9 +107,9 @@ section BaseChange
 
 open scoped TensorProduct
 
-variable {R : Type u} [CommRing R]
-variable {A : Type u} [CommRing A] [Algebra R A]
-variable (B : Type u) [CommRing B] [Algebra R B]
+variable {R : Type*} [CommRing R]
+variable {A : Type*} [CommRing A] [Algebra R A]
+variable (B : Type*) [CommRing B] [Algebra R B]
 
 instance base_change [FormallyEtale R A] : FormallyEtale B (B ⊗[R] A) :=
   FormallyEtale.iff_unramified_and_smooth.mpr ⟨inferInstance, inferInstance⟩
@@ -129,7 +135,7 @@ subset `M` of `R`.
 -/
 
 /-! Let R, S, Rₘ, Sₘ be commutative rings -/
-variable {R S Rₘ Sₘ : Type u} [CommRing R] [CommRing S] [CommRing Rₘ] [CommRing Sₘ]
+variable {R S Rₘ Sₘ : Type*} [CommRing R] [CommRing S] [CommRing Rₘ] [CommRing Sₘ]
 /-! Let M be a multiplicatively closed subset of `R` -/
 variable (M : Submonoid R)
 /-! Assume that the rings are in a commutative diagram as above. -/
@@ -159,8 +165,8 @@ end FormallyEtale
 
 section
 
-variable (R : Type u) [CommRing R]
-variable (A : Type u) [CommRing A] [Algebra R A]
+variable (R : Type*) [CommRing R]
+variable (A : Type*) [CommRing A] [Algebra R A]
 
 /-- An `R`-algebra `A` is étale if it is formally étale and of finite presentation. -/
 @[stacks 00U1 "Note that this is a different definition from this Stacks entry, but
@@ -175,8 +181,8 @@ namespace Etale
 
 attribute [instance] formallyEtale finitePresentation
 
-variable {R : Type u} [CommRing R]
-variable {A B : Type u} [CommRing A] [Algebra R A] [CommRing B] [Algebra R B]
+variable {R : Type*} [CommRing R]
+variable {A B : Type*} [CommRing A] [Algebra R A] [CommRing B] [Algebra R B]
 
 /-- Being étale is transported via algebra isomorphisms. -/
 theorem of_equiv [Etale R A] (e : A ≃ₐ[R] B) : Etale R B where
@@ -208,7 +214,7 @@ end Algebra
 
 namespace RingHom
 
-variable {R S : Type u} [CommRing R] [CommRing S]
+variable {R S : Type*} [CommRing R] [CommRing S]
 
 /--
 A ring homomorphism `R →+* A` is formally étale if it is formally unramified and formally smooth.

--- a/Mathlib/RingTheory/Etale/Field.lean
+++ b/Mathlib/RingTheory/Etale/Field.lean
@@ -32,7 +32,7 @@ Let `K` be a field, `A` be a `K`-algebra and `L` be a field extension of `K`.
 
 universe u
 
-variable (K L A : Type u) [Field K] [Field L] [CommRing A] [Algebra K L] [Algebra K A]
+variable (K L A : Type*) [Field K] [Field L] [CommRing A] [Algebra K L] [Algebra K A]
 
 open Algebra Polynomial
 
@@ -55,7 +55,7 @@ theorem of_isSeparable_aux [Algebra.IsSeparable K L] [EssFiniteType K L] :
   constructor
   -- We shall show that any `f : L → B/I` can be lifted to `L → B` if `I^2 = ⊥`
   intro B _ _ I h
-  refine ⟨FormallyUnramified.iff_comp_injective.mp (FormallyUnramified.of_isSeparable K L) I h, ?_⟩
+  refine ⟨FormallyUnramified.comp_injective I h, ?_⟩
   intro f
   -- By separability and finiteness, we may assume `L = K(α)` with `p` the minpoly of `α`.
   let pb := Field.powerBasisOfFiniteOfSeparable K L
@@ -94,7 +94,8 @@ lemma of_isSeparable [Algebra.IsSeparable K L] : FormallyEtale K L := by
   -- We shall show that any `f : L → B/I` can be lifted to `L → B` if `I^2 = ⊥`.
   -- But we already know that there exists a unique lift for every finite subfield of `L`
   -- by `of_isSeparable_aux`, so we can glue them all together.
-  refine ⟨FormallyUnramified.iff_comp_injective.mp (FormallyUnramified.of_isSeparable K L) I h, ?_⟩
+  have := FormallyUnramified.of_isSeparable K L
+  refine ⟨FormallyUnramified.comp_injective I h, ?_⟩
   intro f
   have : ∀ k : L, ∃! g : K⟮k⟯ →ₐ[K] B,
       (Ideal.Quotient.mkₐ K I).comp g = f.comp (IsScalarTower.toAlgHom K _ L) := by
@@ -158,8 +159,8 @@ attribute [local instance] IsArtinianRing.fieldOfSubtypeIsMaximal in
 If `A` is an essentially of finite type algebra over a field `K`, then `A` is formally étale
 over `K` if and only if `A` is a finite product of separable field extensions.
 -/
-theorem iff_exists_algEquiv_prod [EssFiniteType K A] :
-    FormallyEtale K A ↔
+theorem iff_exists_algEquiv_prod (K : Type*) (A : Type u) [Field K] [CommRing A] [Algebra K A]
+    [EssFiniteType K A] : FormallyEtale K A ↔
       ∃ (I : Type u) (_ : Finite I) (Ai : I → Type u) (_ : ∀ i, Field (Ai i))
         (_ : ∀ i, Algebra K (Ai i)) (_ : A ≃ₐ[K] Π i, Ai i),
         ∀ i, Algebra.IsSeparable K (Ai i) := by
@@ -185,7 +186,8 @@ end Algebra.FormallyEtale
 `A` is étale over a field `K` if and only if
 `A` is a finite product of finite separable field extensions.
 -/
-theorem Algebra.Etale.iff_exists_algEquiv_prod :
+theorem Algebra.Etale.iff_exists_algEquiv_prod (K : Type*) (A : Type u)
+    [Field K] [CommRing A] [Algebra K A] :
     Etale K A ↔
       ∃ (I : Type u) (_ : Finite I) (Ai : I → Type u) (_ : ∀ i, Field (Ai i))
         (_ : ∀ i, Algebra K (Ai i)) (_ : A ≃ₐ[K] Π i, Ai i),

--- a/Mathlib/RingTheory/Etale/Pi.lean
+++ b/Mathlib/RingTheory/Etale/Pi.lean
@@ -18,11 +18,9 @@ import Mathlib.RingTheory.Etale.Basic
 
 -/
 
-universe u v
-
 namespace Algebra.FormallyEtale
 
-variable {R : Type (max u v)} {I : Type u} (A : I → Type (max u v))
+variable {R : Type*} {I : Type*} (A : I → Type*)
 variable [CommRing R] [∀ i, CommRing (A i)] [∀ i, Algebra R (A i)]
 
 theorem pi_iff [Finite I] :

--- a/Mathlib/RingTheory/Ideal/Cotangent.lean
+++ b/Mathlib/RingTheory/Ideal/Cotangent.lean
@@ -188,6 +188,7 @@ def quotCotangent : (R ⧸ I ^ 2) ⧸ I.cotangentIdeal ≃+* R ⧸ I := by
   refine (DoubleQuot.quotQuotEquivQuotSup _ _).trans ?_
   exact Ideal.quotEquivOfEq (sup_eq_right.mpr <| Ideal.pow_le_self two_ne_zero)
 
+/-- The algebra isomorphism `(R ⧸ I ^ 2) ⧸ (I ⧸ I ^ 2) ≃ₐ[R] R ⧸ I`. -/
 def quotCotangentₐ : ((R ⧸ I ^ 2) ⧸ I.cotangentIdeal) ≃ₐ[R] R ⧸ I where
   __ := I.quotCotangent
   commutes' _ := rfl

--- a/Mathlib/RingTheory/Ideal/Cotangent.lean
+++ b/Mathlib/RingTheory/Ideal/Cotangent.lean
@@ -188,6 +188,12 @@ def quotCotangent : (R ⧸ I ^ 2) ⧸ I.cotangentIdeal ≃+* R ⧸ I := by
   refine (DoubleQuot.quotQuotEquivQuotSup _ _).trans ?_
   exact Ideal.quotEquivOfEq (sup_eq_right.mpr <| Ideal.pow_le_self two_ne_zero)
 
+def quotCotangentₐ : ((R ⧸ I ^ 2) ⧸ I.cotangentIdeal) ≃ₐ[R] R ⧸ I where
+  __ := I.quotCotangent
+  commutes' _ := rfl
+
+@[simp] lemma quotCotangentₐ_mk_mk (x : R) : I.quotCotangentₐ x = x := rfl
+
 /-- The map `I/I² → J/J²` if `I ≤ f⁻¹(J)`. -/
 def mapCotangent (I₁ : Ideal A) (I₂ : Ideal B) (f : A →ₐ[R] B) (h : I₁ ≤ I₂.comap f) :
     I₁.Cotangent →ₗ[R] I₂.Cotangent := by

--- a/Mathlib/RingTheory/Smooth/Basic.lean
+++ b/Mathlib/RingTheory/Smooth/Basic.lean
@@ -30,7 +30,7 @@ localization at an element.
 
 open scoped TensorProduct
 
-universe u v w
+universe u v
 
 namespace Algebra
 

--- a/Mathlib/RingTheory/Smooth/Basic.lean
+++ b/Mathlib/RingTheory/Smooth/Basic.lean
@@ -62,16 +62,6 @@ theorem comp_surjective_mvPolynomial (R : Type*) [CommSemiring R] (σ : Type*)
       (MvPolynomial σ R →ₐ[R] A) → MvPolynomial σ R →ₐ[R] A ⧸ I) :=
   fun f ↦ ⟨MvPolynomial.aeval fun s ↦ (f <| .X s).out, by ext; simp⟩
 
--- MOVE
-def _root_.Ideal.quotCotangentₐ {R : Type*} [CommRing R] (I : Ideal R) :
-    ((R ⧸ I ^ 2) ⧸ I.cotangentIdeal) ≃ₐ[R] R ⧸ I where
-  __ := I.quotCotangent
-  commutes' _ := rfl
-
-@[simp] lemma _root_.Ideal.quotCotangentₐ_apply {R : Type*} [CommRing R] (I : Ideal R) (x : R) :
-    I.quotCotangentₐ x = x :=
-  rfl
-
 -- replaced with `iff_split_surjection` below
 private theorem split_of_formallySmooth_of_surjective'
     (R : Type u) (A : Type (max u v)) [CommRing R] [CommRing A] [Algebra R A]

--- a/Mathlib/RingTheory/Smooth/Basic.lean
+++ b/Mathlib/RingTheory/Smooth/Basic.lean
@@ -72,6 +72,7 @@ def _root_.Ideal.quotCotangentₐ {R : Type*} [CommRing R] (I : Ideal R) :
     I.quotCotangentₐ x = x :=
   rfl
 
+-- replaced with `iff_split_surjection` below
 private theorem split_of_formallySmooth_of_surjective'
     (R : Type u) (A : Type (max u v)) [CommRing R] [CommRing A] [Algebra R A]
     (B : Type v) [CommRing B] [Algebra R B] [FormallySmooth R B]
@@ -89,6 +90,7 @@ private theorem split_of_formallySmooth_of_surjective'
   obtain ⟨a, rfl⟩ := Ideal.Quotient.mk_surjective y
   exact hs
 
+-- replaced by `of_split` below
 private theorem comp_surjective_of_split'
     (R σ A : Type*) [CommRing R] [CommRing A] [Algebra R A] (f : MvPolynomial σ R →ₐ[R] A)
     (s : A →ₐ[R] MvPolynomial σ R ⧸ RingHom.ker f ^ 2) (hs : f.kerSquareLift.comp s = AlgHom.id R A)
@@ -108,6 +110,9 @@ private theorem comp_surjective_of_split'
   conv at hs => enter [1,2]; exact hx.symm -- kerSquareLift has RingHom.ker f.toRingHom which is bad
   simpa [← hx, show f x = r from hs] using hφ₁
 
+/-- If an `R`-algebra `A` is formally smooth, then it can "lift along nilpotent ideals", meaning
+that if `B` is any arbitrary `R`-algebra and `I` is an ideal in `B` with `I ^ 2 = ⊥`, then
+the natural map `(A →ₐ[R] B) → (A →ₐ[R] B ⧸ I)` is surjective. -/
 theorem comp_surjective {R A B : Type*} [CommRing R] [CommRing A] [Algebra R A] [FormallySmooth R A]
     [CommRing B] [Algebra R B] (I : Ideal B) (hi : I ^ 2 = ⊥) :
     Function.Surjective ((Ideal.Quotient.mkₐ R I).comp : (A →ₐ[R] B) → A →ₐ[R] B ⧸ I) :=
@@ -216,15 +221,15 @@ instance mvPolynomial : FormallySmooth R (MvPolynomial σ R) :=
   ⟨fun _ _ _ _ _ ↦ comp_surjective_mvPolynomial _ _ _ _⟩
 
 instance polynomial : FormallySmooth R R[X] :=
-  FormallySmooth.of_equiv (MvPolynomial.pUnitAlgEquiv R)
+  ⟨fun _ _ _ _ _ f ↦ ⟨Polynomial.aeval (f .X).out, by ext; simp⟩⟩
 
 end Polynomial
 
 section Comp
 
-variable (R : Type*) [CommSemiring R]
-variable (A : Type*) [CommSemiring A] [Algebra R A]
-variable (B : Type*) [Semiring B] [Algebra R B] [Algebra A B] [IsScalarTower R A B]
+variable (R : Type*) [CommRing R]
+variable (A : Type*) [CommRing A] [Algebra R A]
+variable (B : Type*) [CommRing B] [Algebra R B] [Algebra A B] [IsScalarTower R A B]
 
 theorem comp [FormallySmooth R A] [FormallySmooth A B] : FormallySmooth R B := by
   constructor
@@ -303,9 +308,9 @@ section BaseChange
 
 open scoped TensorProduct
 
-variable {R : Type*} [CommSemiring R]
-variable {A : Type*} [Semiring A] [Algebra R A]
-variable (B : Type*) [CommSemiring B] [Algebra R B]
+variable {R : Type*} [CommRing R]
+variable {A : Type*} [CommRing A] [Algebra R A]
+variable (B : Type*) [CommRing B] [Algebra R B]
 
 instance base_change [FormallySmooth R A] : FormallySmooth B (B ⊗[R] A) := by
   constructor

--- a/Mathlib/RingTheory/Smooth/Kaehler.lean
+++ b/Mathlib/RingTheory/Smooth/Kaehler.lean
@@ -47,6 +47,8 @@ import Mathlib.Tactic.StacksAttribute
 
 -/
 
+universe u₁ u₂
+
 open TensorProduct KaehlerDifferential
 
 open Function (Surjective)
@@ -400,7 +402,7 @@ with kernel `I` (typically a presentation `R[X] → S`),
 -/
 @[stacks 031I]
 theorem Algebra.Extension.formallySmooth_iff_split_injection
-    (P : Algebra.Extension R S) [FormallySmooth R P.Ring] :
+    (P : Algebra.Extension.{u₁} R S) [FormallySmooth R P.Ring] :
     Algebra.FormallySmooth R S ↔ ∃ l, l ∘ₗ P.cotangentComplex = LinearMap.id := by
   refine (Algebra.FormallySmooth.iff_split_injection P.algebraMap_surjective).trans ?_
   let e : P.ker.Cotangent ≃ₗ[P.Ring] P.Cotangent :=
@@ -478,7 +480,7 @@ instance [Algebra.FormallySmooth R S] : Subsingleton (Algebra.H1Cotangent R S) :
 
 namespace Algebra.Extension
 
-lemma CotangentSpace.map_toInfinitesimal_bijective (P : Extension R S) :
+lemma CotangentSpace.map_toInfinitesimal_bijective (P : Extension.{u₁} R S) :
     Function.Bijective (CotangentSpace.map P.toInfinitesimal) := by
   suffices CotangentSpace.map P.toInfinitesimal =
       (tensorKaehlerQuotKerSqEquiv _ _ _).symm.toLinearMap by
@@ -491,7 +493,7 @@ lemma CotangentSpace.map_toInfinitesimal_bijective (P : Extension R S) :
   simp only [map_tmul, algebraMap_self, RingHom.id_apply, Hom.toAlgHom_apply]
   exact (tensorKaehlerQuotKerSqEquiv_symm_tmul_D _ _).symm
 
-lemma Cotangent.map_toInfinitesimal_bijective (P : Extension R S) :
+lemma Cotangent.map_toInfinitesimal_bijective (P : Extension.{u₁} R S) :
     Function.Bijective (Cotangent.map P.toInfinitesimal) := by
   constructor
   · rw [injective_iff_map_eq_zero]
@@ -512,7 +514,7 @@ lemma Cotangent.map_toInfinitesimal_bijective (P : Extension R S) :
     rw [ker_infinitesimal, Ideal.mk_mem_cotangentIdeal] at hx
     exact ⟨.mk ⟨x, hx⟩, rfl⟩
 
-lemma H1Cotangent.map_toInfinitesimal_bijective (P : Extension R S) :
+lemma H1Cotangent.map_toInfinitesimal_bijective (P : Extension.{u₁} R S) :
     Function.Bijective (H1Cotangent.map P.toInfinitesimal) := by
   constructor
   · intro x y e
@@ -529,7 +531,8 @@ Given extensions `0 → I₁ → P₁ → S → 0` and `0 → I₂ → P₂ → 
 this is an arbitrarily chosen map `P₁/I₁² → P₂/I₂²` of extensions.
 -/
 noncomputable
-def homInfinitesimal (P₁ P₂ : Extension R S) [FormallySmooth R P₁.Ring] :
+def homInfinitesimal (P₁ : Extension.{u₁} R S) (P₂ : Extension.{u₂} R S)
+    [FormallySmooth R P₁.Ring] :
     P₁.infinitesimal.Hom P₂.infinitesimal :=
   letI lift : P₁.Ring →ₐ[R] P₂.infinitesimal.Ring := FormallySmooth.liftOfSurjective
     (IsScalarTower.toAlgHom R P₁.Ring S)
@@ -555,14 +558,15 @@ def homInfinitesimal (P₁ P₂ : Extension R S) [FormallySmooth R P₁.Ring] :
 
 /-- Formally smooth extensions have isomorphic `H¹(L_P)`. -/
 noncomputable
-def H1Cotangent.equivOfFormallySmooth (P₁ P₂ : Extension R S)
+def H1Cotangent.equivOfFormallySmooth (P₁ : Extension.{u₁} R S) (P₂ : Extension.{u₂} R S)
     [FormallySmooth R P₁.Ring] [FormallySmooth R P₂.Ring] :
     P₁.H1Cotangent ≃ₗ[S] P₂.H1Cotangent :=
   .ofBijective _ (H1Cotangent.map_toInfinitesimal_bijective P₁) ≪≫ₗ
     H1Cotangent.equiv (Extension.homInfinitesimal _ _) (Extension.homInfinitesimal _ _)
     ≪≫ₗ .symm (.ofBijective _ (H1Cotangent.map_toInfinitesimal_bijective P₂))
 
-lemma H1Cotangent.equivOfFormallySmooth_toLinearMap {P₁ P₂ : Extension R S} (f : P₁.Hom P₂)
+lemma H1Cotangent.equivOfFormallySmooth_toLinearMap
+    {P₁ : Extension.{u₁} R S} {P₂ : Extension.{u₂} R S} (f : P₁.Hom P₂)
     [FormallySmooth R P₁.Ring] [FormallySmooth R P₂.Ring] :
     (H1Cotangent.equivOfFormallySmooth P₁ P₂).toLinearMap = map f := by
   ext1 x
@@ -571,18 +575,19 @@ lemma H1Cotangent.equivOfFormallySmooth_toLinearMap {P₁ P₂ : Extension R S} 
     ((map P₂.toInfinitesimal).restrictScalars S ∘ₗ map f) x
   rw [← map_comp, ← map_comp, map_eq]
 
-lemma H1Cotangent.equivOfFormallySmooth_apply {P₁ P₂ : Extension R S} (f : P₁.Hom P₂)
+lemma H1Cotangent.equivOfFormallySmooth_apply
+    {P₁ : Extension.{u₁} R S} {P₂ : Extension.{u₂} R S} (f : P₁.Hom P₂)
     [FormallySmooth R P₁.Ring] [FormallySmooth R P₂.Ring] (x) :
     H1Cotangent.equivOfFormallySmooth P₁ P₂ x = map f x := by
   rw [← equivOfFormallySmooth_toLinearMap]; rfl
 
-lemma H1Cotangent.equivOfFormallySmooth_symm (P₁ P₂ : Extension R S)
+lemma H1Cotangent.equivOfFormallySmooth_symm (P₁ : Extension.{u₁} R S) (P₂ : Extension.{u₂} R S)
     [FormallySmooth R P₁.Ring] [FormallySmooth R P₂.Ring] :
     (equivOfFormallySmooth P₁ P₂).symm = equivOfFormallySmooth P₂ P₁ := rfl
 
 /-- Any formally smooth extension can be used to calculate `H¹(L_{S/R})`. -/
 noncomputable
-def equivH1CotangentOfFormallySmooth (P : Extension R S) [FormallySmooth R P.Ring] :
+def equivH1CotangentOfFormallySmooth (P : Extension.{u₁} R S) [FormallySmooth R P.Ring] :
     P.H1Cotangent ≃ₗ[S] H1Cotangent R S :=
   have : FormallySmooth R (Generators.self R S).toExtension.Ring :=
     inferInstanceAs (FormallySmooth R (MvPolynomial _ _))

--- a/Mathlib/RingTheory/Smooth/Kaehler.lean
+++ b/Mathlib/RingTheory/Smooth/Kaehler.lean
@@ -47,13 +47,11 @@ import Mathlib.Tactic.StacksAttribute
 
 -/
 
-universe u
-
 open TensorProduct KaehlerDifferential
 
 open Function (Surjective)
 
-variable {R P S : Type u} [CommRing R] [CommRing P] [CommRing S]
+variable {R P S : Type*} [CommRing R] [CommRing P] [CommRing S]
 variable [Algebra R P] [Algebra P S]
 
 section ofSection
@@ -402,7 +400,7 @@ with kernel `I` (typically a presentation `R[X] → S`),
 -/
 @[stacks 031I]
 theorem Algebra.Extension.formallySmooth_iff_split_injection
-    (P : Algebra.Extension.{u} R S) [FormallySmooth R P.Ring] :
+    (P : Algebra.Extension R S) [FormallySmooth R P.Ring] :
     Algebra.FormallySmooth R S ↔ ∃ l, l ∘ₗ P.cotangentComplex = LinearMap.id := by
   refine (Algebra.FormallySmooth.iff_split_injection P.algebraMap_surjective).trans ?_
   let e : P.ker.Cotangent ≃ₗ[P.Ring] P.Cotangent :=
@@ -480,7 +478,7 @@ instance [Algebra.FormallySmooth R S] : Subsingleton (Algebra.H1Cotangent R S) :
 
 namespace Algebra.Extension
 
-lemma CotangentSpace.map_toInfinitesimal_bijective (P : Extension.{u} R S) :
+lemma CotangentSpace.map_toInfinitesimal_bijective (P : Extension R S) :
     Function.Bijective (CotangentSpace.map P.toInfinitesimal) := by
   suffices CotangentSpace.map P.toInfinitesimal =
       (tensorKaehlerQuotKerSqEquiv _ _ _).symm.toLinearMap by
@@ -493,7 +491,7 @@ lemma CotangentSpace.map_toInfinitesimal_bijective (P : Extension.{u} R S) :
   simp only [map_tmul, algebraMap_self, RingHom.id_apply, Hom.toAlgHom_apply]
   exact (tensorKaehlerQuotKerSqEquiv_symm_tmul_D _ _).symm
 
-lemma Cotangent.map_toInfinitesimal_bijective (P : Extension.{u} R S) :
+lemma Cotangent.map_toInfinitesimal_bijective (P : Extension R S) :
     Function.Bijective (Cotangent.map P.toInfinitesimal) := by
   constructor
   · rw [injective_iff_map_eq_zero]
@@ -514,7 +512,7 @@ lemma Cotangent.map_toInfinitesimal_bijective (P : Extension.{u} R S) :
     rw [ker_infinitesimal, Ideal.mk_mem_cotangentIdeal] at hx
     exact ⟨.mk ⟨x, hx⟩, rfl⟩
 
-lemma H1Cotangent.map_toInfinitesimal_bijective (P : Extension.{u} R S) :
+lemma H1Cotangent.map_toInfinitesimal_bijective (P : Extension R S) :
     Function.Bijective (H1Cotangent.map P.toInfinitesimal) := by
   constructor
   · intro x y e

--- a/Mathlib/RingTheory/Smooth/Local.lean
+++ b/Mathlib/RingTheory/Smooth/Local.lean
@@ -11,6 +11,8 @@ import Mathlib.RingTheory.TensorProduct.Free
 # Formally smooth local algebras
 -/
 
+universe u₁
+
 open TensorProduct IsLocalRing KaehlerDifferential
 
 /--
@@ -23,7 +25,7 @@ Then `S` is formally smooth iff `k ⊗ₛ I/I² → k ⊗ₚ Ω[P/R]` is injecti
 where `k` is the residue field of `S`.
 -/
 theorem Algebra.FormallySmooth.iff_injective_lTensor_residueField {R S} [CommRing R]
-    [CommRing S] [IsLocalRing S] [Algebra R S] (P : Algebra.Extension R S)
+    [CommRing S] [IsLocalRing S] [Algebra R S] (P : Algebra.Extension.{u₁} R S)
     [FormallySmooth R P.Ring]
     [Module.Free P.Ring Ω[P.Ring⁄R]] [Module.Finite P.Ring Ω[P.Ring⁄R]]
     (h' : P.ker.FG) :

--- a/Mathlib/RingTheory/Smooth/Locus.lean
+++ b/Mathlib/RingTheory/Smooth/Locus.lean
@@ -22,9 +22,7 @@ Some of them are true for arbitrary algebras but the proof is substantially hard
 - `Algebra.isOpen_smoothLocus` : The smooth locus is open.
 -/
 
-universe u
-
-variable (R A : Type u) [CommRing R] [CommRing A] [Algebra R A]
+variable (R A : Type*) [CommRing R] [CommRing A] [Algebra R A]
 
 namespace Algebra
 
@@ -100,7 +98,7 @@ lemma smoothLocus_eq_univ_iff [FinitePresentation R A] :
     ← basicOpen_subset_smoothLocus_iff]
   simp
 
-lemma smoothLocus_comap_of_isLocalization {Af : Type u} [CommRing Af] [Algebra A Af] [Algebra R Af]
+lemma smoothLocus_comap_of_isLocalization {Af : Type*} [CommRing Af] [Algebra A Af] [Algebra R Af]
     [IsScalarTower R A Af] (f : A) [IsLocalization.Away f Af] :
     PrimeSpectrum.comap (algebraMap A Af) ⁻¹' smoothLocus R A = smoothLocus R Af := by
   ext p

--- a/Mathlib/RingTheory/Smooth/Pi.lean
+++ b/Mathlib/RingTheory/Smooth/Pi.lean
@@ -17,11 +17,9 @@ import Mathlib.RingTheory.Smooth.Basic
 
 -/
 
-universe u v
-
 namespace Algebra.FormallySmooth
 
-variable {R : Type (max u v)} {I : Type u} (A : I → Type (max u v))
+variable {R : Type*} {I : Type*} (A : I → Type*)
 variable [CommRing R] [∀ i, CommRing (A i)] [∀ i, Algebra R (A i)]
 
 theorem of_pi [FormallySmooth R (Π i, A i)] (i) :

--- a/Mathlib/RingTheory/Smooth/StandardSmoothCotangent.lean
+++ b/Mathlib/RingTheory/Smooth/StandardSmoothCotangent.lean
@@ -27,8 +27,6 @@ We also provide the corresponding instances for standard smooth algebras as coro
 We keep the notation `I = ker(R[X] → S)` in all docstrings of this file.
 -/
 
-universe u
-
 namespace Algebra
 
 section
@@ -267,7 +265,7 @@ instance IsStandardSmoothOfRelationDimension.subsingleton_kaehlerDifferential
 
 end
 
-variable {R S : Type u} [CommRing R] [CommRing S] [Algebra R S]
+variable {R S : Type*} [CommRing R] [CommRing S] [Algebra R S]
 
 instance (priority := 900) [IsStandardSmooth R S] : Smooth R S where
   formallySmooth := by

--- a/Mathlib/RingTheory/Unramified/Basic.lean
+++ b/Mathlib/RingTheory/Unramified/Basic.lean
@@ -93,6 +93,21 @@ theorem iff_comp_injective :
       apply RingHom.kerLift_injective (TensorProduct.lmul' R (S := A)).kerSquareLift.toRingHom
       simpa using DFunLike.congr_fun (f₁.2.trans f₂.2.symm) x
 
+-- The injectivity criterion can be checked in any universe higher than `u` (the universe of `A`).
+theorem of_comp_injective (comp_injective' : ∀ ⦃B : Type (max w u)⦄ [CommRing B],
+    ∀ [Algebra R B] (I : Ideal B) (_ : I ^ 2 = ⊥),
+      Function.Injective ((Ideal.Quotient.mkₐ R I).comp : (A →ₐ[R] B) → A →ₐ[R] B ⧸ I)) :
+    FormallyUnramified R A := by
+  rw [iff_comp_injective]
+  introv hi a₁ h
+  let e₁ : ULift.{w} B ≃ₐ[R] B := ULift.algEquiv
+  let e₂ : (ULift.{w} B ⧸ I.comap e₁) ≃ₐ[R] (B ⧸ I) :=
+    Ideal.quotientEquivAlg _ _ e₁ (Ideal.map_comap_eq_self_of_equiv _ _).symm
+  exact (AlgHom.cancel_left (f := e₁.symm.toAlgHom) e₁.symm.injective).mp <|
+    comp_injective' (I.comap e₁) (eq_bot_iff.mpr <| (Ideal.le_comap_pow _ _).trans <| by
+      rw [hi, Ideal.comap_bot_of_injective _ (AlgEquiv.injective _)]) <|
+    (AlgHom.cancel_left (f := e₂.toAlgHom) e₂.injective).mp h
+
 theorem lift_unique
     [FormallyUnramified R A] (I : Ideal B) (hI : IsNilpotent I) (g₁ g₂ : A →ₐ[R] B)
     (h : (Ideal.Quotient.mkₐ R I).comp g₁ = (Ideal.Quotient.mkₐ R I).comp g₂) : g₁ = g₂ := by

--- a/Mathlib/RingTheory/Unramified/Field.lean
+++ b/Mathlib/RingTheory/Unramified/Field.lean
@@ -32,8 +32,6 @@ Let `K` be a field, `A` be a `K`-algebra and `L` be a field extension of `K`.
 open Algebra Module Polynomial
 open scoped TensorProduct
 
-universe u
-
 variable (K A L : Type*) [Field K] [Field L] [CommRing A] [Algebra K A] [Algebra K L]
 
 namespace Algebra.FormallyUnramified
@@ -204,7 +202,7 @@ theorem isSeparable : Algebra.IsSeparable K L := by
   rw [← range_eq_top_of_isPurelyInseparable (separableClosure K L) L]
   simp
 
-theorem iff_isSeparable (L : Type u) [Field L] [Algebra K L] [EssFiniteType K L] :
+theorem iff_isSeparable (L : Type*) [Field L] [Algebra K L] [EssFiniteType K L] :
     FormallyUnramified K L ↔ Algebra.IsSeparable K L :=
   ⟨fun _ ↦ isSeparable K L, fun _ ↦ of_isSeparable K L⟩
 

--- a/Mathlib/RingTheory/Unramified/Locus.lean
+++ b/Mathlib/RingTheory/Unramified/Locus.lean
@@ -20,8 +20,6 @@ import Mathlib.RingTheory.Support
   If `A` is (essentially) of finite type over `R`, then the unramified locus is open.
 -/
 
-universe u
-
 namespace Algebra
 
 section
@@ -60,7 +58,7 @@ end
 
 section
 
-variable {R A : Type u} [CommRing R] [CommRing A] [Algebra R A]
+variable {R A : Type*} [CommRing R] [CommRing A] [Algebra R A]
 
 lemma unramifiedLocus_eq_compl_support :
     unramifiedLocus R A = (Module.support A Ω[A⁄R])ᶜ := by

--- a/Mathlib/RingTheory/Unramified/Pi.lean
+++ b/Mathlib/RingTheory/Unramified/Pi.lean
@@ -11,16 +11,14 @@ import Mathlib.RingTheory.Unramified.Basic
 
 ## Main result
 
-- `Algebra.FormallyUnramified.pi_iff`: If `I` is finite, `Π i : I, A i` is `R`-formally-smooth
-  if and only if each `A i` is `R`-formally-smooth.
+- `Algebra.FormallyUnramified.pi_iff`: If `I` is finite, `Π i : I, A i` is `R`-formally-unramified
+  if and only if each `A i` is `R`-formally-unramified.
 
 -/
 
 namespace Algebra.FormallyUnramified
 
-universe u v
-
-variable {R : Type max u v} {I : Type v} [Finite I] (f : I → Type max u v)
+variable {R : Type*} {I : Type*} [Finite I] (f : I → Type*)
 variable [CommRing R] [∀ i, CommRing (f i)] [∀ i, Algebra R (f i)]
 
 theorem pi_iff :


### PR DESCRIPTION
This PR makes `FormallySmooth`, `FormallyEtale`, and `FormallyUnramified` universe-polymorphic.

In particular, the constructor `FormallySmooth.comp_surjective'` now talks about rings in a fixed universe, and then the lemma `FormallySmooth.comp_surjective` (without the prime) talks about any arbitrary universe. The same happens for `FormallyEtale.comp_bijective(')`.

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include at least one commit authored by each
co-author among the commits in the pull request. If necessary, you may 
create empty commits to indicate co-authorship, using commands like so:

git commit --author="Author Name <author@email.com>" --allow-empty -m "add Author Name as coauthor"

When merging, all the commits will be squashed into a single commit listing all co-authors.

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
