### PR TITLE
[Merged by Bors] - feat(Analysis/InnerProductSpace/TensorProduct): `LinearIsometry.lTensor` and `.rTensor`

### DIFF
--- a/Mathlib/Analysis/InnerProductSpace/TensorProduct.lean
+++ b/Mathlib/Analysis/InnerProductSpace/TensorProduct.lean
@@ -289,8 +289,14 @@ lemma _root_.LinearIsometryEquiv.symm_rTensor (f : E ≃ₗᵢ[𝕜] F) :
 @[simp] lemma _root_.LinearIsometryEquiv.toLinearEquiv_lTensor (f : F ≃ₗᵢ[𝕜] G) :
     (f.lTensor E).toLinearEquiv = f.toLinearEquiv.lTensor E := rfl
 
+@[simp] lemma _root_.LinearIsometryEquiv.toLinearIsometry_lTensor (f : F ≃ₗᵢ[𝕜] G) :
+    (f.lTensor E).toLinearIsometry = f.toLinearIsometry.lTensor E := rfl
+
 @[simp] lemma _root_.LinearIsometryEquiv.toLinearEquiv_rTensor (f : E ≃ₗᵢ[𝕜] F) :
     (f.rTensor G).toLinearEquiv = f.toLinearEquiv.rTensor G := rfl
+
+@[simp] lemma _root_.LinearIsometryEquiv.toLinearIsometry_rTensor (f : E ≃ₗᵢ[𝕜] F) :
+    (f.rTensor G).toLinearIsometry = f.toLinearIsometry.rTensor G := rfl
 
 @[simp] lemma _root_.LinearIsometryEquiv.lTensor_apply (f : F ≃ₗᵢ[𝕜] G) (x : E ⊗[𝕜] F) :
     f.lTensor E x = f.toLinearEquiv.lTensor E x := rfl

--- a/Mathlib/Analysis/InnerProductSpace/TensorProduct.lean
+++ b/Mathlib/Analysis/InnerProductSpace/TensorProduct.lean
@@ -216,12 +216,12 @@ def mapIsometry (f : E →ₗᵢ[𝕜] G) (g : F →ₗᵢ[𝕜] H) :
     mapIsometry (.id : E →ₗᵢ[𝕜] E) (.id : F →ₗᵢ[𝕜] F) = .id := by ext; simp
 
 variable (E) in
-/-- This is the linear isometry version of `LinearMap.lTensor E f` when `f` is a linear isometry. -/
+/-- This is the natural linear isometry induced by `f : F ≃ₗᵢ G`. -/
 def _root_.LinearIsometry.lTensor (f : F →ₗᵢ[𝕜] G) :
     E ⊗[𝕜] F →ₗᵢ[𝕜] E ⊗[𝕜] G := mapIsometry .id f
 
 variable (G) in
-/-- This is the linear isometry version of `LinearMap.rTensor G f` when `f` is a linear isometry. -/
+/-- This is the natural linear isometry induced by `f : E ≃ₗᵢ F`. -/
 def _root_.LinearIsometry.rTensor (f : E →ₗᵢ[𝕜] F) :
     E ⊗[𝕜] G →ₗᵢ[𝕜] F ⊗[𝕜] G := mapIsometry f .id
 
@@ -265,14 +265,12 @@ lemma congrIsometry_symm (f : E ≃ₗᵢ[𝕜] G) (g : F ≃ₗᵢ[𝕜] H) :
   LinearIsometryEquiv.toLinearEquiv_inj.mp <| LinearEquiv.toLinearMap_inj.mp <| by ext; simp
 
 variable (E) in
-/-- This is the linear isometry equivalence version of `LinearEquiv.lTensor E f` when `f` is a
-linear isometry equivalence. -/
+/-- This is the natural linear isometric equivalence induced by `f : F ≃ₗᵢ G`. -/
 def _root_.LinearIsometryEquiv.lTensor (f : F ≃ₗᵢ[𝕜] G) :
     E ⊗[𝕜] F ≃ₗᵢ[𝕜] E ⊗[𝕜] G := congrIsometry (.refl 𝕜 E) f
 
 variable (G) in
