### PR TITLE
[Merged by Bors] - feat(LinearAlgebra/AffineSpace/Simplex/Basic): vertices are not in the interior

### DIFF
--- a/Mathlib/LinearAlgebra/AffineSpace/Simplex/Basic.lean
+++ b/Mathlib/LinearAlgebra/AffineSpace/Simplex/Basic.lean
@@ -348,6 +348,27 @@ lemma interior_subset_closedInterior {n : ℕ} (s : Simplex k P n) :
     s.interior ⊆ s.closedInterior :=
   fun _ ⟨w, hw, hw01, hww⟩ ↦ ⟨w, hw, fun i ↦ ⟨(hw01 i).1.le, (hw01 i).2.le⟩, hww⟩
 
+lemma point_notMem_interior {n : ℕ} (s : Simplex k P n) (i : Fin (n + 1)) :
+    s.points i ∉ s.interior := by
+  rw [← Finset.univ.affineCombination_affineCombinationSingleWeights k s.points
+    (Finset.mem_univ i), affineCombination_mem_interior_iff
+      (sum_affineCombinationSingleWeights _ _ (Finset.mem_univ i)), not_forall]
+  exact ⟨i, by simp⟩
+
+lemma point_mem_closedInterior [ZeroLEOneClass k] {n : ℕ} (s : Simplex k P n) (i : Fin (n + 1)) :
+    s.points i ∈ s.closedInterior := by
+  rw [← Finset.univ.affineCombination_affineCombinationSingleWeights k s.points
+    (Finset.mem_univ i), affineCombination_mem_closedInterior_iff
+      (sum_affineCombinationSingleWeights _ _ (Finset.mem_univ i))]
+  intro j
+  by_cases hj : j = i <;> simp [hj]
+
+lemma interior_ssubset_closedInterior [ZeroLEOneClass k] {n : ℕ} (s : Simplex k P n) :
+    s.interior ⊂ s.closedInterior := by
+  rw [Set.ssubset_iff_exists]
+  exact ⟨s.interior_subset_closedInterior, s.points 0, s.point_mem_closedInterior 0,
+    s.point_notMem_interior 0⟩
+
 lemma closedInterior_subset_affineSpan {n : ℕ} {s : Simplex k P n} :
     s.closedInterior ⊆ affineSpan k (Set.range s.points) := by
   rintro p ⟨w, hw, hi, rfl⟩


### PR DESCRIPTION
Add a lemma that the vertices of a simplex do not lie in its interior. Also add (given `[ZeroLEOneClass k]`) that they do lie in its `closedInterior` and thus (previously suggested by @eric-wieser in review of #26823) that the interior is a strict subset of the `closedInterior`.


---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

When merging, all the commits will be squashed into a single commit
listing all co-authors.

Co-authors in the squash commit are gathered from two sources:

First, all authors of commits to this PR branch are included. Thus,
one way to add co-authors is to include at least one commit authored by
each co-author among the commits in the pull request. If necessary, you
may create empty commits to indicate co-authorship, using commands like so:

git commit --author="Author Name <author@email.com>" --allow-empty -m "add Author Name as coauthor"

Second, co-authors can also be listed in lines at the very bottom of
the commit message (that is, directly before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines
at the bottom of the commit message (before the `---`, and also before
any "Co-authored-by" lines) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
