### PR TITLE
[Merged by Bors] - doc: fix recurring instances of "this files"

### DIFF
--- a/Mathlib/Algebra/Homology/HomotopyCategory/ShiftSequence.lean
+++ b/Mathlib/Algebra/Homology/HomotopyCategory/ShiftSequence.lean
@@ -11,7 +11,7 @@ import Mathlib.Algebra.Homology.QuasiIso
 
 /-! # Compatibilities of the homology functor with the shift
 
-This files studies how homology of cochain complexes behaves with respect to
+This file studies how homology of cochain complexes behaves with respect to
 the shift: there is a natural isomorphism `(K⟦n⟧).homology a ≅ K.homology a`
 when `n + a = a'`. This is summarized by instances
 `(homologyFunctor C (ComplexShape.up ℤ) 0).ShiftSequence ℤ` in the `CochainComplex`

--- a/Mathlib/Algebra/Order/Group/Opposite.lean
+++ b/Mathlib/Algebra/Order/Group/Opposite.lean
@@ -9,7 +9,7 @@ import Mathlib.Algebra.Order.Monoid.Defs
 /-!
 # Order instances for `MulOpposite`/`AddOpposite`
 
-This files transfers order instances and ordered monoid/group instances from `α` to `αᵐᵒᵖ` and
+This file transfers order instances and ordered monoid/group instances from `α` to `αᵐᵒᵖ` and
 `αᵃᵒᵖ`.
 -/
 

--- a/Mathlib/Algebra/Order/Ring/Opposite.lean
+++ b/Mathlib/Algebra/Order/Ring/Opposite.lean
@@ -10,7 +10,7 @@ import Mathlib.Algebra.Ring.Opposite
 /-!
 # Ordered ring instances for `MulOpposite`/`AddOpposite`
 
-This files transfers ordered (semi)ring instances from `R` to `Rᵐᵒᵖ` and `Rᵃᵒᵖ`.
+This file transfers ordered (semi)ring instances from `R` to `Rᵐᵒᵖ` and `Rᵃᵒᵖ`.
 -/
 
 variable {R : Type*}

--- a/Mathlib/Analysis/Convex/Star.lean
+++ b/Mathlib/Analysis/Convex/Star.lean
@@ -13,7 +13,7 @@ import Mathlib.Tactic.Module
 /-!
 # Star-convex sets
 
-This files defines star-convex sets (aka star domains, star-shaped set, radially convex set).
+This file defines star-convex sets (aka star domains, star-shaped set, radially convex set).
 
 A set is star-convex at `x` if every segment from `x` to a point in the set is contained in the set.
 

--- a/Mathlib/Analysis/LocallyConvex/Barrelled.lean
+++ b/Mathlib/Analysis/LocallyConvex/Barrelled.lean
@@ -10,9 +10,9 @@ import Mathlib.Topology.Baire.Lemmas
 /-!
 # Barrelled spaces and the Banach-Steinhaus theorem / Uniform Boundedness Principle
 
-This files defines barrelled spaces over a `NontriviallyNormedField`, and proves the
+This file defines barrelled spaces over a `NontriviallyNormedField`, and proves the
 Banach-Steinhaus theorem for maps from a barrelled space to a space equipped with a family
-of seminorms generating the topology (i.e `WithSeminorms q` for some family of seminorms `q`).
+of seminorms generating the topology (i.e. `WithSeminorms q` for some family of seminorms `q`).
 
 The more standard Banach-Steinhaus theorem for normed spaces is then deduced from that in
 `Mathlib/Analysis/Normed/Operator/BanachSteinhaus.lean`.

--- a/Mathlib/Analysis/LocallyConvex/ContinuousOfBounded.lean
+++ b/Mathlib/Analysis/LocallyConvex/ContinuousOfBounded.lean
@@ -9,7 +9,7 @@ import Mathlib.Analysis.RCLike.Basic
 /-!
 # Continuity and Von Neumann boundedness
 
-This files proves that for `E` and `F` two topological vector spaces over `ℝ` or `ℂ`,
+This file proves that for two topological vector spaces `E` and `F` over `ℝ` or `ℂ`,
 if `E` is first countable, then every locally bounded linear map `E →ₛₗ[σ] F` is continuous
 (this is `LinearMap.continuous_of_locally_bounded`).
 

