### PR TITLE
[Merged by Bors] - feat(RingTheory): resultant is in the span of the two polynomials

### DIFF
--- a/Mathlib/Algebra/Order/Monoid/Unbundled/WithTop.lean
+++ b/Mathlib/Algebra/Order/Monoid/Unbundled/WithTop.lean
@@ -628,6 +628,9 @@ lemma map_eq_natCast_iff {f : β → α} {n : ℕ} {a : WithBot β} :
 lemma natCast_eq_map_iff {f : β → α} {n : ℕ} {a : WithBot β} :
     n = a.map f ↔ ∃ x, a = .some x ∧ f x = n := some_eq_map_iff
 
+@[simp] lemma bot_lt_natCast [LT α] (n : ℕ) : (⊥ : WithBot α) < n :=
+  WithBot.bot_lt_coe _
+
 end AddMonoidWithOne
 
 instance charZero [AddMonoidWithOne α] [CharZero α] : CharZero (WithBot α) :=

--- a/Mathlib/RingTheory/Polynomial/Resultant/Basic.lean
+++ b/Mathlib/RingTheory/Polynomial/Resultant/Basic.lean
@@ -7,6 +7,9 @@ module
 
 public import Mathlib.Algebra.Polynomial.Derivative
 public import Mathlib.Algebra.Polynomial.Div
+public import Mathlib.FieldTheory.Extension
+public import Mathlib.FieldTheory.SplittingField.Construction
+public import Mathlib.RingTheory.Polynomial.DegreeLT
 public import Mathlib.LinearAlgebra.Matrix.Determinant.Basic
 
 /-!
@@ -393,6 +396,96 @@ lemma resultant_X_sub_C_right (r : R) (hf : f.natDegree ≤ m) :
   simp
 
 end resultant
