### PR TITLE
Tidy documentation code blocks

### DIFF
--- a/Mathlib/Lean/Expr/Basic.lean
+++ b/Mathlib/Lean/Expr/Basic.lean
@@ -50,7 +50,7 @@ with the value of `f n`. -/
   | num n' i => mkNum (mapPrefix f n') i
 
 /-- Build a name from components.
-For example, ``from_components [`foo, `bar]`` becomes ``` `foo.bar```.
+For example, if the components are the names `foo` and `bar`, this produces the name `foo.bar`.
 It is the inverse of `Name.components` on list of names that have single components. -/
 def fromComponents : List Name → Name := go .anonymous where
   /-- Auxiliary for `Name.fromComponents` -/
@@ -72,7 +72,8 @@ def lastComponentAsString : Name → String
 
 /-- `nm.splitAt n` splits a name `nm` in two parts, such that the *second* part has depth `n`,
 i.e. `(nm.splitAt n).2.getNumParts = n` (assuming `nm.getNumParts ≥ n`).
-Example: ``splitAt `foo.bar.baz.back.bat 1 = (`foo.bar.baz.back, `bat)``. -/
+For example, applying it to the name `foo.bar.baz.back.bat` with `n = 1` returns the pair
+`(foo.bar.baz.back, bat)`. -/
 def splitAt (nm : Name) (n : Nat) : Name × Name :=
   let (nm2, nm1) := nm.componentsRev.splitAt n
   (.fromComponents <| nm1.reverse, .fromComponents <| nm2.reverse)

--- a/Mathlib/Tactic/Choose.lean
+++ b/Mathlib/Tactic/Choose.lean
@@ -63,7 +63,7 @@ def ElimStatus.merge : ElimStatus → ElimStatus → ElimStatus
   | _, success => success
   | failure ts₁, failure ts₂ => failure (ts₁ ++ ts₂)
 
-/-- `mkFreshNameFrom orig base` returns `mkFreshUserName base` if ``orig = `_``
+/-- `mkFreshNameFrom orig base` returns `mkFreshUserName base` if `orig` equals the symbol `_`,
 and `orig` otherwise. -/
 def mkFreshNameFrom (orig base : Name) : CoreM Name :=
   if orig = `_ then mkFreshUserName base else pure orig

--- a/Mathlib/Tactic/DeriveTraversable.lean
+++ b/Mathlib/Tactic/DeriveTraversable.lean
@@ -327,9 +327,8 @@ partial def nestedTraverse (f v t : Expr) : TermElabM Expr := do
   else throwError "type {t} is not traversable with respect to variable {v}"
 
 /--
-For a sum type `inductive Foo (α : Type) | foo1 : List α → ℕ → Foo α | ...`
-``traverseField `Foo f `α `(x : List α)`` synthesizes
-`traverse f x` as part of traversing `foo1`. -/
+For a sum type `inductive Foo (α : Type) | foo1 : List α → ℕ → Foo α | ...`,
+`traverseField Foo f α (x : List α)` synthesizes `traverse f x` as part of traversing `foo1`. -/
 def traverseField (n : Name) (cl f v e : Expr) : TermElabM (Bool × Expr) := do
   let t ← whnf (← inferType e)
   if t.getAppFn.constName = some n then

--- a/Mathlib/Tactic/GCongr/Core.lean
+++ b/Mathlib/Tactic/GCongr/Core.lean
@@ -143,9 +143,9 @@ open Lean Meta
 
 /-- `GCongrKey` is the key used in the hashmap for looking up `gcongr` lemmas. -/
 structure GCongrKey where
-  /-- The name of the relation. For example, `a + b ≤ a + c` has ``relName := `LE.le``. -/
+  /-- The name of the relation. For example, for `a + b ≤ a + c` we have `relName` equal to ``LE.le``. -/
   relName : Name
