### PR TITLE
[Merged by Bors] - ci: fix concurrency for pull request builds

### DIFF
--- a/.github/build.in.yml
+++ b/.github/build.in.yml
@@ -45,15 +45,13 @@ jobs:
         shell: landrun --rox /usr --ro /etc/timezone --rw /dev --rox /home/lean/.elan --rox /home/lean/actions-runner/_work --rox /home/lean/.cache/mathlib/ --rw pr-branch/.lake/ --env PATH --env HOME --env GITHUB_OUTPUT --env CI -- bash -euxo pipefail {0}
     steps:
       - name: print job info
-        env:
-          CONCURRENCY_GROUP: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}-${{ (github.event_name == 'push' && contains(fromJSON('["refs/heads/master", "refs/heads/staging"]'), github.ref) && github.run_id) || '' }}
         run: |
           echo "workflow: ${{ github.workflow }}"
           echo "pull request number: ${{ github.event.pull_request.number }}"
           echo "github ref: ${{ github.ref }}"
           echo "github event_name: ${{ github.event_name }}"
           echo "github run id: ${{ github.run_id }}"
-          echo "concurrency group: $CONCURRENCY_GROUP"
+          echo "concurrency group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}-${{ (github.event_name == 'push' && contains(fromJSON('["refs/heads/master", "refs/heads/staging"]'), github.ref) && github.run_id) || '' }}"
       - name: cleanup
         shell: bash    # This *just* deletes old files, so is safe to run outside landrun.
         run: |

--- a/.github/build.in.yml
+++ b/.github/build.in.yml
@@ -46,12 +46,12 @@ jobs:
     steps:
       - name: print job info
         run: |
-          echo "workflow: ${{ github.workflow }}"
-          echo "pull request number: ${{ github.event.pull_request.number }}"
-          echo "github ref: ${{ github.ref }}"
-          echo "github event_name: ${{ github.event_name }}"
-          echo "github run id: ${{ github.run_id }}"
-          echo "concurrency group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}-${{ (github.event_name == 'push' && contains(fromJSON('["refs/heads/master", "refs/heads/staging"]'), github.ref) && github.run_id) || '' }}"
+          echo 'workflow: ${{ github.workflow }}'
+          echo 'pull request number: ${{ github.event.pull_request.number }}'
+          echo 'github ref: ${{ github.ref }}'
+          echo 'github event_name: ${{ github.event_name }}'
+          echo 'github run id: ${{ github.run_id }}'
+          echo 'concurrency group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}-${{ (github.event_name == 'push' && contains(fromJSON('["refs/heads/master", "refs/heads/staging"]'), github.ref) && github.run_id) || '' }}'
       - name: cleanup
         shell: bash    # This *just* deletes old files, so is safe to run outside landrun.
         run: |

--- a/.github/build.in.yml
+++ b/.github/build.in.yml
@@ -44,17 +44,17 @@ jobs:
       run:
         shell: landrun --rox /usr --ro /etc/timezone --rw /dev --rox /home/lean/.elan --rox /home/lean/actions-runner/_work --rox /home/lean/.cache/mathlib/ --rw pr-branch/.lake/ --env PATH --env HOME --env GITHUB_OUTPUT --env CI -- bash -euxo pipefail {0}
     steps:
-      - name: print job info
+      - name: job info
+        env:
+          WORKFLOW: ${{ github.workflow }}
+          PR_NUMBER: ${{ github.event.pull_request.number }}
+          REF: ${{ github.ref }}
+          EVENT_NAME: ${{ github.event_name }}
+          RUN_ID: ${{ github.run_id }}
+          CONCURRENCY_GROUP: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}-${{ (github.event_name == 'push' && contains(fromJSON('["refs/heads/master", "refs/heads/staging"]'), github.ref) && github.run_id) || '' }}
         run: |
