### PR TITLE
feat: move `ContinuousSMul` to a finite extension with the module topology

### DIFF
--- a/Mathlib/Algebra/Algebra/Basic.lean
+++ b/Mathlib/Algebra/Algebra/Basic.lean
@@ -434,21 +434,6 @@ instance (priority := 100) {R S A : Type*} [CommSemiring R] [CommSemiring S] [Se
 theorem smul_algebra_smul_comm (r : R) (a : A) (m : M) : a • r • m = r • a • m :=
   smul_comm _ _ _
 
-namespace LinearMap
-
-variable (R)
-
--- TODO: generalize to `CompatibleSMul`
-/-- `A`-linearly coerce an `R`-linear map from `M` to `A` to a function, given an algebra `A` over
-a commutative semiring `R` and `M` a module over `R`. -/
-def ltoFun (R : Type u) (M : Type v) (A : Type w) [CommSemiring R] [AddCommMonoid M] [Module R M]
-    [CommSemiring A] [Algebra R A] : (M →ₗ[R] A) →ₗ[A] M → A where
-  toFun f := f.toFun
-  map_add' _ _ := rfl
-  map_smul' _ _ := rfl
-
-end LinearMap
-
 end IsScalarTower
 
 /-! TODO: The following lemmas no longer involve `Algebra` at all, and could be moved closer

--- a/Mathlib/Algebra/Algebra/Basic.lean
+++ b/Mathlib/Algebra/Algebra/Basic.lean
@@ -438,11 +438,11 @@ namespace LinearMap
 
 variable (R)
 
--- TODO: generalize to `CompatibleSMul`
-/-- `A`-linearly coerce an `R`-linear map from `M` to `A` to a function, given an algebra `A` over
-a commutative semiring `R` and `M` a module over `R`. -/
-def ltoFun (R : Type u) (M : Type v) (A : Type w) [CommSemiring R] [AddCommMonoid M] [Module R M]
-    [CommSemiring A] [Algebra R A] : (M →ₗ[R] A) →ₗ[A] M → A where
+/-- `A`-linearly coerce an `R`-linear map from `M` to `N` to a function, when `N` is an
+`(R, A)`-bimodule. -/
+def ltoFun (R M N A : Type*) [Semiring R] [Semiring A]
+    [AddCommMonoid M] [Module R M] [AddCommMonoid N] [Module R N] [Module A N]
+    [SMulCommClass R A N] : (M →ₗ[R] N) →ₗ[A] (M → N) where
   toFun f := f.toFun
   map_add' _ _ := rfl
   map_smul' _ _ := rfl

--- a/Mathlib/Algebra/Module/LinearMap/Basic.lean
+++ b/Mathlib/Algebra/Module/LinearMap/Basic.lean
@@ -7,6 +7,7 @@ Authors: Nathaniel Thomas, Jeremy Avigad, Johannes Hölzl, Mario Carneiro, Anne 
 module
 
 public import Mathlib.Algebra.Module.LinearMap.Defs
+public import Mathlib.Algebra.Module.Pi
 public import Mathlib.Algebra.NoZeroSMulDivisors.Pi
 public import Mathlib.Algebra.Ring.Opposite
 public import Mathlib.GroupTheory.GroupAction.DomAct.Basic
@@ -27,6 +28,23 @@ universe u u' v w x y z
 variable {R R' S M M' : Type*}
 
 namespace LinearMap
+
+section toFunAsLinearMap
+
+variable {R M N A : Type*} [Semiring R] [Semiring A]
+  [AddCommMonoid M] [Module R M] [AddCommMonoid N] [Module R N] [Module A N] [SMulCommClass R A N]
+
+variable (R M N A) in
+/-- `A`-linearly coerce an `R`-linear map from `M` to `N` to a function, when `N` is an
+`(R, A)`-bimodule. -/
+def ltoFun : (M →ₗ[R] N) →ₗ[A] (M → N) where
+  toFun f := f.toFun
+  map_add' _ _ := rfl
+  map_smul' _ _ := rfl
+
+@[simp] lemma ltoFun_apply {f : M →ₗ[R] N} : ltoFun R M N A f = f := rfl
+
+end toFunAsLinearMap
 
 section SMul
 

--- a/Mathlib/Analysis/LocallyConvex/WeakDual.lean
+++ b/Mathlib/Analysis/LocallyConvex/WeakDual.lean
@@ -184,7 +184,7 @@ theorem LinearMap.weakBilin_withSeminorms (B : E →ₗ[𝕜] F →ₗ[𝕜] �
     WithSeminorms (LinearMap.toSeminormFamily B : F → Seminorm 𝕜 (WeakBilin B)) :=
   let e : F ≃ (Σ _ : F, Fin 1) := .symm <| .sigmaUnique _ _
   withSeminorms_induced (withSeminorms_pi (fun _ ↦ norm_withSeminorms 𝕜 𝕜))
-    (LinearMap.ltoFun 𝕜 F 𝕜 ∘ₗ B : (WeakBilin B) →ₗ[𝕜] (F → 𝕜)) |>.congr_equiv e
+    (LinearMap.ltoFun 𝕜 F 𝕜 𝕜 ∘ₗ B : (WeakBilin B) →ₗ[𝕜] (F → 𝕜)) |>.congr_equiv e
 
 theorem LinearMap.hasBasis_weakBilin (B : E →ₗ[𝕜] F →ₗ[𝕜] 𝕜) :
     (𝓝 (0 : WeakBilin B)).HasBasis B.toSeminormFamily.basisSets _root_.id :=

--- a/Mathlib/FieldTheory/Fixed.lean
+++ b/Mathlib/FieldTheory/Fixed.lean
@@ -290,7 +290,7 @@ end FixedPoints
 theorem linearIndependent_toLinearMap (R : Type u) (A : Type v) (B : Type w) [CommSemiring R]
     [Semiring A] [Algebra R A] [CommRing B] [IsDomain B] [Algebra R B] :
     LinearIndependent B (AlgHom.toLinearMap : (A →ₐ[R] B) → A →ₗ[R] B) :=
-  have : LinearIndependent B (LinearMap.ltoFun R A B ∘ AlgHom.toLinearMap) :=
+  have : LinearIndependent B (LinearMap.ltoFun R A B B ∘ AlgHom.toLinearMap) :=
     ((linearIndependent_monoidHom A B).comp ((↑) : (A →ₐ[R] B) → A →* B) fun _ _ hfg =>
         AlgHom.ext fun _ => DFunLike.ext_iff.1 hfg _ :
       _)

--- a/Mathlib/LinearAlgebra/LinearIndependent/Lemmas.lean
+++ b/Mathlib/LinearAlgebra/LinearIndependent/Lemmas.lean
@@ -455,7 +455,7 @@ theorem exists_maximal_linearIndepOn (v : ι → M) :
 lemma linearIndependent_algHom_toLinearMap
     (K M L) [CommSemiring K] [Semiring M] [Algebra K M] [CommRing L] [IsDomain L] [Algebra K L] :
     LinearIndependent L (AlgHom.toLinearMap : (M →ₐ[K] L) → M →ₗ[K] L) := by
-  apply LinearIndependent.of_comp (LinearMap.ltoFun K M L)
+  apply LinearIndependent.of_comp (LinearMap.ltoFun K M L L)
   exact (linearIndependent_monoidHom M L).comp
     (RingHom.toMonoidHom ∘ AlgHom.toRingHom)
     (fun _ _ e ↦ AlgHom.ext (DFunLike.congr_fun e :))

--- a/Mathlib/LinearAlgebra/Pi.lean
+++ b/Mathlib/LinearAlgebra/Pi.lean
@@ -345,6 +345,14 @@ theorem pi_apply_eq_sum_univ [Fintype ι] (f : (ι → R) →ₗ[R] M₂) (x : �
   refine Finset.sum_congr rfl (fun _ _ => ?_)
   rw [map_smul]
 
+/-- A linear map `f` applied to `x : ι → R` can be computed using the image under `f` of elements
+of the canonical basis. -/
+theorem pi_apply_eq_sum_univ' [Fintype ι] (f : (ι → R) →ₗ[R] M₂) (x : ι → R) :
+    f x = ∑ i, x i • f (Pi.single i 1) := by
+  conv_lhs => rw [pi_eq_sum_univ' x, map_sum]
+  refine Finset.sum_congr rfl (fun _ _ => ?_)
+  rw [map_smul]
+
 end LinearMap
 
 namespace Submodule

--- a/Mathlib/Topology/Algebra/Module/Basic.lean
+++ b/Mathlib/Topology/Algebra/Module/Basic.lean
@@ -253,12 +253,34 @@ theorem LinearMap.continuous_on_pi {ι : Type*} {R : Type*} {M : Type*} [Finite 
   classical
     -- for the proof, write `f` in the standard basis, and use that each coordinate is a continuous
     -- function.
-    have : (f : (ι → R) → M) = fun x => ∑ i : ι, x i • f fun j => if i = j then 1 else 0 := by
+    have : (f : (ι → R) → M) = fun x => ∑ i : ι, x i • f (Pi.single i 1) := by
       ext x
-      exact f.pi_apply_eq_sum_univ x
+      exact f.pi_apply_eq_sum_univ' x
     rw [this]
-    refine continuous_finset_sum _ fun i _ => ?_
-    exact (continuous_apply i).smul continuous_const
+    fun_prop
+
+theorem LinearMap.continuous_on_pi_prod {ι R X M : Type*} [Finite ι] [CommSemiring R]
+    [TopologicalSpace R] [TopologicalSpace X] [AddCommMonoid M] [Module R M] [TopologicalSpace M]
+    [ContinuousAdd M] [ContinuousSMul R M] (f : (ι → R) →ₗ[R] X → M)
+    (f_cont : ∀ a, Continuous (f a)) :
+    Continuous (fun ax : (ι → R) × X ↦ f ax.1 ax.2) := by
+  cases nonempty_fintype ι
+  classical
+    -- for the proof, write `f` in the standard basis, and use that each coordinate is a continuous
+    -- function.
+    have : (fun ax : (ι → R) × X ↦ f ax.1 ax.2) =
+        fun ax : (ι → R) × X => ∑ i : ι, ax.1 i • f (Pi.single i 1) ax.2 := by
+      ext xm
+      simp_rw [f.pi_apply_eq_sum_univ' xm.1, Finset.sum_apply, Pi.smul_apply]
+    rw [this]
+    fun_prop
+
+theorem LinearMap.continuous_on_prod_pi {ι R X M : Type*} [Finite ι] [CommSemiring R]
+    [TopologicalSpace R] [TopologicalSpace X] [AddCommMonoid M] [Module R M] [TopologicalSpace M]
+    [ContinuousAdd M] [ContinuousSMul R M] (f : (ι → R) →ₗ[R] X → M)
+    (f_cont : ∀ a, Continuous (f a)) :
+    Continuous (fun xa : X × (ι → R) ↦ f xa.2 xa.1) :=
+  f.continuous_on_pi_prod f_cont |>.comp continuous_swap
 
 end Pi
 

--- a/Mathlib/Topology/Algebra/Module/ModuleTopology.lean
+++ b/Mathlib/Topology/Algebra/Module/ModuleTopology.lean
@@ -550,25 +550,10 @@ by `IsModuleTopology.continuous_bilinear_of_finite_left`.
 -/
 theorem continuous_bilinear_of_pi_fintype (ι : Type*) [Finite ι]
     (bil : (ι → R) →ₗ[R] B →ₗ[R] C) : Continuous (fun ab ↦ bil ab.1 ab.2 : ((ι → R) × B → C)) := by
-  classical
-  cases nonempty_fintype ι
-  -- The map in question, `(f, b) ↦ bil f b`, is easily checked to be equal to
-  -- `(f, b) ↦ ∑ᵢ f i • bil (single i 1) b` where `single i 1 : ι → R` sends `i` to `1` and
-  -- everything else to `0`.
-  have h : (fun fb ↦ bil fb.1 fb.2 : ((ι → R) × B → C)) =
-      (fun fb ↦ ∑ i, ((fb.1 i) • (bil (Finsupp.single i 1) fb.2) : C)) := by
-    ext ⟨f, b⟩
-    nth_rw 1 [← Finset.univ_sum_single f]
-    simp_rw [← Finsupp.single_eq_pi_single, map_sum, LinearMap.coeFn_sum, Finset.sum_apply]
-    refine Finset.sum_congr rfl (fun x _ ↦ ?_)
-    rw [← Finsupp.smul_single_one]
-    push_cast
-    simp
-  rw [h]
-  -- But this map is obviously continuous, because for a fixed `i`, `bil (single i 1)` is
-  -- linear and thus continuous, and scalar multiplication and finite sums are continuous
   haveI : ContinuousAdd C := toContinuousAdd R C
-  fun_prop
+  exact LinearMap.continuous_on_pi_prod (LinearMap.ltoFun R B C R ∘ₗ bil)
+    fun x ↦ continuous_of_linearMap (bil x)
+
 
 end semiring
 
@@ -577,7 +562,39 @@ section ring
 variable {R : Type*} [TopologicalSpace R] [CommRing R] [IsTopologicalRing R]
 variable {A : Type*} [AddCommGroup A] [Module R A] [aA : TopologicalSpace A] [IsModuleTopology R A]
 variable {B : Type*} [AddCommGroup B] [Module R B] [aB : TopologicalSpace B] [IsModuleTopology R B]
-variable {C : Type*} [AddCommGroup C] [Module R C] [aC : TopologicalSpace C] [IsModuleTopology R C]
+variable {C : Type*} [AddCommGroup C] [Module R C] [aC : TopologicalSpace C]
+variable [ContinuousAdd C] [ContinuousSMul R C]
+
+/--
+If `A` is a finite module with the module topology, a map `f : A × X → B` which is linear in
+the first component and continuous in the second component is actually continuous on the product.
+This generalizes `LinearMap.continuous_on_pi_prod`.
+-/
+theorem continuous_of_linearMap_prod_left {X : Type*} [TopologicalSpace X] [Module.Finite R A]
+    (f : A →ₗ[R] X → C) (f_cont : ∀ a, Continuous (f a)) :
+    Continuous (fun (ax : A × X) ↦ f ax.1 ax.2) := by
+  -- `A` is finite and hence admits a surjection `π` from `Rⁿ` for some finite `n`.
+  obtain ⟨m, π, hπ⟩ := Module.Finite.exists_fin' R A
+  -- Since `A` has the module topology and `π` is surjective, it is an open quotient map...
+  have π_quot : IsOpenQuotientMap π := isOpenQuotientMap_of_surjective hπ
+  -- ... hence the product map `φ = f × id` is as well.
+  let φ : (Fin m → R) × X → A × X := Prod.map π id
+  have hφ : IsOpenQuotientMap φ := π_quot.prodMap .id
+  -- Hence, it suffices to prove that the composite `Rⁿ × X → A × X → B` is
+  -- continuous.
+  rw [hφ.isQuotientMap.continuous_iff]
+  -- But this follows from an earlier result.
+  exact LinearMap.continuous_on_pi_prod (f ∘ₗ π) fun c ↦ f_cont (π c)
+
+/--
+If `A` is a finite module with the module topology, a map `f : X × A → B` which is linear in
+the second component and continuous in the first component is actually continuous on the product.
+This generalizes `LinearMap.continuous_on_prod_pi`.
+-/
+theorem continuous_of_linearMap_prod_right {X : Type*} [TopologicalSpace X] [Module.Finite R A]
+    (f : A →ₗ[R] X → C) (f_cont : ∀ a, Continuous (f a)) :
+    Continuous (fun (xa : X × A) ↦ f xa.2 xa.1) :=
+  continuous_of_linearMap_prod_left f f_cont |>.comp continuous_swap
 
 /--
 If `A`, `B` and `C` have the module topology, and if furthermore `A` is a finite `R`-module,
@@ -586,17 +603,8 @@ then any bilinear map `A × B → C` is automatically continuous
 @[continuity, fun_prop]
 theorem continuous_bilinear_of_finite_left [Module.Finite R A]
     (bil : A →ₗ[R] B →ₗ[R] C) : Continuous (fun ab ↦ bil ab.1 ab.2 : (A × B → C)) := by
-  -- `A` is finite and hence admits a surjection from `Rⁿ` for some finite `n`.
-  obtain ⟨m, f, hf⟩ := Module.Finite.exists_fin' R A
-  -- The induced linear map `φ : Rⁿ × B → A × B` is surjective
-  let bil' : (Fin m → R) →ₗ[R] B →ₗ[R] C := bil.comp f
-  let φ := f.prodMap (LinearMap.id : B →ₗ[R] B)
-  have hφ : Function.Surjective φ := Function.Surjective.prodMap hf fun b ↦ ⟨b, rfl⟩
-  -- ... and thus a quotient map, so it suffices to prove that the composite `Rⁿ × B → C` is
-  -- continuous.
-  rw [Topology.IsQuotientMap.continuous_iff (isQuotientMap_of_surjective hφ)]
-  -- But this follows from an earlier result.
-  exact continuous_bilinear_of_pi_fintype (Fin m) bil'
+  exact continuous_of_linearMap_prod_left (LinearMap.ltoFun R B C R ∘ₗ bil)
+    fun a ↦ continuous_of_linearMap (bil a)
 
 /--
 If `A`, `B` and `C` have the module topology, and if furthermore `B` is a finite `R`-module,
@@ -605,10 +613,8 @@ then any bilinear map `A × B → C` is automatically continuous
 @[continuity, fun_prop]
 theorem continuous_bilinear_of_finite_right [Module.Finite R B]
     (bil : A →ₗ[R] B →ₗ[R] C) : Continuous (fun ab ↦ bil ab.1 ab.2 : (A × B → C)) := by
-  -- We already proved this when `A` is finite instead of `B`, so it's obvious by symmetry
-  rw [show (fun ab ↦ bil ab.1 ab.2 : (A × B → C)) =
-    ((fun ba ↦ bil.flip ba.1 ba.2 : (B × A → C)) ∘ (Prod.swap : A × B → B × A)) by ext; simp]
-  fun_prop
+  exact continuous_of_linearMap_prod_right (LinearMap.ltoFun R A C R ∘ₗ bil.flip)
+    fun b ↦ continuous_of_linearMap (bil.flip b)
 
 end ring
 
@@ -618,13 +624,15 @@ section algebra
 
 variable (R : Type*) [CommRing R] [TopologicalSpace R] [IsTopologicalRing R]
     (D : Type*) [Ring D] [Algebra R D] [Module.Finite R D] [TopologicalSpace D]
-    [IsModuleTopology R D]
+    [IsModuleTopology R D] (M : Type*) [AddCommGroup M] [Module R M] [Module D M]
+    [TopologicalSpace M] [IsScalarTower R D M]
 
 include R in
 /-- If `D` is an `R`-algebra, finite as an `R`-module, and if `D` has the module topology,
 then multiplication on `D` is automatically continuous. -/
 @[continuity, fun_prop]
 theorem continuous_mul_of_finite : Continuous (fun ab ↦ ab.1 * ab.2 : D × D → D) :=
+  haveI := toContinuousAdd R D
   -- Proof: multiplication is bilinear so this follows from previous results.
   continuous_bilinear_of_finite_left (LinearMap.mul R D)
 
@@ -636,6 +644,17 @@ theorem isTopologicalRing : IsTopologicalRing D where
   continuous_add := (toContinuousAdd R D).1
   continuous_mul := continuous_mul_of_finite R D
   continuous_neg := continuous_neg R D
+
+include R in
+/-- Let `R` be a a topological ring and `D` an `R`-algebra, finite as an `R`-module,
+and endowed with the `R`-module topology.
+Then, for any `D`-module `M` which is a topological `R`-module, `ContinuousConstSMul D M`
+implies `ContinuousSMul D M`. -/
+theorem continuousSMul_up_of_tower [ContinuousAdd M] [ContinuousSMul R M]
+    [ContinuousConstSMul D M] : ContinuousSMul D M where
+  continuous_smul := by
+    set φ : D →ₗ[R] M →ₗ[R] M := (Algebra.lsmul R R M).toLinearMap
+    exact continuous_of_linearMap_prod_left (LinearMap.ltoFun R M M R ∘ₗ φ) continuous_const_smul
 
 end algebra
 


### PR DESCRIPTION
My motivation is the following: to define the topology on test functions (see #31806), we take the inductive limit in the category of *real* locally convex topological vector spaces (we don't want the result to depend on the base field!). But then, we need a way to get that complex-valued test functions are also a *complex* topological vector space, which we will obtain by combining this PR with [isModuleTopologyOfFiniteDimensional](https://leanprover-community.github.io/mathlib4_docs/Mathlib/Topology/Algebra/Module/FiniteDimension.html#isModuleTopologyOfFiniteDimensional).

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

When merging, all the commits will be squashed into a single commit
listing all co-authors.

Co-authors in the squash commit are gathered from two sources:

First, all authors of commits to this PR branch are included. Thus,
one way to add co-authors is to include at least one commit authored by
each co-author among the commits in the pull request. If necessary, you
may create empty commits to indicate co-authorship, using commands like so:

git commit --author="Author Name <author@email.com>" --allow-empty -m "add Author Name as coauthor"

Second, co-authors can also be listed in lines at the very bottom of
the commit message (that is, directly before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines
at the bottom of the commit message (before the `---`, and also before
any "Co-authored-by" lines) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
