### PR TITLE
feat(Combinatorics/SimpleGraph): add lemma `getVert_map` for `Walk.map`

### DIFF
--- a/Mathlib/Combinatorics/SimpleGraph/Walk.lean
+++ b/Mathlib/Combinatorics/SimpleGraph/Walk.lean
@@ -1259,7 +1259,7 @@ theorem map_injective_of_injective {f : G →g G'} (hinj : Function.Injective f)
       cases hinj h.1
       grind
 
-@[simp] lemma getVert_map (i : ℕ) : (p.map f).getVert i = f (p.getVert i) := by
+lemma getVert_map (i : ℕ) : (p.map f).getVert i = f (p.getVert i) := by
 revert u; induction i with
 | zero => simp
 | succ => intro _ p; cases p <;> simp [*]

--- a/Mathlib/Combinatorics/SimpleGraph/Walk.lean
+++ b/Mathlib/Combinatorics/SimpleGraph/Walk.lean
@@ -34,6 +34,7 @@ walks
 -/
 
 -- TODO: split
+set_option linter.style.longFile 1700
 
 open Function
 
@@ -1260,9 +1261,13 @@ theorem map_injective_of_injective {f : G →g G'} (hinj : Function.Injective f)
       grind
 
 lemma getVert_map (i : ℕ) : (p.map f).getVert i = f (p.getVert i) := by
-revert u; induction i with
-| zero => simp
-| succ => intro _ p; cases p <;> simp [*]
+  revert u; induction i with
+  | zero => simp
+  | succ i' hi' =>
+    intro u w
+    induction w with
+    | nil => simp
+    | @cons u u' v h q h' => simp; exact @hi' u' q
 
 section mapLe
 

--- a/Mathlib/Combinatorics/SimpleGraph/Walk.lean
+++ b/Mathlib/Combinatorics/SimpleGraph/Walk.lean
@@ -1259,6 +1259,11 @@ theorem map_injective_of_injective {f : G →g G'} (hinj : Function.Injective f)
       cases hinj h.1
       grind
 
+@[simp] lemma getVert_map (i : ℕ) : (p.map f).getVert i = f (p.getVert i) := by
+revert u; induction i with
+| zero => simp
+| succ => intro _ p; cases p <;> simp [*]
+
 section mapLe
 
 variable {G G' : SimpleGraph V} (h : G ≤ G') {u v : V} (p : G.Walk u v)


### PR DESCRIPTION
feat(Combinatorics/SimpleGraph): add lemma `getVert_map` for `Walk.map`

simple fact but can only be proved by reverting the start point of the walk due to the inductive definition

---
- In concept similar to `List.getElem_map` and may deserve a simp lemma (useful when pushing walks between Subgraphs)
- Successful  locally under `lake build`
- It is my first pull request on github. I am not sure what to do exactly. I don't know why there are failed checks even if I add just one lemma. Is it that not adding `set_option linter.style.longFile 1700` prevents me from successful checks?

lemma getVert_map (i : ℕ) : (p.map f).getVert i = f (p.getVert i) := by
  revert u; induction i with
  | zero => simp
  | succ => intro _ p; cases p <;> simp [*]
  
 The above version works just fine locally. But I merge a longer version.