### PR TITLE
[Merged by Bors] - grind(Algebra): golf `coeffs` and `span` using `grind`

### DIFF
--- a/Mathlib/Algebra/CubicDiscriminant.lean
+++ b/Mathlib/Algebra/CubicDiscriminant.lean
@@ -84,8 +84,9 @@ section Coeff
 
 private theorem coeffs : (∀ n > 3, P.toPoly.coeff n = 0) ∧ P.toPoly.coeff 3 = P.a ∧
     P.toPoly.coeff 2 = P.b ∧ P.toPoly.coeff 1 = P.c ∧ P.toPoly.coeff 0 = P.d := by
-  grind [Cubic.toPoly, Polynomial.coeff_add, Polynomial.coeff_C, Polynomial.coeff_C_mul_X,
-    Polynomial.coeff_C_mul_X_pow, add_zero, zero_add]
+  simp only [Cubic.toPoly, Polynomial.coeff_add, Polynomial.coeff_C, Polynomial.coeff_C_mul_X,
+    Polynomial.coeff_C_mul_X_pow]
+  grind [zero_add]
 
 @[simp]
 theorem coeff_eq_zero {n : ℕ} (hn : 3 < n) : P.toPoly.coeff n = 0 :=

--- a/Mathlib/Algebra/CubicDiscriminant.lean
+++ b/Mathlib/Algebra/CubicDiscriminant.lean
@@ -84,12 +84,8 @@ section Coeff
 
 private theorem coeffs : (∀ n > 3, P.toPoly.coeff n = 0) ∧ P.toPoly.coeff 3 = P.a ∧
     P.toPoly.coeff 2 = P.b ∧ P.toPoly.coeff 1 = P.c ∧ P.toPoly.coeff 0 = P.d := by
-  simp only [toPoly, coeff_add, coeff_C, coeff_C_mul_X, coeff_C_mul_X_pow]
-  norm_num
-  intro n hn
-  repeat' rw [if_neg]
-  any_goals cutsat
-  repeat' rw [zero_add]
+  grind [Cubic.toPoly, Polynomial.coeff_add, Polynomial.coeff_C, Polynomial.coeff_C_mul_X,
+    Polynomial.coeff_C_mul_X_pow, add_zero, zero_add]
 
 @[simp]
 theorem coeff_eq_zero {n : ℕ} (hn : 3 < n) : P.toPoly.coeff n = 0 :=

--- a/Mathlib/Algebra/Polynomial/Sequence.lean
+++ b/Mathlib/Algebra/Polynomial/Sequence.lean
@@ -124,15 +124,7 @@ protected lemma span (hCoeff : ∀ i, IsUnit (S i).leadingCoeff) : span R (Set.r
       ← degree_eq_natDegree p_ne_zero, hp] at head_degree_eq
     -- and that this degree is also their `natDegree`
     have head_degree_eq_natDegree : head.degree = head.natDegree := degree_eq_natDegree <| by
-      by_cases n_eq_zero : n = 0
-      · dsimp [head]
-        rw [n_eq_zero, ← coeff_natDegree, natDegree_eq] at rightinv
-        rwa [n_eq_zero, eq_C_of_natDegree_eq_zero <| S.natDegree_eq 0,
-          smul_C, smul_eq_mul, map_mul, ← C_mul, rightinv, smul_C, smul_eq_mul,
-          mul_one, C_eq_zero, leadingCoeff_eq_zero]
-      · apply head.ne_zero_of_degree_gt (n := 0)
-        rw [← head_degree_eq]
-        exact natDegree_pos_iff_degree_pos.mp (by cutsat)
+      grind [degree_eq_bot]
     -- and that they have matching leading coefficients
     have hPhead : P.leadingCoeff = head.leadingCoeff := by
       rw [degree_eq_natDegree p_ne_zero, head_degree_eq_natDegree] at head_degree_eq


### PR DESCRIPTION
---
<details>
<summary>Show trace profiling of <code>coeffs</code>: 150 ms before, 322 ms after </summary>

