### PR TITLE
[Merged by Bors] - chore: Fix notation in ValuativeRel so that they print correctly.

### DIFF
--- a/Mathlib/Topology/Algebra/Valued/ValuativeRel.lean
+++ b/Mathlib/Topology/Algebra/Valued/ValuativeRel.lean
@@ -224,9 +224,9 @@ namespace ValuativeRel
 scoped notation "𝒪[" R "]" => Valuation.integer (valuation R)
 
 @[inherit_doc]
-scoped notation "𝓂[" K "]" => IsLocalRing.maximalIdeal 𝒪[K]
+scoped notation "𝓂[" K "]" => IsLocalRing.maximalIdeal ↥𝒪[K]
 
 @[inherit_doc]
-scoped notation "𝓀[" K "]" => IsLocalRing.ResidueField 𝒪[K]
+scoped notation "𝓀[" K "]" => IsLocalRing.ResidueField ↥𝒪[K]
 
 end ValuativeRel


### PR DESCRIPTION
This PR fixes the existing notations for `𝓂[K]` and `𝓀[K]` so that they print correctly.

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

When merging, all the commits will be squashed into a single commit
listing all co-authors.

Co-authors in the squash commit are gathered from two sources:

First, all authors of commits to this PR branch are included. Thus,
one way to add co-authors is to include at least one commit authored by
each co-author among the commits in the pull request. If necessary, you
may create empty commits to indicate co-authorship, using commands like so:

git commit --author="Author Name <author@email.com>" --allow-empty -m "add Author Name as coauthor"

Second, co-authors can also be listed in lines at the very bottom of
the commit message (that is, directly before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines
at the bottom of the commit message (before the `---`, and also before
any "Co-authored-by" lines) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

You can test that this fix works right now by doing the following:
```lean
import Mathlib

open ValuativeRel

variable (K : Type*) [Field K] [ValuativeRel K]

#check 𝓂[K] -- IsLocalRing.maximalIdeal ↥𝒪[K] : Ideal ↥𝒪[K]
#check 𝓀[K] -- IsLocalRing.ResidueField ↥𝒪[K] : Type u_1

local notation "fixed𝓂[" K "]" => IsLocalRing.maximalIdeal ↥𝒪[K]
local notation "fixed𝓀[" K "]" => IsLocalRing.ResidueField ↥𝒪[K]

#check 𝓂[K] -- fixed𝓂[K] : Ideal ↥𝒪[K]
#check 𝓀[K] -- fixed𝓀[K] : Type u_1
```
[web editor](https://live.lean-lang.org/#codez=JYWwDg9gTgLgBAWQIYwBYBtgCMBQOJgCmAdnAGpLoCuKwAboQEqHp51JTBJbqFwAUAaTgAuOABUAnkQBUASjgBtAGLAWAEziCAukorVaDZui3a8AYgDGqQpYDWcQKwbgIZ3FOuAFoPcAJIBnABkIS0pGYGIAcwA6ECQAD1BKH3VCSjhAUsJHQCqdt10xZNSTTJydHCsbeydAAZ3cz29/IJD0MMio5j9gdSpCVQ0M7NqxKSI4KgB9AEY8dGC04ggYWghSACIAM2A4wnUXRRWtOBXtfYBeAD5fQNnm8OjYhNj0ArTi3JwZprh5xZhgZcONlsdjV9sIjqcLg1ri1ou1Ot1euhNK9SmVrLYHLt3F44IDtli8r4Ui8BqVyhjqrUcXjgYMJNI+OMpkA)

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
