### PR TITLE
[Merged by Bors] - feat: generalize `homeomorphUnitSphereProd`

### DIFF
--- a/Mathlib/Analysis/Normed/Module/Ball/RadialEquiv.lean
+++ b/Mathlib/Analysis/Normed/Module/Ball/RadialEquiv.lean
@@ -7,7 +7,7 @@ module
 
 public import Mathlib.Analysis.Normed.Module.Basic
 public import Mathlib.LinearAlgebra.Basis.VectorSpace
-import Mathlib.Algebra.Ring.Action.Pointwise.Set
+public import Mathlib.Algebra.Ring.Action.Pointwise.Set
 
 /-!
 # Homeomorphism between a normed space and sphere times `(0, +∞)`

--- a/Mathlib/Analysis/Normed/Module/Ball/RadialEquiv.lean
+++ b/Mathlib/Analysis/Normed/Module/Ball/RadialEquiv.lean
@@ -16,7 +16,7 @@ In this file we define a homeomorphism between nonzero elements of a normed spac
 and `Metric.sphere (0 : E) r × Set.Ioi (0 : ℝ)`, `r > 0`.
 One may think about it as generalization of polar coordinates to any normed space.
 
-We also specialize this definition to the case `r = 1` and prove 
+We also specialize this definition to the case `r = 1` and prove
 -/
 
 @[expose] public section

--- a/Mathlib/Analysis/Normed/Module/Ball/RadialEquiv.lean
+++ b/Mathlib/Analysis/Normed/Module/Ball/RadialEquiv.lean
@@ -7,20 +7,55 @@ module
 
 public import Mathlib.Analysis.Normed.Module.Basic
 public import Mathlib.LinearAlgebra.Basis.VectorSpace
+import Mathlib.Algebra.Ring.Action.Pointwise.Set
 
 /-!
 # Homeomorphism between a normed space and sphere times `(0, +∞)`
 
 In this file we define a homeomorphism between nonzero elements of a normed space `E`
-and `Metric.sphere (0 : E) 1 × Set.Ioi (0 : ℝ)`.
+and `Metric.sphere (0 : E) r × Set.Ioi (0 : ℝ)`, `r > 0`.
 One may think about it as generalization of polar coordinates to any normed space.
+
+We also specialize this definition to the case `r = 1` and prove 
 -/
 
 @[expose] public section
 
 variable (E : Type*) [NormedAddCommGroup E] [NormedSpace ℝ E]
 
-open Set Metric
+open Filter Set Metric
+open scoped Pointwise Set.Notation Topology
+
+/-- The natural homeomorphism between nonzero elements of a normed space `E`
+and `Metric.sphere (0 : E) r × Set.Ioi (0 : ℝ)`, `0 < r`.
+
+The forward map sends `⟨x, hx⟩` to `⟨r • ‖x‖⁻¹ • x, ‖x‖ / r⟩`,
+the inverse map sends `(x, r)` to `r • x`.
+
+In the case of the unit sphere `r = `,
+one may think about it as generalization of polar coordinates to any normed space. -/
+@[simps apply_fst_coe apply_snd_coe symm_apply_coe]
+noncomputable def homeomorphSphereProd (E : Type*) [NormedAddCommGroup E] [NormedSpace ℝ E]
+    (r : ℝ) (hr : 0 < r) :
+    ({0}ᶜ : Set E) ≃ₜ (sphere (0 : E) r × Ioi (0 : ℝ)) where
+  toFun x :=
+    have : 0 < ‖(x : E)‖ := by simpa [-Subtype.coe_prop] using x.2
+    (⟨r • ‖x.1‖⁻¹ • x.1, by simp [norm_smul, abs_of_pos hr, this.ne']⟩,
+      ⟨‖x.1‖ / r, by rw [mem_Ioi]; positivity⟩)
+  invFun x := ⟨x.2.1 • x.1.1, smul_ne_zero x.2.2.out.ne' (ne_of_mem_sphere x.1.2 hr.ne')⟩
+  left_inv
+  | ⟨x, hx⟩ => by
+    have : 0 < ‖x‖ := by simpa using hx
+    ext; simp only [smul_smul]; field_simp; simp
+  right_inv
+  | (⟨x, hx⟩, ⟨d, hd⟩) => by
+    rw [mem_Ioi] at hd
+    rw [mem_sphere_zero_iff_norm] at hx
+    simp (disch := positivity) [norm_smul, smul_smul, abs_of_pos hd, hx]
+  continuous_toFun := by
+    simp only
+    fun_prop (disch := simp)
+  continuous_invFun := by fun_prop
 
 /-- The natural homeomorphism between nonzero elements of a normed space `E`
 and `Metric.sphere (0 : E) 1 × Set.Ioi (0 : ℝ)`.
