### PR TITLE
[Merged by Bors] - fix(push_neg): preserve binder names

### DIFF
--- a/Mathlib/Tactic/Push.lean
+++ b/Mathlib/Tactic/Push.lean
@@ -30,7 +30,7 @@ attribute [push ←] ne_eq
 
 @[push] theorem not_iff : ¬ (p ↔ q) ↔ (p ∧ ¬ q) ∨ (¬ p ∧ q) :=
   _root_.not_iff.trans <| iff_iff_and_or_not_and_not.trans <| by rw [not_not, or_comm]
-@[push] theorem not_exists : (¬ ∃ x, s x) ↔ (∀ x, binderNameHint x s <| ¬ s x) :=
+@[push] theorem not_exists : (¬ Exists s) ↔ (∀ x, binderNameHint x s <| ¬ s x) :=
   _root_.not_exists
 
 -- TODO: lemmas involving `∃` should be tagged using `binderNameHint`,

--- a/MathlibTest/push_neg.lean
+++ b/MathlibTest/push_neg.lean
@@ -225,7 +225,7 @@ example {p q : Nat} : ¬ g.Adj p q := by
 
 end no_proj
 
--- text that binder names are preserved by `push_neg`
+-- test that binder names are preserved by `push_neg`
 /-- info: ∀ (a b : ℕ), ∃ c d, a + b ≠ c + d -/
 #guard_msgs in
 #push_neg ¬ ∃ a b : Nat, ∀ c d : Nat, a + b = c + d

--- a/MathlibTest/push_neg.lean
+++ b/MathlibTest/push_neg.lean
@@ -224,3 +224,8 @@ example {p q : Nat} : ¬ g.Adj p q := by
   exact test_sorry
 
 end no_proj
+
+-- text that binder names are preserved by `push_neg`
+/-- info: ∀ (a b : ℕ), ∃ c d, a + b ≠ c + d -/
+#guard_msgs in
+#push_neg ¬ ∃ a b : Nat, ∀ c d : Nat, a + b = c + d


### PR DESCRIPTION
This PR fixes the `push_neg` tactic so that it preserves binder names when pushing through `Exists`. It was previously picking up the `x` name from `∃ x, s x`, so spelling it as `Exists s` fixes the problem.

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include at least one commit authored by each
co-author among the commits in the pull request. If necessary, you may 
create empty commits to indicate co-authorship, using commands like so:

git commit --author="Author Name <author@email.com>" --allow-empty -m "add Author Name as coauthor"

When merging, all the commits will be squashed into a single commit listing all co-authors.

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
