### PR TITLE
[Merged by Bors] - feat(FieldTheory/IntermediateField/Adjoin): generates as an algebra iff generates as an intermediate field

### DIFF
--- a/Mathlib/FieldTheory/CardinalEmb.lean
+++ b/Mathlib/FieldTheory/CardinalEmb.lean
@@ -134,7 +134,7 @@ def leastExt : ι → ι :=
         have : FiniteDimensional F (adjoin F s) :=
           finiteDimensional_adjoin fun x _ ↦ (IsAlgebraic.isAlgebraic x).isIntegral
         exact (Module.rank_lt_aleph0 _ _).trans_eq eq
-      · exact (Subalgebra.equivOfEq _ _ <| adjoin_algebraic_toSubalgebra
+      · exact (Subalgebra.equivOfEq _ _ <| adjoin_toSubalgebra_of_isAlgebraic
           fun x _ ↦ IsAlgebraic.isAlgebraic x)|>.toLinearEquiv.rank_eq.trans_lt <|
           (Algebra.rank_adjoin_le _).trans_lt (max_lt (mk_range_le.trans_lt this) lt)
 

--- a/Mathlib/FieldTheory/Galois/Basic.lean
+++ b/Mathlib/FieldTheory/Galois/Basic.lean
@@ -470,7 +470,7 @@ theorem is_separable_splitting_field [FiniteDimensional F E] [IsGalois F E] :
   obtain ⟨α, h1⟩ := Field.exists_primitive_element F E
   use minpoly F α, separable F α, IsGalois.splits F α
   rw [eq_top_iff, ← IntermediateField.top_toSubalgebra, ← h1]
-  rw [IntermediateField.adjoin_simple_toSubalgebra_of_algebraic (integral F α).isAlgebraic]
+  rw [IntermediateField.adjoin_simple_toSubalgebra_of_isAlgebraic (integral F α).isAlgebraic]
   apply Algebra.adjoin_mono
   rw [Set.singleton_subset_iff, Polynomial.mem_rootSet]
   exact ⟨minpoly.ne_zero (integral F α), minpoly.aeval _ _⟩

--- a/Mathlib/FieldTheory/Galois/Basic.lean
+++ b/Mathlib/FieldTheory/Galois/Basic.lean
@@ -470,7 +470,7 @@ theorem is_separable_splitting_field [FiniteDimensional F E] [IsGalois F E] :
   obtain ⟨α, h1⟩ := Field.exists_primitive_element F E
   use minpoly F α, separable F α, IsGalois.splits F α
   rw [eq_top_iff, ← IntermediateField.top_toSubalgebra, ← h1]
-  rw [IntermediateField.adjoin_simple_toSubalgebra_of_integral (integral F α)]
+  rw [IntermediateField.adjoin_simple_toSubalgebra_of_algebraic (integral F α).isAlgebraic]
   apply Algebra.adjoin_mono
   rw [Set.singleton_subset_iff, Polynomial.mem_rootSet]
   exact ⟨minpoly.ne_zero (integral F α), minpoly.aeval _ _⟩

--- a/Mathlib/FieldTheory/IntermediateField/Adjoin/Algebra.lean
+++ b/Mathlib/FieldTheory/IntermediateField/Adjoin/Algebra.lean
@@ -98,23 +98,23 @@ theorem adjoin_toSubalgebra [Algebra.IsAlgebraic F E] (S : Set E) :
     (adjoin F S).toSubalgebra = Algebra.adjoin F S :=
   adjoin_algebraic_toSubalgebra (fun x _ ↦ Algebra.IsAlgebraic.isAlgebraic x)
 
-theorem adjoin_integral_eq_top_iff {S : Set E} (hS : ∀ x ∈ S, IsAlgebraic F x) :
+theorem adjoin_algebraic_eq_top_iff {S : Set E} (hS : ∀ x ∈ S, IsAlgebraic F x) :
     adjoin F S = ⊤ ↔ Algebra.adjoin F S = ⊤ := by
   rw [← IntermediateField.adjoin_algebraic_toSubalgebra hS,
       ← IntermediateField.toSubalgebra_inj,
       IntermediateField.top_toSubalgebra]
 
-alias ⟨_root_.Algebra.adjoin_eq_top_of_intermediateField, _⟩ := adjoin_integral_eq_top_iff
+alias ⟨_root_.Algebra.adjoin_eq_top_of_intermediateField, _⟩ := adjoin_algebraic_eq_top_iff
 
 theorem adjoin_simple_eq_top_iff {x : E} (hx : IsAlgebraic F x) :
-    F⟮x⟯ = ⊤ ↔ Algebra.adjoin F {x} = ⊤ := adjoin_integral_eq_top_iff (by simp [hx])
+    F⟮x⟯ = ⊤ ↔ Algebra.adjoin F {x} = ⊤ := adjoin_algebraic_eq_top_iff (by simp [hx])
 
 alias ⟨_root_.Algebra.adjoin_eq_top_of_primitive_element, _⟩ := adjoin_simple_eq_top_iff
 
 @[simp]
 theorem adjoin_eq_top_iff [Algebra.IsAlgebraic F E] {S : Set E} :
     adjoin F S = ⊤ ↔ Algebra.adjoin F S = ⊤ :=
-  adjoin_integral_eq_top_iff (fun x _ ↦ Algebra.IsAlgebraic.isAlgebraic x)
+  adjoin_algebraic_eq_top_iff (fun x _ ↦ Algebra.IsAlgebraic.isAlgebraic x)
 
 lemma finite_of_fg_of_isAlgebraic
     (h : FG (⊤ : IntermediateField F E)) [Algebra.IsAlgebraic F E] :

--- a/Mathlib/FieldTheory/IntermediateField/Adjoin/Algebra.lean
+++ b/Mathlib/FieldTheory/IntermediateField/Adjoin/Algebra.lean
@@ -84,18 +84,18 @@ theorem AdjoinSimple.isIntegral_gen : IsIntegral F (AdjoinSimple.gen F α) ↔ I
 
 variable {F} {α}
 
-theorem adjoin_algebraic_toSubalgebra {S : Set E} (hS : ∀ x ∈ S, IsAlgebraic F x) :
+theorem adjoin_toSubalgebra_of_isAlgebraic {S : Set E} (hS : ∀ x ∈ S, IsAlgebraic F x) :
     (adjoin F S).toSubalgebra = Algebra.adjoin F S :=
   adjoin_eq_algebra_adjoin _ _ fun _ ↦
     (Algebra.IsIntegral.adjoin fun x hx ↦ (hS x hx).isIntegral).inv_mem
 
 theorem adjoin_simple_toSubalgebra_of_algebraic (hα : IsAlgebraic F α) :
     F⟮α⟯.toSubalgebra = Algebra.adjoin F {α} :=
-  adjoin_algebraic_toSubalgebra <| by simpa
+  adjoin_toSubalgebra_of_isAlgebraic <| by simpa
 
 @[simp]
 theorem adjoin_toSubalgebra [Algebra.IsAlgebraic F E] (S : Set E) :
-    (adjoin F S).toSubalgebra = Algebra.adjoin F S :=
+    (adjoin F S).toSubalgebra =adjoin_toSubalgebra_of_isAlgebraic
   adjoin_algebraic_toSubalgebra (fun x _ ↦ Algebra.IsAlgebraic.isAlgebraic x)
 
 theorem adjoin_algebraic_eq_top_iff {S : Set E} (hS : ∀ x ∈ S, IsAlgebraic F x) :
@@ -107,7 +107,7 @@ theorem adjoin_algebraic_eq_top_iff {S : Set E} (hS : ∀ x ∈ S, IsAlgebraic F
 alias ⟨_root_.Algebra.adjoin_eq_top_of_intermediateField, _⟩ := adjoin_algebraic_eq_top_iff
 
 theorem adjoin_simple_eq_top_iff {x : E} (hx : IsAlgebraic F x) :
-    F⟮x⟯ = ⊤ ↔ Algebra.adjoin F {x} = ⊤ := adjoin_algebraic_eq_top_iff (by simp [hx])
+    F⟮x⟯ = ⊤ ↔ Algebra.adjoiadjoin_toSubalgebra_of_isAlgebraicic_eq_top_iff (by simp [hx])
 
 alias ⟨_root_.Algebra.adjoin_eq_top_of_primitive_element, _⟩ := adjoin_simple_eq_top_iff
 
@@ -121,7 +121,7 @@ lemma finite_of_fg_of_isAlgebraic
     Module.Finite F E := by
   obtain ⟨s, hs⟩ := h
   have : Algebra.FiniteType F E := by
-    use s
+    use sadjoin_toSubalgebra_of_isAlgebraic
     simpa [← toSubalgebra_inj] using hs
   exact Algebra.IsIntegral.finite
 

--- a/Mathlib/FieldTheory/IntermediateField/Adjoin/Algebra.lean
+++ b/Mathlib/FieldTheory/IntermediateField/Adjoin/Algebra.lean
@@ -84,32 +84,44 @@ theorem AdjoinSimple.isIntegral_gen : IsIntegral F (AdjoinSimple.gen F α) ↔ I
 
 variable {F} {α}
 
-theorem adjoin_algebraic_toSubalgebra {S : Set E} (hS : ∀ x ∈ S, IsAlgebraic F x) :
-    (IntermediateField.adjoin F S).toSubalgebra = Algebra.adjoin F S :=
-  adjoin_eq_algebra_adjoin _ _ fun _ ↦
-    (Algebra.IsIntegral.adjoin fun x hx ↦ (hS x hx).isIntegral).inv_mem
+theorem adjoin_integral_toSubalgebra {S : Set E} (hS : ∀ x ∈ S, IsIntegral F x) :
+    (adjoin F S).toSubalgebra = Algebra.adjoin F S :=
+  adjoin_eq_algebra_adjoin _ _ fun _ ↦ (Algebra.IsIntegral.adjoin (hS · ·)).inv_mem
 
 theorem adjoin_simple_toSubalgebra_of_integral (hα : IsIntegral F α) :
     F⟮α⟯.toSubalgebra = Algebra.adjoin F {α} :=
-  adjoin_algebraic_toSubalgebra <| by simpa [isAlgebraic_iff_isIntegral]
+  adjoin_integral_toSubalgebra <| by simpa
 
-lemma _root_.Algebra.adjoin_eq_top_of_intermediateField {S : Set E} (hS : ∀ x ∈ S, IsAlgebraic F x)
-    (hS₂ : IntermediateField.adjoin F S = ⊤) : Algebra.adjoin F S = ⊤ := by
-  simp [*, ← IntermediateField.adjoin_algebraic_toSubalgebra hS]
+@[simp]
+theorem adjoin_toSubalgebra [Algebra.IsAlgebraic F E] (S : Set E) :
+    (adjoin F S).toSubalgebra = Algebra.adjoin F S :=
+  adjoin_integral_toSubalgebra (fun x _ ↦ Algebra.IsIntegral.isIntegral x)
 
-lemma _root_.Algebra.adjoin_eq_top_of_primitive_element {α : E} (hα : IsIntegral F α)
-    (hα₂ : F⟮α⟯ = ⊤) : Algebra.adjoin F {α} = ⊤ :=
-  Algebra.adjoin_eq_top_of_intermediateField (by simpa [isAlgebraic_iff_isIntegral]) hα₂
+theorem adjoin_integral_eq_top_iff {S : Set E} (hS : ∀ x ∈ S, IsIntegral F x) :
+    adjoin F S = ⊤ ↔ Algebra.adjoin F S = ⊤ := by
+  rw [← IntermediateField.adjoin_integral_toSubalgebra hS,
+      ← IntermediateField.toSubalgebra_inj,
+      IntermediateField.top_toSubalgebra]
+
+alias ⟨_root_.Algebra.adjoin_eq_top_of_intermediateField, _⟩ := adjoin_integral_eq_top_iff
+
+theorem adjoin_simple_eq_top_iff {x : E} (hx : IsIntegral F x) :
+    F⟮x⟯ = ⊤ ↔ Algebra.adjoin F {x} = ⊤ := adjoin_integral_eq_top_iff (by simp [hx])
+
+alias ⟨_root_.Algebra.adjoin_eq_top_of_primitive_element, _⟩ := adjoin_simple_eq_top_iff
+
+@[simp]
+theorem adjoin_eq_top_iff [Algebra.IsAlgebraic F E] {S : Set E} :
+    adjoin F S = ⊤ ↔ Algebra.adjoin F S = ⊤ :=
+  adjoin_integral_eq_top_iff (fun x _ ↦ Algebra.IsIntegral.isIntegral x)
 
 lemma finite_of_fg_of_isAlgebraic
-    (h : IntermediateField.FG (⊤ : IntermediateField F E)) [Algebra.IsAlgebraic F E] :
+    (h : FG (⊤ : IntermediateField F E)) [Algebra.IsAlgebraic F E] :
     Module.Finite F E := by
   obtain ⟨s, hs⟩ := h
   have : Algebra.FiniteType F E := by
     use s
-    rw [← IntermediateField.adjoin_algebraic_toSubalgebra
-      (fun x hx ↦ Algebra.IsAlgebraic.isAlgebraic x)]
-    simpa [← IntermediateField.toSubalgebra_inj] using hs
+    simpa [← toSubalgebra_inj] using hs
   exact Algebra.IsIntegral.finite
 
 section Supremum
@@ -121,9 +133,8 @@ theorem le_sup_toSubalgebra : E1.toSubalgebra ⊔ E2.toSubalgebra ≤ (E1 ⊔ E2
 
 theorem sup_toSubalgebra_of_isAlgebraic_right [Algebra.IsAlgebraic K E2] :
     (E1 ⊔ E2).toSubalgebra = E1.toSubalgebra ⊔ E2.toSubalgebra := by
-  have : (adjoin E1 (E2 : Set L)).toSubalgebra = _ := adjoin_algebraic_toSubalgebra fun x h ↦
-    IsAlgebraic.tower_top E1 (isAlgebraic_iff.1
-      (Algebra.IsAlgebraic.isAlgebraic (⟨x, h⟩ : E2)))
+  have : (adjoin E1 (E2 : Set L)).toSubalgebra = _ := adjoin_integral_toSubalgebra fun x h ↦
+    IsIntegral.tower_top (isIntegral_iff.1 (Algebra.IsIntegral.isIntegral (⟨x, h⟩ : E2)))
   apply_fun Subalgebra.restrictScalars K at this
   rw [← restrictScalars_toSubalgebra, restrictScalars_adjoin] at this
   -- TODO: rather than using `← coe_type_toSubalgera` here, perhaps we should restate another

--- a/Mathlib/FieldTheory/IntermediateField/Adjoin/Algebra.lean
+++ b/Mathlib/FieldTheory/IntermediateField/Adjoin/Algebra.lean
@@ -96,7 +96,7 @@ theorem adjoin_simple_toSubalgebra_of_algebraic (hα : IsAlgebraic F α) :
 @[simp]
 theorem adjoin_toSubalgebra [Algebra.IsAlgebraic F E] (S : Set E) :
     (adjoin F S).toSubalgebra = Algebra.adjoin F S :=
-  adjoin_algebraic_toSubalgebra (fun x _ ↦ Algebra.IsAlgebraic.isAlgebraic x)
+  adjoin_algebraic_toSubalgebra fun x _ ↦ Algebra.IsAlgebraic.isAlgebraic x
 
 theorem adjoin_algebraic_eq_top_iff {S : Set E} (hS : ∀ x ∈ S, IsAlgebraic F x) :
     adjoin F S = ⊤ ↔ Algebra.adjoin F S = ⊤ := by

--- a/Mathlib/FieldTheory/IntermediateField/Adjoin/Algebra.lean
+++ b/Mathlib/FieldTheory/IntermediateField/Adjoin/Algebra.lean
@@ -84,28 +84,29 @@ theorem AdjoinSimple.isIntegral_gen : IsIntegral F (AdjoinSimple.gen F α) ↔ I
 
 variable {F} {α}
 
-theorem adjoin_integral_toSubalgebra {S : Set E} (hS : ∀ x ∈ S, IsIntegral F x) :
+theorem adjoin_algebraic_toSubalgebra {S : Set E} (hS : ∀ x ∈ S, IsAlgebraic F x) :
     (adjoin F S).toSubalgebra = Algebra.adjoin F S :=
-  adjoin_eq_algebra_adjoin _ _ fun _ ↦ (Algebra.IsIntegral.adjoin (hS · ·)).inv_mem
+  adjoin_eq_algebra_adjoin _ _ fun _ ↦
+    (Algebra.IsIntegral.adjoin fun x hx ↦ (hS x hx).isIntegral).inv_mem
 
-theorem adjoin_simple_toSubalgebra_of_integral (hα : IsIntegral F α) :
+theorem adjoin_simple_toSubalgebra_of_algebraic (hα : IsAlgebraic F α) :
     F⟮α⟯.toSubalgebra = Algebra.adjoin F {α} :=
-  adjoin_integral_toSubalgebra <| by simpa
+  adjoin_algebraic_toSubalgebra <| by simpa
 
 @[simp]
 theorem adjoin_toSubalgebra [Algebra.IsAlgebraic F E] (S : Set E) :
     (adjoin F S).toSubalgebra = Algebra.adjoin F S :=
-  adjoin_integral_toSubalgebra (fun x _ ↦ Algebra.IsIntegral.isIntegral x)
+  adjoin_algebraic_toSubalgebra (fun x _ ↦ Algebra.IsAlgebraic.isAlgebraic x)
 
-theorem adjoin_integral_eq_top_iff {S : Set E} (hS : ∀ x ∈ S, IsIntegral F x) :
+theorem adjoin_integral_eq_top_iff {S : Set E} (hS : ∀ x ∈ S, IsAlgebraic F x) :
     adjoin F S = ⊤ ↔ Algebra.adjoin F S = ⊤ := by
-  rw [← IntermediateField.adjoin_integral_toSubalgebra hS,
+  rw [← IntermediateField.adjoin_algebraic_toSubalgebra hS,
       ← IntermediateField.toSubalgebra_inj,
       IntermediateField.top_toSubalgebra]
 
 alias ⟨_root_.Algebra.adjoin_eq_top_of_intermediateField, _⟩ := adjoin_integral_eq_top_iff
 
-theorem adjoin_simple_eq_top_iff {x : E} (hx : IsIntegral F x) :
+theorem adjoin_simple_eq_top_iff {x : E} (hx : IsAlgebraic F x) :
     F⟮x⟯ = ⊤ ↔ Algebra.adjoin F {x} = ⊤ := adjoin_integral_eq_top_iff (by simp [hx])
 
 alias ⟨_root_.Algebra.adjoin_eq_top_of_primitive_element, _⟩ := adjoin_simple_eq_top_iff
@@ -113,7 +114,7 @@ alias ⟨_root_.Algebra.adjoin_eq_top_of_primitive_element, _⟩ := adjoin_simpl
 @[simp]
 theorem adjoin_eq_top_iff [Algebra.IsAlgebraic F E] {S : Set E} :
     adjoin F S = ⊤ ↔ Algebra.adjoin F S = ⊤ :=
-  adjoin_integral_eq_top_iff (fun x _ ↦ Algebra.IsIntegral.isIntegral x)
+  adjoin_integral_eq_top_iff (fun x _ ↦ Algebra.IsAlgebraic.isAlgebraic x)
 
 lemma finite_of_fg_of_isAlgebraic
     (h : FG (⊤ : IntermediateField F E)) [Algebra.IsAlgebraic F E] :
@@ -133,8 +134,8 @@ theorem le_sup_toSubalgebra : E1.toSubalgebra ⊔ E2.toSubalgebra ≤ (E1 ⊔ E2
 
 theorem sup_toSubalgebra_of_isAlgebraic_right [Algebra.IsAlgebraic K E2] :
     (E1 ⊔ E2).toSubalgebra = E1.toSubalgebra ⊔ E2.toSubalgebra := by
-  have : (adjoin E1 (E2 : Set L)).toSubalgebra = _ := adjoin_integral_toSubalgebra fun x h ↦
-    IsIntegral.tower_top (isIntegral_iff.1 (Algebra.IsIntegral.isIntegral (⟨x, h⟩ : E2)))
+  have : (adjoin E1 (E2 : Set L)).toSubalgebra = _ := adjoin_algebraic_toSubalgebra fun x h ↦
+    IsAlgebraic.tower_top _ (isAlgebraic_iff.1 (Algebra.IsAlgebraic.isAlgebraic (⟨x, h⟩ : E2)))
   apply_fun Subalgebra.restrictScalars K at this
   rw [← restrictScalars_toSubalgebra, restrictScalars_adjoin] at this
   -- TODO: rather than using `← coe_type_toSubalgera` here, perhaps we should restate another

--- a/Mathlib/FieldTheory/IntermediateField/Adjoin/Algebra.lean
+++ b/Mathlib/FieldTheory/IntermediateField/Adjoin/Algebra.lean
@@ -117,7 +117,8 @@ alias ⟨_root_.Algebra.adjoin_eq_top_of_intermediateField, _⟩ := adjoin_eq_to
 theorem adjoin_simple_eq_top_iff_of_isAlgebraic {x : E} (hx : IsAlgebraic F x) :
     F⟮x⟯ = ⊤ ↔ Algebra.adjoin F {x} = ⊤ := adjoin_eq_top_iff_of_isAlgebraic (by simp [hx])
 
-alias ⟨_root_.Algebra.adjoin_eq_top_of_primitive_element, _⟩ := adjoin_simple_eq_top_iff
+alias ⟨_root_.Algebra.adjoin_eq_top_of_primitive_element, _⟩ :=
+  adjoin_simple_eq_top_iff_of_isAlgebraic
 
 @[simp]
 theorem adjoin_eq_top_iff [Algebra.IsAlgebraic F E] {S : Set E} :
@@ -129,6 +130,7 @@ lemma finite_of_fg_of_isAlgebraic
     Module.Finite F E := by
   obtain ⟨s, hs⟩ := h
   have : Algebra.FiniteType F E := by
+    use s
     rw [← adjoin_toSubalgebra_of_isAlgebraic
       (fun x hx ↦ Algebra.IsAlgebraic.isAlgebraic x)]
     simpa [← toSubalgebra_inj] using hs
@@ -183,7 +185,7 @@ variable {K : Type*} [Field K] [Algebra F K] [Algebra E K] [IsScalarTower F E K]
 
 /-- If `K / E / F` is a field extension tower, `L` is an intermediate field of `K / F`, such that
 either `E / F` or `L / F` is algebraic, then `E(L) = E[L]`. -/
-theorem adjoin_toSubalgebra_of_isAlgebraic (L : IntermediateField F K)
+theorem adjoin_intermediateField_toSubalgebra_of_isAlgebraic (L : IntermediateField F K)
     (halg : Algebra.IsAlgebraic F E ∨ Algebra.IsAlgebraic F L) :
     (adjoin E (L : Set K)).toSubalgebra = Algebra.adjoin E (L : Set K) := by
   let i := IsScalarTower.toAlgHom F E K
@@ -198,15 +200,21 @@ theorem adjoin_toSubalgebra_of_isAlgebraic (L : IntermediateField F K)
   exact E'.sup_toSubalgebra_of_isAlgebraic L (halg.imp
     (fun (_ : Algebra.IsAlgebraic F E) ↦ i'.isAlgebraic) id)
 
-theorem adjoin_toSubalgebra_of_isAlgebraic_left (L : IntermediateField F K)
+theorem adjoin_intermediateField_toSubalgebra_of_isAlgebraic_left (L : IntermediateField F K)
     [halg : Algebra.IsAlgebraic F E] :
     (adjoin E (L : Set K)).toSubalgebra = Algebra.adjoin E (L : Set K) :=
-  adjoin_toSubalgebra_of_isAlgebraic E L (Or.inl halg)
+  adjoin_intermediateField_toSubalgebra_of_isAlgebraic E L (Or.inl halg)
 
-theorem adjoin_toSubalgebra_of_isAlgebraic_right (L : IntermediateField F K)
+@[deprecated (since := "2025-11-24")] alias adjoin_toSubalgebra_of_isAlgebraic_left :=
+  adjoin_intermediateField_toSubalgebra_of_isAlgebraic_left
+
+theorem adjoin_intermediateField_toSubalgebra_of_isAlgebraic_right (L : IntermediateField F K)
     [halg : Algebra.IsAlgebraic F L] :
     (adjoin E (L : Set K)).toSubalgebra = Algebra.adjoin E (L : Set K) :=
-  adjoin_toSubalgebra_of_isAlgebraic E L (Or.inr halg)
+  adjoin_intermediateField_toSubalgebra_of_isAlgebraic E L (Or.inr halg)
+
+@[deprecated (since := "2025-11-24")] alias adjoin_toSubalgebra_of_isAlgebraic_right :=
+  adjoin_intermediateField_toSubalgebra_of_isAlgebraic_right
 
 end Tower
 

--- a/Mathlib/FieldTheory/IntermediateField/Adjoin/Algebra.lean
+++ b/Mathlib/FieldTheory/IntermediateField/Adjoin/Algebra.lean
@@ -89,16 +89,21 @@ theorem adjoin_algebraic_toSubalgebra {S : Set E} (hS : ∀ x ∈ S, IsAlgebraic
   adjoin_eq_algebra_adjoin _ _ fun _ ↦
     (Algebra.IsIntegral.adjoin fun x hx ↦ (hS x hx).isIntegral).inv_mem
 
-theorem adjoin_simple_toSubalgebra_of_algebraic (hα : IsAlgebraic F α) :
+theorem adjoin_simple_toSubalgebra_of_isAlgebraic (hα : IsAlgebraic F α) :
     F⟮α⟯.toSubalgebra = Algebra.adjoin F {α} :=
   adjoin_algebraic_toSubalgebra <| by simpa
+
+@[deprecated "Use `adjoin_simple_toSubalgebra_of_isAlgebraic` instead" (since := "2025-11-24")]
+theorem adjoin_simple_toSubalgebra_of_integral (hα : IsIntegral F α) :
+    F⟮α⟯.toSubalgebra = Algebra.adjoin F {α} :=
+  adjoin_algebraic_toSubalgebra <| by simpa [isAlgebraic_iff_isIntegral]
 
 @[simp]
 theorem adjoin_toSubalgebra [Algebra.IsAlgebraic F E] (S : Set E) :
     (adjoin F S).toSubalgebra = Algebra.adjoin F S :=
   adjoin_algebraic_toSubalgebra fun x _ ↦ Algebra.IsAlgebraic.isAlgebraic x
 
-theorem adjoin_algebraic_eq_top_iff {S : Set E} (hS : ∀ x ∈ S, IsAlgebraic F x) :
+theorem adjoin_eq_top_iff_of_isAlgebraic {S : Set E} (hS : ∀ x ∈ S, IsAlgebraic F x) :
     adjoin F S = ⊤ ↔ Algebra.adjoin F S = ⊤ := by
   rw [← IntermediateField.adjoin_algebraic_toSubalgebra hS,
       ← IntermediateField.toSubalgebra_inj,
@@ -106,7 +111,7 @@ theorem adjoin_algebraic_eq_top_iff {S : Set E} (hS : ∀ x ∈ S, IsAlgebraic F
 
 alias ⟨_root_.Algebra.adjoin_eq_top_of_intermediateField, _⟩ := adjoin_algebraic_eq_top_iff
 
-theorem adjoin_simple_eq_top_iff {x : E} (hx : IsAlgebraic F x) :
+theorem adjoin_simple_eq_top_iff_of_isAlgebraic {x : E} (hx : IsAlgebraic F x) :
     F⟮x⟯ = ⊤ ↔ Algebra.adjoin F {x} = ⊤ := adjoin_algebraic_eq_top_iff (by simp [hx])
 
 alias ⟨_root_.Algebra.adjoin_eq_top_of_primitive_element, _⟩ := adjoin_simple_eq_top_iff

--- a/Mathlib/FieldTheory/IntermediateField/Adjoin/Algebra.lean
+++ b/Mathlib/FieldTheory/IntermediateField/Adjoin/Algebra.lean
@@ -84,42 +84,44 @@ theorem AdjoinSimple.isIntegral_gen : IsIntegral F (AdjoinSimple.gen F α) ↔ I
 
 variable {F} {α}
 
-theorem adjoin_algebraic_toSubalgebra {S : Set E} (hS : ∀ x ∈ S, IsAlgebraic F x) :
+theorem adjoin_toSubalgebra_of_isAlgebraic {S : Set E} (hS : ∀ x ∈ S, IsAlgebraic F x) :
     (adjoin F S).toSubalgebra = Algebra.adjoin F S :=
   adjoin_eq_algebra_adjoin _ _ fun _ ↦
     (Algebra.IsIntegral.adjoin fun x hx ↦ (hS x hx).isIntegral).inv_mem
 
+@[deprecated (since = "2025-11-24")] alias adjoin_algebraic_toSubalgebra := adjoin_toSubalgebra_of_isAlgebraic
+
 theorem adjoin_simple_toSubalgebra_of_isAlgebraic (hα : IsAlgebraic F α) :
     F⟮α⟯.toSubalgebra = Algebra.adjoin F {α} :=
-  adjoin_algebraic_toSubalgebra <| by simpa
+  adjoin_toSubalgebra_of_isAlgebraic <| by simpa
 
 @[deprecated "Use `adjoin_simple_toSubalgebra_of_isAlgebraic` instead" (since := "2025-11-24")]
 theorem adjoin_simple_toSubalgebra_of_integral (hα : IsIntegral F α) :
     F⟮α⟯.toSubalgebra = Algebra.adjoin F {α} :=
-  adjoin_algebraic_toSubalgebra <| by simpa [isAlgebraic_iff_isIntegral]
+  adjoin_toSubalgebra_of_isAlgebraic <| by simpa [isAlgebraic_iff_isIntegral]
 
 @[simp]
 theorem adjoin_toSubalgebra [Algebra.IsAlgebraic F E] (S : Set E) :
     (adjoin F S).toSubalgebra = Algebra.adjoin F S :=
-  adjoin_algebraic_toSubalgebra fun x _ ↦ Algebra.IsAlgebraic.isAlgebraic x
+  adjoin_toSubalgebra_of_isAlgebraic fun x _ ↦ Algebra.IsAlgebraic.isAlgebraic x
 
 theorem adjoin_eq_top_iff_of_isAlgebraic {S : Set E} (hS : ∀ x ∈ S, IsAlgebraic F x) :
     adjoin F S = ⊤ ↔ Algebra.adjoin F S = ⊤ := by
-  rw [← IntermediateField.adjoin_algebraic_toSubalgebra hS,
+  rw [← IntermediateField.adjoin_toSubalgebra_of_isAlgebraic hS,
       ← IntermediateField.toSubalgebra_inj,
       IntermediateField.top_toSubalgebra]
 
-alias ⟨_root_.Algebra.adjoin_eq_top_of_intermediateField, _⟩ := adjoin_algebraic_eq_top_iff
+alias ⟨_root_.Algebra.adjoin_eq_top_of_intermediateField, _⟩ := adjoin_eq_top_iff_of_isAlgebraic
 
 theorem adjoin_simple_eq_top_iff_of_isAlgebraic {x : E} (hx : IsAlgebraic F x) :
-    F⟮x⟯ = ⊤ ↔ Algebra.adjoin F {x} = ⊤ := adjoin_algebraic_eq_top_iff (by simp [hx])
+    F⟮x⟯ = ⊤ ↔ Algebra.adjoin F {x} = ⊤ := adjoin_eq_top_iff_of_isAlgebraic (by simp [hx])
 
 alias ⟨_root_.Algebra.adjoin_eq_top_of_primitive_element, _⟩ := adjoin_simple_eq_top_iff
 
 @[simp]
 theorem adjoin_eq_top_iff [Algebra.IsAlgebraic F E] {S : Set E} :
     adjoin F S = ⊤ ↔ Algebra.adjoin F S = ⊤ :=
-  adjoin_algebraic_eq_top_iff (fun x _ ↦ Algebra.IsAlgebraic.isAlgebraic x)
+  adjoin_eq_top_iff_of_isAlgebraic (fun x _ ↦ Algebra.IsAlgebraic.isAlgebraic x)
 
 lemma finite_of_fg_of_isAlgebraic
     (h : FG (⊤ : IntermediateField F E)) [Algebra.IsAlgebraic F E] :
@@ -139,7 +141,7 @@ theorem le_sup_toSubalgebra : E1.toSubalgebra ⊔ E2.toSubalgebra ≤ (E1 ⊔ E2
 
 theorem sup_toSubalgebra_of_isAlgebraic_right [Algebra.IsAlgebraic K E2] :
     (E1 ⊔ E2).toSubalgebra = E1.toSubalgebra ⊔ E2.toSubalgebra := by
-  have : (adjoin E1 (E2 : Set L)).toSubalgebra = _ := adjoin_algebraic_toSubalgebra fun x h ↦
+  have : (adjoin E1 (E2 : Set L)).toSubalgebra = _ := adjoin_toSubalgebra_of_isAlgebraic fun x h ↦
     IsAlgebraic.tower_top _ (isAlgebraic_iff.mp (Algebra.IsAlgebraic.isAlgebraic (⟨x, h⟩ : E2)))
   apply_fun Subalgebra.restrictScalars K at this
   rw [← restrictScalars_toSubalgebra, restrictScalars_adjoin] at this

--- a/Mathlib/FieldTheory/IntermediateField/Adjoin/Algebra.lean
+++ b/Mathlib/FieldTheory/IntermediateField/Adjoin/Algebra.lean
@@ -128,7 +128,8 @@ lemma finite_of_fg_of_isAlgebraic
     Module.Finite F E := by
   obtain ⟨s, hs⟩ := h
   have : Algebra.FiniteType F E := by
-    use sadjoin_toSubalgebra_of_isAlgebraic
+    rw [← adjoin_toSubalgebra_of_isAlgebraic
+      (fun x hx ↦ Algebra.IsAlgebraic.isAlgebraic x)]
     simpa [← toSubalgebra_inj] using hs
   exact Algebra.IsIntegral.finite
 

--- a/Mathlib/FieldTheory/IntermediateField/Adjoin/Algebra.lean
+++ b/Mathlib/FieldTheory/IntermediateField/Adjoin/Algebra.lean
@@ -135,7 +135,7 @@ theorem le_sup_toSubalgebra : E1.toSubalgebra ⊔ E2.toSubalgebra ≤ (E1 ⊔ E2
 theorem sup_toSubalgebra_of_isAlgebraic_right [Algebra.IsAlgebraic K E2] :
     (E1 ⊔ E2).toSubalgebra = E1.toSubalgebra ⊔ E2.toSubalgebra := by
   have : (adjoin E1 (E2 : Set L)).toSubalgebra = _ := adjoin_algebraic_toSubalgebra fun x h ↦
-    IsAlgebraic.tower_top _ (isAlgebraic_iff.1 (Algebra.IsAlgebraic.isAlgebraic (⟨x, h⟩ : E2)))
+    IsAlgebraic.tower_top _ (isAlgebraic_iff.mp (Algebra.IsAlgebraic.isAlgebraic (⟨x, h⟩ : E2)))
   apply_fun Subalgebra.restrictScalars K at this
   rw [← restrictScalars_toSubalgebra, restrictScalars_adjoin] at this
   -- TODO: rather than using `← coe_type_toSubalgera` here, perhaps we should restate another

--- a/Mathlib/FieldTheory/IntermediateField/Adjoin/Algebra.lean
+++ b/Mathlib/FieldTheory/IntermediateField/Adjoin/Algebra.lean
@@ -89,7 +89,8 @@ theorem adjoin_toSubalgebra_of_isAlgebraic {S : Set E} (hS : ∀ x ∈ S, IsAlge
   adjoin_eq_algebra_adjoin _ _ fun _ ↦
     (Algebra.IsIntegral.adjoin fun x hx ↦ (hS x hx).isIntegral).inv_mem
 
-@[deprecated (since = "2025-11-24")] alias adjoin_algebraic_toSubalgebra := adjoin_toSubalgebra_of_isAlgebraic
+@[deprecated (since := "2025-11-24")] alias adjoin_algebraic_toSubalgebra :=
+  adjoin_toSubalgebra_of_isAlgebraic
 
 theorem adjoin_simple_toSubalgebra_of_isAlgebraic (hα : IsAlgebraic F α) :
     F⟮α⟯.toSubalgebra = Algebra.adjoin F {α} :=

--- a/Mathlib/FieldTheory/IntermediateField/Adjoin/Basic.lean
+++ b/Mathlib/FieldTheory/IntermediateField/Adjoin/Basic.lean
@@ -175,7 +175,7 @@ theorem adjoin_rank_le_of_isAlgebraic (L : IntermediateField F K)
     Module.rank E (adjoin E (L : Set K)) ≤ Module.rank F L := by
   have h : (adjoin E (L.toSubalgebra : Set K)).toSubalgebra =
       Algebra.adjoin E (L.toSubalgebra : Set K) :=
-    L.adjoin_toSubalgebra_of_isAlgebraic E halg
+    L.adjoin_intermediateField_toSubalgebra_of_isAlgebraic E halg
   have := L.toSubalgebra.adjoin_rank_le E
   rwa [(Subalgebra.equivOfEq _ _ h).symm.toLinearEquiv.rank_eq] at this
 

--- a/Mathlib/FieldTheory/KummerExtension.lean
+++ b/Mathlib/FieldTheory/KummerExtension.lean
@@ -525,7 +525,7 @@ lemma isSplittingField_X_pow_sub_C_of_root_adjoin_eq_top
     rw [mem_primitiveRoots finrank_pos] at hζ
     exact X_pow_sub_C_splits_of_isPrimitiveRoot (hζ.map_of_injective (algebraMap K _).injective) ha
   · rw [eq_top_iff, ← IntermediateField.top_toSubalgebra, ← hα,
-      IntermediateField.adjoin_simple_toSubalgebra_of_algebraic (IsAlgebraic.of_finite K α)]
+      IntermediateField.adjoin_simple_toSubalgebra_of_isAlgebraic (IsAlgebraic.of_finite K α)]
     apply Algebra.adjoin_mono
     rw [Set.singleton_subset_iff, mem_rootSet_of_ne (X_pow_sub_C_ne_zero finrank_pos a),
       aeval_def, eval₂_sub, eval₂_X_pow, eval₂_C, ha, sub_self]

--- a/Mathlib/FieldTheory/KummerExtension.lean
+++ b/Mathlib/FieldTheory/KummerExtension.lean
@@ -525,7 +525,7 @@ lemma isSplittingField_X_pow_sub_C_of_root_adjoin_eq_top
     rw [mem_primitiveRoots finrank_pos] at hζ
     exact X_pow_sub_C_splits_of_isPrimitiveRoot (hζ.map_of_injective (algebraMap K _).injective) ha
   · rw [eq_top_iff, ← IntermediateField.top_toSubalgebra, ← hα,
-      IntermediateField.adjoin_simple_toSubalgebra_of_integral (IsIntegral.of_finite K α)]
+      IntermediateField.adjoin_simple_toSubalgebra_of_algebraic (IsAlgebraic.of_finite K α)]
     apply Algebra.adjoin_mono
     rw [Set.singleton_subset_iff, mem_rootSet_of_ne (X_pow_sub_C_ne_zero finrank_pos a),
       aeval_def, eval₂_sub, eval₂_X_pow, eval₂_C, ha, sub_self]

--- a/Mathlib/FieldTheory/LinearDisjoint.lean
+++ b/Mathlib/FieldTheory/LinearDisjoint.lean
@@ -479,8 +479,8 @@ theorem adjoin_rank_eq_rank_left_of_isAlgebraic (H : A.LinearDisjoint L)
   let i : L ≃ₐ[F] L' := AlgEquiv.ofInjectiveField (IsScalarTower.toAlgHom F L E)
   have heq : (adjoin L (A : Set E)).toSubalgebra.toSubsemiring =
       (Algebra.adjoin L' (A : Set E)).toSubsemiring := by
-    rw [adjoin_intermediateField_toSubalgebra_of_isAlgebraic _ _ halg.symm, Algebra.adjoin_toSubsemiring,
-      Algebra.adjoin_toSubsemiring]
+    rw [adjoin_intermediateField_toSubalgebra_of_isAlgebraic _ _ halg.symm,
+      Algebra.adjoin_toSubsemiring, Algebra.adjoin_toSubsemiring]
     congr 2
     ext x
     simp only [Set.mem_range, Subtype.exists]
@@ -512,8 +512,8 @@ theorem lift_adjoin_rank_eq_lift_rank_right_of_isAlgebraic (H : A.LinearDisjoint
   set L' := (IsScalarTower.toAlgHom F L E).range
   have heq : (adjoin L (A : Set E)).toSubalgebra.toSubsemiring =
       (Algebra.adjoin A (L' : Set E)).toSubsemiring := by
-    rw [adjoin_toSubalgebra_of_isAlgebraic _ _ halg.symm, Algebra.adjoin_toSubsemiring,
-      Algebra.adjoin_toSubsemiring, Set.union_comm]
+    rw [adjoin_intermediateField_toSubalgebra_of_isAlgebraic _ _ halg.symm,
+      Algebra.adjoin_toSubsemiring, Algebra.adjoin_toSubsemiring, Set.union_comm]
     congr 2
     ext x
     simp

--- a/Mathlib/FieldTheory/LinearDisjoint.lean
+++ b/Mathlib/FieldTheory/LinearDisjoint.lean
@@ -479,7 +479,7 @@ theorem adjoin_rank_eq_rank_left_of_isAlgebraic (H : A.LinearDisjoint L)
   let i : L ≃ₐ[F] L' := AlgEquiv.ofInjectiveField (IsScalarTower.toAlgHom F L E)
   have heq : (adjoin L (A : Set E)).toSubalgebra.toSubsemiring =
       (Algebra.adjoin L' (A : Set E)).toSubsemiring := by
-    rw [adjoin_toSubalgebra_of_isAlgebraic _ _ halg.symm, Algebra.adjoin_toSubsemiring,
+    rw [adjoin_intermediateField_toSubalgebra_of_isAlgebraic _ _ halg.symm, Algebra.adjoin_toSubsemiring,
       Algebra.adjoin_toSubsemiring]
     congr 2
     ext x

--- a/Mathlib/FieldTheory/PurelyInseparable/PerfectClosure.lean
+++ b/Mathlib/FieldTheory/PurelyInseparable/PerfectClosure.lean
@@ -311,7 +311,7 @@ theorem Field.span_map_pow_expChar_pow_eq_top_of_isSeparable [Algebra.IsSeparabl
     Submodule.span F (Set.range (v · ^ q ^ n)) = ⊤ := by
   rw [← Algebra.top_toSubmodule, ← top_toSubalgebra, ← adjoin_univ,
     adjoin_eq_adjoin_pow_expChar_pow_of_isSeparable' F E _ q n,
-    adjoin_algebraic_toSubalgebra fun x _ ↦ Algebra.IsAlgebraic.isAlgebraic x,
+    adjoin_toSubalgebra_of_isAlgebraic fun x _ ↦ Algebra.IsAlgebraic.isAlgebraic x,
     Set.image_univ, Algebra.adjoin_eq_span]
   have := (MonoidHom.mrange (powMonoidHom (α := E) (q ^ n))).closure_eq
   simp only [MonoidHom.mrange, powMonoidHom, MonoidHom.coe_mk, OneHom.coe_mk,

--- a/Mathlib/FieldTheory/SplittingField/IsSplittingField.lean
+++ b/Mathlib/FieldTheory/SplittingField/IsSplittingField.lean
@@ -179,7 +179,7 @@ theorem IsIntegral.mem_intermediateField_of_minpoly_splits {x : L} (int : IsInte
 theorem isSplittingField_iff_intermediateField : p.IsSplittingField K L ↔
     (p.map (algebraMap K L)).Splits ∧ IntermediateField.adjoin K (p.rootSet L) = ⊤ := by
   rw [← IntermediateField.toSubalgebra_injective.eq_iff,
-      IntermediateField.adjoin_algebraic_toSubalgebra fun _ ↦ isAlgebraic_of_mem_rootSet]
+      IntermediateField.adjoin_toSubalgebra_of_isAlgebraic fun _ ↦ isAlgebraic_of_mem_rootSet]
   exact ⟨fun ⟨spl, adj⟩ ↦ ⟨spl, adj⟩, fun ⟨spl, adj⟩ ↦ ⟨spl, adj⟩⟩
 
 -- Note: p.Splits (algebraMap F E) also works
@@ -188,7 +188,7 @@ theorem IntermediateField.isSplittingField_iff :
   suffices _ → (Algebra.adjoin K (p.rootSet F) = ⊤ ↔ F = adjoin K (p.rootSet L)) by
     exact ⟨fun h ↦ ⟨h.1, (this h.1).mp h.2⟩, fun h ↦ ⟨h.1, (this h.1).mpr h.2⟩⟩
   rw [← toSubalgebra_injective.eq_iff,
-      adjoin_algebraic_toSubalgebra fun x ↦ isAlgebraic_of_mem_rootSet]
+      adjoin_toSubalgebra_of_isAlgebraic fun x ↦ isAlgebraic_of_mem_rootSet]
   refine fun hp ↦ (adjoin_rootSet_eq_range hp F.val).symm.trans ?_
   rw [← F.range_val, eq_comm]
 

--- a/Mathlib/NumberTheory/Cyclotomic/Basic.lean
+++ b/Mathlib/NumberTheory/Cyclotomic/Basic.lean
@@ -481,7 +481,7 @@ theorem _root_.IsPrimitiveRoot.intermediateField_adjoin_isCyclotomicExtension
     [Algebra.IsIntegral K L] {n : ℕ} [NeZero n] {ζ : L} (hζ : IsPrimitiveRoot ζ n) :
     IsCyclotomicExtension {n} K (IntermediateField.adjoin K {ζ}) := by
   change IsCyclotomicExtension {n} K (IntermediateField.adjoin K {ζ}).toSubalgebra
-  rw [IntermediateField.adjoin_simple_toSubalgebra_of_algebraic (IsAlgebraic.isAlgebraic ζ)]
+  rw [IntermediateField.adjoin_simple_toSubalgebra_of_isAlgebraic (IsAlgebraic.isAlgebraic ζ)]
   exact hζ.adjoin_isCyclotomicExtension K
 
 end
@@ -976,7 +976,7 @@ theorem IsCyclotomicExtension.lcm_sup [NeZero n₁] [NeZero n₂] :
 theorem IntermediateField.isCyclotomicExtension_singleton_iff_eq_adjoin (F : IntermediateField K L)
     {ζ : L} (hζ : IsPrimitiveRoot ζ n) :
     IsCyclotomicExtension {n} K F ↔ F = IntermediateField.adjoin K {ζ} := by
-  rw [← toSubalgebra_inj, adjoin_simple_toSubalgebra_of_algebraic
+  rw [← toSubalgebra_inj, adjoin_simple_toSubalgebra_of_isAlgebraic
     (hζ.isIntegral (NeZero.pos _)).tower_top.isAlgebraic]
   exact _root_.isCyclotomicExtension_singleton_iff_eq_adjoin n F.toSubalgebra hζ
 

--- a/Mathlib/NumberTheory/Cyclotomic/Basic.lean
+++ b/Mathlib/NumberTheory/Cyclotomic/Basic.lean
@@ -516,13 +516,13 @@ theorem _root_.IntermediateField.isCyclotomicExtension_adjoin_of_exists_isPrimit
     rintro b ⟨n, hn, h1, h2⟩
     exact ⟨X ^ n - 1, (monic_X_pow_sub_C (1 : K) h1).ne_zero, by simp [h2]⟩
   change IsCyclotomicExtension S K (IntermediateField.toSubalgebra _)
-  rw [congr(IsCyclotomicExtension S K $(IntermediateField.adjoin_algebraic_toSubalgebra key))]
+  rw [congr(IsCyclotomicExtension S K $(IntermediateField.adjoin_toSubalgebra_of_isAlgebraic key))]
   exact Algebra.isCyclotomicExtension_adjoin_of_exists_isPrimitiveRoot S K L h
 
 theorem isSeparable [IsCyclotomicExtension S K L] : Algebra.IsSeparable K L := by
   have := integral S K L
   have h := (IsCyclotomicExtension.iff_adjoin_eq_top S K L).1 ‹_› |>.2
-  rw [← IntermediateField.adjoin_algebraic_toSubalgebra
+  rw [← IntermediateField.adjoin_toSubalgebra_of_isAlgebraic
     fun b _ ↦ Algebra.IsAlgebraic.isAlgebraic b, ← IntermediateField.top_toSubalgebra] at h
   rw [← AlgEquiv.Algebra.isSeparable_iff <|
     (IntermediateField.equivOfEq (IntermediateField.toSubalgebra_injective h)).trans

--- a/Mathlib/NumberTheory/Cyclotomic/Basic.lean
+++ b/Mathlib/NumberTheory/Cyclotomic/Basic.lean
@@ -977,7 +977,7 @@ theorem IntermediateField.isCyclotomicExtension_singleton_iff_eq_adjoin (F : Int
     {ζ : L} (hζ : IsPrimitiveRoot ζ n) :
     IsCyclotomicExtension {n} K F ↔ F = IntermediateField.adjoin K {ζ} := by
   rw [← toSubalgebra_inj, adjoin_simple_toSubalgebra_of_algebraic
-    (hζ.isIntegral.isAlgebraic (NeZero.pos _)).tower_top]
+    (hζ.isIntegral (NeZero.pos _)).tower_top.isAlgebraic]
   exact _root_.isCyclotomicExtension_singleton_iff_eq_adjoin n F.toSubalgebra hζ
 
 theorem IntermediateField.isCyclotomicExtension_eq (F₁ F₂ : IntermediateField K L)

--- a/Mathlib/NumberTheory/Cyclotomic/Basic.lean
+++ b/Mathlib/NumberTheory/Cyclotomic/Basic.lean
@@ -481,7 +481,7 @@ theorem _root_.IsPrimitiveRoot.intermediateField_adjoin_isCyclotomicExtension
     [Algebra.IsIntegral K L] {n : ℕ} [NeZero n] {ζ : L} (hζ : IsPrimitiveRoot ζ n) :
     IsCyclotomicExtension {n} K (IntermediateField.adjoin K {ζ}) := by
   change IsCyclotomicExtension {n} K (IntermediateField.adjoin K {ζ}).toSubalgebra
-  rw [IntermediateField.adjoin_simple_toSubalgebra_of_integral (IsIntegral.isIntegral ζ)]
+  rw [IntermediateField.adjoin_simple_toSubalgebra_of_algebraic (IsAlgebraic.isAlgebraic ζ)]
   exact hζ.adjoin_isCyclotomicExtension K
 
 end
@@ -976,8 +976,8 @@ theorem IsCyclotomicExtension.lcm_sup [NeZero n₁] [NeZero n₂] :
 theorem IntermediateField.isCyclotomicExtension_singleton_iff_eq_adjoin (F : IntermediateField K L)
     {ζ : L} (hζ : IsPrimitiveRoot ζ n) :
     IsCyclotomicExtension {n} K F ↔ F = IntermediateField.adjoin K {ζ} := by
-  rw [← toSubalgebra_inj, adjoin_simple_toSubalgebra_of_integral
-    (hζ.isIntegral (NeZero.pos _)).tower_top]
+  rw [← toSubalgebra_inj, adjoin_simple_toSubalgebra_of_algebraic
+    (hζ.isIntegral.isAlgebraic (NeZero.pos _)).tower_top]
   exact _root_.isCyclotomicExtension_singleton_iff_eq_adjoin n F.toSubalgebra hζ
 
 theorem IntermediateField.isCyclotomicExtension_eq (F₁ F₂ : IntermediateField K L)

--- a/Mathlib/NumberTheory/Cyclotomic/PrimitiveRoots.lean
+++ b/Mathlib/NumberTheory/Cyclotomic/PrimitiveRoots.lean
@@ -408,7 +408,7 @@ theorem norm_pow_sub_one_of_prime_pow_ne_two {k s : ℕ} (hζ : IsPrimitiveRoot 
         exact sub_mem (IntermediateField.mem_adjoin_simple_self K (η + 1)) (one_mem _)
       · exact add_mem (IntermediateField.mem_adjoin_simple_self K η) (one_mem _)
     rw [HKη]
-    have H := IntermediateField.adjoin_simple_toSubalgebra_of_algebraic
+    have H := IntermediateField.adjoin_simple_toSubalgebra_of_isAlgebraic
       ((integral {p ^ (k + 1)} K L).isIntegral (η + 1)).isAlgebraic
     refine IsCyclotomicExtension.equiv _ _ _ (h := ?_) (.refl : K⟮η + 1⟯.toSubalgebra ≃ₐ[K] _)
     rw [H]

--- a/Mathlib/NumberTheory/Cyclotomic/PrimitiveRoots.lean
+++ b/Mathlib/NumberTheory/Cyclotomic/PrimitiveRoots.lean
@@ -409,7 +409,7 @@ theorem norm_pow_sub_one_of_prime_pow_ne_two {k s : ℕ} (hζ : IsPrimitiveRoot 
       · exact add_mem (IntermediateField.mem_adjoin_simple_self K η) (one_mem _)
     rw [HKη]
     have H := IntermediateField.adjoin_simple_toSubalgebra_of_algebraic
-      ((integral {p ^ (k + 1)} K L).isAlgebraic (η + 1))
+      ((integral {p ^ (k + 1)} K L).isIntegral (η + 1)).isAlgebraic
     refine IsCyclotomicExtension.equiv _ _ _ (h := ?_) (.refl : K⟮η + 1⟯.toSubalgebra ≃ₐ[K] _)
     rw [H]
     have hη' : IsPrimitiveRoot (η + 1) (p ^ (k + 1 - s)) := by simpa using hη

--- a/Mathlib/NumberTheory/Cyclotomic/PrimitiveRoots.lean
+++ b/Mathlib/NumberTheory/Cyclotomic/PrimitiveRoots.lean
@@ -409,7 +409,7 @@ theorem norm_pow_sub_one_of_prime_pow_ne_two {k s : ℕ} (hζ : IsPrimitiveRoot 
       · exact add_mem (IntermediateField.mem_adjoin_simple_self K η) (one_mem _)
     rw [HKη]
     have H := IntermediateField.adjoin_simple_toSubalgebra_of_algebraic
-      ((integral {p ^ (k + 1)} K L).isAlgebraic (η + 1))
+      (integral {p ^ (k + 1)} K L (η + 1)).isAlgebraic
     refine IsCyclotomicExtension.equiv _ _ _ (h := ?_) (.refl : K⟮η + 1⟯.toSubalgebra ≃ₐ[K] _)
     rw [H]
     have hη' : IsPrimitiveRoot (η + 1) (p ^ (k + 1 - s)) := by simpa using hη

--- a/Mathlib/NumberTheory/Cyclotomic/PrimitiveRoots.lean
+++ b/Mathlib/NumberTheory/Cyclotomic/PrimitiveRoots.lean
@@ -408,8 +408,8 @@ theorem norm_pow_sub_one_of_prime_pow_ne_two {k s : ℕ} (hζ : IsPrimitiveRoot 
         exact sub_mem (IntermediateField.mem_adjoin_simple_self K (η + 1)) (one_mem _)
       · exact add_mem (IntermediateField.mem_adjoin_simple_self K η) (one_mem _)
     rw [HKη]
-    have H := IntermediateField.adjoin_simple_toSubalgebra_of_integral
-      ((integral {p ^ (k + 1)} K L).isIntegral (η + 1))
+    have H := IntermediateField.adjoin_simple_toSubalgebra_of_algebraic
+      ((integral {p ^ (k + 1)} K L).isAlgebraic (η + 1))
     refine IsCyclotomicExtension.equiv _ _ _ (h := ?_) (.refl : K⟮η + 1⟯.toSubalgebra ≃ₐ[K] _)
     rw [H]
     have hη' : IsPrimitiveRoot (η + 1) (p ^ (k + 1 - s)) := by simpa using hη

--- a/Mathlib/NumberTheory/Cyclotomic/PrimitiveRoots.lean
+++ b/Mathlib/NumberTheory/Cyclotomic/PrimitiveRoots.lean
@@ -409,7 +409,7 @@ theorem norm_pow_sub_one_of_prime_pow_ne_two {k s : ℕ} (hζ : IsPrimitiveRoot 
       · exact add_mem (IntermediateField.mem_adjoin_simple_self K η) (one_mem _)
     rw [HKη]
     have H := IntermediateField.adjoin_simple_toSubalgebra_of_algebraic
-      (integral {p ^ (k + 1)} K L (η + 1)).isAlgebraic
+      ((integral {p ^ (k + 1)} K L).isAlgebraic (η + 1))
     refine IsCyclotomicExtension.equiv _ _ _ (h := ?_) (.refl : K⟮η + 1⟯.toSubalgebra ≃ₐ[K] _)
     rw [H]
     have hη' : IsPrimitiveRoot (η + 1) (p ^ (k + 1 - s)) := by simpa using hη

--- a/Mathlib/NumberTheory/NumberField/InfinitePlace/Basic.lean
+++ b/Mathlib/NumberTheory/NumberField/InfinitePlace/Basic.lean
@@ -389,7 +389,7 @@ theorem _root_.NumberField.is_primitive_element_of_infinitePlace_lt {x : 𝓞 K}
 theorem _root_.NumberField.adjoin_eq_top_of_infinitePlace_lt {x : 𝓞 K} {w : InfinitePlace K}
     (h₁ : x ≠ 0) (h₂ : ∀ ⦃w'⦄, w' ≠ w → w' x < 1) (h₃ : IsReal w ∨ |(w.embedding x).re| < 1) :
     Algebra.adjoin ℚ {(x : K)} = ⊤ := by
-  rw [← IntermediateField.adjoin_simple_toSubalgebra_of_algebraic (IsAlgebraic.of_finite ℚ _)]
+  rw [← IntermediateField.adjoin_simple_toSubalgebra_of_isAlgebraic (IsAlgebraic.of_finite ℚ _)]
   exact congr_arg IntermediateField.toSubalgebra <|
     NumberField.is_primitive_element_of_infinitePlace_lt h₁ h₂ h₃
 

--- a/Mathlib/NumberTheory/NumberField/InfinitePlace/Basic.lean
+++ b/Mathlib/NumberTheory/NumberField/InfinitePlace/Basic.lean
@@ -389,7 +389,7 @@ theorem _root_.NumberField.is_primitive_element_of_infinitePlace_lt {x : 𝓞 K}
 theorem _root_.NumberField.adjoin_eq_top_of_infinitePlace_lt {x : 𝓞 K} {w : InfinitePlace K}
     (h₁ : x ≠ 0) (h₂ : ∀ ⦃w'⦄, w' ≠ w → w' x < 1) (h₃ : IsReal w ∨ |(w.embedding x).re| < 1) :
     Algebra.adjoin ℚ {(x : K)} = ⊤ := by
-  rw [← IntermediateField.adjoin_simple_toSubalgebra_of_integral (IsIntegral.of_finite ℚ _)]
+  rw [← IntermediateField.adjoin_simple_toSubalgebra_of_algebraic (IsAlgebraic.of_finite ℚ _)]
   exact congr_arg IntermediateField.toSubalgebra <|
     NumberField.is_primitive_element_of_infinitePlace_lt h₁ h₂ h₃
 

--- a/Mathlib/RingTheory/IsAdjoinRoot.lean
+++ b/Mathlib/RingTheory/IsAdjoinRoot.lean
@@ -731,7 +731,7 @@ theorem primitive_element_root (h : IsAdjoinRoot E f) : F⟮h.root⟯ = ⊤ :=
 /-- If `α` is primitive in `E/f`, then `E` is given by adjoining a root of `minpoly F α`. -/
 abbrev mkOfPrimitiveElement {α : E} (hα : IsIntegral F α) (hα₂ : F⟮α⟯ = ⊤) :
     IsAdjoinRoot E (minpoly F α) :=
-  mkOfAdjoinEqTop hα (Algebra.adjoin_eq_top_of_primitive_element hα hα₂)
+  mkOfAdjoinEqTop hα (Algebra.adjoin_eq_top_of_primitive_element hα.isAlgebraic hα₂)
 
 /-- If `α` is primitive in `E/f`, then `E` is given by adjoining a root of `minpoly F α`. -/
 abbrev _root_.IsAdjoinRootMonic.mkOfPrimitiveElement


### PR DESCRIPTION
* Prove equivalence of a set of algebraic elements generating an algebra as an algebra and as an intermediate field
* Make assumptions in this section consistently assume `IsAlgebraic` rather than `IsIntegral`
* Make names consistent with naming convention
* Add `simp` lemma giving the underlying subalgebra of an intermediate field when it is generated by a set of algebraic elements

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

When merging, all the commits will be squashed into a single commit
listing all co-authors.

Co-authors in the squash commit are gathered from two sources:

First, all authors of commits to this PR branch are included. Thus,
one way to add co-authors is to include at least one commit authored by
each co-author among the commits in the pull request. If necessary, you
may create empty commits to indicate co-authorship, using commands like so:

git commit --author="Author Name <author@email.com>" --allow-empty -m "add Author Name as coauthor"

Second, co-authors can also be listed in lines at the very bottom of
the commit message (that is, directly before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines
at the bottom of the commit message (before the `---`, and also before
any "Co-authored-by" lines) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
