### PR TITLE
[Merged by Bors] - typo in a docstring 1 -> 0 as a dummy value for tsum

### DIFF
--- a/Mathlib/Topology/Algebra/InfiniteSum/Defs.lean
+++ b/Mathlib/Topology/Algebra/InfiniteSum/Defs.lean
@@ -128,7 +128,7 @@ satisfying `HasProd f a`. Similar remarks apply to more general summation filter
 @[to_additive /-- `∑' i, f i` is the unconditional sum of `f` if it exists, or 0 otherwise.
 
 More generally, if `L` is a `SummationFilter`, `∑'[L] i, f i` is the sum of `f` with respect to
-`L` if it exists, and `1` otherwise.
+`L` if it exists, and `0` otherwise.
 
 (Note that even if the unconditional sum exists, it might not be unique if the topology is not
 separated. When the support of `f` is finite, we make the most reasonable choice, to use the sum


### PR DESCRIPTION
Confirmed by:
https://leanprover-community.github.io/mathlib4_docs/Mathlib/Topology/Algebra/InfiniteSum/Defs.html#tsum_eq_zero_of_not_summable

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
