### PR TITLE
[Merged by Bors] - ci(check_pr_titles.yaml): fix handling of labels

### DIFF
--- a/.github/workflows/check_pr_titles.yaml
+++ b/.github/workflows/check_pr_titles.yaml
@@ -33,6 +33,7 @@ jobs:
         if: github.event.pull_request.draft == false && github.event.pull_request.base.ref == 'master'
         env:
           TITLE: ${{ github.event.pull_request.title }}
+          PR_LABELS: ${{ toJson(github.event.pull_request.labels) }}
         run: |
           set -o pipefail
           echo "$TITLE"
@@ -43,7 +44,7 @@ jobs:
             exit 0
           fi
 
-          label_names=$(echo "${{ toJson(github.event.pull_request.labels) }}" | jq -r '.[].name')
+          label_names=$(echo "$PR_LABELS" | jq -r '.[].name')
           echo "$label_names"
 
           # build command so build lines don't pollute `output` below


### PR DESCRIPTION
The substitution with `${{ }}` breaks when the PR labels object has multiple lines.

cf. [error](https://github.com/leanprover-community/mathlib4/actions/runs/19515906969/job/55867457030#step:4:49) caused by [malformed script](https://github.com/leanprover-community/mathlib4/actions/runs/19515906969/job/55867457030#step:4:11 )

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

When merging, all the commits will be squashed into a single commit
listing all co-authors.

Co-authors in the squash commit are gathered from two sources:

First, all authors of commits to this PR branch are included. Thus,
one way to add co-authors is to include at least one commit authored by
each co-author among the commits in the pull request. If necessary, you
may create empty commits to indicate co-authorship, using commands like so:

git commit --author="Author Name <author@email.com>" --allow-empty -m "add Author Name as coauthor"

Second, co-authors can also be listed in lines at the very bottom of
the commit message (that is, directly before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines
at the bottom of the commit message (before the `---`, and also before
any "Co-authored-by" lines) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
