### PR TITLE
feat: elementary lemmas aiding computations with `log⁺`

### DIFF
--- a/Mathlib/Analysis/SpecialFunctions/Log/PosLog.lean
+++ b/Mathlib/Analysis/SpecialFunctions/Log/PosLog.lean
@@ -16,6 +16,8 @@ estimates.
 
 - `theorem posLog_sum : log⁺ (∑ i, f i) ≤ log n + ∑ i, log⁺ (f i)`
 
+See `Mathlib.Analysis.SpecialFunctions.Integrals.PosLogEqCircleAverage` for the presentation of
+`log⁺` as a Circle Average.
 -/
 
 namespace Real
@@ -35,6 +37,7 @@ theorem posLog_def {r : ℝ} : log⁺ r = max 0 (log r) := rfl
 /-!
 ## Elementary Properties
 -/
+
 /-- Presentation of `log` in terms of its positive part. -/
 theorem posLog_sub_posLog_inv {r : ℝ} : log⁺ r - log⁺ r⁻¹ = log r := by
   rw [posLog_def, posLog_def, log_inv]
@@ -49,6 +52,10 @@ theorem half_mul_log_add_log_abs {r : ℝ} : 2⁻¹ * (log r + |log r|) = log⁺
   · simp [posLog, hr, abs_of_nonneg]
     ring
   · simp [posLog, le_of_not_ge hr, abs_of_nonpos]
+
+@[simp] lemma posLog_zero : log⁺ 0 = 0 := by simp [posLog]
+
+@[simp] lemma posLog_one : log⁺ 1 = 0 := by simp [posLog]
 
 /-- The positive part of `log` is never negative. -/
 theorem posLog_nonneg {x : ℝ} : 0 ≤ log⁺ x := by simp [posLog]
@@ -91,9 +98,21 @@ theorem monotoneOn_posLog : MonotoneOn log⁺ (Set.Ici 0) := by
     simp only [this, and_true, ge_iff_le]
     linarith
 
+/-- The function `log⁺` commutes with taking powers. -/
+@[simp] lemma posLog_pow {n : ℕ} {a : ℝ} :
+    log⁺ (a ^ n) = n * log⁺ a := by
+  by_cases hn : n = 0
+  · simp_all
+  by_cases h₂a : |a| ≤ 1
+  · simp_all [pow_le_one₀, (posLog_eq_zero_iff _).2]
+  rw [not_le] at h₂a
+  have : 1 < |a ^ n| := by simp [one_lt_pow₀ h₂a hn]
+  simp [posLog_eq_log this.le, posLog_eq_log h₂a.le]
+
 /-!
 ## Estimates for Products
 -/
+
 /-- Estimate for `log⁺` of a product. See `Real.posLog_prod` for a variant involving
 multiple factors. -/
 theorem posLog_mul {a b : ℝ} :
@@ -130,8 +149,10 @@ theorem posLog_prod {α : Type*} (s : Finset α) (f : α → ℝ) :
 /-!
 ## Estimates for Sums
 -/
-/-- Estimate for `log⁺` of a sum. See `Real.posLog_add` for a variant involving
-just two summands. -/
+
+/--
+Estimate for `log⁺` of a sum. See `Real.posLog_add` for a variant involving just two summands.
+-/
 theorem posLog_sum {α : Type*} (s : Finset α) (f : α → ℝ) :
     log⁺ (∑ t ∈ s, f t) ≤ log (s.card) + ∑ t ∈ s, log⁺ (f t) := by
   -- Trivial case: empty sum
@@ -158,8 +179,23 @@ theorem posLog_sum {α : Type*} (s : Finset α) (f : α → ℝ) :
     rw [posLog_abs]
     apply Finset.single_le_sum (fun _ _ ↦ posLog_nonneg) ht_max.1
 
-/-- Estimate for `log⁺` of a sum. See `Real.posLog_sum` for a variant involving
-multiple summands. -/
+/--
+Variant of `posLog_sum` for norms of elements in normed additive commutative
+groups, using monotonicity of `log⁺` and the triangle inequality.
+-/
+lemma posLog_norm_sum_le {E : Type*} [NormedAddCommGroup E]
+    {α : Type*} (s : Finset α) (f : α → E) :
+    log⁺ ‖∑ t ∈ s, f t‖ ≤ log s.card + ∑ t ∈ s, log⁺ ‖f t‖ := by
+  calc log⁺ ‖∑ t ∈ s, f t‖
+  _ ≤ log⁺ (∑ t ∈ s, ‖f t‖) := by
+    apply monotoneOn_posLog (by simp) _ (norm_sum_le s f)
+    simp [Finset.sum_nonneg (fun i _ ↦ norm_nonneg (f i))]
+  _ ≤ log s.card + ∑ t ∈ s, log⁺ ‖f t‖ :=
+    posLog_sum s (‖f ·‖)
+
+/--
+Estimate for `log⁺` of a sum. See `Real.posLog_sum` for a variant involving multiple summands.
+-/
 theorem posLog_add {a b : ℝ} : log⁺ (a + b) ≤ log 2 + log⁺ a + log⁺ b := by
   convert posLog_sum Finset.univ ![a, b] using 1 <;> simp [add_assoc]
 

