### PR TITLE
[Merged by Bors] - chore(Analysis/SpecialFunctions/Log/PosLog): uniformize variable names

### DIFF
--- a/Mathlib/Analysis/SpecialFunctions/Log/PosLog.lean
+++ b/Mathlib/Analysis/SpecialFunctions/Log/PosLog.lean
@@ -22,6 +22,8 @@ See `Mathlib/Analysis/SpecialFunctions/Integrals/PosLogEqCircleAverage.lean` for
 
 namespace Real
 
+variable {x y : ℝ}
+
 /-!
 ## Definition, Notation and Reformulations
 -/
@@ -33,23 +35,23 @@ noncomputable def posLog : ℝ → ℝ := fun r ↦ max 0 (log r)
 scoped notation "log⁺" => posLog
 
 /-- Definition of the positive part of the logarithm, formulated as a theorem. -/
-theorem posLog_def {r : ℝ} : log⁺ r = max 0 (log r) := rfl
+theorem posLog_def : log⁺ x = max 0 (log x) := rfl
 
 /-!
 ## Elementary Properties
 -/
 
 /-- Presentation of `log` in terms of its positive part. -/
-theorem posLog_sub_posLog_inv {r : ℝ} : log⁺ r - log⁺ r⁻¹ = log r := by
+theorem posLog_sub_posLog_inv : log⁺ x - log⁺ x⁻¹ = log x := by
   rw [posLog_def, posLog_def, log_inv]
-  by_cases h : 0 ≤ log r
+  by_cases h : 0 ≤ log x
   · simp [h]
   · rw [not_le] at h
     simp [neg_nonneg.1 (Left.nonneg_neg_iff.2 h.le)]
 
 /-- Presentation of `log⁺` in terms of `log`. -/
-theorem half_mul_log_add_log_abs {r : ℝ} : 2⁻¹ * (log r + |log r|) = log⁺ r := by
-  by_cases hr : 0 ≤ log r
+theorem half_mul_log_add_log_abs : 2⁻¹ * (log x + |log x|) = log⁺ x := by
+  by_cases hr : 0 ≤ log x
   · simp [posLog, hr, abs_of_nonneg]
     ring
   · simp [posLog, le_of_not_ge hr, abs_of_nonpos]
@@ -59,7 +61,7 @@ theorem half_mul_log_add_log_abs {r : ℝ} : 2⁻¹ * (log r + |log r|) = log⁺
 @[simp] lemma posLog_one : log⁺ 1 = 0 := by simp [posLog]
 
 /-- The positive part of `log` is never negative. -/
-theorem posLog_nonneg {x : ℝ} : 0 ≤ log⁺ x := by simp [posLog]
+theorem posLog_nonneg : 0 ≤ log⁺ x := by simp [posLog]
 
 /-- The function `log⁺` is even. -/
 @[simp] theorem posLog_neg (x : ℝ) : log⁺ (-x) = log⁺ x := by simp [posLog]
@@ -73,7 +75,7 @@ theorem posLog_eq_zero_iff (x : ℝ) : log⁺ x = 0 ↔ |x| ≤ 1 := by
   simp [posLog]
 
 /-- The function `log⁺` equals `log` outside of the interval (-1,1). -/
-theorem posLog_eq_log {x : ℝ} (hx : 1 ≤ |x|) : log⁺ x = log x := by
+theorem posLog_eq_log (hx : 1 ≤ |x|) : log⁺ x = log x := by
   simp only [posLog, sup_eq_right]
   rw [← log_abs]
   apply log_nonneg hx
@@ -85,7 +87,7 @@ theorem log_of_nat_eq_posLog {n : ℕ} : log⁺ n = log n := by
   · simp [posLog_eq_log, Nat.one_le_iff_ne_zero.2 hn]
 
 /-- The function `log⁺` equals `log (max 1 _)` for non-negative real numbers. -/
