### PR TITLE
[Merged by Bors] - chore: deprecate `AsLinearOrder`

### DIFF
--- a/Mathlib/Order/Basic.lean
+++ b/Mathlib/Order/Basic.lean
@@ -21,8 +21,6 @@ classes and allows to transfer order instances.
 ## Type synonyms
 
 * `OrderDual α` : A type synonym reversing the meaning of all inequalities, with notation `αᵒᵈ`.
-* `AsLinearOrder α`: A type synonym to promote `PartialOrder α` to `LinearOrder α` using
-  `IsTotal α (≤)`.
 
 ### Transferring orders
 
@@ -1400,16 +1398,20 @@ instance Prop.partialOrder : PartialOrder Prop where
 
 end «Prop»
 
-/-! ### Linear order from a total partial order -/
+/-- Type synonym to create an instance of `LinearOrder` from a `PartialOrder` and `IsTotal α (≤)`.
 
-
-/-- Type synonym to create an instance of `LinearOrder` from a `PartialOrder` and `IsTotal α (≤)` -/
+**Do not use this**: instead, build a `LinearOrder` instance directly. -/
+@[deprecated "build a `LinearOrder` instance directly instead" (since := "2025-10-28")]
 def AsLinearOrder (α : Type*) :=
   α
 
+set_option linter.deprecated false in
+@[deprecated "`AsLinearOrder` is deprecated" (since := "2025-10-28")]
 instance [Inhabited α] : Inhabited (AsLinearOrder α) :=
   ⟨(default : α)⟩
 
+set_option linter.deprecated false in
+@[deprecated "`AsLinearOrder` is deprecated" (since := "2025-10-28")]
 noncomputable instance AsLinearOrder.linearOrder [PartialOrder α] [IsTotal α (· ≤ ·)] :
     LinearOrder (AsLinearOrder α) where
   __ := inferInstanceAs (PartialOrder α)


### PR DESCRIPTION
This goes back to Lean 3 (https://github.com/leanprover-community/mathlib3/pull/4037). It was used to prove two results about "linearly ordered lattices" [`le_sup_iff`](https://leanprover-community.github.io/mathlib4_docs/Mathlib/Order/Lattice.html#le_sup_iff) and [`inf_le_iff`](https://leanprover-community.github.io/mathlib4_docs/Mathlib/Order/Lattice.html#inf_le_iff) which have long since been turned into theorems on linear orders. The proper way to deal with a totally ordered partial order is to just write a `LinearOrder` instance, so there is no need for this.

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include at least one commit authored by each
co-author among the commits in the pull request. If necessary, you may 
create empty commits to indicate co-authorship, using commands like so:

git commit --author="Author Name <author@email.com>" --allow-empty -m "add Author Name as coauthor"

When merging, all the commits will be squashed into a single commit listing all co-authors.

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

See some brief [Zulip](https://leanprover.zulipchat.com/#narrow/channel/287929-mathlib4/topic/AsLinearOrder/near/547525036) discussion.

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
