### PR TITLE
[Merged by Bors] - ci: make new contributor labeling work for users with a private profile

### DIFF
--- a/.github/workflows/label_new_contributor.yml
+++ b/.github/workflows/label_new_contributor.yml
@@ -27,35 +27,50 @@ jobs:
         uses: actions/github-script@ed597411d8f924073f98dfc5c65a23a2325f34cd # v8.0.0
         with:
           script: |
+            const MIN_MERGED = 5;
             const creator = context.payload.sender.login;
             const { owner, repo } = context.repo;
 
-            console.log(`Checking PRs for user: ${creator}`);
-            // Fetch closed PRs by this author using REST API
-            const prs = await github.rest.pulls.list({
-              owner,
-              repo,
-              state: 'closed',
-              creator,
-              per_page: 100
-            });
-            console.log(`Found ${prs.data.length} closed PRs`);
-            
-            // Filter to only PRs with "[Merged by Bors] -" in the title
-            const mergedByBorsPRs = prs.data.filter(pr => 
-              pr.title.startsWith('[Merged by Bors] -')
-            );
+            console.log(`Checking closed issues for user: ${creator}`);
+
+            let mergedByBorsPRs = [];
+            let totalIssuesChecked = 0;
+
+            // Paginate through issues, stopping when we have more than MIN_MERGED qualifying PRs
+            for await (const response of github.paginate.iterator(
+              github.rest.issues.listForRepo,
+              {
+                owner,
+                repo,
+                creator,
+                state: 'closed',
+                per_page: 100
+              }
+            )) {
+              totalIssuesChecked += response.data.length;
+
+              // Filter this page for PRs with "[Merged by Bors] -" in the title
+              const pageMatches = response.data.filter(item => 
+                item.pull_request && item.title.startsWith('[Merged by Bors] -')
+              );
+
+              mergedByBorsPRs.push(...pageMatches);
+
+              console.log(`Checked ${totalIssuesChecked} closed issues, found ${mergedByBorsPRs.length} PRs merged by Bors so far`);
+
+              // Stop early if we've found more than MIN_MERGED
+              if (mergedByBorsPRs.length > MIN_MERGED) {
+                console.log(`Found more than ${MIN_MERGED} PRs, stopping pagination early`);
+                break;
+              }
+            }
+
             const pullRequestCount = mergedByBorsPRs.length;
             console.log(`Found ${pullRequestCount} PRs merged by Bors`);
 
