### PR TITLE
[Merged by Bors] - feat: mfderiv of Sum.swap

### DIFF
--- a/Mathlib/Geometry/Manifold/MFDeriv/SpecificFunctions.lean
+++ b/Mathlib/Geometry/Manifold/MFDeriv/SpecificFunctions.lean
@@ -666,7 +666,7 @@ variable {M' : Type*} [TopologicalSpace M'] [ChartedSpace H M'] {s : Set (M ⊕ 
 
 /-- In extended charts at `p`, `Sum.swap` looks like the identity near `p`. -/
 lemma writtenInExtChartAt_sumSwap_eventuallyEq_id :
-    writtenInExtChartAt I I p Sum.swap =ᶠ[𝓝[range I] I (chartAt H p p)] id := by
+    writtenInExtChartAt I I p Sum.swap =ᶠ[𝓝[range I] (I <|chartAt H p p)] id := by
   cases p with
     | inl x =>
       let t := I.symm ⁻¹' (chartAt H x).target ∩ range I
@@ -695,23 +695,17 @@ lemma writtenInExtChartAt_sumSwap_eventuallyEq_id :
       refine ⟨I.continuousWithinAt_symm.preimage_mem_nhdsWithin ?_, self_mem_nhdsWithin⟩
       exact (chartAt H x).open_target.mem_nhds (by simp)
 
-theorem hasMFDerivWithinAt_sumSwap :
-    HasMFDerivWithinAt I I (@Sum.swap M M') s p (ContinuousLinearMap.id 𝕜 (TangentSpace I p)) := by
+theorem hasMFDerivAt_sumSwap :
+    HasMFDerivAt I I (@Sum.swap M M') p (ContinuousLinearMap.id 𝕜 (TangentSpace I p)) := by
   refine ⟨by fun_prop, ?_⟩
-  apply (hasFDerivWithinAt_id _ <| (extChartAt I p).symm ⁻¹' s ∩ range I).congr_of_eventuallyEq
-  · exact writtenInExtChartAt_sumSwap_eventuallyEq_id.filter_mono <|
-      nhdsWithin_mono _ inter_subset_right
+  apply (hasFDerivWithinAt_id _ (range I)).congr_of_eventuallyEq
+  · exact writtenInExtChartAt_sumSwap_eventuallyEq_id
   · simp only [mfld_simps]
     cases p <;> simp
 
-theorem hasMFDerivAt_sumSwap :
-    HasMFDerivAt I I (@Sum.swap M M') p (ContinuousLinearMap.id 𝕜 (TangentSpace I p)) := by
-  rw [← hasMFDerivWithinAt_univ]
-  exact hasMFDerivWithinAt_sumSwap
-
-theorem mfderivWithin_sumSwap (hU : UniqueMDiffWithinAt I s p) :
+theorem mfderivWithin_sumSwap (hs : UniqueMDiffWithinAt I s p) :
     mfderivWithin I I (@Sum.swap M M') s p = ContinuousLinearMap.id 𝕜 (TangentSpace I p) :=
-  (hasMFDerivWithinAt_sumSwap).mfderivWithin hU
+  hasMFDerivAt_sumSwap.hasMFDerivWithinAt.mfderivWithin hs
 
 theorem mfderiv_sumSwap :
     mfderiv I I (@Sum.swap M M') p = ContinuousLinearMap.id 𝕜 (TangentSpace I p) := by

--- a/Mathlib/Geometry/Manifold/MFDeriv/SpecificFunctions.lean
+++ b/Mathlib/Geometry/Manifold/MFDeriv/SpecificFunctions.lean
@@ -714,8 +714,7 @@ theorem mfderivWithin_sumSwap (hU : UniqueMDiffWithinAt I s p) :
   (hasMFDerivWithinAt_sumSwap).mfderivWithin hU
 
 theorem mfderiv_sumSwap :
-    mfderiv I I (@Sum.swap M M') p
-      = ContinuousLinearMap.id 𝕜 (TangentSpace I p) := by
+    mfderiv I I (@Sum.swap M M') p = ContinuousLinearMap.id 𝕜 (TangentSpace I p) := by
   simpa [mfderivWithin_univ] using (mfderivWithin_sumSwap (uniqueMDiffWithinAt_univ I))
 
 end disjointUnion

--- a/Mathlib/Geometry/Manifold/MFDeriv/SpecificFunctions.lean
+++ b/Mathlib/Geometry/Manifold/MFDeriv/SpecificFunctions.lean
@@ -660,6 +660,70 @@ theorem mfderiv_prod_eq_add_apply {f : M × M' → M''} {p : M × M'} {v : Tange
 
 end Prod
 
+section disjointUnion
+
+variable {M' : Type*} [TopologicalSpace M'] [ChartedSpace H M'] {n : WithTop ℕ∞}
+  {E' : Type*} [NormedAddCommGroup E'] [NormedSpace 𝕜 E'] {H' : Type*} [TopologicalSpace H']
+  {J : Type*} {J : ModelWithCorners 𝕜 E' H'}
+  {N N' : Type*} [TopologicalSpace N] [TopologicalSpace N'] [ChartedSpace H' N] [ChartedSpace H' N']
+
+open Topology
+
+variable {f : M → N} (g : M' → N') {s : Set (M ⊕ M')} {t : Set M'} {p : M ⊕ M'}
+
+attribute [fun_prop] Continuous.continuousWithinAt
+theorem hasMFDerivWithinAt_sumSwap :
+    HasMFDerivWithinAt I I (@Sum.swap M M') s p
+      (ContinuousLinearMap.id 𝕜 (TangentSpace I p)) := by
+  refine ⟨by fun_prop, ?_⟩
+  set U := (extChartAt I p).symm ⁻¹' s ∩ range I
+  have : HasFDerivWithinAt id (ContinuousLinearMap.id 𝕜 _) U (((chartAt H p).extend I) p) :=
+    hasFDerivWithinAt_id _ U
+  apply this.congr_of_eventuallyEq
+  swap
+  · simp only [mfld_simps]
+    cases p with
+    | inl x => simp
+    | inr x => simp
+  -- extract as a lemma about writtenInExtChartAt of Sum.swap? maybe!
+  cases p with
+    | inl x =>
+      let t := I.symm ⁻¹' (chartAt H x).target ∩ range I
+      have : EqOn (writtenInExtChartAt I I (Sum.inl x) (@Sum.swap M M')) id t := by
+        intro y hy
+        simp only [writtenInExtChartAt, extChartAt, Sum.swap_inl,
+          ChartedSpace.sum_chartAt_inl, ChartedSpace.sum_chartAt_inr]
+        dsimp
+        rw [Sum.inr_injective.extend_apply, (chartAt H x).right_inv (by grind)]
+        exact I.right_inv (by grind)
+      sorry -- basic question about filters now!
+    | inr x =>
+      let t := I.symm ⁻¹' (chartAt H x).target ∩ range I
+      have : EqOn (writtenInExtChartAt I I (Sum.inr x) (@Sum.swap M M')) id t := by
+        intro y hy
+        simp only [writtenInExtChartAt, extChartAt, Sum.swap_inr,
+          ChartedSpace.sum_chartAt_inl, ChartedSpace.sum_chartAt_inr]
+        dsimp
+        rw [Sum.inl_injective.extend_apply, (chartAt H x).right_inv (by grind)]
+        exact I.right_inv (by grind)
+      sorry -- same sorry as above
+
+theorem hasMFDerivAt_sumSwap :
+    HasMFDerivAt I I (@Sum.swap M M') p (ContinuousLinearMap.id 𝕜 (TangentSpace I p)) := by
+  rw [← hasMFDerivWithinAt_univ]
+  exact hasMFDerivWithinAt_sumSwap
+
+theorem mfderivWithin_sumSwap (hU : UniqueMDiffWithinAt I s p) :
+    mfderivWithin I I (@Sum.swap M M') s p = ContinuousLinearMap.id 𝕜 (TangentSpace I p) :=
+  (hasMFDerivWithinAt_sumSwap).mfderivWithin hU
+
+theorem mfderiv_sumSwap :
+    mfderiv I I (@Sum.swap M M') p
+      = ContinuousLinearMap.id 𝕜 (TangentSpace I p) := by
+  simpa [mfderivWithin_univ] using (mfderivWithin_sumSwap (uniqueMDiffWithinAt_univ I))
+
+end disjointUnion
+
 section Arithmetic
 
 /-! #### Arithmetic

--- a/Mathlib/Geometry/Manifold/MFDeriv/SpecificFunctions.lean
+++ b/Mathlib/Geometry/Manifold/MFDeriv/SpecificFunctions.lean
@@ -669,7 +669,7 @@ variable {M' : Type*} [TopologicalSpace M'] [ChartedSpace H M'] {n : WithTop ℕ
 
 open Topology
 
-variable {f : M → N} (g : M' → N') {s : Set (M ⊕ M')} {t : Set M'} {p : M ⊕ M'}
+variable {s : Set (M ⊕ M')} {p : M ⊕ M'}
 
 /-- In extended charts at `p`, `Sum.swap` looks like the identity near `p`. -/
 lemma writtenInExtChartAt_sumSwap_eventuallyEq_id :

--- a/Mathlib/Geometry/Manifold/MFDeriv/SpecificFunctions.lean
+++ b/Mathlib/Geometry/Manifold/MFDeriv/SpecificFunctions.lean
@@ -679,20 +679,10 @@ lemma mem_nhdsWithin_inter_self : t ∈ 𝓝[s ∩ t] x := by
 
 attribute [fun_prop] Continuous.continuousWithinAt -- unrelated, but probably desirable
 
-theorem hasMFDerivWithinAt_sumSwap :
-    HasMFDerivWithinAt I I (@Sum.swap M M') s p
-      (ContinuousLinearMap.id 𝕜 (TangentSpace I p)) := by
-  refine ⟨by fun_prop, ?_⟩
-  set U := (extChartAt I p).symm ⁻¹' s ∩ range I
-  have : HasFDerivWithinAt id (ContinuousLinearMap.id 𝕜 _) U (((chartAt H p).extend I) p) :=
-    hasFDerivWithinAt_id _ U
-  apply this.congr_of_eventuallyEq
-  swap
-  · simp only [mfld_simps]
-    cases p with
-    | inl x => simp
-    | inr x => simp
-  -- extract as a lemma about writtenInExtChartAt of Sum.swap?
+/-- In extended charts at `p`, `Sum.swap` looks like the identity near `p`. -/
+lemma writtenInExtChartAt_sumSwap_eventuallyEq_id :
+    writtenInExtChartAt I I p Sum.swap =ᶠ[𝓝[(extChartAt I p).symm ⁻¹' s ∩ range I]
+      extChartAt I p p] id := by
   cases p with
     | inl x =>
       let t := I.symm ⁻¹' (chartAt H x).target ∩ range I
@@ -720,6 +710,17 @@ theorem hasMFDerivWithinAt_sumSwap :
       rw [Filter.inter_mem_iff]
       refine ⟨I.continuousWithinAt_symm.preimage_mem_nhdsWithin ?_, mem_nhdsWithin_inter_self⟩
       exact (chartAt H x).open_target.mem_nhds (by simp)
+
+theorem hasMFDerivWithinAt_sumSwap :
+    HasMFDerivWithinAt I I (@Sum.swap M M') s p
+      (ContinuousLinearMap.id 𝕜 (TangentSpace I p)) := by
+  refine ⟨by fun_prop, ?_⟩
+  set U := (extChartAt I p).symm ⁻¹' s ∩ range I
+  have : HasFDerivWithinAt id (ContinuousLinearMap.id 𝕜 _) U (((chartAt H p).extend I) p) :=
+    hasFDerivWithinAt_id _ U
+  apply this.congr_of_eventuallyEq writtenInExtChartAt_sumSwap_eventuallyEq_id
+  simp only [mfld_simps]
+  cases p <;> simp
 
 theorem hasMFDerivAt_sumSwap :
     HasMFDerivAt I I (@Sum.swap M M') p (ContinuousLinearMap.id 𝕜 (TangentSpace I p)) := by

--- a/Mathlib/Geometry/Manifold/MFDeriv/SpecificFunctions.lean
+++ b/Mathlib/Geometry/Manifold/MFDeriv/SpecificFunctions.lean
@@ -696,13 +696,9 @@ lemma writtenInExtChartAt_sumSwap_eventuallyEq_id :
       exact (chartAt H x).open_target.mem_nhds (by simp)
 
 theorem hasMFDerivWithinAt_sumSwap :
-    HasMFDerivWithinAt I I (@Sum.swap M M') s p
-      (ContinuousLinearMap.id 𝕜 (TangentSpace I p)) := by
+    HasMFDerivWithinAt I I (@Sum.swap M M') s p (ContinuousLinearMap.id 𝕜 (TangentSpace I p)) := by
   refine ⟨by fun_prop, ?_⟩
-  set U := (extChartAt I p).symm ⁻¹' s ∩ range I
-  have : HasFDerivWithinAt id (ContinuousLinearMap.id 𝕜 _) U (((chartAt H p).extend I) p) :=
-    hasFDerivWithinAt_id _ U
-  apply this.congr_of_eventuallyEq
+  apply (hasFDerivWithinAt_id _ <| (extChartAt I p).symm ⁻¹' s ∩ range I).congr_of_eventuallyEq
   · exact writtenInExtChartAt_sumSwap_eventuallyEq_id.filter_mono <|
       nhdsWithin_mono _ inter_subset_right
   · simp only [mfld_simps]

--- a/Mathlib/Geometry/Manifold/MFDeriv/SpecificFunctions.lean
+++ b/Mathlib/Geometry/Manifold/MFDeriv/SpecificFunctions.lean
@@ -671,14 +671,6 @@ open Topology
 
 variable {f : M → N} (g : M' → N') {s : Set (M ⊕ M')} {t : Set M'} {p : M ⊕ M'}
 
--- TODO: move to the right location!
-variable {α : Type*} [TopologicalSpace α] {s t : Set α} {x : α} in
-lemma mem_nhdsWithin_inter_self : t ∈ 𝓝[s ∩ t] x := by
-  refine mem_nhdsWithin_iff_eventuallyEq.mpr ?_
-  filter_upwards with y using by simp [inter_assoc]
-
-attribute [fun_prop] Continuous.continuousWithinAt -- unrelated, but probably desirable
-
 /-- In extended charts at `p`, `Sum.swap` looks like the identity near `p`. -/
 lemma writtenInExtChartAt_sumSwap_eventuallyEq_id :
     writtenInExtChartAt I I p Sum.swap =ᶠ[𝓝[(extChartAt I p).symm ⁻¹' s ∩ range I]

--- a/Mathlib/Geometry/Manifold/MFDeriv/SpecificFunctions.lean
+++ b/Mathlib/Geometry/Manifold/MFDeriv/SpecificFunctions.lean
@@ -671,11 +671,14 @@ open Topology
 
 variable {f : M → N} (g : M' → N') {s : Set (M ⊕ M')} {t : Set M'} {p : M ⊕ M'}
 
-lemma foo {α : Type*} [TopologicalSpace α] {s u : Set α} {x : α} : u ∈ 𝓝[s ∩ u] x := by
+-- TODO: move to the right location!
+variable {α : Type*} [TopologicalSpace α] {s t : Set α} {x : α} in
+lemma mem_nhdsWithin_inter_self : t ∈ 𝓝[s ∩ t] x := by
   refine mem_nhdsWithin_iff_eventuallyEq.mpr ?_
   filter_upwards with y using by simp [inter_assoc]
 
-attribute [fun_prop] Continuous.continuousWithinAt
+attribute [fun_prop] Continuous.continuousWithinAt -- unrelated, but probably desirable
+
 theorem hasMFDerivWithinAt_sumSwap :
     HasMFDerivWithinAt I I (@Sum.swap M M') s p
       (ContinuousLinearMap.id 𝕜 (TangentSpace I p)) := by
@@ -689,7 +692,7 @@ theorem hasMFDerivWithinAt_sumSwap :
     cases p with
     | inl x => simp
     | inr x => simp
-  -- extract as a lemma about writtenInExtChartAt of Sum.swap? maybe!
+  -- extract as a lemma about writtenInExtChartAt of Sum.swap?
   cases p with
     | inl x =>
       let t := I.symm ⁻¹' (chartAt H x).target ∩ range I
@@ -700,22 +703,10 @@ theorem hasMFDerivWithinAt_sumSwap :
         dsimp
         rw [Sum.inr_injective.extend_apply, (chartAt H x).right_inv (by grind)]
         exact I.right_inv (by grind)
-      apply Filter.eventually_of_mem (h := this)
-      set x' := ((chartAt H (@Sum.inl M M' x)).extend I) (Sum.inl x)
-
-      simp only [t, U]
-      simp only [Filter.inter_mem_iff]
-      refine ⟨?_, foo⟩
-      -- too optimistic! apply mem_nhdsWithin_of_mem_nhds
-      -- goal: chartAt H x.target is open, and
-      -- we're taking neighbourhoods within the codomain of I, right?
-
-      -- just for fun; not actually answering the question
-      have : Nonempty H := sorry -- surely?
-      simp
-      rw [ChartedSpace.sum_chartAt_inl, OpenPartialHomeomorph.lift_openEmbedding_symm]
-
-      sorry -- need to think now!
+      apply Filter.eventually_of_mem ?_ this
+      rw [Filter.inter_mem_iff]
+      refine ⟨I.continuousWithinAt_symm.preimage_mem_nhdsWithin ?_, mem_nhdsWithin_inter_self⟩
+      exact (chartAt H x).open_target.mem_nhds (by simp)
     | inr x =>
       let t := I.symm ⁻¹' (chartAt H x).target ∩ range I
       have : EqOn (writtenInExtChartAt I I (Sum.inr x) (@Sum.swap M M')) id t := by
@@ -725,7 +716,10 @@ theorem hasMFDerivWithinAt_sumSwap :
         dsimp
         rw [Sum.inl_injective.extend_apply, (chartAt H x).right_inv (by grind)]
         exact I.right_inv (by grind)
-      sorry -- same sorry as above
+      apply Filter.eventually_of_mem ?_ this
+      rw [Filter.inter_mem_iff]
+      refine ⟨I.continuousWithinAt_symm.preimage_mem_nhdsWithin ?_, mem_nhdsWithin_inter_self⟩
+      exact (chartAt H x).open_target.mem_nhds (by simp)
 
 theorem hasMFDerivAt_sumSwap :
     HasMFDerivAt I I (@Sum.swap M M') p (ContinuousLinearMap.id 𝕜 (TangentSpace I p)) := by

--- a/Mathlib/Geometry/Manifold/MFDeriv/SpecificFunctions.lean
+++ b/Mathlib/Geometry/Manifold/MFDeriv/SpecificFunctions.lean
@@ -703,10 +703,12 @@ theorem hasMFDerivAt_sumSwap :
   · simp only [mfld_simps]
     cases p <;> simp
 
+@[simp]
 theorem mfderivWithin_sumSwap (hs : UniqueMDiffWithinAt I s p) :
     mfderivWithin I I (@Sum.swap M M') s p = ContinuousLinearMap.id 𝕜 (TangentSpace I p) :=
   hasMFDerivAt_sumSwap.hasMFDerivWithinAt.mfderivWithin hs
 
+@[simp]
 theorem mfderiv_sumSwap :
     mfderiv I I (@Sum.swap M M') p = ContinuousLinearMap.id 𝕜 (TangentSpace I p) := by
   simpa [mfderivWithin_univ] using (mfderivWithin_sumSwap (uniqueMDiffWithinAt_univ I))

--- a/Mathlib/Geometry/Manifold/MFDeriv/SpecificFunctions.lean
+++ b/Mathlib/Geometry/Manifold/MFDeriv/SpecificFunctions.lean
@@ -698,7 +698,7 @@ lemma writtenInExtChartAt_sumSwap_eventuallyEq_id :
 theorem hasMFDerivWithinAt_sumSwap :
     HasMFDerivWithinAt I I (@Sum.swap M M') s p
       (ContinuousLinearMap.id 𝕜 (TangentSpace I p)) := by
-  refine ⟨by sorry/-fun_prop-/, ?_⟩
+  refine ⟨by fun_prop, ?_⟩
   set U := (extChartAt I p).symm ⁻¹' s ∩ range I
   have : HasFDerivWithinAt id (ContinuousLinearMap.id 𝕜 _) U (((chartAt H p).extend I) p) :=
     hasFDerivWithinAt_id _ U

--- a/Mathlib/Geometry/Manifold/MFDeriv/SpecificFunctions.lean
+++ b/Mathlib/Geometry/Manifold/MFDeriv/SpecificFunctions.lean
@@ -662,14 +662,7 @@ end Prod
 
 section disjointUnion
 
-variable {M' : Type*} [TopologicalSpace M'] [ChartedSpace H M'] {n : WithTop ℕ∞}
-  {E' : Type*} [NormedAddCommGroup E'] [NormedSpace 𝕜 E'] {H' : Type*} [TopologicalSpace H']
-  {J : Type*} {J : ModelWithCorners 𝕜 E' H'}
-  {N N' : Type*} [TopologicalSpace N] [TopologicalSpace N'] [ChartedSpace H' N] [ChartedSpace H' N']
-
-open Topology
-
-variable {s : Set (M ⊕ M')} {p : M ⊕ M'}
+variable {M' : Type*} [TopologicalSpace M'] [ChartedSpace H M'] {s : Set (M ⊕ M')} {p : M ⊕ M'}
 
 /-- In extended charts at `p`, `Sum.swap` looks like the identity near `p`. -/
 lemma writtenInExtChartAt_sumSwap_eventuallyEq_id :

--- a/Mathlib/Geometry/Manifold/MFDeriv/SpecificFunctions.lean
+++ b/Mathlib/Geometry/Manifold/MFDeriv/SpecificFunctions.lean
@@ -671,6 +671,10 @@ open Topology
 
 variable {f : M → N} (g : M' → N') {s : Set (M ⊕ M')} {t : Set M'} {p : M ⊕ M'}
 
+lemma foo {α : Type*} [TopologicalSpace α] {s u : Set α} {x : α} : u ∈ 𝓝[s ∩ u] x := by
+  refine mem_nhdsWithin_iff_eventuallyEq.mpr ?_
+  filter_upwards with y using by simp [inter_assoc]
+
 attribute [fun_prop] Continuous.continuousWithinAt
 theorem hasMFDerivWithinAt_sumSwap :
     HasMFDerivWithinAt I I (@Sum.swap M M') s p
@@ -696,7 +700,22 @@ theorem hasMFDerivWithinAt_sumSwap :
         dsimp
         rw [Sum.inr_injective.extend_apply, (chartAt H x).right_inv (by grind)]
         exact I.right_inv (by grind)
-      sorry -- basic question about filters now!
+      apply Filter.eventually_of_mem (h := this)
+      set x' := ((chartAt H (@Sum.inl M M' x)).extend I) (Sum.inl x)
+
+      simp only [t, U]
+      simp only [Filter.inter_mem_iff]
+      refine ⟨?_, foo⟩
+      -- too optimistic! apply mem_nhdsWithin_of_mem_nhds
+      -- goal: chartAt H x.target is open, and
+      -- we're taking neighbourhoods within the codomain of I, right?
+
+      -- just for fun; not actually answering the question
+      have : Nonempty H := sorry -- surely?
+      simp
+      rw [ChartedSpace.sum_chartAt_inl, OpenPartialHomeomorph.lift_openEmbedding_symm]
+
+      sorry -- need to think now!
     | inr x =>
       let t := I.symm ⁻¹' (chartAt H x).target ∩ range I
       have : EqOn (writtenInExtChartAt I I (Sum.inr x) (@Sum.swap M M')) id t := by

--- a/Mathlib/Geometry/Manifold/MFDeriv/SpecificFunctions.lean
+++ b/Mathlib/Geometry/Manifold/MFDeriv/SpecificFunctions.lean
@@ -662,7 +662,7 @@ end Prod
 
 section disjointUnion
 
-variable {M' : Type*} [TopologicalSpace M'] [ChartedSpace H M'] {s : Set (M ⊕ M')} {p : M ⊕ M'}
+variable {M' : Type*} [TopologicalSpace M'] [ChartedSpace H M'] {p : M ⊕ M'}
 
 /-- In extended charts at `p`, `Sum.swap` looks like the identity near `p`. -/
 lemma writtenInExtChartAt_sumSwap_eventuallyEq_id :
@@ -704,7 +704,7 @@ theorem hasMFDerivAt_sumSwap :
     cases p <;> simp
 
 @[simp]
-theorem mfderivWithin_sumSwap (hs : UniqueMDiffWithinAt I s p) :
+theorem mfderivWithin_sumSwap {s : Set (M ⊕ M')} (hs : UniqueMDiffWithinAt I s p) :
     mfderivWithin I I (@Sum.swap M M') s p = ContinuousLinearMap.id 𝕜 (TangentSpace I p) :=
   hasMFDerivAt_sumSwap.hasMFDerivWithinAt.mfderivWithin hs
 

--- a/Mathlib/Geometry/Manifold/MFDeriv/SpecificFunctions.lean
+++ b/Mathlib/Geometry/Manifold/MFDeriv/SpecificFunctions.lean
@@ -666,8 +666,7 @@ variable {M' : Type*} [TopologicalSpace M'] [ChartedSpace H M'] {s : Set (M ⊕ 
 
 /-- In extended charts at `p`, `Sum.swap` looks like the identity near `p`. -/
 lemma writtenInExtChartAt_sumSwap_eventuallyEq_id :
-    writtenInExtChartAt I I p Sum.swap =ᶠ[𝓝[(extChartAt I p).symm ⁻¹' s ∩ range I]
-      extChartAt I p p] id := by
+    writtenInExtChartAt I I p Sum.swap =ᶠ[𝓝[range I] I (chartAt H p p)] id := by
   cases p with
     | inl x =>
       let t := I.symm ⁻¹' (chartAt H x).target ∩ range I
@@ -680,7 +679,7 @@ lemma writtenInExtChartAt_sumSwap_eventuallyEq_id :
         exact I.right_inv (by grind)
       apply Filter.eventually_of_mem ?_ this
       rw [Filter.inter_mem_iff]
-      refine ⟨I.continuousWithinAt_symm.preimage_mem_nhdsWithin ?_, mem_nhdsWithin_inter_self⟩
+      refine ⟨I.continuousWithinAt_symm.preimage_mem_nhdsWithin ?_, self_mem_nhdsWithin⟩
       exact (chartAt H x).open_target.mem_nhds (by simp)
     | inr x =>
       let t := I.symm ⁻¹' (chartAt H x).target ∩ range I
@@ -693,19 +692,21 @@ lemma writtenInExtChartAt_sumSwap_eventuallyEq_id :
         exact I.right_inv (by grind)
       apply Filter.eventually_of_mem ?_ this
       rw [Filter.inter_mem_iff]
-      refine ⟨I.continuousWithinAt_symm.preimage_mem_nhdsWithin ?_, mem_nhdsWithin_inter_self⟩
+      refine ⟨I.continuousWithinAt_symm.preimage_mem_nhdsWithin ?_, self_mem_nhdsWithin⟩
       exact (chartAt H x).open_target.mem_nhds (by simp)
 
 theorem hasMFDerivWithinAt_sumSwap :
     HasMFDerivWithinAt I I (@Sum.swap M M') s p
       (ContinuousLinearMap.id 𝕜 (TangentSpace I p)) := by
-  refine ⟨by fun_prop, ?_⟩
+  refine ⟨by sorry/-fun_prop-/, ?_⟩
   set U := (extChartAt I p).symm ⁻¹' s ∩ range I
   have : HasFDerivWithinAt id (ContinuousLinearMap.id 𝕜 _) U (((chartAt H p).extend I) p) :=
     hasFDerivWithinAt_id _ U
-  apply this.congr_of_eventuallyEq writtenInExtChartAt_sumSwap_eventuallyEq_id
-  simp only [mfld_simps]
-  cases p <;> simp
+  apply this.congr_of_eventuallyEq
+  · exact writtenInExtChartAt_sumSwap_eventuallyEq_id.filter_mono <|
+      nhdsWithin_mono _ inter_subset_right
+  · simp only [mfld_simps]
+    cases p <;> simp
 
 theorem hasMFDerivAt_sumSwap :
     HasMFDerivAt I I (@Sum.swap M M') p (ContinuousLinearMap.id 𝕜 (TangentSpace I p)) := by

--- a/Mathlib/Topology/NhdsWithin.lean
+++ b/Mathlib/Topology/NhdsWithin.lean
@@ -110,7 +110,7 @@ theorem mem_nhdsWithin_iff_eventuallyEq {s t : Set α} {x : α} :
     t ∈ 𝓝[s] x ↔ s =ᶠ[𝓝 x] (s ∩ t : Set α) := by
   simp_rw [mem_nhdsWithin_iff_eventually, eventuallyEq_set, mem_inter_iff, iff_self_and]
 
-lemma mem_nhdsWithin_inter_self {s t : Set α} {x : α} : t ∈ 𝓝[s ∩ t] x := by
+lemma mem_nhdsWithin_inter_self {s t : Set α} {x : α} : t ∈ 𝓝[s ∩ t] x :=
   mem_nhdsWithin_iff_eventuallyEq.mpr <| by simp [inter_assoc]
 
 lemma mem_nhdsWithin_self_inter {s t : Set α} {x : α} : s ∈ 𝓝[s ∩ t] x :=

--- a/Mathlib/Topology/NhdsWithin.lean
+++ b/Mathlib/Topology/NhdsWithin.lean
@@ -110,6 +110,10 @@ theorem mem_nhdsWithin_iff_eventuallyEq {s t : Set α} {x : α} :
     t ∈ 𝓝[s] x ↔ s =ᶠ[𝓝 x] (s ∩ t : Set α) := by
   simp_rw [mem_nhdsWithin_iff_eventually, eventuallyEq_set, mem_inter_iff, iff_self_and]
 
+lemma mem_nhdsWithin_inter_self {s t : Set α} {x : α} : t ∈ 𝓝[s ∩ t] x := by
+  refine mem_nhdsWithin_iff_eventuallyEq.mpr ?_
+  filter_upwards with y using by simp [inter_assoc]
+
 theorem nhdsWithin_eq_iff_eventuallyEq {s t : Set α} {x : α} : 𝓝[s] x = 𝓝[t] x ↔ s =ᶠ[𝓝 x] t :=
   set_eventuallyEq_iff_inf_principal.symm
 

--- a/Mathlib/Topology/NhdsWithin.lean
+++ b/Mathlib/Topology/NhdsWithin.lean
@@ -111,8 +111,10 @@ theorem mem_nhdsWithin_iff_eventuallyEq {s t : Set α} {x : α} :
   simp_rw [mem_nhdsWithin_iff_eventually, eventuallyEq_set, mem_inter_iff, iff_self_and]
 
 lemma mem_nhdsWithin_inter_self {s t : Set α} {x : α} : t ∈ 𝓝[s ∩ t] x := by
-  refine mem_nhdsWithin_iff_eventuallyEq.mpr ?_
-  filter_upwards with y using by simp [inter_assoc]
+  mem_nhdsWithin_iff_eventuallyEq.mpr <| by simp [inter_assoc]
+
+lemma mem_nhdsWithin_self_inter {s t : Set α} {x : α} : s ∈ 𝓝[s ∩ t] x :=
+  mem_nhdsWithin_iff_eventuallyEq.mpr <| by simp [inter_comm s t, inter_assoc]
 
 theorem nhdsWithin_eq_iff_eventuallyEq {s t : Set α} {x : α} : 𝓝[s] x = 𝓝[t] x ↔ s =ᶠ[𝓝 x] t :=
   set_eventuallyEq_iff_inf_principal.symm


### PR DESCRIPTION
To be used to simplify the proof of #31200, thus transitively part of my bordism theory project.

---

- [x] depends on: #31285

<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

When merging, all the commits will be squashed into a single commit
listing all co-authors.

Co-authors in the squash commit are gathered from two sources:

First, all authors of commits to this PR branch are included. Thus,
one way to add co-authors is to include at least one commit authored by
each co-author among the commits in the pull request. If necessary, you
may create empty commits to indicate co-authorship, using commands like so:

git commit --author="Author Name <author@email.com>" --allow-empty -m "add Author Name as coauthor"

Second, co-authors can also be listed in lines at the very bottom of
the commit message (that is, directly before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines
at the bottom of the commit message (before the `---`, and also before
any "Co-authored-by" lines) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
