### PR TITLE
[Merged by Bors] - chore(StrictlyUnitary): add cat_disch and rfl_cat

### DIFF
--- a/Mathlib/CategoryTheory/Bicategory/Functor/StrictlyUnitary.lean
+++ b/Mathlib/CategoryTheory/Bicategory/Functor/StrictlyUnitary.lean
@@ -262,7 +262,6 @@ structure StrictlyUnitaryPseudofunctorCore where
           (mapComp f (g ≫ h)).inv := by
     cat_disch
 
-attribute [simp] StrictlyUnitaryPseudofunctor.map_id
 
 namespace StrictlyUnitaryPseudofunctor
 

--- a/Mathlib/CategoryTheory/Bicategory/Functor/StrictlyUnitary.lean
+++ b/Mathlib/CategoryTheory/Bicategory/Functor/StrictlyUnitary.lean
@@ -56,6 +56,8 @@ structure StrictlyUnitaryLaxFunctor extends LaxFunctor B C where
   map_id (X : B) : map (𝟙 X) = 𝟙 (obj X) := by cat_disch
   mapId_eq_eqToHom (X : B) : (mapId X) = eqToHom (map_id X).symm := by cat_disch
 
+attribute [simp] StrictlyUnitaryLaxFunctor.map_id
+
 /-- A helper structure that bundles the necessary data to
 construct a `StrictlyUnitaryLaxFunctor` without specifying the redundant
 field `mapId`. -/
@@ -259,6 +261,8 @@ structure StrictlyUnitaryPseudofunctorCore where
           (α_ (map f) (map g) (map h)).hom ≫ map f ◁ (mapComp g h).inv ≫
           (mapComp f (g ≫ h)).inv := by
     cat_disch
+
+attribute [simp] StrictlyUnitaryPseudofunctor.map_id
 
 namespace StrictlyUnitaryPseudofunctor
 

--- a/Mathlib/CategoryTheory/Bicategory/Functor/StrictlyUnitary.lean
+++ b/Mathlib/CategoryTheory/Bicategory/Functor/StrictlyUnitary.lean
@@ -53,7 +53,7 @@ lax functor `F` from `B` to `C` such that the structure 1-cell
 `𝟙 (obj X) ⟶ map (𝟙 X)` is in fact an identity 1-cell for every `X : B`. -/
 @[kerodon 008R]
 structure StrictlyUnitaryLaxFunctor extends LaxFunctor B C where
-  map_id (X : B) : map (𝟙 X) = 𝟙 (obj X) := by cat_disch
+  map_id (X : B) : map (𝟙 X) = 𝟙 (obj X) := by rfl_cat
   mapId_eq_eqToHom (X : B) : (mapId X) = eqToHom (map_id X).symm := by cat_disch
 
 
@@ -209,7 +209,7 @@ identity 1-cell for every `X : B` (in particular, there is an equality
 `F.map (𝟙 X) = 𝟙 (F.obj x)`). -/
 @[kerodon 008R]
 structure StrictlyUnitaryPseudofunctor extends Pseudofunctor B C where
-  map_id (X : B) : map (𝟙 X) = 𝟙 (obj X) := by cat_disch
+  map_id (X : B) : map (𝟙 X) = 𝟙 (obj X) := by rfl_cat
   mapId_eq_eqToIso (X : B) : (mapId X) = eqToIso (map_id X) := by cat_disch
 
 /-- A helper structure that bundles the necessary data to
@@ -220,7 +220,7 @@ structure StrictlyUnitaryPseudofunctorCore where
   obj : B → C
   /-- action on 1-morphisms -/
   map : ∀ {X Y : B}, (X ⟶ Y) → (obj X ⟶ obj Y)
-  map_id : ∀ (X : B), map (𝟙 X) = 𝟙 (obj X) := by cat_disch
+  map_id : ∀ (X : B), map (𝟙 X) = 𝟙 (obj X) := by rfl_cat
   /-- action on 2-morphisms -/
   map₂ : ∀ {a b : B} {f g : a ⟶ b}, (f ⟶ g) → (map f ⟶ map g)
   map₂_id : ∀ {a b : B} (f : a ⟶ b), map₂ (𝟙 f) = 𝟙 (map f) := by cat_disch
@@ -260,7 +260,6 @@ structure StrictlyUnitaryPseudofunctorCore where
           (α_ (map f) (map g) (map h)).hom ≫ map f ◁ (mapComp g h).inv ≫
           (mapComp f (g ≫ h)).inv := by
     cat_disch
-
 
 namespace StrictlyUnitaryPseudofunctor
 

--- a/Mathlib/CategoryTheory/Bicategory/Functor/StrictlyUnitary.lean
+++ b/Mathlib/CategoryTheory/Bicategory/Functor/StrictlyUnitary.lean
@@ -53,8 +53,8 @@ lax functor `F` from `B` to `C` such that the structure 1-cell
 `𝟙 (obj X) ⟶ map (𝟙 X)` is in fact an identity 1-cell for every `X : B`. -/
 @[kerodon 008R]
 structure StrictlyUnitaryLaxFunctor extends LaxFunctor B C where
