### PR TITLE
[Merged by Bors] - chore(NumberTheory/LegendreSymbol/QuadraticChar): golf `FiniteField.isSquare_odd_prime_iff` using `simp`

### DIFF
--- a/Mathlib/NumberTheory/LegendreSymbol/QuadraticChar/GaussSum.lean
+++ b/Mathlib/NumberTheory/LegendreSymbol/QuadraticChar/GaussSum.lean
@@ -102,11 +102,8 @@ theorem FiniteField.isSquare_odd_prime_iff (hF : ringChar F ≠ 2) {p : ℕ} [Fa
   classical
   by_cases hFp : ringChar F = p
   · rw [show (p : F) = 0 by rw [← hFp]; exact ringChar.Nat.cast_ringChar]
-    simp only [IsSquare.zero, Ne, true_iff, map_mul]
-    obtain ⟨n, _, hc⟩ := FiniteField.card F (ringChar F)
-    have hchar : ringChar F = ringChar (ZMod p) := by rw [hFp]; exact (ringChar_zmod_n p).symm
-    conv => enter [1, 1, 2]; rw [hc, Nat.cast_pow, map_pow, hchar, map_ringChar]
-    simp only [zero_pow n.ne_zero, mul_zero, zero_eq_neg, one_ne_zero, not_false_iff]
+    obtain ⟨⟩ := FiniteField.card F (ringChar F)
+    simp [*]
   · rw [← Iff.not_left (@quadraticChar_neg_one_iff_not_isSquare F _ _ _ _),
       quadraticChar_odd_prime hF hp]
     exact hFp

--- a/Mathlib/NumberTheory/LegendreSymbol/QuadraticChar/GaussSum.lean
+++ b/Mathlib/NumberTheory/LegendreSymbol/QuadraticChar/GaussSum.lean
@@ -100,12 +100,9 @@ theorem FiniteField.isSquare_odd_prime_iff (hF : ringChar F ≠ 2) {p : ℕ} [Fa
     (hp : p ≠ 2) :
     IsSquare (p : F) ↔ quadraticChar (ZMod p) (χ₄ (Fintype.card F) * Fintype.card F) ≠ -1 := by
   classical
-  by_cases hFp : ringChar F = p
-  · rw [show (p : F) = 0 by rw [← hFp]; exact ringChar.Nat.cast_ringChar]
-    obtain ⟨⟩ := FiniteField.card F (ringChar F)
-    simp [*]
-  · rw [← Iff.not_left (@quadraticChar_neg_one_iff_not_isSquare F _ _ _ _),
-      quadraticChar_odd_prime hF hp]
-    exact hFp
+  rcases eq_or_ne (ringChar F) p with rfl | hFp
+  · obtain ⟨q, hq, hq'⟩ := FiniteField.card F (ringChar F)
+    simp [hq']
+  · rwa [← Iff.not_left quadraticChar_neg_one_iff_not_isSquare, quadraticChar_odd_prime hF hp]
 
 end SpecialValues


### PR DESCRIPTION
---
<details>
<summary>Show trace profiling of <code>FiniteField.isSquare_odd_prime_iff</code>: 61 ms before, 139 ms after </summary>

### Trace profiling of `FiniteField.isSquare_odd_prime_iff` before PR 30939
```diff
diff --git a/Mathlib/NumberTheory/LegendreSymbol/QuadraticChar/GaussSum.lean b/Mathlib/NumberTheory/LegendreSymbol/QuadraticChar/GaussSum.lean
index e3281cd154..e042b8dd3f 100644
--- a/Mathlib/NumberTheory/LegendreSymbol/QuadraticChar/GaussSum.lean
+++ b/Mathlib/NumberTheory/LegendreSymbol/QuadraticChar/GaussSum.lean
@@ -94,6 +94,7 @@ theorem quadraticChar_odd_prime [DecidableEq F] (hF : ringChar F ≠ 2) {p : ℕ
     (ne_of_eq_of_ne (ringChar_zmod_n p) hp₂.symm)
   rwa [card p] at h
 
+set_option trace.profiler true in
 /-- An odd prime `p` is a square in `F` iff the quadratic character of `ZMod p` does not
 take the value `-1` on `χ₄#F * #F`. -/
 theorem FiniteField.isSquare_odd_prime_iff (hF : ringChar F ≠ 2) {p : ℕ} [Fact p.Prime]
```
```
ℹ [2828/2828] Built Mathlib.NumberTheory.LegendreSymbol.QuadraticChar.GaussSum (2.6s)
info: Mathlib/NumberTheory/LegendreSymbol/QuadraticChar/GaussSum.lean:98:0: [Elab.command] [0.019186] /-- An odd prime `p` is a square in `F` iff the quadratic character of `ZMod p` does not
    take the value `-1` on `χ₄#F * #F`. -/
    theorem isSquare_odd_prime_iff (hF : ringChar F ≠ 2) {p : ℕ} [Fact p.Prime] (hp : p ≠ 2) :
        IsSquare (p : F) ↔ quadraticChar (ZMod p) (χ₄ (Fintype.card F) * Fintype.card F) ≠ -1 := by
      classical
      by_cases hFp : ringChar F = p
      · rw [show (p : F) = 0 by rw [← hFp]; exact ringChar.Nat.cast_ringChar]
        simp only [IsSquare.zero, Ne, true_iff, map_mul]
        obtain ⟨n, _, hc⟩ := FiniteField.card F (ringChar F)
        have hchar : ringChar F = ringChar (ZMod p) := by rw [hFp]; exact (ringChar_zmod_n p).symm
        conv => enter [1, 1, 2]; rw [hc, Nat.cast_pow, map_pow, hchar, map_ringChar]
        simp only [zero_pow n.ne_zero, mul_zero, zero_eq_neg, one_ne_zero, not_false_iff]
      · rw [← Iff.not_left (@quadraticChar_neg_one_iff_not_isSquare F _ _ _ _), quadraticChar_odd_prime hF hp]
        exact hFp
  [Elab.definition.header] [0.018732] FiniteField.isSquare_odd_prime_iff
    [Elab.step] [0.017563] expected type: Prop, term
        IsSquare (p : F) ↔ quadraticChar (ZMod p) (χ₄ (Fintype.card F) * Fintype.card F) ≠ -1
      [Elab.step] [0.017558] expected type: Prop, term
          Iff✝ (IsSquare (p : F)) (quadraticChar (ZMod p) (χ₄ (Fintype.card F) * Fintype.card F) ≠ -1)
        [Elab.step] [0.015040] expected type: Prop, term
            quadraticChar (ZMod p) (χ₄ (Fintype.card F) * Fintype.card F) ≠ -1
          [Elab.step] [0.015035] expected type: Prop, term
              binrel% Ne✝ (quadraticChar (ZMod p) (χ₄ (Fintype.card F) * Fintype.card F)) (-1)
            [Elab.step] [0.014678] expected type: <not-available>, term
                quadraticChar (ZMod p) (χ₄ (Fintype.card F) * Fintype.card F)
              [Elab.step] [0.011485] expected type: ZMod p, term
                  (χ₄ (Fintype.card F) * Fintype.card F)
                [Elab.step] [0.011479] expected type: ZMod p, term
                    χ₄ (Fintype.card F) * Fintype.card F
                  [Elab.step] [0.011471] expected type: ZMod p, term
                      binop% HMul.hMul✝ (χ₄ (Fintype.card F)) (Fintype.card F)
info: Mathlib/NumberTheory/LegendreSymbol/QuadraticChar/GaussSum.lean:98:0: [Elab.command] [0.019295] /-- An odd prime `p` is a square in `F` iff the quadratic character of `ZMod p` does not
    take the value `-1` on `χ₄#F * #F`. -/
    theorem FiniteField.isSquare_odd_prime_iff (hF : ringChar F ≠ 2) {p : ℕ} [Fact p.Prime] (hp : p ≠ 2) :
        IsSquare (p : F) ↔ quadraticChar (ZMod p) (χ₄ (Fintype.card F) * Fintype.card F) ≠ -1 := by
      classical
      by_cases hFp : ringChar F = p
      · rw [show (p : F) = 0 by rw [← hFp]; exact ringChar.Nat.cast_ringChar]
        simp only [IsSquare.zero, Ne, true_iff, map_mul]
        obtain ⟨n, _, hc⟩ := FiniteField.card F (ringChar F)
        have hchar : ringChar F = ringChar (ZMod p) := by rw [hFp]; exact (ringChar_zmod_n p).symm
        conv => enter [1, 1, 2]; rw [hc, Nat.cast_pow, map_pow, hchar, map_ringChar]
        simp only [zero_pow n.ne_zero, mul_zero, zero_eq_neg, one_ne_zero, not_false_iff]
      · rw [← Iff.not_left (@quadraticChar_neg_one_iff_not_isSquare F _ _ _ _), quadraticChar_odd_prime hF hp]
        exact hFp
info: Mathlib/NumberTheory/LegendreSymbol/QuadraticChar/GaussSum.lean:98:0: [Elab.async] [0.062132] elaborating proof of FiniteField.isSquare_odd_prime_iff
  [Elab.definition.value] [0.060946] FiniteField.isSquare_odd_prime_iff
    [Elab.step] [0.060273] classical
          by_cases hFp : ringChar F = p
          · rw [show (p : F) = 0 by rw [← hFp]; exact ringChar.Nat.cast_ringChar]
            simp only [IsSquare.zero, Ne, true_iff, map_mul]
            obtain ⟨n, _, hc⟩ := FiniteField.card F (ringChar F)
            have hchar : ringChar F = ringChar (ZMod p) := by rw [hFp]; exact (ringChar_zmod_n p).symm
            conv => enter [1, 1, 2]; rw [hc, Nat.cast_pow, map_pow, hchar, map_ringChar]
            simp only [zero_pow n.ne_zero, mul_zero, zero_eq_neg, one_ne_zero, not_false_iff]
          · rw [← Iff.not_left (@quadraticChar_neg_one_iff_not_isSquare F _ _ _ _), quadraticChar_odd_prime hF hp]
            exact hFp
      [Elab.step] [0.060268] classical
            by_cases hFp : ringChar F = p
            · rw [show (p : F) = 0 by rw [← hFp]; exact ringChar.Nat.cast_ringChar]
              simp only [IsSquare.zero, Ne, true_iff, map_mul]
              obtain ⟨n, _, hc⟩ := FiniteField.card F (ringChar F)
              have hchar : ringChar F = ringChar (ZMod p) := by rw [hFp]; exact (ringChar_zmod_n p).symm
              conv => enter [1, 1, 2]; rw [hc, Nat.cast_pow, map_pow, hchar, map_ringChar]
              simp only [zero_pow n.ne_zero, mul_zero, zero_eq_neg, one_ne_zero, not_false_iff]
            · rw [← Iff.not_left (@quadraticChar_neg_one_iff_not_isSquare F _ _ _ _), quadraticChar_odd_prime hF hp]
              exact hFp
        [Elab.step] [0.060263] classical
            by_cases hFp : ringChar F = p
            · rw [show (p : F) = 0 by rw [← hFp]; exact ringChar.Nat.cast_ringChar]
              simp only [IsSquare.zero, Ne, true_iff, map_mul]
              obtain ⟨n, _, hc⟩ := FiniteField.card F (ringChar F)
              have hchar : ringChar F = ringChar (ZMod p) := by rw [hFp]; exact (ringChar_zmod_n p).symm
              conv => enter [1, 1, 2]; rw [hc, Nat.cast_pow, map_pow, hchar, map_ringChar]
              simp only [zero_pow n.ne_zero, mul_zero, zero_eq_neg, one_ne_zero, not_false_iff]
            · rw [← Iff.not_left (@quadraticChar_neg_one_iff_not_isSquare F _ _ _ _), quadraticChar_odd_prime hF hp]
              exact hFp
          [Elab.step] [0.060055] 
                by_cases hFp : ringChar F = p
                · rw [show (p : F) = 0 by rw [← hFp]; exact ringChar.Nat.cast_ringChar]
                  simp only [IsSquare.zero, Ne, true_iff, map_mul]
                  obtain ⟨n, _, hc⟩ := FiniteField.card F (ringChar F)
                  have hchar : ringChar F = ringChar (ZMod p) := by rw [hFp]; exact (ringChar_zmod_n p).symm
                  conv => enter [1, 1, 2]; rw [hc, Nat.cast_pow, map_pow, hchar, map_ringChar]
                  simp only [zero_pow n.ne_zero, mul_zero, zero_eq_neg, one_ne_zero, not_false_iff]
                · rw [← Iff.not_left (@quadraticChar_neg_one_iff_not_isSquare F _ _ _ _), quadraticChar_odd_prime hF hp]
                  exact hFp
            [Elab.step] [0.060044] 
                  by_cases hFp : ringChar F = p
                  · rw [show (p : F) = 0 by rw [← hFp]; exact ringChar.Nat.cast_ringChar]
                    simp only [IsSquare.zero, Ne, true_iff, map_mul]
                    obtain ⟨n, _, hc⟩ := FiniteField.card F (ringChar F)
                    have hchar : ringChar F = ringChar (ZMod p) := by rw [hFp]; exact (ringChar_zmod_n p).symm
                    conv => enter [1, 1, 2]; rw [hc, Nat.cast_pow, map_pow, hchar, map_ringChar]
                    simp only [zero_pow n.ne_zero, mul_zero, zero_eq_neg, one_ne_zero, not_false_iff]
                  · rw [← Iff.not_left (@quadraticChar_neg_one_iff_not_isSquare F _ _ _ _),
                      quadraticChar_odd_prime hF hp]
                    exact hFp
              [Elab.step] [0.055777] ·
                    rw [show (p : F) = 0 by rw [← hFp]; exact ringChar.Nat.cast_ringChar]
                    simp only [IsSquare.zero, Ne, true_iff, map_mul]
                    obtain ⟨n, _, hc⟩ := FiniteField.card F (ringChar F)
                    have hchar : ringChar F = ringChar (ZMod p) := by rw [hFp]; exact (ringChar_zmod_n p).symm
                    conv => enter [1, 1, 2]; rw [hc, Nat.cast_pow, map_pow, hchar, map_ringChar]
                    simp only [zero_pow n.ne_zero, mul_zero, zero_eq_neg, one_ne_zero, not_false_iff]
                [Elab.step] [0.055767] 
                      rw [show (p : F) = 0 by rw [← hFp]; exact ringChar.Nat.cast_ringChar]
                      simp only [IsSquare.zero, Ne, true_iff, map_mul]
                      obtain ⟨n, _, hc⟩ := FiniteField.card F (ringChar F)
                      have hchar : ringChar F = ringChar (ZMod p) := by rw [hFp]; exact (ringChar_zmod_n p).symm
                      conv => enter [1, 1, 2]; rw [hc, Nat.cast_pow, map_pow, hchar, map_ringChar]
                      simp only [zero_pow n.ne_zero, mul_zero, zero_eq_neg, one_ne_zero, not_false_iff]
                  [Elab.step] [0.055761] 
                        rw [show (p : F) = 0 by rw [← hFp]; exact ringChar.Nat.cast_ringChar]
                        simp only [IsSquare.zero, Ne, true_iff, map_mul]
                        obtain ⟨n, _, hc⟩ := FiniteField.card F (ringChar F)
                        have hchar : ringChar F = ringChar (ZMod p) := by rw [hFp]; exact (ringChar_zmod_n p).symm
                        conv => enter [1, 1, 2]; rw [hc, Nat.cast_pow, map_pow, hchar, map_ringChar]
                        simp only [zero_pow n.ne_zero, mul_zero, zero_eq_neg, one_ne_zero, not_false_iff]
                    [Elab.step] [0.013550] simp only [IsSquare.zero, Ne, true_iff, map_mul]
                    [Elab.step] [0.010623] obtain ⟨n, _, hc⟩ := FiniteField.card F (ringChar F)
                    [Elab.step] [0.014198] conv => enter [1, 1, 2]; rw [hc, Nat.cast_pow, map_pow, hchar, map_ringChar]
                      [Elab.step] [0.013464] enter [1, 1, 2]; rw [hc, Nat.cast_pow, map_pow, hchar, map_ringChar]
                        [Elab.step] [0.013460] enter [1, 1, 2]; rw [hc, Nat.cast_pow, map_pow, hchar, map_ringChar]
                          [Elab.step] [0.013234] rw [hc, Nat.cast_pow, map_pow, hchar, map_ringChar]
                            [Elab.step] [0.013208] rewrite [hc, Nat.cast_pow, map_pow, hchar, map_ringChar]
Build completed successfully (2828 jobs).
```

### Trace profiling of `FiniteField.isSquare_odd_prime_iff` after PR 30939
```diff
diff --git a/Mathlib/NumberTheory/LegendreSymbol/QuadraticChar/GaussSum.lean b/Mathlib/NumberTheory/LegendreSymbol/QuadraticChar/GaussSum.lean
index e3281cd154..1f73e5c70f 100644
--- a/Mathlib/NumberTheory/LegendreSymbol/QuadraticChar/GaussSum.lean
+++ b/Mathlib/NumberTheory/LegendreSymbol/QuadraticChar/GaussSum.lean
@@ -94,6 +94,7 @@ theorem quadraticChar_odd_prime [DecidableEq F] (hF : ringChar F ≠ 2) {p : ℕ
     (ne_of_eq_of_ne (ringChar_zmod_n p) hp₂.symm)
   rwa [card p] at h
 
+set_option trace.profiler true in
 /-- An odd prime `p` is a square in `F` iff the quadratic character of `ZMod p` does not
 take the value `-1` on `χ₄#F * #F`. -/
 theorem FiniteField.isSquare_odd_prime_iff (hF : ringChar F ≠ 2) {p : ℕ} [Fact p.Prime]
@@ -102,11 +103,8 @@ theorem FiniteField.isSquare_odd_prime_iff (hF : ringChar F ≠ 2) {p : ℕ} [Fa
   classical
   by_cases hFp : ringChar F = p
   · rw [show (p : F) = 0 by rw [← hFp]; exact ringChar.Nat.cast_ringChar]
-    simp only [IsSquare.zero, Ne, true_iff, map_mul]
-    obtain ⟨n, _, hc⟩ := FiniteField.card F (ringChar F)
-    have hchar : ringChar F = ringChar (ZMod p) := by rw [hFp]; exact (ringChar_zmod_n p).symm
-    conv => enter [1, 1, 2]; rw [hc, Nat.cast_pow, map_pow, hchar, map_ringChar]
-    simp only [zero_pow n.ne_zero, mul_zero, zero_eq_neg, one_ne_zero, not_false_iff]
+    obtain ⟨⟩ := FiniteField.card F (ringChar F)
+    simp [*]
   · rw [← Iff.not_left (@quadraticChar_neg_one_iff_not_isSquare F _ _ _ _),
       quadraticChar_odd_prime hF hp]
     exact hFp
```
```
ℹ [2828/2828] Built Mathlib.NumberTheory.LegendreSymbol.QuadraticChar.GaussSum (1.7s)
info: Mathlib/NumberTheory/LegendreSymbol/QuadraticChar/GaussSum.lean:98:0: [Elab.command] [0.018569] /-- An odd prime `p` is a square in `F` iff the quadratic character of `ZMod p` does not
    take the value `-1` on `χ₄#F * #F`. -/
    theorem isSquare_odd_prime_iff (hF : ringChar F ≠ 2) {p : ℕ} [Fact p.Prime] (hp : p ≠ 2) :
        IsSquare (p : F) ↔ quadraticChar (ZMod p) (χ₄ (Fintype.card F) * Fintype.card F) ≠ -1 := by
      classical
      by_cases hFp : ringChar F = p
      · rw [show (p : F) = 0 by rw [← hFp]; exact ringChar.Nat.cast_ringChar]
        obtain ⟨⟩ := FiniteField.card F (ringChar F)
        simp [*]
      · rw [← Iff.not_left (@quadraticChar_neg_one_iff_not_isSquare F _ _ _ _), quadraticChar_odd_prime hF hp]
        exact hFp
  [Elab.definition.header] [0.018106] FiniteField.isSquare_odd_prime_iff
    [Elab.step] [0.016733] expected type: Prop, term
        IsSquare (p : F) ↔ quadraticChar (ZMod p) (χ₄ (Fintype.card F) * Fintype.card F) ≠ -1
      [Elab.step] [0.016726] expected type: Prop, term
          Iff✝ (IsSquare (p : F)) (quadraticChar (ZMod p) (χ₄ (Fintype.card F) * Fintype.card F) ≠ -1)
        [Elab.step] [0.014053] expected type: Prop, term
            quadraticChar (ZMod p) (χ₄ (Fintype.card F) * Fintype.card F) ≠ -1
          [Elab.step] [0.014046] expected type: Prop, term
              binrel% Ne✝ (quadraticChar (ZMod p) (χ₄ (Fintype.card F) * Fintype.card F)) (-1)
            [Elab.step] [0.013685] expected type: <not-available>, term
                quadraticChar (ZMod p) (χ₄ (Fintype.card F) * Fintype.card F)
              [Elab.step] [0.010420] expected type: ZMod p, term
                  (χ₄ (Fintype.card F) * Fintype.card F)
                [Elab.step] [0.010415] expected type: ZMod p, term
                    χ₄ (Fintype.card F) * Fintype.card F
                  [Elab.step] [0.010409] expected type: ZMod p, term
                      binop% HMul.hMul✝ (χ₄ (Fintype.card F)) (Fintype.card F)
info: Mathlib/NumberTheory/LegendreSymbol/QuadraticChar/GaussSum.lean:98:0: [Elab.command] [0.018685] /-- An odd prime `p` is a square in `F` iff the quadratic character of `ZMod p` does not
    take the value `-1` on `χ₄#F * #F`. -/
    theorem FiniteField.isSquare_odd_prime_iff (hF : ringChar F ≠ 2) {p : ℕ} [Fact p.Prime] (hp : p ≠ 2) :
        IsSquare (p : F) ↔ quadraticChar (ZMod p) (χ₄ (Fintype.card F) * Fintype.card F) ≠ -1 := by
      classical
      by_cases hFp : ringChar F = p
      · rw [show (p : F) = 0 by rw [← hFp]; exact ringChar.Nat.cast_ringChar]
        obtain ⟨⟩ := FiniteField.card F (ringChar F)
        simp [*]
      · rw [← Iff.not_left (@quadraticChar_neg_one_iff_not_isSquare F _ _ _ _), quadraticChar_odd_prime hF hp]
        exact hFp
info: Mathlib/NumberTheory/LegendreSymbol/QuadraticChar/GaussSum.lean:98:0: [Elab.async] [0.139820] elaborating proof of FiniteField.isSquare_odd_prime_iff
  [Elab.definition.value] [0.138910] FiniteField.isSquare_odd_prime_iff
    [Elab.step] [0.138469] classical
          by_cases hFp : ringChar F = p
          · rw [show (p : F) = 0 by rw [← hFp]; exact ringChar.Nat.cast_ringChar]
            obtain ⟨⟩ := FiniteField.card F (ringChar F)
            simp [*]
          · rw [← Iff.not_left (@quadraticChar_neg_one_iff_not_isSquare F _ _ _ _), quadraticChar_odd_prime hF hp]
            exact hFp
      [Elab.step] [0.138464] classical
            by_cases hFp : ringChar F = p
            · rw [show (p : F) = 0 by rw [← hFp]; exact ringChar.Nat.cast_ringChar]
              obtain ⟨⟩ := FiniteField.card F (ringChar F)
              simp [*]
            · rw [← Iff.not_left (@quadraticChar_neg_one_iff_not_isSquare F _ _ _ _), quadraticChar_odd_prime hF hp]
              exact hFp
        [Elab.step] [0.138459] classical
            by_cases hFp : ringChar F = p
            · rw [show (p : F) = 0 by rw [← hFp]; exact ringChar.Nat.cast_ringChar]
              obtain ⟨⟩ := FiniteField.card F (ringChar F)
              simp [*]
            · rw [← Iff.not_left (@quadraticChar_neg_one_iff_not_isSquare F _ _ _ _), quadraticChar_odd_prime hF hp]
              exact hFp
          [Elab.step] [0.138002] 
                by_cases hFp : ringChar F = p
                · rw [show (p : F) = 0 by rw [← hFp]; exact ringChar.Nat.cast_ringChar]
                  obtain ⟨⟩ := FiniteField.card F (ringChar F)
                  simp [*]
                · rw [← Iff.not_left (@quadraticChar_neg_one_iff_not_isSquare F _ _ _ _), quadraticChar_odd_prime hF hp]
                  exact hFp
            [Elab.step] [0.137991] 
                  by_cases hFp : ringChar F = p
                  · rw [show (p : F) = 0 by rw [← hFp]; exact ringChar.Nat.cast_ringChar]
                    obtain ⟨⟩ := FiniteField.card F (ringChar F)
                    simp [*]
                  · rw [← Iff.not_left (@quadraticChar_neg_one_iff_not_isSquare F _ _ _ _),
                      quadraticChar_odd_prime hF hp]
                    exact hFp
              [Elab.step] [0.133856] ·
                    rw [show (p : F) = 0 by rw [← hFp]; exact ringChar.Nat.cast_ringChar]
                    obtain ⟨⟩ := FiniteField.card F (ringChar F)
                    simp [*]
                [Elab.step] [0.133848] 
                      rw [show (p : F) = 0 by rw [← hFp]; exact ringChar.Nat.cast_ringChar]
                      obtain ⟨⟩ := FiniteField.card F (ringChar F)
                      simp [*]
                  [Elab.step] [0.133844] 
                        rw [show (p : F) = 0 by rw [← hFp]; exact ringChar.Nat.cast_ringChar]
                        obtain ⟨⟩ := FiniteField.card F (ringChar F)
                        simp [*]
                    [Elab.step] [0.011009] obtain ⟨⟩ := FiniteField.card F (ringChar F)
                    [Elab.step] [0.113860] simp [*]
                      [Meta.synthInstance] [0.013335] ✅️ ExistsAddOfLE F
                      [Meta.synthInstance] [0.037076] ❌️ PosMulMono F
Build completed successfully (2828 jobs).
```
</details>

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include at least one commit authored by each
co-author among the commits in the pull request. If necessary, you may 
create empty commits to indicate co-authorship, using commands like so:

git commit --author="Author Name <author@email.com>" --allow-empty -m "add Author Name as coauthor"

When merging, all the commits will be squashed into a single commit listing all co-authors.

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
