### PR TITLE
[Merged by Bors] - doc(RingTheory): ensure only a single H1 header per file

### DIFF
--- a/Mathlib/RingTheory/DedekindDomain/LinearDisjoint.lean
+++ b/Mathlib/RingTheory/DedekindDomain/LinearDisjoint.lean
@@ -14,7 +14,7 @@ subrings such that `Frac R₁ ⊔ Frac R₂ = Frac B`, `Frac R₁` and `Frac R�
 over `Frac A`, and that `𝓓(R₁/A)` and `𝓓(R₂/A)` are coprime where `𝓓` denotes the different ideal
 and `Frac R` denotes the fraction field of a domain `R`.
 
-# Main results and definitions
+## Main results and definitions
 
 * `FractionalIdeal.differentIdeal_eq_map_differentIdeal`: `𝓓(B/R₁) = 𝓓(R₂/A)`
 * `FractionalIdeal.differentIdeal_eq_differentIdeal_mul_differentIdeal_of_isCoprime`:

--- a/Mathlib/RingTheory/Derivation/Lie.lean
+++ b/Mathlib/RingTheory/Derivation/Lie.lean
@@ -7,7 +7,9 @@ import Mathlib.Algebra.Lie.OfAssociative
 import Mathlib.RingTheory.Derivation.Basic
 
 /-!
-# Results
+# Lie Algebra Structure on Derivations
+
+## Main statements
 
 - `Derivation.instLieAlgebra`: The `R`-derivations from `A` to `A` form a Lie algebra over `R`.
 
@@ -22,7 +24,7 @@ variable {D1 D2 : Derivation R A A} (a : A)
 
 section LieStructures
 
-/-! # Lie structures -/
+/-! ### Lie structures -/
 
 
 /-- The commutator of derivations is again a derivation. -/

--- a/Mathlib/RingTheory/Derivation/ToSquareZero.lean
+++ b/Mathlib/RingTheory/Derivation/ToSquareZero.lean
@@ -7,7 +7,9 @@ import Mathlib.RingTheory.Derivation.Basic
 import Mathlib.RingTheory.Ideal.Quotient.Operations
 
 /-!
-# Results
+# Derivations into Square-Zero Ideals
+
+## Main statements
 
 - `derivationToSquareZeroOfLift`: The `R`-derivations from `A` into a square-zero ideal `I`
   of `B` corresponds to the lifts `A →ₐ[R] B` of the map `A →ₐ[R] B ⧸ I`.

--- a/Mathlib/RingTheory/FilteredAlgebra/Basic.lean
+++ b/Mathlib/RingTheory/FilteredAlgebra/Basic.lean
@@ -14,7 +14,7 @@ import Mathlib.Algebra.Ring.Int.Defs
 
 In this file, we define the concept of filtration for abelian groups, rings, and modules.
 
-# Main definitions
+## Main definitions
 
 * `IsFiltration` : For a family of subsets `σ` of `A`, an increasing series of `F` in `σ` is a
   filtration if there is another series `F_lt` in `σ` equal to the

--- a/Mathlib/RingTheory/HopfAlgebra/Basic.lean
+++ b/Mathlib/RingTheory/HopfAlgebra/Basic.lean
@@ -12,7 +12,7 @@ In this file we define `HopfAlgebra`, and provide instances for:
 
 * Commutative semirings: `CommSemiring.toHopfAlgebra`
 
-# Main definitions
+## Main definitions
 
 * `HopfAlgebra R A` : the Hopf algebra structure on an `R`-bialgebra `A`.
 * `HopfAlgebra.antipode` : The `R`-linear map `A →ₗ[R] A`.

--- a/Mathlib/RingTheory/Ideal/AssociatedPrime/Localization.lean
+++ b/Mathlib/RingTheory/Ideal/AssociatedPrime/Localization.lean
@@ -13,7 +13,7 @@ import Mathlib.RingTheory.Localization.AtPrime.Basic
 
 This file mainly proves the relation between `Ass(S⁻¹M)` and `Ass(M)`
 
-# Main Results
+## Main Results
 
 * `associatedPrimes.mem_associatePrimes_of_comap_mem_associatePrimes_isLocalizedModule` :
   for an `R` module `M`, if `p` is a prime ideal of `S⁻¹R` and `p ∩ R ∈ Ass(M)` then

--- a/Mathlib/RingTheory/Ideal/Height.lean
+++ b/Mathlib/RingTheory/Ideal/Height.lean
@@ -11,7 +11,7 @@ import Mathlib.RingTheory.Ideal.MinimalPrime.Localization
 
 In this file, we define the height of a prime ideal and the height of an ideal.
 
-# Main definitions
+## Main definitions
 
 * `Ideal.primeHeight` : The height of a prime ideal $\mathfrak{p}$. We define it as the supremum of
   the lengths of strictly decreasing chains of prime ideals below it. This definition is implemented

--- a/Mathlib/RingTheory/LocalRing/LocalSubring.lean
+++ b/Mathlib/RingTheory/LocalRing/LocalSubring.lean
@@ -11,7 +11,7 @@ import Mathlib.RingTheory.Localization.AtPrime.Basic
 /-!
 # Local subrings of fields
 
-# Main result
+## Main results
 - `LocalSubring` : The class of local subrings of a commutative ring.
 - `LocalSubring.ofPrime`: The localization of a subring as a `LocalSubring`.
 -/

--- a/Mathlib/RingTheory/Morita/Basic.lean
+++ b/Mathlib/RingTheory/Morita/Basic.lean
@@ -15,7 +15,7 @@ Two `R`-algebras `A` and `B` are Morita equivalent if the categories of modules 
 `B` are `R`-linearly equivalent. In this file, we prove that Morita equivalence is an equivalence
 relation and that isomorphic algebras are Morita equivalent.
 
-# Main definitions
+## Main definitions
 
 - `MoritaEquivalence R A B`: a structure containing an `R`-linear equivalence of categories between
   the module categories of `A` and `B`.

--- a/Mathlib/RingTheory/Noetherian/UniqueFactorizationDomain.lean
+++ b/Mathlib/RingTheory/Noetherian/UniqueFactorizationDomain.lean
@@ -10,7 +10,7 @@ import Mathlib.RingTheory.UniqueFactorizationDomain.Ideal
 
 ## Main results
 
-# IsNoetherianRing.wfDvdMonoid
+- IsNoetherianRing.wfDvdMonoid
 -/
 
 variable {R : Type*} [CommSemiring R] [IsDomain R]

--- a/Mathlib/RingTheory/NormalClosure.lean
+++ b/Mathlib/RingTheory/NormalClosure.lean
@@ -15,7 +15,8 @@ Under the hood, `T` is defined as the `integralClosure` of `S` inside the
 `IntermediateField.normalClosure` of the extension `Frac S / Frac R` inside the `AlgebraicClosure`
 of `Frac S`. In particular, if `S` is a Dedekind domain, then `T` is also a Dedekind domain.
 
-# Technical notes
+## Technical notes
+
 * Many instances are proved about the `IntermediateField.normalClosure` of the extension
 `Frac S / Frac R` inside the `AlgebraicClosure` of `Frac S`. However these are only needed for the
 construction of `T` and to prove some results about it. Therefore, these instances are local.

--- a/Mathlib/RingTheory/Polynomial/Eisenstein/Criterion.lean
+++ b/Mathlib/RingTheory/Polynomial/Eisenstein/Criterion.lean
@@ -29,7 +29,7 @@ of application of this criterion.
 * `Polynomial.irreducible_of_eisenstein_criterion` : the classic Eisenstein criterion.
   It is the particular case where `q := X`.
 
-# TODO
+## TODO
 
 The case of a polynomial `q := X - a` is interesting,
 then the mod `P ^ 2` hypothesis can rephrased as saying

--- a/Mathlib/RingTheory/Regular/Depth.lean
+++ b/Mathlib/RingTheory/Regular/Depth.lean
@@ -19,7 +19,7 @@ Let `M` and `N` be `R`-modules. In this section we prove that `Hom(N,M)` is subs
 there exist `r : R`, such that `IsSMulRegular M r` and `r ∈ ann(N)`.
 This is the case if `Depth[I](M) = 0`.
 
-# Main Results
+## Main statements
 
 * `IsSMulRegular.subsingleton_linearMap_iff` : for `R` module `N M`, `Hom(N, M) = 0`
   iff there is a `M`-regular in `Module.annihilator R N`.

--- a/Mathlib/RingTheory/Valuation/AlgebraInstances.lean
+++ b/Mathlib/RingTheory/Valuation/AlgebraInstances.lean
@@ -12,11 +12,11 @@ import Mathlib.RingTheory.Valuation.ValuationSubring
 This file contains several `Algebra` and `IsScalarTower` instances related to extensions
 of a field with a valuation, as well as their unit balls.
 
-# Main Definitions
+## Main definitions
 * `ValuationSubring.algebra` : Given an algebra between two field extensions `L` and `E` of a
   field `K` with a valuation, create an algebra between their two rings of integers.
 
-# Main Results
+## Main statements
 
 * `integralClosure_algebraMap_injective` : the unit ball of a field `K` with respect to a
   valuation injects into its integral closure in a field extension `L` of `K`.

--- a/Mathlib/RingTheory/Valuation/Minpoly.lean
+++ b/Mathlib/RingTheory/Valuation/Minpoly.lean
@@ -13,7 +13,8 @@ We prove some results about valuations of zero coefficients of minimal polynomia
 
 Let `K` be a field with a valuation `v` and let `L` be a field extension of `K`.
 
-# Main Results
+## Main statements
+
 * `coeff_zero_minpoly` : for `x ∈ K` the valuation of the zeroth coefficient of the minimal
   polynomial of `algebraMap K L x` over `K` is equal to the valuation of `x`.
 * `pow_coeff_zero_ne_zero_of_unit` : for any unit `x : Lˣ`, we prove that a certain power of the


### PR DESCRIPTION
This PR ensures we only have a single H1 header per lean file in the `RingTheory` subdirectory. We do this for the following reasons:

- Having more than one H1 header per file is likely to hamper both assistive technologies and SEO, since it introduces ambiguity about what the title of the resulting documentation webpage actually is.
- The [documentation style guide](https://leanprover-community.github.io/contribute/doc.html) asks for the title of the file to be H1, any other header in the file-level docstring to be H2, and sectioning headers to be H3.

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

When merging, all the commits will be squashed into a single commit
listing all co-authors.

Co-authors in the squash commit are gathered from two sources:

First, all authors of commits to this PR branch are included. Thus,
one way to add co-authors is to include at least one commit authored by
each co-author among the commits in the pull request. If necessary, you
may create empty commits to indicate co-authorship, using commands like so:

git commit --author="Author Name <author@email.com>" --allow-empty -m "add Author Name as coauthor"

Second, co-authors can also be listed in lines at the very bottom of
the commit message (that is, directly before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines
at the bottom of the commit message (before the `---`, and also before
any "Co-authored-by" lines) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
