### PR TITLE
[Merged by Bors] - chore: don't mention `PartENat` in other files

### DIFF
--- a/Mathlib/Algebra/Order/Sub/Defs.lean
+++ b/Mathlib/Algebra/Order/Sub/Defs.lean
@@ -14,7 +14,7 @@ This file proves lemmas relating (truncated) subtraction with an order. We provi
 `OrderedSub` stating that `a - b ≤ c ↔ a ≤ c + b`.
 
 The subtraction discussed here could both be normal subtraction in an additive group or truncated
-subtraction on a canonically ordered monoid (`ℕ`, `Multiset`, `PartENat`, `ENNReal`, ...)
+subtraction on a canonically ordered monoid (`ℕ`, `Multiset`, `ENNReal`, ...)
 
 ## Implementation details
 

--- a/Mathlib/Data/ENat/Basic.lean
+++ b/Mathlib/Data/ENat/Basic.lean
@@ -48,9 +48,6 @@ deriving instance Zero, CommSemiring, Nontrivial,
   NoZeroDivisors
   for ENat
 
--- In `Mathlib.Data.Nat.PartENat` proofs timed out when we included `deriving AddCommMonoidWithOne`,
--- and it seems to work without.
-
 namespace ENat
 
 variable {a b c m n : ℕ∞}

--- a/Mathlib/Data/Nat/PartENat.lean
+++ b/Mathlib/Data/Nat/PartENat.lean
@@ -12,7 +12,7 @@ import Mathlib.Tactic.NormNum
 # Natural numbers with infinity
 
 The natural numbers and an extra `top` element `⊤`. This implementation uses `Part ℕ` as an
-implementation. Use `ℕ∞` instead unless you care about computability.
+implementation. This version is deprecated, use `ℕ∞` instead.
 
 ## Main definitions
 

--- a/Mathlib/Data/Part.lean
+++ b/Mathlib/Data/Part.lean
@@ -17,9 +17,7 @@ a proof of the domain.
 for some `a : α`, while the domain of `o : Part α` doesn't have to be decidable. That means you can
 translate back and forth between a partial value with a decidable domain and an option, and
 `Option α` and `Part α` are classically equivalent. In general, `Part α` is bigger than `Option α`.
-In current mathlib, `Part ℕ`, aka `PartENat`, is used to move decidability of the order to
-decidability of `PartENat.find` (which is the smallest natural satisfying a predicate, or `∞` if
-there's none).
+
 ## Main declarations
 `Option`-like declarations:
 * `Part.none`: The partial value whose domain is `False`.

--- a/Mathlib/RingTheory/DiscreteValuationRing/Basic.lean
+++ b/Mathlib/RingTheory/DiscreteValuationRing/Basic.lean
@@ -29,7 +29,7 @@ Let R be an integral domain, assumed to be a principal ideal ring and a local ri
 
 ### Definitions
 
-* `addVal R : AddValuation R PartENat` : the additive valuation on a DVR.
+* `addVal R : AddValuation R ℕ∞` : the additive valuation on a DVR.
 * `toEuclideanDomain R : EuclideanDomain R` : a non-canonical structure of Euclidean domain on a
   DVR, where `x % y = 0` if `y ∣ x` and `x % y = x` otherwise. The GCD algorithm terminates in two
   steps.

--- a/Mathlib/RingTheory/PowerSeries/Order.lean
+++ b/Mathlib/RingTheory/PowerSeries/Order.lean
@@ -45,7 +45,7 @@ theorem exists_coeff_ne_zero_iff_ne_zero : (∃ n : ℕ, coeff n φ ≠ 0) ↔ �
   push_neg
   simp
 
-/-- The order of a formal power series `φ` is the greatest `n : PartENat`
+/-- The order of a formal power series `φ` is the greatest `n : ℕ∞`
 such that `X^n` divides `φ`. The order is `⊤` if and only if `φ = 0`. -/
 def order (φ : R⟦X⟧) : ℕ∞ :=
   letI := Classical.decEq R

--- a/Mathlib/Topology/Algebra/InfiniteSum/ENNReal.lean
+++ b/Mathlib/Topology/Algebra/InfiniteSum/ENNReal.lean
@@ -15,8 +15,7 @@ This file provides lemmas relating sums of constants to the cardinality of the d
 ## TODO
 
 + Once we have a topology on `ENat`, provide an `ENat`-valued version
-+ Once we replace `PartENat` entirely with `ENat` (and replace `PartENat.card` with a `ENat.card`),
-  provide versions which sum over the whole type.
++ Provide versions which sum over the whole type.
 -/
 
 open Set Function


### PR DESCRIPTION
---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

When merging, all the commits will be squashed into a single commit
listing all co-authors.

Co-authors in the squash commit are gathered from two sources:

First, all authors of commits to this PR branch are included. Thus,
one way to add co-authors is to include at least one commit authored by
each co-author among the commits in the pull request. If necessary, you
may create empty commits to indicate co-authorship, using commands like so:

git commit --author="Author Name <author@email.com>" --allow-empty -m "add Author Name as coauthor"

Second, co-authors can also be listed in lines at the very bottom of
the commit message (that is, directly before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines
at the bottom of the commit message (before the `---`, and also before
any "Co-authored-by" lines) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
