### PR TITLE
[Merged by Bors] - feat(to_additive): improve error messages when re-tagging a tagged constant

### DIFF
--- a/Mathlib/Tactic/Translate/Core.lean
+++ b/Mathlib/Tactic/Translate/Core.lean
@@ -1068,7 +1068,6 @@ partial def addTranslationAttr (t : TranslateData) (src : Name) (cfg : Config)
     -- If `tgt` is not in the environment, the translation to `tgt` was added only for
     -- translating the namespace, and `src` wasn't actually tagged.
     if (← getEnv).contains tgt then
-      MetaM.run' <| checkExistingType t src tgt cfg.reorder cfg.dontTranslate
       let mut updated := false
       if cfg.reorder != [] then
         modifyEnv (t.reorderAttr.addEntry · (src, cfg.reorder))
@@ -1077,11 +1076,12 @@ partial def addTranslationAttr (t : TranslateData) (src : Name) (cfg : Config)
         modifyEnv (t.relevantArgAttr.addEntry · (src, relevantArg))
         updated := true
       if updated then
+        MetaM.run' <| checkExistingType t src tgt cfg.reorder cfg.dontTranslate
         return #[tgt]
       throwError
-        "Cannot apply attribute @[{t.attrName}] to '{src}': it is already translated to '{tgt}'. \
-        If you need to set the `reorder` or `relevant_arg` option, this is still possible with the \
-        `@[{t.attrName} (reorder := ...)]` or `@[{t.attrName} (relevant_arg := ...)]` syntax."
+      "Cannot apply attribute @[{t.attrName}] to '{src}': it is already translated to '{tgt}'. \n\
+      If you need to set the `reorder` or `relevant_arg` option, this is still possible with the \n\
+      `@[{t.attrName} (reorder := ...)]` or `@[{t.attrName} (relevant_arg := ...)]` syntax."
   let tgt ← targetName t cfg src
   let alreadyExists := (← getEnv).contains tgt
   if cfg.existing != alreadyExists && !(← isInductive src) && !cfg.self then

--- a/Mathlib/Tactic/Translate/Core.lean
+++ b/Mathlib/Tactic/Translate/Core.lean
@@ -1061,16 +1061,27 @@ partial def addTranslationAttr (t : TranslateData) (src : Name) (cfg : Config)
   if (kind != AttributeKind.global) then
     throwError "`{t.attrName}` can only be used as a global attribute"
   withOptions (· |>.updateBool `trace.translate (cfg.trace || ·)) <| do
+  -- If `src` was already tagged, we allow the `(reorder := ...)` or `(relevant_arg := ...)` syntax
+  -- for updating this information on constants that are already tagged.
+  -- In particular, this is necessary for structure projections like `HPow.hPow`.
   if let some tgt := findTranslation? (← getEnv) t src then
-    -- we allow `(reorder := ...)` or `(relevant_arg := ...)` syntax
-    -- for updating this information on constants that are already tagged
-    -- for example, this is necessary for `HPow.hPow`
-    if cfg.reorder != [] then
-      modifyEnv (t.reorderAttr.addEntry · (src, cfg.reorder))
-      return #[tgt]
-    if let some relevantArg := cfg.relevantArg? then
-      modifyEnv (t.relevantArgAttr.addEntry · (src, relevantArg))
-      return #[tgt]
+    -- If `tgt` is not in the environment, the translation to `tgt` was added only for
+    -- translating the namespace, and `src` wasn't actually tagged.
+    if (← getEnv).contains tgt then
+      MetaM.run' <| checkExistingType t src tgt cfg.reorder cfg.dontTranslate
+      let mut updated := false
+      if cfg.reorder != [] then
+        modifyEnv (t.reorderAttr.addEntry · (src, cfg.reorder))
+        updated := true
+      if let some relevantArg := cfg.relevantArg? then
+        modifyEnv (t.relevantArgAttr.addEntry · (src, relevantArg))
+        updated := true
+      if updated then
+        return #[tgt]
+      throwError
+        "Cannot apply attribute @[{t.attrName}] to '{src}': it is already translated to '{tgt}'. \
+        If you need to set the `reorder` or `relevant_arg` option, this is still possible with the \
+        `@[{t.attrName} (reorder := ...)]` or `@[{t.attrName} (relevant_arg := ...)]` syntax."
   let tgt ← targetName t cfg src
   let alreadyExists := (← getEnv).contains tgt
   if cfg.existing != alreadyExists && !(← isInductive src) && !cfg.self then

--- a/MathlibTest/toAdditive.lean
+++ b/MathlibTest/toAdditive.lean
@@ -30,6 +30,21 @@ class my_has_scalar (M : Type u) (α : Type v) where
 
 instance : my_has_scalar Nat Nat := ⟨fun a b => a * b⟩
 attribute [to_additive (reorder := 1 2) my_has_scalar] my_has_pow
+/--
+error: Cannot apply attribute @[to_additive] to 'Test.my_has_pow.pow': it is already translated to 'Test.my_has_scalar.smul'. ⏎
+If you need to set the `reorder` or `relevant_arg` option, this is still possible with the ⏎
+`@[to_additive (reorder := ...)]` or `@[to_additive (relevant_arg := ...)]` syntax.
+-/
+#guard_msgs in
+attribute [to_additive] my_has_pow.pow
+/--
+error: `to_additive` validation failed: expected
+  {β : Type u} → {α : Type v} → [self : my_has_scalar β α] → α → β → α
+but 'Test.my_has_scalar.smul' has type
+  {M : Type u} → {α : Type v} → [self : my_has_scalar M α] → M → α → α
+-/
+#guard_msgs in
+attribute [to_additive (reorder := 1 2)] my_has_pow.pow
 attribute [to_additive (reorder := 1 2, 4 5)] my_has_pow.pow
 
 @[to_additive bar1]


### PR DESCRIPTION
This PR improves error messages in the case of tagging an expression that was already tagged before. It is sometimes neccessary for structure projections to reorder the arguments (but hopefully this can be improved in the future so that this can be done in the original tag, instead of in a separate tag). Importantly, it now checks that the new provided `(reorder := ...)` is correct.

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

When merging, all the commits will be squashed into a single commit
listing all co-authors.

Co-authors in the squash commit are gathered from two sources:

First, all authors of commits to this PR branch are included. Thus,
one way to add co-authors is to include at least one commit authored by
each co-author among the commits in the pull request. If necessary, you
may create empty commits to indicate co-authorship, using commands like so:

git commit --author="Author Name <author@email.com>" --allow-empty -m "add Author Name as coauthor"

Second, co-authors can also be listed in lines at the very bottom of
the commit message (that is, directly before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines
at the bottom of the commit message (before the `---`, and also before
any "Co-authored-by" lines) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
