### PR TITLE
[Merged by Bors] - doc(CategoryTheory): ensure only a single H1 header per file

### DIFF
--- a/Mathlib/CategoryTheory/Bicategory/NaturalTransformation/Oplax.lean
+++ b/Mathlib/CategoryTheory/Bicategory/NaturalTransformation/Oplax.lean
@@ -35,7 +35,7 @@ We also provide API for going between oplax transformations and strong transform
 * `Oplax.mkOfOplax η η'`: given an oplax transformation `η` such that each component
   2-morphism is an isomorphism, `mkOfOplax` gives the corresponding strong transformation.
 
-# TODO
+## TODO
 This file could also include lax transformations between oplax functors.
 
 ## References

--- a/Mathlib/CategoryTheory/Bicategory/Opposites.lean
+++ b/Mathlib/CategoryTheory/Bicategory/Opposites.lean
@@ -16,7 +16,7 @@ We construct the 1-cell opposite of a bicategory `B`, called `Bᵒᵖ`. It is de
 * The 2-morphisms `f ⟶ g` in `Bᵒᵖ` are the 2-morphisms `f ⟶ g` in `B`. In other words, the
   directions of the 2-morphisms are preserved.
 
-# Remarks
+## Remarks
 There are multiple notions of opposite categories for bicategories.
 - There is 1-cell dual `Bᵒᵖ` as defined above.
 - There is the 2-cell dual, `Cᶜᵒ` where only the natural transformations are reversed

--- a/Mathlib/CategoryTheory/Category/ULift.lean
+++ b/Mathlib/CategoryTheory/Category/ULift.lean
@@ -19,7 +19,7 @@ instance on `ULift C` where `C` is a type with a category instance.
 3. `CategoryTheory.ULift.equivalence` is the categorical equivalence between
   `C` and `ULift C`.
 
-# ULiftHom
+## ULiftHom
 
 Given a type `C : Type u`, `ULiftHom.{w} C` is just an alias for `C`.
 If we have `category.{v} C`, then `ULiftHom.{w} C` is endowed with a category instance
@@ -28,7 +28,7 @@ whose morphisms are obtained by applying `ULift.{w}` to the morphisms from `C`.
 This is a category equivalent to `C`. The forward direction of the equivalence is `ULiftHom.up`,
 the backward direction is `ULiftHom.down` and the equivalence is `ULiftHom.equiv`.
 
-# AsSmall
+## AsSmall
 
 This file also contains a construction which takes a type `C : Type u` with a
 category instance `Category.{v} C` and makes a small category

--- a/Mathlib/CategoryTheory/Limits/Indization/Equalizers.lean
+++ b/Mathlib/CategoryTheory/Limits/Indization/Equalizers.lean
@@ -12,7 +12,7 @@ import Mathlib.CategoryTheory.ObjectProperty.LimitsOfShape
 
 We show that if a category `C` has equalizers, then ind-objects are closed under equalizers.
 
-# References
+## References
 * [M. Kashiwara, P. Schapira, *Categories and Sheaves*][Kashiwara2006], Section 6.1
 -/
 

--- a/Mathlib/CategoryTheory/Limits/Preserves/FunctorCategory.lean
+++ b/Mathlib/CategoryTheory/Limits/Preserves/FunctorCategory.lean
@@ -22,7 +22,7 @@ import Mathlib.CategoryTheory.Limits.Yoneda
 * Show that `F : C ⥤ D` preserves limits of a certain shape
   if `Lan F.op : Cᵒᵖ ⥤ Type*` preserves such limits.
 
-# References
+## References
 
 https://ncatlab.org/nlab/show/commutativity+of+limits+and+colimits#preservation_by_functor_categories_and_localizations
 

--- a/Mathlib/CategoryTheory/Limits/Shapes/Pullback/HasPullback.lean
+++ b/Mathlib/CategoryTheory/Limits/Shapes/Pullback/HasPullback.lean
@@ -10,7 +10,7 @@ import Mathlib.CategoryTheory.Limits.Shapes.Pullback.PullbackCone
 `HasPullback f g` and `pullback f g` provides API for `HasLimit` and `limit` in the case of
 pullbacks.
 
-# Main definitions
+## Main definitions
 
 * `HasPullback f g`: this is an abbreviation for `HasLimit (cospan f g)`, and is a typeclass used to
   express the fact that a given pair of morphisms has a pullback.
@@ -45,7 +45,7 @@ pullback.snd f g                       f
       Z ---pushout.inr f g---> pushout f g
 ```
 
-# Main results & API
+## Main results & API
 * The following API is available for using the universal property of `pullback f g`:
   `lift`, `lift_fst`, `lift_snd`, `lift'`, `hom_ext` (for uniqueness).
 

--- a/Mathlib/CategoryTheory/Limits/Shapes/Pullback/PullbackCone.lean
+++ b/Mathlib/CategoryTheory/Limits/Shapes/Pullback/PullbackCone.lean
@@ -11,7 +11,7 @@ import Mathlib.CategoryTheory.Limits.Shapes.Pullback.Cospan
 This file provides API for interacting with cones (resp. cocones) in the case of pullbacks
 (resp. pushouts).
 
