### PR TITLE
[Merged by Bors] - doc(LinearAlgebra): ensure only a single H1 header per file

### DIFF
--- a/Mathlib/LinearAlgebra/Matrix/Transvection.lean
+++ b/Mathlib/LinearAlgebra/Matrix/Transvection.lean
@@ -304,7 +304,7 @@ end TransvectionStruct
 end Transvection
 
 /-!
-# Reducing matrices by left and right multiplication by transvections
+### Reducing matrices by left and right multiplication by transvections
 
 In this section, we show that any matrix can be reduced to diagonal form by left and right
 multiplication by transvections (or, equivalently, by elementary operations on lines and columns).

--- a/Mathlib/LinearAlgebra/Projectivization/Independence.lean
+++ b/Mathlib/LinearAlgebra/Projectivization/Independence.lean
@@ -21,7 +21,7 @@ ambient vector space. Similarly for the definition of dependence.
 - A family of elements is dependent if and only if it is not independent.
 - Two elements are dependent if and only if they are equal.
 
-# Future Work
+## Future Work
 
 - Define collinearity in projective space.
 - Prove the axioms of a projective geometry are satisfied by the dependence relation.

--- a/Mathlib/LinearAlgebra/Quotient/Pi.lean
+++ b/Mathlib/LinearAlgebra/Quotient/Pi.lean
@@ -12,7 +12,7 @@ import Mathlib.LinearAlgebra.Quotient.Basic
 This file contains some results on the quotient of a module by a direct sum of submodules,
 and the direct sum of quotients of modules by submodules.
 
-# Main definitions
+## Main definitions
 
 * `Submodule.piQuotientLift`: create a map out of the direct sum of quotients
 * `Submodule.quotientPiLift`: create a map out of the quotient of a direct sum


### PR DESCRIPTION
This PR ensures we only have a single H1 header per lean file in the `LinearAlgebra` subdirectory. We do this for the following reasons:

- Having more than one H1 header per file is likely to hamper both assistive technologies and SEO, since it introduces ambiguity about what the title of the resulting documentation webpage actually is.
- The [documentation style guide](https://leanprover-community.github.io/contribute/doc.html) asks for the title of the file to be H1, any other header in the file-level docstring to be H2, and sectioning headers to be H3.

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

When merging, all the commits will be squashed into a single commit
listing all co-authors.

Co-authors in the squash commit are gathered from two sources:

First, all authors of commits to this PR branch are included. Thus,
one way to add co-authors is to include at least one commit authored by
each co-author among the commits in the pull request. If necessary, you
may create empty commits to indicate co-authorship, using commands like so:

git commit --author="Author Name <author@email.com>" --allow-empty -m "add Author Name as coauthor"

Second, co-authors can also be listed in lines at the very bottom of
the commit message (that is, directly before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines
at the bottom of the commit message (before the `---`, and also before
any "Co-authored-by" lines) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
