### PR TITLE
chore: partially migrate from `ContinuousMap.continuous`

### DIFF
--- a/Mathlib/AlgebraicGeometry/Morphisms/Constructors.lean
+++ b/Mathlib/AlgebraicGeometry/Morphisms/Constructors.lean
@@ -292,7 +292,7 @@ lemma topologically_isZariskiLocalAtTarget [(topologically P).RespectsIso]
     simp_rw [topologically, morphismRestrict_base]
     exact hP₂ f.base U.carrier f.base.hom.2 U.2 hf
   · intro X Y f ι U hU hf
-    apply hP₃ f.base U hU f.base.hom.continuous fun i ↦ ?_
+    apply hP₃ f.base U hU (map_continuous _) fun i ↦ ?_
     rw [← morphismRestrict_base]
     exact hf i
 

--- a/Mathlib/AlgebraicTopology/FundamentalGroupoid/Basic.lean
+++ b/Mathlib/AlgebraicTopology/FundamentalGroupoid/Basic.lean
@@ -268,7 +268,9 @@ theorem id_eq_path_refl (x : FundamentalGroupoid X) : 𝟙 x = ⟦Path.refl x.as
   obj x := ⟨f x.as⟩
   map p := p.mapFn f
   map_id _ := rfl
-  map_comp := by rintro _ _ _ ⟨p⟩ ⟨q⟩; exact congr_arg Quotient.mk'' (p.map_trans q f.continuous)
+  map_comp := by
+    rintro _ _ _ ⟨p⟩ ⟨q⟩;
+    exact congr_arg Quotient.mk'' (p.map_trans q <| map_continuous f)
 
 /-- The functor sending a topological space `X` to its fundamental groupoid. -/
 def fundamentalGroupoidFunctor : TopCat ⥤ Grpd where

--- a/Mathlib/AlgebraicTopology/FundamentalGroupoid/FundamentalGroup.lean
+++ b/Mathlib/AlgebraicTopology/FundamentalGroupoid/FundamentalGroup.lean
@@ -81,7 +81,7 @@ def mapOfEq : FundamentalGroup X x →* FundamentalGroup Y y :=
   (eqToIso <| congr_arg FundamentalGroupoid.mk h).conj.toMonoidHom.comp (map f x)
 
 theorem mapOfEq_apply (p : Path x x) :
-    mapOfEq f h (fromPath ⟦p⟧) = fromPath ⟦(p.map f.continuous).cast h.symm h.symm⟧ :=
+    mapOfEq f h (fromPath ⟦p⟧) = fromPath ⟦(p.map <| map_continuous f).cast h.symm h.symm⟧ :=
   FundamentalGroupoid.conj_eqToHom ..
 
 end FundamentalGroup

--- a/Mathlib/Analysis/CStarAlgebra/ContinuousFunctionalCalculus/Restrict.lean
+++ b/Mathlib/Analysis/CStarAlgebra/ContinuousFunctionalCalculus/Restrict.lean
@@ -36,9 +36,6 @@ def homeomorph {R S A : Type*} [Semifield R] [Semifield S] [Ring A]
   invFun := MapsTo.restrict (algebraMap R S) _ _ (image_subset_iff.mp h.algebraMap_image.subset)
   left_inv x := Subtype.ext <| h.rightInvOn x.2
   right_inv x := Subtype.ext <| h.left_inv x
-  continuous_toFun := continuous_induced_rng.mpr <| f.continuous.comp continuous_induced_dom
-  continuous_invFun := continuous_induced_rng.mpr <|
-    continuous_algebraMap R S |>.comp continuous_induced_dom
 
 lemma compactSpace {R S A : Type*} [Semifield R] [Semifield S] [Ring A]
     [Algebra R S] [Algebra R A] [Algebra S A] [IsScalarTower R S A] [TopologicalSpace R]

