### PR TITLE
[Merged by Bors] - feat: add `grind` annotations for `SimpleGraph.Walk.length_{support,darts,edges}`

### DIFF
--- a/Mathlib/Combinatorics/SimpleGraph/Hamiltonian.lean
+++ b/Mathlib/Combinatorics/SimpleGraph/Hamiltonian.lean
@@ -76,7 +76,7 @@ lemma IsHamiltonian.length_eq (hp : p.IsHamiltonian) : p.length = Fintype.card �
 /-- The length of the support of a Hamiltonian path equals the number of vertices of the graph. -/
 lemma IsHamiltonian.length_support (hp : p.IsHamiltonian) : p.support.length = Fintype.card α := by
   have : Inhabited α := ⟨a⟩
-  grind [Fintype.card_ne_zero, length_support, length_eq]
+  grind [Fintype.card_ne_zero, length_eq]
 
 end
 

--- a/Mathlib/Combinatorics/SimpleGraph/Walks/Basic.lean
+++ b/Mathlib/Combinatorics/SimpleGraph/Walks/Basic.lean
@@ -263,11 +263,11 @@ theorem edges_cons {u v w : V} (h : G.Adj u v) (p : G.Walk v w) :
 theorem length_support {u v : V} (p : G.Walk u v) : p.support.length = p.length + 1 := by
   induction p <;> simp [*]
 
-@[simp]
+@[simp, grind =]
 theorem length_darts {u v : V} (p : G.Walk u v) : p.darts.length = p.length := by
   induction p <;> simp [*]
 
-@[simp]
+@[simp, grind =]
 theorem length_edges {u v : V} (p : G.Walk u v) : p.edges.length = p.length := by simp [edges]
 
 theorem dart_fst_mem_support_of_mem_darts {u v : V} :

--- a/Mathlib/Combinatorics/SimpleGraph/Walks/Basic.lean
+++ b/Mathlib/Combinatorics/SimpleGraph/Walks/Basic.lean
@@ -259,7 +259,7 @@ theorem edges_nil {u : V} : (nil : G.Walk u u).edges = [] := rfl
 theorem edges_cons {u v w : V} (h : G.Adj u v) (p : G.Walk v w) :
     (cons h p).edges = s(u, v) :: p.edges := rfl
 
-@[simp]
+@[simp, grind =]
 theorem length_support {u v : V} (p : G.Walk u v) : p.support.length = p.length + 1 := by
   induction p <;> simp [*]
 


### PR DESCRIPTION
---
Note that the lemma being annotated is
1. already actively used with `grind` via explicit `grind [lemma]` invocations in Mathlib, and
2. already tagged with `@[simp]`.

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

When merging, all the commits will be squashed into a single commit
listing all co-authors.

Co-authors in the squash commit are gathered from two sources:

First, all authors of commits to this PR branch are included. Thus,
one way to add co-authors is to include at least one commit authored by
each co-author among the commits in the pull request. If necessary, you
may create empty commits to indicate co-authorship, using commands like so:

git commit --author="Author Name <author@email.com>" --allow-empty -m "add Author Name as coauthor"

Second, co-authors can also be listed in lines at the very bottom of
the commit message (that is, directly before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines
at the bottom of the commit message (before the `---`, and also before
any "Co-authored-by" lines) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
