### PR TITLE
[Merged by Bors] - chore(Algebra/Ring): shortcut `IsDomain` instances for `Nat` and `Int`

### DIFF
--- a/Mathlib/Algebra/Ring/Int/Defs.lean
+++ b/Mathlib/Algebra/Ring/Int/Defs.lean
@@ -6,6 +6,7 @@ Authors: Jeremy Avigad
 import Mathlib.Algebra.CharZero.Defs
 import Mathlib.Algebra.Ring.Defs
 import Mathlib.Algebra.Group.Int.Defs
+import Mathlib.Data.Int.Basic
 import Mathlib.Data.Int.Cast.Basic
 import Mathlib.Algebra.Ring.GrindInstances
 
@@ -42,6 +43,8 @@ instance instCommRing : CommRing ℤ where
 
 instance instCancelCommMonoidWithZero : CancelCommMonoidWithZero ℤ where
   mul_left_cancel_of_ne_zero ha _ _ := (mul_eq_mul_left_iff ha).1
+
+instance instIsDomain : IsDomain ℤ where
 
 instance instCharZero : CharZero ℤ where cast_injective _ _ := ofNat.inj
 

--- a/Mathlib/Algebra/Ring/Nat.lean
+++ b/Mathlib/Algebra/Ring/Nat.lean
@@ -6,6 +6,7 @@ Authors: Floris van Doorn, Leonardo de Moura, Jeremy Avigad, Mario Carneiro
 import Mathlib.Algebra.CharZero.Defs
 import Mathlib.Algebra.GroupWithZero.Nat
 import Mathlib.Algebra.Ring.Defs
+import Mathlib.Data.Nat.Basic
 
 /-!
 # The natural numbers form a semiring
@@ -54,5 +55,7 @@ instance instCommSemiring : CommSemiring ℕ where
   __ := instCommMonoid
 
 instance instCharZero : CharZero ℕ where cast_injective := Function.injective_id
+
+instance instIsDomain : IsDomain ℕ where
 
 end Nat


### PR DESCRIPTION
These instances are currently inferred from the `IsStrictOrderedRing` ones (see code snippet), but in #30563 I need these instances earlier than the `IsStrictOrderedRing` ones.

```
import Mathlib

#synth IsDomain ℕ -- IsStrictOrderedRing.isDomain
#synth IsDomain ℤ -- IsStrictOrderedRing.isDomain
```


---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include at least one commit authored by each
co-author among the commits in the pull request. If necessary, you may 
create empty commits to indicate co-authorship, using commands like so:

git commit --author="Author Name <author@email.com>" --allow-empty -m "add Author Name as coauthor"

When merging, all the commits will be squashed into a single commit listing all co-authors.

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
