### PR TITLE
[Merged by Bors] - chore(Probability/ProbabilityMassFunction): golf entire `support_bindOnSupport` using `ext; simp`

### DIFF
--- a/Mathlib/Probability/ProbabilityMassFunction/Monad.lean
+++ b/Mathlib/Probability/ProbabilityMassFunction/Monad.lean
@@ -202,7 +202,9 @@ theorem bindOnSupport_apply (b : β) :
 theorem support_bindOnSupport :
     (p.bindOnSupport f).support = ⋃ (a : α) (h : a ∈ p.support), (f a h).support := by
   ext
-  simp
+  simp only [mem_support_iff, bindOnSupport_apply, ne_eq, ENNReal.tsum_eq_zero,
+    dite_eq_left_iff, mul_eq_zero, not_forall, not_or, and_exists_self,
+    Set.mem_iUnion]
 
 theorem mem_support_bindOnSupport_iff (b : β) :
     b ∈ (p.bindOnSupport f).support ↔ ∃ (a : α) (h : a ∈ p.support), b ∈ (f a h).support := by

--- a/Mathlib/Probability/ProbabilityMassFunction/Monad.lean
+++ b/Mathlib/Probability/ProbabilityMassFunction/Monad.lean
@@ -202,6 +202,7 @@ theorem bindOnSupport_apply (b : β) :
 theorem support_bindOnSupport :
     (p.bindOnSupport f).support = ⋃ (a : α) (h : a ∈ p.support), (f a h).support := by
   ext
+  -- `simp` suffices; squeezed for performance
   simp only [mem_support_iff, bindOnSupport_apply, ne_eq, ENNReal.tsum_eq_zero,
     dite_eq_left_iff, mul_eq_zero, not_forall, not_or, and_exists_self,
     Set.mem_iUnion]

--- a/Mathlib/Probability/ProbabilityMassFunction/Monad.lean
+++ b/Mathlib/Probability/ProbabilityMassFunction/Monad.lean
@@ -201,16 +201,8 @@ theorem bindOnSupport_apply (b : β) :
 @[simp]
 theorem support_bindOnSupport :
     (p.bindOnSupport f).support = ⋃ (a : α) (h : a ∈ p.support), (f a h).support := by
-  refine Set.ext fun b => ?_
-  simp only [ENNReal.tsum_eq_zero, not_or, mem_support_iff, bindOnSupport_apply, Ne, not_forall,
-    mul_eq_zero, Set.mem_iUnion]
-  exact
-    ⟨fun hb =>
-      let ⟨a, ⟨ha, ha'⟩⟩ := hb
-      ⟨a, ha, by simpa [ha] using ha'⟩,
-      fun hb =>
-      let ⟨a, ha, ha'⟩ := hb
-      ⟨a, ⟨ha, by simpa [(mem_support_iff _ a).1 ha] using ha'⟩⟩⟩
+  ext
+  simp
 
 theorem mem_support_bindOnSupport_iff (b : β) :
     b ∈ (p.bindOnSupport f).support ↔ ∃ (a : α) (h : a ∈ p.support), b ∈ (f a h).support := by


### PR DESCRIPTION
---
<details>
<summary>Show trace profiling of <code>support_bindOnSupport</code>: 85 ms before, 27 ms after  🎉</summary>

