### PR TITLE
[Merged by Bors] - doc(Algebra/Ring): fix refs and minor typos in doc strings

### DIFF
--- a/Mathlib/Algebra/Ring/Basic.lean
+++ b/Mathlib/Algebra/Ring/Basic.lean
@@ -14,11 +14,11 @@ import Mathlib.Tactic.TFAE
 # Semirings and rings
 
 This file gives lemmas about semirings, rings and domains.
-This is analogous to `Algebra.Group.Basic`,
+This is analogous to `Mathlib/Algebra/Group/Basic.lean`,
 the difference being that the former is about `+` and `*` separately, while
 the present file is about their interaction.
 
-For the definitions of semirings and rings see `Algebra.Ring.Defs`.
+For the definitions of semirings and rings see `Mathlib/Algebra/Ring/Defs.lean`.
 -/
 
 assert_not_exists Nat.cast_sub
@@ -35,7 +35,7 @@ def mulLeft [Distrib R] (r : R) : AddHom R R where
   toFun := (r * ·)
   map_add' := mul_add r
 
-/-- Left multiplication by an element of a type with distributive multiplication is an `AddHom`. -/
+/-- Right multiplication by an element of a type with distributive multiplication is an `AddHom`. -/
 @[simps -fullyApplied]
 def mulRight [Distrib R] (r : R) : AddHom R R where
   toFun a := a * r

--- a/Mathlib/Algebra/Ring/Defs.lean
+++ b/Mathlib/Algebra/Ring/Defs.lean
@@ -13,8 +13,8 @@ import Mathlib.Tactic.StacksAttribute
 /-!
 # Semirings and rings
 
-This file defines semirings, rings and domains. This is analogous to `Algebra.Group.Defs` and
-`Algebra.Group.Basic`, the difference being that the former is about `+` and `*` separately, while
+This file defines semirings, rings and domains. This is analogous to `Mathlib/Algebra/Group/Defs.lean` and
+`Mathlib/Algebra/Group/Basic.lean`, the difference being that those are about `+` and `*` separately, while
 the present file is about their interaction.
 
 ## Main definitions

--- a/Mathlib/Algebra/Ring/Defs.lean
+++ b/Mathlib/Algebra/Ring/Defs.lean
@@ -13,8 +13,9 @@ import Mathlib.Tactic.StacksAttribute
 /-!
 # Semirings and rings
 
-This file defines semirings, rings and domains. This is analogous to `Mathlib/Algebra/Group/Defs.lean` and
-`Mathlib/Algebra/Group/Basic.lean`, the difference being that those are about `+` and `*` separately, while
+This file defines semirings, rings and domains. This is analogous to
+`Mathlib/Algebra/Group/Defs.lean` and `Mathlib/Algebra/Group/Basic.lean`, the difference being that
+those are about `+` and `*` separately, while the present file is about their interaction.
 the present file is about their interaction.
 
 ## Main definitions


### PR DESCRIPTION
In the doc strings, I changed the format of references to other Mathlib files, so that they will be turned into HTML links. Also fixed two minor typos.


---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

When merging, all the commits will be squashed into a single commit
listing all co-authors.

Co-authors in the squash commit are gathered from two sources:

First, all authors of commits to this PR branch are included. Thus,
one way to add co-authors is to include at least one commit authored by
each co-author among the commits in the pull request. If necessary, you
may create empty commits to indicate co-authorship, using commands like so:

git commit --author="Author Name <author@email.com>" --allow-empty -m "add Author Name as coauthor"

Second, co-authors can also be listed in lines at the very bottom of
the commit message (that is, directly before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines
at the bottom of the commit message (before the `---`, and also before
any "Co-authored-by" lines) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
