### PR TITLE
chore: more flavours of derivatives within the empty set

### DIFF
--- a/Mathlib/Analysis/Analytic/Basic.lean
+++ b/Mathlib/Analysis/Analytic/Basic.lean
@@ -109,12 +109,12 @@ def AnalyticAt (f : E → F) (x : E) :=
 def AnalyticWithinAt (f : E → F) (s : Set E) (x : E) : Prop :=
   ∃ p : FormalMultilinearSeries 𝕜 E F, HasFPowerSeriesWithinAt f p s x
 
-/-- Given a function `f : E → F`, we say that `f` is analytic on a set `s` if it is analytic around
-every point of `s`. -/
+/-- Given a function `f : E → F`, we say that `f` is analytic on a neighborhood of a set `s` if it
+is analytic around every point of `s`. -/
 def AnalyticOnNhd (f : E → F) (s : Set E) :=
   ∀ x, x ∈ s → AnalyticAt 𝕜 f x
 
-/-- `f` is analytic within `s` if it is analytic within `s` at each point of `s`.  Note that
+/-- `f` is analytic on `s` if it is analytic within `s` at each point of `s`.  Note that
 this is weaker than `AnalyticOnNhd 𝕜 f s`, as `f` is allowed to be arbitrary outside `s`. -/
 def AnalyticOn (f : E → F) (s : Set E) : Prop :=
   ∀ x ∈ s, AnalyticWithinAt 𝕜 f s x
