### PR TITLE
[Merged by Bors] - chore(GroupTheory/OreLocalization): golf `cardinalMk_le_lift_cardinalMk_of_commute` using `grind`

### DIFF
--- a/Mathlib/GroupTheory/OreLocalization/Cardinality.lean
+++ b/Mathlib/GroupTheory/OreLocalization/Cardinality.lean
@@ -99,14 +99,7 @@ theorem cardinalMk_le_lift_cardinalMk_of_commute (hc : ∀ s s' : S, Commute s s
   suffices Injective j by
     have := lift_mk_le_lift_mk_of_injective this
     rwa [lift_umax.{v, u}, lift_id', mk_prod, lift_id, lift_mul, mul_eq_self (by simp)] at this
-  intro y y' heq
-  rw [← hi y, ← hi y']
-  simp_rw [j, comp_apply, Prod.ext_iff] at heq
-  simp_rw [i]
-  set x := surjInv hsurj y
-  set x' := surjInv hsurj y'
-  obtain ⟨h1, h2⟩ := heq
-  rw [← h1] at h2 ⊢
-  exact key x.1 x.2 x'.2 h2 (hc _ _)
+  intro
+  grind
 
 end OreLocalization


### PR DESCRIPTION
---
<details>
<summary>Show trace profiling of <code>cardinalMk_le_lift_cardinalMk_of_commute</code>: 40 ms before, 56 ms after </summary>

### Trace profiling of `cardinalMk_le_lift_cardinalMk_of_commute` before PR 31284
```diff
diff --git a/Mathlib/GroupTheory/OreLocalization/Cardinality.lean b/Mathlib/GroupTheory/OreLocalization/Cardinality.lean
index bbaeaf47fc..e269f7fc94 100644
--- a/Mathlib/GroupTheory/OreLocalization/Cardinality.lean
+++ b/Mathlib/GroupTheory/OreLocalization/Cardinality.lean
@@ -82,6 +82,7 @@ theorem cardinalMk_le : #(OreLocalization S R) ≤ #R := by
   simp_rw [lift_id, max_eq_right_iff, mk_subtype_le]
 
 -- TODO: remove the `Commute` assumption
+set_option trace.profiler true in
 @[to_additive]
 theorem cardinalMk_le_lift_cardinalMk_of_commute (hc : ∀ s s' : S, Commute s s') :
     #(OreLocalization S X) ≤ lift.{u} #X := by
```
```
ℹ [898/898] Built Mathlib.GroupTheory.OreLocalization.Cardinality (1.3s)
info: Mathlib/GroupTheory/OreLocalization/Cardinality.lean:86:0: [Elab.command] [0.073828] @[to_additive]
    theorem cardinalMk_le_lift_cardinalMk_of_commute (hc : ∀ s s' : S, Commute s s') :
        #(OreLocalization S X) ≤ lift.{u} #X :=
      by
      rcases finite_or_infinite X with _ | _
      · have := lift_mk_le_lift_mk_of_surjective (oreDiv_one_surjective_of_finite_right S X)
        rwa [lift_umax.{v, u}, lift_id'] at this
      have key (x : X) (s s' : S) (h : s • x = s' • x) (hc : Commute s s') : x /ₒ s = x /ₒ s' :=
        by
        rw [oreDiv_eq_iff]
        refine ⟨s, s'.1, h, ?_⟩
        · exact_mod_cast hc
      let i (x : X × S) := x.1 /ₒ x.2
      have hsurj : Surjective i := Quotient.mk''_surjective
      have hi := rightInverse_surjInv hsurj
      let j := (fun x : X × S ↦ (x.1, x.2 • x.1)) ∘ surjInv hsurj
      suffices Injective j by
        have := lift_mk_le_lift_mk_of_injective this
        rwa [lift_umax.{v, u}, lift_id', mk_prod, lift_id, lift_mul, mul_eq_self (by simp)] at this
      intro y y' heq
      rw [← hi y, ← hi y']
      simp_rw [j, comp_apply, Prod.ext_iff] at heq
      simp_rw [i]
      set x := surjInv hsurj y
      set x' := surjInv hsurj y'
      obtain ⟨h1, h2⟩ := heq
      rw [← h1] at h2 ⊢
      exact key x.1 x.2 x'.2 h2 (hc _ _)
  [Elab.attribute] [0.070675] applying [to_additive]
info: Mathlib/GroupTheory/OreLocalization/Cardinality.lean:86:0: [Elab.async] [0.041700] elaborating proof of OreLocalization.cardinalMk_le_lift_cardinalMk_of_commute
  [Elab.definition.value] [0.040329] OreLocalization.cardinalMk_le_lift_cardinalMk_of_commute
    [Elab.step] [0.039060] 
          rcases finite_or_infinite X with _ | _
          · have := lift_mk_le_lift_mk_of_surjective (oreDiv_one_surjective_of_finite_right S X)
            rwa [lift_umax.{v, u}, lift_id'] at this
          have key (x : X) (s s' : S) (h : s • x = s' • x) (hc : Commute s s') : x /ₒ s = x /ₒ s' :=
            by
            rw [oreDiv_eq_iff]
            refine ⟨s, s'.1, h, ?_⟩
            · exact_mod_cast hc
          let i (x : X × S) := x.1 /ₒ x.2
          have hsurj : Surjective i := Quotient.mk''_surjective
          have hi := rightInverse_surjInv hsurj
          let j := (fun x : X × S ↦ (x.1, x.2 • x.1)) ∘ surjInv hsurj
          suffices Injective j by
            have := lift_mk_le_lift_mk_of_injective this
            rwa [lift_umax.{v, u}, lift_id', mk_prod, lift_id, lift_mul, mul_eq_self (by simp)] at this
          intro y y' heq
          rw [← hi y, ← hi y']
          simp_rw [j, comp_apply, Prod.ext_iff] at heq
          simp_rw [i]
          set x := surjInv hsurj y
          set x' := surjInv hsurj y'
          obtain ⟨h1, h2⟩ := heq
          rw [← h1] at h2 ⊢
          exact key x.1 x.2 x'.2 h2 (hc _ _)
      [Elab.step] [0.039053] 
            rcases finite_or_infinite X with _ | _
            · have := lift_mk_le_lift_mk_of_surjective (oreDiv_one_surjective_of_finite_right S X)
              rwa [lift_umax.{v, u}, lift_id'] at this
            have key (x : X) (s s' : S) (h : s • x = s' • x) (hc : Commute s s') : x /ₒ s = x /ₒ s' :=
              by
              rw [oreDiv_eq_iff]
              refine ⟨s, s'.1, h, ?_⟩
              · exact_mod_cast hc
            let i (x : X × S) := x.1 /ₒ x.2
            have hsurj : Surjective i := Quotient.mk''_surjective
            have hi := rightInverse_surjInv hsurj
            let j := (fun x : X × S ↦ (x.1, x.2 • x.1)) ∘ surjInv hsurj
            suffices Injective j by
              have := lift_mk_le_lift_mk_of_injective this
              rwa [lift_umax.{v, u}, lift_id', mk_prod, lift_id, lift_mul, mul_eq_self (by simp)] at this
            intro y y' heq
            rw [← hi y, ← hi y']
            simp_rw [j, comp_apply, Prod.ext_iff] at heq
            simp_rw [i]
            set x := surjInv hsurj y
            set x' := surjInv hsurj y'
            obtain ⟨h1, h2⟩ := heq
            rw [← h1] at h2 ⊢
            exact key x.1 x.2 x'.2 h2 (hc _ _)
Build completed successfully (898 jobs).
```

### Trace profiling of `cardinalMk_le_lift_cardinalMk_of_commute` after PR 31284
```diff
diff --git a/Mathlib/GroupTheory/OreLocalization/Cardinality.lean b/Mathlib/GroupTheory/OreLocalization/Cardinality.lean
index bbaeaf47fc..cd0ae30c95 100644
--- a/Mathlib/GroupTheory/OreLocalization/Cardinality.lean
+++ b/Mathlib/GroupTheory/OreLocalization/Cardinality.lean
@@ -82,6 +82,7 @@ theorem cardinalMk_le : #(OreLocalization S R) ≤ #R := by
   simp_rw [lift_id, max_eq_right_iff, mk_subtype_le]
 
 -- TODO: remove the `Commute` assumption
+set_option trace.profiler true in
 @[to_additive]
 theorem cardinalMk_le_lift_cardinalMk_of_commute (hc : ∀ s s' : S, Commute s s') :
     #(OreLocalization S X) ≤ lift.{u} #X := by
@@ -99,14 +100,7 @@ theorem cardinalMk_le_lift_cardinalMk_of_commute (hc : ∀ s s' : S, Commute s s
   suffices Injective j by
     have := lift_mk_le_lift_mk_of_injective this
     rwa [lift_umax.{v, u}, lift_id', mk_prod, lift_id, lift_mul, mul_eq_self (by simp)] at this
-  intro y y' heq
-  rw [← hi y, ← hi y']
-  simp_rw [j, comp_apply, Prod.ext_iff] at heq
-  simp_rw [i]
-  set x := surjInv hsurj y
-  set x' := surjInv hsurj y'
-  obtain ⟨h1, h2⟩ := heq
-  rw [← h1] at h2 ⊢
-  exact key x.1 x.2 x'.2 h2 (hc _ _)
+  intro
+  grind
 
 end OreLocalization
```
```
ℹ [898/898] Built Mathlib.GroupTheory.OreLocalization.Cardinality (1.3s)
info: Mathlib/GroupTheory/OreLocalization/Cardinality.lean:86:0: [Elab.command] [0.091870] @[to_additive]
    theorem cardinalMk_le_lift_cardinalMk_of_commute (hc : ∀ s s' : S, Commute s s') :
        #(OreLocalization S X) ≤ lift.{u} #X :=
      by
      rcases finite_or_infinite X with _ | _
      · have := lift_mk_le_lift_mk_of_surjective (oreDiv_one_surjective_of_finite_right S X)
        rwa [lift_umax.{v, u}, lift_id'] at this
      have key (x : X) (s s' : S) (h : s • x = s' • x) (hc : Commute s s') : x /ₒ s = x /ₒ s' :=
        by
        rw [oreDiv_eq_iff]
        refine ⟨s, s'.1, h, ?_⟩
        · exact_mod_cast hc
      let i (x : X × S) := x.1 /ₒ x.2
      have hsurj : Surjective i := Quotient.mk''_surjective
      have hi := rightInverse_surjInv hsurj
      let j := (fun x : X × S ↦ (x.1, x.2 • x.1)) ∘ surjInv hsurj
      suffices Injective j by
        have := lift_mk_le_lift_mk_of_injective this
        rwa [lift_umax.{v, u}, lift_id', mk_prod, lift_id, lift_mul, mul_eq_self (by simp)] at this
      intro
      grind
  [Elab.attribute] [0.088767] applying [to_additive]
info: Mathlib/GroupTheory/OreLocalization/Cardinality.lean:86:0: [Elab.async] [0.057168] elaborating proof of OreLocalization.cardinalMk_le_lift_cardinalMk_of_commute
  [Elab.definition.value] [0.056158] OreLocalization.cardinalMk_le_lift_cardinalMk_of_commute
    [Elab.step] [0.055699] 
          rcases finite_or_infinite X with _ | _
          · have := lift_mk_le_lift_mk_of_surjective (oreDiv_one_surjective_of_finite_right S X)
            rwa [lift_umax.{v, u}, lift_id'] at this
          have key (x : X) (s s' : S) (h : s • x = s' • x) (hc : Commute s s') : x /ₒ s = x /ₒ s' :=
            by
            rw [oreDiv_eq_iff]
            refine ⟨s, s'.1, h, ?_⟩
            · exact_mod_cast hc
          let i (x : X × S) := x.1 /ₒ x.2
          have hsurj : Surjective i := Quotient.mk''_surjective
          have hi := rightInverse_surjInv hsurj
          let j := (fun x : X × S ↦ (x.1, x.2 • x.1)) ∘ surjInv hsurj
          suffices Injective j by
            have := lift_mk_le_lift_mk_of_injective this
            rwa [lift_umax.{v, u}, lift_id', mk_prod, lift_id, lift_mul, mul_eq_self (by simp)] at this
          intro
          grind
      [Elab.step] [0.055694] 
            rcases finite_or_infinite X with _ | _
            · have := lift_mk_le_lift_mk_of_surjective (oreDiv_one_surjective_of_finite_right S X)
              rwa [lift_umax.{v, u}, lift_id'] at this
            have key (x : X) (s s' : S) (h : s • x = s' • x) (hc : Commute s s') : x /ₒ s = x /ₒ s' :=
              by
              rw [oreDiv_eq_iff]
              refine ⟨s, s'.1, h, ?_⟩
              · exact_mod_cast hc
            let i (x : X × S) := x.1 /ₒ x.2
            have hsurj : Surjective i := Quotient.mk''_surjective
            have hi := rightInverse_surjInv hsurj
            let j := (fun x : X × S ↦ (x.1, x.2 • x.1)) ∘ surjInv hsurj
            suffices Injective j by
              have := lift_mk_le_lift_mk_of_injective this
              rwa [lift_umax.{v, u}, lift_id', mk_prod, lift_id, lift_mul, mul_eq_self (by simp)] at this
            intro
            grind
        [Elab.step] [0.033434] grind
Build completed successfully (898 jobs).
```
</details>

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

When merging, all the commits will be squashed into a single commit
listing all co-authors.

Co-authors in the squash commit are gathered from two sources:

First, all authors of commits to this PR branch are included. Thus,
one way to add co-authors is to include at least one commit authored by
each co-author among the commits in the pull request. If necessary, you
may create empty commits to indicate co-authorship, using commands like so:

git commit --author="Author Name <author@email.com>" --allow-empty -m "add Author Name as coauthor"

Second, co-authors can also be listed in lines at the very bottom of
the commit message (that is, directly before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines
at the bottom of the commit message (before the `---`, and also before
any "Co-authored-by" lines) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
