### PR TITLE
[Merged by Bors] - feat: more API on tsupport and operations on functions

### DIFF
--- a/Archive/Hairer.lean
+++ b/Archive/Hairer.lean
@@ -38,7 +38,7 @@ variable (𝕜 E F) in
 /-- The set of `C^n` functions supported in a set `s`, as a submodule of the space of functions. -/
 def ContDiffSupportedOn (n : ℕ∞) (s : Set E) : Submodule 𝕜 (E → F) where
   carrier := { f : E → F | tsupport f ⊆ s ∧ ContDiff 𝕜 n f }
-  add_mem' hf hg := ⟨tsupport_add.trans <| union_subset hf.1 hg.1, hf.2.add hg.2⟩
+  add_mem' hf hg := ⟨(tsupport_add _ _).trans <| union_subset hf.1 hg.1, hf.2.add hg.2⟩
   zero_mem' :=
     ⟨(tsupport_eq_empty_iff.mpr rfl).subset.trans (empty_subset _), contDiff_const (c := 0)⟩
   smul_mem' r f hf :=

--- a/Mathlib/Topology/Algebra/Support.lean
+++ b/Mathlib/Topology/Algebra/Support.lean
@@ -57,7 +57,7 @@ theorem mulTSupport_eq_empty_iff {f : X → α} : mulTSupport f = ∅ ↔ f = 1 
   rw [mulTSupport, closure_empty_iff, mulSupport_eq_empty_iff]
 
 @[to_additive (attr := simp)]
-theorem mulTSupport_fun_one : mulTSupport (fun _ : X ↦ 1) = ∅ := by
+theorem mulTSupport_fun_one : mulTSupport (fun _ ↦ 1 : X → α) = ∅ := by
   rw [mulTSupport, mulSupport_fun_one, closure_empty]
 
 @[to_additive (attr := simp)]

--- a/Mathlib/Topology/Algebra/Support.lean
+++ b/Mathlib/Topology/Algebra/Support.lean
@@ -56,6 +56,20 @@ theorem isClosed_mulTSupport (f : X → α) : IsClosed (mulTSupport f) :=
 theorem mulTSupport_eq_empty_iff {f : X → α} : mulTSupport f = ∅ ↔ f = 1 := by
   rw [mulTSupport, closure_empty_iff, mulSupport_eq_empty_iff]
 
+@[to_additive (attr := simp)]
+theorem mulTSupport_fun_one : mulTSupport (fun _ : X ↦ 1) = ∅ := by
+  rw [mulTSupport, mulSupport_fun_one, closure_empty]
+
+@[to_additive (attr := simp)]
+theorem mulTSupport_one : mulTSupport (1 : X → α) = ∅ := by
+  rw [mulTSupport, mulSupport_one, closure_empty]
+
+@[to_additive]
+theorem mulTSupport_binop_subset [One β] [One γ] (op : α → β → γ)
+    (op1 : op 1 1 = 1) (f : X → α) (g : X → β) :
+    mulTSupport (fun x ↦ op (f x) (g x)) ⊆ mulTSupport f ∪ mulTSupport g :=
+  closure_mono (mulSupport_binop_subset op op1 f g) |>.trans closure_union.subset
+
 @[to_additive]
 theorem image_eq_one_of_notMem_mulTSupport {f : X → α} {x : X} (hx : x ∉ mulTSupport f) : f x = 1 :=
   mulSupport_subset_iff'.mp (subset_mulTSupport f) x hx
