### PR TITLE
[Merged by Bors] - chore(Order/Interval/Set/LinearOrder): golf interval lemmas using `grind`

### DIFF
--- a/Mathlib/Order/Interval/Set/Disjoint.lean
+++ b/Mathlib/Order/Interval/Set/Disjoint.lean
@@ -5,6 +5,7 @@ Authors: Floris van Doorn, Yury Kudryashov
 -/
 import Mathlib.Data.Set.Lattice.Image
 import Mathlib.Order.Interval.Set.LinearOrder
+import Mathlib.Order.MinMax
 
 /-!
 # Extra lemmas about intervals

--- a/Mathlib/Order/Interval/Set/LinearOrder.lean
+++ b/Mathlib/Order/Interval/Set/LinearOrder.lean
@@ -4,7 +4,6 @@ Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Johannes Hölzl, Mario Carneiro, Patrick Massot, Yury Kudryashov, Rémy Degenne
 -/
 import Mathlib.Order.Interval.Set.Basic
-import Mathlib.Order.MinMax
 
 /-!
 # Interval properties in linear orders
@@ -203,18 +202,10 @@ theorem Iio_union_Ioi : Iio a ∪ Ioi a = {a}ᶜ :=
 /-! ### A finite and an infinite interval -/
 
 theorem Ioo_union_Ioi' (h₁ : c < b) : Ioo a b ∪ Ioi c = Ioi (min a c) := by
-  ext1 x
-  simp_rw [mem_union, mem_Ioo, mem_Ioi, min_lt_iff]
-  by_cases hc : c < x
-  · tauto
-  · have hxb : x < b := (le_of_not_gt hc).trans_lt h₁
-    tauto
+  grind
 
 theorem Ioo_union_Ioi (h : c < max a b) : Ioo a b ∪ Ioi c = Ioi (min a c) := by
-  rcases le_total a b with hab | hab
-  · simp only [hab, sup_of_le_right] at h; exact Ioo_union_Ioi' h
-  · rw [min_comm]
-    simp_all [min_eq_left_of_lt]
+  grind
 
 theorem Ioi_subset_Ioo_union_Ici : Ioi a ⊆ Ioo a b ∪ Ici b := fun x hx =>
   (lt_or_ge x b).elim (fun hxb => Or.inl ⟨hx, hxb⟩) fun hxb => Or.inr hxb
@@ -231,17 +222,10 @@ theorem Ico_union_Ici_eq_Ici (h : a ≤ b) : Ico a b ∪ Ici b = Ici a :=
   Subset.antisymm (fun _ hx => hx.elim And.left h.trans) Ici_subset_Ico_union_Ici
 
 theorem Ico_union_Ici' (h₁ : c ≤ b) : Ico a b ∪ Ici c = Ici (min a c) := by
-  ext1 x
-  simp_rw [mem_union, mem_Ico, mem_Ici, min_le_iff]
-  by_cases hc : c ≤ x
-  · tauto
-  · have hxb : x < b := (lt_of_not_ge hc).trans_le h₁
-    tauto
+  grind
 
 theorem Ico_union_Ici (h : c ≤ max a b) : Ico a b ∪ Ici c = Ici (min a c) := by
-  rcases le_total a b with hab | hab
-  · simp only [hab, sup_of_le_right] at h; exact Ico_union_Ici' h
-  · simp_all
+  grind
 
 theorem Ioi_subset_Ioc_union_Ioi : Ioi a ⊆ Ioc a b ∪ Ioi b := fun x hx =>
   (le_or_gt x b).elim (fun hxb => Or.inl ⟨hx, hxb⟩) fun hxb => Or.inr hxb
@@ -251,17 +235,10 @@ theorem Ioc_union_Ioi_eq_Ioi (h : a ≤ b) : Ioc a b ∪ Ioi b = Ioi a :=
   Subset.antisymm (fun _ hx => hx.elim And.left h.trans_lt) Ioi_subset_Ioc_union_Ioi
 
 theorem Ioc_union_Ioi' (h₁ : c ≤ b) : Ioc a b ∪ Ioi c = Ioi (min a c) := by
-  ext1 x
-  simp_rw [mem_union, mem_Ioc, mem_Ioi, min_lt_iff]
-  by_cases hc : c < x
-  · tauto
-  · have hxb : x ≤ b := (le_of_not_gt hc).trans h₁
-    tauto
+  grind
 
 theorem Ioc_union_Ioi (h : c ≤ max a b) : Ioc a b ∪ Ioi c = Ioi (min a c) := by
-  rcases le_total a b with hab | hab
-  · simp only [hab, sup_of_le_right] at h; exact Ioc_union_Ioi' h
-  · simp_all
+  grind
 
 theorem Ici_subset_Icc_union_Ioi : Ici a ⊆ Icc a b ∪ Ioi b := fun x hx =>
   (le_or_gt x b).elim (fun hxb => Or.inl ⟨hx, hxb⟩) fun hxb => Or.inr hxb
@@ -286,20 +263,10 @@ theorem Icc_union_Ici_eq_Ici (h : a ≤ b) : Icc a b ∪ Ici b = Ici a :=
   Subset.antisymm (fun _ hx => hx.elim And.left h.trans) Ici_subset_Icc_union_Ici
 
 theorem Icc_union_Ici' (h₁ : c ≤ b) : Icc a b ∪ Ici c = Ici (min a c) := by
-  ext1 x
-  simp_rw [mem_union, mem_Icc, mem_Ici, min_le_iff]
-  by_cases hc : c ≤ x
-  · tauto
-  · have hxb : x ≤ b := (le_of_not_ge hc).trans h₁
-    tauto
+  grind
 
 theorem Icc_union_Ici (h : c ≤ max a b) : Icc a b ∪ Ici c = Ici (min a c) := by
-  rcases le_or_gt a b with hab | hab
-  · simp only [hab, sup_of_le_right] at h; exact Icc_union_Ici' h
-  · simp only [le_sup_iff] at h; rcases h with h | h
-    · simp [*]
-    · have hca : c ≤ a := h.trans hab.le
-      simp [*]
+  grind
 
 /-! ### An infinite and a finite interval -/
 
@@ -320,17 +287,10 @@ theorem Iio_union_Ico_eq_Iio (h : a ≤ b) : Iio a ∪ Ico a b = Iio b :=
     Iio_subset_Iio_union_Ico
 
 theorem Iio_union_Ico' (h₁ : c ≤ b) : Iio b ∪ Ico c d = Iio (max b d) := by
-  ext1 x
-  simp_rw [mem_union, mem_Iio, mem_Ico, lt_max_iff]
-  by_cases hc : c ≤ x
-  · tauto
-  · have hxb : x < b := (lt_of_not_ge hc).trans_le h₁
-    tauto
+  grind
 
 theorem Iio_union_Ico (h : min c d ≤ b) : Iio b ∪ Ico c d = Iio (max b d) := by
-  rcases le_total c d with hcd | hcd
-  · simp only [hcd, inf_of_le_left] at h; exact Iio_union_Ico' h
-  · simp_all
+  grind
 
 theorem Iic_subset_Iic_union_Ioc : Iic b ⊆ Iic a ∪ Ioc a b := fun x hx =>
   (le_or_gt x a).elim (fun hxa => Or.inl hxa) fun hxa => Or.inr ⟨hxa, hx⟩
@@ -341,18 +301,10 @@ theorem Iic_union_Ioc_eq_Iic (h : a ≤ b) : Iic a ∪ Ioc a b = Iic b :=
     Iic_subset_Iic_union_Ioc
 
 theorem Iic_union_Ioc' (h₁ : c < b) : Iic b ∪ Ioc c d = Iic (max b d) := by
-  ext1 x
-  simp_rw [mem_union, mem_Iic, mem_Ioc, le_max_iff]
-  by_cases hc : c < x
-  · tauto
-  · have hxb : x ≤ b := (le_of_not_gt hc).trans h₁.le
-    tauto
+  grind
 
 theorem Iic_union_Ioc (h : min c d < b) : Iic b ∪ Ioc c d = Iic (max b d) := by
-  rcases le_total c d with hcd | hcd
-  · simp only [hcd, inf_of_le_left] at h; exact Iic_union_Ioc' h
-  · rw [max_comm]
-    simp_all [max_eq_right_of_lt]
+  grind
 
 theorem Iio_subset_Iic_union_Ioo : Iio b ⊆ Iic a ∪ Ioo a b := fun x hx =>
   (le_or_gt x a).elim (fun hxa => Or.inl hxa) fun hxa => Or.inr ⟨hxa, hx⟩
@@ -363,18 +315,10 @@ theorem Iic_union_Ioo_eq_Iio (h : a < b) : Iic a ∪ Ioo a b = Iio b :=
     Iio_subset_Iic_union_Ioo
 
 theorem Iio_union_Ioo' (h₁ : c < b) : Iio b ∪ Ioo c d = Iio (max b d) := by
-  ext x
-  rcases lt_or_ge x b with hba | hba
-  · simp [hba]
-  · simp only [mem_Iio, mem_union, mem_Ioo, lt_max_iff]
-    refine or_congr Iff.rfl ⟨And.right, ?_⟩
-    exact fun h₂ => ⟨h₁.trans_le hba, h₂⟩
+  grind
 
 theorem Iio_union_Ioo (h : min c d < b) : Iio b ∪ Ioo c d = Iio (max b d) := by
-  rcases le_total c d with hcd | hcd
-  · simp only [hcd, inf_of_le_left] at h; exact Iio_union_Ioo' h
-  · rw [max_comm]
-    simp_all [max_eq_right_of_lt]
+  grind
 
 theorem Iic_subset_Iic_union_Icc : Iic b ⊆ Iic a ∪ Icc a b :=
   Subset.trans Iic_subset_Iic_union_Ioc (union_subset_union_right _ Ioc_subset_Icc_self)
@@ -385,20 +329,10 @@ theorem Iic_union_Icc_eq_Iic (h : a ≤ b) : Iic a ∪ Icc a b = Iic b :=
     Iic_subset_Iic_union_Icc
 
 theorem Iic_union_Icc' (h₁ : c ≤ b) : Iic b ∪ Icc c d = Iic (max b d) := by
-  ext1 x
-  simp_rw [mem_union, mem_Iic, mem_Icc, le_max_iff]
-  by_cases hc : c ≤ x
-  · tauto
-  · have hxb : x ≤ b := (le_of_not_ge hc).trans h₁
-    tauto
+  grind
 
 theorem Iic_union_Icc (h : min c d ≤ b) : Iic b ∪ Icc c d = Iic (max b d) := by
-  rcases le_or_gt c d with hcd | hcd
-  · simp only [hcd, inf_of_le_left] at h; exact Iic_union_Icc' h
-  · simp only [inf_le_iff] at h; rcases h with h | h
-    · have hdb : d ≤ b := hcd.le.trans h
-      simp [*]
-    · simp [*]
+  grind
 
 theorem Iio_subset_Iic_union_Ico : Iio b ⊆ Iic a ∪ Ico a b :=
   Subset.trans Iio_subset_Iic_union_Ioo (union_subset_union_right _ Ioo_subset_Ico_self)
@@ -429,21 +363,11 @@ theorem Ico_union_Ico_eq_Ico (h₁ : a ≤ b) (h₂ : b ≤ c) : Ico a b ∪ Ico
     Ico_subset_Ico_union_Ico
 
 theorem Ico_union_Ico' (h₁ : c ≤ b) (h₂ : a ≤ d) : Ico a b ∪ Ico c d = Ico (min a c) (max b d) := by
-  ext1 x
-  simp_rw [mem_union, mem_Ico, min_le_iff, lt_max_iff]
-  by_cases hc : c ≤ x <;> by_cases hd : x < d
-  · tauto
-  · have hax : a ≤ x := h₂.trans (le_of_not_gt hd)
-    tauto
-  · have hxb : x < b := (lt_of_not_ge hc).trans_le h₁
-    tauto
-  · tauto
+  grind
 
 theorem Ico_union_Ico (h₁ : min a b ≤ max c d) (h₂ : min c d ≤ max a b) :
     Ico a b ∪ Ico c d = Ico (min a c) (max b d) := by
-  rcases le_total a b with hab | hab <;> rcases le_total c d with hcd | hcd <;> simp [*] at h₁ h₂
-  · exact Ico_union_Ico' h₂ h₁
-  all_goals simp [*]
+  grind
 
 theorem Icc_subset_Ico_union_Icc : Icc a c ⊆ Ico a b ∪ Icc b c := fun x hx =>
   (lt_or_ge x b).elim (fun hxb => Or.inl ⟨hx.1, hxb⟩) fun hxb => Or.inr ⟨hxb, hx.2⟩
@@ -502,21 +426,11 @@ theorem Ioc_union_Ioc_eq_Ioc (h₁ : a ≤ b) (h₂ : b ≤ c) : Ioc a b ∪ Ioc
     Ioc_subset_Ioc_union_Ioc
 
 theorem Ioc_union_Ioc' (h₁ : c ≤ b) (h₂ : a ≤ d) : Ioc a b ∪ Ioc c d = Ioc (min a c) (max b d) := by
-  ext1 x
-  simp_rw [mem_union, mem_Ioc, min_lt_iff, le_max_iff]
-  by_cases hc : c < x <;> by_cases hd : x ≤ d
-  · tauto
-  · have hax : a < x := h₂.trans_lt (lt_of_not_ge hd)
-    tauto
-  · have hxb : x ≤ b := (le_of_not_gt hc).trans h₁
-    tauto
-  · tauto
+  grind
 
 theorem Ioc_union_Ioc (h₁ : min a b ≤ max c d) (h₂ : min c d ≤ max a b) :
     Ioc a b ∪ Ioc c d = Ioc (min a c) (max b d) := by
