### PR TITLE
[Merged by Bors] - doc(SetTheory): ensure only a single H1 header per file

### DIFF
--- a/Mathlib/SetTheory/Game/Birthday.lean
+++ b/Mathlib/SetTheory/Game/Birthday.lean
@@ -24,12 +24,12 @@ The birthday of a pre-game can be understood as representing the depth of its ga
 other hand, the birthday of a game more closely matches Conway's original description. The lemma
 `SetTheory.Game.birthday_eq_pGameBirthday` links both definitions together.
 
-# Main declarations
+## Main declarations
 
 - `SetTheory.PGame.birthday`: The birthday of a pre-game.
 - `SetTheory.Game.birthday`: The birthday of a game.
 
-# Todo
+## Todo
 
 - Characterize the birthdays of other basic arithmetical operations.
 -/

--- a/Mathlib/SetTheory/Game/Ordinal.lean
+++ b/Mathlib/SetTheory/Game/Ordinal.lean
@@ -19,7 +19,7 @@ game whose left set consists of all previous ordinals.
 
 The map to surreals is defined in `Ordinal.toSurreal`.
 
-# Main declarations
+## Main declarations
 
 - `Ordinal.toPGame`: The canonical map between ordinals and pre-games.
 - `Ordinal.toPGameEmbedding`: The order embedding version of the previous map.

--- a/Mathlib/SetTheory/Ordinal/CantorNormalForm.lean
+++ b/Mathlib/SetTheory/Ordinal/CantorNormalForm.lean
@@ -14,7 +14,7 @@ The Cantor normal form of an ordinal is generally defined as its base `ω` expan
 non-zero exponents in decreasing order. Here, we more generally define a base `b` expansion
 `Ordinal.CNF` in this manner, which is well-behaved for any `b ≥ 2`.
 
-# Implementation notes
+## Implementation notes
 
 We implement `Ordinal.CNF` as an association list, where keys are exponents and values are
 coefficients. This is because this structure intrinsically reflects two key properties of the Cantor
@@ -23,7 +23,7 @@ normal form:
 - It is ordered.
 - It has finitely many entries.
 
-# Todo
+## Todo
 
 - Prove the basic results relating the CNF to the arithmetic operations on ordinals.
 -/


### PR DESCRIPTION
This PR ensures we only have a single H1 header per lean file in the `SetTheory` subdirectory. We do this for the following reasons:

- Having more than one H1 header per file is likely to hamper both assistive technologies and SEO, since it introduces ambiguity about what the title of the resulting documentation webpage actually is.
- The [documentation style guide](https://leanprover-community.github.io/contribute/doc.html) asks for the title of the file to be H1, any other header in the file-level docstring to be H2, and sectioning headers to be H3.

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

When merging, all the commits will be squashed into a single commit
listing all co-authors.

Co-authors in the squash commit are gathered from two sources:

First, all authors of commits to this PR branch are included. Thus,
one way to add co-authors is to include at least one commit authored by
each co-author among the commits in the pull request. If necessary, you
may create empty commits to indicate co-authorship, using commands like so:

git commit --author="Author Name <author@email.com>" --allow-empty -m "add Author Name as coauthor"

Second, co-authors can also be listed in lines at the very bottom of
the commit message (that is, directly before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines
at the bottom of the commit message (before the `---`, and also before
any "Co-authored-by" lines) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
