### PR TITLE
[Merged by Bors] - feat(Computability/DFA): add DFA complement, union, and intersection

### DIFF
--- a/Mathlib/Computability/DFA.lean
+++ b/Mathlib/Computability/DFA.lean
@@ -1,7 +1,7 @@
 /-
 Copyright (c) 2020 Fox Thomson. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
-Authors: Fox Thomson, Chris Wong
+Authors: Fox Thomson, Chris Wong, Rudy Peterson
 -/
 module
 

--- a/Mathlib/Computability/DFA.lean
+++ b/Mathlib/Computability/DFA.lean
@@ -291,7 +291,8 @@ def union (M1 : DFA α σ1) (M2 : DFA α σ2) : DFA α (σ1 × σ2) where
   start := (M1.start, M2.start)
   accept := {s : σ1 × σ2 | s.1 ∈ M1.accept ∨ s.2 ∈ M2.accept}
 
-instance : HAdd (DFA α σ1) (DFA α σ2) (DFA α (σ1 × σ2)) := ⟨union⟩
+instance : HAdd (DFA α σ1) (DFA α σ2) (DFA α (σ1 × σ2)) :=
+  ⟨union⟩
 
 theorem hadd_eq_union (M1 : DFA α σ1) (M2 : DFA α σ2) : M1 + M2 = M1.union M2 :=
   rfl
@@ -324,15 +325,15 @@ def inter : DFA α (σ1 × σ2) where
   accept := {s : σ1 × σ2 | s.1 ∈ M1.accept ∧ s.2 ∈ M2.accept}
 
 theorem acceptsFrom_inter (s1 : σ1) (s2 : σ2) :
-    (M1.inter M2).acceptsFrom (s1, s2) = M1.acceptsFrom s1 ∩ M2.acceptsFrom s2 := by
+    (M1.inter M2).acceptsFrom (s1, s2) = M1.acceptsFrom s1 ⊓ M2.acceptsFrom s2 := by
   ext x
-  simp only [acceptsFrom, Language.mem_inter]
+  simp only [acceptsFrom, Language.mem_inf]
   simp_rw [↑Set.mem_setOf]
   induction x generalizing s1 s2 with
   | nil => simp
   | cons a x ih => simp only [evalFrom_cons, inter_step, ih]
 
-theorem accepts_inter : (M1.inter M2).accepts = M1.accepts ∩ M2.accepts := by
+theorem accepts_inter : (M1.inter M2).accepts = M1.accepts ⊓ M2.accepts := by
   simp [accepts, acceptsFrom_inter]
 
 end inter
@@ -376,15 +377,17 @@ theorem IsRegular_compl_iff {T : Type u} {L : Language T} : Lᶜ.IsRegular ↔ L
   ⟨.from_compl, .compl⟩
 
 /-- Regular languages are closed under union. -/
-theorem IsRegular_union {T : Type u} {L1 L2 : Language T} :
-    L1.IsRegular → L2.IsRegular → (L1 + L2).IsRegular :=
-  fun ⟨σ1, _, M1, hM1⟩ ⟨σ2, _, M2, hM2⟩ =>
-    ⟨σ1 × σ2, inferInstance, M1 + M2, by rw [DFA.accepts_union, hM1, hM2]⟩
+theorem IsRegular_union {T : Type u} {L1 L2 : Language T} (h1 : L1.IsRegular) (h2 : L2.IsRegular) :
+    (L1 + L2).IsRegular :=
+  have ⟨σ1, _, M1, hM1⟩ := h1
+  have ⟨σ2, _, M2, hM2⟩ := h2
+  ⟨σ1 × σ2, inferInstance, M1 + M2, by rw [DFA.accepts_union, hM1, hM2]⟩
 
 /-- Regular languages are closed under intersection. -/
