### PR TITLE
feat(Topology/UniformSpace): thickening with respect to an entourage

### DIFF
--- a/Mathlib/Topology/MetricSpace/Thickening.lean
+++ b/Mathlib/Topology/MetricSpace/Thickening.lean
@@ -160,6 +160,14 @@ theorem thickening_eq_biUnion_ball {δ : ℝ} {E : Set X} : thickening δ E = �
   simp only [mem_iUnion₂, exists_prop]
   exact mem_thickening_iff
 
+theorem thickening_eq_thickening (δ : ℝ) (E : Set X) :
+    UniformSpace.thickening {p | dist p.2 p.1 < δ} E = thickening δ E := by
+  simp only [thickening_eq_biUnion_ball, UniformSpace.thickening, ball_eq_ball]
+
+theorem thickening_eq_thickening' (δ : ℝ) (E : Set X) :
+    UniformSpace.thickening {p | dist p.1 p.2 < δ} E = thickening δ E := by
+  simp only [thickening_eq_biUnion_ball, UniformSpace.thickening, ball_eq_ball']
+
 protected theorem _root_.Bornology.IsBounded.thickening {δ : ℝ} {E : Set X} (h : IsBounded E) :
     IsBounded (thickening δ E) := by
   rcases E.eq_empty_or_nonempty with rfl | ⟨x, hx⟩

--- a/Mathlib/Topology/UniformSpace/Basic.lean
+++ b/Mathlib/Topology/UniformSpace/Basic.lean
@@ -92,6 +92,9 @@ lemma isOpen_ball (x : α) {V : Set (α × α)} (hV : IsOpen V) : IsOpen (ball x
 lemma isClosed_ball (x : α) {V : Set (α × α)} (hV : IsClosed V) : IsClosed (ball x V) :=
   hV.preimage <| .prodMk_right _
 
+theorem isOpen_thickening {V : Set (α × α)} {s : Set α} (h : IsOpen V) : IsOpen (thickening V s) :=
+  isOpen_biUnion fun _ _ => isOpen_ball _ h
+
 /-!
 ### Neighborhoods in uniform spaces
 -/

--- a/Mathlib/Topology/UniformSpace/Defs.lean
+++ b/Mathlib/Topology/UniformSpace/Defs.lean
@@ -631,6 +631,70 @@ theorem mem_comp_comp {V W M : Set (β × β)} (hW' : IsSymmetricRel W) {p : β 
     rw [mem_ball_symmetry hW'] at z_in
     exact ⟨z, ⟨w, w_in, hwz⟩, z_in⟩
 
+/-- The thickening of a set with respect to `V : Set (β × β)`. Recovers the notion of metric
+thickening when `V = {p | dist p.1 p.2 < r}`. -/
+def thickening (V : Set (β × β)) (s : Set β) : Set β := ⋃ x ∈ s, ball x V
+
+@[simp]
+theorem thickening_empty (V : Set (β × β)) : thickening V ∅ = ∅ := by
+  simp [thickening]
+
+@[simp]
+theorem thickening_singleton (V : Set (β × β)) (x : β) : thickening V {x} = ball x V :=
+  Set.biUnion_singleton _ _
+
+@[simp]
+theorem thickening_union (V : Set (β × β)) (s t : Set β) :
+    thickening V (s ∪ t) = thickening V s ∪ thickening V t :=
+  Set.biUnion_union _ _ _
+
+@[simp]
+theorem thickening_iUnion {ι : Sort*} (V : Set (β × β)) (f : ι → Set β) :
+    thickening V (⋃ (i : ι), f i) = ⋃ (i : ι), thickening V (f i) :=
+  Set.biUnion_iUnion _ _
+
+theorem thickening_biUnion {ι : Type*} (V : Set (β × β)) (f : ι → Set β) (I : Set ι) :
+    thickening V (⋃ i ∈ I, f i) = ⋃ i ∈ I, thickening V (f i) := by simp
+
+@[gcongr]
+theorem thickening_mono {V W : Set (β × β)} (h : V ⊆ W) (s : Set β) :
+    thickening V s ⊆ thickening W s :=
+  Set.iUnion₂_mono fun _ _ => ball_mono h _
+
+theorem ball_subset_thickening {x : β} {s : Set β} (hx : x ∈ s) (V : Set (β × β)) :
+    ball x V ⊆ thickening V s :=
+  Set.subset_biUnion_of_mem (u := (ball · V)) hx
+
+@[gcongr]
+theorem thickening_subset_of_subset (V : Set (β × β)) {s t : Set β} (h : s ⊆ t) :
+    thickening V s ⊆ thickening V t :=
+  Set.biUnion_subset_biUnion_left h
+
+theorem thickening_thickening_subset (V W : Set (β × β)) (s : Set β) :
+    thickening V (thickening W s) ⊆ thickening (W ○ V) s := by
+  intro
+  simp only [thickening, Set.mem_iUnion, ball, compRel]
+  grind
+
+theorem thickening_ball (x : β) (V W : Set (β × β)) : thickening V (ball x W) ⊆ ball x (W ○ V) := by
+  simp_rw [← thickening_singleton]
+  exact thickening_thickening_subset _ _ _
+
+theorem self_subset_thickening_of_refl {V : Set (β × β)} (s : Set β) (hV : ∀ x ∈ s, (x, x) ∈ V) :
+    s ⊆ thickening V s :=
+  fun x hx => Set.mem_biUnion hx (hV x hx)
+
+theorem self_subset_thickening {V : Set (α × α)} (hV : V ∈ 𝓤 α) (s : Set α) :
+    s ⊆ thickening V s :=
+  self_subset_thickening_of_refl _ fun _ _ => refl_mem_uniformity hV
+
+theorem closure_subset_thickening {V : Set (α × α)} (hV : V ∈ 𝓤 α) (s : Set α) :
+    closure s ⊆ thickening V s := by
+  intro x hx
+  simp_rw [mem_closure_iff_nhds, nhds_eq_comap_uniformity] at hx
+  obtain ⟨y, hy₁, hy₂⟩ := hx _ <| Filter.preimage_mem_comap <| UniformSpace.symm hV
+  exact Set.mem_biUnion hy₂ hy₁
+
 end UniformSpace
 
 /-!


### PR DESCRIPTION
This PR defines `UniformSpace.thickening` and proves some properties analogous to the ones for `Metric.thickening`.


---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include at least one commit authored by each
co-author among the commits in the pull request. If necessary, you may 
create empty commits to indicate co-authorship, using commands like so:

git commit --author="Author Name <author@email.com>" --allow-empty -m "add Author Name as coauthor"

When merging, all the commits will be squashed into a single commit listing all co-authors.

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
