### PR TITLE
[Merged by Bors] - doc(Tactic): ensure only a single H1 header per file

### DIFF
--- a/Mathlib/Tactic/Linarith/Oracle/SimplexAlgorithm/PositiveVector.lean
+++ b/Mathlib/Tactic/Linarith/Oracle/SimplexAlgorithm/PositiveVector.lean
@@ -17,7 +17,7 @@ the `strictIndexes` are positive and `A v = 0`.
 
 The function `findPositiveVector` solves this problem.
 
-# Algorithm sketch
+## Algorithm sketch
 
 1. We translate the problem stated above to some Linear Programming problem. See `stateLP` for
   details. Let us denote the corresponding matrix `B`.

--- a/Mathlib/Tactic/Linter/Lint.lean
+++ b/Mathlib/Tactic/Linter/Lint.lean
@@ -52,7 +52,7 @@ end Batteries.Tactic.Lint
 namespace Mathlib.Linter
 
 /-!
-# `dupNamespace` linter
+### `dupNamespace` linter
 
 The `dupNamespace` linter produces a warning when a declaration contains the same namespace
 at least twice consecutively.

--- a/Mathlib/Tactic/Linter/MinImports.lean
+++ b/Mathlib/Tactic/Linter/MinImports.lean
@@ -21,7 +21,7 @@ This is better suited, for instance, to split files.
 open Lean Elab Command Linter
 
 /-!
-# The "minImports" linter
+### The "minImports" linter
 
 The "minImports" linter tracks information about minimal imports over several commands.
 -/

--- a/Mathlib/Tactic/Linter/Style.lean
+++ b/Mathlib/Tactic/Linter/Style.lean
@@ -155,7 +155,7 @@ initialize addLinter missingEndLinter
 end Style.missingEnd
 
 /-!
-# The `cdot` linter
+### The `cdot` linter
 
 The `cdot` linter is a syntax-linter that flags uses of the "cdot" `·` that are achieved
 by typing a character different from `·`.
@@ -224,7 +224,7 @@ initialize addLinter cdotLinter
 end Style
 
 /-!
-# The `dollarSyntax` linter
+### The `dollarSyntax` linter
 
 The `dollarSyntax` linter flags uses of `<|` that are achieved by typing `$`.
 These are disallowed by the mathlib style guide, as using `<|` pairs better with `|>`.
@@ -264,7 +264,7 @@ initialize addLinter dollarSyntaxLinter
 end Style.dollarSyntax
 
 /-!
-# The `lambdaSyntax` linter
+### The `lambdaSyntax` linter
 
 The `lambdaSyntax` linter is a syntax linter that flags uses of the symbol `λ` to define anonymous
 functions, as opposed to the `fun` keyword. These are syntactically equivalent; mathlib style
@@ -310,7 +310,7 @@ initialize addLinter lambdaSyntaxLinter
 end Style.lambdaSyntax
 
 /-!
-# The "longFile" linter
+### The "longFile" linter
 
 The "longFile" linter emits a warning on files which are longer than a certain number of lines
 (1500 by default).
@@ -395,7 +395,7 @@ initialize addLinter longFileLinter
 
 end Style.longFile
 
-/-! # The "longLine linter" -/
+/-! ### The "longLine linter" -/
 
 /-- The "longLine" linter emits a warning on lines longer than 100 characters.
 We allow lines containing URLs to be longer, though. -/
@@ -481,7 +481,7 @@ initialize addLinter doubleUnderscore
 
 end Style.nameCheck
 
-/-! # The "openClassical" linter -/
+/-! ### The "openClassical" linter -/
 
 /-- The "openClassical" linter emits a warning on `open Classical` statements which are not
 scoped to a single declaration. A non-scoped `open Classical` can hide that some theorem statements
@@ -531,7 +531,7 @@ initialize addLinter openClassicalLinter
 
 end Style.openClassical
 
-/-! # The "show" linter -/
+/-! ### The "show" linter -/
 
 /--
 The "show" linter emits a warning if the `show` tactic changed the goal. `show` should only be used

