### PR TITLE
[Merged by Bors] - feat: measure real of the complement of a null measurable set

### DIFF
--- a/Mathlib/MeasureTheory/Measure/Real.lean
+++ b/Mathlib/MeasureTheory/Measure/Real.lean
@@ -368,6 +368,11 @@ theorem measureReal_compl [IsFiniteMeasure μ] (h₁ : MeasurableSet s) :
   rw [compl_eq_univ_diff]
   exact measureReal_diff (subset_univ s) h₁
 
+theorem measureReal_compl₀ [IsFiniteMeasure μ] (h₁ : NullMeasurableSet s μ) :
+    μ.real sᶜ = μ.real univ - μ.real s := by
+  simp only [measureReal_def, ne_eq, measure_ne_top, not_false_eq_true, measure_compl₀ h₁]
+  rw [ENNReal.toReal_sub_of_le (measure_mono (subset_univ _)) (by finiteness)]
+
 theorem measureReal_union_congr_of_subset (hs : s₁ ⊆ s₂)
     (hsμ : μ.real s₂ ≤ μ.real s₁) (ht : t₁ ⊆ t₂) (htμ : μ.real t₂ ≤ μ.real t₁)
     (h₁ : μ s₂ ≠ ∞ := by finiteness) (h₂ : μ t₂ ≠ ∞ := by finiteness) :

--- a/Mathlib/MeasureTheory/Measure/Real.lean
+++ b/Mathlib/MeasureTheory/Measure/Real.lean
@@ -370,8 +370,7 @@ theorem measureReal_compl [IsFiniteMeasure μ] (h₁ : MeasurableSet s) :
 
 theorem measureReal_compl₀ [IsFiniteMeasure μ] (h₁ : NullMeasurableSet s μ) :
     μ.real sᶜ = μ.real univ - μ.real s := by
-  simp only [measureReal_def, ne_eq, measure_ne_top, not_false_eq_true, measure_compl₀ h₁]
-  rw [ENNReal.toReal_sub_of_le (measure_mono (subset_univ _)) (by finiteness)]
+  linarith [measureReal_add_measureReal_compl₀ h₁]
 
 theorem measureReal_union_congr_of_subset (hs : s₁ ⊆ s₂)
     (hsμ : μ.real s₂ ≤ μ.real s₁) (ht : t₁ ⊆ t₂) (htμ : μ.real t₂ ≤ μ.real t₁)


### PR DESCRIPTION
---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

When merging, all the commits will be squashed into a single commit
listing all co-authors.

Co-authors in the squash commit are gathered from two sources:

First, all authors of commits to this PR branch are included. Thus,
one way to add co-authors is to include at least one commit authored by
each co-author among the commits in the pull request. If necessary, you
may create empty commits to indicate co-authorship, using commands like so:

git commit --author="Author Name <author@email.com>" --allow-empty -m "add Author Name as coauthor"

Second, co-authors can also be listed in lines at the very bottom of
the commit message (that is, directly before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines
at the bottom of the commit message (before the `---`, and also before
any "Co-authored-by" lines) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
