### PR TITLE
[Merged by Bors] - feat(CategoryTheory/Products): generalize prod to CategoryStruct's

### DIFF
--- a/Mathlib/CategoryTheory/Products/Basic.lean
+++ b/Mathlib/CategoryTheory/Products/Basic.lean
@@ -34,12 +34,16 @@ universe v₁ v₂ v₃ v₄ u₁ u₂ u₃ u₄
 
 section
 
-variable (C : Type u₁) [Category.{v₁} C] (D : Type u₂) [Category.{v₂} D]
+variable (C : Type u₁) (D : Type u₂)
+
+section
+
+variable [CategoryStruct.{v₁} C] [CategoryStruct.{v₂} D]
 
 -- the generates simp lemmas like `id_fst` and `comp_snd`
-/-- `prod C D` gives the Cartesian product of two categories. -/
-@[simps (notRecursive := []) Hom id_fst id_snd comp_fst comp_snd, stacks 001K]
-instance prod : Category.{max v₁ v₂} (C × D) where
+/-- `CategoryStruct.prod C D` gives the Cartesian product of two `CategoryStruct`'s. -/
+@[simps (notRecursive := []) Hom id_fst id_snd comp_fst comp_snd]
+instance CategoryStruct.prod : CategoryStruct.{max v₁ v₂} (C × D) where
   Hom X Y := (X.1 ⟶ Y.1) × (X.2 ⟶ Y.2)
   id X := ⟨𝟙 X.1, 𝟙 X.2⟩
   comp f g := (f.1 ≫ g.1, f.2 ≫ g.2)