-  rcases le_total a b with hab | hab <;> rcases le_total c d with hcd | hcd <;> simp [*] at h₁ h₂
-  · exact Ioc_union_Ioc' h₂ h₁
-  all_goals simp [*]
+  grind
 
 /-! ### Two finite intervals with a common point -/
 
@@ -549,26 +463,14 @@ theorem Icc_union_Icc_eq_Icc (h₁ : a ≤ b) (h₂ : b ≤ c) : Icc a b ∪ Icc
     Icc_subset_Icc_union_Icc
 
 theorem Icc_union_Icc' (h₁ : c ≤ b) (h₂ : a ≤ d) : Icc a b ∪ Icc c d = Icc (min a c) (max b d) := by
-  ext1 x
-  simp_rw [mem_union, mem_Icc, min_le_iff, le_max_iff]
-  by_cases hc : c ≤ x <;> by_cases hd : x ≤ d
-  · tauto
-  · have hax : a ≤ x := h₂.trans (le_of_not_ge hd)
-    tauto
-  · have hxb : x ≤ b := (le_of_not_ge hc).trans h₁
-    tauto
-  · tauto
+  grind
 
 /-- We cannot replace `<` by `≤` in the hypotheses.
 Otherwise for `b < a = d < c` the l.h.s. is `∅` and the r.h.s. is `{a}`.
 -/
 theorem Icc_union_Icc (h₁ : min a b < max c d) (h₂ : min c d < max a b) :
     Icc a b ∪ Icc c d = Icc (min a c) (max b d) := by
-  rcases le_or_gt a b with hab | hab <;> rcases le_or_gt c d with hcd | hcd <;>
-    simp only [min_eq_left, max_eq_right,
-      min_eq_right_of_lt, max_eq_left_of_lt, hab, hcd] at h₁ h₂
-  · exact Icc_union_Icc' h₂.le h₁.le
-  all_goals simp [*, min_eq_left_of_lt, max_eq_left_of_lt, min_eq_right_of_lt, max_eq_right_of_lt]
+  grind
 
 theorem Ioc_subset_Ioc_union_Icc : Ioc a c ⊆ Ioc a b ∪ Icc b c :=
   Subset.trans Ioc_subset_Ioc_union_Ioc (union_subset_union_right _ Ioc_subset_Icc_self)
@@ -580,24 +482,11 @@ theorem Ioc_union_Icc_eq_Ioc (h₁ : a < b) (h₂ : b ≤ c) : Ioc a b ∪ Icc b
     Ioc_subset_Ioc_union_Icc
 
 theorem Ioo_union_Ioo' (h₁ : c < b) (h₂ : a < d) : Ioo a b ∪ Ioo c d = Ioo (min a c) (max b d) := by
-  ext1 x
-  simp_rw [mem_union, mem_Ioo, min_lt_iff, lt_max_iff]
-  by_cases hc : c < x <;> by_cases hd : x < d
-  · tauto
-  · have hax : a < x := h₂.trans_le (le_of_not_gt hd)
-    tauto
-  · have hxb : x < b := (le_of_not_gt hc).trans_lt h₁
-    tauto
-  · tauto
+  grind
 
 theorem Ioo_union_Ioo (h₁ : min a b < max c d) (h₂ : min c d < max a b) :
     Ioo a b ∪ Ioo c d = Ioo (min a c) (max b d) := by
-  rcases le_total a b with hab | hab <;> rcases le_total c d with hcd | hcd <;>
-    simp only [min_eq_left, min_eq_right, max_eq_left, max_eq_right, hab, hcd] at h₁ h₂
-  · exact Ioo_union_Ioo' h₂ h₁
-  all_goals
-    simp [*,
-      le_of_lt h₂, le_of_lt h₁]
+  grind
 
 theorem Ioo_subset_Ioo_union_Ioo (h₁ : a ≤ a₁) (h₂ : c < b) (h₃ : b₁ ≤ d) :
     Ioo a₁ b₁ ⊆ Ioo a b ∪ Ioo c d := fun x hx =>
@@ -615,95 +504,82 @@ theorem Iio_inter_Iio : Iio a ∩ Iio b = Iio (a ⊓ b) :=
   ext fun _ => lt_inf_iff.symm
 
 theorem Ico_inter_Ico : Ico a₁ b₁ ∩ Ico a₂ b₂ = Ico (a₁ ⊔ a₂) (b₁ ⊓ b₂) := by
-  simp only [Ici_inter_Iio.symm, Ici_inter_Ici.symm, Iio_inter_Iio.symm]; ac_rfl
+  grind
 
 theorem Ioc_inter_Ioc : Ioc a₁ b₁ ∩ Ioc a₂ b₂ = Ioc (a₁ ⊔ a₂) (b₁ ⊓ b₂) := by
-  simp only [Ioi_inter_Iic.symm, Ioi_inter_Ioi.symm, Iic_inter_Iic.symm]; ac_rfl
+  grind
 
 theorem Ioo_inter_Ioo : Ioo a₁ b₁ ∩ Ioo a₂ b₂ = Ioo (a₁ ⊔ a₂) (b₁ ⊓ b₂) := by
-  simp only [Ioi_inter_Iio.symm, Ioi_inter_Ioi.symm, Iio_inter_Iio.symm]; ac_rfl
+  grind
 
 theorem Ioo_inter_Iio : Ioo a b ∩ Iio c = Ioo a (min b c) := by
-  ext
-  simp_rw [mem_inter_iff, mem_Ioo, mem_Iio, lt_min_iff, and_assoc]
+  grind
 
 theorem Iio_inter_Ioo : Iio a ∩ Ioo b c = Ioo b (min a c) := by
-  rw [Set.inter_comm, Set.Ioo_inter_Iio, min_comm]
+  grind
 
 theorem Ioo_inter_Ioi : Ioo a b ∩ Ioi c = Ioo (max a c) b := by
-  ext
-  simp_rw [mem_inter_iff, mem_Ioo, mem_Ioi, max_lt_iff, and_assoc, and_comm]
+  grind
 
 theorem Ioi_inter_Ioo : Set.Ioi a ∩ Set.Ioo b c = Set.Ioo (max a b) c := by
-  rw [inter_comm, Ioo_inter_Ioi, max_comm]
+  grind
 
-theorem Ioc_inter_Ioo_of_left_lt (h : b₁ < b₂) : Ioc a₁ b₁ ∩ Ioo a₂ b₂ = Ioc (max a₁ a₂) b₁ :=
-  ext fun x => by
-    simp [and_assoc, @and_left_comm (x ≤ _), and_iff_left_iff_imp.2 fun h' => lt_of_le_of_lt h' h]
+theorem Ioc_inter_Ioo_of_left_lt (h : b₁ < b₂) : Ioc a₁ b₁ ∩ Ioo a₂ b₂ = Ioc (max a₁ a₂) b₁ := by
+  grind
 
-theorem Ioc_inter_Ioo_of_right_le (h : b₂ ≤ b₁) : Ioc a₁ b₁ ∩ Ioo a₂ b₂ = Ioo (max a₁ a₂) b₂ :=
-  ext fun x => by
-    simp [and_assoc, @and_left_comm (x ≤ _),
-      and_iff_right_iff_imp.2 fun h' => (le_of_lt h').trans h]
+theorem Ioc_inter_Ioo_of_right_le (h : b₂ ≤ b₁) : Ioc a₁ b₁ ∩ Ioo a₂ b₂ = Ioo (max a₁ a₂) b₂ := by
+  grind
 
 theorem Ioo_inter_Ioc_of_left_le (h : b₁ ≤ b₂) : Ioo a₁ b₁ ∩ Ioc a₂ b₂ = Ioo (max a₁ a₂) b₁ := by
-  rw [inter_comm, Ioc_inter_Ioo_of_right_le h, max_comm]
+  grind
 
 theorem Ioo_inter_Ioc_of_right_lt (h : b₂ < b₁) : Ioo a₁ b₁ ∩ Ioc a₂ b₂ = Ioc (max a₁ a₂) b₂ := by
-  rw [inter_comm, Ioc_inter_Ioo_of_left_lt h, max_comm]
+  grind
 
 @[simp]
 theorem Ico_diff_Iio : Ico a b \ Iio c = Ico (max a c) b := by
-  rw [diff_eq, compl_Iio, Ico_inter_Ici]
+  grind
 
 @[simp]
-theorem Ioc_diff_Ioi : Ioc a b \ Ioi c = Ioc a (min b c) :=
-  ext <| by simp +contextual [iff_def]
+theorem Ioc_diff_Ioi : Ioc a b \ Ioi c = Ioc a (min b c) := by
+  grind
 
 @[simp]
 theorem Ioc_inter_Ioi : Ioc a b ∩ Ioi c = Ioc (a ⊔ c) b := by
-  rw [← Ioi_inter_Iic, inter_assoc, inter_comm, inter_assoc, Ioi_inter_Ioi, inter_comm,
-    Ioi_inter_Iic, sup_comm]
+  grind
 
 @[simp]
-theorem Ico_inter_Iio : Ico a b ∩ Iio c = Ico a (min b c) :=
-  ext <| by simp +contextual [iff_def]
+theorem Ico_inter_Iio : Ico a b ∩ Iio c = Ico a (min b c) := by
+  grind
 
 @[simp]
 theorem Ioc_diff_Iic : Ioc a b \ Iic c = Ioc (max a c) b := by
-  rw [diff_eq, compl_Iic, Ioc_inter_Ioi]
+  grind
 
 theorem compl_Ioc : (Ioc a b)ᶜ = Iic a ∪ Ioi b := by
-  ext i
-  rw [mem_compl_iff, mem_Ioc, mem_union, mem_Iic, mem_Ioi, not_and_or, not_lt, not_le]
+  grind
 
 theorem Iic_diff_Ioc : Iic b \ Ioc a b = Iic (a ⊓ b) := by
-  rw [diff_eq, compl_Ioc, inter_union_distrib_left, Iic_inter_Iic, ← compl_Iic, inter_compl_self,
-    union_empty, min_comm]
+  grind
 
 theorem Iic_diff_Ioc_self_of_le (hab : a ≤ b) : Iic b \ Ioc a b = Iic a := by
-  rw [Iic_diff_Ioc, min_eq_left hab]
+  grind
 
 @[simp]
 theorem Ioc_union_Ioc_right : Ioc a b ∪ Ioc a c = Ioc a (max b c) := by
-  rw [Ioc_union_Ioc, min_self] <;> exact (min_le_left _ _).trans (le_max_left _ _)
+  grind
 
 @[simp]
 theorem Ioc_union_Ioc_left : Ioc a c ∪ Ioc b c = Ioc (min a b) c := by
-  rw [Ioc_union_Ioc, max_self] <;> exact (min_le_right _ _).trans (le_max_right _ _)
+  grind
 
 @[simp]
 theorem Ioc_union_Ioc_symm : Ioc a b ∪ Ioc b a = Ioc (min a b) (max a b) := by
-  rw [max_comm]
-  apply Ioc_union_Ioc <;> rw [max_comm] <;> exact min_le_max
+  grind
 
 @[simp]
 theorem Ioc_union_Ioc_union_Ioc_cycle :
     Ioc a b ∪ Ioc b c ∪ Ioc c a = Ioc (min a (min b c)) (max a (max b c)) := by
-  rw [Ioc_union_Ioc, Ioc_union_Ioc]
-  · ac_rfl
-  all_goals
-  solve_by_elim (maxDepth := 5) [min_le_of_left_le, min_le_of_right_le,
-    le_max_of_le_left, le_max_of_le_right, le_refl]
+  grind
 
 end Set

--- a/Mathlib/Order/Interval/Set/UnorderedInterval.lean
+++ b/Mathlib/Order/Interval/Set/UnorderedInterval.lean
@@ -8,6 +8,7 @@ import Mathlib.Order.Bounds.Basic
 import Mathlib.Order.Interval.Set.Image
 import Mathlib.Order.Interval.Set.LinearOrder
 import Mathlib.Tactic.Common
+import Mathlib.Order.MinMax
 
 /-!
 # Intervals without endpoints ordering


### PR DESCRIPTION
---
<details>
<summary>Show trace profiling of <code>Ioo_union_Ioi'</code>: 138 ms before, 27 ms after  🎉</summary>

### Trace profiling of `Ioo_union_Ioi'` before PR 31288
```diff
diff --git a/Mathlib/Order/Interval/Set/LinearOrder.lean b/Mathlib/Order/Interval/Set/LinearOrder.lean
index c852c5c841..e0b8d9bce3 100644
--- a/Mathlib/Order/Interval/Set/LinearOrder.lean
+++ b/Mathlib/Order/Interval/Set/LinearOrder.lean
@@ -202,6 +202,7 @@ theorem Iio_union_Ioi : Iio a ∪ Ioi a = {a}ᶜ :=
 
 /-! ### A finite and an infinite interval -/
 
+set_option trace.profiler true in
 theorem Ioo_union_Ioi' (h₁ : c < b) : Ioo a b ∪ Ioi c = Ioi (min a c) := by
   ext1 x
   simp_rw [mem_union, mem_Ioo, mem_Ioi, min_lt_iff]
```
```
ℹ [363/363] Built Mathlib.Order.Interval.Set.LinearOrder (1.9s)
info: Mathlib/Order/Interval/Set/LinearOrder.lean:206:0: [Elab.async] [0.138618] elaborating proof of Set.Ioo_union_Ioi'
  [Elab.definition.value] [0.137787] Set.Ioo_union_Ioi'
    [Elab.step] [0.137367] 
          ext1 x
          simp_rw [mem_union, mem_Ioo, mem_Ioi, min_lt_iff]
          by_cases hc : c < x
          · tauto
          · have hxb : x < b := (le_of_not_gt hc).trans_lt h₁
            tauto
      [Elab.step] [0.137361] 
            ext1 x
            simp_rw [mem_union, mem_Ioo, mem_Ioi, min_lt_iff]
            by_cases hc : c < x
            · tauto
            · have hxb : x < b := (le_of_not_gt hc).trans_lt h₁
              tauto
        [Elab.step] [0.010722] simp_rw [mem_union, mem_Ioo, mem_Ioi, min_lt_iff]
        [Elab.step] [0.021207] · tauto
          [Elab.step] [0.021198] tauto
            [Elab.step] [0.021194] tauto
              [Elab.step] [0.021188] tauto
        [Elab.step] [0.100585] ·
              have hxb : x < b := (le_of_not_gt hc).trans_lt h₁
              tauto
          [Elab.step] [0.100576] 
                have hxb : x < b := (le_of_not_gt hc).trans_lt h₁
                tauto
            [Elab.step] [0.100571] 
                  have hxb : x < b := (le_of_not_gt hc).trans_lt h₁
                  tauto
              [Elab.step] [0.095454] tauto
Build completed successfully (363 jobs).
```