-/-- This is the linear isometry equivalence version of `LinearEquiv.rTensor G f` when `f` is a
-linear isometry equivalence. -/
+/-- This is the natural linear isometric equivalence induced by `f : E ≃ₗᵢ F`. -/
 def _root_.LinearIsometryEquiv.rTensor (f : E ≃ₗᵢ[𝕜] F) :
     E ⊗[𝕜] G ≃ₗᵢ[𝕜] F ⊗[𝕜] G := congrIsometry f (.refl 𝕜 G)
 

--- a/Mathlib/Analysis/InnerProductSpace/TensorProduct.lean
+++ b/Mathlib/Analysis/InnerProductSpace/TensorProduct.lean
@@ -216,10 +216,12 @@ def mapIsometry (f : E →ₗᵢ[𝕜] G) (g : F →ₗᵢ[𝕜] H) :
     mapIsometry (.id : E →ₗᵢ[𝕜] E) (.id : F →ₗᵢ[𝕜] F) = .id := by ext; simp
 
 variable (E) in
+/-- This is the linear isometry version of `LinearMap.lTensor E f` when `f` is a linear isometry. -/
 def _root_.LinearIsometry.lTensor (f : F →ₗᵢ[𝕜] G) :
     E ⊗[𝕜] F →ₗᵢ[𝕜] E ⊗[𝕜] G := mapIsometry .id f
 
 variable (G) in
+/-- This is the linear isometry version of `LinearMap.rTensor G f` when `f` is a linear isometry. -/
 def _root_.LinearIsometry.rTensor (f : E →ₗᵢ[𝕜] F) :
     E ⊗[𝕜] G →ₗᵢ[𝕜] F ⊗[𝕜] G := mapIsometry f .id
 
@@ -263,10 +265,14 @@ lemma congrIsometry_symm (f : E ≃ₗᵢ[𝕜] G) (g : F ≃ₗᵢ[𝕜] H) :
   LinearIsometryEquiv.toLinearEquiv_inj.mp <| LinearEquiv.toLinearMap_inj.mp <| by ext; simp
 
 variable (E) in
+/-- This is the linear isometry equivalence version of `LinearEquiv.lTensor E f` when `f` is a
+linear isometry equivalence. -/
 def _root_.LinearIsometryEquiv.lTensor (f : F ≃ₗᵢ[𝕜] G) :
     E ⊗[𝕜] F ≃ₗᵢ[𝕜] E ⊗[𝕜] G := congrIsometry (.refl 𝕜 E) f
 
 variable (G) in
+/-- This is the linear isometry equivalence version of `LinearEquiv.rTensor G f` when `f` is a
+linear isometry equivalence. -/
 def _root_.LinearIsometryEquiv.rTensor (f : E ≃ₗᵢ[𝕜] F) :
     E ⊗[𝕜] G ≃ₗᵢ[𝕜] F ⊗[𝕜] G := congrIsometry f (.refl 𝕜 G)
 

--- a/Mathlib/Analysis/InnerProductSpace/TensorProduct.lean
+++ b/Mathlib/Analysis/InnerProductSpace/TensorProduct.lean
@@ -282,10 +282,10 @@ lemma _root_.LinearIsometryEquiv.lTensor_def (f : F ≃ₗᵢ[𝕜] G) :
 lemma _root_.LinearIsometryEquiv.rTensor_def (f : E ≃ₗᵢ[𝕜] F) :
     f.rTensor G = congrIsometry f (.refl 𝕜 G) := rfl
 
-lemma _root_.LinearIsometryEquiv.lTensor_symm (f : F ≃ₗᵢ[𝕜] G) :
+lemma _root_.LinearIsometryEquiv.symm_lTensor (f : F ≃ₗᵢ[𝕜] G) :
     (f.lTensor E).symm = f.symm.lTensor E := rfl
 
