### PR TITLE
[Merged by Bors] - feat(RingTheory): bijective descends along faithfully flat ring maps

### DIFF
--- a/Mathlib.lean
+++ b/Mathlib.lean
@@ -5627,6 +5627,7 @@ import Mathlib.RingTheory.Flat.Equalizer
 import Mathlib.RingTheory.Flat.EquationalCriterion
 import Mathlib.RingTheory.Flat.FaithfullyFlat.Algebra
 import Mathlib.RingTheory.Flat.FaithfullyFlat.Basic
+import Mathlib.RingTheory.Flat.FaithfullyFlat.Descent
 import Mathlib.RingTheory.Flat.Localization
 import Mathlib.RingTheory.Flat.Stability
 import Mathlib.RingTheory.Flat.Tensor

--- a/Mathlib/RingTheory/Flat/FaithfullyFlat/Descent.lean
+++ b/Mathlib/RingTheory/Flat/FaithfullyFlat/Descent.lean
@@ -1,0 +1,68 @@
+/-
+Copyright (c) 2025 Christian Merten. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Christian Merten
+-/
+import Mathlib.RingTheory.RingHom.FaithfullyFlat
+import Mathlib.RingTheory.RingHom.Injective
+import Mathlib.RingTheory.RingHom.Surjective
+
+/-!
+# Properties satisfying faithfully flat descent for rings
+
+We show the following properties of ring homomorphisms descend under faithfully flat ring maps:
+
+- injective
+- surjective
+- bijective
+-/
+
+open TensorProduct
+
+section
+
+variable {R S : Type*} [CommRing R] [CommRing S] [Algebra R S]
+    {T : Type*} [CommRing T] [Algebra R T]
+
+lemma Module.FaithfullyFlat.injective_of_tensorProduct [Module.FaithfullyFlat R S]
+    (H : Function.Injective (algebraMap S (S ⊗[R] T))) :
+    Function.Injective (algebraMap R T) := by
+  have : LinearMap.lTensor S (Algebra.linearMap R T) =
+      Algebra.linearMap S (S ⊗[R] T) ∘ₗ (AlgebraTensorModule.rid R S S).toLinearMap := by
+    ext; simp
+  apply (Module.FaithfullyFlat.lTensor_injective_iff_injective R S (Algebra.linearMap R T)).mp
+  simpa [this] using H
+
+lemma Module.FaithfullyFlat.surjective_of_tensorProduct [Module.FaithfullyFlat R S]
+    (H : Function.Surjective (algebraMap S (S ⊗[R] T))) :
+    Function.Surjective (algebraMap R T) := by
+  have : LinearMap.lTensor S (Algebra.linearMap R T) =
+      Algebra.linearMap S (S ⊗[R] T) ∘ₗ (AlgebraTensorModule.rid R S S).toLinearMap := by
+    ext; simp
+  apply (Module.FaithfullyFlat.lTensor_surjective_iff_surjective R S (Algebra.linearMap R T)).mp
+  simpa [this] using H
+
+lemma Module.FaithfullyFlat.bijective_of_tensorProduct [Module.FaithfullyFlat R S]
+    (H : Function.Bijective (algebraMap S (S ⊗[R] T))) :
+    Function.Bijective (algebraMap R T) :=
+  ⟨injective_of_tensorProduct H.1, surjective_of_tensorProduct H.2⟩
+
+end
+
+lemma RingHom.FaithfullyFlat.codescendsAlong_injective :
+    CodescendsAlong (fun f ↦ Function.Injective f) FaithfullyFlat := by
+  apply CodescendsAlong.mk _ injective_respectsIso
+  introv h H
+  rw [faithfullyFlat_algebraMap_iff] at h
+  exact h.injective_of_tensorProduct H
+
+lemma RingHom.FaithfullyFlat.codescendsAlong_surjective :
+    CodescendsAlong (fun f ↦ Function.Surjective f) FaithfullyFlat := by
+  apply CodescendsAlong.mk _ surjective_respectsIso
+  introv h H
+  rw [faithfullyFlat_algebraMap_iff] at h
+  exact h.surjective_of_tensorProduct H
+
+lemma RingHom.FaithfullyFlat.codescendsAlong_bijective :
+    CodescendsAlong (fun f ↦ Function.Bijective f) FaithfullyFlat :=
+  .and codescendsAlong_injective codescendsAlong_surjective

--- a/Mathlib/RingTheory/Flat/FaithfullyFlat/Descent.lean
+++ b/Mathlib/RingTheory/Flat/FaithfullyFlat/Descent.lean
@@ -63,6 +63,8 @@ lemma RingHom.FaithfullyFlat.codescendsAlong_surjective :
   rw [faithfullyFlat_algebraMap_iff] at h
   exact h.surjective_of_tensorProduct H
 
+universe u
+
 lemma RingHom.FaithfullyFlat.codescendsAlong_bijective :
     CodescendsAlong (fun f ↦ Function.Bijective f) FaithfullyFlat :=
-  .and codescendsAlong_injective codescendsAlong_surjective
+  CodescendsAlong.and codescendsAlong_injective codescendsAlong_surjective

