### PR TITLE
[Merged by Bors] - feat(CategoryTheory): a category with a terminal object is κ-filtered

### DIFF
--- a/Mathlib/CategoryTheory/Presentable/IsCardinalFiltered.lean
+++ b/Mathlib/CategoryTheory/Presentable/IsCardinalFiltered.lean
@@ -302,4 +302,16 @@ lemma IsCardinalFiltered.multicoequalizer
     (fun i ↦ IsFiltered.coeqHom (f₁ i) (f₂ i)) hι
   exact ⟨l, b, fun i ↦ by rw [← h i, IsFiltered.coeq_condition_assoc]⟩
 
+lemma Limits.IsTerminal.isCardinalFiltered {J : Type u} [Category.{v} J]
+    {X : J} (hX : IsTerminal X) (κ : Cardinal.{w}) [Fact κ.IsRegular] :
+    IsCardinalFiltered J κ where
+  nonempty_cocone {A _} F _ := ⟨{
+    pt := X
+    ι.app _ := hX.from _ }⟩
+
+lemma isCardinalFiltered_of_hasTerminal (J : Type u) [Category.{v} J]
+    [HasTerminal J] (κ : Cardinal.{w}) [Fact κ.IsRegular] :
+    IsCardinalFiltered J κ :=
+  terminalIsTerminal.isCardinalFiltered _
+
 end CategoryTheory

--- a/Mathlib/CategoryTheory/Presentable/IsCardinalFiltered.lean
+++ b/Mathlib/CategoryTheory/Presentable/IsCardinalFiltered.lean
@@ -305,9 +305,7 @@ lemma IsCardinalFiltered.multicoequalizer
 lemma Limits.IsTerminal.isCardinalFiltered {J : Type u} [Category.{v} J]
     {X : J} (hX : IsTerminal X) (κ : Cardinal.{w}) [Fact κ.IsRegular] :
     IsCardinalFiltered J κ where
-  nonempty_cocone {A _} F _ := ⟨{
-    pt := X
-    ι.app _ := hX.from _ }⟩
+  nonempty_cocone _ _ := ⟨{ pt := X, ι.app _ := hX.from _ }⟩
 
 lemma isCardinalFiltered_of_hasTerminal (J : Type u) [Category.{v} J]
     [HasTerminal J] (κ : Cardinal.{w}) [Fact κ.IsRegular] :


### PR DESCRIPTION
---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

When merging, all the commits will be squashed into a single commit
listing all co-authors.

Co-authors in the squash commit are gathered from two sources:

First, all authors of commits to this PR branch are included. Thus,
one way to add co-authors is to include at least one commit authored by
each co-author among the commits in the pull request. If necessary, you
may create empty commits to indicate co-authorship, using commands like so:

git commit --author="Author Name <author@email.com>" --allow-empty -m "add Author Name as coauthor"

Second, co-authors can also be listed in lines at the very bottom of
the commit message (that is, directly before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines
at the bottom of the commit message (before the `---`, and also before
any "Co-authored-by" lines) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
