### PR TITLE
[Merged by Bors] - doc(Archive): ensure only a single H1 header per file

### DIFF
--- a/Archive/Imo/Imo1975Q1.lean
+++ b/Archive/Imo/Imo1975Q1.lean
@@ -15,7 +15,7 @@ Let `x₁, x₂, ... , xₙ` and `y₁, y₂, ... , yₙ` be two sequences of re
 `x₁ ≥ x₂ ≥ ... ≥ xₙ` and `y₁ ≥ y₂ ≥ ... ≥ yₙ`. Prove that if `z₁, z₂, ... , zₙ` is any permutation
 of `y₁, y₂, ... , yₙ`, then `∑ (xᵢ - yᵢ)^2 ≤ ∑ (xᵢ - zᵢ)^2`
 
-# Solution
+## Solution
 
 Firstly, we expand the squares within both sums and distribute into separate finite sums. Then,
 noting that `∑ yᵢ ^ 2 = ∑ zᵢ ^ 2`, it remains to prove that `∑ xᵢ * zᵢ ≤ ∑ xᵢ * yᵢ`, which is true

--- a/Archive/Imo/Imo1985Q2.lean
+++ b/Archive/Imo/Imo1985Q2.lean
@@ -20,7 +20,7 @@ so that:
 
 Prove that all numbers in $N$ must receive the same color.
 
-# Solution
+## Solution
 
 Let $a \sim b$ denote that $a$ and $b$ have the same color.
 Because $j$ is coprime to $n$, every number in $N$ is of the form $kj\bmod n$ for a unique

