### PR TITLE
[Merged by Bors] - chore: normalize doc heading spacing

### DIFF
--- a/Mathlib/Algebra/MonoidAlgebra/NoZeroDivisors.lean
+++ b/Mathlib/Algebra/MonoidAlgebra/NoZeroDivisors.lean
@@ -27,7 +27,7 @@ that if `R` is a field and `A` is a left-ordered group, then `R[A]` contains no 
 zero-divisors.
 The actual assumptions on `R` are weaker.
 
-##  Main results
+## Main results
 
 * `MonoidAlgebra.mul_apply_mul_eq_mul_of_uniqueMul` and
   `AddMonoidAlgebra.mul_apply_add_eq_mul_of_uniqueAdd`

--- a/Mathlib/Algebra/MonoidAlgebra/Support.lean
+++ b/Mathlib/Algebra/MonoidAlgebra/Support.lean
@@ -9,7 +9,7 @@ import Mathlib.LinearAlgebra.Finsupp.Supported
 import Mathlib.Algebra.Group.Pointwise.Finset.Basic
 
 /-!
-#  Lemmas about the support of a finitely supported function
+# Lemmas about the support of a finitely supported function
 -/
 
 open scoped Pointwise

--- a/Mathlib/Algebra/Polynomial/Laurent.lean
+++ b/Mathlib/Algebra/Polynomial/Laurent.lean
@@ -46,7 +46,7 @@ convenient.
 I made a *heavy* use of `simp` lemmas, aiming to bring Laurent polynomials to the form `C a * T n`.
 Any comments or suggestions for improvements is greatly appreciated!
 
-##  Future work
+## Future work
 Lots is missing!
 -- (Riccardo) add inclusion into Laurent series.
 -- A "better" definition of `trunc` would be as an `R`-linear map.  This works:

--- a/Mathlib/Algebra/SkewMonoidAlgebra/Support.lean
+++ b/Mathlib/Algebra/SkewMonoidAlgebra/Support.lean
@@ -7,7 +7,7 @@ import Mathlib.Algebra.Group.Pointwise.Finset.Basic
 import Mathlib.Algebra.SkewMonoidAlgebra.Basic
 
 /-!
-#  Lemmas about the support of an element of a skew monoid algebra
+# Lemmas about the support of an element of a skew monoid algebra
 
 For `f : SkewMonoidAlgebra k G`, `f.support` is the set of all `a ∈ G` such that `f.coeff a ≠ 0`.
 -/

--- a/Mathlib/Data/Finset/NatDivisors.lean
+++ b/Mathlib/Data/Finset/NatDivisors.lean
@@ -7,7 +7,7 @@ import Mathlib.NumberTheory.Divisors
 import Mathlib.Algebra.Group.Pointwise.Finset.Basic
 
 /-!
-#  `Nat.divisors` as a multiplicative homomorpism
+# `Nat.divisors` as a multiplicative homomorpism
 
 The main definition of this file is `Nat.divisorsHom : ℕ →* Finset ℕ`,
 exhibiting `Nat.divisors` as a multiplicative homomorphism from `ℕ` to `Finset ℕ`.

--- a/Mathlib/Data/Nat/Dist.lean
+++ b/Mathlib/Data/Nat/Dist.lean
@@ -7,7 +7,7 @@ import Mathlib.Algebra.Order.Group.Nat
 import Mathlib.Algebra.Order.Ring.Canonical
 
 /-!
-#  Distance function on ℕ
+# Distance function on ℕ
 
 This file defines a simple distance function on naturals from truncated subtraction.
 -/

--- a/Mathlib/MeasureTheory/Integral/RieszMarkovKakutani/Basic.lean
+++ b/Mathlib/MeasureTheory/Integral/RieszMarkovKakutani/Basic.lean
@@ -8,7 +8,7 @@ import Mathlib.Topology.ContinuousMap.CompactlySupported
 import Mathlib.Topology.PartitionOfUnity
 
 /-!
-#  Riesz–Markov–Kakutani representation theorem
+# Riesz–Markov–Kakutani representation theorem
 
 This file prepares technical definitions and results for the Riesz-Markov-Kakutani representation
 theorem on a locally compact T2 space `X`. As a special case, the statements about linear

--- a/Mathlib/MeasureTheory/Integral/RieszMarkovKakutani/NNReal.lean
+++ b/Mathlib/MeasureTheory/Integral/RieszMarkovKakutani/NNReal.lean
@@ -7,7 +7,7 @@ Authors: Yoh Tanimoto
 import Mathlib.MeasureTheory.Integral.RieszMarkovKakutani.Real
 
 /-!
