### PR TITLE
[Merged by Bors] - feat(Topology/Sets): add `NonemptyCompacts.map`

### DIFF
--- a/Mathlib/Topology/Sets/Compacts.lean
+++ b/Mathlib/Topology/Sets/Compacts.lean
@@ -396,8 +396,9 @@ theorem coe_map {f : α → β} (hf : Continuous f) (s : NonemptyCompacts α) :
   rfl
 
 @[simp]
-theorem map_id (K : NonemptyCompacts α) : K.map id continuous_id = K :=
-  NonemptyCompacts.ext <| Set.image_id _
+theorem map_id (K : NonemptyCompacts α) : K.map id continuous_id = K := by
+  ext
+  simp
 
 theorem map_comp (f : β → γ) (g : α → β) (hf : Continuous f) (hg : Continuous g)
     (K : NonemptyCompacts α) : K.map (f ∘ g) (hf.comp hg) = (K.map g hg).map f hf :=
@@ -414,10 +415,9 @@ theorem map_injective {f : α → β} (hf : Continuous f) (hf' : Function.Inject
 
 @[simp]
 theorem map_injective_iff {f : α → β} (hf : Continuous f) :
-    Function.Injective (NonemptyCompacts.map f hf) ↔ Function.Injective f := by
-  refine ⟨fun h => .of_comp (f := ({·} : β → NonemptyCompacts β)) ?_, map_injective hf⟩
-  simp_rw [Function.comp_def, ← map_singleton hf]
-  exact h.comp singleton_injective
+    Function.Injective (NonemptyCompacts.map f hf) ↔ Function.Injective f :=
+  ⟨fun h => .of_comp (f := ({·} : β → NonemptyCompacts β)) fun _ _ _ ↦ 
+    singleton_injective (h (by simp_all)), map_injective hf⟩
 
 instance toCompactSpace {s : NonemptyCompacts α} : CompactSpace s :=
   isCompact_iff_compactSpace.1 s.isCompact

--- a/Mathlib/Topology/Sets/Compacts.lean
+++ b/Mathlib/Topology/Sets/Compacts.lean
@@ -416,7 +416,7 @@ theorem map_injective {f : α → β} (hf : Continuous f) (hf' : Function.Inject
 @[simp]
 theorem map_injective_iff {f : α → β} (hf : Continuous f) :
     Function.Injective (NonemptyCompacts.map f hf) ↔ Function.Injective f :=
-  ⟨fun h => .of_comp (f := ({·} : β → NonemptyCompacts β)) fun _ _ _ ↦ 
+  ⟨fun h => .of_comp (f := ({·} : β → NonemptyCompacts β)) fun _ _ _ ↦
     singleton_injective (h (by simp_all)), map_injective hf⟩
 
 instance toCompactSpace {s : NonemptyCompacts α} : CompactSpace s :=

--- a/Mathlib/Topology/Sets/Compacts.lean
+++ b/Mathlib/Topology/Sets/Compacts.lean
@@ -385,6 +385,40 @@ instance [Nontrivial α] : Nontrivial (NonemptyCompacts α) :=
 theorem nontrivial_iff : Nontrivial (NonemptyCompacts α) ↔ Nontrivial α := by
   simp_rw [← not_subsingleton_iff_nontrivial, subsingleton_iff]
 
+/-- The image of a nonempty compact set under a continuous function. -/
+@[simps! toCompacts]
+protected def map (f : α → β) (hf : Continuous f) (K : NonemptyCompacts α) : NonemptyCompacts β :=
+  ⟨K.toCompacts.map f hf, K.nonempty.image f⟩
+
+@[simp, norm_cast]
+theorem coe_map {f : α → β} (hf : Continuous f) (s : NonemptyCompacts α) :
+    (s.map f hf : Set β) = f '' s :=
+  rfl
+
+@[simp]
+theorem map_id (K : NonemptyCompacts α) : K.map id continuous_id = K :=
+  NonemptyCompacts.ext <| Set.image_id _
+
+theorem map_comp (f : β → γ) (g : α → β) (hf : Continuous f) (hg : Continuous g)
+    (K : NonemptyCompacts α) : K.map (f ∘ g) (hf.comp hg) = (K.map g hg).map f hf :=
+  NonemptyCompacts.ext <| Set.image_comp _ _ _
+
+@[simp]
+theorem map_singleton {f : α → β} (hf : Continuous f) (x : α) :
+    NonemptyCompacts.map f hf {x} = {f x} :=
+  NonemptyCompacts.ext Set.image_singleton
+
+theorem map_injective {f : α → β} (hf : Continuous f) (hf' : Function.Injective f) :
+    Function.Injective (NonemptyCompacts.map f hf) :=
+  .of_comp (f := SetLike.coe) <| hf'.image_injective.comp SetLike.coe_injective
+
+@[simp]
+theorem map_injective_iff {f : α → β} (hf : Continuous f) :
+    Function.Injective (NonemptyCompacts.map f hf) ↔ Function.Injective f := by
+  refine ⟨fun h => .of_comp (f := ({·} : β → NonemptyCompacts β)) ?_, map_injective hf⟩
+  simp_rw [Function.comp_def, ← map_singleton hf]
+  exact h.comp singleton_injective
+
 instance toCompactSpace {s : NonemptyCompacts α} : CompactSpace s :=
   isCompact_iff_compactSpace.1 s.isCompact
 

--- a/Mathlib/Topology/Sets/Compacts.lean
+++ b/Mathlib/Topology/Sets/Compacts.lean
@@ -401,13 +401,15 @@ theorem map_id (K : NonemptyCompacts α) : K.map id continuous_id = K := by
   simp
 
 theorem map_comp (f : β → γ) (g : α → β) (hf : Continuous f) (hg : Continuous g)
-    (K : NonemptyCompacts α) : K.map (f ∘ g) (hf.comp hg) = (K.map g hg).map f hf :=
-  NonemptyCompacts.ext <| Set.image_comp _ _ _
+    (K : NonemptyCompacts α) : K.map (f ∘ g) (hf.comp hg) = (K.map g hg).map f hf := by
+  ext
+  simp
 
 @[simp]
 theorem map_singleton {f : α → β} (hf : Continuous f) (x : α) :
-    NonemptyCompacts.map f hf {x} = {f x} :=
-  NonemptyCompacts.ext Set.image_singleton
+    NonemptyCompacts.map f hf {x} = {f x} := by
+  ext
+  simp
 
 theorem map_injective {f : α → β} (hf : Continuous f) (hf' : Function.Injective f) :
     Function.Injective (NonemptyCompacts.map f hf) :=


### PR DESCRIPTION
---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

When merging, all the commits will be squashed into a single commit
listing all co-authors.

Co-authors in the squash commit are gathered from two sources:

First, all authors of commits to this PR branch are included. Thus,
one way to add co-authors is to include at least one commit authored by
each co-author among the commits in the pull request. If necessary, you
may create empty commits to indicate co-authorship, using commands like so:

git commit --author="Author Name <author@email.com>" --allow-empty -m "add Author Name as coauthor"

Second, co-authors can also be listed in lines at the very bottom of
the commit message (that is, directly before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines
at the bottom of the commit message (before the `---`, and also before
any "Co-authored-by" lines) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