### Trace profiling of `coeffs` before PR 31280
```diff
diff --git a/Mathlib/Algebra/CubicDiscriminant.lean b/Mathlib/Algebra/CubicDiscriminant.lean
index d5d65cd2fd..981a00835e 100644
--- a/Mathlib/Algebra/CubicDiscriminant.lean
+++ b/Mathlib/Algebra/CubicDiscriminant.lean
@@ -82,6 +82,7 @@ theorem prod_X_sub_C_eq [CommRing S] {x y z : S} :
 
 section Coeff
 
+set_option trace.profiler true in
 private theorem coeffs : (∀ n > 3, P.toPoly.coeff n = 0) ∧ P.toPoly.coeff 3 = P.a ∧
     P.toPoly.coeff 2 = P.b ∧ P.toPoly.coeff 1 = P.c ∧ P.toPoly.coeff 0 = P.d := by
   simp only [toPoly, coeff_add, coeff_C, coeff_C_mul_X, coeff_C_mul_X_pow]
```
```
ℹ [1379/1379] Built Mathlib.Algebra.CubicDiscriminant (1.9s)
info: Mathlib/Algebra/CubicDiscriminant.lean:86:0: [Elab.async] [0.151845] elaborating proof of _private.Mathlib.Algebra.CubicDiscriminant.0.Cubic.coeffs
  [Elab.definition.value] [0.150105] _private.Mathlib.Algebra.CubicDiscriminant.0.Cubic.coeffs
    [Elab.step] [0.149781] 
          simp only [toPoly, coeff_add, coeff_C, coeff_C_mul_X, coeff_C_mul_X_pow]
          norm_num
          intro n hn
          repeat' rw [if_neg]
          any_goals cutsat
          repeat' rw [zero_add]
      [Elab.step] [0.149774] 
            simp only [toPoly, coeff_add, coeff_C, coeff_C_mul_X, coeff_C_mul_X_pow]
            norm_num
            intro n hn
            repeat' rw [if_neg]
            any_goals cutsat
            repeat' rw [zero_add]
        [Elab.step] [0.022335] simp only [toPoly, coeff_add, coeff_C, coeff_C_mul_X, coeff_C_mul_X_pow]
        [Elab.step] [0.084160] norm_num
        [Elab.step] [0.030270] any_goals cutsat
          [Elab.step] [0.010606] cutsat
            [Elab.step] [0.010602] cutsat
              [Elab.step] [0.010597] cutsat
Build completed successfully (1379 jobs).
```

### Trace profiling of `coeffs` after PR 31280
```diff
diff --git a/Mathlib/Algebra/CubicDiscriminant.lean b/Mathlib/Algebra/CubicDiscriminant.lean
index d5d65cd2fd..97628b3a33 100644
--- a/Mathlib/Algebra/CubicDiscriminant.lean
+++ b/Mathlib/Algebra/CubicDiscriminant.lean
@@ -82,14 +82,11 @@ theorem prod_X_sub_C_eq [CommRing S] {x y z : S} :
 
 section Coeff
 
+set_option trace.profiler true in
 private theorem coeffs : (∀ n > 3, P.toPoly.coeff n = 0) ∧ P.toPoly.coeff 3 = P.a ∧
     P.toPoly.coeff 2 = P.b ∧ P.toPoly.coeff 1 = P.c ∧ P.toPoly.coeff 0 = P.d := by
-  simp only [toPoly, coeff_add, coeff_C, coeff_C_mul_X, coeff_C_mul_X_pow]
-  norm_num
-  intro n hn
-  repeat' rw [if_neg]
-  any_goals cutsat
-  repeat' rw [zero_add]
+  grind [Cubic.toPoly, Polynomial.coeff_add, Polynomial.coeff_C, Polynomial.coeff_C_mul_X,
+    Polynomial.coeff_C_mul_X_pow, add_zero, zero_add]
 
 @[simp]
 theorem coeff_eq_zero {n : ℕ} (hn : 3 < n) : P.toPoly.coeff n = 0 :=
```
```
ℹ [1379/1379] Built Mathlib.Algebra.CubicDiscriminant (2.0s)
info: Mathlib/Algebra/CubicDiscriminant.lean:86:0: [Elab.async] [0.322701] elaborating proof of _private.Mathlib.Algebra.CubicDiscriminant.0.Cubic.coeffs
  [Elab.definition.value] [0.322338] _private.Mathlib.Algebra.CubicDiscriminant.0.Cubic.coeffs
    [Elab.step] [0.322220] grind [Cubic.toPoly, Polynomial.coeff_add, Polynomial.coeff_C, Polynomial.coeff_C_mul_X,
            Polynomial.coeff_C_mul_X_pow, add_zero, zero_add]
      [Elab.step] [0.322214] grind [Cubic.toPoly, Polynomial.coeff_add, Polynomial.coeff_C, Polynomial.coeff_C_mul_X,
              Polynomial.coeff_C_mul_X_pow, add_zero, zero_add]
        [Elab.step] [0.322205] grind [Cubic.toPoly, Polynomial.coeff_add, Polynomial.coeff_C, Polynomial.coeff_C_mul_X,
              Polynomial.coeff_C_mul_X_pow, add_zero, zero_add]
          [Meta.synthInstance] [0.012076] ❌️ Lean.Grind.NoNatZeroDivisors (Lean.Grind.IntModule.OfNatModule.Q R[X])
          [Meta.synthInstance] [0.010498] ❌️ Lean.Grind.NoNatZeroDivisors (Lean.Grind.IntModule.OfNatModule.Q R)
Build completed successfully (1379 jobs).
```
</details>

