### PR TITLE
[Merged by Bors] - chore: rename `private mk` to `of` for some bundled categories

### DIFF
--- a/Mathlib/Algebra/Category/BoolRing.lean
+++ b/Mathlib/Algebra/Category/BoolRing.lean
@@ -24,7 +24,8 @@ open CategoryTheory Order
 
 /-- The category of Boolean rings. -/
 structure BoolRing where
-  private mk ::
+  /-- Construct a bundled `BoolRing` from a `BooleanRing`. -/
+  of ::
   /-- The underlying type. -/
   carrier : Type u
   [booleanRing : BooleanRing carrier]
@@ -39,10 +40,6 @@ instance : CoeSort BoolRing Type* :=
 attribute [coe] carrier
 
 attribute [instance] booleanRing
-
-/-- Construct a bundled `BoolRing` from a `BooleanRing`. -/
-abbrev of (α : Type*) [BooleanRing α] : BoolRing :=
-  ⟨α⟩
 
 theorem coe_of (α : Type*) [BooleanRing α] : ↥(of α) = α :=
   rfl

--- a/Mathlib/Algebra/Category/GrpWithZero.lean
+++ b/Mathlib/Algebra/Category/GrpWithZero.lean
@@ -21,6 +21,8 @@ open CategoryTheory
 
 /-- The category of groups with zero. -/
 structure GrpWithZero where
+  /-- Construct a bundled `GrpWithZero` from a `GroupWithZero`. -/
+  of ::
   /-- The underlying group with zero. -/
   carrier : Type*
   [str : GroupWithZero carrier]
@@ -31,10 +33,6 @@ namespace GrpWithZero
 
 instance : CoeSort GrpWithZero Type* :=
   ⟨carrier⟩
-
-/-- Construct a bundled `GrpWithZero` from a `GroupWithZero`. -/
-abbrev of (α : Type*) [GroupWithZero α] : GrpWithZero where
-  carrier := α
 
 instance : Inhabited GrpWithZero :=
   ⟨of (WithZero PUnit)⟩

--- a/Mathlib/Algebra/Category/HopfAlgCat/Basic.lean
+++ b/Mathlib/Algebra/Category/HopfAlgCat/Basic.lean
@@ -24,6 +24,7 @@ variable (R : Type u) [CommRing R]
 
 /-- The category of `R`-Hopf algebras. -/
 structure HopfAlgCat where
+  private mk ::
   /-- The underlying type. -/
   carrier : Type v
   [instRing : Ring carrier]

--- a/Mathlib/Algebra/Category/Ring/Basic.lean
+++ b/Mathlib/Algebra/Category/Ring/Basic.lean
@@ -173,7 +173,7 @@ end SemiRingCat
 
 /-- The category of rings. -/
 structure RingCat where
-  /-- The object in the category of R-algebras associated to a type equipped with the appropriate
+  /-- The object in the category of rings associated to a type equipped with the appropriate
   typeclasses. -/
   of ::
   /-- The underlying type. -/
@@ -332,7 +332,7 @@ end RingCat
 
 /-- The category of commutative semirings. -/
 structure CommSemiRingCat where
-  /-- The object in the category of R-algebras associated to a type equipped with the appropriate
+  /-- The object in the category of commutative semirings associated to a type equipped with the appropriate
   typeclasses. -/
   of ::
   /-- The underlying type. -/
@@ -490,7 +490,7 @@ end CommSemiRingCat
 
 /-- The category of commutative rings. -/
 structure CommRingCat where
-  /-- The object in the category of R-algebras associated to a type equipped with the appropriate
+  /-- The object in the category of commutative rings associated to a type equipped with the appropriate
   typeclasses. -/
   of ::
   /-- The underlying type. -/

--- a/Mathlib/Algebra/Category/Ring/Basic.lean
+++ b/Mathlib/Algebra/Category/Ring/Basic.lean
@@ -490,8 +490,8 @@ end CommSemiRingCat
 
 /-- The category of commutative rings. -/
 structure CommRingCat where
