### PR TITLE
doc(Combinatorics): spell cliquefree as clique-free

### DIFF
--- a/Mathlib/Combinatorics/SimpleGraph/Clique.lean
+++ b/Mathlib/Combinatorics/SimpleGraph/Clique.lean
@@ -397,7 +397,7 @@ theorem CliqueFree.mono (h : m ≤ n) : G.CliqueFree m → G.CliqueFree n := by
 theorem CliqueFree.anti (h : G ≤ H) : H.CliqueFree n → G.CliqueFree n :=
   forall_imp fun _ ↦ mt <| IsNClique.mono h
 
-/-- If a graph is cliquefree, any graph that embeds into it is also cliquefree. -/
+/-- If a graph is clique-free, any graph that embeds into it is also clique-free. -/
 theorem CliqueFree.comap {H : SimpleGraph β} (f : H ↪g G) : G.CliqueFree n → H.CliqueFree n := by
   intro h; contrapose h
   exact not_cliqueFree_of_top_embedding <| f.comp (topEmbeddingOfNotCliqueFree h)

--- a/Mathlib/Combinatorics/SimpleGraph/CompleteMultipartite.lean
+++ b/Mathlib/Combinatorics/SimpleGraph/CompleteMultipartite.lean
@@ -29,7 +29,7 @@ A graph is complete multipartite iff non-adjacency is transitive.
 
 * See also: `Mathlib/Combinatorics/SimpleGraph/FiveWheelLike.lean`.
   The lemma `colorable_iff_isCompleteMultipartite_of_maximal_cliqueFree` states that a maximally
-  `r + 1`-cliquefree graph is `r`-colorable iff it is complete multipartite.
+  `r + 1`-clique-free graph is `r`-colorable iff it is complete multipartite.
 
 * `SimpleGraph.completeEquipartiteGraph`: the **complete equipartite graph** in parts of *equal*
   size such that two vertices are adjacent if and only if they are in different parts.

--- a/Mathlib/Combinatorics/SimpleGraph/Extremal/Turan.lean
+++ b/Mathlib/Combinatorics/SimpleGraph/Extremal/Turan.lean
@@ -11,7 +11,7 @@ import Mathlib.Order.Partition.Equipartition
 # Turán's theorem
 
 In this file we prove Turán's theorem, the first important result of extremal graph theory,
-which states that the `r + 1`-cliquefree graph on `n` vertices with the most edges is the complete
+which states that the `r + 1`-clique-free graph on `n` vertices with the most edges is the complete
 `r`-partite graph with part sizes as equal as possible (`turanGraph n r`).
 
 The forward direction of the proof performs "Zykov symmetrisation", which first shows
@@ -25,8 +25,8 @@ the property through `turanGraph n r` using the isomorphism provided by the forw
 ## Main declarations
 
 * `SimpleGraph.IsTuranMaximal`: `G.IsTuranMaximal r` means that `G` has the most number of edges for
-  its number of vertices while still being `r + 1`-cliquefree.
-* `SimpleGraph.turanGraph n r`: The canonical `r + 1`-cliquefree Turán graph on `n` vertices.
+  its number of vertices while still being `r + 1`-clique-free.
+* `SimpleGraph.turanGraph n r`: The canonical `r + 1`-clique-free Turán graph on `n` vertices.
 * `SimpleGraph.IsTuranMaximal.finpartition`: The result of Zykov symmetrisation, a finpartition of
   the vertices such that two vertices are in the same part iff they are non-adjacent.
 * `SimpleGraph.IsTuranMaximal.nonempty_iso_turanGraph`: The forward direction, an isomorphism
@@ -46,7 +46,7 @@ namespace SimpleGraph
 variable {V : Type*} [Fintype V] {G : SimpleGraph V} [DecidableRel G.Adj] {n r : ℕ}
 
 variable (G) in
-/-- An `r + 1`-cliquefree graph is `r`-Turán-maximal if any other `r + 1`-cliquefree graph on
+/-- An `r + 1`-clique-free graph is `r`-Turán-maximal if any other `r + 1`-clique-free graph on
 the same vertex set has the same or fewer number of edges. -/
 def IsTuranMaximal (r : ℕ) : Prop :=
   G.CliqueFree (r + 1) ∧ ∀ (H : SimpleGraph V) [DecidableRel H.Adj],
