### PR TITLE
[Merged by Bors] - chore(RingTheory/UniqueFactorizationDomain): golf `eq_factors_of_eq_counts` using `grind`

### DIFF
--- a/Mathlib/RingTheory/UniqueFactorizationDomain/FactorSet.lean
+++ b/Mathlib/RingTheory/UniqueFactorizationDomain/FactorSet.lean
@@ -3,7 +3,6 @@ Copyright (c) 2018 Johannes Hölzl. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Johannes Hölzl, Jens Wagemaker, Aaron Anderson
 -/
-import Mathlib.Data.Finsupp.Multiset
 import Mathlib.RingTheory.UniqueFactorizationDomain.Basic
 import Mathlib.Tactic.Ring
 

--- a/Mathlib/RingTheory/UniqueFactorizationDomain/FactorSet.lean
+++ b/Mathlib/RingTheory/UniqueFactorizationDomain/FactorSet.lean
@@ -286,15 +286,9 @@ theorem eq_factors_of_eq_counts {a b : Associates α} (ha : a ≠ 0) (hb : b ≠
     a.factors = b.factors := by
   obtain ⟨sa, h_sa⟩ := factors_eq_some_iff_ne_zero.mpr ha
   obtain ⟨sb, h_sb⟩ := factors_eq_some_iff_ne_zero.mpr hb
-  rw [h_sa, h_sb] at h ⊢
-  rw [WithTop.coe_eq_coe]
-  have h_count : ∀ (p : Associates α) (hp : Irreducible p),
-      sa.count ⟨p, hp⟩ = sb.count ⟨p, hp⟩ := by
-    intro p hp
-    rw [← count_some, ← count_some, h p hp]
-  apply Multiset.toFinsupp.injective
-  ext ⟨p, hp⟩
-  rw [Multiset.toFinsupp_apply, Multiset.toFinsupp_apply, h_count p hp]
+  simp_all only [count_some, WithTop.coe_eq_coe]
+  ext
+  grind
 
 theorem eq_of_eq_counts {a b : Associates α} (ha : a ≠ 0) (hb : b ≠ 0)
     (h : ∀ p : Associates α, Irreducible p → p.count a.factors = p.count b.factors) : a = b :=


### PR DESCRIPTION
---
<details>
<summary>Show trace profiling of <code>eq_factors_of_eq_counts</code>: 16 ms before, 35 ms after </summary>

### Trace profiling of `eq_factors_of_eq_counts` before PR 31277
```diff
diff --git a/Mathlib/RingTheory/UniqueFactorizationDomain/FactorSet.lean b/Mathlib/RingTheory/UniqueFactorizationDomain/FactorSet.lean
index e0b06d0039..948e84c5d1 100644
--- a/Mathlib/RingTheory/UniqueFactorizationDomain/FactorSet.lean
+++ b/Mathlib/RingTheory/UniqueFactorizationDomain/FactorSet.lean
@@ -281,6 +281,7 @@ section count
 
 variable [DecidableEq (Associates α)] [∀ p : Associates α, Decidable (Irreducible p)]
 
+set_option trace.profiler true in
 theorem eq_factors_of_eq_counts {a b : Associates α} (ha : a ≠ 0) (hb : b ≠ 0)
     (h : ∀ p : Associates α, Irreducible p → p.count a.factors = p.count b.factors) :
     a.factors = b.factors := by
```
```
ℹ [930/930] Built Mathlib.RingTheory.UniqueFactorizationDomain.FactorSet (1.6s)
info: Mathlib/RingTheory/UniqueFactorizationDomain/FactorSet.lean:285:0: [Elab.async] [0.016905] elaborating proof of Associates.eq_factors_of_eq_counts
  [Elab.definition.value] [0.015848] Associates.eq_factors_of_eq_counts
    [Elab.step] [0.014678] 
          obtain ⟨sa, h_sa⟩ := factors_eq_some_iff_ne_zero.mpr ha
          obtain ⟨sb, h_sb⟩ := factors_eq_some_iff_ne_zero.mpr hb
          rw [h_sa, h_sb] at h ⊢
          rw [WithTop.coe_eq_coe]
          have h_count : ∀ (p : Associates α) (hp : Irreducible p), sa.count ⟨p, hp⟩ = sb.count ⟨p, hp⟩ :=
            by
            intro p hp
            rw [← count_some, ← count_some, h p hp]
          apply Multiset.toFinsupp.injective
          ext ⟨p, hp⟩
          rw [Multiset.toFinsupp_apply, Multiset.toFinsupp_apply, h_count p hp]
      [Elab.step] [0.014672] 
            obtain ⟨sa, h_sa⟩ := factors_eq_some_iff_ne_zero.mpr ha
            obtain ⟨sb, h_sb⟩ := factors_eq_some_iff_ne_zero.mpr hb
            rw [h_sa, h_sb] at h ⊢
            rw [WithTop.coe_eq_coe]
            have h_count : ∀ (p : Associates α) (hp : Irreducible p), sa.count ⟨p, hp⟩ = sb.count ⟨p, hp⟩ :=
              by
              intro p hp
              rw [← count_some, ← count_some, h p hp]
            apply Multiset.toFinsupp.injective
            ext ⟨p, hp⟩
            rw [Multiset.toFinsupp_apply, Multiset.toFinsupp_apply, h_count p hp]
Build completed successfully (930 jobs).
```

### Trace profiling of `eq_factors_of_eq_counts` after PR 31277
```diff
diff --git a/Mathlib/RingTheory/UniqueFactorizationDomain/FactorSet.lean b/Mathlib/RingTheory/UniqueFactorizationDomain/FactorSet.lean
index e0b06d0039..60f39f0c65 100644
--- a/Mathlib/RingTheory/UniqueFactorizationDomain/FactorSet.lean
+++ b/Mathlib/RingTheory/UniqueFactorizationDomain/FactorSet.lean
@@ -281,20 +281,15 @@ section count
 
 variable [DecidableEq (Associates α)] [∀ p : Associates α, Decidable (Irreducible p)]
 
+set_option trace.profiler true in
 theorem eq_factors_of_eq_counts {a b : Associates α} (ha : a ≠ 0) (hb : b ≠ 0)
     (h : ∀ p : Associates α, Irreducible p → p.count a.factors = p.count b.factors) :
     a.factors = b.factors := by
   obtain ⟨sa, h_sa⟩ := factors_eq_some_iff_ne_zero.mpr ha
   obtain ⟨sb, h_sb⟩ := factors_eq_some_iff_ne_zero.mpr hb
-  rw [h_sa, h_sb] at h ⊢
-  rw [WithTop.coe_eq_coe]
-  have h_count : ∀ (p : Associates α) (hp : Irreducible p),
-      sa.count ⟨p, hp⟩ = sb.count ⟨p, hp⟩ := by
-    intro p hp
-    rw [← count_some, ← count_some, h p hp]
-  apply Multiset.toFinsupp.injective
-  ext ⟨p, hp⟩
-  rw [Multiset.toFinsupp_apply, Multiset.toFinsupp_apply, h_count p hp]
+  simp_all only [count_some, WithTop.coe_eq_coe]
+  ext
+  grind
 
 theorem eq_of_eq_counts {a b : Associates α} (ha : a ≠ 0) (hb : b ≠ 0)
     (h : ∀ p : Associates α, Irreducible p → p.count a.factors = p.count b.factors) : a = b :=
```
```
ℹ [930/930] Built Mathlib.RingTheory.UniqueFactorizationDomain.FactorSet (1.6s)
info: Mathlib/RingTheory/UniqueFactorizationDomain/FactorSet.lean:285:0: [Elab.async] [0.035252] elaborating proof of Associates.eq_factors_of_eq_counts
  [Elab.definition.value] [0.034527] Associates.eq_factors_of_eq_counts
    [Elab.step] [0.034030] 
          obtain ⟨sa, h_sa⟩ := factors_eq_some_iff_ne_zero.mpr ha
          obtain ⟨sb, h_sb⟩ := factors_eq_some_iff_ne_zero.mpr hb
          simp_all only [count_some, WithTop.coe_eq_coe]
          ext
          grind
      [Elab.step] [0.034025] 
            obtain ⟨sa, h_sa⟩ := factors_eq_some_iff_ne_zero.mpr ha
            obtain ⟨sb, h_sb⟩ := factors_eq_some_iff_ne_zero.mpr hb
            simp_all only [count_some, WithTop.coe_eq_coe]
            ext
            grind
        [Elab.step] [0.022600] grind
Build completed successfully (930 jobs).
```
</details>

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

When merging, all the commits will be squashed into a single commit
listing all co-authors.

Co-authors in the squash commit are gathered from two sources:

First, all authors of commits to this PR branch are included. Thus,
one way to add co-authors is to include at least one commit authored by
each co-author among the commits in the pull request. If necessary, you
may create empty commits to indicate co-authorship, using commands like so:

git commit --author="Author Name <author@email.com>" --allow-empty -m "add Author Name as coauthor"

Second, co-authors can also be listed in lines at the very bottom of
the commit message (that is, directly before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines
at the bottom of the commit message (before the `---`, and also before
any "Co-authored-by" lines) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
