### PR TITLE
[Merged by Bors] - chore(Order/Defs): golf multiple lemmas in `LinearOrder` using `grind`

### DIFF
--- a/Mathlib/Order/Defs/LinearOrder.lean
+++ b/Mathlib/Order/Defs/LinearOrder.lean
@@ -88,7 +88,7 @@ lemma lt_of_not_ge (h : ¬b ≤ a) : a < b := lt_of_le_not_ge (le_of_not_ge h) h
 @[deprecated (since := "2025-05-11")] alias le_of_not_le := le_of_not_ge
 
 lemma lt_trichotomy (a b : α) : a < b ∨ a = b ∨ b < a := by
-  grind [le_total, Decidable.lt_or_eq_of_le]
+  grind
 
 lemma le_of_not_gt (h : ¬b < a) : a ≤ b :=
   match lt_trichotomy a b with
@@ -107,7 +107,8 @@ lemma le_or_gt (a b : α) : a ≤ b ∨ b < a := (lt_or_ge b a).symm
 
 @[deprecated (since := "2025-05-11")] alias le_or_lt := le_or_gt
 
-lemma lt_or_gt_of_ne (h : a ≠ b) : a < b ∨ b < a := by simpa [h] using lt_trichotomy a b
+lemma lt_or_gt_of_ne (h : a ≠ b) : a < b ∨ b < a := by
+  grind
 
 lemma ne_iff_lt_or_gt : a ≠ b ↔ a < b ∨ b < a := ⟨lt_or_gt_of_ne, (Or.elim · ne_of_lt ne_of_gt)⟩
 
@@ -132,27 +133,19 @@ lemma min_def (a b : α) : min a b = if a ≤ b then a else b := LinearOrder.min
 lemma max_def (a b : α) : max a b = if a ≤ b then b else a := LinearOrder.max_def a b
 
 lemma min_le_left (a b : α) : min a b ≤ a := by
-  if h : a ≤ b
-  then simp [min_def, if_pos h, le_refl]
-  else simpa [min_def, if_neg h] using le_of_not_ge h
+  grind
 
 lemma min_le_right (a b : α) : min a b ≤ b := by
-  if h : a ≤ b
-  then simpa [min_def, if_pos h] using h
-  else simp [min_def, if_neg h, le_refl]
+  grind
 
 lemma le_min (h₁ : c ≤ a) (h₂ : c ≤ b) : c ≤ min a b := by
   grind
 
 lemma le_max_left (a b : α) : a ≤ max a b := by
-  if h : a ≤ b
-  then simpa [max_def, if_pos h] using h
-  else simp [max_def, if_neg h, le_refl]
+  grind
 
 lemma le_max_right (a b : α) : b ≤ max a b := by
-  if h : a ≤ b
-  then simp [max_def, if_pos h, le_refl]
-  else simpa [max_def, if_neg h] using le_of_not_ge h
+  grind
 
 lemma max_le (h₁ : a ≤ c) (h₂ : b ≤ c) : max a b ≤ c := by
   grind
@@ -164,19 +157,13 @@ lemma min_comm (a b : α) : min a b = min b a :=
   eq_min (min_le_right a b) (min_le_left a b) fun h₁ h₂ => le_min h₂ h₁
 
 lemma min_assoc (a b c : α) : min (min a b) c = min a (min b c) := by
-  apply eq_min
-  · apply le_trans (min_le_left ..) (min_le_left ..)
-  · apply le_min
-    · apply le_trans (min_le_left ..) (min_le_right ..)
-    · apply min_le_right
-  · intro d h₁ h₂; apply le_min
-    · apply le_min h₁; apply le_trans h₂; apply min_le_left
-    · apply le_trans h₂; apply min_le_right
+  grind
 
 lemma min_left_comm (a b c : α) : min a (min b c) = min b (min a c) := by
-  rw [← min_assoc, min_comm a, min_assoc]
+  grind
 
-@[simp] lemma min_self (a : α) : min a a = a := by simp [min_def]
+@[simp] lemma min_self (a : α) : min a a = a := by
+  grind
 
 lemma min_eq_left (h : a ≤ b) : min a b = a := by
   grind
@@ -191,22 +178,16 @@ lemma max_comm (a b : α) : max a b = max b a :=
   eq_max (le_max_right a b) (le_max_left a b) fun h₁ h₂ => max_le h₂ h₁
 
 lemma max_assoc (a b c : α) : max (max a b) c = max a (max b c) := by