---
<details>
<summary>Show trace profiling of <code>span</code>: 255 ms before, 271 ms after </summary>

### Trace profiling of `span` before PR 31280
```diff
diff --git a/Mathlib/Algebra/Polynomial/Sequence.lean b/Mathlib/Algebra/Polynomial/Sequence.lean
index 036343357b..467335eec2 100644
--- a/Mathlib/Algebra/Polynomial/Sequence.lean
+++ b/Mathlib/Algebra/Polynomial/Sequence.lean
@@ -80,6 +80,7 @@ section Ring
 
 variable [Ring R] (S : Sequence R)
 
+set_option trace.profiler true in
 /-- A polynomial sequence spans `R[X]` if all of its elements' leading coefficients are units. -/
 protected lemma span (hCoeff : ∀ i, IsUnit (S i).leadingCoeff) : span R (Set.range S) = ⊤ := by
   rw [eq_top_iff']
```
```
ℹ [1188/1188] Built Mathlib.Algebra.Polynomial.Sequence (1.4s)
info: Mathlib/Algebra/Polynomial/Sequence.lean:84:0: [Elab.command] [0.010495] /--
    A polynomial sequence spans `R[X]` if all of its elements' leading coefficients are units. -/
    protected lemma span (hCoeff : ∀ i, IsUnit (S i).leadingCoeff) : span R (Set.range S) = ⊤ :=
      by
      rw [eq_top_iff']
      intro P
      nontriviality R using Subsingleton.eq_zero P
      generalize hp : P.natDegree = n
      induction n using Nat.strong_induction_on generalizing P with
      | h n ih =>
        by_cases p_ne_zero : P = 0
        ·
          simp [p_ne_zero]
            -- let u be the inverse of `S n`'s leading coefficient
            
        obtain ⟨u, leftinv, rightinv⟩ := isUnit_iff_exists.mp <| hCoeff n
        let head := P.leadingCoeff • u • S n
        let tail := P - head
        have head_mem_span : head ∈ span R (Set.range S) :=
          by
          have in_span : S n ∈ span R (Set.range S) := subset_span (by simp)
          have smul_span := smul_mem (span R (Set.range S)) (P.leadingCoeff • u) in_span
          rwa [smul_assoc] at smul_span
        by_cases tail_eq_zero : tail = 0
        ·
          simp [head_mem_span, sub_eq_iff_eq_add.mp tail_eq_zero]
            -- we'll do so via the induction hypothesis,
                -- and once we show we can use it, `P` is a difference of two members of the span
            
        refine
          sub_mem_iff_left _ head_mem_span |>.mp <|
            -- so let's prove the tail has degree less than `n`
            ih tail.natDegree (natDegree_lt_iff_degree_lt tail_eq_zero |>.mpr ?_) _ rfl
        have isRightRegular_smul_leadingCoeff : IsRightRegular (u • S n).leadingCoeff := by
          simpa [leadingCoeff_smul_of_smul_regular, IsSMulRegular.of_mul_eq_one leftinv, rightinv] using
            isRegular_one.right
        have u_degree_same :=
          degree_smul_of_isRightRegular_leadingCoeff (left_ne_zero_of_mul_eq_one rightinv) (hCoeff n).isRegular.right
        have head_degree_eq :=
          degree_smul_of_isRightRegular_leadingCoeff (leadingCoeff_ne_zero.mpr p_ne_zero)
            isRightRegular_smul_leadingCoeff
        rw [u_degree_same, S.degree_eq n, ← hp, eq_comm, ← degree_eq_natDegree p_ne_zero, hp] at head_degree_eq
        have head_degree_eq_natDegree : head.degree = head.natDegree :=
          degree_eq_natDegree <| by
            by_cases n_eq_zero : n = 0
            · dsimp [head]
              rw [n_eq_zero, ← coeff_natDegree, natDegree_eq] at rightinv
              rwa [n_eq_zero, eq_C_of_natDegree_eq_zero <| S.natDegree_eq 0, smul_C, smul_eq_mul, map_mul, ← C_mul,
                rightinv, smul_C, smul_eq_mul, mul_one, C_eq_zero, leadingCoeff_eq_zero]
            · apply head.ne_zero_of_degree_gt (n := 0)
              rw [← head_degree_eq]
              exact
                natDegree_pos_iff_degree_pos.mp
                  (by cutsat)
                    -- and that they have matching leading coefficients
                    
        have hPhead : P.leadingCoeff = head.leadingCoeff :=
          by
          rw [degree_eq_natDegree p_ne_zero, head_degree_eq_natDegree] at head_degree_eq
          nth_rw 2 [← coeff_natDegree]
          rw_mod_cast [← head_degree_eq, hp]
          dsimp [head]
          nth_rw 2 [← S.natDegree_eq n]
          rw [coeff_smul, coeff_smul, coeff_natDegree, smul_eq_mul, smul_eq_mul, rightinv, mul_one]
            -- which we can now combine to show that `P - head` must have strictly lower degree,
                -- as its leading term has been cancelled, completing our proof.
            
        have tail_degree_lt := P.degree_sub_lt head_degree_eq p_ne_zero hPhead
        rwa [degree_eq_natDegree p_ne_zero, hp] at tail_degree_lt
info: Mathlib/Algebra/Polynomial/Sequence.lean:84:0: [Elab.async] [0.257460] elaborating proof of Polynomial.Sequence.span
  [Elab.definition.value] [0.254608] Polynomial.Sequence.span
    [Elab.step] [0.250181] 
          rw [eq_top_iff']
          intro P
          nontriviality R using Subsingleton.eq_zero P
          generalize hp : P.natDegree = n
          induction n using Nat.strong_induction_on generalizing P with
          | h n ih =>
            by_cases p_ne_zero : P = 0
            ·
              simp [p_ne_zero]
                -- let u be the inverse of `S n`'s leading coefficient
                
            obtain ⟨u, leftinv, rightinv⟩ := isUnit_iff_exists.mp <| hCoeff n
            let head := P.leadingCoeff • u • S n
            let tail := P - head
            have head_mem_span : head ∈ span R (Set.range S) :=
              by
              have in_span : S n ∈ span R (Set.range S) := subset_span (by simp)
              have smul_span := smul_mem (span R (Set.range S)) (P.leadingCoeff • u) in_span
              rwa [smul_assoc] at smul_span
            by_cases tail_eq_zero : tail = 0
            ·
              simp [head_mem_span, sub_eq_iff_eq_add.mp tail_eq_zero]
                -- we'll do so via the induction hypothesis,
                    -- and once we show we can use it, `P` is a difference of two members of the span
                
            refine
              sub_mem_iff_left _ head_mem_span |>.mp <|
[… 838 lines omitted …]
                                    rw [coeff_smul, coeff_smul, coeff_natDegree, smul_eq_mul, smul_eq_mul, rightinv,
                                      mul_one]
                                      -- which we can now combine to show that `P - head` must have strictly lower degree,
                                          -- as its leading term has been cancelled, completing our proof.
                                      )
                                [Elab.step] [0.069742] 
                                      rw [degree_eq_natDegree p_ne_zero, head_degree_eq_natDegree] at head_degree_eq
                                      nth_rw 2 [← coeff_natDegree]
                                      rw_mod_cast [← head_degree_eq, hp]
                                      dsimp [head]
                                      nth_rw 2 [← S.natDegree_eq n]
                                      rw [coeff_smul, coeff_smul, coeff_natDegree, smul_eq_mul, smul_eq_mul, rightinv,
                                        mul_one]
                                  [Elab.step] [0.069740] 
                                        rw [degree_eq_natDegree p_ne_zero, head_degree_eq_natDegree] at head_degree_eq
                                        nth_rw 2 [← coeff_natDegree]
                                        rw_mod_cast [← head_degree_eq, hp]
                                        dsimp [head]
                                        nth_rw 2 [← S.natDegree_eq n]
                                        rw [coeff_smul, coeff_smul, coeff_natDegree, smul_eq_mul, smul_eq_mul, rightinv,
                                          mul_one]
                                    [Elab.step] [0.047324] rw_mod_cast [← head_degree_eq, hp]
                                      [Elab.step] [0.047294] (
                                            (norm_cast at *; rw [← head_degree_eq])
                                            (norm_cast at *; rw [hp]))
                                        [Elab.step] [0.047292] 
                                              (norm_cast at *; rw [← head_degree_eq])
                                              (norm_cast at *; rw [hp])
                                          [Elab.step] [0.047290] 
                                                (norm_cast at *; rw [← head_degree_eq])
                                                (norm_cast at *; rw [hp])
                                            [Elab.step] [0.026171] (norm_cast at *; rw [← head_degree_eq])
                                              [Elab.step] [0.026169] norm_cast at *; rw [← head_degree_eq]
                                                [Elab.step] [0.026167] norm_cast at *; rw [← head_degree_eq]
                                                  [Elab.step] [0.025826] norm_cast at *
                                                    [Elab.step] [0.025819] norm_cast0 at * <;> try trivial
                                                      [Elab.step] [0.025816] focus
                                                            norm_cast0 at *
                                                            with_annotate_state"<;>" skip
                                                            all_goals try trivial
                                                        [Elab.step] [0.025812] 
                                                              norm_cast0 at *
                                                              with_annotate_state"<;>" skip
                                                              all_goals try trivial
                                                          [Elab.step] [0.025810] 
                                                                norm_cast0 at *
                                                                with_annotate_state"<;>" skip
                                                                all_goals try trivial
                                                            [Elab.step] [0.010749] norm_cast0 at *
                                                            [Elab.step] [0.015043] all_goals try trivial
                                                              [Elab.step] [0.015018] try trivial
                                                                [Elab.step] [0.015016] try trivial
                                                                  [Elab.step] [0.015013] try trivial
                                                                    [Elab.step] [0.015009] first
                                                                        | trivial
                                                                        | skip
                                                                      [Elab.step] [0.014998] trivial
                                                                        [Elab.step] [0.014995] trivial
                                                                          [Elab.step] [0.014991] trivial
                                            [Elab.step] [0.021114] (norm_cast at *; rw [hp])
                                              [Elab.step] [0.021101] norm_cast at *; rw [hp]
                                                [Elab.step] [0.021098] norm_cast at *; rw [hp]
                                                  [Elab.step] [0.020775] norm_cast at *
                                                    [Elab.step] [0.020772] norm_cast0 at * <;> try trivial
                                                      [Elab.step] [0.020769] focus
                                                            norm_cast0 at *
                                                            with_annotate_state"<;>" skip
                                                            all_goals try trivial
                                                        [Elab.step] [0.020766] 
                                                              norm_cast0 at *
                                                              with_annotate_state"<;>" skip
                                                              all_goals try trivial
                                                          [Elab.step] [0.020764] 
                                                                norm_cast0 at *
                                                                with_annotate_state"<;>" skip
                                                                all_goals try trivial
                                                            [Elab.step] [0.014340] all_goals try trivial
                                                              [Elab.step] [0.014335] try trivial
                                                                [Elab.step] [0.014332] try trivial
                                                                  [Elab.step] [0.014330] try trivial
                                                                    [Elab.step] [0.014327] first
                                                                        | trivial
                                                                        | skip
                                                                      [Elab.step] [0.014317] trivial
                                                                        [Elab.step] [0.014315] trivial
                                                                          [Elab.step] [0.014312] trivial
                                    [Elab.step] [0.010763] rw [coeff_smul, coeff_smul, coeff_natDegree, smul_eq_mul,
                                          smul_eq_mul, rightinv, mul_one]
                                      [Elab.step] [0.010751] (rewrite [coeff_smul, coeff_smul, coeff_natDegree,
                                              smul_eq_mul, smul_eq_mul, rightinv, mul_one];
                                            with_annotate_state"]" (try (with_reducible rfl)))
                                        [Elab.step] [0.010749] rewrite [coeff_smul, coeff_smul, coeff_natDegree,
                                                smul_eq_mul, smul_eq_mul, rightinv, mul_one];
                                              with_annotate_state"]" (try (with_reducible rfl))
                                          [Elab.step] [0.010746] rewrite [coeff_smul, coeff_smul, coeff_natDegree,
                                                  smul_eq_mul, smul_eq_mul, rightinv, mul_one];
                                                with_annotate_state"]" (try (with_reducible rfl))
                                            [Elab.step] [0.010532] rewrite [coeff_smul, coeff_smul, coeff_natDegree,
                                                  smul_eq_mul, smul_eq_mul, rightinv, mul_one]
Build completed successfully (1188 jobs).
```

