### PR TITLE
[Merged by Bors] - feat(AlgebraicTopology): the opposite of a model category structure

### DIFF
--- a/Mathlib.lean
+++ b/Mathlib.lean
@@ -1341,6 +1341,7 @@ import Mathlib.AlgebraicTopology.ModelCategory.Instances
 import Mathlib.AlgebraicTopology.ModelCategory.IsCofibrant
 import Mathlib.AlgebraicTopology.ModelCategory.JoyalTrick
 import Mathlib.AlgebraicTopology.ModelCategory.LeftHomotopy
+import Mathlib.AlgebraicTopology.ModelCategory.Opposite
 import Mathlib.AlgebraicTopology.ModelCategory.PathObject
 import Mathlib.AlgebraicTopology.ModelCategory.RightHomotopy
 import Mathlib.AlgebraicTopology.MooreComplex

--- a/Mathlib/AlgebraicTopology/ModelCategory/CategoryWithCofibrations.lean
+++ b/Mathlib/AlgebraicTopology/ModelCategory/CategoryWithCofibrations.lean
@@ -149,4 +149,103 @@ lemma mem_trivialCofibrations_iff :
 
 end TrivCof
 
+section
+
+variable [CategoryWithCofibrations C]
+
+instance : CategoryWithFibrations Cᵒᵖ where
+  fibrations := (cofibrations C).op
+
+lemma fibrations_op : fibrations Cᵒᵖ = (cofibrations C).op := rfl
+lemma cofibrations_eq_unop : cofibrations C = (fibrations Cᵒᵖ).unop := rfl
+
+variable {C}
+
+lemma fibration_op_iff : Fibration f.op ↔ Cofibration f := by
+  simp [cofibration_iff, fibration_iff, cofibrations_eq_unop]
+
+lemma cofibration_unop_iff {X Y : Cᵒᵖ} (f : X ⟶ Y) :
+    Cofibration f.unop ↔ Fibration f := by
+  simp [cofibration_iff, fibration_iff, cofibrations_eq_unop]
+
+instance [Cofibration f] : Fibration f.op := by
+  rwa [fibration_op_iff]
+
+instance {X Y : Cᵒᵖ} (f : X ⟶ Y) [Fibration f] : Cofibration f.unop := by
+  rwa [cofibration_unop_iff]
+
+end
+
+section
+
+variable [CategoryWithFibrations C]
+
+instance : CategoryWithCofibrations Cᵒᵖ where
+  cofibrations := (fibrations C).op
+
+lemma cofibrations_op : cofibrations Cᵒᵖ = (fibrations C).op := rfl
+lemma fibrations_eq_unop : fibrations C = (cofibrations Cᵒᵖ).unop := rfl
+
+variable {C}
+
+lemma cofibration_op_iff : Cofibration f.op ↔ Fibration f := by
+  simp [cofibration_iff, fibration_iff, fibrations_eq_unop]
+
+lemma fibration_unop_iff {X Y : Cᵒᵖ} (f : X ⟶ Y) :
+    Fibration f.unop ↔ Cofibration f := by
+  simp [cofibration_iff, fibration_iff, fibrations_eq_unop]
+
+instance [Fibration f] : Cofibration f.op := by
+  rwa [cofibration_op_iff]
+
+instance {X Y : Cᵒᵖ} (f : X ⟶ Y) [Cofibration f] : Fibration f.unop := by
+  rwa [fibration_unop_iff]
+
+end
+
+section
+
+variable [CategoryWithWeakEquivalences C]
+
+instance : CategoryWithWeakEquivalences Cᵒᵖ where
+  weakEquivalences := (weakEquivalences C).op
+
+lemma weakEquivalences_op : weakEquivalences Cᵒᵖ = (weakEquivalences C).op := rfl
+lemma weakEquivalences_eq_unop : weakEquivalences C = (weakEquivalences Cᵒᵖ).unop := rfl
+
+variable {C}
+
+lemma weakEquivalences_op_iff : WeakEquivalence f.op ↔ WeakEquivalence f := by
+  simp [weakEquivalence_iff, weakEquivalences_op]
+
+lemma weakEquivalences_unop_iff {X Y : Cᵒᵖ} (f : X ⟶ Y) :
+    WeakEquivalence f.unop ↔ WeakEquivalence f :=
+  (weakEquivalences_op_iff f.unop).symm
+
+instance [WeakEquivalence f] : WeakEquivalence f.op := by
+  rwa [weakEquivalences_op_iff]
+
+instance {X Y : Cᵒᵖ} (f : X ⟶ Y) [WeakEquivalence f] : WeakEquivalence f.unop := by
+  rwa [weakEquivalences_unop_iff]
+
+end
+
+section
+
+variable [CategoryWithWeakEquivalences C] [CategoryWithCofibrations C]
+
+lemma trivialFibrations_op : trivialFibrations Cᵒᵖ = (trivialCofibrations C).op := rfl
+lemma trivialCofibrations_eq_unop : trivialCofibrations C = (trivialFibrations Cᵒᵖ).unop := rfl
+
+end
+
+section
+
+variable [CategoryWithWeakEquivalences C] [CategoryWithFibrations C]
+
+lemma trivialCofibrations_op : trivialCofibrations Cᵒᵖ = (trivialFibrations C).op := rfl
+lemma trivialFibrations_eq_unop : trivialFibrations C = (trivialCofibrations Cᵒᵖ).unop := rfl
+
+end
+
 end HomotopicalAlgebra