@@ -72,6 +76,18 @@ abbrev mkHom {X₁ X₂ : C} {Y₁ Y₂ : D} (f : X₁ ⟶ X₂) (g : Y₁ ⟶ Y
 scoped infixr:70 " ×ₘ " => Prod.mkHom
 
 end Prod
+
+end
+
+section -- TODO: this section seems pointless?
+
+variable (C : Type u₁) [Category.{v₁} C] (D : Type u₂) [Category.{v₂} D]
+
+-- the generates simp lemmas like `id_fst` and `comp_snd`
+/-- `prod C D` gives the Cartesian product of two categories. -/
+@[simps! (notRecursive := []) Hom id_fst id_snd comp_fst comp_snd, stacks 001K]
+instance prod : Category.{max v₁ v₂} (C × D) where
+
 theorem isIso_prod_iff {P Q : C} {S T : D} {f : (P, S) ⟶ (Q, T)} :
     IsIso f ↔ IsIso f.1 ∧ IsIso f.2 := by
   constructor
@@ -217,6 +233,8 @@ variable {C}
 @[simps!]
 def Functor.constCompEvaluationObj (X : C) : Functor.const C ⋙ (evaluation C D).obj X ≅ 𝟭 D :=
   NatIso.ofComponents fun _ => Iso.refl _
+
+end
 
 end
 

--- a/Mathlib/CategoryTheory/Products/Basic.lean
+++ b/Mathlib/CategoryTheory/Products/Basic.lean
@@ -38,7 +38,7 @@ variable (C : Type u₁) [CategoryStruct.{v₁} C] (D : Type u₂) [CategoryStru
 
 /-- `CategoryStruct.prod C D` gives the Cartesian product of two `CategoryStruct`'s. -/
 @[simps (notRecursive := [])] -- notRecursive to generate simp lemmas like `id_fst` and `comp_snd`
-instance CategoryStruct.prod : CategoryStruct.{max v₁ v₂} (C × D) where
+instance prod : CategoryStruct.{max v₁ v₂} (C × D) where
   Hom X Y := (X.1 ⟶ Y.1) × (X.2 ⟶ Y.2)
   id X := ⟨𝟙 X.1, 𝟙 X.2⟩
   comp f g := (f.1 ≫ g.1, f.2 ≫ g.2)
@@ -79,8 +79,8 @@ section
 variable (C : Type u₁) [Category.{v₁} C] (D : Type u₂) [Category.{v₂} D]
 
 /-- `prod C D` gives the Cartesian product of two categories. -/
-@[simps! (notRecursive := []) Hom id_fst id_snd comp_fst comp_snd, stacks 001K]
-instance prod : Category.{max v₁ v₂} (C × D) where
+@[stacks 001K]
+instance prod' : Category.{max v₁ v₂} (C × D) where
 
 theorem isIso_prod_iff {P Q : C} {S T : D} {f : (P, S) ⟶ (Q, T)} :
     IsIso f ↔ IsIso f.1 ∧ IsIso f.2 := by
@@ -123,7 +123,7 @@ variable (C : Type u₁) [Category.{v₁} C] (D : Type u₁) [Category.{v₁} D]
 universe levels. This helps typeclass resolution.
 -/
 instance uniformProd : Category (C × D) :=
-  CategoryTheory.prod C D
+  CategoryTheory.prod' C D
 
 end
 

--- a/Mathlib/CategoryTheory/Products/Basic.lean
+++ b/Mathlib/CategoryTheory/Products/Basic.lean
@@ -36,9 +36,8 @@ section
 
 variable (C : Type u₁) [CategoryStruct.{v₁} C] (D : Type u₂) [CategoryStruct.{v₂} D]
 
--- the generates simp lemmas like `id_fst` and `comp_snd`
 /-- `CategoryStruct.prod C D` gives the Cartesian product of two `CategoryStruct`'s. -/
-@[simps (notRecursive := []) Hom id_fst id_snd comp_fst comp_snd]
+@[simps (notRecursive := [])] -- notRecursive to generate simp lemmas like `id_fst` and `comp_snd`
 instance CategoryStruct.prod : CategoryStruct.{max v₁ v₂} (C × D) where
   Hom X Y := (X.1 ⟶ Y.1) × (X.2 ⟶ Y.2)
   id X := ⟨𝟙 X.1, 𝟙 X.2⟩
@@ -79,7 +78,6 @@ section
 
 variable (C : Type u₁) [Category.{v₁} C] (D : Type u₂) [Category.{v₂} D]
 
--- the generates simp lemmas like `id_fst` and `comp_snd`
 /-- `prod C D` gives the Cartesian product of two categories. -/
 @[simps! (notRecursive := []) Hom id_fst id_snd comp_fst comp_snd, stacks 001K]
 instance prod : Category.{max v₁ v₂} (C × D) where

--- a/Mathlib/CategoryTheory/Products/Basic.lean
+++ b/Mathlib/CategoryTheory/Products/Basic.lean
@@ -34,11 +34,7 @@ universe v₁ v₂ v₃ v₄ u₁ u₂ u₃ u₄
 
 section
 
-variable (C : Type u₁) (D : Type u₂)
-
-section
-
-variable [CategoryStruct.{v₁} C] [CategoryStruct.{v₂} D]
+variable (C : Type u₁) [CategoryStruct.{v₁} C] (D : Type u₂) [CategoryStruct.{v₂} D]
 
 -- the generates simp lemmas like `id_fst` and `comp_snd`
 /-- `CategoryStruct.prod C D` gives the Cartesian product of two `CategoryStruct`'s. -/
@@ -79,7 +75,7 @@ end Prod
 
 end
 
-section -- TODO: this section seems pointless?
+section
 
 variable (C : Type u₁) [Category.{v₁} C] (D : Type u₂) [Category.{v₂} D]
 
@@ -233,8 +229,6 @@ variable {C}
 @[simps!]
 def Functor.constCompEvaluationObj (X : C) : Functor.const C ⋙ (evaluation C D).obj X ≅ 𝟭 D :=
   NatIso.ofComponents fun _ => Iso.refl _
-
-end
 
 end
 

--- a/Mathlib/CategoryTheory/Yoneda.lean
+++ b/Mathlib/CategoryTheory/Yoneda.lean
@@ -455,10 +455,10 @@ variable (C)
 
 -- We need to help typeclass inference with some awkward universe levels here.
 instance prodCategoryInstance1 : Category ((Cᵒᵖ ⥤ Type v₁) × Cᵒᵖ) :=
-  CategoryTheory.prod.{max u₁ v₁, v₁} (Cᵒᵖ ⥤ Type v₁) Cᵒᵖ
+  CategoryTheory.prod'.{max u₁ v₁, v₁} (Cᵒᵖ ⥤ Type v₁) Cᵒᵖ
 
 instance prodCategoryInstance2 : Category (Cᵒᵖ × (Cᵒᵖ ⥤ Type v₁)) :=
-  CategoryTheory.prod.{v₁, max u₁ v₁} Cᵒᵖ (Cᵒᵖ ⥤ Type v₁)
+  CategoryTheory.prod'.{v₁, max u₁ v₁} Cᵒᵖ (Cᵒᵖ ⥤ Type v₁)
 
 open Yoneda
 


### PR DESCRIPTION
This will allow us to recycle these lemmas when defining the product of bicategories.

In doing this I have renamed the product category instance to `prod'` so that the simp lemmas (which are generated for the categorystruct version) get the names `prod_`. Fruthermore, I removed the manual specification of simp lemmas as it did not seem necessary (it generates the same list anyways).

Note that the diff does not make it clear that `prod.hom_ext` `prod_id` and `prod_comp` have been generalized.

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

When merging, all the commits will be squashed into a single commit
listing all co-authors.

Co-authors in the squash commit are gathered from two sources:

First, all authors of commits to this PR branch are included. Thus,
one way to add co-authors is to include at least one commit authored by
each co-author among the commits in the pull request. If necessary, you
may create empty commits to indicate co-authorship, using commands like so:

git commit --author="Author Name <author@email.com>" --allow-empty -m "add Author Name as coauthor"

Second, co-authors can also be listed in lines at the very bottom of
the commit message (that is, directly before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines
at the bottom of the commit message (before the `---`, and also before
any "Co-authored-by" lines) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
