### PR TITLE
[Merged by Bors] - feat: preparations for LawfulOfScientific

### DIFF
--- a/Mathlib/Algebra/Order/Ring/Unbundled/Rat.lean
+++ b/Mathlib/Algebra/Order/Ring/Unbundled/Rat.lean
@@ -42,6 +42,11 @@ instance _root_.NNRatCast.toOfScientific {K} [NNRatCast K] : OfScientific K wher
   ofScientific (m : ℕ) (b : Bool) (d : ℕ) :=
     NNRat.cast ⟨Rat.ofScientific m b d, ofScientific_nonneg m b d⟩
 
+theorem _root_.NNRatCast.toOfScientific_def {K} [NNRatCast K] (m : ℕ) (b : Bool) (d : ℕ) :
+    (OfScientific.ofScientific m b d : K) =
+      NNRat.cast ⟨(OfScientific.ofScientific m b d : ℚ), ofScientific_nonneg m b d⟩ :=
+  rfl
+
 /-- Casting a scientific literal via `ℚ≥0` is the same as casting directly. -/
 @[simp, norm_cast]
 theorem _root_.NNRat.cast_ofScientific {K} [NNRatCast K] (m : ℕ) (s : Bool) (e : ℕ) :

--- a/Mathlib/Data/Rat/Cast/Lemmas.lean
+++ b/Mathlib/Data/Rat/Cast/Lemmas.lean
@@ -74,6 +74,12 @@ theorem cast_zpow_of_ne_zero {K} [DivisionSemiring K] (q : ℚ≥0) (z : ℤ) (h
     congr
     rw [cast_inv_of_ne_zero hq]
 
+@[simp]
+theorem cast_mk {K} [DivisionRing K] (q : ℚ) (h : 0 ≤ q) :
+    (NNRat.cast ⟨q, h⟩ : K) = (q : K) := by
+  simp only [NNRat.cast_def, NNRat.num_mk, Nat.cast_natAbs, NNRat.den_mk, Rat.cast_def]
+  rw [abs_of_nonneg (by simpa)]
+
 open OfScientific in
 theorem Nonneg.coe_ofScientific {K} [Field K] [LinearOrder K] [IsStrictOrderedRing K]
     (m : ℕ) (s : Bool) (e : ℕ) :


### PR DESCRIPTION
`LawfulOfScientific`, and grind support for it, will be added shortly. This is PR contains the prerequisites which can already go in `master`.

c.f. https://github.com/leanprover/lean4/pull/10971 and the [`lean-pr-testing-10971`](https://github.com/leanprover-community/mathlib4-nightly-testing/commit/4f3ca5121a48872248a70a5098b608cdd13caeca) branch.