### PR TITLE
[Merged by Bors] - refactor(Geometry/Euclidean/Sphere/Tangent): split out `orthRadius`

### DIFF
--- a/Mathlib.lean
+++ b/Mathlib.lean
@@ -4043,6 +4043,7 @@ public import Mathlib.Geometry.Euclidean.Projection
 public import Mathlib.Geometry.Euclidean.SignedDist
 public import Mathlib.Geometry.Euclidean.Simplex
 public import Mathlib.Geometry.Euclidean.Sphere.Basic
+public import Mathlib.Geometry.Euclidean.Sphere.OrthRadius
 public import Mathlib.Geometry.Euclidean.Sphere.Power
 public import Mathlib.Geometry.Euclidean.Sphere.Ptolemy
 public import Mathlib.Geometry.Euclidean.Sphere.SecondInter

--- a/Mathlib/Geometry/Euclidean/Sphere/OrthRadius.lean
+++ b/Mathlib/Geometry/Euclidean/Sphere/OrthRadius.lean
@@ -1,0 +1,127 @@
+/-
+Copyright (c) 2025 Joseph Myers. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Joseph Myers
+-/
+module
+
+public import Mathlib.Analysis.InnerProductSpace.Projection.FiniteDimensional
+public import Mathlib.Geometry.Euclidean.Sphere.Basic
+
+/-!
+# Spaces orthogonal to the radius vector in spheres.
+
+This file defines the affine subspace orthogonal to the radius vector at a point.
+
+## Main definitions
+
+* `EuclideanGeometry.Sphere.orthRadius`: the affine subspace orthogonal to the radius vector at
+  a point (the tangent space, if that point lies in the sphere; more generally, the polar of the
+  inversion of that point in the sphere).
+
+-/
+
+@[expose] public section
+
+
+namespace EuclideanGeometry
+
+namespace Sphere
+
+open AffineSubspace RealInnerProductSpace
+open scoped Affine
+
+variable {V P : Type*}
+variable [NormedAddCommGroup V] [InnerProductSpace ℝ V] [MetricSpace P] [NormedAddTorsor V P]
+
+/-- The affine subspace orthogonal to the radius vector of the sphere `s` at the point `p` (if
+`p` lies in `s`, this is the tangent space; generally, this is the polar of the inversion of `p`
+in `s`). -/
+def orthRadius (s : Sphere P) (p : P) : AffineSubspace ℝ P := .mk' p (ℝ ∙ (p -ᵥ s.center))ᗮ
+
+lemma self_mem_orthRadius (s : Sphere P) (p : P) : p ∈ s.orthRadius p :=
+  self_mem_mk' _ _
+
+lemma mem_orthRadius_iff_inner_left {s : Sphere P} {p x : P} :
+    x ∈ s.orthRadius p ↔ ⟪x -ᵥ p, p -ᵥ s.center⟫ = 0 := by
+  rw [orthRadius, mem_mk', Submodule.mem_orthogonal_singleton_iff_inner_left]
+
+lemma mem_orthRadius_iff_inner_right {s : Sphere P} {p x : P} :
+    x ∈ s.orthRadius p ↔ ⟪p -ᵥ s.center, x -ᵥ p⟫ = 0 := by
+  rw [mem_orthRadius_iff_inner_left, inner_eq_zero_symm]
+
+@[simp] lemma direction_orthRadius (s : Sphere P) (p : P) :
+    (s.orthRadius p).direction = (ℝ ∙ (p -ᵥ s.center))ᗮ := by
+  rw [orthRadius, direction_mk']
+
+@[simp] lemma orthRadius_center (s : Sphere P) : s.orthRadius s.center = ⊤ := by
+  simp [orthRadius]
+
+@[simp] lemma center_mem_orthRadius_iff {s : Sphere P} {p : P} :
+    s.center ∈ s.orthRadius p ↔ p = s.center := by
+  rw [mem_orthRadius_iff_inner_left, ← neg_vsub_eq_vsub_rev, inner_neg_left]
+  simp
+
+lemma orthRadius_le_orthRadius_iff {s : Sphere P} {p q : P} :
+    s.orthRadius p ≤ s.orthRadius q ↔ p = q ∨ q = s.center := by
+  refine ⟨fun h ↦ ?_, fun h ↦ ?_⟩
+  · have h' := direction_le h
+    simp only [direction_orthRadius] at h'
+    have h'' := Submodule.orthogonal_le h'
+    simp only [Submodule.orthogonal_orthogonal, Submodule.span_singleton_le_iff_mem,
+      Submodule.mem_span_singleton] at h''
+    rcases h'' with ⟨r, hr⟩
+    have hp : p ∈ s.orthRadius q := h (s.self_mem_orthRadius p)
+    rw [mem_orthRadius_iff_inner_left, ← vsub_sub_vsub_cancel_right p q s.center, ← hr,
+      inner_sub_left, real_inner_smul_left, real_inner_smul_right, ← mul_assoc, ← sub_mul,
+      mul_eq_zero] at hp
+    rcases hp with hp | hp
+    · nth_rw 1 [← one_mul r] at hp
+      rw [← sub_mul, mul_eq_zero] at hp
+      rcases hp with hp | rfl
+      · rw [sub_eq_zero] at hp
+        rw [← hp, one_smul, vsub_left_cancel_iff] at hr
+        exact .inl hr
+      · rw [zero_smul, eq_comm, vsub_eq_zero_iff_eq] at hr
+        exact .inr hr
+    · simp only [inner_self_eq_zero, vsub_eq_zero_iff_eq] at hp
+      rw [hp, vsub_self, smul_zero, eq_comm, vsub_eq_zero_iff_eq] at hr
+      exact .inr hr
+  · rcases h with rfl | rfl <;> simp
+
+@[simp] lemma orthRadius_eq_orthRadius_iff {s : Sphere P} {p q : P} :
+    s.orthRadius p = s.orthRadius q ↔ p = q := by
+  refine ⟨fun h ↦ ?_, fun h ↦ h ▸ rfl⟩
+  have hpq := orthRadius_le_orthRadius_iff.1 h.le
+  have hqp := orthRadius_le_orthRadius_iff.1 h.symm.le
+  grind
+
+lemma finrank_orthRadius [FiniteDimensional ℝ V] {s : Sphere P} {p : P} (hp : p ≠ s.center) :
+    Module.finrank ℝ (s.orthRadius p).direction + 1 = Module.finrank ℝ V := by
+  rw [orthRadius, add_comm, direction_mk']
+  convert (ℝ ∙ (p -ᵥ s.center)).finrank_add_finrank_orthogonal
+  exact (finrank_span_singleton (vsub_ne_zero.2 hp)).symm
+
+lemma orthRadius_map {s : Sphere P} (p : P) {f : P ≃ᵃⁱ[ℝ] P} (h : f s.center = s.center) :
+    (s.orthRadius p).map f.toAffineMap = s.orthRadius (f p) := by
+  rw [orthRadius, map_mk', orthRadius]
+  convert rfl using 2
+  convert (Submodule.map_orthogonal (ℝ ∙ (p -ᵥ s.center)) f.linearIsometryEquiv).symm
+  simp [Submodule.map_span, Set.image_singleton, h]
+
+lemma direction_orthRadius_le_iff {s : Sphere P} {p q : P} :
+    (s.orthRadius p).direction ≤ (s.orthRadius q).direction ↔
+      ∃ r : ℝ, q -ᵥ s.center = r • (p -ᵥ s.center) := by
+  simp [Submodule.orthogonal_le_orthogonal_iff, Submodule.mem_span_singleton, eq_comm]
+
+lemma orthRadius_parallel_orthRadius_iff {s : Sphere P} {p q : P} :
+    s.orthRadius p ∥ s.orthRadius q ↔ ∃ r : ℝ, r ≠ 0 ∧ q -ᵥ s.center = r • (p -ᵥ s.center) := by
+  simp only [orthRadius, parallel_iff_direction_eq_and_eq_bot_iff_eq_bot, direction_mk',
+    Submodule.orthogonalComplement_eq_orthogonalComplement,
+    Submodule.span_singleton_eq_span_singleton, ← coe_eq_bot_iff,
+    ← Set.not_nonempty_iff_eq_empty, mk'_nonempty, not_true_eq_false, and_true]
+  exact ⟨fun ⟨r, h⟩ ↦ ⟨r, r.ne_zero, h.symm⟩, fun ⟨r, hr, h⟩ ↦ ⟨.mk0 r hr, h.symm⟩⟩
+
+end Sphere
+
+end EuclideanGeometry

--- a/Mathlib/Geometry/Euclidean/Sphere/Tangent.lean
+++ b/Mathlib/Geometry/Euclidean/Sphere/Tangent.lean
@@ -5,9 +5,8 @@ Authors: Joseph Myers
 -/
 module
 
-public import Mathlib.Analysis.InnerProductSpace.Projection.FiniteDimensional
 public import Mathlib.Geometry.Euclidean.Projection
-public import Mathlib.Geometry.Euclidean.Sphere.Basic
+public import Mathlib.Geometry.Euclidean.Sphere.OrthRadius
 
 /-!
 # Tangency for spheres.
@@ -15,9 +14,6 @@ public import Mathlib.Geometry.Euclidean.Sphere.Basic
 This file defines notions of spheres being tangent to affine subspaces and other spheres.
 
 ## Main definitions
-
-* `EuclideanGeometry.Sphere.orthRadius`: the affine subspace orthogonal to the radius vector at
-  a point (the tangent space, if that point lies in the sphere).
 
 * `EuclideanGeometry.Sphere.IsTangentAt`: the property of an affine subspace being tangent to a
   sphere at a given point.
@@ -63,93 +59,6 @@ open scoped Affine
 
 variable {V P : Type*}
 variable [NormedAddCommGroup V] [InnerProductSpace ℝ V] [MetricSpace P] [NormedAddTorsor V P]
-
-/-- The affine subspace orthogonal to the radius vector of the sphere `s` at the point `p` (in
-the typical cases, `p` lies in `s` and this is the tangent space). -/
-def orthRadius (s : Sphere P) (p : P) : AffineSubspace ℝ P := .mk' p (ℝ ∙ (p -ᵥ s.center))ᗮ
-
-lemma self_mem_orthRadius (s : Sphere P) (p : P) : p ∈ s.orthRadius p :=
-  self_mem_mk' _ _
-
-lemma mem_orthRadius_iff_inner_left {s : Sphere P} {p x : P} :
-    x ∈ s.orthRadius p ↔ ⟪x -ᵥ p, p -ᵥ s.center⟫ = 0 := by
-  rw [orthRadius, mem_mk', Submodule.mem_orthogonal_singleton_iff_inner_left]
-
-lemma mem_orthRadius_iff_inner_right {s : Sphere P} {p x : P} :
-    x ∈ s.orthRadius p ↔ ⟪p -ᵥ s.center, x -ᵥ p⟫ = 0 := by
-  rw [mem_orthRadius_iff_inner_left, inner_eq_zero_symm]
-
-@[simp] lemma direction_orthRadius (s : Sphere P) (p : P) :
-    (s.orthRadius p).direction = (ℝ ∙ (p -ᵥ s.center))ᗮ := by
-  rw [orthRadius, direction_mk']
-
-@[simp] lemma orthRadius_center (s : Sphere P) : s.orthRadius s.center = ⊤ := by
-  simp [orthRadius]
-
-@[simp] lemma center_mem_orthRadius_iff {s : Sphere P} {p : P} :
-    s.center ∈ s.orthRadius p ↔ p = s.center := by
-  rw [mem_orthRadius_iff_inner_left, ← neg_vsub_eq_vsub_rev, inner_neg_left]
-  simp
-
-lemma orthRadius_le_orthRadius_iff {s : Sphere P} {p q : P} :
-    s.orthRadius p ≤ s.orthRadius q ↔ p = q ∨ q = s.center := by
-  refine ⟨fun h ↦ ?_, fun h ↦ ?_⟩
-  · have h' := direction_le h
-    simp only [direction_orthRadius] at h'
-    have h'' := Submodule.orthogonal_le h'
-    simp only [Submodule.orthogonal_orthogonal, Submodule.span_singleton_le_iff_mem,
-      Submodule.mem_span_singleton] at h''
-    rcases h'' with ⟨r, hr⟩
-    have hp : p ∈ s.orthRadius q := h (s.self_mem_orthRadius p)
-    rw [mem_orthRadius_iff_inner_left, ← vsub_sub_vsub_cancel_right p q s.center, ← hr,
-      inner_sub_left, real_inner_smul_left, real_inner_smul_right, ← mul_assoc, ← sub_mul,
-      mul_eq_zero] at hp
-    rcases hp with hp | hp
-    · nth_rw 1 [← one_mul r] at hp
-      rw [← sub_mul, mul_eq_zero] at hp
-      rcases hp with hp | rfl
-      · rw [sub_eq_zero] at hp
-        rw [← hp, one_smul, vsub_left_cancel_iff] at hr
-        exact .inl hr
-      · rw [zero_smul, eq_comm, vsub_eq_zero_iff_eq] at hr
-        exact .inr hr
-    · simp only [inner_self_eq_zero, vsub_eq_zero_iff_eq] at hp
-      rw [hp, vsub_self, smul_zero, eq_comm, vsub_eq_zero_iff_eq] at hr
-      exact .inr hr
-  · rcases h with rfl | rfl <;> simp
-
-@[simp] lemma orthRadius_eq_orthRadius_iff {s : Sphere P} {p q : P} :
-    s.orthRadius p = s.orthRadius q ↔ p = q := by
-  refine ⟨fun h ↦ ?_, fun h ↦ h ▸ rfl⟩
-  have hpq := orthRadius_le_orthRadius_iff.1 h.le
-  have hqp := orthRadius_le_orthRadius_iff.1 h.symm.le
-  grind
-
-lemma finrank_orthRadius [FiniteDimensional ℝ V] {s : Sphere P} {p : P} (hp : p ≠ s.center) :
-    Module.finrank ℝ (s.orthRadius p).direction + 1 = Module.finrank ℝ V := by
-  rw [orthRadius, add_comm, direction_mk']
-  convert (ℝ ∙ (p -ᵥ s.center)).finrank_add_finrank_orthogonal
-  exact (finrank_span_singleton (vsub_ne_zero.2 hp)).symm
-
-lemma orthRadius_map {s : Sphere P} (p : P) {f : P ≃ᵃⁱ[ℝ] P} (h : f s.center = s.center) :
-    (s.orthRadius p).map f.toAffineMap = s.orthRadius (f p) := by
-  rw [orthRadius, map_mk', orthRadius]
-  convert rfl using 2
-  convert (Submodule.map_orthogonal (ℝ ∙ (p -ᵥ s.center)) f.linearIsometryEquiv).symm
-  simp [Submodule.map_span, Set.image_singleton, h]
-
-lemma direction_orthRadius_le_iff {s : Sphere P} {p q : P} :
-    (s.orthRadius p).direction ≤ (s.orthRadius q).direction ↔
-      ∃ r : ℝ, q -ᵥ s.center = r • (p -ᵥ s.center) := by
-  simp [Submodule.orthogonal_le_orthogonal_iff, Submodule.mem_span_singleton, eq_comm]
-
-lemma orthRadius_parallel_orthRadius_iff {s : Sphere P} {p q : P} :
-    s.orthRadius p ∥ s.orthRadius q ↔ ∃ r : ℝ, r ≠ 0 ∧ q -ᵥ s.center = r • (p -ᵥ s.center) := by
-  simp only [orthRadius, parallel_iff_direction_eq_and_eq_bot_iff_eq_bot, direction_mk',
-    Submodule.orthogonalComplement_eq_orthogonalComplement,
-    Submodule.span_singleton_eq_span_singleton, ← coe_eq_bot_iff,
-    ← Set.not_nonempty_iff_eq_empty, mk'_nonempty, not_true_eq_false, and_true]
-  exact ⟨fun ⟨r, h⟩ ↦ ⟨r, r.ne_zero, h.symm⟩, fun ⟨r, hr, h⟩ ↦ ⟨.mk0 r hr, h.symm⟩⟩
 
 /-- The affine subspace `as` is tangent to the sphere `s` at the point `p`. -/
 structure IsTangentAt (s : Sphere P) (p : P) (as : AffineSubspace ℝ P) : Prop where


### PR DESCRIPTION
Split the definition and lemmas for `orthRadius` out of `Mathlib.Geometry.Euclidean.Sphere.Tangent` into a separate `Mathlib.Geometry.Euclidean.Sphere.OrthRadius`, in preparation for setting up a further `Mathlib.Geometry.Euclidean.Sphere.PolePolar` (which will import `OrthRadius` and be imported by `Tangent`).

There are no changes to definitions, statements or proofs.  The doc string for `orthRadius` (and corresponding description in the module doc string) is updated to reflect that this definition is not just useful at points on the sphere to define tangents but also more generally for defining polars.


---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

When merging, all the commits will be squashed into a single commit
listing all co-authors.

Co-authors in the squash commit are gathered from two sources:

First, all authors of commits to this PR branch are included. Thus,
one way to add co-authors is to include at least one commit authored by
each co-author among the commits in the pull request. If necessary, you
may create empty commits to indicate co-authorship, using commands like so:

git commit --author="Author Name <author@email.com>" --allow-empty -m "add Author Name as coauthor"

Second, co-authors can also be listed in lines at the very bottom of
the commit message (that is, directly before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines
at the bottom of the commit message (before the `---`, and also before
any "Co-authored-by" lines) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
