### PR TITLE
[Merged by Bors] - chore(MeasureTheory/MeasurableSpace): golf `measurableSet_generateFrom_singleton_iff` using `grind`

### DIFF
--- a/Mathlib/MeasureTheory/MeasurableSpace/MeasurablyGenerated.lean
+++ b/Mathlib/MeasureTheory/MeasurableSpace/MeasurablyGenerated.lean
@@ -51,35 +51,14 @@ theorem measurableSet_generateFrom_singleton_iff {s t : Set α} :
   · rintro ⟨x, rfl⟩
     by_cases hT : True ∈ x
     · by_cases hF : False ∈ x
-      · refine Or.inr <| Or.inr <| Or.inr <| subset_antisymm (subset_univ _) ?_
-        suffices x = univ by simp only [this, preimage_univ, subset_refl]
-        refine subset_antisymm (subset_univ _) ?_
-        rw [univ_eq_true_false]
-        rintro - (rfl | rfl)
-        · assumption
-        · assumption
-      · have hx : x = {True} := by
-          ext p
-          refine ⟨fun hp ↦ mem_singleton_iff.2 ?_, fun hp ↦ hp ▸ hT⟩
-          by_contra hpneg
-          rw [eq_iff_iff, iff_true, ← false_iff] at hpneg
-          exact hF (by convert hp)
-        simp [hx]
+      · suffices x = univ by grind
+        grind [univ_eq_true_false]
+      · grind
     · by_cases hF : False ∈ x
-      · have hx : x = {False} := by
-          ext p
-          refine ⟨fun hp ↦ mem_singleton_iff.2 ?_, fun hp ↦ hp ▸ hF⟩
-          grind
-        refine Or.inr <| Or.inr <| Or.inl <| ?_
-        simp [hx, compl_def]
-      · refine Or.inl <| subset_antisymm ?_ <| empty_subset _
-        suffices x ⊆ ∅ by
-          rw [subset_empty_iff] at this
-          simp only [this, preimage_empty, subset_refl]
+      · grind
+      · suffices x ⊆ ∅ by grind
         intro p hp
-        fin_cases p
-        · contradiction
-        · contradiction
+        fin_cases p <;> contradiction
   · rintro (rfl | rfl | rfl | rfl)
     on_goal 1 => use ∅
     on_goal 2 => use {True}


### PR DESCRIPTION
---
<details>
<summary>Show trace profiling of <code>measurableSet_generateFrom_singleton_iff</code>: 70 ms before, 91 ms after </summary>

