### PR TITLE
[Merged by Bors] - Feat(Logic): basic properties of boolean negation

### DIFF
--- a/Mathlib.lean
+++ b/Mathlib.lean
@@ -4523,6 +4523,7 @@ import Mathlib.Logic.Encodable.Lattice
 import Mathlib.Logic.Encodable.Pi
 import Mathlib.Logic.Equiv.Array
 import Mathlib.Logic.Equiv.Basic
+import Mathlib.Logic.Equiv.Bool
 import Mathlib.Logic.Equiv.Defs
 import Mathlib.Logic.Equiv.Embedding
 import Mathlib.Logic.Equiv.Fin.Basic

--- a/Mathlib/Logic/Equiv/Bool.lean
+++ b/Mathlib/Logic/Equiv/Bool.lean
@@ -20,14 +20,14 @@ namespace Bool
 
 open Function
 
-theorem not_bijective : Bijective Bool.not := Equiv.boolNot.bijective
-theorem not_injective : Injective Bool.not := Equiv.boolNot.injective
-theorem not_surjective : Surjective Bool.not :=  Equiv.boolNot.surjective
+theorem not_bijective : Bijective not := Equiv.boolNot.bijective
+theorem not_injective : Injective not := Equiv.boolNot.injective
+theorem not_surjective : Surjective not :=  Equiv.boolNot.surjective
 
-theorem not_leftInverse : LeftInverse Bool.not Bool.not := Bool.not_not
-theorem not_rightInverse : RightInverse Bool.not Bool.not := Bool.not_not
+theorem not_leftInverse : LeftInverse not not := not_not
+theorem not_rightInverse : RightInverse not not := not_not
 
-theorem not_HasLeftInverse : HasLeftInverse Bool.not := ⟨Bool.not, not_leftInverse⟩
-theorem not_HasRightInverse : HasRightInverse Bool.not := ⟨Bool.not, not_rightInverse⟩
+theorem not_HasLeftInverse : HasLeftInverse not := ⟨not, not_leftInverse⟩
+theorem not_HasRightInverse : HasRightInverse not := ⟨not, not_rightInverse⟩
 
 end Bool

--- a/Mathlib/Logic/Equiv/Bool.lean
+++ b/Mathlib/Logic/Equiv/Bool.lean
@@ -27,7 +27,7 @@ theorem not_surjective : Surjective not :=  Equiv.boolNot.surjective
 theorem not_leftInverse : LeftInverse not not := not_not
 theorem not_rightInverse : RightInverse not not := not_not
 
-theorem not_HasLeftInverse : HasLeftInverse not := ⟨not, not_leftInverse⟩
-theorem not_HasRightInverse : HasRightInverse not := ⟨not, not_rightInverse⟩
+theorem not_hasLeftInverse : HasLeftInverse not := ⟨not, not_leftInverse⟩
+theorem not_hasRightInverse : HasRightInverse not := ⟨not, not_rightInverse⟩
 
 end Bool

--- a/Mathlib/Logic/Equiv/Bool.lean
+++ b/Mathlib/Logic/Equiv/Bool.lean
@@ -12,13 +12,13 @@ import Mathlib.Logic.Function.Basic
 This file shows that `not : Bool → Bool` is an equivalence and derives some consequences
 -/
 
-open Function
-
-namespace Bool
-
 /-- The boolean negation function `not : Bool → Bool` is an involution and thus an equivalence. -/
 @[simps!]
 def Equiv.boolNot : Equiv.Perm Bool := Bool.involutive_not.toPerm
+
+namespace Bool
+
+open Function
 
 theorem not_bijective : Bijective Bool.not := Equiv.boolNot.bijective
 theorem not_injective : Injective Bool.not := Equiv.boolNot.injective

--- a/Mathlib/Logic/Equiv/Bool.lean
+++ b/Mathlib/Logic/Equiv/Bool.lean
@@ -22,7 +22,7 @@ open Function
 
 theorem not_bijective : Bijective not := Equiv.boolNot.bijective
 theorem not_injective : Injective not := Equiv.boolNot.injective
-theorem not_surjective : Surjective not :=  Equiv.boolNot.surjective
+theorem not_surjective : Surjective not := Equiv.boolNot.surjective
 
 theorem not_leftInverse : LeftInverse not not := not_not
 theorem not_rightInverse : RightInverse not not := not_not

--- a/Mathlib/Logic/Equiv/Bool.lean
+++ b/Mathlib/Logic/Equiv/Bool.lean
@@ -5,6 +5,7 @@ Authors: Kenny Lau, Emily Riehl, Wrenna Robson
 -/
 import Mathlib.Logic.Equiv.Basic
 import Mathlib.Logic.Function.Basic
+
 /-!
 # Equivalences involving `Bool`
 

--- a/Mathlib/Logic/Equiv/Bool.lean
+++ b/Mathlib/Logic/Equiv/Bool.lean
@@ -27,7 +27,7 @@ theorem not_surjective : Surjective Bool.not :=  Equiv.boolNot.surjective
 theorem not_leftInverse : LeftInverse Bool.not Bool.not := Bool.not_not
 theorem not_rightInverse : RightInverse Bool.not Bool.not := Bool.not_not
 
-theorem not_HasLeftInverse : HasLeftInverse (Bool.not) := ⟨Bool.not, not_leftInverse⟩
-theorem not_HasRightInverse : HasRightInverse (Bool.not) := ⟨Bool.not, not_rightInverse⟩
+theorem not_HasLeftInverse : HasLeftInverse Bool.not := ⟨Bool.not, not_leftInverse⟩
+theorem not_HasRightInverse : HasRightInverse Bool.not := ⟨Bool.not, not_rightInverse⟩
 
 end Bool

--- a/Mathlib/Logic/Equiv/Bool.lean
+++ b/Mathlib/Logic/Equiv/Bool.lean
@@ -1,0 +1,32 @@
+/-
+Copyright (c) 2025 Emily Riehl. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Kenny Lau, Emily Riehl, Wrenna Robson
+-/
+import Mathlib.Logic.Equiv.Basic
+import Mathlib.Logic.Function.Basic
+/-!
+# Equivalences involving `Bool`
+
+This file shows that `not : Bool → Bool` is an equivalence and derives some consequences
+-/
+
+open Function
+
+namespace Bool
+
+/-- The boolean negation function `not : Bool → Bool` is an involution and thus an equivalence. -/
+@[simps!]
+def Equiv.boolNot : Equiv.Perm Bool := Bool.involutive_not.toPerm
+
+theorem not_bijective : Bijective Bool.not := Equiv.boolNot.bijective
+theorem not_injective : Injective Bool.not := Equiv.boolNot.injective
+theorem not_surjective : Surjective Bool.not :=  Equiv.boolNot.surjective
+
+theorem not_leftInverse : LeftInverse Bool.not Bool.not := Bool.not_not
+theorem not_rightInverse : RightInverse Bool.not Bool.not := Bool.not_not
+
+theorem not_HasLeftInverse : HasLeftInverse (Bool.not) := ⟨Bool.not, not_leftInverse⟩
+theorem not_HasRightInverse : HasRightInverse (Bool.not) := ⟨Bool.not, not_rightInverse⟩
+
+end Bool


### PR DESCRIPTION
We show that `not : Bool -> Bool` is an involutive equivalence and derive some immediate consequences.

Co-authored-by: Kenny Lau <kc_kennylau@yahoo.com.hk>
Co-authored-by: Wrenna Robson <wren.robson@gmail.com>


---

I'm building a Lean game for which it would be useful to have this in the library. 

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