### Trace profiling of `span` after PR 31280
```diff
diff --git a/Mathlib/Algebra/Polynomial/Sequence.lean b/Mathlib/Algebra/Polynomial/Sequence.lean
index 036343357b..ac23880759 100644
--- a/Mathlib/Algebra/Polynomial/Sequence.lean
+++ b/Mathlib/Algebra/Polynomial/Sequence.lean
@@ -80,6 +80,7 @@ section Ring
 
 variable [Ring R] (S : Sequence R)
 
+set_option trace.profiler true in
 /-- A polynomial sequence spans `R[X]` if all of its elements' leading coefficients are units. -/
 protected lemma span (hCoeff : ∀ i, IsUnit (S i).leadingCoeff) : span R (Set.range S) = ⊤ := by
   rw [eq_top_iff']
@@ -124,15 +125,7 @@ protected lemma span (hCoeff : ∀ i, IsUnit (S i).leadingCoeff) : span R (Set.r
       ← degree_eq_natDegree p_ne_zero, hp] at head_degree_eq
     -- and that this degree is also their `natDegree`
     have head_degree_eq_natDegree : head.degree = head.natDegree := degree_eq_natDegree <| by
-      by_cases n_eq_zero : n = 0
-      · dsimp [head]
-        rw [n_eq_zero, ← coeff_natDegree, natDegree_eq] at rightinv
-        rwa [n_eq_zero, eq_C_of_natDegree_eq_zero <| S.natDegree_eq 0,
-          smul_C, smul_eq_mul, map_mul, ← C_mul, rightinv, smul_C, smul_eq_mul,
-          mul_one, C_eq_zero, leadingCoeff_eq_zero]
-      · apply head.ne_zero_of_degree_gt (n := 0)
-        rw [← head_degree_eq]
-        exact natDegree_pos_iff_degree_pos.mp (by cutsat)
+      grind [degree_eq_bot]
     -- and that they have matching leading coefficients
     have hPhead : P.leadingCoeff = head.leadingCoeff := by
       rw [degree_eq_natDegree p_ne_zero, head_degree_eq_natDegree] at head_degree_eq
```
```
ℹ [1188/1188] Built Mathlib.Algebra.Polynomial.Sequence (1.4s)
info: Mathlib/Algebra/Polynomial/Sequence.lean:84:0: [Elab.async] [0.273862] elaborating proof of Polynomial.Sequence.span
  [Elab.definition.value] [0.271416] Polynomial.Sequence.span
    [Elab.step] [0.268031] 
          rw [eq_top_iff']
          intro P
          nontriviality R using Subsingleton.eq_zero P
          generalize hp : P.natDegree = n
          induction n using Nat.strong_induction_on generalizing P with
          | h n ih =>
            by_cases p_ne_zero : P = 0
            ·
              simp [p_ne_zero]
                -- let u be the inverse of `S n`'s leading coefficient
                
            obtain ⟨u, leftinv, rightinv⟩ := isUnit_iff_exists.mp <| hCoeff n
            let head := P.leadingCoeff • u • S n
            let tail := P - head
            have head_mem_span : head ∈ span R (Set.range S) :=
              by
              have in_span : S n ∈ span R (Set.range S) := subset_span (by simp)
              have smul_span := smul_mem (span R (Set.range S)) (P.leadingCoeff • u) in_span
              rwa [smul_assoc] at smul_span
            by_cases tail_eq_zero : tail = 0
            ·
              simp [head_mem_span, sub_eq_iff_eq_add.mp tail_eq_zero]
                -- we'll do so via the induction hypothesis,
                    -- and once we show we can use it, `P` is a difference of two members of the span
                
            refine
              sub_mem_iff_left _ head_mem_span |>.mp <|
                -- so let's prove the tail has degree less than `n`
                ih tail.natDegree (natDegree_lt_iff_degree_lt tail_eq_zero |>.mpr ?_) _ rfl
            have isRightRegular_smul_leadingCoeff : IsRightRegular (u • S n).leadingCoeff := by
              simpa [leadingCoeff_smul_of_smul_regular, IsSMulRegular.of_mul_eq_one leftinv, rightinv] using
                isRegular_one.right
            have u_degree_same :=
              degree_smul_of_isRightRegular_leadingCoeff (left_ne_zero_of_mul_eq_one rightinv)
                (hCoeff n).isRegular.right
            have head_degree_eq :=
              degree_smul_of_isRightRegular_leadingCoeff (leadingCoeff_ne_zero.mpr p_ne_zero)
                isRightRegular_smul_leadingCoeff
            rw [u_degree_same, S.degree_eq n, ← hp, eq_comm, ← degree_eq_natDegree p_ne_zero, hp] at head_degree_eq
            have head_degree_eq_natDegree : head.degree = head.natDegree :=
              degree_eq_natDegree <| by
                grind [degree_eq_bot]
                  -- and that they have matching leading coefficients
                  
            have hPhead : P.leadingCoeff = head.leadingCoeff :=
              by
              rw [degree_eq_natDegree p_ne_zero, head_degree_eq_natDegree] at head_degree_eq
              nth_rw 2 [← coeff_natDegree]
              rw_mod_cast [← head_degree_eq, hp]
              dsimp [head]
              nth_rw 2 [← S.natDegree_eq n]
              rw [coeff_smul, coeff_smul, coeff_natDegree, smul_eq_mul, smul_eq_mul, rightinv, mul_one]
                -- which we can now combine to show that `P - head` must have strictly lower degree,
                    -- as its leading term has been cancelled, completing our proof.
                
            have tail_degree_lt := P.degree_sub_lt head_degree_eq p_ne_zero hPhead
            rwa [degree_eq_natDegree p_ne_zero, hp] at tail_degree_lt
      [Elab.step] [0.268025] 
            rw [eq_top_iff']
            intro P
            nontriviality R using Subsingleton.eq_zero P
            generalize hp : P.natDegree = n
            induction n using Nat.strong_induction_on generalizing P with
            | h n ih =>
              by_cases p_ne_zero : P = 0
              ·
                simp [p_ne_zero]
                  -- let u be the inverse of `S n`'s leading coefficient
                  
              obtain ⟨u, leftinv, rightinv⟩ := isUnit_iff_exists.mp <| hCoeff n
              let head := P.leadingCoeff • u • S n
              let tail := P - head
              have head_mem_span : head ∈ span R (Set.range S) :=
                by
                have in_span : S n ∈ span R (Set.range S) := subset_span (by simp)
                have smul_span := smul_mem (span R (Set.range S)) (P.leadingCoeff • u) in_span
                rwa [smul_assoc] at smul_span
              by_cases tail_eq_zero : tail = 0
              ·
                simp [head_mem_span, sub_eq_iff_eq_add.mp tail_eq_zero]
                  -- we'll do so via the induction hypothesis,
                      -- and once we show we can use it, `P` is a difference of two members of the span
                  
              refine
                sub_mem_iff_left _ head_mem_span |>.mp <|
                  -- so let's prove the tail has degree less than `n`
                  ih tail.natDegree (natDegree_lt_iff_degree_lt tail_eq_zero |>.mpr ?_) _ rfl
              have isRightRegular_smul_leadingCoeff : IsRightRegular (u • S n).leadingCoeff := by
                simpa [leadingCoeff_smul_of_smul_regular, IsSMulRegular.of_mul_eq_one leftinv, rightinv] using
                  isRegular_one.right
              have u_degree_same :=
                degree_smul_of_isRightRegular_leadingCoeff (left_ne_zero_of_mul_eq_one rightinv)
                  (hCoeff n).isRegular.right
              have head_degree_eq :=
                degree_smul_of_isRightRegular_leadingCoeff (leadingCoeff_ne_zero.mpr p_ne_zero)
                  isRightRegular_smul_leadingCoeff
[… 538 lines omitted …]
                                    rw [coeff_smul, coeff_smul, coeff_natDegree, smul_eq_mul, smul_eq_mul, rightinv,
                                      mul_one]
                                      -- which we can now combine to show that `P - head` must have strictly lower degree,
                                          -- as its leading term has been cancelled, completing our proof.
                                      )
                                [Elab.step] [0.068011] 
                                      rw [degree_eq_natDegree p_ne_zero, head_degree_eq_natDegree] at head_degree_eq
                                      nth_rw 2 [← coeff_natDegree]
                                      rw_mod_cast [← head_degree_eq, hp]
                                      dsimp [head]
                                      nth_rw 2 [← S.natDegree_eq n]
                                      rw [coeff_smul, coeff_smul, coeff_natDegree, smul_eq_mul, smul_eq_mul, rightinv,
                                        mul_one]
                                  [Elab.step] [0.068008] 
                                        rw [degree_eq_natDegree p_ne_zero, head_degree_eq_natDegree] at head_degree_eq
                                        nth_rw 2 [← coeff_natDegree]
                                        rw_mod_cast [← head_degree_eq, hp]
                                        dsimp [head]
                                        nth_rw 2 [← S.natDegree_eq n]
                                        rw [coeff_smul, coeff_smul, coeff_natDegree, smul_eq_mul, smul_eq_mul, rightinv,
                                          mul_one]
                                    [Elab.step] [0.046123] rw_mod_cast [← head_degree_eq, hp]
                                      [Elab.step] [0.046096] (
                                            (norm_cast at *; rw [← head_degree_eq])
                                            (norm_cast at *; rw [hp]))
                                        [Elab.step] [0.046093] 
                                              (norm_cast at *; rw [← head_degree_eq])
                                              (norm_cast at *; rw [hp])
                                          [Elab.step] [0.046091] 
                                                (norm_cast at *; rw [← head_degree_eq])
                                                (norm_cast at *; rw [hp])
                                            [Elab.step] [0.025713] (norm_cast at *; rw [← head_degree_eq])
                                              [Elab.step] [0.025711] norm_cast at *; rw [← head_degree_eq]
                                                [Elab.step] [0.025709] norm_cast at *; rw [← head_degree_eq]
                                                  [Elab.step] [0.025372] norm_cast at *
                                                    [Elab.step] [0.025365] norm_cast0 at * <;> try trivial
                                                      [Elab.step] [0.025361] focus
                                                            norm_cast0 at *
                                                            with_annotate_state"<;>" skip
                                                            all_goals try trivial
                                                        [Elab.step] [0.025358] 
                                                              norm_cast0 at *
                                                              with_annotate_state"<;>" skip
                                                              all_goals try trivial
                                                          [Elab.step] [0.025356] 
                                                                norm_cast0 at *
                                                                with_annotate_state"<;>" skip
                                                                all_goals try trivial
                                                            [Elab.step] [0.010624] norm_cast0 at *
                                                            [Elab.step] [0.014717] all_goals try trivial
                                                              [Elab.step] [0.014693] try trivial
                                                                [Elab.step] [0.014691] try trivial
                                                                  [Elab.step] [0.014689] try trivial
                                                                    [Elab.step] [0.014685] first
                                                                        | trivial
                                                                        | skip
                                                                      [Elab.step] [0.014675] trivial
                                                                        [Elab.step] [0.014672] trivial
                                                                          [Elab.step] [0.014669] trivial
                                            [Elab.step] [0.020374] (norm_cast at *; rw [hp])
                                              [Elab.step] [0.020362] norm_cast at *; rw [hp]
                                                [Elab.step] [0.020359] norm_cast at *; rw [hp]
                                                  [Elab.step] [0.020047] norm_cast at *
                                                    [Elab.step] [0.020043] norm_cast0 at * <;> try trivial
                                                      [Elab.step] [0.020040] focus
                                                            norm_cast0 at *
                                                            with_annotate_state"<;>" skip
                                                            all_goals try trivial
                                                        [Elab.step] [0.020037] 
                                                              norm_cast0 at *
                                                              with_annotate_state"<;>" skip
                                                              all_goals try trivial
                                                          [Elab.step] [0.020035] 
                                                                norm_cast0 at *
                                                                with_annotate_state"<;>" skip
                                                                all_goals try trivial
                                                            [Elab.step] [0.013715] all_goals try trivial
                                                              [Elab.step] [0.013710] try trivial
                                                                [Elab.step] [0.013708] try trivial
                                                                  [Elab.step] [0.013705] try trivial
                                                                    [Elab.step] [0.013702] first
                                                                        | trivial
                                                                        | skip
                                                                      [Elab.step] [0.013692] trivial
                                                                        [Elab.step] [0.013689] trivial
                                                                          [Elab.step] [0.013685] trivial
                                    [Elab.step] [0.010488] rw [coeff_smul, coeff_smul, coeff_natDegree, smul_eq_mul,
                                          smul_eq_mul, rightinv, mul_one]
                                      [Elab.step] [0.010477] (rewrite [coeff_smul, coeff_smul, coeff_natDegree,
                                              smul_eq_mul, smul_eq_mul, rightinv, mul_one];
                                            with_annotate_state"]" (try (with_reducible rfl)))
                                        [Elab.step] [0.010474] rewrite [coeff_smul, coeff_smul, coeff_natDegree,
                                                smul_eq_mul, smul_eq_mul, rightinv, mul_one];
                                              with_annotate_state"]" (try (with_reducible rfl))
                                          [Elab.step] [0.010472] rewrite [coeff_smul, coeff_smul, coeff_natDegree,
                                                  smul_eq_mul, smul_eq_mul, rightinv, mul_one];
                                                with_annotate_state"]" (try (with_reducible rfl))
                                            [Elab.step] [0.010272] rewrite [coeff_smul, coeff_smul, coeff_natDegree,
                                                  smul_eq_mul, smul_eq_mul, rightinv, mul_one]
Build completed successfully (1188 jobs).
```
</details>

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

When merging, all the commits will be squashed into a single commit
listing all co-authors.

Co-authors in the squash commit are gathered from two sources:

First, all authors of commits to this PR branch are included. Thus,
one way to add co-authors is to include at least one commit authored by
each co-author among the commits in the pull request. If necessary, you
may create empty commits to indicate co-authorship, using commands like so:

git commit --author="Author Name <author@email.com>" --allow-empty -m "add Author Name as coauthor"

Second, co-authors can also be listed in lines at the very bottom of
the commit message (that is, directly before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines
at the bottom of the commit message (before the `---`, and also before
any "Co-authored-by" lines) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