### Trace profiling of `measurableSet_generateFrom_singleton_iff` before PR 31273
```diff
diff --git a/Mathlib/MeasureTheory/MeasurableSpace/MeasurablyGenerated.lean b/Mathlib/MeasureTheory/MeasurableSpace/MeasurablyGenerated.lean
index baf5299a16..fb8e3fc16d 100644
--- a/Mathlib/MeasureTheory/MeasurableSpace/MeasurablyGenerated.lean
+++ b/Mathlib/MeasureTheory/MeasurableSpace/MeasurablyGenerated.lean
@@ -42,6 +42,7 @@ end MeasurableSpace
 
 namespace MeasureTheory
 
+set_option trace.profiler true in
 theorem measurableSet_generateFrom_singleton_iff {s t : Set α} :
     MeasurableSet[MeasurableSpace.generateFrom {s}] t ↔ t = ∅ ∨ t = s ∨ t = sᶜ ∨ t = univ := by
   simp_rw [MeasurableSpace.generateFrom_singleton]
```
```
ℹ [880/880] Built Mathlib.MeasureTheory.MeasurableSpace.MeasurablyGenerated (1.2s)
info: Mathlib/MeasureTheory/MeasurableSpace/MeasurablyGenerated.lean:46:0: [Elab.async] [0.071352] elaborating proof of MeasureTheory.measurableSet_generateFrom_singleton_iff
  [Elab.definition.value] [0.069878] MeasureTheory.measurableSet_generateFrom_singleton_iff
    [Elab.step] [0.068734] 
          simp_rw [MeasurableSpace.generateFrom_singleton]
          unfold MeasurableSet MeasurableSpace.MeasurableSet' MeasurableSpace.comap
          simp_rw [MeasurableSpace.measurableSet_top, true_and]
          constructor
          · rintro ⟨x, rfl⟩
            by_cases hT : True ∈ x
            · by_cases hF : False ∈ x
              · refine Or.inr <| Or.inr <| Or.inr <| subset_antisymm (subset_univ _) ?_
                suffices x = univ by simp only [this, preimage_univ, subset_refl]
                refine subset_antisymm (subset_univ _) ?_
                rw [univ_eq_true_false]
                rintro - (rfl | rfl)
                · assumption
                · assumption
              · have hx : x = { True } := by
                  ext p
                  refine ⟨fun hp ↦ mem_singleton_iff.2 ?_, fun hp ↦ hp ▸ hT⟩
                  by_contra hpneg
                  rw [eq_iff_iff, iff_true, ← false_iff] at hpneg
                  exact hF (by convert hp)
                simp [hx]
            · by_cases hF : False ∈ x
              · have hx : x = { False } := by
                  ext p
                  refine ⟨fun hp ↦ mem_singleton_iff.2 ?_, fun hp ↦ hp ▸ hF⟩
                  grind
                refine Or.inr <| Or.inr <| Or.inl <| ?_
                simp [hx, compl_def]
              · refine Or.inl <| subset_antisymm ?_ <| empty_subset _
                suffices x ⊆ ∅ by
                  rw [subset_empty_iff] at this
                  simp only [this, preimage_empty, subset_refl]
                intro p hp
                fin_cases p
                · contradiction
                · contradiction
          · rintro (rfl | rfl | rfl | rfl)
            on_goal 1 => use ∅
            on_goal 2 => use { True }
            on_goal 3 => use { False }
            on_goal 4 => use Set.univ
            all_goals simp [compl_def]
      [Elab.step] [0.068727] 
            simp_rw [MeasurableSpace.generateFrom_singleton]
            unfold MeasurableSet MeasurableSpace.MeasurableSet' MeasurableSpace.comap
            simp_rw [MeasurableSpace.measurableSet_top, true_and]
            constructor
            · rintro ⟨x, rfl⟩
              by_cases hT : True ∈ x
              · by_cases hF : False ∈ x
                · refine Or.inr <| Or.inr <| Or.inr <| subset_antisymm (subset_univ _) ?_
                  suffices x = univ by simp only [this, preimage_univ, subset_refl]
                  refine subset_antisymm (subset_univ _) ?_
                  rw [univ_eq_true_false]
                  rintro - (rfl | rfl)
                  · assumption
                  · assumption
                · have hx : x = { True } := by
                    ext p
                    refine ⟨fun hp ↦ mem_singleton_iff.2 ?_, fun hp ↦ hp ▸ hT⟩
                    by_contra hpneg
                    rw [eq_iff_iff, iff_true, ← false_iff] at hpneg
                    exact hF (by convert hp)
                  simp [hx]
              · by_cases hF : False ∈ x
                · have hx : x = { False } := by
                    ext p
                    refine ⟨fun hp ↦ mem_singleton_iff.2 ?_, fun hp ↦ hp ▸ hF⟩
                    grind
                  refine Or.inr <| Or.inr <| Or.inl <| ?_
                  simp [hx, compl_def]
                · refine Or.inl <| subset_antisymm ?_ <| empty_subset _
                  suffices x ⊆ ∅ by
                    rw [subset_empty_iff] at this
                    simp only [this, preimage_empty, subset_refl]
                  intro p hp
                  fin_cases p
                  · contradiction
                  · contradiction
            · rintro (rfl | rfl | rfl | rfl)
              on_goal 1 => use ∅
              on_goal 2 => use { True }
              on_goal 3 => use { False }
              on_goal 4 => use Set.univ
              all_goals simp [compl_def]
        [Elab.step] [0.012541] simp_rw [MeasurableSpace.generateFrom_singleton]
        [Elab.step] [0.041180] ·
              rintro ⟨x, rfl⟩
              by_cases hT : True ∈ x
              · by_cases hF : False ∈ x
                · refine Or.inr <| Or.inr <| Or.inr <| subset_antisymm (subset_univ _) ?_
                  suffices x = univ by simp only [this, preimage_univ, subset_refl]
                  refine subset_antisymm (subset_univ _) ?_
                  rw [univ_eq_true_false]
                  rintro - (rfl | rfl)
                  · assumption
[… 112 lines omitted …]
                        · assumption
                        · assumption
                      · have hx : x = { True } := by
                          ext p
                          refine ⟨fun hp ↦ mem_singleton_iff.2 ?_, fun hp ↦ hp ▸ hT⟩
                          by_contra hpneg
                          rw [eq_iff_iff, iff_true, ← false_iff] at hpneg
                          exact hF (by convert hp)
                        simp [hx]
                  [Elab.step] [0.028797] 
                        by_cases hF : False ∈ x
                        · refine Or.inr <| Or.inr <| Or.inr <| subset_antisymm (subset_univ _) ?_
                          suffices x = univ by simp only [this, preimage_univ, subset_refl]
                          refine subset_antisymm (subset_univ _) ?_
                          rw [univ_eq_true_false]
                          rintro - (rfl | rfl)
                          · assumption
                          · assumption
                        · have hx : x = { True } := by
                            ext p
                            refine ⟨fun hp ↦ mem_singleton_iff.2 ?_, fun hp ↦ hp ▸ hT⟩
                            by_contra hpneg
                            rw [eq_iff_iff, iff_true, ← false_iff] at hpneg
                            exact hF (by convert hp)
                          simp [hx]
                    [Elab.step] [0.025079] ·
                          have hx : x = { True } := by
                            ext p
                            refine ⟨fun hp ↦ mem_singleton_iff.2 ?_, fun hp ↦ hp ▸ hT⟩
                            by_contra hpneg
                            rw [eq_iff_iff, iff_true, ← false_iff] at hpneg
                            exact hF (by convert hp)
                          simp [hx]
                      [Elab.step] [0.025059] 
                            have hx : x = { True } := by
                              ext p
                              refine ⟨fun hp ↦ mem_singleton_iff.2 ?_, fun hp ↦ hp ▸ hT⟩
                              by_contra hpneg
                              rw [eq_iff_iff, iff_true, ← false_iff] at hpneg
                              exact hF (by convert hp)
                            simp [hx]
                        [Elab.step] [0.025057] 
                              have hx : x = { True } := by
                                ext p
                                refine ⟨fun hp ↦ mem_singleton_iff.2 ?_, fun hp ↦ hp ▸ hT⟩
                                by_contra hpneg
                                rw [eq_iff_iff, iff_true, ← false_iff] at hpneg
                                exact hF (by convert hp)
                              simp [hx]
                          [Elab.step] [0.015096] simp [hx]
                            [Meta.synthInstance] [0.011997] ❌️ Nontrivial (Set α)
              [Elab.step] [0.011467] ·
                    by_cases hF : False ∈ x
                    · have hx : x = { False } := by
                        ext p
                        refine ⟨fun hp ↦ mem_singleton_iff.2 ?_, fun hp ↦ hp ▸ hF⟩
                        grind
                      refine Or.inr <| Or.inr <| Or.inl <| ?_
                      simp [hx, compl_def]
                    · refine Or.inl <| subset_antisymm ?_ <| empty_subset _
                      suffices x ⊆ ∅ by
                        rw [subset_empty_iff] at this
                        simp only [this, preimage_empty, subset_refl]
                      intro p hp
                      fin_cases p
                      · contradiction
                      · contradiction
                [Elab.step] [0.011367] 
                      by_cases hF : False ∈ x
                      · have hx : x = { False } := by
                          ext p
                          refine ⟨fun hp ↦ mem_singleton_iff.2 ?_, fun hp ↦ hp ▸ hF⟩
                          grind
                        refine Or.inr <| Or.inr <| Or.inl <| ?_
                        simp [hx, compl_def]
                      · refine Or.inl <| subset_antisymm ?_ <| empty_subset _
                        suffices x ⊆ ∅ by
                          rw [subset_empty_iff] at this
                          simp only [this, preimage_empty, subset_refl]
                        intro p hp
                        fin_cases p
                        · contradiction
                        · contradiction
                  [Elab.step] [0.011363] 
                        by_cases hF : False ∈ x
                        · have hx : x = { False } := by
                            ext p
                            refine ⟨fun hp ↦ mem_singleton_iff.2 ?_, fun hp ↦ hp ▸ hF⟩
                            grind
                          refine Or.inr <| Or.inr <| Or.inl <| ?_
                          simp [hx, compl_def]
                        · refine Or.inl <| subset_antisymm ?_ <| empty_subset _
                          suffices x ⊆ ∅ by
                            rw [subset_empty_iff] at this
                            simp only [this, preimage_empty, subset_refl]
                          intro p hp
                          fin_cases p
                          · contradiction
                          · contradiction
Build completed successfully (880 jobs).
```