+
+section sylvesterMap
+
+variable {m n} {R : Type*} [CommRing R]
+
+attribute [local simp] Polynomial.mem_degreeLT
+
+/-- The map `(p, q) ↦ f * q + g * p` whose associated matrix is `Syl(f, g)`. -/
+@[simps]
+noncomputable
+def sylvesterMap (f g : R[X]) (hf : f.natDegree ≤ m) (hg : g.natDegree ≤ n) :
+    R[X]_m × R[X]_n →ₗ[R] R[X]_(m + n) where
+  toFun pq := ⟨f * pq.2 + g * pq.1, by
+    obtain ⟨⟨p, hp⟩, ⟨q, hq⟩⟩ := pq
+    rw [Polynomial.mem_degreeLT]
+    refine (degree_add_le _ _).trans_lt (max_lt ?_ ?_)
+    · by_cases hf' : f = 0; · simp_all
+      exact (degree_mul_le _ _).trans_lt (WithBot.add_lt_add_of_le_of_lt (by simpa)
+        (degree_le_of_natDegree_le hf) (by simpa using hq))
+    · by_cases hg' : g = 0; · simp_all
+      exact (degree_mul_le _ _).trans_lt ((WithBot.add_lt_add_of_le_of_lt (by simpa)
+        (degree_le_of_natDegree_le hg) (by simpa using hp)).trans_eq (add_comm _ _))⟩
+  map_add' _ _ := by ext1; dsimp; ring
+  map_smul' _ _ := by ext1; simp
+
+lemma toMatrix_sylvesterMap (f g : R[X]) (hf : f.natDegree ≤ m) (hg : g.natDegree ≤ n) :
+    (sylvesterMap f g hf hg).toMatrix
+      ((degreeLT.basis _ _).prod (degreeLT.basis _ _)) (degreeLT.basis _ _) =
+    (sylvester f g m n).reindex (.refl _) finSumFinEquiv.symm := by
+  ext i (j | j)
+  · suffices (if j.1 ≤ i then g.coeff (i - j) else 0) =
+      if j ≤ i.1 ∧ ↑i ≤ j + n then g.coeff (i - j) else 0 by
+        simpa [LinearMap.toMatrix_apply, sylvester, coeff_mul_X_pow']
+    rw [ite_and]
+    split_ifs with h₁ h₂ <;> try rfl
+    exact coeff_eq_zero_of_natDegree_lt (by cutsat)
+  · suffices (if j.1 ≤ i then f.coeff (i - j) else 0) =
+      if j ≤ i.1 ∧ ↑i ≤ j + m then f.coeff (i - j) else 0 by
+        simpa [LinearMap.toMatrix_apply, sylvester, coeff_mul_X_pow']
+    rw [ite_and]
+    split_ifs with h₁ h₂ <;> try rfl
+    exact coeff_eq_zero_of_natDegree_lt (by cutsat)
+
+lemma toMatrix_sylvesterMap' (f g : R[X]) (hf : f.natDegree ≤ m) (hg : g.natDegree ≤ n) :
+    (sylvesterMap f g hf hg).toMatrix
+      (((degreeLT.basis _ _).prod (degreeLT.basis _ _)).reindex finSumFinEquiv)
+      (degreeLT.basis _ _) = sylvester f g m n := by
+  ext i j
+  obtain ⟨j, rfl⟩ := finSumFinEquiv.surjective j
+  simpa [LinearMap.toMatrix_apply] using congr($(toMatrix_sylvesterMap f g hf hg) i j)
+
+set_option linter.unusedVariables false in
+/-- The adjugate map of the sylvester map. It takes `P` to `(p, q)` such that
+`f * q + g * p = Res(f, g) * P`. -/
+@[nolint unusedArguments] -- This def makes no sense if `hf` and `hg` does not hold.
+noncomputable
+def invSylvester (f g : R[X]) (hf : f.natDegree ≤ m) (hg : g.natDegree ≤ n) :
+    R[X]_(m + n) →ₗ[R] R[X]_m × R[X]_n :=
+  (f.sylvester g m n).adjugate.toLin (degreeLT.basis R (m + n))
+    (((degreeLT.basis R m).prod (degreeLT.basis R n)).reindex finSumFinEquiv)
+
+lemma sylveserMap_comp_invSylvester (f g : R[X]) (hf : f.natDegree ≤ m) (hg : g.natDegree ≤ n) :
+    sylvesterMap f g hf hg ∘ₗ invSylvester f g hf hg = f.resultant g m n • LinearMap.id := by
+  let b₁ := ((degreeLT.basis R m).prod (degreeLT.basis R n)).reindex finSumFinEquiv
+  let b₂ := degreeLT.basis R (m + n)
+  have := congr(Matrix.toLin b₂ b₂ $(((sylvesterMap f g hf hg).toMatrix b₁ b₂).mul_adjugate))
+  rwa [Matrix.toLin_mul b₂ b₁ b₂, Matrix.toLin_toMatrix, map_smul,
+    toMatrix_sylvesterMap', Matrix.toLin_one, ← resultant] at this
+
+lemma invSylvester_comp_sylveserMap (f g : R[X]) (hf : f.natDegree ≤ m) (hg : g.natDegree ≤ n) :
+    invSylvester f g hf hg ∘ₗ sylvesterMap f g hf hg = f.resultant g m n • LinearMap.id := by
+  let b₁ := ((degreeLT.basis R m).prod (degreeLT.basis R n)).reindex finSumFinEquiv
+  let b₂ := degreeLT.basis R (m + n)
+  have := congr(Matrix.toLin b₁ b₁ $(((sylvesterMap f g hf hg).toMatrix b₁ b₂).adjugate_mul))
+  rwa [Matrix.toLin_mul b₁ b₂ b₁, Matrix.toLin_toMatrix, map_smul,
+    toMatrix_sylvesterMap', Matrix.toLin_one, ← resultant] at this
+
+/-- Note that if `n = m = 0` then `resultant = 1` but `f` and `g` aren't necessarily coprime. -/
+lemma exists_mul_add_mul_eq_C_resultant
+    (f g : R[X]) (hf : f.natDegree ≤ m) (hg : g.natDegree ≤ n) (H : m ≠ 0 ∨ n ≠ 0) :
+    ∃ p q, p.degree < ↑n ∧ q.degree < ↑m ∧ f * p + g * q = C (f.resultant g m n) := by
+  nontriviality R
+  let X := invSylvester f g hf hg ⟨1, by simpa [Polynomial.mem_degreeLT,
+    ← Nat.cast_add, Nat.pos_iff_ne_zero, not_and_or, -not_and] using H⟩
+  have : ((sylvesterMap f g hf hg X)).1 = _ :=
+    congr(($(sylveserMap_comp_invSylvester f g hf hg) _).1)
+  refine ⟨X.2, X.1, by simpa [-SetLike.coe_mem] using X.2.2,
+    by simpa [-SetLike.coe_mem] using X.1.2, by simpa [Algebra.smul_def] using this⟩
+
+end sylvesterMap
 
 section disc
 

--- a/Mathlib/RingTheory/Polynomial/Resultant/Basic.lean
+++ b/Mathlib/RingTheory/Polynomial/Resultant/Basic.lean
@@ -447,18 +447,16 @@ lemma toMatrix_sylvesterMap' (f g : R[X]) (hf : f.natDegree ≤ m) (hg : g.natDe
   obtain ⟨j, rfl⟩ := finSumFinEquiv.surjective j
   simpa [LinearMap.toMatrix_apply] using congr($(toMatrix_sylvesterMap f g hf hg) i j)
 
-set_option linter.unusedVariables false in
 /-- The adjugate map of the sylvester map. It takes `P` to `(p, q)` such that
 `f * q + g * p = Res(f, g) * P`. -/
-@[nolint unusedArguments] -- This def makes no sense if `hf` and `hg` does not hold.
 noncomputable
-def adjSylvester (f g : R[X]) (hf : f.natDegree ≤ m) (hg : g.natDegree ≤ n) :
+def adjSylvester (f g : R[X]) :
     R[X]_(m + n) →ₗ[R] R[X]_m × R[X]_n :=
   (f.sylvester g m n).adjugate.toLin (degreeLT.basis R (m + n))
     (((degreeLT.basis R m).prod (degreeLT.basis R n)).reindex finSumFinEquiv)
 
 lemma sylveserMap_comp_adjSylvester (f g : R[X]) (hf : f.natDegree ≤ m) (hg : g.natDegree ≤ n) :
-    sylvesterMap f g hf hg ∘ₗ adjSylvester f g hf hg = f.resultant g m n • LinearMap.id := by
+    sylvesterMap f g hf hg ∘ₗ adjSylvester f g = f.resultant g m n • LinearMap.id := by
   let b₁ := ((degreeLT.basis R m).prod (degreeLT.basis R n)).reindex finSumFinEquiv
   let b₂ := degreeLT.basis R (m + n)
   have := congr(Matrix.toLin b₂ b₂ $(((sylvesterMap f g hf hg).toMatrix b₁ b₂).mul_adjugate))
@@ -466,7 +464,7 @@ lemma sylveserMap_comp_adjSylvester (f g : R[X]) (hf : f.natDegree ≤ m) (hg : 
     toMatrix_sylvesterMap', Matrix.toLin_one, ← resultant] at this
 
 lemma adjSylvester_comp_sylveserMap (f g : R[X]) (hf : f.natDegree ≤ m) (hg : g.natDegree ≤ n) :
-    adjSylvester f g hf hg ∘ₗ sylvesterMap f g hf hg = f.resultant g m n • LinearMap.id := by
+    adjSylvester f g ∘ₗ sylvesterMap f g hf hg = f.resultant g m n • LinearMap.id := by
   let b₁ := ((degreeLT.basis R m).prod (degreeLT.basis R n)).reindex finSumFinEquiv
   let b₂ := degreeLT.basis R (m + n)
   have := congr(Matrix.toLin b₁ b₁ $(((sylvesterMap f g hf hg).toMatrix b₁ b₂).adjugate_mul))
@@ -478,7 +476,7 @@ lemma exists_mul_add_mul_eq_C_resultant
     (f g : R[X]) (hf : f.natDegree ≤ m) (hg : g.natDegree ≤ n) (H : m ≠ 0 ∨ n ≠ 0) :
     ∃ p q, p.degree < ↑n ∧ q.degree < ↑m ∧ f * p + g * q = C (f.resultant g m n) := by
   nontriviality R
-  let X := adjSylvester f g hf hg ⟨1, by simpa [Polynomial.mem_degreeLT,
+  let X := adjSylvester f g ⟨1, by simpa [Polynomial.mem_degreeLT,
     ← Nat.cast_add, Nat.pos_iff_ne_zero, not_and_or, -not_and] using H⟩
   have : ((sylvesterMap f g hf hg X)).1 = _ :=
     congr(($(sylveserMap_comp_adjSylvester f g hf hg) _).1)

--- a/Mathlib/RingTheory/Polynomial/Resultant/Basic.lean
+++ b/Mathlib/RingTheory/Polynomial/Resultant/Basic.lean
@@ -452,21 +452,21 @@ set_option linter.unusedVariables false in
 `f * q + g * p = Res(f, g) * P`. -/
 @[nolint unusedArguments] -- This def makes no sense if `hf` and `hg` does not hold.
 noncomputable
-def invSylvester (f g : R[X]) (hf : f.natDegree ≤ m) (hg : g.natDegree ≤ n) :
+def adjSylvester (f g : R[X]) (hf : f.natDegree ≤ m) (hg : g.natDegree ≤ n) :
     R[X]_(m + n) →ₗ[R] R[X]_m × R[X]_n :=
   (f.sylvester g m n).adjugate.toLin (degreeLT.basis R (m + n))
     (((degreeLT.basis R m).prod (degreeLT.basis R n)).reindex finSumFinEquiv)
 
-lemma sylveserMap_comp_invSylvester (f g : R[X]) (hf : f.natDegree ≤ m) (hg : g.natDegree ≤ n) :
-    sylvesterMap f g hf hg ∘ₗ invSylvester f g hf hg = f.resultant g m n • LinearMap.id := by
+lemma sylveserMap_comp_adjSylvester (f g : R[X]) (hf : f.natDegree ≤ m) (hg : g.natDegree ≤ n) :
+    sylvesterMap f g hf hg ∘ₗ adjSylvester f g hf hg = f.resultant g m n • LinearMap.id := by
   let b₁ := ((degreeLT.basis R m).prod (degreeLT.basis R n)).reindex finSumFinEquiv
   let b₂ := degreeLT.basis R (m + n)
   have := congr(Matrix.toLin b₂ b₂ $(((sylvesterMap f g hf hg).toMatrix b₁ b₂).mul_adjugate))
   rwa [Matrix.toLin_mul b₂ b₁ b₂, Matrix.toLin_toMatrix, map_smul,
     toMatrix_sylvesterMap', Matrix.toLin_one, ← resultant] at this
 
-lemma invSylvester_comp_sylveserMap (f g : R[X]) (hf : f.natDegree ≤ m) (hg : g.natDegree ≤ n) :
-    invSylvester f g hf hg ∘ₗ sylvesterMap f g hf hg = f.resultant g m n • LinearMap.id := by
+lemma adjSylvester_comp_sylveserMap (f g : R[X]) (hf : f.natDegree ≤ m) (hg : g.natDegree ≤ n) :
+    adjSylvester f g hf hg ∘ₗ sylvesterMap f g hf hg = f.resultant g m n • LinearMap.id := by
   let b₁ := ((degreeLT.basis R m).prod (degreeLT.basis R n)).reindex finSumFinEquiv
   let b₂ := degreeLT.basis R (m + n)
   have := congr(Matrix.toLin b₁ b₁ $(((sylvesterMap f g hf hg).toMatrix b₁ b₂).adjugate_mul))
@@ -478,10 +478,10 @@ lemma exists_mul_add_mul_eq_C_resultant
     (f g : R[X]) (hf : f.natDegree ≤ m) (hg : g.natDegree ≤ n) (H : m ≠ 0 ∨ n ≠ 0) :
     ∃ p q, p.degree < ↑n ∧ q.degree < ↑m ∧ f * p + g * q = C (f.resultant g m n) := by
   nontriviality R
-  let X := invSylvester f g hf hg ⟨1, by simpa [Polynomial.mem_degreeLT,
+  let X := adjSylvester f g hf hg ⟨1, by simpa [Polynomial.mem_degreeLT,
     ← Nat.cast_add, Nat.pos_iff_ne_zero, not_and_or, -not_and] using H⟩
   have : ((sylvesterMap f g hf hg X)).1 = _ :=
-    congr(($(sylveserMap_comp_invSylvester f g hf hg) _).1)
+    congr(($(sylveserMap_comp_adjSylvester f g hf hg) _).1)
   refine ⟨X.2, X.1, by simpa [-SetLike.coe_mem] using X.2.2,
     by simpa [-SetLike.coe_mem] using X.1.2, by simpa [Algebra.smul_def] using this⟩
 


### PR DESCRIPTION

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

When merging, all the commits will be squashed into a single commit
listing all co-authors.

Co-authors in the squash commit are gathered from two sources:

First, all authors of commits to this PR branch are included. Thus,
one way to add co-authors is to include at least one commit authored by
each co-author among the commits in the pull request. If necessary, you
may create empty commits to indicate co-authorship, using commands like so:

git commit --author="Author Name <author@email.com>" --allow-empty -m "add Author Name as coauthor"

Second, co-authors can also be listed in lines at the very bottom of
the commit message (that is, directly before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines
at the bottom of the commit message (before the `---`, and also before
any "Co-authored-by" lines) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
