### PR TITLE
[Merged by Bors] - feat(Topology/UniformSpace/Closeds): uniform continuity of the singleton map

### DIFF
--- a/Mathlib/Topology/UniformSpace/Closeds.lean
+++ b/Mathlib/Topology/UniformSpace/Closeds.lean
@@ -134,7 +134,7 @@ theorem isClosed_powerset {F : Set α} (hF : IsClosed F) :
   simp_rw [Set.powerset, ← isOpen_compl_iff, Set.compl_setOf, ← Set.inter_compl_nonempty_iff]
   exact isOpen_inter_nonempty_of_isOpen hF.isOpen_compl
 
-theorem isClopen_singleton_bot : IsClopen {(∅ : Set α)} := by
+theorem isClopen_singleton_empty : IsClopen {(∅ : Set α)} := by
   constructor
   · rw [← Set.powerset_empty]
     exact isClosed_powerset isClosed_empty
@@ -157,7 +157,8 @@ theorem isClosedEmbedding_singleton [T0Space α] :
     rw [← isOpen_compl_iff, isOpen_iff_mem_nhds]
     intro s hs
     rcases Set.eq_empty_or_nonempty s with rfl | h
-    · rwa [(isOpen_singleton_iff_nhds_eq_pure _).mp isClopen_singleton_bot.isOpen, Filter.mem_pure]
+    · rwa [(isOpen_singleton_iff_nhds_eq_pure _).mp isClopen_singleton_empty.isOpen,
+        Filter.mem_pure]
     rcases h.exists_eq_singleton_or_nontrivial with ⟨x, rfl⟩ | ⟨x, hx, y, hy, hxy⟩
     · cases hs <| Set.mem_range_self x
     obtain ⟨U, V, hU, hV, hxU, hyV, hUV⟩ := t2_separation hxy

--- a/Mathlib/Topology/UniformSpace/Closeds.lean
+++ b/Mathlib/Topology/UniformSpace/Closeds.lean
@@ -78,6 +78,11 @@ instance isTrans_hausdorffEntourage (U : SetRel α α) [U.IsTrans] :
     (hausdorffEntourage U).IsTrans := by
   grw [isTrans_iff_comp_subset_self, ← hausdorffEntourage_comp, comp_subset_self]
 
+@[simp]
+theorem singleton_mem_hausdorffEntourage (U : SetRel α α) (x y : α) :
+    ({x}, {y}) ∈ hausdorffEntourage U ↔ (x, y) ∈ U := by
+  simp [hausdorffEntourage]
+
 end hausdorffEntourage
 
 variable [UniformSpace α]
@@ -129,6 +134,39 @@ theorem isClosed_powerset {F : Set α} (hF : IsClosed F) :
   simp_rw [Set.powerset, ← isOpen_compl_iff, Set.compl_setOf, ← Set.inter_compl_nonempty_iff]
   exact isOpen_inter_nonempty_of_isOpen hF.isOpen_compl
 
