### PR TITLE
[Merged by Bors] - feat(Analysis/SpecialFunctions/Trigonometric/Angle): equality from equality of twice angles

### DIFF
--- a/Mathlib/Analysis/SpecialFunctions/Trigonometric/Angle.lean
+++ b/Mathlib/Analysis/SpecialFunctions/Trigonometric/Angle.lean
@@ -487,6 +487,16 @@ theorem toReal_pi : (π : Angle).toReal = π := by
 @[simp]
 theorem toReal_eq_pi_iff {θ : Angle} : θ.toReal = π ↔ θ = π := by rw [← toReal_inj, toReal_pi]
 
+lemma toReal_neg_eq_neg_toReal_iff {θ : Angle} : (-θ).toReal = -(θ.toReal) ↔ θ ≠ π := by
+  nth_rw 1 [← coe_toReal θ, ← coe_neg, toReal_coe_eq_self_iff]
+  constructor
+  · rintro ⟨h, h'⟩ rfl
+    simp at h
+  · intro h
+    rw [neg_lt_neg_iff]
+    have h' : θ.toReal ≠ π := by simp [h]
+    exact ⟨(toReal_le_pi θ).lt_of_ne h', by linarith [neg_pi_lt_toReal θ]⟩
+
 theorem pi_ne_zero : (π : Angle) ≠ 0 := by
   rw [← toReal_injective.ne_iff, toReal_pi, toReal_zero]
   exact Real.pi_ne_zero
@@ -585,6 +595,29 @@ theorem two_nsmul_toReal_eq_two_mul_add_two_pi {θ : Angle} :
 theorem two_zsmul_toReal_eq_two_mul_add_two_pi {θ : Angle} :
     ((2 : ℤ) • θ).toReal = 2 * θ.toReal + 2 * π ↔ θ.toReal ≤ -π / 2 := by
   rw [two_zsmul, ← two_nsmul, two_nsmul_toReal_eq_two_mul_add_two_pi]
+
+lemma two_nsmul_eq_iff_eq_of_abs_toReal_lt_pi_div_two {θ ψ : Angle} (hθ : |θ.toReal| < π / 2)
+    (hψ : |ψ.toReal| < π / 2) : (2 : ℕ) • θ = (2 : ℕ) • ψ ↔ θ = ψ := by
+  constructor
+  · intro h
+    rw [two_nsmul_eq_iff] at h
+    rcases h with rfl | rfl
+    · rfl
+    · rw [abs_lt] at hψ hθ
+      rw [← coe_toReal ψ, ← coe_add] at hθ
+      by_cases hψ' : ψ.toReal ≤ 0
+      · have hψt : -π < ψ.toReal + π ∧ ψ.toReal + π ≤ π := ⟨by linarith, by linarith⟩
+        rw [toReal_coe_eq_self_iff.2 hψt] at hθ
+        linarith
+      · have hψt : π < ψ.toReal + π ∧ ψ.toReal + π ≤ 3 * π := ⟨by linarith, by linarith⟩
+        rw [toReal_coe_eq_self_sub_two_pi_iff.2 hψt] at hθ
+        linarith
+  · rintro rfl
+    rfl
+
+lemma two_zsmul_eq_iff_eq_of_abs_toReal_lt_pi_div_two {θ ψ : Angle} (hθ : |θ.toReal| < π / 2)
+    (hψ : |ψ.toReal| < π / 2) : (2 : ℤ) • θ = (2 : ℤ) • ψ ↔ θ = ψ := by
+  simp_rw [two_zsmul, ← two_nsmul, two_nsmul_eq_iff_eq_of_abs_toReal_lt_pi_div_two hθ hψ]
 
 @[simp]
 theorem sin_toReal (θ : Angle) : Real.sin θ.toReal = sin θ := by


### PR DESCRIPTION
Add lemmas that two angles less than `π / 2` are equal if and only if twice those angles are equal, along with a separate lemma

```lean
lemma toReal_neg_eq_neg_toReal_iff {θ : Angle} : (-θ).toReal = -(θ.toReal) ↔ θ ≠ π := by
```

which isn't directly connected but turns out to be useful in the same application (dealing with angles in right-angled triangles that are less then `π / 2`, when you have two such triangles that are oppositely-oriented).


---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include at least one commit authored by each
co-author among the commits in the pull request. If necessary, you may 
create empty commits to indicate co-authorship, using commands like so:

git commit --author="Author Name <author@email.com>" --allow-empty -m "add Author Name as coauthor"

When merging, all the commits will be squashed into a single commit listing all co-authors.

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
