### PR TITLE
[Merged by Bors] - feat: add `splitOnP_append_cons`

### DIFF
--- a/Mathlib/Data/List/SplitOn.lean
+++ b/Mathlib/Data/List/SplitOn.lean
@@ -46,9 +46,8 @@ theorem splitOnP_cons (x : α) (xs : List α) :
       if p x then [] :: xs.splitOnP p else (xs.splitOnP p).modifyHead (cons x) := by
   rw [splitOnP, splitOnP.go]; split <;> [rfl; simp [splitOnP.go_acc]]
 
-@[simp]
 lemma splitOnP_false (h : ∀ (x : α), x ∈ xs → p x = false) :
-    List.splitOnP p (xs) = [xs] := by
+    List.splitOnP p xs = [xs] := by
   induction xs with
   | nil => rfl
   | cons hd tl ih =>

--- a/Mathlib/Data/List/SplitOn.lean
+++ b/Mathlib/Data/List/SplitOn.lean
@@ -46,8 +46,7 @@ theorem splitOnP_cons (x : α) (xs : List α) :
       if p x then [] :: xs.splitOnP p else (xs.splitOnP p).modifyHead (cons x) := by
   rw [splitOnP, splitOnP.go]; split <;> [rfl; simp [splitOnP.go_acc]]
 
-theorem splitOnP_false (h : ∀ (x : α), x ∈ xs → p x = false) :
-    List.splitOnP p xs = [xs] := by
+theorem splitOnP_false (h : ∀ (x : α), x ∈ xs → p x = false) : List.splitOnP p xs = [xs] := by
   induction xs with
   | nil => rfl
   | cons hd tl ih =>
@@ -57,14 +56,13 @@ theorem splitOnP_false (h : ∀ (x : α), x ∈ xs → p x = false) :
 the result is the concatenation of `splitOnP` called on the portions of the input list
 from before and after the split -/
 @[simp]
-theorem splitOnP_append_cons {α : Type} (l1 l2 : List α)
-    (a : α) (P : α → Bool) (hPa : P a = true) :
-    List.splitOnP P (l1 ++ a :: l2) = List.splitOnP P l1 ++ List.splitOnP P l2 := by
+theorem splitOnP_append_cons (l1 l2 : List α) (a : α) (hPa : p a = true) :
+    List.splitOnP p (l1 ++ a :: l2) = List.splitOnP p l1 ++ List.splitOnP p l2 := by
   induction l1 with
   | nil => simp [hPa]
   | cons hd tl ih =>
-    obtain ⟨hd1, tl1, h1'⟩ := List.exists_cons_of_ne_nil (List.splitOnP_ne_nil P tl)
-    by_cases hPh : P hd <;> simp [*]
+    obtain ⟨hd1, tl1, h1'⟩ := List.exists_cons_of_ne_nil (List.splitOnP_ne_nil p tl)
+    by_cases hPh : p hd <;> simp [*]
 
 /-- The original list `L` can be recovered by flattening the lists produced by `splitOnP p L`,
 interspersed with the elements `L.filter p`. -/

--- a/Mathlib/Data/List/SplitOn.lean
+++ b/Mathlib/Data/List/SplitOn.lean
@@ -46,6 +46,27 @@ theorem splitOnP_cons (x : α) (xs : List α) :
       if p x then [] :: xs.splitOnP p else (xs.splitOnP p).modifyHead (cons x) := by
   rw [splitOnP, splitOnP.go]; split <;> [rfl; simp [splitOnP.go_acc]]
 
+@[simp]
+lemma splitOnP_false (h : ∀ (x : α), x ∈ xs → p x = false) :
+    List.splitOnP p (xs) = [xs] := by
+  induction xs with
+  | nil => rfl
+  | cons hd tl ih =>
+    simp_all
+
+/-- If a list is split by `splitOnP`,
+the result is the concatenation of `splitOnP` called on the portions of the input list
+from before and after the split -/
+@[simp]
+lemma splitOnP_append_cons {α : Type} (l1 l2 : List α)
+    (a : α) (P : α → Bool) (hPa : P a = true) :
+    List.splitOnP P (l1 ++ a :: l2) = List.splitOnP P l1 ++ List.splitOnP P l2 := by
+  induction l1 with
+  | nil => simp [hPa]
+  | cons hd tl ih =>
+    obtain ⟨hd1, tl1, h1'⟩ := List.exists_cons_of_ne_nil (List.splitOnP_ne_nil P tl)
+    by_cases hPh : P hd <;> simp [*]
+
 /-- The original list `L` can be recovered by flattening the lists produced by `splitOnP p L`,
 interspersed with the elements `L.filter p`. -/
 theorem splitOnP_spec (as : List α) :

