### PR TITLE
[Merged by Bors] - chore: fix deprecations

### DIFF
--- a/Mathlib/Topology/UniformSpace/DiscreteUniformity.lean
+++ b/Mathlib/Topology/UniformSpace/DiscreteUniformity.lean
@@ -36,7 +36,7 @@ theorem _root_.discreteUniformity_iff_eq_principal_relId {X : Type*} [UniformSpa
   rw [discreteUniformity_iff_eq_bot, UniformSpace.ext_iff, Filter.ext_iff, bot_uniformity]
 
 @[deprecated (since := "2025-10-17")]
-alias discreteUniformity_iff_eq_principal_idRel := discreteUniformity_iff_eq_principal_relId
+alias _root_.discreteUniformity_iff_eq_principal_idRel := discreteUniformity_iff_eq_principal_relId
 
 theorem eq_principal_relId : uniformity X = 𝓟 SetRel.id :=
   discreteUniformity_iff_eq_principal_relId.mp inferInstance
@@ -54,7 +54,8 @@ theorem _root_.discreteUniformity_iff_relId_mem_uniformity {X : Type*} [UniformS
   rw [← uniformSpace_eq_bot, discreteUniformity_iff_eq_bot]
 
 @[deprecated (since := "2025-10-17")]
-alias discreteUniformity_iff_idRel_mem_uniformity := discreteUniformity_iff_relId_mem_uniformity
+alias _root_.discreteUniformity_iff_idRel_mem_uniformity :=
+  discreteUniformity_iff_relId_mem_uniformity
 
 theorem relId_mem_uniformity : SetRel.id ∈ uniformity X :=
   discreteUniformity_iff_relId_mem_uniformity.mp inferInstance


### PR DESCRIPTION
I was just caught out by an incorrect deprecation in #23181.
The issue is that the declaration being deprecated is in the root namespace, and the
deprecated declaration is declared in the current namespace which is not the root
namspace (it's `DiscreteUniformity`). There are two of these in this file; I fixed both.

---

Maybe this link works? https://github.com/leanprover-community/mathlib4/pull/23181/files#diff-002673487a3292d9b29a88ccfcefc7e2110d1799de4e4ac7d1c1c62d38d29efaR34-R35

<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include at least one commit authored by each
co-author among the commits in the pull request. If necessary, you may 
create empty commits to indicate co-authorship, using commands like so:

git commit --author="Author Name <author@email.com>" --allow-empty -m "add Author Name as coauthor"

When merging, all the commits will be squashed into a single commit listing all co-authors.

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