-          # We don't want any substitution here
-          # (after GitHub does its thing with its expressions),
-          # so I'm using single quotes here.
-          echo 'workflow: ${{ github.workflow }}'
-          echo 'pull request number: ${{ github.event.pull_request.number }}'
-          echo 'github ref: ${{ github.ref }}'
-          echo 'github event_name: ${{ github.event_name }}'
-          echo 'github run id: ${{ github.run_id }}'
-          echo 'concurrency group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}-${{ (github.event_name == 'push' && contains(fromJSON('["refs/heads/master", "refs/heads/staging"]'), github.ref) && github.run_id) || '' }}'
+          # We can view these values in the logs under the step environment variables
+          # landrun doesn't see env variables anyways
       - name: cleanup
         shell: bash    # This *just* deletes old files, so is safe to run outside landrun.
         run: |

--- a/.github/build.in.yml
+++ b/.github/build.in.yml
@@ -15,7 +15,7 @@ env:
 concurrency:
   # label each workflow run; only the latest with each label will run
   # workflows on master get more expressive labels
-  group: ${{ github.workflow }}-${{ github.ref }}-${{ (contains(fromJSON('["refs/heads/master", "refs/heads/staging"]'), github.ref) && github.run_id) || '' }}
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}-${{ (github.event_name == 'push' && contains(fromJSON('["refs/heads/master", "refs/heads/staging"]'), github.ref) && github.run_id) || '' }}
   # cancel any running workflow with the same label
   cancel-in-progress: true
 
@@ -44,6 +44,16 @@ jobs:
       run:
         shell: landrun --rox /usr --ro /etc/timezone --rw /dev --rox /home/lean/.elan --rox /home/lean/actions-runner/_work --rox /home/lean/.cache/mathlib/ --rw pr-branch/.lake/ --env PATH --env HOME --env GITHUB_OUTPUT --env CI -- bash -euxo pipefail {0}
     steps:
+      - name: print job info
+        env:
+          CONCURRENCY_GROUP: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}-${{ (github.event_name == 'push' && contains(fromJSON('["refs/heads/master", "refs/heads/staging"]'), github.ref) && github.run_id) || '' }}
+        run: |
+          echo "workflow: ${{ github.workflow }}"
+          echo "pull request number: ${{ github.event.pull_request.number }}"
+          echo "github ref: ${{ github.ref }}"
+          echo "github event_name: ${{ github.event_name }}"
+          echo "github run id: ${{ github.run_id }}"
+          echo "concurrency group: $CONCURRENCY_GROUP"
       - name: cleanup
         shell: bash    # This *just* deletes old files, so is safe to run outside landrun.
         run: |

--- a/.github/build.in.yml
+++ b/.github/build.in.yml
@@ -46,6 +46,9 @@ jobs:
     steps:
       - name: print job info
         run: |
+          # We don't want any substitution here
+          # (after GitHub does its thing with its expressions),
+          # so I'm using single quotes here.
           echo 'workflow: ${{ github.workflow }}'
           echo 'pull request number: ${{ github.event.pull_request.number }}'
           echo 'github ref: ${{ github.ref }}'

--- a/.github/workflows/bors.yml
+++ b/.github/workflows/bors.yml
@@ -25,7 +25,7 @@ env:
 concurrency:
   # label each workflow run; only the latest with each label will run
   # workflows on master get more expressive labels
-  group: ${{ github.workflow }}-${{ github.ref }}-${{ (contains(fromJSON('["refs/heads/master", "refs/heads/staging"]'), github.ref) && github.run_id) || '' }}
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}-${{ (github.event_name == 'push' && contains(fromJSON('["refs/heads/master", "refs/heads/staging"]'), github.ref) && github.run_id) || '' }}
   # cancel any running workflow with the same label
   cancel-in-progress: true
 
@@ -54,6 +54,16 @@ jobs:
       run:
         shell: landrun --rox /usr --ro /etc/timezone --rw /dev --rox /home/lean/.elan --rox /home/lean/actions-runner/_work --rox /home/lean/.cache/mathlib/ --rw pr-branch/.lake/ --env PATH --env HOME --env GITHUB_OUTPUT --env CI -- bash -euxo pipefail {0}
     steps:
