### PR TITLE
[Merged by Bors] - feat(FieldTheory): prerequisites for #31489

### DIFF
--- a/Mathlib/FieldTheory/IntermediateField/Algebraic.lean
+++ b/Mathlib/FieldTheory/IntermediateField/Algebraic.lean
@@ -101,7 +101,7 @@ theorem eq_of_le_of_finrank_eq' [FiniteDimensional F L] (h_le : F ≤ E)
     (h_finrank : finrank F L = finrank E L) : F = E :=
   eq_of_le_of_finrank_le' h_le h_finrank.le
 
-lemma finrank_lt_of_lt [FiniteDimensional F L] (H : F < E) :
+lemma finrank_lt_of_gt [FiniteDimensional F L] (H : F < E) :
     Module.finrank E L < Module.finrank F L := by
   letI := (IntermediateField.inclusion H.le).toAlgebra
   have : IsScalarTower F E L := .of_algebraMap_eq' rfl

--- a/Mathlib/FieldTheory/IntermediateField/Algebraic.lean
+++ b/Mathlib/FieldTheory/IntermediateField/Algebraic.lean
@@ -101,6 +101,14 @@ theorem eq_of_le_of_finrank_eq' [FiniteDimensional F L] (h_le : F ≤ E)
     (h_finrank : finrank F L = finrank E L) : F = E :=
   eq_of_le_of_finrank_le' h_le h_finrank.le
 