-#  Riesz–Markov–Kakutani representation theorem for `ℝ≥0`
+# Riesz–Markov–Kakutani representation theorem for `ℝ≥0`
 
 This file proves the Riesz-Markov-Kakutani representation theorem on a locally compact
 T2 space `X` for `ℝ≥0`-linear functionals `Λ`.

--- a/Mathlib/RingTheory/MvPowerSeries/NoZeroDivisors.lean
+++ b/Mathlib/RingTheory/MvPowerSeries/NoZeroDivisors.lean
@@ -18,7 +18,7 @@ is itself not a zero divisor
 - `MvPowerSeries.order_mul` : multiplicativity of `MvPowerSeries.order`
   if the semiring `R` has no zero divisors
 
-##  Instance
+## Instance
 
 If `R` has `NoZeroDivisors`, then so does `MvPowerSeries σ R`.
 

--- a/Mathlib/RingTheory/Polynomial/Opposites.lean
+++ b/Mathlib/RingTheory/Polynomial/Opposites.lean
@@ -6,7 +6,7 @@ Authors: Damiano Testa
 import Mathlib.Algebra.Polynomial.Degree.Support
 import Mathlib.Tactic.NoncommRing
 
-/-!  #  Interactions between `R[X]` and `Rᵐᵒᵖ[X]`
+/-! # Interactions between `R[X]` and `Rᵐᵒᵖ[X]`
 
 This file contains the basic API for "pushing through" the isomorphism
 `opRingEquiv : R[X]ᵐᵒᵖ ≃+* Rᵐᵒᵖ[X]`.  It allows going back and forth between a polynomial ring

--- a/Mathlib/RingTheory/PowerSeries/NoZeroDivisors.lean
+++ b/Mathlib/RingTheory/PowerSeries/NoZeroDivisors.lean
@@ -14,7 +14,7 @@ that `R⟦X⟧` is an integral domain when `R` is.
 
 We then state various results about `R⟦X⟧` with `R` an integral domain.
 
-##  Instance
+## Instance
 
 If `R` has `NoZeroDivisors`, then so does `R⟦X⟧`.
 

--- a/Mathlib/Tactic/ComputeDegree.lean
+++ b/Mathlib/Tactic/ComputeDegree.lean
@@ -29,7 +29,7 @@ Lean to try harder to close the goal.
 
 See the doc-strings for more details.
 
-##  Future work
+## Future work
 
 * Currently, `compute_degree` does not deal correctly with some edge cases.  For instance,
   ```lean
@@ -44,7 +44,7 @@ See the doc-strings for more details.
 * Add support for proving goals of the from `natDegree f ≠ 0` and `degree f ≠ 0`.
 * Make sure that `degree`, `natDegree` and `coeff` are equally supported.
 
-##  Implementation details
+## Implementation details
 
 Assume that `f : R[X]` is a polynomial with coefficients in a semiring `R` and
 `d` is either in `ℕ` or in `WithBot ℕ`.
@@ -84,7 +84,7 @@ namespace Mathlib.Tactic.ComputeDegree
 
 section recursion_lemmas
 /-!
-###  Simple lemmas about `natDegree`
+### Simple lemmas about `natDegree`
 
 The lemmas in this section all have the form `natDegree <some form of cast> ≤ 0`.
 Their proofs are weakenings of the stronger lemmas `natDegree <same> = 0`.

--- a/Mathlib/Tactic/DeprecateTo.lean
+++ b/Mathlib/Tactic/DeprecateTo.lean
@@ -10,7 +10,7 @@ import Mathlib.Tactic.Lemma
 import Std.Time.Format
 
 /-!
-#  `deprecate to` -- a deprecation tool
+# `deprecate to` -- a deprecation tool
 
 Writing
 ```lean

--- a/Mathlib/Tactic/ExtendDoc.lean
+++ b/Mathlib/Tactic/ExtendDoc.lean
@@ -9,7 +9,7 @@ import Lean.Elab.ElabRules
 import Lean.DocString
 
 /-!
-#  `extend_doc` command
+# `extend_doc` command
 
 In a file where declaration `decl` is defined, writing
 ```lean

--- a/Mathlib/Tactic/ExtractGoal.lean
+++ b/Mathlib/Tactic/ExtractGoal.lean
@@ -11,7 +11,7 @@ import Batteries.Lean.Meta.Inaccessible
 import Mathlib.Tactic.MinImports
 
 /-!
-#  `extract_goal`: Format the current goal as a stand-alone example
+# `extract_goal`: Format the current goal as a stand-alone example
 
 Useful for testing tactics or creating
 [minimal working examples](https://leanprover-community.github.io/mwe.html).

--- a/Mathlib/Tactic/FindSyntax.lean
+++ b/Mathlib/Tactic/FindSyntax.lean
@@ -8,7 +8,7 @@ import Lean.Elab.Command
 import Mathlib.Init
 
 /-!
-#  The `#find_syntax` command
+# The `#find_syntax` command
 
 The `#find_syntax` command takes as input a string `str` and retrieves from the environment
 all the candidates for `syntax` terms that contain the string `str`.

