### PR TITLE
[Merged by Bors] - feat(SetTheory/ZFC): add `ZFSet.iUnion`

### DIFF
--- a/Mathlib/SetTheory/ZFC/Basic.lean
+++ b/Mathlib/SetTheory/ZFC/Basic.lean
@@ -685,6 +685,27 @@ theorem toSet_range {α} [Small.{u} α] (f : α → ZFSet.{u}) :
 
 theorem mem_range_self {α} [Small.{u} α] {f : α → ZFSet.{u}} (a : α) : f a ∈ range f := by simp
 
+/-- Indexed union of a family of ZFC sets. Uses `⋃` notation, scoped under the `ZFSet` namespace. -/
+noncomputable def iUnion {α} [Small.{u} α] (f : α → ZFSet.{u}) : ZFSet.{u} :=
+  sUnion (range f)
+
+@[inherit_doc iUnion] scoped notation3 "⋃ " (...)", " r:60:(scoped f => iUnion f) => r
+
+@[simp]
+theorem mem_iUnion {α} [Small.{u} α] {f : α → ZFSet.{u}} {x : ZFSet.{u}} :
+    x ∈ ⋃ i, f i ↔ ∃ i, x ∈ f i := by
+  simp [iUnion]
+
+@[simp]
+theorem toSet_iUnion {α} [Small.{u} α] (f : α → ZFSet.{u}) :
+    (⋃ i, f i).toSet = ⋃ i, (f i).toSet := by
+  ext
+  simp
+
+theorem subset_iUnion {α} [Small.{u} α] (f : α → ZFSet.{u}) (i : α) : f i ⊆ ⋃ i, f i := by
+  intro x hx
+  simpa using ⟨i, hx⟩
+
 /-- Kuratowski ordered pair -/
 def pair (x y : ZFSet.{u}) : ZFSet.{u} :=
   {{x}, {x, y}}

--- a/Mathlib/SetTheory/ZFC/Basic.lean
+++ b/Mathlib/SetTheory/ZFC/Basic.lean
@@ -662,7 +662,7 @@ theorem toSet_image (f : ZFSet → ZFSet) [Definable₁ f] (x : ZFSet) :
   ext
   simp
 
-section
+section Small
 
 variable {α : Type*} [Small.{u} α]
 
@@ -706,7 +706,7 @@ theorem subset_iUnion (f : α → ZFSet.{u}) (i : α) : f i ⊆ ⋃ i, f i := by
   intro x hx
   simpa using ⟨i, hx⟩
 
-end
+end Small
 
 /-- Kuratowski ordered pair -/
 def pair (x y : ZFSet.{u}) : ZFSet.{u} :=

--- a/Mathlib/SetTheory/ZFC/Basic.lean
+++ b/Mathlib/SetTheory/ZFC/Basic.lean
@@ -662,13 +662,16 @@ theorem toSet_image (f : ZFSet → ZFSet) [Definable₁ f] (x : ZFSet) :
   ext
   simp
 
+section
+
+variable {α : Type*} [Small.{u} α]
+
 /-- The range of a type-indexed family of sets. -/
-noncomputable def range {α : Type*} [Small.{u} α] (f : α → ZFSet.{u}) : ZFSet.{u} :=
+noncomputable def range (f : α → ZFSet.{u}) : ZFSet.{u} :=
   ⟦⟨_, Quotient.out ∘ f ∘ (equivShrink α).symm⟩⟧
 
 @[simp]
-theorem mem_range {α : Type*} [Small.{u} α] {f : α → ZFSet.{u}} {x : ZFSet.{u}} :
-    x ∈ range f ↔ x ∈ Set.range f :=
+theorem mem_range {f : α → ZFSet.{u}} {x : ZFSet.{u}} : x ∈ range f ↔ x ∈ Set.range f :=
   Quotient.inductionOn x fun y => by
     constructor
     · rintro ⟨z, hz⟩