--- a/Archive/Imo/Imo1994Q1.lean
+++ b/Archive/Imo/Imo1994Q1.lean
@@ -18,7 +18,7 @@ such that for any two indices `i` and `j` with `1 ≤ i ≤ j ≤ m` and `aᵢ +
 there exists an index `k` such that `aᵢ + aⱼ = aₖ`.
 Show that `(a₁+a₂+...+aₘ)/m ≥ (n+1)/2`
 
-# Sketch of solution
+## Sketch of solution
 
 We can order the numbers so that `a₁ ≤ a₂ ≤ ... ≤ aₘ`.
 The key idea is to pair the numbers in the sum and show that `aᵢ + aₘ₊₁₋ᵢ ≥ n+1`.

--- a/Archive/Imo/Imo1997Q3.lean
+++ b/Archive/Imo/Imo1997Q3.lean
@@ -18,7 +18,7 @@ $|x_1 + x_2 + \cdots + x_n| = 1$ and $|x_i| ≤ \frac{n+1}2$ for $i = 1, 2, \dot
 Show that there exists a permutation $y_1, y_2, \dots, y_n$ of $x_1, x_2, \dots, x_n$ such that
 $|y_1 + 2y_2 + \cdots + ny_n| ≤ \frac{n+1}2$.
 
-# Solution
+## Solution
 
 For a permutation $π$ let $S(π) = \sum_{i=1}^n i x_{π(i)}$. We wish to show that there exists $π$
 with $|S(π)| ≤ \frac{n+1}2$.

--- a/Archive/Imo/Imo2001Q3.lean
+++ b/Archive/Imo/Imo2001Q3.lean
@@ -20,7 +20,7 @@ both the girl and the boy.
 
 Show that there is a problem that was solved by at least three girls and at least three boys.
 
-# Solution
+## Solution
 
 Note that not all of the problems a girl $g$ solves can be "hard" for boys, in the sense that
 at most two boys solved it. If that was true, by condition 1 at most $6 × 2 = 12$ boys solved

--- a/Archive/Imo/Imo2001Q4.lean
+++ b/Archive/Imo/Imo2001Q4.lean
@@ -15,7 +15,7 @@ $a = (a_1, a_2, \dots, a_n)$ of $\{1, 2, \dots, n\}$, define $S(a) = \sum_{i=1}^
 Prove that there exist two permutations $a ≠ b$ of $\{1, 2, \dots, n\}$ such that
 $n!$ is a divisor of $S(a) - S(b)$.
 
-# Solution
+## Solution
 
 Suppose for contradiction that all the $S(a)$ have distinct residues modulo $n!$, then
 $$\sum_{i=0}^{n!-1} i ≡ \sum_a S(a) = \sum_i c_i \sum_a a_i = (n-1)! \frac{n(n+1)}2 \sum_i c_i$$

--- a/Archive/Imo/Imo2001Q5.lean
+++ b/Archive/Imo/Imo2001Q5.lean
@@ -11,7 +11,7 @@ import Mathlib.Geometry.Euclidean.Triangle
 Let `ABC` be a triangle. Let `AP` bisect `∠BAC` and let `BQ` bisect `∠ABC`, with `P` on `BC` and
 `Q` on `AC`. If `AB + BP = AQ + QB` and `∠BAC = 60°`, what are the angles of the triangle?
 
-# Solution
+## Solution
 
 We follow the solution from https://web.evanchen.cc/exams/IMO-2001-notes.pdf.
 

--- a/Archive/Imo/Imo2005Q3.lean
+++ b/Archive/Imo/Imo2005Q3.lean
@@ -14,7 +14,7 @@ import Mathlib.Tactic.Ring
 Let `x`, `y` and `z` be positive real numbers such that `xyz ≥ 1`. Prove that:
 `(x^5 - x^2)/(x^5 + y^2 + z^2) + (y^5 - y^2)/(y^5 + z^2 + x^2) + (z^5 - z^2)/(z^5 + x^2 + y^2) ≥ 0`
 
-# Solution
+## Solution
 The solution by Iurie Boreico from Moldova is presented, which won a special prize during the exam.
 The key insight is that `(x^5-x^2)/(x^5+y^2+z^2) ≥ (x^2-y*z)/(x^2+y^2+z^2)`, which is proven by
 factoring `(x^5-x^2)/(x^5+y^2+z^2) - (x^5-x^2)/(x^3*(x^2+y^2+z^2))` into a non-negative expression

--- a/Archive/Imo/Imo2008Q2.lean
+++ b/Archive/Imo/Imo2008Q2.lean
@@ -21,7 +21,7 @@ for all real numbers `x`,`y`, `z`, each different from 1, and satisfying `xyz = 
 (b) Prove that equality holds above for infinitely many triples of rational numbers `x`, `y`, `z`,
 each different from 1, and satisfying `xyz = 1`.
 
-# Solution
+## Solution
 (a) Since `xyz = 1`, we can apply the substitution `x = a/b`, `y = b/c`, `z = c/a`.
 Then we define `m = c-b`, `n = b-a` and rewrite the inequality as `LHS - 1 ≥ 0`
 using `c`, `m` and `n`. We factor `LHS - 1` as a square, which finishes the proof.

--- a/Archive/Imo/Imo2008Q3.lean
+++ b/Archive/Imo/Imo2008Q3.lean
@@ -15,7 +15,7 @@ import Mathlib.Tactic.LinearCombination
 Prove that there exist infinitely many positive integers `n` such that `n^2 + 1` has a prime
 divisor which is greater than `2n + √(2n)`.
 
-# Solution
+## Solution
 We first prove the following lemma: for every prime `p > 20`, satisfying `p ≡ 1 [MOD 4]`,
 there exists `n ∈ ℕ` such that `p ∣ n^2 + 1` and `p > 2n + √(2n)`. Then the statement of the
 problem follows from the fact that there exist infinitely many primes `p ≡ 1 [MOD 4]`.

