### PR TITLE
feat: `norm_num` extension for `IsSquare` via `Irrational`

### DIFF
--- a/Mathlib.lean
+++ b/Mathlib.lean
@@ -6428,6 +6428,7 @@ import Mathlib.Tactic.NormNum.Ineq
 import Mathlib.Tactic.NormNum.Inv
 import Mathlib.Tactic.NormNum.Irrational
 import Mathlib.Tactic.NormNum.IsCoprime
+import Mathlib.Tactic.NormNum.IsSquare
 import Mathlib.Tactic.NormNum.LegendreSymbol
 import Mathlib.Tactic.NormNum.ModEq
 import Mathlib.Tactic.NormNum.NatFactorial

--- a/Mathlib/Tactic.lean
+++ b/Mathlib/Tactic.lean
@@ -200,6 +200,7 @@ import Mathlib.Tactic.NormNum.Ineq
 import Mathlib.Tactic.NormNum.Inv
 import Mathlib.Tactic.NormNum.Irrational
 import Mathlib.Tactic.NormNum.IsCoprime
+import Mathlib.Tactic.NormNum.IsSquare
 import Mathlib.Tactic.NormNum.LegendreSymbol
 import Mathlib.Tactic.NormNum.ModEq
 import Mathlib.Tactic.NormNum.NatFactorial

--- a/Mathlib/Tactic/NormNum/Irrational.lean
+++ b/Mathlib/Tactic/NormNum/Irrational.lean
@@ -11,7 +11,7 @@ import Mathlib.Tactic.Rify
 /-! # `norm_num` extension for `Irrational`
 
 This module defines a `norm_num` extension for `Irrational x ^ y` for rational `x` and `y`. It also
-supports `Irrational √x` expressions.
+supports `Irrational √x` expressions. We also disprove `Irrational x` for rational `x`.
 
 ## Implementation details
 To prove that `(a / b) ^ (p / q)` is irrational, we reduce the problem to showing that `(a / b) ^ p`

--- a/Mathlib/Tactic/NormNum/Irrational.lean
+++ b/Mathlib/Tactic/NormNum/Irrational.lean
@@ -19,10 +19,6 @@ is not a `q`-th power of any rational number. This, in turn, reduces to proving 
 `b` is not a `q`-th power of a natural number, assuming `p` and `q` are coprime.
 To show that a given `n : ℕ` is not a `q`-th power, we find a natural number `k`
 such that `k ^ q < n < (k + 1) ^ q`, using binary search.
-
-## TODO
-Disprove `Irrational x` for rational `x`.
-
 -/
 
 namespace Tactic

--- a/Mathlib/Tactic/NormNum/IsSquare.lean
+++ b/Mathlib/Tactic/NormNum/IsSquare.lean
@@ -1,8 +1,20 @@
+/-
+Copyright (c) 2025 Vasilii Nesterov. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Vasilii Nesterov
+-/
 import Mathlib.Tactic.NormNum.Irrational
 
-namespace Tactic
+/-! # `norm_num` extension for `IsSquare`
 
-namespace NormNum
+This module defines a `norm_num` extension for `IsSquare x` for rational `x`.
+
+## Implementation details
+To decide `IsSquare x`, we reduce it to `0 ≤ x ∧ ¬ Irrational √x` and use the existing `norm_num`
+extensions for `Irrational` and `LE`.
+-/
+
+namespace Tactic.NormNum
 
 section Lemmas
 

--- a/Mathlib/Tactic/NormNum/IsSquare.lean
+++ b/Mathlib/Tactic/NormNum/IsSquare.lean
@@ -24,6 +24,7 @@ end Lemmas
 
 open Qq Lean Elab.Tactic Mathlib.Meta.NormNum
 
+/-- `norm_num` extension that decides `IsSquare x` for rational `x`. -/
 @[norm_num IsSquare _]
 def evalIsSquare : NormNumExt where eval {u α} e := do
   let 0 := u | failure

