### PR TITLE
style(Order): fix whitespace

### DIFF
--- a/Mathlib/Order/Basic.lean
+++ b/Mathlib/Order/Basic.lean
@@ -123,7 +123,7 @@ theorem not_lt_iff_not_le_or_ge : ¬a < b ↔ ¬a ≤ b ∨ b ≤ a := by
   rw [lt_iff_le_not_ge, Classical.not_and_iff_not_or_not, Classical.not_not]
 
 -- Unnecessary brackets are here for readability
-lemma not_lt_iff_le_imp_ge : ¬ a < b ↔ (a ≤ b → b ≤ a) := by
+lemma not_lt_iff_le_imp_ge : ¬a < b ↔ (a ≤ b → b ≤ a) := by
   simp [not_lt_iff_not_le_or_ge, or_iff_not_imp_left]
 
 @[deprecated (since := "2025-05-11")] alias not_lt_iff_le_imp_le := not_lt_iff_le_imp_ge
@@ -277,7 +277,7 @@ theorem lt_iff_le_and_ne : a < b ↔ a ≤ b ∧ a ≠ b :=
   ⟨fun h ↦ ⟨le_of_lt h, ne_of_lt h⟩, fun ⟨h1, h2⟩ ↦ h1.lt_of_ne h2⟩
 
 @[deprecated LE.le.not_lt_iff_eq (since := "2025-06-08")]
-lemma eq_iff_not_lt_of_le (hab : a ≤ b) : a = b ↔ ¬ a < b := hab.not_lt_iff_eq.symm
+lemma eq_iff_not_lt_of_le (hab : a ≤ b) : a = b ↔ ¬a < b := hab.not_lt_iff_eq.symm
 
 @[deprecated (since := "2025-06-08")] alias LE.le.eq_iff_not_lt := eq_iff_not_lt_of_le
 
