### PR TITLE
[Merged by Bors] - feat(Probability/Independence): reindexing lemmas for `iIndep*`

### DIFF
--- a/Mathlib/Probability/Independence/Basic.lean
+++ b/Mathlib/Probability/Independence/Basic.lean
@@ -283,55 +283,41 @@ lemma IndepFun.meas_inter [mβ : MeasurableSpace β] [mγ : MeasurableSpace γ] 
     μ (s ∩ t) = μ s * μ t :=
   (IndepFun_iff _ _ _).1 hfg _ _ hs ht
 
-lemma iIndepSets.comp_of_injective (hg : Function.Injective g) (h : iIndepSets π μ) :
+lemma iIndepSets.precomp (hg : Function.Injective g) (h : iIndepSets π μ) :
     iIndepSets (π ∘ g) μ :=
-  Kernel.iIndepSets.comp_of_injective hg h
+  Kernel.iIndepSets.precomp hg h
 
-lemma iIndepSets.of_comp_of_surjective (hg : Function.Surjective g) (h : iIndepSets (π ∘ g) μ) :
+lemma iIndepSets.of_precomp (hg : Function.Surjective g) (h : iIndepSets (π ∘ g) μ) :
     iIndepSets π μ :=
-  Kernel.iIndepSets.of_comp_of_surjective hg h
+  Kernel.iIndepSets.of_precomp hg h
 
-lemma iIndepSets.comp_iff (hg : Function.Bijective g) :
+lemma iIndepSets_precomp_of_bijective (hg : Function.Bijective g) :
     iIndepSets (π ∘ g) μ ↔ iIndepSets π μ :=
-  Kernel.iIndepSets.comp_iff hg
+  Kernel.iIndepSets_precomp_of_bijective hg
 
-lemma iIndep.comp_of_injective (hg : Function.Injective g) (h : iIndep m μ) :
+lemma iIndep.precomp (hg : Function.Injective g) (h : iIndep m μ) :
     iIndep (m ∘ g) μ :=
-  Kernel.iIndep.comp_of_injective hg h
+  Kernel.iIndep.precomp hg h
 
-lemma iIndep.of_comp_of_surjective (hg : Function.Surjective g) (h : iIndep (m ∘ g) μ) :
+lemma iIndep.of_precomp (hg : Function.Surjective g) (h : iIndep (m ∘ g) μ) :
     iIndep m μ :=
-  Kernel.iIndep.of_comp_of_surjective hg h
+  Kernel.iIndep.of_precomp hg h
 
-lemma iIndep.comp_iff (hg : Function.Bijective g) :
+lemma iIndep_precomp_of_bijective (hg : Function.Bijective g) :
     iIndep (m ∘ g) μ ↔ iIndep m μ :=
-  Kernel.iIndep.comp_iff hg
+  Kernel.iIndep_precomp_of_bijective hg
 
-lemma iIndepSet.comp_of_injective (hg : Function.Injective g) (h : iIndepSet s μ) :
+lemma iIndepSet.precomp (hg : Function.Injective g) (h : iIndepSet s μ) :
     iIndepSet (s ∘ g) μ :=
-  Kernel.iIndepSet.comp_of_injective hg h
+  Kernel.iIndepSet.precomp hg h
 
-lemma iIndepSet.of_comp_of_surjective (hg : Function.Surjective g) (h : iIndepSet (s ∘ g) μ) :
+lemma iIndepSet.of_precomp (hg : Function.Surjective g) (h : iIndepSet (s ∘ g) μ) :
     iIndepSet s μ :=
-  Kernel.iIndepSet.of_comp_of_surjective hg h
+  Kernel.iIndepSet.of_precomp hg h
 
-lemma iIndepSet.comp_iff (hg : Function.Bijective g) :
+lemma iIndepSet_precomp_of_bijective (hg : Function.Bijective g) :
     iIndepSet (s ∘ g) μ ↔ iIndepSet s μ :=
