### PR TITLE
chore(Analysis/Calculus/FDeriv): golf `exist_minSmoothness_le_ne_infty` using `grind`

### DIFF
--- a/Mathlib/Analysis/Calculus/FDeriv/Symmetric.lean
+++ b/Mathlib/Analysis/Calculus/FDeriv/Symmetric.lean
@@ -533,12 +533,7 @@ for `n' ≠ ∞`, then it is `C^{n'}` on a neighborhood of the point (this prope
 in `C^∞` smoothness, see `ContDiffWithinAt.contDiffOn`). -/
 lemma exist_minSmoothness_le_ne_infty {n : WithTop ℕ∞} {m : ℕ} (hm : minSmoothness 𝕜 m ≤ n) :
     ∃ n', minSmoothness 𝕜 m ≤ n' ∧ n' ≤ n ∧ n' ≠ ∞ := by
-  simp only [minSmoothness] at hm ⊢
-  split_ifs with h
-  · simp only [h, ↓reduceIte] at hm
-    exact ⟨m, le_rfl, hm, by simp⟩
-  · simp only [h, ↓reduceIte, top_le_iff] at hm
-    refine ⟨ω, le_rfl, by simp [hm], by simp⟩
+  grind [minSmoothness_eq_infty, ENat.natCast_ne_coe_top]
 
 /-- If a function is `C^2` at a point, then its second derivative there is symmetric. Over a field
 different from `ℝ` or `ℂ`, we should require that the function is analytic. -/


### PR DESCRIPTION
---
<details>
<summary>Show trace profiling of <code>exist_minSmoothness_le_ne_infty</code>: 20 ms before, 308 ms after </summary>

### Trace profiling of `exist_minSmoothness_le_ne_infty` before PR 31992
```diff
diff --git a/Mathlib/Analysis/Calculus/FDeriv/Symmetric.lean b/Mathlib/Analysis/Calculus/FDeriv/Symmetric.lean
index 515e9d730b..709e336497 100644
--- a/Mathlib/Analysis/Calculus/FDeriv/Symmetric.lean
+++ b/Mathlib/Analysis/Calculus/FDeriv/Symmetric.lean
@@ -526,6 +526,7 @@ lemma minSmoothness_monotone : Monotone (minSmoothness 𝕜) := by
   simp only [minSmoothness]
   split_ifs with h <;> simp [h]
 
+set_option trace.profiler true in
 /-- If `minSmoothness 𝕜 m ≤ n` for some (finite) integer `m`, then one can
 find `n' ∈ [minSmoothness 𝕜 m, n]` which is not `∞`: over `ℝ` or `ℂ`, just take `m`, and otherwise
 just take `ω`. The interest of this technical lemma is that, if a function is `C^{n'}` at a point
```
```
ℹ [1982/1982] Built Mathlib.Analysis.Calculus.FDeriv.Symmetric (4.0s)
info: Mathlib/Analysis/Calculus/FDeriv/Symmetric.lean:530:0: [Elab.async] [0.020703] elaborating proof of exist_minSmoothness_le_ne_infty
  [Elab.definition.value] [0.020190] exist_minSmoothness_le_ne_infty
    [Elab.step] [0.019955] 
          simp only [minSmoothness] at hm ⊢
          split_ifs with h
          · simp only [h, ↓reduceIte] at hm
            exact ⟨m, le_rfl, hm, by simp⟩
          · simp only [h, ↓reduceIte, top_le_iff] at hm
            refine ⟨ω, le_rfl, by simp [hm], by simp⟩
      [Elab.step] [0.019949] 
            simp only [minSmoothness] at hm ⊢
            split_ifs with h
            · simp only [h, ↓reduceIte] at hm
              exact ⟨m, le_rfl, hm, by simp⟩
            · simp only [h, ↓reduceIte, top_le_iff] at hm
              refine ⟨ω, le_rfl, by simp [hm], by simp⟩
Build completed successfully (1982 jobs).
```

### Trace profiling of `exist_minSmoothness_le_ne_infty` after PR 31992
```diff
diff --git a/Mathlib/Analysis/Calculus/FDeriv/Symmetric.lean b/Mathlib/Analysis/Calculus/FDeriv/Symmetric.lean
index 515e9d730b..da537071eb 100644
--- a/Mathlib/Analysis/Calculus/FDeriv/Symmetric.lean
+++ b/Mathlib/Analysis/Calculus/FDeriv/Symmetric.lean
@@ -526,6 +526,7 @@ lemma minSmoothness_monotone : Monotone (minSmoothness 𝕜) := by
   simp only [minSmoothness]
   split_ifs with h <;> simp [h]
 
