### PR TITLE
[Merged by Bors] - refactor(AlgebraicGeometry) : an argument is incorrectly explicit

### DIFF
--- a/Mathlib/AlgebraicGeometry/EllipticCurve/Affine/Point.lean
+++ b/Mathlib/AlgebraicGeometry/EllipticCurve/Affine/Point.lean
@@ -85,12 +85,14 @@ namespace Affine
 
 /-! ## The affine coordinate ring -/
 
+variable (W') in
 /-- The affine coordinate ring `R[W] := R[X, Y] / ⟨W(X, Y)⟩` of a Weierstrass curve `W`. -/
-abbrev CoordinateRing (W' : Affine R) : Type r :=
+abbrev CoordinateRing : Type r :=
   AdjoinRoot W'.polynomial
 
+variable (W') in
 /-- The function field `R(W) := Frac(R[W])` of a Weierstrass curve `W`. -/
-abbrev FunctionField (W' : Affine R) : Type r :=
+abbrev FunctionField : Type r :=
   FractionRing W'.CoordinateRing
 
 namespace CoordinateRing

--- a/Mathlib/AlgebraicGeometry/EllipticCurve/Affine/Point.lean
+++ b/Mathlib/AlgebraicGeometry/EllipticCurve/Affine/Point.lean
@@ -86,11 +86,11 @@ namespace Affine
 /-! ## The affine coordinate ring -/
 
 /-- The affine coordinate ring `R[W] := R[X, Y] / ⟨W(X, Y)⟩` of a Weierstrass curve `W`. -/
-abbrev CoordinateRing : Type r :=
+abbrev CoordinateRing (W' : Affine R) : Type r :=
   AdjoinRoot W'.polynomial
 
 /-- The function field `R(W) := Frac(R[W])` of a Weierstrass curve `W`. -/
-abbrev FunctionField : Type r :=
+abbrev FunctionField (W' : Affine R) : Type r :=
   FractionRing W'.CoordinateRing
 
 namespace CoordinateRing


### PR DESCRIPTION
An argument `W'` is incorrectly implicit in [`WeierstrassCurve.Affine.CoordinateRing`](https://leanprover-community.github.io/mathlib4_docs/Mathlib/AlgebraicGeometry/EllipticCurve/Affine/Point.html#WeierstrassCurve.Affine.CoordinateRing) and [`WeierstrassCurve.Affine.FunctionField`](https://leanprover-community.github.io/mathlib4_docs/Mathlib/AlgebraicGeometry/EllipticCurve/Affine/Point.html#WeierstrassCurve.Affine.FunctionField). This issue has not surfaced because the dot notation (`W'.CoordinateRing`) is always used.


---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include at least one commit authored by each
co-author among the commits in the pull request. If necessary, you may 
create empty commits to indicate co-authorship, using commands like so:

git commit --author="Author Name <author@email.com>" --allow-empty -m "add Author Name as coauthor"

When merging, all the commits will be squashed into a single commit listing all co-authors.

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