--- a/Mathlib/Analysis/CStarAlgebra/ContinuousFunctionalCalculus/Restrict.lean
+++ b/Mathlib/Analysis/CStarAlgebra/ContinuousFunctionalCalculus/Restrict.lean
@@ -178,9 +178,6 @@ def homeomorph {R S A : Type*} [Semifield R] [Field S] [NonUnitalRing A]
   invFun := MapsTo.restrict (algebraMap R S) _ _ (image_subset_iff.mp h.algebraMap_image.subset)
   left_inv x := Subtype.ext <| h.rightInvOn x.2
   right_inv x := Subtype.ext <| h.left_inv x
-  continuous_toFun := continuous_induced_rng.mpr <| f.continuous.comp continuous_induced_dom
-  continuous_invFun := continuous_induced_rng.mpr <|
-    continuous_algebraMap R S |>.comp continuous_induced_dom
 
 universe u v w
 

--- a/Mathlib/Analysis/Complex/Circle.lean
+++ b/Mathlib/Analysis/Complex/Circle.lean
@@ -197,8 +197,10 @@ theorem fourierChar_apply' (x : ℝ) : 𝐞 x = Circle.exp (2 * π * x) := rfl
 
 theorem fourierChar_apply (x : ℝ) : 𝐞 x = Complex.exp (↑(2 * π * x) * Complex.I) := rfl
 
-@[continuity]
-theorem continuous_fourierChar : Continuous 𝐞 := Circle.exp.continuous.comp (continuous_mul_left _)
+@[fun_prop, continuity]
+theorem continuous_fourierChar : Continuous 𝐞 := by
+  rw [fourierChar, AddChar.coe_mk]
+  fun_prop
 
 theorem fourierChar_ne_one : fourierChar ≠ 1 := by
   rw [DFunLike.ne_iff]
@@ -218,8 +220,8 @@ theorem probChar_apply' (x : ℝ) : probChar x = Circle.exp x := rfl
 
 theorem probChar_apply (x : ℝ) : probChar x = Complex.exp (x * Complex.I) := rfl
 
-@[continuity]
-theorem continuous_probChar : Continuous probChar := Circle.exp.continuous
+@[continuity, fun_prop]
+theorem continuous_probChar : Continuous probChar := map_continuous Circle.exp
 
 theorem probChar_ne_one : probChar ≠ 1 := by
   rw [DFunLike.ne_iff]

--- a/Mathlib/Analysis/Fourier/AddCircleMulti.lean
+++ b/Mathlib/Analysis/Fourier/AddCircleMulti.lean
@@ -49,8 +49,7 @@ variable (n : d → ℤ)
 /-- Exponential monomials in `d` variables. -/
 def mFourier : C(UnitAddTorus d, ℂ) where
   toFun x := ∏ i : d, fourier (n i) (x i)
-  continuous_toFun := continuous_finset_prod _
-    fun i _ ↦ (fourier (n i)).continuous.comp (continuous_apply i)
+  continuous_toFun := by fun_prop
 
 variable {n} {x : UnitAddTorus d}
 

--- a/Mathlib/Condensed/Light/TopCatAdjunction.lean
+++ b/Mathlib/Condensed/Light/TopCatAdjunction.lean
@@ -163,7 +163,7 @@ can only prove this for `X : TopCat.{0}`.
 noncomputable def sequentialAdjunctionHomeo (X : TopCat.{0}) [SequentialSpace X] :
     X.toLightCondSet.toTopCat ≃ₜ X where
   toEquiv := topCatAdjunctionCounitEquiv X
-  continuous_toFun := (topCatAdjunctionCounit X).hom.continuous
+  continuous_toFun := by fun_prop
   continuous_invFun := by
     apply SeqContinuous.continuous
     unfold SeqContinuous

