### PR TITLE
chore(Data/Nat): golf entire `lt_def` using `grind`

### DIFF
--- a/Mathlib/Data/Nat/PartENat.lean
+++ b/Mathlib/Data/Nat/PartENat.lean
@@ -229,22 +229,7 @@ instance partialOrder : PartialOrder PartENat where
     Part.ext' ⟨hyx₁, hxy₁⟩ fun _ _ => le_antisymm (hxy₂ _) (hyx₂ _)
 
 theorem lt_def (x y : PartENat) : x < y ↔ ∃ hx : x.Dom, ∀ hy : y.Dom, x.get hx < y.get hy := by
-  rw [lt_iff_le_not_ge, le_def, le_def, not_exists]
-  constructor
-  · rintro ⟨⟨hyx, H⟩, h⟩
-    by_cases hx : x.Dom
-    · use hx
-      intro hy
-      specialize H hy
-      specialize h fun _ => hy
-      rw [not_forall] at h
-      cutsat
-    · specialize h fun hx' => (hx hx').elim
-      rw [not_forall] at h
-      obtain ⟨hx', h⟩ := h
-      exact (hx hx').elim
-  · rintro ⟨hx, H⟩
-    exact ⟨⟨fun _ => hx, fun hy => (H hy).le⟩, fun hxy h => not_lt_of_ge (h _) (H _)⟩
+  grind +splitImp [lt_iff_le_not_ge, le_def]
 
 noncomputable instance isOrderedAddMonoid : IsOrderedAddMonoid PartENat :=
   { add_le_add_left := fun a b ⟨h₁, h₂⟩ c =>


### PR DESCRIPTION
---
While the line-count reduction (+1 / –16) is impressive, it comes at a cost, so there's a trade-off to consider here:

<details>
<summary>Show trace profiling of <code>lt_def</code>: 20 ms before, 264 ms after </summary>

### Trace profiling of `lt_def` before PR 31488
```diff
diff --git a/Mathlib/Data/Nat/PartENat.lean b/Mathlib/Data/Nat/PartENat.lean
index 9ef5bbcfd8..c83a74cdc5 100644
--- a/Mathlib/Data/Nat/PartENat.lean
+++ b/Mathlib/Data/Nat/PartENat.lean
@@ -228,6 +228,7 @@ instance partialOrder : PartialOrder PartENat where
   le_antisymm := fun _ _ ⟨hxy₁, hxy₂⟩ ⟨hyx₁, hyx₂⟩ =>
     Part.ext' ⟨hyx₁, hxy₁⟩ fun _ _ => le_antisymm (hxy₂ _) (hyx₂ _)
 
+set_option trace.profiler true in
 theorem lt_def (x y : PartENat) : x < y ↔ ∃ hx : x.Dom, ∀ hy : y.Dom, x.get hx < y.get hy := by
   rw [lt_iff_le_not_ge, le_def, le_def, not_exists]
   constructor
```
```
ℹ [903/903] Built Mathlib.Data.Nat.PartENat (1.5s)
info: Mathlib/Data/Nat/PartENat.lean:232:0: [Elab.async] [0.020061] elaborating proof of PartENat.lt_def
  [Elab.definition.value] [0.019623] PartENat.lt_def
    [Elab.step] [0.019323] 
          rw [lt_iff_le_not_ge, le_def, le_def, not_exists]
          constructor
          · rintro ⟨⟨hyx, H⟩, h⟩
            by_cases hx : x.Dom
            · use hx
              intro hy
              specialize H hy
              specialize h fun _ => hy
              rw [not_forall] at h
              cutsat
            · specialize h fun hx' => (hx hx').elim
              rw [not_forall] at h
              obtain ⟨hx', h⟩ := h
              exact (hx hx').elim
          · rintro ⟨hx, H⟩
            exact ⟨⟨fun _ => hx, fun hy => (H hy).le⟩, fun hxy h => not_lt_of_ge (h _) (H _)⟩
      [Elab.step] [0.019317] 
            rw [lt_iff_le_not_ge, le_def, le_def, not_exists]
            constructor
            · rintro ⟨⟨hyx, H⟩, h⟩
              by_cases hx : x.Dom
              · use hx
                intro hy
                specialize H hy
                specialize h fun _ => hy
                rw [not_forall] at h
                cutsat
              · specialize h fun hx' => (hx hx').elim
                rw [not_forall] at h
                obtain ⟨hx', h⟩ := h
                exact (hx hx').elim
            · rintro ⟨hx, H⟩
              exact ⟨⟨fun _ => hx, fun hy => (H hy).le⟩, fun hxy h => not_lt_of_ge (h _) (H _)⟩
        [Elab.step] [0.016029] ·
              rintro ⟨⟨hyx, H⟩, h⟩
              by_cases hx : x.Dom
              · use hx
                intro hy
                specialize H hy
                specialize h fun _ => hy
                rw [not_forall] at h
                cutsat
              · specialize h fun hx' => (hx hx').elim
                rw [not_forall] at h
                obtain ⟨hx', h⟩ := h
                exact (hx hx').elim
          [Elab.step] [0.016003] 
                rintro ⟨⟨hyx, H⟩, h⟩
                by_cases hx : x.Dom
                · use hx
                  intro hy
                  specialize H hy
                  specialize h fun _ => hy
                  rw [not_forall] at h
                  cutsat
                · specialize h fun hx' => (hx hx').elim
                  rw [not_forall] at h
                  obtain ⟨hx', h⟩ := h
                  exact (hx hx').elim
            [Elab.step] [0.015999] 
                  rintro ⟨⟨hyx, H⟩, h⟩
                  by_cases hx : x.Dom
                  · use hx
                    intro hy
                    specialize H hy
                    specialize h fun _ => hy
                    rw [not_forall] at h
                    cutsat
                  · specialize h fun hx' => (hx hx').elim
                    rw [not_forall] at h
                    obtain ⟨hx', h⟩ := h
                    exact (hx hx').elim
              [Elab.step] [0.014143] ·
                    use hx
                    intro hy
                    specialize H hy
                    specialize h fun _ => hy
                    rw [not_forall] at h
                    cutsat
                [Elab.step] [0.014135] 
                      use hx
                      intro hy
                      specialize H hy
                      specialize h fun _ => hy
                      rw [not_forall] at h
                      cutsat
                  [Elab.step] [0.014129] 
                        use hx
                        intro hy
                        specialize H hy
                        specialize h fun _ => hy
                        rw [not_forall] at h
                        cutsat
Build completed successfully (903 jobs).
```

### Trace profiling of `lt_def` after PR 31488
```diff
diff --git a/Mathlib/Data/Nat/PartENat.lean b/Mathlib/Data/Nat/PartENat.lean
index 9ef5bbcfd8..413fb72bfe 100644
--- a/Mathlib/Data/Nat/PartENat.lean
+++ b/Mathlib/Data/Nat/PartENat.lean
@@ -228,23 +228,9 @@ instance partialOrder : PartialOrder PartENat where
   le_antisymm := fun _ _ ⟨hxy₁, hxy₂⟩ ⟨hyx₁, hyx₂⟩ =>
     Part.ext' ⟨hyx₁, hxy₁⟩ fun _ _ => le_antisymm (hxy₂ _) (hyx₂ _)
 
+set_option trace.profiler true in
 theorem lt_def (x y : PartENat) : x < y ↔ ∃ hx : x.Dom, ∀ hy : y.Dom, x.get hx < y.get hy := by
-  rw [lt_iff_le_not_ge, le_def, le_def, not_exists]
-  constructor
-  · rintro ⟨⟨hyx, H⟩, h⟩
-    by_cases hx : x.Dom
-    · use hx
-      intro hy
-      specialize H hy
-      specialize h fun _ => hy
-      rw [not_forall] at h
-      cutsat
-    · specialize h fun hx' => (hx hx').elim
-      rw [not_forall] at h
-      obtain ⟨hx', h⟩ := h
-      exact (hx hx').elim
-  · rintro ⟨hx, H⟩
-    exact ⟨⟨fun _ => hx, fun hy => (H hy).le⟩, fun hxy h => not_lt_of_ge (h _) (H _)⟩
+  grind +splitImp [lt_iff_le_not_ge, le_def]
 
 noncomputable instance isOrderedAddMonoid : IsOrderedAddMonoid PartENat :=
   { add_le_add_left := fun a b ⟨h₁, h₂⟩ c =>
```
```
ℹ [903/903] Built Mathlib.Data.Nat.PartENat (1.5s)
info: Mathlib/Data/Nat/PartENat.lean:232:0: [Elab.async] [0.264170] elaborating proof of PartENat.lt_def
  [Elab.definition.value] [0.263967] PartENat.lt_def
    [Elab.step] [0.263887] grind +splitImp [lt_iff_le_not_ge, le_def]
      [Elab.step] [0.263880] grind +splitImp [lt_iff_le_not_ge, le_def]
        [Elab.step] [0.263870] grind +splitImp [lt_iff_le_not_ge, le_def]
          [Meta.synthInstance] [0.016433] ❌️ LE (Lean.Grind.IntModule.OfNatModule.Q PartENat)
          [Meta.synthInstance] [0.011629] ❌️ LT (Lean.Grind.IntModule.OfNatModule.Q PartENat)
          [Meta.synthInstance] [0.017992] ❌️ LE (Lean.Grind.IntModule.OfNatModule.Q PartENat)
          [Meta.synthInstance] [0.012005] ❌️ LT (Lean.Grind.IntModule.OfNatModule.Q PartENat)
Build completed successfully (903 jobs).
```
</details>

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

When merging, all the commits will be squashed into a single commit
listing all co-authors.

Co-authors in the squash commit are gathered from two sources:

First, all authors of commits to this PR branch are included. Thus,
one way to add co-authors is to include at least one commit authored by
each co-author among the commits in the pull request. If necessary, you
may create empty commits to indicate co-authorship, using commands like so:

git commit --author="Author Name <author@email.com>" --allow-empty -m "add Author Name as coauthor"

Second, co-authors can also be listed in lines at the very bottom of
the commit message (that is, directly before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines
at the bottom of the commit message (before the `---`, and also before
any "Co-authored-by" lines) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
