### PR TITLE
[Merged by Bors] - chore(Data/DFinsupp): golf `mapRange.addMonoidHom_comp` using `ext; simp`

### DIFF
--- a/Mathlib/Data/DFinsupp/Defs.lean
+++ b/Mathlib/Data/DFinsupp/Defs.lean
@@ -1257,10 +1257,8 @@ theorem mapRange.addMonoidHom_id :
 theorem mapRange.addMonoidHom_comp (f : ∀ i, β₁ i →+ β₂ i) (f₂ : ∀ i, β i →+ β₁ i) :
     (mapRange.addMonoidHom fun i => (f i).comp (f₂ i)) =
       (mapRange.addMonoidHom f).comp (mapRange.addMonoidHom f₂) := by
-  refine AddMonoidHom.ext <| mapRange_comp (fun i x => f i x) (fun i x => f₂ i x) ?_ ?_ ?_
-  · intros; apply map_zero
-  · intros; apply map_zero
-  · intros; dsimp; simp only [map_zero]
+  ext
+  simp
 
 /-- `DFinsupp.mapRange.addMonoidHom` as an `AddEquiv`. -/
 @[simps apply]


### PR DESCRIPTION
---
<details>
<summary>Show trace profiling of <code>mapRange.addMonoidHom_comp</code>: 18 ms before, 11 ms after  🎉</summary>

### Trace profiling of `mapRange.addMonoidHom_comp` before PR 31994
```diff
diff --git a/Mathlib/Data/DFinsupp/Defs.lean b/Mathlib/Data/DFinsupp/Defs.lean
index 6079ac9723..df8e812a8a 100644
--- a/Mathlib/Data/DFinsupp/Defs.lean
+++ b/Mathlib/Data/DFinsupp/Defs.lean
@@ -1254,6 +1254,7 @@ theorem mapRange.addMonoidHom_id :
     (mapRange.addMonoidHom fun i => AddMonoidHom.id (β₂ i)) = AddMonoidHom.id _ :=
   AddMonoidHom.ext mapRange_id
 
+set_option trace.profiler true in
 theorem mapRange.addMonoidHom_comp (f : ∀ i, β₁ i →+ β₂ i) (f₂ : ∀ i, β i →+ β₁ i) :
     (mapRange.addMonoidHom fun i => (f i).comp (f₂ i)) =
       (mapRange.addMonoidHom f).comp (mapRange.addMonoidHom f₂) := by
```
```
ℹ [624/624] Built Mathlib.Data.DFinsupp.Defs (2.1s)
info: Mathlib/Data/DFinsupp/Defs.lean:1258:0: [Elab.async] [0.018913] elaborating proof of DFinsupp.mapRange.addMonoidHom_comp
  [Elab.definition.value] [0.018416] DFinsupp.mapRange.addMonoidHom_comp
    [Elab.step] [0.018174] 
          refine AddMonoidHom.ext <| mapRange_comp (fun i x => f i x) (fun i x => f₂ i x) ?_ ?_ ?_
          · intros; apply map_zero
          · intros; apply map_zero
          · intros; dsimp; simp only [map_zero]
      [Elab.step] [0.018168] 
            refine AddMonoidHom.ext <| mapRange_comp (fun i x => f i x) (fun i x => f₂ i x) ?_ ?_ ?_
            · intros; apply map_zero
            · intros; apply map_zero
            · intros; dsimp; simp only [map_zero]
Build completed successfully (624 jobs).
```

### Trace profiling of `mapRange.addMonoidHom_comp` after PR 31994
```diff
diff --git a/Mathlib/Data/DFinsupp/Defs.lean b/Mathlib/Data/DFinsupp/Defs.lean
index 6079ac9723..5c6913a5cc 100644
--- a/Mathlib/Data/DFinsupp/Defs.lean
+++ b/Mathlib/Data/DFinsupp/Defs.lean
@@ -1254,13 +1254,12 @@ theorem mapRange.addMonoidHom_id :
     (mapRange.addMonoidHom fun i => AddMonoidHom.id (β₂ i)) = AddMonoidHom.id _ :=
   AddMonoidHom.ext mapRange_id
 
+set_option trace.profiler true in
 theorem mapRange.addMonoidHom_comp (f : ∀ i, β₁ i →+ β₂ i) (f₂ : ∀ i, β i →+ β₁ i) :
     (mapRange.addMonoidHom fun i => (f i).comp (f₂ i)) =
       (mapRange.addMonoidHom f).comp (mapRange.addMonoidHom f₂) := by
-  refine AddMonoidHom.ext <| mapRange_comp (fun i x => f i x) (fun i x => f₂ i x) ?_ ?_ ?_
-  · intros; apply map_zero
-  · intros; apply map_zero
-  · intros; dsimp; simp only [map_zero]
+  ext
+  simp
 
 /-- `DFinsupp.mapRange.addMonoidHom` as an `AddEquiv`. -/
 @[simps apply]
```
```
ℹ [624/624] Built Mathlib.Data.DFinsupp.Defs (2.1s)
info: Mathlib/Data/DFinsupp/Defs.lean:1258:0: [Elab.async] [0.011843] elaborating proof of DFinsupp.mapRange.addMonoidHom_comp
  [Elab.definition.value] [0.011477] DFinsupp.mapRange.addMonoidHom_comp
    [Elab.step] [0.011156] 
          ext
          simp
      [Elab.step] [0.011149] 
            ext
            simp
Build completed successfully (624 jobs).
```
</details>

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

When merging, all the commits will be squashed into a single commit
listing all co-authors.

Co-authors in the squash commit are gathered from two sources:

First, all authors of commits to this PR branch are included. Thus,
one way to add co-authors is to include at least one commit authored by
each co-author among the commits in the pull request. If necessary, you
may create empty commits to indicate co-authorship, using commands like so:

git commit --author="Author Name <author@email.com>" --allow-empty -m "add Author Name as coauthor"

Second, co-authors can also be listed in lines at the very bottom of
the commit message (that is, directly before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines
at the bottom of the commit message (before the `---`, and also before
any "Co-authored-by" lines) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