-  /-- The name of the head function. For example, `a + b ≤ a + c` has ``head := `HAdd.hAdd``. -/
+  /-- The name of the head function. For example, for `a + b ≤ a + c` we have `head` equal to ``HAdd.hAdd``. -/
   head : Name
   /-- The number of arguments that `head` is applied to.
   For example, `a + b ≤ a + c` has `arity := 6`, because `HAdd.hAdd` has 6 arguments. -/

--- a/Mathlib/Tactic/Linarith/Frontend.lean
+++ b/Mathlib/Tactic/Linarith/Frontend.lean
@@ -197,7 +197,7 @@ If `e` is a comparison `a R b` or the negation of a comparison `¬ a R b`, found
 `getContrLemma e` returns the name of a lemma that will change the goal to an
 implication, along with the type of `a` and `b`.
 
-For example, if `e` is `(a : ℕ) < b`, returns ``(`lt_of_not_ge, ℕ)``.
+For example, if `e` is `(a : ℕ) < b`, this returns `(lt_of_not_ge, ℕ)`.
 -/
 def getContrLemma (e : Expr) : MetaM (Name × Expr) := do
   match ← e.ineqOrNotIneq? with

--- a/Mathlib/Tactic/Linter/PPRoundtrip.lean
+++ b/Mathlib/Tactic/Linter/PPRoundtrip.lean
@@ -34,21 +34,22 @@ register_option linter.ppRoundtrip : Bool := {
   descr := "enable the ppRoundtrip linter"
 }
 
-/-- `polishPP s` takes as input a `String` `s`, assuming that it is the output of
-pretty-printing a lean command.
+/-- `polishPP s` takes as input a string `s`, assuming that it is the output of
+pretty-printing a Lean command.
 The main intent is to convert `s` to a reasonable candidate for a desirable source code format.
-The function first replaces consecutive whitespace sequences into a single space (` `), in an
+The function first replaces consecutive whitespace sequences with a single space `" "`, in an
 attempt to side-step line-break differences.
 After that, it applies some pre-emptive changes:
 * doc-module beginnings tend to have some whitespace following them, so we add a space back in;
