### PR TITLE
[Merged by Bors] - chore: `field_simp` style

### DIFF
--- a/Mathlib/Analysis/Calculus/Deriv/Inv.lean
+++ b/Mathlib/Analysis/Calculus/Deriv/Inv.lean
@@ -98,7 +98,7 @@ variable {c : 𝕜 → 𝕜} {c' : 𝕜}
 theorem HasDerivWithinAt.fun_inv (hc : HasDerivWithinAt c c' s x) (hx : c x ≠ 0) :
     HasDerivWithinAt (fun y => (c y)⁻¹) (-c' / c x ^ 2) s x := by
   convert (hasDerivAt_inv hx).comp_hasDerivWithinAt x hc using 1
-  field
+  ring
 
 theorem HasDerivWithinAt.inv (hc : HasDerivWithinAt c c' s x) (hx : c x ≠ 0) :
     HasDerivWithinAt (c⁻¹) (-c' / c x ^ 2) s x :=

--- a/Mathlib/Analysis/Calculus/FDeriv/Measurable.lean
+++ b/Mathlib/Analysis/Calculus/FDeriv/Measurable.lean
@@ -329,7 +329,7 @@ theorem D_subset_differentiable_set {K : Set (E →L[𝕜] F)} (hK : IsComplete 
       calc
         ‖f (x + y) - f x - L e (n e) m y‖ ≤ (1 / 2) ^ e * (1 / 2) ^ m := by
           simpa only [add_sub_cancel_left] using J1
-        _ = 4 * (1 / 2) ^ e * (1 / 2) ^ (m + 2) := by field
+        _ = 4 * (1 / 2) ^ e * (1 / 2) ^ (m + 2) := by ring
         _ ≤ 4 * (1 / 2) ^ e * ‖y‖ := by gcongr
     -- use the previous estimates to see that `f (x + y) - f x - f' y` is small.
     calc
@@ -604,7 +604,7 @@ theorem D_subset_differentiable_set {K : Set F} (hK : IsComplete K) :
     calc
       ‖L0 e - L0 e'‖ ≤ 12 * (1 / 2) ^ e := M _ _ _ _ _ _ le_rfl le_rfl le_rfl le_rfl he'
       _ < 12 * (ε / 12) := mul_lt_mul' le_rfl he (le_of_lt P) (by norm_num)
-      _ = ε := by field  -- As it is Cauchy, the sequence `L0` converges, to a limit `f'` in `K`.
+      _ = ε := by ring  -- As it is Cauchy, the sequence `L0` converges, to a limit `f'` in `K`.
   obtain ⟨f', f'K, hf'⟩ : ∃ f' ∈ K, Tendsto L0 atTop (𝓝 f') :=
     cauchySeq_tendsto_of_isComplete hK (fun e => (hn e (n e) (n e) le_rfl le_rfl).1) this
   have Lf' : ∀ e p, n e ≤ p → ‖L e (n e) p - f'‖ ≤ 12 * (1 / 2) ^ e := by
@@ -653,7 +653,7 @@ theorem D_subset_differentiable_set {K : Set F} (hK : IsComplete K) :
             positivity
           · simp only [pow_add, tsub_le_iff_left] at h'k
             simpa only [hy.1, mem_Icc, true_and, one_div, pow_one] using h'k
-        _ = 4 * (1 / 2) ^ e * (1 / 2) ^ (m + 2) := by field
+        _ = 4 * (1 / 2) ^ e * (1 / 2) ^ (m + 2) := by ring
         _ ≤ 4 * (1 / 2) ^ e * (y - x) := by gcongr
         _ = 4 * (1 / 2) ^ e * ‖y - x‖ := by rw [Real.norm_of_nonneg yzero.le]
     calc

--- a/Mathlib/Analysis/Normed/Algebra/Exponential.lean
+++ b/Mathlib/Analysis/Normed/Algebra/Exponential.lean
@@ -280,7 +280,6 @@ theorem exp_add_of_commute_of_mem_ball [CharZero 𝕂] {x y : 𝔸} (hxy : Commu
   refine tsum_congr fun n => Finset.sum_congr rfl fun kl hkl => ?_
   rw [← Nat.cast_smul_eq_nsmul 𝕂, smul_smul, smul_mul_smul_comm, ← Finset.mem_antidiagonal.mp hkl,
     Nat.cast_add_choose, Finset.mem_antidiagonal.mp hkl]
-  congr 1
   field_simp [n.factorial_ne_zero]
 
 /-- `NormedSpace.exp 𝕂 x` has explicit two-sided inverse `NormedSpace.exp 𝕂 (-x)`. -/

--- a/Mathlib/Analysis/Normed/Field/Lemmas.lean
+++ b/Mathlib/Analysis/Normed/Field/Lemmas.lean
@@ -102,7 +102,7 @@ instance (priority := 100) NormedDivisionRing.to_continuousInv₀ : ContinuousIn
       ‖e⁻¹ - r⁻¹‖ = ‖r‖⁻¹ * ‖r - e‖ * ‖e‖⁻¹ := by
         rw [← norm_inv, ← norm_inv, ← norm_mul, ← norm_mul, mul_sub, sub_mul,
           mul_assoc _ e, inv_mul_cancel₀ r0, mul_inv_cancel₀ e0, one_mul, mul_one]
-      _ = ‖r - e‖ / ‖r‖ / ‖e‖ := by field
+      _ = ‖r - e‖ / ‖r‖ / ‖e‖ := by ring
       _ ≤ ‖r - e‖ / ‖r‖ / ε := by gcongr
   refine squeeze_zero' (Eventually.of_forall fun _ => norm_nonneg _) this ?_
   refine (((continuous_const.sub continuous_id).norm.div_const _).div_const _).tendsto' _ _ ?_

--- a/Mathlib/Analysis/Real/OfDigits.lean
+++ b/Mathlib/Analysis/Real/OfDigits.lean
@@ -74,7 +74,7 @@ theorem ofDigits_le_one {b : ℕ} (digits : ℕ → Fin b) : ofDigits digits ≤
   · simp_rw [pow_succ', mul_inv, ← inv_pow, ← mul_assoc]
     rw [tsum_mul_left, tsum_geometric_of_lt_one (by positivity) (by simp [inv_lt_one_iff₀, hb])]
     have := sub_pos.mpr hb
-    field_simp
+    field
   · simp_rw [pow_succ', mul_inv, ← inv_pow, ← mul_assoc]
     refine Summable.mul_left _ (summable_geometric_of_lt_one (by positivity) ?_)
     simp [inv_lt_one_iff₀, hb]

--- a/Mathlib/Analysis/SpecialFunctions/ContinuousFunctionalCalculus/Rpow/IntegralRepresentation.lean
+++ b/Mathlib/Analysis/SpecialFunctions/ContinuousFunctionalCalculus/Rpow/IntegralRepresentation.lean
@@ -205,7 +205,7 @@ lemma rpowIntegrand₀₁_eqOn_mul_rpowIntegrand₀₁_one (ht : 0 < t) :
   calc _ = t ^ p * (t⁻¹ - t⁻¹ * (1 + x * t⁻¹)⁻¹) := by simp [field, rpowIntegrand₀₁]
     _ = t ^ (p - 1) * (1 - (1 + x * t⁻¹)⁻¹) := by
           rw [Real.rpow_sub_one ht.ne']
-          field
+          ring
     _ = _ := by simp [mul_comm, smul_eq_mul, rpowIntegrand₀₁]
 
 /- This lemma is private because it is strictly weaker than `integrableOn_rpowIntegrand₀₁_Ioi` -/

--- a/Mathlib/Analysis/SpecialFunctions/Gamma/Deligne.lean
+++ b/Mathlib/Analysis/SpecialFunctions/Gamma/Deligne.lean
@@ -58,7 +58,7 @@ lemma Gammaℝ_add_two {s : ℂ} (hs : s ≠ 0) : Gammaℝ (s + 2) = Gammaℝ s 
 lemma Gammaℂ_add_one {s : ℂ} (hs : s ≠ 0) : Gammaℂ (s + 1) = Gammaℂ s * s / 2 / π := by
   rw [Gammaℂ_def, Gammaℂ_def, Gamma_add_one _ hs, neg_add,
     cpow_add _ _ (mul_ne_zero two_ne_zero (ofReal_ne_zero.mpr pi_ne_zero)), cpow_neg_one]
-  field
+  ring
 
 lemma Gammaℝ_ne_zero_of_re_pos {s : ℂ} (hs : 0 < re s) : Gammaℝ s ≠ 0 := by
   apply mul_ne_zero
@@ -78,7 +78,7 @@ lemma Gammaℝ_one : Gammaℝ 1 = 1 := by
 @[simp]
 lemma Gammaℂ_one : Gammaℂ 1 = 1 / π := by
   rw [Gammaℂ_def, cpow_neg_one, Complex.Gamma_one]
-  field
+  ring
 
 section analyticity
 

--- a/Mathlib/Analysis/SpecialFunctions/Integrals/Basic.lean
+++ b/Mathlib/Analysis/SpecialFunctions/Integrals/Basic.lean
@@ -370,7 +370,7 @@ theorem integral_mul_cpow_one_add_sq {t : ℂ} (ht : t ≠ -1) :
         (Or.inl hz)).div_const (2 * (t + 1)) using 1
       simp [field]
     convert (HasDerivAt.comp (↑x) (g _) f).comp_ofReal using 1
-    · field
+    · ring
     · exact mod_cast add_pos_of_pos_of_nonneg zero_lt_one (sq_nonneg x)
   · apply Continuous.intervalIntegrable
     refine continuous_ofReal.mul ?_

--- a/Mathlib/Analysis/SpecialFunctions/Log/Deriv.lean
+++ b/Mathlib/Analysis/SpecialFunctions/Log/Deriv.lean
@@ -41,7 +41,7 @@ theorem hasStrictDerivAt_log (hx : x ≠ 0) : HasStrictDerivAt log x⁻¹ x := b
   rcases hx.lt_or_gt with hx | hx
   · convert (hasStrictDerivAt_log_of_pos (neg_pos.mpr hx)).comp x (hasStrictDerivAt_neg x) using 1
     · ext y; exact (log_neg_eq_log y).symm
-    · field
+    · ring
   · exact hasStrictDerivAt_log_of_pos hx
 
 theorem hasDerivAt_log (hx : x ≠ 0) : HasDerivAt log x⁻¹ x :=

--- a/Mathlib/Analysis/SpecialFunctions/Trigonometric/Cotangent.lean
+++ b/Mathlib/Analysis/SpecialFunctions/Trigonometric/Cotangent.lean
@@ -160,7 +160,7 @@ lemma logDeriv_sin_div_eq_cot (hz : x ∈ ℂ_ℤ) :
     (DifferentiableAt.comp _ (Complex.differentiableAt_sin) (by fun_prop)) (by fun_prop),
     logDeriv_comp (Complex.differentiableAt_sin) (by fun_prop), Complex.logDeriv_sin,
     deriv_const_mul _ (by fun_prop), deriv_id'', logDeriv_const_mul, logDeriv_id']
-  · field
+  · ring
   · simp
   · simp only [ne_eq, mul_eq_zero, ofReal_eq_zero, not_or]
     exact ⟨Real.pi_ne_zero, integerComplement.ne_zero hz⟩

--- a/Mathlib/Analysis/SpecialFunctions/Trigonometric/EulerSineProd.lean
+++ b/Mathlib/Analysis/SpecialFunctions/Trigonometric/EulerSineProd.lean
@@ -207,7 +207,7 @@ theorem sin_pi_mul_eq (z : ℂ) (n : ℕ) :
       integral_one, sub_zero]
     rw [integral_cos_mul_complex (mul_ne_zero two_ne_zero hz), Complex.ofReal_zero,
       mul_zero, Complex.sin_zero, zero_div, sub_zero,
-      (by push_cast; field_simp : 2 * z * ↑(π / 2) = π * z)]
+      (by push_cast; ring : 2 * z * ↑(π / 2) = π * z)]
     simp [field]
   | succ n hn =>
     rw [hn, Finset.prod_range_succ]

--- a/Mathlib/Analysis/SpecialFunctions/Trigonometric/EulerSineProd.lean
+++ b/Mathlib/Analysis/SpecialFunctions/Trigonometric/EulerSineProd.lean
@@ -72,7 +72,7 @@ theorem integral_cos_mul_cos_pow_aux (hn : 2 ≤ n) (hz : z ≠ 0) :
       cos_pi_div_two, Complex.ofReal_zero, zero_pow (by positivity : n ≠ 0), zero_mul, zero_sub,
       ← integral_neg, ← integral_const_mul]
     refine integral_congr fun x _ => ?_
-    field
+    ring
   · apply Continuous.intervalIntegrable
     exact
       (continuous_const.mul (Complex.continuous_ofReal.comp continuous_sin)).mul

--- a/Mathlib/Analysis/SpecificLimits/ArithmeticGeometric.lean
+++ b/Mathlib/Analysis/SpecificLimits/ArithmeticGeometric.lean
@@ -89,7 +89,7 @@ lemma arithGeom_same_eq_mul_div (ha : a ≠ 1) (n : ℕ) :
 lemma arithGeom_zero_eq_mul_div' (ha : a ≠ 1) (n : ℕ) :
     arithGeom a b 0 n = b * (1 - a ^ n) / (1 - a) := by
   rw [arithGeom_eq ha n]
-  field
+  ring
 
 lemma arithGeom_zero_eq_mul_div (ha : a ≠ 1) (n : ℕ) :
     arithGeom a b 0 n = b * (a ^ n - 1) / (a - 1) := by

--- a/Mathlib/Combinatorics/Additive/VerySmallDoubling.lean
+++ b/Mathlib/Combinatorics/Additive/VerySmallDoubling.lean
@@ -625,9 +625,9 @@ private lemma exists_nonempty_isFragment (hK : K < 1) (hS : S.Nonempty) :
     rw [Nat.lt_iff_add_one_le] at hA
     calc
           κ + 1
-      _ = (κ + 1) / ((κ + 1) / (1 - K)) * ((κ + 1) / (1 - K)) := by field_simp
+      _ = (κ + 1) / ((κ + 1) / (1 - K)) * ((κ + 1) / (1 - K)) := by field
       _ < (κ + 1) / ((κ + 1) / (1 - K)) * (t + 1) := by gcongr; exact Nat.lt_floor_add_one _
-      _ = (1 - K) * (t + 1) := by field_simp
+      _ = (1 - K) * (t + 1) := by field
       _ ≤ (1 - K) * #A      := by norm_cast; gcongr
       _ ≤ ex A              := mul_card_le_expansion hS
   -- On the other hand, we essentially show that there are only finitely many possible values for
@@ -751,25 +751,25 @@ theorem card_mul_finset_lt_two {ε : ℝ} (hε₀ : 0 < ε) (hε₁ : ε ≤ 1) 
         _ = (1 - K) * #(H : Set G).toFinset := by ring
         _ ≤ ex (Set.toFinset H)             := mul_card_le_expansion hS
         _ ≤ (1 - ε / 2) * #S                := calc₁
-        _ = ε / 2 * ((2 / ε - 1) * #S)      := by field_simp
+        _ = ε / 2 * ((2 / ε - 1) * #S)      := by field
   -- To show the bound on `#Z`, we note that `#Z = #(HS) / #H` and show `#(HS) ≤ (2 / ε - 1) * #H`.
   case cardZ =>
     calc
           (#Z : ℝ)
-      _ = #(H : Set G).toFinset * #Z / #(H : Set G).toFinset          := by field_simp
+      _ = #(H : Set G).toFinset * #Z / #(H : Set G).toFinset          := by field
       _ = #(Set.toFinset H * Z) / #(H : Set G).toFinset               := by
         simp [← card_mul_eq_mul_card_of_injOn_opSMul hZinj, Nat.cast_mul]
       _ = #(Set.toFinset H * S) / #(H : Set G).toFinset               := by
         congr 3; simpa using congr(($hHZS).toFinset)
       _ ≤ (2 / ε - 1) * #(H : Set G).toFinset / #(H : Set G).toFinset := ?_
-      _ = 2 / ε - 1                                                   := by field_simp
+      _ = 2 / ε - 1                                                   := by field
     gcongr
     -- Finally, to show `#(HS) ≤ (2 / ε - 1) * #H`, we multiply both sides by `1 - K = ε / 2` and
     -- show `#(HS) = K * #H + ex H ≤ K * #H + (1 - ε / 2) * #S ≤ K * #H + (1 - ε / 2) * #(HS)`,
     -- where we used `calc₁` again.
     rw [← mul_le_mul_iff_right₀ (show 0 < 1 - K by linarith [hK])]
     suffices (1 - K) * #(Set.toFinset H * S) ≤ (1 - ε / 2) * #(H : Set G).toFinset by
-      apply le_of_eq_of_le' _ this; simp [K]; field_simp
+      apply le_of_eq_of_le' _ this; simp [K]; field
     rw [sub_mul, one_mul, sub_le_iff_le_add]
     calc
           (#(Set.toFinset H * S) : ℝ)

--- a/Mathlib/MeasureTheory/Integral/Gamma.lean
+++ b/Mathlib/MeasureTheory/Integral/Gamma.lean
@@ -33,7 +33,7 @@ theorem integral_rpow_mul_exp_neg_rpow {p q : ℝ} (hp : 0 < p) (hq : -1 < q) :
       ring_nf
     _ = (1 / p) * Gamma ((q + 1) / p) := by
       rw [Gamma_eq_integral (div_pos (neg_lt_iff_pos_add.mp hq) hp)]
-      simp_rw [show 1 / p - 1 + q / p = (q + 1) / p - 1 by field, ← integral_const_mul,
+      simp_rw [show 1 / p - 1 + q / p = (q + 1) / p - 1 by ring, ← integral_const_mul,
         ← mul_assoc]
 
 theorem integral_rpow_mul_exp_neg_mul_rpow {p q b : ℝ} (hp : 0 < p) (hq : -1 < q) (hb : 0 < b) :

--- a/Mathlib/MeasureTheory/Integral/IntervalIntegral/TrapezoidalRule.lean
+++ b/Mathlib/MeasureTheory/Integral/IntervalIntegral/TrapezoidalRule.lean
@@ -44,8 +44,7 @@ theorem trapezoidal_integral_symm (f : ℝ → ℝ) {N : ℕ} (N_nonzero : 0 < N
   norm_cast
   rw [tsub_tsub, add_comm 1, Nat.cast_add, Nat.cast_sub (mem_range.mp hk), Nat.cast_sub N_nonzero]
   apply congr_arg
-  field_simp
-  ring
+  field
 
 /-- The absolute error of the trapezoidal rule does not change when the endpoints are swapped. -/
 theorem trapezoidal_error_symm (f : ℝ → ℝ) {N : ℕ} (N_nonzero : 0 < N) (a b : ℝ) :

--- a/Mathlib/MeasureTheory/Integral/IntervalIntegral/TrapezoidalRule.lean
+++ b/Mathlib/MeasureTheory/Integral/IntervalIntegral/TrapezoidalRule.lean
@@ -75,7 +75,7 @@ theorem sum_trapezoidal_integral_adjacent_intervals {f : ℝ → ℝ} {N : ℕ} 
     (N_nonzero : 0 < N) : ∑ i ∈ range N, trapezoidal_integral f 1 (a + i * h) (a + (i + 1) * h)
       = trapezoidal_integral f N a (a + N * h) := by
   simp_rw [trapezoidal_integral_one, add_sub_add_left_eq_sub, ← sub_mul, trapezoidal_integral,
-    add_sub_cancel_left, one_mul, ← mul_sum, ← mul_div, show N * (h / N) = h by field_simp]
+    add_sub_cancel_left, one_mul, ← mul_sum, ← mul_div, show N * (h / N) = h by field]
   rw [sum_add_distrib, ← Nat.sub_one_add_one_eq_of_pos N_nonzero, sum_range_succ', sum_range_succ,
     add_add_add_comm, ← sum_add_distrib, add_comm, Nat.sub_one_add_one_eq_of_pos N_nonzero]
   simp_rw [Nat.cast_sub N_nonzero, Nat.cast_add, Nat.cast_one, ← two_mul, ← mul_sum]

--- a/Mathlib/NumberTheory/NumberField/CanonicalEmbedding/Basic.lean
+++ b/Mathlib/NumberTheory/NumberField/CanonicalEmbedding/Basic.lean
@@ -602,7 +602,7 @@ theorem stdBasis_repr_eq_matrixToStdBasis_mul (x : (K →+* ℂ) → ℂ)
         submatrix_apply, Prod.swap_prod_mk, blockDiagonal_apply, of_apply, cons_val', cons_val_zero,
         empty_val', cons_val_fin_one, ite_mul, cons_val_one, sum_add_distrib, sum_ite_eq,
         mem_univ, ↓reduceIte, ← hx (embedding w), zero_add]
-      field
+      ring
     · simp only [Fin.mk_one, Fin.isValue, stdBasis_apply_isComplex_snd, im_eq_sub_conj,
         mul_neg, fromBlocks_apply₂₁, zero_apply, zero_mul, sum_const_zero, fromBlocks_apply₂₂,
         submatrix_apply, Prod.swap_prod_mk, blockDiagonal_apply, of_apply, cons_val', cons_val_zero,

--- a/Mathlib/NumberTheory/Ostrowski.lean
+++ b/Mathlib/NumberTheory/Ostrowski.lean
@@ -249,7 +249,6 @@ theorem equiv_padic_of_bounded :
       rw [← padicNorm.nat_eq_one_iff] at hpm
       simp only [← rpow_natCast, p.cast_nonneg, ← rpow_mul, neg_mul, mul_one, ← rpow_neg, hpm,
         cast_one]
-      congr
       field_simp [h.1.ne']
   · by_contra! hne
     apply hq_prime.elim.ne_one

--- a/Mathlib/NumberTheory/Real/GoldenRatio.lean
+++ b/Mathlib/NumberTheory/Real/GoldenRatio.lean
@@ -155,7 +155,7 @@ theorem goldenRatio_irrational : Irrational φ := by
   have := this.ratCast_add 1
   convert this.ratCast_mul (show (0.5 : ℚ) ≠ 0 by norm_num)
   simp
-  field
+  ring
 
 @[deprecated (since := "2025-08-23")] alias _root_.gold_irrational := goldenRatio_irrational
 
@@ -165,7 +165,7 @@ theorem goldenConj_irrational : Irrational ψ := by
   have := this.ratCast_sub 1
   convert this.ratCast_mul (show (0.5 : ℚ) ≠ 0 by norm_num)
   simp
-  field
+  ring
 
 @[deprecated (since := "2025-08-23")] alias _root_.goldConj_irrational := goldenConj_irrational
 

--- a/Mathlib/NumberTheory/ZetaValues.lean
+++ b/Mathlib/NumberTheory/ZetaValues.lean
@@ -130,7 +130,7 @@ theorem bernoulliFourierCoeff_eq {k : ℕ} (hk : k ≠ 0) (n : ℤ) :
     split_ifs with h
     · exfalso; exact (ne_of_gt (Nat.lt_succ_iff.mpr hk)) h
     · rw [h'k, Nat.factorial_succ, zero_sub, Nat.cast_mul, pow_add]
-      field [Int.cast_ne_zero.mpr hn, I_ne_zero]
+      ring
 
 end BernoulliFourierCoeffs
 

--- a/Mathlib/Probability/Distributions/Fernique.lean
+++ b/Mathlib/Probability/Distributions/Fernique.lean
@@ -369,7 +369,7 @@ lemma lintegral_closedBall_diff_exp_logRatio_mul_sq_le [IsProbabilityMeasure μ]
     congr
     norm_cast
     simp only [Nat.cast_pow, Nat.cast_ofNat, ENNReal.toReal_div]
-    field
+    ring
 
 open Metric in
 lemma lintegral_exp_mul_sq_norm_le_mul [IsProbabilityMeasure μ]

--- a/Mathlib/RingTheory/Discriminant.lean
+++ b/Mathlib/RingTheory/Discriminant.lean
@@ -191,7 +191,7 @@ theorem discr_powerBasis_eq_prod'' [Algebra.IsSeparable K L] (e : Fin pb.dim ≃
     rw [← hn, Nat.one_le_iff_ne_zero, ← zero_lt_iff, Module.finrank_pos_iff]
     infer_instance
   rw [hn, Nat.cast_div h₂ hne, Nat.cast_mul, Nat.cast_sub hle]
-  field
+  ring
 
 /-- Formula for the discriminant of a power basis using the norm of the field extension. -/
 theorem discr_powerBasis_eq_norm [Algebra.IsSeparable K L] :

--- a/Mathlib/RingTheory/RootsOfUnity/Complex.lean
+++ b/Mathlib/RingTheory/RootsOfUnity/Complex.lean
@@ -60,7 +60,7 @@ theorem isPrimitiveRoot_iff (ζ : ℂ) (n : ℕ) (hn : n ≠ 0) :
   refine ⟨i, hi, ((isPrimitiveRoot_exp n hn).pow_iff_coprime (Nat.pos_of_ne_zero hn) i).mp h, ?_⟩
   rw [← exp_nat_mul]
   congr 1
-  field
+  ring
 
 /-- The complex `n`-th roots of unity are exactly the
 complex numbers of the form `exp (2 * Real.pi * Complex.I * (i / n))` for some `i < n`. -/
@@ -75,7 +75,7 @@ nonrec theorem mem_rootsOfUnity (n : ℕ) [NeZero n] (x : Units ℂ) :
     refine ⟨i, hi, ?_⟩
     rw [← H, ← exp_nat_mul]
     congr 1
-    field
+    ring
   · rintro ⟨i, _, H⟩
     rw [← H, ← exp_nat_mul, exp_eq_one_iff]
     use i

--- a/Mathlib/Topology/TietzeExtension.lean
+++ b/Mathlib/Topology/TietzeExtension.lean
@@ -257,7 +257,7 @@ theorem exists_extension_norm_eq_of_isClosedEmbedding' (f : X →ᵇ ℝ) (e : C
     refine
       (dist_le_of_le_geometric_of_tendsto₀ _ _ (by norm_num1)
         hg_dist hg_cau.tendsto_limUnder).trans_eq ?_
-    field
+    ring
   · rw [← hge]
     exact norm_compContinuous_le _ _
 

--- a/Mathlib/Topology/UrysohnsLemma.lean
+++ b/Mathlib/Topology/UrysohnsLemma.lean
@@ -303,7 +303,7 @@ theorem continuous_lim (c : CU P) : Continuous c.lim := by
       grw [dist_midpoint_midpoint_le, dist_midpoint_midpoint_le, dist_self, zero_add]
       set r := (3 / 4 : ℝ) ^ n
       calc _ ≤ (r / 2 + r) / 2 := by gcongr
-        _ = _ := by field
+        _ = _ := by ring
 
 end CU
 


### PR DESCRIPTION
In #30653 @grunweg proposed enforcing the following style choices in Mathlib:
- `field` should replace terminal `field_simp[; ring]` if it works (effectively the same under the hood, but less verbose)
- `ring` should replace `field` if it works (more lightweight)

#31314 (WIP) contains linters for these. This PR contains the changes to current Mathlib proposed by the linters..

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

When merging, all the commits will be squashed into a single commit
listing all co-authors.

Co-authors in the squash commit are gathered from two sources:

First, all authors of commits to this PR branch are included. Thus,
one way to add co-authors is to include at least one commit authored by
each co-author among the commits in the pull request. If necessary, you
may create empty commits to indicate co-authorship, using commands like so:

git commit --author="Author Name <author@email.com>" --allow-empty -m "add Author Name as coauthor"

Second, co-authors can also be listed in lines at the very bottom of
the commit message (that is, directly before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines
at the bottom of the commit message (before the `---`, and also before
any "Co-authored-by" lines) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
