### PR TITLE
[Merged by Bors] - ci(update_dependencies.yml): force push to PR branch if there's a merge conflict

### DIFF
--- a/.github/workflows/update_dependencies.yml
+++ b/.github/workflows/update_dependencies.yml
@@ -72,11 +72,18 @@ jobs:
             echo "toolchain_modified=false" >> "$GITHUB_OUTPUT"
           fi
 
-      - name: Check if lake-manifest.json was modified
-        if: ${{ !contains(steps.PR.outputs.pr_labels, 'ready-to-merge') && steps.check_toolchain.outputs.toolchain_modified != 'true' }}
+      - name: Check if lake-manifest.json was modified or if no mergeable PR exists
+        # only run if check_toolchain ran and returned "false"
+        if: ${{ steps.check_toolchain.outputs.toolchain_modified == 'false' }}
         id: check_manifest
         run: |
-          if [ -n "${{ steps.get-branch-sha.outputs.sha }}" ]; then
+          if [ "${{ steps.PR.outputs.pr_found }}" != "true" ]; then
+            echo "has_diff=true" >> "${GITHUB_OUTPUT}"
+            echo "PR does not exist, let create-pull-request run"
+          elif [ "${{ contains(steps.PR.outputs.pr_labels, 'merge-conflict') }}" == "true" ]; then
+            echo "has_diff=true" >> "${GITHUB_OUTPUT}"
+            echo "merge-conflict on PR, let create-pull-request run"
+          elif [ -n "${{ steps.get-branch-sha.outputs.sha }}" ]; then
             # Branch exists, compare the file
             if git diff --quiet "origin/$BRANCH_NAME" -- lake-manifest.json; then
               echo "has_diff=false" >> "${GITHUB_OUTPUT}"
@@ -92,13 +99,14 @@ jobs:
           fi
 
       - name: Generate PR title
-        if: ${{ !contains(steps.PR.outputs.pr_labels, 'ready-to-merge') && steps.check_manifest.outputs.has_diff == 'true' }}
+        id: pr-title
+        if: ${{ steps.check_manifest.outputs.has_diff == 'true' }}
         run: |
           echo "timestamp=$(date -u +"%Y-%m-%d-%H-%M")" >> "$GITHUB_ENV"
           echo "pr_title=chore: update Mathlib dependencies $(date -u +"%Y-%m-%d")" >> "$GITHUB_ENV"
 
       - name: Create Pull Request
-        if: ${{ !contains(steps.PR.outputs.pr_labels, 'ready-to-merge') && steps.check_manifest.outputs.has_diff == 'true' }}
+        if: ${{ steps.pr-title.outcome == 'success' }}
         uses: peter-evans/create-pull-request@271a8d0340265f705b14b6d32b9829c1cb33d45e # v7.0.8
         with:
           token: "${{ secrets.UPDATE_DEPENDENCIES_TOKEN }}"
@@ -110,6 +118,8 @@ jobs:
           title: "${{ env.pr_title }}"
           body: |
             This PR updates the Mathlib dependencies.
+
+            ---
 
             [workflow run for this PR](${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }})
           labels: "auto-merge-after-CI"


### PR DESCRIPTION
The "update dependencies" workflow currently has a step which skips force-pushing if the lake manifest resulting from `lake update` run on `master` is the same as the lake manifest on the dedicated branch `update-dependencies-bot-only` which is used for its PRs. 

However, this can result in a stuck PR if there's a merge conflict. For example: #31234 was created before the fixes in #30138 were merged, so it failed CI. Then at some point it was automatically updated to a newer version of `batteries` so it picked up a merge conflict after #30138 was merged. The workflow then ran `lake update` on `master` and found no differences with the lake manifest on the `update-dependencies-bot-only` branch and so was never able to force push over the merge conflict ([example log](https://github.com/leanprover-community/mathlib4/actions/runs/19058465588/job/54433444711#step:9:20)).

This PR will allow the "update dependencies" workflow to force push to its branch in the following situations: 
- when the open "update dependencies" PR has a merge conflict
- when there is no open "update dependencies" PR (this gives us a way to force the workflow to recreate a PR by closing the stuck one)

This PR will not change the fact that if there are no differences with `master` after `lake update`, no pushing and no PRs will be opened. (That logic is handled by the create-pull-request action we use.)

I also streamline some of the run conditions for steps -- now each step just checks the output from the previous one rather than having to combine several conditions with `&&`.

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

When merging, all the commits will be squashed into a single commit
listing all co-authors.

Co-authors in the squash commit are gathered from two sources:

First, all authors of commits to this PR branch are included. Thus,
one way to add co-authors is to include at least one commit authored by
each co-author among the commits in the pull request. If necessary, you
may create empty commits to indicate co-authorship, using commands like so:

git commit --author="Author Name <author@email.com>" --allow-empty -m "add Author Name as coauthor"

Second, co-authors can also be listed in lines at the very bottom of
the commit message (that is, directly before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines
at the bottom of the commit message (before the `---`, and also before
any "Co-authored-by" lines) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
