### PR TITLE
[Merged by Bors] - feat(RingTheory): improve `radical_eq_of_primeFactors_eq`

### DIFF
--- a/Mathlib/RingTheory/Radical.lean
+++ b/Mathlib/RingTheory/Radical.lean
@@ -165,6 +165,7 @@ lemma radical_eq_iff_primeFactors_eq :
     radical a = radical b ↔ primeFactors a = primeFactors b :=
   ⟨fun h => by rw [← primeFactors_radical, h]; exact primeFactors_radical,
     fun h => by simp [radical, h]⟩
+@[deprecated (since := "2025-11-09")] alias radical_eq_of_primeFactors_eq := radical_eq_iff_primeFactors_eq.mpr
 
 theorem radical_eq_of_associated (h : Associated a b) : radical a = radical b :=
   radical_eq_iff_primeFactors_eq.mpr h.primeFactors_eq

--- a/Mathlib/RingTheory/Radical.lean
+++ b/Mathlib/RingTheory/Radical.lean
@@ -267,7 +267,7 @@ theorem radical_eq_one_iff : radical a = 1 ↔ a = 0 ∨ IsUnit a := by
 
 @[simp]
 lemma radical_radical : radical (radical a) = radical a :=
-  radical_eq_iff_primeFactors_eq.2 primeFactors_radical
+  radical_eq_iff_primeFactors_eq.mpr primeFactors_radical
 
 lemma radical_dvd_radical_iff_normalizedFactors_subset_normalizedFactors :
     radical a ∣ radical b ↔ normalizedFactors a ⊆ normalizedFactors b := by

--- a/Mathlib/RingTheory/Radical.lean
+++ b/Mathlib/RingTheory/Radical.lean
@@ -257,7 +257,8 @@ lemma radical_eq_iff_primeFactors_eq :
   ⟨fun h => by rw [← primeFactors_radical, h]; exact primeFactors_radical,
     fun h => by simp [radical, h]⟩
 
-@[deprecated "This lemma is deprecated in favor of using `radical_eq_iff_primeFactors_eq.mpr`. " (since := "2025-11-09")]
+@[deprecated "This lemma is deprecated in favor of using `radical_eq_iff_primeFactors_eq.mpr`. "
+   (since := "2025-11-09")]
 lemma radical_eq_of_primeFactors_eq (h : primeFactors a = primeFactors b) :
     radical a = radical b := radical_eq_iff_primeFactors_eq.mpr h
 

--- a/Mathlib/RingTheory/Radical.lean
+++ b/Mathlib/RingTheory/Radical.lean
@@ -161,14 +161,8 @@ def radical (a : M) : M :=
 @[simp] theorem radical_one : radical (1 : M) = 1 := by simp [radical]
 @[deprecated (since := "2025-05-31")] alias radical_one_eq := radical_one
 
