### PR TITLE
[Merged by Bors] - golf(Combinatorics/Quiver/Path): golf `exists_eq_comp_and_notMem_tail_of_mem_vertices` using `grind`

### DIFF
--- a/Mathlib/Combinatorics/Quiver/Path/Vertices.lean
+++ b/Mathlib/Combinatorics/Quiver/Path/Vertices.lean
@@ -230,18 +230,7 @@ theorem exists_eq_comp_and_notMem_tail_of_mem_vertices {v : V} (hv : v ∈ p.ver
       intro hxPrev hxe_ne
       obtain ⟨q₁, q₂, h_prev, h_not_tail⟩ := ih hxPrev
       let q₂' : Path v (pPrev.cons e).end := q₂.cons e
-      have h_no_tail : v ∉ q₂'.vertices.tail := by
-        intro hmem
-        have hmem' : v ∈ (q₂.vertices ++ [(pPrev.cons e).end]).tail := by
-          simpa [q₂', vertices_cons, concat_eq_append] using hmem
-        cases hq2 : q₂.vertices with
-        | nil => simp [hq2] at hmem'
-        | cons y ys =>
-            have hx_in : v ∈ ys ++ [(pPrev.cons e).end] := by simpa [hq2] using hmem'
-            obtain (hx_ys | hx_last) := List.mem_append.mp hx_in
-            · exact h_not_tail <| by simpa [hq2]
-            · have : v = (pPrev.cons e).end := by simpa [List.mem_singleton] using hx_last
-              exact hxe_ne this
+      have h_no_tail : v ∉ q₂'.vertices.tail := by grind [vertices_cons, end_cons]
       exact ⟨q₁, q₂', by simp [q₂', h_prev], h_no_tail⟩
     cases hv' with
     | inl h_in_prefix =>


### PR DESCRIPTION
---
<details>
<summary>Show trace profiling of <code>exists_eq_comp_and_notMem_tail_of_mem_vertices</code>: 38 ms before, 46 ms after </summary>

### Trace profiling of `exists_eq_comp_and_notMem_tail_of_mem_vertices` before PR 31072
```diff
diff --git a/Mathlib/Combinatorics/Quiver/Path/Vertices.lean b/Mathlib/Combinatorics/Quiver/Path/Vertices.lean
index 9d27be9e85..35d3daa185 100644
--- a/Mathlib/Combinatorics/Quiver/Path/Vertices.lean
+++ b/Mathlib/Combinatorics/Quiver/Path/Vertices.lean
@@ -206,6 +206,7 @@ theorem exists_eq_comp_of_mem_vertices {v : V} (hv : v ∈ p.vertices) :
   obtain ⟨v, p₁, p₂, hp, hv, rfl⟩ := p.exists_eq_comp_and_length_eq_of_lt_length n hn
   exact ⟨p₁, p₂, hp⟩
 
+set_option trace.profiler true in
 /-- Split a path at the *last* occurrence of a vertex. -/
 theorem exists_eq_comp_and_notMem_tail_of_mem_vertices {v : V} (hv : v ∈ p.vertices) :
     ∃ (p₁ : Path a v) (p₂ : Path v b),
```
```
ℹ [521/521] Built Mathlib.Combinatorics.Quiver.Path.Vertices (1.1s)
info: Mathlib/Combinatorics/Quiver/Path/Vertices.lean:210:0: [Elab.async] [0.039993] elaborating proof of Quiver.Path.exists_eq_comp_and_notMem_tail_of_mem_vertices
  [Elab.definition.value] [0.038334] Quiver.Path.exists_eq_comp_and_notMem_tail_of_mem_vertices
    [Elab.step] [0.036860] induction p with
          | nil =>
            have hxa : v = a := by simpa [vertices_nil, List.mem_singleton] using hv
            subst hxa
            exact
              ⟨Path.nil, Path.nil, by simp only [comp_nil], by
                simp only [vertices_nil, tail_cons, not_mem_nil, not_false_eq_true]⟩
          | cons pPrev e
            ih =>
            have hv' : v ∈ pPrev.vertices ∨ v = (pPrev.cons e).end := by simpa using (mem_vertices_cons pPrev e).1 hv
            have h_case₁ :
              v = (pPrev.cons e).end →
                ∃ (p₁ : Path a v) (p₂ : Path v (pPrev.cons e).end), pPrev.cons e = p₁.comp p₂ ∧ v ∉ p₂.vertices.tail :=
              by
              rintro rfl
              exact ⟨pPrev.cons e, Path.nil, by simp [comp_nil], by simp [vertices_nil]⟩
            have h_case₂ :
              v ∈ pPrev.vertices →
                v ≠ (pPrev.cons e).end →
                  ∃ (p₁ : Path a v) (p₂ : Path v (pPrev.cons e).end),
                    pPrev.cons e = p₁.comp p₂ ∧ v ∉ p₂.vertices.tail :=
              by
              intro hxPrev hxe_ne
              obtain ⟨q₁, q₂, h_prev, h_not_tail⟩ := ih hxPrev
              let q₂' : Path v (pPrev.cons e).end := q₂.cons e
              have h_no_tail : v ∉ q₂'.vertices.tail := by
                intro hmem
                have hmem' : v ∈ (q₂.vertices ++ [(pPrev.cons e).end]).tail := by
                  simpa [q₂', vertices_cons, concat_eq_append] using hmem
                cases hq2 : q₂.vertices with
                | nil => simp [hq2] at hmem'
                | cons y ys =>
                  have hx_in : v ∈ ys ++ [(pPrev.cons e).end] := by simpa [hq2] using hmem'
                  obtain (hx_ys | hx_last) := List.mem_append.mp hx_in
                  · exact h_not_tail <| by simpa [hq2]
                  · have : v = (pPrev.cons e).end := by simpa [List.mem_singleton] using hx_last
                    exact hxe_ne this
              exact ⟨q₁, q₂', by simp [q₂', h_prev], h_no_tail⟩
            cases hv' with
            | inl h_in_prefix =>
              by_cases h_eq_end : v = (pPrev.cons e).end
              · exact h_case₁ h_eq_end
              · exact h_case₂ h_in_prefix h_eq_end
            | inr h_eq_end => exact h_case₁ h_eq_end
      [Elab.step] [0.036855] induction p with
            | nil =>
              have hxa : v = a := by simpa [vertices_nil, List.mem_singleton] using hv
              subst hxa
              exact
                ⟨Path.nil, Path.nil, by simp only [comp_nil], by
                  simp only [vertices_nil, tail_cons, not_mem_nil, not_false_eq_true]⟩
            | cons pPrev e
              ih =>
              have hv' : v ∈ pPrev.vertices ∨ v = (pPrev.cons e).end := by simpa using (mem_vertices_cons pPrev e).1 hv
              have h_case₁ :
                v = (pPrev.cons e).end →
                  ∃ (p₁ : Path a v) (p₂ : Path v (pPrev.cons e).end),
                    pPrev.cons e = p₁.comp p₂ ∧ v ∉ p₂.vertices.tail :=
                by
                rintro rfl
                exact ⟨pPrev.cons e, Path.nil, by simp [comp_nil], by simp [vertices_nil]⟩
              have h_case₂ :
                v ∈ pPrev.vertices →
                  v ≠ (pPrev.cons e).end →
                    ∃ (p₁ : Path a v) (p₂ : Path v (pPrev.cons e).end),
                      pPrev.cons e = p₁.comp p₂ ∧ v ∉ p₂.vertices.tail :=
                by
                intro hxPrev hxe_ne
                obtain ⟨q₁, q₂, h_prev, h_not_tail⟩ := ih hxPrev
                let q₂' : Path v (pPrev.cons e).end := q₂.cons e
                have h_no_tail : v ∉ q₂'.vertices.tail := by
                  intro hmem
                  have hmem' : v ∈ (q₂.vertices ++ [(pPrev.cons e).end]).tail := by
                    simpa [q₂', vertices_cons, concat_eq_append] using hmem
                  cases hq2 : q₂.vertices with
                  | nil => simp [hq2] at hmem'
                  | cons y ys =>
                    have hx_in : v ∈ ys ++ [(pPrev.cons e).end] := by simpa [hq2] using hmem'
                    obtain (hx_ys | hx_last) := List.mem_append.mp hx_in
                    · exact h_not_tail <| by simpa [hq2]
                    · have : v = (pPrev.cons e).end := by simpa [List.mem_singleton] using hx_last
                      exact hxe_ne this
                exact ⟨q₁, q₂', by simp [q₂', h_prev], h_no_tail⟩
              cases hv' with
              | inl h_in_prefix =>
                by_cases h_eq_end : v = (pPrev.cons e).end
                · exact h_case₁ h_eq_end
                · exact h_case₂ h_in_prefix h_eq_end
              | inr h_eq_end => exact h_case₁ h_eq_end
        [Elab.step] [0.036851] induction p with
            | nil =>
              have hxa : v = a := by simpa [vertices_nil, List.mem_singleton] using hv
              subst hxa
              exact
                ⟨Path.nil, Path.nil, by simp only [comp_nil], by
                  simp only [vertices_nil, tail_cons, not_mem_nil, not_false_eq_true]⟩
            | cons pPrev e
[… 447 lines omitted …]
                                                        have hx_in : v ∈ ys ++ [(pPrev.cons e).end] := by
                                                          simpa [hq2] using hmem'
                                                        obtain (hx_ys | hx_last) := List.mem_append.mp hx_in
                                                        · exact h_not_tail <| by simpa [hq2]
                                                        · have : v = (pPrev.cons e).end := by
                                                            simpa [List.mem_singleton] using hx_last
                                                          exact hxe_ne this)
                                              [Elab.step] [0.014253] with_annotate_state"by"
                                                      ( intro hmem
                                                        have hmem' : v ∈ (q₂.vertices ++ [(pPrev.cons e).end]).tail :=
                                                          by simpa [q₂', vertices_cons, concat_eq_append] using hmem
                                                        cases hq2 : q₂.vertices with
                                                        | nil => simp [hq2] at hmem'
                                                        | cons y
                                                          ys =>
                                                          have hx_in : v ∈ ys ++ [(pPrev.cons e).end] := by
                                                            simpa [hq2] using hmem'
                                                          obtain (hx_ys | hx_last) := List.mem_append.mp hx_in
                                                          · exact h_not_tail <| by simpa [hq2]
                                                          · have : v = (pPrev.cons e).end := by
                                                              simpa [List.mem_singleton] using hx_last
                                                            exact hxe_ne this)
                                                [Elab.step] [0.014250] with_annotate_state"by"
                                                        ( intro hmem
                                                          have hmem' : v ∈ (q₂.vertices ++ [(pPrev.cons e).end]).tail :=
                                                            by simpa [q₂', vertices_cons, concat_eq_append] using hmem
                                                          cases hq2 : q₂.vertices with
                                                          | nil => simp [hq2] at hmem'
                                                          | cons y
                                                            ys =>
                                                            have hx_in : v ∈ ys ++ [(pPrev.cons e).end] := by
                                                              simpa [hq2] using hmem'
                                                            obtain (hx_ys | hx_last) := List.mem_append.mp hx_in
                                                            · exact h_not_tail <| by simpa [hq2]
                                                            · have : v = (pPrev.cons e).end := by
                                                                simpa [List.mem_singleton] using hx_last
                                                              exact hxe_ne this)
                                                  [Elab.step] [0.014246] with_annotate_state"by"
                                                        ( intro hmem
                                                          have hmem' : v ∈ (q₂.vertices ++ [(pPrev.cons e).end]).tail :=
                                                            by simpa [q₂', vertices_cons, concat_eq_append] using hmem
                                                          cases hq2 : q₂.vertices with
                                                          | nil => simp [hq2] at hmem'
                                                          | cons y
                                                            ys =>
                                                            have hx_in : v ∈ ys ++ [(pPrev.cons e).end] := by
                                                              simpa [hq2] using hmem'
                                                            obtain (hx_ys | hx_last) := List.mem_append.mp hx_in
                                                            · exact h_not_tail <| by simpa [hq2]
                                                            · have : v = (pPrev.cons e).end := by
                                                                simpa [List.mem_singleton] using hx_last
                                                              exact hxe_ne this)
                                                    [Elab.step] [0.014243] (
                                                          intro hmem
                                                          have hmem' : v ∈ (q₂.vertices ++ [(pPrev.cons e).end]).tail :=
                                                            by simpa [q₂', vertices_cons, concat_eq_append] using hmem
                                                          cases hq2 : q₂.vertices with
                                                          | nil => simp [hq2] at hmem'
                                                          | cons y
                                                            ys =>
                                                            have hx_in : v ∈ ys ++ [(pPrev.cons e).end] := by
                                                              simpa [hq2] using hmem'
                                                            obtain (hx_ys | hx_last) := List.mem_append.mp hx_in
                                                            · exact h_not_tail <| by simpa [hq2]
                                                            · have : v = (pPrev.cons e).end := by
                                                                simpa [List.mem_singleton] using hx_last
                                                              exact hxe_ne this)
                                                      [Elab.step] [0.014240] 
                                                            intro hmem
                                                            have hmem' :
                                                              v ∈ (q₂.vertices ++ [(pPrev.cons e).end]).tail := by
                                                              simpa [q₂', vertices_cons, concat_eq_append] using hmem
                                                            cases hq2 : q₂.vertices with
                                                            | nil => simp [hq2] at hmem'
                                                            | cons y
                                                              ys =>
                                                              have hx_in : v ∈ ys ++ [(pPrev.cons e).end] := by
                                                                simpa [hq2] using hmem'
                                                              obtain (hx_ys | hx_last) := List.mem_append.mp hx_in
                                                              · exact h_not_tail <| by simpa [hq2]
                                                              · have : v = (pPrev.cons e).end := by
                                                                  simpa [List.mem_singleton] using hx_last
                                                                exact hxe_ne this
                                                        [Elab.step] [0.014235] 
                                                              intro hmem
                                                              have hmem' :
                                                                v ∈ (q₂.vertices ++ [(pPrev.cons e).end]).tail := by
                                                                simpa [q₂', vertices_cons, concat_eq_append] using hmem
                                                              cases hq2 : q₂.vertices with
                                                              | nil => simp [hq2] at hmem'
                                                              | cons y
                                                                ys =>
                                                                have hx_in : v ∈ ys ++ [(pPrev.cons e).end] := by
                                                                  simpa [hq2] using hmem'
                                                                obtain (hx_ys | hx_last) := List.mem_append.mp hx_in
                                                                · exact h_not_tail <| by simpa [hq2]
                                                                · have : v = (pPrev.cons e).end := by
                                                                    simpa [List.mem_singleton] using hx_last
                                                                  exact hxe_ne this
Build completed successfully (521 jobs).
```

### Trace profiling of `exists_eq_comp_and_notMem_tail_of_mem_vertices` after PR 31072
```diff
diff --git a/Mathlib/Combinatorics/Quiver/Path/Vertices.lean b/Mathlib/Combinatorics/Quiver/Path/Vertices.lean
index 9d27be9e85..d658dc1eb1 100644
--- a/Mathlib/Combinatorics/Quiver/Path/Vertices.lean
+++ b/Mathlib/Combinatorics/Quiver/Path/Vertices.lean
@@ -206,6 +206,7 @@ theorem exists_eq_comp_of_mem_vertices {v : V} (hv : v ∈ p.vertices) :
   obtain ⟨v, p₁, p₂, hp, hv, rfl⟩ := p.exists_eq_comp_and_length_eq_of_lt_length n hn
   exact ⟨p₁, p₂, hp⟩
 
+set_option trace.profiler true in
 /-- Split a path at the *last* occurrence of a vertex. -/
 theorem exists_eq_comp_and_notMem_tail_of_mem_vertices {v : V} (hv : v ∈ p.vertices) :
     ∃ (p₁ : Path a v) (p₂ : Path v b),
@@ -230,18 +231,7 @@ theorem exists_eq_comp_and_notMem_tail_of_mem_vertices {v : V} (hv : v ∈ p.ver
       intro hxPrev hxe_ne
       obtain ⟨q₁, q₂, h_prev, h_not_tail⟩ := ih hxPrev
       let q₂' : Path v (pPrev.cons e).end := q₂.cons e
-      have h_no_tail : v ∉ q₂'.vertices.tail := by
-        intro hmem
-        have hmem' : v ∈ (q₂.vertices ++ [(pPrev.cons e).end]).tail := by
-          simpa [q₂', vertices_cons, concat_eq_append] using hmem
-        cases hq2 : q₂.vertices with
-        | nil => simp [hq2] at hmem'
-        | cons y ys =>
-            have hx_in : v ∈ ys ++ [(pPrev.cons e).end] := by simpa [hq2] using hmem'
-            obtain (hx_ys | hx_last) := List.mem_append.mp hx_in
-            · exact h_not_tail <| by simpa [hq2]
-            · have : v = (pPrev.cons e).end := by simpa [List.mem_singleton] using hx_last
-              exact hxe_ne this
+      have h_no_tail : v ∉ q₂'.vertices.tail := by grind [vertices_cons, end_cons]
       exact ⟨q₁, q₂', by simp [q₂', h_prev], h_no_tail⟩
     cases hv' with
     | inl h_in_prefix =>
```
```
ℹ [521/521] Built Mathlib.Combinatorics.Quiver.Path.Vertices (1.1s)
info: Mathlib/Combinatorics/Quiver/Path/Vertices.lean:210:0: [Elab.async] [0.047236] elaborating proof of Quiver.Path.exists_eq_comp_and_notMem_tail_of_mem_vertices
  [Elab.definition.value] [0.045901] Quiver.Path.exists_eq_comp_and_notMem_tail_of_mem_vertices
    [Elab.step] [0.044896] induction p with
          | nil =>
            have hxa : v = a := by simpa [vertices_nil, List.mem_singleton] using hv
            subst hxa
            exact
              ⟨Path.nil, Path.nil, by simp only [comp_nil], by
                simp only [vertices_nil, tail_cons, not_mem_nil, not_false_eq_true]⟩
          | cons pPrev e
            ih =>
            have hv' : v ∈ pPrev.vertices ∨ v = (pPrev.cons e).end := by simpa using (mem_vertices_cons pPrev e).1 hv
            have h_case₁ :
              v = (pPrev.cons e).end →
                ∃ (p₁ : Path a v) (p₂ : Path v (pPrev.cons e).end), pPrev.cons e = p₁.comp p₂ ∧ v ∉ p₂.vertices.tail :=
              by
              rintro rfl
              exact ⟨pPrev.cons e, Path.nil, by simp [comp_nil], by simp [vertices_nil]⟩
            have h_case₂ :
              v ∈ pPrev.vertices →
                v ≠ (pPrev.cons e).end →
                  ∃ (p₁ : Path a v) (p₂ : Path v (pPrev.cons e).end),
                    pPrev.cons e = p₁.comp p₂ ∧ v ∉ p₂.vertices.tail :=
              by
              intro hxPrev hxe_ne
              obtain ⟨q₁, q₂, h_prev, h_not_tail⟩ := ih hxPrev
              let q₂' : Path v (pPrev.cons e).end := q₂.cons e
              have h_no_tail : v ∉ q₂'.vertices.tail := by grind [vertices_cons, end_cons]
              exact ⟨q₁, q₂', by simp [q₂', h_prev], h_no_tail⟩
            cases hv' with
            | inl h_in_prefix =>
              by_cases h_eq_end : v = (pPrev.cons e).end
              · exact h_case₁ h_eq_end
              · exact h_case₂ h_in_prefix h_eq_end
            | inr h_eq_end => exact h_case₁ h_eq_end
      [Elab.step] [0.044892] induction p with
            | nil =>
              have hxa : v = a := by simpa [vertices_nil, List.mem_singleton] using hv
              subst hxa
              exact
                ⟨Path.nil, Path.nil, by simp only [comp_nil], by
                  simp only [vertices_nil, tail_cons, not_mem_nil, not_false_eq_true]⟩
            | cons pPrev e
              ih =>
              have hv' : v ∈ pPrev.vertices ∨ v = (pPrev.cons e).end := by simpa using (mem_vertices_cons pPrev e).1 hv
              have h_case₁ :
                v = (pPrev.cons e).end →
                  ∃ (p₁ : Path a v) (p₂ : Path v (pPrev.cons e).end),
                    pPrev.cons e = p₁.comp p₂ ∧ v ∉ p₂.vertices.tail :=
                by
                rintro rfl
                exact ⟨pPrev.cons e, Path.nil, by simp [comp_nil], by simp [vertices_nil]⟩
              have h_case₂ :
                v ∈ pPrev.vertices →
                  v ≠ (pPrev.cons e).end →
                    ∃ (p₁ : Path a v) (p₂ : Path v (pPrev.cons e).end),
                      pPrev.cons e = p₁.comp p₂ ∧ v ∉ p₂.vertices.tail :=
                by
                intro hxPrev hxe_ne
                obtain ⟨q₁, q₂, h_prev, h_not_tail⟩ := ih hxPrev
                let q₂' : Path v (pPrev.cons e).end := q₂.cons e
                have h_no_tail : v ∉ q₂'.vertices.tail := by grind [vertices_cons, end_cons]
                exact ⟨q₁, q₂', by simp [q₂', h_prev], h_no_tail⟩
              cases hv' with
              | inl h_in_prefix =>
                by_cases h_eq_end : v = (pPrev.cons e).end
                · exact h_case₁ h_eq_end
                · exact h_case₂ h_in_prefix h_eq_end
              | inr h_eq_end => exact h_case₁ h_eq_end
        [Elab.step] [0.044888] induction p with
            | nil =>
              have hxa : v = a := by simpa [vertices_nil, List.mem_singleton] using hv
              subst hxa
              exact
                ⟨Path.nil, Path.nil, by simp only [comp_nil], by
                  simp only [vertices_nil, tail_cons, not_mem_nil, not_false_eq_true]⟩
            | cons pPrev e
              ih =>
              have hv' : v ∈ pPrev.vertices ∨ v = (pPrev.cons e).end := by simpa using (mem_vertices_cons pPrev e).1 hv
              have h_case₁ :
                v = (pPrev.cons e).end →
                  ∃ (p₁ : Path a v) (p₂ : Path v (pPrev.cons e).end),
                    pPrev.cons e = p₁.comp p₂ ∧ v ∉ p₂.vertices.tail :=
                by
                rintro rfl
                exact ⟨pPrev.cons e, Path.nil, by simp [comp_nil], by simp [vertices_nil]⟩
              have h_case₂ :
                v ∈ pPrev.vertices →
                  v ≠ (pPrev.cons e).end →
                    ∃ (p₁ : Path a v) (p₂ : Path v (pPrev.cons e).end),
                      pPrev.cons e = p₁.comp p₂ ∧ v ∉ p₂.vertices.tail :=
                by
                intro hxPrev hxe_ne
                obtain ⟨q₁, q₂, h_prev, h_not_tail⟩ := ih hxPrev
                let q₂' : Path v (pPrev.cons e).end := q₂.cons e
                have h_no_tail : v ∉ q₂'.vertices.tail := by grind [vertices_cons, end_cons]
                exact ⟨q₁, q₂', by simp [q₂', h_prev], h_no_tail⟩
              cases hv' with
              | inl h_in_prefix =>
[… 96 lines omitted …]
                        case body✝ =>
                          with_annotate_state"by"
                            ( intro hxPrev hxe_ne
                              obtain ⟨q₁, q₂, h_prev, h_not_tail⟩ := ih hxPrev
                              let q₂' : Path v (pPrev.cons e).end := q₂.cons e
                              have h_no_tail : v ∉ q₂'.vertices.tail := by grind [vertices_cons, end_cons]
                              exact ⟨q₁, q₂', by simp [q₂', h_prev], h_no_tail⟩)
                    [Elab.step] [0.029274] 
                          refine
                            no_implicit_lambda%
                              (have h_case₂ :
                                v ∈ pPrev.vertices →
                                  v ≠ (pPrev.cons e).end →
                                    ∃ (p₁ : Path a v) (p₂ : Path v (pPrev.cons e).end),
                                      pPrev.cons e = p₁.comp p₂ ∧ v ∉ p₂.vertices.tail :=
                                ?body✝;
                              ?_)
                          case body✝ =>
                            with_annotate_state"by"
                              ( intro hxPrev hxe_ne
                                obtain ⟨q₁, q₂, h_prev, h_not_tail⟩ := ih hxPrev
                                let q₂' : Path v (pPrev.cons e).end := q₂.cons e
                                have h_no_tail : v ∉ q₂'.vertices.tail := by grind [vertices_cons, end_cons]
                                exact ⟨q₁, q₂', by simp [q₂', h_prev], h_no_tail⟩)
                      [Elab.step] [0.025886] case body✝ =>
                            with_annotate_state"by"
                              ( intro hxPrev hxe_ne
                                obtain ⟨q₁, q₂, h_prev, h_not_tail⟩ := ih hxPrev
                                let q₂' : Path v (pPrev.cons e).end := q₂.cons e
                                have h_no_tail : v ∉ q₂'.vertices.tail := by grind [vertices_cons, end_cons]
                                exact ⟨q₁, q₂', by simp [q₂', h_prev], h_no_tail⟩)
                        [Elab.step] [0.025862] with_annotate_state"by"
                                ( intro hxPrev hxe_ne
                                  obtain ⟨q₁, q₂, h_prev, h_not_tail⟩ := ih hxPrev
                                  let q₂' : Path v (pPrev.cons e).end := q₂.cons e
                                  have h_no_tail : v ∉ q₂'.vertices.tail := by grind [vertices_cons, end_cons]
                                  exact ⟨q₁, q₂', by simp [q₂', h_prev], h_no_tail⟩)
                          [Elab.step] [0.025858] with_annotate_state"by"
                                  ( intro hxPrev hxe_ne
                                    obtain ⟨q₁, q₂, h_prev, h_not_tail⟩ := ih hxPrev
                                    let q₂' : Path v (pPrev.cons e).end := q₂.cons e
                                    have h_no_tail : v ∉ q₂'.vertices.tail := by grind [vertices_cons, end_cons]
                                    exact ⟨q₁, q₂', by simp [q₂', h_prev], h_no_tail⟩)
                            [Elab.step] [0.025854] with_annotate_state"by"
                                  ( intro hxPrev hxe_ne
                                    obtain ⟨q₁, q₂, h_prev, h_not_tail⟩ := ih hxPrev
                                    let q₂' : Path v (pPrev.cons e).end := q₂.cons e
                                    have h_no_tail : v ∉ q₂'.vertices.tail := by grind [vertices_cons, end_cons]
                                    exact ⟨q₁, q₂', by simp [q₂', h_prev], h_no_tail⟩)
                              [Elab.step] [0.025851] (
                                    intro hxPrev hxe_ne
                                    obtain ⟨q₁, q₂, h_prev, h_not_tail⟩ := ih hxPrev
                                    let q₂' : Path v (pPrev.cons e).end := q₂.cons e
                                    have h_no_tail : v ∉ q₂'.vertices.tail := by grind [vertices_cons, end_cons]
                                    exact ⟨q₁, q₂', by simp [q₂', h_prev], h_no_tail⟩)
                                [Elab.step] [0.025848] 
                                      intro hxPrev hxe_ne
                                      obtain ⟨q₁, q₂, h_prev, h_not_tail⟩ := ih hxPrev
                                      let q₂' : Path v (pPrev.cons e).end := q₂.cons e
                                      have h_no_tail : v ∉ q₂'.vertices.tail := by grind [vertices_cons, end_cons]
                                      exact ⟨q₁, q₂', by simp [q₂', h_prev], h_no_tail⟩
                                  [Elab.step] [0.025842] 
                                        intro hxPrev hxe_ne
                                        obtain ⟨q₁, q₂, h_prev, h_not_tail⟩ := ih hxPrev
                                        let q₂' : Path v (pPrev.cons e).end := q₂.cons e
                                        have h_no_tail : v ∉ q₂'.vertices.tail := by grind [vertices_cons, end_cons]
                                        exact ⟨q₁, q₂', by simp [q₂', h_prev], h_no_tail⟩
                                    [Elab.step] [0.022111] have h_no_tail : v ∉ q₂'.vertices.tail := by
                                          grind [vertices_cons, end_cons]
                                      [Elab.step] [0.022085] focus
                                            refine
                                              no_implicit_lambda%
                                                (have h_no_tail : v ∉ q₂'.vertices.tail := ?body✝;
                                                ?_)
                                            case body✝ => with_annotate_state"by" (grind [vertices_cons, end_cons])
                                        [Elab.step] [0.022082] 
                                              refine
                                                no_implicit_lambda%
                                                  (have h_no_tail : v ∉ q₂'.vertices.tail := ?body✝;
                                                  ?_)
                                              case body✝ => with_annotate_state"by" (grind [vertices_cons, end_cons])
                                          [Elab.step] [0.022079] 
                                                refine
                                                  no_implicit_lambda%
                                                    (have h_no_tail : v ∉ q₂'.vertices.tail := ?body✝;
                                                    ?_)
                                                case body✝ => with_annotate_state"by" (grind [vertices_cons, end_cons])
                                            [Elab.step] [0.021564] case body✝ =>
                                                  with_annotate_state"by" (grind [vertices_cons, end_cons])
                                              [Elab.step] [0.021552] with_annotate_state"by"
                                                      (grind [vertices_cons, end_cons])
                                                [Elab.step] [0.021549] with_annotate_state"by"
                                                        (grind [vertices_cons, end_cons])
                                                  [Elab.step] [0.021546] with_annotate_state"by"
                                                        (grind [vertices_cons, end_cons])
                                                    [Elab.step] [0.021542] (grind [vertices_cons, end_cons])
                                                      [Elab.step] [0.021539] grind [vertices_cons, end_cons]
                                                        [Elab.step] [0.021535] grind [vertices_cons, end_cons]
                                                          [Elab.step] [0.021527] grind [vertices_cons, end_cons]
Build completed successfully (521 jobs).
```
</details>

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include at least one commit authored by each
co-author among the commits in the pull request. If necessary, you may 
create empty commits to indicate co-authorship, using commands like so:

git commit --author="Author Name <author@email.com>" --allow-empty -m "add Author Name as coauthor"

When merging, all the commits will be squashed into a single commit listing all co-authors.

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
