### PR TITLE
[Merged by Bors] - chore: rename IrreducibleCloseds fields to match naming convention

### DIFF
--- a/Mathlib/Topology/KrullDimension.lean
+++ b/Mathlib/Topology/KrullDimension.lean
@@ -35,8 +35,8 @@ def IrreducibleCloseds.map {f : X → Y} (hf1 : Continuous f) (hf2 : IsClosedMap
     (c : IrreducibleCloseds X) :
     IrreducibleCloseds Y where
   carrier := f '' c
-  is_irreducible' := c.is_irreducible'.image f hf1.continuousOn
-  is_closed' := hf2 c c.is_closed'
+  isIrreducible' := c.isIrreducible.image f hf1.continuousOn
+  isClosed' := hf2 c c.isClosed
 
 /--
 Taking images under a closed embedding is strictly monotone on the preorder of irreducible closeds.

--- a/Mathlib/Topology/Sets/Closeds.lean
+++ b/Mathlib/Topology/Sets/Closeds.lean
@@ -362,8 +362,8 @@ end Clopens
 structure IrreducibleCloseds (α : Type*) [TopologicalSpace α] where
   /-- the carrier set, i.e. the points in this set -/
   carrier : Set α
-  is_irreducible' : IsIrreducible carrier
-  is_closed' : IsClosed carrier
+  isIrreducible' : IsIrreducible carrier
+  isClosed' : IsClosed carrier
 
 namespace IrreducibleCloseds
 
@@ -374,9 +374,13 @@ instance : SetLike (IrreducibleCloseds α) α where
 instance : CanLift (Set α) (IrreducibleCloseds α) (↑) (fun s ↦ IsIrreducible s ∧ IsClosed s) where
   prf s hs := ⟨⟨s, hs.1, hs.2⟩, rfl⟩
 
-theorem isIrreducible (s : IrreducibleCloseds α) : IsIrreducible (s : Set α) := s.is_irreducible'
+theorem isIrreducible (s : IrreducibleCloseds α) : IsIrreducible (s : Set α) := s.isIrreducible'
 
-theorem isClosed (s : IrreducibleCloseds α) : IsClosed (s : Set α) := s.is_closed'
+@[deprecated (since := "2025-10-14")] alias is_irreducible' := isIrreducible
+
+theorem isClosed (s : IrreducibleCloseds α) : IsClosed (s : Set α) := s.isClosed'
+
+@[deprecated (since := "2025-10-14")] alias is_closed' := isClosed
 
 /-- See Note [custom simps projection]. -/
 def Simps.coe (s : IrreducibleCloseds α) : Set α := s


### PR DESCRIPTION
---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include at least one commit authored by each
co-author among the commits in the pull request. If necessary, you may 
create empty commits to indicate co-authorship, using commands like so:

git commit --author="Author Name <author@email.com>" --allow-empty -m "add Author Name as coauthor"

When merging, all the commits will be squashed into a single commit listing all co-authors.

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
