### PR TITLE
[Merged by Bors] - feat: add ComplexShape.EulerCharSigns for generalized Euler characteristic

### DIFF
--- a/Mathlib.lean
+++ b/Mathlib.lean
@@ -586,6 +586,7 @@ public import Mathlib.Algebra.Homology.Embedding.TruncGE
 public import Mathlib.Algebra.Homology.Embedding.TruncGEHomology
 public import Mathlib.Algebra.Homology.Embedding.TruncLE
 public import Mathlib.Algebra.Homology.Embedding.TruncLEHomology
+public import Mathlib.Algebra.Homology.EulerCharacteristic
 public import Mathlib.Algebra.Homology.ExactSequence
 public import Mathlib.Algebra.Homology.ExactSequenceFour
 public import Mathlib.Algebra.Homology.Factorizations.Basic

--- a/Mathlib/Algebra/GroupWithZero/Indicator.lean
+++ b/Mathlib/Algebra/GroupWithZero/Indicator.lean
@@ -114,6 +114,14 @@ variable [NoZeroDivisors M₀]
 @[simp] lemma support_mul' (f g : ι → M₀) : support (f * g) = support f ∩ support g :=
   support_mul _ _
 
+/-- If `f` is everywhere nonzero, then `support (f * g) = support g`. -/
+lemma support_mul_of_ne_zero_left {f : ι → M₀} (hf : ∀ x, f x ≠ 0) (g : ι → M₀) :
+    support (fun x => f x * g x) = support g := by simp [support_eq_univ hf]
+
+/-- If `g` is everywhere nonzero, then `support (f * g) = support f`. -/
+lemma support_mul_of_ne_zero_right (f : ι → M₀) {g : ι → M₀} (hg : ∀ x, g x ≠ 0) :
+    support (fun x => f x * g x) = support f := by simp [support_eq_univ hg]
+
 end MulZeroClass
 
 section MonoidWithZero

--- a/Mathlib/Algebra/Homology/EulerCharacteristic.lean
+++ b/Mathlib/Algebra/Homology/EulerCharacteristic.lean
@@ -25,12 +25,16 @@ uniformly for chain complexes, cochain complexes, and complexes with other index
 The definitions work on graded objects, with the homological complex versions
 defined as abbreviations that apply the graded object versions to `C.X` and `C.homology`.
 
+## Junk values
+
+These definitions may have junk values from `finsum` (0 for infinite support) and
+`Module.finrank` (0 for modules not free of finite rank).
+
 ## Main definitions
 
 * `ComplexShape.EulerCharSigns`: Typeclass providing alternating signs for Euler characteristic
 * `GradedObject.eulerChar`: The Euler characteristic of a graded object using `finsum`
-  (defaults to 0 if the support is infinite)
-* `GradedObject.finrankSupport`: The support of a graded object (indices with nonzero rank)
+* `GradedObject.finrankSupport`: Indices where `Module.finrank` is nonzero
 * `HomologicalComplex.eulerChar`: The Euler characteristic using `finsum`
 * `HomologicalComplex.homologyEulerChar`: The homological Euler characteristic using `finsum`
 

