### PR TITLE
[Merged by Bors] - chore(NumberTheory): golf `inftyValuation.polynomial`

### DIFF
--- a/Mathlib/NumberTheory/FunctionField.lean
+++ b/Mathlib/NumberTheory/FunctionField.lean
@@ -216,8 +216,7 @@ theorem inftyValuation.X_inv : inftyValuation Fq (1 / RatFunc.X) = exp (-1) := b
 -- https://leanprover.zulipchat.com/#narrow/channel/287929-mathlib4/topic/.60synthInstance.2EmaxHeartbeats.60.20error.20but.20only.20in.20.60simpNF.60
 theorem inftyValuation.polynomial {p : Fq[X]} (hp : p ≠ 0) :
     inftyValuationDef Fq (algebraMap Fq[X] (RatFunc Fq) p) = exp (p.natDegree : ℤ) := by
-  grind [FaithfulSMul.algebraMap_eq_zero_iff, FunctionField.inftyValuation_of_nonzero,
-    RatFunc.intDegree_polynomial]
+  rw [inftyValuationDef, if_neg (by simpa), RatFunc.intDegree_polynomial]
 
 /-- The valued field `Fq(t)` with the valuation at infinity. -/
 def inftyValuedFqt : Valued (RatFunc Fq) ℤᵐ⁰ :=

--- a/Mathlib/NumberTheory/FunctionField.lean
+++ b/Mathlib/NumberTheory/FunctionField.lean
@@ -216,8 +216,8 @@ theorem inftyValuation.X_inv : inftyValuation Fq (1 / RatFunc.X) = exp (-1) := b
 -- https://leanprover.zulipchat.com/#narrow/channel/287929-mathlib4/topic/.60synthInstance.2EmaxHeartbeats.60.20error.20but.20only.20in.20.60simpNF.60
 theorem inftyValuation.polynomial {p : Fq[X]} (hp : p ≠ 0) :
     inftyValuationDef Fq (algebraMap Fq[X] (RatFunc Fq) p) = exp (p.natDegree : ℤ) := by
