### PR TITLE
[Merged by Bors] - chore: use the `positivity [h, h']` syntax when useful

### DIFF
--- a/Archive/Wiedijk100Theorems/BallotProblem.lean
+++ b/Archive/Wiedijk100Theorems/BallotProblem.lean
@@ -58,8 +58,7 @@ theorem staysPositive_cons_pos (x : ℤ) (hx : 0 < x) (l : List ℤ) :
     (x::l) ∈ staysPositive ↔ l ∈ staysPositive := by
   rw [staysPositive_cons, and_iff_left_iff_imp]
   intro h
-  have := sum_nonneg_of_staysPositive h
-  positivity
+  positivity [sum_nonneg_of_staysPositive h]
 
 /-- `countedSequence p q` is the set of lists of integers for which every element is `+1` or `-1`,
 there are `p` lots of `+1` and `q` lots of `-1`.

--- a/Mathlib/Analysis/Complex/Positivity.lean
+++ b/Mathlib/Analysis/Complex/Positivity.lean
@@ -35,8 +35,7 @@ theorem nonneg_of_iteratedDeriv_nonneg {f : ℂ → ℂ} {c : ℂ} {r : ℝ}
   rw [← ofReal_natCast, ← ofReal_pow, ← ofReal_inv, eq_re_of_ofReal_le (h n), ← ofReal_mul,
     ← ofReal_mul]
   norm_cast at hz₁ ⊢
-  have := zero_re ▸ (Complex.le_def.mp (h n)).1
-  positivity
+  positivity [zero_re ▸ (Complex.le_def.mp (h n)).1]
 
 end DifferentiableOn
 

