### PR TITLE
[Merged by Bors] - feat(CategoryTheory/ObjectProperty): generalize `ObjectProperty` to `CategoryStruct`

### DIFF
--- a/Mathlib/CategoryTheory/ObjectProperty/Basic.lean
+++ b/Mathlib/CategoryTheory/ObjectProperty/Basic.lean
@@ -29,45 +29,18 @@ namespace CategoryTheory
 
 /-- A property of objects in a category `C` is a predicate `C → Prop`. -/
 @[nolint unusedArguments]
-abbrev ObjectProperty (C : Type u) [Category.{v} C] : Type u := C → Prop
+abbrev ObjectProperty (C : Type u) [CategoryStruct.{v} C] : Type u := C → Prop
 
 namespace ObjectProperty
 
-variable {C : Type u} {D : Type u'} [Category.{v} C] [Category.{v'} D]
+variable {C : Type u} {D : Type u'}
+
+section
+
+variable [CategoryStruct.{v} C] [CategoryStruct.{v'} D]
 
 lemma le_def {P Q : ObjectProperty C} :
     P ≤ Q ↔ ∀ (X : C), P X → Q X := Iff.rfl
-
-/-- The inverse image of a property of objects by a functor. -/
-def inverseImage (P : ObjectProperty D) (F : C ⥤ D) : ObjectProperty C :=
-  fun X ↦ P (F.obj X)
-
-@[simp]
-lemma prop_inverseImage_iff (P : ObjectProperty D) (F : C ⥤ D) (X : C) :
-    P.inverseImage F X ↔ P (F.obj X) := Iff.rfl
-
-/-- The essential image of a property of objects by a functor. -/
-def map (P : ObjectProperty C) (F : C ⥤ D) : ObjectProperty D :=
-  fun Y ↦ ∃ (X : C), P X ∧ Nonempty (F.obj X ≅ Y)
-
-lemma prop_map_iff (P : ObjectProperty C) (F : C ⥤ D) (Y : D) :
-    P.map F Y ↔ ∃ (X : C), P X ∧ Nonempty (F.obj X ≅ Y) := Iff.rfl
-
-lemma prop_map_obj (P : ObjectProperty C) (F : C ⥤ D) {X : C} (hX : P X) :
-    P.map F (F.obj X) :=
-  ⟨X, hX, ⟨Iso.refl _⟩⟩
-
-/-- The strict image of a property of objects by a functor. -/
-inductive strictMap (P : ObjectProperty C) (F : C ⥤ D) : ObjectProperty D
-  | mk (X : C) (hX : P X) : strictMap P F (F.obj X)
-
-lemma strictMap_iff (P : ObjectProperty C) (F : C ⥤ D) (Y : D) :
-    P.strictMap F Y ↔ ∃ (X : C), P X ∧ F.obj X = Y :=
-  ⟨by rintro ⟨X, hX⟩; exact ⟨X, hX, rfl⟩, by rintro ⟨X, hX, rfl⟩; exact ⟨X, hX⟩⟩
-
-lemma strictMap_obj (P : ObjectProperty C) (F : C ⥤ D) {X : C} (hX : P X) :
-    P.strictMap F (F.obj X) :=
-  ⟨X, hX⟩
 
 /-- The typeclass associated to `P : ObjectProperty C`. -/
 @[mk_iff]
@@ -101,12 +74,6 @@ lemma ofObj_le_iff (P : ObjectProperty C) :
     ofObj X ≤ P ↔ ∀ i, P (X i) :=
   ⟨fun h i ↦ h _ (by simp), fun h ↦ by rintro _ ⟨i⟩; exact h i⟩
 
-@[simp]
-lemma strictMap_ofObj (F : C ⥤ D) :
-    (ofObj X).strictMap F = ofObj (F.obj ∘ X) := by
-  ext Y
-  simp [ofObj_iff, strictMap_iff]
-
 end
 
 /-- The property of objects in a category that is satisfied by a single object `X : C`. -/
@@ -120,12 +87,6 @@ lemma singleton_le_iff {X : C} {P : ObjectProperty C} :
     singleton X ≤ P ↔ P X := by
   simp [ofObj_le_iff]
 
-@[simp high]
-lemma strictMap_singleton (X : C) (F : C ⥤ D) :
-    (singleton X).strictMap F = singleton (F.obj X) := by
-  ext
-  simp [strictMap_iff]
-
 /-- The property of objects in a category that is satisfied by `X : C` and `Y : C`. -/
 def pair (X Y : C) : ObjectProperty C :=
   ofObj (Sum.elim (fun (_ : Unit) ↦ X) (fun (_ : Unit) ↦ Y))
@@ -136,6 +97,57 @@ lemma pair_iff (X Y Z : C) :
   constructor
   · rintro ⟨_ | _⟩ <;> tauto
   · rintro (rfl | rfl); exacts [⟨Sum.inl .unit⟩, ⟨Sum.inr .unit⟩]
+
+end
+
+section
+
+variable [Category.{v} C] [Category.{v'} D]
+
+/-- The inverse image of a property of objects by a functor. -/
+def inverseImage (P : ObjectProperty D) (F : C ⥤ D) : ObjectProperty C :=
+  fun X ↦ P (F.obj X)
+
+@[simp]
+lemma prop_inverseImage_iff (P : ObjectProperty D) (F : C ⥤ D) (X : C) :
+    P.inverseImage F X ↔ P (F.obj X) := Iff.rfl
+
+/-- The essential image of a property of objects by a functor. -/
+def map (P : ObjectProperty C) (F : C ⥤ D) : ObjectProperty D :=
+  fun Y ↦ ∃ (X : C), P X ∧ Nonempty (F.obj X ≅ Y)
+
+lemma prop_map_iff (P : ObjectProperty C) (F : C ⥤ D) (Y : D) :
+    P.map F Y ↔ ∃ (X : C), P X ∧ Nonempty (F.obj X ≅ Y) := Iff.rfl
+
+lemma prop_map_obj (P : ObjectProperty C) (F : C ⥤ D) {X : C} (hX : P X) :
+    P.map F (F.obj X) :=
+  ⟨X, hX, ⟨Iso.refl _⟩⟩
+
+/-- The strict image of a property of objects by a functor. -/
+inductive strictMap (P : ObjectProperty C) (F : C ⥤ D) : ObjectProperty D
+  | mk (X : C) (hX : P X) : strictMap P F (F.obj X)
+
+lemma strictMap_iff (P : ObjectProperty C) (F : C ⥤ D) (Y : D) :
+    P.strictMap F Y ↔ ∃ (X : C), P X ∧ F.obj X = Y :=
+  ⟨by rintro ⟨X, hX⟩; exact ⟨X, hX, rfl⟩, by rintro ⟨X, hX, rfl⟩; exact ⟨X, hX⟩⟩
+
+lemma strictMap_obj (P : ObjectProperty C) (F : C ⥤ D) {X : C} (hX : P X) :
+    P.strictMap F (F.obj X) :=
+  ⟨X, hX⟩
+
+@[simp]
+lemma strictMap_ofObj {ι : Type u'} (X : ι → C) (F : C ⥤ D) :
+    (ofObj X).strictMap F = ofObj (F.obj ∘ X) := by
+  ext Y
+  simp [ofObj_iff, strictMap_iff]
+
+@[simp high]
+lemma strictMap_singleton (X : C) (F : C ⥤ D) :
+    (singleton X).strictMap F = singleton (F.obj X) := by
+  ext
+  simp [strictMap_iff]
+
+end
 
 end ObjectProperty
 

--- a/Mathlib/CategoryTheory/ObjectProperty/Opposite.lean
+++ b/Mathlib/CategoryTheory/ObjectProperty/Opposite.lean
@@ -17,7 +17,11 @@ namespace CategoryTheory.ObjectProperty
 
 open Opposite
 
-variable {C : Type u} [Category.{v} C]
+variable {C : Type u}
+
+section
+
+variable [CategoryStruct.{v} C]
 
 /-- The property of objects of `Cᵒᵖ` corresponding to `P : ObjectProperty C`. -/
 protected def op (P : ObjectProperty C) : ObjectProperty Cᵒᵖ :=
@@ -69,24 +73,6 @@ lemma op_monotone_iff {P Q : ObjectProperty C} : P.op ≤ Q.op ↔ P ≤ Q :=
 lemma unop_monotone_iff {P Q : ObjectProperty Cᵒᵖ} : P.unop ≤ Q.unop ↔ P ≤ Q :=
   ⟨op_monotone, unop_monotone⟩
 
-instance (P : ObjectProperty C) [P.IsClosedUnderIsomorphisms] :
-    P.op.IsClosedUnderIsomorphisms where
-  of_iso e hX := P.prop_of_iso e.symm.unop hX
-
-instance (P : ObjectProperty Cᵒᵖ) [P.IsClosedUnderIsomorphisms] :
-    P.unop.IsClosedUnderIsomorphisms where
-  of_iso e hX := P.prop_of_iso e.symm.op hX
-
-lemma op_isoClosure (P : ObjectProperty C) :
-    P.isoClosure.op = P.op.isoClosure := by
-  ext ⟨X⟩
-  exact ⟨fun ⟨Y, h, ⟨e⟩⟩ ↦ ⟨op Y, h, ⟨e.op.symm⟩⟩,
-    fun ⟨Y, h, ⟨e⟩⟩ ↦ ⟨Y.unop, h, ⟨e.unop.symm⟩⟩⟩
-
-lemma unop_isoClosure (P : ObjectProperty Cᵒᵖ) :
-    P.isoClosure.unop = P.unop.isoClosure := by
-  rw [← op_injective_iff, P.unop.op_isoClosure, op_unop, op_unop]
-
 /-- The bijection `Subtype P.op ≃ Subtype P` for `P : ObjectProperty C`. -/
 def subtypeOpEquiv (P : ObjectProperty C) :
     Subtype P.op ≃ Subtype P where
@@ -116,5 +102,31 @@ lemma op_singleton (X : C) :
 lemma unop_singleton (X : Cᵒᵖ) :
     (singleton X).unop = singleton X.unop := by
   simp
+
+end
+
+section
+
+variable [Category.{v} C]
+
+instance (P : ObjectProperty C) [P.IsClosedUnderIsomorphisms] :
+    P.op.IsClosedUnderIsomorphisms where
+  of_iso e hX := P.prop_of_iso e.symm.unop hX
+
+instance (P : ObjectProperty Cᵒᵖ) [P.IsClosedUnderIsomorphisms] :
+    P.unop.IsClosedUnderIsomorphisms where
+  of_iso e hX := P.prop_of_iso e.symm.op hX
+
+lemma op_isoClosure (P : ObjectProperty C) :
+    P.isoClosure.op = P.op.isoClosure := by
+  ext ⟨X⟩
+  exact ⟨fun ⟨Y, h, ⟨e⟩⟩ ↦ ⟨op Y, h, ⟨e.op.symm⟩⟩,
+    fun ⟨Y, h, ⟨e⟩⟩ ↦ ⟨Y.unop, h, ⟨e.unop.symm⟩⟩⟩
+
+lemma unop_isoClosure (P : ObjectProperty Cᵒᵖ) :
+    P.isoClosure.unop = P.unop.isoClosure := by
+  rw [← op_injective_iff, P.unop.op_isoClosure, op_unop, op_unop]
+
+end
 
 end CategoryTheory.ObjectProperty


### PR DESCRIPTION
This PR generalizes some basic definitions about `ObjectProperty` to only use `CategoryStruct`.

Most of the remaining definitions in the file `Basic.lean` could also be good to generalize to use `Prefunctor` as opposed to functors, but since there as yet is no coercion from Functors to Prefunctors (and I don't know if adding one is a good idea), such a change would be quite inconvenient for now as one would have to add `.toPrefunctor` everywhere down the line.

This will be useful for the development of bicategories and stacks.

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

When merging, all the commits will be squashed into a single commit
listing all co-authors.

Co-authors in the squash commit are gathered from two sources:

First, all authors of commits to this PR branch are included. Thus,
one way to add co-authors is to include at least one commit authored by
each co-author among the commits in the pull request. If necessary, you
may create empty commits to indicate co-authorship, using commands like so:

git commit --author="Author Name <author@email.com>" --allow-empty -m "add Author Name as coauthor"

Second, co-authors can also be listed in lines at the very bottom of
the commit message (that is, directly before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines
at the bottom of the commit message (before the `---`, and also before
any "Co-authored-by" lines) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
