### PR TITLE
[Merged by Bors] - chore(Analysis/Polynomial): golf `logMahlerMeasure_X_sub_C` using `simp`

### DIFF
--- a/Mathlib/Analysis/Polynomial/MahlerMeasure.lean
+++ b/Mathlib/Analysis/Polynomial/MahlerMeasure.lean
@@ -154,41 +154,7 @@ open MeromorphicOn Metric in
 /-- The logarithmic Mahler measure of `X - C z` is the `log⁺` of the absolute value of `z`. -/
 @[simp]
 theorem logMahlerMeasure_X_sub_C (z : ℂ) : (X - C z).logMahlerMeasure = log⁺ ‖z‖ := by
-  rcases eq_or_ne z 0 with rfl | hz₀
-  · simp
-  have hmeroOnB : MeromorphicOn (· - z) (closedBall 0 |1|) := id.sub <| const z
-  simp_rw [logMahlerMeasure_def, eval_sub, eval_X, eval_C]
-  rw [circleAverage_log_norm one_ne_zero hmeroOnB, abs_one,
-  -- get rid of the `meromorphicTrailingCoeffAt`
-    AnalyticAt.meromorphicTrailingCoeffAt_of_ne_zero (by fun_prop) (by simp [hz₀]),
-    ← finsum_mem_support]
-  set B := closedBall (0 : ℂ) 1
-  -- separate cases depending on whether z is in the open `ball 0 1` or not
-  by_cases hzBall : z ∈ ball 0 1
-  · have hzdiv1 := divisor_sub_const_self (show z ∈ B by grind [ball_subset_closedBall])
-    suffices (fun u ↦ -(divisor (· - z) B u * log ‖u‖)).support = {z} by
-      simp [this, hzdiv1, posLog_def]
-      grind [mem_ball_zero_iff, log_nonpos, norm_nonneg]
-    rw [Function.support_eq_iff]
-    constructor
-    · simp_rw [Set.mem_singleton_iff]
-      intro _ rfl
-      rw [hzdiv1]
-      grind [log_eq_zero, norm_eq_zero, mem_ball_zero_iff, norm_nonneg]
-    · intro _ hu
-      rw [Set.mem_singleton_iff] at hu
-      simp [divisor_sub_const_of_ne hu]
-  · have h1lez : 1 ≤ ‖z‖ := by grind [mem_ball_zero_iff]
-    suffices (fun u ↦ -(divisor (· - z) B u * log ‖u‖)).support = ∅ by
-      simp [this, posLog_eq_log_max_one <| norm_nonneg z, h1lez]
-    rw [Function.support_eq_empty_iff]
-    ext x
-    rcases eq_or_ne x z with rfl | hx
-    · by_cases hB : x ∈ B
-      · rw [Pi.zero_apply]
-        grind [log_eq_zero, mem_closedBall_zero_iff]
-      · simpa using .inl <| Function.locallyFinsuppWithin.apply_eq_zero_of_notMem _ hB
-    simpa using .inl <| divisor_sub_const_of_ne hx
+  simp [logMahlerMeasure_def]
 
 @[simp]
 theorem logMahlerMeasure_X_add_C (z : ℂ) : (X + C z).logMahlerMeasure = log⁺ ‖z‖ := by


### PR DESCRIPTION
---
<details>
<summary>Show trace profiling of <code>logMahlerMeasure_X_sub_C</code>: 765 ms before, 36 ms after  🎉</summary>

