### PR TITLE
[Merged by Bors] - feat(LinearAlgebra/AffineSpace/Simplex/Basic): more `reindex` lemmas

### DIFF
--- a/Mathlib/LinearAlgebra/AffineSpace/Simplex/Basic.lean
+++ b/Mathlib/LinearAlgebra/AffineSpace/Simplex/Basic.lean
@@ -285,6 +285,12 @@ theorem restrict_map_subtype {n : ℕ} (s : Affine.Simplex k P n) :
     (s.restrict _ le_rfl).map (AffineSubspace.subtype _) Subtype.coe_injective = s :=
   rfl
 
+lemma restrict_reindex {m n : ℕ} (s : Affine.Simplex k P n) (e : Fin (n + 1) ≃ Fin (m + 1))
+    (S : AffineSubspace k P) (hS : affineSpan k (Set.range s.points) ≤ S) :
+    letI := Nonempty.map (AffineSubspace.inclusion hS) inferInstance
+    (s.reindex e).restrict S (s.reindex_range_points e ▸ hS) = (s.restrict S hS).reindex e :=
+  rfl
+
 end restrict
 
 end Simplex
@@ -312,6 +318,27 @@ lemma affineCombination_mem_setInterior_iff {I : Set k} {n : ℕ} {s : Simplex k
     s.independent w' w hw' hw hww']
   exact hw'01
 
+@[simp] lemma setInterior_reindex (I : Set k) {m n : ℕ} (s : Simplex k P n)
+    (e : Fin (n + 1) ≃ Fin (m + 1)) : (s.reindex e).setInterior I = s.setInterior I := by
+  ext p
+  refine ⟨fun ⟨w, hw, hwI, h⟩ ↦ ?_, fun ⟨w, hw, hwI, h⟩ ↦ ?_⟩
+  · subst h
+    simp_rw [reindex]
+    rw [← Function.comp_id w, ← e.self_comp_symm, ← Function.comp_assoc,
+      ← Equiv.coe_toEmbedding, ← Finset.univ.affineCombination_map e.symm.toEmbedding,
+      map_univ_equiv]
+    have hw' : ∑ i, (w ∘ e) i = 1 := by rwa [sum_comp_equiv, map_univ_equiv]
+    rw [affineCombination_mem_setInterior_iff hw']
+    exact fun i ↦ hwI (e i)
+  · subst h
+    rw [← Function.comp_id w, ← Function.comp_id s.points, ← e.symm_comp_self,
+      ← Function.comp_assoc, ← Function.comp_assoc, ← e.coe_toEmbedding,
+      ← Finset.univ.affineCombination_map e.toEmbedding, map_univ_equiv]
+    change Finset.univ.affineCombination k (s.reindex e).points _ ∈ _
+    have hw' : ∑ i, (w ∘ e.symm) i = 1 := by rwa [sum_comp_equiv, map_univ_equiv]
+    rw [affineCombination_mem_setInterior_iff hw']
+    exact fun i ↦ hwI (e.symm i)
+
 lemma setInterior_mono {I J : Set k} (hij : I ⊆ J) {n : ℕ} (s : Simplex k P n) :
     s.setInterior I ⊆ s.setInterior J :=
   fun _ ⟨w, hw, hw01, hww⟩ ↦ ⟨w, hw, fun i ↦ hij (hw01 i), hww⟩
@@ -329,6 +356,10 @@ interior of the convex hull of the vertices. -/
 protected def interior {n : ℕ} (s : Simplex k P n) : Set P :=
   s.setInterior (Set.Ioo 0 1)
 
+@[simp] lemma interior_reindex {m n : ℕ} (s : Simplex k P n) (e : Fin (n + 1) ≃ Fin (m + 1)) :
+    (s.reindex e).interior = s.interior :=
+  s.setInterior_reindex _ _
+
 lemma affineCombination_mem_interior_iff {n : ℕ} {s : Simplex k P n} {w : Fin (n + 1) → k}
     (hw : ∑ i, w i = 1) :
     Finset.univ.affineCombination k s.points w ∈ s.interior ↔ ∀ i, w i ∈ Set.Ioo 0 1 :=
@@ -339,6 +370,10 @@ of the vertices with weights between 0 and 1 inclusive. This is equivalent to th
 the vertices or the closure of the interior. -/
 protected def closedInterior {n : ℕ} (s : Simplex k P n) : Set P :=
   s.setInterior (Set.Icc 0 1)
+
+@[simp] lemma closedInterior_reindex {m n : ℕ} (s : Simplex k P n) (e : Fin (n + 1) ≃ Fin (m + 1)) :
+    (s.reindex e).closedInterior = s.closedInterior :=
+  s.setInterior_reindex _ _
 
 lemma affineCombination_mem_closedInterior_iff {n : ℕ} {s : Simplex k P n} {w : Fin (n + 1) → k}
     (hw : ∑ i, w i = 1) :

--- a/Mathlib/LinearAlgebra/AffineSpace/Simplex/Basic.lean
+++ b/Mathlib/LinearAlgebra/AffineSpace/Simplex/Basic.lean
@@ -286,7 +286,7 @@ theorem restrict_map_subtype {n : ℕ} (s : Affine.Simplex k P n) :
   rfl
 
 lemma restrict_reindex {m n : ℕ} (s : Affine.Simplex k P n) (e : Fin (n + 1) ≃ Fin (m + 1))
-    (S : AffineSubspace k P) (hS : affineSpan k (Set.range s.points) ≤ S) :
+    {S : AffineSubspace k P} (hS : affineSpan k (Set.range s.points) ≤ S) :
     letI := Nonempty.map (AffineSubspace.inclusion hS) inferInstance
     (s.reindex e).restrict S (s.reindex_range_points e ▸ hS) = (s.restrict S hS).reindex e :=
   rfl


### PR DESCRIPTION
Add lemmas about how `reindex` interacts with `restrict`, `setInterior`, `interior` and `closedInterior`.


---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

When merging, all the commits will be squashed into a single commit
listing all co-authors.

Co-authors in the squash commit are gathered from two sources:

First, all authors of commits to this PR branch are included. Thus,
one way to add co-authors is to include at least one commit authored by
each co-author among the commits in the pull request. If necessary, you
may create empty commits to indicate co-authorship, using commands like so:

git commit --author="Author Name <author@email.com>" --allow-empty -m "add Author Name as coauthor"

Second, co-authors can also be listed in lines at the very bottom of
the commit message (that is, directly before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines
at the bottom of the commit message (before the `---`, and also before
any "Co-authored-by" lines) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
