### PR TITLE
[Merged by Bors] - chore: allow 'exe cache' to upload Canonical oleans

### DIFF
--- a/Cache/IO.lean
+++ b/Cache/IO.lean
@@ -41,7 +41,9 @@ def isPartOfMathlibCache (mod : Name) : Bool := #[
   -- Allow PRs to upload oleans for Reap for testing.
   `Requests,
   `OpenAIClient,
-  `Reap,].contains mod.getRoot
+  `Reap,
+  -- Allow PRs to upload oleans for Canonical for testing.
+  `Canonical,].contains mod.getRoot
 
 /-- Target directory for caching -/
 initialize CACHEDIR : FilePath ← do


### PR DESCRIPTION
See https://leanprover.zulipchat.com/#narrow/channel/113488-general/topic/Canonical