### PR TITLE
[Merged by Bors] - feat(CategoryTheory): twisting a shift

### DIFF
--- a/Mathlib.lean
+++ b/Mathlib.lean
@@ -2896,6 +2896,7 @@ public import Mathlib.CategoryTheory.Shift.ShiftSequence
 public import Mathlib.CategoryTheory.Shift.ShiftedHom
 public import Mathlib.CategoryTheory.Shift.ShiftedHomOpposite
 public import Mathlib.CategoryTheory.Shift.SingleFunctors
+public import Mathlib.CategoryTheory.Shift.Twist
 public import Mathlib.CategoryTheory.Sigma.Basic
 public import Mathlib.CategoryTheory.Simple
 public import Mathlib.CategoryTheory.SingleObj

--- a/Mathlib.lean
+++ b/Mathlib.lean
@@ -2269,6 +2269,7 @@ public import Mathlib.CategoryTheory.Category.ULift
 public import Mathlib.CategoryTheory.Center.Basic
 public import Mathlib.CategoryTheory.Center.Linear
 public import Mathlib.CategoryTheory.Center.Localization
+public import Mathlib.CategoryTheory.Center.Preadditive
 public import Mathlib.CategoryTheory.ChosenFiniteProducts
 public import Mathlib.CategoryTheory.ChosenFiniteProducts.Cat
 public import Mathlib.CategoryTheory.ChosenFiniteProducts.FunctorCategory

--- a/Mathlib/CategoryTheory/Center/Basic.lean
+++ b/Mathlib/CategoryTheory/Center/Basic.lean
@@ -65,7 +65,6 @@ instance : IsMulCommutative (CatCenter C) where
 instance {X Y : C} : SMul (CatCenter C) (X ⟶ Y) where
   smul z f := f ≫ z.app Y
 
-@[simp]
 lemma smul_eq (z : CatCenter C) {X Y : C} (f : X ⟶ Y) : z • f = f ≫ z.app Y := rfl
 
 lemma smul_eq' (z : CatCenter C) {X Y : C} (f : X ⟶ Y) : z • f = z.app X ≫ f :=
@@ -82,7 +81,7 @@ instance {X Y : C} : SMul (CatCenter C)ˣ (X ≅ Y) where
         rw [smul_eq, smul_eq', Category.assoc, ← mul_app_assoc]
         simp }
 
-@[simp, reassoc]
+@[reassoc]
 lemma smul_iso_hom_eq (z : (CatCenter C)ˣ) {X Y : C} (f : X ≅ Y) :
     (z • f).hom = f.hom ≫ z.1.app Y := rfl
 
@@ -91,7 +90,7 @@ lemma smul_iso_hom_eq' (z : (CatCenter C)ˣ) {X Y : C} (f : X ≅ Y) :
     (z • f).hom = z.1.app X ≫ f.hom :=
   z.1.naturality f.hom
 
-@[simp, reassoc]
+@[reassoc]
 lemma smul_iso_inv_eq (z : (CatCenter C)ˣ) {X Y : C} (f : X ≅ Y) :
     (z • f).inv = f.inv ≫ (z⁻¹.1).app X := rfl
 

--- a/Mathlib/CategoryTheory/Center/Basic.lean
+++ b/Mathlib/CategoryTheory/Center/Basic.lean
@@ -36,9 +36,18 @@ namespace CatCenter
 
 variable {C}
 
+/-- The action of the center of a category on an object. (This is necessary as
+`NatTrans.app x X` is syntactically an endomorphism of `(𝟭 C).obj X`
+rather than of `X`.) -/
+abbrev app (x : CatCenter C) (X : C) : X ⟶ X := NatTrans.app x X
+
 @[ext]
 lemma ext (x y : CatCenter C) (h : ∀ (X : C), x.app X = y.app X) : x = y :=
   NatTrans.ext (funext h)
+
+@[reassoc]
+lemma naturality (z : CatCenter C) {X Y : C} (f : X ⟶ Y) :
+    f ≫ z.app Y = z.app X ≫ f := NatTrans.naturality z f
 
 @[reassoc]
 lemma mul_app' (x y : CatCenter C) (X : C) : (x * y).app X = y.app X ≫ x.app X := rfl
