### PR TITLE
[Merged by Bors] - doc(FieldTheory): ensure only a single H1 header per file

### DIFF
--- a/Mathlib/FieldTheory/Galois/GaloisClosure.lean
+++ b/Mathlib/FieldTheory/Galois/GaloisClosure.lean
@@ -19,7 +19,7 @@ In a field extension `K/k`
 * `adjoin` : The finite Galois intermediate field obtained from the normal closure of adjoining a
   finite `s : Set K` to `k`.
 
-# TODO
+## TODO
 
 * `FiniteGaloisIntermediateField` should be a `ConditionallyCompleteLattice` but isn't proved yet.
 

--- a/Mathlib/FieldTheory/Galois/Infinite.lean
+++ b/Mathlib/FieldTheory/Galois/Infinite.lean
@@ -15,7 +15,7 @@ open subgroups and normal subgroups. We first verify that `IntermediateField.fix
 `IntermediateField.fixedField` are inverses of each other between intermediate fields and
 closed subgroups of the Galois group.
 
-# Main definitions and results
+## Main definitions and results
 
 In `K/k`, for any intermediate field `L` :
 

--- a/Mathlib/FieldTheory/Galois/Profinite.lean
+++ b/Mathlib/FieldTheory/Galois/Profinite.lean
@@ -16,7 +16,7 @@ In this file, we prove that given a field extension `K/k`, there is a continuous
 `Gal(K/k)` and the limit of `Gal(L/k)`, where `L` is a finite Galois intermediate field ordered by
 inverse inclusion, thus making `Gal(K/k)` profinite as a limit of finite groups.
 
-# Main definitions and results
+## Main definitions and results
 
 In a field extension `K/k`
 


### PR DESCRIPTION
This PR ensures we only have a single H1 header per lean file in the `FieldTheory` subdirectory. We do this for the following reasons:

- Having more than one H1 header per file is likely to hamper both assistive technologies and SEO, since it introduces ambiguity about what the title of the resulting documentation webpage actually is.
- The [documentation style guide](https://leanprover-community.github.io/contribute/doc.html) asks for the title of the file to be H1, any other header in the file-level docstring to be H2, and sectioning headers to be H3.

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

When merging, all the commits will be squashed into a single commit
listing all co-authors.

Co-authors in the squash commit are gathered from two sources:

First, all authors of commits to this PR branch are included. Thus,
one way to add co-authors is to include at least one commit authored by
each co-author among the commits in the pull request. If necessary, you
may create empty commits to indicate co-authorship, using commands like so:

git commit --author="Author Name <author@email.com>" --allow-empty -m "add Author Name as coauthor"

Second, co-authors can also be listed in lines at the very bottom of
the commit message (that is, directly before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines
at the bottom of the commit message (before the `---`, and also before
any "Co-authored-by" lines) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
