### PR TITLE
[Merged by Bors] - feat: behavior of trailing coefficients of meromorphic functions under addition

### DIFF
--- a/Mathlib/Analysis/Meromorphic/Basic.lean
+++ b/Mathlib/Analysis/Meromorphic/Basic.lean
@@ -182,6 +182,22 @@ lemma fun_sub {f g : 𝕜 → E} (hf : MeromorphicAt f x) (hg : MeromorphicAt g 
     MeromorphicAt (fun z ↦ f z - g z) x :=
   hf.sub hg
 
+/--
+If `f₁` is meromorphic at `x`, then `f₁ + f₂` is meromorphic at `x` if and only if `f₂` is
+meromorphic at `x`.
+-/
+lemma meromorphicAt_iff_meromorphicAt_add {f g : 𝕜 → E} (hf : MeromorphicAt f x) :
+    MeromorphicAt g x ↔ MeromorphicAt (f + g) x := by
+  exact ⟨fun _ ↦ by fun_prop, fun h ↦ by simpa using h.sub hf⟩
+
+/--
+If `f₁` is meromorphic at `x`, then `f₁ - f₂` is meromorphic at `x` if and only if `f₂` is
+meromorphic at `x`.
+-/
+lemma meromorphicAt_iff_meromorphicAt_sub {f g : 𝕜 → E} (hf : MeromorphicAt f x) :
+    MeromorphicAt g x ↔ MeromorphicAt (f - g) x := by
+  exact ⟨fun _ ↦ by fun_prop, fun h ↦ by simpa using h.sub hf⟩
+
 @[deprecated (since := "2025-05-09")] alias sub' := fun_sub
 
 /-- With our definitions, `MeromorphicAt f x` depends only on the values of `f` on a punctured

--- a/Mathlib/Analysis/Meromorphic/Basic.lean
+++ b/Mathlib/Analysis/Meromorphic/Basic.lean
@@ -183,20 +183,37 @@ lemma fun_sub {f g : 𝕜 → E} (hf : MeromorphicAt f x) (hg : MeromorphicAt g 
   hf.sub hg
 
 /--
-If `f₁` is meromorphic at `x`, then `f₁ + f₂` is meromorphic at `x` if and only if `f₂` is
+If `f` is meromorphic at `x`, then `f + g` is meromorphic at `x` if and only if `g` is
 meromorphic at `x`.
 -/
-lemma meromorphicAt_iff_meromorphicAt_add {f g : 𝕜 → E} (hf : MeromorphicAt f x) :
+lemma meromorphicAt_add_iff_meromorphicAt₁ {f g : 𝕜 → E} (hf : MeromorphicAt f x) :
     MeromorphicAt (f + g) x ↔ MeromorphicAt g x := by
   exact ⟨fun h ↦ by simpa using h.sub hf, fun _ ↦ by fun_prop⟩
 
 /--
-If `f₁` is meromorphic at `x`, then `f₁ - f₂` is meromorphic at `x` if and only if `f₂` is
+If `g` is meromorphic at `x`, then `f + g` is meromorphic at `x` if and only if `f` is
 meromorphic at `x`.
 -/
-lemma meromorphicAt_iff_meromorphicAt_sub {f g : 𝕜 → E} (hf : MeromorphicAt f x) :
+lemma meromorphicAt_add_iff_meromorphicAt₂ {f g : 𝕜 → E} (hg : MeromorphicAt g x) :
+    MeromorphicAt (f + g) x ↔ MeromorphicAt f x := by
+  rw [add_comm]
+  exact meromorphicAt_add_iff_meromorphicAt₁ hg
+
+/--
+If `f` is meromorphic at `x`, then `f - g` is meromorphic at `x` if and only if `g` is
+meromorphic at `x`.
+-/
+lemma meromorphicAt_sub_iff_meromorphicAt₁ {f g : 𝕜 → E} (hf : MeromorphicAt f x) :
     MeromorphicAt (f - g) x ↔ MeromorphicAt g x := by
   exact ⟨fun h ↦ by simpa using h.sub hf, fun _ ↦ by fun_prop⟩
+
+/--
+If `g` is meromorphic at `x`, then `f - g` is meromorphic at `x` if and only if `f` is
+meromorphic at `x`.
+-/
+lemma meromorphicAt_sub_iff_meromorphicAt₂ {f g : 𝕜 → E} (hg : MeromorphicAt g x) :
+    MeromorphicAt (f - g) x ↔ MeromorphicAt f x := by
+  exact ⟨fun h ↦ by simpa using h.add hg, fun _ ↦ by fun_prop⟩
 
 @[deprecated (since := "2025-05-09")] alias sub' := fun_sub
 

--- a/Mathlib/Analysis/Meromorphic/Basic.lean
+++ b/Mathlib/Analysis/Meromorphic/Basic.lean
@@ -187,16 +187,16 @@ If `f₁` is meromorphic at `x`, then `f₁ + f₂` is meromorphic at `x` if and
 meromorphic at `x`.
 -/
 lemma meromorphicAt_iff_meromorphicAt_add {f g : 𝕜 → E} (hf : MeromorphicAt f x) :
-    MeromorphicAt g x ↔ MeromorphicAt (f + g) x := by
-  exact ⟨fun _ ↦ by fun_prop, fun h ↦ by simpa using h.sub hf⟩
+    MeromorphicAt (f + g) x ↔ MeromorphicAt g x := by
+  exact ⟨fun h ↦ by simpa using h.sub hf, fun _ ↦ by fun_prop⟩
 
 /--
 If `f₁` is meromorphic at `x`, then `f₁ - f₂` is meromorphic at `x` if and only if `f₂` is
 meromorphic at `x`.
 -/
 lemma meromorphicAt_iff_meromorphicAt_sub {f g : 𝕜 → E} (hf : MeromorphicAt f x) :
-    MeromorphicAt g x ↔ MeromorphicAt (f - g) x := by
-  exact ⟨fun _ ↦ by fun_prop, fun h ↦ by simpa using h.sub hf⟩
+    MeromorphicAt (f - g) x ↔ MeromorphicAt g x := by
+  exact ⟨fun h ↦ by simpa using h.sub hf, fun _ ↦ by fun_prop⟩
 
 @[deprecated (since := "2025-05-09")] alias sub' := fun_sub
 

--- a/Mathlib/Analysis/Meromorphic/Basic.lean
+++ b/Mathlib/Analysis/Meromorphic/Basic.lean
@@ -183,16 +183,16 @@ lemma fun_sub {f g : 𝕜 → E} (hf : MeromorphicAt f x) (hg : MeromorphicAt g 
   hf.sub hg
 
 /--
-If `f` is meromorphic at `x`, then `f + g` is meromorphic at `x` if and only if `g` is
-meromorphic at `x`.
+If `f` is meromorphic at `x`, then `f + g` is meromorphic at `x` if and only if `g` is meromorphic
+at `x`.
 -/
 lemma meromorphicAt_add_iff_meromorphicAt₁ {f g : 𝕜 → E} (hf : MeromorphicAt f x) :
     MeromorphicAt (f + g) x ↔ MeromorphicAt g x := by
   exact ⟨fun h ↦ by simpa using h.sub hf, fun _ ↦ by fun_prop⟩
 
 /--
-If `g` is meromorphic at `x`, then `f + g` is meromorphic at `x` if and only if `f` is
-meromorphic at `x`.
+If `g` is meromorphic at `x`, then `f + g` is meromorphic at `x` if and only if `f` is meromorphic
+at `x`.
 -/
 lemma meromorphicAt_add_iff_meromorphicAt₂ {f g : 𝕜 → E} (hg : MeromorphicAt g x) :
     MeromorphicAt (f + g) x ↔ MeromorphicAt f x := by
@@ -200,16 +200,16 @@ lemma meromorphicAt_add_iff_meromorphicAt₂ {f g : 𝕜 → E} (hg : Meromorphi
   exact meromorphicAt_add_iff_meromorphicAt₁ hg
 
 /--
-If `f` is meromorphic at `x`, then `f - g` is meromorphic at `x` if and only if `g` is
-meromorphic at `x`.
+If `f` is meromorphic at `x`, then `f - g` is meromorphic at `x` if and only if `g` is meromorphic
+at `x`.
 -/
 lemma meromorphicAt_sub_iff_meromorphicAt₁ {f g : 𝕜 → E} (hf : MeromorphicAt f x) :
     MeromorphicAt (f - g) x ↔ MeromorphicAt g x := by
   exact ⟨fun h ↦ by simpa using h.sub hf, fun _ ↦ by fun_prop⟩
 
 /--
-If `g` is meromorphic at `x`, then `f - g` is meromorphic at `x` if and only if `f` is
-meromorphic at `x`.
+If `g` is meromorphic at `x`, then `f - g` is meromorphic at `x` if and only if `f` is meromorphic
+at `x`.
 -/
 lemma meromorphicAt_sub_iff_meromorphicAt₂ {f g : 𝕜 → E} (hg : MeromorphicAt g x) :
     MeromorphicAt (f - g) x ↔ MeromorphicAt f x := by

--- a/Mathlib/Analysis/Meromorphic/TrailingCoefficient.lean
+++ b/Mathlib/Analysis/Meromorphic/TrailingCoefficient.lean
@@ -50,7 +50,7 @@ If `f` is meromorphic of infinite order at `x`, the trailing coefficient is zero
     meromorphicTrailingCoeffAt f x = 0 := by simp_all [meromorphicTrailingCoeffAt]
 
 /-!
-## Characterization of the Leading Coefficient
+## Characterization of the Trailing Coefficient
 -/
 
 /--
@@ -191,6 +191,75 @@ lemma meromorphicTrailingCoeffAt_congr_nhdsNE {f₁ f₂ : 𝕜 → E} (h : f₁
 /-!
 ## Behavior under Arithmetic Operations
 -/
+
+/--
+If `f₁` and `f₂` have unequal order at `x`, then the trailing coefficient of `f₁
++ f₂` at `x` is the trailing coefficient of the function with the lowest order.
+-/
+theorem MeromorphicAt.meromorphicTrailingCoeffAt_add_eq_left_of_lt {f₁ f₂ : 𝕜 → E}
+  (hf₂ : MeromorphicAt f₂ x) (h : meromorphicOrderAt f₁ x < meromorphicOrderAt f₂ x) :
+    meromorphicTrailingCoeffAt (f₁ + f₂) x = meromorphicTrailingCoeffAt f₁ x := by
+  -- Trivial case: f₁ not meromorphic at x
+  by_cases hf₁ : ¬MeromorphicAt f₁ x
+  · have : ¬MeromorphicAt (f₁ + f₂) x := by
+      rwa [add_comm, ← hf₂.meromorphicAt_iff_meromorphicAt_add]
+    simp_all
+  rw [not_not] at hf₁
+  -- Trivial case: f₂ vanishes locally around x
+  by_cases h₁f₂ : meromorphicOrderAt f₂ x = ⊤
+  · apply meromorphicTrailingCoeffAt_congr_nhdsNE
+    filter_upwards [meromorphicOrderAt_eq_top_iff.1 h₁f₂]
+    simp
+  -- General case
+  lift meromorphicOrderAt f₂ x to ℤ using h₁f₂ with n₂ hn₂
+  obtain ⟨g₂, h₁g₂, h₂g₂, h₃g₂⟩ := (meromorphicOrderAt_eq_int_iff hf₂).1 hn₂.symm
+  lift meromorphicOrderAt f₁ x to ℤ using (by aesop) with n₁ hn₁
+  obtain ⟨g₁, h₁g₁, h₂g₁, h₃g₁⟩ := (meromorphicOrderAt_eq_int_iff hf₁).1 hn₁.symm
+  rw [WithTop.coe_lt_coe] at h
+  have τ₀ : ∀ᶠ z in 𝓝[≠] x, (f₁ + f₂) z = (z - x) ^ n₁ • (g₁ + (z - x) ^ (n₂ - n₁) • g₂) z := by
+    filter_upwards [h₃g₁, h₃g₂, self_mem_nhdsWithin] with z h₁z h₂z h₃z
+    simp only [Pi.add_apply, h₁z, h₂z, Pi.smul_apply, smul_add, ← smul_assoc, smul_eq_mul,
+      add_right_inj]
+    rw [← zpow_add₀, add_sub_cancel]
+    simp_all [sub_ne_zero]
+  have τ₁ : AnalyticAt 𝕜 (fun z ↦ g₁ z + (z - x) ^ (n₂ - n₁) • g₂ z) x :=
+    h₁g₁.fun_add (AnalyticAt.fun_smul (AnalyticAt.fun_zpow_nonneg (by fun_prop)
+      (sub_nonneg_of_le h.le)) h₁g₂)
+  have τ₂ : g₁ x + (x - x) ^ (n₂ - n₁) • g₂ x ≠ 0 := by
+    simp_all [zero_zpow _ (sub_ne_zero.2 (ne_of_lt h).symm)]
+  rw [h₁g₁.meromorphicTrailingCoeffAt_of_ne_zero_of_eq_nhdsNE h₂g₁ h₃g₁,
+    τ₁.meromorphicTrailingCoeffAt_of_ne_zero_of_eq_nhdsNE τ₂ τ₀, sub_self, add_eq_left,
+    smul_eq_zero, zero_zpow _ (sub_ne_zero.2 (ne_of_lt h).symm)]
+  tauto
+
+/--
+If `f₁` and `f₂` have equal order at `x` and if their trailing coefficients do not cancel, then the
+trailing coefficient of `f₁ + f₂` at `x` is the sum of the trailing coefficients.
+-/
+theorem MeromorphicAt.meromorphicTrailingCoeffAt_add_eq_add {f₁ f₂ : 𝕜 → E}
+  (hf₁ : MeromorphicAt f₁ x) (hf₂ : MeromorphicAt f₂ x)
+  (h₁ : meromorphicOrderAt f₁ x = meromorphicOrderAt f₂ x)
+  (h₂ : meromorphicTrailingCoeffAt f₁ x + meromorphicTrailingCoeffAt f₂ x ≠ 0) :
+    meromorphicTrailingCoeffAt (f₁ + f₂) x
+      = meromorphicTrailingCoeffAt f₁ x + meromorphicTrailingCoeffAt f₂ x := by
+  -- Trivial case: f₁ vanishes locally around x
+  by_cases h₁f₁ : meromorphicOrderAt f₁ x = ⊤
+  · rw [meromorphicTrailingCoeffAt_of_order_eq_top h₁f₁, zero_add]
+    apply meromorphicTrailingCoeffAt_congr_nhdsNE
+    filter_upwards [meromorphicOrderAt_eq_top_iff.1 h₁f₁]
+    simp
+  -- General case
+  lift meromorphicOrderAt f₁ x to ℤ using (by aesop) with n₁ hn₁
+  obtain ⟨g₁, h₁g₁, h₂g₁, h₃g₁⟩ := (meromorphicOrderAt_eq_int_iff hf₁).1 hn₁.symm
+  lift meromorphicOrderAt f₂ x to ℤ using (by aesop) with n₂ hn₂
+  obtain ⟨g₂, h₁g₂, h₂g₂, h₃g₂⟩ := (meromorphicOrderAt_eq_int_iff hf₂).1 hn₂.symm
+  rw [WithTop.coe_eq_coe, h₁g₁.meromorphicTrailingCoeffAt_of_ne_zero_of_eq_nhdsNE h₂g₁ h₃g₁,
+    h₁g₂.meromorphicTrailingCoeffAt_of_ne_zero_of_eq_nhdsNE h₂g₂ h₃g₂] at *
+  have τ₀ : ∀ᶠ z in 𝓝[≠] x, (f₁ + f₂) z = (z - x) ^ n₁ • (g₁ + g₂) z := by
+    filter_upwards [h₃g₁, h₃g₂, self_mem_nhdsWithin] with z h₁z h₂z h₃z
+    simp_all
+  simp [AnalyticAt.meromorphicTrailingCoeffAt_of_ne_zero_of_eq_nhdsNE (by fun_prop)
+    (by simp_all) τ₀]
 
 /--
 The trailing coefficient of a scalar product is the scalar product of the trailing coefficients.

--- a/Mathlib/Analysis/Meromorphic/TrailingCoefficient.lean
+++ b/Mathlib/Analysis/Meromorphic/TrailingCoefficient.lean
@@ -193,8 +193,8 @@ lemma meromorphicTrailingCoeffAt_congr_nhdsNE {f₁ f₂ : 𝕜 → E} (h : f₁
 -/
 
 /--
-If `f₁` and `f₂` have unequal order at `x`, then the trailing coefficient of `f₁
-+ f₂` at `x` is the trailing coefficient of the function with the lowest order.
+If `f₁` and `f₂` have unequal order at `x`, then the trailing coefficient of `f₁ + f₂` at `x` is the
+trailing coefficient of the function with the lowest order.
 -/
 theorem MeromorphicAt.meromorphicTrailingCoeffAt_add_eq_left_of_lt {f₁ f₂ : 𝕜 → E}
   (hf₂ : MeromorphicAt f₂ x) (h : meromorphicOrderAt f₁ x < meromorphicOrderAt f₂ x) :

--- a/Mathlib/Analysis/Meromorphic/TrailingCoefficient.lean
+++ b/Mathlib/Analysis/Meromorphic/TrailingCoefficient.lean
@@ -202,7 +202,7 @@ theorem MeromorphicAt.meromorphicTrailingCoeffAt_add_eq_left_of_lt {f₁ f₂ : 
   -- Trivial case: f₁ not meromorphic at x
   by_cases hf₁ : ¬MeromorphicAt f₁ x
   · have : ¬MeromorphicAt (f₁ + f₂) x := by
-      rwa [add_comm, ← hf₂.meromorphicAt_iff_meromorphicAt_add]
+      rwa [add_comm, hf₂.meromorphicAt_iff_meromorphicAt_add]
     simp_all
   rw [not_not] at hf₁
   -- Trivial case: f₂ vanishes locally around x

--- a/Mathlib/Analysis/Meromorphic/TrailingCoefficient.lean
+++ b/Mathlib/Analysis/Meromorphic/TrailingCoefficient.lean
@@ -202,7 +202,7 @@ theorem MeromorphicAt.meromorphicTrailingCoeffAt_add_eq_left_of_lt {f₁ f₂ : 
   -- Trivial case: f₁ not meromorphic at x
   by_cases hf₁ : ¬MeromorphicAt f₁ x
   · have : ¬MeromorphicAt (f₁ + f₂) x := by
-      rwa [add_comm, hf₂.meromorphicAt_iff_meromorphicAt_add]
+      rwa [add_comm, hf₂.meromorphicAt_add_iff_meromorphicAt₁]
     simp_all
   rw [not_not] at hf₁
   -- Trivial case: f₂ vanishes locally around x


### PR DESCRIPTION
Establish the behavior of trailing coefficients of meromorphic functions under addition of the functions. Along the way, fix a typo in a docstring and add elementary lemmas concerning addition of meromorphic functions.

This material is used in [Project VD](https://github.com/kebekus/ProjectVD), which aims to formalize Value Distribution Theory for meromorphic functions on the complex plane.

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

When merging, all the commits will be squashed into a single commit
listing all co-authors.

Co-authors in the squash commit are gathered from two sources:

First, all authors of commits to this PR branch are included. Thus,
one way to add co-authors is to include at least one commit authored by
each co-author among the commits in the pull request. If necessary, you
may create empty commits to indicate co-authorship, using commands like so:

git commit --author="Author Name <author@email.com>" --allow-empty -m "add Author Name as coauthor"

Second, co-authors can also be listed in lines at the very bottom of
the commit message (that is, directly before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines
at the bottom of the commit message (before the `---`, and also before
any "Co-authored-by" lines) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
