### PR TITLE
feat: isMulCommutative_of_injective, isMulCommutative_of_surjective

### DIFF
--- a/Mathlib/Algebra/Group/Hom/Basic.lean
+++ b/Mathlib/Algebra/Group/Hom/Basic.lean
@@ -291,6 +291,20 @@ lemma comp_div (f : G →* H) (g h : M →* G) : f.comp (g / h) = f.comp g / f.c
 
 end InvDiv
 
+lemma isMulCommutative_of_injective {G H : Type*} [Mul G] [Mul H]
+    (F : Type*) [FunLike F G H] [MulHomClass F G H] (f : F)
+    (hf : Function.Injective f) [hH : IsMulCommutative H] :
+    IsMulCommutative G :=
+  ⟨⟨fun x y ↦ hf (by simpa [map_mul] using hH.is_comm.comm _ _)⟩⟩
+
+lemma isMulCommutative_of_surjective {G H : Type*} [Mul G] [Mul H]
+    (F : Type*) [FunLike F G H] [MulHomClass F G H] (f : F)
+    (hf : Function.Surjective f) [hG : IsMulCommutative G] :
+    IsMulCommutative H := ⟨⟨fun x y ↦ by
+  rcases hf x with ⟨a, rfl⟩
+  rcases hf y with ⟨b, rfl⟩
+  simp [← map_mul, hG.is_comm.comm a b]⟩⟩
+
 /-- If `H` is commutative and `G →* H` is injective, then `G` is commutative. -/
 def commGroupOfInjective [Group G] [CommGroup H] (f : G →* H) (hf : Function.Injective f) :
     CommGroup G :=

--- a/Mathlib/Algebra/Group/Hom/Basic.lean
+++ b/Mathlib/Algebra/Group/Hom/Basic.lean
@@ -291,12 +291,14 @@ lemma comp_div (f : G →* H) (g h : M →* G) : f.comp (g / h) = f.comp g / f.c
 
 end InvDiv
 
+@[to_additive]
 lemma _root_.isMulCommutative_of_injective {G H : Type*} [Mul G] [Mul H]
     (F : Type*) [FunLike F G H] [MulHomClass F G H] (f : F)
     (hf : Function.Injective f) [hH : IsMulCommutative H] :
     IsMulCommutative G :=
   ⟨⟨fun x y ↦ hf (by simpa [map_mul] using hH.is_comm.comm _ _)⟩⟩
 
+@[to_additive]
 lemma _root_.isMulCommutative_of_surjective {G H : Type*} [Mul G] [Mul H]
     (F : Type*) [FunLike F G H] [MulHomClass F G H] (f : F)
     (hf : Function.Surjective f) [hG : IsMulCommutative G] :

--- a/Mathlib/Algebra/Group/Hom/Basic.lean
+++ b/Mathlib/Algebra/Group/Hom/Basic.lean
@@ -291,13 +291,13 @@ lemma comp_div (f : G →* H) (g h : M →* G) : f.comp (g / h) = f.comp g / f.c
 
 end InvDiv
 
-lemma isMulCommutative_of_injective {G H : Type*} [Mul G] [Mul H]
+lemma _root_.isMulCommutative_of_injective {G H : Type*} [Mul G] [Mul H]
     (F : Type*) [FunLike F G H] [MulHomClass F G H] (f : F)
     (hf : Function.Injective f) [hH : IsMulCommutative H] :
     IsMulCommutative G :=
   ⟨⟨fun x y ↦ hf (by simpa [map_mul] using hH.is_comm.comm _ _)⟩⟩
 
-lemma isMulCommutative_of_surjective {G H : Type*} [Mul G] [Mul H]
+lemma _root_.isMulCommutative_of_surjective {G H : Type*} [Mul G] [Mul H]
     (F : Type*) [FunLike F G H] [MulHomClass F G H] (f : F)
     (hf : Function.Surjective f) [hG : IsMulCommutative G] :
     IsMulCommutative H := ⟨⟨fun x y ↦ by


### PR DESCRIPTION
---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

When merging, all the commits will be squashed into a single commit
listing all co-authors.

Co-authors in the squash commit are gathered from two sources:

First, all authors of commits to this PR branch are included. Thus,
one way to add co-authors is to include at least one commit authored by
each co-author among the commits in the pull request. If necessary, you
may create empty commits to indicate co-authorship, using commands like so:

git commit --author="Author Name <author@email.com>" --allow-empty -m "add Author Name as coauthor"

Second, co-authors can also be listed in lines at the very bottom of
the commit message (that is, directly before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines
at the bottom of the commit message (before the `---`, and also before
any "Co-authored-by" lines) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
