### PR TITLE
[Merged by Bors] - refactor(SetTheory/ZFC): deduplicate coercion to sets

### DIFF
--- a/Mathlib/SetTheory/ZFC/Basic.lean
+++ b/Mathlib/SetTheory/ZFC/Basic.lean
@@ -149,6 +149,7 @@ noncomputable def allZFSetDefinable {n} (F : (Fin n → ZFSet.{u}) → ZFSet.{u}
 end Classical
 
 namespace ZFSet
+variable {x y z : ZFSet.{u}}
 
 open PSet
 
@@ -173,26 +174,35 @@ instance : Membership ZFSet ZFSet where
 theorem mk_mem_iff {x y : PSet} : mk x ∈ mk y ↔ x ∈ y :=
   Iff.rfl
 
+@[ext] lemma ext : (∀ z : ZFSet.{u}, z ∈ x ↔ z ∈ y) → x = y :=
+  Quotient.inductionOn₂ x y fun _ _ h => Quotient.sound (Mem.ext fun w => h ⟦w⟧)
+
+instance : SetLike ZFSet.{u} ZFSet.{u} where
+  coe x := {y | y ∈ x}
+  coe_injective' x y hxy := by ext z; exact congr(z ∈ $hxy)
+
 /-- Convert a ZFC set into a `Set` of ZFC sets -/
+@[deprecated SetLike.coe (since := "2025-11-05")]
 def toSet (u : ZFSet.{u}) : Set ZFSet.{u} :=
   { x | x ∈ u }
 
-@[simp]
-theorem mem_toSet (a u : ZFSet.{u}) : a ∈ u.toSet ↔ a ∈ u :=
+@[deprecated SetLike.mem_coe (since := "2025-11-05")]
+theorem mem_toSet (a u : ZFSet.{u}) : a ∈ (u : Set ZFSet.{u}) ↔ a ∈ u :=
   Iff.rfl
 
-instance small_toSet (x : ZFSet.{u}) : Small.{u} x.toSet :=
+instance small_coe (x : ZFSet.{u}) : Small.{u} x :=
   Quotient.inductionOn x fun a => by
-    let f : a.Type → (mk a).toSet := fun i => ⟨mk <| a.Func i, func_mem a i⟩
+    let f (i : a.Type) : mk a := ⟨mk <| a.Func i, func_mem a i⟩
     suffices Function.Surjective f by exact small_of_surjective this
     rintro ⟨y, hb⟩
     induction y using Quotient.inductionOn
     obtain ⟨i, h⟩ := hb
     exact ⟨i, Subtype.coe_injective (Quotient.sound h.symm)⟩
 
+@[deprecated (since := "2025-11-05")] alias small_toSet := small_coe
+
 /-- A nonempty set is one that contains some element. -/
-protected def Nonempty (u : ZFSet) : Prop :=
-  u.toSet.Nonempty
+protected def Nonempty (u : ZFSet.{u}) : Prop := (u : Set ZFSet.{u}).Nonempty
 
 theorem nonempty_def (u : ZFSet) : u.Nonempty ↔ ∃ x, x ∈ u :=
   Iff.rfl
@@ -200,9 +210,9 @@ theorem nonempty_def (u : ZFSet) : u.Nonempty ↔ ∃ x, x ∈ u :=
 theorem nonempty_of_mem {x u : ZFSet} (h : x ∈ u) : u.Nonempty :=
   ⟨x, h⟩
 
-@[simp]
-theorem nonempty_toSet_iff {u : ZFSet} : u.toSet.Nonempty ↔ u.Nonempty :=
-  Iff.rfl
+@[simp, norm_cast] lemma nonempty_coe : (x : Set ZFSet.{u}).Nonempty ↔ x.Nonempty := .rfl
+
+@[deprecated (since := "2025-11-05")] alias nonempty_toSet := nonempty_coe
 
 /-- `x ⊆ y` as ZFC sets means that all members of `x` are members of `y`. -/
 protected def Subset (x y : ZFSet.{u}) :=
@@ -228,23 +238,18 @@ theorem subset_iff : ∀ {x y : PSet}, mk x ⊆ mk y ↔ x ⊆ y
         let ⟨b, ab⟩ := h a
         ⟨b, za.trans ab⟩⟩
 
-@[simp]
-theorem toSet_subset_iff {x y : ZFSet} : x.toSet ⊆ y.toSet ↔ x ⊆ y := by
+@[deprecated SetLike.coe_subset_coe (since := "2025-11-05")]
+theorem toSet_subset_iff {x y : ZFSet} : (x : Set ZFSet.{u}) ⊆ y ↔ x ⊆ y := by
   simp [subset_def, Set.subset_def]
 
-@[ext]
-theorem ext {x y : ZFSet.{u}} : (∀ z : ZFSet.{u}, z ∈ x ↔ z ∈ y) → x = y :=
-  Quotient.inductionOn₂ x y fun _ _ h => Quotient.sound (Mem.ext fun w => h ⟦w⟧)
+@[deprecated SetLike.coe_injective (since := "2025-11-05")]
+theorem toSet_injective : Function.Injective ((↑) : ZFSet.{u} → Set ZFSet.{u}) :=
+ SetLike.coe_injective
 
-theorem toSet_injective : Function.Injective toSet := fun _ _ h => ext <| Set.ext_iff.1 h
+@[simp, norm_cast]
+lemma coe_inj : (x : Set ZFSet.{u}) = y ↔ x = y := SetLike.coe_injective.eq_iff
 
-@[simp]
-theorem toSet_inj {x y : ZFSet} : x.toSet = y.toSet ↔ x = y :=
-  toSet_injective.eq_iff
-
-instance : SetLike ZFSet ZFSet where
-  coe := toSet
-  coe_injective' := toSet_injective
+@[deprecated (since := "2025-11-05")] alias toSet_inj := coe_inj
 
 instance : HasSSubset ZFSet := ⟨(· < ·)⟩
 
@@ -278,8 +283,9 @@ theorem notMem_empty (x) : x ∉ (∅ : ZFSet.{u}) :=
 
 @[deprecated (since := "2025-05-23")] alias not_mem_empty := notMem_empty
 
-@[simp]
-theorem toSet_empty : toSet ∅ = ∅ := by simp [toSet]
+@[simp, norm_cast] lemma coe_empty : ((∅ : ZFSet.{u}) : Set ZFSet.{u}) = ∅ := by ext; simp
+
+@[deprecated (since := "2025-11-05")] alias toSet_empty := coe_empty
 
 @[simp]
 theorem empty_subset (x : ZFSet.{u}) : (∅ : ZFSet) ⊆ x :=
@@ -338,19 +344,22 @@ theorem mem_insert (x y : ZFSet) : x ∈ insert x y :=
 theorem mem_insert_of_mem {y z : ZFSet} (x) (h : z ∈ y) : z ∈ insert x y :=
   mem_insert_iff.2 <| Or.inr h
 
-@[simp]
-theorem toSet_insert (x y : ZFSet) : (insert x y).toSet = insert x y.toSet := by
-  ext
-  simp
+@[simp, norm_cast]
+lemma coe_insert (x y : ZFSet) : (↑(insert x y) : Set ZFSet.{u}) = insert x ↑y := by ext; simp
+
+@[deprecated (since := "2025-11-05")] alias toSet_insert := coe_insert
 
 @[simp]
-theorem mem_singleton {x y : ZFSet.{u}} : x ∈ @singleton ZFSet.{u} ZFSet.{u} _ y ↔ x = y :=
+theorem mem_singleton {x y : ZFSet.{u}} : x ∈ ({y} : ZFSet.{u}) ↔ x = y :=
   Quotient.inductionOn₂ x y fun _ _ => PSet.mem_singleton.trans eq.symm
 
-@[simp]
-theorem toSet_singleton (x : ZFSet) : ({x} : ZFSet).toSet = {x} := by
-  ext
-  simp
+theorem notMem_singleton {x y : ZFSet.{u}} : x ∉ ({y} : ZFSet.{u}) ↔ x ≠ y :=
+  mem_singleton.not
+
+@[simp, norm_cast]
+lemma coe_singleton (x : ZFSet) : (({x} : ZFSet) : Set ZFSet) = {x} := by ext; simp
+
+@[deprecated (since := "2025-11-05")] alias toSet_singleton := coe_singleton
 
 theorem insert_nonempty (u v : ZFSet) : (insert u v).Nonempty :=
   ⟨u, mem_insert u v⟩
@@ -421,11 +430,15 @@ theorem mem_sep {p : ZFSet.{u} → Prop} {x y : ZFSet.{u}} :
 theorem sep_empty (p : ZFSet → Prop) : (∅ : ZFSet).sep p = ∅ :=
   (eq_empty _).mpr fun _ h ↦ notMem_empty _ (mem_sep.mp h).1
 
-@[simp]
-theorem toSet_sep (a : ZFSet) (p : ZFSet → Prop) :
-    (ZFSet.sep p a).toSet = { x ∈ a.toSet | p x } := by
+theorem sep_subset {x p} : ZFSet.sep p x ⊆ x :=
+  fun _ h => (mem_sep.1 h).1
+
+@[simp, norm_cast]
+lemma coe_sep (a : ZFSet) (p : ZFSet → Prop) : (ZFSet.sep p a : Set ZFSet) = {x ∈ a | p x} := by
   ext
   simp
+
+@[deprecated (since := "2025-11-05")] alias toSet_sep := coe_sep
 
 /-- The powerset operation, the collection of subsets of a ZFC set -/
 def powerset : ZFSet → ZFSet :=
@@ -523,14 +536,19 @@ theorem sUnion_singleton {x : ZFSet.{u}} : ⋃₀ ({x} : ZFSet) = x :=
 theorem sInter_singleton {x : ZFSet.{u}} : ⋂₀ ({x} : ZFSet) = x :=
   ext fun y => by simp_rw [mem_sInter (singleton_nonempty x), mem_singleton, forall_eq]
 
-@[simp]
-theorem toSet_sUnion (x : ZFSet.{u}) : (⋃₀ x).toSet = ⋃₀ (toSet '' x.toSet) := by
+@[simp, norm_cast]
+lemma coe_sUnion (x : ZFSet.{u}) : (⋃₀ x : Set ZFSet) = ⋃₀ (SetLike.coe '' (x : Set ZFSet)) := by
   ext
   simp
 
-theorem toSet_sInter {x : ZFSet.{u}} (h : x.Nonempty) : (⋂₀ x).toSet = ⋂₀ (toSet '' x.toSet) := by
+@[deprecated (since := "2025-11-05")] alias toSet_sUnion := coe_sUnion
+
+@[simp, norm_cast]
+lemma coe_sInter (h : x.Nonempty) : (⋂₀ x : Set ZFSet) = ⋂₀ (SetLike.coe '' (x : Set ZFSet)) := by
   ext
   simp [mem_sInter h]
+
+@[deprecated (since := "2025-11-05")] alias toSet_sInter := coe_sInter
 
 theorem singleton_injective : Function.Injective (@singleton ZFSet ZFSet _) := fun x y H => by
   let this := congr_arg sUnion H
@@ -561,39 +579,29 @@ instance : Inter ZFSet :=
 instance : SDiff ZFSet :=
   ⟨ZFSet.diff⟩
 
-@[simp]
-theorem toSet_union (x y : ZFSet.{u}) : (x ∪ y).toSet = x.toSet ∪ y.toSet := by
-  change (⋃₀ {x, y}).toSet = _
-  simp
+@[simp] lemma sUnion_pair (x y : ZFSet.{u}) : ⋃₀ ({x, y} : ZFSet.{u}) = x ∪ y := rfl
 
-@[simp]
-theorem toSet_inter (x y : ZFSet.{u}) : (x ∩ y).toSet = x.toSet ∩ y.toSet := by
-  change (ZFSet.sep (fun z => z ∈ y) x).toSet = _
-  ext
-  simp
+@[simp] lemma sep_mem (x y : ZFSet.{u}) : x.sep (· ∈ y) = x ∩ y := rfl
+@[simp] lemma sep_notMem (x y : ZFSet.{u}) : x.sep (· ∉ y) = x \ y := rfl
 
-@[simp]
-theorem toSet_sdiff (x y : ZFSet.{u}) : (x \ y).toSet = x.toSet \ y.toSet := by
-  change (ZFSet.sep (fun z => z ∉ y) x).toSet = _
-  ext
-  simp
+@[simp] lemma mem_union : z ∈ x ∪ y ↔ z ∈ x ∨ z ∈ y := by simp [← sUnion_pair]
+@[simp] lemma mem_inter : z ∈ x ∩ y ↔ z ∈ x ∧ z ∈ y := by simp [← sep_mem]
+@[simp] lemma mem_sdiff : z ∈ x \ y ↔ z ∈ x ∧ z ∉ y := by simp [← sep_notMem]
 
-@[simp]
-theorem mem_union {x y z : ZFSet.{u}} : z ∈ x ∪ y ↔ z ∈ x ∨ z ∈ y := by
-  rw [← mem_toSet]
-  simp
+@[simp, norm_cast]
+lemma coe_union (x y : ZFSet.{u}) : (↑(x ∪ y) : Set ZFSet) = ↑x ∪ ↑y := by ext; simp
 
-@[simp]
-theorem mem_inter {x y z : ZFSet.{u}} : z ∈ x ∩ y ↔ z ∈ x ∧ z ∈ y :=
-  @mem_sep (fun z : ZFSet.{u} => z ∈ y) x z
+@[deprecated (since := "2025-11-05")] alias toSet_union := coe_union
 
-@[simp]
-theorem mem_diff {x y z : ZFSet.{u}} : z ∈ x \ y ↔ z ∈ x ∧ z ∉ y :=
-  @mem_sep (fun z : ZFSet.{u} => z ∉ y) x z
+@[simp, norm_cast]
+lemma coe_inter (x y : ZFSet.{u}) : (↑(x ∩ y) : Set ZFSet) = ↑x ∩ ↑y := by ext; simp
 
-@[simp]
-theorem sUnion_pair {x y : ZFSet.{u}} : ⋃₀ ({x, y} : ZFSet.{u}) = x ∪ y :=
-  rfl
+@[deprecated (since := "2025-11-05")] alias toSet_inter := coe_inter
+
+@[simp, norm_cast]
+lemma coe_sdiff (x y : ZFSet.{u}) : (↑(x \ y) : Set ZFSet) = ↑x \ ↑y := by ext; simp
+
+@[deprecated (since := "2025-11-05")] alias toSet_sdiff := coe_sdiff
 
 theorem mem_wf : @WellFounded ZFSet (· ∈ ·) :=
   (wellFounded_lift₂_iff (H := fun a b c d hx hy =>
@@ -656,11 +664,11 @@ theorem mem_image {f : ZFSet.{u} → ZFSet.{u}} [Definable₁ f] {x y : ZFSet.{u
     ⟨fun ⟨a, ya⟩ => ⟨⟦A a⟧, Mem.mk A a, ((Quotient.sound ya).trans Definable₁.mk_out).symm⟩,
       fun ⟨_, hz, e⟩ => e ▸ image.mk _ _ hz⟩
 
-@[simp]
-theorem toSet_image (f : ZFSet → ZFSet) [Definable₁ f] (x : ZFSet) :
-    (image f x).toSet = f '' x.toSet := by
-  ext
-  simp
+@[simp, norm_cast]
+lemma coe_image (f : ZFSet → ZFSet) [Definable₁ f] (x : ZFSet) :
+    (image f x : Set ZFSet) = f '' x := by ext; simp
+
+@[deprecated (since := "2025-11-05")] alias toSet_image := coe_image
 
 section Small
 
@@ -671,7 +679,7 @@ noncomputable def range (f : α → ZFSet.{u}) : ZFSet.{u} :=
   ⟦⟨_, Quotient.out ∘ f ∘ (equivShrink α).symm⟩⟧
 
 @[simp]
-theorem mem_range {f : α → ZFSet.{u}} {x : ZFSet.{u}} : x ∈ range f ↔ x ∈ Set.range f :=
+theorem mem_range {f : α → ZFSet.{u}} {x : ZFSet.{u}} : x ∈ range f ↔ ∃ i, f i = x :=
   Quotient.inductionOn x fun y => by
     constructor
     · rintro ⟨z, hz⟩
@@ -680,10 +688,10 @@ theorem mem_range {f : α → ZFSet.{u}} {x : ZFSet.{u}} : x ∈ range f ↔ x �
       use equivShrink α z
       simpa [hz] using PSet.Equiv.symm (Quotient.mk_out y)
 
-@[simp]
-theorem toSet_range (f : α → ZFSet.{u}) : (range f).toSet = Set.range f := by
-  ext
-  simp
+@[simp, norm_cast]
+lemma coe_range (f : α → ZFSet.{u}) : (range f : Set ZFSet) = .range f := by ext; simp
+
+@[deprecated (since := "2025-11-05")] alias toSet_range := coe_range
 
 theorem mem_range_self {f : α → ZFSet.{u}} (a : α) : f a ∈ range f := by simp
 
@@ -697,10 +705,12 @@ noncomputable def iUnion (f : α → ZFSet.{u}) : ZFSet.{u} :=
 theorem mem_iUnion {f : α → ZFSet.{u}} {x : ZFSet.{u}} : x ∈ ⋃ i, f i ↔ ∃ i, x ∈ f i := by
   simp [iUnion]
 
-@[simp]
-theorem toSet_iUnion (f : α → ZFSet.{u}) : (⋃ i, f i).toSet = ⋃ i, (f i).toSet := by
+@[simp, norm_cast]
+lemma coe_iUnion (f : α → ZFSet.{u}) : (↑(⋃ i, f i) : Set ZFSet) = ⋃ i, (f i : Set ZFSet) := by
   ext
   simp
+
+@[deprecated (since := "2025-11-05")] alias toSet_iUnion := coe_iUnion
 
 theorem subset_iUnion (f : α → ZFSet.{u}) (i : α) : f i ⊆ ⋃ i, f i := by
   intro x hx
@@ -712,8 +722,10 @@ end Small
 def pair (x y : ZFSet.{u}) : ZFSet.{u} :=
   {{x}, {x, y}}
 
-@[simp]
-theorem toSet_pair (x y : ZFSet.{u}) : (pair x y).toSet = {{x}, {x, y}} := by simp [pair]
+@[simp, norm_cast]
+lemma coe_pair (x y : ZFSet.{u}) : (pair x y : Set ZFSet) = {{x}, {x, y}} := by simp [pair]
+
+@[deprecated (since := "2025-11-05")] alias toSet_pair := coe_pair
 
 /-- A subset of pairs `{(a, b) ∈ x × y | p a b}` -/
 def pairSep (p : ZFSet.{u} → ZFSet.{u} → Prop) (x y : ZFSet.{u}) : ZFSet.{u} :=

--- a/Mathlib/SetTheory/ZFC/Basic.lean
+++ b/Mathlib/SetTheory/ZFC/Basic.lean
@@ -246,10 +246,8 @@ theorem toSet_subset_iff {x y : ZFSet} : (x : Set ZFSet.{u}) ⊆ y ↔ x ⊆ y :
 theorem toSet_injective : Function.Injective ((↑) : ZFSet.{u} → Set ZFSet.{u}) :=
  SetLike.coe_injective
 
-@[simp, norm_cast]
-lemma coe_inj : (x : Set ZFSet.{u}) = y ↔ x = y := SetLike.coe_injective.eq_iff
-
-@[deprecated (since := "2025-11-05")] alias toSet_inj := coe_inj
+@[deprecated SetLike.coe_set_eq (since := "2025-11-05")]
+lemma toSet_inj : (x : Set ZFSet.{u}) = y ↔ x = y := SetLike.coe_set_eq
 
 instance : HasSSubset ZFSet := ⟨(· < ·)⟩
 

--- a/Mathlib/SetTheory/ZFC/Basic.lean
+++ b/Mathlib/SetTheory/ZFC/Basic.lean
@@ -336,7 +336,7 @@ theorem mem_insert_of_mem {y z : ZFSet} (x) (h : z ∈ y) : z ∈ insert x y :=
   mem_insert_iff.2 <| Or.inr h
 
 @[simp, norm_cast]
-lemma coe_insert (x y : ZFSet) : (↑(insert x y) : Set ZFSet.{u}) = insert x ↑y := by ext; simp
+lemma coe_insert (x y : ZFSet) : ↑(insert x y) = (insert x ↑y : Set ZFSet) := by ext; simp
 
 @[deprecated (since := "2025-11-05")] alias toSet_insert := coe_insert
 
@@ -582,17 +582,17 @@ instance : SDiff ZFSet :=
 @[deprecated (since := "2025-11-06")] alias mem_diff := mem_sdiff
 
 @[simp, norm_cast]
-lemma coe_union (x y : ZFSet.{u}) : (↑(x ∪ y) : Set ZFSet) = ↑x ∪ ↑y := by ext; simp
+lemma coe_union (x y : ZFSet.{u}) : ↑(x ∪ y) = (↑x ∪ ↑y : Set ZFSet) := by ext; simp
 
 @[deprecated (since := "2025-11-05")] alias toSet_union := coe_union
 
 @[simp, norm_cast]
-lemma coe_inter (x y : ZFSet.{u}) : (↑(x ∩ y) : Set ZFSet) = ↑x ∩ ↑y := by ext; simp
+lemma coe_inter (x y : ZFSet.{u}) : ↑(x ∩ y) = (↑x ∩ ↑y : Set ZFSet) := by ext; simp
 
 @[deprecated (since := "2025-11-05")] alias toSet_inter := coe_inter
 
 @[simp, norm_cast]
-lemma coe_sdiff (x y : ZFSet.{u}) : (↑(x \ y) : Set ZFSet) = ↑x \ ↑y := by ext; simp
+lemma coe_sdiff (x y : ZFSet.{u}) : ↑(x \ y) = (↑x \ ↑y : Set ZFSet) := by ext; simp
 
 @[deprecated (since := "2025-11-05")] alias toSet_sdiff := coe_sdiff
 
@@ -699,7 +699,7 @@ theorem mem_iUnion {f : α → ZFSet.{u}} {x : ZFSet.{u}} : x ∈ ⋃ i, f i ↔
   simp [iUnion]
 
 @[simp, norm_cast]
-lemma coe_iUnion (f : α → ZFSet.{u}) : (↑(⋃ i, f i) : Set ZFSet) = ⋃ i, (f i : Set ZFSet) := by
+lemma coe_iUnion (f : α → ZFSet.{u}) : ↑(⋃ i, f i) = ⋃ i, (f i : Set ZFSet) := by
   ext
   simp
 

--- a/Mathlib/SetTheory/ZFC/Basic.lean
+++ b/Mathlib/SetTheory/ZFC/Basic.lean
@@ -218,7 +218,7 @@ theorem nonempty_of_mem {x u : ZFSet} (h : x ∈ u) : u.Nonempty :=
 protected def Subset (x y : ZFSet.{u}) :=
   ∀ ⦃z⦄, z ∈ x → z ∈ y
 
-instance hasSubset : HasSubset ZFSet := ⟨ZFSet.Subset⟩
+instance : HasSubset ZFSet := ⟨ZFSet.Subset⟩
 instance : HasSSubset ZFSet := ⟨(· < ·)⟩
 
 @[simp] lemma le_def : x ≤ y ↔ x ⊆ y := .rfl
@@ -578,6 +578,8 @@ instance : SDiff ZFSet :=
 @[simp] lemma mem_union : z ∈ x ∪ y ↔ z ∈ x ∨ z ∈ y := by simp [← sUnion_pair]
 @[simp] lemma mem_inter : z ∈ x ∩ y ↔ z ∈ x ∧ z ∈ y := by simp [← sep_mem]
 @[simp] lemma mem_sdiff : z ∈ x \ y ↔ z ∈ x ∧ z ∉ y := by simp [← sep_notMem]
+
+@[deprecated (since := "2025-11-06")] alias mem_diff := mem_sdiff
 
 @[simp, norm_cast]
 lemma coe_union (x y : ZFSet.{u}) : (↑(x ∪ y) : Set ZFSet) = ↑x ∪ ↑y := by ext; simp

--- a/Mathlib/SetTheory/ZFC/Basic.lean
+++ b/Mathlib/SetTheory/ZFC/Basic.lean
@@ -212,14 +212,17 @@ theorem nonempty_of_mem {x u : ZFSet} (h : x ∈ u) : u.Nonempty :=
 
 @[simp, norm_cast] lemma nonempty_coe : (x : Set ZFSet.{u}).Nonempty ↔ x.Nonempty := .rfl
 
-@[deprecated (since := "2025-11-05")] alias nonempty_toSet := nonempty_coe
+@[deprecated (since := "2025-11-05")] alias nonempty_toSet_iff := nonempty_coe
 
 /-- `x ⊆ y` as ZFC sets means that all members of `x` are members of `y`. -/
 protected def Subset (x y : ZFSet.{u}) :=
   ∀ ⦃z⦄, z ∈ x → z ∈ y
 
-instance hasSubset : HasSubset ZFSet :=
-  ⟨ZFSet.Subset⟩
+instance hasSubset : HasSubset ZFSet := ⟨ZFSet.Subset⟩
+instance : HasSSubset ZFSet := ⟨(· < ·)⟩
+
+@[simp] lemma le_def : x ≤ y ↔ x ⊆ y := .rfl
+@[simp] lemma lt_def : x < y ↔ x ⊂ y := .rfl
 
 theorem subset_def {x y : ZFSet.{u}} : x ⊆ y ↔ ∀ ⦃z⦄, z ∈ x → z ∈ y :=
   Iff.rfl
@@ -238,26 +241,16 @@ theorem subset_iff : ∀ {x y : PSet}, mk x ⊆ mk y ↔ x ⊆ y
         let ⟨b, ab⟩ := h a
         ⟨b, za.trans ab⟩⟩
 
-@[deprecated SetLike.coe_subset_coe (since := "2025-11-05")]
-theorem toSet_subset_iff {x y : ZFSet} : (x : Set ZFSet.{u}) ⊆ y ↔ x ⊆ y := by
-  simp [subset_def, Set.subset_def]
+lemma coe_subset_coe : (x : Set ZFSet.{u}) ⊆ y ↔ x ⊆ y := by simp
+
+@[deprecated (since := "2025-11-05")] alias toSet_subset_iff := coe_subset_coe
 
 @[deprecated SetLike.coe_injective (since := "2025-11-05")]
 theorem toSet_injective : Function.Injective ((↑) : ZFSet.{u} → Set ZFSet.{u}) :=
- SetLike.coe_injective
+  SetLike.coe_injective
 
 @[deprecated SetLike.coe_set_eq (since := "2025-11-05")]
 lemma toSet_inj : (x : Set ZFSet.{u}) = y ↔ x = y := SetLike.coe_set_eq
-
-instance : HasSSubset ZFSet := ⟨(· < ·)⟩
-
-@[simp]
-theorem le_def (x y : ZFSet) : x ≤ y ↔ x ⊆ y :=
-  Iff.rfl
-
-@[simp]
-theorem lt_def (x y : ZFSet) : x < y ↔ x ⊂ y :=
-  Iff.rfl
 
 instance : IsAntisymm ZFSet (· ⊆ ·) :=
   ⟨@le_antisymm ZFSet _⟩

--- a/Mathlib/SetTheory/ZFC/Class.lean
+++ b/Mathlib/SetTheory/ZFC/Class.lean
@@ -205,7 +205,7 @@ theorem coe_inter (x y : ZFSet.{u}) : ↑(x ∩ y) = (x : Class.{u}) ∩ y :=
 
 @[simp, norm_cast]
 theorem coe_diff (x y : ZFSet.{u}) : ↑(x \ y) = (x : Class.{u}) \ y :=
-  ext fun _ => ZFSet.mem_diff
+  ext fun _ => ZFSet.mem_sdiff
 
 @[simp, norm_cast]
 theorem coe_powerset (x : ZFSet.{u}) : ↑x.powerset = powerset.{u} x :=
@@ -344,24 +344,26 @@ theorem choice_mem (h : ∅ ∉ x) (y : ZFSet.{u}) (yx : y ∈ x) :
   rw [@map_fval _ (Classical.allZFSetDefinable _) x y yx, Class.coe_mem, Class.coe_apply]
   exact choice_mem_aux x h y yx
 
-private lemma toSet_equiv_aux {s : Set ZFSet.{u}} (hs : Small.{u} s) :
-    (mk <| PSet.mk (Shrink s) fun x ↦ ((equivShrink s).symm x).1.out).toSet = s := by
+private lemma coe_equiv_aux {s : Set ZFSet.{u}} (hs : Small.{u} s) :
+    (mk <| PSet.mk (Shrink s) fun x ↦ ((equivShrink s).symm x).1.out) = s := by
   ext x
-  rw [mem_toSet, ← mk_out x, mk_mem_iff, mk_out]
+  rw [SetLike.mem_coe, ← mk_out x, mk_mem_iff, mk_out]
   refine ⟨?_, fun xs ↦ ⟨equivShrink s (Subtype.mk x xs), ?_⟩⟩
   · rintro ⟨b, h2⟩
     rw [← ZFSet.eq, ZFSet.mk_out] at h2
     simp [h2]
   · simp [PSet.Equiv.refl]
 
-/-- `ZFSet.toSet` as an equivalence. -/
+/-- `SetLike.coe` as an equivalence. -/
 @[simps apply_coe]
-noncomputable def toSet_equiv : ZFSet.{u} ≃ {s : Set ZFSet.{u} // Small.{u, u+1} s} where
-  toFun x := ⟨x.toSet, x.small_toSet⟩
+noncomputable def coeEquiv : ZFSet.{u} ≃ {s : Set ZFSet.{u} // Small.{u, u+1} s} where
+  toFun x := ⟨x, x.small_coe⟩
   invFun := fun ⟨s, _⟩ ↦ mk <| PSet.mk (Shrink s) fun x ↦ ((equivShrink.{u, u + 1} s).symm x).1.out
   left_inv := Function.rightInverse_of_injective_of_leftInverse (by intro _ _; simp)
-    fun s ↦ Subtype.coe_injective <| toSet_equiv_aux s.2
-  right_inv s := Subtype.coe_injective <| toSet_equiv_aux s.2
+    fun s ↦ Subtype.coe_injective <| coe_equiv_aux s.2
+  right_inv s := Subtype.coe_injective <| coe_equiv_aux s.2
+
+@[deprecated (since := "2025-11-05")] alias toSet_equiv := coeEquiv
 
 /-- The **Burali-Forti paradox**: ordinals form a proper class. -/
 theorem isOrdinal_notMem_univ : IsOrdinal ∉ Class.univ.{u} := by

--- a/Mathlib/SetTheory/ZFC/Ordinal.lean
+++ b/Mathlib/SetTheory/ZFC/Ordinal.lean
@@ -157,8 +157,8 @@ theorem subset_iff_eq_or_mem (hx : x.IsOrdinal) (hy : y.IsOrdinal) : x ⊆ y ↔
     intro x y IH hx hy hxy
     by_cases hyx : y ⊆ x
     · exact Or.inl (subset_antisymm hxy hyx)
-    · obtain ⟨m, hm, hm'⟩ := mem_wf.has_min (y.toSet \ x.toSet) (Set.diff_nonempty.2 hyx)
-      have hmy : m ∈ y := show m ∈ y.toSet from Set.mem_of_mem_diff hm
+    · obtain ⟨m, hm, hm'⟩ := mem_wf.has_min (y \ x) (Set.diff_nonempty.2 hyx)
+      have hmy : m ∈ y := by simp only [Set.mem_diff, SetLike.mem_coe] at hm; exact hm.1
       have hmx : m ⊆ x := by
         intro z hzm
         by_contra hzx


### PR DESCRIPTION
Currently, we have both `ZFSet.toSet` and `SetLike.coe` to turn a `ZFSet` into a `Set ZFSet`. This is bad for simp normal form. This PR removes the first spelling in favor of the second one.


---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

When merging, all the commits will be squashed into a single commit
listing all co-authors.

Co-authors in the squash commit are gathered from two sources:

First, all authors of commits to this PR branch are included. Thus,
one way to add co-authors is to include at least one commit authored by
each co-author among the commits in the pull request. If necessary, you
may create empty commits to indicate co-authorship, using commands like so:

git commit --author="Author Name <author@email.com>" --allow-empty -m "add Author Name as coauthor"

Second, co-authors can also be listed in lines at the very bottom of
the commit message (that is, directly before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines
at the bottom of the commit message (before the `---`, and also before
any "Co-authored-by" lines) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
