### PR TITLE
chore(RingTheory/Polynomial): golf entire `degreeLT_succ_eq_degreeLE` using `rfl`

### DIFF
--- a/Mathlib/RingTheory/Polynomial/Basic.lean
+++ b/Mathlib/RingTheory/Polynomial/Basic.lean
@@ -158,12 +158,7 @@ theorem eval_eq_sum_degreeLTEquiv {n : ℕ} {p : R[X]} (hp : p ∈ degreeLT R n)
   simp_rw [eval_eq_sum]
   exact (sum_fin _ (by simp_rw [zero_mul, forall_const]) (mem_degreeLT.mp hp)).symm
 
-theorem degreeLT_succ_eq_degreeLE {n : ℕ} : degreeLT R (n + 1) = degreeLE R n := by
-  ext x
-  by_cases x_zero : x = 0
-  · simp_rw [x_zero, Submodule.zero_mem]
-  · rw [mem_degreeLT, mem_degreeLE, ← natDegree_lt_iff_degree_lt (by rwa [ne_eq]),
-      ← natDegree_le_iff_degree_le, Nat.lt_succ]
+theorem degreeLT_succ_eq_degreeLE {n : ℕ} : degreeLT R (n + 1) = degreeLE R n := rfl
 
 /-- The equivalence between monic polynomials of degree `n` and polynomials of degree less than
 `n`, formed by adding a term `X ^ n`. -/


### PR DESCRIPTION
---
<details>
<summary>Show trace profiling of <code>degreeLT_succ_eq_degreeLE</code>: 12 ms before, <10 ms after  🎉</summary>

### Trace profiling of `degreeLT_succ_eq_degreeLE` before PR 30959
```diff
diff --git a/Mathlib/RingTheory/Polynomial/Basic.lean b/Mathlib/RingTheory/Polynomial/Basic.lean
index 205bce7933..89ab41fcbc 100644
--- a/Mathlib/RingTheory/Polynomial/Basic.lean
+++ b/Mathlib/RingTheory/Polynomial/Basic.lean
@@ -158,6 +158,7 @@ theorem eval_eq_sum_degreeLTEquiv {n : ℕ} {p : R[X]} (hp : p ∈ degreeLT R n)
   simp_rw [eval_eq_sum]
   exact (sum_fin _ (by simp_rw [zero_mul, forall_const]) (mem_degreeLT.mp hp)).symm
 
+set_option trace.profiler true in
 theorem degreeLT_succ_eq_degreeLE {n : ℕ} : degreeLT R (n + 1) = degreeLE R n := by
   ext x
   by_cases x_zero : x = 0
```
```
ℹ [1436/1436] Built Mathlib.RingTheory.Polynomial.Basic (2.4s)
info: Mathlib/RingTheory/Polynomial/Basic.lean:162:0: [Elab.async] [0.012225] elaborating proof of Polynomial.degreeLT_succ_eq_degreeLE
  [Elab.definition.value] [0.011683] Polynomial.degreeLT_succ_eq_degreeLE
    [Elab.step] [0.011420] 
          ext x
          by_cases x_zero : x = 0
          · simp_rw [x_zero, Submodule.zero_mem]
          ·
            rw [mem_degreeLT, mem_degreeLE, ← natDegree_lt_iff_degree_lt (by rwa [ne_eq]), ← natDegree_le_iff_degree_le,
              Nat.lt_succ]
      [Elab.step] [0.011413] 
            ext x
            by_cases x_zero : x = 0
            · simp_rw [x_zero, Submodule.zero_mem]
            ·
              rw [mem_degreeLT, mem_degreeLE, ← natDegree_lt_iff_degree_lt (by rwa [ne_eq]), ←
                natDegree_le_iff_degree_le, Nat.lt_succ]
Build completed successfully (1436 jobs).
```

### Trace profiling of `degreeLT_succ_eq_degreeLE` after PR 30959
```diff
diff --git a/Mathlib/RingTheory/Polynomial/Basic.lean b/Mathlib/RingTheory/Polynomial/Basic.lean
index 205bce7933..5078d7c03c 100644
--- a/Mathlib/RingTheory/Polynomial/Basic.lean
+++ b/Mathlib/RingTheory/Polynomial/Basic.lean
@@ -158,12 +158,8 @@ theorem eval_eq_sum_degreeLTEquiv {n : ℕ} {p : R[X]} (hp : p ∈ degreeLT R n)
   simp_rw [eval_eq_sum]
   exact (sum_fin _ (by simp_rw [zero_mul, forall_const]) (mem_degreeLT.mp hp)).symm
 
-theorem degreeLT_succ_eq_degreeLE {n : ℕ} : degreeLT R (n + 1) = degreeLE R n := by
-  ext x
-  by_cases x_zero : x = 0
-  · simp_rw [x_zero, Submodule.zero_mem]
-  · rw [mem_degreeLT, mem_degreeLE, ← natDegree_lt_iff_degree_lt (by rwa [ne_eq]),
-      ← natDegree_le_iff_degree_le, Nat.lt_succ]
+set_option trace.profiler true in
+theorem degreeLT_succ_eq_degreeLE {n : ℕ} : degreeLT R (n + 1) = degreeLE R n := rfl
 
 /-- The equivalence between monic polynomials of degree `n` and polynomials of degree less than
 `n`, formed by adding a term `X ^ n`. -/
```
```
✔ [1436/1436] Built Mathlib.RingTheory.Polynomial.Basic (2.4s)
Build completed successfully (1436 jobs).
```
</details>

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include at least one commit authored by each
co-author among the commits in the pull request. If necessary, you may 
create empty commits to indicate co-authorship, using commands like so:

git commit --author="Author Name <author@email.com>" --allow-empty -m "add Author Name as coauthor"

When merging, all the commits will be squashed into a single commit listing all co-authors.

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
