### PR TITLE
[Merged by Bors] - chore(Computability/AkraBazzi): golf `growsPolynomially_log` using `grind`

### DIFF
--- a/Mathlib/Computability/AkraBazzi/GrowsPolynomially.lean
+++ b/Mathlib/Computability/AkraBazzi/GrowsPolynomially.lean
@@ -645,12 +645,7 @@ lemma growsPolynomially_log : GrowsPolynomially Real.log := by
   refine ⟨?lb, ?ub⟩
   case lb => calc
     1 / 2 * Real.log x = Real.log x + (-1 / 2) * Real.log x := by ring
-      _ ≤ Real.log x + Real.log b := by
-              gcongr
-              rw [neg_div, neg_mul, ← neg_le]
-              refine le_of_lt (hx x ?_)
-              calc b * x ≤ 1 * x := by gcongr; exact le_of_lt hb.2
-                       _ = x := by rw [one_mul]
+      _ ≤ Real.log x + Real.log b := by grind
       _ = Real.log (b * x) := by rw [← Real.log_mul (by positivity) (by positivity), mul_comm]
       _ ≤ Real.log u := by gcongr; exact hu.1
   case ub =>


### PR DESCRIPTION
---
<details>
<summary>Show trace profiling of <code>growsPolynomially_log</code>: 354 ms before, 255 ms after  🎉</summary>