### Trace profiling of `measurableSet_generateFrom_singleton_iff` after PR 31273
```diff
diff --git a/Mathlib/MeasureTheory/MeasurableSpace/MeasurablyGenerated.lean b/Mathlib/MeasureTheory/MeasurableSpace/MeasurablyGenerated.lean
index baf5299a16..b67f37d372 100644
--- a/Mathlib/MeasureTheory/MeasurableSpace/MeasurablyGenerated.lean
+++ b/Mathlib/MeasureTheory/MeasurableSpace/MeasurablyGenerated.lean
@@ -42,6 +42,7 @@ end MeasurableSpace
 
 namespace MeasureTheory
 
+set_option trace.profiler true in
 theorem measurableSet_generateFrom_singleton_iff {s t : Set α} :
     MeasurableSet[MeasurableSpace.generateFrom {s}] t ↔ t = ∅ ∨ t = s ∨ t = sᶜ ∨ t = univ := by
   simp_rw [MeasurableSpace.generateFrom_singleton]
@@ -51,35 +52,14 @@ theorem measurableSet_generateFrom_singleton_iff {s t : Set α} :
   · rintro ⟨x, rfl⟩
     by_cases hT : True ∈ x
     · by_cases hF : False ∈ x
-      · refine Or.inr <| Or.inr <| Or.inr <| subset_antisymm (subset_univ _) ?_
-        suffices x = univ by simp only [this, preimage_univ, subset_refl]
-        refine subset_antisymm (subset_univ _) ?_
-        rw [univ_eq_true_false]
-        rintro - (rfl | rfl)
-        · assumption
-        · assumption
-      · have hx : x = {True} := by
-          ext p
-          refine ⟨fun hp ↦ mem_singleton_iff.2 ?_, fun hp ↦ hp ▸ hT⟩
-          by_contra hpneg
-          rw [eq_iff_iff, iff_true, ← false_iff] at hpneg
-          exact hF (by convert hp)
-        simp [hx]
+      · suffices x = univ by grind
+        grind [univ_eq_true_false]
+      · grind
     · by_cases hF : False ∈ x
-      · have hx : x = {False} := by
-          ext p
-          refine ⟨fun hp ↦ mem_singleton_iff.2 ?_, fun hp ↦ hp ▸ hF⟩
-          grind
-        refine Or.inr <| Or.inr <| Or.inl <| ?_
-        simp [hx, compl_def]
-      · refine Or.inl <| subset_antisymm ?_ <| empty_subset _
-        suffices x ⊆ ∅ by
-          rw [subset_empty_iff] at this
-          simp only [this, preimage_empty, subset_refl]
+      · grind
+      · suffices x ⊆ ∅ by grind
         intro p hp
-        fin_cases p
-        · contradiction
-        · contradiction
+        fin_cases p <;> contradiction
   · rintro (rfl | rfl | rfl | rfl)
     on_goal 1 => use ∅
     on_goal 2 => use {True}
```
```
ℹ [880/880] Built Mathlib.MeasureTheory.MeasurableSpace.MeasurablyGenerated (1.2s)
info: Mathlib/MeasureTheory/MeasurableSpace/MeasurablyGenerated.lean:46:0: [Elab.async] [0.092756] elaborating proof of MeasureTheory.measurableSet_generateFrom_singleton_iff
  [Elab.definition.value] [0.091377] MeasureTheory.measurableSet_generateFrom_singleton_iff
    [Elab.step] [0.090497] 
          simp_rw [MeasurableSpace.generateFrom_singleton]
          unfold MeasurableSet MeasurableSpace.MeasurableSet' MeasurableSpace.comap
          simp_rw [MeasurableSpace.measurableSet_top, true_and]
          constructor
          · rintro ⟨x, rfl⟩
            by_cases hT : True ∈ x
            · by_cases hF : False ∈ x
              · suffices x = univ by grind
                grind [univ_eq_true_false]
              · grind
            · by_cases hF : False ∈ x
              · grind
              · suffices x ⊆ ∅ by grind
                intro p hp
                fin_cases p <;> contradiction
          · rintro (rfl | rfl | rfl | rfl)
            on_goal 1 => use ∅
            on_goal 2 => use { True }
            on_goal 3 => use { False }
            on_goal 4 => use Set.univ
            all_goals simp [compl_def]
      [Elab.step] [0.090489] 
            simp_rw [MeasurableSpace.generateFrom_singleton]
            unfold MeasurableSet MeasurableSpace.MeasurableSet' MeasurableSpace.comap
            simp_rw [MeasurableSpace.measurableSet_top, true_and]
            constructor
            · rintro ⟨x, rfl⟩
              by_cases hT : True ∈ x
              · by_cases hF : False ∈ x
                · suffices x = univ by grind
                  grind [univ_eq_true_false]
                · grind
              · by_cases hF : False ∈ x
                · grind
                · suffices x ⊆ ∅ by grind
                  intro p hp
                  fin_cases p <;> contradiction
            · rintro (rfl | rfl | rfl | rfl)
              on_goal 1 => use ∅
              on_goal 2 => use { True }
              on_goal 3 => use { False }
              on_goal 4 => use Set.univ
              all_goals simp [compl_def]
        [Elab.step] [0.012749] simp_rw [MeasurableSpace.generateFrom_singleton]
        [Elab.step] [0.062153] ·
              rintro ⟨x, rfl⟩
              by_cases hT : True ∈ x
              · by_cases hF : False ∈ x
                · suffices x = univ by grind
                  grind [univ_eq_true_false]
                · grind
              · by_cases hF : False ∈ x
                · grind
                · suffices x ⊆ ∅ by grind
                  intro p hp
                  fin_cases p <;> contradiction
          [Elab.step] [0.062134] 
                rintro ⟨x, rfl⟩
                by_cases hT : True ∈ x
                · by_cases hF : False ∈ x
                  · suffices x = univ by grind
                    grind [univ_eq_true_false]
                  · grind
                · by_cases hF : False ∈ x
                  · grind
                  · suffices x ⊆ ∅ by grind
                    intro p hp
                    fin_cases p <;> contradiction
            [Elab.step] [0.062131] 
                  rintro ⟨x, rfl⟩
                  by_cases hT : True ∈ x
                  · by_cases hF : False ∈ x
                    · suffices x = univ by grind
                      grind [univ_eq_true_false]
                    · grind
                  · by_cases hF : False ∈ x
                    · grind
                    · suffices x ⊆ ∅ by grind
                      intro p hp
                      fin_cases p <;> contradiction
              [Elab.step] [0.031421] ·
                    by_cases hF : False ∈ x
                    · suffices x = univ by grind
                      grind [univ_eq_true_false]
                    · grind
                [Elab.step] [0.031410] 
                      by_cases hF : False ∈ x
                      · suffices x = univ by grind
                        grind [univ_eq_true_false]
                      · grind
                  [Elab.step] [0.031407] 
                        by_cases hF : False ∈ x
                        · suffices x = univ by grind
                          grind [univ_eq_true_false]
                        · grind
                    [Elab.step] [0.019456] ·
                          suffices x = univ by grind
                          grind [univ_eq_true_false]
                      [Elab.step] [0.019448] 
                            suffices x = univ by grind
                            grind [univ_eq_true_false]
                        [Elab.step] [0.019444] 
                              suffices x = univ by grind
                              grind [univ_eq_true_false]
                          [Elab.step] [0.010344] grind [univ_eq_true_false]
                    [Elab.step] [0.011419] · grind
                      [Elab.step] [0.011411] grind
                        [Elab.step] [0.011407] grind
                          [Elab.step] [0.011402] grind
              [Elab.step] [0.029820] ·
                    by_cases hF : False ∈ x
                    · grind
                    · suffices x ⊆ ∅ by grind
                      intro p hp
                      fin_cases p <;> contradiction
                [Elab.step] [0.029812] 
                      by_cases hF : False ∈ x
                      · grind
                      · suffices x ⊆ ∅ by grind
                        intro p hp
                        fin_cases p <;> contradiction
                  [Elab.step] [0.029808] 
                        by_cases hF : False ∈ x
                        · grind
                        · suffices x ⊆ ∅ by grind
                          intro p hp
                          fin_cases p <;> contradiction
                    [Elab.step] [0.011217] · grind
                      [Elab.step] [0.011211] grind
                        [Elab.step] [0.011208] grind
                          [Elab.step] [0.011203] grind
                    [Elab.step] [0.017927] ·
                          suffices x ⊆ ∅ by grind
                          intro p hp
                          fin_cases p <;> contradiction
                      [Elab.step] [0.017920] 
                            suffices x ⊆ ∅ by grind
                            intro p hp
                            fin_cases p <;> contradiction
                        [Elab.step] [0.017914] 
                              suffices x ⊆ ∅ by grind
                              intro p hp
                              fin_cases p <;> contradiction
                          [Elab.step] [0.014460] suffices x ⊆ ∅ by grind
                            [Elab.step] [0.014455] refine_lift
                                  suffices x ⊆ ∅ by grind;
                                  ?_
                              [Elab.step] [0.014451] focus
                                    (refine
                                        no_implicit_lambda%
                                          (suffices x ⊆ ∅ by grind;
                                          ?_);
                                      rotate_right)
                                [Elab.step] [0.014447] (refine
                                          no_implicit_lambda%
                                            (suffices x ⊆ ∅ by grind;
                                            ?_);
                                        rotate_right)
                                  [Elab.step] [0.014445] (refine
                                            no_implicit_lambda%
                                              (suffices x ⊆ ∅ by grind;
                                              ?_);
                                          rotate_right)
                                    [Elab.step] [0.014442] (refine
                                            no_implicit_lambda%
                                              (suffices x ⊆ ∅ by grind;
                                              ?_);
                                          rotate_right)
                                      [Elab.step] [0.014440] refine
                                              no_implicit_lambda%
                                                (suffices x ⊆ ∅ by grind;
                                                ?_);
                                            rotate_right
                                        [Elab.step] [0.014438] refine
                                                no_implicit_lambda%
                                                  (suffices x ⊆ ∅ by grind;
                                                  ?_);
                                              rotate_right
                                          [Elab.step] [0.014428] refine
                                                no_implicit_lambda%
                                                  (suffices x ⊆ ∅ by grind;
                                                  ?_)
                                            [Elab.step] [0.013889] grind
                                              [Elab.step] [0.013885] grind
                                                [Elab.step] [0.013879] grind
Build completed successfully (880 jobs).
```
</details>

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

When merging, all the commits will be squashed into a single commit
listing all co-authors.

Co-authors in the squash commit are gathered from two sources:

First, all authors of commits to this PR branch are included. Thus,
one way to add co-authors is to include at least one commit authored by
each co-author among the commits in the pull request. If necessary, you
may create empty commits to indicate co-authorship, using commands like so:

git commit --author="Author Name <author@email.com>" --allow-empty -m "add Author Name as coauthor"

Second, co-authors can also be listed in lines at the very bottom of
the commit message (that is, directly before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines
at the bottom of the commit message (before the `---`, and also before
any "Co-authored-by" lines) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