-  /-- The object in the category of commutative rings associated to a type equipped with the appropriate
-  typeclasses. -/
+  /-- The object in the category of commutative rings associated to a type equipped with the
+  appropriate typeclasses. -/
   of ::
   /-- The underlying type. -/
   carrier : Type u

--- a/Mathlib/Algebra/Category/Ring/Basic.lean
+++ b/Mathlib/Algebra/Category/Ring/Basic.lean
@@ -26,7 +26,9 @@ open CategoryTheory
 
 /-- The category of semirings. -/
 structure SemiRingCat where
-  private mk ::
+  /-- The object in the category of R-algebras associated to a type equipped with the appropriate
+  typeclasses. -/
+  of ::
   /-- The underlying type. -/
   carrier : Type u
   [semiring : Semiring carrier]
@@ -41,11 +43,6 @@ instance : CoeSort (SemiRingCat) (Type u) :=
   ⟨SemiRingCat.carrier⟩
 
 attribute [coe] SemiRingCat.carrier
-
-/-- The object in the category of R-algebras associated to a type equipped with the appropriate
-typeclasses. This is the preferred way to construct a term of `SemiRingCat`. -/
-abbrev of (R : Type u) [Semiring R] : SemiRingCat :=
-  ⟨R⟩
 
 lemma coe_of (R : Type u) [Semiring R] : (of R : Type u) = R :=
   rfl
@@ -176,7 +173,9 @@ end SemiRingCat
 
 /-- The category of rings. -/
 structure RingCat where
-  private mk ::
+  /-- The object in the category of R-algebras associated to a type equipped with the appropriate
+  typeclasses. -/
+  of ::
   /-- The underlying type. -/
   carrier : Type u
   [ring : Ring carrier]
@@ -191,11 +190,6 @@ instance : CoeSort (RingCat) (Type u) :=
   ⟨RingCat.carrier⟩
 
 attribute [coe] RingCat.carrier
-
-/-- The object in the category of R-algebras associated to a type equipped with the appropriate
-typeclasses. This is the preferred way to construct a term of `RingCat`. -/
-abbrev of (R : Type u) [Ring R] : RingCat :=
-  ⟨R⟩
 
 lemma coe_of (R : Type u) [Ring R] : (of R : Type u) = R :=
   rfl
@@ -338,7 +332,9 @@ end RingCat
 
 /-- The category of commutative semirings. -/
 structure CommSemiRingCat where
-  private mk ::
+  /-- The object in the category of R-algebras associated to a type equipped with the appropriate
+  typeclasses. -/
+  of ::
   /-- The underlying type. -/
   carrier : Type u
   [commSemiring : CommSemiring carrier]
@@ -353,11 +349,6 @@ instance : CoeSort (CommSemiRingCat) (Type u) :=
   ⟨CommSemiRingCat.carrier⟩
 
 attribute [coe] CommSemiRingCat.carrier
-
-/-- The object in the category of R-algebras associated to a type equipped with the appropriate
-typeclasses. This is the preferred way to construct a term of `CommSemiRingCat`. -/
-abbrev of (R : Type u) [CommSemiring R] : CommSemiRingCat :=
-  ⟨R⟩
 
 lemma coe_of (R : Type u) [CommSemiring R] : (of R : Type u) = R :=
   rfl
@@ -499,7 +490,9 @@ end CommSemiRingCat
 
 /-- The category of commutative rings. -/
 structure CommRingCat where
-  private mk ::
+  /-- The object in the category of R-algebras associated to a type equipped with the appropriate
+  typeclasses. -/
+  of ::
   /-- The underlying type. -/
   carrier : Type u
   [commRing : CommRing carrier]
@@ -514,11 +507,6 @@ instance : CoeSort (CommRingCat) (Type u) :=
   ⟨CommRingCat.carrier⟩
 
 attribute [coe] CommRingCat.carrier
-
-/-- The object in the category of R-algebras associated to a type equipped with the appropriate
-typeclasses. This is the preferred way to construct a term of `CommRingCat`. -/
-abbrev of (R : Type u) [CommRing R] : CommRingCat :=
-  ⟨R⟩
 
 lemma coe_of (R : Type u) [CommRing R] : (of R : Type u) = R :=
   rfl