-# Main definitions
+## Main definitions
 
 * `PullbackCone f g`: Given morphisms `f : X ⟶ Z` and `g : Y ⟶ Z`, a term `t : PullbackCone f g`
   provides the data of a cone pictured as follows

--- a/Mathlib/CategoryTheory/Limits/Shapes/Reflexive.lean
+++ b/Mathlib/CategoryTheory/Limits/Shapes/Reflexive.lean
@@ -39,7 +39,7 @@ reflexive.
 * `hasReflexiveCoequalizers_iff`: A category has coequalizers of reflexive pairs if and only iff it
   has all colimits of shape `WalkingReflexivePair`.
 
-# TODO
+## TODO
 * If `C` has binary coproducts and reflexive coequalizers, then it has all coequalizers.
 * If `T` is a monad on cocomplete category `C`, then `Algebra T` is cocomplete iff it has reflexive
   coequalizers.

--- a/Mathlib/CategoryTheory/Linear/LinearFunctor.lean
+++ b/Mathlib/CategoryTheory/Linear/LinearFunctor.lean
@@ -13,7 +13,7 @@ import Mathlib.Algebra.Module.LinearMap.Rat
 An additive functor between two `R`-linear categories is called *linear*
 if the induced map on hom types is a morphism of `R`-modules.
 
-# Implementation details
+## Implementation details
 
 `Functor.Linear` is a `Prop`-valued class, defined by saying that
 for every two objects `X` and `Y`, the map

--- a/Mathlib/CategoryTheory/Monad/EquivMon.lean
+++ b/Mathlib/CategoryTheory/Monad/EquivMon.lean
@@ -13,7 +13,7 @@ import Mathlib.CategoryTheory.Monoidal.Mon_
 
 A monad "is just" a monoid in the category of endofunctors.
 
-# Definitions/Theorems
+## Definitions/Theorems
 
 1. `toMon` associates a monoid object in `C ⥤ C` to any monad on `C`.
 2. `monadToMon` is the functorial version of `toMon`.

--- a/Mathlib/CategoryTheory/Monoidal/Bimon_.lean
+++ b/Mathlib/CategoryTheory/Monoidal/Bimon_.lean
@@ -265,7 +265,7 @@ def equivMonComon : Bimon C ≌ Mon (Comon C) where
 
 @[deprecated (since := "2025-09-15")] alias equivMon_Comon_ := equivMonComon
 
-/-! # The trivial bimonoid -/
+/-! ### The trivial bimonoid -/
 
 variable (C) in
 /-- The trivial bimonoid object. -/
@@ -282,7 +282,7 @@ def trivialTo (A : Bimon C) : trivial C ⟶ A :=
 def toTrivial (A : Bimon C) : A ⟶ trivial C :=
   (default : @Quiver.Hom (Comon (Mon C)) _ A (Comon.trivial (Mon C)))
 
-/-! # Additional lemmas -/
+/-! ### Additional lemmas -/
 
 theorem BimonObjAux_counit (M : Bimon C) :
     ε[((toComon C).obj M).X] = ε[M.X].hom :=

--- a/Mathlib/CategoryTheory/Monoidal/Braided/Multifunctor.lean
+++ b/Mathlib/CategoryTheory/Monoidal/Braided/Multifunctor.lean
@@ -92,7 +92,7 @@ namespace Forward
 
 /-!
 
-# The forward hexagon identity
+### The forward hexagon identity
 
 Given a braiding in the form of a natural isomorphism of bifunctors
 `β : curriedTensor C ≅ (curriedTensor C).flip` (i.e. `(β.app X₁).app X₂ : X₁ ⊗ X₂ ≅ X₂ ⊗ X₁`),
@@ -148,7 +148,7 @@ namespace Reverse
 
 /-!
 
-# The reverse hexagon identity
+### The reverse hexagon identity
 
 Given a braiding in the form of a natural isomorphism of bifunctors
 `β : curriedTensor C ≅ (curriedTensor C).flip` (i.e. `(β.app X₁).app X₂ : X₁ ⊗ X₂ ≅ X₂ ⊗ X₁`),

--- a/Mathlib/CategoryTheory/Monoidal/Cartesian/Basic.lean
+++ b/Mathlib/CategoryTheory/Monoidal/Cartesian/Basic.lean
@@ -31,7 +31,7 @@ In applications requiring a finite-product-preserving functor to be
 oplax-monoidal/monoidal/braided, avoid `attribute [local instance] ofChosenFiniteProducts` but
 instead turn on the corresponding `ofChosenFiniteProducts` declaration for that functor only.
 
-# Projects
+## Projects
 
 - Construct an instance of chosen finite products in the category of affine scheme, using
   the tensor product.

--- a/Mathlib/CategoryTheory/Monoidal/Multifunctor.lean
+++ b/Mathlib/CategoryTheory/Monoidal/Multifunctor.lean
@@ -75,13 +75,13 @@ namespace Functor.LaxMonoidal
 
 /-!
 
