### PR TITLE
[Merged by Bors] - feat: `#grind_lint check in module Mathlib`

### DIFF
--- a/Mathlib/CategoryTheory/Iso.lean
+++ b/Mathlib/CategoryTheory/Iso.lean
@@ -138,7 +138,10 @@ instance instTransIso : Trans (α := C) (· ≅ ·) (· ≅ ·) (· ≅ ·) wher
 /-- Notation for composition of isomorphisms. -/
 infixr:80 " ≪≫ " => Iso.trans -- type as `\ll \gg`.
 
-@[simp, grind =]
+-- Annotating this with `@[grind =]` triggers a run-away chain of `Category.assoc` instantiations.
+-- Hopefully this can be restored when `grind` has support for associative/commutative operations,
+-- or direct support for category theory.
+@[simp]
 theorem trans_mk {X Y Z : C} (hom : X ⟶ Y) (inv : Y ⟶ X) (hom_inv_id) (inv_hom_id)
     (hom' : Y ⟶ Z) (inv' : Z ⟶ Y) (hom_inv_id') (inv_hom_id') (hom_inv_id'') (inv_hom_id'') :
     Iso.trans ⟨hom, inv, hom_inv_id, inv_hom_id⟩ ⟨hom', inv', hom_inv_id', inv_hom_id'⟩ =

--- a/MathlibTest/grind/lint.lean
+++ b/MathlibTest/grind/lint.lean
@@ -1,0 +1,11 @@
+import Mathlib
+
+-- This check verifies that `grind` annotations in Mathlib do not trigger run-away instantiations.
+-- If this test fails, please modify newly introduced `grind` annotations to use the
+-- `grind_pattern ... where ...` syntax to add side conditions that will prevent the run-away.
+-- See https://lean-lang.org/doc/reference/latest/The--grind--tactic/E___matching/ for details.
+#grind_lint check (min := 20) in module Mathlib
+
+-- (Note: the above #grind_lint take about 20s as of 2025-11-21.
+-- If it becomes too slow, we may need to split this file and lint different submodules separately,
+-- to get paralellism.)


### PR DESCRIPTION
This PR installs the new `#grind_lint` command in Mathlib, to ensure new annotations do not cause run-away instantiations.

The link to the reference manual is not that helpful until we merge https://github.com/leanprover/reference-manual/pull/658.