--- a/Mathlib/Analysis/Convex/Strong.lean
+++ b/Mathlib/Analysis/Convex/Strong.lean
@@ -72,16 +72,14 @@ lemma UniformConvexOn.strictConvexOn (hf : UniformConvexOn s φ f) (hφ : ∀ r,
   refine ⟨hf.1, fun x hx y hy hxy a b ha hb hab ↦ (hf.2 hx hy ha.le hb.le hab).trans_lt <|
     sub_lt_self _ ?_⟩
   rw [← sub_ne_zero, ← norm_pos_iff] at hxy
-  have := hφ _ hxy.ne'
-  positivity
+  positivity [hφ _ hxy.ne']
 
 lemma UniformConcaveOn.strictConcaveOn (hf : UniformConcaveOn s φ f) (hφ : ∀ r, r ≠ 0 → 0 < φ r) :
     StrictConcaveOn ℝ s f := by
   refine ⟨hf.1, fun x hx y hy hxy a b ha hb hab ↦ (hf.2 hx hy ha.le hb.le hab).trans_lt' <|
     lt_add_of_pos_right _ ?_⟩
   rw [← sub_ne_zero, ← norm_pos_iff] at hxy
-  have := hφ _ hxy.ne'
-  positivity
+  positivity [hφ _ hxy.ne']
 
 lemma UniformConvexOn.add (hf : UniformConvexOn s φ f) (hg : UniformConvexOn s ψ g) :
     UniformConvexOn s (φ + ψ) (f + g) := by

--- a/Mathlib/Analysis/Convex/Visible.lean
+++ b/Mathlib/Analysis/Convex/Visible.lean
@@ -107,8 +107,7 @@ lemma IsVisible.of_convexHull_of_pos {ι : Type*} {t : Finset ι} {a : ι → V}
       match_scalars <;> field_simp <;> ring
     refine (convex_convexHull _ _).mem_of_wbtw this hε <| (convex_convexHull _ _).sum_mem ?_ ?_ ?_
     · intro j hj
-      have := hw₀ j <| erase_subset _ _ hj
-      positivity
+      positivity [hw₀ j <| erase_subset _ _ hj]
     · rw [← sum_div, sum_erase_eq_sub hi, hw₁, div_self hwi.ne']
     · exact fun j hj ↦ subset_convexHull _ _ <| ha _ <| erase_subset _ _ hj
   · exact lt_add_of_pos_left _ <| by positivity

--- a/Mathlib/Analysis/SpecialFunctions/BinaryEntropy.lean
+++ b/Mathlib/Analysis/SpecialFunctions/BinaryEntropy.lean
@@ -213,8 +213,7 @@ This is a generalization of the binary entropy function `binEntropy`. -/
 
 lemma qaryEntropy_pos (hp₀ : 0 < p) (hp₁ : p < 1) : 0 < qaryEntropy q p := by
   unfold qaryEntropy
-  have := binEntropy_pos hp₀ hp₁
-  positivity
+  positivity [binEntropy_pos hp₀ hp₁]
 
 lemma qaryEntropy_nonneg (hp₀ : 0 ≤ p) (hp₁ : p ≤ 1) : 0 ≤ qaryEntropy q p := by
   obtain rfl | hp₀ := hp₀.eq_or_lt

--- a/Mathlib/Computability/AkraBazzi/AkraBazzi.lean
+++ b/Mathlib/Computability/AkraBazzi/AkraBazzi.lean
@@ -178,8 +178,7 @@ lemma growsPolynomially_deriv_rpow_p_mul_one_sub_smoothingFn (p : ℝ) :
     have h₁ : (fun x => ‖deriv (fun z => z ^ p * (1 - ε z)) x‖)
         =ᶠ[atTop] fun z => z⁻¹ / (log z ^ 2) := by
       filter_upwards [eventually_deriv_one_sub_smoothingFn, eventually_gt_atTop 1] with x hx hx_pos
-      have : 0 ≤ x⁻¹ / (log x ^ 2) := by
-        positivity
+      have : 0 ≤ x⁻¹ / (log x ^ 2) := by positivity
       simp only [hp, Real.rpow_zero, one_mul, hx, Real.norm_of_nonneg this]
     refine GrowsPolynomially.congr_of_eventuallyEq h₁ ?_
     refine GrowsPolynomially.div (GrowsPolynomially.inv growsPolynomially_id)
@@ -198,8 +197,7 @@ lemma growsPolynomially_deriv_rpow_p_mul_one_add_smoothingFn (p : ℝ) :
     have h₁ : (fun x => ‖deriv (fun z => z ^ p * (1 + ε z)) x‖)
         =ᶠ[atTop] fun z => z⁻¹ / (log z ^ 2) := by
       filter_upwards [eventually_deriv_one_add_smoothingFn, eventually_gt_atTop 1] with x hx hx_pos
-      have : 0 ≤ x⁻¹ / (log x ^ 2) := by
-        positivity
+      have : 0 ≤ x⁻¹ / (log x ^ 2) := by positivity
       simp only [neg_div, norm_neg, hp, Real.rpow_zero,
         one_mul, hx, Real.norm_of_nonneg this]
     refine GrowsPolynomially.congr_of_eventuallyEq h₁ ?_
@@ -546,8 +544,7 @@ lemma T_isBigO_smoothingFn_mul_asympBound :
                 * ((1 + (∑ u ∈ range (r i n), g u / u ^ ((p a b) + 1)))))) + g n := by
         gcongr (∑ i, C * a i * (?_
             * ((1 + (∑ u ∈ range (r i n), g u / u ^ ((p a b) + 1)))))) + g n with i
-        · have := R.a_pos i
-          positivity
+        · positivity [R.a_pos i]
         · refine add_nonneg zero_le_one <| Finset.sum_nonneg fun j _ => ?_
           rw [div_nonneg_iff]
           exact Or.inl ⟨R.g_nonneg j (by positivity), by positivity⟩
@@ -571,10 +568,8 @@ lemma T_isBigO_smoothingFn_mul_asympBound :
       _ ≤ (∑ i, C * a i * ((b i) ^ (p a b) * (1 - ε n)
                 * ((asympBound g a b n - c₁ * g n)))) + g n := by
         gcongr with i
-        · have := R.a_pos i
-          positivity
-        · have := R.b_pos i
-          positivity
+        · positivity [R.a_pos i]
+        · positivity [R.b_pos i]
         · exact h_sumTransform n hn i
       _ = (∑ i, C * (1 - ε n) * ((asympBound g a b n - c₁ * g n))
                 * (a i * (b i) ^ (p a b))) + g n := by
@@ -715,8 +710,7 @@ lemma smoothingFn_mul_asympBound_isBigO_T :
                 * ((1 + (∑ u ∈ range (r i n), g u / u ^ ((p a b) + 1)))))) + g n := by
         gcongr (∑ i, C * a i * (?_ *
             ((1 + (∑ u ∈ range (r i n), g u / u ^ ((p a b) + 1)))))) + g n with i
-        · have := R.a_pos i
-          positivity
+        · positivity [R.a_pos i]
         · refine add_nonneg zero_le_one <| Finset.sum_nonneg fun j _ => ?_
           rw [div_nonneg_iff]
           exact Or.inl ⟨R.g_nonneg j (by positivity), by positivity⟩
@@ -740,10 +734,8 @@ lemma smoothingFn_mul_asympBound_isBigO_T :
       _ ≥ (∑ i, C * a i * ((b i) ^ (p a b) * (1 + ε n)
                 * ((asympBound g a b n - c₁ * g n)))) + g n := by
         gcongr with i
-        · have := R.a_pos i
-          positivity
-        · have := R.b_pos i
-          positivity
+        · positivity [R.a_pos i]
+        · positivity [R.b_pos i]
         · exact h_sumTransform n hn i
       _ = (∑ i, C * (1 + ε n) * ((asympBound g a b n - c₁ * g n))
                 * (a i * (b i) ^ (p a b))) + g n := by congr; ext; ring

