### PR TITLE
fix: deprecate IsTotal in favour of Std.Total

### DIFF
--- a/Mathlib/Algebra/Group/Basic.lean
+++ b/Mathlib/Algebra/Group/Basic.lean
@@ -1027,40 +1027,48 @@ end CommGroup
 
 section multiplicative
 
-variable [Monoid β] (p r : α → α → Prop) [IsTotal α r] (f : α → α → β)
+variable [Monoid β] (p r : α → α → Prop) [Std.Total r] (f : α → α → β)
 
-@[to_additive additive_of_symmetric_of_isTotal]
-lemma multiplicative_of_symmetric_of_isTotal
+@[to_additive additive_of_symmetric_of_stdTotal]
+lemma multiplicative_of_symmetric_of_stdTotal
     (hsymm : Symmetric p) (hf_swap : ∀ {a b}, p a b → f a b * f b a = 1)
     (hmul : ∀ {a b c}, r a b → r b c → p a b → p b c → p a c → f a c = f a b * f b c)
     {a b c : α} (pab : p a b) (pbc : p b c) (pac : p a c) : f a c = f a b * f b c := by
   have hmul' : ∀ {b c}, r b c → p a b → p b c → p a c → f a c = f a b * f b c := by
     intro b c rbc pab pbc pac
-    obtain rab | rba := total_of r a b
+    obtain rab | rba := Std.Total.total (r := r) a b
     · exact hmul rab rbc pab pbc pac
     rw [← one_mul (f a c), ← hf_swap pab, mul_assoc]
-    obtain rac | rca := total_of r a c
+    obtain rac | rca := Std.Total.total (r := r) a c
     · rw [hmul rba rac (hsymm pab) pac pbc]
     · rw [hmul rbc rca pbc (hsymm pac) (hsymm pab), mul_assoc, hf_swap (hsymm pac), mul_one]