### Trace profiling of `logMahlerMeasure_X_sub_C` before PR 32014
```diff
diff --git a/Mathlib/Analysis/Polynomial/MahlerMeasure.lean b/Mathlib/Analysis/Polynomial/MahlerMeasure.lean
index 1ec3859381..3b753541f5 100644
--- a/Mathlib/Analysis/Polynomial/MahlerMeasure.lean
+++ b/Mathlib/Analysis/Polynomial/MahlerMeasure.lean
@@ -150,6 +150,7 @@ theorem logMahlerMeasure_C_mul {a : ℂ} (ha : a ≠ 0) {p : ℂ[X]} (hp : p ≠
     (C a * p).logMahlerMeasure = log ‖a‖ + p.logMahlerMeasure := by
   rw [logMahlerMeasure_mul_eq_add_logMahlerMeasure (by simp [ha, hp]), logMahlerMeasure_const]
 
+set_option trace.profiler true in
 open MeromorphicOn Metric in
 /-- The logarithmic Mahler measure of `X - C z` is the `log⁺` of the absolute value of `z`. -/
 @[simp]
```
```
ℹ [2781/2781] Built Mathlib.Analysis.Polynomial.MahlerMeasure (3.3s)
info: Mathlib/Analysis/Polynomial/MahlerMeasure.lean:154:0: [Elab.command] [0.010111] open MeromorphicOn Metric in
    /-- The logarithmic Mahler measure of `X - C z` is the `log⁺` of the absolute value of `z`. -/
    @[simp]
    theorem logMahlerMeasure_X_sub_C (z : ℂ) : (X - C z).logMahlerMeasure = log⁺ ‖z‖ :=
      by
      rcases eq_or_ne z 0 with rfl | hz₀
      · simp
      have hmeroOnB : MeromorphicOn (· - z) (closedBall 0 |1|) := id.sub <| const z
      simp_rw [logMahlerMeasure_def, eval_sub, eval_X, eval_C]
      rw [circleAverage_log_norm one_ne_zero hmeroOnB, abs_one,
        -- get rid of the `meromorphicTrailingCoeffAt`
        AnalyticAt.meromorphicTrailingCoeffAt_of_ne_zero (by fun_prop) (by simp [hz₀]), ← finsum_mem_support]
      set B :=
        closedBall (0 : ℂ)
          1
            -- separate cases depending on whether z is in the open `ball 0 1` or not
            
      by_cases hzBall : z ∈ ball 0 1
      · have hzdiv1 := divisor_sub_const_self (show z ∈ B by grind [ball_subset_closedBall])
        suffices (fun u ↦ -(divisor (· - z) B u * log ‖u‖)).support = { z }
          by
          simp [this, hzdiv1, posLog_def]
          grind [mem_ball_zero_iff, log_nonpos, norm_nonneg]
        rw [Function.support_eq_iff]
        constructor
        · simp_rw [Set.mem_singleton_iff]
          intro _ rfl
          rw [hzdiv1]
          grind [log_eq_zero, norm_eq_zero, mem_ball_zero_iff, norm_nonneg]
        · intro _ hu
          rw [Set.mem_singleton_iff] at hu
          simp [divisor_sub_const_of_ne hu]
      · have h1lez : 1 ≤ ‖z‖ := by grind [mem_ball_zero_iff]
        suffices (fun u ↦ -(divisor (· - z) B u * log ‖u‖)).support = ∅ by
          simp [this, posLog_eq_log_max_one <| norm_nonneg z, h1lez]
        rw [Function.support_eq_empty_iff]
        ext x
        rcases eq_or_ne x z with rfl | hx
        · by_cases hB : x ∈ B
          · rw [Pi.zero_apply]
            grind [log_eq_zero, mem_closedBall_zero_iff]
          · simpa using .inl <| Function.locallyFinsuppWithin.apply_eq_zero_of_notMem _ hB
        simpa using .inl <| divisor_sub_const_of_ne hx
info: Mathlib/Analysis/Polynomial/MahlerMeasure.lean:155:0: [Elab.async] [0.767313] elaborating proof of Polynomial.logMahlerMeasure_X_sub_C
  [Elab.definition.value] [0.765196] Polynomial.logMahlerMeasure_X_sub_C
    [Elab.step] [0.763629] 
          rcases eq_or_ne z 0 with rfl | hz₀
          · simp
          have hmeroOnB : MeromorphicOn (· - z) (closedBall 0 |1|) := id.sub <| const z
          simp_rw [logMahlerMeasure_def, eval_sub, eval_X, eval_C]
          rw [circleAverage_log_norm one_ne_zero hmeroOnB, abs_one,
            -- get rid of the `meromorphicTrailingCoeffAt`
            AnalyticAt.meromorphicTrailingCoeffAt_of_ne_zero (by fun_prop) (by simp [hz₀]), ← finsum_mem_support]
          set B :=
            closedBall (0 : ℂ)
              1
                -- separate cases depending on whether z is in the open `ball 0 1` or not
                
          by_cases hzBall : z ∈ ball 0 1
          · have hzdiv1 := divisor_sub_const_self (show z ∈ B by grind [ball_subset_closedBall])
            suffices (fun u ↦ -(divisor (· - z) B u * log ‖u‖)).support = { z }
              by
              simp [this, hzdiv1, posLog_def]
              grind [mem_ball_zero_iff, log_nonpos, norm_nonneg]
            rw [Function.support_eq_iff]
            constructor
            · simp_rw [Set.mem_singleton_iff]
              intro _ rfl
              rw [hzdiv1]
              grind [log_eq_zero, norm_eq_zero, mem_ball_zero_iff, norm_nonneg]
            · intro _ hu
              rw [Set.mem_singleton_iff] at hu
              simp [divisor_sub_const_of_ne hu]
          · have h1lez : 1 ≤ ‖z‖ := by grind [mem_ball_zero_iff]
            suffices (fun u ↦ -(divisor (· - z) B u * log ‖u‖)).support = ∅ by
              simp [this, posLog_eq_log_max_one <| norm_nonneg z, h1lez]
            rw [Function.support_eq_empty_iff]
            ext x
            rcases eq_or_ne x z with rfl | hx
            · by_cases hB : x ∈ B
              · rw [Pi.zero_apply]
                grind [log_eq_zero, mem_closedBall_zero_iff]
              · simpa using .inl <| Function.locallyFinsuppWithin.apply_eq_zero_of_notMem _ hB
            simpa using .inl <| divisor_sub_const_of_ne hx
      [Elab.step] [0.763624] 
            rcases eq_or_ne z 0 with rfl | hz₀
            · simp
            have hmeroOnB : MeromorphicOn (· - z) (closedBall 0 |1|) := id.sub <| const z
            simp_rw [logMahlerMeasure_def, eval_sub, eval_X, eval_C]
            rw [circleAverage_log_norm one_ne_zero hmeroOnB, abs_one,
              -- get rid of the `meromorphicTrailingCoeffAt`
              AnalyticAt.meromorphicTrailingCoeffAt_of_ne_zero (by fun_prop) (by simp [hz₀]), ← finsum_mem_support]
            set B :=
              closedBall (0 : ℂ)
                1
                  -- separate cases depending on whether z is in the open `ball 0 1` or not
                  
            by_cases hzBall : z ∈ ball 0 1
            · have hzdiv1 := divisor_sub_const_self (show z ∈ B by grind [ball_subset_closedBall])
[… 438 lines omitted …]
                            [Elab.step] [0.092131] refine
                                    no_implicit_lambda%
                                      (suffices (fun u ↦ -(divisor (· - z) B u * log ‖u‖)).support = ∅ by
                                        simp [this, posLog_eq_log_max_one <| norm_nonneg z, h1lez];
                                      ?_);
                                  rotate_right
                              [Elab.step] [0.092120] refine
                                    no_implicit_lambda%
                                      (suffices (fun u ↦ -(divisor (· - z) B u * log ‖u‖)).support = ∅ by
                                        simp [this, posLog_eq_log_max_one <| norm_nonneg z, h1lez];
                                      ?_)
                                [Elab.step] [0.011108] expected type: ∑ᶠ (a : ℂ) (_ :
                                            a ∈
                                              Function.support fun u ↦
                                                ↑((divisor (fun x ↦ x - z) B) u) * log (1 * ‖0 - u‖⁻¹)),
                                            ↑((divisor (fun x ↦ x - z) B) a) * log (1 * ‖0 - a‖⁻¹) +
                                          ↑((divisor (fun x ↦ x - z) B) 0) * log 1 +
                                        log ‖0 - z‖ =
                                      log⁺ ‖z‖, term
                                    no_implicit_lambda%
                                      (suffices (fun u ↦ -(divisor (· - z) B u * log ‖u‖)).support = ∅ by
                                        simp [this, posLog_eq_log_max_one <| norm_nonneg z, h1lez];
                                      ?_)
                                  [Elab.step] [0.011103] expected type: ∑ᶠ (a : ℂ) (_ :
                                              a ∈
                                                Function.support fun u ↦
                                                  ↑((divisor (fun x ↦ x - z) B) u) * log (1 * ‖0 - u‖⁻¹)),
                                              ↑((divisor (fun x ↦ x - z) B) a) * log (1 * ‖0 - a‖⁻¹) +
                                            ↑((divisor (fun x ↦ x - z) B) 0) * log 1 +
                                          log ‖0 - z‖ =
                                        log⁺ ‖z‖, term
                                      suffices (fun u ↦ -(divisor (· - z) B u * log ‖u‖)).support = ∅ by
                                        simp [this, posLog_eq_log_max_one <| norm_nonneg z, h1lez];
                                      ?_
                                    [Elab.step] [0.011097] expected type: ∑ᶠ (a : ℂ) (_ :
                                                a ∈
                                                  Function.support fun u ↦
                                                    ↑((divisor (fun x ↦ x - z) B) u) * log (1 * ‖0 - u‖⁻¹)),
                                                ↑((divisor (fun x ↦ x - z) B) a) * log (1 * ‖0 - a‖⁻¹) +
                                              ↑((divisor (fun x ↦ x - z) B) 0) * log 1 +
                                            log ‖0 - z‖ =
                                          log⁺ ‖z‖, term
                                        have : (fun u ↦ -(divisor (· - z) B u * log ‖u‖)).support = ∅ := ?_;
                                        by simp [this, posLog_eq_log_max_one <| norm_nonneg z, h1lez]
                                      [Elab.step] [0.011054] expected type: Sort ?u.39220, term
                                          (fun u ↦ -(divisor (· - z) B u * log ‖u‖)).support = ∅
                                        [Elab.step] [0.011048] expected type: Sort ?u.39220, term
                                            binrel% Eq✝ (fun u ↦ -(divisor (· - z) B u * log ‖u‖)).support ∅
                                          [Elab.step] [0.010748] expected type: <not-available>, term
                                              (fun u ↦ -(divisor (· - z) B u * log ‖u‖)).support
                                            [Elab.step] [0.010664] expected type: <not-available>, term
                                                (fun u ↦ -(divisor (· - z) B u * log ‖u‖))
                                              [Elab.step] [0.010660] expected type: <not-available>, term
                                                  fun u ↦ -(divisor (· - z) B u * log ‖u‖)
                                                [Elab.step] [0.010635] expected type: <not-available>, term
                                                    -(divisor (· - z) B u * log ‖u‖)
                                                  [Elab.step] [0.010629] expected type: <not-available>, term
                                                      unop% Neg.neg✝ (divisor (· - z) B u * log ‖u‖)
                                [Elab.step] [0.079018] simp [this, posLog_eq_log_max_one <| norm_nonneg z, h1lez]
                                  [Elab.step] [0.079014] simp [this, posLog_eq_log_max_one <| norm_nonneg z, h1lez]
                                    [Elab.step] [0.079009] simp [this, posLog_eq_log_max_one <| norm_nonneg z, h1lez]
                                      [Meta.synthInstance] [0.036726] ❌️ ZeroHomClass
                                            (Function.locallyFinsuppWithin B ℤ) ℂ ℤ
              [Elab.step] [0.070139] ·
                    by_cases hB : x ∈ B
                    · rw [Pi.zero_apply]
                      grind [log_eq_zero, mem_closedBall_zero_iff]
                    · simpa using .inl <| Function.locallyFinsuppWithin.apply_eq_zero_of_notMem _ hB
                [Elab.step] [0.069996] 
                      by_cases hB : x ∈ B
                      · rw [Pi.zero_apply]
                        grind [log_eq_zero, mem_closedBall_zero_iff]
                      · simpa using .inl <| Function.locallyFinsuppWithin.apply_eq_zero_of_notMem _ hB
                  [Elab.step] [0.069993] 
                        by_cases hB : x ∈ B
                        · rw [Pi.zero_apply]
                          grind [log_eq_zero, mem_closedBall_zero_iff]
                        · simpa using .inl <| Function.locallyFinsuppWithin.apply_eq_zero_of_notMem _ hB
                    [Elab.step] [0.048132] ·
                          rw [Pi.zero_apply]
                          grind [log_eq_zero, mem_closedBall_zero_iff]
                      [Elab.step] [0.048126] 
                            rw [Pi.zero_apply]
                            grind [log_eq_zero, mem_closedBall_zero_iff]
                        [Elab.step] [0.048123] 
                              rw [Pi.zero_apply]
                              grind [log_eq_zero, mem_closedBall_zero_iff]
                          [Elab.step] [0.045963] grind [log_eq_zero, mem_closedBall_zero_iff]
                    [Elab.step] [0.021268] ·
                          simpa using .inl <| Function.locallyFinsuppWithin.apply_eq_zero_of_notMem _ hB
                      [Elab.step] [0.021260] simpa using
                              .inl <| Function.locallyFinsuppWithin.apply_eq_zero_of_notMem _ hB
                        [Elab.step] [0.021257] simpa using
                                .inl <| Function.locallyFinsuppWithin.apply_eq_zero_of_notMem _ hB
                          [Elab.step] [0.021253] simpa using
                                .inl <| Function.locallyFinsuppWithin.apply_eq_zero_of_notMem _ hB
              [Elab.step] [0.010949] simpa using .inl <| divisor_sub_const_of_ne hx
info: Mathlib/Analysis/Polynomial/MahlerMeasure.lean:157:8: [Elab.async] [0.010732] Lean.addDecl
  [Kernel] [0.010685] ✅️ typechecking declarations [Polynomial.logMahlerMeasure_X_sub_C]
Build completed successfully (2781 jobs).
```

