### PR TITLE
[Merged by Bors] - feat(AlgebraicTopology/Quasicategory): define 2-truncated quasicategories and homotopy relations

### DIFF
--- a/Mathlib.lean
+++ b/Mathlib.lean
@@ -1362,6 +1362,7 @@ import Mathlib.AlgebraicTopology.MooreComplex
 import Mathlib.AlgebraicTopology.Quasicategory.Basic
 import Mathlib.AlgebraicTopology.Quasicategory.Nerve
 import Mathlib.AlgebraicTopology.Quasicategory.StrictSegal
+import Mathlib.AlgebraicTopology.Quasicategory.TwoTruncated
 import Mathlib.AlgebraicTopology.RelativeCellComplex.AttachCells
 import Mathlib.AlgebraicTopology.RelativeCellComplex.Basic
 import Mathlib.AlgebraicTopology.SimplexCategory.Augmented

--- a/Mathlib/AlgebraicTopology/Quasicategory/TwoTruncated.lean
+++ b/Mathlib/AlgebraicTopology/Quasicategory/TwoTruncated.lean
@@ -1,0 +1,28 @@
+import Mathlib.AlgebraicTopology.SimplicialSet.Basic
+import Mathlib.AlgebraicTopology.SimplicialSet.CompStructTruncated
+
+open CategoryTheory SimplicialObject.Truncated
+
+namespace SSet.Truncated
+open Edge
+
+class Quasicategory₂ (X : Truncated 2) where
+  fill21 {x₀ x₁ x₂ : X _⦋0⦌₂}
+      (e₀₁ : Edge x₀ x₁) (e₁₂ : Edge x₁ x₂) :
+      Nonempty (Σ e₀₂ : Edge x₀ x₂, CompStruct e₀₁ e₁₂ e₀₂)
+  fill31 {x₀ x₁ x₂ x₃ : X _⦋0⦌₂}
+      {e₀₁ : Edge x₀ x₁} {e₁₂ : Edge x₁ x₂} {e₂₃ : Edge x₂ x₃}
+      {e₀₂ : Edge x₀ x₂} {e₁₃ : Edge x₁ x₃} {e₀₃ : Edge x₀ x₃}
+      (f₃ : CompStruct e₀₁ e₁₂ e₀₂)
+      (f₀ : CompStruct e₁₂ e₂₃ e₁₃)
+      (f₂ : CompStruct e₀₁ e₁₃ e₀₃) :
+      Nonempty (CompStruct e₀₂ e₂₃ e₀₃)
+  fill32 {x₀ x₁ x₂ x₃ : X _⦋0⦌₂}
+      {e₀₁ : Edge x₀ x₁} {e₁₂ : Edge x₁ x₂} {e₂₃ : Edge x₂ x₃}
+      {e₀₂ : Edge x₀ x₂} {e₁₃ : Edge x₁ x₃} {e₀₃ : Edge x₀ x₃}
+      (f₃ : CompStruct e₀₁ e₁₂ e₀₂)
+      (f₀ : CompStruct e₁₂ e₂₃ e₁₃)
+      (f₁ : CompStruct e₀₂ e₂₃ e₀₃) :
+      Nonempty (CompStruct e₀₁ e₁₃ e₀₃)
+
+end SSet.Truncated

--- a/Mathlib/AlgebraicTopology/Quasicategory/TwoTruncated.lean
+++ b/Mathlib/AlgebraicTopology/Quasicategory/TwoTruncated.lean
@@ -74,24 +74,25 @@ abbrev HomotopicR {X : Truncated 2} {x y : X _⦋0⦌₂} (f g : Edge x y) :=
   Nonempty (CompStruct (id x) f g)
 
 section homotopy_eqrel
-variable {X : Truncated 2} [Quasicategory₂ X]
+variable {X : Truncated 2}
 
 /--
 Left homotopy relation is reflexive
 -/
