### PR TITLE
[Merged by Bors] - chore(OpenPartialHomeomorph): tag three lemmas with grind

### DIFF
--- a/Mathlib/Topology/Closure.lean
+++ b/Mathlib/Topology/Closure.lean
@@ -45,6 +45,7 @@ theorem interior_subset : interior s ⊆ s :=
 theorem interior_maximal (h₁ : t ⊆ s) (h₂ : IsOpen t) : t ⊆ interior s :=
   subset_sUnion_of_mem ⟨h₂, h₁⟩
 
+@[grind =]
 theorem IsOpen.interior_eq (h : IsOpen s) : interior s = s :=
   interior_subset.antisymm (interior_maximal (Subset.refl s) h)
 

--- a/Mathlib/Topology/OpenPartialHomeomorph.lean
+++ b/Mathlib/Topology/OpenPartialHomeomorph.lean
@@ -639,6 +639,7 @@ theorem restr_toPartialEquiv (s : Set X) :
     (e.restr s).toPartialEquiv = e.toPartialEquiv.restr (interior s) :=
   rfl
 
+@[grind =]
 theorem restr_source' (s : Set X) (hs : IsOpen s) : (e.restr s).source = e.source ∩ s := by
   rw [e.restr_source, hs.interior_eq]
 
@@ -655,6 +656,7 @@ theorem restr_eq_of_source_subset {e : OpenPartialHomeomorph X Y} {s : Set X} (h
 theorem restr_univ {e : OpenPartialHomeomorph X Y} : e.restr univ = e :=
   restr_eq_of_source_subset (subset_univ _)
 
+@[grind =]
 theorem restr_source_inter (s : Set X) : e.restr (e.source ∩ s) = e.restr s := by
   refine OpenPartialHomeomorph.ext _ _ (fun x => rfl) (fun x => rfl) ?_
   simp [e.open_source.interior_eq, ← inter_assoc]

--- a/Mathlib/Topology/OpenPartialHomeomorph.lean
+++ b/Mathlib/Topology/OpenPartialHomeomorph.lean
@@ -630,7 +630,8 @@ theorem restrOpen_source (s : Set X) (hs : IsOpen s) : (e.restrOpen s hs).source
 make sure that the restriction is well defined whatever the set s, since open partial homeomorphisms
 are by definition defined on open sets. In applications where `s` is open, this coincides with the
 restriction of partial equivalences. -/
-@[simps! (attr := mfld_simps) -fullyApplied apply symm_apply, simps! -isSimp source target]
+@[simps! (attr := mfld_simps) -fullyApplied apply symm_apply,
+  simps! (attr := grind =) -isSimp source target]
 protected def restr (s : Set X) : OpenPartialHomeomorph X Y :=
   e.restrOpen (interior s) isOpen_interior
 
@@ -639,9 +640,8 @@ theorem restr_toPartialEquiv (s : Set X) :
     (e.restr s).toPartialEquiv = e.toPartialEquiv.restr (interior s) :=
   rfl
 
-@[grind =]
 theorem restr_source' (s : Set X) (hs : IsOpen s) : (e.restr s).source = e.source ∩ s := by
-  rw [e.restr_source, hs.interior_eq]
+  grind
 
 theorem restr_toPartialEquiv' (s : Set X) (hs : IsOpen s) :
     (e.restr s).toPartialEquiv = e.toPartialEquiv.restr s := by
@@ -656,7 +656,7 @@ theorem restr_eq_of_source_subset {e : OpenPartialHomeomorph X Y} {s : Set X} (h
 theorem restr_univ {e : OpenPartialHomeomorph X Y} : e.restr univ = e :=
   restr_eq_of_source_subset (subset_univ _)
 
-@[grind =]
+@[simp, grind =]
 theorem restr_source_inter (s : Set X) : e.restr (e.source ∩ s) = e.restr s := by
   refine OpenPartialHomeomorph.ext _ _ (fun x => rfl) (fun x => rfl) ?_
   simp [e.open_source.interior_eq, ← inter_assoc]


### PR DESCRIPTION
and `OpenPartialHomeomorph.restr_source_inter` with simp. Follow-up from #28793.

---

This is my first time adding grind annotations, so a careful review is welcome.

<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

When merging, all the commits will be squashed into a single commit
listing all co-authors.

Co-authors in the squash commit are gathered from two sources:

First, all authors of commits to this PR branch are included. Thus,
one way to add co-authors is to include at least one commit authored by
each co-author among the commits in the pull request. If necessary, you
may create empty commits to indicate co-authorship, using commands like so:

git commit --author="Author Name <author@email.com>" --allow-empty -m "add Author Name as coauthor"

Second, co-authors can also be listed in lines at the very bottom of
the commit message (that is, directly before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines
at the bottom of the commit message (before the `---`, and also before
any "Co-authored-by" lines) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
