### PR TITLE
feat(‎Mathlib/Algebra/Group/Subgroup/Pointwise): subgroup mul

### DIFF
--- a/Mathlib/Algebra/Group/Subgroup/Pointwise.lean
+++ b/Mathlib/Algebra/Group/Subgroup/Pointwise.lean
@@ -40,13 +40,15 @@ open Pointwise
 
 variable {α G A S : Type*}
 
-theorem term_match {G : Type*} [Group G] (a1 a2 b1 b2 : G) : a1 * b1 = a2 * b2 → a2⁻¹ * a1 = b2 * b1⁻¹ := by
+theorem term_match {G : Type*} [Group G] (a1 a2 b1 b2 : G) :
+    a1 * b1 = a2 * b2 → a2⁻¹ * a1 = b2 * b1⁻¹ := by
   intro h
   have : a1 = (a2 * b2) * b1⁻¹ := by exact eq_mul_inv_of_mul_eq h
   simp only [this, mul_assoc, inv_mul_cancel_left]
 
 open scoped Pointwise in
-noncomputable def card_mul_disjoint {G : Type*} [Group G] (H K : Subgroup G) (hHK : Disjoint H K) : ((H.carrier : Set G) * (K.carrier : Set G) : Set G) ≃ (H:Set G) ×ˢ (K:Set G) := by
+noncomputable def equiv_mul_disjoint {G : Type*} [Group G] (H K : Subgroup G) (hHK : Disjoint H K) :
+    ((H.carrier : Set G) * (K.carrier : Set G) : Set G) ≃ (H:Set G) ×ˢ (K:Set G) := by
   symm
   apply Set.BijOn.equiv (fun (h, k) => h * k)
   apply And.intro
