### PR TITLE
[Merged by Bors] - feat: InfoTree API: `InfoTree.findSome`(`M`)`?` and `InfoTree.onHighestNode?`

### DIFF
--- a/Mathlib/Lean/Elab/InfoTree.lean
+++ b/Mathlib/Lean/Elab/InfoTree.lean
@@ -89,7 +89,7 @@ If `ctx?` is `some ctx`, `ctx` is used as an initial context. A `ctx?` of `none`
 used when operating on the first node of the entire infotree. Otherwise, it is likely that no
 context will be found.
 -/
-def onFirstNode? {α} (t : InfoTree) (ctx? : Option ContextInfo)
+def onHighestNode? {α} (t : InfoTree) (ctx? : Option ContextInfo)
     (f : ContextInfo → Info → PersistentArray InfoTree → α) : Option α :=
   t.findSome? (ctx? := ctx?) fun ctx i ch => some (f ctx i ch)
 

--- a/Mathlib/Lean/Elab/InfoTree.lean
+++ b/Mathlib/Lean/Elab/InfoTree.lean
@@ -57,7 +57,9 @@ partial def findSomeM? {m : Type → Type} [Monad m] {α}
     (f : ContextInfo → Info → PersistentArray InfoTree → m (Option α))
     (t : InfoTree) (ctx? : Option ContextInfo := none) : m (Option α) :=
   go ctx? t
-where go ctx?
+where
+  /-- Accumulates contexts and visits nodes if `ctx?` is not `none`. -/
+  go ctx?
   | context ctx t => go (ctx.mergeIntoOuter? ctx?) t
   | node i ts => do
     let a ← match ctx? with

--- a/Mathlib/Lean/Elab/InfoTree.lean
+++ b/Mathlib/Lean/Elab/InfoTree.lean
@@ -45,27 +45,6 @@ where
 namespace InfoTree
 
 /--
-Finds the first result of `f ctx info children` which is `some a`, descending the
-tree from the top. Merges and updates contexts as it descends the tree.
-
-`f` is **only** evaluated on nodes when some context is present. An initial context should be
-provided via the `ctx?` argument if invoking `findSome?` during a larger traversal of the infotree.
-A failure to provide `ctx? := some ctx` when `t` is not the outermost `InfoTree` is thus likely to
-cause `findSome?` to always return `none`.
--/
-partial def findSome? {α} (f : ContextInfo → Info → PersistentArray InfoTree → Option α)
-    (t : InfoTree) (ctx? : Option ContextInfo := none) : Option α :=
-  go ctx? t
-where go ctx?
-  | context ctx t => go (ctx.mergeIntoOuter? ctx?) t
-  | node i ts =>
-    let a := match ctx? with
-      | none => none
-      | some ctx => f ctx i ts
-    a <|> ts.findSome? (go <| i.updateContext? ctx?)
-  | hole _ => none
-
-/--
 Finds the first result of `← f ctx info children` which is `some a`, descending the
 tree from the top. Merges and updates contexts as it descends the tree.
 
@@ -88,6 +67,19 @@ where go ctx?
     | some a => pure a
     | none => ts.findSomeM? (go <| i.updateContext? ctx?)
   | hole _ => pure none
+
+/--
+Finds the first result of `f ctx info children` which is `some a`, descending the
+tree from the top. Merges and updates contexts as it descends the tree.
+
+`f` is **only** evaluated on nodes when some context is present. An initial context should be
+provided via the `ctx?` argument if invoking `findSome?` during a larger traversal of the infotree.
+A failure to provide `ctx? := some ctx` when `t` is not the outermost `InfoTree` is thus likely to
+cause `findSome?` to always return `none`.
+-/
+def findSome? {α} (f : ContextInfo → Info → PersistentArray InfoTree → Option α)
+    (t : InfoTree) (ctx? : Option ContextInfo := none) : Option α :=
+  Id.run <| t.findSomeM? f ctx?
 
 /--
 Returns the value of `f ctx info children` on the outermost `.node info children` which has

--- a/Mathlib/Lean/Elab/InfoTree.lean
+++ b/Mathlib/Lean/Elab/InfoTree.lean
@@ -1,7 +1,7 @@
 /-
 Copyright (c) 2025 Marc Huisinga. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
-Authors: Marc Huisinga
+Authors: Marc Huisinga, Thomas R. Murrills
 -/
 module
 
@@ -42,4 +42,63 @@ where
       | return
     modify (·.push tti.suggestion)
 
