### PR TITLE
[Merged by Bors] - chore(Analysis/Distribution/TemperateGrowth): avoid redefining variables

### DIFF
--- a/Mathlib/Analysis/Distribution/TemperateGrowth.lean
+++ b/Mathlib/Analysis/Distribution/TemperateGrowth.lean
@@ -112,9 +112,9 @@ lemma _root_.ContinuousLinearMap.hasTemperateGrowth (f : E →L[ℝ] F) :
 
 end Function
 
-variable [NormedAddCommGroup E] [MeasurableSpace E]
-
 namespace MeasureTheory.Measure
+
+variable [NormedAddCommGroup E] [MeasurableSpace E]
 
 open Module
 open scoped ENNReal
@@ -192,7 +192,6 @@ lemma _root_.integrable_of_le_of_pow_mul_le {μ : Measure E} [μ.HasTemperateGro
 
 /-- Given a function such that `f` and `x ^ (k + l) * f` are bounded for a suitable `l`, then
 one can bound explicitly the integral of `x ^ k * f`. -/
--- We redeclare `E` here to avoid the `NormedSpace ℝ E` typeclass available throughout this file.
 lemma _root_.integral_pow_mul_le_of_le_of_pow_mul_le
     {μ : Measure E} [μ.HasTemperateGrowth] {f : E → F} {C₁ C₂ : ℝ} {k : ℕ}
     (hf : ∀ x, ‖f x‖ ≤ C₁) (h'f : ∀ x, ‖x‖ ^ (k + μ.integrablePower) * ‖f x‖ ≤ C₂) :


### PR DESCRIPTION
Pointed out by @ADedecker in a previous PR.

Also rename `D` to `E` to have consistent names for the variables in this file. Now all generic maps are from `E` to `F`.

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include at least one commit authored by each
co-author among the commits in the pull request. If necessary, you may 
create empty commits to indicate co-authorship, using commands like so:

git commit --author="Author Name <author@email.com>" --allow-empty -m "add Author Name as coauthor"

When merging, all the commits will be squashed into a single commit listing all co-authors.

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
