### PR TITLE
[Merged by Bors] - chore(LinearAlgebra/CliffordAlgebra): golf `ofQuaternion_comp_toQuaternion` using `ext; simp`

### DIFF
--- a/Mathlib/LinearAlgebra/CliffordAlgebra/Equivs.lean
+++ b/Mathlib/LinearAlgebra/CliffordAlgebra/Equivs.lean
@@ -296,14 +296,7 @@ theorem ofQuaternion_mk (a₁ a₂ a₃ a₄ : R) :
 @[simp]
 theorem ofQuaternion_comp_toQuaternion :
     ofQuaternion.comp toQuaternion = AlgHom.id R (CliffordAlgebra (Q c₁ c₂)) := by
-  ext : 1
-  dsimp -- before we end up with two goals and have to do this twice
-  ext
-  all_goals
-    dsimp
-    rw [toQuaternion_ι]
-    dsimp
-    simp only [zero_smul, one_smul, zero_add, add_zero, RingHom.map_zero]
+  ext : 2 <;> (ext; simp)
 
 @[simp]
 theorem ofQuaternion_toQuaternion (c : CliffordAlgebra (Q c₁ c₂)) :


### PR DESCRIPTION
---
<details>
<summary>Show trace profiling of <code>ofQuaternion_comp_toQuaternion</code>: 153 ms before, 153 ms after  🎉</summary>

### Trace profiling of `ofQuaternion_comp_toQuaternion` before PR 31993
```diff
diff --git a/Mathlib/LinearAlgebra/CliffordAlgebra/Equivs.lean b/Mathlib/LinearAlgebra/CliffordAlgebra/Equivs.lean
index 9a1a319416..ea80ca5c6f 100644
--- a/Mathlib/LinearAlgebra/CliffordAlgebra/Equivs.lean
+++ b/Mathlib/LinearAlgebra/CliffordAlgebra/Equivs.lean
@@ -293,6 +293,7 @@ theorem ofQuaternion_mk (a₁ a₂ a₃ a₄ : R) :
         a₄ • (ι (Q c₁ c₂) (1, 0) * ι (Q c₁ c₂) (0, 1)) :=
   rfl
 
+set_option trace.profiler true in
 @[simp]
 theorem ofQuaternion_comp_toQuaternion :
     ofQuaternion.comp toQuaternion = AlgHom.id R (CliffordAlgebra (Q c₁ c₂)) := by
```
```
ℹ [1736/1736] Built Mathlib.LinearAlgebra.CliffordAlgebra.Equivs (3.5s)
info: Mathlib/LinearAlgebra/CliffordAlgebra/Equivs.lean:297:0: [Elab.command] [0.029845] @[simp]
    theorem ofQuaternion_comp_toQuaternion : ofQuaternion.comp toQuaternion = AlgHom.id R (CliffordAlgebra (Q c₁ c₂)) :=
      by
      ext : 1
      dsimp -- before we end up with two goals and have to do this twice
        
      ext
      all_goals
        dsimp
        rw [toQuaternion_ι]
        dsimp
        simp only [zero_smul, one_smul, zero_add, add_zero, RingHom.map_zero]
  [Elab.definition.header] [0.029109] CliffordAlgebraQuaternion.ofQuaternion_comp_toQuaternion
    [Elab.step] [0.029092] expected type: Prop, term
        ofQuaternion.comp toQuaternion = AlgHom.id R (CliffordAlgebra (Q c₁ c₂))
      [Elab.step] [0.029086] expected type: Prop, term
          binrel% Eq✝ (ofQuaternion.comp toQuaternion) (AlgHom.id R (CliffordAlgebra (Q c₁ c₂)))
        [Elab.step] [0.010952] expected type: <not-available>, term
            ofQuaternion.comp toQuaternion
        [Elab.step] [0.014835] expected type: <not-available>, term
            AlgHom.id R (CliffordAlgebra (Q c₁ c₂))
info: Mathlib/LinearAlgebra/CliffordAlgebra/Equivs.lean:297:0: [Elab.async] [0.154779] elaborating proof of CliffordAlgebraQuaternion.ofQuaternion_comp_toQuaternion
  [Elab.definition.value] [0.153476] CliffordAlgebraQuaternion.ofQuaternion_comp_toQuaternion
    [Elab.step] [0.152971] 
          ext : 1
          dsimp -- before we end up with two goals and have to do this twice
            
          ext
          all_goals
            dsimp
            rw [toQuaternion_ι]
            dsimp
            simp only [zero_smul, one_smul, zero_add, add_zero, RingHom.map_zero]
      [Elab.step] [0.152965] 
            ext : 1
            dsimp -- before we end up with two goals and have to do this twice
              
            ext
            all_goals
              dsimp
              rw [toQuaternion_ι]
              dsimp
              simp only [zero_smul, one_smul, zero_add, add_zero, RingHom.map_zero]
        [Elab.step] [0.011320] ext : 1
        [Elab.step] [0.015193] ext
        [Elab.step] [0.123052] all_goals
              dsimp
              rw [toQuaternion_ι]
              dsimp
              simp only [zero_smul, one_smul, zero_add, add_zero, RingHom.map_zero]
          [Elab.step] [0.061960] 
                dsimp
                rw [toQuaternion_ι]
                dsimp
                simp only [zero_smul, one_smul, zero_add, add_zero, RingHom.map_zero]
            [Elab.step] [0.061957] 
                  dsimp
                  rw [toQuaternion_ι]
                  dsimp
                  simp only [zero_smul, one_smul, zero_add, add_zero, RingHom.map_zero]
              [Elab.step] [0.042311] simp only [zero_smul, one_smul, zero_add, add_zero, RingHom.map_zero]
                [Meta.isDefEq] [0.013665] ✅️ 1 • ?b =?= 1 • (ι (Q c₁ c₂)) (1, 0)
                  [Meta.isDefEq] [0.012446] ✅️ instHSMul =?= instHSMul
                    [Meta.isDefEq.delta] [0.012435] ✅️ instHSMul =?= instHSMul
                      [Meta.synthInstance] [0.012364] ✅️ MulAction R (CliffordAlgebra (Q c₁ c₂))
                [Meta.isDefEq] [0.012088] ✅️ 0 • ?m =?= 0 • (ι (Q c₁ c₂)) (0, 1)
                  [Meta.isDefEq] [0.011983] ✅️ instHSMul =?= instHSMul
                    [Meta.isDefEq.delta] [0.011972] ✅️ instHSMul =?= instHSMul
                      [Meta.synthInstance] [0.011892] ✅️ SMulWithZero R (CliffordAlgebra (Q c₁ c₂))
          [Elab.step] [0.060670] 
                dsimp
                rw [toQuaternion_ι]
                dsimp
                simp only [zero_smul, one_smul, zero_add, add_zero, RingHom.map_zero]
            [Elab.step] [0.060663] 
                  dsimp
                  rw [toQuaternion_ι]
                  dsimp
                  simp only [zero_smul, one_smul, zero_add, add_zero, RingHom.map_zero]
              [Elab.step] [0.040842] simp only [zero_smul, one_smul, zero_add, add_zero, RingHom.map_zero]
                [Meta.isDefEq] [0.019854] ✅️ 0 • ?m =?= 0 • (ι (Q c₁ c₂)) (1, 0)
                  [Meta.isDefEq] [0.019745] ✅️ instHSMul =?= instHSMul
                    [Meta.isDefEq.delta] [0.019734] ✅️ instHSMul =?= instHSMul
                      [Meta.synthInstance] [0.019631] ✅️ SMulWithZero R (CliffordAlgebra (Q c₁ c₂))
info: Mathlib/LinearAlgebra/CliffordAlgebra/Equivs.lean:298:8: [Elab.async] [0.011592] Lean.addDecl
  [Kernel] [0.011547] ✅️ typechecking declarations [CliffordAlgebraQuaternion.ofQuaternion_comp_toQuaternion]
Build completed successfully (1736 jobs).
```

