### PR TITLE
[Merged by Bors] - feat(RingTheory/Valuation): monotonicity of mul wrt `SRel`

### DIFF
--- a/Mathlib/RingTheory/Valuation/ValuativeRel/Basic.lean
+++ b/Mathlib/RingTheory/Valuation/ValuativeRel/Basic.lean
@@ -189,11 +189,9 @@ def posSubmonoid : Submonoid R where
 @[simp]
 lemma posSubmonoid_def (x : R) : x ∈ posSubmonoid R ↔ 0 <ᵥ x := Iff.rfl
 
-@[simp]
 lemma right_cancel_posSubmonoid (x y : R) (u : posSubmonoid R) :
     x * u ≤ᵥ y * u ↔ x ≤ᵥ y := ⟨rel_mul_cancel u.prop, rel_mul_right _⟩
 
-@[simp]
 lemma left_cancel_posSubmonoid (x y : R) (u : posSubmonoid R) :
     u * x ≤ᵥ u * y ↔ x ≤ᵥ y := by
   simp only [← right_cancel_posSubmonoid x y u, mul_comm]

--- a/Mathlib/RingTheory/Valuation/ValuativeRel/Basic.lean
+++ b/Mathlib/RingTheory/Valuation/ValuativeRel/Basic.lean
@@ -101,7 +101,7 @@ class ValuativePreorder (R : Type*) [CommRing R] [ValuativeRel R] [Preorder R] w
 
 namespace ValuativeRel
 
-variable {R : Type*} [CommRing R] [ValuativeRel R]
+variable {R : Type*} [CommRing R] [ValuativeRel R] {x y z : R}
 
 /-- The strict version of the valuative relation. -/
 def SRel (x y : R) : Prop := ¬ y ≤ᵥ x
@@ -154,12 +154,24 @@ lemma mul_rel_mul {x x' y y' : R} (h1 : x ≤ᵥ y) (h2 : x' ≤ᵥ y') : x * x'
   calc x * x' ≤ᵥ x * y' := rel_mul_left _ h2
     _ ≤ᵥ y * y' := rel_mul_right _ h1
 
+@[simp] lemma mul_rel_mul_iff_left (hz : 0 <ᵥ z) : x * z ≤ᵥ y * z ↔ x ≤ᵥ y :=
+  ⟨rel_mul_cancel hz, rel_mul_right _⟩
+
+@[simp] lemma mul_rel_mul_iff_right (hx : 0 <ᵥ x) : x * y ≤ᵥ x * z ↔ y ≤ᵥ z := by
+  simp [mul_comm x, hx]
+
+@[simp] lemma mul_srel_mul_iff_left (hz : 0 <ᵥ z) : x * z <ᵥ y * z ↔ x <ᵥ y :=
+  (mul_rel_mul_iff_left hz).not
+
+@[simp] lemma mul_srel_mul_iff_right (hx : 0 <ᵥ x) : x * y <ᵥ x * z ↔ y <ᵥ z :=
+  (mul_rel_mul_iff_right hx).not
+
 @[deprecated (since := "2025-11-04")] alias rel_mul := mul_rel_mul
 
 theorem rel_add_cases (x y : R) : x + y ≤ᵥ x ∨ x + y ≤ᵥ y :=
   (rel_total y x).imp (fun h => rel_add .rfl h) (fun h => rel_add h .rfl)
 
-lemma zero_srel_mul {x y : R} (hx : 0 <ᵥ x) (hy : 0 <ᵥ y) : 0 <ᵥ x * y := by
+@[simp] lemma zero_srel_mul (hx : 0 <ᵥ x) (hy : 0 <ᵥ y) : 0 <ᵥ x * y := by
   contrapose! hy
   rw [not_srel_iff] at hy ⊢
   rw [show (0 : R) = x * 0 by simp, mul_comm x y, mul_comm x 0] at hy
