### PR TITLE
[Merged by Bors] - chore(Topology/Sets/Closeds): add `Singleton` instance to enable `{·}` notation

### DIFF
--- a/Mathlib/Topology/ContinuousMap/Ideals.lean
+++ b/Mathlib/Topology/ContinuousMap/Ideals.lean
@@ -347,7 +347,7 @@ theorem idealOfSet_isMaximal_iff (s : Opens X) :
   exact idealOfSet_ofIdeal_isClosed inferInstance
 
 theorem idealOf_compl_singleton_isMaximal (x : X) : (idealOfSet 𝕜 ({x}ᶜ : Set X)).IsMaximal :=
-  (idealOfSet_isMaximal_iff 𝕜 (Closeds.singleton x).compl).mpr <| Opens.isCoatom_iff.mpr ⟨x, rfl⟩
+  (idealOfSet_isMaximal_iff 𝕜 _).mpr <| Opens.isCoatom_iff.mpr ⟨x, rfl⟩
 
 variable {𝕜}
 

--- a/Mathlib/Topology/MetricSpace/Closeds.lean
+++ b/Mathlib/Topology/MetricSpace/Closeds.lean
@@ -220,7 +220,7 @@ instance Closeds.compactSpace [CompactSpace α] : CompactSpace (Closeds α) :=
     simp_rw [subset_univ, setOf_true] at this
     exact this.isCompact_of_isClosed isClosed_univ⟩
 
-theorem Closeds.isometry_singleton : Isometry (Closeds.singleton (α := α)) :=
+theorem Closeds.isometry_singleton : Isometry ({·} : α → Closeds α) :=
   fun _ _ => hausdorffEdist_singleton
 
 theorem Closeds.lipschitz_sup :

--- a/Mathlib/Topology/Sets/Closeds.lean
+++ b/Mathlib/Topology/Sets/Closeds.lean
@@ -195,6 +195,11 @@ instance [T1Space α] : Singleton α (Closeds α) where
 @[deprecated "Use `{x}` instead" (since := "2025-11-23")]
 abbrev singleton [T1Space α] (x : α) : Closeds α := {x}
 
+@[simp]
+theorem mk_singleton [T1Space α] {x : α} :
+    (⟨{x}, isClosed_singleton⟩ : Closeds α) = {x} :=
+  rfl
+
 @[simp] lemma mem_singleton [T1Space α] {a b : α} : a ∈ ({b} : Closeds α) ↔ a = b := Iff.rfl
 
 theorem singleton_injective [T1Space α] : Function.Injective ({·} : α → Closeds α) :=
@@ -414,6 +419,11 @@ instance [T1Space α] : Singleton α (IrreducibleCloseds α) where
 /-- The term of `TopologicalSpace.IrreducibleCloseds α` corresponding to a singleton. -/
 @[deprecated "Use `{x}` instead" (since := "2025-11-23")]
 abbrev singleton [T1Space α] (x : α) : IrreducibleCloseds α := {x}
+
+@[simp]
+theorem mk_singleton [T1Space α] {x : α} :
+    (⟨{x}, isIrreducible_singleton, isClosed_singleton⟩ : IrreducibleCloseds α) = {x} :=
+  rfl
 
 @[simp] lemma mem_singleton [T1Space α] {a b : α} : a ∈ ({b} : IrreducibleCloseds α) ↔ a = b :=
   Iff.rfl

--- a/Mathlib/Topology/Sets/Closeds.lean
+++ b/Mathlib/Topology/Sets/Closeds.lean
@@ -187,18 +187,21 @@ def coframeMinimalAxioms : Coframe.MinimalAxioms (Closeds α) where
 
 instance instCoframe : Coframe (Closeds α) := .ofMinimalAxioms coframeMinimalAxioms
 
-/-- The term of `TopologicalSpace.Closeds α` corresponding to a singleton. -/
 @[simps]
-def singleton [T1Space α] (x : α) : Closeds α :=
-  ⟨{x}, isClosed_singleton⟩
+instance [T1Space α] : Singleton α (Closeds α) where
+  singleton x := ⟨{x}, isClosed_singleton⟩
 
-@[simp] lemma mem_singleton [T1Space α] {a b : α} : a ∈ singleton b ↔ a = b := Iff.rfl
+/-- The term of `TopologicalSpace.Closeds α` corresponding to a singleton. -/
+@[deprecated "Use `{x}` instead" (since := "2025-11-23")]
+abbrev singleton [T1Space α] (x : α) : Closeds α := {x}
 
