### PR TITLE
[Merged by Bors] - chore: rename fields in `ImplicitFunctionData`

### DIFF
--- a/Mathlib/Analysis/Calculus/Implicit.lean
+++ b/Mathlib/Analysis/Calculus/Implicit.lean
@@ -108,10 +108,10 @@ structure ImplicitFunctionData (𝕜 : Type*) [NontriviallyNormedField 𝕜] (E 
   rightDeriv : E →L[𝕜] G
   /-- The point at which `leftFun` and `rightFun` are strictly differentiable -/
   pt : E
-  left_has_deriv : HasStrictFDerivAt leftFun leftDeriv pt
-  right_has_deriv : HasStrictFDerivAt rightFun rightDeriv pt
-  left_range : range leftDeriv = ⊤
-  right_range : range rightDeriv = ⊤
+  hasStrictFDerivAt_leftFun : HasStrictFDerivAt leftFun leftDeriv pt
+  hasStrictFDerivAt_rightFun : HasStrictFDerivAt rightFun rightDeriv pt
+  range_leftDeriv : range leftDeriv = ⊤
+  range_rightDeriv : range rightDeriv = ⊤
   isCompl_ker : IsCompl (ker leftDeriv) (ker rightDeriv)
 
 namespace ImplicitFunctionData
@@ -131,11 +131,11 @@ theorem prodFun_apply (x : E) : φ.prodFun x = (φ.leftFun x, φ.rightFun x) :=
 
 protected theorem hasStrictFDerivAt :
     HasStrictFDerivAt φ.prodFun
-      (φ.leftDeriv.equivProdOfSurjectiveOfIsCompl φ.rightDeriv φ.left_range φ.right_range
+      (φ.leftDeriv.equivProdOfSurjectiveOfIsCompl φ.rightDeriv φ.range_leftDeriv φ.range_rightDeriv
           φ.isCompl_ker :
         E →L[𝕜] F × G)
       φ.pt :=
-  φ.left_has_deriv.prodMk φ.right_has_deriv
+  φ.hasStrictFDerivAt_leftFun.prodMk φ.hasStrictFDerivAt_rightFun
 
 /-- Implicit function theorem. If `f : E → F` and `g : E → G` are two maps strictly differentiable
 at `a`, their derivatives `f'`, `g'` are surjective, and the kernels of these derivatives are
@@ -249,11 +249,11 @@ def implicitFunctionDataOfComplemented (hf : HasStrictFDerivAt f f' a) (hf' : ra
   rightFun x := Classical.choose hker (x - a)
   rightDeriv := Classical.choose hker
   pt := a
-  left_has_deriv := hf
-  right_has_deriv :=
+  hasStrictFDerivAt_leftFun := hf
+  hasStrictFDerivAt_rightFun :=
     (Classical.choose hker).hasStrictFDerivAt.comp a ((hasStrictFDerivAt_id a).sub_const a)
-  left_range := hf'
-  right_range := LinearMap.range_eq_of_proj (Classical.choose_spec hker)
+  range_leftDeriv := hf'
+  range_rightDeriv := LinearMap.range_eq_of_proj (Classical.choose_spec hker)
   isCompl_ker := LinearMap.isCompl_of_proj (Classical.choose_spec hker)
 
 /-- An open partial homeomorphism between `E` and `F × f'.ker` sending level surfaces of `f`


### PR DESCRIPTION
Make them match the naming convention, as discussed on zulip: [#mathlib4 > Naming convention @ 💬](https://leanprover.zulipchat.com/#narrow/channel/287929-mathlib4/topic/Naming.20convention/near/545300205)

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include at least one commit authored by each
co-author among the commits in the pull request. If necessary, you may 
create empty commits to indicate co-authorship, using commands like so:

git commit --author="Author Name <author@email.com>" --allow-empty -m "add Author Name as coauthor"

When merging, all the commits will be squashed into a single commit listing all co-authors.

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
