### PR TITLE
feat(Topology/UniformSpace): define the Hausdorff uniformity

### DIFF
--- a/Mathlib.lean
+++ b/Mathlib.lean
@@ -6973,6 +6973,7 @@ import Mathlib.Topology.UniformSpace.AbstractCompletion
 import Mathlib.Topology.UniformSpace.Ascoli
 import Mathlib.Topology.UniformSpace.Basic
 import Mathlib.Topology.UniformSpace.Cauchy
+import Mathlib.Topology.UniformSpace.Closeds
 import Mathlib.Topology.UniformSpace.Compact
 import Mathlib.Topology.UniformSpace.CompactConvergence
 import Mathlib.Topology.UniformSpace.CompareReals

--- a/Mathlib/Topology/MetricSpace/Thickening.lean
+++ b/Mathlib/Topology/MetricSpace/Thickening.lean
@@ -160,6 +160,14 @@ theorem thickening_eq_biUnion_ball {δ : ℝ} {E : Set X} : thickening δ E = �
   simp only [mem_iUnion₂, exists_prop]
   exact mem_thickening_iff
 
+theorem thickening_eq_thickening (δ : ℝ) (E : Set X) :
+    UniformSpace.thickening {p | dist p.2 p.1 < δ} E = thickening δ E := by
+  simp only [thickening_eq_biUnion_ball, UniformSpace.thickening, ball_eq_ball]
+
+theorem thickening_eq_thickening' (δ : ℝ) (E : Set X) :
+    UniformSpace.thickening {p | dist p.1 p.2 < δ} E = thickening δ E := by
+  simp only [thickening_eq_biUnion_ball, UniformSpace.thickening, ball_eq_ball']
+
 protected theorem _root_.Bornology.IsBounded.thickening {δ : ℝ} {E : Set X} (h : IsBounded E) :
     IsBounded (thickening δ E) := by
   rcases E.eq_empty_or_nonempty with rfl | ⟨x, hx⟩

--- a/Mathlib/Topology/Sets/Compacts.lean
+++ b/Mathlib/Topology/Sets/Compacts.lean
@@ -204,9 +204,15 @@ protected theorem isCompact (s : NonemptyCompacts α) : IsCompact (s : Set α) :
 protected theorem nonempty (s : NonemptyCompacts α) : (s : Set α).Nonempty :=
   s.nonempty'
 
+theorem toCompacts_injective : Function.Injective (toCompacts (α := α)) :=
+  .of_comp (f := SetLike.coe) SetLike.coe_injective
+
 /-- Reinterpret a nonempty compact as a closed set. -/
 def toCloseds [T2Space α] (s : NonemptyCompacts α) : Closeds α :=
   ⟨s, s.isCompact.isClosed⟩
+
+theorem toCloseds_injective [T2Space α] : Function.Injective (toCloseds (α := α)) :=
+  .of_comp (f := SetLike.coe) SetLike.coe_injective
 
 @[ext]
 protected theorem ext {s t : NonemptyCompacts α} (h : (s : Set α) = t) : s = t :=

--- a/Mathlib/Topology/UniformSpace/Basic.lean
+++ b/Mathlib/Topology/UniformSpace/Basic.lean
@@ -92,6 +92,9 @@ lemma isOpen_ball (x : α) {V : Set (α × α)} (hV : IsOpen V) : IsOpen (ball x
 lemma isClosed_ball (x : α) {V : Set (α × α)} (hV : IsClosed V) : IsClosed (ball x V) :=
   hV.preimage <| .prodMk_right _
 
+theorem isOpen_thickening {V : Set (α × α)} {s : Set α} (h : IsOpen V) : IsOpen (thickening V s) :=
+  isOpen_biUnion fun _ _ => isOpen_ball _ h
+
 /-!
 ### Neighborhoods in uniform spaces
 -/

--- a/Mathlib/Topology/UniformSpace/Closeds.lean
+++ b/Mathlib/Topology/UniformSpace/Closeds.lean
@@ -1,0 +1,186 @@
+/-
+Copyright (c) 2025 Attila Gáspár. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Attila Gáspár
+-/
+import Mathlib.Topology.Sets.Compacts
+import Mathlib.Topology.UniformSpace.UniformEmbedding
+
+/-!
+# Hausdorff uniformity
+
+This file defines the Hausdorff uniformity on the types of closed subsets, compact subsets and
+and nonempty compact subsets of a uniform space. This is the generalization of the uniformity
+induced by the Hausdorff metric to hyperspaces of uniform spaces.
+-/
+
+open UniformSpace
+open scoped Uniformity
+
+section
+
+variable {α : Type*} {S : Type*} [SetLike S α]
+
+/-- The set of pairs of sets contained in each other's thickening with respect to an entourage.
+These are the generators of the Hausdorff uniformity. -/
+def hausdorffEntourage (U : Set (α × α)) : Set (S × S) :=
+  {x | ↑x.1 ⊆ thickening U x.2 ∧ ↑x.2 ⊆ thickening U x.1}
+
+theorem isSymmetricRel_hausdorffEntourage (U : Set (α × α)) :
+    IsSymmetricRel (hausdorffEntourage (S := S) U) :=
+  Set.ext fun _ => And.comm
+
+theorem refl_mem_hausdorffEntourage {U : Set (α × α)} (hU : ∀ x, (x, x) ∈ U) (s : S) :
+    (s, s) ∈ hausdorffEntourage U :=
+  ⟨self_subset_thickening_of_refl _ fun x _ => hU x,
+    self_subset_thickening_of_refl _ fun x _ => hU x⟩
+
+@[gcongr]
+theorem hausdorffEntourage_mono {U V : Set (α × α)} (h : U ⊆ V) :
+    hausdorffEntourage (S := S) U ⊆ hausdorffEntourage V := by
+  unfold hausdorffEntourage
+  gcongr
+
+theorem monotone_hausdorffEntourage : Monotone (hausdorffEntourage (S := S)) :=
+  fun _ _ => hausdorffEntourage_mono
+
+namespace UniformSpace
+
+variable [UniformSpace α]
+
+/-- The Hausdorff uniformity on a family of subsets of a uniform space.
+See note [reducible non-instances]. -/
+protected abbrev hausdorff : UniformSpace S := .ofCore
+  { uniformity := (𝓤 α).lift' hausdorffEntourage
+    refl := by
+      simp_rw [Filter.principal_le_lift', idRel_subset]
+      exact fun U hU => refl_mem_hausdorffEntourage fun _ => refl_mem_uniformity hU
+    symm := by
+      rw [Filter.tendsto_lift']
+      intro U hU
+      filter_upwards [Filter.mem_lift' hU] with _ _
+      rwa [← Set.mem_preimage, isSymmetricRel_hausdorffEntourage]
+    comp := by
+      rw [Filter.le_lift']
+      intro U hU
+      obtain ⟨V, hV₁, hV₂⟩ := comp_mem_uniformity_sets hU
+      refine Filter.mem_of_superset (Filter.mem_lift' (Filter.mem_lift' hV₁)) ?_
+      intro ⟨s, u⟩ ⟨t, ⟨hst, hts⟩, ⟨htu, hut⟩⟩
+      dsimp only at *
+      grw [hts, thickening_thickening_subset, hV₂] at hut
+      grw [htu, thickening_thickening_subset, hV₂] at hst
+      exact ⟨hst, hut⟩ }
+
+theorem hausdorff.isClosed_disjoint_of_isOpen
+    [t : UniformSpace S] (ht : t = .hausdorff) {U : Set α} (hU : IsOpen U) :
+    IsClosed {s : S | Disjoint (s : Set α) U} := by
+  simp_rw [← isOpen_compl_iff, isOpen_iff_mem_nhds, Set.compl_setOf, Set.not_disjoint_iff]
+  intro s ⟨x, hx₁, hx₂⟩
+  rw [← hU.mem_nhds_iff, mem_nhds_iff_symm] at hx₂
+  obtain ⟨V, hV₁, hV₂, hV₃⟩ := hx₂
+  rw [mem_nhds_iff]
+  subst t
+  refine ⟨_, Filter.mem_lift' hV₁, ?_⟩
+  rintro s' ⟨hs', -⟩
+  obtain ⟨y, hy₁, hy₂⟩ := Set.mem_iUnion₂.mp <| hs' hx₁
+  rw [mem_ball_symmetry hV₂] at hy₂
+  exact ⟨y, hy₁, hV₃ hy₂⟩
+
+theorem hausdorff.isClosed_subsets_of_isClosed
+    [t : UniformSpace S] (ht : t = .hausdorff) {F : Set α} (hF : IsClosed F) :
+    IsClosed {s : S | (s : Set α) ⊆ F} := by
+  simp_rw [← Set.disjoint_compl_right_iff_subset]
+  exact isClosed_disjoint_of_isOpen ht hF.isOpen_compl
+
+end UniformSpace
+
+end
+
+variable {α : Type*} [UniformSpace α]
+
+namespace TopologicalSpace.Closeds
+
+instance uniformSpace : UniformSpace (Closeds α) :=
+  .hausdorff
+
+theorem uniformity_def : 𝓤 (Closeds α) = (𝓤 α).lift' hausdorffEntourage :=
+  rfl
+
+theorem _root_.Filter.HasBasis.uniformity_closeds
+    {ι : Sort*} {p : ι → Prop} {s : ι → Set (α × α)}
+    (h : (𝓤 α).HasBasis p s) : (𝓤 (Closeds α)).HasBasis p (hausdorffEntourage ∘ s) :=
+  h.lift' monotone_hausdorffEntourage
+
+theorem isClosed_disjoint_of_isOpen {s : Set α} (hs : IsOpen s) :
+    IsClosed {t : Closeds α | Disjoint (t : Set α) s} :=
+  hausdorff.isClosed_disjoint_of_isOpen rfl hs
+
+theorem isClosed_subsets_of_isClosed {s : Set α} (hs : IsClosed s) :
+    IsClosed {t : Closeds α | (t : Set α) ⊆ s} :=
+  hausdorff.isClosed_subsets_of_isClosed rfl hs
+
+end TopologicalSpace.Closeds
+
+namespace TopologicalSpace.Compacts
+
+instance uniformSpace : UniformSpace (Compacts α) :=
+  .hausdorff
+
+theorem uniformity_def : 𝓤 (Compacts α) = (𝓤 α).lift' hausdorffEntourage :=
+  rfl
+
+theorem _root_.Filter.HasBasis.uniformity_compacts
+    {ι : Sort*} {p : ι → Prop} {s : ι → Set (α × α)}
+    (h : (𝓤 α).HasBasis p s) : (𝓤 (Compacts α)).HasBasis p (hausdorffEntourage ∘ s) :=
+  h.lift' monotone_hausdorffEntourage
+
+theorem isClosed_disjoint_of_isOpen {s : Set α} (hs : IsOpen s) :
+    IsClosed {t : Compacts α | Disjoint (t : Set α) s} :=
+  hausdorff.isClosed_disjoint_of_isOpen rfl hs
+
+theorem isClosed_subsets_of_isClosed {s : Set α} (hs : IsClosed s) :
+    IsClosed {t : Compacts α | (t : Set α) ⊆ s} :=
+  hausdorff.isClosed_subsets_of_isClosed rfl hs
+
+end TopologicalSpace.Compacts
+
+namespace TopologicalSpace.NonemptyCompacts
+
+instance uniformSpace : UniformSpace (NonemptyCompacts α) :=
+  .hausdorff
+
+theorem uniformity_def : 𝓤 (NonemptyCompacts α) = (𝓤 α).lift' hausdorffEntourage :=
+  rfl
+
+theorem _root_.Filter.HasBasis.uniformity_nonemptyCompacts
+    {ι : Sort*} {p : ι → Prop} {s : ι → Set (α × α)}
+    (h : (𝓤 α).HasBasis p s) : (𝓤 (NonemptyCompacts α)).HasBasis p (hausdorffEntourage ∘ s) :=
+  h.lift' monotone_hausdorffEntourage
+
+theorem isUniformEmbedding_toCloseds [T2Space α] :
+    IsUniformEmbedding (toCloseds (α := α)) where
+  injective := toCloseds_injective
+  comap_uniformity := Filter.comap_lift'_eq
+
+theorem continuous_toCloseds [T2Space α] :
+    Continuous (toCloseds (α := α)) :=
+  isUniformEmbedding_toCloseds.uniformContinuous.continuous
+
+theorem isUniformEmbedding_toCompacts :
+    IsUniformEmbedding (toCompacts (α := α)) where
+  injective := toCompacts_injective
+  comap_uniformity := Filter.comap_lift'_eq
+
+theorem continuous_toCompacts :
+    Continuous (toCompacts (α := α)) :=
+  isUniformEmbedding_toCompacts.uniformContinuous.continuous
+
+theorem isClosed_disjoint_of_isOpen {s : Set α} (hs : IsOpen s) :
+    IsClosed {t : NonemptyCompacts α | Disjoint (t : Set α) s} :=
+  hausdorff.isClosed_disjoint_of_isOpen rfl hs
+
+theorem isClosed_subsets_of_isClosed {s : Set α} (hs : IsClosed s) :
+    IsClosed {t : NonemptyCompacts α | (t : Set α) ⊆ s} :=
+  hausdorff.isClosed_subsets_of_isClosed rfl hs
+
+end TopologicalSpace.NonemptyCompacts

--- a/Mathlib/Topology/UniformSpace/Defs.lean
+++ b/Mathlib/Topology/UniformSpace/Defs.lean
@@ -631,6 +631,70 @@ theorem mem_comp_comp {V W M : Set (β × β)} (hW' : IsSymmetricRel W) {p : β 
     rw [mem_ball_symmetry hW'] at z_in
     exact ⟨z, ⟨w, w_in, hwz⟩, z_in⟩
 
+/-- The thickening of a set with respect to `V : Set (β × β)`. Recovers the notion of metric
+thickening when `V = {p | dist p.1 p.2 < r}`. -/
+def thickening (V : Set (β × β)) (s : Set β) : Set β := ⋃ x ∈ s, ball x V
+
+@[simp]
+theorem thickening_empty (V : Set (β × β)) : thickening V ∅ = ∅ := by
+  simp [thickening]
+
+@[simp]
+theorem thickening_singleton (V : Set (β × β)) (x : β) : thickening V {x} = ball x V :=
+  Set.biUnion_singleton _ _
+
+@[simp]
+theorem thickening_union (V : Set (β × β)) (s t : Set β) :
+    thickening V (s ∪ t) = thickening V s ∪ thickening V t :=
+  Set.biUnion_union _ _ _
+
+@[simp]
+theorem thickening_iUnion {ι : Sort*} (V : Set (β × β)) (f : ι → Set β) :
+    thickening V (⋃ (i : ι), f i) = ⋃ (i : ι), thickening V (f i) :=
+  Set.biUnion_iUnion _ _
+
+theorem thickening_biUnion {ι : Type*} (V : Set (β × β)) (f : ι → Set β) (I : Set ι) :
+    thickening V (⋃ i ∈ I, f i) = ⋃ i ∈ I, thickening V (f i) := by simp
+
+@[gcongr]
+theorem thickening_mono {V W : Set (β × β)} (h : V ⊆ W) (s : Set β) :
+    thickening V s ⊆ thickening W s :=
+  Set.iUnion₂_mono fun _ _ => ball_mono h _
+
+theorem ball_subset_thickening {x : β} {s : Set β} (hx : x ∈ s) (V : Set (β × β)) :
+    ball x V ⊆ thickening V s :=
+  Set.subset_biUnion_of_mem (u := (ball · V)) hx
+
+@[gcongr]
+theorem thickening_subset_of_subset (V : Set (β × β)) {s t : Set β} (h : s ⊆ t) :
+    thickening V s ⊆ thickening V t :=
+  Set.biUnion_subset_biUnion_left h
+
+theorem thickening_thickening_subset (V W : Set (β × β)) (s : Set β) :
+    thickening V (thickening W s) ⊆ thickening (W ○ V) s := by
+  intro
+  simp only [thickening, Set.mem_iUnion, ball, compRel]
+  grind
+
+theorem thickening_ball (x : β) (V W : Set (β × β)) : thickening V (ball x W) ⊆ ball x (W ○ V) := by
+  simp_rw [← thickening_singleton]
+  exact thickening_thickening_subset _ _ _
+
+theorem self_subset_thickening_of_refl {V : Set (β × β)} (s : Set β) (hV : ∀ x ∈ s, (x, x) ∈ V) :
+    s ⊆ thickening V s :=
+  fun x hx => Set.mem_biUnion hx (hV x hx)
+
+theorem self_subset_thickening {V : Set (α × α)} (hV : V ∈ 𝓤 α) (s : Set α) :
+    s ⊆ thickening V s :=
+  self_subset_thickening_of_refl _ fun _ _ => refl_mem_uniformity hV
+
+theorem closure_subset_thickening {V : Set (α × α)} (hV : V ∈ 𝓤 α) (s : Set α) :
+    closure s ⊆ thickening V s := by
+  intro x hx
+  simp_rw [mem_closure_iff_nhds, nhds_eq_comap_uniformity] at hx
+  obtain ⟨y, hy₁, hy₂⟩ := hx _ <| Filter.preimage_mem_comap <| UniformSpace.symm hV
+  exact Set.mem_biUnion hy₂ hy₁
+
 end UniformSpace
 
 /-!


### PR DESCRIPTION
This PR defines the Hausdorff uniformity on `Closeds`, `Compacts` and `NonemptyCompacts`. Since `Closeds` and `NonemptyCompacts` already have metrics, they are changed to use the newly defined uniformity.

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include at least one commit authored by each
co-author among the commits in the pull request. If necessary, you may 
create empty commits to indicate co-authorship, using commands like so:

git commit --author="Author Name <author@email.com>" --allow-empty -m "add Author Name as coauthor"

When merging, all the commits will be squashed into a single commit listing all co-authors.

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

- [ ] depends on: #30756

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)