+set_option trace.profiler true in
 /-- If `minSmoothness 𝕜 m ≤ n` for some (finite) integer `m`, then one can
 find `n' ∈ [minSmoothness 𝕜 m, n]` which is not `∞`: over `ℝ` or `ℂ`, just take `m`, and otherwise
 just take `ω`. The interest of this technical lemma is that, if a function is `C^{n'}` at a point
@@ -533,12 +534,7 @@ for `n' ≠ ∞`, then it is `C^{n'}` on a neighborhood of the point (this prope
 in `C^∞` smoothness, see `ContDiffWithinAt.contDiffOn`). -/
 lemma exist_minSmoothness_le_ne_infty {n : WithTop ℕ∞} {m : ℕ} (hm : minSmoothness 𝕜 m ≤ n) :
     ∃ n', minSmoothness 𝕜 m ≤ n' ∧ n' ≤ n ∧ n' ≠ ∞ := by
-  simp only [minSmoothness] at hm ⊢
-  split_ifs with h
-  · simp only [h, ↓reduceIte] at hm
-    exact ⟨m, le_rfl, hm, by simp⟩
-  · simp only [h, ↓reduceIte, top_le_iff] at hm
-    refine ⟨ω, le_rfl, by simp [hm], by simp⟩
+  grind [minSmoothness_eq_infty, ENat.natCast_ne_coe_top]
 
 /-- If a function is `C^2` at a point, then its second derivative there is symmetric. Over a field
 different from `ℝ` or `ℂ`, we should require that the function is analytic. -/
```
```
ℹ [1982/1982] Built Mathlib.Analysis.Calculus.FDeriv.Symmetric (4.7s)
info: Mathlib/Analysis/Calculus/FDeriv/Symmetric.lean:530:0: [Elab.async] [0.307763] elaborating proof of exist_minSmoothness_le_ne_infty
  [Elab.definition.value] [0.307513] exist_minSmoothness_le_ne_infty
    [Elab.step] [0.307379] grind [minSmoothness_eq_infty, ENat.natCast_ne_coe_top]
      [Elab.step] [0.307374] grind [minSmoothness_eq_infty, ENat.natCast_ne_coe_top]
        [Elab.step] [0.307366] grind [minSmoothness_eq_infty, ENat.natCast_ne_coe_top]
          [Meta.synthInstance] [0.073225] ❌️ Lean.Grind.IsCharP (Lean.Grind.Ring.OfSemiring.Q (WithTop ℕ∞)) ?m.35
          [Meta.synthInstance] [0.012063] ❌️ Lean.Grind.NoNatZeroDivisors (Lean.Grind.Ring.OfSemiring.Q (WithTop ℕ∞))
          [Meta.synthInstance] [0.028596] ❌️ LE (Lean.Grind.IntModule.OfNatModule.Q (WithTop ℕ∞))
          [Meta.synthInstance] [0.026833] ❌️ LT (Lean.Grind.IntModule.OfNatModule.Q (WithTop ℕ∞))
          [Meta.synthInstance] [0.010461] ❌️ Lean.Grind.NoNatZeroDivisors
                (Lean.Grind.IntModule.OfNatModule.Q (WithTop ℕ∞))
          [Meta.synthInstance] [0.026174] ✅️ HSMul ℤ (Lean.Grind.IntModule.OfNatModule.Q (WithTop ℕ∞))
                (Lean.Grind.IntModule.OfNatModule.Q (WithTop ℕ∞))
          [Meta.synthInstance] [0.012764] ✅️ HSMul ℕ (Lean.Grind.IntModule.OfNatModule.Q (WithTop ℕ∞))
                (Lean.Grind.IntModule.OfNatModule.Q (WithTop ℕ∞))
          [Meta.synthInstance] [0.019082] ❌️ Lean.Grind.OrderedAdd (WithTop ℕ∞)
Build completed successfully (1982 jobs).
```
</details>

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

When merging, all the commits will be squashed into a single commit
listing all co-authors.

Co-authors in the squash commit are gathered from two sources:

First, all authors of commits to this PR branch are included. Thus,
one way to add co-authors is to include at least one commit authored by
each co-author among the commits in the pull request. If necessary, you
may create empty commits to indicate co-authorship, using commands like so:

git commit --author="Author Name <author@email.com>" --allow-empty -m "add Author Name as coauthor"

Second, co-authors can also be listed in lines at the very bottom of
the commit message (that is, directly before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines
at the bottom of the commit message (before the `---`, and also before
any "Co-authored-by" lines) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