-end Lean.Elab
+namespace InfoTree
+
+/--
+Finds the first result of `f ctx info children` which is `some a`, descending the
+tree from the top. Merges and updates contexts as it descends the tree.
+
+`f` is **only** evaluated on nodes when some context is present. An initial context should be
+provided via the `ctx?` argument if invoking `findSome?` during a larger traversal of the infotree.
+A failure to provide `ctx? := some ctx` when `t` is not the outermost `InfoTree` is thus likely to
+cause `findSome?` to always return `none`.
+-/
+partial def findSome? {α} (f : ContextInfo → Info → PersistentArray InfoTree → Option α)
+    (t : InfoTree) (ctx? : Option ContextInfo := none) : Option α :=
+  go ctx? t
+where go ctx?
+  | context ctx t => go (ctx.mergeIntoOuter? ctx?) t
+  | node i ts =>
+    let a := match ctx? with
+      | none => none
+      | some ctx => f ctx i ts
+    a <|> ts.findSome? (go <| i.updateContext? ctx?)
+  | hole _ => none
+
+/--
+Finds the first result of `← f ctx info children` which is `some a`, descending the
+tree from the top. Merges and updates contexts as it descends the tree.
+
+`f` is **only** evaluated on nodes when some context is present. An initial context should be
+provided via the `ctx?` argument if invoking `findSomeM?` during a larger traversal of the
+infotree. A failure to provide `ctx? := some ctx` when `t` is not the outermost `InfoTree` is thus
+likely to cause `findSomeM?` to always return `none`.
+-/
+partial def findSomeM? {m : Type → Type} [Monad m] {α}
+    (f : ContextInfo → Info → PersistentArray InfoTree → m (Option α))
+    (t : InfoTree) (ctx? : Option ContextInfo := none) : m (Option α) :=
+  go ctx? t
+where go ctx?
+  | context ctx t => go (ctx.mergeIntoOuter? ctx?) t
+  | node i ts => do
+    let a ← match ctx? with
+      | none => pure none
+      | some ctx => f ctx i ts
+    match a with
+    | some a => pure a
+    | none => ts.findSomeM? (go <| i.updateContext? ctx?)
+  | hole _ => pure none
+
+/--
+Returns the value of `f ctx info children` on the outermost `.node info children` which has
+context, having merged and updated contexts appropriately.
+
+If `ctx?` is `some ctx`, `ctx` is used as an initial context. A `ctx?` of `none` should **only** be
+used when operating on the first node of the entire infotree. Otherwise, it is likely that no
+context will be found.
+-/
+def onFirstNode? {α} (t : InfoTree) (ctx? : Option ContextInfo)
+    (f : ContextInfo → Info → PersistentArray InfoTree → α) : Option α :=
+  t.findSome? (ctx? := ctx?) fun ctx i ch => some (f ctx i ch)
+
+end Lean.Elab.InfoTree


### PR DESCRIPTION
This PR adds the following basic `InfoTree` API:
```lean
def findSome? {α} (f : ContextInfo → Info → PersistentArray InfoTree → Option α)
    (t : InfoTree) (ctx? : Option ContextInfo := none) : Option α
```
```lean
def findSomeM? {m : Type → Type} [Monad m] {α}
    (f : ContextInfo → Info → PersistentArray InfoTree → m (Option α))
    (t : InfoTree) (ctx? : Option ContextInfo := none) : m (Option α)
```
```lean
def onHighestNode? {α} (t : InfoTree) (ctx? : Option ContextInfo)
    (f : ContextInfo → Info → PersistentArray InfoTree → α) : Option α
```
Note that `onHighestNode?` has an explicit `Option ContextInfo` argument. This is because `onHighestNode?` is more likely to be called in the middle of a larger traversal, during which it is essential to pass the surrounding `ContextInfo`. Making this argument explicit mitigates the increased risk of a footgun here.

This functionality is motivated by use in other PRs.

---

Aside: I wonder if we should have `InfoT`. Then the footguns here would not be present, as all API involved would update the `ContextInfo`. But in the meantime we must manage the infotree context manually during traversal.

<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

When merging, all the commits will be squashed into a single commit
listing all co-authors.

Co-authors in the squash commit are gathered from two sources:

First, all authors of commits to this PR branch are included. Thus,
one way to add co-authors is to include at least one commit authored by
each co-author among the commits in the pull request. If necessary, you
may create empty commits to indicate co-authorship, using commands like so:

git commit --author="Author Name <author@email.com>" --allow-empty -m "add Author Name as coauthor"

Second, co-authors can also be listed in lines at the very bottom of
the commit message (that is, directly before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines
at the bottom of the commit message (before the `---`, and also before
any "Co-authored-by" lines) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