--- a/Mathlib/Analysis/SpecialFunctions/Log/PosLog.lean
+++ b/Mathlib/Analysis/SpecialFunctions/Log/PosLog.lean
@@ -16,7 +16,7 @@ estimates.
 
 - `theorem posLog_sum : log⁺ (∑ i, f i) ≤ log n + ∑ i, log⁺ (f i)`
 
-See `Mathlib.Analysis.SpecialFunctions.Integrals.PosLogEqCircleAverage` for the presentation of
+See `Mathlib/Analysis/SpecialFunctions/Integrals/PosLogEqCircleAverage.lean` for the presentation of
 `log⁺` as a Circle Average.
 -/
 

--- a/Mathlib/Analysis/SpecialFunctions/Log/PosLog.lean
+++ b/Mathlib/Analysis/SpecialFunctions/Log/PosLog.lean
@@ -26,29 +26,29 @@ namespace Real
 ## Definition, Notation and Reformulations
 -/
 /-- Definition: the positive part of the logarithm. -/
-noncomputable def posLog : ℝ → ℝ := fun r ↦ max 0 (log r)
+noncomputable def posLog : ℝ → ℝ := fun x ↦ max 0 (log x)
 
 /-- Notation `log⁺` for the positive part of the logarithm. -/
 scoped notation "log⁺" => posLog
 
 /-- Definition of the positive part of the logarithm, formulated as a theorem. -/
-theorem posLog_def {r : ℝ} : log⁺ r = max 0 (log r) := rfl
+theorem posLog_def {x : ℝ} : log⁺ x = max 0 (log x) := rfl
 
 /-!
 ## Elementary Properties
 -/
 
 /-- Presentation of `log` in terms of its positive part. -/
-theorem posLog_sub_posLog_inv {r : ℝ} : log⁺ r - log⁺ r⁻¹ = log r := by
+theorem posLog_sub_posLog_inv {x : ℝ} : log⁺ x - log⁺ x⁻¹ = log x := by
   rw [posLog_def, posLog_def, log_inv]
-  by_cases h : 0 ≤ log r
+  by_cases h : 0 ≤ log x
   · simp [h]
   · rw [not_le] at h
     simp [neg_nonneg.1 (Left.nonneg_neg_iff.2 h.le)]
 
 /-- Presentation of `log⁺` in terms of `log`. -/
-theorem half_mul_log_add_log_abs {r : ℝ} : 2⁻¹ * (log r + |log r|) = log⁺ r := by
-  by_cases hr : 0 ≤ log r
+theorem half_mul_log_add_log_abs {x : ℝ} : 2⁻¹ * (log x + |log x|) = log⁺ x := by
+  by_cases hr : 0 ≤ log x
   · simp [posLog, hr, abs_of_nonneg]
     ring
   · simp [posLog, le_of_not_ge hr, abs_of_nonpos]
@@ -99,15 +99,14 @@ theorem monotoneOn_posLog : MonotoneOn log⁺ (Set.Ici 0) := by
     linarith
 
 /-- The function `log⁺` commutes with taking powers. -/
-@[simp] lemma posLog_pow {n : ℕ} {a : ℝ} :
-    log⁺ (a ^ n) = n * log⁺ a := by
+@[simp] lemma posLog_pow {n : ℕ} {x : ℝ} : log⁺ (x ^ n) = n * log⁺ x := by
   by_cases hn : n = 0
   · simp_all
-  by_cases h₂a : |a| ≤ 1
+  by_cases hx : |x| ≤ 1
   · simp_all [pow_le_one₀, (posLog_eq_zero_iff _).2]
-  rw [not_le] at h₂a
-  have : 1 < |a ^ n| := by simp [one_lt_pow₀ h₂a hn]
-  simp [posLog_eq_log this.le, posLog_eq_log h₂a.le]
+  rw [not_le] at hx
+  have : 1 ≤ |x ^ n| := by simp_all [one_le_pow₀, hx.le]
+  simp [posLog_eq_log this, posLog_eq_log hx.le]
 
 /-!
 ## Estimates for Products
@@ -115,20 +114,18 @@ theorem monotoneOn_posLog : MonotoneOn log⁺ (Set.Ici 0) := by
 
 /-- Estimate for `log⁺` of a product. See `Real.posLog_prod` for a variant involving
 multiple factors. -/
-theorem posLog_mul {a b : ℝ} :
-    log⁺ (a * b) ≤ log⁺ a + log⁺ b := by
-  by_cases ha : a = 0
-  · simp [ha, posLog]
-  by_cases hb : b = 0
-  · simp [hb, posLog]
+theorem posLog_mul {x₁ x₂ : ℝ} : log⁺ (x₁ * x₂) ≤ log⁺ x₁ + log⁺ x₂ := by
+  by_cases h₁ : x₁ = 0
+  · simp [h₁, posLog]
+  by_cases h₂ : x₂ = 0
+  · simp [h₂, posLog]
   unfold posLog