+      - name: print job info
+        env:
+          CONCURRENCY_GROUP: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}-${{ (github.event_name == 'push' && contains(fromJSON('["refs/heads/master", "refs/heads/staging"]'), github.ref) && github.run_id) || '' }}
+        run: |
+          echo "workflow: ${{ github.workflow }}"
+          echo "pull request number: ${{ github.event.pull_request.number }}"
+          echo "github ref: ${{ github.ref }}"
+          echo "github event_name: ${{ github.event_name }}"
+          echo "github run id: ${{ github.run_id }}"
+          echo "concurrency group: $CONCURRENCY_GROUP"
       - name: cleanup
         shell: bash    # This *just* deletes old files, so is safe to run outside landrun.
         run: |

--- a/.github/workflows/bors.yml
+++ b/.github/workflows/bors.yml
@@ -56,12 +56,12 @@ jobs:
     steps:
       - name: print job info
         run: |
-          echo "workflow: ${{ github.workflow }}"
-          echo "pull request number: ${{ github.event.pull_request.number }}"
-          echo "github ref: ${{ github.ref }}"
-          echo "github event_name: ${{ github.event_name }}"
-          echo "github run id: ${{ github.run_id }}"
-          echo "concurrency group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}-${{ (github.event_name == 'push' && contains(fromJSON('["refs/heads/master", "refs/heads/staging"]'), github.ref) && github.run_id) || '' }}"
+          echo 'workflow: ${{ github.workflow }}'
+          echo 'pull request number: ${{ github.event.pull_request.number }}'
+          echo 'github ref: ${{ github.ref }}'
+          echo 'github event_name: ${{ github.event_name }}'
+          echo 'github run id: ${{ github.run_id }}'
+          echo 'concurrency group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}-${{ (github.event_name == 'push' && contains(fromJSON('["refs/heads/master", "refs/heads/staging"]'), github.ref) && github.run_id) || '' }}'
       - name: cleanup
         shell: bash    # This *just* deletes old files, so is safe to run outside landrun.
         run: |

--- a/.github/workflows/bors.yml
+++ b/.github/workflows/bors.yml
@@ -54,17 +54,17 @@ jobs:
       run:
         shell: landrun --rox /usr --ro /etc/timezone --rw /dev --rox /home/lean/.elan --rox /home/lean/actions-runner/_work --rox /home/lean/.cache/mathlib/ --rw pr-branch/.lake/ --env PATH --env HOME --env GITHUB_OUTPUT --env CI -- bash -euxo pipefail {0}
     steps:
-      - name: print job info
+      - name: job info
+        env:
+          WORKFLOW: ${{ github.workflow }}
+          PR_NUMBER: ${{ github.event.pull_request.number }}
+          REF: ${{ github.ref }}
+          EVENT_NAME: ${{ github.event_name }}
+          RUN_ID: ${{ github.run_id }}
+          CONCURRENCY_GROUP: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}-${{ (github.event_name == 'push' && contains(fromJSON('["refs/heads/master", "refs/heads/staging"]'), github.ref) && github.run_id) || '' }}
         run: |
-          # We don't want any substitution here
-          # (after GitHub does its thing with its expressions),
-          # so I'm using single quotes here.
-          echo 'workflow: ${{ github.workflow }}'
-          echo 'pull request number: ${{ github.event.pull_request.number }}'
-          echo 'github ref: ${{ github.ref }}'
-          echo 'github event_name: ${{ github.event_name }}'
-          echo 'github run id: ${{ github.run_id }}'
-          echo 'concurrency group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}-${{ (github.event_name == 'push' && contains(fromJSON('["refs/heads/master", "refs/heads/staging"]'), github.ref) && github.run_id) || '' }}'
+          # We can view these values in the logs under the step environment variables
+          # landrun doesn't see env variables anyways
       - name: cleanup
         shell: bash    # This *just* deletes old files, so is safe to run outside landrun.
         run: |