### Trace profiling of `growsPolynomially_log` before PR 31069
```diff
diff --git a/Mathlib/Computability/AkraBazzi/GrowsPolynomially.lean b/Mathlib/Computability/AkraBazzi/GrowsPolynomially.lean
index dc9ff283cb..f336a9a02d 100644
--- a/Mathlib/Computability/AkraBazzi/GrowsPolynomially.lean
+++ b/Mathlib/Computability/AkraBazzi/GrowsPolynomially.lean
@@ -631,6 +631,7 @@ lemma growsPolynomially_pow (p : ℕ) : GrowsPolynomially fun x => x ^ p :=
 lemma growsPolynomially_zpow (p : ℤ) : GrowsPolynomially fun x => x ^ p :=
   (growsPolynomially_id).zpow p (eventually_ge_atTop 0)
 
+set_option trace.profiler true in
 lemma growsPolynomially_log : GrowsPolynomially Real.log := by
   intro b hb
   have hb₀ : 0 < b := hb.1
```
```
ℹ [1904/1904] Built Mathlib.Computability.AkraBazzi.GrowsPolynomially (3.1s)
info: Mathlib/Computability/AkraBazzi/GrowsPolynomially.lean:635:0: [Elab.async] [0.356638] elaborating proof of AkraBazziRecurrence.growsPolynomially_log
  [Elab.definition.value] [0.354403] AkraBazziRecurrence.growsPolynomially_log
    [Elab.step] [0.353936] 
          intro b hb
          have hb₀ : 0 < b := hb.1
          refine ⟨1 / 2, by norm_num, ?_⟩
          refine ⟨1, by norm_num, ?_⟩
          have h_tendsto : Tendsto (fun x => 1 / 2 * Real.log x) atTop atTop :=
            Tendsto.const_mul_atTop (by norm_num) Real.tendsto_log_atTop
          filter_upwards [eventually_gt_atTop 1,
            (tendsto_id.const_mul_atTop hb.1).eventually_forall_ge_atTop <|
              h_tendsto.eventually (eventually_gt_atTop (-Real.log b))] with
            x hx_pos hx
          intro u hu
          refine ⟨?lb, ?ub⟩
          case lb =>
            calc
              1 / 2 * Real.log x = Real.log x + (-1 / 2) * Real.log x := by ring
              _ ≤ Real.log x + Real.log b := by
                gcongr
                rw [neg_div, neg_mul, ← neg_le]
                refine le_of_lt (hx x ?_)
                calc
                  b * x ≤ 1 * x := by gcongr; exact le_of_lt hb.2
                  _ = x := by rw [one_mul]
              _ = Real.log (b * x) := by rw [← Real.log_mul (by positivity) (by positivity), mul_comm]
              _ ≤ Real.log u := by gcongr; exact hu.1
          case ub =>
            rw [one_mul]
            gcongr
            ·
              calc
                0 < b * x := by positivity
                _ ≤ u := by exact hu.1
            · exact hu.2
      [Elab.step] [0.353929] 
            intro b hb
            have hb₀ : 0 < b := hb.1
            refine ⟨1 / 2, by norm_num, ?_⟩
            refine ⟨1, by norm_num, ?_⟩
            have h_tendsto : Tendsto (fun x => 1 / 2 * Real.log x) atTop atTop :=
              Tendsto.const_mul_atTop (by norm_num) Real.tendsto_log_atTop
            filter_upwards [eventually_gt_atTop 1,
              (tendsto_id.const_mul_atTop hb.1).eventually_forall_ge_atTop <|
                h_tendsto.eventually (eventually_gt_atTop (-Real.log b))] with
              x hx_pos hx
            intro u hu
            refine ⟨?lb, ?ub⟩
            case lb =>
              calc
                1 / 2 * Real.log x = Real.log x + (-1 / 2) * Real.log x := by ring
                _ ≤ Real.log x + Real.log b := by
                  gcongr
                  rw [neg_div, neg_mul, ← neg_le]
                  refine le_of_lt (hx x ?_)
                  calc
                    b * x ≤ 1 * x := by gcongr; exact le_of_lt hb.2
                    _ = x := by rw [one_mul]
                _ = Real.log (b * x) := by rw [← Real.log_mul (by positivity) (by positivity), mul_comm]
                _ ≤ Real.log u := by gcongr; exact hu.1
            case ub =>
              rw [one_mul]
              gcongr
              ·
                calc
                  0 < b * x := by positivity
                  _ ≤ u := by exact hu.1
              · exact hu.2
        [Elab.step] [0.010697] refine ⟨1 / 2, by norm_num, ?_⟩
        [Elab.step] [0.016036] have h_tendsto : Tendsto (fun x => 1 / 2 * Real.log x) atTop atTop :=
              Tendsto.const_mul_atTop (by norm_num) Real.tendsto_log_atTop
          [Elab.step] [0.016024] refine_lift
                have h_tendsto : Tendsto (fun x => 1 / 2 * Real.log x) atTop atTop :=
                  Tendsto.const_mul_atTop (by norm_num) Real.tendsto_log_atTop;
                ?_
            [Elab.step] [0.016018] focus
                  (refine
                      no_implicit_lambda%
                        (have h_tendsto : Tendsto (fun x => 1 / 2 * Real.log x) atTop atTop :=
                          Tendsto.const_mul_atTop (by norm_num) Real.tendsto_log_atTop;
                        ?_);
                    rotate_right)
              [Elab.step] [0.016013] (refine
                        no_implicit_lambda%
                          (have h_tendsto : Tendsto (fun x => 1 / 2 * Real.log x) atTop atTop :=
                            Tendsto.const_mul_atTop (by norm_num) Real.tendsto_log_atTop;
                          ?_);
                      rotate_right)
                [Elab.step] [0.016009] (refine
                          no_implicit_lambda%
                            (have h_tendsto : Tendsto (fun x => 1 / 2 * Real.log x) atTop atTop :=
                              Tendsto.const_mul_atTop (by norm_num) Real.tendsto_log_atTop;
                            ?_);
                        rotate_right)
                  [Elab.step] [0.016004] (refine
                          no_implicit_lambda%
                            (have h_tendsto : Tendsto (fun x => 1 / 2 * Real.log x) atTop atTop :=
                              Tendsto.const_mul_atTop (by norm_num) Real.tendsto_log_atTop;
                            ?_);
[… 141 lines omitted …]
                                  [Meta.synthInstance.tryResolve] [0.011988] ❌️ CanonicallyOrderedAdd
                                        ℝ ≟ CanonicallyOrderedAdd ?m.259
                                    [Meta.isDefEq] [0.011980] ❌️ CanonicallyOrderedAdd
                                          ℝ =?= CanonicallyOrderedAdd ?m.259
                                      [Meta.isDefEq] [0.011927] ❌️ NormedCommRing.toNonUnitalNormedCommRing.toNonUnitalCommRing.toNonUnitalNonAssocCommRing.toNonUnitalNonAssocCommSemiring.toDistrib.toAdd =?= IdemSemiring.toSemiring.toNonAssocSemiring.toDistrib.toAdd
                              [Meta.synthInstance] [0.047429] ❌️ MulRightMono ℝ
                                [Meta.synthInstance] [0.012317] ❌️ apply @IdemSemiring.toMulLeftMono to CovariantClass ℝ
                                      ℝ (fun x1 x2 ↦ x1 * x2) fun x1 x2 ↦ x1 ≤ x2
                                  [Meta.synthInstance.tryResolve] [0.012278] ❌️ CovariantClass ℝ ℝ (fun x1 x2 ↦ x1 * x2)
                                        fun x1 x2 ↦
                                        x1 ≤ x2 ≟ CovariantClass ?m.259 ?m.259 (fun x1 x2 ↦ x1 * x2) fun x1 x2 ↦ x1 ≤ x2
                                    [Meta.isDefEq] [0.012272] ❌️ CovariantClass ℝ ℝ (fun x1 x2 ↦ x1 * x2) fun x1 x2 ↦
                                          x1 ≤
                                            x2 =?= CovariantClass ?m.259 ?m.259 (fun x1 x2 ↦ x1 * x2) fun x1 x2 ↦
                                          x1 ≤ x2
                                      [Meta.isDefEq] [0.012227] ❌️ fun x1 x2 ↦ x1 * x2 =?= fun x1 x2 ↦ x1 * x2
                                        [Meta.isDefEq] [0.012217] ❌️ x1✝ * x2✝ =?= x1✝ * x2✝
                                [Meta.synthInstance] [0.014426] ❌️ apply @IdemSemiring.toCanonicallyOrderedAdd to CanonicallyOrderedAdd
                                      ℝ
                                  [Meta.synthInstance.tryResolve] [0.014410] ❌️ CanonicallyOrderedAdd
                                        ℝ ≟ CanonicallyOrderedAdd ?m.263
                                    [Meta.isDefEq] [0.014405] ❌️ CanonicallyOrderedAdd
                                          ℝ =?= CanonicallyOrderedAdd ?m.263
                                      [Meta.isDefEq] [0.014361] ❌️ NonUnitalCommRing.toNonUnitalCommSemiring.toDistrib.toAdd =?= IdemSemiring.toSemiring.toNonAssocSemiring.toDistrib.toAdd
                                [Meta.synthInstance] [0.012133] ❌️ apply @IdemSemiring.toCanonicallyOrderedAdd to CanonicallyOrderedAdd
                                      ℝ
                                  [Meta.synthInstance.tryResolve] [0.012116] ❌️ CanonicallyOrderedAdd
                                        ℝ ≟ CanonicallyOrderedAdd ?m.259
                                    [Meta.isDefEq] [0.012110] ❌️ CanonicallyOrderedAdd
                                          ℝ =?= CanonicallyOrderedAdd ?m.259
                                      [Meta.isDefEq] [0.012060] ❌️ NormedCommRing.toNonUnitalNormedCommRing.toNonUnitalCommRing.toNonUnitalNonAssocCommRing.toNonUnitalNonAssocCommSemiring.toDistrib.toAdd =?= IdemSemiring.toSemiring.toNonAssocSemiring.toDistrib.toAdd
                              [Elab.step] [0.012992] gcongr_discharger
                                [Elab.step] [0.012652] positivity
                [Elab.step] [0.026298] rw [← Real.log_mul (by positivity) (by positivity), mul_comm]
                  [Elab.step] [0.026291] rw [← Real.log_mul (by positivity) (by positivity), mul_comm]
                    [Elab.step] [0.026286] rw [← Real.log_mul (by positivity) (by positivity), mul_comm]
                      [Elab.step] [0.026280] (rewrite [← Real.log_mul (by positivity) (by positivity), mul_comm];
                            with_annotate_state"]" (try (with_reducible rfl)))
                        [Elab.step] [0.026277] rewrite [← Real.log_mul (by positivity) (by positivity), mul_comm];
                              with_annotate_state"]" (try (with_reducible rfl))
                          [Elab.step] [0.026273] rewrite [← Real.log_mul (by positivity) (by positivity), mul_comm];
                                with_annotate_state"]" (try (with_reducible rfl))
                            [Elab.step] [0.025717] rewrite [← Real.log_mul (by positivity) (by positivity), mul_comm]
                              [Elab.step] [0.012806] positivity
                                [Elab.step] [0.012801] positivity
                                  [Elab.step] [0.012794] positivity
                              [Elab.step] [0.010562] positivity
                                [Elab.step] [0.010554] positivity
                                  [Elab.step] [0.010543] positivity
                [Elab.step] [0.025547] gcongr; exact hu.1
                  [Elab.step] [0.025541] gcongr; exact hu.1
                    [Elab.step] [0.025153] gcongr
                      [Meta.gcongr] [0.025122] gcongr: ⊢ log (b * x) ≤ log u
                        [Elab.step] [0.013425] gcongr_discharger
                          [Elab.step] [0.013181] positivity
        [Elab.step] [0.043300] case ub =>
              rw [one_mul]
              gcongr
              ·
                calc
                  0 < b * x := by positivity
                  _ ≤ u := by exact hu.1
              · exact hu.2
          [Elab.step] [0.043283] 
                rw [one_mul]
                gcongr
                ·
                  calc
                    0 < b * x := by positivity
                    _ ≤ u := by exact hu.1
                · exact hu.2
            [Elab.step] [0.043278] 
                  rw [one_mul]
                  gcongr
                  ·
                    calc
                      0 < b * x := by positivity
                      _ ≤ u := by exact hu.1
                  · exact hu.2
              [Elab.step] [0.023675] gcongr
                [Meta.gcongr] [0.023544] gcongr: ⊢ log u ≤ log x
                  [Elab.step] [0.011538] gcongr_discharger
                    [Elab.step] [0.011293] positivity
              [Elab.step] [0.017687] ·
                    calc
                      0 < b * x := by positivity
                      _ ≤ u := by exact hu.1
                [Elab.step] [0.017638] calc
                        0 < b * x := by positivity
                        _ ≤ u := by exact hu.1
                  [Elab.step] [0.017634] calc
                          0 < b * x := by positivity
                          _ ≤ u := by exact hu.1
                    [Elab.step] [0.017628] calc
                          0 < b * x := by positivity
                          _ ≤ u := by exact hu.1
                      [Elab.step] [0.014369] positivity
                        [Elab.step] [0.014363] positivity
                          [Elab.step] [0.014355] positivity
Build completed successfully (1904 jobs).
```

