### PR TITLE
[Merged by Bors] - doc(Algebra): a collection of nontrivial typo fixes

### DIFF
--- a/Mathlib/Algebra/Algebra/Spectrum/Quasispectrum.lean
+++ b/Mathlib/Algebra/Algebra/Spectrum/Quasispectrum.lean
@@ -56,8 +56,7 @@ In Mathlib, the quasispectrum is the domain of the continuous functions associat
 + `Unitization.isQuasiregular_inr_iff`: `a : A` is quasiregular if and only if it is quasiregular
   in `Unitization R A` (via the coercion `Unitization.inr`).
 + `Unitization.quasispectrum_eq_spectrum_inr`: the quasispectrum of `a` in a non-unital `R`-algebra
-  `A` is precisely the spectrum of `a` in the unitization.
-  in `Unitization R A` (via the coercion `Unitization.inr`).
+  `A` is precisely the spectrum of `a` in `Unitization R A` (via the coercion `Unitization.inr`).
 -/
 
 /-- A type synonym for non-unital rings where an alternative monoid structure is introduced.

--- a/Mathlib/Algebra/BrauerGroup/Defs.lean
+++ b/Mathlib/Algebra/BrauerGroup/Defs.lean
@@ -31,8 +31,8 @@ Brauer group, Central simple algebra, Galois Cohomology
 
 universe u v
 
-/-- `CSA` is the set of all finite-dimensional central simple algebras over field `K`, for its
-generalisation over a `CommRing` please find `IsAzumaya` in `Mathlib/Algebra/Azumaya/Defs.lean`. -/
+/-- `CSA` is the set of all finite-dimensional central simple algebras over a field `K`. For the
+generalization to a `CommRing`, see `IsAzumaya` in `Mathlib/Algebra/Azumaya/Defs.lean`. -/
 structure CSA (K : Type u) [Field K] extends AlgCat.{v} K where
   /-- Any member of `CSA` is central. -/
   [isCentral : Algebra.IsCentral K carrier]

--- a/Mathlib/Algebra/Colimit/Ring.lean
+++ b/Mathlib/Algebra/Colimit/Ring.lean
@@ -44,7 +44,8 @@ variable (f : ∀ i j, i ≤ j → G i → G j)
 
 open FreeCommRing
 
-/-- The direct limit of a directed system is the rings glued together along the maps. -/
+/-- The direct limit of a directed system is the ring obtained by gluing the components along the
+maps. -/
 def DirectLimit : Type _ :=
   FreeCommRing (Σ i, G i) ⧸
     Ideal.span

--- a/Mathlib/Algebra/Field/MinimalAxioms.lean
+++ b/Mathlib/Algebra/Field/MinimalAxioms.lean
@@ -15,13 +15,13 @@ a minimum number of equalities.
 
 ## Main Definitions
 
-* `Field.ofMinimalAxioms`: Define a `Field` structure on a Type by proving a minimized set of axioms
+* `Field.ofMinimalAxioms`: Define a `Field` structure on a Type by proving a minimal set of axioms
 
 -/
 
 universe u
 
-/-- Define a `Field` structure on a Type by proving a minimized set of axioms.
+/-- Define a `Field` structure on a Type by proving a minimal set of axioms.
 Note that this uses the default definitions for `npow`, `nsmul`, `zsmul`, `div` and `sub`.
 See note [reducible non-instances]. -/
 abbrev Field.ofMinimalAxioms (K : Type u)