### Trace profiling of `Ioo_union_Ioi'` after PR 31288
```diff
diff --git a/Mathlib/Order/Interval/Set/LinearOrder.lean b/Mathlib/Order/Interval/Set/LinearOrder.lean
index c852c5c841..b3c65f2bf8 100644
--- a/Mathlib/Order/Interval/Set/LinearOrder.lean
+++ b/Mathlib/Order/Interval/Set/LinearOrder.lean
@@ -202,19 +202,12 @@ theorem Iio_union_Ioi : Iio a ∪ Ioi a = {a}ᶜ :=
 
 /-! ### A finite and an infinite interval -/
 
+set_option trace.profiler true in
 theorem Ioo_union_Ioi' (h₁ : c < b) : Ioo a b ∪ Ioi c = Ioi (min a c) := by
-  ext1 x
-  simp_rw [mem_union, mem_Ioo, mem_Ioi, min_lt_iff]
-  by_cases hc : c < x
-  · tauto
-  · have hxb : x < b := (le_of_not_gt hc).trans_lt h₁
-    tauto
+  grind
 
 theorem Ioo_union_Ioi (h : c < max a b) : Ioo a b ∪ Ioi c = Ioi (min a c) := by
-  rcases le_total a b with hab | hab
-  · simp only [hab, sup_of_le_right] at h; exact Ioo_union_Ioi' h
-  · rw [min_comm]
-    simp_all [min_eq_left_of_lt]
+  grind
 
 theorem Ioi_subset_Ioo_union_Ici : Ioi a ⊆ Ioo a b ∪ Ici b := fun x hx =>
   (lt_or_ge x b).elim (fun hxb => Or.inl ⟨hx, hxb⟩) fun hxb => Or.inr hxb
@@ -231,17 +224,10 @@ theorem Ico_union_Ici_eq_Ici (h : a ≤ b) : Ico a b ∪ Ici b = Ici a :=
   Subset.antisymm (fun _ hx => hx.elim And.left h.trans) Ici_subset_Ico_union_Ici
 
 theorem Ico_union_Ici' (h₁ : c ≤ b) : Ico a b ∪ Ici c = Ici (min a c) := by
-  ext1 x
-  simp_rw [mem_union, mem_Ico, mem_Ici, min_le_iff]
-  by_cases hc : c ≤ x
-  · tauto
-  · have hxb : x < b := (lt_of_not_ge hc).trans_le h₁
-    tauto
+  grind
 
 theorem Ico_union_Ici (h : c ≤ max a b) : Ico a b ∪ Ici c = Ici (min a c) := by
-  rcases le_total a b with hab | hab
-  · simp only [hab, sup_of_le_right] at h; exact Ico_union_Ici' h
-  · simp_all
+  grind
 
 theorem Ioi_subset_Ioc_union_Ioi : Ioi a ⊆ Ioc a b ∪ Ioi b := fun x hx =>
   (le_or_gt x b).elim (fun hxb => Or.inl ⟨hx, hxb⟩) fun hxb => Or.inr hxb
@@ -251,17 +237,10 @@ theorem Ioc_union_Ioi_eq_Ioi (h : a ≤ b) : Ioc a b ∪ Ioi b = Ioi a :=
   Subset.antisymm (fun _ hx => hx.elim And.left h.trans_lt) Ioi_subset_Ioc_union_Ioi
 
 theorem Ioc_union_Ioi' (h₁ : c ≤ b) : Ioc a b ∪ Ioi c = Ioi (min a c) := by
-  ext1 x
-  simp_rw [mem_union, mem_Ioc, mem_Ioi, min_lt_iff]
-  by_cases hc : c < x
-  · tauto
-  · have hxb : x ≤ b := (le_of_not_gt hc).trans h₁
-    tauto
+  grind
 
 theorem Ioc_union_Ioi (h : c ≤ max a b) : Ioc a b ∪ Ioi c = Ioi (min a c) := by
-  rcases le_total a b with hab | hab
-  · simp only [hab, sup_of_le_right] at h; exact Ioc_union_Ioi' h
-  · simp_all
+  grind
 
 theorem Ici_subset_Icc_union_Ioi : Ici a ⊆ Icc a b ∪ Ioi b := fun x hx =>
   (le_or_gt x b).elim (fun hxb => Or.inl ⟨hx, hxb⟩) fun hxb => Or.inr hxb
@@ -286,20 +265,10 @@ theorem Icc_union_Ici_eq_Ici (h : a ≤ b) : Icc a b ∪ Ici b = Ici a :=
   Subset.antisymm (fun _ hx => hx.elim And.left h.trans) Ici_subset_Icc_union_Ici
 
 theorem Icc_union_Ici' (h₁ : c ≤ b) : Icc a b ∪ Ici c = Ici (min a c) := by
-  ext1 x
-  simp_rw [mem_union, mem_Icc, mem_Ici, min_le_iff]
-  by_cases hc : c ≤ x
-  · tauto
-  · have hxb : x ≤ b := (le_of_not_ge hc).trans h₁
-    tauto
+  grind
 
 theorem Icc_union_Ici (h : c ≤ max a b) : Icc a b ∪ Ici c = Ici (min a c) := by
-  rcases le_or_gt a b with hab | hab
-  · simp only [hab, sup_of_le_right] at h; exact Icc_union_Ici' h
-  · simp only [le_sup_iff] at h; rcases h with h | h
-    · simp [*]
-    · have hca : c ≤ a := h.trans hab.le
-      simp [*]
+  grind
 
 /-! ### An infinite and a finite interval -/
 
@@ -320,17 +289,10 @@ theorem Iio_union_Ico_eq_Iio (h : a ≤ b) : Iio a ∪ Ico a b = Iio b :=
     Iio_subset_Iio_union_Ico
 
 theorem Iio_union_Ico' (h₁ : c ≤ b) : Iio b ∪ Ico c d = Iio (max b d) := by
-  ext1 x
-  simp_rw [mem_union, mem_Iio, mem_Ico, lt_max_iff]
-  by_cases hc : c ≤ x
-  · tauto
-  · have hxb : x < b := (lt_of_not_ge hc).trans_le h₁
-    tauto
+  grind
 
 theorem Iio_union_Ico (h : min c d ≤ b) : Iio b ∪ Ico c d = Iio (max b d) := by
-  rcases le_total c d with hcd | hcd
-  · simp only [hcd, inf_of_le_left] at h; exact Iio_union_Ico' h
-  · simp_all
+  grind
 
 theorem Iic_subset_Iic_union_Ioc : Iic b ⊆ Iic a ∪ Ioc a b := fun x hx =>
   (le_or_gt x a).elim (fun hxa => Or.inl hxa) fun hxa => Or.inr ⟨hxa, hx⟩
@@ -341,18 +303,10 @@ theorem Iic_union_Ioc_eq_Iic (h : a ≤ b) : Iic a ∪ Ioc a b = Iic b :=
     Iic_subset_Iic_union_Ioc
 
 theorem Iic_union_Ioc' (h₁ : c < b) : Iic b ∪ Ioc c d = Iic (max b d) := by
-  ext1 x
-  simp_rw [mem_union, mem_Iic, mem_Ioc, le_max_iff]
-  by_cases hc : c < x
-  · tauto
-  · have hxb : x ≤ b := (le_of_not_gt hc).trans h₁.le
-    tauto
+  grind
 
 theorem Iic_union_Ioc (h : min c d < b) : Iic b ∪ Ioc c d = Iic (max b d) := by
-  rcases le_total c d with hcd | hcd
-  · simp only [hcd, inf_of_le_left] at h; exact Iic_union_Ioc' h
-  · rw [max_comm]
-    simp_all [max_eq_right_of_lt]
+  grind
 
 theorem Iio_subset_Iic_union_Ioo : Iio b ⊆ Iic a ∪ Ioo a b := fun x hx =>
   (le_or_gt x a).elim (fun hxa => Or.inl hxa) fun hxa => Or.inr ⟨hxa, hx⟩
@@ -363,18 +317,10 @@ theorem Iic_union_Ioo_eq_Iio (h : a < b) : Iic a ∪ Ioo a b = Iio b :=
     Iio_subset_Iic_union_Ioo
 
 theorem Iio_union_Ioo' (h₁ : c < b) : Iio b ∪ Ioo c d = Iio (max b d) := by
-  ext x
-  rcases lt_or_ge x b with hba | hba
-  · simp [hba]
-  · simp only [mem_Iio, mem_union, mem_Ioo, lt_max_iff]
-    refine or_congr Iff.rfl ⟨And.right, ?_⟩
-    exact fun h₂ => ⟨h₁.trans_le hba, h₂⟩
+  grind
 
 theorem Iio_union_Ioo (h : min c d < b) : Iio b ∪ Ioo c d = Iio (max b d) := by
-  rcases le_total c d with hcd | hcd
-  · simp only [hcd, inf_of_le_left] at h; exact Iio_union_Ioo' h
-  · rw [max_comm]
-    simp_all [max_eq_right_of_lt]
+  grind
 
 theorem Iic_subset_Iic_union_Icc : Iic b ⊆ Iic a ∪ Icc a b :=
   Subset.trans Iic_subset_Iic_union_Ioc (union_subset_union_right _ Ioc_subset_Icc_self)
@@ -385,20 +331,10 @@ theorem Iic_union_Icc_eq_Iic (h : a ≤ b) : Iic a ∪ Icc a b = Iic b :=
     Iic_subset_Iic_union_Icc
 
 theorem Iic_union_Icc' (h₁ : c ≤ b) : Iic b ∪ Icc c d = Iic (max b d) := by
-  ext1 x
-  simp_rw [mem_union, mem_Iic, mem_Icc, le_max_iff]
-  by_cases hc : c ≤ x
-  · tauto
-  · have hxb : x ≤ b := (le_of_not_ge hc).trans h₁
-    tauto
+  grind
 
 theorem Iic_union_Icc (h : min c d ≤ b) : Iic b ∪ Icc c d = Iic (max b d) := by
-  rcases le_or_gt c d with hcd | hcd
-  · simp only [hcd, inf_of_le_left] at h; exact Iic_union_Icc' h
-  · simp only [inf_le_iff] at h; rcases h with h | h
-    · have hdb : d ≤ b := hcd.le.trans h
-      simp [*]
-    · simp [*]
+  grind
 
 theorem Iio_subset_Iic_union_Ico : Iio b ⊆ Iic a ∪ Ico a b :=
   Subset.trans Iio_subset_Iic_union_Ioo (union_subset_union_right _ Ioo_subset_Ico_self)
@@ -429,21 +365,11 @@ theorem Ico_union_Ico_eq_Ico (h₁ : a ≤ b) (h₂ : b ≤ c) : Ico a b ∪ Ico
     Ico_subset_Ico_union_Ico
 
 theorem Ico_union_Ico' (h₁ : c ≤ b) (h₂ : a ≤ d) : Ico a b ∪ Ico c d = Ico (min a c) (max b d) := by
-  ext1 x
-  simp_rw [mem_union, mem_Ico, min_le_iff, lt_max_iff]
-  by_cases hc : c ≤ x <;> by_cases hd : x < d
-  · tauto
-  · have hax : a ≤ x := h₂.trans (le_of_not_gt hd)
-    tauto
-  · have hxb : x < b := (lt_of_not_ge hc).trans_le h₁
-    tauto
-  · tauto
+  grind
 
 theorem Ico_union_Ico (h₁ : min a b ≤ max c d) (h₂ : min c d ≤ max a b) :
     Ico a b ∪ Ico c d = Ico (min a c) (max b d) := by
-  rcases le_total a b with hab | hab <;> rcases le_total c d with hcd | hcd <;> simp [*] at h₁ h₂
-  · exact Ico_union_Ico' h₂ h₁
-  all_goals simp [*]
+  grind
 
 theorem Icc_subset_Ico_union_Icc : Icc a c ⊆ Ico a b ∪ Icc b c := fun x hx =>
   (lt_or_ge x b).elim (fun hxb => Or.inl ⟨hx.1, hxb⟩) fun hxb => Or.inr ⟨hxb, hx.2⟩
@@ -502,21 +428,11 @@ theorem Ioc_union_Ioc_eq_Ioc (h₁ : a ≤ b) (h₂ : b ≤ c) : Ioc a b ∪ Ioc
     Ioc_subset_Ioc_union_Ioc
 
 theorem Ioc_union_Ioc' (h₁ : c ≤ b) (h₂ : a ≤ d) : Ioc a b ∪ Ioc c d = Ioc (min a c) (max b d) := by
-  ext1 x
-  simp_rw [mem_union, mem_Ioc, min_lt_iff, le_max_iff]
-  by_cases hc : c < x <;> by_cases hd : x ≤ d
-  · tauto
-  · have hax : a < x := h₂.trans_lt (lt_of_not_ge hd)
-    tauto
-  · have hxb : x ≤ b := (le_of_not_gt hc).trans h₁
-    tauto
-  · tauto
+  grind
 
 theorem Ioc_union_Ioc (h₁ : min a b ≤ max c d) (h₂ : min c d ≤ max a b) :
     Ioc a b ∪ Ioc c d = Ioc (min a c) (max b d) := by
-  rcases le_total a b with hab | hab <;> rcases le_total c d with hcd | hcd <;> simp [*] at h₁ h₂
-  · exact Ioc_union_Ioc' h₂ h₁
-  all_goals simp [*]
+  grind
 
 /-! ### Two finite intervals with a common point -/
 
@@ -549,26 +465,14 @@ theorem Icc_union_Icc_eq_Icc (h₁ : a ≤ b) (h₂ : b ≤ c) : Icc a b ∪ Icc
     Icc_subset_Icc_union_Icc
 
 theorem Icc_union_Icc' (h₁ : c ≤ b) (h₂ : a ≤ d) : Icc a b ∪ Icc c d = Icc (min a c) (max b d) := by
-  ext1 x
-  simp_rw [mem_union, mem_Icc, min_le_iff, le_max_iff]
-  by_cases hc : c ≤ x <;> by_cases hd : x ≤ d
-  · tauto
-  · have hax : a ≤ x := h₂.trans (le_of_not_ge hd)
-    tauto
-  · have hxb : x ≤ b := (le_of_not_ge hc).trans h₁
-    tauto
-  · tauto
+  grind
 
 /-- We cannot replace `<` by `≤` in the hypotheses.
 Otherwise for `b < a = d < c` the l.h.s. is `∅` and the r.h.s. is `{a}`.
 -/
 theorem Icc_union_Icc (h₁ : min a b < max c d) (h₂ : min c d < max a b) :
     Icc a b ∪ Icc c d = Icc (min a c) (max b d) := by
-  rcases le_or_gt a b with hab | hab <;> rcases le_or_gt c d with hcd | hcd <;>
-    simp only [min_eq_left, max_eq_right,
-      min_eq_right_of_lt, max_eq_left_of_lt, hab, hcd] at h₁ h₂
-  · exact Icc_union_Icc' h₂.le h₁.le
-  all_goals simp [*, min_eq_left_of_lt, max_eq_left_of_lt, min_eq_right_of_lt, max_eq_right_of_lt]
+  grind
 
 theorem Ioc_subset_Ioc_union_Icc : Ioc a c ⊆ Ioc a b ∪ Icc b c :=
   Subset.trans Ioc_subset_Ioc_union_Ioc (union_subset_union_right _ Ioc_subset_Icc_self)
@@ -580,24 +484,11 @@ theorem Ioc_union_Icc_eq_Ioc (h₁ : a < b) (h₂ : b ≤ c) : Ioc a b ∪ Icc b
     Ioc_subset_Ioc_union_Icc
 
 theorem Ioo_union_Ioo' (h₁ : c < b) (h₂ : a < d) : Ioo a b ∪ Ioo c d = Ioo (min a c) (max b d) := by
-  ext1 x
-  simp_rw [mem_union, mem_Ioo, min_lt_iff, lt_max_iff]
-  by_cases hc : c < x <;> by_cases hd : x < d
-  · tauto
-  · have hax : a < x := h₂.trans_le (le_of_not_gt hd)
-    tauto
-  · have hxb : x < b := (le_of_not_gt hc).trans_lt h₁
-    tauto
-  · tauto
+  grind
 
 theorem Ioo_union_Ioo (h₁ : min a b < max c d) (h₂ : min c d < max a b) :
     Ioo a b ∪ Ioo c d = Ioo (min a c) (max b d) := by
-  rcases le_total a b with hab | hab <;> rcases le_total c d with hcd | hcd <;>
-    simp only [min_eq_left, min_eq_right, max_eq_left, max_eq_right, hab, hcd] at h₁ h₂
-  · exact Ioo_union_Ioo' h₂ h₁
-  all_goals
-    simp [*,
-      le_of_lt h₂, le_of_lt h₁]
+  grind
 
 theorem Ioo_subset_Ioo_union_Ioo (h₁ : a ≤ a₁) (h₂ : c < b) (h₃ : b₁ ≤ d) :
     Ioo a₁ b₁ ⊆ Ioo a b ∪ Ioo c d := fun x hx =>
@@ -615,95 +506,82 @@ theorem Iio_inter_Iio : Iio a ∩ Iio b = Iio (a ⊓ b) :=
   ext fun _ => lt_inf_iff.symm
 
 theorem Ico_inter_Ico : Ico a₁ b₁ ∩ Ico a₂ b₂ = Ico (a₁ ⊔ a₂) (b₁ ⊓ b₂) := by
-  simp only [Ici_inter_Iio.symm, Ici_inter_Ici.symm, Iio_inter_Iio.symm]; ac_rfl
+  grind
 
 theorem Ioc_inter_Ioc : Ioc a₁ b₁ ∩ Ioc a₂ b₂ = Ioc (a₁ ⊔ a₂) (b₁ ⊓ b₂) := by
-  simp only [Ioi_inter_Iic.symm, Ioi_inter_Ioi.symm, Iic_inter_Iic.symm]; ac_rfl
+  grind
 
 theorem Ioo_inter_Ioo : Ioo a₁ b₁ ∩ Ioo a₂ b₂ = Ioo (a₁ ⊔ a₂) (b₁ ⊓ b₂) := by
-  simp only [Ioi_inter_Iio.symm, Ioi_inter_Ioi.symm, Iio_inter_Iio.symm]; ac_rfl
+  grind
 
 theorem Ioo_inter_Iio : Ioo a b ∩ Iio c = Ioo a (min b c) := by
-  ext
-  simp_rw [mem_inter_iff, mem_Ioo, mem_Iio, lt_min_iff, and_assoc]
+  grind
 
 theorem Iio_inter_Ioo : Iio a ∩ Ioo b c = Ioo b (min a c) := by
-  rw [Set.inter_comm, Set.Ioo_inter_Iio, min_comm]
+  grind
 
 theorem Ioo_inter_Ioi : Ioo a b ∩ Ioi c = Ioo (max a c) b := by
-  ext
-  simp_rw [mem_inter_iff, mem_Ioo, mem_Ioi, max_lt_iff, and_assoc, and_comm]
+  grind
 
 theorem Ioi_inter_Ioo : Set.Ioi a ∩ Set.Ioo b c = Set.Ioo (max a b) c := by
-  rw [inter_comm, Ioo_inter_Ioi, max_comm]
+  grind
 
-theorem Ioc_inter_Ioo_of_left_lt (h : b₁ < b₂) : Ioc a₁ b₁ ∩ Ioo a₂ b₂ = Ioc (max a₁ a₂) b₁ :=
-  ext fun x => by
-    simp [and_assoc, @and_left_comm (x ≤ _), and_iff_left_iff_imp.2 fun h' => lt_of_le_of_lt h' h]
+theorem Ioc_inter_Ioo_of_left_lt (h : b₁ < b₂) : Ioc a₁ b₁ ∩ Ioo a₂ b₂ = Ioc (max a₁ a₂) b₁ := by
+  grind
 
-theorem Ioc_inter_Ioo_of_right_le (h : b₂ ≤ b₁) : Ioc a₁ b₁ ∩ Ioo a₂ b₂ = Ioo (max a₁ a₂) b₂ :=
-  ext fun x => by
-    simp [and_assoc, @and_left_comm (x ≤ _),
-      and_iff_right_iff_imp.2 fun h' => (le_of_lt h').trans h]
+theorem Ioc_inter_Ioo_of_right_le (h : b₂ ≤ b₁) : Ioc a₁ b₁ ∩ Ioo a₂ b₂ = Ioo (max a₁ a₂) b₂ := by
+    grind
 
 theorem Ioo_inter_Ioc_of_left_le (h : b₁ ≤ b₂) : Ioo a₁ b₁ ∩ Ioc a₂ b₂ = Ioo (max a₁ a₂) b₁ := by
-  rw [inter_comm, Ioc_inter_Ioo_of_right_le h, max_comm]
+  grind
 
 theorem Ioo_inter_Ioc_of_right_lt (h : b₂ < b₁) : Ioo a₁ b₁ ∩ Ioc a₂ b₂ = Ioc (max a₁ a₂) b₂ := by
-  rw [inter_comm, Ioc_inter_Ioo_of_left_lt h, max_comm]
+  grind
 
 @[simp]
 theorem Ico_diff_Iio : Ico a b \ Iio c = Ico (max a c) b := by
-  rw [diff_eq, compl_Iio, Ico_inter_Ici]
+  grind
 
 @[simp]
-theorem Ioc_diff_Ioi : Ioc a b \ Ioi c = Ioc a (min b c) :=
-  ext <| by simp +contextual [iff_def]
+theorem Ioc_diff_Ioi : Ioc a b \ Ioi c = Ioc a (min b c) := by
+  grind
 
 @[simp]
 theorem Ioc_inter_Ioi : Ioc a b ∩ Ioi c = Ioc (a ⊔ c) b := by
-  rw [← Ioi_inter_Iic, inter_assoc, inter_comm, inter_assoc, Ioi_inter_Ioi, inter_comm,
-    Ioi_inter_Iic, sup_comm]
+  grind
 
 @[simp]
-theorem Ico_inter_Iio : Ico a b ∩ Iio c = Ico a (min b c) :=
-  ext <| by simp +contextual [iff_def]
+theorem Ico_inter_Iio : Ico a b ∩ Iio c = Ico a (min b c) := by
+  grind
 
 @[simp]
 theorem Ioc_diff_Iic : Ioc a b \ Iic c = Ioc (max a c) b := by
-  rw [diff_eq, compl_Iic, Ioc_inter_Ioi]
+  grind
 
 theorem compl_Ioc : (Ioc a b)ᶜ = Iic a ∪ Ioi b := by
-  ext i
-  rw [mem_compl_iff, mem_Ioc, mem_union, mem_Iic, mem_Ioi, not_and_or, not_lt, not_le]
+  grind
 
 theorem Iic_diff_Ioc : Iic b \ Ioc a b = Iic (a ⊓ b) := by
-  rw [diff_eq, compl_Ioc, inter_union_distrib_left, Iic_inter_Iic, ← compl_Iic, inter_compl_self,
-    union_empty, min_comm]
+  grind
 
 theorem Iic_diff_Ioc_self_of_le (hab : a ≤ b) : Iic b \ Ioc a b = Iic a := by
-  rw [Iic_diff_Ioc, min_eq_left hab]
+  grind
 
 @[simp]
 theorem Ioc_union_Ioc_right : Ioc a b ∪ Ioc a c = Ioc a (max b c) := by
-  rw [Ioc_union_Ioc, min_self] <;> exact (min_le_left _ _).trans (le_max_left _ _)
+  grind
 
 @[simp]
 theorem Ioc_union_Ioc_left : Ioc a c ∪ Ioc b c = Ioc (min a b) c := by
-  rw [Ioc_union_Ioc, max_self] <;> exact (min_le_right _ _).trans (le_max_right _ _)
+  grind
 
 @[simp]
 theorem Ioc_union_Ioc_symm : Ioc a b ∪ Ioc b a = Ioc (min a b) (max a b) := by
-  rw [max_comm]
-  apply Ioc_union_Ioc <;> rw [max_comm] <;> exact min_le_max
+  grind
 
 @[simp]
 theorem Ioc_union_Ioc_union_Ioc_cycle :
     Ioc a b ∪ Ioc b c ∪ Ioc c a = Ioc (min a (min b c)) (max a (max b c)) := by
-  rw [Ioc_union_Ioc, Ioc_union_Ioc]
-  · ac_rfl
-  all_goals
-  solve_by_elim (maxDepth := 5) [min_le_of_left_le, min_le_of_right_le,
-    le_max_of_le_left, le_max_of_le_right, le_refl]
+  grind
 
 end Set
```
```
ℹ [363/363] Built Mathlib.Order.Interval.Set.LinearOrder (1.4s)
info: Mathlib/Order/Interval/Set/LinearOrder.lean:206:0: [Elab.async] [0.027305] elaborating proof of Set.Ioo_union_Ioi'
  [Elab.definition.value] [0.027029] Set.Ioo_union_Ioi'
    [Elab.step] [0.026919] grind
      [Elab.step] [0.026912] grind
        [Elab.step] [0.026904] grind
Build completed successfully (363 jobs).
```
</details>

