### PR TITLE
fix(LinearAlgebra/Alternating/Basic): avoid deep recursion in MultilinearMap.alternatization

### DIFF
--- a/Mathlib/LinearAlgebra/Alternating/Basic.lean
+++ b/Mathlib/LinearAlgebra/Alternating/Basic.lean
@@ -813,7 +813,7 @@ private theorem alternization_map_eq_zero_of_eq_aux (m : MultilinearMap R (fun _
 
 /-- Produce an `AlternatingMap` out of a `MultilinearMap`, by summing over all argument
 permutations. -/
-def alternatization : MultilinearMap R (fun _ : ι => M) N' →+ M [⋀^ι]→ₗ[R] N' where
+irreducible_def alternatization : MultilinearMap R (fun _ : ι => M) N' →+ M [⋀^ι]→ₗ[R] N' where
   toFun m :=
     { ∑ σ : Perm ι, Equiv.Perm.sign σ • m.domDomCongr σ with
       toFun := ⇑(∑ σ : Perm ι, Equiv.Perm.sign σ • m.domDomCongr σ)
@@ -829,12 +829,14 @@ def alternatization : MultilinearMap R (fun _ : ι => M) N' →+ M [⋀^ι]→�
       zero_apply, smul_zero, Finset.sum_const_zero, AlternatingMap.zero_apply]
 
 theorem alternatization_coeFn (m : MultilinearMap R (fun _ : ι => M) N') :
-    ⇑(alternatization m) = (∑ σ : Perm ι, Equiv.Perm.sign σ • m.domDomCongr σ :) :=
+    ⇑(alternatization m) = (∑ σ : Perm ι, Equiv.Perm.sign σ • m.domDomCongr σ :) := by
+  rw [alternatization_def]
   rfl
 
 theorem alternatization_coe (m : MultilinearMap R (fun _ : ι => M) N') :
-    ↑(alternatization m) = (∑ σ : Perm ι, Equiv.Perm.sign σ • m.domDomCongr σ :) :=
-  coe_injective rfl
+    ↑(alternatization m) = (∑ σ : Perm ι, Equiv.Perm.sign σ • m.domDomCongr σ :) := by
+  rw [alternatization_def]
+  exact coe_injective rfl
 
 theorem alternatization_apply (m : MultilinearMap R (fun _ : ι => M) N') (v : ι → M) :
     alternatization m v = ∑ σ : Perm ι, Equiv.Perm.sign σ • m.domDomCongr σ v := by

--- a/Mathlib/LinearAlgebra/Alternating/Basic.lean
+++ b/Mathlib/LinearAlgebra/Alternating/Basic.lean
@@ -828,7 +828,7 @@ def alternatization : MultilinearMap R (fun _ : ι => M) N' →+ M [⋀^ι]→�
     simp only [mk_coe, AlternatingMap.coe_mk, sum_apply, smul_apply, domDomCongr_apply,
       zero_apply, smul_zero, Finset.sum_const_zero, AlternatingMap.zero_apply]
 
-theorem alternatization_def (m : MultilinearMap R (fun _ : ι => M) N') :
+theorem alternatization_coeFn (m : MultilinearMap R (fun _ : ι => M) N') :
     ⇑(alternatization m) = (∑ σ : Perm ι, Equiv.Perm.sign σ • m.domDomCongr σ :) :=
   rfl
 
@@ -838,7 +838,7 @@ theorem alternatization_coe (m : MultilinearMap R (fun _ : ι => M) N') :
 
 theorem alternatization_apply (m : MultilinearMap R (fun _ : ι => M) N') (v : ι → M) :
     alternatization m v = ∑ σ : Perm ι, Equiv.Perm.sign σ • m.domDomCongr σ v := by
-  simp only [alternatization_def, smul_apply, sum_apply]
+  simp only [alternatization_coeFn, smul_apply, sum_apply]
 
 end MultilinearMap
 
@@ -850,7 +850,7 @@ theorem coe_alternatization [DecidableEq ι] [Fintype ι] (a : M [⋀^ι]→ₗ[
     MultilinearMap.alternatization (a : MultilinearMap R (fun _ => M) N')
     = Nat.factorial (Fintype.card ι) • a := by
   apply AlternatingMap.coe_injective
-  simp_rw [MultilinearMap.alternatization_def, ← coe_domDomCongr, domDomCongr_perm, coe_smul,
+  simp_rw [MultilinearMap.alternatization_coeFn, ← coe_domDomCongr, domDomCongr_perm, coe_smul,
     smul_smul, Int.units_mul_self, one_smul, Finset.sum_const, Finset.card_univ, Fintype.card_perm,
     ← coe_multilinearMap, coe_smul]
 
@@ -866,7 +866,7 @@ theorem compMultilinearMap_alternatization (g : N' →ₗ[R] N'₂)
     MultilinearMap.alternatization (g.compMultilinearMap f)
       = g.compAlternatingMap (MultilinearMap.alternatization f) := by
   ext
-  simp [MultilinearMap.alternatization_def]
+  simp [MultilinearMap.alternatization_coeFn]
 
 end LinearMap
 

--- a/Mathlib/LinearAlgebra/Matrix/SpecialLinearGroup.lean
+++ b/Mathlib/LinearAlgebra/Matrix/SpecialLinearGroup.lean
@@ -498,6 +498,6 @@ lemma S_mul_S_eq : (S : Matrix (Fin 2) (Fin 2) ℤ) * S = -1 := by
 
 lemma T_S_rel : S • S • S • T • S • T • S = T⁻¹ := by
   ext i j
-  fin_cases i <;> fin_cases j <;> rfl
+  fin_cases i <;> fin_cases j <;> simp [S, T]
 
 end ModularGroup

--- a/MathlibTest/DetOne.lean
+++ b/MathlibTest/DetOne.lean
@@ -1,0 +1,25 @@
+import Mathlib.LinearAlgebra.Determinant
+
+/--
+Check that using Matrix.det_one for an explicit matrix doesn't cause a
+(kernel) deep recursion detected
+error, see
+https://leanprover.zulipchat.com/#narrow/stream/287929-mathlib4/topic/kernel.20deep.20recursion.20detected
+-/
+
+example : (1 : Matrix (Fin 8) (Fin 8) ℚ).det = 1 := by
+  rw [Matrix.det_one]
+
+example : (1 : Matrix (Fin 8) (Fin 8) ℚ).det = 1 := Matrix.det_one
+
+example : (1 : Matrix (Fin 8) (Fin 8) ℚ).det = 1 := by
+  have := Matrix.det_one (n := Fin 8) (R := ℚ)
+  exact this
+
+/--
+warning: declaration uses 'sorry'
+-/
+#guard_msgs in
+example : (1 : Matrix (Fin 8) (Fin 8) ℚ).det = 1 := by
+  unfold Matrix.det Matrix.detRowAlternating MultilinearMap.alternatization
+  sorry


### PR DESCRIPTION
Makes `MultilinearMap.alternatization` an `irreducible_def` to avoid errors
about deep recursion.

This is an update of #15045 according to the suggestions in [this zulip thread](https://leanprover.zulipchat.com/#narrow/channel/287929-mathlib4/topic/kernel.20deep.20recursion.20detected/near/454301820).

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include at least one commit authored by each
co-author among the commits in the pull request. If necessary, you may 
create empty commits to indicate co-authorship, using commands like so:

git commit --author="Author Name <author@email.com>" --allow-empty -m "add Author Name as coauthor"

When merging, all the commits will be squashed into a single commit listing all co-authors.

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
