### PR TITLE
[Merged by Bors] - feat(Geometry/Euclidean/Incenter): `incenter_mem_interior`

### DIFF
--- a/Mathlib/Geometry/Euclidean/Incenter.lean
+++ b/Mathlib/Geometry/Euclidean/Incenter.lean
@@ -368,7 +368,7 @@ lemma incenter_mem_interior : s.incenter ∈ s.interior := by
   obtain ⟨j, hj⟩ := exists_ne i
   rw [← Finset.sum_add_sum_compl {j, i}, Finset.sum_pair hj] at h
   revert h
-  apply LT.lt.ne'
+  apply ne_of_gt
   nth_rw 2 [add_comm]
   grw [hp]
   rw [add_assoc, lt_add_iff_pos_right]

--- a/Mathlib/Geometry/Euclidean/Incenter.lean
+++ b/Mathlib/Geometry/Euclidean/Incenter.lean
@@ -120,11 +120,14 @@ lemma sum_excenterWeightsUnnorm_empty_pos : 0 < ∑ i, s.excenterWeightsUnnorm �
   simp_rw [excenterWeightsUnnorm_empty_apply]
   positivity
 
+lemma excenterWeights_empty_pos (i : Fin (n + 1)) : 0 < s.excenterWeights ∅ i := by
+  simp only [excenterWeights, excenterWeightsUnnorm_empty_apply, Pi.smul_apply, smul_eq_mul]
+  positivity
+
 @[simp]
 lemma sign_excenterWeights_empty (i : Fin (n + 1)) : SignType.sign (s.excenterWeights ∅ i) = 1 := by
-  simp only [excenterWeights, excenterWeightsUnnorm_empty_apply, Pi.smul_apply, smul_eq_mul]
   rw [sign_eq_one_iff]
-  positivity
+  exact s.excenterWeights_empty_pos i
 
 /-- The existence of the incenter, expressed in terms of `ExcenterExists`. -/
 @[simp] lemma excenterExists_empty : s.ExcenterExists ∅ :=
@@ -355,6 +358,22 @@ lemma ExcenterExists.excenter_mem_affineSpan_range {signs : Finset (Fin (n + 1))
 
 lemma incenter_mem_affineSpan_range : s.incenter ∈ affineSpan ℝ (Set.range s.points) :=
   s.excenterExists_empty.excenter_mem_affineSpan_range
+
+lemma incenter_mem_interior : s.incenter ∈ s.interior := by
+  have h := s.excenterExists_empty.sum_excenterWeights_eq_one
+  rw [incenter_eq_affineCombination, s.affineCombination_mem_interior_iff h]
+  intro i
+  refine ⟨s.excenterWeights_empty_pos i, ?_⟩
+  by_contra! hp
+  obtain ⟨j, hj⟩ := exists_ne i
+  rw [← Finset.sum_add_sum_compl {j, i}, Finset.sum_pair hj] at h
+  revert h
+  apply LT.lt.ne'
+  nth_rw 2 [add_comm]
+  grw [hp]
+  rw [add_assoc, lt_add_iff_pos_right]
+  exact add_pos_of_pos_of_nonneg (s.excenterWeights_empty_pos j)
+    (Finset.sum_nonneg fun k _ ↦ (s.excenterWeights_empty_pos k).le)
 
 lemma excenter_singleton_mem_affineSpan_range [Nat.AtLeastTwo n] (i : Fin (n + 1)) :
     s.excenter {i} ∈ affineSpan ℝ (Set.range s.points) :=


### PR DESCRIPTION
Add a direct statement that the incenter of a simplex lies in its interior (along with factoring out a lemma `excenterWeights_empty_pos` that turns out to be useful several times in its proof).


---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

When merging, all the commits will be squashed into a single commit
listing all co-authors.

Co-authors in the squash commit are gathered from two sources:

First, all authors of commits to this PR branch are included. Thus,
one way to add co-authors is to include at least one commit authored by
each co-author among the commits in the pull request. If necessary, you
may create empty commits to indicate co-authorship, using commands like so:

git commit --author="Author Name <author@email.com>" --allow-empty -m "add Author Name as coauthor"

Second, co-authors can also be listed in lines at the very bottom of
the commit message (that is, directly before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines
at the bottom of the commit message (before the `---`, and also before
any "Co-authored-by" lines) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
