### PR TITLE
[Merged by Bors] - feat(Topology/UniformSpace/Closeds): total boundedness of the powerset

### DIFF
--- a/Mathlib/Topology/MetricSpace/Closeds.lean
+++ b/Mathlib/Topology/MetricSpace/Closeds.lean
@@ -216,48 +216,9 @@ instance Closeds.completeSpace [CompleteSpace α] : CompleteSpace (Closeds α) :
 /-- In a compact space, the type of closed subsets is compact. -/
 instance Closeds.compactSpace [CompactSpace α] : CompactSpace (Closeds α) :=
   ⟨by
-    /- by completeness, it suffices to show that it is totally bounded,
-        i.e., for all ε>0, there is a finite set which is ε-dense.
-        start from a set `s` which is ε-dense in α. Then the subsets of `s`
-        are finitely many, and ε-dense for the Hausdorff distance. -/
-    refine
-      (EMetric.totallyBounded_iff.2 fun ε εpos => ?_).isCompact_of_isClosed isClosed_univ
-    rcases exists_between εpos with ⟨δ, δpos, δlt⟩
-    obtain ⟨s : Set α, fs : s.Finite, hs : univ ⊆ ⋃ y ∈ s, ball y δ⟩ :=
-      EMetric.totallyBounded_iff.1
-        (isCompact_iff_totallyBounded_isComplete.1 (@isCompact_univ α _ _)).1 δ δpos
-    -- we first show that any set is well approximated by a subset of `s`.
-    have main : ∀ u : Set α, ∃ v ⊆ s, hausdorffEdist u v ≤ δ := by
-      intro u
-      let v := { x : α | x ∈ s ∧ ∃ y ∈ u, edist x y < δ }
-      exists v, (fun x hx => hx.1 : v ⊆ s)
-      refine hausdorffEdist_le_of_mem_edist ?_ ?_
-      · intro x hx
-        have : x ∈ ⋃ y ∈ s, ball y δ := hs (by simp)
-        rcases mem_iUnion₂.1 this with ⟨y, ys, dy⟩
-        have : edist y x < δ := by simpa [edist_comm]
-        exact ⟨y, ⟨ys, ⟨x, hx, this⟩⟩, le_of_lt dy⟩
-      · rintro x ⟨_, ⟨y, yu, hy⟩⟩
-        exact ⟨y, yu, le_of_lt hy⟩
-    -- introduce the set F of all subsets of `s` (seen as members of `Closeds α`).
-    let F := { f : Closeds α | (f : Set α) ⊆ s }
-    refine ⟨F, ?_, fun u _ => ?_⟩
-    -- `F` is finite
-    · apply @Finite.of_finite_image _ _ F _
-      · apply fs.finite_subsets.subset fun b => _
-        · exact fun s => (s : Set α)
-        simp only [F, and_imp, Set.mem_image, Set.mem_setOf_eq, exists_imp]
-        intro _ x hx hx'
-        rwa [hx'] at hx
-      · exact SetLike.coe_injective.injOn
-    -- `F` is ε-dense
-    · obtain ⟨t0, t0s, Dut0⟩ := main u
-      have : IsClosed t0 := (fs.subset t0s).isCompact.isClosed
-      let t : Closeds α := ⟨t0, this⟩
-      have : t ∈ F := t0s
-      have : edist u t < ε := lt_of_le_of_lt Dut0 δlt
-      apply mem_iUnion₂.2
-      exact ⟨t, ‹t ∈ F›, this⟩⟩
+    have := Closeds.totallyBounded_subsets_of_totallyBounded (α := α) isCompact_univ.totallyBounded
+    simp_rw [subset_univ, setOf_true] at this
+    exact this.isCompact_of_isClosed isClosed_univ⟩
 
 theorem Closeds.isometry_singleton : Isometry (Closeds.singleton (α := α)) :=
   fun _ _ => hausdorffEdist_singleton

--- a/Mathlib/Topology/UniformSpace/Closeds.lean
+++ b/Mathlib/Topology/UniformSpace/Closeds.lean
@@ -134,17 +134,6 @@ theorem isClosed_powerset {F : Set α} (hF : IsClosed F) :
   simp_rw [Set.powerset, ← isOpen_compl_iff, Set.compl_setOf, ← Set.inter_compl_nonempty_iff]
   exact isOpen_inter_nonempty_of_isOpen hF.isOpen_compl
 
-theorem totallyBounded_powerset {t : Set α} (ht : TotallyBounded t) :
-    TotallyBounded t.powerset := by
-  simp_rw [(𝓤 α).basis_sets.uniformity_hausdorff.totallyBounded_iff, Function.comp_id,
-    Set.powerset, Set.setOf_subset, Set.mem_iUnion]
-  intro (U : SetRel α α) hU
-  obtain ⟨u, hu, ht⟩ := ht U hU
-  refine ⟨u.powerset, hu.powerset, fun s hs => ⟨u ∩ U.image s, by grind, fun x hx => ?_,
-    fun x ⟨_, hx⟩ => hx⟩⟩
-  obtain ⟨y, hy, hxy⟩ := Set.mem_iUnion₂.mp (ht (hs hx))
-  exact ⟨y, ⟨hy, ⟨x, hx, hxy⟩⟩, hxy⟩
-
 theorem isClopen_singleton_empty : IsClopen {(∅ : Set α)} := by
   constructor
   · rw [← Set.powerset_empty]
@@ -181,6 +170,18 @@ theorem isClosedEmbedding_singleton [T0Space α] :
 
 end UniformSpace.hausdorff
 
+/-- In the Hausdorff uniformity, the powerset of a totally bounded set is totally bounded. -/
+theorem TotallyBounded.powerset_hausdorff {t : Set α} (ht : TotallyBounded t) :
+    TotallyBounded t.powerset := by
+  simp_rw [(𝓤 α).basis_sets.uniformity_hausdorff.totallyBounded_iff, Function.comp_id,
+    Set.powerset, Set.setOf_subset, Set.mem_iUnion]
+  intro (U : SetRel α α) hU
+  obtain ⟨u, hu, ht⟩ := ht U hU
+  refine ⟨u.powerset, hu.powerset, fun s hs => ⟨u ∩ U.image s, by grind, fun x hx => ?_,
+    fun x ⟨_, hx⟩ => hx⟩⟩
+  obtain ⟨y, hy, hxy⟩ := Set.mem_iUnion₂.mp (ht (hs hx))
+  exact ⟨y, ⟨hy, ⟨x, hx, hxy⟩⟩, hxy⟩
+
 namespace TopologicalSpace.Closeds
 
 instance uniformSpace : UniformSpace (Closeds α) :=
@@ -212,8 +213,7 @@ theorem isClosed_subsets_of_isClosed {s : Set α} (hs : IsClosed s) :
 
 theorem totallyBounded_subsets_of_totallyBounded {t : Set α} (ht : TotallyBounded t) :
     TotallyBounded {F : Closeds α | ↑F ⊆ t} :=
-  totallyBounded_preimage isUniformEmbedding_coe.isUniformInducing <|
-    UniformSpace.hausdorff.totallyBounded_powerset ht
+  totallyBounded_preimage isUniformEmbedding_coe.isUniformInducing ht.powerset_hausdorff
 
 section T0Space
 
@@ -292,8 +292,7 @@ theorem isClosed_subsets_of_isClosed {s : Set α} (hs : IsClosed s) :
 
 theorem totallyBounded_subsets_of_totallyBounded {t : Set α} (ht : TotallyBounded t) :
     TotallyBounded {K : Compacts α | ↑K ⊆ t} :=
-  totallyBounded_preimage isUniformEmbedding_coe.isUniformInducing <|
-    UniformSpace.hausdorff.totallyBounded_powerset ht
+  totallyBounded_preimage isUniformEmbedding_coe.isUniformInducing ht.powerset_hausdorff
 
 theorem isUniformEmbedding_singleton : IsUniformEmbedding ({·} : α → Compacts α) :=
   isUniformEmbedding_coe.of_comp_iff.mp UniformSpace.hausdorff.isUniformEmbedding_singleton
@@ -365,8 +364,7 @@ theorem isClosed_subsets_of_isClosed {s : Set α} (hs : IsClosed s) :
 
 theorem totallyBounded_subsets_of_totallyBounded {t : Set α} (ht : TotallyBounded t) :
     TotallyBounded {K : NonemptyCompacts α | ↑K ⊆ t} :=
-  totallyBounded_preimage isUniformEmbedding_coe.isUniformInducing <|
-    UniformSpace.hausdorff.totallyBounded_powerset ht
+  totallyBounded_preimage isUniformEmbedding_coe.isUniformInducing ht.powerset_hausdorff
 
 theorem isUniformEmbedding_singleton : IsUniformEmbedding ({·} : α → NonemptyCompacts α) :=
   isUniformEmbedding_coe.of_comp_iff.mp UniformSpace.hausdorff.isUniformEmbedding_singleton

--- a/Mathlib/Topology/UniformSpace/Closeds.lean
+++ b/Mathlib/Topology/UniformSpace/Closeds.lean
@@ -134,6 +134,17 @@ theorem isClosed_powerset {F : Set α} (hF : IsClosed F) :
   simp_rw [Set.powerset, ← isOpen_compl_iff, Set.compl_setOf, ← Set.inter_compl_nonempty_iff]
   exact isOpen_inter_nonempty_of_isOpen hF.isOpen_compl
 
+theorem totallyBounded_powerset {t : Set α} (ht : TotallyBounded t) :
+    TotallyBounded t.powerset := by
+  simp_rw [(𝓤 α).basis_sets.uniformity_hausdorff.totallyBounded_iff, Function.comp_id,
+    Set.powerset, Set.setOf_subset, Set.mem_iUnion]
+  intro (U : SetRel α α) hU
+  obtain ⟨u, hu, ht⟩ := ht U hU
+  refine ⟨u.powerset, hu.powerset, fun s hs => ⟨u ∩ U.image s, by grind, fun x hx => ?_,
+    fun x ⟨_, hx⟩ => hx⟩⟩
+  obtain ⟨y, hy, hxy⟩ := Set.mem_iUnion₂.mp (ht (hs hx))
+  exact ⟨y, ⟨hy, ⟨x, hx, hxy⟩⟩, hxy⟩
+
 theorem isClopen_singleton_empty : IsClopen {(∅ : Set α)} := by
   constructor
   · rw [← Set.powerset_empty]
@@ -198,6 +209,11 @@ theorem isOpen_inter_nonempty_of_isOpen {s : Set α} (hs : IsOpen s) :
 theorem isClosed_subsets_of_isClosed {s : Set α} (hs : IsClosed s) :
     IsClosed {t : Closeds α | (t : Set α) ⊆ s} :=
   isClosed_induced (UniformSpace.hausdorff.isClosed_powerset hs)
+
+theorem totallyBounded_subsets_of_totallyBounded {t : Set α} (ht : TotallyBounded t) :
+    TotallyBounded {F : Closeds α | ↑F ⊆ t} :=
+  totallyBounded_preimage isUniformEmbedding_coe.isUniformInducing <|
+    UniformSpace.hausdorff.totallyBounded_powerset ht
 
 section T0Space
 
@@ -274,6 +290,11 @@ theorem isClosed_subsets_of_isClosed {s : Set α} (hs : IsClosed s) :
     IsClosed {t : Compacts α | (t : Set α) ⊆ s} :=
   isClosed_induced (UniformSpace.hausdorff.isClosed_powerset hs)
 
+theorem totallyBounded_subsets_of_totallyBounded {t : Set α} (ht : TotallyBounded t) :
+    TotallyBounded {K : Compacts α | ↑K ⊆ t} :=
+  totallyBounded_preimage isUniformEmbedding_coe.isUniformInducing <|
+    UniformSpace.hausdorff.totallyBounded_powerset ht
+
 theorem isUniformEmbedding_singleton : IsUniformEmbedding ({·} : α → Compacts α) :=
   isUniformEmbedding_coe.of_comp_iff.mp UniformSpace.hausdorff.isUniformEmbedding_singleton
 
@@ -341,6 +362,11 @@ theorem isOpen_inter_nonempty_of_isOpen {s : Set α} (hs : IsOpen s) :
 theorem isClosed_subsets_of_isClosed {s : Set α} (hs : IsClosed s) :
     IsClosed {t : NonemptyCompacts α | (t : Set α) ⊆ s} :=
   isClosed_induced (UniformSpace.hausdorff.isClosed_powerset hs)
+
+theorem totallyBounded_subsets_of_totallyBounded {t : Set α} (ht : TotallyBounded t) :
+    TotallyBounded {K : NonemptyCompacts α | ↑K ⊆ t} :=
+  totallyBounded_preimage isUniformEmbedding_coe.isUniformInducing <|
+    UniformSpace.hausdorff.totallyBounded_powerset ht
 
 theorem isUniformEmbedding_singleton : IsUniformEmbedding ({·} : α → NonemptyCompacts α) :=
   isUniformEmbedding_coe.of_comp_iff.mp UniformSpace.hausdorff.isUniformEmbedding_singleton


### PR DESCRIPTION
---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

When merging, all the commits will be squashed into a single commit
listing all co-authors.

Co-authors in the squash commit are gathered from two sources:

First, all authors of commits to this PR branch are included. Thus,
one way to add co-authors is to include at least one commit authored by
each co-author among the commits in the pull request. If necessary, you
may create empty commits to indicate co-authorship, using commands like so:

git commit --author="Author Name <author@email.com>" --allow-empty -m "add Author Name as coauthor"

Second, co-authors can also be listed in lines at the very bottom of
the commit message (that is, directly before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines
at the bottom of the commit message (before the `---`, and also before
any "Co-authored-by" lines) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
