### PR TITLE
feat(IsGaloisGroup): add `IsGaloisGroup.of_subgroup`

### DIFF
--- a/Mathlib/FieldTheory/Galois/IsGaloisGroup.lean
+++ b/Mathlib/FieldTheory/Galois/IsGaloisGroup.lean
@@ -184,4 +184,26 @@ theorem mulEquivCongr_apply_smul [IsGaloisGroup G K L] [Finite G] [IsGaloisGroup
     (g : G) (x : L) : mulEquivCongr G H K L g • x = g • x :=
   AlgEquiv.ext_iff.mp ((mulEquivAlgEquiv H K L).apply_symm_apply (mulEquivAlgEquiv G K L g)) x
 
+def fixedField [IsGaloisGroup G K L] [Finite G] (S : Subgroup G) : IntermediateField K L :=
+    .fixedField <| (IsGaloisGroup.mulEquivAlgEquiv G K L).mapSubgroup S
+
+theorem mem_fixedField_iff [IsGaloisGroup G K L] [Finite G] (S : Subgroup G) (x : L) :
+    x ∈ IsGaloisGroup.fixedField G K L S ↔ ∀ σ ∈ S, σ • x = x := by
+  simp [fixedField]
+
+theorem of_subgroup [IsGaloisGroup G K L] [Finite G] (S : Subgroup G) :
+    IsGaloisGroup S (IsGaloisGroup.fixedField G K L S) L where
+  faithful :=
+    have : FaithfulSMul G L := IsGaloisGroup.faithful K
+    inferInstance
+  commutes := ⟨by
+    intro ⟨σ, hσ⟩ ⟨x, hx⟩ a
+    rw [IsGaloisGroup.mem_fixedField_iff] at hx
+    simp [IntermediateField.smul_def, hx, hσ]⟩
+  isInvariant := ⟨by
+    intro x hx
+    refine ⟨⟨x, ?_⟩, by rw [IntermediateField.algebraMap_apply]⟩
+    · rw [IsGaloisGroup.mem_fixedField_iff]
+      exact fun σ hσ ↦ hx ⟨σ, hσ⟩⟩
+
 end IsGaloisGroup

--- a/Mathlib/FieldTheory/Galois/IsGaloisGroup.lean
+++ b/Mathlib/FieldTheory/Galois/IsGaloisGroup.lean
@@ -151,6 +151,32 @@ instance of_isGalois [FiniteDimensional K L] [IsGalois K L] : IsGaloisGroup Gal(
   commutes := inferInstance
   isInvariant := ⟨fun x ↦ (IsGalois.mem_bot_iff_fixed x).mpr⟩
 
+/--
+For `G` be a Galois group for `L/K` and `S ⊆ G` be a subgroup, the `IntermediateField` of the
+points in `L` fixed by elements of `S`.
+-/
+def fixedField [IsGaloisGroup G K L] (S : Subgroup G) : IntermediateField K L :=
+  FixedPoints.intermediateField S
+
+theorem mem_fixedField_iff [IsGaloisGroup G K L] (S : Subgroup G) (x : L) :
+    x ∈ IsGaloisGroup.fixedField G K L S ↔ ∀ σ ∈ S, σ • x = x := by
+  simp [fixedField]
+
+theorem of_subgroup [IsGaloisGroup G K L] (S : Subgroup G) :
+    IsGaloisGroup S (IsGaloisGroup.fixedField G K L S) L where
+  faithful :=
+    have : FaithfulSMul G L := IsGaloisGroup.faithful K
+    inferInstance
+  commutes := ⟨by
+    intro ⟨σ, hσ⟩ ⟨x, hx⟩ a
+    rw [IsGaloisGroup.mem_fixedField_iff] at hx
+    simp [IntermediateField.smul_def, hx, hσ]⟩
+  isInvariant := ⟨by
+    intro x hx
+    refine ⟨⟨x, ?_⟩, by rw [IntermediateField.algebraMap_apply]⟩
+    · rw [IsGaloisGroup.mem_fixedField_iff]
+      exact fun σ hσ ↦ hx ⟨σ, hσ⟩⟩
+
 theorem card_eq_finrank [IsGaloisGroup G K L] : Nat.card G = Module.finrank K L := by
   rcases fintypeOrInfinite G with _ | hG
   · have : FaithfulSMul G L := faithful K
@@ -184,26 +210,6 @@ theorem mulEquivCongr_apply_smul [IsGaloisGroup G K L] [Finite G] [IsGaloisGroup
     (g : G) (x : L) : mulEquivCongr G H K L g • x = g • x :=
   AlgEquiv.ext_iff.mp ((mulEquivAlgEquiv H K L).apply_symm_apply (mulEquivAlgEquiv G K L g)) x
 
-def fixedField [IsGaloisGroup G K L] [Finite G] (S : Subgroup G) : IntermediateField K L :=
-    .fixedField <| (IsGaloisGroup.mulEquivAlgEquiv G K L).mapSubgroup S
 
-theorem mem_fixedField_iff [IsGaloisGroup G K L] [Finite G] (S : Subgroup G) (x : L) :
-    x ∈ IsGaloisGroup.fixedField G K L S ↔ ∀ σ ∈ S, σ • x = x := by
-  simp [fixedField]
-
-theorem of_subgroup [IsGaloisGroup G K L] [Finite G] (S : Subgroup G) :
-    IsGaloisGroup S (IsGaloisGroup.fixedField G K L S) L where
-  faithful :=
-    have : FaithfulSMul G L := IsGaloisGroup.faithful K
-    inferInstance
-  commutes := ⟨by
-    intro ⟨σ, hσ⟩ ⟨x, hx⟩ a
-    rw [IsGaloisGroup.mem_fixedField_iff] at hx
-    simp [IntermediateField.smul_def, hx, hσ]⟩
-  isInvariant := ⟨by
-    intro x hx
-    refine ⟨⟨x, ?_⟩, by rw [IntermediateField.algebraMap_apply]⟩
-    · rw [IsGaloisGroup.mem_fixedField_iff]
-      exact fun σ hσ ↦ hx ⟨σ, hσ⟩⟩
 
 end IsGaloisGroup

--- a/Mathlib/FieldTheory/Galois/IsGaloisGroup.lean
+++ b/Mathlib/FieldTheory/Galois/IsGaloisGroup.lean
@@ -151,6 +151,8 @@ instance of_isGalois [FiniteDimensional K L] [IsGalois K L] : IsGaloisGroup Gal(
   commutes := inferInstance
   isInvariant := ⟨fun x ↦ (IsGalois.mem_bot_iff_fixed x).mpr⟩
 
+variable {G}
+
 /--
 For `G` be a Galois group for `L/K` and `S ⊆ G` be a subgroup, the `IntermediateField` of the
 points in `L` fixed by elements of `S`.
@@ -159,11 +161,11 @@ def fixedField [IsGaloisGroup G K L] (S : Subgroup G) : IntermediateField K L :=
   FixedPoints.intermediateField S
 
 theorem mem_fixedField_iff [IsGaloisGroup G K L] (S : Subgroup G) (x : L) :
-    x ∈ IsGaloisGroup.fixedField G K L S ↔ ∀ σ ∈ S, σ • x = x := by
+    x ∈ IsGaloisGroup.fixedField K L S ↔ ∀ σ ∈ S, σ • x = x := by
   simp [fixedField]
 
 theorem of_subgroup [IsGaloisGroup G K L] (S : Subgroup G) :
-    IsGaloisGroup S (IsGaloisGroup.fixedField G K L S) L where
+    IsGaloisGroup S (IsGaloisGroup.fixedField K L S) L where
   faithful :=
     have : FaithfulSMul G L := IsGaloisGroup.faithful K
     inferInstance
@@ -176,6 +178,8 @@ theorem of_subgroup [IsGaloisGroup G K L] (S : Subgroup G) :
     refine ⟨⟨x, ?_⟩, by rw [IntermediateField.algebraMap_apply]⟩
     · rw [IsGaloisGroup.mem_fixedField_iff]
       exact fun σ hσ ↦ hx ⟨σ, hσ⟩⟩
+
+variable (G)
 
 theorem card_eq_finrank [IsGaloisGroup G K L] : Nat.card G = Module.finrank K L := by
   rcases fintypeOrInfinite G with _ | hG


### PR DESCRIPTION
Assume that `L/K` is a Galois extension of fields with Galois group `G` and let `S` be a subgroup of `G`. Define `IsGaloisGroup.fixedField L K S` as the `IntermediateField K L` of points in `L` fixed by `S` and prove that `S` is a Galois group for `L/(IsGaloisGroup.fixedField L K S)`.

This is the analogue for `IsGaloisGroup` of [IntermediateField.subgroupEquivAlgEquiv](https://leanprover-community.github.io/mathlib4_docs/Mathlib/FieldTheory/Galois/Basic.html#IntermediateField.subgroupEquivAlgEquiv) except that we do not require any finitess condition. 

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

When merging, all the commits will be squashed into a single commit
listing all co-authors.

Co-authors in the squash commit are gathered from two sources:

First, all authors of commits to this PR branch are included. Thus,
one way to add co-authors is to include at least one commit authored by
each co-author among the commits in the pull request. If necessary, you
may create empty commits to indicate co-authorship, using commands like so:

git commit --author="Author Name <author@email.com>" --allow-empty -m "add Author Name as coauthor"

Second, co-authors can also be listed in lines at the very bottom of
the commit message (that is, directly before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines
at the bottom of the commit message (before the `---`, and also before
any "Co-authored-by" lines) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

