### PR TITLE
[Merged by Bors] - chore: cleanup of some cast lemmas

### DIFF
--- a/Mathlib/Logic/Equiv/Defs.lean
+++ b/Mathlib/Logic/Equiv/Defs.lean
@@ -285,12 +285,12 @@ theorem apply_eq_iff_eq_symm_apply {x : α} {y : β} (f : α ≃ β) : f x = y �
 
 @[simp] theorem cast_apply {α β} (h : α = β) (x : α) : Equiv.cast h x = cast h x := rfl
 
-@[simp] theorem cast_symm {α β} (h : α = β) : (Equiv.cast h).symm = Equiv.cast h.symm := rfl
+theorem cast_symm {α β} (h : α = β) : Equiv.cast h.symm = (Equiv.cast h).symm := rfl
 
 @[simp] theorem cast_refl {α} (h : α = α := rfl) : Equiv.cast h = Equiv.refl α := rfl
 
-@[simp] theorem cast_trans {α β γ} (h : α = β) (h2 : β = γ) :
-    (Equiv.cast h).trans (Equiv.cast h2) = Equiv.cast (h.trans h2) :=
+theorem cast_trans {α β γ} (h : α = β) (h2 : β = γ) :
+    Equiv.cast (h.trans h2) = (Equiv.cast h).trans (Equiv.cast h2) :=
   ext fun x => by substs h h2; rfl
 
 theorem cast_eq_iff_heq {α β} (h : α = β) {a : α} {b : β} : Equiv.cast h a = b ↔ a ≍ b := by

--- a/Mathlib/Order/RelIso/Basic.lean
+++ b/Mathlib/Order/RelIso/Basic.lean
@@ -664,17 +664,14 @@ protected def cast {α β : Type u} {r : α → α → Prop} {s : β → β → 
     rw [eq_of_heq h₂]
     rfl⟩
 
-@[simp]
 protected theorem cast_symm {α β : Type u} {r : α → α → Prop} {s : β → β → Prop} (h₁ : α = β)
     (h₂ : r ≍ s) : (RelIso.cast h₁ h₂).symm = RelIso.cast h₁.symm h₂.symm :=
   rfl
 
-@[simp]
 protected theorem cast_refl {α : Type u} {r : α → α → Prop} (h₁ : α = α := rfl)
     (h₂ : r ≍ r := HEq.rfl) : RelIso.cast h₁ h₂ = RelIso.refl r :=
   rfl
 
-@[simp]
 protected theorem cast_trans {α β γ : Type u} {r : α → α → Prop} {s : β → β → Prop}
     {t : γ → γ → Prop} (h₁ : α = β) (h₁' : β = γ) (h₂ : r ≍ s) (h₂' : s ≍ t) :
     (RelIso.cast h₁ h₂).trans (RelIso.cast h₁' h₂') = RelIso.cast (h₁.trans h₁') (h₂.trans h₂') :=


### PR DESCRIPTION
Remove some unused `simp` annotations on `cast` lemmas, and reverse the direction of two `Equiv.cast` lemmas, to push casts inwards rather than outwards. c.f. #31575 