### PR TITLE
[Merged by Bors] - feat: if the order topology for a dense linear ordering is discrete, the space has at most one point

### DIFF
--- a/Mathlib/Analysis/NormedSpace/PiTensorProduct/InjectiveSeminorm.lean
+++ b/Mathlib/Analysis/NormedSpace/PiTensorProduct/InjectiveSeminorm.lean
@@ -212,7 +212,8 @@ theorem injectiveSeminorm_le_projectiveSeminorm :
     existsi PUnit, inferInstance, inferInstance
     ext x
     simp only [Seminorm.zero_apply, Seminorm.comp_apply, coe_normSeminorm]
-    rw [Subsingleton.elim (toDualContinuousMultilinearMap PUnit x) 0, norm_zero]
+    rw [Subsingleton.elim (toDualContinuousMultilinearMap PUnit.{(max (max uE uι) u𝕜) + 1} x) 0,
+      norm_zero]
   · intro p hp
     simp only [Set.mem_setOf_eq] at hp
     obtain ⟨G, _, _, h⟩ := hp

--- a/Mathlib/Topology/Order/DenselyOrdered.lean
+++ b/Mathlib/Topology/Order/DenselyOrdered.lean
@@ -334,6 +334,20 @@ instance (x : α) [Nontrivial α] : NeBot (𝓝[≠] x) := by
   obtain ⟨z, hz⟩ : ∃ z, a < z ∧ z < x := exists_between hy.1
   exact ⟨z, us ⟨hab ⟨hz.1, hz.2.trans hy.2⟩, hz.2.ne⟩⟩
 
+instance [DiscreteTopology α] : Subsingleton α := by
+  suffices ∀ a b : α, b ≤ a by
+    refine ⟨fun a b ↦ ?_⟩
+    rcases lt_trichotomy a b with h | rfl | h
+    · simpa using lt_of_le_of_lt (this a b) h
+    · rfl
+    · simpa using lt_of_le_of_lt (this b a) h
+  intro a b
+  by_contra! contra
+  replace contra : b ∈ Ioo a b := by
+    rw [← (isClosed_discrete (Ioo a b)).closure_eq, closure_Ioo contra.ne]
+    simpa using contra.le
+  simp at contra
+
 /-- Let `s` be a dense set in a nontrivial dense linear order `α`. If `s` is a
 separable space (e.g., if `α` has a second countable topology), then there exists a countable
 dense subset `t ⊆ s` such that `t` does not contain bottom/top elements of `α`. -/

--- a/Mathlib/Topology/Order/DenselyOrdered.lean
+++ b/Mathlib/Topology/Order/DenselyOrdered.lean
@@ -334,7 +334,11 @@ instance (x : α) [Nontrivial α] : NeBot (𝓝[≠] x) := by
   obtain ⟨z, hz⟩ : ∃ z, a < z ∧ z < x := exists_between hy.1
   exact ⟨z, us ⟨hab ⟨hz.1, hz.2.trans hy.2⟩, hz.2.ne⟩⟩
 
-instance [DiscreteTopology α] : Subsingleton α := by
+/-- If the order topology for a dense linear ordering is discrete, the space has at most one point.
+
+We would prefer for this to be an instance but even at `(priority := 100)` this was problematic so
+we have deferred this issue. TODO Promote this to an `instance`! -/
+def DenselyOrdered.subsingleton_of_discreteTopology [DiscreteTopology α] : Subsingleton α := by
   suffices ∀ a b : α, b ≤ a by
     refine ⟨fun a b ↦ ?_⟩
     rcases lt_trichotomy a b with h | rfl | h

--- a/Mathlib/Topology/Order/DenselyOrdered.lean
+++ b/Mathlib/Topology/Order/DenselyOrdered.lean
@@ -339,18 +339,12 @@ instance (x : α) [Nontrivial α] : NeBot (𝓝[≠] x) := by
 We would prefer for this to be an instance but even at `(priority := 100)` this was problematic so
 we have deferred this issue. TODO Promote this to an `instance`! -/
 lemma DenselyOrdered.subsingleton_of_discreteTopology [DiscreteTopology α] : Subsingleton α := by
-  suffices ∀ a b : α, b ≤ a by
-    refine ⟨fun a b ↦ ?_⟩
-    rcases lt_trichotomy a b with h | rfl | h
-    · simpa using lt_of_le_of_lt (this a b) h
-    · rfl
-    · simpa using lt_of_le_of_lt (this b a) h
+  suffices ∀ a b : α, b ≤ a from ⟨fun a b ↦ le_antisymm (this b a) (this a b)⟩
   intro a b
   by_contra! contra
-  replace contra : b ∈ Ioo a b := by
-    rw [← (isClosed_discrete (Ioo a b)).closure_eq, closure_Ioo contra.ne]
-    simpa using contra.le
-  simp at contra
+  suffices b ∈ Ioo a b by grind
+  rw [← (isClosed_discrete (Ioo a b)).closure_eq, closure_Ioo contra.ne]
+  grind
 
 /-- Let `s` be a dense set in a nontrivial dense linear order `α`. If `s` is a
 separable space (e.g., if `α` has a second countable topology), then there exists a countable

--- a/Mathlib/Topology/Order/DenselyOrdered.lean
+++ b/Mathlib/Topology/Order/DenselyOrdered.lean
@@ -338,7 +338,7 @@ instance (x : α) [Nontrivial α] : NeBot (𝓝[≠] x) := by
 
 We would prefer for this to be an instance but even at `(priority := 100)` this was problematic so
 we have deferred this issue. TODO Promote this to an `instance`! -/
-def DenselyOrdered.subsingleton_of_discreteTopology [DiscreteTopology α] : Subsingleton α := by
+lemma DenselyOrdered.subsingleton_of_discreteTopology [DiscreteTopology α] : Subsingleton α := by
   suffices ∀ a b : α, b ≤ a by
     refine ⟨fun a b ↦ ?_⟩
     rcases lt_trichotomy a b with h | rfl | h


### PR DESCRIPTION
Co-authored-by: Aristotle Harmonic <aristotle-harmonic@harmonic.fun>

See also [Zulip discussion](https://leanprover.zulipchat.com/#narrow/channel/217875-Is-there-code-for-X.3F/topic/Characterisation.20of.20the.20integers/with/546911488)

---

Intended to help with #30471

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
