### PR TITLE
[Merged by Bors] - doc: fix latex error

### DIFF
--- a/Mathlib/Probability/Independence/Process.lean
+++ b/Mathlib/Probability/Independence/Process.lean
@@ -87,9 +87,9 @@ lemma IndepFun.process_indepFun_process {T : Type*} {𝓧 : S → Type*} {𝓨 :
   exact IndepFun.indepFun_process (measurable_pi_lambda _ fun _ ↦ hX _) hY fun J ↦ h I J
 
 /-- Stochastic processes $((X^s_t)_{t \in T_s})_{s \in S}$ are mutually independent if
-for all $s_1, ..., s_n$ and all $t^{s_i}_1, ..., t^{s_i}_{p_i}^ the families
-$(X^{s_1}_{t^{s_1}_1}, ..., X^{s_1}_{t^{s_1}_{p_1}}), ...,
-(X^{s_n}_{t^{s_n}_1}, ..., X^{s_n}_{t^{s_n}_{p_n}})$ are mutually independent. -/
+for all $s_1, ..., s_n$ and all ${t^{s_i}}_1, ..., {t^{s_i}}_{p_i}$ the families
+$({X^{s_1}}_{{t^{s_1}}_1}, ..., {X^{s_1}}_{{t^{s_1}}_{p_1}}), ...,
+({X^{s_n}}_{{t^{s_n}}_1}, ..., {X^{s_n}}_{{t^{s_n}}_{p_n}})$ are mutually independent. -/
 lemma iIndepFun.iIndepFun_process {T : S → Type*} {𝓧 : (i : S) → (j : T i) → Type*}
     [∀ i j, MeasurableSpace (𝓧 i j)] {X : (i : S) → (j : T i) → Ω → 𝓧 i j}
     (hX : ∀ i j, Measurable (X i j))
@@ -169,9 +169,9 @@ lemma IndepFun.process_indepFun_process {T : Type*} {𝓧 : S → Type*} {𝓨 :
   Kernel.IndepFun.process_indepFun_process hX hY h
 
 /-- Stochastic processes $((X^s_t)_{t \in T_s})_{s \in S}$ are mutually independent if
-for all $s_1, ..., s_n$ and all $t^{s_i}_1, ..., t^{s_i}_{p_i}^ the families
-$(X^{s_1}_{t^{s_1}_1}, ..., X^{s_1}_{t^{s_1}_{p_1}}), ...,
-(X^{s_n}_{t^{s_n}_1}, ..., X^{s_n}_{t^{s_n}_{p_n}})$ are mutually independent. -/
+for all $s_1, ..., s_n$ and all ${t^{s_i}}_1, ..., {t^{s_i}}_{p_i}$ the families
+$({X^{s_1}}_{{t^{s_1}}_1}, ..., {X^{s_1}}_{{t^{s_1}}_{p_1}}), ...,
+({X^{s_n}}_{{t^{s_n}}_1}, ..., {X^{s_n}}_{{t^{s_n}}_{p_n}})$ are mutually independent. -/
 lemma iIndepFun.iIndepFun_process {T : S → Type*} {𝓧 : (i : S) → (j : T i) → Type*}
     [∀ i j, MeasurableSpace (𝓧 i j)] {X : (i : S) → (j : T i) → Ω → 𝓧 i j}
     (hX : ∀ i j, Measurable (X i j))

--- a/Mathlib/Probability/Independence/Process.lean
+++ b/Mathlib/Probability/Independence/Process.lean
@@ -87,9 +87,9 @@ lemma IndepFun.process_indepFun_process {T : Type*} {𝓧 : S → Type*} {𝓨 :
   exact IndepFun.indepFun_process (measurable_pi_lambda _ fun _ ↦ hX _) hY fun J ↦ h I J
 
 /-- Stochastic processes $((X^s_t)_{t \in T_s})_{s \in S}$ are mutually independent if
-for all $s_1, ..., s_n$ and all ${t^{s_i}}_1, ..., {t^{s_i}}_{p_i}$ the families
-$({X^{s_1}}_{{t^{s_1}}_1}, ..., {X^{s_1}}_{{t^{s_1}}_{p_1}}), ...,
-({X^{s_n}}_{{t^{s_n}}_1}, ..., {X^{s_n}}_{{t^{s_n}}_{p_n}})$ are mutually independent. -/
+for all $s_1, ..., s_n$ and all $t^{s_i}_1, ..., t^{s_i}_{p_i}$ the families
+$(X^{s_1}_{t^{s_1}_1}, ..., X^{s_1}_{t^{s_1}_{p_1}}), ...,
+(X^{s_n}_{t^{s_n}_1}, ..., X^{s_n}_{t^{s_n}_{p_n}})$ are mutually independent. -/
 lemma iIndepFun.iIndepFun_process {T : S → Type*} {𝓧 : (i : S) → (j : T i) → Type*}
     [∀ i j, MeasurableSpace (𝓧 i j)] {X : (i : S) → (j : T i) → Ω → 𝓧 i j}
     (hX : ∀ i j, Measurable (X i j))
@@ -169,9 +169,9 @@ lemma IndepFun.process_indepFun_process {T : Type*} {𝓧 : S → Type*} {𝓨 :
   Kernel.IndepFun.process_indepFun_process hX hY h
 
 /-- Stochastic processes $((X^s_t)_{t \in T_s})_{s \in S}$ are mutually independent if
-for all $s_1, ..., s_n$ and all ${t^{s_i}}_1, ..., {t^{s_i}}_{p_i}$ the families
-$({X^{s_1}}_{{t^{s_1}}_1}, ..., {X^{s_1}}_{{t^{s_1}}_{p_1}}), ...,
-({X^{s_n}}_{{t^{s_n}}_1}, ..., {X^{s_n}}_{{t^{s_n}}_{p_n}})$ are mutually independent. -/
+for all $s_1, ..., s_n$ and all $t^{s_i}_1, ..., t^{s_i}_{p_i}$ the families
+$(X^{s_1}_{t^{s_1}_1}, ..., X^{s_1}_{t^{s_1}_{p_1}}), ...,
+(X^{s_n}_{t^{s_n}_1}, ..., X^{s_n}_{t^{s_n}_{p_n}})$ are mutually independent. -/
 lemma iIndepFun.iIndepFun_process {T : S → Type*} {𝓧 : (i : S) → (j : T i) → Type*}
     [∀ i j, MeasurableSpace (𝓧 i j)] {X : (i : S) → (j : T i) → Ω → 𝓧 i j}
     (hX : ∀ i j, Measurable (X i j))


### PR DESCRIPTION
There was an error in the latex code which breaks the doc at [ProbabilityTheory.Kernel.iIndepFun.iIndepFun_process](https://leanprover-community.github.io/mathlib4_docs/Mathlib/Probability/Independence/Process.html#ProbabilityTheory.Kernel.iIndepFun.iIndepFun_process) and lower in the same file.

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

When merging, all the commits will be squashed into a single commit
listing all co-authors.

Co-authors in the squash commit are gathered from two sources:

First, all authors of commits to this PR branch are included. Thus,
one way to add co-authors is to include at least one commit authored by
each co-author among the commits in the pull request. If necessary, you
may create empty commits to indicate co-authorship, using commands like so:

git commit --author="Author Name <author@email.com>" --allow-empty -m "add Author Name as coauthor"

Second, co-authors can also be listed in lines at the very bottom of
the commit message (that is, directly before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines
at the bottom of the commit message (before the `---`, and also before
any "Co-authored-by" lines) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
