### PR TITLE
[Merged by Bors] - chore(LinearAlgebra/AffineSpace): golf entire `attach_affineCombination_of_injective` using `simp`

### DIFF
--- a/Mathlib/LinearAlgebra/AffineSpace/Combination.lean
+++ b/Mathlib/LinearAlgebra/AffineSpace/Combination.lean
@@ -402,17 +402,7 @@ theorem affineCombination_vsub (w₁ w₂ : ι → k) (p : ι → P) :
 theorem attach_affineCombination_of_injective [DecidableEq P] (s : Finset P) (w : P → k) (f : s → P)
     (hf : Function.Injective f) :
     s.attach.affineCombination k f (w ∘ f) = (image f univ).affineCombination k id w := by
-  simp only [affineCombination, weightedVSubOfPoint_apply, id, vadd_right_cancel_iff,
-    Function.comp_apply, AffineMap.coe_mk]
-  let g₁ : s → V := fun i => w (f i) • (f i -ᵥ Classical.choice S.nonempty)
-  let g₂ : P → V := fun i => w i • (i -ᵥ Classical.choice S.nonempty)
-  change univ.sum g₁ = (image f univ).sum g₂
-  have hgf : g₁ = g₂ ∘ f := by
-    ext
-    simp [g₁, g₂]
-  rw [hgf, sum_image]
-  · simp only [g₂,Function.comp_apply]
-  · exact fun _ _ _ _ hxy => hf hxy
+  simp_all [affineCombination]
 
 theorem attach_affineCombination_coe (s : Finset P) (w : P → k) :
     s.attach.affineCombination k ((↑) : s → P) (w ∘ (↑)) = s.affineCombination k id w := by

--- a/Mathlib/LinearAlgebra/AffineSpace/Combination.lean
+++ b/Mathlib/LinearAlgebra/AffineSpace/Combination.lean
@@ -402,7 +402,7 @@ theorem affineCombination_vsub (w₁ w₂ : ι → k) (p : ι → P) :
 theorem attach_affineCombination_of_injective [DecidableEq P] (s : Finset P) (w : P → k) (f : s → P)
     (hf : Function.Injective f) :
     s.attach.affineCombination k f (w ∘ f) = (image f univ).affineCombination k id w := by
-  simp_all [affineCombination]
+  simp [affineCombination, hf]
 
 theorem attach_affineCombination_coe (s : Finset P) (w : P → k) :
     s.attach.affineCombination k ((↑) : s → P) (w ∘ (↑)) = s.affineCombination k id w := by


### PR DESCRIPTION
---
<details>
<summary>Show trace profiling of <code>attach_affineCombination_of_injective</code>: 39 ms before, 83 ms after </summary>

### Trace profiling of `attach_affineCombination_of_injective` before PR 31363
```diff
diff --git a/Mathlib/LinearAlgebra/AffineSpace/Combination.lean b/Mathlib/LinearAlgebra/AffineSpace/Combination.lean
index dbcbffbf97..80a6e546e8 100644
--- a/Mathlib/LinearAlgebra/AffineSpace/Combination.lean
+++ b/Mathlib/LinearAlgebra/AffineSpace/Combination.lean
@@ -399,6 +399,7 @@ theorem affineCombination_vsub (w₁ w₂ : ι → k) (p : ι → P) :
     s.affineCombination k p w₁ -ᵥ s.affineCombination k p w₂ = s.weightedVSub p (w₁ - w₂) := by
   rw [← AffineMap.linearMap_vsub, affineCombination_linear, vsub_eq_sub]
 
+set_option trace.profiler true in
 theorem attach_affineCombination_of_injective [DecidableEq P] (s : Finset P) (w : P → k) (f : s → P)
     (hf : Function.Injective f) :
     s.attach.affineCombination k f (w ∘ f) = (image f univ).affineCombination k id w := by
```
```
ℹ [1120/1120] Built Mathlib.LinearAlgebra.AffineSpace.Combination (2.4s)
info: Mathlib/LinearAlgebra/AffineSpace/Combination.lean:403:0: [Elab.command] [0.011952] theorem attach_affineCombination_of_injective [DecidableEq P] (s : Finset P) (w : P → k)
        (f : s → P) (hf : Function.Injective f) :
        s.attach.affineCombination k f (w ∘ f) = (image f univ).affineCombination k id w :=
      by
      simp only [affineCombination, weightedVSubOfPoint_apply, id, vadd_right_cancel_iff, Function.comp_apply,
        AffineMap.coe_mk]
      let g₁ : s → V := fun i => w (f i) • (f i -ᵥ Classical.choice S.nonempty)
      let g₂ : P → V := fun i => w i • (i -ᵥ Classical.choice S.nonempty)
      change univ.sum g₁ = (image f univ).sum g₂
      have hgf : g₁ = g₂ ∘ f := by
        ext
        simp [g₁, g₂]
      rw [hgf, sum_image]
      · simp only [g₂, Function.comp_apply]
      · exact fun _ _ _ _ hxy => hf hxy
info: Mathlib/LinearAlgebra/AffineSpace/Combination.lean:403:0: [Elab.async] [0.041027] elaborating proof of Finset.attach_affineCombination_of_injective
  [Elab.definition.value] [0.039381] Finset.attach_affineCombination_of_injective
    [Elab.step] [0.038759] 
          simp only [affineCombination, weightedVSubOfPoint_apply, id, vadd_right_cancel_iff, Function.comp_apply,
            AffineMap.coe_mk]
          let g₁ : s → V := fun i => w (f i) • (f i -ᵥ Classical.choice S.nonempty)
          let g₂ : P → V := fun i => w i • (i -ᵥ Classical.choice S.nonempty)
          change univ.sum g₁ = (image f univ).sum g₂
          have hgf : g₁ = g₂ ∘ f := by
            ext
            simp [g₁, g₂]
          rw [hgf, sum_image]
          · simp only [g₂, Function.comp_apply]
          · exact fun _ _ _ _ hxy => hf hxy
      [Elab.step] [0.038753] 
            simp only [affineCombination, weightedVSubOfPoint_apply, id, vadd_right_cancel_iff, Function.comp_apply,
              AffineMap.coe_mk]
            let g₁ : s → V := fun i => w (f i) • (f i -ᵥ Classical.choice S.nonempty)
            let g₂ : P → V := fun i => w i • (i -ᵥ Classical.choice S.nonempty)
            change univ.sum g₁ = (image f univ).sum g₂
            have hgf : g₁ = g₂ ∘ f := by
              ext
              simp [g₁, g₂]
            rw [hgf, sum_image]
            · simp only [g₂, Function.comp_apply]
            · exact fun _ _ _ _ hxy => hf hxy
        [Elab.step] [0.014701] simp only [affineCombination, weightedVSubOfPoint_apply, id, vadd_right_cancel_iff,
              Function.comp_apply, AffineMap.coe_mk]
Build completed successfully (1120 jobs).
```

