### PR TITLE
[Merged by Bors] - feat(RingTheory): Noetherian ring of fractions is semilocal

### DIFF
--- a/Mathlib/Algebra/GroupWithZero/NonZeroDivisors.lean
+++ b/Mathlib/Algebra/GroupWithZero/NonZeroDivisors.lean
@@ -150,6 +150,9 @@ theorem mul_right_coe_nonZeroDivisors_eq_zero_iff {c : M₀⁰} : x * c = 0 ↔ 
 lemma IsUnit.mem_nonZeroDivisors (hx : IsUnit x) : x ∈ M₀⁰ :=
   ⟨fun _ ↦ hx.mul_right_eq_zero.mp, fun _ ↦ hx.mul_left_eq_zero.mp⟩
 
+variable (M₀) in
+lemma isUnit_le_nonZeroDivisors : IsUnit.submonoid M₀ ≤ M₀⁰ := fun _ ↦ (·.mem_nonZeroDivisors)
+
 section Nontrivial
 variable [Nontrivial M₀]
 

--- a/Mathlib/RingTheory/Ideal/AssociatedPrime/Basic.lean
+++ b/Mathlib/RingTheory/Ideal/AssociatedPrime/Basic.lean
@@ -182,6 +182,11 @@ theorem biUnion_associatedPrimes_eq_zero_divisors [IsNoetherianRing R] :
     obtain ⟨P, hP, hx⟩ := exists_le_isAssociatedPrime_of_isNoetherianRing R x h
     exact Set.mem_biUnion hP (hx h')
 
+theorem biUnion_associatedPrimes_eq_compl_nonZeroDivisors [IsNoetherianRing R] :
+    ⋃ p ∈ associatedPrimes R R, p = (nonZeroDivisors R : Set R)ᶜ :=
+  (biUnion_associatedPrimes_eq_zero_divisors R R).trans <| by
+    ext; simp [← nonZeroDivisorsLeft_eq_nonZeroDivisors, and_comm]
+
 variable {R M}
 
 theorem IsAssociatedPrime.annihilator_le (h : IsAssociatedPrime I M) :

--- a/Mathlib/RingTheory/Ideal/AssociatedPrime/Finiteness.lean
+++ b/Mathlib/RingTheory/Ideal/AssociatedPrime/Finiteness.lean
@@ -5,8 +5,10 @@ Authors: Jinzhao Pan
 -/
 import Mathlib.Order.RelSeries
 import Mathlib.RingTheory.Ideal.AssociatedPrime.Basic
+import Mathlib.RingTheory.Localization.FractionRing
 import Mathlib.RingTheory.Noetherian.Basic
 import Mathlib.RingTheory.Spectrum.Prime.Defs
+import Mathlib.RingTheory.Spectrum.Maximal.Basic
 
 /-!
 
@@ -155,3 +157,18 @@ theorem associatedPrimes.finite : (associatedPrimes A M).Finite := by
     simp [LinearEquiv.AssociatedPrimes.eq f, this]
   | exact N₁ N₂ N₃ f g hf _ hfg h₁ h₃ =>
     exact (h₁.union h₃).subset (associatedPrimes.subset_union_of_exact hf hfg)
+
+theorem MaximalSpectrum.finite_of_nonZeroDivisors_le_isUnit
+    (le : nonZeroDivisors A ≤ IsUnit.submonoid A) :
+    Finite (MaximalSpectrum A) :=
+  have fin := associatedPrimes.finite A A
+  (equivSubtype A).finite_iff.mpr <| Set.finite_coe_iff.mpr <| fin.subset fun I (hI : I.IsMaximal) ↦
+    have ⟨P, hP⟩ := (I.subset_union_prime_finite fin (f := id) 0 0 fun _ h _ _ ↦ h.isPrime).1 <| by
+      simp_rw [id, biUnion_associatedPrimes_eq_compl_nonZeroDivisors]
+      exact fun x hx h ↦ hI.ne_top (I.eq_top_of_isUnit_mem hx (le h))
+    hI.eq_of_le hP.1.isPrime.ne_top hP.2 ▸ hP.1
+
+/-- A commutative Noetherian total ring of fractions is semilocal. -/
+instance [IsFractionRing A A] : Finite (MaximalSpectrum A) :=
+  MaximalSpectrum.finite_of_nonZeroDivisors_le_isUnit _
+    (IsFractionRing.self_iff_nonZeroDivisors_le_isUnit.mp ‹_›)

--- a/Mathlib/RingTheory/Ideal/AssociatedPrime/Finiteness.lean
+++ b/Mathlib/RingTheory/Ideal/AssociatedPrime/Finiteness.lean
@@ -158,17 +158,18 @@ theorem associatedPrimes.finite : (associatedPrimes A M).Finite := by
   | exact N₁ N₂ N₃ f g hf _ hfg h₁ h₃ =>
     exact (h₁.union h₃).subset (associatedPrimes.subset_union_of_exact hf hfg)
 
-theorem MaximalSpectrum.finite_of_nonZeroDivisors_le_isUnit
-    (le : nonZeroDivisors A ≤ IsUnit.submonoid A) :
-    Finite (MaximalSpectrum A) :=
+/-- Every maximal ideal of a commutative Noetherian total ring of fractions `A` is
+an associated prime of the `A`-module `A`. -/
+theorem Ideal.IsMaximal.mem_associatedPrimes_of_isFractionRing [IsFractionRing A A]
+    (I : Ideal A) [hI : I.IsMaximal] : I ∈ associatedPrimes A A :=
   have fin := associatedPrimes.finite A A
-  (equivSubtype A).finite_iff.mpr <| Set.finite_coe_iff.mpr <| fin.subset fun I (hI : I.IsMaximal) ↦
-    have ⟨P, hP⟩ := (I.subset_union_prime_finite fin (f := id) 0 0 fun _ h _ _ ↦ h.isPrime).1 <| by
-      simp_rw [id, biUnion_associatedPrimes_eq_compl_nonZeroDivisors]
-      exact fun x hx h ↦ hI.ne_top (I.eq_top_of_isUnit_mem hx (le h))
-    hI.eq_of_le hP.1.isPrime.ne_top hP.2 ▸ hP.1
+  have ⟨P, hP⟩ := (I.subset_union_prime_finite fin (f := id) 0 0 fun _ h _ _ ↦ h.isPrime).1 <| by
+    simp_rw [id, biUnion_associatedPrimes_eq_compl_nonZeroDivisors]
+    exact fun x hx h ↦ hI.ne_top <| I.eq_top_of_isUnit_mem hx
+      (IsFractionRing.self_iff_nonZeroDivisors_le_isUnit.mp ‹_› h)
+  hI.eq_of_le hP.1.isPrime.ne_top hP.2 ▸ hP.1
 
 /-- A commutative Noetherian total ring of fractions is semilocal. -/
 instance [IsFractionRing A A] : Finite (MaximalSpectrum A) :=
-  MaximalSpectrum.finite_of_nonZeroDivisors_le_isUnit _
-    (IsFractionRing.self_iff_nonZeroDivisors_le_isUnit.mp ‹_›)
+  (MaximalSpectrum.equivSubtype A).finite_iff.mpr <| Set.finite_coe_iff.mpr <|
+    (associatedPrimes.finite A A).subset fun _ ↦ (·.mem_associatedPrimes_of_isFractionRing)

--- a/Mathlib/RingTheory/Localization/Basic.lean
+++ b/Mathlib/RingTheory/Localization/Basic.lean
@@ -302,6 +302,10 @@ theorem isLocalization_of_algEquiv [Algebra R P] [IsLocalization M S] (h : S ≃
       h.symm.commutes]
     exact id
 
+variable {M} in
+protected theorem self (H : M ≤ IsUnit.submonoid R) : IsLocalization M R :=
+  isLocalization_of_algEquiv _ (atUnits _ _ (S := Localization M) H).symm
+
 theorem isLocalization_iff_of_algEquiv [Algebra R P] (h : S ≃ₐ[R] P) :
     IsLocalization M S ↔ IsLocalization M P :=
   ⟨fun _ => isLocalization_of_algEquiv M h, fun _ => isLocalization_of_algEquiv M h.symm⟩

--- a/Mathlib/RingTheory/Localization/FractionRing.lean
+++ b/Mathlib/RingTheory/Localization/FractionRing.lean
@@ -128,14 +128,16 @@ theorem nonZeroDivisors_eq_isUnit : K⁰ = IsUnit.submonoid K := by
   exact isUnit_of_mul_isUnit_left <| eq ▸ map_units K r'
 
 include R in
-/-- Taking fraction ring is idempotent: a fraction ring of a fraction ring of `R` is
-itself a fraction ring of `R`. -/
+/-- If `L` is a fraction ring of `K` which is a fraction ring of `R`,
+the `K`-algebra homomorphism from `K` to `L` is an isomorphism. -/
 noncomputable def algEquiv (L) [CommRing L] [Algebra K L] [IsFractionRing K L] : K ≃ₐ[K] L :=
   atUnits K _ (nonZeroDivisors_eq_isUnit R K).le
 
 include R in
 theorem idem : IsFractionRing K K := IsLocalization.self (nonZeroDivisors_eq_isUnit R K).le
 
+/-- Taking fraction ring is idempotent: a fraction ring of a fraction ring of `R` is
+itself a fraction ring of `R`. -/
 theorem trans (L) [CommRing L] [Algebra K L] [IsFractionRing K L] [Algebra R L]
     [IsScalarTower R K L] : IsFractionRing R L :=
   isLocalization_of_algEquiv _ <| (algEquiv R K L).restrictScalars R

--- a/Mathlib/RingTheory/Localization/FractionRing.lean
+++ b/Mathlib/RingTheory/Localization/FractionRing.lean
@@ -36,6 +36,8 @@ commutative ring, field of fractions
 
 assert_not_exists Ideal
 
+open nonZeroDivisors
+
 variable (R : Type*) [CommRing R] {M : Submonoid R} (S : Type*) [CommRing S]
 variable [Algebra R S] {P : Type*} [CommRing P]
 variable {A : Type*} [CommRing A] (K : Type*)
@@ -117,10 +119,48 @@ variable (R K)
 protected theorem injective : Function.Injective (algebraMap R K) :=
   IsLocalization.injective _ (le_of_eq rfl)
 
+include R in
+theorem nonZeroDivisors_eq_isUnit : K⁰ = IsUnit.submonoid K := by
+  refine le_antisymm (fun x hx ↦ ?_) (isUnit_le_nonZeroDivisors K)
+  have ⟨r, eq⟩ := surj R⁰ x
+  let r' : R⁰ := ⟨r.1, mem_nonZeroDivisors_of_injective (IsFractionRing.injective R K)
+    (eq ▸ mul_mem hx (map_units ..).mem_nonZeroDivisors)⟩
+  exact isUnit_of_mul_isUnit_left <| eq ▸ map_units K r'
+
+include R in
+/-- Taking fraction ring is idempotent: a fraction ring of a fraction ring of `R` is
+itself a fraction ring of `R`. -/
+noncomputable def algEquiv (L) [CommRing L] [Algebra K L] [IsFractionRing K L] : K ≃ₐ[K] L :=
+  atUnits K _ (nonZeroDivisors_eq_isUnit R K).le
+
+include R in
+theorem idem : IsFractionRing K K := IsLocalization.self (nonZeroDivisors_eq_isUnit R K).le
+
+theorem trans (L) [CommRing L] [Algebra K L] [IsFractionRing K L] [Algebra R L]
+    [IsScalarTower R K L] : IsFractionRing R L :=
+  isLocalization_of_algEquiv _ <| (algEquiv R K L).restrictScalars R
+
 instance (priority := 100) : FaithfulSMul R K :=
   (faithfulSMul_iff_algebraMap_injective R K).mpr <| IsFractionRing.injective R K
 
-variable {R K}
+variable {R}
+
+theorem self_iff_nonZeroDivisors_eq_isUnit : IsFractionRing R R ↔ R⁰ = IsUnit.submonoid R where
+  mp _ := nonZeroDivisors_eq_isUnit R R
+  mpr h := IsLocalization.self h.le
+
+theorem self_iff_nonZeroDivisors_le_isUnit : IsFractionRing R R ↔ R⁰ ≤ IsUnit.submonoid R := by
+  rw [self_iff_nonZeroDivisors_eq_isUnit, le_antisymm_iff,
+    and_iff_left (isUnit_le_nonZeroDivisors R)]
+
+theorem self_iff_bijective : IsFractionRing R R ↔ Function.Bijective (algebraMap R K) where
+  mp h := (atUnits R _ <| self_iff_nonZeroDivisors_le_isUnit.mp h).bijective
+  mpr h := isLocalization_of_algEquiv _ (AlgEquiv.ofBijective (Algebra.ofId R K) h).symm
+
+theorem self_iff_surjective : IsFractionRing R R ↔ Function.Surjective (algebraMap R K) := by
+  rw [self_iff_bijective K, Function.Bijective, and_iff_right (IsFractionRing.injective R K)]
+
+variable {K}
 
 open algebraMap in
 @[norm_cast]
@@ -534,6 +574,8 @@ abbrev FractionRing :=
   Localization (nonZeroDivisors R)
 
 namespace FractionRing
+
+instance : IsFractionRing (FractionRing R) (FractionRing R) := IsFractionRing.idem R _
 
 instance unique [Subsingleton R] : Unique (FractionRing R) := inferInstance
 


### PR DESCRIPTION
A step towards showing invertible modules over Noetherian (comm.) rings are isomorphic to ideals, see https://mathoverflow.net/a/499611.

The argument is [due to Gemini](https://gemini.google.com/share/0266bae9b43b) even though it was initially mistaken.

A ring of fractions is a ring `R` that is its own ring of fractions (i.e. satisfying `IsFractionRing R R`). We show this is equivalent to the condition that all non-zerodivisors are units.

---

<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include at least one commit authored by each
co-author among the commits in the pull request. If necessary, you may 
create empty commits to indicate co-authorship, using commands like so:

git commit --author="Author Name <author@email.com>" --allow-empty -m "add Author Name as coauthor"

When merging, all the commits will be squashed into a single commit listing all co-authors.

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
