### PR TITLE
chore(Data/List): golf entire `drop_length_sub_one` using `ext; grind`

### DIFF
--- a/Mathlib/Data/List/TakeDrop.lean
+++ b/Mathlib/Data/List/TakeDrop.lean
@@ -69,13 +69,8 @@ theorem cons_get_drop_succ {l : List α} {n} :
   (drop_eq_getElem_cons n.2).symm
 
 lemma drop_length_sub_one {l : List α} (h : l ≠ []) : l.drop (l.length - 1) = [l.getLast h] := by
-  induction l with
-  | nil => aesop
-  | cons a l ih =>
-    by_cases hl : l = []
-    · simp_all
-    rw [length_cons, Nat.add_one_sub_one, List.drop_length_cons hl a]
-    simp [getLast_cons, hl]
+  ext
+  grind
 
 section TakeI
 


### PR DESCRIPTION
---
<details>
<summary>Show trace profiling of <code>drop_length_sub_one</code>: 131 ms before, 272 ms after </summary>

### Trace profiling of `drop_length_sub_one` before PR 31530
```diff
diff --git a/Mathlib/Data/List/TakeDrop.lean b/Mathlib/Data/List/TakeDrop.lean
index 7598f40935..efa3cdfbb1 100644
--- a/Mathlib/Data/List/TakeDrop.lean
+++ b/Mathlib/Data/List/TakeDrop.lean
@@ -68,6 +68,7 @@ theorem cons_get_drop_succ {l : List α} {n} :
     l.get n :: l.drop (n.1 + 1) = l.drop n.1 :=
   (drop_eq_getElem_cons n.2).symm
 
+set_option trace.profiler true in
 lemma drop_length_sub_one {l : List α} (h : l ≠ []) : l.drop (l.length - 1) = [l.getLast h] := by
   induction l with
   | nil => aesop
```
```
ℹ [436/436] Built Mathlib.Data.List.TakeDrop (1.2s)
info: Mathlib/Data/List/TakeDrop.lean:72:0: [Elab.async] [0.131338] elaborating proof of List.drop_length_sub_one
  [Elab.definition.value] [0.130820] List.drop_length_sub_one
    [Elab.step] [0.130582] induction l with
          | nil => aesop
          | cons a l ih =>
            by_cases hl : l = []
            · simp_all
            rw [length_cons, Nat.add_one_sub_one, List.drop_length_cons hl a]
            simp [getLast_cons, hl]
      [Elab.step] [0.130577] induction l with
            | nil => aesop
            | cons a l ih =>
              by_cases hl : l = []
              · simp_all
              rw [length_cons, Nat.add_one_sub_one, List.drop_length_cons hl a]
              simp [getLast_cons, hl]
        [Elab.step] [0.130571] induction l with
            | nil => aesop
            | cons a l ih =>
              by_cases hl : l = []
              · simp_all
              rw [length_cons, Nat.add_one_sub_one, List.drop_length_cons hl a]
              simp [getLast_cons, hl]
          [Elab.step] [0.124915] aesop
            [Elab.step] [0.124908] aesop
              [Elab.step] [0.124896] aesop
                [aesop.forward] [0.025181] building initial forward state
                [aesop] [0.017932] ✅️ (G0) [100.0000%] ⋯ ⊢ drop ([].length - 1) [] = [[].getLast h]
                  [aesop] [0.013220] ✅️ Safe rules
                [aesop] [0.014939] 🏁 (G1) [100.0000%] ⋯ ⊢ drop ([].length - 1) [] = [[].getLast h]
                  [aesop] [0.014777] 🏁 Normalisation
Build completed successfully (436 jobs).
```

### Trace profiling of `drop_length_sub_one` after PR 31530
```diff
diff --git a/Mathlib/Data/List/TakeDrop.lean b/Mathlib/Data/List/TakeDrop.lean
index 7598f40935..d5c64d154e 100644
--- a/Mathlib/Data/List/TakeDrop.lean
+++ b/Mathlib/Data/List/TakeDrop.lean
@@ -68,14 +68,10 @@ theorem cons_get_drop_succ {l : List α} {n} :
     l.get n :: l.drop (n.1 + 1) = l.drop n.1 :=
   (drop_eq_getElem_cons n.2).symm
 
+set_option trace.profiler true in
 lemma drop_length_sub_one {l : List α} (h : l ≠ []) : l.drop (l.length - 1) = [l.getLast h] := by
-  induction l with
-  | nil => aesop
-  | cons a l ih =>
-    by_cases hl : l = []
-    · simp_all
-    rw [length_cons, Nat.add_one_sub_one, List.drop_length_cons hl a]
-    simp [getLast_cons, hl]
+  ext
+  grind
 
 section TakeI
 
```
```
ℹ [436/436] Built Mathlib.Data.List.TakeDrop (1.4s)
info: Mathlib/Data/List/TakeDrop.lean:72:0: [Elab.async] [0.273157] elaborating proof of List.drop_length_sub_one
  [Elab.definition.value] [0.272410] List.drop_length_sub_one
    [Elab.step] [0.272252] 
          ext
          grind
      [Elab.step] [0.272245] 
            ext
            grind
        [Elab.step] [0.271667] grind
info: Mathlib/Data/List/TakeDrop.lean:74:2: [Elab.async] [0.030869] Lean.addDecl
  [Kernel] [0.030851] ✅️ typechecking declarations [List.drop_length_sub_one._proof_1_24]
Build completed successfully (436 jobs).
```
</details>

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

When merging, all the commits will be squashed into a single commit
listing all co-authors.

Co-authors in the squash commit are gathered from two sources:

First, all authors of commits to this PR branch are included. Thus,
one way to add co-authors is to include at least one commit authored by
each co-author among the commits in the pull request. If necessary, you
may create empty commits to indicate co-authorship, using commands like so:

git commit --author="Author Name <author@email.com>" --allow-empty -m "add Author Name as coauthor"

Second, co-authors can also be listed in lines at the very bottom of
the commit message (that is, directly before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines
at the bottom of the commit message (before the `---`, and also before
any "Co-authored-by" lines) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
