### PR TITLE
[Merged by Bors] - feat(Data/Nat/Log): add 2 lemmas

### DIFF
--- a/Mathlib/Data/Nat/Log.lean
+++ b/Mathlib/Data/Nat/Log.lean
@@ -258,6 +258,19 @@ lemma log2_eq_log_two {n : ℕ} : Nat.log2 n = Nat.log 2 n := by
   intro m
   rw [Nat.le_log2 hn, Nat.le_log_iff_pow_le Nat.one_lt_two hn]
 
+@[simp]
+lemma log_pow_left (b k n : ℕ) : log (b ^ k) n = log b n / k := by
+  rcases eq_or_ne n 0 with rfl | hn
+  · simp
+  · rcases k.eq_zero_or_pos with rfl | hk
+    · simp
+    · rcases Nat.lt_or_ge 1 b with hb | hb
+      · refine eq_of_forall_le_iff fun c ↦ ?_
+        rw [le_log_iff_pow_le (Nat.one_lt_pow (Nat.ne_of_gt hk) hb) hn, Nat.le_div_iff_mul_le hk,
+          le_log_iff_pow_le hb hn, Nat.pow_mul']
+      · rw [log_of_left_le_one hb, Nat.zero_div, log_of_left_le_one]
+        rwa [Nat.pow_le_one_iff (Nat.ne_of_gt hk)]
+
 /-! ### Ceil logarithm -/
 
 
@@ -392,6 +405,22 @@ theorem clog_eq_clog_succ_iff {b n : ℕ} (hb : 1 < b) :
   rw [ne_eq, ← clog_lt_clog_succ_iff hb, not_lt]
   simp only [le_antisymm_iff, and_iff_right_iff_imp]
   exact fun _ ↦ clog_monotone b (le_add_right n 1)
+
+/-- This lemma says that `⌈log (b ^ k) n⌉ = ⌈(⌈log b n⌉ / k)⌉, using operations on natural numbers
+to express this equality.
+
+Since Lean has no dedicated function for the ceiling division,
+we use `(a + (b - 1)) / b` for `⌈a / b⌉`. -/
+theorem clog_pow_left (b k n : ℕ) : clog (b ^ k) n = (clog b n + (k - 1)) / k := by
+  rcases k.eq_zero_or_pos with rfl | hk
+  · simp
+  · rcases Nat.lt_or_ge 1 b with hb | hb
+    · refine eq_of_forall_lt_iff fun c ↦ ?_
+      rw [lt_clog_iff_pow_lt (Nat.one_lt_pow (Nat.ne_of_gt hk) hb), Nat.lt_div_iff_mul_lt hk,
+        Nat.add_sub_cancel, lt_clog_iff_pow_lt hb, Nat.pow_mul']
+    · suffices (k - 1) / k = 0 by grind [clog_of_left_le_one, Nat.pow_le_one_iff]
+      apply Nat.div_eq_of_lt
+      grind
 
 /-! ### Computating the logarithm efficiently -/
 section computation


### PR DESCRIPTION
---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

When merging, all the commits will be squashed into a single commit
listing all co-authors.

Co-authors in the squash commit are gathered from two sources:

First, all authors of commits to this PR branch are included. Thus,
one way to add co-authors is to include at least one commit authored by
each co-author among the commits in the pull request. If necessary, you
may create empty commits to indicate co-authorship, using commands like so:

git commit --author="Author Name <author@email.com>" --allow-empty -m "add Author Name as coauthor"

Second, co-authors can also be listed in lines at the very bottom of
the commit message (that is, directly before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines
at the bottom of the commit message (before the `---`, and also before
any "Co-authored-by" lines) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