### Trace profiling of `attach_affineCombination_of_injective` after PR 31363
```diff
diff --git a/Mathlib/LinearAlgebra/AffineSpace/Combination.lean b/Mathlib/LinearAlgebra/AffineSpace/Combination.lean
index dbcbffbf97..f7919e28b5 100644
--- a/Mathlib/LinearAlgebra/AffineSpace/Combination.lean
+++ b/Mathlib/LinearAlgebra/AffineSpace/Combination.lean
@@ -399,20 +399,11 @@ theorem affineCombination_vsub (w₁ w₂ : ι → k) (p : ι → P) :
     s.affineCombination k p w₁ -ᵥ s.affineCombination k p w₂ = s.weightedVSub p (w₁ - w₂) := by
   rw [← AffineMap.linearMap_vsub, affineCombination_linear, vsub_eq_sub]
 
+set_option trace.profiler true in
 theorem attach_affineCombination_of_injective [DecidableEq P] (s : Finset P) (w : P → k) (f : s → P)
     (hf : Function.Injective f) :
     s.attach.affineCombination k f (w ∘ f) = (image f univ).affineCombination k id w := by
-  simp only [affineCombination, weightedVSubOfPoint_apply, id, vadd_right_cancel_iff,
-    Function.comp_apply, AffineMap.coe_mk]
-  let g₁ : s → V := fun i => w (f i) • (f i -ᵥ Classical.choice S.nonempty)
-  let g₂ : P → V := fun i => w i • (i -ᵥ Classical.choice S.nonempty)
-  change univ.sum g₁ = (image f univ).sum g₂
-  have hgf : g₁ = g₂ ∘ f := by
-    ext
-    simp [g₁, g₂]
-  rw [hgf, sum_image]
-  · simp only [g₂,Function.comp_apply]
-  · exact fun _ _ _ _ hxy => hf hxy
+  simp [affineCombination, hf]
 
 theorem attach_affineCombination_coe (s : Finset P) (w : P → k) :
     s.attach.affineCombination k ((↑) : s → P) (w ∘ (↑)) = s.affineCombination k id w := by
```
```
ℹ [1120/1120] Built Mathlib.LinearAlgebra.AffineSpace.Combination (2.4s)
info: Mathlib/LinearAlgebra/AffineSpace/Combination.lean:403:0: [Elab.command] [0.012162] theorem attach_affineCombination_of_injective [DecidableEq P] (s : Finset P) (w : P → k)
        (f : s → P) (hf : Function.Injective f) :
        s.attach.affineCombination k f (w ∘ f) = (image f univ).affineCombination k id w := by
      simp [affineCombination, hf]
info: Mathlib/LinearAlgebra/AffineSpace/Combination.lean:403:0: [Elab.async] [0.084734] elaborating proof of Finset.attach_affineCombination_of_injective
  [Elab.definition.value] [0.083451] Finset.attach_affineCombination_of_injective
    [Elab.step] [0.082443] simp [affineCombination, hf]
      [Elab.step] [0.082438] simp [affineCombination, hf]
        [Elab.step] [0.082430] simp [affineCombination, hf]
          [Meta.Tactic.simp.discharge] [0.030281] univ_eq_empty discharge ❌️
                IsEmpty ↥s
            [Meta.synthInstance] [0.028689] ❌️ Nonempty ↥s
Build completed successfully (1120 jobs).
```
</details>

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

When merging, all the commits will be squashed into a single commit
listing all co-authors.

Co-authors in the squash commit are gathered from two sources:

First, all authors of commits to this PR branch are included. Thus,
one way to add co-authors is to include at least one commit authored by
each co-author among the commits in the pull request. If necessary, you
may create empty commits to indicate co-authorship, using commands like so:

git commit --author="Author Name <author@email.com>" --allow-empty -m "add Author Name as coauthor"

Second, co-authors can also be listed in lines at the very bottom of
the commit message (that is, directly before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines
at the bottom of the commit message (before the `---`, and also before
any "Co-authored-by" lines) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
