### PR TITLE
[Merged by Bors] - doc: mention freeness in `IsCancelSMul`

### DIFF
--- a/Mathlib/Algebra/Group/Action/Basic.lean
+++ b/Mathlib/Algebra/Group/Action/Basic.lean
@@ -62,6 +62,13 @@ lemma smul_left_cancel_iff (g : α) {x y : β} : g • x = g • y ↔ x = y :=
 lemma smul_eq_iff_eq_inv_smul (g : α) {x y : β} : g • x = y ↔ x = g⁻¹ • y :=
   (MulAction.toPerm g).apply_eq_iff_eq_symm_apply
 
+@[to_additive]
+lemma isCancelSMul_iff_eq_one_of_smul_eq :
+    IsCancelSMul α β ↔ (∀ (g : α) (x : β), g • x = x → g = 1) := by
+  refine ⟨fun H _ _ ↦ IsCancelSMul.eq_one_of_smul, fun H ↦ ⟨fun g h x ↦ ?_⟩⟩
+  rw [smul_eq_iff_eq_inv_smul, eq_comm, ← mul_smul, ← inv_mul_eq_one (G := α)]
+  exact H (g⁻¹ * h) x
+
 end Group
 
 section Monoid

--- a/Mathlib/Algebra/Group/Action/Defs.lean
+++ b/Mathlib/Algebra/Group/Action/Defs.lean
@@ -590,7 +590,9 @@ lemma IsLeftCancelSMul.left_cancel {G P} [SMul G P] [IsLeftCancelSMul G P] (a : 
 instance [LeftCancelMonoid G] : IsLeftCancelSMul G G where
   left_cancel' := IsLeftCancelMul.mul_left_cancel
 
-/-- A vector addition is cancellative if it is pointwise injective on the left and right. -/
+/-- A vector addition is cancellative if it is pointwise injective on the left and right.
+
+A group action is cancellative in this sense if and only if it is **free**. -/
 class IsCancelVAdd [VAdd G P] : Prop extends IsLeftCancelVAdd G P where
   protected right_cancel' : ∀ (a b : G) (c : P), a +ᵥ c = b +ᵥ c → a = b
 

--- a/Mathlib/Algebra/Group/Action/Defs.lean
+++ b/Mathlib/Algebra/Group/Action/Defs.lean
@@ -612,6 +612,11 @@ lemma IsCancelSMul.right_cancel {G P} [SMul G P] [IsCancelSMul G P] (a b : G) (c
     a • c = b • c → a = b := IsCancelSMul.right_cancel' a b c
 
 @[to_additive]
+lemma IsCancelSMul.eq_one_of_smul {G P} [Monoid G] [MulAction G P] [IsCancelSMul G P] {g : G}
+    {x : P} (h : g • x = x) : g = 1 :=
+  IsCancelSMul.right_cancel g 1 x ((one_smul G x).symm ▸ h)
+
+@[to_additive]
 instance [CancelMonoid G] : IsCancelSMul G G where
   left_cancel' := IsLeftCancelMul.mul_left_cancel
   right_cancel' _ _ _ := mul_right_cancel

--- a/Mathlib/Algebra/Group/Action/Defs.lean
+++ b/Mathlib/Algebra/Group/Action/Defs.lean
@@ -594,7 +594,9 @@ instance [LeftCancelMonoid G] : IsLeftCancelSMul G G where
 class IsCancelVAdd [VAdd G P] : Prop extends IsLeftCancelVAdd G P where
   protected right_cancel' : ∀ (a b : G) (c : P), a +ᵥ c = b +ᵥ c → a = b
 
-/-- A scalar multiplication is cancellative if it is pointwise injective on the left and right. -/
+/-- A scalar multiplication is cancellative if it is pointwise injective on the left and right.
+
+A group action is cancellative in this sense if and only if it is **free**. -/
 @[to_additive]
 class IsCancelSMul [SMul G P] : Prop extends IsLeftCancelSMul G P where
   protected right_cancel' : ∀ (a b : G) (c : P), a • c = b • c → a = b

--- a/Mathlib/Algebra/Group/Action/Defs.lean
+++ b/Mathlib/Algebra/Group/Action/Defs.lean
@@ -592,13 +592,15 @@ instance [LeftCancelMonoid G] : IsLeftCancelSMul G G where
 
 /-- A vector addition is cancellative if it is pointwise injective on the left and right.
 
-A group action is cancellative in this sense if and only if it is **free**. -/
+A group action is cancellative in this sense if and only if it is **free**.
+See `isCancelVAdd_iff_eq_zero_of_vadd_eq` for a more familiar condition. -/
 class IsCancelVAdd [VAdd G P] : Prop extends IsLeftCancelVAdd G P where
   protected right_cancel' : ∀ (a b : G) (c : P), a +ᵥ c = b +ᵥ c → a = b
 
 /-- A scalar multiplication is cancellative if it is pointwise injective on the left and right.
 
-A group action is cancellative in this sense if and only if it is **free**. -/
+A group action is cancellative in this sense if and only if it is **free**.
+See `isCancelSMul_iff_eq_one_of_smul_eq` for a more familiar condition. -/
 @[to_additive]
 class IsCancelSMul [SMul G P] : Prop extends IsLeftCancelSMul G P where
   protected right_cancel' : ∀ (a b : G) (c : P), a • c = b • c → a = b

--- a/Mathlib/GroupTheory/GroupAction/Basic.lean
+++ b/Mathlib/GroupTheory/GroupAction/Basic.lean
@@ -233,9 +233,16 @@ lemma orbitRel_le_snd :
 end Orbit
 
 section Stabilizer
-variable (G)
 
-variable {G}
+@[to_additive (attr := simp)]
+lemma _root_.IsCancelSMul.stabilizer_eq_bot [IsCancelSMul G α] (a : α) :
+    stabilizer G a = ⊥ :=
+  Subgroup.eq_bot_iff_forall _ |>.mpr fun _ hg ↦ IsCancelSMul.eq_one_of_smul hg
+
+@[to_additive]
+lemma _root_.isCancelSMul_iff_stabilizer_eq_bot :
+    IsCancelSMul G α ↔ (∀ a : α, stabilizer G a = ⊥) := by
+  simp [isCancelSMul_iff_eq_one_of_smul_eq, Subgroup.eq_bot_iff_forall, forall_swap (α := G)]
 
 /-- If the stabilizer of `a` is `S`, then the stabilizer of `g • a` is `gSg⁻¹`. -/
 theorem stabilizer_smul_eq_stabilizer_map_conj (g : G) (a : α) :

--- a/Mathlib/GroupTheory/GroupAction/Quotient.lean
+++ b/Mathlib/GroupTheory/GroupAction/Quotient.lean
@@ -339,7 +339,7 @@ action of a subgroup and the quotient group. -/
 @[to_additive /-- Given an additive group acting freely and transitively, an equivalence between the
 orbits under the action of an additive subgroup and the quotient group. -/]
 noncomputable def equivSubgroupOrbitsQuotientGroup [IsPretransitive α β]
-    (free : ∀ y : β, MulAction.stabilizer α y = ⊥) (H : Subgroup α) :
+    [IsCancelSMul α β] (H : Subgroup α) :
     orbitRel.Quotient H β ≃ α ⧸ H where
   toFun := fun q ↦ q.liftOn' (fun y ↦ (exists_smul_eq α y x).choose) (by
     intro y₁ y₂ h
@@ -350,11 +350,9 @@ noncomputable def equivSubgroupOrbitsQuotientGroup [IsPretransitive α β]
     dsimp only
     suffices (exists_smul_eq α (g • y₂) x).choose = (exists_smul_eq α y₂ x).choose * g⁻¹ by
       simp [this]
-    rw [← inv_mul_eq_one, ← Subgroup.mem_bot, ← free ((g : α) • y₂)]
-    simp only [mem_stabilizer_iff, smul_smul, mul_assoc, InvMemClass.coe_inv, inv_mul_cancel,
-               mul_one]
-    rw [← smul_smul, (exists_smul_eq α y₂ x).choose_spec, inv_smul_eq_iff,
-        (exists_smul_eq α ((g : α) • y₂) x).choose_spec])
+    refine IsCancelSMul.right_cancel _ _ (g • y₂) ?_
+    rw [(exists_smul_eq α (g • y₂) x).choose_spec, Subgroup.smul_def, Subgroup.coe_inv,
+        smul_smul, inv_mul_cancel_right, (exists_smul_eq α y₂ x).choose_spec])
   invFun := fun q ↦ q.liftOn' (fun g ↦ ⟦g⁻¹ • x⟧) (by
     intro g₁ g₂ h
     rw [leftRel_eq] at h
