### PR TITLE
[Merged by Bors] - feat(Data/Sign/Defs): `sign_eq_sign_or_eq_neg`

### DIFF
--- a/Mathlib/Data/Sign/Defs.lean
+++ b/Mathlib/Data/Sign/Defs.lean
@@ -328,6 +328,12 @@ theorem sign_nonpos_iff : sign a ≤ 0 ↔ a ≤ 0 := by
   · simp [← h]
   · simp [h, h.le]
 
+lemma sign_eq_sign_or_eq_neg {b : α} (ha : a ≠ 0) (hb : b ≠ 0) :
+    sign a = sign b ∨ sign a = -sign b := by
+  rcases trichotomy (sign a) with hsa | hsa | hsa <;>
+    rcases trichotomy (sign b) with hsb | hsb | hsb <;>
+    simp_all
+
 end LinearOrder
 
 section OrderedSemiring


### PR DESCRIPTION
Add the lemma that, in a linear order with zero, two nonzero values have the same sign or opposite signs.

```lean
lemma sign_eq_sign_or_eq_neg {b : α} (ha : a ≠ 0) (hb : b ≠ 0) :
    sign a = sign b ∨ sign a = -sign b := by
```


---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include at least one commit authored by each
co-author among the commits in the pull request. If necessary, you may 
create empty commits to indicate co-authorship, using commands like so:

git commit --author="Author Name <author@email.com>" --allow-empty -m "add Author Name as coauthor"

When merging, all the commits will be squashed into a single commit listing all co-authors.

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
