### PR TITLE
[Merged by Bors] - chore(Probability/Independence): golf `iCondIndepSets_singleton_iff` using `simp`

### DIFF
--- a/Mathlib/Probability/Independence/Conditional.lean
+++ b/Mathlib/Probability/Independence/Conditional.lean
@@ -239,15 +239,12 @@ lemma iCondIndepSets_singleton_iff (s : ι → Set Ω) (hπ : ∀ i, MeasurableS
     iCondIndepSets m' hm' (fun i ↦ {s i}) μ ↔ ∀ S : Finset ι,
       μ⟦⋂ i ∈ S, s i | m'⟧ =ᵐ[μ] ∏ i ∈ S, (μ⟦s i | m'⟧) := by
   rw [iCondIndepSets_iff]
-  · simp only [Set.mem_singleton_iff]
-    refine ⟨fun h S ↦ h S (fun i _ ↦ rfl), fun h S f hf ↦ ?_⟩
-    filter_upwards [h S] with a ha
-    refine Eq.trans ?_ (ha.trans ?_)
+  · simp_all only [Set.mem_singleton_iff]
+    constructor
+    · intros
+      simp [*]
     · grind
-    · simp_rw [Finset.prod_apply]
-      refine Finset.prod_congr rfl (fun i hi ↦ ?_)
-      rw [hf i hi]
-  · simpa only [Set.mem_singleton_iff, forall_eq]
+  · simpa
 
 theorem condIndepSets_singleton_iff {μ : Measure Ω} [IsFiniteMeasure μ]
     {s t : Set Ω} (hs : MeasurableSet s) (ht : MeasurableSet t) :


### PR DESCRIPTION
---
<details>
<summary>Show trace profiling of <code>iCondIndepSets_singleton_iff</code>: 67 ms before, 135 ms after </summary>

### Trace profiling of `iCondIndepSets_singleton_iff` before PR 31279
```diff
diff --git a/Mathlib/Probability/Independence/Conditional.lean b/Mathlib/Probability/Independence/Conditional.lean
index 6d62265ac9..1c82bb3689 100644
--- a/Mathlib/Probability/Independence/Conditional.lean
+++ b/Mathlib/Probability/Independence/Conditional.lean
@@ -234,6 +234,7 @@ lemma condIndepSets_iff (s1 s2 : Set (Set Ω)) (hs1 : ∀ s ∈ s1, MeasurableSe
     exact ENNReal.mul_ne_top (measure_ne_top (condExpKernel μ m' ω) s)
       (measure_ne_top (condExpKernel μ m' ω) t)
 
+set_option trace.profiler true in
 lemma iCondIndepSets_singleton_iff (s : ι → Set Ω) (hπ : ∀ i, MeasurableSet (s i))
     (μ : Measure Ω) [IsFiniteMeasure μ] :
     iCondIndepSets m' hm' (fun i ↦ {s i}) μ ↔ ∀ S : Finset ι,
```
```
ℹ [2520/2520] Built Mathlib.Probability.Independence.Conditional (4.0s)
info: Mathlib/Probability/Independence/Conditional.lean:238:0: [Elab.async] [0.068546] elaborating proof of ProbabilityTheory.iCondIndepSets_singleton_iff
  [Elab.definition.value] [0.067359] ProbabilityTheory.iCondIndepSets_singleton_iff
    [Elab.step] [0.066882] 
          rw [iCondIndepSets_iff]
          · simp only [Set.mem_singleton_iff]
            refine ⟨fun h S ↦ h S (fun i _ ↦ rfl), fun h S f hf ↦ ?_⟩
            filter_upwards [h S] with a ha
            refine Eq.trans ?_ (ha.trans ?_)
            · grind
            · simp_rw [Finset.prod_apply]
              refine Finset.prod_congr rfl (fun i hi ↦ ?_)
              rw [hf i hi]
          · simpa only [Set.mem_singleton_iff, forall_eq]
      [Elab.step] [0.066875] 
            rw [iCondIndepSets_iff]
            · simp only [Set.mem_singleton_iff]
              refine ⟨fun h S ↦ h S (fun i _ ↦ rfl), fun h S f hf ↦ ?_⟩
              filter_upwards [h S] with a ha
              refine Eq.trans ?_ (ha.trans ?_)
              · grind
              · simp_rw [Finset.prod_apply]
                refine Finset.prod_congr rfl (fun i hi ↦ ?_)
                rw [hf i hi]
            · simpa only [Set.mem_singleton_iff, forall_eq]
        [Elab.step] [0.063292] ·
              simp only [Set.mem_singleton_iff]
              refine ⟨fun h S ↦ h S (fun i _ ↦ rfl), fun h S f hf ↦ ?_⟩
              filter_upwards [h S] with a ha
              refine Eq.trans ?_ (ha.trans ?_)
              · grind
              · simp_rw [Finset.prod_apply]
                refine Finset.prod_congr rfl (fun i hi ↦ ?_)
                rw [hf i hi]
          [Elab.step] [0.063209] 
                simp only [Set.mem_singleton_iff]
                refine ⟨fun h S ↦ h S (fun i _ ↦ rfl), fun h S f hf ↦ ?_⟩
                filter_upwards [h S] with a ha
                refine Eq.trans ?_ (ha.trans ?_)
                · grind
                · simp_rw [Finset.prod_apply]
                  refine Finset.prod_congr rfl (fun i hi ↦ ?_)
                  rw [hf i hi]
            [Elab.step] [0.063204] 
                  simp only [Set.mem_singleton_iff]
                  refine ⟨fun h S ↦ h S (fun i _ ↦ rfl), fun h S f hf ↦ ?_⟩
                  filter_upwards [h S] with a ha
                  refine Eq.trans ?_ (ha.trans ?_)
                  · grind
                  · simp_rw [Finset.prod_apply]
                    refine Finset.prod_congr rfl (fun i hi ↦ ?_)
                    rw [hf i hi]
              [Elab.step] [0.042873] · grind
                [Elab.step] [0.042847] grind
                  [Elab.step] [0.042842] grind
                    [Elab.step] [0.042833] grind
Build completed successfully (2520 jobs).
```

