### PR TITLE
[Merged by Bors] - feat: interplay of posPart, negPart, untop₀, min and max

### DIFF
--- a/Mathlib/Algebra/Order/Group/PosPart.lean
+++ b/Mathlib/Algebra/Order/Group/PosPart.lean
@@ -109,6 +109,9 @@ lemma leOnePart_le_one' : a⁻ᵐ ≤ 1 ↔ a⁻¹ ≤ 1 := by simp [leOnePart]
 @[to_additive (attr := simp)] lemma leOnePart_inv (a : α) : a⁻¹⁻ᵐ = a⁺ᵐ := by
   simp [oneLePart, leOnePart]
 
+@[to_additive] lemma oneLePart_max (a b : α) : (max a b)⁺ᵐ = max a⁺ᵐ b⁺ᵐ := by
+  simp [oneLePart, sup_sup_distrib_right]
+
 section MulLeftMono
 variable [MulLeftMono α]
 
@@ -212,6 +215,19 @@ lemma div_mabs_eq_inv_leOnePart_sq (a : α) : a / |a|ₘ = (a⁻ᵐ ^ 2)⁻¹ :=
 
 end CommGroup
 end Lattice
+
+section DistribLattice
+variable [DistribLattice α] [Group α]
+
+@[to_additive] lemma oneLePart_min (a b : α) : (min a b)⁺ᵐ = min a⁺ᵐ b⁺ᵐ := by
+  simp [oneLePart, sup_inf_right]
+
+variable [MulLeftMono α] [MulRightMono α]
+
+@[to_additive] lemma leOnePart_max (a b : α) : (max a b)⁻ᵐ = min a⁻ᵐ b⁻ᵐ := by
+  simp [leOnePart, inv_sup, sup_inf_right]
+
+end DistribLattice
 
 section LinearOrder
 variable [LinearOrder α] [Group α] {a b : α}

--- a/Mathlib/Algebra/Order/Group/PosPart.lean
+++ b/Mathlib/Algebra/Order/Group/PosPart.lean
@@ -168,6 +168,9 @@ lemma leOnePart_eq_inv_inf_one (a : α) : a⁻ᵐ = (a ⊓ 1)⁻¹ := by
   rw [← mul_left_inj a⁻ᵐ⁻¹, inf_mul, one_mul, mul_inv_cancel, ← div_eq_mul_inv,
     oneLePart_div_leOnePart, leOnePart_eq_inv_inf_one, inv_inv]
 
+@[to_additive] lemma leOnePart_min (a b : α) : (min a b)⁻ᵐ = max a⁻ᵐ b⁻ᵐ := by
+  simp [leOnePart, inv_inf, sup_sup_distrib_right]
+
 end MulRightMono
 
 end MulLeftMono

