### PR TITLE
[Merged by Bors] - chore(Data/List/Perm): golf `Perm.bagInter_right` using `grind`

### DIFF
--- a/Mathlib/Data/List/Perm/Lattice.lean
+++ b/Mathlib/Data/List/Perm/Lattice.lean
@@ -28,18 +28,7 @@ variable [DecidableEq α]
 
 theorem Perm.bagInter_right {l₁ l₂ : List α} (t : List α) (h : l₁ ~ l₂) :
     l₁.bagInter t ~ l₂.bagInter t := by
-  induction h generalizing t with
-  | nil => simp
-  | cons x => by_cases x ∈ t <;> simp [*]
-  | swap x y =>
-    by_cases h : x = y
-    · simp [h]
-    by_cases xt : x ∈ t <;> by_cases yt : y ∈ t
-    · simp [xt, yt, mem_erase_of_ne h, mem_erase_of_ne (Ne.symm h), erase_comm, swap]
-    · simp [xt, yt, mt mem_of_mem_erase]
-    · simp [xt, yt, mt mem_of_mem_erase]
-    · simp [xt, yt]
-  | trans _ _ ih_1 ih_2 => exact (ih_1 _).trans (ih_2 _)
+  induction h generalizing t with grind
 
 theorem Perm.bagInter_left (l : List α) {t₁ t₂ : List α} (p : t₁ ~ t₂) :
     l.bagInter t₁ = l.bagInter t₂ := by


### PR DESCRIPTION
---
<details>
<summary>Show trace profiling of <code>Perm.bagInter_right</code>: 43 ms before, 134 ms after </summary>

### Trace profiling of `Perm.bagInter_right` before PR 30589
```diff
diff --git a/Mathlib/Data/List/Perm/Lattice.lean b/Mathlib/Data/List/Perm/Lattice.lean
index 96c0389c29..b71bc44f7f 100644
--- a/Mathlib/Data/List/Perm/Lattice.lean
+++ b/Mathlib/Data/List/Perm/Lattice.lean
@@ -26,6 +26,7 @@ open Perm (swap)
 
 variable [DecidableEq α]
 
+set_option trace.profiler true in
 theorem Perm.bagInter_right {l₁ l₂ : List α} (t : List α) (h : l₁ ~ l₂) :
     l₁.bagInter t ~ l₂.bagInter t := by
   induction h generalizing t with
```
```
ℹ [454/454] Built Mathlib.Data.List.Perm.Lattice (769ms)
info: Mathlib/Data/List/Perm/Lattice.lean:30:0: [Elab.async] [0.044658] elaborating proof of List.Perm.bagInter_right
  [Elab.definition.value] [0.043499] List.Perm.bagInter_right
    [Elab.step] [0.042758] induction h generalizing t with
          | nil => simp
          | cons x => by_cases x ∈ t <;> simp [*]
          | swap x y =>
            by_cases h : x = y
            · simp [h]
            by_cases xt : x ∈ t <;> by_cases yt : y ∈ t
            · simp [xt, yt, mem_erase_of_ne h, mem_erase_of_ne (Ne.symm h), erase_comm, swap]
            · simp [xt, yt, mt mem_of_mem_erase]
            · simp [xt, yt, mt mem_of_mem_erase]
            · simp [xt, yt]
          | trans _ _ ih_1 ih_2 => exact (ih_1 _).trans (ih_2 _)
      [Elab.step] [0.042746] induction h generalizing t with
            | nil => simp
            | cons x => by_cases x ∈ t <;> simp [*]
            | swap x y =>
              by_cases h : x = y
              · simp [h]
              by_cases xt : x ∈ t <;> by_cases yt : y ∈ t
              · simp [xt, yt, mem_erase_of_ne h, mem_erase_of_ne (Ne.symm h), erase_comm, swap]
              · simp [xt, yt, mt mem_of_mem_erase]
              · simp [xt, yt, mt mem_of_mem_erase]
              · simp [xt, yt]
            | trans _ _ ih_1 ih_2 => exact (ih_1 _).trans (ih_2 _)
        [Elab.step] [0.042738] induction h generalizing t with
            | nil => simp
            | cons x => by_cases x ∈ t <;> simp [*]
            | swap x y =>
              by_cases h : x = y
              · simp [h]
              by_cases xt : x ∈ t <;> by_cases yt : y ∈ t
              · simp [xt, yt, mem_erase_of_ne h, mem_erase_of_ne (Ne.symm h), erase_comm, swap]
              · simp [xt, yt, mt mem_of_mem_erase]
              · simp [xt, yt, mt mem_of_mem_erase]
              · simp [xt, yt]
            | trans _ _ ih_1 ih_2 => exact (ih_1 _).trans (ih_2 _)
          [Elab.step] [0.034137] 
                by_cases h : x = y
                · simp [h]
                by_cases xt : x ∈ t <;> by_cases yt : y ∈ t
                · simp [xt, yt, mem_erase_of_ne h, mem_erase_of_ne (Ne.symm h), erase_comm, swap]
                · simp [xt, yt, mt mem_of_mem_erase]
                · simp [xt, yt, mt mem_of_mem_erase]
                · simp [xt, yt]
            [Elab.step] [0.034116] 
                  by_cases h : x = y
                  · simp [h]
                  by_cases xt : x ∈ t <;> by_cases yt : y ∈ t
                  · simp [xt, yt, mem_erase_of_ne h, mem_erase_of_ne (Ne.symm h), erase_comm, swap]
                  · simp [xt, yt, mt mem_of_mem_erase]
                  · simp [xt, yt, mt mem_of_mem_erase]
                  · simp [xt, yt]
              [Elab.step] [0.010183] · simp [xt, yt, mem_erase_of_ne h, mem_erase_of_ne (Ne.symm h), erase_comm, swap]
                [Elab.step] [0.010173] simp [xt, yt, mem_erase_of_ne h, mem_erase_of_ne (Ne.symm h), erase_comm, swap]
                  [Elab.step] [0.010168] simp [xt, yt, mem_erase_of_ne h, mem_erase_of_ne (Ne.symm h), erase_comm, swap]
                    [Elab.step] [0.010161] simp [xt, yt, mem_erase_of_ne h, mem_erase_of_ne (Ne.symm h), erase_comm,
                          swap]
Build completed successfully (454 jobs).
```

