### PR TITLE
[Merged by Bors] - doc(GroupTheory): tidy backticks

### DIFF
--- a/Mathlib/GroupTheory/GroupAction/Iwasawa.lean
+++ b/Mathlib/GroupTheory/GroupAction/Iwasawa.lean
@@ -14,7 +14,7 @@ import Mathlib.GroupTheory.Subgroup.Simple
 For a group `G`, this consists of an action of `G` on a type `α` and,
 for every `a : α`, of a subgroup `T a`, such that the following properties hold:
   - for all `a`, `T a` is commutative
-  - for all `g : G` and `a : α`, `T (g • a) = MulAut.conj g • T a
+  - for all `g : G` and `a : α`, `T (g • a) = MulAut.conj g • T a`
   - the subgroups `T a` generate `G`
 
 We then prove two versions of the Iwasawa criterion when

--- a/Mathlib/GroupTheory/GroupAction/SubMulAction/OfFixingSubgroup.lean
+++ b/Mathlib/GroupTheory/GroupAction/SubMulAction/OfFixingSubgroup.lean
@@ -24,7 +24,7 @@ and permit to manipulate them in a relatively smooth way:
   the identity map, when the set is the empty set.
 
   * `SubMulAction.fixingSubgroupInsertEquiv M a s` : the
-  multiplicative equivalence between `fixingSubgroup M (insert a s)``
+  multiplicative equivalence between `fixingSubgroup M (insert a s)`
   and `fixingSubgroup (stabilizer M a) s`
 
   * `SubMulAction.ofFixingSubgroup_insert_map` : the equivariant

--- a/Mathlib/GroupTheory/NoncommCoprod.lean
+++ b/Mathlib/GroupTheory/NoncommCoprod.lean
@@ -49,7 +49,7 @@ def noncommCoprod (comm : ∀ m n, Commute (f m) (g n)) : M × N →ₙ* P where
   toFun mn := f mn.fst * g mn.snd
   map_mul' mn mn' := by simpa using (comm _ _).mul_mul_mul_comm _ _
 
-/-- Variant of `MulHom.noncommCoprod_apply` with the product written in the other direction` -/
+/-- Variant of `MulHom.noncommCoprod_apply` with the product written in the other direction. -/
 @[to_additive
   /-- Variant of `AddHom.noncommCoprod_apply`, with the sum written in the other direction -/]
 theorem noncommCoprod_apply' (comm) (mn : M × N) :
@@ -84,7 +84,7 @@ def noncommCoprod : M × N →* P where
   map_one' := by simp only [Prod.fst_one, Prod.snd_one, map_one, mul_one]
   __ := f.toMulHom.noncommCoprod g.toMulHom comm
 
-/-- Variant of `MonoidHom.noncomCoprod_apply` with the product written in the other direction` -/
+/-- Variant of `MonoidHom.noncomCoprod_apply` with the product written in the other direction. -/
 @[to_additive
   /-- Variant of `AddMonoidHom.noncomCoprod_apply` with the sum written in the other direction -/]
 theorem noncommCoprod_apply' (comm) (mn : M × N) :

--- a/Mathlib/GroupTheory/Perm/DomMulAct.lean
+++ b/Mathlib/GroupTheory/Perm/DomMulAct.lean
@@ -45,7 +45,7 @@ lemma mem_stabilizer_iff {g : (Perm α)ᵈᵐᵃ} :
   simp only [MulAction.mem_stabilizer_iff]; rfl
 
 /-- The `invFun` component of `MulEquiv` from `MulAction.stabilizer (Perm α) f`
-  to the product of the `Equiv.Perm {a // f a = i} -/
+  to the product of the `Equiv.Perm {a // f a = i}`. -/
 def stabilizerEquiv_invFun (g : ∀ i, Perm {a // f a = i}) (a : α) : α := g (f a) ⟨a, rfl⟩
 
 lemma stabilizerEquiv_invFun_eq (g : ∀ i, Perm {a // f a = i}) {a : α} {i : ι} (h : f a = i) :
@@ -56,7 +56,7 @@ lemma comp_stabilizerEquiv_invFun (g : ∀ i, Perm {a // f a = i}) (a : α) :
   (g (f a) ⟨a, rfl⟩).prop
 
 /-- The `invFun` component of `MulEquiv` from `MulAction.stabilizer (Perm α) p`
-  to the product of the `Equiv.Perm {a | f a = i} (as an `Equiv.Perm α`) -/
+  to the product of the `Equiv.Perm {a | f a = i}` (as an `Equiv.Perm α`). -/
 def stabilizerEquiv_invFun_aux (g : ∀ i, Perm {a // f a = i}) : Perm α where
   toFun := stabilizerEquiv_invFun g
   invFun := stabilizerEquiv_invFun (fun i ↦ (g i).symm)


### PR DESCRIPTION
Issues found and fixed with help from Codex.

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

When merging, all the commits will be squashed into a single commit
listing all co-authors.

Co-authors in the squash commit are gathered from two sources:

First, all authors of commits to this PR branch are included. Thus,
one way to add co-authors is to include at least one commit authored by
each co-author among the commits in the pull request. If necessary, you
may create empty commits to indicate co-authorship, using commands like so:

git commit --author="Author Name <author@email.com>" --allow-empty -m "add Author Name as coauthor"

Second, co-authors can also be listed in lines at the very bottom of
the commit message (that is, directly before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines
at the bottom of the commit message (before the `---`, and also before
any "Co-authored-by" lines) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