-theorem IsRegular_inter {T : Type u} {L1 L2 : Language T} :
-    L1.IsRegular → L2.IsRegular → (L1 ∩ L2).IsRegular :=
-  fun ⟨σ1, _, M1, hM1⟩ ⟨σ2, _, M2, hM2⟩ =>
-    ⟨σ1 × σ2, inferInstance, M1.inter M2, by rw [DFA.accepts_inter, hM1, hM2]⟩
+theorem IsRegular_inter {T : Type u} {L1 L2 : Language T} (h1 : L1.IsRegular) (h2 : L2.IsRegular) :
+    (L1 ⊓ L2).IsRegular :=
+  have ⟨σ1, _, M1, hM1⟩ := h1
+  have ⟨σ2, _, M2, hM2⟩ := h2
+  ⟨σ1 × σ2, inferInstance, M1.inter M2, by rw [DFA.accepts_inter, hM1, hM2]⟩
 
 end Language

--- a/Mathlib/Computability/DFA.lean
+++ b/Mathlib/Computability/DFA.lean
@@ -284,7 +284,8 @@ section union
 
 variable {σ1 σ2 : Type v}
 
-/-- DFAs are closed under union. -/
+/-- DFAs are closed under union. We denote union of DFAs `M1` and `M2` via `M1 + M2`, corresponding
+to `Language` and regular expression union. -/
 @[simps]
 def union (M1 : DFA α σ1) (M2 : DFA α σ2) : DFA α (σ1 × σ2) where
   step (s : σ1 × σ2) (a : α) : σ1 × σ2 := (M1.step s.1 a, M2.step s.2 a)
@@ -377,14 +378,14 @@ theorem IsRegular_compl_iff {T : Type u} {L : Language T} : Lᶜ.IsRegular ↔ L
   ⟨.from_compl, .compl⟩
 
 /-- Regular languages are closed under union. -/
-theorem IsRegular_union {T : Type u} {L1 L2 : Language T} (h1 : L1.IsRegular) (h2 : L2.IsRegular) :
+theorem IsRegular.add {T : Type u} {L1 L2 : Language T} (h1 : L1.IsRegular) (h2 : L2.IsRegular) :
     (L1 + L2).IsRegular :=
   have ⟨σ1, _, M1, hM1⟩ := h1
   have ⟨σ2, _, M2, hM2⟩ := h2
   ⟨σ1 × σ2, inferInstance, M1 + M2, by rw [DFA.accepts_union, hM1, hM2]⟩
 
 /-- Regular languages are closed under intersection. -/
-theorem IsRegular_inter {T : Type u} {L1 L2 : Language T} (h1 : L1.IsRegular) (h2 : L2.IsRegular) :
+theorem IsRegular.inf {T : Type u} {L1 L2 : Language T} (h1 : L1.IsRegular) (h2 : L2.IsRegular) :
     (L1 ⊓ L2).IsRegular :=
   have ⟨σ1, _, M1, hM1⟩ := h1
   have ⟨σ2, _, M2, hM2⟩ := h2

--- a/Mathlib/Computability/DFA.lean
+++ b/Mathlib/Computability/DFA.lean
@@ -269,14 +269,25 @@ section compl
 
 /-- DFAs are closed under complement:
 Given a DFA `M`, `Mᶜ` is also a DFA such that `L(Mᶜ) = {x ∣ x ∉ L(M)}`. -/
+@[simps]
+def compl : DFA α σ where
+  step := M.step
+  start := M.start
+  accept := M.acceptᶜ
+
 instance : HasCompl (DFA α σ) where
-  compl M := DFA.mk M.step M.start M.acceptᶜ
+  compl M := M.compl
+
+theorem compl_def : Mᶜ = M.compl :=
+  rfl
 
 theorem acceptsFrom_compl (s : σ) : (Mᶜ).acceptsFrom s = (M.acceptsFrom s)ᶜ := by
-  ext x; simp [compl, acceptsFrom, evalFrom]
+  simp [compl_def, acceptsFrom, evalFrom, DFA.compl,
+    Set.compl_setOf (p:=(fun y ↦ List.foldl M.step s y ∈ M.accept))]
 
 theorem accepts_compl : (Mᶜ).accepts = (M.accepts)ᶜ := by
-  simp only [accepts, acceptsFrom_compl]; simp [compl]
+  simp only [accepts, acceptsFrom_compl]
+  simp [compl_def]
 
 end compl
 

