### PR TITLE
[Merged by Bors] - chore(Logic/Equiv): golf entire `Perm.subtypeCongr.symm` using `rfl`

### DIFF
--- a/Mathlib/Logic/Equiv/Basic.lean
+++ b/Mathlib/Logic/Equiv/Basic.lean
@@ -85,13 +85,8 @@ theorem Perm.subtypeCongr.refl :
   by_cases h : p x <;> simp [h]
 
 @[simp]
-theorem Perm.subtypeCongr.symm : (ep.subtypeCongr en).symm = Perm.subtypeCongr ep.symm en.symm := by
-  ext x
-  by_cases h : p x
-  · have : p (ep.symm ⟨x, h⟩) := Subtype.property _
-    simp [h, symm_apply_eq, this]
-  · have : ¬p (en.symm ⟨x, h⟩) := Subtype.property (en.symm _)
-    simp [h, symm_apply_eq, this]
+theorem Perm.subtypeCongr.symm : (ep.subtypeCongr en).symm = Perm.subtypeCongr ep.symm en.symm :=
+  rfl
 
 @[simp]
 theorem Perm.subtypeCongr.trans :


### PR DESCRIPTION
---
<details>
<summary>Show trace profiling of <code>Perm.subtypeCongr.symm</code>: 15 ms before, <10 ms after  🎉</summary>

### Trace profiling of `Perm.subtypeCongr.symm` before PR 31237
```diff
diff --git a/Mathlib/Logic/Equiv/Basic.lean b/Mathlib/Logic/Equiv/Basic.lean
index 0c39837098..557e0228df 100644
--- a/Mathlib/Logic/Equiv/Basic.lean
+++ b/Mathlib/Logic/Equiv/Basic.lean
@@ -83,6 +83,7 @@ theorem Perm.subtypeCongr.refl :
   ext x
   by_cases h : p x <;> simp [h]
 
+set_option trace.profiler true in
 @[simp]
 theorem Perm.subtypeCongr.symm : (ep.subtypeCongr en).symm = Perm.subtypeCongr ep.symm en.symm := by
   ext x
```
```
ℹ [310/310] Built Mathlib.Logic.Equiv.Basic (1.5s)
info: Mathlib/Logic/Equiv/Basic.lean:87:0: [Elab.async] [0.015219] elaborating proof of Equiv.Perm.subtypeCongr.symm
  [Elab.definition.value] [0.014659] Equiv.Perm.subtypeCongr.symm
    [Elab.step] [0.014391] 
          ext x
          by_cases h : p x
          · have : p (ep.symm ⟨x, h⟩) := Subtype.property _
            simp [h, symm_apply_eq, this]
          · have : ¬p (en.symm ⟨x, h⟩) := Subtype.property (en.symm _)
            simp [h, symm_apply_eq, this]
      [Elab.step] [0.014380] 
            ext x
            by_cases h : p x
            · have : p (ep.symm ⟨x, h⟩) := Subtype.property _
              simp [h, symm_apply_eq, this]
            · have : ¬p (en.symm ⟨x, h⟩) := Subtype.property (en.symm _)
              simp [h, symm_apply_eq, this]
Build completed successfully (310 jobs).
```

### Trace profiling of `Perm.subtypeCongr.symm` after PR 31237
```diff
diff --git a/Mathlib/Logic/Equiv/Basic.lean b/Mathlib/Logic/Equiv/Basic.lean
index 0c39837098..f3cfa176a3 100644
--- a/Mathlib/Logic/Equiv/Basic.lean
+++ b/Mathlib/Logic/Equiv/Basic.lean
@@ -83,14 +83,10 @@ theorem Perm.subtypeCongr.refl :
   ext x
   by_cases h : p x <;> simp [h]
 
+set_option trace.profiler true in
 @[simp]
-theorem Perm.subtypeCongr.symm : (ep.subtypeCongr en).symm = Perm.subtypeCongr ep.symm en.symm := by
-  ext x
-  by_cases h : p x
-  · have : p (ep.symm ⟨x, h⟩) := Subtype.property _
-    simp [h, symm_apply_eq, this]
-  · have : ¬p (en.symm ⟨x, h⟩) := Subtype.property (en.symm _)
-    simp [h, symm_apply_eq, this]
+theorem Perm.subtypeCongr.symm : (ep.subtypeCongr en).symm = Perm.subtypeCongr ep.symm en.symm :=
+  rfl
 
 @[simp]
 theorem Perm.subtypeCongr.trans :
```
```
ℹ [310/310] Built Mathlib.Logic.Equiv.Basic (1.5s)
info: Mathlib/Logic/Equiv/Basic.lean:87:0: [Elab.async] [0.010065] elaborating proof of Equiv.Perm.subtypeCongr.symm
Build completed successfully (310 jobs).
```
</details>

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

When merging, all the commits will be squashed into a single commit
listing all co-authors.

Co-authors in the squash commit are gathered from two sources:

First, all authors of commits to this PR branch are included. Thus,
one way to add co-authors is to include at least one commit authored by
each co-author among the commits in the pull request. If necessary, you
may create empty commits to indicate co-authorship, using commands like so:

git commit --author="Author Name <author@email.com>" --allow-empty -m "add Author Name as coauthor"

Second, co-authors can also be listed in lines at the very bottom of
the commit message (that is, directly before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines
at the bottom of the commit message (before the `---`, and also before
any "Co-authored-by" lines) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