@@ -678,34 +681,32 @@ theorem mem_range {α : Type*} [Small.{u} α] {f : α → ZFSet.{u}} {x : ZFSet.
       simpa [hz] using PSet.Equiv.symm (Quotient.mk_out y)
 
 @[simp]
-theorem toSet_range {α : Type*} [Small.{u} α] (f : α → ZFSet.{u}) :
-    (range f).toSet = Set.range f := by
+theorem toSet_range (f : α → ZFSet.{u}) : (range f).toSet = Set.range f := by
   ext
   simp
 
-theorem mem_range_self {α : Type*} [Small.{u} α] {f : α → ZFSet.{u}} (a : α) : f a ∈ range f := by
-  simp
+theorem mem_range_self {f : α → ZFSet.{u}} (a : α) : f a ∈ range f := by simp
 
 /-- Indexed union of a family of ZFC sets. Uses `⋃` notation, scoped under the `ZFSet` namespace. -/
-noncomputable def iUnion {α : Type*} [Small.{u} α] (f : α → ZFSet.{u}) : ZFSet.{u} :=
+noncomputable def iUnion (f : α → ZFSet.{u}) : ZFSet.{u} :=
   sUnion (range f)
 
 @[inherit_doc iUnion] scoped notation3 "⋃ " (...)", " r:60:(scoped f => iUnion f) => r
 
 @[simp]
-theorem mem_iUnion {α : Type*} [Small.{u} α] {f : α → ZFSet.{u}} {x : ZFSet.{u}} :
-    x ∈ ⋃ i, f i ↔ ∃ i, x ∈ f i := by
+theorem mem_iUnion {f : α → ZFSet.{u}} {x : ZFSet.{u}} : x ∈ ⋃ i, f i ↔ ∃ i, x ∈ f i := by
   simp [iUnion]
 
 @[simp]
-theorem toSet_iUnion {α : Type*} [Small.{u} α] (f : α → ZFSet.{u}) :
-    (⋃ i, f i).toSet = ⋃ i, (f i).toSet := by
+theorem toSet_iUnion (f : α → ZFSet.{u}) : (⋃ i, f i).toSet = ⋃ i, (f i).toSet := by
   ext
   simp
 
-theorem subset_iUnion {α : Type*} [Small.{u} α] (f : α → ZFSet.{u}) (i : α) : f i ⊆ ⋃ i, f i := by
+theorem subset_iUnion (f : α → ZFSet.{u}) (i : α) : f i ⊆ ⋃ i, f i := by
   intro x hx
   simpa using ⟨i, hx⟩
+
+end
 
 /-- Kuratowski ordered pair -/
 def pair (x y : ZFSet.{u}) : ZFSet.{u} :=

--- a/Mathlib/SetTheory/ZFC/Basic.lean
+++ b/Mathlib/SetTheory/ZFC/Basic.lean
@@ -663,11 +663,11 @@ theorem toSet_image (f : ZFSet → ZFSet) [Definable₁ f] (x : ZFSet) :
   simp
 
 /-- The range of a type-indexed family of sets. -/
-noncomputable def range {α} [Small.{u} α] (f : α → ZFSet.{u}) : ZFSet.{u} :=
+noncomputable def range {α : Type*} [Small.{u} α] (f : α → ZFSet.{u}) : ZFSet.{u} :=
   ⟦⟨_, Quotient.out ∘ f ∘ (equivShrink α).symm⟩⟧
 
 @[simp]
-theorem mem_range {α} [Small.{u} α] {f : α → ZFSet.{u}} {x : ZFSet.{u}} :
+theorem mem_range {α : Type*} [Small.{u} α] {f : α → ZFSet.{u}} {x : ZFSet.{u}} :
     x ∈ range f ↔ x ∈ Set.range f :=
   Quotient.inductionOn x fun y => by
     constructor
@@ -678,31 +678,32 @@ theorem mem_range {α} [Small.{u} α] {f : α → ZFSet.{u}} {x : ZFSet.{u}} :
       simpa [hz] using PSet.Equiv.symm (Quotient.mk_out y)
 
 @[simp]
-theorem toSet_range {α} [Small.{u} α] (f : α → ZFSet.{u}) :
+theorem toSet_range {α : Type*} [Small.{u} α] (f : α → ZFSet.{u}) :
     (range f).toSet = Set.range f := by
   ext
   simp
 
-theorem mem_range_self {α} [Small.{u} α] {f : α → ZFSet.{u}} (a : α) : f a ∈ range f := by simp
+theorem mem_range_self {α : Type*} [Small.{u} α] {f : α → ZFSet.{u}} (a : α) : f a ∈ range f := by
+  simp
 
 /-- Indexed union of a family of ZFC sets. Uses `⋃` notation, scoped under the `ZFSet` namespace. -/
-noncomputable def iUnion {α} [Small.{u} α] (f : α → ZFSet.{u}) : ZFSet.{u} :=
+noncomputable def iUnion {α : Type*} [Small.{u} α] (f : α → ZFSet.{u}) : ZFSet.{u} :=
   sUnion (range f)
 
 @[inherit_doc iUnion] scoped notation3 "⋃ " (...)", " r:60:(scoped f => iUnion f) => r
 
 @[simp]
-theorem mem_iUnion {α} [Small.{u} α] {f : α → ZFSet.{u}} {x : ZFSet.{u}} :
+theorem mem_iUnion {α : Type*} [Small.{u} α] {f : α → ZFSet.{u}} {x : ZFSet.{u}} :
     x ∈ ⋃ i, f i ↔ ∃ i, x ∈ f i := by
   simp [iUnion]
 
 @[simp]
-theorem toSet_iUnion {α} [Small.{u} α] (f : α → ZFSet.{u}) :
+theorem toSet_iUnion {α : Type*} [Small.{u} α] (f : α → ZFSet.{u}) :
     (⋃ i, f i).toSet = ⋃ i, (f i).toSet := by
   ext
   simp
 
-theorem subset_iUnion {α} [Small.{u} α] (f : α → ZFSet.{u}) (i : α) : f i ⊆ ⋃ i, f i := by
+theorem subset_iUnion {α : Type*} [Small.{u} α] (f : α → ZFSet.{u}) (i : α) : f i ⊆ ⋃ i, f i := by
   intro x hx
   simpa using ⟨i, hx⟩
 

--- a/Mathlib/SetTheory/ZFC/Ordinal.lean
+++ b/Mathlib/SetTheory/ZFC/Ordinal.lean
@@ -65,6 +65,10 @@ theorem IsTransitive.sUnion' (H : ∀ y ∈ x, IsTransitive y) :
   rcases mem_sUnion.1 hy with ⟨w, hw, hw'⟩
   exact mem_sUnion_of_mem ((H w hw).mem_trans hz hw') hw
 
+protected theorem IsTransitive.iUnion {α} [Small.{u} α] {f : α → ZFSet.{u}}
+    (hf : ∀ i, (f i).IsTransitive) : (⋃ i, f i).IsTransitive :=
+  sUnion' (by simpa)
+
 protected theorem IsTransitive.union (hx : x.IsTransitive) (hy : y.IsTransitive) :
     (x ∪ y).IsTransitive := by
   rw [← sUnion_pair]

--- a/Mathlib/SetTheory/ZFC/Ordinal.lean
+++ b/Mathlib/SetTheory/ZFC/Ordinal.lean
@@ -65,7 +65,7 @@ theorem IsTransitive.sUnion' (H : ∀ y ∈ x, IsTransitive y) :
   rcases mem_sUnion.1 hy with ⟨w, hw, hw'⟩
   exact mem_sUnion_of_mem ((H w hw).mem_trans hz hw') hw
 
-protected theorem IsTransitive.iUnion {α} [Small.{u} α] {f : α → ZFSet.{u}}
+protected theorem IsTransitive.iUnion {α : Type*} [Small.{u} α] {f : α → ZFSet.{u}}
     (hf : ∀ i, (f i).IsTransitive) : (⋃ i, f i).IsTransitive :=
   sUnion' (by simpa)
 

--- a/Mathlib/SetTheory/ZFC/Rank.lean
+++ b/Mathlib/SetTheory/ZFC/Rank.lean
@@ -201,6 +201,15 @@ theorem rank_range {α : Type*} [Small.{u} α] (f : α → ZFSet.{u}) :
   · simpa [rank_le_iff, ← succ_le_iff] using Ordinal.le_iSup _
   · simp [rank_lt_of_mem]
 
+@[simp]
+theorem rank_iUnion {α} [Small.{u} α] (f : α → ZFSet.{u}) :
+    rank (⋃ i, f i) = ⨆ i, rank (f i) := by
+  apply le_antisymm
+  · simp_rw [rank_le_iff, mem_iUnion]
+    intro y ⟨i, hy⟩
+    exact (rank_lt_of_mem hy).trans_le (Ordinal.le_iSup _ _)
+  · exact Ordinal.iSup_le fun i => rank_mono (subset_iUnion f i)
+
 /-- `ZFSet.rank` is equal to the `IsWellFounded.rank` over `∈`. -/
 theorem rank_eq_wfRank : lift.{u + 1, u} (rank x) = IsWellFounded.rank (α := ZFSet) (· ∈ ·) x := by
   induction x using inductionOn with | _ x ih

--- a/Mathlib/SetTheory/ZFC/Rank.lean
+++ b/Mathlib/SetTheory/ZFC/Rank.lean
@@ -202,7 +202,7 @@ theorem rank_range {α : Type*} [Small.{u} α] (f : α → ZFSet.{u}) :
   · simp [rank_lt_of_mem]
 
 @[simp]
-theorem rank_iUnion {α} [Small.{u} α] (f : α → ZFSet.{u}) :
+theorem rank_iUnion {α : Type*} [Small.{u} α] (f : α → ZFSet.{u}) :
     rank (⋃ i, f i) = ⨆ i, rank (f i) := by
   apply le_antisymm
   · simp_rw [rank_le_iff, mem_iUnion]

--- a/Mathlib/SetTheory/ZFC/VonNeumann.lean
+++ b/Mathlib/SetTheory/ZFC/VonNeumann.lean
@@ -33,7 +33,7 @@ namespace ZFSet
 - `vonNeumann_of_isSuccPrelimit`: `IsSuccPrelimit a → V_ a = ⋃ b < a, V_ b`
 -/
 noncomputable def vonNeumann (o : Ordinal.{u}) : ZFSet.{u} :=
-  ⋃₀ range fun a : Set.Iio o ↦ powerset (vonNeumann a)
+  ⋃ a : Set.Iio o, powerset (vonNeumann a)
 termination_by o
 decreasing_by exact a.2
 
@@ -46,9 +46,7 @@ lemma mem_vonNeumann' : x ∈ V_ o ↔ ∃ a < o, x ⊆ V_ a := by rw [vonNeuman
 
 theorem isTransitive_vonNeumann (o : Ordinal) : IsTransitive (V_ o) := by
   rw [vonNeumann]
-  refine IsTransitive.sUnion' fun x hx ↦ ?_
-  obtain ⟨⟨a, _⟩, rfl⟩ := mem_range.1 hx
-  exact (isTransitive_vonNeumann a).powerset
+  exact IsTransitive.iUnion fun ⟨a, _⟩ => (isTransitive_vonNeumann a).powerset
 termination_by o
 
 @[gcongr] theorem vonNeumann_mem_of_lt (h : a < b) : V_ a ∈ V_ b := by
@@ -123,7 +121,7 @@ theorem vonNeumann_succ (o : Ordinal) : V_ (succ o) = powerset (V_ o) :=
   ext fun z ↦ by rw [mem_vonNeumann, mem_powerset, subset_vonNeumann, lt_succ_iff]
 
 theorem vonNeumann_of_isSuccPrelimit (h : IsSuccPrelimit o) :
-    V_ o = (⋃₀ range fun a : Set.Iio o ↦ vonNeumann a : ZFSet) :=
+    V_ o = ⋃ a : Set.Iio o, vonNeumann a :=
   ext fun z ↦ by simpa [mem_vonNeumann] using h.lt_iff_exists_lt
 
 theorem iUnion_vonNeumann : ⋃ o, (V_ o : Class) = Class.univ :=

--- a/Mathlib/SetTheory/ZFC/VonNeumann.lean
+++ b/Mathlib/SetTheory/ZFC/VonNeumann.lean
@@ -46,7 +46,7 @@ lemma mem_vonNeumann' : x ∈ V_ o ↔ ∃ a < o, x ⊆ V_ a := by rw [vonNeuman
 
 theorem isTransitive_vonNeumann (o : Ordinal) : IsTransitive (V_ o) := by
   rw [vonNeumann]
-  exact IsTransitive.iUnion fun ⟨a, _⟩ => (isTransitive_vonNeumann a).powerset
+  exact .iUnion fun ⟨a, _⟩ => (isTransitive_vonNeumann a).powerset
 termination_by o
 
 @[gcongr] theorem vonNeumann_mem_of_lt (h : a < b) : V_ a ∈ V_ b := by


### PR DESCRIPTION
which is just `sUnion (range f)`.  We add a new definition for it instead of making `⋃ i, f i` a notation of `sUnion (range f)`, because the simp normal form of `(sUnion (range f)).toSet` is not `⋃ i, (f i).toSet`.

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include at least one commit authored by each
co-author among the commits in the pull request. If necessary, you may 
create empty commits to indicate co-authorship, using commands like so:

git commit --author="Author Name <author@email.com>" --allow-empty -m "add Author Name as coauthor"

When merging, all the commits will be squashed into a single commit listing all co-authors.

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
