### PR TITLE
[Merged by Bors] - doc(Geometry): ensure only a single H1 header per file

### DIFF
--- a/Mathlib/Geometry/Manifold/LocalDiffeomorph.lean
+++ b/Mathlib/Geometry/Manifold/LocalDiffeomorph.lean
@@ -252,7 +252,7 @@ lemma IsLocalDiffeomorph.isLocalDiffeomorphOn
     {f : M → N} (hf : IsLocalDiffeomorph I J n f) (s : Set M) : IsLocalDiffeomorphOn I J n f s :=
   fun x ↦ hf x
 
-/-! # Basic properties of local diffeomorphisms -/
+/-! ### Basic properties of local diffeomorphisms -/
 section Basic
 variable {f : M → N} {s : Set M} {x : M}
 variable {I J n}

--- a/Mathlib/Geometry/Manifold/Riemannian/Basic.lean
+++ b/Mathlib/Geometry/Manifold/Riemannian/Basic.lean
@@ -82,7 +82,7 @@ end
 section
 
 /-!
-# Riemannian structure on an inner product vector space
+### Riemannian structure on an inner product vector space
 
 We endow an inner product vector space with the canonical Riemannian metric, given by the
 inner product of the vector space in each of the tangent spaces, and we show that this construction
@@ -179,7 +179,7 @@ end
 section
 
 /-!
-# Constructing a distance from a Riemannian structure
+### Constructing a distance from a Riemannian structure
 
 Let `M` be a real manifold with a Riemannian structure. We construct the associated distance and
 show that the associated topology coincides with the pre-existing topology. Therefore, one may

--- a/Mathlib/Geometry/Manifold/Sheaf/Smooth.lean
+++ b/Mathlib/Geometry/Manifold/Sheaf/Smooth.lean
@@ -36,7 +36,7 @@ functions from `M` to `𝕜` is a sheaf of commutative rings, the *structure she
   abelian Lie groups `A`, `A'`, the 'postcomposition-by-`φ`' morphism of sheaves from
   `smoothSheafCommGroup IM I M A` to `smoothSheafCommGroup IM I' M A'`
 
-# Main results
+## Main results
 
 * `smoothSheaf.eval_surjective`: `smoothSheaf.eval` is surjective.
 * `smoothSheafCommRing.eval_surjective`: `smoothSheafCommRing.eval` is surjective.

--- a/Mathlib/Geometry/Manifold/VectorBundle/LocalFrame.lean
+++ b/Mathlib/Geometry/Manifold/VectorBundle/LocalFrame.lean
@@ -59,7 +59,7 @@ Suppose `{sᵢ}` is a local frame on `U`, and `hs : IsLocalFrameOn s U`.
   ff all of its frame coefficients are
 * `MDifferentiable` versions of the above three statements
 
-# TODO
+## TODO
 * `IsLocalFrameOn.contMDiffOn_coeff hs`: if `t` is a `C^k` section, each coefficient
   `hs.coeff i t` is `C^k` on `U`
 * `IsLocalFrameOn.contMDiffAt_iff_coeff hs`: a section `t` is `C^k` at `x ∈ U`


### PR DESCRIPTION
This PR ensures we only have a single H1 header per lean file in the `Geometry` subdirectory. We do this for the following reasons:

- Having more than one H1 header per file is likely to hamper both assistive technologies and SEO, since it introduces ambiguity about what the title of the resulting documentation webpage actually is.
- The [documentation style guide](https://leanprover-community.github.io/contribute/doc.html) asks for the title of the file to be H1, any other header in the file-level docstring to be H2, and sectioning headers to be H3.

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

When merging, all the commits will be squashed into a single commit
listing all co-authors.

Co-authors in the squash commit are gathered from two sources:

First, all authors of commits to this PR branch are included. Thus,
one way to add co-authors is to include at least one commit authored by
each co-author among the commits in the pull request. If necessary, you
may create empty commits to indicate co-authorship, using commands like so:

git commit --author="Author Name <author@email.com>" --allow-empty -m "add Author Name as coauthor"

Second, co-authors can also be listed in lines at the very bottom of
the commit message (that is, directly before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines
at the bottom of the commit message (before the `---`, and also before
any "Co-authored-by" lines) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