--- a/Mathlib/GroupTheory/CommutingProbability.lean
+++ b/Mathlib/GroupTheory/CommutingProbability.lean
@@ -205,7 +205,6 @@ theorem commProb_reciprocal (n : ℕ) :
       have h1 := (Nat.div_add_mod n 4).symm
       zify at h0 h1 ⊢
       linear_combination (h0 + h1 * (n % 4)) * n
-    · have := hn.pos.ne'
-      positivity
+    · positivity [hn.pos.ne']
 
 end DihedralGroup

--- a/Mathlib/NumberTheory/LSeries/PrimesInAP.lean
+++ b/Mathlib/NumberTheory/LSeries/PrimesInAP.lean
@@ -199,8 +199,7 @@ private lemma summable_F'' : Summable F'' := by
   suffices Summable fun (pk : Nat.Primes × ℕ) ↦ (pk.1 : ℝ)⁻¹ ^ (pk.2 + 3 / 2 : ℝ) by
     refine (Summable.mul_left 2 this).of_nonneg_of_le (fun pk ↦ ?_) (fun pk ↦ F''_le pk.1 pk.2)
     simp only [F'', Function.comp_apply, F', F₀, Prod.map_fst, id_eq, Prod.map_snd, Nat.cast_pow]
-    have := vonMangoldt_nonneg (n := (pk.1 : ℕ) ^ (pk.2 + 2))
-    positivity
+    positivity [vonMangoldt_nonneg (n := (pk.1 : ℕ) ^ (pk.2 + 2))]
   conv => enter [1, pk]; rw [Real.rpow_add <| hp₀ pk.1, Real.rpow_natCast]
   refine (summable_prod_of_nonneg (fun _ ↦ by positivity)).mpr ⟨(fun p ↦ ?_), ?_⟩
   · dsimp only -- otherwise the `exact` below times out
@@ -209,8 +208,7 @@ private lemma summable_F'' : Summable F'' := by
     conv => enter [1, p]; rw [tsum_mul_right, tsum_geometric_of_lt_one (hp₀ p).le (hp₁ p)]
     refine (summable_rpow.mpr (by norm_num : -(3 / 2 : ℝ) < -1)).mul_left 2
       |>.of_nonneg_of_le (fun p ↦ ?_) (fun p ↦ ?_)
-    · have := sub_pos.mpr (hp₁ p)
-      positivity
+    · positivity [sub_pos.mpr (hp₁ p)]
     · rw [Real.inv_rpow p.val.cast_nonneg, Real.rpow_neg p.val.cast_nonneg]
       gcongr
       rw [inv_le_comm₀ (sub_pos.mpr (hp₁ p)) zero_lt_two, le_sub_comm,
@@ -223,8 +221,7 @@ on primes in an arithmetic progression. -/
 lemma summable_residueClass_non_primes_div :
     Summable fun n : ℕ ↦ (if n.Prime then 0 else residueClass a n) / n := by
   have h₀ (n : ℕ) : 0 ≤ (if n.Prime then 0 else residueClass a n) / n := by
-    have := residueClass_nonneg a n
-    positivity
+    positivity [residueClass_nonneg a n]
   have hleF₀ (n : ℕ) : (if n.Prime then 0 else residueClass a n) / n ≤ F₀ n := by
     refine div_le_div_of_nonneg_right ?_ n.cast_nonneg
     split_ifs; exacts [le_rfl, residueClass_le a n]

--- a/Mathlib/Probability/Distributions/Geometric.lean
+++ b/Mathlib/Probability/Distributions/Geometric.lean
@@ -47,14 +47,12 @@ lemma geometricPMFRealSum (hp_pos : 0 < p) (hp_le_one : p ≤ 1) :
 lemma geometricPMFReal_pos {n : ℕ} (hp_pos : 0 < p) (hp_lt_one : p < 1) :
     0 < geometricPMFReal p n := by
   rw [geometricPMFReal]
-  have : 0 < 1 - p := sub_pos.mpr hp_lt_one
-  positivity
+  positivity [sub_pos.mpr hp_lt_one]
 
 lemma geometricPMFReal_nonneg {n : ℕ} (hp_pos : 0 < p) (hp_le_one : p ≤ 1) :
     0 ≤ geometricPMFReal p n := by
   rw [geometricPMFReal]
-  have : 0 ≤ 1 - p := sub_nonneg.mpr hp_le_one
-  positivity
+  positivity [sub_nonneg.mpr hp_le_one]
 
 /-- Geometric distribution with success probability `p`. -/
 noncomputable

--- a/Mathlib/Probability/Distributions/Pareto.lean
+++ b/Mathlib/Probability/Distributions/Pareto.lean
@@ -85,8 +85,7 @@ lemma paretoPDFReal_nonneg (ht : 0 ≤ t) (hr : 0 ≤ r) (x : ℝ) :
       rw [← ht0] at h
       positivity
     | inr htp =>
-      have := lt_of_lt_of_le htp h
-      positivity
+      positivity [lt_of_lt_of_le htp h]
   · positivity
 
 open Measure
@@ -105,9 +104,7 @@ lemma lintegral_paretoPDF_eq_one (ht : 0 < t) (hr : 0 < r) :
     · simp [field, ← rpow_add ht]
     linarith
   · rw [EventuallyLE, ae_restrict_iff' measurableSet_Ici]
-    refine ae_of_all _ fun x (hx : t ≤ x) ↦ ?_
-    have := lt_of_lt_of_le ht hx
-    positivity
+    filter_upwards with x hx using by positivity [lt_of_lt_of_le ht hx]
   · apply (measurable_paretoPDFReal t r).aestronglyMeasurable.congr
     refine (ae_restrict_iff' measurableSet_Ici).mpr <| ae_of_all _ fun x (hx : t ≤ x) ↦ ?_
     simp_rw [paretoPDFReal, eq_true_intro hx, ite_true]

--- a/MathlibTest/positivity.lean
+++ b/MathlibTest/positivity.lean
@@ -557,9 +557,7 @@ example (f : ULift.{2} ℕ → ℤ) (s : Finset (ULift.{2} ℕ)) : 0 ≤ ∑ j �
 example (n : ℕ) (f : ℕ → ℤ) : 0 ≤ ∑ j : Fin 8, ∑ i ∈ range n, (f j ^ 2 + i ^ 2) := by positivity
 example (n : ℕ) (f : ℕ → ℤ) : 0 < ∑ j : Fin (n + 1), (f j ^ 2 + 1) := by positivity
 example (f : Empty → ℤ) : 0 ≤ ∑ j : Empty, f j ^ 2 := by positivity
-example (f : ℕ → ℤ) : 0 < ∑ j ∈ ({1} : Finset ℕ), (f j ^ 2 + 1) := by
-  have : Finset.Nonempty {1} := singleton_nonempty 1
-  positivity
+example (f : ℕ → ℤ) : 0 < ∑ j ∈ ({1} : Finset ℕ), (f j ^ 2 + 1) := by positivity
 example (s : Finset ℕ) : 0 ≤ ∑ j ∈ s, j := by positivity
 example (s : Finset ℕ) : 0 ≤ s.sum id := by positivity
 example (s : Finset ℕ) (f : ℕ → ℕ) (a : ℕ) : 0 ≤ s.sum (f a) := by positivity
@@ -575,9 +573,7 @@ example (n : ℕ) (a : ℕ → ℤ) : 0 ≤ ∏ j ∈ range n, a j^2 := by posit
 example (a : ULift.{2} ℕ → ℤ) (s : Finset (ULift.{2} ℕ)) : 0 ≤ ∏ j ∈ s, a j^2 := by positivity
 example (n : ℕ) (a : ℕ → ℤ) : 0 ≤ ∏ j : Fin 8, ∏ i ∈ range n, (a j^2 + i ^ 2) := by positivity
 example (n : ℕ) (a : ℕ → ℤ) : 0 < ∏ j : Fin (n + 1), (a j^2 + 1) := by positivity
-example (a : ℕ → ℤ) : 0 < ∏ j ∈ ({1} : Finset ℕ), (a j^2 + 1) := by
-  have : Finset.Nonempty {1} := singleton_nonempty 1
-  positivity
+example (a : ℕ → ℤ) : 0 < ∏ j ∈ ({1} : Finset ℕ), (a j^2 + 1) := by positivity
 example (s : Finset ℕ) : 0 ≤ ∏ j ∈ s, j := by positivity
 example (s : Finset ℕ) : 0 ≤ s.sum id := by positivity
 example (s : Finset ℕ) (f : ℕ → ℕ) (a : ℕ) : 0 ≤ s.sum (f a) := by positivity


### PR DESCRIPTION
Since #30388, `have := foo; positivity` can be shortened to `positivity [foo]`.
Make use of that when sensible.

I searched for all occurrences of `have :.*\n\s*positi` (using VS Code, i.e. using `rg` internally) and inspected them manually. In a few cases, keeping the `have` separate seemed more readable to me.

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include at least one commit authored by each
co-author among the commits in the pull request. If necessary, you may 
create empty commits to indicate co-authorship, using commands like so:

git commit --author="Author Name <author@email.com>" --allow-empty -m "add Author Name as coauthor"

When merging, all the commits will be squashed into a single commit listing all co-authors.

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