### Trace profiling of `iCondIndepSets_singleton_iff` after PR 31279
```diff
diff --git a/Mathlib/Probability/Independence/Conditional.lean b/Mathlib/Probability/Independence/Conditional.lean
index 6d62265ac9..6e0582706a 100644
--- a/Mathlib/Probability/Independence/Conditional.lean
+++ b/Mathlib/Probability/Independence/Conditional.lean
@@ -234,20 +234,18 @@ lemma condIndepSets_iff (s1 s2 : Set (Set Ω)) (hs1 : ∀ s ∈ s1, MeasurableSe
     exact ENNReal.mul_ne_top (measure_ne_top (condExpKernel μ m' ω) s)
       (measure_ne_top (condExpKernel μ m' ω) t)
 
+set_option trace.profiler true in
 lemma iCondIndepSets_singleton_iff (s : ι → Set Ω) (hπ : ∀ i, MeasurableSet (s i))
     (μ : Measure Ω) [IsFiniteMeasure μ] :
     iCondIndepSets m' hm' (fun i ↦ {s i}) μ ↔ ∀ S : Finset ι,
       μ⟦⋂ i ∈ S, s i | m'⟧ =ᵐ[μ] ∏ i ∈ S, (μ⟦s i | m'⟧) := by
   rw [iCondIndepSets_iff]
-  · simp only [Set.mem_singleton_iff]
-    refine ⟨fun h S ↦ h S (fun i _ ↦ rfl), fun h S f hf ↦ ?_⟩
-    filter_upwards [h S] with a ha
-    refine Eq.trans ?_ (ha.trans ?_)
+  · simp_all only [Set.mem_singleton_iff]
+    constructor
+    · intros
+      simp [*]
     · grind
-    · simp_rw [Finset.prod_apply]
-      refine Finset.prod_congr rfl (fun i hi ↦ ?_)
-      rw [hf i hi]
-  · simpa only [Set.mem_singleton_iff, forall_eq]
+  · simpa
 
 theorem condIndepSets_singleton_iff {μ : Measure Ω} [IsFiniteMeasure μ]
     {s t : Set Ω} (hs : MeasurableSet s) (ht : MeasurableSet t) :
```
```
ℹ [2520/2520] Built Mathlib.Probability.Independence.Conditional (2.8s)
info: Mathlib/Probability/Independence/Conditional.lean:238:0: [Elab.async] [0.135403] elaborating proof of ProbabilityTheory.iCondIndepSets_singleton_iff
  [Elab.definition.value] [0.134502] ProbabilityTheory.iCondIndepSets_singleton_iff
    [Elab.step] [0.133927] 
          rw [iCondIndepSets_iff]
          · simp_all only [Set.mem_singleton_iff]
            constructor
            · intros
              simp [*]
            · grind
          · simpa
      [Elab.step] [0.133922] 
            rw [iCondIndepSets_iff]
            · simp_all only [Set.mem_singleton_iff]
              constructor
              · intros
                simp [*]
              · grind
            · simpa
        [Elab.step] [0.095699] ·
              simp_all only [Set.mem_singleton_iff]
              constructor
              · intros
                simp [*]
              · grind
          [Elab.step] [0.095607] 
                simp_all only [Set.mem_singleton_iff]
                constructor
                · intros
                  simp [*]
                · grind
            [Elab.step] [0.095603] 
                  simp_all only [Set.mem_singleton_iff]
                  constructor
                  · intros
                    simp [*]
                  · grind
              [Elab.step] [0.015794] simp_all only [Set.mem_singleton_iff]
              [Elab.step] [0.048834] ·
                    intros
                    simp [*]
                [Elab.step] [0.048802] 
                      intros
                      simp [*]
                  [Elab.step] [0.048797] 
                        intros
                        simp [*]
                    [Elab.step] [0.048738] simp [*]
                      [Meta.Tactic.simp.discharge] [0.035568] Set.iInter_of_empty discharge ❌️
                            IsEmpty ι
                        [Meta.synthInstance] [0.034928] ❌️ Nonempty ι
              [Elab.step] [0.030845] · grind
                [Elab.step] [0.030576] grind
                  [Elab.step] [0.030571] grind
                    [Elab.step] [0.030563] grind
        [Elab.step] [0.036126] · simpa
          [Elab.step] [0.036117] simpa
            [Elab.step] [0.036113] simpa
              [Elab.step] [0.036105] simpa
                [Meta.Tactic.simp.discharge] [0.026647] IsEmpty.forall_iff discharge ❌️
                      IsEmpty ι
                  [Meta.synthInstance] [0.026271] ❌️ Nonempty ι
Build completed successfully (2520 jobs).
```
</details>

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

When merging, all the commits will be squashed into a single commit
listing all co-authors.

Co-authors in the squash commit are gathered from two sources:

First, all authors of commits to this PR branch are included. Thus,
one way to add co-authors is to include at least one commit authored by
each co-author among the commits in the pull request. If necessary, you
may create empty commits to indicate co-authorship, using commands like so:

git commit --author="Author Name <author@email.com>" --allow-empty -m "add Author Name as coauthor"

Second, co-authors can also be listed in lines at the very bottom of
the commit message (that is, directly before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines
at the bottom of the commit message (before the `---`, and also before
any "Co-authored-by" lines) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
