### PR TITLE
[Merged by Bors] - chore: tidy instance SecondCountableTopology GHSpace

### DIFF
--- a/Mathlib/Topology/MetricSpace/GromovHausdorff.lean
+++ b/Mathlib/Topology/MetricSpace/GromovHausdorff.lean
@@ -703,7 +703,7 @@ instance : SecondCountableTopology GHSpace := by
       have I :=
         calc
           ε⁻¹ * |dist x y - dist (Ψ x) (Ψ y)| = |ε⁻¹ * (dist x y - dist (Ψ x) (Ψ y))| := by
-            rw [abs_mul, abs_of_nonneg (le_of_lt (inv_pos.2 εpos))]
+            rw [abs_mul, abs_of_nonneg (inv_pos.2 εpos).le]
           _ = |ε⁻¹ * dist x y - ε⁻¹ * dist (Ψ x) (Ψ y)| := by congr; ring
           _ ≤ 1 := le_of_lt (abs_sub_lt_one_of_floor_eq_floor this)
       calc

--- a/Mathlib/Topology/MetricSpace/GromovHausdorff.lean
+++ b/Mathlib/Topology/MetricSpace/GromovHausdorff.lean
@@ -627,13 +627,13 @@ instance : SecondCountableTopology GHSpace := by
     ⟨N p, fun a b => ⌊ε⁻¹ * dist ((E p).symm a) ((E p).symm b)⌋⟩
   refine ⟨Σ n, Fin n → Fin n → ℤ, inferInstance, F, fun p q hpq => ?_⟩
   /- As the target space of F is countable, it suffices to show that two points
-    `p` and `q` with `F p = F q` are at distance `≤ δ`.
-    For this, we construct a map `Φ` from `s p ⊆ p.Rep` (representing `p`)
-    to `q.Rep` (representing `q`) which is almost an isometry on `s p`, and
-    with image `s q`. For this, we compose the identification of `s p` with `Fin (N p)`
-    and the inverse of the identification of `s q` with `Fin (N q)`. Together with
-    the fact that `N p = N q`, this constructs `Ψ` between `s p` and `s q`, and then
-    composing with the canonical inclusion we get `Φ`. -/
+  `p` and `q` with `F p = F q` are at distance `≤ δ`.
+  For this, we construct a map `Φ` from `s p ⊆ p.Rep` (representing `p`)
+  to `q.Rep` (representing `q`) which is almost an isometry on `s p`, and
+  with image `s q`. For this, we compose the identification of `s p` with `Fin (N p)`
+  and the inverse of the identification of `s q` with `Fin (N q)`. Together with
+  the fact that `N p = N q`, this constructs `Ψ` between `s p` and `s q`, and then
+  composing with the canonical inclusion we get `Φ`. -/
   have Npq : N p = N q := (Sigma.mk.inj_iff.1 hpq).1
   let Ψ : s p → s q := fun x => (E q).symm (Fin.cast Npq ((E p) x))
   let Φ : s p → q.Rep := fun x => Ψ x
@@ -668,8 +668,8 @@ instance : SecondCountableTopology GHSpace := by
       exact hy.le
     · show ∀ x y : s p, |dist x y - dist (Φ x) (Φ y)| ≤ ε
       /- the distance between `x` and `y` is encoded in `F p`, and the distance between
-        `Φ x` and `Φ y` (two points of `s q`) is encoded in `F q`, all this up to `ε`.
-        As `F p = F q`, the distances are almost equal. -/
+      `Φ x` and `Φ y` (two points of `s q`) is encoded in `F q`, all this up to `ε`.
+      As `F p = F q`, the distances are almost equal. -/
       intro x y
       -- introduce `i`, that codes both `x` and `Φ x` in `Fin (N p) = Fin (N q)`
       let i : ℕ := E p x

--- a/Mathlib/Topology/MetricSpace/GromovHausdorff.lean
+++ b/Mathlib/Topology/MetricSpace/GromovHausdorff.lean
@@ -604,38 +604,32 @@ theorem ghDist_le_of_approx_subsets {s : Set X} (Φ : s → Y) {ε₁ ε₂ ε�
     exact ⟨Φ y, mem_range_self _, Dy⟩
   linarith
 
-end
+end --section
 
---section
 /-- The Gromov-Hausdorff space is second countable. -/
 instance : SecondCountableTopology GHSpace := by
   refine secondCountable_of_countable_discretization fun δ δpos => ?_
   let ε := 2 / 5 * δ
   have εpos : 0 < ε := mul_pos (by simp) δpos
-  have : ∀ p : GHSpace, ∃ s : Set p.Rep, s.Finite ∧ univ ⊆ ⋃ x ∈ s, ball x ε := fun p => by
+  have (p : GHSpace) : ∃ s : Set p.Rep, s.Finite ∧ univ ⊆ ⋃ x ∈ s, ball x ε := by
     simpa only [subset_univ, true_and] using
       finite_cover_balls_of_compact (X := p.Rep) isCompact_univ εpos
   -- for each `p`, `s p` is a finite `ε`-dense subset of `p` (or rather the metric space
-  -- `p.rep` representing `p`)
+  -- `p.Rep` representing `p`)
   choose s hs using this
