### PR TITLE
[Merged by Bors] - fix: adjust `abel`'s `hint` prio to avoid suggesting `abel` on unrelated trivial goals

### DIFF
--- a/Mathlib/Tactic/Abel.lean
+++ b/Mathlib/Tactic/Abel.lean
@@ -548,4 +548,4 @@ end Mathlib.Tactic.Abel
 We register `abel` with the `hint` tactic.
 -/
 
-register_hint 1000 abel
+register_hint 950 abel

--- a/MathlibTest/hintAll.lean
+++ b/MathlibTest/hintAll.lean
@@ -115,6 +115,14 @@ info: Try these:
 #guard_msgs in
 example {P : Nat → Prop} (h : { x // P x }) : ∃ x, P x ∧ 0 ≤ x := by hint
 
+def f (p : Nat × Nat) := (p.fst, p.snd)
+/--
+info: Try these:
+  [apply] 🎉 abel
+-/
+#guard_msgs in
+example : f = id := by hint
+
 section multiline_hint
 
 local macro "this_is_a_multiline_exact" ppLine t:term : tactic => `(tactic| exact $t)

--- a/MathlibTest/hintAll.lean
+++ b/MathlibTest/hintAll.lean
@@ -89,9 +89,6 @@ info: Try these:
   [apply] ring_nf
   Remaining subgoals:
   ⊢ Nat.Prime 37
-  [apply] norm_num
-  Remaining subgoals:
-  ⊢ Nat.Prime 37
 -/
 #guard_msgs in
 example : Nat.Prime 37 := by hint
@@ -118,7 +115,10 @@ example {P : Nat → Prop} (h : { x // P x }) : ∃ x, P x ∧ 0 ≤ x := by hin
 def f (p : Nat × Nat) := (p.fst, p.snd)
 /--
 info: Try these:
-  [apply] 🎉 abel
+  [apply] 🎉 trivial
+  [apply] norm_num
+  Remaining subgoals:
+  ⊢ f = id
 -/
 #guard_msgs in
 example : f = id := by hint
@@ -212,10 +212,10 @@ info: Try these:
   [apply] ring_nf
   Remaining subgoals:
   ⊢ a /ₚ u₁ + b /ₚ u₁ = (a + b) /ₚ u₁
-  [apply] abel_nf
+  [apply] norm_num
   Remaining subgoals:
   ⊢ a /ₚ u₁ + b /ₚ u₁ = (a + b) /ₚ u₁
-  [apply] norm_num
+  [apply] abel_nf
   Remaining subgoals:
   ⊢ a /ₚ u₁ + b /ₚ u₁ = (a + b) /ₚ u₁
   [apply] group


### PR DESCRIPTION
---
Consider the following goal, which is entirely unrelated to additive or commutative monoids or groups.

`hint` before this change:

```lean
import Mathlib
def f (p : Nat × Nat) := (p.fst, p.snd)
example : f = id := by hint -- suggests `abel`
```

`hint` after this change:

```lean
import Mathlib
def f (p : Nat × Nat) := (p.fst, p.snd)
example : f = id := by hint -- suggests `trivial`
```

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

When merging, all the commits will be squashed into a single commit
listing all co-authors.

Co-authors in the squash commit are gathered from two sources:

First, all authors of commits to this PR branch are included. Thus,
one way to add co-authors is to include at least one commit authored by
each co-author among the commits in the pull request. If necessary, you
may create empty commits to indicate co-authorship, using commands like so:

git commit --author="Author Name <author@email.com>" --allow-empty -m "add Author Name as coauthor"

Second, co-authors can also be listed in lines at the very bottom of
the commit message (that is, directly before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines
at the bottom of the commit message (before the `---`, and also before
any "Co-authored-by" lines) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
