### PR TITLE
[Merged by Bors] - refactor(Dynamics): use `SetRel` notions of separation and cover

### DIFF
--- a/Mathlib/Data/Rel/Cover.lean
+++ b/Mathlib/Data/Rel/Cover.lean
@@ -16,7 +16,7 @@ entourage.
 A `U`-cover of a set `s` is a set `N` such that every element of `s` is `U`-close to some element of
 `N`.
 
-The concept of uniform covers can be used to define two further notions of covering:
+The concept of uniform covers is used to define two further notions of covering:
 * Metric covers: `Metric.IsCover`, defined using the distance entourage.
 * Dynamical covers: `Dynamics.IsDynCoverOf`, defined using the dynamical entourage.
 
@@ -64,6 +64,10 @@ lemma IsCover.anti (hst : s ⊆ t) (ht : IsCover U t N) : IsCover U s N := fun _
 lemma IsCover.mono_entourage (hUV : U ⊆ V) (hU : IsCover U s N) : IsCover V s N :=
   fun _x hx ↦ let ⟨y, hy, hxy⟩ := hU hx; ⟨y, hy, hUV hxy⟩
 
+lemma IsCover.union (hs : IsCover U s N₁) (ht : IsCover U t N₂) : IsCover U (s ∪ t) (N₁ ∪ N₂) := fun
+  | _x, .inl hx => let ⟨y, hy, hxy⟩ := hs hx; ⟨y, .inl hy, hxy⟩
+  | _x, .inr hx => let ⟨y, hy, hxy⟩ := ht hx; ⟨y, .inr hy, hxy⟩
+
 /-- A maximal `U`-separated subset of a set `s` is a `U`-cover of `s`.
 
 [R. Vershynin, *High Dimensional Probability*][vershynin2018high], 4.2.6. -/
@@ -74,6 +78,6 @@ lemma IsCover.of_maximal_isSeparated [U.IsRefl] [U.IsSymm]
   simpa [U.rfl] using h _ <| hN.2 (y := insert x N) ⟨by simp [insert_subset_iff, hx, hN.1.1],
     hN.1.2.insert fun y hy hxy ↦ (h y hy hxy).elim⟩ (subset_insert _ _) (mem_insert _ _)
 
-@[simp] lemma isCover_relId : IsCover .id s N ↔ s ⊆ N := by simp [IsCover, subset_def]
+@[simp] lemma isCover_id : IsCover .id s N ↔ s ⊆ N := by simp [IsCover, subset_def]
 
 end SetRel

--- a/Mathlib/Dynamics/TopologicalEntropy/CoverEntropy.lean
+++ b/Mathlib/Dynamics/TopologicalEntropy/CoverEntropy.lean
@@ -63,12 +63,12 @@ Get versions of the topological entropy on (pseudo-e)metric spaces.
 
 @[expose] public section
 
-open Set Uniformity UniformSpace
-open scoped SetRel
+open Set SetRel Uniformity UniformSpace
+open scoped Finset
 
 namespace Dynamics
 
-variable {X : Type*}
+variable {X : Type*} {T : X → X} {U V : SetRel X X} {n : ℕ} {F s : Set X} {m n : ℕ}
 
 /-! ### Dynamical covers -/
 
@@ -76,63 +76,44 @@ variable {X : Type*}
 dynamical cover of `F` if any orbit of length `n` in `F` is `U`-shadowed by an orbit of length `n`
 of a point in `s`. -/
 def IsDynCoverOf (T : X → X) (F : Set X) (U : SetRel X X) (n : ℕ) (s : Set X) : Prop :=
-  F ⊆ ⋃ x ∈ s, ball x (dynEntourage T U n)
+  IsCover (dynEntourage T U n) F s
 
-lemma IsDynCoverOf.of_le {T : X → X} {F : Set X} {U : SetRel X X} {m n : ℕ} (m_n : m ≤ n)
-    {s : Set X} (h : IsDynCoverOf T F U n s) :
-    IsDynCoverOf T F U m s :=
-  h.trans (iUnion₂_mono fun x _ ↦ ball_mono (dynEntourage_antitone T U m_n) x)
+lemma IsDynCoverOf.of_le (m_n : m ≤ n) (h : IsDynCoverOf T F U n s) : IsDynCoverOf T F U m s :=
+  h.mono_entourage <| by gcongr
 
-lemma IsDynCoverOf.of_entourage_subset {T : X → X} {F : Set X} {U V : SetRel X X} (U_V : U ⊆ V)
-    {n : ℕ} {s : Set X} (h : IsDynCoverOf T F U n s) :
-    IsDynCoverOf T F V n s :=
-  h.trans (iUnion₂_mono fun x _ ↦ ball_mono (dynEntourage_monotone T n U_V) x)
+lemma IsDynCoverOf.of_entourage_subset (U_V : U ⊆ V) (h : IsDynCoverOf T F U n s) :
+    IsDynCoverOf T F V n s := h.mono_entourage <| by gcongr
 
-@[simp]
-lemma isDynCoverOf_empty {T : X → X} {U : SetRel X X} {n : ℕ} {s : Set X} :
-    IsDynCoverOf T ∅ U n s := by
-  simp only [IsDynCoverOf, empty_subset]
+@[simp] lemma isDynCoverOf_empty : IsDynCoverOf T ∅ U n s := .empty
 
