### PR TITLE
[Merged by Bors] - feat(Order/Category): partial orders with order embeddings as morphisms

### DIFF
--- a/Mathlib.lean
+++ b/Mathlib.lean
@@ -5087,6 +5087,7 @@ import Mathlib.Order.Category.LinOrd
 import Mathlib.Order.Category.NonemptyFinLinOrd
 import Mathlib.Order.Category.OmegaCompletePartialOrder
 import Mathlib.Order.Category.PartOrd
+import Mathlib.Order.Category.PartOrdEmb
 import Mathlib.Order.Category.Preord
 import Mathlib.Order.Category.Semilat
 import Mathlib.Order.Chain

--- a/Mathlib/Order/Category/PartOrdEmb.lean
+++ b/Mathlib/Order/Category/PartOrdEmb.lean
@@ -1,0 +1,168 @@
+/-
+Copyright (c) 2025 Joël Riou. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Joël Riou, Johan Commelin
+-/
+import Mathlib.Order.Category.PartOrd
+
+/-!
+# Category of partial orders, with order embeddings as morphisms
+
+This defines `PartOrd`, the category of partial orders with order embeddings
+as morphisms.
+
+-/
+
+open CategoryTheory
+
+universe u
+
+/-- The category of partial orders. -/
+structure PartOrdEmb where
+  /-- The underlying partially ordered type. -/
+  (carrier : Type*)
+  [str : PartialOrder carrier]
+
+attribute [instance] PartOrdEmb.str
+
+initialize_simps_projections PartOrdEmb (carrier → coe, -str)
+
+namespace PartOrdEmb
+
+instance : CoeSort PartOrdEmb (Type _) :=
+  ⟨PartOrdEmb.carrier⟩
+
+attribute [coe] PartOrdEmb.carrier
+
+/-- Construct a bundled `PartOrdEmb` from the underlying type and typeclass. -/
+abbrev of (X : Type*) [PartialOrder X] : PartOrdEmb := ⟨X⟩
+
+/-- The type of morphisms in `PartOrdEmb R`. -/
+@[ext]
+structure Hom (X Y : PartOrdEmb.{u}) where
+  private mk ::
+  /-- The underlying `OrderEmbedding`. -/
+  hom' : X ↪o Y
+
+instance : Category PartOrdEmb.{u} where
+  Hom X Y := Hom X Y
+  id _ := ⟨RelEmbedding.refl _⟩
+  comp f g := ⟨f.hom'.trans g.hom'⟩
+
+instance : ConcreteCategory PartOrdEmb (· ↪o ·) where
+  hom := Hom.hom'
+  ofHom := Hom.mk
+
+/-- Turn a morphism in `PartOrdEmb` back into a `OrderEmbedding`. -/
+abbrev Hom.hom {X Y : PartOrdEmb.{u}} (f : Hom X Y) :=
+  ConcreteCategory.hom (C := PartOrdEmb) f
+
+/-- Typecheck a `OrderEmbedding` as a morphism in `PartOrdEmb`. -/
+abbrev ofHom {X Y : Type u} [PartialOrder X] [PartialOrder Y] (f : X ↪o Y) : of X ⟶ of Y :=
+  ConcreteCategory.ofHom (C := PartOrdEmb) f
+
+variable {R} in
+/-- Use the `ConcreteCategory.hom` projection for `@[simps]` lemmas. -/
+def Hom.Simps.hom (X Y : PartOrdEmb.{u}) (f : Hom X Y) :=
+  f.hom
+
+initialize_simps_projections Hom (hom' → hom)
+
+/-!
+The results below duplicate the `ConcreteCategory` simp lemmas, but we can keep them for `dsimp`.
+-/
+
+@[simp]
+lemma coe_id {X : PartOrdEmb} : (𝟙 X : X → X) = id := rfl
+
+@[simp]
+lemma coe_comp {X Y Z : PartOrdEmb} {f : X ⟶ Y} {g : Y ⟶ Z} : (f ≫ g : X → Z) = g ∘ f := rfl
+
+@[simp]
+lemma forget_map {X Y : PartOrdEmb} (f : X ⟶ Y) :
+    (forget PartOrdEmb).map f = f := rfl
+
+@[ext]
+lemma ext {X Y : PartOrdEmb} {f g : X ⟶ Y} (w : ∀ x : X, f x = g x) : f = g :=
+  ConcreteCategory.hom_ext _ _ w
+
+-- This is not `simp` to avoid rewriting in types of terms.
+theorem coe_of (X : Type u) [PartialOrder X] : (PartOrdEmb.of X : Type u) = X := rfl
+
+lemma hom_id {X : PartOrdEmb} : (𝟙 X : X ⟶ X).hom = RelEmbedding.refl _ := rfl
+
+/- Provided for rewriting. -/
+lemma id_apply (X : PartOrdEmb) (x : X) :
+    (𝟙 X : X ⟶ X) x = x := by simp
+
+@[simp]
+lemma hom_comp {X Y Z : PartOrdEmb} (f : X ⟶ Y) (g : Y ⟶ Z) :
+    (f ≫ g).hom = f.hom.trans g.hom := rfl
+
+/- Provided for rewriting. -/
+lemma comp_apply {X Y Z : PartOrdEmb} (f : X ⟶ Y) (g : Y ⟶ Z) (x : X) :
+    (f ≫ g) x = g (f x) := by simp
+
+lemma Hom.injective {X Y : PartOrdEmb.{u}} (f : X ⟶ Y) : Function.Injective f :=
+  f.hom'.injective
+
+@[ext]
+lemma hom_ext {X Y : PartOrdEmb} {f g : X ⟶ Y} (hf : f.hom = g.hom) : f = g :=
+  Hom.ext hf
+
+@[simp]
+lemma hom_ofHom {X Y : Type u} [PartialOrder X] [PartialOrder Y] (f : X ↪o Y) :
+    (ofHom f).hom = f :=
+  rfl
+
+@[simp]
+lemma ofHom_hom {X Y : PartOrdEmb} (f : X ⟶ Y) : ofHom (Hom.hom f) = f := rfl
+
+@[simp]
+lemma ofHom_id {X : Type u} [PartialOrder X] : ofHom (RelEmbedding.refl _) = 𝟙 (of X) := rfl
+
+@[simp]
+lemma ofHom_comp {X Y Z : Type u} [PartialOrder X] [PartialOrder Y] [PartialOrder Z]
+    (f : X ↪o Y) (g : Y ↪o Z) :
+    ofHom (f.trans g) = ofHom f ≫ ofHom g :=
+  rfl
+
+lemma ofHom_apply {X Y : Type u} [PartialOrder X] [PartialOrder Y] (f : X ↪o Y) (x : X) :
+    (ofHom f) x = f x := rfl
+
+lemma inv_hom_apply {X Y : PartOrdEmb} (e : X ≅ Y) (x : X) : e.inv (e.hom x) = x := by
+  simp
+
+lemma hom_inv_apply {X Y : PartOrdEmb} (e : X ≅ Y) (s : Y) : e.hom (e.inv s) = s := by
+  simp
+
+instance hasForgetToPartOrd : HasForget₂ PartOrdEmb PartOrd where
+  forget₂.obj X := .of X
+  forget₂.map f := PartOrd.ofHom f.hom
+
+/-- Constructs an equivalence between partial orders from an order isomorphism between them. -/
+@[simps]
+def Iso.mk {α β : PartOrdEmb.{u}} (e : α ≃o β) : α ≅ β where
+  hom := ofHom e
+  inv := ofHom e.symm
+
+/-- `OrderDual` as a functor. -/
+@[simps map]
+def dual : PartOrdEmb ⥤ PartOrdEmb where
+  obj X := of Xᵒᵈ
+  map f := ofHom f.hom.dual
+
+/-- The equivalence between `PartOrdEmb` and itself induced by `OrderDual` both ways. -/
+@[simps functor inverse]
+def dualEquiv : PartOrdEmb ≌ PartOrdEmb where
+  functor := dual
+  inverse := dual
+  unitIso := NatIso.ofComponents fun X => Iso.mk <| OrderIso.dualDual X
+  counitIso := NatIso.ofComponents fun X => Iso.mk <| OrderIso.dualDual X
+
+end PartOrdEmb
+
+theorem partOrdEmb_dual_comp_forget_to_pardOrd :
+    PartOrdEmb.dual ⋙ forget₂ PartOrdEmb PartOrd =
+      forget₂ PartOrdEmb PartOrd ⋙ PartOrd.dual :=
+  rfl

--- a/Mathlib/Order/Category/PartOrdEmb.lean
+++ b/Mathlib/Order/Category/PartOrdEmb.lean
@@ -8,7 +8,7 @@ import Mathlib.Order.Category.PartOrd
 /-!
 # Category of partial orders, with order embeddings as morphisms
 
-This defines `PartOrd`, the category of partial orders with order embeddings
+This defines `PartOrdEmb`, the category of partial orders with order embeddings
 as morphisms.
 
 -/


### PR DESCRIPTION
This category will be relevant in the study of accessible categories. I am making Johan Commelin a co-author as the new file `PartOrdEmb.lean` is essentially a copy-paste of `PartOrd.Lean`.

Co-authored-by: Johan Commelin <johan@commelin.net>

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include at least one commit authored by each
co-author among the commits in the pull request. If necessary, you may 
create empty commits to indicate co-authorship, using commands like so:

git commit --author="Author Name <author@email.com>" --allow-empty -m "add Author Name as coauthor"

When merging, all the commits will be squashed into a single commit listing all co-authors.

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
