### PR TITLE
[Merged by Bors] - feat: biUnion_inter_of_pairwise_disjoint

### DIFF
--- a/Mathlib/Data/Set/Lattice/Image.lean
+++ b/Mathlib/Data/Set/Lattice/Image.lean
@@ -368,6 +368,16 @@ lemma iInter₂_union_iInter₂ {ι₁ κ₁ : Sort*} {ι₂ : ι₁ → Sort*} 
     (⋂ i₁, ⋂ i₂, f i₁ i₂) ∪ ⋂ j₁, ⋂ j₂, g j₁ j₂ = ⋂ i₁, ⋂ i₂, ⋂ j₁, ⋂ j₂, f i₁ i₂ ∪ g j₁ j₂ := by
   simp_rw [iInter_union, union_iInter]
 
+theorem biUnion_inter_of_pairwise_disjoint {ι : Type*} {f : ι → Set α}
+    (h : Pairwise (Disjoint on f)) (s t : Set ι) :
+    (⋃ i ∈ (s ∩ t), f i) = (⋃ i ∈ s, f i) ∩ (⋃ i ∈ t, f i) :=
+  biSup_inter_of_pairwise_disjoint h s t
+
+theorem biUnion_iInter_of_pairwise_disjoint {ι κ : Type*}
+    [hκ : Nonempty κ] {f : ι → Set α} (h : Pairwise (Disjoint on f)) (s : κ → Set ι) :
+    (⋃ i ∈ (⋂ j, s j), f i) = ⋂ j, (⋃ i ∈ s j, f i) :=
+  biSup_iInter_of_pairwise_disjoint h s
+
 end Image
 
 section Preimage

--- a/Mathlib/Order/CompleteBooleanAlgebra.lean
+++ b/Mathlib/Order/CompleteBooleanAlgebra.lean
@@ -336,7 +336,7 @@ theorem biSup_iInter_of_pairwise_disjoint [CompletelyDistribLattice α] {ι κ :
   · exact le_iSup₂_of_le (I j) (fun k ↦ (H k) ▸ (hI k)) (iInf_le _ _)
   · push_neg at H
     rcases H with ⟨k, hk⟩
-    calc ⨅ k, f (I k)
+    calc ⨅ l, f (I l)
     _ ≤ f (I k) ⊓ f (I j) := le_inf (iInf_le _ _) (iInf_le _ _)
     _ = ⊥ := (h hk).eq_bot
     _ ≤ _ := bot_le


### PR DESCRIPTION
A basic order/set lemma: given a family `f` of pairwise disjoint sets, one has `⋃ i ∈ (s ∩ t), f i = (⋃ i ∈ s, f i) ∩ (⋃ i ∈ t, f i)`.

Prompted by #30109 

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include at least one commit authored by each
co-author among the commits in the pull request. If necessary, you may 
create empty commits to indicate co-authorship, using commands like so:

git commit --author="Author Name <author@email.com>" --allow-empty -m "add Author Name as coauthor"

When merging, all the commits will be squashed into a single commit listing all co-authors.

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
