### PR TITLE
[Merged by Bors] - feat: ContinuousLinearEquiv.submoduleMap and friends

### DIFF
--- a/Mathlib/Topology/Algebra/Module/Equiv.lean
+++ b/Mathlib/Topology/Algebra/Module/Equiv.lean
@@ -1224,8 +1224,21 @@ section map
 namespace ContinuousLinearEquiv
 
 variable {R R₂ M M₂ : Type*} [Semiring R] [Semiring R₂] [AddCommMonoid M] [AddCommMonoid M₂]
+    [TopologicalSpace M] [TopologicalSpace M₂]
     {module_M : Module R M} {module_M₂ : Module R₂ M₂} {σ₁₂ : R →+* R₂} {σ₂₁ : R₂ →+* R}
     {re₁₂ : RingHomInvPair σ₁₂ σ₂₁} {re₂₁ : RingHomInvPair σ₂₁ σ₁₂}
+
+-- XXX: should p and q be implicit or explicit? adjust adjust LinearEquiv.of_eq in the same way
+/-- Continuous linear equivalence between two equal submodules. -/
+def ofEq {p q : Submodule R M} (h : p = q) : p ≃L[R] q where
+  toLinearEquiv := LinearEquiv.ofEq _ _ h
+  continuous_toFun := by
+    -- want a better lemma: equal subtypes define a homeomorphism
+    dsimp
+    have h' : (fun x ↦ x ∈ p) = (fun x ↦ x ∈ q) := by simp [h]
+    change Continuous (Equiv.subtypeEquivProp h')
+    sorry -- not in mathlib
+  continuous_invFun := sorry -- should follow from toFun proof
 
 /--
 A continuous linear equivalence of two modules restricts to a continuous linear equivalence
@@ -1234,7 +1247,7 @@ from any submodule `p` of the domain onto the image of that submodule.
 This is the continuous linear version of `LinearEquiv.submoduleMap`.
 This is `ContinuousLinearEquiv.ofSubmodule'` but with map on the right instead of comap on the left.
 -/
-def submoduleMap [TopologicalSpace M] [TopologicalSpace M₂]
+def submoduleMap
     (e : M ≃SL[σ₁₂] M₂) (p : Submodule R M) : p ≃SL[σ₁₂] Submodule.map e p where
   toLinearMap := (e.comp p.subtype).codRestrict (p.map e) (fun ⟨c, hc⟩ ↦ by simpa)
   invFun := (e.symm.comp (p.map e).subtype).codRestrict p (fun ⟨c, y, hy, eyc⟩ ↦ by
@@ -1250,28 +1263,16 @@ def submoduleMap [TopologicalSpace M] [TopologicalSpace M₂]
     dsimp
     exact continuous_induced_rng.mpr this
 
+omit [TopologicalSpace M] [TopologicalSpace M₂] in
 @[simp]
 lemma submoduleMap_apply (e : M ≃ₛₗ[σ₁₂] M₂) (p : Submodule R M) (x : p) :
   e.submoduleMap p x = e x := by rfl
 
+omit [TopologicalSpace M] [TopologicalSpace M₂] in
 @[simp]
 lemma submoduleMap_symm_apply
     (e : M ≃ₛₗ[σ₁₂] M₂) (p : Submodule R M) (x : p.map e) :
   (e.submoduleMap p).symm x = e.symm x := by rfl
-
-variable [TopologicalSpace M] [TopologicalSpace M₂]
-
--- XXX: should p and q be implicit or explicit? adjust adjust LinearEquiv.of_eq in the same way
-/-- Continuous linear equivalence between two equal submodules. -/
-def ofEq {p q : Submodule R M} (h : p = q) : p ≃L[R] q where
-  toLinearEquiv := LinearEquiv.ofEq _ _ h
-  continuous_toFun := by
-    -- want a better lemma: equal subtypes define a homeomorphism
-    dsimp
-    have h' : (fun x ↦ x ∈ p) = (fun x ↦ x ∈ q) := by simp [h]
-    change Continuous (Equiv.subtypeEquivProp h')
-    sorry -- not in mathlib
-  continuous_invFun := sorry -- should follow from toFun proof
 
 /-- A continuous linear equivalence which maps a submodule of one module onto another,
 restricts to a continuous linear equivalence of the two submodules. -/

--- a/Mathlib/Topology/Algebra/Module/Equiv.lean
+++ b/Mathlib/Topology/Algebra/Module/Equiv.lean
@@ -1273,7 +1273,8 @@ lemma submoduleMap_symm_apply (e : M ≃SL[σ₁₂] M₂) (p : Submodule R M) (
   rfl
 
 /-- A continuous linear equivalence which maps a submodule of one module onto another,
-restricts to a continuous linear equivalence of the two submodules. -/
+restricts to a continuous linear equivalence of the two submodules.
+This is `LinearEquiv.ofSubmodules` as a continuous linear equivalence. -/
 def ofSubmodules (e : M ≃SL[σ₁₂] M₂)
     (p : Submodule R M) (q : Submodule R₂ M₂) (h : p.map (e : M →SL[σ₁₂] M₂) = q) : p ≃SL[σ₁₂] q :=
   (e.submoduleMap p).trans (.ofEq _ _ h)

--- a/Mathlib/Topology/Algebra/Module/Equiv.lean
+++ b/Mathlib/Topology/Algebra/Module/Equiv.lean
@@ -1218,6 +1218,51 @@ theorem coprod_comp_prodComm [ContinuousAdd M] (f : M₂ →L[R] M) (g : M₃ �
 
 end ContinuousLinearMap
 
+-- Restricting a continuous linear equivalence to a map between submodules.
+section map
+
+namespace ContinuousLinearEquiv
+
+variable {R R₂ M M₂ : Type*} [Semiring R] [Semiring R₂] [AddCommMonoid M] [AddCommMonoid M₂]
+    {module_M : Module R M} {module_M₂ : Module R₂ M₂} {σ₁₂ : R →+* R₂} {σ₂₁ : R₂ →+* R}
+    {re₁₂ : RingHomInvPair σ₁₂ σ₂₁} {re₂₁ : RingHomInvPair σ₂₁ σ₁₂}
+
+/--
+A continuous linear equivalence of two modules restricts to a continuous linear equivalence
+from any submodule `p` of the domain onto the image of that submodule.
+
+This is the continuous linear version of `LinearEquiv.submoduleMap`.
+This is `ContinuousLinearEquiv.ofSubmodule'` but with map on the right instead of comap on the left.
+-/
+def submoduleMap [TopologicalSpace M] [TopologicalSpace M₂]
+    (e : M ≃SL[σ₁₂] M₂) (p : Submodule R M) : p ≃SL[σ₁₂] Submodule.map e p where
+  toLinearMap := (e.comp p.subtype).codRestrict (p.map e) (fun ⟨c, hc⟩ ↦ by simpa)
+  invFun := (e.symm.comp (p.map e).subtype).codRestrict p (fun ⟨c, y, hy, eyc⟩ ↦ by
+    simpa [← eyc, e.symm_apply_apply])
+  left_inv x := by ext; simp
+  right_inv x := by ext; simp
+  continuous_toFun := by
+    have : Continuous (e.comp p.subtype) := by dsimp; fun_prop
+    dsimp
+    exact continuous_induced_rng.mpr this
+  continuous_invFun := by
+    have : Continuous (e.symm.comp (p.map e).subtype) := by dsimp; fun_prop
+    dsimp
+    exact continuous_induced_rng.mpr this
+
+@[simp]
+lemma submoduleMap_apply (e : M ≃ₛₗ[σ₁₂] M₂) (p : Submodule R M) (x : p) :
+  e.submoduleMap p x = e x := by rfl
+
+@[simp]
+lemma submoduleMap_symm_apply
+    (e : M ≃ₛₗ[σ₁₂] M₂) (p : Submodule R M) (x : p.map e) :
+  (e.submoduleMap p).symm x = e.symm x := by rfl
+
+end ContinuousLinearEquiv
+
+end map
+
 namespace Submodule
 
 variable {R : Type*} [Ring R] {M : Type*} [TopologicalSpace M] [AddCommGroup M] [Module R M]

--- a/Mathlib/Topology/Algebra/Module/Equiv.lean
+++ b/Mathlib/Topology/Algebra/Module/Equiv.lean
@@ -1228,9 +1228,9 @@ variable {R R₂ M M₂ : Type*} [Semiring R] [Semiring R₂] [AddCommMonoid M] 
     {module_M : Module R M} {module_M₂ : Module R₂ M₂} {σ₁₂ : R →+* R₂} {σ₂₁ : R₂ →+* R}
     {re₁₂ : RingHomInvPair σ₁₂ σ₂₁} {re₂₁ : RingHomInvPair σ₂₁ σ₁₂}
 
--- XXX: should p and q be implicit or explicit? adjust adjust LinearEquiv.of_eq in the same way
-/-- Continuous linear equivalence between two equal submodules. -/
-def ofEq {p q : Submodule R M} (h : p = q) : p ≃L[R] q where
+/-- Continuous linear equivalence between two equal submodules:
+this is `LinearEquiv.ofEq` as a continuous linear equivalence -/
+def ofEq (p q : Submodule R M) (h : p = q) : p ≃L[R] q where
   toLinearEquiv := LinearEquiv.ofEq _ _ h
   continuous_toFun := by
     have h' : (fun x ↦ x ∈ p) = (fun x ↦ x ∈ q) := by simp [h]
@@ -1262,22 +1262,20 @@ def submoduleMap
     dsimp
     exact continuous_induced_rng.mpr this
 
-omit [TopologicalSpace M] [TopologicalSpace M₂] in
 @[simp]
-lemma submoduleMap_apply (e : M ≃ₛₗ[σ₁₂] M₂) (p : Submodule R M) (x : p) :
+lemma submoduleMap_apply (e : M ≃SL[σ₁₂] M₂) (p : Submodule R M) (x : p) :
   e.submoduleMap p x = e x := by rfl
 
-omit [TopologicalSpace M] [TopologicalSpace M₂] in
 @[simp]
 lemma submoduleMap_symm_apply
-    (e : M ≃ₛₗ[σ₁₂] M₂) (p : Submodule R M) (x : p.map e) :
+    (e : M ≃SL[σ₁₂] M₂) (p : Submodule R M) (x : p.map e) :
   (e.submoduleMap p).symm x = e.symm x := by rfl
 
 /-- A continuous linear equivalence which maps a submodule of one module onto another,
 restricts to a continuous linear equivalence of the two submodules. -/
 def ofSubmodules (e : M ≃SL[σ₁₂] M₂)
     (p : Submodule R M) (q : Submodule R₂ M₂) (h : p.map (e : M →SL[σ₁₂] M₂) = q) : p ≃SL[σ₁₂] q :=
-  (e.submoduleMap p).trans (.ofEq h)
+  (e.submoduleMap p).trans (.ofEq _ _ h)
 
 @[simp]
 theorem ofSubmodules_apply (e : M ≃SL[σ₁₂] M₂) {p : Submodule R M} {q : Submodule R₂ M₂}

--- a/Mathlib/Topology/Algebra/Module/Equiv.lean
+++ b/Mathlib/Topology/Algebra/Module/Equiv.lean
@@ -1223,10 +1223,10 @@ section map
 
 namespace ContinuousLinearEquiv
 
-variable {R R₂ M M₂ : Type*} [Semiring R] [Semiring R₂] [AddCommMonoid M] [AddCommMonoid M₂]
-    [TopologicalSpace M] [TopologicalSpace M₂]
-    {module_M : Module R M} {module_M₂ : Module R₂ M₂} {σ₁₂ : R →+* R₂} {σ₂₁ : R₂ →+* R}
-    {re₁₂ : RingHomInvPair σ₁₂ σ₂₁} {re₂₁ : RingHomInvPair σ₂₁ σ₁₂}
+variable {R R₂ M M₂ : Type*} [Semiring R] [Semiring R₂] [AddCommMonoid M] [TopologicalSpace M]
+  [AddCommMonoid M₂] [TopologicalSpace M₂]
+  {module_M : Module R M} {module_M₂ : Module R₂ M₂} {σ₁₂ : R →+* R₂} {σ₂₁ : R₂ →+* R}
+  {re₁₂ : RingHomInvPair σ₁₂ σ₂₁} {re₂₁ : RingHomInvPair σ₂₁ σ₁₂}
 
 /-- Continuous linear equivalence between two equal submodules:
 this is `LinearEquiv.ofEq` as a continuous linear equivalence -/
@@ -1246,8 +1246,8 @@ from any submodule `p` of the domain onto the image of that submodule.
 This is the continuous linear version of `LinearEquiv.submoduleMap`.
 This is `ContinuousLinearEquiv.ofSubmodule'` but with map on the right instead of comap on the left.
 -/
-def submoduleMap
-    (e : M ≃SL[σ₁₂] M₂) (p : Submodule R M) : p ≃SL[σ₁₂] Submodule.map e p where
+def submoduleMap (e : M ≃SL[σ₁₂] M₂) (p : Submodule R M) :
+    p ≃SL[σ₁₂] Submodule.map e p where
   toLinearMap := (e.comp p.subtype).codRestrict (p.map e) (fun ⟨c, hc⟩ ↦ by simpa)
   invFun := (e.symm.comp (p.map e).subtype).codRestrict p (fun ⟨c, y, hy, eyc⟩ ↦ by
     simpa [← eyc, e.symm_apply_apply])
@@ -1264,12 +1264,13 @@ def submoduleMap
 
 @[simp]
 lemma submoduleMap_apply (e : M ≃SL[σ₁₂] M₂) (p : Submodule R M) (x : p) :
-  e.submoduleMap p x = e x := by rfl
+    e.submoduleMap p x = e x := by
+  rfl
 
 @[simp]
-lemma submoduleMap_symm_apply
-    (e : M ≃SL[σ₁₂] M₂) (p : Submodule R M) (x : p.map e) :
-  (e.submoduleMap p).symm x = e.symm x := by rfl
+lemma submoduleMap_symm_apply (e : M ≃SL[σ₁₂] M₂) (p : Submodule R M) (x : p.map e) :
+    (e.submoduleMap p).symm x = e.symm x := by
+  rfl
 
 /-- A continuous linear equivalence which maps a submodule of one module onto another,
 restricts to a continuous linear equivalence of the two submodules. -/
@@ -1292,15 +1293,13 @@ theorem ofSubmodules_symm_apply (e : M ≃SL[σ₁₂] M₂) {p : Submodule R M}
 from the preimage of any submodule to that submodule.
 This is `ContinuousLinearEquiv.ofSubmodule` but with `comap` on the left
 instead of `map` on the right. -/
-def ofSubmodule' (f : M ≃SL[σ₁₂] M₂) (U : Submodule R₂ M₂) :
-    U.comap f ≃SL[σ₁₂] U :=
+def ofSubmodule' (f : M ≃SL[σ₁₂] M₂) (U : Submodule R₂ M₂) : U.comap f ≃SL[σ₁₂] U :=
   f.symm.ofSubmodules _ _ (U.map_equiv_eq_comap_symm f.toLinearEquiv.symm) |>.symm
 
-theorem ofSubmodule'_toContinuousLinearMap (f : M ≃SL[σ₁₂] M₂)
-    (U : Submodule R₂ M₂) :
+theorem ofSubmodule'_toContinuousLinearMap (f : M ≃SL[σ₁₂] M₂) (U : Submodule R₂ M₂) :
     (f.ofSubmodule' U).toContinuousLinearMap =
-      (f.toContinuousLinearMap.comp ((U.comap f).subtypeL)).codRestrict U ((fun ⟨x, hx⟩ ↦ by
-        simpa [Submodule.mem_comap])) := by
+      (f.toContinuousLinearMap.comp ((U.comap f).subtypeL)).codRestrict U
+        ((fun ⟨x, hx⟩ ↦ by simpa [Submodule.mem_comap])) := by
   rfl
 
 @[simp]

--- a/Mathlib/Topology/Algebra/Module/Equiv.lean
+++ b/Mathlib/Topology/Algebra/Module/Equiv.lean
@@ -1221,20 +1221,6 @@ end ContinuousLinearMap
 -- Restricting a continuous linear equivalence to a map between submodules.
 section map
 
--- TODO_ move this!
-variable {X : Type*} [TopologicalSpace X] {p q : X → Prop}
-
-/-- A homeomorphism between two equal subtypes of a given topological space:
-the underlying equivalence is `Equiv.subtypeEquivProp`. -/
-def Homeomorph.subtypes_of_eq (hpq : p = q) : Subtype p ≃ₜ Subtype q where
-  toEquiv := Equiv.subtypeEquivProp hpq
-  continuous_toFun := continuous_id.subtype_map (fun x ↦ by simp [hpq])
-  continuous_invFun := continuous_id.subtype_map (fun x ↦ by simp [hpq])
-
-@[simp]
-lemma Homeomorph.subtypes_of_eq_toEquiv (hpq : p = q) :
-    (Homeomorph.subtypes_of_eq hpq).toEquiv = Equiv.subtypeEquivProp hpq := rfl
-
 namespace ContinuousLinearEquiv
 
 variable {R R₂ M M₂ : Type*} [Semiring R] [Semiring R₂] [AddCommMonoid M] [AddCommMonoid M₂]

--- a/Mathlib/Topology/Algebra/Module/Equiv.lean
+++ b/Mathlib/Topology/Algebra/Module/Equiv.lean
@@ -1259,6 +1259,61 @@ lemma submoduleMap_symm_apply
     (e : M ≃ₛₗ[σ₁₂] M₂) (p : Submodule R M) (x : p.map e) :
   (e.submoduleMap p).symm x = e.symm x := by rfl
 
+variable [TopologicalSpace M] [TopologicalSpace M₂]
+
+-- XXX: should p and q be implicit or explicit? adjust adjust LinearEquiv.of_eq in the same way
+/-- Continuous linear equivalence between two equal submodules. -/
+def ofEq {p q : Submodule R M} (h : p = q) : p ≃L[R] q where
+  toLinearEquiv := LinearEquiv.ofEq _ _ h
+  continuous_toFun := by
+    -- want a better lemma: equal subtypes define a homeomorphism
+    dsimp
+    have h' : (fun x ↦ x ∈ p) = (fun x ↦ x ∈ q) := by simp [h]
+    change Continuous (Equiv.subtypeEquivProp h')
+    sorry -- not in mathlib
+  continuous_invFun := sorry -- should follow from toFun proof
+
+/-- A continuous linear equivalence which maps a submodule of one module onto another,
+restricts to a continuous linear equivalence of the two submodules. -/
+def ofSubmodules (e : M ≃SL[σ₁₂] M₂)
+    (p : Submodule R M) (q : Submodule R₂ M₂) (h : p.map (e : M →SL[σ₁₂] M₂) = q) : p ≃SL[σ₁₂] q :=
+  (e.submoduleMap p).trans (.ofEq h)
+
+@[simp]
+theorem ofSubmodules_apply (e : M ≃SL[σ₁₂] M₂) {p : Submodule R M} {q : Submodule R₂ M₂}
+    (h : p.map e = q) (x : p) :
+    e.ofSubmodules p q h x = e x :=
+  rfl
+
+@[simp]
+theorem ofSubmodules_symm_apply (e : M ≃SL[σ₁₂] M₂) {p : Submodule R M} {q : Submodule R₂ M₂}
+    (h : p.map e = q) (x : q) : (e.ofSubmodules p q h).symm x = e.symm x :=
+  rfl
+
+/-- A continuous linear equivalence of two modules restricts to a continuous linear equivalence
+from the preimage of any submodule to that submodule.
+This is `ContinuousLinearEquiv.ofSubmodule` but with `comap` on the left
+instead of `map` on the right. -/
+def ofSubmodule' (f : M ≃SL[σ₁₂] M₂) (U : Submodule R₂ M₂) :
+    U.comap f ≃SL[σ₁₂] U :=
+  f.symm.ofSubmodules _ _ (U.map_equiv_eq_comap_symm f.toLinearEquiv.symm) |>.symm
+
+theorem ofSubmodule'_toContinuousLinearMap (f : M ≃SL[σ₁₂] M₂)
+    (U : Submodule R₂ M₂) :
+    (f.ofSubmodule' U).toContinuousLinearMap =
+      (f.toContinuousLinearMap.comp ((U.comap f).subtypeL)).codRestrict U ((fun ⟨x, hx⟩ ↦ by
+        simpa [Submodule.mem_comap])) := by
+  rfl
+
+@[simp]
+theorem ofSubmodule'_apply (f : M ≃SL[σ₁₂] M₂) (U : Submodule R₂ M₂) (x : U.comap f) :
+    (f.ofSubmodule' U x : M₂) = f (x : M) :=
+  rfl
+
+@[simp]
+theorem ofSubmodule'_symm_apply (f : M ≃SL[σ₁₂] M₂) (U : Submodule R₂ M₂) (x : U) :
+    ((f.ofSubmodule' U).symm x : M) = f.symm (x : M₂) := rfl
+
 end ContinuousLinearEquiv
 
 end map

--- a/Mathlib/Topology/Algebra/Module/Equiv.lean
+++ b/Mathlib/Topology/Algebra/Module/Equiv.lean
@@ -1221,6 +1221,20 @@ end ContinuousLinearMap
 -- Restricting a continuous linear equivalence to a map between submodules.
 section map
 
+-- TODO_ move this!
+variable {X : Type*} [TopologicalSpace X] {p q : X → Prop}
+
+/-- A homeomorphism between two equal subtypes of a given topological space:
+the underlying equivalence is `Equiv.subtypeEquivProp`. -/
+def Homeomorph.subtypes_of_eq (hpq : p = q) : Subtype p ≃ₜ Subtype q where
+  toEquiv := Equiv.subtypeEquivProp hpq
+  continuous_toFun := continuous_id.subtype_map (fun x ↦ by simp [hpq])
+  continuous_invFun := continuous_id.subtype_map (fun x ↦ by simp [hpq])
+
+@[simp]
+lemma Homeomorph.subtypes_of_eq_toEquiv (hpq : p = q) :
+    (Homeomorph.subtypes_of_eq hpq).toEquiv = Equiv.subtypeEquivProp hpq := rfl
+
 namespace ContinuousLinearEquiv
 
 variable {R R₂ M M₂ : Type*} [Semiring R] [Semiring R₂] [AddCommMonoid M] [AddCommMonoid M₂]
@@ -1233,12 +1247,11 @@ variable {R R₂ M M₂ : Type*} [Semiring R] [Semiring R₂] [AddCommMonoid M] 
 def ofEq {p q : Submodule R M} (h : p = q) : p ≃L[R] q where
   toLinearEquiv := LinearEquiv.ofEq _ _ h
   continuous_toFun := by
-    -- want a better lemma: equal subtypes define a homeomorphism
-    dsimp
     have h' : (fun x ↦ x ∈ p) = (fun x ↦ x ∈ q) := by simp [h]
-    change Continuous (Equiv.subtypeEquivProp h')
-    sorry -- not in mathlib
-  continuous_invFun := sorry -- should follow from toFun proof
+    exact (Homeomorph.subtypes_of_eq h').continuous
+  continuous_invFun := by
+    have h' : (fun x ↦ x ∈ p) = (fun x ↦ x ∈ q) := by simp [h]
+    exact (Homeomorph.subtypes_of_eq h').symm.continuous
 
 /--
 A continuous linear equivalence of two modules restricts to a continuous linear equivalence

--- a/Mathlib/Topology/Algebra/Module/Equiv.lean
+++ b/Mathlib/Topology/Algebra/Module/Equiv.lean
@@ -1234,10 +1234,10 @@ def ofEq {p q : Submodule R M} (h : p = q) : p ≃L[R] q where
   toLinearEquiv := LinearEquiv.ofEq _ _ h
   continuous_toFun := by
     have h' : (fun x ↦ x ∈ p) = (fun x ↦ x ∈ q) := by simp [h]
-    exact (Homeomorph.subtypes_of_eq h').continuous
+    exact (Homeomorph.ofEqSubtypes h').continuous
   continuous_invFun := by
     have h' : (fun x ↦ x ∈ p) = (fun x ↦ x ∈ q) := by simp [h]
-    exact (Homeomorph.subtypes_of_eq h').symm.continuous
+    exact (Homeomorph.ofEqSubtypes h').symm.continuous
 
 /--
 A continuous linear equivalence of two modules restricts to a continuous linear equivalence

--- a/Mathlib/Topology/Constructions.lean
+++ b/Mathlib/Topology/Constructions.lean
@@ -442,14 +442,14 @@ theorem continuousAt_subtype_val {p : X → Prop} {x : Subtype p} :
 
 /-- The induced homeomorphism between two equal subtypes of a given topological space:
 the underlying equivalence is `Equiv.subtypeEquivProp`. -/
-def Homeomorph.subtypes_of_eq {p q : X → Prop} (hpq : p = q) : Subtype p ≃ₜ Subtype q where
+def Homeomorph.ofEqSubtypes {p q : X → Prop} (hpq : p = q) : Subtype p ≃ₜ Subtype q where
   toEquiv := Equiv.subtypeEquivProp hpq
   continuous_toFun := continuous_id.subtype_map (fun x ↦ by simp [hpq])
   continuous_invFun := continuous_id.subtype_map (fun x ↦ by simp [hpq])
 
 @[simp]
-lemma Homeomorph.subtypes_of_eq_toEquiv {p q : X → Prop} (hpq : p = q) :
-    (Homeomorph.subtypes_of_eq hpq).toEquiv = Equiv.subtypeEquivProp hpq := rfl
+lemma Homeomorph.ofEqSubtypes_toEquiv {p q : X → Prop} (hpq : p = q) :
+    (Homeomorph.ofEqSubtypes hpq).toEquiv = Equiv.subtypeEquivProp hpq := rfl
 
 theorem Subtype.dense_iff {s : Set X} {t : Set s} : Dense t ↔ s ⊆ closure ((↑) '' t) := by
   rw [IsInducing.subtypeVal.dense_iff, SetCoe.forall]

--- a/Mathlib/Topology/Constructions.lean
+++ b/Mathlib/Topology/Constructions.lean
@@ -440,6 +440,17 @@ theorem continuousAt_subtype_val {p : X → Prop} {x : Subtype p} :
     ContinuousAt ((↑) : Subtype p → X) x :=
   continuous_subtype_val.continuousAt
 
+/-- The induced homeomorphism between two equal subtypes of a given topological space:
+the underlying equivalence is `Equiv.subtypeEquivProp`. -/
+def Homeomorph.subtypes_of_eq {p q : X → Prop} (hpq : p = q) : Subtype p ≃ₜ Subtype q where
+  toEquiv := Equiv.subtypeEquivProp hpq
+  continuous_toFun := continuous_id.subtype_map (fun x ↦ by simp [hpq])
+  continuous_invFun := continuous_id.subtype_map (fun x ↦ by simp [hpq])
+
+@[simp]
+lemma Homeomorph.subtypes_of_eq_toEquiv {p q : X → Prop} (hpq : p = q) :
+    (Homeomorph.subtypes_of_eq hpq).toEquiv = Equiv.subtypeEquivProp hpq := rfl
+
 theorem Subtype.dense_iff {s : Set X} {t : Set s} : Dense t ↔ s ⊆ closure ((↑) '' t) := by
   rw [IsInducing.subtypeVal.dense_iff, SetCoe.forall]
   rfl


### PR DESCRIPTION
The continuous analogue of `LinearEquiv.{submoduleMap, submoduleMap', ofSubmodules}`.
Also add `ContinuousLinearMap.ofEq` and `Homeomorph.ofEqSubtypes`, as these are necessary for the proof.

This will be used in #28793 for dealing with a universe-polymorphic definition for smooth immersions.

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

When merging, all the commits will be squashed into a single commit
listing all co-authors.

Co-authors in the squash commit are gathered from two sources:

First, all authors of commits to this PR branch are included. Thus,
one way to add co-authors is to include at least one commit authored by
each co-author among the commits in the pull request. If necessary, you
may create empty commits to indicate co-authorship, using commands like so:

git commit --author="Author Name <author@email.com>" --allow-empty -m "add Author Name as coauthor"

Second, co-authors can also be listed in lines at the very bottom of
the commit message (that is, directly before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines
at the bottom of the commit message (before the `---`, and also before
any "Co-authored-by" lines) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
