### PR TITLE
fix(gcongr): use `whnfR` on the sides of the relation

### DIFF
--- a/Mathlib/Tactic/GCongr/Core.lean
+++ b/Mathlib/Tactic/GCongr/Core.lean
@@ -194,6 +194,7 @@ def getCongrAppFnArgs (e : Expr) : Option (Name × Array Expr) :=
       some (`_Forall, #[.lam n d b bi])
     else
       some (`_Implies, #[d, b])
+  | .proj n i e => some (.num n i, #[e])
   | e => e.withApp fun f args => f.constName?.map (·, args)
 
 /-- If `e` is of the form `r a b`, return `(r, a, b)`. -/


### PR DESCRIPTION
In `gcongr`, with a goal `(f _ ... _) ∼ (f _ ... _)`, the current implementation uses `whnfR` on the relation `∼`, but not on the two sides `f _ ... _`. This is a bit troublesome, so this PR adds a `whnf` call for the constant on the sides.

The current motivation is that in #30739, `gcongr` got confused between `≤` and `≥` being the same, but with the arguments swapped. If we always `whnf`, then `gcongr` will never see `≥`, fixing the issue.

Another motivation for this is that we may want to use a discrimination tree in `gcongr` in the future. And that also uses `whnf` internally.

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include at least one commit authored by each
co-author among the commits in the pull request. If necessary, you may 
create empty commits to indicate co-authorship, using commands like so:

git commit --author="Author Name <author@email.com>" --allow-empty -m "add Author Name as coauthor"

When merging, all the commits will be squashed into a single commit listing all co-authors.

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
