### PR TITLE
[Merged by Bors] - feat: add `WithLp.map` and variants

### DIFF
--- a/Mathlib/Analysis/Normed/Lp/WithLp.lean
+++ b/Mathlib/Analysis/Normed/Lp/WithLp.lean
@@ -59,7 +59,7 @@ def WithLp.delabToLp : Delab := delabApp
 
 end Notation
 
-variable (p : ℝ≥0∞) (K K' K'' V V' V'' : Type*)
+variable (p : ℝ≥0∞) (K K' : Type*) {K'' : Type*} (V : Type*) {V' V'' : Type*}
 
 namespace WithLp
 
@@ -114,8 +114,6 @@ lemma ofLp_bijective : Function.Bijective (@ofLp p V) :=
 
 lemma toLp_bijective : Function.Bijective (@toLp p V) :=
   ⟨toLp_injective p, toLp_surjective p⟩
-
-variable {V' V''}
 
 /-- Lift a function to `WithLp`. -/
 @[simp]
@@ -263,7 +261,7 @@ instance instModuleFinite
 
 section LinearMap
 
-variable {K K' K'' V} [Semiring K] [Semiring K'] [Semiring K'']
+variable {K K' V} [Semiring K] [Semiring K'] [Semiring K'']
   {σ : K →+* K'} {σ' : K' →+* K} [RingHomInvPair σ σ'] [RingHomInvPair σ' σ]
   {τ : K' →+* K''} {τ' : K'' →+* K'} [RingHomInvPair τ τ'] [RingHomInvPair τ' τ]
   {ρ : K →+* K''} {ρ' : K'' →+* K} [RingHomInvPair ρ ρ'] [RingHomInvPair ρ' ρ]

--- a/Mathlib/Analysis/Normed/Lp/WithLp.lean
+++ b/Mathlib/Analysis/Normed/Lp/WithLp.lean
@@ -273,20 +273,20 @@ variable {K K' V} [Semiring K] [Semiring K'] [Semiring K'']
 namespace LinearMap
 
 /-- Lift a (semi)linear map to `WithLp`. -/
-def withLp (f : V →ₛₗ[σ] V') : WithLp p V →ₛₗ[σ] WithLp p V' :=
+def withLpMap (f : V →ₛₗ[σ] V') : WithLp p V →ₛₗ[σ] WithLp p V' :=
   (WithLp.linearEquiv p K' V').symm.toLinearMap ∘ₛₗ f ∘ₛₗ (WithLp.linearEquiv p K V).toLinearMap
 
 @[simp]
-theorem coe_withLp (f : V →ₛₗ[σ] V') : ⇑(withLp p f) = WithLp.map p f :=
+theorem coe_withLpMap (f : V →ₛₗ[σ] V') : ⇑(withLpMap p f) = WithLp.map p f :=
   rfl
 
 @[simp]
-theorem withLp_id : withLp p (LinearMap.id (R := K) (M := V)) = LinearMap.id :=
+theorem withLpMap_id : withLpMap p (LinearMap.id (R := K) (M := V)) = LinearMap.id :=
   rfl
 
 @[simp]
-theorem withLp_comp (f : V' →ₛₗ[τ] V'') (g : V →ₛₗ[σ] V') :
-    withLp p (f ∘ₛₗ g) = withLp p f ∘ₛₗ withLp p g :=
+theorem withLpMap_comp (f : V' →ₛₗ[τ] V'') (g : V →ₛₗ[σ] V') :
+    withLpMap p (f ∘ₛₗ g) = withLpMap p f ∘ₛₗ withLpMap p g :=
   rfl
 
 end LinearMap

--- a/Mathlib/Analysis/Normed/Lp/WithLp.lean
+++ b/Mathlib/Analysis/Normed/Lp/WithLp.lean
@@ -259,7 +259,9 @@ instance instModuleFinite
     Module.Finite K (WithLp p V) :=
   Module.Finite.equiv (WithLp.linearEquiv p K V).symm
 
-section LinearMap
+end WithLp
+
+section
 
 variable {K K' V} [Semiring K] [Semiring K'] [Semiring K'']
   {σ : K →+* K'} {σ' : K' →+* K} [RingHomInvPair σ σ'] [RingHomInvPair σ' σ]
@@ -268,43 +270,50 @@ variable {K K' V} [Semiring K] [Semiring K'] [Semiring K'']
   [RingHomCompTriple σ τ ρ] [RingHomCompTriple τ' σ' ρ']
   [AddCommGroup V] [Module K V] [AddCommGroup V'] [Module K' V'] [AddCommGroup V''] [Module K'' V'']
 
+namespace LinearMap
+
 /-- Lift a (semi)linear map to `WithLp`. -/
-protected def mapₗ (f : V →ₛₗ[σ] V') : WithLp p V →ₛₗ[σ] WithLp p V' :=
+def withLp (f : V →ₛₗ[σ] V') : WithLp p V →ₛₗ[σ] WithLp p V' :=
   (WithLp.linearEquiv p K' V').symm.toLinearMap ∘ₛₗ f ∘ₛₗ (WithLp.linearEquiv p K V).toLinearMap
 
 @[simp]
-theorem coe_mapₗ (f : V →ₛₗ[σ] V') : ⇑(WithLp.mapₗ p f) = WithLp.map p f :=
+theorem coe_withLp (f : V →ₛₗ[σ] V') : ⇑(withLp p f) = WithLp.map p f :=
   rfl
 
 @[simp]
-theorem mapₗ_id : WithLp.mapₗ p (LinearMap.id (R := K) (M := V)) = LinearMap.id :=
+theorem withLp_id : withLp p (LinearMap.id (R := K) (M := V)) = LinearMap.id :=
   rfl
 
 @[simp]
-theorem mapₗ_comp (f : V' →ₛₗ[τ] V'') (g : V →ₛₗ[σ] V') :
-    WithLp.mapₗ p (f ∘ₛₗ g) = WithLp.mapₗ p f ∘ₛₗ WithLp.mapₗ p g :=
-  rfl
-
-/-- Lift a (semi)linear equivalence to `WithLp`. -/
-protected def congrₗ (f : V ≃ₛₗ[σ] V') : WithLp p V ≃ₛₗ[σ] WithLp p V' :=
-  (WithLp.linearEquiv p K V).trans <| f.trans <| (WithLp.linearEquiv p K' V').symm
-
-@[simp]
-theorem coe_congrₗ (f : V ≃ₛₗ[σ] V') : ⇑(WithLp.congrₗ p f) = WithLp.map p f :=
-  rfl
-
-@[simp]
-theorem congrₗ_symm (f : V ≃ₛₗ[σ] V') : (WithLp.congrₗ p f).symm = WithLp.congrₗ p f.symm :=
-  rfl
-
-@[simp]
-theorem congrₗ_refl : WithLp.congrₗ p (LinearEquiv.refl K V) = LinearEquiv.refl K _ :=
-  rfl
-
-theorem congrₗ_comp (f : V ≃ₛₗ[σ] V') (g : V' ≃ₛₗ[τ] V'') :
-    WithLp.congrₗ p (f.trans g) = (WithLp.congrₗ p f).trans (WithLp.congrₗ p g) :=
+theorem withLp_comp (f : V' →ₛₗ[τ] V'') (g : V →ₛₗ[σ] V') :
+    withLp p (f ∘ₛₗ g) = withLp p f ∘ₛₗ withLp p g :=
   rfl
 
 end LinearMap
 
-end WithLp
+namespace LinearEquiv
+
+/-- Lift a (semi)linear equivalence to `WithLp`. -/
+def withLpCongr (f : V ≃ₛₗ[σ] V') : WithLp p V ≃ₛₗ[σ] WithLp p V' :=
+  (WithLp.linearEquiv p K V).trans <| f.trans <| (WithLp.linearEquiv p K' V').symm
+
+@[simp]
+theorem coe_withLpCongr (f : V ≃ₛₗ[σ] V') : ⇑(withLpCongr p f) = WithLp.map p f :=
+  rfl
+
+@[simp]
+theorem withLpCongr_symm (f : V ≃ₛₗ[σ] V') : (withLpCongr p f).symm = withLpCongr p f.symm :=
+  rfl
+
+@[simp]
+theorem withLpCongr_refl :
+    withLpCongr p (LinearEquiv.refl K V) = LinearEquiv.refl K _ :=
+  rfl
+
+theorem withLpCongr_trans (f : V ≃ₛₗ[σ] V') (g : V' ≃ₛₗ[τ] V'') :
+    withLpCongr p (f.trans g) = (withLpCongr p f).trans (withLpCongr p g) :=
+  rfl
+
+end LinearEquiv
+
+end


### PR DESCRIPTION
---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

When merging, all the commits will be squashed into a single commit
listing all co-authors.

Co-authors in the squash commit are gathered from two sources:

First, all authors of commits to this PR branch are included. Thus,
one way to add co-authors is to include at least one commit authored by
each co-author among the commits in the pull request. If necessary, you
may create empty commits to indicate co-authorship, using commands like so:

git commit --author="Author Name <author@email.com>" --allow-empty -m "add Author Name as coauthor"

Second, co-authors can also be listed in lines at the very bottom of
the commit message (that is, directly before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines
at the bottom of the commit message (before the `---`, and also before
any "Co-authored-by" lines) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
