### PR TITLE
feat: implementation of `Finmap.merge`

### DIFF
--- a/Mathlib/Data/Finmap.lean
+++ b/Mathlib/Data/Finmap.lean
@@ -777,4 +777,3 @@ theorem merge_comm {m₁ m₂ : Finmap β} {f : {x : α} → β x → β x → �
     simp [flip]
 
 end Finmap
-

--- a/Mathlib/Data/List/Permutation.lean
+++ b/Mathlib/Data/List/Permutation.lean
@@ -520,4 +520,29 @@ theorem nodup_permutations_iff {s : List α} : Nodup s.permutations ↔ Nodup s 
 
 -- TODO: `count s s.permutations = (zipWith count s s.tails).prod`
 
+theorem cons_perm_iff_perm_append [DecidableEq α] {a : α} {l₁ l₂ : List α} :
+  a :: l₁ ~ l₂ ↔
+    ∃ t₁ t₂,
+      a ∉ t₁ ∧
+      l₂ = t₁ ++ a :: t₂ ∧
+      l₁ ~ t₁ ++ t₂
+:=
+  calc a :: l₁ ~ l₂
+    _ ↔ a ∈ l₂ ∧ l₁ ~ l₂.erase a := by
+      apply cons_perm_iff_perm_erase
+    _ ↔ (∃ t₁ t₂, l₂ = t₁ ++ a :: t₂ ∧ a ∉ t₁) ∧ l₁ ~ l₂.erase a := by
+      apply and_congr_left; intro h; apply Iff.intro
+      · apply eq_append_cons_of_mem
+      · intro ⟨t₁, t₂, hl₂, _⟩; rw [hl₂]; apply mem_append_cons_self
+    _ ↔ ∃ t₁ t₂, a ∉ t₁ ∧ l₂ = t₁ ++ a :: t₂ ∧ l₁ ~ l₂.erase a := by
+      apply Iff.intro
+      · exact fun ⟨⟨t₁, t₂, hl₂, ha⟩, hperm⟩ => ⟨t₁, t₂, ha, hl₂, hperm⟩
+      · exact fun ⟨t₁, t₂, ha, hl₂, hperm⟩ => ⟨⟨t₁, t₂, hl₂, ha⟩, hperm⟩
+    _ ↔ ∃ t₁ t₂, a ∉ t₁ ∧ l₂ = t₁ ++ a :: t₂ ∧ l₁ ~ t₁ ++ t₂ := by
+      apply exists_congr; intro t₁
+      apply exists_congr; intro t₂
+      apply and_congr_right; intro ha
+      apply and_congr_right; intro hl₂
+      simp [hl₂, erase_append_right _ ha]
+
 end List

--- a/Mathlib/Data/List/Sigma.lean
+++ b/Mathlib/Data/List/Sigma.lean
@@ -748,6 +748,21 @@ theorem dlookup_kunion_eq_some {a} {b : β a} {l₁ l₂ : List (Sigma β)} :
       dlookup a l₁ = some b ∨ a ∉ l₁.keys ∧ dlookup a l₂ = some b :=
   mem_dlookup_kunion
 
+@[simp]
+theorem dlookup_kunion_eq_none {a} {l₁ l₂ : List (Sigma β)} :
+  dlookup a (kunion l₁ l₂) = none ↔ dlookup a l₁ = none ∧ dlookup a l₂ = none := by
+  induction l₁ generalizing l₂ with
+  | nil => simp
+  | cons s _ ih =>
+    let ⟨a', b'⟩ := s
+    by_cases h₁ : a = a'
+    · subst h₁
+      simp
+    · let h₂ := @ih (kerase a' l₂)
+      simp? [h₁] at h₂ says
+        simp only [ne_eq, h₁, not_false_eq_true, dlookup_kerase_ne] at h₂
+      simp [h₁, h₂]
+
 theorem mem_dlookup_kunion_middle {a} {b : β a} {l₁ l₂ l₃ : List (Sigma β)}
     (h₁ : b ∈ dlookup a (kunion l₁ l₃)) (h₂ : a ∉ keys l₂) :
     b ∈ dlookup a (kunion (kunion l₁ l₂) l₃) :=


### PR DESCRIPTION
The main contribution of this pull request is the implementation of a `merge` function for finite maps (`Finmap`). The construction relies on the definition of a `merge` function for association lists (`AList`).

There is also a side (unrelated) contribution on `Mathlib/Data/List/Permutation.lean`: the addition of a theorem about the permutation of a list with a head element (that is, a list of the form `a :: l`).

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include at least one commit authored by each
co-author among the commits in the pull request. If necessary, you may 
create empty commits to indicate co-authorship, using commands like so:

git commit --author="Author Name <author@email.com>" --allow-empty -m "add Author Name as coauthor"

When merging, all the commits will be squashed into a single commit listing all co-authors.

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
