### PR TITLE
[Merged by Bors] - feat(FieldTheory): prime fields

### DIFF
--- a/Mathlib.lean
+++ b/Mathlib.lean
@@ -3958,6 +3958,7 @@ import Mathlib.FieldTheory.NormalizedTrace
 import Mathlib.FieldTheory.Perfect
 import Mathlib.FieldTheory.PerfectClosure
 import Mathlib.FieldTheory.PolynomialGaloisGroup
+import Mathlib.FieldTheory.PrimeField
 import Mathlib.FieldTheory.PrimitiveElement
 import Mathlib.FieldTheory.PurelyInseparable.Basic
 import Mathlib.FieldTheory.PurelyInseparable.Exponent

--- a/Mathlib/FieldTheory/PrimeField.lean
+++ b/Mathlib/FieldTheory/PrimeField.lean
@@ -1,0 +1,55 @@
+/-
+Copyright (c) 2025 Xavier Roblot. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Xavier Roblot, Kenny Lau
+-/
+import Mathlib.Algebra.Algebra.Rat
+import Mathlib.Algebra.CharP.IntermediateField
+import Mathlib.Algebra.Field.ZMod
+
+/-!
+# Prime fields
+
+A prime field is a field that does not contain any nontrivial subfield. Prime fields are `ℚ` in
+characteristic `0` and `ZMod p` in characteristic `p` with `p` a prime number. Any field `K`
+contains a prime field, it is the smallest field contained in `K`.
+
+## Results
+
+* The fields `ℚ` and `ZMod p` are prime fields. This is stated as the instance that
+  the corresponding `Subfield` type is a `Subsingleton`.
+* `Subfield.bot_eq_of_charZero` : the smallest subfield of a field of characteristic `0` is (the
+  image of) `ℚ`.
+* `Subfield.bot_eq_of_zMod_algebra`: the smallest subfield of a field of characteristic `p` is (the
+  image of) `ZMod p`.
+
+-/
+
+instance : Subsingleton (Subfield ℚ) := subsingleton_of_top_le_bot fun x _ ↦
+  have h := Subsingleton.elim ((⊥ : Subfield ℚ).subtype.comp (Rat.castHom _)) (.id _ : ℚ →+* ℚ)
+  (congr($h x) : _ = x) ▸ Subtype.prop _
+
+instance (p : ℕ) [hp : Fact (Nat.Prime p)] : Subsingleton (Subfield (ZMod p)) :=
+ subsingleton_of_top_le_bot fun x _ ↦
+  have h := Subsingleton.elim ((⊥ : Subfield (ZMod p)).subtype.comp
+    (ZMod.castHom dvd_rfl _)) (.id _ : ZMod p →+* ZMod p)
+  (congr($h x) : _ = x) ▸ Subtype.prop _
+
+/--
+The smallest subfield of a field of characteristic `0` is (the image of) `ℚ`.
+-/
+theorem Subfield.bot_eq_of_charZero {K : Type*} [Field K] [CharZero K] :
+    (⊥ : Subfield K) = (algebraMap ℚ K).fieldRange := by
+  rw [eq_comm, eq_bot_iff, ← Subfield.map_bot (algebraMap ℚ K),
+    subsingleton_iff_bot_eq_top.mpr inferInstance, ← RingHom.fieldRange_eq_map]
+
+/--
+The smallest subfield of a field of characteristic `p` is (the image of) `ZMod p`.
+Note that the fact that the field `K` is of characteristic `p` is stated by the fact that it is
+`ZMod p`-algebra.
+-/
+theorem Subfield.bot_eq_of_zMod_algebra {K : Type*} (p : ℕ) [hp : Fact (Nat.Prime p)]
+    [Field K] [Algebra (ZMod p) K] :
+    (⊥ : Subfield K) = (algebraMap (ZMod p) K).fieldRange := by
+  rw [eq_comm, eq_bot_iff, ← Subfield.map_bot (algebraMap (ZMod p) K),
+    subsingleton_iff_bot_eq_top.mpr inferInstance, ← RingHom.fieldRange_eq_map]

--- a/Mathlib/FieldTheory/PrimeField.lean
+++ b/Mathlib/FieldTheory/PrimeField.lean
@@ -12,11 +12,11 @@ import Mathlib.Algebra.Field.ZMod
 
 A prime field is a field that does not contain any nontrivial subfield. Prime fields are `ℚ` in
 characteristic `0` and `ZMod p` in characteristic `p` with `p` a prime number. Any field `K`
-contains a prime field, it is the smallest field contained in `K`.
+contains a unique prime field: it is the smallest field contained in `K`.
 
 ## Results
 
-* The fields `ℚ` and `ZMod p` are prime fields. This is stated as the instance that
+* The fields `ℚ` and `ZMod p` are prime fields. These are stated as the instances that says yha
   the corresponding `Subfield` type is a `Subsingleton`.
 * `Subfield.bot_eq_of_charZero` : the smallest subfield of a field of characteristic `0` is (the
   image of) `ℚ`.

--- a/Mathlib/FieldTheory/PrimeField.lean
+++ b/Mathlib/FieldTheory/PrimeField.lean
@@ -16,7 +16,7 @@ contains a unique prime field: it is the smallest field contained in `K`.
 
 ## Results
 
-* The fields `ℚ` and `ZMod p` are prime fields. These are stated as the instances that says yha
+* The fields `ℚ` and `ZMod p` are prime fields. These are stated as the instances that says that
   the corresponding `Subfield` type is a `Subsingleton`.
 * `Subfield.bot_eq_of_charZero` : the smallest subfield of a field of characteristic `0` is (the
   image of) `ℚ`.


### PR DESCRIPTION
A prime field is a field that does not contain any nontrivial subfield.

In this PR, we prove that
- `ℚ` and `ZMod p` (`p` prime number) are prime fields.
- the smallest subfield of a field of characteristic `0` is `ℚ`.
- the smallest subfield of a field of characteristic `p` is `ZMod p`.


Co-authored-by: Kenny Lau <kc_kennylau@yahoo.com.hk>

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

When merging, all the commits will be squashed into a single commit
listing all co-authors.

Co-authors in the squash commit are gathered from two sources:

First, all authors of commits to this PR branch are included. Thus,
one way to add co-authors is to include at least one commit authored by
each co-author among the commits in the pull request. If necessary, you
may create empty commits to indicate co-authorship, using commands like so:

git commit --author="Author Name <author@email.com>" --allow-empty -m "add Author Name as coauthor"

Second, co-authors can also be listed in lines at the very bottom of
the commit message (that is, directly before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines
at the bottom of the commit message (before the `---`, and also before
any "Co-authored-by" lines) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->


