### PR TITLE
[Merged by Bors] - chore(Data/List): golf entire `nodup_iff_getElem?_ne_getElem?` and `Nodup.pmap` using `grind`

### DIFF
--- a/Mathlib/Data/List/Nodup.lean
+++ b/Mathlib/Data/List/Nodup.lean
@@ -96,14 +96,7 @@ theorem Nodup.getElem_inj_iff {l : List α} (h : Nodup l)
 
 theorem nodup_iff_getElem?_ne_getElem? {l : List α} :
     l.Nodup ↔ ∀ i j : ℕ, i < j → j < l.length → l[i]? ≠ l[j]? := by
-  rw [Nodup, pairwise_iff_getElem]
-  constructor
-  · intro h i j hij hj
-    rw [getElem?_eq_getElem (lt_trans hij hj), getElem?_eq_getElem hj, Ne, Option.some_inj]
-    exact h _ _ (by cutsat) hj hij
-  · intro h i j hi hj hij
-    rw [Ne, ← Option.some_inj, ← getElem?_eq_getElem, ← getElem?_eq_getElem]
-    exact h i j hij hj
+  grind [List.pairwise_iff_getElem]
 
 theorem Nodup.ne_singleton_iff {l : List α} (h : Nodup l) (x : α) :
     l ≠ [x] ↔ l = [] ∨ ∃ y ∈ l, y ≠ x := by
@@ -233,8 +226,7 @@ protected alias ⟨Nodup.of_attach, Nodup.attach⟩ := nodup_attach
 
 theorem Nodup.pmap {p : α → Prop} {f : ∀ a, p a → β} {l : List α} {H}
     (hf : ∀ a ha b hb, f a ha = f b hb → a = b) (h : Nodup l) : Nodup (pmap f l H) := by
-  rw [pmap_eq_map_attach]
-  exact h.attach.map fun ⟨a, ha⟩ ⟨b, hb⟩ h => by congr; exact hf a (H _ ha) b (H _ hb) h
+  grind
 
 theorem Nodup.filter (p : α → Bool) {l} : Nodup l → Nodup (filter p l) := by
   simpa using Pairwise.filter p


### PR DESCRIPTION
---
<details>
<summary>Show trace profiling of <code>nodup_iff_getElem?_ne_getElem?</code>: 22 ms before, 75 ms after </summary>

### Trace profiling of `nodup_iff_getElem\?_ne_getElem\?` before PR 30961
```diff
diff --git a/Mathlib/Data/List/Nodup.lean b/Mathlib/Data/List/Nodup.lean
index 6089f380ff..5a498f3f96 100644
--- a/Mathlib/Data/List/Nodup.lean
+++ b/Mathlib/Data/List/Nodup.lean
@@ -94,6 +94,7 @@ theorem Nodup.getElem_inj_iff {l : List α} (h : Nodup l)
   have := @Nodup.get_inj_iff _ _ h ⟨i, hi⟩ ⟨j, hj⟩
   simpa
 
+set_option trace.profiler true in
 theorem nodup_iff_getElem?_ne_getElem? {l : List α} :
     l.Nodup ↔ ∀ i j : ℕ, i < j → j < l.length → l[i]? ≠ l[j]? := by
   rw [Nodup, pairwise_iff_getElem]
```
```
ℹ [455/455] Built Mathlib.Data.List.Nodup (1.2s)
info: Mathlib/Data/List/Nodup.lean:98:0: [Elab.async] [0.022583] elaborating proof of List.nodup_iff_getElem?_ne_getElem?
  [Elab.definition.value] [0.022013] List.nodup_iff_getElem?_ne_getElem?
    [Elab.step] [0.021688] 
          rw [Nodup, pairwise_iff_getElem]
          constructor
          · intro h i j hij hj
            rw [getElem?_eq_getElem (lt_trans hij hj), getElem?_eq_getElem hj, Ne, Option.some_inj]
            exact h _ _ (by cutsat) hj hij
          · intro h i j hi hj hij
            rw [Ne, ← Option.some_inj, ← getElem?_eq_getElem, ← getElem?_eq_getElem]
            exact h i j hij hj
      [Elab.step] [0.021683] 
            rw [Nodup, pairwise_iff_getElem]
            constructor
            · intro h i j hij hj
              rw [getElem?_eq_getElem (lt_trans hij hj), getElem?_eq_getElem hj, Ne, Option.some_inj]
              exact h _ _ (by cutsat) hj hij
            · intro h i j hi hj hij
              rw [Ne, ← Option.some_inj, ← getElem?_eq_getElem, ← getElem?_eq_getElem]
              exact h i j hij hj
        [Elab.step] [0.018398] ·
              intro h i j hij hj
              rw [getElem?_eq_getElem (lt_trans hij hj), getElem?_eq_getElem hj, Ne, Option.some_inj]
              exact h _ _ (by cutsat) hj hij
          [Elab.step] [0.018378] 
                intro h i j hij hj
                rw [getElem?_eq_getElem (lt_trans hij hj), getElem?_eq_getElem hj, Ne, Option.some_inj]
                exact h _ _ (by cutsat) hj hij
            [Elab.step] [0.018374] 
                  intro h i j hij hj
                  rw [getElem?_eq_getElem (lt_trans hij hj), getElem?_eq_getElem hj, Ne, Option.some_inj]
                  exact h _ _ (by cutsat) hj hij
              [Elab.step] [0.015423] exact h _ _ (by cutsat) hj hij
                [Elab.step] [0.014856] cutsat
                  [Elab.step] [0.014851] cutsat
                    [Elab.step] [0.014844] cutsat
Build completed successfully (455 jobs).
```

