### PR TITLE
[Merged by Bors] - feat: add a `positivity` extension for `Real.toNNReal`

### DIFF
--- a/Mathlib/Data/NNReal/Defs.lean
+++ b/Mathlib/Data/NNReal/Defs.lean
@@ -995,4 +995,16 @@ meta def evalNNRealtoReal : PositivityExt where eval {u α} _zα _pα e := do
     | _ => pure (.nonnegative q(NNReal.coe_nonneg $a))
   | _, _, _ => throwError "not NNReal.toReal"
 
+/-- Extension for the `positivity` tactic: `Real.toNNReal. -/
+@[positivity Real.toNNReal _]
+meta def evalRealToNNReal : PositivityExt where eval {u α} _zα _pα e := do
+  match u, α, e with
+  | 0, ~q(ℝ), ~q(Real.toNNReal $a) =>
+    let ra ← core q(inferInstance) q(inferInstance) a
+    assertInstancesCommute
+    match ra with
+    | .positive pa => pure (.positive q(toNNReal_pos.mpr $pa))
+    | _ => failure
+  | _, _, _ => throwError "not NNReal.toReal"
+
 end Mathlib.Meta.Positivity

--- a/Mathlib/Data/NNReal/Defs.lean
+++ b/Mathlib/Data/NNReal/Defs.lean
@@ -999,12 +999,12 @@ meta def evalNNRealtoReal : PositivityExt where eval {u α} _zα _pα e := do
 @[positivity Real.toNNReal _]
 meta def evalRealToNNReal : PositivityExt where eval {u α} _zα _pα e := do
   match u, α, e with
-  | 0, ~q(ℝ), ~q(Real.toNNReal $a) =>
+  | 0, ~q(ℝ≥0), ~q(Real.toNNReal $a) =>
     let ra ← core q(inferInstance) q(inferInstance) a
     assertInstancesCommute
     match ra with
     | .positive pa => pure (.positive q(toNNReal_pos.mpr $pa))
     | _ => failure
-  | _, _, _ => throwError "not NNReal.toReal"
+  | _, _, _ => throwError "not Real.toNNReal"
 
 end Mathlib.Meta.Positivity

--- a/Mathlib/Data/NNReal/Defs.lean
+++ b/Mathlib/Data/NNReal/Defs.lean
@@ -909,9 +909,7 @@ theorem cast_natAbs_eq_nnabs_cast (n : ℤ) : (n.natAbs : ℝ≥0) = nnabs n := 
   rw [NNReal.coe_natCast, Nat.cast_natAbs, Real.coe_nnabs, Int.cast_abs]
 
 @[simp]
-theorem nnabs_pos_iff {x : ℝ} : 0 < x.nnabs ↔ x ≠ 0 := by simp [← NNReal.coe_pos]
-
-alias ⟨_, nnabs_pos⟩ := nnabs_pos_iff
+theorem nnabs_pos {x : ℝ} : 0 < x.nnabs ↔ x ≠ 0 := by simp [← NNReal.coe_pos]
 
 /-- Every real number nonnegative or nonpositive, phrased using `ℝ≥0`. -/
 lemma nnreal_dichotomy (r : ℝ) : ∃ x : ℝ≥0, r = x ∨ r = -x := by
@@ -1011,6 +1009,8 @@ meta def evalRealToNNReal : PositivityExt where eval {u α} _zα _pα e := do
     | _ => failure
   | _, _, _ => throwError "not Real.toNNReal"
 
+private alias ⟨_, nnabs_pos_of_pos⟩ := Real.nnabs_pos
+
 /-- Extension for the `positivity` tactic: `Real.nnabs. -/
 @[positivity Real.nnabs _]
 meta def evalRealNNAbs : PositivityExt where eval {u α} _zα _pα e := do
@@ -1018,7 +1018,7 @@ meta def evalRealNNAbs : PositivityExt where eval {u α} _zα _pα e := do
   | 0, ~q(ℝ≥0), ~q(Real.nnabs $a) =>
     assertInstancesCommute
     match (← core q(inferInstance) q(inferInstance) a).toNonzero with
-    | some pa => pure (.positive q(nnabs_pos $pa))
+    | some pa => pure (.positive q(nnabs_pos_of_pos $pa))
     | _ => failure
   | _, _, _ => throwError "not Real.nnabs"
 

--- a/Mathlib/Data/NNReal/Defs.lean
+++ b/Mathlib/Data/NNReal/Defs.lean
@@ -908,6 +908,11 @@ theorem cast_natAbs_eq_nnabs_cast (n : ℤ) : (n.natAbs : ℝ≥0) = nnabs n := 
   ext
   rw [NNReal.coe_natCast, Nat.cast_natAbs, Real.coe_nnabs, Int.cast_abs]
 
+@[simp]
+theorem nnabs_pos_iff {x : ℝ} : 0 < x.nnabs ↔ x ≠ 0 := by simp [← NNReal.coe_pos]
+
+alias ⟨_, nnabs_pos⟩ := nnabs_pos_iff
+
 /-- Every real number nonnegative or nonpositive, phrased using `ℝ≥0`. -/
 lemma nnreal_dichotomy (r : ℝ) : ∃ x : ℝ≥0, r = x ∨ r = -x := by
   obtain (hr | hr) : 0 ≤ r ∨ 0 ≤ -r := by simpa using le_total ..
