### PR TITLE
feat (CategoryTheory/Comma/Over/Pushforward): define pushforwards

### DIFF
--- a/Mathlib.lean
+++ b/Mathlib.lean
@@ -2212,6 +2212,7 @@ import Mathlib.CategoryTheory.Comma.LocallySmall
 import Mathlib.CategoryTheory.Comma.Over.Basic
 import Mathlib.CategoryTheory.Comma.Over.OverClass
 import Mathlib.CategoryTheory.Comma.Over.Pullback
+import Mathlib.CategoryTheory.Comma.Over.Pushforward
 import Mathlib.CategoryTheory.Comma.Presheaf.Basic
 import Mathlib.CategoryTheory.Comma.Presheaf.Colimit
 import Mathlib.CategoryTheory.Comma.StructuredArrow.Basic

--- a/Mathlib/CategoryTheory/Comma/Over/Pullback.lean
+++ b/Mathlib/CategoryTheory/Comma/Over/Pullback.lean
@@ -14,8 +14,8 @@ import Mathlib.CategoryTheory.Limits.Shapes.Pullback.Iso
 /-!
 # Adjunctions related to the over category
 
-In a category with pullbacks, for any morphism `f : X ⟶ Y`, the functor
-`Over.map f : Over X ⥤ Over Y` has a right adjoint `Over.pullback f`.
+If pullbacks along a morphism `f : X ⟶ Y` exist,
+the functor `Over.map f : Over X ⥤ Over Y` has a right adjoint `Over.pullback f`.
 
 In a category with binary products, for any object `X` the functor
 `Over.forget X : Over X ⥤ C` has a right adjoint `Over.star X`.

