### PR TITLE
[Merged by Bors] - chore(CategoryTheory/Abelian): rename the functors to `im`/`coim`

### DIFF
--- a/Mathlib/CategoryTheory/Abelian/Basic.lean
+++ b/Mathlib/CategoryTheory/Abelian/Basic.lean
@@ -415,6 +415,8 @@ def im : Arrow C ⥤ C where
   obj f := Abelian.image f.hom
   map {f g} u := kernel.lift _ (Abelian.image.ι f.hom ≫ u.right) <| by simp [← Arrow.w_assoc u]
 
+@[deprecated (since := "2025-10-31")] noncomputable alias imageFunctor := im
+
 /-- `Abelian.coimage` as a functor from the arrow category. -/
 @[simps]
 def coim : Arrow C ⥤ C where
@@ -422,10 +424,14 @@ def coim : Arrow C ⥤ C where
   map {f g} u := cokernel.desc _ (u.left ≫ Abelian.coimage.π g.hom) <| by
     simp [← Category.assoc, coimage.comp_π_eq_zero]; simp
 
+@[deprecated (since := "2025-10-31")] noncomputable alias coimageFunctor := coim
+
 /-- The image and coimage of an arrow are naturally isomorphic. -/
 @[simps!]
 def coimIsoIm : coim (C := C) ≅ im :=
   NatIso.ofComponents fun _ ↦ Abelian.coimageIsoImage _
+
+@[deprecated (since := "2025-10-31")] noncomputable alias coimageFunctorIsoImageFunctor := coimIsoIm
 
 /-- There is a canonical isomorphism between the abelian image and the categorical image of a
     morphism. -/

--- a/Mathlib/CategoryTheory/Abelian/Basic.lean
+++ b/Mathlib/CategoryTheory/Abelian/Basic.lean
@@ -411,20 +411,20 @@ variable {Z : C} (g : Y ⟶ Z)
 
 /-- `Abelian.image` as a functor from the arrow category. -/
 @[simps]
-def imageFunctor : Arrow C ⥤ C where
+def im : Arrow C ⥤ C where
   obj f := Abelian.image f.hom
   map {f g} u := kernel.lift _ (Abelian.image.ι f.hom ≫ u.right) <| by simp [← Arrow.w_assoc u]
 
 /-- `Abelian.coimage` as a functor from the arrow category. -/
 @[simps]
-def coimageFunctor : Arrow C ⥤ C where
+def coim : Arrow C ⥤ C where
   obj f := Abelian.coimage f.hom
   map {f g} u := cokernel.desc _ (u.left ≫ Abelian.coimage.π g.hom) <| by
     simp [← Category.assoc, coimage.comp_π_eq_zero]; simp
 
 /-- The image and coimage of an arrow are naturally isomorphic. -/
 @[simps!]
-def coimageFunctorIsoImageFunctor : coimageFunctor (C := C) ≅ imageFunctor :=
+def coimIsoIm : coim (C := C) ≅ im :=
   NatIso.ofComponents fun _ ↦ Abelian.coimageIsoImage _
 
 /-- There is a canonical isomorphism between the abelian image and the categorical image of a


### PR DESCRIPTION
I introduced these definitions two weeks ago without realising that there already was a naming convention for these functors.


---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

When merging, all the commits will be squashed into a single commit
listing all co-authors.

Co-authors in the squash commit are gathered from two sources:

First, all authors of commits to this PR branch are included. Thus,
one way to add co-authors is to include at least one commit authored by
each co-author among the commits in the pull request. If necessary, you
may create empty commits to indicate co-authorship, using commands like so:

git commit --author="Author Name <author@email.com>" --allow-empty -m "add Author Name as coauthor"

Second, co-authors can also be listed in lines at the very bottom of
the commit message (that is, directly before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines
at the bottom of the commit message (before the `---`, and also before
any "Co-authored-by" lines) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