@@ -373,8 +371,9 @@ noncomputable def equivSubgroupOrbitsQuotientGroup [IsPretransitive α β]
     rw [Quotient.eq'', leftRel_eq]
     simp only
     convert one_mem H
-    · rw [inv_mul_eq_one, eq_comm, ← inv_mul_eq_one, ← Subgroup.mem_bot, ← free (g⁻¹ • x),
-        mem_stabilizer_iff, mul_smul, (exists_smul_eq α (g⁻¹ • x) x).choose_spec]
+    rw [inv_mul_eq_one, eq_comm, ← inv_mul_eq_one, ← Subgroup.mem_bot,
+        ← IsCancelSMul.stabilizer_eq_bot (g⁻¹ • x), mem_stabilizer_iff, mul_smul,
+        (exists_smul_eq α (g⁻¹ • x) x).choose_spec]
 
 /-- If `α` acts on `β` with trivial stabilizers, `β` is equivalent
 to the product of the quotient of `β` by `α` and `α`.


### PR DESCRIPTION
Future work: come up with a mechanism for discovering these. I would advocate for a permanently deprecated alias `IsFreeAction` just for that purpose.

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include at least one commit authored by each
co-author among the commits in the pull request. If necessary, you may 
create empty commits to indicate co-authorship, using commands like so:

git commit --author="Author Name <author@email.com>" --allow-empty -m "add Author Name as coauthor"

When merging, all the commits will be squashed into a single commit listing all co-authors.

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

Zulip discussion: https://leanprover.zulipchat.com/#narrow/channel/217875-Is-there-code-for-X.3F/topic/Free.20actions/near/546328709

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