-            // We could filter out bot users here, with:
-            // const isBot = (github.rest.users.getByUsername(creator).type === "Bot");
-            // But we choose to label PRs by new bot contributors as well.
-
-            // Determine if the creator has 5 or fewer merged pull requests
-            if (pullRequestCount <= 5) {
+            // Determine if the creator has MIN_MERGED or fewer merged pull requests
+            if (pullRequestCount <= MIN_MERGED) {
               console.log('Adding "new-contributor" label...');
-              // Add the "new-contributor" label to the current pull request
               await github.rest.issues.addLabels({
                 issue_number: context.issue.number,
                 owner,
@@ -64,8 +79,7 @@ jobs:
               });
             }
 
-            console.log('Creating check run...');
-            // Create a check run with a message about the PR count by this author
+            console.log('Creating check run with a message about the PR count by this author...');
             const message = `Found ${pullRequestCount} merged PRs by ${creator}.`;
             await github.rest.checks.create({
               owner,

--- a/.github/workflows/label_new_contributor.yml
+++ b/.github/workflows/label_new_contributor.yml
@@ -31,15 +31,15 @@ jobs:
             const { owner, repo } = context.repo;
 
             console.log(`Checking PRs for user: ${creator}`);
-            // Fetch PRs by this author using REST API
+            // Fetch closed PRs by this author using REST API
             const prs = await github.rest.pulls.list({
               owner,
               repo,
-              state: 'all',
+              state: 'closed',
               creator: creator,
               per_page: 100
             });
-            console.log(`Found ${prs.data.length} total PRs`);
+            console.log(`Found ${prs.data.length} closed PRs`);
             
             // Filter to only PRs with "[Merged by Bors] -" in the title
             const mergedByBorsPRs = prs.data.filter(pr => 

--- a/.github/workflows/label_new_contributor.yml
+++ b/.github/workflows/label_new_contributor.yml
@@ -27,17 +27,26 @@ jobs:
         uses: actions/github-script@ed597411d8f924073f98dfc5c65a23a2325f34cd # v8.0.0
         with:
           script: |
-            const creator = context.payload.sender.login
+            const creator = context.payload.sender.login;
             const { owner, repo } = context.repo;
 
-            // Use search API to find merged PRs by this author
-            // Note: mathlib4 uses bors for merging, which doesn't mark PRs as merged in GitHub's sense
-            // Instead, we search for the exact "[Merged by Bors] - " prefix that bors adds to PR titles
-            const searchQuery = `repo:${owner}/${repo}+is:pr+author:${creator}+in:title+"[Merged by Bors] -"`;
-            const searchResult = await github.rest.search.issuesAndPullRequests({
-              q: searchQuery
+            console.log(`Checking PRs for user: ${creator}`);
+            // Fetch PRs by this author using REST API
+            const prs = await github.rest.pulls.list({
+              owner,
+              repo,
+              state: 'all',
+              creator: creator,
+              per_page: 100
             });
-            const pullRequestCount = searchResult.data.total_count;
+            console.log(`Found ${prs.data.length} total PRs`);
+            
+            // Filter to only PRs with "[Merged by Bors] -" in the title
+            const mergedByBorsPRs = prs.data.filter(pr => 
+              pr.title.startsWith('[Merged by Bors] -')
+            );
+            const pullRequestCount = mergedByBorsPRs.length;
+            console.log(`Found ${pullRequestCount} PRs merged by Bors`);
 
             // We could filter out bot users here, with:
             // const isBot = (github.rest.users.getByUsername(creator).type === "Bot");
@@ -45,6 +54,7 @@ jobs:
 
             // Determine if the creator has 5 or fewer merged pull requests
             if (pullRequestCount <= 5) {
+              console.log('Adding "new-contributor" label...');
               // Add the "new-contributor" label to the current pull request
               await github.rest.issues.addLabels({
                 issue_number: context.issue.number,
@@ -54,7 +64,8 @@ jobs:
               });
             }
 
-            // Create a check run with a message about the merged PR count by this author
+            console.log('Creating check run...');
+            // Create a check run with a message about the PR count by this author
             const message = `Found ${pullRequestCount} merged PRs by ${creator}.`;
             await github.rest.checks.create({
               owner,

--- a/.github/workflows/label_new_contributor.yml
+++ b/.github/workflows/label_new_contributor.yml
@@ -36,7 +36,7 @@ jobs:
               owner,
               repo,
               state: 'closed',
-              creator: creator,
+              creator,
               per_page: 100
             });
             console.log(`Found ${prs.data.length} closed PRs`);


### PR DESCRIPTION
The search API we switched to in #30859 returns an error when we try to filter for users with a private profile ([example log](https://github.com/leanprover-community/mathlib4/actions/runs/19093647472/job/54548944242?pr=31272)). We switch to searching for closed issues in the repo, which was working before. We then filter these for closed PRs whose titles start with `[Merged by bors] -`.

We also include a slight optimization so that we don't have to page through all of a user's closed issues but stop when we find enough that count as merged PRs (>5 at the moment).

written with help from Claude

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

When merging, all the commits will be squashed into a single commit
listing all co-authors.

Co-authors in the squash commit are gathered from two sources:

First, all authors of commits to this PR branch are included. Thus,
one way to add co-authors is to include at least one commit authored by
each co-author among the commits in the pull request. If necessary, you
may create empty commits to indicate co-authorship, using commands like so:

git commit --author="Author Name <author@email.com>" --allow-empty -m "add Author Name as coauthor"

Second, co-authors can also be listed in lines at the very bottom of
the commit message (that is, directly before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines
at the bottom of the commit message (before the `---`, and also before
any "Co-authored-by" lines) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
