### PR TITLE
[Merged by Bors] - chore: rewrite Equiv.algebra to make algebraMap defeq

### DIFF
--- a/Mathlib/Algebra/Algebra/TransferInstance.lean
+++ b/Mathlib/Algebra/Algebra/TransferInstance.lean
@@ -23,8 +23,7 @@ variable (R) in
 /-- Transfer `Algebra` across an `Equiv` -/
 protected abbrev algebra (e : α ≃ β) [Semiring β] :
     let _ := Equiv.semiring e
-    ∀ [Algebra R β], Algebra R α := by
-  intros
+    ∀ [Algebra R β], Algebra R α := fast_instance% by
   letI := Equiv.semiring e
   letI := e.smul R
   refine ⟨{

--- a/Mathlib/Algebra/Algebra/TransferInstance.lean
+++ b/Mathlib/Algebra/Algebra/TransferInstance.lean
@@ -4,7 +4,6 @@ Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Johannes Hölzl
 -/
 import Mathlib.Algebra.Algebra.Equiv
-import Mathlib.Algebra.Module.TransferInstance
 import Mathlib.Algebra.Ring.TransferInstance
 
 /-!

--- a/Mathlib/Algebra/Algebra/TransferInstance.lean
+++ b/Mathlib/Algebra/Algebra/TransferInstance.lean
@@ -25,21 +25,34 @@ protected abbrev algebra (e : α ≃ β) [Semiring β] :
     let _ := Equiv.semiring e
     ∀ [Algebra R β], Algebra R α := by
   intros
-  letI : Module R α := e.module R
-  fapply Algebra.ofModule
-  · intro r x y
-    change e.symm (e (e.symm (r • e x)) * e y) = e.symm (r • e.ringEquiv (x * y))
-    simp only [apply_symm_apply, Algebra.smul_mul_assoc, map_mul, ringEquiv_apply]
-  · intro r x y
-    change e.symm (e x * e (e.symm (r • e y))) = e.symm (r • e (e.symm (e x * e y)))
-    simp only [apply_symm_apply, Algebra.mul_smul_comm]
+  letI := Equiv.semiring e
+  letI := e.smul R
+  refine ⟨{
+    toFun r := e.symm (algebraMap R β r)
+    map_one' := by rw [map_one]; rfl
+    map_mul' x y := by
+      nth_rw 1 [map_mul, ← e.apply_symm_apply (algebraMap R β x),
+        ← e.apply_symm_apply (algebraMap R β y)]; rfl
+    map_zero' := by simp; rfl
+    map_add' x y := by
+      nth_rw 1 [map_add, ← e.apply_symm_apply (algebraMap R β x),
+        ← e.apply_symm_apply (algebraMap R β y)]; rfl
+  },
+  fun r x ↦ ?_, fun r x ↦ ?_⟩
+  · simp only [RingHom.coe_mk, MonoidHom.coe_mk, OneHom.coe_mk]
+    calc
+    _ = e.symm ((e (e.symm (algebraMap R β r)) * e x)) := rfl
+    _ = e.symm (e x * e (e.symm (algebraMap R β r))) := by simp [Algebra.commutes]
+    _ = x * e.symm (algebraMap R β r) := rfl
+  · simp only [RingHom.coe_mk, MonoidHom.coe_mk, OneHom.coe_mk]
+    calc r • x
+      = e.symm (r • e x) := rfl
+    _ = e.symm (e (e.symm (algebraMap R β r)) * e x) := by simp [Algebra.smul_def]
+    _ = e.symm (algebraMap R β r) * x := rfl
 
 lemma algebraMap_def (e : α ≃ β) [Semiring β] [Algebra R β] (r : R) :
-    (@algebraMap R α _ (Equiv.semiring e) (Equiv.algebra R e)) r = e.symm ((algebraMap R β) r) := by
-  let _ := Equiv.semiring e
-  simp only [Algebra.algebraMap_eq_smul_one]
-  change e.symm (r • e 1) = e.symm (r • 1)
-  simp only [Equiv.one_def, apply_symm_apply]
+    (@algebraMap R α _ (Equiv.semiring e) (Equiv.algebra R e)) r = e.symm ((algebraMap R β) r) :=
+  rfl
 
 variable (R) in
 /-- An equivalence `e : α ≃ β` gives an algebra equivalence `α ≃ₐ[R] β`

--- a/Mathlib/Algebra/Algebra/TransferInstance.lean
+++ b/Mathlib/Algebra/Algebra/TransferInstance.lean
@@ -25,15 +25,17 @@ protected abbrev algebra (e : α ≃ β) [Semiring β] :
     ∀ [Algebra R β], Algebra R α := fast_instance%
   letI := Equiv.semiring e
   letI := e.smul R
-  { algebraMap := e.ringEquiv.symm.toRingHom.comp (algebraMap R β)
+  { algebraMap :=
+    { toFun r := e.symm (algebraMap R β r)
+      __ := e.ringEquiv.symm.toRingHom.comp (algebraMap R β) }
     commutes' r x := by
-      simp only [RingEquiv.toRingHom_eq_coe, RingHom.coe_comp, RingHom.coe_coe, Function.comp_apply]
+      simp only [RingHom.coe_mk, MonoidHom.coe_mk, OneHom.coe_mk]
       calc
       _ = e.symm ((e (e.symm (algebraMap R β r)) * e x)) := rfl
       _ = e.symm (e x * e (e.symm (algebraMap R β r))) := by simp [Algebra.commutes]
       _ = x * e.symm (algebraMap R β r) := rfl
     smul_def' r x := by
-      simp only [RingEquiv.toRingHom_eq_coe, RingHom.coe_comp, RingHom.coe_coe, Function.comp_apply]
+      simp only [RingHom.coe_mk, MonoidHom.coe_mk, OneHom.coe_mk]
       calc r • x
         = e.symm (r • e x) := rfl
       _ = e.symm (e (e.symm (algebraMap R β r)) * e x) := by simp [Algebra.smul_def]

--- a/Mathlib/Algebra/Algebra/TransferInstance.lean
+++ b/Mathlib/Algebra/Algebra/TransferInstance.lean
@@ -28,18 +28,13 @@ protected abbrev algebra (e : α ≃ β) [Semiring β] :
   { algebraMap :=
     { toFun r := e.symm (algebraMap R β r)
       __ := e.ringEquiv.symm.toRingHom.comp (algebraMap R β) }
-    commutes' r x := by
-      simp only [RingHom.coe_mk, MonoidHom.coe_mk, OneHom.coe_mk]
-      calc
-      _ = e.symm ((e (e.symm (algebraMap R β r)) * e x)) := rfl
-      _ = e.symm (e x * e (e.symm (algebraMap R β r))) := by simp [Algebra.commutes]
-      _ = x * e.symm (algebraMap R β r) := rfl
-    smul_def' r x := by
-      simp only [RingHom.coe_mk, MonoidHom.coe_mk, OneHom.coe_mk]
-      calc r • x
-        = e.symm (r • e x) := rfl
-      _ = e.symm (e (e.symm (algebraMap R β r)) * e x) := by simp [Algebra.smul_def]
-      _ = e.symm (algebraMap R β r) * x := rfl }
+    commutes' r x :=
+      show e.symm ((e (e.symm (algebraMap R β r)) * e x)) =
+          e.symm (e x * e (e.symm (algebraMap R β r))) by
+        simp [Algebra.commutes]
+    smul_def' r x :=
+      show e.symm (r • e x) = e.symm (e (e.symm (algebraMap R β r)) * e x) by
+        simp [Algebra.smul_def] }
 
 lemma algebraMap_def (e : α ≃ β) [Semiring β] [Algebra R β] (r : R) :
     (@algebraMap R α _ (Equiv.semiring e) (Equiv.algebra R e)) r = e.symm ((algebraMap R β) r) :=

--- a/Mathlib/Algebra/Algebra/TransferInstance.lean
+++ b/Mathlib/Algebra/Algebra/TransferInstance.lean
@@ -22,31 +22,22 @@ variable (R) in
 /-- Transfer `Algebra` across an `Equiv` -/
 protected abbrev algebra (e : α ≃ β) [Semiring β] :
     let _ := Equiv.semiring e
-    ∀ [Algebra R β], Algebra R α := fast_instance% by
+    ∀ [Algebra R β], Algebra R α := fast_instance%
   letI := Equiv.semiring e
   letI := e.smul R
-  refine ⟨{
-    toFun r := e.symm (algebraMap R β r)
-    map_one' := by rw [map_one]; rfl
-    map_mul' x y := by
-      nth_rw 1 [map_mul, ← e.apply_symm_apply (algebraMap R β x),
-        ← e.apply_symm_apply (algebraMap R β y)]; rfl
-    map_zero' := by simp; rfl
-    map_add' x y := by
-      nth_rw 1 [map_add, ← e.apply_symm_apply (algebraMap R β x),
-        ← e.apply_symm_apply (algebraMap R β y)]; rfl
-  },
-  fun r x ↦ ?_, fun r x ↦ ?_⟩
-  · simp only [RingHom.coe_mk, MonoidHom.coe_mk, OneHom.coe_mk]
-    calc
-    _ = e.symm ((e (e.symm (algebraMap R β r)) * e x)) := rfl
-    _ = e.symm (e x * e (e.symm (algebraMap R β r))) := by simp [Algebra.commutes]
-    _ = x * e.symm (algebraMap R β r) := rfl
-  · simp only [RingHom.coe_mk, MonoidHom.coe_mk, OneHom.coe_mk]
-    calc r • x
-      = e.symm (r • e x) := rfl
-    _ = e.symm (e (e.symm (algebraMap R β r)) * e x) := by simp [Algebra.smul_def]
-    _ = e.symm (algebraMap R β r) * x := rfl
+  { algebraMap := e.ringEquiv.symm.toRingHom.comp (algebraMap R β)
+    commutes' r x := by
+      simp only [RingEquiv.toRingHom_eq_coe, RingHom.coe_comp, RingHom.coe_coe, Function.comp_apply]
+      calc
+      _ = e.symm ((e (e.symm (algebraMap R β r)) * e x)) := rfl
+      _ = e.symm (e x * e (e.symm (algebraMap R β r))) := by simp [Algebra.commutes]
+      _ = x * e.symm (algebraMap R β r) := rfl
+    smul_def' r x := by
+      simp only [RingEquiv.toRingHom_eq_coe, RingHom.coe_comp, RingHom.coe_coe, Function.comp_apply]
+      calc r • x
+        = e.symm (r • e x) := rfl
+      _ = e.symm (e (e.symm (algebraMap R β r)) * e x) := by simp [Algebra.smul_def]
+      _ = e.symm (algebraMap R β r) * x := rfl }
 
 lemma algebraMap_def (e : α ≃ β) [Semiring β] [Algebra R β] (r : R) :
     (@algebraMap R α _ (Equiv.semiring e) (Equiv.algebra R e)) r = e.symm ((algebraMap R β) r) :=

--- a/Mathlib/Algebra/Algebra/TransferInstance.lean
+++ b/Mathlib/Algebra/Algebra/TransferInstance.lean
@@ -37,8 +37,9 @@ protected abbrev algebra (e : α ≃ β) [Semiring β] :
         simp [Algebra.smul_def] }
 
 lemma algebraMap_def (e : α ≃ β) [Semiring β] [Algebra R β] (r : R) :
-    (@algebraMap R α _ (Equiv.semiring e) (Equiv.algebra R e)) r = e.symm ((algebraMap R β) r) :=
-  rfl
+    letI := Equiv.semiring e
+    letI := Equiv.algebra R e
+    algebraMap R α r = e.symm (algebraMap R β r) := rfl
 
 variable (R) in
 /-- An equivalence `e : α ≃ β` gives an algebra equivalence `α ≃ₐ[R] β`


### PR DESCRIPTION
This came up in #27270, [here](https://github.com/leanprover-community/mathlib4/pull/27270#discussion_r2491486707).

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

When merging, all the commits will be squashed into a single commit
listing all co-authors.

Co-authors in the squash commit are gathered from two sources:

First, all authors of commits to this PR branch are included. Thus,
one way to add co-authors is to include at least one commit authored by
each co-author among the commits in the pull request. If necessary, you
may create empty commits to indicate co-authorship, using commands like so:

git commit --author="Author Name <author@email.com>" --allow-empty -m "add Author Name as coauthor"

Second, co-authors can also be listed in lines at the very bottom of
the commit message (that is, directly before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines
at the bottom of the commit message (before the `---`, and also before
any "Co-authored-by" lines) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