--- a/Mathlib/Tactic/NormNum/IsSquare.lean
+++ b/Mathlib/Tactic/NormNum/IsSquare.lean
@@ -1,0 +1,58 @@
+import Mathlib.Tactic.NormNum.Irrational
+
+namespace Tactic
+
+namespace NormNum
+
+section Lemmas
+
+private lemma IsSquare_nat_iff_not_Irrational_sqrt (n : ℕ) :
+    ¬ Irrational √(n : ℝ) ↔ IsSquare n := by
+  simp [irrational_sqrt_natCast_iff]
+
+private lemma IsSquare_int_iff_not_Irrational_sqrt (n : ℤ) (h : 0 ≤ n) :
+    ¬ Irrational √(n : ℝ) ↔ IsSquare n := by
+  rw [irrational_sqrt_intCast_iff]
+  simp [h]
+
+private lemma IsSquare_rat_iff_not_Irrational_sqrt (n : ℚ) (h : 0 ≤ n) :
+    ¬ Irrational √(n : ℝ) ↔ IsSquare n := by
+  rw [irrational_sqrt_ratCast_iff]
+  simp [h]
+
+end Lemmas
+
+open Qq Lean Elab.Tactic Mathlib.Meta.NormNum
+
+@[norm_num IsSquare _]
+def evalIsSquare : NormNumExt where eval {u α} e := do
+  let 0 := u | failure
+  let ~q(Prop) := α | failure
+  match e with
+  | ~q(@IsSquare ℕ _ $x) =>
+    let e' := q(¬ Irrational (√($x : ℝ)))
+    let ⟨b, br⟩ ← deriveBoolOfIff e' e q(IsSquare_nat_iff_not_Irrational_sqrt $x)
+    return .ofBoolResult br
+  | ~q(@IsSquare ℤ _ $x) =>
+    let e₁ := q(0 ≤ $x)
+    let ⟨b₁, br₁⟩ ← deriveBool e₁
+    match b₁ with
+    | false =>
+      return .isFalse (x := q(IsSquare $x)) q(fun h ↦ $br₁ h.nonneg)
+    | true =>
+    let e₂ := q(¬ Irrational √($x : ℝ))
+    let ⟨b, br⟩ ← deriveBoolOfIff e₂ e q(IsSquare_int_iff_not_Irrational_sqrt $x $br₁)
+    return .ofBoolResult br
+  | ~q(@IsSquare ℚ _ $x) =>
+    let e₁ := q(0 ≤ $x)
+    let ⟨b₁, br₁⟩ ← deriveBool e₁
+    match b₁ with
+    | false =>
+      return .isFalse (x := q(IsSquare $x)) q(fun h ↦ $br₁ h.nonneg)
+    | true =>
+    let e₂ := q(¬ Irrational √($x : ℝ))
+    let ⟨b, br⟩ ← deriveBoolOfIff e₂ e q(IsSquare_rat_iff_not_Irrational_sqrt $x $br₁)
+    return .ofBoolResult br
+  | _ => failure
+
+end Tactic.NormNum

--- a/MathlibTest/norm_num_ext.lean
+++ b/MathlibTest/norm_num_ext.lean
@@ -20,7 +20,7 @@ import Mathlib.Data.Rat.Floor
 import Mathlib.Tactic.NormNum.LegendreSymbol
 import Mathlib.Tactic.NormNum.Pow
 import Mathlib.Tactic.NormNum.RealSqrt
-import Mathlib.Tactic.NormNum.Irrational
+import Mathlib.Tactic.NormNum.IsSquare
 import Mathlib.Tactic.Simproc.Factors
 
 /-!
@@ -608,6 +608,11 @@ end Factorial
 
 section irrational
 
+example : ¬ Irrational (2 : ℕ) := by norm_num1
+example : ¬ Irrational (-2 : ℤ) := by norm_num1
+example : ¬ Irrational (33/11 : ℚ) := by norm_num1
+example : ¬ Irrational (-33/11 - 1/2 : ℚ) := by norm_num1
+
 example : Irrational √2 := by norm_num1
 example : Irrational √(5 - 2) := by norm_num1
 example : Irrational √(7/4) := by norm_num1
@@ -622,9 +627,17 @@ example : Irrational ((87/6) ^ (54/321 : ℝ)) := by norm_num1
 example : Irrational
   √5210644015679228794060694325390955853335898483908056458352183851018372555735221 := by norm_num1
 
