### PR TITLE
[Merged by Bors] - refactor(FieldTheory/IsAlgClosed,IsSepClosed): redefine in terms of `Polynomial.Factors`

### DIFF
--- a/Mathlib/FieldTheory/IsAlgClosed/Basic.lean
+++ b/Mathlib/FieldTheory/IsAlgClosed/Basic.lean
@@ -57,15 +57,15 @@ see `IsAlgClosed.splits_codomain` and `IsAlgClosed.splits_domain`.
 -/
 @[stacks 09GR "The definition of `IsAlgClosed` in mathlib is 09GR (4)"]
 class IsAlgClosed : Prop where
-  splits : ∀ p : k[X], p.Splits <| RingHom.id k
+  factors : ∀ p : k[X], p.Factors
 
 /-- Every polynomial splits in the field extension `f : K →+* k` if `k` is algebraically closed.
 
 See also `IsAlgClosed.splits_domain` for the case where `K` is algebraically closed.
 -/
 theorem IsAlgClosed.splits_codomain {k K : Type*} [Field k] [IsAlgClosed k] [CommRing K]
-    {f : K →+* k} (p : K[X]) : p.Splits f := by
-  convert IsAlgClosed.splits (p.map f); simp [splits_map_iff]
+    {f : K →+* k} (p : K[X]) : p.Splits f :=
+  IsAlgClosed.factors (p.map f)
 
 /-- Every polynomial splits in the field extension `f : K →+* k` if `K` is algebraically closed.
 
@@ -73,11 +73,14 @@ See also `IsAlgClosed.splits_codomain` for the case where `k` is algebraically c
 -/
 theorem IsAlgClosed.splits_domain {k K : Type*} [Field k] [IsAlgClosed k] [Field K] {f : k →+* K}
     (p : k[X]) : p.Splits f :=
-  Polynomial.splits_of_splits_id _ <| IsAlgClosed.splits _
+  (IsAlgClosed.factors p).map f
 
 namespace IsAlgClosed
 
 variable {k}
+
+theorem splits [IsAlgClosed k] (p : k[X]) : p.Splits (RingHom.id k) :=
+  (IsAlgClosed.factors p).map (RingHom.id k)
 
 /--
 If `k` is algebraically closed, then every nonconstant polynomial has a root.

--- a/Mathlib/FieldTheory/IsSepClosed.lean
+++ b/Mathlib/FieldTheory/IsSepClosed.lean
@@ -59,13 +59,18 @@ To show `Polynomial.Splits p f` for an arbitrary ring homomorphism `f`,
 see `IsSepClosed.splits_codomain` and `IsSepClosed.splits_domain`.
 -/
 class IsSepClosed : Prop where
-  splits_of_separable : ∀ p : k[X], p.Separable → (p.Splits <| RingHom.id k)
+  factors_of_separable : ∀ p : k[X], p.Separable → p.Factors
 
 /-- An algebraically closed field is also separably closed. -/
 instance IsSepClosed.of_isAlgClosed [IsAlgClosed k] : IsSepClosed k :=
-  ⟨fun p _ ↦ IsAlgClosed.splits p⟩
+  ⟨fun p _ ↦ IsAlgClosed.factors p⟩
 
 variable {k} {K}
+
+theorem IsSepClosed.splits_of_separable [IsSepClosed k] (p : k[X]) (hp : p.Separable) :
+    p.Splits (RingHom.id k) :=
+  (factors_of_separable p hp).map (RingHom.id k)
+
 
 /-- Every separable polynomial splits in the field extension `f : k →+* K` if `K` is
 separably closed.
@@ -173,7 +178,6 @@ theorem of_exists_root (H : ∀ p : k[X], p.Monic → Irreducible p → Separabl
     IsSepClosed k := by
   refine ⟨fun p hsep ↦ factors_iff_splits.mpr <| Or.inr ?_⟩
   intro q hq hdvd
-  simp only [map_id] at hdvd
   have hlc : IsUnit (leadingCoeff q)⁻¹ := IsUnit.inv <| Ne.isUnit <|
     leadingCoeff_ne_zero.2 <| Irreducible.ne_zero hq
   have hsep' : Separable (q * C (leadingCoeff q)⁻¹) :=

--- a/Mathlib/FieldTheory/IsSepClosed.lean
+++ b/Mathlib/FieldTheory/IsSepClosed.lean
@@ -71,7 +71,6 @@ theorem IsSepClosed.splits_of_separable [IsSepClosed k] (p : k[X]) (hp : p.Separ
     p.Splits (RingHom.id k) :=
   (factors_of_separable p hp).map (RingHom.id k)
 
-
 /-- Every separable polynomial splits in the field extension `f : k →+* K` if `K` is
 separably closed.
 


### PR DESCRIPTION
This PR redefines `IsAlgClosed` and `IsSepClosed` in terms of `Polynomial.Factors` rather than in terms of `Polynomial.Splits (RingHom.id k)`. This is part of a larger effort to switch over from `Polynomial.Splits` to `Polynomial.Factors`.

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include at least one commit authored by each
co-author among the commits in the pull request. If necessary, you may 
create empty commits to indicate co-authorship, using commands like so:

git commit --author="Author Name <author@email.com>" --allow-empty -m "add Author Name as coauthor"

When merging, all the commits will be squashed into a single commit listing all co-authors.

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
