### PR TITLE
[Merged by Bors] - feat(Analysis): |sin x - sin y| ≤ |x - y|

### DIFF
--- a/Mathlib/Analysis/SpecialFunctions/Trigonometric/Bounds.lean
+++ b/Mathlib/Analysis/SpecialFunctions/Trigonometric/Bounds.lean
@@ -233,28 +233,21 @@ theorem cos_le_one_div_sqrt_sq_add_one {x : ℝ} (hx1 : -(3 * π / 2) ≤ x) (hx
   · simp
   · exact (cos_lt_one_div_sqrt_sq_add_one hx1 hx2 hx3).le
 
-theorem abs_sin_sub_sin_le (x y : ℝ) : |sin x - sin y| ≤ |x - y| := by
-  wlog h : y ≤ x
-  · convert this y x (not_le.mp h).le using 1 <;> apply abs_sub_comm
-  suffices ‖sin x - sin y‖ ≤ 1 * (x - y) by
-    convert this using 1
-    simpa using h
-  have hx : x ∈ Set.Icc y x := by simpa using h
-  have hcos (z : ℝ) (_ : z ∈ Set.Ico y x) : ‖cos z‖ ≤ 1 := by
-    simpa using abs_cos_le_one z
-  refine norm_image_sub_le_of_norm_deriv_le_segment' (fun x _ ↦ ?_) hcos _ hx
-  simpa using (hasDerivAt_id x).sin.hasDerivWithinAt
-
-theorem abs_cos_sub_cos_le (x y : ℝ) : |cos x - cos y| ≤ |x - y| := by
-  simpa [sin_add_pi_div_two] using abs_sin_sub_sin_le (x + π / 2) (y + π / 2)
-
 theorem lipschitzWith_sin : LipschitzWith 1 sin := by
-  intro x y
-  simpa [edist_dist] using abs_sin_sub_sin_le x y
+  apply lipschitzWith_of_nnnorm_deriv_le differentiable_sin
+  intro x
+  simpa using abs_cos_le_one x
 
 theorem lipschitzWith_cos : LipschitzWith 1 cos := by
-  intro x y
-  simpa [edist_dist] using abs_cos_sub_cos_le x y
+  apply lipschitzWith_of_nnnorm_deriv_le differentiable_cos
+  intro x
+  simpa using abs_sin_le_one x
+
+theorem abs_sin_sub_sin_le (x y : ℝ) : |sin x - sin y| ≤ |x - y| := by
+  simpa [edist_dist] using lipschitzWith_sin x y
+
+theorem abs_cos_sub_cos_le (x y : ℝ) : |cos x - cos y| ≤ |x - y| := by
+  simpa [edist_dist] using lipschitzWith_cos x y
 
 theorem norm_exp_I_mul_ofReal_sub_one_le {x : ℝ} : ‖.exp (.I * x) - (1 : ℂ)‖ ≤ ‖x‖ := by
   rw [Complex.norm_exp_I_mul_ofReal_sub_one]

--- a/Mathlib/Analysis/SpecialFunctions/Trigonometric/Bounds.lean
+++ b/Mathlib/Analysis/SpecialFunctions/Trigonometric/Bounds.lean
@@ -248,6 +248,14 @@ theorem abs_sin_sub_sin_le (x y : ℝ) : |sin x - sin y| ≤ |x - y| := by
 theorem abs_cos_sub_cos_le (x y : ℝ) : |cos x - cos y| ≤ |x - y| := by
   simpa [sin_add_pi_div_two] using abs_sin_sub_sin_le (x + π / 2) (y + π / 2)
 
+theorem lipschitzWith_sin : LipschitzWith 1 sin := by
+  intro x y
+  simpa [edist_dist] using abs_sin_sub_sin_le x y
+
+theorem lipschitzWith_cos : LipschitzWith 1 cos := by
+  intro x y
+  simpa [edist_dist] using abs_cos_sub_cos_le x y
+
 theorem norm_exp_I_mul_ofReal_sub_one_le {x : ℝ} : ‖.exp (.I * x) - (1 : ℂ)‖ ≤ ‖x‖ := by
   rw [Complex.norm_exp_I_mul_ofReal_sub_one]
   calc

--- a/Mathlib/Analysis/SpecialFunctions/Trigonometric/Bounds.lean
+++ b/Mathlib/Analysis/SpecialFunctions/Trigonometric/Bounds.lean
@@ -233,15 +233,11 @@ theorem cos_le_one_div_sqrt_sq_add_one {x : ℝ} (hx1 : -(3 * π / 2) ≤ x) (hx
   · simp
   · exact (cos_lt_one_div_sqrt_sq_add_one hx1 hx2 hx3).le
 
-theorem lipschitzWith_sin : LipschitzWith 1 sin := by
-  apply lipschitzWith_of_nnnorm_deriv_le differentiable_sin
-  intro x
-  simpa using abs_cos_le_one x
+theorem lipschitzWith_sin : LipschitzWith 1 sin :=
+  lipschitzWith_of_nnnorm_deriv_le differentiable_sin <| by simpa using abs_cos_le_one
 
-theorem lipschitzWith_cos : LipschitzWith 1 cos := by
-  apply lipschitzWith_of_nnnorm_deriv_le differentiable_cos
-  intro x
-  simpa using abs_sin_le_one x
+theorem lipschitzWith_cos : LipschitzWith 1 cos :=
+  lipschitzWith_of_nnnorm_deriv_le differentiable_cos <| by simpa using abs_sin_le_one
 
 theorem abs_sin_sub_sin_le (x y : ℝ) : |sin x - sin y| ≤ |x - y| := by
   simpa [edist_dist] using lipschitzWith_sin x y

--- a/Mathlib/Analysis/SpecialFunctions/Trigonometric/Bounds.lean
+++ b/Mathlib/Analysis/SpecialFunctions/Trigonometric/Bounds.lean
@@ -233,6 +233,21 @@ theorem cos_le_one_div_sqrt_sq_add_one {x : ℝ} (hx1 : -(3 * π / 2) ≤ x) (hx
   · simp
   · exact (cos_lt_one_div_sqrt_sq_add_one hx1 hx2 hx3).le
 
+theorem abs_sin_sub_sin_le (x y : ℝ) : |sin x - sin y| ≤ |x - y| := by
+  wlog h : y ≤ x
+  · convert this y x (not_le.mp h).le using 1 <;> apply abs_sub_comm
+  suffices ‖sin x - sin y‖ ≤ 1 * (x - y) by
+    convert this using 1
+    simpa using h
+  have hx : x ∈ Set.Icc y x := by simpa using h
+  have hcos (z : ℝ) (_ : z ∈ Set.Ico y x) : ‖cos z‖ ≤ 1 := by
+    simpa using abs_cos_le_one z
+  refine norm_image_sub_le_of_norm_deriv_le_segment' (fun x _ ↦ ?_) hcos _ hx
+  simpa using (hasDerivAt_id x).sin.hasDerivWithinAt
+
+theorem abs_cos_sub_cos_le (x y : ℝ) : |cos x - cos y| ≤ |x - y| := by
+  simpa [sin_add_pi_div_two] using abs_sin_sub_sin_le (x + π / 2) (y + π / 2)
+
 theorem norm_exp_I_mul_ofReal_sub_one_le {x : ℝ} : ‖.exp (.I * x) - (1 : ℂ)‖ ≤ ‖x‖ := by
   rw [Complex.norm_exp_I_mul_ofReal_sub_one]
   calc


### PR DESCRIPTION
Not sure if this is a good place to put these. I originally wanted to put these in Deriv.lean but that file is too long.

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

When merging, all the commits will be squashed into a single commit
listing all co-authors.

Co-authors in the squash commit are gathered from two sources:

First, all authors of commits to this PR branch are included. Thus,
one way to add co-authors is to include at least one commit authored by
each co-author among the commits in the pull request. If necessary, you
may create empty commits to indicate co-authorship, using commands like so:

git commit --author="Author Name <author@email.com>" --allow-empty -m "add Author Name as coauthor"

Second, co-authors can also be listed in lines at the very bottom of
the commit message (that is, directly before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines
at the bottom of the commit message (before the `---`, and also before
any "Co-authored-by" lines) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
