### PR TITLE
feat(Tactic): add set_default_numeral_type command

### DIFF
--- a/Mathlib/Tactic/Common.lean
+++ b/Mathlib/Tactic/Common.lean
@@ -46,6 +46,7 @@ import Mathlib.Tactic.Contrapose
 import Mathlib.Tactic.Conv
 import Mathlib.Tactic.Convert
 import Mathlib.Tactic.DefEqTransformations
+import Mathlib.Tactic.DefaultNumeralType
 import Mathlib.Tactic.DeprecateTo
 import Mathlib.Tactic.ErwQuestion
 import Mathlib.Tactic.Eqns

--- a/Mathlib/Tactic/DefaultNumeralType.lean
+++ b/Mathlib/Tactic/DefaultNumeralType.lean
@@ -1,5 +1,5 @@
 /-
-Copyright (c) 2025 Mathlib Contributors. All rights reserved.
+Copyright (c) 2025 LEAN FRO, LLC. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Claude Code
 -/
@@ -83,8 +83,6 @@ def elabSetDefaultNumeralType : CommandElab := fun stx => do
     -- Add the default_instance attribute to this instance by running an attribute command
     let attrCmd ← `(command| attribute [default_instance] $(mkIdent instName))
     elabCommand attrCmd
-
-    logInfo m!"Set default numeral type to {α} using instance {instName}"
 
   | _ => throwUnsupportedSyntax
 

--- a/Mathlib/Tactic/DefaultNumeralType.lean
+++ b/Mathlib/Tactic/DefaultNumeralType.lean
@@ -62,10 +62,12 @@ def elabSetDefaultNumeralType : CommandElab := fun stx => do
     let α ← liftTermElabM do
       Term.elabType typ
 
-    -- Try to synthesize an OfNat instance for this type with a concrete numeral (1)
-    -- The instance type is: OfNat α 1
+    -- Try to synthesize an OfNat instance for this type
+    -- The instance type is: ∀ (n : Nat), OfNat α n
     let ofNatType ← liftTermElabM do
-      mkAppM ``OfNat #[α, mkNatLit 1]
+      withLocalDeclD `n (mkConst ``Nat) fun n => do
+        let body ← mkAppM ``OfNat #[α, n]
+        mkForallFVars #[n] body
 
     let inst ← liftTermElabM do
       try

--- a/Mathlib/Tactic/DefaultNumeralType.lean
+++ b/Mathlib/Tactic/DefaultNumeralType.lean
@@ -1,0 +1,91 @@
+/-
+Copyright (c) 2025 Mathlib Contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Claude Code
+-/
+import Lean
+
+/-!
+# `set_default_numeral_type` command
+
+This file provides a command to set the default type for numeric literals
+without needing to know the instance name.
+
+## Main declarations
+
+* `set_default_numeral_type α`: Sets numeric literals to default to type `α` by finding
+  the appropriate `OfNat` instance and marking it with the `default_instance` attribute.
+
+## Example
+
+```lean
+set_default_numeral_type Rat
+
+#check 1  -- 1 : Rat
+```
+-/
+
+open Lean Elab Command Meta
+
+namespace Mathlib.Tactic.DefaultNumeralType
+
+/-- Syntax for the `set_default_numeral_type` command. -/
+syntax (name := setDefaultNumeralType) "set_default_numeral_type " term : command
+
+/--
+`set_default_numeral_type α` sets numeric literals to default to type `α`.
+
+This command finds the `OfNat` instance for type `α` and marks it with the
+`default_instance` attribute, so that numeric literals like `1`, `42`, etc.
+will be interpreted as having type `α` by default.
+
+Example:
+```lean
+set_default_numeral_type Rat
+
+#check 1  -- 1 : Rat
+```
+
+This is equivalent to manually writing:
+```lean
+attribute [default_instance] Rat.instOfNat
+```
+but you don't need to know the instance name.
+
+Note: You can reset to the default behavior by running `set_default_numeral_type Nat`.
+-/
+@[command_elab setDefaultNumeralType]
+def elabSetDefaultNumeralType : CommandElab := fun stx => do
+  match stx with
+  | `(set_default_numeral_type $typ) => do
+    -- Elaborate the type
+    let α ← liftTermElabM do
+      Term.elabType typ
+
+    -- Try to synthesize an OfNat instance for this type with a concrete numeral (1)
+    -- The instance type is: OfNat α 1
+    let ofNatType ← liftTermElabM do
+      mkAppM ``OfNat #[α, mkNatLit 1]
+
+    let inst ← liftTermElabM do
+      try
+        synthInstance ofNatType
+      catch e =>
+        throwError "Could not find OfNat instance for type {α}\nError: {e.toMessageData}"
+
+    -- Extract the instance name from the synthesized instance
+    -- The instance should be a constant or an application of a constant
+    let instName := inst.getAppFn.constName?.getD default
+
+    if instName.isAnonymous then
+      throwError "Could not determine instance name for OfNat instance of {α}"
+
+    -- Add the default_instance attribute to this instance by running an attribute command
+    let attrCmd ← `(command| attribute [default_instance] $(mkIdent instName))
+    elabCommand attrCmd
+
+    logInfo m!"Set default numeral type to {α} using instance {instName}"
+
+  | _ => throwUnsupportedSyntax
+
+end Mathlib.Tactic.DefaultNumeralType

