### PR TITLE
[Merged by Bors] - feat: Linearity of Derivation.compAlgebraMap

### DIFF
--- a/Mathlib/RingTheory/Derivation/Basic.lean
+++ b/Mathlib/RingTheory/Derivation/Basic.lean
@@ -321,6 +321,8 @@ def compAlgebraMap [Algebra A B] [IsScalarTower R A B] [IsScalarTower A B M]
   leibniz' a b := by simp
   toLinearMap := d.toLinearMap.comp (IsScalarTower.toAlgHom R A B).toLinearMap
 
+/-- For a tower `R → A → B → M`, the precomposition defined in `compAlgebraMap`
+is an `A`-linear map. -/
 def compAlgebraHom [Algebra A B] [IsScalarTower R A B] [IsScalarTower A B M] [IsScalarTower R A M] :
 (Derivation R B M) →ₗ[A] Derivation R A M :=
 {

--- a/Mathlib/RingTheory/Derivation/Basic.lean
+++ b/Mathlib/RingTheory/Derivation/Basic.lean
@@ -324,12 +324,10 @@ def compAlgebraMap [Algebra A B] [IsScalarTower R A B] [IsScalarTower A B M]
 /-- For a tower `R → A → B → M`, the precomposition defined in `compAlgebraMap`
 is an `A`-linear map. -/
 def compAlgebraHom [Algebra A B] [IsScalarTower R A B] [IsScalarTower A B M] [IsScalarTower R A M] :
-(Derivation R B M) →ₗ[A] Derivation R A M :=
-{
-  toFun := fun d ↦ compAlgebraMap A d
-  map_add' := by exact fun x y ↦ rfl
-  map_smul' := by exact fun m x ↦ rfl
-}
+    Derivation R B M →ₗ[A] Derivation R A M where
+  toFun d := d.compAlgebraMap A
+  map_add' _ _ := rfl
+  map_smul' _ _ := rfl
 
 section RestrictScalars
 

--- a/Mathlib/RingTheory/Derivation/Basic.lean
+++ b/Mathlib/RingTheory/Derivation/Basic.lean
@@ -321,9 +321,12 @@ def compAlgebraMap [Algebra A B] [IsScalarTower R A B] [IsScalarTower A B M]
   leibniz' a b := by simp
   toLinearMap := d.toLinearMap.comp (IsScalarTower.toAlgHom R A B).toLinearMap
 
+variable (R A B M) in
 /-- For a tower `R → A → B → M`, the precomposition defined in `compAlgebraMap`
 is an `A`-linear map. -/
-def compAlgebraHom [Algebra A B] [IsScalarTower R A B] [IsScalarTower A B M] [IsScalarTower R A M] :
+@[simps!]
+def compAlgebraMapL [Algebra A B] [IsScalarTower R A B] [IsScalarTower A B M]
+    [IsScalarTower R A M] :
     Derivation R B M →ₗ[A] Derivation R A M where
   toFun d := d.compAlgebraMap A
   map_add' _ _ := rfl

--- a/Mathlib/RingTheory/Derivation/Basic.lean
+++ b/Mathlib/RingTheory/Derivation/Basic.lean
@@ -321,6 +321,14 @@ def compAlgebraMap [Algebra A B] [IsScalarTower R A B] [IsScalarTower A B M]
   leibniz' a b := by simp
   toLinearMap := d.toLinearMap.comp (IsScalarTower.toAlgHom R A B).toLinearMap
 
+def compAlgebraHom [Algebra A B] [IsScalarTower R A B] [IsScalarTower A B M] [IsScalarTower R A M] :
+(Derivation R B M) →ₗ[A] Derivation R A M :=
+{
+  toFun := fun d ↦ compAlgebraMap A d
+  map_add' := by exact fun x y ↦ rfl
+  map_smul' := by exact fun m x ↦ rfl
+}
+
 section RestrictScalars
 
 variable {S : Type*} [CommSemiring S]


### PR DESCRIPTION
Let $Der_R(B,M)$ denote the $M$-valued derivations an $R$-algebra $B$. Assume we are also given an $R$-algebra homomorphism $\sigma: A\to B$. Then precomposing with $\sigma$ induces a map  $Der_R(B,M)\to  Der_R(A,M)$.
This map is defined `Derivation.compAlgebraMap`. 

In this PR we enhance this map: When $R$ $A$ $M$ also form a scalar tower, this map is in fact $A$-linear,
as witnessed by the added `Derivation.compAlgebraHom`.

---

A thing I could not really access whether one should add  `variable (A) in` and the `@[simps!]` to the declarations.
(These two are used before  `Derivation.compAlgebraMap` ).

An alternative name for this definition would be something relating to Pullbacks, but it might not be fully fitting, since the map $\sigma$  we are pulling back along is implicit and hidden inside `Algebra A B`.


<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

When merging, all the commits will be squashed into a single commit
listing all co-authors.

Co-authors in the squash commit are gathered from two sources:

First, all authors of commits to this PR branch are included. Thus,
one way to add co-authors is to include at least one commit authored by
each co-author among the commits in the pull request. If necessary, you
may create empty commits to indicate co-authorship, using commands like so:

git commit --author="Author Name <author@email.com>" --allow-empty -m "add Author Name as coauthor"

Second, co-authors can also be listed in lines at the very bottom of
the commit message (that is, directly before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines
at the bottom of the commit message (before the `---`, and also before
any "Co-authored-by" lines) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
