### PR TITLE
chore(Data/Complex): golf `{horizontal,vertical}Segment_eq` using `grind`

### DIFF
--- a/Mathlib/Data/Complex/Basic.lean
+++ b/Mathlib/Data/Complex/Basic.lean
@@ -799,29 +799,13 @@ section Segments
 lemma horizontalSegment_eq (a₁ a₂ b : ℝ) :
     (fun (x : ℝ) ↦ x + b * I) '' [[a₁, a₂]] = [[a₁, a₂]] ×ℂ {b} := by
   rw [← preimage_equivRealProd_prod]
-  ext x
-  constructor
-  · intro hx
-    obtain ⟨x₁, hx₁, hx₁'⟩ := hx
-    simp [← hx₁', mem_preimage, mem_prod, hx₁]
-  · intro hx
-    obtain ⟨x₁, hx₁, hx₁', hx₁''⟩ := hx
-    refine ⟨x.re, x₁, by simp⟩
+  grind [ofReal_re, ofReal_im, I_im, add_im, mul_im, re_add_im, equivRealProd_apply]
 
 /-- A vertical segment `[b₁, b₂]` translated by `a` is the complex line segment. -/
 lemma verticalSegment_eq (a b₁ b₂ : ℝ) :
     (fun (y : ℝ) ↦ a + y * I) '' [[b₁, b₂]] = {a} ×ℂ [[b₁, b₂]] := by
   rw [← preimage_equivRealProd_prod]
-  ext x
-  constructor
-  · intro hx
-    obtain ⟨x₁, hx₁, hx₁'⟩ := hx
-    simp [← hx₁', mem_preimage, mem_prod, hx₁]
-  · intro hx
-    simp only [equivRealProd_apply, singleton_prod, mem_image, Prod.mk.injEq,
-      exists_eq_right_right, mem_preimage] at hx
-    obtain ⟨x₁, hx₁, hx₁', hx₁''⟩ := hx
-    refine ⟨x.im, x₁, by simp⟩
+  grind [ofReal_re, ofReal_im, I_im, add_im, mul_im, re_add_im, equivRealProd_apply]
 
 end Segments
 


### PR DESCRIPTION
---
<details>
<summary>Show trace profiling of <code>horizontalSegment_eq</code>: 14 ms before, 94 ms after </summary>

### Trace profiling of `horizontalSegment_eq` before PR 31202
```diff
diff --git a/Mathlib/Data/Complex/Basic.lean b/Mathlib/Data/Complex/Basic.lean
index 32567a2258..15a4296de3 100644
--- a/Mathlib/Data/Complex/Basic.lean
+++ b/Mathlib/Data/Complex/Basic.lean
@@ -795,6 +795,7 @@ end Rectangle
 
 section Segments
 
+set_option trace.profiler true in
 /-- A real segment `[a₁, a₂]` translated by `b * I` is the complex line segment. -/
 lemma horizontalSegment_eq (a₁ a₂ b : ℝ) :
     (fun (x : ℝ) ↦ x + b * I) '' [[a₁, a₂]] = [[a₁, a₂]] ×ℂ {b} := by
```
```
ℹ [761/761] Built Mathlib.Data.Complex.Basic (2.1s)
info: Mathlib/Data/Complex/Basic.lean:799:0: [Elab.command] [0.010569] /-- A real segment `[a₁, a₂]` translated by `b * I` is the complex line segment. -/
    theorem horizontalSegment_eq (a₁ a₂ b : ℝ) : (fun (x : ℝ) ↦ x + b * I) '' [[a₁, a₂]] = [[a₁, a₂]] ×ℂ { b } :=
      by
      rw [← preimage_equivRealProd_prod]
      ext x
      constructor
      · intro hx
        obtain ⟨x₁, hx₁, hx₁'⟩ := hx
        simp [← hx₁', mem_preimage, mem_prod, hx₁]
      · intro hx
        obtain ⟨x₁, hx₁, hx₁', hx₁''⟩ := hx
        refine ⟨x.re, x₁, by simp⟩
  [Elab.definition.header] [0.010308] Complex.horizontalSegment_eq
info: Mathlib/Data/Complex/Basic.lean:799:0: [Elab.command] [0.010667] /-- A real segment `[a₁, a₂]` translated by `b * I` is the complex line segment. -/
    lemma horizontalSegment_eq (a₁ a₂ b : ℝ) : (fun (x : ℝ) ↦ x + b * I) '' [[a₁, a₂]] = [[a₁, a₂]] ×ℂ { b } :=
      by
      rw [← preimage_equivRealProd_prod]
      ext x
      constructor
      · intro hx
        obtain ⟨x₁, hx₁, hx₁'⟩ := hx
        simp [← hx₁', mem_preimage, mem_prod, hx₁]
      · intro hx
        obtain ⟨x₁, hx₁, hx₁', hx₁''⟩ := hx
        refine ⟨x.re, x₁, by simp⟩
info: Mathlib/Data/Complex/Basic.lean:799:0: [Elab.async] [0.014638] elaborating proof of Complex.horizontalSegment_eq
  [Elab.definition.value] [0.014084] Complex.horizontalSegment_eq
    [Elab.step] [0.013771] 
          rw [← preimage_equivRealProd_prod]
          ext x
          constructor
          · intro hx
            obtain ⟨x₁, hx₁, hx₁'⟩ := hx
            simp [← hx₁', mem_preimage, mem_prod, hx₁]
          · intro hx
            obtain ⟨x₁, hx₁, hx₁', hx₁''⟩ := hx
            refine ⟨x.re, x₁, by simp⟩
      [Elab.step] [0.013765] 
            rw [← preimage_equivRealProd_prod]
            ext x
            constructor
            · intro hx
              obtain ⟨x₁, hx₁, hx₁'⟩ := hx
              simp [← hx₁', mem_preimage, mem_prod, hx₁]
            · intro hx
              obtain ⟨x₁, hx₁, hx₁', hx₁''⟩ := hx
              refine ⟨x.re, x₁, by simp⟩
        [Elab.step] [0.010160] ·
              intro hx
              obtain ⟨x₁, hx₁, hx₁'⟩ := hx
              simp [← hx₁', mem_preimage, mem_prod, hx₁]
          [Elab.step] [0.010145] 
                intro hx
                obtain ⟨x₁, hx₁, hx₁'⟩ := hx
                simp [← hx₁', mem_preimage, mem_prod, hx₁]
            [Elab.step] [0.010140] 
                  intro hx
                  obtain ⟨x₁, hx₁, hx₁'⟩ := hx
                  simp [← hx₁', mem_preimage, mem_prod, hx₁]
Build completed successfully (761 jobs).
```

### Trace profiling of `horizontalSegment_eq` after PR 31202
```diff
diff --git a/Mathlib/Data/Complex/Basic.lean b/Mathlib/Data/Complex/Basic.lean
index 32567a2258..485462a0d3 100644
--- a/Mathlib/Data/Complex/Basic.lean
+++ b/Mathlib/Data/Complex/Basic.lean
@@ -795,33 +795,18 @@ end Rectangle
 
 section Segments
 
+set_option trace.profiler true in
 /-- A real segment `[a₁, a₂]` translated by `b * I` is the complex line segment. -/
 lemma horizontalSegment_eq (a₁ a₂ b : ℝ) :
     (fun (x : ℝ) ↦ x + b * I) '' [[a₁, a₂]] = [[a₁, a₂]] ×ℂ {b} := by
   rw [← preimage_equivRealProd_prod]
-  ext x
-  constructor
-  · intro hx
-    obtain ⟨x₁, hx₁, hx₁'⟩ := hx
-    simp [← hx₁', mem_preimage, mem_prod, hx₁]
-  · intro hx
-    obtain ⟨x₁, hx₁, hx₁', hx₁''⟩ := hx
-    refine ⟨x.re, x₁, by simp⟩
+  grind [ofReal_re, ofReal_im, I_im, add_im, mul_im, re_add_im, equivRealProd_apply]
 
 /-- A vertical segment `[b₁, b₂]` translated by `a` is the complex line segment. -/
 lemma verticalSegment_eq (a b₁ b₂ : ℝ) :
     (fun (y : ℝ) ↦ a + y * I) '' [[b₁, b₂]] = {a} ×ℂ [[b₁, b₂]] := by
   rw [← preimage_equivRealProd_prod]
-  ext x
-  constructor
-  · intro hx
-    obtain ⟨x₁, hx₁, hx₁'⟩ := hx
-    simp [← hx₁', mem_preimage, mem_prod, hx₁]
-  · intro hx
-    simp only [equivRealProd_apply, singleton_prod, mem_image, Prod.mk.injEq,
-      exists_eq_right_right, mem_preimage] at hx
-    obtain ⟨x₁, hx₁, hx₁', hx₁''⟩ := hx
-    refine ⟨x.im, x₁, by simp⟩
+  grind [ofReal_re, ofReal_im, I_im, add_im, mul_im, re_add_im, equivRealProd_apply]
 
 end Segments
 
```
```
ℹ [761/761] Built Mathlib.Data.Complex.Basic (2.3s)
info: Mathlib/Data/Complex/Basic.lean:799:0: [Elab.command] [0.011048] /-- A real segment `[a₁, a₂]` translated by `b * I` is the complex line segment. -/
    theorem horizontalSegment_eq (a₁ a₂ b : ℝ) : (fun (x : ℝ) ↦ x + b * I) '' [[a₁, a₂]] = [[a₁, a₂]] ×ℂ { b } :=
      by
      rw [← preimage_equivRealProd_prod]
      grind [ofReal_re, ofReal_im, I_im, add_im, mul_im, re_add_im, equivRealProd_apply]
  [Elab.definition.header] [0.010785] Complex.horizontalSegment_eq
    [Elab.step] [0.010302] expected type: Sort ?u.66983, term
        (fun (x : ℝ) ↦ x + b * I) '' [[a₁, a₂]] = [[a₁, a₂]] ×ℂ { b }
      [Elab.step] [0.010296] expected type: Sort ?u.66983, term
          binrel% Eq✝ ((fun (x : ℝ) ↦ x + b * I) '' [[a₁, a₂]]) ([[a₁, a₂]] ×ℂ { b })
info: Mathlib/Data/Complex/Basic.lean:799:0: [Elab.command] [0.011196] /-- A real segment `[a₁, a₂]` translated by `b * I` is the complex line segment. -/
    lemma horizontalSegment_eq (a₁ a₂ b : ℝ) : (fun (x : ℝ) ↦ x + b * I) '' [[a₁, a₂]] = [[a₁, a₂]] ×ℂ { b } :=
      by
      rw [← preimage_equivRealProd_prod]
      grind [ofReal_re, ofReal_im, I_im, add_im, mul_im, re_add_im, equivRealProd_apply]
info: Mathlib/Data/Complex/Basic.lean:799:0: [Elab.async] [0.094480] elaborating proof of Complex.horizontalSegment_eq
  [Elab.definition.value] [0.094168] Complex.horizontalSegment_eq
    [Elab.step] [0.094076] 
          rw [← preimage_equivRealProd_prod]
          grind [ofReal_re, ofReal_im, I_im, add_im, mul_im, re_add_im, equivRealProd_apply]
      [Elab.step] [0.094070] 
            rw [← preimage_equivRealProd_prod]
            grind [ofReal_re, ofReal_im, I_im, add_im, mul_im, re_add_im, equivRealProd_apply]
        [Elab.step] [0.093483] grind [ofReal_re, ofReal_im, I_im, add_im, mul_im, re_add_im, equivRealProd_apply]
info: Mathlib/Data/Complex/Basic.lean:803:2: [Elab.async] [0.018401] Lean.addDecl
  [Kernel] [0.018382] ✅️ typechecking declarations [Complex.horizontalSegment_eq._proof_1_1]
Build completed successfully (761 jobs).
```
</details>

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

When merging, all the commits will be squashed into a single commit
listing all co-authors.

Co-authors in the squash commit are gathered from two sources:

First, all authors of commits to this PR branch are included. Thus,
one way to add co-authors is to include at least one commit authored by
each co-author among the commits in the pull request. If necessary, you
may create empty commits to indicate co-authorship, using commands like so:

git commit --author="Author Name <author@email.com>" --allow-empty -m "add Author Name as coauthor"

Second, co-authors can also be listed in lines at the very bottom of
the commit message (that is, directly before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines
at the bottom of the commit message (before the `---`, and also before
any "Co-authored-by" lines) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
