### PR TITLE
[Merged by Bors] - chore(RingTheory): golf `isPrimary_decomposition_pairwise_ne_radical` using `grind`

### DIFF
--- a/Mathlib/RingTheory/Lasker.lean
+++ b/Mathlib/RingTheory/Lasker.lean
@@ -64,16 +64,8 @@ lemma isPrimary_decomposition_pairwise_ne_radical {I : Ideal R}
   classical
   refine ⟨(s.image (fun J ↦ {I ∈ s | I.radical = J.radical})).image fun t ↦ t.inf id,
     ?_, ?_, ?_⟩
-  · rw [← hs]
-    refine le_antisymm ?_ ?_ <;> intro x hx
-    · simp only [Finset.inf_image, CompTriple.comp_eq, Submodule.mem_finsetInf,
-      Function.comp_apply, Finset.mem_filter, id_eq, and_imp] at hx ⊢
-      intro J hJ
-      exact hx J hJ J hJ rfl
-    · simp only [Submodule.mem_finsetInf, id_eq, Finset.inf_image, CompTriple.comp_eq,
-      Function.comp_apply, Finset.mem_filter, and_imp] at hx ⊢
-      intro J _ K hK _
-      exact hx K hK
+  · ext
+    grind [Finset.inf_image, Submodule.mem_finsetInf]
   · simp only [Finset.mem_image, exists_exists_and_eq_and, forall_exists_index, and_imp,
     forall_apply_eq_imp_iff₂]
     intro J hJ


### PR DESCRIPTION
---
<details>
<summary>Show trace profiling of <code>isPrimary_decomposition_pairwise_ne_radical</code>: 89 ms before, 156 ms after </summary>