@@ -171,6 +183,8 @@ def posSubmonoid : Submonoid R where
   carrier := { x | 0 <ᵥ x }
   mul_mem' := zero_srel_mul
   one_mem' := zero_srel_one
+
+@[simp] lemma zero_srel_posSubmonoid_def (x : posSubmonoid R) : 0 <ᵥ x.val := x.prop
 
 @[simp]
 lemma posSubmonoid_def (x : R) : x ∈ posSubmonoid R ↔ 0 <ᵥ x := Iff.rfl
@@ -447,6 +461,10 @@ instance : LinearOrder (ValueGroupWithZero R) where
 theorem ValueGroupWithZero.mk_lt_mk (x y : R) (t s : posSubmonoid R) :
     ValueGroupWithZero.mk x t < ValueGroupWithZero.mk y s ↔ x * s <ᵥ y * t := by
   rw [lt_iff_not_ge, srel_iff, mk_le_mk]
+
+@[simp]
+lemma ValueGroupWithZero.mk_pos {x : R} {s : posSubmonoid R} :
+    0 < ValueGroupWithZero.mk x s ↔ 0 <ᵥ x := by rw [← mk_zero 1]; simp [-mk_zero]
 
 instance : Bot (ValueGroupWithZero R) where
   bot := 0

--- a/Mathlib/RingTheory/Valuation/ValuativeRel/Basic.lean
+++ b/Mathlib/RingTheory/Valuation/ValuativeRel/Basic.lean
@@ -190,11 +190,10 @@ def posSubmonoid : Submonoid R where
 lemma posSubmonoid_def (x : R) : x ∈ posSubmonoid R ↔ 0 <ᵥ x := Iff.rfl
 
 lemma right_cancel_posSubmonoid (x y : R) (u : posSubmonoid R) :
-    x * u ≤ᵥ y * u ↔ x ≤ᵥ y := ⟨rel_mul_cancel u.prop, rel_mul_right _⟩
+    x * u ≤ᵥ y * u ↔ x ≤ᵥ y := by simp
 
 lemma left_cancel_posSubmonoid (x y : R) (u : posSubmonoid R) :
-    u * x ≤ᵥ u * y ↔ x ≤ᵥ y := by
-  simp only [← right_cancel_posSubmonoid x y u, mul_comm]
+    u * x ≤ᵥ u * y ↔ x ≤ᵥ y := by simp
 
 @[simp]
 lemma val_posSubmonoid_ne_zero (x : posSubmonoid R) :

--- a/Mathlib/RingTheory/Valuation/ValuativeRel/Basic.lean
+++ b/Mathlib/RingTheory/Valuation/ValuativeRel/Basic.lean
@@ -184,7 +184,7 @@ def posSubmonoid : Submonoid R where
   mul_mem' := zero_srel_mul
   one_mem' := zero_srel_one
 
-@[simp] lemma zero_srel_posSubmonoid_def (x : posSubmonoid R) : 0 <ᵥ x.val := x.prop
+@[simp] lemma zero_srel_coe_posSubmonoid (x : posSubmonoid R) : 0 <ᵥ x.val := x.prop
 
 @[simp]
 lemma posSubmonoid_def (x : R) : x ∈ posSubmonoid R ↔ 0 <ᵥ x := Iff.rfl


### PR DESCRIPTION



---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

When merging, all the commits will be squashed into a single commit
listing all co-authors.

Co-authors in the squash commit are gathered from two sources:

First, all authors of commits to this PR branch are included. Thus,
one way to add co-authors is to include at least one commit authored by
each co-author among the commits in the pull request. If necessary, you
may create empty commits to indicate co-authorship, using commands like so:

git commit --author="Author Name <author@email.com>" --allow-empty -m "add Author Name as coauthor"

Second, co-authors can also be listed in lines at the very bottom of
the commit message (that is, directly before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines
at the bottom of the commit message (before the `---`, and also before
any "Co-authored-by" lines) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
