### PR TITLE
[Merged by Bors] - doc(AlgebraicGeometry): fix typos

### DIFF
--- a/Mathlib/AlgebraicGeometry/AffineTransitionLimit.lean
+++ b/Mathlib/AlgebraicGeometry/AffineTransitionLimit.lean
@@ -184,7 +184,7 @@ lemma exists_map_eq_top
 
 attribute [local simp] Scheme.Hom.resLE_comp_resLE
 
-/-- Given a diagram `{ Dᵢ }` of schemes and a open `U ⊆ Dᵢ`,
+/-- Given a diagram `{ Dᵢ }` of schemes and an open `U ⊆ Dᵢ`,
 this is the diagram of `{ Dⱼᵢ⁻¹ U }_{j ≤ i}`. -/
 @[simps] noncomputable
 def opensDiagram (i : I) (U : (D.obj i).Opens) : Over i ⥤ Scheme where
@@ -201,7 +201,7 @@ instance (i : I) (U : (D.obj i).Opens) (j : Over i) :
     IsOpenImmersion ((opensDiagramι D i U).app j) := by
   delta opensDiagramι; infer_instance
 
-/-- Given a diagram `{ Dᵢ }` of schemes and a open `U ⊆ Dᵢ`,
+/-- Given a diagram `{ Dᵢ }` of schemes and an open `U ⊆ Dᵢ`,
 the preimage of `U ⊆ Dᵢ` under the map `lim Dᵢ ⟶ Dᵢ` is the limit of `{ Dⱼᵢ⁻¹ U }_{j ≤ i}`.
 This is the underlying cone, and it is limiting as witnessed by `isLimitOpensCone` below. -/
 @[simps] noncomputable
@@ -211,7 +211,7 @@ def opensCone (i : I) (U : (D.obj i).Opens) : Cone (opensDiagram D i U) where
 
 attribute [local instance] CategoryTheory.isConnected_of_hasTerminal
 
-/-- Given a diagram `{ Dᵢ }_{i ∈ I}` of schemes and a open `U ⊆ Dᵢ`,
+/-- Given a diagram `{ Dᵢ }_{i ∈ I}` of schemes and an open `U ⊆ Dᵢ`,
 the preimage of `U ⊆ Dᵢ` under the map `lim Dᵢ ⟶ Dᵢ` is the limit of `{ Dⱼᵢ⁻¹ U }_{j ≤ i}`. -/
 noncomputable
 def isLimitOpensCone [IsCofiltered I] (i : I) (U : (D.obj i).Opens) :
@@ -264,7 +264,7 @@ lemma Scheme.compactSpace_of_isLimit [IsCofiltered I]
 
 /-!
 
-# Cofiltered Limits and Schemes of Finite Type
+## Cofiltered Limits and Schemes of Finite Type
 
 Given a cofiltered diagram `D` of quasi-compact `S`-schemes with affine transition maps,
 and another scheme `X` of finite type over `S`.
@@ -575,13 +575,13 @@ lemma Scheme.exists_hom_hom_comp_eq_comp_of_locallyOfFiniteType
 end LocallyOfFiniteType
 
 /-!
-## Sections of the limit
+### Sections of the limit
 
-Let `D` be a cofiltered diagram schemes with affine transition map.
+Let `D` be a cofiltered diagram of schemes with affine transition maps.
 Consider the canonical map `colim Γ(Dᵢ, ⊤) ⟶ Γ(lim Dᵢ, ⊤)`.
 
 If `D` consists of quasicompact schemes, then this map is injective. More generally, we show
-that if `s t : Γ(Dᵢ, U)` have equal image in `lim Dᵢ`, then they are equal at some `Γ(Dⱼ, Dⱼᵢ⁻¹U)`.
+that if `s t : Γ(Dᵢ, U)` have equal image in `lim Dᵢ`, then they are equal at some `Γ(Dⱼ, Dⱼᵢ⁻¹ U)`.
 See `AlgebraicGeometry.exists_app_map_eq_map_of_isLimit`.
 
 If `D` consists of qcqs schemes, then this map is surjective. Specifically, we show that

--- a/Mathlib/AlgebraicGeometry/Morphisms/Immersion.lean
+++ b/Mathlib/AlgebraicGeometry/Morphisms/Immersion.lean
@@ -15,7 +15,7 @@ A morphism of schemes `f : X ⟶ Y` is an immersion if the underlying map of top
 is a locally closed embedding, and the induced morphisms of stalks are all surjective. This is true
 if and only if it can be factored into a closed immersion followed by an open immersion.
 
-# Main result
+## Main results
 - `isImmersion_iff_exists`:
   A morphism is a (locally-closed) immersion if and only if it can be factored into
   a closed immersion followed by a (dominant) open immersion.


### PR DESCRIPTION
This PR fixes a batch of typos in `AlgebraicGeometry`. The typos were identified and fixed with the help of Codex.

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

When merging, all the commits will be squashed into a single commit
listing all co-authors.

Co-authors in the squash commit are gathered from two sources:

First, all authors of commits to this PR branch are included. Thus,
one way to add co-authors is to include at least one commit authored by
each co-author among the commits in the pull request. If necessary, you
may create empty commits to indicate co-authorship, using commands like so:

git commit --author="Author Name <author@email.com>" --allow-empty -m "add Author Name as coauthor"

Second, co-authors can also be listed in lines at the very bottom of
the commit message (that is, directly before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines
at the bottom of the commit message (before the `---`, and also before
any "Co-authored-by" lines) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
