### PR TITLE
[Merged by Bors] - chore(RingSeminorm): use `grw` and `positivity`

### DIFF
--- a/Mathlib/Analysis/Normed/Unbundled/RingSeminorm.lean
+++ b/Mathlib/Analysis/Normed/Unbundled/RingSeminorm.lean
@@ -172,9 +172,7 @@ theorem map_pow_le_pow {F α : Type*} [Ring α] [FunLike F α ℝ] [RingSeminorm
   | 1, _ => by simp only [pow_one, le_refl]
   | n + 2, _ => by
     simp only [pow_succ _ (n + 1)]
-    exact
-      le_trans (map_mul_le_mul f _ a)
-        (mul_le_mul_of_nonneg_right (map_pow_le_pow _ _ n.succ_ne_zero) (apply_nonneg f a))
+    grw [map_mul_le_mul, map_pow_le_pow _ _ n.succ_ne_zero]
 
 /-- If `f` is a ring seminorm on `a` with `f 1 ≤ 1`, then `∀ (n : ℕ), f (a ^ n) ≤ f a ^ n`. -/
 theorem map_pow_le_pow' {F α : Type*} [Ring α] [FunLike F α ℝ] [RingSeminormClass F α ℝ] {f : F}
@@ -201,18 +199,15 @@ theorem isBoundedUnder (hp : p 1 ≤ 1) {s : ℕ → ℕ} (hs_le : ∀ n : ℕ, 
   have h_le : ∀ m : ℕ, p (x ^ s (ψ m)) ^ (1 / (ψ m : ℝ)) ≤ p x ^ ((s (ψ m) : ℝ) / (ψ m : ℝ)) := by
     intro m
     rw [← mul_one_div (s (ψ m) : ℝ), rpow_mul (apply_nonneg p x), rpow_natCast]
-    exact rpow_le_rpow (apply_nonneg _ _) (map_pow_le_pow' hp x _)
-      (one_div_nonneg.mpr (cast_nonneg _))
+    grw [map_pow_le_pow' hp x]
   apply isBoundedUnder_of
-  by_cases! hfx : p x ≤ 1
-  · use 1, fun m => le_trans (h_le m)
-      (rpow_le_one (apply_nonneg _ _) hfx (div_nonneg (cast_nonneg _) (cast_nonneg _)))
-  · use p x
-    intro m
-    apply le_trans (h_le m)
-    conv_rhs => rw [← rpow_one (p x)]
-    exact rpow_le_rpow_of_exponent_le hfx.le
-      (div_le_one_of_le₀ (cast_le.mpr (hs_le _)) (cast_nonneg _))
+  cases le_or_gt (p x) 1 with
+  | inl hfx =>
+    use 1, fun m => le_trans (h_le m) (rpow_le_one (by positivity) hfx (by positivity))
+  | inr hfx =>
+    use p x
+    refine fun m ↦ le_trans (h_le m) <| rpow_le_self_of_one_le hfx.le ?_
+    exact div_le_one_of_le₀ (mod_cast hs_le _) (cast_nonneg _)
 
 end RingSeminorm
 

--- a/Mathlib/Analysis/Normed/Unbundled/RingSeminorm.lean
+++ b/Mathlib/Analysis/Normed/Unbundled/RingSeminorm.lean
@@ -203,7 +203,7 @@ theorem isBoundedUnder (hp : p 1 ≤ 1) {s : ℕ → ℕ} (hs_le : ∀ n : ℕ, 
   apply isBoundedUnder_of
   cases le_or_gt (p x) 1 with
   | inl hfx =>
-    use 1, fun m => le_trans (h_le m) (rpow_le_one (by positivity) hfx (by positivity))
+    use 1, fun m ↦ le_trans (h_le m) (rpow_le_one (by positivity) hfx (by positivity))
   | inr hfx =>
     use p x
     refine fun m ↦ le_trans (h_le m) <| rpow_le_self_of_one_le hfx.le ?_


### PR DESCRIPTION
---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

When merging, all the commits will be squashed into a single commit
listing all co-authors.

Co-authors in the squash commit are gathered from two sources:

First, all authors of commits to this PR branch are included. Thus,
one way to add co-authors is to include at least one commit authored by
each co-author among the commits in the pull request. If necessary, you
may create empty commits to indicate co-authorship, using commands like so:

git commit --author="Author Name <author@email.com>" --allow-empty -m "add Author Name as coauthor"

Second, co-authors can also be listed in lines at the very bottom of
the commit message (that is, directly before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines
at the bottom of the commit message (before the `---`, and also before
any "Co-authored-by" lines) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