-  Kernel.iIndepSet.comp_iff hg
-
-variable {β : ι → Type*} {mβ : ∀ i, MeasurableSpace (β i)} {f : ∀ x : ι, Ω → β x}
-
-lemma iIndepFun.comp_of_injective (hg : Function.Injective g) (h : iIndepFun f μ) :
-    iIndepFun (f ∘' g) μ :=
-  Kernel.iIndepFun.comp_of_injective hg h
-
-lemma iIndepFun.of_comp_of_surjective (hg : Function.Surjective g) (h : iIndepFun (f ∘' g) μ) :
-    iIndepFun f μ :=
-  Kernel.iIndepFun.of_comp_of_surjective hg h
-
-lemma iIndepFun.comp_iff (hg : Function.Bijective g) :
-    iIndepFun (f ∘' g) μ ↔ iIndepFun f μ :=
-  Kernel.iIndepFun.comp_iff hg
+  Kernel.iIndepSet_precomp_of_bijective hg
 
 end Definition_lemmas
 
@@ -870,15 +856,9 @@ lemma iIndepFun.indepFun_prodMk_prodMk₀ (h_indep : iIndepFun f μ) (hf : ∀ i
 
 variable {ι' : Type*} {α : ι → Type*} [∀ i, MeasurableSpace (α i)]
 
-open Function in
 lemma iIndepFun.precomp {g : ι' → ι} (hg : g.Injective) (h : iIndepFun f μ) :
-    iIndepFun (m := fun i ↦ m (g i)) (fun i ↦ f (g i)) μ := by
-  have : IsProbabilityMeasure μ := h.isProbabilityMeasure
-  nontriviality ι'
-  have A (x) : Function.invFun g (g x) = x := Function.leftInverse_invFun hg x
-  rw [iIndepFun_iff] at h ⊢
-  intro t s' hs'
-  simpa [A] using h (t.map ⟨g, hg⟩) (f' := fun i ↦ s' (invFun g i)) (by simpa [A] using hs')
+    iIndepFun (m := fun i ↦ m (g i)) (fun i ↦ f (g i)) μ :=
+  Kernel.iIndepFun.precomp hg h
 
 lemma iIndepFun_iff_finset : iIndepFun f μ ↔ ∀ s : Finset ι, iIndepFun (s.restrict f) μ where
   mp h s := h.precomp (g := ((↑) : s → ι)) Subtype.val_injective
@@ -890,28 +870,12 @@ lemma iIndepFun_iff_finset : iIndepFun f μ ↔ ∀ s : Finset ι, iIndepFun (s.
     exact (h s).meas_iInter fun i ↦ hs i i.2
 
 lemma iIndepFun.of_precomp {g : ι' → ι} (hg : g.Surjective)
-    (h : iIndepFun (m := fun i ↦ m (g i)) (fun i ↦ f (g i)) μ) : iIndepFun f μ := by
-  have : IsProbabilityMeasure μ := h.isProbabilityMeasure
-  nontriviality ι
-  have := hg.nontrivial
-  classical
-  rw [iIndepFun_iff] at h ⊢
-  intro t s hs
-  have A (x) : g (Function.invFun g x) = x := Function.rightInverse_invFun hg x
-  have : ∀ i ∈ Finset.image (Function.invFun g) t,
-    @MeasurableSet _ (MeasurableSpace.comap (f <| g i) (m <| g i)) (s <| g i) := by
-    intro i hi
-    obtain ⟨j, hj, rfl⟩ := Finset.mem_image.mp hi
-    simpa [A] using (A j).symm ▸ hs j hj
-  have eq : ∏ i ∈ Finset.image (Function.invFun g) t, μ (s (g i)) = ∏ i ∈ t, μ (s i) := by
-    rw [Finset.prod_image (fun x hx y hy h => ?_), Finset.prod_congr rfl (fun x _ => by rw [A])]
-    rw [← A x, ← A y, h]
-  simpa [A, eq] using h (t.image (Function.invFun g)) (f' := fun i ↦ s (g i)) this
+    (h : iIndepFun (m := fun i ↦ m (g i)) (fun i ↦ f (g i)) μ) : iIndepFun f μ :=
+  Kernel.iIndepFun.of_precomp hg h
 
 lemma iIndepFun_precomp_of_bijective {g : ι' → ι} (hg : g.Bijective) :
-    iIndepFun (m := fun i ↦ m (g i)) (fun i ↦ f (g i)) μ ↔ iIndepFun f μ where
-  mp := .of_precomp hg.surjective
-  mpr := .precomp hg.injective
+    iIndepFun (m := fun i ↦ m (g i)) (fun i ↦ f (g i)) μ ↔ iIndepFun f μ :=
+  Kernel.iIndepFun_precomp_of_bijective hg
 
 end iIndepFun
 

--- a/Mathlib/Probability/Independence/Basic.lean
+++ b/Mathlib/Probability/Independence/Basic.lean
@@ -155,7 +155,7 @@ scoped[ProbabilityTheory] notation3 X:50 " ⟂ᵢ " Y:50 => ProbabilityTheory.In
 
 section Definition_lemmas
 variable {π : ι → Set (Set Ω)} {m : ι → MeasurableSpace Ω} {_ : MeasurableSpace Ω} {μ : Measure Ω}
-  {S : Finset ι} {s : ι → Set Ω}
+  {S : Finset ι} {s : ι → Set Ω} {ι' : Type*} {g : ι' → ι}
 
 lemma iIndepSets_iff (π : ι → Set (Set Ω)) (μ : Measure Ω) :
     iIndepSets π μ ↔ ∀ (s : Finset ι) {f : ι → Set Ω} (_H : ∀ i, i ∈ s → f i ∈ π i),
@@ -282,6 +282,56 @@ lemma IndepFun.meas_inter [mβ : MeasurableSpace β] [mγ : MeasurableSpace γ] 
     (ht : MeasurableSet[mγ.comap g] t) :
     μ (s ∩ t) = μ s * μ t :=
   (IndepFun_iff _ _ _).1 hfg _ _ hs ht
+
+lemma iIndepSets.comp_of_injective (hg : Function.Injective g) (h : iIndepSets π μ) :
+    iIndepSets (π ∘ g) μ :=
+  Kernel.iIndepSets.comp_of_injective hg h
+
+lemma iIndepSets.of_comp_of_surjective (hg : Function.Surjective g) (h : iIndepSets (π ∘ g) μ) :
+    iIndepSets π μ :=
+  Kernel.iIndepSets.of_comp_of_surjective hg h
+
+lemma iIndepSets.comp_iff (hg : Function.Bijective g) :
+    iIndepSets (π ∘ g) μ ↔ iIndepSets π μ :=
+  Kernel.iIndepSets.comp_iff hg
+
+lemma iIndep.comp_of_injective (hg : Function.Injective g) (h : iIndep m μ) :
+    iIndep (m ∘ g) μ :=
+  Kernel.iIndep.comp_of_injective hg h
+
+lemma iIndep.of_comp_of_surjective (hg : Function.Surjective g) (h : iIndep (m ∘ g) μ) :
+    iIndep m μ :=
+  Kernel.iIndep.of_comp_of_surjective hg h
+
+lemma iIndep.comp_iff (hg : Function.Bijective g) :
+    iIndep (m ∘ g) μ ↔ iIndep m μ :=
+  Kernel.iIndep.comp_iff hg
+
+lemma iIndepSet.comp_of_injective (hg : Function.Injective g) (h : iIndepSet s μ) :
+    iIndepSet (s ∘ g) μ :=
+  Kernel.iIndepSet.comp_of_injective hg h
+
+lemma iIndepSet.of_comp_of_surjective (hg : Function.Surjective g) (h : iIndepSet (s ∘ g) μ) :
+    iIndepSet s μ :=
+  Kernel.iIndepSet.of_comp_of_surjective hg h
+
+lemma iIndepSet.comp_iff (hg : Function.Bijective g) :
+    iIndepSet (s ∘ g) μ ↔ iIndepSet s μ :=
+  Kernel.iIndepSet.comp_iff hg
+
+variable {β : ι → Type*} {mβ : ∀ i, MeasurableSpace (β i)} {f : ∀ x : ι, Ω → β x}
+
+lemma iIndepFun.comp_of_injective (hg : Function.Injective g) (h : iIndepFun f μ) :
+    iIndepFun (f ∘' g) μ :=
+  Kernel.iIndepFun.comp_of_injective hg h
+
+lemma iIndepFun.of_comp_of_surjective (hg : Function.Surjective g) (h : iIndepFun (f ∘' g) μ) :
+    iIndepFun f μ :=
+  Kernel.iIndepFun.of_comp_of_surjective hg h
+
+lemma iIndepFun.comp_iff (hg : Function.Bijective g) :
+    iIndepFun (f ∘' g) μ ↔ iIndepFun f μ :=
+  Kernel.iIndepFun.comp_iff hg
 
 end Definition_lemmas
 

--- a/Mathlib/Probability/Independence/Basic.lean
+++ b/Mathlib/Probability/Independence/Basic.lean
@@ -319,6 +319,20 @@ lemma iIndepSet_precomp_of_bijective (hg : Function.Bijective g) :
     iIndepSet (s ∘ g) μ ↔ iIndepSet s μ :=
   Kernel.iIndepSet_precomp_of_bijective hg
 
+variable {β : ι → Type*} {m : ∀ i, MeasurableSpace (β i)} {f : ∀ i, Ω → β i}
+
+lemma iIndepFun.precomp (hg : g.Injective) (h : iIndepFun f μ) :
+    iIndepFun (m := fun i ↦ m (g i)) (fun i ↦ f (g i)) μ :=
+  Kernel.iIndepFun.precomp hg h
+
+lemma iIndepFun.of_precomp (hg : g.Surjective)
+    (h : iIndepFun (m := fun i ↦ m (g i)) (fun i ↦ f (g i)) μ) : iIndepFun f μ :=
+  Kernel.iIndepFun.of_precomp hg h
+
+lemma iIndepFun_precomp_of_bijective (hg : g.Bijective) :
+    iIndepFun (m := fun i ↦ m (g i)) (fun i ↦ f (g i)) μ ↔ iIndepFun f μ :=
+  Kernel.iIndepFun_precomp_of_bijective hg
+
 end Definition_lemmas
 
 section Indep
@@ -854,12 +868,6 @@ lemma iIndepFun.indepFun_prodMk_prodMk₀ (h_indep : iIndepFun f μ) (hf : ∀ i
     IndepFun (fun a ↦ (f i a, f j a)) (fun a ↦ (f k a, f l a)) μ :=
   Kernel.iIndepFun.indepFun_prodMk_prodMk₀ h_indep (by simp [hf]) i j k l hik hil hjk hjl
 
-variable {ι' : Type*} {α : ι → Type*} [∀ i, MeasurableSpace (α i)]
-
-lemma iIndepFun.precomp {g : ι' → ι} (hg : g.Injective) (h : iIndepFun f μ) :
-    iIndepFun (m := fun i ↦ m (g i)) (fun i ↦ f (g i)) μ :=
-  Kernel.iIndepFun.precomp hg h
-
 lemma iIndepFun_iff_finset : iIndepFun f μ ↔ ∀ s : Finset ι, iIndepFun (s.restrict f) μ where
   mp h s := h.precomp (g := ((↑) : s → ι)) Subtype.val_injective
   mpr h := by
@@ -868,14 +876,6 @@ lemma iIndepFun_iff_finset : iIndepFun f μ ↔ ∀ s : Finset ι, iIndepFun (s.
     have : ⋂ i ∈ s, f i = ⋂ i : s, f i := by ext; simp
     rw [← Finset.prod_coe_sort, this]
     exact (h s).meas_iInter fun i ↦ hs i i.2
-
-lemma iIndepFun.of_precomp {g : ι' → ι} (hg : g.Surjective)
-    (h : iIndepFun (m := fun i ↦ m (g i)) (fun i ↦ f (g i)) μ) : iIndepFun f μ :=
-  Kernel.iIndepFun.of_precomp hg h
-
-lemma iIndepFun_precomp_of_bijective {g : ι' → ι} (hg : g.Bijective) :
-    iIndepFun (m := fun i ↦ m (g i)) (fun i ↦ f (g i)) μ ↔ iIndepFun f μ :=
-  Kernel.iIndepFun_precomp_of_bijective hg
 
 end iIndepFun
 

--- a/Mathlib/Probability/Independence/Kernel.lean
+++ b/Mathlib/Probability/Independence/Kernel.lean
@@ -283,8 +283,7 @@ lemma iIndepSets.precomp (hg : Function.Injective g) (h : iIndepSets π κ μ) :
     simp_rw [Finset.forall_mem_image, f'_apply]
     exact hf
   filter_upwards [@h (s.image g) f' hf'] with a ha
-  simp_rw [Finset.set_biInter_finset_image, Finset.prod_image hg.injOn, f'_apply] at ha
-  exact ha
+  simpa [Finset.set_biInter_finset_image, Finset.prod_image hg.injOn, f'_apply] using ha
 
 lemma iIndepSets.of_precomp (hg : Function.Surjective g) (h : iIndepSets (π ∘ g) κ μ) :
     iIndepSets π κ μ := by

--- a/Mathlib/Probability/Independence/Kernel.lean
+++ b/Mathlib/Probability/Independence/Kernel.lean
@@ -127,7 +127,7 @@ variable {β : ι → Type*} {mβ : ∀ i, MeasurableSpace (β i)}
   {_mα : MeasurableSpace α} {m : ι → MeasurableSpace Ω} {_mΩ : MeasurableSpace Ω}
   {κ η : Kernel α Ω} {μ : Measure α}
   {π : ι → Set (Set Ω)} {s : ι → Set Ω} {S : Finset ι} {f : ∀ x : ι, Ω → β x}
-  {s1 s2 : Set (Set Ω)}
+  {s1 s2 : Set (Set Ω)} {ι' : Type*} {g : ι' → ι}
 
 @[simp] lemma iIndepSets_zero_right : iIndepSets π κ 0 := by simp [iIndepSets]
 
@@ -272,6 +272,65 @@ lemma IndepFun.meas_inter {β γ : Type*} [mβ : MeasurableSpace β] [mγ : Meas
     {f : Ω → β} {g : Ω → γ} (hfg : IndepFun f g κ μ)
     {s t : Set Ω} (hs : MeasurableSet[mβ.comap f] s) (ht : MeasurableSet[mγ.comap g] t) :
     ∀ᵐ a ∂μ, κ a (s ∩ t) = κ a s * κ a t := hfg _ _ hs ht
+
+lemma iIndepSets.comp_of_injective (hg : Function.Injective g) (h : iIndepSets π κ μ) :
+    iIndepSets (π ∘ g) κ μ := by
+  intro s f hf
+  let f' := Function.extend g f fun _ => ∅
+  have f'_apply x : f' (g x) = f x := hg.extend_apply ..
+  classical
+  have hf' : ∀ i ∈ s.image g, f' i ∈ π i := by
+    simp_rw [Finset.forall_mem_image, f'_apply]
+    exact hf
+  filter_upwards [@h (s.image g) f' hf'] with a ha
+  simp_rw [Finset.set_biInter_finset_image, Finset.prod_image hg.injOn, f'_apply] at ha
+  exact ha
+
+lemma iIndepSets.of_comp_of_surjective (hg : Function.Surjective g) (h : iIndepSets (π ∘ g) κ μ) :
+    iIndepSets π κ μ := by
+  obtain ⟨g', hg'⟩ := hg.hasRightInverse
+  convert h.comp_of_injective hg'.injective
+  rw [Function.comp_assoc, hg'.comp_eq_id, Function.comp_id]
+
+lemma iIndepSets.comp_iff (hg : Function.Bijective g) :
+    iIndepSets (π ∘ g) κ μ ↔ iIndepSets π κ μ :=
+  ⟨.of_comp_of_surjective hg.surjective, .comp_of_injective hg.injective⟩
+
+lemma iIndep.comp_of_injective (hg : Function.Injective g) (h : iIndep m κ μ) :
+    iIndep (m ∘ g) κ μ :=
+  (iIndepSets.comp_of_injective hg h :)
+
+lemma iIndep.of_comp_of_surjective (hg : Function.Surjective g) (h : iIndep (m ∘ g) κ μ) :
+    iIndep m κ μ :=
+  iIndepSets.of_comp_of_surjective hg h
+
+lemma iIndep.comp_iff (hg : Function.Bijective g) :
+    iIndep (m ∘ g) κ μ ↔ iIndep m κ μ :=
+  ⟨.of_comp_of_surjective hg.surjective, .comp_of_injective hg.injective⟩
+
+lemma iIndepSet.comp_of_injective (hg : Function.Injective g) (h : iIndepSet s κ μ) :
+    iIndepSet (s ∘ g) κ μ :=
+  iIndep.comp_of_injective hg h
+
+lemma iIndepSet.of_comp_of_surjective (hg : Function.Surjective g) (h : iIndepSet (s ∘ g) κ μ) :
+    iIndepSet s κ μ :=
+  iIndep.of_comp_of_surjective hg h
+
+lemma iIndepSet.comp_iff (hg : Function.Bijective g) :
+    iIndepSet (s ∘ g) κ μ ↔ iIndepSet s κ μ :=
+  ⟨.of_comp_of_surjective hg.surjective, .comp_of_injective hg.injective⟩
+
+lemma iIndepFun.comp_of_injective (hg : Function.Injective g) (h : iIndepFun f κ μ) :
+    iIndepFun (f ∘' g) κ μ :=
+  iIndep.comp_of_injective hg h
+
+lemma iIndepFun.of_comp_of_surjective (hg : Function.Surjective g) (h : iIndepFun (f ∘' g) κ μ) :
+    iIndepFun f κ μ :=
+  iIndep.of_comp_of_surjective hg h
+
+lemma iIndepFun.comp_iff (hg : Function.Bijective g) :
+    iIndepFun (f ∘' g) κ μ ↔ iIndepFun f κ μ :=
+  ⟨.of_comp_of_surjective hg.surjective, .comp_of_injective hg.injective⟩
 
 end ByDefinition
 
@@ -1482,3 +1541,5 @@ lemma iIndepFun.cond_iInter [Finite ι] (hY : ∀ i, Measurable (Y i))
 -- for kernels
 
 end ProbabilityTheory.Kernel
+
+set_option linter.style.longFile 1700

--- a/Mathlib/Probability/Independence/Kernel.lean
+++ b/Mathlib/Probability/Independence/Kernel.lean
@@ -273,7 +273,7 @@ lemma IndepFun.meas_inter {β γ : Type*} [mβ : MeasurableSpace β] [mγ : Meas
     {s t : Set Ω} (hs : MeasurableSet[mβ.comap f] s) (ht : MeasurableSet[mγ.comap g] t) :
     ∀ᵐ a ∂μ, κ a (s ∩ t) = κ a s * κ a t := hfg _ _ hs ht
 
-lemma iIndepSets.comp_of_injective (hg : Function.Injective g) (h : iIndepSets π κ μ) :
+lemma iIndepSets.precomp (hg : Function.Injective g) (h : iIndepSets π κ μ) :
     iIndepSets (π ∘ g) κ μ := by
   intro s f hf
   let f' := Function.extend g f fun _ => ∅
@@ -286,51 +286,51 @@ lemma iIndepSets.comp_of_injective (hg : Function.Injective g) (h : iIndepSets �
   simp_rw [Finset.set_biInter_finset_image, Finset.prod_image hg.injOn, f'_apply] at ha
   exact ha
 
-lemma iIndepSets.of_comp_of_surjective (hg : Function.Surjective g) (h : iIndepSets (π ∘ g) κ μ) :
+lemma iIndepSets.of_precomp (hg : Function.Surjective g) (h : iIndepSets (π ∘ g) κ μ) :
     iIndepSets π κ μ := by
   obtain ⟨g', hg'⟩ := hg.hasRightInverse
-  convert h.comp_of_injective hg'.injective
+  convert h.precomp hg'.injective
   rw [Function.comp_assoc, hg'.comp_eq_id, Function.comp_id]
 
-lemma iIndepSets.comp_iff (hg : Function.Bijective g) :
+lemma iIndepSets_precomp_of_bijective (hg : Function.Bijective g) :
     iIndepSets (π ∘ g) κ μ ↔ iIndepSets π κ μ :=
-  ⟨.of_comp_of_surjective hg.surjective, .comp_of_injective hg.injective⟩
+  ⟨.of_precomp hg.surjective, .precomp hg.injective⟩
 
-lemma iIndep.comp_of_injective (hg : Function.Injective g) (h : iIndep m κ μ) :
+lemma iIndep.precomp (hg : Function.Injective g) (h : iIndep m κ μ) :
     iIndep (m ∘ g) κ μ :=
-  (iIndepSets.comp_of_injective hg h :)
+  (iIndepSets.precomp hg h :)
 
-lemma iIndep.of_comp_of_surjective (hg : Function.Surjective g) (h : iIndep (m ∘ g) κ μ) :
+lemma iIndep.of_precomp (hg : Function.Surjective g) (h : iIndep (m ∘ g) κ μ) :
     iIndep m κ μ :=
-  iIndepSets.of_comp_of_surjective hg h
+  iIndepSets.of_precomp hg h
 
-lemma iIndep.comp_iff (hg : Function.Bijective g) :
+lemma iIndep_precomp_of_bijective (hg : Function.Bijective g) :
     iIndep (m ∘ g) κ μ ↔ iIndep m κ μ :=
-  ⟨.of_comp_of_surjective hg.surjective, .comp_of_injective hg.injective⟩
+  ⟨.of_precomp hg.surjective, .precomp hg.injective⟩
 
-lemma iIndepSet.comp_of_injective (hg : Function.Injective g) (h : iIndepSet s κ μ) :
+lemma iIndepSet.precomp (hg : Function.Injective g) (h : iIndepSet s κ μ) :
     iIndepSet (s ∘ g) κ μ :=
-  iIndep.comp_of_injective hg h
+  iIndep.precomp hg h
 
-lemma iIndepSet.of_comp_of_surjective (hg : Function.Surjective g) (h : iIndepSet (s ∘ g) κ μ) :
+lemma iIndepSet.of_precomp (hg : Function.Surjective g) (h : iIndepSet (s ∘ g) κ μ) :
     iIndepSet s κ μ :=
-  iIndep.of_comp_of_surjective hg h
+  iIndep.of_precomp hg h
 
-lemma iIndepSet.comp_iff (hg : Function.Bijective g) :
+lemma iIndepSet_precomp_of_bijective (hg : Function.Bijective g) :
     iIndepSet (s ∘ g) κ μ ↔ iIndepSet s κ μ :=
-  ⟨.of_comp_of_surjective hg.surjective, .comp_of_injective hg.injective⟩
+  ⟨.of_precomp hg.surjective, .precomp hg.injective⟩
 
-lemma iIndepFun.comp_of_injective (hg : Function.Injective g) (h : iIndepFun f κ μ) :
-    iIndepFun (f ∘' g) κ μ :=
-  iIndep.comp_of_injective hg h
+lemma iIndepFun.precomp (hg : Function.Injective g) (h : iIndepFun f κ μ) :
+    iIndepFun (fun i ↦ f (g i)) κ μ :=
+  iIndep.precomp hg h
 
-lemma iIndepFun.of_comp_of_surjective (hg : Function.Surjective g) (h : iIndepFun (f ∘' g) κ μ) :
+lemma iIndepFun.of_precomp (hg : Function.Surjective g) (h : iIndepFun (fun i ↦ f (g i)) κ μ) :
     iIndepFun f κ μ :=
-  iIndep.of_comp_of_surjective hg h
+  iIndep.of_precomp hg h
 
-lemma iIndepFun.comp_iff (hg : Function.Bijective g) :
-    iIndepFun (f ∘' g) κ μ ↔ iIndepFun f κ μ :=
-  ⟨.of_comp_of_surjective hg.surjective, .comp_of_injective hg.injective⟩
+lemma iIndepFun_precomp_of_bijective (hg : Function.Bijective g) :
+    iIndepFun (fun i ↦ f (g i)) κ μ ↔ iIndepFun f κ μ :=
+  ⟨.of_precomp hg.surjective, .precomp hg.injective⟩
 
 end ByDefinition
 


### PR DESCRIPTION
---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

When merging, all the commits will be squashed into a single commit
listing all co-authors.

Co-authors in the squash commit are gathered from two sources:

First, all authors of commits to this PR branch are included. Thus,
one way to add co-authors is to include at least one commit authored by
each co-author among the commits in the pull request. If necessary, you
may create empty commits to indicate co-authorship, using commands like so:

git commit --author="Author Name <author@email.com>" --allow-empty -m "add Author Name as coauthor"

Second, co-authors can also be listed in lines at the very bottom of
the commit message (that is, directly before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines
at the bottom of the commit message (before the `---`, and also before
any "Co-authored-by" lines) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
