### PR TITLE
[Merged by Bors] - style: fix whitespace

### DIFF
--- a/Mathlib/Algebra/Azumaya/Basic.lean
+++ b/Mathlib/Algebra/Azumaya/Basic.lean
@@ -40,7 +40,7 @@ lemma AlgHom.mulLeftRight_bij [h : IsAzumaya R A] :
 /-- The "canonical" isomorphism between `R ⊗ Rᵒᵖ` and `End R R` which is equal
   to `AlgHom.mulLeftRight R R`. -/
 abbrev tensorEquivEnd : R ⊗[R] Rᵐᵒᵖ ≃ₐ[R] Module.End R R :=
-  Algebra.TensorProduct.lid R Rᵐᵒᵖ|>.trans <| .moduleEndSelf R
+  Algebra.TensorProduct.lid R Rᵐᵒᵖ |>.trans <| .moduleEndSelf R
 
 lemma coe_tensorEquivEnd : tensorEquivEnd R = AlgHom.mulLeftRight R R := by
   ext; simp

--- a/Mathlib/Algebra/BigOperators/Associated.lean
+++ b/Mathlib/Algebra/BigOperators/Associated.lean
@@ -94,7 +94,7 @@ theorem divisor_closure_eq_closure [CancelCommMonoidWithZero M₀]
     simp only [Set.mem_setOf_eq] at hind
     obtain ⟨ha₁ | ha₂, hs⟩ := hm
     · rcases ha₁.exists_right_inv with ⟨k, hk⟩
-      refine hind x (y*k) ?_ hs ?_
+      refine hind x (y * k) ?_ hs ?_
       · simp only [← mul_assoc, ← hprod, ← Multiset.prod_cons, mul_comm]
         refine multiset_prod_mem _ _ (Multiset.forall_mem_cons.2 ⟨subset_closure ?_,
           Multiset.forall_mem_cons.2 ⟨subset_closure ?_, fun t ht => subset_closure (hs t ht)⟩⟩)

--- a/Mathlib/Algebra/BigOperators/Ring/Nat.lean
+++ b/Mathlib/Algebra/BigOperators/Ring/Nat.lean
@@ -32,14 +32,14 @@ lemma odd_sum_iff_odd_card_odd {s : Finset ι} (f : ι → ℕ) :
 
 theorem card_preimage_eq_sum_card_image_eq {M : Type*} {f : ι → M} {s : Finset M}
     (hb : ∀ b ∈ s, Set.Finite {a | f a = b}) :