--- a/Mathlib/Condensed/TopCatAdjunction.lean
+++ b/Mathlib/Condensed/TopCatAdjunction.lean
@@ -178,7 +178,7 @@ noncomputable def compactlyGeneratedAdjunctionCounitHomeo
     (X : TopCat.{u + 1}) [UCompactlyGeneratedSpace.{u} X] :
     X.toCondensedSet.toTopCat ≃ₜ X where
   toEquiv := topCatAdjunctionCounitEquiv X
-  continuous_toFun := (topCatAdjunctionCounit X).hom.continuous
+  continuous_toFun := by fun_prop
   continuous_invFun := by
     apply continuous_from_uCompactlyGeneratedSpace
     exact fun _ _ ↦ continuous_coinducingCoprod X.toCondensedSet _

--- a/Mathlib/Condensed/TopComparison.lean
+++ b/Mathlib/Condensed/TopComparison.lean
@@ -111,7 +111,7 @@ def TopCat.toSheafCompHausLike :
     apply (config := { allowSynthFailures := true }) equalizerCondition_yonedaPresheaf
       (CompHausLike.compHausLikeToTop.{u} P) X
     intro Z B π he
-    apply IsQuotientMap.of_surjective_continuous (hs _ he) π.hom.continuous
+    apply IsQuotientMap.of_surjective_continuous (hs _ he) (by fun_prop)
 
 /--
 `TopCat.toSheafCompHausLike` yields a functor from `TopCat.{max u w}` to

--- a/Mathlib/Dynamics/Ergodic/Action/OfMinimal.lean
+++ b/Mathlib/Dynamics/Ergodic/Action/OfMinimal.lean
@@ -54,7 +54,7 @@ theorem aeconst_of_dense_setOf_preimage_smul_ae (hsm : NullMeasurableSet s μ)
   refine aeconst_of_forall_preimage_smul_ae_eq M hsm ?_
   rwa [dense_iff_closure_eq, IsClosed.closure_eq, eq_univ_iff_forall] at hd
   let f : C(M × X, X) := ⟨(· • ·).uncurry, continuous_smul⟩
-  exact isClosed_setOf_preimage_ae_eq f.curry.continuous (measurePreserving_smul · μ) _ hsm
+  exact isClosed_setOf_preimage_ae_eq (map_continuous f.curry) (measurePreserving_smul · μ) _ hsm
     (measure_ne_top _ _)
 
 @[to_additive]

--- a/Mathlib/MeasureTheory/Constructions/BorelSpace/Basic.lean
+++ b/Mathlib/MeasureTheory/Constructions/BorelSpace/Basic.lean
@@ -552,7 +552,7 @@ end Homeomorph
 
 @[measurability]
 theorem ContinuousMap.measurable (f : C(α, γ)) : Measurable f :=
-  f.continuous.measurable
+  (map_continuous f).measurable
 
 @[fun_prop]
 theorem measurable_of_continuousOn_compl_singleton [T1Space α] {f : α → γ} (a : α)

--- a/Mathlib/Topology/Category/CompHausLike/Limits.lean
+++ b/Mathlib/Topology/Category/CompHausLike/Limits.lean
@@ -75,9 +75,7 @@ def finiteCoproduct.desc {B : CompHausLike P} (e : (a : α) → (X a ⟶ B)) :
     finiteCoproduct X ⟶ B :=
   ofHom _
   { toFun := fun ⟨a, x⟩ ↦ e a x
-    continuous_toFun := by
-      apply continuous_sigma
-      intro a; exact (e a).hom.continuous }
+    continuous_toFun := continuous_sigma <| by fun_prop }
 
 @[reassoc (attr := simp)]
 lemma finiteCoproduct.ι_desc {B : CompHausLike P} (e : (a : α) → (X a ⟶ B)) (a : α) :
@@ -199,8 +197,7 @@ pairs `(x,y)` such that `f x = g y`, with the topology induced by the product.
 def pullback : CompHausLike P :=
   letI set := { xy : X × Y | f xy.fst = g xy.snd }
   haveI : CompactSpace set :=
