### PR TITLE
[Merged by Bors] - chore(Data/Finset): golf `powersetCard_succ_insert` using `grind`

### DIFF
--- a/Mathlib/Data/Finset/Powerset.lean
+++ b/Mathlib/Data/Finset/Powerset.lean
@@ -222,14 +222,7 @@ theorem powersetCard_succ_insert [DecidableEq α] {x : α} {s : Finset α} (h : 
     powersetCard n.succ (insert x s) =
     powersetCard n.succ s ∪ (powersetCard n s).image (insert x) := by
   rw [powersetCard_eq_filter, powerset_insert, filter_union, ← powersetCard_eq_filter]
-  congr
-  rw [powersetCard_eq_filter, filter_image]
-  congr 1
-  ext t
-  simp only [mem_powerset, mem_filter, and_congr_right_iff]
-  intro ht
-  have : x ∉ t := fun H => h (ht H)
-  simp [card_insert_of_notMem this]
+  grind
 
 @[simp]
 lemma powersetCard_nonempty : (powersetCard n s).Nonempty ↔ n ≤ s.card := by


### PR DESCRIPTION
---
<details>
<summary>Show trace profiling of <code>powersetCard_succ_insert</code>: 27 ms before, 54 ms after </summary>

### Trace profiling of `powersetCard_succ_insert` before PR 30593
```diff
diff --git a/Mathlib/Data/Finset/Powerset.lean b/Mathlib/Data/Finset/Powerset.lean
index 360948612e..cdf67a5be6 100644
--- a/Mathlib/Data/Finset/Powerset.lean
+++ b/Mathlib/Data/Finset/Powerset.lean
@@ -218,6 +218,7 @@ theorem powersetCard_eq_filter {n} {s : Finset α} :
   ext
   simp [mem_powersetCard]
 
+set_option trace.profiler true in
 theorem powersetCard_succ_insert [DecidableEq α] {x : α} {s : Finset α} (h : x ∉ s) (n : ℕ) :
     powersetCard n.succ (insert x s) =
     powersetCard n.succ s ∪ (powersetCard n s).image (insert x) := by
```
```
ℹ [670/670] Built Mathlib.Data.Finset.Powerset (1.2s)
info: Mathlib/Data/Finset/Powerset.lean:222:0: [Elab.async] [0.027673] elaborating proof of Finset.powersetCard_succ_insert
  [Elab.definition.value] [0.026806] Finset.powersetCard_succ_insert
    [Elab.step] [0.026396] 
          rw [powersetCard_eq_filter, powerset_insert, filter_union, ← powersetCard_eq_filter]
          congr
          rw [powersetCard_eq_filter, filter_image]
          congr 1
          ext t
          simp only [mem_powerset, mem_filter, and_congr_right_iff]
          intro ht
          have : x ∉ t := fun H => h (ht H)
          simp [card_insert_of_notMem this]
      [Elab.step] [0.026387] 
            rw [powersetCard_eq_filter, powerset_insert, filter_union, ← powersetCard_eq_filter]
            congr
            rw [powersetCard_eq_filter, filter_image]
            congr 1
            ext t
            simp only [mem_powerset, mem_filter, and_congr_right_iff]
            intro ht
            have : x ∉ t := fun H => h (ht H)
            simp [card_insert_of_notMem this]
        [Elab.step] [0.010184] congr
Build completed successfully (670 jobs).
```

### Trace profiling of `powersetCard_succ_insert` after PR 30593
```diff
diff --git a/Mathlib/Data/Finset/Powerset.lean b/Mathlib/Data/Finset/Powerset.lean
index 360948612e..a4c6b0e1f2 100644
--- a/Mathlib/Data/Finset/Powerset.lean
+++ b/Mathlib/Data/Finset/Powerset.lean
@@ -218,18 +218,12 @@ theorem powersetCard_eq_filter {n} {s : Finset α} :
   ext
   simp [mem_powersetCard]
 
+set_option trace.profiler true in
 theorem powersetCard_succ_insert [DecidableEq α] {x : α} {s : Finset α} (h : x ∉ s) (n : ℕ) :
     powersetCard n.succ (insert x s) =
     powersetCard n.succ s ∪ (powersetCard n s).image (insert x) := by
   rw [powersetCard_eq_filter, powerset_insert, filter_union, ← powersetCard_eq_filter]
-  congr
-  rw [powersetCard_eq_filter, filter_image]
-  congr 1
-  ext t
-  simp only [mem_powerset, mem_filter, and_congr_right_iff]
-  intro ht
-  have : x ∉ t := fun H => h (ht H)
-  simp [card_insert_of_notMem this]
+  grind
 
 @[simp]
 lemma powersetCard_nonempty : (powersetCard n s).Nonempty ↔ n ≤ s.card := by
```
```
ℹ [670/670] Built Mathlib.Data.Finset.Powerset (1.1s)
info: Mathlib/Data/Finset/Powerset.lean:222:0: [Elab.async] [0.054375] elaborating proof of Finset.powersetCard_succ_insert
  [Elab.definition.value] [0.053777] Finset.powersetCard_succ_insert
    [Elab.step] [0.053567] 
          rw [powersetCard_eq_filter, powerset_insert, filter_union, ← powersetCard_eq_filter]
          grind
      [Elab.step] [0.053561] 
            rw [powersetCard_eq_filter, powerset_insert, filter_union, ← powersetCard_eq_filter]
            grind
        [Elab.step] [0.050257] grind
Build completed successfully (670 jobs).
```
</details>

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include at least one commit authored by each
co-author among the commits in the pull request. If necessary, you may 
create empty commits to indicate co-authorship, using commands like so:

git commit --author="Author Name <author@email.com>" --allow-empty -m "add Author Name as coauthor"

When merging, all the commits will be squashed into a single commit listing all co-authors.

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