--- a/Mathlib/Tactic/NormNum/Basic.lean
+++ b/Mathlib/Tactic/NormNum/Basic.lean
@@ -12,7 +12,7 @@ import Mathlib.Tactic.HaveI
 import Mathlib.Tactic.ClearExclamation
 
 /-!
-## `norm_num` basic plugins
+# `norm_num` basic plugins
 
 This file adds `norm_num` plugins for
 * constructors and constants
@@ -34,7 +34,7 @@ open Qq
 
 theorem IsInt.raw_refl (n : ℤ) : IsInt n n := ⟨rfl⟩
 
-/-! # Constructors and constants -/
+/-! ### Constructors and constants -/
 
 theorem isNat_zero (α) [AddMonoidWithOne α] : IsNat (Zero.zero : α) (nat_lit 0) :=
   ⟨Nat.cast_zero.symm⟩
@@ -113,7 +113,7 @@ theorem isNat_natAbs_neg : {n : ℤ} → {a : ℕ} → IsInt n (.negOfNat a) →
   | .isNegNat _ a p => assumeInstancesCommute; return .isNat sℕ a q(isNat_natAbs_neg $p)
   | _ => failure
 
-/-! # Casts -/
+/-! ### Casts -/
 
 theorem isNat_natCast {R} [AddMonoidWithOne R] (n m : ℕ) :
     IsNat n m → IsNat (n : R) m := by rintro ⟨⟨⟩⟩; exact ⟨rfl⟩
@@ -149,7 +149,7 @@ theorem isintCast {R} [Ring R] (n m : ℤ) :
     return .isNegNat _ na q(isintCast $a (.negOfNat $na) $pa)
   | _ => failure
 
-/-! # Arithmetic -/
+/-! ### Arithmetic -/
 
 library_note2 «norm_num lemma function equality» /--
 Note: Many of the lemmas in this file use a function equality hypothesis like `f = HAdd.hAdd`
@@ -579,7 +579,7 @@ such that `norm_num` successfully recognises both `a` and `b`. -/
     assumeInstancesCommute
     return .isRat dα qa na da q(isRat_div $pa)
 
-/-! # Logic -/
+/-! ### Logic -/
 
 /-- The `norm_num` extension which identifies `True`. -/
 @[norm_num True] def evalTrue : NormNumExt where eval {u α} e :=
@@ -599,7 +599,7 @@ such that `norm_num` successfully recognises `a`. -/
   | true => return .isFalse q(not_not_intro $p)
   | false => return .isTrue q($p)
 
-/-! # (In)equalities -/
+/-! ### (In)equalities -/
 
 variable {α : Type u}
 
