### PR TITLE
[Merged by Bors] - fix(tacticAnalysis): use `toArray` and check the final two tactics

### DIFF
--- a/Mathlib/Tactic/TacticAnalysis/Declarations.lean
+++ b/Mathlib/Tactic/TacticAnalysis/Declarations.lean
@@ -195,7 +195,7 @@ private abbrev mergeWithGrindAllowed : Std.HashSet Name := { `«tactic#adaptatio
   inherit_doc linter.tacticAnalysis.mergeWithGrind]
 def mergeWithGrind : TacticAnalysis.Config where
   run seq := do
-    if let #[(preCtx, preI), (_postCtx, postI)] := seq[0:2].array then
+    if let #[(preCtx, preI), (_postCtx, postI)] := seq[seq.size - 2:].toArray then
       if postI.stx.getKind == ``Lean.Parser.Tactic.grind && preI.stx.getKind ∉ mergeWithGrindAllowed then
         if let [goal] := preI.goalsBefore then
           let goals ← try

--- a/MathlibTest/TacticAnalysis.lean
+++ b/MathlibTest/TacticAnalysis.lean
@@ -60,6 +60,20 @@ example : 1 + 1 = 2 := by
   #adaptation_note /-- -/
   grind
 
+set_option linter.unusedTactic false
+
+/-- warning: 'skip; grind' can be replaced with 'grind' -/
+#guard_msgs in
+example : 0 = 0 := by
+  intros
+  intros
+  intros
+  intros
+  skip
+  grind
+
+set_option linter.unusedTactic true
+
 end mergeWithGrind
 
 section replaceWithGrind


### PR DESCRIPTION
This PR addresses two separate "bugs".

1. The function `Subarray.array` returns the *full* array, not the one specified by the ranges.  For that, there is `Subarray.toArray`.
2. The tacticAnalysis should inspect the final two tactics of each block and check whether the last element is `grind` and the previous one is redundant.

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include at least one commit authored by each
co-author among the commits in the pull request. If necessary, you may 
create empty commits to indicate co-authorship, using commands like so:

git commit --author="Author Name <author@email.com>" --allow-empty -m "add Author Name as coauthor"

When merging, all the commits will be squashed into a single commit listing all co-authors.

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