--- a/Mathlib/CategoryTheory/Limits/ConeCategory.lean
+++ b/Mathlib/CategoryTheory/Limits/ConeCategory.lean
@@ -11,7 +11,7 @@ import Mathlib.CategoryTheory.Limits.Shapes.Equivalence
 /-!
 # Limits and the category of (co)cones
 
-This files contains results that stem from the limit API. For the definition and the category
+This file contains results that stem from the limit API. For the definition and the category
 instance of `Cone`, please refer to `CategoryTheory/Limits/Cones.lean`.
 
 ## Main results

--- a/Mathlib/CategoryTheory/Limits/Shapes/Pullback/Categorical/CatCospanTransform.lean
+++ b/Mathlib/CategoryTheory/Limits/Shapes/Pullback/Categorical/CatCospanTransform.lean
@@ -8,7 +8,7 @@ import Mathlib.CategoryTheory.CatCommSq
 /-! # Morphisms of categorical cospans.
 
 Given `F : A ⥤ B`, `G : C ⥤ B`, `F' : A' ⥤ B'` and `G' : C' ⥤ B'`,
-this files defines `CatCospanTransform F G F' G'`, the category of
+this file defines `CatCospanTransform F G F' G'`, the category of
 "categorical transformations" from the (categorical) cospan `F G` to
 the (categorical) cospan `F' G'`. Such a transformation consists of a
 diagram

--- a/Mathlib/CategoryTheory/Triangulated/TStructure/Basic.lean
+++ b/Mathlib/CategoryTheory/Triangulated/TStructure/Basic.lean
@@ -9,7 +9,7 @@ import Mathlib.CategoryTheory.Triangulated.Pretriangulated
 /-!
 # t-structures on triangulated categories
 
-This files introduces the notion of t-structure on (pre)triangulated categories.
+This file introduces the notion of t-structure on (pre)triangulated categories.
 
 The first example of t-structure shall be the canonical t-structure on the
 derived category of an abelian category (TODO).
@@ -26,7 +26,7 @@ use depending on the context.
 
 ## TODO
 
-* define functors `t.truncLE n : C ⥤ C`,`t.truncGE n : C ⥤ C` and the
+* define functors `t.truncLE n : C ⥤ C`, `t.truncGE n : C ⥤ C` and the
   associated distinguished triangles
 * promote these truncations to a (functorial) spectral object
 * define the heart of `t` and show it is an abelian category

--- a/Mathlib/Combinatorics/Quiver/Push.lean
+++ b/Mathlib/Combinatorics/Quiver/Push.lean
@@ -9,7 +9,7 @@ import Mathlib.Combinatorics.Quiver.Prefunctor
 
 # Pushing a quiver structure along a map
 
-Given a map `σ : V → W` and a `Quiver` instance on `V`, this files defines a `Quiver` instance
+Given a map `σ : V → W` and a `Quiver` instance on `V`, this file defines a `Quiver` instance
 on `W` by associating to each arrow `v ⟶ v'` in `V` an arrow `σ v ⟶ σ v'` in `W`.
 
 -/

--- a/Mathlib/Condensed/Light/Module.lean
+++ b/Mathlib/Condensed/Light/Module.lean
@@ -15,7 +15,7 @@ import Mathlib.Condensed.Light.Basic
 
 # Light condensed `R`-modules
 
-This files defines light condensed modules over a ring `R`.
+This file defines light condensed modules over a ring `R`.
 
 ## Main results
 
@@ -53,7 +53,7 @@ def LightCondensed.free : LightCondSet ⥤ LightCondMod R :=
 
 /-- The condensed version of the free-forgetful adjunction. -/
 noncomputable
-def LightCondensed.freeForgetAdjunction : free R ⊣ forget R :=  Sheaf.adjunction _ (ModuleCat.adj R)
+def LightCondensed.freeForgetAdjunction : free R ⊣ forget R := Sheaf.adjunction _ (ModuleCat.adj R)
 
 /--
 The category of condensed abelian groups, defined as sheaves of abelian groups over

--- a/Mathlib/Condensed/Module.lean
+++ b/Mathlib/Condensed/Module.lean
@@ -15,7 +15,7 @@ import Mathlib.Condensed.Basic
 
 # Condensed `R`-modules
 
-This files defines condensed modules over a ring `R`.
+This file defines condensed modules over a ring `R`.
 
 ## Main results
 

--- a/Mathlib/Data/Finsupp/Weight.lean
+++ b/Mathlib/Data/Finsupp/Weight.lean
@@ -12,8 +12,8 @@ import Mathlib.LinearAlgebra.Finsupp.LinearCombination
 The theory of multivariate polynomials and power series is built
 on the type `σ →₀ ℕ` which gives the exponents of the monomials.
 Many aspects of the theory (degree, order, graded ring structure)