@@ -463,21 +463,21 @@ lemma ltByCases_eq (h : x = y) {h₁ : x < y → P} {h₂ : x = y → P} {h₃ :
 
 set_option linter.deprecated false in
 @[deprecated lt_trichotomy (since := "2025-04-21")]
-lemma ltByCases_not_lt (h : ¬ x < y) {h₁ : x < y → P} {h₂ : x = y → P} {h₃ : y < x → P}
-    (p : ¬ y < x → x = y := fun h' => (le_antisymm (le_of_not_gt h') (le_of_not_gt h))) :
+lemma ltByCases_not_lt (h : ¬x < y) {h₁ : x < y → P} {h₂ : x = y → P} {h₃ : y < x → P}
+    (p : ¬y < x → x = y := fun h' => (le_antisymm (le_of_not_gt h') (le_of_not_gt h))) :
     ltByCases x y h₁ h₂ h₃ = if h' : y < x then h₃ h' else h₂ (p h') := dif_neg h
 
 set_option linter.deprecated false in
 @[deprecated lt_trichotomy (since := "2025-04-21")]
-lemma ltByCases_not_gt (h : ¬ y < x) {h₁ : x < y → P} {h₂ : x = y → P} {h₃ : y < x → P}
-    (p : ¬ x < y → x = y := fun h' => (le_antisymm (le_of_not_gt h) (le_of_not_gt h'))) :
+lemma ltByCases_not_gt (h : ¬y < x) {h₁ : x < y → P} {h₂ : x = y → P} {h₃ : y < x → P}
+    (p : ¬x < y → x = y := fun h' => (le_antisymm (le_of_not_gt h) (le_of_not_gt h'))) :
     ltByCases x y h₁ h₂ h₃ = if h' : x < y then h₁ h' else h₂ (p h') :=
   dite_congr rfl (fun _ => rfl) (fun _ => dif_neg h)
 
 set_option linter.deprecated false in
 @[deprecated lt_trichotomy (since := "2025-04-21")]
 lemma ltByCases_ne (h : x ≠ y) {h₁ : x < y → P} {h₂ : x = y → P} {h₃ : y < x → P}
-    (p : ¬ x < y → y < x := fun h' => h.lt_or_gt.resolve_left h') :
+    (p : ¬x < y → y < x := fun h' => h.lt_or_gt.resolve_left h') :
     ltByCases x y h₁ h₂ h₃ = if h' : x < y then h₁ h' else h₃ (p h') :=
   dite_congr rfl (fun _ => rfl) (fun _ => dif_pos _)
 
@@ -554,12 +554,12 @@ lemma ltTrichotomy_eq (h : x = y) : ltTrichotomy x y p q r = q := ltByCases_eq h
 
 set_option linter.deprecated false in
 @[deprecated lt_trichotomy (since := "2025-04-21")]
-lemma ltTrichotomy_not_lt (h : ¬ x < y) :
+lemma ltTrichotomy_not_lt (h : ¬x < y) :
     ltTrichotomy x y p q r = if y < x then r else q := ltByCases_not_lt h
 
 set_option linter.deprecated false in
 @[deprecated lt_trichotomy (since := "2025-04-21")]
-lemma ltTrichotomy_not_gt (h : ¬ y < x) :
+lemma ltTrichotomy_not_gt (h : ¬y < x) :
     ltTrichotomy x y p q r = if x < y then p else q := ltByCases_not_gt h
 
 set_option linter.deprecated false in
@@ -1040,7 +1040,7 @@ theorem compare_of_injective_eq_compareOfLessAndEq (a b : α) [LinearOrder β]
   have h := LinearOrder.compare_eq_compareOfLessAndEq (f a) (f b)
   simp only [h, compareOfLessAndEq]
   split_ifs <;> try (first | rfl | contradiction)
-  · have : ¬ f a = f b := by rename_i h; exact inj.ne h
+  · have : ¬f a = f b := by rename_i h; exact inj.ne h
     contradiction
   · grind
 

--- a/Mathlib/Order/Bounds/Image.lean
+++ b/Mathlib/Order/Bounds/Image.lean
@@ -204,7 +204,7 @@ lemma StrictMono.mem_upperBounds_image (hf : StrictMono f) :
     f a ∈ upperBounds (f '' s) ↔ a ∈ upperBounds s := by simp [upperBounds, hf.le_iff_le]
 
 lemma StrictMono.mem_lowerBounds_image (hf : StrictMono f) :
-    f a ∈ lowerBounds (f '' s) ↔ a ∈ lowerBounds s :=  by simp [lowerBounds, hf.le_iff_le]
+    f a ∈ lowerBounds (f '' s) ↔ a ∈ lowerBounds s := by simp [lowerBounds, hf.le_iff_le]
 
 lemma StrictMono.map_isLeast (hf : StrictMono f) : IsLeast (f '' s) (f a) ↔ IsLeast s a := by
   simp [IsLeast, hf.injective.eq_iff, hf.mem_lowerBounds_image]

--- a/Mathlib/Order/Defs/PartialOrder.lean
+++ b/Mathlib/Order/Defs/PartialOrder.lean
@@ -67,14 +67,14 @@ lemma lt_iff_le_not_ge : a < b ↔ a ≤ b ∧ ¬b ≤ a := Preorder.lt_iff_le_n
 
 @[deprecated (since := "2025-05-11")] alias lt_iff_le_not_le := lt_iff_le_not_ge
 
-lemma lt_of_le_not_ge (hab : a ≤ b) (hba : ¬ b ≤ a) : a < b := lt_iff_le_not_ge.2 ⟨hab, hba⟩
+lemma lt_of_le_not_ge (hab : a ≤ b) (hba : ¬b ≤ a) : a < b := lt_iff_le_not_ge.2 ⟨hab, hba⟩
 
 @[deprecated (since := "2025-05-11")] alias lt_of_le_not_le := lt_of_le_not_ge
 
 lemma le_of_eq (hab : a = b) : a ≤ b := by rw [hab]
 lemma le_of_lt (hab : a < b) : a ≤ b := (lt_iff_le_not_ge.1 hab).1
-lemma not_le_of_gt (hab : a < b) : ¬ b ≤ a := (lt_iff_le_not_ge.1 hab).2
-lemma not_lt_of_ge (hab : a ≤ b) : ¬ b < a := imp_not_comm.1 not_le_of_gt hab
+lemma not_le_of_gt (hab : a < b) : ¬b ≤ a := (lt_iff_le_not_ge.1 hab).2
+lemma not_lt_of_ge (hab : a ≤ b) : ¬b < a := imp_not_comm.1 not_le_of_gt hab
 
 @[deprecated (since := "2025-05-11")] alias not_le_of_lt := not_le_of_gt
 @[deprecated (since := "2025-05-11")] alias not_lt_of_le := not_lt_of_ge

--- a/Mathlib/Order/Filter/Cocardinal.lean
+++ b/Mathlib/Order/Filter/Cocardinal.lean
@@ -64,8 +64,8 @@ theorem hasBasis_cocardinal : HasBasis (cocardinal α hreg) {s : Set α | #s < c
       simp_all only [mem_cocardinal] ⟩⟩
 
 theorem frequently_cocardinal {p : α → Prop} :
-    (∃ᶠ x in cocardinal α hreg, p x) ↔ c ≤ # { x | p x } := by
-  simp only [Filter.Frequently, eventually_cocardinal, not_not,coe_setOf, not_lt]
+    (∃ᶠ x in cocardinal α hreg, p x) ↔ c ≤ #{ x | p x } := by
+  simp only [Filter.Frequently, eventually_cocardinal, not_not, coe_setOf, not_lt]
 
 lemma frequently_cocardinal_mem {s : Set α} :
     (∃ᶠ x in cocardinal α hreg, x ∈ s) ↔ c ≤ #s := frequently_cocardinal

--- a/Mathlib/Order/Heyting/Basic.lean
+++ b/Mathlib/Order/Heyting/Basic.lean
@@ -1066,7 +1066,7 @@ namespace PUnit
 
 variable (a b : PUnit.{u + 1})
 
-instance instBiheytingAlgebra : BiheytingAlgebra PUnit.{u+1} :=
+instance instBiheytingAlgebra : BiheytingAlgebra PUnit.{u + 1} :=
   { PUnit.instLinearOrder.{u} with
     top := unit,
     bot := unit,

--- a/Mathlib/Order/KonigLemma.lean
+++ b/Mathlib/Order/KonigLemma.lean
@@ -59,7 +59,7 @@ variable {α : Type*} [PartialOrder α] [IsStronglyAtomic α] {b : α}
 is covered by only finitely many others, and `b` is an element with infinitely many things above it,
 then there is a sequence starting with `b` in which each element is covered by the next. -/
 theorem exists_seq_covby_of_forall_covby_finite (hfin : ∀ (a : α), {x | a ⋖ x}.Finite)
-    (hb : (Ici b).Infinite) : ∃ f : ℕ → α, f 0 = b ∧ ∀ i, f i ⋖ f (i+1) :=
+    (hb : (Ici b).Infinite) : ∃ f : ℕ → α, f 0 = b ∧ ∀ i, f i ⋖ f (i + 1) :=
   let h := fun a : {a : α // (Ici a).Infinite} ↦
     exists_covby_infinite_Ici_of_infinite_Ici a.2 (hfin a)
   let ks : ℕ → {a : α // (Ici a).Infinite} := Nat.rec ⟨b, hb⟩ fun _ a ↦ ⟨_, (h a).choose_spec.2⟩
@@ -67,18 +67,18 @@ theorem exists_seq_covby_of_forall_covby_finite (hfin : ∀ (a : α), {x | a ⋖
 
 /-- The sequence given by Kőnig's lemma as an order embedding -/
 theorem exists_orderEmbedding_covby_of_forall_covby_finite (hfin : ∀ (a : α), {x | a ⋖ x}.Finite)
-    (hb : (Ici b).Infinite) : ∃ f : ℕ ↪o α, f 0 = b ∧ ∀ i, f i ⋖ f (i+1) := by
+    (hb : (Ici b).Infinite) : ∃ f : ℕ ↪o α, f 0 = b ∧ ∀ i, f i ⋖ f (i + 1) := by
   obtain ⟨f, hf⟩ := exists_seq_covby_of_forall_covby_finite hfin hb
   exact ⟨OrderEmbedding.ofStrictMono f (strictMono_nat_of_lt_succ (fun i ↦ (hf.2 i).lt)), hf⟩
 
 /-- A version of Kőnig's lemma where the sequence starts at the minimum of an infinite order. -/
 theorem exists_orderEmbedding_covby_of_forall_covby_finite_of_bot [OrderBot α] [Infinite α]
-    (hfin : ∀ (a : α), {x | a ⋖ x}.Finite) : ∃ f : ℕ ↪o α, f 0 = ⊥ ∧ ∀ i, f i ⋖ f (i+1) :=
+    (hfin : ∀ (a : α), {x | a ⋖ x}.Finite) : ∃ f : ℕ ↪o α, f 0 = ⊥ ∧ ∀ i, f i ⋖ f (i + 1) :=
   exists_orderEmbedding_covby_of_forall_covby_finite hfin (by simpa using infinite_univ)
 
 theorem GradeMinOrder.exists_nat_orderEmbedding_of_forall_covby_finite
     [GradeMinOrder ℕ α] [OrderBot α] [Infinite α] (hfin : ∀ (a : α), {x | a ⋖ x}.Finite) :
-    ∃ f : ℕ ↪o α, f 0 = ⊥ ∧ (∀ i, f i ⋖ f (i+1)) ∧ ∀ i, grade ℕ (f i) = i := by
+    ∃ f : ℕ ↪o α, f 0 = ⊥ ∧ (∀ i, f i ⋖ f (i + 1)) ∧ ∀ i, grade ℕ (f i) = i := by
   obtain ⟨f, h0, hf⟩ := exists_orderEmbedding_covby_of_forall_covby_finite_of_bot hfin
   refine ⟨f, h0, hf, fun i ↦ ?_⟩
   induction i with
@@ -123,7 +123,7 @@ theorem exists_seq_forall_proj_of_forall_finite {α : ℕ → Type*} [Finite (α
     rintro i a j b ⟨h : i ≤ j, rfl : π h b = a⟩
     refine ⟨fun ⟨hne, h'⟩ ↦ ?_, ?_⟩
     · have hle' : i + 1 ≤ j := h.lt_of_ne <| by rintro rfl; simp [π_refl] at hne
-      exact congr_arg Sigma.fst <| h' (i+1) (π hle' b) ⟨by simp, by rw [π_trans]⟩ ⟨hle', by simp⟩
+      exact congr_arg Sigma.fst <| h' (i + 1) (π hle' b) ⟨by simp, by rw [π_trans]⟩ ⟨hle', by simp⟩
         (fun h ↦ by simp at h)
     rintro rfl
     refine ⟨fun h ↦ by simp at h, ?_⟩

--- a/Mathlib/Order/Max.lean
+++ b/Mathlib/Order/Max.lean
@@ -332,18 +332,18 @@ protected theorem IsBot.lt_of_ne (ha : IsBot a) (h : a ≠ b) : a < b :=
 protected theorem IsTop.lt_of_ne (ha : IsTop a) (h : b ≠ a) : b < a :=
   (ha b).lt_of_ne h
 
-protected theorem IsBot.not_isMax [Nontrivial α] (ha : IsBot a) : ¬ IsMax a := by
+protected theorem IsBot.not_isMax [Nontrivial α] (ha : IsBot a) : ¬IsMax a := by
   intro ha'
   obtain ⟨b, hb⟩ := exists_ne a
   exact hb <| ha'.eq_of_ge (ha.lt_of_ne hb.symm).le
 
-protected theorem IsTop.not_isMin [Nontrivial α] (ha : IsTop a) : ¬ IsMin a :=
+protected theorem IsTop.not_isMin [Nontrivial α] (ha : IsTop a) : ¬IsMin a :=
   ha.toDual.not_isMax
 
-protected theorem IsBot.not_isTop [Nontrivial α] (ha : IsBot a) : ¬ IsTop a :=
+protected theorem IsBot.not_isTop [Nontrivial α] (ha : IsBot a) : ¬IsTop a :=
   mt IsTop.isMax ha.not_isMax
 
-protected theorem IsTop.not_isBot [Nontrivial α] (ha : IsTop a) : ¬ IsBot a :=
+protected theorem IsTop.not_isBot [Nontrivial α] (ha : IsTop a) : ¬IsBot a :=
   ha.toDual.not_isTop
 
 end PartialOrder

--- a/Mathlib/Order/Minimal.lean
+++ b/Mathlib/Order/Minimal.lean
@@ -71,10 +71,10 @@ alias ⟨Minimal.of_dual, Minimal.dual⟩ := minimal_toDual
 
 alias ⟨Maximal.of_dual, Maximal.dual⟩ := maximal_toDual
 
-@[simp] theorem minimal_false : ¬ Minimal (fun _ ↦ False) x := by
+@[simp] theorem minimal_false : ¬Minimal (fun _ ↦ False) x := by
   simp [Minimal]
 
-@[simp] theorem maximal_false : ¬ Maximal (fun _ ↦ False) x := by
+@[simp] theorem maximal_false : ¬Maximal (fun _ ↦ False) x := by
   simp [Maximal]
 
 @[simp] theorem minimal_true : Minimal (fun _ ↦ True) x ↔ IsMin x := by
@@ -141,10 +141,10 @@ theorem Maximal.and_left (h : Maximal P x) (hQ : Q x) : Maximal (fun x ↦ (Q x 
 @[simp] theorem maximal_eq_iff : Maximal (· = y) x ↔ x = y := by
   simp +contextual [Maximal]
 
-theorem not_minimal_iff (hx : P x) : ¬ Minimal P x ↔ ∃ y, P y ∧ y ≤ x ∧ ¬ (x ≤ y) := by
+theorem not_minimal_iff (hx : P x) : ¬Minimal P x ↔ ∃ y, P y ∧ y ≤ x ∧ ¬(x ≤ y) := by
   simp [Minimal, hx]
 
-theorem not_maximal_iff (hx : P x) : ¬ Maximal P x ↔ ∃ y, P y ∧ x ≤ y ∧ ¬ (y ≤ x) :=
+theorem not_maximal_iff (hx : P x) : ¬Maximal P x ↔ ∃ y, P y ∧ x ≤ y ∧ ¬(y ≤ x) :=
   not_minimal_iff (α := αᵒᵈ) hx
 
 theorem Minimal.or (h : Minimal (fun x ↦ P x ∨ Q x) x) : Minimal P x ∨ Minimal Q x := by
@@ -178,16 +178,16 @@ section Preorder
 
 variable [Preorder α]
 
-theorem minimal_iff_forall_lt : Minimal P x ↔ P x ∧ ∀ ⦃y⦄, y < x → ¬ P y := by
+theorem minimal_iff_forall_lt : Minimal P x ↔ P x ∧ ∀ ⦃y⦄, y < x → ¬P y := by
   simp [Minimal, lt_iff_le_not_ge, imp.swap]
 
-theorem maximal_iff_forall_gt : Maximal P x ↔ P x ∧ ∀ ⦃y⦄, x < y → ¬ P y :=
+theorem maximal_iff_forall_gt : Maximal P x ↔ P x ∧ ∀ ⦃y⦄, x < y → ¬P y :=
   minimal_iff_forall_lt (α := αᵒᵈ)
 
-theorem Minimal.not_prop_of_lt (h : Minimal P x) (hlt : y < x) : ¬ P y :=
+theorem Minimal.not_prop_of_lt (h : Minimal P x) (hlt : y < x) : ¬P y :=
   (minimal_iff_forall_lt.1 h).2 hlt
 
-theorem Maximal.not_prop_of_gt (h : Maximal P x) (hlt : x < y) : ¬ P y :=
+theorem Maximal.not_prop_of_gt (h : Maximal P x) (hlt : x < y) : ¬P y :=
   (maximal_iff_forall_gt.1 h).2 hlt
 
 theorem Minimal.not_lt (h : Minimal P x) (hy : P y) : ¬(y < x) :=
@@ -208,12 +208,12 @@ theorem Maximal.not_gt (h : Maximal P x) (hy : P y) : ¬(x < y) :=
 @[simp] theorem maximal_gt_iff : Maximal (y < ·) x ↔ y < x ∧ IsMax x :=
   minimal_lt_iff (α := αᵒᵈ)
 
-theorem not_minimal_iff_exists_lt (hx : P x) : ¬ Minimal P x ↔ ∃ y, y < x ∧ P y := by
+theorem not_minimal_iff_exists_lt (hx : P x) : ¬Minimal P x ↔ ∃ y, y < x ∧ P y := by
   simp_rw [not_minimal_iff hx, lt_iff_le_not_ge, and_comm]
 
 alias ⟨exists_lt_of_not_minimal, _⟩ := not_minimal_iff_exists_lt
 
-theorem not_maximal_iff_exists_gt (hx : P x) : ¬ Maximal P x ↔ ∃ y, x < y ∧ P y :=
+theorem not_maximal_iff_exists_gt (hx : P x) : ¬Maximal P x ↔ ∃ y, x < y ∧ P y :=
   not_minimal_iff_exists_lt (α := αᵒᵈ) hx
 
 alias ⟨exists_gt_of_not_maximal, _⟩ := not_maximal_iff_exists_gt
@@ -338,19 +338,19 @@ theorem minimal_subset_iff' : Minimal P s ↔ P s ∧ ∀ ⦃t⦄, P t → t ⊆
 theorem maximal_subset_iff' : Maximal P s ↔ P s ∧ ∀ ⦃t⦄, P t → s ⊆ t → t ⊆ s :=
   Iff.rfl
 
-theorem not_minimal_subset_iff (hs : P s) : ¬ Minimal P s ↔ ∃ t, t ⊂ s ∧ P t :=
+theorem not_minimal_subset_iff (hs : P s) : ¬Minimal P s ↔ ∃ t, t ⊂ s ∧ P t :=
   not_minimal_iff_exists_lt hs
 
-theorem not_maximal_subset_iff (hs : P s) : ¬ Maximal P s ↔ ∃ t, s ⊂ t ∧ P t :=
+theorem not_maximal_subset_iff (hs : P s) : ¬Maximal P s ↔ ∃ t, s ⊂ t ∧ P t :=
   not_maximal_iff_exists_gt hs
 
-theorem Set.minimal_iff_forall_ssubset : Minimal P s ↔ P s ∧ ∀ ⦃t⦄, t ⊂ s → ¬ P t :=
+theorem Set.minimal_iff_forall_ssubset : Minimal P s ↔ P s ∧ ∀ ⦃t⦄, t ⊂ s → ¬P t :=
   minimal_iff_forall_lt
 
-theorem Minimal.not_prop_of_ssubset (h : Minimal P s) (ht : t ⊂ s) : ¬ P t :=
+theorem Minimal.not_prop_of_ssubset (h : Minimal P s) (ht : t ⊂ s) : ¬P t :=
   (minimal_iff_forall_lt.1 h).2 ht
 
-theorem Minimal.not_ssubset (h : Minimal P s) (ht : P t) : ¬ t ⊂ s :=
+theorem Minimal.not_ssubset (h : Minimal P s) (ht : P t) : ¬t ⊂ s :=
   h.not_lt ht
 
 theorem Maximal.mem_of_prop_insert (h : Maximal P s) (hx : P (insert x s)) : x ∈ s :=
@@ -363,32 +363,32 @@ theorem Minimal.notMem_of_prop_diff_singleton (h : Minimal P s) (hx : P (s \ {x}
 alias Minimal.not_mem_of_prop_diff_singleton := Minimal.notMem_of_prop_diff_singleton
 
 theorem Set.minimal_iff_forall_diff_singleton (hP : ∀ ⦃s t⦄, P t → t ⊆ s → P s) :
-    Minimal P s ↔ P s ∧ ∀ x ∈ s, ¬ P (s \ {x}) :=
+    Minimal P s ↔ P s ∧ ∀ x ∈ s, ¬P (s \ {x}) :=
   ⟨fun h ↦ ⟨h.1, fun _ hx hP ↦ h.notMem_of_prop_diff_singleton hP hx⟩,
     fun h ↦ ⟨h.1, fun _ ht hts x hxs ↦ by_contra fun hxt ↦
       h.2 x hxs (hP ht <| subset_diff_singleton hts hxt)⟩⟩
 
 theorem Set.exists_diff_singleton_of_not_minimal (hP : ∀ ⦃s t⦄, P t → t ⊆ s → P s) (hs : P s)
-    (h : ¬ Minimal P s) : ∃ x ∈ s, P (s \ {x}) := by
+    (h : ¬Minimal P s) : ∃ x ∈ s, P (s \ {x}) := by
   simpa [Set.minimal_iff_forall_diff_singleton hP, hs] using h
 
-theorem Set.maximal_iff_forall_ssuperset : Maximal P s ↔ P s ∧ ∀ ⦃t⦄, s ⊂ t → ¬ P t :=
+theorem Set.maximal_iff_forall_ssuperset : Maximal P s ↔ P s ∧ ∀ ⦃t⦄, s ⊂ t → ¬P t :=
   maximal_iff_forall_gt
 
-theorem Maximal.not_prop_of_ssuperset (h : Maximal P s) (ht : s ⊂ t) : ¬ P t :=
+theorem Maximal.not_prop_of_ssuperset (h : Maximal P s) (ht : s ⊂ t) : ¬P t :=
   (maximal_iff_forall_gt.1 h).2 ht
 
-theorem Maximal.not_ssuperset (h : Maximal P s) (ht : P t) : ¬ s ⊂ t :=
+theorem Maximal.not_ssuperset (h : Maximal P s) (ht : P t) : ¬s ⊂ t :=
   h.not_gt ht
 
 theorem Set.maximal_iff_forall_insert (hP : ∀ ⦃s t⦄, P t → s ⊆ t → P s) :
-    Maximal P s ↔ P s ∧ ∀ x ∉ s, ¬ P (insert x s) := by
+    Maximal P s ↔ P s ∧ ∀ x ∉ s, ¬P (insert x s) := by
   simp only [not_imp_not]
   exact ⟨fun h ↦ ⟨h.1, fun x ↦ h.mem_of_prop_insert⟩,
     fun h ↦ ⟨h.1, fun t ht hst x hxt ↦ h.2 x (hP ht <| insert_subset hxt hst)⟩⟩
 
 theorem Set.exists_insert_of_not_maximal (hP : ∀ ⦃s t⦄, P t → s ⊆ t → P s) (hs : P s)
-    (h : ¬ Maximal P s) : ∃ x ∉ s, P (insert x s) := by
+    (h : ¬Maximal P s) : ∃ x ∉ s, P (insert x s) := by
   simpa [Set.maximal_iff_forall_insert hP, hs] using h
 
 /- TODO : generalize `minimal_iff_forall_diff_singleton` and `maximal_iff_forall_insert`

--- a/Mathlib/Order/Monotone/Basic.lean
+++ b/Mathlib/Order/Monotone/Basic.lean
@@ -253,7 +253,7 @@ theorem StrictAnti.isMin_of_apply (hf : StrictAnti f) (ha : IsMax (f a)) : IsMin
     let ⟨_, hb⟩ := not_isMin_iff.1 h
     (hf hb).not_isMax ha
 
-lemma StrictMono.add_le_nat {f : ℕ → ℕ} (hf : StrictMono f) (m n : ℕ) : m + f n ≤ f (m + n)  := by
+lemma StrictMono.add_le_nat {f : ℕ → ℕ} (hf : StrictMono f) (m n : ℕ) : m + f n ≤ f (m + n) := by
   rw [Nat.add_comm m, Nat.add_comm m]
   induction m with
   | zero => rw [Nat.add_zero, Nat.add_zero]
@@ -456,7 +456,7 @@ variable [LinearOrder β] {f : α → β} {s : Set α} {x y : α}
 /-- A function between linear orders which is neither monotone nor antitone makes a dent upright or
 downright. -/
 lemma not_monotone_not_antitone_iff_exists_le_le :
-    ¬ Monotone f ∧ ¬ Antitone f ↔
+    ¬Monotone f ∧ ¬Antitone f ↔
       ∃ a b c, a ≤ b ∧ b ≤ c ∧ ((f a < f b ∧ f c < f b) ∨ (f b < f a ∧ f b < f c)) := by
   simp_rw [Monotone, Antitone, not_forall, not_le]
   refine Iff.symm ⟨?_, ?_⟩
@@ -486,7 +486,7 @@ lemma not_monotone_not_antitone_iff_exists_le_le :
 /-- A function between linear orders which is neither monotone nor antitone makes a dent upright or
 downright. -/
 lemma not_monotone_not_antitone_iff_exists_lt_lt :
-    ¬ Monotone f ∧ ¬ Antitone f ↔ ∃ a b c, a < b ∧ b < c ∧
+    ¬Monotone f ∧ ¬Antitone f ↔ ∃ a b c, a < b ∧ b < c ∧
     (f a < f b ∧ f c < f b ∨ f b < f a ∧ f b < f c) := by
   simp_rw [not_monotone_not_antitone_iff_exists_le_le, ← and_assoc]
   refine exists₃_congr (fun a b c ↦ and_congr_left <|

--- a/Mathlib/Order/PiLex.lean
+++ b/Mathlib/Order/PiLex.lean
@@ -47,7 +47,7 @@ protected def Lex (x y : ∀ i, β i) : Prop :=
 /- This unfortunately results in a type that isn't delta-reduced, so we keep the notation out of the
 basic API, just in case -/
 /-- The notation `Πₗ i, α i` refers to a pi type equipped with the lexicographic order. -/
-notation3 (prettyPrint := false) "Πₗ "(...)", "r:(scoped p => Lex (∀ i, p i)) => r
+notation3 (prettyPrint := false) "Πₗ " (...) ", " r:(scoped p => Lex (∀ i, p i)) => r
 
 @[simp]
 theorem toLex_apply (x : ∀ i, β i) (i : ι) : toLex x i = x i :=

--- a/Mathlib/Order/RelClasses.lean
+++ b/Mathlib/Order/RelClasses.lean
@@ -102,7 +102,7 @@ theorem IsStrictTotalOrder.swap (r) [IsStrictTotalOrder α r] : IsStrictTotalOrd
 /-- A connected order is one satisfying the condition `a < c → a < b ∨ b < c`.
   This is recognizable as an intuitionistic substitute for `a ≤ b ∨ b ≤ a` on
   the constructive reals, and is also known as negative transitivity,
-  since the contrapositive asserts transitivity of the relation `¬ a < b`. -/
+  since the contrapositive asserts transitivity of the relation `¬a < b`. -/
 class IsOrderConnected (α : Type u) (lt : α → α → Prop) : Prop where
   /-- A connected order is one satisfying the condition `a < c → a < b ∨ b < c`. -/
   conn : ∀ a b c, lt a c → lt a b ∨ lt b c
@@ -127,7 +127,7 @@ instance (priority := 100) isStrictOrderConnected_of_isStrictTotalOrder [IsStric
 /-! ### Inverse Image -/
 
 theorem InvImage.isTrichotomous [IsTrichotomous α r] {f : β → α} (h : Function.Injective f) :
-    IsTrichotomous β (InvImage r f)  where
+    IsTrichotomous β (InvImage r f) where
   trichotomous a b := trichotomous (f a) (f b) |>.imp3 id (h ·) id
 
 instance InvImage.isAsymm [IsAsymm α r] (f : β → α) : IsAsymm β (InvImage r f) where
@@ -146,12 +146,12 @@ instance WellFoundedRelation.isWellFounded [h : WellFoundedRelation α] :
   { h with }
 
 theorem WellFoundedRelation.asymmetric {α : Sort*} [WellFoundedRelation α] {a b : α} :
-    WellFoundedRelation.rel a b → ¬ WellFoundedRelation.rel b a :=
+    WellFoundedRelation.rel a b → ¬WellFoundedRelation.rel b a :=
   fun hab hba => WellFoundedRelation.asymmetric hba hab
 termination_by a
 
 theorem WellFoundedRelation.asymmetric₃ {α : Sort*} [WellFoundedRelation α] {a b c : α} :
-    WellFoundedRelation.rel a b → WellFoundedRelation.rel b c → ¬ WellFoundedRelation.rel c a :=
+    WellFoundedRelation.rel a b → WellFoundedRelation.rel b c → ¬WellFoundedRelation.rel c a :=
   fun hab hbc hca => WellFoundedRelation.asymmetric₃ hca hab hbc
 termination_by a
 
@@ -612,10 +612,10 @@ theorem eq_or_ssubset_of_subset [IsAntisymm α (· ⊆ ·)] (h : a ⊆ b) : a = 
 theorem ssubset_or_eq_of_subset [IsAntisymm α (· ⊆ ·)] (h : a ⊆ b) : a ⊂ b ∨ a = b :=
   (eq_or_ssubset_of_subset h).symm
 
-lemma eq_of_subset_of_not_ssubset [IsAntisymm α (· ⊆ ·)] (hab : a ⊆ b) (hba : ¬ a ⊂ b) : a = b :=
+lemma eq_of_subset_of_not_ssubset [IsAntisymm α (· ⊆ ·)] (hab : a ⊆ b) (hba : ¬a ⊂ b) : a = b :=
   (eq_or_ssubset_of_subset hab).resolve_right hba
 
-lemma eq_of_superset_of_not_ssuperset [IsAntisymm α (· ⊆ ·)] (hab : a ⊆ b) (hba : ¬ a ⊂ b) :
+lemma eq_of_superset_of_not_ssuperset [IsAntisymm α (· ⊆ ·)] (hab : a ⊆ b) (hba : ¬a ⊂ b) :
     b = a := ((eq_or_ssubset_of_subset hab).resolve_right hba).symm
 
 alias HasSubset.Subset.trans_ssubset := ssubset_of_subset_of_ssubset

--- a/Mathlib/Order/SetIsMax.lean
+++ b/Mathlib/Order/SetIsMax.lean
@@ -20,12 +20,12 @@ namespace Set
 
 variable {J : Type u} [Preorder J] {S : Set J} (m : S)
 
-lemma not_isMax_coe (hm : ¬ IsMax m) :
-    ¬ IsMax m.1 :=
+lemma not_isMax_coe (hm : ¬IsMax m) :
+    ¬IsMax m.1 :=
   fun h ↦ hm (fun _ hb ↦ h hb)
 
-lemma not_isMin_coe (hm : ¬ IsMin m) :
-    ¬ IsMin m.1 :=
+lemma not_isMin_coe (hm : ¬IsMin m) :
+    ¬IsMin m.1 :=
   fun h ↦ hm (fun _ hb ↦ h hb)
 
 end Set

--- a/Mathlib/Order/SetNotation.lean
+++ b/Mathlib/Order/SetNotation.lean
@@ -67,10 +67,10 @@ instance (priority := 50) supSet_to_nonempty (α) [SupSet α] : Nonempty α :=
   ⟨sSup ∅⟩
 
 /-- Indexed supremum. -/
-notation3 "⨆ "(...)", "r:60:(scoped f => iSup f) => r
+notation3 "⨆ " (...)", " r:60:(scoped f => iSup f) => r
 
 /-- Indexed infimum. -/
-notation3 "⨅ "(...)", "r:60:(scoped f => iInf f) => r
+notation3 "⨅ " (...)", " r:60:(scoped f => iInf f) => r
 
 section delaborators
 
@@ -172,10 +172,10 @@ def iInter (s : ι → Set α) : Set α :=
   iInf s
 
 /-- Notation for `Set.iUnion`. Indexed union of a family of sets -/
-notation3 "⋃ "(...)", "r:60:(scoped f => iUnion f) => r
+notation3 "⋃ " (...)", " r:60:(scoped f => iUnion f) => r
 
 /-- Notation for `Set.iInter`. Indexed intersection of a family of sets -/
-notation3 "⋂ "(...)", "r:60:(scoped f => iInter f) => r
+notation3 "⋂ " (...)", " r:60:(scoped f => iInter f) => r
 
 section delaborators
 
@@ -250,7 +250,7 @@ theorem mem_iInter {x : α} {s : ι → Set α} : (x ∈ ⋂ i, s i) ↔ ∀ i, 
     fun h _ ⟨a, (eq : s a = _)⟩ => eq ▸ h a⟩
 
 @[simp]
-theorem sSup_eq_sUnion (S : Set (Set α)) : sSup S = ⋃₀S :=
+theorem sSup_eq_sUnion (S : Set (Set α)) : sSup S = ⋃₀ S :=
   rfl
 
 @[simp]

--- a/Mathlib/Order/WithBot.lean
+++ b/Mathlib/Order/WithBot.lean
@@ -955,7 +955,7 @@ alias ⟨_, _root_.StrictMono.withTop_map⟩ := strictMono_map_iff
 theorem map_le_iff (f : α → β) (mono_iff : ∀ {a b}, f a ≤ f b ↔ a ≤ b) :
     x.map f ≤ y.map f ↔ x ≤ y := by cases x <;> cases y <;> simp [mono_iff]
 
-theorem coe_untopD_le (y : WithTop α) (a : α) : y.untopD a ≤ y :=  by cases y <;> simp
+theorem coe_untopD_le (y : WithTop α) (a : α) : y.untopD a ≤ y := by cases y <;> simp
 
 @[simp]
 theorem coe_top_lt [OrderTop α] : (⊤ : α) < x ↔ x = ⊤ := by cases x <;> simp
@@ -1200,7 +1200,7 @@ lemma WithTop.le_ofDual_iff {x : WithBot α} {y : WithTop αᵒᵈ} :
 
 @[simp]
 lemma WithTop.ofDual_le_ofDual_iff {x y : WithTop αᵒᵈ} :
-    WithTop.ofDual x ≤ WithTop.ofDual y ↔ y ≤ x :=  by cases x <;> cases y <;> simp
+    WithTop.ofDual x ≤ WithTop.ofDual y ↔ y ≤ x := by cases x <;> cases y <;> simp
 
 end LE
 


### PR DESCRIPTION
Extracted from #30658. Found by extending the commandStart linter to proof bodies.


---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include at least one commit authored by each
co-author among the commits in the pull request. If necessary, you may 
create empty commits to indicate co-authorship, using commands like so:

git commit --author="Author Name <author@email.com>" --allow-empty -m "add Author Name as coauthor"

When merging, all the commits will be squashed into a single commit listing all co-authors.

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