-  have : ∀ p : GHSpace, ∀ t : Set p.Rep, t.Finite → ∃ n : ℕ, ∃ _ : Equiv t (Fin n), True := by
-    intro p t ht
-    let _ : Fintype t := Finite.fintype ht
-    exact ⟨Fintype.card t, Fintype.equivFin t, trivial⟩
-  choose N e _ using this
-  -- cardinality of the nice finite subset `s p` of `p.rep`, called `N p`
-  let N := fun p : GHSpace => N p (s p) (hs p).1
-  -- equiv from `s p`, a nice finite subset of `p.rep`, to `Fin (N p)`, called `E p`
-  let E := fun p : GHSpace => e p (s p) (hs p).1
+  -- cardinality of the nice finite subset `s p` of `p.Rep`, called `N p`
+  let N := fun p : GHSpace => Nat.card (s p)
+  -- equiv from `s p`, a nice finite subset of `p.Rep`, to `Fin (N p)`, called `E p`
+  let E := fun p : GHSpace => (hs p).1.equivFin
   -- A function `F` associating to `p : GHSpace` the data of all distances between points
   -- in the `ε`-dense set `s p`.
   let F : GHSpace → Σ n : ℕ, Fin n → Fin n → ℤ := fun p =>
     ⟨N p, fun a b => ⌊ε⁻¹ * dist ((E p).symm a) ((E p).symm b)⌋⟩
-  refine ⟨Σ n, Fin n → Fin n → ℤ, by infer_instance, F, fun p q hpq => ?_⟩
+  refine ⟨Σ n, Fin n → Fin n → ℤ, inferInstance, F, fun p q hpq => ?_⟩
   /- As the target space of F is countable, it suffices to show that two points
     `p` and `q` with `F p = F q` are at distance `≤ δ`.
-    For this, we construct a map `Φ` from `s p ⊆ p.rep` (representing `p`)
-    to `q.rep` (representing `q`) which is almost an isometry on `s p`, and
+    For this, we construct a map `Φ` from `s p ⊆ p.Rep` (representing `p`)
+    to `q.Rep` (representing `q`) which is almost an isometry on `s p`, and
     with image `s q`. For this, we compose the identification of `s p` with `Fin (N p)`
     and the inverse of the identification of `s q` with `Fin (N q)`. Together with
     the fact that `N p = N q`, this constructs `Ψ` between `s p` and `s q`, and then
@@ -643,7 +637,7 @@ instance : SecondCountableTopology GHSpace := by
   have Npq : N p = N q := (Sigma.mk.inj_iff.1 hpq).1
   let Ψ : s p → s q := fun x => (E q).symm (Fin.cast Npq ((E p) x))
   let Φ : s p → q.Rep := fun x => Ψ x
-  -- Use the almost isometry `Φ` to show that `p.rep` and `q.rep`
+  -- Use the almost isometry `Φ` to show that `p.Rep` and `q.Rep`
   -- are within controlled Gromov-Hausdorff distance.
   have main : ghDist p.Rep q.Rep ≤ ε + ε / 2 + ε := by
     refine ghDist_le_of_approx_subsets Φ ?_ ?_ ?_
@@ -651,13 +645,13 @@ instance : SecondCountableTopology GHSpace := by
       -- by construction, `s p` is `ε`-dense
       intro x
       have : x ∈ ⋃ y ∈ s p, ball y ε := (hs p).2 (mem_univ _)
-      rcases mem_iUnion₂.1 this with ⟨y, ys, hy⟩
-      exact ⟨y, ys, le_of_lt hy⟩
+      obtain ⟨y, ys, hy⟩ := mem_iUnion₂.1 this
+      exact ⟨y, ys, hy.le⟩
     · show ∀ x : q.Rep, ∃ z : s p, dist x (Φ z) ≤ ε
       -- by construction, `s q` is `ε`-dense, and it is the range of `Φ`
       intro x
       have : x ∈ ⋃ y ∈ s q, ball y ε := (hs q).2 (mem_univ _)