@@ -1000,11 +1005,21 @@ meta def evalNNRealtoReal : PositivityExt where eval {u α} _zα _pα e := do
 meta def evalRealToNNReal : PositivityExt where eval {u α} _zα _pα e := do
   match u, α, e with
   | 0, ~q(ℝ≥0), ~q(Real.toNNReal $a) =>
-    let ra ← core q(inferInstance) q(inferInstance) a
     assertInstancesCommute
-    match ra with
+    match (← core q(inferInstance) q(inferInstance) a) with
     | .positive pa => pure (.positive q(toNNReal_pos.mpr $pa))
     | _ => failure
   | _, _, _ => throwError "not Real.toNNReal"
+
+/-- Extension for the `positivity` tactic: `Real.nnabs. -/
+@[positivity Real.nnabs _]
+meta def evalRealNNAbs : PositivityExt where eval {u α} _zα _pα e := do
+  match u, α, e with
+  | 0, ~q(ℝ≥0), ~q(Real.nnabs $a) =>
+    assertInstancesCommute
+    match (← core q(inferInstance) q(inferInstance) a).toNonzero with
+    | some pa => pure (.positive q(nnabs_pos $pa))
+    | _ => failure
+  | _, _, _ => throwError "not Real.nnabs"
 
 end Mathlib.Meta.Positivity

--- a/MathlibTest/positivity.lean
+++ b/MathlibTest/positivity.lean
@@ -259,6 +259,7 @@ example (a : ℝ) : 0 ≤ a.toNNReal := by positivity
 example (a : ℝ) : 0 ≤ a.nnabs := by positivity
 example (a : ℝ) (ha : 0 < a) : 0 < a.nnabs := by positivity
 example (a : ℝ) (ha : a ≠ 0) : 0 < a.nnabs := by positivity
+example (a : ℝ≥0) (ha : 0 < a) : 0 < (a : ℝ) := by positivity
 example (a : ℝ≥0) (ha : a ≠ 0) : 0 < (a : ℝ) := by positivity
 example (a : ℝ≥0) : 0 ≤ (a : ℝ) := by positivity
 

--- a/MathlibTest/positivity.lean
+++ b/MathlibTest/positivity.lean
@@ -258,6 +258,7 @@ example (a : ℝ) (ha : 0 < a) : 0 < a.toNNReal := by positivity
 example (a : ℝ) : 0 ≤ a.toNNReal := by positivity
 example (a : ℝ) : 0 ≤ a.nnabs := by positivity
 example (a : ℝ) (ha : 0 < a) : 0 < a.nnabs := by positivity
+example (a : ℝ) (ha : a ≠ 0) : 0 < a.nnabs := by positivity
 example (a : ℝ≥0) (ha : 0 < a) : 0 < (a : ℝ) := by positivity
 example (a : ℝ≥0) : 0 ≤ (a : ℝ) := by positivity
 

--- a/MathlibTest/positivity.lean
+++ b/MathlibTest/positivity.lean
@@ -252,6 +252,17 @@ example (a b : ℤ) (ha : a ≠ 0) (hb : b ≠ 0) : 0 < a.lcm b := by positivity
 example (a : ℕ) (ha : a ≠ 0) : 0 < a.sqrt := by positivity
 example (a : ℕ) (ha : a ≠ 0) : 0 < a.totient := by positivity
 
+section NNReal
+
+example (a : ℝ) (ha : 0 < a) : 0 < a.toNNReal := by positivity
+example (a : ℝ) : 0 ≤ a.toNNReal := by positivity
+example (a : ℝ) : 0 ≤ a.nnabs := by positivity
+example (a : ℝ) (ha : 0 < a) : 0 < a.nnabs := by positivity
+example (a : ℝ≥0) (ha : 0 < a) : 0 < (a : ℝ) := by positivity
+example (a : ℝ≥0) : 0 ≤ (a : ℝ) := by positivity
+
+end NNReal
+
 section ENNReal
 
 variable {a b : ℝ≥0∞}

--- a/MathlibTest/positivity.lean
+++ b/MathlibTest/positivity.lean
@@ -259,7 +259,7 @@ example (a : ℝ) : 0 ≤ a.toNNReal := by positivity
 example (a : ℝ) : 0 ≤ a.nnabs := by positivity
 example (a : ℝ) (ha : 0 < a) : 0 < a.nnabs := by positivity
 example (a : ℝ) (ha : a ≠ 0) : 0 < a.nnabs := by positivity
-example (a : ℝ≥0) (ha : 0 < a) : 0 < (a : ℝ) := by positivity
+example (a : ℝ≥0) (ha : a ≠ 0) : 0 < (a : ℝ) := by positivity
 example (a : ℝ≥0) : 0 ≤ (a : ℝ) := by positivity
 
 end NNReal


### PR DESCRIPTION

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

When merging, all the commits will be squashed into a single commit
listing all co-authors.

Co-authors in the squash commit are gathered from two sources:

First, all authors of commits to this PR branch are included. Thus,
one way to add co-authors is to include at least one commit authored by
each co-author among the commits in the pull request. If necessary, you
may create empty commits to indicate co-authorship, using commands like so:

git commit --author="Author Name <author@email.com>" --allow-empty -m "add Author Name as coauthor"

Second, co-authors can also be listed in lines at the very bottom of
the commit message (that is, directly before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines
at the bottom of the commit message (before the `---`, and also before
any "Co-authored-by" lines) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
