### PR TITLE
[Merged by Bors] - chore(Tactic/Measurability): `fun_prop` lemmas for solving `MeasurableSet {x | ...}` goals

### DIFF
--- a/Mathlib/MeasureTheory/Constructions/BorelSpace/Order.lean
+++ b/Mathlib/MeasureTheory/Constructions/BorelSpace/Order.lean
@@ -157,11 +157,13 @@ section PartialOrder
 
 variable [PartialOrder α] [OrderClosedTopology α] [SecondCountableTopology α] {a b : α}
 
-@[measurability]
 theorem measurableSet_le' : MeasurableSet { p : α × α | p.1 ≤ p.2 } :=
   OrderClosedTopology.isClosed_le'.measurableSet
 
-@[measurability]
+@[fun_prop]
+theorem measurable_le : Measurable fun p : α × α => p.1 ≤ p.2 :=
+  measurableSet_setOf.mp measurableSet_le'
+
 theorem measurableSet_le {f g : δ → α} (hf : Measurable f) (hg : Measurable g) :
     MeasurableSet { a | f a ≤ g a } :=
   hf.prodMk hg measurableSet_le'
@@ -219,11 +221,13 @@ instance nhdsWithin_Iio_isMeasurablyGenerated : (𝓝[Iio b] a).IsMeasurablyGene
 instance nhdsWithin_uIcc_isMeasurablyGenerated : IsMeasurablyGenerated (𝓝[[[a, b]]] x) :=
   nhdsWithin_Icc_isMeasurablyGenerated
 
-@[measurability]
 theorem measurableSet_lt' [SecondCountableTopology α] : MeasurableSet { p : α × α | p.1 < p.2 } :=
   (isOpen_lt continuous_fst continuous_snd).measurableSet
 
-@[measurability]
+@[fun_prop]
+theorem measurable_lt [SecondCountableTopology α] : Measurable fun p : α × α => p.1 < p.2 :=
+  measurableSet_setOf.mp measurableSet_lt'
+
 theorem measurableSet_lt [SecondCountableTopology α] {f g : δ → α} (hf : Measurable f)
     (hg : Measurable g) : MeasurableSet { a | f a < g a } :=
   hf.prodMk hg measurableSet_lt'

--- a/Mathlib/MeasureTheory/Constructions/BorelSpace/Order.lean
+++ b/Mathlib/MeasureTheory/Constructions/BorelSpace/Order.lean
@@ -168,6 +168,10 @@ theorem measurableSet_le {f g : δ → α} (hf : Measurable f) (hg : Measurable 
     MeasurableSet { a | f a ≤ g a } :=
   hf.prodMk hg measurableSet_le'
 
+theorem Measurable.le' {f g : δ → α} (hf : Measurable f) (hg : Measurable g) :
+    Measurable fun a => f a ≤ g a := by
+  fun_prop
+
 end PartialOrder
 
 section LinearOrder
@@ -231,6 +235,10 @@ theorem measurable_lt [SecondCountableTopology α] : Measurable fun p : α × α
 theorem measurableSet_lt [SecondCountableTopology α] {f g : δ → α} (hf : Measurable f)
     (hg : Measurable g) : MeasurableSet { a | f a < g a } :=
   hf.prodMk hg measurableSet_lt'
+
+theorem Measurable.lt [SecondCountableTopology α] {f g : δ → α} (hf : Measurable f)
+    (hg : Measurable g) : Measurable fun a => f a < g a := by
+  fun_prop
 
 theorem nullMeasurableSet_lt [SecondCountableTopology α] {μ : Measure δ} {f g : δ → α}
     (hf : AEMeasurable f μ) (hg : AEMeasurable g μ) : NullMeasurableSet { a | f a < g a } μ :=

--- a/Mathlib/MeasureTheory/MeasurableSpace/Constructions.lean
+++ b/Mathlib/MeasureTheory/MeasurableSpace/Constructions.lean
@@ -911,17 +911,14 @@ lemma measurable_set_iff : Measurable g ↔ ∀ a, Measurable fun x ↦ a ∈ g 
 @[fun_prop]
 lemma measurable_set_mem (a : α) : Measurable fun s : Set α ↦ a ∈ s := measurable_pi_apply _
 
-@[fun_prop, aesop safe 100 apply (rule_sets := [Measurable])]
 lemma measurable_set_notMem (a : α) : Measurable fun s : Set α ↦ a ∉ s :=
   (Measurable.of_discrete (f := Not)).comp <| measurable_set_mem a
 
 @[deprecated (since := "2025-05-23")] alias measurable_set_not_mem := measurable_set_notMem
 
-@[aesop safe 100 apply (rule_sets := [Measurable])]
 lemma measurableSet_mem (a : α) : MeasurableSet {s : Set α | a ∈ s} :=
   measurableSet_setOf.2 <| measurable_set_mem _
 
-@[aesop safe 100 apply (rule_sets := [Measurable])]
 lemma measurableSet_notMem (a : α) : MeasurableSet {s : Set α | a ∉ s} :=
   measurableSet_setOf.2 <| measurable_set_notMem _
 

--- a/MathlibTest/measurability.lean
+++ b/MathlibTest/measurability.lean
@@ -135,3 +135,8 @@ example {s t : Set ℝ} {f : ℝ → ℝ} (hs : MeasurableSet s) (hf : Measurabl
 example : Continuous (fun x : ℝ => x) := by
   fail_if_success measurability
   exact continuous_id
+
+-- `measurability` used to fail on this example, see
+-- https://github.com/leanprover-community/mathlib4/issues/26620
+example (τ : ℝ) : MeasurableSet {x : ℝ | x > τ} := by
+  measurability


### PR DESCRIPTION
Currently, lemmas of the form `MeasurableSet {x | ...}` cannot be used by `measurability`, because `simp` changes the goal to `Measurable fun x => ...`. This PR adds the necessary `fun_prop` lemmas so that they work with `measurability` (except for statements involving equality, which are done in #31512). This fixes #26620.


---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

When merging, all the commits will be squashed into a single commit
listing all co-authors.

Co-authors in the squash commit are gathered from two sources:

First, all authors of commits to this PR branch are included. Thus,
one way to add co-authors is to include at least one commit authored by
each co-author among the commits in the pull request. If necessary, you
may create empty commits to indicate co-authorship, using commands like so:

git commit --author="Author Name <author@email.com>" --allow-empty -m "add Author Name as coauthor"

Second, co-authors can also be listed in lines at the very bottom of
the commit message (that is, directly before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines
at the bottom of the commit message (before the `---`, and also before
any "Co-authored-by" lines) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
