### PR TITLE
[Merged by Bors] - feat(Algebra/BigOperators/Finsupp/Fin): add finTwoArrowEquiv

### DIFF
--- a/Mathlib/Algebra/BigOperators/Finsupp/Fin.lean
+++ b/Mathlib/Algebra/BigOperators/Finsupp/Fin.lean
@@ -29,4 +29,34 @@ lemma sum_cons' [Zero M] [AddCommMonoid N] (n : ℕ) (σ : Fin n →₀ M) (i : 
   simp_rw [Fin.sum_univ_succ, cons_zero, cons_succ]
   congr
 
+theorem ofSupportFinite_fin_two_eq (n : Fin 2 →₀ ℕ) :
+    ofSupportFinite ![n 0, n 1] (Set.toFinite _) = n := by
+  rw [Finsupp.ext_iff, Fin.forall_fin_two]
+  exact ⟨rfl, rfl⟩
+
 end Finsupp
+
+section Fin2
+
+variable (X : Type*) [Zero X]
+
+/-- The space of finitely supported functions `Fin 2 →₀ α` is equivalent to `α × α`.
+See also `finTwoArrowEquiv`. -/
+@[simps -fullyApplied]
+noncomputable def finTwoArrowEquiv' : (Fin 2 →₀ X) ≃ (X × X) where
+  toFun x     := (x 0, x 1)
+  invFun x    := Finsupp.ofSupportFinite ![x.1, x.2] (Set.toFinite _)
+  left_inv x  := by
+    simp only [Fin.isValue, Finsupp.ext_iff, Fin.forall_fin_two]
+    exact ⟨rfl, rfl⟩
+  right_inv x := rfl
+
+theorem finTwoArrowEquiv'_sum_eq {d : ℕ × ℕ} :
+    (((finTwoArrowEquiv' ℕ).symm d).sum fun _ n ↦ n) = d.1 + d.2 := by
+  simp [Finsupp.sum, finTwoArrowEquiv'_symm_apply, Finsupp.ofSupportFinite_coe]
+  rw [Finset.sum_subset (Finset.subset_univ _)
+    (fun _ _ h ↦ by simpa [Finsupp.ofSupportFinite_coe] using h)]
+  simp [Fin.sum_univ_two, Fin.isValue, Matrix.cons_val_zero, Matrix.cons_val_one,
+    Matrix.cons_val_fin_one]
+
+end Fin2


### PR DESCRIPTION
Co-authored by: @AntoineChambert-Loir

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include at least one commit authored by each
co-author among the commits in the pull request. If necessary, you may 
create empty commits to indicate co-authorship, using commands like so:

git commit --author="Author Name <author@email.com>" --allow-empty -m "add Author Name as coauthor"

When merging, all the commits will be squashed into a single commit listing all co-authors.

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