+lemma finrank_lt_of_lt [FiniteDimensional F L] (H : F < E) :
+    Module.finrank E L < Module.finrank F L := by
+  letI := (IntermediateField.inclusion H.le).toAlgebra
+  have : IsScalarTower F E L := .of_algebraMap_eq' rfl
+  refine lt_of_le_of_ne ?_ ?_
+  · exact Module.finrank_top_le_finrank_of_isScalarTower _ _ _
+  · exact .symm (mt (eq_of_le_of_finrank_eq' H.le) H.ne)
+
 theorem finrank_dvd_of_le_left (h : F ≤ E) : finrank E L ∣ finrank F L := by
   let _ := (inclusion h).toRingHom.toAlgebra
   have : IsScalarTower F E L := IsScalarTower.of_algebraMap_eq fun x ↦ rfl

--- a/Mathlib/FieldTheory/Normal/Closure.lean
+++ b/Mathlib/FieldTheory/Normal/Closure.lean
@@ -256,11 +256,13 @@ variable (F L)
 
 /-- `normalClosure` as a `ClosureOperator`. -/
 @[simps]
-noncomputable def closureOperator : ClosureOperator (IntermediateField F L) where
-  toFun := fun K ↦ normalClosure F K L
-  monotone' := fun K K' ↦ normalClosure_mono K K'
+noncomputable def normalClosureOperator : ClosureOperator (IntermediateField F L) where
+  toFun K := normalClosure F K L
+  monotone' K K' := normalClosure_mono K K'
   le_closure' := le_normalClosure
-  idempotent' := fun K ↦ normalClosure_of_normal (normalClosure F K L)
+  idempotent' K := normalClosure_of_normal (normalClosure F K L)
+
+@[deprecated (since := "2025-11-21")] alias closureOperator := normalClosureOperator
 
 variable {K : IntermediateField F L} {F L}
 

--- a/Mathlib/FieldTheory/Separable.lean
+++ b/Mathlib/FieldTheory/Separable.lean
@@ -584,12 +584,23 @@ theorem Algebra.isSeparable_iff :
   ⟨fun _ x => ⟨Algebra.IsSeparable.isIntegral F x, Algebra.IsSeparable.isSeparable F x⟩,
     fun h => ⟨fun x => (h x).2⟩⟩
 
-variable {L} in
-lemma IsSeparable.map [Ring L] [Algebra F L] {x : K} (f : K →ₐ[F] L) (hf : Function.Injective f)
-    (H : IsSeparable F x) : IsSeparable F (f x) := by
-  rwa [IsSeparable, minpoly.algHom_eq _ hf]
+variable {L}
 
-variable {E : Type*}
+lemma isSeparable_map_iff [Ring L] [Algebra F L] {x : K} (f : K →ₐ[F] L)
+    (hf : Function.Injective f) : IsSeparable F (f x) ↔ IsSeparable F x := by
+  simp_rw [IsSeparable, minpoly.algHom_eq _ hf]
+
+lemma IsSeparable.map [Ring L] [Algebra F L] {x : K} (f : K →ₐ[F] L) (hf : Function.Injective f)
+    (H : IsSeparable F x) : IsSeparable F (f x) :=
+  (isSeparable_map_iff f hf).mpr H
+
+lemma Subalgebra.isSeparable_iff [Ring L] [Algebra F L] {S : Subalgebra F L} :
+    Algebra.IsSeparable F S ↔ ∀ x ∈ S, IsSeparable F x := by
+  simp_rw [Algebra.isSeparable_def, Subtype.forall,
+    ← isSeparable_map_iff S.val Subtype.val_injective]
+  rfl
+
+variable (L) {E : Type*}
 
 section AlgEquiv
 

--- a/Mathlib/FieldTheory/SeparableClosure.lean
+++ b/Mathlib/FieldTheory/SeparableClosure.lean
@@ -397,7 +397,7 @@ lemma FG.exists_finset_maximalFor_isTranscendenceBasis_separableClosure
     · convert hs.isAlgebraic_field <;> simp [s]
   have : Module.Finite ((separableClosure (adjoin F (s : Set E)) E).restrictScalars F) E :=
     inferInstanceAs <| Module.Finite (separableClosure (adjoin F (s : Set E)) E) E
-  exact d.not_lt_argminOn _ ht Hexists (by apply finrank_lt_of_lt H)
+  exact d.not_lt_argminOn _ ht Hexists (by apply finrank_lt_of_gt H)
 
 @[simp]
 theorem sepDegree_bot : sepDegree F (⊥ : IntermediateField F E) = 1 := by

--- a/Mathlib/FieldTheory/SeparableClosure.lean
+++ b/Mathlib/FieldTheory/SeparableClosure.lean
@@ -7,6 +7,7 @@ module
 
 public import Mathlib.FieldTheory.SeparableDegree
 public import Mathlib.FieldTheory.IsSepClosed
+public import Mathlib.RingTheory.AlgebraicIndependent.AlgebraicClosure
 
 /-!
 
@@ -82,7 +83,7 @@ def separableClosure : IntermediateField F E where
   carrier := {x | IsSeparable F x}
   mul_mem' := isSeparable_mul
   add_mem' := isSeparable_add
-  algebraMap_mem' := isSeparable_algebraMap E
+  algebraMap_mem' := isSeparable_algebraMap
   inv_mem' _ := isSeparable_inv
 
 variable {F E K}
@@ -163,8 +164,7 @@ theorem le_separableClosure (L : IntermediateField F E) [Algebra.IsSeparable F L
 if and only if it is separable over `F`. -/
 theorem le_separableClosure_iff (L : IntermediateField F E) :
     L ≤ separableClosure F E ↔ Algebra.IsSeparable F L :=
-  ⟨fun h ↦ ⟨fun x ↦ by simpa only [IsSeparable, minpoly_eq] using h x.2⟩,
-    fun _ ↦ le_separableClosure _ _ _⟩
+  Subalgebra.isSeparable_iff.symm
 
 /-- The separable closure in `E` of the separable closure of `F` in `E` is equal to itself. -/
 theorem separableClosure.separableClosure_eq_bot :
@@ -259,6 +259,33 @@ instance IntermediateField.isSeparable_iSup {ι : Type*} {t : ι → Intermediat
   simp_rw [← le_separableClosure_iff] at h ⊢
   exact iSup_le h
 
+variable {F E} in
+theorem le_restrictScalars_separableClosure (L : IntermediateField F E) :
+    L ≤ (separableClosure L E).restrictScalars F :=
+  fun x hx ↦ isSeparable_algebraMap (F := L) ⟨x, hx⟩
+
+/-- `separableClosure` as a `ClosureOperator`. -/
+abbrev separableClosureOperator : ClosureOperator (IntermediateField F E) := by
+  refine .mk' (fun K ↦ (separableClosure K E).restrictScalars F) (fun K L le x hx ↦ ?_)
+    le_restrictScalars_separableClosure fun K x hx ↦ ?_ <;> dsimp only at hx ⊢
+  · let _ := (inclusion le).toAlgebra
+    have : IsScalarTower K L E := .of_algebraMap_eq' rfl
+    exact hx.tower_top _
+  · obtain ⟨x, rfl⟩ := (separableClosure.separableClosure_eq_bot K E).le hx
+    exact x.2
+
+lemma isClosed_restrictScalars_separableClosure [Algebra K E] [IsScalarTower F K E] :
+    (separableClosureOperator F E).IsClosed ((separableClosure K E).restrictScalars F) :=
+  ClosureOperator.isClosed_iff_closure_le.mpr fun x hx ↦ by
+    obtain ⟨x, rfl⟩ := (separableClosure.separableClosure_eq_bot K E).le hx
+    exact x.2
+
+lemma separableClosure_le_separableClosure_iff
+    [Algebra K E] [IsScalarTower F K E] {L : IntermediateField F E} :
+    (separableClosure L E).restrictScalars F ≤ (separableClosure K E).restrictScalars F ↔
+      L ≤ (separableClosure K E).restrictScalars F :=
+   (isClosed_restrictScalars_separableClosure F E K).closure_le_iff
+
 end separableClosure
 
 namespace Field
@@ -342,6 +369,35 @@ theorem finInsepDegree_self : finInsepDegree F F = 1 := by
 end Field
 
 namespace IntermediateField
+
+/-- In a finitely generated field extension, there exists a maximal
+separably generated field extension. -/
+lemma FG.exists_finset_maximalFor_isTranscendenceBasis_separableClosure
+    (Hfg : FG (F := F) (E := E) ⊤) :
+    ∃ s : Finset E, MaximalFor (fun t : Set E ↦ IsTranscendenceBasis F ((↑) : t → E))
+      (fun t ↦ (separableClosure (adjoin F t) E).restrictScalars F) s := by
+  let d (s : Finset E) := Field.finInsepDegree (adjoin F (s : Set E)) E
+  have Hexists : {s : Finset E | IsTranscendenceBasis F ((↑) : s → E)}.Nonempty := by
+    have ⟨s, hs⟩ := Hfg
+    have : Algebra.IsAlgebraic (Algebra.adjoin F (s : Set E)) E := by
+      rw [← isAlgebraic_adjoin_iff_top, hs, Algebra.isAlgebraic_iff_isIntegral]
+      refine Algebra.isIntegral_of_surjective topEquiv.surjective
+    have ⟨t, hts, ht⟩ := exists_isTranscendenceBasis_subset (R := F) (s : Set E)
+    lift t to Finset E using s.finite_toSet.subset hts
+    exact ⟨t, ht⟩
+  let s := d.argminOn _ Hexists
+  have hs := d.argminOn_mem _ Hexists
+  refine ⟨s, hs, fun t ht ↦ not_lt_iff_le_imp_ge.mp fun H ↦ ?_⟩
+  have : t.Finite := by
+    simp [Set.Finite, ← Cardinal.mk_lt_aleph0_iff, ht.cardinalMk_eq hs, Cardinal.nat_lt_aleph0]
+  lift t to Finset E using this
+  have : Module.Finite (adjoin F (s : Set E)) E := by
+    apply (config := { allowSynthFailures := true }) finite_of_fg_of_isAlgebraic
+    · exact .of_restrictScalars (K := F) (by rwa [restrictScalars_top])
+    · convert hs.isAlgebraic_field <;> simp [s]
+  have : Module.Finite ((separableClosure (adjoin F (s : Set E)) E).restrictScalars F) E :=
+    inferInstanceAs <| Module.Finite (separableClosure (adjoin F (s : Set E)) E) E
+  exact d.not_lt_argminOn _ ht Hexists (by apply finrank_lt_of_lt H)
 
 @[simp]
 theorem sepDegree_bot : sepDegree F (⊥ : IntermediateField F E) = 1 := by

--- a/Mathlib/FieldTheory/SeparableDegree.lean
+++ b/Mathlib/FieldTheory/SeparableDegree.lean
@@ -850,14 +850,11 @@ theorem IntermediateField.isSeparable_adjoin_pair_of_isSeparable {x y : E}
 
 namespace Field
 
-variable {F}
-
 /-- Any element `x` of `F` is a separable element of `E / F` when embedded into `E`. -/
-theorem isSeparable_algebraMap (x : F) : IsSeparable F ((algebraMap F E) x) := by
-  rw [IsSeparable, minpoly.algebraMap_eq (algebraMap F E).injective]
-  exact Algebra.IsSeparable.isSeparable F x
+@[deprecated (since := "2025-11-21")]
+protected alias isSeparable_algebraMap := _root_.isSeparable_algebraMap
 
-variable {E}
+variable {F E}
 
 /-- If `x` and `y` are both separable elements, then `x * y` is also a separable element. -/
 theorem isSeparable_mul {x y : E} (hx : IsSeparable F x) (hy : IsSeparable F y) :

--- a/Mathlib/Logic/Equiv/Basic.lean
+++ b/Mathlib/Logic/Equiv/Basic.lean
@@ -710,6 +710,18 @@ theorem swap_apply_eq_iff {x y z w : α} : swap x y z = w ↔ z = swap x y w := 
 theorem swap_apply_ne_self_iff {a b x : α} : swap a b x ≠ x ↔ a ≠ b ∧ (x = a ∨ x = b) := by
   grind
 
+lemma image_swap_of_mem_of_notMem {α : Type*} [DecidableEq α] {s : Set α} {i j : α}
+    (hi : i ∈ s) (hj : j ∉ s) : s.image (swap i j) = insert j s \ {i} :=
+  Set.ext fun a ↦ by
+    constructor
+    · rintro ⟨a, ha, rfl⟩
+      obtain rfl | ne := eq_or_ne a i
+      · rw [swap_apply_left]; exact ⟨.inl rfl, (ne_of_mem_of_not_mem hi hj).symm⟩
+      · rw [swap_apply_of_ne_of_ne ne (ne_of_mem_of_not_mem ha hj)]; exact ⟨.inr ha, ne⟩
+    · rintro ⟨rfl | has, hai⟩
+      · exact ⟨i, hi, swap_apply_left ..⟩
+      · exact ⟨a, has, swap_apply_of_ne_of_ne hai (ne_of_mem_of_not_mem has hj)⟩
+
 namespace Perm
 
 @[simp]

--- a/Mathlib/RingTheory/AlgebraicIndependent/Defs.lean
+++ b/Mathlib/RingTheory/AlgebraicIndependent/Defs.lean
@@ -114,11 +114,15 @@ theorem algebraicIndependent_image {ι} {s : Set ι} {f : ι → A} (hf : Set.In
     (AlgebraicIndependent R fun x : s => f x) ↔ AlgebraicIndependent R fun x : f '' s => (x : A) :=
   algebraicIndependent_equiv' (Equiv.Set.imageOfInjOn _ _ hf) rfl
 
+lemma AlgebraicIndepOn.mono {s t : Set ι} (H : AlgebraicIndepOn R x t) (hst : s ⊆ t) :
+    AlgebraicIndepOn R x s := by
+  simpa [Function.comp] using H.comp (Set.inclusion hst) (Set.inclusion_injective hst)
+
 namespace AlgebraicIndependent
 
 theorem mono {t s : Set A} (h : t ⊆ s)
-    (hx : AlgebraicIndependent R ((↑) : s → A)) : AlgebraicIndependent R ((↑) : t → A) := by
-  simpa [Function.comp] using hx.comp (inclusion h) (inclusion_injective h)
+    (hx : AlgebraicIndependent R ((↑) : s → A)) : AlgebraicIndependent R ((↑) : t → A) :=
+  AlgebraicIndepOn.mono (x := id) hx h
 
 section repr
 

--- a/Mathlib/RingTheory/AlgebraicIndependent/TranscendenceBasis.lean
+++ b/Mathlib/RingTheory/AlgebraicIndependent/TranscendenceBasis.lean
@@ -547,3 +547,56 @@ variable (R S A)
     trdeg R S + trdeg S A = trdeg R A := by
   rw [← (trdeg R S).lift_id, ← (trdeg S A).lift_id, ← (trdeg R A).lift_id]
   exact lift_trdeg_add_eq R S A
+
+namespace IsTranscendenceBasis
+
+variable {R S} [FaithfulSMul R S] [NoZeroDivisors S] (s : Set ι) (i j : ι) (v : ι → S)
+
+/-- If `s` is a transcendence basis and `j` is algebraic over `s ∪ {i} \ {j}`,
+then `s ∪ {i} \ {j}` is also a transcendence basis. -/
+lemma of_isAlgebraic_adjoin_insert_diff (hj : j ∈ insert i s)
+    (H₁ : IsTranscendenceBasis R fun x : s ↦ v x)
+    (H₂ : IsAlgebraic (Algebra.adjoin R (v '' (insert i s \ {j}))) (v j)) :
+    IsTranscendenceBasis R fun x : ↥(insert i s \ {j}) ↦ v x := by
+  have := H₂.nontrivial
+  have := (adjoin R (v '' (insert i s \ {j}))).subtype_injective.nontrivial
+  have := (isDomain_iff_noZeroDivisors_and_nontrivial S).mpr ⟨‹_›, ‹_›⟩
+  have := Module.nontrivial R S
+  rw [← mem_algebraicClosure, ← SetLike.mem_coe, ← matroid_closure_eq] at H₂
+  have inj := injOn_iff_injective.mpr H₁.1.injective
+  have H' := image_eq_range .. ▸ matroid_isBase_iff.mpr H₁.to_subtype_range
+  obtain hj' | hj := (em (j ∈ s)).symm
+  · cases hj.resolve_right hj'; rwa [insert_diff_self_of_notMem hj']
+  have Hj := H'.indep.notMem_closure_diff_of_mem ⟨j, hj, rfl⟩
+  have hi : i ∉ s := fun hi ↦ Hj <| by
+    rw [← image_singleton, ← inj.image_diff_subset (singleton_subset_iff.mpr hj)]
+    rwa [insert_eq_of_mem hi] at H₂
+  obtain eq | ne := eq_or_ne (v i) (v j)
+  · classical
+    convert H₁.comp_equiv <| .symm <| ((Equiv.swap j i).image s).trans <|
+      .setCongr <| Equiv.image_swap_of_mem_of_notMem hj hi with ⟨x, rfl | hxi, hxj⟩
+    · simp [eq]
+    · simp [Equiv.swap_apply_of_ne_of_ne hxj (ne_of_mem_of_not_mem hxi hi)]
+  have hi' : v i ∉ v '' s := fun his ↦ Hj <| by
+    refine Matroid.closure_subset_closure _ ?_ H₂
+    rintro x ⟨k, ⟨rfl | hks, hkj⟩, rfl⟩
+    · exact ⟨his, ne⟩
+    · exact ⟨⟨k, hks, rfl⟩, inj.ne hks hj hkj⟩
+  have : (insert i s).InjOn v := (injOn_insert hi).mpr ⟨inj, hi'⟩
+  rw [← isTranscendenceBasis_subtype_range (by exact injOn_iff_injective.1 (this.mono diff_subset)),
+    ← matroid_isBase_iff, ← image_eq_range]
+  rw [this.image_diff_subset (singleton_subset_iff.mpr (.inr hj)), image_singleton,
+    image_insert_eq] at H₂ ⊢
+  exact H'.isBase_insert_diff_of_mem_closure H₂ (.inr ⟨j, hj, rfl⟩)
+
+lemma of_isAlgebraic_adjoin_image_compl
+    (H₁ : IsTranscendenceBasis R fun x : {x // x ≠ i} ↦ v x)
+    (H₂ : IsAlgebraic (Algebra.adjoin R (v '' {j}ᶜ)) (v j)) :
+    IsTranscendenceBasis R fun x : {x // x ≠ j} ↦ v x := by
+  obtain rfl | ne := eq_or_ne j i
+  · exact H₁
+  have := H₁.of_isAlgebraic_adjoin_insert_diff {i}ᶜ i j v (.inr ne)
+  rw [compl_eq_univ_diff, insert_diff_self_of_mem (mem_univ _), ← compl_eq_univ_diff] at this
+  exact this H₂
+
+end IsTranscendenceBasis


### PR DESCRIPTION
---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

When merging, all the commits will be squashed into a single commit
listing all co-authors.

Co-authors in the squash commit are gathered from two sources:

First, all authors of commits to this PR branch are included. Thus,
one way to add co-authors is to include at least one commit authored by
each co-author among the commits in the pull request. If necessary, you
may create empty commits to indicate co-authorship, using commands like so:

git commit --author="Author Name <author@email.com>" --allow-empty -m "add Author Name as coauthor"

Second, co-authors can also be listed in lines at the very bottom of
the commit message (that is, directly before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines
at the bottom of the commit message (before the `---`, and also before
any "Co-authored-by" lines) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