--- a/Mathlib/RingTheory/RingHomProperties.lean
+++ b/Mathlib/RingTheory/RingHomProperties.lean
@@ -259,6 +259,12 @@ lemma CodescendsAlong.includeRight (hPQ : CodescendsAlong P Q) (h : Q (algebraMa
   let _ : Algebra T (S ⊗[R] T) := Algebra.TensorProduct.rightAlgebra
   apply hPQ R S T (S ⊗[R] T) h H
 
+variable {Q} {P' : ∀ {R S : Type u} [CommRing R] [CommRing S], (R →+* S) → Prop}
+
+lemma CodescendsAlong.and (hP : CodescendsAlong P Q) (hP' : CodescendsAlong P' Q) :
+    CodescendsAlong (fun f ↦ P f ∧ P' f) Q :=
+  fun _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ h₁ h₂ ↦ ⟨hP _ _ _ _ h₁ h₂.1, hP' _ _ _ _ h₁ h₂.2⟩
+
 end Descent
 
 end RingHom

--- a/Mathlib/RingTheory/RingHomProperties.lean
+++ b/Mathlib/RingTheory/RingHomProperties.lean
@@ -227,7 +227,7 @@ variable (P) in
 /-- A property of ring homomorphisms `Q` codescends along `Q'` if whenever
 `R' →+* R' ⊗[R] S` satisfies `Q` and `R →+* R'` satisfies `Q'`, then `R →+* S` satisfies `Q`. -/
 def CodescendsAlong : Prop :=
-  ∀ (R S R' S' : Type u) [CommRing R] [CommRing S] [CommRing R'] [CommRing S'],
+  ∀ {R S R' S' : Type u} [CommRing R] [CommRing S] [CommRing R'] [CommRing S'],
   ∀ [Algebra R S] [Algebra R R'] [Algebra R S'] [Algebra S S'] [Algebra R' S'],
     ∀ [IsScalarTower R S S'] [IsScalarTower R R' S'],
       ∀ [Algebra.IsPushout R S R' S'],
@@ -251,19 +251,19 @@ lemma CodescendsAlong.algebraMap_tensorProduct (hPQ : CodescendsAlong P Q)
     (h : Q (algebraMap R S)) (H : P (algebraMap S (S ⊗[R] T))) :
     P (algebraMap R T) :=
   let _ : Algebra T (S ⊗[R] T) := Algebra.TensorProduct.rightAlgebra
-  hPQ R T S (S ⊗[R] T) h H
+  hPQ h H
 
 lemma CodescendsAlong.includeRight (hPQ : CodescendsAlong P Q) (h : Q (algebraMap R T))
     (H : P ((Algebra.TensorProduct.includeRight.toRingHom : T →+* S ⊗[R] T))) :
     P (algebraMap R S) := by
   let _ : Algebra T (S ⊗[R] T) := Algebra.TensorProduct.rightAlgebra
-  apply hPQ R S T (S ⊗[R] T) h H
+  apply hPQ h H
 
 variable {Q} {P' : ∀ {R S : Type u} [CommRing R] [CommRing S], (R →+* S) → Prop}
 
 lemma CodescendsAlong.and (hP : CodescendsAlong P Q) (hP' : CodescendsAlong P' Q) :
     CodescendsAlong (fun f ↦ P f ∧ P' f) Q :=
-  fun _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ h₁ h₂ ↦ ⟨hP _ _ _ _ h₁ h₂.1, hP' _ _ _ _ h₁ h₂.2⟩
+  fun h₁ h₂ ↦ ⟨hP h₁ h₂.1, hP' h₁ h₂.2⟩
 
 end Descent
 

--- a/Mathlib/RingTheory/RingHomProperties.lean
+++ b/Mathlib/RingTheory/RingHomProperties.lean
@@ -227,7 +227,7 @@ variable (P) in
 /-- A property of ring homomorphisms `Q` codescends along `Q'` if whenever
 `R' →+* R' ⊗[R] S` satisfies `Q` and `R →+* R'` satisfies `Q'`, then `R →+* S` satisfies `Q`. -/
 def CodescendsAlong : Prop :=
-  ∀ {R S R' S' : Type u} [CommRing R] [CommRing S] [CommRing R'] [CommRing S'],
+  ∀ ⦃R S R' S' : Type u⦄ [CommRing R] [CommRing S] [CommRing R'] [CommRing S'],
   ∀ [Algebra R S] [Algebra R R'] [Algebra R S'] [Algebra S S'] [Algebra R' S'],
     ∀ [IsScalarTower R S S'] [IsScalarTower R R' S'],
       ∀ [Algebra.IsPushout R S R' S'],
@@ -263,7 +263,7 @@ variable {Q} {P' : ∀ {R S : Type u} [CommRing R] [CommRing S], (R →+* S) →
 
 lemma CodescendsAlong.and (hP : CodescendsAlong P Q) (hP' : CodescendsAlong P' Q) :
     CodescendsAlong (fun f ↦ P f ∧ P' f) Q :=
-  fun h₁ h₂ ↦ ⟨hP h₁ h₂.1, hP' h₁ h₂.2⟩
+  fun _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ h₁ h₂ ↦ ⟨hP h₁ h₂.1, hP' h₁ h₂.2⟩
 
 end Descent
 


### PR DESCRIPTION
From Pi1.

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include at least one commit authored by each
co-author among the commits in the pull request. If necessary, you may 
create empty commits to indicate co-authorship, using commands like so:

git commit --author="Author Name <author@email.com>" --allow-empty -m "add Author Name as coauthor"

When merging, all the commits will be squashed into a single commit listing all co-authors.

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
