### PR TITLE
[Merged by Bors] - feat(Computability/NFA): NFA acceptsFrom definitions and lemmas

### DIFF
--- a/Mathlib/Computability/NFA.lean
+++ b/Mathlib/Computability/NFA.lean
@@ -207,9 +207,10 @@ theorem acceptsFrom_biUnion {ι : Type*} (t : Set ι) (f : ι → Set σ) :
 
 theorem mem_acceptsFrom_sep_fact {S : Set σ} {p : Prop} {x : List α} :
     x ∈ M.acceptsFrom {s ∈ S | p} ↔ x ∈ M.acceptsFrom S ∧ p := by
-  induction x generalizing S <;> simp
-  case nil => tauto
-  case cons a x ih =>
+  induction x generalizing S with
+  | nil => simp only [mem_acceptsFrom_nil, mem_setOf_eq]; tauto
+  | cons a x ih =>
+    simp only [mem_acceptsFrom_cons]
     have h : M.stepSet {s ∈ S | p} a = {s ∈ M.stepSet S a | p} := by
       ext s; simp only [stepSet, mem_setOf_eq, mem_iUnion, exists_prop]; tauto
     rw [h, ih]

--- a/Mathlib/Computability/NFA.lean
+++ b/Mathlib/Computability/NFA.lean
@@ -119,6 +119,7 @@ theorem evalFrom_append (S : Set σ) (x y : List α) :
     M.evalFrom S (x ++ y) = M.evalFrom (M.evalFrom S x) y := by
   simp only [evalFrom, List.foldl_append]
 
+@[deprecated "Use evalFrom_append, evalFrom_cons, and evalFrom_nil" (since := "2025-11-17")]
 theorem evalFrom_append_singleton (S : Set σ) (x : List α) (a : α) :
     M.evalFrom S (x ++ [a]) = M.stepSet (M.evalFrom S x) a := by
   simp only [evalFrom_append, evalFrom_cons, evalFrom_nil]
@@ -143,6 +144,13 @@ variable (M) in
 theorem evalFrom_iUnion₂ {ι : Sort*} {κ : ι → Sort*} (f : ∀ i, κ i → Set σ) (x : List α) :
     M.evalFrom (⋃ (i) (j), f i j) x = ⋃ (i) (j), M.evalFrom (f i j) x := by
   simp
+
+variable (M) in
+@[deprecated "Use evalFrom_iUnion₂" (since := "2025-11-17")]
+theorem evalFrom_biUnion {ι : Type*} (t : Set ι) (f : ι → Set σ) :
+    ∀ (x : List α), M.evalFrom (⋃ i ∈ t, f i) x = ⋃ i ∈ t, M.evalFrom (f i) x
+  | [] => by simp
+  | a :: x => by simp [stepSet, evalFrom_biUnion _ _ x]
 
 variable (M) in
 theorem evalFrom_eq_biUnion_singleton (S : Set σ) (x : List α) :
@@ -244,8 +252,9 @@ theorem eval_singleton (a : α) : M.eval [a] = M.stepSet M.start a :=
 
 variable (M) in
 @[simp]
-theorem eval_append_singleton (x : List α) (a : α) : M.eval (x ++ [a]) = M.stepSet (M.eval x) a :=
-  evalFrom_append_singleton ..
+theorem eval_append_singleton (x : List α) (a : α) :
+    M.eval (x ++ [a]) = M.stepSet (M.eval x) a := by
+  simp [eval]
 
 variable (M) in
 /-- `M.accepts` is the language of `x` such that there is an accept state in `M.eval x`. -/