### Trace profiling of `nodup_iff_getElem\?_ne_getElem\?` after PR 30961
```diff
diff --git a/Mathlib/Data/List/Nodup.lean b/Mathlib/Data/List/Nodup.lean
index 6089f380ff..3ae96fc46e 100644
--- a/Mathlib/Data/List/Nodup.lean
+++ b/Mathlib/Data/List/Nodup.lean
@@ -94,16 +94,10 @@ theorem Nodup.getElem_inj_iff {l : List α} (h : Nodup l)
   have := @Nodup.get_inj_iff _ _ h ⟨i, hi⟩ ⟨j, hj⟩
   simpa
 
+set_option trace.profiler true in
 theorem nodup_iff_getElem?_ne_getElem? {l : List α} :
     l.Nodup ↔ ∀ i j : ℕ, i < j → j < l.length → l[i]? ≠ l[j]? := by
-  rw [Nodup, pairwise_iff_getElem]
-  constructor
-  · intro h i j hij hj
-    rw [getElem?_eq_getElem (lt_trans hij hj), getElem?_eq_getElem hj, Ne, Option.some_inj]
-    exact h _ _ (by cutsat) hj hij
-  · intro h i j hi hj hij
-    rw [Ne, ← Option.some_inj, ← getElem?_eq_getElem, ← getElem?_eq_getElem]
-    exact h i j hij hj
+  grind [List.pairwise_iff_getElem]
 
 theorem Nodup.ne_singleton_iff {l : List α} (h : Nodup l) (x : α) :
     l ≠ [x] ↔ l = [] ∨ ∃ y ∈ l, y ≠ x := by
@@ -233,8 +227,7 @@ protected alias ⟨Nodup.of_attach, Nodup.attach⟩ := nodup_attach
 
 theorem Nodup.pmap {p : α → Prop} {f : ∀ a, p a → β} {l : List α} {H}
     (hf : ∀ a ha b hb, f a ha = f b hb → a = b) (h : Nodup l) : Nodup (pmap f l H) := by
-  rw [pmap_eq_map_attach]
-  exact h.attach.map fun ⟨a, ha⟩ ⟨b, hb⟩ h => by congr; exact hf a (H _ ha) b (H _ hb) h
+  grind
 
 theorem Nodup.filter (p : α → Bool) {l} : Nodup l → Nodup (filter p l) := by
   simpa using Pairwise.filter p
```
```
ℹ [455/455] Built Mathlib.Data.List.Nodup (1.2s)
info: Mathlib/Data/List/Nodup.lean:98:0: [Elab.async] [0.075485] elaborating proof of List.nodup_iff_getElem?_ne_getElem?
  [Elab.definition.value] [0.075150] List.nodup_iff_getElem?_ne_getElem?
    [Elab.step] [0.075070] grind [List.pairwise_iff_getElem]
      [Elab.step] [0.075065] grind [List.pairwise_iff_getElem]
        [Elab.step] [0.075058] grind [List.pairwise_iff_getElem]
Build completed successfully (455 jobs).
```
</details>