-      rcases mem_iUnion₂.1 this with ⟨y, ys, hy⟩
+      obtain ⟨y, ys, hy⟩ := mem_iUnion₂.1 this
       let i : ℕ := E q ⟨y, ys⟩
       let hi := ((E q) ⟨y, ys⟩).is_lt
       have ihi_eq : (⟨i, hi⟩ : Fin (N q)) = (E q) ⟨y, ys⟩ := by rw [Fin.ext_iff, Fin.val_mk]
@@ -671,11 +665,11 @@ instance : SecondCountableTopology GHSpace := by
         rw [ihi_eq]; exact (E q).symm_apply_apply ⟨y, ys⟩
       have : Φ z = y := by simp only [Φ, Ψ]; rw [C1, C2, C3]
       rw [this]
-      exact le_of_lt hy
+      exact hy.le
     · show ∀ x y : s p, |dist x y - dist (Φ x) (Φ y)| ≤ ε
       /- the distance between `x` and `y` is encoded in `F p`, and the distance between
-            `Φ x` and `Φ y` (two points of `s q`) is encoded in `F q`, all this up to `ε`.
-            As `F p = F q`, the distances are almost equal. -/
+        `Φ x` and `Φ y` (two points of `s q`) is encoded in `F q`, all this up to `ε`.
+        As `F p = F q`, the distances are almost equal. -/
       intro x y
       -- introduce `i`, that codes both `x` and `Φ x` in `Fin (N p) = Fin (N q)`
       let i : ℕ := E p x
@@ -696,8 +690,7 @@ instance : SecondCountableTopology GHSpace := by
       have : (F q).2 ((E q) (Ψ x)) ((E q) (Ψ y)) = ⌊ε⁻¹ * dist (Ψ x) (Ψ y)⌋ := by
         simp only [F, (E q).symm_apply_apply]
       have Aq : (F q).2 ⟨i, hiq⟩ ⟨j, hjq⟩ = ⌊ε⁻¹ * dist (Ψ x) (Ψ y)⌋ := by
-        rw [← this]
-        congr!
+        simp [← this, *]
       -- use the equality between `F p` and `F q` to deduce that the distances have equal
       -- integer parts
       have : (F p).2 ⟨i, hip⟩ ⟨j, hjp⟩ = (F q).2 ⟨i, hiq⟩ ⟨j, hjq⟩ := by
@@ -709,16 +702,14 @@ instance : SecondCountableTopology GHSpace := by
       -- that should be automated
       have I :=
         calc
-          |ε⁻¹| * |dist x y - dist (Ψ x) (Ψ y)| = |ε⁻¹ * (dist x y - dist (Ψ x) (Ψ y))| :=
-            (abs_mul _ _).symm
+          ε⁻¹ * |dist x y - dist (Ψ x) (Ψ y)| = |ε⁻¹ * (dist x y - dist (Ψ x) (Ψ y))| := by
+            rw [abs_mul, abs_of_nonneg (le_of_lt (inv_pos.2 εpos))]
           _ = |ε⁻¹ * dist x y - ε⁻¹ * dist (Ψ x) (Ψ y)| := by congr; ring
           _ ≤ 1 := le_of_lt (abs_sub_lt_one_of_floor_eq_floor this)
       calc
-        |dist x y - dist (Ψ x) (Ψ y)| = ε * ε⁻¹ * |dist x y - dist (Ψ x) (Ψ y)| := by
-          rw [mul_inv_cancel₀ (ne_of_gt εpos), one_mul]
-        _ = ε * (|ε⁻¹| * |dist x y - dist (Ψ x) (Ψ y)|) := by
-          rw [abs_of_nonneg (le_of_lt (inv_pos.2 εpos)), mul_assoc]
-        _ ≤ ε * 1 := mul_le_mul_of_nonneg_left I (le_of_lt εpos)
+        |dist x y - dist (Ψ x) (Ψ y)|
+        _ = ε * (ε⁻¹ * |dist x y - dist (Ψ x) (Ψ y)|) := by grind
+        _ ≤ ε * 1 := by gcongr
         _ = ε := mul_one _
   calc
     dist p q = ghDist p.Rep q.Rep := dist_ghDist p q


### PR DESCRIPTION
This is listed as an example to follow in the PR Review guide, so it feels worth simplifying a little and fixing typos.


---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

When merging, all the commits will be squashed into a single commit
listing all co-authors.

Co-authors in the squash commit are gathered from two sources:

First, all authors of commits to this PR branch are included. Thus,
one way to add co-authors is to include at least one commit authored by
each co-author among the commits in the pull request. If necessary, you
may create empty commits to indicate co-authorship, using commands like so:

git commit --author="Author Name <author@email.com>" --allow-empty -m "add Author Name as coauthor"

Second, co-authors can also be listed in lines at the very bottom of
the commit message (that is, directly before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines
at the bottom of the commit message (before the `---`, and also before
any "Co-authored-by" lines) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
