### PR TITLE
[Merged by Bors] - feat: Add exists_toCycle_toList and toCycle_next

### DIFF
--- a/Mathlib/GroupTheory/Perm/Cycle/Concrete.lean
+++ b/Mathlib/GroupTheory/Perm/Cycle/Concrete.lean
@@ -380,6 +380,19 @@ theorem nontrivial_toCycle (f : Perm α) (hf : IsCycle f) : (toCycle f hf).Nontr
   simp [toCycle_eq_toList f hf x hx, hx, Cycle.nontrivial_coe_nodup_iff (nodup_toList _ _)]
 
 @[simp]
+theorem mem_toCycle_iff_support (f : Perm α) (hf : f.IsCycle) : x ∈ f.toCycle hf ↔ f x ≠ x := by
+  constructor
+  · have ⟨ l, hl ⟩ := exists_toCycle_toList f hf
+    simp only [hl, Cycle.mem_coe_iff, ne_eq]
+    intro h
+    have ⟨ h1, h2 ⟩ := mem_toList_iff.mp h
+    exact ((isCycle_iff_sameCycle (mem_support.mp h2)).mp (y := x) hf).mp h1
+  · intro h
+    simp only [toCycle_eq_toList f hf x h, Cycle.mem_coe_iff, toList, mem_iterate, iterate_eq_pow]
+    use 0
+    exact ⟨ by simpa, by simp ⟩
+
+@[simp]
 theorem toCycle_next (f : Perm α) (hf : f.IsCycle) (hx : x ∈ toCycle f hf) :
     (toCycle f hf).next (nodup_toCycle f hf) x hx = f x := by
   have ⟨ l, hl ⟩ := exists_toCycle_toList f hf

--- a/Mathlib/GroupTheory/Perm/Cycle/Concrete.lean
+++ b/Mathlib/GroupTheory/Perm/Cycle/Concrete.lean
@@ -368,6 +368,9 @@ theorem toCycle_eq_toList (f : Perm α) (hf : IsCycle f) (x : α) (hx : f x ≠ 
   rw [toCycle, key]
   simp [hx]
 
+theorem exists_toCycle_toList (f : Perm α) (hf : IsCycle f) : ∃ x, toCycle f hf = toList f x :=
+  Exists.casesOn hf (fun x h => ⟨ x, Perm.toCycle_eq_toList f hf x h.1⟩)
+
 theorem nodup_toCycle (f : Perm α) (hf : IsCycle f) : (toCycle f hf).Nodup := by
   obtain ⟨x, hx, -⟩ := id hf
   simpa [toCycle_eq_toList f hf x hx] using nodup_toList _ _
@@ -375,6 +378,13 @@ theorem nodup_toCycle (f : Perm α) (hf : IsCycle f) : (toCycle f hf).Nodup := b
 theorem nontrivial_toCycle (f : Perm α) (hf : IsCycle f) : (toCycle f hf).Nontrivial := by
   obtain ⟨x, hx, -⟩ := id hf
   simp [toCycle_eq_toList f hf x hx, hx, Cycle.nontrivial_coe_nodup_iff (nodup_toList _ _)]
+
+@[simp]
+theorem toCycle_next (f : Perm α) (hf : f.IsCycle) (hx : x ∈ toCycle f hf) :
+    (toCycle f hf).next (nodup_toCycle f hf) x hx = f x := by
+  have ⟨ l, hl ⟩ := exists_toCycle_toList f hf
+  simp only [hl, Cycle.mem_coe_iff] at ⊢ hx
+  exact Equiv.Perm.next_toList_eq_apply f l x hx
 
 /-- Any cyclic `f : Perm α` is isomorphic to the nontrivial `Cycle α`
 that corresponds to repeated application of `f`.


### PR DESCRIPTION
Adds exists_toCycle_toList and toCycle_next.


See this discussion:
https://leanprover.zulipchat.com/#narrow/channel/217875-Is-there-code-for-X.3F/topic/Cycles.20of.20permutation.20appear.20to.20be.20missing.20glue.20lemmas/with/556731504