### PR TITLE
[Merged by Bors] - chore(Data/Prod): golf `toLex_covBy_toLex_iff` using `grind`

### DIFF
--- a/Mathlib/Data/Prod/Lex.lean
+++ b/Mathlib/Data/Prod/Lex.lean
@@ -91,15 +91,7 @@ theorem toLex_covBy_toLex_iff {a₁ a₂ : α} {b₁ b₂ : β} :
     toLex (a₁, b₁) ⋖ toLex (a₂, b₂) ↔ a₁ = a₂ ∧ b₁ ⋖ b₂ ∨ a₁ ⋖ a₂ ∧ IsMax b₁ ∧ IsMin b₂ := by
   simp only [CovBy, toLex_lt_toLex, toLex.surjective.forall, Prod.forall, isMax_iff_forall_not_lt,
     isMin_iff_forall_not_lt]
-  constructor
-  · grind
-  · rintro (⟨rfl, hb, h⟩ | ⟨⟨ha, h⟩, hb₁, hb₂⟩)
-    · refine ⟨.inr ⟨rfl, hb⟩, fun a b ↦ ?_⟩
-      rintro (hlt₁ | ⟨rfl, hlt₁⟩) (hlt₂ | ⟨heq, hlt₂⟩)
-      exacts [hlt₁.not_gt hlt₂, hlt₁.ne' heq, hlt₂.false, h hlt₁ hlt₂]
-    · refine ⟨.inl ha, fun a b ↦ ?_⟩
-      rintro (hlt₁ | ⟨rfl, hlt₁⟩) (hlt₂ | ⟨heq, hlt₂⟩)
-      exacts [h hlt₁ hlt₂, hb₂ _ hlt₂, hb₁ _ hlt₁, hb₁ _ hlt₁]
+  grind
 
 theorem covBy_iff {a b : α ×ₗ β} :
     a ⋖ b ↔ (ofLex a).1 = (ofLex b).1 ∧ (ofLex a).2 ⋖ (ofLex b).2 ∨


### PR DESCRIPTION
---
<details>
<summary>Show trace profiling of <code>toLex_covBy_toLex_iff</code>: 54 ms before, 82 ms after </summary>

### Trace profiling of `toLex_covBy_toLex_iff` before PR 30888
```diff
diff --git a/Mathlib/Data/Prod/Lex.lean b/Mathlib/Data/Prod/Lex.lean
index d0af456db9..1977003966 100644
--- a/Mathlib/Data/Prod/Lex.lean
+++ b/Mathlib/Data/Prod/Lex.lean
@@ -87,6 +87,7 @@ theorem monotone_fst_ofLex : Monotone fun x : α ×ₗ β ↦ (ofLex x).1 := mon
 theorem _root_.WCovBy.fst_ofLex {a b : α ×ₗ β} (h : a ⩿ b) : (ofLex a).1 ⩿ (ofLex b).1 :=
   ⟨monotone_fst _ _ h.1, fun c hac hcb ↦ h.2 (c := toLex (c, a.2)) (.left _ _ hac) (.left _ _ hcb)⟩
 
+set_option trace.profiler true in
 theorem toLex_covBy_toLex_iff {a₁ a₂ : α} {b₁ b₂ : β} :
     toLex (a₁, b₁) ⋖ toLex (a₂, b₂) ↔ a₁ = a₂ ∧ b₁ ⋖ b₂ ∨ a₁ ⋖ a₂ ∧ IsMax b₁ ∧ IsMin b₂ := by
   simp only [CovBy, toLex_lt_toLex, toLex.surjective.forall, Prod.forall, isMax_iff_forall_not_lt,
```
```
ℹ [346/346] Built Mathlib.Data.Prod.Lex (1.3s)
info: Mathlib/Data/Prod/Lex.lean:91:0: [Elab.async] [0.055828] elaborating proof of Prod.Lex.toLex_covBy_toLex_iff
  [Elab.definition.value] [0.054413] Prod.Lex.toLex_covBy_toLex_iff
    [Elab.step] [0.053523] 
          simp only [CovBy, toLex_lt_toLex, toLex.surjective.forall, Prod.forall, isMax_iff_forall_not_lt,
            isMin_iff_forall_not_lt]
          constructor
          · grind
          · rintro (⟨rfl, hb, h⟩ | ⟨⟨ha, h⟩, hb₁, hb₂⟩)
            · refine ⟨.inr ⟨rfl, hb⟩, fun a b ↦ ?_⟩
              rintro (hlt₁ | ⟨rfl, hlt₁⟩) (hlt₂ | ⟨heq, hlt₂⟩)
              exacts [hlt₁.not_gt hlt₂, hlt₁.ne' heq, hlt₂.false, h hlt₁ hlt₂]
            · refine ⟨.inl ha, fun a b ↦ ?_⟩
              rintro (hlt₁ | ⟨rfl, hlt₁⟩) (hlt₂ | ⟨heq, hlt₂⟩)
              exacts [h hlt₁ hlt₂, hb₂ _ hlt₂, hb₁ _ hlt₁, hb₁ _ hlt₁]
      [Elab.step] [0.053516] 
            simp only [CovBy, toLex_lt_toLex, toLex.surjective.forall, Prod.forall, isMax_iff_forall_not_lt,
              isMin_iff_forall_not_lt]
            constructor
            · grind
            · rintro (⟨rfl, hb, h⟩ | ⟨⟨ha, h⟩, hb₁, hb₂⟩)
              · refine ⟨.inr ⟨rfl, hb⟩, fun a b ↦ ?_⟩
                rintro (hlt₁ | ⟨rfl, hlt₁⟩) (hlt₂ | ⟨heq, hlt₂⟩)
                exacts [hlt₁.not_gt hlt₂, hlt₁.ne' heq, hlt₂.false, h hlt₁ hlt₂]
              · refine ⟨.inl ha, fun a b ↦ ?_⟩
                rintro (hlt₁ | ⟨rfl, hlt₁⟩) (hlt₂ | ⟨heq, hlt₂⟩)
                exacts [h hlt₁ hlt₂, hb₂ _ hlt₂, hb₁ _ hlt₁, hb₁ _ hlt₁]
        [Elab.step] [0.042503] · grind
          [Elab.step] [0.042445] grind
            [Elab.step] [0.042441] grind
              [Elab.step] [0.042434] grind
Build completed successfully (346 jobs).
```

### Trace profiling of `toLex_covBy_toLex_iff` after PR 30888
```diff
diff --git a/Mathlib/Data/Prod/Lex.lean b/Mathlib/Data/Prod/Lex.lean
index d0af456db9..d40fed45cd 100644
--- a/Mathlib/Data/Prod/Lex.lean
+++ b/Mathlib/Data/Prod/Lex.lean
@@ -87,19 +87,12 @@ theorem monotone_fst_ofLex : Monotone fun x : α ×ₗ β ↦ (ofLex x).1 := mon
 theorem _root_.WCovBy.fst_ofLex {a b : α ×ₗ β} (h : a ⩿ b) : (ofLex a).1 ⩿ (ofLex b).1 :=
   ⟨monotone_fst _ _ h.1, fun c hac hcb ↦ h.2 (c := toLex (c, a.2)) (.left _ _ hac) (.left _ _ hcb)⟩
 
+set_option trace.profiler true in
 theorem toLex_covBy_toLex_iff {a₁ a₂ : α} {b₁ b₂ : β} :
     toLex (a₁, b₁) ⋖ toLex (a₂, b₂) ↔ a₁ = a₂ ∧ b₁ ⋖ b₂ ∨ a₁ ⋖ a₂ ∧ IsMax b₁ ∧ IsMin b₂ := by
   simp only [CovBy, toLex_lt_toLex, toLex.surjective.forall, Prod.forall, isMax_iff_forall_not_lt,
     isMin_iff_forall_not_lt]
-  constructor
-  · grind
-  · rintro (⟨rfl, hb, h⟩ | ⟨⟨ha, h⟩, hb₁, hb₂⟩)
-    · refine ⟨.inr ⟨rfl, hb⟩, fun a b ↦ ?_⟩
-      rintro (hlt₁ | ⟨rfl, hlt₁⟩) (hlt₂ | ⟨heq, hlt₂⟩)
-      exacts [hlt₁.not_gt hlt₂, hlt₁.ne' heq, hlt₂.false, h hlt₁ hlt₂]
-    · refine ⟨.inl ha, fun a b ↦ ?_⟩
-      rintro (hlt₁ | ⟨rfl, hlt₁⟩) (hlt₂ | ⟨heq, hlt₂⟩)
-      exacts [h hlt₁ hlt₂, hb₂ _ hlt₂, hb₁ _ hlt₁, hb₁ _ hlt₁]
+  grind
 
 theorem covBy_iff {a b : α ×ₗ β} :
     a ⋖ b ↔ (ofLex a).1 = (ofLex b).1 ∧ (ofLex a).2 ⋖ (ofLex b).2 ∨
```
```
ℹ [346/346] Built Mathlib.Data.Prod.Lex (1.2s)
info: Mathlib/Data/Prod/Lex.lean:91:0: [Elab.async] [0.083386] elaborating proof of Prod.Lex.toLex_covBy_toLex_iff
  [Elab.definition.value] [0.082313] Prod.Lex.toLex_covBy_toLex_iff
    [Elab.step] [0.082097] 
          simp only [CovBy, toLex_lt_toLex, toLex.surjective.forall, Prod.forall, isMax_iff_forall_not_lt,
            isMin_iff_forall_not_lt]
          grind
      [Elab.step] [0.082089] 
            simp only [CovBy, toLex_lt_toLex, toLex.surjective.forall, Prod.forall, isMax_iff_forall_not_lt,
              isMin_iff_forall_not_lt]
            grind
        [Elab.step] [0.075240] grind
Build completed successfully (346 jobs).
```
</details>

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include at least one commit authored by each
co-author among the commits in the pull request. If necessary, you may 
create empty commits to indicate co-authorship, using commands like so:

git commit --author="Author Name <author@email.com>" --allow-empty -m "add Author Name as coauthor"

When merging, all the commits will be squashed into a single commit listing all co-authors.

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