-lemma _root_.LinearIsometryEquiv.rTensor_symm (f : E ≃ₗᵢ[𝕜] F) :
+lemma _root_.LinearIsometryEquiv.symm_rTensor (f : E ≃ₗᵢ[𝕜] F) :
     (f.rTensor G).symm = f.symm.rTensor G := rfl
 
 @[simp] lemma _root_.LinearIsometryEquiv.toLinearEquiv_lTensor (f : F ≃ₗᵢ[𝕜] G) :

--- a/Mathlib/Analysis/InnerProductSpace/TensorProduct.lean
+++ b/Mathlib/Analysis/InnerProductSpace/TensorProduct.lean
@@ -212,6 +212,35 @@ def mapIsometry (f : E →ₗᵢ[𝕜] G) (g : F →ₗᵢ[𝕜] H) :
 @[simp] lemma enorm_map (f : E →ₗᵢ[𝕜] G) (g : F →ₗᵢ[𝕜] H) (x : E ⊗[𝕜] F) :
     ‖map f.toLinearMap g.toLinearMap x‖ₑ = ‖x‖ₑ := mapIsometry f g |>.enorm_map x
 
+@[simp] lemma mapIsometry_id_id :
+    mapIsometry (.id : E →ₗᵢ[𝕜] E) (.id : F →ₗᵢ[𝕜] F) = .id := by ext; simp
+
+variable (E) in
+def _root_.LinearIsometry.lTensor (f : F →ₗᵢ[𝕜] G) :
+    E ⊗[𝕜] F →ₗᵢ[𝕜] E ⊗[𝕜] G := mapIsometry .id f
+
+variable (G) in
+def _root_.LinearIsometry.rTensor (f : E →ₗᵢ[𝕜] F) :
+    E ⊗[𝕜] G →ₗᵢ[𝕜] F ⊗[𝕜] G := mapIsometry f .id
+
+lemma _root_.LinearIsometry.lTensor_def (f : F →ₗᵢ[𝕜] G) :
+    f.lTensor E = mapIsometry .id f := rfl
+
+lemma _root_.LinearIsometry.rTensor_def (f : E →ₗᵢ[𝕜] F) :
+    f.rTensor G = mapIsometry f .id := rfl
+
+@[simp] lemma _root_.LinearIsometry.toLinearMap_lTensor (f : F →ₗᵢ[𝕜] G) :
+    (f.lTensor E).toLinearMap = f.toLinearMap.lTensor E := rfl
+
+@[simp] lemma _root_.LinearIsometry.toLinearMap_rTensor (f : E →ₗᵢ[𝕜] F) :
+    (f.rTensor G).toLinearMap = f.toLinearMap.rTensor G := rfl
+
+@[simp] lemma _root_.LinearIsometry.lTensor_apply (f : F →ₗᵢ[𝕜] G) (x : E ⊗[𝕜] F) :
+    f.lTensor E x = f.toLinearMap.lTensor E x := rfl
+
+@[simp] lemma _root_.LinearIsometry.rTensor_apply (f : E →ₗᵢ[𝕜] F) (x : E ⊗[𝕜] G) :
+    f.rTensor G x = f.toLinearMap.rTensor G x := rfl
+
 /-- The tensor product of two linear isometry equivalences is a linear isometry equivalence.
 In particular, this is the linear isometry equivalence version of `TensorProduct.congr f g` when `f`
 and `g` are linear isometry equivalences. -/
@@ -228,6 +257,36 @@ lemma congrIsometry_symm (f : E ≃ₗᵢ[𝕜] G) (g : F ≃ₗᵢ[𝕜] H) :
 
 @[simp] lemma toLinearEquiv_congrIsometry (f : E ≃ₗᵢ[𝕜] G) (g : F ≃ₗᵢ[𝕜] H) :
     (congrIsometry f g).toLinearEquiv = congr f.toLinearEquiv g.toLinearEquiv := rfl