--- a/MathlibTest/DefaultNumeralType.lean
+++ b/MathlibTest/DefaultNumeralType.lean
@@ -1,9 +1,8 @@
 /-
-Copyright (c) 2025 Mathlib Contributors. All rights reserved.
+Copyright (c) 2025 LEAN FRO, LLC. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Claude Code
 -/
-import Mathlib.Tactic.DefaultNumeralType
 import Mathlib.Data.Rat.Defs
 
 /-!
@@ -14,19 +13,19 @@ way to set the default type for numeric literals without needing to know the ins
 -/
 
 -- Test with Rat (Rational numbers)
-set_default_numeral_type Rat
+set_default_numeral_type ℚ
 
-/-- info: 1 : Rat -/
+/-- info: 1 : ℚ -/
 #guard_msgs in
 #check 1
 
-/-- info: 42 : Rat -/
+/-- info: 42 : ℚ -/
 #guard_msgs in
 #check 42
 
 -- Reset to default (Nat)
-set_default_numeral_type Nat
+set_default_numeral_type ℕ
 
-/-- info: 1 : Nat -/
+/-- info: 1 : ℕ -/
 #guard_msgs in
 #check 1

--- a/MathlibTest/DefaultNumeralType.lean
+++ b/MathlibTest/DefaultNumeralType.lean
@@ -1,0 +1,32 @@
+/-
+Copyright (c) 2025 Mathlib Contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Claude Code
+-/
+import Mathlib.Tactic.DefaultNumeralType
+import Mathlib.Data.Rat.Defs
+
+/-!
+# Tests for `set_default_numeral_type`
+
+This file tests the `set_default_numeral_type` command which provides a user-friendly
+way to set the default type for numeric literals without needing to know the instance name.
+-/
+
+-- Test with Rat (Rational numbers)
+set_default_numeral_type Rat
+
+/-- info: 1 : Rat -/
+#guard_msgs in
+#check 1
+
+/-- info: 42 : Rat -/
+#guard_msgs in
+#check 42
+
+-- Reset to default (Nat)
+set_default_numeral_type Nat
+
+/-- info: 1 : Nat -/
+#guard_msgs in
+#check 1


### PR DESCRIPTION
## Summary

- Adds a new `set_default_numeral_type` command that provides a user-friendly way to set default types for numeric literals
- Users can now write `set_default_numeral_type ℚ` instead of needing to know the instance name (e.g., `attribute [default_instance] Rat.instOfNat`)
- The command automatically finds the appropriate `OfNat` instance and marks it with the `default_instance` attribute
- Includes comprehensive tests demonstrating the functionality with rational numbers

## Changes

- **Mathlib/Tactic/DefaultNumeralType.lean**: New file implementing the command
- **Mathlib/Tactic/Common.lean**: Export the new tactic
- **MathlibTest/DefaultNumeralType.lean**: Test file with examples

## Example Usage

```lean
set_default_numeral_type ℚ
#check 1  -- 1 : ℚ

set_default_numeral_type ℕ  -- reset to default
#check 1  -- 1 : ℕ
```

## Test plan

- [x] Tests pass in MathlibTest/DefaultNumeralType.lean
- [x] Command correctly sets default numeral type for Rat
- [x] Command correctly resets to Nat
- [x] Guard messages verify expected types

🤖 Generated with [Claude Code](https://claude.com/claude-code)