### PR TITLE
[Merged by Bors] - feat(Geometry/Euclidean/Projection): characteristic property

### DIFF
--- a/Mathlib/Geometry/Euclidean/Projection.lean
+++ b/Mathlib/Geometry/Euclidean/Projection.lean
@@ -276,9 +276,10 @@ theorem orthogonalProjection_vsub_orthogonalProjection (s : AffineSubspace ℝ P
   rw [← neg_vsub_eq_vsub_rev, inner_neg_right,
     orthogonalProjection_vsub_mem_direction_orthogonal s p c hc, neg_zero]
 
-/-- The characteristic property of the orthogonal projection. This form is typically more
-convenient to use than `inter_eq_singleton_orthogonalProjection`. -/
-lemma orthogonalProjection_eq_iff_mem {s : AffineSubspace ℝ P} [Nonempty s]
+/-- The characteristic property of the orthogonal projection, for a point given in the underlying
+space. This form is typically more convenient to use than
+`inter_eq_singleton_orthogonalProjection`. -/
+lemma coe_orthogonalProjection_eq_iff_mem {s : AffineSubspace ℝ P} [Nonempty s]
     [s.direction.HasOrthogonalProjection] {p q : P} :
     orthogonalProjection s p = q ↔ q ∈ s ∧ p -ᵥ q ∈ s.directionᗮ := by
   constructor
@@ -293,11 +294,19 @@ lemma orthogonalProjection_eq_iff_mem {s : AffineSubspace ℝ P} [Nonempty s]
     simp only [Set.mem_inter_iff, SetLike.mem_coe]
     exact ⟨hqs, hq⟩
 
+/-- The characteristic property of the orthogonal projection, for a point given in the relevant
+subspace. This form is typically more convenient to use than
+`inter_eq_singleton_orthogonalProjection`. -/
+lemma orthogonalProjection_eq_iff_mem {s : AffineSubspace ℝ P} [Nonempty s]
+    [s.direction.HasOrthogonalProjection] {p : P} {q : s} :
+    orthogonalProjection s p = q ↔ p -ᵥ q ∈ s.directionᗮ := by
+  simpa using coe_orthogonalProjection_eq_iff_mem (s := s) (p := p) (q := (q : P))
+
 /-- A condition for two points to have the same orthogonal projection onto a given subspace. -/
 lemma orthogonalProjection_eq_orthogonalProjection_iff_vsub_mem {s : AffineSubspace ℝ P}
     [Nonempty s] [s.direction.HasOrthogonalProjection] {p q : P} :
     orthogonalProjection s p = orthogonalProjection s q ↔ p -ᵥ q ∈ s.directionᗮ := by
-  rw [← Subtype.coe_inj, orthogonalProjection_eq_iff_mem]
+  rw [← Subtype.coe_inj, coe_orthogonalProjection_eq_iff_mem]
   simp only [SetLike.coe_mem, true_and]
   rw [← s.directionᗮ.add_mem_iff_left (x := p -ᵥ q)
     (vsub_orthogonalProjection_mem_direction_orthogonal s q)]

--- a/Mathlib/Geometry/Euclidean/Projection.lean
+++ b/Mathlib/Geometry/Euclidean/Projection.lean
@@ -306,7 +306,7 @@ lemma orthogonalProjection_eq_iff_mem {s : AffineSubspace ℝ P} [Nonempty s]
 lemma orthogonalProjection_eq_orthogonalProjection_iff_vsub_mem {s : AffineSubspace ℝ P}
     [Nonempty s] [s.direction.HasOrthogonalProjection] {p q : P} :
     orthogonalProjection s p = orthogonalProjection s q ↔ p -ᵥ q ∈ s.directionᗮ := by
-  rw [← Subtype.coe_inj, coe_orthogonalProjection_eq_iff_mem]
+  rw [Subtype.ext_iff, coe_orthogonalProjection_eq_iff_mem]
   simp only [SetLike.coe_mem, true_and]
   rw [← s.directionᗮ.add_mem_iff_left (x := p -ᵥ q)
     (vsub_orthogonalProjection_mem_direction_orthogonal s q)]

--- a/Mathlib/Geometry/Euclidean/Projection.lean
+++ b/Mathlib/Geometry/Euclidean/Projection.lean
@@ -297,10 +297,7 @@ lemma orthogonalProjection_eq_iff_mem {s : AffineSubspace ℝ P} [Nonempty s]
 lemma orthogonalProjection_eq_orthogonalProjection_iff_vsub_mem {s : AffineSubspace ℝ P}
     [Nonempty s] [s.direction.HasOrthogonalProjection] {p q : P} :
     orthogonalProjection s p = orthogonalProjection s q ↔ p -ᵥ q ∈ s.directionᗮ := by
-  suffices (orthogonalProjection s p : P) = orthogonalProjection s q ↔
-      p -ᵥ q ∈ s.directionᗮ by
-    simpa using this
-  rw [orthogonalProjection_eq_iff_mem]
+  rw [← Subtype.coe_inj, orthogonalProjection_eq_iff_mem]
   simp only [SetLike.coe_mem, true_and]
   rw [← s.directionᗮ.add_mem_iff_left (x := p -ᵥ q)
     (vsub_orthogonalProjection_mem_direction_orthogonal s q)]

--- a/Mathlib/Geometry/Euclidean/Projection.lean
+++ b/Mathlib/Geometry/Euclidean/Projection.lean
@@ -276,6 +276,36 @@ theorem orthogonalProjection_vsub_orthogonalProjection (s : AffineSubspace ℝ P
   rw [← neg_vsub_eq_vsub_rev, inner_neg_right,
     orthogonalProjection_vsub_mem_direction_orthogonal s p c hc, neg_zero]
 
+/-- The characteristic property of the orthogonal projection. This form is typically more
+convenient to use than `inter_eq_singleton_orthogonalProjection`. -/
+lemma orthogonalProjection_eq_iff_mem {s : AffineSubspace ℝ P} [Nonempty s]
+    [s.direction.HasOrthogonalProjection] {p q : P} :
+    orthogonalProjection s p = q ↔ q ∈ s ∧ p -ᵥ q ∈ s.directionᗮ := by
+  constructor
+  · rintro rfl
+    exact ⟨orthogonalProjection_mem _, vsub_orthogonalProjection_mem_direction_orthogonal _ _⟩
+  · rintro ⟨hqs, hpq⟩
+    have hq : q ∈ mk' p s.directionᗮ := by
+      rwa [mem_mk', ← neg_mem_iff, neg_vsub_eq_vsub_rev]
+    suffices q ∈ ({(orthogonalProjection s p : P)} : Set P) by
+      simpa [eq_comm] using this
+    rw [← inter_eq_singleton_orthogonalProjection]
+    simp only [Set.mem_inter_iff, SetLike.mem_coe]
+    exact ⟨hqs, hq⟩
+
+/-- A condition for two points to have the same orthogonal projection onto a given subspace. -/
+lemma orthogonalProjection_eq_orthogonalProjection_iff_vsub_mem {s : AffineSubspace ℝ P}
+    [Nonempty s] [s.direction.HasOrthogonalProjection] {p q : P} :
+    orthogonalProjection s p = orthogonalProjection s q ↔ p -ᵥ q ∈ s.directionᗮ := by
+  suffices (orthogonalProjection s p : P) = orthogonalProjection s q ↔
+      p -ᵥ q ∈ s.directionᗮ by
+    simpa using this
+  rw [orthogonalProjection_eq_iff_mem]
+  simp only [SetLike.coe_mem, true_and]
+  rw [← s.directionᗮ.add_mem_iff_left (x := p -ᵥ q)
+    (vsub_orthogonalProjection_mem_direction_orthogonal s q)]
+  simp
+
 /-- Adding a vector to a point in the given subspace, then taking the
 orthogonal projection, produces the original point if the vector was
 in the orthogonal direction. -/

--- a/Mathlib/Geometry/Euclidean/Projection.lean
+++ b/Mathlib/Geometry/Euclidean/Projection.lean
@@ -306,9 +306,7 @@ lemma orthogonalProjection_eq_iff_mem {s : AffineSubspace ℝ P} [Nonempty s]
 lemma orthogonalProjection_eq_orthogonalProjection_iff_vsub_mem {s : AffineSubspace ℝ P}
     [Nonempty s] [s.direction.HasOrthogonalProjection] {p q : P} :
     orthogonalProjection s p = orthogonalProjection s q ↔ p -ᵥ q ∈ s.directionᗮ := by
-  rw [Subtype.ext_iff, coe_orthogonalProjection_eq_iff_mem]
-  simp only [SetLike.coe_mem, true_and]
-  rw [← s.directionᗮ.add_mem_iff_left (x := p -ᵥ q)
+  rw [orthogonalProjection_eq_iff_mem, ← s.directionᗮ.add_mem_iff_left (x := p -ᵥ q)
     (vsub_orthogonalProjection_mem_direction_orthogonal s q)]
   simp
 


### PR DESCRIPTION
Add a lemma

```lean
lemma orthogonalProjection_eq_iff_mem {s : AffineSubspace ℝ P} [Nonempty s]
    [s.direction.HasOrthogonalProjection] {p q : P} :
    orthogonalProjection s p = q ↔ q ∈ s ∧ p -ᵥ q ∈ s.directionᗮ := by
```

that gives the characteristic property of the orthogonal projection in a more convenient form to use than the existing
`inter_eq_singleton_orthogonalProjection` (from which it is derived).

Deduce a lemma `orthogonalProjection_eq_orthogonalProjection_iff_vsub_mem` about equality of two projections onto the same subspace.

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include at least one commit authored by each
co-author among the commits in the pull request. If necessary, you may 
create empty commits to indicate co-authorship, using commands like so:

git commit --author="Author Name <author@email.com>" --allow-empty -m "add Author Name as coauthor"

When merging, all the commits will be squashed into a single commit listing all co-authors.

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
