### PR TITLE
[Merged by Bors] - feat(contrapose): cancel negations, and support `↔`

### DIFF
--- a/Mathlib/LinearAlgebra/LinearIndependent/Lemmas.lean
+++ b/Mathlib/LinearAlgebra/LinearIndependent/Lemmas.lean
@@ -438,7 +438,7 @@ theorem exists_maximal_linearIndepOn (v : ι → M) :
       rintro x hx
       refine (memJ.mp (supp_f hx)).resolve_left ?_
       rintro rfl
-      exact hIlinind (Finsupp.mem_support_iff.mp hx)
+      exact (Finsupp.mem_support_iff.mp hx) hIlinind
     use f i, hfi
     have hfi' : i ∈ f.support := Finsupp.mem_support_iff.mpr hfi
     rw [← Finset.insert_erase hfi', Finset.sum_insert (Finset.notMem_erase _ _),

--- a/Mathlib/LinearAlgebra/RootSystem/GeckConstruction/Semisimple.lean
+++ b/Mathlib/LinearAlgebra/RootSystem/GeckConstruction/Semisimple.lean
@@ -209,9 +209,9 @@ private lemma instIsIrreducible_aux₀ {U : LieSubmodule K H (b.support ⊕ ι �
   obtain ⟨i, hi⟩ : ∃ i, w (Sum.inr i) ≠ 0 := by
     obtain ⟨l, hl⟩ : ∃ l, χ (h' l) ≠ 0 := by
       replace hw₀ : genWeightSpace (b.support ⊕ ι → K) χ ≠ ⊥ := by
-        contrapose! hw₀; rw [LieSubmodule.eq_bot_iff] at hw₀; exact hw₀ _ hw
+        contrapose hw₀; rw [LieSubmodule.eq_bot_iff] at hw₀; exact hw₀ _ hw
       let χ' : H →ₗ[K] K := (Weight.mk χ hw₀).toLinear
-      replace hχ : χ' ≠ 0 := by contrapose! hχ; ext x; simpa using LinearMap.congr_fun hχ x
+      replace hχ : χ' ≠ 0 := by contrapose hχ; ext x; simpa using LinearMap.congr_fun hχ x
       contrapose! hχ
       apply LinearMap.ext_on (span_range_h'_eq_top b)
       rintro - ⟨l, rfl⟩

--- a/Mathlib/RingTheory/Localization/Integral.lean
+++ b/Mathlib/RingTheory/Localization/Integral.lean
@@ -57,7 +57,7 @@ alias coeffIntegerNormalization_of_not_mem_support := coeffIntegerNormalization_
 theorem coeffIntegerNormalization_mem_support (p : S[X]) (i : ℕ)
     (h : coeffIntegerNormalization M p i ≠ 0) : i ∈ p.support := by
   contrapose h
-  rw [Ne, Classical.not_not, coeffIntegerNormalization, dif_neg h]
+  rw [coeffIntegerNormalization, dif_neg h]
 
 /-- `integerNormalization g` normalizes `g` to have integer coefficients
 by clearing the denominators -/

--- a/Mathlib/RingTheory/Valuation/ValuationRing.lean
+++ b/Mathlib/RingTheory/Valuation/ValuationRing.lean
@@ -175,7 +175,6 @@ instance commGroupWithZero :
       simp only [one_smul]
       apply (mul_inv_cancel₀ _).symm
       contrapose ha
-      simp only [Classical.not_not] at ha ⊢
       rw [ha]
       rfl }
 

--- a/Mathlib/Tactic/Contrapose.lean
+++ b/Mathlib/Tactic/Contrapose.lean
@@ -52,13 +52,13 @@ macro_rules
 open Lean Meta Elab.Tactic
 
 elab_rules : tactic
-| `(tactic| contrapose) => liftMetaTactic fun g => do
+| `(tactic| contrapose) => liftMetaTactic fun g => withReducible do
   let target ← g.getType'
   match target with
   | mkApp2 (.const ``Iff _) p q =>
     if ← contrapose.negate_iff.getM then
-      -- we use `whnfR`, so that `a ≠ b` is recognized as a negation
-      match (← whnfR p).not?, (← whnfR q).not? with
+      -- we use reducible `whnf`, so that `a ≠ b` is recognized as a negation
+      match (← whnf p).not?, (← whnf q).not? with
       | none, none => g.apply (mkApp2 (.const ``contrapose_iff₁ []) p q)
       | some p, none => g.apply (mkApp2 (.const ``contrapose_iff₂ []) p q)
       | none, some q => g.apply (mkApp2 (.const ``contrapose_iff₃ []) p q)
@@ -73,7 +73,7 @@ elab_rules : tactic
       throwTacticEx `contrapose g m!"hypothesis `{p}` is not a proposition"
     unless ← Meta.isProp q do
       throwTacticEx `contrapose g m!"conclusion `{q}` is not a proposition"
-    match (← whnfR p).not?, (← whnfR q).not? with
+    match (← whnf p).not?, (← whnf q).not? with
     | none, none => g.apply (mkApp2 (.const ``contrapose₁ []) p q)
     | some p, none => g.apply (mkApp2 (.const ``contrapose₂ []) p q)
     | none, some q => g.apply (mkApp2 (.const ``contrapose₃ []) p q)

--- a/Mathlib/Tactic/Contrapose.lean
+++ b/Mathlib/Tactic/Contrapose.lean
@@ -57,7 +57,8 @@ elab_rules : tactic
   match target with
   | mkApp2 (.const ``Iff _) p q =>
     if ← contrapose.negate_iff.getM then
-      match p.cleanupAnnotations.not?, q.cleanupAnnotations.not? with
+      -- we use `whnfR`, so that `a ≠ b` is recognized as a negation
+      match (← whnfR p).not?, (← whnfR q).not? with
       | none, none => g.apply (mkApp2 (.const ``contrapose_iff₁ []) p q)
       | some p, none => g.apply (mkApp2 (.const ``contrapose_iff₂ []) p q)
       | none, some q => g.apply (mkApp2 (.const ``contrapose_iff₃ []) p q)
@@ -72,7 +73,7 @@ elab_rules : tactic
       throwTacticEx `contrapose g m!"hypothesis `{p}` is not a proposition"
     unless ← Meta.isProp q do
       throwTacticEx `contrapose g m!"conclusion `{q}` is not a proposition"
-    match p.cleanupAnnotations.not?, q.cleanupAnnotations.not? with
+    match (← whnfR p).not?, (← whnfR q).not? with
     | none, none => g.apply (mkApp2 (.const ``contrapose₁ []) p q)
     | some p, none => g.apply (mkApp2 (.const ``contrapose₂ []) p q)
     | none, some q => g.apply (mkApp2 (.const ``contrapose₃ []) p q)

--- a/Mathlib/Tactic/Contrapose.lean
+++ b/Mathlib/Tactic/Contrapose.lean
@@ -20,9 +20,9 @@ implication or an iff. It also avoids creating double negations if there already
 -/
 namespace Mathlib.Tactic.Contrapose
 
-/-- An option to turn off the feature that `contrapose` contraposes `↔` goals.
+/-- An option to turn off the feature that `contrapose` negates both sides of `↔` goals.
 This may be useful for teaching. -/
-register_option contrapose.iff : Bool := {
+register_option contrapose.negate_iff : Bool := {
   defValue := true
   descr := "contrapose a goal `a ↔ b` into the goal `¬ a ↔ ¬ b`"
 }
@@ -56,7 +56,7 @@ elab_rules : tactic
   let target ← g.getType'
   match target with
   | mkApp2 (.const ``Iff _) p q =>
-    if ← contrapose.iff.getM then
+    if ← contrapose.negate_iff.getM then
       match p.cleanupAnnotations.not?, q.cleanupAnnotations.not? with
       | none, none => g.apply (mkApp2 (.const ``contrapose_iff₁ []) p q)
       | some p, none => g.apply (mkApp2 (.const ``contrapose_iff₂ []) p q)
@@ -64,7 +64,7 @@ elab_rules : tactic
       | some p, some q => g.apply (mkApp2 (.const ``contrapose_iff₄ []) p q)
     else
       throwTacticEx `contrapose g "contraposing `↔` relations has been disabled.\n\
-        To enable it, use `set_option contrapose.iff true`."
+        To enable it, use `set_option contrapose.negate_iff true`."
   | .forallE _ p q _ =>
     if q.hasLooseBVars then
       throwTacticEx `contrapose g m!"the goal `{target}` is a dependent arrow"

--- a/Mathlib/Tactic/Contrapose.lean
+++ b/Mathlib/Tactic/Contrapose.lean
@@ -9,34 +9,73 @@ import Mathlib.Tactic.Push
 /-! # Contrapose
 
 The `contrapose` tactic transforms the goal into its contrapositive when that goal is an
-implication.
+implication or an if and only if.
 
-* `contrapose`     turns a goal `P → Q` into `¬ Q → ¬ P`
-* `contrapose!`    turns a goal `P → Q` into `¬ Q → ¬ P` and pushes negations inside `P` and `Q`
-  using `push_neg`
-* `contrapose h`   first reverts the local assumption `h`, and then uses `contrapose` and `intro h`
-* `contrapose! h`  first reverts the local assumption `h`, and then uses `contrapose!` and `intro h`
+* `contrapose` turns a goal `P → Q` into `¬ Q → ¬ P` and a goal `P ↔ Q` into `¬ P ↔ ¬ Q`
+* `contrapose!` runs `contrapose` and then pushes negations inside `P` and `Q` using `push_neg`
+* `contrapose h` first reverts the local assumption `h`, and then uses `contrapose` and `intro h`
+* `contrapose! h` first reverts the local assumption `h`, and then uses `contrapose!` and `intro h`
 * `contrapose h with new_h` uses the name `new_h` for the introduced hypothesis
 
 -/
 namespace Mathlib.Tactic.Contrapose
 
-lemma mtr {p q : Prop} : (¬ q → ¬ p) → (p → q) := fun h hp ↦ by_contra (fun h' ↦ h h' hp)
+/-- An option to turn off the `contrapose` feature of contraposing `↔` relations.
+This may be useful for teaching. -/
+register_option contrapose.iff : Bool := {
+  defValue := true
+  descr := "contrapose a goal `a ↔ b` into the goal `¬ a ↔ ¬ b`"
+}
+
+lemma contrapose₁ {p q : Prop} : (¬ q → ¬ p) → (p → q) := fun h hp ↦ by_contra fun h' ↦ h h' hp
+lemma contrapose₂ {p q : Prop} : (¬ q → p) → (¬ p → q) := fun h hp ↦ by_contra fun h' ↦ hp (h h')
+lemma contrapose₃ {p q : Prop} : (q → ¬ p) → (p → ¬ q) := fun h hp hq ↦ h hq hp
+lemma contrapose₄ {p q : Prop} : (q → p) → (¬ p → ¬ q) := mt
+
+lemma contrapose_iff₁ {p q : Prop} : (¬ p ↔ ¬ q) → (p ↔ q) := not_iff_not.mp
+lemma contrapose_iff₂ {p q : Prop} : (p ↔ ¬ q) → (¬ p ↔ q) := (not_iff_comm.trans Iff.comm).mpr
+lemma contrapose_iff₃ {p q : Prop} : (¬ p ↔ q) → (p ↔ ¬ q) := (not_iff_comm.trans Iff.comm).mp
+lemma contrapose_iff₄ {p q : Prop} : (p ↔ q) → (¬ p ↔ ¬ q) := not_iff_not.mpr
 
 /--
 Transforms the goal into its contrapositive.
-* `contrapose`     turns a goal `P → Q` into `¬ Q → ¬ P`
-* `contrapose h`   first reverts the local assumption `h`, and then uses `contrapose` and `intro h`
+* `contrapose` turns a goal `P → Q` into `¬ Q → ¬ P` and it turns a goal `P ↔ Q` into `¬ P ↔ ¬ Q`
+* `contrapose h` first reverts the local assumption `h`, and then uses `contrapose` and `intro h`
 * `contrapose h with new_h` uses the name `new_h` for the introduced hypothesis
 -/
 syntax (name := contrapose) "contrapose" (ppSpace colGt ident (" with " ident)?)? : tactic
 macro_rules
-  | `(tactic| contrapose) => `(tactic| (refine mtr ?_))
   | `(tactic| contrapose $e) => `(tactic| (revert $e:ident; contrapose; intro $e:ident))
   | `(tactic| contrapose $e with $e') => `(tactic| (revert $e:ident; contrapose; intro $e':ident))
 
+open Lean Meta Elab.Tactic
+
+elab_rules : tactic
+| `(tactic| contrapose) => liftMetaTactic fun g => do
+  match ← g.getType' with
+  | mkApp2 (.const ``Iff _) p q =>
+    if ← contrapose.iff.getM then
+      match p.not?, q.not? with
+      | none, none => g.apply (mkApp2 (.const ``contrapose_iff₁ []) p q)
+      | some p, none => g.apply (mkApp2 (.const ``contrapose_iff₂ []) p q)
+      | none, some q => g.apply (mkApp2 (.const ``contrapose_iff₃ []) p q)
+      | some p, some q => g.apply (mkApp2 (.const ``contrapose_iff₄ []) p q)
+    else
+      throwTacticEx `contrapose g "contraposing `↔` relations has been disabled.\n\
+        To enable it, use `set_option contrapose.iff true`."
+  | .forallE _ p q _ =>
+    if q.hasLooseBVars then
+      throwTacticEx `contrapose g m!"conclusion {q} has loose bound variables"
+    match p.not?, q.not? with
+    | none, none => g.apply (mkApp2 (.const ``contrapose₁ []) p q)
+    | some p, none => g.apply (mkApp2 (.const ``contrapose₂ []) p q)
+    | none, some q => g.apply (mkApp2 (.const ``contrapose₃ []) p q)
+    | some p, some q => g.apply (mkApp2 (.const ``contrapose₄ []) p q)
+  | e =>
+    throwTacticEx `contrapose g m!"{e} is not of the form `_ → _` or `_ ↔ _`"
+
 /--
-Transforms the goal into its contrapositive and uses pushes negations inside `P` and `Q`.
+Transforms the goal into its contrapositive and pushes negations in the resulting goal.
 Usage matches `contrapose`
 -/
 syntax (name := contrapose!) "contrapose!" (ppSpace colGt ident (" with " ident)?)? : tactic

--- a/Mathlib/Tactic/Contrapose.lean
+++ b/Mathlib/Tactic/Contrapose.lean
@@ -9,7 +9,7 @@ import Mathlib.Tactic.Push
 /-! # Contrapose
 
 The `contrapose` tactic transforms the goal into its contrapositive when that goal is an
-implication or an iff. It also avoids creating double negations if there already is a negation.
+implication or an iff. It also avoids creating a double negation if there already is a negation.
 
 * `contrapose` turns a goal `P → Q` into `¬ Q → ¬ P` and a goal `P ↔ Q` into `¬ P ↔ ¬ Q`
 * `contrapose!` runs `contrapose` and then pushes negations inside `P` and `Q` using `push_neg`
@@ -82,7 +82,7 @@ elab_rules : tactic
     throwTacticEx `contrapose g m!"the goal `{target}` is not of the form `_ → _` or `_ ↔ _`"
 
 /--
-Transforms the goal into its contrapositive and pushes negations in the resulting goal.
+Transforms the goal into its contrapositive and pushes negations in the result.
 Usage matches `contrapose`
 -/
 syntax (name := contrapose!) "contrapose!" (ppSpace colGt ident (" with " ident)?)? : tactic

--- a/Mathlib/Tactic/Contrapose.lean
+++ b/Mathlib/Tactic/Contrapose.lean
@@ -27,7 +27,7 @@ register_option contrapose.iff : Bool := {
   descr := "contrapose a goal `a ↔ b` into the goal `¬ a ↔ ¬ b`"
 }
 
--- `contrapose₃`, `contrapose₄` and `contrapose_iff₄` don't depend on any axioms
+-- `contrapose₃`, `contrapose₄` and `contrapose_iff₄` don't depend on any axioms.
 lemma contrapose₁ {p q : Prop} : (¬ q → ¬ p) → (p → q) := fun h hp ↦ by_contra fun h' ↦ h h' hp
 lemma contrapose₂ {p q : Prop} : (¬ q → p) → (¬ p → q) := fun h hp ↦ by_contra fun h' ↦ hp (h h')
 lemma contrapose₃ {p q : Prop} : (q → ¬ p) → (p → ¬ q) := Imp.swap.mp
@@ -57,7 +57,7 @@ elab_rules : tactic
   match target with
   | mkApp2 (.const ``Iff _) p q =>
     if ← contrapose.iff.getM then
-      match p.not?, q.not? with
+      match p.cleanupAnnotations.not?, q.cleanupAnnotations.not? with
       | none, none => g.apply (mkApp2 (.const ``contrapose_iff₁ []) p q)
       | some p, none => g.apply (mkApp2 (.const ``contrapose_iff₂ []) p q)
       | none, some q => g.apply (mkApp2 (.const ``contrapose_iff₃ []) p q)
@@ -72,7 +72,7 @@ elab_rules : tactic
       throwTacticEx `contrapose g m!"hypothesis `{p}` is not a proposition"
     unless ← Meta.isProp q do
       throwTacticEx `contrapose g m!"conclusion `{q}` is not a proposition"
-    match p.not?, q.not? with
+    match p.cleanupAnnotations.not?, q.cleanupAnnotations.not? with
     | none, none => g.apply (mkApp2 (.const ``contrapose₁ []) p q)
     | some p, none => g.apply (mkApp2 (.const ``contrapose₂ []) p q)
     | none, some q => g.apply (mkApp2 (.const ``contrapose₃ []) p q)

--- a/Mathlib/Tactic/Contrapose.lean
+++ b/Mathlib/Tactic/Contrapose.lean
@@ -9,7 +9,7 @@ import Mathlib.Tactic.Push
 /-! # Contrapose
 
 The `contrapose` tactic transforms the goal into its contrapositive when that goal is an
-implication or an if and only if.
+implication or an iff. It also avoids creating double negations if there already is a negation.
 
 * `contrapose` turns a goal `P → Q` into `¬ Q → ¬ P` and a goal `P ↔ Q` into `¬ P ↔ ¬ Q`
 * `contrapose!` runs `contrapose` and then pushes negations inside `P` and `Q` using `push_neg`
@@ -20,20 +20,21 @@ implication or an if and only if.
 -/
 namespace Mathlib.Tactic.Contrapose
 
-/-- An option to turn off the `contrapose` feature of contraposing `↔` relations.
+/-- An option to turn off the feature that `contrapose` contraposes `↔` goals.
 This may be useful for teaching. -/
 register_option contrapose.iff : Bool := {
   defValue := true
   descr := "contrapose a goal `a ↔ b` into the goal `¬ a ↔ ¬ b`"
 }
 
+-- `contrapose₃`, `contrapose₄` and `contrapose_iff₄` don't depend on any axioms
 lemma contrapose₁ {p q : Prop} : (¬ q → ¬ p) → (p → q) := fun h hp ↦ by_contra fun h' ↦ h h' hp
 lemma contrapose₂ {p q : Prop} : (¬ q → p) → (¬ p → q) := fun h hp ↦ by_contra fun h' ↦ hp (h h')
-lemma contrapose₃ {p q : Prop} : (q → ¬ p) → (p → ¬ q) := fun h hp hq ↦ h hq hp
+lemma contrapose₃ {p q : Prop} : (q → ¬ p) → (p → ¬ q) := Imp.swap.mp
 lemma contrapose₄ {p q : Prop} : (q → p) → (¬ p → ¬ q) := mt
 
 lemma contrapose_iff₁ {p q : Prop} : (¬ p ↔ ¬ q) → (p ↔ q) := not_iff_not.mp
-lemma contrapose_iff₂ {p q : Prop} : (p ↔ ¬ q) → (¬ p ↔ q) := (not_iff_comm.trans Iff.comm).mpr
+lemma contrapose_iff₂ {p q : Prop} : (p ↔ ¬ q) → (¬ p ↔ q) := (iff_not_comm.trans Iff.comm).mp
 lemma contrapose_iff₃ {p q : Prop} : (¬ p ↔ q) → (p ↔ ¬ q) := (not_iff_comm.trans Iff.comm).mp
 lemma contrapose_iff₄ {p q : Prop} : (p ↔ q) → (¬ p ↔ ¬ q) := fun ⟨h₁, h₂⟩ ↦ ⟨mt h₂, mt h₁⟩
 

--- a/Mathlib/Tactic/Contrapose.lean
+++ b/Mathlib/Tactic/Contrapose.lean
@@ -35,7 +35,7 @@ lemma contrapose₄ {p q : Prop} : (q → p) → (¬ p → ¬ q) := mt
 lemma contrapose_iff₁ {p q : Prop} : (¬ p ↔ ¬ q) → (p ↔ q) := not_iff_not.mp
 lemma contrapose_iff₂ {p q : Prop} : (p ↔ ¬ q) → (¬ p ↔ q) := (not_iff_comm.trans Iff.comm).mpr
 lemma contrapose_iff₃ {p q : Prop} : (¬ p ↔ q) → (p ↔ ¬ q) := (not_iff_comm.trans Iff.comm).mp
-lemma contrapose_iff₄ {p q : Prop} : (p ↔ q) → (¬ p ↔ ¬ q) := not_iff_not.mpr
+lemma contrapose_iff₄ {p q : Prop} : (p ↔ q) → (¬ p ↔ ¬ q) := fun ⟨h₁, h₂⟩ ↦ ⟨mt h₂, mt h₁⟩
 
 /--
 Transforms the goal into its contrapositive.

--- a/MathlibTest/Contrapose.lean
+++ b/MathlibTest/Contrapose.lean
@@ -23,6 +23,21 @@ example (p q : Prop) (h : p) (hpq : ¬q → ¬p) : q := by
   exact hpq h'
 
 example (p q : Prop) (h : q → p) : ¬p → ¬q := by
+  contrapose
+  guard_target = q → p
+  exact h
+
+example (p q : Prop) (h : q → ¬p) : p → ¬q := by
+  contrapose
+  guard_target = q → ¬p
+  exact h
+
+example (p q : Prop) (h : ¬q → p) : ¬p → q := by
+  contrapose
+  guard_target = ¬q → p
+  exact h
+
+example (p q : Prop) (h : q → p) : ¬p → ¬q := by
   contrapose!
   guard_target = q → p
   exact h
@@ -37,10 +52,54 @@ example (p q : Prop) (h : ¬p) (hpq : q → p) : ¬q := by
   guard_target = p
   exact hpq h'
 
+example (p q r : Prop) (h : ¬ q ∧ ¬ r → ¬ p) : p → q ∨ r := by
+  fail_if_success (contrapose; exact h)
+  contrapose!; exact h
+
 example (p : Prop) (h : p) : p := by
-  fail_if_success { contrapose }
+  fail_if_success contrapose
   exact h
 
 example (p q : Type) (h : p → q) : p → q := by
   fail_if_success { contrapose }
   exact h
+
+/-! test contraposing `↔` -/
+
+example (p q : Prop) (h : p ↔ q) : ¬p ↔ ¬q := by
+  contrapose
+  guard_target = p ↔ q
+  exact h
+
+example (p q : Prop) (h : ¬p ↔ q) : p ↔ ¬q := by
+  contrapose
+  guard_target = ¬p ↔ q
+  exact h
+
+example (p q : Prop) (h : p ↔ ¬q) : ¬p ↔ q := by
+  contrapose
+  guard_target = p ↔ ¬q
+  exact h
+
+example (p q : Prop) (h : p ↔ q) : ¬p ↔ ¬q := by
+  contrapose
+  guard_target = p ↔ q
+  exact h
+
+example (p q r : Prop) (h : ¬p ↔ ¬q ∧ ¬r) : p ↔ q ∨ r := by
+  contrapose!
+  guard_target = ¬p ↔ ¬q ∧ ¬r
+  exact h
+
+set_option contrapose.iff false in
+/--
+error: Tactic `contrapose` failed: contraposing `↔` relations has been disabled.
+To enable it, use `set_option contrapose.iff true`.
+
+p q : Prop
+h : p ↔ q
+⊢ ¬p ↔ ¬q
+-/
+#guard_msgs in
+example (p q : Prop) (h : p ↔ q) : ¬p ↔ ¬q := by
+  contrapose

--- a/MathlibTest/Contrapose.lean
+++ b/MathlibTest/Contrapose.lean
@@ -37,11 +37,6 @@ example (p q : Prop) (h : ¬q → p) : ¬p → q := by
   guard_target = ¬q → p
   exact h
 
-example {α : Type} (a b : α) (p : Prop) (h : a = b → p) : ¬p → a ≠ b := by
-  contrapose
-  guard_target = a = b → p
-  exact h
-
 example (p q : Prop) (h : q → p) : ¬p → ¬q := by
   contrapose!
   guard_target = q → p
@@ -135,3 +130,25 @@ h : p ↔ q
 #guard_msgs in
 example (p q : Prop) (h : p ↔ q) : ¬p ↔ ¬q := by
   contrapose
+
+/-! Test that we unfold reducible, but not semireducible definitions -/
+
+example {α : Type} (a b : α) (p : Prop) (h : a = b → p) : ¬p → a ≠ b := by
+  contrapose
+  guard_target = a = b → p
+  exact h
+
+abbrev MyImp' (p q : Prop) := p → q
+def MyImp := MyImp'
+abbrev MyNot' (p : Prop) := ¬p
+def MyNot := MyNot'
+
+example (p q : Prop) (h : ¬q → ¬p) : MyImp p q := by
+  fail_if_success contrapose
+  unfold MyImp
+  contrapose
+
+example (p q : Prop) (h : q → ¬p) : p → MyNot q := by
+  fail_if_success (contrapose; exact h)
+  unfold MyNot
+  contrapose; exact h

--- a/MathlibTest/Contrapose.lean
+++ b/MathlibTest/Contrapose.lean
@@ -56,13 +56,40 @@ example (p q r : Prop) (h : ¬ q ∧ ¬ r → ¬ p) : p → q ∨ r := by
   fail_if_success (contrapose; exact h)
   contrapose!; exact h
 
+/--
+error: Tactic `contrapose` failed: the goal `p` is not of the form `_ → _` or `_ ↔ _`
+
+p : Prop
+h : p
+⊢ p
+-/
+#guard_msgs in
 example (p : Prop) (h : p) : p := by
-  fail_if_success contrapose
+  contrapose
   exact h
 
+/--
+error: Tactic `contrapose` failed: hypothesis `p` is not a proposition
+
+p q : Type
+h : p → q
+⊢ p → q
+-/
+#guard_msgs in
 example (p q : Type) (h : p → q) : p → q := by
-  fail_if_success { contrapose }
+  contrapose
   exact h
+
+/--
+error: Tactic `contrapose` failed: the goal `∀ (h : p), q h` is a dependent arrow
+
+p : Prop
+q : p → Prop
+⊢ ∀ (h : p), q h
+-/
+#guard_msgs in
+example (p : Prop) (q : p → Prop) : (h : p) → q h := by
+  contrapose
 
 /-! test contraposing `↔` -/
 

--- a/MathlibTest/Contrapose.lean
+++ b/MathlibTest/Contrapose.lean
@@ -37,6 +37,11 @@ example (p q : Prop) (h : ¬q → p) : ¬p → q := by
   guard_target = ¬q → p
   exact h
 
+example {α : Type} (a b : α) (p : Prop) (h : a = b → p) : ¬p → a ≠ b := by
+  contrapose
+  guard_target = a = b → p
+  exact h
+
 example (p q : Prop) (h : q → p) : ¬p → ¬q := by
   contrapose!
   guard_target = q → p

--- a/MathlibTest/Contrapose.lean
+++ b/MathlibTest/Contrapose.lean
@@ -118,10 +118,10 @@ example (p q r : Prop) (h : ¬p ↔ ¬q ∧ ¬r) : p ↔ q ∨ r := by
   guard_target = ¬p ↔ ¬q ∧ ¬r
   exact h
 
-set_option contrapose.iff false in
+set_option contrapose.negate_iff false in
 /--
 error: Tactic `contrapose` failed: contraposing `↔` relations has been disabled.
-To enable it, use `set_option contrapose.iff true`.
+To enable it, use `set_option contrapose.negate_iff true`.
 
 p q : Prop
 h : p ↔ q

--- a/MathlibTest/Contrapose.lean
+++ b/MathlibTest/Contrapose.lean
@@ -147,6 +147,7 @@ example (p q : Prop) (h : ¬q → ¬p) : MyImp p q := by
   fail_if_success contrapose
   unfold MyImp
   contrapose
+  exact h
 
 example (p q : Prop) (h : q → ¬p) : p → MyNot q := by
   fail_if_success (contrapose; exact h)


### PR DESCRIPTION
This PR introduces two features for `contrapose`:
- `contrapose` applied to a goal `p ↔ q` creates the goal `¬p ↔ ¬q`.
- Instead of creating double negations, contrapose will try to cancel out double negations that it creates.
  This will allow for replacing some occurrences of `contrapose!` with `contrapose` (TODO: write a linter for this?). It also allows avoiding classical logic in some cases.

[Zulip discussion](https://leanprover.zulipchat.com/#narrow/channel/287929-mathlib4/topic/RFC.3A.20contrapose.20for.20.60a.20.E2.86.94.20b.60/with/554945103)

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

When merging, all the commits will be squashed into a single commit
listing all co-authors.

Co-authors in the squash commit are gathered from two sources:

First, all authors of commits to this PR branch are included. Thus,
one way to add co-authors is to include at least one commit authored by
each co-author among the commits in the pull request. If necessary, you
may create empty commits to indicate co-authorship, using commands like so:

git commit --author="Author Name <author@email.com>" --allow-empty -m "add Author Name as coauthor"

Second, co-authors can also be listed in lines at the very bottom of
the commit message (that is, directly before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines
at the bottom of the commit message (before the `---`, and also before
any "Co-authored-by" lines) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
