### PR TITLE
[Merged by Bors] - feat(Analysis/Convex/Slope): `StrictAntiOn` and `ConcaveOn` versions of `ConvexOn.strict_mono_of_lt`

### DIFF
--- a/Mathlib/Analysis/Convex/Slope.lean
+++ b/Mathlib/Analysis/Convex/Slope.lean
@@ -275,3 +275,29 @@ theorem ConvexOn.strict_mono_of_lt (hf : ConvexOn 𝕜 s f) {x y : 𝕜} (hx : x
       exact ⟨hxy.le, hu.2⟩
     · rw [openSegment_eq_Ioo (hu2.trans huv)]
       exact ⟨hu2, huv⟩
+
+/-- If `f` is convex on a set `s` in a linearly ordered field, and `f y < f x` for two points
+`x < y` in `s`, then `f` is strictly antitone on `s ∩ (∞, x]`. -/
+theorem ConvexOn.strict_anti_of_lt (hf : ConvexOn 𝕜 s f) {x y : 𝕜} (hy : y ∈ s) (hxy : x < y)
+    (hxy' : f y < f x) : StrictAntiOn f (s ∩ .Iic x) := by
+  have := (hf.comp_affineMap (-.id ..)).strict_mono_of_lt (neg_neg y |>.symm ▸ hy : - - y ∈ s)
+    (neg_lt_neg hxy) ((neg_neg y).symm ▸ (neg_neg x).symm ▸ hxy' :)
+  convert StrictMonoOn.comp_strictAntiOn this (strictMonoOn_id (s := s ∩ .Iic x) |>.neg) fun z hz ↦
+    ⟨(neg_neg z |>.symm ▸ hz.left :),
+      (Set.neg_Iic x ▸ Set.neg_mem_neg.mpr hz.right : -z ∈ .Ici (-x))⟩
+  ext
+  simp
+
+/-- If `f` is concave on a set `s` in a linearly ordered field, and `f x < f y` for two points
+`x < y` in `s`, then `f` is strictly monotone on `s ∩ (∞, x]`. -/
+theorem ConcaveOn.strict_mono_of_lt (hf : ConcaveOn 𝕜 s f) {x y : 𝕜} (hy : y ∈ s) (hxy : x < y)
+    (hxy' : f x < f y) : StrictMonoOn f (s ∩ .Iic x) := by
+  convert (neg_convexOn_iff.mpr hf |>.strict_anti_of_lt hy hxy <| neg_lt_neg hxy').neg using 1
+  simp
+
+/-- If `f` is concave on a set `s` in a linearly ordered field, and `f y < f x` for two points
+`x < y` in `s`, then `f` is strictly antitone on `s ∩ [y, ∞)`. -/
+theorem ConcaveOn.strict_anti_of_lt (hf : ConcaveOn 𝕜 s f) {x y : 𝕜} (hx : x ∈ s) (hxy : x < y)
+    (hxy' : f y < f x) : StrictAntiOn f (s ∩ .Ici y) := by
+  convert (neg_convexOn_iff.mpr hf |>.strict_mono_of_lt hx hxy <| neg_lt_neg hxy').neg using 1
+  simp

--- a/Mathlib/Analysis/Convex/Slope.lean
+++ b/Mathlib/Analysis/Convex/Slope.lean
@@ -259,7 +259,7 @@ theorem StrictConcaveOn.secant_strict_mono (hf : StrictConcaveOn 𝕜 s f) {a x 
 
 /-- If `f` is convex on a set `s` in a linearly ordered field, and `f x < f y` for two points
 `x < y` in `s`, then `f` is strictly monotone on `s ∩ [y, ∞)`. -/
-theorem ConvexOn.strict_mono_of_lt (hf : ConvexOn 𝕜 s f) {x y : 𝕜} (hx : x ∈ s) (hxy : x < y)
+theorem ConvexOn.strictMonoOn (hf : ConvexOn 𝕜 s f) {x y : 𝕜} (hx : x ∈ s) (hxy : x < y)
     (hxy' : f x < f y) : StrictMonoOn f (s ∩ Set.Ici y) := by
   intro u hu v hv huv
   have step1 : ∀ {z : 𝕜}, z ∈ s ∩ Set.Ioi y → f y < f z := by
@@ -276,21 +276,23 @@ theorem ConvexOn.strict_mono_of_lt (hf : ConvexOn 𝕜 s f) {x y : 𝕜} (hx : x
     · rw [openSegment_eq_Ioo (hu2.trans huv)]
       exact ⟨hu2, huv⟩
 
+@[deprecated (since := "2025-11-11")] alias ConvexOn.strict_mono_of_lt := ConvexOn.strictMonoOn
+
 /-- If `f` is convex on a set `s` in a linearly ordered field, and `f y < f x` for two points
 `x < y` in `s`, then `f` is strictly antitone on `s ∩ (∞, x]`. -/
-theorem ConvexOn.strict_anti_of_lt (hf : ConvexOn 𝕜 s f) {x y : 𝕜} (hy : y ∈ s) (hxy : x < y)
+theorem ConvexOn.strictAntiOn (hf : ConvexOn 𝕜 s f) {x y : 𝕜} (hy : y ∈ s) (hxy : x < y)
     (hxy' : f y < f x) : StrictAntiOn f (s ∩ .Iic x) := by
-  have := hf.comp_affineMap (-.id ..) |>.strict_mono_of_lt (by simpa) (neg_lt_neg hxy) (by simpa)
+  have := hf.comp_affineMap (-.id ..) |>.strictMonoOn (by simpa) (neg_lt_neg hxy) (by simpa)
   simpa [Function.comp_def] using this.comp_strictAntiOn strictMonoOn_id.neg fun _ _ ↦ by simpa
 
 /-- If `f` is concave on a set `s` in a linearly ordered field, and `f x < f y` for two points
 `x < y` in `s`, then `f` is strictly monotone on `s ∩ (∞, x]`. -/
-theorem ConcaveOn.strict_mono_of_lt (hf : ConcaveOn 𝕜 s f) {x y : 𝕜} (hy : y ∈ s) (hxy : x < y)
+theorem ConcaveOn.strictMonoOn (hf : ConcaveOn 𝕜 s f) {x y : 𝕜} (hy : y ∈ s) (hxy : x < y)
     (hxy' : f x < f y) : StrictMonoOn f (s ∩ .Iic x) := by
-  simpa using (neg_convexOn_iff.mpr hf |>.strict_anti_of_lt hy hxy <| neg_lt_neg hxy').neg
+  simpa using (neg_convexOn_iff.mpr hf |>.strictAntiOn hy hxy <| neg_lt_neg hxy').neg
 
 /-- If `f` is concave on a set `s` in a linearly ordered field, and `f y < f x` for two points
 `x < y` in `s`, then `f` is strictly antitone on `s ∩ [y, ∞)`. -/
-theorem ConcaveOn.strict_anti_of_lt (hf : ConcaveOn 𝕜 s f) {x y : 𝕜} (hx : x ∈ s) (hxy : x < y)
+theorem ConcaveOn.strictAntiOn (hf : ConcaveOn 𝕜 s f) {x y : 𝕜} (hx : x ∈ s) (hxy : x < y)
     (hxy' : f y < f x) : StrictAntiOn f (s ∩ .Ici y) := by
-  simpa using (neg_convexOn_iff.mpr hf |>.strict_mono_of_lt hx hxy <| neg_lt_neg hxy').neg
+  simpa using (neg_convexOn_iff.mpr hf |>.strictMonoOn hx hxy <| neg_lt_neg hxy').neg

--- a/Mathlib/Analysis/Convex/Slope.lean
+++ b/Mathlib/Analysis/Convex/Slope.lean
@@ -280,24 +280,17 @@ theorem ConvexOn.strict_mono_of_lt (hf : ConvexOn 𝕜 s f) {x y : 𝕜} (hx : x
 `x < y` in `s`, then `f` is strictly antitone on `s ∩ (∞, x]`. -/
 theorem ConvexOn.strict_anti_of_lt (hf : ConvexOn 𝕜 s f) {x y : 𝕜} (hy : y ∈ s) (hxy : x < y)
     (hxy' : f y < f x) : StrictAntiOn f (s ∩ .Iic x) := by
-  have := (hf.comp_affineMap (-.id ..)).strict_mono_of_lt (neg_neg y |>.symm ▸ hy : - - y ∈ s)
-    (neg_lt_neg hxy) ((neg_neg y).symm ▸ (neg_neg x).symm ▸ hxy' :)
-  convert StrictMonoOn.comp_strictAntiOn this (strictMonoOn_id (s := s ∩ .Iic x) |>.neg) fun z hz ↦
-    ⟨(neg_neg z |>.symm ▸ hz.left :),
-      (Set.neg_Iic x ▸ Set.neg_mem_neg.mpr hz.right : -z ∈ .Ici (-x))⟩
-  ext
-  simp
+  have := hf.comp_affineMap (-.id ..) |>.strict_mono_of_lt (by simpa) (neg_lt_neg hxy) (by simpa)
+  simpa [Function.comp_def] using this.comp_strictAntiOn strictMonoOn_id.neg fun _ _ ↦ by simpa
 
 /-- If `f` is concave on a set `s` in a linearly ordered field, and `f x < f y` for two points
 `x < y` in `s`, then `f` is strictly monotone on `s ∩ (∞, x]`. -/
 theorem ConcaveOn.strict_mono_of_lt (hf : ConcaveOn 𝕜 s f) {x y : 𝕜} (hy : y ∈ s) (hxy : x < y)
     (hxy' : f x < f y) : StrictMonoOn f (s ∩ .Iic x) := by
-  convert (neg_convexOn_iff.mpr hf |>.strict_anti_of_lt hy hxy <| neg_lt_neg hxy').neg using 1
-  simp
+  simpa using (neg_convexOn_iff.mpr hf |>.strict_anti_of_lt hy hxy <| neg_lt_neg hxy').neg
 
 /-- If `f` is concave on a set `s` in a linearly ordered field, and `f y < f x` for two points
 `x < y` in `s`, then `f` is strictly antitone on `s ∩ [y, ∞)`. -/
 theorem ConcaveOn.strict_anti_of_lt (hf : ConcaveOn 𝕜 s f) {x y : 𝕜} (hx : x ∈ s) (hxy : x < y)
     (hxy' : f y < f x) : StrictAntiOn f (s ∩ .Ici y) := by
-  convert (neg_convexOn_iff.mpr hf |>.strict_mono_of_lt hx hxy <| neg_lt_neg hxy').neg using 1
-  simp
+  simpa using (neg_convexOn_iff.mpr hf |>.strict_mono_of_lt hx hxy <| neg_lt_neg hxy').neg

--- a/Mathlib/Analysis/SpecialFunctions/Gamma/BohrMollerup.lean
+++ b/Mathlib/Analysis/SpecialFunctions/Gamma/BohrMollerup.lean
@@ -346,7 +346,7 @@ theorem Gamma_three_div_two_lt_one : Gamma (3 / 2) < 1 := by
 
 theorem Gamma_strictMonoOn_Ici : StrictMonoOn Gamma (Ici 2) := by
   convert
-    convexOn_Gamma.strict_mono_of_lt (by simp : (0 : ℝ) < 3 / 2)
+    convexOn_Gamma.strictMonoOn (by simp : (0 : ℝ) < 3 / 2)
       (by norm_num : (3 / 2 : ℝ) < 2) (Gamma_two.symm ▸ Gamma_three_div_two_lt_one)
   symm
   rw [inter_eq_right]


### PR DESCRIPTION
---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

When merging, all the commits will be squashed into a single commit
listing all co-authors.

Co-authors in the squash commit are gathered from two sources:

First, all authors of commits to this PR branch are included. Thus,
one way to add co-authors is to include at least one commit authored by
each co-author among the commits in the pull request. If necessary, you
may create empty commits to indicate co-authorship, using commands like so:

git commit --author="Author Name <author@email.com>" --allow-empty -m "add Author Name as coauthor"

Second, co-authors can also be listed in lines at the very bottom of
the commit message (that is, directly before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines
at the bottom of the commit message (before the `---`, and also before
any "Co-authored-by" lines) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