-def HomotopicL.refl {x y : X _⦋0⦌₂} {f : Edge x y} : HomotopicL f f := ⟨compId f⟩
+lemma HomotopicL.refl {x y : X _⦋0⦌₂} {f : Edge x y} : HomotopicL f f := ⟨compId f⟩
 
 /--
 Left homotopy relation is symmetric
 -/
-def HomotopicL.symm {x y : X _⦋0⦌₂} {f g : Edge x y} (hfg : HomotopicL f g) : HomotopicL g f := by
+lemma HomotopicL.symm [Quasicategory₂ X] {x y : X _⦋0⦌₂} {f g : Edge x y} (hfg : HomotopicL f g) :
+    HomotopicL g f := by
   rcases hfg with ⟨hfg⟩
   exact Quasicategory₂.fill31 hfg (idComp (id y)) (compId f)
 
 /--
 Left homotopy relation is transitive
 -/
-def HomotopicL.trans {x y : X _⦋0⦌₂} {f g h : Edge x y} (hfg : HomotopicL f g)
+lemma HomotopicL.trans [Quasicategory₂ X] {x y : X _⦋0⦌₂} {f g h : Edge x y} (hfg : HomotopicL f g)
     (hgh : HomotopicL g h) : HomotopicL f h := by
   rcases hfg with ⟨hfg⟩
   rcases hgh with ⟨hgh⟩