-# Lax monoidal functors
+## Lax monoidal functors
 
 Given a unit morphism `ε : 𝟙_ D ⟶ F.obj (𝟙_ C))` and a tensorator `μ : F - ⊗ F - ⟶ F (- ⊗ -)`
 such that the diagrams below commute, we define
 `CategoryTheory.Functor.LaxMonoidal.ofBifunctor : F.LaxMonoidal`.
 
-## Associativity hexagon
+### Associativity hexagon
 
 ```
       (F - ⊗ F -) ⊗ F -
@@ -96,7 +96,7 @@ F ((- ⊗ -) ⊗ -)    F - ⊗ F (- ⊗ -)
        F (- ⊗ (- ⊗ -))
 ```
 
-## Left unitality square
+### Left unitality square
 
 ```
 𝟙 ⊗ F - ⟶ F 𝟙 ⊗ F -
@@ -105,7 +105,7 @@ F ((- ⊗ -) ⊗ -)    F - ⊗ F (- ⊗ -)
   F    ←   F (𝟙 ⊗ -)
 ```
 
-## Right unitality square
+### Right unitality square
 
 ```
 F - ⊗ 𝟙 ⟶ F - ⊗ F 𝟙
@@ -261,13 +261,13 @@ namespace OplaxMonoidal
 
 /-!
 
-# Oplax monoidal functors
+## Oplax monoidal functors
 
 Given a counit morphism `η : F.obj (𝟙_ C)) ⟶ 𝟙_ D` and a tensorator `δ : F (- ⊗ -) ⟶ F - ⊗ F -`
 such that the diagrams below commute, we define
 `CategoryTheory.Functor.OplaxMonoidal.ofBifunctor : F.OplaxMonoidal`.
 
-## Oplax associativity hexagon
+### Oplax associativity hexagon
 
 ```
       F ((- ⊗ -) ⊗ -)
@@ -282,7 +282,7 @@ F (- ⊗ -) ⊗ F -      F (- ⊗ (- ⊗ -))
        F - ⊗ (F - ⊗ F -)
 ```
 
-## Oplax left unitality square
+### Oplax left unitality square
 
 ```
   F   ⟶  F (𝟙 ⊗ -)
@@ -291,7 +291,7 @@ F (- ⊗ -) ⊗ F -      F (- ⊗ (- ⊗ -))
 𝟙 ⊗ F - ← F 𝟙 ⊗ F -
 ```
 
-## Oplax right unitality square
+### Oplax right unitality square
 
 ```
   F  ⟶   F (- ⊗ 𝟙)

--- a/Mathlib/CategoryTheory/Preadditive/AdditiveFunctor.lean
+++ b/Mathlib/CategoryTheory/Preadditive/AdditiveFunctor.lean
@@ -21,7 +21,7 @@ biproducts, and if `F` preserves binary biproducts, then `F` is additive.
 
 We also define the category of bundled additive functors.
 
-# Implementation details
+## Implementation details
 
 `Functor.Additive` is a `Prop`-valued class, defined by saying that for every two objects `X` and
 `Y`, the map `F.map : (X ⟶ Y) → (F.obj X ⟶ F.obj Y)` is a morphism of abelian groups.

--- a/Mathlib/CategoryTheory/Sites/Coverage.lean
+++ b/Mathlib/CategoryTheory/Sites/Coverage.lean
@@ -39,7 +39,7 @@ All definitions are in the `CategoryTheory` namespace.
   Grothendieck topology `J`, a `Type*`-valued presheaf on `C` is a sheaf for `K` if and only if
   it is a sheaf for `J`.
 
-# References
+## References
 We don't follow any particular reference, but the arguments can probably be distilled from
 the following sources:
 - [Elephant]: *Sketches of an Elephant*, P. T. Johnstone: C2.1.


### PR DESCRIPTION
This PR ensures we only have a single H1 header per lean file in the `CategoryTheory` subdirectory. We do this for the following reasons:

- Having more than one H1 header per file is likely to hamper both assistive technologies and SEO, since it introduces ambiguity about what the title of the resulting documentation webpage actually should be.
- The [documentation style guide](https://leanprover-community.github.io/contribute/doc.html) asks for the title of the file to be H1, any other header in the file-level docstring to be H2, and sectioning headers to be H3.

I have used my own judgement to decide whether to demote the extra H1 headers to H2 or H3. I've also tried to ensure that any intended header hierarchy is maintained, by further demoting existing H2 comments to H3 where applicable. I ask reviewers to verify that my choices makes sense to them.

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

When merging, all the commits will be squashed into a single commit
listing all co-authors.

Co-authors in the squash commit are gathered from two sources:

First, all authors of commits to this PR branch are included. Thus,
one way to add co-authors is to include at least one commit authored by
each co-author among the commits in the pull request. If necessary, you
may create empty commits to indicate co-authorship, using commands like so:

git commit --author="Author Name <author@email.com>" --allow-empty -m "add Author Name as coauthor"

Second, co-authors can also be listed in lines at the very bottom of
the commit message (that is, directly before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines
at the bottom of the commit message (before the `---`, and also before
any "Co-authored-by" lines) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