@@ -52,6 +61,44 @@ instance : IsMulCommutative (CatCenter C) where
   is_comm := ⟨fun x y ↦ by
     ext X
     rw [mul_app' x y, mul_app y x]⟩
+
+instance {X Y : C} : SMul (CatCenter C) (X ⟶ Y) where
+  smul z f := f ≫ z.app Y
+
+@[simp]
+lemma smul_eq (z : CatCenter C) {X Y : C} (f : X ⟶ Y) : z • f = f ≫ z.app Y := rfl
+
+lemma smul_eq' (z : CatCenter C) {X Y : C} (f : X ⟶ Y) : z • f = z.app X ≫ f :=
+  z.naturality f
+
+instance {X Y : C} : SMul (CatCenter C)ˣ (X ≅ Y) where
+  smul z e :=
+    { hom := z.1 • e.hom
+      inv := (z⁻¹).1 • e.inv
+      hom_inv_id := by
+        rw [smul_eq, smul_eq', Category.assoc, ← mul_app_assoc]
+        simp
+      inv_hom_id := by
+        rw [smul_eq, smul_eq', Category.assoc, ← mul_app_assoc]
+        simp }
+
+@[simp, reassoc]
+lemma smul_iso_hom_eq (z : (CatCenter C)ˣ) {X Y : C} (f : X ≅ Y) :
+    (z • f).hom = f.hom ≫ z.1.app Y := rfl
+
+@[reassoc]
+lemma smul_iso_hom_eq' (z : (CatCenter C)ˣ) {X Y : C} (f : X ≅ Y) :
+    (z • f).hom = z.1.app X ≫ f.hom :=
+  z.1.naturality f.hom
+
+@[simp, reassoc]
+lemma smul_iso_inv_eq (z : (CatCenter C)ˣ) {X Y : C} (f : X ≅ Y) :
+    (z • f).inv = f.inv ≫ (z⁻¹.1).app X := rfl
+
+@[reassoc]
+lemma smul_iso_inv_eq' (z : (CatCenter C)ˣ) {X Y : C} (f : X ≅ Y) :
+    (z • f).inv = (z⁻¹.1).app Y ≫ f.inv :=
+  z.2.naturality f.inv
 
 end CatCenter
 

--- a/Mathlib/CategoryTheory/Center/Linear.lean
+++ b/Mathlib/CategoryTheory/Center/Linear.lean
@@ -7,7 +7,7 @@ module
 
 public import Mathlib.CategoryTheory.Preadditive.FunctorCategory
 public import Mathlib.CategoryTheory.Linear.Basic
-public import Mathlib.CategoryTheory.Center.Basic
+public import Mathlib.CategoryTheory.Center.Preadditive
 
 /-!
 # Center of a linear category
@@ -43,11 +43,7 @@ def toCatCenter [Linear R C] : R →+* CatCenter C where
     rw [Linear.smul_comp, Linear.comp_smul, smul_smul]
     simp
   map_zero' := by cat_disch
-  map_add' a b := by
-    ext X
-    dsimp [CatCenter.app]
-    rw [add_smul]
-    rfl
+  map_add' a b := by ext X; simp [add_smul]
 
 section
 
@@ -86,15 +82,14 @@ def homModuleOfRingMorphism : Module R (X ⟶ Y) := by
       simp only [smulOfRingMorphism_smul_eq', Functor.id_obj, map_mul, End.mul_def,
         NatTrans.comp_app, assoc]
     smul_zero := fun a => by
-      simp only [smulOfRingMorphism_smul_eq, Functor.id_obj, comp_zero]
+      simp only [smulOfRingMorphism_smul_eq, comp_zero]
     zero_smul := fun a => by
-      simp only [smulOfRingMorphism_smul_eq, Functor.id_obj, map_zero,
+      simp only [smulOfRingMorphism_smul_eq, map_zero,
         zero_app, zero_comp]
     smul_add := fun a b => by
       simp [smulOfRingMorphism_smul_eq]
     add_smul := fun a b f => by
-      simp only [smulOfRingMorphism_smul_eq]
-      rw [map_add, NatTrans.app_add, Preadditive.add_comp] }
+      simp [smulOfRingMorphism_smul_eq] }
 
 /-- The `R`-linear structure on a preadditive category `C` equipped with
 a ring morphism `R →+* CatCenter C`. -/

--- a/Mathlib/CategoryTheory/Center/Linear.lean
+++ b/Mathlib/CategoryTheory/Center/Linear.lean
@@ -45,8 +45,9 @@ def toCatCenter [Linear R C] : R →+* CatCenter C where
   map_zero' := by cat_disch
   map_add' a b := by
     ext X
-    dsimp
-    rw [NatTrans.app_add, add_smul]
+    dsimp [CatCenter.app]
+    rw [add_smul]
+    rfl
 
 section
 

--- a/Mathlib/CategoryTheory/Center/Localization.lean
+++ b/Mathlib/CategoryTheory/Center/Localization.lean
@@ -5,7 +5,7 @@ Authors: Joël Riou
 -/
 module
 
-public import Mathlib.CategoryTheory.Center.Basic
+public import Mathlib.CategoryTheory.Center.Preadditive
 public import Mathlib.CategoryTheory.Localization.Predicate
 public import Mathlib.CategoryTheory.Preadditive.AdditiveFunctor
 
@@ -67,9 +67,7 @@ lemma localization_zero :
 
 lemma localization_add :
     (r + s).localization L W = r.localization L W + s.localization L W :=
-  ext_of_localization L W _ _ (fun X => by
-    rw [localization_app, NatTrans.app_add, NatTrans.app_add, L.map_add,
-      localization_app, localization_app])
+  ext_of_localization L W _ _ (by simp)
 
 /-- The morphism of rings `CatCenter C →+* CatCenter D` when `L : C ⥤ D`
 is an additive localization functor between preadditive categories. -/

--- a/Mathlib/CategoryTheory/Center/Preadditive.lean
+++ b/Mathlib/CategoryTheory/Center/Preadditive.lean
@@ -1,0 +1,32 @@
+/-
+Copyright (c) 2025 Joël Riou. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Joël Riou
+-/
+module
+
+public import Mathlib.CategoryTheory.Preadditive.FunctorCategory
+public import Mathlib.CategoryTheory.Center.Basic
+
+/-!
+# The center of an additive category
+
+-/
+
+@[expose] public section
+
+universe v u
+
+namespace CategoryTheory
+
+namespace CatCenter
+
+variable {C : Type u} [Category.{v} C] [Preadditive C]
+
+@[simp]
+lemma app_add (z₁ z₂ : CatCenter C) (X : C) :
+    (z₁ + z₂).app X = z₁.app X + z₂.app X := rfl
+
+end CatCenter
+
+end CategoryTheory

--- a/Mathlib/CategoryTheory/Center/Preadditive.lean
+++ b/Mathlib/CategoryTheory/Center/Preadditive.lean
@@ -27,6 +27,14 @@ variable {C : Type u} [Category.{v} C] [Preadditive C]
 lemma app_add (z₁ z₂ : CatCenter C) (X : C) :
     (z₁ + z₂).app X = z₁.app X + z₂.app X := rfl
 
+@[simp]
+lemma app_sub (z₁ z₂ : CatCenter C) (X : C) :
+    (z₁ - z₂).app X = z₁.app X - z₂.app X := rfl
+
+@[simp]
+lemma app_neg (z : CatCenter C) (X : C) :
+    (-z).app X = - z.app X := rfl
+
 end CatCenter
 
 end CategoryTheory

--- a/Mathlib/CategoryTheory/Localization/Linear.lean
+++ b/Mathlib/CategoryTheory/Localization/Linear.lean
@@ -44,8 +44,7 @@ lemma functor_linear :
   constructor
   intro X Y f r
   change L.map (r • f) = ((Linear.toCatCenter R C r).localization L W).app (L.obj X) ≫ L.map f
-  simp only [CatCenter.localization_app, ← L.map_comp,
-    Functor.id_obj, Linear.toCatCenter_apply_app, Linear.smul_comp, Category.id_comp]
+  simp [← L.map_comp]
 
 section
 

--- a/Mathlib/CategoryTheory/Shift/Twist.lean
+++ b/Mathlib/CategoryTheory/Shift/Twist.lean
@@ -36,7 +36,7 @@ structure TwistShiftData where
   z_zero_right (a : A) : z a 0 = 1 := by cat_disch
   z_zero_left (b : A) : z 0 b = 1 := by cat_disch
   assoc (a b c : A) : z (a + b) c * z a b = z a (b + c) * z b c := by cat_disch
-  commShift (a b : A) : NatTrans.CommShift (z a b).1 A := by infer_instance
+  commShift (a b : A) : NatTrans.CommShift (z a b).val A := by infer_instance
 
 namespace TwistShiftData
 
@@ -47,8 +47,8 @@ attribute [instance] commShift
 
 @[simp]
 lemma shift_z_app (a b c : A) (X : C) :
-    ((t.z a b).1.app X)⟦c⟧' = (t.z a b).1.app (X⟦c⟧) := by
-  simpa using NatTrans.shift_app_comm (t.z a b).1 c X
+    ((t.z a b).val.app X)⟦c⟧' = (t.z a b).val.app (X⟦c⟧) := by
+  simpa using NatTrans.shift_app_comm (t.z a b).val c X
 
 end TwistShiftData
 
@@ -103,14 +103,14 @@ lemma shiftFunctorZero_inv_app (X : TwistShift t) :
 @[simp]
 lemma shiftFunctorAdd'_hom_app (i j k : A) (h : i + j = k) (X : TwistShift t) :
     (shiftFunctorAdd' (TwistShift t) i j k h).hom.app X =
-      (t.z i j).1 • (shiftFunctorAdd' C i j k h).hom.app X := by
+      (t.z i j).val • (shiftFunctorAdd' C i j k h).hom.app X := by
   dsimp [shiftFunctorAdd']
   cat_disch
 
 @[simp]
 lemma shiftFunctorAdd'_inv_app (i j k : A) (h : i + j = k) (X : TwistShift t) :
     (shiftFunctorAdd' (TwistShift t) i j k h).inv.app X =
-      ((t.z i j)⁻¹).1 • (shiftFunctorAdd' C i j k h).inv.app X := by
+      ((t.z i j)⁻¹).val • (shiftFunctorAdd' C i j k h).inv.app X := by
   dsimp [shiftFunctorAdd']
   cat_disch
 

--- a/Mathlib/CategoryTheory/Shift/Twist.lean
+++ b/Mathlib/CategoryTheory/Shift/Twist.lean
@@ -1,0 +1,117 @@
+/-
+Copyright (c) 2025 Joël Riou. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Joël Riou
+-/
+module
+
+public import Mathlib.CategoryTheory.Center.Basic
+public import Mathlib.CategoryTheory.Shift.CommShift
+
+/-!
+# Twisting a shift
+
+Given a category `C` equipped with a shift by a monoid `A`, we introduce a structure
+`t : TwistShiftData C A` which consists of a collection of invertible elements in the
+center of the category `C` (typically, this will be suitable signs when we
+assume `C` is preadditive), which allow to introduce a type synonym
+category `TwistShift t` which identical shift functors as `C` but where
+the isomorphisms `shiftFunctorAdd` have been modified.
+
+-/
+
+@[expose] public section
+
+namespace CategoryTheory
+
+variable (C : Type*) [Category C] (A : Type*) [AddMonoid A] [HasShift C A]
+
+/-- Given a category `C` equipped with a shift by a monoid `A` -/
+structure TwistShiftData where
+  /-- The invertible elements in the center of `C` which are used to
+  modify the `shiftFunctorAdd` isomorphisms . -/
+  z (a b : A) : (CatCenter C)ˣ
+  z_zero_right (a : A) : z a 0 = 1 := by cat_disch
+  z_zero_left (b : A) : z 0 b = 1 := by cat_disch
+  assoc (a b c : A) : z (a + b) c * z a b = z a (b + c) * z b c := by cat_disch
+  commShift (a b : A) : NatTrans.CommShift (z a b).1 A := by infer_instance
+
+namespace TwistShiftData
+
+variable {C A} (t : TwistShiftData C A)
+
+attribute [simp] z_zero_right z_zero_left
+attribute [instance] commShift
+
+@[simp]
+lemma shift_z_app (a b c : A) (X : C) :
+    ((t.z a b).1.app X)⟦c⟧' = (t.z a b).1.app (X⟦c⟧) := by
+  simpa using NatTrans.shift_app_comm (t.z a b).1 c X
+
+end TwistShiftData
+
+variable {C A}
+
+/-- Given `t : TwistShiftData C A`, this is a type synonym for the category `C`,
+which the same shift functors as `C` but where the `shiftFunctorAdd` isomorphisms
+have been modified using `t`. -/
+@[nolint unusedArguments]
+def TwistShift (_ : TwistShiftData C A) : Type _ := C
+
+variable (t : TwistShiftData C A)
+
+namespace TwistShift
+
+instance : Category (TwistShift t) := inferInstanceAs (Category C)
+
+/-- Given `t : TwistShiftData C A`, the shift on the category `TwistShift t` has
+the same shift functors as `C`, the same isomorphism `shiftFunctorZero` isomorphism,
+but the `shiftFunctorAdd` isomorphisms are modified using `t`. -/
+def shiftMkCore : ShiftMkCore (TwistShift t) A where
+  F a := shiftFunctor C a
+  zero := shiftFunctorZero C A
+  add a b := NatIso.ofComponents (fun X ↦ t.z a b • (shiftFunctorAdd C a b).app X) (by
+    simp [CatCenter.naturality_assoc, CatCenter.naturality])
+  add_zero_hom_app := by simp [shiftFunctorAdd_add_zero_hom_app]
+  zero_add_hom_app := by simp [shiftFunctorAdd_zero_add_hom_app]
+  assoc_hom_app a b c X := by
+    dsimp
+    simp only [Functor.map_comp, Category.assoc]
+    rw [CatCenter.naturality, CatCenter.naturality_assoc, CatCenter.naturality_assoc,
+      CatCenter.naturality_assoc, CatCenter.naturality_assoc, CatCenter.naturality_assoc,
+      t.shift_z_app, CatCenter.naturality, CatCenter.naturality_assoc,
+      ← CatCenter.mul_app_assoc, ← CatCenter.mul_app_assoc,
+      ← Units.val_mul, ← Units.val_mul, t.assoc a b c]
+    simp [shiftFunctorAdd_assoc_hom_app (C := C) a b c X, shiftFunctorAdd']
+
+instance : HasShift (TwistShift t) A := hasShiftMk _ _ (shiftMkCore t)
+
+@[simp]
+lemma shiftFunctor_obj (X : TwistShift t) (a : A) :
+    (shiftFunctor (TwistShift t) a).obj X = (shiftFunctor C a).obj X := rfl
+
+@[simp]
+lemma shiftFunctorZero_hom_app (X : TwistShift t) :
+    (shiftFunctorZero (TwistShift t) A).hom.app X = (shiftFunctorZero C A).hom.app X := rfl
+
+@[simp]
+lemma shiftFunctorZero_inv_app (X : TwistShift t) :
+    (shiftFunctorZero (TwistShift t) A).inv.app X = (shiftFunctorZero C A).inv.app X := rfl
+
+@[simp]
+lemma shiftFunctorAdd'_hom_app (i j k : A) (h : i + j = k) (X : TwistShift t) :
+    (shiftFunctorAdd' (TwistShift t) i j k h).hom.app X =
+      (t.z i j).1 • (shiftFunctorAdd' C i j k h).hom.app X := by
+  dsimp [shiftFunctorAdd']
+  cat_disch
+
+@[simp]
+lemma shiftFunctorAdd'_inv_app (i j k : A) (h : i + j = k) (X : TwistShift t) :
+    (shiftFunctorAdd' (TwistShift t) i j k h).inv.app X =
+      ((t.z i j)⁻¹).1 • (shiftFunctorAdd' C i j k h).inv.app X := by
+  dsimp [shiftFunctorAdd']
+  cat_disch
+
+end TwistShift
+
+end CategoryTheory

--- a/Mathlib/CategoryTheory/Shift/Twist.lean
+++ b/Mathlib/CategoryTheory/Shift/Twist.lean
@@ -115,7 +115,7 @@ lemma shiftFunctorAdd'_hom_app (i j k : A) (h : i + j = k) (X : t.Category) :
   have : (shiftFunctorAdd' t.Category i j k h).hom.app X =
       (t.z i j).val • (shiftFunctorAdd' C i j k h).hom.app X := by
     dsimp [shiftFunctorAdd']
-    aesop
+    cat_disch
   rw [this]
   congr
   change _ = 𝟙 _ ≫ _ ≫ (shiftFunctor C j).map (𝟙 _) ≫ 𝟙 _
@@ -131,7 +131,7 @@ lemma shiftFunctorAdd'_inv_app (i j k : A) (h : i + j = k) (X : t.Category) :
   have : (shiftFunctorAdd' t.Category i j k h).inv.app X =
       ((t.z i j)⁻¹).val • (shiftFunctorAdd' C i j k h).inv.app X := by
     dsimp [shiftFunctorAdd']
-    aesop
+    cat_disch
   rw [this]
   congr
   change _ = 𝟙 _ ≫ (shiftFunctor C j).map (𝟙 _) ≫ _ ≫ 𝟙 _

--- a/Mathlib/CategoryTheory/Shift/Twist.lean
+++ b/Mathlib/CategoryTheory/Shift/Twist.lean
@@ -22,9 +22,11 @@ the isomorphisms `shiftFunctorAdd` have been modified.
 
 @[expose] public section
 
+universe w v u
+
 namespace CategoryTheory
 
-variable (C : Type*) [Category C] (A : Type*) [AddMonoid A] [HasShift C A]
+variable (C : Type u) [Category.{v} C] (A : Type w) [AddMonoid A] [HasShift C A]
 
 /-- Given a category `C` equipped with a shift by a monoid `A` -/
 structure TwistShiftData where
@@ -56,7 +58,7 @@ variable {C A}
 which the same shift functors as `C` but where the `shiftFunctorAdd` isomorphisms
 have been modified using `t`. -/
 @[nolint unusedArguments]
-def TwistShift (_ : TwistShiftData C A) : Type _ := C
+def TwistShift (_ : TwistShiftData C A) : Type u := C
 
 variable (t : TwistShiftData C A)
 


### PR DESCRIPTION
Given a category `C` equipped with a shift by an additive monoid `A`, we introduce a structure `TwistShiftData C A` which allows to modify the `shiftFunctorAdd` isomorphisms of the shift by multiplying by a suitable collection of invertible elements in the center of the category `C` (typically, `C` will be preadditive, and these will just be signs).
This notion will be important when formalising triangulated functors in two variables and their derived functors. (The idea is that "a bifunctor `F : C₁ ⥤ C₂ ⥤ D` will commute to shifts by `ℤ` in two variables..." iff the uncurried functor `C₁ × C₂ ⥤ D` commutes with suitable shifts by `ℤ × ℤ`, where the shift by `ℤ × ℤ` on `C₁ × C₂` is obtained by twisting the obvious product shift, and the shift by `(a, b)` on `D` is the shift by `a + b`.)

(I am not aware there is anything comparable in the mathematical literature. The only evidence I can currently give that it is going to be useful is the file https://github.com/joelriou/mathlib4/blob/jriou_localization/Mathlib/CategoryTheory/Shift/CommShiftTwo.lean which shows that under suitable conditions, the data of a commutation with the shifts on two variables for `F : C₁ ⥤ C₂ ⥤ D` is essentially the same as the commutation with the (twisted) shift by `M × M` of the uncurried functor.)

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

When merging, all the commits will be squashed into a single commit
listing all co-authors.

Co-authors in the squash commit are gathered from two sources:

First, all authors of commits to this PR branch are included. Thus,
one way to add co-authors is to include at least one commit authored by
each co-author among the commits in the pull request. If necessary, you
may create empty commits to indicate co-authorship, using commands like so:

git commit --author="Author Name <author@email.com>" --allow-empty -m "add Author Name as coauthor"

Second, co-authors can also be listed in lines at the very bottom of
the commit message (that is, directly before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines
at the bottom of the commit message (before the `---`, and also before
any "Co-authored-by" lines) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