-lemma radical_eq_iff_primeFactors_eq :
-    radical a = radical b ↔ primeFactors a = primeFactors b :=
-  ⟨fun h => by rw [← primeFactors_radical, h]; exact primeFactors_radical,
-    fun h => by simp [radical, h]⟩
-@[deprecated (since := "2025-11-09")] alias radical_eq_of_primeFactors_eq := radical_eq_iff_primeFactors_eq.mpr
-
-theorem radical_eq_of_associated (h : Associated a b) : radical a = radical b :=
-  radical_eq_iff_primeFactors_eq.mpr h.primeFactors_eq
+theorem radical_eq_of_associated (h : Associated a b) : radical a = radical b := by
+  rw [radical, radical, Associated.primeFactors_eq h]
 
 lemma radical_associated (ha : IsRadical a) (ha' : a ≠ 0) :
     Associated (radical a) a := by
@@ -257,6 +251,15 @@ lemma squarefree_radical : Squarefree (radical a) := by
   ext p
   simp +contextual [mem_primeFactors, mem_normalizedFactors_iff',
     dvd_radical_iff_of_irreducible, ha₀]
+
+lemma radical_eq_iff_primeFactors_eq :
+    radical a = radical b ↔ primeFactors a = primeFactors b :=
+  ⟨fun h => by rw [← primeFactors_radical, h]; exact primeFactors_radical,
+    fun h => by simp [radical, h]⟩
+
+@[deprecated "This lemma is deprecated in favor of using `radical_eq_iff_primeFactors_eq.mpr`. " (since := "2025-11-09")]
+lemma radical_eq_of_primeFactors_eq (h : primeFactors a = primeFactors b) :
+    radical a = radical b := radical_eq_iff_primeFactors_eq.mpr h
 
 theorem radical_eq_one_iff : radical a = 1 ↔ a = 0 ∨ IsUnit a := by
   refine ⟨?_, (Or.elim · (by simp +contextual) radical_of_isUnit)⟩

--- a/Mathlib/RingTheory/Radical.lean
+++ b/Mathlib/RingTheory/Radical.lean
@@ -161,12 +161,13 @@ def radical (a : M) : M :=
 @[simp] theorem radical_one : radical (1 : M) = 1 := by simp [radical]
 @[deprecated (since := "2025-05-31")] alias radical_one_eq := radical_one
 
-lemma radical_eq_of_primeFactors_eq (h : primeFactors a = primeFactors b) :
-    radical a = radical b := by
-  simp only [radical, h]
+lemma radical_eq_iff_primeFactors_eq :
+    radical a = radical b ↔ primeFactors a = primeFactors b :=
+  ⟨fun h => by rw [← primeFactors_radical, h]; exact primeFactors_radical,
+    fun h => by simp [radical, h]⟩
 
 theorem radical_eq_of_associated (h : Associated a b) : radical a = radical b :=
-  radical_eq_of_primeFactors_eq h.primeFactors_eq
+  radical_eq_iff_primeFactors_eq.2 h.primeFactors_eq
 
 lemma radical_associated (ha : IsRadical a) (ha' : a ≠ 0) :
     Associated (radical a) a := by
@@ -266,7 +267,7 @@ theorem radical_eq_one_iff : radical a = 1 ↔ a = 0 ∨ IsUnit a := by
 
 @[simp]
 lemma radical_radical : radical (radical a) = radical a :=
-  radical_eq_of_primeFactors_eq primeFactors_radical
+  radical_eq_iff_primeFactors_eq.2 primeFactors_radical
 
 lemma radical_dvd_radical_iff_normalizedFactors_subset_normalizedFactors :
     radical a ∣ radical b ↔ normalizedFactors a ⊆ normalizedFactors b := by

--- a/Mathlib/RingTheory/Radical.lean
+++ b/Mathlib/RingTheory/Radical.lean
@@ -167,7 +167,7 @@ lemma radical_eq_iff_primeFactors_eq :
     fun h => by simp [radical, h]⟩
 
 theorem radical_eq_of_associated (h : Associated a b) : radical a = radical b :=
-  radical_eq_iff_primeFactors_eq.2 h.primeFactors_eq
+  radical_eq_iff_primeFactors_eq.mpr h.primeFactors_eq
 
 lemma radical_associated (ha : IsRadical a) (ha' : a ≠ 0) :
     Associated (radical a) a := by


### PR DESCRIPTION
The radicals of two elements are equal if and only if their sets of prime factors coincide.
Moves:
- UniqueFactorizationMonoid.radical_eq_of_primeFactors_eq -> UniqueFactorizationMonoid.radical_eq_iff_primeFactors_eq

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

When merging, all the commits will be squashed into a single commit
listing all co-authors.

Co-authors in the squash commit are gathered from two sources:

First, all authors of commits to this PR branch are included. Thus,
one way to add co-authors is to include at least one commit authored by
each co-author among the commits in the pull request. If necessary, you
may create empty commits to indicate co-authorship, using commands like so:

git commit --author="Author Name <author@email.com>" --allow-empty -m "add Author Name as coauthor"

Second, co-authors can also be listed in lines at the very bottom of
the commit message (that is, directly before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines
at the bottom of the commit message (before the `---`, and also before
any "Co-authored-by" lines) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