-theorem posLog_eq_log_max_one {x : ℝ} (hx : 0 ≤ x) : log⁺ x = log (max 1 x) := by
+theorem posLog_eq_log_max_one (hx : 0 ≤ x) : log⁺ x = log (max 1 x) := by
   grind [le_abs, posLog_eq_log, log_one, max_eq_left, log_nonpos, posLog_def]
 
 /-- The function `log⁺` is monotone on the positive axis. -/
@@ -100,7 +102,7 @@ theorem monotoneOn_posLog : MonotoneOn log⁺ (Set.Ici 0) := by
     linarith
 
 @[gcongr]
-lemma posLog_le_posLog {x y : ℝ} (hx : 0 ≤ x) (hxy : x ≤ y) : log⁺ x ≤ log⁺ y :=
+lemma posLog_le_posLog (hx : 0 ≤ x) (hxy : x ≤ y) : log⁺ x ≤ log⁺ y :=
   monotoneOn_posLog hx (hx.trans hxy) hxy
 
 /-- The function `log⁺` commutes with taking powers. -/
@@ -119,11 +121,10 @@ lemma posLog_le_posLog {x y : ℝ} (hx : 0 ≤ x) (hxy : x ≤ y) : log⁺ x ≤
 
 /-- Estimate for `log⁺` of a product. See `Real.posLog_prod` for a variant involving
 multiple factors. -/
-theorem posLog_mul {a b : ℝ} :
-    log⁺ (a * b) ≤ log⁺ a + log⁺ b := by
-  by_cases ha : a = 0
+theorem posLog_mul : log⁺ (x * y) ≤ log⁺ x + log⁺ y := by
+  by_cases ha : x = 0
   · simp [ha, posLog]
-  by_cases hb : b = 0
+  by_cases hb : y = 0
   · simp [hb, posLog]
   unfold posLog
   nth_rw 1 [← add_zero 0, log_mul ha hb]
@@ -131,7 +132,7 @@ theorem posLog_mul {a b : ℝ} :
 
 /-- Estimate for `log⁺` of a product. Special case of `Real.posLog_mul` where one of
 the factors is a natural number. -/
-theorem posLog_nat_mul {n : ℕ} {a : ℝ} : log⁺ (n * a) ≤ log n + log⁺ a := by
+theorem posLog_nat_mul {n : ℕ} : log⁺ (n * x) ≤ log n + log⁺ x := by
   rw [← log_of_nat_eq_posLog]
   exact posLog_mul
 
@@ -194,8 +195,8 @@ lemma posLog_norm_sum_le {E : Type*} [SeminormedAddCommGroup E] {α : Type*} (s 
 /--
 Estimate for `log⁺` of a sum. See `Real.posLog_sum` for a variant involving multiple summands.
 -/
-theorem posLog_add {a b : ℝ} : log⁺ (a + b) ≤ log 2 + log⁺ a + log⁺ b := by
-  convert posLog_sum Finset.univ ![a, b] using 1 <;> simp [add_assoc]
+theorem posLog_add : log⁺ (x + y) ≤ log 2 + log⁺ x + log⁺ y := by
+  convert posLog_sum Finset.univ ![x, y] using 1 <;> simp [add_assoc]
 
 /--
 Variant of `posLog_add` for norms of elements in normed additive commutative groups, using


### PR DESCRIPTION
As a follow-up to PR #30641, uniformize the variable names in `Analysis/SpecialFunctions/Log/PosLog.lean`, for brevity and improved readability.

---------

This material was originally part of PR #30641, but was split off at a reviewer's request.

<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include at least one commit authored by each
co-author among the commits in the pull request. If necessary, you may 
create empty commits to indicate co-authorship, using commands like so:

git commit --author="Author Name <author@email.com>" --allow-empty -m "add Author Name as coauthor"

When merging, all the commits will be squashed into a single commit listing all co-authors.

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
