### PR TITLE
[Merged by Bors] - feat(NNReal): `AddCancelCommMonoid` instance

### DIFF
--- a/Mathlib/Algebra/Order/Nonneg/Basic.lean
+++ b/Mathlib/Algebra/Order/Nonneg/Basic.lean
@@ -161,6 +161,14 @@ instance addCommMonoid : AddCommMonoid { x : α // 0 ≤ x } :=
 
 end AddCommMonoid
 
+section AddCancelCommMonoid
+variable [AddCancelCommMonoid α] [Preorder α] [AddLeftMono α]
+
+instance addCancelCommMonoid : AddCancelCommMonoid { x : α // 0 ≤ x } :=
+  Subtype.coe_injective.addCancelCommMonoid _ Nonneg.coe_zero (fun _ _ => rfl) (fun _ _ => rfl)
+
+end AddCancelCommMonoid
+
 section AddMonoidWithOne
 
 variable [AddMonoidWithOne α] [PartialOrder α] [AddLeftMono α] [ZeroLEOneClass α]

--- a/Mathlib/Algebra/Order/Nonneg/Basic.lean
+++ b/Mathlib/Algebra/Order/Nonneg/Basic.lean
@@ -164,7 +164,7 @@ end AddCommMonoid
 section AddCancelCommMonoid
 variable [AddCancelCommMonoid α] [Preorder α] [AddLeftMono α]
 
-instance addCancelCommMonoid : AddCancelCommMonoid { x : α // 0 ≤ x } :=
+instance addCancelCommMonoid : AddCancelCommMonoid {x : α // 0 ≤ x} :=
   Subtype.coe_injective.addCancelCommMonoid _ Nonneg.coe_zero (fun _ _ => rfl) (fun _ _ => rfl)
 
 end AddCancelCommMonoid

--- a/Mathlib/Data/NNRat/Defs.lean
+++ b/Mathlib/Data/NNRat/Defs.lean
@@ -55,6 +55,7 @@ instance Rat.instPosMulMono : PosMulMono ℚ where
     simpa [mul_sub, sub_nonneg] using Rat.mul_nonneg hr (sub_nonneg.2 hpq)
 
 deriving instance CommSemiring for NNRat
+deriving instance AddCancelCommMonoid for NNRat
 deriving instance LinearOrder for NNRat
 deriving instance Sub for NNRat
 deriving instance Inhabited for NNRat

--- a/Mathlib/Data/NNReal/Defs.lean
+++ b/Mathlib/Data/NNReal/Defs.lean
@@ -52,7 +52,7 @@ open Function
 -- to ensure these instances are computable
 /-- Nonnegative real numbers, denoted as `ℝ≥0` within the NNReal namespace -/
 def NNReal := { r : ℝ // 0 ≤ r } deriving
-  Zero, One, Semiring, CommMonoidWithZero, CommSemiring,
+  Zero, One, Semiring, CommMonoidWithZero, CommSemiring, AddCancelCommMonoid,
   PartialOrder, SemilatticeInf, SemilatticeSup, DistribLattice,
   Nontrivial, Inhabited
 


### PR DESCRIPTION
---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

When merging, all the commits will be squashed into a single commit
listing all co-authors.

Co-authors in the squash commit are gathered from two sources:

First, all authors of commits to this PR branch are included. Thus,
one way to add co-authors is to include at least one commit authored by
each co-author among the commits in the pull request. If necessary, you
may create empty commits to indicate co-authorship, using commands like so:

git commit --author="Author Name <author@email.com>" --allow-empty -m "add Author Name as coauthor"

Second, co-authors can also be listed in lines at the very bottom of
the commit message (that is, directly before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines
at the bottom of the commit message (before the `---`, and also before
any "Co-authored-by" lines) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
