### PR TITLE
[Merged by Bors] - chore: deprecate frobenius_xxx lemmas

### DIFF
--- a/Mathlib/Algebra/CharP/Frobenius.lean
+++ b/Mathlib/Algebra/CharP/Frobenius.lean
@@ -70,9 +70,11 @@ lemma coe_iterateFrobenius_mul : iterateFrobenius R p (m * n) = (iterateFrobeniu
 
 variable {R}
 
+@[deprecated map_mul (since := "2025-10-28")]
 lemma frobenius_mul : frobenius R p (x * y) = frobenius R p x * frobenius R p y :=
   map_mul (frobenius R p) x y
 
+@[deprecated map_one (since := "2025-10-28")]
 lemma frobenius_one : frobenius R p 1 = 1 := one_pow _
 
 lemma MonoidHom.map_frobenius : f (frobenius R p x) = frobenius S p (f x) := map_pow f x p
@@ -129,12 +131,15 @@ theorem LinearMap.frobenius_def [Algebra R S] (x : S) : frobenius R S p x = x ^ 
 theorem LinearMap.iterateFrobenius_def [Algebra R S] (n : ℕ) (x : S) :
     iterateFrobenius R S p n x = x ^ p ^ n := rfl
 
+@[deprecated map_zero (since := "2025-10-28")]
 theorem frobenius_zero : frobenius R p 0 = 0 :=
   (frobenius R p).map_zero
 
+@[deprecated map_add (since := "2025-10-28")]
 theorem frobenius_add : frobenius R p (x + y) = frobenius R p x + frobenius R p y :=
   (frobenius R p).map_add x y
 
+@[deprecated map_natCast (since := "2025-10-28")]
 theorem frobenius_natCast (n : ℕ) : frobenius R p n = n :=
   map_natCast (frobenius R p) n
 
@@ -144,8 +149,10 @@ section CommRing
 
 variable {R : Type*} [CommRing R] (p : ℕ) [ExpChar R p] (x y : R)
 
+@[deprecated map_neg (since := "2025-10-28")]
 lemma frobenius_neg : frobenius R p (-x) = -frobenius R p x := map_neg ..
 
+@[deprecated map_sub (since := "2025-10-28")]
 lemma frobenius_sub : frobenius R p (x - y) = frobenius R p x - frobenius R p y := map_sub ..
 
 end CommRing

--- a/Mathlib/FieldTheory/PerfectClosure.lean
+++ b/Mathlib/FieldTheory/PerfectClosure.lean
@@ -115,7 +115,7 @@ private theorem mul_aux_left (x1 x2 y : ℕ × K) (H : R K p x1 x2) :
   match x1, x2, H with
   | _, _, R.intro n x =>
     Quot.sound <| by
-      rw [← iterate_succ_apply, iterate_succ_apply', iterate_succ_apply', ← frobenius_mul,
+      rw [← iterate_succ_apply, iterate_succ_apply', iterate_succ_apply', ← map_mul,
         Nat.succ_add]
       apply R.intro
 
@@ -125,7 +125,7 @@ private theorem mul_aux_right (x y1 y2 : ℕ × K) (H : R K p y1 y2) :
   match y1, y2, H with
   | _, _, R.intro n y =>
     Quot.sound <| by
-      rw [← iterate_succ_apply, iterate_succ_apply', iterate_succ_apply', ← frobenius_mul]
+      rw [← iterate_succ_apply, iterate_succ_apply', iterate_succ_apply', ← map_mul]
       apply R.intro
 
 instance instMul : Mul (PerfectClosure K p) :=
@@ -179,7 +179,7 @@ private theorem add_aux_left (x1 x2 y : ℕ × K) (H : R K p x1 x2) :
   match x1, x2, H with
   | _, _, R.intro n x =>
     Quot.sound <| by
-      rw [← iterate_succ_apply, iterate_succ_apply', iterate_succ_apply', ← frobenius_add,
+      rw [← iterate_succ_apply, iterate_succ_apply', iterate_succ_apply', ← map_add,
         Nat.succ_add]
       apply R.intro
 
@@ -189,7 +189,7 @@ private theorem add_aux_right (x y1 y2 : ℕ × K) (H : R K p y1 y2) :
   match y1, y2, H with
   | _, _, R.intro n y =>
     Quot.sound <| by
-      rw [← iterate_succ_apply, iterate_succ_apply', iterate_succ_apply', ← frobenius_add]
+      rw [← iterate_succ_apply, iterate_succ_apply', iterate_succ_apply', ← map_add]
       apply R.intro
 
 instance instAdd : Add (PerfectClosure K p) :=
@@ -211,7 +211,7 @@ theorem mk_add_mk (x y : ℕ × K) :
 instance instNeg : Neg (PerfectClosure K p) :=
   ⟨Quot.lift (fun x : ℕ × K => mk K p (x.1, -x.2)) fun x y (H : R K p x y) =>
       match x, y, H with
-      | _, _, R.intro n x => Quot.sound <| by rw [← frobenius_neg]; apply R.intro⟩
+      | _, _, R.intro n x => Quot.sound <| by rw [← map_neg]; apply R.intro⟩
 
 @[simp]
 theorem neg_mk (x : ℕ × K) : -mk K p x = mk K p (x.1, -x.2) :=
@@ -237,7 +237,7 @@ theorem mk_zero_right (n : ℕ) : mk K p (n, 0) = 0 := by
     rw [← ih]
     apply (Quot.sound _).symm
     have := R.intro (p := p) n (0 : K)
-    rwa [frobenius_zero K p] at this
+    rwa [map_zero] at this
 
 theorem R.sound (m n : ℕ) (x y : K) (H : (frobenius K p)^[m] x = y) :
     mk K p (n, x) = mk K p (m + n, y) := by
@@ -349,7 +349,7 @@ theorem natCast (n x : ℕ) : (x : PerfectClosure K p) = mk K p (n, x) := by
   | succ n ih =>
     rw [ih]; apply Quot.sound
     suffices R K p (n, (x : K)) (Nat.succ n, frobenius K p (x : K)) by
-      rwa [frobenius_natCast K p x] at this
+      rwa [map_natCast] at this
     apply R.intro
 
 theorem intCast (x : ℤ) : (x : PerfectClosure K p) = mk K p (0, x) := by
@@ -359,7 +359,7 @@ theorem natCast_eq_iff (x y : ℕ) : (x : PerfectClosure K p) = y ↔ (x : K) = 
   constructor <;> intro H
   · rw [natCast K p 0, natCast K p 0, mk_eq_iff] at H
     obtain ⟨z, H⟩ := H
-    simpa only [zero_add, iterate_fixed (frobenius_natCast K p _)] using H
+    simpa only [zero_add, iterate_fixed (map_natCast _ _)] using H
   rw [natCast K p 0, natCast K p 0, H]
 
 instance instCharP : CharP (PerfectClosure K p) p := by

--- a/Mathlib/RingTheory/Perfection.lean
+++ b/Mathlib/RingTheory/Perfection.lean
@@ -43,7 +43,7 @@ def Ring.perfectionSubsemiring (R : Type u₁) [CommSemiring R] (p : ℕ) [hp : 
     [CharP R p] : Subsemiring (ℕ → R) :=
   { Monoid.perfection R p with
     zero_mem' := fun _ ↦ zero_pow hp.1.ne_zero
-    add_mem' := fun hf hg n => (frobenius_add R p _ _).trans <| congr_arg₂ _ (hf n) (hg n) }
+    add_mem' := fun hf hg n => (map_add (frobenius R p) _ _).trans <| congr_arg₂ _ (hf n) (hg n) }
 
 /-- The perfection of a ring `R` with characteristic `p`, as a subring,
 defined to be the projective limit of `R` using the Frobenius maps `R → R`

--- a/Mathlib/RingTheory/RootsOfUnity/PrimitiveRoots.lean
+++ b/Mathlib/RingTheory/RootsOfUnity/PrimitiveRoots.lean
@@ -385,21 +385,14 @@ theorem primitiveRoots_one : primitiveRoots 1 R = {(1 : R)} := by
 
 theorem neZero' {n : ℕ} [NeZero n] (hζ : IsPrimitiveRoot ζ n) : NeZero ((n : ℕ) : R) := by
   let p := ringChar R
-  have hfin := Nat.finiteMultiplicity_iff.2 ⟨CharP.char_ne_one R p, NeZero.pos n⟩
-  obtain ⟨m, hm⟩ := hfin.exists_eq_pow_mul_and_not_dvd
-  by_cases hp : p ∣ n
-  · obtain ⟨k, hk⟩ := Nat.exists_eq_succ_of_ne_zero (multiplicity_pos_of_dvd hp).ne'
-    have : NeZero p := NeZero.of_pos (Nat.pos_of_dvd_of_pos hp (NeZero.pos n))
-    have hpri : Fact p.Prime := CharP.char_is_prime_of_pos R p
-    have := hζ.pow_eq_one
-    rw [hm.1, hk, pow_succ', mul_assoc, pow_mul', ← frobenius_def, ← frobenius_one p] at this
-    exfalso
-    have hpos : 0 < p ^ k * m :=
-      mul_pos (pow_pos hpri.1.pos _) <| Nat.pos_of_ne_zero (fun H ↦ hm.2 <| H ▸ p.dvd_zero)
-    refine hζ.pow_ne_one_of_pos_of_lt hpos.ne' ?_ (frobenius_inj R p this)
-    rw [hm.1, hk, pow_succ', mul_assoc, mul_comm p]
-    exact lt_mul_of_one_lt_right hpos hpri.1.one_lt
-  · exact NeZero.of_not_dvd R hp
+  refine .of_not_dvd R (p := p) fun hpn ↦ ?_
+  obtain ⟨n, rfl⟩ := hpn
+  have h : p ≠ 0 ∧ n ≠ 0 := by aesop
+  have : NeZero p := .mk h.1
+  have hp : Fact p.Prime := CharP.char_is_prime_of_pos R p
+  refine (hζ.pow_ne_one_of_pos_of_lt h.2 (lt_mul_of_one_lt_left (by grind) hp.1.one_lt) <|
+    frobenius_inj R p ?_).elim
+  rw [frobenius_def, ← pow_mul', hζ.1, map_one]
 
 nonrec theorem mem_nthRootsFinset (hζ : IsPrimitiveRoot ζ k) (hk : 0 < k) :
     ζ ∈ nthRootsFinset k (1 : R) :=


### PR DESCRIPTION
e.g. `frobenius_add` should be replaced with `map_add _`.

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include at least one commit authored by each
co-author among the commits in the pull request. If necessary, you may 
create empty commits to indicate co-authorship, using commands like so:

git commit --author="Author Name <author@email.com>" --allow-empty -m "add Author Name as coauthor"

When merging, all the commits will be squashed into a single commit listing all co-authors.

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
