### PR TITLE
[Merged by Bors] - feat: `WithLp.{fst,snd}` as a `(Continuous)LinearMap`

### DIFF
--- a/Mathlib/Analysis/Normed/Lp/ProdLp.lean
+++ b/Mathlib/Analysis/Normed/Lp/ProdLp.lean
@@ -110,6 +110,22 @@ theorem smul_fst : (c • x).fst = c • x.fst :=
 theorem smul_snd : (c • x).snd = c • x.snd :=
   rfl
 
+variable (p 𝕜 α β)
+
+/-- `WithLp.fst` as a linear map. -/
+@[simps]
+def fstₗ : WithLp p (α × β) →ₗ[𝕜] α where
+  toFun := WithLp.fst
+  map_add' _ _ := rfl
+  map_smul' _ _ := rfl
+
+/-- `WithLp.snd` as a linear map. -/
+@[simps]
+def sndₗ : WithLp p (α × β) →ₗ[𝕜] β where
+  toFun := WithLp.snd
+  map_add' _ _ := rfl
+  map_smul' _ _ := rfl
+
 end algebra
 
 /-! Note that the unapplied versions of these lemmas are deliberately omitted, as they break
@@ -469,6 +485,14 @@ def homeomorphProd : WithLp p (α × β) ≃ₜ α × β where
 @[simp]
 lemma toEquiv_homeomorphProd : (homeomorphProd p α β).toEquiv = WithLp.equiv p (α × β) := rfl
 
+@[fun_prop]
+protected lemma continuous_fst : Continuous (@WithLp.fst p α β) :=
+  continuous_fst.comp <| prod_continuous_ofLp ..
+
+@[fun_prop]
+protected lemma continuous_snd : Continuous (@WithLp.snd p α β) :=
+  continuous_snd.comp <| prod_continuous_ofLp ..
+
 variable [T0Space α] [T0Space β]
 
 instance instProdT0Space : T0Space (WithLp p (α × β)) :=
@@ -531,6 +555,18 @@ def prodContinuousLinearEquiv : WithLp p (α × β) ≃L[𝕜] α × β where
 @[simp]
 lemma prodContinuousLinearEquiv_symm_apply (x : α × β) :
     (prodContinuousLinearEquiv p 𝕜 α β).symm x = toLp p x := rfl
+
+/-- `WithLp.fst` as a continuous linear map. -/
+@[simps! coe apply]
+def fstL : WithLp p (α × β) →L[𝕜] α where
+  __ := fstₗ ..
+  cont := WithLp.continuous_fst ..
+
+/-- `WithLp.snd` as a continuous linear map. -/
+@[simps! coe apply]
+def sndL : WithLp p (α × β) →L[𝕜] β where
+  __ := sndₗ ..
+  cont := WithLp.continuous_snd ..
 
 end ContinuousLinearEquiv
 


### PR DESCRIPTION
---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

When merging, all the commits will be squashed into a single commit
listing all co-authors.

Co-authors in the squash commit are gathered from two sources:

First, all authors of commits to this PR branch are included. Thus,
one way to add co-authors is to include at least one commit authored by
each co-author among the commits in the pull request. If necessary, you
may create empty commits to indicate co-authorship, using commands like so:

git commit --author="Author Name <author@email.com>" --allow-empty -m "add Author Name as coauthor"

Second, co-authors can also be listed in lines at the very bottom of
the commit message (that is, directly before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines
at the bottom of the commit message (before the `---`, and also before
any "Co-authored-by" lines) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
