### PR TITLE
[Merged by Bors] - feat: Qq version of getLevel

### DIFF
--- a/Mathlib/Util/Qq.lean
+++ b/Mathlib/Util/Qq.lean
@@ -19,8 +19,7 @@ namespace Qq
 
 /-- If `e` has type `Sort u` for some level `u`, return `u` and `e : Q(Sort u)`. -/
 def getLevelQ (e : Expr) : MetaM (Σ u : Lean.Level, Q(Sort u)) := do
-  let .sort u ← whnf (← inferType e) | throwError "not a type{indentExpr e}"
-  return ⟨u, e⟩
+  return ⟨← getLevel e, e⟩
 
 /-- If `e` has type `Type u` for some level `u`, return `u` and `e : Q(Type u)`. -/
 def getLevelQ' (e : Expr) : MetaM (Σ u : Lean.Level, Q(Type u)) := do

--- a/Mathlib/Util/Qq.lean
+++ b/Mathlib/Util/Qq.lean
@@ -17,14 +17,24 @@ open Lean Elab Tactic Meta
 
 namespace Qq
 
+/-- If `e` has type `Sort u` for some level `u`, return `u` and `e : Q(Sort u)`. -/
+def getLevelQ (e : Expr) : MetaM (Σ u : Lean.Level, Q(Sort u)) := do
+  let .sort u ← whnf (← inferType e) | throwError "not a type{indentExpr e}"
+  return ⟨u, e⟩
+
+/-- If `e` has type `Type u` for some level `u`, return `u` and `e : Q(Type u)`. -/
+def getLevelQ' (e : Expr) : MetaM (Σ u : Lean.Level, Q(Type u)) := do
+  let u ← getLevel e
+  let some v := (← instantiateLevelMVars u).dec | throwError "not a Type{indentExpr e}"
+  return ⟨v, e⟩
+
 /-- Variant of `inferTypeQ` that yields a type in `Type u` rather than `Sort u`.
 Throws an error if the type is a `Prop` or if it's otherwise not possible to represent
 the universe as `Type u` (for example due to universe level metavariables). -/
 -- See https://leanprover.zulipchat.com/#narrow/stream/287929-mathlib4/topic/Using.20.60QQ.60.20when.20you.20only.20have.20an.20.60Expr.60/near/303349037
 def inferTypeQ' (e : Expr) : MetaM ((u : Level) × (α : Q(Type $u)) × Q($α)) := do
   let α ← inferType e
-  let .sort u ← whnf (← inferType α) | throwError "not a type{indentExpr α}"
-  let some v := (← instantiateLevelMVars u).dec | throwError "not a Type{indentExpr e}"
+  let ⟨v, α⟩ ← getLevelQ' α
   pure ⟨v, α, e⟩
 
 theorem QuotedDefEq.rfl {u : Level} {α : Q(Sort u)} {a : Q($α)} : @QuotedDefEq u α a a := ⟨⟩


### PR DESCRIPTION
These were helpful for writing the `algebra` tactic for adding Qq annotations in cases where I know that an expression is a type. 

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

When merging, all the commits will be squashed into a single commit
listing all co-authors.

Co-authors in the squash commit are gathered from two sources:

First, all authors of commits to this PR branch are included. Thus,
one way to add co-authors is to include at least one commit authored by
each co-author among the commits in the pull request. If necessary, you
may create empty commits to indicate co-authorship, using commands like so:

git commit --author="Author Name <author@email.com>" --allow-empty -m "add Author Name as coauthor"

Second, co-authors can also be listed in lines at the very bottom of
the commit message (that is, directly before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines
at the bottom of the commit message (before the `---`, and also before
any "Co-authored-by" lines) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