--- a/Mathlib/Algebra/Category/Ring/Basic.lean
+++ b/Mathlib/Algebra/Category/Ring/Basic.lean
@@ -26,7 +26,7 @@ open CategoryTheory
 
 /-- The category of semirings. -/
 structure SemiRingCat where
-  /-- The object in the category of R-algebras associated to a type equipped with the appropriate
+  /-- The object in the category of semirings associated to a type equipped with the appropriate
   typeclasses. -/
   of ::
   /-- The underlying type. -/

--- a/Mathlib/Algebra/Category/Ring/Basic.lean
+++ b/Mathlib/Algebra/Category/Ring/Basic.lean
@@ -332,8 +332,8 @@ end RingCat
 
 /-- The category of commutative semirings. -/
 structure CommSemiRingCat where
-  /-- The object in the category of commutative semirings associated to a type equipped with the appropriate
-  typeclasses. -/
+  /-- The object in the category of commutative semirings associated to a type equipped with the
+  appropriate typeclasses. -/
   of ::
   /-- The underlying type. -/
   carrier : Type u

--- a/Mathlib/Analysis/Normed/Group/SemiNormedGrp.lean
+++ b/Mathlib/Analysis/Normed/Group/SemiNormedGrp.lean
@@ -24,6 +24,8 @@ open CategoryTheory
 
 /-- The category of seminormed abelian groups and bounded group homomorphisms. -/
 structure SemiNormedGrp : Type (u + 1) where
+  /-- Construct a bundled `SemiNormedGrp` from the underlying type and typeclass. -/
+  of ::
   /-- The underlying seminormed abelian group. -/
   carrier : Type u
   [str : SeminormedAddCommGroup carrier]
@@ -34,10 +36,6 @@ namespace SemiNormedGrp
 
 instance : CoeSort SemiNormedGrp Type* where
   coe X := X.carrier
-
-/-- Construct a bundled `SemiNormedGrp` from the underlying type and typeclass. -/
-abbrev of (M : Type u) [SeminormedAddCommGroup M] : SemiNormedGrp where
-  carrier := M
 
 /-- The type of morphisms in `SemiNormedGrp` -/
 @[ext]
@@ -209,6 +207,8 @@ end SemiNormedGrp
 which we shall equip with the category structure consisting only of the norm non-increasing maps.
 -/
 structure SemiNormedGrp₁ : Type (u + 1) where
+  /-- Construct a bundled `SemiNormedGrp₁` from the underlying type and typeclass. -/
+  of ::
   /-- The underlying seminormed abelian group. -/
   carrier : Type u
   [str : SeminormedAddCommGroup carrier]
@@ -219,10 +219,6 @@ namespace SemiNormedGrp₁
 
 instance : CoeSort SemiNormedGrp₁ Type* where
   coe X := X.carrier
-
-/-- Construct a bundled `SemiNormedGrp₁` from the underlying type and typeclass. -/
-abbrev of (M : Type u) [SeminormedAddCommGroup M] : SemiNormedGrp₁ where
-  carrier := M
 
 /-- The type of morphisms in `SemiNormedGrp₁` -/
 @[ext]

--- a/Mathlib/CategoryTheory/FintypeCat.lean
+++ b/Mathlib/CategoryTheory/FintypeCat.lean
@@ -25,6 +25,8 @@ open CategoryTheory
 
 /-- The category of finite types. -/
 structure FintypeCat where
+  /-- Construct a bundled `FintypeCat` from the underlying type and typeclass. -/
+  of ::
   /-- The underlying type. -/
   carrier : Type*
   [str : Fintype carrier]
@@ -35,10 +37,6 @@ namespace FintypeCat
 
 instance instCoeSort : CoeSort FintypeCat Type* :=
   ⟨carrier⟩
-
-/-- Construct a bundled `FintypeCat` from the underlying type and typeclass. -/
-abbrev of (X : Type*) [Fintype X] : FintypeCat where
-  carrier := X
 
 instance : Inhabited FintypeCat :=
   ⟨of PEmpty⟩

