### PR TITLE
[Merged by Bors] - feat: relation-covered sets

### DIFF
--- a/Mathlib.lean
+++ b/Mathlib.lean
@@ -3704,6 +3704,7 @@ import Mathlib.Data.Real.Sqrt
 import Mathlib.Data.Real.Star
 import Mathlib.Data.Real.StarOrdered
 import Mathlib.Data.Rel
+import Mathlib.Data.Rel.Cover
 import Mathlib.Data.Rel.Separated
 import Mathlib.Data.SProd
 import Mathlib.Data.Semiquot

--- a/Mathlib/Data/Rel/Cover.lean
+++ b/Mathlib/Data/Rel/Cover.lean
@@ -41,8 +41,8 @@ def IsCover (U : SetRel X X) (s N : Set X) : Prop := ∀ ⦃x⦄, x ∈ s → �
 @[simp] lemma isCover_empty_right : IsCover U s ∅ ↔ s = ∅ := by
   simp [IsCover, eq_empty_iff_forall_notMem]
 
-@[simp] protected nonrec lemma IsCover.nonempty (hsN : IsCover U s N) (hs : s.Nonempty) :
-    N.Nonempty := let ⟨_x, hx⟩ := hs; let ⟨y, hy, _⟩ := hsN hx; ⟨y, hy⟩
+protected nonrec lemma IsCover.nonempty (hsN : IsCover U s N) (hs : s.Nonempty) : N.Nonempty :=
+  let ⟨_x, hx⟩ := hs; let ⟨y, hy, _⟩ := hsN hx; ⟨y, hy⟩
 
 @[simp] protected lemma isCover_univ : IsCover univ s N ↔ (s.Nonempty → N.Nonempty) := by
   simp [IsCover, Set.Nonempty]

--- a/Mathlib/Data/Rel/Cover.lean
+++ b/Mathlib/Data/Rel/Cover.lean
@@ -68,4 +68,3 @@ lemma IsCover.of_maximal_isSeparated [U.IsRefl] [U.IsSymm]
 @[simp] lemma isCover_relId : IsCover .id s N ↔ s ⊆ N := by simp [IsCover, subset_def]
 
 end SetRel
-  

--- a/Mathlib/Data/Rel/Cover.lean
+++ b/Mathlib/Data/Rel/Cover.lean
@@ -1,0 +1,71 @@
+/-
+Copyright (c) 2025 Yaël Dillies. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Yaël Dillies
+-/
+import Mathlib.Data.Rel.Separated
+
+/-!
+# Covers in a uniform space
+
+This file defines covers, aka nets, which are a quantitative notion of compactness given an
+entourage.
+
+A `U`-cover of a set `s` is a set `N` such that every element of `s` is `U`-close to some element of
+`N`.
+
+The concept of uniform covers is used to define two further notions of covering:
+* Metric covers: `Metric.IsCover`, defined using the distance entourage.
+* Dynamical covers: `Dynamics.IsDynCoverOf`, defined using the dynamical entourage.
+
+## References
+
+[R. Vershynin, *High Dimensional Probability*][vershynin2018high], Section 4.2.
+-/
+
+open Set
+
+namespace SetRel
+variable {X : Type*} {U V : SetRel X X} {s t N N₁ N₂ : Set X} {x : X}
+
+/-- For an entourage `U`, a set `N` is a *`U`-cover* of a set `s` if every point of `s` is `U`-close
+to some point of `N`.
+
+This is also called a *`U`-net* in the literature.
+
+[R. Vershynin, *High Dimensional Probability*][vershynin2018high], 4.2.1. -/
+def IsCover (U : SetRel X X) (s N : Set X) : Prop := ∀ ⦃x⦄, x ∈ s → ∃ y ∈ N, x ~[U] y
+
+@[simp] lemma IsCover.empty : IsCover U ∅ N := by simp [IsCover]
+
+@[simp] lemma isCover_empty_right : IsCover U s ∅ ↔ s = ∅ := by
+  simp [IsCover, eq_empty_iff_forall_notMem]
+
+@[simp] protected nonrec lemma IsCover.nonempty (hsN : IsCover U s N) (hs : s.Nonempty) :
+    N.Nonempty := let ⟨_x, hx⟩ := hs; let ⟨y, hy, _⟩ := hsN hx; ⟨y, hy⟩
+
+@[simp] protected lemma isCover_univ : IsCover univ s N ↔ (s.Nonempty → N.Nonempty) := by
+  simp [IsCover, Set.Nonempty]
+
+lemma IsCover.mono (hN : N₁ ⊆ N₂) (h₁ : IsCover U s N₁) : IsCover U s N₂ :=
+  fun _x hx ↦ let ⟨y, hy, hxy⟩ := h₁ hx; ⟨y, hN hy, hxy⟩
+
+lemma IsCover.anti (hst : s ⊆ t) (ht : IsCover U t N) : IsCover U s N := fun _x hx ↦ ht <| hst hx
+
+lemma IsCover.mono_entourage (hUV : U ⊆ V) (hU : IsCover U s N) : IsCover V s N :=
+  fun _x hx ↦ let ⟨y, hy, hxy⟩ := hU hx; ⟨y, hy, hUV hxy⟩
+
+/-- A maximal `U`-separated subset of a set `s` is a `U`-cover of `s`.
+
+[R. Vershynin, *High Dimensional Probability*][vershynin2018high], 4.2.6. -/
+lemma IsCover.of_maximal_isSeparated [U.IsRefl] [U.IsSymm]
+    (hN : Maximal (fun N ↦ N ⊆ s ∧ IsSeparated U N) N) : IsCover U s N := by
+  rintro x hx
+  by_contra! h
+  simpa [U.rfl] using h _ <| hN.2 (y := insert x N) ⟨by simp [insert_subset_iff, hx, hN.1.1],
+    hN.1.2.insert fun y hy hxy ↦ (h y hy hxy).elim⟩ (subset_insert _ _) (mem_insert _ _)
+
+@[simp] lemma isCover_relId : IsCover .id s N ↔ s ⊆ N := by simp [IsCover, subset_def]
+
+end SetRel
+  

--- a/Mathlib/Data/Rel/Cover.lean
+++ b/Mathlib/Data/Rel/Cover.lean
@@ -14,7 +14,7 @@ entourage.
 A `U`-cover of a set `s` is a set `N` such that every element of `s` is `U`-close to some element of
 `N`.
 
-The concept of uniform covers is used to define two further notions of covering:
+The concept of uniform covers can be used to define two further notions of covering:
 * Metric covers: `Metric.IsCover`, defined using the distance entourage.
 * Dynamical covers: `Dynamics.IsDynCoverOf`, defined using the dynamical entourage.
 


### PR DESCRIPTION
Define a notion of cover of a set relative to a relation. This will be used to unify metric and dynamical covers.

From MiscYD and LeanAPAP


---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include at least one commit authored by each
co-author among the commits in the pull request. If necessary, you may 
create empty commits to indicate co-authorship, using commands like so:

git commit --author="Author Name <author@email.com>" --allow-empty -m "add Author Name as coauthor"

When merging, all the commits will be squashed into a single commit listing all co-authors.

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
