### PR TITLE
[branch renamed] feat(Meta): declaration manipulation meta API: allow logging on type signature of theorems

### DIFF
--- a/Mathlib.lean
+++ b/Mathlib.lean
@@ -4261,6 +4261,7 @@ import Mathlib.Lean.Meta.Simp
 import Mathlib.Lean.Meta.Tactic.Rewrite
 import Mathlib.Lean.Name
 import Mathlib.Lean.PrettyPrinter.Delaborator
+import Mathlib.Lean.Syntax
 import Mathlib.Lean.Thunk
 import Mathlib.LinearAlgebra.AffineSpace.AffineEquiv
 import Mathlib.LinearAlgebra.AffineSpace.AffineMap
@@ -7139,6 +7140,7 @@ import Mathlib.Util.AtomM
 import Mathlib.Util.AtomM.Recurse
 import Mathlib.Util.CompileInductive
 import Mathlib.Util.CountHeartbeats
+import Mathlib.Util.DeclarationManipulation
 import Mathlib.Util.Delaborators
 import Mathlib.Util.DischargerAsTactic
 import Mathlib.Util.ElabWithoutMVars

--- a/Mathlib/Lean/Elab/InfoTree.lean
+++ b/Mathlib/Lean/Elab/InfoTree.lean
@@ -41,27 +41,6 @@ where
 namespace InfoTree
 
 /--
-Finds the first result of `f ctx info children` which is `some a`, descending the
-tree from the top. Merges and updates contexts as it descends the tree.
-
-`f` is **only** evaluated on nodes when some context is present. An initial context should be
-provided via the `ctx?` argument if invoking `findSome?` during a larger traversal of the infotree.
-A failure to provide `ctx? := some ctx` when `t` is not the outermost `InfoTree` is thus likely to
-cause `findSome?` to always return `none`.
--/
-partial def findSome? {α} (f : ContextInfo → Info → PersistentArray InfoTree → Option α)
-    (t : InfoTree) (ctx? : Option ContextInfo := none) : Option α :=
-  go ctx? t
-where go ctx?
-  | context ctx t => go (ctx.mergeIntoOuter? ctx?) t
-  | node i ts =>
-    let a := match ctx? with
-      | none => none
-      | some ctx => f ctx i ts
-    a <|> ts.findSome? (go <| i.updateContext? ctx?)
-  | hole _ => none
-
-/--
 Finds the first result of `← f ctx info children` which is `some a`, descending the
 tree from the top. Merges and updates contexts as it descends the tree.
 
@@ -84,6 +63,19 @@ where go ctx?
     | some a => pure a
     | none => ts.findSomeM? (go <| i.updateContext? ctx?)
   | hole _ => pure none
+
+/--
+Finds the first result of `f ctx info children` which is `some a`, descending the
+tree from the top. Merges and updates contexts as it descends the tree.
+
+`f` is **only** evaluated on nodes when some context is present. An initial context should be
+provided via the `ctx?` argument if invoking `findSome?` during a larger traversal of the infotree.
+A failure to provide `ctx? := some ctx` when `t` is not the outermost `InfoTree` is thus likely to
+cause `findSome?` to always return `none`.
+-/
+def findSome? {α} (f : ContextInfo → Info → PersistentArray InfoTree → Option α)
+    (t : InfoTree) (ctx? : Option ContextInfo := none) : Option α :=
+  Id.run <| t.findSomeM? f ctx?
 
 /--
 Returns the value of `f ctx info children` on the outermost `.node info children` which has

--- a/Mathlib/Lean/Elab/InfoTree.lean
+++ b/Mathlib/Lean/Elab/InfoTree.lean
@@ -85,7 +85,7 @@ If `ctx?` is `some ctx`, `ctx` is used as an initial context. A `ctx?` of `none`
 used when operating on the first node of the entire infotree. Otherwise, it is likely that no
 context will be found.
 -/