-    isCompact_iff_compactSpace.mp (isClosed_eq (f.hom.continuous.comp continuous_fst)
-      (g.hom.continuous.comp continuous_snd)).isCompact
+    isCompact_iff_compactSpace.mp (isClosed_eq (by fun_prop) (by fun_prop)).isCompact
   CompHausLike.of P set
 
 /--

--- a/Mathlib/Topology/Compactification/OnePoint/Basic.lean
+++ b/Mathlib/Topology/Compactification/OnePoint/Basic.lean
@@ -397,7 +397,7 @@ def continuousMapMk {Y : Type*} [TopologicalSpace Y] (f : C(X, Y)) (y : Y)
   toFun x := x.elim y f
   continuous_toFun := by
     rw [continuous_iff]
-    refine ⟨h, f.continuous⟩
+    refine ⟨h, map_continuous f⟩
 
 lemma continuous_iff_from_discrete {Y : Type*} [TopologicalSpace Y]
     [DiscreteTopology X] (f : OnePoint X → Y) :

--- a/Mathlib/Topology/Compactness/CompactlyGeneratedSpace.lean
+++ b/Mathlib/Topology/Compactness/CompactlyGeneratedSpace.lean
@@ -207,8 +207,7 @@ instance (priority := 100) [SequentialSpace X] : UCompactlyGeneratedSpace.{u} X 
   apply IsClosed.mem_of_tendsto _ ((continuous_uliftUp.tendsto ∞).comp this)
   · simp only [Function.comp_apply, mem_preimage, eventually_atTop, ge_iff_le]
     exact ⟨0, fun b _ ↦ hu b⟩
-  · exact h (CompHaus.of (ULift.{u} (OnePoint ℕ)))
-      ⟨g, (continuousMapMkNat u p hup).continuous.comp continuous_uliftDown⟩
+  · exact h (CompHaus.of (ULift.{u} (OnePoint ℕ))) ⟨g, by fun_prop⟩
 
 end UCompactlyGeneratedSpace
 

