### PR TITLE
[Merged by Bors] - chore(Algebra/Group/Pi/Lemmas): golf using `aesop` / `grind`

### DIFF
--- a/Mathlib/Algebra/Group/Pi/Lemmas.lean
+++ b/Mathlib/Algebra/Group/Pi/Lemmas.lean
@@ -294,7 +294,7 @@ theorem Pi.mulSingle_apply_commute [∀ i, MulOneClass <| f i] (x : ∀ i, f i) 
 theorem Pi.update_eq_div_mul_mulSingle [∀ i, Group <| f i] (g : ∀ i : I, f i) (x : f i) :
     Function.update g i x = g / mulSingle i (g i) * mulSingle i x := by
   ext j
-  by_cases j = i <;> aesop
+  by_cases i = j <;> aesop
 
 @[to_additive]
 theorem Pi.mulSingle_mul_mulSingle_eq_mulSingle_mul_mulSingle {M : Type*} [CommMonoid M]

--- a/Mathlib/Algebra/Group/Pi/Lemmas.lean
+++ b/Mathlib/Algebra/Group/Pi/Lemmas.lean
@@ -280,10 +280,7 @@ For injections of commuting elements at the same index, see `Commute.map` -/
 theorem Pi.mulSingle_commute [∀ i, MulOneClass <| f i] :
     Pairwise fun i j => ∀ (x : f i) (y : f j), Commute (mulSingle i x) (mulSingle j y) := by
   intro i j hij x y; ext k
-  by_cases h1 : i = k
-  · subst h1
-    simp [hij]
-  simp_all
+  by_cases i = k <;> simp_all
 
 /-- The injection into a pi group with the same values commutes. -/
 @[to_additive /-- The injection into an additive pi group with the same values commutes. -/]
@@ -297,7 +294,7 @@ theorem Pi.mulSingle_apply_commute [∀ i, MulOneClass <| f i] (x : ∀ i, f i) 
 theorem Pi.update_eq_div_mul_mulSingle [∀ i, Group <| f i] (g : ∀ i : I, f i) (x : f i) :
     Function.update g i x = g / mulSingle i (g i) * mulSingle i x := by
   ext j
-  by_cases i = j <;> aesop
+  by_cases j = i <;> aesop
 
 @[to_additive]
 theorem Pi.mulSingle_mul_mulSingle_eq_mulSingle_mul_mulSingle {M : Type*} [CommMonoid M]
