### PR TITLE
[Merged by Bors] - feat: sums of meromorphic functions are meromorphic

### DIFF
--- a/Mathlib/Analysis/Meromorphic/Basic.lean
+++ b/Mathlib/Analysis/Meromorphic/Basic.lean
@@ -117,7 +117,7 @@ theorem prod {ι : Type*} {s : Finset ι} {f : ι → 𝕜 → 𝕜} {x : 𝕜}
   classical
   induction s using Finset.induction with
   | empty =>
-    simp only [Finset.prod_empty]
+    rw [Finset.prod_empty]
     exact analyticAt_const.meromorphicAt
   | insert σ s hσ hind =>
     rw [Finset.prod_insert hσ]

--- a/Mathlib/Analysis/Meromorphic/Basic.lean
+++ b/Mathlib/Analysis/Meromorphic/Basic.lean
@@ -55,7 +55,7 @@ namespace MeromorphicAt
 @[fun_prop]
 lemma id (x : 𝕜) : MeromorphicAt id x := analyticAt_id.meromorphicAt
 
-@[fun_prop]
+@[fun_prop, simp]
 lemma const (e : E) (x : 𝕜) : MeromorphicAt (fun _ ↦ e) x :=
   analyticAt_const.meromorphicAt
 
@@ -109,7 +109,7 @@ lemma fun_mul {f g : 𝕜 → 𝕜} {x : 𝕜} (hf : MeromorphicAt f x) (hg : Me
 
 @[deprecated (since := "2025-05-09")] alias mul' := fun_mul
 
-/-- Finite products of meromorphic functions are analytic. -/
+/-- Finite products of meromorphic functions are meromorphic. -/
 @[fun_prop]
 theorem prod {ι : Type*} {s : Finset ι} {f : ι → 𝕜 → 𝕜} {x : 𝕜}
     (h : ∀ σ, MeromorphicAt (f σ) x) :
@@ -117,18 +117,39 @@ theorem prod {ι : Type*} {s : Finset ι} {f : ι → 𝕜 → 𝕜} {x : 𝕜}
   classical
   induction s using Finset.induction with
   | empty =>
-    rw [Finset.prod_empty]
+    simp only [Finset.prod_empty]
     exact analyticAt_const.meromorphicAt
   | insert σ s hσ hind =>
     rw [Finset.prod_insert hσ]
     exact (h σ).mul hind
 
-/-- Finite products of meromorphic functions are analytic. -/
+/-- Finite products of meromorphic functions are meromorphic. -/
 @[fun_prop]
 theorem fun_prod {ι : Type*} {s : Finset ι} {f : ι → 𝕜 → 𝕜} {x : 𝕜}
     (h : ∀ σ, MeromorphicAt (f σ) x) :
     MeromorphicAt (fun z ↦ ∏ n ∈ s, f n z) x := by
   convert prod h (s := s)
+  simp
+
+/-- Finite sums of meromorphic functions are meromorphic. -/
+@[fun_prop]
+theorem sum {ι : Type*} {s : Finset ι} {f : ι → 𝕜 → E} {x : 𝕜} (h : ∀ σ, MeromorphicAt (f σ) x) :
+    MeromorphicAt (∑ n ∈ s, f n) x := by
+  classical
+  induction s using Finset.induction with
+  | empty =>
+    simp only [Finset.sum_empty]
+    exact analyticAt_const.meromorphicAt
+  | insert σ s hσ hind =>
+    rw [Finset.sum_insert hσ]
+    exact (h σ).add hind
+
+/-- Finite sums of meromorphic functions are meromorphic. -/
+@[fun_prop]
+theorem fun_sum {ι : Type*} {s : Finset ι} {f : ι → 𝕜 → E} {x : 𝕜}
+    (h : ∀ σ, MeromorphicAt (f σ) x) :
+    MeromorphicAt (fun z ↦ ∑ n ∈ s, f n z) x := by
+  convert sum h (s := s)
   simp
 
 @[fun_prop]
@@ -401,17 +422,28 @@ lemma mul : MeromorphicOn (s * t) U := fun x hx ↦ (hs x hx).mul (ht x hx)
 include hs ht in
 lemma fun_mul : MeromorphicOn (fun z ↦ s z * t z) U := fun x hx ↦ (hs x hx).mul (ht x hx)
 
-/-- Finite products of meromorphic functions are analytic. -/
+/-- Finite products of meromorphic functions are meromorphic. -/
 lemma prod {U : Set 𝕜} {ι : Type*} {s : Finset ι} {f : ι → 𝕜 → 𝕜}
     (h : ∀ σ, MeromorphicOn (f σ) U) :
     MeromorphicOn (∏ n ∈ s, f n) U :=
   fun z hz ↦ MeromorphicAt.prod (fun σ ↦ h σ z hz)
 
-/-- Finite products of meromorphic functions are analytic. -/
+/-- Finite products of meromorphic functions are meromorphic. -/
 lemma fun_prod {U : Set 𝕜} {ι : Type*} {s : Finset ι} {f : ι → 𝕜 → 𝕜}
     (h : ∀ σ, MeromorphicOn (f σ) U) :
     MeromorphicOn (fun z ↦ ∏ n ∈ s, f n z) U :=
   fun z hz ↦ MeromorphicAt.fun_prod (fun σ ↦ h σ z hz)
+
+/-- Finite sums of meromorphic functions are meromorphic. -/
+lemma sum {U : Set 𝕜} {ι : Type*} {s : Finset ι} {f : ι → 𝕜 → E} (h : ∀ σ, MeromorphicOn (f σ) U) :
+    MeromorphicOn (∑ n ∈ s, f n) U :=
+  fun z hz ↦ MeromorphicAt.sum (fun σ ↦ h σ z hz)
+
+/-- Finite sums of meromorphic functions are meromorphic. -/
+lemma fun_sum {U : Set 𝕜} {ι : Type*} {s : Finset ι} {f : ι → 𝕜 → E}
+    (h : ∀ σ, MeromorphicOn (f σ) U) :
+    MeromorphicOn (fun z ↦ ∑ n ∈ s, f n z) U :=
+  fun z hz ↦ MeromorphicAt.fun_sum (fun σ ↦ h σ z hz)
 
 include hs in
 lemma inv : MeromorphicOn s⁻¹ U := fun x hx ↦ (hs x hx).inv


### PR DESCRIPTION
In complete analogy to existing statements about products, establish in very few lines that sums of meromorphic functions are meromorphic. Fix several docstrings.

---

This is Mark II of my original PR #30587. I decided to open a new, clean PR after the original PR became too messy because of substantial changes to the original PR that then needed to be reverted.


<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include at least one commit authored by each
co-author among the commits in the pull request. If necessary, you may 
create empty commits to indicate co-authorship, using commands like so:

git commit --author="Author Name <author@email.com>" --allow-empty -m "add Author Name as coauthor"

When merging, all the commits will be squashed into a single commit listing all co-authors.

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