--- a/Mathlib/Algebra/GroupWithZero/Hom.lean
+++ b/Mathlib/Algebra/GroupWithZero/Hom.lean
@@ -213,7 +213,8 @@ instance {β} [CommMonoidWithZero β] : Mul (α →*₀ β) where
     { (f * g : α →* β) with
       map_zero' := by dsimp; rw [map_zero, zero_mul] }
 
-/-- The trivial homomorphism between monoids with zero, sending everything to 1 other than 0. -/
+/-- The trivial homomorphism between monoids with zero, sending 0 to 0 and all other elements to 1.
+-/
 protected instance one (M₀ N₀ : Type*) [MulZeroOneClass M₀] [MulZeroOneClass N₀]
     [DecidablePred fun x : M₀ ↦ x = 0] [Nontrivial M₀] [NoZeroDivisors M₀] :
     One (M₀ →*₀ N₀) where

--- a/Mathlib/Algebra/Homology/ComplexShapeSigns.lean
+++ b/Mathlib/Algebra/Homology/ComplexShapeSigns.lean
@@ -30,7 +30,7 @@ variable {I₁ I₂ I₃ I₁₂ I₂₃ J : Type*}
   (c₁ : ComplexShape I₁) (c₂ : ComplexShape I₂) (c₃ : ComplexShape I₃)
   (c₁₂ : ComplexShape I₁₂) (c₂₃ : ComplexShape I₂₃) (c : ComplexShape J)
 
-/-- A total complex shape for three complexes shapes `c₁`, `c₂`, `c₁₂` on three types
+/-- A total complex shape for three complex shapes `c₁`, `c₂`, `c₁₂` on three types
 `I₁`, `I₂` and `I₁₂` consists of the data and properties that will allow the construction
 of a total complex functor `HomologicalComplex₂ C c₁ c₂ ⥤ HomologicalComplex C c₁₂` which
 sends `K` to a complex which in degree `i₁₂ : I₁₂` consists of the coproduct

--- a/Mathlib/Algebra/Homology/HomologySequenceLemmas.lean
+++ b/Mathlib/Algebra/Homology/HomologySequenceLemmas.lean
@@ -17,7 +17,7 @@ of the homology sequence of `S₁` and `S₂` with respect to `φ`
 
 Then, we shall show in this file that if two out of the three maps `φ.τ₁`,
 `φ.τ₂`, `φ.τ₃` are quasi-isomorphisms, then the third is. We also obtain
-more specific separate lemmas which gives sufficient condition for one
+more specific separate lemmas which give sufficient conditions for one
 of these three morphisms to induce a mono/epi/iso in a given degree
 in terms of properties of the two others in the same or neighboring degrees.
 

--- a/Mathlib/Algebra/Homology/HomotopyCategory/HomologicalFunctor.lean
+++ b/Mathlib/Algebra/Homology/HomotopyCategory/HomologicalFunctor.lean
@@ -15,7 +15,7 @@ then `homologyFunctor C (ComplexShape.up ℤ) n` is a homological functor
 `HomotopyCategory C (ComplexShape.up ℤ) ⥤ C`. As distinguished triangles
 in the homotopy category can be characterized in terms of degreewise split
 short exact sequences of cochain complexes, this follows from the homology
-sequence of a short exact sequences of homological complexes.
+sequence associated to a short exact sequence of homological complexes.
 
 -/
 

--- a/Mathlib/Algebra/Homology/HomotopyCategory/ShiftSequence.lean
+++ b/Mathlib/Algebra/Homology/HomotopyCategory/ShiftSequence.lean
@@ -76,7 +76,7 @@ variable [CategoryWithHomology C]
 namespace ShiftSequence
 
 variable (C) in
-/-- The natural isomorphism `(K⟦n⟧).homology a ≅ K.homology a'`when `n + a = a`. -/
+/-- The natural isomorphism `(K⟦n⟧).homology a ≅ K.homology a'` when `n + a = a'`. -/
 noncomputable def shiftIso (n a a' : ℤ) (ha' : n + a = a') :
     (CategoryTheory.shiftFunctor _ n) ⋙ homologyFunctor C (ComplexShape.up ℤ) a ≅
       homologyFunctor C (ComplexShape.up ℤ) a' :=

--- a/Mathlib/Algebra/Lie/CartanExists.lean
+++ b/Mathlib/Algebra/Lie/CartanExists.lean
@@ -68,7 +68,7 @@ open LieModule LinearMap
 
 local notation "φ" => LieModule.toEnd R L M
 
-/-- Let `x` and `y` be elements of a Lie `R`-algebra `L`, and `M` a Lie module over `M`.
+/-- Let `x` and `y` be elements of a Lie `R`-algebra `L`, and `M` a Lie module over `L`.
 Then the characteristic polynomials of the family of endomorphisms `⁅r • y + x, _⁆` of `M`
 have coefficients that are polynomial in `r : R`.
 In other words, we obtain a polynomial over `R[X]`


### PR DESCRIPTION
This is a collection of typo fixes suggested to me by Codex. I decided to split these changes out of #30669, because I feel none of these are completely trivial to review, mostly because they require inspecting the context of the text as opposed to just the text itself.

I've manually reviewed all of them to the best of my abilities and I'm reasonably sure they are all correct, and that they represent an improvement over the status quo. However, I am not an expert in Algebra, so please review with care.

I suspect that there might still be quite a wide span in the difficulty of reviewing the changes in this PR, but I don't have a strong intuition for which changes herein might still be seen as relatively easy to review. I'm open to splitting this PR further should any reviewer think that is a good idea.

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include at least one commit authored by each
co-author among the commits in the pull request. If necessary, you may 
create empty commits to indicate co-authorship, using commands like so:

git commit --author="Author Name <author@email.com>" --allow-empty -m "add Author Name as coauthor"

When merging, all the commits will be squashed into a single commit listing all co-authors.

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
