### PR TITLE
[Merged by Bors] - feat: indicator of a product of sets

### DIFF
--- a/Mathlib/Algebra/BigOperators/GroupWithZero/Finset.lean
+++ b/Mathlib/Algebra/BigOperators/GroupWithZero/Finset.lean
@@ -41,7 +41,7 @@ lemma support_prod_subset (s : Finset ι) (f : ι → κ → M₀) :
     support (fun x ↦ ∏ i ∈ s, f i x) ⊆ ⋂ i ∈ s, support (f i) :=
   fun _ hx ↦ Set.mem_iInter₂.2 fun _ hi H ↦ hx <| prod_eq_zero hi H
 
-@[simp] lemma _root_.Set.indicator_one_apply (s : Finset ι) (t : ∀ i, Set (α i)) (f : ∀ i, α i) :
+@[simp] lemma _root_.Set.indicator_pi_one_apply (s : Finset ι) (t : ∀ i, Set (α i)) (f : ∀ i, α i) :
     ((s : Set ι).pi t).indicator 1 f = ∏ i ∈ s, (t i).indicator (M := M₀) 1 (f i) := by
   simp [Set.indicator, prod_boole]; congr
 

--- a/Mathlib/Algebra/BigOperators/GroupWithZero/Finset.lean
+++ b/Mathlib/Algebra/BigOperators/GroupWithZero/Finset.lean
@@ -5,7 +5,7 @@ Authors: Johannes Hölzl
 -/
 import Mathlib.Algebra.BigOperators.Group.Finset.Basic
 import Mathlib.Algebra.GroupWithZero.Units.Basic
-import Mathlib.Algebra.Notation.Support
+import Mathlib.Algebra.Notation.Indicator
 import Mathlib.Data.Set.Lattice
 
 /-!
@@ -17,7 +17,7 @@ zero.
 
 open Function
 
-variable {ι κ G₀ M₀ : Type*}
+variable {ι κ G₀ M₀ : Type*} {α : ι → Type*}
 
 namespace Finset
 variable [CommMonoidWithZero M₀] {p : ι → Prop} [DecidablePred p] {f : ι → M₀} {s : Finset ι}
@@ -40,6 +40,10 @@ lemma prod_boole : ∏ i ∈ s, (ite (p i) 1 0 : M₀) = ite (∀ i ∈ s, p i) 
 lemma support_prod_subset (s : Finset ι) (f : ι → κ → M₀) :
     support (fun x ↦ ∏ i ∈ s, f i x) ⊆ ⋂ i ∈ s, support (f i) :=
   fun _ hx ↦ Set.mem_iInter₂.2 fun _ hi H ↦ hx <| prod_eq_zero hi H
+
+@[simp] lemma _root_.Set.indicator_one_apply (s : Finset ι) (t : ∀ i, Set (α i)) (f : ∀ i, α i) :
+    ((s : Set ι).pi t).indicator 1 f = ∏ i ∈ s, (t i).indicator (M := M₀) 1 (f i) := by
+  simp [Set.indicator, prod_boole]; congr
 
 variable [Nontrivial M₀] [NoZeroDivisors M₀]
 

--- a/Mathlib/Algebra/BigOperators/GroupWithZero/Finset.lean
+++ b/Mathlib/Algebra/BigOperators/GroupWithZero/Finset.lean
@@ -43,7 +43,7 @@ lemma support_prod_subset (s : Finset ι) (f : ι → κ → M₀) :
 
 @[simp] lemma _root_.Set.indicator_pi_one_apply (s : Finset ι) (t : ∀ i, Set (α i)) (f : ∀ i, α i) :
     ((s : Set ι).pi t).indicator 1 f = ∏ i ∈ s, (t i).indicator (M := M₀) 1 (f i) := by
-  simp [Set.indicator, prod_boole]; congr
+  classical simp [Set.indicator, prod_boole]
 
 variable [Nontrivial M₀] [NoZeroDivisors M₀]
 


### PR DESCRIPTION
---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

When merging, all the commits will be squashed into a single commit
listing all co-authors.

Co-authors in the squash commit are gathered from two sources:

First, all authors of commits to this PR branch are included. Thus,
one way to add co-authors is to include at least one commit authored by
each co-author among the commits in the pull request. If necessary, you
may create empty commits to indicate co-authorship, using commands like so:

git commit --author="Author Name <author@email.com>" --allow-empty -m "add Author Name as coauthor"

Second, co-authors can also be listed in lines at the very bottom of
the commit message (that is, directly before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines
at the bottom of the commit message (before the `---`, and also before
any "Co-authored-by" lines) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
