### PR TITLE
reorder inheritance for Normed*

### DIFF
--- a/Mathlib/Analysis/Matrix.lean
+++ b/Mathlib/Analysis/Matrix.lean
@@ -658,8 +658,7 @@ declared as an instance because there are several natural choices for defining t
 matrix. -/
 @[local instance]
 def frobeniusNormedRing [DecidableEq m] : NormedRing (Matrix m m α) :=
-  { Matrix.frobeniusSeminormedAddCommGroup, Matrix.instRing with
-    norm := Norm.norm
+  { Matrix.instRing, Matrix.frobeniusSeminormedAddCommGroup with
     norm_mul_le := frobenius_norm_mul
     eq_of_dist_eq_zero := eq_of_dist_eq_zero }
 

--- a/Mathlib/Analysis/Normed/Algebra/TrivSqZeroExt.lean
+++ b/Mathlib/Analysis/Normed/Algebra/TrivSqZeroExt.lean
@@ -219,6 +219,8 @@ variable [Module R M] [IsBoundedSMul R M] [Module Rᵐᵒᵖ M] [IsBoundedSMul R
   [SMulCommClass R Rᵐᵒᵖ M]
 
 instance instL1SeminormedRing : SeminormedRing (tsze R M) where
+  __ : Ring (tsze R M) := inferInstance
+  __ : SeminormedAddCommGroup (tsze R M) := inferInstance
   norm_mul_le
   | ⟨r₁, m₁⟩, ⟨r₂, m₂⟩ => by
     simp_rw [norm_def]
@@ -232,8 +234,6 @@ instance instL1SeminormedRing : SeminormedRing (tsze R M) where
       apply le_add_of_nonneg_right
       positivity
     _ = (‖r₁‖ + ‖m₁‖) * (‖r₂‖ + ‖m₂‖) := by ring
-  __ : SeminormedAddCommGroup (tsze R M) := inferInstance
-  __ : Ring (tsze R M) := inferInstance
 
 instance instL1IsBoundedSMul : IsBoundedSMul S (tsze R M) :=
   inferInstanceAs <| IsBoundedSMul S (WithLp 1 <| R × M)
@@ -269,8 +269,8 @@ instance instL1NormedAddCommGroup : NormedAddCommGroup (tsze R M) :=
   inferInstanceAs <| NormedAddCommGroup (WithLp 1 <| R × M)
 
 instance instL1NormedRing : NormedRing (tsze R M) where
-  __ : NormedAddCommGroup (tsze R M) := inferInstance
   __ : SeminormedRing (tsze R M) := inferInstance
+  __ : NormedAddCommGroup (tsze R M) := inferInstance
 
 end Ring
 

--- a/Mathlib/Analysis/Normed/Field/Basic.lean
+++ b/Mathlib/Analysis/Normed/Field/Basic.lean
@@ -33,7 +33,7 @@ open scoped Topology NNReal ENNReal
 
 /-- A normed division ring is a division ring endowed with a seminorm which satisfies the equality
 `‖x y‖ = ‖x‖ ‖y‖`. -/
-class NormedDivisionRing (α : Type*) extends Norm α, DivisionRing α, MetricSpace α where
+class NormedDivisionRing (α : Type*) extends DivisionRing α, Norm α, MetricSpace α where
   /-- The distance is induced by the norm. -/
   dist_eq : ∀ x y, dist x y = norm (x - y)
   /-- The norm is multiplicative. -/
@@ -145,7 +145,7 @@ end NormedDivisionRing
 end NormedDivisionRing
 
 /-- A normed field is a field with a norm satisfying ‖x y‖ = ‖x‖ ‖y‖. -/
-class NormedField (α : Type*) extends Norm α, Field α, MetricSpace α where
+class NormedField (α : Type*) extends Field α, Norm α, MetricSpace α where
   /-- The distance is induced by the norm. -/
   dist_eq : ∀ x y, dist x y = norm (x - y)
   /-- The norm is multiplicative. -/
@@ -291,9 +291,10 @@ def NontriviallyNormedField.ofNormNeOne {𝕜 : Type*} [h' : NormedField 𝕜]
       exact (one_lt_inv₀ (norm_pos_iff.2 hx)).2 hlt
     · exact ⟨x, hlt⟩
 
-noncomputable instance Real.normedField : NormedField ℝ :=
-  { Real.normedAddCommGroup, Real.instField with
-    norm_mul := abs_mul }
+noncomputable instance Real.normedField : NormedField ℝ where
+  __ := Real.instField
+  __ := Real.normedAddCommGroup
+  norm_mul := abs_mul
 
 noncomputable instance Real.denselyNormedField : DenselyNormedField ℝ where
   lt_norm_lt _ _ h₀ hr :=

--- a/Mathlib/Analysis/Normed/Group/Basic.lean
+++ b/Mathlib/Analysis/Normed/Group/Basic.lean
@@ -160,7 +160,7 @@ class ENormedCommMonoid (E : Type*) [TopologicalSpace E]
 
 /-- A seminormed group is an additive group endowed with a norm for which `dist x y = ‖x - y‖`
 defines a pseudometric space structure. -/
-class SeminormedAddGroup (E : Type*) extends Norm E, AddGroup E, PseudoMetricSpace E where
+class SeminormedAddGroup (E : Type*) extends AddGroup E, Norm E, PseudoMetricSpace E where
   dist := fun x y => ‖x - y‖
   /-- The distance function is induced by the norm. -/
   dist_eq : ∀ x y, dist x y = ‖x - y‖ := by aesop
@@ -168,14 +168,14 @@ class SeminormedAddGroup (E : Type*) extends Norm E, AddGroup E, PseudoMetricSpa
 /-- A seminormed group is a group endowed with a norm for which `dist x y = ‖x / y‖` defines a
 pseudometric space structure. -/
 @[to_additive]
-class SeminormedGroup (E : Type*) extends Norm E, Group E, PseudoMetricSpace E where
+class SeminormedGroup (E : Type*) extends Group E, Norm E, PseudoMetricSpace E where
   dist := fun x y => ‖x / y‖
   /-- The distance function is induced by the norm. -/
   dist_eq : ∀ x y, dist x y = ‖x / y‖ := by aesop
 
 /-- A normed group is an additive group endowed with a norm for which `dist x y = ‖x - y‖` defines a
 metric space structure. -/
-class NormedAddGroup (E : Type*) extends Norm E, AddGroup E, MetricSpace E where
+class NormedAddGroup (E : Type*) extends AddGroup E, Norm E, MetricSpace E where
   dist := fun x y => ‖x - y‖
   /-- The distance function is induced by the norm. -/
   dist_eq : ∀ x y, dist x y = ‖x - y‖ := by aesop
@@ -183,15 +183,14 @@ class NormedAddGroup (E : Type*) extends Norm E, AddGroup E, MetricSpace E where
 /-- A normed group is a group endowed with a norm for which `dist x y = ‖x / y‖` defines a metric
 space structure. -/
 @[to_additive]
-class NormedGroup (E : Type*) extends Norm E, Group E, MetricSpace E where
+class NormedGroup (E : Type*) extends Group E, Norm E, MetricSpace E where
   dist := fun x y => ‖x / y‖
   /-- The distance function is induced by the norm. -/
   dist_eq : ∀ x y, dist x y = ‖x / y‖ := by aesop
 
 /-- A seminormed group is an additive group endowed with a norm for which `dist x y = ‖x - y‖`
 defines a pseudometric space structure. -/
-class SeminormedAddCommGroup (E : Type*) extends Norm E, AddCommGroup E,
-  PseudoMetricSpace E where
+class SeminormedAddCommGroup (E : Type*) extends AddCommGroup E, Norm E, PseudoMetricSpace E where
   dist := fun x y => ‖x - y‖
   /-- The distance function is induced by the norm. -/
   dist_eq : ∀ x y, dist x y = ‖x - y‖ := by aesop
@@ -199,14 +198,14 @@ class SeminormedAddCommGroup (E : Type*) extends Norm E, AddCommGroup E,
 /-- A seminormed group is a group endowed with a norm for which `dist x y = ‖x / y‖`
 defines a pseudometric space structure. -/
 @[to_additive]
-class SeminormedCommGroup (E : Type*) extends Norm E, CommGroup E, PseudoMetricSpace E where
+class SeminormedCommGroup (E : Type*) extends CommGroup E, Norm E, PseudoMetricSpace E where
   dist := fun x y => ‖x / y‖
   /-- The distance function is induced by the norm. -/
   dist_eq : ∀ x y, dist x y = ‖x / y‖ := by aesop
 
 /-- A normed group is an additive group endowed with a norm for which `dist x y = ‖x - y‖` defines a
 metric space structure. -/
-class NormedAddCommGroup (E : Type*) extends Norm E, AddCommGroup E, MetricSpace E where
+class NormedAddCommGroup (E : Type*) extends AddCommGroup E, Norm E, MetricSpace E where
   dist := fun x y => ‖x - y‖
   /-- The distance function is induced by the norm. -/
   dist_eq : ∀ x y, dist x y = ‖x - y‖ := by aesop
@@ -214,7 +213,7 @@ class NormedAddCommGroup (E : Type*) extends Norm E, AddCommGroup E, MetricSpace
 /-- A normed group is a group endowed with a norm for which `dist x y = ‖x / y‖` defines a metric
 space structure. -/
 @[to_additive]
-class NormedCommGroup (E : Type*) extends Norm E, CommGroup E, MetricSpace E where
+class NormedCommGroup (E : Type*) extends CommGroup E, Norm E, MetricSpace E where
   dist := fun x y => ‖x / y‖
   /-- The distance function is induced by the norm. -/
   dist_eq : ∀ x y, dist x y = ‖x / y‖ := by aesop

--- a/Mathlib/Analysis/Normed/Operator/Basic.lean
+++ b/Mathlib/Analysis/Normed/Operator/Basic.lean
@@ -344,8 +344,10 @@ theorem opNorm_comp_le (f : E →SL[σ₁₂] F) : ‖h.comp f‖ ≤ ‖h‖ * 
     exact h.le_opNorm_of_le (f.le_opNorm x)⟩
 
 /-- Continuous linear maps form a seminormed ring with respect to the operator norm. -/
-instance toSeminormedRing : SeminormedRing (E →L[𝕜] E) :=
-  { toSeminormedAddCommGroup, ring with norm_mul_le := opNorm_comp_le }
+instance toSeminormedRing : SeminormedRing (E →L[𝕜] E) where
+  __ := ring
+  __ := toSeminormedAddCommGroup
+  norm_mul_le := opNorm_comp_le
 
 /-- For a normed space `E`, continuous linear endomorphisms form a normed algebra with
 respect to the operator norm. -/

--- a/Mathlib/Analysis/Normed/Operator/NormedSpace.lean
+++ b/Mathlib/Analysis/Normed/Operator/NormedSpace.lean
@@ -122,8 +122,8 @@ instance toNormedAddCommGroup [RingHomIsometric σ₁₂] : NormedAddCommGroup (
 
 /-- Continuous linear maps form a normed ring with respect to the operator norm. -/
 instance toNormedRing : NormedRing (E →L[𝕜] E) where
-  __ := toNormedAddCommGroup
   __ := toSeminormedRing
+  __ := toNormedAddCommGroup
 
 variable {f} in
 theorem homothety_norm [RingHomIsometric σ₁₂] [Nontrivial E] (f : E →SL[σ₁₂] F) {a : ℝ}

--- a/Mathlib/Analysis/Normed/Ring/Basic.lean
+++ b/Mathlib/Analysis/Normed/Ring/Basic.lean
@@ -29,7 +29,7 @@ open scoped Topology NNReal
 
 /-- A non-unital seminormed ring is a not-necessarily-unital ring
 endowed with a seminorm which satisfies the inequality `‖x y‖ ≤ ‖x‖ ‖y‖`. -/
-class NonUnitalSeminormedRing (α : Type*) extends Norm α, NonUnitalRing α,
+class NonUnitalSeminormedRing (α : Type*) extends NonUnitalRing α, Norm α,
   PseudoMetricSpace α where
   /-- The distance is induced by the norm. -/
   dist_eq : ∀ x y, dist x y = norm (x - y)
@@ -38,7 +38,7 @@ class NonUnitalSeminormedRing (α : Type*) extends Norm α, NonUnitalRing α,
 
 /-- A seminormed ring is a ring endowed with a seminorm which satisfies the inequality
 `‖x y‖ ≤ ‖x‖ ‖y‖`. -/
-class SeminormedRing (α : Type*) extends Norm α, Ring α, PseudoMetricSpace α where
+class SeminormedRing (α : Type*) extends Ring α, Norm α, PseudoMetricSpace α where
   /-- The distance is induced by the norm. -/
   dist_eq : ∀ x y, dist x y = norm (x - y)
   /-- The norm is submultiplicative. -/
@@ -52,7 +52,7 @@ instance (priority := 100) SeminormedRing.toNonUnitalSeminormedRing [β : Semino
 
 /-- A non-unital normed ring is a not-necessarily-unital ring
 endowed with a norm which satisfies the inequality `‖x y‖ ≤ ‖x‖ ‖y‖`. -/
-class NonUnitalNormedRing (α : Type*) extends Norm α, NonUnitalRing α, MetricSpace α where
+class NonUnitalNormedRing (α : Type*) extends NonUnitalRing α, Norm α, MetricSpace α where
   /-- The distance is induced by the norm. -/
   dist_eq : ∀ x y, dist x y = norm (x - y)
   /-- The norm is submultiplicative. -/
@@ -65,7 +65,7 @@ instance (priority := 100) NonUnitalNormedRing.toNonUnitalSeminormedRing
   { β with }
 
 /-- A normed ring is a ring endowed with a norm which satisfies the inequality `‖x y‖ ≤ ‖x‖ ‖y‖`. -/
-class NormedRing (α : Type*) extends Norm α, Ring α, MetricSpace α where
+class NormedRing (α : Type*) extends Ring α, Norm α, MetricSpace α where
   /-- The distance is induced by the norm. -/
   dist_eq : ∀ x y, dist x y = norm (x - y)
   /-- The norm is submultiplicative. -/
@@ -263,9 +263,10 @@ instance (priority := 75) NonUnitalSubalgebraClass.nonUnitalNormedRing {S 𝕜 E
   { nonUnitalSeminormedRing s with
     eq_of_dist_eq_zero := eq_of_dist_eq_zero }
 
-instance ULift.nonUnitalSeminormedRing : NonUnitalSeminormedRing (ULift α) :=
-  { ULift.seminormedAddCommGroup, ULift.nonUnitalRing with
-    norm_mul_le x y := norm_mul_le x.down y.down }
+instance ULift.nonUnitalSeminormedRing : NonUnitalSeminormedRing (ULift α) where
+  __ := ULift.nonUnitalRing
+  __ := ULift.seminormedAddCommGroup
+  norm_mul_le x y := norm_mul_le x.down y.down
 
 /-- Non-unital seminormed ring structure on the product of two non-unital seminormed rings,
   using the sup norm. -/
@@ -416,12 +417,12 @@ theorem eventually_norm_pow_le (a : α) : ∀ᶠ n : ℕ in atTop, ‖a ^ n‖ �
   eventually_atTop.mpr ⟨1, fun _b h => norm_pow_le' a (Nat.succ_le_iff.mp h)⟩
 
 instance ULift.seminormedRing : SeminormedRing (ULift α) :=
-  { ULift.nonUnitalSeminormedRing, ULift.ring with }
+  { ULift.ring, ULift.nonUnitalSeminormedRing with }
 
 /-- Seminormed ring structure on the product of two seminormed rings,
   using the sup norm. -/
 instance Prod.seminormedRing [SeminormedRing β] : SeminormedRing (α × β) :=
-  { nonUnitalSeminormedRing, instRing with }
+  { instRing, nonUnitalSeminormedRing with }
 
 instance MulOpposite.instSeminormedRing : SeminormedRing αᵐᵒᵖ where
   __ := instRing
@@ -575,7 +576,7 @@ section SeminormedCommRing
 variable [SeminormedCommRing α]
 
 instance ULift.seminormedCommRing : SeminormedCommRing (ULift α) :=
-  { ULift.nonUnitalSeminormedRing, ULift.commRing with }
+  { ULift.commRing, ULift.nonUnitalSeminormedRing with }
 
 /-- Seminormed commutative ring structure on the product of two seminormed commutative rings,
   using the sup norm. -/

--- a/Mathlib/NumberTheory/Padics/PadicNumbers.lean
+++ b/Mathlib/NumberTheory/Padics/PadicNumbers.lean
@@ -812,12 +812,11 @@ instance metricSpace : MetricSpace ℚ_[p] where
 instance : Norm ℚ_[p] :=
   ⟨fun x ↦ padicNormE x⟩
 
-instance normedField : NormedField ℚ_[p] :=
-  { Padic.field,
-    Padic.metricSpace p with
-    dist_eq := fun _ _ ↦ rfl
-    norm_mul := by simp [Norm.norm, map_mul]
-    norm := norm }
+instance normedField : NormedField ℚ_[p] where
+  __ := Padic.field
+  __ := Padic.metricSpace p
+  dist_eq := fun _ _ ↦ rfl
+  norm_mul := by simp [Norm.norm, map_mul]
 
 instance isAbsoluteValue : IsAbsoluteValue fun a : ℚ_[p] ↦ ‖a‖ where
   abv_nonneg' := norm_nonneg

--- a/Mathlib/Topology/Algebra/Valued/NormedValued.lean
+++ b/Mathlib/Topology/Algebra/Valued/NormedValued.lean
@@ -99,8 +99,7 @@ variable (L) (Γ₀)
 
 /-- The normed field structure determined by a rank one valuation. -/
 def toNormedField : NormedField L :=
-  { (inferInstance : Field L) with
-    norm := norm
+  { ‹Field L› with
     dist := fun x y => norm (x - y)
     dist_self := fun x => by
       simp only [sub_self, norm, Valuation.map_zero, hv.hom.map_zero, NNReal.coe_zero]

--- a/Mathlib/Topology/Algebra/Valued/NormedValued.lean
+++ b/Mathlib/Topology/Algebra/Valued/NormedValued.lean
@@ -99,7 +99,8 @@ variable (L) (Γ₀)
 
 /-- The normed field structure determined by a rank one valuation. -/
 def toNormedField : NormedField L :=
-  { ‹Field L› with
+  { (inferInstance : Field L) with
+    norm := norm
     dist := fun x y => norm (x - y)
     dist_self := fun x => by
       simp only [sub_self, norm, Valuation.map_zero, hv.hom.map_zero, NNReal.coe_zero]

--- a/Mathlib/Topology/ContinuousMap/Bounded/Normed.lean
+++ b/Mathlib/Topology/ContinuousMap/Bounded/Normed.lean
@@ -294,8 +294,8 @@ instance instNonUnitalRing : NonUnitalRing (α →ᵇ R) := fast_instance%
     (fun _ _ => coe_nsmul _ _) fun _ _ => coe_zsmul _ _
 
 instance instNonUnitalSeminormedRing : NonUnitalSeminormedRing (α →ᵇ R) where
-  __ := instSeminormedAddCommGroup
   __ := instNonUnitalRing
+  __ := instSeminormedAddCommGroup
   norm_mul_le f g := norm_ofNormedAddCommGroup_le _ (by positivity)
     (fun x ↦ (norm_mul_le _ _).trans <| mul_le_mul
       (norm_coe_le_norm f x) (norm_coe_le_norm g x) (norm_nonneg _) (norm_nonneg _))

--- a/Mathlib/Topology/ContinuousMap/Compact.lean
+++ b/Mathlib/Topology/ContinuousMap/Compact.lean
@@ -164,12 +164,10 @@ theorem _root_.BoundedContinuousFunction.norm_toContinuousMap_eq (f : α →ᵇ 
 open BoundedContinuousFunction
 
 instance : SeminormedAddCommGroup C(α, E) where
-  __ := ContinuousMap.instPseudoMetricSpace _ _
   __ := ContinuousMap.instAddCommGroupContinuousMap
+  __ := ContinuousMap.instPseudoMetricSpace _ _
   dist_eq x y := by
     rw [← norm_mkOfCompact, ← dist_mkOfCompact, dist_eq_norm, mkOfCompact_sub]
-  dist := dist
-  norm := norm
 
 instance {E : Type*} [NormedAddCommGroup E] : NormedAddCommGroup C(α, E) where
   __ : SeminormedAddCommGroup C(α, E) := inferInstance
@@ -241,8 +239,8 @@ section
 variable {R : Type*}
 
 instance [NonUnitalSeminormedRing R] : NonUnitalSeminormedRing C(α, R) where
-  __ : SeminormedAddCommGroup C(α, R) := inferInstance
   __ : NonUnitalRing C(α, R) := inferInstance
+  __ : SeminormedAddCommGroup C(α, R) := inferInstance
   norm_mul_le f g := norm_mul_le (mkOfCompact f) (mkOfCompact g)
 
 instance [NonUnitalSeminormedCommRing R] : NonUnitalSeminormedCommRing C(α, R) where
@@ -250,24 +248,24 @@ instance [NonUnitalSeminormedCommRing R] : NonUnitalSeminormedCommRing C(α, R) 
   __ : NonUnitalCommRing C(α, R) := inferInstance
 
 instance [SeminormedRing R] : SeminormedRing C(α, R) where
-  __ : NonUnitalSeminormedRing C(α, R) := inferInstance
   __ : Ring C(α, R) := inferInstance
+  __ : NonUnitalSeminormedRing C(α, R) := inferInstance
 
 instance [SeminormedCommRing R] : SeminormedCommRing C(α, R) where
   __ : SeminormedRing C(α, R) := inferInstance
   __ : CommRing C(α, R) := inferInstance
 
 instance [NonUnitalNormedRing R] : NonUnitalNormedRing C(α, R) where
+  __ : NonUnitalRing C(α, R) := inferInstance
   __ : NormedAddCommGroup C(α, R) := inferInstance
-  __ : NonUnitalSeminormedRing C(α, R) := inferInstance
 
 instance [NonUnitalNormedCommRing R] : NonUnitalNormedCommRing C(α, R) where
   __ : NonUnitalNormedRing C(α, R) := inferInstance
   __ : NonUnitalCommRing C(α, R) := inferInstance
 
 instance [NormedRing R] : NormedRing C(α, R) where
-  __ : NormedAddCommGroup C(α, R) := inferInstance
-  __ : SeminormedRing C(α, R) := inferInstance
+  __ : Ring C(α, R) := inferInstance
+  __ : NonUnitalNormedRing C(α, R) := inferInstance
 
 instance [NormedCommRing R] : NormedCommRing C(α, R) where
   __ : NormedRing C(α, R) := inferInstance

--- a/Mathlib/Topology/ContinuousMap/Compact.lean
+++ b/Mathlib/Topology/ContinuousMap/Compact.lean
@@ -256,7 +256,7 @@ instance [SeminormedCommRing R] : SeminormedCommRing C(α, R) where
   __ : CommRing C(α, R) := inferInstance
 
 instance [NonUnitalNormedRing R] : NonUnitalNormedRing C(α, R) where
-  __ : NonUnitalRing C(α, R) := inferInstance
+  __ : NonUnitalSeminormedRing C(α, R) := inferInstance
   __ : NormedAddCommGroup C(α, R) := inferInstance
 
 instance [NonUnitalNormedCommRing R] : NonUnitalNormedCommRing C(α, R) where


### PR DESCRIPTION
This PR changes order in which the parents to some `Normed*` classes are declared. Hopefully this can show a performance improvement.

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include at least one commit authored by each
co-author among the commits in the pull request. If necessary, you may 
create empty commits to indicate co-authorship, using commands like so:

git commit --author="Author Name <author@email.com>" --allow-empty -m "add Author Name as coauthor"

When merging, all the commits will be squashed into a single commit listing all co-authors.

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
