### PR TITLE
[Merged by Bors] - chore(Data/List): golf `ofFn_eq_pmap` using `ext; grind`

### DIFF
--- a/Mathlib/Data/List/FinRange.lean
+++ b/Mathlib/Data/List/FinRange.lean
@@ -78,8 +78,8 @@ theorem finRange_succ_eq_map (n : ℕ) : finRange n.succ = 0 :: (finRange n).map
 
 theorem ofFn_eq_pmap {n} {f : Fin n → α} :
     ofFn f = pmap (fun i hi => f ⟨i, hi⟩) (range n) fun _ => mem_range.1 := by
-  rw [pmap_eq_map_attach]
-  exact ext_getElem (by simp) fun i hi1 hi2 => by simp [List.getElem_ofFn hi1]
+  ext
+  grind
 
 theorem ofFn_id (n) : ofFn id = finRange n :=
   rfl


### PR DESCRIPTION
---
<details>
<summary>Show trace profiling of <code>ofFn_eq_pmap</code>: 24 ms before, 74 ms after </summary>

### Trace profiling of `ofFn_eq_pmap` before PR 31598
```diff
diff --git a/Mathlib/Data/List/FinRange.lean b/Mathlib/Data/List/FinRange.lean
index 85f6e14dba..6e76b6640f 100644
--- a/Mathlib/Data/List/FinRange.lean
+++ b/Mathlib/Data/List/FinRange.lean
@@ -76,6 +76,7 @@ theorem map_coe_finRange (n : ℕ) : ((finRange n) : List (Fin n)).map (Fin.val)
 theorem finRange_succ_eq_map (n : ℕ) : finRange n.succ = 0 :: (finRange n).map Fin.succ :=
   finRange_succ
 
+set_option trace.profiler true in
 theorem ofFn_eq_pmap {n} {f : Fin n → α} :
     ofFn f = pmap (fun i hi => f ⟨i, hi⟩) (range n) fun _ => mem_range.1 := by
   rw [pmap_eq_map_attach]
```
```
ℹ [529/529] Built Mathlib.Data.List.FinRange (1.0s)
info: Mathlib/Data/List/FinRange.lean:80:0: [Elab.async] [0.024331] elaborating proof of List.ofFn_eq_pmap
  [Elab.definition.value] [0.023824] List.ofFn_eq_pmap
    [Elab.step] [0.023649] 
          rw [pmap_eq_map_attach]
          exact ext_getElem (by simp) fun i hi1 hi2 => by simp [List.getElem_ofFn hi1]
      [Elab.step] [0.023643] 
            rw [pmap_eq_map_attach]
            exact ext_getElem (by simp) fun i hi1 hi2 => by simp [List.getElem_ofFn hi1]
        [Elab.step] [0.022707] exact ext_getElem (by simp) fun i hi1 hi2 => by simp [List.getElem_ofFn hi1]
          [Elab.step] [0.012198] simp [List.getElem_ofFn hi1]
            [Elab.step] [0.012193] simp [List.getElem_ofFn hi1]
              [Elab.step] [0.012186] simp [List.getElem_ofFn hi1]
Build completed successfully (529 jobs).
```

### Trace profiling of `ofFn_eq_pmap` after PR 31598
```diff
diff --git a/Mathlib/Data/List/FinRange.lean b/Mathlib/Data/List/FinRange.lean
index 85f6e14dba..5ef8e4c1d0 100644
--- a/Mathlib/Data/List/FinRange.lean
+++ b/Mathlib/Data/List/FinRange.lean
@@ -76,10 +76,11 @@ theorem map_coe_finRange (n : ℕ) : ((finRange n) : List (Fin n)).map (Fin.val)
 theorem finRange_succ_eq_map (n : ℕ) : finRange n.succ = 0 :: (finRange n).map Fin.succ :=
   finRange_succ
 
+set_option trace.profiler true in
 theorem ofFn_eq_pmap {n} {f : Fin n → α} :
     ofFn f = pmap (fun i hi => f ⟨i, hi⟩) (range n) fun _ => mem_range.1 := by
-  rw [pmap_eq_map_attach]
-  exact ext_getElem (by simp) fun i hi1 hi2 => by simp [List.getElem_ofFn hi1]
+  ext
+  grind
 
 theorem ofFn_id (n) : ofFn id = finRange n :=
   rfl
```
```
ℹ [529/529] Built Mathlib.Data.List.FinRange (1.0s)
info: Mathlib/Data/List/FinRange.lean:80:0: [Elab.async] [0.074365] elaborating proof of List.ofFn_eq_pmap
  [Elab.definition.value] [0.074039] List.ofFn_eq_pmap
    [Elab.step] [0.073924] 
          ext
          grind
      [Elab.step] [0.073917] 
            ext
            grind
        [Elab.step] [0.073402] grind
Build completed successfully (529 jobs).
```
</details>

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

When merging, all the commits will be squashed into a single commit
listing all co-authors.

Co-authors in the squash commit are gathered from two sources:

First, all authors of commits to this PR branch are included. Thus,
one way to add co-authors is to include at least one commit authored by
each co-author among the commits in the pull request. If necessary, you
may create empty commits to indicate co-authorship, using commands like so:

git commit --author="Author Name <author@email.com>" --allow-empty -m "add Author Name as coauthor"

Second, co-authors can also be listed in lines at the very bottom of
the commit message (that is, directly before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines
at the bottom of the commit message (before the `---`, and also before
any "Co-authored-by" lines) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
