### PR TITLE
[Merged by Bors] - chore: generalize Egorov file to measurable edist assumption

### DIFF
--- a/Mathlib/MeasureTheory/Function/ConvergenceInMeasure.lean
+++ b/Mathlib/MeasureTheory/Function/ConvergenceInMeasure.lean
@@ -149,16 +149,16 @@ section ExistsSeqTendstoAe
 variable [PseudoEMetricSpace E]
 variable {f : ℕ → α → E} {g : α → E}
 
-/-- Auxiliary lemma for `tendstoInMeasure_of_tendsto_ae`. -/
-theorem tendstoInMeasure_of_tendsto_ae_of_stronglyMeasurable [IsFiniteMeasure μ]
-    (hf : ∀ n, StronglyMeasurable (f n)) (hg : StronglyMeasurable g)
+theorem tendstoInMeasure_of_tendsto_ae_of_stronglyMeasurable_edist [IsFiniteMeasure μ]
+    (hf : ∀ n, StronglyMeasurable (fun a ↦ edist (f n a) (g a)))
     (hfg : ∀ᵐ x ∂μ, Tendsto (fun n => f n x) atTop (𝓝 (g x))) : TendstoInMeasure μ f atTop g := by
   refine fun ε hε => ENNReal.tendsto_atTop_zero.mpr fun δ hδ => ?_
   by_cases hδi : δ = ∞
   · simp only [hδi, imp_true_iff, le_top, exists_const]
   lift δ to ℝ≥0 using hδi
   rw [gt_iff_lt, ENNReal.coe_pos, ← NNReal.coe_pos] at hδ
-  obtain ⟨t, _, ht, hunif⟩ := tendstoUniformlyOn_of_ae_tendsto' hf hg hfg hδ
+  obtain ⟨t, _, ht, hunif⟩ :=
+    tendstoUniformlyOn_of_ae_tendsto_of_stronglyMeasurable_edist' hf hfg hδ
   rw [ENNReal.ofReal_coe_nnreal] at ht
   rw [EMetric.tendstoUniformlyOn_iff] at hunif
   obtain ⟨N, hN⟩ := eventually_atTop.1 (hunif ε hε)
