### PR TITLE
[Merged by Bors] - feat(GroupTheory/Finiteness): submonoid finiteness from well-quasi-order, Gordan's lemma

### DIFF
--- a/Mathlib/GroupTheory/Finiteness.lean
+++ b/Mathlib/GroupTheory/Finiteness.lean
@@ -560,12 +560,12 @@ theorem AddSubmonoid.fg_of_subtractive {P : AddSubmonoid M} (hP : ∀ x ∈ P, �
     rcases exists_add_of_le hz₁.le with ⟨y, rfl⟩
     apply add_mem
     · exact ih _ hz₂ hz₃ hz₁.le hz₁.not_ge
-    · apply ih
-      · exact hP _ hz₂ _ hy₁
-      · exact (pos_of_lt_add_right hz₁).ne.symm
-      · exact le_add_self
-      · rw [add_le_iff_nonpos_left]
-        exact (pos_of_ne_zero hz₃).not_ge
+    apply ih
+    · exact hP _ hz₂ _ hy₁
+    · exact (pos_of_lt_add_right hz₁).ne.symm
+    · exact le_add_self
+    · rw [add_le_iff_nonpos_left]
+      exact (pos_of_ne_zero hz₃).not_ge
 
 /-- If `f` `g` are homomorphisms from a canonically ordered and well-quasi-ordered monoid `M` to a
 cancellative monoid `N`, the submonoid `eqLocusM f g` is finitely generated in `M`. When `M` and `N`

--- a/Mathlib/GroupTheory/Finiteness.lean
+++ b/Mathlib/GroupTheory/Finiteness.lean
@@ -536,8 +536,8 @@ section WellQuasiOrderedLE
 variable {M N : Type*} [AddCommMonoid M] [PartialOrder M] [WellQuasiOrderedLE M]
   [IsOrderedCancelAddMonoid M] [CanonicallyOrderedAdd M]
 
-/-- In a canonically ordered and well-quasi-ordered monoid, any subtractive submonoid is finitely
-generated. -/
+/-- In a canonically ordered and well-quasi-ordered monoid (typical example is `ℕ ^ k`), any
+subtractive submonoid is finitely generated. -/
 theorem AddSubmonoid.fg_of_subtractive {P : AddSubmonoid M} (hP : ∀ x ∈ P, ∀ y, x + y ∈ P → y ∈ P) :
     P.FG := by
   have hpwo := Set.isPWO_of_wellQuasiOrderedLE { x | x ∈ P ∧ x ≠ 0 }
@@ -568,8 +568,8 @@ theorem AddSubmonoid.fg_of_subtractive {P : AddSubmonoid M} (hP : ∀ x ∈ P, �
       exact (pos_of_ne_zero hz₃).not_ge
 
 /-- If `f` `g` are homomorphisms from a canonically ordered and well-quasi-ordered monoid `M` to a
-cancellative monoid `N`, the submonoid `eqLocusM f g` is finitely generated in `M`. When `M` and `N`
-are `ℕ ^ k`, this is also known as a version of **Gordan's lemma**. -/
+cancellative monoid `N`, the submonoid of `M` on which `f` and `g` agree is finitely generated. When
+`M` and `N` are `ℕ ^ k`, this is also known as a version of **Gordan's lemma**. -/
 theorem AddSubmonoid.fg_eqLocusM [AddMonoid N] [IsCancelAdd N] (f g : M →+ N) : (f.eqLocusM g).FG :=
   fg_of_subtractive (by simp_all)
 


### PR DESCRIPTION
We show that in a monoid whose algebraic order is a well-quasi-order (typical example is `ℕ ^ k`), any subtractive submonoid is finitely generated. As a corollary, `AddMonoidHom.eqLocusM f g` is finitely generated, which is also known as [a version of Gordan's lemma](https://en.wikipedia.org/wiki/Gordan%27s_lemma) when specialized for `ℕ ^ k`.

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include at least one commit authored by each
co-author among the commits in the pull request. If necessary, you may 
create empty commits to indicate co-authorship, using commands like so:

git commit --author="Author Name <author@email.com>" --allow-empty -m "add Author Name as coauthor"

When merging, all the commits will be squashed into a single commit listing all co-authors.

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