-lemma IsDynCoverOf.nonempty {T : X → X} {F : Set X} (h : F.Nonempty) {U : SetRel X X} {n : ℕ}
-    {s : Set X} (h' : IsDynCoverOf T F U n s) :
-    s.Nonempty := by
-  obtain ⟨x, x_s, _⟩ := nonempty_biUnion.1 (Nonempty.mono h' h)
-  exact nonempty_of_mem x_s
+@[simp] lemma isDynCoverOf_empty_right : IsDynCoverOf T F U n ∅ ↔ F = ∅ := by simp [IsDynCoverOf]
 
-lemma isDynCoverOf_zero (T : X → X) (F : Set X) (U : SetRel X X) {s : Set X} (h : s.Nonempty) :
-    IsDynCoverOf T F U 0 s := by
-  simp only [IsDynCoverOf, ball, dynEntourage, not_lt_zero', Prod.map_iterate, iInter_of_empty,
-    iInter_univ, preimage_univ]
-  obtain ⟨x, x_s⟩ := h
-  exact subset_iUnion₂_of_subset x x_s (subset_univ F)
+nonrec lemma IsDynCoverOf.nonempty (h : F.Nonempty) (h' : IsDynCoverOf T F U n s) : s.Nonempty :=
+  h'.nonempty h
 
-lemma isDynCoverOf_univ (T : X → X) (F : Set X) (n : ℕ) {s : Set X} (h : s.Nonempty) :
-    IsDynCoverOf T F univ n s := by
-  simp only [IsDynCoverOf, ball, dynEntourage, Prod.map_iterate, preimage_univ, iInter_univ]
-  obtain ⟨x, x_s⟩ := h
-  exact subset_iUnion₂_of_subset x x_s (subset_univ F)
+lemma isDynCoverOf_zero (T : X → X) (F : Set X) (U : SetRel X X) (h : s.Nonempty) :
+    IsDynCoverOf T F U 0 s := by simp [IsDynCoverOf, h]
 
-lemma IsDynCoverOf.nonempty_inter {T : X → X} {F : Set X} {U : SetRel X X} {n : ℕ} {s : Finset X}
-    (h : IsDynCoverOf T F U n s) :
-    ∃ t : Finset X, IsDynCoverOf T F U n t ∧ t.card ≤ s.card
-    ∧ ∀ x ∈ t, ((ball x (dynEntourage T U n)) ∩ F).Nonempty := by
+lemma isDynCoverOf_univ (T : X → X) (F : Set X) (n : ℕ) (h : s.Nonempty) :
+    IsDynCoverOf T F univ n s := by simp [IsDynCoverOf, h]
+
+lemma IsDynCoverOf.nonempty_inter [U.IsSymm] {s : Finset X} (h : IsDynCoverOf T F U n s) :
+    ∃ t : Finset X, IsDynCoverOf T F U n t ∧ #t ≤ #s ∧
+      ∀ x ∈ t, (ball x (dynEntourage T U n) ∩ F).Nonempty := by
   classical
-  use Finset.filter (fun x : X ↦ ((ball x (dynEntourage T U n)) ∩ F).Nonempty) s
+  use {x ∈ s | (ball x (dynEntourage T U n) ∩ F).Nonempty}
   simp only [Finset.coe_filter, Finset.mem_filter, and_imp, imp_self, implies_true, and_true]
-  refine ⟨fun y y_F ↦ ?_, Finset.card_mono (s.filter_subset _)⟩
-  specialize h y_F
-  simp only [mem_iUnion, exists_prop] at h
-  obtain ⟨z, z_s, y_Bz⟩ := h
-  simp only [mem_setOf_eq, mem_iUnion, exists_prop]
-  exact ⟨z, ⟨z_s, nonempty_of_mem ⟨y_Bz, y_F⟩⟩, y_Bz⟩
+  refine ⟨fun y y_F ↦ ?_, Finset.card_mono (Finset.filter_subset _ s)⟩
+  obtain ⟨z, z_s, y_Bz⟩ := h y_F
+  exact ⟨z, ⟨z_s, _, (dynEntourage T U n).symm y_Bz, y_F⟩, y_Bz⟩
 
 /-- From a dynamical cover `s` with entourage `U` and time `m`, we construct covers with entourage
 `U ○ U` and any multiple `m * n` of `m` with controlled cardinality. This lemma is the first step
 in a submultiplicative-like property of `coverMincard`, with consequences such as explicit bounds
 for the topological entropy (`coverEntropyInfEntourage_le_card_div`) and an equality between
 two notions of topological entropy (`coverEntropyInf_eq_coverEntropySup_of_inv`). -/
-lemma IsDynCoverOf.iterate_le_pow {T : X → X} {F : Set X} (F_inv : MapsTo T F F) {U : SetRel X X}
-    [U.IsSymm] {m : ℕ} (n : ℕ) {s : Finset X} (h : IsDynCoverOf T F U m s) :
+lemma IsDynCoverOf.iterate_le_pow (F_inv : MapsTo T F F) [U.IsSymm] (n : ℕ) {s : Finset X}
+    (h : IsDynCoverOf T F U m s) :
     ∃ t : Finset X, IsDynCoverOf T F (U ○ U) (m * n) t ∧ t.card ≤ s.card ^ n := by
   classical
   -- Deal with the edge cases: `F = ∅` or `m = 0`.
@@ -163,8 +144,8 @@ lemma IsDynCoverOf.iterate_le_pow {T : X → X} {F : Set X} (F_inv : MapsTo T F 
     · exact inter_empt ▸ ⟨x, empty_subset _⟩
     · obtain ⟨y, y_int⟩ := inter_nemp
       refine ⟨y, fun z z_int ↦ ?_⟩
-      simp only [ball, dynEntourage, Prod.map_iterate, mem_preimage, mem_iInter,
-        Prod.map_apply] at y_int z_int ⊢
+      simp only [ball, dynEntourage, Prod.map_iterate, mem_iInter, Set.mem_preimage, Prod.map_apply,
+        mem_comp] at y_int z_int ⊢
       intro k k_mn
       replace k_mn := Nat.div_lt_of_lt_mul k_mn
       specialize z_int ⟨(k / m), k_mn⟩ (k % m) (Nat.mod_lt k m_pos)
@@ -187,37 +168,33 @@ lemma IsDynCoverOf.iterate_le_pow {T : X → X} {F : Set X} (F_inv : MapsTo T F 
     have key : ∀ k : Fin n, ∃ z : s, y ∈ T^[m * k] ⁻¹' ball z (dynEntourage T U m) := by
       intro k
       have := h (MapsTo.iterate F_inv (m * k) y_F)
-      simp only [mem_iUnion, exists_prop] at this
+      simp only [Finset.mem_coe] at this
       obtain ⟨z, z_s, hz⟩ := this
-      exact ⟨⟨z, z_s⟩, hz⟩
+      exact ⟨⟨z, z_s⟩, (dynEntourage T U m).symm hz⟩
     choose! t ht using key
     simp only [toFinset_range, Finset.coe_image, Finset.coe_univ, image_univ, mem_range,
-      iUnion_exists, iUnion_iUnion_eq', mem_iUnion, sn]
-    use t
-    apply h_dyncover t
-    simp only [mem_iInter, mem_preimage] at ht ⊢
-    exact ht
+      exists_exists_eq_and, sn]
+    refine ⟨t, (dynEntourage T (U ○ U) (m * n)).symm <| h_dyncover t <| by simpa using ht⟩
   · rw [toFinset_card]
     apply (Fintype.card_range_le dyncover).trans
     simp only [Fintype.card_fun, Fintype.card_coe, Fintype.card_fin, le_refl]
 
-lemma exists_isDynCoverOf_of_isCompact_uniformContinuous [UniformSpace X] {T : X → X} {F : Set X}
-    (F_comp : IsCompact F) (h : UniformContinuous T) {U : SetRel X X} (U_uni : U ∈ 𝓤 X) (n : ℕ) :
+lemma exists_isDynCoverOf_of_isCompact_uniformContinuous [UniformSpace X]
+    (F_comp : IsCompact F) (h : UniformContinuous T) (U_uni : U ∈ 𝓤 X) (n : ℕ) :
     ∃ s : Finset X, IsDynCoverOf T F U n s := by
-  have uni_ite := dynEntourage_mem_uniformity h U_uni n
-  let open_cover := fun x : X ↦ ball x (dynEntourage T U n)
-  obtain ⟨s, _, s_cover⟩ := IsCompact.elim_nhds_subcover F_comp open_cover
-    fun (x : X) _ ↦ ball_mem_nhds x uni_ite
-  exact ⟨s, s_cover⟩
+  obtain ⟨(V : SetRel X X), hV, hVsymm, hVU⟩ := symm_of_uniformity U_uni
+  have uni_ite := dynEntourage_mem_uniformity h hV n
+  let openCover x := ball x (dynEntourage T V n)
+  obtain ⟨s, _, s_cover⟩ := F_comp.elim_nhds_subcover openCover fun x _ ↦ ball_mem_nhds x uni_ite
+  exact ⟨s, .of_entourage_subset hVU <| .of_subset_iUnion_ball s_cover⟩
 
-lemma exists_isDynCoverOf_of_isCompact_invariant [UniformSpace X] {T : X → X} {F : Set X}
-    (F_comp : IsCompact F) (F_inv : MapsTo T F F) {U : SetRel X X} (U_uni : U ∈ 𝓤 X) (n : ℕ) :
+lemma exists_isDynCoverOf_of_isCompact_invariant [UniformSpace X]
+    (F_comp : IsCompact F) (F_inv : MapsTo T F F) (U_uni : U ∈ 𝓤 X) (n : ℕ) :
     ∃ s : Finset X, IsDynCoverOf T F U n s := by
-  obtain ⟨V, V_uni, V_symm, V_U⟩ := comp_symm_mem_uniformity_sets U_uni
-  obtain ⟨s, _, s_cover⟩ := IsCompact.elim_nhds_subcover F_comp (fun x : X ↦ ball x V)
+  obtain ⟨(V : SetRel X X), V_uni, V_symm, V_U⟩ := comp_symm_mem_uniformity_sets U_uni
+  obtain ⟨s, _, s_cover⟩ := F_comp.elim_nhds_subcover (ball · V)
     fun (x : X) _ ↦ ball_mem_nhds x V_uni
-  have : IsDynCoverOf T F V 1 s := by
-    simp only [IsDynCoverOf, Finset.mem_coe, dynEntourage_one, s_cover]
+  have : IsDynCoverOf T F V 1 s := .of_subset_iUnion_ball <| by simpa using s_cover
   obtain ⟨t, t_dyncover, t_card⟩ := this.iterate_le_pow F_inv n
   rw [one_mul n] at t_dyncover
   exact ⟨t, t_dyncover.of_entourage_subset V_U⟩
@@ -229,8 +206,7 @@ lemma exists_isDynCoverOf_of_isCompact_invariant [UniformSpace X] {T : X → X} 
 noncomputable def coverMincard (T : X → X) (F : Set X) (U : SetRel X X) (n : ℕ) : ℕ∞ :=
   ⨅ (s : Finset X) (_ : IsDynCoverOf T F U n s), (s.card : ℕ∞)
 
-lemma IsDynCoverOf.coverMincard_le_card {T : X → X} {F : Set X} {U : SetRel X X} {n : ℕ}
-    {s : Finset X} (h : IsDynCoverOf T F U n s) :
+lemma IsDynCoverOf.coverMincard_le_card {s : Finset X} (h : IsDynCoverOf T F U n s) :
     coverMincard T F U n ≤ s.card :=
   iInf₂_le s h
 
@@ -263,24 +239,19 @@ lemma coverMincard_finite_iff (T : X → X) (F : Set X) (U : SetRel X X) (n : �
   exact key
 
 @[simp]
-lemma coverMincard_empty {T : X → X} {U : SetRel X X} {n : ℕ} : coverMincard T ∅ U n = 0 :=
+lemma coverMincard_empty : coverMincard T ∅ U n = 0 :=
   (sInf_le (by simp [IsDynCoverOf])).antisymm (zero_le (coverMincard T ∅ U n))
 
 lemma coverMincard_eq_zero_iff (T : X → X) (F : Set X) (U : SetRel X X) (n : ℕ) :
     coverMincard T F U n = 0 ↔ F = ∅ := by
-  refine ⟨fun h ↦ subset_empty_iff.1 ?_, fun F_empt ↦ by rw [F_empt, coverMincard_empty]⟩
-  have := coverMincard_finite_iff T F U n
-  rw [h, eq_true ENat.top_pos, true_iff] at this
-  simp only [IsDynCoverOf, Finset.mem_coe, Nat.cast_eq_zero, Finset.card_eq_zero, exists_eq_right,
-    Finset.notMem_empty, iUnion_of_empty, iUnion_empty] at this
-  exact this
+  simp [coverMincard, ENat.iInf_eq_zero]
 
 lemma one_le_coverMincard_iff (T : X → X) (F : Set X) (U : SetRel X X) (n : ℕ) :
     1 ≤ coverMincard T F U n ↔ F.Nonempty := by
   rw [ENat.one_le_iff_ne_zero, nonempty_iff_ne_empty, not_iff_not]
   exact coverMincard_eq_zero_iff T F U n
 
-lemma coverMincard_zero (T : X → X) {F : Set X} (h : F.Nonempty) (U : SetRel X X) :
+lemma coverMincard_zero (T : X → X) (h : F.Nonempty) (U : SetRel X X) :
     coverMincard T F U 0 = 1 := by
   apply le_antisymm _ ((one_le_coverMincard_iff T F U 0).2 h)
   obtain ⟨x, _⟩ := h
@@ -289,8 +260,7 @@ lemma coverMincard_zero (T : X → X) {F : Set X} (h : F.Nonempty) (U : SetRel X
   apply this.coverMincard_le_card.trans_eq
   rw [Finset.card_singleton, Nat.cast_one]
 
-lemma coverMincard_univ (T : X → X) {F : Set X} (h : F.Nonempty) (n : ℕ) :
-    coverMincard T F univ n = 1 := by
+lemma coverMincard_univ (T : X → X) (h : F.Nonempty) (n : ℕ) : coverMincard T F univ n = 1 := by
   apply le_antisymm _ ((one_le_coverMincard_iff T F univ n).2 h)
   obtain ⟨x, _⟩ := h
   have := isDynCoverOf_univ T F n (singleton_nonempty x)
@@ -298,8 +268,7 @@ lemma coverMincard_univ (T : X → X) {F : Set X} (h : F.Nonempty) (n : ℕ) :
   apply this.coverMincard_le_card.trans_eq
   rw [Finset.card_singleton, Nat.cast_one]
 
-lemma coverMincard_mul_le_pow {T : X → X} {F : Set X} (F_inv : MapsTo T F F) {U : SetRel X X}
-    [U.IsSymm] (m n : ℕ) :
+lemma coverMincard_mul_le_pow (F_inv : MapsTo T F F) [U.IsSymm] (m n : ℕ) :
     coverMincard T F (U ○ U) (m * n) ≤ coverMincard T F U m ^ n := by
   rcases F.eq_empty_or_nonempty with rfl | F_nonempty
   · rw [coverMincard_empty]; exact zero_le _
@@ -312,21 +281,19 @@ lemma coverMincard_mul_le_pow {T : X → X} {F : Set X} (F_inv : MapsTo T F F) {
     rw [← s_coverMincard]
     exact t_cover.coverMincard_le_card.trans (WithTop.coe_le_coe.2 t_sn)
 
-lemma coverMincard_le_pow {T : X → X} {F : Set X} (F_inv : MapsTo T F F) {U : SetRel X X}
-    [U.IsSymm] {m : ℕ} (m_pos : 0 < m) (n : ℕ) :
+lemma coverMincard_le_pow (F_inv : MapsTo T F F) [U.IsSymm] (m_pos : 0 < m) (n : ℕ) :
     coverMincard T F (U ○ U) n ≤ coverMincard T F U m ^ (n / m + 1) :=
   (coverMincard_monotone_time T F (U ○ U) (Nat.lt_mul_div_succ n m_pos).le).trans
     (coverMincard_mul_le_pow F_inv m (n / m + 1))
 
-lemma coverMincard_finite_of_isCompact_uniformContinuous [UniformSpace X] {T : X → X}
-    {F : Set X} (F_comp : IsCompact F) (h : UniformContinuous T) {U : SetRel X X} (U_uni : U ∈ 𝓤 X)
-    (n : ℕ) :
+lemma coverMincard_finite_of_isCompact_uniformContinuous [UniformSpace X] (F_comp : IsCompact F)
+    (h : UniformContinuous T) (U_uni : U ∈ 𝓤 X) (n : ℕ) :
     coverMincard T F U n < ⊤ := by
   obtain ⟨s, s_cover⟩ := exists_isDynCoverOf_of_isCompact_uniformContinuous F_comp h U_uni n
   exact s_cover.coverMincard_le_card.trans_lt (WithTop.coe_lt_top s.card)
 
-lemma coverMincard_finite_of_isCompact_invariant [UniformSpace X] {T : X → X} {F : Set X}
-    (F_comp : IsCompact F) (F_inv : MapsTo T F F) {U : SetRel X X} (U_uni : U ∈ 𝓤 X) (n : ℕ) :
+lemma coverMincard_finite_of_isCompact_invariant [UniformSpace X] (F_comp : IsCompact F)
+    (F_inv : MapsTo T F F) (U_uni : U ∈ 𝓤 X) (n : ℕ) :
     coverMincard T F U n < ⊤ := by
   obtain ⟨s, s_cover⟩ := exists_isDynCoverOf_of_isCompact_invariant F_comp F_inv U_uni n
   exact s_cover.coverMincard_le_card.trans_lt (WithTop.coe_lt_top s.card)
@@ -334,8 +301,8 @@ lemma coverMincard_finite_of_isCompact_invariant [UniformSpace X] {T : X → X} 
 /-- All dynamical balls of a minimal dynamical cover of `F` intersect `F`. This lemma is the key
   to relate Bowen-Dinaburg's definition of topological entropy with covers and their definition
   of topological entropy with nets. -/
-lemma nonempty_inter_of_coverMincard {T : X → X} {F : Set X} {U : SetRel X X} {n : ℕ}
-    {s : Finset X} (h : IsDynCoverOf T F U n s) (h' : s.card = coverMincard T F U n) :
+lemma nonempty_inter_of_coverMincard [U.IsSymm] {s : Finset X} (h : IsDynCoverOf T F U n s)
+    (h' : #s = coverMincard T F U n) :
     ∀ x ∈ s, (F ∩ ball x (dynEntourage T U n)).Nonempty := by
   -- Otherwise, there is a ball which does not intersect `F`. Removing it yields a smaller cover.
   classical
@@ -344,13 +311,13 @@ lemma nonempty_inter_of_coverMincard {T : X → X} {F : Set X} {U : SetRel X X} 
   have smaller_cover : IsDynCoverOf T F U n (s.erase x) := by
     intro y y_F
     specialize h y_F
-    simp only [s.mem_coe, mem_iUnion, exists_prop] at h
-    simp only [s.coe_erase, mem_diff, s.mem_coe, mem_singleton_iff, mem_iUnion, exists_prop]
+    simp only [s.mem_coe] at h
+    simp only [s.coe_erase, mem_diff, s.mem_coe, mem_singleton_iff]
     obtain ⟨z, z_s, hz⟩ := h
     refine ⟨z, ⟨z_s, fun z_x ↦ notMem_empty y ?_⟩, hz⟩
     rw [← ball_empt]
     rw [z_x] at hz
-    exact mem_inter y_F hz
+    exact mem_inter y_F <| (dynEntourage T U n).symm hz
   apply smaller_cover.coverMincard_le_card.not_gt
   rw [← h']
   exact_mod_cast s.card_erase_lt_of_mem x_s
@@ -384,17 +351,15 @@ lemma coverEntropyInfEntourage_le_coverEntropyEntourage (T : X → X) (F : Set X
   expGrowthInf_le_expGrowthSup
 
 @[simp]
-lemma coverEntropyEntourage_empty {T : X → X} {U : SetRel X X} :
-    coverEntropyEntourage T ∅ U = ⊥ := by
+lemma coverEntropyEntourage_empty : coverEntropyEntourage T ∅ U = ⊥ := by
   simp only [coverEntropyEntourage, coverMincard_empty]
   rw [ENat.toENNReal_zero, ← Pi.zero_def, expGrowthSup_zero]
 
 @[simp]
-lemma coverEntropyInfEntourage_empty {T : X → X} {U : SetRel X X} :
-    coverEntropyInfEntourage T ∅ U = ⊥ :=
+lemma coverEntropyInfEntourage_empty : coverEntropyInfEntourage T ∅ U = ⊥ :=
   eq_bot_mono (coverEntropyInfEntourage_le_coverEntropyEntourage T ∅ U) coverEntropyEntourage_empty
 
-lemma coverEntropyInfEntourage_nonneg (T : X → X) {F : Set X} (h : F.Nonempty) (U : SetRel X X) :
+lemma coverEntropyInfEntourage_nonneg (T : X → X) (h : F.Nonempty) (U : SetRel X X) :
     0 ≤ coverEntropyInfEntourage T F U := by
   apply Monotone.expGrowthInf_nonneg
   · exact fun _ _ m_n ↦ ENat.toENNReal_mono (coverMincard_monotone_time T F U m_n)
@@ -403,23 +368,23 @@ lemma coverEntropyInfEntourage_nonneg (T : X → X) {F : Set X} (h : F.Nonempty)
     rw [coverMincard_zero T h U, Pi.zero_apply, ENat.toENNReal_one]
     exact one_ne_zero
 
-lemma coverEntropyEntourage_nonneg (T : X → X) {F : Set X} (h : F.Nonempty) (U : SetRel X X) :
+lemma coverEntropyEntourage_nonneg (T : X → X) (h : F.Nonempty) (U : SetRel X X) :
     0 ≤ coverEntropyEntourage T F U :=
   (coverEntropyInfEntourage_nonneg T h U).trans
     (coverEntropyInfEntourage_le_coverEntropyEntourage T F U)
 
-lemma coverEntropyEntourage_univ (T : X → X) {F : Set X} (h : F.Nonempty) :
+lemma coverEntropyEntourage_univ (T : X → X) (h : F.Nonempty) :
     coverEntropyEntourage T F univ = 0 := by
   rw [← expGrowthSup_const one_ne_zero one_ne_top, coverEntropyEntourage]
   simp only [coverMincard_univ T h, ENat.toENNReal_one]
 
-lemma coverEntropyInfEntourage_univ (T : X → X) {F : Set X} (h : F.Nonempty) :
+lemma coverEntropyInfEntourage_univ (T : X → X) (h : F.Nonempty) :
     coverEntropyInfEntourage T F univ = 0 := by
   rw [← expGrowthInf_const one_ne_zero one_ne_top, coverEntropyInfEntourage]
   simp only [coverMincard_univ T h, ENat.toENNReal_one]
 
-lemma coverEntropyEntourage_le_log_coverMincard_div {T : X → X} {F : Set X} (F_inv : MapsTo T F F)
-    {U : SetRel X X} [U.IsSymm] {n : ℕ} (n_pos : n ≠ 0) :
+lemma coverEntropyEntourage_le_log_coverMincard_div (F_inv : MapsTo T F F) [U.IsSymm]
+    (n_pos : n ≠ 0) :
     coverEntropyEntourage T F (U ○ U) ≤ log (coverMincard T F U n) / n := by
   have cv_mono : Monotone fun m ↦ (coverMincard T F (U ○ U) m).toENNReal :=
     fun _ _ k_m ↦ ENat.toENNReal_mono (coverMincard_monotone_time T F (U ○ U) k_m)
@@ -432,22 +397,20 @@ lemma coverEntropyEntourage_le_log_coverMincard_div {T : X → X} {F : Set X} (F
   rw [← ENat.toENNReal_pow]
   exact ENat.toENNReal_mono (coverMincard_mul_le_pow F_inv n m)
 
-lemma IsDynCoverOf.coverEntropyEntourage_le_log_card_div {T : X → X} {F : Set X}
-    (F_inv : MapsTo T F F) {U : SetRel X X} [U.IsSymm] {n : ℕ} (n_pos : n ≠ 0)
-    {s : Finset X} (h : IsDynCoverOf T F U n s) :
+lemma IsDynCoverOf.coverEntropyEntourage_le_log_card_div (F_inv : MapsTo T F F) [U.IsSymm]
+    (n_pos : n ≠ 0) {s : Finset X} (h : IsDynCoverOf T F U n s) :
     coverEntropyEntourage T F (U ○ U) ≤ log s.card / n := by
   apply (coverEntropyEntourage_le_log_coverMincard_div F_inv n_pos).trans
   apply monotone_div_right_of_nonneg n.cast_nonneg' (log_monotone _)
   exact_mod_cast coverMincard_le_card h
 
-lemma coverEntropyEntourage_le_coverEntropyInfEntourage {T : X → X} {F : Set X}
-    (F_inv : MapsTo T F F) {U : SetRel X X} [U.IsSymm] :
+lemma coverEntropyEntourage_le_coverEntropyInfEntourage (F_inv : MapsTo T F F) [U.IsSymm] :
     coverEntropyEntourage T F (U ○ U) ≤ coverEntropyInfEntourage T F U := by
   refine (le_liminf_of_le) (eventually_atTop.2 ⟨1, fun m m_pos ↦ ?_⟩)
   exact coverEntropyEntourage_le_log_coverMincard_div F_inv (Nat.one_le_iff_ne_zero.1 m_pos)
 
-lemma coverEntropyEntourage_finite_of_isCompact_invariant [UniformSpace X] {T : X → X} {F : Set X}
-    (F_comp : IsCompact F) (F_inv : MapsTo T F F) {U : SetRel X X} (U_uni : U ∈ 𝓤 X) :
+lemma coverEntropyEntourage_finite_of_isCompact_invariant [UniformSpace X]
+    (F_comp : IsCompact F) (F_inv : MapsTo T F F) (U_uni : U ∈ 𝓤 X) :
     coverEntropyEntourage T F U < ⊤ := by
   obtain ⟨V, V_uni, V_symm, V_U⟩ := comp_symm_mem_uniformity_sets U_uni
   obtain ⟨s, s_cover⟩ := exists_isDynCoverOf_of_isCompact_invariant F_comp F_inv V_uni 1
@@ -482,12 +445,12 @@ lemma coverEntropy_antitone (T : X → X) (F : Set X) :
 
 variable [UniformSpace X]
 
-lemma coverEntropyEntourage_le_coverEntropy (T : X → X) (F : Set X) {U : SetRel X X}
+lemma coverEntropyEntourage_le_coverEntropy (T : X → X) (F : Set X)
     (h : U ∈ 𝓤 X) :
     coverEntropyEntourage T F U ≤ coverEntropy T F :=
   le_iSup₂ (f := fun (U : SetRel X X) (_ : U ∈ 𝓤 X) ↦ coverEntropyEntourage T F U) U h
 
-lemma coverEntropyInfEntourage_le_coverEntropyInf (T : X → X) (F : Set X) {U : SetRel X X}
+lemma coverEntropyInfEntourage_le_coverEntropyInf (T : X → X) (F : Set X)
     (h : U ∈ 𝓤 X) :
     coverEntropyInfEntourage T F U ≤ coverEntropyInf T F :=
   le_iSup₂ (f := fun (U : SetRel X X) (_ : U ∈ 𝓤 X) ↦ coverEntropyInfEntourage T F U) U h
@@ -516,23 +479,21 @@ lemma coverEntropyInf_le_coverEntropy (T : X → X) (F : Set X) :
     coverEntropyInfEntourage_le_coverEntropyEntourage T F U
 
 @[simp]
-lemma coverEntropy_empty {T : X → X} : coverEntropy T ∅ = ⊥ := by
+lemma coverEntropy_empty : coverEntropy T ∅ = ⊥ := by
   simp only [coverEntropy, coverEntropyEntourage_empty, iSup_bot]
 
 @[simp]
-lemma coverEntropyInf_empty {T : X → X} : coverEntropyInf T ∅ = ⊥ := by
+lemma coverEntropyInf_empty : coverEntropyInf T ∅ = ⊥ := by
   simp only [coverEntropyInf, coverEntropyInfEntourage_empty, iSup_bot]
 
-lemma coverEntropyInf_nonneg (T : X → X) {F : Set X} (h : F.Nonempty) :
-    0 ≤ coverEntropyInf T F :=
+lemma coverEntropyInf_nonneg (T : X → X) (h : F.Nonempty) : 0 ≤ coverEntropyInf T F :=
   (coverEntropyInfEntourage_le_coverEntropyInf T F univ_mem).trans_eq'
     (coverEntropyInfEntourage_univ T h).symm
 
-lemma coverEntropy_nonneg (T : X → X) {F : Set X} (h : F.Nonempty) :
-    0 ≤ coverEntropy T F :=
+lemma coverEntropy_nonneg (T : X → X) (h : F.Nonempty) : 0 ≤ coverEntropy T F :=
   (coverEntropyInf_nonneg T h).trans (coverEntropyInf_le_coverEntropy T F)
 
-lemma coverEntropyInf_eq_coverEntropy (T : X → X) {F : Set X} (h : MapsTo T F F) :
+lemma coverEntropyInf_eq_coverEntropy (T : X → X) (h : MapsTo T F F) :
     coverEntropyInf T F = coverEntropy T F := by
   refine le_antisymm (coverEntropyInf_le_coverEntropy T F) (iSup₂_le fun U U_uni ↦ ?_)
   obtain ⟨V, V_uni, V_symm, V_U⟩ := comp_symm_mem_uniformity_sets U_uni

--- a/Mathlib/Dynamics/TopologicalEntropy/DynamicalEntourage.lean
+++ b/Mathlib/Dynamics/TopologicalEntropy/DynamicalEntourage.lean
@@ -44,7 +44,7 @@ namespace Dynamics
 open Prod Set UniformSpace
 open scoped SetRel Topology Uniformity
 
-variable {X : Type*} {T : X → X} {U : SetRel X X} {n : ℕ} {x y : X}
+variable {X : Type*} {T : X → X} {U V : SetRel X X} {m n : ℕ} {x y : X}
 
 /-- The dynamical entourage associated to a transformation `T`, entourage `U` and time `n`
 is the entourage where `x` and `y` are close iff `T^[k] x` and `T^[k] y` are `U`-close
@@ -124,6 +124,10 @@ lemma dynEntourage_monotone (T : X → X) (n : ℕ) :
 lemma dynEntourage_antitone (T : X → X) (U : SetRel X X) :
     Antitone (fun n : ℕ ↦ dynEntourage T U n) :=
   fun m n m_n ↦ iInter₂_mono' fun k k_m ↦ by use k, lt_of_lt_of_le k_m m_n
+
+@[gcongr]
+lemma dynEntourage_mono (hUV : U ⊆ V) (hmn : m ≤ n) : dynEntourage T U n ⊆ dynEntourage T V m :=
+  (dynEntourage_monotone _ _ hUV).trans (dynEntourage_antitone _ _ hmn)
 
 @[simp] lemma dynEntourage_zero : dynEntourage T U 0 = univ := by simp [dynEntourage]
 @[simp] lemma dynEntourage_one : dynEntourage T U 1 = U := by simp [dynEntourage]

--- a/Mathlib/Dynamics/TopologicalEntropy/NetEntropy.lean
+++ b/Mathlib/Dynamics/TopologicalEntropy/NetEntropy.lean
@@ -83,15 +83,12 @@ lemma isDynNetIn_singleton (T : X → X) (U : SetRel X X) (n : ℕ) (h : x ∈ F
 /-- Given an entourage `U` and a time `n`, a dynamical net has a smaller cardinality than
   a dynamical cover. This lemma is the first of two key results to compare two versions of
   topological entropy: with cover and with nets, the second being `coverMincard_le_netMaxcard`. -/
-lemma IsDynNetIn.card_le_card_of_isDynCoverOf [U.IsSymm] {s t : Finset X}
+lemma IsDynNetIn.card_le_card_of_isDynCoverOf {s t : Finset X}
     (hs : IsDynNetIn T F U n s) (ht : IsDynCoverOf T F U n t) :
     s.card ≤ t.card := by
-  have (x : X) (x_s : x ∈ s) : ∃ z ∈ t, x ∈ ball z (dynEntourage T U n) := by
-    specialize ht (hs.1 x_s)
-    simp only [mem_iUnion, exists_prop] at ht
-    exact ht
+  have (x : X) (x_s : x ∈ s) : ∃ z ∈ t, z ∈ ball x (dynEntourage T U n) := by
+    simpa using ht (hs.1 x_s)
   choose! F s_t using this
-  simp only [mem_ball_symmetry] at s_t
   apply Finset.card_le_card_of_injOn F fun x x_s ↦ (s_t x x_s).1
   exact fun x x_s y y_s Fx_Fy ↦
     PairwiseDisjoint.elim_set hs.2 x_s y_s (F x) (s_t x x_s).2 (Fx_Fy ▸ (s_t y y_s).2)
@@ -206,7 +203,7 @@ lemma netMaxcard_infinite_iff (T : X → X) (F : Set X) (U : SetRel X X) (n : �
     rw [ENat.some_eq_coe, Nat.cast_lt]
     exact (lt_add_one k).trans_le s_card
 
-lemma netMaxcard_le_coverMincard (T : X → X) (F : Set X) [U.IsSymm] (n : ℕ) :
+lemma netMaxcard_le_coverMincard (T : X → X) (F : Set X) (n : ℕ) :
     netMaxcard T F U n ≤ coverMincard T F U n := by
   rcases eq_top_or_lt_top (coverMincard T F U n) with h | h
   · exact h ▸ le_top
@@ -229,6 +226,7 @@ lemma coverMincard_le_netMaxcard (T : X → X) (F : Set X) [U.IsRefl] [U.IsSymm]
   --  We have to check that `s` is a cover for `dynEntourage T F (U ○ U) n`.
   -- If `s` is not a cover, then we can add to `s` a point `x` which is not covered
   -- and get a new net. This contradicts the maximality of `s`.
+  rw [IsDynCoverOf, isCover_iff_subset_iUnion_ball]
   by_contra h
   obtain ⟨x, x_F, x_uncov⟩ := not_subset.1 h
   simp only [Finset.mem_coe, mem_iUnion, exists_prop, not_exists, not_and] at x_uncov
@@ -304,7 +302,7 @@ lemma netEntropyEntourage_univ (T : X → X) {F : Set X} (h : F.Nonempty) :
   rw [← expGrowthSup_const one_ne_zero one_ne_top, netEntropyEntourage]
   simp only [netMaxcard_univ T h, ENat.toENNReal_one]
 
-lemma netEntropyInfEntourage_le_coverEntropyInfEntourage (T : X → X) (F : Set X) [U.IsSymm] :
+lemma netEntropyInfEntourage_le_coverEntropyInfEntourage (T : X → X) (F : Set X) :
     netEntropyInfEntourage T F U ≤ coverEntropyInfEntourage T F U :=
   expGrowthInf_monotone fun n ↦ ENat.toENNReal_mono (netMaxcard_le_coverMincard T F n)
 
@@ -313,7 +311,7 @@ lemma coverEntropyInfEntourage_le_netEntropyInfEntourage (T : X → X) (F : Set 
     coverEntropyInfEntourage T F (U ○ U) ≤ netEntropyInfEntourage T F U :=
   expGrowthInf_monotone fun n ↦ ENat.toENNReal_mono (coverMincard_le_netMaxcard T F n)
 
-lemma netEntropyEntourage_le_coverEntropyEntourage (T : X → X) (F : Set X) [U.IsSymm] :
+lemma netEntropyEntourage_le_coverEntropyEntourage (T : X → X) (F : Set X) :
     netEntropyEntourage T F U ≤ coverEntropyEntourage T F U :=
   expGrowthSup_monotone fun n ↦ ENat.toENNReal_mono (netMaxcard_le_coverMincard T F n)
 

--- a/Mathlib/Dynamics/TopologicalEntropy/Semiconj.lean
+++ b/Mathlib/Dynamics/TopologicalEntropy/Semiconj.lean
@@ -64,9 +64,10 @@ variable {X Y : Type*} {s F : Set X} {V : SetRel Y Y} {S : X → X} {T : Y → Y
 
 lemma IsDynCoverOf.image (h : Semiconj φ S T) (h' : IsDynCoverOf S F (map φ φ ⁻¹' V) n s) :
     IsDynCoverOf T (φ '' F) V n (φ '' s) := by
-  simp only [IsDynCoverOf, image_subset_iff, preimage_iUnion₂, biUnion_image]
-  refine h'.trans (iUnion₂_mono fun i _ ↦ subset_of_eq ?_)
-  rw [← h.preimage_dynEntourage V n, ball_preimage]
+  rintro _ ⟨x, hx, rfl⟩
+  obtain ⟨y, hy, hxy⟩ := h' hx
+  refine ⟨_, Set.mem_image_of_mem _ hy, show (x, y) ∈ map φ φ ⁻¹' dynEntourage T V n from ?_⟩
+  rwa [h.preimage_dynEntourage V n]
 
 lemma IsDynCoverOf.preimage (h : Semiconj φ S T) [V.IsSymm] {t : Finset Y}
     (h' : IsDynCoverOf T (φ '' F) V n t) :
@@ -79,18 +80,15 @@ lemma IsDynCoverOf.preimage (h : Semiconj φ S T) [V.IsSymm] {t : Finset Y}
   -- and may not even be in the range of `φ`. Hence, we first modify `t` to make it a subset
   -- of `φ '' F`. This requires taking larger entourages.
   obtain ⟨s, s_cover, s_card, s_inter⟩ := h'.nonempty_inter
-  choose! g gs_cover using fun (x : Y) (h : x ∈ s) ↦ nonempty_def.1 (s_inter x h)
-  choose! f f_section using fun (y : Y) (a : y ∈ φ '' F) ↦ a
-  refine ⟨s.image (f ∘ g), ?_, Finset.card_image_le.trans s_card⟩
-  simp only [IsDynCoverOf, Finset.mem_coe, image_subset_iff, preimage_iUnion₂] at s_cover ⊢
-  apply s_cover.trans
-  rw [← h.preimage_dynEntourage (V ○ V) n, Finset.set_biUnion_finset_image]
-  refine iUnion₂_mono fun i i_s ↦ ?_
-  rw [comp_apply, ball_preimage, (f_section (g i) (gs_cover i i_s).2).2]
-  refine preimage_mono fun x x_i ↦ mem_ball_dynEntourage_comp T n x (g i) ⟨i, ?_⟩
-  replace gs_cover := (gs_cover i i_s).1
-  rw [mem_ball_symmetry] at x_i gs_cover
-  exact ⟨x_i, gs_cover⟩
+  choose! g g_rel g_mem using fun (x : Y) (h : x ∈ s) ↦ nonempty_def.1 (s_inter x h)
+  choose! f _ φ_f using fun (y : Y) (hy : y ∈ φ '' F) ↦ hy
+  refine ⟨s.image (f ∘ g), fun x hx ↦ ?_, Finset.card_image_le.trans s_card⟩
+  simp only [Finset.coe_image, comp_apply, mem_image, SetLike.mem_coe, ← h.preimage_dynEntourage,
+    mem_preimage, map_apply, exists_exists_and_eq_and]
+  obtain ⟨y, hy, hxy⟩ := s_cover (Set.mem_image_of_mem _ hx)
+  refine ⟨y, hy, dynEntourage_comp_subset _ _ _ _ ⟨_, hxy, ?_⟩⟩
+  rw [φ_f _ (g_mem _ hy)]
+  exact g_rel _ hy
 
 lemma le_coverMincard_image (h : Semiconj φ S T) (F : Set X) [V.IsSymm] (n : ℕ) :
     coverMincard S F ((map φ φ) ⁻¹' (V ○ V)) n ≤ coverMincard T (φ '' F) V n := by
@@ -135,11 +133,14 @@ lemma coverEntropyInfEntourage_image_le (h : Semiconj φ S T) (F : Set X) (V : S
 theorem coverEntropy_image_of_comap (u : UniformSpace Y) {S : X → X} {T : Y → Y} {φ : X → Y}
     (h : Semiconj φ S T) (F : Set X) :
     coverEntropy T (φ '' F) = @coverEntropy X (comap φ u) S F := by
+  let : UniformSpace X := comap φ u
   apply le_antisymm
-  · refine iSup₂_le fun V V_uni ↦ (coverEntropyEntourage_image_le h F V).trans ?_
-    apply @coverEntropyEntourage_le_coverEntropy X (comap φ u) S F
+  · refine iSup₂_le fun V V_uni ↦
+      (coverEntropyEntourage_antitone _ _ SetRel.symmetrize_subset_self).trans <|
+      (coverEntropyEntourage_image_le h F _).trans ?_
+    apply coverEntropyEntourage_le_coverEntropy
     rw [uniformity_comap φ, mem_comap]
-    exact ⟨V, V_uni, Subset.rfl⟩
+    exact ⟨_, symmetrize_mem_uniformity V_uni, .rfl⟩
   · refine iSup₂_le fun U U_uni ↦ ?_
     simp only [uniformity_comap φ, mem_comap] at U_uni
     obtain ⟨V, V_uni, V_sub⟩ := U_uni
@@ -153,11 +154,14 @@ theorem coverEntropy_image_of_comap (u : UniformSpace Y) {S : X → X} {T : Y �
 theorem coverEntropyInf_image_of_comap (u : UniformSpace Y) {S : X → X} {T : Y → Y} {φ : X → Y}
     (h : Semiconj φ S T) (F : Set X) :
     coverEntropyInf T (φ '' F) = @coverEntropyInf X (comap φ u) S F := by
+  let : UniformSpace X := comap φ u
   apply le_antisymm
-  · refine iSup₂_le fun V V_uni ↦ (coverEntropyInfEntourage_image_le h F V).trans ?_
-    apply @coverEntropyInfEntourage_le_coverEntropyInf X (comap φ u) S F
+  · refine iSup₂_le fun V V_uni ↦
+      (coverEntropyInfEntourage_antitone _ _ SetRel.symmetrize_subset_self).trans <|
+      (coverEntropyInfEntourage_image_le h F _).trans ?_
+    apply coverEntropyInfEntourage_le_coverEntropyInf
     rw [uniformity_comap φ, mem_comap]
-    exact ⟨V, V_uni, Subset.rfl⟩
+    exact ⟨_, symmetrize_mem_uniformity V_uni, .rfl⟩
   · refine iSup₂_le fun U U_uni ↦ ?_
     simp only [uniformity_comap φ, mem_comap] at U_uni
     obtain ⟨V, V_uni, V_sub⟩ := U_uni

--- a/Mathlib/Dynamics/TopologicalEntropy/Subset.lean
+++ b/Mathlib/Dynamics/TopologicalEntropy/Subset.lean
@@ -41,46 +41,43 @@ namespace Dynamics
 open ExpGrowth Set UniformSpace
 open scoped SetRel Uniformity
 
-variable {X : Type*}
+variable {X : Type*} {T : X → X} {F G s t : Set X} {U V : SetRel X X} {n : ℕ}
 
 /-! ### Monotonicity of entropy as a function of the subset -/
 
 section Subset
 
-lemma IsDynCoverOf.monotone_subset {T : X → X} {F G : Set X} (F_G : F ⊆ G) {U : Set (X × X)} {n : ℕ}
-    {s : Set X} (h : IsDynCoverOf T G U n s) :
+lemma IsDynCoverOf.monotone_subset (F_G : F ⊆ G) (h : IsDynCoverOf T G U n s) :
     IsDynCoverOf T F U n s :=
   F_G.trans h
 
-lemma IsDynNetIn.monotone_subset {T : X → X} {F G : Set X} (F_G : F ⊆ G) {U : Set (X × X)} {n : ℕ}
-    {s : Set X} (h : IsDynNetIn T F U n s) :
-    IsDynNetIn T G U n s :=
+lemma IsDynNetIn.monotone_subset (F_G : F ⊆ G) (h : IsDynNetIn T F U n s) : IsDynNetIn T G U n s :=
   ⟨h.1.trans F_G, h.2⟩
 
-lemma coverMincard_monotone_subset (T : X → X) (U : Set (X × X)) (n : ℕ) :
+lemma coverMincard_monotone_subset (T : X → X) (U : SetRel X X) (n : ℕ) :
     Monotone fun F : Set X ↦ coverMincard T F U n :=
   fun _ _ F_G ↦ biInf_mono fun _ h ↦ h.monotone_subset F_G
 
-lemma netMaxcard_monotone_subset (T : X → X) (U : Set (X × X)) (n : ℕ) :
+lemma netMaxcard_monotone_subset (T : X → X) (U : SetRel X X) (n : ℕ) :
     Monotone fun F : Set X ↦ netMaxcard T F U n :=
   fun _ _ F_G ↦ biSup_mono fun _ h ↦ h.monotone_subset F_G
 
-lemma coverEntropyInfEntourage_monotone (T : X → X) (U : Set (X × X)) :
+lemma coverEntropyInfEntourage_monotone (T : X → X) (U : SetRel X X) :
     Monotone fun F : Set X ↦ coverEntropyInfEntourage T F U := by
   refine fun F G F_G ↦ ExpGrowth.expGrowthInf_monotone fun n ↦ ?_
   exact ENat.toENNReal_mono (coverMincard_monotone_subset T U n F_G)
 
-lemma coverEntropyEntourage_monotone (T : X → X) (U : Set (X × X)) :
+lemma coverEntropyEntourage_monotone (T : X → X) (U : SetRel X X) :
     Monotone fun F : Set X ↦ coverEntropyEntourage T F U := by
   refine fun F G F_G ↦ ExpGrowth.expGrowthSup_monotone fun n ↦ ?_
   exact ENat.toENNReal_mono (coverMincard_monotone_subset T U n F_G)
 
-lemma netEntropyInfEntourage_monotone (T : X → X) (U : Set (X × X)) :
+lemma netEntropyInfEntourage_monotone (T : X → X) (U : SetRel X X) :
     Monotone fun F : Set X ↦ netEntropyInfEntourage T F U := by
   refine fun F G F_G ↦ ExpGrowth.expGrowthInf_monotone fun n ↦ ?_
   exact ENat.toENNReal_mono (netMaxcard_monotone_subset T U n F_G)
 
-lemma netEntropyEntourage_monotone (T : X → X) (U : Set (X × X)) :
+lemma netEntropyEntourage_monotone (T : X → X) (U : SetRel X X) :
     Monotone fun F : Set X ↦ netEntropyEntourage T F U := by
   refine fun F G F_G ↦ ExpGrowth.expGrowthSup_monotone fun n ↦ ?_
   exact ENat.toENNReal_mono (netMaxcard_monotone_subset T U n F_G)
@@ -99,45 +96,43 @@ end Subset
 
 section Closure
 
-variable [UniformSpace X] {T : X → X}
+variable [UniformSpace X]
 
-lemma IsDynCoverOf.closure (h : Continuous T) {F : Set X} {U V : Set (X × X)}
-    (V_uni : V ∈ 𝓤 X) {n : ℕ} {s : Set X} (s_cover : IsDynCoverOf T F U n s) :
-    IsDynCoverOf T (closure F) (U ○ V) n s := by
+lemma IsDynCoverOf.closure (h : Continuous T)
+    (V_uni : V ∈ 𝓤 X) (s_cover : IsDynCoverOf T F U n s) :
+    IsDynCoverOf T (closure F) (V ○ U) n s := by
   rcases (hasBasis_symmetric.mem_iff' V).1 V_uni with ⟨W, ⟨W_uni, W_symm⟩, W_V⟩
-  refine IsDynCoverOf.of_entourage_subset (SetRel.comp_subset_comp_right W_V) fun x x_clos ↦ ?_
-  obtain ⟨y, y_x, y_F⟩ := mem_closure_iff_nhds.1 x_clos _ (ball_dynEntourage_mem_nhds h W_uni n x)
-  obtain ⟨z, z_s, y_z⟩ := mem_iUnion₂.1 (s_cover y_F)
-  refine mem_iUnion₂.2 ⟨z, z_s, ?_⟩
-  rw [mem_ball_symmetry] at y_x
-  exact ball_mono (dynEntourage_comp_subset T U W n) z (mem_ball_comp y_z y_x)
+  refine IsDynCoverOf.of_entourage_subset (SetRel.comp_subset_comp_left W_V) fun x hx ↦ ?_
+  obtain ⟨y, hxy, hy⟩ := mem_closure_iff_nhds.1 hx _ (ball_dynEntourage_mem_nhds h W_uni n x)
+  obtain ⟨z, hz, hyz⟩ := s_cover hy
+  exact ⟨z, hz, dynEntourage_comp_subset _ _ _ _ ⟨y, hxy, hyz⟩⟩
 
-lemma coverMincard_closure_le (h : Continuous T) (F : Set X) (U : Set (X × X)) {V : Set (X × X)}
+lemma coverMincard_closure_le (h : Continuous T) (F : Set X) (U : SetRel X X)
     (V_uni : V ∈ 𝓤 X) (n : ℕ) :
-    coverMincard T (closure F) (U ○ V) n ≤ coverMincard T F U n := by
+    coverMincard T (closure F) (V ○ U) n ≤ coverMincard T F U n := by
   rcases eq_top_or_lt_top (coverMincard T F U n) with h' | h'
   · exact h' ▸ le_top
   obtain ⟨s, s_cover, s_coverMincard⟩ := (coverMincard_finite_iff T F U n).1 h'
   exact s_coverMincard ▸ (s_cover.closure h V_uni).coverMincard_le_card
 
-lemma coverEntropyInfEntourage_closure (h : Continuous T) (F : Set X) (U : Set (X × X))
-    {V : Set (X × X)} (V_uni : V ∈ 𝓤 X) :
-    coverEntropyInfEntourage T (closure F) (U ○ V) ≤ coverEntropyInfEntourage T F U :=
+lemma coverEntropyInfEntourage_closure (h : Continuous T) (F : Set X) (U : SetRel X X)
+    (V_uni : V ∈ 𝓤 X) :
+    coverEntropyInfEntourage T (closure F) (V ○ U) ≤ coverEntropyInfEntourage T F U :=
   expGrowthInf_monotone fun n ↦ ENat.toENNReal_mono (coverMincard_closure_le h F U V_uni n)
 
-lemma coverEntropyEntourage_closure (h : Continuous T) (F : Set X) (U : Set (X × X))
-    {V : Set (X × X)} (V_uni : V ∈ 𝓤 X) :
-    coverEntropyEntourage T (closure F) (U ○ V) ≤ coverEntropyEntourage T F U :=
+lemma coverEntropyEntourage_closure (h : Continuous T) (F : Set X) (U : SetRel X X)
+    (V_uni : V ∈ 𝓤 X) :
+    coverEntropyEntourage T (closure F) (V ○ U) ≤ coverEntropyEntourage T F U :=
   expGrowthSup_monotone fun n ↦ ENat.toENNReal_mono (coverMincard_closure_le h F U V_uni n)
 
-lemma coverEntropyInf_closure (h : Continuous T) {F : Set X} :
+lemma coverEntropyInf_closure (h : Continuous T) :
     coverEntropyInf T (closure F) = coverEntropyInf T F := by
   refine (iSup₂_le fun U U_uni ↦ ?_).antisymm (coverEntropyInf_monotone T subset_closure)
   obtain ⟨V, V_uni, V_U⟩ := comp_mem_uniformity_sets U_uni
   exact le_iSup₂_of_le V V_uni ((coverEntropyInfEntourage_antitone T (closure F) V_U).trans
     (coverEntropyInfEntourage_closure h F V V_uni))
 
-theorem coverEntropy_closure (h : Continuous T) {F : Set X} :
+theorem coverEntropy_closure (h : Continuous T) :
     coverEntropy T (closure F) = coverEntropy T F := by
   refine (iSup₂_le fun U U_uni ↦ ?_).antisymm (coverEntropy_monotone T subset_closure)
   obtain ⟨V, V_uni, V_U⟩ := comp_mem_uniformity_sets U_uni
@@ -150,13 +145,10 @@ end Closure
 
 section Union
 
-lemma IsDynCoverOf.union {T : X → X} {F G : Set X} {U : Set (X × X)} {n : ℕ} {s t : Set X}
-    (hs : IsDynCoverOf T F U n s) (ht : IsDynCoverOf T G U n t) :
-    IsDynCoverOf T (F ∪ G) U n (s ∪ t) :=
-  union_subset (hs.trans (biUnion_subset_biUnion_left subset_union_left))
-    (ht.trans (biUnion_subset_biUnion_left subset_union_right))
+lemma IsDynCoverOf.union (hs : IsDynCoverOf T F U n s) (ht : IsDynCoverOf T G U n t) :
+    IsDynCoverOf T (F ∪ G) U n (s ∪ t) := SetRel.IsCover.union hs ht
 
-lemma coverMincard_union_le (T : X → X) (F G : Set X) (U : Set (X × X)) (n : ℕ) :
+lemma coverMincard_union_le (T : X → X) (F G : Set X) (U : SetRel X X) (n : ℕ) :
     coverMincard T (F ∪ G) U n ≤ coverMincard T F U n + coverMincard T G U n := by
   classical
   rcases eq_top_or_lt_top (coverMincard T F U n) with hF | hF
@@ -170,7 +162,7 @@ lemma coverMincard_union_le (T : X → X) (F G : Set X) (U : Set (X × X)) (n : 
   rw [s.coe_union t]
   exact s_cover.union t_cover
 
-lemma coverEntropyEntourage_union {T : X → X} {F G : Set X} {U : Set (X × X)} :
+lemma coverEntropyEntourage_union :
     coverEntropyEntourage T (F ∪ G) U
       = max (coverEntropyEntourage T F U) (coverEntropyEntourage T G U) := by
   refine le_antisymm ?_ ?_
@@ -182,7 +174,7 @@ lemma coverEntropyEntourage_union {T : X → X} {F G : Set X} {U : Set (X × X)}
 
 variable {ι : Type*} [UniformSpace X]
 
-lemma coverEntropy_union {T : X → X} {F G : Set X} :
+lemma coverEntropy_union :
     coverEntropy T (F ∪ G) = max (coverEntropy T F) (coverEntropy T G) := by
   simp only [coverEntropy, ← iSup_sup_eq]
   exact biSup_congr fun _ _ ↦ coverEntropyEntourage_union

--- a/Mathlib/Topology/UniformSpace/Defs.lean
+++ b/Mathlib/Topology/UniformSpace/Defs.lean
@@ -5,7 +5,7 @@ Authors: Johannes Hölzl, Mario Carneiro, Patrick Massot
 -/
 module
 
-public import Mathlib.Data.Rel
+public import Mathlib.Data.Rel.Cover
 public import Mathlib.Topology.Order
 
 /-!
@@ -510,15 +510,15 @@ theorem tendsto_const_uniformity {a : α} {f : Filter β} : Tendsto (fun _ => (a
   tendsto_diag_uniformity (fun _ => a) f
 
 theorem symm_of_uniformity {s : SetRel α α} (hs : s ∈ 𝓤 α) :
-    ∃ t ∈ 𝓤 α, (∀ a b, (a, b) ∈ t → (b, a) ∈ t) ∧ t ⊆ s :=
+    ∃ t ∈ 𝓤 α, SetRel.IsSymm t ∧ t ⊆ s :=
   have : preimage Prod.swap s ∈ 𝓤 α := symm_le_uniformity hs
-  ⟨s ∩ preimage Prod.swap s, inter_mem hs this, fun _ _ ⟨h₁, h₂⟩ => ⟨h₂, h₁⟩, inter_subset_left⟩
+  ⟨s ∩ preimage Prod.swap s, inter_mem hs this, ⟨fun _ _ ⟨h₁, h₂⟩ => ⟨h₂, h₁⟩⟩, inter_subset_left⟩
 
 theorem comp_symm_of_uniformity {s : SetRel α α} (hs : s ∈ 𝓤 α) :
     ∃ t ∈ 𝓤 α, (∀ {a b}, (a, b) ∈ t → (b, a) ∈ t) ∧ t ○ t ⊆ s :=
   let ⟨_t, ht₁, ht₂⟩ := comp_mem_uniformity_sets hs
-  let ⟨t', ht', ht'₁, ht'₂⟩ := symm_of_uniformity ht₁
-  ⟨t', ht', ht'₁ _ _, Subset.trans (monotone_id.relComp monotone_id ht'₂) ht₂⟩
+  let ⟨t', ht', _, ht'₂⟩ := symm_of_uniformity ht₁
+  ⟨t', ht', SetRel.symm _, Subset.trans (monotone_id.relComp monotone_id ht'₂) ht₂⟩
 
 theorem uniformity_le_symm : 𝓤 α ≤ map Prod.swap (𝓤 α) := by
   rw [map_swap_eq_comap_swap]; exact tendsto_swap_uniformity.le_comap
@@ -652,6 +652,13 @@ theorem mem_comp_comp {V W M : SetRel β β} [W.IsSymm] {p : β × β} :
   · rintro ⟨⟨w, z⟩, ⟨w_in, z_in⟩, hwz⟩
     rw [mem_ball_symmetry] at z_in
     exact ⟨z, ⟨w, w_in, hwz⟩, z_in⟩
+
+lemma isCover_iff_subset_iUnion_ball {U : SetRel β β} [U.IsSymm] {s N : Set β} :
+    U.IsCover s N ↔ s ⊆ ⋃ y ∈ N, ball y U := by
+  simp [SetRel.IsCover, subset_def, ball, U.comm]
+
+alias ⟨_root_.SetRel.IsCover.subset_iUnion_ball, _root_.SetRel.IsCover.of_subset_iUnion_ball⟩ :=
+  isCover_iff_subset_iUnion_ball
 
 end UniformSpace
 


### PR DESCRIPTION
... instead of the handmade ones.


---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

When merging, all the commits will be squashed into a single commit
listing all co-authors.

Co-authors in the squash commit are gathered from two sources:

First, all authors of commits to this PR branch are included. Thus,
one way to add co-authors is to include at least one commit authored by
each co-author among the commits in the pull request. If necessary, you
may create empty commits to indicate co-authorship, using commands like so:

git commit --author="Author Name <author@email.com>" --allow-empty -m "add Author Name as coauthor"

Second, co-authors can also be listed in lines at the very bottom of
the commit message (that is, directly before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines
at the bottom of the commit message (before the `---`, and also before
any "Co-authored-by" lines) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