--- a/Mathlib/AlgebraicTopology/ModelCategory/Opposite.lean
+++ b/Mathlib/AlgebraicTopology/ModelCategory/Opposite.lean
@@ -1,0 +1,55 @@
+/-
+Copyright (c) 2025 Joël Riou. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Joël Riou
+-/
+import Mathlib.AlgebraicTopology.ModelCategory.Basic
+
+/-!
+# The opposite of a model category structure
+
+-/
+
+universe v u
+
+open CategoryTheory
+
+namespace HomotopicalAlgebra
+
+variable (C : Type u) [Category.{v} C] [ModelCategory C]
+
+instance [(weakEquivalences C).HasTwoOutOfThreeProperty] :
+    (weakEquivalences Cᵒᵖ).HasTwoOutOfThreeProperty := by
+  rw [weakEquivalences_op]
+  infer_instance
+
+instance [(weakEquivalences C).IsStableUnderRetracts] :
+    (weakEquivalences Cᵒᵖ).IsStableUnderRetracts := by
+  rw [weakEquivalences_op]
+  infer_instance
+
+instance [(cofibrations C).IsStableUnderRetracts] :
+    (fibrations Cᵒᵖ).IsStableUnderRetracts := by
+  rw [fibrations_op]
+  infer_instance
+
+instance [(fibrations C).IsStableUnderRetracts] :
+    (cofibrations Cᵒᵖ).IsStableUnderRetracts := by
+  rw [cofibrations_op]
+  infer_instance
+
+instance [(trivialCofibrations C).HasFactorization (fibrations C)] :
+    (cofibrations Cᵒᵖ).HasFactorization (trivialFibrations Cᵒᵖ) := by
+  rw [cofibrations_op, trivialFibrations_op]
+  infer_instance
+
+instance [(cofibrations C).HasFactorization (trivialFibrations C)] :
+    (trivialCofibrations Cᵒᵖ).HasFactorization (fibrations Cᵒᵖ) := by
+  rw [trivialCofibrations_op, fibrations_op, ]
+  infer_instance
+
+instance : ModelCategory Cᵒᵖ where
+  cm4a i p _ _ _ := (HasLiftingProperty.iff_unop i p).2 inferInstance
+  cm4b i p _ _ _ := (HasLiftingProperty.iff_unop i p).2 inferInstance
+
+end HomotopicalAlgebra

