### PR TITLE
[Merged by Bors] - chore: remove unused `Decidable*` instances in theorem types

### DIFF
--- a/Archive/Wiedijk100Theorems/Partition.lean
+++ b/Archive/Wiedijk100Theorems/Partition.lean
@@ -97,11 +97,11 @@ theorem coeff_indicator (s : Set ℕ) [Semiring α] (n : ℕ) [Decidable (n ∈ 
     coeff n (indicatorSeries α s) = if n ∈ s then 1 else 0 := by
   convert coeff_mk _ _
 
-theorem coeff_indicator_pos (s : Set ℕ) [Semiring α] (n : ℕ) (h : n ∈ s) [Decidable (n ∈ s)] :
-    coeff n (indicatorSeries α s) = 1 := by rw [coeff_indicator, if_pos h]
+theorem coeff_indicator_pos (s : Set ℕ) [Semiring α] (n : ℕ) (h : n ∈ s) :
+    coeff n (indicatorSeries α s) = 1 := by classical rw [coeff_indicator, if_pos h]
 
-theorem coeff_indicator_neg (s : Set ℕ) [Semiring α] (n : ℕ) (h : n ∉ s) [Decidable (n ∈ s)] :
-    coeff n (indicatorSeries α s) = 0 := by rw [coeff_indicator, if_neg h]
+theorem coeff_indicator_neg (s : Set ℕ) [Semiring α] (n : ℕ) (h : n ∉ s) :
+    coeff n (indicatorSeries α s) = 0 := by classical rw [coeff_indicator, if_neg h]
 
 theorem constantCoeff_indicator (s : Set ℕ) [Semiring α] [Decidable (0 ∈ s)] :
     constantCoeff (indicatorSeries α s) = if 0 ∈ s then 1 else 0 := by

--- a/Mathlib/Algebra/GCDMonoid/Basic.lean
+++ b/Mathlib/Algebra/GCDMonoid/Basic.lean
@@ -956,7 +956,7 @@ open Associates
 
 variable [CancelCommMonoidWithZero α]
 
-private theorem map_mk_unit_aux [DecidableEq α] {f : Associates α →* α}
+private theorem map_mk_unit_aux {f : Associates α →* α}
     (hinv : Function.RightInverse f Associates.mk) (a : α) :
     a * ↑(Classical.choose (associated_map_mk hinv a)) = f (Associates.mk a) :=
   Classical.choose_spec (associated_map_mk hinv a)

--- a/Mathlib/Algebra/Homology/Homotopy.lean
+++ b/Mathlib/Algebra/Homology/Homotopy.lean
@@ -805,9 +805,10 @@ noncomputable def Homotopy.toShortComplex (ho : Homotopy f g) (i : ι) :
       rw [congr_arg (fun j => ho.hom (c.next i) j ≫ L.d j (c.next i)) (c.prev_eq' h)]
     · abel
 
+omit [DecidableRel c.Rel]
 lemma Homotopy.homologyMap_eq (ho : Homotopy f g) (i : ι) [K.HasHomology i] [L.HasHomology i] :
     homologyMap f i = homologyMap g i :=
-  ShortComplex.Homotopy.homologyMap_congr (ho.toShortComplex i)
+  open scoped Classical in ShortComplex.Homotopy.homologyMap_congr (ho.toShortComplex i)
 
 /-- The isomorphism in homology induced by an homotopy equivalence. -/
 noncomputable def HomotopyEquiv.toHomologyIso (h : HomotopyEquiv K L) (i : ι)

--- a/Mathlib/Algebra/Homology/HomotopyCofiber.lean
+++ b/Mathlib/Algebra/Homology/HomotopyCofiber.lean
@@ -340,6 +340,7 @@ lemma eq_desc (f : homotopyCofiber φ ⟶ K) (hc : ∀ j, ∃ i, c.Rel i j) :
 
 end
 
+omit [DecidableRel c.Rel] in
 lemma descSigma_ext_iff {φ : F ⟶ G} {K : HomologicalComplex C c}
     (x y : Σ (α : G ⟶ K), Homotopy (φ ≫ α) 0) :
     x = y ↔ x.1 = y.1 ∧ (∀ (i j : ι) (_ : c.Rel j i), x.2.hom i j = y.2.hom i j) := by
@@ -543,6 +544,7 @@ end
 
 end cylinder
 
+omit [DecidableRel c.Rel] in
 /-- If a functor inverts homotopy equivalences, it sends homotopic maps to the same map. -/
 lemma _root_.Homotopy.map_eq_of_inverts_homotopyEquivalences
     {φ₀ φ₁ : F ⟶ G} (h : Homotopy φ₀ φ₁) (hc : ∀ j, ∃ i, c.Rel i j)
@@ -551,6 +553,7 @@ lemma _root_.Homotopy.map_eq_of_inverts_homotopyEquivalences
     {D : Type*} [Category D] (H : HomologicalComplex C c ⥤ D)
     (hH : (homotopyEquivalences C c).IsInvertedBy H) :
     H.map φ₀ = H.map φ₁ := by
+  classical
   simp only [← cylinder.ι₀_desc _ _ h, ← cylinder.ι₁_desc _ _ h, H.map_comp,
     cylinder.map_ι₀_eq_map_ι₁ _ hc _ hH]
 

--- a/Mathlib/Algebra/Polynomial/Roots.lean
+++ b/Mathlib/Algebra/Polynomial/Roots.lean
@@ -831,8 +831,9 @@ theorem card_roots_map_le_natDegree {A B : Type*} [Semiring A] [CommRing B] [IsD
   card_roots' _ |>.trans natDegree_map_le
 
 theorem filter_roots_map_range_eq_map_roots [IsDomain A] [IsDomain B] {f : A →+* B}
-    [DecidableEq A] [DecidableEq B] [DecidablePred (· ∈ f.range)] (hf : Function.Injective f)
+    [DecidablePred (· ∈ f.range)] (hf : Function.Injective f)
     (p : A[X]) : (p.map f).roots.filter (· ∈ f.range) = p.roots.map f := by
+  classical
   ext b
   rw [Multiset.count_filter]
   split_ifs with h

--- a/Mathlib/Analysis/AbsoluteValue/Equivalence.lean
+++ b/Mathlib/Analysis/AbsoluteValue/Equivalence.lean
@@ -163,7 +163,7 @@ open scoped Topology
 
 variable {R S : Type*} [Field R] [Field S] [LinearOrder S] {v w : AbsoluteValue R S}
   [TopologicalSpace S] [IsStrictOrderedRing S] [Archimedean S] [OrderTopology S]
-  {ι : Type*} [Fintype ι] [DecidableEq ι] {v : ι → AbsoluteValue R S} {w : AbsoluteValue R S}
+  {ι : Type*} [Fintype ι] {v : ι → AbsoluteValue R S} {w : AbsoluteValue R S}
   {a b : R} {i : ι}
 
 /--
@@ -179,6 +179,7 @@ each `v j` for `j ≠ i`.
 private theorem exists_one_lt_lt_one_pi_of_eq_one (ha : 1 < v i a) (haj : ∀ j ≠ i, v j a < 1)
     (haw : w a = 1) (hb : 1 < v i b) (hbw : w b < 1) :
     ∃ k : R, 1 < v i k ∧ (∀ j ≠ i, v j k < 1) ∧ w k < 1 := by
+  classical
   let c : ℕ → R := fun n ↦ a ^ n * b
   have hcᵢ : Tendsto (fun n ↦ (v i) (c n)) atTop atTop := by
     simpa [c] using Tendsto.atTop_mul_const (by linarith) (tendsto_pow_atTop_atTop_of_one_lt ha)
@@ -206,6 +207,7 @@ each `v j` for `j ≠ i`.
 private theorem exists_one_lt_lt_one_pi_of_one_lt (ha : 1 < v i a) (haj : ∀ j ≠ i, v j a < 1)
     (haw : 1 < w a) (hb : 1 < v i b) (hbw : w b < 1) :
     ∃ k : R, 1 < v i k ∧ (∀ j ≠ i, v j k < 1) ∧ w k < 1 := by
+  classical
   let c : ℕ → R := fun n ↦ 1 / (1 + a⁻¹ ^ n) * b
   have hcᵢ : Tendsto (fun n ↦ v i (c n)) atTop (𝓝 (v i b)) := by
     have : v i a⁻¹ < 1 := map_inv₀ (v i) a ▸ inv_lt_one_of_one_lt₀ ha
@@ -239,12 +241,13 @@ absolute values, then for any `i` there is some `a : R` such that `1 < v i a` an
 theorem exists_one_lt_lt_one_pi_of_not_isEquiv (h : ∀ i, (v i).IsNontrivial)
     (hv : Pairwise fun i j ↦ ¬(v i).IsEquiv (v j)) :
     ∀ i, ∃ (a : R), 1 < v i a ∧ ∀ j ≠ i, v j a < 1 := by
-  let P (ι : Type _) [Fintype ι] : Prop := [DecidableEq ι] →
+  classical
+  let P (ι : Type _) [Fintype ι] : Prop :=
     ∀ v : ι → AbsoluteValue R S, (∀ i, (v i).IsNontrivial) →
       (Pairwise fun i j ↦ ¬(v i).IsEquiv (v j)) → ∀ i, ∃ (a : R), 1 < v i a ∧ ∀ j ≠ i, v j a < 1
   -- Use strong induction on the index.
-  revert hv h; refine induction_subsingleton_or_nontrivial (P := P) ι (fun ι _ _ _ v h hv i ↦ ?_)
-    (fun ι _ _ ih _ v h hv i ↦ ?_) v
+  revert hv h; refine induction_subsingleton_or_nontrivial (P := P) ι (fun ι _ _ v h hv i ↦ ?_)
+    (fun ι _ _ ih v h hv i ↦ ?_) v
   · -- If `ι` is trivial this follows immediately from `(v i).IsNontrivial`.
     let ⟨a, ha⟩ := (h i).exists_abv_gt_one
     exact ⟨a, ha, fun j hij ↦ absurd (Subsingleton.elim i j) hij.symm⟩

--- a/Mathlib/Analysis/InnerProductSpace/TensorProduct.lean
+++ b/Mathlib/Analysis/InnerProductSpace/TensorProduct.lean
@@ -442,10 +442,11 @@ open Module
 /-- The tensor product of two orthonormal vectors is orthonormal. -/
 theorem Orthonormal.tmul
     {b₁ : ι₁ → E} {b₂ : ι₂ → F} (hb₁ : Orthonormal 𝕜 b₁) (hb₂ : Orthonormal 𝕜 b₂) :
-    Orthonormal 𝕜 fun i : ι₁ × ι₂ ↦ b₁ i.1 ⊗ₜ[𝕜] b₂ i.2 :=
-  open scoped Classical in orthonormal_iff_ite.mpr fun ⟨i₁, i₂⟩ ⟨j₁, j₂⟩ => by
-    classical
-    simp [orthonormal_iff_ite.mp, hb₁, hb₂, ← ite_and, and_comm]
+    Orthonormal 𝕜 fun i : ι₁ × ι₂ ↦ b₁ i.1 ⊗ₜ[𝕜] b₂ i.2 := by
+  classical
+  rw [orthonormal_iff_ite]
+  rintro ⟨i₁, i₂⟩ ⟨j₁, j₂⟩
+  simp [orthonormal_iff_ite.mp, hb₁, hb₂, ← ite_and, and_comm]
 
 /-- The tensor product of two orthonormal bases is orthonormal. -/
 theorem Orthonormal.basisTensorProduct

--- a/Mathlib/Analysis/InnerProductSpace/TensorProduct.lean
+++ b/Mathlib/Analysis/InnerProductSpace/TensorProduct.lean
@@ -435,7 +435,7 @@ theorem ext_iff_inner_left_threefold' {x y : E ⊗[𝕜] (F ⊗[𝕜] G)} :
 end TensorProduct
 
 section orthonormal
-variable {ι₁ ι₂ : Type*} [DecidableEq ι₁] [DecidableEq ι₂]
+variable {ι₁ ι₂ : Type*}
 
 open Module
 
@@ -443,7 +443,8 @@ open Module
 theorem Orthonormal.tmul
     {b₁ : ι₁ → E} {b₂ : ι₂ → F} (hb₁ : Orthonormal 𝕜 b₁) (hb₂ : Orthonormal 𝕜 b₂) :
     Orthonormal 𝕜 fun i : ι₁ × ι₂ ↦ b₁ i.1 ⊗ₜ[𝕜] b₂ i.2 :=
-  orthonormal_iff_ite.mpr fun ⟨i₁, i₂⟩ ⟨j₁, j₂⟩ => by
+  open scoped Classical in orthonormal_iff_ite.mpr fun ⟨i₁, i₂⟩ ⟨j₁, j₂⟩ => by
+    classical
     simp [orthonormal_iff_ite.mp, hb₁, hb₂, ← ite_and, and_comm]
 
 /-- The tensor product of two orthonormal bases is orthonormal. -/

--- a/Mathlib/Combinatorics/SimpleGraph/Bipartite.lean
+++ b/Mathlib/Combinatorics/SimpleGraph/Bipartite.lean
@@ -142,11 +142,15 @@ theorem isBipartiteWith_neighborSet_disjoint' (h : G.IsBipartiteWith s t) (hw : 
     Disjoint (G.neighborSet w) t :=
   Set.disjoint_of_subset_left (isBipartiteWith_neighborSet_subset' h hw) h.disjoint
 
-variable {s t : Finset V} [DecidableRel G.Adj]
+variable {s t : Finset V}
 
 section
 
 variable [Fintype ↑(G.neighborSet v)] [Fintype ↑(G.neighborSet w)]
+
+section decidableRel
+
+variable [DecidableRel G.Adj]
 
 /-- If `G.IsBipartiteWith s t` and `v ∈ s`, then the neighbor finset of `v` is the set of vertices
 in `s` adjacent to `v` in `G`. -/
@@ -156,19 +160,35 @@ theorem isBipartiteWith_neighborFinset (h : G.IsBipartiteWith s t) (hv : v ∈ s
   rw [mem_neighborFinset, mem_filter, iff_and_self]
   exact h.mem_of_mem_adj hv
 
+/-- If `G.IsBipartiteWith s t` and `w ∈ t`, then the neighbor finset of `w` is the set of vertices
+in `s` adjacent to `w` in `G`. -/
+theorem isBipartiteWith_neighborFinset' (h : G.IsBipartiteWith s t) (hw : w ∈ t) :
+    G.neighborFinset w = { v ∈ s | G.Adj v w } := by
+  ext v
+  rw [mem_neighborFinset, adj_comm, mem_filter, iff_and_self]
+  exact h.mem_of_mem_adj' hw
+
 /-- If `G.IsBipartiteWith s t` and `v ∈ s`, then the neighbor finset of `v` is the set of vertices
 "above" `v` according to the adjacency relation of `G`. -/
 theorem isBipartiteWith_bipartiteAbove (h : G.IsBipartiteWith s t) (hv : v ∈ s) :
     G.neighborFinset v = bipartiteAbove G.Adj t v := by
   rw [isBipartiteWith_neighborFinset h hv, bipartiteAbove]
 
+/-- If `G.IsBipartiteWith s t` and `w ∈ t`, then the neighbor finset of `w` is the set of vertices
+"below" `w` according to the adjacency relation of `G`. -/
+theorem isBipartiteWith_bipartiteBelow (h : G.IsBipartiteWith s t) (hw : w ∈ t) :
+    G.neighborFinset w = bipartiteBelow G.Adj s w := by
+  rw [isBipartiteWith_neighborFinset' h hw, bipartiteBelow]
+
+end decidableRel
+
 /-- If `G.IsBipartiteWith s t` and `v ∈ s`, then the neighbor finset of `v` is a subset of `s`. -/
 theorem isBipartiteWith_neighborFinset_subset (h : G.IsBipartiteWith s t) (hv : v ∈ s) :
     G.neighborFinset v ⊆ t := by
+  classical
   rw [isBipartiteWith_neighborFinset h hv]
   exact filter_subset (G.Adj v ·) t
 
-omit [DecidableRel G.Adj] in
 /-- If `G.IsBipartiteWith s t` and `v ∈ s`, then the neighbor finset of `v` is disjoint to `s`. -/
 theorem isBipartiteWith_neighborFinset_disjoint (h : G.IsBipartiteWith s t) (hv : v ∈ s) :
     Disjoint (G.neighborFinset v) s := by
@@ -181,27 +201,13 @@ theorem isBipartiteWith_degree_le (h : G.IsBipartiteWith s t) (hv : v ∈ s) : G
   rw [← card_neighborFinset_eq_degree]
   exact card_le_card (isBipartiteWith_neighborFinset_subset h hv)
 
-/-- If `G.IsBipartiteWith s t` and `w ∈ t`, then the neighbor finset of `w` is the set of vertices
-in `s` adjacent to `w` in `G`. -/
-theorem isBipartiteWith_neighborFinset' (h : G.IsBipartiteWith s t) (hw : w ∈ t) :
-    G.neighborFinset w = { v ∈ s | G.Adj v w } := by
-  ext v
-  rw [mem_neighborFinset, adj_comm, mem_filter, iff_and_self]
-  exact h.mem_of_mem_adj' hw
-
-/-- If `G.IsBipartiteWith s t` and `w ∈ t`, then the neighbor finset of `w` is the set of vertices
-"below" `w` according to the adjacency relation of `G`. -/
-theorem isBipartiteWith_bipartiteBelow (h : G.IsBipartiteWith s t) (hw : w ∈ t) :
-    G.neighborFinset w = bipartiteBelow G.Adj s w := by
-  rw [isBipartiteWith_neighborFinset' h hw, bipartiteBelow]
-
 /-- If `G.IsBipartiteWith s t` and `w ∈ t`, then the neighbor finset of `w` is a subset of `s`. -/
 theorem isBipartiteWith_neighborFinset_subset' (h : G.IsBipartiteWith s t) (hw : w ∈ t) :
     G.neighborFinset w ⊆ s := by
+  classical
   rw [isBipartiteWith_neighborFinset' h hw]
   exact filter_subset (G.Adj · w) s
 
-omit [DecidableRel G.Adj] in
 /-- If `G.IsBipartiteWith s t` and `w ∈ t`, then the neighbor finset of `w` is disjoint to `t`. -/
 theorem isBipartiteWith_neighborFinset_disjoint' (h : G.IsBipartiteWith s t) (hw : w ∈ t) :
     Disjoint (G.neighborFinset w) t := by
@@ -222,6 +228,7 @@ of the degrees of vertices in `t`.
 See `Finset.sum_card_bipartiteAbove_eq_sum_card_bipartiteBelow`. -/
 theorem isBipartiteWith_sum_degrees_eq [G.LocallyFinite] (h : G.IsBipartiteWith s t) :
     ∑ v ∈ s, G.degree v = ∑ w ∈ t, G.degree w := by
+  classical
   simp_rw [← sum_attach t, ← sum_attach s, ← card_neighborFinset_eq_degree]
   conv_lhs =>
     rhs; intro v
@@ -233,7 +240,7 @@ theorem isBipartiteWith_sum_degrees_eq [G.LocallyFinite] (h : G.IsBipartiteWith 
     sum_attach t fun v ↦ #(bipartiteBelow G.Adj s v)]
   exact sum_card_bipartiteAbove_eq_sum_card_bipartiteBelow G.Adj
 
-variable [Fintype V]
+variable [Fintype V] [DecidableRel G.Adj]
 
 lemma isBipartiteWith_sum_degrees_eq_twice_card_edges [DecidableEq V] (h : G.IsBipartiteWith s t) :
     ∑ v ∈ s ∪ t, G.degree v = 2 * #G.edgeFinset := by

--- a/Mathlib/Combinatorics/SimpleGraph/Coloring.lean
+++ b/Mathlib/Combinatorics/SimpleGraph/Coloring.lean
@@ -430,8 +430,9 @@ theorem chromaticNumber_top_eq_top_of_infinite (V : Type*) [Infinite V] :
   obtain ⟨n, ⟨hn⟩⟩ := hc
   exact not_injective_infinite_finite _ hn.injective_of_top_hom
 
-theorem eq_top_of_chromaticNumber_eq_card [DecidableEq V] [Fintype V]
+theorem eq_top_of_chromaticNumber_eq_card [Fintype V]
     (h : G.chromaticNumber = Fintype.card V) : G = ⊤ := by
+  classical
   by_contra! hh
   have : G.chromaticNumber ≤ Fintype.card V - 1 := by
     obtain ⟨a, b, hne, _⟩ := ne_top_iff_exists_not_adj.mp hh
@@ -443,7 +444,7 @@ theorem eq_top_of_chromaticNumber_eq_card [DecidableEq V] [Fintype V]
   have := Fintype.one_lt_card_iff_nontrivial.mpr <| SimpleGraph.nontrivial_iff.mp ⟨_, _, hh⟩
   grind
 
-theorem chromaticNumber_eq_card_iff [DecidableEq V] [Fintype V] :
+theorem chromaticNumber_eq_card_iff [Fintype V] :
     G.chromaticNumber = Fintype.card V ↔ G = ⊤ :=
   ⟨eq_top_of_chromaticNumber_eq_card, fun h ↦ h ▸ chromaticNumber_top⟩
 

--- a/Mathlib/Combinatorics/SimpleGraph/FiveWheelLike.lean
+++ b/Mathlib/Combinatorics/SimpleGraph/FiveWheelLike.lean
@@ -228,9 +228,12 @@ lemma exists_max_isFiveWheelLike_of_maximal_cliqueFree_not_isCompleteMultipartit
 lemma CliqueFree.fiveWheelLikeFree_of_le (h : G.CliqueFree (r + 2)) (hk : r ≤ k) :
     G.FiveWheelLikeFree r k := fun hw ↦ (hw.card_inter_lt_of_cliqueFree h).not_ge hk
 
+end withDecEq
+
 /-- A maximally `Kᵣ₊₁`-free graph is `r`-colorable iff it is complete-multipartite. -/
 theorem colorable_iff_isCompleteMultipartite_of_maximal_cliqueFree
     (h : Maximal (fun H => H.CliqueFree (r + 1)) G) : G.Colorable r ↔ G.IsCompleteMultipartite := by
+  classical
   match r with
   | 0 => exact ⟨fun _ ↦ fun x ↦ cliqueFree_one.1 h.1 |>.elim' x,
                 fun _ ↦ G.colorable_zero_iff.2 <| cliqueFree_one.1 h.1⟩
@@ -240,8 +243,6 @@ theorem colorable_iff_isCompleteMultipartite_of_maximal_cliqueFree
     obtain ⟨_, _, _, _, _, hw⟩ :=
       exists_isFiveWheelLike_of_maximal_cliqueFree_not_isCompleteMultipartite h hc
     exact hw.not_colorable_succ
-
-end withDecEq
 
 section AES
 variable {i j n : ℕ} {d x v w₁ w₂ : α} {s t : Finset α}
@@ -422,6 +423,7 @@ is `2`-colorable.
 theorem colorable_of_cliqueFree_lt_minDegree [Fintype α] [DecidableRel G.Adj]
     (hf : G.CliqueFree (r + 1)) (hd : (3 * r - 4) * ‖α‖ / (3 * r - 1) < G.minDegree) :
     G.Colorable r := by
+  classical
   match r with
   | 0 | 1 => aesop
   | r + 2 =>

--- a/Mathlib/Combinatorics/SimpleGraph/FiveWheelLike.lean
+++ b/Mathlib/Combinatorics/SimpleGraph/FiveWheelLike.lean
@@ -412,8 +412,6 @@ lemma minDegree_le_of_cliqueFree_fiveWheelLikeFree_succ [Fintype α]
 
 end IsFiveWheelLike
 
-variable [DecidableEq α]
-
 /-- **Andrasfái-Erdős-Sós** theorem
 
 If `G` is a `Kᵣ₊₁`-free graph with `n` vertices and `(3 * r - 4) * n / (3 * r - 1) < G.minDegree`
@@ -423,10 +421,10 @@ is `2`-colorable.
 theorem colorable_of_cliqueFree_lt_minDegree [Fintype α] [DecidableRel G.Adj]
     (hf : G.CliqueFree (r + 1)) (hd : (3 * r - 4) * ‖α‖ / (3 * r - 1) < G.minDegree) :
     G.Colorable r := by
-  classical
   match r with
   | 0 | 1 => aesop
   | r + 2 =>
+    classical
     -- There is an edge maximal `Kᵣ₊₃`-free supergraph `H` of `G`
     obtain ⟨H, hle, hmcf⟩ := @Finite.exists_le_maximal _ _ _ (fun H ↦ H.CliqueFree (r + 3)) G hf
     -- If `H` is `r + 2`-colorable then so is `G`
@@ -438,7 +436,6 @@ theorem colorable_of_cliqueFree_lt_minDegree [Fintype α] [DecidableRel G.Adj]
     -- Hence `H` contains `Wᵣ₊₁,ₖ` but not `Wᵣ₊₁,ₖ₊₁`, for some `k < r + 1`
     obtain ⟨k, _, _, _, _, _, hw, hlt, hm⟩ :=
       exists_max_isFiveWheelLike_of_maximal_cliqueFree_not_isCompleteMultipartite hmcf hn
-    classical
     -- But the minimum degree of `G`, and hence of `H`, is too large for it to be `Wᵣ₊₁,ₖ₊₁`-free,
     -- a contradiction.
     have hD := hw.minDegree_le_of_cliqueFree_fiveWheelLikeFree_succ hmcf.1 <| hm _ <| lt_add_one _

--- a/Mathlib/Combinatorics/SimpleGraph/Hall.lean
+++ b/Mathlib/Combinatorics/SimpleGraph/Hall.lean
@@ -53,14 +53,15 @@ abbrev hall_subgraph {p : Set V} [DecidablePred (· ∈ p)] (f : p → V) (h₁ 
   edge_vert {v w} := by grind
   symm {x y} := by grind
 
-variable [DecidableEq V] [G.LocallyFinite] {p₁ p₂ : Set V}
+variable [G.LocallyFinite] {p₁ p₂ : Set V}
 
 /-- This is the version of **Hall's marriage theorem** for bipartite graphs that finds a matching
 for a single partition given that the neighborhood-condition only holds for elements of that
 partition. -/
-theorem exists_isMatching_of_forall_ncard_le [DecidablePred (· ∈ p₁)] (h₁ : G.IsBipartiteWith p₁ p₂)
+theorem exists_isMatching_of_forall_ncard_le (h₁ : G.IsBipartiteWith p₁ p₂)
     (h₂ : ∀ s ⊆ p₁, s.ncard ≤ (⋃ x ∈ s, G.neighborSet x).ncard) :
     ∃ M : Subgraph G, p₁ ⊆ M.verts ∧ M.IsMatching := by
+  classical
   obtain ⟨f, hf₁, hf₂⟩ := Finset.all_card_le_biUnion_card_iff_exists_injective
       (fun (x : p₁) ↦ G.neighborFinset x) |>.mp fun s ↦ by
     have := h₂ (s.image Subtype.val) (by simp)
@@ -80,6 +81,7 @@ theorem exists_isMatching_of_forall_ncard_le [DecidablePred (· ∈ p₁)] (h₁
 
 lemma union_eq_univ_of_forall_ncard_le (h₁ : G.IsBipartiteWith p₁ p₂)
     (h₂ : ∀ s : Set V, s.ncard ≤ (⋃ x ∈ s, G.neighborSet x).ncard) : p₁ ∪ p₂ = Set.univ := by
+  classical
   obtain ⟨f, _, hf₂⟩ := Finset.all_card_le_biUnion_card_iff_exists_injective
       (fun x ↦ G.neighborFinset x) |>.mp fun s ↦ by
     have := h₂ s
@@ -91,6 +93,7 @@ lemma union_eq_univ_of_forall_ncard_le (h₁ : G.IsBipartiteWith p₁ p₂)
 lemma exists_bijective_of_forall_ncard_le (h₁ : G.IsBipartiteWith p₁ p₂)
     (h₂ : ∀ s : Set V, s.ncard ≤ (⋃ x ∈ s, G.neighborSet x).ncard) :
     ∃ (h : p₁ → p₂), Function.Bijective h ∧ ∀ (a : p₁), G.Adj a (h a) := by
+  classical
   obtain ⟨f, hf₁, hf₂⟩ := Finset.all_card_le_biUnion_card_iff_exists_injective
       (fun x ↦ G.neighborFinset x) |>.mp fun s ↦ by
     have := h₂ s
@@ -111,9 +114,10 @@ lemma exists_bijective_of_forall_ncard_le (h₁ : G.IsBipartiteWith p₁ p₂)
 
 /-- This is the version of **Hall's marriage theorem** for bipartite graphs that finds a perfect
 matching given that the neighborhood-condition holds globally. -/
-theorem exists_isPerfectMatching_of_forall_ncard_le [DecidablePred (· ∈ p₁)]
+theorem exists_isPerfectMatching_of_forall_ncard_le
     (h₁ : G.IsBipartiteWith p₁ p₂) (h₂ : ∀ s : Set V, s.ncard ≤ (⋃ x ∈ s, G.neighborSet x).ncard) :
     ∃ M : Subgraph G, M.IsPerfectMatching := by
+  classical
   obtain ⟨b, hb₁, hb₂⟩ := exists_bijective_of_forall_ncard_le h₁ h₂
   use hall_subgraph (fun v ↦ b v) (fun v ↦ h₁.disjoint.notMem_of_mem_right (b v).property) hb₂
   have : p₁ ∪ Set.range (fun v ↦ (b v).1) = Set.univ := by

--- a/Mathlib/Data/Finset/Grade.lean
+++ b/Mathlib/Data/Finset/Grade.lean
@@ -106,8 +106,9 @@ variable [DecidableEq α]
 lemma covBy_insert (ha : a ∉ s) : s ⋖ insert a s :=
   (wcovBy_insert _ _).covBy_of_lt <| ssubset_insert ha
 
+omit [DecidableEq α] in
 @[simp] lemma empty_covBy_singleton (a : α) : ∅ ⋖ ({a} : Finset α) :=
-  insert_empty_eq (β := Finset α) a ▸ covBy_insert <| notMem_empty a
+  by classical exact insert_empty_eq (β := Finset α) a ▸ covBy_insert <| notMem_empty a
 
 @[simp] lemma erase_covBy (ha : a ∈ s) : s.erase a ⋖ s := ⟨erase_ssubset ha, (erase_wcovBy _ _).2⟩
 

--- a/Mathlib/Data/List/Sigma.lean
+++ b/Mathlib/Data/List/Sigma.lean
@@ -235,8 +235,10 @@ theorem dlookup_map₂ {γ δ : α → Type*} {l : List (Σ a, γ a)} {f : ∀ a
     (l.map (.map id f) : List (Σ a, δ a)).dlookup a = (l.dlookup a).map (f a) :=
   dlookup_map l Function.injective_id _ _
 
+omit [DecidableEq α] [DecidableEq α'] in
 theorem NodupKeys.map₁ {β : Type v} (f : α → α') (hf : Function.Injective f) {l : List (Σ _ : α, β)}
     (nd : l.NodupKeys) : (l.map (.map f fun _ => id) : List (Σ _ : α', β)).NodupKeys := by
+  classical
   induction l with
   | nil => grind [nodupKeys_nil]
   | cons hd tl =>

--- a/Mathlib/GroupTheory/Perm/Cycle/Factors.lean
+++ b/Mathlib/GroupTheory/Perm/Cycle/Factors.lean
@@ -183,8 +183,9 @@ theorem cycleOf_mul_of_apply_right_eq_self [DecidableRel f.SameCycle]
     simp [h.mul_zpow, zpow_apply_eq_self_of_apply_eq_self hx]
 
 theorem Disjoint.cycleOf_mul_distrib [DecidableRel f.SameCycle] [DecidableRel g.SameCycle]
-    [DecidableRel (f * g).SameCycle] [DecidableRel (g * f).SameCycle] (h : f.Disjoint g) (x : α) :
+    [DecidableRel (f * g).SameCycle] (h : f.Disjoint g) (x : α) :
     (f * g).cycleOf x = f.cycleOf x * g.cycleOf x := by
+  classical
   rcases (disjoint_iff_eq_or_eq.mp h) x with hfx | hgx
   · simp [h.commute.eq, cycleOf_mul_of_apply_right_eq_self h.symm.commute, hfx]
   · simp [cycleOf_mul_of_apply_right_eq_self h.commute, hgx]

--- a/Mathlib/LinearAlgebra/DFinsupp.lean
+++ b/Mathlib/LinearAlgebra/DFinsupp.lean
@@ -572,9 +572,11 @@ theorem iSupIndep_iff_dfinsupp_lsum_injective (p : ι → Submodule R N) :
     iSupIndep p ↔ Function.Injective (lsum ℕ fun i => (p i).subtype) :=
   ⟨iSupIndep.dfinsupp_lsum_injective, iSupIndep_of_dfinsupp_lsum_injective p⟩
 
+omit [DecidableEq ι] in
 theorem iSupIndep_iff_finset_sum_eq_zero_imp_eq_zero (p : ι → Submodule R N) :
     iSupIndep p ↔ ∀ (s : Finset ι) (v : ι → N),
     (∀ i ∈ s, v i ∈ p i) → (∑ i ∈ s, v i = 0) → ∀ i ∈ s, v i = 0 := by
+  classical
   simp_rw [iSupIndep_def, Submodule.disjoint_def]
   constructor
   · intro h s v hv hv0 i hi
@@ -595,6 +597,7 @@ theorem iSupIndep_iff_finset_sum_eq_zero_imp_eq_zero (p : ι → Submodule R N) 
       simp at hf
       grind [Finsupp.sum, Finset.sum_congr, Finsupp.mem_support_iff]
 
+omit [DecidableEq ι] in
 theorem iSupIndep_iff_finset_sum_eq_imp_eq (p : ι → Submodule R N) :
     iSupIndep p ↔ ∀ (s : Finset ι) (v w : ι → N),
     (∀ i ∈ s, v i ∈ p i ∧ w i ∈ p i) → (∑ i ∈ s, v i = ∑ i ∈ s, w i) → ∀ i ∈ s, v i = w i := by

--- a/Mathlib/LinearAlgebra/RootSystem/GeckConstruction/Semisimple.lean
+++ b/Mathlib/LinearAlgebra/RootSystem/GeckConstruction/Semisimple.lean
@@ -147,9 +147,10 @@ lemma isNilpotent_f :
   | zero => simp
   | succ n ih => rw [pow_succ, pow_succ, ← mul_assoc, ih, mul_assoc, ω_mul_f, ← mul_assoc]
 
-omit [P.IsReduced] [IsDomain R] in
+omit [P.IsReduced] [IsDomain R] [DecidableEq ι] in
 @[simp] lemma trace_h_eq_zero :
     (h i).trace = 0 := by
+  classical
   letI _i := P.indexNeg
   suffices ∑ j, P.pairingIn ℤ j i = 0 by
     simp only [h_eq_diagonal, Matrix.trace_diagonal, Fintype.sum_sum_type, Finset.univ_eq_attach,

--- a/Mathlib/RepresentationTheory/FiniteIndex.lean
+++ b/Mathlib/RepresentationTheory/FiniteIndex.lean
@@ -35,7 +35,7 @@ namespace Rep
 open CategoryTheory Finsupp TensorProduct Representation
 
 variable {k G : Type u} [CommRing k] [Group G] {S : Subgroup G}
-  [inst : DecidableRel (QuotientGroup.rightRel S)] (A : Rep k S)
+  [DecidableRel (QuotientGroup.rightRel S)] (A : Rep k S)
 
 /-- Let `S ≤ G` be a subgroup and `(A, ρ)` a `k`-linear `S`-representation. Then given `g : G` and
 `a : A`, this is the function `G → A` sending `sg` to `ρ(s)(a)` for all `s : S` and everything else

--- a/Mathlib/RepresentationTheory/FiniteIndex.lean
+++ b/Mathlib/RepresentationTheory/FiniteIndex.lean
@@ -35,7 +35,7 @@ namespace Rep
 open CategoryTheory Finsupp TensorProduct Representation
 
 variable {k G : Type u} [CommRing k] [Group G] {S : Subgroup G}
-  [DecidableRel (QuotientGroup.rightRel S)] (A : Rep k S)
+  [inst : DecidableRel (QuotientGroup.rightRel S)] (A : Rep k S)
 
 /-- Let `S ≤ G` be a subgroup and `(A, ρ)` a `k`-linear `S`-representation. Then given `g : G` and
 `a : A`, this is the function `G → A` sending `sg` to `ρ(s)(a)` for all `s : S` and everything else
@@ -188,8 +188,11 @@ noncomputable def indCoindNatIso : indFunctor k S.subtype ≅ coindFunctor k S.s
 noncomputable def resIndAdjunction : Action.res _ S.subtype ⊣ indFunctor k S.subtype :=
   (resCoindAdjunction k S.subtype).ofNatIsoRight (indCoindNatIso k S).symm
 
-noncomputable instance : (indFunctor k S.subtype).IsRightAdjoint :=
-  (resIndAdjunction k S).isRightAdjoint
+omit [DecidableRel (QuotientGroup.rightRel S)] in
+@[instance] -- Note: we must use `@[instance] theorem` here due to [lean4#5595](https://github.com/leanprover/lean4/issues/5595).
+theorem instIsRightAdjointSubtypeMemSubgroupIndFunctorSubtype :
+    (indFunctor k S.subtype).IsRightAdjoint :=
+  open scoped Classical in (resIndAdjunction k S).isRightAdjoint
 
 variable {k S}
 
@@ -225,8 +228,11 @@ variable (k S) in
 noncomputable def coindResAdjunction : coindFunctor k S.subtype ⊣ Action.res _ S.subtype :=
   (indResAdjunction k S.subtype).ofNatIsoLeft (indCoindNatIso k S)
 
-noncomputable instance : (coindFunctor k S.subtype).IsLeftAdjoint :=
-  (coindResAdjunction k S).isLeftAdjoint
+omit [DecidableRel (QuotientGroup.rightRel S)] in
+@[instance] -- Note: we must use `@[instance] theorem` here due to [lean4#5595](https://github.com/leanprover/lean4/issues/5595).
+theorem instIsLeftAdjointSubtypeMemSubgroupCoindFunctorSubtype :
+    (coindFunctor k S.subtype).IsLeftAdjoint :=
+  open scoped Classical in (coindResAdjunction k S).isLeftAdjoint
 
 @[simp]
 lemma coindResAdjunction_counit_app (B : Rep k G) :


### PR DESCRIPTION
This PR removes `Decidable*` instances that are not used by the remainder of a theorem's type and so can be replaced by `classical` in the proof (found by the  #31142). This allows us to turn on the `unusedDecidableInType` linter, which is done in #31747.

Notes:

- We rearrange the order of theorems slightly in [Mathlib/Combinatorics/SimpleGraph/Bipartite.lean](https://github.com/leanprover-community/mathlib4/pull/31747/files#diff-8acbd485d15b1e94a2afaf205ebedba12259361421342c715188192f1b0045f8) in order to put the ones that do require `DecidableRel` in a section.
- [lean4#5565](https://github.com/leanprover/lean4/issues/5595) forces us to change two `instance`s to `@[instance] theorem` because of a failure in `omit`. We preserve the autogenerated name here.

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

When merging, all the commits will be squashed into a single commit
listing all co-authors.

Co-authors in the squash commit are gathered from two sources:

First, all authors of commits to this PR branch are included. Thus,
one way to add co-authors is to include at least one commit authored by
each co-author among the commits in the pull request. If necessary, you
may create empty commits to indicate co-authorship, using commands like so:

git commit --author="Author Name <author@email.com>" --allow-empty -m "add Author Name as coauthor"

Second, co-authors can also be listed in lines at the very bottom of
the commit message (that is, directly before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines
at the bottom of the commit message (before the `---`, and also before
any "Co-authored-by" lines) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