### Trace profiling of `isPrimary_decomposition_pairwise_ne_radical` before PR 31201
```diff
diff --git a/Mathlib/RingTheory/Lasker.lean b/Mathlib/RingTheory/Lasker.lean
index 8f522d48f8..21bf4d68b6 100644
--- a/Mathlib/RingTheory/Lasker.lean
+++ b/Mathlib/RingTheory/Lasker.lean
@@ -57,6 +57,7 @@ lemma decomposition_erase_inf [DecidableEq (Ideal R)] {I : Ideal R}
 
 open scoped Function -- required for scoped `on` notation
 
+set_option trace.profiler true in
 lemma isPrimary_decomposition_pairwise_ne_radical {I : Ideal R}
     {s : Finset (Ideal R)} (hs : s.inf id = I) (hs' : ∀ ⦃J⦄, J ∈ s → J.IsPrimary) :
     ∃ t : Finset (Ideal R), t.inf id = I ∧ (∀ ⦃J⦄, J ∈ t → J.IsPrimary) ∧
```
```
ℹ [1261/1261] Built Mathlib.RingTheory.Lasker (1.3s)
info: Mathlib/RingTheory/Lasker.lean:61:0: [Elab.command] [0.013044] theorem isPrimary_decomposition_pairwise_ne_radical {I : Ideal R} {s : Finset (Ideal R)}
        (hs : s.inf id = I) (hs' : ∀ ⦃J⦄, J ∈ s → J.IsPrimary) :
        ∃ t : Finset (Ideal R),
          t.inf id = I ∧ (∀ ⦃J⦄, J ∈ t → J.IsPrimary) ∧ (t : Set (Ideal R)).Pairwise ((· ≠ ·) on radical) :=
      by
      classical
      refine ⟨(s.image (fun J ↦ {I ∈ s | I.radical = J.radical})).image fun t ↦ t.inf id, ?_, ?_, ?_⟩
      · rw [← hs]
        refine le_antisymm ?_ ?_ <;> intro x hx
        · simp only [Finset.inf_image, CompTriple.comp_eq, Submodule.mem_finsetInf, Function.comp_apply,
            Finset.mem_filter, id_eq, and_imp] at hx ⊢
          intro J hJ
          exact hx J hJ J hJ rfl
        · simp only [Submodule.mem_finsetInf, id_eq, Finset.inf_image, CompTriple.comp_eq, Function.comp_apply,
            Finset.mem_filter, and_imp] at hx ⊢
          intro J _ K hK _
          exact hx K hK
      · simp only [Finset.mem_image, exists_exists_and_eq_and, forall_exists_index, and_imp, forall_apply_eq_imp_iff₂]
        intro J hJ
        refine isPrimary_finset_inf (i := J) ?_ ?_ (by simp)
        · simp [hJ]
        · simp only [Finset.mem_filter, id_eq, and_imp]
          intro y hy
          simp [hs' hy]
      · intro I hI J hJ hIJ
        simp only [Finset.coe_image, Set.mem_image, Finset.mem_coe, exists_exists_and_eq_and] at hI hJ
        obtain ⟨I', hI', hI⟩ := hI
        obtain ⟨J', hJ', hJ⟩ := hJ
        simp only [Function.onFun, ne_eq]
        contrapose! hIJ
        suffices I'.radical = J'.radical by rw [← hI, ← hJ, this]
        · rw [← hI, radical_finset_inf (i := I') (by simp [hI']) (by simp), id_eq] at hIJ
          rw [hIJ, ← hJ, radical_finset_inf (i := J') (by simp [hJ']) (by simp), id_eq]
  [Elab.definition.header] [0.010071] Ideal.isPrimary_decomposition_pairwise_ne_radical
info: Mathlib/RingTheory/Lasker.lean:61:0: [Elab.command] [0.016459] lemma isPrimary_decomposition_pairwise_ne_radical {I : Ideal R} {s : Finset (Ideal R)}
        (hs : s.inf id = I) (hs' : ∀ ⦃J⦄, J ∈ s → J.IsPrimary) :
        ∃ t : Finset (Ideal R),
          t.inf id = I ∧ (∀ ⦃J⦄, J ∈ t → J.IsPrimary) ∧ (t : Set (Ideal R)).Pairwise ((· ≠ ·) on radical) :=
      by
      classical
      refine ⟨(s.image (fun J ↦ {I ∈ s | I.radical = J.radical})).image fun t ↦ t.inf id, ?_, ?_, ?_⟩
      · rw [← hs]
        refine le_antisymm ?_ ?_ <;> intro x hx
        · simp only [Finset.inf_image, CompTriple.comp_eq, Submodule.mem_finsetInf, Function.comp_apply,
            Finset.mem_filter, id_eq, and_imp] at hx ⊢
          intro J hJ
          exact hx J hJ J hJ rfl
        · simp only [Submodule.mem_finsetInf, id_eq, Finset.inf_image, CompTriple.comp_eq, Function.comp_apply,
            Finset.mem_filter, and_imp] at hx ⊢
          intro J _ K hK _
          exact hx K hK
      · simp only [Finset.mem_image, exists_exists_and_eq_and, forall_exists_index, and_imp, forall_apply_eq_imp_iff₂]
        intro J hJ
        refine isPrimary_finset_inf (i := J) ?_ ?_ (by simp)
        · simp [hJ]
        · simp only [Finset.mem_filter, id_eq, and_imp]
          intro y hy
          simp [hs' hy]
      · intro I hI J hJ hIJ
        simp only [Finset.coe_image, Set.mem_image, Finset.mem_coe, exists_exists_and_eq_and] at hI hJ
        obtain ⟨I', hI', hI⟩ := hI
        obtain ⟨J', hJ', hJ⟩ := hJ
        simp only [Function.onFun, ne_eq]
        contrapose! hIJ
        suffices I'.radical = J'.radical by rw [← hI, ← hJ, this]
        · rw [← hI, radical_finset_inf (i := I') (by simp [hI']) (by simp), id_eq] at hIJ
          rw [hIJ, ← hJ, radical_finset_inf (i := J') (by simp [hJ']) (by simp), id_eq]
info: Mathlib/RingTheory/Lasker.lean:61:0: [Elab.async] [0.091697] elaborating proof of Ideal.isPrimary_decomposition_pairwise_ne_radical
  [Elab.definition.value] [0.089099] Ideal.isPrimary_decomposition_pairwise_ne_radical
    [Elab.step] [0.086924] classical
          refine ⟨(s.image (fun J ↦ {I ∈ s | I.radical = J.radical})).image fun t ↦ t.inf id, ?_, ?_, ?_⟩
          · rw [← hs]
            refine le_antisymm ?_ ?_ <;> intro x hx
            · simp only [Finset.inf_image, CompTriple.comp_eq, Submodule.mem_finsetInf, Function.comp_apply,
                Finset.mem_filter, id_eq, and_imp] at hx ⊢
              intro J hJ
              exact hx J hJ J hJ rfl
            · simp only [Submodule.mem_finsetInf, id_eq, Finset.inf_image, CompTriple.comp_eq, Function.comp_apply,
                Finset.mem_filter, and_imp] at hx ⊢
              intro J _ K hK _
              exact hx K hK
          · simp only [Finset.mem_image, exists_exists_and_eq_and, forall_exists_index, and_imp,
              forall_apply_eq_imp_iff₂]
            intro J hJ
            refine isPrimary_finset_inf (i := J) ?_ ?_ (by simp)
            · simp [hJ]
            · simp only [Finset.mem_filter, id_eq, and_imp]
              intro y hy
              simp [hs' hy]
          · intro I hI J hJ hIJ
            simp only [Finset.coe_image, Set.mem_image, Finset.mem_coe, exists_exists_and_eq_and] at hI hJ
            obtain ⟨I', hI', hI⟩ := hI
            obtain ⟨J', hJ', hJ⟩ := hJ
            simp only [Function.onFun, ne_eq]
            contrapose! hIJ
            suffices I'.radical = J'.radical by rw [← hI, ← hJ, this]
            · rw [← hI, radical_finset_inf (i := I') (by simp [hI']) (by simp), id_eq] at hIJ
              rw [hIJ, ← hJ, radical_finset_inf (i := J') (by simp [hJ']) (by simp), id_eq]
      [Elab.step] [0.086918] classical
[… 154 lines omitted …]
                          Finset.mem_filter, id_eq, and_imp] at hx ⊢
                        intro J hJ
                        exact hx J hJ J hJ rfl
                      · simp only [Submodule.mem_finsetInf, id_eq, Finset.inf_image, CompTriple.comp_eq,
                          Function.comp_apply, Finset.mem_filter, and_imp] at hx ⊢
                        intro J _ K hK _
                        exact hx K hK
                  [Elab.step] [0.020717] 
                        rw [← hs]
                        refine le_antisymm ?_ ?_ <;> intro x hx
                        · simp only [Finset.inf_image, CompTriple.comp_eq, Submodule.mem_finsetInf, Function.comp_apply,
                            Finset.mem_filter, id_eq, and_imp] at hx ⊢
                          intro J hJ
                          exact hx J hJ J hJ rfl
                        · simp only [Submodule.mem_finsetInf, id_eq, Finset.inf_image, CompTriple.comp_eq,
                            Function.comp_apply, Finset.mem_filter, and_imp] at hx ⊢
                          intro J _ K hK _
                          exact hx K hK
                    [Elab.step] [0.010102] ·
                          simp only [Finset.inf_image, CompTriple.comp_eq, Submodule.mem_finsetInf, Function.comp_apply,
                            Finset.mem_filter, id_eq, and_imp] at hx ⊢
                          intro J hJ
                          exact hx J hJ J hJ rfl
                      [Elab.step] [0.010064] 
                            simp only [Finset.inf_image, CompTriple.comp_eq, Submodule.mem_finsetInf,
                              Function.comp_apply, Finset.mem_filter, id_eq, and_imp] at hx ⊢
                            intro J hJ
                            exact hx J hJ J hJ rfl
                        [Elab.step] [0.010060] 
                              simp only [Finset.inf_image, CompTriple.comp_eq, Submodule.mem_finsetInf,
                                Function.comp_apply, Finset.mem_filter, id_eq, and_imp] at hx ⊢
                              intro J hJ
                              exact hx J hJ J hJ rfl
              [Elab.step] [0.015365] ·
                    simp only [Finset.mem_image, exists_exists_and_eq_and, forall_exists_index, and_imp,
                      forall_apply_eq_imp_iff₂]
                    intro J hJ
                    refine isPrimary_finset_inf (i := J) ?_ ?_ (by simp)
                    · simp [hJ]
                    · simp only [Finset.mem_filter, id_eq, and_imp]
                      intro y hy
                      simp [hs' hy]
                [Elab.step] [0.015273] 
                      simp only [Finset.mem_image, exists_exists_and_eq_and, forall_exists_index, and_imp,
                        forall_apply_eq_imp_iff₂]
                      intro J hJ
                      refine isPrimary_finset_inf (i := J) ?_ ?_ (by simp)
                      · simp [hJ]
                      · simp only [Finset.mem_filter, id_eq, and_imp]
                        intro y hy
                        simp [hs' hy]
                  [Elab.step] [0.015268] 
                        simp only [Finset.mem_image, exists_exists_and_eq_and, forall_exists_index, and_imp,
                          forall_apply_eq_imp_iff₂]
                        intro J hJ
                        refine isPrimary_finset_inf (i := J) ?_ ?_ (by simp)
                        · simp [hJ]
                        · simp only [Finset.mem_filter, id_eq, and_imp]
                          intro y hy
                          simp [hs' hy]
              [Elab.step] [0.027960] ·
                    intro I hI J hJ hIJ
                    simp only [Finset.coe_image, Set.mem_image, Finset.mem_coe, exists_exists_and_eq_and] at hI hJ
                    obtain ⟨I', hI', hI⟩ := hI
                    obtain ⟨J', hJ', hJ⟩ := hJ
                    simp only [Function.onFun, ne_eq]
                    contrapose! hIJ
                    suffices I'.radical = J'.radical by rw [← hI, ← hJ, this]
                    · rw [← hI, radical_finset_inf (i := I') (by simp [hI']) (by simp), id_eq] at hIJ
                      rw [hIJ, ← hJ, radical_finset_inf (i := J') (by simp [hJ']) (by simp), id_eq]
                [Elab.step] [0.027947] 
                      intro I hI J hJ hIJ
                      simp only [Finset.coe_image, Set.mem_image, Finset.mem_coe, exists_exists_and_eq_and] at hI hJ
                      obtain ⟨I', hI', hI⟩ := hI
                      obtain ⟨J', hJ', hJ⟩ := hJ
                      simp only [Function.onFun, ne_eq]
                      contrapose! hIJ
                      suffices I'.radical = J'.radical by rw [← hI, ← hJ, this]
                      · rw [← hI, radical_finset_inf (i := I') (by simp [hI']) (by simp), id_eq] at hIJ
                        rw [hIJ, ← hJ, radical_finset_inf (i := J') (by simp [hJ']) (by simp), id_eq]
                  [Elab.step] [0.027944] 
                        intro I hI J hJ hIJ
                        simp only [Finset.coe_image, Set.mem_image, Finset.mem_coe, exists_exists_and_eq_and] at hI hJ
                        obtain ⟨I', hI', hI⟩ := hI
                        obtain ⟨J', hJ', hJ⟩ := hJ
                        simp only [Function.onFun, ne_eq]
                        contrapose! hIJ
                        suffices I'.radical = J'.radical by rw [← hI, ← hJ, this]
                        · rw [← hI, radical_finset_inf (i := I') (by simp [hI']) (by simp), id_eq] at hIJ
                          rw [hIJ, ← hJ, radical_finset_inf (i := J') (by simp [hJ']) (by simp), id_eq]
                    [Elab.step] [0.014324] ·
                          rw [← hI, radical_finset_inf (i := I') (by simp [hI']) (by simp), id_eq] at hIJ
                          rw [hIJ, ← hJ, radical_finset_inf (i := J') (by simp [hJ']) (by simp), id_eq]
                      [Elab.step] [0.014317] 
                            rw [← hI, radical_finset_inf (i := I') (by simp [hI']) (by simp), id_eq] at hIJ
                            rw [hIJ, ← hJ, radical_finset_inf (i := J') (by simp [hJ']) (by simp), id_eq]
                        [Elab.step] [0.014310] 
                              rw [← hI, radical_finset_inf (i := I') (by simp [hI']) (by simp), id_eq] at hIJ
                              rw [hIJ, ← hJ, radical_finset_inf (i := J') (by simp [hJ']) (by simp), id_eq]
Build completed successfully (1261 jobs).
```