--- a/.github/workflows/bors.yml
+++ b/.github/workflows/bors.yml
@@ -55,15 +55,13 @@ jobs:
         shell: landrun --rox /usr --ro /etc/timezone --rw /dev --rox /home/lean/.elan --rox /home/lean/actions-runner/_work --rox /home/lean/.cache/mathlib/ --rw pr-branch/.lake/ --env PATH --env HOME --env GITHUB_OUTPUT --env CI -- bash -euxo pipefail {0}
     steps:
       - name: print job info
-        env:
-          CONCURRENCY_GROUP: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}-${{ (github.event_name == 'push' && contains(fromJSON('["refs/heads/master", "refs/heads/staging"]'), github.ref) && github.run_id) || '' }}
         run: |
           echo "workflow: ${{ github.workflow }}"
           echo "pull request number: ${{ github.event.pull_request.number }}"
           echo "github ref: ${{ github.ref }}"
           echo "github event_name: ${{ github.event_name }}"
           echo "github run id: ${{ github.run_id }}"
-          echo "concurrency group: $CONCURRENCY_GROUP"
+          echo "concurrency group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}-${{ (github.event_name == 'push' && contains(fromJSON('["refs/heads/master", "refs/heads/staging"]'), github.ref) && github.run_id) || '' }}"
       - name: cleanup
         shell: bash    # This *just* deletes old files, so is safe to run outside landrun.
         run: |

--- a/.github/workflows/bors.yml
+++ b/.github/workflows/bors.yml
@@ -56,6 +56,9 @@ jobs:
     steps:
       - name: print job info
         run: |
+          # We don't want any substitution here
+          # (after GitHub does its thing with its expressions),
+          # so I'm using single quotes here.
           echo 'workflow: ${{ github.workflow }}'
           echo 'pull request number: ${{ github.event.pull_request.number }}'
           echo 'github ref: ${{ github.ref }}'

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -32,7 +32,7 @@ env:
 concurrency:
   # label each workflow run; only the latest with each label will run
   # workflows on master get more expressive labels
-  group: ${{ github.workflow }}-${{ github.ref }}-${{ (contains(fromJSON('["refs/heads/master", "refs/heads/staging"]'), github.ref) && github.run_id) || '' }}
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}-${{ (github.event_name == 'push' && contains(fromJSON('["refs/heads/master", "refs/heads/staging"]'), github.ref) && github.run_id) || '' }}
   # cancel any running workflow with the same label
   cancel-in-progress: true
 
@@ -61,6 +61,16 @@ jobs:
       run:
         shell: landrun --rox /usr --ro /etc/timezone --rw /dev --rox /home/lean/.elan --rox /home/lean/actions-runner/_work --rox /home/lean/.cache/mathlib/ --rw pr-branch/.lake/ --env PATH --env HOME --env GITHUB_OUTPUT --env CI -- bash -euxo pipefail {0}
     steps:
+      - name: print job info
+        env:
+          CONCURRENCY_GROUP: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}-${{ (github.event_name == 'push' && contains(fromJSON('["refs/heads/master", "refs/heads/staging"]'), github.ref) && github.run_id) || '' }}
+        run: |
+          echo "workflow: ${{ github.workflow }}"
+          echo "pull request number: ${{ github.event.pull_request.number }}"
+          echo "github ref: ${{ github.ref }}"
+          echo "github event_name: ${{ github.event_name }}"
+          echo "github run id: ${{ github.run_id }}"
+          echo "concurrency group: $CONCURRENCY_GROUP"
       - name: cleanup
         shell: bash    # This *just* deletes old files, so is safe to run outside landrun.
         run: |

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -63,12 +63,12 @@ jobs:
     steps:
       - name: print job info
         run: |