-  map_id (X : B) : map (𝟙 X) = 𝟙 (obj X)
-  mapId_eq_eqToHom (X : B) : (mapId X) = eqToHom (map_id X).symm
+  map_id (X : B) : map (𝟙 X) = 𝟙 (obj X) := by cat_disch
+  mapId_eq_eqToHom (X : B) : (mapId X) = eqToHom (map_id X).symm := by cat_disch
 
 /-- A helper structure that bundles the necessary data to
 construct a `StrictlyUnitaryLaxFunctor` without specifying the redundant
@@ -64,41 +64,41 @@ structure StrictlyUnitaryLaxFunctorCore where
   obj : B → C
   /-- action on 1-morphisms -/
   map : ∀ {X Y : B}, (X ⟶ Y) → (obj X ⟶ obj Y)
-  map_id : ∀ (X : B), map (𝟙 X) = 𝟙 (obj X)
+  map_id : ∀ (X : B), map (𝟙 X) = 𝟙 (obj X) := by cat_disch
   /-- action on 2-morphisms -/
   map₂ : ∀ {a b : B} {f g : a ⟶ b}, (f ⟶ g) → (map f ⟶ map g)
-  map₂_id : ∀ {a b : B} (f : a ⟶ b), map₂ (𝟙 f) = 𝟙 (map f) := by aesop_cat
+  map₂_id : ∀ {a b : B} (f : a ⟶ b), map₂ (𝟙 f) = 𝟙 (map f) := by cat_disch
   map₂_comp :
       ∀ {a b : B} {f g h : a ⟶ b} (η : f ⟶ g) (θ : g ⟶ h),
         map₂ (η ≫ θ) = map₂ η ≫ map₂ θ := by
-    aesop_cat
+    cat_disch
   /-- structure 2-morphism for composition of 1-morphism -/
   mapComp : ∀ {a b c : B} (f : a ⟶ b) (g : b ⟶ c),
     map f ≫ map g ⟶ map (f ≫ g)
   mapComp_naturality_left :
       ∀ {a b c : B} {f f' : a ⟶ b} (η : f ⟶ f') (g : b ⟶ c),
         mapComp f g ≫ map₂ (η ▷ g) = map₂ η ▷ map g ≫ mapComp f' g := by
-    aesop_cat
+    cat_disch
   mapComp_naturality_right :
       ∀ {a b c : B} (f : a ⟶ b) {g g' : b ⟶ c} (η : g ⟶ g'),
         mapComp f g ≫ map₂ (f ◁ η) = map f ◁ map₂ η ≫ mapComp f g' := by
-    aesop_cat
+    cat_disch
   map₂_leftUnitor :
       ∀ {a b : B} (f : a ⟶ b),
         map₂ (λ_ f).inv =
         (λ_ (map f)).inv ≫ eqToHom (by rw [map_id a]) ≫ mapComp (𝟙 a) f := by
-    aesop_cat
+    cat_disch
   map₂_rightUnitor :
       ∀ {a b : B} (f : a ⟶ b),
         map₂ (ρ_ f).inv =
         (ρ_ (map f)).inv ≫ eqToHom (by rw [map_id b]) ≫ mapComp f (𝟙 b) := by
-    aesop_cat
+    cat_disch
   map₂_associator :
       ∀ {a b c d : B} (f : a ⟶ b) (g : b ⟶ c) (h : c ⟶ d),
         mapComp f g ▷ map h ≫ mapComp (f ≫ g) h ≫ map₂ (α_ f g h).hom =
         (α_ (map f) (map g) (map h)).hom ≫ map f ◁ mapComp g h ≫
           mapComp f (g ≫ h) := by
-    aesop_cat
+    cat_disch
 
 namespace StrictlyUnitaryLaxFunctor
 
@@ -208,8 +208,8 @@ identity 1-cell for every `X : B` (in particular, there is an equality
 `F.map (𝟙 X) = 𝟙 (F.obj x)`). -/
 @[kerodon 008R]
 structure StrictlyUnitaryPseudofunctor extends Pseudofunctor B C where
-  map_id (X : B) : map (𝟙 X) = 𝟙 (obj X)
-  mapId_eq_eqToIso (X : B) : (mapId X) = eqToIso (map_id X)
+  map_id (X : B) : map (𝟙 X) = 𝟙 (obj X) := by cat_disch
+  mapId_eq_eqToIso (X : B) : (mapId X) = eqToIso (map_id X) := by cat_disch
 
 /-- A helper structure that bundles the necessary data to
 construct a `StrictlyUnitaryPseudofunctor` without specifying the redundant
