### PR TITLE
[Merged by Bors] - doc: ensure only a single H1 header per file

### DIFF
--- a/Mathlib/Dynamics/Ergodic/Ergodic.lean
+++ b/Mathlib/Dynamics/Ergodic/Ergodic.lean
@@ -17,7 +17,7 @@ In this file we define ergodic maps / measures together with quasi-ergodic maps 
 provide some basic API. Quasi-ergodicity is a weaker condition than ergodicity for which the measure
 preserving condition is relaxed to quasi-measure-preserving.
 
-# Main definitions:
+## Main definitions
 
 * `PreErgodic`: the ergodicity condition without the measure-preserving condition. This exists
   to share code between the `Ergodic` and `QuasiErgodic` definitions.

--- a/Mathlib/Order/Filter/CardinalInter.lean
+++ b/Mathlib/Order/Filter/CardinalInter.lean
@@ -16,7 +16,7 @@ In this file we define `CardinalInterFilter l c` to be the class of filters with
 property: for any collection of sets `s ∈ l` with cardinality strictly less than `c`,
 their intersection belongs to `l` as well.
 
-# Main results
+## Main results
 * `Filter.cardinalInterFilter_aleph0` establishes that every filter `l` is a
     `CardinalInterFilter l ℵ₀`
 * `CardinalInterFilter.toCountableInterFilter` establishes that every `CardinalInterFilter l c` with

--- a/Mathlib/Probability/Independence/BoundedContinuousFunction.lean
+++ b/Mathlib/Probability/Independence/BoundedContinuousFunction.lean
@@ -43,19 +43,19 @@ function `f : (Π s : I, E s) → ℝ`, we have `∫ ω in A, f (X · ω) ∂P =
 This again is formulated with different versions. We also provide versions in terms of
 `IndepSets` instead of `Indep`.
 
-# Main statement
+## Main statement
 
 * `indep_comap_process_of_bcf`: A `σ`-algebra `m` is independent from a stochastic process `X`
   if for any `A` such that `MeasurableSet[m] A`, any `I : Finset S`, and any bounded continuous
   function `f : (Π s : I, E s) → ℝ`, we have
   `∫ ω in A, f (X · ω) ∂P = P.real A * ∫ ω, f (X · ω) ∂P`.
 
-# Notations
+## Notations
 
 to avoid writing `boundedContinuousFunction` in the names, which is quite lengthy, we abbreviate it
 to `bcf`.
 
-# Tags
+## Tags
 
 independence, bounded continuous functions
 -/

--- a/Mathlib/RingTheory/Localization/AtPrime/Extension.lean
+++ b/Mathlib/RingTheory/Localization/AtPrime/Extension.lean
@@ -16,7 +16,7 @@ In this file, we study the relation between the (nonzero) prime ideals of `Sₚ`
 ideals of `S` above `p`. In particular, we prove that (under suitable conditions) they are in
 bijection.
 
-# Main definitions and results
+## Main definitions and results
 
 - `IsLocalization.AtPrime.mem_primesOver_of_isPrime`: The nonzero prime ideals of `Sₚ` are
   primes over the maximal ideal of `Rₚ`.


### PR DESCRIPTION
---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

When merging, all the commits will be squashed into a single commit
listing all co-authors.

Co-authors in the squash commit are gathered from two sources:

First, all authors of commits to this PR branch are included. Thus,
one way to add co-authors is to include at least one commit authored by
each co-author among the commits in the pull request. If necessary, you
may create empty commits to indicate co-authorship, using commands like so:

git commit --author="Author Name <author@email.com>" --allow-empty -m "add Author Name as coauthor"

Second, co-authors can also be listed in lines at the very bottom of
the commit message (that is, directly before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines
at the bottom of the commit message (before the `---`, and also before
any "Co-authored-by" lines) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
