### PR TITLE
[Merged by Bors] - feat(UnitInterval): `x : I` and its symmetric sum to 1

### DIFF
--- a/Mathlib/MeasureTheory/Measure/Typeclasses/Probability.lean
+++ b/Mathlib/MeasureTheory/Measure/Typeclasses/Probability.lean
@@ -4,6 +4,7 @@ Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Johannes Hölzl, Mario Carneiro
 -/
 import Mathlib.MeasureTheory.Measure.Typeclasses.Finite
+import Mathlib.Topology.UnitInterval
 
 /-!
 # Classes for probability measures
@@ -91,6 +92,11 @@ instance isProbabilityMeasure_dite {p : Prop} [Decidable p] {μ : p → Measure 
 instance isProbabilityMeasure_ite {p : Prop} [Decidable p] {μ ν : Measure α}
     [IsProbabilityMeasure μ] [IsProbabilityMeasure ν] :
     IsProbabilityMeasure (ite p μ ν) := by split <;> infer_instance
+
+open unitInterval in
+instance {μ ν : Measure α} [IsProbabilityMeasure μ] [IsProbabilityMeasure ν] {p : I} :
+    IsProbabilityMeasure (toNNReal p • μ + toNNReal (σ p) • ν) where
+  measure_univ := by simp [← add_smul]
 
 variable [IsProbabilityMeasure μ] {p : α → Prop} {f : β → α}
 

--- a/Mathlib/Topology/UnitInterval.lean
+++ b/Mathlib/Topology/UnitInterval.lean
@@ -385,19 +385,21 @@ theorem iccHomeoI_symm_apply_coe (a b : 𝕜) (h : a < b) (x : Set.Icc (0 : 𝕜
 
 end
 
-section NNReal
+namespace unitInterval
 
-open unitInterval NNReal
+open NNReal
 
 /-- The coercion from `I` to `ℝ≥0`. -/
-def unitInterval.toNNReal : I → ℝ≥0 := fun i ↦ ⟨i.1, i.2.1⟩
+def toNNReal : I → ℝ≥0 := fun i ↦ ⟨i.1, i.2.1⟩
 
-@[fun_prop]
-lemma unitInterval.toNNReal_continuous : Continuous toNNReal := by
-  delta toNNReal
-  fun_prop
+@[simp] lemma toNNReal_zero : toNNReal 0 = 0 := rfl
+@[simp] lemma toNNReal_one : toNNReal 1 = 1 := rfl
 
-@[simp]
-lemma unitInterval.coe_toNNReal (x : I) : ((toNNReal x) : ℝ) = x := rfl
+@[fun_prop] lemma toNNReal_continuous : Continuous toNNReal := by delta toNNReal; fun_prop
 
-end NNReal
+@[simp] lemma coe_toNNReal (x : I) : ((toNNReal x) : ℝ) = x := rfl
+
+@[simp] lemma toNNReal_add_toNNReal_symm (x : I) : toNNReal x + toNNReal (σ x) = 1 := by ext; simp
+@[simp] lemma toNNReal_symm_add_toNNReal (x : I) : toNNReal (σ x) + toNNReal x = 1 := by ext; simp
+
+end unitInterval


### PR DESCRIPTION
---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

When merging, all the commits will be squashed into a single commit
listing all co-authors.

Co-authors in the squash commit are gathered from two sources:

First, all authors of commits to this PR branch are included. Thus,
one way to add co-authors is to include at least one commit authored by
each co-author among the commits in the pull request. If necessary, you
may create empty commits to indicate co-authorship, using commands like so:

git commit --author="Author Name <author@email.com>" --allow-empty -m "add Author Name as coauthor"

Second, co-authors can also be listed in lines at the very bottom of
the commit message (that is, directly before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines
at the bottom of the commit message (before the `---`, and also before
any "Co-authored-by" lines) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