-          echo "workflow: ${{ github.workflow }}"
-          echo "pull request number: ${{ github.event.pull_request.number }}"
-          echo "github ref: ${{ github.ref }}"
-          echo "github event_name: ${{ github.event_name }}"
-          echo "github run id: ${{ github.run_id }}"
-          echo "concurrency group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}-${{ (github.event_name == 'push' && contains(fromJSON('["refs/heads/master", "refs/heads/staging"]'), github.ref) && github.run_id) || '' }}"
+          echo 'workflow: ${{ github.workflow }}'
+          echo 'pull request number: ${{ github.event.pull_request.number }}'
+          echo 'github ref: ${{ github.ref }}'
+          echo 'github event_name: ${{ github.event_name }}'
+          echo 'github run id: ${{ github.run_id }}'
+          echo 'concurrency group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}-${{ (github.event_name == 'push' && contains(fromJSON('["refs/heads/master", "refs/heads/staging"]'), github.ref) && github.run_id) || '' }}'
       - name: cleanup
         shell: bash    # This *just* deletes old files, so is safe to run outside landrun.
         run: |

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -61,17 +61,17 @@ jobs:
       run:
         shell: landrun --rox /usr --ro /etc/timezone --rw /dev --rox /home/lean/.elan --rox /home/lean/actions-runner/_work --rox /home/lean/.cache/mathlib/ --rw pr-branch/.lake/ --env PATH --env HOME --env GITHUB_OUTPUT --env CI -- bash -euxo pipefail {0}
     steps:
-      - name: print job info
+      - name: job info
+        env:
+          WORKFLOW: ${{ github.workflow }}
+          PR_NUMBER: ${{ github.event.pull_request.number }}
+          REF: ${{ github.ref }}
+          EVENT_NAME: ${{ github.event_name }}
+          RUN_ID: ${{ github.run_id }}
+          CONCURRENCY_GROUP: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}-${{ (github.event_name == 'push' && contains(fromJSON('["refs/heads/master", "refs/heads/staging"]'), github.ref) && github.run_id) || '' }}
         run: |
-          # We don't want any substitution here
-          # (after GitHub does its thing with its expressions),
-          # so I'm using single quotes here.
-          echo 'workflow: ${{ github.workflow }}'
-          echo 'pull request number: ${{ github.event.pull_request.number }}'
-          echo 'github ref: ${{ github.ref }}'
-          echo 'github event_name: ${{ github.event_name }}'
-          echo 'github run id: ${{ github.run_id }}'
-          echo 'concurrency group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}-${{ (github.event_name == 'push' && contains(fromJSON('["refs/heads/master", "refs/heads/staging"]'), github.ref) && github.run_id) || '' }}'
+          # We can view these values in the logs under the step environment variables
+          # landrun doesn't see env variables anyways
       - name: cleanup
         shell: bash    # This *just* deletes old files, so is safe to run outside landrun.
         run: |

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -62,15 +62,13 @@ jobs:
         shell: landrun --rox /usr --ro /etc/timezone --rw /dev --rox /home/lean/.elan --rox /home/lean/actions-runner/_work --rox /home/lean/.cache/mathlib/ --rw pr-branch/.lake/ --env PATH --env HOME --env GITHUB_OUTPUT --env CI -- bash -euxo pipefail {0}
     steps:
       - name: print job info
-        env:
-          CONCURRENCY_GROUP: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}-${{ (github.event_name == 'push' && contains(fromJSON('["refs/heads/master", "refs/heads/staging"]'), github.ref) && github.run_id) || '' }}
         run: |
           echo "workflow: ${{ github.workflow }}"
           echo "pull request number: ${{ github.event.pull_request.number }}"
           echo "github ref: ${{ github.ref }}"
           echo "github event_name: ${{ github.event_name }}"
           echo "github run id: ${{ github.run_id }}"
-          echo "concurrency group: $CONCURRENCY_GROUP"
+          echo "concurrency group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}-${{ (github.event_name == 'push' && contains(fromJSON('["refs/heads/master", "refs/heads/staging"]'), github.ref) && github.run_id) || '' }}"
       - name: cleanup
         shell: bash    # This *just* deletes old files, so is safe to run outside landrun.
         run: |

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -63,6 +63,9 @@ jobs:
     steps:
       - name: print job info
         run: |
+          # We don't want any substitution here
+          # (after GitHub does its thing with its expressions),
+          # so I'm using single quotes here.
           echo 'workflow: ${{ github.workflow }}'
           echo 'pull request number: ${{ github.event.pull_request.number }}'
           echo 'github ref: ${{ github.ref }}'