---
<details>
<summary>Show trace profiling of <code>Ioo_union_Ioi</code>: 32 ms before, 28 ms after  🎉</summary>

### Trace profiling of `Ioo_union_Ioi` before PR 31288
```diff
diff --git a/Mathlib/Order/Interval/Set/LinearOrder.lean b/Mathlib/Order/Interval/Set/LinearOrder.lean
index c852c5c841..bb366a3f94 100644
--- a/Mathlib/Order/Interval/Set/LinearOrder.lean
+++ b/Mathlib/Order/Interval/Set/LinearOrder.lean
@@ -210,6 +210,7 @@ theorem Ioo_union_Ioi' (h₁ : c < b) : Ioo a b ∪ Ioi c = Ioi (min a c) := by
   · have hxb : x < b := (le_of_not_gt hc).trans_lt h₁
     tauto
 
+set_option trace.profiler true in
 theorem Ioo_union_Ioi (h : c < max a b) : Ioo a b ∪ Ioi c = Ioi (min a c) := by
   rcases le_total a b with hab | hab
   · simp only [hab, sup_of_le_right] at h; exact Ioo_union_Ioi' h
```
```
ℹ [363/363] Built Mathlib.Order.Interval.Set.LinearOrder (1.9s)
info: Mathlib/Order/Interval/Set/LinearOrder.lean:214:0: [Elab.async] [0.031903] elaborating proof of Set.Ioo_union_Ioi
  [Elab.definition.value] [0.031516] Set.Ioo_union_Ioi
    [Elab.step] [0.031245] 
          rcases le_total a b with hab | hab
          · simp only [hab, sup_of_le_right] at h; exact Ioo_union_Ioi' h
          · rw [min_comm]
            simp_all [min_eq_left_of_lt]
      [Elab.step] [0.031239] 
            rcases le_total a b with hab | hab
            · simp only [hab, sup_of_le_right] at h; exact Ioo_union_Ioi' h
            · rw [min_comm]
              simp_all [min_eq_left_of_lt]
        [Elab.step] [0.028389] ·
              rw [min_comm]
              simp_all [min_eq_left_of_lt]
          [Elab.step] [0.028360] 
                rw [min_comm]
                simp_all [min_eq_left_of_lt]
            [Elab.step] [0.028356] 
                  rw [min_comm]
                  simp_all [min_eq_left_of_lt]
              [Elab.step] [0.027307] simp_all [min_eq_left_of_lt]
                [Meta.Tactic.simp.discharge] [0.012044] IsMax.Ioi_eq discharge ❌️
                      IsMax c
                  [Meta.synthInstance] [0.010329] ❌️ OrderTop α
Build completed successfully (363 jobs).
```

