### PR TITLE
[Merged by Bors] - feat(Analysis/Complex): `enorm` versions for `OperatorNorm.lean`

### DIFF
--- a/Mathlib/Analysis/Complex/OperatorNorm.lean
+++ b/Mathlib/Analysis/Complex/OperatorNorm.lean
@@ -37,6 +37,10 @@ theorem reCLM_norm : ‖reCLM‖ = 1 :=
       _ ≤ ‖reCLM‖ := unit_le_opNorm _ _ (by simp)
 
 @[simp]
+theorem reCLM_enorm : ‖reCLM‖ₑ = 1 := by
+  simp [← ofReal_norm]
+
+@[simp]
 theorem reCLM_nnnorm : ‖reCLM‖₊ = 1 :=
   Subtype.ext reCLM_norm
 
@@ -48,6 +52,10 @@ theorem imCLM_norm : ‖imCLM‖ = 1 :=
       _ ≤ ‖imCLM‖ := unit_le_opNorm _ _ (by simp)
 
 @[simp]
+theorem imCLM_enorm : ‖imCLM‖ₑ = 1 := by
+  simp [← ofReal_norm]
+
+@[simp]
 theorem imCLM_nnnorm : ‖imCLM‖₊ = 1 :=
   Subtype.ext imCLM_norm
 
@@ -56,12 +64,20 @@ theorem conjCLE_norm : ‖(conjCLE : ℂ →L[ℝ] ℂ)‖ = 1 :=
   conjLIE.toLinearIsometry.norm_toContinuousLinearMap
 
 @[simp]
+theorem conjCLE_enorm : ‖(conjCLE : ℂ →L[ℝ] ℂ)‖ₑ = 1 := by
+  simp [← ofReal_norm]
+
+@[simp]
 theorem conjCLE_nnorm : ‖(conjCLE : ℂ →L[ℝ] ℂ)‖₊ = 1 :=
   Subtype.ext conjCLE_norm
 
 @[simp]
 theorem ofRealCLM_norm : ‖ofRealCLM‖ = 1 :=
   ofRealLI.norm_toContinuousLinearMap
+
+@[simp]
+theorem ofRealCLM_enorm : ‖ofRealCLM‖ₑ = 1 := by
+  simp [← ofReal_norm]
 
 @[simp]
 theorem ofRealCLM_nnnorm : ‖ofRealCLM‖₊ = 1 :=

--- a/Mathlib/Analysis/Complex/OperatorNorm.lean
+++ b/Mathlib/Analysis/Complex/OperatorNorm.lean
@@ -37,8 +37,7 @@ theorem reCLM_norm : ‖reCLM‖ = 1 :=
       _ ≤ ‖reCLM‖ := unit_le_opNorm _ _ (by simp)
 
 @[simp]
-theorem reCLM_enorm : ‖reCLM‖ₑ = 1 := by
-  simp [← ofReal_norm]
+theorem reCLM_enorm : ‖reCLM‖ₑ = 1 := by simp [← ofReal_norm]
 
 @[simp]
 theorem reCLM_nnnorm : ‖reCLM‖₊ = 1 :=
@@ -52,8 +51,7 @@ theorem imCLM_norm : ‖imCLM‖ = 1 :=
       _ ≤ ‖imCLM‖ := unit_le_opNorm _ _ (by simp)
 
 @[simp]
-theorem imCLM_enorm : ‖imCLM‖ₑ = 1 := by
-  simp [← ofReal_norm]
+theorem imCLM_enorm : ‖imCLM‖ₑ = 1 := by simp [← ofReal_norm]
 
 @[simp]
 theorem imCLM_nnnorm : ‖imCLM‖₊ = 1 :=
@@ -64,8 +62,7 @@ theorem conjCLE_norm : ‖(conjCLE : ℂ →L[ℝ] ℂ)‖ = 1 :=
   conjLIE.toLinearIsometry.norm_toContinuousLinearMap
 
 @[simp]
-theorem conjCLE_enorm : ‖(conjCLE : ℂ →L[ℝ] ℂ)‖ₑ = 1 := by
-  simp [← ofReal_norm]
+theorem conjCLE_enorm : ‖(conjCLE : ℂ →L[ℝ] ℂ)‖ₑ = 1 := by simp [← ofReal_norm]
 
 @[simp]
 theorem conjCLE_nnorm : ‖(conjCLE : ℂ →L[ℝ] ℂ)‖₊ = 1 :=
@@ -76,8 +73,7 @@ theorem ofRealCLM_norm : ‖ofRealCLM‖ = 1 :=
   ofRealLI.norm_toContinuousLinearMap
 
 @[simp]
-theorem ofRealCLM_enorm : ‖ofRealCLM‖ₑ = 1 := by
-  simp [← ofReal_norm]
+theorem ofRealCLM_enorm : ‖ofRealCLM‖ₑ = 1 := by simp [← ofReal_norm]
 
 @[simp]
 theorem ofRealCLM_nnnorm : ‖ofRealCLM‖₊ = 1 :=


### PR DESCRIPTION
Add `enorm` versions of theorems in `OperatorNorm.lean` as it currently has only `norm` and `nnnorm` versions.

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include at least one commit authored by each
co-author among the commits in the pull request. If necessary, you may 
create empty commits to indicate co-authorship, using commands like so:

git commit --author="Author Name <author@email.com>" --allow-empty -m "add Author Name as coauthor"

When merging, all the commits will be squashed into a single commit listing all co-authors.

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