### Trace profiling of `support_bindOnSupport` before PR 31534
```diff
diff --git a/Mathlib/Probability/ProbabilityMassFunction/Monad.lean b/Mathlib/Probability/ProbabilityMassFunction/Monad.lean
index 876540f3fb..120616c4bd 100644
--- a/Mathlib/Probability/ProbabilityMassFunction/Monad.lean
+++ b/Mathlib/Probability/ProbabilityMassFunction/Monad.lean
@@ -198,6 +198,7 @@ variable {p : PMF α} (f : ∀ a ∈ p.support, PMF β)
 theorem bindOnSupport_apply (b : β) :
     p.bindOnSupport f b = ∑' a, p a * if h : p a = 0 then 0 else f a h b := rfl
 
+set_option trace.profiler true in
 @[simp]
 theorem support_bindOnSupport :
     (p.bindOnSupport f).support = ⋃ (a : α) (h : a ∈ p.support), (f a h).support := by
```
```
ℹ [1636/1636] Built Mathlib.Probability.ProbabilityMassFunction.Monad (1.7s)
info: Mathlib/Probability/ProbabilityMassFunction/Monad.lean:202:0: [Elab.async] [0.085915] elaborating proof of PMF.support_bindOnSupport
  [Elab.definition.value] [0.084841] PMF.support_bindOnSupport
    [Elab.step] [0.084554] 
          refine Set.ext fun b => ?_
          simp only [ENNReal.tsum_eq_zero, not_or, mem_support_iff, bindOnSupport_apply, Ne, not_forall, mul_eq_zero,
            Set.mem_iUnion]
          exact
            ⟨fun hb =>
              let ⟨a, ⟨ha, ha'⟩⟩ := hb
              ⟨a, ha, by simpa [ha] using ha'⟩,
              fun hb =>
              let ⟨a, ha, ha'⟩ := hb
              ⟨a, ⟨ha, by simpa [(mem_support_iff _ a).1 ha] using ha'⟩⟩⟩
      [Elab.step] [0.084547] 
            refine Set.ext fun b => ?_
            simp only [ENNReal.tsum_eq_zero, not_or, mem_support_iff, bindOnSupport_apply, Ne, not_forall, mul_eq_zero,
              Set.mem_iUnion]
            exact
              ⟨fun hb =>
                let ⟨a, ⟨ha, ha'⟩⟩ := hb
                ⟨a, ha, by simpa [ha] using ha'⟩,
                fun hb =>
                let ⟨a, ha, ha'⟩ := hb
                ⟨a, ⟨ha, by simpa [(mem_support_iff _ a).1 ha] using ha'⟩⟩⟩
        [Elab.step] [0.018660] simp only [ENNReal.tsum_eq_zero, not_or, mem_support_iff, bindOnSupport_apply, Ne,
              not_forall, mul_eq_zero, Set.mem_iUnion]
        [Elab.step] [0.065626] exact
              ⟨fun hb =>
                let ⟨a, ⟨ha, ha'⟩⟩ := hb
                ⟨a, ha, by simpa [ha] using ha'⟩,
                fun hb =>
                let ⟨a, ha, ha'⟩ := hb
                ⟨a, ⟨ha, by simpa [(mem_support_iff _ a).1 ha] using ha'⟩⟩⟩
          [Elab.step] [0.016407] expected type: (∃ x, ¬p x = 0 ∧ ¬(if h : p x = 0 then 0 else (f x h) b) = 0) ↔
                ∃ i, ∃ (h : ¬p i = 0), ¬(f i ⋯) b = 0, term
              ⟨fun hb =>
                let ⟨a, ⟨ha, ha'⟩⟩ := hb
                ⟨a, ha, by simpa [ha] using ha'⟩,
                fun hb =>
                let ⟨a, ha, ha'⟩ := hb
                ⟨a, ⟨ha, by simpa [(mem_support_iff _ a).1 ha] using ha'⟩⟩⟩
            [Elab.step] [0.016383] expected type: (∃ x, ¬p x = 0 ∧ ¬(if h : p x = 0 then 0 else (f x h) b) = 0) ↔
                  ∃ i, ∃ (h : ¬p i = 0), ¬(f i ⋯) b = 0, term
                Iff.intro✝
                  (fun hb =>
                    let ⟨a, ⟨ha, ha'⟩⟩ := hb
                    ⟨a, ha, by simpa [ha] using ha'⟩)
                  fun hb =>
                  let ⟨a, ha, ha'⟩ := hb
                  ⟨a, ⟨ha, by simpa [(mem_support_iff _ a).1 ha] using ha'⟩⟩
          [Elab.step] [0.025217] simpa [ha] using ha'
            [Elab.step] [0.025211] simpa [ha] using ha'
              [Elab.step] [0.025204] simpa [ha] using ha'
          [Elab.step] [0.023087] simpa [(mem_support_iff _ a).1 ha] using ha'
            [Elab.step] [0.023082] simpa [(mem_support_iff _ a).1 ha] using ha'
              [Elab.step] [0.023076] simpa [(mem_support_iff _ a).1 ha] using ha'
Build completed successfully (1636 jobs).
```