-def onFirstNode? {α} (t : InfoTree) (ctx? : Option ContextInfo)
+def onHighestNode? {α} (t : InfoTree) (ctx? : Option ContextInfo)
     (f : ContextInfo → Info → PersistentArray InfoTree → α) : Option α :=
   t.findSome? (ctx? := ctx?) fun ctx i ch => some (f ctx i ch)
 

--- a/Mathlib/Lean/Elab/InfoTree.lean
+++ b/Mathlib/Lean/Elab/InfoTree.lean
@@ -1,7 +1,7 @@
 /-
 Copyright (c) 2025 Marc Huisinga. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
-Authors: Marc Huisinga
+Authors: Marc Huisinga, Thomas R. Murrills
 -/
 import Mathlib.Init
 import Lean.Server.InfoUtils
@@ -38,4 +38,63 @@ where
       | return
     modify (·.push tti.suggestion)
 
-end Lean.Elab
+namespace InfoTree
+
+/--
+Finds the first result of `f ctx info children` which is `some a`, descending the
+tree from the top. Merges and updates contexts as it descends the tree.
+
+`f` is **only** evaluated on nodes when some context is present. An initial context should be
+provided via the `ctx?` argument if invoking `findSome?` during a larger traversal of the infotree.
+A failure to provide `ctx? := some ctx` when `t` is not the outermost `InfoTree` is thus likely to
+cause `findSome?` to always return `none`.
+-/
+partial def findSome? {α} (f : ContextInfo → Info → PersistentArray InfoTree → Option α)
+    (t : InfoTree) (ctx? : Option ContextInfo := none) : Option α :=
+  go ctx? t
+where go ctx?
+  | context ctx t => go (ctx.mergeIntoOuter? ctx?) t
+  | node i ts =>
+    let a := match ctx? with
+      | none => none
+      | some ctx => f ctx i ts
+    a <|> ts.findSome? (go <| i.updateContext? ctx?)
+  | hole _ => none
+
+/--
+Finds the first result of `← f ctx info children` which is `some a`, descending the
+tree from the top. Merges and updates contexts as it descends the tree.
+
+`f` is **only** evaluated on nodes when some context is present. An initial context should be
+provided via the `ctx?` argument if invoking `findSomeM?` during a larger traversal of the
+infotree. A failure to provide `ctx? := some ctx` when `t` is not the outermost `InfoTree` is thus
+likely to cause `findSomeM?` to always return `none`.
+-/
+partial def findSomeM? {m : Type → Type} [Monad m] {α}
+    (f : ContextInfo → Info → PersistentArray InfoTree → m (Option α))
+    (t : InfoTree) (ctx? : Option ContextInfo := none) : m (Option α) :=
+  go ctx? t
+where go ctx?
+  | context ctx t => go (ctx.mergeIntoOuter? ctx?) t
+  | node i ts => do
+    let a ← match ctx? with
+      | none => pure none
+      | some ctx => f ctx i ts
+    match a with
+    | some a => pure a
+    | none => ts.findSomeM? (go <| i.updateContext? ctx?)
+  | hole _ => pure none
+
+/--
+Returns the value of `f ctx info children` on the outermost `.node info children` which has
+context, having merged and updated contexts appropriately.
+
+If `ctx?` is `some ctx`, `ctx` is used as an initial context. A `ctx?` of `none` should **only** be
+used when operating on the first node of the entire infotree. Otherwise, it is likely that no
+context will be found.
+-/
+def onFirstNode? {α} (t : InfoTree) (ctx? : Option ContextInfo)
+    (f : ContextInfo → Info → PersistentArray InfoTree → α) : Option α :=
+  t.findSome? (ctx? := ctx?) fun ctx i ch => some (f ctx i ch)
+
+end Lean.Elab.InfoTree

