### PR TITLE
[Merged by Bors] - feat: deriv_const_rpow

### DIFF
--- a/Mathlib/Analysis/SpecialFunctions/Pow/Deriv.lean
+++ b/Mathlib/Analysis/SpecialFunctions/Pow/Deriv.lean
@@ -671,18 +671,18 @@ lemma isBigO_deriv_rpow_const_atTop (p : ℝ) :
 variable {a : ℝ}
 
 theorem HasDerivWithinAt.const_rpow (ha : 0 < a) (hf : HasDerivWithinAt f f' s x) :
-    HasDerivWithinAt (fun x ↦ a ^ f x) (Real.log a * f' * a ^ f x) s x := by
+    HasDerivWithinAt (a ^ f ·) (Real.log a * f' * a ^ f x) s x := by
   convert (hasDerivWithinAt_const x s a).rpow hf ha using 1
   ring
 
 theorem HasDerivAt.const_rpow (ha : 0 < a) (hf : HasDerivAt f f' x) :
-    HasDerivAt (fun x ↦ a ^ f x) (Real.log a * f' * a ^ f x) x := by
+    HasDerivAt (a ^ f ·) (Real.log a * f' * a ^ f x) x := by
   rw [← hasDerivWithinAt_univ] at *
   exact hf.const_rpow ha
 
 theorem derivWithin_const_rpow (ha : 0 < a) (hf : DifferentiableWithinAt ℝ f s x)
     (hxs : UniqueDiffWithinAt ℝ s x) :
-    derivWithin (fun x => a ^ f x) s x = Real.log a * derivWithin f s x * a ^ f x :=
+    derivWithin (a ^ f ·) s x = Real.log a * derivWithin f s x * a ^ f x :=
   (hf.hasDerivWithinAt.const_rpow ha).derivWithin hxs
 
 @[simp]

--- a/Mathlib/Analysis/SpecialFunctions/Pow/Deriv.lean
+++ b/Mathlib/Analysis/SpecialFunctions/Pow/Deriv.lean
@@ -668,6 +668,29 @@ lemma isBigO_deriv_rpow_const_atTop (p : ℝ) :
   case inr =>
     exact (isTheta_deriv_rpow_const_atTop hp).1
 
+variable {a : ℝ}
+
+theorem HasDerivWithinAt.const_rpow (ha : 0 < a) (hf : HasDerivWithinAt f f' s x) :
+    HasDerivWithinAt (fun x ↦ a ^ f x) (Real.log a * f' * a ^ f x) s x := by
+  convert (hasDerivWithinAt_const x s a).rpow hf ha using 1
+  ring
+
+theorem HasDerivAt.const_rpow (ha : 0 < a) (hf : HasDerivAt f f' x) :
+    HasDerivAt (fun x ↦ a ^ f x) (Real.log a * f' * a ^ f x) x := by
+  rw [← hasDerivWithinAt_univ] at *
+  exact hf.const_rpow ha
+
+theorem derivWithin_const_rpow (ha : 0 < a) (hf : DifferentiableWithinAt ℝ f s x)
+    (hxs : UniqueDiffWithinAt ℝ s x) :
+    derivWithin (fun x => a ^ f x) s x = Real.log a * derivWithin f s x * a ^ f x :=
+  (hf.hasDerivWithinAt.const_rpow ha).derivWithin hxs
+
+@[simp]
+theorem deriv_const_rpow (ha : 0 < a) (hf : DifferentiableAt ℝ f x) :
+    deriv (a ^ f ·) x = Real.log a * deriv f x * a ^ f x :=
+  (hf.hasDerivAt.const_rpow ha).deriv
+
+
 end deriv
 
 end Differentiability


### PR DESCRIPTION
From carleson.


---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

When merging, all the commits will be squashed into a single commit
listing all co-authors.

Co-authors in the squash commit are gathered from two sources:

First, all authors of commits to this PR branch are included. Thus,
one way to add co-authors is to include at least one commit authored by
each co-author among the commits in the pull request. If necessary, you
may create empty commits to indicate co-authorship, using commands like so:

git commit --author="Author Name <author@email.com>" --allow-empty -m "add Author Name as coauthor"

Second, co-authors can also be listed in lines at the very bottom of
the commit message (that is, directly before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines
at the bottom of the commit message (before the `---`, and also before
any "Co-authored-by" lines) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