--- a/Mathlib/Algebra/Homology/EulerCharacteristic.lean
+++ b/Mathlib/Algebra/Homology/EulerCharacteristic.lean
@@ -130,17 +130,8 @@ noncomputable def eulerCharTsum (X : CategoryTheory.GradedObject ι (ModuleCat R
 because the sign `c.χ i` is always nonzero (it's a unit). -/
 lemma support_eulerChar_summand (X : CategoryTheory.GradedObject ι (ModuleCat R)) :
     Function.support (fun i => (c.χ i : ℤ) * Module.finrank R (X i)) = finrankSupport X := by
-  simp only [finrankSupport]
-  rw [Function.support_mul]
-  have h_chi : Function.support (fun i => (c.χ i : ℤ)) = Set.univ := by
-    ext i
-    simp only [Function.mem_support, ne_eq, Set.mem_univ, iff_true]
-    exact Units.ne_zero (c.χ i)
-  have h_cast : Function.support (fun i => (Module.finrank R (X i) : ℤ)) =
-      Function.support (fun i => Module.finrank R (X i)) := by
-    ext i
-    simp only [Function.mem_support, ne_eq, Nat.cast_eq_zero]
-  rw [h_chi, Set.univ_inter, h_cast]
+  simp only [finrankSupport, Function.support_mul_of_ne_zero_left (fun i => Units.ne_zero (c.χ i))]
+  ext i; simp [Function.mem_support]
 
 /-- If a graded object has finite rank support contained in a finite set,
 the `finsum` Euler characteristic equals the finite one. -/

--- a/Mathlib/Algebra/Homology/EulerCharacteristic.lean
+++ b/Mathlib/Algebra/Homology/EulerCharacteristic.lean
@@ -1,0 +1,187 @@
+/-
+Copyright (c) 2025 Jesse Alama. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Jesse Alama
+-/
+module
+
+public import Mathlib.Algebra.Homology.HomologicalComplex
+public import Mathlib.Algebra.Homology.ShortComplex.HomologicalComplex
+public import Mathlib.Algebra.Homology.ComplexShape
+public import Mathlib.Algebra.Ring.NegOnePow
+public import Mathlib.Algebra.Category.ModuleCat.Basic
+public import Mathlib.CategoryTheory.GradedObject
+public import Mathlib.LinearAlgebra.Dimension.Finrank
+
+/-!
+# Euler characteristic of homological complexes
+
+The Euler characteristic is defined using the `ComplexShape.EulerCharSigns` typeclass,
+which provides the alternating signs for each index. This allows the definition to work
+uniformly for chain complexes, cochain complexes, and complexes with other index types.
+
+The definitions work on graded objects, with the homological complex versions
+defined as abbreviations that apply the graded object versions to `C.X` and `C.homology`.
+
+## Main definitions
+
+* `ComplexShape.EulerCharSigns`: Typeclass providing alternating signs for Euler characteristic
+* `GradedObject.eulerChar`: The Euler characteristic of a graded object over a finite set
+* `GradedObject.finrankSupport`: The support of a graded object (indices with nonzero rank)
+* `GradedObject.eulerCharTsum`: The Euler characteristic of a graded object as an infinite sum
+* `HomologicalComplex.eulerChar`: The Euler characteristic over a finite set of indices
+* `HomologicalComplex.eulerCharTsum`: The Euler characteristic as an infinite sum
+* `HomologicalComplex.homologyEulerChar`: The homological Euler characteristic over a
+  finite set
+* `HomologicalComplex.homologyEulerCharTsum`: The homological Euler characteristic as an
+  infinite sum
+
+## Main results
+
+* `GradedObject.eulerCharTsum_eq_eulerChar`: The infinite sum equals the finite sum
+  when the graded object vanishes outside the finite set
+* `HomologicalComplex.eulerCharTsum_eq_eulerChar`: The infinite sum equals the finite sum
+  when the complex vanishes outside the finite set
+* `HomologicalComplex.homologyEulerCharTsum_eq_homologyEulerChar`: The infinite homological
+  Euler characteristic equals the finite one when homology vanishes outside the finite set
+
+-/
+
+@[expose] public section
+
+namespace ComplexShape
+
+variable {ι : Type*} (c : ComplexShape ι)
+
+/-- Signs for terms of Euler characteristic on complexes. -/
+class EulerCharSigns where
+  /-- The sign for each index -/
+  χ : ι → ℤˣ
+  /-- Signs alternate along relations in the complex shape -/
+  χ_next {i j : ι} (h : c.Rel i j) : χ j = - χ i
+
+variable [c.EulerCharSigns]
+
+/-- The sign at index `i` for Euler characteristic computations. -/
+abbrev χ : ι → ℤˣ := EulerCharSigns.χ c
+
+/-- Signs alternate in the forward direction of the complex shape. -/
+lemma χ_next {i j : ι} (h : c.Rel i j) : c.χ j = - c.χ i := EulerCharSigns.χ_next h
+
+/-- Signs alternate in the backward direction of the complex shape. -/
+lemma χ_prev {i j : ι} (h : c.Rel i j) : c.χ i = - c.χ j := by simp [c.χ_next h]
+
+@[simps]
+instance eulerCharSignsUpInt : (up ℤ).EulerCharSigns where
+  χ := Int.negOnePow
+  χ_next := by rintro _ _ rfl; rw [Int.negOnePow_succ]
+
+@[simps]
+instance eulerCharSignsDownInt : (down ℤ).EulerCharSigns where
+  χ := Int.negOnePow
+  χ_next := by rintro _ _ rfl; simp [Int.negOnePow_succ]
+
+@[simps]
+instance eulerCharSignsUpNat : (up ℕ).EulerCharSigns where
+  χ n := (-1) ^ n
+  χ_next := by rintro _ _ rfl; simp [pow_add]
+
+@[simps]
+instance eulerCharSignsDownNat : (down ℕ).EulerCharSigns where
+  χ n := (-1) ^ n
+  χ_next := by rintro _ _ rfl; simp [pow_add]
+
+end ComplexShape
+
+open ComplexShape CategoryTheory
+
+variable {R : Type*} [Ring R] {ι : Type*}
+
+namespace GradedObject
+
+variable (c : ComplexShape ι) [c.EulerCharSigns]
+
+/-- The Euler characteristic of a graded object over a finite set of indices.
+The sign at each index is determined by the `ComplexShape.EulerCharSigns` instance. -/
+noncomputable def eulerChar (X : CategoryTheory.GradedObject ι (ModuleCat R))
+    (indices : Finset ι) : ℤ :=
+  ∑ i ∈ indices, (c.χ i : ℤ) * Module.finrank R (X i)
+
+/-- The support of a graded object with respect to finite rank:
+the set of indices where the rank is nonzero. -/
+def finrankSupport (X : CategoryTheory.GradedObject ι (ModuleCat R)) : Set ι :=
+  Function.support (fun i => Module.finrank R (X i))
+
+/-- The finite rank support is contained in a set if and only if
+the rank vanishes outside that set. -/
+lemma finrankSupport_subset_iff (X : CategoryTheory.GradedObject ι (ModuleCat R)) (s : Set ι) :
+    finrankSupport X ⊆ s ↔ ∀ i ∉ s, Module.finrank R (X i) = 0 :=
+  Function.support_subset_iff'
+
+variable [Fintype ι]
+
+/-- The Euler characteristic as an infinite sum over all indices.
+This requires the index type to be finite. -/
+noncomputable def eulerCharTsum (X : CategoryTheory.GradedObject ι (ModuleCat R)) : ℤ :=
+  ∑ i : ι, (c.χ i : ℤ) * Module.finrank R (X i)
+
+/-- If a graded object has finite rank support contained in a finite set,
+the infinite Euler characteristic equals the finite one. -/
+theorem eulerCharTsum_eq_eulerChar (X : CategoryTheory.GradedObject ι (ModuleCat R))
+    (indices : Finset ι)
+    (h_support : finrankSupport X ⊆ indices) :
+    eulerCharTsum c X = eulerChar c X indices := by
+  simp only [eulerCharTsum, eulerChar]
+  symm
+  apply Finset.sum_subset (Finset.subset_univ indices)
+  intro i _ hi
+  simp [(finrankSupport_subset_iff X indices).mp h_support i hi]
+
+end GradedObject
+
+namespace HomologicalComplex
+
+variable {c : ComplexShape ι} [c.EulerCharSigns]
+
+/-- The Euler characteristic of a homological complex over a finite set of indices.
+The sign at each index is determined by the `ComplexShape.EulerCharSigns` instance. -/
+noncomputable abbrev eulerChar (C : HomologicalComplex (ModuleCat R) c)
+    (indices : Finset ι) : ℤ :=
+  GradedObject.eulerChar c C.X indices
+
+/-- The homological Euler characteristic over a finite set of indices.
+This is the Euler characteristic computed from the homology groups rather than
+the original complex. -/
+noncomputable abbrev homologyEulerChar (C : HomologicalComplex (ModuleCat R) c)
+    [∀ i : ι, C.HasHomology i] (indices : Finset ι) : ℤ :=
+  GradedObject.eulerChar c (fun i => C.homology i) indices
+
+variable [Fintype ι]
+
+/-- The Euler characteristic as an infinite sum over all indices.
+This requires the index type to be finite. -/
+noncomputable abbrev eulerCharTsum (C : HomologicalComplex (ModuleCat R) c) : ℤ :=
+  GradedObject.eulerCharTsum c C.X
+
+/-- The homological Euler characteristic as an infinite sum. -/
+noncomputable abbrev homologyEulerCharTsum (C : HomologicalComplex (ModuleCat R) c)
+    [∀ i : ι, C.HasHomology i] : ℤ :=
+  GradedObject.eulerCharTsum c (fun i => C.homology i)
+
+/-- If a complex has finite rank support contained in a finite set,
+the infinite Euler characteristic equals the finite one. -/
+theorem eulerCharTsum_eq_eulerChar (C : HomologicalComplex (ModuleCat R) c)
+    (indices : Finset ι)
+    (h_support : GradedObject.finrankSupport (C.X) ⊆ indices) :
+    eulerCharTsum C = eulerChar C indices :=
+  GradedObject.eulerCharTsum_eq_eulerChar c C.X indices h_support
+
+/-- If homology has finite rank support contained in a finite set,
+the infinite homological Euler characteristic equals the finite one. -/
+theorem homologyEulerCharTsum_eq_homologyEulerChar (C : HomologicalComplex (ModuleCat R) c)
+    [∀ i : ι, C.HasHomology i] (indices : Finset ι)
+    (h_support : GradedObject.finrankSupport (fun i => C.homology i) ⊆ indices) :
+    homologyEulerCharTsum C = homologyEulerChar C indices :=
+  GradedObject.eulerCharTsum_eq_eulerChar c (fun i => C.homology i) indices h_support
+
+end HomologicalComplex

--- a/Mathlib/Algebra/Homology/EulerCharacteristic.lean
+++ b/Mathlib/Algebra/Homology/EulerCharacteristic.lean
@@ -118,12 +118,10 @@ lemma finrankSupport_subset_iff (X : CategoryTheory.GradedObject ι (ModuleCat R
     finrankSupport X ⊆ s ↔ ∀ i ∉ s, Module.finrank R (X i) = 0 :=
   Function.support_subset_iff'
 
-variable [Fintype ι]
-
-/-- The Euler characteristic as an infinite sum over all indices.
-This requires the index type to be finite. -/
+/-- The Euler characteristic as a sum over all indices. Defaults to 0 if the support of the ranks of the objects of `X` is
+infinite. -/
 noncomputable def eulerCharTsum (X : CategoryTheory.GradedObject ι (ModuleCat R)) : ℤ :=
-  ∑ i : ι, (c.χ i : ℤ) * Module.finrank R (X i)
+  ∑ᶠ i : ι, (c.χ i : ℤ) * Module.finrank R (X i)
 
 /-- If a graded object has finite rank support contained in a finite set,
 the infinite Euler characteristic equals the finite one. -/

--- a/Mathlib/Algebra/Homology/EulerCharacteristic.lean
+++ b/Mathlib/Algebra/Homology/EulerCharacteristic.lean
@@ -5,15 +5,11 @@ Authors: Jesse Alama
 -/
 module
 
-public import Mathlib.Algebra.Homology.HomologicalComplex
-public import Mathlib.Algebra.Homology.ShortComplex.HomologicalComplex
-public import Mathlib.Algebra.Homology.ComplexShape
-public import Mathlib.Algebra.Ring.NegOnePow
 public import Mathlib.Algebra.Category.ModuleCat.Basic
-public import Mathlib.CategoryTheory.GradedObject
-public import Mathlib.LinearAlgebra.Dimension.Finrank
-public import Mathlib.Algebra.BigOperators.Finprod
 public import Mathlib.Algebra.GroupWithZero.Indicator
+public import Mathlib.Algebra.Homology.ShortComplex.HomologicalComplex
+public import Mathlib.Algebra.Ring.NegOnePow
+public import Mathlib.LinearAlgebra.Dimension.Finrank
 
 /-!
 # Euler characteristic of homological complexes

--- a/Mathlib/Algebra/Homology/EulerCharacteristic.lean
+++ b/Mathlib/Algebra/Homology/EulerCharacteristic.lean
@@ -156,7 +156,7 @@ noncomputable abbrev homologyEulerChar (C : HomologicalComplex (ModuleCat R) c)
 the `finsum` Euler characteristic equals the finite sum over that set. -/
 theorem eulerChar_eq_sum_finSet_of_finrankSupport_subset (C : HomologicalComplex (ModuleCat R) c)
     (indices : Finset ι)
-    (h_support : GradedObject.finrankSupport (C.X) ⊆ indices) :
+    (h_support : GradedObject.finrankSupport C.X ⊆ indices) :
     eulerChar C = ∑ i ∈ indices, (c.χ i : ℤ) * Module.finrank R (C.X i) :=
   GradedObject.eulerChar_eq_sum_finSet_of_finrankSupport_subset c C.X indices h_support
 

--- a/Mathlib/Algebra/Notation/Support.lean
+++ b/Mathlib/Algebra/Notation/Support.lean
@@ -141,6 +141,11 @@ lemma mulSupport_fun_one : mulSupport (fun _ ↦ 1 : ι → M) = ∅ := mulSuppo
 lemma mulSupport_const {c : M} (hc : c ≠ 1) : (mulSupport fun _ : ι ↦ c) = Set.univ := by
   ext x; simp [hc]
 
+/-- The multiplicative support of a function that is everywhere non-one is the whole space. -/
+@[to_additive /-- The support of a function that is everywhere nonzero is the whole space. -/]
+lemma mulSupport_eq_univ (hf : ∀ x, f x ≠ 1) : mulSupport f = Set.univ :=
+  Set.eq_univ_of_forall hf
+
 @[to_additive]
 lemma mulSupport_binop_subset (op : M → N → P) (op1 : op 1 1 = 1) (f : ι → M) (g : ι → N) :
     mulSupport (fun x ↦ op (f x) (g x)) ⊆ mulSupport f ∪ mulSupport g := fun x hx ↦


### PR DESCRIPTION
Add `ComplexShape.EulerCharSigns` typeclass providing the alternating signs `χ : ι → ℤˣ` for Euler characteristic computations. Instances are provided for `up ℕ`, `down ℕ`, `up ℤ`, and `down ℤ`.

The Euler characteristic definition (`eulerChar`) uses `finsum` to sum over all indices, with the `ComplexShape` as an explicit parameter. This allows working with arbitrary index types without requiring a `Fintype` instance, defaulting to 0 when the support is infinite.

The `GradedObject` version is the primary definition, with `HomologicalComplex.eulerChar` and `HomologicalComplex.homologyEulerChar` as abbreviations that apply the graded object version to `C.X` and `C.homology` respectively.

Split from #29713 as suggested by @joelriou.