-  have hp' : algebraMap Fq[X] (RatFunc Fq) p ≠ 0 := by simpa
-  rw [inftyValuationDef, if_neg hp', RatFunc.intDegree_polynomial]
+  grind [FaithfulSMul.algebraMap_eq_zero_iff, FunctionField.inftyValuation_of_nonzero,
+    RatFunc.intDegree_polynomial]
 
 /-- The valued field `Fq(t)` with the valuation at infinity. -/
 def inftyValuedFqt : Valued (RatFunc Fq) ℤᵐ⁰ :=


### PR DESCRIPTION
---
<details>
<summary>Show trace profiling of <code>inftyValuation.polynomial</code>: 126 ms before, 128 ms after </summary>

### Trace profiling of `inftyValuation.polynomial` before PR 30979
```diff
diff --git a/Mathlib/NumberTheory/FunctionField.lean b/Mathlib/NumberTheory/FunctionField.lean
index 5a2d27c879..c85bbf0f65 100644
--- a/Mathlib/NumberTheory/FunctionField.lean
+++ b/Mathlib/NumberTheory/FunctionField.lean
@@ -214,6 +214,7 @@ theorem inftyValuation.X_inv : inftyValuation Fq (1 / RatFunc.X) = exp (-1) := b
 
 -- Dropped attribute `@[simp]` due to issue described here:
 -- https://leanprover.zulipchat.com/#narrow/channel/287929-mathlib4/topic/.60synthInstance.2EmaxHeartbeats.60.20error.20but.20only.20in.20.60simpNF.60
+set_option trace.profiler true in
 theorem inftyValuation.polynomial {p : Fq[X]} (hp : p ≠ 0) :
     inftyValuationDef Fq (algebraMap Fq[X] (RatFunc Fq) p) = exp (p.natDegree : ℤ) := by
   have hp' : algebraMap Fq[X] (RatFunc Fq) p ≠ 0 := by simpa
```
```
ℹ [2087/2087] Built Mathlib.NumberTheory.FunctionField (2.2s)
info: Mathlib/NumberTheory/FunctionField.lean:218:0: [Elab.async] [0.126561] elaborating proof of FunctionField.inftyValuation.polynomial
  [Elab.definition.value] [0.126065] FunctionField.inftyValuation.polynomial
    [Elab.step] [0.125833] 
          have hp' : algebraMap Fq[X] (RatFunc Fq) p ≠ 0 := by simpa
          rw [inftyValuationDef, if_neg hp', RatFunc.intDegree_polynomial]
      [Elab.step] [0.125828] 
            have hp' : algebraMap Fq[X] (RatFunc Fq) p ≠ 0 := by simpa
            rw [inftyValuationDef, if_neg hp', RatFunc.intDegree_polynomial]
        [Elab.step] [0.123933] have hp' : algebraMap Fq[X] (RatFunc Fq) p ≠ 0 := by simpa
          [Elab.step] [0.123923] focus
                refine
                  no_implicit_lambda%
                    (have hp' : algebraMap Fq[X] (RatFunc Fq) p ≠ 0 := ?body✝;
                    ?_)
                case body✝ => with_annotate_state"by" (simpa)
            [Elab.step] [0.123918] 
                  refine
                    no_implicit_lambda%
                      (have hp' : algebraMap Fq[X] (RatFunc Fq) p ≠ 0 := ?body✝;
                      ?_)
                  case body✝ => with_annotate_state"by" (simpa)
              [Elab.step] [0.123915] 
                    refine
                      no_implicit_lambda%
                        (have hp' : algebraMap Fq[X] (RatFunc Fq) p ≠ 0 := ?body✝;
                        ?_)
                    case body✝ => with_annotate_state"by" (simpa)
                [Elab.step] [0.118769] case body✝ => with_annotate_state"by" (simpa)
                  [Elab.step] [0.118740] with_annotate_state"by" (simpa)
                    [Elab.step] [0.118737] with_annotate_state"by" (simpa)
                      [Elab.step] [0.118734] with_annotate_state"by" (simpa)
                        [Elab.step] [0.118730] (simpa)
                          [Elab.step] [0.118727] simpa
                            [Elab.step] [0.118724] simpa
                              [Elab.step] [0.118716] simpa
                                [Meta.synthInstance] [0.104456] ✅️ FaithfulSMul Fq[X] (RatFunc Fq)
Build completed successfully (2087 jobs).
```

### Trace profiling of `inftyValuation.polynomial` after PR 30979
```diff
diff --git a/Mathlib/NumberTheory/FunctionField.lean b/Mathlib/NumberTheory/FunctionField.lean
index 5a2d27c879..d20823c457 100644
--- a/Mathlib/NumberTheory/FunctionField.lean
+++ b/Mathlib/NumberTheory/FunctionField.lean
@@ -214,10 +214,10 @@ theorem inftyValuation.X_inv : inftyValuation Fq (1 / RatFunc.X) = exp (-1) := b
 
 -- Dropped attribute `@[simp]` due to issue described here:
 -- https://leanprover.zulipchat.com/#narrow/channel/287929-mathlib4/topic/.60synthInstance.2EmaxHeartbeats.60.20error.20but.20only.20in.20.60simpNF.60
+set_option trace.profiler true in
 theorem inftyValuation.polynomial {p : Fq[X]} (hp : p ≠ 0) :
     inftyValuationDef Fq (algebraMap Fq[X] (RatFunc Fq) p) = exp (p.natDegree : ℤ) := by
-  have hp' : algebraMap Fq[X] (RatFunc Fq) p ≠ 0 := by simpa
-  rw [inftyValuationDef, if_neg hp', RatFunc.intDegree_polynomial]
+  rw [inftyValuationDef, if_neg (by simpa), RatFunc.intDegree_polynomial]
 
 /-- The valued field `Fq(t)` with the valuation at infinity. -/
 def inftyValuedFqt : Valued (RatFunc Fq) ℤᵐ⁰ :=
```
```
ℹ [2087/2087] Built Mathlib.NumberTheory.FunctionField (2.2s)
info: Mathlib/NumberTheory/FunctionField.lean:218:0: [Elab.async] [0.128163] elaborating proof of FunctionField.inftyValuation.polynomial
  [Elab.definition.value] [0.127703] FunctionField.inftyValuation.polynomial
    [Elab.step] [0.127470] rw [inftyValuationDef, if_neg (by simpa), RatFunc.intDegree_polynomial]
      [Elab.step] [0.127465] rw [inftyValuationDef, if_neg (by simpa), RatFunc.intDegree_polynomial]
        [Elab.step] [0.127461] rw [inftyValuationDef, if_neg (by simpa), RatFunc.intDegree_polynomial]
          [Elab.step] [0.127454] (rewrite [inftyValuationDef, if_neg (by simpa), RatFunc.intDegree_polynomial];
                with_annotate_state"]" (try (with_reducible rfl)))
            [Elab.step] [0.127451] rewrite [inftyValuationDef, if_neg (by simpa), RatFunc.intDegree_polynomial];
                  with_annotate_state"]" (try (with_reducible rfl))
              [Elab.step] [0.127448] rewrite [inftyValuationDef, if_neg (by simpa), RatFunc.intDegree_polynomial];
                    with_annotate_state"]" (try (with_reducible rfl))
                [Elab.step] [0.127194] rewrite [inftyValuationDef, if_neg (by simpa), RatFunc.intDegree_polynomial]
                  [Elab.step] [0.125540] simpa
                    [Elab.step] [0.125535] simpa
                      [Elab.step] [0.125527] simpa
                        [Meta.synthInstance] [0.110075] ✅️ FaithfulSMul Fq[X] (RatFunc Fq)
Build completed successfully (2087 jobs).
```
</details>

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include at least one commit authored by each
co-author among the commits in the pull request. If necessary, you may 
create empty commits to indicate co-authorship, using commands like so:

git commit --author="Author Name <author@email.com>" --allow-empty -m "add Author Name as coauthor"

When merging, all the commits will be squashed into a single commit listing all co-authors.

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