### Trace profiling of `Ioo_union_Ioi` after PR 31288
```diff
diff --git a/Mathlib/Order/Interval/Set/LinearOrder.lean b/Mathlib/Order/Interval/Set/LinearOrder.lean
index c852c5c841..5918fb9fd9 100644
--- a/Mathlib/Order/Interval/Set/LinearOrder.lean
+++ b/Mathlib/Order/Interval/Set/LinearOrder.lean
@@ -203,18 +203,11 @@ theorem Iio_union_Ioi : Iio a ∪ Ioi a = {a}ᶜ :=
 /-! ### A finite and an infinite interval -/
 
 theorem Ioo_union_Ioi' (h₁ : c < b) : Ioo a b ∪ Ioi c = Ioi (min a c) := by
-  ext1 x
-  simp_rw [mem_union, mem_Ioo, mem_Ioi, min_lt_iff]
-  by_cases hc : c < x
-  · tauto
-  · have hxb : x < b := (le_of_not_gt hc).trans_lt h₁
-    tauto
+  grind
 
+set_option trace.profiler true in
 theorem Ioo_union_Ioi (h : c < max a b) : Ioo a b ∪ Ioi c = Ioi (min a c) := by
-  rcases le_total a b with hab | hab
-  · simp only [hab, sup_of_le_right] at h; exact Ioo_union_Ioi' h
-  · rw [min_comm]
-    simp_all [min_eq_left_of_lt]
+  grind
 
 theorem Ioi_subset_Ioo_union_Ici : Ioi a ⊆ Ioo a b ∪ Ici b := fun x hx =>
   (lt_or_ge x b).elim (fun hxb => Or.inl ⟨hx, hxb⟩) fun hxb => Or.inr hxb
@@ -231,17 +224,10 @@ theorem Ico_union_Ici_eq_Ici (h : a ≤ b) : Ico a b ∪ Ici b = Ici a :=
   Subset.antisymm (fun _ hx => hx.elim And.left h.trans) Ici_subset_Ico_union_Ici
 
 theorem Ico_union_Ici' (h₁ : c ≤ b) : Ico a b ∪ Ici c = Ici (min a c) := by
-  ext1 x
-  simp_rw [mem_union, mem_Ico, mem_Ici, min_le_iff]
-  by_cases hc : c ≤ x
-  · tauto
-  · have hxb : x < b := (lt_of_not_ge hc).trans_le h₁
-    tauto
+  grind
 
 theorem Ico_union_Ici (h : c ≤ max a b) : Ico a b ∪ Ici c = Ici (min a c) := by
-  rcases le_total a b with hab | hab
-  · simp only [hab, sup_of_le_right] at h; exact Ico_union_Ici' h
-  · simp_all
+  grind
 
 theorem Ioi_subset_Ioc_union_Ioi : Ioi a ⊆ Ioc a b ∪ Ioi b := fun x hx =>
   (le_or_gt x b).elim (fun hxb => Or.inl ⟨hx, hxb⟩) fun hxb => Or.inr hxb
@@ -251,17 +237,10 @@ theorem Ioc_union_Ioi_eq_Ioi (h : a ≤ b) : Ioc a b ∪ Ioi b = Ioi a :=
   Subset.antisymm (fun _ hx => hx.elim And.left h.trans_lt) Ioi_subset_Ioc_union_Ioi
 
 theorem Ioc_union_Ioi' (h₁ : c ≤ b) : Ioc a b ∪ Ioi c = Ioi (min a c) := by
-  ext1 x
-  simp_rw [mem_union, mem_Ioc, mem_Ioi, min_lt_iff]
-  by_cases hc : c < x
-  · tauto
-  · have hxb : x ≤ b := (le_of_not_gt hc).trans h₁
-    tauto
+  grind
 
 theorem Ioc_union_Ioi (h : c ≤ max a b) : Ioc a b ∪ Ioi c = Ioi (min a c) := by
-  rcases le_total a b with hab | hab
-  · simp only [hab, sup_of_le_right] at h; exact Ioc_union_Ioi' h
-  · simp_all
+  grind
 
 theorem Ici_subset_Icc_union_Ioi : Ici a ⊆ Icc a b ∪ Ioi b := fun x hx =>
   (le_or_gt x b).elim (fun hxb => Or.inl ⟨hx, hxb⟩) fun hxb => Or.inr hxb
@@ -286,20 +265,10 @@ theorem Icc_union_Ici_eq_Ici (h : a ≤ b) : Icc a b ∪ Ici b = Ici a :=
   Subset.antisymm (fun _ hx => hx.elim And.left h.trans) Ici_subset_Icc_union_Ici
 
 theorem Icc_union_Ici' (h₁ : c ≤ b) : Icc a b ∪ Ici c = Ici (min a c) := by
-  ext1 x
-  simp_rw [mem_union, mem_Icc, mem_Ici, min_le_iff]
-  by_cases hc : c ≤ x
-  · tauto
-  · have hxb : x ≤ b := (le_of_not_ge hc).trans h₁
-    tauto
+  grind
 
 theorem Icc_union_Ici (h : c ≤ max a b) : Icc a b ∪ Ici c = Ici (min a c) := by
-  rcases le_or_gt a b with hab | hab
-  · simp only [hab, sup_of_le_right] at h; exact Icc_union_Ici' h
-  · simp only [le_sup_iff] at h; rcases h with h | h
-    · simp [*]
-    · have hca : c ≤ a := h.trans hab.le
-      simp [*]
+  grind
 
 /-! ### An infinite and a finite interval -/
 
@@ -320,17 +289,10 @@ theorem Iio_union_Ico_eq_Iio (h : a ≤ b) : Iio a ∪ Ico a b = Iio b :=
     Iio_subset_Iio_union_Ico
 
 theorem Iio_union_Ico' (h₁ : c ≤ b) : Iio b ∪ Ico c d = Iio (max b d) := by
-  ext1 x
-  simp_rw [mem_union, mem_Iio, mem_Ico, lt_max_iff]
-  by_cases hc : c ≤ x
-  · tauto
-  · have hxb : x < b := (lt_of_not_ge hc).trans_le h₁
-    tauto
+  grind
 
 theorem Iio_union_Ico (h : min c d ≤ b) : Iio b ∪ Ico c d = Iio (max b d) := by
-  rcases le_total c d with hcd | hcd
-  · simp only [hcd, inf_of_le_left] at h; exact Iio_union_Ico' h
-  · simp_all
+  grind
 
 theorem Iic_subset_Iic_union_Ioc : Iic b ⊆ Iic a ∪ Ioc a b := fun x hx =>
   (le_or_gt x a).elim (fun hxa => Or.inl hxa) fun hxa => Or.inr ⟨hxa, hx⟩
@@ -341,18 +303,10 @@ theorem Iic_union_Ioc_eq_Iic (h : a ≤ b) : Iic a ∪ Ioc a b = Iic b :=
     Iic_subset_Iic_union_Ioc
 
 theorem Iic_union_Ioc' (h₁ : c < b) : Iic b ∪ Ioc c d = Iic (max b d) := by
-  ext1 x
-  simp_rw [mem_union, mem_Iic, mem_Ioc, le_max_iff]
-  by_cases hc : c < x
-  · tauto
-  · have hxb : x ≤ b := (le_of_not_gt hc).trans h₁.le
-    tauto
+  grind
 
 theorem Iic_union_Ioc (h : min c d < b) : Iic b ∪ Ioc c d = Iic (max b d) := by
-  rcases le_total c d with hcd | hcd
-  · simp only [hcd, inf_of_le_left] at h; exact Iic_union_Ioc' h
-  · rw [max_comm]
-    simp_all [max_eq_right_of_lt]
+  grind
 
 theorem Iio_subset_Iic_union_Ioo : Iio b ⊆ Iic a ∪ Ioo a b := fun x hx =>
   (le_or_gt x a).elim (fun hxa => Or.inl hxa) fun hxa => Or.inr ⟨hxa, hx⟩
@@ -363,18 +317,10 @@ theorem Iic_union_Ioo_eq_Iio (h : a < b) : Iic a ∪ Ioo a b = Iio b :=
     Iio_subset_Iic_union_Ioo
 
 theorem Iio_union_Ioo' (h₁ : c < b) : Iio b ∪ Ioo c d = Iio (max b d) := by
-  ext x
-  rcases lt_or_ge x b with hba | hba
-  · simp [hba]
-  · simp only [mem_Iio, mem_union, mem_Ioo, lt_max_iff]
-    refine or_congr Iff.rfl ⟨And.right, ?_⟩
-    exact fun h₂ => ⟨h₁.trans_le hba, h₂⟩
+  grind
 
 theorem Iio_union_Ioo (h : min c d < b) : Iio b ∪ Ioo c d = Iio (max b d) := by
-  rcases le_total c d with hcd | hcd
-  · simp only [hcd, inf_of_le_left] at h; exact Iio_union_Ioo' h
-  · rw [max_comm]
-    simp_all [max_eq_right_of_lt]
+  grind
 
 theorem Iic_subset_Iic_union_Icc : Iic b ⊆ Iic a ∪ Icc a b :=
   Subset.trans Iic_subset_Iic_union_Ioc (union_subset_union_right _ Ioc_subset_Icc_self)
@@ -385,20 +331,10 @@ theorem Iic_union_Icc_eq_Iic (h : a ≤ b) : Iic a ∪ Icc a b = Iic b :=
     Iic_subset_Iic_union_Icc
 
 theorem Iic_union_Icc' (h₁ : c ≤ b) : Iic b ∪ Icc c d = Iic (max b d) := by
-  ext1 x
-  simp_rw [mem_union, mem_Iic, mem_Icc, le_max_iff]
-  by_cases hc : c ≤ x
-  · tauto
-  · have hxb : x ≤ b := (le_of_not_ge hc).trans h₁
-    tauto
+  grind
 
 theorem Iic_union_Icc (h : min c d ≤ b) : Iic b ∪ Icc c d = Iic (max b d) := by
-  rcases le_or_gt c d with hcd | hcd
-  · simp only [hcd, inf_of_le_left] at h; exact Iic_union_Icc' h
-  · simp only [inf_le_iff] at h; rcases h with h | h
-    · have hdb : d ≤ b := hcd.le.trans h
-      simp [*]
-    · simp [*]
+  grind
 
 theorem Iio_subset_Iic_union_Ico : Iio b ⊆ Iic a ∪ Ico a b :=
   Subset.trans Iio_subset_Iic_union_Ioo (union_subset_union_right _ Ioo_subset_Ico_self)
@@ -429,21 +365,11 @@ theorem Ico_union_Ico_eq_Ico (h₁ : a ≤ b) (h₂ : b ≤ c) : Ico a b ∪ Ico
     Ico_subset_Ico_union_Ico
 
 theorem Ico_union_Ico' (h₁ : c ≤ b) (h₂ : a ≤ d) : Ico a b ∪ Ico c d = Ico (min a c) (max b d) := by
-  ext1 x
-  simp_rw [mem_union, mem_Ico, min_le_iff, lt_max_iff]
-  by_cases hc : c ≤ x <;> by_cases hd : x < d
-  · tauto
-  · have hax : a ≤ x := h₂.trans (le_of_not_gt hd)
-    tauto
-  · have hxb : x < b := (lt_of_not_ge hc).trans_le h₁
-    tauto
-  · tauto
+  grind
 
 theorem Ico_union_Ico (h₁ : min a b ≤ max c d) (h₂ : min c d ≤ max a b) :
     Ico a b ∪ Ico c d = Ico (min a c) (max b d) := by
-  rcases le_total a b with hab | hab <;> rcases le_total c d with hcd | hcd <;> simp [*] at h₁ h₂
-  · exact Ico_union_Ico' h₂ h₁
-  all_goals simp [*]
+  grind
 
 theorem Icc_subset_Ico_union_Icc : Icc a c ⊆ Ico a b ∪ Icc b c := fun x hx =>
   (lt_or_ge x b).elim (fun hxb => Or.inl ⟨hx.1, hxb⟩) fun hxb => Or.inr ⟨hxb, hx.2⟩
@@ -502,21 +428,11 @@ theorem Ioc_union_Ioc_eq_Ioc (h₁ : a ≤ b) (h₂ : b ≤ c) : Ioc a b ∪ Ioc
     Ioc_subset_Ioc_union_Ioc
 
 theorem Ioc_union_Ioc' (h₁ : c ≤ b) (h₂ : a ≤ d) : Ioc a b ∪ Ioc c d = Ioc (min a c) (max b d) := by
-  ext1 x
-  simp_rw [mem_union, mem_Ioc, min_lt_iff, le_max_iff]
-  by_cases hc : c < x <;> by_cases hd : x ≤ d
-  · tauto
-  · have hax : a < x := h₂.trans_lt (lt_of_not_ge hd)
-    tauto
-  · have hxb : x ≤ b := (le_of_not_gt hc).trans h₁
-    tauto
-  · tauto
+  grind
 
 theorem Ioc_union_Ioc (h₁ : min a b ≤ max c d) (h₂ : min c d ≤ max a b) :
     Ioc a b ∪ Ioc c d = Ioc (min a c) (max b d) := by
-  rcases le_total a b with hab | hab <;> rcases le_total c d with hcd | hcd <;> simp [*] at h₁ h₂
-  · exact Ioc_union_Ioc' h₂ h₁
-  all_goals simp [*]
+  grind
 
 /-! ### Two finite intervals with a common point -/
 
@@ -549,26 +465,14 @@ theorem Icc_union_Icc_eq_Icc (h₁ : a ≤ b) (h₂ : b ≤ c) : Icc a b ∪ Icc
     Icc_subset_Icc_union_Icc
 
 theorem Icc_union_Icc' (h₁ : c ≤ b) (h₂ : a ≤ d) : Icc a b ∪ Icc c d = Icc (min a c) (max b d) := by
-  ext1 x
-  simp_rw [mem_union, mem_Icc, min_le_iff, le_max_iff]
-  by_cases hc : c ≤ x <;> by_cases hd : x ≤ d
-  · tauto
-  · have hax : a ≤ x := h₂.trans (le_of_not_ge hd)
-    tauto
-  · have hxb : x ≤ b := (le_of_not_ge hc).trans h₁
-    tauto
-  · tauto
+  grind
 
 /-- We cannot replace `<` by `≤` in the hypotheses.
 Otherwise for `b < a = d < c` the l.h.s. is `∅` and the r.h.s. is `{a}`.
 -/
 theorem Icc_union_Icc (h₁ : min a b < max c d) (h₂ : min c d < max a b) :
     Icc a b ∪ Icc c d = Icc (min a c) (max b d) := by
-  rcases le_or_gt a b with hab | hab <;> rcases le_or_gt c d with hcd | hcd <;>
-    simp only [min_eq_left, max_eq_right,
-      min_eq_right_of_lt, max_eq_left_of_lt, hab, hcd] at h₁ h₂
-  · exact Icc_union_Icc' h₂.le h₁.le
-  all_goals simp [*, min_eq_left_of_lt, max_eq_left_of_lt, min_eq_right_of_lt, max_eq_right_of_lt]
+  grind
 
 theorem Ioc_subset_Ioc_union_Icc : Ioc a c ⊆ Ioc a b ∪ Icc b c :=
   Subset.trans Ioc_subset_Ioc_union_Ioc (union_subset_union_right _ Ioc_subset_Icc_self)
@@ -580,24 +484,11 @@ theorem Ioc_union_Icc_eq_Ioc (h₁ : a < b) (h₂ : b ≤ c) : Ioc a b ∪ Icc b
     Ioc_subset_Ioc_union_Icc
 
 theorem Ioo_union_Ioo' (h₁ : c < b) (h₂ : a < d) : Ioo a b ∪ Ioo c d = Ioo (min a c) (max b d) := by
-  ext1 x
-  simp_rw [mem_union, mem_Ioo, min_lt_iff, lt_max_iff]
-  by_cases hc : c < x <;> by_cases hd : x < d
-  · tauto
-  · have hax : a < x := h₂.trans_le (le_of_not_gt hd)
-    tauto
-  · have hxb : x < b := (le_of_not_gt hc).trans_lt h₁
-    tauto
-  · tauto
+  grind
 
 theorem Ioo_union_Ioo (h₁ : min a b < max c d) (h₂ : min c d < max a b) :
     Ioo a b ∪ Ioo c d = Ioo (min a c) (max b d) := by
-  rcases le_total a b with hab | hab <;> rcases le_total c d with hcd | hcd <;>
-    simp only [min_eq_left, min_eq_right, max_eq_left, max_eq_right, hab, hcd] at h₁ h₂
-  · exact Ioo_union_Ioo' h₂ h₁
-  all_goals
-    simp [*,
-      le_of_lt h₂, le_of_lt h₁]
+  grind
 
 theorem Ioo_subset_Ioo_union_Ioo (h₁ : a ≤ a₁) (h₂ : c < b) (h₃ : b₁ ≤ d) :
     Ioo a₁ b₁ ⊆ Ioo a b ∪ Ioo c d := fun x hx =>
@@ -615,95 +506,82 @@ theorem Iio_inter_Iio : Iio a ∩ Iio b = Iio (a ⊓ b) :=
   ext fun _ => lt_inf_iff.symm
 
 theorem Ico_inter_Ico : Ico a₁ b₁ ∩ Ico a₂ b₂ = Ico (a₁ ⊔ a₂) (b₁ ⊓ b₂) := by
-  simp only [Ici_inter_Iio.symm, Ici_inter_Ici.symm, Iio_inter_Iio.symm]; ac_rfl
+  grind
 
 theorem Ioc_inter_Ioc : Ioc a₁ b₁ ∩ Ioc a₂ b₂ = Ioc (a₁ ⊔ a₂) (b₁ ⊓ b₂) := by
-  simp only [Ioi_inter_Iic.symm, Ioi_inter_Ioi.symm, Iic_inter_Iic.symm]; ac_rfl
+  grind
 
 theorem Ioo_inter_Ioo : Ioo a₁ b₁ ∩ Ioo a₂ b₂ = Ioo (a₁ ⊔ a₂) (b₁ ⊓ b₂) := by
-  simp only [Ioi_inter_Iio.symm, Ioi_inter_Ioi.symm, Iio_inter_Iio.symm]; ac_rfl
+  grind
 
 theorem Ioo_inter_Iio : Ioo a b ∩ Iio c = Ioo a (min b c) := by
-  ext
-  simp_rw [mem_inter_iff, mem_Ioo, mem_Iio, lt_min_iff, and_assoc]
+  grind
 
 theorem Iio_inter_Ioo : Iio a ∩ Ioo b c = Ioo b (min a c) := by
-  rw [Set.inter_comm, Set.Ioo_inter_Iio, min_comm]
+  grind
 
 theorem Ioo_inter_Ioi : Ioo a b ∩ Ioi c = Ioo (max a c) b := by
-  ext
-  simp_rw [mem_inter_iff, mem_Ioo, mem_Ioi, max_lt_iff, and_assoc, and_comm]
+  grind
 
 theorem Ioi_inter_Ioo : Set.Ioi a ∩ Set.Ioo b c = Set.Ioo (max a b) c := by
-  rw [inter_comm, Ioo_inter_Ioi, max_comm]
+  grind
 
-theorem Ioc_inter_Ioo_of_left_lt (h : b₁ < b₂) : Ioc a₁ b₁ ∩ Ioo a₂ b₂ = Ioc (max a₁ a₂) b₁ :=
-  ext fun x => by
-    simp [and_assoc, @and_left_comm (x ≤ _), and_iff_left_iff_imp.2 fun h' => lt_of_le_of_lt h' h]
+theorem Ioc_inter_Ioo_of_left_lt (h : b₁ < b₂) : Ioc a₁ b₁ ∩ Ioo a₂ b₂ = Ioc (max a₁ a₂) b₁ := by
+  grind
 
-theorem Ioc_inter_Ioo_of_right_le (h : b₂ ≤ b₁) : Ioc a₁ b₁ ∩ Ioo a₂ b₂ = Ioo (max a₁ a₂) b₂ :=
-  ext fun x => by
-    simp [and_assoc, @and_left_comm (x ≤ _),
-      and_iff_right_iff_imp.2 fun h' => (le_of_lt h').trans h]
+theorem Ioc_inter_Ioo_of_right_le (h : b₂ ≤ b₁) : Ioc a₁ b₁ ∩ Ioo a₂ b₂ = Ioo (max a₁ a₂) b₂ := by
+    grind
 
 theorem Ioo_inter_Ioc_of_left_le (h : b₁ ≤ b₂) : Ioo a₁ b₁ ∩ Ioc a₂ b₂ = Ioo (max a₁ a₂) b₁ := by
-  rw [inter_comm, Ioc_inter_Ioo_of_right_le h, max_comm]
+  grind
 
 theorem Ioo_inter_Ioc_of_right_lt (h : b₂ < b₁) : Ioo a₁ b₁ ∩ Ioc a₂ b₂ = Ioc (max a₁ a₂) b₂ := by
-  rw [inter_comm, Ioc_inter_Ioo_of_left_lt h, max_comm]
+  grind
 
 @[simp]
 theorem Ico_diff_Iio : Ico a b \ Iio c = Ico (max a c) b := by
-  rw [diff_eq, compl_Iio, Ico_inter_Ici]
+  grind
 
 @[simp]
-theorem Ioc_diff_Ioi : Ioc a b \ Ioi c = Ioc a (min b c) :=
-  ext <| by simp +contextual [iff_def]
+theorem Ioc_diff_Ioi : Ioc a b \ Ioi c = Ioc a (min b c) := by
+  grind
 
 @[simp]
 theorem Ioc_inter_Ioi : Ioc a b ∩ Ioi c = Ioc (a ⊔ c) b := by
-  rw [← Ioi_inter_Iic, inter_assoc, inter_comm, inter_assoc, Ioi_inter_Ioi, inter_comm,
-    Ioi_inter_Iic, sup_comm]
+  grind
 
 @[simp]
-theorem Ico_inter_Iio : Ico a b ∩ Iio c = Ico a (min b c) :=
-  ext <| by simp +contextual [iff_def]
+theorem Ico_inter_Iio : Ico a b ∩ Iio c = Ico a (min b c) := by
+  grind
 
 @[simp]
 theorem Ioc_diff_Iic : Ioc a b \ Iic c = Ioc (max a c) b := by
-  rw [diff_eq, compl_Iic, Ioc_inter_Ioi]
+  grind
 
 theorem compl_Ioc : (Ioc a b)ᶜ = Iic a ∪ Ioi b := by
-  ext i
-  rw [mem_compl_iff, mem_Ioc, mem_union, mem_Iic, mem_Ioi, not_and_or, not_lt, not_le]
+  grind
 
 theorem Iic_diff_Ioc : Iic b \ Ioc a b = Iic (a ⊓ b) := by
-  rw [diff_eq, compl_Ioc, inter_union_distrib_left, Iic_inter_Iic, ← compl_Iic, inter_compl_self,
-    union_empty, min_comm]
+  grind
 
 theorem Iic_diff_Ioc_self_of_le (hab : a ≤ b) : Iic b \ Ioc a b = Iic a := by
-  rw [Iic_diff_Ioc, min_eq_left hab]
+  grind
 
 @[simp]
 theorem Ioc_union_Ioc_right : Ioc a b ∪ Ioc a c = Ioc a (max b c) := by
-  rw [Ioc_union_Ioc, min_self] <;> exact (min_le_left _ _).trans (le_max_left _ _)
+  grind
 
 @[simp]
 theorem Ioc_union_Ioc_left : Ioc a c ∪ Ioc b c = Ioc (min a b) c := by
-  rw [Ioc_union_Ioc, max_self] <;> exact (min_le_right _ _).trans (le_max_right _ _)
+  grind
 
 @[simp]
 theorem Ioc_union_Ioc_symm : Ioc a b ∪ Ioc b a = Ioc (min a b) (max a b) := by
-  rw [max_comm]
-  apply Ioc_union_Ioc <;> rw [max_comm] <;> exact min_le_max
+  grind
 
 @[simp]
 theorem Ioc_union_Ioc_union_Ioc_cycle :
     Ioc a b ∪ Ioc b c ∪ Ioc c a = Ioc (min a (min b c)) (max a (max b c)) := by
-  rw [Ioc_union_Ioc, Ioc_union_Ioc]
-  · ac_rfl
-  all_goals
-  solve_by_elim (maxDepth := 5) [min_le_of_left_le, min_le_of_right_le,
-    le_max_of_le_left, le_max_of_le_right, le_refl]
+  grind
 
 end Set
```
```
ℹ [363/363] Built Mathlib.Order.Interval.Set.LinearOrder (1.4s)
info: Mathlib/Order/Interval/Set/LinearOrder.lean:209:0: [Elab.async] [0.027982] elaborating proof of Set.Ioo_union_Ioi
  [Elab.definition.value] [0.027660] Set.Ioo_union_Ioi
    [Elab.step] [0.027529] grind
      [Elab.step] [0.027523] grind
        [Elab.step] [0.027515] grind
Build completed successfully (363 jobs).
```
</details>