-require to classify these exponents according to their total sum
-`∑  i, f i`, or variants, and this files provides some API for that.
+require classifying these exponents according to their total sum
+`∑ i, f i`, or variants, and this file provides some API for that.
 
 ## Weight
 

--- a/Mathlib/Data/List/Lattice.lean
+++ b/Mathlib/Data/List/Lattice.lean
@@ -9,19 +9,19 @@ import Mathlib.Data.List.Basic
 /-!
 # Lattice structure of lists
 
-This files prove basic properties about `List.disjoint`, `List.union`, `List.inter` and
+This file proves basic properties about `List.disjoint`, `List.union`, `List.inter` and
 `List.bagInter`, which are defined in core Lean and `Data.List.Defs`.
 
 `l₁ ∪ l₂` is the list where all elements of `l₁` have been inserted in `l₂` in order. For example,
-`[0, 0, 1, 2, 2, 3] ∪ [4, 3, 3, 0] = [1, 2, 4, 3, 3, 0]`
+`[0, 0, 1, 2, 2, 3] ∪ [4, 3, 3, 0] = [1, 2, 4, 3, 3, 0]`.
 
 `l₁ ∩ l₂` is the list of elements of `l₁` in order which are in `l₂`. For example,
-`[0, 0, 1, 2, 2, 3] ∪ [4, 3, 3, 0] = [0, 0, 3]`
+`[0, 0, 1, 2, 2, 3] ∩ [4, 3, 3, 0] = [0, 0, 3]`.
 
 `List.bagInter l₁ l₂` is the list of elements that are in both `l₁` and `l₂`,
 counted with multiplicity and in the order they appear in `l₁`.
 As opposed to `List.inter`, `List.bagInter` copes well with multiplicity. For example,
-`bagInter [0, 1, 2, 3, 2, 1, 0] [1, 0, 1, 4, 3] = [0, 1, 3, 1]`
+`bagInter [0, 1, 2, 3, 2, 1, 0] [1, 0, 1, 4, 3] = [0, 1, 3, 1]`.
 -/
 
 

--- a/Mathlib/Data/Sym/Sym2/Order.lean
+++ b/Mathlib/Data/Sym/Sym2/Order.lean
@@ -9,7 +9,7 @@ import Mathlib.Order.Lattice
 /-!
 # Sorting the elements of `Sym2`
 
-This files provides `Sym2.sortEquiv`, the forward direction of which is somewhat analogous to
+This file provides `Sym2.sortEquiv`, the forward direction of which is somewhat analogous to
 `Multiset.sort`.
 -/
 

--- a/Mathlib/GroupTheory/QuotientGroup/Basic.lean
+++ b/Mathlib/GroupTheory/QuotientGroup/Basic.lean
@@ -15,7 +15,7 @@ import Mathlib.Algebra.BigOperators.Group.Finset.Defs
 /-!
 # Quotients of groups by normal subgroups
 
-This files develops the basic theory of quotients of groups by normal subgroups. In particular it
+This file develops the basic theory of quotients of groups by normal subgroups. In particular, it
 proves Noether's first and second isomorphism theorems.
 
 ## Main statements

--- a/Mathlib/LinearAlgebra/Matrix/SemiringInverse.lean
+++ b/Mathlib/LinearAlgebra/Matrix/SemiringInverse.lean
@@ -10,7 +10,7 @@ import Mathlib.GroupTheory.Perm.Sign
 /-!
 # Nonsingular inverses over semirings
 
-This files proves `A * B = 1 ↔ B * A = 1` for square matrices over a commutative semiring.
+This file proves `A * B = 1 ↔ B * A = 1` for square matrices over a commutative semiring.
 
 -/
 

--- a/Mathlib/LinearAlgebra/SesquilinearForm/Basic.lean
+++ b/Mathlib/LinearAlgebra/SesquilinearForm/Basic.lean
@@ -22,7 +22,7 @@ basic lemmas about construction and elementary calculations are found there.
 ## Main declarations
 
 * `IsOrtho`: states that two vectors are orthogonal with respect to a sesquilinear map
-* `IsSymm`, `IsAlt`: state that a sesquilinear form is symmetric and alternating, respectively
+* `IsSymm`, `IsAlt`: states that a sesquilinear form is symmetric and alternating, respectively
 * `orthogonalBilin` provides the orthogonal complement with respect to a sesquilinear form
 
 ## References

