### PR TITLE
[Merged by Bors] - doc(Combinatorics): ensure only a single H1 header per file

### DIFF
--- a/Mathlib/Combinatorics/Derangements/Finite.lean
+++ b/Mathlib/Combinatorics/Derangements/Finite.lean
@@ -13,7 +13,7 @@ import Mathlib.Tactic.Ring
 
 This file contains lemmas that describe the cardinality of `derangements α` when `α` is a fintype.
 
-# Main definitions
+## Main definitions
 
 * `card_derangements_invariant`: A lemma stating that the number of derangements on a type `α`
     depends only on the cardinality of `α`.

--- a/Mathlib/Combinatorics/Enumerative/Stirling.lean
+++ b/Mathlib/Combinatorics/Enumerative/Stirling.lean
@@ -12,20 +12,18 @@ import Mathlib.Data.Nat.Choose.Basic
 
 This file defines Stirling numbers of the first and second kinds, proves their fundamental
 recurrence relations, and establishes some of their key properties and identities.
--/
 
-/-!
-# The Stirling numbers of the first kind
+## The Stirling numbers of the first kind
 
 The unsigned Stirling numbers of the first kind, represent the number of ways
 to partition `n` distinct elements into `k` non-empty cycles.
 
-# The Stirling numbers of the second kind
+## The Stirling numbers of the second kind
 
 The Stirling numbers of the second kind, represent the number of ways to partition
 `n` distinct elements into `k` non-empty subsets.
 
-# Main definitions
+## Main definitions
 
 * `Nat.stirlingFirst`: the number of ways to partition `n` distinct elements into `k` non-empty
   cycles, defined by the recursive relationship it satisfies.

--- a/Mathlib/Combinatorics/Matroid/Circuit.lean
+++ b/Mathlib/Combinatorics/Matroid/Circuit.lean
@@ -13,7 +13,7 @@ A matroid is determined by its set of circuits, and often the circuits
 offer a more compact description of a matroid than the collection of independent sets or bases.
 In matroids arising from graphs, circuits correspond to graphical cycles.
 
-# Main Declarations
+## Main Declarations
 
 * `Matroid.IsCircuit M C` means that `C` is minimally dependent in `M`.
 * For an `Indep`endent set `I` whose closure contains an element `e ∉ I`,
@@ -36,7 +36,7 @@ In matroids arising from graphs, circuits correspond to graphical cycles.
 * `Matroid.IsBase.mem_fundCocircuit_iff_mem_fundCircuit` : `e` is in the fundamental circuit
   for `B` and `f` iff `f` is in the fundamental cocircuit for `B` and `e`.
 
-# Implementation Details
+## Implementation Details
 
 Since `Matroid.fundCircuit M e I` is only sensible if `I` is independent and `e ∈ M.closure I \ I`,
 to avoid hypotheses being explicitly included in the definition,

--- a/Mathlib/Combinatorics/Matroid/Minor/Contract.lean
+++ b/Mathlib/Combinatorics/Matroid/Minor/Contract.lean
@@ -23,7 +23,7 @@ While this is perhaps less intuitive, we use this very concise expression as the
 and prove with the lemma `Matroid.IsBasis.contract_indep_iff` that this is equivalent to
 the more verbose definition above.
 
-# Main Declarations
+## Main Declarations
 
 * `Matroid.contract M C`, written `M ／ C`, is the matroid on ground set `M.E \ C` in which a set
   `I ⊆ M.E \ C` is independent if and only if `I ∪ J` is independent in `M`,
@@ -34,7 +34,7 @@ the more verbose definition above.
   sets of `M ／ C` are exactly the `J ⊆ M.E \ C` for which `I ∪ J` is independent in `M`.
 * `Matroid.contract_delete_comm` : `M ／ C ＼ D = M ＼ D ／ C` for disjoint `C` and `D`.
 
