### PR TITLE
[Merged by Bors] - feat(Topology/UniformSpace/Closeds): uniform continuity of `Set.image`

### DIFF
--- a/Mathlib/Topology/UniformSpace/Closeds.lean
+++ b/Mathlib/Topology/UniformSpace/Closeds.lean
@@ -333,20 +333,20 @@ theorem isUniformEmbedding_singleton : IsUniformEmbedding ({·} : α → Compact
 theorem uniformContinuous_singleton : UniformContinuous ({·} : α → Compacts α) :=
   isUniformEmbedding_singleton.uniformContinuous
 
-theorem uniformContinuous_map {f : α → β} (hf : UniformContinuous f) :
+theorem _root_.UniformContinuous.compacts_map {f : α → β} (hf : UniformContinuous f) :
     UniformContinuous (Compacts.map f hf.continuous) :=
   isUniformEmbedding_coe.uniformContinuous_iff.mpr <|
     (UniformSpace.hausdorff.uniformContinuous_image hf).comp uniformContinuous_coe
 
-theorem isUniformInducing_map {f : α → β} (hf : IsUniformInducing f) :
+theorem _root_.IsUniformInducing.compacts_map {f : α → β} (hf : IsUniformInducing f) :
     IsUniformInducing (Compacts.map f hf.uniformContinuous.continuous) :=
-  .of_comp (uniformContinuous_map hf.uniformContinuous) uniformContinuous_coe <|
+  .of_comp hf.uniformContinuous.compacts_map uniformContinuous_coe <|
     (UniformSpace.hausdorff.isUniformInducing_image hf).comp
       isUniformEmbedding_coe.isUniformInducing
 
-theorem isUniformEmbedding_map {f : α → β} (hf : IsUniformEmbedding f) :
+theorem _root_.IsUniformEmbedding.compacts_map {f : α → β} (hf : IsUniformEmbedding f) :
     IsUniformEmbedding (Compacts.map f hf.uniformContinuous.continuous) where
-  __ := isUniformInducing_map hf.isUniformInducing
+  __ := hf.isUniformInducing.compacts_map
   injective := map_injective hf.uniformContinuous.continuous hf.injective
 
 end TopologicalSpace.Compacts
@@ -421,20 +421,20 @@ theorem isUniformEmbedding_singleton : IsUniformEmbedding ({·} : α → Nonempt
 theorem uniformContinuous_singleton : UniformContinuous ({·} : α → NonemptyCompacts α) :=
   isUniformEmbedding_singleton.uniformContinuous
 
-theorem uniformContinuous_map {f : α → β} (hf : UniformContinuous f) :
+theorem _root_.UniformContinuous.nonemptyCompacts_map {f : α → β} (hf : UniformContinuous f) :
     UniformContinuous (NonemptyCompacts.map f hf.continuous) :=
   isUniformEmbedding_coe.uniformContinuous_iff.mpr <|
     (UniformSpace.hausdorff.uniformContinuous_image hf).comp uniformContinuous_coe
 
-theorem isUniformInducing_map {f : α → β} (hf : IsUniformInducing f) :
+theorem _root_.IsUniformInducing.nonemptyCompacts_map {f : α → β} (hf : IsUniformInducing f) :
     IsUniformInducing (NonemptyCompacts.map f hf.uniformContinuous.continuous) :=
-  .of_comp (uniformContinuous_map hf.uniformContinuous) uniformContinuous_coe <|
+  .of_comp hf.uniformContinuous.nonemptyCompacts_map uniformContinuous_coe <|
     (UniformSpace.hausdorff.isUniformInducing_image hf).comp
       isUniformEmbedding_coe.isUniformInducing
 
-theorem isUniformEmbedding_map {f : α → β} (hf : IsUniformEmbedding f) :
+theorem _root_.IsUniformEmbedding.nonemptyCompacts_map {f : α → β} (hf : IsUniformEmbedding f) :
     IsUniformEmbedding (NonemptyCompacts.map f hf.uniformContinuous.continuous) where
-  __ := isUniformInducing_map hf.isUniformInducing
+  __ := hf.isUniformInducing.nonemptyCompacts_map
   injective := map_injective hf.uniformContinuous.continuous hf.injective
 
 end TopologicalSpace.NonemptyCompacts

--- a/Mathlib/Topology/UniformSpace/Closeds.lean
+++ b/Mathlib/Topology/UniformSpace/Closeds.lean
@@ -168,7 +168,11 @@ theorem isClosedEmbedding_singleton [T0Space α] :
     rw [Set.mem_setOf, Set.singleton_inter_nonempty] at hzU hzV
     exact hUV.notMem_of_mem_left hzU hzV
 
-theorem uniformContinuous_image {f : α → β} (hf : UniformContinuous f) :
+end UniformSpace.hausdorff
+
+/-- When `Set` is equipped with the Hausdorff uniformity, taking the image under a uniformly
+continuous map is uniformly continuous. -/
+theorem UniformContinuous.image_hausdorff {f : α → β} (hf : UniformContinuous f) :
     UniformContinuous (f '' ·) := by
   refine Filter.tendsto_lift'.mpr fun U hU => ?_
   filter_upwards [Filter.mem_lift' (hf hU)] with ⟨s, t⟩ ⟨h₁, h₂⟩
@@ -176,7 +180,9 @@ theorem uniformContinuous_image {f : α → β} (hf : UniformContinuous f) :
   exact ⟨h₁.trans fun x ⟨y, hy, hxy⟩ => ⟨f y, Set.mem_image_of_mem f hy, hxy⟩,
     h₂.trans fun x ⟨y, hy, hxy⟩ => ⟨f y, Set.mem_image_of_mem f hy, hxy⟩⟩
 
-theorem isUniformInducing_image {f : α → β} (hf : IsUniformInducing f) :
+/-- When `Set` is equipped with the Hausdorff uniformity, taking the image under a uniform
+inducing map is uniform inducing. -/
+theorem IsUniformInducing.image_hausdorff {f : α → β} (hf : IsUniformInducing f) :
     IsUniformInducing (f '' ·) := by
   constructor
   change Filter.comap _ (Filter.lift' _ _) = Filter.lift' _ _
@@ -186,12 +192,12 @@ theorem isUniformInducing_image {f : α → β} (hf : IsUniformInducing f) :
   simp only [Function.comp, hausdorffEntourage, SetRel.preimage, SetRel.image, Set.preimage,
     Set.mem_setOf, Set.image_subset_iff, Set.exists_mem_image]
 
-theorem isUniformEmbedding_image {f : α → β} (hf : IsUniformEmbedding f) :
+/-- When `Set` is equipped with the Hausdorff uniformity, taking the image under a uniform
+embedding is a uniform embedding. -/
+theorem IsUniformEmbedding.image_hausdorff {f : α → β} (hf : IsUniformEmbedding f) :
     IsUniformEmbedding (f '' ·) where
-  __ := isUniformInducing_image hf.isUniformInducing
+  __ := hf.isUniformInducing.image_hausdorff
   injective := hf.injective.image_injective
-
-end UniformSpace.hausdorff
 
 /-- In the Hausdorff uniformity, the powerset of a totally bounded set is totally bounded. -/
 theorem TotallyBounded.powerset_hausdorff {t : Set α} (ht : TotallyBounded t) :
@@ -335,14 +341,12 @@ theorem uniformContinuous_singleton : UniformContinuous ({·} : α → Compacts 
 
 theorem _root_.UniformContinuous.compacts_map {f : α → β} (hf : UniformContinuous f) :
     UniformContinuous (Compacts.map f hf.continuous) :=
-  isUniformEmbedding_coe.uniformContinuous_iff.mpr <|
-    (UniformSpace.hausdorff.uniformContinuous_image hf).comp uniformContinuous_coe
+  isUniformEmbedding_coe.uniformContinuous_iff.mpr <| hf.image_hausdorff.comp uniformContinuous_coe
 
 theorem _root_.IsUniformInducing.compacts_map {f : α → β} (hf : IsUniformInducing f) :
     IsUniformInducing (Compacts.map f hf.uniformContinuous.continuous) :=
   .of_comp hf.uniformContinuous.compacts_map uniformContinuous_coe <|
-    (UniformSpace.hausdorff.isUniformInducing_image hf).comp
-      isUniformEmbedding_coe.isUniformInducing
+    hf.image_hausdorff.comp isUniformEmbedding_coe.isUniformInducing
 
 theorem _root_.IsUniformEmbedding.compacts_map {f : α → β} (hf : IsUniformEmbedding f) :
     IsUniformEmbedding (Compacts.map f hf.uniformContinuous.continuous) where
@@ -423,14 +427,12 @@ theorem uniformContinuous_singleton : UniformContinuous ({·} : α → NonemptyC
 
 theorem _root_.UniformContinuous.nonemptyCompacts_map {f : α → β} (hf : UniformContinuous f) :
     UniformContinuous (NonemptyCompacts.map f hf.continuous) :=
-  isUniformEmbedding_coe.uniformContinuous_iff.mpr <|
-    (UniformSpace.hausdorff.uniformContinuous_image hf).comp uniformContinuous_coe
+  isUniformEmbedding_coe.uniformContinuous_iff.mpr <| hf.image_hausdorff.comp uniformContinuous_coe
 
 theorem _root_.IsUniformInducing.nonemptyCompacts_map {f : α → β} (hf : IsUniformInducing f) :
     IsUniformInducing (NonemptyCompacts.map f hf.uniformContinuous.continuous) :=
   .of_comp hf.uniformContinuous.nonemptyCompacts_map uniformContinuous_coe <|
-    (UniformSpace.hausdorff.isUniformInducing_image hf).comp
-      isUniformEmbedding_coe.isUniformInducing
+    hf.image_hausdorff.comp isUniformEmbedding_coe.isUniformInducing
 
 theorem _root_.IsUniformEmbedding.nonemptyCompacts_map {f : α → β} (hf : IsUniformEmbedding f) :
     IsUniformEmbedding (NonemptyCompacts.map f hf.uniformContinuous.continuous) where


### PR DESCRIPTION
---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

When merging, all the commits will be squashed into a single commit
listing all co-authors.

Co-authors in the squash commit are gathered from two sources:

First, all authors of commits to this PR branch are included. Thus,
one way to add co-authors is to include at least one commit authored by
each co-author among the commits in the pull request. If necessary, you
may create empty commits to indicate co-authorship, using commands like so:

git commit --author="Author Name <author@email.com>" --allow-empty -m "add Author Name as coauthor"

Second, co-authors can also be listed in lines at the very bottom of
the commit message (that is, directly before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines
at the bottom of the commit message (before the `---`, and also before
any "Co-authored-by" lines) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