-  obtain rbc | rcb := total_of r b c
+  obtain rbc | rcb := Std.Total.total (r := r) b c
   · exact hmul' rbc pab pbc pac
   · rw [hmul' rcb pac (hsymm pbc) pab, mul_assoc, hf_swap (hsymm pbc), mul_one]
+
+@[to_additive (attr := deprecated additive_of_symmetric_of_stdTotal (since := "2025-10-24"))
+additive_of_symmetric_of_isTotal]
+alias multiplicative_of_symmetric_of_isTotal := multiplicative_of_symmetric_of_stdTotal
 
 /-- If a binary function from a type equipped with a total relation `r` to a monoid is
   anti-symmetric (i.e. satisfies `f a b * f b a = 1`), in order to show it is multiplicative
   (i.e. satisfies `f a c = f a b * f b c`), we may assume `r a b` and `r b c` are satisfied.
   We allow restricting to a subset specified by a predicate `p`. -/
-@[to_additive additive_of_isTotal /-- If a binary function from a type equipped with a total
+@[to_additive additive_of_stdTotal /-- If a binary function from a type equipped with a total
   relation `r` to an additive monoid is anti-symmetric (i.e. satisfies `f a b + f b a = 0`), in
   order to show it is additive (i.e. satisfies `f a c = f a b + f b c`), we may assume `r a b` and
   `r b c` are satisfied. We allow restricting to a subset specified by a predicate `p`. -/]
-theorem multiplicative_of_isTotal (p : α → Prop) (hswap : ∀ {a b}, p a → p b → f a b * f b a = 1)
+theorem multiplicative_of_stdTotal (p : α → Prop) (hswap : ∀ {a b}, p a → p b → f a b * f b a = 1)
     (hmul : ∀ {a b c}, r a b → r b c → p a → p b → p c → f a c = f a b * f b c) {a b c : α}
     (pa : p a) (pb : p b) (pc : p c) : f a c = f a b * f b c := by
-  apply multiplicative_of_symmetric_of_isTotal (fun a b => p a ∧ p b) r f fun _ _ => And.symm
+  apply multiplicative_of_symmetric_of_stdTotal (fun a b => p a ∧ p b) r f fun _ _ => And.symm
   · simp_rw [and_imp]; exact @hswap
   · exact fun rab rbc pab _pbc pac => hmul rab rbc pab.1 pab.2 pac.2
   exacts [⟨pa, pb⟩, ⟨pb, pc⟩, ⟨pa, pc⟩]
+
+@[to_additive (attr := deprecated additive_of_stdTotal (since := "2025-10-24"))
+additive_of_isTotal]
+alias multiplicative_of_isTotal := multiplicative_of_stdTotal
 
 end multiplicative
 

--- a/Mathlib/Algebra/Order/Archimedean/Class.lean
+++ b/Mathlib/Algebra/Order/Archimedean/Class.lean
@@ -137,7 +137,7 @@ instance : Preorder (MulArchimedeanOrder M) where
     exact ⟨1, by simpa using h⟩
 
 @[to_additive]
-instance : IsTotal (MulArchimedeanOrder M) (· ≤ ·) where
+instance : Std.Total (α := MulArchimedeanOrder M) (· ≤ ·) where
   total a b := by
     obtain hab | hab := le_total |a.val|ₘ |b.val|ₘ
     · exact .inr ⟨1, by simpa using hab⟩

--- a/Mathlib/Algebra/Order/GroupWithZero/Canonical.lean
+++ b/Mathlib/Algebra/Order/GroupWithZero/Canonical.lean
@@ -470,8 +470,9 @@ instance decidableLT [Preorder α] [DecidableLT α] : DecidableLT (WithZero α)
   | 0, (a : α) => isTrue <| by simp
   | (a : α), (b : α) => decidable_of_iff' _ coe_lt_coe
 
-instance isTotal_le [Preorder α] [IsTotal α (· ≤ ·)] : IsTotal (WithZero α) (· ≤ ·) where
-  total x y := by cases x <;> cases y <;> simp; simpa using IsTotal.total ..
+instance inst_stdTotal_le [Preorder α] [Std.Total (α := α) (· ≤ ·)] :
+    Std.Total (α := WithZero α) (· ≤ ·) where
+  total x y := by cases x <;> cases y <;> simp; simpa using Std.Total.total ..
 
 section LinearOrder
 variable [LinearOrder α] {a b c : α} {x y : WithZero α}

--- a/Mathlib/Algebra/Order/Ring/Canonical.lean
+++ b/Mathlib/Algebra/Order/Ring/Canonical.lean
@@ -88,20 +88,20 @@ section Sub
 section NonUnitalNonAssocSemiring
 
 variable [NonUnitalNonAssocSemiring R] [PartialOrder R] [CanonicallyOrderedAdd R]
-  [Sub R] [OrderedSub R] [IsTotal R (· ≤ ·)]
+  [Sub R] [OrderedSub R] [Std.Total (α := R) (· ≤ ·)]
 
 namespace AddLECancellable
 
 protected theorem mul_tsub {a b c : R}
     (h : AddLECancellable (a * c)) : a * (b - c) = a * b - a * c := by
-  obtain (hbc | hcb) := total_of (· ≤ ·) b c
+  obtain (hbc | hcb) := Std.Total.total (r := (· ≤ ·)) b c
   · rw [tsub_eq_zero_iff_le.2 hbc, mul_zero, tsub_eq_zero_iff_le.2 (mul_le_mul_left' hbc a)]
   · apply h.eq_tsub_of_add_eq
     rw [← mul_add, tsub_add_cancel_of_le hcb]
 
 protected theorem tsub_mul [MulRightMono R] {a b c : R}
     (h : AddLECancellable (b * c)) : (a - b) * c = a * c - b * c := by
-  obtain (hab | hba) := total_of (· ≤ ·) a b
+  obtain (hab | hba) := Std.Total.total (r := (· ≤ ·)) a b
   · rw [tsub_eq_zero_iff_le.2 hab, zero_mul, tsub_eq_zero_iff_le.2 (mul_le_mul_right' hab c)]
   · apply h.eq_tsub_of_add_eq
     rw [← add_mul, tsub_add_cancel_of_le hba]
@@ -122,7 +122,7 @@ end NonUnitalNonAssocSemiring
 section NonAssocSemiring
 
 variable [NonAssocSemiring R] [PartialOrder R] [CanonicallyOrderedAdd R]
-  [Sub R] [OrderedSub R] [IsTotal R (· ≤ ·)]
+  [Sub R] [OrderedSub R] [Std.Total (α := R) (· ≤ ·)]
 
 lemma mul_tsub_one [AddLeftReflectLE R] (a b : R) :
     a * (b - 1) = a * b - a := by rw [mul_tsub, mul_one]
@@ -134,7 +134,7 @@ end NonAssocSemiring
 section CommSemiring
 
 variable [CommSemiring R] [PartialOrder R] [CanonicallyOrderedAdd R]
-  [Sub R] [OrderedSub R] [IsTotal R (· ≤ ·)] [AddLeftReflectLE R]
+  [Sub R] [OrderedSub R] [Std.Total (α := R) (· ≤ ·)] [AddLeftReflectLE R]
 
 /-- The `tsub` version of `mul_self_sub_mul_self`. Notably, this holds for `Nat` and `NNReal`. -/
 theorem mul_self_tsub_mul_self (a b : R) :

--- a/Mathlib/Data/Finset/Sort.lean
+++ b/Mathlib/Data/Finset/Sort.lean
@@ -26,14 +26,14 @@ section sort
 /-- `sort s` constructs a sorted list from the unordered set `s`.
   (Uses merge sort algorithm.) -/
 def sort (s : Finset α) (r : α → α → Prop := by exact fun a b => a ≤ b)
-    [DecidableRel r] [IsTrans α r] [IsAntisymm α r] [IsTotal α r] : List α :=
+    [DecidableRel r] [IsTrans α r] [IsAntisymm α r] [Std.Total r] : List α :=
   Multiset.sort s.1 r
 
 section
 
 variable (f : α ↪ β) (s : Finset α)
-variable (r : α → α → Prop) [DecidableRel r] [IsTrans α r] [IsAntisymm α r] [IsTotal α r]
-variable (r' : β → β → Prop) [DecidableRel r'] [IsTrans β r'] [IsAntisymm β r'] [IsTotal β r']
+variable (r : α → α → Prop) [DecidableRel r] [IsTrans α r] [IsAntisymm α r] [Std.Total r]
+variable (r' : β → β → Prop) [DecidableRel r'] [IsTrans β r'] [IsAntisymm β r'] [Std.Total r']
 
 @[simp]
 theorem sort_val : Multiset.sort s.val r  = sort s r :=
@@ -95,7 +95,7 @@ end
 section
 
 variable {m : Multiset α} {s : Finset α}
-variable (r : α → α → Prop) [DecidableRel r] [IsTrans α r] [IsAntisymm α r] [IsTotal α r]
+variable (r : α → α → Prop) [DecidableRel r] [IsTrans α r] [IsAntisymm α r] [Std.Total r]
 
 @[simp]
 theorem sort_mk (h : m.Nodup) : sort ⟨m, h⟩ r = m.sort r := rfl

--- a/Mathlib/Data/List/Sort.lean
+++ b/Mathlib/Data/List/Sort.lean
@@ -584,7 +584,7 @@ theorem Sublist.orderedInsert_sublist [IsTrans α r] {as bs} (x) (hs : as <+ bs)
 
 section TotalAndTransitive
 
-variable [IsTotal α r] [IsTrans α r]
+variable [Std.Total r] [IsTrans α r]
 
 theorem Sorted.orderedInsert (a : α) : ∀ l, Sorted r l → Sorted r (orderedInsert r a l)
   | [], _ => sorted_singleton a
@@ -596,7 +596,7 @@ theorem Sorted.orderedInsert (a : α) : ∀ l, Sorted r l → Sorted r (orderedI
       intro b' bm
       rcases (mem_orderedInsert r).mp bm with be | bm
       · subst b'
-        exact (total_of r _ _).resolve_left h'
+        exact (Std.Total.total _ _).resolve_left h'
       · exact rel_of_sorted_cons h _ bm
 
 variable (r)
@@ -631,11 +631,11 @@ theorem pair_sublist_insertionSort {a b : α} {l : List α} (hab : r a b) (h : [
     [a, b] <+ insertionSort r l :=
   sublist_insertionSort (pairwise_pair.mpr hab) h
 
-variable [IsAntisymm α r] [IsTotal α r] [IsTrans α r]
+variable [IsAntisymm α r] [Std.Total r] [IsTrans α r]
 
 /--
 A version of `insertionSort_stable` which only assumes `c <+~ l` (instead of `c <+ l`), but
-additionally requires `IsAntisymm α r`, `IsTotal α r` and `IsTrans α r`.
+additionally requires `IsAntisymm α r`, `Std.Total r` and `IsTrans α r`.
 -/
 theorem sublist_insertionSort' {l c : List α} (hs : c.Sorted r) (hc : c <+~ l) :
     c <+ insertionSort r l := by
@@ -682,13 +682,13 @@ section Correctness
 
 section TotalAndTransitive
 
-variable {r} [IsTotal α r] [IsTrans α r]
+variable {r} [Std.Total r] [IsTrans α r]
 
 theorem Sorted.merge {l l' : List α} (h : Sorted r l) (h' : Sorted r l') :
     Sorted r (merge l l' (r · ·)) := by
   simpa using sorted_merge (le := (r · ·))
     (fun a b c h₁ h₂ => by simpa using _root_.trans (by simpa using h₁) (by simpa using h₂))
-    (fun a b => by simpa using IsTotal.total a b)
+    (fun a b => by simpa using Std.Total.total a b)
     l l' (by simpa using h) (by simpa using h')
 
 variable (r)
@@ -697,7 +697,7 @@ variable (r)
 theorem sorted_mergeSort' (l : List α) : Sorted r (mergeSort l (r · ·)) := by
   simpa using sorted_mergeSort (le := (r · ·))
     (fun _ _ _ => by simpa using trans_of r)
-    (by simpa using total_of r)
+    (by simpa using Std.Total.total)
     l
 
 variable [IsAntisymm α r]

--- a/Mathlib/Data/Multiset/Sort.lean
+++ b/Mathlib/Data/Multiset/Sort.lean
@@ -23,19 +23,19 @@ section sort
 /-- `sort s` constructs a sorted list from the multiset `s`.
   (Uses merge sort algorithm.) -/
 def sort (s : Multiset α) (r : α → α → Prop := by exact fun a b => a ≤ b)
-    [DecidableRel r] [IsTrans α r] [IsAntisymm α r] [IsTotal α r] : List α :=
+    [DecidableRel r] [IsTrans α r] [IsAntisymm α r] [Std.Total r] : List α :=
   Quot.liftOn s (mergeSort · (r · ·)) fun _ _ h =>
     eq_of_perm_of_sorted ((mergeSort_perm _ _).trans <| h.trans (mergeSort_perm _ _).symm)
       (sorted_mergeSort IsTrans.trans
-        (fun a b => by simpa using IsTotal.total a b) _)
+        (fun a b => by simpa using Std.Total.total a b) _)
       (sorted_mergeSort IsTrans.trans
-        (fun a b => by simpa using IsTotal.total a b) _)
+        (fun a b => by simpa using Std.Total.total a b) _)
 
 section
 
 variable (a : α) (f : α → β) (l : List α) (s : Multiset α)
-variable (r : α → α → Prop) [DecidableRel r] [IsTrans α r] [IsAntisymm α r] [IsTotal α r]
-variable (r' : β → β → Prop) [DecidableRel r'] [IsTrans β r'] [IsAntisymm β r'] [IsTotal β r']
+variable (r : α → α → Prop) [DecidableRel r] [IsTrans α r] [IsAntisymm α r] [Std.Total r]
+variable (r' : β → β → Prop) [DecidableRel r'] [IsTrans β r'] [IsAntisymm β r'] [Std.Total r']
 
 @[simp]
 theorem coe_sort : sort l r = mergeSort l (r · ·) :=
@@ -75,7 +75,7 @@ end
 section
 
 variable {a : α} {s : Multiset α}
-variable (r : α → α → Prop) [DecidableRel r] [IsTrans α r] [IsAntisymm α r] [IsTotal α r]
+variable (r : α → α → Prop) [DecidableRel r] [IsTrans α r] [IsAntisymm α r] [Std.Total r]
 
 @[simp]
 theorem mem_sort : a ∈ sort s r ↔ a ∈ s := by rw [← mem_coe, sort_eq]

--- a/Mathlib/Data/Nat/PartENat.lean
+++ b/Mathlib/Data/Nat/PartENat.lean
@@ -379,7 +379,7 @@ theorem pos_iff_one_le {x : PartENat} : 0 < x ↔ 1 ≤ x :=
       rw [← Nat.cast_zero, ← Nat.cast_one, PartENat.coe_lt_coe, PartENat.coe_le_coe]
       rfl
 
-instance isTotal : IsTotal PartENat (· ≤ ·) where
+instance inst_stdTotal_le : Std.Total (α := PartENat) (· ≤ ·) where
   total x y :=
     PartENat.casesOn (P := fun z => z ≤ y ∨ y ≤ z) x (Or.inr le_top)
       (PartENat.casesOn y (fun _ => Or.inl le_top) fun x y =>
@@ -387,7 +387,7 @@ instance isTotal : IsTotal PartENat (· ≤ ·) where
 
 noncomputable instance linearOrder : LinearOrder PartENat :=
   { PartENat.partialOrder with
-    le_total := IsTotal.total
+    le_total := Std.Total.total
     toDecidableLE := Classical.decRel _
     max := (· ⊔ ·)
     max_def a b := congr_fun₂ (@sup_eq_maxDefault PartENat _ (_) _) _ _ }

--- a/Mathlib/Data/Ordmap/Invariants.lean
+++ b/Mathlib/Data/Ordmap/Invariants.lean
@@ -539,7 +539,7 @@ theorem merge_node {ls ll lx lr rs rl rx rr} :
 /-! ### `insert` -/
 
 
-theorem dual_insert [LE α] [IsTotal α (· ≤ ·)] [DecidableLE α] (x : α) :
+theorem dual_insert [LE α] [Std.Total (α := α) (· ≤ ·)] [DecidableLE α] (x : α) :
     ∀ t : Ordnode α, dual (Ordnode.insert x t) = @Ordnode.insert αᵒᵈ _ _ x (dual t)
   | nil => rfl
   | node _ l y r => by

--- a/Mathlib/Data/Ordmap/Ordset.lean
+++ b/Mathlib/Data/Ordmap/Ordset.lean
@@ -473,7 +473,7 @@ theorem Valid.merge {l r} (hl : Valid l) (hr : Valid r)
     (sep : l.All fun x => r.All fun y => x < y) : Valid (@merge α l r) :=
   (Valid'.merge_aux hl hr sep).1
 
-theorem insertWith.valid_aux [IsTotal α (· ≤ ·)] [DecidableLE α] (f : α → α) (x : α)
+theorem insertWith.valid_aux [Std.Total (α := α) (· ≤ ·)] [DecidableLE α] (f : α → α) (x : α)
     (hf : ∀ y, x ≤ y ∧ y ≤ x → x ≤ f y ∧ f y ≤ x) :
     ∀ {t o₁ o₂},
       Valid' o₁ t o₂ →
@@ -494,7 +494,7 @@ theorem insertWith.valid_aux [IsTotal α (· ≤ ·)] [DecidableLE α] (f : α �
         rw [size_balanceL vl.3 h.3.2.2 vl.2 h.2.2.2 H, h.2.size_eq]
         exact (e.add_right _).add_right _
       exact Or.inl ⟨_, e, h.3.1⟩
-    · have : y < x := lt_of_le_not_ge ((total_of (· ≤ ·) _ _).resolve_left h_1) h_1
+    · have : y < x := lt_of_le_not_ge ((Std.Total.total _ _).resolve_left h_1) h_1
       rcases insertWith.valid_aux f x hf h.right this br with ⟨vr, e⟩
       suffices H : _ by
         refine ⟨h.left.balanceR vr H, ?_⟩
@@ -502,7 +502,7 @@ theorem insertWith.valid_aux [IsTotal α (· ≤ ·)] [DecidableLE α] (f : α �
         exact (e.add_left _).add_right _
       exact Or.inr ⟨_, e, h.3.1⟩
 
-theorem insertWith.valid [IsTotal α (· ≤ ·)] [DecidableLE α] (f : α → α) (x : α)
+theorem insertWith.valid [Std.Total (α := α) (· ≤ ·)] [DecidableLE α] (f : α → α) (x : α)
     (hf : ∀ y, x ≤ y ∧ y ≤ x → x ≤ f y ∧ f y ≤ x) {t} (h : Valid t) : Valid (insertWith f x t) :=
   (insertWith.valid_aux _ _ hf h ⟨⟩ ⟨⟩).1
 
@@ -512,7 +512,7 @@ theorem insert_eq_insertWith [DecidableLE α] (x : α) :
   | node _ l y r => by
     unfold Ordnode.insert insertWith; cases cmpLE x y <;> simp [insert_eq_insertWith]
 
-theorem insert.valid [IsTotal α (· ≤ ·)] [DecidableLE α] (x : α) {t} (h : Valid t) :
+theorem insert.valid [Std.Total (α := α) (· ≤ ·)] [DecidableLE α] (x : α) {t} (h : Valid t) :
     Valid (Ordnode.insert x t) := by
   rw [insert_eq_insertWith]; exact insertWith.valid _ _ (fun _ _ => ⟨le_rfl, le_rfl⟩) h
 
@@ -522,7 +522,7 @@ theorem insert'_eq_insertWith [DecidableLE α] (x : α) :
   | node _ l y r => by
     unfold insert' insertWith; cases cmpLE x y <;> simp [insert'_eq_insertWith]
 
-theorem insert'.valid [IsTotal α (· ≤ ·)] [DecidableLE α]
+theorem insert'.valid [Std.Total (α := α) (· ≤ ·)] [DecidableLE α]
     (x : α) {t} (h : Valid t) : Valid (insert' x t) := by
   rw [insert'_eq_insertWith]; exact insertWith.valid _ _ (fun _ => id) h
 
@@ -684,16 +684,16 @@ instance Empty.instDecidablePred : DecidablePred (@Empty α _) :=
 
 /-- O(log n). Insert an element into the set, preserving balance and the BST property.
   If an equivalent element is already in the set, this replaces it. -/
-protected def insert [IsTotal α (· ≤ ·)] [DecidableLE α] (x : α) (s : Ordset α) :
+protected def insert [Std.Total (α := α) (· ≤ ·)] [DecidableLE α] (x : α) (s : Ordset α) :
     Ordset α :=
   ⟨Ordnode.insert x s.1, insert.valid _ s.2⟩
 
-instance instInsert [IsTotal α (· ≤ ·)] [DecidableLE α] : Insert α (Ordset α) :=
+instance instInsert [Std.Total (α := α) (· ≤ ·)] [DecidableLE α] : Insert α (Ordset α) :=
   ⟨Ordset.insert⟩
 
 /-- O(log n). Insert an element into the set, preserving balance and the BST property.
   If an equivalent element is already in the set, the set is returned as is. -/
-nonrec def insert' [IsTotal α (· ≤ ·)] [DecidableLE α] (x : α) (s : Ordset α) :
+nonrec def insert' [Std.Total (α := α) (· ≤ ·)] [DecidableLE α] (x : α) (s : Ordset α) :
     Ordset α :=
   ⟨insert' x s.1, insert'.valid _ s.2⟩
 

--- a/Mathlib/Data/Prod/Basic.lean
+++ b/Mathlib/Data/Prod/Basic.lean
@@ -179,16 +179,17 @@ instance {r : α → α → Prop} {s : β → β → Prop} [IsStrictOrder α r] 
     | (_, _), (_, _), .right _ _,     .left  _ _ hr₂ => (irrefl _ hr₂).elim
     | (_, _), (_, _), .right _ hs₁,   .right _ hs₂   => antisymm hs₁ hs₂ ▸ rfl⟩
 
-instance isTotal_left {r : α → α → Prop} {s : β → β → Prop} [IsTotal α r] :
-    IsTotal (α × β) (Prod.Lex r s) :=
-  ⟨fun ⟨a₁, _⟩ ⟨a₂, _⟩ ↦ (IsTotal.total a₁ a₂).imp (Lex.left _ _) (Lex.left _ _)⟩
+instance inst_stdTotal_left {r : α → α → Prop} {s : β → β → Prop} [Std.Total r] :
+    Std.Total (Prod.Lex r s) :=
+  ⟨fun ⟨a₁, _⟩ ⟨a₂, _⟩ ↦ (Std.Total.total a₁ a₂).imp (Lex.left _ _) (Lex.left _ _)⟩
 
-instance isTotal_right {r : α → α → Prop} {s : β → β → Prop} [IsTrichotomous α r] [IsTotal β s] :
-    IsTotal (α × β) (Prod.Lex r s) :=
+instance inst_stdTotal_right {r : α → α → Prop} {s : β → β → Prop} [IsTrichotomous α r]
+    [Std.Total s] :
+    Std.Total (Prod.Lex r s) :=
   ⟨fun ⟨i, a⟩ ⟨j, b⟩ ↦ by
     obtain hij | rfl | hji := trichotomous_of r i j
     · exact Or.inl (.left _ _ hij)
-    · exact (total_of s a b).imp (.right _) (.right _)
+    · exact (Std.Total.total a b).imp (.right _) (.right _)
     · exact Or.inr (.left _ _ hji) ⟩
 
 instance IsTrichotomous [IsTrichotomous α r] [IsTrichotomous β s] :

--- a/Mathlib/Data/Prod/Lex.lean
+++ b/Mathlib/Data/Prod/Lex.lean
@@ -167,7 +167,7 @@ instance [Ord α] [Ord β] [Std.TransOrd α] [Std.TransOrd β] : Std.TransOrd (�
 /-- Dictionary / lexicographic linear order for pairs. -/
 instance instLinearOrder (α β : Type*) [LinearOrder α] [LinearOrder β] : LinearOrder (α ×ₗ β) :=
   { Prod.Lex.instPartialOrder α β with
-    le_total := total_of (Prod.Lex _ _)
+    le_total := Std.Total.total (r := Prod.Lex _ _)
     toDecidableLE := Prod.Lex.decidable _ _
     toDecidableLT := Prod.Lex.decidable _ _
     toDecidableEq := instDecidableEqLex _

--- a/Mathlib/Data/Real/Basic.lean
+++ b/Mathlib/Data/Real/Basic.lean
@@ -455,7 +455,7 @@ instance : SemilatticeInf ℝ :=
 instance : SemilatticeSup ℝ :=
   inferInstance
 
-instance leTotal_R : IsTotal ℝ (· ≤ ·) :=
+instance inst_stdTotal_le : Std.Total (α := ℝ) (· ≤ ·) :=
   ⟨by
     intro a b
     induction a using Real.ind_mk

--- a/Mathlib/Data/Sigma/Lex.lean
+++ b/Mathlib/Data/Sigma/Lex.lean
@@ -112,12 +112,12 @@ instance [IsAsymm ι r] [∀ i, IsAntisymm (α i) (s i)] : IsAntisymm _ (Lex r s
     · exact (irrefl _ hji).elim
     · exact congr_arg (Sigma.mk _ ·) <| antisymm hab hba⟩
 
-instance [IsTrichotomous ι r] [∀ i, IsTotal (α i) (s i)] : IsTotal _ (Lex r s) :=
+instance [IsTrichotomous ι r] [∀ i, Std.Total (s i)] : Std.Total (Lex r s) :=
   ⟨by
     rintro ⟨i, a⟩ ⟨j, b⟩
     obtain hij | rfl | hji := trichotomous_of r i j
     · exact Or.inl (Lex.left _ _ hij)
-    · obtain hab | hba := total_of (s i) a b
+    · obtain hab | hba := Std.Total.total (r := s i) a b
       · exact Or.inl (Lex.right _ _ hab)
       · exact Or.inr (Lex.right _ _ hba)
     · exact Or.inr (Lex.left _ _ hji)⟩

--- a/Mathlib/Data/Sigma/Order.lean
+++ b/Mathlib/Data/Sigma/Order.lean
@@ -164,7 +164,7 @@ instance partialOrder [Preorder ι] [∀ i, PartialOrder (α i)] :
 instance linearOrder [LinearOrder ι] [∀ i, LinearOrder (α i)] :
     LinearOrder (Σₗ i, α i) :=
   { Lex.partialOrder with
-    le_total := total_of ((Lex (· < ·)) fun _ => (· ≤ ·)),
+    le_total := Std.Total.total (r := (Lex (· < ·)) fun _ => (· ≤ ·)),
     toDecidableEq := Sigma.instDecidableEqSigma
     toDecidableLE := Lex.decidable _ _
     toDecidableLT := Lex.decidable _ _ }

--- a/Mathlib/Data/Sum/Order.lean
+++ b/Mathlib/Data/Sum/Order.lean
@@ -83,13 +83,13 @@ instance [IsTrans α r] [IsTrans β s] : IsTrans (α ⊕ β) (Lex r s) :=
 instance [IsAntisymm α r] [IsAntisymm β s] : IsAntisymm (α ⊕ β) (Lex r s) :=
   ⟨by rintro _ _ (⟨hab⟩ | ⟨hab⟩) (⟨hba⟩ | ⟨hba⟩) <;> rw [antisymm hab hba]⟩
 
-instance [IsTotal α r] [IsTotal β s] : IsTotal (α ⊕ β) (Lex r s) :=
+instance [Std.Total r] [Std.Total s] : Std.Total (Lex r s) :=
   ⟨fun a b =>
     match a, b with
-    | inl a, inl b => (total_of r a b).imp Lex.inl Lex.inl
+    | inl a, inl b => (Std.Total.total a b).imp Lex.inl Lex.inl
     | inl _, inr _ => Or.inl (Lex.sep _ _)
     | inr _, inl _ => Or.inr (Lex.sep _ _)
-    | inr a, inr b => (total_of s a b).imp Lex.inr Lex.inr⟩
+    | inr a, inr b => (Std.Total.total a b).imp Lex.inr Lex.inr⟩
 
 instance [IsTrichotomous α r] [IsTrichotomous β s] : IsTrichotomous (α ⊕ β) (Lex r s) :=
   ⟨fun a b =>
@@ -405,7 +405,7 @@ instance partialOrder [PartialOrder α] [PartialOrder β] : PartialOrder (α ⊕
 
 instance linearOrder [LinearOrder α] [LinearOrder β] : LinearOrder (α ⊕ₗ β) :=
   { Lex.partialOrder with
-    le_total := total_of (Lex (· ≤ ·) (· ≤ ·)),
+    le_total := Std.Total.total (r := Lex (· ≤ ·) (· ≤ ·)),
     toDecidableLE := instDecidableRelSumLex,
     toDecidableLT := instDecidableRelSumLex,
     toDecidableEq := instDecidableEqSum }

--- a/Mathlib/Logic/Encodable/Basic.lean
+++ b/Mathlib/Logic/Encodable/Basic.lean
@@ -518,8 +518,8 @@ def encode' (α) [Encodable α] : α ↪ ℕ :=
 instance {α} [Encodable α] : IsAntisymm _ (Encodable.encode' α ⁻¹'o (· ≤ ·)) :=
   (RelEmbedding.preimage _ _).isAntisymm
 
-instance {α} [Encodable α] : IsTotal _ (Encodable.encode' α ⁻¹'o (· ≤ ·)) :=
-  (RelEmbedding.preimage _ _).isTotal
+instance {α} [Encodable α] : Std.Total (Encodable.encode' α ⁻¹'o (· ≤ ·)) :=
+  (RelEmbedding.preimage _ _).stdTotal
 
 end Encodable
 

--- a/Mathlib/Order/Antisymmetrization.lean
+++ b/Mathlib/Order/Antisymmetrization.lean
@@ -279,10 +279,10 @@ instance [WellFoundedLT α] : WellFoundedLT (Antisymmetrization α (· ≤ ·)) 
 instance [WellFoundedGT α] : WellFoundedGT (Antisymmetrization α (· ≤ ·)) :=
   wellFoundedGT_antisymmetrization_iff.mpr ‹_›
 
-instance [DecidableLE α] [DecidableLT α] [IsTotal α (· ≤ ·)] :
+instance [DecidableLE α] [DecidableLT α] [Std.Total (α := α) (· ≤ ·)] :
     LinearOrder (Antisymmetrization α (· ≤ ·)) :=
   { instPartialOrderAntisymmetrization with
-    le_total := fun a b => Quotient.inductionOn₂' a b <| total_of (· ≤ ·),
+    le_total := fun a b => Quotient.inductionOn₂' a b <| Std.Total.total (r := (· ≤ ·)),
     toDecidableLE := fun _ _ => show Decidable (Quotient.liftOn₂' _ _ _ _) from inferInstance,
     toDecidableLT := fun _ _ => show Decidable (Quotient.liftOn₂' _ _ _ _) from inferInstance }
 

--- a/Mathlib/Order/Basic.lean
+++ b/Mathlib/Order/Basic.lean
@@ -22,7 +22,7 @@ classes and allows to transfer order instances.
 
 * `OrderDual α` : A type synonym reversing the meaning of all inequalities, with notation `αᵒᵈ`.
 * `AsLinearOrder α`: A type synonym to promote `PartialOrder α` to `LinearOrder α` using
-  `IsTotal α (≤)`.
+  `Std.Total (α := α) (· ≤ ·)`.
 
 ### Transferring orders
 
@@ -1403,15 +1403,16 @@ end «Prop»
 /-! ### Linear order from a total partial order -/
 
 
-/-- Type synonym to create an instance of `LinearOrder` from a `PartialOrder` and `IsTotal α (≤)` -/
+/-- Type synonym to create an instance of `LinearOrder` from a `PartialOrder` and
+`Std.Total (α := α) (· ≤ ·)` -/
 def AsLinearOrder (α : Type*) :=
   α
 
 instance [Inhabited α] : Inhabited (AsLinearOrder α) :=
   ⟨(default : α)⟩
 
-noncomputable instance AsLinearOrder.linearOrder [PartialOrder α] [IsTotal α (· ≤ ·)] :
+noncomputable instance AsLinearOrder.linearOrder [PartialOrder α] [Std.Total (α := α) (· ≤ ·)] :
     LinearOrder (AsLinearOrder α) where
   __ := inferInstanceAs (PartialOrder α)
-  le_total := @total_of α (· ≤ ·) _
+  le_total := Std.Total.total
   toDecidableLE := Classical.decRel _

--- a/Mathlib/Order/Comparable.lean
+++ b/Mathlib/Order/Comparable.lean
@@ -84,6 +84,11 @@ theorem AntisymmRel.compRel (h : AntisymmRel r a b) : CompRel r a b :=
   Or.inl h.1
 
 @[simp]
+theorem Std.Total.compRel [Std.Total r] (a b : α) : CompRel r a b :=
+  Std.Total.total a b
+
+set_option linter.deprecated false in
+@[deprecated Std.Total.compRel (since := "2025-10-23"), simp]
 theorem IsTotal.compRel [IsTotal α r] (a b : α) : CompRel r a b :=
   IsTotal.total a b
 
@@ -226,6 +231,12 @@ theorem not_incompRel_iff : ¬ IncompRel r a b ↔ CompRel r a b := by
   rw [← not_compRel_iff, not_not]
 
 @[simp]
+theorem Std.Total.not_incompRel [Std.Total r] (a b : α) : ¬ IncompRel r a b := by
+  rw [not_incompRel_iff]
+  exact Std.Total.compRel a b
+
+set_option linter.deprecated false in
+@[deprecated Std.Total.not_incompRel (since := "2025-10-23"), simp]
 theorem IsTotal.not_incompRel [IsTotal α r] (a b : α) : ¬ IncompRel r a b := by
   rw [not_incompRel_iff]
   exact IsTotal.compRel a b

--- a/Mathlib/Order/Compare.lean
+++ b/Mathlib/Order/Compare.lean
@@ -28,15 +28,15 @@ three-way comparison result `Ordering`. -/
 def cmpLE {α} [LE α] [DecidableLE α] (x y : α) : Ordering :=
   if x ≤ y then if y ≤ x then Ordering.eq else Ordering.lt else Ordering.gt
 
-theorem cmpLE_swap {α} [LE α] [IsTotal α (· ≤ ·)] [DecidableLE α] (x y : α) :
+theorem cmpLE_swap {α} [LE α] [Std.Total (α := α) (· ≤ ·)] [DecidableLE α] (x y : α) :
     (cmpLE x y).swap = cmpLE y x := by
   by_cases xy : x ≤ y <;> by_cases yx : y ≤ x <;> simp [cmpLE, *, Ordering.swap]
-  cases not_or_intro xy yx (total_of _ _ _)
+  cases not_or_intro xy yx (Std.Total.total _ _)
 
-theorem cmpLE_eq_cmp {α} [Preorder α] [IsTotal α (· ≤ ·)] [DecidableLE α] [DecidableLT α]
+theorem cmpLE_eq_cmp {α} [Preorder α] [Std.Total (α := α) (· ≤ ·)] [DecidableLE α] [DecidableLT α]
     (x y : α) : cmpLE x y = cmp x y := by
   by_cases xy : x ≤ y <;> by_cases yx : y ≤ x <;> simp [cmpLE, lt_iff_le_not_ge, *, cmp, cmpUsing]
-  cases not_or_intro xy yx (total_of _ _ _)
+  cases not_or_intro xy yx (Std.Total.total _ _)
 
 namespace Ordering
 

--- a/Mathlib/Order/Directed.lean
+++ b/Mathlib/Order/Directed.lean
@@ -16,7 +16,7 @@ directed iff each pair of elements has a shared upper bound.
 * `Directed r f`: Predicate stating that the indexed family `f` is `r`-directed.
 * `DirectedOn r s`: Predicate stating that the set `s` is `r`-directed.
 * `IsDirected α r`: Prop-valued mixin stating that `α` is `r`-directed. Follows the style of the
-  unbundled relation classes such as `IsTotal`.
+  unbundled relation classes such as `Std.Total`.
 
 ## TODO
 
@@ -121,6 +121,11 @@ theorem directedOn_of_inf_mem [SemilatticeInf α] {S : Set α}
     (H : ∀ ⦃i j⦄, i ∈ S → j ∈ S → i ⊓ j ∈ S) : DirectedOn (· ≥ ·) S :=
   directedOn_of_sup_mem (α := αᵒᵈ) H
 
+theorem Std.Total.directed [Std.Total r] (f : ι → α) : Directed r f := fun i j =>
+  Or.casesOn (Total.total (r := r) (f i) (f j)) (fun h => ⟨j, h, refl _⟩) fun h => ⟨i, refl _, h⟩
+
+set_option linter.deprecated false in
+@[deprecated Std.Total.directed (since := "2025-10-23")]
 theorem IsTotal.directed [IsTotal α r] (f : ι → α) : Directed r f := fun i j =>
   Or.casesOn (total_of r (f i) (f j)) (fun h => ⟨j, h, refl _⟩) fun h => ⟨i, refl _, h⟩
 
@@ -156,6 +161,12 @@ theorem directedOn_univ_iff : DirectedOn r Set.univ ↔ IsDirected α r :=
     @directedOn_univ _ _⟩
 
 -- see Note [lower instance priority]
+instance (priority := 100) Std.Total.to_isDirected [Std.Total r] : IsDirected α r :=
+  directed_id_iff.1 <| Std.Total.directed _
+
+-- see Note [lower instance priority]
+set_option linter.deprecated false in
+@[deprecated Std.Total.to_isDirected (since := "2025-10-23")]
 instance (priority := 100) IsTotal.to_isDirected [IsTotal α r] : IsDirected α r :=
   directed_id_iff.1 <| IsTotal.directed _
 

--- a/Mathlib/Order/Filter/FilterProduct.lean
+++ b/Mathlib/Order/Filter/FilterProduct.lean
@@ -79,9 +79,10 @@ theorem lt_def [Preorder β] : ((· < ·) : β* → β* → Prop) = LiftRel (· 
   ext ⟨f⟩ ⟨g⟩
   exact coe_lt
 
-instance isTotal [LE β] [IsTotal β (· ≤ ·)] : IsTotal β* (· ≤ ·) :=
+instance inst_stdTotal_le [LE β] [Std.Total (α := β) (· ≤ ·)] : Std.Total (α := β*) (· ≤ ·) :=
   ⟨fun f g =>
-    inductionOn₂ f g fun _f _g => eventually_or.1 <| Eventually.of_forall fun _x => total_of _ _ _⟩
+    inductionOn₂ f g fun _f _g => eventually_or.1 <|
+      Eventually.of_forall fun _x => Std.Total.total _ _⟩
 
 open Classical in
 /-- If `φ` is an ultrafilter then the ultraproduct is a linear order. -/

--- a/Mathlib/Order/Lattice.lean
+++ b/Mathlib/Order/Lattice.lean
@@ -695,29 +695,29 @@ theorem min_min_min_comm : min (min a b) (min c d) = min (min a c) (min b d) :=
 
 end LinearOrder
 
-theorem sup_eq_maxDefault [SemilatticeSup α] [DecidableLE α] [IsTotal α (· ≤ ·)] :
+theorem sup_eq_maxDefault [SemilatticeSup α] [DecidableLE α] [Std.Total (α := α) (· ≤ ·)] :
     (· ⊔ ·) = (maxDefault : α → α → α) := by
   ext x y
   unfold maxDefault
   split_ifs with h'
-  exacts [sup_of_le_right h', sup_of_le_left <| (total_of (· ≤ ·) x y).resolve_left h']
+  exacts [sup_of_le_right h', sup_of_le_left <| (Std.Total.total x y).resolve_left h']
 
-theorem inf_eq_minDefault [SemilatticeInf α] [DecidableLE α] [IsTotal α (· ≤ ·)] :
+theorem inf_eq_minDefault [SemilatticeInf α] [DecidableLE α] [Std.Total (α := α) (· ≤ ·)] :
     (· ⊓ ·) = (minDefault : α → α → α) := by
   ext x y
   unfold minDefault
   split_ifs with h'
-  exacts [inf_of_le_left h', inf_of_le_right <| (total_of (· ≤ ·) x y).resolve_left h']
+  exacts [inf_of_le_left h', inf_of_le_right <| (Std.Total.total x y).resolve_left h']
 
 /-- A lattice with total order is a linear order.
 
 See note [reducible non-instances]. -/
 abbrev Lattice.toLinearOrder (α : Type u) [Lattice α] [DecidableEq α]
-    [DecidableLE α] [DecidableLT α] [IsTotal α (· ≤ ·)] : LinearOrder α where
+    [DecidableLE α] [DecidableLT α] [Std.Total (α := α) (· ≤ ·)] : LinearOrder α where
   toDecidableLE := ‹_›
   toDecidableEq := ‹_›
   toDecidableLT := ‹_›
-  le_total := total_of (· ≤ ·)
+  le_total := Std.Total.total
   max_def := by exact congr_fun₂ sup_eq_maxDefault
   min_def := by exact congr_fun₂ inf_eq_minDefault
 

--- a/Mathlib/Order/PropInstances.lean
+++ b/Mathlib/Order/PropInstances.lean
@@ -40,7 +40,7 @@ theorem Prop.bot_eq_false : (⊥ : Prop) = False :=
 theorem Prop.top_eq_true : (⊤ : Prop) = True :=
   rfl
 
-instance Prop.le_isTotal : IsTotal Prop (· ≤ ·) :=
+instance Prop.inst_stdTotal_le : Std.Total (α := Prop) (· ≤ ·) :=
   ⟨fun p q => by by_cases h : q <;> simp [h]⟩
 
 noncomputable instance Prop.linearOrder : LinearOrder Prop := by

--- a/Mathlib/Order/RelClasses.lean
+++ b/Mathlib/Order/RelClasses.lean
@@ -38,6 +38,12 @@ theorem IsAntisymm.swap (r) [IsAntisymm α r] : IsAntisymm α (swap r) :=
 theorem IsAsymm.swap (r) [IsAsymm α r] : IsAsymm α (swap r) :=
   ⟨fun _ _ h₁ h₂ => asymm_of r h₂ h₁⟩
 
+variable (r) in
+theorem Std.Total.swap [Std.Total r] : Std.Total (swap r) :=
+  ⟨fun a b => (Std.Total.total a b).symm⟩
+
+set_option linter.deprecated false in
+@[deprecated Std.Total.swap (since := "2025-10-23")]
 theorem IsTotal.swap (r) [IsTotal α r] : IsTotal α (swap r) :=
   ⟨fun a b => (total_of r a b).symm⟩
 
@@ -449,6 +455,11 @@ instance instIsStrictWeakOrder [IsStrictWeakOrder α r] {f : β → α} :
 
 instance instIsEquiv [IsEquiv α r] {f : β → α} : IsEquiv β (f ⁻¹'o r) where
 
+instance inst_stdTotal [Std.Total r] {f : β → α} : Std.Total (f ⁻¹'o r) :=
+  ⟨fun _ _ => Std.Total.total (r := r) _ _⟩
+
+set_option linter.deprecated false in
+@[deprecated Order.Preimage.inst_stdTotal (since := "2025-10-23")]
 instance instIsTotal [IsTotal α r] {f : β → α} : IsTotal β (f ⁻¹'o r) :=
   ⟨fun _ _ => total_of r _ _⟩
 
@@ -720,11 +731,16 @@ instance [PartialOrder α] : IsPartialOrder α (· ≤ ·) where
 
 instance [PartialOrder α] : IsPartialOrder α (· ≥ ·) where
 
-instance LE.isTotal [LinearOrder α] : IsTotal α (· ≤ ·) :=
+instance LinearOrder.inst_stdTotal_le [LinearOrder α] : Std.Total (α := α) (· ≤ ·) :=
   ⟨le_total⟩
 
-instance [LinearOrder α] : IsTotal α (· ≥ ·) :=
-  IsTotal.swap _
+set_option linter.deprecated false in
+@[deprecated LinearOrder.inst_stdTotal_le (since := "2025-10-23")]
+instance LE.isTotal [LinearOrder α] : IsTotal α (· ≤ ·) :=
+  inferInstance
+
+instance [LinearOrder α] : Std.Total (α := α) (· ≥ ·) :=
+  Std.Total.swap _
 
 instance [LinearOrder α] : IsLinearOrder α (· ≤ ·) where
 
@@ -737,10 +753,10 @@ instance [LinearOrder α] : IsTrichotomous α (· > ·) :=
   IsTrichotomous.swap _
 
 instance [LinearOrder α] : IsTrichotomous α (· ≤ ·) :=
-  IsTotal.isTrichotomous _
+  Std.Total.isTrichotomous _
 
 instance [LinearOrder α] : IsTrichotomous α (· ≥ ·) :=
-  IsTotal.isTrichotomous _
+  Std.Total.isTrichotomous _
 
 instance [LinearOrder α] : IsStrictTotalOrder α (· < ·) where
 
@@ -758,6 +774,12 @@ theorem transitive_ge [Preorder α] : Transitive (@GE.ge α _) :=
 theorem transitive_gt [Preorder α] : Transitive (@GT.gt α _) :=
   transitive_of_trans _
 
+instance OrderDual.inst_stdTotal_le [LE α] [h : Std.Total (α := α) (· ≤ ·)] :
+    Std.Total (α := αᵒᵈ) (· ≤ ·) :=
+  @Std.Total.swap α _ h
+
+set_option linter.deprecated false in
+@[deprecated OrderDual.inst_stdTotal_le (since := "2025-10-23")]
 instance OrderDual.isTotal_le [LE α] [h : IsTotal α (· ≤ ·)] : IsTotal αᵒᵈ (· ≤ ·) :=
   @IsTotal.swap α _ h
 

--- a/Mathlib/Order/RelIso/Basic.lean
+++ b/Mathlib/Order/RelIso/Basic.lean
@@ -309,6 +309,11 @@ protected theorem isAntisymm : ∀ (_ : r ↪r s) [IsAntisymm β s], IsAntisymm 
 protected theorem isTrans : ∀ (_ : r ↪r s) [IsTrans β s], IsTrans α r
   | ⟨_, o⟩, ⟨H⟩ => ⟨fun _ _ _ h₁ h₂ => o.1 (H _ _ _ (o.2 h₁) (o.2 h₂))⟩
 
+protected theorem stdTotal : ∀ (_ : r ↪r s) [Std.Total s], Std.Total r
+  | ⟨_, o⟩, ⟨H⟩ => ⟨fun _ _ => (or_congr o o).1 (H _ _)⟩
+
+set_option linter.deprecated false in
+@[deprecated RelEmbedding.stdTotal (since := "2025-10-23")]
 protected theorem isTotal : ∀ (_ : r ↪r s) [IsTotal β s], IsTotal α r
   | ⟨_, o⟩, ⟨H⟩ => ⟨fun _ _ => (or_congr o o).1 (H _ _)⟩
 
@@ -319,7 +324,7 @@ protected theorem isPartialOrder : ∀ (_ : r ↪r s) [IsPartialOrder β s], IsP
   | f, _ => { f.isPreorder, f.isAntisymm with }
 
 protected theorem isLinearOrder : ∀ (_ : r ↪r s) [IsLinearOrder β s], IsLinearOrder α r
-  | f, _ => { f.isPartialOrder, f.isTotal with }
+  | f, _ => { f.isPartialOrder, f.stdTotal with }
 
 protected theorem isStrictOrder : ∀ (_ : r ↪r s) [IsStrictOrder β s], IsStrictOrder α r
   | f, _ => { f.isIrrefl, f.isTrans with }

--- a/Mathlib/Order/UpperLower/CompleteLattice.lean
+++ b/Mathlib/Order/UpperLower/CompleteLattice.lean
@@ -486,9 +486,11 @@ end LE
 section LinearOrder
 variable [LinearOrder α]
 
-instance UpperSet.isTotal_le : IsTotal (UpperSet α) (· ≤ ·) := ⟨fun s t => t.upper.total s.upper⟩
+instance UpperSet.inst_stdTotal_le : Std.Total (α := UpperSet α) (· ≤ ·) :=
+  ⟨fun s t => t.upper.total s.upper⟩
 
-instance LowerSet.isTotal_le : IsTotal (LowerSet α) (· ≤ ·) := ⟨fun s t => s.lower.total t.lower⟩
+instance LowerSet.inst_stdTotal_le : Std.Total (α := LowerSet α) (· ≤ ·) :=
+  ⟨fun s t => s.lower.total t.lower⟩
 
 noncomputable instance UpperSet.instLinearOrder : LinearOrder (UpperSet α) := by
   classical exact Lattice.toLinearOrder _

--- a/Mathlib/Order/WithBot.lean
+++ b/Mathlib/Order/WithBot.lean
@@ -473,8 +473,9 @@ instance decidableLT [LT α] [DecidableLT α] : DecidableLT (WithBot α)
   | ⊥, (a : α) => isTrue <| by simp
   | (a : α), (b : α) => decidable_of_iff' _ coe_lt_coe
 
-instance isTotal_le [LE α] [IsTotal α (· ≤ ·)] : IsTotal (WithBot α) (· ≤ ·) where
-  total x y := by cases x <;> cases y <;> simp; simpa using IsTotal.total ..
+instance inst_stdTotal_le [LE α] [Std.Total (α := α) (· ≤ ·)] :
+    Std.Total (α := WithBot α) (· ≤ ·) where
+  total x y := by cases x <;> cases y <;> simp; simpa using Std.Total.total ..
 
 section LinearOrder
 variable [LinearOrder α] {x y : WithBot α}
@@ -1026,8 +1027,9 @@ instance decidableLT [LT α] [DecidableLT α] : DecidableLT (WithTop α)
   | (a : α), ⊤ => isTrue <| by simp
   | (a : α), (b : α) => decidable_of_iff' _ coe_lt_coe
 
-instance isTotal_le [LE α] [IsTotal α (· ≤ ·)] : IsTotal (WithTop α) (· ≤ ·) where
-  total x y := by cases x <;> cases y <;> simp; simpa using IsTotal.total ..
+instance inst_stdTotal_le [LE α] [Std.Total (α := α) (· ≤ ·)] :
+    Std.Total (α := WithTop α) (· ≤ ·) where
+  total x y := by cases x <;> cases y <;> simp; simpa using Std.Total.total ..
 
 section LinearOrder
 variable [LinearOrder α] {x y : WithTop α}

--- a/Mathlib/RingTheory/Valuation/ValuationRing.lean
+++ b/Mathlib/RingTheory/Valuation/ValuationRing.lean
@@ -266,7 +266,7 @@ instance (priority := 100) isLocalRing : IsLocalRing A :=
         apply isUnit_of_mul_eq_one _ (c + 1)
         simp [mul_add, h])
 
-instance le_total_ideal : IsTotal (Ideal A) LE.le := by
+instance inst_stdTotal_le : Std.Total (α := Ideal A) LE.le := by
   constructor; intro α β
   by_cases h : α ≤ β; · exact Or.inl h
   rw [SetLike.le_def, not_forall] at h
@@ -294,35 +294,35 @@ section dvd
 variable {R : Type*}
 
 theorem _root_.PreValuationRing.iff_dvd_total [Semigroup R] :
-    PreValuationRing R ↔ IsTotal R (· ∣ ·) := by
+    PreValuationRing R ↔ Std.Total (α := R) (· ∣ ·) := by
   classical
   refine ⟨fun H => ⟨fun a b => ?_⟩, fun H => ⟨fun a b => ?_⟩⟩
   · obtain ⟨c, rfl | rfl⟩ := PreValuationRing.cond a b <;> simp
-  · obtain ⟨c, rfl⟩ | ⟨c, rfl⟩ := @IsTotal.total _ _ H a b <;> use c <;> simp
+  · obtain ⟨c, rfl⟩ | ⟨c, rfl⟩ := @Std.Total.total _ _ H a b <;> use c <;> simp
 
 theorem _root_.PreValuationRing.iff_ideal_total [CommRing R] :
-    PreValuationRing R ↔ IsTotal (Ideal R) (· ≤ ·) := by
+    PreValuationRing R ↔ Std.Total (α := Ideal R) (· ≤ ·) := by
   classical
   refine ⟨fun _ => ⟨le_total⟩, fun H => PreValuationRing.iff_dvd_total.mpr ⟨fun a b => ?_⟩⟩
-  have := @IsTotal.total _ _ H (Ideal.span {a}) (Ideal.span {b})
+  have := @Std.Total.total _ _ H (Ideal.span {a}) (Ideal.span {b})
   simp_rw [Ideal.span_singleton_le_span_singleton] at this
   exact this.symm
 
 variable (K)
 
 theorem dvd_total [Semigroup R] [h : PreValuationRing R] (x y : R) : x ∣ y ∨ y ∣ x :=
-  @IsTotal.total _ _ (PreValuationRing.iff_dvd_total.mp h) x y
+  @Std.Total.total _ _ (PreValuationRing.iff_dvd_total.mp h) x y
 
 end dvd
 
 variable {R : Type*} [CommRing R] [IsDomain R] (K : Type*)
 variable [Field K] [Algebra R K] [IsFractionRing R K]
 
-theorem iff_dvd_total : ValuationRing R ↔ IsTotal R (· ∣ ·) :=
+theorem iff_dvd_total : ValuationRing R ↔ Std.Total (α := R) (· ∣ ·) :=
   Iff.trans (⟨fun inst ↦ inst.toPreValuationRing, fun _ ↦ .mk⟩)
     PreValuationRing.iff_dvd_total
 
-theorem iff_ideal_total : ValuationRing R ↔ IsTotal (Ideal R) (· ≤ ·) :=
+theorem iff_ideal_total : ValuationRing R ↔ Std.Total (α := Ideal R) (· ≤ ·) :=
   Iff.trans (⟨fun inst ↦ inst.toPreValuationRing, fun _ ↦ .mk⟩)
     PreValuationRing.iff_ideal_total
 
@@ -400,7 +400,8 @@ protected theorem TFAE (R : Type u) [CommRing R] [IsDomain R] :
     List.TFAE
       [ValuationRing R,
         ∀ x : FractionRing R, IsLocalization.IsInteger R x ∨ IsLocalization.IsInteger R x⁻¹,
-        IsTotal R (· ∣ ·), IsTotal (Ideal R) (· ≤ ·), IsLocalRing R ∧ IsBezout R] := by
+        Std.Total (α := R) (· ∣ ·), Std.Total (α := Ideal R) (· ≤ ·),
+        IsLocalRing R ∧ IsBezout R] := by
   tfae_have 1 ↔ 2 := iff_isInteger_or_isInteger R _
   tfae_have 1 ↔ 3 := iff_dvd_total
   tfae_have 1 ↔ 4 := iff_ideal_total

--- a/Mathlib/RingTheory/Valuation/ValuationSubring.lean
+++ b/Mathlib/RingTheory/Valuation/ValuationSubring.lean
@@ -345,14 +345,15 @@ def primeSpectrumOrderEquiv : (PrimeSpectrum A)ᵒᵈ ≃o {S // A ≤ S} :=
         all_goals exact le_ofPrime A (PrimeSpectrum.asIdeal _),
       fun h => by apply ofPrime_le_of_le; exact h⟩ }
 
-instance le_total_ideal : IsTotal {S // A ≤ S} LE.le := by
+instance inst_stdTotal_le : Std.Total (α := {S // A ≤ S}) LE.le := by
   classical
-  let _ : IsTotal (PrimeSpectrum A) (· ≤ ·) := ⟨fun ⟨x, _⟩ ⟨y, _⟩ => LE.isTotal.total x y⟩
-  exact ⟨(primeSpectrumOrderEquiv A).symm.toRelEmbedding.isTotal.total⟩
+  let _ : Std.Total (α := PrimeSpectrum A) (· ≤ ·) := ⟨fun x y => by
+    simp_rw [← PrimeSpectrum.asIdeal_le_asIdeal]; exact Std.Total.total ..⟩
+  exact (primeSpectrumOrderEquiv A).symm.toRelEmbedding.stdTotal
 
 open scoped Classical in
 instance linearOrderOverring : LinearOrder {S // A ≤ S} where
-  le_total := (le_total_ideal A).1
+  le_total := Std.Total.total
   max_def a b := congr_fun₂ sup_eq_maxDefault a b
   toDecidableLE := _
 

--- a/Mathlib/Topology/EMetricSpace/BoundedVariation.lean
+++ b/Mathlib/Topology/EMetricSpace/BoundedVariation.lean
@@ -608,7 +608,7 @@ protected theorem add {f : α → E} {s : Set α} (hf : LocallyBoundedVariationO
     (ha : a ∈ s) (hb : b ∈ s) (hc : c ∈ s) :
     variationOnFromTo f s a b + variationOnFromTo f s b c = variationOnFromTo f s a c := by
   symm
-  refine additive_of_isTotal (· ≤ · : α → α → Prop) (variationOnFromTo f s) (· ∈ s) ?_ ?_ ha hb hc
+  refine additive_of_stdTotal (· ≤ · : α → α → Prop) (variationOnFromTo f s) (· ∈ s) ?_ ?_ ha hb hc
   · rintro x y _xs _ys
     simp only [variationOnFromTo.eq_neg_swap f s y x, add_neg_cancel]
   · rintro x y z xy yz xs ys zs


### PR DESCRIPTION
---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include at least one commit authored by each
co-author among the commits in the pull request. If necessary, you may 
create empty commits to indicate co-authorship, using commands like so:

git commit --author="Author Name <author@email.com>" --allow-empty -m "add Author Name as coauthor"

When merging, all the commits will be squashed into a single commit listing all co-authors.

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