@@ -100,19 +101,20 @@ def HomotopicL.trans {x y : X _⦋0⦌₂} {f g h : Edge x y} (hfg : HomotopicL 
 /--
 Right homotopy relation is reflexive
 -/
-def HomotopicR.refl {x y : X _⦋0⦌₂} {f : Edge x y} : HomotopicR f f := ⟨idComp f⟩
+lemma HomotopicR.refl {x y : X _⦋0⦌₂} {f : Edge x y} : HomotopicR f f := ⟨idComp f⟩
 
 /--
 Right homotopy relation is symmetric
 -/
-def HomotopicR.symm {x y : X _⦋0⦌₂} {f g : Edge x y} (hfg : HomotopicR f g) : HomotopicR g f := by
+lemma HomotopicR.symm [Quasicategory₂ X] {x y : X _⦋0⦌₂} {f g : Edge x y} (hfg : HomotopicR f g) :
+    HomotopicR g f := by
   rcases hfg with ⟨hfg⟩
   exact Quasicategory₂.fill32 (idComp (id x)) hfg (idComp f)
 
 /--
 Right homotopy relation is transitive
 -/
-def HomotopicR.trans {x y : X _⦋0⦌₂} {f g h : Edge x y} (hfg : HomotopicR f g)
+lemma HomotopicR.trans [Quasicategory₂ X] {x y : X _⦋0⦌₂} {f g h : Edge x y} (hfg : HomotopicR f g)
     (hgh : HomotopicR g h) : HomotopicR f h := by
   rcases hfg with ⟨hfg⟩
   rcases hgh with ⟨hgh⟩

--- a/Mathlib/AlgebraicTopology/Quasicategory/TwoTruncated.lean
+++ b/Mathlib/AlgebraicTopology/Quasicategory/TwoTruncated.lean
@@ -1,11 +1,43 @@
+/-
+Copyright (c) 2025 Julian Komaromy. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Julian Komaromy
+-/
 import Mathlib.AlgebraicTopology.SimplicialSet.Basic
 import Mathlib.AlgebraicTopology.SimplicialSet.CompStructTruncated
+
+/-!
+# 2-truncated quasicategories and homotopy relations
+
+We define 2-truncated quasicategories `Quasicategory₂` by three horn-filling properties
+and the left and right homotopy relations `HomotopicL` and `HomotopicR` on the edges in a
+2-truncated simplicial set.
+
+We prove that for 2-truncated quasicategories, both homotopy relations are equivalence
+relations, and that the left and right homotopy relations coincide.
+
+## Implementation notes
+
+Throughout this file, we make use of `Edge` and `CompStruct` to conveniently deal with
+edges and triangles in a 2-truncated simplicial set.
+-/
 
 open CategoryTheory SimplicialObject.Truncated
 
 namespace SSet.Truncated
 open Edge CompStruct
 
+/--
+A 2-truncated quasicategory is a 2-truncated simplicial set with the properties:
+* (2, 1)-filling: given two consecutive `Edge`s `e₀₁` and `e₁₂`, there exists a `CompStruct`
+  with (0, 1)-edge `e₀₁` and (0, 2)-edge `e₁₂`.
+* (3, 1)-filling: given three `CompStruct`s `f₃`, `f₀` and `f₂` which form a (3, 1)-horn,
+  there exists a fourth `CompStruct` such that the four faces form the boundary
+  ∂Δ[3] of a 3-simplex.
+* (3, 2)-filling: given three `CompStruct`s `f₃`, `f₀` and `f₁` which form a (3, 2)-horn,
+  there exists a fourth `CompStruct` such that the four faces form the boundary
+  ∂Δ[3] of a 3-simplex.
+-/
 class Quasicategory₂ (X : Truncated 2) where
   fill21 {x₀ x₁ x₂ : X _⦋0⦌₂}
       (e₀₁ : Edge x₀ x₁) (e₁₂ : Edge x₁ x₂) :
@@ -26,7 +58,7 @@ class Quasicategory₂ (X : Truncated 2) where
       Nonempty (CompStruct e₀₁ e₁₃ e₀₃)
 
 /--
-Two edges `f` and `g` are left homotopic if there is a 2-simplex with
+Two edges `f` and `g` are left homotopic if there is a `CompStruct` with
 (0, 1)-edge `f`, (1, 2)-edge `id` and (0, 2)-edge `g`. We use `Nonempty` to
 have a `Prop` valued `HomotopicL`.
 -/
@@ -34,22 +66,20 @@ abbrev HomotopicL {X : Truncated 2} {x y : X _⦋0⦌₂} (f g : Edge x y) :=
   Nonempty (CompStruct f (id y) g)
 
 /--
-Two edges `f` and `g` are right homotopic if there is a 2-simplex with
+Two edges `f` and `g` are right homotopic if there is a `CompStruct` with
 (0, 1)-edge `id`, (1, 2)-edge `f`, and (0, 2)-edge `g`. We use `Nonempty` to
 have a `Prop` valued `HomotopicR`.
 -/
 abbrev HomotopicR {X : Truncated 2} {x y : X _⦋0⦌₂} (f g : Edge x y) :=
   Nonempty (CompStruct (id x) f g)
 
-
-section left_homotopy_eqrel
+section homotopy_eqrel
 variable {X : Truncated 2} [Quasicategory₂ X]
 
 /--
 Left homotopy relation is reflexive
 -/
-def HomotopicL.refl {x y : X _⦋0⦌₂} {f : Edge x y} : HomotopicL f f
-  := ⟨compId f⟩
+def HomotopicL.refl {x y : X _⦋0⦌₂} {f : Edge x y} : HomotopicL f f := ⟨compId f⟩
 
 /--
 Left homotopy relation is symmetric
@@ -66,11 +96,6 @@ def HomotopicL.trans {x y : X _⦋0⦌₂} {f g h : Edge x y} (hfg : HomotopicL 
   rcases hfg with ⟨hfg⟩
   rcases hgh with ⟨hgh⟩
   exact Quasicategory₂.fill32 hfg (idComp (id y)) hgh
-
-end left_homotopy_eqrel
-
-section right_homotopy_eqrel
-variable {X : Truncated 2} [Quasicategory₂ X]
 
 /--
 Right homotopy relation is reflexive
@@ -93,6 +118,15 @@ def HomotopicR.trans {x y : X _⦋0⦌₂} {f g h : Edge x y} (hfg : HomotopicR 
   rcases hgh with ⟨hgh⟩
   exact Quasicategory₂.fill31 (idComp (id x)) hfg hgh
 
-end right_homotopy_eqrel
+end homotopy_eqrel
+
+/--
+The right and left homotopy relations coincide
+-/
+theorem left_homotopic_iff_right_homotopic {X : Truncated 2} [Quasicategory₂ X]
+    {x y : X _⦋0⦌₂} {f g : Edge x y} : HomotopicL f g ↔ HomotopicR f g := by
+  constructor
+  · rintro ⟨lhfg⟩; exact Quasicategory₂.fill32 (idComp f) (compId f) lhfg
+  · rintro ⟨rhfg⟩; exact Quasicategory₂.fill31 (idComp f) (compId f) rhfg
 
 end SSet.Truncated

--- a/Mathlib/AlgebraicTopology/Quasicategory/TwoTruncated.lean
+++ b/Mathlib/AlgebraicTopology/Quasicategory/TwoTruncated.lean
@@ -9,7 +9,7 @@ import Mathlib.AlgebraicTopology.SimplicialSet.CompStructTruncated
 /-!
 # 2-truncated quasicategories and homotopy relations
 
-We define 2-truncated quasicategories `Quasicategory₂` by three horn-filling properties
+We define 2-truncated quasicategories `Quasicategory₂` by three horn-filling properties,
 and the left and right homotopy relations `HomotopicL` and `HomotopicR` on the edges in a
 2-truncated simplicial set.
 
@@ -120,15 +120,29 @@ lemma HomotopicR.trans [Quasicategory₂ X] {x y : X _⦋0⦌₂} {f g h : Edge 
   rcases hgh with ⟨hgh⟩
   exact Quasicategory₂.fill31 (idComp (id x)) hfg hgh
 
-end homotopy_eqrel
+/--
+In a 2-truncated quasicategory, left homotopy implies right homotopy
+-/
+lemma HomotopicL.homotopicR [Quasicategory₂ X] {x y : X _⦋0⦌₂} {f g : Edge x y}
+    (h : HomotopicL f g) : HomotopicR f g := by
+  rcases h with ⟨h⟩
+  exact Quasicategory₂.fill32 (idComp f) (compId f) h
 
 /--
-The right and left homotopy relations coincide
+In a 2-truncated quasicategory, right homotopy implies left homotopy
 -/
-theorem left_homotopic_iff_right_homotopic {X : Truncated 2} [Quasicategory₂ X]
-    {x y : X _⦋0⦌₂} {f g : Edge x y} : HomotopicL f g ↔ HomotopicR f g := by
-  constructor
-  · rintro ⟨lhfg⟩; exact Quasicategory₂.fill32 (idComp f) (compId f) lhfg
-  · rintro ⟨rhfg⟩; exact Quasicategory₂.fill31 (idComp f) (compId f) rhfg
+lemma HomotopicR.homotopicL [Quasicategory₂ X] {x y : X _⦋0⦌₂} {f g : Edge x y}
+    (h : HomotopicR f g) : HomotopicL f g := by
+  rcases h with ⟨h⟩
+  exact Quasicategory₂.fill31 (idComp f) (compId f) h
+
+/--
+In a 2-truncated quasicategory, the right and left homotopy relations coincide
+-/
+theorem homotopicL_iff_homotopicR [Quasicategory₂ X] {x y : X _⦋0⦌₂} {f g : Edge x y} :
+    HomotopicL f g ↔ HomotopicR f g :=
+  ⟨HomotopicL.homotopicR, HomotopicR.homotopicL⟩
+
+end homotopy_eqrel
 
 end SSet.Truncated

--- a/Mathlib/AlgebraicTopology/Quasicategory/TwoTruncated.lean
+++ b/Mathlib/AlgebraicTopology/Quasicategory/TwoTruncated.lean
@@ -4,7 +4,7 @@ import Mathlib.AlgebraicTopology.SimplicialSet.CompStructTruncated
 open CategoryTheory SimplicialObject.Truncated
 
 namespace SSet.Truncated
-open Edge
+open Edge CompStruct
 
 class Quasicategory₂ (X : Truncated 2) where
   fill21 {x₀ x₁ x₂ : X _⦋0⦌₂}
@@ -24,5 +24,75 @@ class Quasicategory₂ (X : Truncated 2) where
       (f₀ : CompStruct e₁₂ e₂₃ e₁₃)
       (f₁ : CompStruct e₀₂ e₂₃ e₀₃) :
       Nonempty (CompStruct e₀₁ e₁₃ e₀₃)
+
+/--
+Two edges `f` and `g` are left homotopic if there is a 2-simplex with
+(0, 1)-edge `f`, (1, 2)-edge `id` and (0, 2)-edge `g`. We use `Nonempty` to
+have a `Prop` valued `HomotopicL`.
+-/
+abbrev HomotopicL {X : Truncated 2} {x y : X _⦋0⦌₂} (f g : Edge x y) :=
+  Nonempty (CompStruct f (id y) g)
+
+/--
+Two edges `f` and `g` are right homotopic if there is a 2-simplex with
+(0, 1)-edge `id`, (1, 2)-edge `f`, and (0, 2)-edge `g`. We use `Nonempty` to
+have a `Prop` valued `HomotopicR`.
+-/
+abbrev HomotopicR {X : Truncated 2} {x y : X _⦋0⦌₂} (f g : Edge x y) :=
+  Nonempty (CompStruct (id x) f g)
+
+
+section left_homotopy_eqrel
+variable {X : Truncated 2} [Quasicategory₂ X]
+
+/--
+Left homotopy relation is reflexive
+-/
+def HomotopicL.refl {x y : X _⦋0⦌₂} {f : Edge x y} : HomotopicL f f
+  := ⟨compId f⟩
+
+/--
+Left homotopy relation is symmetric
+-/
+def HomotopicL.symm {x y : X _⦋0⦌₂} {f g : Edge x y} (hfg : HomotopicL f g) : HomotopicL g f := by
+  rcases hfg with ⟨hfg⟩
+  exact Quasicategory₂.fill31 hfg (idComp (id y)) (compId f)
+
+/--
+Left homotopy relation is transitive
+-/
+def HomotopicL.trans {x y : X _⦋0⦌₂} {f g h : Edge x y} (hfg : HomotopicL f g)
+    (hgh : HomotopicL g h) : HomotopicL f h := by
+  rcases hfg with ⟨hfg⟩
+  rcases hgh with ⟨hgh⟩
+  exact Quasicategory₂.fill32 hfg (idComp (id y)) hgh
+
+end left_homotopy_eqrel
+
+section right_homotopy_eqrel
+variable {X : Truncated 2} [Quasicategory₂ X]
+
+/--
+Right homotopy relation is reflexive
+-/
+def HomotopicR.refl {x y : X _⦋0⦌₂} {f : Edge x y} : HomotopicR f f := ⟨idComp f⟩
+
+/--
+Right homotopy relation is symmetric
+-/
+def HomotopicR.symm {x y : X _⦋0⦌₂} {f g : Edge x y} (hfg : HomotopicR f g) : HomotopicR g f := by
+  rcases hfg with ⟨hfg⟩
+  exact Quasicategory₂.fill32 (idComp (id x)) hfg (idComp f)
+
+/--
+Right homotopy relation is transitive
+-/
+def HomotopicR.trans {x y : X _⦋0⦌₂} {f g h : Edge x y} (hfg : HomotopicR f g)
+    (hgh : HomotopicR g h) : HomotopicR f h := by
+  rcases hfg with ⟨hfg⟩
+  rcases hgh with ⟨hgh⟩
+  exact Quasicategory₂.fill31 (idComp (id x)) hfg hgh
+
+end right_homotopy_eqrel
 
 end SSet.Truncated


### PR DESCRIPTION
A 2-truncated quasicategory is a 2-truncated simplicial set admitting (2, 1)-, (3, 1)- and (3, 2)-horn filling. We also define
left and right homotopy relations and show for 2-truncated quasicategories that:
* left and right homotopy relations are equivalence relations,
* left and right homotopy relations coincide.

From: https://github.com/emilyriehl/infinity-cosmos

---

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)