--- a/Mathlib/LinearAlgebra/SesquilinearForm/Basic.lean
+++ b/Mathlib/LinearAlgebra/SesquilinearForm/Basic.lean
@@ -23,7 +23,7 @@ basic lemmas about construction and elementary calculations are found there.
 
 * `IsOrtho`: states that two vectors are orthogonal with respect to a sesquilinear map
 * `IsSymm`, `IsAlt`: state that a sesquilinear form is symmetric and alternating, respectively
-* `orthogonalBilin`: provides the orthogonal complement with respect to a sesquilinear form
+* `orthogonalBilin` provides the orthogonal complement with respect to a sesquilinear form
 
 ## References
 

--- a/Mathlib/LinearAlgebra/SesquilinearForm/Basic.lean
+++ b/Mathlib/LinearAlgebra/SesquilinearForm/Basic.lean
@@ -10,20 +10,20 @@ import Mathlib.LinearAlgebra.LinearIndependent.Lemmas
 /-!
 # Sesquilinear maps
 
-This files provides properties about sesquilinear maps and forms. The maps considered are of the
+This file provides properties about sesquilinear maps and forms. The maps considered are of the
 form `M₁ →ₛₗ[I₁] M₂ →ₛₗ[I₂] M`, where `I₁ : R₁ →+* R` and `I₂ : R₂ →+* R` are ring homomorphisms and
 `M₁` is a module over `R₁`, `M₂` is a module over `R₂` and `M` is a module over `R`.
 Sesquilinear forms are the special case that `M₁ = M₂`, `M = R₁ = R₂ = R`, and `I₁ = RingHom.id R`.
 Taking additionally `I₂ = RingHom.id R`, then one obtains bilinear forms.
 
-Sesquilinear maps are a special case of the bilinear maps defined in `BilinearMap.lean` and `many`
+Sesquilinear maps are a special case of the bilinear maps defined in `BilinearMap.lean`, and many
 basic lemmas about construction and elementary calculations are found there.
 
 ## Main declarations
 
 * `IsOrtho`: states that two vectors are orthogonal with respect to a sesquilinear map
-* `IsSymm`, `IsAlt`: states that a sesquilinear form is symmetric and alternating, respectively
-* `orthogonalBilin`: provides the orthogonal complement with respect to sesquilinear form
+* `IsSymm`, `IsAlt`: state that a sesquilinear form is symmetric and alternating, respectively
+* `orthogonalBilin`: provides the orthogonal complement with respect to a sesquilinear form
 
 ## References
 
@@ -31,7 +31,7 @@ basic lemmas about construction and elementary calculations are found there.
 
 ## Tags
 
-Sesquilinear form, Sesquilinear map,
+Sesquilinear form, Sesquilinear map
 -/
 
 open Module

--- a/Mathlib/Logic/Equiv/PartialEquiv.lean
+++ b/Mathlib/Logic/Equiv/PartialEquiv.lean
@@ -11,7 +11,7 @@ import Mathlib.Tactic.Attr.Core
 /-!
 # Partial equivalences
 
-This files defines equivalences between subsets of given types.
+This file defines equivalences between subsets of given types.
 An element `e` of `PartialEquiv α β` is made of two maps `e.toFun` and `e.invFun` respectively
 from α to β and from β to α (just like equivs), which are inverse to each other on the subsets
 `e.source` and `e.target` of respectively α and β.

--- a/Mathlib/Probability/ProbabilityMassFunction/Integrals.lean
+++ b/Mathlib/Probability/ProbabilityMassFunction/Integrals.lean
@@ -10,7 +10,7 @@ import Mathlib.MeasureTheory.Integral.Bochner.Basic
 /-!
 # Integrals with a measure derived from probability mass functions.
 