### Trace profiling of `Perm.bagInter_right` after PR 30589
```diff
diff --git a/Mathlib/Data/List/Perm/Lattice.lean b/Mathlib/Data/List/Perm/Lattice.lean
index 96c0389c29..e2a27287d8 100644
--- a/Mathlib/Data/List/Perm/Lattice.lean
+++ b/Mathlib/Data/List/Perm/Lattice.lean
@@ -26,20 +26,10 @@ open Perm (swap)
 
 variable [DecidableEq α]
 
+set_option trace.profiler true in
 theorem Perm.bagInter_right {l₁ l₂ : List α} (t : List α) (h : l₁ ~ l₂) :
     l₁.bagInter t ~ l₂.bagInter t := by
-  induction h generalizing t with
-  | nil => simp
-  | cons x => by_cases x ∈ t <;> simp [*]
-  | swap x y =>
-    by_cases h : x = y
-    · simp [h]
-    by_cases xt : x ∈ t <;> by_cases yt : y ∈ t
-    · simp [xt, yt, mem_erase_of_ne h, mem_erase_of_ne (Ne.symm h), erase_comm, swap]
-    · simp [xt, yt, mt mem_of_mem_erase]
-    · simp [xt, yt, mt mem_of_mem_erase]
-    · simp [xt, yt]
-  | trans _ _ ih_1 ih_2 => exact (ih_1 _).trans (ih_2 _)
+  induction h generalizing t with grind
 
 theorem Perm.bagInter_left (l : List α) {t₁ t₂ : List α} (p : t₁ ~ t₂) :
     l.bagInter t₁ = l.bagInter t₂ := by
```
```
ℹ [454/454] Built Mathlib.Data.List.Perm.Lattice (848ms)
info: Mathlib/Data/List/Perm/Lattice.lean:30:0: [Elab.async] [0.134701] elaborating proof of List.Perm.bagInter_right
  [Elab.definition.value] [0.133799] List.Perm.bagInter_right
    [Elab.step] [0.133622] induction h generalizing t with grind
      [Elab.step] [0.133610] induction h generalizing t with grind
        [Elab.step] [0.133599] induction h generalizing t with grind
          [Elab.step] [0.052692] grind
          [Elab.step] [0.064967] grind
info: Mathlib/Data/List/Perm/Lattice.lean:32:34: [Elab.async] [0.017325] Lean.addDecl
  [Kernel] [0.017314] ✅️ typechecking declarations [List.Perm.bagInter_right._proof_1_3]
Build completed successfully (454 jobs).
```
</details>

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include at least one commit authored by each
co-author among the commits in the pull request. If necessary, you may 
create empty commits to indicate co-authorship, using commands like so:

git commit --author="Author Name <author@email.com>" --allow-empty -m "add Author Name as coauthor"

When merging, all the commits will be squashed into a single commit listing all co-authors.

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