--- a/Mathlib/Lean/Syntax.lean
+++ b/Mathlib/Lean/Syntax.lean
@@ -1,0 +1,23 @@
+/-
+Copyright (c) 2025 Thomas R. Murrills. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Thomas R. Murrills
+-/
+import Mathlib.Init
+
+namespace Lean.Syntax
+
+/-- Finds the first subtree of `stx` for which `p subtree` is `some a`, descending the tree from
+the top. -/
+partial def findSome? {α} (p : Syntax → Option α) : Syntax → Option α
+  | stx@(.node _ _ args) => p stx <|> args.findSome? (findSome? p)
+  | stx                  => p stx
+
+/-- Returns `true` exactly when `stxᵢ.getRange? canonicalOnlyᵢ` are both `some _` and are equal.
+This means that `rangeEq` returns `false` if either arguments have no position information. -/
+def rangeEq (stx₁ stx₂ : Syntax) (canonicalOnly₁ canonicalOnly₂ := true) : Bool :=
+  match stx₁.getRange? canonicalOnly₁, stx₂.getRange? canonicalOnly₂ with
+  | some r₁, some r₂ => r₁ == r₂
+  | _, _ => false
+
+end Lean.Syntax

--- a/Mathlib/Util/DeclarationManipulation.lean
+++ b/Mathlib/Util/DeclarationManipulation.lean
@@ -1,0 +1,102 @@
+/-
+Copyright (c) 2025 Thomas R. Murrills. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Thomas R. Murrills
+-/
+import Mathlib.Init
+import Mathlib.Lean.Syntax
+import Mathlib.Lean.Elab.InfoTree
+import Mathlib.Tactic.Lemma
+
+/-!
+# Declaration manipulation tools for metaprogramming
+
+This module defines a suite of tools for working with user-written declarations in metaprogramming,
+which often involves interactions betweeen the infotrees, source syntax, and the environment.
+
+This is a work-in-progress, and only in its early stages.
+-/
+
+namespace Lean.Elab.InfoTree
+
+section declToInfoAndSyntax
+
+/-! Given a declaration, these tools help us access `Info` associated with those declarations and
+let us extract components of the command syntax corresponding to different parts of the
+declaration. -/
+
+/--
+Given a constant name, find the first `TermInfo` whose expression is exactly that constant. Expects
+`decl` to be a fully resolved name.
+-/
+def getConstTermInfo? (t : InfoTree) (decl : Name) : Option TermInfo :=
+  t.findSome? fun
+    | _, .ofTermInfo ti, _ => if ti.expr.isConstOf decl then some ti else none
+    | _, _, _ => none
+
+/--
+Get the syntax of the `TermInfo` corresponding to the first appearance of `decl` as an
+`Expr.const ..`.
+
+Usually, this is the syntax of the identifier occurring after a token like `def` or `theorem`,
+*excluding*  universe syntax (i.e., `id` in `$id$[.{$_,*}]?`). In the case of `instance` with no
+identifier, the `instance` token is used.
+
+Note that the behavior described here is undocumented, and subject to change.
+-/
+def getConstRef? (t : InfoTree) (decl : Name) : Option Syntax :=
+  t.getConstTermInfo? decl |>.map (·.stx)
+
+/- TODO: refactor through more general "declaration syntax view", like a more fine-grained version
+of `mkDefView` and without the unneeded (for our purposes) elaboration state. -/
+-- TODO: generalize to `def`s, etc.
+open Parser.Command in
+/--
+Attempts find the type signature part of the originating syntax for `decl` appearing within the
+syntax `cmd` by matching the position info of the syntax of the identifier occurring after a token
+like `def` or `theorem`, *excluding*  universe syntax (i.e., `id` in `$id$[.{$_,*}]?`). (In the
+case of `instance` with no identifier, the `instance` token is used.)
+
+This `idRef : Syntax`, with the properties described here, can be extracted from the infotrees with
+`InfoTree.getConstRef?`.
+
+Only handles declarations originating from `theorem`, `lemma`, and `instance` (including
+when nested in `mutual` blocks or buried somewhere in `cmd`). Does not handle `let rec`/
+`where`-style `let rec` declarations.
+-/
+def _root_.Lean.Syntax.getThmSigRefOfId? (cmd idRef : Syntax) : Option (TSyntax ``declSig) :=
+  cmd.findSome? fun
+    | `(Parser.Command.theorem| theorem $id$[.{$_,*}]? $sig:declSig $_:declVal)
+    | `(«lemma»| lemma $id$[.{$_,*}]? $sig:declSig $_:declVal)
+    | `(Parser.Command.instance| $_:attrKind instance $[$_:namedPrio]?
+        $id$[.{$_,*}]? $sig:declSig $_:declVal) =>
+      if id.raw.rangeEq idRef then sig else none
+    -- When no `declId` is present, Lean uses the position information for the `instance` token.
+    | `(Parser.Command.instance| $_:attrKind instance%$tk $[$_:namedPrio]?
+        $sig:declSig $_:declVal) => if tk.rangeEq idRef then sig else none
+    -- TODO: handle `let rec` decls (after `where`), handle defs etc.
+    | _ => none
+
+-- TODO: generalize to `def`s, etc.
+/--
+Attempts to run `x : m α` with the monad's ref set to the syntax for the type signature of the
+originating syntax of `decl` appearing within the syntax `cmd`, according to the link between the
+`decl` and its syntax carried by the infotree `t`.
+
+If the type signature's position info cannot be found, uses the position info of the syntax for
+`decl` found in `t`. If that can't be found either, uses `cmd` as the ref.
+
+Only handles declarations originating from `theorem`, `lemma`, and `instance` (including
+when nested in `mutual` blocks or buried somewhere in `cmd`). Does not handle `let rec`/
+`where`-style `let rec` declarations.
+-/
+def withThmSigRef {m : Type → Type} [Monad m] [MonadRef m] {α}
+    (t : InfoTree) (cmd : Syntax) (decl : Name) (x : m α) : m α := withRef cmd do
+  let some idRef := t.getConstRef? decl | x
+  let sigRef? := cmd.getThmSigRefOfId? idRef
+  -- Fall back to `idRef` if `sigRef` is not found or has no position info.
+  withRef idRef <| withRef? sigRef? x
+
+end declToInfoAndSyntax
+
+end Lean.Elab.InfoTree