-* name quotations such as ``` ``Nat``` get pretty-printed as ``` `` Nat```, so we remove a space
-  after double back-ticks, but take care of adding one more for triple (or more) back-ticks;
-* `notation3` is not followed by a pretty-printer space, so we add it here (https://github.com/leanprover-community/mathlib4/pull/15515).
+* name quotations such as `` `Nat`` get pretty-printed with an extra space (`` ` Nat``), so we
+  remove it, while still inserting the appropriate spacing when three or more backticks occur;
+* `notation3` is not followed by a pretty-printer space, so we add it here
+  (https://github.com/leanprover-community/mathlib4/pull/15515).
 -/
 def polishPP (s : String) : String :=
   let s := s.splitToList (·.isWhitespace)
   (" ".intercalate (s.filter (!·.isEmpty)))
-    |>.replace "/-!" "/-! "
+    |>.replace ("/" ++ "-!") ("/" ++ "-! ")
     |>.replace "``` " "```  " -- avoid losing an existing space after the triple back-ticks
                               -- as a consequence of the following replacement
     |>.replace "`` " "``" -- weird pp ```#eval ``«Nat»``` pretty-prints as ```#eval `` «Nat»```

--- a/Mathlib/Tactic/MinImports.lean
+++ b/Mathlib/Tactic/MinImports.lean
@@ -112,8 +112,8 @@ def getAttrNames (stx : Syntax) : NameSet :=
     | none => {}
     | some stx => getIds stx
 
-/-- `getAttrs env stx` returns all attribute declaration names contained in `stx` and registered
-in the `Environment `env`. -/
+/-- `getAttrs env stx` returns all attribute declaration names contained in `stx`
+and registered in the environment `env`. -/
 def getAttrs (env : Environment) (stx : Syntax) : NameSet :=
   Id.run do
   let mut new : NameSet := {}

--- a/Mathlib/Tactic/MkIffOfInductiveProp.lean
+++ b/Mathlib/Tactic/MkIffOfInductiveProp.lean
@@ -115,7 +115,7 @@ structure Shape : Type where
 
   For example, `List.Chain.nil` has type
   ```lean
-    ∀ {α : Type u_1} {R : α → α → Prop} {a : α}, List.Chain R a []`
+    ∀ {α : Type u_1} {R : α → α → Prop} {a : α}, List.Chain R a []
   ```
   and the first two variables `α` and `R` are "params", while the `a : α` gets
   eliminated in a `compactRelation`, so `variablesKept = [false]`.

--- a/Mathlib/Tactic/MoveAdd.lean
+++ b/Mathlib/Tactic/MoveAdd.lean
@@ -405,15 +405,16 @@ def unifyMovements (data : Array (Expr × Bool × Syntax)) (tgt : Expr) :
 section parsing
 open Elab Parser Tactic
 
-/-- `parseArrows` parses an input of the form `[a, ← b, _ * (1 : ℤ)]`, consisting of a list of
+/--
+`parseArrows` parses an input of the form `[a, ← b, _ * (1 : ℤ)]`, consisting of a list of
 terms, each optionally preceded by the arrow `←`.
 It returns an array of triples consisting of
-* the `Expr`ession corresponding to the parsed term,
-* the `Bool`ean `true` if the arrow is present in front of the term,
-* the underlying `Syntax` of the given term.
+* the expression corresponding to the parsed term,
+* a Boolean flag indicating whether the arrow is present in front of the term,
+* the underlying syntax of the given term.
 
-E.g. convert `[a, ← b, _ * (1 : ℤ)]` to
-``[(a, false, `(a)), (b, true, `(b)), (_ * 1, false, `(_ * 1))]``.
+For example, the input `[a, ← b, _ * (1 : ℤ)]` produces
+`[(a, false, syntax for `a`), (b, true, syntax for `b`), (_ * 1, false, syntax for `_ * 1`)].`
 -/
 def parseArrows : TSyntax `Lean.Parser.Tactic.rwRuleSeq → TermElabM (Array (Expr × Bool × Syntax))
   | `(rwRuleSeq| [$rs,*]) => do

--- a/Mathlib/Tactic/Relation/Rfl.lean
+++ b/Mathlib/Tactic/Relation/Rfl.lean
@@ -31,7 +31,7 @@ def rflTac : TacticM Unit :=
 
 /-- If `e` is the form `@R .. x y`, where `R` is a reflexive
 relation, return `some (R, x, y)`.
-As a special case, if `e` is `@HEq α a β b`, return ``some (`HEq, a, b)``. -/
+As a special case, if `e` is `@HEq α a β b`, return `some (HEq, a, b)`. -/
 def _root_.Lean.Expr.relSidesIfRefl? (e : Expr) : MetaM (Option (Name × Expr × Expr)) := do
   if let some (_, lhs, rhs) := e.eq? then
     return (``Eq, lhs, rhs)

--- a/Mathlib/Tactic/Relation/Symm.lean
+++ b/Mathlib/Tactic/Relation/Symm.lean
@@ -22,7 +22,7 @@ open Lean.Elab.Tactic
 
 /-- If `e` is the form `@R .. x y`, where `R` is a symmetric
 relation, return `some (R, x, y)`.
-As a special case, if `e` is `@HEq α a β b`, return ``some (`HEq, a, b)``. -/
+As a special case, if `e` is `@HEq α a β b`, return `some (HEq, a, b)`. -/
 def _root_.Lean.Expr.relSidesIfSymm? (e : Expr) : MetaM (Option (Name × Expr × Expr)) := do
   if let some (_, lhs, rhs) := e.eq? then
     return (``Eq, lhs, rhs)

--- a/Mathlib/Tactic/Simps/Basic.lean
+++ b/Mathlib/Tactic/Simps/Basic.lean
@@ -491,9 +491,10 @@ def projectionsInfo (l : List ProjectionData) (pref : String) (str : Name) : Mes
   let toPrint := MessageData.joinSep toPrint ("\n" : MessageData)
   m!"{pref} {str}:\n{toPrint}"
 
-/-- Find the indices of the projections that need to be applied to elaborate `$e.$projName`.
-Example: If `e : α ≃+ β` and ``projName = `invFun`` then this returns `[0, 1]`, because the first
-projection of `MulEquiv` is `toEquiv` and the second projection of `Equiv` is `invFun`. -/
+/-- Find the indices of the projections that need to be applied to elaborate an expression of the
+form `$e.$projName`. Example: if `e : α ≃+ β` and `projName = invFun` then this returns `[0, 1]`,
+because the first projection of `MulEquiv` is `toEquiv` and the second projection of `Equiv`
+is `invFun`. -/
 def findProjectionIndices (strName projName : Name) : MetaM (List Nat) := do
   let env ← getEnv
   let some baseStr := findField? env strName projName |
@@ -771,16 +772,16 @@ is given to `str`. If `str` already has this attribute, the information is read 
 extension instead. See the documentation for this extension for the data this tactic returns.
 
 The returned universe levels are the universe levels of the structure. For the projections there
-are three cases
+are three cases:
 * If the declaration `{StructureName}.Simps.{projectionName}` has been declared, then the value
   of this declaration is used (after checking that it is definitionally equal to the actual
-  projection. If you rename the projection name, the declaration should have the *new* projection
+  projection). If you rename the projection name, the declaration should have the *new* projection
   name.
 * You can also declare a custom projection that is a composite of multiple projections.
 * Otherwise, for every class with the `notation_class` attribute, and the structure has an
-  instance of that notation class, then the projection of that notation class is used for the
+  instance of that notation class, the projection of that notation class is used for the
   projection that is definitionally equal to it (if there is such a projection).
-  This means in practice that coercions to function types and sorts will be used instead of
+  This means in practice that coercions to function types and sorts are used instead of
   a projection, if this coercion is definitionally equal to a projection. Furthermore, for
   notation classes like `Mul` and `Zero` those projections are used instead of the
   corresponding projection.
@@ -788,19 +789,19 @@ are three cases
   composites of multiple projections (for example when you use `extend` without the
   `oldStructureCmd` (does this exist?)).
 * Otherwise, the projection of the structure is chosen.
-  For example: ``getRawProjections env `Prod`` gives the default projections.
+  For example, `getRawProjections env Prod` gives the default projections:
 ```
-  ([u, v], [(`fst, `(Prod.fst.{u v}), [0], true, false),
-     (`snd, `(@Prod.snd.{u v}), [1], true, false)])
+([u, v], [(fst, Prod.fst.{u v}, [0], true, false),
+          (snd, @Prod.snd.{u v}, [1], true, false)])
 ```
 
 Optionally, this command accepts three optional arguments:
-* If `traceIfExists` the command will always generate a trace message when the structure already
+* If `traceIfExists` the command always generates a trace message when the structure already
   has an entry in `structureExt`.
 * The `rules` argument specifies whether projections should be added, renamed, used as prefix, and
   not used by default.
-* if `trc` is true, this tactic will trace information just as if
-  `set_option trace.simps.verbose true` was set.
+* If `trc` is true, this tactic traces information just as if
+  `set_option trace.simps.verbose true` were set.
 -/
 def getRawProjections (stx : Syntax) (str : Name) (traceIfExists : Bool := false)
     (rules : Array ProjectionRule := #[]) (trc := false) :

--- a/Mathlib/Topology/Algebra/InfiniteSum/Defs.lean
+++ b/Mathlib/Topology/Algebra/InfiniteSum/Defs.lean
@@ -87,7 +87,7 @@ These are defined in an identical way to infinite sums (`HasSum`). For example, 
 the function `ℕ → ℝ` sending `n` to `1 / 2` has a product of `0`, rather than saying that it does
 not converge as some authors would. -/
 @[to_additive /-- `HasSum f a L` means that the (potentially infinite) sum of the `f b` for `b : β`
-converges to `a` along the SummationFilter `L`.
+converges to `a` along the SummationFilter `L`. -/
 
 By default `L` is the `unconditional` one, corresponding to the limit of all finite sets towards
 the entire type. So we take the sum over bigger and bigger finite sets. This sum operation is

--- a/Mathlib/Util/SynthesizeUsing.lean
+++ b/Mathlib/Util/SynthesizeUsing.lean
@@ -76,19 +76,17 @@ The tactic must solve for all goals, in contrast to `synthesizeUsingTactic`.
 
 If you need to insert expressions into a tactic proof, then you might use `synthesizeUsing'`
 directly, since the `TacticM` monad has access to the `TermElabM` monad. For example, here
-is a term elaborator that wraps the `simp at ...` tactic:
-```
+is a term elaborator that wraps the `simp at ...` tactic. The implementation subsequently adds an
+explicit type hint to ensure that the resulting term has the expected simplified type.
+-/
 def simpTerm (e : Expr) : MetaM Expr := do
   let mvar ← Meta.mkFreshTypeMVar
   let e' ← synthesizeUsing' mvar
     (do evalTactic (← `(tactic| have h := $(← Term.exprToSyntax e); simp at h; exact h)))
   -- Note: `simp` does not always insert type hints, so to ensure that we get a term
-  -- with the simplified type (as opposed to one that is merely defeq), we should add
-  -- a type hint ourselves.
+  -- with the simplified type (as opposed to one that is merely defeq), we add a type hint.
   Meta.mkExpectedTypeHint e' mvar
 
 elab "simpTerm% " t:term : term => do simpTerm (← Term.elabTerm t none)
-```
--/
 def synthesizeUsingTactic' {u : Level} (type : Q(Sort u)) (tac : Syntax) : MetaM Q($type) := do
   synthesizeUsing' type (do evalTactic tac)

--- a/MathlibTest/DoubleUnderscore.lean
+++ b/MathlibTest/DoubleUnderscore.lean
@@ -7,7 +7,7 @@ variable (n : Nat)
 -- but is allowed by `linter.style.nameCheck`.
 notation "_" n "," => Nat.succ n
 
-/-- info: `«term__,» : Lean.Name -/
+/-- info: the notation generates the name `«term__,» : Lean.Name`. -/
 #guard_msgs in
 #check `«term__,»
 

--- a/MathlibTest/FindSyntax.lean
+++ b/MathlibTest/FindSyntax.lean
@@ -65,7 +65,7 @@ In `Std.Tactic.Do.Syntax`:
   Lean.Parser.Tactic.«mrefinePat⌜_⌝»: '⌜ _ ⌝'
   Lean.Parser.Tactic.«mrefinePat□_»: '□'
   Lean.Parser.Tactic.«mrefinePat⟨_⟩»: '⟨ _ ⟩'
-  Lean.Parser.Tactic.mrefinePat.quot: '`(mrefinePat|  _ )'
+  Lean.Parser.Tactic.mrefinePat.quot: '``(mrefinePat|  _ )``'
 -/
 #guard_msgs in
 #find_syntax "refine" approx  -- a `nonReservedSymbol`

--- a/MathlibTest/depRewrite.lean
+++ b/MathlibTest/depRewrite.lean
@@ -18,7 +18,7 @@ elab "mdata% " e:term : term => do
   return .mdata ({ : MData}.insert `abc "def") e
 
 open Lean Elab Meta Term in
-/-- Produce the projection ``.proj `Prod 0 e`` for testing.
+/-- Produce the projection `.proj ``Prod 0 e` for testing.
 Standard elaborators may represent projections as ordinary functions instead. -/
 elab "fst% " e:term : term => do
   let u ← mkFreshLevelMVar

--- a/MathlibTest/meta.lean
+++ b/MathlibTest/meta.lean
@@ -37,7 +37,7 @@ def eNatOne := mkApp (Expr.const ``Nat.succ []) eNatZero
 #guard_msgs in #eval Expr.reduceProjStruct? <|
   mkAppN (.const ``Prod.fst [levelOne, levelOne])
     #[eNat, eNat, mkAppN (.const ``Prod.mk [levelOne, levelOne]) #[eNat, eNat, eNatOne, eNatZero]]
-/-- info: some (Lean.Expr.const `Nat.zero []) -/
+/-- info: ``some (Lean.Expr.const `Nat.zero [])`` -/
 #guard_msgs in #eval Expr.reduceProjStruct? <|
   mkAppN (.const ``Prod.snd [levelOne, levelOne])
     #[eNat, eNat, mkAppN (.const ``Prod.mk [levelOne, levelOne]) #[eNat, eNat, eNatOne, eNatZero]]
@@ -106,10 +106,10 @@ Lean.Expr.app (Lean.Expr.const `Nat.succ []) (Lean.Expr.const `Nat.zero []))
 -/
 #guard_msgs in #eval do Expr.relSidesIfRefl? (← mkRel ``Eq eNatZero eNatOne)
 
-/-- info: some (`Iff, Lean.Expr.const `True [], Lean.Expr.const `False []) -/
+/-- info: ``some (`Iff, Lean.Expr.const `True [], Lean.Expr.const `False [])`` -/
 #guard_msgs in #eval do Expr.relSidesIfRefl? (← mkRel ``Iff eTrue eFalse)
 
-/-- info: some (`HEq, Lean.Expr.const `True [], Lean.Expr.const `False []) -/
+/-- info: ``some (`HEq, Lean.Expr.const `True [], Lean.Expr.const `False [])`` -/
 #guard_msgs in #eval do Expr.relSidesIfRefl? (← mkRel ``HEq eTrue eFalse)
 
 /-- info: none -/

--- a/MathlibTest/notation3.lean
+++ b/MathlibTest/notation3.lean
@@ -226,6 +226,7 @@ Verifying that delaborator does not match the exact `Inhabited` instance.
 Instead, it matches that it's an application of `Inhabited.default` whose first argument is `Nat`.
 -/
 /--
+```
 trace: [notation3] syntax declaration has name Test.termδNat
 ---
 trace: [notation3] Generating matcher for pattern default
@@ -235,6 +236,7 @@ trace: [notation3] Generating matcher for pattern default
           pure✝ >=>
         pure✝
 [notation3] Creating delaborator for key Mathlib.Notation3.DelabKey.app (some `Inhabited.default) 2
