### PR TITLE
[Merged by Bors] - feat: characterise regular elements of type synonyms

### DIFF
--- a/Mathlib/Algebra/Group/TypeTags/Basic.lean
+++ b/Mathlib/Algebra/Group/TypeTags/Basic.lean
@@ -288,6 +288,56 @@ theorem ofAdd_nsmul [AddMonoid α] (n : ℕ) (a : α) : ofAdd (n • a) = ofAdd 
 theorem toAdd_pow [AddMonoid α] (a : Multiplicative α) (n : ℕ) : (a ^ n).toAdd = n • a.toAdd :=
   rfl
 
+section Monoid
+variable [Monoid α]
+
+@[simp]
+lemma isAddLeftRegular_ofMul {a : α} : IsAddLeftRegular (Additive.ofMul a) ↔ IsLeftRegular a := .rfl
+
+@[simp]
+lemma isLeftRegular_toMul {a : Additive α} : IsLeftRegular a.toMul ↔ IsAddLeftRegular a := .rfl
+
+@[simp]
+lemma isAddRightRegular_ofMul {a : α} : IsAddRightRegular (Additive.ofMul a) ↔ IsRightRegular a :=
+  .rfl
+
+@[simp]
+lemma isRightRegular_toMul {a : Additive α} : IsRightRegular a.toMul ↔ IsAddRightRegular a := .rfl
+
+@[simp] lemma isAddRegular_ofMul {a : α} : IsAddRegular (Additive.ofMul a) ↔ IsRegular a := by
+  simp [isAddRegular_iff, isRegular_iff]
+
+@[simp] lemma isRegular_toMul {a : Additive α} : IsRegular a.toMul ↔ IsAddRegular a := by
+  simp [isAddRegular_iff, isRegular_iff]
+
+end Monoid
+
+section AddMonoid
+variable [AddMonoid α]
+
+@[simp]
+lemma isLeftRegular_ofAdd {a : α} : IsLeftRegular (Multiplicative.ofAdd a) ↔ IsAddLeftRegular a :=
+  .rfl
+
+@[simp]
+lemma isAddLeftRegular_toAdd {a : Multiplicative α} : IsAddLeftRegular a.toAdd ↔ IsLeftRegular a :=
+  .rfl
+
+@[simp]
+lemma isRightRegular_ofAdd {a : α} :
+    IsRightRegular (Multiplicative.ofAdd a) ↔ IsAddRightRegular a := .rfl
+
+@[simp] lemma isAddRightRegular_toAdd {a : Multiplicative α} :
+    IsAddRightRegular a.toAdd ↔ IsRightRegular a := .rfl
+
+@[simp] lemma isRegular_ofAdd {a : α} : IsRegular (Multiplicative.ofAdd a) ↔ IsAddRegular a := by
+  simp [isAddRegular_iff, isRegular_iff]
+
+@[simp] lemma isAddRegular_toAdd {a : Multiplicative α} : IsAddRegular a.toAdd ↔ IsRegular a := by
+  simp [isAddRegular_iff, isRegular_iff]
+
+end AddMonoid
+
 instance Additive.addLeftCancelMonoid [LeftCancelMonoid α] : AddLeftCancelMonoid (Additive α) :=
   { Additive.addMonoid, Additive.addLeftCancelSemigroup with }
 

--- a/Mathlib/Algebra/Order/Group/Synonym.lean
+++ b/Mathlib/Algebra/Order/Group/Synonym.lean
@@ -104,6 +104,9 @@ theorem toDual_one [One α] : toDual (1 : α) = 1 := rfl
 @[to_additive (attr := simp)]
 theorem ofDual_one [One α] : (ofDual 1 : α) = 1 := rfl
 
+@[to_additive (attr := simp)] lemma toDual_eq_one [One α] {a : α} : toDual a = 1 ↔ a = 1 := .rfl
+@[to_additive (attr := simp)] lemma ofDual_eq_one [One α] {a : αᵒᵈ} : ofDual a = 1 ↔  a = 1 := .rfl
+
 @[to_additive (attr := simp)]
 theorem toDual_mul [Mul α] (a b : α) : toDual (a * b) = toDual a * toDual b := rfl
 
