### PR TITLE
[Merged by Bors] - feat(LinearAlgebra/Transvection): transvections in a module

### DIFF
--- a/Mathlib.lean
+++ b/Mathlib.lean
@@ -4535,6 +4535,7 @@ import Mathlib.LinearAlgebra.TensorProduct.Submodule
 import Mathlib.LinearAlgebra.TensorProduct.Tower
 import Mathlib.LinearAlgebra.TensorProduct.Vanishing
 import Mathlib.LinearAlgebra.Trace
+import Mathlib.LinearAlgebra.Transvection
 import Mathlib.LinearAlgebra.UnitaryGroup
 import Mathlib.LinearAlgebra.Vandermonde
 import Mathlib.Logic.Basic

--- a/Mathlib/LinearAlgebra/Transvection.lean
+++ b/Mathlib/LinearAlgebra/Transvection.lean
@@ -1,0 +1,143 @@
+/-
+Copyright (c) 2025 Antoine Chambert-Loir. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Antoine Chambert-Loir
+-/
+
+import Mathlib.LinearAlgebra.Basis.Defs
+import Mathlib.LinearAlgebra.DFinsupp
+import Mathlib.LinearAlgebra.Dual.Defs
+
+/-!
+# Transvections in a module
+
+* When `f : Module.Dual R V` and `v : V`,
+  `LinearMap.transvection f v` is the linear map given by `x ↦ x + f x • v`,
+
+* If, moreover, `f v = 0`, then `LinearEquiv.transvection` shows that it is
+  a linear equivalence.
+
+-/
+
+namespace LinearMap
+
+variable {R V : Type*} [CommSemiring R] [AddCommMonoid V] [Module R V]
+
+/-- The transvection associated with a linear form `f` and a vector `v`.
+
+NB. It is only a transvection when `f v = 0` -/
+def transvection (f : Module.Dual R V) (v : V) : V →ₗ[R] V where
+  toFun x := x + f x • v
+  map_add' x y := by simp only [map_add]; module
+  map_smul' r x := by simp only [map_smul, RingHom.id_apply, smul_eq_mul]; module
+
+namespace transvection
+
+theorem apply (f : Module.Dual R V) (v x : V) :
+    transvection f v x = x + f x • v :=
+  rfl
+
+theorem comp_of_left_eq_apply {f : Module.Dual R V} {v w : V} {x : V} (hw : f w = 0) :
+    transvection f v (transvection f w x) = transvection f (v + w) x := by
+  simp only [transvection, coe_mk, AddHom.coe_mk, map_add, map_smul, hw, smul_add]
+  module
+
+theorem comp_of_left_eq {f : Module.Dual R V} {v w : V} (hw : f w = 0) :
+    (transvection f v) ∘ₗ (transvection f w) = transvection f (v + w) := by
+  ext; simp [comp_of_left_eq_apply hw]
+
+theorem comp_of_right_eq_apply {f g : Module.Dual R V} {v : V} {x : V} (hf : f v = 0) :
+    (transvection f v) (transvection g v x) = transvection (f + g) v x := by
+  simp only [transvection, coe_mk, AddHom.coe_mk, map_add, map_smul, hf, add_apply]
+  module
+
+theorem comp_of_right_eq {f g : Module.Dual R V} {v : V} (hf : f v = 0) :
+    (transvection f v) ∘ₗ (transvection g v) = transvection (f + g) v := by
+  ext; simp [comp_of_right_eq_apply hf]
+
+@[simp]
+theorem of_left_eq_zero (v : V) :
+    transvection (0 : Module.Dual R V) v = LinearMap.id := by
+  ext
+  simp [transvection]
+
+@[simp]
+theorem of_right_eq_zero (f : Module.Dual R V) :
+    transvection f 0 = LinearMap.id := by
+  ext
+  simp [transvection]
+
+theorem congr {W : Type*} [AddCommMonoid W] [Module R W]
+    (f : Module.Dual R V) (v : V) (e : V ≃ₗ[R] W) :
+    e ∘ₗ (transvection f v) ∘ₗ e.symm = transvection (f ∘ₗ e.symm) (e v) := by
+  ext; simp [transvection.apply]
+
+end LinearMap.transvection
+
+variable {R V : Type*} [CommRing R] [AddCommGroup V] [Module R V]
+
+namespace LinearEquiv
+
+open LinearMap LinearMap.transvection
+
+/-- The transvection associated with a linear form `f` and a vector `v` such that `f v = 0`. -/
+def transvection {f : Module.Dual R V} {v : V} (h : f v = 0) :
+    V ≃ₗ[R] V where
+  toFun := LinearMap.transvection f v
+  invFun := LinearMap.transvection f (-v)
+  map_add' x y := by simp [map_add]
+  map_smul' r x := by simp
+  left_inv x := by
+    simp [comp_of_left_eq_apply h]
+  right_inv x := by
+    have h' : f (-v) = 0 := by simp [h]
+    simp [comp_of_left_eq_apply h']
+
+namespace transvection
+
+theorem apply {f : Module.Dual R V} {v : V} (h : f v = 0) (x : V) :
+    transvection h x = x + f x • v :=
+  rfl
+
+@[simp]
+theorem coe_toLinearMap {f : Module.Dual R V} {v : V} (h : f v = 0) :
+    LinearEquiv.transvection h = LinearMap.transvection f v :=
+  rfl
+
+@[simp]
+theorem coe_apply {f : Module.Dual R V} {v x : V} {h : f v = 0} :
+    LinearEquiv.transvection h x = LinearMap.transvection f v x :=
+  rfl
+
+theorem trans_of_left_eq {f : Module.Dual R V} {v w : V}
+    (hv : f v = 0) (hw : f w = 0) (hvw : f (v + w) = 0 := by simp [hv, hw]) :
+    (transvection hw).trans (transvection hv) = transvection hvw := by
+  ext; simp [comp_of_left_eq_apply hw]
+
+theorem trans_of_right_eq {f g : Module.Dual R V} {v : V}
+    (hf : f v = 0) (hg : g v = 0) (hfg : (f + g) v = 0 := by simp [hf, hg]) :
+    (transvection hg).trans (transvection hf) = transvection hfg := by
+  ext; simp [comp_of_right_eq_apply hf]
+
+@[simp]
+theorem of_left_eq_zero (v : V) (hv := LinearMap.zero_apply v) :
+    transvection hv = LinearEquiv.refl R V := by
+  ext; simp [transvection]
+
+@[simp]
+theorem of_right_eq_zero (f : Module.Dual R V) (hf := f.map_zero) :
+    transvection hf = LinearEquiv.refl R V := by
+  ext; simp [transvection]
+
+theorem symm_eq {f : Module.Dual R V} {v : V}
+    (hv : f v = 0) (hv' : f (-v) = 0 := by simp [hv]) :
+    (transvection hv).symm = transvection hv' := by
+  ext;
+  simp [LinearEquiv.symm_apply_eq, comp_of_left_eq_apply hv']
+
+theorem symm_eq' {f : Module.Dual R V} {v : V}
+    (hf : f v = 0) (hf' : (-f) v = 0 := by simp [hf]) :
+    (transvection hf).symm = transvection hf' := by
+  ext; simp [LinearEquiv.symm_apply_eq, comp_of_right_eq_apply hf]
+
+end LinearEquiv.transvection

--- a/Mathlib/LinearAlgebra/Transvection.lean
+++ b/Mathlib/LinearAlgebra/Transvection.lean
@@ -4,7 +4,6 @@ Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Antoine Chambert-Loir
 -/
 
-import Mathlib.LinearAlgebra.Basis.Defs
 import Mathlib.LinearAlgebra.DFinsupp
 import Mathlib.LinearAlgebra.Dual.Defs
 

--- a/Mathlib/LinearAlgebra/Transvection.lean
+++ b/Mathlib/LinearAlgebra/Transvection.lean
@@ -24,7 +24,7 @@ variable {R V : Type*} [CommSemiring R] [AddCommMonoid V] [Module R V]
 
 /-- The transvection associated with a linear form `f` and a vector `v`.
 
-NB. It is only a transvection when `f v = 0` -/
+NB. It is only a transvection when `f v = 0`. See also `Module.preReflection`. -/
 def transvection (f : Module.Dual R V) (v : V) : V →ₗ[R] V where
   toFun x := x + f x • v
   map_add' x y := by simp only [map_add]; module


### PR DESCRIPTION
Definition of a transvection in a module, a linear map of the form $$ x \mapsto x+f(x) v$$.

When $$f(v)=0$$, this is a linear equivalence.

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

When merging, all the commits will be squashed into a single commit
listing all co-authors.

Co-authors in the squash commit are gathered from two sources:

First, all authors of commits to this PR branch are included. Thus,
one way to add co-authors is to include at least one commit authored by
each co-author among the commits in the pull request. If necessary, you
may create empty commits to indicate co-authorship, using commands like so:

git commit --author="Author Name <author@email.com>" --allow-empty -m "add Author Name as coauthor"

Second, co-authors can also be listed in lines at the very bottom of
the commit message (that is, directly before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines
at the bottom of the commit message (before the `---`, and also before
any "Co-authored-by" lines) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
