### PR TITLE
[Merged by Bors] - chore: allow uploading oleans for Reap

### DIFF
--- a/Cache/IO.lean
+++ b/Cache/IO.lean
@@ -37,7 +37,11 @@ def isPartOfMathlibCache (mod : Name) : Bool := #[
   `ProofWidgets,
   `Archive,
   `Counterexamples,
-  `MathlibTest ].contains mod.getRoot
+  `MathlibTest,
+  -- Allow PRs to upload oleans for Reap for testing.
+  `Requests,
+  `OpenAIClient,
+  `Reap,].contains mod.getRoot
 
 /-- Target directory for caching -/
 initialize CACHEDIR : FilePath ← do


### PR DESCRIPTION
`reap` is a promising neural theorem prover, with an API and public weights, that we can use in Mathlib already. In #29953 we're trying to prepare a branch that requires `reap`, and imports it in `Tactic.Common`, so that oleans are available. However because this requires a change to Cache.lean, we need to merge that to `master` before oleans can be uploaded, even from another branch.