--- a/Mathlib/Data/List/SplitOn.lean
+++ b/Mathlib/Data/List/SplitOn.lean
@@ -46,7 +46,7 @@ theorem splitOnP_cons (x : α) (xs : List α) :
       if p x then [] :: xs.splitOnP p else (xs.splitOnP p).modifyHead (cons x) := by
   rw [splitOnP, splitOnP.go]; split <;> [rfl; simp [splitOnP.go_acc]]
 
-lemma splitOnP_false (h : ∀ (x : α), x ∈ xs → p x = false) :
+theorem splitOnP_false (h : ∀ (x : α), x ∈ xs → p x = false) :
     List.splitOnP p xs = [xs] := by
   induction xs with
   | nil => rfl
@@ -57,7 +57,7 @@ lemma splitOnP_false (h : ∀ (x : α), x ∈ xs → p x = false) :
 the result is the concatenation of `splitOnP` called on the portions of the input list
 from before and after the split -/
 @[simp]
-lemma splitOnP_append_cons {α : Type} (l1 l2 : List α)
+theorem splitOnP_append_cons {α : Type} (l1 l2 : List α)
     (a : α) (P : α → Bool) (hPa : P a = true) :
     List.splitOnP P (l1 ++ a :: l2) = List.splitOnP P l1 ++ List.splitOnP P l2 := by
   induction l1 with

--- a/Mathlib/Data/List/SplitOn.lean
+++ b/Mathlib/Data/List/SplitOn.lean
@@ -46,24 +46,6 @@ theorem splitOnP_cons (x : α) (xs : List α) :
       if p x then [] :: xs.splitOnP p else (xs.splitOnP p).modifyHead (cons x) := by
   rw [splitOnP, splitOnP.go]; split <;> [rfl; simp [splitOnP.go_acc]]
 
-theorem splitOnP_false (h : ∀ (x : α), x ∈ xs → p x = false) : List.splitOnP p xs = [xs] := by
-  induction xs with
-  | nil => rfl
-  | cons hd tl ih =>
-    simp_all
-
-/-- If a list is split by `splitOnP`,
-the result is the concatenation of `splitOnP` called on the portions of the input list
-from before and after the split -/
-@[simp]
-theorem splitOnP_append_cons (l1 l2 : List α) (a : α) (hPa : p a = true) :
-    List.splitOnP p (l1 ++ a :: l2) = List.splitOnP p l1 ++ List.splitOnP p l2 := by
-  induction l1 with
-  | nil => simp [hPa]
-  | cons hd tl ih =>
-    obtain ⟨hd1, tl1, h1'⟩ := List.exists_cons_of_ne_nil (List.splitOnP_ne_nil p tl)
-    by_cases hPh : p hd <;> simp [*]
-
 /-- The original list `L` can be recovered by flattening the lists produced by `splitOnP p L`,
 interspersed with the elements `L.filter p`. -/
 theorem splitOnP_spec (as : List α) :
@@ -93,6 +75,17 @@ theorem splitOnP_eq_single (h : ∀ x ∈ xs, ¬p x) : xs.splitOnP p = [xs] := b
   | cons hd tl ih =>
     simp only [splitOnP_cons, h hd mem_cons_self, if_false, Bool.false_eq_true,
       modifyHead_cons, ih <| forall_mem_of_forall_mem_cons h]