@@ -219,14 +219,14 @@ structure StrictlyUnitaryPseudofunctorCore where
   obj : B → C
   /-- action on 1-morphisms -/
   map : ∀ {X Y : B}, (X ⟶ Y) → (obj X ⟶ obj Y)
-  map_id : ∀ (X : B), map (𝟙 X) = 𝟙 (obj X)
+  map_id : ∀ (X : B), map (𝟙 X) = 𝟙 (obj X) := by cat_disch
   /-- action on 2-morphisms -/
   map₂ : ∀ {a b : B} {f g : a ⟶ b}, (f ⟶ g) → (map f ⟶ map g)
-  map₂_id : ∀ {a b : B} (f : a ⟶ b), map₂ (𝟙 f) = 𝟙 (map f) := by aesop_cat
+  map₂_id : ∀ {a b : B} (f : a ⟶ b), map₂ (𝟙 f) = 𝟙 (map f) := by cat_disch
   map₂_comp :
       ∀ {a b : B} {f g h : a ⟶ b} (η : f ⟶ g) (θ : g ⟶ h),
         map₂ (η ≫ θ) = map₂ η ≫ map₂ θ := by
-    aesop_cat
+    cat_disch
   /-- structure 2-isomorphism for composition of 1-morphisms -/
   mapComp : ∀ {a b c : B} (f : a ⟶ b) (g : b ⟶ c),
     map (f ≫ g) ≅ map f ≫ map g
@@ -234,31 +234,31 @@ structure StrictlyUnitaryPseudofunctorCore where
       ∀ {a b c : B} (f : a ⟶ b) {g h : b ⟶ c} (η : g ⟶ h),
         map₂ (f ◁ η) =
         (mapComp f g).hom ≫ map f ◁ map₂ η ≫ (mapComp f h).inv := by
-    aesop_cat
+    cat_disch
   map₂_whisker_right :
       ∀ {a b c : B} {f g : a ⟶ b} (η : f ⟶ g) (h : b ⟶ c),
         map₂ (η ▷ h) =
         (mapComp f h).hom ≫ map₂ η ▷ map h ≫ (mapComp g h).inv := by
-    aesop_cat
+    cat_disch
   map₂_left_unitor :
       ∀ {a b : B} (f : a ⟶ b),
         map₂ (λ_ f).hom =
         (mapComp (𝟙 a) f).hom ≫ eqToHom (by rw [map_id a]) ≫
           (λ_ (map f)).hom := by
-    aesop_cat
+    cat_disch
   map₂_right_unitor :
       ∀ {a b : B} (f : a ⟶ b),
         map₂ (ρ_ f).hom =
         (mapComp f (𝟙 b)).hom ≫ eqToHom (by rw [map_id b]) ≫
           (ρ_ (map f)).hom := by
-    aesop_cat
+    cat_disch
   map₂_associator :
       ∀ {a b c d : B} (f : a ⟶ b) (g : b ⟶ c) (h : c ⟶ d),
         map₂ (α_ f g h).hom =
           (mapComp (f ≫ g) h).hom ≫ (mapComp f g).hom ▷ map h ≫
           (α_ (map f) (map g) (map h)).hom ≫ map f ◁ (mapComp g h).inv ≫
           (mapComp f (g ≫ h)).inv := by
-    aesop_cat
+    cat_disch
 
 namespace StrictlyUnitaryPseudofunctor
 

--- a/Mathlib/CategoryTheory/Bicategory/Functor/StrictlyUnitary.lean
+++ b/Mathlib/CategoryTheory/Bicategory/Functor/StrictlyUnitary.lean
@@ -56,7 +56,6 @@ structure StrictlyUnitaryLaxFunctor extends LaxFunctor B C where
   map_id (X : B) : map (𝟙 X) = 𝟙 (obj X) := by cat_disch
   mapId_eq_eqToHom (X : B) : (mapId X) = eqToHom (map_id X).symm := by cat_disch
 
-attribute [simp] StrictlyUnitaryLaxFunctor.map_id
 
 /-- A helper structure that bundles the necessary data to
 construct a `StrictlyUnitaryLaxFunctor` without specifying the redundant


### PR DESCRIPTION
Replace aesop_cat with cat_disch, and add autoparam `cat_rfl` to `map_id` fields.

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

When merging, all the commits will be squashed into a single commit
listing all co-authors.

Co-authors in the squash commit are gathered from two sources:

First, all authors of commits to this PR branch are included. Thus,
one way to add co-authors is to include at least one commit authored by
each co-author among the commits in the pull request. If necessary, you
may create empty commits to indicate co-authorship, using commands like so:

git commit --author="Author Name <author@email.com>" --allow-empty -m "add Author Name as coauthor"

Second, co-authors can also be listed in lines at the very bottom of
the commit message (that is, directly before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines
at the bottom of the commit message (before the `---`, and also before
any "Co-authored-by" lines) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
