### PR TITLE
[Merged by Bors] - doc(AlgebraicTopology/SingularSet): fix typos

### DIFF
--- a/Mathlib/AlgebraicTopology/SingularSet.lean
+++ b/Mathlib/AlgebraicTopology/SingularSet.lean
@@ -13,15 +13,15 @@ import Mathlib.Topology.Category.TopCat.ULift
 # The singular simplicial set of a topological space and geometric realization of a simplicial set
 
 The *singular simplicial set* `TopCat.toSSet.obj X` of a topological space `X`
-has `n`-simplices which identify to continuous maps `stdSimplex ℝ (Fin (n + 1) → X`,
-where `stdSimplex ℝ (Fin (n + 1) → X` is the standard topological `n`-simplex,
-which is defined as the subtype of `Fin (n + 1) → ℝ` consists of functions `f`
+has `n`-simplices which identify to continuous maps `stdSimplex ℝ (Fin (n + 1)) → X`,
+where `stdSimplex ℝ (Fin (n + 1))` is the standard topological `n`-simplex,
+defined as the subtype of `Fin (n + 1) → ℝ` consisting of functions `f`
 such that `0 ≤ f i` for all `i` and `∑ i, f i = 1`.
 
 The *geometric realization* functor `SSet.toTop.obj` is left adjoint to `TopCat.toSSet`.
 It is the left Kan extension of `SimplexCategory.toTop` along the Yoneda embedding.
 
-# Main definitions
+## Main definitions
 
 * `TopCat.toSSet : TopCat ⥤ SSet` is the functor
   assigning the singular simplicial set to a topological space.
@@ -45,8 +45,8 @@ open CategoryTheory
 Let `X : TopCat.{u}` be a topological space.
 Then the singular simplicial set of `X`
 has as `n`-simplices the continuous maps `ULift.{u} (stdSimplex ℝ (Fin (n + 1))) → X`.
-Here, `stdSimplex ℝ (Fin (n + 1)` is the standard topological `n`-simplex,
-defined as `{ f : Fin (n + 1) → ℝ // ∀ i, 0 ≤ f i ∧ ∑ i, f i = 1 }` with its subspace topology. -/
+Here, `stdSimplex ℝ (Fin (n + 1))` is the standard topological `n`-simplex,
+defined as `{ f : Fin (n + 1) → ℝ // (∀ i, 0 ≤ f i) ∧ ∑ i, f i = 1 }` with its subspace topology. -/
 noncomputable def TopCat.toSSet : TopCat.{u} ⥤ SSet.{u} :=
   Presheaf.restrictedULiftYoneda.{0} SimplexCategory.toTop.{u}
 

--- a/Mathlib/AlgebraicTopology/SingularSet.lean
+++ b/Mathlib/AlgebraicTopology/SingularSet.lean
@@ -18,7 +18,7 @@ where `stdSimplex ℝ (Fin (n + 1))` is the standard topological `n`-simplex,
 defined as the subtype of `Fin (n + 1) → ℝ` consisting of functions `f`
 such that `0 ≤ f i` for all `i` and `∑ i, f i = 1`.
 
-The *geometric realization* functor `SSet.toTop.obj` is left adjoint to `TopCat.toSSet`.
+The *geometric realization* functor `SSet.toTop` is left adjoint to `TopCat.toSSet`.
 It is the left Kan extension of `SimplexCategory.toTop` along the Yoneda embedding.
 
 ## Main definitions


### PR DESCRIPTION
This PR fixes some apparent typos in `SingularSet`. The typos were found and corrected with the help of Codex.

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

When merging, all the commits will be squashed into a single commit
listing all co-authors.

Co-authors in the squash commit are gathered from two sources:

First, all authors of commits to this PR branch are included. Thus,
one way to add co-authors is to include at least one commit authored by
each co-author among the commits in the pull request. If necessary, you
may create empty commits to indicate co-authorship, using commands like so:

git commit --author="Author Name <author@email.com>" --allow-empty -m "add Author Name as coauthor"

Second, co-authors can also be listed in lines at the very bottom of
the commit message (that is, directly before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines
at the bottom of the commit message (before the `---`, and also before
any "Co-authored-by" lines) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
