### PR TITLE
[Merged by Bors] - feat: set-valued product of bernoulli random variables

### DIFF
--- a/Mathlib.lean
+++ b/Mathlib.lean
@@ -5639,6 +5639,7 @@ public import Mathlib.Probability.Distributions.Gaussian.Real
 public import Mathlib.Probability.Distributions.Geometric
 public import Mathlib.Probability.Distributions.Pareto
 public import Mathlib.Probability.Distributions.Poisson
+public import Mathlib.Probability.Distributions.SetBernoulli
 public import Mathlib.Probability.Distributions.Uniform
 public import Mathlib.Probability.HasLaw
 public import Mathlib.Probability.HasLawExists

--- a/Mathlib/Probability/Distributions/SetBernoulli.lean
+++ b/Mathlib/Probability/Distributions/SetBernoulli.lean
@@ -18,12 +18,17 @@ For a set `u : Set ι` and `p` between `0` and `1`, this is the measure on `Set 
 ## Notation
 
 `setBer(u, p)` is the product of `p`-Bernoulli distributions on `u`.
+
+## TODO
+
+It is painful to convert from `unitInterval` to `ENNReal`. Should we introduce a coercion or
+explicit operation (like `unitInterval.toNNReal`, note the lack of dot notation!)?
 -/
 
 public section
 
 open MeasureTheory Measure unitInterval
-open scoped Finset
+open scoped ENNReal Finset
 
 namespace ProbabilityTheory
 variable {ι Ω : Type*} {m : MeasurableSpace Ω} {X Y : Ω → Set ι} {s u : Set ι} {i j : ι} {p q : I}
@@ -35,30 +40,28 @@ on `Set V` such that each element of `u` is taken with probability `p`, and the 
 `u` are never taken. -/
 @[expose]
 noncomputable def setBernoulli : Measure (Set ι) :=
-  .comap (fun s i ↦ i ∈ s) <| infinitePi fun i ↦
+  .comap (fun s i ↦ i ∈ s) <| infinitePi fun i : ι ↦
     toNNReal p • dirac (i ∈ u) + toNNReal (σ p) • dirac False
 
 @[inherit_doc] scoped notation "setBer(" u ", " p ")" => setBernoulli u p
 
 instance : IsProbabilityMeasure setBer(u, p) :=
   MeasurableEquiv.setOf.symm.measurableEmbedding.isProbabilityMeasure_comap <| .of_forall fun P ↦
-    ⟨{a | P a}, rfl⟩
+    ⟨{i | P i}, rfl⟩
 
 variable (u p) in
 lemma setBernoulli_eq_map :
-    setBer(u, p) = .map (fun p ↦ {i | p i})
-      (infinitePi fun i ↦ toNNReal p • dirac (i ∈ u) + toNNReal (σ p) • dirac False) :=
+    setBer(u, p) = .map (fun p : ι → Prop ↦ {i | p i})
+      (infinitePi fun i : ι ↦ toNNReal p • dirac (i ∈ u) + toNNReal (σ p) • dirac False) :=
   MeasurableEquiv.setOf.comap_symm
 
 lemma setBernoulli_apply (S : Set (Set ι)) :
-    setBer(u, p) S = (infinitePi fun a ↦ toNNReal p • dirac (a ∈ u) + toNNReal (σ p) • dirac False)
-      ((fun t a ↦ a ∈ t) '' S) := by
-  convert MeasurableEquiv.setOf.symm.measurableEmbedding.comap_apply ..
+    setBer(u, p) S = (infinitePi fun i ↦ toNNReal p • dirac (i ∈ u) + toNNReal (σ p) • dirac False)
+      ((fun t i ↦ i ∈ t) '' S) := MeasurableEquiv.setOf.symm.measurableEmbedding.comap_apply ..
 
 lemma setBernoulli_apply' (S : Set (Set ι)) :
-    setBer(u, p) S = (infinitePi fun a ↦ toNNReal p • dirac (a ∈ u) + toNNReal (σ p) • dirac False)
-      ((fun p ↦ {a | p a}) ⁻¹' S) := by
-  convert MeasurableEquiv.setOf.symm.comap_apply ..
+    setBer(u, p) S = (infinitePi fun i ↦ toNNReal p • dirac (i ∈ u) + toNNReal (σ p) • dirac False)
+      ((fun p ↦ {i | p i}) ⁻¹' S) := MeasurableEquiv.setOf.symm.comap_apply ..
 
 variable (u) in
 @[simp] lemma setBernoulli_zero : setBer(u, 0) = dirac ∅ := by simp [setBernoulli_eq_map]
@@ -74,19 +77,16 @@ lemma setBernoulli_ae_subset : ∀ᵐ s ∂setBer(u, p), s ⊆ u := by
   change _ = _
   simp only [Set.compl_setOf, Set.not_subset_iff_exists_mem_notMem, Set.setOf_exists, Set.setOf_and,
     measure_iUnion_null_iff]
-  rintro a
-  by_cases ha : a ∈ u
+  rintro i
+  by_cases hi : i ∈ u
   · simp [*]
   calc
-    setBer(u, p) ({s | a ∈ s} ∩ {s | a ∉ u})
-    _ = setBer(u, p) {s | a ∈ s} := by simp [ha]
-    _ = infinitePi (fun a ↦ toNNReal p • dirac (a ∈ u) + toNNReal (σ p) • dirac False)
-            (cylinder {a} {fun _ ↦ True}) := by
-      rw [setBernoulli_apply']
-      congr!
-      ext
-      simp [funext_iff]
-    _ = 0 := by simp [infinitePi_cylinder _ (.singleton _), ha]
+    setBer(u, p) ({s | i ∈ s} ∩ {s | i ∉ u})
+    _ = setBer(u, p) {s | i ∈ s} := by simp [hi]
+    _ = infinitePi (fun i ↦ toNNReal p • dirac (i ∈ u) + toNNReal (σ p) • dirac False)
+          (cylinder {i} {fun _ ↦ True}) := by
+      rw [setBernoulli_apply']; congr!; ext; simp [funext_iff]
+    _ = 0 := by simp [infinitePi_cylinder, hi]
 
 variable (u p) in
 @[simp] lemma setBernoulli_singleton (hsu : s ⊆ u) (hu : u.Finite) :
@@ -95,11 +95,11 @@ variable (u p) in
   lift u to Finset ι using hu
   calc
     setBer(u, p) {s}
-    _ = ∏' i, ((if i ∈ u ↔ i ∈ s then (toNNReal p : ENNReal) else 0) +
-          if i ∈ s then 0 else (toNNReal (σ p) : ENNReal)) := by
+    _ = ∏' i, ((if i ∈ u ↔ i ∈ s then (toNNReal p : ℝ≥0∞) else 0) +
+          if i ∈ s then 0 else (toNNReal (σ p) : ℝ≥0∞)) := by
       simp [setBernoulli_apply, Set.image_singleton, Set.indicator]
       simp [ENNReal.smul_def]
-    _ = ∏ i ∈ u, (if i ∈ s then (toNNReal p : ENNReal) else (toNNReal (σ p) : ENNReal)) := by
+    _ = ∏ i ∈ u, (if i ∈ s then (toNNReal p : ℝ≥0∞) else (toNNReal (σ p) : ℝ≥0∞)) := by
       rw [tprod_eq_prod, Finset.prod_congr rfl] <;>
         simp +contextual [ite_add_ite, mt (@hsu _), ← ENNReal.coe_add]
     _ = toNNReal p ^ s.ncard * toNNReal (σ p) ^ (↑u \ s).ncard := by

--- a/Mathlib/Probability/Distributions/SetBernoulli.lean
+++ b/Mathlib/Probability/Distributions/SetBernoulli.lean
@@ -1,0 +1,126 @@
+/-
+Copyright (c) 2025 Yaël Dillies. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Yaël Dillies
+-/
+module
+
+public import Mathlib.Probability.ProductMeasure
+public import Mathlib.Probability.HasLaw
+
+/-!
+# Product of bernoulli distributions on a set
+
+This file defines the product of bernoulli distributions on a set as a measure on sets.
+For a set `u : Set ι` and `p` between `0` and `1`, this is the measure on `Set ι` such that each
+`i ∈ u` belongs to the random set with probability `p`, and each `i ∉ u` doesn't belong to it.
+
+## Notation
+
+`setBer(u, p)` is the product of `p`-Bernoulli distributions on `u`.
+-/
+
+public section
+
+open MeasureTheory Measure unitInterval
+open scoped Finset
+
+namespace ProbabilityTheory
+variable {ι Ω : Type*} {m : MeasurableSpace Ω} {X Y : Ω → Set ι} {s u : Set ι} {i j : ι} {p q : I}
+  {P : Measure Ω}
+
+variable (u p) in
+/-- The product of bernoulli distributions with parameter `p` on the set `u : Set V` is the measure
+on `Set V` such that each element of `u` is taken with probability `p`, and the elements outside of
+`u` are never taken. -/
+@[expose]
+noncomputable def setBernoulli : Measure (Set ι) :=
+  .comap (fun s i ↦ i ∈ s) <| infinitePi fun i ↦
+    toNNReal p • dirac (i ∈ u) + toNNReal (σ p) • dirac False
+
+@[inherit_doc] scoped notation "setBer(" u ", " p ")" => setBernoulli u p
+
+instance : IsProbabilityMeasure setBer(u, p) :=
+  MeasurableEquiv.setOf.symm.measurableEmbedding.isProbabilityMeasure_comap <| .of_forall fun P ↦
+    ⟨{a | P a}, rfl⟩
+
+variable (u p) in
+lemma setBernoulli_eq_map :
+    setBer(u, p) = .map (fun p ↦ {i | p i})
+      (infinitePi fun i ↦ toNNReal p • dirac (i ∈ u) + toNNReal (σ p) • dirac False) :=
+  MeasurableEquiv.setOf.comap_symm
+
+lemma setBernoulli_apply (S : Set (Set ι)) :
+    setBer(u, p) S = (infinitePi fun a ↦ toNNReal p • dirac (a ∈ u) + toNNReal (σ p) • dirac False)
+      ((fun t a ↦ a ∈ t) '' S) := by
+  convert MeasurableEquiv.setOf.symm.measurableEmbedding.comap_apply ..
+
+lemma setBernoulli_apply' (S : Set (Set ι)) :
+    setBer(u, p) S = (infinitePi fun a ↦ toNNReal p • dirac (a ∈ u) + toNNReal (σ p) • dirac False)
+      ((fun p ↦ {a | p a}) ⁻¹' S) := by
+  convert MeasurableEquiv.setOf.symm.comap_apply ..
+
+variable (u) in
+@[simp] lemma setBernoulli_zero : setBer(u, 0) = dirac ∅ := by simp [setBernoulli_eq_map]
+
+variable (u) in
+@[simp] lemma setBernoulli_one : setBer(u, 1) = dirac u := by simp [setBernoulli_eq_map]
+
+section Countable
+variable [Countable ι]
+
+lemma setBernoulli_ae_subset : ∀ᵐ s ∂setBer(u, p), s ⊆ u := by
+  classical
+  change _ = _
+  simp only [Set.compl_setOf, Set.not_subset_iff_exists_mem_notMem, Set.setOf_exists, Set.setOf_and,
+    measure_iUnion_null_iff]
+  rintro a
+  by_cases ha : a ∈ u
+  · simp [*]
+  calc
+    setBer(u, p) ({s | a ∈ s} ∩ {s | a ∉ u})
+    _ = setBer(u, p) {s | a ∈ s} := by simp [ha]
+    _ = infinitePi (fun a ↦ toNNReal p • dirac (a ∈ u) + toNNReal (σ p) • dirac False)
+            (cylinder {a} {fun _ ↦ True}) := by
+      rw [setBernoulli_apply']
+      congr!
+      ext
+      simp [funext_iff]
+    _ = 0 := by simp [infinitePi_cylinder _ (.singleton _), ha]
+
+variable (u p) in
+@[simp] lemma setBernoulli_singleton (hsu : s ⊆ u) (hu : u.Finite) :
+    setBer(u, p) {s} = toNNReal p ^ s.ncard * toNNReal (σ p) ^ (u \ s).ncard := by
+  classical
+  lift u to Finset ι using hu
+  calc
+    setBer(u, p) {s}
+    _ = ∏' i, ((if i ∈ u ↔ i ∈ s then (toNNReal p : ENNReal) else 0) +
+          if i ∈ s then 0 else (toNNReal (σ p) : ENNReal)) := by
+      simp [setBernoulli_apply, Set.image_singleton, Set.indicator]
+      simp [ENNReal.smul_def]
+    _ = ∏ i ∈ u, (if i ∈ s then (toNNReal p : ENNReal) else (toNNReal (σ p) : ENNReal)) := by
+      rw [tprod_eq_prod, Finset.prod_congr rfl] <;>
+        simp +contextual [ite_add_ite, mt (@hsu _), ← ENNReal.coe_add]
+    _ = toNNReal p ^ s.ncard * toNNReal (σ p) ^ (↑u \ s).ncard := by
+      simp [Finset.prod_ite, ← Set.ncard_coe_finset, Set.setOf_and,
+        Set.inter_eq_right.2 hsu, ← Set.compl_setOf, Set.diff_eq_compl_inter, Set.inter_comm]
+
+end Countable
+
+/-! ### Bernoulli random variables -/
+
+variable (X u p P) in
+/-- A random variable `X : Ω → Set ι` is `p`-bernoulli on a set `u : Set ι` if its distribution is
+the product over `u` of `p`-bernoulli distributions. -/
+abbrev IsSetBernoulli : Prop := HasLaw X setBer(u, p) P
+
+lemma isSetBernoulli_congr (hXY : X =ᵐ[P] Y) : IsSetBernoulli X u p P ↔ IsSetBernoulli Y u p P :=
+  hasLaw_congr hXY
+
+variable [Countable ι]
+
+lemma IsSetBernoulli.ae_subset (hX : IsSetBernoulli X u p P) : ∀ᵐ ω ∂P, X ω ⊆ u :=
+  (hX.ae_iff <| by fun_prop).2 setBernoulli_ae_subset
+
+end ProbabilityTheory

--- a/Mathlib/Probability/HasLaw.lean
+++ b/Mathlib/Probability/HasLaw.lean
@@ -27,9 +27,10 @@ open scoped ENNReal
 
 namespace ProbabilityTheory
 
-variable {Ω 𝓧 : Type*} {mΩ : MeasurableSpace Ω} {m𝓧 : MeasurableSpace 𝓧} (X : Ω → 𝓧)
-  (μ : Measure 𝓧)
+variable {Ω 𝓧 : Type*} {mΩ : MeasurableSpace Ω} {m𝓧 : MeasurableSpace 𝓧} {X Y : Ω → 𝓧}
+  {μ : Measure 𝓧} {P : Measure Ω}
 
+variable (X μ) in
 /-- The predicate `HasLaw X μ P` registers the fact that the random variable `X` has law `μ` under
 the measure `P`, in other words that `P.map X = μ`. We also require `X` to be `AEMeasurable`,
 to allow for nice interactions with operations on the codomain of `X`. See for instance
@@ -41,11 +42,13 @@ structure HasLaw (P : Measure Ω := by volume_tac) : Prop where
 
 attribute [fun_prop] HasLaw.aemeasurable
 
-variable {X μ} {P : Measure Ω}
-
-lemma HasLaw.congr {Y : Ω → 𝓧} (hX : HasLaw X μ P) (hY : Y =ᵐ[P] X) : HasLaw Y μ P where
+lemma HasLaw.congr (hX : HasLaw X μ P) (hY : Y =ᵐ[P] X) : HasLaw Y μ P where
   aemeasurable := hX.aemeasurable.congr hY.symm
   map_eq := by rw [map_congr hY, hX.map_eq]
+
+lemma hasLaw_congr (hXY : X =ᵐ[P] Y) : HasLaw X μ P ↔ HasLaw Y μ P where
+  mp h := h.congr hXY.symm
+  mpr h := h.congr hXY
 
 lemma _root_.MeasureTheory.MeasurePreserving.hasLaw (h : MeasurePreserving X P μ) :
     HasLaw X μ P where
@@ -60,13 +63,23 @@ lemma HasLaw.measurePreserving (h₁ : HasLaw X μ P) (h₂ : Measurable X) :
 protected lemma HasLaw.id : HasLaw id μ μ where
   map_eq := map_id
 
+protected lemma HasLaw.ae_iff (hX : HasLaw X μ P) {p : 𝓧 → Prop} (hp : Measurable p) :
+    (∀ᵐ ω ∂P, p (X ω)) ↔ ∀ᵐ x ∂μ, p x := by
+  rw [← hX.map_eq, ae_map_iff hX.aemeasurable (measurableSet_setOf.2 hp)]
+
 protected theorem HasLaw.isFiniteMeasure_iff (hX : HasLaw X μ P) :
-    IsFiniteMeasure μ ↔ IsFiniteMeasure P := by
+    IsFiniteMeasure P ↔ IsFiniteMeasure μ := by
   rw [← hX.map_eq, isFiniteMeasure_map_iff hX.aemeasurable]
 
 protected theorem HasLaw.isProbabilityMeasure_iff (hX : HasLaw X μ P) :
-    IsProbabilityMeasure μ ↔ IsProbabilityMeasure P := by
+    IsProbabilityMeasure P ↔ IsProbabilityMeasure μ := by
   rw [← hX.map_eq, isProbabilityMeasure_map_iff hX.aemeasurable]
+
+lemma HasLaw.isFiniteMeasure [IsFiniteMeasure μ] (hX : HasLaw X μ P) : IsFiniteMeasure P :=
+  hX.isFiniteMeasure_iff.2 ‹_›
+
+lemma HasLaw.isProbabilityMeasure [IsProbabilityMeasure μ] (hX : HasLaw X μ P) :
+    IsProbabilityMeasure P := hX.isProbabilityMeasure_iff.2 ‹_›
 
 @[fun_prop]
 lemma HasLaw.comp {𝒴 : Type*} {m𝒴 : MeasurableSpace 𝒴} {ν : Measure 𝒴} {Y : 𝓧 → 𝒴}


### PR DESCRIPTION
Define the product distribution of `p`-Bernoulli random variables a measure on `Set ι`.

It is important in applications to be able to restrict the product to a subset `u` of `ι`, eg in #31364 I define the `G(V, p)` distribution of binomial random graphs by setting `ι := Sym2 V` and `u := {e |¬ e.IsDiag}`.

---
- [x] depends on: #31909
- [x] depends on: #31911
- [x] depends on: #32096
- [x] depends on: #32287

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