@@ -626,7 +626,7 @@ theorem ne_of_false_of_true {a b : Prop} (ha : ¬a) (hb : b) : a ≠ b := mt (·
 theorem ne_of_true_of_false {a b : Prop} (ha : a) (hb : ¬b) : a ≠ b := mt (· ▸ ha) hb
 theorem eq_of_false {a b : Prop} (ha : ¬a) (hb : ¬b) : a = b := propext (iff_of_false ha hb)
 
-/-! # Nat operations -/
+/-! ### Nat operations -/
 
 theorem isNat_natSucc : {a : ℕ} → {a' c : ℕ} →
     IsNat a a' → Nat.succ a' = c → IsNat (a.succ) c

--- a/Mathlib/Tactic/NormNum/Ineq.lean
+++ b/Mathlib/Tactic/NormNum/Ineq.lean
@@ -143,7 +143,7 @@ theorem isRat_lt_false [Ring α] [LinearOrder α] [IsStrictOrderedRing α]
     (ha : IsRat a na da) (hb : IsRat b nb db) (h : decide (nb * da ≤ na * db)) : ¬a < b :=
   not_lt_of_ge (isRat_le_true hb ha h)
 
-/-! # (In)equalities -/
+/-! ### (In)equalities -/
 
 theorem isNat_lt_true [Semiring α] [PartialOrder α] [IsOrderedRing α] [CharZero α] :
     {a b : α} → {a' b' : ℕ} →

--- a/Mathlib/Tactic/TFAE.lean
+++ b/Mathlib/Tactic/TFAE.lean
@@ -18,7 +18,7 @@ This file provides the tactics `tfae_have` and `tfae_finish` for proving goals o
 
 namespace Mathlib.Tactic.TFAE
 
-/-! # Parsing and syntax
+/-! ### Parsing and syntax
 
 We implement `tfae_have` in terms of a syntactic `have`. To support as much of the same syntax as
 possible, we recreate the parsers for `have`, except with the changes necessary for `tfae_have`.
@@ -139,7 +139,7 @@ example : TFAE [P, Q, R] := by
 syntax (name := tfaeFinish) "tfae_finish" : tactic
 
 
-/-! # Setup -/
+/-! ### Setup -/
 
 open List Lean Meta Expr Elab Tactic Mathlib.Tactic Qq
 
@@ -159,7 +159,7 @@ where
     | ~q($a :: $l') => return (a :: (← getExplicitList l'))
     | e => throwError "{e} must be an explicit list of propositions"
 
-/-! # Proof construction -/
+/-! ### Proof construction -/
 
 variable (hyps : Array (ℕ × ℕ × Expr)) (atoms : Array Q(Prop))
 
@@ -219,7 +219,7 @@ def proveTFAE (is : List ℕ) (l : Q(List Prop)) : MetaM Q(TFAE $l) := do
     let il ← proveGetLastDImpl hyps atoms i i' is' P P' l'
     return q(tfae_of_cycle $c $il)
 
-/-! # `tfae_have` components -/
+/-! ### `tfae_have` components -/
 
 /-- Construct a name for a hypothesis introduced by `tfae_have`. -/
 def mkTFAEId : TSyntax ``tfaeType → MacroM Name
@@ -240,7 +240,7 @@ def elabIndex (i : TSyntax `num) (maxIndex : ℕ) : MetaM ℕ := do
     throwErrorAt i "{i} must be between 1 and {maxIndex}"
   return i'
 
-/-! # Tactic implementation -/
+/-! ### Tactic implementation -/
 
 /-- Accesses the propositions at indices `i` and `j` of `tfaeList`, and constructs the expression
 `Pi <arr> Pj`, which will be the type of our `tfae_have` hypothesis -/
@@ -317,7 +317,7 @@ end Mathlib.Tactic.TFAE
 
 /-!
 
-# Deprecated "Goal-style" `tfae_have`
+### Deprecated "Goal-style" `tfae_have`
 
 This syntax and its implementation, which behaves like "Mathlib `have`" is deprecated; we preserve
 it here to provide graceful deprecation behavior.

--- a/Mathlib/Tactic/Widget/CongrM.lean
+++ b/Mathlib/Tactic/Widget/CongrM.lean
@@ -16,7 +16,7 @@ a `congrm` call with holes specified by selecting subexpressions in the goal.
 open Lean Meta Server ProofWidgets
 
 
-/-! # CongrM widget -/
+/-! ### CongrM widget -/
 
 /-- Return the link text and inserted text above and below of the congrm widget. -/
 @[nolint unusedArguments]


### PR DESCRIPTION
This PR ensures we only have a single H1 header per lean file in the `Tactic` subdirectory. We do this for the following reasons:

- Having more than one H1 header per file is likely to hamper both assistive technologies and SEO, since it introduces ambiguity about what the title of the resulting documentation webpage actually is.
- The [documentation style guide](https://leanprover-community.github.io/contribute/doc.html) asks for the title of the file to be H1, any other header in the file-level docstring to be H2, and sectioning headers to be H3.

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

When merging, all the commits will be squashed into a single commit
listing all co-authors.

Co-authors in the squash commit are gathered from two sources:

First, all authors of commits to this PR branch are included. Thus,
one way to add co-authors is to include at least one commit authored by
each co-author among the commits in the pull request. If necessary, you
may create empty commits to indicate co-authorship, using commands like so:

git commit --author="Author Name <author@email.com>" --allow-empty -m "add Author Name as coauthor"

Second, co-authors can also be listed in lines at the very bottom of
the commit message (that is, directly before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines
at the bottom of the commit message (before the `---`, and also before
any "Co-authored-by" lines) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
