### PR TITLE
[Merged by Bors] - doc(Mathlib/Analysis/Asymptotics): fix typo

### DIFF
--- a/Mathlib/Analysis/Asymptotics/SpecificAsymptotics.lean
+++ b/Mathlib/Analysis/Asymptotics/SpecificAsymptotics.lean
@@ -10,7 +10,8 @@ import Mathlib.Analysis.SpecialFunctions.Pow.Continuity
 # A collection of specific asymptotic results
 
 This file contains specific lemmas about asymptotics which don't have their place in the general
-theory developed in `Mathlib/Analysis/Asymptotics/Asymptotics.lean`.
+theory developed in `Mathlib/Analysis/Asymptotics/Defs.lean` and
+`Mathlib/Analysis/Asymptotics/Lemmas.lean`.
 -/
 
 


### PR DESCRIPTION
Since <https://github.com/leanprover-community/mathlib4/pull/20785>.