### PR DESCRIPTION
This PR introduces some initial definitions in the space of a declaration manipulation meta API.

In the course of #31142, it became apparent that we could benefit from having tools for handling the syntax and elaboration info of user-written declarations.

This PR makes a small beginning towards that end in the Mathlib.Util.DeclarationManipulation module, and provides API for
- getting the info and syntax ref of a declaration given its `Name`
- getting the ref of a theorem's type signature from within some command source syntax given the declaration's ref given above
- running a monadic action with the ambient ref set to that of the type signature of a theorem, with sensible fallbacks

This is used to improve logging locations for the unused-instances-in-types linters, and may be useful for other linters that want to inpsect a theorem's type at the expression level (instead of the syntax level).

(It also introduces the small helper definitions `Syntax.findSome?` and `Syntax.rangeEq`, which behave as expected.)

For context: in the future, it would be nice to
- provide support for all sorts of declarations, not just theorems--but this requires a lot more syntax matching
- provide "exploded views" of declaration syntax like `mkDefView`, but finer grained, and geared for use during linting rather than elaboration
- make it easy to compose complex suggestions to transform different parts of a declaration at once

---

- [ ] depends on: #31725 

<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

When merging, all the commits will be squashed into a single commit
listing all co-authors.

Co-authors in the squash commit are gathered from two sources:

First, all authors of commits to this PR branch are included. Thus,
one way to add co-authors is to include at least one commit authored by
each co-author among the commits in the pull request. If necessary, you
may create empty commits to indicate co-authorship, using commands like so:

git commit --author="Author Name <author@email.com>" --allow-empty -m "add Author Name as coauthor"

Second, co-authors can also be listed in lines at the very bottom of
the commit message (that is, directly before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines
at the bottom of the commit message (before the `---`, and also before
any "Co-authored-by" lines) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
