### PR TITLE
[Merged by Bors] - style(CategoryTheory): fix whitespace

### DIFF
--- a/Mathlib/CategoryTheory/FiberedCategory/Cocartesian.lean
+++ b/Mathlib/CategoryTheory/FiberedCategory/Cocartesian.lean
@@ -81,21 +81,21 @@ variable {b' : 𝒳} (φ' : a ⟶ b') [IsHomLift p f φ']
 `φ' : a ⟶ b'` which also lifts `f`, then `IsCocartesian.map f φ φ'` is the morphism `b ⟶ b'` lying
 over `𝟙 S` obtained from the universal property of `φ`. -/
 protected noncomputable def map : b ⟶ b' :=
-  Classical.choose <| IsCocartesian.universal_property (p:=p) (f:=f) (φ:=φ) φ'
+  Classical.choose <| IsCocartesian.universal_property (p := p) (f := f) (φ := φ) φ'
 
 instance map_isHomLift : IsHomLift p (𝟙 S) (IsCocartesian.map p f φ φ') :=
-  (Classical.choose_spec <| IsCocartesian.universal_property (p:=p) (f:=f) (φ:=φ) φ').1.1
+  (Classical.choose_spec <| IsCocartesian.universal_property (p := p) (f := f) (φ := φ) φ').1.1
 
 @[reassoc (attr := simp)]
 lemma fac : φ ≫ IsCocartesian.map p f φ φ' = φ' :=
-  (Classical.choose_spec <| IsCocartesian.universal_property (p:=p) (f:=f) (φ:=φ) φ').1.2
+  (Classical.choose_spec <| IsCocartesian.universal_property (p := p) (f := f) (φ := φ) φ').1.2
 
 /-- Given a co-Cartesian morphism `φ : a ⟶ b` lying over `f : R ⟶ S` in `𝒳`, and another morphism
 `φ' : a ⟶ b'` which also lifts `f`. Then any morphism `ψ : b ⟶ b'` lifting `𝟙 S` such that
 `g ≫ ψ = φ'` must equal the map induced by the universal property of `φ`. -/
 lemma map_uniq (ψ : b ⟶ b') [IsHomLift p (𝟙 S) ψ] (hψ : φ ≫ ψ = φ') :
     ψ = IsCocartesian.map p f φ φ' :=
-  (Classical.choose_spec <| IsCocartesian.universal_property (p:=p) (f:=f) (φ:=φ) φ').2
+  (Classical.choose_spec <| IsCocartesian.universal_property (p := p) (f := f) (φ := φ) φ').2
     ψ ⟨inferInstance, hψ⟩
 
 end

--- a/Mathlib/CategoryTheory/Functor/Basic.lean
+++ b/Mathlib/CategoryTheory/Functor/Basic.lean
@@ -50,7 +50,7 @@ end
 /-- Notation for a functor between categories. -/
 -- A functor is basically a function, so give ⥤ a similar precedence to → (25).
 -- For example, `C × D ⥤ E` should parse as `(C × D) ⥤ E` not `C × (D ⥤ E)`.
-scoped [CategoryTheory] infixr:26 " ⥤ " => Functor -- type as \func
+scoped[CategoryTheory] infixr:26 " ⥤ " => Functor -- type as \func
 
 attribute [simp] Functor.map_id Functor.map_comp
 attribute [grind =] Functor.map_id
@@ -78,7 +78,7 @@ protected def id : C ⥤ C where
   map f := f
 
 /-- Notation for the identity functor on a category. -/
-scoped [CategoryTheory] notation "𝟭" => Functor.id -- Type this as `\sb1`
+scoped[CategoryTheory] notation "𝟭" => Functor.id -- Type this as `\sb1`
 
 instance : Inhabited (C ⥤ C) :=
   ⟨Functor.id C⟩
@@ -114,7 +114,7 @@ def comp (F : C ⥤ D) (G : D ⥤ E) : C ⥤ E where
   map f := G.map (F.map f)
 
 /-- Notation for composition of functors. -/
-scoped [CategoryTheory] infixr:80 " ⋙ " => Functor.comp
+scoped[CategoryTheory] infixr:80 " ⋙ " => Functor.comp
 
 @[simp, grind =]
 theorem comp_map (F : C ⥤ D) (G : D ⥤ E) {X Y : C} (f : X ⟶ Y) :

--- a/Mathlib/CategoryTheory/Functor/KanExtension/Preserves.lean
+++ b/Mathlib/CategoryTheory/Functor/KanExtension/Preserves.lean
@@ -76,7 +76,7 @@ extensions of `F` along `L` at the point `c`. -/
 class PreservesPointwiseLeftKanExtensionAt (c : C) where
   /-- `G` preserves every pointwise extensions of `F` along `L` at `c`. -/
   preserves : ∀ (E : LeftExtension L F), E.IsPointwiseLeftKanExtensionAt c →
-    Nonempty ((LeftExtension.postcompose₂ L F G|>.obj E).IsPointwiseLeftKanExtensionAt c)
+    Nonempty ((LeftExtension.postcompose₂ L F G |>.obj E).IsPointwiseLeftKanExtensionAt c)
 
 /-- `G.PreservesLeftKanExtension F L` asserts that `G` preserves all pointwise left Kan extensions
 of `F` along `L`. -/
@@ -89,8 +89,8 @@ variable {F L} in
 def LeftExtension.IsPointwiseLeftKanExtensionAt.postcompose {c : C}
     [PreservesPointwiseLeftKanExtensionAt G F L c]
     {E : LeftExtension L F} (hE : E.IsPointwiseLeftKanExtensionAt c) :
-    LeftExtension.postcompose₂ L F G|>.obj E|>.IsPointwiseLeftKanExtensionAt c :=
-  PreservesPointwiseLeftKanExtensionAt.preserves E hE|>.some
+    LeftExtension.postcompose₂ L F G |>.obj E |>.IsPointwiseLeftKanExtensionAt c :=
+  PreservesPointwiseLeftKanExtensionAt.preserves E hE |>.some
 
 variable {F L} in
 /-- Given a pointwise left Kan extension of `F` along `L`, exhibits
@@ -99,14 +99,14 @@ variable {F L} in
 def LeftExtension.IsPointwiseLeftKanExtension.postcompose
     [PreservesPointwiseLeftKanExtension G F L]
     {E : LeftExtension L F} (hE : E.IsPointwiseLeftKanExtension) :
-    LeftExtension.postcompose₂ L F G|>.obj E|>.IsPointwiseLeftKanExtension := fun c ↦
+    LeftExtension.postcompose₂ L F G |>.obj E |>.IsPointwiseLeftKanExtension := fun c ↦
   (hE c).postcompose G
 
 /-- The cocone at a point of the whiskering right by `G`of an extension is isomorphic to the
 action of `G` on the cocone at that point for the original extension. -/
 @[simps!]
 def LeftExtension.coconeAtWhiskerRightIso (E : LeftExtension L F) (c : C) :
-    (LeftExtension.postcompose₂ L F G|>.obj E).coconeAt c ≅ G.mapCocone (E.coconeAt c) :=
+    (LeftExtension.postcompose₂ L F G |>.obj E).coconeAt c ≅ G.mapCocone (E.coconeAt c) :=
   Limits.Cocones.ext (Iso.refl _)
 
 /-- If `G` preserves any pointwise left Kan extension of `F` along `L` at `c`, then it preserves
@@ -131,7 +131,7 @@ instance hasLeftKanExtension_of_preserves [L.HasLeftKanExtension F]
 instance hasPointwiseLeftKanExtension_of_preserves [L.HasPointwiseLeftKanExtension F]
     [PreservesPointwiseLeftKanExtension G F L] : L.HasPointwiseLeftKanExtension (F ⋙ G) :=
   (pointwiseLeftKanExtensionIsPointwiseLeftKanExtension
-    L F|>.postcompose G).hasPointwiseLeftKanExtension
+    L F |>.postcompose G).hasPointwiseLeftKanExtension
 
 /-- Extract an isomorphism `(leftKanExtension L F) ⋙ G ≅ leftKanExtension L (F ⋙ G)` when `G`
 preserves left Kan extensions. -/
@@ -163,7 +163,7 @@ lemma leftKanExtensionCompIsoOfPreserves_hom_fac_app (a : A) :
     G.map ((L.leftKanExtensionUnit F).app a) ≫
       (G.leftKanExtensionCompIsoOfPreserves F L).hom.app (L.obj a) =
     (L.leftKanExtensionUnit (F ⋙ G)).app a := by
-  simpa [- leftKanExtensionCompIsoOfPreserves_hom_fac] using
+  simpa [-leftKanExtensionCompIsoOfPreserves_hom_fac] using
     NatTrans.congr_app (leftKanExtensionCompIsoOfPreserves_hom_fac G F L) a
 
 @[reassoc (attr := simp)]
@@ -178,7 +178,7 @@ lemma leftKanExtensionCompIsoOfPreserves_inv_fac_app (a : A) :
     (L.leftKanExtensionUnit (F ⋙ G)).app a ≫
       (G.leftKanExtensionCompIsoOfPreserves F L).inv.app (L.obj a) =
     G.map ((L.leftKanExtensionUnit F).app a) := by
-  simpa [- leftKanExtensionCompIsoOfPreserves_inv_fac] using
+  simpa [-leftKanExtensionCompIsoOfPreserves_inv_fac] using
     NatTrans.congr_app (leftKanExtensionCompIsoOfPreserves_inv_fac G F L) a
 
 end
@@ -234,7 +234,7 @@ lemma pointwiseLeftKanExtensionCompIsoOfPreserves_hom_fac_app (a : A) :
     G.map ((L.pointwiseLeftKanExtensionUnit F).app a) ≫
       (G.pointwiseLeftKanExtensionCompIsoOfPreserves F L).hom.app (L.obj a) =
     (L.pointwiseLeftKanExtensionUnit <| F ⋙ G).app a := by
-  simpa [- pointwiseLeftKanExtensionCompIsoOfPreserves_hom_fac] using
+  simpa [-pointwiseLeftKanExtensionCompIsoOfPreserves_hom_fac] using
     NatTrans.congr_app (pointwiseLeftKanExtensionCompIsoOfPreserves_hom_fac G F L) a
 
 @[reassoc (attr := simp)]
@@ -248,7 +248,7 @@ lemma pointwiseLeftKanExtensionCompIsoOfPreserves_inv_fac :
 lemma pointwiseLeftKanExtensionCompIsoOfPreserves_fac_app (a : A) :
     (L.pointwiseLeftKanExtensionUnit <| F ⋙ G).app a ≫
       (G.pointwiseLeftKanExtensionCompIsoOfPreserves F L).inv.app (L.obj a) =
-    G.map (L.pointwiseLeftKanExtensionUnit F|>.app a) := by
+    G.map (L.pointwiseLeftKanExtensionUnit F |>.app a) := by
   simpa [-pointwiseLeftKanExtensionCompIsoOfPreserves_inv_fac] using
     NatTrans.congr_app (pointwiseLeftKanExtensionCompIsoOfPreserves_inv_fac G F L) a
 
@@ -308,7 +308,7 @@ lemma PreservesRightKanExtension.mk_of_preserves_isRightKanExtension
   .mk fun F'' α' h ↦
     isRightKanExtension_of_iso
       (isoWhiskerRight (rightKanExtensionUnique F' α F'' α') G)
-      ((Functor.associator _ _ _).inv ≫ whiskerRight α G )
+      ((Functor.associator _ _ _).inv ≫ whiskerRight α G)
       ((Functor.associator _ _ _).inv ≫ whiskerRight α' G)
       (by ext x; simp [← G.map_comp])
 
@@ -319,7 +319,8 @@ lemma PreservesRightKanExtension.mk_of_preserves_isUniversal (E : RightExtension
     G.PreservesRightKanExtension F L :=
   .mk' G F L fun hE' ↦
     ⟨Limits.IsTerminal.equivOfIso
-      (RightExtension.postcompose₂ L F G|>.mapIso <| Limits.IsTerminal.uniqueUpToIso hE hE') h.some⟩
+      (RightExtension.postcompose₂ L F G |>.mapIso
+        <| Limits.IsTerminal.uniqueUpToIso hE hE') h.some⟩
 
 attribute [instance] PreservesRightKanExtension.preserves
 
@@ -328,7 +329,7 @@ extensions of `F` along `L` at `c`. -/
 class PreservesPointwiseRightKanExtensionAt (c : C) where
   /-- `G` preserves every pointwise extensions of `F` along `L` at `c`. -/
   preserves : ∀ (E : RightExtension L F), E.IsPointwiseRightKanExtensionAt c →
-    Nonempty ((RightExtension.postcompose₂ L F G|>.obj E).IsPointwiseRightKanExtensionAt c)
+    Nonempty ((RightExtension.postcompose₂ L F G |>.obj E).IsPointwiseRightKanExtensionAt c)
 
 /-- `G.PreservesRightKanExtensions L` asserts that `G` preserves all pointwise right Kan
 extensions of `F` along `L` for every `F`. -/
@@ -341,8 +342,8 @@ variable {F L} in
 def RightExtension.IsPointwiseRightKanExtensionAt.postcompose {c : C}
     [PreservesPointwiseRightKanExtensionAt G F L c]
     {E : RightExtension L F} (hE : E.IsPointwiseRightKanExtensionAt c) :
-    RightExtension.postcompose₂ L F G|>.obj E|>.IsPointwiseRightKanExtensionAt c :=
-  PreservesPointwiseRightKanExtensionAt.preserves E hE|>.some
+    RightExtension.postcompose₂ L F G |>.obj E |>.IsPointwiseRightKanExtensionAt c :=
+  PreservesPointwiseRightKanExtensionAt.preserves E hE |>.some
 
 variable {F L} in
 /-- Given a pointwise right Kan extension of `F` along `L`, exhibits
@@ -350,14 +351,14 @@ variable {F L} in
 def RightExtension.IsPointwiseRightKanExtension.postcompose
     [PreservesPointwiseRightKanExtension G F L]
     {E : RightExtension L F} (hE : E.IsPointwiseRightKanExtension) :
-    RightExtension.postcompose₂ L F G|>.obj E|>.IsPointwiseRightKanExtension := fun c ↦
+    RightExtension.postcompose₂ L F G |>.obj E |>.IsPointwiseRightKanExtension := fun c ↦
   (hE c).postcompose G
 
 /-- The cone at a point of the whiskering right by `G`of an extension is isomorphic to the
 action of `G` on the cone at that point for the original extension. -/
 @[simps!]
 def RightExtension.coneAtWhiskerRightIso (E : RightExtension L F) (c : C) :
-    (RightExtension.postcompose₂ L F G|>.obj E).coneAt c ≅ G.mapCone (E.coneAt c) :=
+    (RightExtension.postcompose₂ L F G |>.obj E).coneAt c ≅ G.mapCone (E.coneAt c) :=
   Limits.Cones.ext (Iso.refl _)
 
 /-- If `G` preserves any pointwise right Kan extension of `F` along `L` at `c`, then it preserves
@@ -382,7 +383,7 @@ instance hasRightKanExtension_of_preserves [L.HasRightKanExtension F]
 instance hasPointwiseRightKanExtension_of_preserves [L.HasPointwiseRightKanExtension F]
     [PreservesPointwiseRightKanExtension G F L] : L.HasPointwiseRightKanExtension (F ⋙ G) :=
   (pointwiseRightKanExtensionIsPointwiseRightKanExtension
-    L F|>.postcompose G).hasPointwiseRightKanExtension
+    L F |>.postcompose G).hasPointwiseRightKanExtension
 
 /-- Extract an isomorphism `rightKanExtension L F ⋙ G ≅ rightKanExtension L (F ⋙ G)` when `G`
 preserves right Kan extensions. -/
@@ -410,7 +411,7 @@ lemma rightKanExtensionCompIsoOfPreserves_hom_fac :
 lemma rightKanExtensionCompIsoOfPreserves_hom_fac_app (a : A) :
     (G.rightKanExtensionCompIsoOfPreserves F L).hom.app (L.obj a) ≫
       (L.rightKanExtensionCounit (F ⋙ G)).app a =
-    G.map (L.rightKanExtensionCounit F|>.app a) := by
+    G.map (L.rightKanExtensionCounit F |>.app a) := by
   simp [rightKanExtensionCompIsoOfPreserves]
 
 @[reassoc (attr := simp)]
@@ -423,7 +424,7 @@ lemma rightKanExtensionCompIsoOfPreserves_inv_fac :
 @[reassoc (attr := simp)]
 lemma rightKanExtensionCompIsoOfPreserves_inv_fac_app (a : A) :
     (G.rightKanExtensionCompIsoOfPreserves F L).inv.app (L.obj a) ≫
-      G.map (L.rightKanExtensionCounit F|>.app a) =
+      G.map (L.rightKanExtensionCounit F |>.app a) =
     (L.rightKanExtensionCounit (F ⋙ G)).app a := by
   simpa [-rightKanExtensionCompIsoOfPreserves_inv_fac] using
     NatTrans.congr_app (rightKanExtensionCompIsoOfPreserves_inv_fac G F L) a
@@ -479,7 +480,7 @@ lemma pointwiseRightKanExtensionCompIsoOfPreserves_hom_fac :
 lemma pointwiseRightKanExtensionCompIsoOfPreserves_hom_fac_app (a : A) :
     (G.pointwiseRightKanExtensionCompIsoOfPreserves F L).hom.app (L.obj a) ≫
       (L.pointwiseRightKanExtensionCounit <| F ⋙ G).app a =
-    G.map (L.pointwiseRightKanExtensionCounit F|>.app a) := by
+    G.map (L.pointwiseRightKanExtensionCounit F |>.app a) := by
   simpa [-pointwiseRightKanExtensionCompIsoOfPreserves_hom_fac] using
     NatTrans.congr_app (pointwiseRightKanExtensionCompIsoOfPreserves_hom_fac G F L) a
 
@@ -493,7 +494,7 @@ lemma pointwiseRightKanExtensionCompIsoOfPreserves_inv_fac :
 @[reassoc]
 lemma pointwiseRightKanExtensionCompIsoOfPreserves_inv_fac_app (a : A) :
     (G.pointwiseRightKanExtensionCompIsoOfPreserves F L).inv.app (L.obj a) ≫
-      G.map (L.pointwiseRightKanExtensionCounit F|>.app a) =
+      G.map (L.pointwiseRightKanExtensionCounit F |>.app a) =
     (L.pointwiseRightKanExtensionCounit <| F ⋙ G).app a := by
   simpa [-pointwiseRightKanExtensionCompIsoOfPreserves_inv_fac] using
     NatTrans.congr_app (pointwiseRightKanExtensionCompIsoOfPreserves_inv_fac G F L) a

--- a/Mathlib/CategoryTheory/Iso.lean
+++ b/Mathlib/CategoryTheory/Iso.lean
@@ -66,6 +66,7 @@ variable {C : Type u} [Category.{v} C] {X Y Z : C}
 
 namespace Iso
 
+set_option linter.style.commandStart false in -- false positive, calc blocks
 @[ext, grind ext]
 theorem ext ⦃α β : X ≅ Y⦄ (w : α.hom = β.hom) : α = β :=
   suffices α.inv = β.inv by grind [Iso]

--- a/Mathlib/CategoryTheory/Limits/Preserves/Bifunctor.lean
+++ b/Mathlib/CategoryTheory/Limits/Preserves/Bifunctor.lean
@@ -32,7 +32,7 @@ by applying `G` to both `c₁` and `c₂`. -/
 @[simps!]
 def Functor.mapCocone₂ (G : C₁ ⥤ C₂ ⥤ C) {K₁ : J₁ ⥤ C₁} {K₂ : J₂ ⥤ C₂}
     (c₁ : Cocone K₁) (c₂ : Cocone K₂) :
-    Cocone <| uncurry.obj (whiskeringLeft₂ C|>.obj K₁|>.obj K₂|>.obj G) where
+    Cocone <| uncurry.obj (whiskeringLeft₂ C |>.obj K₁ |>.obj K₂ |>.obj G) where
   pt := (G.obj c₁.pt).obj c₂.pt
   ι :=
     { app := fun ⟨j₁, j₂⟩ ↦ (G.map <| c₁.ι.app j₁).app _ ≫ (G.obj _).map (c₂.ι.app j₂)
@@ -49,7 +49,7 @@ by applying `G` to both `c₁` and `c₂`. -/
 @[simps!]
 def Functor.mapCone₂ (G : C₁ ⥤ C₂ ⥤ C) {K₁ : J₁ ⥤ C₁} {K₂ : J₂ ⥤ C₂}
     (c₁ : Cone K₁) (c₂ : Cone K₂) :
-    Cone <| uncurry.obj (whiskeringLeft₂ C|>.obj K₁|>.obj K₂|>.obj G) where
+    Cone <| uncurry.obj (whiskeringLeft₂ C |>.obj K₁ |>.obj K₂ |>.obj G) where
   pt := (G.obj c₁.pt).obj c₂.pt
   π :=
     { app := fun ⟨j₁, j₂⟩ ↦ (G.map <| c₁.π.app j₁).app _ ≫ (G.obj _).map (c₂.π.app j₂)
@@ -89,7 +89,7 @@ noncomputable def isColimitOfPreserves₂ [PreservesColimit₂ K₁ K₂ G]
     {c₁ : Cocone K₁} (hc₁ : IsColimit c₁)
     {c₂ : Cocone K₂} (hc₂ : IsColimit c₂) :
     IsColimit (G.mapCocone₂ c₁ c₂) :=
-  PreservesColimit₂.nonempty_isColimit_mapCocone₂ hc₁ hc₂|>.some
+  PreservesColimit₂.nonempty_isColimit_mapCocone₂ hc₁ hc₂ |>.some
 
 /-- If `PreservesLimit₂ K₁ K₂ G`, obtain that `G.mapCone₂ c₁ c₂` is a limit cone
 whenever c₁ c₂ are limit cones. -/
@@ -97,19 +97,19 @@ noncomputable def isLimitOfPreserves₂ [PreservesLimit₂ K₁ K₂ G]
     {c₁ : Cone K₁} (hc₁ : IsLimit c₁)
     {c₂ : Cone K₂} (hc₂ : IsLimit c₂) :
     IsLimit (G.mapCone₂ c₁ c₂) :=
-  PreservesLimit₂.nonempty_isLimit_mapCone₂ hc₁ hc₂|>.some
+  PreservesLimit₂.nonempty_isLimit_mapCone₂ hc₁ hc₂ |>.some
 
 instance [HasColimit K₁] [HasColimit K₂] [PreservesColimit₂ K₁ K₂ G] :
-    HasColimit <| uncurry.obj (whiskeringLeft₂ C|>.obj K₁|>.obj K₂|>.obj G) where
+    HasColimit <| uncurry.obj (whiskeringLeft₂ C |>.obj K₁ |>.obj K₂ |>.obj G) where
   exists_colimit := ⟨{
     cocone := _
     isColimit :=
       PreservesColimit₂.nonempty_isColimit_mapCocone₂
         (getColimitCocone K₁).isColimit
-        (getColimitCocone K₂).isColimit|>.some }⟩
+        (getColimitCocone K₂).isColimit |>.some }⟩
 
 instance [HasLimit K₁] [HasLimit K₂] [PreservesLimit₂ K₁ K₂ G] :
-    HasLimit <| uncurry.obj (whiskeringLeft₂ C|>.obj K₁|>.obj K₂|>.obj G) where
+    HasLimit <| uncurry.obj (whiskeringLeft₂ C |>.obj K₁ |>.obj K₂ |>.obj G) where
   exists_limit := ⟨{
     cone := _
     isLimit :=
@@ -170,16 +170,16 @@ variable (K₁ K₂) [HasColimit K₁] [HasColimit K₂]
 `(G.obj (colim K₁)).obj (colim K₂)` from a `PreservesColimit₂` instance, provided the relevant
 colimits exist. -/
 noncomputable def isoColimitUncurryWhiskeringLeft₂ :
-    colimit (uncurry.obj (whiskeringLeft₂ C|>.obj K₁|>.obj K₂|>.obj G)) ≅
+    colimit (uncurry.obj (whiskeringLeft₂ C |>.obj K₁ |>.obj K₂ |>.obj G)) ≅
     (G.obj <| colimit K₁).obj (colimit K₂) :=
   isoObjCoconePointsOfIsColimit G
-    (colimit.isColimit _) (colimit.isColimit _) (colimit.isColimit _)|>.symm
+    (colimit.isColimit _) (colimit.isColimit _) (colimit.isColimit _) |>.symm
 
 /-- Characterize the forward direction of the isomorphism
 `PreservesColimit₂.isoColimitUncurryWhiskeringLeft₂` w.r.t. the canonical maps to the colimit. -/
 @[reassoc (attr := simp)]
 lemma ι_comp_isoColimitUncurryWhiskeringLeft₂_hom (j : J₁ × J₂) :
-    colimit.ι (uncurry.obj (whiskeringLeft₂ C|>.obj K₁|>.obj K₂|>.obj G)) j ≫
+    colimit.ι (uncurry.obj (whiskeringLeft₂ C |>.obj K₁ |>.obj K₂ |>.obj G)) j ≫
       (PreservesColimit₂.isoColimitUncurryWhiskeringLeft₂ K₁ K₂ G).hom =
     (G.map <| colimit.ι K₁ j.1).app (K₂.obj j.2) ≫ (G.obj <| colimit K₁).map (colimit.ι K₂ j.2) :=
   ι_comp_isoObjConePointsOfIsColimit_inv G
@@ -191,7 +191,7 @@ lemma ι_comp_isoColimitUncurryWhiskeringLeft₂_hom (j : J₁ × J₂) :
 lemma map_ι_comp_isoColimitUncurryWhiskeringLeft₂_inv (j : J₁ × J₂) :
     (G.map (colimit.ι K₁ j.1)).app (K₂.obj j.2) ≫ (G.obj <| colimit K₁).map (colimit.ι K₂ j.2) ≫
       (PreservesColimit₂.isoColimitUncurryWhiskeringLeft₂ K₁ K₂ G).inv =
-    colimit.ι (uncurry.obj (whiskeringLeft₂ C|>.obj K₁|>.obj K₂|>.obj G)) j :=
+    colimit.ι (uncurry.obj (whiskeringLeft₂ C |>.obj K₁ |>.obj K₂ |>.obj G)) j :=
   map_ι_comp_isoObjConePointsOfIsColimit_hom G
     (colimit.isColimit _) (colimit.isColimit _) (colimit.isColimit _) j
 
@@ -297,17 +297,17 @@ variable (K₁) (K₂) [HasLimit K₁] [HasLimit K₂]
 `(G.obj (colim K₁)).obj (colim K₂)` from a `PreservesLimit₂` instance, provided the relevant
 limits exist. -/
 noncomputable def isoLimitUncurryWhiskeringLeft₂ :
-    limit (uncurry.obj (whiskeringLeft₂ C|>.obj K₁|>.obj K₂|>.obj G)) ≅
+    limit (uncurry.obj (whiskeringLeft₂ C |>.obj K₁ |>.obj K₂ |>.obj G)) ≅
     (G.obj <| limit K₁).obj (limit K₂) :=
   isoObjConePointsOfIsLimit G
-    (limit.isLimit _) (limit.isLimit _) (limit.isLimit _)|>.symm
+    (limit.isLimit _) (limit.isLimit _) (limit.isLimit _) |>.symm
 
 /-- Characterize the inverse direction of the isomorphism
 `PreservesLimit₂.isoLimitUncurryWhiskeringLeft₂` w.r.t. the canonical maps to the limit. -/
 @[reassoc (attr := simp)]
 lemma isoLimitUncurryWhiskeringLeft₂_inv_comp_π (j : J₁ × J₂) :
     (PreservesLimit₂.isoLimitUncurryWhiskeringLeft₂ K₁ K₂ G).inv ≫
-      limit.π (uncurry.obj (whiskeringLeft₂ C|>.obj K₁|>.obj K₂|>.obj G)) j =
+      limit.π (uncurry.obj (whiskeringLeft₂ C |>.obj K₁ |>.obj K₂ |>.obj G)) j =
     (G.map <| limit.π K₁ j.1).app (limit K₂) ≫ (G.obj <| K₁.obj j.1).map (limit.π K₂ j.2) :=
   isoObjConePointsOfIsLimit_hom_comp_π G
     (limit.isLimit _) (limit.isLimit _) (limit.isLimit _) _
@@ -318,7 +318,7 @@ lemma isoLimitUncurryWhiskeringLeft₂_inv_comp_π (j : J₁ × J₂) :
 lemma isoLimitUncurryWhiskeringLeft₂_hom_comp_map_π (j : J₁ × J₂) :
     (PreservesLimit₂.isoLimitUncurryWhiskeringLeft₂ K₁ K₂ G).hom ≫
       (G.map (limit.π K₁ j.1)).app (limit K₂) ≫ (G.obj <| K₁.obj j.1).map (limit.π K₂ j.2) =
-    limit.π (uncurry.obj (whiskeringLeft₂ C|>.obj K₁|>.obj K₂|>.obj G)) j :=
+    limit.π (uncurry.obj (whiskeringLeft₂ C |>.obj K₁ |>.obj K₂ |>.obj G)) j :=
   isoObjConePointsOfIsColimit_inv_comp_map_π G
     (limit.isLimit _) (limit.isLimit _) (limit.isLimit _) _
 

--- a/Mathlib/CategoryTheory/Limits/Types/Shapes.lean
+++ b/Mathlib/CategoryTheory/Limits/Types/Shapes.lean
@@ -741,7 +741,7 @@ def isColimitCocone : IsColimit (cocone f g) :=
       | Sum.inr x₂ => s.inr x₂) (by
     rintro _ _ ⟨t⟩
     exact congr_fun s.condition t)) (fun _ => rfl) (fun _ => rfl) (fun s m h₁ h₂ => by
-      ext ⟨x₁|x₂⟩
+      ext ⟨x₁ | x₂⟩
       · exact congr_fun h₁ x₁
       · exact congr_fun h₂ x₂)
 

--- a/Mathlib/CategoryTheory/Monoidal/DayConvolution.lean
+++ b/Mathlib/CategoryTheory/Monoidal/DayConvolution.lean
@@ -80,7 +80,7 @@ variable (F G : C ⥤ V)
 
 instance leftKanExtension [DayConvolution F G] :
     (F ⊛ G).IsLeftKanExtension (unit F G) :=
-  isPointwiseLeftKanExtensionUnit F G|>.isLeftKanExtension
+  isPointwiseLeftKanExtensionUnit F G |>.isLeftKanExtension
 
 variable {F G}
 
@@ -156,7 +156,7 @@ variable (F G)
 corepresented by `F ⊛ G`. -/
 @[simps!]
 def corepresentableBy :
-    (Functor.whiskeringLeft _ _ _).obj (tensor C) ⋙ coyoneda.obj (.op <| F ⊠ G)|>.CorepresentableBy
+    (Functor.whiskeringLeft _ _ _).obj (tensor C) ⋙ coyoneda.obj (.op <| F ⊠ G) |>.CorepresentableBy
       (F ⊛ G) where
   homEquiv := Functor.homEquivOfIsLeftKanExtension _ (unit F G) _
   homEquiv_comp := by aesop
@@ -198,7 +198,7 @@ instance : ((F ⊛ G) ⊠ H).IsLeftKanExtension <|
 def corepresentableBy₂ :
     (whiskeringLeft _ _ _).obj (tensor C) ⋙
       (whiskeringLeft _ _ _).obj ((𝟭 C).prod (tensor C)) ⋙
-      coyoneda.obj (.op <| F ⊠ G ⊠ H)|>.CorepresentableBy (F ⊛ G ⊛ H) where
+      coyoneda.obj (.op <| F ⊠ G ⊠ H) |>.CorepresentableBy (F ⊛ G ⊛ H) where
   homEquiv :=
     (corepresentableBy F (G ⊛ H)).homEquiv.trans <|
       Functor.homEquivOfIsLeftKanExtension _ (extensionUnitRight (G ⊛ H) (unit G H) F) _
@@ -211,7 +211,7 @@ def corepresentableBy₂ :
 def corepresentableBy₂' :
     (whiskeringLeft _ _ _).obj (tensor C) ⋙
       (whiskeringLeft _ _ _).obj ((tensor C).prod (𝟭 C)) ⋙
-      coyoneda.obj (.op <| (F ⊠ G) ⊠ H)|>.CorepresentableBy ((F ⊛ G) ⊛ H) where
+      coyoneda.obj (.op <| (F ⊠ G) ⊠ H) |>.CorepresentableBy ((F ⊛ G) ⊛ H) where
   homEquiv :=
     (corepresentableBy (F ⊛ G) H).homEquiv.trans <|
       Functor.homEquivOfIsLeftKanExtension _ (extensionUnitLeft (F ⊛ G) (unit F G) H) _
@@ -247,11 +247,11 @@ def associatorCorepresentingIso :
     _ ≅ (whiskeringLeft _ _ _).obj ((𝟭 C).prod (tensor C) ⋙ tensor C) ⋙
           coyoneda.obj (.op <| F ⊠ G ⊠ H) :=
       isoWhiskerLeft _ <|
-        coyoneda.mapIso <| Iso.op <| NatIso.ofComponents (fun _ ↦ α_ _ _ _|>.symm)
+        coyoneda.mapIso <| Iso.op <| NatIso.ofComponents (fun _ ↦ α_ _ _ _ |>.symm)
 
 /-- The associator isomorphism for Day convolution -/
 def associator : (F ⊛ G) ⊛ H ≅ F ⊛ G ⊛ H :=
-  corepresentableBy₂' F G H|>.ofIso (associatorCorepresentingIso F G H)|>.uniqueUpToIso <|
+  corepresentableBy₂' F G H |>.ofIso (associatorCorepresentingIso F G H) |>.uniqueUpToIso <|
     corepresentableBy₂ F G H
 
 /-- Characterizing the forward direction of the associator isomorphism
@@ -267,8 +267,8 @@ lemma associator_hom_unit_unit (x y z : C) :
       (F ⊛ G ⊛ H).map (α_ _ _ _).inv := by
   have := congrArg (fun t ↦ t.app ((x, y), z)) <|
       (corepresentableBy₂' F G H).homEquiv.rightInverse_symm <|
-        (corepresentableBy₂ F G H|>.ofIso
-          (associatorCorepresentingIso F G H).symm|>.homEquiv (𝟙 _))
+        (corepresentableBy₂ F G H |>.ofIso
+          (associatorCorepresentingIso F G H).symm |>.homEquiv (𝟙 _))
   dsimp [associator, Coyoneda.fullyFaithful, corepresentableBy₂,
     corepresentableBy₂', Functor.CorepresentableBy.ofIso, corepresentableBy₂,
     Functor.corepresentableByEquiv, associatorCorepresentingIso] at this ⊢
@@ -288,8 +288,8 @@ lemma associator_inv_unit_unit (x y z : C) :
       ((F ⊛ G) ⊛ H).map (α_ x y z).hom := by
   have := congrArg (fun t ↦ t.app (x, y, z)) <|
       (corepresentableBy₂ F G H).homEquiv.rightInverse_symm <|
-        (corepresentableBy₂' F G H|>.ofIso
-          (associatorCorepresentingIso F G H)|>.homEquiv (𝟙 _))
+        (corepresentableBy₂' F G H |>.ofIso
+          (associatorCorepresentingIso F G H) |>.homEquiv (𝟙 _))
   dsimp [associator, Coyoneda.fullyFaithful, corepresentableBy₂,
     corepresentableBy₂', Functor.CorepresentableBy.ofIso, corepresentableBy₂,
     Functor.corepresentableByEquiv, associatorCorepresentingIso] at this ⊢
@@ -305,7 +305,7 @@ theorem associator_naturality {F' G' H' : C ⥤ V}
       map (map f g) h ≫
         (associator F' G' H').hom =
       (associator F G H).hom ≫ map f (map g h) := by
-  apply (corepresentableBy₂' F G H)|>.homEquiv.injective
+  apply (corepresentableBy₂' F G H) |>.homEquiv.injective
   dsimp
   ext
   simp only [externalProductBifunctor_obj_obj, Functor.comp_obj, Functor.prod_obj, tensor_obj,
@@ -344,7 +344,7 @@ lemma pentagon (H K : C ⥤ V)
       (extensionUnitLeft _ (unit F G) H) K) :=
     isPointwiseLeftKanExtensionExtensionUnitLeft _ _ _
       (isPointwiseLeftKanExtensionExtensionUnitLeft _ _ _
-        (isPointwiseLeftKanExtensionUnit F G))|>.isLeftKanExtension
+        (isPointwiseLeftKanExtensionUnit F G)) |>.isLeftKanExtension
   apply Functor.hom_ext_of_isLeftKanExtension (α := extensionUnitLeft ((F ⊛ G) ⊠ H)
       (extensionUnitLeft _ (unit F G) H) K)
   -- And then we compute...
@@ -396,7 +396,7 @@ class DayConvolutionUnit (F : C ⥤ V) where
   of `fromPUnit.{0} 𝟙_ V` along `fromPUnit.{0} 𝟙_ C`. -/
   isPointwiseLeftKanExtensionCan : Functor.LeftExtension.mk F
     ({app _ := can} : Functor.fromPUnit.{0} (𝟙_ V) ⟶
-      Functor.fromPUnit.{0} (𝟙_ C) ⋙ F)|>.IsPointwiseLeftKanExtension
+      Functor.fromPUnit.{0} (𝟙_ C) ⋙ F) |>.IsPointwiseLeftKanExtension
 
 namespace DayConvolutionUnit
 
@@ -426,11 +426,11 @@ variable (F : C ⥤ V)
 
 instance : (F ⊠ U).IsLeftKanExtension <| extensionUnitRight U (φ U) F :=
   isPointwiseLeftKanExtensionExtensionUnitRight
-    U (φ U) F isPointwiseLeftKanExtensionCan|>.isLeftKanExtension
+    U (φ U) F isPointwiseLeftKanExtensionCan |>.isLeftKanExtension
 
 instance : (U ⊠ F).IsLeftKanExtension <| extensionUnitLeft U (φ U) F :=
   isPointwiseLeftKanExtensionExtensionUnitLeft
-    U (φ U) F isPointwiseLeftKanExtensionCan|>.isLeftKanExtension
+    U (φ U) F isPointwiseLeftKanExtensionCan |>.isLeftKanExtension
 
 /-- A `CorepresentableBy` structure that characterizes maps out of `U ⊛ F`
 by leveraging the fact that `U ⊠ F` is a left Kan extension of `(fromPUnit 𝟙_ V) ⊠ F`. -/
@@ -438,9 +438,9 @@ by leveraging the fact that `U ⊠ F` is a left Kan extension of `(fromPUnit �
 def corepresentableByLeft [DayConvolution U F] :
     (whiskeringLeft _ _ _).obj (tensor C) ⋙
       (whiskeringLeft _ _ _).obj ((Functor.fromPUnit.{0} (𝟙_ C)).prod (𝟭 C)) ⋙
-      coyoneda.obj (.op <| Functor.fromPUnit.{0} (𝟙_ V) ⊠ F)|>.CorepresentableBy (U ⊛ F) where
+      coyoneda.obj (.op <| Functor.fromPUnit.{0} (𝟙_ V) ⊠ F) |>.CorepresentableBy (U ⊛ F) where
   homEquiv :=
-    Functor.homEquivOfIsLeftKanExtension _ (DayConvolution.unit U F) _|>.trans <|
+    Functor.homEquivOfIsLeftKanExtension _ (DayConvolution.unit U F) _ |>.trans <|
       Functor.homEquivOfIsLeftKanExtension _ (extensionUnitLeft U (φ U) F) _
   homEquiv_comp := by aesop
 
@@ -450,9 +450,9 @@ leveraging the fact that `F ⊠ U` is a left Kan extension of `F ⊠ (fromPUnit 
 def corepresentableByRight [DayConvolution F U] :
     (whiskeringLeft _ _ _).obj (tensor C) ⋙
       (whiskeringLeft _ _ _).obj ((𝟭 C).prod (Functor.fromPUnit.{0} (𝟙_ C))) ⋙
-      coyoneda.obj (.op <| F ⊠ Functor.fromPUnit.{0} (𝟙_ V))|>.CorepresentableBy (F ⊛ U) where
+      coyoneda.obj (.op <| F ⊠ Functor.fromPUnit.{0} (𝟙_ V)) |>.CorepresentableBy (F ⊛ U) where
   homEquiv :=
-    Functor.homEquivOfIsLeftKanExtension _ (DayConvolution.unit F U) _|>.trans <|
+    Functor.homEquivOfIsLeftKanExtension _ (DayConvolution.unit F U) _ |>.trans <|
       Functor.homEquivOfIsLeftKanExtension _ (extensionUnitRight U (φ U) F) _
   homEquiv_comp := by aesop
 
@@ -514,12 +514,12 @@ def rightUnitorCorepresentingIso :
 
 /-- The left unitor isomorphism for Day convolution. -/
 def leftUnitor [DayConvolution U F] : U ⊛ F ≅ F :=
-  corepresentableByLeft U F|>.ofIso (leftUnitorCorepresentingIso F)|>.uniqueUpToIso
+  corepresentableByLeft U F |>.ofIso (leftUnitorCorepresentingIso F) |>.uniqueUpToIso
     <| Functor.corepresentableByEquiv.symm (.refl _)
 
 /-- The right unitor isomorphism for Day convolution. -/
 def rightUnitor [DayConvolution F U] : F ⊛ U ≅ F :=
-  corepresentableByRight U F|>.ofIso (rightUnitorCorepresentingIso F)|>.uniqueUpToIso
+  corepresentableByRight U F |>.ofIso (rightUnitorCorepresentingIso F) |>.uniqueUpToIso
     <| Functor.corepresentableByEquiv.symm (.refl _)
 
 section
@@ -643,11 +643,11 @@ lemma DayConvolution.triangle (F G U : C ⥤ V) [DayConvolutionUnit U]
   apply Functor.hom_ext_of_isLeftKanExtension _ (DayConvolution.unit _ _) _
   apply Functor.hom_ext_of_isLeftKanExtension
     (α := extensionUnitLeft (F ⊛ U) (DayConvolution.unit F U) G)
-  have : (F ⊠ U) ⊠ G|>.IsLeftKanExtension
+  have : (F ⊠ U) ⊠ G |>.IsLeftKanExtension
       (α := extensionUnitLeft (F ⊠ U) (extensionUnitRight U (DayConvolutionUnit.φ U) F) G) :=
     isPointwiseLeftKanExtensionExtensionUnitLeft (F ⊠ U) _ G
       (isPointwiseLeftKanExtensionExtensionUnitRight U (DayConvolutionUnit.φ U) F <|
-        DayConvolutionUnit.isPointwiseLeftKanExtensionCan (F := U))|>.isLeftKanExtension
+        DayConvolutionUnit.isPointwiseLeftKanExtensionCan (F := U)) |>.isLeftKanExtension
   apply Functor.hom_ext_of_isLeftKanExtension
     (α := extensionUnitLeft (F ⊠ U) (extensionUnitRight U (DayConvolutionUnit.φ U) F) G)
   ext


### PR DESCRIPTION
Extracted from #30658. Found by extending the commandStart linter to proof bodies.


---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include at least one commit authored by each
co-author among the commits in the pull request. If necessary, you may 
create empty commits to indicate co-authorship, using commands like so:

git commit --author="Author Name <author@email.com>" --allow-empty -m "add Author Name as coauthor"

When merging, all the commits will be squashed into a single commit listing all co-authors.

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
