### PR TITLE
[Merged by Bors] - chore(Data/Set): golf `image_sUnion` using `grind`

### DIFF
--- a/Mathlib/Data/Set/Lattice/Image.lean
+++ b/Mathlib/Data/Set/Lattice/Image.lean
@@ -392,13 +392,9 @@ theorem preimage_iUnion₂ {f : α → β} {s : ∀ i, κ i → Set β} :
     (f ⁻¹' ⋃ (i) (j), s i j) = ⋃ (i) (j), f ⁻¹' s i j := by simp_rw [preimage_iUnion]
 
 theorem image_sUnion {f : α → β} {s : Set (Set α)} : (f '' ⋃₀ s) = ⋃₀ (image f '' s) := by
-  ext b
-  simp only [mem_image, mem_sUnion, exists_prop, sUnion_image, mem_iUnion]
-  constructor
-  · rintro ⟨a, ⟨t, ht₁, ht₂⟩, rfl⟩
-    exact ⟨t, ht₁, a, ht₂, rfl⟩
-  · rintro ⟨t, ht₁, a, ht₂, rfl⟩
-    exact ⟨a, ⟨t, ht₁, ht₂⟩, rfl⟩
+  ext
+  simp only [Set.mem_iUnion, Set.sUnion_image]
+  grind
 
 @[simp]
 theorem preimage_sUnion {f : α → β} {s : Set (Set β)} : f ⁻¹' ⋃₀ s = ⋃ t ∈ s, f ⁻¹' t := by


### PR DESCRIPTION
---
<details>
<summary>Show trace profiling of <code>image_sUnion</code>: 11 ms before, 32 ms after </summary>

### Trace profiling of `image_sUnion` before PR 31602
```diff
diff --git a/Mathlib/Data/Set/Lattice/Image.lean b/Mathlib/Data/Set/Lattice/Image.lean
index 5f342155da..e416a9f7d3 100644
--- a/Mathlib/Data/Set/Lattice/Image.lean
+++ b/Mathlib/Data/Set/Lattice/Image.lean
@@ -391,6 +391,7 @@ theorem preimage_iUnion {f : α → β} {s : ι → Set β} : (f ⁻¹' ⋃ i, s
 theorem preimage_iUnion₂ {f : α → β} {s : ∀ i, κ i → Set β} :
     (f ⁻¹' ⋃ (i) (j), s i j) = ⋃ (i) (j), f ⁻¹' s i j := by simp_rw [preimage_iUnion]
 
+set_option trace.profiler true in
 theorem image_sUnion {f : α → β} {s : Set (Set α)} : (f '' ⋃₀ s) = ⋃₀ (image f '' s) := by
   ext b
   simp only [mem_image, mem_sUnion, exists_prop, sUnion_image, mem_iUnion]
```
```
ℹ [414/414] Built Mathlib.Data.Set.Lattice.Image (1.9s)
info: Mathlib/Data/Set/Lattice/Image.lean:395:0: [Elab.async] [0.011457] elaborating proof of Set.image_sUnion
  [Elab.definition.value] [0.010753] Set.image_sUnion
    [Elab.step] [0.010230] 
          ext b
          simp only [mem_image, mem_sUnion, exists_prop, sUnion_image, mem_iUnion]
          constructor
          · rintro ⟨a, ⟨t, ht₁, ht₂⟩, rfl⟩
            exact ⟨t, ht₁, a, ht₂, rfl⟩
          · rintro ⟨t, ht₁, a, ht₂, rfl⟩
            exact ⟨a, ⟨t, ht₁, ht₂⟩, rfl⟩
      [Elab.step] [0.010223] 
            ext b
            simp only [mem_image, mem_sUnion, exists_prop, sUnion_image, mem_iUnion]
            constructor
            · rintro ⟨a, ⟨t, ht₁, ht₂⟩, rfl⟩
              exact ⟨t, ht₁, a, ht₂, rfl⟩
            · rintro ⟨t, ht₁, a, ht₂, rfl⟩
              exact ⟨a, ⟨t, ht₁, ht₂⟩, rfl⟩
Build completed successfully (414 jobs).
```

### Trace profiling of `image_sUnion` after PR 31602
```diff
diff --git a/Mathlib/Data/Set/Lattice/Image.lean b/Mathlib/Data/Set/Lattice/Image.lean
index 5f342155da..010feb9b00 100644
--- a/Mathlib/Data/Set/Lattice/Image.lean
+++ b/Mathlib/Data/Set/Lattice/Image.lean
@@ -391,14 +391,11 @@ theorem preimage_iUnion {f : α → β} {s : ι → Set β} : (f ⁻¹' ⋃ i, s
 theorem preimage_iUnion₂ {f : α → β} {s : ∀ i, κ i → Set β} :
     (f ⁻¹' ⋃ (i) (j), s i j) = ⋃ (i) (j), f ⁻¹' s i j := by simp_rw [preimage_iUnion]
 
+set_option trace.profiler true in
 theorem image_sUnion {f : α → β} {s : Set (Set α)} : (f '' ⋃₀ s) = ⋃₀ (image f '' s) := by
-  ext b
-  simp only [mem_image, mem_sUnion, exists_prop, sUnion_image, mem_iUnion]
-  constructor
-  · rintro ⟨a, ⟨t, ht₁, ht₂⟩, rfl⟩
-    exact ⟨t, ht₁, a, ht₂, rfl⟩
-  · rintro ⟨t, ht₁, a, ht₂, rfl⟩
-    exact ⟨a, ⟨t, ht₁, ht₂⟩, rfl⟩
+  ext
+  simp only [Set.mem_iUnion, Set.sUnion_image]
+  grind
 
 @[simp]
 theorem preimage_sUnion {f : α → β} {s : Set (Set β)} : f ⁻¹' ⋃₀ s = ⋃ t ∈ s, f ⁻¹' t := by
```
```
ℹ [414/414] Built Mathlib.Data.Set.Lattice.Image (1.9s)
info: Mathlib/Data/Set/Lattice/Image.lean:395:0: [Elab.async] [0.031914] elaborating proof of Set.image_sUnion
  [Elab.definition.value] [0.031515] Set.image_sUnion
    [Elab.step] [0.031392] 
          ext
          simp only [Set.mem_iUnion, Set.sUnion_image]
          grind
      [Elab.step] [0.031386] 
            ext
            simp only [Set.mem_iUnion, Set.sUnion_image]
            grind
        [Elab.step] [0.026423] grind
Build completed successfully (414 jobs).
```
</details>

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

When merging, all the commits will be squashed into a single commit
listing all co-authors.

Co-authors in the squash commit are gathered from two sources:

First, all authors of commits to this PR branch are included. Thus,
one way to add co-authors is to include at least one commit authored by
each co-author among the commits in the pull request. If necessary, you
may create empty commits to indicate co-authorship, using commands like so:

git commit --author="Author Name <author@email.com>" --allow-empty -m "add Author Name as coauthor"

Second, co-authors can also be listed in lines at the very bottom of
the commit message (that is, directly before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines
at the bottom of the commit message (before the `---`, and also before
any "Co-authored-by" lines) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