@@ -86,20 +100,49 @@ theorem tsupport_mul_subset_right {α : Type*} [MulZeroClass α] {f g : X → α
 
 end One
 
-theorem tsupport_smul_subset_left {M α} [TopologicalSpace X] [Zero M] [Zero α] [SMulWithZero M α]
+section Operations
+
+variable [TopologicalSpace X]
+
+@[to_additive (attr := simp)]
+theorem mulTSupport_mul [MulOneClass α] (f g : X → α) :
+    (mulTSupport fun x ↦ f x * g x) ⊆ mulTSupport f ∪ mulTSupport g :=
+  mulTSupport_binop_subset (· * ·) (by simp) f g
+
+@[to_additive]
+theorem mulTSupport_pow [Monoid α] (f : X → α) (n : ℕ) :
+    (mulTSupport fun x => f x ^ n) ⊆ mulTSupport f :=
+  closure_mono <| mulSupport_pow f n
+
+@[to_additive (attr := simp)]
+theorem mulTSupport_fun_inv [DivisionMonoid α] (f : X → α) :
+    (mulTSupport fun x => (f x)⁻¹) = mulTSupport f :=
+  congrArg closure <| mulSupport_fun_inv f
+
+@[to_additive (attr := simp)]
+theorem mulTSupport_inv [DivisionMonoid α] (f : X → α) :
+    mulTSupport f⁻¹ = mulTSupport f :=
+  mulTSupport_fun_inv f
+
+@[to_additive]
+theorem mulTSupport_mul_inv [DivisionMonoid α] (f g : X → α) :
+    (mulTSupport fun x => f x * (g x)⁻¹) ⊆ mulTSupport f ∪ mulTSupport g :=
+  mulTSupport_binop_subset (· * ·⁻¹) (by simp) f g
+
+@[to_additive]
+theorem mulTSupport_div [DivisionMonoid α] (f g : X → α) :
+    (mulTSupport fun x => f x / g x) ⊆ mulTSupport f ∪ mulTSupport g :=
+  mulTSupport_binop_subset (· / ·) one_div_one f g
+
+theorem tsupport_smul_subset_left {M α} [Zero M] [Zero α] [SMulWithZero M α]
     (f : X → M) (g : X → α) : (tsupport fun x => f x • g x) ⊆ tsupport f :=
   closure_mono <| support_smul_subset_left f g
 
-theorem tsupport_smul_subset_right {M α} [TopologicalSpace X] [Zero α] [SMulZeroClass M α]
+theorem tsupport_smul_subset_right {M α} [Zero α] [SMulZeroClass M α]
     (f : X → M) (g : X → α) : (tsupport fun x => f x • g x) ⊆ tsupport g :=
   closure_mono <| support_smul_subset_right f g
 
-@[to_additive]
-theorem mulTSupport_mul [TopologicalSpace X] [MulOneClass α] {f g : X → α} :
-    (mulTSupport fun x ↦ f x * g x) ⊆ mulTSupport f ∪ mulTSupport g :=
-  closure_minimal
-    ((mulSupport_mul f g).trans (union_subset_union (subset_mulTSupport _) (subset_mulTSupport _)))
-    (isClosed_closure.union isClosed_closure)
+end Operations
 
 section
 


### PR DESCRIPTION
Variants of [Function.mulSupport_one](https://leanprover-community.github.io/mathlib4_docs/Mathlib/Algebra/Notation/Support.html#Function.mulSupport_one), [Function.mulSupport_binop_subset](https://leanprover-community.github.io/mathlib4_docs/Mathlib/Algebra/Notation/Support.html#Function.mulSupport_binop_subset), [Function.mulSupport_inv](https://leanprover-community.github.io/mathlib4_docs/Mathlib/Algebra/Group/Support.html#Function.mulSupport_inv), [Function.mulSupport_div](https://leanprover-community.github.io/mathlib4_docs/Mathlib/Algebra/Group/Support.html#Function.mulSupport_div)... for the topological support.

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

When merging, all the commits will be squashed into a single commit
listing all co-authors.

Co-authors in the squash commit are gathered from two sources:

First, all authors of commits to this PR branch are included. Thus,
one way to add co-authors is to include at least one commit authored by
each co-author among the commits in the pull request. If necessary, you
may create empty commits to indicate co-authorship, using commands like so:

git commit --author="Author Name <author@email.com>" --allow-empty -m "add Author Name as coauthor"

Second, co-authors can also be listed in lines at the very bottom of
the commit message (that is, directly before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines
at the bottom of the commit message (before the `---`, and also before
any "Co-authored-by" lines) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
