### PR TITLE
[Merged by Bors] - fix: update the continuity lemma library note

### DIFF
--- a/Mathlib/Topology/Continuous.lean
+++ b/Mathlib/Topology/Continuous.lean
@@ -324,7 +324,7 @@ in different definitionally equal ways (omitting some typing information)
 * `Continuous ↿(+)`. (`↿` is notation for recursively uncurrying a function)
 
 However, lemmas with this conclusion are not nice to use in practice because
-1. They confuse the elaborator. The following examples fails, because of limitations in the
+1. They confuse the elaborator. The following example fails, because of limitations in the
   elaboration process.
   ```
   variable {M : Type*} [Add M] [TopologicalSpace M] [ContinuousAdd M]

--- a/Mathlib/Topology/Continuous.lean
+++ b/Mathlib/Topology/Continuous.lean
@@ -324,18 +324,18 @@ in different definitionally equal ways (omitting some typing information)
 * `Continuous ↿(+)`. (`↿` is notation for recursively uncurrying a function)
 
 However, lemmas with this conclusion are not nice to use in practice because
-1. They confuse the elaborator. The following two examples fail, because of limitations in the
+1. They confuse the elaborator. The following examples fails, because of limitations in the
   elaboration process.
   ```
   variable {M : Type*} [Add M] [TopologicalSpace M] [ContinuousAdd M]
   example : Continuous (fun x : M ↦ x + x) :=
     continuous_add.comp _
 
+  -- This example used to fail, but would be accepted if you wrote is as
+  -- `continuous_add.comp (continuous_id.prodMk continuous_id :)`.
   example : Continuous (fun x : M ↦ x + x) :=
     continuous_add.comp (continuous_id.prodMk continuous_id)
   ```
-  The second is a valid proof, which is accepted if you write it as
-  `continuous_add.comp (continuous_id.prodMk continuous_id :)`
 
 2. If the operation has more than 2 arguments, they are impractical to use, because in your
   application the arguments in the domain might be in a different order or associated differently.
@@ -345,17 +345,18 @@ However, lemmas with this conclusion are not nice to use in practice because
 A much more convenient way to write continuity lemmas is like `Continuous.add`:
 ```
 Continuous.add {f g : X → M} (hf : Continuous f) (hg : Continuous g) :
-  Continuous (fun x ↦ f x + g x)
+  Continuous (f + g)
 ```
-The conclusion can be `Continuous (f + g)`, which is definitionally equal.
+The conclusion can be `Continuous (fun x ↦ f x + g x)`, which is definitionally equal.
 This has the following advantages
 * It supports projection notation, so is shorter to write.
 * `Continuous.add _ _` is recognized correctly by the elaborator and gives useful new goals.
 * It works generally, since the domain is a variable.
+  (Having a domain `Y × Z` would be less convenient in general.)
 
 As an example for a unary operation, we have `Continuous.neg`.
 ```
-Continuous.neg {f : X → G} (hf : Continuous f) : Continuous (fun x ↦ -f x)
+Continuous.neg {f : X → G} (hf : Continuous f) : Continuous (-f)
 ```
 For unary functions, the elaborator is not confused when applying the traditional lemma
 (like `continuous_neg`), but it's still convenient to have the short version available (compare


### PR DESCRIPTION
One previously failing example elaborates fine now, and update the lemma examples to follow mathlib's naming convention.

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include at least one commit authored by each
co-author among the commits in the pull request. If necessary, you may 
create empty commits to indicate co-authorship, using commands like so:

git commit --author="Author Name <author@email.com>" --allow-empty -m "add Author Name as coauthor"

When merging, all the commits will be squashed into a single commit listing all co-authors.

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
