### PR TITLE
[Merged by Bors] - chore: shortcut instance for `Nat` to be mul-torsion-free

### DIFF
--- a/Mathlib/Algebra/Group/Int/Defs.lean
+++ b/Mathlib/Algebra/Group/Int/Defs.lean
@@ -48,6 +48,9 @@ instance instAddCommGroup : AddCommGroup ℤ where
   zsmul_neg' m n := by simp only [negSucc_eq, natCast_succ, Int.neg_mul]
   sub_eq_add_neg _ _ := Int.sub_eq_add_neg
 
+instance instIsAddTorsionFree : IsAddTorsionFree ℤ where
+  nsmul_right_injective _n hn _x _y := Int.eq_of_mul_eq_mul_left (by cutsat)
+
 /-!
 ### Extra instances to short-circuit type class resolution
 

--- a/Mathlib/Algebra/Group/Int/Defs.lean
+++ b/Mathlib/Algebra/Group/Int/Defs.lean
@@ -48,6 +48,10 @@ instance instAddCommGroup : AddCommGroup ℤ where
   zsmul_neg' m n := by simp only [negSucc_eq, natCast_succ, Int.neg_mul]
   sub_eq_add_neg _ _ := Int.sub_eq_add_neg
 
+-- Thise instance can also be found from the `LinearOrderedCommMonoidWithZero ℤ` instance by
+-- typeclass search, but it is better practice to not rely on algebraic order theory to prove
+-- purely algebraic results on concrete types. Eg the results can be made available earlier.
+
 instance instIsAddTorsionFree : IsAddTorsionFree ℤ where
   nsmul_right_injective _n hn _x _y := Int.eq_of_mul_eq_mul_left (by cutsat)
 

--- a/Mathlib/Algebra/Group/Nat/Defs.lean
+++ b/Mathlib/Algebra/Group/Nat/Defs.lean
@@ -46,6 +46,12 @@ instance instCommMonoid : CommMonoid ℕ where
   npow_zero := Nat.pow_zero
   npow_succ _ _ := rfl
 
+instance instIsMulTorsionFree : IsMulTorsionFree ℕ where
+  pow_left_injective _ h _ _ := (Nat.pow_left_inj h).mp
+
+instance instIsAddTorsionFree : IsAddTorsionFree ℕ where
+  nsmul_right_injective _n hn _x _y hxy := Nat.mul_left_cancel (Nat.pos_of_ne_zero hn) hxy
+
 /-!
 ### Extra instances to short-circuit type class resolution
 
@@ -62,9 +68,6 @@ instance instSemigroup        : Semigroup ℕ        := by infer_instance
 instance instAddCommSemigroup : AddCommSemigroup ℕ := by infer_instance
 instance instAddSemigroup     : AddSemigroup ℕ     := by infer_instance
 instance instOne              : One ℕ              := inferInstance
-
-instance instIsAddTorsionFree : IsAddTorsionFree ℕ where
-  nsmul_right_injective _n hn _x _y hxy := Nat.mul_left_cancel (Nat.pos_of_ne_zero hn) hxy
 
 set_option linter.style.commandStart true
 

--- a/Mathlib/Algebra/Group/Nat/Defs.lean
+++ b/Mathlib/Algebra/Group/Nat/Defs.lean
@@ -46,6 +46,10 @@ instance instCommMonoid : CommMonoid ℕ where
   npow_zero := Nat.pow_zero
   npow_succ _ _ := rfl
 
+-- These instances can also be found from the `LinearOrderedCommMonoidWithZero ℕ` instance by
+-- typeclass search, but it is better practice to not rely on algebraic order theory to prove
+-- purely algebraic results on concrete types. Eg the results can be made available earlier.
+
 instance instIsMulTorsionFree : IsMulTorsionFree ℕ where
   pow_left_injective _ h _ _ := (Nat.pow_left_inj h).mp
 


### PR DESCRIPTION
This instance can already be found by typeclass search using the fact that `Nat` is a `LinearOrderedCommMonoidWithZero`, but it is better practice to not rely on algebraic order theory to prove algebraic results about such basic types. Similarly for `IsAddTorsionFree Int`.

From ClassFieldTheory

---

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
