### PR TITLE
[Merged by Bors] - ci(update_dependencies): fix conditions for running create-pull-request

### DIFF
--- a/.github/workflows/update_dependencies.yml
+++ b/.github/workflows/update_dependencies.yml
@@ -88,6 +88,11 @@ jobs:
             create_pr=true
             echo "PR does not exist, need to run create-pull-request to check whether one should be created"
           fi
+          if [ "${{ steps.PR.outputs.pr_found }}" == "true" ] && \
+             git diff --quiet "origin/master" -- lake-manifest.json; then
+            create_pr=true
+            echo "No differences found with lake-manifest.json on master, need to run create-pull-request to close the PR"
+          fi
           if [ "${{ contains(steps.PR.outputs.pr_labels, 'merge-conflict') }}" == "true" ]; then
             create_pr=true
             echo "merge-conflict on PR, need to run create-pull-request to update $BRANCH_NAME"
@@ -96,11 +101,6 @@ jobs:
              ! git diff --quiet "origin/$BRANCH_NAME" -- lake-manifest.json; then
             create_pr=true
             echo "Differences found with lake-manifest.json on $BRANCH_NAME, need to run create-pull-request to update $BRANCH_NAME"
-          fi
-          if [ "${{ steps.PR.outputs.pr_found }}" == "true" ] && \
-             git diff --quiet "origin/master" -- lake-manifest.json; then
-            create_pr=true
-            echo "No differences in lake-manifest.json on master, need to run create-pull-request to close the PR"
           fi
           # Otherwise, there's no reason to run create-pull-request
           echo "create_pr=$create_pr" >> "${GITHUB_OUTPUT}"

--- a/.github/workflows/update_dependencies.yml
+++ b/.github/workflows/update_dependencies.yml
@@ -77,30 +77,37 @@ jobs:
         if: ${{ steps.check_toolchain.outputs.toolchain_modified == 'false' }}
         id: check_manifest
         run: |
-          if [ "${{ steps.PR.outputs.pr_found }}" != "true" ]; then
-            echo "has_diff=true" >> "${GITHUB_OUTPUT}"
-            echo "PR does not exist, let create-pull-request run"
-          elif [ "${{ contains(steps.PR.outputs.pr_labels, 'merge-conflict') }}" == "true" ]; then
-            echo "has_diff=true" >> "${GITHUB_OUTPUT}"
-            echo "merge-conflict on PR, let create-pull-request run"
-          elif [ -n "${{ steps.get-branch-sha.outputs.sha }}" ]; then
-            # Branch exists, compare the file
-            if git diff --quiet "origin/$BRANCH_NAME" -- lake-manifest.json; then
-              echo "has_diff=false" >> "${GITHUB_OUTPUT}"
-              echo "No differences in lake-manifest.json"
-            else
-              echo "has_diff=true" >> "${GITHUB_OUTPUT}"
-              echo "Differences found in lake-manifest.json"
-            fi
-          else
-            # Branch doesn't exist, consider it as different
-            echo "has_diff=true" >> "${GITHUB_OUTPUT}"
-            echo "Branch does not exist, treating as different"
+          # Default to false
+          create_pr=false
+          # Log individual reasons for running the create-pull-request action
+          if [ -z "${{ steps.get-branch-sha.outputs.sha }}" ]; then
+            create_pr=true
+            echo "$BRANCH_NAME does not exist, need to run create-pull-request to create it"
           fi
+          if [ "${{ steps.PR.outputs.pr_found }}" != "true" ]; then
+            create_pr=true
+            echo "PR does not exist, need to run create-pull-request to check whether one should be created"
+          fi
+          if [ "${{ contains(steps.PR.outputs.pr_labels, 'merge-conflict') }}" == "true" ]; then
+            create_pr=true
+            echo "merge-conflict on PR, need to run create-pull-request to update $BRANCH_NAME"
+          fi
+          if [ -n "${{ steps.get-branch-sha.outputs.sha }}" ] && \
+             ! git diff --quiet "origin/$BRANCH_NAME" -- lake-manifest.json; then
+            create_pr=true
+            echo "Differences found with lake-manifest.json on $BRANCH_NAME, need to run create-pull-request to update $BRANCH_NAME"
+          fi
+          if [ "${{ steps.PR.outputs.pr_found }}" == "true" ] && \
+             git diff --quiet "origin/master" -- lake-manifest.json; then
+            create_pr=true
+            echo "No differences in lake-manifest.json on master, need to run create-pull-request to close the PR"
+          fi
+          # Otherwise, there's no reason to run create-pull-request
+          echo "create_pr=$create_pr" >> "${GITHUB_OUTPUT}"
 
       - name: Generate PR title
         id: pr-title
-        if: ${{ steps.check_manifest.outputs.has_diff == 'true' }}
+        if: ${{ steps.check_manifest.outputs.create_pr == 'true' }}
         run: |
           echo "timestamp=$(date -u +"%Y-%m-%d-%H-%M")" >> "$GITHUB_ENV"
           echo "pr_title=chore: update Mathlib dependencies $(date -u +"%Y-%m-%d")" >> "$GITHUB_ENV"


### PR DESCRIPTION
Follow-up to #31245. I missed the case where we need to run `create-pull-request` to automatically close the PR when there are no longer any differences with `master`. The `if`, `elif` conditions were getting hairy, so I rewrote the step so that it logs the reasoning for running the `create-pull-request` action.

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

When merging, all the commits will be squashed into a single commit
listing all co-authors.

Co-authors in the squash commit are gathered from two sources:

First, all authors of commits to this PR branch are included. Thus,
one way to add co-authors is to include at least one commit authored by
each co-author among the commits in the pull request. If necessary, you
may create empty commits to indicate co-authorship, using commands like so:

git commit --author="Author Name <author@email.com>" --allow-empty -m "add Author Name as coauthor"

Second, co-authors can also be listed in lines at the very bottom of
the commit message (that is, directly before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines
at the bottom of the commit message (before the `---`, and also before
any "Co-authored-by" lines) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
