### PR TITLE
[Merged by Bors] - doc(Analysis): tidy backticks

### DIFF
--- a/Mathlib/Analysis/Calculus/LocalExtr/Rolle.lean
+++ b/Mathlib/Analysis/Calculus/LocalExtr/Rolle.lean
@@ -29,7 +29,7 @@ We prove four versions of this theorem.
   continuity on the closed interval $[a, b]$ it assumes that $f$ tends to the same limit as $x$
   tends to $a$ from the right and as $x$ tends to $b$ from the left.
 * `exists_deriv_eq_zero'` relates to `exists_deriv_eq_zero` as `exists_hasDerivAt_eq_zero'`
-  relates to ``exists_hasDerivAt_eq_zero`.
+  relates to `exists_hasDerivAt_eq_zero`.
 
 ## References
 

--- a/Mathlib/Analysis/Complex/Hadamard.lean
+++ b/Mathlib/Analysis/Complex/Hadamard.lean
@@ -405,7 +405,7 @@ lemma sSupNormIm_scale_right (f : ℂ → E) {l u : ℝ} (hul : l < u) :
   rw [this]
 
 /-- A technical lemma relating the bounds given by the three lines lemma on a general strip
-to the bounds for its scaled version on the strip ``re ⁻¹' [0, 1]`. -/
+to the bounds for its scaled version on the strip `re ⁻¹' [0, 1]`. -/
 lemma interpStrip_scale (f : ℂ → E) {l u : ℝ} (hul : l < u) (z : ℂ) : interpStrip (scale f l u)
     ((z - ↑l) / (↑u - ↑l)) = interpStrip' f l u z := by
   simp only [interpStrip, interpStrip']

--- a/Mathlib/Analysis/Convex/StdSimplex.lean
+++ b/Mathlib/Analysis/Convex/StdSimplex.lean
@@ -136,7 +136,7 @@ theorem convexHull_basis_eq_stdSimplex [DecidableEq ι] :
     exact Finset.univ.centerMass_mem_convexHull (fun i _ => hw₀ i) (hw₁.symm ▸ zero_lt_one)
       fun i _ => mem_range_self i
 
-/-- `stdSimplex 𝕜 ι` is the convex hull of the points `Pi.single i 1` for `i : `i`. -/
+/-- `stdSimplex 𝕜 ι` is the convex hull of the points `Pi.single i 1` for `i : ι`. -/
 theorem convexHull_rangle_single_eq_stdSimplex [DecidableEq ι] :
     convexHull R (range fun i : ι ↦ Pi.single i 1) = stdSimplex R ι := by
   convert convexHull_basis_eq_stdSimplex R ι

--- a/Mathlib/Analysis/InnerProductSpace/Laplacian.lean
+++ b/Mathlib/Analysis/InnerProductSpace/Laplacian.lean
@@ -42,7 +42,7 @@ variable
 variable (𝕜) in
 /--
 Convenience reformulation of the second iterated derivative, as a map from `E` to bilinear maps
-`E →ₗ[ℝ] E →ₗ[ℝ] ℝ
+`E →ₗ[ℝ] E →ₗ[ℝ] ℝ`.
 -/
 noncomputable def bilinearIteratedFDerivWithinTwo (f : E → F) (s : Set E) : E → E →ₗ[𝕜] E →ₗ[𝕜] F :=
   fun x ↦ (fderivWithin 𝕜 (fderivWithin 𝕜 f s) s x).toLinearMap₁₂
@@ -50,7 +50,7 @@ noncomputable def bilinearIteratedFDerivWithinTwo (f : E → F) (s : Set E) : E 
 variable (𝕜) in
 /--
 Convenience reformulation of the second iterated derivative, as a map from `E` to bilinear maps
-`E →ₗ[ℝ] E →ₗ[ℝ] ℝ
+`E →ₗ[ℝ] E →ₗ[ℝ] ℝ`.
 -/
 noncomputable def bilinearIteratedFDerivTwo (f : E → F) : E → E →ₗ[𝕜] E →ₗ[𝕜] F :=
   fun x ↦ (fderiv 𝕜 (fderiv 𝕜 f) x).toLinearMap₁₂

--- a/Mathlib/Analysis/Normed/Group/SeparationQuotient.lean
+++ b/Mathlib/Analysis/Normed/Group/SeparationQuotient.lean
@@ -28,7 +28,7 @@ All the following definitions are in the `SeparationQuotient` namespace. Hence w
 
 ## Main results
 
-* `norm_normedMk_eq_one : the operator norm of the projection is `1` if the subspace is not `⊤`.
+* `norm_normedMk_eq_one` : the operator norm of the projection is `1` if the subspace is not `⊤`.
 
 * `norm_liftNormedAddGroupHom_le` : `‖liftNormedAddGroupHom f hf‖ ≤ ‖f‖`.
 -/

--- a/Mathlib/Analysis/Normed/Unbundled/SmoothingSeminorm.lean
+++ b/Mathlib/Analysis/Normed/Unbundled/SmoothingSeminorm.lean
@@ -12,8 +12,8 @@ import Mathlib.Topology.Algebra.Order.LiminfLimsup
 
 /-!
 # smoothingSeminorm
-In this file, we prove [BGR, Proposition 1.3.2/1][bosch-guntzer-remmert] : if `μ` is a
-nonarchimedean seminorm on a commutative ring `R`, then `
+In this file, we prove [BGR, Proposition 1.3.2/1][bosch-guntzer-remmert]: if `μ` is a
+nonarchimedean seminorm on a commutative ring `R`, then
 `iInf (fun (n : PNat), (μ(x ^ (n : ℕ))) ^ (1 / (n : ℝ)))` is a power-multiplicative nonarchimedean
 seminorm on `R`.
 

--- a/Mathlib/Analysis/SpecialFunctions/MulExpNegMulSq.lean
+++ b/Mathlib/Analysis/SpecialFunctions/MulExpNegMulSq.lean
@@ -120,7 +120,7 @@ theorem mulExpNegMulSq_eq_sqrt_mul_mulExpNegMulSq_one (hε : 0 < ε) (x : ℝ) :
     mulExpNegMulSq ε x = (√ε)⁻¹ * mulExpNegMulSq 1 (sqrt ε * x) := by
   grind [mulExpNegMulSq]
 
-/-- For fixed `ε > 0`, the mapping `x ↦ mulExpNegMulSq ε x` is bounded by `(√ε)⁻¹ -/
+/-- For fixed `ε > 0`, the mapping `x ↦ mulExpNegMulSq ε x` is bounded by `(√ε)⁻¹`. -/
 theorem abs_mulExpNegMulSq_le (hε : 0 < ε) {x : ℝ} : |mulExpNegMulSq ε x| ≤ (√ε)⁻¹ := by
   rw [mulExpNegMulSq_eq_sqrt_mul_mulExpNegMulSq_one hε x, abs_mul, abs_of_pos (by positivity)]
   apply mul_le_of_le_one_right

--- a/Mathlib/Analysis/SpecialFunctions/Pow/Integral.lean
+++ b/Mathlib/Analysis/SpecialFunctions/Pow/Integral.lean
@@ -22,7 +22,7 @@ A variant of the formula with measures of sets of the form `{ω | f(ω) > t}` in
   `MeasureTheory.lintegral_rpow_eq_lintegral_meas_lt_mul`:
   other common special cases of the layer cake formulas, stating that for a nonnegative function `f`
   and `p > 0`, we have `∫ f(ω)ᵖ ∂μ(ω) = p * ∫ μ {ω | f(ω) ≥ t} * tᵖ⁻¹ dt` and
-  `∫ f(ω)ᵖ ∂μ(ω) = p * ∫ μ {ω | f(ω) > t} * tᵖ⁻¹ dt, respectively.
+  `∫ f(ω)ᵖ ∂μ(ω) = p * ∫ μ {ω | f(ω) > t} * tᵖ⁻¹ dt`, respectively.
 
 ## Tags
 


### PR DESCRIPTION
Found and fixed with the help of Codex.

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

When merging, all the commits will be squashed into a single commit
listing all co-authors.

Co-authors in the squash commit are gathered from two sources:

First, all authors of commits to this PR branch are included. Thus,
one way to add co-authors is to include at least one commit authored by
each co-author among the commits in the pull request. If necessary, you
may create empty commits to indicate co-authorship, using commands like so:

git commit --author="Author Name <author@email.com>" --allow-empty -m "add Author Name as coauthor"

Second, co-authors can also be listed in lines at the very bottom of
the commit message (that is, directly before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines
at the bottom of the commit message (before the `---`, and also before
any "Co-authored-by" lines) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
