### PR TITLE
[Merged by Bors] - feat: add an element to a linear indep family, more general version

### DIFF
--- a/Mathlib/Analysis/Normed/Unbundled/FiniteExtension.lean
+++ b/Mathlib/Analysis/Normed/Unbundled/FiniteExtension.lean
@@ -181,7 +181,7 @@ theorem exists_nonarchimedean_pow_mul_seminorm_of_finiteDimensional (hfd : Finit
     ∃ f : AlgebraNorm K L, IsPowMul f ∧ (∀ (x : K), f ((algebraMap K L) x) = ‖x‖) ∧
       IsNonarchimedean f := by
   -- Choose a basis B = {1, e2,..., en} of the K-vector space L
-  have h1 : LinearIndepOn K id ({1} : Set L) := .singleton _ one_ne_zero
+  have h1 : LinearIndepOn K id ({1} : Set L) := .singleton one_ne_zero
   set ι := { x // x ∈ LinearIndepOn.extend h1 (Set.subset_univ ({1} : Set L)) }
   set B : Basis ι K L := Basis.extend h1
   letI hfin : Fintype ι := FiniteDimensional.fintypeBasisIndex B

--- a/Mathlib/Analysis/Normed/Unbundled/FiniteExtension.lean
+++ b/Mathlib/Analysis/Normed/Unbundled/FiniteExtension.lean
@@ -181,8 +181,7 @@ theorem exists_nonarchimedean_pow_mul_seminorm_of_finiteDimensional (hfd : Finit
     ∃ f : AlgebraNorm K L, IsPowMul f ∧ (∀ (x : K), f ((algebraMap K L) x) = ‖x‖) ∧
       IsNonarchimedean f := by
   -- Choose a basis B = {1, e2,..., en} of the K-vector space L
-  set h1 : LinearIndepOn K id ({1} : Set L) :=
-    LinearIndepOn.id_singleton _ one_ne_zero
+  have h1 : LinearIndepOn K id ({1} : Set L) := .singleton _ one_ne_zero
   set ι := { x // x ∈ LinearIndepOn.extend h1 (Set.subset_univ ({1} : Set L)) }
   set B : Basis ι K L := Basis.extend h1
   letI hfin : Fintype ι := FiniteDimensional.fintypeBasisIndex B

--- a/Mathlib/Geometry/Euclidean/Altitude.lean
+++ b/Mathlib/Geometry/Euclidean/Altitude.lean
@@ -129,7 +129,7 @@ theorem affineSpan_pair_eq_altitude_iff {n : ℕ} [NeZero n] (s : Simplex ℝ P 
       simpa using h
     · rw [finrank_direction_altitude, finrank_span_set_eq_card]
       · simp
-      · exact LinearIndepOn.id_singleton _ <| by simpa using hne
+      · exact .singleton <| by simpa using hne
 
 /-- The foot of an altitude is the orthogonal projection of a vertex of a simplex onto the
 opposite face. -/

--- a/Mathlib/LinearAlgebra/AffineSpace/Independent.lean
+++ b/Mathlib/LinearAlgebra/AffineSpace/Independent.lean
@@ -662,7 +662,7 @@ theorem affineIndependent_of_ne {p₁ p₂ : P} (h : p₁ ≠ p₂) : AffineInde
     · simp at hi
     · simp [i₁]
   haveI : Unique { x // x ≠ (0 : Fin 2) } := ⟨⟨i₁⟩, he'⟩
-  apply linearIndependent_unique
+  refine .of_subsingleton default ?_
   rw [he' default]
   simpa using h.symm
 

--- a/Mathlib/LinearAlgebra/Dimension/Constructions.lean
+++ b/Mathlib/LinearAlgebra/Dimension/Constructions.lean
@@ -535,8 +535,8 @@ variable [StrongRankCondition F] [NoZeroSMulDivisors F E] [Nontrivial E]
 theorem Subalgebra.rank_bot : Module.rank F (⊥ : Subalgebra F E) = 1 :=
   (Subalgebra.toSubmoduleEquiv (⊥ : Subalgebra F E)).symm.rank_eq.trans <| by
     rw [Algebra.toSubmodule_bot, one_eq_span, rank_span_set, mk_singleton _]
-    letI := Module.nontrivial F E
-    exact LinearIndepOn.id_singleton _ one_ne_zero
+    have := Module.nontrivial F E
+    exact .singleton one_ne_zero
 
 @[simp]
 theorem Subalgebra.finrank_bot : finrank F (⊥ : Subalgebra F E) = 1 :=

--- a/Mathlib/LinearAlgebra/Dimension/RankNullity.lean
+++ b/Mathlib/LinearAlgebra/Dimension/RankNullity.lean
@@ -137,7 +137,7 @@ independent of the first one. -/
 theorem exists_linearIndependent_pair_of_one_lt_rank [StrongRankCondition R]
     [NoZeroSMulDivisors R M] (h : 1 < Module.rank R M) {x : M} (hx : x ≠ 0) :
     ∃ y, LinearIndependent R ![x, y] := by
-  obtain ⟨y, hy⟩ := exists_linearIndependent_snoc_of_lt_rank (linearIndependent_unique ![x] hx) h
+  obtain ⟨y, hy⟩ := exists_linearIndependent_snoc_of_lt_rank (.of_subsingleton _ hx) h
   have : Fin.snoc ![x] y = ![x, y] := by simp [Fin.snoc, ← List.ofFn_inj]
   rw [this] at hy
   exact ⟨y, hy⟩

--- a/Mathlib/LinearAlgebra/Dimension/RankNullity.lean
+++ b/Mathlib/LinearAlgebra/Dimension/RankNullity.lean
@@ -137,7 +137,7 @@ independent of the first one. -/
 theorem exists_linearIndependent_pair_of_one_lt_rank [StrongRankCondition R]
     [NoZeroSMulDivisors R M] (h : 1 < Module.rank R M) {x : M} (hx : x ≠ 0) :
     ∃ y, LinearIndependent R ![x, y] := by
-  obtain ⟨y, hy⟩ := exists_linearIndependent_snoc_of_lt_rank (.of_subsingleton _ hx) h
+  obtain ⟨y, hy⟩ := exists_linearIndependent_snoc_of_lt_rank (.of_subsingleton (v := ![x]) 0 hx) h
   have : Fin.snoc ![x] y = ![x, y] := by simp [Fin.snoc, ← List.ofFn_inj]
   rw [this] at hy
   exact ⟨y, hy⟩

--- a/Mathlib/LinearAlgebra/FiniteDimensional/Basic.lean
+++ b/Mathlib/LinearAlgebra/FiniteDimensional/Basic.lean
@@ -534,7 +534,7 @@ section finrank_eq_one
 theorem finrank_eq_one_iff_of_nonzero (v : V) (nz : v ≠ 0) :
     finrank K V = 1 ↔ span K ({v} : Set V) = ⊤ where
   mp h := by simpa using (basisSingleton Unit h v nz).span_eq
-  mpr s := finrank_eq_card_basis <| .mk (.singleton nz) <| by simp [← s]
+  mpr s := finrank_eq_card_basis <| .mk (.of_subsingleton (v := ![v]) 0 nz) <| by simp [← s]
 
 /-- A module with a nonzero vector `v` has dimension 1 iff every vector is a multiple of `v`.
 -/

--- a/Mathlib/LinearAlgebra/FiniteDimensional/Basic.lean
+++ b/Mathlib/LinearAlgebra/FiniteDimensional/Basic.lean
@@ -532,11 +532,9 @@ section finrank_eq_one
 /-- A vector space with a nonzero vector `v` has dimension 1 iff `v` spans.
 -/
 theorem finrank_eq_one_iff_of_nonzero (v : V) (nz : v ≠ 0) :
-    finrank K V = 1 ↔ span K ({v} : Set V) = ⊤ :=
-  ⟨fun h => by simpa using (basisSingleton Unit h v nz).span_eq, fun s =>
-    finrank_eq_card_basis
-      (Basis.mk (LinearIndepOn.id_singleton _ nz)
-        (by simp [← s]))⟩
+    finrank K V = 1 ↔ span K ({v} : Set V) = ⊤ where
+  mp h := by simpa using (basisSingleton Unit h v nz).span_eq
+  mpr s := finrank_eq_card_basis <| .mk (.singleton nz) <| by simp [← s]
 
 /-- A module with a nonzero vector `v` has dimension 1 iff every vector is a multiple of `v`.
 -/

--- a/Mathlib/LinearAlgebra/LinearIndependent/Basic.lean
+++ b/Mathlib/LinearAlgebra/LinearIndependent/Basic.lean
@@ -272,15 +272,9 @@ alias LinearIndependent.linearCombination_ne_of_not_mem_support :=
 
 end Subtype
 
-section union
-
-open LinearMap Finsupp
-
 theorem LinearIndepOn.id_imageₛ {s : Set M} {f : M →ₗ[R] M'} (hs : LinearIndepOn R id s)
     (hf_inj : Set.InjOn f (span R s)) : LinearIndepOn R id (f '' s) :=
   id_image <| hs.map_injOn f (by simpa using hf_inj)
-
-end union
 
 theorem surjective_of_linearIndependent_of_span [Nontrivial R] (hv : LinearIndependent R v)
     (f : ι' ↪ ι) (hss : range v ⊆ span R (range (v ∘ f))) : Surjective f := by
@@ -559,30 +553,21 @@ theorem linearIndependent_monoidHom (G : Type*) [MulOneClass G] (L : Type*) [Com
 end Module
 
 section Nontrivial
+variable [Ring R] [AddCommGroup M] [Module R M] [Nontrivial R] [NoZeroSMulDivisors R M]
+  {v : ι → M} {i : ι}
 
-variable [Ring R] [Nontrivial R] [AddCommGroup M]
-variable [Module R M] [NoZeroSMulDivisors R M]
-variable {s t : Set M}
+lemma linearIndependent_unique_iff [Unique ι] : LinearIndependent R v ↔ v default ≠ 0 := by
+  refine ⟨?_, .of_subsingleton _⟩
+  simpa [linearIndependent_iff, Finsupp.linearCombination_unique, Finsupp.ext_iff,
+    Unique.forall_iff, or_imp] using fun h hv ↦ by simpa using h (.single default 1) hv
 
-theorem linearIndependent_unique_iff (v : ι → M) [Unique ι] :
-    LinearIndependent R v ↔ v default ≠ 0 := by
-  simp only [linearIndependent_iff, Finsupp.linearCombination_unique, smul_eq_zero]
-  refine ⟨fun h hv => ?_, fun hv l hl => Finsupp.unique_ext <| hl.resolve_right hv⟩
-  have := h (Finsupp.single default 1) (Or.inr hv)
-  exact one_ne_zero (Finsupp.single_eq_zero.1 this)
-
+@[deprecated LinearIndependent.of_subsingleton (since := "2025-11-11")]
 alias ⟨_, linearIndependent_unique⟩ := linearIndependent_unique_iff
 
 variable (R) in
 @[simp]
-theorem linearIndepOn_singleton_iff {i : ι} {v : ι → M} : LinearIndepOn R v {i} ↔ v i ≠ 0 :=
-  ⟨fun h ↦ h.ne_zero rfl, fun h ↦ linearIndependent_unique _ h⟩
-
-alias ⟨_, LinearIndepOn.singleton⟩ := linearIndepOn_singleton_iff
-
-variable (R) in
-theorem LinearIndepOn.id_singleton {x : M} (hx : x ≠ 0) : LinearIndepOn R id {x} :=
-  linearIndependent_unique Subtype.val hx
+theorem linearIndepOn_singleton_iff : LinearIndepOn R v {i} ↔ v i ≠ 0 :=
+  ⟨fun h ↦ h.ne_zero rfl, .singleton⟩
 
 @[simp]
 theorem linearIndependent_subsingleton_index_iff [Subsingleton ι] (f : ι → M) :

--- a/Mathlib/LinearAlgebra/LinearIndependent/Defs.lean
+++ b/Mathlib/LinearAlgebra/LinearIndependent/Defs.lean
@@ -702,9 +702,9 @@ end Semiring
 
 section Module
 
-variable {v : ι → M}
 variable [Ring R] [AddCommGroup M] [AddCommGroup M']
 variable [Module R M] [Module R M']
+variable {v : ι → M} {i : ι}
 
 theorem linearIndependent_iff_ker :
     LinearIndependent R v ↔ LinearMap.ker (Finsupp.linearCombination R v) = ⊥ :=
@@ -855,6 +855,27 @@ theorem linearIndependent_iff_eq_zero_of_smul_mem_span :
             hj ((mem_diff _).2 ⟨mem_univ _, fun h => hij (eq_of_mem_singleton h)⟩)
         simp [hij]
       · simp [hl]⟩
+
+lemma LinearIndependent.of_subsingleton' [Subsingleton ι] (i : ι)
+    (hi : ∀ r : R, r • v i = 0 → r = 0) : LinearIndependent R v := by
+  let := uniqueOfSubsingleton i
+  simpa [linearIndependent_iff, Finsupp.linearCombination_unique, Finsupp.ext_iff,
+    Unique.forall_iff] using fun _ ↦ hi _
+
+@[simp]
+lemma LinearIndepOn.singleton' (hi : ∀ r : R, r • v i = 0 → r = 0) : LinearIndepOn R v {i} :=
+  LinearIndependent.of_subsingleton' ⟨i, rfl⟩ hi
+
+variable [NoZeroSMulDivisors R M]
+
+lemma LinearIndependent.of_subsingleton [Subsingleton ι] (i : ι) (hi : v i ≠ 0) :
+    LinearIndependent R v := .of_subsingleton' i (by simp [hi])
+
+lemma LinearIndepOn.singleton (hi : v i ≠ 0) : LinearIndepOn R v {i} := by simp [hi]
+
+variable (R) in
+@[deprecated LinearIndepOn.singleton (since := "2025-11-11")]
+lemma LinearIndepOn.id_singleton {x : M} (hx : x ≠ 0) : LinearIndepOn R id {x} := .singleton hx
 
 end Module
 

--- a/Mathlib/LinearAlgebra/LinearIndependent/Defs.lean
+++ b/Mathlib/LinearAlgebra/LinearIndependent/Defs.lean
@@ -856,12 +856,14 @@ theorem linearIndependent_iff_eq_zero_of_smul_mem_span :
         simp [hij]
       · simp [hl]⟩
 
+/-- Version of `LinearIndependent.of_subsingleton` that works for the zero ring. -/
 lemma LinearIndependent.of_subsingleton' [Subsingleton ι] (i : ι)
     (hi : ∀ r : R, r • v i = 0 → r = 0) : LinearIndependent R v := by
   let := uniqueOfSubsingleton i
   simpa [linearIndependent_iff, Finsupp.linearCombination_unique, Finsupp.ext_iff,
     Unique.forall_iff] using fun _ ↦ hi _
 
+/-- Version of `LinearIndepOn.singleton` that works for the zero ring. -/
 @[simp]
 lemma LinearIndepOn.singleton' (hi : ∀ r : R, r • v i = 0 → r = 0) : LinearIndepOn R v {i} :=
   LinearIndependent.of_subsingleton' ⟨i, rfl⟩ hi

--- a/Mathlib/LinearAlgebra/LinearIndependent/Lemmas.lean
+++ b/Mathlib/LinearAlgebra/LinearIndependent/Lemmas.lean
@@ -480,6 +480,17 @@ lemma LinearMap.bijective_of_linearIndependent_of_span_eq_top {N : Type*} [AddCo
   rw [Set.range_comp, ← Submodule.map_span, hv, Submodule.map_top] at hsp
   rwa [← range_eq_top]
 
+lemma LinearIndepOn.insert' {s : Set ι} {i : ι} (hs : LinearIndepOn R v s)
+    (hx : ∀ r : R, r • v i ∈ Submodule.span R (v '' s) → r = 0) :
+    LinearIndepOn R v (insert i s) := by
+  rw [← Set.union_singleton]
+  refine hs.union (.singleton' fun r hr ↦ hx _ <| by simp [hr]) ?_
+  simp +contextual [disjoint_span_singleton'', hx]
+
+lemma LinearIndepOn.id_insert' {s : Set M} {x : M} (hs : LinearIndepOn R id s)
+    (hx : ∀ r : R, r • x ∈ Submodule.span R s → r = 0) : LinearIndepOn R id (insert x s) :=
+  hs.insert' <| by simpa
+
 end Module
 
 /-!
@@ -512,7 +523,7 @@ protected theorem LinearIndepOn.insert {s : Set ι} {x : ι} (hs : LinearIndepOn
     (hx : v x ∉ span K (v '' s)) : LinearIndepOn K v (insert x s) := by
   rw [← union_singleton]
   have x0 : v x ≠ 0 := fun h => hx (h ▸ zero_mem _)
-  apply hs.union (LinearIndepOn.singleton _ x0)
+  apply hs.union (LinearIndepOn.singleton x0)
   rwa [image_singleton, disjoint_span_singleton' x0]
 
 protected theorem LinearIndepOn.id_insert (hs : LinearIndepOn K id s) (hx : x ∉ span K s) :
@@ -589,9 +600,8 @@ theorem LinearIndepOn.notMem_span_iff_id {s : Set V} {a : V} (h : LinearIndepOn 
 alias LinearIndepOn.not_mem_span_iff_id := LinearIndepOn.notMem_span_iff_id
 
 theorem linearIndepOn_id_pair {x y : V} (hx : x ≠ 0) (hy : ∀ a : K, a • x ≠ y) :
-    LinearIndepOn K id {x, y} :=
-  pair_comm y x ▸ (LinearIndepOn.id_singleton K hx).id_insert (x := y) <|
-    mt mem_span_singleton.1 <| not_exists.2 hy
+    LinearIndepOn K id {x, y} := by
+  rw [pair_comm]; exact .id_insert (.singleton hx) <| by simpa [mem_span_singleton]
 
 /-- `LinearIndepOn.pair_iff` is a version that works over arbitrary rings. -/
 theorem linearIndepOn_pair_iff {i j : ι} (v : ι → V) (hij : i ≠ j) (hi : v i ≠ 0) :

--- a/Mathlib/LinearAlgebra/LinearIndependent/Lemmas.lean
+++ b/Mathlib/LinearAlgebra/LinearIndependent/Lemmas.lean
@@ -480,6 +480,7 @@ lemma LinearMap.bijective_of_linearIndependent_of_span_eq_top {N : Type*} [AddCo
   rw [Set.range_comp, ← Submodule.map_span, hv, Submodule.map_top] at hsp
   rwa [← range_eq_top]
 
+/-- Version of `LinearIndepOn.insert` that works when the scalars are not a field. -/
 lemma LinearIndepOn.insert' {s : Set ι} {i : ι} (hs : LinearIndepOn R v s)
     (hx : ∀ r : R, r • v i ∈ Submodule.span R (v '' s) → r = 0) :
     LinearIndepOn R v (insert i s) := by
@@ -487,6 +488,7 @@ lemma LinearIndepOn.insert' {s : Set ι} {i : ι} (hs : LinearIndepOn R v s)
   refine hs.union (.singleton' fun r hr ↦ hx _ <| by simp [hr]) ?_
   simp +contextual [disjoint_span_singleton'', hx]
 
+/-- Version of `LinearIndepOn.id_insert` that works when the scalars are not a field. -/
 lemma LinearIndepOn.id_insert' {s : Set M} {x : M} (hs : LinearIndepOn R id s)
     (hx : ∀ r : R, r • x ∈ Submodule.span R s → r = 0) : LinearIndepOn R id (insert x s) :=
   hs.insert' <| by simpa

--- a/Mathlib/LinearAlgebra/Span/Basic.lean
+++ b/Mathlib/LinearAlgebra/Span/Basic.lean
@@ -589,6 +589,10 @@ theorem map_strict_mono_of_ker_inf_eq {f : F} (hab : p < p')
     (q : LinearMap.ker f ⊓ p = LinearMap.ker f ⊓ p') : Submodule.map f p < Submodule.map f p' :=
   map_strict_mono_or_ker_sup_lt_ker_sup f hab |>.resolve_right q.not_lt
 
+lemma disjoint_span_singleton'' {s : Submodule R M} {x : M} :
+    Disjoint s (R ∙ x) ↔ ∀ r : R, r • x ∈ s → r • x = 0 := by
+  rw [disjoint_comm]; simp +contextual [disjoint_def, mem_span_singleton]
+
 end Ring
 
 section DivisionRing
@@ -612,21 +616,14 @@ theorem covBy_span_singleton_sup {x : V} {s : Submodule K V} (h : x ∉ s) : Cov
   ⟨by simpa, (wcovBy_span_singleton_sup _ _).2⟩
 
 theorem disjoint_span_singleton : Disjoint s (K ∙ x) ↔ x ∈ s → x = 0 := by
-  refine disjoint_def.trans ⟨fun H hx => H x hx <| subset_span <| mem_singleton x, ?_⟩
-  intro H y hy hyx
-  obtain ⟨c, rfl⟩ := mem_span_singleton.1 hyx
-  by_cases hc : c = 0
-  · rw [hc, zero_smul]
-  · rw [s.smul_mem_iff hc] at hy
-    rw [H hy, smul_zero]
+  simpa +contextual [disjoint_span_singleton'', or_iff_not_imp_left, forall_swap (β := ¬_),
+    s.smul_mem_iff] using ⟨fun h ↦ h _ one_ne_zero, fun h _ _ ↦ h⟩
 
-theorem disjoint_span_singleton' (x0 : x ≠ 0) : Disjoint s (K ∙ x) ↔ x ∉ s :=
-  disjoint_span_singleton.trans ⟨fun h₁ h₂ => x0 (h₁ h₂), fun h₁ h₂ => (h₁ h₂).elim⟩
+theorem disjoint_span_singleton' (hx : x ≠ 0) : Disjoint s (K ∙ x) ↔ x ∉ s := by
+  simp [disjoint_span_singleton, hx]
 
 lemma disjoint_span_singleton_of_notMem (hx : x ∉ s) : Disjoint s (K ∙ x) := by
-  rw [disjoint_span_singleton]
-  intro h
-  contradiction
+  simp [disjoint_span_singleton, hx]
 
 @[deprecated (since := "2025-05-23")]
 alias disjoint_span_singleton_of_not_mem := disjoint_span_singleton_of_notMem

--- a/Mathlib/LinearAlgebra/Span/Basic.lean
+++ b/Mathlib/LinearAlgebra/Span/Basic.lean
@@ -589,6 +589,7 @@ theorem map_strict_mono_of_ker_inf_eq {f : F} (hab : p < p')
     (q : LinearMap.ker f ⊓ p = LinearMap.ker f ⊓ p') : Submodule.map f p < Submodule.map f p' :=
   map_strict_mono_or_ker_sup_lt_ker_sup f hab |>.resolve_right q.not_lt
 
+/-- Version of `disjoint_span_singleton` that works when the scalars are not a field. -/
 lemma disjoint_span_singleton'' {s : Submodule R M} {x : M} :
     Disjoint s (R ∙ x) ↔ ∀ r : R, r • x ∈ s → r • x = 0 := by
   rw [disjoint_comm]; simp +contextual [disjoint_def, mem_span_singleton]

--- a/Mathlib/Topology/Category/Profinite/Nobeling/ZeroLimit.lean
+++ b/Mathlib/Topology/Category/Profinite/Nobeling/ZeroLimit.lean
@@ -91,9 +91,8 @@ instance (α : Type*) [TopologicalSpace α] : IsAddTorsionFree (LocallyConstant 
   LocallyConstant.coe_injective.isAddTorsionFree LocallyConstant.coeFnAddMonoidHom
 
 theorem GoodProducts.linearIndependentSingleton {I} [LinearOrder I] :
-    LinearIndependent ℤ (eval ({fun _ ↦ false} : Set (I → Bool))) := by
-  refine linearIndependent_unique (eval ({fun _ ↦ false} : Set (I → Bool))) ?_
-  simp [eval, Products.eval, Products.nil, default]
+    LinearIndependent ℤ (eval ({fun _ ↦ false} : Set (I → Bool))) :=
+  .of_subsingleton default <| by simp [eval, Products.eval, Products.nil, default]
 
 end Zero
 


### PR DESCRIPTION
---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

When merging, all the commits will be squashed into a single commit
listing all co-authors.

Co-authors in the squash commit are gathered from two sources:

First, all authors of commits to this PR branch are included. Thus,
one way to add co-authors is to include at least one commit authored by
each co-author among the commits in the pull request. If necessary, you
may create empty commits to indicate co-authorship, using commands like so:

git commit --author="Author Name <author@email.com>" --allow-empty -m "add Author Name as coauthor"

Second, co-authors can also be listed in lines at the very bottom of
the commit message (that is, directly before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines
at the bottom of the commit message (before the `---`, and also before
any "Co-authored-by" lines) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
