### PR TITLE
[Merged by Bors] - feat: removing leaves from a connected graph keeps it connected

### DIFF
--- a/Mathlib/Combinatorics/SimpleGraph/Connectivity/Connected.lean
+++ b/Mathlib/Combinatorics/SimpleGraph/Connectivity/Connected.lean
@@ -26,6 +26,11 @@ import Mathlib.Combinatorics.SimpleGraph.Subgraph
 * `SimpleGraph.isBridge_iff_mem_and_forall_cycle_notMem` characterizes bridge edges in terms of
   there being no cycle containing them.
 
+## TODO
+
+`IsBridge` is unpractical: we shouldn't require the edge to be present.
+See https://github.com/leanprover-community/mathlib4/issues/31690.
+
 ## Tags
 trails, paths, cycles, bridge edges
 -/
@@ -804,10 +809,12 @@ In this section, we prove results about 2-connected components of a graph, but w
 
 Should we explicitly have
 ```
-def IsTwoEdgeReachable (u v : V) : Prop := ∀ e, (G.deleteEdges {e}).Reachable u v
+def IsEdgeReachable (k : ℕ) (u v : V) : Prop :=
+  ∀ ⦃s : Set (Sym2 V)⦄, s.encard < k → (G.deleteEdges s).Reachable u v
 ```
-? This is equivalent to the less idiomatic condition
+? `G.IsEdgeReachable 2 u v` would then be equivalent to the less idiomatic condition
 `∃ x, ¬ (G.deleteEdges {s(x, y)}).Reachable u y` we use below.
+See https://github.com/leanprover-community/mathlib4/issues/31691.
 -/
 
 namespace Walk

--- a/Mathlib/Combinatorics/SimpleGraph/Connectivity/Connected.lean
+++ b/Mathlib/Combinatorics/SimpleGraph/Connectivity/Connected.lean
@@ -818,16 +818,10 @@ lemma exists_mem_edges_of_not_reachable_deleteEdges (w : G.Walk u v) {s : Set (S
     (huv : ¬ (G.deleteEdges s).Reachable u v) : ∃ e ∈ s, e ∈ w.edges := by
   contrapose! huv; exact ⟨w.toDeleteEdges _ fun _ ↦ imp_not_comm.1 <| huv _⟩
 
-/-- A walk between two vertices separated by a set of edges must go through one of those edges. -/
+/-- A walk between two vertices separated by an edge must go through that edge. -/
 lemma mem_edges_of_not_reachable_deleteEdges (w : G.Walk u v) {e : Sym2 V}
     (huv : ¬ (G.deleteEdges {e}).Reachable u v) : e ∈ w.edges := by
   simpa using w.exists_mem_edges_of_not_reachable_deleteEdges huv
-
-lemma IsTrail.disjoint_edges_takeUntil_dropUntil [DecidableEq V] (hw : w.IsTrail)
-    (hx : x ∈ w.support) : (w.takeUntil x hx).edges.Disjoint (w.dropUntil x hx).edges := by
-  have := hw.edges_nodup
-  rw [← w.take_spec hx, edges_append] at this
-  exact this.disjoint
 
 /-- A trail doesn't go through an edge that disconnects one of its endpoints from the endpoints of
 the trail. -/

--- a/Mathlib/Combinatorics/SimpleGraph/Paths.lean
+++ b/Mathlib/Combinatorics/SimpleGraph/Paths.lean
@@ -467,6 +467,10 @@ protected theorem IsPath.dropUntil {u v w : V} {p : G.Walk v w} (hc : p.IsPath)
   IsPath.of_append_right (p := p.takeUntil u h) (q := p.dropUntil u h)
     (by rwa [← take_spec _ h] at hc)
 
+lemma IsTrail.disjoint_edges_takeUntil_dropUntil {x : V} {w : G.Walk u v} (hw : w.IsTrail)
+    (hx : x ∈ w.support) : (w.takeUntil x hx).edges.Disjoint (w.dropUntil x hx).edges :=
+  List.disjoint_of_nodup_append <| by simpa [← edges_append] using hw.edges_nodup
+
 protected theorem IsTrail.rotate {u v : V} {c : G.Walk v v} (hc : c.IsTrail) (h : u ∈ c.support) :
     (c.rotate h).IsTrail := by
   rw [isTrail_def, (c.rotate_edges h).perm.nodup_iff]

--- a/Mathlib/Data/List/Nodup.lean
+++ b/Mathlib/Data/List/Nodup.lean
@@ -172,6 +172,8 @@ theorem nodup_append' {l₁ l₂ : List α} :
 theorem disjoint_of_nodup_append {l₁ l₂ : List α} (d : Nodup (l₁ ++ l₂)) : Disjoint l₁ l₂ :=
   (nodup_append'.1 d).2.2
 
+protected alias Nodup.disjoint := disjoint_of_nodup_append
+
 theorem Nodup.append (d₁ : Nodup l₁) (d₂ : Nodup l₂) (dj : Disjoint l₁ l₂) : Nodup (l₁ ++ l₂) :=
   nodup_append'.2 ⟨d₁, d₂, dj⟩
 


### PR DESCRIPTION
... using properties of 2-connected components.

From the ProofBench workshop


---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include at least one commit authored by each
co-author among the commits in the pull request. If necessary, you may 
create empty commits to indicate co-authorship, using commands like so:

git commit --author="Author Name <author@email.com>" --allow-empty -m "add Author Name as coauthor"

When merging, all the commits will be squashed into a single commit listing all co-authors.

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
