### PR TITLE
[Merged by Bors] - feat: small tweaks to `PointwiseConvergenceCLM`

### DIFF
--- a/Mathlib/Topology/Algebra/Module/PointwiseConvergence.lean
+++ b/Mathlib/Topology/Algebra/Module/PointwiseConvergence.lean
@@ -39,11 +39,12 @@ continuous if for every `x : E` the evaluation `g · x` is continuous.
 variable {α ι : Type*} [TopologicalSpace α]
 variable {𝕜 𝕜₁ 𝕜₂ : Type*} [NormedField 𝕜] [NormedField 𝕜₁] [NormedField 𝕜₂]
 variable {σ : 𝕜₁ →+* 𝕜₂}
-variable {E F : Type*} [AddCommGroup E] [TopologicalSpace E]
+variable {E F Fᵤ : Type*} [AddCommGroup E] [TopologicalSpace E]
   [AddCommGroup F] [TopologicalSpace F] [IsTopologicalAddGroup F]
-  [Module 𝕜 E] [Module 𝕜 F] [Module 𝕜₁ E] [Module 𝕜₂ F]
+  [AddCommGroup Fᵤ] [UniformSpace Fᵤ] [IsUniformAddGroup Fᵤ]
+  [Module 𝕜 E] [Module 𝕜 F] [Module 𝕜 Fᵤ] [Module 𝕜₁ E] [Module 𝕜₂ F] [Module 𝕜₂ Fᵤ]
 
-open Topology
+open Set Topology
 
 variable (σ E F) in
 /-- The space of continuous linear maps equipped with the topology of pointwise convergence,
@@ -61,6 +62,10 @@ notation:25 E " →Lₚₜ[" R "] " F => PointwiseConvergenceCLM (RingHom.id R) 
 
 namespace PointwiseConvergenceCLM
 
+instance continuousEvalConst : ContinuousEvalConst (E →SLₚₜ[σ] F) E F :=
+  UniformConvergenceCLM.continuousEvalConst _ _ _
+    (sUnion_eq_univ_iff.mpr fun x ↦ ⟨{x}, finite_singleton x, rfl⟩)
+
 protected theorem hasBasis_nhds_zero_of_basis
     {ι : Type*} {p : ι → Prop} {b : ι → Set F} (h : (𝓝 0 : Filter F).HasBasis p b) :
     (𝓝 (0 : E →SLₚₜ[σ] F)).HasBasis (fun Si : Set E × ι => Finite Si.1 ∧ p Si.2)
@@ -74,11 +79,17 @@ protected theorem hasBasis_nhds_zero :
       fun SV => { f : E →SLₚₜ[σ] F | ∀ x ∈ SV.1, f x ∈ SV.2 } :=
   PointwiseConvergenceCLM.hasBasis_nhds_zero_of_basis (𝓝 0).basis_sets
 
+variable (σ E Fᵤ) in
+protected theorem isUniformEmbedding_coeFn :
+    IsUniformEmbedding ((↑) : (E →SLₚₜ[σ] Fᵤ) → (E → Fᵤ)) :=
+  (UniformOnFun.isUniformEmbedding_toFun_finite E Fᵤ).comp
+    (UniformConvergenceCLM.isUniformEmbedding_coeFn σ Fᵤ _)
+
 variable (σ E F) in
 protected theorem isEmbedding_coeFn : IsEmbedding ((↑) : (E →SLₚₜ[σ] F) → (E → F)) :=
   let _: UniformSpace F := IsTopologicalAddGroup.toUniformSpace F
   have _ : IsUniformAddGroup F := isUniformAddGroup_of_addCommGroup
-  (UniformOnFun.isEmbedding_toFun_finite E F).comp (UniformConvergenceCLM.isEmbedding_coeFn σ F _)
+  PointwiseConvergenceCLM.isUniformEmbedding_coeFn σ E F |>.isEmbedding
 
 /-- In the topology of pointwise convergence, `a` converges to `a₀` iff for every `x : E` the map
 `a · x` converges to `a₀ x`. -/
@@ -102,13 +113,7 @@ variable (σ F) in
 @[simps!]
 def evalCLM [ContinuousConstSMul 𝕜₂ F] (a : E) : (E →SLₚₜ[σ] F) →L[𝕜₂] F where
   toLinearMap := (coeLMₛₗ σ E F).flip a
-  cont := by
-    apply continuous_of_continuousAt_zero (f := (coeLMₛₗ σ E F).flip a)
-    simp only [ContinuousAt, map_zero]
-    rw [PointwiseConvergenceCLM.hasBasis_nhds_zero.tendsto_left_iff]
-    intro s hs
-    use ({a}, s)
-    simpa [hs] using ⟨Set.finite_singleton _, fun _ hy ↦ by rwa [Set.mem_setOf_eq] at hy⟩
+  cont := continuous_eval_const a
 
 /-- A map to `E →SLₚₜ[σ] F` is continuous if for every `x : E` the evaluation `g · x` is
 continuous. -/


### PR DESCRIPTION
These are small suggestions I would have made about #11496: 
- add a `IsUniformEmbedding` variant of `isEmbedding_coeFn`
- add a `ContinuousEvalConst` instance using [UniformConvergenceCLM.continuousEvalConst](https://leanprover-community.github.io/mathlib4_docs/Mathlib/Topology/Algebra/Module/StrongTopology.html#UniformConvergenceCLM.continuousEvalConst)
- use said instance to golf continuity in `evalCLM`

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

When merging, all the commits will be squashed into a single commit
listing all co-authors.

Co-authors in the squash commit are gathered from two sources:

First, all authors of commits to this PR branch are included. Thus,
one way to add co-authors is to include at least one commit authored by
each co-author among the commits in the pull request. If necessary, you
may create empty commits to indicate co-authorship, using commands like so:

git commit --author="Author Name <author@email.com>" --allow-empty -m "add Author Name as coauthor"

Second, co-authors can also be listed in lines at the very bottom of
the commit message (that is, directly before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines
at the bottom of the commit message (before the `---`, and also before
any "Co-authored-by" lines) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
