### PR TITLE
[Merged by Bors] - chore(without_cdot): remove all uses of `without_cdot`

### DIFF
--- a/Mathlib/Tactic/CongrM.lean
+++ b/Mathlib/Tactic/CongrM.lean
@@ -76,6 +76,6 @@ elab_rules : tactic
     withMainContext do
       let gStx ← Term.exprToSyntax (← getMainTarget)
       -- Gives the expected type to `refine` as a workaround for its elaboration order.
-      evalTactic <| ← `(tactic| refine without_cdot(congr($(⟨pattern⟩)) : $gStx))
+      evalTactic <| ← `(tactic| refine (congr($(⟨pattern⟩)) : $gStx))
 
 end Mathlib.Tactic

--- a/Mathlib/Tactic/Use.lean
+++ b/Mathlib/Tactic/Use.lean
@@ -97,7 +97,7 @@ def useLoop (eager : Bool) (gs : List MVarId) (args : List Term) (acc insts : Li
           "argument is not definitionally equal to inferred value{indentExpr (.mvar g)}"
       return ← useLoop eager gs' args' acc insts
     -- Type ascription is a workaround for `refine` ensuring the type after synthesizing mvars.
-    let refineArg ← `(tactic| refine without_cdot($arg : $(← Term.exprToSyntax (← g.getType))))
+    let refineArg ← `(tactic| refine ($arg : $(← Term.exprToSyntax (← g.getType))))
     if eager then
       -- In eager mode, first try refining with the argument before applying the constructor
       if let some newGoals ← observing? (run g do withoutRecover <| evalTactic refineArg) then


### PR DESCRIPTION
This PR removes all 2 uses of `without_cdot`. It is not needed anymore, because Lean automatically avoids accidental cdot capture. `without_cdot` may be deprecated in a future PR.

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include at least one commit authored by each
co-author among the commits in the pull request. If necessary, you may 
create empty commits to indicate co-authorship, using commands like so:

git commit --author="Author Name <author@email.com>" --allow-empty -m "add Author Name as coauthor"

When merging, all the commits will be squashed into a single commit listing all co-authors.

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
