### PR TITLE
[Merged by Bors] - doc(grw): mention `nth_grw` in doc-string

### DIFF
--- a/Mathlib/Tactic/GRewrite/Elab.lean
+++ b/Mathlib/Tactic/GRewrite/Elab.lean
@@ -56,24 +56,8 @@ def grewriteLocalDecl (stx : Syntax) (symm : Bool) (fvarId : FVarId) (config : G
 declare_config_elab elabGRewriteConfig GRewrite.Config
 
 /--
-`grewrite [e]` works just like `rewrite [e]`, but `e` can be a relation other than `=` or `↔`.
-
-For example,
-```lean
-variable {a b c d n : ℤ}
-
-example (h₁ : a < b) (h₂ : b ≤ c) : a + d ≤ c + d := by
-  grewrite [h₁, h₂]; rfl
-
-example (h : a ≡ b [ZMOD n]) : a ^ 2 ≡ b ^ 2 [ZMOD n] := by
-  grewrite [h]; rfl
-
-example (h₁ : a ∣ b) (h₂ : b ∣ a ^ 2 * c) : a ∣ b ^ 2 * c := by
-  grewrite [h₁] at *
-  exact h₂
-```
-To be able to use `grewrite`, the relevant lemmas need to be tagged with `@[gcongr]`.
-To rewrite inside a transitive relation, you can also give it an `IsTrans` instance.
+`grewrite [e]` is like `grw [e]`, but it doesn't try to close the goal with `rfl`.
+This is analogous to `rw` and `rewrite`, where `rewrite` doesn't try to close the goal with `rfl`.
 -/
 syntax (name := grewriteSeq) "grewrite" optConfig rwRuleSeq (location)? : tactic
 
@@ -103,6 +87,9 @@ example (h₁ : a ∣ b) (h₂ : b ∣ a ^ 2 * c) : a ∣ b ^ 2 * c := by
   grw [h₁] at *
   exact h₂
 ```
+To rewrite only in the `n`-th position, use `nth_grw n`.
+This is useful when `grw` tries to rewrite in a position that is not valid for the given relation.
+
 To be able to use `grw`, the relevant lemmas need to be tagged with `@[gcongr]`.
 To rewrite inside a transitive relation, you can also give it an `IsTrans` instance.
 -/


### PR DESCRIPTION
This PR mentions `nth_grw` in the doc-string of `grw`.

To avoid needing to also write this in the `grewrite` doc-string, I've changed that doc-string to just refer to `grw` instead of having the same description copied over.

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

When merging, all the commits will be squashed into a single commit
listing all co-authors.

Co-authors in the squash commit are gathered from two sources:

First, all authors of commits to this PR branch are included. Thus,
one way to add co-authors is to include at least one commit authored by
each co-author among the commits in the pull request. If necessary, you
may create empty commits to indicate co-authorship, using commands like so:

git commit --author="Author Name <author@email.com>" --allow-empty -m "add Author Name as coauthor"

Second, co-authors can also be listed in lines at the very bottom of
the commit message (that is, directly before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines
at the bottom of the commit message (before the `---`, and also before
any "Co-authored-by" lines) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