--- Large numerator does not affect performance.
--- We only need to check that it is coprime with the denominator.
-example : Irrational (100 ^ ((10^1000 + 10^500) / 3 : ℝ)) := by norm_num1
-
-
 end irrational
+
+section IsSquare
+
+example : IsSquare (243089725342304986 ^ 2 : ℕ) := by norm_num1
+example : ¬IsSquare (243089725342304986 ^ 2 + 1 : ℤ) := by norm_num1
+example : ¬IsSquare (10^101 : ℕ) := by norm_num1
+example : IsSquare (100^100 : ℤ) := by norm_num1
+example : ¬IsSquare (-256 : ℤ) := by norm_num1
+example : IsSquare ((15553 * 256) / (15553 * 289) : ℚ) := by norm_num1
+example : ¬IsSquare (21/8 : ℚ) := by norm_num1
+example : ¬IsSquare (-21/8 : ℚ) := by norm_num1
+
+end IsSquare

--- a/scripts/noshake.json
+++ b/scripts/noshake.json
@@ -104,7 +104,6 @@
   "Mathlib.Tactic.FastInstance",
   "Mathlib.Tactic.Field",
   "Mathlib.Tactic.FieldSimp",
-  "Mathlib.Tactic.Field",
   "Mathlib.Tactic.FinCases",
   "Mathlib.Tactic.Find",
   "Mathlib.Tactic.Finiteness",
@@ -217,8 +216,8 @@
   ["Mathlib.Topology.Connected.TotallyDisconnected"],
   "Mathlib.Topology.Order.LeftRightNhds":
   ["Mathlib.Algebra.Ring.Pointwise.Set"],
-  "Mathlib.Topology.Instances.CantorSet": ["Mathlib.Data.Stream.Init"],
   "Mathlib.Topology.Instances.ENNReal.Lemmas": ["Mathlib.Tactic.Bound"],
+  "Mathlib.Topology.Instances.CantorSet": ["Mathlib.Data.Stream.Init"],
   "Mathlib.Topology.DiscreteSubset": ["Mathlib.Tactic.TautoSet"],
   "Mathlib.Topology.Defs.Basic": ["Mathlib.Tactic.FunProp"],
   "Mathlib.Topology.Category.UniformSpace":
@@ -266,8 +265,8 @@
   "Mathlib.Tactic.NormNum.Parity": ["Mathlib.Algebra.Ring.Int.Parity"],
   "Mathlib.Tactic.NormNum.ModEq":
   ["Mathlib.Data.Int.ModEq", "Mathlib.Tactic.NormNum.DivMod"],
-  "Mathlib.Tactic.NormNum.Ineq":
-  ["Mathlib.Algebra.Order.Monoid.WithTop"],
+  "Mathlib.Tactic.NormNum.IsSquare": ["Mathlib.Tactic.NormNum.Irrational"],
+  "Mathlib.Tactic.NormNum.Ineq": ["Mathlib.Algebra.Order.Monoid.WithTop"],
   "Mathlib.Tactic.NormNum.BigOperators":
   ["Mathlib.Algebra.BigOperators.Group.Finset.Basic",
    "Mathlib.Data.List.FinRange"],


### PR DESCRIPTION
1. Add `evalIrrational`: `norm_num` extension for disproving `Irrational x` for rational `x`.
2. Add `evalIsSquare`: `norm_num` extension for deciding `IsSquare x` for rational `x`. It rewrites the goal as `0 ≤ x ∧ ¬ Irrational √x` and reuses `evalIrrationalSqrt` to prove/disprove it.

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

When merging, all the commits will be squashed into a single commit
listing all co-authors.

Co-authors in the squash commit are gathered from two sources:

First, all authors of commits to this PR branch are included. Thus,
one way to add co-authors is to include at least one commit authored by
each co-author among the commits in the pull request. If necessary, you
may create empty commits to indicate co-authorship, using commands like so:

git commit --author="Author Name <author@email.com>" --allow-empty -m "add Author Name as coauthor"

Second, co-authors can also be listed in lines at the very bottom of
the commit message (that is, directly before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines
at the bottom of the commit message (before the `---`, and also before
any "Co-authored-by" lines) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
