### PR TITLE
[Merged by Bors] - chore: fix names of Dirichlet's theorems

### DIFF
--- a/Mathlib/NumberTheory/LSeries/PrimesInAP.lean
+++ b/Mathlib/NumberTheory/LSeries/PrimesInAP.lean
@@ -507,16 +507,16 @@ theorem forall_exists_prime_gt_and_modEq (n : ℕ) {q a : ℕ} (hq : q ≠ 0) (h
   simpa using forall_exists_prime_gt_and_zmodEq n (q := q) (a := a) hq (by simpa)
 
 open Filter in
-lemma frequently_atTop_prime_and_modEq_one {q a : ℕ} (hq : q ≠ 0) (h : a.Coprime q) :
+lemma frequently_atTop_prime_and_modEq {q a : ℕ} (hq : q ≠ 0) (h : a.Coprime q) :
     ∃ᶠ p in atTop, p.Prime ∧ p ≡ a [MOD q] := by
   rw [frequently_atTop]
   intro n
   obtain ⟨p, hn, hp, ha⟩ := forall_exists_prime_gt_and_modEq n hq h
   exact ⟨p, hn.le, hp, ha⟩
 
-lemma infinite_setOf_prime_and_modEq_one {q a : ℕ} (hq : q ≠ 0) (h : a.Coprime q) :
+lemma infinite_setOf_prime_and_modEq {q a : ℕ} (hq : q ≠ 0) (h : a.Coprime q) :
     Set.Infinite {p : ℕ | p.Prime ∧ p ≡ a [MOD q]} :=
-  frequently_atTop_iff_infinite.1 (frequently_atTop_prime_and_modEq_one hq h)
+  frequently_atTop_iff_infinite.1 (frequently_atTop_prime_and_modEq hq h)
 
 end Nat
 

--- a/Mathlib/NumberTheory/LSeries/PrimesInAP.lean
+++ b/Mathlib/NumberTheory/LSeries/PrimesInAP.lean
@@ -56,7 +56,7 @@ The main steps of the proof are as follows.
 ## Main Result
 
 We give two versions of **Dirichlet's Theorem**:
-* `Nat.setOf_prime_and_eq_mod_infinite` states that the set of primes `p`
+* `Nat.infinite_setOf_prime_and_eq_mod` states that the set of primes `p`
   such that `(p : ZMod q) = a` is infinite (when `a` is invertible in `ZMod q`).
 * `Nat.forall_exists_prime_gt_and_eq_mod` states that for any natural number `n`
   there is a prime `p > n` such that `(p : ZMod q) = a`.
@@ -469,19 +469,22 @@ variable {q : ℕ} [NeZero q] {a : ZMod q}
 /-- **Dirichlet's Theorem** on primes in arithmetic progression: if `q` is a positive
 integer and `a : ZMod q` is a unit, then there are infinitely many prime numbers `p`
 such that `(p : ZMod q) = a`. -/
-theorem setOf_prime_and_eq_mod_infinite (ha : IsUnit a) :
+theorem infinite_setOf_prime_and_eq_mod (ha : IsUnit a) :
     {p : ℕ | p.Prime ∧ (p : ZMod q) = a}.Infinite := by
   by_contra H
   rw [Set.not_infinite] at H
   exact not_summable_residueClass_prime_div ha <|
     summable_of_finite_support <| support_residueClass_prime_div a ▸ H
 
+@[deprecated (since := "2025-11-01")]
+alias setOf_prime_and_eq_mod_infinite := infinite_setOf_prime_and_eq_mod
+
 /-- **Dirichlet's Theorem** on primes in arithmetic progression: if `q` is a positive
 integer and `a : ZMod q` is a unit, then there are infinitely many prime numbers `p`
 such that `(p : ZMod q) = a`. -/
 theorem forall_exists_prime_gt_and_eq_mod (ha : IsUnit a) (n : ℕ) :
     ∃ p > n, p.Prime ∧ (p : ZMod q) = a := by
-  obtain ⟨p, hp₁, hp₂⟩ := Set.infinite_iff_exists_gt.mp (setOf_prime_and_eq_mod_infinite ha) n
+  obtain ⟨p, hp₁, hp₂⟩ := Set.infinite_iff_exists_gt.mp (infinite_setOf_prime_and_eq_mod ha) n
   exact ⟨p, hp₂.gt, Set.mem_setOf.mp hp₁⟩
 
 /-- **Dirichlet's Theorem** on primes in arithmetic progression: if `q` is a positive

--- a/docs/100.yaml
+++ b/docs/100.yaml
@@ -195,7 +195,7 @@
   title  : The Central Limit Theorem
 48:
   title  : Dirichlet’s Theorem
-  decl   : Nat.setOf_prime_and_eq_mod_infinite
+  decl   : Nat.infinite_setOf_prime_and_eq_mod
   authors: David Loeffler, Michael Stoll
 49:
   title  : The Cayley-Hamilton Theorem

--- a/docs/1000.yaml
+++ b/docs/1000.yaml
@@ -535,7 +535,7 @@ Q544369:
 
 Q550402:
   title: Dirichlet's theorem on arithmetic progressions
-  decl: Nat.setOf_prime_and_eq_mod_infinite
+  decl: Nat.infinite_setOf_prime_and_eq_mod
   authors: David Loeffler, Michael Stoll
 
 Q552367:


### PR DESCRIPTION
---

This  is to make it consistent with the new version added in #31139, and it addresses the comments from [here](https://github.com/leanprover-community/mathlib4/pull/31139#discussion_r2483660980).

<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

When merging, all the commits will be squashed into a single commit
listing all co-authors.

Co-authors in the squash commit are gathered from two sources:

First, all authors of commits to this PR branch are included. Thus,
one way to add co-authors is to include at least one commit authored by
each co-author among the commits in the pull request. If necessary, you
may create empty commits to indicate co-authorship, using commands like so:

git commit --author="Author Name <author@email.com>" --allow-empty -m "add Author Name as coauthor"

Second, co-authors can also be listed in lines at the very bottom of
the commit message (that is, directly before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines
at the bottom of the commit message (before the `---`, and also before
any "Co-authored-by" lines) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
