### PR TITLE
[Merged by Bors] - doc: explain when to tag more specific lemmas with `gcongr`

### DIFF
--- a/Mathlib/Tactic/GCongr/Core.lean
+++ b/Mathlib/Tactic/GCongr/Core.lean
@@ -287,6 +287,11 @@ or more generally of the form `∀ i h h' j h'', f₁ i j ≈ f₂ i j` (say) fo
 pair `f₁`/`f₂`. (Other antecedents are considered to generate "side goals".) The index of the
 "varying argument" pair corresponding to each "main" antecedent is recorded.
 
+If a lemma such as `add_le_add : a ≤ b → c ≤ d → a + c ≤ b + d` has been tagged with `gcongr`,
+then a direct consequence like `a ≤ b → a + c ≤ b + d` does *not* need to be tagged.
+However, if a more specific lemma has fewer side conditions, is should also be tagged with `gcongr`.
+For example, `mul_le_mul_of_nonneg_right` and `mul_le_mul_of_nonneg_left` are both tagged.
+
 Lemmas involving `<` or `≤` can also be marked `@[bound]` for use in the related `bound` tactic. -/
 initialize registerBuiltinAttribute {
   name := `gcongr

--- a/Mathlib/Tactic/GCongr/Core.lean
+++ b/Mathlib/Tactic/GCongr/Core.lean
@@ -288,8 +288,8 @@ pair `f₁`/`f₂`. (Other antecedents are considered to generate "side goals".)
 "varying argument" pair corresponding to each "main" antecedent is recorded.
 
 If a lemma such as `add_le_add : a ≤ b → c ≤ d → a + c ≤ b + d` has been tagged with `gcongr`,
-then a direct consequence like `a ≤ b → a + c ≤ b + d` does *not* need to be tagged.
-However, if a more specific lemma has fewer side conditions, is should also be tagged with `gcongr`.
+then a direct consequence like `a ≤ b → a + c ≤ b + c` does *not* need to be tagged.
+However, if a more specific lemma has fewer side conditions, it should also be tagged with `gcongr`.
 For example, `mul_le_mul_of_nonneg_right` and `mul_le_mul_of_nonneg_left` are both tagged.
 
 Lemmas involving `<` or `≤` can also be marked `@[bound]` for use in the related `bound` tactic. -/


### PR DESCRIPTION
This documentation was requested by @grunweg

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

When merging, all the commits will be squashed into a single commit
listing all co-authors.

Co-authors in the squash commit are gathered from two sources:

First, all authors of commits to this PR branch are included. Thus,
one way to add co-authors is to include at least one commit authored by
each co-author among the commits in the pull request. If necessary, you
may create empty commits to indicate co-authorship, using commands like so:

git commit --author="Author Name <author@email.com>" --allow-empty -m "add Author Name as coauthor"

Second, co-authors can also be listed in lines at the very bottom of
the commit message (that is, directly before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines
at the bottom of the commit message (before the `---`, and also before
any "Co-authored-by" lines) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