+
+@[simp] lemma congrIsometry_refl_refl :
+    congrIsometry (.refl 𝕜 E) (.refl 𝕜 F) = .refl 𝕜 (E ⊗ F) :=
+  LinearIsometryEquiv.toLinearEquiv_inj.mp <| LinearEquiv.toLinearMap_inj.mp <| by ext; simp
+
+variable (E) in
+def _root_.LinearIsometryEquiv.lTensor (f : F ≃ₗᵢ[𝕜] G) :
+    E ⊗[𝕜] F ≃ₗᵢ[𝕜] E ⊗[𝕜] G := congrIsometry (.refl 𝕜 E) f
+
+variable (G) in
+def _root_.LinearIsometryEquiv.rTensor (f : E ≃ₗᵢ[𝕜] F) :
+    E ⊗[𝕜] G ≃ₗᵢ[𝕜] F ⊗[𝕜] G := congrIsometry f (.refl 𝕜 G)
+
+lemma _root_.LinearIsometryEquiv.lTensor_def (f : F ≃ₗᵢ[𝕜] G) :
+    f.lTensor E = congrIsometry (.refl 𝕜 E) f := rfl
+
+lemma _root_.LinearIsometryEquiv.rTensor_def (f : E ≃ₗᵢ[𝕜] F) :
+    f.rTensor G = congrIsometry f (.refl 𝕜 G) := rfl
+
+@[simp] lemma _root_.LinearIsometryEquiv.toLinearEquiv_lTensor (f : F ≃ₗᵢ[𝕜] G) :
+    (f.lTensor E).toLinearEquiv = f.toLinearEquiv.lTensor E := rfl
+
+@[simp] lemma _root_.LinearIsometryEquiv.toLinearEquiv_rTensor (f : E ≃ₗᵢ[𝕜] F) :
+    (f.rTensor G).toLinearEquiv = f.toLinearEquiv.rTensor G := rfl
+
+@[simp] lemma _root_.LinearIsometryEquiv.lTensor_apply (f : F ≃ₗᵢ[𝕜] G) (x : E ⊗[𝕜] F) :
+    f.lTensor E x = f.toLinearEquiv.lTensor E x := rfl
+
+@[simp] lemma _root_.LinearIsometryEquiv.rTensor_apply (f : E ≃ₗᵢ[𝕜] F) (x : E ⊗[𝕜] G) :
+    f.rTensor G x = f.toLinearEquiv.rTensor G x := rfl
 
 /-- The linear isometry version of `TensorProduct.mapIncl`. -/
 def mapInclIsometry (E' : Submodule 𝕜 E) (F' : Submodule 𝕜 F) :

--- a/Mathlib/Analysis/InnerProductSpace/TensorProduct.lean
+++ b/Mathlib/Analysis/InnerProductSpace/TensorProduct.lean
@@ -276,6 +276,12 @@ lemma _root_.LinearIsometryEquiv.lTensor_def (f : F ≃ₗᵢ[𝕜] G) :
 lemma _root_.LinearIsometryEquiv.rTensor_def (f : E ≃ₗᵢ[𝕜] F) :
     f.rTensor G = congrIsometry f (.refl 𝕜 G) := rfl
 
+lemma _root_.LinearIsometryEquiv.lTensor_symm (f : F ≃ₗᵢ[𝕜] G) :
+    (f.lTensor E).symm = f.symm.lTensor E := rfl
+
+lemma _root_.LinearIsometryEquiv.rTensor_symm (f : E ≃ₗᵢ[𝕜] F) :
+    (f.rTensor G).symm = f.symm.rTensor G := rfl
+
 @[simp] lemma _root_.LinearIsometryEquiv.toLinearEquiv_lTensor (f : F ≃ₗᵢ[𝕜] G) :
     (f.lTensor E).toLinearEquiv = f.toLinearEquiv.lTensor E := rfl
 


### PR DESCRIPTION
This adds the linear isometry versions of `LinearMap.lTensor` and `LinearMap.rTensor`.

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include at least one commit authored by each
co-author among the commits in the pull request. If necessary, you may 
create empty commits to indicate co-authorship, using commands like so:

git commit --author="Author Name <author@email.com>" --allow-empty -m "add Author Name as coauthor"

When merging, all the commits will be squashed into a single commit listing all co-authors.

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
