### PR TITLE
feat(Computability/NFA): NFA closure under concatenation

### DIFF
--- a/Mathlib/Computability/NFA.lean
+++ b/Mathlib/Computability/NFA.lean
@@ -506,7 +506,7 @@ theorem concat_acceptsFrom {S1 : Set σ1} :
     rw [mem_acceptsFrom_nil]; tauto
   case cons a z ih =>
     simp only [mem_acceptsFrom_cons, stepSet, mem_image, hmul_concatStep, concatStep, iUnion_exists,
-      biUnion_and', iUnion_iUnion_eq_right, mem_acceptsFrom_biUnion, acceptsFrom_union, add_eq_sup,
+      biUnion_and', iUnion_iUnion_eq_right, acceptsFrom_biUnion, acceptsFrom_union, add_eq_sup,
       max, SemilatticeSup.sup, concat_acceptsFrom_inr]
     rw [Set.mem_iUnion₂]
     simp only [mem_union, ih, mem_iUnion, exists_prop]
@@ -514,13 +514,13 @@ theorem concat_acceptsFrom {S1 : Set σ1} :
     constructor
     · rintro ⟨s1, hs1, ⟨x, hx, y, hy, rfl⟩ | ⟨s2, hstart2, hz, haccept1⟩⟩
       · exists (a :: x); rw [mem_acceptsFrom_cons]
