### PR TITLE
[Merged by Bors] - chore(Probability/Process): golf `measurableSet_inter_le` using `grind`

### DIFF
--- a/Mathlib/Probability/Process/Stopping.lean
+++ b/Mathlib/Probability/Process/Stopping.lean
@@ -617,21 +617,8 @@ theorem measurableSet_inter_le [TopologicalSpace ι] [SecondCountableTopology ι
   have h_eq i : s ∩ {ω | τ ω ≤ π ω} ∩ {ω | min (τ ω) (π ω) ≤ i} =
       s ∩ {ω | τ ω ≤ i} ∩ {ω | min (τ ω) (π ω) ≤ i} ∩
         {ω | min (τ ω) i ≤ min (min (τ ω) (π ω)) i} := by
-    ext1 ω
-    simp only [min_le_iff, Set.mem_inter_iff, Set.mem_setOf_eq, le_min_iff, le_refl, true_and,
-      true_or]
-    by_cases hτi : τ ω ≤ i
-    · simp only [hτi, true_or, and_true, and_congr_right_iff]
-      intro
-      constructor <;> intro h
-      · exact Or.inl h
-      · rcases h with h | h
-        · exact h
-        · exact hτi.trans h
-    simp only [hτi, false_or, and_false, false_and, iff_false, not_and, not_le, and_imp]
-    refine fun _ hτ_le_π => lt_of_lt_of_le ?_ hτ_le_π
-    rw [← not_le]
-    exact hτi
+    ext ω
+    by_cases hτi : τ ω ≤ i <;> grind
   simp_rw [h_eq]
   refine ⟨hs.1.inter (measurableSet_le hτ.measurable' hπ.measurable'), fun i ↦ ?_⟩
   refine ((hs.2 i).inter ((hτ.min hπ) i)).inter ?_


### PR DESCRIPTION
---
<details>
<summary>Show trace profiling of <code>measurableSet_inter_le</code>: 96 ms before, 279 ms after </summary>

### Trace profiling of `measurableSet_inter_le` before PR 31272
```diff
diff --git a/Mathlib/Probability/Process/Stopping.lean b/Mathlib/Probability/Process/Stopping.lean
index 552c277d1a..987f0c4ee1 100644
--- a/Mathlib/Probability/Process/Stopping.lean
+++ b/Mathlib/Probability/Process/Stopping.lean
@@ -394,7 +394,6 @@ theorem measurableSpace_mono (hτ : IsStoppingTime f τ) (hπ : IsStoppingTime f
 
 theorem measurableSpace_le (hτ : IsStoppingTime f τ) : hτ.measurableSpace ≤ m := fun _ hs ↦ hs.1
 
 @[deprecated (since := "2025-09-08")] alias measurableSpace_le_of_countable := measurableSpace_le
 @[deprecated (since := "2025-09-08")] alias measurableSpace_le_of_countable_range :=
     measurableSpace_le
 
@@ -609,6 +608,7 @@ theorem measurableSet_min_const_iff (hτ : IsStoppingTime f τ) (s : Set Ω) {i
       MeasurableSet[hτ.measurableSpace] s ∧ MeasurableSet[f i] s := by
   rw [measurableSpace_min_const hτ]; apply MeasurableSpace.measurableSet_inf
 
+set_option trace.profiler true in
 theorem measurableSet_inter_le [TopologicalSpace ι] [SecondCountableTopology ι] [OrderTopology ι]
     (hτ : IsStoppingTime f τ) (hπ : IsStoppingTime f π)
     (s : Set Ω) (hs : MeasurableSet[hτ.measurableSpace] s) :
```
```
ℹ [2440/2440] Built Mathlib.Probability.Process.Stopping (3.4s)
info: Mathlib/Probability/Process/Stopping.lean:612:0: [Elab.command] [0.011490] theorem measurableSet_inter_le [TopologicalSpace ι] [SecondCountableTopology ι]
        [OrderTopology ι] (hτ : IsStoppingTime f τ) (hπ : IsStoppingTime f π) (s : Set Ω)
        (hs : MeasurableSet[hτ.measurableSpace] s) : MeasurableSet[(hτ.min hπ).measurableSpace] (s ∩ {ω | τ ω ≤ π ω}) :=
      by
      simp_rw [IsStoppingTime.measurableSet] at hs ⊢
      have h_eq i :
        s ∩ {ω | τ ω ≤ π ω} ∩ {ω | min (τ ω) (π ω) ≤ i} =
          s ∩ {ω | τ ω ≤ i} ∩ {ω | min (τ ω) (π ω) ≤ i} ∩ {ω | min (τ ω) i ≤ min (min (τ ω) (π ω)) i} :=
        by
        ext1 ω
        simp only [min_le_iff, Set.mem_inter_iff, Set.mem_setOf_eq, le_min_iff, le_refl, true_and, true_or]
        by_cases hτi : τ ω ≤ i
        · simp only [hτi, true_or, and_true, and_congr_right_iff]
          intro
          constructor <;> intro h
          · exact Or.inl h
          · rcases h with h | h
            · exact h
            · exact hτi.trans h
        simp only [hτi, false_or, and_false, false_and, iff_false, not_and, not_le, and_imp]
        refine fun _ hτ_le_π => lt_of_lt_of_le ?_ hτ_le_π
        rw [← not_le]
        exact hτi
      simp_rw [h_eq]
      refine ⟨hs.1.inter (measurableSet_le hτ.measurable' hπ.measurable'), fun i ↦ ?_⟩
      refine ((hs.2 i).inter ((hτ.min hπ) i)).inter ?_
      apply @measurableSet_le _ _ _ _ _ (Filtration.seq f i) _ _ _ _ _ ?_ ?_
      · exact (hτ.min_const i).measurable_of_le fun _ => min_le_right _ _
      · exact ((hτ.min hπ).min_const i).measurable_of_le fun _ => min_le_right _ _
info: Mathlib/Probability/Process/Stopping.lean:612:0: [Elab.async] [0.097216] elaborating proof of MeasureTheory.IsStoppingTime.measurableSet_inter_le
  [Elab.definition.value] [0.095532] MeasureTheory.IsStoppingTime.measurableSet_inter_le
    [Elab.step] [0.094475] 
          simp_rw [IsStoppingTime.measurableSet] at hs ⊢
          have h_eq i :
            s ∩ {ω | τ ω ≤ π ω} ∩ {ω | min (τ ω) (π ω) ≤ i} =
              s ∩ {ω | τ ω ≤ i} ∩ {ω | min (τ ω) (π ω) ≤ i} ∩ {ω | min (τ ω) i ≤ min (min (τ ω) (π ω)) i} :=
            by
            ext1 ω
            simp only [min_le_iff, Set.mem_inter_iff, Set.mem_setOf_eq, le_min_iff, le_refl, true_and, true_or]
            by_cases hτi : τ ω ≤ i
            · simp only [hτi, true_or, and_true, and_congr_right_iff]
              intro
              constructor <;> intro h
              · exact Or.inl h
              · rcases h with h | h
                · exact h
                · exact hτi.trans h
            simp only [hτi, false_or, and_false, false_and, iff_false, not_and, not_le, and_imp]
            refine fun _ hτ_le_π => lt_of_lt_of_le ?_ hτ_le_π
            rw [← not_le]
            exact hτi
          simp_rw [h_eq]
          refine ⟨hs.1.inter (measurableSet_le hτ.measurable' hπ.measurable'), fun i ↦ ?_⟩
          refine ((hs.2 i).inter ((hτ.min hπ) i)).inter ?_
          apply @measurableSet_le _ _ _ _ _ (Filtration.seq f i) _ _ _ _ _ ?_ ?_
          · exact (hτ.min_const i).measurable_of_le fun _ => min_le_right _ _
          · exact ((hτ.min hπ).min_const i).measurable_of_le fun _ => min_le_right _ _
      [Elab.step] [0.094468] 
            simp_rw [IsStoppingTime.measurableSet] at hs ⊢
            have h_eq i :
              s ∩ {ω | τ ω ≤ π ω} ∩ {ω | min (τ ω) (π ω) ≤ i} =
                s ∩ {ω | τ ω ≤ i} ∩ {ω | min (τ ω) (π ω) ≤ i} ∩ {ω | min (τ ω) i ≤ min (min (τ ω) (π ω)) i} :=
              by
              ext1 ω
              simp only [min_le_iff, Set.mem_inter_iff, Set.mem_setOf_eq, le_min_iff, le_refl, true_and, true_or]
              by_cases hτi : τ ω ≤ i
              · simp only [hτi, true_or, and_true, and_congr_right_iff]
                intro
                constructor <;> intro h
                · exact Or.inl h
                · rcases h with h | h
                  · exact h
                  · exact hτi.trans h
              simp only [hτi, false_or, and_false, false_and, iff_false, not_and, not_le, and_imp]
              refine fun _ hτ_le_π => lt_of_lt_of_le ?_ hτ_le_π
              rw [← not_le]
              exact hτi
            simp_rw [h_eq]
            refine ⟨hs.1.inter (measurableSet_le hτ.measurable' hπ.measurable'), fun i ↦ ?_⟩
            refine ((hs.2 i).inter ((hτ.min hπ) i)).inter ?_
            apply @measurableSet_le _ _ _ _ _ (Filtration.seq f i) _ _ _ _ _ ?_ ?_
            · exact (hτ.min_const i).measurable_of_le fun _ => min_le_right _ _
            · exact ((hτ.min hπ).min_const i).measurable_of_le fun _ => min_le_right _ _
        [Elab.step] [0.055624] have h_eq i :
              s ∩ {ω | τ ω ≤ π ω} ∩ {ω | min (τ ω) (π ω) ≤ i} =
                s ∩ {ω | τ ω ≤ i} ∩ {ω | min (τ ω) (π ω) ≤ i} ∩ {ω | min (τ ω) i ≤ min (min (τ ω) (π ω)) i} :=
              by
              ext1 ω
              simp only [min_le_iff, Set.mem_inter_iff, Set.mem_setOf_eq, le_min_iff, le_refl, true_and, true_or]
              by_cases hτi : τ ω ≤ i
              · simp only [hτi, true_or, and_true, and_congr_right_iff]
                intro
                constructor <;> intro h
                · exact Or.inl h
                · rcases h with h | h
                  · exact h
                  · exact hτi.trans h
              simp only [hτi, false_or, and_false, false_and, iff_false, not_and, not_le, and_imp]
              refine fun _ hτ_le_π => lt_of_lt_of_le ?_ hτ_le_π
[… 113 lines omitted …]
                              simp only [min_le_iff, Set.mem_inter_iff, Set.mem_setOf_eq, le_min_iff, le_refl, true_and,
                                true_or]
                              by_cases hτi : τ ω ≤ i
                              · simp only [hτi, true_or, and_true, and_congr_right_iff]
                                intro
                                constructor <;> intro h
                                · exact Or.inl h
                                · rcases h with h | h
                                  · exact h
                                  · exact hτi.trans h
                              simp only [hτi, false_or, and_false, false_and, iff_false, not_and, not_le, and_imp]
                              refine fun _ hτ_le_π => lt_of_lt_of_le ?_ hτ_le_π
                              rw [← not_le]
                              exact hτi)
                      [Elab.step] [0.047370] with_annotate_state"by"
                            ( ext1 ω
                              simp only [min_le_iff, Set.mem_inter_iff, Set.mem_setOf_eq, le_min_iff, le_refl, true_and,
                                true_or]
                              by_cases hτi : τ ω ≤ i
                              · simp only [hτi, true_or, and_true, and_congr_right_iff]
                                intro
                                constructor <;> intro h
                                · exact Or.inl h
                                · rcases h with h | h
                                  · exact h
                                  · exact hτi.trans h
                              simp only [hτi, false_or, and_false, false_and, iff_false, not_and, not_le, and_imp]
                              refine fun _ hτ_le_π => lt_of_lt_of_le ?_ hτ_le_π
                              rw [← not_le]
                              exact hτi)
                        [Elab.step] [0.047366] (
                              ext1 ω
                              simp only [min_le_iff, Set.mem_inter_iff, Set.mem_setOf_eq, le_min_iff, le_refl, true_and,
                                true_or]
                              by_cases hτi : τ ω ≤ i
                              · simp only [hτi, true_or, and_true, and_congr_right_iff]
                                intro
                                constructor <;> intro h
                                · exact Or.inl h
                                · rcases h with h | h
                                  · exact h
                                  · exact hτi.trans h
                              simp only [hτi, false_or, and_false, false_and, iff_false, not_and, not_le, and_imp]
                              refine fun _ hτ_le_π => lt_of_lt_of_le ?_ hτ_le_π
                              rw [← not_le]
                              exact hτi)
                          [Elab.step] [0.047362] 
                                ext1 ω
                                simp only [min_le_iff, Set.mem_inter_iff, Set.mem_setOf_eq, le_min_iff, le_refl,
                                  true_and, true_or]
                                by_cases hτi : τ ω ≤ i
                                · simp only [hτi, true_or, and_true, and_congr_right_iff]
                                  intro
                                  constructor <;> intro h
                                  · exact Or.inl h
                                  · rcases h with h | h
                                    · exact h
                                    · exact hτi.trans h
                                simp only [hτi, false_or, and_false, false_and, iff_false, not_and, not_le, and_imp]
                                refine fun _ hτ_le_π => lt_of_lt_of_le ?_ hτ_le_π
                                rw [← not_le]
                                exact hτi
                            [Elab.step] [0.047358] 
                                  ext1 ω
                                  simp only [min_le_iff, Set.mem_inter_iff, Set.mem_setOf_eq, le_min_iff, le_refl,
                                    true_and, true_or]
                                  by_cases hτi : τ ω ≤ i
                                  · simp only [hτi, true_or, and_true, and_congr_right_iff]
                                    intro
                                    constructor <;> intro h
                                    · exact Or.inl h
                                    · rcases h with h | h
                                      · exact h
                                      · exact hτi.trans h
                                  simp only [hτi, false_or, and_false, false_and, iff_false, not_and, not_le, and_imp]
                                  refine fun _ hτ_le_π => lt_of_lt_of_le ?_ hτ_le_π
                                  rw [← not_le]
                                  exact hτi
                              [Elab.step] [0.019105] simp only [min_le_iff, Set.mem_inter_iff, Set.mem_setOf_eq,
                                    le_min_iff, le_refl, true_and, true_or]
        [Elab.step] [0.016871] refine ⟨hs.1.inter (measurableSet_le hτ.measurable' hπ.measurable'), fun i ↦ ?_⟩
          [Elab.step] [0.016836] expected type: MeasurableSet (s ∩ {ω | τ ω ≤ π ω}) ∧
                ∀ (i : ι),
                  MeasurableSet
                    (s ∩ {ω | τ ω ≤ ↑i} ∩ {ω | min (τ ω) (π ω) ≤ ↑i} ∩
                      {ω | min (τ ω) ↑i ≤ min (min (τ ω) (π ω)) ↑i}), term
              ⟨hs.1.inter (measurableSet_le hτ.measurable' hπ.measurable'), fun i ↦ ?_⟩
            [Elab.step] [0.016820] expected type: MeasurableSet (s ∩ {ω | τ ω ≤ π ω}) ∧
                  ∀ (i : ι),
                    MeasurableSet
                      (s ∩ {ω | τ ω ≤ ↑i} ∩ {ω | min (τ ω) (π ω) ≤ ↑i} ∩
                        {ω | min (τ ω) ↑i ≤ min (min (τ ω) (π ω)) ↑i}), term
                And.intro✝ (hs.1.inter (measurableSet_le hτ.measurable' hπ.measurable')) fun i ↦ ?_
              [Elab.step] [0.016636] expected type: MeasurableSet (s ∩ {ω | τ ω ≤ π ω}), term
                  hs.1.inter (measurableSet_le hτ.measurable' hπ.measurable')
                [Elab.step] [0.016282] expected type: MeasurableSet {ω | τ ω ≤ π ω}, term
                    (measurableSet_le hτ.measurable' hπ.measurable')
                  [Elab.step] [0.016275] expected type: MeasurableSet {ω | τ ω ≤ π ω}, term
                      measurableSet_le hτ.measurable' hπ.measurable'
Build completed successfully (2440 jobs).
```

### Trace profiling of `measurableSet_inter_le` after PR 31272
```diff
diff --git a/Mathlib/Probability/Process/Stopping.lean b/Mathlib/Probability/Process/Stopping.lean
index 552c277d1a..551aa8a470 100644
--- a/Mathlib/Probability/Process/Stopping.lean
+++ b/Mathlib/Probability/Process/Stopping.lean
@@ -394,7 +394,6 @@ theorem measurableSpace_mono (hτ : IsStoppingTime f τ) (hπ : IsStoppingTime f
 
 theorem measurableSpace_le (hτ : IsStoppingTime f τ) : hτ.measurableSpace ≤ m := fun _ hs ↦ hs.1
 
 @[deprecated (since := "2025-09-08")] alias measurableSpace_le_of_countable := measurableSpace_le
 @[deprecated (since := "2025-09-08")] alias measurableSpace_le_of_countable_range :=
     measurableSpace_le
 
@@ -609,6 +608,7 @@ theorem measurableSet_min_const_iff (hτ : IsStoppingTime f τ) (s : Set Ω) {i
       MeasurableSet[hτ.measurableSpace] s ∧ MeasurableSet[f i] s := by
   rw [measurableSpace_min_const hτ]; apply MeasurableSpace.measurableSet_inf
 
+set_option trace.profiler true in
 theorem measurableSet_inter_le [TopologicalSpace ι] [SecondCountableTopology ι] [OrderTopology ι]
     (hτ : IsStoppingTime f τ) (hπ : IsStoppingTime f π)
     (s : Set Ω) (hs : MeasurableSet[hτ.measurableSpace] s) :
@@ -617,21 +617,8 @@ theorem measurableSet_inter_le [TopologicalSpace ι] [SecondCountableTopology ι
   have h_eq i : s ∩ {ω | τ ω ≤ π ω} ∩ {ω | min (τ ω) (π ω) ≤ i} =
       s ∩ {ω | τ ω ≤ i} ∩ {ω | min (τ ω) (π ω) ≤ i} ∩
         {ω | min (τ ω) i ≤ min (min (τ ω) (π ω)) i} := by
-    ext1 ω
-    simp only [min_le_iff, Set.mem_inter_iff, Set.mem_setOf_eq, le_min_iff, le_refl, true_and,
-      true_or]
-    by_cases hτi : τ ω ≤ i
-    · simp only [hτi, true_or, and_true, and_congr_right_iff]
-      intro
-      constructor <;> intro h
-      · exact Or.inl h
-      · rcases h with h | h
-        · exact h
-        · exact hτi.trans h
-    simp only [hτi, false_or, and_false, false_and, iff_false, not_and, not_le, and_imp]
-    refine fun _ hτ_le_π => lt_of_lt_of_le ?_ hτ_le_π
-    rw [← not_le]
-    exact hτi
+    ext ω
+    by_cases hτi : τ ω ≤ i <;> grind
   simp_rw [h_eq]
   refine ⟨hs.1.inter (measurableSet_le hτ.measurable' hπ.measurable'), fun i ↦ ?_⟩
   refine ((hs.2 i).inter ((hτ.min hπ) i)).inter ?_
```
```
ℹ [2440/2440] Built Mathlib.Probability.Process.Stopping (3.4s)
info: Mathlib/Probability/Process/Stopping.lean:612:0: [Elab.command] [0.011634] theorem measurableSet_inter_le [TopologicalSpace ι] [SecondCountableTopology ι]
        [OrderTopology ι] (hτ : IsStoppingTime f τ) (hπ : IsStoppingTime f π) (s : Set Ω)
        (hs : MeasurableSet[hτ.measurableSpace] s) : MeasurableSet[(hτ.min hπ).measurableSpace] (s ∩ {ω | τ ω ≤ π ω}) :=
      by
      simp_rw [IsStoppingTime.measurableSet] at hs ⊢
      have h_eq i :
        s ∩ {ω | τ ω ≤ π ω} ∩ {ω | min (τ ω) (π ω) ≤ i} =
          s ∩ {ω | τ ω ≤ i} ∩ {ω | min (τ ω) (π ω) ≤ i} ∩ {ω | min (τ ω) i ≤ min (min (τ ω) (π ω)) i} :=
        by
        ext ω
        by_cases hτi : τ ω ≤ i <;> grind
      simp_rw [h_eq]
      refine ⟨hs.1.inter (measurableSet_le hτ.measurable' hπ.measurable'), fun i ↦ ?_⟩
      refine ((hs.2 i).inter ((hτ.min hπ) i)).inter ?_
      apply @measurableSet_le _ _ _ _ _ (Filtration.seq f i) _ _ _ _ _ ?_ ?_
      · exact (hτ.min_const i).measurable_of_le fun _ => min_le_right _ _
      · exact ((hτ.min hπ).min_const i).measurable_of_le fun _ => min_le_right _ _
info: Mathlib/Probability/Process/Stopping.lean:612:0: [Elab.async] [0.280692] elaborating proof of MeasureTheory.IsStoppingTime.measurableSet_inter_le
  [Elab.definition.value] [0.278824] MeasureTheory.IsStoppingTime.measurableSet_inter_le
    [Elab.step] [0.278156] 
          simp_rw [IsStoppingTime.measurableSet] at hs ⊢
          have h_eq i :
            s ∩ {ω | τ ω ≤ π ω} ∩ {ω | min (τ ω) (π ω) ≤ i} =
              s ∩ {ω | τ ω ≤ i} ∩ {ω | min (τ ω) (π ω) ≤ i} ∩ {ω | min (τ ω) i ≤ min (min (τ ω) (π ω)) i} :=
            by
            ext ω
            by_cases hτi : τ ω ≤ i <;> grind
          simp_rw [h_eq]
          refine ⟨hs.1.inter (measurableSet_le hτ.measurable' hπ.measurable'), fun i ↦ ?_⟩
          refine ((hs.2 i).inter ((hτ.min hπ) i)).inter ?_
          apply @measurableSet_le _ _ _ _ _ (Filtration.seq f i) _ _ _ _ _ ?_ ?_
          · exact (hτ.min_const i).measurable_of_le fun _ => min_le_right _ _
          · exact ((hτ.min hπ).min_const i).measurable_of_le fun _ => min_le_right _ _
      [Elab.step] [0.278149] 
            simp_rw [IsStoppingTime.measurableSet] at hs ⊢
            have h_eq i :
              s ∩ {ω | τ ω ≤ π ω} ∩ {ω | min (τ ω) (π ω) ≤ i} =
                s ∩ {ω | τ ω ≤ i} ∩ {ω | min (τ ω) (π ω) ≤ i} ∩ {ω | min (τ ω) i ≤ min (min (τ ω) (π ω)) i} :=
              by
              ext ω
              by_cases hτi : τ ω ≤ i <;> grind
            simp_rw [h_eq]
            refine ⟨hs.1.inter (measurableSet_le hτ.measurable' hπ.measurable'), fun i ↦ ?_⟩
            refine ((hs.2 i).inter ((hτ.min hπ) i)).inter ?_
            apply @measurableSet_le _ _ _ _ _ (Filtration.seq f i) _ _ _ _ _ ?_ ?_
            · exact (hτ.min_const i).measurable_of_le fun _ => min_le_right _ _
            · exact ((hτ.min hπ).min_const i).measurable_of_le fun _ => min_le_right _ _
        [Elab.step] [0.239988] have h_eq i :
              s ∩ {ω | τ ω ≤ π ω} ∩ {ω | min (τ ω) (π ω) ≤ i} =
                s ∩ {ω | τ ω ≤ i} ∩ {ω | min (τ ω) (π ω) ≤ i} ∩ {ω | min (τ ω) i ≤ min (min (τ ω) (π ω)) i} :=
              by
              ext ω
              by_cases hτi : τ ω ≤ i <;> grind
          [Elab.step] [0.239934] focus
                refine
                  no_implicit_lambda%
                    (have h_eq i :
                      s ∩ {ω | τ ω ≤ π ω} ∩ {ω | min (τ ω) (π ω) ≤ i} =
                        s ∩ {ω | τ ω ≤ i} ∩ {ω | min (τ ω) (π ω) ≤ i} ∩ {ω | min (τ ω) i ≤ min (min (τ ω) (π ω)) i} :=
                      ?body✝;
                    ?_)
                case body✝ =>
                  with_annotate_state"by"
                    ( ext ω
                      by_cases hτi : τ ω ≤ i <;> grind)
            [Elab.step] [0.239929] 
                  refine
                    no_implicit_lambda%
                      (have h_eq i :
                        s ∩ {ω | τ ω ≤ π ω} ∩ {ω | min (τ ω) (π ω) ≤ i} =
                          s ∩ {ω | τ ω ≤ i} ∩ {ω | min (τ ω) (π ω) ≤ i} ∩ {ω | min (τ ω) i ≤ min (min (τ ω) (π ω)) i} :=
                        ?body✝;
                      ?_)
                  case body✝ =>
                    with_annotate_state"by"
                      ( ext ω
                        by_cases hτi : τ ω ≤ i <;> grind)
              [Elab.step] [0.239925] 
                    refine
                      no_implicit_lambda%
                        (have h_eq i :
                          s ∩ {ω | τ ω ≤ π ω} ∩ {ω | min (τ ω) (π ω) ≤ i} =
                            s ∩ {ω | τ ω ≤ i} ∩ {ω | min (τ ω) (π ω) ≤ i} ∩
                              {ω | min (τ ω) i ≤ min (min (τ ω) (π ω)) i} :=
                          ?body✝;
                        ?_)
                    case body✝ =>
                      with_annotate_state"by"
                        ( ext ω
                          by_cases hτi : τ ω ≤ i <;> grind)
                [Elab.step] [0.231743] case body✝ =>
                      with_annotate_state"by"
                        ( ext ω
                          by_cases hτi : τ ω ≤ i <;> grind)
                  [Elab.step] [0.231665] with_annotate_state"by"
                          ( ext ω
                            by_cases hτi : τ ω ≤ i <;> grind)
                    [Elab.step] [0.231661] with_annotate_state"by"
                            ( ext ω
                              by_cases hτi : τ ω ≤ i <;> grind)
                      [Elab.step] [0.231657] with_annotate_state"by"
                            ( ext ω
                              by_cases hτi : τ ω ≤ i <;> grind)
                        [Elab.step] [0.231653] (
                              ext ω
                              by_cases hτi : τ ω ≤ i <;> grind)
                          [Elab.step] [0.231650] 
                                ext ω
                                by_cases hτi : τ ω ≤ i <;> grind
                            [Elab.step] [0.231646] 
                                  ext ω
                                  by_cases hτi : τ ω ≤ i <;> grind
                              [Elab.step] [0.231402] (by_cases hτi : τ ω ≤ i) <;> grind
                                [Elab.step] [0.231386] focus
                                      by_cases hτi : τ ω ≤ i
                                      with_annotate_state"<;>" skip
                                      all_goals grind
                                  [Elab.step] [0.231382] 
                                        by_cases hτi : τ ω ≤ i
                                        with_annotate_state"<;>" skip
                                        all_goals grind
                                    [Elab.step] [0.231379] 
                                          by_cases hτi : τ ω ≤ i
                                          with_annotate_state"<;>" skip
                                          all_goals grind
                                      [Elab.step] [0.224536] all_goals grind
                                        [Elab.step] [0.152357] grind
                                          [Elab.step] [0.152352] grind
                                            [Elab.step] [0.152345] grind
                                              [Meta.synthInstance] [0.017121] ❌️ Lean.Grind.NatModule (WithTop ι)
                                        [Elab.step] [0.072168] grind
                                          [Elab.step] [0.072161] grind
                                            [Elab.step] [0.072152] grind
                                              [Meta.synthInstance] [0.018375] ❌️ Lean.Grind.NatModule (WithTop ι)
        [Elab.step] [0.015569] refine ⟨hs.1.inter (measurableSet_le hτ.measurable' hπ.measurable'), fun i ↦ ?_⟩
          [Elab.step] [0.015531] expected type: MeasurableSet (s ∩ {ω | τ ω ≤ π ω}) ∧
                ∀ (i : ι),
                  MeasurableSet
                    (s ∩ {ω | τ ω ≤ ↑i} ∩ {ω | min (τ ω) (π ω) ≤ ↑i} ∩
                      {ω | min (τ ω) ↑i ≤ min (min (τ ω) (π ω)) ↑i}), term
              ⟨hs.1.inter (measurableSet_le hτ.measurable' hπ.measurable'), fun i ↦ ?_⟩
            [Elab.step] [0.015515] expected type: MeasurableSet (s ∩ {ω | τ ω ≤ π ω}) ∧
                  ∀ (i : ι),
                    MeasurableSet
                      (s ∩ {ω | τ ω ≤ ↑i} ∩ {ω | min (τ ω) (π ω) ≤ ↑i} ∩
                        {ω | min (τ ω) ↑i ≤ min (min (τ ω) (π ω)) ↑i}), term
                And.intro✝ (hs.1.inter (measurableSet_le hτ.measurable' hπ.measurable')) fun i ↦ ?_
              [Elab.step] [0.015314] expected type: MeasurableSet (s ∩ {ω | τ ω ≤ π ω}), term
                  hs.1.inter (measurableSet_le hτ.measurable' hπ.measurable')
                [Elab.step] [0.014950] expected type: MeasurableSet {ω | τ ω ≤ π ω}, term
                    (measurableSet_le hτ.measurable' hπ.measurable')
                  [Elab.step] [0.014943] expected type: MeasurableSet {ω | τ ω ≤ π ω}, term
                      measurableSet_le hτ.measurable' hπ.measurable'
Build completed successfully (2440 jobs).
```
</details>

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

When merging, all the commits will be squashed into a single commit
listing all co-authors.

Co-authors in the squash commit are gathered from two sources:

First, all authors of commits to this PR branch are included. Thus,
one way to add co-authors is to include at least one commit authored by
each co-author among the commits in the pull request. If necessary, you
may create empty commits to indicate co-authorship, using commands like so:

git commit --author="Author Name <author@email.com>" --allow-empty -m "add Author Name as coauthor"

Second, co-authors can also be listed in lines at the very bottom of
the commit message (that is, directly before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines
at the bottom of the commit message (before the `---`, and also before
any "Co-authored-by" lines) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