### Trace profiling of `isPrimary_decomposition_pairwise_ne_radical` after PR 31201
```diff
diff --git a/Mathlib/RingTheory/Lasker.lean b/Mathlib/RingTheory/Lasker.lean
index 8f522d48f8..6f1c39f8a7 100644
--- a/Mathlib/RingTheory/Lasker.lean
+++ b/Mathlib/RingTheory/Lasker.lean
@@ -57,6 +57,7 @@ lemma decomposition_erase_inf [DecidableEq (Ideal R)] {I : Ideal R}
 
 open scoped Function -- required for scoped `on` notation
 
+set_option trace.profiler true in
 lemma isPrimary_decomposition_pairwise_ne_radical {I : Ideal R}
     {s : Finset (Ideal R)} (hs : s.inf id = I) (hs' : ∀ ⦃J⦄, J ∈ s → J.IsPrimary) :
     ∃ t : Finset (Ideal R), t.inf id = I ∧ (∀ ⦃J⦄, J ∈ t → J.IsPrimary) ∧
@@ -64,16 +65,8 @@ lemma isPrimary_decomposition_pairwise_ne_radical {I : Ideal R}
   classical
   refine ⟨(s.image (fun J ↦ {I ∈ s | I.radical = J.radical})).image fun t ↦ t.inf id,
     ?_, ?_, ?_⟩
-  · rw [← hs]
-    refine le_antisymm ?_ ?_ <;> intro x hx
-    · simp only [Finset.inf_image, CompTriple.comp_eq, Submodule.mem_finsetInf,
-      Function.comp_apply, Finset.mem_filter, id_eq, and_imp] at hx ⊢
-      intro J hJ
-      exact hx J hJ J hJ rfl
-    · simp only [Submodule.mem_finsetInf, id_eq, Finset.inf_image, CompTriple.comp_eq,
-      Function.comp_apply, Finset.mem_filter, and_imp] at hx ⊢
-      intro J _ K hK _
-      exact hx K hK
+  · ext
+    grind [Finset.inf_image, Submodule.mem_finsetInf]
   · simp only [Finset.mem_image, exists_exists_and_eq_and, forall_exists_index, and_imp,
     forall_apply_eq_imp_iff₂]
     intro J hJ
```
```
ℹ [1261/1261] Built Mathlib.RingTheory.Lasker (1.2s)
info: Mathlib/RingTheory/Lasker.lean:61:0: [Elab.command] [0.011121] theorem isPrimary_decomposition_pairwise_ne_radical {I : Ideal R} {s : Finset (Ideal R)}
        (hs : s.inf id = I) (hs' : ∀ ⦃J⦄, J ∈ s → J.IsPrimary) :
        ∃ t : Finset (Ideal R),
          t.inf id = I ∧ (∀ ⦃J⦄, J ∈ t → J.IsPrimary) ∧ (t : Set (Ideal R)).Pairwise ((· ≠ ·) on radical) :=
      by
      classical
      refine ⟨(s.image (fun J ↦ {I ∈ s | I.radical = J.radical})).image fun t ↦ t.inf id, ?_, ?_, ?_⟩
      · ext
        grind [Finset.inf_image, Submodule.mem_finsetInf]
      · simp only [Finset.mem_image, exists_exists_and_eq_and, forall_exists_index, and_imp, forall_apply_eq_imp_iff₂]
        intro J hJ
        refine isPrimary_finset_inf (i := J) ?_ ?_ (by simp)
        · simp [hJ]
        · simp only [Finset.mem_filter, id_eq, and_imp]
          intro y hy
          simp [hs' hy]
      · intro I hI J hJ hIJ
        simp only [Finset.coe_image, Set.mem_image, Finset.mem_coe, exists_exists_and_eq_and] at hI hJ
        obtain ⟨I', hI', hI⟩ := hI
        obtain ⟨J', hJ', hJ⟩ := hJ
        simp only [Function.onFun, ne_eq]
        contrapose! hIJ
        suffices I'.radical = J'.radical by rw [← hI, ← hJ, this]
        · rw [← hI, radical_finset_inf (i := I') (by simp [hI']) (by simp), id_eq] at hIJ
          rw [hIJ, ← hJ, radical_finset_inf (i := J') (by simp [hJ']) (by simp), id_eq]
info: Mathlib/RingTheory/Lasker.lean:61:0: [Elab.command] [0.012898] lemma isPrimary_decomposition_pairwise_ne_radical {I : Ideal R} {s : Finset (Ideal R)}
        (hs : s.inf id = I) (hs' : ∀ ⦃J⦄, J ∈ s → J.IsPrimary) :
        ∃ t : Finset (Ideal R),
          t.inf id = I ∧ (∀ ⦃J⦄, J ∈ t → J.IsPrimary) ∧ (t : Set (Ideal R)).Pairwise ((· ≠ ·) on radical) :=
      by
      classical
      refine ⟨(s.image (fun J ↦ {I ∈ s | I.radical = J.radical})).image fun t ↦ t.inf id, ?_, ?_, ?_⟩
      · ext
        grind [Finset.inf_image, Submodule.mem_finsetInf]
      · simp only [Finset.mem_image, exists_exists_and_eq_and, forall_exists_index, and_imp, forall_apply_eq_imp_iff₂]
        intro J hJ
        refine isPrimary_finset_inf (i := J) ?_ ?_ (by simp)
        · simp [hJ]
        · simp only [Finset.mem_filter, id_eq, and_imp]
          intro y hy
          simp [hs' hy]
      · intro I hI J hJ hIJ
        simp only [Finset.coe_image, Set.mem_image, Finset.mem_coe, exists_exists_and_eq_and] at hI hJ
        obtain ⟨I', hI', hI⟩ := hI
        obtain ⟨J', hJ', hJ⟩ := hJ
        simp only [Function.onFun, ne_eq]
        contrapose! hIJ
        suffices I'.radical = J'.radical by rw [← hI, ← hJ, this]
        · rw [← hI, radical_finset_inf (i := I') (by simp [hI']) (by simp), id_eq] at hIJ
          rw [hIJ, ← hJ, radical_finset_inf (i := J') (by simp [hJ']) (by simp), id_eq]
info: Mathlib/RingTheory/Lasker.lean:61:0: [Elab.async] [0.157957] elaborating proof of Ideal.isPrimary_decomposition_pairwise_ne_radical
  [Elab.definition.value] [0.156050] Ideal.isPrimary_decomposition_pairwise_ne_radical
    [Elab.step] [0.154194] classical
          refine ⟨(s.image (fun J ↦ {I ∈ s | I.radical = J.radical})).image fun t ↦ t.inf id, ?_, ?_, ?_⟩
          · ext
            grind [Finset.inf_image, Submodule.mem_finsetInf]
          · simp only [Finset.mem_image, exists_exists_and_eq_and, forall_exists_index, and_imp,
              forall_apply_eq_imp_iff₂]
            intro J hJ
            refine isPrimary_finset_inf (i := J) ?_ ?_ (by simp)
            · simp [hJ]
            · simp only [Finset.mem_filter, id_eq, and_imp]
              intro y hy
              simp [hs' hy]
          · intro I hI J hJ hIJ
            simp only [Finset.coe_image, Set.mem_image, Finset.mem_coe, exists_exists_and_eq_and] at hI hJ
            obtain ⟨I', hI', hI⟩ := hI
            obtain ⟨J', hJ', hJ⟩ := hJ
            simp only [Function.onFun, ne_eq]
            contrapose! hIJ
            suffices I'.radical = J'.radical by rw [← hI, ← hJ, this]
            · rw [← hI, radical_finset_inf (i := I') (by simp [hI']) (by simp), id_eq] at hIJ
              rw [hIJ, ← hJ, radical_finset_inf (i := J') (by simp [hJ']) (by simp), id_eq]
      [Elab.step] [0.154189] classical
            refine ⟨(s.image (fun J ↦ {I ∈ s | I.radical = J.radical})).image fun t ↦ t.inf id, ?_, ?_, ?_⟩
            · ext
              grind [Finset.inf_image, Submodule.mem_finsetInf]
            · simp only [Finset.mem_image, exists_exists_and_eq_and, forall_exists_index, and_imp,
                forall_apply_eq_imp_iff₂]
              intro J hJ
              refine isPrimary_finset_inf (i := J) ?_ ?_ (by simp)
              · simp [hJ]
              · simp only [Finset.mem_filter, id_eq, and_imp]
                intro y hy
                simp [hs' hy]
            · intro I hI J hJ hIJ
              simp only [Finset.coe_image, Set.mem_image, Finset.mem_coe, exists_exists_and_eq_and] at hI hJ
              obtain ⟨I', hI', hI⟩ := hI
              obtain ⟨J', hJ', hJ⟩ := hJ
              simp only [Function.onFun, ne_eq]
              contrapose! hIJ
              suffices I'.radical = J'.radical by rw [← hI, ← hJ, this]
              · rw [← hI, radical_finset_inf (i := I') (by simp [hI']) (by simp), id_eq] at hIJ
                rw [hIJ, ← hJ, radical_finset_inf (i := J') (by simp [hJ']) (by simp), id_eq]
        [Elab.step] [0.154184] classical
            refine ⟨(s.image (fun J ↦ {I ∈ s | I.radical = J.radical})).image fun t ↦ t.inf id, ?_, ?_, ?_⟩
            · ext
              grind [Finset.inf_image, Submodule.mem_finsetInf]
            · simp only [Finset.mem_image, exists_exists_and_eq_and, forall_exists_index, and_imp,
[… 59 lines omitted …]
                    ⟨(s.image (fun J ↦ {I ∈ s | I.radical = J.radical})).image fun t ↦ t.inf id, ?_, ?_, ?_⟩
                [Elab.step] [0.017062] expected type: ∃ t,
                      t.inf id = I ∧
                        (∀ ⦃J : Ideal R⦄, J ∈ t → J.IsPrimary) ∧ (↑t).Pairwise ((fun x1 x2 ↦ x1 ≠ x2) on radical), term
                    ⟨(s.image (fun J ↦ {I ∈ s | I.radical = J.radical})).image fun t ↦ t.inf id, ?_, ?_, ?_⟩
                  [Elab.step] [0.017043] expected type: ∃ t,
                        t.inf id = I ∧
                          (∀ ⦃J : Ideal R⦄, J ∈ t → J.IsPrimary) ∧
                            (↑t).Pairwise ((fun x1 x2 ↦ x1 ≠ x2) on radical), term
                      Exists.intro✝ ((s.image (fun J ↦ {I ∈ s | I.radical = J.radical})).image fun t ↦ t.inf id)
                        ⟨?_, ?_, ?_⟩
                    [Elab.step] [0.016253] expected type: Finset (Ideal R), term
                        (s.image (fun J ↦ {I ∈ s | I.radical = J.radical})).image fun t ↦ t.inf id
                      [Elab.step] [0.013756] expected type: <not-available>, term
                          (s.image (fun J ↦ {I ∈ s | I.radical = J.radical}))
                        [Elab.step] [0.013751] expected type: <not-available>, term
                            s.image (fun J ↦ {I ∈ s | I.radical = J.radical})
                          [Elab.step] [0.011627] expected type: ?m.44 → Finset (Ideal R), term
                              (fun J ↦ {I ∈ s | I.radical = J.radical})
                            [Elab.step] [0.011622] expected type: ?m.44 → Finset (Ideal R), term
                                fun J ↦ {I ∈ s | I.radical = J.radical}
                              [Elab.step] [0.011555] expected type: Finset (Ideal R), term
                                  {I ∈ s | I.radical = J.radical}
              [Elab.step] [0.090158] ·
                    ext
                    grind [Finset.inf_image, Submodule.mem_finsetInf]
                [Elab.step] [0.090093] 
                      ext
                      grind [Finset.inf_image, Submodule.mem_finsetInf]
                  [Elab.step] [0.090089] 
                        ext
                        grind [Finset.inf_image, Submodule.mem_finsetInf]
                    [Elab.step] [0.089120] grind [Finset.inf_image, Submodule.mem_finsetInf]
              [Elab.step] [0.014619] ·
                    simp only [Finset.mem_image, exists_exists_and_eq_and, forall_exists_index, and_imp,
                      forall_apply_eq_imp_iff₂]
                    intro J hJ
                    refine isPrimary_finset_inf (i := J) ?_ ?_ (by simp)
                    · simp [hJ]
                    · simp only [Finset.mem_filter, id_eq, and_imp]
                      intro y hy
                      simp [hs' hy]
                [Elab.step] [0.014610] 
                      simp only [Finset.mem_image, exists_exists_and_eq_and, forall_exists_index, and_imp,
                        forall_apply_eq_imp_iff₂]
                      intro J hJ
                      refine isPrimary_finset_inf (i := J) ?_ ?_ (by simp)
                      · simp [hJ]
                      · simp only [Finset.mem_filter, id_eq, and_imp]
                        intro y hy
                        simp [hs' hy]
                  [Elab.step] [0.014605] 
                        simp only [Finset.mem_image, exists_exists_and_eq_and, forall_exists_index, and_imp,
                          forall_apply_eq_imp_iff₂]
                        intro J hJ
                        refine isPrimary_finset_inf (i := J) ?_ ?_ (by simp)
                        · simp [hJ]
                        · simp only [Finset.mem_filter, id_eq, and_imp]
                          intro y hy
                          simp [hs' hy]
              [Elab.step] [0.026753] ·
                    intro I hI J hJ hIJ
                    simp only [Finset.coe_image, Set.mem_image, Finset.mem_coe, exists_exists_and_eq_and] at hI hJ
                    obtain ⟨I', hI', hI⟩ := hI
                    obtain ⟨J', hJ', hJ⟩ := hJ
                    simp only [Function.onFun, ne_eq]
                    contrapose! hIJ
                    suffices I'.radical = J'.radical by rw [← hI, ← hJ, this]
                    · rw [← hI, radical_finset_inf (i := I') (by simp [hI']) (by simp), id_eq] at hIJ
                      rw [hIJ, ← hJ, radical_finset_inf (i := J') (by simp [hJ']) (by simp), id_eq]
                [Elab.step] [0.026740] 
                      intro I hI J hJ hIJ
                      simp only [Finset.coe_image, Set.mem_image, Finset.mem_coe, exists_exists_and_eq_and] at hI hJ
                      obtain ⟨I', hI', hI⟩ := hI
                      obtain ⟨J', hJ', hJ⟩ := hJ
                      simp only [Function.onFun, ne_eq]
                      contrapose! hIJ
                      suffices I'.radical = J'.radical by rw [← hI, ← hJ, this]
                      · rw [← hI, radical_finset_inf (i := I') (by simp [hI']) (by simp), id_eq] at hIJ
                        rw [hIJ, ← hJ, radical_finset_inf (i := J') (by simp [hJ']) (by simp), id_eq]
                  [Elab.step] [0.026737] 
                        intro I hI J hJ hIJ
                        simp only [Finset.coe_image, Set.mem_image, Finset.mem_coe, exists_exists_and_eq_and] at hI hJ
                        obtain ⟨I', hI', hI⟩ := hI
                        obtain ⟨J', hJ', hJ⟩ := hJ
                        simp only [Function.onFun, ne_eq]
                        contrapose! hIJ
                        suffices I'.radical = J'.radical by rw [← hI, ← hJ, this]
                        · rw [← hI, radical_finset_inf (i := I') (by simp [hI']) (by simp), id_eq] at hIJ
                          rw [hIJ, ← hJ, radical_finset_inf (i := J') (by simp [hJ']) (by simp), id_eq]
                    [Elab.step] [0.013805] ·
                          rw [← hI, radical_finset_inf (i := I') (by simp [hI']) (by simp), id_eq] at hIJ
                          rw [hIJ, ← hJ, radical_finset_inf (i := J') (by simp [hJ']) (by simp), id_eq]
                      [Elab.step] [0.013799] 
                            rw [← hI, radical_finset_inf (i := I') (by simp [hI']) (by simp), id_eq] at hIJ
                            rw [hIJ, ← hJ, radical_finset_inf (i := J') (by simp [hJ']) (by simp), id_eq]
                        [Elab.step] [0.013796] 
                              rw [← hI, radical_finset_inf (i := I') (by simp [hI']) (by simp), id_eq] at hIJ
                              rw [hIJ, ← hJ, radical_finset_inf (i := J') (by simp [hJ']) (by simp), id_eq]
Build completed successfully (1261 jobs).
```
</details>

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

When merging, all the commits will be squashed into a single commit
listing all co-authors.

Co-authors in the squash commit are gathered from two sources:

First, all authors of commits to this PR branch are included. Thus,
one way to add co-authors is to include at least one commit authored by
each co-author among the commits in the pull request. If necessary, you
may create empty commits to indicate co-authorship, using commands like so:

git commit --author="Author Name <author@email.com>" --allow-empty -m "add Author Name as coauthor"

Second, co-authors can also be listed in lines at the very bottom of
the commit message (that is, directly before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines
at the bottom of the commit message (before the `---`, and also before
any "Co-authored-by" lines) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
