### PR TITLE
[Merged by Bors] - doc(NumberTheory): ensure only a single H1 header per file

### DIFF
--- a/Mathlib/NumberTheory/Fermat.lean
+++ b/Mathlib/NumberTheory/Fermat.lean
@@ -187,7 +187,7 @@ lemma fermat_primeFactors_one_lt (n p : ℕ) (hn : 1 < n) (hp : p.Prime)
 
 -- TODO: move to NumberTheory.Mersenne, once we have that.
 /-!
-# Primality of Mersenne numbers `Mₙ = a ^ n - 1`
+### Primality of Mersenne numbers `Mₙ = a ^ n - 1`
 -/
 
 /-- Prime `a ^ n - 1` implies `a = 2` and prime `n`. -/

--- a/Mathlib/NumberTheory/Modular.lean
+++ b/Mathlib/NumberTheory/Modular.lean
@@ -37,7 +37,7 @@ Any `z : ℍ` can be moved to `𝒟` by an element of `SL(2,ℤ)`:
 If both `z` and `γ • z` are in the open domain `𝒟ᵒ` then `z = γ • z`:
 `eq_smul_self_of_mem_fdo_mem_fdo {z : ℍ} {g : SL(2,ℤ)} (hz : z ∈ 𝒟ᵒ) (hg : g • z ∈ 𝒟ᵒ) : z = g • z`
 
-# Discussion
+## Discussion
 
 Standard proofs make use of the identity
 

--- a/Mathlib/NumberTheory/ModularForms/EisensteinSeries/Basic.lean
+++ b/Mathlib/NumberTheory/ModularForms/EisensteinSeries/Basic.lean
@@ -14,7 +14,7 @@ import Mathlib.NumberTheory.ModularForms.EisensteinSeries.MDifferentiable
 We show that Eisenstein series of weight `k` and level `Γ(N)` with congruence condition
 `a : Fin 2 → ZMod N` are Modular Forms.
 
-# TODO
+## TODO
 
 Add q-expansions and prove that they are not all identically zero.
 -/

--- a/Mathlib/NumberTheory/NumberField/DedekindZeta.lean
+++ b/Mathlib/NumberTheory/NumberField/DedekindZeta.lean
@@ -21,7 +21,7 @@ In this file, we define and prove results about the Dedekind zeta function of a 
   computation of the residue of the Dedekind zeta function at `s = 1`, see Chap. 7 of
   [D. Marcus, *Number Fields*][marcus1977number]
 
-# TODO
+## TODO
 
 Generalize the construction of the Dedekind zeta function.
 -/


### PR DESCRIPTION
This PR ensures we only have a single H1 header per lean file in the`NumberTheory` subdirectory. We do this for the following reasons:

- Having more than one H1 header per file is likely to hamper both assistive technologies and SEO, since it introduces ambiguity about what the title of the resulting documentation webpage actually is.
- The [documentation style guide](https://leanprover-community.github.io/contribute/doc.html) asks for the title of the file to be H1, any other header in the file-level docstring to be H2, and sectioning headers to be H3.

I have used my own judgement to decide whether to demote the extra H1 headers to H2 or H3. I ask reviewers to verify that my choices makes sense to them.

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

When merging, all the commits will be squashed into a single commit
listing all co-authors.

Co-authors in the squash commit are gathered from two sources:

First, all authors of commits to this PR branch are included. Thus,
one way to add co-authors is to include at least one commit authored by
each co-author among the commits in the pull request. If necessary, you
may create empty commits to indicate co-authorship, using commands like so:

git commit --author="Author Name <author@email.com>" --allow-empty -m "add Author Name as coauthor"

Second, co-authors can also be listed in lines at the very bottom of
the commit message (that is, directly before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines
at the bottom of the commit message (before the `---`, and also before
any "Co-authored-by" lines) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