--- a/Mathlib/CategoryTheory/MorphismProperty/Composition.lean
+++ b/Mathlib/CategoryTheory/MorphismProperty/Composition.lean
@@ -339,6 +339,28 @@ lemma HasOfPrecompProperty.of_le (Q : MorphismProperty C) [W.HasOfPrecompPropert
     (hle : W' ≤ Q) : W.HasOfPrecompProperty W' where
   of_precomp f g hg hfg := W.of_precomp (W' := Q) f g (hle _ hg) hfg
 
+instance [W.HasOfPostcompProperty W'] : W.op.HasOfPrecompProperty W'.op where
+  of_precomp _ _ hf hfg := W.of_postcomp _ _ hf hfg
+
+instance [W.HasOfPrecompProperty W'] : W.op.HasOfPostcompProperty W'.op where
+  of_postcomp _ _ hg hfg := W.of_precomp _ _ hg hfg
+
+instance [W.HasTwoOutOfThreeProperty] : W.op.HasTwoOutOfThreeProperty where
+
+end
+
+section
+
+variable (W₁ W₂ : MorphismProperty Cᵒᵖ)
+
+instance [W₁.HasOfPostcompProperty W₂] : W₁.unop.HasOfPrecompProperty W₂.unop where
+  of_precomp _ _ hf hfg := W₁.of_postcomp _ _ hf hfg
+
+instance [W₁.HasOfPrecompProperty W₂] : W₁.unop.HasOfPostcompProperty W₂.unop where
+  of_postcomp _ _ hg hfg := W₁.of_precomp _ _ hg hfg
+
+instance [W₁.HasTwoOutOfThreeProperty] : W₁.unop.HasTwoOutOfThreeProperty where
+
 end
 
 instance : (isomorphisms C).HasTwoOutOfThreeProperty where

--- a/Mathlib/CategoryTheory/MorphismProperty/Factorization.lean
+++ b/Mathlib/CategoryTheory/MorphismProperty/Factorization.lean
@@ -51,7 +51,24 @@ structure MapFactorizationData {X Y : C} (f : X ⟶ Y) where
   hi : W₁ i
   hp : W₂ p
 
-attribute [reassoc (attr := simp)] MapFactorizationData.fac
+namespace MapFactorizationData
+
+attribute [reassoc (attr := simp)] fac
+
+variable {X Y : C} (f : X ⟶ Y)
+
+/-- The opposite of a factorization. -/
+@[simps]
+def op {X Y : C} {f : X ⟶ Y} (hf : MapFactorizationData W₁ W₂ f) :
+    MapFactorizationData W₂.op W₁.op f.op where
+  Z := Opposite.op hf.Z
+  i := hf.p.op
+  p := hf.i.op
+  fac := Quiver.Hom.unop_inj (by simp)
+  hi := hf.hp
+  hp := hf.hi
+
+end MapFactorizationData
 
 /-- The data of a term in `MapFactorizationData W₁ W₂ f` for any morphism `f`. -/
 abbrev FactorizationData := ∀ {X Y : C} (f : X ⟶ Y), MapFactorizationData W₁ W₂ f
@@ -65,6 +82,9 @@ class HasFactorization : Prop where
 /-- A chosen term in `FactorizationData W₁ W₂` when `HasFactorization W₁ W₂` holds. -/
 noncomputable def factorizationData [HasFactorization W₁ W₂] : FactorizationData W₁ W₂ :=
   fun _ => Nonempty.some (HasFactorization.nonempty_mapFactorizationData _)
+
+instance [HasFactorization W₁ W₂] : HasFactorization W₂.op W₁.op where
+  nonempty_mapFactorizationData f := ⟨(factorizationData W₁ W₂ f.unop).op⟩
 
 /-- The class of morphisms that are of the form `i ≫ p` with `W₁ i` and `W₂ p`. -/
 def comp : MorphismProperty C := fun _ _ f => Nonempty (MapFactorizationData W₁ W₂ f)

--- a/Mathlib/CategoryTheory/MorphismProperty/Retract.lean
+++ b/Mathlib/CategoryTheory/MorphismProperty/Retract.lean
@@ -48,6 +48,14 @@ instance IsStableUnderRetracts.isomorphisms : (isomorphisms C).IsStableUnderRetr
     · rw [← h.i_w_assoc, IsIso.hom_inv_id_assoc, h.retract_left]
     · rw [Category.assoc, Category.assoc, h.r_w, IsIso.inv_hom_id_assoc, h.retract_right]
 
+instance (P : MorphismProperty C) [P.IsStableUnderRetracts] :
+    P.op.IsStableUnderRetracts where
+  of_retract h₁ h₂ := P.of_retract h₁.unop h₂
+
+instance (P : MorphismProperty Cᵒᵖ) [P.IsStableUnderRetracts] :
+    P.unop.IsStableUnderRetracts where
+  of_retract h₁ h₂ := P.of_retract h₁.op h₂
+
 instance (P₁ P₂ : MorphismProperty C)
     [P₁.IsStableUnderRetracts] [P₂.IsStableUnderRetracts] :
     (P₁ ⊓ P₂).IsStableUnderRetracts where

--- a/Mathlib/CategoryTheory/Retract.lean
+++ b/Mathlib/CategoryTheory/Retract.lean
@@ -128,6 +128,30 @@ instance : IsSplitMono h.i.left := ⟨⟨h.left.splitMono⟩⟩
 
 instance : IsSplitMono h.i.right := ⟨⟨h.right.splitMono⟩⟩
 
+/-- If a morphism `f` is a retract of `g`, then `f.op` is a retract of `g.op`. -/
+@[simps]
+def op : RetractArrow f.op g.op where
+  i.left := h.r.right.op
+  i.right := h.r.left.op
+  i.w := by simp [← op_comp]
+  r.left := h.i.right.op
+  r.right := h.i.left.op
+  r.w := by simp [← op_comp]
+  retract := by ext <;> simp [← op_comp]
+
+/-- If a morphism `f` in the opposite category is a retract of `g`,
+then `f.unop` is a retract of `g.unop`. -/
+@[simps]
+def unop {X Y Z W : Cᵒᵖ} {f : X ⟶ Y} {g : Z ⟶ W} (h : RetractArrow f g)
+ : RetractArrow f.unop g.unop where
+  i.left := h.r.right.unop
+  i.right := h.r.left.unop
+  i.w := by simp [← unop_comp]
+  r.left := h.i.right.unop
+  r.right := h.i.left.unop
+  r.w := by simp [← unop_comp]
+  retract := by ext <;> simp [← unop_comp]
+
 end RetractArrow
 
 namespace Iso


### PR DESCRIPTION
In this PR, we show that if `C` is a model category, then so is `Cᵒᵖ`.

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include at least one commit authored by each
co-author among the commits in the pull request. If necessary, you may 
create empty commits to indicate co-authorship, using commands like so:

git commit --author="Author Name <author@email.com>" --allow-empty -m "add Author Name as coauthor"

When merging, all the commits will be squashed into a single commit listing all co-authors.

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