### Trace profiling of `logMahlerMeasure_X_sub_C` after PR 32014
```diff
diff --git a/Mathlib/Analysis/Polynomial/MahlerMeasure.lean b/Mathlib/Analysis/Polynomial/MahlerMeasure.lean
index 1ec3859381..9947e096a9 100644
--- a/Mathlib/Analysis/Polynomial/MahlerMeasure.lean
+++ b/Mathlib/Analysis/Polynomial/MahlerMeasure.lean
@@ -150,45 +150,12 @@ theorem logMahlerMeasure_C_mul {a : ℂ} (ha : a ≠ 0) {p : ℂ[X]} (hp : p ≠
     (C a * p).logMahlerMeasure = log ‖a‖ + p.logMahlerMeasure := by
   rw [logMahlerMeasure_mul_eq_add_logMahlerMeasure (by simp [ha, hp]), logMahlerMeasure_const]
 
+set_option trace.profiler true in
 open MeromorphicOn Metric in
 /-- The logarithmic Mahler measure of `X - C z` is the `log⁺` of the absolute value of `z`. -/
 @[simp]
 theorem logMahlerMeasure_X_sub_C (z : ℂ) : (X - C z).logMahlerMeasure = log⁺ ‖z‖ := by
-  rcases eq_or_ne z 0 with rfl | hz₀
-  · simp
-  have hmeroOnB : MeromorphicOn (· - z) (closedBall 0 |1|) := id.sub <| const z
-  simp_rw [logMahlerMeasure_def, eval_sub, eval_X, eval_C]
-  rw [circleAverage_log_norm one_ne_zero hmeroOnB, abs_one,
-  -- get rid of the `meromorphicTrailingCoeffAt`
-    AnalyticAt.meromorphicTrailingCoeffAt_of_ne_zero (by fun_prop) (by simp [hz₀]),
-    ← finsum_mem_support]
-  set B := closedBall (0 : ℂ) 1
-  -- separate cases depending on whether z is in the open `ball 0 1` or not
-  by_cases hzBall : z ∈ ball 0 1
-  · have hzdiv1 := divisor_sub_const_self (show z ∈ B by grind [ball_subset_closedBall])
-    suffices (fun u ↦ -(divisor (· - z) B u * log ‖u‖)).support = {z} by
-      simp [this, hzdiv1, posLog_def]
-      grind [mem_ball_zero_iff, log_nonpos, norm_nonneg]
-    rw [Function.support_eq_iff]
-    constructor
-    · simp_rw [Set.mem_singleton_iff]
-      intro _ rfl
-      rw [hzdiv1]
-      grind [log_eq_zero, norm_eq_zero, mem_ball_zero_iff, norm_nonneg]
-    · intro _ hu
-      rw [Set.mem_singleton_iff] at hu
-      simp [divisor_sub_const_of_ne hu]
-  · have h1lez : 1 ≤ ‖z‖ := by grind [mem_ball_zero_iff]
-    suffices (fun u ↦ -(divisor (· - z) B u * log ‖u‖)).support = ∅ by
-      simp [this, posLog_eq_log_max_one <| norm_nonneg z, h1lez]
-    rw [Function.support_eq_empty_iff]
-    ext x
-    rcases eq_or_ne x z with rfl | hx
-    · by_cases hB : x ∈ B
-      · rw [Pi.zero_apply]
-        grind [log_eq_zero, mem_closedBall_zero_iff]
-      · simpa using .inl <| Function.locallyFinsuppWithin.apply_eq_zero_of_notMem _ hB
-    simpa using .inl <| divisor_sub_const_of_ne hx
+  simp [logMahlerMeasure_def]
 
 @[simp]
 theorem logMahlerMeasure_X_add_C (z : ℂ) : (X + C z).logMahlerMeasure = log⁺ ‖z‖ := by
```
```
ℹ [2781/2781] Built Mathlib.Analysis.Polynomial.MahlerMeasure (2.2s)
info: Mathlib/Analysis/Polynomial/MahlerMeasure.lean:154:0: [Elab.command] [0.010145] open MeromorphicOn Metric in
    /-- The logarithmic Mahler measure of `X - C z` is the `log⁺` of the absolute value of `z`. -/
    @[simp]
    theorem logMahlerMeasure_X_sub_C (z : ℂ) : (X - C z).logMahlerMeasure = log⁺ ‖z‖ := by simp [logMahlerMeasure_def]
info: Mathlib/Analysis/Polynomial/MahlerMeasure.lean:155:0: [Elab.async] [0.036041] elaborating proof of Polynomial.logMahlerMeasure_X_sub_C
  [Elab.definition.value] [0.035663] Polynomial.logMahlerMeasure_X_sub_C
    [Elab.step] [0.035309] simp [logMahlerMeasure_def]
      [Elab.step] [0.035303] simp [logMahlerMeasure_def]
        [Elab.step] [0.035296] simp [logMahlerMeasure_def]
Build completed successfully (2781 jobs).
```
</details>

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

When merging, all the commits will be squashed into a single commit
listing all co-authors.

Co-authors in the squash commit are gathered from two sources:

First, all authors of commits to this PR branch are included. Thus,
one way to add co-authors is to include at least one commit authored by
each co-author among the commits in the pull request. If necessary, you
may create empty commits to indicate co-authorship, using commands like so:

git commit --author="Author Name <author@email.com>" --allow-empty -m "add Author Name as coauthor"

Second, co-authors can also be listed in lines at the very bottom of
the commit message (that is, directly before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines
at the bottom of the commit message (before the `---`, and also before
any "Co-authored-by" lines) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
