### PR TITLE
[Merged by Bors] - feat(Geometry/Euclidean/Incenter): cases for excenters of triangles

### DIFF
--- a/Mathlib/Geometry/Euclidean/Incenter.lean
+++ b/Mathlib/Geometry/Euclidean/Incenter.lean
@@ -283,9 +283,20 @@ def inradius : ℝ :=
 @[simp] lemma exradius_empty : s.exradius ∅ = s.inradius :=
   rfl
 
+@[simp] lemma exsphere_compl (signs : Finset (Fin (n + 1))) :
+    s.exsphere signsᶜ = s.exsphere signs := by
+  simp [exsphere, excenterWeights_compl, excenterWeightsUnnorm_compl, Pi.neg_apply]
+
+@[simp] lemma excenter_compl (signs : Finset (Fin (n + 1))) :
+    s.excenter signsᶜ = s.excenter signs := by
+  simp_rw [excenter, exsphere_compl]
+
+@[simp] lemma exradius_compl (signs : Finset (Fin (n + 1))) :
+    s.exradius signsᶜ = s.exradius signs := by
+  simp_rw [exradius, exsphere_compl]
+
 @[simp] lemma exsphere_univ : s.exsphere Finset.univ = s.insphere := by
-  rw [exsphere, ← Finset.compl_empty, excenterWeightsUnnorm_compl, excenterWeights_compl]
-  simp [Pi.neg_apply, Finset.sum_neg_distrib, insphere, exsphere]
+  rw [← Finset.compl_empty, exsphere_compl, insphere]
 
 @[simp] lemma excenter_univ : s.excenter Finset.univ = s.incenter := by
   rw [excenter, exsphere_univ, insphere_center]
@@ -724,6 +735,42 @@ end Simplex
 namespace Triangle
 
 variable (t : Triangle ℝ P)
+
+/-- All excenters exist for a triangle. -/
+lemma excenterExists (signs : Finset (Fin 3)) : t.ExcenterExists signs := by
+  have h : signs = ∅ ∨ signs = ∅ᶜ ∨ ∃ i, signs = {i} ∨ signs = {i}ᶜ := by decide +revert
+  rcases h with rfl | rfl | ⟨i, rfl | rfl⟩
+  · exact t.excenterExists_empty
+  · rw [Simplex.excenterExists_compl]
+    exact t.excenterExists_empty
+  · exact t.excenterExists_singleton _
+  · rw [Simplex.excenterExists_compl]
+    exact t.excenterExists_singleton _
+
+/-- An excenter of a triangle is either the incenter or the excenter opposite a vertex. -/
+lemma excenter_eq_incenter_or_excenter_singleton (signs : Finset (Fin 3)) :
+    t.excenter signs = t.incenter ∨ ∃ i, t.excenter signs = t.excenter {i} := by
+  have h : signs = ∅ ∨ signs = Finset.univ ∨ ∃ i, signs = {i} ∨ signs = {i}ᶜ := by decide +revert
+  rcases h with rfl | rfl | ⟨i, rfl | rfl⟩
+  · exact .inl rfl
+  · exact .inl t.excenter_univ
+  · exact .inr ⟨i, rfl⟩
+  · refine .inr ⟨i, ?_⟩
+    rw [t.excenter_compl]
+
+/-- An excenter of a triangle is either the incenter or the excenter opposite one of three
+enumerated different vertices. This is intended for when it is known a point is an excenter and
+it is to be proved which excenter it is by elimination of the other cases. -/
+lemma excenter_eq_incenter_or_excenter_singleton_of_ne (signs : Finset (Fin 3)) {i₁ i₂ i₃ : Fin 3}
+    (h₁₂ : i₁ ≠ i₂) (h₁₃ : i₁ ≠ i₃) (h₂₃ : i₂ ≠ i₃) :
+    t.excenter signs = t.incenter ∨ t.excenter signs = t.excenter {i₁} ∨
+      t.excenter signs = t.excenter {i₂} ∨ t.excenter signs = t.excenter {i₃} := by
+  rcases t.excenter_eq_incenter_or_excenter_singleton signs with h | ⟨i, h⟩
+  · exact .inl h
+  · refine .inr ?_
+    rw [h]
+    have : i = i₁ ∨ i = i₂ ∨ i = i₃ := by clear h; decide +revert
+    grind
 
 lemma sbtw_touchpoint_empty {i₁ i₂ i₃ : Fin 3} (h₁₂ : i₁ ≠ i₂) (h₁₃ : i₁ ≠ i₃) (h₂₃ : i₂ ≠ i₃) :
     Sbtw ℝ (t.points i₁) (t.touchpoint ∅ i₂) (t.points i₃) := by


### PR DESCRIPTION
Add lemmas that all choices of signs give a valid excenter for a triangle, and that any excenter for a triangle is either the incenter or the excenter opposite a vertex.


---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include at least one commit authored by each
co-author among the commits in the pull request. If necessary, you may 
create empty commits to indicate co-authorship, using commands like so:

git commit --author="Author Name <author@email.com>" --allow-empty -m "add Author Name as coauthor"

When merging, all the commits will be squashed into a single commit listing all co-authors.

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
