### PR TITLE
[Merged by Bors] - chore: remove `MulAction ℚ α → MulAction ℚ≥0 α` instances

### DIFF
--- a/Mathlib/Algebra/Algebra/Rat.lean
+++ b/Mathlib/Algebra/Algebra/Rat.lean
@@ -4,7 +4,6 @@ Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Kenny Lau, Yury Kudryashov
 -/
 import Mathlib.Algebra.Algebra.Defs
-import Mathlib.Algebra.GroupWithZero.Action.Basic
 import Mathlib.Algebra.Module.Equiv.Defs
 import Mathlib.Data.Rat.Cast.CharZero
 
@@ -28,24 +27,7 @@ theorem map_rat_algebraMap [Semiring R] [Semiring S] [Algebra ℚ R] [Algebra �
 end RingHom
 
 namespace NNRat
-variable [DivisionSemiring R] [CharZero R]
-
-section Semiring
-variable [Semiring S] [Module ℚ≥0 S]
-
-variable (R) in
-/-- `nnqsmul` is equal to any other module structure via a cast. -/
-lemma cast_smul_eq_nnqsmul [Module R S] (q : ℚ≥0) (a : S) : (q : R) • a = q • a := by
-  refine MulAction.injective₀ (G₀ := ℚ≥0) (Nat.cast_ne_zero.2 q.den_pos.ne') ?_
-  dsimp
-  rw [← mul_smul, den_mul_eq_num, Nat.cast_smul_eq_nsmul, Nat.cast_smul_eq_nsmul, ← smul_assoc,
-    nsmul_eq_mul q.den, ← cast_natCast, ← cast_mul, den_mul_eq_num, cast_natCast,
-    Nat.cast_smul_eq_nsmul]
-
-end Semiring
-
-section DivisionSemiring
-variable [DivisionSemiring S] [CharZero S]
+variable [DivisionSemiring R] [CharZero R] [DivisionSemiring S] [CharZero S]
 
 instance _root_.DivisionSemiring.toNNRatAlgebra : Algebra ℚ≥0 R where
   smul_def' := smul_def
@@ -64,28 +46,10 @@ instance instSMulCommClass [SMulCommClass R S S] : SMulCommClass ℚ≥0 R S whe
 instance instSMulCommClass' [SMulCommClass S R S] : SMulCommClass R ℚ≥0 S :=
   have := SMulCommClass.symm S R S; SMulCommClass.symm _ _ _
 
-end DivisionSemiring
 end NNRat
 
 namespace Rat
-variable [DivisionRing R] [CharZero R]
-
-section Ring
-variable [Ring S] [Module ℚ S]
-
-variable (R) in
-/-- `qsmul` is equal to any other module structure via a cast. -/
-lemma cast_smul_eq_qsmul [Module R S] (q : ℚ) (a : S) : (q : R) • a = q • a := by
-  refine MulAction.injective₀ (G₀ := ℚ) (Nat.cast_ne_zero.2 q.den_pos.ne') ?_
-  dsimp
-  rw [← mul_smul, den_mul_eq_num, Nat.cast_smul_eq_nsmul, Int.cast_smul_eq_zsmul, ← smul_assoc,
-    nsmul_eq_mul q.den, ← cast_natCast, ← cast_mul, den_mul_eq_num, cast_intCast,
-    Int.cast_smul_eq_zsmul]
-
-end Ring
-
-section DivisionRing
-variable [DivisionRing S] [CharZero S]
+variable [DivisionRing R] [CharZero R] [DivisionRing S] [CharZero S]
 
 instance _root_.DivisionRing.toRatAlgebra : Algebra ℚ R where
   smul_def' := smul_def
@@ -107,8 +71,6 @@ instance instSMulCommClass [SMulCommClass R S S] : SMulCommClass ℚ R S where
 
 instance instSMulCommClass' [SMulCommClass S R S] : SMulCommClass R ℚ S :=
   have := SMulCommClass.symm S R S; SMulCommClass.symm _ _ _
-
-end DivisionRing
 
 instance algebra_rat_subsingleton {R} [Semiring R] : Subsingleton (Algebra ℚ R) :=
   ⟨fun x y => Algebra.algebra_ext x y <| RingHom.congr_fun <| Subsingleton.elim _ _⟩

--- a/Mathlib/Algebra/Module/Rat.lean
+++ b/Mathlib/Algebra/Module/Rat.lean
@@ -57,11 +57,22 @@ theorem nnratCast_smul_eq {E : Type*} (R S : Type*) [AddCommMonoid E] [DivisionS
     [DivisionSemiring S] [Module R E] [Module S E] (r : ℚ≥0) (x : E) : (r : R) • x = (r : S) • x :=
   map_nnratCast_smul (AddMonoidHom.id E) R S r x
 
+/-- `nnqsmul` is equal to any other module structure via a cast. -/
+lemma NNRat.cast_smul_eq_nnqsmul (R : Type*) [DivisionSemiring R]
+    [AddCommMonoid M] [Module ℚ≥0 M] [Module R M] (q : ℚ≥0) (a : M) :
+    (q : R) • a = q • a :=
+  nnratCast_smul_eq _ _ _ _
+
 /-- If `E` is a vector space over two division rings `R` and `S`, then scalar multiplications
 agree on rational numbers in `R` and `S`. -/
 theorem ratCast_smul_eq {E : Type*} (R S : Type*) [AddCommGroup E] [DivisionRing R]
     [DivisionRing S] [Module R E] [Module S E] (r : ℚ) (x : E) : (r : R) • x = (r : S) • x :=
   map_ratCast_smul (AddMonoidHom.id E) R S r x
+
+/-- `qsmul` is equal to any other module structure via a cast. -/
+lemma Rat.cast_smul_eq_qsmul (R : Type*) [DivisionRing R]
+    [AddCommGroup M] [Module ℚ M] [Module R M] (q : ℚ) (a : M) : (q : R) • a = q • a :=
+  ratCast_smul_eq _ _ _ _
 
 instance IsScalarTower.nnrat {R : Type u} {M : Type v} [Semiring R] [AddCommMonoid M] [Module R M]
     [Module ℚ≥0 R] [Module ℚ≥0 M] : IsScalarTower ℚ≥0 R M where
@@ -70,6 +81,16 @@ instance IsScalarTower.nnrat {R : Type u} {M : Type v} [Semiring R] [AddCommMono
 instance IsScalarTower.rat {R : Type u} {M : Type v} [Ring R] [AddCommGroup M] [Module R M]
     [Module ℚ R] [Module ℚ M] : IsScalarTower ℚ R M where
   smul_assoc r x y := map_rat_smul ((smulAddHom R M).flip y) r x
+
+lemma NNRat.cast_smul_eq_nnqsmul' (R) {α}
+    [DivisionSemiring R] [MulAction R α] [MulAction ℚ≥0 α] [IsScalarTower ℚ≥0 R α]
+    (q : ℚ≥0) (x : α) : (q : R) • x = q • x := by
+  rw [← one_smul R x, ← smul_assoc, ← smul_assoc]; simp
+
+lemma Rat.cast_smul_eq_qsmul' (R) {α}
+    [DivisionRing R] [MulAction R α] [MulAction ℚ α] [IsScalarTower ℚ R α]
+    (q : ℚ) (x : α) : (q : R) • x = q • x := by
+  rw [← one_smul R x, ← smul_assoc, ← smul_assoc]; simp
 
 section
 variable {α : Type u} {M : Type v}

--- a/Mathlib/Algebra/Module/Rat.lean
+++ b/Mathlib/Algebra/Module/Rat.lean
@@ -57,22 +57,11 @@ theorem nnratCast_smul_eq {E : Type*} (R S : Type*) [AddCommMonoid E] [DivisionS
     [DivisionSemiring S] [Module R E] [Module S E] (r : ℚ≥0) (x : E) : (r : R) • x = (r : S) • x :=
   map_nnratCast_smul (AddMonoidHom.id E) R S r x
 
-/-- `nnqsmul` is equal to any other module structure via a cast. -/
-lemma NNRat.cast_smul_eq_nnqsmul (R : Type*) [DivisionSemiring R]
-    [AddCommMonoid M] [Module ℚ≥0 M] [Module R M] (q : ℚ≥0) (a : M) :
-    (q : R) • a = q • a :=
-  nnratCast_smul_eq _ _ _ _
-
 /-- If `E` is a vector space over two division rings `R` and `S`, then scalar multiplications
 agree on rational numbers in `R` and `S`. -/
 theorem ratCast_smul_eq {E : Type*} (R S : Type*) [AddCommGroup E] [DivisionRing R]
     [DivisionRing S] [Module R E] [Module S E] (r : ℚ) (x : E) : (r : R) • x = (r : S) • x :=
   map_ratCast_smul (AddMonoidHom.id E) R S r x
-
-/-- `qsmul` is equal to any other module structure via a cast. -/
-lemma Rat.cast_smul_eq_qsmul (R : Type*) [DivisionRing R]
-    [AddCommGroup M] [Module ℚ M] [Module R M] (q : ℚ) (a : M) : (q : R) • a = q • a :=
-  ratCast_smul_eq _ _ _ _
 
 instance IsScalarTower.nnrat {R : Type u} {M : Type v} [Semiring R] [AddCommMonoid M] [Module R M]
     [Module ℚ≥0 R] [Module ℚ≥0 M] : IsScalarTower ℚ≥0 R M where
@@ -82,14 +71,16 @@ instance IsScalarTower.rat {R : Type u} {M : Type v} [Ring R] [AddCommGroup M] [
     [Module ℚ R] [Module ℚ M] : IsScalarTower ℚ R M where
   smul_assoc r x y := map_rat_smul ((smulAddHom R M).flip y) r x
 
-lemma NNRat.cast_smul_eq_nnqsmul' (R) {α}
-    [DivisionSemiring R] [MulAction R α] [MulAction ℚ≥0 α] [IsScalarTower ℚ≥0 R α]
-    (q : ℚ≥0) (x : α) : (q : R) • x = q • x := by
+/-- `nnqsmul` is equal to any other module structure via a cast. -/
+lemma NNRat.cast_smul_eq_nnqsmul (R : Type*) [DivisionSemiring R]
+    [MulAction R M] [MulAction ℚ≥0 M] [IsScalarTower ℚ≥0 R M]
+    (q : ℚ≥0) (x : M) : (q : R) • x = q • x := by
   rw [← one_smul R x, ← smul_assoc, ← smul_assoc]; simp
 
-lemma Rat.cast_smul_eq_qsmul' (R) {α}
-    [DivisionRing R] [MulAction R α] [MulAction ℚ α] [IsScalarTower ℚ R α]
-    (q : ℚ) (x : α) : (q : R) • x = q • x := by
+/-- `qsmul` is equal to any other module structure via a cast. -/
+lemma Rat.cast_smul_eq_qsmul (R : Type*) [DivisionRing R]
+    [MulAction R M] [MulAction ℚ M] [IsScalarTower ℚ R M]
+    (q : ℚ) (x : M) : (q : R) • x = q • x := by
   rw [← one_smul R x, ← smul_assoc, ← smul_assoc]; simp
 
 section

--- a/Mathlib/Algebra/Order/Module/Rat.lean
+++ b/Mathlib/Algebra/Order/Module/Rat.lean
@@ -17,14 +17,14 @@ instance PosSMulMono.nnrat_of_rat [Preorder α] [MulAction ℚ α] [MulAction �
     [IsScalarTower ℚ≥0 ℚ α] [PosSMulMono ℚ α] :
     PosSMulMono ℚ≥0 α where
   smul_le_smul_of_nonneg_left _q hq _a₁ _a₂ ha := by
-    rw [← NNRat.cast_smul_eq_nnqsmul' ℚ, ← NNRat.cast_smul_eq_nnqsmul' ℚ]
+    rw [← NNRat.cast_smul_eq_nnqsmul ℚ, ← NNRat.cast_smul_eq_nnqsmul ℚ]
     exact smul_le_smul_of_nonneg_left (α := ℚ) ha hq
 
 instance PosSMulStrictMono.nnrat_of_rat [Preorder α] [MulAction ℚ≥0 α] [MulAction ℚ α]
     [IsScalarTower ℚ≥0 ℚ α] [PosSMulStrictMono ℚ α] :
     PosSMulStrictMono ℚ≥0 α where
   smul_lt_smul_of_pos_left _q hq _a₁ _a₂ ha := by
-    rw [← NNRat.cast_smul_eq_nnqsmul' ℚ, ← NNRat.cast_smul_eq_nnqsmul' ℚ]
+    rw [← NNRat.cast_smul_eq_nnqsmul ℚ, ← NNRat.cast_smul_eq_nnqsmul ℚ]
     exact smul_lt_smul_of_pos_left (α := ℚ) ha hq
 
 section LinearOrderedAddCommGroup

--- a/Mathlib/Algebra/Order/Module/Rat.lean
+++ b/Mathlib/Algebra/Order/Module/Rat.lean
@@ -5,7 +5,6 @@ Authors: Yaël Dillies
 -/
 import Mathlib.Algebra.Module.Rat
 import Mathlib.Algebra.Order.Module.Basic
-import Mathlib.Data.NNRat.Lemmas
 import Mathlib.Data.Rat.Cast.Order
 
 /-!

--- a/Mathlib/Algebra/Order/Module/Rat.lean
+++ b/Mathlib/Algebra/Order/Module/Rat.lean
@@ -3,6 +3,7 @@ Copyright (c) 2024 Yaël Dillies. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Yaël Dillies
 -/
+import Mathlib.Algebra.Module.Rat
 import Mathlib.Algebra.Order.Module.Basic
 import Mathlib.Data.NNRat.Lemmas
 import Mathlib.Data.Rat.Cast.Order
@@ -13,13 +14,19 @@ import Mathlib.Data.Rat.Cast.Order
 
 variable {α : Type*}
 
-instance PosSMulMono.nnrat_of_rat [Preorder α] [MulAction ℚ α] [PosSMulMono ℚ α] :
+instance PosSMulMono.nnrat_of_rat [Preorder α] [MulAction ℚ α] [MulAction ℚ≥0 α]
+    [IsScalarTower ℚ≥0 ℚ α] [PosSMulMono ℚ α] :
     PosSMulMono ℚ≥0 α where
-  smul_le_smul_of_nonneg_left _q hq _a₁ _a₂ ha := smul_le_smul_of_nonneg_left (α := ℚ) ha hq
+  smul_le_smul_of_nonneg_left _q hq _a₁ _a₂ ha := by
+    rw [← NNRat.cast_smul_eq_nnqsmul' ℚ, ← NNRat.cast_smul_eq_nnqsmul' ℚ]
+    exact smul_le_smul_of_nonneg_left (α := ℚ) ha hq
 
-instance PosSMulStrictMono.nnrat_of_rat [Preorder α] [MulAction ℚ α] [PosSMulStrictMono ℚ α] :
+instance PosSMulStrictMono.nnrat_of_rat [Preorder α] [MulAction ℚ≥0 α] [MulAction ℚ α]
+    [IsScalarTower ℚ≥0 ℚ α] [PosSMulStrictMono ℚ α] :
     PosSMulStrictMono ℚ≥0 α where
-  smul_lt_smul_of_pos_left _q hq _a₁ _a₂ ha := smul_lt_smul_of_pos_left (α := ℚ) ha hq
+  smul_lt_smul_of_pos_left _q hq _a₁ _a₂ ha := by
+    rw [← NNRat.cast_smul_eq_nnqsmul' ℚ, ← NNRat.cast_smul_eq_nnqsmul' ℚ]
+    exact smul_lt_smul_of_pos_left (α := ℚ) ha hq
 
 section LinearOrderedAddCommGroup
 variable [AddCommGroup α] [LinearOrder α] [IsOrderedAddMonoid α]

--- a/Mathlib/Data/NNRat/Lemmas.lean
+++ b/Mathlib/Data/NNRat/Lemmas.lean
@@ -5,7 +5,6 @@ Authors: Yaël Dillies, Bhavik Mehta
 -/
 import Mathlib.Algebra.Field.Rat
 import Mathlib.Algebra.Group.Indicator
-import Mathlib.Algebra.GroupWithZero.Action.End
 import Mathlib.Algebra.Order.Field.Rat
 import Mathlib.Data.Rat.Lemmas
 import Mathlib.Tactic.Zify

--- a/Mathlib/Data/NNRat/Lemmas.lean
+++ b/Mathlib/Data/NNRat/Lemmas.lean
@@ -23,14 +23,6 @@ open scoped NNRat
 namespace NNRat
 variable {α : Type*} {q : ℚ≥0}
 
-/-- A `MulAction` over `ℚ` restricts to a `MulAction` over `ℚ≥0`. -/
-instance [MulAction ℚ α] : MulAction ℚ≥0 α :=
-  MulAction.compHom α coeHom.toMonoidHom
-
-/-- A `DistribMulAction` over `ℚ` restricts to a `DistribMulAction` over `ℚ≥0`. -/
-instance [AddCommMonoid α] [DistribMulAction ℚ α] : DistribMulAction ℚ≥0 α :=
-  DistribMulAction.compHom α coeHom.toMonoidHom
-
 @[simp, norm_cast]
 lemma coe_indicator (s : Set α) (f : α → ℚ≥0) (a : α) :
     ((s.indicator f a : ℚ≥0) : ℚ) = s.indicator (fun x ↦ ↑(f x)) a :=


### PR DESCRIPTION
This fixes the instances diamond in the `NNRat` action.


---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include at least one commit authored by each
co-author among the commits in the pull request. If necessary, you may 
create empty commits to indicate co-authorship, using commands like so:

git commit --author="Author Name <author@email.com>" --allow-empty -m "add Author Name as coauthor"

When merging, all the commits will be squashed into a single commit listing all co-authors.

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[Zulip](https://leanprover.zulipchat.com/#narrow/channel/287929-mathlib4/topic/.60SMul.20NNRat.60.20diamond.3F/with/545816108)

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
