### PR TITLE
[Merged by Bors] - chore: add tests about the differential geometry elaborators inferring the type of x

### DIFF
--- a/MathlibTest/DifferentialGeometry/Notation.lean
+++ b/MathlibTest/DifferentialGeometry/Notation.lean
@@ -844,7 +844,7 @@ section
 variable {EM' : Type*} [NormedAddCommGroup EM']
   [NormedSpace 𝕜 EM'] {H' : Type*} [TopologicalSpace H'] (I' : ModelWithCorners 𝕜 EM' H')
   {M' : Type*} [TopologicalSpace M'] [ChartedSpace H' M']
-variable {f : M → M'} {s: Set M}
+  {f : M → M'} {s : Set M}
 
 /-- info: {x | MDifferentiableAt I I' f x} : Set M -/
 #guard_msgs in

--- a/MathlibTest/DifferentialGeometry/Notation.lean
+++ b/MathlibTest/DifferentialGeometry/Notation.lean
@@ -862,7 +862,10 @@ variable {f : M → M'} {s: Set M}
 #guard_msgs in
 #check {x | CMDiffAt[s] 2 f x}
 
--- TODO: this errors, separate issue! #check {x | CMDiffAt ∞ f x}
+open ContDiff in -- for the ∞ notation
+/-- info: {x | ContMDiffAt I I' ∞ f x} : Set M -/
+#guard_msgs in
+#check {x | CMDiffAt ∞ f x}
 
 /-- info: {x | Injective ⇑(mfderiv I I' f x)} : Set M -/
 #guard_msgs in

--- a/MathlibTest/DifferentialGeometry/Notation.lean
+++ b/MathlibTest/DifferentialGeometry/Notation.lean
@@ -838,6 +838,42 @@ variable {f : E → E'} {s : Set E} {x : E}
 
 end smoothness
 
+-- Inferring the type of `x` for all ContMDiff/MDifferentiable{Within}At elaborators.
+section
+
+variable {EM' : Type*} [NormedAddCommGroup EM']
+  [NormedSpace 𝕜 EM'] {H' : Type*} [TopologicalSpace H'] (I' : ModelWithCorners 𝕜 EM' H')
+  {M' : Type*} [TopologicalSpace M'] [ChartedSpace H' M']
+variable {f : M → M'} {s: Set M}
+
+/-- info: {x | MDifferentiableAt I I' f x} : Set M -/
+#guard_msgs in
+#check {x | MDiffAt f x}
+
+/-- info: {x | MDifferentiableWithinAt I I' f s x} : Set M -/
+#guard_msgs in
+#check {x | MDiffAt[s] f x}
+
+/-- info: {x | ContMDiffAt I I' ⊤ f x} : Set M -/
+#guard_msgs in
+#check {x | CMDiffAt ⊤ f x}
+
+/-- info: {x | ContMDiffWithinAt I I' 2 f s x} : Set M -/
+#guard_msgs in
+#check {x | CMDiffAt[s] 2 f x}
+
+-- TODO: this errors, separate issue! #check {x | CMDiffAt ∞ f x}
+
+/-- info: {x | Injective ⇑(mfderiv I I' f x)} : Set M -/
+#guard_msgs in
+#check {x | Function.Injective (mfderiv% f x) }
+
+/-- info: {x | Surjective ⇑(mfderivWithin I I' f s x)} : Set M -/
+#guard_msgs in
+#check {x | Function.Surjective (mfderiv[s] f x) }
+
+end
+
 section trace
 
 /- Test that basic tracing works. -/

--- a/MathlibTest/DifferentialGeometry/NotationAdvanced.lean
+++ b/MathlibTest/DifferentialGeometry/NotationAdvanced.lean
@@ -6,6 +6,7 @@ import Mathlib.Geometry.Manifold.MFDeriv.SpecificFunctions
 import Mathlib.Geometry.Manifold.BumpFunction
 import Mathlib.Geometry.Manifold.VectorBundle.MDifferentiable
 import Mathlib.Geometry.Manifold.VectorField.LieBracket
+
 /-!
 # Tests for the differential geometry elaborators which require stronger imports
 -/


### PR DESCRIPTION
A first version of the in-progress elaborator for `IsImmersionAt` had a bug where this fails.
It turns out this already worked for `CMDiffAt` and friends (without any further changes); let's add a test for it.

---

- [x] depends on: #30412
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include at least one commit authored by each
co-author among the commits in the pull request. If necessary, you may 
create empty commits to indicate co-authorship, using commands like so:

git commit --author="Author Name <author@email.com>" --allow-empty -m "add Author Name as coauthor"

When merging, all the commits will be squashed into a single commit listing all co-authors.

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