@@ -28,24 +63,39 @@ and `Metric.sphere (0 : E) 1 × Set.Ioi (0 : ℝ)`.
 The forward map sends `⟨x, hx⟩` to `⟨‖x‖⁻¹ • x, ‖x‖⟩`,
 the inverse map sends `(x, r)` to `r • x`.
 
-One may think about it as generalization of polar coordinates to any normed space. -/
-@[simps apply_fst_coe apply_snd_coe symm_apply_coe]
+One may think about it as generalization of polar coordinates to any normed space.
+See also `homeomorphSphereProd` for a version that works for a sphere of any positive radius. -/
+@[simps! apply_fst_coe apply_snd_coe symm_apply_coe]
 noncomputable def homeomorphUnitSphereProd :
-    ({0}ᶜ : Set E) ≃ₜ (sphere (0 : E) 1 × Ioi (0 : ℝ)) where
-  toFun x := (⟨‖x.1‖⁻¹ • x.1, by
-    rw [mem_sphere_zero_iff_norm, norm_smul, norm_inv, norm_norm,
-      inv_mul_cancel₀ (norm_ne_zero_iff.2 x.2)]⟩, ⟨‖x.1‖, norm_pos_iff.2 x.2⟩)
-  invFun x := ⟨x.2.1 • x.1.1, smul_ne_zero x.2.2.out.ne' (ne_of_mem_sphere x.1.2 one_ne_zero)⟩
-  left_inv x := Subtype.ext <| by simp [smul_inv_smul₀ (norm_ne_zero_iff.2 x.2)]
-  right_inv
-  | (⟨x, hx⟩, ⟨r, hr⟩) => by
-    rw [mem_sphere_zero_iff_norm] at hx
-    rw [mem_Ioi] at hr
-    ext <;> simp [hx, norm_smul, abs_of_pos hr, hr.ne']
-  continuous_toFun := by
-    refine .prodMk (.codRestrict (.smul (.inv₀ ?_ ?_) ?_) _) ?_
-    · fun_prop
-    · simp
-    · fun_prop
-    · fun_prop
-  continuous_invFun := by apply Continuous.subtype_mk (by fun_prop)
+    ({0}ᶜ : Set E) ≃ₜ (sphere (0 : E) 1 × Ioi (0 : ℝ)) :=
+  homeomorphSphereProd E 1 one_pos
+
+variable {E}
+
+/-- If `U ∌ 0` is an open set on the real line and `V` is an open set on a sphere of nonzero radius,
+then their pointwise scalar product is an open set. -/
+theorem IsOpen.smul_sphere {r : ℝ} (hr : r ≠ 0) {U : Set ℝ} {V : Set (Metric.sphere (0 : E) r)}
+    (hU : IsOpen U) (hU₀ : 0 ∉ U) (hV : IsOpen V) : IsOpen (U • (V : Set E)) := by
+  rw [isOpen_iff_mem_nhds]
+  rintro _ ⟨x, hxU, _, ⟨y, hyV, rfl⟩, rfl⟩
+  wlog hx₀ : 0 < x generalizing x U
+  · replace hx₀ : 0 < -x := by
+      rw [not_lt, le_iff_eq_or_lt, ← neg_pos] at hx₀
+      exact hx₀.resolve_left <| ne_of_mem_of_not_mem hxU hU₀
+    specialize this hU.neg (by simpa) (-x) (by simpa) hx₀
+    simp only [neg_smul, nhds_neg, Set.neg_smul, Filter.mem_neg] at this
+    simpa using this
+  have hr₀ : 0 < r := lt_of_le_of_ne (by simpa using norm_nonneg y.1) hr.symm
+  lift x to Ioi (0 : ℝ) using hx₀
+  have : V ×ˢ (Ioi (0 : ℝ) ↓∩ U) ∈ 𝓝 (y, x) :=
+    prod_mem_nhds (hV.mem_nhds hyV) (hU.preimage_val.mem_nhds hxU)
+  replace := image_mem_map (m := Subtype.val ∘ (homeomorphSphereProd E r hr₀).symm) this
+  rw [← Filter.map_map, (homeomorphSphereProd _ r hr₀).symm.map_nhds_eq,
+    map_nhds_subtype_val, IsOpen.nhdsWithin_eq, homeomorphSphereProd_symm_apply_coe] at this
+  · filter_upwards [this]
+    rintro _ ⟨⟨a, b⟩, ⟨ha, hb⟩, rfl⟩
+    rw [Function.comp_apply, homeomorphSphereProd_symm_apply_coe]
+    apply Set.smul_mem_smul
+    exacts [hb, mem_image_of_mem _ ha]
+  · exact isOpen_compl_singleton
+  · simp [x.2.out.ne', ne_zero_of_mem_sphere, hr₀.ne']

--- a/Mathlib/MeasureTheory/Constructions/HaarToSphere.lean
+++ b/Mathlib/MeasureTheory/Constructions/HaarToSphere.lean
@@ -173,9 +173,9 @@ lemma integral_fun_norm_addHaar (f : ℝ → F) :
     ∫ x, f (‖x‖) ∂μ = ∫ x : ({(0)}ᶜ : Set E), f (‖x.1‖) ∂(μ.comap (↑)) := by
       rw [integral_subtype_comap (measurableSet_singleton _).compl fun x ↦ f (‖x‖),
         restrict_compl_singleton]
-    _ = ∫ x : sphere (0 : E) 1 × Ioi (0 : ℝ), f x.2 ∂μ.toSphere.prod (.volumeIoiPow (dim E - 1)) :=
-      μ.measurePreserving_homeomorphUnitSphereProd.integral_comp (Homeomorph.measurableEmbedding _)
-        (f ∘ Subtype.val ∘ Prod.snd)
+    _ = ∫ x, f x.2 ∂μ.toSphere.prod (.volumeIoiPow (dim E - 1)) := by
+      simpa using μ.measurePreserving_homeomorphUnitSphereProd.integral_comp
+        (Homeomorph.measurableEmbedding _) (f ∘ Subtype.val ∘ Prod.snd)
     _ = μ.toSphere.real univ • ∫ x : Ioi (0 : ℝ), f x ∂.volumeIoiPow (dim E - 1) :=
       integral_fun_snd (f ∘ Subtype.val)
     _ = _ := by


### PR DESCRIPTION
Also prove that the pointwise scalar product of an open set on the real line and an open set on a sphere is an open set.

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

When merging, all the commits will be squashed into a single commit
listing all co-authors.

Co-authors in the squash commit are gathered from two sources:

First, all authors of commits to this PR branch are included. Thus,
one way to add co-authors is to include at least one commit authored by
each co-author among the commits in the pull request. If necessary, you
may create empty commits to indicate co-authorship, using commands like so:

git commit --author="Author Name <author@email.com>" --allow-empty -m "add Author Name as coauthor"

Second, co-authors can also be listed in lines at the very bottom of
the commit message (that is, directly before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines
at the bottom of the commit message (before the `---`, and also before
any "Co-authored-by" lines) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