--- a/Mathlib/MeasureTheory/Category/MeasCat.lean
+++ b/Mathlib/MeasureTheory/Category/MeasCat.lean
@@ -37,6 +37,8 @@ universe u v
 
 /-- The category of measurable spaces and measurable functions. -/
 structure MeasCat : Type (u + 1) where
+  /-- Construct a bundled `MeasCat` from the underlying type and the typeclass. -/
+  of ::
   /-- The underlying measurable space. -/
   carrier : Type u
   [str : MeasurableSpace carrier]
@@ -47,10 +49,6 @@ namespace MeasCat
 
 instance : CoeSort MeasCat Type* :=
   ⟨carrier⟩
-
-/-- Construct a bundled `MeasCat` from the underlying type and the typeclass. -/
-abbrev of (α : Type u) [ms : MeasurableSpace α] : MeasCat where
-  carrier := α
 
 theorem coe_of (X : Type u) [MeasurableSpace X] : (of X : Type u) = X :=
   rfl

--- a/Mathlib/Order/Category/BoolAlg.lean
+++ b/Mathlib/Order/Category/BoolAlg.lean
@@ -21,6 +21,8 @@ open CategoryTheory
 
 /-- The category of Boolean algebras. -/
 structure BoolAlg where
+  /-- Construct a bundled `BoolAlg` from the underlying type and typeclass. -/
+  of ::
   /-- The underlying Boolean algebra. -/
   carrier : Type*
   [str : BooleanAlgebra carrier]
@@ -35,9 +37,6 @@ instance : CoeSort BoolAlg (Type _) :=
   ⟨BoolAlg.carrier⟩
 
 attribute [coe] BoolAlg.carrier
-
-/-- Construct a bundled `BoolAlg` from the underlying type and typeclass. -/
-abbrev of (X : Type*) [BooleanAlgebra X] : BoolAlg := ⟨X⟩
 
 /-- The type of morphisms in `BoolAlg R`. -/
 @[ext]

--- a/Mathlib/Order/Category/CompleteLat.lean
+++ b/Mathlib/Order/Category/CompleteLat.lean
@@ -19,6 +19,8 @@ open CategoryTheory
 
 /-- The category of complete lattices. -/
 structure CompleteLat where
+  /-- Construct a bundled `CompleteLat` from the underlying type and typeclass. -/
+  of ::
   /-- The underlying lattice. -/
   (carrier : Type*)
   [str : CompleteLattice carrier]
@@ -33,9 +35,6 @@ instance : CoeSort CompleteLat (Type _) :=
   ⟨CompleteLat.carrier⟩
 
 attribute [coe] CompleteLat.carrier
-
-/-- Construct a bundled `CompleteLat` from the underlying type and typeclass. -/
-abbrev of (X : Type*) [CompleteLattice X] : CompleteLat := ⟨X⟩
 
 theorem coe_of (α : Type*) [CompleteLattice α] : ↥(of α) = α :=
   rfl

--- a/Mathlib/Order/Category/Frm.lean
+++ b/Mathlib/Order/Category/Frm.lean
@@ -24,6 +24,8 @@ open CategoryTheory Order
 
 /-- The category of frames. -/
 structure Frm where
+  /-- Construct a bundled `Frm` from the underlying type and typeclass. -/
+  of ::
   /-- The underlying frame. -/
   (carrier : Type*)
   [str : Frame carrier]
@@ -38,9 +40,6 @@ instance : CoeSort Frm (Type _) :=
   ⟨Frm.carrier⟩
 
 attribute [coe] Frm.carrier
-
-/-- Construct a bundled `Frm` from the underlying type and typeclass. -/
-abbrev of (X : Type*) [Frame X] : Frm := ⟨X⟩
 
 /-- The type of morphisms in `Frm R`. -/
 @[ext]

--- a/Mathlib/Order/Category/LinOrd.lean
+++ b/Mathlib/Order/Category/LinOrd.lean
@@ -18,6 +18,8 @@ universe u
 
 /-- The category of linear orders. -/
 structure LinOrd where