-# Naming conventions
+## Naming conventions
 
 Mirroring the convention for deletion, we use the abbreviation `contractElem` in lemma names
 to refer to the contraction `M ／ {e}` of a single element `e : α` from `M : Matroid α`.

--- a/Mathlib/Combinatorics/Matroid/Minor/Delete.lean
+++ b/Mathlib/Combinatorics/Matroid/Minor/Delete.lean
@@ -38,7 +38,7 @@ variable {α : Type*} {M M' N : Matroid α} {e f : α} {I B D R X : Set α}
 
 namespace Matroid
 
-/-! ### Deletion -/
+/-! ## Deletion -/
 
 section Delete
 

--- a/Mathlib/Combinatorics/Matroid/Minor/Delete.lean
+++ b/Mathlib/Combinatorics/Matroid/Minor/Delete.lean
@@ -21,12 +21,12 @@ the relation `M ↾ R ≤r M` holds only with the assumption `R ⊆ M.E`,
 whereas `M ＼ D`, being defined as `M ↾ (M.E \ D)`, satisfies `M ＼ D ≤r M` unconditionally.
 This is often quite convenient.
 
-# Main Declarations
+## Main Declarations
 
 * `Matroid.delete M D`, written `M ＼ D`, is the restriction of `M` to the set `M.E \ D`,
   or equivalently the matroid on `M.E \ D` whose independent sets are the `M`-independent sets.
 
-# Naming conventions
+## Naming conventions
 
 We use the abbreviation `deleteElem` in lemma names to refer to the deletion `M ＼ {e}`
 of a single element `e : α` from `M : Matroid α`.
@@ -38,7 +38,7 @@ variable {α : Type*} {M M' N : Matroid α} {e f : α} {I B D R X : Set α}
 
 namespace Matroid
 
-/-! ## Deletion -/
+/-! ### Deletion -/
 
 section Delete
 

--- a/Mathlib/Combinatorics/Matroid/Minor/Order.lean
+++ b/Mathlib/Combinatorics/Matroid/Minor/Order.lean
@@ -17,7 +17,7 @@ Although we provide a `PartialOrder` instance on `Matroid α` corresponding to t
 we do not use the `M ≤ N` / `N < M` notation directly,
 instead writing `N ≤m M` and `N <m M` for more convenient dot notation.
 
-# Main Declarations
+## Main Declarations
 
 * `Matroid.IsMinor N M`, written `N ≤m M`, means that `N = M ／ C ＼ D` for some
   subset `C` and `D` of `M.E`.

--- a/Mathlib/Combinatorics/Matroid/Rank/Cardinal.lean
+++ b/Mathlib/Combinatorics/Matroid/Rank/Cardinal.lean
@@ -20,7 +20,7 @@ such that this property holds for all `I`, `J` and `X`.
 A matroid satisfying this condition has a well-defined cardinality-valued rank function,
 both for itself and all its minors.
 
-# Main Declarations
+## Main Declarations
 
 * `Matroid.InvariantCardinalRank` : a typeclass capturing the idea that a matroid and all its minors
   have a well-behaved cardinal-valued rank function.
@@ -30,7 +30,7 @@ both for itself and all its minors.
   showing that `Finitary` matroids are `InvariantCardinalRank`.
 * `cRk_inter_add_cRk_union_le` states that cardinal rank is submodular.
 
-# Notes
+## Notes
 
 It is not (provably) the case that all matroids are `InvariantCardinalRank`,
 since the equicardinality of bases in general matroids is independent of ZFC
@@ -41,7 +41,7 @@ The `ℕ∞`-valued rank and rank functions `Matroid.eRank` and `Matroid.eRk`,
 which have a more unconditionally strong API,
 are developed in `Mathlib/Data/Matroid/Rank/ENat.lean`.
 
-# Implementation Details
+## Implementation Details
 
 Since the functions `cRank` and `cRk` are defined as suprema,
 independently of the `Matroid.InvariantCardinalRank` typeclass,
@@ -52,7 +52,7 @@ and its value may differ on a set `X` and the closure of `X`.
 We state and prove theorems without `InvariantCardinalRank` whenever possible,
 which sometime makes their proofs longer than they would be with the instance.
 
-# TODO
+## TODO
 
 * Higgs' theorem : if the generalized continuum hypothesis holds,
   then every matroid is `InvariantCardinalRank`.

--- a/Mathlib/Combinatorics/Matroid/Rank/ENat.lean
+++ b/Mathlib/Combinatorics/Matroid/Rank/ENat.lean
@@ -32,14 +32,14 @@ the rank function is often the preferred perspective on matroids in the literatu
 (The above doesn't work as well for infinite matroids,
 which is why mathlib defines matroids using bases/independence. )
 
-# Main Declarations
+## Main Declarations
 
 * `Matroid.eRank M` is the `ℕ∞`-valued cardinality of each base of `M`.
 * `Matroid.eRk M X` is the `ℕ∞`-valued cardinality of each `M`-basis of `X`.
 * `Matroid.eRk_inter_add_eRk_union_le` : the function `M.eRk` is submodular.
 * `Matroid.dual_eRk_add_eRank` : a subtraction-free formula for the dual rank of a set.
 
-# Notes
+## Notes
 
 It is natural to ask if equicardinality of bases holds if 'cardinality' refers to
 a term in `Cardinal` instead of `ℕ∞`, but the answer is that it doesn't.
@@ -47,7 +47,7 @@ The cardinal-valued rank functions `Matroid.cRank` and `Matroid.cRk` are defined
 `Mathlib/Data/Matroid/Rank/Cardinal.lean`, but have less desirable properties in general.
 See the module docstring of that file for a discussion.
 
-# Implementation Details
+## Implementation Details
 
 It would be equivalent to define `Matroid.eRank (M : Matroid α) := (Matroid.cRank M).toENat`
 and similar for `Matroid.eRk`, and some of the API for `cRank`/`cRk` would carry over

--- a/Mathlib/Combinatorics/Matroid/Rank/Finite.lean
+++ b/Mathlib/Combinatorics/Matroid/Rank/Finite.lean
@@ -13,7 +13,7 @@ or equivalently that the restriction of `M` to `X` is `Matroid.RankFinite`.
 Sets in a matroid with `IsRkFinite` are the largest class of sets for which one can do nontrivial
 integer arithmetic involving the rank function.
 
-# Implementation Details
+## Implementation Details
 
 Unlike most set predicates on matroids, a set `X` with `M.IsRkFinite X` need not satisfy `X ⊆ M.E`,
 so may contain junk elements. This seems to be what makes the definition easiest to use.


### PR DESCRIPTION
This PR ensures we only have a single H1 header per lean file in the `Combinatorics` subdirectory. We do this for the following reasons:

- Having more than one H1 header per file is likely to hamper both assistive technologies and SEO, since it introduces ambiguity about what the title of the resulting documentation webpage actually should be.
- The [documentation style guide](https://leanprover-community.github.io/contribute/doc.html) asks for the title of the file to be H1, any other header in the file-level docstring to be H2, and sectioning headers to be H3.

I have used my own judgement to decide whether to demote the extra H1 headers to H2 or H3. I've also tried to ensure that any intended header hierarchy is maintained, by further demoting existing H2 comments to H3 where applicable. I ask reviewers to verify that my choices makes sense to them.

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

When merging, all the commits will be squashed into a single commit
listing all co-authors.

Co-authors in the squash commit are gathered from two sources:

First, all authors of commits to this PR branch are included. Thus,
one way to add co-authors is to include at least one commit authored by
each co-author among the commits in the pull request. If necessary, you
may create empty commits to indicate co-authorship, using commands like so:

git commit --author="Author Name <author@email.com>" --allow-empty -m "add Author Name as coauthor"

Second, co-authors can also be listed in lines at the very bottom of
the commit message (that is, directly before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines
at the bottom of the commit message (before the `---`, and also before
any "Co-authored-by" lines) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
