### PR TITLE
[Merged by Bors] - feat(LinearAlgebra/AffineSpace): affine maps/equivs determined by values on spanning sets

### DIFF
--- a/Mathlib/LinearAlgebra/AffineSpace/AffineSubspace/Basic.lean
+++ b/Mathlib/LinearAlgebra/AffineSpace/AffineSubspace/Basic.lean
@@ -594,6 +594,28 @@ theorem span_eq_top_of_surjective {s : Set P₁} (hf : Function.Surjective f)
     (h : affineSpan k s = ⊤) : affineSpan k (f '' s) = ⊤ := by
   rw [← AffineSubspace.map_span, h, map_top_of_surjective f hf]
 
+/-- If two affine maps agree on a set, their linear parts agree on the vector span of that set. -/
+theorem linear_eqOn_vectorSpan {V₂ P₂ : Type*} [AddCommGroup V₂] [Module k V₂] [AddTorsor V₂ P₂]
+    {s : Set P₁} {f g : P₁ →ᵃ[k] P₂}
+    (h_agree : s.EqOn f g) : Set.EqOn f.linear g.linear (vectorSpan k s) := by
+  simp only [vectorSpan_def]
+  apply LinearMap.eqOn_span
+  rintro - ⟨x, hx, y, hy, rfl⟩
+  simp [h_agree hx, h_agree hy]
+
+/-- If two affine maps agree on a set that spans the entire space, then they are equal. -/
+theorem ext_on {V₂ P₂ : Type*} [AddCommGroup V₂] [Module k V₂] [AddTorsor V₂ P₂]
+    {s : Set P₁} {f g : P₁ →ᵃ[k] P₂}
+    (h_span : affineSpan k s = ⊤)
+    (h_agree : s.EqOn f g) : f = g := by
+  have aux : Set.EqOn f.linear g.linear (affineSpan k s).direction := by
+    rw [direction_affineSpan]
+    exact linear_eqOn_vectorSpan h_agree
+  obtain ⟨q, hq⟩ : s.Nonempty := by contrapose! h_span; simp [h_span]
+  refine AffineMap.ext_linear (LinearMap.ext_on ?_ aux) (h_agree hq)
+  simpa [direction_affineSpan] using
+    AffineSubspace.vectorSpan_eq_top_of_affineSpan_eq_top k V₁ P₁ h_span
+
 end AffineMap
 
 namespace AffineEquiv

