### PR TITLE
[Merged by Bors] - chore: allow uploading oleans for LeanHammer

### DIFF
--- a/Cache/IO.lean
+++ b/Cache/IO.lean
@@ -43,7 +43,12 @@ def isPartOfMathlibCache (mod : Name) : Bool := #[
   `OpenAIClient,
   `Reap,
   -- Allow PRs to upload oleans for Canonical for testing.
-  `Canonical,].contains mod.getRoot
+  `Canonical,
+  -- Allow PRs to upload oleans for LeanHammer for testing.
+  `Duper,
+  `Auto,
+  `PremiseSelection,
+  `Hammer].contains mod.getRoot
 
 /-- Target directory for caching -/
 initialize CACHEDIR : FilePath ← do


### PR DESCRIPTION
This is a preparatory PR that modifies Cache.lean to allow uploading oleans for LeanHammer, paving the way for future PRs to experiment with adding LeanHammer to mathlib. Requested from [#general > lean hammer install failing for 4.24 @ 💬](https://leanprover.zulipchat.com/#narrow/channel/113488-general/topic/lean.20hammer.20install.20failing.20for.204.2E24/near/554002277)

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

When merging, all the commits will be squashed into a single commit
listing all co-authors.

Co-authors in the squash commit are gathered from two sources:

First, all authors of commits to this PR branch are included. Thus,
one way to add co-authors is to include at least one commit authored by
each co-author among the commits in the pull request. If necessary, you
may create empty commits to indicate co-authorship, using commands like so:

git commit --author="Author Name <author@email.com>" --allow-empty -m "add Author Name as coauthor"

Second, co-authors can also be listed in lines at the very bottom of
the commit message (that is, directly before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines
at the bottom of the commit message (before the `---`, and also before
any "Co-authored-by" lines) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