@@ -54,9 +56,7 @@ noncomputable def card_mul_disjoint {G : Type*} [Group G] (H K : Subgroup G) (hH
     simp only [mem_prod, SetLike.mem_coe] at HH
     exact ⟨h, HH.1, k, HH.2, rfl⟩
   apply And.intro
-  · intro ⟨h1, k1⟩ H1 ⟨h2, k2⟩ H2
-    intro HH
-    simp at HH
+  · intro ⟨h1, k1⟩ H1 ⟨h2, k2⟩ H2 HH
     have crux : h2⁻¹ * h1 = k2 * k1⁻¹ := term_match _ _ _ _ HH
     rw [Subgroup.disjoint_def] at hHK
     have : h2⁻¹ * h1 ∈ H := by
@@ -78,7 +78,6 @@ noncomputable def card_mul_disjoint {G : Type*} [Group G] (H K : Subgroup G) (hH
     obtain ⟨h, hh, k, hk, HH⟩ := hg
     simp only [Set.image_prod, Set.image2_mul, Set.mem_mul]
     exact ⟨h, hh, k, hk, HH⟩
-
 
 @[to_additive (attr := simp, norm_cast)]
 theorem inv_coe_set [InvolutiveInv G] [SetLike S G] [InvMemClass S G] {H : S} : (H : Set G)⁻¹ = H :=

--- a/Mathlib/Algebra/Group/Subgroup/Pointwise.lean
+++ b/Mathlib/Algebra/Group/Subgroup/Pointwise.lean
@@ -40,12 +40,11 @@ open Pointwise
 
 variable {α G A S : Type*}
 
-theorem term_match [Group G] (a1 a2 b1 b2 : G) :
-    a1 * b1 = a2 * b2 → a2⁻¹ * a1 = b2 * b1⁻¹ := by
-  intro h
-  simp only [eq_mul_inv_of_mul_eq h, mul_assoc, inv_mul_cancel_left]
-
 open scoped Pointwise in
+/--
+If `H` and `K` are disjoint subgroups of `G` then `(h, k) ↦ h * k` gives a bijection between
+`H ×ᵃ K` and `H * K`
+-/
 theorem bijOn_product_mul [Group G] (H K : Subgroup G) (hHK : Disjoint H K) :
     BijOn (fun (h, k) => h * k) (H ×ˢ K) (H * K : Set G) := by
   refine ⟨?_, ?_, ?_⟩
@@ -53,7 +52,9 @@ theorem bijOn_product_mul [Group G] (H K : Subgroup G) (hHK : Disjoint H K) :
     simp only [mem_prod, SetLike.mem_coe] at HH
     exact ⟨h, HH.1, k, HH.2, rfl⟩
   · intro ⟨h1, k1⟩ H1 ⟨h2, k2⟩ H2 HH
-    have crux : h2⁻¹ * h1 = k2 * k1⁻¹ := term_match _ _ _ _ HH
+    have crux : h2⁻¹ * h1 = k2 * k1⁻¹ := by
+      simpa only [mul_assoc, mul_inv_cancel, mul_one, inv_mul_cancel_left]
+        using congr(h2⁻¹ * $HH * k1⁻¹)
     rw [Subgroup.disjoint_def] at hHK
     have : h2⁻¹ * h1 ∈ H := by
       rw [Subgroup.mul_mem_cancel_right H H1.1]

--- a/Mathlib/Algebra/Group/Subgroup/Pointwise.lean
+++ b/Mathlib/Algebra/Group/Subgroup/Pointwise.lean
@@ -45,7 +45,7 @@ open scoped Pointwise in
 If `H` and `K` are disjoint subgroups of `G` then `(h, k) ↦ h * k` gives a bijection between
 `H ×ᵃ K` and `H * K`
 -/
-theorem bijOn_product_mul [Group G] (H K : Subgroup G) (hHK : Disjoint H K) :
+theorem bijOn_product_mul_of_disjoint [Group G] (H K : Subgroup G) (hHK : Disjoint H K) :
     BijOn (fun (h, k) => h * k) (H ×ˢ K) (H * K : Set G) := by
   refine ⟨?_, ?_, ?_⟩
   · intro ⟨h, k⟩ HH
@@ -70,7 +70,7 @@ theorem bijOn_product_mul [Group G] (H K : Subgroup G) (hHK : Disjoint H K) :
     simp only [mul_inv_cancel_left, mul_one] at this
     have : (k2 * k1⁻¹) * k1 = 1 * k1 := by
       rw [← crux, hHK]
-    grind [inv_mul_cancel_right, one_mul]
+    grind only [= mem_prod, one_mul, inv_mul_cancel_right]
   · intro g hg
     obtain ⟨h, hh, k, hk, HH⟩ := hg
     simp only [Set.image_prod, Set.image2_mul, Set.mem_mul]
@@ -85,7 +85,7 @@ noncomputable def equivMulDisjoint [Group G] (H K : Subgroup G) (hHK : Disjoint 
     ((H : Set G) * (K : Set G) : Set G) ≃ (H:Set G) ×ˢ (K:Set G) := by
   symm
   apply Set.BijOn.equiv (fun (h, k) => h * k)
-  exact bijOn_product_mul H K hHK
+  exact bijOn_product_mul_of_disjoint H K hHK
 
 @[to_additive (attr := simp, norm_cast)]
 theorem inv_coe_set [InvolutiveInv G] [SetLike S G] [InvMemClass S G] {H : S} : (H : Set G)⁻¹ = H :=

--- a/Mathlib/Algebra/Group/Subgroup/Pointwise.lean
+++ b/Mathlib/Algebra/Group/Subgroup/Pointwise.lean
@@ -59,7 +59,7 @@ If `H` and `K` are disjoint subgroups of `G`, gives an equivalence
 between the point-wise product `H.carrier * K.carrier` and cartesian product `H ×ˢ K`.
 -/
 noncomputable def equivMulDisjoint [Group G] (H K : Subgroup G) (hHK : Disjoint H K) :
-    ((H : Set G) * (K : Set G) : Set G) ≃ (H:Set G) ×ˢ (K:Set G) :=
+    ((H : Set G) * (K : Set G) : Set G) ≃ (H : Set G) ×ˢ (K : Set G) :=
   (Set.BijOn.equiv (fun (h, k) => h * k) (bijOn_product_mul_of_disjoint H K hHK)).symm
 
 @[to_additive (attr := simp, norm_cast)]

--- a/Mathlib/Algebra/Group/Subgroup/Pointwise.lean
+++ b/Mathlib/Algebra/Group/Subgroup/Pointwise.lean
@@ -43,10 +43,10 @@ variable {α G A S : Type*}
 open scoped Pointwise in
 /--
 If `H` and `K` are disjoint subgroups of `G` then `(h, k) ↦ h * k` gives a bijection between
-`H ×ᵃ K` and `H * K`
+`H ×ˢ K` and `H * K`
 -/
 theorem bijOn_product_mul_of_disjoint [Group G] (H K : Subgroup G) (hHK : Disjoint H K) :
-    BijOn (fun (h, k) => h * k) (H ×ˢ K) (H * K : Set G) := by
+    BijOn (fun hk => hk.1 * hk.2) (H ×ˢ K) (H * K : Set G) := by
   refine ⟨?_, ?_, ?_⟩
   · intro ⟨h, k⟩ HH
     simp only [mem_prod, SetLike.mem_coe] at HH

--- a/Mathlib/Algebra/Group/Subgroup/Pointwise.lean
+++ b/Mathlib/Algebra/Group/Subgroup/Pointwise.lean
@@ -47,34 +47,11 @@ If `H` and `K` are disjoint subgroups of `G` then `(h, k) ↦ h * k` gives a bij
 -/
 theorem bijOn_product_mul_of_disjoint [Group G] (H K : Subgroup G) (hHK : Disjoint H K) :
     BijOn (fun hk => hk.1 * hk.2) (H ×ˢ K) (H * K : Set G) := by
-  refine ⟨?_, ?_, ?_⟩
-  · intro ⟨h, k⟩ HH
-    simp only [mem_prod, SetLike.mem_coe] at HH
-    exact ⟨h, HH.1, k, HH.2, rfl⟩
-  · intro ⟨h1, k1⟩ H1 ⟨h2, k2⟩ H2 HH
-    have crux : h2⁻¹ * h1 = k2 * k1⁻¹ := by
-      simpa only [mul_assoc, mul_inv_cancel, mul_one, inv_mul_cancel_left]
-        using congr(h2⁻¹ * $HH * k1⁻¹)
-    rw [Subgroup.disjoint_def] at hHK
-    have : h2⁻¹ * h1 ∈ H := by
-      rw [Subgroup.mul_mem_cancel_right H H1.1]
-      exact (Subgroup.inv_mem_iff H).mpr (H2.1)
-    specialize hHK this
-    have : k2 * k1⁻¹ ∈ K := by
-      have : k1⁻¹ ∈ K := (Subgroup.inv_mem_iff K).mpr (H1.2)
-      exact (Subgroup.mul_mem_cancel_right K this).mpr H2.2
-    rw [← crux] at this
-    specialize hHK this
-    have : h2 * (h2 ⁻¹ * h1) = h2 * 1 := by
-      rw [hHK]
-    simp only [mul_inv_cancel_left, mul_one] at this
-    have : (k2 * k1⁻¹) * k1 = 1 * k1 := by
-      rw [← crux, hHK]
-    grind only [= mem_prod, one_mul, inv_mul_cancel_right]
-  · intro g hg
-    obtain ⟨h, hh, k, hk, HH⟩ := hg
-    simp only [Set.image_prod, Set.image2_mul, Set.mem_mul]
-    exact ⟨h, hh, k, hk, HH⟩
+  rw [← image2_mul, ← image_prod]
+  apply Set.InjOn.bijOn_image
+  intro ⟨h1, k1⟩ H1 ⟨h2, k2⟩ H2 HH
+  suffices ((⟨h1, H1.1⟩, ⟨k1, H1.2⟩) : H × K) = (⟨h2, H2.1⟩, ⟨k2, H2.2⟩) by grind
+  exact Subgroup.mul_injective_of_disjoint hHK (by grind)
 
 open scoped Pointwise in
 /--
@@ -82,10 +59,8 @@ If `H` and `K` are disjoint subgroups of `G`, gives an equivalence
 between the point-wise product `H.carrier * K.carrier` and cartesian product `H ×ˢ K`.
 -/
 noncomputable def equivMulDisjoint [Group G] (H K : Subgroup G) (hHK : Disjoint H K) :
-    ((H : Set G) * (K : Set G) : Set G) ≃ (H:Set G) ×ˢ (K:Set G) := by
-  symm
-  apply Set.BijOn.equiv (fun (h, k) => h * k)
-  exact bijOn_product_mul_of_disjoint H K hHK
+    ((H : Set G) * (K : Set G) : Set G) ≃ (H:Set G) ×ˢ (K:Set G) :=
+  (Set.BijOn.equiv (fun (h, k) => h * k) (bijOn_product_mul_of_disjoint H K hHK)).symm
 
 @[to_additive (attr := simp, norm_cast)]
 theorem inv_coe_set [InvolutiveInv G] [SetLike S G] [InvMemClass S G] {H : S} : (H : Set G)⁻¹ = H :=

--- a/Mathlib/Algebra/Group/Subgroup/Pointwise.lean
+++ b/Mathlib/Algebra/Group/Subgroup/Pointwise.lean
@@ -40,6 +40,46 @@ open Pointwise
 
 variable {α G A S : Type*}
 
+theorem term_match {G : Type*} [Group G] (a1 a2 b1 b2 : G) : a1 * b1 = a2 * b2 → a2⁻¹ * a1 = b2 * b1⁻¹ := by
+  intro h
+  have : a1 = (a2 * b2) * b1⁻¹ := by exact eq_mul_inv_of_mul_eq h
+  simp only [this, mul_assoc, inv_mul_cancel_left]
+
+open scoped Pointwise in
+noncomputable def card_mul_disjoint {G : Type*} [Group G] (H K : Subgroup G) (hHK : Disjoint H K) : ((H.carrier : Set G) * (K.carrier : Set G) : Set G) ≃ (H:Set G) ×ˢ (K:Set G) := by
+  symm
+  apply Set.BijOn.equiv (fun (h, k) => h * k)
+  apply And.intro
+  · intro ⟨h, k⟩ HH
+    simp only [mem_prod, SetLike.mem_coe] at HH
+    exact ⟨h, HH.1, k, HH.2, rfl⟩
+  apply And.intro
+  · intro ⟨h1, k1⟩ H1 ⟨h2, k2⟩ H2
+    intro HH
+    simp at HH
+    have crux : h2⁻¹ * h1 = k2 * k1⁻¹ := term_match _ _ _ _ HH
+    rw [Subgroup.disjoint_def] at hHK
+    have : h2⁻¹ * h1 ∈ H := by
+      have : h2⁻¹ ∈ H := by exact (Subgroup.inv_mem_iff H).mpr (H2.1)
+      exact (Subgroup.mul_mem_cancel_right H H1.1).mpr this
+    specialize hHK this
+    have : k2 * k1⁻¹ ∈ K := by
+      have : k1⁻¹ ∈ K := by exact (Subgroup.inv_mem_iff K).mpr (H1.2)
+      exact (Subgroup.mul_mem_cancel_right K this).mpr H2.2
+    rw [← crux] at this
+    specialize hHK this
+    have : h2 * (h2 ⁻¹ * h1) = h2 * 1 := by
+      rw [hHK]
+    simp at this
+    have : (k2 * k1⁻¹) * k1 = 1 * k1 := by
+      rw [← crux, hHK]
+    grind [inv_mul_cancel_right, one_mul]
+  · intro g hg
+    obtain ⟨h, hh, k, hk, HH⟩ := hg
+    simp only [Set.image_prod, Set.image2_mul, Set.mem_mul]
+    exact ⟨h, hh, k, hk, HH⟩
+
+
 @[to_additive (attr := simp, norm_cast)]
 theorem inv_coe_set [InvolutiveInv G] [SetLike S G] [InvMemClass S G] {H : S} : (H : Set G)⁻¹ = H :=
   Set.ext fun _ => inv_mem_iff

--- a/Mathlib/Algebra/Group/Subgroup/Pointwise.lean
+++ b/Mathlib/Algebra/Group/Subgroup/Pointwise.lean
@@ -43,23 +43,15 @@ variable {α G A S : Type*}
 theorem term_match [Group G] (a1 a2 b1 b2 : G) :
     a1 * b1 = a2 * b2 → a2⁻¹ * a1 = b2 * b1⁻¹ := by
   intro h
-  have : a1 = (a2 * b2) * b1⁻¹ := by exact eq_mul_inv_of_mul_eq h
-  simp only [this, mul_assoc, inv_mul_cancel_left]
+  simp only [eq_mul_inv_of_mul_eq h, mul_assoc, inv_mul_cancel_left]
 
 open scoped Pointwise in
-/--
-If `H` and `K` are disjoint subgroups of `G`, gives an equivalence
-between the point-wise product `H.carrier * K.carrier` and cartesian product `H ×ˢ K`.
--/
-noncomputable def equiv_mul_disjoint [Group G] (H K : Subgroup G) (hHK : Disjoint H K) :
-    ((H.carrier : Set G) * (K.carrier : Set G) : Set G) ≃ (H:Set G) ×ˢ (K:Set G) := by
-  symm
-  apply Set.BijOn.equiv (fun (h, k) => h * k)
-  apply And.intro
+theorem bijOn_product_mul [Group G] (H K : Subgroup G) (hHK : Disjoint H K) :
+    BijOn (fun (h, k) => h * k) (↑H ×ˢ ↑K) (H.carrier * K.carrier) := by
+  refine ⟨?_, ?_, ?_⟩
   · intro ⟨h, k⟩ HH
     simp only [mem_prod, SetLike.mem_coe] at HH
     exact ⟨h, HH.1, k, HH.2, rfl⟩
-  apply And.intro
   · intro ⟨h1, k1⟩ H1 ⟨h2, k2⟩ H2 HH
     have crux : h2⁻¹ * h1 = k2 * k1⁻¹ := term_match _ _ _ _ HH
     rw [Subgroup.disjoint_def] at hHK
@@ -74,7 +66,7 @@ noncomputable def equiv_mul_disjoint [Group G] (H K : Subgroup G) (hHK : Disjoin
     specialize hHK this
     have : h2 * (h2 ⁻¹ * h1) = h2 * 1 := by
       rw [hHK]
-    simp at this
+    simp only [mul_inv_cancel_left, mul_one] at this
     have : (k2 * k1⁻¹) * k1 = 1 * k1 := by
       rw [← crux, hHK]
     grind [inv_mul_cancel_right, one_mul]
@@ -82,6 +74,17 @@ noncomputable def equiv_mul_disjoint [Group G] (H K : Subgroup G) (hHK : Disjoin
     obtain ⟨h, hh, k, hk, HH⟩ := hg
     simp only [Set.image_prod, Set.image2_mul, Set.mem_mul]
     exact ⟨h, hh, k, hk, HH⟩
+
+open scoped Pointwise in
+/--
+If `H` and `K` are disjoint subgroups of `G`, gives an equivalence
+between the point-wise product `H.carrier * K.carrier` and cartesian product `H ×ˢ K`.
+-/
+noncomputable def equivMulDisjoint [Group G] (H K : Subgroup G) (hHK : Disjoint H K) :
+    ((H.carrier : Set G) * (K.carrier : Set G) : Set G) ≃ (H:Set G) ×ˢ (K:Set G) := by
+  symm
+  apply Set.BijOn.equiv (fun (h, k) => h * k)
+  exact bijOn_product_mul H K hHK
 
 @[to_additive (attr := simp, norm_cast)]
 theorem inv_coe_set [InvolutiveInv G] [SetLike S G] [InvMemClass S G] {H : S} : (H : Set G)⁻¹ = H :=

--- a/Mathlib/Algebra/Group/Subgroup/Pointwise.lean
+++ b/Mathlib/Algebra/Group/Subgroup/Pointwise.lean
@@ -40,14 +40,14 @@ open Pointwise
 
 variable {α G A S : Type*}
 
-theorem term_match {G : Type*} [Group G] (a1 a2 b1 b2 : G) :
+theorem term_match [Group G] (a1 a2 b1 b2 : G) :
     a1 * b1 = a2 * b2 → a2⁻¹ * a1 = b2 * b1⁻¹ := by
   intro h
   have : a1 = (a2 * b2) * b1⁻¹ := by exact eq_mul_inv_of_mul_eq h
   simp only [this, mul_assoc, inv_mul_cancel_left]
 
 open scoped Pointwise in
-noncomputable def equiv_mul_disjoint {G : Type*} [Group G] (H K : Subgroup G) (hHK : Disjoint H K) :
+noncomputable def equiv_mul_disjoint [Group G] (H K : Subgroup G) (hHK : Disjoint H K) :
     ((H.carrier : Set G) * (K.carrier : Set G) : Set G) ≃ (H:Set G) ×ˢ (K:Set G) := by
   symm
   apply Set.BijOn.equiv (fun (h, k) => h * k)

--- a/Mathlib/Algebra/Group/Subgroup/Pointwise.lean
+++ b/Mathlib/Algebra/Group/Subgroup/Pointwise.lean
@@ -62,6 +62,12 @@ noncomputable def equivMulDisjoint [Group G] (H K : Subgroup G) (hHK : Disjoint 
     ((H : Set G) * (K : Set G) : Set G) ≃ (H : Set G) ×ˢ (K : Set G) :=
   (Set.BijOn.equiv (fun (h, k) => h * k) (bijOn_product_mul_of_disjoint H K hHK)).symm
 
+theorem equivMulDisjoint_def [Group G] (H K : Subgroup G) (hHK : Disjoint H K) : ∀ p : (H : Set G) ×ˢ (K : Set G),
+  ((equivMulDisjoint H K hHK).symm p).val = p.1.1 * p.1.2 := by
+  simp only [equivMulDisjoint, BijOn.equiv, Equiv.symm_symm, Equiv.ofBijective_apply,
+    MapsTo.val_restrict_apply, implies_true]
+
+
 @[to_additive (attr := simp, norm_cast)]
 theorem inv_coe_set [InvolutiveInv G] [SetLike S G] [InvMemClass S G] {H : S} : (H : Set G)⁻¹ = H :=
   Set.ext fun _ => inv_mem_iff

--- a/Mathlib/Algebra/Group/Subgroup/Pointwise.lean
+++ b/Mathlib/Algebra/Group/Subgroup/Pointwise.lean
@@ -47,7 +47,7 @@ theorem term_match [Group G] (a1 a2 b1 b2 : G) :
 
 open scoped Pointwise in
 theorem bijOn_product_mul [Group G] (H K : Subgroup G) (hHK : Disjoint H K) :
-    BijOn (fun (h, k) => h * k) (↑H ×ˢ ↑K) (H.carrier * K.carrier) := by
+    BijOn (fun (h, k) => h * k) (H ×ˢ K) (H * K : Set G) := by
   refine ⟨?_, ?_, ?_⟩
   · intro ⟨h, k⟩ HH
     simp only [mem_prod, SetLike.mem_coe] at HH
@@ -56,11 +56,11 @@ theorem bijOn_product_mul [Group G] (H K : Subgroup G) (hHK : Disjoint H K) :
     have crux : h2⁻¹ * h1 = k2 * k1⁻¹ := term_match _ _ _ _ HH
     rw [Subgroup.disjoint_def] at hHK
     have : h2⁻¹ * h1 ∈ H := by
-      have : h2⁻¹ ∈ H := by exact (Subgroup.inv_mem_iff H).mpr (H2.1)
-      exact (Subgroup.mul_mem_cancel_right H H1.1).mpr this
+      rw [Subgroup.mul_mem_cancel_right H H1.1]
+      exact (Subgroup.inv_mem_iff H).mpr (H2.1)
     specialize hHK this
     have : k2 * k1⁻¹ ∈ K := by
-      have : k1⁻¹ ∈ K := by exact (Subgroup.inv_mem_iff K).mpr (H1.2)
+      have : k1⁻¹ ∈ K := (Subgroup.inv_mem_iff K).mpr (H1.2)
       exact (Subgroup.mul_mem_cancel_right K this).mpr H2.2
     rw [← crux] at this
     specialize hHK this
@@ -81,7 +81,7 @@ If `H` and `K` are disjoint subgroups of `G`, gives an equivalence
 between the point-wise product `H.carrier * K.carrier` and cartesian product `H ×ˢ K`.
 -/
 noncomputable def equivMulDisjoint [Group G] (H K : Subgroup G) (hHK : Disjoint H K) :
-    ((H.carrier : Set G) * (K.carrier : Set G) : Set G) ≃ (H:Set G) ×ˢ (K:Set G) := by
+    ((H : Set G) * (K : Set G) : Set G) ≃ (H:Set G) ×ˢ (K:Set G) := by
   symm
   apply Set.BijOn.equiv (fun (h, k) => h * k)
   exact bijOn_product_mul H K hHK

--- a/Mathlib/Algebra/Group/Subgroup/Pointwise.lean
+++ b/Mathlib/Algebra/Group/Subgroup/Pointwise.lean
@@ -47,6 +47,10 @@ theorem term_match [Group G] (a1 a2 b1 b2 : G) :
   simp only [this, mul_assoc, inv_mul_cancel_left]
 
 open scoped Pointwise in
+/--
+If `H` and `K` are disjoint subgroups of `G`, gives an equivalence
+between the point-wise product `H.carrier * K.carrier` and cartesian product `H ×ˢ K`.
+-/
 noncomputable def equiv_mul_disjoint [Group G] (H K : Subgroup G) (hHK : Disjoint H K) :
     ((H.carrier : Set G) * (K.carrier : Set G) : Set G) ≃ (H:Set G) ×ˢ (K:Set G) := by
   symm


### PR DESCRIPTION
Title:
feat: pointwise products for subgroups

Description:
showed the point-wise product of disjoint subgroups is equivalent to their Cartesian product. Based on https://leanprover.zulipchat.com/#narrow/channel/113488-general/topic/useful.20group.20theory.20lemmas/with/546738566.

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include at least one commit authored by each
co-author among the commits in the pull request. If necessary, you may 
create empty commits to indicate co-authorship, using commands like so:

git commit --author="Author Name <author@email.com>" --allow-empty -m "add Author Name as coauthor"

When merging, all the commits will be squashed into a single commit listing all co-authors.

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