--- a/Mathlib/Algebra/Order/WithTop/Untop0.lean
+++ b/Mathlib/Algebra/Order/WithTop/Untop0.lean
@@ -68,9 +68,7 @@ lemma untop₀_add [AddZeroClass α] {a b : WithTop α} (ha : a ≠ ⊤) (hb : b
 @[simp]
 lemma untop₀_neg [AddCommGroup α] : ∀ a : WithTop α, (-a).untop₀ = -a.untop₀
   | ⊤ => by simp
-  | (a : α) => by
-    rw [← LinearOrderedAddCommGroup.coe_neg, untop₀_coe]
-    simp
+  | (a : α) => rfl
 
 /-!
 ## Simplifying Lemmas in cases where α is a MulZeroClass

--- a/Mathlib/Algebra/Order/WithTop/Untop0.lean
+++ b/Mathlib/Algebra/Order/WithTop/Untop0.lean
@@ -108,13 +108,9 @@ theorem le_of_untop₀_le_untop₀ (ha : a ≠ ⊤) (h : a.untop₀ ≤ b.untop�
   lift a to α using ha
   simp_all
 
-theorem untop₀_le_untop₀_iff :
-    a.untop₀ ≤ b.untop₀ ↔ (a = ⊤ ∧ 0 ≤ b) ∨ (a ≤ 0 ∧ b = ⊤) ∨ (a ≤ b ∧ a ≠ ⊤ ∧ b ≠ ⊤) := by
-  by_cases ha : a = ⊤
-  · simp_all
+theorem untop₀_le_untop₀_iff (ha : a ≠ ⊤) (hb : b ≠ ⊤) :
+    a.untop₀ ≤ b.untop₀ ↔ a ≤ b := by
   lift a to α using ha
-  by_cases hb : b = ⊤
-  · simp_all
   lift b to α using hb
   simp
 

--- a/Mathlib/Algebra/Order/WithTop/Untop0.lean
+++ b/Mathlib/Algebra/Order/WithTop/Untop0.lean
@@ -101,12 +101,22 @@ theorem le_of_untop₀_le_untop₀ (ha : a ≠ ⊤) (h : a.untop₀ ≤ b.untop�
   lift b to α using hb
   simp_all
 
-@[simp, gcongr] theorem untop₀_le_untop₀_of_le (hb : b ≠ ⊤) (h : a ≤ b) : a.untop₀ ≤ b.untop₀ := by
+@[simp, gcongr] theorem untop₀_le_untop₀ (hb : b ≠ ⊤) (h : a ≤ b) : a.untop₀ ≤ b.untop₀ := by
   lift b to α using hb
   by_cases ha : a = ⊤
   · simp_all
   lift a to α using ha
   simp_all
+
+theorem untop₀_le_untop₀_iff :
+    a.untop₀ ≤ b.untop₀ ↔ (a = ⊤ ∧ 0 ≤ b) ∨ (a ≤ 0 ∧ b = ⊤) ∨ (a ≤ b ∧ a ≠ ⊤ ∧ b ≠ ⊤) := by
+  by_cases ha : a = ⊤
+  · simp_all
+  lift a to α using ha
+  by_cases hb : b = ⊤
+  · simp_all
+  lift b to α using hb
+  simp
 
 end OrderedAddCommGroup
 

--- a/Mathlib/Algebra/Order/WithTop/Untop0.lean
+++ b/Mathlib/Algebra/Order/WithTop/Untop0.lean
@@ -10,12 +10,11 @@ import Mathlib.Algebra.Order.Ring.WithTop
 /-!
 # Conversion from WithTop to Base Type
 
-For types α that are instances of `Zero`, we provide a convenient conversion,
-`WithTop.untop₀`, that maps elements `a : WithTop α` to `α`, by mapping `⊤` to
-zero.
+For types α that are instances of `Zero`, we provide a convenient conversion, `WithTop.untop₀`, that
+maps elements `a : WithTop α` to `α`, by mapping `⊤` to zero.
 
-For settings where `α` has additional structure, we provide a large number of
-simplifier lemmas, akin to those that already exists for `ENat.toNat`.
+For settings where `α` has additional structure, we provide a large number of simplifier lemmas,
+akin to those that already exists for `ENat.toNat`.
 -/
 
 namespace WithTop
@@ -25,7 +24,7 @@ section Zero
 variable [Zero α]
 
 /-- Conversion from `WithTop α` to `α`, mapping `⊤` to zero. -/
-def untop₀ [Zero α] (a : WithTop α) : α := a.untopD 0
+def untop₀ (a : WithTop α) : α := a.untopD 0
 
 /-!
 ## Simplifying Lemmas in cases where α is an Instance of Zero
@@ -52,8 +51,9 @@ lemma coe_untop₀_of_ne_top {a : WithTop α} (ha : a ≠ ⊤) :
 end Zero
 
 /-!
-## Simplifying Lemmas in cases where α is an AddMonoid
+## Simplifying Lemmas involving addition and negation
 -/
+
 @[simp]
 lemma untopD_add [Add α] {a b : WithTop α} {c : α} (ha : a ≠ ⊤) (hb : b ≠ ⊤) :
     (a + b).untopD c = a.untopD c + b.untopD c := by
@@ -64,6 +64,13 @@ lemma untopD_add [Add α] {a b : WithTop α} {c : α} (ha : a ≠ ⊤) (hb : b �
 @[simp]
 lemma untop₀_add [AddZeroClass α] {a b : WithTop α} (ha : a ≠ ⊤) (hb : b ≠ ⊤) :
     (a + b).untop₀ = a.untop₀ + b.untop₀ := untopD_add ha hb
+
+@[simp]
+lemma untop₀_neg [AddCommGroup α] : ∀ a : WithTop α, (-a).untop₀ = -a.untop₀
+  | ⊤ => by simp
+  | (a : α) => by
+    rw [← LinearOrderedAddCommGroup.coe_neg, untop₀_coe]
+    simp
 
 /-!
 ## Simplifying Lemmas in cases where α is a MulZeroClass
@@ -77,27 +84,58 @@ lemma untop₀_mul [DecidableEq α] [MulZeroClass α] (a b : WithTop α) :
 ## Simplifying Lemmas in cases where α is a OrderedAddCommGroup
 -/
 
+section OrderedAddCommGroup
+
+variable [AddCommGroup α] [PartialOrder α] {a b : WithTop α}
+
 /--
 Elements of ordered additive commutative groups are nonnegative iff their untop₀ is nonnegative.
 -/
-@[simp]
-lemma untop₀_nonneg [AddCommGroup α] [PartialOrder α] {a : WithTop α} :
-    0 ≤ a.untop₀ ↔ 0 ≤ a := by
+@[simp] lemma untop₀_nonneg : 0 ≤ a.untop₀ ↔ 0 ≤ a := by
   cases a with
   | top => tauto
   | coe a => simp
+
+theorem le_of_untop₀_le_untop₀ (ha : a ≠ ⊤) (h : a.untop₀ ≤ b.untop₀) : a ≤ b := by
+  lift a to α using ha
+  by_cases hb : b = ⊤
+  · simp_all
+  lift b to α using hb
+  simp_all
+
+@[simp, gcongr] theorem untop₀_le_untop₀_of_le (hb : b ≠ ⊤) (h : a ≤ b) : a.untop₀ ≤ b.untop₀ := by
+  lift b to α using hb
+  by_cases ha : a = ⊤
+  · simp_all
+  lift a to α using ha
+  simp_all
+
+end OrderedAddCommGroup
 
 /-!
 ## Simplifying Lemmas in cases where α is a LinearOrderedAddCommGroup
 -/
 
-@[simp]
-lemma untop₀_neg [AddCommGroup α] [LinearOrder α] [IsOrderedAddMonoid α] (a : WithTop α) :
-    (-a).untop₀ = -a.untop₀ := by
-  cases a with
-  | top => simp
-  | coe a =>
-    rw [← LinearOrderedAddCommGroup.coe_neg, untop₀_coe]
-    simp
+section LinearOrderedAddCommGroup
+
+variable [AddCommGroup α] [LinearOrder α] {a b : WithTop α}
+
+@[simp] theorem untop₀_max (ha : a ≠ ⊤) (hb : b ≠ ⊤) :
+    (max a b).untop₀ = max a.untop₀ b.untop₀ := by
+  lift a to α using ha
+  lift b to α using hb
+  simp only [untop₀_coe]
+  by_cases h : a ≤ b
+  · simp [max_eq_right h, max_eq_right (coe_le_coe.mpr h)]
+  rw [not_le] at h
+  simp [max_eq_left h.le, max_eq_left (coe_lt_coe.mpr h).le]
+
+@[simp] theorem untop₀_min (ha : a ≠ ⊤) (hb : b ≠ ⊤) :
+    (min a b).untop₀ = min a.untop₀ b.untop₀ := by
+  lift a to α using ha
+  lift b to α using hb
+  norm_cast
+
+end LinearOrderedAddCommGroup
 
 end WithTop

--- a/Mathlib/Topology/LocallyFinsupp.lean
+++ b/Mathlib/Topology/LocallyFinsupp.lean
@@ -5,8 +5,6 @@ Authors: Stefan Kebekus
 -/
 import Mathlib.Algebra.Group.Subgroup.Defs
 import Mathlib.Algebra.Group.Support
-import Mathlib.Algebra.Order.Group.PosPart
-import Mathlib.Algebra.Order.Monoid.Unbundled.Pow
 import Mathlib.Algebra.Order.Pi
 import Mathlib.Topology.Separation.Hausdorff
 import Mathlib.Topology.DiscreteSubset
@@ -324,48 +322,12 @@ instance [Lattice Y] [Zero Y] : Lattice (locallyFinsuppWithin U Y) where
   inf_le_right D₁ D₂ := fun x ↦ by simp
   le_inf D₁ D₂ D₃ h₁₃ h₂₃ := fun x ↦ by simp [h₁₃ x, h₂₃ x]
 
-@[simp]
-lemma posPart_apply [AddCommGroup Y] [LinearOrder Y] (a : locallyFinsuppWithin U Y) (x : X) :
-    a⁺ x = (a x)⁺ := rfl
-
-@[simp]
-lemma negPart_apply [AddCommGroup Y] [LinearOrder Y] (a : locallyFinsuppWithin U Y) (x : X) :
-    a⁻ x = (a x)⁻ := rfl
-
 /--
 Functions with locally finite support within `U` form an ordered commutative group.
 -/
 instance [AddCommGroup Y] [LinearOrder Y] [IsOrderedAddMonoid Y] :
     IsOrderedAddMonoid (locallyFinsuppWithin U Y) where
   add_le_add_left := fun _ _ _ _ ↦ by simpa [le_def]
-
-/--
-Taking the positive part of a function with locally finite support commutes with
-scalar multiplication by a natural number.
--/
-theorem nsmul_posPart [AddCommGroup Y] [LinearOrder Y] [IsOrderedAddMonoid Y]
-    (f : locallyFinsuppWithin U Y) (n : ℕ) :
-    n • f⁺ = (n • f)⁺ := by
-  unfold instPosPart
-  ext x
-  simp only [coe_nsmul, Pi.smul_apply, max_apply, coe_zero, Pi.zero_apply]
-  by_cases h : f x < 0
-  · simpa [max_eq_right_of_lt h] using nsmul_le_nsmul_right h.le n
-  · simpa [not_lt.1 h] using nsmul_nonneg (not_lt.1 h) n
-
-/--
-Taking the negative part of a function with locally finite support commutes with
-scalar multiplication by a natural number.
--/
-theorem nsmul_negPart [AddCommGroup Y] [LinearOrder Y] [IsOrderedAddMonoid Y]
-    (f : locallyFinsuppWithin U Y) (n : ℕ) :
-    n • f⁻ = (n • f)⁻ := by
-  unfold instNegPart
-  ext x
-  simp only [coe_nsmul, Pi.smul_apply, max_apply, coe_neg, Pi.neg_apply, coe_zero, Pi.zero_apply]
-  by_cases h : -f x < 0
-  · simpa [max_eq_right_of_lt h] using nsmul_le_nsmul_right h.le n
-  · simpa [not_lt.1 h] using nsmul_nonneg (not_lt.1 h) n
 
 /-!
 ## Restriction

--- a/Mathlib/Topology/LocallyFinsupp.lean
+++ b/Mathlib/Topology/LocallyFinsupp.lean
@@ -5,6 +5,8 @@ Authors: Stefan Kebekus
 -/
 import Mathlib.Algebra.Group.Subgroup.Defs
 import Mathlib.Algebra.Group.Support
+import Mathlib.Algebra.Order.Group.PosPart
+import Mathlib.Algebra.Order.Monoid.Unbundled.Pow
 import Mathlib.Algebra.Order.Pi
 import Mathlib.Topology.Separation.Hausdorff
 import Mathlib.Topology.DiscreteSubset
@@ -322,12 +324,48 @@ instance [Lattice Y] [Zero Y] : Lattice (locallyFinsuppWithin U Y) where
   inf_le_right D₁ D₂ := fun x ↦ by simp
   le_inf D₁ D₂ D₃ h₁₃ h₂₃ := fun x ↦ by simp [h₁₃ x, h₂₃ x]
 
+@[simp]
+lemma posPart_apply [AddCommGroup Y] [LinearOrder Y] (a : locallyFinsuppWithin U Y) (x : X) :
+    a⁺ x = (a x)⁺ := rfl
+
+@[simp]
+lemma negPart_apply [AddCommGroup Y] [LinearOrder Y] (a : locallyFinsuppWithin U Y) (x : X) :
+    a⁻ x = (a x)⁻ := rfl
+
 /--
 Functions with locally finite support within `U` form an ordered commutative group.
 -/
 instance [AddCommGroup Y] [LinearOrder Y] [IsOrderedAddMonoid Y] :
     IsOrderedAddMonoid (locallyFinsuppWithin U Y) where
   add_le_add_left := fun _ _ _ _ ↦ by simpa [le_def]
+
+/--
+Taking the positive part of a function with locally finite support commutes with
+scalar multiplication by a natural number.
+-/
+theorem nsmul_posPart [AddCommGroup Y] [LinearOrder Y] [IsOrderedAddMonoid Y]
+    (f : locallyFinsuppWithin U Y) (n : ℕ) :
+    n • f⁺ = (n • f)⁺ := by
+  unfold instPosPart
+  ext x
+  simp only [coe_nsmul, Pi.smul_apply, max_apply, coe_zero, Pi.zero_apply]
+  by_cases h : f x < 0
+  · simpa [max_eq_right_of_lt h] using nsmul_le_nsmul_right h.le n
+  · simpa [not_lt.1 h] using nsmul_nonneg (not_lt.1 h) n
+
+/--
+Taking the negative part of a function with locally finite support commutes with
+scalar multiplication by a natural number.
+-/
+theorem nsmul_negPart [AddCommGroup Y] [LinearOrder Y] [IsOrderedAddMonoid Y]
+    (f : locallyFinsuppWithin U Y) (n : ℕ) :
+    n • f⁻ = (n • f)⁻ := by
+  unfold instNegPart
+  ext x
+  simp only [coe_nsmul, Pi.smul_apply, max_apply, coe_neg, Pi.neg_apply, coe_zero, Pi.zero_apply]
+  by_cases h : -f x < 0
+  · simpa [max_eq_right_of_lt h] using nsmul_le_nsmul_right h.le n
+  · simpa [not_lt.1 h] using nsmul_nonneg (not_lt.1 h) n
 
 /-!
 ## Restriction


### PR DESCRIPTION
Add a host of elementary (but somewhat delicate) lemmas on the interplay of posPart, negPart, untop₀, min, and max.

This material is used in [Project VD](https://github.com/kebekus/ProjectVD), which aims to formalize Value Distribution Theory for meromorphic functions on the complex plane. It will be used in follow-up PRs to compare pole- and zero-divisors attached to meromorphic functions on the complex plane, and their behavior under algebraic manipulations of the functions.

---

This PR is a variant of PR #30630, which was closed because of error messages from the CI that the author failed to understand.

<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include at least one commit authored by each
co-author among the commits in the pull request. If necessary, you may 
create empty commits to indicate co-authorship, using commands like so:

git commit --author="Author Name <author@email.com>" --allow-empty -m "add Author Name as coauthor"

When merging, all the commits will be squashed into a single commit listing all co-authors.

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
