### PR TITLE
[Merged by Bors] - chore: refactor `Type*` and `Sort*` to use `mkFreshLevelParam`

### DIFF
--- a/Mathlib/Tactic/TypeStar.lean
+++ b/Mathlib/Tactic/TypeStar.lean
@@ -6,6 +6,7 @@ Authors: Kyle Miller
 module
 
 public import Mathlib.Init
+public import Mathlib.Lean.Elab.Term
 
 /-!
 # Support for `Sort*` and `Type*`.
@@ -15,16 +16,12 @@ These elaborate as `Sort u` and `Type u` with a fresh implicit universe variable
 
 public meta section
 
-open Lean
+open Lean Elab Term
 
 /-- The syntax `variable (X Y ... Z : Sort*)` creates a new distinct implicit universe variable
 for each variable in the sequence. -/
-elab "Sort*" : term => do
-  let u ← Lean.Meta.mkFreshLevelMVar
-  Elab.Term.levelMVarToParam (.sort u)
+elab "Sort*" : term => return .sort <|← mkFreshLevelParam
 
 /-- The syntax `variable (X Y ... Z : Type*)` creates a new distinct implicit universe variable
 `> 0` for each variable in the sequence. -/
-elab "Type*" : term => do
-  let u ← Lean.Meta.mkFreshLevelMVar
-  Elab.Term.levelMVarToParam (.sort (.succ u))
+elab "Type*" : term => return .sort <| .succ <|← mkFreshLevelParam


### PR DESCRIPTION
Uses the API for creating new level parameters introduced in #30797.

---

- [ ] depends on: #30797
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

When merging, all the commits will be squashed into a single commit
listing all co-authors.

Co-authors in the squash commit are gathered from two sources:

First, all authors of commits to this PR branch are included. Thus,
one way to add co-authors is to include at least one commit authored by
each co-author among the commits in the pull request. If necessary, you
may create empty commits to indicate co-authorship, using commands like so:

git commit --author="Author Name <author@email.com>" --allow-empty -m "add Author Name as coauthor"

Second, co-authors can also be listed in lines at the very bottom of
the commit message (that is, directly before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines
at the bottom of the commit message (before the `---`, and also before
any "Co-authored-by" lines) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
