### PR TITLE
chore(Data/List): golf `insertIdx_pmap` using `ext; grind`

### DIFF
--- a/Mathlib/Data/List/InsertIdx.lean
+++ b/Mathlib/Data/List/InsertIdx.lean
@@ -67,9 +67,8 @@ theorem insertIdx_pmap {p : α → Prop} (f : ∀ a, p a → β) {l : List α} {
     (hl : ∀ x ∈ l, p x) (ha : p a) :
     (l.pmap f hl).insertIdx n (f a ha) = (l.insertIdx n a).pmap f
       (fun _ h ↦ (eq_or_mem_of_mem_insertIdx h).elim (fun heq ↦ heq ▸ ha) (hl _)) := by
-  induction n generalizing l with
-  | zero => cases l <;> simp
-  | succ n ihn => cases l <;> simp_all
+  ext
+  grind
 
 theorem map_insertIdx (f : α → β) (l : List α) (n : ℕ) (a : α) :
     (l.insertIdx n a).map f = (l.map f).insertIdx n (f a) := by


### PR DESCRIPTION
---
<details>
<summary>Show trace profiling of <code>insertIdx_pmap</code>: 51 ms before, 285 ms after </summary>

### Trace profiling of `insertIdx_pmap` before PR 31599
```diff
diff --git a/Mathlib/Data/List/InsertIdx.lean b/Mathlib/Data/List/InsertIdx.lean
index b90a16262e..43de114107 100644
--- a/Mathlib/Data/List/InsertIdx.lean
+++ b/Mathlib/Data/List/InsertIdx.lean
@@ -63,6 +63,7 @@ theorem insertIdx_subset_cons (n : ℕ) (a : α) (l : List α) : l.insertIdx n a
   intro b hb
   simpa using eq_or_mem_of_mem_insertIdx hb
 
+set_option trace.profiler true in
 theorem insertIdx_pmap {p : α → Prop} (f : ∀ a, p a → β) {l : List α} {a : α} {n : ℕ}
     (hl : ∀ x ∈ l, p x) (ha : p a) :
     (l.pmap f hl).insertIdx n (f a ha) = (l.insertIdx n a).pmap f
```
```
ℹ [452/452] Built Mathlib.Data.List.InsertIdx (997ms)
info: Mathlib/Data/List/InsertIdx.lean:67:0: [Elab.async] [0.051760] elaborating proof of List.insertIdx_pmap
  [Elab.definition.value] [0.050893] List.insertIdx_pmap
    [Elab.step] [0.050251] induction n generalizing l with
          | zero => cases l <;> simp
          | succ n ihn => cases l <;> simp_all
      [Elab.step] [0.050245] induction n generalizing l with
            | zero => cases l <;> simp
            | succ n ihn => cases l <;> simp_all
        [Elab.step] [0.050239] induction n generalizing l with
            | zero => cases l <;> simp
            | succ n ihn => cases l <;> simp_all
          [Elab.step] [0.046111] cases l <;> simp_all
            [Elab.step] [0.046075] cases l <;> simp_all
              [Elab.step] [0.046069] (cases l) <;> simp_all
                [Elab.step] [0.046061] focus
                      cases l
                      with_annotate_state"<;>" skip
                      all_goals simp_all
                  [Elab.step] [0.046055] 
                        cases l
                        with_annotate_state"<;>" skip
                        all_goals simp_all
                    [Elab.step] [0.046051] 
                          cases l
                          with_annotate_state"<;>" skip
                          all_goals simp_all
                      [Elab.step] [0.045526] all_goals simp_all
                        [Elab.step] [0.024558] simp_all
                          [Elab.step] [0.024554] simp_all
                            [Elab.step] [0.024544] simp_all
                              [Meta.Tactic.simp.discharge] [0.017061] IsEmpty.forall_iff discharge ❌️
                                    IsEmpty (∀ (x : α), x ∈ l → p x)
                        [Elab.step] [0.020878] simp_all
                          [Elab.step] [0.020871] simp_all
                            [Elab.step] [0.020864] simp_all
                              [Meta.Tactic.simp.discharge] [0.012786] IsEmpty.forall_iff discharge ❌️
                                    IsEmpty (∀ (x : α), x ∈ l → p x)
Build completed successfully (452 jobs).
```

### Trace profiling of `insertIdx_pmap` after PR 31599
```diff
diff --git a/Mathlib/Data/List/InsertIdx.lean b/Mathlib/Data/List/InsertIdx.lean
index b90a16262e..77ecfea7cb 100644
--- a/Mathlib/Data/List/InsertIdx.lean
+++ b/Mathlib/Data/List/InsertIdx.lean
@@ -63,13 +63,13 @@ theorem insertIdx_subset_cons (n : ℕ) (a : α) (l : List α) : l.insertIdx n a
   intro b hb
   simpa using eq_or_mem_of_mem_insertIdx hb
 
+set_option trace.profiler true in
 theorem insertIdx_pmap {p : α → Prop} (f : ∀ a, p a → β) {l : List α} {a : α} {n : ℕ}
     (hl : ∀ x ∈ l, p x) (ha : p a) :
     (l.pmap f hl).insertIdx n (f a ha) = (l.insertIdx n a).pmap f
       (fun _ h ↦ (eq_or_mem_of_mem_insertIdx h).elim (fun heq ↦ heq ▸ ha) (hl _)) := by
-  induction n generalizing l with
-  | zero => cases l <;> simp
-  | succ n ihn => cases l <;> simp_all
+  ext
+  grind
 
 theorem map_insertIdx (f : α → β) (l : List α) (n : ℕ) (a : α) :
     (l.insertIdx n a).map f = (l.map f).insertIdx n (f a) := by
```
```
ℹ [452/452] Built Mathlib.Data.List.InsertIdx (1.2s)
info: Mathlib/Data/List/InsertIdx.lean:67:0: [Elab.async] [0.286042] elaborating proof of List.insertIdx_pmap
  [Elab.definition.value] [0.284883] List.insertIdx_pmap
    [Elab.step] [0.284702] 
          ext
          grind
      [Elab.step] [0.284696] 
            ext
            grind
        [Elab.step] [0.284160] grind
info: Mathlib/Data/List/InsertIdx.lean:72:2: [Elab.async] [0.012667] Lean.addDecl
  [Kernel] [0.012657] ✅️ typechecking declarations [List.insertIdx_pmap._proof_1_47]
Build completed successfully (452 jobs).
```
</details>

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

When merging, all the commits will be squashed into a single commit
listing all co-authors.

Co-authors in the squash commit are gathered from two sources:

First, all authors of commits to this PR branch are included. Thus,
one way to add co-authors is to include at least one commit authored by
each co-author among the commits in the pull request. If necessary, you
may create empty commits to indicate co-authorship, using commands like so:

git commit --author="Author Name <author@email.com>" --allow-empty -m "add Author Name as coauthor"

Second, co-authors can also be listed in lines at the very bottom of
the commit message (that is, directly before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines
at the bottom of the commit message (before the `---`, and also before
any "Co-authored-by" lines) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