@@ -145,6 +145,24 @@ theorem HasFPowerSeriesWithinAt.analyticWithinAt (hf : HasFPowerSeriesWithinAt f
 theorem HasFPowerSeriesWithinOnBall.analyticWithinAt (hf : HasFPowerSeriesWithinOnBall f p s x r) :
     AnalyticWithinAt 𝕜 f s x :=
   hf.hasFPowerSeriesWithinAt.analyticWithinAt
+
+-- Note: this may also be obtained by combining `hasFPowerSeriesOnBall_const`
+-- together with `HasFPowerSeriesWithinOnBall.congr`. This has the downside of moving
+-- things down in the import tree, so we prefer to redo the proof by hand.
+theorem HasFPowerSeriesWithinAt.empty :
+    HasFPowerSeriesWithinAt f (constFormalMultilinearSeries 𝕜 E (f x)) ∅ x := by
+  refine ⟨⊤, ⟨by simp, by simp, fun {y} hxy hy ↦ ?_⟩⟩
+  simp only [insert_empty_eq, mem_singleton_iff] at hxy
+  rw [hxy]
+  exact hasSum_constFormalMultilinearSeries
+
+@[simp]
+theorem AnalyticWithinAt.empty : AnalyticWithinAt 𝕜 f ∅ x :=
+  ⟨_, .empty⟩
+
+@[simp]
+theorem AnalyticOn.empty : AnalyticOn 𝕜 f ∅ :=
+  fun _ ↦ False.elim
 
 /-- If a function `f` has a power series `p` around `x`, then the function `z ↦ f (z - y)` has the
 same power series around `x + y`. -/

--- a/Mathlib/Analysis/Analytic/Constructions.lean
+++ b/Mathlib/Analysis/Analytic/Constructions.lean
@@ -38,9 +38,8 @@ variable {A : Type*} [NormedRing A] [NormedAlgebra 𝕜 A]
 -/
 
 theorem hasFPowerSeriesOnBall_const {c : F} {e : E} :
-    HasFPowerSeriesOnBall (fun _ => c) (constFormalMultilinearSeries 𝕜 E c) e ⊤ := by
-  refine ⟨by simp, WithTop.top_pos, fun _ => hasSum_single 0 fun n hn => ?_⟩
-  simp [constFormalMultilinearSeries_apply_of_nonzero hn]
+    HasFPowerSeriesOnBall (fun _ => c) (constFormalMultilinearSeries 𝕜 E c) e ⊤ :=
+  ⟨by simp, WithTop.top_pos, fun _ => hasSum_constFormalMultilinearSeries⟩
 
 theorem hasFPowerSeriesAt_const {c : F} {e : E} :
     HasFPowerSeriesAt (fun _ => c) (constFormalMultilinearSeries 𝕜 E c) e :=

--- a/Mathlib/Analysis/Analytic/ConvergenceRadius.lean
+++ b/Mathlib/Analysis/Analytic/ConvergenceRadius.lean
@@ -125,10 +125,15 @@ theorem radius_eq_top_of_forall_image_add_eq_zero (n : ℕ) (hn : ∀ m, p (m + 
     mem_atTop_sets.2 ⟨n, fun _ hk => tsub_add_cancel_of_le hk ▸ hn _⟩
 
 @[simp]
-theorem constFormalMultilinearSeries_radius {v : F} :
+theorem _root_.constFormalMultilinearSeries_radius {v : F} :
     (constFormalMultilinearSeries 𝕜 E v).radius = ⊤ :=
   (constFormalMultilinearSeries 𝕜 E v).radius_eq_top_of_forall_image_add_eq_zero 1
     (by simp [constFormalMultilinearSeries])
+
+theorem _root_.hasSum_constFormalMultilinearSeries {x : E} {v : F} :
+    HasSum (fun n ↦ constFormalMultilinearSeries 𝕜 E v n (fun _ ↦ x)) v := by
+  refine hasSum_single 0 fun n hn => ?_
+  simp [constFormalMultilinearSeries_apply_of_nonzero hn]
 
 /-- `0` has infinite radius of convergence -/
 @[simp] lemma zero_radius : (0 : FormalMultilinearSeries 𝕜 E F).radius = ∞ := by

--- a/Mathlib/Analysis/Analytic/Within.lean
+++ b/Mathlib/Analysis/Analytic/Within.lean
@@ -42,7 +42,7 @@ lemma analyticWithinAt_of_singleton_mem {f : E → F} {s : Set E} {x : E} (h : {
   rcases mem_nhdsWithin.mp h with ⟨t, ot, xt, st⟩
   rcases Metric.mem_nhds_iff.mp (ot.mem_nhds xt) with ⟨r, r0, rt⟩
   exact ⟨constFormalMultilinearSeries 𝕜 E (f x), .ofReal r,
-  { r_le := by simp only [FormalMultilinearSeries.constFormalMultilinearSeries_radius, le_top]
+  { r_le := by simp only [constFormalMultilinearSeries_radius, le_top]
     r_pos := by positivity
     hasSum := by
       intro y ys yr

--- a/Mathlib/Analysis/Calculus/FDeriv/Basic.lean
+++ b/Mathlib/Analysis/Calculus/FDeriv/Basic.lean
@@ -291,6 +291,9 @@ protected theorem HasFDerivWithinAt.empty : HasFDerivWithinAt f f' ∅ x := by
 protected theorem DifferentiableWithinAt.empty : DifferentiableWithinAt 𝕜 f ∅ x :=
   ⟨0, .empty⟩
 
+@[fun_prop]
+theorem differentiableOn_empty : DifferentiableOn 𝕜 f ∅ := fun _ => False.elim
+
 theorem HasFDerivWithinAt.of_finite (h : s.Finite) : HasFDerivWithinAt f f' s x := by
   induction s, h using Set.Finite.induction_on with
   | empty => exact .empty

--- a/Mathlib/Analysis/Calculus/FDeriv/Const.lean
+++ b/Mathlib/Analysis/Calculus/FDeriv/Const.lean
@@ -297,9 +297,6 @@ theorem hasFDerivAt_of_subsingleton [h : Subsingleton E] (f : E → F) (x : E) :
   exact hasFDerivWithinAt_singleton f x
 
 @[fun_prop]
-theorem differentiableOn_empty : DifferentiableOn 𝕜 f ∅ := fun _ => False.elim
-
-@[fun_prop]
 theorem differentiableOn_singleton : DifferentiableOn 𝕜 f {x} :=
   forall_eq.2 (hasFDerivWithinAt_singleton f x).differentiableWithinAt
 


### PR DESCRIPTION
---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

When merging, all the commits will be squashed into a single commit
listing all co-authors.

Co-authors in the squash commit are gathered from two sources:

First, all authors of commits to this PR branch are included. Thus,
one way to add co-authors is to include at least one commit authored by
each co-author among the commits in the pull request. If necessary, you
may create empty commits to indicate co-authorship, using commands like so:

git commit --author="Author Name <author@email.com>" --allow-empty -m "add Author Name as coauthor"

Second, co-authors can also be listed in lines at the very bottom of
the commit message (that is, directly before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines
at the bottom of the commit message (before the `---`, and also before
any "Co-authored-by" lines) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
