### PR TITLE
[Merged by Bors] - chore: clean up more unused `Decidable*` instances in types

### DIFF
--- a/Mathlib/RingTheory/TensorProduct/IsBaseChangeFree.lean
+++ b/Mathlib/RingTheory/TensorProduct/IsBaseChangeFree.lean
@@ -24,7 +24,7 @@ variable {R : Type*} [CommSemiring R]
     {S : Type*} [CommSemiring S] [Algebra R S]
     {V : Type*} [AddCommMonoid V] [Module R V]
     {W : Type*} [AddCommMonoid W] [Module R W] [Module S W] [IsScalarTower R S W]
-    {ι : Type*} [DecidableEq ι]
+    {ι : Type*}
     {ε : V →ₗ[R] W}
 
 variable (b : Module.Basis ι R V) (ibc : IsBaseChange S ε)

--- a/Mathlib/RingTheory/TensorProduct/IsBaseChangePi.lean
+++ b/Mathlib/RingTheory/TensorProduct/IsBaseChangePi.lean
@@ -110,7 +110,7 @@ section DirectSum
 
 open TensorProduct LinearMap DirectSum
 
-variable {ι : Type*} [DecidableEq ι]
+variable {ι : Type*}
     {N : ι → Type*} [(i : ι) → AddCommMonoid (N i)] [(i : ι) → Module R (N i)]
     {P : ι → Type*} [∀ i, AddCommMonoid (P i)] [∀ i, Module R (P i)]
     [∀ i, Module S (P i)] [∀ i, IsScalarTower R S (P i)]
@@ -119,6 +119,7 @@ variable {ι : Type*} [DecidableEq ι]
 /-- Base change for direct sums. -/
 theorem directSum (ibc : ∀ i, IsBaseChange S (ε i)) :
     IsBaseChange S (lmap ε) := by
+  classical
   apply of_equiv <| directSumRight' R S S N ≪≫ₗ congr_linearEquiv fun i ↦ (ibc i).equiv
   intros; ext
   simp [coe_directSumRight', coe_congr_linearEquiv, equiv_tmul]
@@ -135,6 +136,7 @@ theorem directSumPow (ibc : IsBaseChange S ε) :
 
 theorem finsuppPow (ibc : IsBaseChange S ε) :
     IsBaseChange S (Finsupp.mapRange.linearMap (α := ι) ε) := by
+  classical
   apply of_equiv <|
     LinearEquiv.baseChange R S _ _ (finsuppLEquivDirectSum ..) ≪≫ₗ
       (directSum (fun _ ↦ ibc)).equiv ≪≫ₗ (finsuppLEquivDirectSum ..).symm


### PR DESCRIPTION
Found by #10235 and #31142.

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

When merging, all the commits will be squashed into a single commit
listing all co-authors.

Co-authors in the squash commit are gathered from two sources:

First, all authors of commits to this PR branch are included. Thus,
one way to add co-authors is to include at least one commit authored by
each co-author among the commits in the pull request. If necessary, you
may create empty commits to indicate co-authorship, using commands like so:

git commit --author="Author Name <author@email.com>" --allow-empty -m "add Author Name as coauthor"

Second, co-authors can also be listed in lines at the very bottom of
the commit message (that is, directly before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines
at the bottom of the commit message (before the `---`, and also before
any "Co-authored-by" lines) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