--- a/Mathlib/Tactic/Linter/CommandRanges.lean
+++ b/Mathlib/Tactic/Linter/CommandRanges.lean
@@ -7,7 +7,7 @@ Authors: Damiano Testa
 import Mathlib.Init -- `import Lean.Elab.Command` is enough
 
 /-!
-#  The "commandRanges" linter
+# The "commandRanges" linter
 
 The "commandRanges" linter simply logs the `getRange?` and the `getRangeWithTrailing?`
 for each command.

--- a/Mathlib/Tactic/Linter/CommandStart.lean
+++ b/Mathlib/Tactic/Linter/CommandStart.lean
@@ -7,7 +7,7 @@ Authors: Damiano Testa
 import Mathlib.Tactic.Linter.Header
 
 /-!
-#  The `commandStart` linter
+# The `commandStart` linter
 
 The `commandStart` linter emits a warning if
 * either a command does not start at the beginning of a line;

--- a/Mathlib/Tactic/Linter/DeprecatedModule.lean
+++ b/Mathlib/Tactic/Linter/DeprecatedModule.lean
@@ -7,7 +7,7 @@ import Std.Time.Format
 import Mathlib.Init
 
 /-!
-#  The `deprecated.module` linter
+# The `deprecated.module` linter
 
 The `deprecated.module` linter emits a warning when a file that has been renamed or split
 is imported.

--- a/Mathlib/Tactic/Linter/DocString.lean
+++ b/Mathlib/Tactic/Linter/DocString.lean
@@ -7,7 +7,7 @@ Authors: Michael Rothgang, Damiano Testa
 import Mathlib.Tactic.Linter.Header
 
 /-!
-#  The "DocString" style linter
+# The "DocString" style linter
 
 The "DocString" linter validates style conventions regarding doc-string formatting.
 -/

--- a/Mathlib/Tactic/Linter/FlexibleLinter.lean
+++ b/Mathlib/Tactic/Linter/FlexibleLinter.lean
@@ -7,7 +7,7 @@ import Lean.Elab.Command
 import Mathlib.Tactic.Linter.Header
 
 /-!
-#  The "flexible" linter
+# The "flexible" linter
 
 The "flexible" linter makes sure that a "rigid" tactic (such as `rw`) does not act on the
 output of a "flexible" tactic (such as `simp`).
@@ -117,7 +117,7 @@ section goals_heuristic
 namespace Lean.Elab.TacticInfo
 
 /-!
-###  Heuristics for determining goals that a tactic modifies and what they become
+### Heuristics for determining goals that a tactic modifies and what they become
 
 The two definitions `goalsTargetedBy`, `goalsCreatedBy` extract a list of
 `MVarId`s attempting to determine on which goals the tactic `t` is acting and what are the

--- a/Mathlib/Tactic/Linter/HaveLetLinter.lean
+++ b/Mathlib/Tactic/Linter/HaveLetLinter.lean
@@ -10,7 +10,7 @@ import Lean.Server.InfoUtils
 import Mathlib.Tactic.DeclarationNames
 
 /-!
-#  The `have` vs `let` linter
+# The `have` vs `let` linter
 
 The `have` vs `let` linter flags uses of `have` to introduce a hypothesis whose Type is not `Prop`.
 

--- a/Mathlib/Tactic/Linter/Header.lean
+++ b/Mathlib/Tactic/Linter/Header.lean
@@ -8,7 +8,7 @@ import Lean.Elab.ParseImportsFast
 import Mathlib.Tactic.Linter.DirectoryDependency
 
 /-!