### Trace profiling of `ofQuaternion_comp_toQuaternion` after PR 31993
```diff
diff --git a/Mathlib/LinearAlgebra/CliffordAlgebra/Equivs.lean b/Mathlib/LinearAlgebra/CliffordAlgebra/Equivs.lean
index 9a1a319416..d325802b57 100644
--- a/Mathlib/LinearAlgebra/CliffordAlgebra/Equivs.lean
+++ b/Mathlib/LinearAlgebra/CliffordAlgebra/Equivs.lean
@@ -293,17 +293,11 @@ theorem ofQuaternion_mk (a₁ a₂ a₃ a₄ : R) :
         a₄ • (ι (Q c₁ c₂) (1, 0) * ι (Q c₁ c₂) (0, 1)) :=
   rfl
 
+set_option trace.profiler true in
 @[simp]
 theorem ofQuaternion_comp_toQuaternion :
     ofQuaternion.comp toQuaternion = AlgHom.id R (CliffordAlgebra (Q c₁ c₂)) := by
-  ext : 1
-  dsimp -- before we end up with two goals and have to do this twice
-  ext
-  all_goals
-    dsimp
-    rw [toQuaternion_ι]
-    dsimp
-    simp only [zero_smul, one_smul, zero_add, add_zero, RingHom.map_zero]
+  ext : 2 <;> (ext; simp)
 
 @[simp]
 theorem ofQuaternion_toQuaternion (c : CliffordAlgebra (Q c₁ c₂)) :
```
```
ℹ [1736/1736] Built Mathlib.LinearAlgebra.CliffordAlgebra.Equivs (3.1s)
info: Mathlib/LinearAlgebra/CliffordAlgebra/Equivs.lean:297:0: [Elab.command] [0.029855] @[simp]
    theorem ofQuaternion_comp_toQuaternion : ofQuaternion.comp toQuaternion = AlgHom.id R (CliffordAlgebra (Q c₁ c₂)) :=
      by ext : 2 <;> (ext; simp)
  [Elab.definition.header] [0.029108] CliffordAlgebraQuaternion.ofQuaternion_comp_toQuaternion
    [Elab.step] [0.029090] expected type: Prop, term
        ofQuaternion.comp toQuaternion = AlgHom.id R (CliffordAlgebra (Q c₁ c₂))
      [Elab.step] [0.029085] expected type: Prop, term
          binrel% Eq✝ (ofQuaternion.comp toQuaternion) (AlgHom.id R (CliffordAlgebra (Q c₁ c₂)))
        [Elab.step] [0.010786] expected type: <not-available>, term
            ofQuaternion.comp toQuaternion
        [Elab.step] [0.014917] expected type: <not-available>, term
            AlgHom.id R (CliffordAlgebra (Q c₁ c₂))
info: Mathlib/LinearAlgebra/CliffordAlgebra/Equivs.lean:297:0: [Elab.async] [0.153988] elaborating proof of CliffordAlgebraQuaternion.ofQuaternion_comp_toQuaternion
  [Elab.definition.value] [0.152960] CliffordAlgebraQuaternion.ofQuaternion_comp_toQuaternion
    [Elab.step] [0.152150] ext : 2 <;> (ext; simp)
      [Elab.step] [0.152144] ext : 2 <;> (ext; simp)
        [Elab.step] [0.152139] ext : 2 <;> (ext; simp)
          [Elab.step] [0.152130] focus
                ext : 2
                with_annotate_state"<;>" skip
                all_goals (ext; simp)
            [Elab.step] [0.152123] 
                  ext : 2
                  with_annotate_state"<;>" skip
                  all_goals (ext; simp)
              [Elab.step] [0.152120] 
                    ext : 2
                    with_annotate_state"<;>" skip
                    all_goals (ext; simp)
                [Elab.step] [0.023247] ext : 2
                [Elab.step] [0.128851] all_goals (ext; simp)
                  [Elab.step] [0.080450] (ext; simp)
                    [Elab.step] [0.080447] (ext; simp)
                      [Elab.step] [0.080443] (ext; simp)
                        [Elab.step] [0.080439] ext; simp
                          [Elab.step] [0.080436] ext; simp
                            [Elab.step] [0.078900] simp
                              [Meta.isDefEq] [0.012947] ✅️ 1 • ?b =?= 1 • (ι (Q c₁ c₂)) (1, 0)
                                [Meta.isDefEq] [0.011813] ✅️ instHSMul =?= instHSMul
                                  [Meta.isDefEq.delta] [0.011803] ✅️ instHSMul =?= instHSMul
                                    [Meta.synthInstance] [0.011732] ✅️ MulAction R (CliffordAlgebra (Q c₁ c₂))
                              [Meta.isDefEq] [0.012142] ✅️ 0 • ?m =?= 0 • (ι (Q c₁ c₂)) (0, 1)
                                [Meta.isDefEq] [0.012042] ✅️ instHSMul =?= instHSMul
                                  [Meta.isDefEq.delta] [0.012032] ✅️ instHSMul =?= instHSMul
                                    [Meta.synthInstance] [0.011949] ✅️ SMulWithZero R (CliffordAlgebra (Q c₁ c₂))
                  [Elab.step] [0.048248] (ext; simp)
                    [Elab.step] [0.048243] (ext; simp)
                      [Elab.step] [0.048240] (ext; simp)
                        [Elab.step] [0.048236] ext; simp
                          [Elab.step] [0.048233] ext; simp
                            [Elab.step] [0.046557] simp
Build completed successfully (1736 jobs).
```
</details>

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

When merging, all the commits will be squashed into a single commit
listing all co-authors.

Co-authors in the squash commit are gathered from two sources:

First, all authors of commits to this PR branch are included. Thus,
one way to add co-authors is to include at least one commit authored by
each co-author among the commits in the pull request. If necessary, you
may create empty commits to indicate co-authorship, using commands like so:

git commit --author="Author Name <author@email.com>" --allow-empty -m "add Author Name as coauthor"

Second, co-authors can also be listed in lines at the very bottom of
the commit message (that is, directly before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines
at the bottom of the commit message (before the `---`, and also before
any "Co-authored-by" lines) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
