### PR TITLE
[Merged by Bors] - feat: basic lemmas about convexity over NNReal

### DIFF
--- a/Mathlib.lean
+++ b/Mathlib.lean
@@ -1707,6 +1707,7 @@ public import Mathlib.Analysis.Convex.KreinMilman
 public import Mathlib.Analysis.Convex.LinearIsometry
 public import Mathlib.Analysis.Convex.Measure
 public import Mathlib.Analysis.Convex.Mul
+public import Mathlib.Analysis.Convex.NNReal
 public import Mathlib.Analysis.Convex.PartitionOfUnity
 public import Mathlib.Analysis.Convex.PathConnected
 public import Mathlib.Analysis.Convex.Piecewise

--- a/Mathlib/Analysis/Convex/NNReal.lean
+++ b/Mathlib/Analysis/Convex/NNReal.lean
@@ -1,0 +1,43 @@
+/-
+Copyright (c) 2025 Anatole Dedecker. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Anatole Dedecker
+-/
+module
+
+public import Mathlib.Analysis.Convex.Basic
+public import Mathlib.Data.NNReal.Basic
+
+/-!
+# Specific lemmas about convexity over `ℝ≥0`
+
+This file collects some specific results about convexity over the ring `ℝ≥0`.
+Expand as needed.
+-/
+
+@[expose] public section
+
+open Set
+open scoped NNReal
+
+namespace NNReal
+
+protected lemma Icc_subset_segment {x y : ℝ≥0} :
+    Icc x y ⊆ segment ℝ≥0 x y :=
+  Nonneg.Icc_subset_segment
+
+protected lemma segment_eq_Icc {x y : ℝ≥0} (hxy : x ≤ y) :
+    segment ℝ≥0 x y = Icc x y :=
+  Nonneg.segment_eq_Icc hxy
+
+protected lemma segment_eq_uIcc {x y : ℝ≥0} :
+    segment ℝ≥0 x y = uIcc x y :=
+  Nonneg.segment_eq_uIcc
+
+protected lemma convex_iff {M : Type*} [AddCommMonoid M] [Module ℝ M] {s : Set M} :
+    Convex ℝ≥0 s ↔ Convex ℝ s := by
+  refine ⟨fun H ↦ ?_, Convex.lift ℝ≥0⟩
+  intro _ hx _ hy a b ha hb hab
+  exact H hx hy (a := ⟨a, ha⟩) (b := ⟨b, hb⟩) (zero_le _) (zero_le _) (by ext; simpa)
+
+end NNReal

--- a/Mathlib/Analysis/Convex/Segment.lean
+++ b/Mathlib/Analysis/Convex/Segment.lean
@@ -5,6 +5,7 @@ Authors: Alexander Bentkamp, Yury Kudryashov, Yaël Dillies
 -/
 module
 
+public import Mathlib.Algebra.Order.Nonneg.Ring
 public import Mathlib.LinearAlgebra.AffineSpace.Midpoint
 public import Mathlib.LinearAlgebra.LinearIndependent.Lemmas
 public import Mathlib.LinearAlgebra.Ray
@@ -574,6 +575,30 @@ theorem Convex.mem_Ico (h : x < y) :
     · exact Ioo_subset_Ico_self ((Convex.mem_Ioo h).2 ⟨a, b, ha, hb', hab, rfl⟩)
 
 end LinearOrderedField
+
+namespace Nonneg
+
+variable [Field 𝕜] [LinearOrder 𝕜] [IsStrictOrderedRing 𝕜] {x y z : 𝕜}
+
+protected lemma Icc_subset_segment {x y : {t : 𝕜 // 0 ≤ t}} :
+    Icc x y ⊆ segment {t : 𝕜 // 0 ≤ t} x y := by
+  intro a ⟨hxa, hay⟩
+  rw [← Subtype.coe_le_coe] at hxa hay
+  rcases Icc_subset_segment ⟨hxa, hay⟩ with ⟨t₁, t₂, t₁_nonneg, t₂_nonneg, t_add, hta⟩
+  refine ⟨⟨t₁, t₁_nonneg⟩, ⟨t₂, t₂_nonneg⟩, zero_le _, zero_le _, ?_, ?_⟩ <;>
+  ext <;> simpa
+
+protected lemma segment_eq_Icc {x y : {t : 𝕜 // 0 ≤ t}} (hxy : x ≤ y) :
+    segment {t : 𝕜 // 0 ≤ t} x y = Icc x y := by
+  refine subset_antisymm (segment_subset_Icc hxy) Nonneg.Icc_subset_segment
+
+protected lemma segment_eq_uIcc {x y : {t : 𝕜 // 0 ≤ t}} :
+    segment {t : 𝕜 // 0 ≤ t} x y = uIcc x y := by
+  rcases le_total x y with h | h
+  · simp [h, Nonneg.segment_eq_Icc]
+  · simp [h, segment_symm _ x y, Nonneg.segment_eq_Icc]
+
+end Nonneg
 
 namespace Prod
 


### PR DESCRIPTION
---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

When merging, all the commits will be squashed into a single commit
listing all co-authors.

Co-authors in the squash commit are gathered from two sources:

First, all authors of commits to this PR branch are included. Thus,
one way to add co-authors is to include at least one commit authored by
each co-author among the commits in the pull request. If necessary, you
may create empty commits to indicate co-authorship, using commands like so:

git commit --author="Author Name <author@email.com>" --allow-empty -m "add Author Name as coauthor"

Second, co-authors can also be listed in lines at the very bottom of
the commit message (that is, directly before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines
at the bottom of the commit message (before the `---`, and also before
any "Co-authored-by" lines) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
