### PR TITLE
[Merged by Bors] - chore(Topology/Sets/Compacts): switch to `×ˢ` notation for products

### DIFF
--- a/Mathlib/MeasureTheory/Measure/Haar/OfBasis.lean
+++ b/Mathlib/MeasureTheory/Measure/Haar/OfBasis.lean
@@ -214,7 +214,7 @@ theorem parallelepiped_map (b : Basis ι ℝ E) (e : E ≃ₗ[ℝ] F) :
   PositiveCompacts.ext (image_parallelepiped e.toLinearMap _).symm
 
 theorem prod_parallelepiped (v : Basis ι ℝ E) (w : Basis ι' ℝ F) :
-    (v.prod w).parallelepiped = v.parallelepiped.prod w.parallelepiped := by
+    (v.prod w).parallelepiped = v.parallelepiped ×ˢ w.parallelepiped := by
   ext x
   simp only [Basis.coe_parallelepiped, TopologicalSpace.PositiveCompacts.coe_prod, Set.mem_prod,
     mem_parallelepiped_iff]

--- a/Mathlib/Topology/MetricSpace/Closeds.lean
+++ b/Mathlib/Topology/MetricSpace/Closeds.lean
@@ -396,7 +396,7 @@ theorem lipschitz_sup :
   .of_edist_le fun _ _ => hausdorffEdist_union_le
 
 theorem lipschitz_prod :
-    LipschitzWith 1 fun p : NonemptyCompacts α × NonemptyCompacts β => p.1.prod p.2 :=
+    LipschitzWith 1 fun p : NonemptyCompacts α × NonemptyCompacts β => p.1 ×ˢ p.2 :=
   .of_edist_le fun _ _ => hausdorffEdist_prod_le
 
 end NonemptyCompacts

--- a/Mathlib/Topology/Sets/Compacts.lean
+++ b/Mathlib/Topology/Sets/Compacts.lean
@@ -195,18 +195,23 @@ theorem coe_equiv_apply_eq_preimage (f : α ≃ₜ β) (K : Compacts α) :
 
 /-- The product of two `TopologicalSpace.Compacts`, as a `TopologicalSpace.Compacts` in the product
 space. -/
-protected def prod (K : Compacts α) (L : Compacts β) : Compacts (α × β) where
-  carrier := K ×ˢ L
-  isCompact' := IsCompact.prod K.2 L.2
+instance : SProd (Compacts α) (Compacts β) (Compacts (α × β)) where
+  sprod K L := { carrier := K ×ˢ L, isCompact' := IsCompact.prod K.2 L.2 }
+
+/-- The product of two `TopologicalSpace.Compacts`, as a `TopologicalSpace.Compacts` in the product
+space. -/
+@[deprecated "Use `K ×ˢ L` instead" (since := "2025-11-15")]
+protected abbrev prod (K : Compacts α) (L : Compacts β) : Compacts (α × β) :=
+  K ×ˢ L
 
 @[simp]
 theorem coe_prod (K : Compacts α) (L : Compacts β) :
-    (K.prod L : Set (α × β)) = (K : Set α) ×ˢ (L : Set β) :=
+    (K ×ˢ L : Compacts (α × β)) = (K : Set α) ×ˢ (L : Set β) :=
   rfl
 
 @[simp]
 theorem singleton_prod_singleton (x : α) (y : β) :
-    Compacts.prod {x} {y} = {(x, y)} :=
+    ({x} ×ˢ {y} : Compacts (α × β)) = {(x, y)} :=
   Compacts.ext Set.singleton_prod_singleton
 
 -- todo: add `pi`
@@ -313,17 +318,24 @@ instance toNonempty {s : NonemptyCompacts α} : Nonempty s :=
 
 /-- The product of two `TopologicalSpace.NonemptyCompacts`, as a `TopologicalSpace.NonemptyCompacts`
 in the product space. -/
-protected def prod (K : NonemptyCompacts α) (L : NonemptyCompacts β) : NonemptyCompacts (α × β) :=
-  { K.toCompacts.prod L.toCompacts with nonempty' := K.nonempty.prod L.nonempty }
+instance : SProd (NonemptyCompacts α) (NonemptyCompacts β) (NonemptyCompacts (α × β)) where
+  sprod K L := { K.toCompacts ×ˢ L.toCompacts with nonempty' := K.nonempty.prod L.nonempty }
+
+/-- The product of two `TopologicalSpace.NonemptyCompacts`, as a `TopologicalSpace.NonemptyCompacts`
+in the product space. -/
+@[deprecated "Use `K ×ˢ L` instead" (since := "2025-11-15")]
+protected abbrev prod (K : NonemptyCompacts α) (L : NonemptyCompacts β) :
+    NonemptyCompacts (α × β) :=
+  K ×ˢ L
 
 @[simp]
 theorem coe_prod (K : NonemptyCompacts α) (L : NonemptyCompacts β) :
-    (K.prod L : Set (α × β)) = (K : Set α) ×ˢ (L : Set β) :=
+    (K ×ˢ L : NonemptyCompacts (α × β)) = (K : Set α) ×ˢ (L : Set β) :=
   rfl
 
 @[simp]
 theorem singleton_prod_singleton (x : α) (y : β) :
-    NonemptyCompacts.prod {x} {y} = {(x, y)} :=
+    ({x} ×ˢ {y} : NonemptyCompacts (α × β)) = {(x, y)} :=
   NonemptyCompacts.ext Set.singleton_prod_singleton
 
 end NonemptyCompacts
@@ -442,16 +454,23 @@ instance nonempty' [WeaklyLocallyCompactSpace α] [Nonempty α] : Nonempty (Posi
 
 /-- The product of two `TopologicalSpace.PositiveCompacts`, as a `TopologicalSpace.PositiveCompacts`
 in the product space. -/
-protected def prod (K : PositiveCompacts α) (L : PositiveCompacts β) :
-    PositiveCompacts (α × β) where
-  toCompacts := K.toCompacts.prod L.toCompacts
-  interior_nonempty' := by
-    simp only [Compacts.carrier_eq_coe, Compacts.coe_prod, interior_prod_eq]
-    exact K.interior_nonempty.prod L.interior_nonempty
+instance : SProd (PositiveCompacts α) (PositiveCompacts β) (PositiveCompacts (α × β)) where
+  sprod K L :=
+    { toCompacts := K.toCompacts ×ˢ L.toCompacts
+      interior_nonempty' := by
+        simp only [Compacts.carrier_eq_coe, Compacts.coe_prod, interior_prod_eq]
+        exact K.interior_nonempty.prod L.interior_nonempty }
+
+/-- The product of two `TopologicalSpace.PositiveCompacts`, as a `TopologicalSpace.PositiveCompacts`
+in the product space. -/
+@[deprecated "Use `K ×ˢ L` instead" (since := "2025-11-15")]
+protected abbrev prod (K : PositiveCompacts α) (L : PositiveCompacts β) :
+    PositiveCompacts (α × β) :=
+  K ×ˢ L
 
 @[simp]
 theorem coe_prod (K : PositiveCompacts α) (L : PositiveCompacts β) :
-    (K.prod L : Set (α × β)) = (K : Set α) ×ˢ (L : Set β) :=
+    (K ×ˢ L : PositiveCompacts (α × β)) = (K : Set α) ×ˢ (L : Set β) :=
   rfl
 
 end PositiveCompacts
@@ -598,12 +617,19 @@ theorem map_comp (f : β → γ) (g : α → β) (hf : Continuous f) (hg : Conti
 
 /-- The product of two `TopologicalSpace.CompactOpens`, as a `TopologicalSpace.CompactOpens` in the
 product space. -/
-protected def prod (K : CompactOpens α) (L : CompactOpens β) : CompactOpens (α × β) :=
-  { K.toCompacts.prod L.toCompacts with isOpen' := K.isOpen.prod L.isOpen }
+instance : SProd (CompactOpens α) (CompactOpens β) (CompactOpens (α × β)) where
+  sprod K L := { K.toCompacts ×ˢ L.toCompacts with isOpen' := K.isOpen.prod L.isOpen }
+
+/-- The product of two `TopologicalSpace.CompactOpens`, as a `TopologicalSpace.CompactOpens` in the
+product space. -/
+@[deprecated "Use `K ×ˢ L` instead" (since := "2025-11-15")]
+protected abbrev prod (K : CompactOpens α) (L : CompactOpens β) :
+    CompactOpens (α × β) :=
+  K ×ˢ L
 
 @[simp]
 theorem coe_prod (K : CompactOpens α) (L : CompactOpens β) :
-    (K.prod L : Set (α × β)) = (K : Set α) ×ˢ (L : Set β) :=
+    (K ×ˢ L : CompactOpens (α × β)) = (K : Set α) ×ˢ (L : Set β) :=
   rfl
 
 end CompactOpens


### PR DESCRIPTION
---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

When merging, all the commits will be squashed into a single commit
listing all co-authors.

Co-authors in the squash commit are gathered from two sources:

First, all authors of commits to this PR branch are included. Thus,
one way to add co-authors is to include at least one commit authored by
each co-author among the commits in the pull request. If necessary, you
may create empty commits to indicate co-authorship, using commands like so:

git commit --author="Author Name <author@email.com>" --allow-empty -m "add Author Name as coauthor"

Second, co-authors can also be listed in lines at the very bottom of
the commit message (that is, directly before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines
at the bottom of the commit message (before the `---`, and also before
any "Co-authored-by" lines) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