--- a/Mathlib/Topology/ContinuousMap/CompactlySupported.lean
+++ b/Mathlib/Topology/ContinuousMap/CompactlySupported.lean
@@ -444,7 +444,7 @@ variable [SemilatticeSup β] [Zero β] [TopologicalSpace β] [ContinuousSup β]
 
 instance instSup : Max C_c(α, β) where max f g :=
   { toFun := f ⊔ g
-    continuous_toFun := Continuous.sup f.continuous g.continuous
+    continuous_toFun := by simp only [Pi.sup_def]; fun_prop
     hasCompactSupport' := f.hasCompactSupport.sup g.hasCompactSupport }
 
 @[simp, norm_cast] lemma coe_sup (f g : C_c(α, β)) : ⇑(f ⊔ g) = ⇑f ⊔ g := rfl
@@ -470,7 +470,7 @@ variable [SemilatticeInf β] [Zero β] [TopologicalSpace β] [ContinuousInf β]
 
 instance instInf : Min C_c(α, β) where min f g :=
   { toFun := f ⊓ g
-    continuous_toFun := Continuous.inf f.continuous g.continuous
+    continuous_toFun := by simp only [Pi.inf_def]; fun_prop
     hasCompactSupport' := f.hasCompactSupport.inf g.hasCompactSupport }
 
 @[simp, norm_cast] lemma coe_inf (f g : C_c(α, β)) : ⇑(f ⊓ g) = ⇑f ⊓ g := rfl

--- a/Mathlib/Topology/ContinuousMap/Units.lean
+++ b/Mathlib/Topology/ContinuousMap/Units.lean
@@ -32,8 +32,8 @@ and the units of the monoid of continuous maps. -/
 continuous addition and the additive units of the additive monoid of continuous maps. -/]
 def unitsLift : C(X, Mˣ) ≃ C(X, M)ˣ where
   toFun f :=
-    { val := ⟨fun x => f x, Units.continuous_val.comp f.continuous⟩
-      inv := ⟨fun x => ↑(f x)⁻¹, Units.continuous_val.comp (continuous_inv.comp f.continuous)⟩
+    { val := ⟨fun x => f x, by fun_prop⟩
+      inv := ⟨fun x => ↑(f x)⁻¹, by fun_prop⟩
       val_inv := ext fun _ => Units.mul_inv _
       inv_val := ext fun _ => Units.inv_mul _ }
   invFun f :=

--- a/Mathlib/Topology/ContinuousMap/ZeroAtInfty.lean
+++ b/Mathlib/Topology/ContinuousMap/ZeroAtInfty.lean
@@ -130,7 +130,6 @@ infinity. -/
 def ContinuousMap.liftZeroAtInfty [CompactSpace α] : C(α, β) ≃ C₀(α, β) where
   toFun f :=
     { toFun := f
-      continuous_toFun := f.continuous
       zero_at_infty' := by simp }
   invFun f := f
 

--- a/Mathlib/Topology/LocallyConstant/Basic.lean
+++ b/Mathlib/Topology/LocallyConstant/Basic.lean
@@ -386,7 +386,7 @@ variable [TopologicalSpace Y]
 
 /-- Pull back of locally constant maps under a continuous map, by pre-composition. -/
 def comap (f : C(X, Y)) (g : LocallyConstant Y Z) : LocallyConstant X Z :=
-  ⟨g ∘ f, g.isLocallyConstant.comp_continuous f.continuous⟩
+  ⟨g ∘ f, g.isLocallyConstant.comp_continuous <| map_continuous f⟩
 
 @[simp]
 theorem coe_comap (f : C(X, Y)) (g : LocallyConstant Y Z) :

--- a/Mathlib/Topology/PartitionOfUnity.lean
+++ b/Mathlib/Topology/PartitionOfUnity.lean
@@ -544,8 +544,7 @@ theorem exists_finset_toPOUFun_eventuallyEq (i : ι) (x : X) : ∃ t : Finset ι
   exact hf.mem_toFinset.2 ⟨y, ⟨hj, hyU⟩⟩
 
 theorem continuous_toPOUFun (i : ι) : Continuous (f.toPOUFun i) := by
-  refine (f i).continuous.mul <|
-    continuous_finprod_cond (fun j _ => continuous_const.sub (f j).continuous) ?_
+  refine (map_continuous <| f i).mul <| continuous_finprod_cond (fun j _ => by fun_prop) ?_
   simp only [mulSupport_one_sub]
   exact f.locallyFinite
 

--- a/Mathlib/Topology/Sets/Opens.lean
+++ b/Mathlib/Topology/Sets/Opens.lean
@@ -359,7 +359,7 @@ theorem isCompactElement_iff (s : Opens α) :
 
 /-- The preimage of an open set, as an open set. -/
 def comap (f : C(α, β)) : FrameHom (Opens β) (Opens α) where
-  toFun s := ⟨f ⁻¹' s, s.2.preimage f.continuous⟩
+  toFun s := ⟨f ⁻¹' s, s.2.preimage <| map_continuous f⟩
   map_sSup' s := ext <| by simp only [coe_sSup, preimage_iUnion, biUnion_image, coe_mk]
   map_inf' _ _ := rfl
   map_top' := rfl

--- a/Mathlib/Topology/TietzeExtension.lean
+++ b/Mathlib/Topology/TietzeExtension.lean
@@ -460,7 +460,7 @@ theorem exists_extension_forall_mem_of_isClosedEmbedding (f : C(X, ℝ)) {t : Se
   have h : ℝ ≃o Ioo (-1 : ℝ) 1 := orderIsoIooNegOneOne ℝ
   let F : X →ᵇ ℝ :=
     { toFun := (↑) ∘ h ∘ f
-      continuous_toFun := continuous_subtype_val.comp (h.continuous.comp f.continuous)
+      continuous_toFun := by fun_prop
       map_bounded' := isBounded_range_iff.1
         ((isBounded_Ioo (-1 : ℝ) 1).subset <| range_subset_iff.2 fun x => (h (f x)).2) }
   let t' : Set ℝ := (↑) ∘ h '' t

--- a/Mathlib/Topology/UniformSpace/CompactConvergence.lean
+++ b/Mathlib/Topology/UniformSpace/CompactConvergence.lean
@@ -119,7 +119,7 @@ theorem tendsto_iff_forall_isCompact_tendstoUniformlyOn
     have hnhds : s ∈ 𝓝[K] x := inter_mem_nhdsWithin _ <| f.continuousAt _ (ball_mem_nhds _ hW)
     -- This set is compact because it is an intersection of `K`
     -- with a closed set `{y | (f x, f y) ∈ W} = f ⁻¹' UniformSpace.ball (f x) W`
-    have hcomp : IsCompact s := hK.inter_right <| (isClosed_ball _ hWc).preimage f.continuous
+    have hcomp : IsCompact s := hK.inter_right <| (isClosed_ball _ hWc).preimage (map_continuous f)
     -- `f` maps `s` to the open set `ball (f x) V = {z | (f x, z) ∈ V}`
     have hmaps : MapsTo f s (ball (f x) V) := fun x hx ↦ hWU hx.2
     use s, hnhds
@@ -279,7 +279,7 @@ theorem isUniformEmbedding_comp (g : C(β, δ)) (hg : IsUniformEmbedding g) :
 theorem uniformContinuous_comp_left (g : C(α, γ)) :
     UniformContinuous (fun f ↦ f.comp g : C(γ, β) → C(α, β)) :=
   isUniformEmbedding_toUniformOnFunIsCompact.uniformContinuous_iff.mpr <|
-    UniformOnFun.precomp_uniformContinuous (fun _ hK ↦ hK.image g.continuous) |>.comp
+    UniformOnFun.precomp_uniformContinuous (fun _ hK ↦ hK.image (map_continuous g)) |>.comp
       isUniformEmbedding_toUniformOnFunIsCompact.uniformContinuous
 
 /-- Any pair of a homeomorphism `X ≃ₜ Z` and an isomorphism `Y ≃ᵤ T` of uniform spaces gives rise
@@ -376,8 +376,8 @@ theorem uniformSpace_eq_inf_precomp_of_cover {δ₁ δ₂ : Type*} [TopologicalS
   set 𝔖 : Set (Set α) := {K | IsCompact K}
   set 𝔗₁ : Set (Set δ₁) := {K | IsCompact K}
   set 𝔗₂ : Set (Set δ₂) := {K | IsCompact K}
-  have h_image₁ : MapsTo (φ₁ '' ·) 𝔗₁ 𝔖 := fun K hK ↦ hK.image φ₁.continuous
-  have h_image₂ : MapsTo (φ₂ '' ·) 𝔗₂ 𝔖 := fun K hK ↦ hK.image φ₂.continuous
+  have h_image₁ : MapsTo (φ₁ '' ·) 𝔗₁ 𝔖 := fun K hK ↦ hK.image (map_continuous φ₁)
+  have h_image₂ : MapsTo (φ₂ '' ·) 𝔗₂ 𝔖 := fun K hK ↦ hK.image (map_continuous φ₂)
   have h_preimage₁ : MapsTo (φ₁ ⁻¹' ·) 𝔖 𝔗₁ := fun K ↦ h_proper₁.isCompact_preimage
   have h_preimage₂ : MapsTo (φ₂ ⁻¹' ·) 𝔖 𝔗₂ := fun K ↦ h_proper₂.isCompact_preimage
   have h_cover' : ∀ S ∈ 𝔖, S ⊆ range φ₁ ∪ range φ₂ := fun S _ ↦ h_cover ▸ subset_univ _
@@ -396,7 +396,7 @@ theorem uniformSpace_eq_iInf_precomp_of_cover {δ : ι → Type*} [∀ i, Topolo
   -- `UniformOnFun.uniformSpace_eq_iInf_precomp_of_cover`...
   set 𝔖 : Set (Set α) := {K | IsCompact K}
   set 𝔗 : Π i, Set (Set (δ i)) := fun i ↦ {K | IsCompact K}
-  have h_image : ∀ i, MapsTo (φ i '' ·) (𝔗 i) 𝔖 := fun i K hK ↦ hK.image (φ i).continuous
+  have h_image : ∀ i, MapsTo (φ i '' ·) (𝔗 i) 𝔖 := fun i K hK ↦ hK.image (map_continuous (φ i))
   have h_preimage : ∀ i, MapsTo (φ i ⁻¹' ·) 𝔖 (𝔗 i) := fun i K ↦ (h_proper i).isCompact_preimage
   have h_cover' : ∀ S ∈ 𝔖, ∃ I : Set ι, I.Finite ∧ S ⊆ ⋃ i ∈ I, range (φ i) := fun S hS ↦ by
     refine ⟨{i | (range (φ i) ∩ S).Nonempty}, h_lf.finite_nonempty_inter_compact hS,

--- a/Mathlib/Topology/UniformSpace/Dini.lean
+++ b/Mathlib/Topology/UniformSpace/Dini.lean
@@ -147,7 +147,8 @@ lemma tendsto_of_monotone_of_pointwise (hF_mono : Monotone F)
     (h_tendsto : ∀ x, Tendsto (F · x) atTop (𝓝 (f x))) :
     Tendsto F atTop (𝓝 f) :=
   tendsto_of_tendstoLocallyUniformly <|
-    hF_mono.tendstoLocallyUniformly_of_forall_tendsto (F · |>.continuous) f.continuous h_tendsto
+    hF_mono.tendstoLocallyUniformly_of_forall_tendsto (F · |> map_continuous)
+      (map_continuous _) h_tendsto
 
 /-- **Dini's theorem**: if `F n` is a monotone decreasing collection of continuous functions
 converging pointwise to a continuous function `f`, then `F n` converges to `f` in the

--- a/Mathlib/Topology/UrysohnsLemma.lean
+++ b/Mathlib/Topology/UrysohnsLemma.lean
@@ -455,7 +455,7 @@ theorem exists_continuous_one_zero_of_isCompact_of_isGδ [RegularSpace X] [Local
   have S x : Summable (fun n ↦ u n * f n x) := Summable.of_nonneg_of_le
       (fun n ↦ mul_nonneg (u_pos n).le (f_range n x).1) (fun n ↦ I n x) u_sum
   refine ⟨⟨g, ?_⟩, ?_, hgmc.mono (subset_compl_comm.mp mt), ?_, fun x ↦ ⟨?_, ?_⟩⟩
-  · apply continuous_tsum (fun n ↦ continuous_const.mul (f n).continuous) u_sum (fun n x ↦ ?_)
+  · apply continuous_tsum (fun n ↦ by fun_prop) u_sum (fun n x ↦ ?_)
     simpa [abs_of_nonneg, (u_pos n).le, (f_range n x).1] using I n x
   · apply Subset.antisymm (fun x hx ↦ by simp [g, fs _ hx, hu]) ?_
     apply compl_subset_compl.1


### PR DESCRIPTION
... to `map_continuous` or `by fun_prop`.


---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include at least one commit authored by each
co-author among the commits in the pull request. If necessary, you may 
create empty commits to indicate co-authorship, using commands like so:

git commit --author="Author Name <author@email.com>" --allow-empty -m "add Author Name as coauthor"

When merging, all the commits will be squashed into a single commit listing all co-authors.

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
