### PR TITLE
[Merged by Bors] - feat(Geometry/Euclidean/Incenter): `dist_excenter_eq_dist_excenter`

### DIFF
--- a/Mathlib/Geometry/Euclidean/Incenter.lean
+++ b/Mathlib/Geometry/Euclidean/Incenter.lean
@@ -420,6 +420,19 @@ lemma dist_incenter (i : Fin (n + 1)) :
   s.excenterExists_empty.dist_excenter _
 
 variable {s} in
+/-- An excenter is equidistant to any two of its touchpoints. -/
+lemma ExcenterExists.dist_excenter_eq_dist_excenter {signs : Finset (Fin (n + 1))}
+    (h : s.ExcenterExists signs) (i₁ i₂ : Fin (n + 1)) :
+    dist (s.excenter signs) (s.touchpoint signs i₁) =
+      dist (s.excenter signs) (s.touchpoint signs i₂) := by
+  simp_rw [h.dist_excenter]
+
+/-- The incenter is equidistant to any two of its touchpoints. -/
+lemma dist_incenter_eq_dist_incenter (i₁ i₂ : Fin (n + 1)) :
+    dist s.incenter (s.touchpoint ∅ i₁) = dist s.incenter (s.touchpoint ∅ i₂) :=
+  s.excenterExists_empty.dist_excenter_eq_dist_excenter _ _
+
+variable {s} in
 lemma ExcenterExists.touchpoint_mem_exsphere {signs : Finset (Fin (n + 1))}
     (h : s.ExcenterExists signs) (i : Fin (n + 1)) : s.touchpoint signs i ∈ s.exsphere signs :=
   mem_sphere'.2 (h.dist_excenter i)


### PR DESCRIPTION
Add lemmas

```lean
lemma ExcenterExists.dist_excenter_eq_dist_excenter {signs : Finset (Fin (n + 1))}
    (h : s.ExcenterExists signs) (i₁ i₂ : Fin (n + 1)) :
    dist (s.excenter signs) (s.touchpoint signs i₁) =
      dist (s.excenter signs) (s.touchpoint signs i₂) := by
```

```lean
lemma dist_incenter_eq_dist_incenter (i₁ i₂ : Fin (n + 1)) :
    dist s.incenter (s.touchpoint ∅ i₁) = dist s.incenter (s.touchpoint ∅ i₂) :=
```

that an excenter of a simplex is equidistant to any two of its touchpoints. These are trivial variants of the existing lemmas that the distance equals the exradius, but they are useful several times when relating excenters to angle bisection, so it seems worth having them as separate lemmas.


---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include at least one commit authored by each
co-author among the commits in the pull request. If necessary, you may 
create empty commits to indicate co-authorship, using commands like so:

git commit --author="Author Name <author@email.com>" --allow-empty -m "add Author Name as coauthor"

When merging, all the commits will be squashed into a single commit listing all co-authors.

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