-  apply eq_max
-  · apply le_trans (le_max_left a b) (le_max_left ..)
-  · apply max_le
-    · apply le_trans (le_max_right a b) (le_max_left ..)
-    · apply le_max_right
-  · intro d h₁ h₂; apply max_le
-    · apply max_le h₁; apply le_trans (le_max_left _ _) h₂
-    · apply le_trans (le_max_right _ _) h₂
+  grind
 
 lemma max_left_comm (a b c : α) : max a (max b c) = max b (max a c) := by
-  rw [← max_assoc, max_comm a, max_assoc]
+  grind
 
-@[simp] lemma max_self (a : α) : max a a = a := by simp [max_def]
+@[simp] lemma max_self (a : α) : max a a = a := by
+  grind
 
 lemma max_eq_left (h : b ≤ a) : max a b = a := by
-  apply Eq.symm; apply eq_max (le_refl _) h; intros; assumption
+  grind
 
 lemma max_eq_right (h : a ≤ b) : max a b = b := max_comm b a ▸ max_eq_left h
 
@@ -225,21 +206,15 @@ section Ord
 
 lemma compare_lt_iff_lt : compare a b = .lt ↔ a < b := by
   rw [LinearOrder.compare_eq_compareOfLessAndEq, compareOfLessAndEq]
-  split_ifs <;> simp only [*, lt_irrefl]
+  grind
 
 lemma compare_gt_iff_gt : compare a b = .gt ↔ b < a := by
   rw [LinearOrder.compare_eq_compareOfLessAndEq, compareOfLessAndEq]
-  split_ifs <;> simp only [*, lt_irrefl, not_lt_of_gt]
-  case _ h₁ h₂ =>
-    have h : b < a := lt_trichotomy a b |>.resolve_left h₁ |>.resolve_left h₂
-    rwa [true_iff]
+  grind
 
 lemma compare_eq_iff_eq : compare a b = .eq ↔ a = b := by
   rw [LinearOrder.compare_eq_compareOfLessAndEq, compareOfLessAndEq]
-  split_ifs <;> try simp only
-  case _ h => rw [false_iff]; exact ne_iff_lt_or_gt.2 <| .inl h
-  case _ _ h => rwa [true_iff]
-  case _ _ h => rwa [false_iff]
+  grind
 
 lemma compare_le_iff_le : compare a b ≠ .gt ↔ a ≤ b := by
   cases h : compare a b

--- a/Mathlib/Order/Defs/LinearOrder.lean
+++ b/Mathlib/Order/Defs/LinearOrder.lean
@@ -87,8 +87,7 @@ lemma lt_of_not_ge (h : ¬b ≤ a) : a < b := lt_of_le_not_ge (le_of_not_ge h) h
 
 @[deprecated (since := "2025-05-11")] alias le_of_not_le := le_of_not_ge
 
-lemma lt_trichotomy (a b : α) : a < b ∨ a = b ∨ b < a := by
-  grind
+lemma lt_trichotomy (a b : α) : a < b ∨ a = b ∨ b < a := by grind
 
 lemma le_of_not_gt (h : ¬b < a) : a ≤ b :=
   match lt_trichotomy a b with
@@ -107,8 +106,7 @@ lemma le_or_gt (a b : α) : a ≤ b ∨ b < a := (lt_or_ge b a).symm
 
 @[deprecated (since := "2025-05-11")] alias le_or_lt := le_or_gt
 
-lemma lt_or_gt_of_ne (h : a ≠ b) : a < b ∨ b < a := by
-  grind
+lemma lt_or_gt_of_ne (h : a ≠ b) : a < b ∨ b < a := by grind
 
 lemma ne_iff_lt_or_gt : a ≠ b ↔ a < b ∨ b < a := ⟨lt_or_gt_of_ne, (Or.elim · ne_of_lt ne_of_gt)⟩
 
@@ -132,23 +130,17 @@ lemma min_def (a b : α) : min a b = if a ≤ b then a else b := LinearOrder.min
 @[grind =]
 lemma max_def (a b : α) : max a b = if a ≤ b then b else a := LinearOrder.max_def a b
 