--- a/Archive/Imo/Imo2008Q4.lean
+++ b/Archive/Imo/Imo2008Q4.lean
@@ -17,7 +17,7 @@ numbers to the positive real numbers) such that
       ```
 for all positive real numbers `w`, `x`, `y`, `z`, satisfying `wx = yz`.
 
-# Solution
+## Solution
 The desired theorem is that either `f = fun x => x` or `f = fun x => 1/x`
 -/
 

--- a/Archive/Imo/Imo2011Q3.lean
+++ b/Archive/Imo/Imo2011Q3.lean
@@ -15,7 +15,7 @@ Let f : ℝ → ℝ be a function that satisfies
 
 for all x and y. Prove that f(x) = 0 for all x ≤ 0.
 
-# Solution
+## Solution
 
 Direct translation of the solution found in https://www.imo-official.org/problems/IMO2011SL.pdf
 -/

--- a/Archive/Imo/Imo2013Q1.lean
+++ b/Archive/Imo/Imo2013Q1.lean
@@ -17,7 +17,7 @@ m₁, m₂, ..., mₖ (not necessarily different) such that
 
   1 + (2ᵏ - 1)/ n = (1 + 1/m₁) * (1 + 1/m₂) * ... * (1 + 1/mₖ).
 
-# Solution
+## Solution
 
 Adaptation of the solution found in https://www.imo-official.org/problems/IMO2013SL.pdf
 

--- a/Archive/Imo/Imo2013Q5.lean
+++ b/Archive/Imo/Imo2013Q5.lean
@@ -22,7 +22,7 @@ the conditions
 for all `x, y ∈ ℚ>₀`. Given that `f(a) = a` for some rational `a > 1`, prove that `f(x) = x` for
 all `x ∈ ℚ>₀`.
 
-# Solution
+## Solution
 
 We provide a direct translation of the solution found in
 https://www.imo-official.org/problems/IMO2013SL.pdf

--- a/Archive/Imo/Imo2015Q6.lean
+++ b/Archive/Imo/Imo2015Q6.lean
@@ -20,7 +20,7 @@ Prove that there exist two positive integers $b$ and $N$ for which
 $$\left|\sum_{j=m+1}^n (a_j-b)\right| ≤ 1007^2$$
 for all integers $m,n$ such that $N ≤ m < n$.
 
-# Solution
+## Solution
 
 We follow solution 2 ("juggling") from https://web.evanchen.cc/exams/IMO-2015-notes.pdf.
 

--- a/Archive/Imo/Imo2021Q1.lean
+++ b/Archive/Imo/Imo2021Q1.lean
@@ -14,7 +14,7 @@ Let `n ≥ 100` be an integer. Ivan writes the numbers `n, n+1, ..., 2*n` each o
 He then shuffles these `n+1` cards, and divides them into two piles. Prove that at least one
 of the piles contains two cards such that the sum of their numbers is a perfect square.
 
-# Solution
+## Solution
 
 We show there exists a triplet `a, b, c ∈ [n , 2n]` with `a < b < c` and each of the sums `(a + b)`,
 `(b + c)`, `(a + c)` being a perfect square. Specifically, we consider the linear system of


### PR DESCRIPTION
This PR ensures we only have a single H1 header per lean file in the Archive subdirectory. We do this for the following reasons:

- Having more than one H1 header per file is likely to hamper both assistive technologies and SEO, since it introduces ambiguity about what the title of the resulting webpage actually is.
- The [documentation style guide](https://leanprover-community.github.io/contribute/doc.html) asks for the title of the file to be H1, any other header in the file-level docstring to be H2, and sectioning headers to be H3.

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

When merging, all the commits will be squashed into a single commit
listing all co-authors.

Co-authors in the squash commit are gathered from two sources:

First, all authors of commits to this PR branch are included. Thus,
one way to add co-authors is to include at least one commit authored by
each co-author among the commits in the pull request. If necessary, you
may create empty commits to indicate co-authorship, using commands like so:

git commit --author="Author Name <author@email.com>" --allow-empty -m "add Author Name as coauthor"

Second, co-authors can also be listed in lines at the very bottom of
the commit message (that is, directly before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines
at the bottom of the commit message (before the `---`, and also before
any "Co-authored-by" lines) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