### Trace profiling of `support_bindOnSupport` after PR 31534
```diff
diff --git a/Mathlib/Probability/ProbabilityMassFunction/Monad.lean b/Mathlib/Probability/ProbabilityMassFunction/Monad.lean
index 876540f3fb..eac77ce041 100644
--- a/Mathlib/Probability/ProbabilityMassFunction/Monad.lean
+++ b/Mathlib/Probability/ProbabilityMassFunction/Monad.lean
@@ -198,19 +198,14 @@ variable {p : PMF α} (f : ∀ a ∈ p.support, PMF β)
 theorem bindOnSupport_apply (b : β) :
     p.bindOnSupport f b = ∑' a, p a * if h : p a = 0 then 0 else f a h b := rfl
 
+set_option trace.profiler true in
 @[simp]
 theorem support_bindOnSupport :
     (p.bindOnSupport f).support = ⋃ (a : α) (h : a ∈ p.support), (f a h).support := by
-  refine Set.ext fun b => ?_
-  simp only [ENNReal.tsum_eq_zero, not_or, mem_support_iff, bindOnSupport_apply, Ne, not_forall,
-    mul_eq_zero, Set.mem_iUnion]
-  exact
-    ⟨fun hb =>
-      let ⟨a, ⟨ha, ha'⟩⟩ := hb
-      ⟨a, ha, by simpa [ha] using ha'⟩,
-      fun hb =>
-      let ⟨a, ha, ha'⟩ := hb
-      ⟨a, ⟨ha, by simpa [(mem_support_iff _ a).1 ha] using ha'⟩⟩⟩
+  ext
+  simp only [mem_support_iff, bindOnSupport_apply, ne_eq, ENNReal.tsum_eq_zero,
+    dite_eq_left_iff, mul_eq_zero, not_forall, not_or, and_exists_self,
+    Set.mem_iUnion]
 
 theorem mem_support_bindOnSupport_iff (b : β) :
     b ∈ (p.bindOnSupport f).support ↔ ∃ (a : α) (h : a ∈ p.support), b ∈ (f a h).support := by
```
```
ℹ [1636/1636] Built Mathlib.Probability.ProbabilityMassFunction.Monad (1.6s)
info: Mathlib/Probability/ProbabilityMassFunction/Monad.lean:202:0: [Elab.async] [0.027228] elaborating proof of PMF.support_bindOnSupport
  [Elab.definition.value] [0.026530] PMF.support_bindOnSupport
    [Elab.step] [0.026091] 
          ext
          simp only [mem_support_iff, bindOnSupport_apply, ne_eq, ENNReal.tsum_eq_zero, dite_eq_left_iff, mul_eq_zero,
            not_forall, not_or, and_exists_self, Set.mem_iUnion]
      [Elab.step] [0.026083] 
            ext
            simp only [mem_support_iff, bindOnSupport_apply, ne_eq, ENNReal.tsum_eq_zero, dite_eq_left_iff, mul_eq_zero,
              not_forall, not_or, and_exists_self, Set.mem_iUnion]
        [Elab.step] [0.025849] simp only [mem_support_iff, bindOnSupport_apply, ne_eq, ENNReal.tsum_eq_zero,
              dite_eq_left_iff, mul_eq_zero, not_forall, not_or, and_exists_self, Set.mem_iUnion]
Build completed successfully (1636 jobs).
```
</details>

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

When merging, all the commits will be squashed into a single commit
listing all co-authors.

Co-authors in the squash commit are gathered from two sources:

First, all authors of commits to this PR branch are included. Thus,
one way to add co-authors is to include at least one commit authored by
each co-author among the commits in the pull request. If necessary, you
may create empty commits to indicate co-authorship, using commands like so:

git commit --author="Author Name <author@email.com>" --allow-empty -m "add Author Name as coauthor"

Second, co-authors can also be listed in lines at the very bottom of
the commit message (that is, directly before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines
at the bottom of the commit message (before the `---`, and also before
any "Co-authored-by" lines) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