+  /-- Construct a bundled `LinOrd` from the underlying type and typeclass. -/
+  of ::
   /-- The underlying linearly ordered type. -/
   (carrier : Type*)
   [str : LinearOrder carrier]
@@ -32,9 +34,6 @@ instance : CoeSort LinOrd (Type _) :=
   ⟨LinOrd.carrier⟩
 
 attribute [coe] LinOrd.carrier
-
-/-- Construct a bundled `LinOrd` from the underlying type and typeclass. -/
-abbrev of (X : Type*) [LinearOrder X] : LinOrd := ⟨X⟩
 
 /-- The type of morphisms in `LinOrd R`. -/
 @[ext]

--- a/Mathlib/Order/Category/OmegaCompletePartialOrder.lean
+++ b/Mathlib/Order/Category/OmegaCompletePartialOrder.lean
@@ -31,6 +31,8 @@ universe u v
 
 /-- The category of types with an omega complete partial order. -/
 structure ωCPO : Type (u + 1) where
+  /-- Construct a bundled ωCPO from the underlying type and typeclass. -/
+  of ::
   /-- The underlying type. -/
   carrier : Type u
   [str : OmegaCompletePartialOrder carrier]
@@ -43,10 +45,6 @@ open OmegaCompletePartialOrder
 
 instance : CoeSort ωCPO Type* :=
   ⟨carrier⟩
-
-/-- Construct a bundled ωCPO from the underlying type and typeclass. -/
-abbrev of (α : Type*) [OmegaCompletePartialOrder α] : ωCPO where
-  carrier := α
 
 theorem coe_of (α : Type*) [OmegaCompletePartialOrder α] : ↥(of α) = α :=
   rfl

--- a/Mathlib/Order/Category/PartOrd.lean
+++ b/Mathlib/Order/Category/PartOrd.lean
@@ -19,6 +19,8 @@ universe u
 
 /-- The category of partial orders. -/
 structure PartOrd where
+  /-- Construct a bundled `PartOrd` from the underlying type and typeclass. -/
+  of ::
   /-- The underlying partially ordered type. -/
   (carrier : Type*)
   [str : PartialOrder carrier]
@@ -33,9 +35,6 @@ instance : CoeSort PartOrd (Type _) :=
   ⟨PartOrd.carrier⟩
 
 attribute [coe] PartOrd.carrier
-
-/-- Construct a bundled `PartOrd` from the underlying type and typeclass. -/
-abbrev of (X : Type*) [PartialOrder X] : PartOrd := ⟨X⟩
 
 /-- The type of morphisms in `PartOrd R`. -/
 @[ext]

--- a/Mathlib/Order/Category/PartOrdEmb.lean
+++ b/Mathlib/Order/Category/PartOrdEmb.lean
@@ -19,6 +19,8 @@ universe u
 
 /-- The category of partial orders. -/
 structure PartOrdEmb where
+  /-- Construct a bundled `PartOrdEmb` from the underlying type and typeclass. -/
+  of ::
   /-- The underlying partially ordered type. -/
   (carrier : Type*)
   [str : PartialOrder carrier]
@@ -33,9 +35,6 @@ instance : CoeSort PartOrdEmb (Type _) :=
   ⟨PartOrdEmb.carrier⟩
 
 attribute [coe] PartOrdEmb.carrier
-
-/-- Construct a bundled `PartOrdEmb` from the underlying type and typeclass. -/
-abbrev of (X : Type*) [PartialOrder X] : PartOrdEmb := ⟨X⟩
 
 /-- The type of morphisms in `PartOrdEmb R`. -/
 @[ext]

--- a/Mathlib/Order/Category/Preord.lean
+++ b/Mathlib/Order/Category/Preord.lean
@@ -22,6 +22,8 @@ open CategoryTheory
 
 /-- The category of preorders. -/
 structure Preord where
+  /-- Construct a bundled `Preord` from the underlying type and typeclass. -/
+  of ::
   /-- The underlying preordered type. -/
   (carrier : Type*)
   [str : Preorder carrier]