---
<details>
<summary>Show trace profiling of <code>Ico_union_Ici'</code>: 150 ms before, 24 ms after  🎉</summary>

### Trace profiling of `Ico_union_Ici'` before PR 31288
```diff
diff --git a/Mathlib/Order/Interval/Set/LinearOrder.lean b/Mathlib/Order/Interval/Set/LinearOrder.lean
index c852c5c841..0e46142c1a 100644
--- a/Mathlib/Order/Interval/Set/LinearOrder.lean
+++ b/Mathlib/Order/Interval/Set/LinearOrder.lean
@@ -230,6 +230,7 @@ theorem Ici_subset_Ico_union_Ici : Ici a ⊆ Ico a b ∪ Ici b := fun x hx =>
 theorem Ico_union_Ici_eq_Ici (h : a ≤ b) : Ico a b ∪ Ici b = Ici a :=
   Subset.antisymm (fun _ hx => hx.elim And.left h.trans) Ici_subset_Ico_union_Ici
 
+set_option trace.profiler true in
 theorem Ico_union_Ici' (h₁ : c ≤ b) : Ico a b ∪ Ici c = Ici (min a c) := by
   ext1 x
   simp_rw [mem_union, mem_Ico, mem_Ici, min_le_iff]
```
```
ℹ [363/363] Built Mathlib.Order.Interval.Set.LinearOrder (2.0s)
info: Mathlib/Order/Interval/Set/LinearOrder.lean:234:0: [Elab.async] [0.151182] elaborating proof of Set.Ico_union_Ici'
  [Elab.definition.value] [0.150467] Set.Ico_union_Ici'
    [Elab.step] [0.150057] 
          ext1 x
          simp_rw [mem_union, mem_Ico, mem_Ici, min_le_iff]
          by_cases hc : c ≤ x
          · tauto
          · have hxb : x < b := (lt_of_not_ge hc).trans_le h₁
            tauto
      [Elab.step] [0.150051] 
            ext1 x
            simp_rw [mem_union, mem_Ico, mem_Ici, min_le_iff]
            by_cases hc : c ≤ x
            · tauto
            · have hxb : x < b := (lt_of_not_ge hc).trans_le h₁
              tauto
        [Elab.step] [0.022785] · tauto
          [Elab.step] [0.022775] tauto
            [Elab.step] [0.022771] tauto
              [Elab.step] [0.022764] tauto
        [Elab.step] [0.115910] ·
              have hxb : x < b := (lt_of_not_ge hc).trans_le h₁
              tauto
          [Elab.step] [0.115901] 
                have hxb : x < b := (lt_of_not_ge hc).trans_le h₁
                tauto
            [Elab.step] [0.115896] 
                  have hxb : x < b := (lt_of_not_ge hc).trans_le h₁
                  tauto
              [Elab.step] [0.110313] tauto
Build completed successfully (363 jobs).
```