+
+/-- When a list of the form `[...xs, sep, ...as]` is split on `p`,
+the result is the concatenation of `splitOnP` called on `xs` and `as` -/
+@[simp]
+theorem splitOnP_append_cons (l1 l2 : List α) (a : α) (hPa : p a = true) :
+    List.splitOnP p (l1 ++ a :: l2) = List.splitOnP p l1 ++ List.splitOnP p l2 := by
+  induction l1 with
+  | nil => simp [hPa]
+  | cons hd tl ih =>
+    obtain ⟨hd1, tl1, h1'⟩ := List.exists_cons_of_ne_nil (List.splitOnP_ne_nil p tl)
+    by_cases hPh : p hd <;> simp [*]
 
 /-- When a list of the form `[...xs, sep, ...as]` is split on `p`, the first element is `xs`,
   assuming no element in `xs` satisfies `p` but `sep` does satisfy `p` -/

--- a/Mathlib/Data/List/SplitOn.lean
+++ b/Mathlib/Data/List/SplitOn.lean
@@ -76,24 +76,22 @@ theorem splitOnP_eq_single (h : ∀ x ∈ xs, ¬p x) : xs.splitOnP p = [xs] := b
     simp only [splitOnP_cons, h hd mem_cons_self, if_false, Bool.false_eq_true,
       modifyHead_cons, ih <| forall_mem_of_forall_mem_cons h]
 
-/-- When a list of the form `[...xs, sep, ...as]` is split on `p`,
+/-- When a list of the form `[...xs, sep, ...as]` is split at the `sep` element satisfying `p`,
 the result is the concatenation of `splitOnP` called on `xs` and `as` -/
-@[simp]
-theorem splitOnP_append_cons (l1 l2 : List α) (a : α) (hPa : p a = true) :
-    List.splitOnP p (l1 ++ a :: l2) = List.splitOnP p l1 ++ List.splitOnP p l2 := by
-  induction l1 with
-  | nil => simp [hPa]
+theorem splitOnP_append_cons (xs as : List α) (sep : α) (hsep : p sep) :
+    (xs ++ sep :: as).splitOnP p = List.splitOnP p xs ++ List.splitOnP p as := by
+  induction xs with
+  | nil => simp [hsep]
   | cons hd tl ih =>
     obtain ⟨hd1, tl1, h1'⟩ := List.exists_cons_of_ne_nil (List.splitOnP_ne_nil p tl)
     by_cases hPh : p hd <;> simp [*]
 
 /-- When a list of the form `[...xs, sep, ...as]` is split on `p`, the first element is `xs`,
   assuming no element in `xs` satisfies `p` but `sep` does satisfy `p` -/
-theorem splitOnP_first (h : ∀ x ∈ xs, ¬p x) (sep : α) (hsep : p sep) (as : List α) :
+theorem splitOnP_first (h : ∀ x ∈ xs, ¬p x) (sep : α) (hsep : p sep = true) (as : List α) :
     (xs ++ sep :: as).splitOnP p = xs :: as.splitOnP p := by
-  induction xs with
-  | nil => simp [hsep]
-  | cons hd tl ih => simp [h hd _, ih <| forall_mem_of_forall_mem_cons h]
+  rw [splitOnP_append_cons p xs as sep hsep, splitOnP_eq_single p xs h]
+  rfl
 
 /-- `intercalate [x]` is the left inverse of `splitOn x` -/
 theorem intercalate_splitOn (x : α) [DecidableEq α] : [x].intercalate (xs.splitOn x) = xs := by


### PR DESCRIPTION
This PR adds a lemma for `splitOnP`, allowing expressions where a `splitOnP` on a concatenation to be better simplified. Also golfs a relevant consequence with the new lemma.

Related to https://github.com/google-deepmind/formal-conjectures/pull/1120

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

When merging, all the commits will be squashed into a single commit
listing all co-authors.

Co-authors in the squash commit are gathered from two sources:

First, all authors of commits to this PR branch are included. Thus,
one way to add co-authors is to include at least one commit authored by
each co-author among the commits in the pull request. If necessary, you
may create empty commits to indicate co-authorship, using commands like so:

git commit --author="Author Name <author@email.com>" --allow-empty -m "add Author Name as coauthor"

Second, co-authors can also be listed in lines at the very bottom of
the commit message (that is, directly before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines
at the bottom of the commit message (before the `---`, and also before
any "Co-authored-by" lines) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