@@ -36,9 +38,6 @@ instance : CoeSort Preord (Type u) :=
   ⟨Preord.carrier⟩
 
 attribute [coe] Preord.carrier
-
-/-- Construct a bundled `Preord` from the underlying type and typeclass. -/
-abbrev of (X : Type u) [Preorder X] : Preord := ⟨X⟩
 
 /-- The type of morphisms in `Preord R`. -/
 @[ext]

--- a/Mathlib/Order/Category/Semilat.lean
+++ b/Mathlib/Order/Category/Semilat.lean
@@ -24,6 +24,8 @@ open CategoryTheory
 
 /-- The category of sup-semilattices with a bottom element. -/
 structure SemilatSupCat : Type (u + 1) where
+  /-- Construct a bundled `SemilatSupCat` from a `SemilatticeSup`. -/
+  of ::
   /-- The underlying type of a sup-semilattice with a bottom element. -/
   protected X : Type u
   [isSemilatticeSup : SemilatticeSup X]
@@ -31,6 +33,8 @@ structure SemilatSupCat : Type (u + 1) where
 
 /-- The category of inf-semilattices with a top element. -/
 structure SemilatInfCat : Type (u + 1) where
+  /-- Construct a bundled `SemilatInfCat` from a `SemilatticeInf`. -/
+  of ::
   /-- The underlying type of an inf-semilattice with a top element. -/
   protected X : Type u
   [isSemilatticeInf : SemilatticeInf X]
@@ -42,10 +46,6 @@ instance : CoeSort SemilatSupCat Type* :=
   ⟨SemilatSupCat.X⟩
 
 attribute [instance] isSemilatticeSup isOrderBot
-
-/-- Construct a bundled `SemilatSupCat` from a `SemilatticeSup`. -/
-abbrev of (α : Type*) [SemilatticeSup α] [OrderBot α] : SemilatSupCat :=
-  ⟨α⟩
 
 theorem coe_of (α : Type*) [SemilatticeSup α] [OrderBot α] : ↥(of α) = α :=
   rfl
@@ -82,10 +82,6 @@ instance : CoeSort SemilatInfCat Type* :=
   ⟨SemilatInfCat.X⟩
 
 attribute [instance] isSemilatticeInf isOrderTop
-
-/-- Construct a bundled `SemilatInfCat` from a `SemilatticeInf`. -/
-abbrev of (α : Type*) [SemilatticeInf α] [OrderTop α] : SemilatInfCat :=
-  ⟨α⟩
 
 theorem coe_of (α : Type*) [SemilatticeInf α] [OrderTop α] : ↥(of α) = α :=
   rfl

--- a/Mathlib/Topology/Category/Born.lean
+++ b/Mathlib/Topology/Category/Born.lean
@@ -19,6 +19,8 @@ open CategoryTheory
 
 /-- The category of bornologies. -/
 structure Born where
+  /-- Construct a bundled `Born` from a `Bornology`. -/
+  of ::
   /-- The underlying bornology. -/
   carrier : Type*
   [str : Bornology carrier]
@@ -29,10 +31,6 @@ namespace Born
 
 instance : CoeSort Born Type* :=
   ⟨carrier⟩
-
-/-- Construct a bundled `Born` from a `Bornology`. -/
-abbrev of (α : Type*) [Bornology α] : Born where
-  carrier := α
 
 instance : Inhabited Born :=
   ⟨of PUnit⟩

--- a/Mathlib/Topology/Category/TopCat/Basic.lean
+++ b/Mathlib/Topology/Category/TopCat/Basic.lean
@@ -24,7 +24,9 @@ universe u
 
 /-- The category of topological spaces. -/
 structure TopCat where
-  private mk ::
+  /-- The object in `TopCat` associated to a type equipped with the appropriate
+  typeclasses. This is the preferred way to construct a term of `TopCat`. -/
+  of ::
   /-- The underlying type. -/
   carrier : Type u
   [str : TopologicalSpace carrier]
