### PR TITLE
chore(Algebra/Lie/Semisimple): golf `finitelyAtomistic` using `order`

### DIFF
--- a/Mathlib/Algebra/Lie/Semisimple/Basic.lean
+++ b/Mathlib/Algebra/Lie/Semisimple/Basic.lean
@@ -5,6 +5,7 @@ Authors: Oliver Nash
 -/
 import Mathlib.Algebra.Lie.Semisimple.Defs
 import Mathlib.Order.BooleanGenerators
+import Mathlib.Tactic.Order
 
 /-!
 # Semisimple Lie algebras
@@ -242,11 +243,7 @@ lemma finitelyAtomistic : ∀ s : Finset (LieIdeal R L), ↑s ⊆ {I : LieIdeal 
     apply LieSubmodule.lie_le_inf
     exact LieSubmodule.lie_mem_lie j.2 hx
   -- Indeed `J ⊓ I = ⊥`, since `J` is an atom that is not contained in `I`.
-  apply ((hs hJs).le_iff.mp _).resolve_right
-  · contrapose! hJI
-    rw [← hJI]
-    exact inf_le_right
-  exact inf_le_left
+  apply ((hs hJs).le_iff.mp _).resolve_right <;> order
 termination_by s => s.card
 decreasing_by exact Finset.card_lt_card hs'
 


### PR DESCRIPTION
---
_Update: Unfortunately the numbers do not look great here. Perhaps not worth it?_

<details>
<summary>Show trace profiling of <code>finitelyAtomistic</code>: 384 ms before, 515 ms after </summary>

### Trace profiling of `finitelyAtomistic` before PR 31369
```diff
diff --git a/Mathlib/Algebra/Lie/Semisimple/Basic.lean b/Mathlib/Algebra/Lie/Semisimple/Basic.lean
index 4d347c3612..9cdbbb887d 100644
--- a/Mathlib/Algebra/Lie/Semisimple/Basic.lean
+++ b/Mathlib/Algebra/Lie/Semisimple/Basic.lean
@@ -176,6 +176,7 @@ lemma isSimple_of_isAtom (I : LieIdeal R L) (hI : IsAtom I) : IsSimple R I where
     rcases hx with ⟨y, hy, rfl⟩
     exact hy
 
+set_option trace.profiler true in
 /--
 In a semisimple Lie algebra,
 Lie ideals that are contained in the supremum of a finite collection of atoms
```
```
ℹ [1607/1607] Built Mathlib.Algebra.Lie.Semisimple.Basic (3.7s)
info: Mathlib/Algebra/Lie/Semisimple/Basic.lean:180:0: [Elab.command] [0.065626] /-- In a semisimple Lie algebra,
    Lie ideals that are contained in the supremum of a finite collection of atoms
    are themselves the supremum of a finite subcollection of those atoms.
    
    By a compactness argument, this statement can be extended to arbitrary sets of atoms.
    See `atomistic`.
    
    The proof is by induction on the finite set of atoms.
    -/
    private theorem finitelyAtomistic :
        ∀ s : Finset (LieIdeal R L),
          ↑s ⊆ {I : LieIdeal R L | IsAtom I} → ∀ I : LieIdeal R L, I ≤ s.sup id → ∃ t ⊆ s, I = t.sup id :=
      by
      intro s hs I hI
      let S := {I : LieIdeal R L | IsAtom I}
      obtain rfl | hI := hI.eq_or_lt
      ·
        exact
          ⟨s, Finset.Subset.rfl, rfl⟩
            -- We assume that `I` is strictly smaller than the supremum of `s`.
              -- Hence there must exist an atom `J` that is not contained in `I`.
            
      obtain ⟨J, hJs, hJI⟩ : ∃ J ∈ s, ¬J ≤ I := by
        by_contra! H
        exact hI.ne (le_antisymm hI.le (s.sup_le H))
      classical
      let s' := s.erase J
      have hs' : s' ⊂ s := Finset.erase_ssubset hJs
      have hs'S : ↑s' ⊆ S := Set.Subset.trans (Finset.coe_subset.mpr hs'.subset) hs
      set K := s'.sup id
      suffices I ≤ K by
        obtain ⟨t, hts', htI⟩ := finitelyAtomistic s' hs'S I this
        exact
          ⟨t, hts'.trans hs'.subset, htI⟩
            -- Since `I` is contained in the supremum of `J` with the supremum of `s'`,
              -- any element `x` of `I` can be written as `y + z` for some `y ∈ J` and `z ∈ K`.
            
      intro x hx
      obtain ⟨y, hy, z, hz, rfl⟩ : ∃ y ∈ id J, ∃ z ∈ K, y + z = x :=
        by
        rw [← LieSubmodule.mem_sup, ← Finset.sup_insert, Finset.insert_erase hJs]
        exact hI.le hx
      suffices ⟨y, hy⟩ ∈ LieAlgebra.center R J
        by
        have _inst := isSimple_of_isAtom J (hs hJs)
        simp_all
          -- To show that `y` is in the center of `J`,
            -- we show that any `j ∈ J` brackets to `0` with `z` and with `x = y + z`.
            -- By a simple computation, that implies `⁅j, y⁆ = 0`, for all `j`, as desired.
          
      intro j
      suffices ⁅(j : L), z⁆ = 0 ∧ ⁅(j : L), y + z⁆ = 0
        by
        rw [lie_add, this.1, add_zero] at this
        ext
        exact this.2
      rw [← LieSubmodule.mem_bot (R := R) (L := L), ← LieSubmodule.mem_bot (R := R) (L := L)]
      constructor
        -- `j` brackets to `0` with `z`, since `⁅j, z⁆` is contained in `⁅J, K⁆ ≤ J ⊓ K`,
          -- and `J ⊓ K = ⊥` by the independence of the atoms.
        
      · apply (sSupIndep_isAtom.disjoint_sSup (hs hJs) hs'S (Finset.notMem_erase _ _)).le_bot
        apply LieSubmodule.lie_le_inf
        apply LieSubmodule.lie_mem_lie j.2
        simpa only [K, Finset.sup_id_eq_sSup] using hz
      suffices J ⊓ I = ⊥ by
        apply this.le
        apply LieSubmodule.lie_le_inf
        exact LieSubmodule.lie_mem_lie j.2 hx
      apply ((hs hJs).le_iff.mp _).resolve_right
      · contrapose! hJI
        rw [← hJI]
        exact inf_le_right
      exact inf_le_left
    termination_by s => s.card
    decreasing_by exact Finset.card_lt_card hs'
  [Elab.definition.header] [0.061504] _private.Mathlib.Algebra.Lie.Semisimple.Basic.0.LieAlgebra.IsSemisimple.finitelyAtomistic
    [Elab.step] [0.056783] expected type: Sort ?u.6922, term
        ∀ s : Finset (LieIdeal R L),
          ↑s ⊆ {I : LieIdeal R L | IsAtom I} → ∀ I : LieIdeal R L, I ≤ s.sup id → ∃ t ⊆ s, I = t.sup id
      [Elab.step] [0.056769] expected type: Sort ?u.6922, term
          ∀ (s : Finset (LieIdeal R L)),
            ↑s ⊆ {I : LieIdeal R L | IsAtom I} → ∀ I : LieIdeal R L, I ≤ s.sup id → ∃ t ⊆ s, I = t.sup id
        [Elab.step] [0.056268] expected type: Sort ?u.6939, term
            ↑s ⊆ {I : LieIdeal R L | IsAtom I} → ∀ I : LieIdeal R L, I ≤ s.sup id → ∃ t ⊆ s, I = t.sup id
          [Elab.step] [0.021088] expected type: Prop, term
              ↑s ⊆ {I : LieIdeal R L | IsAtom I}
            [Elab.step] [0.021076] expected type: Prop, term
                Subset✝ ↑s {I : LieIdeal R L | IsAtom I}
              [Elab.step] [0.020810] expected type: Set (LieIdeal R L), term
                  {I : LieIdeal R L | IsAtom I}
                [Elab.step] [0.018898] expected type: Set (LieIdeal R L), term
                    setOf✝ fun I : LieIdeal R L ↦ IsAtom I
                  [Elab.step] [0.018632] expected type: LieIdeal R L → Prop, term
                      fun I : LieIdeal R L ↦ IsAtom I
                    [Elab.step] [0.018620] expected type: LieIdeal R L → Prop, term
                        failed to pretty print term (use 'set_option pp.rawOnError true' for raw representation)
                      [Elab.step] [0.017904] expected type: Prop, term
                          IsAtom I
[… 2969 lines omitted …]
                                                                  (Eq.mp
                                                                    (congrArg (fun _a ↦ ⁅↑j, z⁆ = 0 ∧ _a = 0)
                                                                      (lie_add (↑j) y z))
                                                                    this))).right
                                                    [Meta.letToHave.debug] [0.018870] ✅️ visit (check := true)
                                                          Eq.mpr
                                                            (id
                                                              (congrArg (fun _a ↦ _a ∧ ⁅↑j, y + z⁆ = 0)
                                                                (Eq.symm (propext (LieSubmodule.mem_bot ⁅↑j, z⁆)))))
                                                            (Eq.mpr
                                                              (id
                                                                (congrArg (fun _a ↦ ⁅↑j, z⁆ ∈ ⊥ ∧ _a)
                                                                  (Eq.symm
                                                                    (propext (LieSubmodule.mem_bot ⁅↑j, y + z⁆)))))
                                                              ⟨Disjoint.le_bot
                                                                  (sSupIndep.disjoint_sSup sSupIndep_isAtom (a✝¹ hJs)
                                                                    hs'S (Finset.notMem_erase J s))
                                                                  (LieSubmodule.lie_le_inf J (sSup ↑s')
                                                                    (LieSubmodule.lie_mem_lie j.property
                                                                      (Eq.mp
                                                                        (congrArg (fun x ↦ z ∈ x)
                                                                          (Finset.sup_id_eq_sSup s'))
                                                                        hz))),
                                                                have this :=
                                                                  Or.resolve_right
                                                                    ((IsAtom.le_iff (a✝¹ hJs)).mp inf_le_left)
                                                                    (Mathlib.Tactic.Contrapose.mtr
                                                                      (Eq.mpr
                                                                        (id
                                                                          (implies_congr Classical.not_not._simp_3
                                                                            Classical.not_not._simp_3))
                                                                        fun hJI ↦
                                                                        Eq.mpr
                                                                          (id
                                                                            (congrArg (fun _a ↦ _a ≤ I) (Eq.symm hJI)))
                                                                          inf_le_right)
                                                                      hJI);
                                                                Eq.le this
                                                                  (LieSubmodule.lie_le_inf J I
                                                                    (LieSubmodule.lie_mem_lie j.property hx))⟩)
                                                      [Meta.letToHave.debug] [0.018399] ✅️ visit (check := true)
                                                            Eq.mpr
                                                              (id
                                                                (congrArg (fun _a ↦ ⁅↑j, z⁆ ∈ ⊥ ∧ _a)
                                                                  (Eq.symm
                                                                    (propext (LieSubmodule.mem_bot ⁅↑j, y + z⁆)))))
                                                              ⟨Disjoint.le_bot
                                                                  (sSupIndep.disjoint_sSup sSupIndep_isAtom (a✝¹ hJs)
                                                                    hs'S (Finset.notMem_erase J s))
                                                                  (LieSubmodule.lie_le_inf J (sSup ↑s')
                                                                    (LieSubmodule.lie_mem_lie j.property
                                                                      (Eq.mp
                                                                        (congrArg (fun x ↦ z ∈ x)
                                                                          (Finset.sup_id_eq_sSup s'))
                                                                        hz))),
                                                                have this :=
                                                                  Or.resolve_right
                                                                    ((IsAtom.le_iff (a✝¹ hJs)).mp inf_le_left)
                                                                    (Mathlib.Tactic.Contrapose.mtr
                                                                      (Eq.mpr
                                                                        (id
                                                                          (implies_congr Classical.not_not._simp_3
                                                                            Classical.not_not._simp_3))
                                                                        fun hJI ↦
                                                                        Eq.mpr
                                                                          (id
                                                                            (congrArg (fun _a ↦ _a ≤ I) (Eq.symm hJI)))
                                                                          inf_le_right)
                                                                      hJI);
                                                                Eq.le this
                                                                  (LieSubmodule.lie_le_inf J I
                                                                    (LieSubmodule.lie_mem_lie j.property hx))⟩
                                                        [Meta.letToHave.debug] [0.018179] ✅️ visit (check := true)
                                                              ⟨Disjoint.le_bot
                                                                  (sSupIndep.disjoint_sSup sSupIndep_isAtom (a✝¹ hJs)
                                                                    hs'S (Finset.notMem_erase J s))
                                                                  (LieSubmodule.lie_le_inf J (sSup ↑s')
                                                                    (LieSubmodule.lie_mem_lie j.property
                                                                      (Eq.mp
                                                                        (congrArg (fun x ↦ z ∈ x)
                                                                          (Finset.sup_id_eq_sSup s'))
                                                                        hz))),
                                                                have this :=
                                                                  Or.resolve_right
                                                                    ((IsAtom.le_iff (a✝¹ hJs)).mp inf_le_left)
                                                                    (Mathlib.Tactic.Contrapose.mtr
                                                                      (Eq.mpr
                                                                        (id
                                                                          (implies_congr Classical.not_not._simp_3
                                                                            Classical.not_not._simp_3))
                                                                        fun hJI ↦
                                                                        Eq.mpr
                                                                          (id
                                                                            (congrArg (fun _a ↦ _a ≤ I) (Eq.symm hJI)))
                                                                          inf_le_right)
                                                                      hJI);
                                                                Eq.le this
                                                                  (LieSubmodule.lie_le_inf J I
                                                                    (LieSubmodule.lie_mem_lie j.property hx))⟩
Build completed successfully (1607 jobs).
```

### Trace profiling of `finitelyAtomistic` after PR 31369
```diff
diff --git a/Mathlib/Algebra/Lie/Semisimple/Basic.lean b/Mathlib/Algebra/Lie/Semisimple/Basic.lean
index 4d347c3612..acffe7dcfc 100644
--- a/Mathlib/Algebra/Lie/Semisimple/Basic.lean
+++ b/Mathlib/Algebra/Lie/Semisimple/Basic.lean
@@ -5,6 +5,7 @@ Authors: Oliver Nash
 -/
 import Mathlib.Algebra.Lie.Semisimple.Defs
 import Mathlib.Order.BooleanGenerators
+import Mathlib.Tactic.Order
 
 /-!
 # Semisimple Lie algebras
@@ -176,6 +177,7 @@ lemma isSimple_of_isAtom (I : LieIdeal R L) (hI : IsAtom I) : IsSimple R I where
     rcases hx with ⟨y, hy, rfl⟩
     exact hy
 
+set_option trace.profiler true in
 /--
 In a semisimple Lie algebra,
 Lie ideals that are contained in the supremum of a finite collection of atoms
@@ -242,11 +244,7 @@ lemma finitelyAtomistic : ∀ s : Finset (LieIdeal R L), ↑s ⊆ {I : LieIdeal
     apply LieSubmodule.lie_le_inf
     exact LieSubmodule.lie_mem_lie j.2 hx
   -- Indeed `J ⊓ I = ⊥`, since `J` is an atom that is not contained in `I`.
-  apply ((hs hJs).le_iff.mp _).resolve_right
-  · contrapose! hJI
-    rw [← hJI]
-    exact inf_le_right
-  exact inf_le_left
+  apply ((hs hJs).le_iff.mp _).resolve_right <;> order
 termination_by s => s.card
 decreasing_by exact Finset.card_lt_card hs'
 
```
```
ℹ [1612/1612] Built Mathlib.Algebra.Lie.Semisimple.Basic (3.0s)
info: Mathlib/Algebra/Lie/Semisimple/Basic.lean:181:0: [Elab.command] [0.029180] /-- In a semisimple Lie algebra,
    Lie ideals that are contained in the supremum of a finite collection of atoms
    are themselves the supremum of a finite subcollection of those atoms.
    
    By a compactness argument, this statement can be extended to arbitrary sets of atoms.
    See `atomistic`.
    
    The proof is by induction on the finite set of atoms.
    -/
    private theorem finitelyAtomistic :
        ∀ s : Finset (LieIdeal R L),
          ↑s ⊆ {I : LieIdeal R L | IsAtom I} → ∀ I : LieIdeal R L, I ≤ s.sup id → ∃ t ⊆ s, I = t.sup id :=
      by
      intro s hs I hI
      let S := {I : LieIdeal R L | IsAtom I}
      obtain rfl | hI := hI.eq_or_lt
      ·
        exact
          ⟨s, Finset.Subset.rfl, rfl⟩
            -- We assume that `I` is strictly smaller than the supremum of `s`.
              -- Hence there must exist an atom `J` that is not contained in `I`.
            
      obtain ⟨J, hJs, hJI⟩ : ∃ J ∈ s, ¬J ≤ I := by
        by_contra! H
        exact hI.ne (le_antisymm hI.le (s.sup_le H))
      classical
      let s' := s.erase J
      have hs' : s' ⊂ s := Finset.erase_ssubset hJs
      have hs'S : ↑s' ⊆ S := Set.Subset.trans (Finset.coe_subset.mpr hs'.subset) hs
      set K := s'.sup id
      suffices I ≤ K by
        obtain ⟨t, hts', htI⟩ := finitelyAtomistic s' hs'S I this
        exact
          ⟨t, hts'.trans hs'.subset, htI⟩
            -- Since `I` is contained in the supremum of `J` with the supremum of `s'`,
              -- any element `x` of `I` can be written as `y + z` for some `y ∈ J` and `z ∈ K`.
            
      intro x hx
      obtain ⟨y, hy, z, hz, rfl⟩ : ∃ y ∈ id J, ∃ z ∈ K, y + z = x :=
        by
        rw [← LieSubmodule.mem_sup, ← Finset.sup_insert, Finset.insert_erase hJs]
        exact hI.le hx
      suffices ⟨y, hy⟩ ∈ LieAlgebra.center R J
        by
        have _inst := isSimple_of_isAtom J (hs hJs)
        simp_all
          -- To show that `y` is in the center of `J`,
            -- we show that any `j ∈ J` brackets to `0` with `z` and with `x = y + z`.
            -- By a simple computation, that implies `⁅j, y⁆ = 0`, for all `j`, as desired.
          
      intro j
      suffices ⁅(j : L), z⁆ = 0 ∧ ⁅(j : L), y + z⁆ = 0
        by
        rw [lie_add, this.1, add_zero] at this
        ext
        exact this.2
      rw [← LieSubmodule.mem_bot (R := R) (L := L), ← LieSubmodule.mem_bot (R := R) (L := L)]
      constructor
        -- `j` brackets to `0` with `z`, since `⁅j, z⁆` is contained in `⁅J, K⁆ ≤ J ⊓ K`,
          -- and `J ⊓ K = ⊥` by the independence of the atoms.
        
      · apply (sSupIndep_isAtom.disjoint_sSup (hs hJs) hs'S (Finset.notMem_erase _ _)).le_bot
        apply LieSubmodule.lie_le_inf
        apply LieSubmodule.lie_mem_lie j.2
        simpa only [K, Finset.sup_id_eq_sSup] using hz
      suffices J ⊓ I = ⊥ by
        apply this.le
        apply LieSubmodule.lie_le_inf
        exact LieSubmodule.lie_mem_lie j.2 hx
      apply ((hs hJs).le_iff.mp _).resolve_right <;> order
    termination_by s => s.card
    decreasing_by exact Finset.card_lt_card hs'
  [Elab.definition.header] [0.026744] _private.Mathlib.Algebra.Lie.Semisimple.Basic.0.LieAlgebra.IsSemisimple.finitelyAtomistic
    [Elab.step] [0.024521] expected type: Sort ?u.6922, term
        ∀ s : Finset (LieIdeal R L),
          ↑s ⊆ {I : LieIdeal R L | IsAtom I} → ∀ I : LieIdeal R L, I ≤ s.sup id → ∃ t ⊆ s, I = t.sup id
      [Elab.step] [0.024511] expected type: Sort ?u.6922, term
          ∀ (s : Finset (LieIdeal R L)),
            ↑s ⊆ {I : LieIdeal R L | IsAtom I} → ∀ I : LieIdeal R L, I ≤ s.sup id → ∃ t ⊆ s, I = t.sup id
        [Elab.step] [0.024050] expected type: Sort ?u.6939, term
            ↑s ⊆ {I : LieIdeal R L | IsAtom I} → ∀ I : LieIdeal R L, I ≤ s.sup id → ∃ t ⊆ s, I = t.sup id
          [Elab.step] [0.015083] expected type: Sort ?u.7124, term
              ∀ I : LieIdeal R L, I ≤ s.sup id → ∃ t ⊆ s, I = t.sup id
            [Elab.step] [0.015075] expected type: Sort ?u.7124, term
                ∀ (I : LieIdeal R L), I ≤ s.sup id → ∃ t ⊆ s, I = t.sup id
              [Elab.step] [0.014757] expected type: Sort ?u.7132, term
                  I ≤ s.sup id → ∃ t ⊆ s, I = t.sup id
info: Mathlib/Algebra/Lie/Semisimple/Basic.lean:181:0: [Elab.command] [0.029355] /-- In a semisimple Lie algebra,
    Lie ideals that are contained in the supremum of a finite collection of atoms
    are themselves the supremum of a finite subcollection of those atoms.
    
    By a compactness argument, this statement can be extended to arbitrary sets of atoms.
    See `atomistic`.
    
    The proof is by induction on the finite set of atoms.
    -/
    private lemma finitelyAtomistic :
        ∀ s : Finset (LieIdeal R L),
          ↑s ⊆ {I : LieIdeal R L | IsAtom I} → ∀ I : LieIdeal R L, I ≤ s.sup id → ∃ t ⊆ s, I = t.sup id :=
[… 3001 lines omitted …]
                                                                                (Mathlib.Tactic.Order.not_lt_of_not_le
                                                                                  _order_neg_goal)
                                                                                (le_trans inf_le_left (le_refl J)))
                                                                              (le_refl (J ⊓ I))))))
                                                                    fun _order_neg_goal ↦
                                                                    ne_of_not_le hJI
                                                                      (le_antisymm
                                                                        (le_trans (ge_of_eq _order_neg_goal)
                                                                          (le_trans inf_le_right (le_refl I)))
                                                                        (le_trans
                                                                          (Mathlib.Tactic.Order.le_of_not_lt_le
                                                                            (Mathlib.Tactic.Order.not_lt_of_not_le hJI)
                                                                            (le_trans (ge_of_eq _order_neg_goal)
                                                                              (le_trans inf_le_right (le_refl I))))
                                                                          (le_refl J)));
                                                                Eq.le this
                                                                  (LieSubmodule.lie_le_inf J I
                                                                    (LieSubmodule.lie_mem_lie j.property hx))⟩)
                                                      [Meta.letToHave.debug] [0.012176] ✅️ visit (check := true)
                                                            Eq.mpr
                                                              (id
                                                                (congrArg (fun _a ↦ ⁅↑j, z⁆ ∈ ⊥ ∧ _a)
                                                                  (Eq.symm
                                                                    (propext (LieSubmodule.mem_bot ⁅↑j, y + z⁆)))))
                                                              ⟨Disjoint.le_bot
                                                                  (sSupIndep.disjoint_sSup sSupIndep_isAtom (a✝¹ hJs)
                                                                    hs'S (Finset.notMem_erase J s))
                                                                  (LieSubmodule.lie_le_inf J (sSup ↑s')
                                                                    (LieSubmodule.lie_mem_lie j.property
                                                                      (Eq.mp
                                                                        (congrArg (fun x ↦ z ∈ x)
                                                                          (Finset.sup_id_eq_sSup s'))
                                                                        hz))),
                                                                have this :=
                                                                  Or.resolve_right
                                                                    ((IsAtom.le_iff (a✝¹ hJs)).mp
                                                                      (Decidable.byContradiction fun _order_neg_goal ↦
                                                                        ne_of_not_le _order_neg_goal
                                                                          (le_antisymm
                                                                            (le_trans inf_le_left (le_refl J))
                                                                            (le_trans
                                                                              (Mathlib.Tactic.Order.le_of_not_lt_le
                                                                                (Mathlib.Tactic.Order.not_lt_of_not_le
                                                                                  _order_neg_goal)
                                                                                (le_trans inf_le_left (le_refl J)))
                                                                              (le_refl (J ⊓ I))))))
                                                                    fun _order_neg_goal ↦
                                                                    ne_of_not_le hJI
                                                                      (le_antisymm
                                                                        (le_trans (ge_of_eq _order_neg_goal)
                                                                          (le_trans inf_le_right (le_refl I)))
                                                                        (le_trans
                                                                          (Mathlib.Tactic.Order.le_of_not_lt_le
                                                                            (Mathlib.Tactic.Order.not_lt_of_not_le hJI)
                                                                            (le_trans (ge_of_eq _order_neg_goal)
                                                                              (le_trans inf_le_right (le_refl I))))
                                                                          (le_refl J)));
                                                                Eq.le this
                                                                  (LieSubmodule.lie_le_inf J I
                                                                    (LieSubmodule.lie_mem_lie j.property hx))⟩
                                                        [Meta.letToHave.debug] [0.012092] ✅️ visit (check := true)
                                                              ⟨Disjoint.le_bot
                                                                  (sSupIndep.disjoint_sSup sSupIndep_isAtom (a✝¹ hJs)
                                                                    hs'S (Finset.notMem_erase J s))
                                                                  (LieSubmodule.lie_le_inf J (sSup ↑s')
                                                                    (LieSubmodule.lie_mem_lie j.property
                                                                      (Eq.mp
                                                                        (congrArg (fun x ↦ z ∈ x)
                                                                          (Finset.sup_id_eq_sSup s'))
                                                                        hz))),
                                                                have this :=
                                                                  Or.resolve_right
                                                                    ((IsAtom.le_iff (a✝¹ hJs)).mp
                                                                      (Decidable.byContradiction fun _order_neg_goal ↦
                                                                        ne_of_not_le _order_neg_goal
                                                                          (le_antisymm
                                                                            (le_trans inf_le_left (le_refl J))
                                                                            (le_trans
                                                                              (Mathlib.Tactic.Order.le_of_not_lt_le
                                                                                (Mathlib.Tactic.Order.not_lt_of_not_le
                                                                                  _order_neg_goal)
                                                                                (le_trans inf_le_left (le_refl J)))
                                                                              (le_refl (J ⊓ I))))))
                                                                    fun _order_neg_goal ↦
                                                                    ne_of_not_le hJI
                                                                      (le_antisymm
                                                                        (le_trans (ge_of_eq _order_neg_goal)
                                                                          (le_trans inf_le_right (le_refl I)))
                                                                        (le_trans
                                                                          (Mathlib.Tactic.Order.le_of_not_lt_le
                                                                            (Mathlib.Tactic.Order.not_lt_of_not_le hJI)
                                                                            (le_trans (ge_of_eq _order_neg_goal)
                                                                              (le_trans inf_le_right (le_refl I))))
                                                                          (le_refl J)));
                                                                Eq.le this
                                                                  (LieSubmodule.lie_le_inf J I
                                                                    (LieSubmodule.lie_mem_lie j.property hx))⟩
info: Mathlib/Algebra/Lie/Semisimple/Basic.lean:192:6: [Elab.async] [0.012336] Lean.addDecl
  [Kernel] [0.011739] ✅️ typechecking declarations [_private.Mathlib.Algebra.Lie.Semisimple.Basic.0.LieAlgebra.IsSemisimple.finitelyAtomistic._unary]
Build completed successfully (1612 jobs).
```
</details>

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

When merging, all the commits will be squashed into a single commit
listing all co-authors.

Co-authors in the squash commit are gathered from two sources:

First, all authors of commits to this PR branch are included. Thus,
one way to add co-authors is to include at least one commit authored by
each co-author among the commits in the pull request. If necessary, you
may create empty commits to indicate co-authorship, using commands like so:

git commit --author="Author Name <author@email.com>" --allow-empty -m "add Author Name as coauthor"

Second, co-authors can also be listed in lines at the very bottom of
the commit message (that is, directly before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines
at the bottom of the commit message (before the `---`, and also before
any "Co-authored-by" lines) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
