### PR TITLE
[Merged by Bors] - feat(LinearAlgebra/AffineSpace/Simplex/Basic): `range_mkOfPoint_points`

### DIFF
--- a/Mathlib/LinearAlgebra/AffineSpace/Simplex/Basic.lean
+++ b/Mathlib/LinearAlgebra/AffineSpace/Simplex/Basic.lean
@@ -69,6 +69,13 @@ instance [Inhabited P] : Inhabited (Simplex k P 0) :=
 instance nonempty : Nonempty (Simplex k P 0) :=
   ⟨mkOfPoint k <| AddTorsor.nonempty.some⟩
 
+-- Although `simp` can prove this, it is still useful as a `simp` lemma, since the `simp`-generated
+-- proof uses `range_eq_singleton_iff`, which does not apply when the LHS of this lemma appears
+-- as part of a more complicated expression.
+/-- The set of points in a simplex constructed with `mkOfPoint`. -/
+@[simp] lemma range_mkOfPoint_points (p : P) : Set.range (mkOfPoint k p).points = {p} := by
+  simp
+
 variable {k}
 
 /-- Two simplices are equal if they have the same points. -/


### PR DESCRIPTION
Add a lemma:

```lean
@[simp] lemma range_mkOfPoint_points (p : P) : Set.range (mkOfPoint k p).points = {p} := by
```

Despite being proved by `simp`, this still is a valid and useful `simp` lemma for the reason explained in the comment on the lemma: `simp` proves this lemma using another `simp` lemma (`range_eq_singleton_iff`) which doesn't generally apply when the LHS of the present lemma appears as part of a larger expression to be simplified.


---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

When merging, all the commits will be squashed into a single commit
listing all co-authors.

Co-authors in the squash commit are gathered from two sources:

First, all authors of commits to this PR branch are included. Thus,
one way to add co-authors is to include at least one commit authored by
each co-author among the commits in the pull request. If necessary, you
may create empty commits to indicate co-authorship, using commands like so:

git commit --author="Author Name <author@email.com>" --allow-empty -m "add Author Name as coauthor"

Second, co-authors can also be listed in lines at the very bottom of
the commit message (that is, directly before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines
at the bottom of the commit message (before the `---`, and also before
any "Co-authored-by" lines) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