--- a/Mathlib/CategoryTheory/Comma/Over/Pushforward.lean
+++ b/Mathlib/CategoryTheory/Comma/Over/Pushforward.lean
@@ -1,0 +1,77 @@
+/-
+Copyright (c) 2025 Joseph Hua. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Joseph Hua
+
+NOTESThis expresses the universal property of the right adjoint to
+pullback without requiring the existence of the entire adjoint.
+See `Mathlib.CategoryTheory.Adjunction.PartialAdjoint`.
+
+This definition could be generalised to not require pullbacks, but such settings are rare.
+
+(also called exponentiable)
+-/
+import Mathlib.CategoryTheory.Comma.Over.Pullback
+import Mathlib.CategoryTheory.Adjunction.PartialAdjoint
+
+noncomputable section
+
+universe v v₂ u u₂
+
+namespace CategoryTheory
+
+open Category Limits Comonad
+
+variable {C : Type u} [Category.{v} C] (X : C)
+variable {D : Type u₂} [Category.{v₂} D]
+
+variable {S S' : C} (f : S ⟶ S') [∀ {W} (h : W ⟶ S'), HasPullback h f]
+
+/-- `Y` is the pushforward of `X` along `f` when it represents the presheaf
+`Hom(pullback f (-), X)`. -/
+abbrev IsPushforward (X : Over S) (Y : Over S') :=
+  ((Over.pullback f).op ⋙ yoneda.obj X).RepresentableBy Y
+
+/-- An object `X` in the slice over `S` has a pushforward along morphism `f : S ⟶ S'`
+when the partial right adjoint of pullback along `f` is well-defined on the object `X`. -/
+abbrev HasPushforward (X : Over S) : Prop :=
+  ((Over.pullback f).op ⋙ yoneda.obj X).IsRepresentable
+
+/-- Assuming a pushforward along along `f` of `X` exists,
+`pushforward` chooses such a pushforward. -/
+abbrev pushforward (X : Over S) [HasPushforward f X] : Over S' :=
+  ((Over.pullback f).op ⋙ yoneda.obj X).reprX
+
+/-- The pushforward of an object satisfies the universal property of the pushforward. -/
+def pushforward.isPushforward (X : Over S) [HasPushforward f X] :
+    IsPushforward f X (pushforward f X) :=
+  ((Over.pullback f).op ⋙ yoneda.obj X).representableBy
+
+/-- A morphism `f` has pushforwards when there is a pushforward
+along `f` for any map into its domain. -/
+abbrev HasPushforwards : Prop := ∀ (X : Over S), HasPushforward f X
+
+namespace Over
+
+variable [HasPushforwards f]
+
+lemma pullback_rightAdjointObjIsDefined_eq_top :
+    (Over.pullback f).rightAdjointObjIsDefined = ⊤ := by aesop_cat
+
+instance : (pullback f).IsLeftAdjoint :=
+  Functor.isLeftAdjoint_of_rightAdjointObjIsDefined_eq_top
+  (pullback_rightAdjointObjIsDefined_eq_top f)
+
+/-- When pushforwards along `f` exist,
+we can define a left adjoint to the pullback functor between over categories. -/
+def pushforward : Over S ⥤ Over S' :=
+  (pullback f).rightAdjoint
+
+/-- The pullback-pushforward adjunction. -/
+def pullbackPushforwardAdjunction : pullback f ⊣ pushforward f :=
+  Adjunction.ofIsLeftAdjoint (pullback f)
+
+end Over
+
+end CategoryTheory
+end

--- a/Mathlib/CategoryTheory/Comma/Over/Pushforward.lean
+++ b/Mathlib/CategoryTheory/Comma/Over/Pushforward.lean
@@ -2,17 +2,36 @@
 Copyright (c) 2025 Joseph Hua. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Joseph Hua
-
-NOTESThis expresses the universal property of the right adjoint to
-pullback without requiring the existence of the entire adjoint.
-See `Mathlib.CategoryTheory.Adjunction.PartialAdjoint`.
-
-This definition could be generalised to not require pullbacks, but such settings are rare.
-
-(also called exponentiable)
 -/
 import Mathlib.CategoryTheory.Comma.Over.Pullback
 import Mathlib.CategoryTheory.Adjunction.PartialAdjoint
+
+/-!
+# Pushforward
+
+If pullbacks along a morphism `f : S ⟶ S'` exist,
+we say that an object `Y : Over S'` is a pushforward along `f` of an object `X : Over S`
+when it locally satisfies the right adjoint universal property with respect to
+the pullback functor `Over.pullback f : Over Y ⥤ Over X`.
+More formally,
+this means that the object `Y` represents the presheaf `Hom(pullback f (-), X)`.
+
+## Main declarations
+
+- `IsPushforward f X Y` says that `Y` is a pushforward along `f` of `X`.
+- `HasPushforward f X` says that a pushforward of `f` along `X` exists.
+- `pushforward f : Over S ⥤ Over S'` is the functor induced by a morphism `f : S ⟶ S'`
+  when all pushforwards along `f` exist.
+- `pullbackPushforwardAdjunction f : pullback f ⊣ pushforward f` is the defining adjunction
+  of pushforwards when all pushforwards along `f` exist.
+
+## Notes
+
+- There is a partial right adjoint induced by the condition `HasPushforward`.
+  See `Mathlib.CategoryTheory.Adjunction.PartialAdjoint`.
+- In the literature, the condition `HasPushforwards f` is also called "exponentiable",
+  and `IsPushforwardf f X Y` is also read as "`Y` is the internal product".
+-/
 
 noncomputable section
 
@@ -33,7 +52,7 @@ abbrev IsPushforward (X : Over S) (Y : Over S') :=
   ((Over.pullback f).op ⋙ yoneda.obj X).RepresentableBy Y
 
 /-- An object `X` in the slice over `S` has a pushforward along morphism `f : S ⟶ S'`
-when the partial right adjoint of pullback along `f` is well-defined on the object `X`. -/
+when the presheaf `Hom(pullback f (-), X)` is representable. -/
 abbrev HasPushforward (X : Over S) : Prop :=
   ((Over.pullback f).op ⋙ yoneda.obj X).IsRepresentable
 


### PR DESCRIPTION
Define what it means to be a pushforward, what it means to have pushforwards, and the pullback/pushforward adjunction when all pushforwards exist.

This is related to PRs #30375 and PR #29810

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include at least one commit authored by each
co-author among the commits in the pull request. If necessary, you may 
create empty commits to indicate co-authorship, using commands like so:

git commit --author="Author Name <author@email.com>" --allow-empty -m "add Author Name as coauthor"

When merging, all the commits will be squashed into a single commit listing all co-authors.

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