-  nth_rw 1 [← add_zero 0, log_mul ha hb]
+  nth_rw 1 [← add_zero 0, log_mul h₁ h₂]
   exact max_add_add_le_max_add_max
 
 /-- Estimate for `log⁺` of a product. Special case of `Real.posLog_mul` where one of
 the factors is a natural number. -/
-theorem posLog_nat_mul {n : ℕ} {a : ℝ} :
-    log⁺ (n * a) ≤ log n + log⁺ a := by
+theorem posLog_nat_mul {n : ℕ} {x : ℝ} : log⁺ (n * x) ≤ log n + log⁺ x := by
   rw [← log_of_nat_eq_posLog]
   exact posLog_mul
 
@@ -196,20 +193,20 @@ lemma posLog_norm_sum_le {E : Type*} [NormedAddCommGroup E]
 /--
 Estimate for `log⁺` of a sum. See `Real.posLog_sum` for a variant involving multiple summands.
 -/
-theorem posLog_add {a b : ℝ} : log⁺ (a + b) ≤ log 2 + log⁺ a + log⁺ b := by
-  convert posLog_sum Finset.univ ![a, b] using 1 <;> simp [add_assoc]
+theorem posLog_add {x₁ x₂ : ℝ} : log⁺ (x₁ + x₂) ≤ log 2 + log⁺ x₁ + log⁺ x₂ := by
+  convert posLog_sum Finset.univ ![x₁, x₂] using 1 <;> simp [add_assoc]
 
 /--
 Variant of `posLog_add` for norms of elements in normed additive commutative groups, using
 monotonicity of `log⁺` and the triangle inequality.
 -/
-lemma posLog_norm_add_le {E : Type*} [NormedAddCommGroup E] (a b : E) :
-    log⁺ ‖a + b‖ ≤ log⁺ ‖a‖ + log⁺ ‖b‖ + log 2 := by
-  calc log⁺ ‖a + b‖
-  _ ≤ log⁺ (‖a‖ + ‖b‖) := by
-    apply monotoneOn_posLog _ _ (norm_add_le a b)
-    <;> simp [add_nonneg (norm_nonneg a) (norm_nonneg b)]
-  _ ≤ log⁺ ‖a‖ + log⁺ ‖b‖ + log 2 := by
+lemma posLog_norm_add_le {E : Type*} [NormedAddCommGroup E] (x₁ x₂ : E) :
+    log⁺ ‖x₁ + x₂‖ ≤ log⁺ ‖x₁‖ + log⁺ ‖x₂‖ + log 2 := by
+  calc log⁺ ‖x₁ + x₂‖
+  _ ≤ log⁺ (‖x₁‖ + ‖x₂‖) := by
+    apply monotoneOn_posLog _ _ (norm_add_le x₁ x₂)
+    <;> simp [add_nonneg (norm_nonneg x₁) (norm_nonneg x₂)]
+  _ ≤ log⁺ ‖x₁‖ + log⁺ ‖x₂‖ + log 2 := by
     convert posLog_add using 1
     ring
 

--- a/Mathlib/Analysis/SpecialFunctions/Log/PosLog.lean
+++ b/Mathlib/Analysis/SpecialFunctions/Log/PosLog.lean
@@ -25,6 +25,7 @@ namespace Real
 /-!
 ## Definition, Notation and Reformulations
 -/
+
 /-- Definition: the positive part of the logarithm. -/
 noncomputable def posLog : ℝ → ℝ := fun x ↦ max 0 (log x)
 
@@ -114,10 +115,10 @@ theorem monotoneOn_posLog : MonotoneOn log⁺ (Set.Ici 0) := by
 
 /-- Estimate for `log⁺` of a product. See `Real.posLog_prod` for a variant involving
 multiple factors. -/
-theorem posLog_mul {x₁ x₂ : ℝ} : log⁺ (x₁ * x₂) ≤ log⁺ x₁ + log⁺ x₂ := by
-  by_cases h₁ : x₁ = 0
+theorem posLog_mul {x y : ℝ} : log⁺ (x * y) ≤ log⁺ x + log⁺ y := by
+  by_cases h₁ : x = 0
   · simp [h₁, posLog]
-  by_cases h₂ : x₂ = 0
+  by_cases h₂ : y = 0
   · simp [h₂, posLog]
   unfold posLog
   nth_rw 1 [← add_zero 0, log_mul h₁ h₂]


### PR DESCRIPTION
Add several elementary lemmas aiding computations with `log⁺`. Improve the docstrings a little.

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include at least one commit authored by each
co-author among the commits in the pull request. If necessary, you may 
create empty commits to indicate co-authorship, using commands like so:

git commit --author="Author Name <author@email.com>" --allow-empty -m "add Author Name as coauthor"

When merging, all the commits will be squashed into a single commit listing all co-authors.

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
