### PR TITLE
[Merged by Bors] - doc(push_neg): mention `by_cases!` and friends

### DIFF
--- a/Mathlib/Tactic/Push.lean
+++ b/Mathlib/Tactic/Push.lean
@@ -231,7 +231,7 @@ transformed to either `p → ¬ q` (the default) or `¬ p ∨ ¬ q`. To get `¬ 
 `set_option push_neg.use_distrib true`.
 
 Tactics that introduce a negation usually have a version that automatically calls `push_neg` on
-that negation. For example, `by_cases!`, `contrapose!` and `by_contra!`.
+that negation. These include `by_cases!`, `contrapose!` and `by_contra!`.
 
 Another example: given a hypothesis
 ```lean

--- a/Mathlib/Tactic/Push.lean
+++ b/Mathlib/Tactic/Push.lean
@@ -230,6 +230,9 @@ built in for `push Not`, so that it can preserve binder names, and so that `¬ (
 transformed to either `p → ¬ q` (the default) or `¬ p ∨ ¬ q`. To get `¬ p ∨ ¬ q`, use
 `set_option push_neg.use_distrib true`.
 
+Tactics that introduce a negation usually have a version that automatically calls `push_neg` on
+that negation. For example, `by_cases!`, `contrapose!` and `by_contra!`.
+
 Another example: given a hypothesis
 ```lean
 h : ¬ ∀ ε > 0, ∃ δ > 0, ∀ x, |x - x₀| ≤ δ → |f x - y₀| ≤ ε


### PR DESCRIPTION
This PR modifies the doc-string of `push_neg` to mention `by_cases!`, `contrapose!` and `by_contra!`.

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

When merging, all the commits will be squashed into a single commit
listing all co-authors.

Co-authors in the squash commit are gathered from two sources:

First, all authors of commits to this PR branch are included. Thus,
one way to add co-authors is to include at least one commit authored by
each co-author among the commits in the pull request. If necessary, you
may create empty commits to indicate co-authorship, using commands like so:

git commit --author="Author Name <author@email.com>" --allow-empty -m "add Author Name as coauthor"

Second, co-authors can also be listed in lines at the very bottom of
the commit message (that is, directly before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines
at the bottom of the commit message (before the `---`, and also before
any "Co-authored-by" lines) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