---
<details>
<summary>Show trace profiling of <code>Nodup.pmap</code>: <10 ms before, 21 ms after </summary>

### Trace profiling of `Nodup.pmap` before PR 30961
```diff
diff --git a/Mathlib/Data/List/Nodup.lean b/Mathlib/Data/List/Nodup.lean
index 6089f380ff..142ff16c25 100644
--- a/Mathlib/Data/List/Nodup.lean
+++ b/Mathlib/Data/List/Nodup.lean
@@ -231,6 +231,7 @@ theorem nodup_attach {l : List α} : Nodup (attach l) ↔ Nodup l :=
 
 protected alias ⟨Nodup.of_attach, Nodup.attach⟩ := nodup_attach
 
+set_option trace.profiler true in
 theorem Nodup.pmap {p : α → Prop} {f : ∀ a, p a → β} {l : List α} {H}
     (hf : ∀ a ha b hb, f a ha = f b hb → a = b) (h : Nodup l) : Nodup (pmap f l H) := by
   rw [pmap_eq_map_attach]
```
```
✔ [455/455] Built Mathlib.Data.List.Nodup (1.2s)
Build completed successfully (455 jobs).
```

### Trace profiling of `Nodup.pmap` after PR 30961
```diff
diff --git a/Mathlib/Data/List/Nodup.lean b/Mathlib/Data/List/Nodup.lean
index 6089f380ff..7a38a4430f 100644
--- a/Mathlib/Data/List/Nodup.lean
+++ b/Mathlib/Data/List/Nodup.lean
@@ -96,14 +96,7 @@ theorem Nodup.getElem_inj_iff {l : List α} (h : Nodup l)
 
 theorem nodup_iff_getElem?_ne_getElem? {l : List α} :
     l.Nodup ↔ ∀ i j : ℕ, i < j → j < l.length → l[i]? ≠ l[j]? := by
-  rw [Nodup, pairwise_iff_getElem]
-  constructor
-  · intro h i j hij hj
-    rw [getElem?_eq_getElem (lt_trans hij hj), getElem?_eq_getElem hj, Ne, Option.some_inj]
-    exact h _ _ (by cutsat) hj hij
-  · intro h i j hi hj hij
-    rw [Ne, ← Option.some_inj, ← getElem?_eq_getElem, ← getElem?_eq_getElem]
-    exact h i j hij hj
+  grind [List.pairwise_iff_getElem]
 
 theorem Nodup.ne_singleton_iff {l : List α} (h : Nodup l) (x : α) :
     l ≠ [x] ↔ l = [] ∨ ∃ y ∈ l, y ≠ x := by
@@ -231,10 +224,10 @@ theorem nodup_attach {l : List α} : Nodup (attach l) ↔ Nodup l :=
 
 protected alias ⟨Nodup.of_attach, Nodup.attach⟩ := nodup_attach
 
+set_option trace.profiler true in
 theorem Nodup.pmap {p : α → Prop} {f : ∀ a, p a → β} {l : List α} {H}
     (hf : ∀ a ha b hb, f a ha = f b hb → a = b) (h : Nodup l) : Nodup (pmap f l H) := by
-  rw [pmap_eq_map_attach]
-  exact h.attach.map fun ⟨a, ha⟩ ⟨b, hb⟩ h => by congr; exact hf a (H _ ha) b (H _ hb) h
+  grind
 
 theorem Nodup.filter (p : α → Bool) {l} : Nodup l → Nodup (filter p l) := by
   simpa using Pairwise.filter p
```
```
ℹ [455/455] Built Mathlib.Data.List.Nodup (1.2s)
info: Mathlib/Data/List/Nodup.lean:228:0: [Elab.async] [0.021381] elaborating proof of List.Nodup.pmap
  [Elab.definition.value] [0.021101] List.Nodup.pmap
    [Elab.step] [0.021001] grind
      [Elab.step] [0.020996] grind
        [Elab.step] [0.020990] grind
Build completed successfully (455 jobs).
```
</details>

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include at least one commit authored by each
co-author among the commits in the pull request. If necessary, you may 
create empty commits to indicate co-authorship, using commands like so:

git commit --author="Author Name <author@email.com>" --allow-empty -m "add Author Name as coauthor"

When merging, all the commits will be squashed into a single commit listing all co-authors.

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
