### PR TITLE
[Merged by Bors] - doc(MathlibTest): demote repeated H1 headers to H2

### DIFF
--- a/MathlibTest/norm_num.lean
+++ b/MathlibTest/norm_num.lean
@@ -425,7 +425,7 @@ example : True := by norm_num1
 -- example : True ∧ True := by norm_num1
 
 /-!
-# Nat operations
+## Nat operations
 -/
 
 section Nat.sub
@@ -465,7 +465,7 @@ example : 1099 / 100 = 10 := by norm_num1
 end Nat.div
 
 /-!
-# Numbers in algebraic structures
+## Numbers in algebraic structures
 -/
 
 noncomputable def foo : ℝ := 1


### PR DESCRIPTION
This PR demotes H1 headers beyond the first per file to H2.

Having only a single H1 header per file is considered good practice when writing markdown. The mathlib documentation style guide does not explicitly state that a module docstring should only contain a single H1, but this seems to be taken for granted, since only the file header is requested to be an H1, while any other header mentioned is asked to be either H2 or H3.

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

When merging, all the commits will be squashed into a single commit
listing all co-authors.

Co-authors in the squash commit are gathered from two sources:

First, all authors of commits to this PR branch are included. Thus,
one way to add co-authors is to include at least one commit authored by
each co-author among the commits in the pull request. If necessary, you
may create empty commits to indicate co-authorship, using commands like so:

git commit --author="Author Name <author@email.com>" --allow-empty -m "add Author Name as coauthor"

Second, co-authors can also be listed in lines at the very bottom of
the commit message (that is, directly before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines
at the bottom of the commit message (before the `---`, and also before
any "Co-authored-by" lines) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
