### PR TITLE
[Merged by Bors] - chore(CategoryTheory/EffectiveEpi): golf entire `effectiveEpiFamilyStructCompIso_aux` using `grind`

### DIFF
--- a/Mathlib/CategoryTheory/EffectiveEpi/Comp.lean
+++ b/Mathlib/CategoryTheory/EffectiveEpi/Comp.lean
@@ -108,9 +108,7 @@ theorem effectiveEpiFamilyStructCompIso_aux
       g₁ ≫ π a₁ ≫ i = g₂ ≫ π a₂ ≫ i → g₁ ≫ e a₁ = g₂ ≫ e a₂)
     {Z : C} (a₁ a₂ : α) (g₁ : Z ⟶ X a₁) (g₂ : Z ⟶ X a₂) (hg : g₁ ≫ π a₁ = g₂ ≫ π a₂) :
     g₁ ≫ e a₁ = g₂ ≫ e a₂ := by
-  apply h
-  rw [← Category.assoc, hg]
-  simp
+  grind
 
 variable [EffectiveEpiFamily X π] [IsIso i]
 


### PR DESCRIPTION
---
<details>
<summary>Show trace profiling of <code>effectiveEpiFamilyStructCompIso_aux</code>: <10 ms before, 11 ms after </summary>

### Trace profiling of `effectiveEpiFamilyStructCompIso_aux` before PR 31343
```diff
diff --git a/Mathlib/CategoryTheory/EffectiveEpi/Comp.lean b/Mathlib/CategoryTheory/EffectiveEpi/Comp.lean
index 0794c9d1b2..7d18df85be 100644
--- a/Mathlib/CategoryTheory/EffectiveEpi/Comp.lean
+++ b/Mathlib/CategoryTheory/EffectiveEpi/Comp.lean
@@ -102,6 +102,7 @@ section CompIso
 variable {B B' : C} {α : Type*} (X : α → C) (π : (a : α) → (X a ⟶ B))
   (i : B ⟶ B')
 
+set_option trace.profiler true in
 theorem effectiveEpiFamilyStructCompIso_aux
     {W : C} (e : (a : α) → X a ⟶ W)
     (h : ∀ {Z : C} (a₁ a₂ : α) (g₁ : Z ⟶ X a₁) (g₂ : Z ⟶ X a₂),
```
```
✔ [585/585] Built Mathlib.CategoryTheory.EffectiveEpi.Comp (1.0s)
Build completed successfully (585 jobs).
```

### Trace profiling of `effectiveEpiFamilyStructCompIso_aux` after PR 31343
```diff
diff --git a/Mathlib/CategoryTheory/EffectiveEpi/Comp.lean b/Mathlib/CategoryTheory/EffectiveEpi/Comp.lean
index 0794c9d1b2..f4e94a9b22 100644
--- a/Mathlib/CategoryTheory/EffectiveEpi/Comp.lean
+++ b/Mathlib/CategoryTheory/EffectiveEpi/Comp.lean
@@ -102,15 +102,14 @@ section CompIso
 variable {B B' : C} {α : Type*} (X : α → C) (π : (a : α) → (X a ⟶ B))
   (i : B ⟶ B')
 
+set_option trace.profiler true in
 theorem effectiveEpiFamilyStructCompIso_aux
     {W : C} (e : (a : α) → X a ⟶ W)
     (h : ∀ {Z : C} (a₁ a₂ : α) (g₁ : Z ⟶ X a₁) (g₂ : Z ⟶ X a₂),
       g₁ ≫ π a₁ ≫ i = g₂ ≫ π a₂ ≫ i → g₁ ≫ e a₁ = g₂ ≫ e a₂)
     {Z : C} (a₁ a₂ : α) (g₁ : Z ⟶ X a₁) (g₂ : Z ⟶ X a₂) (hg : g₁ ≫ π a₁ = g₂ ≫ π a₂) :
     g₁ ≫ e a₁ = g₂ ≫ e a₂ := by
-  apply h
-  rw [← Category.assoc, hg]
-  simp
+  grind
 
 variable [EffectiveEpiFamily X π] [IsIso i]
 
```
```
ℹ [585/585] Built Mathlib.CategoryTheory.EffectiveEpi.Comp (1.1s)
info: Mathlib/CategoryTheory/EffectiveEpi/Comp.lean:106:0: [Elab.async] [0.011259] elaborating proof of CategoryTheory.effectiveEpiFamilyStructCompIso_aux
  [Elab.definition.value] [0.010913] CategoryTheory.effectiveEpiFamilyStructCompIso_aux
    [Elab.step] [0.010729] grind
      [Elab.step] [0.010723] grind
        [Elab.step] [0.010716] grind
Build completed successfully (585 jobs).
```
</details>

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

When merging, all the commits will be squashed into a single commit
listing all co-authors.

Co-authors in the squash commit are gathered from two sources:

First, all authors of commits to this PR branch are included. Thus,
one way to add co-authors is to include at least one commit authored by
each co-author among the commits in the pull request. If necessary, you
may create empty commits to indicate co-authorship, using commands like so:

git commit --author="Author Name <author@email.com>" --allow-empty -m "add Author Name as coauthor"

Second, co-authors can also be listed in lines at the very bottom of
the commit message (that is, directly before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines
at the bottom of the commit message (before the `---`, and also before
any "Co-authored-by" lines) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
