### PR TITLE
[Merged by Bors] - chore: golf proof for `choose_le_two_pow`

### DIFF
--- a/Mathlib/Data/Nat/Choose/Bounds.lean
+++ b/Mathlib/Data/Nat/Choose/Bounds.lean
@@ -79,8 +79,8 @@ theorem choose_lt_two_pow (n k : ℕ) (p : 0 < n) : n.choose k < 2 ^ n := by
   exact choose_succ_le_two_pow (n - 1) k
 
 theorem choose_le_two_pow (n k : ℕ) : n.choose k ≤ 2 ^ n := by
-  obtain (rfl | hk) := eq_zero_or_pos n
+  obtain (rfl | hn) := eq_zero_or_pos n
   · cases k <;> simp
-  · exact le_of_lt (choose_lt_two_pow n k hk)
+  · exact (Nat.choose_lt_two_pow _ _ hn).le
 
 end Nat

--- a/Mathlib/Data/Nat/Choose/Bounds.lean
+++ b/Mathlib/Data/Nat/Choose/Bounds.lean
@@ -79,11 +79,8 @@ theorem choose_lt_two_pow (n k : ℕ) (p : 0 < n) : n.choose k < 2 ^ n := by
   exact choose_succ_le_two_pow (n - 1) k
 
 theorem choose_le_two_pow (n k : ℕ) : n.choose k ≤ 2 ^ n := by
-  obtain (rfl | hk) := eq_zero_or_pos k
-  · simp [Nat.one_le_two_pow]
-  · obtain (rfl | hn) := eq_zero_or_pos n
-    · have : choose 0 k = 0 := by convert Nat.choose_zero_succ (k - 1); omega
-      simp [this]
-    · exact (Nat.choose_lt_two_pow _ _ hn).le
+  obtain (rfl | hk) := eq_zero_or_pos n
+  · cases k <;> simp
+  · exact le_of_lt (choose_lt_two_pow n k hk)
 
 end Nat


### PR DESCRIPTION
This is a quick PR for golf I noticed on a lemma bounding `Nat.choose`

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include at least one commit authored by each
co-author among the commits in the pull request. If necessary, you may 
create empty commits to indicate co-authorship, using commands like so:

git commit --author="Author Name <author@email.com>" --allow-empty -m "add Author Name as coauthor"

When merging, all the commits will be squashed into a single commit listing all co-authors.

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
