### PR TITLE
[Merged by Bors] - feat(Combinatorics/Quiver): add congruence theorems for reflexive prefunctors

### DIFF
--- a/Mathlib/Combinatorics/Quiver/ReflQuiver.lean
+++ b/Mathlib/Combinatorics/Quiver/ReflQuiver.lean
@@ -122,6 +122,17 @@ notation "𝟭rq" => id
 theorem congr_map {U V : Type*} [Quiver U] [Quiver V] (F : U ⥤q V) {X Y : U} {f g : X ⟶ Y}
     (h : f = g) : F.map f = F.map g := congrArg F.map h
 
+/-- An equality of refl prefunctors gives an equality on objects. -/
+theorem congr_obj {U V : Type*} [ReflQuiver U] [ReflQuiver V] {F G : U ⥤rq V}
+    (e : F = G) (X : U) : F.obj X = G.obj X := by cases e; rfl
+
+/-- An equality of refl prefunctors gives an equality on homs. -/
+theorem congr_hom {U V : Type*} [ReflQuiver U] [ReflQuiver V] {F G : U ⥤rq V}
+    (e : F = G) {X Y : U} (f : X ⟶ Y) :
+    Quiver.homOfEq (F.map f) (congr_obj e X) (congr_obj e Y) = G.map f := by
+  subst e
+  simp
+
 end ReflPrefunctor
 
 /-- A functor has an underlying refl prefunctor. -/


### PR DESCRIPTION
An equality of reflexive prefunctors gives an equality on homs (`ReflPrefunctor.congr_hom`) and objects (`ReflPrefunctor.congr_obj`). Mirrors the existing theorems `Prefunctor.congr_hom` and `Prefunctor.congr_obj`.

---
This should make the API of `ReflPrefunctor` easier to use.

<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include at least one commit authored by each
co-author among the commits in the pull request. If necessary, you may 
create empty commits to indicate co-authorship, using commands like so:

git commit --author="Author Name <author@email.com>" --allow-empty -m "add Author Name as coauthor"

When merging, all the commits will be squashed into a single commit listing all co-authors.

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
