### PR TITLE
[Merged by Bors] - chore: remove a `@[simps]` from a theorem

### DIFF
--- a/Mathlib/RingTheory/Perfection.lean
+++ b/Mathlib/RingTheory/Perfection.lean
@@ -215,7 +215,6 @@ variable {R : Type u₁} [CommSemiring R] [CharP R p]
 variable {P : Type u₃} [CommSemiring P] [CharP P p] [PerfectRing P p]
 
 /-- Create a `PerfectionMap` from an isomorphism to the perfection. -/
-@[simps]
 theorem mk' {f : P →+* R} (g : P ≃+* Ring.Perfection R p) (hfg : Perfection.lift p P R f = g) :
     PerfectionMap p f :=
   { injective := fun x y hxy =>


### PR DESCRIPTION
`@[simps]` can make useful theorems out of a theorem, I think! This causes a breakage on the `modulize` branch, so I'm backporting this change to `master`.