### PR TITLE
[Merged by Bors] - chore(Data/Seq): golf `terminates_parallel` using `grind`

### DIFF
--- a/Mathlib/Data/Seq/Parallel.lean
+++ b/Mathlib/Data/Seq/Parallel.lean
@@ -156,14 +156,7 @@ theorem terminates_parallel {S : WSeq (Computation α)} {c} (h : c ∈ S) [T : T
         apply IH _ _ _ (Or.inr _) T
         rw [a, Seq.get?_tail]
       rcases e : Seq.get? S 0 with - | o
-      · have D : Seq.destruct S = none := by
-          dsimp [Seq.destruct]
-          rw [e]
-          rfl
-        rw [D]
-        simp only
-        have TT := TT l'
-        rwa [Seq.destruct_eq_none D, Seq.tail_nil] at TT
+      · grind [Seq.get?_zero_eq_none, Seq.get?_nil]
       · have D : Seq.destruct S = some (o, S.tail) := by
           dsimp [Seq.destruct]
           rw [e]


### PR DESCRIPTION
---
<details>
<summary>Show trace profiling of <code>terminates_parallel</code>: 57 ms before, 85 ms after </summary>

### Trace profiling of `terminates_parallel` before PR 30944
```diff
diff --git a/Mathlib/Data/Seq/Parallel.lean b/Mathlib/Data/Seq/Parallel.lean
index c21a8d4aa4..b211c360b5 100644
--- a/Mathlib/Data/Seq/Parallel.lean
+++ b/Mathlib/Data/Seq/Parallel.lean
@@ -107,6 +107,7 @@ theorem terminates_parallel.aux :
       have := H1 _ h
       rcases Seq.destruct S with (_ | ⟨_ | c, S'⟩) <;> apply IH <;> simp [this]
 
+set_option trace.profiler true in
 theorem terminates_parallel {S : WSeq (Computation α)} {c} (h : c ∈ S) [T : Terminates c] :
     Terminates (parallel S) := by
   suffices
```
```
ℹ [708/708] Built Mathlib.Data.Seq.Parallel (1.2s)
info: Mathlib/Data/Seq/Parallel.lean:111:0: [Elab.async] [0.058751] elaborating proof of Computation.terminates_parallel
  [Elab.definition.value] [0.056625] Computation.terminates_parallel
    [Elab.step] [0.053849] 
          suffices
            ∀ (n) (l : List (Computation α)) (S c),
              c ∈ l ∨ some (some c) = Seq.get? S n → Terminates c → Terminates (corec parallel.aux1 (l, S))
            from
            let ⟨n, h⟩ := h
            this n [] S c (Or.inr h) T
          intro n; induction n <;> intro l S c o T
          case zero =>
            rcases o with a | a
            · exact terminates_parallel.aux a T
            have H : Seq.destruct S = some (some c, Seq.tail S) := by simp [Seq.destruct, (· <$> ·), ← a]
            rcases h : parallel.aux2 l with a | l'
            · have C : corec parallel.aux1 (l, S) = pure a :=
                by
                apply destruct_eq_pure
                rw [corec_eq, parallel.aux1]
                rw [h]
                simp only [rmap]
              rw [C]
              infer_instance
            · have C : corec parallel.aux1 (l, S) = _ :=
                destruct_eq_think
                  (by
                    simp only [corec_eq, rmap, parallel.aux1.eq_1]
                    rw [h, H])
              rw [C]
              refine @Computation.think_terminates _ _ ?_
              apply terminates_parallel.aux _ T
              simp
          case succ n IH =>
            rcases o with a | a
            · exact terminates_parallel.aux a T
            rcases h : parallel.aux2 l with a | l'
            · have C : corec parallel.aux1 (l, S) = pure a :=
                by
                apply destruct_eq_pure
                rw [corec_eq, parallel.aux1]
                rw [h]
                simp only [rmap]
              rw [C]
              infer_instance
            · have C : corec parallel.aux1 (l, S) = _ :=
                destruct_eq_think
                  (by
                    simp only [corec_eq, rmap, parallel.aux1.eq_1]
                    rw [h])
              rw [C]
              refine @Computation.think_terminates _ _ ?_
              have TT : ∀ l', Terminates (corec parallel.aux1 (l', S.tail)) :=
                by
                intro
                apply IH _ _ _ (Or.inr _) T
                rw [a, Seq.get?_tail]
              rcases e : Seq.get? S 0 with - | o
              · have D : Seq.destruct S = none := by
                  dsimp [Seq.destruct]
                  rw [e]
                  rfl
                rw [D]
                simp only
                have TT := TT l'
                rwa [Seq.destruct_eq_none D, Seq.tail_nil] at TT
              · have D : Seq.destruct S = some (o, S.tail) :=
                  by
                  dsimp [Seq.destruct]
                  rw [e]
                  rfl
                rw [D]
                cases o <;> simp [TT]
      [Elab.step] [0.053842] 
            suffices
              ∀ (n) (l : List (Computation α)) (S c),
                c ∈ l ∨ some (some c) = Seq.get? S n → Terminates c → Terminates (corec parallel.aux1 (l, S))
              from
              let ⟨n, h⟩ := h
              this n [] S c (Or.inr h) T
            intro n; induction n <;> intro l S c o T
            case zero =>
              rcases o with a | a
              · exact terminates_parallel.aux a T
              have H : Seq.destruct S = some (some c, Seq.tail S) := by simp [Seq.destruct, (· <$> ·), ← a]
              rcases h : parallel.aux2 l with a | l'
              · have C : corec parallel.aux1 (l, S) = pure a :=
                  by
                  apply destruct_eq_pure
                  rw [corec_eq, parallel.aux1]
                  rw [h]
                  simp only [rmap]
                rw [C]
                infer_instance
              · have C : corec parallel.aux1 (l, S) = _ :=
                  destruct_eq_think
                    (by
                      simp only [corec_eq, rmap, parallel.aux1.eq_1]
                      rw [h, H])
                rw [C]
[… 247 lines omitted …]
                        rfl
                      rw [D]
                      simp only
                      have TT := TT l'
                      rwa [Seq.destruct_eq_none D, Seq.tail_nil] at TT
                    · have D : Seq.destruct S = some (o, S.tail) :=
                        by
                        dsimp [Seq.destruct]
                        rw [e]
                        rfl
                      rw [D]
                      cases o <;> simp [TT]
              [Elab.step] [0.020083] ·
                    have C : corec parallel.aux1 (l, S) = _ :=
                      destruct_eq_think
                        (by
                          simp only [corec_eq, rmap, parallel.aux1.eq_1]
                          rw [h])
                    rw [C]
                    refine @Computation.think_terminates _ _ ?_
                    have TT : ∀ l', Terminates (corec parallel.aux1 (l', S.tail)) :=
                      by
                      intro
                      apply IH _ _ _ (Or.inr _) T
                      rw [a, Seq.get?_tail]
                    rcases e : Seq.get? S 0 with - | o
                    · have D : Seq.destruct S = none := by
                        dsimp [Seq.destruct]
                        rw [e]
                        rfl
                      rw [D]
                      simp only
                      have TT := TT l'
                      rwa [Seq.destruct_eq_none D, Seq.tail_nil] at TT
                    · have D : Seq.destruct S = some (o, S.tail) :=
                        by
                        dsimp [Seq.destruct]
                        rw [e]
                        rfl
                      rw [D]
                      cases o <;> simp [TT]
                [Elab.step] [0.020062] 
                      have C : corec parallel.aux1 (l, S) = _ :=
                        destruct_eq_think
                          (by
                            simp only [corec_eq, rmap, parallel.aux1.eq_1]
                            rw [h])
                      rw [C]
                      refine @Computation.think_terminates _ _ ?_
                      have TT : ∀ l', Terminates (corec parallel.aux1 (l', S.tail)) :=
                        by
                        intro
                        apply IH _ _ _ (Or.inr _) T
                        rw [a, Seq.get?_tail]
                      rcases e : Seq.get? S 0 with - | o
                      · have D : Seq.destruct S = none := by
                          dsimp [Seq.destruct]
                          rw [e]
                          rfl
                        rw [D]
                        simp only
                        have TT := TT l'
                        rwa [Seq.destruct_eq_none D, Seq.tail_nil] at TT
                      · have D : Seq.destruct S = some (o, S.tail) :=
                          by
                          dsimp [Seq.destruct]
                          rw [e]
                          rfl
                        rw [D]
                        cases o <;> simp [TT]
                  [Elab.step] [0.020057] 
                        have C : corec parallel.aux1 (l, S) = _ :=
                          destruct_eq_think
                            (by
                              simp only [corec_eq, rmap, parallel.aux1.eq_1]
                              rw [h])
                        rw [C]
                        refine @Computation.think_terminates _ _ ?_
                        have TT : ∀ l', Terminates (corec parallel.aux1 (l', S.tail)) :=
                          by
                          intro
                          apply IH _ _ _ (Or.inr _) T
                          rw [a, Seq.get?_tail]
                        rcases e : Seq.get? S 0 with - | o
                        · have D : Seq.destruct S = none := by
                            dsimp [Seq.destruct]
                            rw [e]
                            rfl
                          rw [D]
                          simp only
                          have TT := TT l'
                          rwa [Seq.destruct_eq_none D, Seq.tail_nil] at TT
                        · have D : Seq.destruct S = some (o, S.tail) :=
                            by
                            dsimp [Seq.destruct]
                            rw [e]
                            rfl
                          rw [D]
                          cases o <;> simp [TT]
Build completed successfully (708 jobs).
```

### Trace profiling of `terminates_parallel` after PR 30944
```diff
diff --git a/Mathlib/Data/Seq/Parallel.lean b/Mathlib/Data/Seq/Parallel.lean
index c21a8d4aa4..aa263d4631 100644
--- a/Mathlib/Data/Seq/Parallel.lean
+++ b/Mathlib/Data/Seq/Parallel.lean
@@ -107,6 +107,7 @@ theorem terminates_parallel.aux :
       have := H1 _ h
       rcases Seq.destruct S with (_ | ⟨_ | c, S'⟩) <;> apply IH <;> simp [this]
 
+set_option trace.profiler true in
 theorem terminates_parallel {S : WSeq (Computation α)} {c} (h : c ∈ S) [T : Terminates c] :
     Terminates (parallel S) := by
   suffices
@@ -156,14 +157,7 @@ theorem terminates_parallel {S : WSeq (Computation α)} {c} (h : c ∈ S) [T : T
         apply IH _ _ _ (Or.inr _) T
         rw [a, Seq.get?_tail]
       rcases e : Seq.get? S 0 with - | o
-      · have D : Seq.destruct S = none := by
-          dsimp [Seq.destruct]
-          rw [e]
-          rfl
-        rw [D]
-        simp only
-        have TT := TT l'
-        rwa [Seq.destruct_eq_none D, Seq.tail_nil] at TT
+      · grind [Seq.get?_zero_eq_none, Seq.get?_nil]
       · have D : Seq.destruct S = some (o, S.tail) := by
           dsimp [Seq.destruct]
           rw [e]
```
```
ℹ [708/708] Built Mathlib.Data.Seq.Parallel (1.2s)
info: Mathlib/Data/Seq/Parallel.lean:111:0: [Elab.async] [0.086694] elaborating proof of Computation.terminates_parallel
  [Elab.definition.value] [0.084753] Computation.terminates_parallel
    [Elab.step] [0.081870] 
          suffices
            ∀ (n) (l : List (Computation α)) (S c),
              c ∈ l ∨ some (some c) = Seq.get? S n → Terminates c → Terminates (corec parallel.aux1 (l, S))
            from
            let ⟨n, h⟩ := h
            this n [] S c (Or.inr h) T
          intro n; induction n <;> intro l S c o T
          case zero =>
            rcases o with a | a
            · exact terminates_parallel.aux a T
            have H : Seq.destruct S = some (some c, Seq.tail S) := by simp [Seq.destruct, (· <$> ·), ← a]
            rcases h : parallel.aux2 l with a | l'
            · have C : corec parallel.aux1 (l, S) = pure a :=
                by
                apply destruct_eq_pure
                rw [corec_eq, parallel.aux1]
                rw [h]
                simp only [rmap]
              rw [C]
              infer_instance
            · have C : corec parallel.aux1 (l, S) = _ :=
                destruct_eq_think
                  (by
                    simp only [corec_eq, rmap, parallel.aux1.eq_1]
                    rw [h, H])
              rw [C]
              refine @Computation.think_terminates _ _ ?_
              apply terminates_parallel.aux _ T
              simp
          case succ n IH =>
            rcases o with a | a
            · exact terminates_parallel.aux a T
            rcases h : parallel.aux2 l with a | l'
            · have C : corec parallel.aux1 (l, S) = pure a :=
                by
                apply destruct_eq_pure
                rw [corec_eq, parallel.aux1]
                rw [h]
                simp only [rmap]
              rw [C]
              infer_instance
            · have C : corec parallel.aux1 (l, S) = _ :=
                destruct_eq_think
                  (by
                    simp only [corec_eq, rmap, parallel.aux1.eq_1]
                    rw [h])
              rw [C]
              refine @Computation.think_terminates _ _ ?_
              have TT : ∀ l', Terminates (corec parallel.aux1 (l', S.tail)) :=
                by
                intro
                apply IH _ _ _ (Or.inr _) T
                rw [a, Seq.get?_tail]
              rcases e : Seq.get? S 0 with - | o
              · grind [Seq.get?_zero_eq_none, Seq.get?_nil]
              · have D : Seq.destruct S = some (o, S.tail) :=
                  by
                  dsimp [Seq.destruct]
                  rw [e]
                  rfl
                rw [D]
                cases o <;> simp [TT]
      [Elab.step] [0.081865] 
            suffices
              ∀ (n) (l : List (Computation α)) (S c),
                c ∈ l ∨ some (some c) = Seq.get? S n → Terminates c → Terminates (corec parallel.aux1 (l, S))
              from
              let ⟨n, h⟩ := h
              this n [] S c (Or.inr h) T
            intro n; induction n <;> intro l S c o T
            case zero =>
              rcases o with a | a
              · exact terminates_parallel.aux a T
              have H : Seq.destruct S = some (some c, Seq.tail S) := by simp [Seq.destruct, (· <$> ·), ← a]
              rcases h : parallel.aux2 l with a | l'
              · have C : corec parallel.aux1 (l, S) = pure a :=
                  by
                  apply destruct_eq_pure
                  rw [corec_eq, parallel.aux1]
                  rw [h]
                  simp only [rmap]
                rw [C]
                infer_instance
              · have C : corec parallel.aux1 (l, S) = _ :=
                  destruct_eq_think
                    (by
                      simp only [corec_eq, rmap, parallel.aux1.eq_1]
                      rw [h, H])
                rw [C]
                refine @Computation.think_terminates _ _ ?_
                apply terminates_parallel.aux _ T
                simp
            case succ n IH =>
              rcases o with a | a
              · exact terminates_parallel.aux a T
              rcases h : parallel.aux2 l with a | l'
[… 195 lines omitted …]
                  · have C : corec parallel.aux1 (l, S) = pure a :=
                      by
                      apply destruct_eq_pure
                      rw [corec_eq, parallel.aux1]
                      rw [h]
                      simp only [rmap]
                    rw [C]
                    infer_instance
                  · have C : corec parallel.aux1 (l, S) = _ :=
                      destruct_eq_think
                        (by
                          simp only [corec_eq, rmap, parallel.aux1.eq_1]
                          rw [h])
                    rw [C]
                    refine @Computation.think_terminates _ _ ?_
                    have TT : ∀ l', Terminates (corec parallel.aux1 (l', S.tail)) :=
                      by
                      intro
                      apply IH _ _ _ (Or.inr _) T
                      rw [a, Seq.get?_tail]
                    rcases e : Seq.get? S 0 with - | o
                    · grind [Seq.get?_zero_eq_none, Seq.get?_nil]
                    · have D : Seq.destruct S = some (o, S.tail) :=
                        by
                        dsimp [Seq.destruct]
                        rw [e]
                        rfl
                      rw [D]
                      cases o <;> simp [TT]
              [Elab.step] [0.053278] ·
                    have C : corec parallel.aux1 (l, S) = _ :=
                      destruct_eq_think
                        (by
                          simp only [corec_eq, rmap, parallel.aux1.eq_1]
                          rw [h])
                    rw [C]
                    refine @Computation.think_terminates _ _ ?_
                    have TT : ∀ l', Terminates (corec parallel.aux1 (l', S.tail)) :=
                      by
                      intro
                      apply IH _ _ _ (Or.inr _) T
                      rw [a, Seq.get?_tail]
                    rcases e : Seq.get? S 0 with - | o
                    · grind [Seq.get?_zero_eq_none, Seq.get?_nil]
                    · have D : Seq.destruct S = some (o, S.tail) :=
                        by
                        dsimp [Seq.destruct]
                        rw [e]
                        rfl
                      rw [D]
                      cases o <;> simp [TT]
                [Elab.step] [0.053255] 
                      have C : corec parallel.aux1 (l, S) = _ :=
                        destruct_eq_think
                          (by
                            simp only [corec_eq, rmap, parallel.aux1.eq_1]
                            rw [h])
                      rw [C]
                      refine @Computation.think_terminates _ _ ?_
                      have TT : ∀ l', Terminates (corec parallel.aux1 (l', S.tail)) :=
                        by
                        intro
                        apply IH _ _ _ (Or.inr _) T
                        rw [a, Seq.get?_tail]
                      rcases e : Seq.get? S 0 with - | o
                      · grind [Seq.get?_zero_eq_none, Seq.get?_nil]
                      · have D : Seq.destruct S = some (o, S.tail) :=
                          by
                          dsimp [Seq.destruct]
                          rw [e]
                          rfl
                        rw [D]
                        cases o <;> simp [TT]
                  [Elab.step] [0.053250] 
                        have C : corec parallel.aux1 (l, S) = _ :=
                          destruct_eq_think
                            (by
                              simp only [corec_eq, rmap, parallel.aux1.eq_1]
                              rw [h])
                        rw [C]
                        refine @Computation.think_terminates _ _ ?_
                        have TT : ∀ l', Terminates (corec parallel.aux1 (l', S.tail)) :=
                          by
                          intro
                          apply IH _ _ _ (Or.inr _) T
                          rw [a, Seq.get?_tail]
                        rcases e : Seq.get? S 0 with - | o
                        · grind [Seq.get?_zero_eq_none, Seq.get?_nil]
                        · have D : Seq.destruct S = some (o, S.tail) :=
                            by
                            dsimp [Seq.destruct]
                            rw [e]
                            rfl
                          rw [D]
                          cases o <;> simp [TT]
                    [Elab.step] [0.038546] · grind [Seq.get?_zero_eq_none, Seq.get?_nil]
                      [Elab.step] [0.038513] grind [Seq.get?_zero_eq_none, Seq.get?_nil]
                        [Elab.step] [0.038509] grind [Seq.get?_zero_eq_none, Seq.get?_nil]
                          [Elab.step] [0.038502] grind [Seq.get?_zero_eq_none, Seq.get?_nil]
Build completed successfully (708 jobs).
```
</details>

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include at least one commit authored by each
co-author among the commits in the pull request. If necessary, you may 
create empty commits to indicate co-authorship, using commands like so:

git commit --author="Author Name <author@email.com>" --allow-empty -m "add Author Name as coauthor"

When merging, all the commits will be squashed into a single commit listing all co-authors.

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