### Trace profiling of `growsPolynomially_log` after PR 31069
```diff
diff --git a/Mathlib/Computability/AkraBazzi/GrowsPolynomially.lean b/Mathlib/Computability/AkraBazzi/GrowsPolynomially.lean
index dc9ff283cb..46c497efe6 100644
--- a/Mathlib/Computability/AkraBazzi/GrowsPolynomially.lean
+++ b/Mathlib/Computability/AkraBazzi/GrowsPolynomially.lean
@@ -631,6 +631,7 @@ lemma growsPolynomially_pow (p : ℕ) : GrowsPolynomially fun x => x ^ p :=
 lemma growsPolynomially_zpow (p : ℤ) : GrowsPolynomially fun x => x ^ p :=
   (growsPolynomially_id).zpow p (eventually_ge_atTop 0)
 
+set_option trace.profiler true in
 lemma growsPolynomially_log : GrowsPolynomially Real.log := by
   intro b hb
   have hb₀ : 0 < b := hb.1
@@ -645,12 +646,7 @@ lemma growsPolynomially_log : GrowsPolynomially Real.log := by
   refine ⟨?lb, ?ub⟩
   case lb => calc
     1 / 2 * Real.log x = Real.log x + (-1 / 2) * Real.log x := by ring
-      _ ≤ Real.log x + Real.log b := by
-              gcongr
-              rw [neg_div, neg_mul, ← neg_le]
-              refine le_of_lt (hx x ?_)
-              calc b * x ≤ 1 * x := by gcongr; exact le_of_lt hb.2
-                       _ = x := by rw [one_mul]
+      _ ≤ Real.log x + Real.log b := by grind
       _ = Real.log (b * x) := by rw [← Real.log_mul (by positivity) (by positivity), mul_comm]
       _ ≤ Real.log u := by gcongr; exact hu.1
   case ub =>
```
```
ℹ [1904/1904] Built Mathlib.Computability.AkraBazzi.GrowsPolynomially (3.0s)
info: Mathlib/Computability/AkraBazzi/GrowsPolynomially.lean:635:0: [Elab.async] [0.256365] elaborating proof of AkraBazziRecurrence.growsPolynomially_log
  [Elab.definition.value] [0.255131] AkraBazziRecurrence.growsPolynomially_log
    [Elab.step] [0.254766] 
          intro b hb
          have hb₀ : 0 < b := hb.1
          refine ⟨1 / 2, by norm_num, ?_⟩
          refine ⟨1, by norm_num, ?_⟩
          have h_tendsto : Tendsto (fun x => 1 / 2 * Real.log x) atTop atTop :=
            Tendsto.const_mul_atTop (by norm_num) Real.tendsto_log_atTop
          filter_upwards [eventually_gt_atTop 1,
            (tendsto_id.const_mul_atTop hb.1).eventually_forall_ge_atTop <|
              h_tendsto.eventually (eventually_gt_atTop (-Real.log b))] with
            x hx_pos hx
          intro u hu
          refine ⟨?lb, ?ub⟩
          case lb =>
            calc
              1 / 2 * Real.log x = Real.log x + (-1 / 2) * Real.log x := by ring
              _ ≤ Real.log x + Real.log b := by grind
              _ = Real.log (b * x) := by rw [← Real.log_mul (by positivity) (by positivity), mul_comm]
              _ ≤ Real.log u := by gcongr; exact hu.1
          case ub =>
            rw [one_mul]
            gcongr
            ·
              calc
                0 < b * x := by positivity
                _ ≤ u := by exact hu.1
            · exact hu.2
      [Elab.step] [0.254760] 
            intro b hb
            have hb₀ : 0 < b := hb.1
            refine ⟨1 / 2, by norm_num, ?_⟩
            refine ⟨1, by norm_num, ?_⟩
            have h_tendsto : Tendsto (fun x => 1 / 2 * Real.log x) atTop atTop :=
              Tendsto.const_mul_atTop (by norm_num) Real.tendsto_log_atTop
            filter_upwards [eventually_gt_atTop 1,
              (tendsto_id.const_mul_atTop hb.1).eventually_forall_ge_atTop <|
                h_tendsto.eventually (eventually_gt_atTop (-Real.log b))] with
              x hx_pos hx
            intro u hu
            refine ⟨?lb, ?ub⟩
            case lb =>
              calc
                1 / 2 * Real.log x = Real.log x + (-1 / 2) * Real.log x := by ring
                _ ≤ Real.log x + Real.log b := by grind
                _ = Real.log (b * x) := by rw [← Real.log_mul (by positivity) (by positivity), mul_comm]
                _ ≤ Real.log u := by gcongr; exact hu.1
            case ub =>
              rw [one_mul]
              gcongr
              ·
                calc
                  0 < b * x := by positivity
                  _ ≤ u := by exact hu.1
              · exact hu.2
        [Elab.step] [0.010469] refine ⟨1 / 2, by norm_num, ?_⟩
        [Elab.step] [0.018483] have h_tendsto : Tendsto (fun x => 1 / 2 * Real.log x) atTop atTop :=
              Tendsto.const_mul_atTop (by norm_num) Real.tendsto_log_atTop
          [Elab.step] [0.018475] refine_lift
                have h_tendsto : Tendsto (fun x => 1 / 2 * Real.log x) atTop atTop :=
                  Tendsto.const_mul_atTop (by norm_num) Real.tendsto_log_atTop;
                ?_
            [Elab.step] [0.018470] focus
                  (refine
                      no_implicit_lambda%
                        (have h_tendsto : Tendsto (fun x => 1 / 2 * Real.log x) atTop atTop :=
                          Tendsto.const_mul_atTop (by norm_num) Real.tendsto_log_atTop;
                        ?_);
                    rotate_right)
              [Elab.step] [0.018466] (refine
                        no_implicit_lambda%
                          (have h_tendsto : Tendsto (fun x => 1 / 2 * Real.log x) atTop atTop :=
                            Tendsto.const_mul_atTop (by norm_num) Real.tendsto_log_atTop;
                          ?_);
                      rotate_right)
                [Elab.step] [0.018462] (refine
                          no_implicit_lambda%
                            (have h_tendsto : Tendsto (fun x => 1 / 2 * Real.log x) atTop atTop :=
                              Tendsto.const_mul_atTop (by norm_num) Real.tendsto_log_atTop;
                            ?_);
                        rotate_right)
                  [Elab.step] [0.018458] (refine
                          no_implicit_lambda%
                            (have h_tendsto : Tendsto (fun x => 1 / 2 * Real.log x) atTop atTop :=
                              Tendsto.const_mul_atTop (by norm_num) Real.tendsto_log_atTop;
                            ?_);
                        rotate_right)
                    [Elab.step] [0.018454] refine
                            no_implicit_lambda%
                              (have h_tendsto : Tendsto (fun x => 1 / 2 * Real.log x) atTop atTop :=
                                Tendsto.const_mul_atTop (by norm_num) Real.tendsto_log_atTop;
                              ?_);
                          rotate_right
                      [Elab.step] [0.018451] refine
                              no_implicit_lambda%
                                (have h_tendsto : Tendsto (fun x => 1 / 2 * Real.log x) atTop atTop :=
                                  Tendsto.const_mul_atTop (by norm_num) Real.tendsto_log_atTop;
                                ?_);
[… 26 lines omitted …]
                _ ≤ Real.log u := by gcongr; exact hu.1
          [Elab.step] [0.160640] calc
                  1 / 2 * Real.log x = Real.log x + (-1 / 2) * Real.log x := by ring
                  _ ≤ Real.log x + Real.log b := by grind
                  _ = Real.log (b * x) := by rw [← Real.log_mul (by positivity) (by positivity), mul_comm]
                  _ ≤ Real.log u := by gcongr; exact hu.1
            [Elab.step] [0.160636] calc
                    1 / 2 * Real.log x = Real.log x + (-1 / 2) * Real.log x := by ring
                    _ ≤ Real.log x + Real.log b := by grind
                    _ = Real.log (b * x) := by rw [← Real.log_mul (by positivity) (by positivity), mul_comm]
                    _ ≤ Real.log u := by gcongr; exact hu.1
              [Elab.step] [0.160628] calc
                    1 / 2 * Real.log x = Real.log x + (-1 / 2) * Real.log x := by ring
                    _ ≤ Real.log x + Real.log b := by grind
                    _ = Real.log (b * x) := by rw [← Real.log_mul (by positivity) (by positivity), mul_comm]
                    _ ≤ Real.log u := by gcongr; exact hu.1
                [Elab.step] [0.018421] ring
                  [Elab.step] [0.018416] ring
                    [Elab.step] [0.018409] ring
                      [Elab.step] [0.017998] first
                          | ring1
                          |
                            try_this
                              ring_nf"\n\nThe `ring` tactic failed to close the goal. Use `ring_nf` to obtain a normal form.
                                \nNote that `ring` works primarily in *commutative* rings. \
                                If you have a noncommutative ring, abelian group or module, consider using \
                                `noncomm_ring`, `abel` or `module` instead."
                        [Elab.step] [0.017991] ring1
                          [Elab.step] [0.017986] ring1
                            [Elab.step] [0.017977] ring1
                [Elab.step] [0.079877] grind
                  [Elab.step] [0.079871] grind
                    [Elab.step] [0.079863] grind
                [Elab.step] [0.025277] rw [← Real.log_mul (by positivity) (by positivity), mul_comm]
                  [Elab.step] [0.025270] rw [← Real.log_mul (by positivity) (by positivity), mul_comm]
                    [Elab.step] [0.025264] rw [← Real.log_mul (by positivity) (by positivity), mul_comm]
                      [Elab.step] [0.025256] (rewrite [← Real.log_mul (by positivity) (by positivity), mul_comm];
                            with_annotate_state"]" (try (with_reducible rfl)))
                        [Elab.step] [0.025252] rewrite [← Real.log_mul (by positivity) (by positivity), mul_comm];
                              with_annotate_state"]" (try (with_reducible rfl))
                          [Elab.step] [0.025249] rewrite [← Real.log_mul (by positivity) (by positivity), mul_comm];
                                with_annotate_state"]" (try (with_reducible rfl))
                            [Elab.step] [0.024729] rewrite [← Real.log_mul (by positivity) (by positivity), mul_comm]
                              [Elab.step] [0.011931] positivity
                                [Elab.step] [0.011927] positivity
                                  [Elab.step] [0.011919] positivity
                              [Elab.step] [0.010298] positivity
                                [Elab.step] [0.010293] positivity
                                  [Elab.step] [0.010286] positivity
                [Elab.step] [0.027232] gcongr; exact hu.1
                  [Elab.step] [0.027227] gcongr; exact hu.1
                    [Elab.step] [0.026834] gcongr
                      [Meta.gcongr] [0.026673] gcongr: ⊢ log (b * x) ≤ log u
                        [Elab.step] [0.014302] gcongr_discharger
                          [Elab.step] [0.014078] positivity
        [Elab.step] [0.043672] case ub =>
              rw [one_mul]
              gcongr
              ·
                calc
                  0 < b * x := by positivity
                  _ ≤ u := by exact hu.1
              · exact hu.2
          [Elab.step] [0.043657] 
                rw [one_mul]
                gcongr
                ·
                  calc
                    0 < b * x := by positivity
                    _ ≤ u := by exact hu.1
                · exact hu.2
            [Elab.step] [0.043653] 
                  rw [one_mul]
                  gcongr
                  ·
                    calc
                      0 < b * x := by positivity
                      _ ≤ u := by exact hu.1
                  · exact hu.2
              [Elab.step] [0.024217] gcongr
                [Meta.gcongr] [0.024065] gcongr: ⊢ log u ≤ log x
                  [Elab.step] [0.011367] gcongr_discharger
                    [Elab.step] [0.011105] positivity
              [Elab.step] [0.017394] ·
                    calc
                      0 < b * x := by positivity
                      _ ≤ u := by exact hu.1
                [Elab.step] [0.017355] calc
                        0 < b * x := by positivity
                        _ ≤ u := by exact hu.1
                  [Elab.step] [0.017351] calc
                          0 < b * x := by positivity
                          _ ≤ u := by exact hu.1
                    [Elab.step] [0.017344] calc
                          0 < b * x := by positivity
                          _ ≤ u := by exact hu.1
                      [Elab.step] [0.014229] positivity
                        [Elab.step] [0.014224] positivity
                          [Elab.step] [0.014217] positivity
Build completed successfully (1904 jobs).
```
</details>

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include at least one commit authored by each
co-author among the commits in the pull request. If necessary, you may 
create empty commits to indicate co-authorship, using commands like so:

git commit --author="Author Name <author@email.com>" --allow-empty -m "add Author Name as coauthor"

When merging, all the commits will be squashed into a single commit listing all co-authors.

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