@@ -39,11 +41,6 @@ instance : CoeSort (TopCat) (Type u) :=
   ⟨TopCat.carrier⟩
 
 attribute [coe] TopCat.carrier
-
-/-- The object in `TopCat` associated to a type equipped with the appropriate
-typeclasses. This is the preferred way to construct a term of `TopCat`. -/
-abbrev of (X : Type u) [TopologicalSpace X] : TopCat :=
-  ⟨X⟩
 
 lemma coe_of (X : Type u) [TopologicalSpace X] : (of X : Type u) = X :=
   rfl

--- a/Mathlib/Topology/Category/TopCat/Basic.lean
+++ b/Mathlib/Topology/Category/TopCat/Basic.lean
@@ -25,7 +25,7 @@ universe u
 /-- The category of topological spaces. -/
 structure TopCat where
   /-- The object in `TopCat` associated to a type equipped with the appropriate
-  typeclasses. This is the preferred way to construct a term of `TopCat`. -/
+  typeclasses. -/
   of ::
   /-- The underlying type. -/
   carrier : Type u

--- a/Mathlib/Topology/Category/TopCommRingCat.lean
+++ b/Mathlib/Topology/Category/TopCommRingCat.lean
@@ -22,6 +22,9 @@ open CategoryTheory
 
 /-- A bundled topological commutative ring. -/
 structure TopCommRingCat where
+  /-- Construct a bundled `TopCommRingCat` from the underlying type and the appropriate typeclasses.
+  -/
+  of ::
   /-- carrier of a topological commutative ring. -/
   α : Type u
   [isCommRing : CommRing α]
@@ -55,11 +58,6 @@ instance (R S : TopCommRingCat.{u}) : FunLike { f : R →+* S // Continuous f } 
 instance : ConcreteCategory TopCommRingCat.{u} fun R S => { f : R →+* S // Continuous f } where
   hom f := f
   ofHom f := f
-
-/-- Construct a bundled `TopCommRingCat` from the underlying type and the appropriate typeclasses.
--/
-abbrev of (X : Type u) [CommRing X] [TopologicalSpace X] [IsTopologicalRing X] : TopCommRingCat :=
-  ⟨X⟩
 
 theorem coe_of (X : Type u) [CommRing X] [TopologicalSpace X] [IsTopologicalRing X] :
     (of X : Type u) = X := rfl

--- a/Mathlib/Topology/Category/UniformSpace.lean
+++ b/Mathlib/Topology/Category/UniformSpace.lean
@@ -25,6 +25,8 @@ open CategoryTheory
 
 /-- An object in the category of uniform spaces. -/
 structure UniformSpaceCat : Type (u + 1) where
+  /-- Construct a bundled `UniformSpace` from the underlying type and the typeclass. -/
+  of ::
   /-- The underlying uniform space. -/
   carrier : Type u
   [str : UniformSpace carrier]
@@ -35,10 +37,6 @@ namespace UniformSpaceCat
 
 instance : CoeSort UniformSpaceCat Type* :=
   ⟨carrier⟩
-
-/-- Construct a bundled `UniformSpace` from the underlying type and the typeclass. -/
-abbrev of (α : Type u) [UniformSpace α] : UniformSpaceCat where
-  carrier := α
 
 /-- A bundled uniform continuous map. -/
 @[ext]


### PR DESCRIPTION
In a few places we can replace `private mk` by `of` and save some lines. Whilst searching for this I also replaced a few non-private `mk` with `of` where possible.

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

When merging, all the commits will be squashed into a single commit
listing all co-authors.

Co-authors in the squash commit are gathered from two sources:

First, all authors of commits to this PR branch are included. Thus,
one way to add co-authors is to include at least one commit authored by
each co-author among the commits in the pull request. If necessary, you
may create empty commits to indicate co-authorship, using commands like so:

git commit --author="Author Name <author@email.com>" --allow-empty -m "add Author Name as coauthor"

Second, co-authors can also be listed in lines at the very bottom of
the commit message (that is, directly before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines
at the bottom of the commit message (before the `---`, and also before
any "Co-authored-by" lines) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
