### PR TITLE
[Merged by Bors] - feat: totally bounded sets have finite covers

### DIFF
--- a/Mathlib/Data/Rel/Cover.lean
+++ b/Mathlib/Data/Rel/Cover.lean
@@ -44,6 +44,11 @@ def IsCover (U : SetRel X X) (s N : Set X) : Prop := ∀ ⦃x⦄, x ∈ s → �
 protected nonrec lemma IsCover.nonempty (hsN : IsCover U s N) (hs : s.Nonempty) : N.Nonempty :=
   let ⟨_x, hx⟩ := hs; let ⟨y, hy, _⟩ := hsN hx; ⟨y, hy⟩
 
+@[simp] lemma IsCover.refl (U : SetRel X X) [U.IsRefl] (s : Set X) : IsCover U s s :=
+  fun a ha ↦ ⟨a, ha, U.rfl⟩
+
+lemma IsCover.rfl {U : SetRel X X} [U.IsRefl] {s : Set X} : IsCover U s s := refl U s
+
 @[simp] protected lemma isCover_univ : IsCover univ s N ↔ (s.Nonempty → N.Nonempty) := by
   simp [IsCover, Set.Nonempty]
 

--- a/Mathlib/Topology/MetricSpace/Cover.lean
+++ b/Mathlib/Topology/MetricSpace/Cover.lean
@@ -50,7 +50,8 @@ def IsCover (ε : ℝ≥0) (s N : Set X) : Prop := SetRel.IsCover {(x, y) | edis
 protected nonrec lemma IsCover.nonempty (hsN : IsCover ε s N) (hs : s.Nonempty) : N.Nonempty :=
   hsN.nonempty hs
 
-@[simp] lemma IsCover.self (ε : ℝ≥0) (s : Set X) : IsCover ε s s := fun a ha ↦ ⟨a, ha, by simp⟩
+@[simp] lemma IsCover.refl (ε : ℝ≥0) (s : Set X) : IsCover ε s s := fun a ha ↦ ⟨a, ha, by simp⟩
+lemma IsCover.rfl {ε : ℝ≥0} {s : Set X} : IsCover ε s s := refl ε s
 
 nonrec lemma IsCover.mono (hN : N₁ ⊆ N₂) (h₁ : IsCover ε s N₁) : IsCover ε s N₂ := h₁.mono hN
 
@@ -59,7 +60,7 @@ nonrec lemma IsCover.anti (hst : s ⊆ t) (ht : IsCover ε t N) : IsCover ε s N
 lemma IsCover.mono_radius (hεδ : ε ≤ δ) (hε : IsCover ε s N) : IsCover δ s N :=
   hε.mono_entourage fun xy hxy ↦ by dsimp at *; exact le_trans hxy <| mod_cast hεδ
 
-lemma isCover_singleton_of_ediam_le (hA : EMetric.diam s ≤ ε) (hx : x ∈ s) :
+lemma IsCover.singleton_of_ediam_le (hA : EMetric.diam s ≤ ε) (hx : x ∈ s) :
     IsCover ε s ({x} : Set X) :=
   fun _ h_mem ↦ ⟨x, by simp, (EMetric.edist_le_diam_of_mem h_mem hx).trans hA⟩
 
@@ -75,7 +76,7 @@ nonrec lemma IsCover.of_maximal_isSeparated (hN : Maximal (fun N ↦ N ⊆ s ∧
   .of_maximal_isSeparated <| by simpa [isSeparated_iff_setRelIsSeparated] using hN
 
 /-- A totally bounded set has finite `ε`-covers for all `ε > 0`. -/
-lemma _root_.TotallyBounded.exists_finite_isCover (hs : TotallyBounded s) (hε : ε ≠ 0) :
+lemma exists_finite_isCover_of_totallyBounded (hε : ε ≠ 0) (hs : TotallyBounded s) :
     ∃ N ⊆ s, N.Finite ∧ IsCover ε s N := by
   rw [EMetric.totallyBounded_iff'] at hs
   obtain ⟨N, hNA, hN_finite, hN⟩ := hs ε (mod_cast hε.bot_lt)
@@ -89,12 +90,12 @@ lemma _root_.TotallyBounded.exists_finite_isCover (hs : TotallyBounded s) (hε :
 /-- A relatively compact set admits a finite cover. -/
 lemma exists_finite_isCover_of_isCompact_closure (hε : ε ≠ 0) (hs : IsCompact (closure s)) :
     ∃ N ⊆ s, N.Finite ∧ IsCover ε s N :=
-  (hs.totallyBounded.subset subset_closure).exists_finite_isCover hε
+  exists_finite_isCover_of_totallyBounded hε (hs.totallyBounded.subset subset_closure)
 
 /-- A compact set admits a finite cover. -/
 lemma exists_finite_isCover_of_isCompact (hε : ε ≠ 0) (hs : IsCompact s) :
     ∃ N ⊆ s, N.Finite ∧ IsCover ε s N :=
-  hs.totallyBounded.exists_finite_isCover hε
+  exists_finite_isCover_of_totallyBounded hε hs.totallyBounded
 
 end PseudoEMetricSpace
 

--- a/Mathlib/Topology/MetricSpace/Cover.lean
+++ b/Mathlib/Topology/MetricSpace/Cover.lean
@@ -45,8 +45,12 @@ def IsCover (ε : ℝ≥0) (s N : Set X) : Prop := SetRel.IsCover {(x, y) | edis
 
 @[simp] protected nonrec lemma IsCover.empty : IsCover ε ∅ N := .empty
 
+@[simp] lemma isCover_empty_right : IsCover ε s ∅ ↔ s = ∅ := by simp [IsCover]
+
 protected nonrec lemma IsCover.nonempty (hsN : IsCover ε s N) (hs : s.Nonempty) : N.Nonempty :=
   hsN.nonempty hs
+
+@[simp] lemma IsCover.self (ε : ℝ≥0) (s : Set X) : IsCover ε s s := fun a ha ↦ ⟨a, ha, by simp⟩
 
 nonrec lemma IsCover.mono (hN : N₁ ⊆ N₂) (h₁ : IsCover ε s N₁) : IsCover ε s N₂ := h₁.mono hN
 
@@ -54,6 +58,10 @@ nonrec lemma IsCover.anti (hst : s ⊆ t) (ht : IsCover ε t N) : IsCover ε s N
 
 lemma IsCover.mono_radius (hεδ : ε ≤ δ) (hε : IsCover ε s N) : IsCover δ s N :=
   hε.mono_entourage fun xy hxy ↦ by dsimp at *; exact le_trans hxy <| mod_cast hεδ
+
+lemma isCover_singleton_of_ediam_le (hA : EMetric.diam s ≤ ε) (hx : x ∈ s) :
+    IsCover ε s ({x} : Set X) :=
+  fun _ h_mem ↦ ⟨x, by simp, (EMetric.edist_le_diam_of_mem h_mem hx).trans hA⟩
 
 lemma isCover_iff_subset_iUnion_emetricClosedBall :
     IsCover ε s N ↔ s ⊆ ⋃ y ∈ N, EMetric.closedBall y ε := by
@@ -66,6 +74,28 @@ nonrec lemma IsCover.of_maximal_isSeparated (hN : Maximal (fun N ↦ N ⊆ s ∧
     IsCover ε s N :=
   .of_maximal_isSeparated <| by simpa [isSeparated_iff_setRelIsSeparated] using hN
 
+/-- A totally bounded set has finite `ε`-covers for all `ε > 0`. -/
+lemma _root_.TotallyBounded.exists_finite_isCover (hs : TotallyBounded s) (hε : ε ≠ 0) :
+    ∃ N ⊆ s, N.Finite ∧ IsCover ε s N := by
+  rw [EMetric.totallyBounded_iff'] at hs
+  obtain ⟨N, hNA, hN_finite, hN⟩ := hs ε (mod_cast hε.bot_lt)
+  simp only [isCover_iff_subset_iUnion_emetricClosedBall]
+  refine ⟨N, by simpa, by simpa, ?_⟩
+  · refine hN.trans fun x hx ↦ ?_
+    simp only [Set.mem_iUnion, EMetric.mem_ball, exists_prop, EMetric.mem_closedBall] at hx ⊢
+    obtain ⟨y, hyN, hy⟩ := hx
+    exact ⟨y, hyN, hy.le⟩
+
+/-- A relatively compact set admits a finite cover. -/
+lemma exists_finite_isCover_of_isCompact_closure (hε : ε ≠ 0) (hs : IsCompact (closure s)) :
+    ∃ N ⊆ s, N.Finite ∧ IsCover ε s N :=
+  (hs.totallyBounded.subset subset_closure).exists_finite_isCover hε
+
+/-- A compact set admits a finite cover. -/
+lemma exists_finite_isCover_of_isCompact (hε : ε ≠ 0) (hs : IsCompact s) :
+    ∃ N ⊆ s, N.Finite ∧ IsCover ε s N :=
+  hs.totallyBounded.exists_finite_isCover hε
+
 end PseudoEMetricSpace
 
 section PseudoMetricSpace
@@ -76,23 +106,6 @@ lemma isCover_iff_subset_iUnion_closedBall : IsCover ε s N ↔ s ⊆ ⋃ y ∈ 
 
 alias ⟨IsCover.subset_iUnion_closedBall, IsCover.of_subset_iUnion_closedBall⟩ :=
   isCover_iff_subset_iUnion_closedBall
-
-/-- A relatively compact set admits a finite cover. -/
-lemma exists_finite_isCover_of_isCompact_closure (hε : ε ≠ 0) (hs : IsCompact (closure s)) :
-    ∃ N ⊆ s, N.Finite ∧ IsCover ε s N := by
-  obtain ⟨N, hNs, hN, hsN⟩ :=
-    exists_finite_cover_balls_of_isCompact_closure hs (ε := ε) (by positivity)
-  refine ⟨N, hNs, hN, .of_subset_iUnion_closedBall <| hsN.trans ?_⟩
-  gcongr
-  exact ball_subset_closedBall
-
-/-- A compact set admits a finite cover. -/
-lemma exists_finite_isCover_of_isCompact (hε : ε ≠ 0) (hs : IsCompact s) :
-    ∃ N ⊆ s, N.Finite ∧ IsCover ε s N := by
-  obtain ⟨N, hNs, hN, hsN⟩ := hs.finite_cover_balls (e := ε) (by positivity)
-  refine ⟨N, hNs, hN, .of_subset_iUnion_closedBall <| hsN.trans ?_⟩
-  gcongr
-  exact ball_subset_closedBall
 
 lemma IsCover.of_subset_cthickening_of_lt {δ : ℝ≥0} (hsN : s ⊆ cthickening ε N) (hεδ : ε < δ) :
     IsCover δ s N :=

--- a/Mathlib/Topology/MetricSpace/Cover.lean
+++ b/Mathlib/Topology/MetricSpace/Cover.lean
@@ -45,12 +45,12 @@ def IsCover (ε : ℝ≥0) (s N : Set X) : Prop := SetRel.IsCover {(x, y) | edis
 
 @[simp] protected nonrec lemma IsCover.empty : IsCover ε ∅ N := .empty
 
-@[simp] lemma isCover_empty_right : IsCover ε s ∅ ↔ s = ∅ := by simp [IsCover]
+@[simp] lemma isCover_empty_right : IsCover ε s ∅ ↔ s = ∅ := SetRel.isCover_empty_right
 
 protected nonrec lemma IsCover.nonempty (hsN : IsCover ε s N) (hs : s.Nonempty) : N.Nonempty :=
   hsN.nonempty hs
 
-@[simp] lemma IsCover.refl (ε : ℝ≥0) (s : Set X) : IsCover ε s s := fun a ha ↦ ⟨a, ha, by simp⟩
+@[simp] lemma IsCover.refl (ε : ℝ≥0) (s : Set X) : IsCover ε s s := .rfl
 lemma IsCover.rfl {ε : ℝ≥0} {s : Set X} : IsCover ε s s := refl ε s
 
 nonrec lemma IsCover.mono (hN : N₁ ⊆ N₂) (h₁ : IsCover ε s N₁) : IsCover ε s N₂ := h₁.mono hN


### PR DESCRIPTION
New result: a totally bounded set has finite `ε`-covers for all `ε > 0`.
I then use it to golf and generalize `exists_finite_isCover_of_isCompact_closure` and `exists_finite_isCover_of_isCompact` to extended pseudo-metric spaces.

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

When merging, all the commits will be squashed into a single commit
listing all co-authors.

Co-authors in the squash commit are gathered from two sources:

First, all authors of commits to this PR branch are included. Thus,
one way to add co-authors is to include at least one commit authored by
each co-author among the commits in the pull request. If necessary, you
may create empty commits to indicate co-authorship, using commands like so:

git commit --author="Author Name <author@email.com>" --allow-empty -m "add Author Name as coauthor"

Second, co-authors can also be listed in lines at the very bottom of
the commit message (that is, directly before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines
at the bottom of the commit message (before the `---`, and also before
any "Co-authored-by" lines) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