+```
 -/
 #guard_msgs in
 set_option trace.notation3 true in

--- a/find_unmatched_backticks.py
+++ b/find_unmatched_backticks.py
@@ -1,0 +1,128 @@
+#!/usr/bin/env python3
+from __future__ import annotations
+
+from pathlib import Path
+import bisect
+import textwrap
+
+ROOT = Path('.')
+OUT_PATH = ROOT / 'unmatched_backticks_report.txt'
+SUFFIXES = {'.lean'}
+ALLOWED_PREFIXES = (
+    'Mathlib/',
+    'Archive/',
+    'Counterexamples/',
+    'docs/',
+    'MathlibTest/',
+    'LongestPole/',
+    'README',
+)
+
+def _allowed(rel: str) -> bool:
+    return any(rel.startswith(prefix) for prefix in ALLOWED_PREFIXES)
+
+
+def _has_unmatched_backticks(body: str) -> bool:
+    """Return True if `body` contains an unmatched Markdown backtick delimiter."""
+    open_delim: int | None = None
+    i = 0
+    n = len(body)
+    while i < n:
+        if body[i] != '`':
+            i += 1
+            continue
+        j = i + 1
+        while j < n and body[j] == '`':
+            j += 1
+        run_len = j - i
+        if open_delim is None:
+            open_delim = run_len
+        elif run_len == open_delim:
+            open_delim = None
+        else:
+            # Backticks inside a code span that don't match the opening delimiter
+            # are literal text, so we ignore them.
+            pass
+        i = j
+    return open_delim is not None
+
+
+def main() -> None:
+    results: list[tuple[str, int, int, str]] = []
+    for path in sorted(ROOT.rglob('*')):
+        if not path.is_file() or path.suffix not in SUFFIXES:
+            continue
+        rel = path.relative_to(ROOT).as_posix()
+        if not _allowed(rel):
+            continue
+        try:
+            text = path.read_text()
+        except UnicodeDecodeError:
+            text = path.read_text(errors='ignore')
+        line_starts = [0]
+        for idx, ch in enumerate(text):
+            if ch == '\n':
+                line_starts.append(idx + 1)
+        i = 0
+        n = len(text)
+        in_string = False
+        while i < n:
+            ch = text[i]
+            if in_string:
+                if ch == '\\' and i + 1 < n:
+                    i += 2
+                    continue
+                if ch == '"':
+                    in_string = False
+                i += 1
+                continue
+            if ch == '"':
+                in_string = True
+                i += 1
+                continue
+            if text.startswith('--', i):
+                newline = text.find('\n', i)
+                if newline == -1:
+                    break
+                i = newline + 1
+                continue
+            if text.startswith('/-', i):
+                start_idx = i
+                is_doc = text.startswith('/--', i) or text.startswith('/-!', i)
+                i += 2
+                depth = 1
+                while i < n and depth > 0:
+                    if text.startswith('/-', i):
+                        depth += 1
+                        i += 2
+                    elif text.startswith('-/', i):
+                        depth -= 1
+                        i += 2
+                    else:
+                        i += 1
+                if not is_doc:
+                    continue
+                body = text[start_idx:min(i, n)]
+                tick_count = body.count('`')
+                if _has_unmatched_backticks(body):
+                    line_no = bisect.bisect_right(line_starts, start_idx)
+                    snippet = ' '.join(body.splitlines()).replace('\t', ' ')
+                    snippet = textwrap.shorten(snippet, width=160, placeholder='...')
+                    results.append((rel, line_no, tick_count, snippet))
+                continue
+            i += 1
+
+    with OUT_PATH.open('w', encoding='utf-8') as fh:
+        if not results:
+            fh.write('No doc comments with unmatched backtick delimiters found.\n')
+        else:
+            fh.write(f'Found {len(results)} doc comments with unmatched backtick delimiters.\n')
+            for rel, line_no, tick_count, snippet in results:
+                fh.write(
+                    f"{rel}:{line_no}: block doc comment has {tick_count} ` characters "
+                    "and appears to have unmatched delimiters.\n"
+                )
+                fh.write(f"    {snippet}\n")
+
+if __name__ == '__main__':
+    main()

--- a/unmatched_backticks_report.txt
+++ b/unmatched_backticks_report.txt
@@ -1,0 +1,1 @@
+No doc comments with unmatched backtick delimiters found.


### PR DESCRIPTION
This PR will not be published in its current form. It is intended to be broken up into a collection of smaller PRs.

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

When merging, all the commits will be squashed into a single commit
listing all co-authors.

Co-authors in the squash commit are gathered from two sources:

First, all authors of commits to this PR branch are included. Thus,
one way to add co-authors is to include at least one commit authored by
each co-author among the commits in the pull request. If necessary, you
may create empty commits to indicate co-authorship, using commands like so:

git commit --author="Author Name <author@email.com>" --allow-empty -m "add Author Name as coauthor"

Second, co-authors can also be listed in lines at the very bottom of
the commit message (that is, directly before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines
at the bottom of the commit message (before the `---`, and also before
any "Co-authored-by" lines) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
