### PR TITLE
[Merged by Bors] - feat: make sure that simp computes `{a} ∩ s`

### DIFF
--- a/Mathlib/Data/Set/Insert.lean
+++ b/Mathlib/Data/Set/Insert.lean
@@ -253,6 +253,12 @@ theorem singleton_inter_eq_empty : {a} ∩ s = ∅ ↔ a ∉ s :=
 theorem inter_singleton_eq_empty : s ∩ {a} = ∅ ↔ a ∉ s := by
   rw [inter_comm, singleton_inter_eq_empty]
 
+@[simp] alias ⟨_, singleton_inter_of_notMem⟩ := singleton_inter_eq_empty
+@[simp] alias ⟨_, inter_singleton_of_notMem⟩ := inter_singleton_eq_empty
+
+@[simp] lemma singleton_inter_of_mem (ha : a ∈ s) : {a} ∩ s = {a} := by simpa
+@[simp] lemma inter_singleton_of_mem (ha : a ∈ s) : s ∩ {a} = {a} := by simpa
+
 theorem notMem_singleton_empty {s : Set α} : s ∉ ({∅} : Set (Set α)) ↔ s.Nonempty :=
   nonempty_iff_ne_empty.symm
 

--- a/Mathlib/Topology/Compactification/OnePoint/Basic.lean
+++ b/Mathlib/Topology/Compactification/OnePoint/Basic.lean
@@ -10,7 +10,7 @@ public import Mathlib.Topology.Homeomorph.Lemmas
 public import Mathlib.Topology.Sets.Opens
 
 /-!
-# The one-point Compactification
+# The one-point compactification
 
 We construct the one-point compactification of an arbitrary topological space `X` and prove some
 properties inherited from `X`.

--- a/Mathlib/Topology/Compactification/OnePoint/Basic.lean
+++ b/Mathlib/Topology/Compactification/OnePoint/Basic.lean
@@ -10,14 +10,14 @@ public import Mathlib.Topology.Homeomorph.Lemmas
 public import Mathlib.Topology.Sets.Opens
 
 /-!
-# The OnePoint Compactification
+# The one-point Compactification
 
-We construct the OnePoint compactification (the one-point compactification) of an arbitrary
-topological space `X` and prove some properties inherited from `X`.
+We construct the one-point compactification of an arbitrary topological space `X` and prove some
+properties inherited from `X`.
 
 ## Main definitions
 
-* `OnePoint`: the OnePoint compactification, we use coercion for the canonical embedding
+* `OnePoint`: the one-point compactification, we use coercion for the canonical embedding
   `X → OnePoint X`; when `X` is already compact, the compactification adds an isolated point
   to the space.
 * `OnePoint.infty`: the extra point
@@ -32,7 +32,7 @@ topological space `X` and prove some properties inherited from `X`.
 
 ## Tags
 
-one-point compactification, Alexandroff compactification, compactness
+one point compactification, Alexandroff compactification, compactness
 -/
 
 @[expose] public section
@@ -50,7 +50,7 @@ In this section we define `OnePoint X` to be the disjoint union of `X` and `∞`
 
 variable {X Y : Type*}
 
-/-- The OnePoint extension of an arbitrary topological space `X` -/
+/-- The one-point extension of an arbitrary topological space `X` -/
 def OnePoint (X : Type*) :=
   Option X
 
@@ -134,9 +134,8 @@ theorem range_coe_union_infty : range ((↑) : X → OnePoint X) ∪ {∞} = uni
 theorem insert_infty_range_coe : insert ∞ (range (@some X)) = univ :=
   insert_none_range_some _
 
-@[simp]
-theorem range_coe_inter_infty : range ((↑) : X → OnePoint X) ∩ {∞} = ∅ :=
-  range_some_inter_none X
+@[deprecated "Use simp" (since := "2025-11-22")]
+theorem range_coe_inter_infty : range ((↑) : X → OnePoint X) ∩ {∞} = ∅ := by simp
 
 @[simp]
 theorem compl_range_coe : (range ((↑) : X → OnePoint X))ᶜ = {∞} :=


### PR DESCRIPTION
These simp lemmas were missing for simp to be able to compute `{a} ∩ s` depending on whether `a` is in `s` or not.


---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

When merging, all the commits will be squashed into a single commit
listing all co-authors.

Co-authors in the squash commit are gathered from two sources:

First, all authors of commits to this PR branch are included. Thus,
one way to add co-authors is to include at least one commit authored by
each co-author among the commits in the pull request. If necessary, you
may create empty commits to indicate co-authorship, using commands like so:

git commit --author="Author Name <author@email.com>" --allow-empty -m "add Author Name as coauthor"

Second, co-authors can also be listed in lines at the very bottom of
the commit message (that is, directly before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines
at the bottom of the commit message (before the `---`, and also before
any "Co-authored-by" lines) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
