### PR TITLE
[Merged by Bors] - chore(Order): golf `top_mem_range_transfiniteIterate` using `grind`

### DIFF
--- a/Mathlib/Order/TransfiniteIteration.lean
+++ b/Mathlib/Order/TransfiniteIteration.lean
@@ -104,15 +104,7 @@ lemma top_mem_range_transfiniteIterate
     · exact (hφ' i hi).le
   obtain ⟨j₁, j₂, hj, eq⟩ : ∃ (j₁ j₂ : J) (hj : j₁ < j₂),
       transfiniteIterate φ j₁ i₀ = transfiniteIterate φ j₂ i₀ := by
-    dsimp [Function.Injective] at H
-    simp only [not_forall] at H
-    obtain ⟨j₁, j₂, eq, hj⟩ := H
-    by_cases hj' : j₁ < j₂
-    · exact ⟨j₁, j₂, hj', eq⟩
-    · simp only [not_lt] at hj'
-      obtain hj' | rfl := hj'.lt_or_eq
-      · exact ⟨j₂, j₁, hj', eq.symm⟩
-      · simp at hj
+    grind [Function.Injective]
   by_contra!
   suffices transfiniteIterate φ j₁ i₀ < transfiniteIterate φ j₂ i₀ by
     simp only [eq, lt_self_iff_false] at this


### PR DESCRIPTION
---
<details>
<summary>Show trace profiling of <code>top_mem_range_transfiniteIterate</code>: 40 ms before, 51 ms after </summary>

### Trace profiling of `top_mem_range_transfiniteIterate` before PR 31275
```diff
diff --git a/Mathlib/Order/TransfiniteIteration.lean b/Mathlib/Order/TransfiniteIteration.lean
index 8d65506b7d..5b1f3da52d 100644
--- a/Mathlib/Order/TransfiniteIteration.lean
+++ b/Mathlib/Order/TransfiniteIteration.lean
@@ -93,6 +93,7 @@ lemma monotone_transfiniteIterate (hφ : ∀ (i : I), i ≤ φ i) :
       exact le_iSup (fun (⟨l, hl⟩ : Set.Iio k') ↦ transfiniteIterate φ l i₀) ⟨k, hkj⟩
     · rfl
 
+set_option trace.profiler true in
 lemma top_mem_range_transfiniteIterate
     (hφ' : ∀ i ≠ (⊤ : I), i < φ i) (φtop : φ ⊤ = ⊤)
     (H : ¬ Function.Injective (fun (j : J) ↦ transfiniteIterate φ j i₀)) :
```
```
ℹ [559/559] Built Mathlib.Order.TransfiniteIteration (1.0s)
info: Mathlib/Order/TransfiniteIteration.lean:97:0: [Elab.async] [0.041479] elaborating proof of top_mem_range_transfiniteIterate
  [Elab.definition.value] [0.040500] top_mem_range_transfiniteIterate
    [Elab.step] [0.039594] 
          have hφ (i : I) : i ≤ φ i := by
            by_cases hi : i = ⊤
            · subst hi
              rw [φtop]
            · exact (hφ' i hi).le
          obtain ⟨j₁, j₂, hj, eq⟩ :
            ∃ (j₁ j₂ : J) (hj : j₁ < j₂), transfiniteIterate φ j₁ i₀ = transfiniteIterate φ j₂ i₀ :=
            by
            dsimp [Function.Injective] at H
            simp only [not_forall] at H
            obtain ⟨j₁, j₂, eq, hj⟩ := H
            by_cases hj' : j₁ < j₂
            · exact ⟨j₁, j₂, hj', eq⟩
            · simp only [not_lt] at hj'
              obtain hj' | rfl := hj'.lt_or_eq
              · exact ⟨j₂, j₁, hj', eq.symm⟩
              · simp at hj
          by_contra!
          suffices transfiniteIterate φ j₁ i₀ < transfiniteIterate φ j₂ i₀ by simp only [eq, lt_self_iff_false] at this
          have hj₁ : ¬IsMax j₁ := by
            simp only [not_isMax_iff]
            exact ⟨_, hj⟩
          refine lt_of_lt_of_le (hφ' _ (this j₁)) ?_
          rw [← transfiniteIterate_succ φ i₀ j₁ hj₁]
          exact monotone_transfiniteIterate _ _ hφ (Order.succ_le_of_lt hj)
      [Elab.step] [0.039589] 
            have hφ (i : I) : i ≤ φ i := by
              by_cases hi : i = ⊤
              · subst hi
                rw [φtop]
              · exact (hφ' i hi).le
            obtain ⟨j₁, j₂, hj, eq⟩ :
              ∃ (j₁ j₂ : J) (hj : j₁ < j₂), transfiniteIterate φ j₁ i₀ = transfiniteIterate φ j₂ i₀ :=
              by
              dsimp [Function.Injective] at H
              simp only [not_forall] at H
              obtain ⟨j₁, j₂, eq, hj⟩ := H
              by_cases hj' : j₁ < j₂
              · exact ⟨j₁, j₂, hj', eq⟩
              · simp only [not_lt] at hj'
                obtain hj' | rfl := hj'.lt_or_eq
                · exact ⟨j₂, j₁, hj', eq.symm⟩
                · simp at hj
            by_contra!
            suffices transfiniteIterate φ j₁ i₀ < transfiniteIterate φ j₂ i₀ by
              simp only [eq, lt_self_iff_false] at this
            have hj₁ : ¬IsMax j₁ := by
              simp only [not_isMax_iff]
              exact ⟨_, hj⟩
            refine lt_of_lt_of_le (hφ' _ (this j₁)) ?_
            rw [← transfiniteIterate_succ φ i₀ j₁ hj₁]
            exact monotone_transfiniteIterate _ _ hφ (Order.succ_le_of_lt hj)
        [Elab.step] [0.018251] obtain ⟨j₁, j₂, hj, eq⟩ :
              ∃ (j₁ j₂ : J) (hj : j₁ < j₂), transfiniteIterate φ j₁ i₀ = transfiniteIterate φ j₂ i₀ :=
              by
              dsimp [Function.Injective] at H
              simp only [not_forall] at H
              obtain ⟨j₁, j₂, eq, hj⟩ := H
              by_cases hj' : j₁ < j₂
              · exact ⟨j₁, j₂, hj', eq⟩
              · simp only [not_lt] at hj'
                obtain hj' | rfl := hj'.lt_or_eq
                · exact ⟨j₂, j₁, hj', eq.symm⟩
                · simp at hj
          [Elab.step] [0.014599] 
                dsimp [Function.Injective] at H
                simp only [not_forall] at H
                obtain ⟨j₁, j₂, eq, hj⟩ := H
                by_cases hj' : j₁ < j₂
                · exact ⟨j₁, j₂, hj', eq⟩
                · simp only [not_lt] at hj'
                  obtain hj' | rfl := hj'.lt_or_eq
                  · exact ⟨j₂, j₁, hj', eq.symm⟩
                  · simp at hj
            [Elab.step] [0.014593] 
                  dsimp [Function.Injective] at H
                  simp only [not_forall] at H
                  obtain ⟨j₁, j₂, eq, hj⟩ := H
                  by_cases hj' : j₁ < j₂
                  · exact ⟨j₁, j₂, hj', eq⟩
                  · simp only [not_lt] at hj'
                    obtain hj' | rfl := hj'.lt_or_eq
                    · exact ⟨j₂, j₁, hj', eq.symm⟩
                    · simp at hj
Build completed successfully (559 jobs).
```

### Trace profiling of `top_mem_range_transfiniteIterate` after PR 31275
```diff
diff --git a/Mathlib/Order/TransfiniteIteration.lean b/Mathlib/Order/TransfiniteIteration.lean
index 8d65506b7d..f64b6956d9 100644
--- a/Mathlib/Order/TransfiniteIteration.lean
+++ b/Mathlib/Order/TransfiniteIteration.lean
@@ -93,6 +93,7 @@ lemma monotone_transfiniteIterate (hφ : ∀ (i : I), i ≤ φ i) :
       exact le_iSup (fun (⟨l, hl⟩ : Set.Iio k') ↦ transfiniteIterate φ l i₀) ⟨k, hkj⟩
     · rfl
 
+set_option trace.profiler true in
 lemma top_mem_range_transfiniteIterate
     (hφ' : ∀ i ≠ (⊤ : I), i < φ i) (φtop : φ ⊤ = ⊤)
     (H : ¬ Function.Injective (fun (j : J) ↦ transfiniteIterate φ j i₀)) :
@@ -104,15 +105,7 @@ lemma top_mem_range_transfiniteIterate
     · exact (hφ' i hi).le
   obtain ⟨j₁, j₂, hj, eq⟩ : ∃ (j₁ j₂ : J) (hj : j₁ < j₂),
       transfiniteIterate φ j₁ i₀ = transfiniteIterate φ j₂ i₀ := by
-    dsimp [Function.Injective] at H
-    simp only [not_forall] at H
-    obtain ⟨j₁, j₂, eq, hj⟩ := H
-    by_cases hj' : j₁ < j₂
-    · exact ⟨j₁, j₂, hj', eq⟩
-    · simp only [not_lt] at hj'
-      obtain hj' | rfl := hj'.lt_or_eq
-      · exact ⟨j₂, j₁, hj', eq.symm⟩
-      · simp at hj
+    grind [Function.Injective]
   by_contra!
   suffices transfiniteIterate φ j₁ i₀ < transfiniteIterate φ j₂ i₀ by
     simp only [eq, lt_self_iff_false] at this
```
```
ℹ [559/559] Built Mathlib.Order.TransfiniteIteration (986ms)
info: Mathlib/Order/TransfiniteIteration.lean:97:0: [Elab.async] [0.051521] elaborating proof of top_mem_range_transfiniteIterate
  [Elab.definition.value] [0.050783] top_mem_range_transfiniteIterate
    [Elab.step] [0.050263] 
          have hφ (i : I) : i ≤ φ i := by
            by_cases hi : i = ⊤
            · subst hi
              rw [φtop]
            · exact (hφ' i hi).le
          obtain ⟨j₁, j₂, hj, eq⟩ :
            ∃ (j₁ j₂ : J) (hj : j₁ < j₂), transfiniteIterate φ j₁ i₀ = transfiniteIterate φ j₂ i₀ := by
            grind [Function.Injective]
          by_contra!
          suffices transfiniteIterate φ j₁ i₀ < transfiniteIterate φ j₂ i₀ by simp only [eq, lt_self_iff_false] at this
          have hj₁ : ¬IsMax j₁ := by
            simp only [not_isMax_iff]
            exact ⟨_, hj⟩
          refine lt_of_lt_of_le (hφ' _ (this j₁)) ?_
          rw [← transfiniteIterate_succ φ i₀ j₁ hj₁]
          exact monotone_transfiniteIterate _ _ hφ (Order.succ_le_of_lt hj)
      [Elab.step] [0.050258] 
            have hφ (i : I) : i ≤ φ i := by
              by_cases hi : i = ⊤
              · subst hi
                rw [φtop]
              · exact (hφ' i hi).le
            obtain ⟨j₁, j₂, hj, eq⟩ :
              ∃ (j₁ j₂ : J) (hj : j₁ < j₂), transfiniteIterate φ j₁ i₀ = transfiniteIterate φ j₂ i₀ := by
              grind [Function.Injective]
            by_contra!
            suffices transfiniteIterate φ j₁ i₀ < transfiniteIterate φ j₂ i₀ by
              simp only [eq, lt_self_iff_false] at this
            have hj₁ : ¬IsMax j₁ := by
              simp only [not_isMax_iff]
              exact ⟨_, hj⟩
            refine lt_of_lt_of_le (hφ' _ (this j₁)) ?_
            rw [← transfiniteIterate_succ φ i₀ j₁ hj₁]
            exact monotone_transfiniteIterate _ _ hφ (Order.succ_le_of_lt hj)
        [Elab.step] [0.029432] obtain ⟨j₁, j₂, hj, eq⟩ :
              ∃ (j₁ j₂ : J) (hj : j₁ < j₂), transfiniteIterate φ j₁ i₀ = transfiniteIterate φ j₂ i₀ := by
              grind [Function.Injective]
          [Elab.step] [0.025776] grind [Function.Injective]
            [Elab.step] [0.025771] grind [Function.Injective]
              [Elab.step] [0.025763] grind [Function.Injective]
Build completed successfully (559 jobs).
```
</details>

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

When merging, all the commits will be squashed into a single commit
listing all co-authors.

Co-authors in the squash commit are gathered from two sources:

First, all authors of commits to this PR branch are included. Thus,
one way to add co-authors is to include at least one commit authored by
each co-author among the commits in the pull request. If necessary, you
may create empty commits to indicate co-authorship, using commands like so:

git commit --author="Author Name <author@email.com>" --allow-empty -m "add Author Name as coauthor"

Second, co-authors can also be listed in lines at the very bottom of
the commit message (that is, directly before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines
at the bottom of the commit message (before the `---`, and also before
any "Co-authored-by" lines) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
