### PR TITLE
[Merged by Bors] - feat(Topology/Sets): add `Compacts.toCloseds`

### DIFF
--- a/Mathlib/Topology/Sets/Compacts.lean
+++ b/Mathlib/Topology/Sets/Compacts.lean
@@ -283,7 +283,7 @@ theorem carrier_eq_coe (s : NonemptyCompacts α) : s.carrier = s :=
 theorem coe_toCompacts (s : NonemptyCompacts α) : (s.toCompacts : Set α) = s := rfl
 
 @[simp]
-theorem mem_toCompacts [T2Space α] (x : α) (s : NonemptyCompacts α) :
+theorem mem_toCompacts (x : α) (s : NonemptyCompacts α) :
     x ∈ s.toCompacts ↔ x ∈ s :=
   Iff.rfl
 

--- a/Mathlib/Topology/Sets/Compacts.lean
+++ b/Mathlib/Topology/Sets/Compacts.lean
@@ -59,7 +59,7 @@ def toCloseds [T2Space α] (s : Compacts α) : Closeds α :=
   ⟨s, s.isCompact.isClosed⟩
 
 @[simp]
-theorem mem_toCloseds [T2Space α] (x : α) (s : Compacts α) :
+theorem mem_toCloseds [T2Space α] {x : α} {s : Compacts α} :
     x ∈ s.toCloseds ↔ x ∈ s :=
   Iff.rfl
 
@@ -264,7 +264,7 @@ theorem toCloseds_toCompacts [T2Space α] (s : NonemptyCompacts α) :
   rfl
 
 @[simp]
-theorem mem_toCloseds [T2Space α] (x : α) (s : NonemptyCompacts α) :
+theorem mem_toCloseds [T2Space α] {x : α} {s : NonemptyCompacts α} :
     x ∈ s.toCloseds ↔ x ∈ s :=
   Iff.rfl
 
@@ -283,7 +283,7 @@ theorem carrier_eq_coe (s : NonemptyCompacts α) : s.carrier = s :=
 theorem coe_toCompacts (s : NonemptyCompacts α) : (s.toCompacts : Set α) = s := rfl
 
 @[simp]
-theorem mem_toCompacts (x : α) (s : NonemptyCompacts α) :
+theorem mem_toCompacts {x : α} {s : NonemptyCompacts α} :
     x ∈ s.toCompacts ↔ x ∈ s :=
   Iff.rfl
 

--- a/Mathlib/Topology/Sets/Compacts.lean
+++ b/Mathlib/Topology/Sets/Compacts.lean
@@ -53,6 +53,11 @@ protected theorem isCompact (s : Compacts α) : IsCompact (s : Set α) :=
 instance (K : Compacts α) : CompactSpace K :=
   isCompact_iff_compactSpace.1 K.isCompact
 
+/-- Reinterpret a compact as a closed set. -/
+@[simps]
+def toCloseds [T2Space α] (s : Compacts α) : Closeds α :=
+  ⟨s, s.isCompact.isClosed⟩
+
 instance : CanLift (Set α) (Compacts α) (↑) IsCompact where prf K hK := ⟨⟨K, hK⟩, rfl⟩
 
 @[ext]
@@ -124,6 +129,10 @@ instance : Singleton α (Compacts α) where
 @[simp]
 theorem mem_singleton (x y : α) : x ∈ ({y} : Compacts α) ↔ x = y :=
   Iff.rfl
+
+@[simp]
+theorem toCloseds_singleton [T2Space α] (x : α) : toCloseds {x} = Closeds.singleton x :=
+  rfl
 
 theorem singleton_injective : Function.Injective ({·} : α → Compacts α) :=
   .of_comp (f := SetLike.coe) Set.singleton_injective
@@ -240,8 +249,14 @@ protected theorem nonempty (s : NonemptyCompacts α) : (s : Set α).Nonempty :=
   s.nonempty'
 
 /-- Reinterpret a nonempty compact as a closed set. -/
+@[simps]
 def toCloseds [T2Space α] (s : NonemptyCompacts α) : Closeds α :=
   ⟨s, s.isCompact.isClosed⟩
+
+@[simp]
+theorem toCloseds_toCompacts [T2Space α] (s : NonemptyCompacts α) :
+    s.toCompacts.toCloseds = s.toCloseds :=
+  rfl
 
 @[ext]
 protected theorem ext {s t : NonemptyCompacts α} (h : (s : Set α) = t) : s = t :=

--- a/Mathlib/Topology/Sets/Compacts.lean
+++ b/Mathlib/Topology/Sets/Compacts.lean
@@ -58,6 +58,11 @@ instance (K : Compacts α) : CompactSpace K :=
 def toCloseds [T2Space α] (s : Compacts α) : Closeds α :=
   ⟨s, s.isCompact.isClosed⟩
 
+@[simp]
+theorem mem_toCloseds [T2Space α] (x : α) (s : Compacts α) :
+    x ∈ s.toCloseds ↔ x ∈ s :=
+  Iff.rfl
+
 instance : CanLift (Set α) (Compacts α) (↑) IsCompact where prf K hK := ⟨⟨K, hK⟩, rfl⟩
 
 @[ext]
@@ -258,6 +263,11 @@ theorem toCloseds_toCompacts [T2Space α] (s : NonemptyCompacts α) :
     s.toCompacts.toCloseds = s.toCloseds :=
   rfl
 
+@[simp]
+theorem mem_toCloseds [T2Space α] (x : α) (s : NonemptyCompacts α) :
+    x ∈ s.toCloseds ↔ x ∈ s :=
+  Iff.rfl
+
 @[ext]
 protected theorem ext {s t : NonemptyCompacts α} (h : (s : Set α) = t) : s = t :=
   SetLike.ext' h
@@ -271,6 +281,11 @@ theorem carrier_eq_coe (s : NonemptyCompacts α) : s.carrier = s :=
 
 @[simp]
 theorem coe_toCompacts (s : NonemptyCompacts α) : (s.toCompacts : Set α) = s := rfl
+
+@[simp]
+theorem mem_toCompacts [T2Space α] (x : α) (s : NonemptyCompacts α) :
+    x ∈ s.toCompacts ↔ x ∈ s :=
+  Iff.rfl
 
 instance : Max (NonemptyCompacts α) :=
   ⟨fun s t => ⟨s.toCompacts ⊔ t.toCompacts, s.nonempty.mono subset_union_left⟩⟩


### PR DESCRIPTION
---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

When merging, all the commits will be squashed into a single commit
listing all co-authors.

Co-authors in the squash commit are gathered from two sources:

First, all authors of commits to this PR branch are included. Thus,
one way to add co-authors is to include at least one commit authored by
each co-author among the commits in the pull request. If necessary, you
may create empty commits to indicate co-authorship, using commands like so:

git commit --author="Author Name <author@email.com>" --allow-empty -m "add Author Name as coauthor"

Second, co-authors can also be listed in lines at the very bottom of
the commit message (that is, directly before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines
at the bottom of the commit message (before the `---`, and also before
any "Co-authored-by" lines) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
