### PR TITLE
[Merged by Bors] - chore(Algebra/Action): fix name `Sum.instSMul_mathlib`

### DIFF
--- a/Mathlib/Algebra/Group/Action/Sum.lean
+++ b/Mathlib/Algebra/Group/Action/Sum.lean
@@ -29,7 +29,7 @@ section SMul
 variable [SMul M α] [SMul M β] [SMul N α] [SMul N β] (a : M) (b : α) (c : β)
   (x : α ⊕ β)
 
-@[to_additive Sum.instVAdd]
+@[to_additive]
 instance instSMul : SMul M (α ⊕ β) :=
   ⟨fun a => Sum.map (a • ·) (a • ·)⟩
 

--- a/Mathlib/Algebra/Group/Action/Sum.lean
+++ b/Mathlib/Algebra/Group/Action/Sum.lean
@@ -30,7 +30,7 @@ variable [SMul M α] [SMul M β] [SMul N α] [SMul N β] (a : M) (b : α) (c : �
   (x : α ⊕ β)
 
 @[to_additive Sum.instVAdd]
-instance Sum.instSMul : SMul M (α ⊕ β) :=
+instance instSMul : SMul M (α ⊕ β) :=
   ⟨fun a => Sum.map (a • ·) (a • ·)⟩
 
 @[to_additive]

--- a/Mathlib/Algebra/Group/Action/Sum.lean
+++ b/Mathlib/Algebra/Group/Action/Sum.lean
@@ -29,8 +29,8 @@ section SMul
 variable [SMul M α] [SMul M β] [SMul N α] [SMul N β] (a : M) (b : α) (c : β)
   (x : α ⊕ β)
 
-@[to_additive Sum.hasVAdd]
-instance : SMul M (α ⊕ β) :=
+@[to_additive Sum.instVAdd]
+instance Sum.instSMul : SMul M (α ⊕ β) :=
   ⟨fun a => Sum.map (a • ·) (a • ·)⟩
 
 @[to_additive]


### PR DESCRIPTION
We rename `Sum.instSMul_mathlib` to `Sum.instSMul` and `Sum.hasVAdd` to `Sum.instVAdd`.

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

When merging, all the commits will be squashed into a single commit
listing all co-authors.

Co-authors in the squash commit are gathered from two sources:

First, all authors of commits to this PR branch are included. Thus,
one way to add co-authors is to include at least one commit authored by
each co-author among the commits in the pull request. If necessary, you
may create empty commits to indicate co-authorship, using commands like so:

git commit --author="Author Name <author@email.com>" --allow-empty -m "add Author Name as coauthor"

Second, co-authors can also be listed in lines at the very bottom of
the commit message (that is, directly before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines
at the bottom of the commit message (before the `---`, and also before
any "Co-authored-by" lines) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