### Trace profiling of `Ico_union_Ici'` after PR 31288
```diff
diff --git a/Mathlib/Order/Interval/Set/LinearOrder.lean b/Mathlib/Order/Interval/Set/LinearOrder.lean
index c852c5c841..4d45c90c3d 100644
--- a/Mathlib/Order/Interval/Set/LinearOrder.lean
+++ b/Mathlib/Order/Interval/Set/LinearOrder.lean
@@ -203,18 +203,10 @@ theorem Iio_union_Ioi : Iio a ∪ Ioi a = {a}ᶜ :=
 /-! ### A finite and an infinite interval -/
 
 theorem Ioo_union_Ioi' (h₁ : c < b) : Ioo a b ∪ Ioi c = Ioi (min a c) := by
-  ext1 x
-  simp_rw [mem_union, mem_Ioo, mem_Ioi, min_lt_iff]
-  by_cases hc : c < x
-  · tauto
-  · have hxb : x < b := (le_of_not_gt hc).trans_lt h₁
-    tauto
+  grind
 
 theorem Ioo_union_Ioi (h : c < max a b) : Ioo a b ∪ Ioi c = Ioi (min a c) := by
-  rcases le_total a b with hab | hab
-  · simp only [hab, sup_of_le_right] at h; exact Ioo_union_Ioi' h
-  · rw [min_comm]
-    simp_all [min_eq_left_of_lt]
+  grind
 
 theorem Ioi_subset_Ioo_union_Ici : Ioi a ⊆ Ioo a b ∪ Ici b := fun x hx =>
   (lt_or_ge x b).elim (fun hxb => Or.inl ⟨hx, hxb⟩) fun hxb => Or.inr hxb
@@ -230,18 +222,12 @@ theorem Ici_subset_Ico_union_Ici : Ici a ⊆ Ico a b ∪ Ici b := fun x hx =>
 theorem Ico_union_Ici_eq_Ici (h : a ≤ b) : Ico a b ∪ Ici b = Ici a :=
   Subset.antisymm (fun _ hx => hx.elim And.left h.trans) Ici_subset_Ico_union_Ici
 
+set_option trace.profiler true in
 theorem Ico_union_Ici' (h₁ : c ≤ b) : Ico a b ∪ Ici c = Ici (min a c) := by
-  ext1 x
-  simp_rw [mem_union, mem_Ico, mem_Ici, min_le_iff]
-  by_cases hc : c ≤ x
-  · tauto
-  · have hxb : x < b := (lt_of_not_ge hc).trans_le h₁
-    tauto
+  grind
 
 theorem Ico_union_Ici (h : c ≤ max a b) : Ico a b ∪ Ici c = Ici (min a c) := by
-  rcases le_total a b with hab | hab
-  · simp only [hab, sup_of_le_right] at h; exact Ico_union_Ici' h
-  · simp_all
+  grind
 
 theorem Ioi_subset_Ioc_union_Ioi : Ioi a ⊆ Ioc a b ∪ Ioi b := fun x hx =>
   (le_or_gt x b).elim (fun hxb => Or.inl ⟨hx, hxb⟩) fun hxb => Or.inr hxb
@@ -251,17 +237,10 @@ theorem Ioc_union_Ioi_eq_Ioi (h : a ≤ b) : Ioc a b ∪ Ioi b = Ioi a :=
   Subset.antisymm (fun _ hx => hx.elim And.left h.trans_lt) Ioi_subset_Ioc_union_Ioi
 
 theorem Ioc_union_Ioi' (h₁ : c ≤ b) : Ioc a b ∪ Ioi c = Ioi (min a c) := by
-  ext1 x
-  simp_rw [mem_union, mem_Ioc, mem_Ioi, min_lt_iff]
-  by_cases hc : c < x
-  · tauto
-  · have hxb : x ≤ b := (le_of_not_gt hc).trans h₁
-    tauto
+  grind
 
 theorem Ioc_union_Ioi (h : c ≤ max a b) : Ioc a b ∪ Ioi c = Ioi (min a c) := by
-  rcases le_total a b with hab | hab
-  · simp only [hab, sup_of_le_right] at h; exact Ioc_union_Ioi' h
-  · simp_all
+  grind
 
 theorem Ici_subset_Icc_union_Ioi : Ici a ⊆ Icc a b ∪ Ioi b := fun x hx =>
   (le_or_gt x b).elim (fun hxb => Or.inl ⟨hx, hxb⟩) fun hxb => Or.inr hxb
@@ -286,20 +265,10 @@ theorem Icc_union_Ici_eq_Ici (h : a ≤ b) : Icc a b ∪ Ici b = Ici a :=
   Subset.antisymm (fun _ hx => hx.elim And.left h.trans) Ici_subset_Icc_union_Ici
 
 theorem Icc_union_Ici' (h₁ : c ≤ b) : Icc a b ∪ Ici c = Ici (min a c) := by
-  ext1 x
-  simp_rw [mem_union, mem_Icc, mem_Ici, min_le_iff]
-  by_cases hc : c ≤ x
-  · tauto
-  · have hxb : x ≤ b := (le_of_not_ge hc).trans h₁
-    tauto
+  grind
 
 theorem Icc_union_Ici (h : c ≤ max a b) : Icc a b ∪ Ici c = Ici (min a c) := by
-  rcases le_or_gt a b with hab | hab
-  · simp only [hab, sup_of_le_right] at h; exact Icc_union_Ici' h
-  · simp only [le_sup_iff] at h; rcases h with h | h
-    · simp [*]
-    · have hca : c ≤ a := h.trans hab.le
-      simp [*]
+  grind
 
 /-! ### An infinite and a finite interval -/
 
@@ -320,17 +289,10 @@ theorem Iio_union_Ico_eq_Iio (h : a ≤ b) : Iio a ∪ Ico a b = Iio b :=
     Iio_subset_Iio_union_Ico
 
 theorem Iio_union_Ico' (h₁ : c ≤ b) : Iio b ∪ Ico c d = Iio (max b d) := by
-  ext1 x
-  simp_rw [mem_union, mem_Iio, mem_Ico, lt_max_iff]
-  by_cases hc : c ≤ x
-  · tauto
-  · have hxb : x < b := (lt_of_not_ge hc).trans_le h₁
-    tauto
+  grind
 
 theorem Iio_union_Ico (h : min c d ≤ b) : Iio b ∪ Ico c d = Iio (max b d) := by
-  rcases le_total c d with hcd | hcd
-  · simp only [hcd, inf_of_le_left] at h; exact Iio_union_Ico' h
-  · simp_all
+  grind
 
 theorem Iic_subset_Iic_union_Ioc : Iic b ⊆ Iic a ∪ Ioc a b := fun x hx =>
   (le_or_gt x a).elim (fun hxa => Or.inl hxa) fun hxa => Or.inr ⟨hxa, hx⟩
@@ -341,18 +303,10 @@ theorem Iic_union_Ioc_eq_Iic (h : a ≤ b) : Iic a ∪ Ioc a b = Iic b :=
     Iic_subset_Iic_union_Ioc
 
 theorem Iic_union_Ioc' (h₁ : c < b) : Iic b ∪ Ioc c d = Iic (max b d) := by
-  ext1 x
-  simp_rw [mem_union, mem_Iic, mem_Ioc, le_max_iff]
-  by_cases hc : c < x
-  · tauto
-  · have hxb : x ≤ b := (le_of_not_gt hc).trans h₁.le
-    tauto
+  grind
 
 theorem Iic_union_Ioc (h : min c d < b) : Iic b ∪ Ioc c d = Iic (max b d) := by
-  rcases le_total c d with hcd | hcd
-  · simp only [hcd, inf_of_le_left] at h; exact Iic_union_Ioc' h
-  · rw [max_comm]
-    simp_all [max_eq_right_of_lt]
+  grind
 
 theorem Iio_subset_Iic_union_Ioo : Iio b ⊆ Iic a ∪ Ioo a b := fun x hx =>
   (le_or_gt x a).elim (fun hxa => Or.inl hxa) fun hxa => Or.inr ⟨hxa, hx⟩
@@ -363,18 +317,10 @@ theorem Iic_union_Ioo_eq_Iio (h : a < b) : Iic a ∪ Ioo a b = Iio b :=
     Iio_subset_Iic_union_Ioo
 
 theorem Iio_union_Ioo' (h₁ : c < b) : Iio b ∪ Ioo c d = Iio (max b d) := by
-  ext x
-  rcases lt_or_ge x b with hba | hba
-  · simp [hba]
-  · simp only [mem_Iio, mem_union, mem_Ioo, lt_max_iff]
-    refine or_congr Iff.rfl ⟨And.right, ?_⟩
-    exact fun h₂ => ⟨h₁.trans_le hba, h₂⟩
+  grind
 
 theorem Iio_union_Ioo (h : min c d < b) : Iio b ∪ Ioo c d = Iio (max b d) := by
-  rcases le_total c d with hcd | hcd
-  · simp only [hcd, inf_of_le_left] at h; exact Iio_union_Ioo' h
-  · rw [max_comm]
-    simp_all [max_eq_right_of_lt]
+  grind
 
 theorem Iic_subset_Iic_union_Icc : Iic b ⊆ Iic a ∪ Icc a b :=
   Subset.trans Iic_subset_Iic_union_Ioc (union_subset_union_right _ Ioc_subset_Icc_self)
@@ -385,20 +331,10 @@ theorem Iic_union_Icc_eq_Iic (h : a ≤ b) : Iic a ∪ Icc a b = Iic b :=
     Iic_subset_Iic_union_Icc
 
 theorem Iic_union_Icc' (h₁ : c ≤ b) : Iic b ∪ Icc c d = Iic (max b d) := by
-  ext1 x
-  simp_rw [mem_union, mem_Iic, mem_Icc, le_max_iff]
-  by_cases hc : c ≤ x
-  · tauto
-  · have hxb : x ≤ b := (le_of_not_ge hc).trans h₁
-    tauto
+  grind
 
 theorem Iic_union_Icc (h : min c d ≤ b) : Iic b ∪ Icc c d = Iic (max b d) := by
-  rcases le_or_gt c d with hcd | hcd
-  · simp only [hcd, inf_of_le_left] at h; exact Iic_union_Icc' h
-  · simp only [inf_le_iff] at h; rcases h with h | h
-    · have hdb : d ≤ b := hcd.le.trans h
-      simp [*]
-    · simp [*]
+  grind
 
 theorem Iio_subset_Iic_union_Ico : Iio b ⊆ Iic a ∪ Ico a b :=
   Subset.trans Iio_subset_Iic_union_Ioo (union_subset_union_right _ Ioo_subset_Ico_self)
@@ -429,21 +365,11 @@ theorem Ico_union_Ico_eq_Ico (h₁ : a ≤ b) (h₂ : b ≤ c) : Ico a b ∪ Ico
     Ico_subset_Ico_union_Ico
 
 theorem Ico_union_Ico' (h₁ : c ≤ b) (h₂ : a ≤ d) : Ico a b ∪ Ico c d = Ico (min a c) (max b d) := by
-  ext1 x
-  simp_rw [mem_union, mem_Ico, min_le_iff, lt_max_iff]
-  by_cases hc : c ≤ x <;> by_cases hd : x < d
-  · tauto
-  · have hax : a ≤ x := h₂.trans (le_of_not_gt hd)
-    tauto
-  · have hxb : x < b := (lt_of_not_ge hc).trans_le h₁
-    tauto
-  · tauto
+  grind
 
 theorem Ico_union_Ico (h₁ : min a b ≤ max c d) (h₂ : min c d ≤ max a b) :
     Ico a b ∪ Ico c d = Ico (min a c) (max b d) := by
-  rcases le_total a b with hab | hab <;> rcases le_total c d with hcd | hcd <;> simp [*] at h₁ h₂
-  · exact Ico_union_Ico' h₂ h₁
-  all_goals simp [*]
+  grind
 
 theorem Icc_subset_Ico_union_Icc : Icc a c ⊆ Ico a b ∪ Icc b c := fun x hx =>
   (lt_or_ge x b).elim (fun hxb => Or.inl ⟨hx.1, hxb⟩) fun hxb => Or.inr ⟨hxb, hx.2⟩
@@ -502,21 +428,11 @@ theorem Ioc_union_Ioc_eq_Ioc (h₁ : a ≤ b) (h₂ : b ≤ c) : Ioc a b ∪ Ioc
     Ioc_subset_Ioc_union_Ioc
 
 theorem Ioc_union_Ioc' (h₁ : c ≤ b) (h₂ : a ≤ d) : Ioc a b ∪ Ioc c d = Ioc (min a c) (max b d) := by
-  ext1 x
-  simp_rw [mem_union, mem_Ioc, min_lt_iff, le_max_iff]
-  by_cases hc : c < x <;> by_cases hd : x ≤ d
-  · tauto
-  · have hax : a < x := h₂.trans_lt (lt_of_not_ge hd)
-    tauto
-  · have hxb : x ≤ b := (le_of_not_gt hc).trans h₁
-    tauto
-  · tauto
+  grind
 
 theorem Ioc_union_Ioc (h₁ : min a b ≤ max c d) (h₂ : min c d ≤ max a b) :
     Ioc a b ∪ Ioc c d = Ioc (min a c) (max b d) := by
-  rcases le_total a b with hab | hab <;> rcases le_total c d with hcd | hcd <;> simp [*] at h₁ h₂
-  · exact Ioc_union_Ioc' h₂ h₁
-  all_goals simp [*]
+  grind
 
 /-! ### Two finite intervals with a common point -/
 
@@ -549,26 +465,14 @@ theorem Icc_union_Icc_eq_Icc (h₁ : a ≤ b) (h₂ : b ≤ c) : Icc a b ∪ Icc
     Icc_subset_Icc_union_Icc
 
 theorem Icc_union_Icc' (h₁ : c ≤ b) (h₂ : a ≤ d) : Icc a b ∪ Icc c d = Icc (min a c) (max b d) := by
-  ext1 x
-  simp_rw [mem_union, mem_Icc, min_le_iff, le_max_iff]
-  by_cases hc : c ≤ x <;> by_cases hd : x ≤ d
-  · tauto
-  · have hax : a ≤ x := h₂.trans (le_of_not_ge hd)
-    tauto
-  · have hxb : x ≤ b := (le_of_not_ge hc).trans h₁
-    tauto
-  · tauto
+  grind
 
 /-- We cannot replace `<` by `≤` in the hypotheses.
 Otherwise for `b < a = d < c` the l.h.s. is `∅` and the r.h.s. is `{a}`.
 -/
 theorem Icc_union_Icc (h₁ : min a b < max c d) (h₂ : min c d < max a b) :
     Icc a b ∪ Icc c d = Icc (min a c) (max b d) := by
-  rcases le_or_gt a b with hab | hab <;> rcases le_or_gt c d with hcd | hcd <;>
-    simp only [min_eq_left, max_eq_right,
-      min_eq_right_of_lt, max_eq_left_of_lt, hab, hcd] at h₁ h₂
-  · exact Icc_union_Icc' h₂.le h₁.le
-  all_goals simp [*, min_eq_left_of_lt, max_eq_left_of_lt, min_eq_right_of_lt, max_eq_right_of_lt]
+  grind
 
 theorem Ioc_subset_Ioc_union_Icc : Ioc a c ⊆ Ioc a b ∪ Icc b c :=
   Subset.trans Ioc_subset_Ioc_union_Ioc (union_subset_union_right _ Ioc_subset_Icc_self)
@@ -580,24 +484,11 @@ theorem Ioc_union_Icc_eq_Ioc (h₁ : a < b) (h₂ : b ≤ c) : Ioc a b ∪ Icc b
     Ioc_subset_Ioc_union_Icc
 
 theorem Ioo_union_Ioo' (h₁ : c < b) (h₂ : a < d) : Ioo a b ∪ Ioo c d = Ioo (min a c) (max b d) := by
-  ext1 x
-  simp_rw [mem_union, mem_Ioo, min_lt_iff, lt_max_iff]
-  by_cases hc : c < x <;> by_cases hd : x < d
-  · tauto
-  · have hax : a < x := h₂.trans_le (le_of_not_gt hd)
-    tauto
-  · have hxb : x < b := (le_of_not_gt hc).trans_lt h₁
-    tauto
-  · tauto
+  grind
 
 theorem Ioo_union_Ioo (h₁ : min a b < max c d) (h₂ : min c d < max a b) :
     Ioo a b ∪ Ioo c d = Ioo (min a c) (max b d) := by
-  rcases le_total a b with hab | hab <;> rcases le_total c d with hcd | hcd <;>
-    simp only [min_eq_left, min_eq_right, max_eq_left, max_eq_right, hab, hcd] at h₁ h₂
-  · exact Ioo_union_Ioo' h₂ h₁
-  all_goals
-    simp [*,
-      le_of_lt h₂, le_of_lt h₁]
+  grind
 
 theorem Ioo_subset_Ioo_union_Ioo (h₁ : a ≤ a₁) (h₂ : c < b) (h₃ : b₁ ≤ d) :
     Ioo a₁ b₁ ⊆ Ioo a b ∪ Ioo c d := fun x hx =>
@@ -615,95 +506,82 @@ theorem Iio_inter_Iio : Iio a ∩ Iio b = Iio (a ⊓ b) :=
   ext fun _ => lt_inf_iff.symm
 
 theorem Ico_inter_Ico : Ico a₁ b₁ ∩ Ico a₂ b₂ = Ico (a₁ ⊔ a₂) (b₁ ⊓ b₂) := by
-  simp only [Ici_inter_Iio.symm, Ici_inter_Ici.symm, Iio_inter_Iio.symm]; ac_rfl
+  grind
 
 theorem Ioc_inter_Ioc : Ioc a₁ b₁ ∩ Ioc a₂ b₂ = Ioc (a₁ ⊔ a₂) (b₁ ⊓ b₂) := by
-  simp only [Ioi_inter_Iic.symm, Ioi_inter_Ioi.symm, Iic_inter_Iic.symm]; ac_rfl
+  grind
 
 theorem Ioo_inter_Ioo : Ioo a₁ b₁ ∩ Ioo a₂ b₂ = Ioo (a₁ ⊔ a₂) (b₁ ⊓ b₂) := by
-  simp only [Ioi_inter_Iio.symm, Ioi_inter_Ioi.symm, Iio_inter_Iio.symm]; ac_rfl
+  grind
 
 theorem Ioo_inter_Iio : Ioo a b ∩ Iio c = Ioo a (min b c) := by
-  ext
-  simp_rw [mem_inter_iff, mem_Ioo, mem_Iio, lt_min_iff, and_assoc]
+  grind
 
 theorem Iio_inter_Ioo : Iio a ∩ Ioo b c = Ioo b (min a c) := by
-  rw [Set.inter_comm, Set.Ioo_inter_Iio, min_comm]
+  grind
 
 theorem Ioo_inter_Ioi : Ioo a b ∩ Ioi c = Ioo (max a c) b := by
-  ext
-  simp_rw [mem_inter_iff, mem_Ioo, mem_Ioi, max_lt_iff, and_assoc, and_comm]
+  grind
 
 theorem Ioi_inter_Ioo : Set.Ioi a ∩ Set.Ioo b c = Set.Ioo (max a b) c := by
-  rw [inter_comm, Ioo_inter_Ioi, max_comm]
+  grind
 
-theorem Ioc_inter_Ioo_of_left_lt (h : b₁ < b₂) : Ioc a₁ b₁ ∩ Ioo a₂ b₂ = Ioc (max a₁ a₂) b₁ :=
-  ext fun x => by
-    simp [and_assoc, @and_left_comm (x ≤ _), and_iff_left_iff_imp.2 fun h' => lt_of_le_of_lt h' h]
+theorem Ioc_inter_Ioo_of_left_lt (h : b₁ < b₂) : Ioc a₁ b₁ ∩ Ioo a₂ b₂ = Ioc (max a₁ a₂) b₁ := by
+  grind
 
-theorem Ioc_inter_Ioo_of_right_le (h : b₂ ≤ b₁) : Ioc a₁ b₁ ∩ Ioo a₂ b₂ = Ioo (max a₁ a₂) b₂ :=
-  ext fun x => by
-    simp [and_assoc, @and_left_comm (x ≤ _),
-      and_iff_right_iff_imp.2 fun h' => (le_of_lt h').trans h]
+theorem Ioc_inter_Ioo_of_right_le (h : b₂ ≤ b₁) : Ioc a₁ b₁ ∩ Ioo a₂ b₂ = Ioo (max a₁ a₂) b₂ := by
+    grind
 
 theorem Ioo_inter_Ioc_of_left_le (h : b₁ ≤ b₂) : Ioo a₁ b₁ ∩ Ioc a₂ b₂ = Ioo (max a₁ a₂) b₁ := by
-  rw [inter_comm, Ioc_inter_Ioo_of_right_le h, max_comm]
+  grind
 
 theorem Ioo_inter_Ioc_of_right_lt (h : b₂ < b₁) : Ioo a₁ b₁ ∩ Ioc a₂ b₂ = Ioc (max a₁ a₂) b₂ := by
-  rw [inter_comm, Ioc_inter_Ioo_of_left_lt h, max_comm]
+  grind
 
 @[simp]
 theorem Ico_diff_Iio : Ico a b \ Iio c = Ico (max a c) b := by
-  rw [diff_eq, compl_Iio, Ico_inter_Ici]
+  grind
 
 @[simp]
-theorem Ioc_diff_Ioi : Ioc a b \ Ioi c = Ioc a (min b c) :=
-  ext <| by simp +contextual [iff_def]
+theorem Ioc_diff_Ioi : Ioc a b \ Ioi c = Ioc a (min b c) := by
+  grind
 
 @[simp]
 theorem Ioc_inter_Ioi : Ioc a b ∩ Ioi c = Ioc (a ⊔ c) b := by
-  rw [← Ioi_inter_Iic, inter_assoc, inter_comm, inter_assoc, Ioi_inter_Ioi, inter_comm,
-    Ioi_inter_Iic, sup_comm]
+  grind
 
 @[simp]
-theorem Ico_inter_Iio : Ico a b ∩ Iio c = Ico a (min b c) :=
-  ext <| by simp +contextual [iff_def]
+theorem Ico_inter_Iio : Ico a b ∩ Iio c = Ico a (min b c) := by
+  grind
 
 @[simp]
 theorem Ioc_diff_Iic : Ioc a b \ Iic c = Ioc (max a c) b := by
-  rw [diff_eq, compl_Iic, Ioc_inter_Ioi]
+  grind
 
 theorem compl_Ioc : (Ioc a b)ᶜ = Iic a ∪ Ioi b := by
-  ext i
-  rw [mem_compl_iff, mem_Ioc, mem_union, mem_Iic, mem_Ioi, not_and_or, not_lt, not_le]
+  grind
 
 theorem Iic_diff_Ioc : Iic b \ Ioc a b = Iic (a ⊓ b) := by
-  rw [diff_eq, compl_Ioc, inter_union_distrib_left, Iic_inter_Iic, ← compl_Iic, inter_compl_self,
-    union_empty, min_comm]
+  grind
 
 theorem Iic_diff_Ioc_self_of_le (hab : a ≤ b) : Iic b \ Ioc a b = Iic a := by
-  rw [Iic_diff_Ioc, min_eq_left hab]
+  grind
 
 @[simp]
 theorem Ioc_union_Ioc_right : Ioc a b ∪ Ioc a c = Ioc a (max b c) := by
-  rw [Ioc_union_Ioc, min_self] <;> exact (min_le_left _ _).trans (le_max_left _ _)
+  grind
 
 @[simp]
 theorem Ioc_union_Ioc_left : Ioc a c ∪ Ioc b c = Ioc (min a b) c := by
-  rw [Ioc_union_Ioc, max_self] <;> exact (min_le_right _ _).trans (le_max_right _ _)
+  grind
 
 @[simp]
 theorem Ioc_union_Ioc_symm : Ioc a b ∪ Ioc b a = Ioc (min a b) (max a b) := by
-  rw [max_comm]
-  apply Ioc_union_Ioc <;> rw [max_comm] <;> exact min_le_max
+  grind
 
 @[simp]
 theorem Ioc_union_Ioc_union_Ioc_cycle :
     Ioc a b ∪ Ioc b c ∪ Ioc c a = Ioc (min a (min b c)) (max a (max b c)) := by
-  rw [Ioc_union_Ioc, Ioc_union_Ioc]
-  · ac_rfl
-  all_goals
-  solve_by_elim (maxDepth := 5) [min_le_of_left_le, min_le_of_right_le,
-    le_max_of_le_left, le_max_of_le_right, le_refl]
+  grind
 
 end Set
```
```
ℹ [363/363] Built Mathlib.Order.Interval.Set.LinearOrder (1.4s)
info: Mathlib/Order/Interval/Set/LinearOrder.lean:226:0: [Elab.async] [0.024113] elaborating proof of Set.Ico_union_Ici'
  [Elab.definition.value] [0.023804] Set.Ico_union_Ici'
    [Elab.step] [0.023695] grind
      [Elab.step] [0.023688] grind
        [Elab.step] [0.023680] grind
Build completed successfully (363 jobs).
```
</details>

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

When merging, all the commits will be squashed into a single commit
listing all co-authors.

Co-authors in the squash commit are gathered from two sources:

First, all authors of commits to this PR branch are included. Thus,
one way to add co-authors is to include at least one commit authored by
each co-author among the commits in the pull request. If necessary, you
may create empty commits to indicate co-authorship, using commands like so:

git commit --author="Author Name <author@email.com>" --allow-empty -m "add Author Name as coauthor"

Second, co-authors can also be listed in lines at the very bottom of
the commit message (that is, directly before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines
at the bottom of the commit message (before the `---`, and also before
any "Co-authored-by" lines) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
