### PR TITLE
[Merged by Bors] - feat(Geometry/Euclidean/PerpBisector): add distance inequalities for Sbtw with perpendicularity

### DIFF
--- a/Mathlib/Analysis/InnerProductSpace/Affine.lean
+++ b/Mathlib/Analysis/InnerProductSpace/Affine.lean
@@ -62,4 +62,33 @@ theorem inner_vsub_vsub_right_eq_dist_sq_right_iff {a b c : P} :
     ⟪a -ᵥ c, b -ᵥ c⟫ = dist b c ^ 2 ↔ ⟪a -ᵥ b, b -ᵥ c⟫ = 0 := by
   rw [real_inner_comm, inner_vsub_vsub_right_eq_dist_sq_left_iff, real_inner_comm]
 
+/-- Squared distance between two points on lines from a common origin,
+given orthogonality of the direction vectors. -/
+theorem dist_sq_lineMap_lineMap_of_inner_eq_zero {a b c : P} (t₁ t₂ : ℝ)
+    (h_inner : ⟪b -ᵥ a, c -ᵥ a⟫ = 0) :
+    dist (AffineMap.lineMap a b t₁) (AffineMap.lineMap a c t₂) ^ 2 =
+      t₁ ^ 2 * dist a b ^ 2 + t₂ ^ 2 * dist a c ^ 2 := by
+  have hvec : AffineMap.lineMap a b t₁ -ᵥ AffineMap.lineMap a c t₂ =
+              t₁ • (b -ᵥ a) - t₂ • (c -ᵥ a) := by
+    rw [AffineMap.lineMap_apply, AffineMap.lineMap_apply, vadd_vsub_vadd_cancel_right]
+  rw [dist_eq_norm_vsub V, hvec, norm_sub_sq_real, norm_smul, norm_smul,
+      Real.norm_eq_abs, Real.norm_eq_abs, inner_smul_left, inner_smul_right, h_inner]
+  simp only [mul_zero, sub_zero, mul_pow, sq_abs, ← dist_eq_norm_vsub' V]
+
+/-- Squared distance from `p` to a point on the line from `a` to `b`,
+given that `p -ᵥ a` is orthogonal to `b -ᵥ a`. -/
+theorem dist_sq_lineMap_of_inner_eq_zero {a b p : P} (t : ℝ)
+    (h_inner : ⟪p -ᵥ a, b -ᵥ a⟫ = 0) :
+    dist p (AffineMap.lineMap a b t) ^ 2 = dist p a ^ 2 + t ^ 2 * dist a b ^ 2 := by
+  have h := dist_sq_lineMap_lineMap_of_inner_eq_zero (t₁ := 1) (t₂ := t) h_inner
+  simp only [AffineMap.lineMap_apply_one, one_pow, one_mul] at h
+  rwa [dist_comm a p] at h
+
+/-- **Pythagorean theorem**: if `p -ᵥ a` is orthogonal to `b -ᵥ a`, then
+`dist p b ^ 2 = dist p a ^ 2 + dist a b ^ 2`. -/
+theorem dist_sq_of_inner_eq_zero {a b p : P}
+    (h_inner : ⟪p -ᵥ a, b -ᵥ a⟫ = 0) :
+    dist p b ^ 2 = dist p a ^ 2 + dist a b ^ 2 := by
+  simpa using dist_sq_lineMap_of_inner_eq_zero 1 h_inner
+
 end Real

--- a/Mathlib/Geometry/Euclidean/PerpBisector.lean
+++ b/Mathlib/Geometry/Euclidean/PerpBisector.lean
@@ -8,6 +8,7 @@ module
 public import Mathlib.Analysis.InnerProductSpace.Orthogonal
 public import Mathlib.Analysis.Normed.Group.AddTorsor
 public import Mathlib.Analysis.Convex.Between
+public import Mathlib.Analysis.InnerProductSpace.Affine
 
 /-!
 # Perpendicular bisector of a segment
@@ -124,32 +125,7 @@ open AffineSubspace
 
 namespace EuclideanGeometry
 
-/-- Pythagorean theorem: if `p - a` is perpendicular to `c - a`, then
-`dist p (lineMap a c t) ^ 2 = dist p a ^ 2 + t ^ 2 * dist a c ^ 2`. -/
-lemma dist_sq_lineMap_of_inner_eq_zero {a c p : P} {t : ℝ}
-    (h_inner : ⟪p -ᵥ a, c -ᵥ a⟫ = 0) :
-    dist p (AffineMap.lineMap a c t) ^ 2 = dist p a ^ 2 + t ^ 2 * dist a c ^ 2 := by
-  set v := c -ᵥ a
-  have hbv : AffineMap.lineMap a c t -ᵥ a = t • v := by simp [AffineMap.lineMap_apply, v]
-  rw [dist_eq_norm_vsub, dist_eq_norm_vsub, dist_eq_norm_vsub' V,
-      show p -ᵥ AffineMap.lineMap a c t = (p -ᵥ a) - t • v by
-      rw [← hbv, vsub_sub_vsub_cancel_right],
-      ← real_inner_self_eq_norm_sq, ← real_inner_self_eq_norm_sq, ← real_inner_self_eq_norm_sq,
-      inner_sub_left, inner_sub_right, inner_sub_right,
-      inner_smul_right, inner_smul_left, inner_smul_left, inner_smul_right,
-      real_inner_comm (p -ᵥ a) v, h_inner]
-  simp only [inner_self_eq_norm_sq_to_K, RCLike.ofReal_real_eq_id, id_eq, mul_zero, sub_zero,
-    conj_trivial, zero_sub, sub_neg_eq_add, add_right_inj]
-  ring
-
-/-- Pythagorean theorem: if `p - a` is perpendicular to `c - a`, then
-`dist p c ^ 2 = dist p a ^ 2 + dist a c ^ 2`. -/
-lemma dist_sq_of_inner_eq_zero {a c p : P}
-    (h_inner : ⟪p -ᵥ a, c -ᵥ a⟫ = 0) :
-    dist p c ^ 2 = dist p a ^ 2 + dist a c ^ 2 := by
-  simpa using dist_sq_lineMap_of_inner_eq_zero (t := 1) h_inner
-
-/-- If `b` is strictly between `a` and `c`, and `p - a` is perpendicular to `b - a`,
+/-- If `b` is strictly between `a` and `c`, and `p -ᵥ a` is orthogonal to `b -ᵥ a`,
 then `p` is closer to `b` than to `c`. -/
 theorem dist_lt_of_sbtw_of_inner_eq_zero {a b c p : P}
     (h_sbtw : Sbtw ℝ a b c)
@@ -159,13 +135,13 @@ theorem dist_lt_of_sbtw_of_inner_eq_zero {a b c p : P}
   have hb : b -ᵥ a = t • (c -ᵥ a) := by simp [← hb_eq, AffineMap.lineMap_apply]
   have hpc : ⟪p -ᵥ a, c -ᵥ a⟫ = 0 := by simpa [ht0.ne', hb, inner_smul_right] using h_inner
   have h_sq_ineq : dist p b ^ 2 < dist p c ^ 2 := by
-    rw [← hb_eq, dist_sq_lineMap_of_inner_eq_zero hpc, dist_sq_of_inner_eq_zero hpc]
+    rw [← hb_eq, dist_sq_lineMap_of_inner_eq_zero t hpc, dist_sq_of_inner_eq_zero hpc]
     have hv_pos : 0 < dist a c ^ 2 := sq_pos_of_pos (dist_pos.mpr h_sbtw.left_ne_right)
     have ht_sq_lt : t ^ 2 < 1 := sq_lt_one_iff₀ ht0.le |>.mpr ht1
     nlinarith [sq_nonneg (dist p a), sq_nonneg (dist a c)]
   simpa only [Real.sqrt_sq dist_nonneg] using Real.sqrt_lt_sqrt (sq_nonneg _) h_sq_ineq
 
-/-- If `b` is weakly between `a` and `c`, and `p - a` is perpendicular to `c - a`,
+/-- If `b` is weakly between `a` and `c`, and `p -ᵥ a` is orthogonal to `c -ᵥ a`,
 then `p` is at least as close to `b` as to `c`. -/
 theorem dist_le_of_wbtw_of_inner_eq_zero {a b c p : P}
     (h_wbtw : Wbtw ℝ a b c)
@@ -173,7 +149,7 @@ theorem dist_le_of_wbtw_of_inner_eq_zero {a b c p : P}
     dist p b ≤ dist p c := by
   obtain ⟨t, ⟨ht0, ht1⟩, hb_eq⟩ := h_wbtw
   have h_sq_ineq : dist p b ^ 2 ≤ dist p c ^ 2 := by
-    rw [← hb_eq, dist_sq_lineMap_of_inner_eq_zero h_inner, dist_sq_of_inner_eq_zero h_inner]
+    rw [← hb_eq, dist_sq_lineMap_of_inner_eq_zero t h_inner, dist_sq_of_inner_eq_zero h_inner]
     have ht_sq_le : t ^ 2 ≤ 1 := sq_le_one_iff₀ ht0 |>.mpr ht1
     nlinarith [sq_nonneg (dist p a), sq_nonneg (dist a c)]
   simpa only [Real.sqrt_sq dist_nonneg] using Real.sqrt_le_sqrt h_sq_ineq

--- a/Mathlib/Geometry/Euclidean/PerpBisector.lean
+++ b/Mathlib/Geometry/Euclidean/PerpBisector.lean
@@ -7,7 +7,7 @@ module
 
 public import Mathlib.Analysis.InnerProductSpace.Orthogonal
 public import Mathlib.Analysis.Normed.Group.AddTorsor
-import Mathlib.Analysis.Convex.Between
+public import Mathlib.Analysis.Convex.Between
 
 /-!
 # Perpendicular bisector of a segment
@@ -124,6 +124,30 @@ open AffineSubspace
 
 namespace EuclideanGeometry
 
+/-- Helper lemma: calculate squared distances to a point on a line and the endpoint,
+given orthogonality at the origin `a`. -/
+lemma dist_sq_lineMap_of_inner_eq_zero {a c p : P} {t : ℝ}
+    (b : P) (hb : b = AffineMap.lineMap a c t)
+    (h_inner : ⟪p -ᵥ a, c -ᵥ a⟫ = 0) :
+    dist p b ^ 2 = dist p a ^ 2 + t ^ 2 * ‖c -ᵥ a‖ ^ 2 ∧
+    dist p c ^ 2 = dist p a ^ 2 + ‖c -ᵥ a‖ ^ 2 := by
+  set v := c -ᵥ a
+  have hbv : b -ᵥ a = t • v := by simp [hb, AffineMap.lineMap_apply, v]
+  constructor
+  · rw [dist_eq_norm_vsub, dist_eq_norm_vsub,
+        show p -ᵥ b = (p -ᵥ a) - t • v by rw [← hbv, vsub_sub_vsub_cancel_right],
+        ← real_inner_self_eq_norm_sq, ← real_inner_self_eq_norm_sq, inner_sub_left, inner_sub_right,
+        inner_sub_right, inner_smul_right, inner_smul_left, inner_smul_left, inner_smul_right,
+        real_inner_comm (p -ᵥ a) v, h_inner]
+    simp only [inner_self_eq_norm_sq_to_K, RCLike.ofReal_real_eq_id, id_eq, mul_zero, sub_zero,
+      conj_trivial, zero_sub, sub_neg_eq_add, add_right_inj]
+    ring
+  · rw [dist_eq_norm_vsub, dist_eq_norm_vsub, ← real_inner_self_eq_norm_sq,
+        ← real_inner_self_eq_norm_sq, ← vsub_sub_vsub_cancel_right, inner_sub_left, inner_sub_right,
+        inner_sub_right, real_inner_comm (p -ᵥ a) (c -ᵥ a), h_inner]
+    simp only [sub_zero, zero_sub, sub_neg_eq_add, add_right_inj]
+    exact real_inner_self_eq_norm_sq (c -ᵥ a)
+
 /-- If `b` is strictly between `a` and `c`, and `p - a` is perpendicular to `b - a`,
 then `p` is closer to `b` than to `c`. -/
 theorem dist_lt_of_sbtw_of_inner_eq_zero {a b c p : P}
@@ -131,33 +155,33 @@ theorem dist_lt_of_sbtw_of_inner_eq_zero {a b c p : P}
     (h_inner : ⟪p -ᵥ a, b -ᵥ a⟫ = 0) :
     dist p b < dist p c := by
   obtain ⟨t, ⟨ht0, ht1⟩, hb_eq⟩ := h_sbtw.mem_image_Ioo
-  set v := c -ᵥ a
-  have hb : b -ᵥ a = t • v := by simp [← hb_eq, AffineMap.lineMap_apply, v]
-  have hpc : ⟪p -ᵥ a, v⟫ = 0 := by simpa [ht0.ne', hb, inner_smul_right] using h_inner
-  have hb_sq : dist p b ^ 2 = dist p a ^ 2 + t^2 * ‖v‖^2 := by
-    rw [dist_eq_norm_vsub, dist_eq_norm_vsub,
-        show p -ᵥ b = (p -ᵥ a) - t • v by rw [← hb, vsub_sub_vsub_cancel_right],
-        ← real_inner_self_eq_norm_sq, ← real_inner_self_eq_norm_sq, inner_sub_left, inner_sub_right,
-        inner_sub_right, inner_smul_right, inner_smul_left, inner_smul_left, inner_smul_right,
-        real_inner_comm (p -ᵥ a) v, hpc]
-    simp [real_inner_self_eq_norm_sq]
-    ring
-  have hc_sq : dist p c ^ 2 = dist p a ^ 2 + ‖c -ᵥ a‖^2 := by
-    rw [dist_eq_norm_vsub, dist_eq_norm_vsub, ← real_inner_self_eq_norm_sq,
-        ← real_inner_self_eq_norm_sq, ← vsub_sub_vsub_cancel_right, inner_sub_left, inner_sub_right,
-        inner_sub_right, real_inner_comm (p -ᵥ a) (c -ᵥ a), hpc]
-    simp only [sub_zero, zero_sub, sub_neg_eq_add, add_right_inj]
-    exact real_inner_self_eq_norm_sq (c -ᵥ a)
-  have ht_sq_lt : t^2 < 1 := by
-    rw [sq_lt_one_iff₀ ht0.le]
-    exact ht1
-  have hv_pos : 0 < ‖v‖^2 :=
+  have hb : b -ᵥ a = t • (c -ᵥ a) := by simp [← hb_eq, AffineMap.lineMap_apply]
+  have hpc : ⟪p -ᵥ a, c -ᵥ a⟫ = 0 := by simpa [ht0.ne', hb, inner_smul_right] using h_inner
+  obtain ⟨hb_sq, hc_sq⟩ := dist_sq_lineMap_of_inner_eq_zero b hb_eq.symm hpc
+  have ht_sq_lt : t ^ 2 < 1 := sq_lt_one_iff₀ ht0.le |>.mpr ht1
+  have hv_pos : 0 < ‖c -ᵥ a‖ ^ 2 :=
     sq_pos_of_pos (norm_pos_iff.mpr (vsub_ne_zero.mpr h_sbtw.left_ne_right.symm))
   have h_sq_ineq : dist p b ^ 2 < dist p c ^ 2 := by
     rw [hb_sq, hc_sq]
-    have : t ^ 2 * ‖v‖ ^ 2 < ‖v‖ ^ 2 := mul_lt_of_lt_one_left hv_pos ht_sq_lt
+    have : t ^ 2 * ‖c -ᵥ a‖ ^ 2 < ‖c -ᵥ a‖ ^ 2 := mul_lt_of_lt_one_left hv_pos ht_sq_lt
     linarith
   simpa only [Real.sqrt_sq dist_nonneg] using Real.sqrt_lt_sqrt (sq_nonneg _) h_sq_ineq
+
+/-- If `b` is weakly between `a` and `c`, and `p - a` is perpendicular to `c - a`,
+then `p` is at least as close to `b` as to `c`. -/
+theorem dist_le_of_wbtw_of_inner_eq_zero {a b c p : P}
+    (h_wbtw : Wbtw ℝ a b c)
+    (h_inner : ⟪p -ᵥ a, c -ᵥ a⟫ = 0) :
+    dist p b ≤ dist p c := by
+  obtain ⟨t, ⟨ht0, ht1⟩, hb_eq⟩ := h_wbtw
+  obtain ⟨hb_sq, hc_sq⟩ := dist_sq_lineMap_of_inner_eq_zero b hb_eq.symm h_inner
+  have ht_sq_le : t ^ 2 ≤ 1 := sq_le_one_iff₀ ht0 |>.mpr ht1
+  have h_sq_ineq : dist p b ^ 2 ≤ dist p c ^ 2 := by
+    rw [hb_sq, hc_sq]
+    have : t ^ 2 * ‖c -ᵥ a‖ ^ 2 ≤ 1 * ‖c -ᵥ a‖ ^ 2 :=
+      mul_le_mul_of_nonneg_right ht_sq_le (sq_nonneg _)
+    linarith
+  simpa only [Real.sqrt_sq dist_nonneg] using Real.sqrt_le_sqrt h_sq_ineq
 
 /-- If `p` lies on the perpendicular bisector of `ab` and `b` is strictly between `a` and `c`,
 then `p` is closer to `b` than to `c`. -/
@@ -169,6 +193,20 @@ theorem dist_lt_of_sbtw_of_mem_perpBisector {a b c p : P}
     (h_sbtw.trans_left_right (sbtw_midpoint_of_ne ℝ h_sbtw.left_ne)) <| by
     rw [right_vsub_midpoint, inner_smul_right,
         mem_perpBisector_iff_inner_eq_zero.mp hp, invOf_eq_inv, mul_zero]
+
+/-- If `p` lies on the perpendicular bisector of `ab` and `b` is weakly between `a` and `c`,
+then `p` is at least as close to `b` as to `c`. -/
+theorem dist_le_of_wbtw_of_mem_perpBisector {a b c p : P}
+    (h_wbtw : Wbtw ℝ a b c) (hab : a ≠ b)
+    (hp : p ∈ AffineSubspace.perpBisector a b) :
+    dist p b ≤ dist p c :=
+  dist_le_of_wbtw_of_inner_eq_zero
+    (h_wbtw.trans_left_right (wbtw_midpoint ℝ a b)) <| by
+    rcases h_wbtw.right_mem_image_Ici_of_left_ne hab with ⟨s, -, rfl⟩
+    rw [← vsub_add_vsub_cancel (AffineMap.lineMap a b s) a, AffineMap.lineMap_vsub_left,
+        left_vsub_midpoint, ← neg_vsub_eq_vsub_rev b a, smul_neg, ← sub_eq_add_neg,
+        inner_sub_right, inner_smul_right, inner_smul_right,
+        mem_perpBisector_iff_inner_eq_zero.mp hp, mul_zero, mul_zero, sub_self]
 
 /-- Suppose that `c₁` is equidistant from `p₁` and `p₂`, and the same applies to `c₂`. Then the
 vector between `c₁` and `c₂` is orthogonal to that between `p₁` and `p₂`. (In two dimensions, this


### PR DESCRIPTION
This PR adds two theorems about distance relationships when points satisfy strict betweenness (`Sbtw`) and perpendicularity conditions:

### New theorems

- `dist_lt_of_sbtw_of_inner_eq_zero`: If `b` is strictly between `a` and `c`, and `p - a` is perpendicular to `b - a`, then `dist p b < dist p c`.

- `dist_lt_of_sbtw_of_mem_perpBisector`: If `p` lies on the perpendicular bisector of `ab` and `b` is strictly between `a` and `c`, then `dist p b < dist p c`.