-        simp only [stepSet, mem_acceptsFrom_biUnion, List.cons_append, List.cons.injEq,
+        simp only [stepSet, acceptsFrom_biUnion, List.cons_append, List.cons.injEq,
           List.append_cancel_left_eq, true_and, exists_eq_right]
         rw [Set.mem_iUnion₂]; tauto
       · exists []; rw [mem_acceptsFrom_nil]
         simp only [accepts_acceptsFrom, List.nil_append, exists_eq_right]
         rw [mem_acceptsFrom_cons]
-        simp only [stepSet, mem_acceptsFrom_biUnion]
+        simp only [stepSet, acceptsFrom_biUnion]
         rw [Set.mem_iUnion₂]
         tauto
     · rintro ⟨x, hx, y, hy, heq⟩
@@ -531,13 +531,13 @@ theorem concat_acceptsFrom {S1 : Set σ1} :
         exists s1
         simp at heq; subst y
         rw [accepts_acceptsFrom, mem_acceptsFrom_cons] at hy
-        simp only [stepSet, mem_acceptsFrom_biUnion] at hy
+        simp only [stepSet, acceptsFrom_biUnion] at hy
         rw [Set.mem_iUnion₂] at hy
         tauto
       case cons b x =>
         obtain ⟨rfl, rfl⟩ := heq
         rw [mem_acceptsFrom_cons] at hx
-        simp only [stepSet, mem_acceptsFrom_biUnion] at hx
+        simp only [stepSet, acceptsFrom_biUnion] at hx
         rw [Set.mem_iUnion₂] at hx
         obtain ⟨s1, hs1, hx⟩ := hx
         exists s1

--- a/Mathlib/Computability/NFA.lean
+++ b/Mathlib/Computability/NFA.lean
@@ -416,6 +416,10 @@ end NFA
 
 namespace NFA
 
+section concat
+
+open Sum
+
 /-!
 ### Declarations about `NFA.concat`
 
@@ -438,14 +442,14 @@ variable {σ1 σ2 : Type v} (M1 : NFA α σ1) (M2 : NFA α σ2)
 
 /-- `M1.concatStart` is `(M1 * M2).start`, merely including `M1.start`. -/
 @[simp]
-def concatStart : Set (σ1 ⊕ σ2) := Sum.inl '' M1.start
+def concatStart : Set (σ1 ⊕ σ2) := inl '' M1.start
 
 /-- `concatAccept M1 M2` is `(M1 * M2).accept`, including `M2.accepts`, and if `[] ∈ M2.accepts`
 then also `M1.accepts`. If [] ∈ M2.accepts`, then without including `M1.accepts`, a final state in
 `M2.accept` is unreachable in `M1 * M2`. -/
 @[simp]
 def concatAccept : Set (σ1 ⊕ σ2) :=
-  Sum.inl '' { s1 ∈ M1.accept | [] ∈ M2.accepts } ∪ Sum.inr '' M2.accept
+  inl '' { s1 ∈ M1.accept | [] ∈ M2.accepts } ∪ inr '' M2.accept
 
 /-- `concatStep M1 M2 s a` is `(M1 * M2).step s a`, the set of states available in `M1 * M2` by a
 transition from state `s` via character `a`. We include all transitions from `M1.step` and
@@ -455,9 +459,9 @@ transition from state `s` via character `a`. We include all transitions from `M1
 @[simp]
 def concatStep : σ1 ⊕ σ2 → α → Set (σ1 ⊕ σ2)
 | .inl s1, a =>
-  Sum.inl '' M1.step s1 a ∪ Sum.inr '' ⋃ s2 ∈ M2.start, { s2' ∈ M2.step s2 a | s1 ∈ M1.accept }
+  inl '' M1.step s1 a ∪ inr '' ⋃ s2 ∈ M2.start, { s2' ∈ M2.step s2 a | s1 ∈ M1.accept }
 | .inr s2, a =>
-  Sum.inr '' M2.step s2 a
+  inr '' M2.step s2 a
 
 /-- `M1.concat M2` is `M1 * M2`, the concatenation of `M1` and `M2` achieved without ε-transitions.
 We decline to attatch a `@[simp]` nor `@[simps]` attribute in order to avoid unfolding the entire
@@ -483,18 +487,18 @@ lemma hmul_concatAccept : (M1 * M2).accept = concatAccept M1 M2 := rfl
 lemma hmul_concatStep : (M1 * M2).step = concatStep M1 M2 := rfl
 
 lemma concat_stepSet_inr {S2 : Set σ2} {a : α} :
-    (M1 * M2).stepSet (Sum.inr '' S2) a = Sum.inr '' M2.stepSet S2 a := by
+    (M1 * M2).stepSet (inr '' S2) a = inr '' M2.stepSet S2 a := by
   ext (s1 | s2) <;> simp [stepSet]
 
 lemma concat_acceptsFrom_inr {S2 : Set σ2} :
-    (M1 * M2).acceptsFrom (Sum.inr '' S2) = M2.acceptsFrom S2 := by
+    (M1 * M2).acceptsFrom (inr '' S2) = M2.acceptsFrom S2 := by
   ext y
   induction y generalizing S2 with
   | nil => simp
   | cons a y ih => simp [←ih, concat_stepSet_inr]
 
 theorem concat_acceptsFrom {S1 : Set σ1} :
-    (M1 * M2).acceptsFrom (Sum.inl '' S1) = M1.acceptsFrom S1 * M2.accepts := by
+    (M1 * M2).acceptsFrom (inl '' S1) = M1.acceptsFrom S1 * M2.accepts := by
   ext z
   rw [Language.mul_def, Set.mem_image2]
   induction z generalizing S1 with
@@ -546,6 +550,8 @@ theorem concat_acceptsFrom {S1 : Set σ1} :
 (`M1.concat M2`) is exactly equal to `L = L1 * L2`. -/
 theorem concat_accepts : (M1 * M2).accepts = M1.accepts * M2.accepts := by
   simp [concat_acceptsFrom, accepts_acceptsFrom]
+
+end concat
 
 end NFA
 

--- a/Mathlib/Computability/NFA.lean
+++ b/Mathlib/Computability/NFA.lean
@@ -89,12 +89,7 @@ variable (M) in
 theorem stepSet_union {S1 S2 : Set σ} {a : α} :
     M.stepSet (S1 ∪ S2) a = M.stepSet S1 a ∪ M.stepSet S2 a := by
   ext s
-  simp only [mem_stepSet, mem_union]
-  constructor
-  · rintro ⟨s', (h1 | h2), hstep⟩
-    · left; tauto
-    · right; tauto
-  · rintro (⟨s', h, hstep⟩ | ⟨s', h, hstep⟩) <;> exists s' <;> tauto
+  simp [mem_stepSet, or_and_right, exists_or]
 
 variable (M) in
 @[simp]

--- a/Mathlib/Computability/NFA.lean
+++ b/Mathlib/Computability/NFA.lean
@@ -87,7 +87,7 @@ theorem stepSet_singleton (s : σ) (a : α) : M.stepSet {s} a = M.step s a := by
 theorem stepSet_union {S1 S2 : Set σ} {a : α} :
     M.stepSet (S1 ∪ S2) a = M.stepSet S1 a ∪ M.stepSet S2 a := by
   ext s
-  simp [mem_stepSet]
+  simp only [mem_stepSet, mem_union]
   constructor
   · rintro ⟨s', (h1 | h2), hstep⟩
     · left; tauto

--- a/Mathlib/Computability/NFA.lean
+++ b/Mathlib/Computability/NFA.lean
@@ -572,7 +572,7 @@ theorem isRegular_reverse_iff {L : Language α} : L.reverse.IsRegular ↔ L.IsRe
   ⟨.of_reverse, .reverse⟩
 
 /-- Regular languages are closed under concatenation. -/
-theorem IsRegular.concat {L1 L2 : Language α}
+theorem IsRegular.mul {L1 L2 : Language α}
   (h1 : L1.IsRegular) (h2 : L2.IsRegular) : (L1 * L2).IsRegular :=
   have ⟨σ1, _, M1, hM1⟩ := h1
   have ⟨σ2, _, M2, hM2⟩ := h2

--- a/Mathlib/Computability/NFA.lean
+++ b/Mathlib/Computability/NFA.lean
@@ -84,6 +84,8 @@ variable (M) in
 theorem stepSet_singleton (s : σ) (a : α) : M.stepSet {s} a = M.step s a := by
   simp [stepSet]
 
+variable (M) in
+@[simp]
 theorem stepSet_union {S1 S2 : Set σ} {a : α} :
     M.stepSet (S1 ∪ S2) a = M.stepSet S1 a ∪ M.stepSet S2 a := by
   ext s
@@ -177,6 +179,7 @@ variable (M) in
 in `M.evalFrom S x`. -/
 def acceptsFrom (S : Set σ) : Language α := {x | ∃ s ∈ M.accept, s ∈ M.evalFrom S x}
 
+variable (M) in
 theorem mem_acceptsFrom {S : Set σ} {x : List α} :
     x ∈ M.acceptsFrom S ↔ ∃ s ∈ M.accept, s ∈ M.evalFrom S x := by
   rfl

--- a/Mathlib/Computability/NFA.lean
+++ b/Mathlib/Computability/NFA.lean
@@ -529,7 +529,7 @@ theorem concat_acceptsFrom {S1 : Set σ1} :
         · simp only [nil_mem_acceptsFrom (M:=M1)]
           tauto
         · exists (a :: z)
-          simp only [accepts_acceptsFrom, cons_mem_acceptsFrom (M:=M2), stepSet,
+          simp only [accepts_eq_acceptsFrom_start, cons_mem_acceptsFrom (M:=M2), stepSet,
             acceptsFrom_iUnion₂,
             Set.mem_iUnion₂ (s:=fun i _ => M2.acceptsFrom (M2.step i a))]
           tauto
@@ -539,8 +539,8 @@ theorem concat_acceptsFrom {S1 : Set σ1} :
         rw [nil_mem_acceptsFrom] at hx
         obtain ⟨s1, hs1, haccept1⟩ := hx
         simp only [List.nil_append] at heq; subst y
-        simp only [accepts_acceptsFrom, cons_mem_acceptsFrom (M:=M2), stepSet, acceptsFrom_iUnion₂,
-          Set.mem_iUnion₂ (s:=fun i _ => M2.acceptsFrom (M2.step i a))] at hy
+        simp only [accepts_eq_acceptsFrom_start, cons_mem_acceptsFrom (M:=M2), stepSet,
+          acceptsFrom_iUnion₂, Set.mem_iUnion₂ (s:=fun i _ => M2.acceptsFrom (M2.step i a))] at hy
         tauto
       | cons b x =>
         obtain ⟨rfl, rfl⟩ := heq
@@ -551,7 +551,7 @@ theorem concat_acceptsFrom {S1 : Set σ1} :
 /-- If `M1` accepts language `L1` and `M2` accepts language `L2`, then the language `L` of `M1 * M2`
 (`M1.concat M2`) is exactly equal to `L = L1 * L2`. -/
 theorem concat_accepts : (M1 * M2).accepts = M1.accepts * M2.accepts := by
-  simp [concat_acceptsFrom, accepts_acceptsFrom]
+  simp [concat_acceptsFrom, accepts_eq_acceptsFrom_start]
 
 end concat
 

--- a/Mathlib/Computability/NFA.lean
+++ b/Mathlib/Computability/NFA.lean
@@ -510,10 +510,10 @@ theorem concat_acceptsFrom {S1 : Set σ1} :
   induction z generalizing S1 with
   | nil =>
     suffices h : (∃ a ∈ S1, a ∈ M1.accept ∧ [] ∈ M2.accepts)
-      ↔ (∃ s ∈ S1, s ∈ M1.accept) ∧ [] ∈ M2.accepts by simpa [mem_acceptsFrom_nil M1]
+      ↔ (∃ s ∈ S1, s ∈ M1.accept) ∧ [] ∈ M2.accepts by simpa [nil_mem_acceptsFrom M1]
     tauto
   | cons a z ih =>
-    simp only [mem_acceptsFrom_cons, ↓concat_stepSet_inl, stepSet, acceptsFrom_union,
+    simp only [cons_mem_acceptsFrom, ↓concat_stepSet_inl, stepSet, acceptsFrom_union,
       concat_acceptsFrom_inr, acceptsFrom_iUnion, add_eq_sup, max, SemilatticeSup.sup,
       Set.mem_union z, ih, mem_iUnion, exists_prop]; clear ih
     simp_rw [↑mem_acceptsFrom_sep_fact]
@@ -521,30 +521,30 @@ theorem concat_acceptsFrom {S1 : Set σ1} :
     · rintro (⟨x, hx, ⟨y, hy, rfl⟩⟩ | ⟨s1, hs1, s2, hs2, hz, haccept1⟩)
       · exists (a :: x)
         constructor
-        · simpa [mem_acceptsFrom_cons (M:=M1), stepSet,
+        · simpa [cons_mem_acceptsFrom (M:=M1), stepSet,
             Set.mem_iUnion₂ (s:=fun i _ => M1.acceptsFrom (M1.step i a))]
         · tauto
       · exists []
         constructor
-        · simp only [mem_acceptsFrom_nil (M:=M1)]
+        · simp only [nil_mem_acceptsFrom (M:=M1)]
           tauto
         · exists (a :: z)
-          simp only [accepts_acceptsFrom, mem_acceptsFrom_cons (M:=M2), stepSet,
-            acceptsFrom_biUnion,
+          simp only [accepts_acceptsFrom, cons_mem_acceptsFrom (M:=M2), stepSet,
+            acceptsFrom_iUnion₂,
             Set.mem_iUnion₂ (s:=fun i _ => M2.acceptsFrom (M2.step i a))]
           tauto
     · rintro ⟨x, hx, y, hy, heq⟩
       cases x with
       | nil =>
-        rw [mem_acceptsFrom_nil] at hx
+        rw [nil_mem_acceptsFrom] at hx
         obtain ⟨s1, hs1, haccept1⟩ := hx
         simp only [List.nil_append] at heq; subst y
-        simp only [accepts_acceptsFrom, mem_acceptsFrom_cons (M:=M2), stepSet, acceptsFrom_biUnion,
+        simp only [accepts_acceptsFrom, cons_mem_acceptsFrom (M:=M2), stepSet, acceptsFrom_iUnion₂,
           Set.mem_iUnion₂ (s:=fun i _ => M2.acceptsFrom (M2.step i a))] at hy
         tauto
       | cons b x =>
         obtain ⟨rfl, rfl⟩ := heq
-        simp only [mem_acceptsFrom_cons (M:=M1), stepSet, acceptsFrom_biUnion,
+        simp only [cons_mem_acceptsFrom (M:=M1), stepSet, acceptsFrom_iUnion₂,
           Set.mem_iUnion₂ (s:=fun i _ => M1.acceptsFrom (M1.step i a))] at hx
         left; tauto
 

--- a/Mathlib/Computability/NFA.lean
+++ b/Mathlib/Computability/NFA.lean
@@ -499,20 +499,30 @@ theorem concat_acceptsFrom {S1 : Set σ1} :
   rw [Language.mul_def, Set.mem_image2]
   induction z generalizing S1
   case nil =>
-    simp; rw [mem_acceptsFrom_nil]; tauto
+    simp only [mem_acceptsFrom_nil, mem_image, hmul_concatAccept, concatAccept, mem_union,
+      mem_setOf_eq, exists_exists_and_eq_and, Sum.inl.injEq, exists_eq_right, reduceCtorEq,
+      and_false, exists_false, or_false,
+    List.append_eq_nil_iff, exists_eq_right_right]
+    rw [mem_acceptsFrom_nil]; tauto
   case cons a z ih =>
-    simp [stepSet, mem_acceptsFrom_biUnion, acceptsFrom_union, max, SemilatticeSup.sup]
-    simp [ih, concat_acceptsFrom_inr]; clear ih
-    simp_rw [↑mem_acceptsFrom_biUnion]
-    simp
-    simp_rw [↑mem_acceptsFrom_setOf_fact]
+    simp only [mem_acceptsFrom_cons, stepSet, mem_image, hmul_concatStep, concatStep, iUnion_exists,
+      biUnion_and', iUnion_iUnion_eq_right, mem_acceptsFrom_biUnion, acceptsFrom_union, add_eq_sup,
+      max, SemilatticeSup.sup, concat_acceptsFrom_inr]
+    rw [Set.mem_iUnion₂]
+    simp only [mem_union, ih, mem_iUnion, exists_prop]
+    simp_rw [↑mem_acceptsFrom_sep_fact]
     constructor
     · rintro ⟨s1, hs1, ⟨x, hx, y, hy, rfl⟩ | ⟨s2, hstart2, hz, haccept1⟩⟩
       · exists (a :: x); rw [mem_acceptsFrom_cons]
-        simp [stepSet, mem_acceptsFrom_biUnion]; tauto
+        simp only [stepSet, mem_acceptsFrom_biUnion, List.cons_append, List.cons.injEq,
+          List.append_cancel_left_eq, true_and, exists_eq_right]
+        rw [Set.mem_iUnion₂]; tauto
       · exists []; rw [mem_acceptsFrom_nil]
-        simp [accepts_acceptsFrom]; rw [mem_acceptsFrom_cons]
-        simp [stepSet, mem_acceptsFrom_biUnion]; tauto
+        simp only [accepts_acceptsFrom, List.nil_append, exists_eq_right]
+        rw [mem_acceptsFrom_cons]
+        simp only [stepSet, mem_acceptsFrom_biUnion]
+        rw [Set.mem_iUnion₂]
+        tauto
     · rintro ⟨x, hx, y, hy, heq⟩
       cases x
       case nil =>
@@ -521,12 +531,14 @@ theorem concat_acceptsFrom {S1 : Set σ1} :
         exists s1
         simp at heq; subst y
         rw [accepts_acceptsFrom, mem_acceptsFrom_cons] at hy
-        simp [stepSet, mem_acceptsFrom_biUnion] at hy
+        simp only [stepSet, mem_acceptsFrom_biUnion] at hy
+        rw [Set.mem_iUnion₂] at hy
         tauto
       case cons b x =>
         obtain ⟨rfl, rfl⟩ := heq
         rw [mem_acceptsFrom_cons] at hx
-        simp [stepSet, mem_acceptsFrom_biUnion] at hx
+        simp only [stepSet, mem_acceptsFrom_biUnion] at hx
+        rw [Set.mem_iUnion₂] at hx
         obtain ⟨s1, hs1, hx⟩ := hx
         exists s1
         constructor; next => assumption

--- a/Mathlib/Computability/NFA.lean
+++ b/Mathlib/Computability/NFA.lean
@@ -86,8 +86,8 @@ theorem stepSet_singleton (s : σ) (a : α) : M.stepSet {s} a = M.step s a := by
 
 variable (M) in
 @[simp]
-theorem stepSet_union {S1 S2 : Set σ} {a : α} :
-    M.stepSet (S1 ∪ S2) a = M.stepSet S1 a ∪ M.stepSet S2 a := by
+theorem stepSet_union {S T : Set σ} {a : α} :
+    M.stepSet (S ∪ T) a = M.stepSet S a ∪ M.stepSet T a := by
   ext s
   simp [mem_stepSet, or_and_right, exists_or]
 

--- a/Mathlib/Computability/NFA.lean
+++ b/Mathlib/Computability/NFA.lean
@@ -174,7 +174,6 @@ variable (M) in
 in `M.evalFrom S x`. -/
 def acceptsFrom (S : Set σ) : Language α := {x | ∃ s ∈ M.accept, s ∈ M.evalFrom S x}
 
-variable (M) in
 theorem mem_acceptsFrom {S : Set σ} {x : List α} :
     x ∈ M.acceptsFrom S ↔ ∃ s ∈ M.accept, s ∈ M.evalFrom S x := by
   rfl

--- a/Mathlib/Computability/NFA.lean
+++ b/Mathlib/Computability/NFA.lean
@@ -489,22 +489,20 @@ lemma concat_stepSet_inr {S2 : Set σ2} {a : α} :
 lemma concat_acceptsFrom_inr {S2 : Set σ2} :
     (M1 * M2).acceptsFrom (Sum.inr '' S2) = M2.acceptsFrom S2 := by
   ext y
-  induction y generalizing S2
-  case nil => simp
-  case cons a y ih => simp [←ih, concat_stepSet_inr]
+  induction y generalizing S2 with
+  | nil => simp
+  | cons a y ih => simp [←ih, concat_stepSet_inr]
 
 theorem concat_acceptsFrom {S1 : Set σ1} :
     (M1 * M2).acceptsFrom (Sum.inl '' S1) = M1.acceptsFrom S1 * M2.accepts := by
   ext z
   rw [Language.mul_def, Set.mem_image2]
-  induction z generalizing S1
-  case nil =>
-    simp only [mem_acceptsFrom_nil, mem_image, hmul_concatAccept, concatAccept, mem_union,
-      mem_setOf_eq, exists_exists_and_eq_and, Sum.inl.injEq, exists_eq_right, reduceCtorEq,
-      and_false, exists_false, or_false,
-    List.append_eq_nil_iff, exists_eq_right_right]
-    rw [mem_acceptsFrom_nil]; tauto
-  case cons a z ih =>
+  induction z generalizing S1 with
+  | nil =>
+    suffices h : (∃ a ∈ S1, a ∈ M1.accept ∧ [] ∈ M2.accepts)
+      ↔ (∃ s ∈ S1, s ∈ M1.accept) ∧ [] ∈ M2.accepts by simpa [mem_acceptsFrom_nil M1]
+    tauto
+  | cons a z ih =>
     simp only [mem_acceptsFrom_cons, stepSet, mem_image, hmul_concatStep, concatStep, iUnion_exists,
       biUnion_and', iUnion_iUnion_eq_right, acceptsFrom_biUnion, acceptsFrom_union, add_eq_sup,
       max, SemilatticeSup.sup, concat_acceptsFrom_inr]

--- a/Mathlib/Computability/NFA.lean
+++ b/Mathlib/Computability/NFA.lean
@@ -92,13 +92,6 @@ theorem stepSet_union {S T : Set σ} {a : α} :
   simp [mem_stepSet, or_and_right, exists_or]
 
 variable (M) in
-@[simp]
-theorem stepSet_union {S T : Set σ} {a : α} :
-    M.stepSet (S ∪ T) a = M.stepSet S a ∪ M.stepSet T a := by
-  ext s
-  simp [mem_stepSet, or_and_right, exists_or]
-
-variable (M) in
 /-- `M.evalFrom S x` computes all possible paths through `M` with input `x` starting at an element
   of `S`. -/
 def evalFrom (S : Set σ) : List α → Set σ :=

--- a/Mathlib/Computability/NFA.lean
+++ b/Mathlib/Computability/NFA.lean
@@ -84,6 +84,16 @@ variable (M) in
 theorem stepSet_singleton (s : σ) (a : α) : M.stepSet {s} a = M.step s a := by
   simp [stepSet]
 
+theorem stepSet_union {S1 S2 : Set σ} {a : α} :
+    M.stepSet (S1 ∪ S2) a = M.stepSet S1 a ∪ M.stepSet S2 a := by
+  ext s
+  simp [mem_stepSet]
+  constructor
+  · rintro ⟨s', (h1 | h2), hstep⟩
+    · left; tauto
+    · right; tauto
+  · rintro (⟨s', h, hstep⟩ | ⟨s', h, hstep⟩) <;> exists s' <;> tauto
+
 variable (M) in
 @[simp]
 theorem stepSet_union {S T : Set σ} {a : α} :

--- a/Mathlib/Computability/NFA.lean
+++ b/Mathlib/Computability/NFA.lean
@@ -477,11 +477,10 @@ theorem acceptsFrom_concat_inl {S1 : Set σ1} :
         · simpa [M1.cons_mem_acceptsFrom, stepSet,
             Set.mem_iUnion₂ (s:=fun i _ => M1.acceptsFrom (M1.step i a))]
         · tauto
-      · refine ⟨[], ?_, ?_⟩
+      · refine ⟨[], ?_, a :: z, ?_⟩
         · simp only [M1.nil_mem_acceptsFrom]
           tauto
-        · exists (a :: z)
-          simp only [accepts, M2.cons_mem_acceptsFrom, stepSet,
+        · simp only [accepts, M2.cons_mem_acceptsFrom, stepSet,
             acceptsFrom_iUnion₂,
             Set.mem_iUnion₂ (s:=fun i _ => M2.acceptsFrom (M2.step i a))]
           tauto

--- a/Mathlib/Computability/NFA.lean
+++ b/Mathlib/Computability/NFA.lean
@@ -194,7 +194,7 @@ theorem append_mem_acceptsFrom {S : Set σ} {x y : List α} :
 
 variable (M) in
 theorem append_preimage_acceptsFrom {S : Set σ} {x : List α} :
-    (x ++ ·) ⁻¹'  M.acceptsFrom S = M.acceptsFrom (M.evalFrom S x) := by
+    (x ++ ·) ⁻¹' M.acceptsFrom S = M.acceptsFrom (M.evalFrom S x) := by
   ext y; simp [M.append_mem_acceptsFrom]
 
 variable (M) in
@@ -346,7 +346,7 @@ theorem toNFA_evalFrom_match (M : DFA α σ) (start : σ) (s : List α) :
   | nil => tauto
   | cons a s ih =>
     rw [List.foldl, List.foldl,
-      show M.toNFA.stepSet {start} a = {M.step start a} by simp [NFA.stepSet] ]
+      show M.toNFA.stepSet {start} a = {M.step start a} by simp [NFA.stepSet]]
     tauto
 
 @[simp]

--- a/Mathlib/Computability/NFA.lean
+++ b/Mathlib/Computability/NFA.lean
@@ -176,7 +176,6 @@ variable (M) in
 theorem nil_mem_acceptsFrom {S : Set σ} : [] ∈ M.acceptsFrom S ↔ ∃ s ∈ S, s ∈ M.accept := by
   simp only [mem_acceptsFrom, evalFrom_nil]; tauto
 
-variable (M) in
 @[simp]
 theorem cons_mem_acceptsFrom {S : Set σ} {a : α} {x : List α} :
     a :: x ∈ M.acceptsFrom S ↔ x ∈ M.acceptsFrom (M.stepSet S a) := by
@@ -185,7 +184,7 @@ theorem cons_mem_acceptsFrom {S : Set σ} {a : α} {x : List α} :
 variable (M) in
 theorem cons_preimage_acceptsFrom {S : Set σ} {a : α} :
     (a :: ·) ⁻¹' M.acceptsFrom S = M.acceptsFrom (M.stepSet S a) := by
-  ext x; simp [cons_mem_acceptsFrom M]
+  ext x; simp [cons_mem_acceptsFrom (M:=M)]
 
 variable (M) in
 @[simp]
@@ -509,7 +508,7 @@ theorem concat_acceptsFrom {S1 : Set σ1} :
     simp only [cons_mem_acceptsFrom, ↓concat_stepSet_inl, stepSet, acceptsFrom_union,
       concat_acceptsFrom_inr, acceptsFrom_iUnion, add_eq_sup, max, SemilatticeSup.sup,
       Set.mem_union z, ih, mem_iUnion, exists_prop]; clear ih
-    simp_rw [↑mem_acceptsFrom_sep_fact]
+    simp_rw [↑mem_acceptsFrom_sep]
     constructor
     · rintro (⟨x, hx, ⟨y, hy, rfl⟩⟩ | ⟨s1, hs1, s2, hs2, hz, haccept1⟩)
       · exists (a :: x)

--- a/Mathlib/Computability/NFA.lean
+++ b/Mathlib/Computability/NFA.lean
@@ -225,7 +225,7 @@ theorem acceptsFrom_iUnion₂ {ι : Sort*} {κ : ι → Sort*} (f : ∀ i, κ i 
 
 variable (M) in
 @[simp]
-private theorem mem_acceptsFrom_sep_fact {S : Set σ} {p : Prop} {x : List α} :
+private theorem mem_acceptsFrom_sep {S : Set σ} {p : Prop} {x : List α} :
     x ∈ M.acceptsFrom {s ∈ S | p} ↔ x ∈ M.acceptsFrom S ∧ p := by
   induction x generalizing S with
   | nil => simp only [nil_mem_acceptsFrom, mem_setOf_eq]; tauto

--- a/Mathlib/Computability/NFA.lean
+++ b/Mathlib/Computability/NFA.lean
@@ -440,22 +440,22 @@ def concat : NFA α (σ1 ⊕ σ2) where
   start := inl '' M1.start
   accept := inl '' { s1 ∈ M1.accept | [] ∈ M2.accepts } ∪ inr '' M2.accept
 
-lemma concat_stepSet_inr {S2 : Set σ2} {a : α} :
+lemma stepSet_concat_inr {S2 : Set σ2} {a : α} :
     (M1.concat M2).stepSet (inr '' S2) a = inr '' M2.stepSet S2 a := by
   ext (s1 | s2) <;> simp [stepSet]
 
-lemma concat_stepSet_inl {S1 : Set σ1} {a : α} :
+lemma stepSet_concat_inl {S1 : Set σ1} {a : α} :
     (M1.concat M2).stepSet (inl '' S1) a =
       inl '' M1.stepSet S1 a ∪
       inr '' ⋃ s1 ∈ S1, ⋃ s2 ∈ M2.start, { s2' ∈ M2.step s2 a | s1 ∈ M1.accept } := by
   ext (s1 | s2) <;> simp [stepSet]
 
-lemma concat_acceptsFrom_inr {S2 : Set σ2} :
+lemma acceptsFrom_concat_inr {S2 : Set σ2} :
     (M1.concat M2).acceptsFrom (inr '' S2) = M2.acceptsFrom S2 := by
   ext y
   induction y generalizing S2 with
   | nil => simp
-  | cons a y ih => simp [←ih, concat_stepSet_inr]
+  | cons a y ih => simp [←ih, stepSet_concat_inr]
 
 theorem acceptsFrom_concat_inl {S1 : Set σ1} :
     (M1.concat M2).acceptsFrom (inl '' S1) = M1.acceptsFrom S1 * M2.accepts := by
@@ -467,8 +467,8 @@ theorem acceptsFrom_concat_inl {S1 : Set σ1} :
       ↔ (∃ s ∈ S1, s ∈ M1.accept) ∧ [] ∈ M2.accepts by simpa [nil_mem_acceptsFrom M1]
     tauto
   | cons a z ih =>
-    simp only [cons_mem_acceptsFrom, ↓concat_stepSet_inl, stepSet, acceptsFrom_union,
-      concat_acceptsFrom_inr, acceptsFrom_iUnion, add_eq_sup, max, SemilatticeSup.sup,
+    simp only [cons_mem_acceptsFrom, ↓stepSet_concat_inl, stepSet, acceptsFrom_union,
+      acceptsFrom_concat_inr, acceptsFrom_iUnion, add_eq_sup, max, SemilatticeSup.sup,
       Set.mem_union z, ih, mem_iUnion, exists_prop]; clear ih
     simp_rw [↑mem_acceptsFrom_sep]
     constructor
@@ -477,8 +477,7 @@ theorem acceptsFrom_concat_inl {S1 : Set σ1} :
         · simpa [M1.cons_mem_acceptsFrom, stepSet,
             Set.mem_iUnion₂ (s:=fun i _ => M1.acceptsFrom (M1.step i a))]
         · tauto
-      · exists []
-        constructor
+      · refine ⟨[], ?_, ?_⟩
         · simp only [M1.nil_mem_acceptsFrom]
           tauto
         · exists (a :: z)
@@ -504,7 +503,7 @@ theorem acceptsFrom_concat_inl {S1 : Set σ1} :
 /-- If `M1` accepts language `L1` and `M2` accepts language `L2`, then the language `L` of
 `M1.concat M2` is exactly equal to `L = L1 * L2`. -/
 theorem accepts_concat : (M1.concat M2).accepts = M1.accepts * M2.accepts := by
-  simp [concat_acceptsFrom, accepts]
+  simp [acceptsFrom_concat_inl, accepts]
 
 end concat
 
@@ -529,6 +528,6 @@ theorem IsRegular.mul {L1 L2 : Language α}
   (h1 : L1.IsRegular) (h2 : L2.IsRegular) : (L1 * L2).IsRegular :=
   have ⟨σ1, _, M1, hM1⟩ := h1
   have ⟨σ2, _, M2, hM2⟩ := h2
-  ⟨_, inferInstance, (M1.toNFA.concat M2.toNFA).toDFA, by simp [NFA.concat_accepts, hM1, hM2]⟩
+  ⟨_, inferInstance, (M1.toNFA.concat M2.toNFA).toDFA, by simp [NFA.accepts_concat, hM1, hM2]⟩
 
 end Language

--- a/Mathlib/Computability/NFA.lean
+++ b/Mathlib/Computability/NFA.lean
@@ -457,7 +457,7 @@ lemma concat_acceptsFrom_inr {S2 : Set σ2} :
   | nil => simp
   | cons a y ih => simp [←ih, concat_stepSet_inr]
 
-theorem concat_acceptsFrom {S1 : Set σ1} :
+theorem acceptsFrom_concat_inl {S1 : Set σ1} :
     (M1.concat M2).acceptsFrom (inl '' S1) = M1.acceptsFrom S1 * M2.accepts := by
   ext z
   rw [Language.mul_def, Set.mem_image2]
@@ -472,9 +472,8 @@ theorem concat_acceptsFrom {S1 : Set σ1} :
       Set.mem_union z, ih, mem_iUnion, exists_prop]; clear ih
     simp_rw [↑mem_acceptsFrom_sep]
     constructor
-    · rintro (⟨x, hx, ⟨y, hy, rfl⟩⟩ | ⟨s1, hs1, s2, hs2, hz, haccept1⟩)
-      · exists (a :: x)
-        constructor
+    · rintro (⟨x, hx, y, hy, rfl⟩ | ⟨s1, hs1, s2, hs2, hz, haccept1⟩)
+      · refine ⟨a :: x, ?_, ?_⟩
         · simpa [M1.cons_mem_acceptsFrom, stepSet,
             Set.mem_iUnion₂ (s:=fun i _ => M1.acceptsFrom (M1.step i a))]
         · tauto
@@ -504,7 +503,7 @@ theorem concat_acceptsFrom {S1 : Set σ1} :
 
 /-- If `M1` accepts language `L1` and `M2` accepts language `L2`, then the language `L` of
 `M1.concat M2` is exactly equal to `L = L1 * L2`. -/
-theorem concat_accepts : (M1.concat M2).accepts = M1.accepts * M2.accepts := by
+theorem accepts_concat : (M1.concat M2).accepts = M1.accepts * M2.accepts := by
   simp [concat_acceptsFrom, accepts]
 
 end concat

--- a/Mathlib/Computability/NFA.lean
+++ b/Mathlib/Computability/NFA.lean
@@ -430,37 +430,14 @@ analogue for `NFA` is different from the weighted analogue for `εNFA`.
 
 variable {σ1 σ2 : Type v} (M1 : NFA α σ1) (M2 : NFA α σ2)
 
-/-- `M1.concatStart` is `(M1 * M2).start`, merely including `M1.start`. -/
-@[simp]
-def concatStart : Set (σ1 ⊕ σ2) := inl '' M1.start
-
-/-- `concatAccept M1 M2` is `(M1 * M2).accept`, including `M2.accepts`, and if `[] ∈ M2.accepts`
-then also `M1.accepts`. If [] ∈ M2.accepts`, then without including `M1.accepts`, a final state in
-`M2.accept` is unreachable in `M1 * M2`. -/
-@[simp]
-def concatAccept : Set (σ1 ⊕ σ2) :=
-  inl '' { s1 ∈ M1.accept | [] ∈ M2.accepts } ∪ inr '' M2.accept
-
-/-- `concatStep M1 M2 s a` is `(M1 * M2).step s a`, the set of states available in `M1 * M2` by a
-transition from state `s` via character `a`. We include all transitions from `M1.step` and
-`M2.step`. In order to "concatenate" `M1` and `M2`, for `(M1 * M2).step (inl s1) a` when
-`s1 ∈ M1.accept`, we must also include states reachable from a state in `M2.start` via `a`,
-`⋃ s2 ∈ M2.start, M2.step s2 a`. -/
-@[simp]
-def concatStep : σ1 ⊕ σ2 → α → Set (σ1 ⊕ σ2)
-| .inl s1, a =>
-  inl '' M1.step s1 a ∪ inr '' ⋃ s2 ∈ M2.start, { s2' ∈ M2.step s2 a | s1 ∈ M1.accept }
-| .inr s2, a =>
-  inr '' M2.step s2 a
-
-/-- `M1.concat M2` is `M1 * M2`, the concatenation of `M1` and `M2` achieved without ε-transitions.
-We decline to attatch a `@[simp]` nor `@[simps]` attribute in order to avoid unfolding the entire
-construction, and instead prefer the `M1 * M2` notation, and only simplify the projections for
-`M1 * M2`. -/
+/-- `M1.concat M2` is `M1 * M2`, the concatenation of `M1` and `M2` achieved without ε-transitions. -/
+@[simps]
 def concat : NFA α (σ1 ⊕ σ2) where
-  step := concatStep M1 M2
-  start := concatStart M1
-  accept := concatAccept M1 M2
+  step
+  | .inl s1, a => inl '' M1.step s1 a ∪ inr '' ⋃ s2 ∈ M2.start, { s2' ∈ M2.step s2 a | s1 ∈ M1.accept }
+  | .inr s2, a => inr '' M2.step s2 a
+  start := inl '' M1.start
+  accept := inl '' { s1 ∈ M1.accept | [] ∈ M2.accepts } ∪ inr '' M2.accept
 
 instance : HMul (NFA α σ1) (NFA α σ2) (NFA α (σ1 ⊕ σ2)) :=
   ⟨concat⟩

--- a/Mathlib/Computability/NFA.lean
+++ b/Mathlib/Computability/NFA.lean
@@ -502,6 +502,7 @@ theorem acceptsFrom_concat_inl {S1 : Set σ1} :
 
 /-- If `M1` accepts language `L1` and `M2` accepts language `L2`, then the language `L` of
 `M1.concat M2` is exactly equal to `L = L1 * L2`. -/
+@[simp]
 theorem accepts_concat : (M1.concat M2).accepts = M1.accepts * M2.accepts := by
   simp [acceptsFrom_concat_inl, accepts]
 
@@ -528,6 +529,6 @@ theorem IsRegular.mul {L1 L2 : Language α}
   (h1 : L1.IsRegular) (h2 : L2.IsRegular) : (L1 * L2).IsRegular :=
   have ⟨σ1, _, M1, hM1⟩ := h1
   have ⟨σ2, _, M2, hM2⟩ := h2
-  ⟨_, inferInstance, (M1.toNFA.concat M2.toNFA).toDFA, by simp [NFA.accepts_concat, hM1, hM2]⟩
+  ⟨_, inferInstance, (M1.toNFA.concat M2.toNFA).toDFA, by simp [hM1, hM2]⟩
 
 end Language

--- a/Mathlib/Computability/NFA.lean
+++ b/Mathlib/Computability/NFA.lean
@@ -468,7 +468,7 @@ theorem acceptsFrom_concat_inl {S1 : Set σ1} :
     tauto
   | cons a z ih =>
     simp only [cons_mem_acceptsFrom, ↓stepSet_concat_inl, stepSet, acceptsFrom_union,
-      acceptsFrom_concat_inr, acceptsFrom_iUnion, add_eq_sup, max, SemilatticeSup.sup,
+      acceptsFrom_concat_inr, acceptsFrom_iUnion, Language.add_def,
       Set.mem_union z, ih, mem_iUnion, exists_prop]; clear ih
     simp_rw [↑mem_acceptsFrom_sep]
     constructor

--- a/Mathlib/Computability/NFA.lean
+++ b/Mathlib/Computability/NFA.lean
@@ -467,37 +467,25 @@ theorem acceptsFrom_concat_inl {S1 : Set σ1} :
       ↔ (∃ s ∈ S1, s ∈ M1.accept) ∧ [] ∈ M2.accepts by simpa [nil_mem_acceptsFrom M1]
     tauto
   | cons a z ih =>
-    simp only [cons_mem_acceptsFrom, ↓stepSet_concat_inl, stepSet, acceptsFrom_union,
-      acceptsFrom_concat_inr, acceptsFrom_iUnion, Language.add_def,
-      Set.mem_union z, ih, mem_iUnion, exists_prop]; clear ih
-    simp_rw [↑mem_acceptsFrom_sep]
-    constructor
-    · rintro (⟨x, hx, y, hy, rfl⟩ | ⟨s1, hs1, s2, hs2, hz, haccept1⟩)
-      · refine ⟨a :: x, ?_, ?_⟩
-        · simpa [M1.cons_mem_acceptsFrom, stepSet,
-            Set.mem_iUnion₂ (s:=fun i _ => M1.acceptsFrom (M1.step i a))]
-        · tauto
-      · refine ⟨[], ?_, a :: z, ?_⟩
-        · simp only [M1.nil_mem_acceptsFrom]
-          tauto
-        · simp only [accepts, M2.cons_mem_acceptsFrom, stepSet,
-            acceptsFrom_iUnion₂,
-            Set.mem_iUnion₂ (s:=fun i _ => M2.acceptsFrom (M2.step i a))]
-          tauto
-    · rintro ⟨x, hx, y, hy, heq⟩
-      cases x with
-      | nil =>
-        rw [nil_mem_acceptsFrom] at hx
-        obtain ⟨s1, hs1, haccept1⟩ := hx
-        simp only [List.nil_append] at heq; subst y
-        simp only [accepts, M2.cons_mem_acceptsFrom, stepSet,
-          acceptsFrom_iUnion₂, Set.mem_iUnion₂ (s:=fun i _ => M2.acceptsFrom (M2.step i a))] at hy
-        tauto
-      | cons b x =>
-        obtain ⟨rfl, rfl⟩ := heq
-        simp only [M1.cons_mem_acceptsFrom, stepSet, acceptsFrom_iUnion₂,
-          Set.mem_iUnion₂ (s:=fun i _ => M1.acceptsFrom (M1.step i a))] at hx
-        left; tauto
+  simp only [cons_mem_acceptsFrom, ↓stepSet_concat_inl, stepSet, acceptsFrom_union,
+    acceptsFrom_concat_inr, acceptsFrom_iUnion, Language.add_def,
+    Set.mem_union z, ih, mem_iUnion, exists_prop]
+  clear ih
+  simp_rw [↑mem_acceptsFrom_sep]
+  constructor
+  · rintro (⟨x, hx, y, hy, rfl⟩ | ⟨s1, hs1, s2, hs2, hz, haccept1⟩)
+    · exact ⟨a :: x, by simp [M1.cons_mem_acceptsFrom, stepSet, Language, *]⟩
+    refine ⟨[], ⟨s1, haccept1, hs1⟩, a :: z, ?_, rfl⟩
+    simp [accepts, M2.cons_mem_acceptsFrom, stepSet, Language]
+    tauto
+  · rintro ⟨x | ⟨b, x⟩, hx, _, hz, rfl, rfl⟩
+    · rw [nil_mem_acceptsFrom] at hx
+      obtain ⟨s1, hs1, haccept1⟩ := hx
+      simp [accepts, M2.cons_mem_acceptsFrom, stepSet, Language] at hz
+      tauto
+    · simp [M1.cons_mem_acceptsFrom, stepSet, Language] at hx
+      left
+      tauto
 
 /-- If `M1` accepts language `L1` and `M2` accepts language `L2`, then the language `L` of
 `M1.concat M2` is exactly equal to `L = L1 * L2`. -/

--- a/Mathlib/Computability/NFA.lean
+++ b/Mathlib/Computability/NFA.lean
@@ -257,12 +257,10 @@ theorem eval_append_singleton (x : List α) (a : α) :
 
 variable (M) in
 /-- `M.accepts` is the language of `x` such that there is an accept state in `M.eval x`. -/
-def accepts : Language α := {x | ∃ S ∈ M.accept, S ∈ M.eval x}
+def accepts : Language α := M.acceptsFrom M.start
 
 theorem mem_accepts {x : List α} : x ∈ M.accepts ↔ ∃ S ∈ M.accept, S ∈ M.evalFrom M.start x := by
   rfl
-
-theorem accepts_eq_acceptsFrom_start : M.accepts = M.acceptsFrom M.start := rfl
 
 variable (M) in
 /-- `M.Path` represents a concrete path through the NFA from a start state to an end state
@@ -521,7 +519,7 @@ theorem concat_acceptsFrom {S1 : Set σ1} :
         · simp only [nil_mem_acceptsFrom (M:=M1)]
           tauto
         · exists (a :: z)
-          simp only [accepts_eq_acceptsFrom_start, cons_mem_acceptsFrom (M:=M2), stepSet,
+          simp only [accepts, cons_mem_acceptsFrom (M:=M2), stepSet,
             acceptsFrom_iUnion₂,
             Set.mem_iUnion₂ (s:=fun i _ => M2.acceptsFrom (M2.step i a))]
           tauto
@@ -531,7 +529,7 @@ theorem concat_acceptsFrom {S1 : Set σ1} :
         rw [nil_mem_acceptsFrom] at hx
         obtain ⟨s1, hs1, haccept1⟩ := hx
         simp only [List.nil_append] at heq; subst y
-        simp only [accepts_eq_acceptsFrom_start, cons_mem_acceptsFrom (M:=M2), stepSet,
+        simp only [accepts, cons_mem_acceptsFrom (M:=M2), stepSet,
           acceptsFrom_iUnion₂, Set.mem_iUnion₂ (s:=fun i _ => M2.acceptsFrom (M2.step i a))] at hy
         tauto
       | cons b x =>
@@ -543,7 +541,7 @@ theorem concat_acceptsFrom {S1 : Set σ1} :
 /-- If `M1` accepts language `L1` and `M2` accepts language `L2`, then the language `L` of `M1 * M2`
 (`M1.concat M2`) is exactly equal to `L = L1 * L2`. -/
 theorem concat_accepts : (M1 * M2).accepts = M1.accepts * M2.accepts := by
-  simp [concat_acceptsFrom, accepts_eq_acceptsFrom_start]
+  simp [concat_acceptsFrom, accepts]
 
 end concat
 

--- a/Mathlib/Computability/NFA.lean
+++ b/Mathlib/Computability/NFA.lean
@@ -513,7 +513,7 @@ theorem isRegular_reverse_iff {L : Language α} : L.reverse.IsRegular ↔ L.IsRe
 
 /-- Regular languages are closed under concatenation. -/
 theorem IsRegular.mul {L1 L2 : Language α}
-  (h1 : L1.IsRegular) (h2 : L2.IsRegular) : (L1 * L2).IsRegular :=
+    (h1 : L1.IsRegular) (h2 : L2.IsRegular) : (L1 * L2).IsRegular :=
   have ⟨σ1, _, M1, hM1⟩ := h1
   have ⟨σ2, _, M2, hM2⟩ := h2
   ⟨_, inferInstance, (M1.toNFA.concat M2.toNFA).toDFA, by simp [hM1, hM2]⟩


### PR DESCRIPTION
This PR proves that regular languages are closed under concatenation via a direct construction on `NFA`s without `εNFA` nor ε-transitions. The main new definitions and results include:

- `M1.concat M2`, the concatenation of `NFA`s `M1` and `M2`, a direct construction without ε-transitions.
- Theorem `accepts_concat : (M1.concat M2).accepts = M1.accepts * M2.accepts`, showing the correctness of the construction.
- Theorem `IsRegular.mul`, showing that regular languages are closed under concatenation.

---

- [x] depends on: #31038

<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include at least one commit authored by each
co-author among the commits in the pull request. If necessary, you may 
create empty commits to indicate co-authorship, using commands like so:

git commit --author="Author Name <author@email.com>" --allow-empty -m "add Author Name as coauthor"

When merging, all the commits will be squashed into a single commit listing all co-authors.

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
