### PR TITLE
[Merged by Bors] - feat(CategoryTheory/Sites): pre-`0`-hypercover families

### DIFF
--- a/Mathlib.lean
+++ b/Mathlib.lean
@@ -2833,6 +2833,7 @@ import Mathlib.CategoryTheory.Sites.Hypercover.Homotopy
 import Mathlib.CategoryTheory.Sites.Hypercover.IsSheaf
 import Mathlib.CategoryTheory.Sites.Hypercover.One
 import Mathlib.CategoryTheory.Sites.Hypercover.Zero
+import Mathlib.CategoryTheory.Sites.Hypercover.ZeroFamily
 import Mathlib.CategoryTheory.Sites.IsSheafFor
 import Mathlib.CategoryTheory.Sites.JointlySurjective
 import Mathlib.CategoryTheory.Sites.LeftExact

--- a/Mathlib/CategoryTheory/Sites/Hypercover/ZeroFamily.lean
+++ b/Mathlib/CategoryTheory/Sites/Hypercover/ZeroFamily.lean
@@ -1,0 +1,124 @@
+/-
+Copyright (c) 2025 Christian Merten. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Christian Merten
+-/
+import Mathlib.CategoryTheory.Sites.Hypercover.Zero
+
+/-!
+# Defining precoverages via pre-`0`-hypercovers
+
+A precoverage is a condition on all presieves. In some applications, it is practical
+to instead define a condition on all pre-`0`-hypercovers. Such a condition
+for every object is a pre-`0`-hypercover family if these conditions are
+invariant under deduplication.
+-/
+
+universe w' w v u
+
+namespace CategoryTheory
+open Limits
+
+variable {C : Type u} [Category.{v} C]
+
+variable (C) in
+/--
+A pre-`0`-hypercover family on `C` is a property on the category of pre-`0`-hypercovers
+for every `X : C` that is invariant under deduplication.
+The data of a pre-`0`-hypercover family is the same as the data of a precoverage
+(see: `Precoverage.equivPreZeroHypercoverFamily`).
+-/
+@[ext]
+structure PreZeroHypercoverFamily where
+  /-- The condition on pre-`0`-hypercovers for every object. -/
+  property ⦃X : C⦄ : ObjectProperty (PreZeroHypercover.{max u v} X)
+  iff_shrink {X : C} {E : PreZeroHypercover.{max u v} X} : property E ↔ property E.shrink
+
+instance : CoeFun (PreZeroHypercoverFamily C)
+    fun _ ↦ ⦃X : C⦄ → (E : PreZeroHypercover.{max u v} X) → Prop where
+  coe P := P.property
+
+/-- The induced condition on presieves in `C`, given by a pre-`0`-hypercover family. -/
+inductive PreZeroHypercoverFamily.presieve (P : PreZeroHypercoverFamily C) {X : C} :
+    Presieve X → Prop where
+  | mk (E : PreZeroHypercover.{max u v} X) : P E → presieve P E.presieve₀
+
+/-- The associated precoverage to a pre-`0`-hypercover family. -/
+def PreZeroHypercoverFamily.precoverage (P : PreZeroHypercoverFamily C) :
+    Precoverage C where
+  coverings _ R := P.presieve R
+
+lemma PreZeroHypercoverFamily.mem_precoverage_iff {P : PreZeroHypercoverFamily C} {X : C}
+    {R : Presieve X} :
+    R ∈ P.precoverage X ↔ ∃ (E : PreZeroHypercover.{max u v} X), P E ∧ R = E.presieve₀ :=
+  ⟨fun ⟨E, hE⟩ ↦ ⟨E, hE, rfl⟩, fun ⟨_, hE, h⟩ ↦ h ▸ ⟨_, hE⟩⟩
+
+@[simp]
+lemma PreZeroHypercover.presieve₀_mem_precoverage_iff {P : PreZeroHypercoverFamily C} {X : C}
+    {E : PreZeroHypercover.{max u v} X} :
+    E.presieve₀ ∈ P.precoverage X ↔ P E := by
+  refine ⟨fun h ↦ ?_, fun h ↦ .mk _ h⟩
+  rw [PreZeroHypercoverFamily.mem_precoverage_iff] at h
+  obtain ⟨F, h, heq⟩ := h
+  rw [P.iff_shrink] at h ⊢
+  rwa [PreZeroHypercover.shrink_eq_shrink_of_presieve₀_eq_presieve₀ heq]
+
+/-- The associated pre-`0`-hypercover family to a precoverage. -/
+@[simps]
+def Precoverage.preZeroHypercoverFamily (K : Precoverage C) :
+    PreZeroHypercoverFamily C where
+  property X E := E.presieve₀ ∈ K X
+  iff_shrink {X} E := by simp
+
+variable (C) in
+/-- Giving a precoverage on a category is the same as giving a predicate
+on every pre-`0`-hypercover that is stable under deduplication. -/
+def Precoverage.equivPreZeroHypercoverFamily :
+    Precoverage C ≃ PreZeroHypercoverFamily C where
+  toFun K := K.preZeroHypercoverFamily
+  invFun P := P.precoverage
+  left_inv K := by
+    ext X R
+    obtain ⟨E, rfl⟩ := R.exists_eq_preZeroHypercover
+    simp
+  right_inv P := by cat_disch
+
+lemma Precoverage.HasIsos.of_preZeroHypercoverFamily {P : PreZeroHypercoverFamily C}
+    (h : ∀ ⦃X Y : C⦄ (f : X ⟶ Y) [IsIso f], P (.singleton f)) :
+    P.precoverage.HasIsos where
+  mem_coverings_of_isIso {S T} f hf := by
+    rw [← PreZeroHypercover.presieve₀_singleton.{_, _, max u v}]
+    refine .mk _ (h _)
+
+lemma Precoverage.IsStableUnderBaseChange.of_preZeroHypercoverFamily_of_isClosedUnderIsomorphisms
+    {P : PreZeroHypercoverFamily C}
+    (h₁ : ∀ {X : C}, (P (X := X)).IsClosedUnderIsomorphisms)
+    (h₂ : ∀ {X Y : C} (f : X ⟶ Y) (E : PreZeroHypercover.{max u v} Y)
+      [∀ (i : E.I₀), HasPullback f (E.f i)], P E → P (E.pullback₁ f)) :
+    Precoverage.IsStableUnderBaseChange P.precoverage where
+  mem_coverings_of_isPullback {ι} S X f hf Y g Z p₁ p₂ h := by
+    let E : PreZeroHypercover S := ⟨ι, X, f⟩
+    have (i : E.I₀) : HasPullback g (E.f i) := (h i).hasPullback
+    let F : PreZeroHypercover Y := ⟨_, _, p₁⟩
+    let e : F ≅ E.pullback₁ g :=
+      PreZeroHypercover.isoMk (Equiv.refl _) (fun i ↦ (h i).isoPullback)
+    change F.presieve₀ ∈ _
+    rw [F.presieve₀_mem_precoverage_iff, (P (X := Y)).prop_iff_of_iso e]
+    refine h₂ _ _ ?_
+    rwa [← E.presieve₀_mem_precoverage_iff]
+
+lemma Precoverage.IsStableUnderComposition.of_preZeroHypercoverFamily
+    {P : PreZeroHypercoverFamily C}
+    (h : ∀ {X : C} (E : PreZeroHypercover.{max u v} X)
+      (F : ∀ i, PreZeroHypercover.{max u v} (E.X i)),
+      P E → (∀ i, P (F i)) → P (E.bind F)) :
+    Precoverage.IsStableUnderComposition P.precoverage where
+  comp_mem_coverings {ι} S X f hf σ Y g hg := by
+    let E : PreZeroHypercover S := ⟨_, _, f⟩
+    let F (i : ι) : PreZeroHypercover (E.X i) := ⟨_, _, g i⟩
+    refine (E.bind F).presieve₀_mem_precoverage_iff.mpr (h _ _ ?_ fun i ↦ ?_)
+    · rwa [← E.presieve₀_mem_precoverage_iff]
+    · rw [← (F i).presieve₀_mem_precoverage_iff]
+      exact hg i
+
+end CategoryTheory


### PR DESCRIPTION
When defining a precoverage on a category, it is sometimes convenient to only define it on indexed covers. For this,
we introduce a structure `PreZeroHypercoverFamily` that is the data of a property on the pre-`0`-hypercovers of every object that is invariant under deduplication. This induces a precoverage and conversely every precoverage induces such a family.

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include at least one commit authored by each
co-author among the commits in the pull request. If necessary, you may 
create empty commits to indicate co-authorship, using commands like so:

git commit --author="Author Name <author@email.com>" --allow-empty -m "add Author Name as coauthor"

When merging, all the commits will be squashed into a single commit listing all co-authors.

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
