### PR TITLE
[Merged by Bors] - fix: panic in tactic analysis framework

### DIFF
--- a/Mathlib/Lean/ContextInfo.lean
+++ b/Mathlib/Lean/ContextInfo.lean
@@ -78,21 +78,15 @@ def runTactic (ctx : ContextInfo) (i : TacticInfo) (goal : MVarId) (x : MVarId �
     let goal ← Meta.mkFreshExprSyntheticOpaqueMVar type
     x goal.mvarId!
 
-/-- Run tactic code, given by a piece of syntax, in the context of an infotree node. -/
-def runTacticCode (ctx : ContextInfo) (i : TacticInfo) (goal : MVarId) (code : Syntax) :
-    CommandElabM (List MVarId) := do
-  let termCtx ← liftTermElabM read
-  let termState ← liftTermElabM get
-  ctx.runTactic i goal fun goal =>
-    Lean.Elab.runTactic' (ctx := termCtx) (s := termState) goal code
-
-/-- Run tactic code, given by a piece of syntax, in the context of an infotree node. -/
-def runTacticCodeWithTypes (ctx : ContextInfo) (i : TacticInfo) (goal : MVarId) (code : Syntax) :
-    CommandElabM (List (MVarId × Expr)) := do
+/-- Run tactic code, given by a piece of syntax, in the context of an infotree node.
+The optional `MetaM` argument `m` performs postprocessing on the goals produced. -/
+def runTacticCode (ctx : ContextInfo) (i : TacticInfo) (goal : MVarId) (code : Syntax)
+    (m : Σ α : Type, MVarId → MetaM α := ⟨MVarId, pure⟩) :
+    CommandElabM (List m.1) := do
   let termCtx ← liftTermElabM read
   let termState ← liftTermElabM get
   ctx.runTactic i goal fun goal => do
-    let goals ← Lean.Elab.runTactic' (ctx := termCtx) (s := termState) goal code
-    goals.mapM fun g ↦ do pure (g, ← g.getType')
+    let newGoals ← Lean.Elab.runTactic' (ctx := termCtx) (s := termState) goal code
+    newGoals.mapM m.2
 
 end Lean.Elab.ContextInfo

--- a/Mathlib/Lean/ContextInfo.lean
+++ b/Mathlib/Lean/ContextInfo.lean
@@ -86,4 +86,13 @@ def runTacticCode (ctx : ContextInfo) (i : TacticInfo) (goal : MVarId) (code : S
   ctx.runTactic i goal fun goal =>
     Lean.Elab.runTactic' (ctx := termCtx) (s := termState) goal code
 
+/-- Run tactic code, given by a piece of syntax, in the context of an infotree node. -/
+def runTacticCodeWithTypes (ctx : ContextInfo) (i : TacticInfo) (goal : MVarId) (code : Syntax) :
+    CommandElabM (List (MVarId × Expr)) := do
+  let termCtx ← liftTermElabM read
+  let termState ← liftTermElabM get
+  ctx.runTactic i goal fun goal => do
+    let goals ← Lean.Elab.runTactic' (ctx := termCtx) (s := termState) goal code
+    goals.mapM fun g ↦ do pure (g, ← g.getType')
+
 end Lean.Elab.ContextInfo

--- a/Mathlib/Tactic/TacticAnalysis.lean
+++ b/Mathlib/Tactic/TacticAnalysis.lean
@@ -354,3 +354,8 @@ def Config.ofComplex (config : ComplexConfig) : Config where
 end ComplexConfig
 
 end Mathlib.TacticAnalysis
+
+/-- A dummy option for testing the tactic analysis framework -/
+register_option linter.tacticAnalysis.dummy : Bool := {
+  defValue := false
+}

--- a/Mathlib/Tactic/TacticAnalysis/Declarations.lean
+++ b/Mathlib/Tactic/TacticAnalysis/Declarations.lean
@@ -51,11 +51,11 @@ def terminalReplacement (oldTacticName newTacticName : String) (oldTacticKind : 
   test ctxI i stx goal := do
     let tac ← newTactic ctxI i stx
     try
-      let goalsWithTypes ← ctxI.runTacticCodeWithTypes i goal tac
-      match goalsWithTypes with
+      let goalTypes ← ctxI.runTacticCode i goal tac ⟨Expr, MVarId.getType'⟩
+      match goalTypes with
       | [] => return .success tac
       | _ => do
-        let goalsMessages := goalsWithTypes.map fun (_, e) => m!"⊢ {MessageData.ofExpr e}\n"
+        let goalsMessages := goalTypes.map fun e => m!"⊢ {MessageData.ofExpr e}\n"
         return .remainingGoals tac goalsMessages
     catch _e =>
       let name ← mkAuxDeclName `extracted

--- a/Mathlib/Tactic/TacticAnalysis/Declarations.lean
+++ b/Mathlib/Tactic/TacticAnalysis/Declarations.lean
@@ -51,13 +51,11 @@ def terminalReplacement (oldTacticName newTacticName : String) (oldTacticKind : 
   test ctxI i stx goal := do
     let tac ← newTactic ctxI i stx
     try
-      let goals ← ctxI.runTacticCode i goal tac
-      match goals with
+      let goalsWithTypes ← ctxI.runTacticCodeWithTypes i goal tac
+      match goalsWithTypes with
       | [] => return .success tac
       | _ => do
-        let goalsMessages ← goals.mapM fun g => do
-          let e ← ctxI.runTactic i g <| fun g => do instantiateMVars (← g.getType)
-          pure m!"⊢ {MessageData.ofExpr e}\n"
+        let goalsMessages := goalsWithTypes.map fun (_, e) => m!"⊢ {MessageData.ofExpr e}\n"
         return .remainingGoals tac goalsMessages
     catch _e =>
       let name ← mkAuxDeclName `extracted

--- a/MathlibTest/TacticAnalysis.lean
+++ b/MathlibTest/TacticAnalysis.lean
@@ -15,6 +15,26 @@ example : 1 + 1 = 2 := by
 
 end omega
 
+@[tacticAnalysis linter.tacticAnalysis.dummy]
+def foo : Mathlib.TacticAnalysis.Config :=
+  Mathlib.TacticAnalysis.terminalReplacement "simp" "simp only" ``Lean.Parser.Tactic.simp
+    (fun _ _ _ => `(tactic| simp only))
+    (reportSuccess := true) (reportFailure := true)
+
+/--
+warning: `simp only` left unsolved goals where `simp` succeeded.
+Original tactic:
+  simp
+Replacement tactic:
+  simp only
+Unsolved goals:
+  [⊢ (List.map (fun x => x + 1) [1, 2, 3]).sum = 9 ]
+-/
+#guard_msgs in
+set_option linter.tacticAnalysis.dummy true in
+example : List.sum ([1,2,3].map fun x ↦ x + 1) = 9 := by
+  simp
+
 end terminalReplacement
 
 section rwMerge


### PR DESCRIPTION
The test added in this PR causes a panic on current mathlib, the panic being this one:
https://github.com/leanprover-community/mathlib4/blob/32fb6832e1009174e2787a2cbbc7669399175c61/Mathlib/Lean/ContextInfo.lean#L72 

This PR fixes the panic. The issue is in the tactic analysis framework's `terminalReplacement` linter builder. The idea with `terminalReplacement` is to try all `old_tactic` occurrences to see if swapping in `new_tactic` finishes at that point. If `new_tactic` works but doesn't finish it is supposed to print the new goal(s) produced by `new_tactic`; this is the case that was causing the panic.

The issue was that the `MetaM` call(s) to infer the type(s) of the new goal(s) were being routed through the `Lean.Elab.ContextInfo.runTactic` function, which panics if (as will typically be the case) one of these goals represents nontrivial progress from the previous goal state.  I have fixed this by storing the types of the new goals at the time they are generated, so we don't need `Lean.Elab.ContextInfo.runTactic` to cook up a new `MetaM` instance. 


---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

When merging, all the commits will be squashed into a single commit
listing all co-authors.

Co-authors in the squash commit are gathered from two sources:

First, all authors of commits to this PR branch are included. Thus,
one way to add co-authors is to include at least one commit authored by
each co-author among the commits in the pull request. If necessary, you
may create empty commits to indicate co-authorship, using commands like so:

git commit --author="Author Name <author@email.com>" --allow-empty -m "add Author Name as coauthor"

Second, co-authors can also be listed in lines at the very bottom of
the commit message (that is, directly before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines
at the bottom of the commit message (before the `---`, and also before
any "Co-authored-by" lines) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
