### PR TITLE
[Merged by Bors] - chore(CMField): refactor the definition of `IsCMField`

### DIFF
--- a/Mathlib/NumberTheory/NumberField/CMField.lean
+++ b/Mathlib/NumberTheory/NumberField/CMField.lean
@@ -60,19 +60,23 @@ section maximalRealSubfield
 A number field `K` is `CM` if `K` is a totally complex quadratic extension of its maximal
 real subfield `K⁺`.
 -/
-class IsCMField (K : Type*) [Field K] [NumberField K] [IsTotallyComplex K] : Prop where
-  is_quadratic : IsQuadraticExtension (maximalRealSubfield K) K
+class IsCMField (K : Type*) [Field K] [NumberField K] : Prop where
+  [to_isTotallyComplex : IsTotallyComplex K]
+  [is_quadratic : IsQuadraticExtension (maximalRealSubfield K) K]
 
 namespace IsCMField
 
 open ComplexEmbedding
 
-variable (K : Type*) [Field K] [NumberField K] [IsTotallyComplex K] [IsCMField K]
+variable (K : Type*) [Field K] [NumberField K] [IsCMField K]
 
 local notation3 "K⁺" => maximalRealSubfield K
 
 instance isQuadraticExtension : IsQuadraticExtension K⁺ K :=
   IsCMField.is_quadratic
+
+instance isTotallyComplex : IsTotallyComplex K :=
+  IsCMField.to_isTotallyComplex
 
 theorem card_infinitePlace_eq_card_infinitePlace :
     Fintype.card (InfinitePlace K⁺) = Fintype.card (InfinitePlace K) := by
@@ -251,7 +255,7 @@ by the complex conjugation, see `IsCMField.unitsComplexConj_eq_self_iff`.
 -/
 def realUnits : Subgroup (𝓞 K)ˣ := (Units.map (algebraMap (𝓞 K⁺) (𝓞 K)).toMonoidHom).range
 
-omit [IsTotallyComplex K] [IsCMField K] in
+omit [IsCMField K] in
 theorem mem_realUnits_iff (u : (𝓞 K)ˣ) :
     u ∈ realUnits K ↔ ∃ v : (𝓞 K⁺)ˣ, algebraMap (𝓞 K⁺) (𝓞 K) v = u := by
   simp [realUnits, MonoidHom.mem_range, RingHom.toMonoidHom_eq_coe, Units.ext_iff]


### PR DESCRIPTION
Change the definition to
```lean
class IsCMField (K : Type*) [Field K] [NumberField K] : Prop where
  [to_isTotallyComplex : IsTotallyComplex K]
  [is_quadratic : IsQuadraticExtension (maximalRealSubfield K) K]
```

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include at least one commit authored by each
co-author among the commits in the pull request. If necessary, you may 
create empty commits to indicate co-authorship, using commands like so:

git commit --author="Author Name <author@email.com>" --allow-empty -m "add Author Name as coauthor"

When merging, all the commits will be squashed into a single commit listing all co-authors.

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

