### PR TITLE
[Merged by Bors] - feat: FiniteExhaustion 

### DIFF
--- a/Mathlib.lean
+++ b/Mathlib.lean
@@ -3813,6 +3813,7 @@ public import Mathlib.Data.Set.Finite.List
 public import Mathlib.Data.Set.Finite.Monad
 public import Mathlib.Data.Set.Finite.Powerset
 public import Mathlib.Data.Set.Finite.Range
+public import Mathlib.Data.Set.FiniteExhaustion
 public import Mathlib.Data.Set.Function
 public import Mathlib.Data.Set.Functor
 public import Mathlib.Data.Set.Image

--- a/Mathlib/Data/Set/FiniteExhaustion.lean
+++ b/Mathlib/Data/Set/FiniteExhaustion.lean
@@ -68,10 +68,7 @@ noncomputable def choice (s : Set α) [Countable s] : FiniteExhaustion s := by
     · obtain ⟨f, hf⟩ := exists_surjective_nat s
       refine ⟨fun n ↦ (Subtype.val ∘ f) '' {i | i ≤ n}, ?_, ?_, ?_⟩
       · exact fun n ↦ Finite.image _ (finite_le_nat n)
-      · intro n
-        simp only [Function.comp_apply]
-        gcongr
-        simp
+      · grind
       · simp [← image_image, ← image_iUnion, iUnion_le_nat, range_eq_univ.mpr hf]
     · refine ⟨fun _ ↦ ∅, by simp [Finite.to_subtype], fun n ↦ by simp, ?_⟩
       simp [Set.not_nonempty_iff_eq_empty'.mp h]

--- a/Mathlib/Data/Set/FiniteExhaustion.lean
+++ b/Mathlib/Data/Set/FiniteExhaustion.lean
@@ -62,7 +62,8 @@ theorem iUnion_eq : ⋃ n, K n = s :=
   K.iUnion_eq'
 
 /-- A choice of a `FiniteExhaustion` for a countable set `s`. -/
-noncomputable def choice (s : Set α) [Countable s] : FiniteExhaustion s := by
+noncomputable def _root_.Set.Countable.finiteExhaustion {s : Set α} (hs : s.Countable) :
+    FiniteExhaustion s := by
     apply Classical.choice
     by_cases h : Nonempty s
     · obtain ⟨f, hf⟩ := exists_surjective_nat s

--- a/Mathlib/Data/Set/FiniteExhaustion.lean
+++ b/Mathlib/Data/Set/FiniteExhaustion.lean
@@ -75,7 +75,7 @@ noncomputable def _root_.Set.Countable.finiteExhaustion {s : Set α} (hs : s.Cou
     simp [Set.not_nonempty_iff_eq_empty'.mp h]
 
 noncomputable instance [Countable s] :
-    Nonempty (FiniteExhaustion s) := ⟨Set.Countable.finiteExhaustion ‹Countable s›⟩
+    Nonempty (FiniteExhaustion s) := ⟨Countable.finiteExhaustion ‹Countable s›⟩
 
 section prod
 

--- a/Mathlib/Data/Set/FiniteExhaustion.lean
+++ b/Mathlib/Data/Set/FiniteExhaustion.lean
@@ -74,7 +74,7 @@ noncomputable def choice (s : Set α) [Countable s] : FiniteExhaustion s := by
       simp [Set.not_nonempty_iff_eq_empty'.mp h]
 
 noncomputable instance [Countable s] :
-    Inhabited (FiniteExhaustion s) :=
+    Nonempty (FiniteExhaustion s) :=
   ⟨FiniteExhaustion.choice s⟩
 
 section prod

--- a/Mathlib/Data/Set/FiniteExhaustion.lean
+++ b/Mathlib/Data/Set/FiniteExhaustion.lean
@@ -74,8 +74,11 @@ noncomputable def _root_.Set.Countable.finiteExhaustion {s : Set α} (hs : s.Cou
   · refine ⟨fun _ ↦ ∅, by simp [Finite.to_subtype], fun n ↦ by simp, ?_⟩
     simp [Set.not_nonempty_iff_eq_empty'.mp h]
 
-noncomputable instance [Countable s] :
-    Nonempty (FiniteExhaustion s) := ⟨Countable.finiteExhaustion ‹Countable s›⟩
+lemma Set.nonempty_finiteExhaustion_iff {s : Set α} :
+    Nonempty s.FiniteExhaustion ↔ s.Countable := by
+  refine ⟨fun ⟨K⟩ ↦ ?_, fun h ↦ ⟨h.finiteExhaustion⟩⟩
+  rw [← K.iUnion_eq]
+  exact countable_iUnion <| fun i ↦ (K.finite i).countable
 
 section prod
 

--- a/Mathlib/Data/Set/FiniteExhaustion.lean
+++ b/Mathlib/Data/Set/FiniteExhaustion.lean
@@ -53,6 +53,7 @@ protected theorem finite (n : ℕ) : (K n).Finite := K.finite' n
 
 theorem subset_succ (n : ℕ) : K n ⊆ K (n + 1) := K.subset_succ' n
 
+@[gcongr]
 protected theorem mono {m n : ℕ} (h : m ≤ n) : K m ⊆ K n :=
   OrderHomClass.mono K h
 

--- a/Mathlib/Data/Set/FiniteExhaustion.lean
+++ b/Mathlib/Data/Set/FiniteExhaustion.lean
@@ -99,4 +99,4 @@ protected theorem prod_apply (n : ℕ) : (K.prod K') n = K n ×ˢ K' n := by rfl
 
 end prod
 
-end FiniteExhaustion
+end Set.FiniteExhaustion

--- a/Mathlib/Data/Set/FiniteExhaustion.lean
+++ b/Mathlib/Data/Set/FiniteExhaustion.lean
@@ -57,6 +57,7 @@ theorem subset_succ (n : ℕ) : K n ⊆ K (n + 1) := K.subset_succ' n
 protected theorem mono {m n : ℕ} (h : m ≤ n) : K m ⊆ K n :=
   OrderHomClass.mono K h
 
+@[simp]
 theorem iUnion_eq : ⋃ n, K n = s :=
   K.iUnion_eq'
 

--- a/Mathlib/Data/Set/FiniteExhaustion.lean
+++ b/Mathlib/Data/Set/FiniteExhaustion.lean
@@ -32,7 +32,7 @@ structure Set.FiniteExhaustion {α : Type*} (s : Set α) where
   /-- The union of all sets in a `FiniteExhaustion` equals `s` -/
   iUnion_eq' : ⋃ n, toFun n = s
 
-namespace FiniteExhaustion
+namespace Set.FiniteExhaustion
 
 instance {α : Type*} {s : Set α} : FunLike (FiniteExhaustion s) ℕ (Set α) where
   coe := toFun

--- a/Mathlib/Data/Set/FiniteExhaustion.lean
+++ b/Mathlib/Data/Set/FiniteExhaustion.lean
@@ -75,8 +75,7 @@ noncomputable def _root_.Set.Countable.finiteExhaustion {s : Set α} (hs : s.Cou
     simp [Set.not_nonempty_iff_eq_empty'.mp h]
 
 noncomputable instance [Countable s] :
-    Nonempty (FiniteExhaustion s) :=
-  ⟨Set.Countable.finiteExhaustion ‹Countable s›⟩
+    Nonempty (FiniteExhaustion s) := ⟨Set.Countable.finiteExhaustion ‹Countable s›⟩
 
 section prod
 

--- a/Mathlib/Data/Set/FiniteExhaustion.lean
+++ b/Mathlib/Data/Set/FiniteExhaustion.lean
@@ -22,7 +22,7 @@ open Set
 
 /-- A `FiniteExhaustion` of a set `s` is a monotonically increasing sequence
 of finite sets such that their union is `s`. -/
-structure FiniteExhaustion {α : Type*} (s : Set α) where
+structure Set.FiniteExhaustion {α : Type*} (s : Set α) where
   /-- The underlying sequence of a `FiniteExhaustion`. -/
   toFun : ℕ → Set α
   /-- Every set in a `FiniteExhaustion` is finite. -/

--- a/Mathlib/Data/Set/FiniteExhaustion.lean
+++ b/Mathlib/Data/Set/FiniteExhaustion.lean
@@ -64,19 +64,19 @@ theorem iUnion_eq : ⋃ n, K n = s :=
 /-- A choice of a `FiniteExhaustion` for a countable set `s`. -/
 noncomputable def _root_.Set.Countable.finiteExhaustion {s : Set α} (hs : s.Countable) :
     FiniteExhaustion s := by
-    apply Classical.choice
-    by_cases h : Nonempty s
-    · obtain ⟨f, hf⟩ := exists_surjective_nat s
-      refine ⟨fun n ↦ (Subtype.val ∘ f) '' {i | i ≤ n}, ?_, ?_, ?_⟩
-      · exact fun n ↦ Finite.image _ (finite_le_nat n)
-      · grind
-      · simp [← image_image, ← image_iUnion, iUnion_le_nat, range_eq_univ.mpr hf]
-    · refine ⟨fun _ ↦ ∅, by simp [Finite.to_subtype], fun n ↦ by simp, ?_⟩
-      simp [Set.not_nonempty_iff_eq_empty'.mp h]
+  apply Classical.choice
+  by_cases h : Nonempty s
+  · obtain ⟨f, hf⟩ := @exists_surjective_nat s h hs
+    refine ⟨fun n ↦ (Subtype.val ∘ f) '' {i | i ≤ n}, ?_, ?_, ?_⟩
+    · exact fun n ↦ Finite.image _ (finite_le_nat n)
+    · grind
+    · simp [← image_image, ← image_iUnion, iUnion_le_nat, range_eq_univ.mpr hf]
+  · refine ⟨fun _ ↦ ∅, by simp [Finite.to_subtype], fun n ↦ by simp, ?_⟩
+    simp [Set.not_nonempty_iff_eq_empty'.mp h]
 
 noncomputable instance [Countable s] :
     Nonempty (FiniteExhaustion s) :=
-  ⟨FiniteExhaustion.choice s⟩
+  ⟨Set.Countable.finiteExhaustion ‹Countable s›⟩
 
 section prod
 

--- a/Mathlib/Data/Set/FiniteExhaustion.lean
+++ b/Mathlib/Data/Set/FiniteExhaustion.lean
@@ -16,6 +16,8 @@ countable set by an increasing sequence of finite sets. Given a countable set `s
 `FiniteExhaustion.choice s` is a choice of a finite exhaustion.
 -/
 
+@[expose] public section
+
 /-- A `FiniteExhaustion` of a set `s` is a monotonically increasing sequence
 of finite sets such that their union is `s`. -/
 structure FiniteExhaustion {α : Type*} (s : Set α) where

--- a/Mathlib/Data/Set/FiniteExhaustion.lean
+++ b/Mathlib/Data/Set/FiniteExhaustion.lean
@@ -84,7 +84,7 @@ variable {β : Type*} {t : Set β} (K' : FiniteExhaustion t)
 is the finite exhaustion on `s ×ˢ t` given by the pointwise set product of the exhaustions. -/
 protected def prod :
     FiniteExhaustion (s ×ˢ t) :=
-  { toFun := fun n ↦ K n ×ˢ K' n
+  { toFun n := K n ×ˢ K' n
     Finite' := fun n ↦ Set.Finite.prod (K.Finite n) (K'.Finite n)
     subset_succ' := fun n ↦ Set.prod_mono (K.subset_succ n) (K'.subset_succ n)
     iUnion_eq' := by

--- a/Mathlib/Data/Set/FiniteExhaustion.lean
+++ b/Mathlib/Data/Set/FiniteExhaustion.lean
@@ -18,6 +18,8 @@ countable set by an increasing sequence of finite sets. Given a countable set `s
 
 @[expose] public section
 
+open Set
+
 /-- A `FiniteExhaustion` of a set `s` is a monotonically increasing sequence
 of finite sets such that their union is `s`. -/
 structure FiniteExhaustion {α : Type*} (s : Set α) where
@@ -40,18 +42,18 @@ instance {α : Type*} {s : Set α} : RelHomClass (FiniteExhaustion s) LE.le HasS
   map_rel K _ _ h := monotone_nat_of_le_succ (fun n ↦ K.subset_succ' n) h
 
 instance {α : Type*} {s : Set α} {K : FiniteExhaustion s} {n : ℕ} : Finite (K n) :=
-  K.Finite' n
+  K.finite' n
 
 variable {α : Type*} {s : Set α} (K : FiniteExhaustion s)
 
 @[simp]
 theorem toFun_eq_coe : K.toFun = K := rfl
 
-protected theorem Finite (n : ℕ) : (K n).Finite := K.Finite' n
+protected theorem finite (n : ℕ) : (K n).Finite := K.finite' n
 
 theorem subset_succ (n : ℕ) : K n ⊆ K (n + 1) := K.subset_succ' n
 
-protected theorem subset {m n : ℕ} (h : m ≤ n) : K m ⊆ K n :=
+protected theorem subset_mono {m n : ℕ} (h : m ≤ n) : K m ⊆ K n :=
   OrderHomClass.mono K h
 
 theorem iUnion_eq : ⋃ n, K n = s :=
@@ -63,13 +65,13 @@ noncomputable def choice (s : Set α) [Countable s] : FiniteExhaustion s := by
     by_cases h : Nonempty s
     · obtain ⟨f, hf⟩ := exists_surjective_nat s
       refine ⟨fun n ↦ (Subtype.val ∘ f) '' {i | i ≤ n}, ?_, ?_, ?_⟩
-      · exact fun n ↦ Set.Finite.image _ (Set.finite_le_nat n)
+      · exact fun n ↦ Finite.image _ (finite_le_nat n)
       · intro n
         simp only [Function.comp_apply]
         gcongr
         simp
-      · simp [← Set.image_image, ← Set.image_iUnion, Set.iUnion_le_nat, Set.range_eq_univ.mpr hf]
-    · refine ⟨fun _ ↦ ∅, by simp [Set.Finite.to_subtype], fun n ↦ by simp, ?_⟩
+      · simp [← image_image, ← image_iUnion, iUnion_le_nat, range_eq_univ.mpr hf]
+    · refine ⟨fun _ ↦ ∅, by simp [Finite.to_subtype], fun n ↦ by simp, ?_⟩
       simp [Set.not_nonempty_iff_eq_empty'.mp h]
 
 noncomputable instance [Countable s] :
@@ -85,8 +87,9 @@ is the finite exhaustion on `s ×ˢ t` given by the pointwise set product of the
 protected def prod :
     FiniteExhaustion (s ×ˢ t) :=
   { toFun n := K n ×ˢ K' n
-    Finite' n := (K.Finite n).prod (K'.Finite n)
+    finite' n := (K.finite n).prod (K'.finite n)
     subset_succ' := fun n ↦ Set.prod_mono (K.subset_succ n) (K'.subset_succ n)
+    iUnion_eq' := by
       rw [Set.iUnion_prod_of_monotone (OrderHomClass.mono K) (OrderHomClass.mono K'),
           K.iUnion_eq, K'.iUnion_eq] }
 

--- a/Mathlib/Data/Set/FiniteExhaustion.lean
+++ b/Mathlib/Data/Set/FiniteExhaustion.lean
@@ -1,0 +1,104 @@
+/-
+Copyright (c) 2025 David Ledvinka. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: David Ledvinka
+-/
+module
+
+public import Mathlib.Data.Set.Countable
+public import Mathlib.Data.Finite.Prod
+
+/-!
+# Finite Exhaustions
+
+This file defines a structure called `FiniteExhaustion` which represents an exhaustion of a
+countable set by an increasing sequence of finite sets. Given a countable set `s`,
+`FiniteExhaustion.choice s` is a choice of a finite exhaustion.
+-/
+
+/-- A `FiniteExhaustion` of a set `s` is a monotonically increasing sequence
+of finite sets such that their union is `s`. -/
+structure FiniteExhaustion {α : Type*} (s : Set α) where
+  /-- The underlying sequence of a `FiniteExhaustion`. -/
+  toFun : ℕ → Set α
+  /-- Every set in a `FiniteExhaustion` is finite. -/
+  Finite' : ∀ n, Finite (toFun n)
+  /-- The sequence of sets in a `FiniteExhaustion` are monotonically increasing. -/
+  subset_succ' : ∀ n, toFun n ⊆ toFun (n + 1)
+  /-- The union of all sets in a `FiniteExhaustion` equals `s` -/
+  iUnion_eq' : ⋃ n, toFun n = s
+
+namespace FiniteExhaustion
+
+instance {α : Type*} {s : Set α} : FunLike (FiniteExhaustion s) ℕ (Set α) where
+  coe := toFun
+  coe_injective' | ⟨_, _, _, _⟩, ⟨_, _, _, _⟩, rfl => rfl
+
+instance {α : Type*} {s : Set α} : RelHomClass (FiniteExhaustion s) LE.le HasSubset.Subset where
+  map_rel K _ _ h := monotone_nat_of_le_succ (fun n ↦ K.subset_succ' n) h
+
+instance {α : Type*} {s : Set α} {K : FiniteExhaustion s} {n : ℕ} : Finite (K n) :=
+  K.Finite' n
+
+variable {α : Type*} {s : Set α} (K : FiniteExhaustion s)
+
+@[simp]
+theorem toFun_eq_coe : K.toFun = K := rfl
+
+protected theorem Finite (n : ℕ) : (K n).Finite := K.Finite' n
+
+theorem subset_succ (n : ℕ) : K n ⊆ K (n + 1) := K.subset_succ' n
+
+protected theorem subset {m n : ℕ} (h : m ≤ n) : K m ⊆ K n :=
+  OrderHomClass.mono K h
+
+theorem iUnion_eq : ⋃ n, K n = s :=
+  K.iUnion_eq'
+
+/-- A choice of a `FiniteExhaustion` for a countable set `s`. -/
+noncomputable def choice (s : Set α) [Countable s] : FiniteExhaustion s := by
+    apply Classical.choice
+    by_cases h : Nonempty s
+    · obtain ⟨f, hf⟩ := exists_surjective_nat s
+      refine ⟨fun n ↦ (Subtype.val ∘ f) '' {i | i ≤ n}, ?_, ?_, ?_⟩
+      · exact fun n ↦ Set.Finite.image _ (Set.finite_le_nat n)
+      · intro n
+        simp only [Function.comp_apply]
+        gcongr
+        simp
+      · simp [← Set.image_image, ← Set.image_iUnion, Set.iUnion_le_nat, Set.range_eq_univ.mpr hf]
+    · refine ⟨fun _ ↦ ∅, by simp [Set.Finite.to_subtype], fun n ↦ by simp, ?_⟩
+      simp [Set.not_nonempty_iff_eq_empty'.mp h]
+
+noncomputable instance [Countable s] :
+    Inhabited (FiniteExhaustion s) :=
+  ⟨FiniteExhaustion.choice s⟩
+
+section prod
+
+variable {β : Type*} {t : Set β} (K' : FiniteExhaustion t)
+
+/-- Given `K : FiniteExhaustion s` and `K' : FiniteExhaustion t`, `FiniteExhaustion.prod K K'`
+is the finite exhaustion on `s ×ˢ t` given by the pointwise set product of the exhaustions. -/
+protected def prod :
+    FiniteExhaustion (s ×ˢ t) :=
+  { toFun := fun n ↦ K n ×ˢ K' n
+    Finite' := fun n ↦ Set.Finite.prod (K.Finite n) (K'.Finite n)
+    subset_succ' := fun n ↦ Set.prod_mono (K.subset_succ n) (K'.subset_succ n)
+    iUnion_eq' := by
+      apply subset_antisymm
+      · rw [Set.iUnion_subset_iff]
+        refine fun i ↦ Set.prod_mono ?_ ?_
+        · simp [← K.iUnion_eq, Set.subset_iUnion]
+        · simp [← K'.iUnion_eq, Set.subset_iUnion]
+      rintro ⟨a, b⟩ h
+      simp only [← K.iUnion_eq, ← K'.iUnion_eq, Set.mem_prod, Set.mem_iUnion] at h
+      obtain ⟨⟨i,hi⟩, ⟨j, hj⟩⟩ := h
+      simp only [Set.mem_iUnion, Set.mem_prod]
+      exact ⟨max i j, K.subset (le_max_left _ _) hi, K'.subset (le_max_right _ _ ) hj⟩ }
+
+protected theorem prod_apply (n : ℕ) : (K.prod K') n = K n ×ˢ K' n := by rfl
+
+end prod
+
+end FiniteExhaustion

--- a/Mathlib/Data/Set/FiniteExhaustion.lean
+++ b/Mathlib/Data/Set/FiniteExhaustion.lean
@@ -53,7 +53,7 @@ protected theorem finite (n : ℕ) : (K n).Finite := K.finite' n
 
 theorem subset_succ (n : ℕ) : K n ⊆ K (n + 1) := K.subset_succ' n
 
-protected theorem subset_mono {m n : ℕ} (h : m ≤ n) : K m ⊆ K n :=
+protected theorem mono {m n : ℕ} (h : m ≤ n) : K m ⊆ K n :=
   OrderHomClass.mono K h
 
 theorem iUnion_eq : ⋃ n, K n = s :=

--- a/Mathlib/Data/Set/FiniteExhaustion.lean
+++ b/Mathlib/Data/Set/FiniteExhaustion.lean
@@ -24,7 +24,7 @@ structure FiniteExhaustion {α : Type*} (s : Set α) where
   /-- The underlying sequence of a `FiniteExhaustion`. -/
   toFun : ℕ → Set α
   /-- Every set in a `FiniteExhaustion` is finite. -/
-  Finite' : ∀ n, Finite (toFun n)
+  finite' : ∀ n, Finite (toFun n)
   /-- The sequence of sets in a `FiniteExhaustion` are monotonically increasing. -/
   subset_succ' : ∀ n, toFun n ⊆ toFun (n + 1)
   /-- The union of all sets in a `FiniteExhaustion` equals `s` -/

--- a/Mathlib/Data/Set/FiniteExhaustion.lean
+++ b/Mathlib/Data/Set/FiniteExhaustion.lean
@@ -85,7 +85,7 @@ is the finite exhaustion on `s ×ˢ t` given by the pointwise set product of the
 protected def prod :
     FiniteExhaustion (s ×ˢ t) :=
   { toFun n := K n ×ˢ K' n
-    Finite' := fun n ↦ Set.Finite.prod (K.Finite n) (K'.Finite n)
+    Finite' n := (K.Finite n).prod (K'.Finite n)
     subset_succ' := fun n ↦ Set.prod_mono (K.subset_succ n) (K'.subset_succ n)
       rw [Set.iUnion_prod_of_monotone (OrderHomClass.mono K) (OrderHomClass.mono K'),
           K.iUnion_eq, K'.iUnion_eq] }

--- a/Mathlib/Data/Set/FiniteExhaustion.lean
+++ b/Mathlib/Data/Set/FiniteExhaustion.lean
@@ -87,17 +87,8 @@ protected def prod :
   { toFun n := K n ×ˢ K' n
     Finite' := fun n ↦ Set.Finite.prod (K.Finite n) (K'.Finite n)
     subset_succ' := fun n ↦ Set.prod_mono (K.subset_succ n) (K'.subset_succ n)
-    iUnion_eq' := by
-      apply subset_antisymm
-      · rw [Set.iUnion_subset_iff]
-        refine fun i ↦ Set.prod_mono ?_ ?_
-        · simp [← K.iUnion_eq, Set.subset_iUnion]
-        · simp [← K'.iUnion_eq, Set.subset_iUnion]
-      rintro ⟨a, b⟩ h
-      simp only [← K.iUnion_eq, ← K'.iUnion_eq, Set.mem_prod, Set.mem_iUnion] at h
-      obtain ⟨⟨i,hi⟩, ⟨j, hj⟩⟩ := h
-      simp only [Set.mem_iUnion, Set.mem_prod]
-      exact ⟨max i j, K.subset (le_max_left _ _) hi, K'.subset (le_max_right _ _ ) hj⟩ }
+      rw [Set.iUnion_prod_of_monotone (OrderHomClass.mono K) (OrderHomClass.mono K'),
+          K.iUnion_eq, K'.iUnion_eq] }
 
 protected theorem prod_apply (n : ℕ) : (K.prod K') n = K n ×ˢ K' n := by rfl
 

--- a/Mathlib/Data/Set/Lattice.lean
+++ b/Mathlib/Data/Set/Lattice.lean
@@ -1358,6 +1358,10 @@ theorem union_iUnion_nat_succ (u : ℕ → Set α) : (u 0 ∪ ⋃ i, u (i + 1)) 
 theorem inter_iInter_nat_succ (u : ℕ → Set α) : (u 0 ∩ ⋂ i, u (i + 1)) = ⋂ i, u i :=
   inf_iInf_nat_succ u
 
+theorem iUnion_le_nat : ⋃ n : ℕ, {i | i ≤ n} = Set.univ :=
+ subset_antisymm (Set.subset_univ _)
+   (fun i _ ↦ Set.mem_iUnion_of_mem i (Set.mem_setOf.mpr (le_refl _)))
+
 end Set
 
 open Set


### PR DESCRIPTION
Creates a structure that contains the data of a non-decreasing sequence of finite sets whose union equals some countable set. This is used in the brownian motion project to transfer a theorem that holds over finite sets to a countable set (with monotone convergence). 

The design is modelled on CompactExhaustion (of course it can be seen as precisely a special case but I think taking that approach would be much more convoluted). 

I didn't want to give this its own file, but I couldn't put it in `Mathlib.Data.Set.Countable` without creating a `large-import` because I needed the fact that product of finite sets is finite, and couldn't find anywhere else sensible to put it that wouldn't create a `large-import`. Would be happy if someone has a better suggestion. 