### PR TITLE
chore: use `order` instead of `linarith` to make the intent clearer

### DIFF
--- a/Mathlib/Analysis/Convex/Slope.lean
+++ b/Mathlib/Analysis/Convex/Slope.lean
@@ -7,6 +7,7 @@ import Mathlib.Analysis.Convex.Function
 import Mathlib.Tactic.AdaptationNote
 import Mathlib.Tactic.FieldSimp
 import Mathlib.Tactic.Linarith
+import Mathlib.Tactic.Order
 
 /-!
 # Slopes of convex functions
@@ -214,7 +215,7 @@ theorem StrictConvexOn.secant_strict_mono_aux1 (hf : StrictConvexOn 𝕜 s f) {x
   have hxz' : 0 < z - x := by linarith
   have ha : 0 < (z - y) / (z - x) := by positivity
   have hb : 0 < (y - x) / (z - x) := by positivity
-  have key := hf.2 hx hz (by linarith) ha hb ?_
+  have key := hf.2 hx hz (by order) ha hb ?_
   · simp only [smul_eq_mul] at key
     ring_nf at key
     field_simp at key

--- a/Mathlib/Analysis/InnerProductSpace/Subspace.lean
+++ b/Mathlib/Analysis/InnerProductSpace/Subspace.lean
@@ -210,7 +210,7 @@ theorem OrthogonalFamily.summable_iff_norm_sq_summable [CompleteSpace E] (f : �
           abs_of_nonneg (norm_nonneg _)]
         exact H s₁ hs₁ s₂ hs₂
       have hη := sq_sqrt (le_of_lt hε)
-      linarith
+      order
     · intro hf ε hε
       have hε' : 0 < ε ^ 2 / 2 := half_pos (sq_pos_of_pos hε)
       obtain ⟨a, H⟩ := hf _ hε'

--- a/Mathlib/Analysis/MeanInequalities.lean
+++ b/Mathlib/Analysis/MeanInequalities.lean
@@ -156,7 +156,7 @@ theorem geom_mean_le_arith_mean {ι : Type*} (s : Finset ι) (w : ι → ℝ) (z
   · simp_rw [div_eq_mul_inv, mul_assoc, mul_comm, ← mul_assoc, ← Finset.sum_mul, mul_comm]
   · exact fun _ hi => div_nonneg (hw _ hi) (le_of_lt hw')
   · simp_rw [div_eq_mul_inv, ← Finset.sum_mul]
-    exact mul_inv_cancel₀ (by linarith)
+    exact mul_inv_cancel₀ (by order)
 
 theorem geom_mean_weighted_of_constant (w z : ι → ℝ) (x : ℝ) (hw : ∀ i ∈ s, 0 ≤ w i)
     (hw' : ∑ i ∈ s, w i = 1) (hz : ∀ i ∈ s, 0 ≤ z i) (hx : ∀ i ∈ s, w i ≠ 0 → z i = x) :

--- a/Mathlib/Analysis/SpecialFunctions/BinaryEntropy.lean
+++ b/Mathlib/Analysis/SpecialFunctions/BinaryEntropy.lean
@@ -102,7 +102,7 @@ lemma binEntropy_neg_of_neg (hp : p < 0) : binEntropy p < 0 := by
     nlinarith [log_pos_of_lt_neg_one hp']
   · have : -p * log p ≤ 0 := by
       wlog h : -1 < p
-      · simp only [show p = -1 by linarith, log_neg_eq_log, log_one, le_refl, mul_zero]
+      · simp only [show p = -1 by order, log_neg_eq_log, log_one, le_refl, mul_zero]
       · nlinarith [log_neg_of_lt_zero hp h]
     nlinarith [(log_pos (by linarith) : 0 < log (1 - p))]
 
@@ -136,7 +136,7 @@ lemma binEntropy_lt_log_two : binEntropy p < log 2 ↔ p ≠ 2⁻¹ := by
     simp at h
   wlog hp : p < 2⁻¹
   · have hp : 1 - p < 2⁻¹ := by
-      rw [sub_lt_comm]; norm_num at *; linarith +splitNe
+      rw [sub_lt_comm]; norm_num at *; order
     rw [← binEntropy_one_sub]
     exact this hp.ne hp
   obtain hp₀ | hp₀ := le_or_gt p 0
@@ -302,7 +302,7 @@ lemma not_continuousAt_deriv_qaryEntropy_one :
   · simp_all only [mem_Ioo, ne_eq]
     linarith [show (1 : ℝ) = 2⁻¹ + 2⁻¹ by norm_num]
   · simp_all only [mem_Ioo, ne_eq]
-    linarith [two_inv_lt_one (α := ℝ)]
+    order
 
 lemma not_continuousAt_deriv_qaryEntropy_zero :
     ¬ContinuousAt (deriv (qaryEntropy q)) 0 := by
@@ -315,11 +315,9 @@ lemma not_continuousAt_deriv_qaryEntropy_zero :
   · simp only [disjoint_nhds_atTop_iff, not_isTop, not_false_eq_true]
   filter_upwards [Ioo_mem_nhdsGT (show (0 : ℝ) < 2⁻¹ by norm_num)]
   intros
-  apply (deriv_qaryEntropy _ _).symm
-  · simp_all only [mem_Ioo, ne_eq]
-    linarith
-  · simp_all only [mem_Ioo, ne_eq]
-    linarith [two_inv_lt_one (α := ℝ)]
+  apply (deriv_qaryEntropy _ _).symm <;>
+    simp_all only [mem_Ioo, ne_eq] <;>
+    order [two_inv_lt_one (α := ℝ)]
 
 /-- Second derivative of q-ary entropy. -/
 lemma deriv2_qaryEntropy :
@@ -374,9 +372,9 @@ lemma qaryEntropy_strictMonoOn (qLe2 : 2 ≤ q) :
         simp_all only [inv_pos, interior_Icc, mem_Ioo, one_div]
       linarith
     simp only [one_div, interior_Icc, mem_Ioo] at hp
-    rw [deriv_qaryEntropy (by linarith)]
+    rw [deriv_qaryEntropy (by order)]
     · simp only [sub_pos, gt_iff_lt]
-      rw [← log_mul (by linarith) (by linarith)]
+      rw [← log_mul (by linarith) (by order)]
       apply Real.strictMonoOn_log (mem_Ioi.mpr hp.1)
       · simp_all only [mem_Ioi, mul_pos_iff_of_pos_left, show 0 < (q : ℝ) - 1 by linarith]
       · have qpos : 0 < (q : ℝ) := by positivity
@@ -400,7 +398,7 @@ lemma qaryEntropy_strictAntiOn (qLe2 : 2 ≤ q) :
     simp only [one_div, interior_Icc, mem_Ioo] at hp
     rw [deriv_qaryEntropy (by linarith)]
     · simp only [sub_neg, gt_iff_lt]
-      rw [← log_mul (by linarith) (by linarith)]
+      rw [← log_mul (by linarith) (by order)]
       apply Real.strictMonoOn_log (mem_Ioi.mpr (show 0 < (↑q - 1) * (1 - p) by nlinarith))
       · simp_all only [mem_Ioi]
         linarith

--- a/Mathlib/Analysis/SpecialFunctions/Gamma/Basic.lean
+++ b/Mathlib/Analysis/SpecialFunctions/Gamma/Basic.lean
@@ -304,7 +304,7 @@ theorem Gamma_eq_GammaAux (s : ℂ) (n : ℕ) (h1 : -s.re < ↑n) : Gamma s = Ga
     exact_mod_cast lt_of_le_of_lt (Nat.floor_le h) (by linarith : 1 - s.re < n + 1)
   · rw [Nat.floor_of_nonpos]
     · cutsat
-    · linarith
+    · order
 
 /-- The recurrence relation for the `Γ` function. -/
 theorem Gamma_add_one (s : ℂ) (h2 : s ≠ 0) : Gamma (s + 1) = s * Gamma s := by

--- a/Mathlib/Analysis/SpecialFunctions/Integrals/PosLogEqCircleAverage.lean
+++ b/Mathlib/Analysis/SpecialFunctions/Integrals/PosLogEqCircleAverage.lean
@@ -161,7 +161,7 @@ theorem circleAverage_log_norm_sub_const₂ (h : 1 < ‖a‖) :
   rw [sub_ne_zero]
   by_contra!
   simp_all only [abs_one, Metric.mem_closedBall, dist_zero_right]
-  linarith
+  order
 
 /-!
 ## Presentation of `log⁺` in Terms of Circle Averages

--- a/Mathlib/Analysis/SpecialFunctions/Log/Base.lean
+++ b/Mathlib/Analysis/SpecialFunctions/Log/Base.lean
@@ -179,7 +179,7 @@ include hb
 private theorem b_pos : 0 < b := by linarith
 
 -- Name has a prime added to avoid clashing with `b_ne_one` further down the file
-private theorem b_ne_one' : b ≠ 1 := by linarith
+private theorem b_ne_one' : b ≠ 1 := by order
 
 @[simp]
 theorem logb_le_logb (h : 0 < x) (h₁ : 0 < y) : logb b x ≤ logb b y ↔ x ≤ y := by
@@ -187,7 +187,7 @@ theorem logb_le_logb (h : 0 < x) (h₁ : 0 < y) : logb b x ≤ logb b y ↔ x �
 
 @[gcongr]
 theorem logb_le_logb_of_le (h : 0 < x) (hxy : x ≤ y) : logb b x ≤ logb b y :=
-  (logb_le_logb hb h (by linarith)).mpr hxy
+  (logb_le_logb hb h (by order)).mpr hxy
 
 @[gcongr]
 theorem logb_lt_logb (hx : 0 < x) (hxy : x < y) : logb b x < logb b y := by
@@ -271,7 +271,7 @@ section BPosAndBLtOne
 variable (b_pos : 0 < b) (b_lt_one : b < 1)
 include b_lt_one
 
-private theorem b_ne_one : b ≠ 1 := by linarith
+private theorem b_ne_one : b ≠ 1 := by order
 
 include b_pos
 
@@ -451,7 +451,7 @@ lemma tendsto_abs_logb_atTop (hb : b ≠ -1 ∧ b ≠ 0 ∧ b ≠ 1) :
   · exact (this (b := -b) (by simp [hb, neg_eq_iff_eq_neg]) (by linarith +splitNe)).congr (by simp)
   wlog hb₁ : 1 < b generalizing b
   · exact (this (b := b⁻¹) (by simp [hb, inv_eq_iff_eq_inv, inv_neg]) (by simpa)
-      ((one_lt_inv₀ hb₀).2 (by linarith +splitNe))).congr (by simp)
+      ((one_lt_inv₀ hb₀).2 (by order))).congr (by simp)
   refine (tendsto_logb_atTop hb₁).congr' ?_
   filter_upwards [eventually_ge_atTop 1] with x hx₁
   rw [abs_of_nonneg]

--- a/Mathlib/Analysis/SpecialFunctions/Log/Monotone.lean
+++ b/Mathlib/Analysis/SpecialFunctions/Log/Monotone.lean
@@ -52,7 +52,7 @@ theorem log_div_self_rpow_antitoneOn {a : ℝ} (ha : 0 < a) :
   simp only [AntitoneOn, mem_setOf_eq]
   intro x hex y _ hxy
   have x_pos : 0 < x := lt_of_lt_of_le (exp_pos (1 / a)) hex
-  have y_pos : 0 < y := by linarith
+  have y_pos : 0 < y := by order
   nth_rw 1 [← rpow_one y]
   nth_rw 1 [← rpow_one x]
   rw [← div_self (ne_of_lt ha).symm, div_eq_mul_one_div a a, rpow_mul y_pos.le, rpow_mul x_pos.le,

--- a/Mathlib/Analysis/SpecialFunctions/Log/PosLog.lean
+++ b/Mathlib/Analysis/SpecialFunctions/Log/PosLog.lean
@@ -98,7 +98,7 @@ theorem monotoneOn_posLog : MonotoneOn log⁺ (Set.Ici 0) := by
   · right
     have := log_le_log (lt_trans Real.zero_lt_one ((log_pos_iff hx).1 h)) hxy
     simp only [this, and_true, ge_iff_le]
-    linarith
+    order
 
 @[gcongr]
 lemma posLog_le_posLog (hx : 0 ≤ x) (hxy : x ≤ y) : log⁺ x ≤ log⁺ y :=

--- a/Mathlib/Combinatorics/Schnirelmann.lean
+++ b/Mathlib/Combinatorics/Schnirelmann.lean
@@ -8,6 +8,7 @@ import Mathlib.Data.Nat.ModEq
 import Mathlib.Data.Nat.Prime.Defs
 import Mathlib.Data.Real.Archimedean
 import Mathlib.Order.Interval.Finset.Nat
+import Mathlib.Tactic.Order
 
 /-!
 # Schnirelmann density
@@ -183,7 +184,7 @@ lemma exists_of_schnirelmannDensity_eq_zero {ε : ℝ} (hε : 0 < ε) (hA : schn
     ∃ n, 0 < n ∧ #{a ∈ Ioc 0 n | a ∈ A} / n < ε := by
   by_contra! h
   rw [← le_schnirelmannDensity_iff] at h
-  linarith
+  order
 
 end
 

--- a/Mathlib/Computability/AkraBazzi/GrowsPolynomially.lean
+++ b/Mathlib/Computability/AkraBazzi/GrowsPolynomially.lean
@@ -189,7 +189,7 @@ lemma eventually_atTop_nonneg_or_nonpos (hf : GrowsPolynomially f) :
         intro x ⟨hxlb, hxub⟩
         have h₁ := calc n₀ ≤ 1 * max n₀ 2 := by simp
                         _ ≤ 2 * max n₀ 2 := by gcongr; norm_num
-        have h₂ := hn₀ (2 * max n₀ 2) h₁ (max n₀ 2) ⟨by simp, by linarith⟩
+        have h₂ := hn₀ (2 * max n₀ 2) h₁ (max n₀ 2) ⟨by simp, by order⟩
         rw [h₂]
         exact hn₀ (2 * max n₀ 2) h₁ x ⟨by simp [hxlb], le_of_lt hxub⟩
       case step =>
@@ -608,7 +608,7 @@ protected lemma GrowsPolynomially.rpow (p : ℝ) (hf : GrowsPolynomially f)
           _ = _ := by rw [← mul_rpow (le_of_lt hc₁_mem) (le_of_lt hf_pos)]
     | .inr (.inr hneg) => -- eventually negative (which is impossible)
       have : ∀ᶠ (_ : ℝ) in atTop, False := by
-        filter_upwards [hf_nonneg, hneg] with x hx hx'; linarith
+        filter_upwards [hf_nonneg, hneg] with x hx hx'; order
       rw [Filter.eventually_false_iff_eq_bot] at this
       exact False.elim <| (atTop_neBot).ne this
 

--- a/Mathlib/Computability/AkraBazzi/SumTransform.lean
+++ b/Mathlib/Computability/AkraBazzi/SumTransform.lean
@@ -506,7 +506,7 @@ lemma tendsto_zero_sumCoeffsExp : Tendsto (fun (p : ℝ) => ∑ i, a i * (b i) ^
 lemma tendsto_atTop_sumCoeffsExp : Tendsto (fun (p : ℝ) => ∑ i, a i * (b i) ^ p) atBot atTop := by
   have h₁ : Tendsto (fun p : ℝ => (a (max_bi b) : ℝ) * b (max_bi b) ^ p) atBot atTop :=
     Tendsto.const_mul_atTop (R.a_pos (max_bi b)) <| tendsto_rpow_atBot_of_base_lt_one _
-      (by have := R.b_pos (max_bi b); linarith) (R.b_lt_one _)
+      (by have := R.b_pos (max_bi b); order) (R.b_lt_one _)
   refine tendsto_atTop_mono (fun p => ?_) h₁
   refine Finset.single_le_sum (f := fun i => (a i : ℝ) * b i ^ p) (fun i _ => ?_) (mem_univ _)
   positivity [R.a_pos i, R.b_pos i]

--- a/Mathlib/FieldTheory/PrimitiveElement.lean
+++ b/Mathlib/FieldTheory/PrimitiveElement.lean
@@ -8,6 +8,7 @@ import Mathlib.FieldTheory.IsAlgClosed.Basic
 import Mathlib.FieldTheory.SplittingField.Construction
 import Mathlib.RingTheory.IntegralDomain
 import Mathlib.RingTheory.Polynomial.UniqueFactorization
+import Mathlib.Tactic.Order
 
 /-!
 # Primitive Element Theorem
@@ -253,7 +254,7 @@ theorem isAlgebraic_of_adjoin_eq_adjoin {α : E} {m n : ℕ} (hneq : m ≠ n)
   let f : F[X] := X ^ m * expand F n s - expand F n r
   refine ⟨f, ?_, ?_⟩
   · have : f.coeff (n * s.natDegree + m) ≠ 0 := by
-      have hn : 0 < n := by linarith only [hm, hmn]
+      have hn : 0 < n := by order
       have hndvd : ¬ n ∣ n * s.natDegree + m := by
         rw [← Nat.dvd_add_iff_right (n.dvd_mul_right s.natDegree)]
         exact Nat.not_dvd_of_pos_of_lt hm hmn

--- a/Mathlib/FieldTheory/SeparableDegree.lean
+++ b/Mathlib/FieldTheory/SeparableDegree.lean
@@ -11,6 +11,7 @@ import Mathlib.RingTheory.AlgebraicIndependent.Adjoin
 import Mathlib.RingTheory.AlgebraicIndependent.TranscendenceBasis
 import Mathlib.RingTheory.Polynomial.SeparableDegree
 import Mathlib.RingTheory.Polynomial.UniqueFactorization
+import Mathlib.Tactic.Order
 
 /-!
 
@@ -777,7 +778,7 @@ theorem finSepDegree_eq_finrank_iff [FiniteDimensional F E] :
     have := Nat.mul_lt_mul_of_lt_of_le' h (finSepDegree_le_finrank F⟮x⟯ E) Fin.pos'
     rw [finSepDegree_mul_finSepDegree_of_isAlgebraic F F⟮x⟯ E,
       Module.finrank_mul_finrank F F⟮x⟯ E] at this
-    linarith only [heq, this]⟩, fun _ ↦ finSepDegree_eq_finrank_of_isSeparable F E⟩
+    order⟩, fun _ ↦ finSepDegree_eq_finrank_of_isSeparable F E⟩
 
 end Field
 

--- a/Mathlib/Geometry/Euclidean/Triangle.lean
+++ b/Mathlib/Geometry/Euclidean/Triangle.lean
@@ -360,19 +360,19 @@ theorem dist_lt_of_angle_lt {a b c : P} (h : ¬Collinear ℝ ({a, b, c} : Set P)
     by_contra! w
     have h4 : Real.sin (∠ a c b) * dist a c < Real.sin (∠ a b c) * dist a b := by
       exact mul_lt_mul h3 w hac hsinabc
-    linarith
+    order
   · by_contra! w
     have h3 : Real.sin (∠ a b c) ≤ Real.sin (∠ a c b) := by
       by_contra! w1
       have h4 : Real.sin (∠ a c b) * dist a c < Real.sin (∠ a b c) * dist a b := by
         exact mul_lt_mul w1 w hac hsinabc
-      linarith
+      order
     rw [← Real.sin_pi_sub (∠ a b c)] at h3
     have h5 : π - ∠ a b c < π / 2 := by linarith
     have h6 : π - ∠ a b c ≤ ∠ a c b := by
       by_contra! w1
       have := Real.sin_lt_sin_of_lt_of_le_pi_div_two (by linarith [angle_nonneg a c b]) h5.le w1
-      linarith
+      order
     have h7 := angle_add_angle_add_angle_eq_pi c (ne₁₂_of_not_collinear h).symm
     rw [angle_comm b c a] at h7
     have h8 : ∠ c a b > 0 := by
@@ -394,10 +394,10 @@ theorem angle_lt_iff_dist_lt {a b c : P} (h : ¬Collinear ℝ ({a, b, c} : Set P
         apply dist_eq_of_angle_eq_angle_of_angle_ne_pi h2
         rw [show ({a, b, c} : Set P) = {b, a, c} by exact Set.insert_comm a b {c}] at h
         linarith [angle_lt_pi_of_not_collinear h]
-      linarith
+      order
     · rw [show ({a, b, c} : Set P) = {a, c, b} by grind] at h
       have h5 := dist_lt_of_angle_lt h h3
-      linarith
+      order
 
 theorem angle_le_iff_dist_le {a b c : P} (h : ¬Collinear ℝ ({a, b, c} : Set P)) :
     ∠ a c b ≤ ∠ a b c ↔ dist a b ≤ dist a c := by

--- a/Mathlib/MeasureTheory/Covering/BesicovitchVectorSpace.lean
+++ b/Mathlib/MeasureTheory/Covering/BesicovitchVectorSpace.lean
@@ -322,7 +322,7 @@ theorem exists_normalized_aux1 {N : ℕ} {τ : ℝ} (a : SatelliteConfig E N τ)
       _ ≤ 1 := by linarith only [sq_nonneg δ]
   have J : 1 - δ ≤ 1 - δ / 4 := by linarith only [δnonneg]
   have K : 1 - δ / 4 ≤ τ⁻¹ := by rw [inv_eq_one_div, le_div_iff₀ τpos]; exact I
-  suffices L : τ⁻¹ ≤ ‖a.c i - a.c j‖ by linarith only [J, K, L]
+  suffices L : τ⁻¹ ≤ ‖a.c i - a.c j‖ by order
   have hτ' : ∀ k, τ⁻¹ ≤ a.r k := by
     intro k
     rw [inv_eq_one_div, div_le_iff₀ τpos, ← lastr, mul_comm]

--- a/Mathlib/MeasureTheory/Function/AbsolutelyContinuous.lean
+++ b/Mathlib/MeasureTheory/Function/AbsolutelyContinuous.lean
@@ -284,7 +284,7 @@ theorem boundedVariationOn (hf : AbsolutelyContinuousOnInterval f a b) :
     BoundedVariationOn f (uIcc a b) := by
   -- We may assume wlog that `a ≤ b`.
   wlog hab₀ : a ≤ b generalizing a b
-  · specialize @this b a hf.symm (by linarith)
+  · specialize @this b a hf.symm (by order)
     rwa [uIcc_comm]
   rw [uIcc_of_le hab₀]
   -- Split the cases `a = b` (which is trivial) and `a < b`.

--- a/Mathlib/MeasureTheory/Function/LpSeminorm/Basic.lean
+++ b/Mathlib/MeasureTheory/Function/LpSeminorm/Basic.lean
@@ -1090,7 +1090,7 @@ theorem eLpNorm'_le_nnreal_smul_eLpNorm'_of_ae_le_mul' {f : α → ε} {g : α �
     ← ENNReal.coe_rpow_of_nonneg _ hp.le, ← lintegral_const_mul' _ _ ENNReal.coe_ne_top]
   apply lintegral_mono_ae
   have aux (x) : (↑c) ^ p * ‖g x‖ₑ ^ p = (↑c * ‖g x‖ₑ) ^ p := by
-    have : ¬(p < 0) := by linarith
+    have : ¬(p < 0) := by order
     simp [ENNReal.mul_rpow_eq_ite, this]
   simpa [ENNReal.coe_rpow_of_nonneg _ hp.le, aux, ENNReal.rpow_le_rpow_iff hp]
 
@@ -1102,7 +1102,7 @@ variable {ε : Type*} [TopologicalSpace ε] [ESeminormedAddMonoid ε]
 theorem eLpNorm'_le_mul_eLpNorm'_of_ae_le_mul {f : α → ε} {c : ℝ≥0∞} {g : α → ε'} {p : ℝ}
     (hg : AEStronglyMeasurable g μ) (h : ∀ᵐ x ∂μ, ‖f x‖ₑ ≤ c * ‖g x‖ₑ) (hp : 0 < p) :
     eLpNorm' f p μ ≤ c * eLpNorm' g p μ := by
-  have hp' : ¬(p < 0) := by linarith
+  have hp' : ¬(p < 0) := by order
   by_cases hc : c = ⊤
   · by_cases hg' : eLpNorm' g p μ = 0
     · have : ∀ᵐ (x : α) ∂μ, ‖g x‖ₑ = 0 := by

--- a/Mathlib/MeasureTheory/Integral/Bochner/Set.lean
+++ b/Mathlib/MeasureTheory/Integral/Bochner/Set.lean
@@ -474,7 +474,7 @@ theorem integral_norm_eq_pos_sub_neg {f : X → ℝ} (hfi : Integrable f μ) :
       dsimp only
       rw [Real.norm_eq_abs, abs_eq_neg_self.mpr _]
       rw [Set.mem_compl_iff, Set.notMem_setOf_iff] at hx
-      linarith
+      order
     _ = ∫ x in {x | 0 ≤ f x}, f x ∂μ - ∫ x in {x | f x ≤ 0}, f x ∂μ := by
       rw [← setIntegral_neg_eq_setIntegral_nonpos hfi.1, compl_setOf]; simp only [not_le]
 

--- a/Mathlib/MeasureTheory/Integral/IntervalIntegral/DerivIntegrable.lean
+++ b/Mathlib/MeasureTheory/Integral/IntervalIntegral/DerivIntegrable.lean
@@ -83,7 +83,7 @@ theorem MonotoneOn.intervalIntegrable_deriv {f : ℝ → ℝ} {a b : ℝ}
     (hf : MonotoneOn f (uIcc a b)) :
     IntervalIntegrable (deriv f) volume a b := by
   wlog hab : a ≤ b generalizing a b with h
-  · exact h (uIcc_comm a b ▸ hf) (by linarith) |>.symm
+  · exact h (uIcc_comm a b ▸ hf) (by order) |>.symm
   rw [uIcc_of_le hab] at hf
   obtain ⟨G, hGf, hG, hG'⟩ := hf.exists_tendsto_deriv_liminf_lintegral_enorm_le hab
   have hG'₀ : liminf (fun (n : ℕ) ↦ ∫⁻ (x : ℝ) in Icc a b, ‖G n x‖ₑ) atTop ≠ ⊤ :=
@@ -97,8 +97,8 @@ theorem MonotoneOn.intervalIntegral_deriv_mem_uIcc {f : ℝ → ℝ} {a b : ℝ}
     (hf : MonotoneOn f (uIcc a b)) :
     ∫ x in a..b, deriv f x ∈ uIcc 0 (f b - f a) := by
   wlog hab : a ≤ b generalizing a b with h
-  · specialize h (uIcc_comm a b ▸ hf) (by linarith)
-    have : f b ≤ f a := hf (by simp) (by simp) (by linarith)
+  · specialize h (uIcc_comm a b ▸ hf) (by order)
+    have : f b ≤ f a := hf (by simp) (by simp) (by order)
     rw [intervalIntegral.integral_symm, uIcc_of_ge (by linarith)]
     refine neg_mem_Icc_iff.mpr ?_
     simp only [neg_zero, neg_sub]

--- a/Mathlib/MeasureTheory/Integral/IntervalIntegral/LebesgueDifferentiationThm.lean
+++ b/Mathlib/MeasureTheory/Integral/IntervalIntegral/LebesgueDifferentiationThm.lean
@@ -60,7 +60,7 @@ theorem IntervalIntegrable.ae_hasDerivAt_integral {f : ℝ → ℝ} {a b : ℝ}
     (hf : IntervalIntegrable f volume a b) :
     ∀ᵐ x, x ∈ uIcc a b → ∀ c ∈ uIcc a b, HasDerivAt (fun x => ∫ (t : ℝ) in c..x, f t) (f x) x := by
   wlog hab : a ≤ b
-  · exact uIcc_comm b a ▸ @this f b a hf.symm (by linarith)
+  · exact uIcc_comm b a ▸ @this f b a hf.symm (by order)
   rw [uIcc_of_le hab]
   have h₁ : ∀ᵐ x, x ≠ a := by simp [ae_iff, measure_singleton]
   have h₂ : ∀ᵐ x, x ≠ b := by simp [ae_iff, measure_singleton]

--- a/Mathlib/MeasureTheory/Integral/IntervalIntegral/Periodic.lean
+++ b/Mathlib/MeasureTheory/Integral/IntervalIntegral/Periodic.lean
@@ -387,7 +387,7 @@ theorem sInf_add_zsmul_le_integral_of_pos (h_int : IntervalIntegrable g MeasureS
   let h'_int := hg.intervalIntegrable₀ hT h_int
   let ε := Int.fract (t / T) * T
   conv_rhs =>
-    rw [← Int.fract_div_mul_self_add_zsmul_eq T t (by linarith),
+    rw [← Int.fract_div_mul_self_add_zsmul_eq T t (by order),
       ← integral_add_adjacent_intervals (h'_int 0 ε) (h'_int _ _)]
   rw [hg.intervalIntegral_add_zsmul_eq ⌊t / T⌋ ε (hg.intervalIntegrable₀ hT h_int),
     hg.intervalIntegral_add_eq ε 0, zero_add, add_le_add_iff_right]
@@ -404,7 +404,7 @@ theorem integral_le_sSup_add_zsmul_of_pos (h_int : IntervalIntegrable g MeasureS
   let h'_int := hg.intervalIntegrable₀ hT h_int
   let ε := Int.fract (t / T) * T
   conv_lhs =>
-    rw [← Int.fract_div_mul_self_add_zsmul_eq T t (by linarith), ←
+    rw [← Int.fract_div_mul_self_add_zsmul_eq T t (by order), ←
       integral_add_adjacent_intervals (h'_int 0 ε) (h'_int _ _)]
   rw [hg.intervalIntegral_add_zsmul_eq ⌊t / T⌋ ε h'_int, hg.intervalIntegral_add_eq ε 0, zero_add,
     add_le_add_iff_right]

--- a/Mathlib/MeasureTheory/Integral/PeakFunction.lean
+++ b/Mathlib/MeasureTheory/Integral/PeakFunction.lean
@@ -124,7 +124,7 @@ theorem tendsto_setIntegral_peak_smul_of_integrableOn_of_tendsto_aux
   have I : IntegrableOn (φ i) t μ := by
     apply Integrable.of_integral_ne_zero (fun h ↦ ?_)
     simp [h] at h'i
-    linarith
+    order
   have B : ‖∫ x in s ∩ u, φ i x • g x ∂μ‖ ≤ 2 * δ :=
     calc
       ‖∫ x in s ∩ u, φ i x • g x ∂μ‖ ≤ ∫ x in s ∩ u, ‖φ i x • g x‖ ∂μ :=

--- a/Mathlib/MeasureTheory/Measure/Lebesgue/VolumeOfBalls.lean
+++ b/Mathlib/MeasureTheory/Measure/Lebesgue/VolumeOfBalls.lean
@@ -185,7 +185,7 @@ theorem MeasureTheory.volume_sum_rpow_lt_one (hp : 1 ≤ p) :
   -- We use `measure_lt_one_eq_integral_div_gamma` with `g` equals to the norm `L_p`
   convert (measure_lt_one_eq_integral_div_gamma (volume : Measure (ι → ℝ))
     (g := fun x => (∑ i, |x i| ^ p) ^ (1 / p)) nm_zero nm_neg nm_add (eq_zero _).mp
-    (fun r x => nm_smul r x) (by linarith : 0 < p)) using 4
+    (fun r x => nm_smul r x) (by order : 0 < p)) using 4
   · rw [rpow_lt_one_iff' _ (one_div_pos.mpr h₁)]
     exact Finset.sum_nonneg' (fun _ => rpow_nonneg (abs_nonneg _) _)
   · simp_rw [← rpow_mul (h₂ _), div_mul_cancel₀ _ (ne_of_gt h₁), Real.rpow_one,
@@ -258,7 +258,7 @@ theorem Complex.volume_sum_rpow_lt_one {p : ℝ} (hp : 1 ≤ p) :
   -- We use `measure_lt_one_eq_integral_div_gamma` with `g` equals to the norm `L_p`
   convert measure_lt_one_eq_integral_div_gamma (volume : Measure (ι → ℂ))
     (g := fun x => (∑ i, ‖x i‖ ^ p) ^ (1 / p)) nm_zero nm_neg nm_add (eq_zero _).mp
-    (fun r x => nm_smul r x) (by linarith : 0 < p) using 4
+    (fun r x => nm_smul r x) (by order : 0 < p) using 4
   · rw [rpow_lt_one_iff' _ (one_div_pos.mpr h₁)]
     exact Finset.sum_nonneg' (fun _ => rpow_nonneg (norm_nonneg _) _)
   · simp_rw [← rpow_mul (h₂ _), div_mul_cancel₀ _ (ne_of_gt h₁), Real.rpow_one,

--- a/Mathlib/NumberTheory/ClassNumber/Finite.lean
+++ b/Mathlib/NumberTheory/ClassNumber/Finite.lean
@@ -198,7 +198,7 @@ theorem exists_mem_finsetApprox (a : S) {b} (hb : b ≠ (0 : R)) :
       mul_left_comm, mul_inv_cancel₀, mul_one, rpow_natCast] <;>
       try norm_cast; cutsat
     · exact Iff.mpr Int.cast_nonneg_iff this
-    · linarith
+    · order
   set μ : Fin (cardM bS adm).succ ↪ R := distinctElems bS adm
   let s : ι →₀ R := bS.repr a
   have s_eq : ∀ i, s i = bS.repr a i := fun i => rfl

--- a/Mathlib/NumberTheory/Modular.lean
+++ b/Mathlib/NumberTheory/Modular.lean
@@ -485,7 +485,7 @@ theorem c_eq_zero (hz : z ∈ 𝒟ᵒ) (hg : g • z ∈ 𝒟ᵒ) : g 1 0 = 0 :=
     have h₁ : w = S • T ^ d • z := by simp only [w, ← mul_smul, had]
     replace h₁ : normSq w < 1 := h₁.symm ▸ normSq_S_smul_lt_one (one_lt_normSq_T_zpow_smul hz d)
     have h₂ : 1 < normSq w := one_lt_normSq_T_zpow_smul hg' (-a)
-    linarith
+    order
   have hn : g 1 0 ≠ -1 := by
     intro hc
     replace hc : (-g) 1 0 = 1 := by simp [← neg_eq_iff_eq_neg.mpr hc]

--- a/Mathlib/NumberTheory/NumberField/ClassNumber.lean
+++ b/Mathlib/NumberTheory/NumberField/ClassNumber.lean
@@ -186,7 +186,7 @@ theorem isPrincipalIdealRing_of_isPrincipal_of_lt_or_isPrincipal_of_mem_primesOv
   have := (isPrime_of_prime (prime_span_singleton_iff.mpr (prime_iff_prime_int.mp hp))).isMaximal
     (by simp [hp.ne_zero])
   by_cases h : ⌊(M K)⌋₊ < p ^ ((span ({↑p} : Set ℤ)).inertiaDeg P)
-  · linarith
+  · order
   rw [inertiaDeg_eq_of_isGaloisGroup _ Q P (K ≃ₐ[ℚ] K)] at H
   obtain ⟨σ, rfl⟩ := exists_smul_eq_of_isGaloisGroup (span ({↑p} : Set ℤ)) Q P (K ≃ₐ[ℚ] K)
   exact (H.resolve_left h).map_ringHom (MulSemiringAction.toRingHom (K ≃ₐ[ℚ] K) (𝓞 K) σ)

--- a/Mathlib/NumberTheory/NumberField/FinitePlaces.lean
+++ b/Mathlib/NumberTheory/NumberField/FinitePlaces.lean
@@ -263,7 +263,7 @@ theorem mk_eq_iff {v₁ v₂ : HeightOneSpectrum (𝓞 K)} : mk v₁ = mk v₂ �
   simp only [mk_apply]
   rw [← norm_lt_one_iff_mem] at hx1
   rw [← norm_eq_one_iff_notMem] at hx2
-  linarith
+  order
 
 theorem maximalIdeal_mk (v : HeightOneSpectrum (𝓞 K)) : maximalIdeal (mk v) = v := by
   rw [← mk_eq_iff, mk_maximalIdeal]

--- a/Mathlib/NumberTheory/Ostrowski.lean
+++ b/Mathlib/NumberTheory/Ostrowski.lean
@@ -448,7 +448,7 @@ theorem equiv_real_of_unbounded : f.IsEquiv real := by
   · simp only [real_eq_abs, abs_cast, Rat.cast_natCast]
     rw [rpow_inv_eq (apply_nonneg f ↑n) (Nat.cast_nonneg n)
       (logb_ne_zero_of_pos_of_ne_one (one_lt_cast.mpr oneltm) (by linarith only [hm])
-      (by linarith only [hm]))]
+      (by order))]
     have hfm : f m = m ^ s := by
       rw [rpow_logb (mod_cast zero_lt_of_lt oneltm) (mod_cast oneltm.ne') (by linarith only [hm])]
     have hfn : f n = n ^ logb n (f n) := by

--- a/Mathlib/Probability/Distributions/Exponential.lean
+++ b/Mathlib/Probability/Distributions/Exponential.lean
@@ -139,7 +139,7 @@ lemma lintegral_exponentialPDF_eq_antiDeriv {r : ℝ} (hr : 0 < r) (x : ℝ) :
   case neg =>
     simp only [exponentialPDF_eq]
     rw [setLIntegral_congr_fun measurableSet_Iic, lintegral_zero, ENNReal.ofReal_zero]
-    exact fun a (_ : a ≤ _) ↦ by rw [if_neg (by linarith), ENNReal.ofReal_eq_zero]
+    exact fun a (_ : a ≤ _) ↦ by rw [if_neg (by order), ENNReal.ofReal_eq_zero]
   case pos =>
     rw [lintegral_Iic_eq_lintegral_Iio_add_Icc _ h, lintegral_exponentialPDF_of_nonpos (le_refl 0),
       zero_add]

--- a/Mathlib/Probability/Distributions/Gamma.lean
+++ b/Mathlib/Probability/Distributions/Gamma.lean
@@ -66,7 +66,7 @@ lemma lintegral_gammaPDF_of_nonpos {x a r : ℝ} (hx : x ≤ 0) :
   · rw [lintegral_zero, ← ENNReal.ofReal_zero]
   · intro a (_ : a < _)
     simp only [gammaPDF_eq, ENNReal.ofReal_eq_zero]
-    rw [if_neg (by linarith)]
+    rw [if_neg (by order)]
 
 /-- The gamma pdf is measurable. -/
 @[fun_prop, measurability]

--- a/Mathlib/Probability/StrongLaw.lean
+++ b/Mathlib/Probability/StrongLaw.lean
@@ -160,7 +160,7 @@ theorem moment_truncation_eq_intervalIntegral_of_nonneg (hf : AEStronglyMeasurab
       filter_upwards [this] with x hx
       simp only [indicator, Set.mem_Ioc, Pi.zero_apply, ite_eq_right_iff, and_imp]
       intro _ h''x
-      have : x = 0 := by linarith
+      have : x = 0 := by order
       simp [this, zero_pow hn]
     · exact ((measurable_id.indicator M).pow_const n).aestronglyMeasurable
 


### PR DESCRIPTION
---
Separated from the non-`linarith` cases for benchmarking reasons.

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

When merging, all the commits will be squashed into a single commit
listing all co-authors.

Co-authors in the squash commit are gathered from two sources:

First, all authors of commits to this PR branch are included. Thus,
one way to add co-authors is to include at least one commit authored by
each co-author among the commits in the pull request. If necessary, you
may create empty commits to indicate co-authorship, using commands like so:

git commit --author="Author Name <author@email.com>" --allow-empty -m "add Author Name as coauthor"

Second, co-authors can also be listed in lines at the very bottom of
the commit message (that is, directly before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines
at the bottom of the commit message (before the `---`, and also before
any "Co-authored-by" lines) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
