### PR TITLE
[Merged by Bors] - feat(LinearAlgebra/AffineSpace/FiniteDimensional): `finiteDimensional_sup`

### DIFF
--- a/Mathlib/LinearAlgebra/AffineSpace/FiniteDimensional.lean
+++ b/Mathlib/LinearAlgebra/AffineSpace/FiniteDimensional.lean
@@ -103,11 +103,9 @@ instance AffineSubspace.finiteDimensional_sup (s₁ s₂ : AffineSubspace k P)
     [FiniteDimensional k s₁.direction] [FiniteDimensional k s₂.direction] :
     FiniteDimensional k (s₁ ⊔ s₂).direction := by
   rcases eq_bot_or_nonempty s₁ with rfl | ⟨p₁, hp₁⟩
-  · rw [bot_sup_eq]
-    infer_instance
+  · rwa [bot_sup_eq]
   rcases eq_bot_or_nonempty s₂ with rfl | ⟨p₂, hp₂⟩
-  · rw [sup_bot_eq]
-    infer_instance
+  · rwa [sup_bot_eq]
   rw [AffineSubspace.direction_sup hp₁ hp₂]
   infer_instance
 

--- a/Mathlib/LinearAlgebra/AffineSpace/FiniteDimensional.lean
+++ b/Mathlib/LinearAlgebra/AffineSpace/FiniteDimensional.lean
@@ -99,7 +99,7 @@ theorem finite_set_of_fin_dim_affineIndependent [FiniteDimensional k V] {s : Set
 variable {k}
 
 /-- The supremum of two finite-dimensional affine subspaces is finite-dimensional. -/
-instance finiteDimensional_sup (s₁ s₂ : AffineSubspace k P)
+instance AffineSubspace.finiteDimensional_sup (s₁ s₂ : AffineSubspace k P)
     [FiniteDimensional k s₁.direction] [FiniteDimensional k s₂.direction] :
     FiniteDimensional k (s₁ ⊔ s₂).direction := by
   rcases eq_bot_or_nonempty s₁ with rfl | ⟨p₁, hp₁⟩

--- a/Mathlib/LinearAlgebra/AffineSpace/FiniteDimensional.lean
+++ b/Mathlib/LinearAlgebra/AffineSpace/FiniteDimensional.lean
@@ -98,6 +98,19 @@ theorem finite_set_of_fin_dim_affineIndependent [FiniteDimensional k V] {s : Set
 
 variable {k}
 
+/-- The supremum of two finite-dimensional affine subspaces is finite-dimensional. -/
+instance finiteDimensional_sup (s₁ s₂ : AffineSubspace k P)
+    [FiniteDimensional k s₁.direction] [FiniteDimensional k s₂.direction] :
+    FiniteDimensional k (s₁ ⊔ s₂).direction := by
+  rcases eq_bot_or_nonempty s₁ with rfl | ⟨p₁, hp₁⟩
+  · rw [bot_sup_eq]
+    infer_instance
+  rcases eq_bot_or_nonempty s₂ with rfl | ⟨p₂, hp₂⟩
+  · rw [sup_bot_eq]
+    infer_instance
+  rw [AffineSubspace.direction_sup hp₁ hp₂]
+  infer_instance
+
 /-- The `vectorSpan` of a finite subset of an affinely independent
 family has dimension one less than its cardinality. -/
 theorem AffineIndependent.finrank_vectorSpan_image_finset [DecidableEq P]


### PR DESCRIPTION
Add an instance that the supremum of two finite-dimensional affine subspaces is finite-dimensional.  This is useful when working with orthogonal projections.


---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include at least one commit authored by each
co-author among the commits in the pull request. If necessary, you may 
create empty commits to indicate co-authorship, using commands like so:

git commit --author="Author Name <author@email.com>" --allow-empty -m "add Author Name as coauthor"

When merging, all the commits will be squashed into a single commit listing all co-authors.

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