@@ -311,13 +308,13 @@ theorem Pi.mulSingle_mul_mulSingle_eq_mulSingle_mul_mulSingle {M : Type*} [CommM
     have hn := (congr_fun h n).symm
     simp only [mul_apply, mulSingle_apply] at hk hl hm hn
     rcases eq_or_ne k m with (rfl | hkm)
-    · by_cases k = l <;> aesop
-    · rcases eq_or_ne m n with (rfl | hmn)
+    · by_cases l = k <;> aesop
+    · rcases eq_or_ne n m with (rfl | hmn)
       · rcases eq_or_ne k l with (rfl | hkl)
-        · aesop
-        · rw [if_neg hkm.symm, if_neg hkl.symm, mul_one] at hk
-          aesop
-      · rw [if_neg hkm, if_neg hmn.symm, one_mul, mul_one] at hm
+        · simp_all
+        · rw [if_neg hkm, if_neg hkl, mul_one] at hk
+          simp_all
+      · rw [if_neg hkm.symm, if_neg hmn.symm, one_mul, mul_one] at hm
         aesop
   · rintro (⟨rfl, rfl⟩ | ⟨rfl, rfl, rfl⟩ | ⟨h, rfl, rfl⟩)
     · rfl

--- a/Mathlib/Algebra/Group/Pi/Lemmas.lean
+++ b/Mathlib/Algebra/Group/Pi/Lemmas.lean
@@ -294,7 +294,9 @@ theorem Pi.mulSingle_apply_commute [∀ i, MulOneClass <| f i] (x : ∀ i, f i) 
 theorem Pi.update_eq_div_mul_mulSingle [∀ i, Group <| f i] (g : ∀ i : I, f i) (x : f i) :
     Function.update g i x = g / mulSingle i (g i) * mulSingle i x := by
   ext j
-  by_cases j = i <;> aesop
+  rcases eq_or_ne i j with (rfl | h)
+  · simp
+  · simp [Function.update_of_ne h.symm, h]
 
 @[to_additive]
 theorem Pi.mulSingle_mul_mulSingle_eq_mulSingle_mul_mulSingle {M : Type*} [CommMonoid M]

--- a/Mathlib/Algebra/Group/Pi/Lemmas.lean
+++ b/Mathlib/Algebra/Group/Pi/Lemmas.lean
@@ -294,7 +294,7 @@ theorem Pi.mulSingle_apply_commute [∀ i, MulOneClass <| f i] (x : ∀ i, f i) 
 theorem Pi.update_eq_div_mul_mulSingle [∀ i, Group <| f i] (g : ∀ i : I, f i) (x : f i) :
     Function.update g i x = g / mulSingle i (g i) * mulSingle i x := by
   ext j
-  by_cases i = j <;> aesop
+  by_cases j = i <;> aesop
 
 @[to_additive]
 theorem Pi.mulSingle_mul_mulSingle_eq_mulSingle_mul_mulSingle {M : Type*} [CommMonoid M]

--- a/Mathlib/Algebra/Group/Pi/Lemmas.lean
+++ b/Mathlib/Algebra/Group/Pi/Lemmas.lean
@@ -297,9 +297,7 @@ theorem Pi.mulSingle_apply_commute [∀ i, MulOneClass <| f i] (x : ∀ i, f i) 
 theorem Pi.update_eq_div_mul_mulSingle [∀ i, Group <| f i] (g : ∀ i : I, f i) (x : f i) :
     Function.update g i x = g / mulSingle i (g i) * mulSingle i x := by
   ext j
-  rcases eq_or_ne i j with (rfl | h)
-  · simp
-  · simp [Function.update_of_ne h.symm, h]
+  by_cases i = j <;> aesop
 
 @[to_additive]
 theorem Pi.mulSingle_mul_mulSingle_eq_mulSingle_mul_mulSingle {M : Type*} [CommMonoid M]
@@ -313,22 +311,14 @@ theorem Pi.mulSingle_mul_mulSingle_eq_mulSingle_mul_mulSingle {M : Type*} [CommM
     have hn := (congr_fun h n).symm
     simp only [mul_apply, mulSingle_apply] at hk hl hm hn
     rcases eq_or_ne k m with (rfl | hkm)
-    · refine Or.inl ⟨rfl, not_ne_iff.mp fun hln => (hv ?_).elim⟩
-      rcases eq_or_ne k l with (rfl | hkl)
-      · rwa [if_neg hln.symm, if_neg hln.symm, one_mul, one_mul] at hn
-      · rwa [if_neg hkl.symm, if_neg hln, one_mul, one_mul] at hl
+    · by_cases k = l <;> aesop
     · rcases eq_or_ne m n with (rfl | hmn)
       · rcases eq_or_ne k l with (rfl | hkl)
-        · rw [if_neg hkm.symm, if_neg hkm.symm, one_mul, if_pos rfl] at hm
-          exact Or.inr (Or.inr ⟨hm, rfl, rfl⟩)
-        · simp only [if_neg hkm, if_neg hkl, mul_one] at hk
-          dsimp at hk
-          contradiction
-      · rw [if_neg hkm.symm, if_neg hmn, one_mul, mul_one] at hm
-        obtain rfl := (ite_ne_right_iff.mp (ne_of_eq_of_ne hm.symm hu)).1
-        rw [if_neg hkm, if_neg hkm, one_mul, mul_one] at hk
-        obtain rfl := (ite_ne_right_iff.mp (ne_of_eq_of_ne hk.symm hu)).1
-        exact Or.inr (Or.inl ⟨hk.trans (if_pos rfl), rfl, rfl⟩)
+        · aesop
+        · rw [if_neg hkm.symm, if_neg hkl.symm, mul_one] at hk
+          aesop
+      · rw [if_neg hkm, if_neg hmn.symm, one_mul, mul_one] at hm
+        aesop
   · rintro (⟨rfl, rfl⟩ | ⟨rfl, rfl, rfl⟩ | ⟨h, rfl, rfl⟩)
     · rfl
     · apply mul_comm

--- a/Mathlib/Algebra/Group/Pi/Lemmas.lean
+++ b/Mathlib/Algebra/Group/Pi/Lemmas.lean
@@ -310,10 +310,7 @@ theorem Pi.mulSingle_mul_mulSingle_eq_mulSingle_mul_mulSingle {M : Type*} [CommM
     rcases eq_or_ne k m with (rfl | hkm)
     · by_cases l = k <;> aesop
     · rcases eq_or_ne n m with (rfl | hmn)
-      · rcases eq_or_ne k l with (rfl | hkl)
-        · simp_all
-        · rw [if_neg hkm, if_neg hkl, mul_one] at hk
-          simp_all
+      · by_cases k = l <;> simp_all
       · rw [if_neg hkm.symm, if_neg hmn.symm, one_mul, mul_one] at hm
         aesop
   · rintro (⟨rfl, rfl⟩ | ⟨rfl, rfl, rfl⟩ | ⟨h, rfl, rfl⟩)

--- a/Mathlib/Algebra/Group/Pi/Lemmas.lean
+++ b/Mathlib/Algebra/Group/Pi/Lemmas.lean
@@ -301,22 +301,14 @@ theorem Pi.mulSingle_mul_mulSingle_eq_mulSingle_mul_mulSingle {M : Type*} [CommM
     {k l m n : I} {u v : M} (hu : u ≠ 1) (hv : v ≠ 1) :
     (mulSingle k u : I → M) * mulSingle l v = mulSingle m u * mulSingle n v ↔
       k = m ∧ l = n ∨ u = v ∧ k = n ∧ l = m ∨ u * v = 1 ∧ k = l ∧ m = n := by
-  refine ⟨fun h => ?_, ?_⟩
+  refine ⟨fun h ↦ ?_, ?_⟩
   · have hk := congr_fun h k
     have hl := congr_fun h l
-    have hm := (congr_fun h m).symm
-    have hn := (congr_fun h n).symm
+    have hm := congr_fun h m
+    have hn := congr_fun h n
     simp only [mul_apply, mulSingle_apply] at hk hl hm hn
-    rcases eq_or_ne k m with (rfl | hkm)
-    · by_cases l = k <;> aesop
-    · rcases eq_or_ne n m with (rfl | hmn)
-      · by_cases k = l <;> simp_all
-      · rw [if_neg hkm.symm, if_neg hmn.symm, one_mul, mul_one] at hm
-        aesop
-  · rintro (⟨rfl, rfl⟩ | ⟨rfl, rfl, rfl⟩ | ⟨h, rfl, rfl⟩)
-    · rfl
-    · apply mul_comm
-    · simp_rw [← Pi.mulSingle_mul, h, mulSingle_one]
+    grind [mul_one, one_mul]
+  · aesop (add simp [mulSingle_apply])
 
 end Single
 

--- a/Mathlib/Logic/Equiv/Basic.lean
+++ b/Mathlib/Logic/Equiv/Basic.lean
@@ -644,6 +644,7 @@ theorem swap_self (a : α) : swap a a = Equiv.refl _ :=
 theorem swap_comm (a b : α) : swap a b = swap b a :=
   ext fun r => swapCore_comm r _ _
 
+@[aesop simp, grind =]
 theorem swap_apply_def (a b x : α) : swap a b x = if x = a then b else if x = b then a else x :=
   rfl
 

--- a/Mathlib/Logic/Equiv/Basic.lean
+++ b/Mathlib/Logic/Equiv/Basic.lean
@@ -644,7 +644,6 @@ theorem swap_self (a : α) : swap a a = Equiv.refl _ :=
 theorem swap_comm (a b : α) : swap a b = swap b a :=
   ext fun r => swapCore_comm r _ _
 
-@[aesop simp, grind =]
 theorem swap_apply_def (a b x : α) : swap a b x = if x = a then b else if x = b then a else x :=
   rfl
 


### PR DESCRIPTION
---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include at least one commit authored by each
co-author among the commits in the pull request. If necessary, you may 
create empty commits to indicate co-authorship, using commands like so:

git commit --author="Author Name <author@email.com>" --allow-empty -m "add Author Name as coauthor"

When merging, all the commits will be squashed into a single commit listing all co-authors.

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

The new proof of `Pi.mulSingle_mul_mulSingle_eq_mulSingle_mul_mulSingle` is slower but arguably much more understandable.

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