-    Nat.card (f⁻¹' s) = ∑ b ∈ s, Nat.card {a // f a = b} := by
+    Nat.card (f ⁻¹' s) = ∑ b ∈ s, Nat.card {a // f a = b} := by
   classical
   -- `t = s ∩ Set.range f` as a `Finset`
   let t := (Set.finite_coe_iff.mp (Finite.Set.finite_inter_of_left ↑s (Set.range f))).toFinset
-  rw [show Nat.card (f⁻¹' s) = Nat.card (f⁻¹' t) by simp [t]]
+  rw [show Nat.card (f ⁻¹' s) = Nat.card (f ⁻¹' t) by simp [t]]
   rw [show ∑ b ∈ s, Nat.card {a //f a = b} = ∑ b ∈ t, Nat.card {a | f a = b} by
     exact (Finset.sum_subset (by simp [t]) (by aesop)).symm]
-  have ht : Set.Finite (f⁻¹' t) := Set.Finite.preimage' (finite_toSet t) (by aesop)
+  have ht : Set.Finite (f ⁻¹' t) := Set.Finite.preimage' (finite_toSet t) (by aesop)
   rw [Nat.card_eq_card_finite_toFinset ht, Finset.card_eq_sum_card_image (f := f)]
   refine Finset.sum_congr ?_ fun m hm ↦ ?_
   · simpa [← Finset.coe_inj, t] using Set.image_preimage_eq_inter_range

--- a/Mathlib/Analysis/SpecificLimits/Basic.lean
+++ b/Mathlib/Analysis/SpecificLimits/Basic.lean
@@ -34,7 +34,7 @@ theorem tendsto_const_div_atTop_nhds_zero_nat (C : ℝ) :
     Tendsto (fun n : ℕ ↦ C / n) atTop (𝓝 0) := by
   simpa only [mul_zero] using tendsto_const_nhds.mul tendsto_inverse_atTop_nhds_zero_nat
 
-theorem tendsto_one_div_atTop_nhds_zero_nat : Tendsto (fun n : ℕ ↦ 1/(n : ℝ)) atTop (𝓝 0) :=
+theorem tendsto_one_div_atTop_nhds_zero_nat : Tendsto (fun n : ℕ ↦ 1 / (n : ℝ)) atTop (𝓝 0) :=
   tendsto_const_div_atTop_nhds_zero_nat 1
 
 theorem NNReal.tendsto_inverse_atTop_nhds_zero_nat :
@@ -99,7 +99,7 @@ theorem tendsto_mod_div_atTop_nhds_zero_nat {m : ℕ} (hm : 0 < m) :
     Tendsto (fun n : ℕ => ((n % m : ℕ) : ℝ) / (n : ℝ)) atTop (𝓝 0) := by
   have h0 : ∀ᶠ n : ℕ in atTop, 0 ≤ (fun n : ℕ => ((n % m : ℕ) : ℝ)) n := by aesop
   exact tendsto_bdd_div_atTop_nhds_zero h0
-    (.of_forall (fun n ↦  cast_le.mpr (mod_lt n hm).le)) tendsto_natCast_atTop_atTop
+    (.of_forall (fun n ↦ cast_le.mpr (mod_lt n hm).le)) tendsto_natCast_atTop_atTop
 
 /-- If `a ≠ 0`, `(a * x + c)⁻¹` tends to `0` as `x` tends to `∞`. -/
 theorem tendsto_mul_add_inv_atTop_nhds_zero (a c : ℝ) (ha : a ≠ 0) :
@@ -189,7 +189,7 @@ theorem tendsto_pow_atTop_nhds_zero_of_lt_one {𝕜 : Type*}
   rw [tendsto_zero_iff_abs_tendsto_zero]
   refine ⟨fun h ↦ by_contra (fun hr_le ↦ ?_), fun h ↦ ?_⟩
   · by_cases hr : 1 = |r|
-    · replace h : Tendsto (fun n : ℕ ↦ |r|^n) atTop (𝓝 0) := by simpa only [← abs_pow, h]
+    · replace h : Tendsto (fun n : ℕ ↦ |r| ^ n) atTop (𝓝 0) := by simpa only [← abs_pow, h]
       simp only [hr.symm, one_pow] at h
       exact zero_ne_one <| tendsto_nhds_unique h tendsto_const_nhds
     · apply @not_tendsto_nhds_of_tendsto_atTop 𝕜 ℕ _ _ _ _ atTop _ (fun n ↦ |r| ^ n) _ 0 _
@@ -275,7 +275,7 @@ protected theorem ENNReal.tendsto_pow_atTop_nhds_zero_iff {r : ℝ≥0∞} :
 
 @[simp]
 protected theorem ENNReal.tendsto_pow_atTop_nhds_top_iff {r : ℝ≥0∞} :
-    Tendsto (fun n ↦ r^n) atTop (𝓝 ∞) ↔ 1 < r := by
+    Tendsto (fun n ↦ r ^ n) atTop (𝓝 ∞) ↔ 1 < r := by
   refine ⟨?_, ?_⟩
   · contrapose!
     intro r_le_one h_tends
@@ -284,7 +284,7 @@ protected theorem ENNReal.tendsto_pow_atTop_nhds_top_iff {r : ℝ≥0∞} :
     obtain ⟨n, hn⟩ := h_tends
     exact lt_irrefl _ <| lt_of_lt_of_le (hn n le_rfl) <| pow_le_one₀ (zero_le _) r_le_one
   · intro r_gt_one
-    have obs := @Tendsto.inv ℝ≥0∞ ℕ _ _ _ (fun n ↦ (r⁻¹)^n) atTop 0
+    have obs := @Tendsto.inv ℝ≥0∞ ℕ _ _ _ (fun n ↦ (r⁻¹) ^ n) atTop 0
     simp only [ENNReal.tendsto_pow_atTop_nhds_zero_iff, inv_zero] at obs
     simpa [← ENNReal.inv_pow] using obs <| ENNReal.inv_lt_one.mpr r_gt_one
 
@@ -398,8 +398,8 @@ theorem ENNReal.tsum_geometric_add_one (r : ℝ≥0∞) : ∑' n : ℕ, r ^ (n +
   simp only [_root_.pow_succ', ENNReal.tsum_mul_left, ENNReal.tsum_geometric]
 
 lemma ENNReal.tsum_two_zpow_neg_add_one :
-    ∑' m : ℕ, 2 ^ (-1 - m  : ℤ) = (1 : ℝ≥0∞) := by
-  simp_rw [neg_sub_left, ENNReal.zpow_neg,← Nat.cast_one (R := ℤ), ← Nat.cast_add, zpow_natCast,
+    ∑' m : ℕ, 2 ^ (-1 - m : ℤ) = (1 : ℝ≥0∞) := by
+  simp_rw [neg_sub_left, ENNReal.zpow_neg, ← Nat.cast_one (R := ℤ), ← Nat.cast_add, zpow_natCast,
     ENNReal.inv_pow, ENNReal.tsum_geometric_add_one, one_sub_inv_two, inv_inv]
   exact ENNReal.inv_mul_cancel (Ne.symm (NeZero.ne' 2)) (Ne.symm top_ne_ofNat)
 

--- a/Mathlib/CategoryTheory/Adjunction/Basic.lean
+++ b/Mathlib/CategoryTheory/Adjunction/Basic.lean
@@ -523,7 +523,7 @@ lemma comp_counit_app (X : E) :
     (adj₁.comp adj₂).counit.app X = H.map (adj₁.counit.app (I.obj X)) ≫ adj₂.counit.app X := by
   simp [Adjunction.comp]
 
-lemma comp_homEquiv :  (adj₁.comp adj₂).homEquiv =
+lemma comp_homEquiv : (adj₁.comp adj₂).homEquiv =
     fun _ _ ↦ Equiv.trans (adj₂.homEquiv _ _) (adj₁.homEquiv _ _) :=
   mk'_homEquiv _
 

--- a/Mathlib/CategoryTheory/ConcreteCategory/Basic.lean
+++ b/Mathlib/CategoryTheory/ConcreteCategory/Basic.lean
@@ -84,7 +84,7 @@ abbrev forget (C : Type u) [Category.{v} C] [HasForget.{w} C] : C ⥤ Type w :=
   HasForget.forget
 
 -- this is reducible because we want `forget (Type u)` to unfold to `𝟭 _`
-@[instance] abbrev HasForget.types : HasForget.{u, u, u+1} (Type u) where
+@[instance] abbrev HasForget.types : HasForget.{u, u, u + 1} (Type u) where
   forget := 𝟭 _
 
 /-- Provide a coercion to `Type u` for a concrete category. This is not marked as an instance

--- a/Mathlib/CategoryTheory/Limits/Shapes/BinaryProducts.lean
+++ b/Mathlib/CategoryTheory/Limits/Shapes/BinaryProducts.lean
@@ -434,8 +434,8 @@ theorem BinaryCofan.isColimit_iff_isIso_inl {X Y : C} (h : IsInitial Y) (c : Bin
     obtain ⟨l, hl, -⟩ := BinaryCofan.IsColimit.desc' H (𝟙 X) (h.to X)
     refine ⟨⟨l, hl, BinaryCofan.IsColimit.hom_ext H (?_) (h.hom_ext _ _)⟩⟩
     rw [Category.comp_id]
-    have e : (inl c ≫ l) ≫ inl c = 𝟙 X ≫ inl c := congrArg (·≫inl c) hl
-    rwa [Category.assoc,Category.id_comp] at e
+    have e : (inl c ≫ l) ≫ inl c = 𝟙 X ≫ inl c := congrArg (· ≫ inl c) hl
+    rwa [Category.assoc, Category.id_comp] at e
   · intro
     exact
       ⟨BinaryCofan.IsColimit.mk _ (fun f _ => inv c.inl ≫ f)

--- a/Mathlib/CategoryTheory/Limits/Shapes/Pullback/Categorical/Basic.lean
+++ b/Mathlib/CategoryTheory/Limits/Shapes/Pullback/Categorical/Basic.lean
@@ -201,7 +201,7 @@ Note that this is *exactly* what an object of
 so `CatCommSqOver F G X` is in fact an abbreviation for
 `((whiskeringRight X A B).obj F) ⊡ ((whiskeringRight X C B).obj G)`. -/
 abbrev CatCommSqOver :=
-  (whiskeringRight X A B|>.obj F) ⊡ (whiskeringRight X C B|>.obj G)
+  (whiskeringRight X A B |>.obj F) ⊡ (whiskeringRight X C B |>.obj G)
 
 namespace CatCommSqOver
 
@@ -444,7 +444,7 @@ lemma transform_map_whiskerLeft
     {φ φ' : CatCospanTransform F₁ G₁ F₂ G₂} (α : φ ⟶ φ') :
     (transform X).map (ψ ◁ α) =
     (transformObjComp X ψ φ).hom ≫
-      whiskerLeft (transform X|>.obj ψ) (transform X|>.map α) ≫
+      whiskerLeft (transform X |>.obj ψ) (transform X |>.map α) ≫
       (transformObjComp X ψ φ').inv := by
   cat_disch
 
@@ -454,7 +454,7 @@ lemma transform_map_whiskerRight
     (φ : CatCospanTransform F₁ G₁ F₂ G₂) :
     (transform X).map (α ▷ φ) =
     (transformObjComp X ψ φ).hom ≫
-      whiskerRight (transform X|>.map α) (transform X|>.obj φ) ≫
+      whiskerRight (transform X |>.map α) (transform X |>.obj φ) ≫
       (transformObjComp X ψ' φ).inv := by
   cat_disch
 
@@ -467,10 +467,10 @@ lemma transform_map_associator
     (τ : CatCospanTransform F₂ G₂ F₃ G₃) :
     (transform X).map (α_ ψ φ τ).hom =
     (transformObjComp X (ψ.comp φ) τ).hom ≫
-      whiskerRight (transformObjComp X ψ φ).hom (transform X|>.obj τ) ≫
-      ((transform X|>.obj ψ).associator
-        (transform X|>.obj φ) (transform X|>.obj τ)).hom ≫
-      whiskerLeft (transform X|>.obj ψ) (transformObjComp X φ τ).inv ≫
+      whiskerRight (transformObjComp X ψ φ).hom (transform X |>.obj τ) ≫
+      ((transform X |>.obj ψ).associator
+        (transform X |>.obj φ) (transform X |>.obj τ)).hom ≫
+      whiskerLeft (transform X |>.obj ψ) (transformObjComp X φ τ).inv ≫
       (transformObjComp X ψ (φ.comp τ)).inv := by
   cat_disch
 
@@ -478,16 +478,16 @@ lemma transform_map_leftUnitor (X : Type u₇) [Category.{v₇} X]
     (ψ : CatCospanTransform F G F₁ G₁) :
     (transform X).map (λ_ ψ).hom =
     (transformObjComp X (.id F G) ψ).hom ≫
-      whiskerRight (transformObjId X F G).hom (transform X|>.obj ψ) ≫
-      (transform X|>.obj ψ).leftUnitor.hom := by
+      whiskerRight (transformObjId X F G).hom (transform X |>.obj ψ) ≫
+      (transform X |>.obj ψ).leftUnitor.hom := by
   cat_disch
 
 lemma transform_map_rightUnitor (X : Type u₇) [Category.{v₇} X]
     (ψ : CatCospanTransform F G F₁ G₁) :
     (transform X).map (ρ_ ψ).hom =
     (transformObjComp X ψ (.id F₁ G₁)).hom ≫
-      whiskerLeft (transform X|>.obj ψ) (transformObjId X F₁ G₁).hom ≫
-      (transform X|>.obj ψ).rightUnitor.hom := by
+      whiskerLeft (transform X |>.obj ψ) (transformObjId X F₁ G₁).hom ≫
+      (transform X |>.obj ψ).rightUnitor.hom := by
   cat_disch
 
 end transform
@@ -543,14 +543,14 @@ def precomposeObjComp (U : X ⥤ Y) (V : Y ⥤ Z) :
 lemma precompose_map_whiskerLeft (U : X ⥤ Y) {V W : Y ⥤ Z} (α : V ⟶ W) :
     (precompose F G).map (whiskerLeft U α) =
     (precomposeObjComp F G U V).hom ≫
-      whiskerRight (precompose F G|>.map α) (precompose F G|>.obj U) ≫
+      whiskerRight (precompose F G |>.map α) (precompose F G |>.obj U) ≫
       (precomposeObjComp F G U W).inv := by
   cat_disch
 
 lemma precompose_map_whiskerRight {U V : X ⥤ Y} (α : U ⟶ V) (W : Y ⥤ Z) :
     (precompose F G).map (whiskerRight α W) =
     (precomposeObjComp F G U W).hom ≫
-      whiskerLeft (precompose F G|>.obj W) (precompose F G|>.map α) ≫
+      whiskerLeft (precompose F G |>.obj W) (precompose F G |>.map α) ≫
       (precomposeObjComp F G V W).inv := by
   cat_disch
 
@@ -558,23 +558,23 @@ lemma precompose_map_associator {T : Type u₇} [Category.{v₇} T]
     (U : X ⥤ Y) (V : Y ⥤ Z) (W : Z ⥤ T) :
     (precompose F G).map (U.associator V W).hom =
     (precomposeObjComp F G (U ⋙ V) W).hom ≫
-      whiskerLeft (precompose F G|>.obj W) (precomposeObjComp F G U V).hom ≫
-      ((precompose F G|>.obj W).associator _ _).inv ≫
-      whiskerRight (precomposeObjComp F G V W).inv (precompose F G|>.obj U) ≫
+      whiskerLeft (precompose F G |>.obj W) (precomposeObjComp F G U V).hom ≫
+      ((precompose F G |>.obj W).associator _ _).inv ≫
+      whiskerRight (precomposeObjComp F G V W).inv (precompose F G |>.obj U) ≫
       (precomposeObjComp F G _ _).inv := by
   cat_disch
 
 lemma precompose_map_leftUnitor (U : X ⥤ Y) :
     (precompose F G).map U.leftUnitor.hom =
     (precomposeObjComp F G (𝟭 _) U).hom ≫
-      whiskerLeft (precompose F G|>.obj U) (precomposeObjId F G X).hom ≫
+      whiskerLeft (precompose F G |>.obj U) (precomposeObjId F G X).hom ≫
       (Functor.rightUnitor _).hom := by
   cat_disch
 
 lemma precompose_map_rightUnitor (U : X ⥤ Y) :
     (precompose F G).map U.rightUnitor.hom =
     (precomposeObjComp F G U (𝟭 _)).hom ≫
-      whiskerRight (precomposeObjId F G Y).hom (precompose F G|>.obj U) ≫
+      whiskerRight (precomposeObjId F G Y).hom (precompose F G |>.obj U) ≫
       (Functor.leftUnitor _).hom := by
   cat_disch
 
@@ -598,8 +598,8 @@ instance precomposeObjTransformObjSquare
     {X : Type u₇} {Y : Type u₈} [Category.{v₇} X] [Category.{v₈} Y]
     (ψ : CatCospanTransform F G F₁ G₁) (U : X ⥤ Y) :
     CatCommSq
-      (precompose F G|>.obj U) (transform Y|>.obj ψ)
-      (transform X|>.obj ψ) (precompose F₁ G₁|>.obj U) where
+      (precompose F G |>.obj U) (transform Y |>.obj ψ)
+      (transform X |>.obj ψ) (precompose F₁ G₁ |>.obj U) where
   iso := NatIso.ofComponents fun _ =>
     CategoricalPullback.mkIso
       (Functor.associator _ _ _)
@@ -613,19 +613,19 @@ lemma precomposeObjTransformObjSquare_iso_hom_naturality₂
     {X : Type u₇} {Y : Type u₈} [Category.{v₇} X] [Category.{v₈} Y]
     (ψ : CatCospanTransform F G F₁ G₁)
     {U V : X ⥤ Y} (α : U ⟶ V) :
-    whiskerRight (precompose F G|>.map α) (transform X|>.obj ψ) ≫
-      (CatCommSq.iso _ (transform Y|>.obj ψ) _ (precompose F₁ G₁|>.obj V)).hom =
-    (CatCommSq.iso _ (transform Y|>.obj ψ) _ (precompose F₁ G₁|>.obj U)).hom ≫
-      whiskerLeft (transform Y|>.obj ψ) (precompose F₁ G₁|>.map α) := by
+    whiskerRight (precompose F G |>.map α) (transform X |>.obj ψ) ≫
+      (CatCommSq.iso _ (transform Y |>.obj ψ) _ (precompose F₁ G₁ |>.obj V)).hom =
+    (CatCommSq.iso _ (transform Y |>.obj ψ) _ (precompose F₁ G₁ |>.obj U)).hom ≫
+      whiskerLeft (transform Y |>.obj ψ) (precompose F₁ G₁ |>.map α) := by
   cat_disch
 
 /-- The square `precomposeObjTransformOBjSquare` respects identities. -/
 lemma precomposeObjTransformObjSquare_iso_hom_id
     (ψ : CatCospanTransform F G F₁ G₁) (X : Type u₇) [Category.{v₇} X] :
-    (CatCommSq.iso (precompose F G|>.obj <| 𝟭 X) (transform X|>.obj ψ)
-      (transform X|>.obj ψ) (precompose F₁ G₁|>.obj <| 𝟭 X)).hom ≫
-      whiskerLeft (transform X|>.obj ψ) (precomposeObjId F₁ G₁ X).hom =
-    whiskerRight (precomposeObjId F G X).hom (transform X|>.obj ψ) ≫
+    (CatCommSq.iso (precompose F G |>.obj <| 𝟭 X) (transform X |>.obj ψ)
+      (transform X |>.obj ψ) (precompose F₁ G₁ |>.obj <| 𝟭 X)).hom ≫
+      whiskerLeft (transform X |>.obj ψ) (precomposeObjId F₁ G₁ X).hom =
+    whiskerRight (precomposeObjId F G X).hom (transform X |>.obj ψ) ≫
       (Functor.leftUnitor _).hom ≫ (Functor.rightUnitor _).inv := by
   cat_disch
 
@@ -635,16 +635,16 @@ lemma precomposeObjTransformObjSquare_iso_hom_comp
     [Category.{v₇} X] [Category.{v₈} Y] [Category.{v₉} Z]
     (ψ : CatCospanTransform F G F₁ G₁)
     (U : X ⥤ Y) (V : Y ⥤ Z) :
-    (CatCommSq.iso (precompose F G|>.obj <| U ⋙ V) (transform Z|>.obj ψ)
-      (transform X|>.obj ψ) (precompose F₁ G₁|>.obj <| U ⋙ V)).hom ≫
-      whiskerLeft (transform Z|>.obj ψ) (precomposeObjComp F₁ G₁ U V).hom =
-    whiskerRight (precomposeObjComp F G U V).hom (transform X|>.obj ψ) ≫
+    (CatCommSq.iso (precompose F G |>.obj <| U ⋙ V) (transform Z |>.obj ψ)
+      (transform X |>.obj ψ) (precompose F₁ G₁ |>.obj <| U ⋙ V)).hom ≫
+      whiskerLeft (transform Z |>.obj ψ) (precomposeObjComp F₁ G₁ U V).hom =
+    whiskerRight (precomposeObjComp F G U V).hom (transform X |>.obj ψ) ≫
       (Functor.associator _ _ _).hom ≫
-      whiskerLeft (precompose F G|>.obj V)
-        (CatCommSq.iso _ (transform _|>.obj ψ) _ _).hom ≫
+      whiskerLeft (precompose F G |>.obj V)
+        (CatCommSq.iso _ (transform _ |>.obj ψ) _ _).hom ≫
       (Functor.associator _ _ _).inv ≫
       whiskerRight (CatCommSq.iso _ _ _ _).hom
-        (precompose F₁ G₁|>.obj U) ≫
+        (precompose F₁ G₁ |>.obj U) ≫
       (Functor.associator _ _ _).hom := by
   cat_disch
 
@@ -659,8 +659,8 @@ instance transformObjPrecomposeObjSquare
     {X : Type u₇} {Y : Type u₈} [Category.{v₇} X] [Category.{v₈} Y]
     (U : X ⥤ Y) (ψ : CatCospanTransform F G F₁ G₁) :
     CatCommSq
-      (transform Y|>.obj ψ) (precompose F G|>.obj U)
-      (precompose F₁ G₁|>.obj U) (transform X|>.obj ψ) where
+      (transform Y |>.obj ψ) (precompose F G |>.obj U)
+      (precompose F₁ G₁ |>.obj U) (transform X |>.obj ψ) where
   iso := NatIso.ofComponents fun _ =>
     CategoricalPullback.mkIso
       (Functor.associator _ _ _).symm
@@ -673,22 +673,22 @@ instance transformObjPrecomposeObjSquare
 lemma transformObjPrecomposeObjSquare_iso_hom_naturality₂
     {X : Type u₇} {Y : Type u₈} [Category.{v₇} X] [Category.{v₈} Y]
     (U : X ⥤ Y) {ψ ψ' : CatCospanTransform F G F₁ G₁} (η : ψ ⟶ ψ') :
-    whiskerRight (transform Y|>.map η) (precompose F₁ G₁|>.obj U) ≫
-      (CatCommSq.iso _ (precompose F G|>.obj U) _ (transform X|>.obj ψ')).hom =
-    (CatCommSq.iso _ (precompose F G|>.obj U) _ (transform X|>.obj ψ)).hom ≫
-      whiskerLeft (precompose F G|>.obj U) (transform X|>.map η) := by
+    whiskerRight (transform Y |>.map η) (precompose F₁ G₁ |>.obj U) ≫
+      (CatCommSq.iso _ (precompose F G |>.obj U) _ (transform X |>.obj ψ')).hom =
+    (CatCommSq.iso _ (precompose F G |>.obj U) _ (transform X |>.obj ψ)).hom ≫
+      whiskerLeft (precompose F G |>.obj U) (transform X |>.map η) := by
   cat_disch
 
 /-- The square `transformObjPrecomposeObjSquare` respects identities. -/
 lemma transformObjPrecomposeObjSquare_iso_hom_id
     {X : Type u₇} {Y : Type u₈} [Category.{v₇} X] [Category.{v₈} Y]
     (U : X ⥤ Y) (F : A ⥤ B) (G : C ⥤ B) :
-    (CatCommSq.iso (transform Y|>.obj <| .id F G) (precompose F G|>.obj U)
-      (precompose F G|>.obj U) (transform X|>.obj <| .id F G)).hom ≫
-      whiskerLeft (precompose F G|>.obj U) (transformObjId X F G).hom =
-    whiskerRight (transformObjId Y F G).hom (precompose F G|>.obj U) ≫
-      (precompose F G|>.obj U).leftUnitor.hom ≫
-      (precompose F G|>.obj U).rightUnitor.inv := by
+    (CatCommSq.iso (transform Y |>.obj <| .id F G) (precompose F G |>.obj U)
+      (precompose F G |>.obj U) (transform X |>.obj <| .id F G)).hom ≫
+      whiskerLeft (precompose F G |>.obj U) (transformObjId X F G).hom =
+    whiskerRight (transformObjId Y F G).hom (precompose F G |>.obj U) ≫
+      (precompose F G |>.obj U).leftUnitor.hom ≫
+      (precompose F G |>.obj U).rightUnitor.inv := by
   cat_disch
 
 /-- The square `transformPrecomposeSquare` respects compositions. -/
@@ -699,16 +699,16 @@ lemma transformPrecomposeObjSquare_iso_hom_comp
     {X : Type u₁₀} {Y : Type u₁₁} [Category.{v₁₀} X] [Category.{v₁₁} Y]
     (U : X ⥤ Y) (ψ : CatCospanTransform F G F₁ G₁)
     (ψ' : CatCospanTransform F₁ G₁ F₂ G₂) :
-    (CatCommSq.iso (transform Y|>.obj <| ψ.comp ψ') (precompose F G|>.obj U)
-      (precompose F₂ G₂|>.obj U) (transform X|>.obj <| ψ.comp ψ')).hom ≫
-      whiskerLeft (precompose F G|>.obj U) (transformObjComp X ψ ψ').hom =
-    whiskerRight (transformObjComp Y ψ ψ').hom (precompose F₂ G₂|>.obj U) ≫
+    (CatCommSq.iso (transform Y |>.obj <| ψ.comp ψ') (precompose F G |>.obj U)
+      (precompose F₂ G₂ |>.obj U) (transform X |>.obj <| ψ.comp ψ')).hom ≫
+      whiskerLeft (precompose F G |>.obj U) (transformObjComp X ψ ψ').hom =
+    whiskerRight (transformObjComp Y ψ ψ').hom (precompose F₂ G₂ |>.obj U) ≫
       (Functor.associator _ _ _).hom ≫
-      whiskerLeft (transform Y|>.obj ψ)
-        (CatCommSq.iso _ (precompose F₁ G₁|>.obj U)
-          _ (transform X|>.obj ψ')).hom ≫
+      whiskerLeft (transform Y |>.obj ψ)
+        (CatCommSq.iso _ (precompose F₁ G₁ |>.obj U)
+          _ (transform X |>.obj ψ')).hom ≫
       (Functor.associator _ _ _).inv ≫
-      whiskerRight (CatCommSq.iso _ _ _ _).hom (transform X|>.obj ψ') ≫
+      whiskerRight (CatCommSq.iso _ _ _ _).hom (transform X |>.obj ψ') ≫
       (Functor.associator _ _ _).hom := by
   cat_disch
 

--- a/Mathlib/CategoryTheory/Monoidal/Action/Basic.lean
+++ b/Mathlib/CategoryTheory/Monoidal/Action/Basic.lean
@@ -331,12 +331,12 @@ def curriedAction : C ⥤ D ⥤ D where
 variable {C} in
 /-- Bundle `d ↦ c ⊙ₗ d` as a functor. -/
 @[simps!]
-abbrev actionLeft (c : C) : D ⥤ D := curriedAction C D|>.obj c
+abbrev actionLeft (c : C) : D ⥤ D := curriedAction C D |>.obj c
 
 variable {D} in
 /-- Bundle `c ↦ c ⊙ₗ d` as a functor. -/
 @[simps!]
-abbrev actionRight (d : D) : C ⥤ D := curriedAction C D|>.flip.obj d
+abbrev actionRight (d : D) : C ⥤ D := curriedAction C D |>.flip.obj d
 
 /-- Bundle `αₗ _ _ _` as an isomorphism of trifunctors. -/
 @[simps!]
@@ -641,12 +641,12 @@ def curriedAction : C ⥤ D ⥤ D where
 variable {C} in
 /-- Bundle `d ↦ d ⊙ᵣ c` as a functor. -/
 @[simps!]
-abbrev actionRight (c : C) : D ⥤ D := curriedAction C D|>.obj c
+abbrev actionRight (c : C) : D ⥤ D := curriedAction C D |>.obj c
 
 variable {D} in
 /-- Bundle `c ↦ d ⊙ᵣ c` as a functor. -/
 @[simps!]
-abbrev actionLeft (d : D) : C ⥤ D := curriedAction C D|>.flip.obj d
+abbrev actionLeft (d : D) : C ⥤ D := curriedAction C D |>.flip.obj d
 
 /-- Bundle `αᵣ _ _ _` as an isomorphism of trifunctors. -/
 @[simps!]

--- a/Mathlib/CategoryTheory/Monoidal/Action/LinearFunctor.lean
+++ b/Mathlib/CategoryTheory/Monoidal/Action/LinearFunctor.lean
@@ -46,7 +46,7 @@ class LaxLeftLinear
     [MonoidalLeftAction C D] [MonoidalLeftAction C D'] where
   /-- The "μₗ" morphism. -/
   μₗ (F) (c : C) (d : D) : c ⊙ₗ F.obj d ⟶ F.obj (c ⊙ₗ d)
-  μₗ_naturality_left (F) {c c': C} (f : c ⟶ c') (d : D) :
+  μₗ_naturality_left (F) {c c' : C} (f : c ⟶ c') (d : D) :
     f ⊵ₗ F.obj d ≫ μₗ c' d = μₗ c d ≫ F.map (f ⊵ₗ d) := by cat_disch
   μₗ_naturality_right (F) (c : C) {d d' : D} (f : d ⟶ d') :
     c ⊴ₗ F.map f ≫ μₗ c d' = μₗ c d ≫ F.map (c ⊴ₗ f) := by cat_disch
@@ -99,7 +99,7 @@ class OplaxLeftLinear
     [MonoidalLeftAction C D] [MonoidalLeftAction C D'] where
   /-- The oplax lineator morphism. -/
   δₗ (F) (c : C) (d : D) : F.obj (c ⊙ₗ d) ⟶ c ⊙ₗ F.obj d
-  δₗ_naturality_left (F) {c c': C} (f : c ⟶ c') (d : D) :
+  δₗ_naturality_left (F) {c c' : C} (f : c ⟶ c') (d : D) :
     F.map (f ⊵ₗ d) ≫ δₗ c' d =
     δₗ c d ≫ f ⊵ₗ F.obj d := by cat_disch
   δₗ_naturality_right (F) (c : C) {d d' : D} (f : d ⟶ d') :
@@ -208,7 +208,7 @@ class LaxRightLinear
     [MonoidalRightAction C D] [MonoidalRightAction C D'] where
   /-- The "μᵣ" morphism. -/
   μᵣ (F) (d : D) (c : C) : F.obj d ⊙ᵣ c ⟶ F.obj (d ⊙ᵣ c)
-  μᵣ_naturality_right (F) (d : D) {c c': C} (f : c ⟶ c') :
+  μᵣ_naturality_right (F) (d : D) {c c' : C} (f : c ⟶ c') :
     F.obj d ⊴ᵣ f ≫ μᵣ d c' = μᵣ d c ≫ F.map (d ⊴ᵣ f) := by cat_disch
   μᵣ_naturality_left (F) {d d' : D} (f : d ⟶ d') (c : C) :
     F.map f ⊵ᵣ c ≫ μᵣ d' c = μᵣ d c ≫ F.map (f ⊵ᵣ c) := by cat_disch
@@ -236,7 +236,7 @@ variable
 @[reassoc (attr := simp)]
 lemma μᵣ_associativity_inv (d : D) (c c' : C) :
     μᵣ F d c ⊵ᵣ c' ≫ μᵣ F (d ⊙ᵣ c) c' ≫ F.map (αᵣ _ _ _).inv =
-    (αᵣ (F.obj d) c c' ).inv ≫ μᵣ F d (c ⊗ c') := by
+    (αᵣ (F.obj d) c c').inv ≫ μᵣ F d (c ⊗ c') := by
   simpa [-μᵣ_associativity, -μᵣ_associativity_assoc] using
     (αᵣ _ _ _).inv ≫=
       (μᵣ_associativity F d c c').symm =≫
@@ -261,7 +261,7 @@ class OplaxRightLinear
     [MonoidalRightAction C D] [MonoidalRightAction C D'] where
   /-- The oplax lineator morphism. -/
   δᵣ (F) (d : D) (c : C) : F.obj (d ⊙ᵣ c) ⟶ (F.obj d) ⊙ᵣ c
-  δᵣ_naturality_right (F) (d : D) {c c': C} (f : c ⟶ c') :
+  δᵣ_naturality_right (F) (d : D) {c c' : C} (f : c ⟶ c') :
     F.map (d ⊴ᵣ f) ≫ δᵣ d c' =
     δᵣ d c ≫ F.obj d ⊴ᵣ f := by cat_disch
   δᵣ_naturality_left (F) {d d' : D} (f : d ⟶ d') (c : C) :

--- a/Mathlib/CategoryTheory/ObjectProperty/Small.lean
+++ b/Mathlib/CategoryTheory/ObjectProperty/Small.lean
@@ -44,7 +44,7 @@ instance (P : ObjectProperty Cᵒᵖ) [ObjectProperty.Small.{w} P] :
 
 instance {ι : Type*} (X : ι → C) [Small.{w} ι] :
     ObjectProperty.Small.{w} (ofObj X) :=
-  small_of_surjective (f := fun i ↦ ⟨X i, by simp⟩) (by rintro ⟨_, ⟨i⟩⟩;simp )
+  small_of_surjective (f := fun i ↦ ⟨X i, by simp⟩) (by rintro ⟨_, ⟨i⟩⟩; simp)
 
 instance (X Y : C) : ObjectProperty.Small.{w} (.pair X Y) := by
   dsimp [pair]

--- a/Mathlib/Data/EReal/Inv.lean
+++ b/Mathlib/Data/EReal/Inv.lean
@@ -255,7 +255,7 @@ lemma sign_mul_inv_abs (a : EReal) : (sign a) * (a.abs : EReal)⁻¹ = a⁻¹ :=
 
 lemma sign_mul_inv_abs' (a : EReal) : (sign a) * ((a.abs⁻¹ : ℝ≥0∞) : EReal) = a⁻¹ := by
   induction a with
-  | bot | top  => simp
+  | bot | top => simp
   | coe a =>
     rcases lt_trichotomy a 0 with (a_neg | rfl | a_pos)
     · rw [sign_coe, _root_.sign_neg a_neg, coe_neg_one, neg_one_mul, abs_def a,
@@ -449,7 +449,7 @@ lemma lt_div_iff (h : 0 < b) (h' : b ≠ ⊤) : a < c / b ↔ a * b < c := by
   rw [EReal.mul_div b a b, mul_comm a b]
   exact (strictMono_div_right_of_pos h h').lt_iff_lt
 
-lemma div_lt_iff (h : 0 < c) (h' : c ≠ ⊤) :  b / c < a ↔ b < a * c := by
+lemma div_lt_iff (h : 0 < c) (h' : c ≠ ⊤) : b / c < a ↔ b < a * c := by
   nth_rw 1 [← @mul_div_cancel a c (ne_bot_of_gt h) h' (ne_of_gt h)]
   rw [EReal.mul_div c a c, mul_comm a c]
   exact (strictMono_div_right_of_pos h h').lt_iff_lt

--- a/Mathlib/Data/EReal/Operations.lean
+++ b/Mathlib/Data/EReal/Operations.lean
@@ -303,12 +303,12 @@ def negOrderIso : EReal ≃o ERealᵒᵈ :=
     map_rel_iff' := neg_le_neg_iff }
 
 lemma neg_add {x y : EReal} (h1 : x ≠ ⊥ ∨ y ≠ ⊤) (h2 : x ≠ ⊤ ∨ y ≠ ⊥) :
-    - (x + y) = - x - y := by
+    -(x + y) = -x - y := by
   induction x <;> induction y <;> try tauto
   rw [← coe_add, ← coe_neg, ← coe_neg, ← coe_sub, neg_add']
 
 lemma neg_sub {x y : EReal} (h1 : x ≠ ⊥ ∨ y ≠ ⊥) (h2 : x ≠ ⊤ ∨ y ≠ ⊤) :
-    - (x - y) = - x + y := by
+    -(x - y) = -x + y := by
   rw [sub_eq_add_neg, neg_add _ _, sub_eq_add_neg, neg_neg] <;> simp_all
 
 /-- Induction principle for `EReal`s splitting into cases `↑(x : ℝ≥0∞)` and `-↑(x : ℝ≥0∞)`.

--- a/Mathlib/Data/FP/Basic.lean
+++ b/Mathlib/Data/FP/Basic.lean
@@ -207,7 +207,7 @@ instance : Neg Float :=
 unsafe def add (mode : RMode) : Float → Float → Float
   | nan, _ => nan
   | _, nan => nan
-  | inf Bool.true, inf Bool.false=> nan
+  | inf Bool.true, inf Bool.false => nan
   | inf Bool.false, inf Bool.true => nan
   | inf s₁, _ => inf s₁
   | _, inf s₂ => inf s₂

--- a/Mathlib/Data/Fin/Tuple/Embedding.lean
+++ b/Mathlib/Data/Fin/Tuple/Embedding.lean
@@ -66,7 +66,7 @@ theorem init_snoc {n : ℕ} (x : Fin n ↪ α) {a : α} (ha : a ∉ range x) :
   simp [snoc, init]
 
 theorem snoc_castSucc {n : ℕ} {x : Fin n ↪ α} {a : α} {ha : a ∉ range x} {i : Fin n} :
-    snoc x ha i.castSucc  = x i := by
+    snoc x ha i.castSucc = x i := by
   rw [coe_snoc, Fin.snoc_castSucc]
 
 theorem snoc_last {n : ℕ} {x : Fin n ↪ α} {a : α} {ha : a ∉ range x} :

--- a/Mathlib/Data/List/Sort.lean
+++ b/Mathlib/Data/List/Sort.lean
@@ -571,7 +571,7 @@ theorem Sublist.orderedInsert_sublist [IsTrans α r] {as bs} (x) (hs : as <+ bs)
       unfold orderedInsert
       cases hs <;> split_ifs with hr
       · exact .cons₂ _ <| .cons _ ‹a :: as <+ bs›
-      · have ih := orderedInsert_sublist x ‹a :: as <+ bs›  hb.of_cons
+      · have ih := orderedInsert_sublist x ‹a :: as <+ bs› hb.of_cons
         simp only [hr, orderedInsert, ite_true] at ih
         exact .trans ih <| .cons _ (.refl _)
       · have hba := pairwise_cons.mp hb |>.left _ (mem_of_cons_sublist ‹a :: as <+ bs›)

--- a/Mathlib/Data/List/Sym.lean
+++ b/Mathlib/Data/List/Sym.lean
@@ -193,7 +193,7 @@ protected theorem Perm.sym2 {xs ys : List α} (h : xs ~ ys) :
     exact (h.map _).append ih
   | swap x y xs =>
     simp only [List.sym2, map_cons, cons_append]
-    conv => enter [1,2,1]; rw [Sym2.eq_swap]
+    conv => enter [1, 2, 1]; rw [Sym2.eq_swap]
     -- Explicit permutation to speed up simps that follow.
     refine Perm.trans (Perm.swap ..) (Perm.trans (Perm.cons _ ?_) (Perm.swap ..))
     simp only [← Multiset.coe_eq_coe, ← Multiset.cons_coe,

--- a/Mathlib/Data/Nat/ChineseRemainder.lean
+++ b/Mathlib/Data/Nat/ChineseRemainder.lean
@@ -136,7 +136,7 @@ def chineseRemainderOfMultiset {m : Multiset ι} :
       funext fun nod' : l'.Nodup =>
       have nod : l.Nodup := pp.symm.nodup_iff.mp nod'
       funext fun hs' : ∀ i ∈ l', s i ≠ 0 =>
-      have hs : ∀ i ∈ l, s i ≠ 0  := by simpa [List.Perm.mem_iff pp] using hs'
+      have hs : ∀ i ∈ l, s i ≠ 0 := by simpa [List.Perm.mem_iff pp] using hs'
       funext fun co' : Set.Pairwise {x | x ∈ l'} (Coprime on s) =>
       have co : Set.Pairwise {x | x ∈ l} (Coprime on s) := by simpa [List.Perm.mem_iff pp] using co'
       have lco : l.Pairwise (Coprime on s) := List.Nodup.pairwise_of_forall_ne nod co

--- a/Mathlib/Data/Num/Lemmas.lean
+++ b/Mathlib/Data/Num/Lemmas.lean
@@ -778,7 +778,7 @@ theorem castNum_eq_bitwise {f : Num → Num → Num} {g : Bool → Bool → Bool
   · rw [fnn]
     have this b (n : PosNum) : (cond b (↑n) 0 : ℕ) = ↑(cond b (pos n) 0 : Num) := by
       cases b <;> rfl
-    have this' b (n : PosNum) : ↑ (pos (PosNum.bit b n)) = Nat.bit b ↑n := by
+    have this' b (n : PosNum) : ↑(pos (PosNum.bit b n)) = Nat.bit b ↑n := by
       cases b <;> simp
     induction m generalizing n with | one => ?_ | bit1 m IH => ?_ | bit0 m IH => ?_ <;>
     obtain - | n | n := n

--- a/Mathlib/Data/Num/ZNum.lean
+++ b/Mathlib/Data/Num/ZNum.lean
@@ -117,7 +117,7 @@ theorem cast_bit1 [AddGroupWithOne α] : ∀ n : ZNum, (n.bit1 : α) = ((n : α)
       simp
     · dsimp only [Num.succ'] at ep
       subst p
-      have : (↑(-↑a : ℤ) : α) = -1 + ↑(-↑a + 1 : ℤ) := by simp [add_comm (- ↑a : ℤ) 1]
+      have : (↑(-↑a : ℤ) : α) = -1 + ↑(-↑a + 1 : ℤ) := by simp [add_comm (-↑a : ℤ) 1]
       simpa using this
 
 @[simp]

--- a/Mathlib/Data/Ordmap/Invariants.lean
+++ b/Mathlib/Data/Ordmap/Invariants.lean
@@ -105,7 +105,7 @@ theorem size_eq_realSize : ∀ {t : Ordnode α}, Sized t → size t = realSize t
 
 @[simp]
 theorem Sized.size_eq_zero {t : Ordnode α} (ht : Sized t) : size t = 0 ↔ t = nil := by
-  cases t <;> [simp;simp [ht.1]]
+  cases t <;> [simp; simp [ht.1]]
 
 theorem Sized.pos {s l x r} (h : Sized (@node α s l x r)) : 0 < s := by
   rw [h.1]; apply Nat.le_add_left

--- a/Mathlib/Data/Prod/TProd.lean
+++ b/Mathlib/Data/Prod/TProd.lean
@@ -62,7 +62,7 @@ theorem fst_mk (i : ι) (l : List ι) (f : ∀ i, α i) : (TProd.mk (i :: l) f).
 
 @[simp]
 theorem snd_mk (i : ι) (l : List ι) (f : ∀ i, α i) :
-    (TProd.mk.{u,v} (i :: l) f).2 = TProd.mk.{u,v} l f :=
+    (TProd.mk.{u, v} (i :: l) f).2 = TProd.mk.{u, v} l f :=
   rfl
 
 variable [DecidableEq ι]

--- a/Mathlib/Data/Sign/Defs.lean
+++ b/Mathlib/Data/Sign/Defs.lean
@@ -70,7 +70,7 @@ instance : LE SignType :=
   ⟨SignType.LE⟩
 
 instance LE.decidableRel : DecidableRel SignType.LE := fun a b => by
-  cases a <;> cases b <;> first | exact isTrue (by constructor)| exact isFalse (by rintro ⟨_⟩)
+  cases a <;> cases b <;> first | exact isTrue (by constructor) | exact isFalse (by rintro ⟨_⟩)
 
 private lemma mul_comm : ∀ (a b : SignType), a * b = b * a := by rintro ⟨⟩ ⟨⟩ <;> rfl
 private lemma mul_assoc : ∀ (a b c : SignType), (a * b) * c = a * (b * c) := by

--- a/Mathlib/Data/Sym/Sym2.lean
+++ b/Mathlib/Data/Sym/Sym2.lean
@@ -624,7 +624,7 @@ theorem mem_toFinset {x : α} {z : Sym2 α} : x ∈ z.toFinset ↔ x ∈ z := by
   rw [← Sym2.mem_toMultiset, Sym2.toFinset, Multiset.mem_toFinset]
 
 lemma toFinset_mk_eq {x y : α} : s(x, y).toFinset = {x, y} := by
-  ext; simp [←Sym2.mem_toFinset, ←Sym2.mem_iff]
+  ext; simp [← Sym2.mem_toFinset, ← Sym2.mem_iff]
 
 /-- Mapping an unordered pair on the diagonal to a finite set produces a finset of size `1`. -/
 theorem card_toFinset_of_isDiag (z : Sym2 α) (h : z.IsDiag) : #(z : Sym2 α).toFinset = 1 := by

--- a/Mathlib/Data/Vector/MapLemmas.lean
+++ b/Mathlib/Data/Vector/MapLemmas.lean
@@ -392,11 +392,11 @@ variable (xs : Vector α n) (ys : Vector β n)
 
 theorem map₂_flip (f : α → β → γ) :
     map₂ f xs ys = map₂ (flip f) ys xs := by
-  induction xs, ys using Vector.inductionOn₂ <;> simp_all[flip]
+  induction xs, ys using Vector.inductionOn₂ <;> simp_all [flip]
 
 theorem mapAccumr₂_flip (f : α → β → σ → σ × γ) :
     mapAccumr₂ f xs ys s = mapAccumr₂ (flip f) ys xs s := by
-  induction xs, ys using Vector.inductionOn₂ <;> simp_all[flip]
+  induction xs, ys using Vector.inductionOn₂ <;> simp_all [flip]
 
 end Flip
 

--- a/Mathlib/GroupTheory/FreeGroup/CyclicallyReduced.lean
+++ b/Mathlib/GroupTheory/FreeGroup/CyclicallyReduced.lean
@@ -40,7 +40,7 @@ theorem isCyclicallyReduced_iff :
 theorem isCyclicallyReduced_cons_append_iff {a b : α × Bool} :
     IsCyclicallyReduced (b :: L ++ [a]) ↔
     IsReduced (b :: L ++ [a]) ∧ (a.1 = b.1 → a.2 = b.2) := by
-  rw [isCyclicallyReduced_iff,List.getLast?_concat]
+  rw [isCyclicallyReduced_iff, List.getLast?_concat]
   simp
 
 namespace IsCyclicallyReduced

--- a/Mathlib/Order/Filter/Partial.lean
+++ b/Mathlib/Order/Filter/Partial.lean
@@ -105,7 +105,7 @@ theorem rcomap_rcomap (r : SetRel α β) (s : SetRel β γ) (l : Filter γ) :
     rcomap r (rcomap s l) = rcomap (r.comp s) l :=
   filter_eq <| by
     ext t
-    simp only [rcomap_sets, SetRel.image, Filter.mem_sets, Set.mem_setOf_eq,SetRel.core_comp]
+    simp only [rcomap_sets, SetRel.image, Filter.mem_sets, Set.mem_setOf_eq, SetRel.core_comp]
     constructor
     · rintro ⟨u, ⟨v, vsets, hv⟩, h⟩
       exact ⟨v, vsets, Set.Subset.trans (SetRel.core_mono hv) h⟩

--- a/Mathlib/Order/ScottContinuity/Prod.lean
+++ b/Mathlib/Order/ScottContinuity/Prod.lean
@@ -34,10 +34,10 @@ lemma ScottContinuousOn.fromProd [Preorder α] [Preorder β] [Preorder γ]
     ← isLUB_iUnion_iff_of_isLUB (fun a => by
       rw [singleton_prod, image_image f (fun b ↦ (a, b))]
       exact h₁ _ (mem_image_of_mem (fun d ↦ Prod.snd '' d) hX) (Nonempty.image Prod.snd hd₁)
-        (DirectedOn.snd hd₂) ((isLUB_prod (_,_)).mp hdp).2) _, Set.range]
+        (DirectedOn.snd hd₂) ((isLUB_prod (_, _)).mp hdp).2) _, Set.range]
   convert (h₂ _
     (mem_image_of_mem (fun d ↦ Prod.fst '' d) hX) (Nonempty.image Prod.fst hd₁) (DirectedOn.fst hd₂)
-    ((isLUB_prod (p1,p2)).mp hdp).1)
+    ((isLUB_prod (p1, p2)).mp hdp).1)
   ext : 1
   simp_all only [Subtype.exists, mem_image, Prod.exists,
     exists_and_right, exists_eq_right, exists_prop, mem_setOf_eq]

--- a/Mathlib/Probability/Kernel/Composition/KernelLemmas.lean
+++ b/Mathlib/Probability/Kernel/Composition/KernelLemmas.lean
@@ -106,7 +106,7 @@ lemma parallelComp_id_right_comp_parallelComp {η : Kernel X' Z} [IsSFiniteKerne
     _ = swap Y T ∘ₖ (swap T Y ∘ₖ (ξ ∥ₖ Kernel.id) ∘ₖ (η ∥ₖ κ)) := by
       simp_rw [← comp_assoc, swap_swap, id_comp]
     _ = swap Y T ∘ₖ (swap T Y ∘ₖ ((ξ ∘ₖ η) ∥ₖ κ)) := by rw [this]
-    _ = ξ ∘ₖ η ∥ₖ κ  := by simp_rw [← comp_assoc, swap_swap, id_comp]
+    _ = ξ ∘ₖ η ∥ₖ κ := by simp_rw [← comp_assoc, swap_swap, id_comp]
   simp_rw [swap_parallelComp, comp_assoc, swap_parallelComp, ← comp_assoc,
     parallelComp_id_left_comp_parallelComp]
 

--- a/Mathlib/Probability/ProbabilityMassFunction/Binomial.lean
+++ b/Mathlib/Probability/ProbabilityMassFunction/Binomial.lean
@@ -24,7 +24,7 @@ open ENNReal NNReal
 independent coin tosses, each having probability `p` of coming up “heads”. -/
 def binomial (p : ℝ≥0) (h : p ≤ 1) (n : ℕ) : PMF (Fin (n + 1)) :=
   .ofFintype (fun i =>
-      ↑(p^(i : ℕ) * (1-p)^((Fin.last n - i) : ℕ) * (n.choose i : ℕ))) (by
+      ↑(p ^ (i : ℕ) * (1 - p) ^ ((Fin.last n - i) : ℕ) * (n.choose i : ℕ))) (by
     dsimp only
     norm_cast
     convert (add_pow p (1-p) n).symm

--- a/Mathlib/RepresentationTheory/Homological/GroupHomology/LowDegree.lean
+++ b/Mathlib/RepresentationTheory/Homological/GroupHomology/LowDegree.lean
@@ -559,10 +559,10 @@ theorem isBoundary₀_iff (a : A) :
     IsBoundary₀ G a ↔ ∃ x : G →₀ A, x.sum (fun g z => g • z - z) = a := by
   constructor
   · rintro ⟨x, hx⟩
-    use x.sum (fun g a => single g (- (g⁻¹ • a)))
+    use x.sum (fun g a => single g (-(g⁻¹ • a)))
     simp_all [sum_neg_index, sum_sum_index, neg_add_eq_sub]
   · rintro ⟨x, hx⟩
-    use x.sum (fun g a => single g (- (g • a)))
+    use x.sum (fun g a => single g (-(g • a)))
     simp_all [sum_neg_index, sum_sum_index, neg_add_eq_sub]
 
 theorem isBoundary₁_iff (x : G →₀ A) :

--- a/Mathlib/SetTheory/Cardinal/UnivLE.lean
+++ b/Mathlib/SetTheory/Cardinal/UnivLE.lean
@@ -16,14 +16,14 @@ universe u v
 
 open Cardinal
 
-theorem univLE_iff_cardinal_le : UnivLE.{u, v} ↔ univ.{u, v+1} ≤ univ.{v, u+1} := by
+theorem univLE_iff_cardinal_le : UnivLE.{u, v} ↔ univ.{u, v + 1} ≤ univ.{v, u + 1} := by
   rw [← not_iff_not, univLE_iff]; simp_rw [small_iff_lift_mk_lt_univ]; push_neg
   -- strange: simp_rw [univ_umax.{v,u}] doesn't work
   refine ⟨fun ⟨α, le⟩ ↦ ?_, fun h ↦ ?_⟩
-  · rw [univ_umax.{v,u}, ← lift_le.{u+1}, lift_univ, lift_lift] at le
-    exact le.trans_lt (lift_lt_univ'.{u,v+1} #α)
+  · rw [univ_umax.{v, u}, ← lift_le.{u + 1}, lift_univ, lift_lift] at le
+    exact le.trans_lt (lift_lt_univ'.{u, v + 1} #α)
   · obtain ⟨⟨α⟩, h⟩ := lt_univ'.mp h; use α
-    rw [univ_umax.{v,u}, ← lift_le.{u+1}, lift_univ, lift_lift]
+    rw [univ_umax.{v, u}, ← lift_le.{u + 1}, lift_univ, lift_lift]
     exact h.le
 
 theorem univLE_iff_exists_embedding : UnivLE.{u, v} ↔ Nonempty (Ordinal.{u} ↪ Ordinal.{v}) := by

--- a/Mathlib/Topology/Instances/ENNReal/Lemmas.lean
+++ b/Mathlib/Topology/Instances/ENNReal/Lemmas.lean
@@ -514,7 +514,7 @@ theorem exists_frequently_lt_of_liminf_ne_top' {ι : Type*} {l : Filter ι} {x :
   simp_rw [not_exists, not_frequently, not_lt] at h
   refine hx (ENNReal.eq_top_of_forall_nnreal_le fun r => le_limsInf_of_le (by isBoundedDefault) ?_)
   simp only [eventually_map, ENNReal.coe_le_coe]
-  filter_upwards [h (-r)] with i hi using(le_neg.1 hi).trans (neg_le_abs _)
+  filter_upwards [h (-r)] with i hi using (le_neg.1 hi).trans (neg_le_abs _)
 
 theorem exists_upcrossings_of_not_bounded_under {ι : Type*} {l : Filter ι} {x : ι → ℝ}
     (hf : liminf (fun i => (Real.nnabs (x i) : ℝ≥0∞)) l ≠ ∞)
@@ -1440,7 +1440,7 @@ theorem limsup_add_of_right_tendsto_zero {u : Filter ι} {g : ι → ℝ≥0∞}
   rw [Filter.limsup_le_iff']
   rintro a hba
   filter_upwards [hb, ENNReal.tendsto_nhds_zero.1 hg _ <| tsub_pos_of_lt hba] with i hf hg
-  calc  f i + g i
+  calc f i + g i
     _ ≤ b + g i := by gcongr
     _ ≤ a := add_le_of_le_tsub_left_of_le hba.le hg
 

--- a/Mathlib/Topology/Instances/EReal/Lemmas.lean
+++ b/Mathlib/Topology/Instances/EReal/Lemmas.lean
@@ -250,10 +250,10 @@ section LimInfSup
 
 variable {α : Type*} {f : Filter α} {u v : α → EReal}
 
-lemma liminf_neg : liminf (- v) f = - limsup v f :=
+lemma liminf_neg : liminf (-v) f = -limsup v f :=
   EReal.negOrderIso.limsup_apply.symm
 
-lemma limsup_neg : limsup (- v) f = - liminf v f :=
+lemma limsup_neg : limsup (-v) f = -liminf v f :=
   EReal.negOrderIso.liminf_apply.symm
 
 lemma le_liminf_add : (liminf u f) + (liminf v f) ≤ liminf (u + v) f := by
@@ -484,7 +484,7 @@ private lemma continuousAt_mul_top_pos {a : ℝ} (h : 0 < a) :
   simp only [ContinuousAt, EReal.top_mul_coe_of_pos h, EReal.tendsto_nhds_top_iff_real]
   intro x
   rw [_root_.eventually_nhds_iff]
-  use (Set.Ioi ((2*(max (x+1) 0)/a : ℝ) : EReal)) ×ˢ (Set.Ioi ((a/2 : ℝ) : EReal))
+  use (Set.Ioi ((2 * (max (x + 1) 0) / a : ℝ) : EReal)) ×ˢ (Set.Ioi ((a / 2 : ℝ) : EReal))
   split_ands
   · intro p p_in_prod
     simp only [Set.mem_prod, Set.mem_Ioi] at p_in_prod
@@ -494,7 +494,7 @@ private lemma continuousAt_mul_top_pos {a : ℝ} (h : 0 < a) :
       rw [EReal.coe_nonneg]
       apply mul_nonneg _ (le_of_lt (inv_pos_of_pos h))
       simp only [Nat.ofNat_pos, mul_nonneg_iff_of_pos_left, le_max_iff, le_refl, or_true]
-    have a2_pos : 0 < ((a/2 : ℝ) : EReal) := by rw [EReal.coe_pos]; linarith
+    have a2_pos : 0 < ((a / 2 : ℝ) : EReal) := by rw [EReal.coe_pos]; linarith
     have lock := mul_le_mul_of_nonneg_right (le_of_lt p1_gt) (le_of_lt a2_pos)
     have key := mul_le_mul_of_nonneg_left (le_of_lt p2_gt) (le_of_lt p1_pos)
     replace lock := le_trans lock key

--- a/Mathlib/Topology/Order/IntermediateValue.lean
+++ b/Mathlib/Topology/Order/IntermediateValue.lean
@@ -328,7 +328,7 @@ theorem IsClosed.mem_of_ge_of_forall_exists_lt {a b : α} {s : Set α} (hs : IsC
     (hb : b ∈ s) (hab : a ≤ b) (hgt : ∀ x ∈ s ∩ Ioc a b, (s ∩ Ico a x).Nonempty) : a ∈ s := by
   suffices OrderDual.toDual a ∈ ofDual ⁻¹' s by aesop
   have : IsClosed (OrderDual.ofDual ⁻¹' (s ∩ Icc a b)) := hs
-  rw [preimage_inter, ←Icc_toDual ] at this
+  rw [preimage_inter, ← Icc_toDual] at this
   apply this.mem_of_ge_of_forall_exists_gt (by aesop) (by aesop) (fun x hx ↦ ?_)
   rw [Ico_toDual, ← preimage_inter, preimage_equiv_eq_image_symm, mem_image] at hx
   aesop


### PR DESCRIPTION
Found by extending the commandStart linter to proof bodies. Extracted from #30658.


---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include at least one commit authored by each
co-author among the commits in the pull request. If necessary, you may 
create empty commits to indicate co-authorship, using commands like so:

git commit --author="Author Name <author@email.com>" --allow-empty -m "add Author Name as coauthor"

When merging, all the commits will be squashed into a single commit listing all co-authors.

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
