### PR TITLE
[Merged by Bors] - chore: rename `isUnit_of_mul_eq_one` to `IsUnit.of_mul_eq_one`

### DIFF
--- a/Mathlib/Algebra/BigOperators/Associated.lean
+++ b/Mathlib/Algebra/BigOperators/Associated.lean
@@ -87,7 +87,7 @@ theorem divisor_closure_eq_closure [CancelCommMonoidWithZero M₀]
     apply subset_closure
     simp only [Set.mem_setOf]
     simp only [Multiset.prod_zero] at hprod
-    left; exact isUnit_of_mul_eq_one _ _ hprod.symm
+    left; exact .of_mul_eq_one _ hprod.symm
   | cons c s hind =>
     simp only [Multiset.mem_cons, forall_eq_or_imp, Set.mem_setOf] at hm
     simp only [Multiset.prod_cons] at hprod
@@ -98,7 +98,7 @@ theorem divisor_closure_eq_closure [CancelCommMonoidWithZero M₀]
       · simp only [← mul_assoc, ← hprod, ← Multiset.prod_cons, mul_comm]
         refine multiset_prod_mem _ _ (Multiset.forall_mem_cons.2 ⟨subset_closure ?_,
           Multiset.forall_mem_cons.2 ⟨subset_closure ?_, fun t ht => subset_closure (hs t ht)⟩⟩)
-        · left; exact isUnit_of_mul_eq_one_right _ _ hk
+        · left; exact .of_mul_eq_one_right _ hk
         · left; exact ha₁
       · rw [← mul_one s.prod, ← hk, ← mul_assoc, ← mul_assoc, mul_eq_mul_right_iff, mul_comm]
         left; exact hprod

