### PR TITLE
[Merged by Bors] - feat(Geometry/Euclidean/Sphere/Power): power equals squared tangent length and characterization of tangency

### DIFF
--- a/Mathlib/Geometry/Euclidean/Sphere/Power.lean
+++ b/Mathlib/Geometry/Euclidean/Sphere/Power.lean
@@ -224,25 +224,27 @@ theorem dist_sq_eq_mul_dist_of_tangent_and_secant {a b t p : P} {s : Sphere P}
   ring
 
 /-- The power of a point with respect to a sphere equals the square of its tangent length. -/
-theorem power_eq_dist_sq_of_IsTangentAt {s : Sphere P} {t p : P}
+theorem IsTangentAt.power_eq_dist_sq {s : Sphere P} {t p : P}
     (h_tangent : s.IsTangentAt t (line[ℝ, p, t])) :
     s.power p = dist p t ^ 2 := by
   rw [Sphere.power, h_tangent.dist_sq_eq_of_mem (left_mem_affineSpan_pair ℝ p t)]
   ring_nf
 
-/-- A line through a point is tangent to a sphere if and only if the squared tangent length
-equals the power of the point with respect to the sphere. -/
-theorem IsTangentAt_of_dist_sq_eq_power {t p : P} {s : Sphere P} (ht : t ∈ s)
-    (h_dist_eq : dist p t ^ 2 = s.power p) :
-    s.IsTangentAt t (line[ℝ, p, t]) := by
-  have h_orth : ⟪p -ᵥ t, t -ᵥ s.center⟫ = 0 := by
-    simp only [Sphere.power, ← mem_sphere.mp ht, dist_eq_norm_vsub V, sq,
-               ← vsub_add_vsub_cancel p t s.center] at h_dist_eq
-    exact (norm_add_sq_eq_norm_sq_add_norm_sq_iff_real_inner_eq_zero _ _).mp (by linarith)
-  refine ⟨ht, right_mem_affineSpan_pair ℝ p t, fun x hx ↦ ?_⟩
-  rw [SetLike.mem_coe, mem_orthRadius_iff_inner_left]
-  obtain ⟨r, hr⟩ := (vadd_right_mem_affineSpan_pair (k := ℝ)).mp (vsub_vadd x t ▸ hx)
-  rw [← hr, inner_smul_left, h_orth, mul_zero]
+/-- A line through a point on a sphere is tangent if and only if the squared distance
+from the external point to the tangent point equals the power of the point. -/
+theorem isTangentAt_iff_dist_sq_eq_power {t p : P} {s : Sphere P} (ht : t ∈ s) :
+    s.IsTangentAt t (line[ℝ, p, t]) ↔ dist p t ^ 2 = s.power p :=
+  ⟨fun h ↦ h.power_eq_dist_sq.symm, fun h_dist_eq ↦ by
+    have h_orth : ⟪p -ᵥ t, t -ᵥ s.center⟫ = 0 := by
+      simp only [Sphere.power, ← mem_sphere.mp ht, dist_eq_norm_vsub V, sq,
+                 ← vsub_add_vsub_cancel p t s.center] at h_dist_eq
+      exact (norm_add_sq_eq_norm_sq_add_norm_sq_iff_real_inner_eq_zero _ _).mp (by linarith)
+    refine ⟨ht, right_mem_affineSpan_pair ℝ p t, fun x hx ↦ ?_⟩
+    rw [SetLike.mem_coe, mem_orthRadius_iff_inner_left]
+    obtain ⟨r, hr⟩ := (vadd_right_mem_affineSpan_pair (k := ℝ)).mp (vsub_vadd x t ▸ hx)
+    rw [← hr, inner_smul_left, h_orth, mul_zero]⟩
+
+alias ⟨_, isTangentAt_of_dist_sq_eq_power⟩ := isTangentAt_iff_dist_sq_eq_power
 
 end Sphere
 

--- a/Mathlib/Geometry/Euclidean/Sphere/Power.lean
+++ b/Mathlib/Geometry/Euclidean/Sphere/Power.lean
@@ -8,6 +8,7 @@ module
 public import Mathlib.Geometry.Euclidean.Angle.Unoriented.Affine
 public import Mathlib.Geometry.Euclidean.Sphere.Basic
 public import Mathlib.Geometry.Euclidean.Sphere.Tangent