@@ -133,6 +136,29 @@ theorem pow_toDual [Pow α β] (a : α) (b : β) : a ^ toDual b = a ^ b := rfl
 
 @[to_additive (attr := simp, to_additive) (reorder := 1 2, 4 5) ofDual_smul']
 theorem pow_ofDual [Pow α β] (a : α) (b : βᵒᵈ) : a ^ ofDual b = a ^ b := rfl
+
+section Monoid
+variable [Monoid α]
+
+@[to_additive (attr := simp)]
+lemma isLeftRegular_toDual {a : α} : IsLeftRegular (toDual a) ↔ IsLeftRegular a := .rfl
+
+@[to_additive (attr := simp)]
+lemma isLeftRegular_ofDual {a : αᵒᵈ} : IsLeftRegular (ofDual a) ↔ IsLeftRegular a := .rfl
+
+@[to_additive (attr := simp)]
+lemma isRightRegular_toDual {a : α} : IsRightRegular (toDual a) ↔ IsRightRegular a := .rfl
+
+@[to_additive (attr := simp)]
+lemma isRightRegular_ofDual {a : αᵒᵈ} : IsRightRegular (ofDual a) ↔ IsRightRegular a := .rfl
+
+@[to_additive (attr := simp)]
+lemma isRegular_toDual {a : α} : IsRegular (toDual a) ↔ IsRegular a := .rfl
+
+@[to_additive (attr := simp)]
+lemma isRegular_ofDual {a : αᵒᵈ} : IsRegular (ofDual a) ↔ IsRegular a := .rfl
+
+end Monoid
 
 /-! ### Lexicographical order -/
 
@@ -260,6 +286,29 @@ theorem pow_toLex [Pow α β] (a : α) (b : β) : a ^ toLex b = a ^ b := rfl
 @[to_additive (attr := simp, to_additive) (reorder := 1 2, 4 5) ofLex_smul']
 theorem pow_ofLex [Pow α β] (a : α) (b : Lex β) : a ^ ofLex b = a ^ b := rfl
 
+section Monoid
+variable [Monoid α]
+
+@[to_additive (attr := simp)]
+lemma isLeftRegular_toLex {a : α} : IsLeftRegular (toLex a) ↔ IsLeftRegular a := .rfl
+
+@[to_additive (attr := simp)]
+lemma isLeftRegular_ofLex {a : Lex α} : IsLeftRegular (ofLex a) ↔ IsLeftRegular a := .rfl
+
+@[to_additive (attr := simp)]
+lemma isRightRegular_toLex {a : α} : IsRightRegular (toLex a) ↔ IsRightRegular a := .rfl
+
+@[to_additive (attr := simp)]
+lemma isRightRegular_ofLex {a : Lex α} : IsRightRegular (ofLex a) ↔ IsRightRegular a := .rfl
+
+@[to_additive (attr := simp)]
+lemma isRegular_toLex {a : α} : IsRegular (toLex a) ↔ IsRegular a := .rfl
+
+@[to_additive (attr := simp)]
+lemma isRegular_ofLex {a : Lex α} : IsRegular (ofLex a) ↔ IsRegular a := .rfl
+
+end Monoid
+
 /-! ### Colexicographical order -/
 
 
@@ -385,3 +434,26 @@ theorem pow_toColex [Pow α β] (a : α) (b : β) : a ^ toColex b = a ^ b := rfl
 
 @[to_additive (attr := simp, to_additive) (reorder := 1 2, 4 5) ofColex_smul']
 theorem pow_ofColex [Pow α β] (a : α) (b : Colex β) : a ^ ofColex b = a ^ b := rfl
+
+section Monoid
+variable [Monoid α]
+
+@[to_additive (attr := simp)]
+lemma isLeftRegular_toColex {a : α} : IsLeftRegular (toColex a) ↔ IsLeftRegular a := .rfl
+
+@[to_additive (attr := simp)]
+lemma isLeftRegular_ofColex {a : Colex α} : IsLeftRegular (ofColex a) ↔ IsLeftRegular a := .rfl
+
+@[to_additive (attr := simp)]
+lemma isRightRegular_toColex {a : α} : IsRightRegular (toColex a) ↔ IsRightRegular a := .rfl
+
+@[to_additive (attr := simp)]
+lemma isRightRegular_ofColex {a : Colex α} : IsRightRegular (ofColex a) ↔ IsRightRegular a := .rfl
+
+@[to_additive (attr := simp)]
+lemma isRegular_toColex {a : α} : IsRegular (toColex a) ↔ IsRegular a := .rfl
+
+@[to_additive (attr := simp)]
+lemma isRegular_ofColex {a : Colex α} : IsRegular (ofColex a) ↔ IsRegular a := .rfl
+
+end Monoid

--- a/Mathlib/Algebra/Order/GroupWithZero/Canonical.lean
+++ b/Mathlib/Algebra/Order/GroupWithZero/Canonical.lean
@@ -206,15 +206,15 @@ instance instLinearOrderedCommMonoidWithZeroMultiplicativeOrderDual
   mul_zero := @add_top _ (_)
   zero_le_one := (le_top : (0 : α) ≤ ⊤)
 
-@[simp]
+@[deprecated "Use simp" (since := "2025-11-17")]
 theorem ofAdd_toDual_eq_zero_iff [LinearOrderedAddCommMonoidWithTop α]
     (x : α) : Multiplicative.ofAdd (OrderDual.toDual x) = 0 ↔ x = ⊤ := Iff.rfl
 
-@[simp]
+@[deprecated "Use simp" (since := "2025-11-17")]
 theorem ofDual_toAdd_eq_top_iff [LinearOrderedAddCommMonoidWithTop α]
     (x : Multiplicative αᵒᵈ) : OrderDual.ofDual x.toAdd = ⊤ ↔ x = 0 := Iff.rfl
 
-@[simp]
+@[deprecated bot_eq_zero'' (since := "2025-11-17")]
 theorem ofAdd_bot [LinearOrderedAddCommMonoidWithTop α] :
     Multiplicative.ofAdd ⊥ = (0 : Multiplicative αᵒᵈ) := rfl
 

--- a/Mathlib/Algebra/Order/Monoid/Unbundled/TypeTags.lean
+++ b/Mathlib/Algebra/Order/Monoid/Unbundled/TypeTags.lean
@@ -91,6 +91,8 @@ theorem toMul_lt {a b : Additive α} : a.toMul < b.toMul ↔ a < b :=
 @[gcongr] alias ⟨_, toMul_strictMono⟩ := toMul_lt
 @[gcongr] alias ⟨_, ofMul_strictMono⟩ := ofMul_lt
 
+@[deprecated (since := "2025-11-18")] alias foMul_strictMono := ofMul_strictMono
+
 end Preorder
 
 section OrderTop

--- a/Mathlib/Algebra/Order/Monoid/Unbundled/TypeTags.lean
+++ b/Mathlib/Algebra/Order/Monoid/Unbundled/TypeTags.lean
@@ -67,7 +67,7 @@ instance Additive.existsAddOfLe [Mul α] [LE α] [ExistsMulOfLE α] : ExistsAddO
   ⟨@exists_mul_of_le α _ _ _⟩
 
 namespace Additive
-
+section Preorder
 variable [Preorder α]
 
 @[simp]
@@ -89,12 +89,35 @@ theorem toMul_lt {a b : Additive α} : a.toMul < b.toMul ↔ a < b :=
 @[gcongr] alias ⟨_, toMul_mono⟩ := toMul_le
 @[gcongr] alias ⟨_, ofMul_mono⟩ := ofMul_le
 @[gcongr] alias ⟨_, toMul_strictMono⟩ := toMul_lt
-@[gcongr] alias ⟨_, foMul_strictMono⟩ := ofMul_lt
+@[gcongr] alias ⟨_, ofMul_strictMono⟩ := ofMul_lt
 
+end Preorder
+
+section OrderTop
+variable [LE α] [OrderTop α]
+
+@[simp] lemma ofMul_top : ofMul (⊤ : α) = ⊤ := rfl
+@[simp] lemma toMul_top : toMul ⊤ = (⊤ : α) := rfl
+
+@[simp] lemma ofMul_eq_top {a : α} : ofMul a = ⊤ ↔ a = ⊤ := .rfl
+@[simp] lemma toMul_eq_top {a : Additive α} : toMul a = ⊤ ↔ a = ⊤ := .rfl
+
+end OrderTop
+
+section OrderBot
+variable [LE α] [OrderBot α]
+
+@[simp] lemma ofMul_bot : ofMul (⊥ : α) = ⊥ := rfl
+@[simp] lemma toMul_bot : toMul ⊥ = (⊥ : α) := rfl
+
+@[simp] lemma ofMul_eq_bot {a : α} : ofMul a = ⊥ ↔ a = ⊥ := .rfl
+@[simp] lemma toMul_eq_bot {a : Additive α} : toMul a = ⊥ ↔ a = ⊥ := .rfl
+
+end OrderBot
 end Additive
 
 namespace Multiplicative
-
+section Preorder
 variable [Preorder α]
 
 @[simp]
@@ -117,5 +140,29 @@ theorem toAdd_lt {a b : Multiplicative α} : a.toAdd < b.toAdd ↔ a < b :=
 @[gcongr] alias ⟨_, ofAdd_mono⟩ := ofAdd_le
 @[gcongr] alias ⟨_, toAdd_strictMono⟩ := toAdd_lt
 @[gcongr] alias ⟨_, ofAdd_strictMono⟩ := ofAdd_lt
+
+end Preorder
+
+section OrderTop
+variable [LE α] [OrderTop α]
+
+@[simp] lemma ofAdd_top : ofAdd (⊤ : α) = ⊤ := rfl
+@[simp] lemma toAdd_top : toAdd ⊤ = (⊤ : α) := rfl
+
+@[simp] lemma ofAdd_eq_top {a : α} : ofAdd a = ⊤ ↔ a = ⊤ := .rfl
+@[simp] lemma toAdd_eq_top {a : Multiplicative α} : toAdd a = ⊤ ↔ a = ⊤ := .rfl
+
+end OrderTop
+
+section OrderBot
+variable [LE α] [OrderBot α]
+
+@[simp] lemma ofAdd_bot : ofAdd (⊥ : α) = ⊥ := rfl
+@[simp] lemma toAdd_bot : toAdd ⊥ = (⊥ : α) := rfl
+
+@[simp] lemma ofAdd_eq_bot {a : α} : ofAdd a = ⊥ ↔ a = ⊥ := .rfl
+@[simp] lemma toAdd_eq_bot {a : Multiplicative α} : toAdd a = ⊥ ↔ a = ⊥ := .rfl
+
+end OrderBot
 
 end Multiplicative

--- a/Mathlib/Order/BoundedOrder/Basic.lean
+++ b/Mathlib/Order/BoundedOrder/Basic.lean
@@ -227,21 +227,15 @@ instance instOrderBot [LE α] [OrderTop α] : OrderBot αᵒᵈ where
   __ := inferInstanceAs (Bot αᵒᵈ)
   bot_le := @le_top α _ _
 
-@[simp]
-theorem ofDual_bot [Top α] : ofDual ⊥ = (⊤ : α) :=
-  rfl
+@[simp] lemma ofDual_bot [Top α] : ofDual ⊥ = (⊤ : α) := rfl
+@[simp] lemma ofDual_top [Bot α] : ofDual ⊤ = (⊥ : α) := rfl
+@[simp] lemma toDual_bot [Bot α] : toDual (⊥ : α) = ⊤ := rfl
+@[simp] lemma toDual_top [Top α] : toDual (⊤ : α) = ⊥ := rfl
 
-@[simp]
-theorem ofDual_top [Bot α] : ofDual ⊤ = (⊥ : α) :=
-  rfl
-
-@[simp]
-theorem toDual_bot [Bot α] : toDual (⊥ : α) = ⊤ :=
-  rfl
-
-@[simp]
-theorem toDual_top [Top α] : toDual (⊤ : α) = ⊥ :=
-  rfl
+@[simp] lemma ofDual_eq_bot [Bot α] {a : αᵒᵈ} : ofDual a = ⊥ ↔ a = ⊤ := .rfl
+@[simp] lemma ofDual_eq_top [Top α] {a : αᵒᵈ} : ofDual a = ⊤ ↔ a = ⊥ := .rfl
+@[simp] lemma toDual_eq_bot [Top α] {a : α} : toDual a = ⊥ ↔ a = ⊤ := .rfl
+@[simp] lemma toDual_eq_top [Bot α] {a : α} : toDual a = ⊤ ↔ a = ⊥ := .rfl
 
 end OrderDual
 


### PR DESCRIPTION
---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

When merging, all the commits will be squashed into a single commit
listing all co-authors.

Co-authors in the squash commit are gathered from two sources:

First, all authors of commits to this PR branch are included. Thus,
one way to add co-authors is to include at least one commit authored by
each co-author among the commits in the pull request. If necessary, you
may create empty commits to indicate co-authorship, using commands like so:

git commit --author="Author Name <author@email.com>" --allow-empty -m "add Author Name as coauthor"

Second, co-authors can also be listed in lines at the very bottom of
the commit message (that is, directly before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines
at the bottom of the commit message (before the `---`, and also before
any "Co-authored-by" lines) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
