### PR TITLE
[Merged by Bors] - refactor(LinearAlgebra/Matrix): generalize positive semidefinite matrices to infinite dimensions

### DIFF
--- a/Mathlib/Analysis/InnerProductSpace/GramMatrix.lean
+++ b/Mathlib/Analysis/InnerProductSpace/GramMatrix.lean
@@ -80,7 +80,7 @@ variable (𝕜) in
 /-- A Gram matrix is positive semidefinite. -/
 theorem posSemidef_gram (v : n → E) :
     PosSemidef (gram 𝕜 v) := by
-  refine ⟨isHermitian_gram _ _, fun x ↦ ?_⟩
+  refine posSemidef_iff_dotProduct_mulVec.mpr ⟨isHermitian_gram _ _, fun x ↦ ?_⟩
   rw [star_dotProduct_gram_mulVec, le_iff_re_im]
   simp
 
@@ -89,7 +89,7 @@ theorem linearIndependent_of_posDef_gram {v : n → E} (h_gram : PosDef (gram �
     LinearIndependent 𝕜 v := by
   rw [Fintype.linearIndependent_iff]
   intro y hy
-  obtain ⟨h1, h2⟩ := h_gram
+  have h2 := h_gram.dotProduct_mulVec_pos
   specialize h2 y
   simp_all [star_dotProduct_gram_mulVec]
 
@@ -102,8 +102,8 @@ variable [NormedAddCommGroup E] [InnerProductSpace 𝕜 E] [Fintype n]
 theorem posDef_gram_of_linearIndependent
     {v : n → E} (h_li : LinearIndependent 𝕜 v) : PosDef (gram 𝕜 v) := by
   rw [Fintype.linearIndependent_iff] at h_li
-  obtain ⟨h0, h1⟩ := posSemidef_gram 𝕜 v
-  refine ⟨h0, fun x hx ↦ (h1 x).lt_of_ne' ?_⟩
+  obtain ⟨h0, h1⟩ := posSemidef_iff_dotProduct_mulVec.mp <| (posSemidef_gram 𝕜 v)
+  refine posDef_iff_dotProduct_mulVec.mpr ⟨h0, fun x hx ↦ ((h1 x).lt_of_ne' ?_)⟩
   rw [star_dotProduct_gram_mulVec, inner_self_eq_zero.ne]
   exact mt (h_li x) (mt funext hx)
 

--- a/Mathlib/Analysis/InnerProductSpace/GramMatrix.lean
+++ b/Mathlib/Analysis/InnerProductSpace/GramMatrix.lean
@@ -102,7 +102,7 @@ theorem posDef_gram_of_linearIndependent
     {v : n → E} (h_li : LinearIndependent 𝕜 v) : PosDef (gram 𝕜 v) := by
   rw [Fintype.linearIndependent_iff] at h_li
   refine .of_dotProduct_mulVec_pos (isHermitian_gram _ _) fun x hx ↦
-    (posSemidef_gram ..).dotProduct_mulVec_nonneg.lt_of_ne' ?_
+    ((posSemidef_gram ..).dotProduct_mulVec_nonneg _).lt_of_ne' ?_
   rw [star_dotProduct_gram_mulVec, inner_self_eq_zero.ne]
   exact mt (h_li x) (mt funext hx)
 

--- a/Mathlib/Analysis/InnerProductSpace/GramMatrix.lean
+++ b/Mathlib/Analysis/InnerProductSpace/GramMatrix.lean
@@ -101,8 +101,8 @@ variable [NormedAddCommGroup E] [InnerProductSpace 𝕜 E] [Fintype n]
 theorem posDef_gram_of_linearIndependent
     {v : n → E} (h_li : LinearIndependent 𝕜 v) : PosDef (gram 𝕜 v) := by
   rw [Fintype.linearIndependent_iff] at h_li
-  obtain ⟨h0, h1⟩ := posSemidef_iff_dotProduct_mulVec.mp <| (posSemidef_gram 𝕜 v)
-  refine .of_dotProduct_mulVec_pos h0 fun x hx ↦ (h1 x).lt_of_ne' ?_
+  refine .of_dotProduct_mulVec_pos (isHermitian_gram _ _) fun x hx ↦
+    (posSemidef_gram ..).dotProduct_mulVec_nonneg.lt_of_ne' ?_
   rw [star_dotProduct_gram_mulVec, inner_self_eq_zero.ne]
   exact mt (h_li x) (mt funext hx)
 

--- a/Mathlib/Analysis/InnerProductSpace/GramMatrix.lean
+++ b/Mathlib/Analysis/InnerProductSpace/GramMatrix.lean
@@ -80,7 +80,7 @@ variable (𝕜) in
 /-- A Gram matrix is positive semidefinite. -/
 theorem posSemidef_gram (v : n → E) :
     PosSemidef (gram 𝕜 v) := by
-  refine posSemidef_iff_dotProduct_mulVec.mpr ⟨isHermitian_gram _ _, fun x ↦ ?_⟩
+  refine .of_dotProduct_mulVec_nonneg (isHermitian_gram _ _) fun x ↦ ?_
   rw [star_dotProduct_gram_mulVec, le_iff_re_im]
   simp
 
@@ -89,8 +89,7 @@ theorem linearIndependent_of_posDef_gram {v : n → E} (h_gram : PosDef (gram �
     LinearIndependent 𝕜 v := by
   rw [Fintype.linearIndependent_iff]
   intro y hy
-  have h2 := h_gram.dotProduct_mulVec_pos
-  specialize h2 y
+  have := h_gram.dotProduct_mulVec_pos (x := y)
   simp_all [star_dotProduct_gram_mulVec]
 
 end SemiInnerProductSpace
@@ -103,7 +102,7 @@ theorem posDef_gram_of_linearIndependent
     {v : n → E} (h_li : LinearIndependent 𝕜 v) : PosDef (gram 𝕜 v) := by
   rw [Fintype.linearIndependent_iff] at h_li
   obtain ⟨h0, h1⟩ := posSemidef_iff_dotProduct_mulVec.mp <| (posSemidef_gram 𝕜 v)
-  refine posDef_iff_dotProduct_mulVec.mpr ⟨h0, fun x hx ↦ ((h1 x).lt_of_ne' ?_)⟩
+  refine .of_dotProduct_mulVec_pos h0 fun x hx ↦ (h1 x).lt_of_ne' ?_
   rw [star_dotProduct_gram_mulVec, inner_self_eq_zero.ne]
   exact mt (h_li x) (mt funext hx)
 

--- a/Mathlib/Analysis/InnerProductSpace/Positive.lean
+++ b/Mathlib/Analysis/InnerProductSpace/Positive.lean
@@ -190,7 +190,7 @@ open scoped ComplexOrder in
     {A : Matrix n n 𝕜} : A.toEuclideanLin.IsPositive ↔ A.PosSemidef := by
   simp_rw [LinearMap.IsPositive, ← Matrix.isHermitian_iff_isSymmetric, inner_re_symm,
     EuclideanSpace.inner_eq_star_dotProduct, Matrix.piLp_ofLp_toEuclideanLin, Matrix.toLin'_apply,
-    dotProduct_comm (A.mulVec _), Matrix.PosSemidef, and_congr_right_iff,
+    dotProduct_comm (A.mulVec _), Matrix.posSemidef_iff_dotProduct_mulVec, and_congr_right_iff,
     RCLike.nonneg_iff (K := 𝕜)]
   refine fun hA ↦ (EuclideanSpace.equiv n 𝕜).forall_congr' fun x ↦ ?_
   simp [hA.im_star_dotProduct_mulVec_self]

--- a/Mathlib/Analysis/Matrix/Order.lean
+++ b/Mathlib/Analysis/Matrix/Order.lean
@@ -32,7 +32,7 @@ Please `open scoped MatrixOrder` to use this.
 
 @[expose] public section
 
-variable {𝕜 n : Type*} [RCLike 𝕜] [Fintype n]
+variable {𝕜 n : Type*} [RCLike 𝕜]
 
 open scoped ComplexOrder
 open Matrix
@@ -59,12 +59,21 @@ protected alias ⟨LE.le.posSemidef, PosSemidef.nonneg⟩ := nonneg_iff_posSemid
 
 attribute [aesop safe forward (rule_sets := [CStarAlgebra])] PosSemidef.nonneg
 
+private lemma hej {A : Matrix n n 𝕜} (h₁ : A.PosSemidef) (h₂ : (-A).PosSemidef) : A = 0 := by
+  classical
+  ext i j
+  have hdiag i : A i i = 0 :=
+    le_antisymm (by simpa using h₂.diag_nonneg) (by simpa using h₁.diag_nonneg)
+  have h1 := h₁.2 (.single i 1 + .single j (A j i))
+  have h2 := h₂.2 (.single i 1 + .single j (A j i))
+  simp [Finsupp.sum_add_index, mul_add, add_mul,
+      -neg_add_rev, hdiag, ← h₁.1.apply j i, -RCLike.star_def] at *
+  simpa using le_antisymm h2 h1
+
 /-- The partial order on matrices given by `A ≤ B := (B - A).PosSemidef`. -/
 abbrev instPartialOrder : PartialOrder (Matrix n n 𝕜) where
   le_antisymm A B h₁ h₂ := by
-    rw [← sub_eq_zero, ← h₂.trace_eq_zero_iff]
-    have := neg_nonneg.mp <| trace_neg (A - B) ▸ neg_sub A B ▸ h₁.trace_nonneg
-    exact le_antisymm this h₂.trace_nonneg
+    simpa [sub_eq_zero, eq_comm] using hej h₁ (by simpa only [← neg_sub B, le_iff] using h₂)
 
 scoped[MatrixOrder] attribute [instance] Matrix.instPartialOrder
 
@@ -72,6 +81,8 @@ lemma instIsOrderedAddMonoid : IsOrderedAddMonoid (Matrix n n 𝕜) where
   add_le_add_left _ _ _ _ := by rwa [le_iff, add_sub_add_right_eq_sub]
 
 scoped[MatrixOrder] attribute [instance] Matrix.instIsOrderedAddMonoid
+
+variable [Fintype n]
 
 lemma instNonnegSpectrumClass : NonnegSpectrumClass ℝ (Matrix n n 𝕜) where
   quasispectrum_nonneg_of_nonneg A hA := by
@@ -100,6 +111,8 @@ scoped[MatrixOrder] attribute [instance] instStarOrderedRing
 end PartialOrder
 
 open scoped MatrixOrder
+
+variable [Fintype n]
 
 namespace PosSemidef
 
@@ -205,7 +218,7 @@ theorem PosSemidef.commute_iff {A B : Matrix n n 𝕜} (hA : A.PosSemidef) (hB :
 @[grind =]
 theorem PosSemidef.posDef_iff_isUnit [DecidableEq n] {x : Matrix n n 𝕜}
     (hx : x.PosSemidef) : x.PosDef ↔ IsUnit x := by
-  refine ⟨fun h => h.isUnit, fun h => ⟨hx.1, fun v hv => ?_⟩⟩
+  refine ⟨fun h => h.isUnit, fun h => posDef_iff_dotProduct_mulVec.mpr ⟨hx.1, fun v hv => ?_⟩⟩
   obtain ⟨y, rfl⟩ := CStarAlgebra.nonneg_iff_eq_star_mul_self.mp hx.nonneg
   simp_rw [dotProduct_mulVec, ← vecMul_vecMul, star_eq_conjTranspose, ← star_mulVec,
     ← dotProduct_mulVec, dotProduct_star_self_pos_iff]

--- a/Mathlib/Analysis/Matrix/Order.lean
+++ b/Mathlib/Analysis/Matrix/Order.lean
@@ -59,7 +59,8 @@ protected alias ⟨LE.le.posSemidef, PosSemidef.nonneg⟩ := nonneg_iff_posSemid
 
 attribute [aesop safe forward (rule_sets := [CStarAlgebra])] PosSemidef.nonneg
 
-private lemma hej {A : Matrix n n 𝕜} (h₁ : A.PosSemidef) (h₂ : (-A).PosSemidef) : A = 0 := by
+private lemma le_antisymm_aux {A : Matrix n n 𝕜} (h₁ : A.PosSemidef) (h₂ : (-A).PosSemidef) :
+    A = 0 := by
   classical
   ext i j
   have hdiag i : A i i = 0 :=
@@ -73,7 +74,8 @@ private lemma hej {A : Matrix n n 𝕜} (h₁ : A.PosSemidef) (h₂ : (-A).PosSe
 /-- The partial order on matrices given by `A ≤ B := (B - A).PosSemidef`. -/
 abbrev instPartialOrder : PartialOrder (Matrix n n 𝕜) where
   le_antisymm A B h₁ h₂ := by
-    simpa [sub_eq_zero, eq_comm] using hej h₁ (by simpa only [← neg_sub B, le_iff] using h₂)
+    simpa [sub_eq_zero, eq_comm] using le_antisymm_aux h₁
+     (by simpa only [← neg_sub B, le_iff] using h₂)
 
 scoped[MatrixOrder] attribute [instance] Matrix.instPartialOrder
 

--- a/Mathlib/Analysis/Matrix/Order.lean
+++ b/Mathlib/Analysis/Matrix/Order.lean
@@ -218,7 +218,7 @@ theorem PosSemidef.commute_iff {A B : Matrix n n 𝕜} (hA : A.PosSemidef) (hB :
 @[grind =]
 theorem PosSemidef.posDef_iff_isUnit [DecidableEq n] {x : Matrix n n 𝕜}
     (hx : x.PosSemidef) : x.PosDef ↔ IsUnit x := by
-  refine ⟨fun h => h.isUnit, fun h => posDef_iff_dotProduct_mulVec.mpr ⟨hx.1, fun v hv => ?_⟩⟩
+  refine ⟨fun h => h.isUnit, fun h => .of_dotProduct_mulVec_pos hx.1 fun v hv => ?_⟩
   obtain ⟨y, rfl⟩ := CStarAlgebra.nonneg_iff_eq_star_mul_self.mp hx.nonneg
   simp_rw [dotProduct_mulVec, ← vecMul_vecMul, star_eq_conjTranspose, ← star_mulVec,
     ← dotProduct_mulVec, dotProduct_star_self_pos_iff]

--- a/Mathlib/Analysis/Matrix/PosDef.lean
+++ b/Mathlib/Analysis/Matrix/PosDef.lean
@@ -46,7 +46,7 @@ lemma eigenvalues_nonneg [DecidableEq n] (hA : A.PosSemidef) (i : n) : 0 ≤ hA.
   hA.isHermitian.posSemidef_iff_eigenvalues_nonneg.mp hA _
 
 lemma re_dotProduct_nonneg (hA : A.PosSemidef) (x : n → 𝕜) : 0 ≤ RCLike.re (star x ⬝ᵥ (A *ᵥ x)) :=
-  RCLike.nonneg_iff.mp (hA.2 _) |>.1
+  RCLike.nonneg_iff.mp (hA.dotProduct_mulVec_nonneg _) |>.1
 
 lemma det_nonneg [DecidableEq n] (hA : A.PosSemidef) : 0 ≤ A.det := by
   rw [hA.isHermitian.det_eq_prod_eigenvalues]
@@ -79,7 +79,7 @@ lemma IsHermitian.posDef_iff_eigenvalues_pos [DecidableEq n] (hA : A.IsHermitian
 namespace PosDef
 
 lemma re_dotProduct_pos (hA : A.PosDef) {x : n → 𝕜} (hx : x ≠ 0) :
-    0 < RCLike.re (star x ⬝ᵥ (A *ᵥ x)) := RCLike.pos_iff.mp (hA.2 _ hx) |>.1
+    0 < RCLike.re (star x ⬝ᵥ (A *ᵥ x)) := RCLike.pos_iff.mp (hA.dotProduct_mulVec_pos _ hx) |>.1
 
 /-- The eigenvalues of a positive definite matrix are positive. -/
 lemma eigenvalues_pos [DecidableEq n] (hA : A.PosDef) (i : n) : 0 < hA.1.eigenvalues i :=

--- a/Mathlib/Analysis/Matrix/PosDef.lean
+++ b/Mathlib/Analysis/Matrix/PosDef.lean
@@ -79,7 +79,7 @@ lemma IsHermitian.posDef_iff_eigenvalues_pos [DecidableEq n] (hA : A.IsHermitian
 namespace PosDef
 
 lemma re_dotProduct_pos (hA : A.PosDef) {x : n → 𝕜} (hx : x ≠ 0) :
-    0 < RCLike.re (star x ⬝ᵥ (A *ᵥ x)) := RCLike.pos_iff.mp (hA.dotProduct_mulVec_pos _ hx) |>.1
+    0 < RCLike.re (star x ⬝ᵥ (A *ᵥ x)) := RCLike.pos_iff.mp (hA.dotProduct_mulVec_pos hx) |>.1
 
 /-- The eigenvalues of a positive definite matrix are positive. -/
 lemma eigenvalues_pos [DecidableEq n] (hA : A.PosDef) (i : n) : 0 < hA.1.eigenvalues i :=

--- a/Mathlib/Combinatorics/SimpleGraph/LapMatrix.lean
+++ b/Mathlib/Combinatorics/SimpleGraph/LapMatrix.lean
@@ -96,8 +96,7 @@ theorem lapMatrix_toLinearMap₂' [Field R] [CharZero R] (x : V → R) :
 /-- The Laplacian matrix is positive semidefinite -/
 theorem posSemidef_lapMatrix [Field R] [LinearOrder R] [IsStrictOrderedRing R] [StarRing R]
     [TrivialStar R] : PosSemidef (G.lapMatrix R) := by
-  refine posSemidef_iff_dotProduct_mulVec.mpr ?_
-  constructor
+  refine .of_dotProduct_mulVec_nonneg ?_ ?_
   · rw [IsHermitian, conjTranspose_eq_transpose_of_trivial, isSymm_lapMatrix]
   · intro x
     rw [star_trivial, ← toLinearMap₂'_apply', lapMatrix_toLinearMap₂']

--- a/Mathlib/Combinatorics/SimpleGraph/LapMatrix.lean
+++ b/Mathlib/Combinatorics/SimpleGraph/LapMatrix.lean
@@ -96,6 +96,7 @@ theorem lapMatrix_toLinearMap₂' [Field R] [CharZero R] (x : V → R) :
 /-- The Laplacian matrix is positive semidefinite -/
 theorem posSemidef_lapMatrix [Field R] [LinearOrder R] [IsStrictOrderedRing R] [StarRing R]
     [TrivialStar R] : PosSemidef (G.lapMatrix R) := by
+  refine posSemidef_iff_dotProduct_mulVec.mpr ?_
   constructor
   · rw [IsHermitian, conjTranspose_eq_transpose_of_trivial, isSymm_lapMatrix]
   · intro x

--- a/Mathlib/Combinatorics/SimpleGraph/LapMatrix.lean
+++ b/Mathlib/Combinatorics/SimpleGraph/LapMatrix.lean
@@ -96,10 +96,9 @@ theorem lapMatrix_toLinearMap₂' [Field R] [CharZero R] (x : V → R) :
 /-- The Laplacian matrix is positive semidefinite -/
 theorem posSemidef_lapMatrix [Field R] [LinearOrder R] [IsStrictOrderedRing R] [StarRing R]
     [TrivialStar R] : PosSemidef (G.lapMatrix R) := by
-  refine .of_dotProduct_mulVec_nonneg ?_ ?_
+  refine .of_dotProduct_mulVec_nonneg ?_ (fun x ↦ ?_)
   · rw [IsHermitian, conjTranspose_eq_transpose_of_trivial, isSymm_lapMatrix]
-  · intro x
-    rw [star_trivial, ← toLinearMap₂'_apply', lapMatrix_toLinearMap₂']
+  · rw [star_trivial, ← toLinearMap₂'_apply', lapMatrix_toLinearMap₂']
     positivity
 
 theorem lapMatrix_toLinearMap₂'_apply'_eq_zero_iff_forall_adj

--- a/Mathlib/Data/Finsupp/Defs.lean
+++ b/Mathlib/Data/Finsupp/Defs.lean
@@ -168,6 +168,7 @@ theorem ext_iff' {f g : α →₀ M} : f = g ↔ f.support = g.support ∧ ∀ x
 theorem support_eq_empty {f : α →₀ M} : f.support = ∅ ↔ f = 0 :=
   mod_cast @Function.support_eq_empty_iff _ _ _ f
 
+@[simp]
 theorem support_nonempty_iff {f : α →₀ M} : f.support.Nonempty ↔ f ≠ 0 := by
   contrapose!; exact support_eq_empty
 

--- a/Mathlib/Data/Finsupp/Defs.lean
+++ b/Mathlib/Data/Finsupp/Defs.lean
@@ -312,6 +312,11 @@ theorem mapRange_zero {f : M → N} {hf : f 0 = 0} : mapRange f hf (0 : α →�
   ext fun _ => by simp only [hf, zero_apply, mapRange_apply]
 
 @[simp]
+theorem mapRange_eq_zero {a : α →₀ M} {f : M → N} (hf : Function.Injective f)
+    (h : f 0 = 0) : mapRange f h a = 0 ↔ a = 0 := by
+  simp [Finsupp.ext_iff, ← h, hf.eq_iff]
+
+@[simp]
 theorem mapRange_id (g : α →₀ M) : mapRange id rfl g = g :=
   ext fun _ => rfl
 

--- a/Mathlib/Data/Finsupp/Defs.lean
+++ b/Mathlib/Data/Finsupp/Defs.lean
@@ -313,8 +313,8 @@ theorem mapRange_zero {f : M → N} {hf : f 0 = 0} : mapRange f hf (0 : α →�
   ext fun _ => by simp only [hf, zero_apply, mapRange_apply]
 
 @[simp]
-theorem mapRange_eq_zero {a : α →₀ M} {f : M → N} (hf : Function.Injective f)
-    (h : f 0 = 0) : mapRange f h a = 0 ↔ a = 0 := by
+theorem mapRange_eq_zero {a : α →₀ M} {f : M → N} (hf : f.Injective) (h) :
+    mapRange f h a = 0 ↔ a = 0 := by
   simp [Finsupp.ext_iff, ← h, hf.eq_iff]
 
 @[simp]

--- a/Mathlib/Data/Finsupp/Order.lean
+++ b/Mathlib/Data/Finsupp/Order.lean
@@ -59,13 +59,13 @@ end OrderedAddCommMonoid
 section IsOrderedCancelAddMonoid
 
 variable [AddCommMonoid β] [PartialOrder β] [IsOrderedCancelAddMonoid β]
-variable {f : ι →₀ α} {h₁ : ι → α → β}
+variable {f : ι →₀ α} {g : ι → α → β}
 
-theorem sum_pos (h : ∀ i ∈ f.support, 0 < h₁ i (f i)) (hs : f.support.Nonempty) :
-    0 < f.sum h₁ := Finset.sum_pos h hs
+theorem sum_pos (h : ∀ i ∈ f.support, 0 < g i (f i)) (hf : f ≠ 0) : 0 < f.sum g :=
+  Finset.sum_pos h (by simpa)
 
-theorem sum_pos' (h : ∀ i ∈ f.support, 0 ≤ h₁ i (f i))
-    (hs : ∃ i ∈ f.support, 0 < h₁ i (f i)) : 0 < f.sum h₁ := Finset.sum_pos' h hs
+theorem sum_pos' (h : ∀ i ∈ f.support, 0 ≤ g i (f i)) (hf : ∃ i ∈ f.support, 0 < g i (f i)) :
+    0 < f.sum g := Finset.sum_pos' h hf
 
 end IsOrderedCancelAddMonoid
 

--- a/Mathlib/Data/Finsupp/Order.lean
+++ b/Mathlib/Data/Finsupp/Order.lean
@@ -56,6 +56,19 @@ theorem sum_nonpos (h : ∀ i ∈ f.support, h₁ i (f i) ≤ 0) : f.sum h₁ �
 
 end OrderedAddCommMonoid
 
+section IsOrderedCancelAddMonoid
+
+variable [AddCommMonoid β] [PartialOrder β] [IsOrderedCancelAddMonoid β]
+variable {f : ι →₀ α} {h₁ : ι → α → β}
+
+theorem sum_pos (h : ∀ i ∈ f.support, 0 < h₁ i (f i)) (hs : f.support.Nonempty) :
+    0 < f.sum h₁ := Finset.sum_pos h hs
+
+theorem sum_pos' (h : ∀ i ∈ f.support, 0 ≤ h₁ i (f i))
+    (hs : ∃ i ∈ f.support, 0 < h₁ i (f i)) : 0 < f.sum h₁ := Finset.sum_pos' h hs
+
+end IsOrderedCancelAddMonoid
+
 section Preorder
 variable [Preorder α] {f g : ι →₀ α} {i : ι} {a b : α}
 

--- a/Mathlib/Data/Matrix/Diagonal.lean
+++ b/Mathlib/Data/Matrix/Diagonal.lean
@@ -11,6 +11,8 @@ public import Mathlib.Data.Nat.Cast.Basic
 public import Mathlib.LinearAlgebra.Matrix.Defs
 public import Mathlib.Logic.Embedding.Basic
 
+import Mathlib.Data.Int.Cast.Lemmas
+
 /-!
 # Diagonal matrices
 
@@ -172,6 +174,10 @@ protected theorem map_intCast [AddGroupWithOne α] [Zero β]
     {f : α → β} (h : f 0 = 0) (d : ℤ) :
     (d : Matrix n n α).map f = diagonal (fun _ => f d) :=
   diagonal_map h
+
+theorem intCast_apply [AddGroupWithOne α] {i j} {d : ℤ} :
+    (d : Matrix n n α) i j = if i = j then d else 0 := by
+  rw [Int.cast_ite, Int.cast_zero, ← diagonal_intCast, diagonal_apply]
 
 theorem diagonal_unique [Unique m] [DecidableEq m] [Zero α] (d : m → α) :
     diagonal d = of fun _ _ => d default := by

--- a/Mathlib/LinearAlgebra/Matrix/PosDef.lean
+++ b/Mathlib/LinearAlgebra/Matrix/PosDef.lean
@@ -280,7 +280,7 @@ lemma diag_pos [Nontrivial R] {A : Matrix n n R} (hA : A.PosDef) {i : n} : 0 < A
 end PosDef
 
 /-!
-## Finite Positive semidefinite matrices
+## Finite positive semidefinite matrices
 -/
 
 variable [Fintype n] [Fintype m]

--- a/Mathlib/LinearAlgebra/Matrix/PosDef.lean
+++ b/Mathlib/LinearAlgebra/Matrix/PosDef.lean
@@ -196,25 +196,14 @@ theorem _root_.Matrix.posDef_diagonal_iff
     [StarOrderedRing R] [DecidableEq n] [NoZeroDivisors R] [Nontrivial R] {d : n → R} :
     PosDef (diagonal d) ↔ ∀ i, 0 < d i := ⟨fun h i => by simpa using h.2 (.single i 1), .diagonal⟩
 
-protected theorem one [StarOrderedRing R] [DecidableEq n] [NoZeroDivisors R] :
-    PosDef (1 : Matrix n n R) := ⟨isHermitian_one, fun x hx ↦ by
-    refine Finsupp.sum_pos' (fun _ _ ↦ Finsupp.sum_nonneg fun _ _ ↦ ?_) ?_
-    · simp +contextual [Matrix.one_apply,apply_ite]
-    · have : ∃i ∈ x.support, x i ≠ 0 := by
-        contrapose! hx
-        ext i
-        by_cases hi : i ∈ x.support <;> simp[hx i _, Finsupp.notMem_support_iff.mp _, *]
-      obtain ⟨i,hi,hxi⟩ := this
-      refine ⟨i, hi, Finsupp.sum_pos' (fun _ _ ↦ ?_) ⟨i, hi, ?_⟩⟩ <;> simp +contextual only [one_apply_eq,
-        mul_one]
-      have : Nontrivial R := by
-        exact nontrivial_of_ne (x i) 0 hxi
-      have := isRegular_of_ne_zero hxi
-      exact star_mul_self_pos (isRegular_of_ne_zero hxi)⟩
-
 @[simp, nontriviality]
-theorem of_Subsingelton (h : Subsingleton R) (M : Matrix n n R) : M.PosDef :=
+theorem of_subsingleton (h : Subsingleton R) (M : Matrix n n R) : M.PosDef :=
   ⟨.of_subsingleton, fun _ hx ↦ (hx <| Subsingleton.elim ..).elim⟩
+
+protected theorem one [StarOrderedRing R] [DecidableEq n] [NoZeroDivisors R] :
+    PosDef (1 : Matrix n n R) := by
+  nontriviality R
+  exact .diagonal fun i ↦ zero_lt_one' R
 
 protected theorem natCast [StarOrderedRing R] [DecidableEq n] [NoZeroDivisors R]
     (d : ℕ) (hd : d ≠ 0) :

--- a/Mathlib/LinearAlgebra/Matrix/PosDef.lean
+++ b/Mathlib/LinearAlgebra/Matrix/PosDef.lean
@@ -46,7 +46,6 @@ open Matrix
 namespace Matrix
 
 variable {m n R R' : Type*}
-variable [Fintype m] [Fintype n]
 variable [Ring R] [PartialOrder R] [StarRing R]
 variable [CommRing R'] [PartialOrder R'] [StarRing R']
 
@@ -55,56 +54,42 @@ variable [CommRing R'] [PartialOrder R'] [StarRing R']
 -/
 
 /-- A matrix `M : Matrix n n R` is positive semidefinite if it is Hermitian and `xᴴ * M * x` is
-nonnegative for all `x`. -/
-def PosSemidef (M : Matrix n n R) :=
-  M.IsHermitian ∧ ∀ x : n → R, 0 ≤ star x ⬝ᵥ (M *ᵥ x)
+nonnegative for all `x` of finite support. -/
+def PosSemidef (M : Matrix n n R) : Prop :=
+  M.IsHermitian ∧ ∀ x : n →₀ R, 0 ≤ x.sum fun i xi ↦ x.sum fun j xj ↦ star xi * M i j * xj
 
 protected theorem PosSemidef.diagonal [StarOrderedRing R] [DecidableEq n] {d : n → R} (h : 0 ≤ d) :
-    PosSemidef (diagonal d) :=
-  ⟨isHermitian_diagonal_of_self_adjoint _ <| funext fun i => IsSelfAdjoint.of_nonneg (h i),
-    fun x => by
-      refine Fintype.sum_nonneg fun i => ?_
-      simpa only [mulVec_diagonal, ← mul_assoc] using star_left_conjugate_nonneg (h i) _⟩
+    PosSemidef (diagonal d) where
+  left := isHermitian_diagonal_of_self_adjoint _ <| funext fun i => IsSelfAdjoint.of_nonneg (h i)
+  right x := by
+    -- TODO: positivity
+    refine Finsupp.sum_nonneg fun i _ ↦ Finsupp.sum_nonneg fun j _ ↦ ?_
+    simp +contextual [diagonal, apply_ite, star_left_conjugate_nonneg (h _)]
 
 /-- A diagonal matrix is positive semidefinite iff its diagonal entries are nonnegative. -/
-lemma posSemidef_diagonal_iff [StarOrderedRing R] [DecidableEq n] {d : n → R} :
-    PosSemidef (diagonal d) ↔ (∀ i : n, 0 ≤ d i) :=
-  ⟨fun ⟨_, hP⟩ i ↦ by simpa using hP (Pi.single i 1), .diagonal⟩
+@[simp] lemma posSemidef_diagonal_iff [StarOrderedRing R] [DecidableEq n] {d : n → R} :
+    PosSemidef (diagonal d) ↔ ∀ i, 0 ≤ d i :=
+  ⟨fun ⟨_, hP⟩ i ↦ by simpa using hP (.single i 1), .diagonal⟩
 
 namespace PosSemidef
 
 theorem isHermitian {M : Matrix n n R} (hM : M.PosSemidef) : M.IsHermitian :=
   hM.1
 
-lemma conjTranspose_mul_mul_same {A : Matrix n n R} (hA : PosSemidef A)
-    {m : Type*} [Fintype m] (B : Matrix n m R) :
-    PosSemidef (Bᴴ * A * B) := by
-  constructor
-  · exact isHermitian_conjTranspose_mul_mul B hA.1
-  · intro x
-    simpa only [star_mulVec, dotProduct_mulVec, vecMul_vecMul] using hA.2 (B *ᵥ x)
-
-lemma mul_mul_conjTranspose_same {A : Matrix n n R} (hA : PosSemidef A)
-    {m : Type*} [Fintype m] (B : Matrix m n R) :
-    PosSemidef (B * A * Bᴴ) := by
-  simpa only [conjTranspose_conjTranspose] using hA.conjTranspose_mul_mul_same Bᴴ
-
 theorem submatrix {M : Matrix n n R} (hM : M.PosSemidef) (e : m → n) :
     (M.submatrix e e).PosSemidef := by
-  classical
-  rw [(by simp : M = 1 * M * 1), submatrix_mul (he₂ := Function.bijective_id),
-    submatrix_mul (he₂ := Function.bijective_id), submatrix_id_id]
-  simpa only [conjTranspose_submatrix, conjTranspose_one] using
-    conjTranspose_mul_mul_same hM (Matrix.submatrix 1 id e)
+  refine ⟨hM.1.submatrix _, fun x ↦ ?_⟩
+  simpa [Finsupp.sum_mapDomain_index, add_mul, mul_add] using hM.2 <| x.mapDomain e
 
 theorem transpose {M : Matrix n n R'} (hM : M.PosSemidef) : Mᵀ.PosSemidef := by
-  refine ⟨IsHermitian.transpose hM.1, fun x => ?_⟩
-  convert hM.2 (star x) using 1
-  rw [mulVec_transpose, dotProduct_mulVec, star_star, dotProduct_comm]
+  have (a b c : R') : a * b * c = c * b * a := by ring
+  refine ⟨hM.1.transpose, fun x => ?_⟩
+  rw [Finsupp.sum_comm]
+  simpa [Finsupp.sum_mapRange_index, this] using hM.2 (Finsupp.mapRange star (star_zero R') x)
 
 @[simp]
 theorem _root_.Matrix.posSemidef_transpose_iff {M : Matrix n n R'} : Mᵀ.PosSemidef ↔ M.PosSemidef :=
-  ⟨(by simpa using ·.transpose), .transpose⟩
+  ⟨.transpose, .transpose⟩
 
 theorem conjTranspose {M : Matrix n n R} (hM : M.PosSemidef) : Mᴴ.PosSemidef := hM.1.symm ▸ hM
 
@@ -113,18 +98,27 @@ theorem _root_.Matrix.posSemidef_conjTranspose_iff {M : Matrix n n R} :
     Mᴴ.PosSemidef ↔ M.PosSemidef :=
   ⟨(by simpa using ·.conjTranspose), .conjTranspose⟩
 
-protected lemma zero : PosSemidef (0 : Matrix n n R) :=
-  ⟨isHermitian_zero, by simp⟩
+protected lemma add [AddLeftMono R] {A : Matrix m m R} {B : Matrix m m R}
+    (hA : A.PosSemidef) (hB : B.PosSemidef) : (A + B).PosSemidef :=
+  ⟨hA.isHermitian.add hB.isHermitian, fun x => by
+    simpa [mul_add, add_mul] using add_nonneg (hA.2 x) (hB.2 x)⟩
+
+protected theorem smul {α : Type*} [CommSemiring α] [PartialOrder α] [StarRing α]
+    [StarOrderedRing α] [Algebra α R] [StarModule α R] [PosSMulMono α R] {x : Matrix n n R}
+    (hx : x.PosSemidef) {a : α} (ha : 0 ≤ a) : (a • x).PosSemidef := by
+  refine ⟨IsSelfAdjoint.smul (.of_nonneg ha) hx.1, fun y => ?_⟩
+  simpa [mul_smul_comm, smul_mul_assoc, ← Finsupp.smul_sum] using smul_nonneg ha (hx.2 _)
+
+protected lemma zero : PosSemidef (0 : Matrix n n R) := ⟨isHermitian_zero, by simp⟩
 
 protected lemma one [StarOrderedRing R] [DecidableEq n] : PosSemidef (1 : Matrix n n R) :=
-  ⟨isHermitian_one, fun x => by
-    rw [one_mulVec]; exact Fintype.sum_nonneg fun i => star_mul_self_nonneg _⟩
+  ⟨isHermitian_one, fun x => Finsupp.sum_nonneg fun i _ ↦ Finsupp.sum_nonneg fun j _ ↦ by
+    obtain rfl | hij := eq_or_ne i j <;> simp [*]⟩
 
 protected theorem natCast [StarOrderedRing R] [DecidableEq n] (d : ℕ) :
     PosSemidef (d : Matrix n n R) :=
-  ⟨isHermitian_natCast _, fun x => by
-    rw [natCast_mulVec, Nat.cast_smul_eq_nsmul, dotProduct_smul]
-    exact nsmul_nonneg (dotProduct_star_self_nonneg _) _⟩
+  ⟨isHermitian_natCast _, fun x => Finsupp.sum_nonneg fun i _ ↦ Finsupp.sum_nonneg fun j _ ↦ by
+    obtain rfl | hij := eq_or_ne i j <;> simp [← diagonal_natCast', star_left_conjugate_nonneg, *]⟩
 
 protected theorem ofNat [StarOrderedRing R] [DecidableEq n] (d : ℕ) [d.AtLeastTwo] :
     PosSemidef (ofNat(d) : Matrix n n R) :=
@@ -132,15 +126,198 @@ protected theorem ofNat [StarOrderedRing R] [DecidableEq n] (d : ℕ) [d.AtLeast
 
 protected theorem intCast [StarOrderedRing R] [DecidableEq n] (d : ℤ) (hd : 0 ≤ d) :
     PosSemidef (d : Matrix n n R) :=
-  ⟨isHermitian_intCast _, fun x => by
-    rw [intCast_mulVec, Int.cast_smul_eq_zsmul, dotProduct_smul]
-    exact zsmul_nonneg (dotProduct_star_self_nonneg _) hd⟩
+  ⟨isHermitian_intCast _, fun x => Finsupp.sum_nonneg fun i _ ↦ Finsupp.sum_nonneg fun j _ ↦ by
+    obtain rfl | hij := eq_or_ne i j <;> simp [← diagonal_intCast', star_left_conjugate_nonneg, *]⟩
 
 @[simp]
 protected theorem _root_.Matrix.posSemidef_intCast_iff
     [StarOrderedRing R] [DecidableEq n] [Nonempty n] [Nontrivial R] (d : ℤ) :
-    PosSemidef (d : Matrix n n R) ↔ 0 ≤ d :=
-  posSemidef_diagonal_iff.trans <| by simp
+    PosSemidef (d : Matrix n n R) ↔ 0 ≤ d := by simp [← diagonal_intCast']
+
+lemma diag_nonneg {A : Matrix n n R} (hA : A.PosSemidef) {i : n} : 0 ≤ A i i := by
+  simpa using hA.2 <| .single i 1
+
+end PosSemidef
+
+@[simp]
+theorem posSemidef_submatrix_equiv {M : Matrix n n R} (e : m ≃ n) :
+    (M.submatrix e e).PosSemidef ↔ M.PosSemidef :=
+  ⟨fun h => by simpa using h.submatrix e.symm, fun h => h.submatrix _⟩
+
+theorem posSemidef_sum {ι : Type*} [AddLeftMono R]
+    {x : ι → Matrix n n R} (s : Finset ι) (h : ∀ i ∈ s, PosSemidef (x i)) :
+    PosSemidef (∑ i ∈ s, x i) := by
+  refine ⟨isSelfAdjoint_sum s fun _ hi => h _ hi |>.1, fun y => ?_⟩
+  simp[sum_apply, Finset.mul_sum,Finset.sum_mul, Finsupp.sum_finsetSum_comm,
+    Finset.sum_nonneg fun _ hi => (h _ hi).2 _]
+
+/-!
+## Positive definite matrices
+-/
+
+/-- A matrix `M : Matrix n n R` is positive definite if it is Hermitian
+and `xᴴMx` is greater than zero for all nonzero `x`. -/
+def PosDef (M : Matrix n n R) :=
+  M.IsHermitian ∧ ∀ x : n →₀ R, x ≠ 0 → 0 < x.sum fun i xi ↦ x.sum fun j xj ↦ star xi * M i j * xj
+
+namespace PosDef
+
+theorem isHermitian {M : Matrix n n R} (hM : M.PosDef) : M.IsHermitian :=
+  hM.1
+
+theorem posSemidef {M : Matrix n n R} (hM : M.PosDef) : M.PosSemidef :=
+  ⟨hM.1, fun x ↦ by obtain rfl | hx := eq_or_ne x 0 <;> simp [le_of_lt, hM.2, *]⟩
+
+theorem transpose {M : Matrix n n R'} (hM : M.PosDef) : Mᵀ.PosDef := by
+  have (a b c : R') : a * b * c = c * b * a := by ring
+  refine ⟨hM.1.transpose, fun x => ?_⟩
+  rw [Finsupp.sum_comm]
+  simpa [star_injective, Finsupp.sum_mapRange_index, this] using
+      hM.2 (Finsupp.mapRange star (star_zero R') x)
+
+@[simp]
+theorem transpose_iff {M : Matrix n n R'} : Mᵀ.PosDef ↔ M.PosDef :=
+  ⟨(by simpa using ·.transpose), .transpose⟩
+
+protected theorem diagonal [StarOrderedRing R] [DecidableEq n] [NoZeroDivisors R]
+    {d : n → R} (h : ∀ i, 0 < d i) :
+    PosDef (diagonal d) where
+  left := isHermitian_diagonal_of_self_adjoint _ <| funext fun i => IsSelfAdjoint.of_nonneg (h i).le
+  right x hx := by
+    refine Finsupp.sum_pos' (fun _ _ ↦ Finsupp.sum_nonneg ?_) ?_
+    · simp +contextual [diagonal, apply_ite,star_left_conjugate_nonneg (le_of_lt (h _))]
+    obtain ⟨i,hxi⟩ := by simpa [Finsupp.ext_iff] using hx
+    refine ⟨i, ?_, Finsupp.sum_pos' ?_ ⟨i, ?_, ?_⟩⟩ <;> simp +contextual [diagonal,
+      apply_ite,star_left_conjugate_nonneg (le_of_lt (h _)),
+      star_left_conjugate_pos (h i),isRegular_of_ne_zero hxi, Finsupp.mem_support_iff.mpr hxi]
+
+@[simp]
+theorem _root_.Matrix.posDef_diagonal_iff
+    [StarOrderedRing R] [DecidableEq n] [NoZeroDivisors R] [Nontrivial R] {d : n → R} :
+    PosDef (diagonal d) ↔ ∀ i, 0 < d i := ⟨fun h i => by simpa using h.2 (.single i 1), .diagonal⟩
+
+protected theorem one [StarOrderedRing R] [DecidableEq n] [NoZeroDivisors R] :
+    PosDef (1 : Matrix n n R) := ⟨isHermitian_one, fun x hx ↦ by
+    refine Finsupp.sum_pos' (fun _ _ ↦ Finsupp.sum_nonneg fun _ _ ↦ ?_) ?_
+    · simp +contextual [Matrix.one_apply,apply_ite]
+    · have : ∃i ∈ x.support, x i ≠ 0 := by
+        contrapose! hx
+        ext i
+        by_cases hi : i ∈ x.support <;> simp[hx i _, Finsupp.notMem_support_iff.mp _, *]
+      obtain ⟨i,hi,hxi⟩ := this
+      refine ⟨i, hi, Finsupp.sum_pos' (fun _ _ ↦ ?_) ⟨i, hi, ?_⟩⟩ <;> simp +contextual only [one_apply_eq,
+        mul_one]
+      have : Nontrivial R := by
+        exact nontrivial_of_ne (x i) 0 hxi
+      have := isRegular_of_ne_zero hxi
+      exact star_mul_self_pos (isRegular_of_ne_zero hxi)⟩
+
+@[simp, nontriviality]
+theorem of_Subsingelton (h : Subsingleton R) (M : Matrix n n R) : M.PosDef :=
+  ⟨.of_subsingleton, fun _ hx ↦ (hx <| Subsingleton.elim ..).elim⟩
+
+protected theorem natCast [StarOrderedRing R] [DecidableEq n] [NoZeroDivisors R]
+    (d : ℕ) (hd : d ≠ 0) :
+    PosDef (d : Matrix n n R) := by
+  nontriviality R
+  exact .diagonal fun _ ↦ by simpa [pos_iff_ne_zero]
+
+@[simp]
+theorem _root_.Matrix.posDef_natCast_iff [StarOrderedRing R] [DecidableEq n] [NoZeroDivisors R]
+    [Nonempty n] [Nontrivial R] {d : ℕ} :
+    PosDef (d : Matrix n n R) ↔ 0 < d :=
+  posDef_diagonal_iff.trans <| by simp
+
+protected theorem ofNat [StarOrderedRing R] [DecidableEq n] [NoZeroDivisors R]
+    (d : ℕ) [d.AtLeastTwo] :
+    PosDef (ofNat(d) : Matrix n n R) :=
+  .natCast d (NeZero.ne _)
+
+protected theorem intCast [StarOrderedRing R] [DecidableEq n] [NoZeroDivisors R]
+    (d : ℤ) (hd : 0 < d) :
+    PosDef (d : Matrix n n R) := by
+  nontriviality R
+  exact .diagonal fun _ ↦ by simpa [pos_iff_ne_zero]
+
+@[simp]
+theorem _root_.Matrix.posDef_intCast_iff [StarOrderedRing R] [DecidableEq n] [NoZeroDivisors R]
+    [Nonempty n] [Nontrivial R] {d : ℤ} :
+    PosDef (d : Matrix n n R) ↔ 0 < d :=
+  posDef_diagonal_iff.trans <| by simp
+
+protected lemma add_posSemidef [AddLeftMono R]
+    {A : Matrix m m R} {B : Matrix m m R}
+    (hA : A.PosDef) (hB : B.PosSemidef) : (A + B).PosDef :=
+  ⟨hA.isHermitian.add hB.isHermitian, fun x hx => by
+    simpa [mul_add,add_mul] using add_pos_of_pos_of_nonneg (hA.2 x hx) (hB.2 x)⟩
+
+protected lemma posSemidef_add [AddLeftMono R]
+    {A : Matrix m m R} {B : Matrix m m R}
+    (hA : A.PosSemidef) (hB : B.PosDef) : (A + B).PosDef :=
+  add_comm A B ▸ hB.add_posSemidef hA
+
+protected lemma add [AddLeftMono R] {A : Matrix m m R} {B : Matrix m m R}
+    (hA : A.PosDef) (hB : B.PosDef) : (A + B).PosDef :=
+  hA.add_posSemidef hB.posSemidef
+
+theorem _root_.Matrix.posDef_sum {ι : Type*} [AddLeftMono R] {A : ι → Matrix m m R}
+    {s : Finset ι} (hs : s.Nonempty) (hA : ∀ i ∈ s, (A i).PosDef) : (∑ i ∈ s, A i).PosDef := by
+  classical
+  induction s using Finset.induction_on with
+  | empty => simp at hs
+  | insert i hi hins H =>
+      rw [Finset.sum_insert hins]
+      by_cases h : ¬ hi.Nonempty
+      · simp_all
+      · exact PosDef.add (hA _ <| Finset.mem_insert_self i hi) <|
+          H (not_not.mp h) fun _ _hi => hA _ (Finset.mem_insert_of_mem _hi)
+
+protected theorem smul {α : Type*} [CommSemiring α] [PartialOrder α] [StarRing α]
+    [StarOrderedRing α] [Algebra α R] [StarModule α R] [PosSMulStrictMono α R]
+    {x : Matrix n n R} (hx : x.PosDef) {a : α} (ha : 0 < a) : (a • x).PosDef := by
+  refine ⟨IsSelfAdjoint.smul (IsSelfAdjoint.of_nonneg ha.le) hx.1, fun y hy => ?_⟩
+  simpa [← Finsupp.smul_sum] using smul_pos ha (hx.2 _ hy)
+
+theorem conjTranspose {M : Matrix n n R} (hM : M.PosDef) : Mᴴ.PosDef := hM.1.symm ▸ hM
+
+@[simp]
+theorem _root_.Matrix.posDef_conjTranspose_iff {M : Matrix n n R} : Mᴴ.PosDef ↔ M.PosDef :=
+  ⟨(by simpa using ·.conjTranspose), .conjTranspose⟩
+
+lemma diag_pos [Nontrivial R] {A : Matrix n n R} (hA : A.PosDef) {i : n} : 0 < A i i := by
+  classical simpa [trace] using hA.2 <| .single i 1
+
+
+end PosDef
+
+
+/-!
+## Finite Positive semidefinite matrices
+-/
+
+variable [Fintype n] [Fintype m]
+
+namespace PosSemidef
+
+/-- A finite matrix `M : Matrix n n R` is positive semidefinite iff it is
+Hermitian and `xᴴ * M * x` is nonnegative for all `x`. -/
+theorem iff_mulVec {M : Matrix n n R} :
+    M.PosSemidef ↔ M.IsHermitian ∧ ∀ x : n → R, 0 ≤ star x ⬝ᵥ (M *ᵥ x) := by
+  simp [PosSemidef, ← Finsupp.equivFunOnFinite.forall_congr_right, dotProduct, mulVec,
+    Finsupp.sum_fintype, Finset.mul_sum, mul_assoc]
+
+@[simp]
+theorem dotProduct_nonneg {M : Matrix n n R} (hM : M.PosSemidef) :
+    ∀ x : n → R, 0 ≤ star x ⬝ᵥ (M *ᵥ x) := (iff_mulVec.mp hM).2
+
+lemma conjTranspose_mul_mul_same {A : Matrix n n R} (hA : PosSemidef A) (B : Matrix n m R) :
+    PosSemidef (Bᴴ * A * B) := by
+  refine iff_mulVec.mpr ⟨isHermitian_conjTranspose_mul_mul B hA.1, fun x ↦ ?_⟩
+  simpa only [star_mulVec, dotProduct_mulVec, vecMul_vecMul] using hA.dotProduct_nonneg (B *ᵥ x)
+
+lemma mul_mul_conjTranspose_same {A : Matrix n n R} (hA : PosSemidef A) (B : Matrix m n R) :
+    PosSemidef (B * A * Bᴴ) := by
+  simpa only [conjTranspose_conjTranspose] using hA.conjTranspose_mul_mul_same Bᴴ
 
 protected lemma pow [StarOrderedRing R] [DecidableEq n]
     {M : Matrix n n R} (hM : M.PosSemidef) (k : ℕ) :
@@ -166,36 +343,18 @@ protected lemma zpow [StarOrderedRing R'] [DecidableEq n]
   · simpa using hM.pow n
   · simpa using (hM.pow n).inv
 
-protected lemma add [AddLeftMono R] {A : Matrix m m R} {B : Matrix m m R}
-    (hA : A.PosSemidef) (hB : B.PosSemidef) : (A + B).PosSemidef :=
-  ⟨hA.isHermitian.add hB.isHermitian, fun x => by
-    rw [add_mulVec, dotProduct_add]
-    exact add_nonneg (hA.2 x) (hB.2 x)⟩
 
-protected theorem smul {α : Type*} [CommSemiring α] [PartialOrder α] [StarRing α]
-    [StarOrderedRing α] [Algebra α R] [StarModule α R] [PosSMulMono α R] {x : Matrix n n R}
-    (hx : x.PosSemidef) {a : α} (ha : 0 ≤ a) : (a • x).PosSemidef := by
-  refine ⟨IsSelfAdjoint.smul (IsSelfAdjoint.of_nonneg ha) hx.1, fun y => ?_⟩
-  simp only [smul_mulVec, dotProduct_smul]
-  exact smul_nonneg ha (hx.2 _)
-
-lemma diag_nonneg {A : Matrix n n R} (hA : A.PosSemidef) {i : n} : 0 ≤ A i i := by
-  classical simpa [trace] using hA.2 <| Pi.single i 1
 
 lemma trace_nonneg [AddLeftMono R] {A : Matrix n n R} (hA : A.PosSemidef) : 0 ≤ A.trace :=
   Fintype.sum_nonneg fun _ ↦ hA.diag_nonneg
 
 end PosSemidef
 
-@[simp]
-theorem posSemidef_submatrix_equiv {M : Matrix n n R} (e : m ≃ n) :
-    (M.submatrix e e).PosSemidef ↔ M.PosSemidef :=
-  ⟨fun h => by simpa using h.submatrix e.symm, fun h => h.submatrix _⟩
-
 /-- The conjugate transpose of a matrix multiplied by the matrix is positive semidefinite -/
-theorem posSemidef_conjTranspose_mul_self [StarOrderedRing R] (A : Matrix m n R) :
+theorem posSemidef_conjTranspose_mul_self [StarOrderedRing R]
+    (A : Matrix m n R) :
     PosSemidef (Aᴴ * A) := by
-  refine ⟨isHermitian_conjTranspose_mul_self _, fun x => ?_⟩
+  refine PosSemidef.iff_mulVec.mpr ⟨isHermitian_conjTranspose_mul_self _, fun x => ?_⟩
   rw [← mulVec_mulVec, dotProduct_mulVec, vecMul_conjTranspose, star_star]
   exact Finset.sum_nonneg fun i _ => star_mul_self_nonneg _
 
@@ -204,11 +363,7 @@ theorem posSemidef_self_mul_conjTranspose [StarOrderedRing R] (A : Matrix m n R)
     PosSemidef (A * Aᴴ) := by
   simpa only [conjTranspose_conjTranspose] using posSemidef_conjTranspose_mul_self Aᴴ
 
-theorem posSemidef_sum {ι : Type*} [AddLeftMono R]
-    {x : ι → Matrix n n R} (s : Finset ι) (h : ∀ i ∈ s, PosSemidef (x i)) :
-    PosSemidef (∑ i ∈ s, x i) := by
-  refine ⟨isSelfAdjoint_sum s fun _ hi => h _ hi |>.1, fun y => ?_⟩
-  simp [sum_mulVec, dotProduct_sum, Finset.sum_nonneg fun _ hi => (h _ hi).2 _]
+
 
 section trace
 -- TODO: move these results to an earlier file
@@ -262,133 +417,27 @@ theorem posSemidef_vecMulVec_star_self [StarOrderedRing R] (a : n → R) :
   simp [vecMulVec_eq Unit, ← conjTranspose_replicateRow, posSemidef_conjTranspose_mul_self]
 
 /-!
-## Positive definite matrices
+## Finite Positive definite matrices
 -/
 
-/-- A matrix `M : Matrix n n R` is positive definite if it is Hermitian
-and `xᴴMx` is greater than zero for all nonzero `x`. -/
-def PosDef (M : Matrix n n R) :=
-  M.IsHermitian ∧ ∀ x : n → R, x ≠ 0 → 0 < star x ⬝ᵥ (M *ᵥ x)
 
 namespace PosDef
 
-theorem isHermitian {M : Matrix n n R} (hM : M.PosDef) : M.IsHermitian :=
-  hM.1
-
-theorem posSemidef {M : Matrix n n R} (hM : M.PosDef) : M.PosSemidef := by
-  refine ⟨hM.1, ?_⟩
-  intro x
-  by_cases hx : x = 0
-  · simp only [hx, zero_dotProduct, star_zero]
-    exact le_rfl
-  · exact le_of_lt (hM.2 x hx)
-
-theorem transpose {M : Matrix n n R'} (hM : M.PosDef) : Mᵀ.PosDef := by
-  refine ⟨IsHermitian.transpose hM.1, fun x hx => ?_⟩
-  convert hM.2 (star x) (star_ne_zero.2 hx) using 1
-  rw [mulVec_transpose, dotProduct_mulVec, star_star, dotProduct_comm]
-
-@[simp]
-theorem transpose_iff {M : Matrix n n R'} : Mᵀ.PosDef ↔ M.PosDef :=
-  ⟨(by simpa using ·.transpose), .transpose⟩
-
-protected theorem diagonal [StarOrderedRing R] [DecidableEq n] [NoZeroDivisors R]
-    {d : n → R} (h : ∀ i, 0 < d i) :
-    PosDef (diagonal d) :=
-  ⟨isHermitian_diagonal_of_self_adjoint _ <| funext fun i => IsSelfAdjoint.of_nonneg (h i).le,
-    fun x hx => by
-      refine Fintype.sum_pos ?_
-      simp_rw [mulVec_diagonal, ← mul_assoc, Pi.lt_def]
-      obtain ⟨i, hi⟩ := Function.ne_iff.mp hx
-      exact ⟨fun i => star_left_conjugate_nonneg (h i).le _,
-        i, star_left_conjugate_pos (h _) (isRegular_of_ne_zero hi)⟩⟩
-
-@[simp]
-theorem _root_.Matrix.posDef_diagonal_iff
-    [StarOrderedRing R] [DecidableEq n] [NoZeroDivisors R] [Nontrivial R] {d : n → R} :
-    PosDef (diagonal d) ↔ ∀ i, 0 < d i := by
-  refine ⟨fun h i => ?_, .diagonal⟩
-  have := h.2 (Pi.single i 1)
-  simp_rw [mulVec_single_one, ← Pi.single_star, star_one, single_dotProduct, one_mul,
-    col_apply, diagonal_apply_eq, Function.ne_iff] at this
-  exact this ⟨i, by simp⟩
-
-protected theorem one [StarOrderedRing R] [DecidableEq n] [NoZeroDivisors R] :
-    PosDef (1 : Matrix n n R) :=
-  ⟨isHermitian_one, fun x hx => by simpa only [one_mulVec, dotProduct_star_self_pos_iff]⟩
-
-protected theorem natCast [StarOrderedRing R] [DecidableEq n] [NoZeroDivisors R]
-    (d : ℕ) (hd : d ≠ 0) :
-    PosDef (d : Matrix n n R) :=
-  ⟨isHermitian_natCast _, fun x hx => by
-    rw [natCast_mulVec, Nat.cast_smul_eq_nsmul, dotProduct_smul]
-    exact nsmul_pos (dotProduct_star_self_pos_iff.mpr hx) hd⟩
-
-@[simp]
-theorem _root_.Matrix.posDef_natCast_iff [StarOrderedRing R] [DecidableEq n] [NoZeroDivisors R]
-    [Nonempty n] [Nontrivial R] {d : ℕ} :
-    PosDef (d : Matrix n n R) ↔ 0 < d :=
-  posDef_diagonal_iff.trans <| by simp
-
-protected theorem ofNat [StarOrderedRing R] [DecidableEq n] [NoZeroDivisors R]
-    (d : ℕ) [d.AtLeastTwo] :
-    PosDef (ofNat(d) : Matrix n n R) :=
-  .natCast d (NeZero.ne _)
-
-protected theorem intCast [StarOrderedRing R] [DecidableEq n] [NoZeroDivisors R]
-    (d : ℤ) (hd : 0 < d) :
-    PosDef (d : Matrix n n R) :=
-  ⟨isHermitian_intCast _, fun x hx => by
-    rw [intCast_mulVec, Int.cast_smul_eq_zsmul, dotProduct_smul]
-    exact zsmul_pos (dotProduct_star_self_pos_iff.mpr hx) hd⟩
-
-@[simp]
-theorem _root_.Matrix.posDef_intCast_iff [StarOrderedRing R] [DecidableEq n] [NoZeroDivisors R]
-    [Nonempty n] [Nontrivial R] {d : ℤ} :
-    PosDef (d : Matrix n n R) ↔ 0 < d :=
-  posDef_diagonal_iff.trans <| by simp
-
-protected lemma add_posSemidef [AddLeftMono R]
-    {A : Matrix m m R} {B : Matrix m m R}
-    (hA : A.PosDef) (hB : B.PosSemidef) : (A + B).PosDef :=
-  ⟨hA.isHermitian.add hB.isHermitian, fun x hx => by
-    rw [add_mulVec, dotProduct_add]
-    exact add_pos_of_pos_of_nonneg (hA.2 x hx) (hB.2 x)⟩
-
-protected lemma posSemidef_add [AddLeftMono R]
-    {A : Matrix m m R} {B : Matrix m m R}
-    (hA : A.PosSemidef) (hB : B.PosDef) : (A + B).PosDef :=
-  add_comm A B ▸ hB.add_posSemidef hA
-
-protected lemma add [AddLeftMono R] {A : Matrix m m R} {B : Matrix m m R}
-    (hA : A.PosDef) (hB : B.PosDef) : (A + B).PosDef :=
-  hA.add_posSemidef hB.posSemidef
-
-theorem _root_.Matrix.posDef_sum {ι : Type*} [AddLeftMono R] {A : ι → Matrix m m R}
-    {s : Finset ι} (hs : s.Nonempty) (hA : ∀ i ∈ s, (A i).PosDef) : (∑ i ∈ s, A i).PosDef := by
-  classical
-  induction s using Finset.induction_on with
-  | empty => simp at hs
-  | insert i hi hins H =>
-      rw [Finset.sum_insert hins]
-      by_cases h : ¬ hi.Nonempty
-      · simp_all
-      · exact PosDef.add (hA _ <| Finset.mem_insert_self i hi) <|
-          H (not_not.mp h) fun _ _hi => hA _ (Finset.mem_insert_of_mem _hi)
-
-protected theorem smul {α : Type*} [CommSemiring α] [PartialOrder α] [StarRing α]
-    [StarOrderedRing α] [Algebra α R] [StarModule α R] [PosSMulStrictMono α R]
-    {x : Matrix n n R} (hx : x.PosDef) {a : α} (ha : 0 < a) : (a • x).PosDef := by
-  refine ⟨IsSelfAdjoint.smul (IsSelfAdjoint.of_nonneg ha.le) hx.1, fun y hy => ?_⟩
-  simp only [smul_mulVec, dotProduct_smul]
-  exact smul_pos ha (hx.2 _ hy)
+/-- A matrix `M : Matrix n n R` is positive definite if it is Hermitian
+and `xᴴMx` is greater than zero for all nonzero `x`. -/
+theorem iff_mulVec {M : Matrix n n R} :
+    M.PosDef ↔ M.IsHermitian ∧ ∀ x : n → R, x ≠ 0 → 0 < star x ⬝ᵥ (M *ᵥ x) := by
+  have (x : n →₀ R) : x = 0 ↔ Finsupp.equivFunOnFinite x = 0 :=
+    ⟨fun h1 ↦ Finsupp.coe_eq_zero.mpr h1,fun h2 ↦ Finsupp.coe_eq_zero.mp h2⟩
+  simp [PosDef, ← Finsupp.equivFunOnFinite.forall_congr_right,dotProduct,mulVec,
+    Finsupp.sum_fintype, Finset.mul_sum, mul_assoc,this]
 
 lemma conjTranspose_mul_mul_same {A : Matrix n n R} {B : Matrix n m R} (hA : A.PosDef)
     (hB : Function.Injective B.mulVec) :
     (Bᴴ * A * B).PosDef := by
-  refine ⟨Matrix.isHermitian_conjTranspose_mul_mul _ hA.1, fun x hx => ?_⟩
+  refine iff_mulVec.mpr ⟨Matrix.isHermitian_conjTranspose_mul_mul _ hA.1, fun x hx => ?_⟩
   have : B *ᵥ x ≠ 0 := fun h => hx <| hB.eq_iff' (mulVec_zero _) |>.1 h
-  simpa only [star_mulVec, dotProduct_mulVec, vecMul_vecMul] using hA.2 _ this
+  simpa only [star_mulVec, dotProduct_mulVec, vecMul_vecMul] using (iff_mulVec.mp hA).2 _ this
 
 lemma mul_mul_conjTranspose_same {A : Matrix n n R} {B : Matrix m n R} (hA : A.PosDef)
     (hB : Function.Injective B.vecMul) :
@@ -409,15 +458,9 @@ theorem mul_conjTranspose_self [StarOrderedRing R] [NoZeroDivisors R] (A : Matri
   classical
   simpa using mul_mul_conjTranspose_same .one hA
 
-theorem conjTranspose {M : Matrix n n R} (hM : M.PosDef) : Mᴴ.PosDef := hM.1.symm ▸ hM
-
-@[simp]
-theorem _root_.Matrix.posDef_conjTranspose_iff {M : Matrix n n R} : Mᴴ.PosDef ↔ M.PosDef :=
-  ⟨(by simpa using ·.conjTranspose), .conjTranspose⟩
-
 theorem of_toQuadraticForm' [DecidableEq n] {M : Matrix n n ℝ} (hM : M.IsSymm)
     (hMq : M.toQuadraticMap'.PosDef) : M.PosDef := by
-  refine ⟨hM, fun x hx => ?_⟩
+  refine iff_mulVec.mpr ⟨hM, fun x hx ↦ ?_⟩
   simp only [toQuadraticMap', QuadraticMap.PosDef, LinearMap.BilinMap.toQuadraticMap_apply,
     toLinearMap₂'_apply'] at hMq
   apply hMq x hx
@@ -427,10 +470,7 @@ theorem toQuadraticForm' [DecidableEq n] {M : Matrix n n ℝ} (hM : M.PosDef) :
   intro x hx
   simp only [Matrix.toQuadraticMap', LinearMap.BilinMap.toQuadraticMap_apply,
     toLinearMap₂'_apply']
-  apply hM.2 x hx
-
-lemma diag_pos [Nontrivial R] {A : Matrix n n R} (hA : A.PosDef) {i : n} : 0 < A i i := by
-  classical simpa [trace] using hA.2 <| Pi.single i 1
+  apply (iff_mulVec.mp hM).2 x hx
 
 lemma trace_pos [Nontrivial R] [IsOrderedCancelAddMonoid R] [Nonempty n] {A : Matrix n n R}
     (hA : A.PosDef) : 0 < A.trace :=
@@ -444,7 +484,7 @@ theorem isUnit [DecidableEq n] {M : Matrix n n K} (hM : M.PosDef) : IsUnit M := 
   obtain ⟨a, ha, ha2⟩ : ∃ a ≠ 0, M *ᵥ a = 0 := by
     obtain ⟨a, b, ha⟩ := Function.not_injective_iff.mp <| mulVec_injective_iff_isUnit.not.mpr h
     exact ⟨a - b, by simp [sub_eq_zero, ha, mulVec_sub]⟩
-  simpa [ha2] using hM.2 _ ha
+  simpa [ha2] using (iff_mulVec.mp hM).2 _ ha
 
 protected theorem inv [DecidableEq n] {M : Matrix n n K} (hM : M.PosDef) : M⁻¹.PosDef := by
   have := hM.mul_mul_conjTranspose_same (B := M⁻¹) ?_
@@ -497,9 +537,9 @@ variable [StarOrderedRing R']
 theorem fromBlocks₁₁ [DecidableEq m] {A : Matrix m m R'}
     (B : Matrix m n R') (D : Matrix n n R') (hA : A.PosDef) [Invertible A] :
     (fromBlocks A B Bᴴ D).PosSemidef ↔ (D - Bᴴ * A⁻¹ * B).PosSemidef := by
-  rw [PosSemidef, IsHermitian.fromBlocks₁₁ _ _ hA.1]
+  rw [PosSemidef.iff_mulVec, IsHermitian.fromBlocks₁₁ _ _ hA.1]
   constructor
-  · refine fun h => ⟨h.1, fun x => ?_⟩
+  · refine fun h => PosSemidef.iff_mulVec.mpr ⟨h.1, fun x => ?_⟩
     have := h.2 (-((A⁻¹ * B) *ᵥ x) ⊕ᵥ x)
     rwa [dotProduct_mulVec, schur_complement_eq₁₁ B D _ _ hA.1, neg_add_cancel, dotProduct_zero,
       zero_add, ← dotProduct_mulVec] at this
@@ -507,9 +547,9 @@ theorem fromBlocks₁₁ [DecidableEq m] {A : Matrix m m R'}
     rw [dotProduct_mulVec, ← Sum.elim_comp_inl_inr x, schur_complement_eq₁₁ B D _ _ hA.1]
     apply le_add_of_nonneg_of_le
     · rw [← dotProduct_mulVec]
-      apply hA.posSemidef.2
+      apply (PosSemidef.iff_mulVec.mp hA.posSemidef).2
     · rw [← dotProduct_mulVec (star (x ∘ Sum.inr))]
-      apply h.2
+      apply (PosSemidef.iff_mulVec.mp h).2
 
 theorem fromBlocks₂₂ [DecidableEq n] (A : Matrix m m R')
     (B : Matrix m n R') {D : Matrix n n R'} (hD : D.PosDef) [Invertible D] :

--- a/Mathlib/LinearAlgebra/Matrix/PosDef.lean
+++ b/Mathlib/LinearAlgebra/Matrix/PosDef.lean
@@ -106,7 +106,7 @@ protected lemma add [AddLeftMono R] {A : Matrix m m R} {B : Matrix m m R}
 protected theorem smul {α : Type*} [CommSemiring α] [PartialOrder α] [StarRing α]
     [StarOrderedRing α] [Algebra α R] [StarModule α R] [PosSMulMono α R] {x : Matrix n n R}
     (hx : x.PosSemidef) {a : α} (ha : 0 ≤ a) : (a • x).PosSemidef := by
-  refine ⟨IsSelfAdjoint.smul (.of_nonneg ha) hx.1, fun y => ?_⟩
+  refine ⟨.smul (.of_nonneg ha) hx.1, fun y => ?_⟩
   simpa [mul_smul_comm, smul_mul_assoc, ← Finsupp.smul_sum] using smul_nonneg ha (hx.2 _)
 
 protected lemma zero : PosSemidef (0 : Matrix n n R) := ⟨isHermitian_zero, by simp⟩

--- a/Mathlib/LinearAlgebra/Matrix/PosDef.lean
+++ b/Mathlib/LinearAlgebra/Matrix/PosDef.lean
@@ -106,7 +106,7 @@ protected lemma add [AddLeftMono R] {A : Matrix m m R} {B : Matrix m m R}
 protected theorem smul {α : Type*} [CommSemiring α] [PartialOrder α] [StarRing α]
     [StarOrderedRing α] [Algebra α R] [StarModule α R] [PosSMulMono α R] {x : Matrix n n R}
     (hx : x.PosSemidef) {a : α} (ha : 0 ≤ a) : (a • x).PosSemidef := by
-  refine ⟨.smul (.of_nonneg ha) hx.1, fun y => ?_⟩
+  refine ⟨IsSelfAdjoint.smul (.of_nonneg ha) hx.1, fun y => ?_⟩
   simpa [mul_smul_comm, smul_mul_assoc, ← Finsupp.smul_sum] using smul_nonneg ha (hx.2 _)
 
 protected lemma zero : PosSemidef (0 : Matrix n n R) := ⟨isHermitian_zero, by simp⟩

--- a/Mathlib/LinearAlgebra/SesquilinearForm/Star.lean
+++ b/Mathlib/LinearAlgebra/SesquilinearForm/Star.lean
@@ -58,7 +58,7 @@ variable {R : Type*} [CommRing R] [StarRing R] [PartialOrder R] [Module R M]
 
 lemma LinearMap.isPosSemidef_iff_posSemidef_toMatrix :
     B.IsPosSemidef ↔ (toMatrix₂ b b B).PosSemidef := by
-  rw [isPosSemidef_def, Matrix.PosSemidef]
+  rw [isPosSemidef_def, Matrix.posSemidef_iff_dotProduct_mulVec]
   apply and_congr (B.isSymm_iff_isHermitian_toMatrix b)
   rw [isNonneg_def]
   refine ⟨fun h x ↦ ?_, fun h x ↦ ?_⟩


### PR DESCRIPTION

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

When merging, all the commits will be squashed into a single commit
listing all co-authors.

Co-authors in the squash commit are gathered from two sources:

First, all authors of commits to this PR branch are included. Thus,
one way to add co-authors is to include at least one commit authored by
each co-author among the commits in the pull request. If necessary, you
may create empty commits to indicate co-authorship, using commands like so:

git commit --author="Author Name <author@email.com>" --allow-empty -m "add Author Name as coauthor"

Second, co-authors can also be listed in lines at the very bottom of
the commit message (that is, directly before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines
at the bottom of the commit message (before the `---`, and also before
any "Co-authored-by" lines) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