--- a/.github/workflows/build_fork.yml
+++ b/.github/workflows/build_fork.yml
@@ -60,12 +60,12 @@ jobs:
     steps:
       - name: print job info
         run: |
-          echo "workflow: ${{ github.workflow }}"
-          echo "pull request number: ${{ github.event.pull_request.number }}"
-          echo "github ref: ${{ github.ref }}"
-          echo "github event_name: ${{ github.event_name }}"
-          echo "github run id: ${{ github.run_id }}"
-          echo "concurrency group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}-${{ (github.event_name == 'push' && contains(fromJSON('["refs/heads/master", "refs/heads/staging"]'), github.ref) && github.run_id) || '' }}"
+          echo 'workflow: ${{ github.workflow }}'
+          echo 'pull request number: ${{ github.event.pull_request.number }}'
+          echo 'github ref: ${{ github.ref }}'
+          echo 'github event_name: ${{ github.event_name }}'
+          echo 'github run id: ${{ github.run_id }}'
+          echo 'concurrency group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}-${{ (github.event_name == 'push' && contains(fromJSON('["refs/heads/master", "refs/heads/staging"]'), github.ref) && github.run_id) || '' }}'
       - name: cleanup
         shell: bash    # This *just* deletes old files, so is safe to run outside landrun.
         run: |

--- a/.github/workflows/build_fork.yml
+++ b/.github/workflows/build_fork.yml
@@ -60,6 +60,9 @@ jobs:
     steps:
       - name: print job info
         run: |
+          # We don't want any substitution here
+          # (after GitHub does its thing with its expressions),
+          # so I'm using single quotes here.
           echo 'workflow: ${{ github.workflow }}'
           echo 'pull request number: ${{ github.event.pull_request.number }}'
           echo 'github ref: ${{ github.ref }}'

--- a/.github/workflows/build_fork.yml
+++ b/.github/workflows/build_fork.yml
@@ -29,7 +29,7 @@ env:
 concurrency:
   # label each workflow run; only the latest with each label will run
   # workflows on master get more expressive labels
-  group: ${{ github.workflow }}-${{ github.ref }}-${{ (contains(fromJSON('["refs/heads/master", "refs/heads/staging"]'), github.ref) && github.run_id) || '' }}
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}-${{ (github.event_name == 'push' && contains(fromJSON('["refs/heads/master", "refs/heads/staging"]'), github.ref) && github.run_id) || '' }}
   # cancel any running workflow with the same label
   cancel-in-progress: true
 
@@ -58,6 +58,16 @@ jobs:
       run:
         shell: landrun --rox /usr --ro /etc/timezone --rw /dev --rox /home/lean/.elan --rox /home/lean/actions-runner/_work --rox /home/lean/.cache/mathlib/ --rw pr-branch/.lake/ --env PATH --env HOME --env GITHUB_OUTPUT --env CI -- bash -euxo pipefail {0}
     steps:
+      - name: print job info
+        env:
+          CONCURRENCY_GROUP: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}-${{ (github.event_name == 'push' && contains(fromJSON('["refs/heads/master", "refs/heads/staging"]'), github.ref) && github.run_id) || '' }}
+        run: |
+          echo "workflow: ${{ github.workflow }}"
+          echo "pull request number: ${{ github.event.pull_request.number }}"
+          echo "github ref: ${{ github.ref }}"
+          echo "github event_name: ${{ github.event_name }}"
+          echo "github run id: ${{ github.run_id }}"
+          echo "concurrency group: $CONCURRENCY_GROUP"
       - name: cleanup
         shell: bash    # This *just* deletes old files, so is safe to run outside landrun.
         run: |

--- a/.github/workflows/build_fork.yml
+++ b/.github/workflows/build_fork.yml
@@ -59,15 +59,13 @@ jobs:
         shell: landrun --rox /usr --ro /etc/timezone --rw /dev --rox /home/lean/.elan --rox /home/lean/actions-runner/_work --rox /home/lean/.cache/mathlib/ --rw pr-branch/.lake/ --env PATH --env HOME --env GITHUB_OUTPUT --env CI -- bash -euxo pipefail {0}
     steps:
       - name: print job info