-This files connects `PMF` with `integral`. The main result is that the integral (i.e. the expected
+This file connects `PMF` with `integral`. The main result is that the integral (i.e. the expected
 value) with regard to a measure derived from a `PMF` is a sum weighted by the `PMF`.
 
 It also provides the expected value for specific probability mass functions.

--- a/Mathlib/RingTheory/MvPowerSeries/PiTopology.lean
+++ b/Mathlib/RingTheory/MvPowerSeries/PiTopology.lean
@@ -60,7 +60,7 @@ topological nilpotency by proving that, if the base ring is equipped with a *lin
 a power series is topologically nilpotent if and only if its constant coefficient is.
 This is lemma `MvPowerSeries.LinearTopology.isTopologicallyNilpotent_iff_constantCoeff`.
 
-Mathematically, everything proven in this files follows from that general statement. However,
+Mathematically, everything proven in this file follows from that general statement. However,
 formalizing this yields a few (minor) annoyances:
 
 - we would need to push the results in this file slightly lower in the import tree
@@ -73,7 +73,7 @@ formalizing this yields a few (minor) annoyances:
 
 Since the code duplication is rather minor (the interesting part of the proof is already extracted
 as `MvPowerSeries.coeff_eq_zero_of_constantCoeff_nilpotent`), we just leave this as is for now.
-But future contributors wishing to clean this up should feel free to give it a try !
+But future contributors wishing to clean this up should feel free to give it a try!
 
 -/
 

--- a/Mathlib/RingTheory/TensorProduct/Quotient.lean
+++ b/Mathlib/RingTheory/TensorProduct/Quotient.lean
@@ -10,7 +10,7 @@ import Mathlib.RingTheory.TensorProduct.Basic
 /-!
 # Interaction between quotients and tensor products for algebras
 
-This files proves algebra analogs of the isomorphisms in
+This file proves algebra analogs of the isomorphisms in
 `Mathlib/LinearAlgebra/TensorProduct/Quotient.lean`.
 
 ## Main results

--- a/Mathlib/Tactic/HaveI.lean
+++ b/Mathlib/Tactic/HaveI.lean
@@ -8,7 +8,7 @@ import Mathlib.Init
 /-!
 # Variants of `haveI`/`letI` for use in do-notation.
 
-This files implements the `haveI'` and `letI'` macros which have the same semantics as
+This file implements the `haveI'` and `letI'` macros which have the same semantics as
 `haveI` and `letI`, but are `doElem`s and can be used inside do-notation.
 
 They need an apostrophe after their name for disambiguation with the term variants.

--- a/Mathlib/Topology/Algebra/Group/ClosedSubgroup.lean
+++ b/Mathlib/Topology/Algebra/Group/ClosedSubgroup.lean
@@ -11,8 +11,8 @@ import Mathlib.Topology.Algebra.Group.Quotient
 /-!
 # Closed subgroups of a topological group
 
-This file builds the frame of closed subgroups in a topological group `G` and its additive
-version `ClosedAddSubgroup`.
+This file builds the frame of closed subgroups in a topological group `G`,
+and its additive version `ClosedAddSubgroup`.
 
 # Main definitions and results
 

--- a/Mathlib/Topology/Algebra/Group/ClosedSubgroup.lean
+++ b/Mathlib/Topology/Algebra/Group/ClosedSubgroup.lean
@@ -11,14 +11,14 @@ import Mathlib.Topology.Algebra.Group.Quotient
 /-!
 # Closed subgroups of a topological group
 
-This files builds the frame of closed subgroups in a topological group `G`,
-and its additive version `ClosedAddSubgroup`.
+This file builds the frame of closed subgroups in a topological group `G` and its additive
+version `ClosedAddSubgroup`.
 
 # Main definitions and results
 
-* `normalCore_isClosed` : The `normalCore` of a closed subgroup is closed.
+* `normalCore_isClosed`: The `normalCore` of a closed subgroup is closed.
 
-* `finindex_closedSubgroup_isOpen` : A closed subgroup with finite index is open.
+* `finindex_closedSubgroup_isOpen`: A closed subgroup with finite index is open.
 
 ## TODO
 

--- a/Mathlib/Topology/Algebra/GroupCompletion.lean
+++ b/Mathlib/Topology/Algebra/GroupCompletion.lean
@@ -10,7 +10,7 @@ import Mathlib.Topology.Algebra.Group.Pointwise
 /-!
 # Completion of topological groups:
 
-This files endows the completion of a topological abelian group with a group structure.
+This file endows the completion of a topological abelian group with a group structure.
 More precisely the instance `UniformSpace.Completion.addGroup` builds an abelian group structure
 on the completion of an abelian group endowed with a compatible uniform structure.
 Then the instance `UniformSpace.Completion.isUniformAddGroup` proves this group structure is

--- a/Mathlib/Topology/Algebra/Module/ClosedSubmodule.lean
+++ b/Mathlib/Topology/Algebra/Module/ClosedSubmodule.lean
@@ -9,7 +9,7 @@ import Mathlib.Topology.Sets.Closeds
 /-!
 # Closed submodules of a topological module
 
-This files builds the frame of closed `R`-submodules of a topological module `M`.
+This file builds the frame of closed `R`-submodules of a topological module `M`.
 
 One can turn `s : Submodule R E` + `hs : IsClosed s` into `s : ClosedSubmodule R E` in a tactic
 block by doing `lift s to ClosedSubmodule R E using hs`.

--- a/Mathlib/Topology/Algebra/Nonarchimedean/Bases.lean
+++ b/Mathlib/Topology/Algebra/Nonarchimedean/Bases.lean
@@ -22,7 +22,7 @@ family as a basis of neighborhoods of zero. In particular, the given subgroups b
 (`RingSubgroupsBasis.nonarchimedean`).
 
 A special case of this construction is given by `SubmodulesBasis` where the subgroups are
-submodules in a commutative algebra. This important example gives rise to the adic topology
+sub-modules in a commutative algebra. This important example gives rise to the adic topology
 (studied in its own file).
 -/
 

--- a/Mathlib/Topology/Algebra/Nonarchimedean/Bases.lean
+++ b/Mathlib/Topology/Algebra/Nonarchimedean/Bases.lean
@@ -11,18 +11,18 @@ import Mathlib.Topology.Algebra.Nonarchimedean.Basic
 /-!
 # Neighborhood bases for non-archimedean rings and modules
 
-This files contains special families of filter bases on rings and modules that give rise to
+This file contains special families of filter bases on rings and modules that give rise to
 non-archimedean topologies.
 
 The main definition is `RingSubgroupsBasis` which is a predicate on a family of
 additive subgroups of a ring. The predicate ensures there is a topology
 `RingSubgroupsBasis.topology` which is compatible with a ring structure and admits the given
-family as a basis of neighborhoods of zero. In particular the given subgroups become open subgroups
+family as a basis of neighborhoods of zero. In particular, the given subgroups become open subgroups
 (bundled in `RingSubgroupsBasis.openAddSubgroup`) and we get a non-archimedean topological ring
 (`RingSubgroupsBasis.nonarchimedean`).
 
 A special case of this construction is given by `SubmodulesBasis` where the subgroups are
-sub-modules in a commutative algebra. This important example gives rise to the adic topology
+submodules in a commutative algebra. This important example gives rise to the adic topology
 (studied in its own file).
 -/
 

--- a/Mathlib/Topology/Algebra/OpenSubgroup.lean
+++ b/Mathlib/Topology/Algebra/OpenSubgroup.lean
@@ -13,7 +13,7 @@ import Mathlib.Topology.Sets.Opens
 # Open subgroups of a topological group
 
 This file builds the lattice `OpenSubgroup G` of open subgroups in a topological group `G`,
- and its additive version `OpenAddSubgroup`. This lattice has a top element, the subgroup of all
+and its additive version `OpenAddSubgroup`. This lattice has a top element, the subgroup of all
 elements, but no bottom element in general. The trivial subgroup which is the natural candidate
 bottom has no reason to be open (this happens only in discrete groups).
 

--- a/Mathlib/Topology/Algebra/OpenSubgroup.lean
+++ b/Mathlib/Topology/Algebra/OpenSubgroup.lean
@@ -12,8 +12,8 @@ import Mathlib.Topology.Sets.Opens
 /-!
 # Open subgroups of a topological group
 
-This file builds the lattice `OpenSubgroup G` of open subgroups in a topological group `G` and its
-additive version `OpenAddSubgroup`. This lattice has a top element, the subgroup of all
+This file builds the lattice `OpenSubgroup G` of open subgroups in a topological group `G`,
+ and its additive version `OpenAddSubgroup`. This lattice has a top element, the subgroup of all
 elements, but no bottom element in general. The trivial subgroup which is the natural candidate
 bottom has no reason to be open (this happens only in discrete groups).
 

--- a/Mathlib/Topology/Algebra/OpenSubgroup.lean
+++ b/Mathlib/Topology/Algebra/OpenSubgroup.lean
@@ -12,8 +12,8 @@ import Mathlib.Topology.Sets.Opens
 /-!
 # Open subgroups of a topological group
 
-This files builds the lattice `OpenSubgroup G` of open subgroups in a topological group `G`,
-and its additive version `OpenAddSubgroup`.  This lattice has a top element, the subgroup of all
+This file builds the lattice `OpenSubgroup G` of open subgroups in a topological group `G` and its
+additive version `OpenAddSubgroup`. This lattice has a top element, the subgroup of all
 elements, but no bottom element in general. The trivial subgroup which is the natural candidate
 bottom has no reason to be open (this happens only in discrete groups).
 

--- a/Mathlib/Topology/Algebra/UniformFilterBasis.lean
+++ b/Mathlib/Topology/Algebra/UniformFilterBasis.lean
@@ -9,7 +9,7 @@ import Mathlib.Topology.Algebra.IsUniformGroup.Defs
 /-!
 # Uniform properties of neighborhood bases in topological algebra
 
-This files contains properties of filter bases on algebraic structures that also require the theory
+This file contains properties of filter bases on algebraic structures that also require the theory
 of uniform spaces.
 
 The only result so far is a characterization of Cauchy filters in topological groups.

--- a/Mathlib/Topology/Algebra/UniformRing.lean
+++ b/Mathlib/Topology/Algebra/UniformRing.lean
@@ -13,8 +13,8 @@ import Mathlib.Topology.Algebra.IsUniformGroup.Basic
 /-!
 # Completion of topological rings:
 
-This files endows the completion of a topological ring with a ring structure.
-More precisely the instance `UniformSpace.Completion.ring` builds a ring structure
+This file endows the completion of a topological ring with a ring structure.
+More precisely, the instance `UniformSpace.Completion.ring` builds a ring structure
 on the completion of a ring endowed with a compatible uniform structure in the sense of
 `IsUniformAddGroup`. There is also a commutative version when the original ring is commutative.
 Moreover, if a topological ring is an algebra over a commutative semiring, then so is its
@@ -29,7 +29,7 @@ the main constructions deal with continuous ring morphisms.
 
 * `UniformSpace.Completion.extensionHom`: extends a continuous ring morphism from `R`
   to a complete separated group `S` to `Completion R`.
-* `UniformSpace.Completion.mapRingHom` : promotes a continuous ring morphism
+* `UniformSpace.Completion.mapRingHom`: promotes a continuous ring morphism
   from `R` to `S` into a continuous ring morphism from `Completion R` to `Completion S`.
 
 TODO: Generalise the results here from the concrete `Completion` to any `AbstractCompletion`.

--- a/Mathlib/Topology/Category/LightProfinite/Sequence.lean
+++ b/Mathlib/Topology/Category/LightProfinite/Sequence.lean
@@ -9,7 +9,7 @@ import Mathlib.Topology.Category.LightProfinite.Basic
 
 # The light profinite set classifying convergent sequences
 
-This files defines the light profinite set `ℕ∪{∞}`, defined as the one point compactification of
+This file defines the light profinite set `ℕ∪{∞}`, defined as the one point compactification of
 `ℕ`.
 -/
 

--- a/Mathlib/Topology/Category/TopCat/Sphere.lean
+++ b/Mathlib/Topology/Category/TopCat/Sphere.lean
@@ -10,7 +10,7 @@ import Mathlib.Topology.Category.TopCat.EpiMono
 /-!
 # Euclidean spheres
 
-This files defines the `n`-sphere `𝕊 n`, the `n`-disk `𝔻 n`, its boundary `∂𝔻 n` and its interior
+This file defines the `n`-sphere `𝕊 n`, the `n`-disk `𝔻 n`, its boundary `∂𝔻 n` and its interior
 `𝔹 n` as objects in `TopCat`.
 
 -/

--- a/Mathlib/Topology/MetricSpace/Equicontinuity.lean
+++ b/Mathlib/Topology/MetricSpace/Equicontinuity.lean
@@ -9,7 +9,7 @@ import Mathlib.Topology.MetricSpace.Pseudo.Lemmas
 /-!
 # Equicontinuity in metric spaces
 
-This files contains various facts about (uniform) equicontinuity in metric spaces. Most
+This file contains various facts about (uniform) equicontinuity in metric spaces. Most
 importantly, we prove the usual characterization of equicontinuity of `F` at `x₀` in the case of
 (pseudo) metric spaces: `∀ ε > 0, ∃ δ > 0, ∀ x, dist x x₀ < δ → ∀ i, dist (F i x₀) (F i x) < ε`,
 and we prove that functions sharing a common (local or global) continuity modulus are

--- a/Mathlib/Topology/MetricSpace/HausdorffDistance.lean
+++ b/Mathlib/Topology/MetricSpace/HausdorffDistance.lean
@@ -13,13 +13,13 @@ import Mathlib.Tactic.Finiteness
 The Hausdorff distance on subsets of a metric (or emetric) space.
 
 Given two subsets `s` and `t` of a metric space, their Hausdorff distance is the smallest `d`
-such that any point `s` is within `d` of a point in `t`, and conversely. This quantity
+such that any point of `s` is within `d` of a point in `t`, and conversely. This quantity
 is often infinite (think of `s` bounded and `t` unbounded), and therefore better
 expressed in the setting of emetric spaces.
 
 ## Main definitions
 
-This files introduces:
+This file introduces:
 * `EMetric.infEdist x s`, the infimum edistance of a point `x` to a set `s` in an emetric space
 * `EMetric.hausdorffEdist s t`, the Hausdorff edistance of two sets in an emetric space
 * Versions of these notions on metric spaces, called respectively `Metric.infDist`

--- a/Mathlib/Topology/UniformSpace/Separation.lean
+++ b/Mathlib/Topology/UniformSpace/Separation.lean
@@ -73,7 +73,7 @@ by defining `SeparationQuotient.lift'` and `SeparationQuotient.map` operations.
 
 ## Implementation notes
 
-This files used to contain definitions of `separationRel α` and `UniformSpace.SeparationQuotient α`.
+This file used to contain definitions of `separationRel α` and `UniformSpace.SeparationQuotient α`.
 These definitions were equal (but not definitionally equal)
 to `{x : α × α | Inseparable x.1 x.2}` and `SeparationQuotient α`, respectively,
 and were added to the library before their generalizations to topological spaces.

--- a/Mathlib/Topology/UniformSpace/UniformConvergenceTopology.lean
+++ b/Mathlib/Topology/UniformSpace/UniformConvergenceTopology.lean
@@ -11,7 +11,7 @@ import Mathlib.Topology.UniformSpace.UniformApproximation
 /-!
 # Topology and uniform structure of uniform convergence
 
-This files endows `α → β` with the topologies / uniform structures of
+This file endows `α → β` with the topologies / uniform structures of
 - uniform convergence on `α`
 - uniform convergence on a specified family `𝔖` of sets of `α`, also called `𝔖`-convergence
 
@@ -20,7 +20,7 @@ convergence, we introduce type aliases `UniformFun α β` (denoted `α →ᵤ β
 `UniformOnFun α β 𝔖` (denoted `α →ᵤ[𝔖] β`) and we actually endow *these* with the structures
 of uniform and `𝔖`-convergence respectively.
 
-Usual examples of the second construction include :
+Usual examples of the second construction include:
 - the topology of compact convergence, when `𝔖` is the set of compacts of `α`
 - the strong topology on the dual of a topological vector space (TVS) `E`, when `𝔖` is the set of
   Von Neumann bounded subsets of `E`
@@ -57,7 +57,7 @@ This file contains a lot of technical facts, so it is heavily commented, proofs 
 * `UniformOnFun.t2Space_of_covering`: the topology of `𝔖`-convergence on `α →ᵤ[𝔖] β` is T₂ if
   `β` is T₂ and `𝔖` covers `α`
 * `UniformOnFun.tendsto_iff_tendstoUniformlyOn`:
-  `𝒱(α, β, 𝔖 uβ)` is indeed the uniform structure of `𝔖`-convergence
+  `𝒱(α, β, 𝔖, uβ)` is indeed the uniform structure of `𝔖`-convergence
 
 ### Functoriality and compatibility with product of uniform spaces
 


### PR DESCRIPTION
I noticed that there were a lot of instances of the typo "this files" in the repo. I fixed these while doing some drive-by typo fixes in the files I touched while I was at it.

The drive-by fixes are due to Codex and consist of:
- Minor textual tweaks to improve flow of sentences.
- Punctuation, like adding commas and full stops where appropriate in sentences.
- Trimming superfluous white space and adding missing white space.
- Swapping a `∪`-operator for a `∩`, where the latter was intended.
- Swapping `𝒱(α, β, 𝔖 uβ)` for `𝒱(α, β, 𝔖, uβ)` where the latter was intended.


---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include at least one commit authored by each
co-author among the commits in the pull request. If necessary, you may 
create empty commits to indicate co-authorship, using commands like so:

git commit --author="Author Name <author@email.com>" --allow-empty -m "add Author Name as coauthor"

When merging, all the commits will be squashed into a single commit listing all co-authors.

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
