### PR TITLE
[Merged by Bors] - fix(grw): use `Expr.cleanupAnnotations`

### DIFF
--- a/Mathlib/Tactic/GCongr/Core.lean
+++ b/Mathlib/Tactic/GCongr/Core.lean
@@ -196,7 +196,8 @@ def getCongrAppFnArgs (e : Expr) : Option (Name × Array Expr) :=
       some (`_Implies, #[d, b])
   | e => e.withApp fun f args => f.constName?.map (·, args)
 
-/-- If `e` is of the form `r a b`, return `(r, a, b)`. -/
+/-- If `e` is of the form `r a b`, return `(r, a, b)`.
+Note: we assume that `e` does not have an `Expr.mdata` annotation. -/
 def getRel (e : Expr) : Option (Name × Expr × Expr) :=
   match e with
   | .app (.app rel lhs) rhs => rel.getAppFn.constName?.map (·, lhs, rhs)

--- a/Mathlib/Tactic/GRewrite/Core.lean
+++ b/Mathlib/Tactic/GRewrite/Core.lean
@@ -78,6 +78,8 @@ def _root_.Lean.MVarId.grewrite (goal : MVarId) (e : Expr) (hrel : Expr)
         pure none
     let (newMVars, binderInfos, hrelType) ←
       withReducible <| forallMetaTelescopeReducing hrelType maxMVars?
+    /- We don't reduce `hrelType` because if it is `a > b`, turning it into `b < a` would
+    reverse the direction of the rewrite. However, we do need to clear metadata annotations. -/
     let hrelType := hrelType.cleanupAnnotations
 
     -- If we can use the normal `rewrite` tactic, we default to using that.

--- a/Mathlib/Tactic/GRewrite/Core.lean
+++ b/Mathlib/Tactic/GRewrite/Core.lean
@@ -78,6 +78,7 @@ def _root_.Lean.MVarId.grewrite (goal : MVarId) (e : Expr) (hrel : Expr)
         pure none
     let (newMVars, binderInfos, hrelType) ←
       withReducible <| forallMetaTelescopeReducing hrelType maxMVars?
+    let hrelType := hrelType.cleanupAnnotations
 
     -- If we can use the normal `rewrite` tactic, we default to using that.
     if (hrelType.isAppOfArity ``Iff 2 || hrelType.isAppOfArity ``Eq 3) && config.useRewrite then

--- a/MathlibTest/GRewrite.lean
+++ b/MathlibTest/GRewrite.lean
@@ -341,7 +341,7 @@ example (h : b ≈ a) : f a ≤ f b := by
 
 end AntiSymmRelTest
 
--- test that we use `Expr.clearupAnnotations`
+-- Test that `grw` works even in the presence of metadata.
 example (a b : Nat) (h : Nat → no_index (a ≤ b)) : a ≤ b := by
   grw [h]
   exact 0

--- a/MathlibTest/GRewrite.lean
+++ b/MathlibTest/GRewrite.lean
@@ -340,3 +340,11 @@ example (h : b ≈ a) : f a ≤ f b := by
   grw [h]
 
 end AntiSymmRelTest
+
+-- test that we use `Expr.clearupAnnotations`
+example (a b : Nat) (h : Nat → no_index (a ≤ b)) : a ≤ b := by
+  grw [h]
+  exact 0
+
+example (a b : Nat) (h : Nat → no_index (a ≤ b)) : a ≤ b := by
+  grw [h 0]


### PR DESCRIPTION
This bug was found by Bhavik.

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

When merging, all the commits will be squashed into a single commit
listing all co-authors.

Co-authors in the squash commit are gathered from two sources:

First, all authors of commits to this PR branch are included. Thus,
one way to add co-authors is to include at least one commit authored by
each co-author among the commits in the pull request. If necessary, you
may create empty commits to indicate co-authorship, using commands like so:

git commit --author="Author Name <author@email.com>" --allow-empty -m "add Author Name as coauthor"

Second, co-authors can also be listed in lines at the very bottom of
the commit message (that is, directly before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines
at the bottom of the commit message (before the `---`, and also before
any "Co-authored-by" lines) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
