### PR TITLE
[Merged by Bors] - chore: do not set `group` when declaring option

### DIFF
--- a/Mathlib/Tactic/Push.lean
+++ b/Mathlib/Tactic/Push.lean
@@ -62,7 +62,6 @@ theorem not_forall_eq : (¬ ∀ x, s x) = (∃ x, ¬ s x) := propext not_forall
 /-- Make `push_neg` use `not_and_or` rather than the default `not_and`. -/
 register_option push_neg.use_distrib : Bool :=
   { defValue := false
-    group := ""
     descr := "Make `push_neg` use `not_and_or` rather than the default `not_and`." }
 
 open Lean Meta Elab.Tactic Parser.Tactic

--- a/Mathlib/Tactic/Says.lean
+++ b/Mathlib/Tactic/Says.lean
@@ -39,13 +39,11 @@ namespace Mathlib.Tactic.Says
 /-- If this option is `true`, verify for `X says Y` that `X says` outputs `Y`. -/
 register_option says.verify : Bool :=
   { defValue := false
-    group := "says"
     descr := "Verify the output" }
 
 /-- This option is only used in CI to negate `says.verify`. -/
 register_option says.no_verify_in_CI : Bool :=
   { defValue := false
-    group := "says"
     descr := "Disable reverification, even if the `CI` environment variable is set." }
 
 open Parser Tactic

--- a/Mathlib/Tactic/Variable.lean
+++ b/Mathlib/Tactic/Variable.lean
@@ -31,13 +31,11 @@ initialize registerTraceClass `variable?
 
 register_option variable?.maxSteps : Nat :=
   { defValue := 15
-    group := "variable?"
     descr :=
       "The maximum number of instance arguments `variable?` will try to insert before giving up" }
 
 register_option variable?.checkRedundant : Bool :=
   { defValue := true
-    group := "variable?"
     descr := "Warn if instance arguments can be inferred from preceding ones" }
 
 /-- Get the type out of a bracketed binder. -/

--- a/Mathlib/Util/PPOptions.lean
+++ b/Mathlib/Util/PPOptions.lean
@@ -23,7 +23,6 @@ should use binder predicate notation (such as `∀ x < 2, p x`).
 -/
 register_option pp.mathlib.binderPredicates : Bool := {
   defValue := true
-  group    := "pp"
   descr    := "(pretty printer) pretty prints binders such as \
     `∀ (x : α) (x < 2), p x` as `∀ x < 2, p x`"
 }


### PR DESCRIPTION
The `group` field of an option declaration is unused, does not have a clear meaning and often matches the first component of the option name. Thus do not set it. Also for forward-compatibility when and if the field is dropped in core.
