### PR TITLE
[Merged by Bors] - feat(CategoryTheory/Abelian): iso between image and coimage functors

### DIFF
--- a/Mathlib/CategoryTheory/Abelian/Basic.lean
+++ b/Mathlib/CategoryTheory/Abelian/Basic.lean
@@ -401,6 +401,32 @@ theorem factorThruImage_comp_coimageIsoImage'_inv :
   simp only [IsImage.isoExt_inv, image.isImage_lift, image.fac_lift,
     coimageStrongEpiMonoFactorisation_e]
 
+variable {Z : C} (g : Y ⟶ Z)
+
+@[simp] lemma image.ι_comp_eq_zero : image.ι f ≫ g = 0 ↔ f ≫ g = 0 := by
+  simp [← cancel_epi (Abelian.factorThruImage _)]
+
+@[simp] lemma coimage.comp_π_eq_zero : f ≫ coimage.π g = 0 ↔ f ≫ g = 0 := by
+  simp [← cancel_mono (Abelian.factorThruCoimage _)]
+
+/-- `Abelian.image` as a functor from the arrow category. -/
+@[simps]
+def imageFunctor : Arrow C ⥤ C where
+  obj f := Abelian.image f.hom
+  map {f g} u := kernel.lift _ (Abelian.image.ι f.hom ≫ u.right) <| by simp [← Arrow.w_assoc u]
+
+/-- `Abelian.coimage` as a functor from the arrow category. -/
+@[simps]
+def coimageFunctor : Arrow C ⥤ C where
+  obj f := Abelian.coimage f.hom
+  map {f g} u := cokernel.desc _ (u.left ≫ Abelian.coimage.π g.hom) <| by
+    simp [← Category.assoc, coimage.comp_π_eq_zero]; simp
+
+/-- The image and coimage of an arrow are naturally isomorphic. -/
+@[simps!]
+def coimageFunctorIsoImageFunctor : coimageFunctor (C := C) ≅ imageFunctor :=
+  NatIso.ofComponents fun _ ↦ Abelian.coimageIsoImage _
+
 /-- There is a canonical isomorphism between the abelian image and the categorical image of a
     morphism. -/
 abbrev imageIsoImage : Abelian.image f ≅ image f :=


### PR DESCRIPTION
From ClassFieldTheory

Co-authored-by: Yaël Dillies <yael.dillies@gmail.com>

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include at least one commit authored by each
co-author among the commits in the pull request. If necessary, you may 
create empty commits to indicate co-authorship, using commands like so:

git commit --author="Author Name <author@email.com>" --allow-empty -m "add Author Name as coauthor"

When merging, all the commits will be squashed into a single commit listing all co-authors.

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
