### PR TITLE
feat: yet another lemma about differentiability of parametric integrals

### DIFF
--- a/Mathlib/Analysis/Calculus/ParametricIntegral.lean
+++ b/Mathlib/Analysis/Calculus/ParametricIntegral.lean
@@ -299,15 +299,14 @@ theorem hasFDerivAt_parametric_primitive_of_lip' (F : H → ℝ → E) (F' : ℝ
     replace h_lipsch : ∀ᵐ t ∂volume.restrict (Ι a (s x₀)),
         LipschitzOnWith (nnabs (bound t)) (fun x : H ↦ F x t) (ball x₀ ε) :=
       ae_restrict_of_ae_restrict_of_subset (ordConnected_Ioo.uIoc_subset ha hsx₀) h_lipsch
-    filter_upwards [h_lipsch, h_diff]
-    intro t ht_lip ht_diff
+    filter_upwards [h_lipsch, h_diff] with t ht_lip ht_diff
     rw [show bound t = nnabs (bound t) by simp [bound_nonneg t] ]
     exact ht_diff.le_of_lipschitzOn (ball_mem_nhds x₀ ε_pos) ht_lip
   · have D₁ : HasFDerivAt (fun x ↦ φ x (s x₀)) (∫ t in a..s x₀, F' t) x₀ := by
       replace hF_meas : ∀ᶠ x in 𝓝 x₀, AEStronglyMeasurable (F x) (volume.restrict (Ι a (s x₀))) :=
         Eventually.mono (ball_mem_nhds x₀ ε_pos) fun x hx ↦ hF_meas_ball hx ha hsx₀
-      replace hF_int : IntervalIntegrable (F x₀) volume a (s x₀) := hF_int_ball hx₀ ha hsx₀
-      exact (hasFDerivAt_integral_of_dominated_loc_of_lip_interval ε_pos hF_meas hF_int hF'_meas
+      exact (hasFDerivAt_integral_of_dominated_loc_of_lip_interval ε_pos hF_meas
+        (hF_int_ball hx₀ ha hsx₀) hF'_meas
         (ae_restrict_of_ae_restrict_of_subset (ordConnected_Ioo.uIoc_subset ha hsx₀) h_lipsch)
         (bound_int ha hsx₀) h_diff).2
     have D₂ : HasFDerivAt (fun x ↦ φ x₀ (s x)) ((toSpanSingleton ℝ (F x₀ (s x₀))).comp s') x₀ := by
@@ -326,8 +325,7 @@ theorem hasFDerivAt_parametric_primitive_of_lip' (F : H → ℝ → E) (F' : ℝ
           ⟨Ioo a₀ b₀, Ioo_nhds, bound_integrable.1⟩
         refine (intervalIntegral.integral_hasDerivAt_right (bound_int ha hsx₀)
           M bound_cont).hasFDerivAt.isBigO_sub.congr' ?_ EventuallyEq.rfl
-        filter_upwards [Ioo_nhds]
-        rintro t ht
+        filter_upwards [Ioo_nhds] with t ht
         rw [intervalIntegral.integral_interval_sub_left (bound_int ha ht) (bound_int ha hsx₀)]
       have O₂ : (fun x ↦ ‖x - x₀‖) =O[𝓝 x₀] fun x ↦ ‖x - x₀‖ := isBigO_refl _ _
       have O₃ : (fun x ↦ ∫ t : ℝ in s x₀..s x, F x t - F x₀ t) =O[𝓝 x₀] fun x ↦

--- a/Mathlib/Analysis/Calculus/ParametricIntegral.lean
+++ b/Mathlib/Analysis/Calculus/ParametricIntegral.lean
@@ -8,6 +8,8 @@ import Mathlib.MeasureTheory.Integral.DominatedConvergence
 import Mathlib.MeasureTheory.Integral.Bochner.Set
 import Mathlib.Analysis.NormedSpace.HahnBanach.SeparatingDual
 
+import Mathlib.MeasureTheory.Integral.IntervalIntegral.FundThmCalculus
+
 /-!
 # Derivatives of integrals depending on parameters
 
@@ -244,6 +246,131 @@ theorem hasFDerivAt_integral_of_dominated_of_fderiv_le'' [NormedSpace ℝ H] {μ
           bound_integrable.1 h_diff.1).sub
       (hasFDerivAt_integral_of_dominated_of_fderiv_le ε_pos hF_meas.2 hF_int.2 hF'_meas.2 h_bound.2
         bound_integrable.2 h_diff.2)
+
+section
+
+open Real ContinuousLinearMap Asymptotics Interval
+open Set
+
+variable {E : Type*} [NormedAddCommGroup E] [NormedSpace ℝ E] [CompleteSpace E]
+  {H : Type*} [NormedAddCommGroup H] [NormedSpace ℝ H]
+
+theorem hasFDerivAt_parametric_primitive_of_lip' (F : H → ℝ → E) (F' : ℝ → H →L[ℝ] E) {x₀ : H}
+    {G' : H →L[ℝ] E} {bound : ℝ → ℝ} {s : H → ℝ} {ε : ℝ} (ε_pos : 0 < ε) {a a₀ b₀ : ℝ}
+    {s' : H →L[ℝ] ℝ} (ha : a ∈ Ioo a₀ b₀) (hsx₀ : s x₀ ∈ Ioo a₀ b₀)
+    (hF_meas : ∀ x ∈ ball x₀ ε, AEStronglyMeasurable (F x) (volume.restrict (Ioo a₀ b₀)))
+    (hF_int : IntegrableOn (F x₀) (Ioo a₀ b₀)) (hF_cont : ContinuousAt (F x₀) (s x₀))
+    (hF'_meas : AEStronglyMeasurable F' (volume.restrict <| Ι a (s x₀)))
+    (h_lipsch :
+      ∀ᵐ t ∂volume.restrict <| Ioo a₀ b₀,
+        LipschitzOnWith (nnabs <| bound t) (fun x ↦ F x t) (ball x₀ ε))
+    (bound_integrable : IntegrableOn bound (Ioo a₀ b₀)) (bound_cont : ContinuousAt bound (s x₀))
+    (bound_nonneg : ∀ t, 0 ≤ bound t)
+    -- This assumption could be weakened, but this way is much more convenient.
+    (h_diff : ∀ᵐ a ∂volume.restrict (Ι a (s x₀)), HasFDerivAt (fun x ↦ F x a) (F' a) x₀)
+    (s_diff : HasFDerivAt s s' x₀)
+    (hG' : (∫ t in a..s x₀, F' t) + (toSpanSingleton ℝ (F x₀ (s x₀))).comp s' = G') :
+    IntervalIntegrable F' volume a (s x₀) ∧
+      HasFDerivAt (fun x : H ↦ ∫ t in a..s x, F x t) G' x₀ := by
+  subst hG'
+  let φ : H → ℝ → E := fun x t ↦ ∫ s in a..t, F x s
+  have Ioo_nhds : Ioo a₀ b₀ ∈ 𝓝 (s x₀) := Ioo_mem_nhds hsx₀.1 hsx₀.2
+  have bound_int {s u} (hs : s ∈ Ioo a₀ b₀) (hu : u ∈ Ioo a₀ b₀) :
+      IntervalIntegrable bound volume s u :=
+    (bound_integrable.mono_set <| ordConnected_Ioo.uIcc_subset hs hu).intervalIntegrable
+  have mem_nhds : ball x₀ ε ∩ s ⁻¹' Ioo a₀ b₀ ∈ 𝓝 x₀ :=
+    Filter.inter_mem (ball_mem_nhds x₀ ε_pos) (s_diff.continuousAt.preimage_mem_nhds Ioo_nhds)
+  have hx₀ : x₀ ∈ ball x₀ ε := mem_ball_self ε_pos
+  have hF_meas_ball {x} (hx : x ∈ ball x₀ ε) {s u} (hs : s ∈ Ioo a₀ b₀) (hu : u ∈ Ioo a₀ b₀) :
+      AEStronglyMeasurable (F x) (volume.restrict <| Ι s u) :=
+    (hF_meas _ hx).mono_set (ordConnected_Ioo.uIoc_subset hs hu)
+  have hF_int_ball {x} (hx : x ∈ ball x₀ ε) {s u} (hs : s ∈ Ioo a₀ b₀) (hu : u ∈ Ioo a₀ b₀) :
+      IntervalIntegrable (F x) volume s u := by
+    have : IntegrableOn (F x) (Ioo a₀ b₀) := by
+      apply integrable_of_norm_sub_le (hF_meas x hx) hF_int (bound_integrable.mul_const ‖x - x₀‖)
+      apply h_lipsch.mono
+      intro t ht
+      rw [norm_sub_rev]
+      rw [lipschitzOnWith_iff_norm_sub_le] at ht
+      simpa [bound_nonneg t] using ht hx hx₀
+    exact (this.mono_set <| ordConnected_Ioo.uIcc_subset hs hu).intervalIntegrable
+  constructor
+  · apply (bound_int ha hsx₀).mono_fun' hF'_meas _
+    replace h_lipsch : ∀ᵐ t ∂volume.restrict (Ι a (s x₀)),
+        LipschitzOnWith (nnabs (bound t)) (fun x : H ↦ F x t) (ball x₀ ε) :=
+      ae_restrict_of_ae_restrict_of_subset (ordConnected_Ioo.uIoc_subset ha hsx₀) h_lipsch
+    filter_upwards [h_lipsch, h_diff]
+    intro t ht_lip ht_diff
+    rw [show bound t = nnabs (bound t) by simp [bound_nonneg t] ]
+    exact ht_diff.le_of_lipschitzOn (ball_mem_nhds x₀ ε_pos) ht_lip
+  · have D₁ : HasFDerivAt (fun x ↦ φ x (s x₀)) (∫ t in a..s x₀, F' t) x₀ := by
+      replace hF_meas : ∀ᶠ x in 𝓝 x₀, AEStronglyMeasurable (F x) (volume.restrict (Ι a (s x₀))) :=
+        Eventually.mono (ball_mem_nhds x₀ ε_pos) fun x hx ↦ hF_meas_ball hx ha hsx₀
+      replace hF_int : IntervalIntegrable (F x₀) volume a (s x₀) := hF_int_ball hx₀ ha hsx₀
+      exact (hasFDerivAt_integral_of_dominated_loc_of_lip_interval ε_pos hF_meas hF_int hF'_meas
+        (ae_restrict_of_ae_restrict_of_subset (ordConnected_Ioo.uIoc_subset ha hsx₀) h_lipsch)
+        (bound_int ha hsx₀) h_diff).2
+    have D₂ : HasFDerivAt (fun x ↦ φ x₀ (s x)) ((toSpanSingleton ℝ (F x₀ (s x₀))).comp s') x₀ := by
+      suffices HasFDerivAt (φ x₀) (toSpanSingleton ℝ (F x₀ (s x₀))) (s x₀) from this.comp _ s_diff
+      rw [hasFDerivAt_iff_hasDerivAt, toSpanSingleton_apply, one_smul]
+      exact intervalIntegral.integral_hasDerivAt_right (hF_int_ball hx₀ ha hsx₀)
+        ⟨Ioo a₀ b₀, Ioo_nhds, hF_meas x₀ hx₀⟩ hF_cont
+    have D₃ : HasFDerivAt (𝕜 := ℝ) (fun x ↦ ∫ t in s x₀..s x, F x t - F x₀ t) 0 x₀ := by
+      refine IsBigO.hasFDerivAt (𝕜 := ℝ) ?_ one_lt_two
+      have O₁ : (fun x ↦ ∫ s in s x₀..s x, bound s) =O[𝓝 x₀] fun x ↦ ‖x - x₀‖ := by
+        have : (fun x ↦ s x - s x₀) =O[𝓝 x₀] fun x ↦ ‖x - x₀‖ := s_diff.isBigO_sub.norm_right
+        refine IsBigO.trans ?_ this
+        change ((fun t ↦ ∫ s in s x₀..t, bound s) ∘ s) =O[𝓝 x₀] ((fun t ↦ t - s x₀) ∘ s)
+        refine IsBigO.comp_tendsto ?_ s_diff.continuousAt
+        have M : StronglyMeasurableAtFilter bound (𝓝 (s x₀)) volume :=
+          ⟨Ioo a₀ b₀, Ioo_nhds, bound_integrable.1⟩
+        refine (intervalIntegral.integral_hasDerivAt_right (bound_int ha hsx₀)
+          M bound_cont).hasFDerivAt.isBigO_sub.congr' ?_ EventuallyEq.rfl
+        filter_upwards [Ioo_nhds]
+        rintro t ht
+        rw [intervalIntegral.integral_interval_sub_left (bound_int ha ht) (bound_int ha hsx₀)]
+      have O₂ : (fun x ↦ ‖x - x₀‖) =O[𝓝 x₀] fun x ↦ ‖x - x₀‖ := isBigO_refl _ _
+      have O₃ : (fun x ↦ ∫ t : ℝ in s x₀..s x, F x t - F x₀ t) =O[𝓝 x₀] fun x ↦
+          (∫ t' in s x₀..s x, bound t') * ‖x - x₀‖ := by
+        have bdd : ∀ᶠ x in 𝓝 x₀,
+            ‖∫ s in s x₀..s x, F x s - F x₀ s‖ ≤ |∫ s in s x₀..s x, bound s| * ‖x - x₀‖ := by
+          filter_upwards [mem_nhds]
+          rintro x ⟨hx : x ∈ ball x₀ ε, hsx : s x ∈ Ioo a₀ b₀⟩
+          rw [← abs_of_nonneg (norm_nonneg <| x - x₀), ← abs_mul, ←
+            intervalIntegral.integral_mul_const]
+          apply intervalIntegral.norm_integral_le_abs_of_norm_le _
+            ((bound_int hsx₀ hsx).mul_const _)
+          apply ae_restrict_of_ae_restrict_of_subset (ordConnected_Ioo.uIoc_subset hsx₀ hsx)
+          apply h_lipsch.mono
+          intro t ht
+          rw [lipschitzOnWith_iff_norm_sub_le] at ht
+          simp only [coe_nnabs] at ht
+          rw [← abs_of_nonneg (bound_nonneg t)]
+          exact ht hx (mem_ball_self ε_pos)
+        rw [← isBigO_norm_right]
+        simp only [norm_eq_abs, abs_mul, abs_norm]
+        exact bdd.isBigO
+      simp_rw [pow_two]
+      exact O₃.trans (O₁.mul O₂)
+    have : ∀ᶠ x in 𝓝 x₀,
+        ∫ t in a..s x, F x t =
+          (φ x (s x₀) + φ x₀ (s x) + ∫ t in s x₀..s x, F x t - F x₀ t) - φ x₀ (s x₀) := by
+      filter_upwards [mem_nhds]
+      rintro x ⟨hx : x ∈ ball x₀ ε, hsx : s x ∈ Ioo a₀ b₀⟩
+      have int₁ : IntervalIntegrable (F x₀) volume (s x₀) (s x) := hF_int_ball hx₀ hsx₀ hsx
+      have int₂ : IntervalIntegrable (F x) volume (s x₀) (s x) := hF_int_ball hx hsx₀ hsx
+      dsimp [φ]
+      rw [intervalIntegral.integral_sub int₂ int₁, add_sub, add_right_comm, sub_sub,
+        intervalIntegral.integral_add_adjacent_intervals (hF_int_ball hx ha hsx₀) int₂,
+        ← intervalIntegral.integral_add_adjacent_intervals (hF_int_ball hx₀ ha hsx₀) int₁]
+      abel
+    apply HasFDerivAt.congr_of_eventuallyEq _ this
+    simpa [Pi.sub_def] using ((D₁.add D₂).add D₃).sub (hasFDerivAt_const (φ x₀ (s x₀)) x₀)
+
+@[inherit_doc] local notation:70 u " ⬝ " φ =>
+  ContinuousLinearMap.comp (ContinuousLinearMap.toSpanSingleton ℝ u) φ
+
+end
 
 section
 


### PR DESCRIPTION
From sphere-eversion.

---

TODO: explicitly make Floris a co-author again
- [ ] depends on: #30608
- [ ] depends on: #30612


<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include at least one commit authored by each
co-author among the commits in the pull request. If necessary, you may 
create empty commits to indicate co-authorship, using commands like so:

git commit --author="Author Name <author@email.com>" --allow-empty -m "add Author Name as coauthor"

When merging, all the commits will be squashed into a single commit listing all co-authors.

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
