### PR TITLE
[Merged by Bors] - doc(Algebra/Group/Defs): change reference so that it will become an HTML link

### DIFF
--- a/Mathlib/Algebra/Group/Defs.lean
+++ b/Mathlib/Algebra/Group/Defs.lean
@@ -26,7 +26,7 @@ The file does not contain any lemmas except for
 * axioms of typeclasses restated in the root namespace;
 * lemmas required for instances.
 
-For basic lemmas about these classes see `Algebra.Group.Basic`.
+For basic lemmas about these classes see `Mathlib/Algebra/Group/Basic.lean`.
 
 We register the following instances:
 


### PR DESCRIPTION
Change format of the reference inside a doc string, so that the HTML file at https://leanprover-community.github.io/mathlib4_docs/Mathlib/Algebra/Group/Defs.html will get a working link.

---
[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
