### PR TITLE
feat: add monotonicity and relation lemmas for mgf and cgf

### DIFF
--- a/Mathlib/Probability/Moments/Basic.lean
+++ b/Mathlib/Probability/Moments/Basic.lean
@@ -163,6 +163,13 @@ theorem cgf_zero' : cgf X μ 0 = log (μ.real Set.univ) := by simp only [cgf, mg
 theorem cgf_zero [IsZeroOrProbabilityMeasure μ] : cgf X μ 0 = 0 := by
   rcases eq_zero_or_isProbabilityMeasure μ with rfl | h <;> simp [cgf_zero']
 
+/-- If the moment-generating function equals `1` at `t`,
+    then the cumulant-generating function equals `0` at `t`. -/
+lemma cgf_zero_of_mgf_one [MeasurableSpace Ω]
+    (μ : Measure Ω) {X : Ω → ℝ} {t : ℝ} (h : mgf X μ t = 1) :
+    cgf X μ t = 0 := by
+  simp only [cgf, h, log_one]
+
 theorem mgf_undef (hX : ¬Integrable (fun ω => exp (t * X ω)) μ) : mgf X μ t = 0 := by
   simp only [mgf, integral_undef hX]
 
@@ -269,6 +276,20 @@ lemma mgf_anti_of_nonpos {Y : Ω → ℝ} (hXY : X ≤ᵐ[μ] Y) (ht : t ≤ 0)
     filter_upwards [hXY] with ω hω using exp_monotone <| mul_le_mul_of_nonpos_left hω ht
   · rw [mgf_undef htY]
     exact mgf_nonneg
+
+/-- For a nonnegative random variable `X` (a.e.), the `mgf` is monotone in the parameter `t`:
+    if `s ≤ t` and both integrals exist, then `mgf X μ s ≤ mgf X μ t`. -/
+lemma mgf_mono_in_t_of_nonneg {Ω : Type*} [MeasurableSpace Ω]
+    (μ : Measure Ω) {X : Ω → ℝ} {s t : ℝ}
+    (hst : s ≤ t) (hX_nonneg : 0 ≤ᵐ[μ] X)
+    (h_int_s : Integrable (fun ω => Real.exp (s * X ω)) μ)
+    (h_int_t : Integrable (fun ω => Real.exp (t * X ω)) μ) :
+    mgf X μ s ≤ mgf X μ t := by
+  simp only [mgf] at h_int_s h_int_t ⊢
+  have h_ae : (fun ω => Real.exp (s * X ω)) ≤ᵐ[μ] fun ω => Real.exp (t * X ω) := by
+    refine hX_nonneg.mono fun ω hω => ?_
+    exact Real.exp_le_exp.mpr (mul_le_mul_of_nonneg_right hst hω)
+  exact integral_mono_ae h_int_s h_int_t h_ae
 
 section IndepFun
 


### PR DESCRIPTION
Add two lemmas about moment-generating and cumulant-generating functions:

- `mgf_mono_in_t_of_nonneg`: For nonnegative random variables, the mgf is monotone in the parameter `t`
- `cgf_zero_of_mgf_one`: The cgf equals zero iff the mgf equals one

These lemmas are useful for studying properties of mgf and cgf in probability theory.

Contributed by sequential-intelligence-lab(SIL), University of Virginia

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

When merging, all the commits will be squashed into a single commit
listing all co-authors.

Co-authors in the squash commit are gathered from two sources:

First, all authors of commits to this PR branch are included. Thus,
one way to add co-authors is to include at least one commit authored by
each co-author among the commits in the pull request. If necessary, you
may create empty commits to indicate co-authorship, using commands like so:

git commit --author="Author Name <author@email.com>" --allow-empty -m "add Author Name as coauthor"

Second, co-authors can also be listed in lines at the very bottom of
the commit message (that is, directly before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines
at the bottom of the commit message (before the `---`, and also before
any "Co-authored-by" lines) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