--- a/Mathlib/Computability/DFA.lean
+++ b/Mathlib/Computability/DFA.lean
@@ -380,12 +380,12 @@ protected theorem IsRegular.compl {T : Type u} {L : Language T} (h : L.IsRegular
   have ⟨σ, _, M, hM⟩ := h
   ⟨σ, inferInstance, Mᶜ, by simp [DFA.accepts_compl, hM]⟩
 
-protected theorem IsRegular.from_compl {T : Type u} {L : Language T} (h : Lᶜ.IsRegular) :
+protected theorem IsRegular.of_compl {T : Type u} {L : Language T} (h : Lᶜ.IsRegular) :
   L.IsRegular :=
   L.compl_compl ▸ h.compl
 
 /-- Regular languages are closed under complement. -/
-theorem IsRegular_compl_iff {T : Type u} {L : Language T} : Lᶜ.IsRegular ↔ L.IsRegular :=
+theorem IsRegular_compl {T : Type u} {L : Language T} : Lᶜ.IsRegular ↔ L.IsRegular :=
   ⟨.from_compl, .compl⟩
 
 /-- Regular languages are closed under union. -/

--- a/Mathlib/Computability/Language.lean
+++ b/Mathlib/Computability/Language.lean
@@ -1,7 +1,7 @@
 /-
 Copyright (c) 2020 Fox Thomson. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
-Authors: Fox Thomson, Martin Dvorak
+Authors: Fox Thomson, Martin Dvorak, Rudy Peterson
 -/
 module
 
@@ -34,6 +34,8 @@ with respect to other language operations.
 * `l∗`: Kleene star – language of strings consisting of arbitrarily many members of `l`
   concatenated together. Note that this notation uses the Unicode asterisk operator `∗`, as opposed
   to the more common ASCII asterisk `*`.
+* `lᶜ`: complement, language of strings `x` such that `x ∉ l`
+* `l ∩ m`: intersection of languages `l` and `m`
 
 ## Main definitions
 

--- a/Mathlib/Computability/Language.lean
+++ b/Mathlib/Computability/Language.lean
@@ -407,10 +407,10 @@ lemma reverse_kstar (l : Language α) : l∗.reverse = l.reverse∗ := by
   simp only [kstar_eq_iSup_pow, reverse_iSup, reverse_pow]
 
 @[simp]
-lemma mem_inf (x : List α) (l m : Language α) : x ∈ l ⊓ m ↔ x ∈ l ∧ x ∈ m := by
+lemma mem_inf {x : List α} {l m : Language α} : x ∈ l ⊓ m ↔ x ∈ l ∧ x ∈ m := by
   apply Set.mem_inter_iff
 
-lemma compl_compl {l : Language α} : lᶜᶜ = l := by
+@[simp] lemma compl_compl (l : Language α) : lᶜᶜ = l := by
   simp [compl]
 
 end Language

--- a/Mathlib/Computability/Language.lean
+++ b/Mathlib/Computability/Language.lean
@@ -404,6 +404,11 @@ lemma reverse_pow (l : Language α) (n : ℕ) : (l ^ n).reverse = l.reverse ^ n 
 lemma reverse_kstar (l : Language α) : l∗.reverse = l.reverse∗ := by
   simp only [kstar_eq_iSup_pow, reverse_iSup, reverse_pow]
 
+instance : HasCompl (Language α) := ⟨compl⟩
+
+lemma compl_compl {l : Language α} : lᶜᶜ = l := by
+  simp [compl]
+
 end Language
 
 /-- Symbols for use by all kinds of grammars. -/

--- a/Mathlib/Computability/Language.lean
+++ b/Mathlib/Computability/Language.lean
@@ -35,7 +35,7 @@ with respect to other language operations.
   concatenated together. Note that this notation uses the Unicode asterisk operator `∗`, as opposed
   to the more common ASCII asterisk `*`.
 * `lᶜ`: complement, language of strings `x` such that `x ∉ l`
-* `l ∩ m`: intersection of languages `l` and `m`
+* `l ⊓ m`: intersection of languages `l` and `m`
 
 ## Main definitions
 
@@ -96,12 +96,6 @@ instance : Sub (Language α) where
 `x ∈ l` and `y ∈ m`. -/
 instance : Mul (Language α) :=
   ⟨image2 (· ++ ·)⟩
-
-instance : HasCompl (Language α) :=
-  ⟨((· ᶜ) : Set (List α) → Set (List α))⟩
-
-instance : Inter (Language α) :=
-  ⟨((· ∩ ·) : Set (List α) → Set (List α) → Set (List α))⟩
 
 theorem zero_def : (0 : Language α) = (∅ : Set _) :=
   rfl
@@ -413,7 +407,7 @@ lemma reverse_kstar (l : Language α) : l∗.reverse = l.reverse∗ := by
   simp only [kstar_eq_iSup_pow, reverse_iSup, reverse_pow]
 
 @[simp]
-lemma mem_inter (x : List α) (l m : Language α) : x ∈ l ∩ m ↔ x ∈ l ∧ x ∈ m := by
+lemma mem_inf (x : List α) (l m : Language α) : x ∈ l ⊓ m ↔ x ∈ l ∧ x ∈ m := by
   apply Set.mem_inter_iff
 
 lemma compl_compl {l : Language α} : lᶜᶜ = l := by

--- a/Mathlib/Computability/Language.lean
+++ b/Mathlib/Computability/Language.lean
@@ -410,7 +410,7 @@ lemma reverse_kstar (l : Language α) : l∗.reverse = l.reverse∗ := by
 lemma mem_inf {x : List α} {l m : Language α} : x ∈ l ⊓ m ↔ x ∈ l ∧ x ∈ m := by
   apply Set.mem_inter_iff
 
-@[simp] lemma compl_compl (l : Language α) : lᶜᶜ = l := by
+lemma compl_compl (l : Language α) : lᶜᶜ = l := by
   simp [compl]
 
 end Language

--- a/Mathlib/Computability/Language.lean
+++ b/Mathlib/Computability/Language.lean
@@ -95,6 +95,12 @@ instance : Sub (Language α) where
 instance : Mul (Language α) :=
   ⟨image2 (· ++ ·)⟩
 
+instance : HasCompl (Language α) :=
+  ⟨((· ᶜ) : Set (List α) → Set (List α))⟩
+
+instance : Inter (Language α) :=
+  ⟨((· ∩ ·) : Set (List α) → Set (List α) → Set (List α))⟩
+
 theorem zero_def : (0 : Language α) = (∅ : Set _) :=
   rfl
 
@@ -404,7 +410,9 @@ lemma reverse_pow (l : Language α) (n : ℕ) : (l ^ n).reverse = l.reverse ^ n 
 lemma reverse_kstar (l : Language α) : l∗.reverse = l.reverse∗ := by
   simp only [kstar_eq_iSup_pow, reverse_iSup, reverse_pow]
 
-instance : HasCompl (Language α) := ⟨compl⟩
+@[simp]
+lemma mem_inter (x : List α) (l m : Language α) : x ∈ l ∩ m ↔ x ∈ l ∧ x ∈ m := by
+  apply Set.mem_inter_iff
 
 lemma compl_compl {l : Language α} : lᶜᶜ = l := by
   simp [compl]


### PR DESCRIPTION
Add theorems for DFA complement, union, and intersection closure, and prove that regular languages are closed under complement, union, and intersection.

---

Note there's a [zulip discussion](https://leanprover.zulipchat.com/#narrow/channel/287929-mathlib4/topic/Regular.20languages.3A.20the.20review.20queue/with/553522644) regarding PRs for regular languages (also tracked in #24205). Admittedly, this is yet another PR, and this may prove obsolete if other PRs are merged first. In particular, this PR competes with #20238 and #15651.

<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

When merging, all the commits will be squashed into a single commit
listing all co-authors.

Co-authors in the squash commit are gathered from two sources:

First, all authors of commits to this PR branch are included. Thus,
one way to add co-authors is to include at least one commit authored by
each co-author among the commits in the pull request. If necessary, you
may create empty commits to indicate co-authorship, using commands like so:

git commit --author="Author Name <author@email.com>" --allow-empty -m "add Author Name as coauthor"

Second, co-authors can also be listed in lines at the very bottom of
the commit message (that is, directly before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines
at the bottom of the commit message (before the `---`, and also before
any "Co-authored-by" lines) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
