### PR TITLE
[Merged by Bors] - ci: more robust step for finding branch SHA

### DIFF
--- a/.github/workflows/remove_deprecated_decls.yml
+++ b/.github/workflows/remove_deprecated_decls.yml
@@ -169,7 +169,6 @@ jobs:
       run: |
         # Check if the branch exists remotely
         SHA=$(git ls-remote --heads origin "$BRANCH_NAME" | awk '{print $1}')
-        
         if [ -n "$SHA" ]; then
           echo "Branch '$BRANCH_NAME' exists with SHA: $SHA"
           echo "sha=$SHA" >> "${GITHUB_OUTPUT}"

--- a/.github/workflows/remove_deprecated_decls.yml
+++ b/.github/workflows/remove_deprecated_decls.yml
@@ -168,13 +168,14 @@ jobs:
       id: get-branch-sha
       run: |
         # Check if the branch exists remotely
-        if git fetch origin "$BRANCH_NAME"; then
-          SHA=$(git rev-parse "origin/$BRANCH_NAME")
+        SHA=$(git ls-remote --heads origin "$BRANCH_NAME" | awk '{print $1}')
+        
+        if [ -n "$SHA" ]; then
           echo "Branch '$BRANCH_NAME' exists with SHA: $SHA"
           echo "sha=$SHA" >> "${GITHUB_OUTPUT}"
         else
           echo "Branch '$BRANCH_NAME' does not exist"
-          echo "sha=" >>" ${GITHUB_OUTPUT}"
+          echo "sha=" >> "${GITHUB_OUTPUT}"
         fi
 
     - name: Get PR

--- a/.github/workflows/update_dependencies.yml
+++ b/.github/workflows/update_dependencies.yml
@@ -30,7 +30,6 @@ jobs:
         run: |
           # Check if the branch exists remotely
           SHA=$(git ls-remote --heads origin "$BRANCH_NAME" | awk '{print $1}')
-
           if [ -n "$SHA" ]; then
             echo "Branch '$BRANCH_NAME' exists with SHA: $SHA"
             echo "sha=$SHA" >> "${GITHUB_OUTPUT}"

--- a/.github/workflows/update_dependencies.yml
+++ b/.github/workflows/update_dependencies.yml
@@ -29,13 +29,14 @@ jobs:
         id: get-branch-sha
         run: |
           # Check if the branch exists remotely
-          if git fetch origin "$BRANCH_NAME"; then
-            SHA=$(git rev-parse "origin/$BRANCH_NAME")
+          SHA=$(git ls-remote --heads origin "$BRANCH_NAME" | awk '{print $1}')
+
+          if [ -n "$SHA" ]; then
             echo "Branch '$BRANCH_NAME' exists with SHA: $SHA"
             echo "sha=$SHA" >> "${GITHUB_OUTPUT}"
           else
             echo "Branch '$BRANCH_NAME' does not exist"
-            echo "sha=" >>" ${GITHUB_OUTPUT}"
+            echo "sha=" >> "${GITHUB_OUTPUT}"
           fi
 
       - name: Get PR and labels


### PR DESCRIPTION
The current step using `git fetch` exits with a nonzero exit code if the branch is missing; `git ls-remote` will just return an empty string instead. It's used in two workflows so I fixed it in both places. (the branch used in `update_dependencies.yml` is protected from being deleted so we never noticed this issue)

cf. https://github.com/leanprover-community/mathlib4/actions/runs/19384254316/job/55468689653

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

When merging, all the commits will be squashed into a single commit
listing all co-authors.

Co-authors in the squash commit are gathered from two sources:

First, all authors of commits to this PR branch are included. Thus,
one way to add co-authors is to include at least one commit authored by
each co-author among the commits in the pull request. If necessary, you
may create empty commits to indicate co-authorship, using commands like so:

git commit --author="Author Name <author@email.com>" --allow-empty -m "add Author Name as coauthor"

Second, co-authors can also be listed in lines at the very bottom of
the commit message (that is, directly before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines
at the bottom of the commit message (before the `---`, and also before
any "Co-authored-by" lines) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