--- a/Mathlib/Algebra/CharP/CharAndCard.lean
+++ b/Mathlib/Algebra/CharP/CharAndCard.lean
@@ -43,7 +43,7 @@ theorem isUnit_iff_not_dvd_char_of_ringChar_ne_zero (R : Type*) [CommRing R] (p 
     apply_fun ((↑) : ℤ → R) at hab
     push_cast at hab
     rw [hch, mul_zero, add_zero, mul_comm] at hab
-    exact isUnit_of_mul_eq_one (p : R) a hab
+    exact .of_mul_eq_one a hab
 
 /-- A prime `p` is a unit in a finite commutative ring `R`
 iff it does not divide the characteristic. -/

--- a/Mathlib/Algebra/Field/Equiv.lean
+++ b/Mathlib/Algebra/Field/Equiv.lean
@@ -22,7 +22,7 @@ protected theorem IsLocalHom.isField [FunLike F A B] [MonoidWithZeroHomClass F A
   mul_inv_cancel h :=
     have ⟨a', he⟩ := hB.mul_inv_cancel ((inj.ne h).trans_eq <| map_zero f)
     let _ := hB.toSemifield
-    ((isUnit_of_mul_eq_one _ _ he).of_map).exists_right_inv
+    (IsUnit.of_mul_eq_one _ he).of_map.exists_right_inv
 
 protected theorem MulEquiv.isField (hB : IsField B) (e : A ≃* B) : IsField A :=
   IsLocalHom.isField e.injective hB

--- a/Mathlib/Algebra/Group/Int/Units.lean
+++ b/Mathlib/Algebra/Group/Int/Units.lean
@@ -45,7 +45,7 @@ lemma isUnit_iff : IsUnit u ↔ u = 1 ∨ u = -1 := by
   · exact ⟨⟨-1, -1, by decide, by decide⟩, rfl⟩
 
 lemma eq_one_or_neg_one_of_mul_eq_one (h : u * v = 1) : u = 1 ∨ u = -1 :=
-  isUnit_iff.1 (isUnit_of_mul_eq_one u v h)
+  isUnit_iff.1 (.of_mul_eq_one v h)
 
 lemma eq_one_or_neg_one_of_mul_eq_one' (h : u * v = 1) : u = 1 ∧ v = 1 ∨ u = -1 ∧ v = -1 := by
   have h' : v * u = 1 := mul_comm u v ▸ h

--- a/Mathlib/Algebra/Group/Units/Defs.lean
+++ b/Mathlib/Algebra/Group/Units/Defs.lean
@@ -390,13 +390,16 @@ theorem isUnit_one [Monoid M] : IsUnit (1 : M) :=
   ⟨1, rfl⟩
 
 @[to_additive]
-theorem isUnit_of_mul_eq_one [CommMonoid M] (a b : M) (h : a * b = 1) : IsUnit a :=
-  ⟨Units.mkOfMulEqOne a b h, rfl⟩
+theorem IsUnit.of_mul_eq_one [CommMonoid M] {a : M} (b : M) (h : a * b = 1) : IsUnit a :=
+  ⟨.mkOfMulEqOne a b h, rfl⟩
+
+@[deprecated (since := "2025-11-05")] alias isUnit_of_mul_eq_one := IsUnit.of_mul_eq_one
 
 @[to_additive]
-theorem isUnit_of_mul_eq_one_right [CommMonoid M] (a b : M) (h : a * b = 1) : IsUnit b := by
-  rw [mul_comm] at h
-  exact isUnit_of_mul_eq_one b a h
+theorem IsUnit.of_mul_eq_one_right [CommMonoid M] {b : M} (a : M) (h : a * b = 1) : IsUnit b :=
+  .of_mul_eq_one a <| mul_comm a b ▸ h
+
+@[deprecated (since := "2025-11-05")] alias isUnit_of_mul_eq_one_right := IsUnit.of_mul_eq_one_right
 
 section Monoid
 variable [Monoid M] {a b : M}
@@ -425,7 +428,7 @@ end Monoid
 
 @[to_additive]
 theorem isUnit_iff_exists_inv [CommMonoid M] {a : M} : IsUnit a ↔ ∃ b, a * b = 1 :=
-  ⟨fun h => h.exists_right_inv, fun ⟨b, hab⟩ => isUnit_of_mul_eq_one _ b hab⟩
+  ⟨fun h => h.exists_right_inv, fun ⟨b, hab⟩ => .of_mul_eq_one b hab⟩
 
 @[to_additive]
 theorem isUnit_iff_exists_inv' [CommMonoid M] {a : M} : IsUnit a ↔ ∃ b, b * a = 1 := by

--- a/Mathlib/Algebra/GroupWithZero/Associated.lean
+++ b/Mathlib/Algebra/GroupWithZero/Associated.lean
@@ -739,7 +739,7 @@ section CancelCommMonoidWithZero
 theorem isUnit_of_associated_mul [CancelCommMonoidWithZero M] {p b : M} (h : Associated (p * b) p)
     (hp : p ≠ 0) : IsUnit b := by
   obtain ⟨a, ha⟩ := h
-  refine isUnit_of_mul_eq_one b a ((mul_right_inj' hp).mp ?_)
+  refine .of_mul_eq_one a ((mul_right_inj' hp).mp ?_)
   rwa [← mul_assoc, mul_one]
 
 theorem DvdNotUnit.not_associated [CancelCommMonoidWithZero M] {p q : M} (h : DvdNotUnit p q) :

--- a/Mathlib/Algebra/Polynomial/Eval/Irreducible.lean
+++ b/Mathlib/Algebra/Polynomial/Eval/Irreducible.lean
@@ -46,7 +46,7 @@ lemma Monic.irreducible_of_irreducible_map (f : R[X]) (h_mon : Monic f)
   refine (h_irr.isUnit_or_isUnit <|
     (congr_arg (Polynomial.map φ) h).trans (Polynomial.map_mul φ)).imp ?_ ?_ <;>
       apply isUnit_of_isUnit_leadingCoeff_of_isUnit_map <;>
-    apply isUnit_of_mul_eq_one
+    apply IsUnit.of_mul_eq_one
   · exact q
   · rw [mul_comm]
     exact q

--- a/Mathlib/Algebra/Polynomial/FieldDivision.lean
+++ b/Mathlib/Algebra/Polynomial/FieldDivision.lean
@@ -648,7 +648,7 @@ theorem irreducible_iff_degree_lt (p : R[X]) (hp0 : p ≠ 0) (hpu : ¬ IsUnit p)
       (monic_mul_leadingCoeff_inv hp0).irreducible_iff_degree_lt]
   · simp [hp0, natDegree_mul_leadingCoeff_inv]
   · contrapose! hpu
-    exact isUnit_of_mul_eq_one _ _ hpu
+    exact .of_mul_eq_one _ hpu
 
 /-- To check a polynomial `p` over a field is irreducible, it suffices to check there are no
 divisors of degree `0 < d ≤ degree p / 2`.
@@ -659,7 +659,7 @@ theorem irreducible_iff_lt_natDegree_lt {p : R[X]} (hp0 : p ≠ 0) (hpu : ¬ IsU
     Irreducible p ↔ ∀ q, Monic q → natDegree q ∈ Finset.Ioc 0 (natDegree p / 2) → ¬ q ∣ p := by
   have : p * C (leadingCoeff p)⁻¹ ≠ 1 := by
     contrapose! hpu
-    exact isUnit_of_mul_eq_one _ _ hpu
+    exact .of_mul_eq_one _ hpu
   rw [← irreducible_mul_leadingCoeff_inv,
       (monic_mul_leadingCoeff_inv hp0).irreducible_iff_lt_natDegree_lt this,
       natDegree_mul_leadingCoeff_inv _ hp0]

--- a/Mathlib/Algebra/Polynomial/Monic.lean
+++ b/Mathlib/Algebra/Polynomial/Monic.lean
@@ -279,8 +279,8 @@ lemma irreducible_of_monic (hp : p.Monic) (hp1 : p ≠ 1) :
     ⟨fun h f g hf hg hp => (h.2 hp.symm).imp hf.eq_one_of_isUnit hg.eq_one_of_isUnit, fun h =>
       ⟨hp1 ∘ hp.eq_one_of_isUnit, fun f g hfg =>
         (h (g * C f.leadingCoeff) (f * C g.leadingCoeff) ?_ ?_ ?_).symm.imp
-          (isUnit_of_mul_eq_one f _)
-          (isUnit_of_mul_eq_one g _)⟩⟩
+          (.of_mul_eq_one _)
+          (.of_mul_eq_one _)⟩⟩
   · rwa [Monic, leadingCoeff_mul, leadingCoeff_C, ← leadingCoeff_mul, mul_comm, ← hfg, ← Monic]
   · rwa [Monic, leadingCoeff_mul, leadingCoeff_C, ← leadingCoeff_mul, ← hfg, ← Monic]
   · rw [mul_mul_mul_comm, ← C_mul, ← leadingCoeff_mul, ← hfg, hp.leadingCoeff, C_1, mul_one,

--- a/Mathlib/AlgebraicGeometry/EllipticCurve/ModelsWithJ.lean
+++ b/Mathlib/AlgebraicGeometry/EllipticCurve/ModelsWithJ.lean
@@ -159,7 +159,7 @@ lemma ofJ_ne_0_ne_1728 (h0 : j ≠ 0) (h1728 : j ≠ 1728) : ofJ j = ofJNe0Or172
 instance : (ofJ j).IsElliptic := by
   by_cases h0 : j = 0
   · by_cases h3 : (3 : F) = 0
-    · have := Fact.mk (isUnit_of_mul_eq_one (2 : F) 2 (by linear_combination h3))
+    · have : Fact <| IsUnit (2 : F) := ⟨.of_mul_eq_one 2 <| by linear_combination h3⟩
       rw [h0, ofJ_0_of_three_eq_zero h3]
       infer_instance
     · have := Fact.mk (Ne.isUnit h3)
@@ -178,7 +178,7 @@ instance : (ofJ j).IsElliptic := by
 lemma ofJ_j : (ofJ j).j = j := by
   by_cases h0 : j = 0
   · by_cases h3 : (3 : F) = 0
-    · have := Fact.mk (isUnit_of_mul_eq_one (2 : F) 2 (by linear_combination h3))
+    · have : Fact <| IsUnit (2 : F) := ⟨.of_mul_eq_one 2 <| by linear_combination h3⟩
       simp_rw [h0, ofJ_0_of_three_eq_zero h3, ofJ1728_j]
       linear_combination 576 * h3
     · have := Fact.mk (Ne.isUnit h3)

--- a/Mathlib/AlgebraicGeometry/ProjectiveSpectrum/Scheme.lean
+++ b/Mathlib/AlgebraicGeometry/ProjectiveSpectrum/Scheme.lean
@@ -720,7 +720,7 @@ lemma isLocalization_atPrime (f) (x : pbo f) {m} (f_deg : f ∈ 𝒜 m) (hm : 0 
   constructor
   · rintro ⟨y, hy⟩
     obtain ⟨y, rfl⟩ := HomogeneousLocalization.mk_surjective y
-    refine isUnit_of_mul_eq_one _
+    refine .of_mul_eq_one
       (.mk ⟨y.deg, y.den, y.num, (mk_mem_toSpec_base_apply _ _ _).not.mp hy⟩) <| val_injective _ ?_
     simp only [RingHom.algebraMap_toAlgebra, map_mk, RingHom.id_apply, val_mul, val_mk, mk_eq_mk',
       val_one, IsLocalization.mk'_mul_mk'_eq_one']

--- a/Mathlib/AlgebraicGeometry/StructureSheaf.lean
+++ b/Mathlib/AlgebraicGeometry/StructureSheaf.lean
@@ -414,7 +414,7 @@ theorem toOpen_Γgerm_apply (x : PrimeSpectrum.Top R) (f : R) :
   rfl
 
 theorem isUnit_to_basicOpen_self (f : R) : IsUnit (toOpen R (PrimeSpectrum.basicOpen f) f) :=
-  isUnit_of_mul_eq_one _ (const R 1 f (PrimeSpectrum.basicOpen f) fun _ => id) <| by
+  .of_mul_eq_one (const R 1 f (PrimeSpectrum.basicOpen f) fun _ => id) <| by
     rw [toOpen_eq_const, const_mul_rev]
 
 theorem isUnit_toStalk (x : PrimeSpectrum.Top R) (f : x.asIdeal.primeCompl) :

--- a/Mathlib/Data/Nat/Factorial/NatCast.lean
+++ b/Mathlib/Data/Nat/Factorial/NatCast.lean
@@ -76,7 +76,7 @@ lemma natCast_of_isNilpotent_of_coprime (h : p.Coprime n) :
   obtain ⟨m, hm⟩ := hp
   suffices ∃ a b : A, p ^ m * a + n * b = 1 by
     obtain ⟨a, b, h⟩ := this
-    apply isUnit_of_mul_eq_one (n : A) b
+    refine .of_mul_eq_one b ?_
     simpa [hm] using h
   refine ⟨(p ^ m).gcdA n, (p ^ m).gcdB n, ?_⟩
   norm_cast

--- a/Mathlib/Geometry/RingedSpace/Basic.lean
+++ b/Mathlib/Geometry/RingedSpace/Basic.lean
@@ -113,9 +113,7 @@ theorem isUnit_of_isUnit_germ (U : Opens X) (f : X.presheaf.obj (op U))
     -- We need to rephrase the result from `HasForget` to `CommRingCat`.
     ∃ gl : X.presheaf.obj (op U), (∀ i, ((sheaf X).val.map (iVU i).op) gl = g i) ∧ _ :=
     X.sheaf.existsUnique_gluing' V U iVU hcover g ic
-  apply .of_mul_eq_one gl
-  apply X.sheaf.eq_of_locally_eq' V U iVU hcover
-  intro i
+  refine .of_mul_eq_one gl <| X.sheaf.eq_of_locally_eq' V U iVU hcover _ _ fun i ↦ ?_
   -- We need to rephrase the goal from `HasForget` to `CommRingCat`.
   change ((sheaf X).val.map (iVU i).op).hom (f * gl) = ((sheaf X).val.map (iVU i).op) 1
   rw [RingHom.map_one, RingHom.map_mul, gl_spec]

--- a/Mathlib/Geometry/RingedSpace/Basic.lean
+++ b/Mathlib/Geometry/RingedSpace/Basic.lean
@@ -82,7 +82,7 @@ theorem isUnit_res_of_isUnit_germ (U : Opens X) (f : X.presheaf.obj (op U)) (x :
   obtain ⟨W', hxW', i₁, i₂, heq'⟩ := X.presheaf.germ_eq x hxW hxW _ _ heq
   use W', i₁ ≫ Opens.infLELeft U V, hxW'
   simp only [map_mul, map_one] at heq'
-  simpa using isUnit_of_mul_eq_one _ _ heq'
+  simpa using .of_mul_eq_one _ heq'
 
 /-- If a section `f` is a unit in each stalk, `f` must be a unit. -/
 theorem isUnit_of_isUnit_germ (U : Opens X) (f : X.presheaf.obj (op U))
@@ -113,7 +113,7 @@ theorem isUnit_of_isUnit_germ (U : Opens X) (f : X.presheaf.obj (op U))
     -- We need to rephrase the result from `HasForget` to `CommRingCat`.
     ∃ gl : X.presheaf.obj (op U), (∀ i, ((sheaf X).val.map (iVU i).op) gl = g i) ∧ _ :=
     X.sheaf.existsUnique_gluing' V U iVU hcover g ic
-  apply isUnit_of_mul_eq_one f gl
+  apply .of_mul_eq_one gl
   apply X.sheaf.eq_of_locally_eq' V U iVU hcover
   intro i
   -- We need to rephrase the goal from `HasForget` to `CommRingCat`.

--- a/Mathlib/GroupTheory/MonoidLocalization/Away.lean
+++ b/Mathlib/GroupTheory/MonoidLocalization/Away.lean
@@ -70,7 +70,7 @@ respectively, the homomorphism induced from `N` to `P`. -/
 noncomputable def awayToAwayRight (y : M) (G : AwayMap (x * y) P) : N →* P :=
   F.lift x <|
     show IsUnit (G x) from
-      isUnit_of_mul_eq_one (G x) (G.mk' y ⟨x * y, mem_powers _⟩) <| by
+      .of_mul_eq_one (G.mk' y ⟨x * y, mem_powers _⟩) <| by
         rw [mul_mk'_eq_mk'_of_mul, mk'_self]
 
 end AwayMap
@@ -117,7 +117,7 @@ respectively, the homomorphism induced from `B` to `C`. -/
 noncomputable def awayToAwayRight (y : A) (G : AwayMap (x + y) C) : B →+ C :=
   F.lift x <|
     show IsAddUnit (G x) from
-      isAddUnit_of_add_eq_zero (G x) (G.mk' y ⟨x + y, mem_multiples _⟩) <| by
+      .of_add_eq_zero (G.mk' y ⟨x + y, mem_multiples _⟩) <| by
         rw [add_mk'_eq_mk'_of_add, mk'_self]
 
 end AwayMap

--- a/Mathlib/LinearAlgebra/Determinant.lean
+++ b/Mathlib/LinearAlgebra/Determinant.lean
@@ -451,7 +451,7 @@ theorem LinearEquiv.isUnit_det (f : M ≃ₗ[R] M') (v : Basis ι R M) (v' : Bas
 /-- Specialization of `LinearEquiv.isUnit_det` -/
 theorem LinearEquiv.isUnit_det' {A : Type*} [CommRing A] [Module A M] (f : M ≃ₗ[A] M) :
     IsUnit (LinearMap.det (f : M →ₗ[A] M)) :=
-  isUnit_of_mul_eq_one _ _ f.det_mul_det_symm
+  .of_mul_eq_one _ f.det_mul_det_symm
 
 -- see https://github.com/leanprover-community/mathlib4/issues/29041
 set_option linter.unusedSimpArgs false in

--- a/Mathlib/LinearAlgebra/JordanChevalley.lean
+++ b/Mathlib/LinearAlgebra/JordanChevalley.lean
@@ -55,7 +55,7 @@ theorem exists_isNilpotent_isSemisimple_of_separable_of_dvd_pow {P : K[X]} {k : 
     replace h : (aeval f b) * (aeval f P') = 1 := by
       simpa only [map_add, map_mul, map_one, minpoly.dvd_iff.mp nil, mul_zero, zero_add]
         using (aeval f).congr_arg h
-    refine isUnit_of_mul_eq_one_right (aeval ff b) _ (Subtype.ext_iff.mpr ?_)
+    refine .of_mul_eq_one_right (aeval ff b) (Subtype.ext_iff.mpr ?_)
     simpa [ff, coe_aeval_mk_apply] using h
   obtain ⟨⟨s, mem⟩, ⟨⟨k, hk⟩, hss⟩, -⟩ := existsUnique_nilpotent_sub_and_aeval_eq_zero nil' sep'
   refine ⟨f - s, ?_, s, mem, ⟨k, ?_⟩, ?_, (sub_add_cancel f s).symm⟩

--- a/Mathlib/LinearAlgebra/Matrix/NonsingularInverse.lean
+++ b/Mathlib/LinearAlgebra/Matrix/NonsingularInverse.lean
@@ -414,7 +414,7 @@ theorem det_nonsing_inv : A⁻¹.det = Ring.inverse A.det := by
   · rw [Ring.inverse_non_unit _ h, nonsing_inv_apply_not_isUnit _ h, det_zero ‹_›]
 
 theorem isUnit_nonsing_inv_det (h : IsUnit A.det) : IsUnit A⁻¹.det :=
-  isUnit_of_mul_eq_one _ _ (A.det_nonsing_inv_mul_det h)
+  .of_mul_eq_one _ (A.det_nonsing_inv_mul_det h)
 
 @[simp]
 theorem nonsing_inv_nonsing_inv (h : IsUnit A.det) : A⁻¹⁻¹ = A :=

--- a/Mathlib/LinearAlgebra/RootSystem/Base.lean
+++ b/Mathlib/LinearAlgebra/RootSystem/Base.lean
@@ -177,7 +177,7 @@ lemma eq_one_or_neg_one_of_mem_support_of_smul_mem [Finite ι]
     (i : ι) (h : i ∈ b.support) (t : R) (ht : t • P.root i ∈ range P.root) :
     t = 1 ∨ t = -1 := by
   obtain ⟨z, hz⟩ := b.eq_one_or_neg_one_of_mem_support_of_smul_mem_aux i h t ht
-  obtain ⟨s, hs⟩ := IsUnit.exists_left_inv <| isUnit_of_mul_eq_one_right _ t hz
+  obtain ⟨s, hs⟩ := IsUnit.exists_left_inv <| .of_mul_eq_one_right t hz
   replace ht : s • P.coroot i ∈ range P.coroot := by
     obtain ⟨j, hj⟩ := ht
     simpa only [coroot_eq_smul_coroot_iff.mpr hj, smul_smul, hs, one_smul] using mem_range_self j

--- a/Mathlib/LinearAlgebra/RootSystem/Base.lean
+++ b/Mathlib/LinearAlgebra/RootSystem/Base.lean
@@ -177,13 +177,12 @@ lemma eq_one_or_neg_one_of_mem_support_of_smul_mem [Finite ι]
     (i : ι) (h : i ∈ b.support) (t : R) (ht : t • P.root i ∈ range P.root) :
     t = 1 ∨ t = -1 := by
   obtain ⟨z, hz⟩ := b.eq_one_or_neg_one_of_mem_support_of_smul_mem_aux i h t ht
-  obtain ⟨s, hs⟩ := IsUnit.exists_left_inv <| .of_mul_eq_one_right t hz
-  replace ht : s • P.coroot i ∈ range P.coroot := by
+  replace ht : (z : R) • P.coroot i ∈ range P.coroot := by
     obtain ⟨j, hj⟩ := ht
-    simpa only [coroot_eq_smul_coroot_iff.mpr hj, smul_smul, hs, one_smul] using mem_range_self j
-  obtain ⟨w, hw⟩ := b.flip.eq_one_or_neg_one_of_mem_support_of_smul_mem_aux i h s ht
+    simpa only [coroot_eq_smul_coroot_iff.mpr hj, smul_smul, hz, one_smul] using mem_range_self j
+  obtain ⟨w, hw⟩ := b.flip.eq_one_or_neg_one_of_mem_support_of_smul_mem_aux i h _ ht
   have : (z : R) * w = 1 := by
-    simpa [mul_mul_mul_comm _ t _ s, mul_comm t s, hs] using congr_arg₂ (· * ·) hz hw
+    simpa [mul_mul_mul_comm _ t, mul_comm t, mul_comm _ (z : R), hz] using congr_arg₂ (· * ·) hz hw
   suffices z = 1 ∨ z = -1 by
     rcases this with rfl | rfl
     · left; simpa using hz

--- a/Mathlib/NumberTheory/LucasLehmer.lean
+++ b/Mathlib/NumberTheory/LucasLehmer.lean
@@ -449,7 +449,7 @@ lemma pow_ω [Fact q.Prime] (odd : Odd q)
   have coe : (2 : X q) = (2 : ZMod q) := by rw [map_ofNat]
   rw [coe, ← RingHom.map_pow, pow2, ← coe,
     (by ring : (-2 : X q) = 2 * -1)] at this
-  refine (IsUnit.of_mul_eq_one ((q + 1) / 2 : ℕ) ?_).mul_left_cancel this
+  refine (IsUnit.of_mul_eq_one (M := X q) ↑((q + 1) / 2) ?_).mul_left_cancel this
   norm_cast
   simp [Nat.mul_div_cancel' odd.add_one.two_dvd]
 

--- a/Mathlib/NumberTheory/LucasLehmer.lean
+++ b/Mathlib/NumberTheory/LucasLehmer.lean
@@ -449,7 +449,7 @@ lemma pow_ω [Fact q.Prime] (odd : Odd q)
   have coe : (2 : X q) = (2 : ZMod q) := by rw [map_ofNat]
   rw [coe, ← RingHom.map_pow, pow2, ← coe,
     (by ring : (-2 : X q) = 2 * -1)] at this
-  refine (isUnit_of_mul_eq_one (2 : X q) ((q + 1) / 2 : ℕ) ?_).mul_left_cancel this
+  refine (IsUnit.of_mul_eq_one ((q + 1) / 2 : ℕ) ?_).mul_left_cancel this
   norm_cast
   simp [Nat.mul_div_cancel' odd.add_one.two_dvd]
 

--- a/Mathlib/NumberTheory/Pell.lean
+++ b/Mathlib/NumberTheory/Pell.lean
@@ -641,7 +641,7 @@ theorem existsUnique_pos_generator (h₀ : 0 < d) (hd : ¬IsSquare d) :
       zpow_neg_one, neg_mul, ← zpow_add, ← sub_eq_add_neg] at hn₁
     rcases hn₁ with hn₁ | hn₁
     · rcases Int.isUnit_iff.mp
-          (isUnit_of_mul_eq_one _ _ <|
+          (.of_mul_eq_one _ <|
             sub_eq_zero.mp <| (ha₁.zpow_eq_one_iff (n₂ * n₁ - 1)).mp hn₁) with
         (rfl | rfl)
       · rw [zpow_one]

--- a/Mathlib/RingTheory/Coprime/Basic.lean
+++ b/Mathlib/RingTheory/Coprime/Basic.lean
@@ -50,12 +50,12 @@ theorem isCoprime_comm : IsCoprime x y ↔ IsCoprime y x :=
   ⟨IsCoprime.symm, IsCoprime.symm⟩
 
 theorem isCoprime_self : IsCoprime x x ↔ IsUnit x :=
-  ⟨fun ⟨a, b, h⟩ => isUnit_of_mul_eq_one x (a + b) <| by rwa [mul_comm, add_mul], fun h =>
+  ⟨fun ⟨a, b, h⟩ => .of_mul_eq_one (a + b) <| by rwa [mul_comm, add_mul], fun h =>
     let ⟨b, hb⟩ := isUnit_iff_exists_inv'.1 h
     ⟨b, 0, by rwa [zero_mul, add_zero]⟩⟩
 
 theorem isCoprime_zero_left : IsCoprime 0 x ↔ IsUnit x :=
-  ⟨fun ⟨a, b, H⟩ => isUnit_of_mul_eq_one x b <| by rwa [mul_zero, zero_add, mul_comm] at H, fun H =>
+  ⟨fun ⟨a, b, H⟩ => .of_mul_eq_one b <| by rwa [mul_zero, zero_add, mul_comm] at H, fun H =>
     let ⟨b, hb⟩ := isUnit_iff_exists_inv'.1 H
     ⟨1, b, by rwa [one_mul, zero_add]⟩⟩
 

--- a/Mathlib/RingTheory/DedekindDomain/Ideal/Basic.lean
+++ b/Mathlib/RingTheory/DedekindDomain/Ideal/Basic.lean
@@ -100,7 +100,7 @@ theorem inv_mul_eq_one {I : FractionalIdeal A⁰ K} (hI : I ≠ 0) : I⁻¹ * I 
   (mul_comm _ _).trans (h.mul_inv_eq_one hI)
 
 protected theorem isUnit {I : FractionalIdeal A⁰ K} (hI : I ≠ 0) : IsUnit I :=
-  isUnit_of_mul_eq_one _ _ (h.mul_inv_eq_one hI)
+  .of_mul_eq_one _ (h.mul_inv_eq_one hI)
 
 theorem isNoetherianRing : IsNoetherianRing A := by
   refine isNoetherianRing_iff.mpr ⟨fun I : Ideal A => ?_⟩

--- a/Mathlib/RingTheory/DedekindDomain/PID.lean
+++ b/Mathlib/RingTheory/DedekindDomain/PID.lean
@@ -178,7 +178,7 @@ theorem IsPrincipalIdealRing.of_finite_maximals [IsDedekindDomain R]
     obtain rfl | hI := eq_or_ne I ⊥
     · exact bot_isPrincipal
     apply Ideal.IsPrincipal.of_finite_maximals_of_isUnit h
-    exact isUnit_of_mul_eq_one _ _ (FractionalIdeal.coe_ideal_mul_inv I hI)⟩
+    exact .of_mul_eq_one _ (FractionalIdeal.coe_ideal_mul_inv I hI)⟩
 
 /-- A Dedekind domain is a PID if its set of primes is finite. -/
 theorem IsPrincipalIdealRing.of_finite_primes [IsDedekindDomain R]

--- a/Mathlib/RingTheory/GradedAlgebra/HomogeneousLocalization.lean
+++ b/Mathlib/RingTheory/GradedAlgebra/HomogeneousLocalization.lean
@@ -576,7 +576,7 @@ theorem isUnit_iff_isUnit_val (f : HomogeneousLocalization.AtPrime 𝒜 𝔭) :
   have : f.num.1 ∉ 𝔭 := by
     exact fun h ↦ mul_mem c.2 (mul_mem f.den_mem s.2)
       (hc ▸ Ideal.mul_mem_left _ c.1 (Ideal.mul_mem_right b _ h))
-  refine isUnit_of_mul_eq_one _ (Quotient.mk'' ⟨f.1, f.3, f.2, this⟩) ?_
+  refine .of_mul_eq_one (Quotient.mk'' ⟨f.1, f.3, f.2, this⟩) ?_
   rw [← mk_mul, ext_iff_val, val_mk]
   simp [mul_comm f.den.1]
 

--- a/Mathlib/RingTheory/HahnSeries/Summable.lean
+++ b/Mathlib/RingTheory/HahnSeries/Summable.lean
@@ -756,7 +756,7 @@ theorem unit_aux (x : HahnSeries Γ R) {r : R} (hr : r * x.leadingCoeff = 1)
   · have hrx : (single oinv) r * x = 1 := by
       rw [eq_of_sub_eq_zero hy, single_mul_single, hxo, hr, single_zero_one]
     simp only [hrx, sub_self, orderTop_zero, WithTop.top_pos]
-  · have hr' : IsRegular r := IsUnit.isRegular <| isUnit_of_mul_eq_one r x.leadingCoeff hr
+  · have hr' : IsRegular r := IsUnit.isRegular <| .of_mul_eq_one x.leadingCoeff hr
     have hy' : 0 < (single oinv r * y).order := by
       rw [(order_single_mul_of_isRegular hr' hy)]
       refine pos_of_lt_add_right (a := x.order) ?_
@@ -772,7 +772,7 @@ theorem isUnit_of_isUnit_leadingCoeff_AddUnitOrder {x : HahnSeries Γ R} (hx : I
   rw [h] at iu
   have h' := SummableFamily.one_sub_self_mul_hsum_powers (unit_aux x iu _ hxo.addUnit.neg_add)
   rw [sub_sub_cancel] at h'
-  exact isUnit_of_mul_isUnit_right (isUnit_of_mul_eq_one _ _ h')
+  exact isUnit_of_mul_isUnit_right (.of_mul_eq_one _ h')
 
 end CommRing
 
@@ -784,7 +784,7 @@ theorem isUnit_iff {x : HahnSeries Γ R} : IsUnit x ↔ IsUnit (x.leadingCoeff) 
   constructor
   · rintro ⟨⟨u, i, ui, iu⟩, rfl⟩
     refine
-      isUnit_of_mul_eq_one (u.leadingCoeff) (i.leadingCoeff)
+      .of_mul_eq_one (i.leadingCoeff)
         ((coeff_mul_order_add_order u i).symm.trans ?_)
     rw [ui, coeff_one, if_pos]
     rw [← order_mul (left_ne_zero_of_mul_eq_one ui) (right_ne_zero_of_mul_eq_one ui), ui, order_one]
@@ -794,7 +794,7 @@ theorem isUnit_iff {x : HahnSeries Γ R} : IsUnit x ↔ IsUnit (x.leadingCoeff) 
     have h :=
       SummableFamily.one_sub_self_mul_hsum_powers (unit_aux x iu _ (neg_add_cancel x.order))
     rw [sub_sub_cancel] at h
-    exact isUnit_of_mul_isUnit_right (isUnit_of_mul_eq_one _ _ h)
+    exact isUnit_of_mul_isUnit_right (.of_mul_eq_one _ h)
 
 end IsDomain
 

--- a/Mathlib/RingTheory/Ideal/Quotient/Nilpotent.lean
+++ b/Mathlib/RingTheory/Ideal/Quotient/Nilpotent.lean
@@ -70,4 +70,4 @@ theorem IsNilpotent.isUnit_quotient_mk_iff {R : Type*} [CommRing R] {I : Ideal R
     have : x * (y * (2 - x * y)) = 1 := by
       rw [eq_comm, ← sub_eq_zero, ← this]
       ring
-    exact isUnit_of_mul_eq_one _ _ this
+    exact .of_mul_eq_one _ this

--- a/Mathlib/RingTheory/Ideal/Quotient/PowTransition.lean
+++ b/Mathlib/RingTheory/Ideal/Quotient/PowTransition.lean
@@ -139,10 +139,10 @@ lemma factorPowSucc.isUnit_of_isUnit_image {n : ℕ} (npos : n > 0) {a : R ⧸ I
   rw [factor_ker (pow_le_pow_right n.le_succ)] at hb
   rcases Ideal.mem_image_of_mem_map_of_surjective (Ideal.Quotient.mk (I ^ (n + 1)))
     Ideal.Quotient.mk_surjective hb with ⟨c, hc, eq⟩
-  apply .of_mul_eq_one (b' * (1 - ((Ideal.Quotient.mk (I ^ (n + 1))) c)))
+  refine .of_mul_eq_one (b' * (1 - Ideal.Quotient.mk (I ^ (n + 1)) c)) ?_
   calc
-    _ = (a * b' - 1) * (1 - ((Ideal.Quotient.mk (I ^ (n + 1))) c)) +
-        (1 - ((Ideal.Quotient.mk (I ^ (n + 1))) c)) := by ring
+    _ = (a * b' - 1) * (1 - Ideal.Quotient.mk (I ^ (n + 1)) c) +
+        (1 - Ideal.Quotient.mk (I ^ (n + 1)) c) := by ring
     _ = 1 := by
       rw [← eq, mul_sub, mul_one, sub_add_sub_cancel', sub_eq_self, ← map_mul,
         Ideal.Quotient.eq_zero_iff_mem, pow_add]

--- a/Mathlib/RingTheory/Ideal/Quotient/PowTransition.lean
+++ b/Mathlib/RingTheory/Ideal/Quotient/PowTransition.lean
@@ -139,7 +139,7 @@ lemma factorPowSucc.isUnit_of_isUnit_image {n : ℕ} (npos : n > 0) {a : R ⧸ I
   rw [factor_ker (pow_le_pow_right n.le_succ)] at hb
   rcases Ideal.mem_image_of_mem_map_of_surjective (Ideal.Quotient.mk (I ^ (n + 1)))
     Ideal.Quotient.mk_surjective hb with ⟨c, hc, eq⟩
-  apply isUnit_of_mul_eq_one _ (b' * (1 - ((Ideal.Quotient.mk (I ^ (n + 1))) c)))
+  apply .of_mul_eq_one (b' * (1 - ((Ideal.Quotient.mk (I ^ (n + 1))) c)))
   calc
     _ = (a * b' - 1) * (1 - ((Ideal.Quotient.mk (I ^ (n + 1))) c)) +
         (1 - ((Ideal.Quotient.mk (I ^ (n + 1))) c)) := by ring

--- a/Mathlib/RingTheory/IntegralClosure/IsIntegralClosure/Basic.lean
+++ b/Mathlib/RingTheory/IntegralClosure/IsIntegralClosure/Basic.lean
@@ -594,7 +594,7 @@ theorem RingHom.IsIntegral.isLocalHom {f : R →+* S} (hf : f.IsIntegral)
     obtain ⟨p, p_monic, hp⟩ := hf (ha.unit⁻¹ : _)
     -- and `q` be `p` with coefficients reversed (so `q(a) = q'(a) * a + 1`).
     -- We have `q(a) = 0`, so `-q'(a)` is the inverse of `a`.
-    refine isUnit_of_mul_eq_one _ (-p.reverse.divX.eval a) ?_
+    refine .of_mul_eq_one (-p.reverse.divX.eval a) ?_
     nth_rewrite 1 [mul_neg, ← eval_X (x := a), ← eval_mul, ← p_monic, ← coeff_zero_reverse,
       ← add_eq_zero_iff_neg_eq, ← eval_C (a := p.reverse.coeff 0), ← eval_add, X_mul_divX_add,
       ← (injective_iff_map_eq_zero' _).mp inj, ← eval₂_hom]

--- a/Mathlib/RingTheory/Jacobson/Ideal.lean
+++ b/Mathlib/RingTheory/Jacobson/Ideal.lean
@@ -279,7 +279,7 @@ theorem isUnit_of_sub_one_mem_jacobson_bot (r : R) (h : r - 1 ∈ jacobson (⊥ 
     IsUnit r := by
   obtain ⟨s, hs⟩ := exists_mul_sub_mem_of_sub_one_mem_jacobson r h
   rw [mem_bot, sub_eq_zero, mul_comm] at hs
-  exact isUnit_of_mul_eq_one _ _ hs
+  exact .of_mul_eq_one _ hs
 
 theorem mem_jacobson_bot {x : R} : x ∈ jacobson (⊥ : Ideal R) ↔ ∀ y, IsUnit (x * y + 1) :=
   ⟨fun hx y =>

--- a/Mathlib/RingTheory/Localization/Away/AdjoinRoot.lean
+++ b/Mathlib/RingTheory/Localization/Away/AdjoinRoot.lean
@@ -23,7 +23,7 @@ noncomputable def Localization.awayEquivAdjoin (r : R) : Away r ≃ₐ[R] Adjoin
   AlgEquiv.ofAlgHom
     { awayLift _ r _ with
       commutes' :=
-        IsLocalization.Away.lift_eq r (isUnit_of_mul_eq_one _ _ <| root_isInv r) }
+        IsLocalization.Away.lift_eq r (.of_mul_eq_one _ <| root_isInv r) }
     (liftAlgHom _ (Algebra.ofId _ _) (IsLocalization.Away.invSelf r) <| show aeval _ _ = _ by simp)
     (Subsingleton.elim _ _)
     (Subsingleton.elim (h := IsLocalization.algHom_subsingleton (Submonoid.powers r)) _ _)

--- a/Mathlib/RingTheory/Multiplicity.lean
+++ b/Mathlib/RingTheory/Multiplicity.lean
@@ -652,7 +652,7 @@ theorem multiplicity_self {a : α} : multiplicity a a = 1 := by
     nth_rw 1 [← mul_one a] at hv
     simp only [sq, mul_assoc, mul_eq_mul_left_iff] at hv
     obtain hv | rfl := hv
-    · have : IsUnit a := isUnit_of_mul_eq_one a v hv.symm
+    · have : IsUnit a := .of_mul_eq_one v hv.symm
       simpa [this] using ha.not_unit
     · simpa using ha.ne_zero
   · simp [ha]

--- a/Mathlib/RingTheory/MvPowerSeries/Inverse.lean
+++ b/Mathlib/RingTheory/MvPowerSeries/Inverse.lean
@@ -151,7 +151,7 @@ instance [IsLocalRing R] : IsLocalRing (MvPowerSeries σ R) :=
     intro φ
     obtain ⟨u, h⟩ | ⟨u, h⟩ := IsLocalRing.isUnit_or_isUnit_one_sub_self (constantCoeff φ) <;>
         [left; right] <;>
-      · refine isUnit_of_mul_eq_one _ _ (mul_invOfUnit _ u ?_)
+      · refine .of_mul_eq_one _ (mul_invOfUnit _ u ?_)
         simpa using h.symm
 
 -- TODO(jmc): once adic topology lands, show that this is complete
@@ -174,7 +174,7 @@ theorem map.isLocalHom : IsLocalHom (map (σ := σ) f) :=
     have : IsUnit (constantCoeff ψ.val) := isUnit_constantCoeff _ ψ.isUnit
     rw [h] at this
     rcases isUnit_of_map_unit f _ this with ⟨c, hc⟩
-    exact isUnit_of_mul_eq_one φ (invOfUnit φ c) (mul_invOfUnit φ c hc.symm)⟩
+    exact .of_mul_eq_one (invOfUnit φ c) (mul_invOfUnit φ c hc.symm)⟩
 
 end IsLocalRing
 

--- a/Mathlib/RingTheory/Polynomial/Content.lean
+++ b/Mathlib/RingTheory/Polynomial/Content.lean
@@ -50,7 +50,7 @@ theorem isPrimitive_one : IsPrimitive (1 : R[X]) := fun _ h =>
 
 theorem Monic.isPrimitive {p : R[X]} (hp : p.Monic) : p.IsPrimitive := by
   rintro r ⟨q, h⟩
-  exact isUnit_of_mul_eq_one r (q.coeff p.natDegree) (by rwa [← coeff_C_mul, ← h])
+  exact .of_mul_eq_one (q.coeff p.natDegree) (by rwa [← coeff_C_mul, ← h])
 
 theorem IsPrimitive.ne_zero [Nontrivial R] {p : R[X]} (hp : p.IsPrimitive) : p ≠ 0 := by
   rintro rfl

--- a/Mathlib/RingTheory/Polynomial/Nilpotent.lean
+++ b/Mathlib/RingTheory/Polynomial/Nilpotent.lean
@@ -132,7 +132,7 @@ theorem coeff_isUnit_isNilpotent_of_isUnit (hunit : IsUnit P) :
     IsUnit (P.coeff 0) ∧ (∀ i, i ≠ 0 → IsNilpotent (P.coeff i)) := by
   obtain ⟨Q, hQ⟩ := IsUnit.exists_right_inv hunit
   constructor
-  · refine isUnit_of_mul_eq_one _ (Q.coeff 0) ?_
+  · refine .of_mul_eq_one (Q.coeff 0) ?_
     have h := (mul_coeff_zero P Q).symm
     rwa [hQ, coeff_one_zero] at h
   · intro n hn

--- a/Mathlib/RingTheory/PowerSeries/WeierstrassPreparation.lean
+++ b/Mathlib/RingTheory/PowerSeries/WeierstrassPreparation.lean
@@ -736,7 +736,7 @@ theorem IsWeierstrassDivision.isUnit_of_map_ne_zero
   rw [isUnit_iff_constantCoeff, ← isUnit_map_iff (IsLocalRing.residue A)]
   rw [coeff_mul, ← Finset.sum_subset (s₁ := {(n, 0)}) (by simp) (fun p hp hnotMem ↦ ?_),
     Finset.sum_singleton, coeff_map, coeff_map, coeff_zero_eq_constantCoeff, mul_comm] at H2
-  · exact isUnit_of_mul_eq_one _ _ H2.symm
+  · exact .of_mul_eq_one _ H2.symm
   · rw [coeff_of_lt_order p.1 ?_]
     · rw [zero_mul]
     · rw [← ENat.lt_lift_iff (h := order_finite_iff_ne_zero.2 hg), ENat.lift_eq_toNat_of_lt_top]

--- a/Mathlib/RingTheory/RootsOfUnity/PrimitiveRoots.lean
+++ b/Mathlib/RingTheory/RootsOfUnity/PrimitiveRoots.lean
@@ -118,7 +118,7 @@ theorem pow_eq_one_iff_dvd (h : IsPrimitiveRoot ζ k) (l : ℕ) : ζ ^ l = 1 ↔
     rintro ⟨i, rfl⟩; simp only [pow_mul, h.pow_eq_one, one_pow]⟩
 
 theorem isUnit (h : IsPrimitiveRoot ζ k) (h0 : k ≠ 0) : IsUnit ζ := by
-  apply isUnit_of_mul_eq_one ζ (ζ ^ (k - 1))
+  apply .of_mul_eq_one (ζ ^ (k - 1))
   rw [← pow_succ', Nat.sub_one_add_one h0, h.pow_eq_one]
 
 theorem pow_ne_one_of_pos_of_lt (h : IsPrimitiveRoot ζ k) (h0 : l ≠ 0) (hl : l < k) : ζ ^ l ≠ 1 :=

--- a/Mathlib/RingTheory/RootsOfUnity/PrimitiveRoots.lean
+++ b/Mathlib/RingTheory/RootsOfUnity/PrimitiveRoots.lean
@@ -117,9 +117,8 @@ theorem pow_eq_one_iff_dvd (h : IsPrimitiveRoot ζ k) (l : ℕ) : ζ ^ l = 1 ↔
   ⟨h.dvd_of_pow_eq_one l, by
     rintro ⟨i, rfl⟩; simp only [pow_mul, h.pow_eq_one, one_pow]⟩
 
-theorem isUnit (h : IsPrimitiveRoot ζ k) (h0 : k ≠ 0) : IsUnit ζ := by
-  apply .of_mul_eq_one (ζ ^ (k - 1))
-  rw [← pow_succ', Nat.sub_one_add_one h0, h.pow_eq_one]
+theorem isUnit (h : IsPrimitiveRoot ζ k) (h0 : k ≠ 0) : IsUnit ζ :=
+  .of_mul_eq_one (ζ ^ (k - 1)) <| by rw [← pow_succ', Nat.sub_one_add_one h0, h.pow_eq_one]
 
 theorem pow_ne_one_of_pos_of_lt (h : IsPrimitiveRoot ζ k) (h0 : l ≠ 0) (hl : l < k) : ζ ^ l ≠ 1 :=
   mt (Nat.le_of_dvd (Nat.pos_iff_ne_zero.mpr h0) ∘ h.dvd_of_pow_eq_one _) <| not_le_of_gt hl

--- a/Mathlib/RingTheory/Trace/Basic.lean
+++ b/Mathlib/RingTheory/Trace/Basic.lean
@@ -479,7 +479,7 @@ theorem det_traceForm_ne_zero [Algebra.IsSeparable K L] [Fintype ι] [DecidableE
   swap; · apply Basis.toMatrix_mul_toMatrix_flip
   refine
     mul_ne_zero
-      (isUnit_of_mul_eq_one _ ((b.toMatrix pb.basis)ᵀ * b.toMatrix pb.basis).det ?_).ne_zero ?_
+      (IsUnit.of_mul_eq_one ((b.toMatrix pb.basis)ᵀ * b.toMatrix pb.basis).det ?_).ne_zero ?_
   · calc
       (pb.basis.toMatrix b * (pb.basis.toMatrix b)ᵀ).det *
             ((b.toMatrix pb.basis)ᵀ * b.toMatrix pb.basis).det =

--- a/Mathlib/RingTheory/Valuation/ValuationRing.lean
+++ b/Mathlib/RingTheory/Valuation/ValuationRing.lean
@@ -255,16 +255,14 @@ section
 variable (A : Type u) [CommRing A] [Nontrivial A] [PreValuationRing A]
 
 instance (priority := 100) isLocalRing : IsLocalRing A :=
-  IsLocalRing.of_isUnit_or_isUnit_one_sub_self
-    (by
-      intro a
-      obtain ⟨c, h | h⟩ := PreValuationRing.cond a (1 - a)
-      · left
-        apply .of_mul_eq_one (c + 1)
-        simp [mul_add, h]
-      · right
-        apply .of_mul_eq_one (c + 1)
-        simp [mul_add, h])
+  IsLocalRing.of_isUnit_or_isUnit_one_sub_self fun a ↦ by
+    obtain ⟨c, h | h⟩ := PreValuationRing.cond a (1 - a)
+    · left
+      refine .of_mul_eq_one (c + 1) ?_
+      simp [mul_add, h]
+    · right
+      refine .of_mul_eq_one (c + 1) ?_
+      simp [mul_add, h]
 
 instance le_total_ideal : IsTotal (Ideal A) LE.le := by
   constructor; intro α β

--- a/Mathlib/RingTheory/Valuation/ValuationRing.lean
+++ b/Mathlib/RingTheory/Valuation/ValuationRing.lean
@@ -260,10 +260,10 @@ instance (priority := 100) isLocalRing : IsLocalRing A :=
       intro a
       obtain ⟨c, h | h⟩ := PreValuationRing.cond a (1 - a)
       · left
-        apply isUnit_of_mul_eq_one _ (c + 1)
+        apply .of_mul_eq_one (c + 1)
         simp [mul_add, h]
       · right
-        apply isUnit_of_mul_eq_one _ (c + 1)
+        apply .of_mul_eq_one (c + 1)
         simp [mul_add, h])
 
 instance le_total_ideal : IsTotal (Ideal A) LE.le := by

--- a/Mathlib/RingTheory/Valuation/ValuationSubring.lean
+++ b/Mathlib/RingTheory/Valuation/ValuationSubring.lean
@@ -169,14 +169,17 @@ theorem valuation_surjective : Function.Surjective A.valuation := Quot.mk_surjec
 theorem valuation_unit (a : Aˣ) : A.valuation a = 1 := by
   rw [← A.valuation.map_one, valuation_eq_iff]; use a; simp
 
-theorem valuation_eq_one_iff (a : A) : IsUnit a ↔ A.valuation a = 1 :=
-  ⟨fun h => A.valuation_unit h.unit, fun h => by
+theorem valuation_eq_one_iff (a : A) : IsUnit a ↔ A.valuation a = 1 where
+  mp h := A.valuation_unit h.unit
+  mpr h := by
     have ha : (a : K) ≠ 0 := by
       intro c
       rw [c, A.valuation.map_zero] at h
       exact zero_ne_one h
     have ha' : (a : K)⁻¹ ∈ A := by rw [← valuation_le_one_iff, map_inv₀, h, inv_one]
-    apply .of_mul_eq_one ⟨a⁻¹, ha'⟩; ext; simp [field]⟩
+    refine .of_mul_eq_one ⟨a⁻¹, ha'⟩ ?_
+    ext
+    simp [field]
 
 theorem valuation_lt_one_or_eq_one (a : A) : A.valuation a < 1 ∨ A.valuation a = 1 :=
   lt_or_eq_of_le (A.valuation_le_one a)
@@ -309,8 +312,9 @@ theorem ofPrime_idealOfLE (R S : ValuationSubring K) (h : R ≤ S) :
         SetLike.mem_coe, idealOfLE, Ideal.mem_comap, IsLocalRing.mem_maximalIdeal, mem_nonunits_iff,
         not_not]
       change IsUnit (⟨x⁻¹, h hr⟩ : S)
-      apply .of_mul_eq_one (⟨x, hx⟩ : S)
-      ext; simp [field]
+      refine .of_mul_eq_one (⟨x, hx⟩ : S) ?_
+      ext
+      simp [field]
     · simp
 
 theorem ofPrime_le_of_le (P Q : Ideal A) [P.IsPrime] [Q.IsPrime] (h : P ≤ Q) :

--- a/Mathlib/RingTheory/Valuation/ValuationSubring.lean
+++ b/Mathlib/RingTheory/Valuation/ValuationSubring.lean
@@ -176,7 +176,7 @@ theorem valuation_eq_one_iff (a : A) : IsUnit a ↔ A.valuation a = 1 :=
       rw [c, A.valuation.map_zero] at h
       exact zero_ne_one h
     have ha' : (a : K)⁻¹ ∈ A := by rw [← valuation_le_one_iff, map_inv₀, h, inv_one]
-    apply isUnit_of_mul_eq_one a ⟨a⁻¹, ha'⟩; ext; simp [field]⟩
+    apply .of_mul_eq_one ⟨a⁻¹, ha'⟩; ext; simp [field]⟩
 
 theorem valuation_lt_one_or_eq_one (a : A) : A.valuation a < 1 ∨ A.valuation a = 1 :=
   lt_or_eq_of_le (A.valuation_le_one a)
@@ -309,7 +309,7 @@ theorem ofPrime_idealOfLE (R S : ValuationSubring K) (h : R ≤ S) :
         SetLike.mem_coe, idealOfLE, Ideal.mem_comap, IsLocalRing.mem_maximalIdeal, mem_nonunits_iff,
         not_not]
       change IsUnit (⟨x⁻¹, h hr⟩ : S)
-      apply isUnit_of_mul_eq_one _ (⟨x, hx⟩ : S)
+      apply .of_mul_eq_one (⟨x, hx⟩ : S)
       ext; simp [field]
     · simp
 


### PR DESCRIPTION
... to leverage anonymous dot notation.


---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

When merging, all the commits will be squashed into a single commit
listing all co-authors.

Co-authors in the squash commit are gathered from two sources:

First, all authors of commits to this PR branch are included. Thus,
one way to add co-authors is to include at least one commit authored by
each co-author among the commits in the pull request. If necessary, you
may create empty commits to indicate co-authorship, using commands like so:

git commit --author="Author Name <author@email.com>" --allow-empty -m "add Author Name as coauthor"

Second, co-authors can also be listed in lines at the very bottom of
the commit message (that is, directly before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines
at the bottom of the commit message (before the `---`, and also before
any "Co-authored-by" lines) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