-        env:
-          CONCURRENCY_GROUP: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}-${{ (github.event_name == 'push' && contains(fromJSON('["refs/heads/master", "refs/heads/staging"]'), github.ref) && github.run_id) || '' }}
         run: |
           echo "workflow: ${{ github.workflow }}"
           echo "pull request number: ${{ github.event.pull_request.number }}"
           echo "github ref: ${{ github.ref }}"
           echo "github event_name: ${{ github.event_name }}"
           echo "github run id: ${{ github.run_id }}"
-          echo "concurrency group: $CONCURRENCY_GROUP"
+          echo "concurrency group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}-${{ (github.event_name == 'push' && contains(fromJSON('["refs/heads/master", "refs/heads/staging"]'), github.ref) && github.run_id) || '' }}"
       - name: cleanup
         shell: bash    # This *just* deletes old files, so is safe to run outside landrun.
         run: |

--- a/.github/workflows/build_fork.yml
+++ b/.github/workflows/build_fork.yml
@@ -58,17 +58,17 @@ jobs:
       run:
         shell: landrun --rox /usr --ro /etc/timezone --rw /dev --rox /home/lean/.elan --rox /home/lean/actions-runner/_work --rox /home/lean/.cache/mathlib/ --rw pr-branch/.lake/ --env PATH --env HOME --env GITHUB_OUTPUT --env CI -- bash -euxo pipefail {0}
     steps:
-      - name: print job info
+      - name: job info
+        env:
+          WORKFLOW: ${{ github.workflow }}
+          PR_NUMBER: ${{ github.event.pull_request.number }}
+          REF: ${{ github.ref }}
+          EVENT_NAME: ${{ github.event_name }}
+          RUN_ID: ${{ github.run_id }}
+          CONCURRENCY_GROUP: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}-${{ (github.event_name == 'push' && contains(fromJSON('["refs/heads/master", "refs/heads/staging"]'), github.ref) && github.run_id) || '' }}
         run: |
-          # We don't want any substitution here
-          # (after GitHub does its thing with its expressions),
-          # so I'm using single quotes here.
-          echo 'workflow: ${{ github.workflow }}'
-          echo 'pull request number: ${{ github.event.pull_request.number }}'
-          echo 'github ref: ${{ github.ref }}'
-          echo 'github event_name: ${{ github.event_name }}'
-          echo 'github run id: ${{ github.run_id }}'
-          echo 'concurrency group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}-${{ (github.event_name == 'push' && contains(fromJSON('["refs/heads/master", "refs/heads/staging"]'), github.ref) && github.run_id) || '' }}'
+          # We can view these values in the logs under the step environment variables
+          # landrun doesn't see env variables anyways
       - name: cleanup
         shell: bash    # This *just* deletes old files, so is safe to run outside landrun.
         run: |


### PR DESCRIPTION
The issue (as [explained to me by Claude](https://claude.ai/share/9880d667-ff16-455f-b875-b273558d5256)) is apparently that `github.ref` for workflows triggered by `pull_request_target` is always `refs/heads/master`, so they all end up getting unique concurrency groups.

I also add a step that ends up putting some build info in the logs, on the off chance that this still doesn't fix things. (Strictly speaking we don't log the data, we just put them in the env vars so that they are visible by expanding the "Run ..." details.)

Follow-up to #31032 which was only a partial fix.  

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

When merging, all the commits will be squashed into a single commit
listing all co-authors.

Co-authors in the squash commit are gathered from two sources:

First, all authors of commits to this PR branch are included. Thus,
one way to add co-authors is to include at least one commit authored by
each co-author among the commits in the pull request. If necessary, you
may create empty commits to indicate co-authorship, using commands like so:

git commit --author="Author Name <author@email.com>" --allow-empty -m "add Author Name as coauthor"

Second, co-authors can also be listed in lines at the very bottom of
the commit message (that is, directly before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines
at the bottom of the commit message (before the `---`, and also before
any "Co-authored-by" lines) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
