### PR TITLE
[Merged by Bors] - doc(Topology): ensure only a single H1 header per file

### DIFF
--- a/Mathlib/Topology/Algebra/Category/ProfiniteGrp/Basic.lean
+++ b/Mathlib/Topology/Algebra/Category/ProfiniteGrp/Basic.lean
@@ -277,7 +277,7 @@ instance : (forget ProfiniteGrp.{u}).ReflectsIsomorphisms :=
 end ProfiniteGrp
 
 /-!
-# Limits in the category of profinite groups
+### Limits in the category of profinite groups
 
 In this section, we construct limits in the category of profinite groups.
 

--- a/Mathlib/Topology/Algebra/ContinuousMonoidHom.lean
+++ b/Mathlib/Topology/Algebra/ContinuousMonoidHom.lean
@@ -271,12 +271,9 @@ section
 
 /-!
 
-# Continuous MulEquiv
+### Continuous MulEquiv
 
 This section defines the space of continuous isomorphisms between two topological groups.
-
-## Main definitions
-
 -/
 
 universe u v

--- a/Mathlib/Topology/Algebra/Group/ClosedSubgroup.lean
+++ b/Mathlib/Topology/Algebra/Group/ClosedSubgroup.lean
@@ -14,7 +14,7 @@ import Mathlib.Topology.Algebra.Group.Quotient
 This file builds the frame of closed subgroups in a topological group `G`,
 and its additive version `ClosedAddSubgroup`.
 
-# Main definitions and results
+## Main definitions and results
 
 * `normalCore_isClosed`: The `normalCore` of a closed subgroup is closed.
 

--- a/Mathlib/Topology/Algebra/OpenSubgroup.lean
+++ b/Mathlib/Topology/Algebra/OpenSubgroup.lean
@@ -354,7 +354,7 @@ theorem isOpen_of_isOpen_subideal {U I : Ideal R} (h : U ≤ I) (hU : IsOpen (U 
 end Ideal
 
 /-!
-# Open normal subgroups of a topological group
+### Open normal subgroups of a topological group
 
 This section builds the lattice `OpenNormalSubgroup G` of open subgroups in a topological group `G`,
 and its additive version `OpenNormalAddSubgroup`.
@@ -442,7 +442,7 @@ end OpenNormalSubgroup
 end
 
 /-!
-# Existence of an open subgroup in any clopen neighborhood of the neutral element
+### Existence of an open subgroup in any clopen neighborhood of the neutral element
 
 This section proves the lemma `IsTopologicalGroup.exist_openSubgroup_sub_clopen_nhds_of_one`, which
 states that in a compact topological group, for any clopen neighborhood of 1,

--- a/Mathlib/Topology/Algebra/Valued/ValuativeRel.lean
+++ b/Mathlib/Topology/Algebra/Valued/ValuativeRel.lean
@@ -22,7 +22,7 @@ namespace IsValuativeTopology
 
 section
 
-/-! # Alternate constructors -/
+/-! ### Alternate constructors -/
 
 variable {R : Type*} [CommRing R] [ValuativeRel R] [TopologicalSpace R]
 

--- a/Mathlib/Topology/Homeomorph/Defs.lean
+++ b/Mathlib/Topology/Homeomorph/Defs.lean
@@ -12,7 +12,7 @@ import Mathlib.Topology.Maps.Basic
 This file defines homeomorphisms between two topological spaces. They are bijections with both
 directions continuous. We denote homeomorphisms with the notation `≃ₜ`.
 
-# Main definitions and results
+## Main definitions and results
 
 * `Homeomorph X Y`: The type of homeomorphisms from `X` to `Y`.
   This type can be denoted using the following notation: `X ≃ₜ Y`.

--- a/Mathlib/Topology/Order/NhdsSet.lean
+++ b/Mathlib/Topology/Order/NhdsSet.lean
@@ -26,7 +26,7 @@ section OrderClosedTopology
 variable {α : Type*} [LinearOrder α] [TopologicalSpace α] [OrderClosedTopology α] {a b c d : α}
 
 /-!
-# Formulae for `𝓝ˢ` of intervals
+### Formulae for `𝓝ˢ` of intervals
 -/
 
 @[simp] theorem nhdsSet_Ioi : 𝓝ˢ (Ioi a) = 𝓟 (Ioi a) := isOpen_Ioi.nhdsSet_eq

--- a/Mathlib/Topology/UniformSpace/Equiv.lean
+++ b/Mathlib/Topology/UniformSpace/Equiv.lean
@@ -14,7 +14,7 @@ import Mathlib.Topology.UniformSpace.Pi
 This file defines uniform isomorphisms between two uniform spaces. They are bijections with both
 directions uniformly continuous. We denote uniform isomorphisms with the notation `≃ᵤ`.
 
-# Main definitions
+## Main definitions
 
 * `UniformEquiv α β`: The type of uniform isomorphisms from `α` to `β`.
   This type can be denoted using the following notation: `α ≃ᵤ β`.


### PR DESCRIPTION
This PR ensures we only have a single H1 header per lean file in the `Topology` subdirectory. We do this for the following reasons:

- Having more than one H1 header per file is likely to hamper both assistive technologies and SEO, since it introduces ambiguity about what the title of the resulting documentation webpage actually is.
- The [documentation style guide](https://leanprover-community.github.io/contribute/doc.html) asks for the title of the file to be H1, any other header in the file-level docstring to be H2, and sectioning headers to be H3.

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

When merging, all the commits will be squashed into a single commit
listing all co-authors.

Co-authors in the squash commit are gathered from two sources:

First, all authors of commits to this PR branch are included. Thus,
one way to add co-authors is to include at least one commit authored by
each co-author among the commits in the pull request. If necessary, you
may create empty commits to indicate co-authorship, using commands like so:

git commit --author="Author Name <author@email.com>" --allow-empty -m "add Author Name as coauthor"

Second, co-authors can also be listed in lines at the very bottom of
the commit message (that is, directly before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines
at the bottom of the commit message (before the `---`, and also before
any "Co-authored-by" lines) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