+theorem isClopen_singleton_bot : IsClopen {(∅ : Set α)} := by
+  constructor
+  · rw [← Set.powerset_empty]
+    exact isClosed_powerset isClosed_empty
+  · simp_rw [isOpen_iff_mem_nhds, Set.mem_singleton_iff, forall_eq, nhds_eq_uniformity]
+    filter_upwards [Filter.mem_lift' <| Filter.mem_lift' Filter.univ_mem] with F ⟨_, hF⟩
+    simpa using hF
+
+theorem isUniformEmbedding_singleton : IsUniformEmbedding ({·} : α → Set α) where
+  injective := Set.singleton_injective
+  comap_uniformity := by
+    change Filter.comap _ (Filter.lift' _ _) = _
+    simp_rw [Filter.comap_lift'_eq, Function.comp_def, Set.preimage,
+      singleton_mem_hausdorffEntourage]
+    exact Filter.lift'_id
+
+theorem isClosedEmbedding_singleton [T0Space α] :
+    Topology.IsClosedEmbedding ({·} : α → Set α) where
+  __ := isUniformEmbedding_singleton.isEmbedding
+  isClosed_range := by
+    rw [← isOpen_compl_iff, isOpen_iff_mem_nhds]
+    intro s hs
+    rcases Set.eq_empty_or_nonempty s with rfl | h
+    · rwa [(isOpen_singleton_iff_nhds_eq_pure _).mp isClopen_singleton_bot.isOpen, Filter.mem_pure]
+    rcases h.exists_eq_singleton_or_nontrivial with ⟨x, rfl⟩ | ⟨x, hx, y, hy, hxy⟩
+    · cases hs <| Set.mem_range_self x
+    obtain ⟨U, V, hU, hV, hxU, hyV, hUV⟩ := t2_separation hxy
+    filter_upwards [(isOpen_inter_nonempty_of_isOpen hU).inter (isOpen_inter_nonempty_of_isOpen hV)
+      |>.mem_nhds ⟨⟨x, hx, hxU⟩, ⟨y, hy, hyV⟩⟩]
+    rintro _ ⟨hzU, hzV⟩ ⟨z, rfl⟩
+    rw [Set.mem_setOf, Set.singleton_inter_nonempty] at hzU hzV
+    exact hUV.notMem_of_mem_left hzU hzV
+
 end UniformSpace.hausdorff
 
 namespace TopologicalSpace.Closeds
@@ -159,6 +197,35 @@ theorem isOpen_inter_nonempty_of_isOpen {s : Set α} (hs : IsOpen s) :
 theorem isClosed_subsets_of_isClosed {s : Set α} (hs : IsClosed s) :
     IsClosed {t : Closeds α | (t : Set α) ⊆ s} :=
   isClosed_induced (UniformSpace.hausdorff.isClosed_powerset hs)
+
+section T0Space
+
+variable [T0Space α]
+
+theorem isUniformEmbedding_singleton : IsUniformEmbedding (Closeds.singleton (α := α)) :=
+  isUniformEmbedding_coe.of_comp_iff.mp UniformSpace.hausdorff.isUniformEmbedding_singleton
+
+theorem uniformContinuous_singleton : UniformContinuous (Closeds.singleton (α := α)) :=
+  isUniformEmbedding_singleton.uniformContinuous
+
+@[fun_prop]
+theorem isEmbedding_singleton : IsEmbedding (Closeds.singleton (α := α)) :=
+  isUniformEmbedding_singleton.isEmbedding
+
+@[fun_prop]
+theorem continuous_singleton : Continuous (Closeds.singleton (α := α)) :=
+  isEmbedding_singleton.continuous
+
+@[fun_prop]
+theorem isClosedEmbedding_singleton :
+    Topology.IsClosedEmbedding (Closeds.singleton (α := α)) where
+  __ := isUniformEmbedding_singleton.isEmbedding
+  isClosed_range := by
+    rw [← SetLike.coe_injective.preimage_image (s := Set.range singleton), ← Set.range_comp]
+    exact UniformSpace.hausdorff.isClosedEmbedding_singleton.isClosed_range.preimage
+      uniformContinuous_coe.continuous
+
+end T0Space
 
 end TopologicalSpace.Closeds
 
@@ -205,6 +272,12 @@ theorem isOpen_inter_nonempty_of_isOpen {s : Set α} (hs : IsOpen s) :
 theorem isClosed_subsets_of_isClosed {s : Set α} (hs : IsClosed s) :
     IsClosed {t : Compacts α | (t : Set α) ⊆ s} :=
   isClosed_induced (UniformSpace.hausdorff.isClosed_powerset hs)
+
+theorem isUniformEmbedding_singleton : IsUniformEmbedding ({·} : α → Compacts α) :=
+  isUniformEmbedding_coe.of_comp_iff.mp UniformSpace.hausdorff.isUniformEmbedding_singleton
+
+theorem uniformContinuous_singleton : UniformContinuous ({·} : α → Compacts α) :=
+  isUniformEmbedding_singleton.uniformContinuous
 
 end TopologicalSpace.Compacts
 
@@ -267,5 +340,11 @@ theorem isOpen_inter_nonempty_of_isOpen {s : Set α} (hs : IsOpen s) :
 theorem isClosed_subsets_of_isClosed {s : Set α} (hs : IsClosed s) :
     IsClosed {t : NonemptyCompacts α | (t : Set α) ⊆ s} :=
   isClosed_induced (UniformSpace.hausdorff.isClosed_powerset hs)
+
+theorem isUniformEmbedding_singleton : IsUniformEmbedding ({·} : α → NonemptyCompacts α) :=
+  isUniformEmbedding_coe.of_comp_iff.mp UniformSpace.hausdorff.isUniformEmbedding_singleton
+
+theorem uniformContinuous_singleton : UniformContinuous ({·} : α → NonemptyCompacts α) :=
+  isUniformEmbedding_singleton.uniformContinuous
 
 end TopologicalSpace.NonemptyCompacts


### PR DESCRIPTION

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

When merging, all the commits will be squashed into a single commit
listing all co-authors.

Co-authors in the squash commit are gathered from two sources:

First, all authors of commits to this PR branch are included. Thus,
one way to add co-authors is to include at least one commit authored by
each co-author among the commits in the pull request. If necessary, you
may create empty commits to indicate co-authorship, using commands like so:

git commit --author="Author Name <author@email.com>" --allow-empty -m "add Author Name as coauthor"

Second, co-authors can also be listed in lines at the very bottom of
the commit message (that is, directly before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines
at the bottom of the commit message (before the `---`, and also before
any "Co-authored-by" lines) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
