### PR TITLE
[Merged by Bors] - feat(RingTheory): `S[X] ⊗[R] R[Y] ≃ S[X, Y]`

### DIFF
--- a/Mathlib/RingTheory/TensorProduct/MvPolynomial.lean
+++ b/Mathlib/RingTheory/TensorProduct/MvPolynomial.lean
@@ -51,7 +51,7 @@ open Set LinearMap Submodule
 
 variable {R : Type u} {N : Type v} [CommSemiring R]
 
-variable {σ : Type*}
+variable {σ ι : Type*}
 
 variable {S : Type*} [CommSemiring S] [Algebra R S]
 
@@ -259,6 +259,35 @@ lemma aeval_one_tmul (f : σ → S) (p : MvPolynomial σ R) :
     rw [← mul_one ((algebraMap R N) a), ← Algebra.smul_def, smul_tmul, Algebra.smul_def, mul_one]
   | add p q hp hq => simp [hp, hq, tmul_add]
   | mul_X p i h => simp [h]
+
+variable (S σ ι) in
+/-- `S[X] ⊗[R] R[Y] ≃ S[X, Y]` -/
+def tensorEquivSum :
+    MvPolynomial σ S ⊗[R] MvPolynomial ι R ≃ₐ[S] MvPolynomial (σ ⊕ ι) S :=
+  ((algebraTensorAlgEquiv _ _).restrictScalars _).trans
+    ((sumAlgEquiv _ _ _).symm.trans  (renameEquiv _ (.sumComm ι σ)))
+
+variable {R}
+
+attribute [local simp] Algebra.smul_def
+
+@[simp] lemma tensorEquivSum_X_tmul_one (i) :
+    tensorEquivSum R σ ι S (.X i ⊗ₜ 1) = .X (.inl i) := by simp [tensorEquivSum]
+
+@[simp] lemma tensorEquivSum_C_tmul_one (r) :
+    tensorEquivSum R σ ι S (.C r ⊗ₜ 1) = .C r := by simp [tensorEquivSum]
+
+@[simp] lemma tensorEquivSum_one_tmul_X (i) :
+    tensorEquivSum R σ ι S (1 ⊗ₜ .X i) = .X (.inr i) := by simp [tensorEquivSum]
+
+@[simp] lemma tensorEquivSum_one_tmul_C (r) :
+    tensorEquivSum R σ ι S (1 ⊗ₜ .C r) = .C (algebraMap R S r) := by simp [tensorEquivSum]
+
+@[simp] lemma tensorEquivSum_C_tmul_C (r : R) (s : S) :
+    tensorEquivSum R σ ι S (.C s ⊗ₜ .C r) = .C (r • s) := by simp [tensorEquivSum, mul_comm (C s)]
+
+@[simp] lemma tensorEquivSum_X_tmul_X (i j) :
+    tensorEquivSum R σ ι S (.X i ⊗ₜ .X j) = .X (.inl i) * .X (.inr j) := by simp [tensorEquivSum]
 
 section Pushout
 


### PR DESCRIPTION

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

When merging, all the commits will be squashed into a single commit
listing all co-authors.

Co-authors in the squash commit are gathered from two sources:

First, all authors of commits to this PR branch are included. Thus,
one way to add co-authors is to include at least one commit authored by
each co-author among the commits in the pull request. If necessary, you
may create empty commits to indicate co-authorship, using commands like so:

git commit --author="Author Name <author@email.com>" --allow-empty -m "add Author Name as coauthor"

Second, co-authors can also be listed in lines at the very bottom of
the commit message (that is, directly before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines
at the bottom of the commit message (before the `---`, and also before
any "Co-authored-by" lines) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
