### PR TITLE
[Merged by Bors] - feat: new `by_cases!` tactic

### DIFF
--- a/Mathlib.lean
+++ b/Mathlib.lean
@@ -6118,6 +6118,7 @@ import Mathlib.Tactic.Basic
 import Mathlib.Tactic.Bound
 import Mathlib.Tactic.Bound.Attribute
 import Mathlib.Tactic.Bound.Init
+import Mathlib.Tactic.ByCases
 import Mathlib.Tactic.ByContra
 import Mathlib.Tactic.CC
 import Mathlib.Tactic.CC.Addition

--- a/Mathlib/Tactic.lean
+++ b/Mathlib/Tactic.lean
@@ -13,6 +13,7 @@ import Mathlib.Tactic.Basic
 import Mathlib.Tactic.Bound
 import Mathlib.Tactic.Bound.Attribute
 import Mathlib.Tactic.Bound.Init
+import Mathlib.Tactic.ByCases
 import Mathlib.Tactic.ByContra
 import Mathlib.Tactic.CC
 import Mathlib.Tactic.CC.Addition

--- a/Mathlib/Tactic/ByCases.lean
+++ b/Mathlib/Tactic/ByCases.lean
@@ -7,17 +7,19 @@ import Mathlib.Tactic.Push
 import Batteries.Tactic.PermuteGoals
 
 /-!
-# The `by_cases` tactic
+# The `by_cases!` tactic
 
-The `by_cases!` tactic is a variant of the `by_cases` tactic that also calls `push_neg`.
+The `by_cases!` tactic is a variant of the `by_cases` tactic that also calls `push_neg`
+on the generated hypothesis that is a negation.
 -/
 
 /--
 `by_cases! h : p` runs the `by_cases h : p` tactic, followed by
-`try push_neg at h` in the second subgoals.
-
-For example, `by_cases! h : a < b` creates one goal with the hypothesis `h : a < b` and
-one goal with `h : b ≤ a`.
+`try push_neg at h` in the second subgoal. For example,
+- `by_cases! h : a < b` creates one goal with hypothesis `h : a < b` and
+  another with `h : b ≤ a`.
+- `by_cases! h : a ≠ b` creates one goal with hypothesis `h : a ≠ b` and
+  another with `h : a = b`.
 -/
 syntax (name := byCases!) "by_cases! " (atomic(ident " : "))? term : tactic
 

--- a/Mathlib/Tactic/ByCases.lean
+++ b/Mathlib/Tactic/ByCases.lean
@@ -1,0 +1,27 @@
+/-
+Copyright (c) 2025 Jovan Gerbscheid. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Jovan Gerbscheid
+-/
+import Mathlib.Tactic.Push
+import Batteries.Tactic.PermuteGoals
+
+/-!
+# The `by_cases` tactic
+
+The `by_cases!` tactic is a variant of the `by_cases` tactic that also calls `push_neg`.
+-/
+
+/--
+`by_cases! h : p` runs the `by_cases h : p` tactic, followed by
+`try push_neg at h` in the second subgoals.
+
+For example, `by_cases! h : a < b` creates one goal with the hypothesis `h : a < b` and
+one goal with `h : b ≤ a`.
+-/
+syntax (name := byCases!) "by_cases! " (atomic(ident " : "))? term : tactic
+
+macro_rules
+  | `(tactic| by_cases! $e) => `(tactic| by_cases! h : $e)
+  | `(tactic| by_cases! $h : $e) =>
+    `(tactic| by_cases $h : $e; try on_goal 2 => push_neg at $h:ident)

--- a/scripts/noshake.json
+++ b/scripts/noshake.json
@@ -68,6 +68,7 @@
   "Mathlib.Tactic.Attr.Register",
   "Mathlib.Tactic.Basic",
   "Mathlib.Tactic.Bound.Attribute",
+  "Mathlib.Tactic.ByCases",
   "Mathlib.Tactic.ByContra",
   "Mathlib.Tactic.CC",
   "Mathlib.Tactic.CancelDenoms",
@@ -336,6 +337,7 @@
   "Mathlib.Tactic.CC.Datatypes":
   ["Mathlib.Lean.Meta.CongrTheorems", "Mathlib.Lean.Meta.Datatypes"],
   "Mathlib.Tactic.ByContra": ["Batteries.Tactic.Init"],
+  "Mathlib.Tactic.ByCases": ["Batteries.Tactic.PermuteGoals"],
   "Mathlib.Tactic.Bound.Init": ["Aesop.Frontend.Command"],
   "Mathlib.Tactic.Bound.Attribute":
   ["Mathlib.Algebra.Group.ZeroOne", "Mathlib.Tactic.Bound.Init"],


### PR DESCRIPTION
This PR defines the `by_cases! h : p` tactic, which is a macro for `by_cases h : p` followed by a `try push_neg at h`  in the second goal. We use `try push_neg` instead of `push_neg` to make the tactic also succeed when no negation is pushed. Should there maybe be an optional linter telling you to use `by_cases` instead if possible?

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include at least one commit authored by each
co-author among the commits in the pull request. If necessary, you may 
create empty commits to indicate co-authorship, using commands like so:

git commit --author="Author Name <author@email.com>" --allow-empty -m "add Author Name as coauthor"

When merging, all the commits will be squashed into a single commit listing all co-authors.

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