-lemma min_le_left (a b : α) : min a b ≤ a := by
-  grind
+lemma min_le_left (a b : α) : min a b ≤ a := by grind
 
-lemma min_le_right (a b : α) : min a b ≤ b := by
-  grind
+lemma min_le_right (a b : α) : min a b ≤ b := by grind
 
-lemma le_min (h₁ : c ≤ a) (h₂ : c ≤ b) : c ≤ min a b := by
-  grind
+lemma le_min (h₁ : c ≤ a) (h₂ : c ≤ b) : c ≤ min a b := by grind
 
-lemma le_max_left (a b : α) : a ≤ max a b := by
-  grind
+lemma le_max_left (a b : α) : a ≤ max a b := by grind
 
-lemma le_max_right (a b : α) : b ≤ max a b := by
-  grind
+lemma le_max_right (a b : α) : b ≤ max a b := by grind
 
-lemma max_le (h₁ : a ≤ c) (h₂ : b ≤ c) : max a b ≤ c := by
-  grind
+lemma max_le (h₁ : a ≤ c) (h₂ : b ≤ c) : max a b ≤ c := by grind
 
 lemma eq_min (h₁ : c ≤ a) (h₂ : c ≤ b) (h₃ : ∀ {d}, d ≤ a → d ≤ b → d ≤ c) : c = min a b :=
   le_antisymm (le_min h₁ h₂) (h₃ (min_le_left a b) (min_le_right a b))
