### PR TITLE
[Merged by Bors] - feat: Add multiplicative version of structure theorem for finitely generated abelian groups

### DIFF
--- a/Mathlib/GroupTheory/FiniteAbelian/Basic.lean
+++ b/Mathlib/GroupTheory/FiniteAbelian/Basic.lean
@@ -13,6 +13,7 @@ import Mathlib.Data.ZMod.QuotientRing
 * `AddCommGroup.equiv_free_prod_directSum_zmod` : Any finitely generated abelian group is the
   product of a power of `ℤ` and a direct sum of some `ZMod (p i ^ e i)` for some prime powers
   `p i ^ e i`.
+* `CommGroup.equiv_free_prod_prod_multiplicative_zmod` is a version for multiplicative groups.
 * `AddCommGroup.equiv_directSum_zmod_of_finite` : Any finite abelian group is a direct sum of
   some `ZMod (p i ^ e i)` for some prime powers `p i ^ e i`.
 * `CommGroup.equiv_prod_multiplicative_zmod_of_finite` is a version for multiplicative groups.
@@ -172,5 +173,22 @@ theorem equiv_prod_multiplicative_zmod_of_finite (G : Type*) [CommGroup G] [Fini
   obtain ⟨ι, inst, n, h₁, h₂⟩ := AddCommGroup.equiv_directSum_zmod_of_finite' (Additive G)
   exact ⟨ι, inst, n, h₁, ⟨MulEquiv.toAdditive.symm <| h₂.some.trans <|
     (DirectSum.addEquivProd _).trans (MulEquiv.piMultiplicative _).toAdditiveRight⟩⟩
+
+/-- The **Structure theorem of finitely generated abelian groups** in a multiplicative version :
+    Any finitely generated abelian group is the product of a power of `ℤ`
+    and a direct product of some `ZMod (p i ^ e i)` for some prime powers `p i ^ e i`. -/
+theorem equiv_free_prod_prod_multiplicative_zmod (G : Type*) [CommGroup G] [hG : Group.FG G] :
+    ∃ (ι j : Type) (_ : Fintype ι) (_ : Fintype j) (p : ι → ℕ)
+    (_ : ∀ i, Nat.Prime <| p i) (e : ι → ℕ),
+      Nonempty <| G ≃* (j → Multiplicative ℤ) × ((i : ι) → Multiplicative (ZMod (p i ^ e i))) := by
+  obtain ⟨n, ι, inst, x, p, e, equiv⟩ := AddCommGroup.equiv_free_prod_directSum_zmod (Additive G)
+  exact ⟨ι, (Fin n), inst, by infer_instance, x, p, e, ⟨MulEquiv.toAdditive (G := G).symm <|
+    equiv.some.trans <|
+    (((Finsupp.addEquivFunOnFinite.trans <|
+      (((AddEquiv.piAdditive _).trans
+        (AddEquiv.arrowCongr (Equiv.refl _) (AddEquiv.additiveMultiplicative ℤ)
+    )).symm)).prodCongr (DirectSum.addEquivProd _ )).trans <|
+    (AddEquiv.prodAdditive _ _).symm
+  )⟩⟩
 
 end CommGroup

--- a/Mathlib/GroupTheory/FiniteAbelian/Basic.lean
+++ b/Mathlib/GroupTheory/FiniteAbelian/Basic.lean
@@ -182,13 +182,9 @@ theorem equiv_free_prod_prod_multiplicative_zmod (G : Type*) [CommGroup G] [hG :
     (_ : ∀ i, Nat.Prime <| p i) (e : ι → ℕ),
       Nonempty <| G ≃* (j → Multiplicative ℤ) × ((i : ι) → Multiplicative (ZMod (p i ^ e i))) := by
   obtain ⟨n, ι, inst, x, p, e, equiv⟩ := AddCommGroup.equiv_free_prod_directSum_zmod (Additive G)
-  exact ⟨ι, (Fin n), inst, by infer_instance, x, p, e, ⟨MulEquiv.toAdditive (G := G).symm <|
-    equiv.some.trans <|
-    (((Finsupp.addEquivFunOnFinite.trans <|
-      (((AddEquiv.piAdditive _).trans
-        (AddEquiv.arrowCongr (Equiv.refl _) (AddEquiv.additiveMultiplicative ℤ)
-    )).symm)).prodCongr (DirectSum.addEquivProd _ )).trans <|
-    (AddEquiv.prodAdditive _ _).symm
-  )⟩⟩
+  exact ⟨ι, Fin n, inst, inferInstance, x, p, e, ⟨MulEquiv.toAdditive.symm <| equiv.some.trans <|
+    ((Finsupp.addEquivFunOnFinite.trans <| ((AddEquiv.piAdditive _).trans <|
+        (AddEquiv.additiveMultiplicative ℤ).arrowCongr (Equiv.refl _)).symm).prodCongr
+          (DirectSum.addEquivProd _ )).trans <| (AddEquiv.prodAdditive _ _).symm⟩⟩
 
 end CommGroup


### PR DESCRIPTION
This is similar to the multiplicative version of the structure theorem for *finite* abelian groups (using a pi type instead of a direct sum)


---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

When merging, all the commits will be squashed into a single commit
listing all co-authors.

Co-authors in the squash commit are gathered from two sources:

First, all authors of commits to this PR branch are included. Thus,
one way to add co-authors is to include at least one commit authored by
each co-author among the commits in the pull request. If necessary, you
may create empty commits to indicate co-authorship, using commands like so:

git commit --author="Author Name <author@email.com>" --allow-empty -m "add Author Name as coauthor"

Second, co-authors can also be listed in lines at the very bottom of
the commit message (that is, directly before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines
at the bottom of the commit message (before the `---`, and also before
any "Co-authored-by" lines) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
