### PR TITLE
feat(Combinatorics/SimpleGraph): add simp lemma `getVert_map` for Walk.map

### DIFF
--- a/Mathlib/Combinatorics/SimpleGraph/Walk.lean
+++ b/Mathlib/Combinatorics/SimpleGraph/Walk.lean
@@ -1259,6 +1259,11 @@ theorem map_injective_of_injective {f : G →g G'} (hinj : Function.Injective f)
       cases hinj h.1
       grind
 
+@[simp] lemma getVert_map (i : ℕ) : (p.map f).getVert i = f (p.getVert i) := by
+  revert u; induction i with
+  | zero => simp
+  | succ => intro _ p; cases p <;> simp [*]
+
 section mapLe
 
 variable {G G' : SimpleGraph V} (h : G ≤ G') {u v : V} (p : G.Walk u v)


### PR DESCRIPTION
feat(Combinatorics/SimpleGraph): add simp lemma `getVert_map` for Walk.map

simple fact but can only be proved by reverting the start point of the walk due to the inductive definition

---
- In concept similar to `List.getElem_map` and deserves a simp lemma (useful when pushing walks between Subgraphs)
- Successful under `lake build`

@[simp] lemma getVert_map (i : ℕ) : (p.map f).getVert i = f (p.getVert i) := by
  revert u; induction i with
  | zero => simp
  | succ => intro _ p; cases p <;> simp [*]