### PR TITLE
[Merged by Bors] - chore: deprecate duplicate Quotient{,Add}Group.kerLift_mk'

### DIFF
--- a/Mathlib/GroupTheory/QuotientGroup/Basic.lean
+++ b/Mathlib/GroupTheory/QuotientGroup/Basic.lean
@@ -81,9 +81,10 @@ def kerLift : G ⧸ ker φ →* H :=
 theorem kerLift_mk (g : G) : (kerLift φ) g = φ g :=
   rfl
 
-@[to_additive (attr := simp)]
-theorem kerLift_mk' (g : G) : (kerLift φ) (mk g) = φ g :=
-  lift_mk' _ _ _
+@[deprecated (since := "2025-10-28")]
+alias _root_.QuotientAddGroup.kerLift_mk' := _root_.QuotientAddGroup.kerLift_mk
+@[to_additive existing, deprecated (since := "2025-10-28")]
+alias kerLift_mk' := kerLift_mk
 
 @[to_additive]
 theorem kerLift_injective : Injective (kerLift φ) := fun a b =>
@@ -125,7 +126,7 @@ def quotientKerEquivOfRightInverse (ψ : H → G) (hφ : RightInverse ψ φ) : G
   { kerLift φ with
     toFun := kerLift φ
     invFun := mk ∘ ψ
-    left_inv := fun x => kerLift_injective φ (by rw [Function.comp_apply, kerLift_mk', hφ])
+    left_inv := fun x => kerLift_injective φ (by rw [Function.comp_apply, kerLift_mk, hφ])
     right_inv := hφ }
 
 /-- The canonical isomorphism `G/⊥ ≃* G`. -/


### PR DESCRIPTION
These were syntactically different in lean 3, but not in lean 4 due to the coercion expansion.


---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include at least one commit authored by each
co-author among the commits in the pull request. If necessary, you may 
create empty commits to indicate co-authorship, using commands like so:

git commit --author="Author Name <author@email.com>" --allow-empty -m "add Author Name as coauthor"

When merging, all the commits will be squashed into a single commit listing all co-authors.

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