@@ -168,6 +168,12 @@ theorem tendstoInMeasure_of_tendsto_ae_of_stronglyMeasurable [IsFiniteMeasure μ
   intro x hx
   rw [Set.mem_compl_iff, Set.notMem_setOf_iff, edist_comm, not_le]
   exact hN n hn x hx
+
+/-- Auxiliary lemma for `tendstoInMeasure_of_tendsto_ae`. -/
+theorem tendstoInMeasure_of_tendsto_ae_of_stronglyMeasurable [IsFiniteMeasure μ]
+    (hf : ∀ n, StronglyMeasurable (f n)) (hg : StronglyMeasurable g)
+    (hfg : ∀ᵐ x ∂μ, Tendsto (fun n => f n x) atTop (𝓝 (g x))) : TendstoInMeasure μ f atTop g :=
+  tendstoInMeasure_of_tendsto_ae_of_stronglyMeasurable_edist (fun n ↦ (hf n).edist hg) hfg
 
 /-- Convergence a.e. implies convergence in measure in a finite measure space. -/
 theorem tendstoInMeasure_of_tendsto_ae [IsFiniteMeasure μ] (hf : ∀ n, AEStronglyMeasurable (f n) μ)

--- a/Mathlib/MeasureTheory/Function/ConvergenceInMeasure.lean
+++ b/Mathlib/MeasureTheory/Function/ConvergenceInMeasure.lean
@@ -169,19 +169,13 @@ theorem tendstoInMeasure_of_tendsto_ae_of_stronglyMeasurable_edist [IsFiniteMeas
   rw [Set.mem_compl_iff, Set.notMem_setOf_iff, edist_comm, not_le]
   exact hN n hn x hx
 
-/-- Auxiliary lemma for `tendstoInMeasure_of_tendsto_ae`. -/
-theorem tendstoInMeasure_of_tendsto_ae_of_stronglyMeasurable [IsFiniteMeasure μ]
-    (hf : ∀ n, StronglyMeasurable (f n)) (hg : StronglyMeasurable g)
-    (hfg : ∀ᵐ x ∂μ, Tendsto (fun n => f n x) atTop (𝓝 (g x))) : TendstoInMeasure μ f atTop g :=
-  tendstoInMeasure_of_tendsto_ae_of_stronglyMeasurable_edist (fun n ↦ (hf n).edist hg) hfg
-
 /-- Convergence a.e. implies convergence in measure in a finite measure space. -/
 theorem tendstoInMeasure_of_tendsto_ae [IsFiniteMeasure μ] (hf : ∀ n, AEStronglyMeasurable (f n) μ)
     (hfg : ∀ᵐ x ∂μ, Tendsto (fun n => f n x) atTop (𝓝 (g x))) : TendstoInMeasure μ f atTop g := by
   have hg : AEStronglyMeasurable g μ := aestronglyMeasurable_of_tendsto_ae _ hf hfg
   refine TendstoInMeasure.congr (fun i => (hf i).ae_eq_mk.symm) hg.ae_eq_mk.symm ?_
-  refine tendstoInMeasure_of_tendsto_ae_of_stronglyMeasurable
-    (fun i => (hf i).stronglyMeasurable_mk) hg.stronglyMeasurable_mk ?_
+  refine tendstoInMeasure_of_tendsto_ae_of_stronglyMeasurable_edist
+    (fun n ↦ (hf n).stronglyMeasurable_mk.edist hg.stronglyMeasurable_mk) ?_
   have hf_eq_ae : ∀ᵐ x ∂μ, ∀ n, (hf n).mk (f n) x = f n x :=
     ae_all_iff.mpr fun n => (hf n).ae_eq_mk.symm
   filter_upwards [hf_eq_ae, hg.ae_eq_mk, hfg] with x hxf hxg hxfg

--- a/Mathlib/MeasureTheory/Function/ConvergenceInMeasure.lean
+++ b/Mathlib/MeasureTheory/Function/ConvergenceInMeasure.lean
@@ -149,8 +149,8 @@ section ExistsSeqTendstoAe
 variable [PseudoEMetricSpace E]
 variable {f : ℕ → α → E} {g : α → E}
 
-theorem tendstoInMeasure_of_tendsto_ae_of_stronglyMeasurable_edist [IsFiniteMeasure μ]
-    (hf : ∀ n, StronglyMeasurable (fun a ↦ edist (f n a) (g a)))
+theorem tendstoInMeasure_of_tendsto_ae_of_measurable_edist [IsFiniteMeasure μ]
+    (hf : ∀ n, Measurable (fun a ↦ edist (f n a) (g a)))
     (hfg : ∀ᵐ x ∂μ, Tendsto (fun n => f n x) atTop (𝓝 (g x))) : TendstoInMeasure μ f atTop g := by
   refine fun ε hε => ENNReal.tendsto_atTop_zero.mpr fun δ hδ => ?_
   by_cases hδi : δ = ∞
@@ -158,7 +158,7 @@ theorem tendstoInMeasure_of_tendsto_ae_of_stronglyMeasurable_edist [IsFiniteMeas
   lift δ to ℝ≥0 using hδi
   rw [gt_iff_lt, ENNReal.coe_pos, ← NNReal.coe_pos] at hδ
   obtain ⟨t, _, ht, hunif⟩ :=
-    tendstoUniformlyOn_of_ae_tendsto_of_stronglyMeasurable_edist' hf hfg hδ
+    tendstoUniformlyOn_of_ae_tendsto_of_measurable_edist' hf hfg hδ
   rw [ENNReal.ofReal_coe_nnreal] at ht
   rw [EMetric.tendstoUniformlyOn_iff] at hunif
   obtain ⟨N, hN⟩ := eventually_atTop.1 (hunif ε hε)
@@ -174,8 +174,8 @@ theorem tendstoInMeasure_of_tendsto_ae [IsFiniteMeasure μ] (hf : ∀ n, AEStron
     (hfg : ∀ᵐ x ∂μ, Tendsto (fun n => f n x) atTop (𝓝 (g x))) : TendstoInMeasure μ f atTop g := by
   have hg : AEStronglyMeasurable g μ := aestronglyMeasurable_of_tendsto_ae _ hf hfg
   refine TendstoInMeasure.congr (fun i => (hf i).ae_eq_mk.symm) hg.ae_eq_mk.symm ?_
-  refine tendstoInMeasure_of_tendsto_ae_of_stronglyMeasurable_edist
-    (fun n ↦ (hf n).stronglyMeasurable_mk.edist hg.stronglyMeasurable_mk) ?_
+  refine tendstoInMeasure_of_tendsto_ae_of_measurable_edist
+    (fun n ↦ ((hf n).stronglyMeasurable_mk.edist hg.stronglyMeasurable_mk).measurable) ?_
   have hf_eq_ae : ∀ᵐ x ∂μ, ∀ n, (hf n).mk (f n) x = f n x :=
     ae_all_iff.mpr fun n => (hf n).ae_eq_mk.symm
   filter_upwards [hf_eq_ae, hg.ae_eq_mk, hfg] with x hxf hxg hxfg

--- a/Mathlib/MeasureTheory/Function/Egorov.lean
+++ b/Mathlib/MeasureTheory/Function/Egorov.lean
@@ -64,14 +64,13 @@ theorem measure_inter_notConvergentSeq_eq_zero [SemilatticeSup ι] [Nonempty ι]
   exact ⟨n, hn₁, hn₂.le⟩
 
 theorem notConvergentSeq_measurableSet [Preorder ι] [Countable ι]
-    (hf : ∀ n, StronglyMeasurable[m] (f n)) (hg : StronglyMeasurable g) :
+    (hf : ∀ n, StronglyMeasurable (fun a ↦ edist (f n a) (g a))) :
     MeasurableSet (notConvergentSeq f g n j) :=
-  MeasurableSet.iUnion fun k =>
-    MeasurableSet.iUnion fun _ =>
-      StronglyMeasurable.measurableSet_lt stronglyMeasurable_const <| (hf k).edist hg
+  MeasurableSet.iUnion fun k ↦ MeasurableSet.iUnion fun _ ↦
+      StronglyMeasurable.measurableSet_lt stronglyMeasurable_const <| hf k
 
 theorem measure_notConvergentSeq_tendsto_zero [SemilatticeSup ι] [Countable ι]
-    (hf : ∀ n, StronglyMeasurable (f n)) (hg : StronglyMeasurable g) (hsm : MeasurableSet s)
+    (hf : ∀ n, StronglyMeasurable (fun a ↦ edist (f n a) (g a))) (hsm : MeasurableSet s)
     (hs : μ s ≠ ∞) (hfg : ∀ᵐ x ∂μ, x ∈ s → Tendsto (fun n => f n x) atTop (𝓝 (g x))) (n : ℕ) :
     Tendsto (fun j => μ (s ∩ notConvergentSeq f g n j)) atTop (𝓝 0) := by
   rcases isEmpty_or_nonempty ι with h | h
@@ -81,18 +80,19 @@ theorem measure_notConvergentSeq_tendsto_zero [SemilatticeSup ι] [Countable ι]
     exact tendsto_const_nhds
   rw [← measure_inter_notConvergentSeq_eq_zero hfg n, Set.inter_iInter]
   refine tendsto_measure_iInter_atTop
-    (fun n ↦ (hsm.inter <| notConvergentSeq_measurableSet hf hg).nullMeasurableSet)
+    (fun n ↦ (hsm.inter <| notConvergentSeq_measurableSet hf).nullMeasurableSet)
     (fun k l hkl => Set.inter_subset_inter_right _ <| notConvergentSeq_antitone hkl)
     ⟨h.some, ne_top_of_le_ne_top hs (measure_mono Set.inter_subset_left)⟩
 
 variable [SemilatticeSup ι] [Nonempty ι] [Countable ι]
 
-theorem exists_notConvergentSeq_lt (hε : 0 < ε) (hf : ∀ n, StronglyMeasurable (f n))
-    (hg : StronglyMeasurable g) (hsm : MeasurableSet s) (hs : μ s ≠ ∞)
+theorem exists_notConvergentSeq_lt (hε : 0 < ε)
+    (hf : ∀ n, StronglyMeasurable (fun a ↦ edist (f n a) (g a)))
+    (hsm : MeasurableSet s) (hs : μ s ≠ ∞)
     (hfg : ∀ᵐ x ∂μ, x ∈ s → Tendsto (fun n => f n x) atTop (𝓝 (g x))) (n : ℕ) :
     ∃ j : ι, μ (s ∩ notConvergentSeq f g n j) ≤ ENNReal.ofReal (ε * 2⁻¹ ^ n) := by
   have ⟨N, hN⟩ := (ENNReal.tendsto_atTop ENNReal.zero_ne_top).1
-    (measure_notConvergentSeq_tendsto_zero hf hg hsm hs hfg n) (.ofReal (ε * 2⁻¹ ^ n))
+    (measure_notConvergentSeq_tendsto_zero hf hsm hs hfg n) (.ofReal (ε * 2⁻¹ ^ n))
       (by positivity)
   rw [zero_add] at hN
   exact ⟨N, (hN N le_rfl).2⟩
@@ -102,39 +102,44 @@ theorem exists_notConvergentSeq_lt (hε : 0 < ε) (hf : ∀ n, StronglyMeasurabl
 `ε * 2⁻¹ ^ n`.
 
 This definition is useful for Egorov's theorem. -/
-def notConvergentSeqLTIndex (hε : 0 < ε) (hf : ∀ n, StronglyMeasurable (f n))
-    (hg : StronglyMeasurable g) (hsm : MeasurableSet s) (hs : μ s ≠ ∞)
+def notConvergentSeqLTIndex (hε : 0 < ε)
+    (hf : ∀ n, StronglyMeasurable (fun a ↦ edist (f n a) (g a)))
+    (hsm : MeasurableSet s) (hs : μ s ≠ ∞)
     (hfg : ∀ᵐ x ∂μ, x ∈ s → Tendsto (fun n => f n x) atTop (𝓝 (g x))) (n : ℕ) : ι :=
-  Classical.choose <| exists_notConvergentSeq_lt hε hf hg hsm hs hfg n
+  Classical.choose <| exists_notConvergentSeq_lt hε hf hsm hs hfg n
 
-theorem notConvergentSeqLTIndex_spec (hε : 0 < ε) (hf : ∀ n, StronglyMeasurable (f n))
-    (hg : StronglyMeasurable g) (hsm : MeasurableSet s) (hs : μ s ≠ ∞)
+theorem notConvergentSeqLTIndex_spec (hε : 0 < ε)
+    (hf : ∀ n, StronglyMeasurable (fun a ↦ edist (f n a) (g a)))
+    (hsm : MeasurableSet s) (hs : μ s ≠ ∞)
     (hfg : ∀ᵐ x ∂μ, x ∈ s → Tendsto (fun n => f n x) atTop (𝓝 (g x))) (n : ℕ) :
-    μ (s ∩ notConvergentSeq f g n (notConvergentSeqLTIndex hε hf hg hsm hs hfg n)) ≤
+    μ (s ∩ notConvergentSeq f g n (notConvergentSeqLTIndex hε hf hsm hs hfg n)) ≤
       ENNReal.ofReal (ε * 2⁻¹ ^ n) :=
-  Classical.choose_spec <| exists_notConvergentSeq_lt hε hf hg hsm hs hfg n
+  Classical.choose_spec <| exists_notConvergentSeq_lt hε hf hsm hs hfg n
 
 /-- Given some `ε > 0`, `iUnionNotConvergentSeq` is the union of `notConvergentSeq` with
 specific indices such that `iUnionNotConvergentSeq` has measure less equal than `ε`.
 
 This definition is useful for Egorov's theorem. -/
-def iUnionNotConvergentSeq (hε : 0 < ε) (hf : ∀ n, StronglyMeasurable (f n))
-    (hg : StronglyMeasurable g) (hsm : MeasurableSet s) (hs : μ s ≠ ∞)
+def iUnionNotConvergentSeq (hε : 0 < ε)
+    (hf : ∀ n, StronglyMeasurable (fun a ↦ edist (f n a) (g a)))
+    (hsm : MeasurableSet s) (hs : μ s ≠ ∞)
     (hfg : ∀ᵐ x ∂μ, x ∈ s → Tendsto (fun n => f n x) atTop (𝓝 (g x))) : Set α :=
-  ⋃ n, s ∩ notConvergentSeq f g n (notConvergentSeqLTIndex (half_pos hε) hf hg hsm hs hfg n)
+  ⋃ n, s ∩ notConvergentSeq f g n (notConvergentSeqLTIndex (half_pos hε) hf hsm hs hfg n)
 
-theorem iUnionNotConvergentSeq_measurableSet (hε : 0 < ε) (hf : ∀ n, StronglyMeasurable (f n))
-    (hg : StronglyMeasurable g) (hsm : MeasurableSet s) (hs : μ s ≠ ∞)
+theorem iUnionNotConvergentSeq_measurableSet (hε : 0 < ε)
+    (hf : ∀ n, StronglyMeasurable (fun a ↦ edist (f n a) (g a)))
+    (hsm : MeasurableSet s) (hs : μ s ≠ ∞)
     (hfg : ∀ᵐ x ∂μ, x ∈ s → Tendsto (fun n => f n x) atTop (𝓝 (g x))) :
-    MeasurableSet <| iUnionNotConvergentSeq hε hf hg hsm hs hfg :=
-  MeasurableSet.iUnion fun _ => hsm.inter <| notConvergentSeq_measurableSet hf hg
+    MeasurableSet <| iUnionNotConvergentSeq hε hf hsm hs hfg :=
+  MeasurableSet.iUnion fun _ ↦ hsm.inter <| notConvergentSeq_measurableSet hf
 
-theorem measure_iUnionNotConvergentSeq (hε : 0 < ε) (hf : ∀ n, StronglyMeasurable (f n))
-    (hg : StronglyMeasurable g) (hsm : MeasurableSet s) (hs : μ s ≠ ∞)
+theorem measure_iUnionNotConvergentSeq (hε : 0 < ε)
+    (hf : ∀ n, StronglyMeasurable (fun a ↦ edist (f n a) (g a)))
+    (hsm : MeasurableSet s) (hs : μ s ≠ ∞)
     (hfg : ∀ᵐ x ∂μ, x ∈ s → Tendsto (fun n => f n x) atTop (𝓝 (g x))) :
-    μ (iUnionNotConvergentSeq hε hf hg hsm hs hfg) ≤ ENNReal.ofReal ε := by
+    μ (iUnionNotConvergentSeq hε hf hsm hs hfg) ≤ ENNReal.ofReal ε := by
   refine le_trans (measure_iUnion_le _) (le_trans
-    (ENNReal.tsum_le_tsum <| notConvergentSeqLTIndex_spec (half_pos hε) hf hg hsm hs hfg) ?_)
+    (ENNReal.tsum_le_tsum <| notConvergentSeqLTIndex_spec (half_pos hε) hf hsm hs hfg) ?_)
   simp_rw [ENNReal.ofReal_mul (half_pos hε).le]
   rw [ENNReal.tsum_mul_left, ← ENNReal.ofReal_tsum_of_nonneg, inv_eq_one_div, tsum_geometric_two,
     ← ENNReal.ofReal_mul (half_pos hε).le, div_mul_cancel₀ ε two_ne_zero]
@@ -142,22 +147,23 @@ theorem measure_iUnionNotConvergentSeq (hε : 0 < ε) (hf : ∀ n, StronglyMeasu
   · rw [inv_eq_one_div]
     exact summable_geometric_two
 
-theorem iUnionNotConvergentSeq_subset (hε : 0 < ε) (hf : ∀ n, StronglyMeasurable (f n))
-    (hg : StronglyMeasurable g) (hsm : MeasurableSet s) (hs : μ s ≠ ∞)
+theorem iUnionNotConvergentSeq_subset (hε : 0 < ε)
+    (hf : ∀ n, StronglyMeasurable (fun a ↦ edist (f n a) (g a)))
+    (hsm : MeasurableSet s) (hs : μ s ≠ ∞)
     (hfg : ∀ᵐ x ∂μ, x ∈ s → Tendsto (fun n => f n x) atTop (𝓝 (g x))) :
-    iUnionNotConvergentSeq hε hf hg hsm hs hfg ⊆ s := by
+    iUnionNotConvergentSeq hε hf hsm hs hfg ⊆ s := by
   rw [iUnionNotConvergentSeq, ← Set.inter_iUnion]
   exact Set.inter_subset_left
 
 theorem tendstoUniformlyOn_diff_iUnionNotConvergentSeq (hε : 0 < ε)
-    (hf : ∀ n, StronglyMeasurable (f n)) (hg : StronglyMeasurable g) (hsm : MeasurableSet s)
+    (hf : ∀ n, StronglyMeasurable (fun a ↦ edist (f n a) (g a))) (hsm : MeasurableSet s)
     (hs : μ s ≠ ∞) (hfg : ∀ᵐ x ∂μ, x ∈ s → Tendsto (fun n => f n x) atTop (𝓝 (g x))) :
-    TendstoUniformlyOn f g atTop (s \ Egorov.iUnionNotConvergentSeq hε hf hg hsm hs hfg) := by
+    TendstoUniformlyOn f g atTop (s \ Egorov.iUnionNotConvergentSeq hε hf hsm hs hfg) := by
   rw [EMetric.tendstoUniformlyOn_iff]
   intro δ hδ
   obtain ⟨N, hN⟩ := ENNReal.exists_inv_nat_lt hδ.ne'
   rw [eventually_atTop]
-  refine ⟨Egorov.notConvergentSeqLTIndex (half_pos hε) hf hg hsm hs hfg N, fun n hn x hx => ?_⟩
+  refine ⟨Egorov.notConvergentSeqLTIndex (half_pos hε) hf hsm hs hfg N, fun n hn x hx => ?_⟩
   simp only [Set.mem_diff, Egorov.iUnionNotConvergentSeq, not_exists, Set.mem_iUnion,
     Set.mem_inter_iff, not_and, exists_and_left] at hx
   obtain ⟨hxs, hx⟩ := hx
@@ -172,6 +178,25 @@ end Egorov
 variable [SemilatticeSup ι] [Nonempty ι] [Countable ι]
   {f : ι → α → β} {g : α → β} {s : Set α}
 
+/-- **Egorov's theorem**: If `f : ι → α → β` is a sequence of functions that
+converges to `g : α → β` almost everywhere on a measurable set `s` of finite measure,
+and the distance between `f n a` and `g a` is strongly measurable for all `n`,
+then for all `ε > 0`, there exists a subset `t ⊆ s` such that `μ t ≤ ε` and `f` converges to `g`
+uniformly on `s \ t`. We require the index type `ι` to be countable, and usually `ι = ℕ`.
+
+In other words, a sequence of almost everywhere convergent functions converges uniformly except on
+an arbitrarily small set. -/
+theorem tendstoUniformlyOn_of_ae_tendsto_of_stronglyMeasurable_edist
+    (hf : ∀ n, StronglyMeasurable (fun a ↦ edist (f n a) (g a)))
+    (hsm : MeasurableSet s) (hs : μ s ≠ ∞)
+    (hfg : ∀ᵐ x ∂μ, x ∈ s → Tendsto (fun n => f n x) atTop (𝓝 (g x))) {ε : ℝ} (hε : 0 < ε) :
+    ∃ t ⊆ s, MeasurableSet t ∧ μ t ≤ ENNReal.ofReal ε ∧ TendstoUniformlyOn f g atTop (s \ t) :=
+  ⟨Egorov.iUnionNotConvergentSeq hε hf hsm hs hfg,
+    Egorov.iUnionNotConvergentSeq_subset hε hf hsm hs hfg,
+    Egorov.iUnionNotConvergentSeq_measurableSet hε hf hsm hs hfg,
+    Egorov.measure_iUnionNotConvergentSeq hε hf hsm hs hfg,
+    Egorov.tendstoUniformlyOn_diff_iUnionNotConvergentSeq hε hf hsm hs hfg⟩
+
 /-- **Egorov's theorem**: If `f : ι → α → β` is a sequence of strongly measurable functions that
 converges to `g : α → β` almost everywhere on a measurable set `s` of finite measure,
 then for all `ε > 0`, there exists a subset `t ⊆ s` such that `μ t ≤ ε` and `f` converges to `g`
@@ -183,20 +208,26 @@ theorem tendstoUniformlyOn_of_ae_tendsto (hf : ∀ n, StronglyMeasurable (f n))
     (hg : StronglyMeasurable g) (hsm : MeasurableSet s) (hs : μ s ≠ ∞)
     (hfg : ∀ᵐ x ∂μ, x ∈ s → Tendsto (fun n => f n x) atTop (𝓝 (g x))) {ε : ℝ} (hε : 0 < ε) :
     ∃ t ⊆ s, MeasurableSet t ∧ μ t ≤ ENNReal.ofReal ε ∧ TendstoUniformlyOn f g atTop (s \ t) :=
-  ⟨Egorov.iUnionNotConvergentSeq hε hf hg hsm hs hfg,
-    Egorov.iUnionNotConvergentSeq_subset hε hf hg hsm hs hfg,
-    Egorov.iUnionNotConvergentSeq_measurableSet hε hf hg hsm hs hfg,
-    Egorov.measure_iUnionNotConvergentSeq hε hf hg hsm hs hfg,
-    Egorov.tendstoUniformlyOn_diff_iUnionNotConvergentSeq hε hf hg hsm hs hfg⟩
+  tendstoUniformlyOn_of_ae_tendsto_of_stronglyMeasurable_edist
+    (fun n ↦ (hf n).edist hg) hsm hs hfg hε
+
+/-- Egorov's theorem for finite measure spaces.
+Version with strongly measurable distances. -/
+theorem tendstoUniformlyOn_of_ae_tendsto_of_stronglyMeasurable_edist' [IsFiniteMeasure μ]
+    (hf : ∀ n, StronglyMeasurable (fun a ↦ edist (f n a) (g a)))
+    (hfg : ∀ᵐ x ∂μ, Tendsto (fun n => f n x) atTop (𝓝 (g x))) {ε : ℝ} (hε : 0 < ε) :
+    ∃ t, MeasurableSet t ∧ μ t ≤ ENNReal.ofReal ε ∧ TendstoUniformlyOn f g atTop tᶜ := by
+  have ⟨t, _, ht, htendsto⟩ :=
+    tendstoUniformlyOn_of_ae_tendsto_of_stronglyMeasurable_edist hf MeasurableSet.univ
+    (measure_ne_top μ Set.univ) (by filter_upwards [hfg] with _ htendsto _ using htendsto) hε
+  refine ⟨_, ht, ?_⟩
+  rwa [Set.compl_eq_univ_diff]
 
 /-- Egorov's theorem for finite measure spaces. -/
 theorem tendstoUniformlyOn_of_ae_tendsto' [IsFiniteMeasure μ] (hf : ∀ n, StronglyMeasurable (f n))
     (hg : StronglyMeasurable g) (hfg : ∀ᵐ x ∂μ, Tendsto (fun n => f n x) atTop (𝓝 (g x))) {ε : ℝ}
     (hε : 0 < ε) :
-    ∃ t, MeasurableSet t ∧ μ t ≤ ENNReal.ofReal ε ∧ TendstoUniformlyOn f g atTop tᶜ := by
-  have ⟨t, _, ht, htendsto⟩ := tendstoUniformlyOn_of_ae_tendsto hf hg MeasurableSet.univ
-    (measure_ne_top μ Set.univ) (by filter_upwards [hfg] with _ htendsto _ using htendsto) hε
-  refine ⟨_, ht, ?_⟩
-  rwa [Set.compl_eq_univ_diff]
+    ∃ t, MeasurableSet t ∧ μ t ≤ ENNReal.ofReal ε ∧ TendstoUniformlyOn f g atTop tᶜ :=
+  tendstoUniformlyOn_of_ae_tendsto_of_stronglyMeasurable_edist' (fun n ↦ (hf n).edist hg) hfg hε
 
 end MeasureTheory

--- a/Mathlib/MeasureTheory/Function/Egorov.lean
+++ b/Mathlib/MeasureTheory/Function/Egorov.lean
@@ -64,13 +64,13 @@ theorem measure_inter_notConvergentSeq_eq_zero [SemilatticeSup ι] [Nonempty ι]
   exact ⟨n, hn₁, hn₂.le⟩
 
 theorem notConvergentSeq_measurableSet [Preorder ι] [Countable ι]
-    (hf : ∀ n, StronglyMeasurable (fun a ↦ edist (f n a) (g a))) :
+    (hf : ∀ n, Measurable (fun a ↦ edist (f n a) (g a))) :
     MeasurableSet (notConvergentSeq f g n j) :=
   MeasurableSet.iUnion fun k ↦ MeasurableSet.iUnion fun _ ↦
-      StronglyMeasurable.measurableSet_lt stronglyMeasurable_const <| hf k
+      StronglyMeasurable.measurableSet_lt stronglyMeasurable_const <| (hf k).stronglyMeasurable
 
 theorem measure_notConvergentSeq_tendsto_zero [SemilatticeSup ι] [Countable ι]
-    (hf : ∀ n, StronglyMeasurable (fun a ↦ edist (f n a) (g a))) (hsm : MeasurableSet s)
+    (hf : ∀ n, Measurable (fun a ↦ edist (f n a) (g a))) (hsm : MeasurableSet s)
     (hs : μ s ≠ ∞) (hfg : ∀ᵐ x ∂μ, x ∈ s → Tendsto (fun n => f n x) atTop (𝓝 (g x))) (n : ℕ) :
     Tendsto (fun j => μ (s ∩ notConvergentSeq f g n j)) atTop (𝓝 0) := by
   rcases isEmpty_or_nonempty ι with h | h
@@ -87,7 +87,7 @@ theorem measure_notConvergentSeq_tendsto_zero [SemilatticeSup ι] [Countable ι]
 variable [SemilatticeSup ι] [Nonempty ι] [Countable ι]
 
 theorem exists_notConvergentSeq_lt (hε : 0 < ε)
-    (hf : ∀ n, StronglyMeasurable (fun a ↦ edist (f n a) (g a)))
+    (hf : ∀ n, Measurable (fun a ↦ edist (f n a) (g a)))
     (hsm : MeasurableSet s) (hs : μ s ≠ ∞)
     (hfg : ∀ᵐ x ∂μ, x ∈ s → Tendsto (fun n => f n x) atTop (𝓝 (g x))) (n : ℕ) :
     ∃ j : ι, μ (s ∩ notConvergentSeq f g n j) ≤ ENNReal.ofReal (ε * 2⁻¹ ^ n) := by
@@ -103,13 +103,13 @@ theorem exists_notConvergentSeq_lt (hε : 0 < ε)
 
 This definition is useful for Egorov's theorem. -/
 def notConvergentSeqLTIndex (hε : 0 < ε)
-    (hf : ∀ n, StronglyMeasurable (fun a ↦ edist (f n a) (g a)))
+    (hf : ∀ n, Measurable (fun a ↦ edist (f n a) (g a)))
     (hsm : MeasurableSet s) (hs : μ s ≠ ∞)
     (hfg : ∀ᵐ x ∂μ, x ∈ s → Tendsto (fun n => f n x) atTop (𝓝 (g x))) (n : ℕ) : ι :=
   Classical.choose <| exists_notConvergentSeq_lt hε hf hsm hs hfg n
 
 theorem notConvergentSeqLTIndex_spec (hε : 0 < ε)
-    (hf : ∀ n, StronglyMeasurable (fun a ↦ edist (f n a) (g a)))
+    (hf : ∀ n, Measurable (fun a ↦ edist (f n a) (g a)))
     (hsm : MeasurableSet s) (hs : μ s ≠ ∞)
     (hfg : ∀ᵐ x ∂μ, x ∈ s → Tendsto (fun n => f n x) atTop (𝓝 (g x))) (n : ℕ) :
     μ (s ∩ notConvergentSeq f g n (notConvergentSeqLTIndex hε hf hsm hs hfg n)) ≤
@@ -121,20 +121,20 @@ specific indices such that `iUnionNotConvergentSeq` has measure less equal than 
 
 This definition is useful for Egorov's theorem. -/
 def iUnionNotConvergentSeq (hε : 0 < ε)
-    (hf : ∀ n, StronglyMeasurable (fun a ↦ edist (f n a) (g a)))
+    (hf : ∀ n, Measurable (fun a ↦ edist (f n a) (g a)))
     (hsm : MeasurableSet s) (hs : μ s ≠ ∞)
     (hfg : ∀ᵐ x ∂μ, x ∈ s → Tendsto (fun n => f n x) atTop (𝓝 (g x))) : Set α :=
   ⋃ n, s ∩ notConvergentSeq f g n (notConvergentSeqLTIndex (half_pos hε) hf hsm hs hfg n)
 
 theorem iUnionNotConvergentSeq_measurableSet (hε : 0 < ε)
-    (hf : ∀ n, StronglyMeasurable (fun a ↦ edist (f n a) (g a)))
+    (hf : ∀ n, Measurable (fun a ↦ edist (f n a) (g a)))
     (hsm : MeasurableSet s) (hs : μ s ≠ ∞)
     (hfg : ∀ᵐ x ∂μ, x ∈ s → Tendsto (fun n => f n x) atTop (𝓝 (g x))) :
     MeasurableSet <| iUnionNotConvergentSeq hε hf hsm hs hfg :=
   MeasurableSet.iUnion fun _ ↦ hsm.inter <| notConvergentSeq_measurableSet hf
 
 theorem measure_iUnionNotConvergentSeq (hε : 0 < ε)
-    (hf : ∀ n, StronglyMeasurable (fun a ↦ edist (f n a) (g a)))
+    (hf : ∀ n, Measurable (fun a ↦ edist (f n a) (g a)))
     (hsm : MeasurableSet s) (hs : μ s ≠ ∞)
     (hfg : ∀ᵐ x ∂μ, x ∈ s → Tendsto (fun n => f n x) atTop (𝓝 (g x))) :
     μ (iUnionNotConvergentSeq hε hf hsm hs hfg) ≤ ENNReal.ofReal ε := by
@@ -148,7 +148,7 @@ theorem measure_iUnionNotConvergentSeq (hε : 0 < ε)
     exact summable_geometric_two
 
 theorem iUnionNotConvergentSeq_subset (hε : 0 < ε)
-    (hf : ∀ n, StronglyMeasurable (fun a ↦ edist (f n a) (g a)))
+    (hf : ∀ n, Measurable (fun a ↦ edist (f n a) (g a)))
     (hsm : MeasurableSet s) (hs : μ s ≠ ∞)
     (hfg : ∀ᵐ x ∂μ, x ∈ s → Tendsto (fun n => f n x) atTop (𝓝 (g x))) :
     iUnionNotConvergentSeq hε hf hsm hs hfg ⊆ s := by
@@ -156,7 +156,7 @@ theorem iUnionNotConvergentSeq_subset (hε : 0 < ε)
   exact Set.inter_subset_left
 
 theorem tendstoUniformlyOn_diff_iUnionNotConvergentSeq (hε : 0 < ε)
-    (hf : ∀ n, StronglyMeasurable (fun a ↦ edist (f n a) (g a))) (hsm : MeasurableSet s)
+    (hf : ∀ n, Measurable (fun a ↦ edist (f n a) (g a))) (hsm : MeasurableSet s)
     (hs : μ s ≠ ∞) (hfg : ∀ᵐ x ∂μ, x ∈ s → Tendsto (fun n => f n x) atTop (𝓝 (g x))) :
     TendstoUniformlyOn f g atTop (s \ Egorov.iUnionNotConvergentSeq hε hf hsm hs hfg) := by
   rw [EMetric.tendstoUniformlyOn_iff]
@@ -180,14 +180,14 @@ variable [SemilatticeSup ι] [Nonempty ι] [Countable ι]
 
 /-- **Egorov's theorem**: If `f : ι → α → β` is a sequence of functions that
 converges to `g : α → β` almost everywhere on a measurable set `s` of finite measure,
-and the distance between `f n a` and `g a` is strongly measurable for all `n`,
+and the distance between `f n a` and `g a` is measurable for all `n`,
 then for all `ε > 0`, there exists a subset `t ⊆ s` such that `μ t ≤ ε` and `f` converges to `g`
 uniformly on `s \ t`. We require the index type `ι` to be countable, and usually `ι = ℕ`.
 
 In other words, a sequence of almost everywhere convergent functions converges uniformly except on
 an arbitrarily small set. -/
-theorem tendstoUniformlyOn_of_ae_tendsto_of_stronglyMeasurable_edist
-    (hf : ∀ n, StronglyMeasurable (fun a ↦ edist (f n a) (g a)))
+theorem tendstoUniformlyOn_of_ae_tendsto_of_measurable_edist
+    (hf : ∀ n, Measurable (fun a ↦ edist (f n a) (g a)))
     (hsm : MeasurableSet s) (hs : μ s ≠ ∞)
     (hfg : ∀ᵐ x ∂μ, x ∈ s → Tendsto (fun n => f n x) atTop (𝓝 (g x))) {ε : ℝ} (hε : 0 < ε) :
     ∃ t ⊆ s, MeasurableSet t ∧ μ t ≤ ENNReal.ofReal ε ∧ TendstoUniformlyOn f g atTop (s \ t) :=
@@ -208,17 +208,17 @@ theorem tendstoUniformlyOn_of_ae_tendsto (hf : ∀ n, StronglyMeasurable (f n))
     (hg : StronglyMeasurable g) (hsm : MeasurableSet s) (hs : μ s ≠ ∞)
     (hfg : ∀ᵐ x ∂μ, x ∈ s → Tendsto (fun n => f n x) atTop (𝓝 (g x))) {ε : ℝ} (hε : 0 < ε) :
     ∃ t ⊆ s, MeasurableSet t ∧ μ t ≤ ENNReal.ofReal ε ∧ TendstoUniformlyOn f g atTop (s \ t) :=
-  tendstoUniformlyOn_of_ae_tendsto_of_stronglyMeasurable_edist
-    (fun n ↦ (hf n).edist hg) hsm hs hfg hε
+  tendstoUniformlyOn_of_ae_tendsto_of_measurable_edist
+    (fun n ↦ ((hf n).edist hg).measurable) hsm hs hfg hε
 
 /-- Egorov's theorem for finite measure spaces.
-Version with strongly measurable distances. -/
-theorem tendstoUniformlyOn_of_ae_tendsto_of_stronglyMeasurable_edist' [IsFiniteMeasure μ]
-    (hf : ∀ n, StronglyMeasurable (fun a ↦ edist (f n a) (g a)))
+Version with measurable distances. -/
+theorem tendstoUniformlyOn_of_ae_tendsto_of_measurable_edist' [IsFiniteMeasure μ]
+    (hf : ∀ n, Measurable (fun a ↦ edist (f n a) (g a)))
     (hfg : ∀ᵐ x ∂μ, Tendsto (fun n => f n x) atTop (𝓝 (g x))) {ε : ℝ} (hε : 0 < ε) :
     ∃ t, MeasurableSet t ∧ μ t ≤ ENNReal.ofReal ε ∧ TendstoUniformlyOn f g atTop tᶜ := by
   have ⟨t, _, ht, htendsto⟩ :=
-    tendstoUniformlyOn_of_ae_tendsto_of_stronglyMeasurable_edist hf MeasurableSet.univ
+    tendstoUniformlyOn_of_ae_tendsto_of_measurable_edist hf MeasurableSet.univ
     (measure_ne_top μ Set.univ) (by filter_upwards [hfg] with _ htendsto _ using htendsto) hε
   refine ⟨_, ht, ?_⟩
   rwa [Set.compl_eq_univ_diff]
@@ -228,6 +228,7 @@ theorem tendstoUniformlyOn_of_ae_tendsto' [IsFiniteMeasure μ] (hf : ∀ n, Stro
     (hg : StronglyMeasurable g) (hfg : ∀ᵐ x ∂μ, Tendsto (fun n => f n x) atTop (𝓝 (g x))) {ε : ℝ}
     (hε : 0 < ε) :
     ∃ t, MeasurableSet t ∧ μ t ≤ ENNReal.ofReal ε ∧ TendstoUniformlyOn f g atTop tᶜ :=
-  tendstoUniformlyOn_of_ae_tendsto_of_stronglyMeasurable_edist' (fun n ↦ (hf n).edist hg) hfg hε
+  tendstoUniformlyOn_of_ae_tendsto_of_measurable_edist' (fun n ↦ ((hf n).edist hg).measurable)
+    hfg hε
 
 end MeasureTheory

--- a/Mathlib/MeasureTheory/Function/Egorov.lean
+++ b/Mathlib/MeasureTheory/Function/Egorov.lean
@@ -67,7 +67,7 @@ theorem notConvergentSeq_measurableSet [Preorder ι] [Countable ι]
     (hf : ∀ n, Measurable (fun a ↦ edist (f n a) (g a))) :
     MeasurableSet (notConvergentSeq f g n j) :=
   MeasurableSet.iUnion fun k ↦ MeasurableSet.iUnion fun _ ↦
-      StronglyMeasurable.measurableSet_lt stronglyMeasurable_const <| (hf k).stronglyMeasurable
+      measurableSet_lt measurable_const <| hf k
 
 theorem measure_notConvergentSeq_tendsto_zero [SemilatticeSup ι] [Countable ι]
     (hf : ∀ n, Measurable (fun a ↦ edist (f n a) (g a))) (hsm : MeasurableSet s)


### PR DESCRIPTION
This PR generalizes the lemmas of the Egorov theorem file to use measurability of distances instead of strong measurability of the processes.

For the proof of the Kolmogorov-Chentsov theorem in the Brownian process project, we don't have strong measurability of the processes but we have measurability of the distances and we want to use an equivalent of `tendstoInMeasure_of_tendsto_ae`.


---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include at least one commit authored by each
co-author among the commits in the pull request. If necessary, you may 
create empty commits to indicate co-authorship, using commands like so:

git commit --author="Author Name <author@email.com>" --allow-empty -m "add Author Name as coauthor"

When merging, all the commits will be squashed into a single commit listing all co-authors.

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
