### PR TITLE
[Merged by Bors] - feat: bounded distance implies bounded space

### DIFF
--- a/Mathlib/Topology/MetricSpace/Pseudo/Basic.lean
+++ b/Mathlib/Topology/MetricSpace/Pseudo/Basic.lean
@@ -271,7 +271,7 @@ theorem ContinuousOn.isSeparable_image [TopologicalSpace β] {f : α → β} {s 
 
 section BoundedSpace
 
-/-- If a pseudoemetric space has bounded distance, then it is bounded as a metric space. -/
+/-- If a pseudoemetric space has bounded distance, then it is bounded as a pseudometric space. -/
 lemma PseudoEMetricSpace.boundedSpace_toPseudoMetricSpace [PseudoEMetricSpace β]
     {C : ℝ≥0} (hβ : ∀ a b : β, edist a b ≤ C) :
     letI : PseudoMetricSpace β := PseudoEMetricSpace.toPseudoMetricSpace

--- a/Mathlib/Topology/MetricSpace/Pseudo/Basic.lean
+++ b/Mathlib/Topology/MetricSpace/Pseudo/Basic.lean
@@ -268,19 +268,3 @@ theorem ContinuousOn.isSeparable_image [TopologicalSpace β] {f : α → β} {s 
     (hf : ContinuousOn f s) (hs : IsSeparable s) : IsSeparable (f '' s) := by
   rw [image_eq_range, ← image_univ]
   exact (isSeparable_univ_iff.2 hs.separableSpace).image hf.restrict
-
-section BoundedSpace
-
-/-- If a pseudoemetric space has bounded distance, then it is bounded as a pseudometric space. -/
-lemma PseudoEMetricSpace.boundedSpace_toPseudoMetricSpace [PseudoEMetricSpace β]
-    {C : ℝ≥0} (hβ : ∀ a b : β, edist a b ≤ C) :
-    letI : PseudoMetricSpace β := PseudoEMetricSpace.toPseudoMetricSpace
-      fun x y ↦ ne_top_of_le_ne_top ENNReal.coe_ne_top (hβ x y)
-    BoundedSpace β := by
-  letI := PseudoEMetricSpace.toPseudoMetricSpace
-    fun x y ↦ ne_top_of_le_ne_top ENNReal.coe_ne_top (hβ x y)
-  refine Metric.boundedSpace_iff.2 ⟨C, fun x y ↦ ?_⟩
-  grw [dist_edist, hβ, ENNReal.coe_toReal]
-  exact ENNReal.coe_ne_top
-
-end BoundedSpace

--- a/Mathlib/Topology/MetricSpace/Pseudo/Basic.lean
+++ b/Mathlib/Topology/MetricSpace/Pseudo/Basic.lean
@@ -268,3 +268,19 @@ theorem ContinuousOn.isSeparable_image [TopologicalSpace β] {f : α → β} {s 
     (hf : ContinuousOn f s) (hs : IsSeparable s) : IsSeparable (f '' s) := by
   rw [image_eq_range, ← image_univ]
   exact (isSeparable_univ_iff.2 hs.separableSpace).image hf.restrict
+
+section BoundedSpace
+
+/-- If a pseudoemetric space has bounded distance, then it is bounded as a metric space. -/
+lemma PseudoEMetricSpace.boundedSpace_toPseudoMetricSpace [PseudoEMetricSpace β]
+    {C : ℝ≥0} (hβ : ∀ a b : β, edist a b ≤ C) :
+    letI : PseudoMetricSpace β := PseudoEMetricSpace.toPseudoMetricSpace
+      fun x y ↦ ne_top_of_le_ne_top ENNReal.coe_ne_top (hβ x y)
+    BoundedSpace β := by
+  letI := PseudoEMetricSpace.toPseudoMetricSpace
+    fun x y ↦ ne_top_of_le_ne_top ENNReal.coe_ne_top (hβ x y)
+  refine Metric.boundedSpace_iff.2 ⟨C, fun x y ↦ ?_⟩
+  grw [dist_edist, hβ, ENNReal.coe_toReal]
+  exact ENNReal.coe_ne_top
+
+end BoundedSpace

--- a/Mathlib/Topology/MetricSpace/Pseudo/Defs.lean
+++ b/Mathlib/Topology/MetricSpace/Pseudo/Defs.lean
@@ -594,6 +594,10 @@ theorem isBounded_iff {s : Set α} :
   rw [isBounded_def, ← Filter.mem_sets, @PseudoMetricSpace.cobounded_sets α, mem_setOf_eq,
     compl_compl]
 
+lemma boundedSpace_iff : BoundedSpace α ↔ ∃ C, ∀ a b : α, dist a b ≤ C := by
+  rw [← isBounded_univ, Metric.isBounded_iff]
+  simp
+
 theorem isBounded_iff_eventually {s : Set α} :
     IsBounded s ↔ ∀ᶠ C in atTop, ∀ ⦃x⦄, x ∈ s → ∀ ⦃y⦄, y ∈ s → dist x y ≤ C :=
   isBounded_iff.trans
@@ -609,6 +613,10 @@ theorem isBounded_iff_nndist {s : Set α} :
     IsBounded s ↔ ∃ C : ℝ≥0, ∀ ⦃x⦄, x ∈ s → ∀ ⦃y⦄, y ∈ s → nndist x y ≤ C := by
   simp only [isBounded_iff_exists_ge 0, NNReal.exists, ← NNReal.coe_le_coe, ← dist_nndist,
     NNReal.coe_mk, exists_prop]
+
+lemma boundedSpace_iff_nndist : BoundedSpace α ↔ ∃ C, ∀ a b : α, nndist a b ≤ C := by
+  rw [← isBounded_univ, Metric.isBounded_iff_nndist]
+  simp
 
 theorem toUniformSpace_eq :
     ‹PseudoMetricSpace α›.toUniformSpace = .ofDist dist dist_self dist_comm dist_triangle :=

--- a/Mathlib/Topology/MetricSpace/Pseudo/Defs.lean
+++ b/Mathlib/Topology/MetricSpace/Pseudo/Defs.lean
@@ -618,6 +618,9 @@ lemma boundedSpace_iff_nndist : BoundedSpace α ↔ ∃ C, ∀ a b : α, nndist 
   rw [← isBounded_univ, Metric.isBounded_iff_nndist]
   simp
 
+lemma boundedSpace_iff_edist : BoundedSpace α ↔ ∃ C : ℝ≥0, ∀ a b : α, edist a b ≤ C := by
+  simp [Metric.boundedSpace_iff_nndist]
+
 theorem toUniformSpace_eq :
     ‹PseudoMetricSpace α›.toUniformSpace = .ofDist dist dist_self dist_comm dist_triangle :=
   UniformSpace.ext PseudoMetricSpace.uniformity_dist


### PR DESCRIPTION
---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

When merging, all the commits will be squashed into a single commit
listing all co-authors.

Co-authors in the squash commit are gathered from two sources:

First, all authors of commits to this PR branch are included. Thus,
one way to add co-authors is to include at least one commit authored by
each co-author among the commits in the pull request. If necessary, you
may create empty commits to indicate co-authorship, using commands like so:

git commit --author="Author Name <author@email.com>" --allow-empty -m "add Author Name as coauthor"

Second, co-authors can also be listed in lines at the very bottom of
the commit message (that is, directly before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines
at the bottom of the commit message (before the `---`, and also before
any "Co-authored-by" lines) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