--- a/Mathlib/Computability/NFA.lean
+++ b/Mathlib/Computability/NFA.lean
@@ -146,7 +146,7 @@ theorem evalFrom_iUnion₂ {ι : Sort*} {κ : ι → Sort*} (f : ∀ i, κ i →
   simp
 
 variable (M) in
-@[deprecated "Use evalFrom_iUnion₂" (since := "2025-11-17")]
+@[deprecated evalFrom_iUnion₂ (since := "2025-11-17")]
 theorem evalFrom_biUnion {ι : Type*} (t : Set ι) (f : ι → Set σ) :
     ∀ (x : List α), M.evalFrom (⋃ i ∈ t, f i) x = ⋃ i ∈ t, M.evalFrom (f i) x
   | [] => by simp
@@ -155,7 +155,7 @@ theorem evalFrom_biUnion {ι : Type*} (t : Set ι) (f : ι → Set σ) :
 variable (M) in
 theorem evalFrom_eq_biUnion_singleton (S : Set σ) (x : List α) :
     M.evalFrom S x = ⋃ s ∈ S, M.evalFrom {s} x := by
-  simp [←evalFrom_iUnion₂]
+  simp [← evalFrom_iUnion₂]
 
 theorem mem_evalFrom_iff_exists {s : σ} {S : Set σ} {x : List α} :
     s ∈ M.evalFrom S x ↔ ∃ t ∈ S, s ∈ M.evalFrom {t} x := by

--- a/Mathlib/Computability/NFA.lean
+++ b/Mathlib/Computability/NFA.lean
@@ -175,7 +175,7 @@ theorem mem_acceptsFrom_cons {S : Set σ} {a : α} {x : List α} :
   simp [mem_acceptsFrom]
 
 @[simp]
-theorem mem_acceptsFrom_append {S : Set σ} {x y : List α} :
+theorem append_mem_acceptsFrom {S : Set σ} {x y : List α} :
     x ++ y ∈ M.acceptsFrom S ↔ y ∈ M.acceptsFrom (M.evalFrom S x) := by
   simp [mem_acceptsFrom]
 

--- a/Mathlib/Computability/NFA.lean
+++ b/Mathlib/Computability/NFA.lean
@@ -134,14 +134,14 @@ theorem evalFrom_union (S1 S2 : Set σ) (x : List α) :
 variable (M) in
 @[simp]
 theorem evalFrom_iUnion {ι : Sort*} (s : ι → Set σ) (x : List α) :
-    M.evalFrom (⋃ (i : ι), s i) x = ⋃ (i : ι), M.evalFrom (s i) x := by
+    M.evalFrom (⋃ i, s i) x = ⋃ i, M.evalFrom (s i) x := by
   induction x generalizing s with
   | nil => simp
   | cons a x ih => simp [stepSet, Set.iUnion_comm (ι:=σ) (ι':=ι), ih]
 
 variable (M) in
-theorem evalFrom_biUnion {ι : Type*} (t : Set ι) (f : ι → Set σ) (x : List α) :
-    M.evalFrom (⋃ i ∈ t, f i) x = ⋃ i ∈ t, M.evalFrom (f i) x := by
+theorem evalFrom_iUnion₂ {ι : Sort*} {κ : ι → Sort*} (f : ∀ i, κ i → Set σ) (x : List α) :
+    M.evalFrom (⋃ i j, f i j) x = ⋃ i j, M.evalFrom (f i j) x := by
   simp
 
 variable (M) in
@@ -159,19 +159,18 @@ variable (M) in
 in `M.evalFrom S x`. -/
 def acceptsFrom (S : Set σ) : Language α := {x | ∃ s ∈ M.accept, s ∈ M.evalFrom S x}
 
-variable (M) in
 theorem mem_acceptsFrom {S : Set σ} {x : List α} :
     x ∈ M.acceptsFrom S ↔ ∃ s ∈ M.accept, s ∈ M.evalFrom S x := by
   rfl
 
 variable (M) in
 @[simp]
-theorem mem_acceptsFrom_nil {S : Set σ} : [] ∈ M.acceptsFrom S ↔ ∃ s ∈ S, s ∈ M.accept := by
+theorem nil_mem_acceptsFrom {S : Set σ} : [] ∈ M.acceptsFrom S ↔ ∃ s ∈ S, s ∈ M.accept := by
   simp only [mem_acceptsFrom, evalFrom_nil]; tauto
 
 variable (M) in
 @[simp]
-theorem mem_acceptsFrom_cons {S : Set σ} {a : α} {x : List α} :
+theorem cons_mem_acceptsFrom {S : Set σ} {a : α} {x : List α} :
     a :: x ∈ M.acceptsFrom S ↔ x ∈ M.acceptsFrom (M.stepSet S a) := by
   simp [mem_acceptsFrom]
 

--- a/Mathlib/Computability/NFA.lean
+++ b/Mathlib/Computability/NFA.lean
@@ -141,13 +141,13 @@ theorem evalFrom_iUnion {ι : Sort*} (s : ι → Set σ) (x : List α) :
 
 variable (M) in
 theorem evalFrom_iUnion₂ {ι : Sort*} {κ : ι → Sort*} (f : ∀ i, κ i → Set σ) (x : List α) :
-    M.evalFrom (⋃ i j, f i j) x = ⋃ i j, M.evalFrom (f i j) x := by
+    M.evalFrom (⋃ (i) (j), f i j) x = ⋃ (i) (j), M.evalFrom (f i j) x := by
   simp
 
 variable (M) in
 theorem evalFrom_eq_biUnion_singleton (S : Set σ) (x : List α) :
     M.evalFrom S x = ⋃ s ∈ S, M.evalFrom {s} x := by
-  simp [← evalFrom_biUnion]
+  simp [←evalFrom_iUnion₂]
 
 theorem mem_evalFrom_iff_exists {s : σ} {S : Set σ} {x : List α} :
     s ∈ M.evalFrom S x ↔ ∃ t ∈ S, s ∈ M.evalFrom {t} x := by
@@ -177,7 +177,7 @@ theorem cons_mem_acceptsFrom {S : Set σ} {a : α} {x : List α} :
 variable (M) in
 theorem acceptsFrom_cons {S : Set σ} {a : α} :
     (a :: ·) ⁻¹' M.acceptsFrom S = M.acceptsFrom (M.stepSet S a) := by
-  ext x; simp [mem_acceptsFrom_cons M]
+  ext x; simp [cons_mem_acceptsFrom M]
 
 variable (M) in
 @[simp]
@@ -211,8 +211,8 @@ theorem acceptsFrom_iUnion {ι : Sort*} (s : ι → Set σ) :
   simp_rw [↑mem_iUnion, ↑mem_setOf_eq]; tauto
 
 variable (M) in
-theorem acceptsFrom_biUnion {ι : Type*} (t : Set ι) (f : ι → Set σ) :
-    M.acceptsFrom (⋃ i ∈ t, f i) = ⋃ i ∈ t, M.acceptsFrom (f i) := by
+theorem acceptsFrom_iUnion₂ {ι : Sort*} {κ : ι → Sort*} (f : ∀ i, κ i → Set σ) :
+    M.acceptsFrom (⋃ (i) (j), f i j) = ⋃ (i) (j), M.acceptsFrom (f i j) := by
   simp
 
 variable (M) in
@@ -220,7 +220,7 @@ variable (M) in
 theorem mem_acceptsFrom_sep_fact {S : Set σ} {p : Prop} {x : List α} :
     x ∈ M.acceptsFrom {s ∈ S | p} ↔ x ∈ M.acceptsFrom S ∧ p := by
   induction x generalizing S with
-  | nil => simp only [mem_acceptsFrom_nil, mem_setOf_eq]; tauto
+  | nil => simp only [nil_mem_acceptsFrom, mem_setOf_eq]; tauto
   | cons a x ih =>
     have h : M.stepSet {s ∈ S | p} a = {s ∈ M.stepSet S a | p} := by
       ext s; simp only [stepSet, mem_setOf_eq, mem_iUnion, exists_prop]; tauto

--- a/Mathlib/Computability/NFA.lean
+++ b/Mathlib/Computability/NFA.lean
@@ -89,12 +89,7 @@ variable (M) in
 theorem stepSet_union {S1 S2 : Set σ} {a : α} :
     M.stepSet (S1 ∪ S2) a = M.stepSet S1 a ∪ M.stepSet S2 a := by
   ext s
-  simp only [mem_stepSet, mem_union]
-  constructor
-  · rintro ⟨s', (h1 | h2), hstep⟩
-    · left; tauto
-    · right; tauto
-  · rintro (⟨s', h, hstep⟩ | ⟨s', h, hstep⟩) <;> exists s' <;> tauto
+  simp [mem_stepSet, or_and_right, exists_or]
 
 variable (M) in
 /-- `M.evalFrom S x` computes all possible paths through `M` with input `x` starting at an element

--- a/Mathlib/Computability/NFA.lean
+++ b/Mathlib/Computability/NFA.lean
@@ -263,8 +263,7 @@ def accepts : Language α := {x | ∃ S ∈ M.accept, S ∈ M.eval x}
 theorem mem_accepts {x : List α} : x ∈ M.accepts ↔ ∃ S ∈ M.accept, S ∈ M.evalFrom M.start x := by
   rfl
 
-theorem accepts_acceptsFrom : M.accepts = M.acceptsFrom M.start := by
-  rfl
+theorem accepts_eq_acceptsFrom_start : M.accepts = M.acceptsFrom M.start := rfl
 
 variable (M) in
 /-- `M.Path` represents a concrete path through the NFA from a start state to an end state

--- a/Mathlib/Computability/NFA.lean
+++ b/Mathlib/Computability/NFA.lean
@@ -200,8 +200,8 @@ theorem append_preimage_acceptsFrom {S : Set σ} {x : List α} :
 
 variable (M) in
 @[simp]
-theorem acceptsFrom_union {S1 S2 : Set σ} :
-    M.acceptsFrom (S1 ∪ S2) = M.acceptsFrom S1 + M.acceptsFrom S2 := by
+theorem acceptsFrom_union {S T : Set σ} :
+    M.acceptsFrom (S ∪ T) = M.acceptsFrom S + M.acceptsFrom T := by
   rw [Language.add_def]; ext x
   simp only [mem_acceptsFrom, evalFrom_union, mem_union]
   constructor
@@ -213,7 +213,7 @@ theorem acceptsFrom_union {S1 S2 : Set σ} :
 variable (M) in
 @[simp]
 theorem acceptsFrom_iUnion {ι : Sort*} (s : ι → Set σ) :
-    M.acceptsFrom (⋃ (i : ι), s i) = ⋃ (i : ι), M.acceptsFrom (s i) := by
+    M.acceptsFrom (⋃ i, s i) = ⋃ i, M.acceptsFrom (s i) := by
   ext x
   simp only [acceptsFrom, evalFrom_iUnion, mem_iUnion]
   simp_rw [↑mem_iUnion, ↑mem_setOf_eq]; tauto

--- a/Mathlib/Computability/NFA.lean
+++ b/Mathlib/Computability/NFA.lean
@@ -183,7 +183,7 @@ theorem cons_mem_acceptsFrom {S : Set σ} {a : α} {x : List α} :
   simp [mem_acceptsFrom]
 
 variable (M) in
-theorem acceptsFrom_cons {S : Set σ} {a : α} :
+theorem cons_preimage_acceptsFrom {S : Set σ} {a : α} :
     (a :: ·) ⁻¹' M.acceptsFrom S = M.acceptsFrom (M.stepSet S a) := by
   ext x; simp [cons_mem_acceptsFrom M]
 
@@ -225,7 +225,7 @@ theorem acceptsFrom_iUnion₂ {ι : Sort*} {κ : ι → Sort*} (f : ∀ i, κ i 
 
 variable (M) in
 @[simp]
-theorem mem_acceptsFrom_sep_fact {S : Set σ} {p : Prop} {x : List α} :
+private theorem mem_acceptsFrom_sep_fact {S : Set σ} {p : Prop} {x : List α} :
     x ∈ M.acceptsFrom {s ∈ S | p} ↔ x ∈ M.acceptsFrom S ∧ p := by
   induction x generalizing S with
   | nil => simp only [nil_mem_acceptsFrom, mem_setOf_eq]; tauto

--- a/Mathlib/Computability/NFA.lean
+++ b/Mathlib/Computability/NFA.lean
@@ -86,8 +86,8 @@ theorem stepSet_singleton (s : σ) (a : α) : M.stepSet {s} a = M.step s a := by
 
 variable (M) in
 @[simp]
-theorem stepSet_union {S1 S2 : Set σ} {a : α} :
-    M.stepSet (S1 ∪ S2) a = M.stepSet S1 a ∪ M.stepSet S2 a := by
+theorem stepSet_union {S T : Set σ} {a : α} :
+    M.stepSet (S ∪ T) a = M.stepSet S a ∪ M.stepSet T a := by
   ext s
   simp [mem_stepSet, or_and_right, exists_or]
 
@@ -126,9 +126,9 @@ theorem evalFrom_append_singleton (S : Set σ) (x : List α) (a : α) :
 
 variable (M) in
 @[simp]
-theorem evalFrom_union (S1 S2 : Set σ) (x : List α) :
-    M.evalFrom (S1 ∪ S2) x = M.evalFrom S1 x ∪ M.evalFrom S2 x := by
-  induction x generalizing S1 S2 with
+theorem evalFrom_union (S T : Set σ) (x : List α) :
+    M.evalFrom (S ∪ T) x = M.evalFrom S x ∪ M.evalFrom T x := by
+  induction x generalizing S T with
   | nil => simp
   | cons a x ih => simp [ih]
 

--- a/Mathlib/Computability/NFA.lean
+++ b/Mathlib/Computability/NFA.lean
@@ -189,13 +189,13 @@ theorem acceptsFrom_union {S1 S2 : Set σ} :
     · right; tauto
   · rintro (⟨s, hs, h⟩ | ⟨s, hs, h⟩) <;> exists s <;> tauto
 
-theorem mem_acceptsFrom_iUnion.{i} {ι : Type i} (f : ι → Set σ) :
+theorem acceptsFrom_iUnion.{i} {ι : Type i} (f : ι → Set σ) :
     M.acceptsFrom (⋃ (i : ι), f i) = ⋃ (i : ι), M.acceptsFrom (f i) := by
   ext x
   simp only [acceptsFrom, evalFrom_iUnion, mem_iUnion]
   simp_rw [↑mem_iUnion, ↑mem_setOf_eq]; tauto
 
-theorem mem_acceptsFrom_biUnion {ι : Type*} (t : Set ι) (f : ι → Set σ) :
+theorem acceptsFrom_biUnion {ι : Type*} (t : Set ι) (f : ι → Set σ) :
     M.acceptsFrom (⋃ i ∈ t, f i) = ⋃ i ∈ t, M.acceptsFrom (f i) := by
   ext x
   simp only [acceptsFrom, evalFrom_biUnion, mem_iUnion, exists_prop]


### PR DESCRIPTION
This PR defines `NFA.acceptsFrom`, similar to [`DFA.acceptsFrom`](https://leanprover-community.github.io/mathlib4_docs/Mathlib/Computability/DFA.html#DFA.acceptsFrom), and provides helper lemmas.

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include at least one commit authored by each
co-author among the commits in the pull request. If necessary, you may 
create empty commits to indicate co-authorship, using commands like so:

git commit --author="Author Name <author@email.com>" --allow-empty -m "add Author Name as coauthor"

When merging, all the commits will be squashed into a single commit listing all co-authors.

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
