### PR TITLE
[Merged by Bors] - feat(Data/Set/Image): add Option.range lemmas for elim function

### DIFF
--- a/Mathlib/Data/Set/Image.lean
+++ b/Mathlib/Data/Set/Image.lean
@@ -1248,6 +1248,23 @@ theorem injective_iff {α β} {f : Option α → β} :
 theorem range_eq {α β} (f : Option α → β) : range f = insert (f none) (range (f ∘ some)) :=
   Set.ext fun _ => Option.exists.trans <| eq_comm.or Iff.rfl
 
+theorem range_elim {α β} (b : β) (f : α → β) :
+    range (fun o : Option α => o.elim b f) = insert b (range f) := by
+  rw [range_eq]
+  simp [Function.comp_def]
+
+theorem elim_image_some_eq_range {α β} (f : α → β) (b : β) :
+    (fun o : Option α => o.elim b f) '' {x : Option α | x ≠ none} = range f := by
+  ext y
+  simp only [mem_range, mem_image, mem_setOf_eq]
+  constructor
+  · intro ⟨x, hx_ne, hx_eq⟩
+    cases x with
+    | none => contradiction
+    | some i => exact ⟨i, hx_eq⟩
+  · intro ⟨i, hi⟩
+    exact ⟨some i, some_ne_none i, hi⟩
+
 end Option
 
 namespace Set

--- a/Mathlib/Data/Set/Image.lean
+++ b/Mathlib/Data/Set/Image.lean
@@ -1254,19 +1254,17 @@ theorem range_elim {α β} (b : β) (f : α → β) :
   rw [range_eq]
   simp [Function.comp_def]
 
-/-- The image of the non-`none` elements of `Option α` under `Option.elim b f` equals
-`range f`. -/
-theorem elim_image_some_eq_range {α β} (f : α → β) (b : β) :
-    (fun o : Option α => o.elim b f) '' {x : Option α | x ≠ none} = range f := by
+/-- The image of `range some` under `Option.elim b f` equals `range f`. -/
+theorem image_elim_range_some_eq_range {α β} (f : α → β) (b : β) :
+    (fun o : Option α => o.elim b f) '' range some = range f := by
   ext y
-  simp only [mem_range, mem_image, mem_setOf_eq]
+  simp only [mem_range, mem_image]
   constructor
-  · intro ⟨x, hx_ne, hx_eq⟩
-    cases x with
-    | none => contradiction
-    | some i => exact ⟨i, hx_eq⟩
+  · intro ⟨x, ⟨i, hi⟩, hx_eq⟩
+    subst hi
+    exact ⟨i, hx_eq⟩
   · intro ⟨i, hi⟩
-    exact ⟨some i, some_ne_none i, hi⟩
+    exact ⟨some i, ⟨i, rfl⟩, hi⟩
 
 end Option
 

--- a/Mathlib/Data/Set/Image.lean
+++ b/Mathlib/Data/Set/Image.lean
@@ -1248,11 +1248,14 @@ theorem injective_iff {α β} {f : Option α → β} :
 theorem range_eq {α β} (f : Option α → β) : range f = insert (f none) (range (f ∘ some)) :=
   Set.ext fun _ => Option.exists.trans <| eq_comm.or Iff.rfl
 
+/-- The range of `Option.elim b f` is `{b} ∪ range f`. -/
 theorem range_elim {α β} (b : β) (f : α → β) :
     range (fun o : Option α => o.elim b f) = insert b (range f) := by
   rw [range_eq]
   simp [Function.comp_def]
 
+/-- The image of the non-`none` elements of `Option α` under `Option.elim b f` equals
+`range f`. -/
 theorem elim_image_some_eq_range {α β} (f : α → β) (b : β) :
     (fun o : Option α => o.elim b f) '' {x : Option α | x ≠ none} = range f := by
   ext y

--- a/Mathlib/Data/Set/Image.lean
+++ b/Mathlib/Data/Set/Image.lean
@@ -1257,14 +1257,8 @@ theorem range_elim {α β} (b : β) (f : α → β) :
 /-- The image of `range some` under `Option.elim b f` equals `range f`. -/
 theorem image_elim_range_some_eq_range {α β} (f : α → β) (b : β) :
     (fun o : Option α => o.elim b f) '' range some = range f := by
-  ext y
-  simp only [mem_range, mem_image]
-  constructor
-  · intro ⟨x, ⟨i, hi⟩, hx_eq⟩
-    subst hi
-    exact ⟨i, hx_eq⟩
-  · intro ⟨i, hi⟩
-    exact ⟨some i, ⟨i, rfl⟩, hi⟩
+  rw [← range_comp']
+  simp
 
 end Option
 


### PR DESCRIPTION
This PR adds two new lemmas about `Option.elim` and `range`:
- `Option.range_elim`: characterizes the range of a function defined via `Option.elim`
- `Option.image_elim_range_some_eq_range`: the image of `range some` under `Option.elim b f` equals `range f`

## Context

These lemmas are part of a larger PR (#30854) that touched multiple areas of Mathlib. Following reviewer suggestions, the PR has been split into smaller, focused contributions. This PR contains only the changes to `Mathlib/Data/Set/Image.lean`.

## Potential Reviewers

Based on recent contributions to `Mathlib/Data/Set/Image.lean`:
- @euprunin 
- @plp127