### PR TITLE
chore(Analysis/Convex): golf `sbtw_of_sbtw_of_sbtw_of_mem_affineSpan_pair` using `grind`

### DIFF
--- a/Mathlib/Analysis/Convex/Between.lean
+++ b/Mathlib/Analysis/Convex/Between.lean
@@ -801,14 +801,7 @@ theorem sbtw_of_sbtw_of_sbtw_of_mem_affineSpan_pair [NoZeroSMulDivisors R V]
   have hs' := sign_sum Finset.univ_nonempty (SignType.sign (w i₃)) fun i _ => hs i
   rw [hs'] at hss
   simp_rw [hss, sign_eq_one_iff] at hs
-  refine ⟨hs i₁, ?_⟩
-  rw [hu] at hw
-  rw [Finset.sum_insert, Finset.sum_insert, Finset.sum_singleton] at hw
-  · by_contra hle
-    rw [not_lt] at hle
-    exact (hle.trans_lt (lt_add_of_pos_right _ (Left.add_pos (hs i₂) (hs i₃)))).ne' hw
-  · simpa using h₂₃
-  · simpa [not_or] using ⟨h₁₂, h₁₃⟩
+  grind
 
 end LinearOrderedRing
 


### PR DESCRIPTION
---
<details>
<summary>Show trace profiling of <code>sbtw_of_sbtw_of_sbtw_of_mem_affineSpan_pair</code>: 368 ms before, 510 ms after </summary>

### Trace profiling of `sbtw_of_sbtw_of_sbtw_of_mem_affineSpan_pair` before PR 30993
```diff
diff --git a/Mathlib/Analysis/Convex/Between.lean b/Mathlib/Analysis/Convex/Between.lean
index c046576ad8..63c6b96cae 100644
--- a/Mathlib/Analysis/Convex/Between.lean
+++ b/Mathlib/Analysis/Convex/Between.lean
@@ -740,6 +740,7 @@ variable [Ring R] [LinearOrder R] [IsStrictOrderedRing R]
   [AddCommGroup V] [Module R V] [AddTorsor V P]
 variable {R}
 
+set_option trace.profiler true in
 /-- Suppose lines from two vertices of a triangle to interior points of the opposite side meet at
 `p`. Then `p` lies in the interior of the first (and by symmetry the other) segment from a
 vertex to the point on the opposite side. -/
```
```
ℹ [1510/1510] Built Mathlib.Analysis.Convex.Between (3.4s)
info: Mathlib/Analysis/Convex/Between.lean:744:0: [Elab.command] [0.039396] /--
    Suppose lines from two vertices of a triangle to interior points of the opposite side meet at
    `p`. Then `p` lies in the interior of the first (and by symmetry the other) segment from a
    vertex to the point on the opposite side. -/
    theorem sbtw_of_sbtw_of_sbtw_of_mem_affineSpan_pair [NoZeroSMulDivisors R V] {t : Affine.Triangle R P}
        {i₁ i₂ i₃ : Fin 3} (h₁₂ : i₁ ≠ i₂) {p₁ p₂ p : P} (h₁ : Sbtw R (t.points i₂) p₁ (t.points i₃))
        (h₂ : Sbtw R (t.points i₁) p₂ (t.points i₃)) (h₁' : p ∈ line[R, t.points i₁, p₁])
        (h₂' : p ∈ line[R, t.points i₂, p₂]) : Sbtw R (t.points i₁) p p₁ :=
      by
      have h₁₃ : i₁ ≠ i₃ := by
        rintro rfl
        simp at h₂
      have h₂₃ : i₂ ≠ i₃ := by
        rintro rfl
        simp at h₁
      have h3 : ∀ i : Fin 3, i = i₁ ∨ i = i₂ ∨ i = i₃ := by omega
      have hu : (Finset.univ : Finset (Fin 3)) = { i₁, i₂, i₃ } :=
        by
        clear h₁ h₂ h₁' h₂'
        decide +revert
      have hp : p ∈ affineSpan R (Set.range t.points) :=
        by
        have hle : line[R, t.points i₁, p₁] ≤ affineSpan R (Set.range t.points) :=
          by
          refine affineSpan_pair_le_of_mem_of_mem (mem_affineSpan R (Set.mem_range_self _)) ?_
          have hle : line[R, t.points i₂, t.points i₃] ≤ affineSpan R (Set.range t.points) :=
            by
            refine affineSpan_mono R ?_
            simp [Set.insert_subset_iff]
          rw [AffineSubspace.le_def'] at hle
          exact hle _ h₁.wbtw.mem_affineSpan
        rw [AffineSubspace.le_def'] at hle
        exact hle _ h₁'
      have h₁i := h₁.mem_image_Ioo
      have h₂i := h₂.mem_image_Ioo
      rw [Set.mem_image] at h₁i h₂i
      rcases h₁i with ⟨r₁, ⟨hr₁0, hr₁1⟩, rfl⟩
      rcases h₂i with ⟨r₂, ⟨hr₂0, hr₂1⟩, rfl⟩
      rcases eq_affineCombination_of_mem_affineSpan_of_fintype hp with ⟨w, hw, rfl⟩
      have h₁s :=
        sign_eq_of_affineCombination_mem_affineSpan_single_lineMap t.independent hw (Finset.mem_univ _)
          (Finset.mem_univ _) (Finset.mem_univ _) h₁₂ h₁₃ h₂₃ hr₁0 hr₁1 h₁'
      have h₂s :=
        sign_eq_of_affineCombination_mem_affineSpan_single_lineMap t.independent hw (Finset.mem_univ _)
          (Finset.mem_univ _) (Finset.mem_univ _) h₁₂.symm h₂₃ h₁₃ hr₂0 hr₂1 h₂'
      rw [← Finset.univ.affineCombination_affineCombinationSingleWeights R t.points (Finset.mem_univ i₁), ←
        Finset.univ.affineCombination_affineCombinationLineMapWeights t.points (Finset.mem_univ _)
          (Finset.mem_univ _)] at h₁' ⊢
      refine
        Sbtw.affineCombination_of_mem_affineSpan_pair t.independent hw
          (Finset.univ.sum_affineCombinationSingleWeights R (Finset.mem_univ _))
          (Finset.univ.sum_affineCombinationLineMapWeights (Finset.mem_univ _) (Finset.mem_univ _) _) h₁'
          (Finset.mem_univ i₁) ?_
      rw [Finset.affineCombinationSingleWeights_apply_self, Finset.affineCombinationLineMapWeights_apply_of_ne h₁₂ h₁₃,
        sbtw_one_zero_iff]
      have hs : ∀ i : Fin 3, SignType.sign (w i) = SignType.sign (w i₃) :=
        by
        intro i
        rcases h3 i with (rfl | rfl | rfl)
        · exact h₂s
        · exact h₁s
        · rfl
      have hss : SignType.sign (∑ i, w i) = 1 := by simp [hw]
      have hs' := sign_sum Finset.univ_nonempty (SignType.sign (w i₃)) fun i _ => hs i
      rw [hs'] at hss
      simp_rw [hss, sign_eq_one_iff] at hs
      refine ⟨hs i₁, ?_⟩
      rw [hu] at hw
      rw [Finset.sum_insert, Finset.sum_insert, Finset.sum_singleton] at hw
      · by_contra hle
        rw [not_lt] at hle
        exact (hle.trans_lt (lt_add_of_pos_right _ (Left.add_pos (hs i₂) (hs i₃)))).ne' hw
      · simpa using h₂₃
      · simpa [not_or] using ⟨h₁₂, h₁₃⟩
  [Elab.definition.header] [0.029190] sbtw_of_sbtw_of_sbtw_of_mem_affineSpan_pair
    [Elab.step] [0.013458] expected type: Prop, term
        NoZeroSMulDivisors R V
info: Mathlib/Analysis/Convex/Between.lean:744:0: [Elab.async] [0.375398] elaborating proof of sbtw_of_sbtw_of_sbtw_of_mem_affineSpan_pair
  [Elab.definition.value] [0.368189] sbtw_of_sbtw_of_sbtw_of_mem_affineSpan_pair
    [Elab.step] [0.352778] 
          have h₁₃ : i₁ ≠ i₃ := by
            rintro rfl
            simp at h₂
          have h₂₃ : i₂ ≠ i₃ := by
            rintro rfl
            simp at h₁
          have h3 : ∀ i : Fin 3, i = i₁ ∨ i = i₂ ∨ i = i₃ := by omega
          have hu : (Finset.univ : Finset (Fin 3)) = { i₁, i₂, i₃ } :=
            by
            clear h₁ h₂ h₁' h₂'
            decide +revert
          have hp : p ∈ affineSpan R (Set.range t.points) :=
            by
            have hle : line[R, t.points i₁, p₁] ≤ affineSpan R (Set.range t.points) :=
              by
              refine affineSpan_pair_le_of_mem_of_mem (mem_affineSpan R (Set.mem_range_self _)) ?_
              have hle : line[R, t.points i₂, t.points i₃] ≤ affineSpan R (Set.range t.points) :=
                by
                refine affineSpan_mono R ?_
[… 1038 lines omitted …]
                                                                      _a})
                                                              (Eq.symm
                                                                (Finset.affineCombination_affineCombinationLineMapWeights
                                                                  Finset.univ t.points (Finset.mem_univ i₂)
                                                                  (Finset.mem_univ i₃) r₁)))
                                                            (Eq.mp
                                                              (congrArg
                                                                (fun _a ↦
                                                                  (Finset.affineCombination R Finset.univ t.points) w ∈
                                                                    affineSpan R (insert _a ⋯))
                                                                (Eq.symm
                                                                  (Finset.affineCombination_affineCombinationSingleWeights
                                                                    R Finset.univ t.points (Finset.mem_univ i₁))))
                                                              h₁'))
                                                          h₂' h₁s)
                                                      fun h ↦
                                                      Eq.ndrec (motive := fun {i₃} ↦
                                                        i₁ ≠ i₃ →
                                                          i₂ ≠ i₃ →
                                                            (∀ (i : Fin 3), i = i₁ ∨ i = i₂ ∨ i = i₃) →
                                                              Finset.univ = {i₁, i₂, i₃} →
                                                                Sbtw R (t.points i₂) ⋯ (t.points i₃) → ⋯ → ⋯)
                                                        (fun h₁₃ h₂₃ h3 hu h₁ h₂ h₁' h₂' h₁s h₂s ↦
                                                          Eq.refl (SignType.sign (w i)))
                                                        h h₁₃ h₂₃ h3 hu h₁ h₂
                                                        (Eq.mp
                                                          (congrArg
                                                            (fun _a ↦
                                                              (Finset.affineCombination R Finset.univ t.points) w ∈
                                                                affineSpan R
                                                                  {(Finset.affineCombination R Finset.univ t.points)
                                                                      (Finset.affineCombinationSingleWeights R i₁),
                                                                    _a})
                                                            (Eq.symm
                                                              (Finset.affineCombination_affineCombinationLineMapWeights
                                                                Finset.univ t.points (Finset.mem_univ i₂)
                                                                (Finset.mem_univ i₃) r₁)))
                                                          (Eq.mp
                                                            (congrArg
                                                              (fun _a ↦
                                                                (Finset.affineCombination R Finset.univ t.points) w ∈
                                                                  affineSpan R (insert _a ⋯))
                                                              (Eq.symm
                                                                (Finset.affineCombination_affineCombinationSingleWeights
                                                                  R Finset.univ t.points (Finset.mem_univ i₁))))
                                                            h₁'))
                                                        h₂' h₁s h₂s;
                                                have hss :=
                                                  of_eq_true
                                                    (Eq.trans
                                                      (congrArg (fun x ↦ x = 1)
                                                        (Eq.trans (congrArg (⇑SignType.sign) hw)
                                                          (sign_pos (of_eq_true zero_lt_one._simp_1))))
                                                      (eq_self 1));
                                                have hs' :=
                                                  sign_sum Finset.univ_nonempty (SignType.sign (w i₃)) fun i x ↦ hs i;
                                                ⟨Eq.mp
                                                    (forall_congr fun i ↦
                                                      sbtw_of_sbtw_of_sbtw_of_mem_affineSpan_pair._simp_1_3)
                                                    (Eq.mp
                                                      (forall_congr fun i ↦
                                                        congrArg (Eq (SignType.sign (w i)))
                                                          (Eq.mp (congrArg (fun _a ↦ _a = 1) hs') hss))
                                                      hs)
                                                    i₁,
                                                  Decidable.byContradiction fun hle ↦
                                                    LT.lt.ne'
                                                      (LE.le.trans_lt
                                                        (Eq.mp (congrArg (fun _a ↦ _a) (propext not_lt)) hle)
                                                        (lt_add_of_pos_right (w i₁)
                                                          (Left.add_pos
                                                            (Eq.mp
                                                              (forall_congr fun i ↦
                                                                sbtw_of_sbtw_of_sbtw_of_mem_affineSpan_pair._simp_1_3)
                                                              (Eq.mp (forall_congr fun i ↦ ⋯) hs) i₂)
                                                            (Eq.mp
                                                              (forall_congr fun i ↦
                                                                sbtw_of_sbtw_of_sbtw_of_mem_affineSpan_pair._simp_1_3)
                                                              (Eq.mp (forall_congr fun i ↦ ⋯) hs) i₃))))
                                                      (Eq.mp
                                                        (congrArg (fun _a ↦ w i₁ + (w i₂ + _a) = 1)
                                                          (Finset.sum_singleton w i₃))
                                                        (Eq.mp
                                                          (congrArg (fun _a ↦ w i₁ + _a = 1)
                                                            (Finset.sum_insert
                                                              (Eq.mpr
                                                                (_root_.id (congrArg Not Finset.mem_singleton._simp_1))
                                                                h₂₃)))
                                                          (Eq.mp
                                                            (congrArg (fun _a ↦ _a = 1)
                                                              (Finset.sum_insert (Eq.mpr (_root_.id ⋯) ⟨h₁₂, h₁₃⟩)))
                                                            (Eq.mp (congrArg (fun _a ↦ ⋯ = 1) hu) hw))))⟩)))))))
                                  (Eq.symm right) hp h₁' h₂')
                          right h₂ h₂')
                right h₁ h₁'
info: Mathlib/Analysis/Convex/Between.lean:758:56: [Elab.async] [0.035119] Lean.addDecl
  [Kernel] [0.035088] ✅️ typechecking declarations [sbtw_of_sbtw_of_sbtw_of_mem_affineSpan_pair._proof_1_1]
info: Mathlib/Analysis/Convex/Between.lean:747:8: [Elab.async] [0.020899] Lean.addDecl
  [Kernel] [0.020849] ✅️ typechecking declarations [sbtw_of_sbtw_of_sbtw_of_mem_affineSpan_pair]
Build completed successfully (1510 jobs).
```

### Trace profiling of `sbtw_of_sbtw_of_sbtw_of_mem_affineSpan_pair` after PR 30993
```diff
diff --git a/Mathlib/Analysis/Convex/Between.lean b/Mathlib/Analysis/Convex/Between.lean
index c046576ad8..eed42b41c6 100644
--- a/Mathlib/Analysis/Convex/Between.lean
+++ b/Mathlib/Analysis/Convex/Between.lean
@@ -740,6 +740,7 @@ variable [Ring R] [LinearOrder R] [IsStrictOrderedRing R]
   [AddCommGroup V] [Module R V] [AddTorsor V P]
 variable {R}
 
+set_option trace.profiler true in
 /-- Suppose lines from two vertices of a triangle to interior points of the opposite side meet at
 `p`. Then `p` lies in the interior of the first (and by symmetry the other) segment from a
 vertex to the point on the opposite side. -/
@@ -801,14 +802,7 @@ theorem sbtw_of_sbtw_of_sbtw_of_mem_affineSpan_pair [NoZeroSMulDivisors R V]
   have hs' := sign_sum Finset.univ_nonempty (SignType.sign (w i₃)) fun i _ => hs i
   rw [hs'] at hss
   simp_rw [hss, sign_eq_one_iff] at hs
-  refine ⟨hs i₁, ?_⟩
-  rw [hu] at hw
-  rw [Finset.sum_insert, Finset.sum_insert, Finset.sum_singleton] at hw
-  · by_contra hle
-    rw [not_lt] at hle
-    exact (hle.trans_lt (lt_add_of_pos_right _ (Left.add_pos (hs i₂) (hs i₃)))).ne' hw
-  · simpa using h₂₃
-  · simpa [not_or] using ⟨h₁₂, h₁₃⟩
+  grind
 
 end LinearOrderedRing
 
```
```
ℹ [1510/1510] Built Mathlib.Analysis.Convex.Between (3.3s)
info: Mathlib/Analysis/Convex/Between.lean:744:0: [Elab.command] [0.036769] /--
    Suppose lines from two vertices of a triangle to interior points of the opposite side meet at
    `p`. Then `p` lies in the interior of the first (and by symmetry the other) segment from a
    vertex to the point on the opposite side. -/
    theorem sbtw_of_sbtw_of_sbtw_of_mem_affineSpan_pair [NoZeroSMulDivisors R V] {t : Affine.Triangle R P}
        {i₁ i₂ i₃ : Fin 3} (h₁₂ : i₁ ≠ i₂) {p₁ p₂ p : P} (h₁ : Sbtw R (t.points i₂) p₁ (t.points i₃))
        (h₂ : Sbtw R (t.points i₁) p₂ (t.points i₃)) (h₁' : p ∈ line[R, t.points i₁, p₁])
        (h₂' : p ∈ line[R, t.points i₂, p₂]) : Sbtw R (t.points i₁) p p₁ :=
      by
      have h₁₃ : i₁ ≠ i₃ := by
        rintro rfl
        simp at h₂
      have h₂₃ : i₂ ≠ i₃ := by
        rintro rfl
        simp at h₁
      have h3 : ∀ i : Fin 3, i = i₁ ∨ i = i₂ ∨ i = i₃ := by omega
      have hu : (Finset.univ : Finset (Fin 3)) = { i₁, i₂, i₃ } :=
        by
        clear h₁ h₂ h₁' h₂'
        decide +revert
      have hp : p ∈ affineSpan R (Set.range t.points) :=
        by
        have hle : line[R, t.points i₁, p₁] ≤ affineSpan R (Set.range t.points) :=
          by
          refine affineSpan_pair_le_of_mem_of_mem (mem_affineSpan R (Set.mem_range_self _)) ?_
          have hle : line[R, t.points i₂, t.points i₃] ≤ affineSpan R (Set.range t.points) :=
            by
            refine affineSpan_mono R ?_
            simp [Set.insert_subset_iff]
          rw [AffineSubspace.le_def'] at hle
          exact hle _ h₁.wbtw.mem_affineSpan
        rw [AffineSubspace.le_def'] at hle
        exact hle _ h₁'
      have h₁i := h₁.mem_image_Ioo
      have h₂i := h₂.mem_image_Ioo
      rw [Set.mem_image] at h₁i h₂i
      rcases h₁i with ⟨r₁, ⟨hr₁0, hr₁1⟩, rfl⟩
      rcases h₂i with ⟨r₂, ⟨hr₂0, hr₂1⟩, rfl⟩
      rcases eq_affineCombination_of_mem_affineSpan_of_fintype hp with ⟨w, hw, rfl⟩
      have h₁s :=
        sign_eq_of_affineCombination_mem_affineSpan_single_lineMap t.independent hw (Finset.mem_univ _)
          (Finset.mem_univ _) (Finset.mem_univ _) h₁₂ h₁₃ h₂₃ hr₁0 hr₁1 h₁'
      have h₂s :=
        sign_eq_of_affineCombination_mem_affineSpan_single_lineMap t.independent hw (Finset.mem_univ _)
          (Finset.mem_univ _) (Finset.mem_univ _) h₁₂.symm h₂₃ h₁₃ hr₂0 hr₂1 h₂'
      rw [← Finset.univ.affineCombination_affineCombinationSingleWeights R t.points (Finset.mem_univ i₁), ←
        Finset.univ.affineCombination_affineCombinationLineMapWeights t.points (Finset.mem_univ _)
          (Finset.mem_univ _)] at h₁' ⊢
      refine
        Sbtw.affineCombination_of_mem_affineSpan_pair t.independent hw
          (Finset.univ.sum_affineCombinationSingleWeights R (Finset.mem_univ _))
          (Finset.univ.sum_affineCombinationLineMapWeights (Finset.mem_univ _) (Finset.mem_univ _) _) h₁'
          (Finset.mem_univ i₁) ?_
      rw [Finset.affineCombinationSingleWeights_apply_self, Finset.affineCombinationLineMapWeights_apply_of_ne h₁₂ h₁₃,
        sbtw_one_zero_iff]
      have hs : ∀ i : Fin 3, SignType.sign (w i) = SignType.sign (w i₃) :=
        by
        intro i
        rcases h3 i with (rfl | rfl | rfl)
        · exact h₂s
        · exact h₁s
        · rfl
      have hss : SignType.sign (∑ i, w i) = 1 := by simp [hw]
      have hs' := sign_sum Finset.univ_nonempty (SignType.sign (w i₃)) fun i _ => hs i
      rw [hs'] at hss
      simp_rw [hss, sign_eq_one_iff] at hs
      grind
  [Elab.definition.header] [0.027384] sbtw_of_sbtw_of_sbtw_of_mem_affineSpan_pair
    [Elab.step] [0.013866] expected type: Prop, term
        NoZeroSMulDivisors R V
info: Mathlib/Analysis/Convex/Between.lean:744:0: [Elab.async] [0.517542] elaborating proof of sbtw_of_sbtw_of_sbtw_of_mem_affineSpan_pair
  [Elab.definition.value] [0.510462] sbtw_of_sbtw_of_sbtw_of_mem_affineSpan_pair
    [Elab.step] [0.494049] 
          have h₁₃ : i₁ ≠ i₃ := by
            rintro rfl
            simp at h₂
          have h₂₃ : i₂ ≠ i₃ := by
            rintro rfl
            simp at h₁
          have h3 : ∀ i : Fin 3, i = i₁ ∨ i = i₂ ∨ i = i₃ := by omega
          have hu : (Finset.univ : Finset (Fin 3)) = { i₁, i₂, i₃ } :=
            by
            clear h₁ h₂ h₁' h₂'
            decide +revert
          have hp : p ∈ affineSpan R (Set.range t.points) :=
            by
            have hle : line[R, t.points i₁, p₁] ≤ affineSpan R (Set.range t.points) :=
              by
              refine affineSpan_pair_le_of_mem_of_mem (mem_affineSpan R (Set.mem_range_self _)) ?_
              have hle : line[R, t.points i₂, t.points i₃] ≤ affineSpan R (Set.range t.points) :=
                by
                refine affineSpan_mono R ?_
                simp [Set.insert_subset_iff]
              rw [AffineSubspace.le_def'] at hle
              exact hle _ h₁.wbtw.mem_affineSpan
            rw [AffineSubspace.le_def'] at hle
            exact hle _ h₁'
          have h₁i := h₁.mem_image_Ioo
          have h₂i := h₂.mem_image_Ioo
[… 1050 lines omitted …]
                                                                (Finset.affineCombination R Finset.univ t.points) w ∈
                                                                  affineSpan R {_a, ⋯ r₁})
                                                              (Eq.symm
                                                                (Finset.affineCombination_affineCombinationSingleWeights
                                                                  R Finset.univ t.points (Finset.mem_univ i₁))))
                                                            h₁'))
                                                        h₂' h₂s)
                                                    fun h ↦
                                                    Or.casesOn h
                                                      (fun h ↦
                                                        Eq.ndrec (motive := fun {i₂} ↦
                                                          i₁ ≠ i₂ →
                                                            i₂ ≠ i₃ →
                                                              (∀ (i : Fin 3), i = i₁ ∨ i = i₂ ∨ i = i₃) →
                                                                Finset.univ = {i₁, i₂, i₃} →
                                                                  Sbtw R (t.points i₂) ⋯ (t.points i₃) → ⋯ → ⋯)
                                                          (fun h₁₂ h₂₃ h3 hu h₁ h₁' h₂' h₁s ↦ h₁s) h h₁₂ h₂₃ h3 hu h₁
                                                          (Eq.mp
                                                            (congrArg
                                                              (fun _a ↦
                                                                (Finset.affineCombination R Finset.univ t.points) w ∈
                                                                  affineSpan R
                                                                    {(Finset.affineCombination R Finset.univ t.points)
                                                                        (Finset.affineCombinationSingleWeights R i₁),
                                                                      _a})
                                                              (Eq.symm
                                                                (Finset.affineCombination_affineCombinationLineMapWeights
                                                                  Finset.univ t.points (Finset.mem_univ i₂)
                                                                  (Finset.mem_univ i₃) r₁)))
                                                            (Eq.mp
                                                              (congrArg
                                                                (fun _a ↦
                                                                  (Finset.affineCombination R Finset.univ t.points) w ∈
                                                                    affineSpan R (insert _a ⋯))
                                                                (Eq.symm
                                                                  (Finset.affineCombination_affineCombinationSingleWeights
                                                                    R Finset.univ t.points (Finset.mem_univ i₁))))
                                                              h₁'))
                                                          h₂' h₁s)
                                                      fun h ↦
                                                      Eq.ndrec (motive := fun {i₃} ↦
                                                        i₁ ≠ i₃ →
                                                          i₂ ≠ i₃ →
                                                            (∀ (i : Fin 3), i = i₁ ∨ i = i₂ ∨ i = i₃) →
                                                              Finset.univ = {i₁, i₂, i₃} →
                                                                Sbtw R (t.points i₂) ⋯ (t.points i₃) → ⋯ → ⋯)
                                                        (fun h₁₃ h₂₃ h3 hu h₁ h₂ h₁' h₂' h₁s h₂s ↦
                                                          Eq.refl (SignType.sign (w i)))
                                                        h h₁₃ h₂₃ h3 hu h₁ h₂
                                                        (Eq.mp
                                                          (congrArg
                                                            (fun _a ↦
                                                              (Finset.affineCombination R Finset.univ t.points) w ∈
                                                                affineSpan R
                                                                  {(Finset.affineCombination R Finset.univ t.points)
                                                                      (Finset.affineCombinationSingleWeights R i₁),
                                                                    _a})
                                                            (Eq.symm
                                                              (Finset.affineCombination_affineCombinationLineMapWeights
                                                                Finset.univ t.points (Finset.mem_univ i₂)
                                                                (Finset.mem_univ i₃) r₁)))
                                                          (Eq.mp
                                                            (congrArg
                                                              (fun _a ↦
                                                                (Finset.affineCombination R Finset.univ t.points) w ∈
                                                                  affineSpan R (insert _a ⋯))
                                                              (Eq.symm
                                                                (Finset.affineCombination_affineCombinationSingleWeights
                                                                  R Finset.univ t.points (Finset.mem_univ i₁))))
                                                            h₁'))
                                                        h₂' h₁s h₂s;
                                                have hss :=
                                                  of_eq_true
                                                    (Eq.trans
                                                      (congrArg (fun x ↦ x = 1)
                                                        (Eq.trans (congrArg (⇑SignType.sign) hw)
                                                          (sign_pos (of_eq_true zero_lt_one._simp_1))))
                                                      (eq_self 1));
                                                have hs' :=
                                                  sign_sum Finset.univ_nonempty (SignType.sign (w i₃)) fun i x ↦ hs i;
                                                sbtw_of_sbtw_of_sbtw_of_mem_affineSpan_pair._proof_1_4 h₁₂ h₁₃ h₂₃ hu w
                                                  hw
                                                  (Eq.mp
                                                    (forall_congr fun i ↦
                                                      sbtw_of_sbtw_of_sbtw_of_mem_affineSpan_pair._simp_1_3)
                                                    (Eq.mp
                                                      (forall_congr fun i ↦
                                                        congrArg (Eq (SignType.sign (w i)))
                                                          (Eq.mp (congrArg (fun _a ↦ _a = 1) hs') hss))
                                                      hs)))))))))
                                  (Eq.symm right) hp h₁' h₂')
                          right h₂ h₂')
                right h₁ h₁'
info: Mathlib/Analysis/Convex/Between.lean:758:56: [Elab.async] [0.034446] Lean.addDecl
  [Kernel] [0.034414] ✅️ typechecking declarations [sbtw_of_sbtw_of_sbtw_of_mem_affineSpan_pair._proof_1_1]
info: Mathlib/Analysis/Convex/Between.lean:805:2: [Elab.async] [0.010829] Lean.addDecl
  [Kernel] [0.010814] ✅️ typechecking declarations [sbtw_of_sbtw_of_sbtw_of_mem_affineSpan_pair._proof_1_4]
info: Mathlib/Analysis/Convex/Between.lean:747:8: [Elab.async] [0.019719] Lean.addDecl
  [Kernel] [0.019644] ✅️ typechecking declarations [sbtw_of_sbtw_of_sbtw_of_mem_affineSpan_pair]
Build completed successfully (1510 jobs).
```
</details>

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include at least one commit authored by each
co-author among the commits in the pull request. If necessary, you may 
create empty commits to indicate co-authorship, using commands like so:

git commit --author="Author Name <author@email.com>" --allow-empty -m "add Author Name as coauthor"

When merging, all the commits will be squashed into a single commit listing all co-authors.

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