@@ -156,17 +148,13 @@ lemma eq_min (h₁ : c ≤ a) (h₂ : c ≤ b) (h₃ : ∀ {d}, d ≤ a → d �
 lemma min_comm (a b : α) : min a b = min b a :=
   eq_min (min_le_right a b) (min_le_left a b) fun h₁ h₂ => le_min h₂ h₁
 
-lemma min_assoc (a b c : α) : min (min a b) c = min a (min b c) := by
-  grind
+lemma min_assoc (a b c : α) : min (min a b) c = min a (min b c) := by grind
 
-lemma min_left_comm (a b c : α) : min a (min b c) = min b (min a c) := by
-  grind
+lemma min_left_comm (a b c : α) : min a (min b c) = min b (min a c) := by grind
 
-@[simp] lemma min_self (a : α) : min a a = a := by
-  grind
+@[simp] lemma min_self (a : α) : min a a = a := by grind
 
-lemma min_eq_left (h : a ≤ b) : min a b = a := by
-  grind
+lemma min_eq_left (h : a ≤ b) : min a b = a := by grind
 
 lemma min_eq_right (h : b ≤ a) : min a b = b := min_comm b a ▸ min_eq_left h
 
@@ -177,17 +165,13 @@ lemma eq_max (h₁ : a ≤ c) (h₂ : b ≤ c) (h₃ : ∀ {d}, a ≤ d → b �
 lemma max_comm (a b : α) : max a b = max b a :=
   eq_max (le_max_right a b) (le_max_left a b) fun h₁ h₂ => max_le h₂ h₁
 
-lemma max_assoc (a b c : α) : max (max a b) c = max a (max b c) := by
-  grind
+lemma max_assoc (a b c : α) : max (max a b) c = max a (max b c) := by grind
 
-lemma max_left_comm (a b c : α) : max a (max b c) = max b (max a c) := by
-  grind
+lemma max_left_comm (a b c : α) : max a (max b c) = max b (max a c) := by grind
 
-@[simp] lemma max_self (a : α) : max a a = a := by
-  grind
+@[simp] lemma max_self (a : α) : max a a = a := by grind
 
-lemma max_eq_left (h : b ≤ a) : max a b = a := by
-  grind
+lemma max_eq_left (h : b ≤ a) : max a b = a := by grind
 
 lemma max_eq_right (h : a ≤ b) : max a b = b := max_comm b a ▸ max_eq_left h
 


### PR DESCRIPTION
---
<details>
<summary>Show trace profiling of <code>lt_trichotomy</code>: <10 ms before, <10 ms after  🎉</summary>

### Trace profiling of `lt_trichotomy` before PR 30897
```diff
diff --git a/Mathlib/Order/Defs/LinearOrder.lean b/Mathlib/Order/Defs/LinearOrder.lean
index 7b6f0d5598..12b8e67c46 100644
--- a/Mathlib/Order/Defs/LinearOrder.lean
+++ b/Mathlib/Order/Defs/LinearOrder.lean
@@ -87,6 +87,7 @@ lemma lt_of_not_ge (h : ¬b ≤ a) : a < b := lt_of_le_not_ge (le_of_not_ge h) h
 
 @[deprecated (since := "2025-05-11")] alias le_of_not_le := le_of_not_ge
 
+set_option trace.profiler true in
 lemma lt_trichotomy (a b : α) : a < b ∨ a = b ∨ b < a := by
   grind [le_total, Decidable.lt_or_eq_of_le]
 
```
```
✔ [61/61] Built Mathlib.Order.Defs.LinearOrder (524ms)
Build completed successfully (61 jobs).
```

### Trace profiling of `lt_trichotomy` after PR 30897
```diff
diff --git a/Mathlib/Order/Defs/LinearOrder.lean b/Mathlib/Order/Defs/LinearOrder.lean
index 7b6f0d5598..ea19594593 100644
--- a/Mathlib/Order/Defs/LinearOrder.lean
+++ b/Mathlib/Order/Defs/LinearOrder.lean
@@ -87,8 +87,9 @@ lemma lt_of_not_ge (h : ¬b ≤ a) : a < b := lt_of_le_not_ge (le_of_not_ge h) h
 
 @[deprecated (since := "2025-05-11")] alias le_of_not_le := le_of_not_ge
 
+set_option trace.profiler true in
 lemma lt_trichotomy (a b : α) : a < b ∨ a = b ∨ b < a := by
-  grind [le_total, Decidable.lt_or_eq_of_le]
+  grind
 
 lemma le_of_not_gt (h : ¬b < a) : a ≤ b :=
   match lt_trichotomy a b with
```
```
✔ [61/61] Built Mathlib.Order.Defs.LinearOrder (522ms)
Build completed successfully (61 jobs).
```
</details>

---
<details>
<summary>Show trace profiling of <code>lt_or_gt_of_ne</code>: <10 ms before, <10 ms after  🎉</summary>

### Trace profiling of `lt_or_gt_of_ne` before PR 30897
```diff
diff --git a/Mathlib/Order/Defs/LinearOrder.lean b/Mathlib/Order/Defs/LinearOrder.lean
index 7b6f0d5598..f6b239762a 100644
--- a/Mathlib/Order/Defs/LinearOrder.lean
+++ b/Mathlib/Order/Defs/LinearOrder.lean
@@ -107,6 +107,7 @@ lemma le_or_gt (a b : α) : a ≤ b ∨ b < a := (lt_or_ge b a).symm
 
 @[deprecated (since := "2025-05-11")] alias le_or_lt := le_or_gt
 
+set_option trace.profiler true in
 lemma lt_or_gt_of_ne (h : a ≠ b) : a < b ∨ b < a := by simpa [h] using lt_trichotomy a b
 
 lemma ne_iff_lt_or_gt : a ≠ b ↔ a < b ∨ b < a := ⟨lt_or_gt_of_ne, (Or.elim · ne_of_lt ne_of_gt)⟩
```
```
✔ [61/61] Built Mathlib.Order.Defs.LinearOrder (526ms)
Build completed successfully (61 jobs).
```

### Trace profiling of `lt_or_gt_of_ne` after PR 30897
```diff
diff --git a/Mathlib/Order/Defs/LinearOrder.lean b/Mathlib/Order/Defs/LinearOrder.lean
index 7b6f0d5598..32b1b7866a 100644
--- a/Mathlib/Order/Defs/LinearOrder.lean
+++ b/Mathlib/Order/Defs/LinearOrder.lean
@@ -107,7 +107,9 @@ lemma le_or_gt (a b : α) : a ≤ b ∨ b < a := (lt_or_ge b a).symm
 
 @[deprecated (since := "2025-05-11")] alias le_or_lt := le_or_gt
 
-lemma lt_or_gt_of_ne (h : a ≠ b) : a < b ∨ b < a := by simpa [h] using lt_trichotomy a b
+set_option trace.profiler true in
+lemma lt_or_gt_of_ne (h : a ≠ b) : a < b ∨ b < a := by
+  grind
 
 lemma ne_iff_lt_or_gt : a ≠ b ↔ a < b ∨ b < a := ⟨lt_or_gt_of_ne, (Or.elim · ne_of_lt ne_of_gt)⟩
 
```
```
✔ [61/61] Built Mathlib.Order.Defs.LinearOrder (523ms)
Build completed successfully (61 jobs).
```
</details>

---
<details>
<summary>Show trace profiling of <code>min_le_left</code>: <10 ms before, 11 ms after </summary>

### Trace profiling of `min_le_left` before PR 30897
```diff
diff --git a/Mathlib/Order/Defs/LinearOrder.lean b/Mathlib/Order/Defs/LinearOrder.lean
index 7b6f0d5598..7df1c3ca17 100644
--- a/Mathlib/Order/Defs/LinearOrder.lean
+++ b/Mathlib/Order/Defs/LinearOrder.lean
@@ -131,6 +131,7 @@ lemma min_def (a b : α) : min a b = if a ≤ b then a else b := LinearOrder.min
 @[grind =]
 lemma max_def (a b : α) : max a b = if a ≤ b then b else a := LinearOrder.max_def a b
 
+set_option trace.profiler true in
 lemma min_le_left (a b : α) : min a b ≤ a := by
   if h : a ≤ b
   then simp [min_def, if_pos h, le_refl]
```
```
✔ [61/61] Built Mathlib.Order.Defs.LinearOrder (522ms)
Build completed successfully (61 jobs).
```

### Trace profiling of `min_le_left` after PR 30897
```diff
diff --git a/Mathlib/Order/Defs/LinearOrder.lean b/Mathlib/Order/Defs/LinearOrder.lean
index 7b6f0d5598..5b358180c5 100644
--- a/Mathlib/Order/Defs/LinearOrder.lean
+++ b/Mathlib/Order/Defs/LinearOrder.lean
@@ -131,10 +131,9 @@ lemma min_def (a b : α) : min a b = if a ≤ b then a else b := LinearOrder.min
 @[grind =]
 lemma max_def (a b : α) : max a b = if a ≤ b then b else a := LinearOrder.max_def a b
 
+set_option trace.profiler true in
 lemma min_le_left (a b : α) : min a b ≤ a := by
-  if h : a ≤ b
-  then simp [min_def, if_pos h, le_refl]
-  else simpa [min_def, if_neg h] using le_of_not_ge h
+  grind
 
 lemma min_le_right (a b : α) : min a b ≤ b := by
   if h : a ≤ b
```
```
ℹ [61/61] Built Mathlib.Order.Defs.LinearOrder (537ms)
info: Mathlib/Order/Defs/LinearOrder.lean:135:0: [Elab.async] [0.011028] elaborating proof of min_le_left
  [Elab.definition.value] [0.010868] min_le_left
    [Elab.step] [0.010797] grind
      [Elab.step] [0.010791] grind
        [Elab.step] [0.010784] grind
Build completed successfully (61 jobs).
```
</details>

---
<details>
<summary>Show trace profiling of <code>min_assoc</code>: <10 ms before, 19 ms after </summary>

### Trace profiling of `min_assoc` before PR 30897
```diff
diff --git a/Mathlib/Order/Defs/LinearOrder.lean b/Mathlib/Order/Defs/LinearOrder.lean
index 7b6f0d5598..5d78975606 100644
--- a/Mathlib/Order/Defs/LinearOrder.lean
+++ b/Mathlib/Order/Defs/LinearOrder.lean
@@ -163,6 +163,7 @@ lemma eq_min (h₁ : c ≤ a) (h₂ : c ≤ b) (h₃ : ∀ {d}, d ≤ a → d 
 lemma min_comm (a b : α) : min a b = min b a :=
   eq_min (min_le_right a b) (min_le_left a b) fun h₁ h₂ => le_min h₂ h₁
 
+set_option trace.profiler true in
 lemma min_assoc (a b c : α) : min (min a b) c = min a (min b c) := by
   apply eq_min
   · apply le_trans (min_le_left ..) (min_le_left ..)
```
```
✔ [61/61] Built Mathlib.Order.Defs.LinearOrder (531ms)
Build completed successfully (61 jobs).
```

### Trace profiling of `min_assoc` after PR 30897
```diff
diff --git a/Mathlib/Order/Defs/LinearOrder.lean b/Mathlib/Order/Defs/LinearOrder.lean
index 7b6f0d5598..abb242c8ee 100644
--- a/Mathlib/Order/Defs/LinearOrder.lean
+++ b/Mathlib/Order/Defs/LinearOrder.lean
@@ -163,15 +163,9 @@ lemma eq_min (h₁ : c ≤ a) (h₂ : c ≤ b) (h₃ : ∀ {d}, d ≤ a → d 
 lemma min_comm (a b : α) : min a b = min b a :=
   eq_min (min_le_right a b) (min_le_left a b) fun h₁ h₂ => le_min h₂ h₁
 
+set_option trace.profiler true in
 lemma min_assoc (a b c : α) : min (min a b) c = min a (min b c) := by
-  apply eq_min
-  · apply le_trans (min_le_left ..) (min_le_left ..)
-  · apply le_min
-    · apply le_trans (min_le_left ..) (min_le_right ..)
-    · apply min_le_right
-  · intro d h₁ h₂; apply le_min
-    · apply le_min h₁; apply le_trans h₂; apply min_le_left
-    · apply le_trans h₂; apply min_le_right
+  grind
 
 lemma min_left_comm (a b c : α) : min a (min b c) = min b (min a c) := by
   rw [← min_assoc, min_comm a, min_assoc]
```
```
ℹ [61/61] Built Mathlib.Order.Defs.LinearOrder (521ms)
info: Mathlib/Order/Defs/LinearOrder.lean:167:0: [Elab.async] [0.019168] elaborating proof of min_assoc
  [Elab.definition.value] [0.018952] min_assoc
    [Elab.step] [0.018863] grind
      [Elab.step] [0.018857] grind
        [Elab.step] [0.018848] grind
Build completed successfully (61 jobs).
```
</details>

---
<details>
<summary>Show trace profiling of <code>min_left_comm</code>: <10 ms before, 19 ms after </summary>

### Trace profiling of `min_left_comm` before PR 30897
```diff
diff --git a/Mathlib/Order/Defs/LinearOrder.lean b/Mathlib/Order/Defs/LinearOrder.lean
index 7b6f0d5598..331ed67051 100644
--- a/Mathlib/Order/Defs/LinearOrder.lean
+++ b/Mathlib/Order/Defs/LinearOrder.lean
@@ -173,6 +173,7 @@ lemma min_assoc (a b c : α) : min (min a b) c = min a (min b c) := by
     · apply le_min h₁; apply le_trans h₂; apply min_le_left
     · apply le_trans h₂; apply min_le_right
 
+set_option trace.profiler true in
 lemma min_left_comm (a b c : α) : min a (min b c) = min b (min a c) := by
   rw [← min_assoc, min_comm a, min_assoc]
 
```
```
✔ [61/61] Built Mathlib.Order.Defs.LinearOrder (529ms)
Build completed successfully (61 jobs).
```

### Trace profiling of `min_left_comm` after PR 30897
```diff
diff --git a/Mathlib/Order/Defs/LinearOrder.lean b/Mathlib/Order/Defs/LinearOrder.lean
index 7b6f0d5598..dc93dd47af 100644
--- a/Mathlib/Order/Defs/LinearOrder.lean
+++ b/Mathlib/Order/Defs/LinearOrder.lean
@@ -173,8 +173,9 @@ lemma min_assoc (a b c : α) : min (min a b) c = min a (min b c) := by
     · apply le_min h₁; apply le_trans h₂; apply min_le_left
     · apply le_trans h₂; apply min_le_right
 
+set_option trace.profiler true in
 lemma min_left_comm (a b c : α) : min a (min b c) = min b (min a c) := by
-  rw [← min_assoc, min_comm a, min_assoc]
+  grind
 
 @[simp] lemma min_self (a : α) : min a a = a := by simp [min_def]
 
```
```
ℹ [61/61] Built Mathlib.Order.Defs.LinearOrder (522ms)
info: Mathlib/Order/Defs/LinearOrder.lean:177:0: [Elab.async] [0.019701] elaborating proof of min_left_comm
  [Elab.definition.value] [0.019485] min_left_comm
    [Elab.step] [0.019416] grind
      [Elab.step] [0.019411] grind
        [Elab.step] [0.019404] grind
Build completed successfully (61 jobs).
```
</details>

---
<details>
<summary>Show trace profiling of <code>compare_lt_iff_lt</code>: 23 ms before, 14 ms after  🎉</summary>

### Trace profiling of `compare_lt_iff_lt` before PR 30897
```diff
diff --git a/Mathlib/Order/Defs/LinearOrder.lean b/Mathlib/Order/Defs/LinearOrder.lean
index 7b6f0d5598..a38e430f94 100644
--- a/Mathlib/Order/Defs/LinearOrder.lean
+++ b/Mathlib/Order/Defs/LinearOrder.lean
@@ -223,6 +223,7 @@ lemma max_lt (h₁ : a < c) (h₂ : b < c) : max a b < c := by
 
 section Ord
 
+set_option trace.profiler true in
 lemma compare_lt_iff_lt : compare a b = .lt ↔ a < b := by
   rw [LinearOrder.compare_eq_compareOfLessAndEq, compareOfLessAndEq]
   split_ifs <;> simp only [*, lt_irrefl]
```
```
ℹ [61/61] Built Mathlib.Order.Defs.LinearOrder (521ms)
info: Mathlib/Order/Defs/LinearOrder.lean:227:0: [Elab.async] [0.023362] elaborating proof of compare_lt_iff_lt
  [Elab.definition.value] [0.022981] compare_lt_iff_lt
    [Elab.step] [0.022850] 
          rw [LinearOrder.compare_eq_compareOfLessAndEq, compareOfLessAndEq]
          split_ifs <;> simp only [*, lt_irrefl]
      [Elab.step] [0.022844] 
            rw [LinearOrder.compare_eq_compareOfLessAndEq, compareOfLessAndEq]
            split_ifs <;> simp only [*, lt_irrefl]
        [Elab.step] [0.021754] split_ifs <;> simp only [*, lt_irrefl]
          [Elab.step] [0.021740] focus
                split_ifs
                with_annotate_state"<;>" skip
                all_goals simp only [*, lt_irrefl]
            [Elab.step] [0.021735] 
                  split_ifs
                  with_annotate_state"<;>" skip
                  all_goals simp only [*, lt_irrefl]
              [Elab.step] [0.021730] 
                    split_ifs
                    with_annotate_state"<;>" skip
                    all_goals simp only [*, lt_irrefl]
                [Elab.step] [0.018987] split_ifs
Build completed successfully (61 jobs).
```

### Trace profiling of `compare_lt_iff_lt` after PR 30897
```diff
diff --git a/Mathlib/Order/Defs/LinearOrder.lean b/Mathlib/Order/Defs/LinearOrder.lean
index 7b6f0d5598..a97d025c43 100644
--- a/Mathlib/Order/Defs/LinearOrder.lean
+++ b/Mathlib/Order/Defs/LinearOrder.lean
@@ -223,9 +223,10 @@ lemma max_lt (h₁ : a < c) (h₂ : b < c) : max a b < c := by
 
 section Ord
 
+set_option trace.profiler true in
 lemma compare_lt_iff_lt : compare a b = .lt ↔ a < b := by
   rw [LinearOrder.compare_eq_compareOfLessAndEq, compareOfLessAndEq]
-  split_ifs <;> simp only [*, lt_irrefl]
+  grind
 
 lemma compare_gt_iff_gt : compare a b = .gt ↔ b < a := by
   rw [LinearOrder.compare_eq_compareOfLessAndEq, compareOfLessAndEq]
```
```
ℹ [61/61] Built Mathlib.Order.Defs.LinearOrder (518ms)
info: Mathlib/Order/Defs/LinearOrder.lean:227:0: [Elab.async] [0.014062] elaborating proof of compare_lt_iff_lt
  [Elab.definition.value] [0.013827] compare_lt_iff_lt
    [Elab.step] [0.013735] 
          rw [LinearOrder.compare_eq_compareOfLessAndEq, compareOfLessAndEq]
          grind
      [Elab.step] [0.013730] 
            rw [LinearOrder.compare_eq_compareOfLessAndEq, compareOfLessAndEq]
            grind
        [Elab.step] [0.012536] grind
Build completed successfully (61 jobs).
```
</details>

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include at least one commit authored by each
co-author among the commits in the pull request. If necessary, you may 
create empty commits to indicate co-authorship, using commands like so:

git commit --author="Author Name <author@email.com>" --allow-empty -m "add Author Name as coauthor"

When merging, all the commits will be squashed into a single commit listing all co-authors.

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