+import Mathlib.Geometry.Euclidean.Angle.Sphere
 
 /-!
 # Power of a point (intersecting chords and secants)
@@ -222,6 +223,23 @@ theorem dist_sq_eq_mul_dist_of_tangent_and_secant {a b t p : P} {s : Sphere P}
   rw [mul_dist_eq_power_of_radius_le_dist_center hr hp ha hb radius_le_dist,
     Sphere.power, h_tangent.dist_sq_eq_of_mem (left_mem_affineSpan_pair ℝ p t)]
   ring
+
+/-- The power of a point with respect to a sphere equals the square of its tangent length. -/
+theorem power_eq_dist_sq_of_IsTangentAt {s : Sphere P} {t p : P}
+    (h_tangent : s.IsTangentAt t (line[ℝ, p, t])) :
+    s.power p = dist p t ^ 2 := by
+  rw [Sphere.power, h_tangent.dist_sq_eq_of_mem (left_mem_affineSpan_pair ℝ p t)]
+  ring_nf
+
+/-- A line through a point is tangent to a sphere if and only if the squared tangent length
+equals the power of the point with respect to the sphere. -/
+theorem IsTangentAt_of_dist_sq_eq_power {t p : P} {s : Sphere P} (ht : t ∈ s)
+    (h_dist_eq : dist p t ^ 2 = s.power p) :
+    s.IsTangentAt t (line[ℝ, p, t]) := by
+  rw [Set.pair_comm, IsTangentAt_iff_angle_eq_pi_div_two ht,
+      ← dist_sq_eq_dist_sq_add_dist_sq_iff_angle_eq_pi_div_two]
+  simp only [sq, power, mem_sphere.mp ht, dist_comm s.center t] at h_dist_eq ⊢
+  linarith
 
 end Sphere
 

--- a/Mathlib/Geometry/Euclidean/Sphere/Power.lean
+++ b/Mathlib/Geometry/Euclidean/Sphere/Power.lean
@@ -8,7 +8,6 @@ module
 public import Mathlib.Geometry.Euclidean.Angle.Unoriented.Affine
 public import Mathlib.Geometry.Euclidean.Sphere.Basic
 public import Mathlib.Geometry.Euclidean.Sphere.Tangent
-import Mathlib.Geometry.Euclidean.Angle.Sphere
 
 /-!
 # Power of a point (intersecting chords and secants)
@@ -236,10 +235,14 @@ equals the power of the point with respect to the sphere. -/
 theorem IsTangentAt_of_dist_sq_eq_power {t p : P} {s : Sphere P} (ht : t ∈ s)
     (h_dist_eq : dist p t ^ 2 = s.power p) :
     s.IsTangentAt t (line[ℝ, p, t]) := by
-  rw [Set.pair_comm, IsTangentAt_iff_angle_eq_pi_div_two ht,
-      ← dist_sq_eq_dist_sq_add_dist_sq_iff_angle_eq_pi_div_two]
-  simp only [sq, power, mem_sphere.mp ht, dist_comm s.center t] at h_dist_eq ⊢
-  linarith
+  have h_orth : ⟪p -ᵥ t, t -ᵥ s.center⟫ = 0 := by
+    simp only [Sphere.power, ← mem_sphere.mp ht, dist_eq_norm_vsub V, sq,
+               ← vsub_add_vsub_cancel p t s.center] at h_dist_eq
+    exact (norm_add_sq_eq_norm_sq_add_norm_sq_iff_real_inner_eq_zero _ _).mp (by linarith)
+  refine ⟨ht, right_mem_affineSpan_pair ℝ p t, fun x hx ↦ ?_⟩
+  rw [SetLike.mem_coe, mem_orthRadius_iff_inner_left]
+  obtain ⟨r, hr⟩ := (vadd_right_mem_affineSpan_pair (k := ℝ)).mp (vsub_vadd x t ▸ hx)
+  rw [← hr, inner_smul_left, h_orth, mul_zero]
 
 end Sphere
 


### PR DESCRIPTION
Adds two lemmas in `Geometry.Euclidean.Sphere.Power`:

* `power_eq_dist_sq_of_IsTangentAt` — the power of a point equals the square of its tangent length.
* `IsTangentAt_of_dist_sq_eq_power` — characterization of tangency via the power of a point.