-#  The "header" linter
+# The "header" linter
 
 The "header" style linter checks that a file starts with
 ```

--- a/Mathlib/Tactic/Linter/Lint.lean
+++ b/Mathlib/Tactic/Linter/Lint.lean
@@ -52,7 +52,7 @@ end Batteries.Tactic.Lint
 namespace Mathlib.Linter
 
 /-!
-#  `dupNamespace` linter
+# `dupNamespace` linter
 
 The `dupNamespace` linter produces a warning when a declaration contains the same namespace
 at least twice consecutively.

--- a/Mathlib/Tactic/Linter/MinImports.lean
+++ b/Mathlib/Tactic/Linter/MinImports.lean
@@ -21,7 +21,7 @@ This is better suited, for instance, to split files.
 open Lean Elab Command Linter
 
 /-!
-#  The "minImports" linter
+# The "minImports" linter
 
 The "minImports" linter tracks information about minimal imports over several commands.
 -/

--- a/Mathlib/Tactic/Linter/Multigoal.lean
+++ b/Mathlib/Tactic/Linter/Multigoal.lean
@@ -9,7 +9,7 @@ import Lean.Elab.Command
 import Mathlib.Tactic.Linter.Header
 
 /-!
-#  The "multiGoal" linter
+# The "multiGoal" linter
 
 The "multiGoal" linter emits a warning where there is more than a single goal in scope.
 There is an exception: a tactic that closes *all* remaining goals is allowed.

--- a/Mathlib/Tactic/Linter/PPRoundtrip.lean
+++ b/Mathlib/Tactic/Linter/PPRoundtrip.lean
@@ -8,7 +8,7 @@ import Lean.Elab.Command
 import Mathlib.Init
 
 /-!
-#  The "ppRoundtrip" linter
+# The "ppRoundtrip" linter
 
 The "ppRoundtrip" linter emits a warning when the syntax of a command differs substantially
 from the pretty-printed version of itself.

--- a/Mathlib/Tactic/Linter/Style.lean
+++ b/Mathlib/Tactic/Linter/Style.lean
@@ -310,7 +310,7 @@ initialize addLinter lambdaSyntaxLinter
 end Style.lambdaSyntax
 
 /-!
-#  The "longFile" linter
+# The "longFile" linter
 
 The "longFile" linter emits a warning on files which are longer than a certain number of lines
 (1500 by default).

--- a/Mathlib/Tactic/Linter/UnusedTactic.lean
+++ b/Mathlib/Tactic/Linter/UnusedTactic.lean
@@ -49,7 +49,7 @@ before and after and see if there is some change.
 ## TODO
 * The linter seems to be silenced by `set_option ... in`: maybe it should enter `in`s?
 
-##  Implementation notes
+## Implementation notes
 
 Yet another linter copied from the `unreachableTactic` linter!
 -/

--- a/Mathlib/Tactic/MoveAdd.lean
+++ b/Mathlib/Tactic/MoveAdd.lean
@@ -9,7 +9,7 @@ import Mathlib.Order.Defs.LinearOrder
 
 /-!
 
-#  `move_add` a tactic for moving summands in expressions
+# `move_add` a tactic for moving summands in expressions
 
 The tactic `move_add` rearranges summands in expressions.
 
@@ -125,7 +125,7 @@ section reorder
 variable {α : Type*} [BEq α]
 
 /-!
-##  Reordering the variables
+## Reordering the variables
 
 This section produces the permutations of the variables for `move_add`.
 

--- a/Mathlib/Util/CountHeartbeats.lean
+++ b/Mathlib/Util/CountHeartbeats.lean
@@ -203,7 +203,7 @@ end CountHeartbeats
 end Mathlib
 
 /-!
-#  The "countHeartbeats" linter
+# The "countHeartbeats" linter
 
 The "countHeartbeats" linter counts the heartbeats of every declaration.
 -/

--- a/MathlibTest/MoveAdd.lean
+++ b/MathlibTest/MoveAdd.lean
@@ -77,7 +77,7 @@ example {R : Type u} [Add R] [CommSemigroup R] {a b c d e f g : R} :
   rfl
 
 /-
-#  Sample usage of `move_oper`
+# Sample usage of `move_oper`
 -/
 
 example (a b c : Prop) : a ∧ b ∧ c ↔ b ∧ c ∧ a := by

--- a/scripts/create_deprecated_modules.lean
+++ b/scripts/create_deprecated_modules.lean
@@ -11,7 +11,7 @@ import Lean.Meta.Tactic.TryThis
 -- a comment here to test `keepTrailing
 
 /-!
-#  Create a deprecated module
+# Create a deprecated module
 
 This file defines the lean script for creating a deprecated module.
 -/

--- a/scripts/declarations_diff.sh
+++ b/scripts/declarations_diff.sh
@@ -2,7 +2,7 @@
 
  : <<'BASH_DOC_MODULE'
 
-#  The `declarations_diff` script
+# The `declarations_diff` script
 
 The `declarations_diff` script is a text-based script that attempts to find which declarations
 have been removed and which declarations have been added in the current PR with respect to `master`.


### PR DESCRIPTION
This PR removes superfluous white-space in the markdown headers of the docs: remove repeated spaces before a `#`, or between it and the actual heading.

I've tried to figure out whether there exists subtle reasons why one might want to have more than one space after the #-symbol, but I've been unable to find any.

---

I first noticed these extra spaces while working on other doc-related cleanup work.

<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include at least one commit authored by each
co-author among the commits in the pull request. If necessary, you may 
create empty commits to indicate co-authorship, using commands like so:

git commit --author="Author Name <author@email.com>" --allow-empty -m "add Author Name as coauthor"

When merging, all the commits will be squashed into a single commit listing all co-authors.

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
