### PR TITLE
[Merged by Bors] - feat(LinearAlgebra/AffineSpace/Independent): `inf_affineSpan_eq_affineSpan_inter`

### DIFF
--- a/Mathlib/LinearAlgebra/AffineSpace/Independent.lean
+++ b/Mathlib/LinearAlgebra/AffineSpace/Independent.lean
@@ -418,7 +418,7 @@ lemma AffineIndependent.inf_affineSpan_eq_affineSpan_inter [Nontrivial k] {p : �
   simp_rw [AffineSubspace.mem_inf_iff, Set.image_eq_range, mem_affineSpan_iff_eq_affineCombination,
     ← Finset.eq_affineCombination_subset_iff_eq_affineCombination_subtype]
   constructor
-  · rintro ⟨⟨fs₁, hfs₁, w₁, hw₁, hp's₁⟩, ⟨fs₂, hfs₂, w₂, hw₂, hp's₂⟩⟩
+  · rintro ⟨⟨fs₁, hfs₁, w₁, hw₁, rfl⟩, ⟨fs₂, hfs₂, w₂, hw₂, hw₁₂⟩⟩
     rw [affineIndependent_iff_indicator_eq_of_affineCombination_eq] at ha
     replace ha := ha fs₁ fs₂ w₁ w₂ hw₁ hw₂ (hp's₁ ▸ hp's₂)
     refine ⟨fs₁ ∩ fs₂, by grind, w₁, ?_, ?_⟩

--- a/Mathlib/LinearAlgebra/AffineSpace/Independent.lean
+++ b/Mathlib/LinearAlgebra/AffineSpace/Independent.lean
@@ -436,8 +436,7 @@ lemma AffineIndependent.inf_affineSpan_eq_affineSpan_inter [Nontrivial k] {p : �
       intro hi₂
       rw [← Set.indicator_of_mem (s := ↑fs₁) (by simpa using hi) w₁, ha]
       simp [hi₂]
-  · rintro ⟨fs, hfs, w, hw, hp's⟩
-    exact ⟨⟨fs, by grind, w, hw, hp's⟩, ⟨fs, by grind, w, hw, hp's⟩⟩
+  · grind
 
 /-- If a family is affinely independent, and the spans of points
 indexed by two subsets of the index type have a point in common, those

--- a/Mathlib/LinearAlgebra/AffineSpace/Independent.lean
+++ b/Mathlib/LinearAlgebra/AffineSpace/Independent.lean
@@ -420,14 +420,14 @@ lemma AffineIndependent.inf_affineSpan_eq_affineSpan_inter [Nontrivial k] {p : �
   constructor
   · rintro ⟨⟨fs₁, hfs₁, w₁, hw₁, rfl⟩, ⟨fs₂, hfs₂, w₂, hw₂, hw₁₂⟩⟩
     rw [affineIndependent_iff_indicator_eq_of_affineCombination_eq] at ha
-    replace ha := ha fs₁ fs₂ w₁ w₂ hw₁ hw₂ (hp's₁ ▸ hp's₂)
+    replace ha := ha fs₁ fs₂ w₁ w₂ hw₁ hw₂ hw₁₂
     refine ⟨fs₁ ∩ fs₂, by grind, w₁, ?_, ?_⟩
     · rw [← hw₁, ← fs₁.sum_inter_add_sum_diff fs₂, eq_comm]
       convert add_zero _
       refine Finset.sum_eq_zero ?_
       intro i hi
       rw [← Set.indicator_of_mem (s := ↑fs₁) (by grind) w₁, ha, Set.indicator_of_notMem (by grind)]
-    · rw [affineCombination_indicator_subset w₁ p Finset.inter_subset_left, hp's₁]
+    · rw [affineCombination_indicator_subset w₁ p Finset.inter_subset_left]
       refine affineCombination_congr (k := k) (P := P) _ ?_ (fun _ _ ↦ rfl)
       intro i hi
       rw [coe_inter, ← Set.indicator_indicator, Set.indicator_of_mem (by simpa using hi),

--- a/Mathlib/LinearAlgebra/AffineSpace/Independent.lean
+++ b/Mathlib/LinearAlgebra/AffineSpace/Independent.lean
@@ -407,6 +407,38 @@ theorem AffineEquiv.affineIndependent_set_of_eq_iff {s : Set P} (e : P ≃ᵃ[k]
 
 end Composition
 
+/-- If a family is affinely independent, the infimum of the affine spans of points indexed by two
+subsets equals the affine span of points indexed by the intersection of those subsets, if the
+underlying ring is nontrivial. -/
+lemma AffineIndependent.inf_affineSpan_eq_affineSpan_inter [Nontrivial k] {p : ι → P}
+    (ha : AffineIndependent k p) (s₁ s₂ : Set ι) :
+    affineSpan k (p '' s₁) ⊓ affineSpan k (p '' s₂) = affineSpan k (p '' (s₁ ∩ s₂)) := by
+  classical
+  ext p'
+  simp_rw [AffineSubspace.mem_inf_iff, Set.image_eq_range, mem_affineSpan_iff_eq_affineCombination,
+    ← Finset.eq_affineCombination_subset_iff_eq_affineCombination_subtype]
+  constructor
+  · rintro ⟨⟨fs₁, hfs₁, w₁, hw₁, hp's₁⟩, ⟨fs₂, hfs₂, w₂, hw₂, hp's₂⟩⟩
+    rw [affineIndependent_iff_indicator_eq_of_affineCombination_eq] at ha
+    replace ha := ha fs₁ fs₂ w₁ w₂ hw₁ hw₂ (hp's₁ ▸ hp's₂)
+    refine ⟨fs₁ ∩ fs₂, by grind, w₁, ?_, ?_⟩
+    · rw [← hw₁, ← fs₁.sum_inter_add_sum_diff fs₂, eq_comm]
+      convert add_zero _
+      refine Finset.sum_eq_zero ?_
+      intro i hi
+      rw [← Set.indicator_of_mem (s := ↑fs₁) (by grind) w₁, ha, Set.indicator_of_notMem (by grind)]
+    · rw [affineCombination_indicator_subset w₁ p Finset.inter_subset_left, hp's₁]
+      refine affineCombination_congr (k := k) (P := P) _ ?_ (fun _ _ ↦ rfl)
+      intro i hi
+      rw [coe_inter, ← Set.indicator_indicator, Set.indicator_of_mem (by simpa using hi),
+        Set.indicator_apply]
+      simp only [mem_coe, left_eq_ite_iff]
+      intro hi₂
+      rw [← Set.indicator_of_mem (s := ↑fs₁) (by simpa using hi) w₁, ha]
+      simp [hi₂]
+  · rintro ⟨fs, hfs, w, hw, hp's⟩
+    exact ⟨⟨fs, by grind, w, hw, hp's⟩, ⟨fs, by grind, w, hw, hp's⟩⟩
+
 /-- If a family is affinely independent, and the spans of points
 indexed by two subsets of the index type have a point in common, those
 subsets of the index type have an element in common, if the underlying
@@ -414,18 +446,12 @@ ring is nontrivial. -/
 theorem AffineIndependent.exists_mem_inter_of_exists_mem_inter_affineSpan [Nontrivial k] {p : ι → P}
     (ha : AffineIndependent k p) {s1 s2 : Set ι} {p0 : P} (hp0s1 : p0 ∈ affineSpan k (p '' s1))
     (hp0s2 : p0 ∈ affineSpan k (p '' s2)) : ∃ i : ι, i ∈ s1 ∩ s2 := by
-  rw [Set.image_eq_range] at hp0s1 hp0s2
-  rw [mem_affineSpan_iff_eq_affineCombination, ←
-    Finset.eq_affineCombination_subset_iff_eq_affineCombination_subtype] at hp0s1 hp0s2
-  rcases hp0s1 with ⟨fs1, hfs1, w1, hw1, hp0s1⟩
-  rcases hp0s2 with ⟨fs2, hfs2, w2, hw2, hp0s2⟩
-  rw [affineIndependent_iff_indicator_eq_of_affineCombination_eq] at ha
-  replace ha := ha fs1 fs2 w1 w2 hw1 hw2 (hp0s1 ▸ hp0s2)
-  have hnz : ∑ i ∈ fs1, w1 i ≠ 0 := hw1.symm ▸ one_ne_zero
-  rcases Finset.exists_ne_zero_of_sum_ne_zero hnz with ⟨i, hifs1, hinz⟩
-  simp_rw [← Set.indicator_of_mem (Finset.mem_coe.2 hifs1) w1, ha] at hinz
-  use i, hfs1 hifs1
-  exact hfs2 (Set.mem_of_indicator_ne_zero hinz)
+  have hp0' : p0 ∈ affineSpan k (p '' s1) ⊓ affineSpan k (p '' s2) := ⟨hp0s1, hp0s2⟩
+  rw [ha.inf_affineSpan_eq_affineSpan_inter] at hp0'
+  rw [← Set.Nonempty]
+  by_contra he
+  rw [Set.not_nonempty_iff_eq_empty] at he
+  simp [he, AffineSubspace.notMem_bot] at hp0'
 
 /-- If a family is affinely independent, the spans of points indexed
 by disjoint subsets of the index type are disjoint, if the underlying


### PR DESCRIPTION
Add a lemma

```lean
lemma AffineIndependent.inf_affineSpan_eq_affineSpan_inter [Nontrivial k] {p : ι → P}
    (ha : AffineIndependent k p) (s₁ s₂ : Set ι) :
    affineSpan k (p '' s₁) ⊓ affineSpan k (p '' s₂) = affineSpan k (p '' (s₁ ∩ s₂)) := by
```

with a proof adapted from that of the existing weaker `exists_mem_inter_of_exists_mem_inter_affineSpan`, and change `exists_mem_inter_of_exists_mem_inter_affineSpan` to be proved using the new lemma.


---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include at least one commit authored by each
co-author among the commits in the pull request. If necessary, you may 
create empty commits to indicate co-authorship, using commands like so:

git commit --author="Author Name <author@email.com>" --allow-empty -m "add Author Name as coauthor"

When merging, all the commits will be squashed into a single commit listing all co-authors.

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