-theorem singleton_injective [T1Space α] : Function.Injective (singleton (α := α)) :=
+@[simp] lemma mem_singleton [T1Space α] {a b : α} : a ∈ ({b} : Closeds α) ↔ a = b := Iff.rfl
+
+theorem singleton_injective [T1Space α] : Function.Injective ({·} : α → Closeds α) :=
   .of_comp (f := SetLike.coe) Set.singleton_injective
 
 @[simp]
-theorem singleton_inj [T1Space α] {x y : α} : singleton x = singleton y ↔ x = y :=
+theorem singleton_inj [T1Space α] {x y : α} : ({x} : Closeds α) = {y} ↔ x = y :=
   singleton_injective.eq_iff
 
 /-- The preimage of a closed set under a continuous map. -/
@@ -265,16 +268,15 @@ lemma Closeds.coe_eq_singleton_of_isAtom [T0Space α] {s : Closeds α} (hs : IsA
   Closeds.gi.isAtom_iff' rfl
     (fun t ht ↦ by obtain ⟨x, rfl⟩ := Set.isAtom_iff.1 ht; exact closure_singleton) s
 
-/-- in a `T1Space`, atoms of `TopologicalSpace.Closeds α` are precisely the
-`TopologicalSpace.Closeds.singleton`s. -/
+/-- in a `T1Space`, atoms of `TopologicalSpace.Closeds α` are precisely the singletons. -/
 theorem Closeds.isAtom_iff [T1Space α] {s : Closeds α} :
-    IsAtom s ↔ ∃ x, s = Closeds.singleton x := by
+    IsAtom s ↔ ∃ x, s = {x} := by
   simp [← Closeds.isAtom_coe, Set.isAtom_iff, SetLike.ext_iff, Set.ext_iff]
 
 /-- in a `T1Space`, coatoms of `TopologicalSpace.Opens α` are precisely complements of singletons:
-`(TopologicalSpace.Closeds.singleton x).compl`. -/
+`({x} : Closeds α).compl`. -/
 theorem Opens.isCoatom_iff [T1Space α] {s : Opens α} :
-    IsCoatom s ↔ ∃ x, s = (Closeds.singleton x).compl := by
+    IsCoatom s ↔ ∃ x, s = ({x} : Closeds α).compl := by
   rw [← s.compl_compl, ← isAtom_dual_iff_isCoatom]
   change IsAtom (Closeds.complOrderIso α s.compl) ↔ _
   simp only [(Closeds.complOrderIso α).isAtom_iff, Closeds.isAtom_iff,
@@ -405,18 +407,22 @@ protected theorem ext {s t : IrreducibleCloseds α} (h : (s : Set α) = t) : s =
 theorem coe_mk (s : Set α) (h : IsIrreducible s) (h' : IsClosed s) : (mk s h h' : Set α) = s :=
   rfl
 
-/-- The term of `TopologicalSpace.IrreducibleCloseds α` corresponding to a singleton. -/
 @[simps]
-def singleton [T1Space α] (x : α) : IrreducibleCloseds α :=
-  ⟨{x}, isIrreducible_singleton, isClosed_singleton⟩
+instance [T1Space α] : Singleton α (IrreducibleCloseds α) where
+  singleton x := ⟨{x}, isIrreducible_singleton, isClosed_singleton⟩
 
-@[simp] lemma mem_singleton [T1Space α] {a b : α} : a ∈ singleton b ↔ a = b := Iff.rfl
+/-- The term of `TopologicalSpace.IrreducibleCloseds α` corresponding to a singleton. -/
+@[deprecated "Use `{x}` instead" (since := "2025-11-23")]
+abbrev singleton [T1Space α] (x : α) : IrreducibleCloseds α := {x}
 
-theorem singleton_injective [T1Space α] : Function.Injective (singleton (α := α)) :=
+@[simp] lemma mem_singleton [T1Space α] {a b : α} : a ∈ ({b} : IrreducibleCloseds α) ↔ a = b :=
+  Iff.rfl
+
+theorem singleton_injective [T1Space α] : Function.Injective ({·} : α → IrreducibleCloseds α) :=
   .of_comp (f := SetLike.coe) Set.singleton_injective
 
 @[simp]
-theorem singleton_inj [T1Space α] {x y : α} : singleton x = singleton y ↔ x = y :=
+theorem singleton_inj [T1Space α] {x y : α} : ({x} : IrreducibleCloseds α) = {y} ↔ x = y :=
   singleton_injective.eq_iff
 
 /--

--- a/Mathlib/Topology/Sets/Compacts.lean
+++ b/Mathlib/Topology/Sets/Compacts.lean
@@ -146,7 +146,7 @@ theorem mem_singleton (x y : α) : x ∈ ({y} : Compacts α) ↔ x = y :=
   Iff.rfl
 
 @[simp]
-theorem toCloseds_singleton [T2Space α] (x : α) : toCloseds {x} = Closeds.singleton x :=
+theorem toCloseds_singleton [T2Space α] (x : α) : toCloseds {x} = {x} :=
   rfl
 
 theorem singleton_injective : Function.Injective ({·} : α → Compacts α) :=
@@ -352,7 +352,7 @@ theorem mem_singleton (x y : α) : x ∈ ({y} : NonemptyCompacts α) ↔ x = y :
   Iff.rfl
 
 @[simp]
-theorem toCloseds_singleton [T2Space α] (x : α) : toCloseds {x} = Closeds.singleton x :=
+theorem toCloseds_singleton [T2Space α] (x : α) : toCloseds {x} = {x} :=
   rfl
 
 theorem singleton_injective : Function.Injective ({·} : α → NonemptyCompacts α) :=

--- a/Mathlib/Topology/UniformSpace/Closeds.lean
+++ b/Mathlib/Topology/UniformSpace/Closeds.lean
@@ -219,26 +219,25 @@ section T0Space
 
 variable [T0Space α]
 
-theorem isUniformEmbedding_singleton : IsUniformEmbedding (Closeds.singleton (α := α)) :=
+theorem isUniformEmbedding_singleton : IsUniformEmbedding ({·} : α → Closeds α) :=
   isUniformEmbedding_coe.of_comp_iff.mp UniformSpace.hausdorff.isUniformEmbedding_singleton
 
-theorem uniformContinuous_singleton : UniformContinuous (Closeds.singleton (α := α)) :=
+theorem uniformContinuous_singleton : UniformContinuous ({·} : α → Closeds α) :=
   isUniformEmbedding_singleton.uniformContinuous
 
 @[fun_prop]
-theorem isEmbedding_singleton : IsEmbedding (Closeds.singleton (α := α)) :=
+theorem isEmbedding_singleton : IsEmbedding ({·} : α → Closeds α) :=
   isUniformEmbedding_singleton.isEmbedding
 
 @[fun_prop]
-theorem continuous_singleton : Continuous (Closeds.singleton (α := α)) :=
+theorem continuous_singleton : Continuous ({·} : α → Closeds α) :=
   isEmbedding_singleton.continuous
 
 @[fun_prop]
-theorem isClosedEmbedding_singleton :
-    Topology.IsClosedEmbedding (Closeds.singleton (α := α)) where
+theorem isClosedEmbedding_singleton : Topology.IsClosedEmbedding ({·} : α → Closeds α) where
   __ := isUniformEmbedding_singleton.isEmbedding
   isClosed_range := by
-    rw [← SetLike.coe_injective.preimage_image (s := Set.range singleton), ← Set.range_comp]
+    rw [← SetLike.coe_injective.preimage_image (s := Set.range ({·})), ← Set.range_comp]
     exact UniformSpace.hausdorff.isClosedEmbedding_singleton.isClosed_range.preimage
       uniformContinuous_coe.continuous
 


### PR DESCRIPTION
---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

When merging, all the commits will be squashed into a single commit
listing all co-authors.

Co-authors in the squash commit are gathered from two sources:

First, all authors of commits to this PR branch are included. Thus,
one way to add co-authors is to include at least one commit authored by
each co-author among the commits in the pull request. If necessary, you
may create empty commits to indicate co-authorship, using commands like so:

git commit --author="Author Name <author@email.com>" --allow-empty -m "add Author Name as coauthor"

Second, co-authors can also be listed in lines at the very bottom of
the commit message (that is, directly before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines
at the bottom of the commit message (before the `---`, and also before
any "Co-authored-by" lines) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