--- a/Mathlib/LinearAlgebra/AffineSpace/AffineSubspace/Basic.lean
+++ b/Mathlib/LinearAlgebra/AffineSpace/AffineSubspace/Basic.lean
@@ -603,18 +603,20 @@ theorem linear_eqOn_vectorSpan {V₂ P₂ : Type*} [AddCommGroup V₂] [Module k
   rintro - ⟨x, hx, y, hy, rfl⟩
   simp [h_agree hx, h_agree hy]
 
+/-- Two affine maps which agree on a set, agree on its affine span. -/
+theorem eqOn_affineSpan {V₂ P₂ : Type*} [AddCommGroup V₂] [Module k V₂] [AddTorsor V₂ P₂]
+    {s : Set P₁} {f g : P₁ →ᵃ[k] P₂}
+    (h_agree : s.EqOn f g) : Set.EqOn f g (affineSpan k s) := by
+  rcases s.eq_empty_or_nonempty with rfl | ⟨q, hq⟩; · simp
+  rintro - ⟨x, hx, y, hy, rfl⟩
+  simp [h_agree hx, linear_eqOn_vectorSpan h_agree hy]
+
 /-- If two affine maps agree on a set that spans the entire space, then they are equal. -/
 theorem ext_on {V₂ P₂ : Type*} [AddCommGroup V₂] [Module k V₂] [AddTorsor V₂ P₂]
     {s : Set P₁} {f g : P₁ →ᵃ[k] P₂}
     (h_span : affineSpan k s = ⊤)
     (h_agree : s.EqOn f g) : f = g := by
-  have aux : Set.EqOn f.linear g.linear (affineSpan k s).direction := by
-    rw [direction_affineSpan]
-    exact linear_eqOn_vectorSpan h_agree
-  obtain ⟨q, hq⟩ : s.Nonempty := by contrapose! h_span; simp [h_span]
-  refine AffineMap.ext_linear (LinearMap.ext_on ?_ aux) (h_agree hq)
-  simpa [direction_affineSpan] using
-    AffineSubspace.vectorSpan_eq_top_of_affineSpan_eq_top k V₁ P₁ h_span
+  simpa [h_span]  using eqOn_affineSpan h_agree
 
 end AffineMap
 

--- a/Mathlib/LinearAlgebra/AffineSpace/AffineSubspace/Basic.lean
+++ b/Mathlib/LinearAlgebra/AffineSpace/AffineSubspace/Basic.lean
@@ -622,6 +622,12 @@ end AffineMap
 
 namespace AffineEquiv
 
+/-- If two affine equivalences agree on a set that spans the entire space, then they are equal. -/
+theorem ext_on {V₂ P₂ : Type*} [AddCommGroup V₂] [Module k V₂] [AddTorsor V₂ P₂]
+    {s : Set P₁} (h_span : affineSpan k s = ⊤)
+    (T₁ T₂ : P₁ ≃ᵃ[k] P₂) (h_agree : s.EqOn T₁ T₂) : T₁ = T₂ :=
+  (AffineEquiv.toAffineMap_inj).mp <| AffineMap.ext_on h_span h_agree
+
 section ofEq
 variable (S₁ S₂ : AffineSubspace k P₁) [Nonempty S₁] [Nonempty S₂]
 

--- a/Mathlib/LinearAlgebra/AffineSpace/Combination.lean
+++ b/Mathlib/LinearAlgebra/AffineSpace/Combination.lean
@@ -952,20 +952,3 @@ def weightedVSubOfPoint (w : ι → k) : (ι → P) × P →ᵃ[k] V where
 
 end AffineMap
 
-namespace AffineEquiv
-
-variable {k : Type*} {V : Type*} {P : Type*}
-
-/-- If two affine automorphisms agree on a set that spans the entire space, then they are equal.
-
-Specialization of `AffineMap.ext_on` to affine automorphisms. -/
-theorem ext_of_span_eq_top [CommRing k] [AddCommGroup V] [Module k V] [AffineSpace V P]
-    {s : Set P}
-    (h_span : affineSpan k s = ⊤)
-    (T₁ T₂ : P ≃ᵃ[k] P)
-    (h_agree : s.restrict T₁ = s.restrict T₂) : T₁ = T₂ := by
-  rw [← AffineEquiv.toAffineMap_inj]
-  apply AffineMap.ext_on h_span
-  exact fun x hx => congr_fun h_agree ⟨x, hx⟩
-
-end AffineEquiv

--- a/Mathlib/LinearAlgebra/AffineSpace/Combination.lean
+++ b/Mathlib/LinearAlgebra/AffineSpace/Combination.lean
@@ -959,7 +959,7 @@ theorem ext_of_span_eq_top {V₁ V₂ P₁ P₂ : Type*}
     {s : Set P₁}
     (h_span : affineSpan k s = ⊤)
     (f g : P₁ →ᵃ[k] P₂)
-    (h_agree : ∀ p ∈ s, f p = g p) : f = g := by
+    (h_agree : s.restrict f = s.restrict g) : f = g := by
   ext x
   have hx : x ∈ affineSpan k s := by
     rw [h_span]
@@ -972,7 +972,7 @@ theorem ext_of_span_eq_top {V₁ V₂ P₁ P₂ : Type*}
   apply Finset.affineCombination_congr
   · simp
   · intro i _
-    exact h_agree i.val i.property
+    exact congr_fun h_agree i
 
 end AffineMap
 
@@ -987,7 +987,7 @@ theorem ext_of_span_eq_top [CommRing k] [AddCommGroup V] [Module k V] [AffineSpa
     {s : Set P}
     (h_span : affineSpan k s = ⊤)
     (T₁ T₂ : P ≃ᵃ[k] P)
-    (h_agree : ∀ p ∈ s, T₁ p = T₂ p) : T₁ = T₂ := by
+    (h_agree : s.restrict T₁ = s.restrict T₂) : T₁ = T₂ := by
   rw [← AffineEquiv.toAffineMap_inj]
   exact @AffineMap.ext_of_span_eq_top k _ V V P P _ _ _ _ _ _ s h_span
     T₁.toAffineMap T₂.toAffineMap h_agree

--- a/Mathlib/LinearAlgebra/AffineSpace/Combination.lean
+++ b/Mathlib/LinearAlgebra/AffineSpace/Combination.lean
@@ -951,4 +951,3 @@ def weightedVSubOfPoint (w : ι → k) : (ι → P) × P →ᵃ[k] V where
      vadd_vsub_assoc, ← sub_add_eq_add_sub, smul_add, Finset.sum_add_distrib]
 
 end AffineMap
-

--- a/Mathlib/LinearAlgebra/AffineSpace/Combination.lean
+++ b/Mathlib/LinearAlgebra/AffineSpace/Combination.lean
@@ -950,23 +950,6 @@ def weightedVSubOfPoint (w : ι → k) : (ι → P) × P →ᵃ[k] V where
     simp [LinearMap.sum_apply, Finset.weightedVSubOfPoint, vsub_vadd_eq_vsub_sub,
      vadd_vsub_assoc, ← sub_add_eq_add_sub, smul_add, Finset.sum_add_distrib]
 
-variable {P}
-
-/-- If two affine maps agree on a set that spans the entire space, then they are equal. -/
-theorem ext_on {V₂ P₂ : Type*} [AddCommGroup V₂] [Module k V₂] [AddTorsor V₂ P₂]
-    {s : Set P} {f g : P →ᵃ[k] P₂}
-    (h_span : affineSpan k s = ⊤)
-    (h_agree : s.EqOn f g) : f = g := by
-  have aux : Set.EqOn f.linear g.linear (affineSpan k s).direction := by
-    simp only [direction_affineSpan, vectorSpan_def]
-    apply LinearMap.eqOn_span
-    rintro - ⟨x, hx, y, hy, rfl⟩
-    simp [h_agree hx, h_agree hy]
-  obtain ⟨q, hq⟩ : s.Nonempty := by contrapose! h_span; simp [h_span]
-  refine AffineMap.ext_linear (LinearMap.ext_on ?_ aux) (h_agree hq)
-  simpa [direction_affineSpan] using
-    AffineSubspace.vectorSpan_eq_top_of_affineSpan_eq_top k V P h_span
-
 end AffineMap
 
 namespace AffineEquiv
@@ -975,14 +958,14 @@ variable {k : Type*} {V : Type*} {P : Type*}
 
 /-- If two affine automorphisms agree on a set that spans the entire space, then they are equal.
 
-Specialization of `AffineMap.ext_of_span_eq_top` to affine automorphisms. -/
+Specialization of `AffineMap.ext_on` to affine automorphisms. -/
 theorem ext_of_span_eq_top [CommRing k] [AddCommGroup V] [Module k V] [AffineSpace V P]
     {s : Set P}
     (h_span : affineSpan k s = ⊤)
     (T₁ T₂ : P ≃ᵃ[k] P)
     (h_agree : s.restrict T₁ = s.restrict T₂) : T₁ = T₂ := by
   rw [← AffineEquiv.toAffineMap_inj]
-  exact @AffineMap.ext_of_span_eq_top k _ V V P P _ _ _ _ _ _ s h_span
-    T₁.toAffineMap T₂.toAffineMap h_agree
+  apply AffineMap.ext_on h_span
+  exact fun x hx => congr_fun h_agree ⟨x, hx⟩
 
 end AffineEquiv

--- a/Mathlib/LinearAlgebra/AffineSpace/Combination.lean
+++ b/Mathlib/LinearAlgebra/AffineSpace/Combination.lean
@@ -950,4 +950,46 @@ def weightedVSubOfPoint (w : ι → k) : (ι → P) × P →ᵃ[k] V where
     simp [LinearMap.sum_apply, Finset.weightedVSubOfPoint, vsub_vadd_eq_vsub_sub,
      vadd_vsub_assoc, ← sub_add_eq_add_sub, smul_add, Finset.sum_add_distrib]
 
+variable {P}
+
+/-- If two affine maps agree on a set that spans the entire space, then they are equal. -/
+theorem ext_of_span_eq_top {V₁ V₂ P₁ P₂ : Type*}
+    [AddCommGroup V₁] [Module k V₁] [AddTorsor V₁ P₁]
+    [AddCommGroup V₂] [Module k V₂] [AddTorsor V₂ P₂]
+    {s : Set P₁}
+    (h_span : affineSpan k s = ⊤)
+    (f g : P₁ →ᵃ[k] P₂)
+    (h_agree : ∀ p ∈ s, f p = g p) : f = g := by
+  ext x
+  have hx : x ∈ affineSpan k s := by
+    rw [h_span]
+    exact AffineSubspace.mem_top k V₁ x
+  rw [← Subtype.range_coe (s := s)] at hx
+  obtain ⟨t, w, hw_sum, hw_eq⟩ := eq_affineCombination_of_mem_affineSpan hx
+  rw [hw_eq]
+  rw [Finset.map_affineCombination t (Subtype.val : s → P₁) w hw_sum f,
+      Finset.map_affineCombination t (Subtype.val : s → P₁) w hw_sum g]
+  apply Finset.affineCombination_congr
+  · simp
+  · intro i _
+    exact h_agree i.val i.property
+
 end AffineMap
+
+namespace AffineEquiv
+
+variable {k : Type*} {V : Type*} {P : Type*}
+
+/-- If two affine automorphisms agree on a set that spans the entire space, then they are equal.
+
+Specialization of `AffineMap.ext_of_span_eq_top` to affine automorphisms. -/
+theorem ext_of_span_eq_top [CommRing k] [AddCommGroup V] [Module k V] [AffineSpace V P]
+    {s : Set P}
+    (h_span : affineSpan k s = ⊤)
+    (T₁ T₂ : P ≃ᵃ[k] P)
+    (h_agree : ∀ p ∈ s, T₁ p = T₂ p) : T₁ = T₂ := by
+  rw [← AffineEquiv.toAffineMap_inj]
+  exact @AffineMap.ext_of_span_eq_top k _ V V P P _ _ _ _ _ _ s h_span
+    T₁.toAffineMap T₂.toAffineMap h_agree
+
+end AffineEquiv

--- a/Mathlib/LinearAlgebra/AffineSpace/Combination.lean
+++ b/Mathlib/LinearAlgebra/AffineSpace/Combination.lean
@@ -953,26 +953,19 @@ def weightedVSubOfPoint (w : ι → k) : (ι → P) × P →ᵃ[k] V where
 variable {P}
 
 /-- If two affine maps agree on a set that spans the entire space, then they are equal. -/
-theorem ext_of_span_eq_top {V₁ V₂ P₁ P₂ : Type*}
-    [AddCommGroup V₁] [Module k V₁] [AddTorsor V₁ P₁]
-    [AddCommGroup V₂] [Module k V₂] [AddTorsor V₂ P₂]
-    {s : Set P₁}
+theorem ext_on {V₂ P₂ : Type*} [AddCommGroup V₂] [Module k V₂] [AddTorsor V₂ P₂]
+    {s : Set P} {f g : P →ᵃ[k] P₂}
     (h_span : affineSpan k s = ⊤)
-    (f g : P₁ →ᵃ[k] P₂)
-    (h_agree : s.restrict f = s.restrict g) : f = g := by
-  ext x
-  have hx : x ∈ affineSpan k s := by
-    rw [h_span]
-    exact AffineSubspace.mem_top k V₁ x
-  rw [← Subtype.range_coe (s := s)] at hx
-  obtain ⟨t, w, hw_sum, hw_eq⟩ := eq_affineCombination_of_mem_affineSpan hx
-  rw [hw_eq]
-  rw [Finset.map_affineCombination t (Subtype.val : s → P₁) w hw_sum f,
-      Finset.map_affineCombination t (Subtype.val : s → P₁) w hw_sum g]
-  apply Finset.affineCombination_congr
-  · simp
-  · intro i _
-    exact congr_fun h_agree i
+    (h_agree : s.EqOn f g) : f = g := by
+  have aux : Set.EqOn f.linear g.linear (affineSpan k s).direction := by
+    simp only [direction_affineSpan, vectorSpan_def]
+    apply LinearMap.eqOn_span
+    rintro - ⟨x, hx, y, hy, rfl⟩
+    simp [h_agree hx, h_agree hy]
+  obtain ⟨q, hq⟩ : s.Nonempty := by contrapose! h_span; simp [h_span]
+  refine AffineMap.ext_linear (LinearMap.ext_on ?_ aux) (h_agree hq)
+  simpa [direction_affineSpan] using
+    AffineSubspace.vectorSpan_eq_top_of_affineSpan_eq_top k V P h_span
 
 end AffineMap
 


### PR DESCRIPTION
This PR adds extensionality lemmas showing that affine maps and equivalences are uniquely determined by their values on any set that affinely spans the entire space.

All theorems are in `Mathlib.LinearAlgebra.AffineSpace.AffineSubspace.Basic`:

- `AffineMap.linear_eqOn_vectorSpan`: If two affine maps agree on a set, their linear parts agree on the vector span
- `AffineMap.eqOn_affineSpan`: Two affine maps which agree on a set, agree on its affine span
- `AffineMap.ext_on`: If two affine maps agree on a set that spans the entire space, they are equal
- `AffineEquiv.ext_on`: If two affine equivalences agree on a set that spans the entire space, they are equal (generalized to work between different spaces)

Extracted from #30854.