@@ -61,7 +61,7 @@ lemma IsTuranMaximal.le_iff_eq (hG : G.IsTuranMaximal r) (hH : H.CliqueFree (r +
   classical exact ⟨fun hGH ↦ edgeFinset_inj.1 <| eq_of_subset_of_card_le
     (edgeFinset_subset_edgeFinset.2 hGH) (hG.2 _ hH), le_of_eq⟩
 
-/-- The canonical `r + 1`-cliquefree Turán graph on `n` vertices. -/
+/-- The canonical `r + 1`-clique-free Turán graph on `n` vertices. -/
 def turanGraph (n r : ℕ) : SimpleGraph (Fin n) where Adj v w := v % r ≠ w % r
 
 lemma turanGraph_adj {v w} : (turanGraph n r).Adj v w ↔ v % r ≠ w % r :=
@@ -95,7 +95,7 @@ theorem turanGraph_cliqueFree (hr : 0 < r) : (turanGraph n r).CliqueFree (r + 1)
   simp only [Fin.mk.injEq] at c
   exact absurd c ((@ha x y).mpr d)
 
-/-- An `r + 1`-cliquefree Turán-maximal graph is _not_ `r`-cliquefree
+/-- An `r + 1`-clique-free Turán-maximal graph is _not_ `r`-clique-free
 if it can accommodate such a clique. -/
 theorem not_cliqueFree_of_isTuranMaximal (hn : r ≤ Fintype.card V) (hG : G.IsTuranMaximal r) :
     ¬G.CliqueFree r := by
@@ -241,7 +241,7 @@ lemma card_parts_le [DecidableEq V] : #h.finpartition.parts ≤ r := by
   exact absurd (h.1.mono (Nat.succ_le_of_lt l)) ncf
 
 /-- There are `min n r` parts in a graph on `n` vertices satisfying `G.IsTuranMaximal r`.
-`min` handles the `n < r` case, when `G` is complete but still `r + 1`-cliquefree
+`min` handles the `n < r` case, when `G` is complete but still `r + 1`-clique-free
 for having insufficiently many vertices. -/
 theorem card_parts [DecidableEq V] : #h.finpartition.parts = min (Fintype.card V) r := by
   set fp := h.finpartition
@@ -265,7 +265,7 @@ theorem card_parts [DecidableEq V] : #h.finpartition.parts = min (Fintype.card V
 
 /-- **Turán's theorem**, forward direction.
 
-Any `r + 1`-cliquefree Turán-maximal graph on `n` vertices is isomorphic to `turanGraph n r`. -/
+Any `r + 1`-clique-free Turán-maximal graph on `n` vertices is isomorphic to `turanGraph n r`. -/
 theorem nonempty_iso_turanGraph :
     Nonempty (G ≃g turanGraph (Fintype.card V) r) := by
   classical
@@ -304,7 +304,7 @@ theorem isTuranMaximal_turanGraph (hr : 0 < r) : (turanGraph n r).IsTuranMaximal
   isTuranMaximal_of_iso Iso.refl hr
 
 /-- **Turán's theorem**. `turanGraph n r` is, up to isomorphism, the unique
-`r + 1`-cliquefree Turán-maximal graph on `n` vertices. -/
+`r + 1`-clique-free Turán-maximal graph on `n` vertices. -/
 theorem isTuranMaximal_iff_nonempty_iso_turanGraph (hr : 0 < r) :
     G.IsTuranMaximal r ↔ Nonempty (G ≃g turanGraph (Fintype.card V) r) :=
   ⟨fun h ↦ h.nonempty_iso_turanGraph, fun h ↦ isTuranMaximal_of_iso h.some hr⟩

--- a/Mathlib/Combinatorics/SimpleGraph/FiveWheelLike.lean
+++ b/Mathlib/Combinatorics/SimpleGraph/FiveWheelLike.lean
@@ -110,7 +110,7 @@ private lemma IsNClique.insert_insert_erase (hs : G.IsNClique r (insert a s)) (h
 An `IsFiveWheelLike r k v w₁ w₂ s t` structure in `G` consists of vertices `v w₁ w₂` and `r`-sets
 `s` and `t` such that `{v, w₁, w₂}` induces the single edge `w₁w₂` (i.e. they form an
 `IsPathGraph3Compl`), `v, w₁, w₂ ∉ s ∪ t`, `s ∪ {v}, t ∪ {v}, s ∪ {w₁}, t ∪ {w₂}` are all
-`(r + 1)`-cliques and `#(s ∩ t) = k`. (If `G` is maximally `(r + 2)`-cliquefree and not complete
+`(r + 1)`-cliques and `#(s ∩ t) = k`. (If `G` is maximally `(r + 2)`-clique-free and not complete
 multipartite then `G` will contain such a structure: see
 `exists_isFiveWheelLike_of_maximal_cliqueFree_not_isCompleteMultipartite`.)
 -/


### PR DESCRIPTION
This change was initially suggested to me by Codex, as part of #30621, but it made sense to do this as a free-standing PR, since this change requires some justification, and this PR provides just that.

The fact that Codex is encouraging this change does not mean much on its own, so I did my best to check the literature. Searching on Google Scholar yields a mere [four results](https://scholar.google.com/scholar?hl=en&as_sdt=0%2C5&q=%22cliquefree%22) for "cliquefree" and [423 results](https://scholar.google.com/scholar?hl=en&as_sdt=0%2C5&q=%22clique-free%22) for "clique-free". Based on these results, I think it is safe to say that "cliquefree" is quite idiosyncratic, and should be avoided.

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include at least one commit authored by each
co-author among the commits in the pull request. If necessary, you may 
create empty commits to indicate co-authorship, using commands like so:

git commit --author="Author Name <author@email.com>" --allow-empty -m "add Author Name as coauthor"

When merging, all the commits will be squashed into a single commit listing all co-authors.

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
