### PR TITLE
[Merged by Bors] - feat(Analysis/Analytic/RadiusLiminf): finish the Cauchy-Hadamard theorem

### DIFF
--- a/Mathlib/Analysis/Analytic/RadiusLiminf.lean
+++ b/Mathlib/Analysis/Analytic/RadiusLiminf.lean
@@ -56,4 +56,13 @@ theorem radius_eq_liminf :
     filter_upwards [eventually_lt_of_lt_liminf hr, eventually_gt_atTop 0] with n hn hn₀
     simpa using NNReal.coe_le_coe.2 ((this _ hn₀).1 hn.le)
 
+/-- The **Cauchy-Hadamard theorem** for formal multilinear series: The inverse of the radius of
+a formal multilinear series is equal to $\limsup_{n\to\infty} \sqrt[n]{‖p n‖}$. -/
+theorem radius_inv_eq_limsup :
+    p.radius⁻¹ = limsup (fun n ↦ ((‖p n‖₊ ^ (1 / (n : ℝ)) : ℝ≥0) : ℝ≥0∞)) atTop := by
+  rw [← inv_inv <| limsup ..]
+  congr
+  rw [ENNReal.inv_limsup, funext inv_eq_one_div]
+  exact p.radius_eq_liminf
+
 end FormalMultilinearSeries

--- a/Mathlib/Analysis/Analytic/RadiusLiminf.lean
+++ b/Mathlib/Analysis/Analytic/RadiusLiminf.lean
@@ -56,13 +56,10 @@ theorem radius_eq_liminf :
     filter_upwards [eventually_lt_of_lt_liminf hr, eventually_gt_atTop 0] with n hn hn₀
     simpa using NNReal.coe_le_coe.2 ((this _ hn₀).1 hn.le)
 
-/-- The **Cauchy-Hadamard theorem** for formal multilinear series: The inverse of the radius of
-a formal multilinear series is equal to $\limsup_{n\to\infty} \sqrt[n]{‖p n‖}$. -/
+/-- The **Cauchy-Hadamard theorem** for formal multilinear series: The inverse of the radius
+is equal to $\limsup_{n\to\infty} \sqrt[n]{‖p n‖}$. -/
 theorem radius_inv_eq_limsup :
     p.radius⁻¹ = limsup (fun n ↦ ((‖p n‖₊ ^ (1 / (n : ℝ)) : ℝ≥0) : ℝ≥0∞)) atTop := by
-  rw [← inv_inv <| limsup ..]
-  congr
-  rw [ENNReal.inv_limsup, funext inv_eq_one_div]
-  exact p.radius_eq_liminf
+  simpa [ENNReal.inv_liminf] using congr($(p.radius_eq_liminf)⁻¹)
 
 end FormalMultilinearSeries

--- a/docs/1000.yaml
+++ b/docs/1000.yaml
@@ -965,6 +965,9 @@ Q858978:
 
 Q859122:
   title: Cauchy–Hadamard theorem
+  decl: FormalMultilinearSeries.radius_inv_eq_limsup
+  authors: Yury Kudryashov
+  date: 2020
 
 Q865665:
   title: Birkhoff's theorem (relativity)


### PR DESCRIPTION
---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

When merging, all the commits will be squashed into a single commit
listing all co-authors.

Co-authors in the squash commit are gathered from two sources:

First, all authors of commits to this PR branch are included. Thus,
one way to add co-authors is to include at least one commit authored by
each co-author among the commits in the pull request. If necessary, you
may create empty commits to indicate co-authorship, using commands like so:

git commit --author="Author Name <author@email.com>" --allow-empty -m "add Author Name as coauthor"

Second, co-authors can also be listed in lines at the very bottom of
the commit message (that is, directly before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines
at the bottom of the commit message (before the `---`, and also before
any "Co-authored-by" lines) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
