### PR TITLE
[Merged by Bors] - refactor(Algebra/Polynomial/Splits): begin deprecation

### DIFF
--- a/Mathlib/Algebra/Polynomial/Splits.lean
+++ b/Mathlib/Algebra/Polynomial/Splits.lean
@@ -44,6 +44,10 @@ variable (i : K →+* L)
 @[deprecated (since := "2025-11-24")]
 alias splits_zero := Splits.zero
 
+@[deprecated "Use `Splits.C` instead." (since := "2025-11-24")]
+theorem splits_of_map_eq_C {f : K[X]} {a : L} (h : f.map i = C a) : Splits (f.map i) :=
+  h ▸ Splits.C a
+
 @[deprecated (since := "2025-11-24")]
 alias splits_C := Splits.C
 
@@ -71,6 +75,11 @@ theorem splits_of_splits_mul' {f g : K[X]} (hfg : (f * g).map i ≠ 0) (h : Spli
   simp only [Splits, Polynomial.map_mul, mul_ne_zero_iff] at hfg h
   exact (splits_mul_iff hfg.1 hfg.2).mp h
 
+@[deprecated "Use `Polynomial.map_map` instead." (since := "2025-11-24")]
+theorem splits_map_iff {L : Type*} [CommRing L] (i : K →+* L) (j : L →+* F) {f : K[X]} :
+    Splits ((f.map i).map j) ↔ Splits (f.map (j.comp i)) := by
+  rw [Polynomial.map_map]
+
 @[deprecated (since := "2025-11-24")]
 alias splits_one := Splits.one
 
@@ -91,6 +100,11 @@ alias splits_pow := Splits.pow
 
 @[deprecated (since := "2025-11-24")]
 alias splits_X_pow := Splits.X_pow
+
+@[deprecated "Use `Polynomial.map_id` instead." (since := "2025-11-24")]
+theorem splits_id_iff_splits {f : K[X]} :
+    ((f.map i).map (RingHom.id L)).Splits ↔ (f.map i).Splits := by
+  rw [map_id]
 
 variable {i}
 

--- a/Mathlib/Algebra/Polynomial/Splits.lean
+++ b/Mathlib/Algebra/Polynomial/Splits.lean
@@ -105,7 +105,7 @@ theorem Splits.comp_of_degree_le_one {f : L[X]} {p : L[X]} (hd : p.degree ≤ 1)
   grw [sub_comp, X_comp, C_comp, degree_sub_le, hd, degree_C_le, max_eq_left zero_le_one]
 
 @[deprecated (since := "2025-11-24")]
-alias comp_of_map_degree_le_one := Splits.comp_of_degree_le_one
+alias Splits.comp_of_map_degree_le_one := Splits.comp_of_degree_le_one
 
 theorem splits_iff_comp_splits_of_degree_eq_one {f : L[X]} {p : L[X]} (hd : p.degree = 1) :
     f.Splits ↔ (f.comp p).Splits := by

--- a/Mathlib/Algebra/Polynomial/Splits.lean
+++ b/Mathlib/Algebra/Polynomial/Splits.lean
@@ -41,29 +41,26 @@ section CommRing
 variable [CommRing K] [Field L] [Field F]
 variable (i : K →+* L)
 
-theorem splits_zero : Splits (0 : K[X]) := by
-  simp
+@[deprecated (since := "2025-11-24")]
+alias splits_zero := Splits.zero
 
-theorem splits_of_map_eq_C {f : K[X]} {a : L} (h : f.map i = C a) : Splits (f.map i) := by
-  simp [h]
+@[deprecated (since := "2025-11-24")]
+alias splits_C := Splits.C
 
-theorem splits_C (a : K) : Splits (C a) := by
-  simp
+@[deprecated (since := "2025-11-24")]
+alias splits_of_map_degree_eq_one := Splits.of_degree_eq_one
 
-theorem splits_of_map_degree_eq_one {f : K[X]} (hf : degree (f.map i) = 1) : Splits (f.map i) :=
-  Splits.of_degree_eq_one hf
+@[deprecated (since := "2025-11-24")]
+alias splits_of_degree_le_one := Splits.of_degree_le_one
 
-theorem splits_of_degree_le_one {f : K[X]} (hf : degree f ≤ 1) : Splits (f.map i) :=
-  Splits.of_degree_le_one (degree_map_le.trans hf)
+@[deprecated (since := "2025-11-24")]
+alias splits_of_degree_eq_one := Splits.of_degree_eq_one
 
-theorem splits_of_degree_eq_one {f : K[X]} (hf : degree f = 1) : Splits (f.map i) :=
-  splits_of_degree_le_one i hf.le
+@[deprecated (since := "2025-11-24")]
+alias splits_of_natDegree_le_one := Splits.of_natDegree_le_one
 
-theorem splits_of_natDegree_le_one {f : K[X]} (hf : natDegree f ≤ 1) : Splits (f.map i) :=
-  splits_of_degree_le_one i (degree_le_of_natDegree_le hf)
-
-theorem splits_of_natDegree_eq_one {f : K[X]} (hf : natDegree f = 1) : Splits (f.map i) :=
-  splits_of_natDegree_le_one i (le_of_eq hf)
+@[deprecated (since := "2025-11-24")]
+alias splits_of_natDegree_eq_one := Splits.of_natDegree_eq_one
 
 theorem splits_mul {f g : K[X]} (hf : Splits (f.map i)) (hg : Splits (g.map i)) :
     Splits ((f * g).map i) := by
@@ -74,106 +71,68 @@ theorem splits_of_splits_mul' {f g : K[X]} (hfg : (f * g).map i ≠ 0) (h : Spli
   simp only [Splits, Polynomial.map_mul, mul_ne_zero_iff] at hfg h
   exact (splits_mul_iff hfg.1 hfg.2).mp h
 
-theorem splits_map_iff {L : Type*} [CommRing L] (i : K →+* L) (j : L →+* F) {f : K[X]} :
-    Splits ((f.map i).map j) ↔ Splits (f.map (j.comp i)) := by
-  simp [Splits, Polynomial.map_map]
-
-theorem splits_one : Splits (map i 1) :=
-  map_C i ▸ splits_C _
+@[deprecated (since := "2025-11-24")]
+alias splits_one := Splits.one
 
 theorem splits_of_isUnit [IsDomain K] {u : K[X]} (hu : IsUnit u) : (u.map i).Splits :=
-  (isUnit_iff.mp hu).choose_spec.2 ▸ map_C i ▸ splits_C _
+  (isUnit_iff.mp hu).choose_spec.2 ▸ map_C i ▸ Splits.C _
 
-theorem splits_X_sub_C {x : K} : ((X - C x).map i).Splits :=
-  splits_of_degree_le_one _ <| degree_X_sub_C_le _
+@[deprecated (since := "2025-11-24")]
+alias splits_X_sub_C := Splits.X_sub_C
 
-theorem splits_X : (X.map i).Splits :=
-  splits_of_degree_le_one _ degree_X_le
+@[deprecated (since := "2025-11-24")]
+alias splits_X := Splits.X
 
-theorem splits_prod {ι : Type u} {s : ι → K[X]} {t : Finset ι} :
-    (∀ j ∈ t, ((s j).map i).Splits) → ((∏ x ∈ t, s x).map i).Splits := by
-  classical
-  refine Finset.induction_on t (fun _ => splits_one i) fun a t hat ih ht => ?_
-  rw [Finset.forall_mem_insert] at ht; rw [Finset.prod_insert hat]
-  exact splits_mul i ht.1 (ih ht.2)
+@[deprecated (since := "2025-11-24")]
+alias splits_prod := Splits.prod
 
-theorem splits_pow {f : K[X]} (hf : (f.map i).Splits) (n : ℕ) : ((f ^ n).map i).Splits := by
-  rw [← Finset.card_range n, ← Finset.prod_const]
-  exact splits_prod i fun j _ => hf
+@[deprecated (since := "2025-11-24")]
+alias splits_pow := Splits.pow
 
-theorem splits_X_pow (n : ℕ) : ((X ^ n).map i).Splits :=
-  splits_pow i (splits_X i) n
-
-theorem splits_id_iff_splits {f : K[X]} :
-    ((f.map i).map (RingHom.id L)).Splits ↔ (f.map i).Splits := by
-  rw [splits_map_iff, RingHom.id_comp]
+@[deprecated (since := "2025-11-24")]
+alias splits_X_pow := Splits.X_pow
 
 variable {i}
 
--- TODO: Prove the analogous composition theorems for `Factors`
-theorem Splits.comp_of_map_degree_le_one {f : K[X]} {p : K[X]} (hd : (p.map i).degree ≤ 1)
-    (h : (f.map i).Splits) : ((f.comp p).map i).Splits := by
-  rw [splits_iff_splits] at h ⊢
-  by_cases hzero : map i (f.comp p) = 0
-  · exact Or.inl hzero
-  cases h with
-  | inl h0 =>
-    exact Or.inl <| map_comp i _ _ ▸ h0.symm ▸ zero_comp
-  | inr h =>
-    right
-    intro g irr dvd
-    rw [map_comp] at dvd hzero
-    cases lt_or_eq_of_le hd with
-    | inl hd =>
-      rw [eq_C_of_degree_le_zero (Nat.WithBot.lt_one_iff_le_zero.mp hd), comp_C] at dvd hzero
-      refine False.elim (irr.1 (isUnit_of_dvd_unit dvd ?_))
-      simpa using hzero
-    | inr hd =>
-      let _ := invertibleOfNonzero (leadingCoeff_ne_zero.mpr
-          (ne_zero_of_degree_gt (n := ⊥) (by rw [hd]; decide)))
-      rw [eq_X_add_C_of_degree_eq_one hd, dvd_comp_C_mul_X_add_C_iff _ _] at dvd
-      have := h (irr.map (algEquivCMulXAddC _ _).symm) dvd
-      rw [degree_eq_natDegree irr.ne_zero]
-      rwa [algEquivCMulXAddC_symm_apply, ← comp_eq_aeval,
-        degree_eq_natDegree (fun h => WithBot.bot_ne_one (h ▸ this)),
-        natDegree_comp, natDegree_C_mul (invertibleInvOf.ne_zero),
-        natDegree_X_sub_C, mul_one] at this
+theorem Splits.comp_of_degree_le_one {f : L[X]} {p : L[X]} (hd : p.degree ≤ 1)
+    (h : f.Splits) : (f.comp p).Splits := by
+  obtain ⟨m, hm⟩ := splits_iff_exists_multiset.mp h
+  rw [hm, mul_comp, C_comp, multiset_prod_comp]
+  refine (Splits.C _).mul (Splits.multisetProd ?_)
+  simp only [Multiset.mem_map]
+  rintro - ⟨-, ⟨a, -, rfl⟩, rfl⟩
+  apply Splits.of_degree_le_one
+  grw [sub_comp, X_comp, C_comp, degree_sub_le, hd, degree_C_le, max_eq_left zero_le_one]
 
-theorem splits_iff_comp_splits_of_degree_eq_one {f : K[X]} {p : K[X]} (hd : (p.map i).degree = 1) :
-    (f.map i).Splits ↔ ((f.comp p).map i).Splits := by
-  rw [← splits_id_iff_splits, ← splits_id_iff_splits (f := f.comp p), map_comp]
-  refine ⟨fun h => Splits.comp_of_map_degree_le_one
-    (le_of_eq (map_id (R := L) ▸ hd)) h, fun h => ?_⟩
+@[deprecated (since := "2025-11-24")]
+alias comp_of_map_degree_le_one := Splits.comp_of_degree_le_one
+
+theorem splits_iff_comp_splits_of_degree_eq_one {f : L[X]} {p : L[X]} (hd : p.degree = 1) :
+    f.Splits ↔ (f.comp p).Splits := by
+  refine ⟨Splits.comp_of_degree_le_one hd.le, fun h ↦ ?_⟩
   let _ := invertibleOfNonzero (leadingCoeff_ne_zero.mpr
       (ne_zero_of_degree_gt (n := ⊥) (by rw [hd]; decide)))
-  have : (map i f) = ((map i f).comp (map i p)).comp ((C ⅟(map i p).leadingCoeff *
-      (X - C ((map i p).coeff 0)))) := by
+  have : f = (f.comp p).comp ((C ⅟p.leadingCoeff *
+      (X - C (p.coeff 0)))) := by
     rw [comp_assoc]
     nth_rw 1 [eq_X_add_C_of_degree_eq_one hd]
-    simp only [coeff_map, invOf_eq_inv, mul_sub, ← C_mul, add_comp, mul_comp, C_comp, X_comp,
+    simp only [invOf_eq_inv, mul_sub, ← C_mul, add_comp, mul_comp, C_comp, X_comp,
       ← mul_assoc]
     simp
-  refine this ▸ Splits.comp_of_map_degree_le_one ?_ h
-  simp [degree_C (inv_ne_zero (Invertible.ne_zero (a := (map i p).leadingCoeff)))]
+  rw [this]
+  refine Splits.comp_of_degree_le_one ?_ h
+  simp [degree_C (inv_ne_zero (Invertible.ne_zero (a := p.leadingCoeff)))]
 
-/--
-This is a weaker variant of `Splits.comp_of_map_degree_le_one`,
-but its conditions are easier to check.
--/
-theorem Splits.comp_of_degree_le_one {f : K[X]} {p : K[X]} (hd : p.degree ≤ 1)
-    (h : (f.map i).Splits) : ((f.comp p).map i).Splits :=
-  Splits.comp_of_map_degree_le_one (degree_map_le.trans hd) h
-
-theorem Splits.comp_X_sub_C (a : K) {f : K[X]}
-    (h : (f.map i).Splits) : ((f.comp (X - C a)).map i).Splits :=
+theorem Splits.comp_X_sub_C (a : L) {f : L[X]}
+    (h : f.Splits) : (f.comp (X - C a)).Splits :=
   Splits.comp_of_degree_le_one (degree_X_sub_C_le _) h
 
-theorem Splits.comp_X_add_C (a : K) {f : K[X]}
-    (h : (f.map i).Splits) : ((f.comp (X + C a)).map i).Splits :=
-  Splits.comp_of_degree_le_one (by simpa using degree_X_sub_C_le (-a)) h
+theorem Splits.comp_X_add_C (a : L) {f : L[X]}
+    (h : f.Splits) : (f.comp (X + C a)).Splits :=
+  Splits.comp_of_degree_le_one (degree_X_add_C a).le h
 
-theorem Splits.comp_neg_X {f : K[X]} (h : (f.map i).Splits) : ((f.comp (-X)).map i).Splits :=
-  Splits.comp_of_degree_le_one (by simpa using degree_X_sub_C_le (0 : K)) h
+theorem Splits.comp_neg_X {f : L[X]} (h : f.Splits) : (f.comp (-X)).Splits :=
+  Splits.comp_of_degree_le_one (by rw [degree_neg, degree_X]) h
 
 variable (i)
 
@@ -246,7 +205,7 @@ theorem splits_prod_iff {ι : Type u} {s : ι → K[X]} {t : Finset ι} :
   classical
   refine
     Finset.induction_on t (fun _ =>
-        ⟨fun _ _ h => by simp only [Finset.notMem_empty] at h, fun _ => splits_one i⟩)
+        ⟨fun _ _ h => by simp only [Finset.notMem_empty] at h, by simp⟩)
       fun a t hat ih ht => ?_
   rw [Finset.forall_mem_insert] at ht ⊢
   rw [Finset.prod_insert hat, Polynomial.map_mul, splits_mul_iff (map_ne_zero ht.1)
@@ -430,7 +389,7 @@ theorem splits_id_of_splits {f : K[X]} (h : Splits (f.map i))
 
 theorem splits_comp_of_splits (i : R →+* K) (j : K →+* L) {f : R[X]} (h : Splits (f.map i)) :
     Splits (f.map (j.comp i)) :=
-  (splits_map_iff i j).mp (splits_of_splits_id _ <| (splits_map_iff i <| .id K).mpr h)
+  f.map_map i j ▸ h.map j
 
 variable [Algebra R K] [Algebra R L]
 

--- a/Mathlib/FieldTheory/AbelRuffini.lean
+++ b/Mathlib/FieldTheory/AbelRuffini.lean
@@ -181,8 +181,9 @@ theorem gal_X_pow_sub_C_isSolvable (n : ℕ) (x : F) : IsSolvable (X ^ n - C x).
   · exact gal_X_pow_sub_one_isSolvable n
   · rw [Polynomial.map_sub, Polynomial.map_pow, map_X, map_C]
     apply gal_X_pow_sub_C_isSolvable_aux
+    rw [map_id]
     have key := SplittingField.splits (X ^ n - 1 : F[X])
-    rwa [← splits_id_iff_splits, Polynomial.map_sub, Polynomial.map_pow, map_X,
+    rwa [Polynomial.map_sub, Polynomial.map_pow, map_X,
       Polynomial.map_one] at key
 
 end GalXPowSubC

--- a/Mathlib/FieldTheory/Fixed.lean
+++ b/Mathlib/FieldTheory/Fixed.lean
@@ -259,11 +259,11 @@ variable [Finite G]
 instance normal : Normal (FixedPoints.subfield G F) F where
   isAlgebraic x := (isIntegral G F x).isAlgebraic
   splits' x :=
-    (Polynomial.splits_id_iff_splits _).1 <| by
+    by
       cases nonempty_fintype G
       rw [← minpoly_eq_minpoly, minpoly, coe_algebraMap, ← Subfield.toSubring_subtype_eq_subtype,
         Polynomial.map_toSubring _ (subfield G F).toSubring, prodXSubSMul]
-      exact Polynomial.splits_prod _ fun _ _ => Polynomial.splits_X_sub_C _
+      exact Polynomial.Splits.prod fun _ _ => Polynomial.Splits.X_sub_C _
 
 instance isSeparable : Algebra.IsSeparable (FixedPoints.subfield G F) F := by
   classical

--- a/Mathlib/FieldTheory/Galois/Basic.lean
+++ b/Mathlib/FieldTheory/Galois/Basic.lean
@@ -524,7 +524,7 @@ theorem of_separable_splitting_field_aux [hFE : FiniteDimensional F E] [sp : p.I
   rw [← @IntermediateField.card_algHom_adjoin_integral K _ E _ _ x E _ (RingHom.toAlgebra f) h]
   · exact Polynomial.Separable.of_dvd ((Polynomial.separable_map (algebraMap F K)).mpr hp) h2
   · refine Polynomial.splits_of_splits_of_dvd _ (Polynomial.map_ne_zero h1) ?_ h2
-    rw [Polynomial.splits_map_iff, ← IsScalarTower.algebraMap_eq]
+    rw [Polynomial.map_map, ← IsScalarTower.algebraMap_eq]
     exact sp.splits
 
 theorem of_separable_splitting_field [sp : p.IsSplittingField F E] (hp : p.Separable) :
@@ -547,7 +547,7 @@ theorem of_separable_splitting_field [sp : p.IsSplittingField F E] (hp : p.Separ
   · have key := IntermediateField.card_algHom_adjoin_integral F (K := E)
       (show IsIntegral F (0 : E) from isIntegral_zero)
     rw [IsSeparable, minpoly.zero, Polynomial.natDegree_X] at key
-    specialize key Polynomial.separable_X (Polynomial.splits_X (algebraMap F E))
+    specialize key Polynomial.separable_X (Polynomial.Splits.X.map (algebraMap F E))
     rw [← @Subalgebra.finrank_bot F E _ _ _, ← IntermediateField.bot_toSubalgebra] at key
     refine Eq.trans ?_ key
     apply Nat.card_congr
@@ -584,7 +584,7 @@ theorem sup_right (K L : IntermediateField F E) [IsGalois F K] [FiniteDimensiona
   suffices T'.IsSplittingField L E from IsGalois.of_separable_splitting_field (p := T') hT₁.map
   rw [isSplittingField_iff_intermediateField] at hT₂ ⊢
   constructor
-  · rw [Polynomial.splits_map_iff, ← IsScalarTower.algebraMap_eq]
+  · rw [Polynomial.map_map, ← IsScalarTower.algebraMap_eq]
     exact Polynomial.splits_of_algHom hT₂.1 (IsScalarTower.toAlgHom _ _ _)
   · have h' : T'.rootSet E = T.rootSet E := by simp [Set.ext_iff, Polynomial.mem_rootSet', T']
     rw [← lift_inj, lift_adjoin, ← coe_val, T.image_rootSet hT₂.1] at hT₂

--- a/Mathlib/FieldTheory/IntermediateField/Adjoin/Basic.lean
+++ b/Mathlib/FieldTheory/IntermediateField/Adjoin/Basic.lean
@@ -151,9 +151,9 @@ theorem isSplittingField_iSup {p : ι → K[X]}
     (∏ i ∈ s, p i).IsSplittingField K (⨆ i ∈ s, t i : IntermediateField K L) := by
   let F : IntermediateField K L := ⨆ i ∈ s, t i
   have hF : ∀ i ∈ s, t i ≤ F := fun i hi ↦ le_iSup_of_le i (le_iSup (fun _ ↦ t i) hi)
-  simp only [isSplittingField_iff] at h ⊢
+  simp only [isSplittingField_iff, Polynomial.map_prod] at h ⊢
   refine
-    ⟨splits_prod (algebraMap K F) fun i hi ↦
+    ⟨Splits.prod fun i hi ↦
         splits_comp_of_splits (algebraMap K (t i)) (inclusion (hF i hi)).toRingHom
           (h i hi).1,
       ?_⟩

--- a/Mathlib/FieldTheory/IsAlgClosed/AlgebraicClosure.lean
+++ b/Mathlib/FieldTheory/IsAlgClosed/AlgebraicClosure.lean
@@ -188,8 +188,8 @@ instance isAlgebraic : Algebra.IsAlgebraic k (AlgebraicClosure k) :=
           simp⟩
 
 instance : IsAlgClosure k (AlgebraicClosure k) := .of_splits fun f hf _ ↦ by
-  rw [show f = (⟨f, hf⟩ : Monics k) from rfl, ← splits_id_iff_splits, Monics.map_eq_prod]
-  exact splits_prod _ fun _ _ ↦ (splits_id_iff_splits _).mpr (splits_X_sub_C _)
+  rw [show f = (⟨f, hf⟩ : Monics k) from rfl, Monics.map_eq_prod]
+  exact Splits.prod fun _ _ ↦ (Splits.X_sub_C _).map _
 
 instance isAlgClosed : IsAlgClosed (AlgebraicClosure k) := IsAlgClosure.isAlgClosed k
 

--- a/Mathlib/FieldTheory/IsAlgClosed/Basic.lean
+++ b/Mathlib/FieldTheory/IsAlgClosed/Basic.lean
@@ -304,8 +304,7 @@ theorem IsAlgClosure.of_splits {R K} [CommRing R] [IsDomain R] [Field K] [Algebr
   isAlgebraic := inferInstance
   isAlgClosed := .of_exists_root _ fun _p _ p_irred ↦
     have ⟨g, monic, irred, dvd⟩ := p_irred.exists_dvd_monic_irreducible_of_isIntegral (K := R)
-    exists_root_of_splits _ (splits_of_splits_of_dvd _ (map_monic_ne_zero monic)
-      ((splits_id_iff_splits _).mpr <| h g monic irred) dvd) <|
+    Splits.exists_eval_eq_zero (Splits.of_dvd (h g monic irred) (map_monic_ne_zero monic) dvd) <|
         degree_ne_of_natDegree_ne p_irred.natDegree_pos.ne'
 
 namespace IsAlgClosed

--- a/Mathlib/FieldTheory/Isaacs.lean
+++ b/Mathlib/FieldTheory/Isaacs.lean
@@ -46,7 +46,8 @@ theorem nonempty_algHom_of_exist_roots (h : ∀ x : E, ∃ y : K, aeval y (minpo
   have splits s (hs : s ∈ S) : ((minpoly F s).map (algebraMap F K')).Splits := by
     apply splits_of_splits_of_dvd _
       (Finset.prod_ne_zero_iff.mpr fun _ _ ↦ minpoly.ne_zero <| (alg.isIntegral).1 _)
-      ((splits_map_iff _ _).mp <| SplittingField.splits p) (Finset.dvd_prod_of_mem _ hs)
+      (map_map (algebraMap F K) (algebraMap K p.SplittingField) _ ▸ SplittingField.splits p)
+      (Finset.dvd_prod_of_mem _ hs)
   let K₀ := (⊥ : IntermediateField K K').restrictScalars F
   let FS := adjoin F (S : Set E)
   let Ω := FS →ₐ[F] K'

--- a/Mathlib/FieldTheory/KummerExtension.lean
+++ b/Mathlib/FieldTheory/KummerExtension.lean
@@ -60,7 +60,7 @@ theorem X_pow_sub_C_splits_of_isPrimitiveRoot
     (X ^ n - C a).Splits := by
   cases n.eq_zero_or_pos with
   | inl hn =>
-    simp only [hn, pow_zero, ← C.map_one, ← map_sub, splits_C]
+    simp only [hn, pow_zero, ← C.map_one, ← map_sub, Splits.C]
   | inr hn =>
     rw [splits_iff_card_roots, ← nthRoots, hζ.card_nthRoots, natDegree_X_pow_sub_C, if_pos ⟨α, e⟩]
 

--- a/Mathlib/FieldTheory/Normal/Basic.lean
+++ b/Mathlib/FieldTheory/Normal/Basic.lean
@@ -38,8 +38,8 @@ theorem Normal.exists_isSplittingField [h : Normal F K] [FiniteDimensional F K] 
   classical
   let s := Module.Basis.ofVectorSpace F K
   refine
-    ⟨∏ x, minpoly F (s x), splits_prod _ fun x _ => h.splits (s x),
-      Subalgebra.toSubmodule.injective ?_⟩
+    ⟨∏ x, minpoly F (s x), Polynomial.map_prod (algebraMap F K) _ _ ▸
+      Splits.prod fun x _ => h.splits (s x), Subalgebra.toSubmodule.injective ?_⟩
   rw [Algebra.top_toSubmodule, eq_top_iff, ← s.span_eq, Submodule.span_le, Set.range_subset_iff]
   refine fun x =>
     Algebra.subset_adjoin
@@ -80,7 +80,7 @@ theorem Normal.of_isSplittingField (p : F[X]) [hFEp : IsSplittingField F E p] : 
       rw [← IsSplittingField.adjoin_rootSet_eq_range E p j,
             IsSplittingField.adjoin_rootSet_eq_range E p (j'.restrictScalars F)]
       exact ⟨x, (j'.commutes _).trans (algHomAdjoinIntegralEquiv_symm_apply_gen F hx _)⟩
-    · rw [splits_map_iff, ← IsScalarTower.algebraMap_eq]; exact hL.1
+    · rw [Polynomial.map_map, ← IsScalarTower.algebraMap_eq]; exact hL.1
   · rw [Polynomial.map_ne_zero_iff (algebraMap F L).injective, mul_ne_zero_iff]
     exact ⟨hp, minpoly.ne_zero hx⟩
 
@@ -191,7 +191,7 @@ noncomputable def AlgHom.liftNormal [h : Normal F E] : E →ₐ[F] E :=
         ((IsScalarTower.toAlgHom F K₂ E).comp ϕ).toRingHom.toAlgebra _
         (fun x _ ↦ ⟨(h.out x).1.tower_top,
           splits_of_splits_of_dvd _ (map_ne_zero (minpoly.ne_zero (h.out x).1))
-            (by rw [splits_map_iff, ← IsScalarTower.algebraMap_eq]
+            (by rw [Polynomial.map_map, ← IsScalarTower.algebraMap_eq]
                 exact (h.out x).2)
             (minpoly.dvd_map_of_isScalarTower F K₁ x)⟩)
         (IntermediateField.adjoin_univ _ _)
@@ -291,5 +291,5 @@ instance Algebra.IsQuadraticExtension.normal (F K : Type*) [Field F] [Field K] [
   splits' := by
     intro x
     obtain h | h := le_iff_lt_or_eq.mp (finrank_eq_two F K ▸ minpoly.natDegree_le x)
-    · exact splits_of_natDegree_le_one _ (by rwa [Nat.le_iff_lt_add_one])
+    · exact Splits.of_natDegree_le_one <| natDegree_map_le.trans (by rwa [Nat.le_iff_lt_add_one])
     · exact splits_of_natDegree_eq_two _ h (minpoly.aeval F x)

--- a/Mathlib/FieldTheory/Normal/Defs.lean
+++ b/Mathlib/FieldTheory/Normal/Defs.lean
@@ -57,7 +57,7 @@ variable (F K)
 
 instance normal_self : Normal F F where
   isAlgebraic := fun _ => isIntegral_algebraMap.isAlgebraic
-  splits' := fun x => (minpoly.eq_X_sub_C' x).symm ▸ splits_X_sub_C _
+  splits' := fun x => (minpoly.eq_X_sub_C' x).symm ▸ by simp
 
 section NormalTower
 
@@ -72,7 +72,7 @@ theorem Normal.tower_top_of_normal [h : Normal F E] : Normal K E :=
       ⟨hx.tower_top,
         Polynomial.splits_of_splits_of_dvd (algebraMap K E)
           (Polynomial.map_ne_zero (minpoly.ne_zero hx))
-          ((Polynomial.splits_map_iff (algebraMap F K) (algebraMap K E)).mpr hhx)
+          (map_map (algebraMap F K) (algebraMap K E) (minpoly F x) ▸ hhx)
           (minpoly.dvd_map_of_isScalarTower F K x)⟩
 
 theorem AlgHom.normal_bijective [h : Normal F E] (ϕ : E →ₐ[F] K) : Function.Bijective ϕ :=
@@ -98,7 +98,7 @@ theorem Normal.of_equiv_equiv {M N : Type*} [Field N] [Field M] [Algebra M N]
   intro x
   rw [← g.apply_symm_apply x]
   refine ⟨(h (g.symm x)).1.map_of_comp_eq _ _ hcomp, ?_⟩
-  rw [← minpoly.map_eq_of_equiv_equiv hcomp, Polynomial.splits_map_iff, hcomp]
+  rw [← minpoly.map_eq_of_equiv_equiv hcomp, map_map, hcomp]
   exact Polynomial.splits_comp_of_splits _ _ (h (g.symm x)).2
 
 end NormalTower

--- a/Mathlib/FieldTheory/PolynomialGaloisGroup.lean
+++ b/Mathlib/FieldTheory/PolynomialGaloisGroup.lean
@@ -301,7 +301,7 @@ theorem splits_in_splittingField_of_comp (hq : q.natDegree ≠ 0) :
   have key1 : ∀ {r : F[X]}, Irreducible r → P r := by
     intro r hr
     by_cases hr' : natDegree r = 0
-    · exact splits_of_natDegree_le_one _ (le_trans (le_of_eq hr') zero_le_one)
+    · exact Splits.of_natDegree_le_one <| natDegree_map_le.trans (hr'.trans_le zero_le_one)
     obtain ⟨x, hx⟩ :=
       exists_root_of_splits _ (SplittingField.splits (r.comp q)) fun h =>
         hr'

--- a/Mathlib/FieldTheory/PurelyInseparable/Basic.lean
+++ b/Mathlib/FieldTheory/PurelyInseparable/Basic.lean
@@ -464,8 +464,8 @@ instance IsPurelyInseparable.normal [IsPurelyInseparable F E] : Normal F E where
   toIsAlgebraic := isAlgebraic F E
   splits' x := by
     obtain ⟨n, h⟩ := IsPurelyInseparable.minpoly_eq_X_sub_C_pow F (ringExpChar F) x
-    rw [← splits_id_iff_splits, h]
-    exact splits_pow _ (splits_X_sub_C _) _
+    rw [h]
+    exact Splits.pow (Splits.X_sub_C _) _
 
 /-- If `E / F` is algebraic, then `E` is purely inseparable over the
 separable closure of `F` in `E`. -/

--- a/Mathlib/FieldTheory/SplittingField/Construction.lean
+++ b/Mathlib/FieldTheory/SplittingField/Construction.lean
@@ -170,12 +170,13 @@ protected theorem splits (n : ℕ) :
   Nat.recOn (motive := fun n => ∀ {K : Type u} [Field K], ∀ (f : K[X]) (_hfn : f.natDegree = n),
       Splits (f.map (algebraMap K <| SplittingFieldAux n f))) n
     (fun {_} _ _ hf =>
-      splits_of_degree_le_one _
+      Splits.of_degree_le_one <| degree_map_le.trans
         (le_trans degree_le_natDegree <| hf.symm ▸ WithBot.coe_le_coe.2 zero_le_one))
     fun n ih {K} _ f hf => by
-    rw [← splits_id_iff_splits, algebraMap_succ, ← map_map, splits_id_iff_splits,
+    rw [algebraMap_succ, ← map_map,
       ← X_sub_C_mul_removeFactor f fun h => by rw [h] at hf; cases hf]
-    exact splits_mul _ (splits_X_sub_C _) (ih _ (natDegree_removeFactor' hf))
+    rw [Polynomial.map_mul]
+    exact Splits.mul ((Splits.X_sub_C _).map _) (ih _ (natDegree_removeFactor' hf))
 
 theorem adjoin_rootSet (n : ℕ) :
     ∀ {K : Type u} [Field K],

--- a/Mathlib/FieldTheory/SplittingField/IsSplittingField.lean
+++ b/Mathlib/FieldTheory/SplittingField/IsSplittingField.lean
@@ -64,7 +64,7 @@ section ScalarTower
 variable [Algebra F K] [Algebra F L] [IsScalarTower F K L]
 
 instance map (f : F[X]) [IsSplittingField F L f] : IsSplittingField K L (f.map <| algebraMap F K) :=
-  ⟨by rw [splits_map_iff, ← IsScalarTower.algebraMap_eq]; exact splits L f,
+  ⟨by rw [map_map, ← IsScalarTower.algebraMap_eq]; exact splits L f,
     Subalgebra.restrictScalars_injective F <| by
       rw [rootSet, aroots, map_map, ← IsScalarTower.algebraMap_eq, Subalgebra.restrictScalars_top,
         eq_top_iff, ← adjoin_rootSet L f, Algebra.adjoin_le_iff]
@@ -96,7 +96,7 @@ theorem mul (f g : F[X]) (hf : f ≠ 0) (hg : g ≠ 0) [IsSplittingField F K f]
     [IsSplittingField K L (g.map <| algebraMap F K)] : IsSplittingField F L (f * g) :=
   ⟨(IsScalarTower.algebraMap_eq F K L).symm ▸
       splits_mul _ (splits_comp_of_splits _ _ (splits K f))
-        ((splits_map_iff _ _).1 (splits L <| g.map <| algebraMap F K)), by
+        (map_map (algebraMap F K) (algebraMap K L) g ▸ (splits L <| g.map <| algebraMap F K)), by
     classical
     rw [rootSet, aroots_mul (mul_ne_zero hf hg),
       Multiset.toFinset_add, Finset.coe_union, Algebra.adjoin_union_eq_adjoin_adjoin,

--- a/Mathlib/RingTheory/Adjoin/Field.lean
+++ b/Mathlib/RingTheory/Adjoin/Field.lean
@@ -85,8 +85,8 @@ theorem Polynomial.lift_of_splits {F K L : Type*} [Field F] [Field K] [Field L] 
     have H5 : IsIntegral Ks a := H1.tower_top
     have H6 : ((minpoly Ks a).map (algebraMap Ks L)).Splits := by
       refine splits_of_splits_of_dvd _ ((minpoly.monic H1).map (algebraMap F Ks)).ne_zero
-        ((splits_map_iff _ _).2 ?_) (minpoly.dvd _ _ ?_)
-      · rw [← IsScalarTower.algebraMap_eq]
+        ?_ (minpoly.dvd _ _ ?_)
+      · rw [map_map, ← IsScalarTower.algebraMap_eq]
         exact H2
       · rw [Polynomial.aeval_map_algebraMap, minpoly.aeval]
     obtain ⟨y, hy⟩ := Polynomial.exists_root_of_splits _ H6 (minpoly.degree_pos H5).ne'
@@ -115,14 +115,14 @@ theorem IsIntegral.mem_range_algebraMap_of_minpoly_splits [Algebra K L] [IsScala
 theorem minpoly_neg_splits [Algebra K L] {x : L} (g : ((minpoly K x).map (algebraMap K L)).Splits) :
     ((minpoly K (-x)).map (algebraMap K L)).Splits := by
   rw [minpoly.neg]
-  apply splits_mul _ _ g.comp_neg_X
+  apply splits_mul _ _ (by simpa [map_comp] using g.comp_neg_X)
   simpa only [map_pow, map_neg, map_one] using
-    (map_C (algebraMap K L) ▸ splits_C (algebraMap K L <| (-1) ^ _) :)
+    (map_C (algebraMap K L) ▸ Splits.C (algebraMap K L <| (-1) ^ _) :)
 
 theorem minpoly_add_algebraMap_splits [Algebra K L] {x : L} (r : K)
     (g : ((minpoly K x).map (algebraMap K L)).Splits) :
     ((minpoly K (x + algebraMap K L r)).map (algebraMap K L)).Splits := by
-  simpa [minpoly.add_algebraMap] using g.comp_X_sub_C r
+  simpa [minpoly.add_algebraMap, map_comp] using g.comp_X_sub_C (algebraMap K L r)
 
 theorem minpoly_sub_algebraMap_splits [Algebra K L] {x : L} (r : K)
     (g : ((minpoly K x).map (algebraMap K L)).Splits) :
@@ -148,7 +148,7 @@ theorem IsIntegral.minpoly_splits_tower_top' (int : IsIntegral R x) {f : K →+*
     (h : Splits ((minpoly R x).map (f.comp <| algebraMap R K))) :
     Splits ((minpoly K x).map f) :=
   splits_of_splits_of_dvd _ ((minpoly.monic int).map _).ne_zero
-    ((splits_map_iff _ _).mpr h) (minpoly.dvd_map_of_isScalarTower R _ x)
+    (map_map (algebraMap R K) f (minpoly R x) ▸ h) (minpoly.dvd_map_of_isScalarTower R _ x)
 
 theorem IsIntegral.minpoly_splits_tower_top [Algebra K L] [Algebra R L] [IsScalarTower R K L]
     (int : IsIntegral R x) (h : Splits ((minpoly R x).map (algebraMap R L))) :

--- a/Mathlib/RingTheory/Invariant/Basic.lean
+++ b/Mathlib/RingTheory/Invariant/Basic.lean
@@ -493,9 +493,9 @@ lemma Ideal.Quotient.normal [P.IsMaximal] [Q.IsMaximal] :
     (by rw [Polynomial.aeval_map_algebraMap, Polynomial.aeval_algebraMap_apply, H, map_zero])
   refine Polynomial.splits_of_splits_of_dvd (algebraMap (A ⧸ P) (B ⧸ Q)) ?_ ?_ this
   · exact (h₂.map (algebraMap A (A ⧸ P))).ne_zero
-  · rw [Polynomial.splits_map_iff, ← IsScalarTower.algebraMap_eq, IsScalarTower.algebraMap_eq A B,
-      ← Polynomial.splits_map_iff, hp, MulSemiringAction.charpoly_eq]
-    exact Polynomial.splits_prod _ (fun _ _ ↦ Polynomial.splits_X_sub_C _)
+  · rw [Polynomial.map_map, ← IsScalarTower.algebraMap_eq, IsScalarTower.algebraMap_eq A B,
+      ← Polynomial.map_map, hp, MulSemiringAction.charpoly_eq, Polynomial.map_prod]
+    exact Polynomial.Splits.prod (fun _ _ ↦ (Polynomial.Splits.X_sub_C _).map _)
 
 attribute [local instance] Ideal.Quotient.field in
 include G in


### PR DESCRIPTION
This PR begins the deprecation in `Splits.lean` as we move over to the new API in `Factors.lean`.

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

When merging, all the commits will be squashed into a single commit
listing all co-authors.

Co-authors in the squash commit are gathered from two sources:

First, all authors of commits to this PR branch are included. Thus,
one way to add co-authors is to include at least one commit authored by
each co-author among the commits in the pull request. If necessary, you
may create empty commits to indicate co-authorship, using commands like so:

git commit --author="Author Name <author@email.com>" --allow-empty -m "add Author Name as coauthor"

Second, co-authors can also be listed in lines at the very bottom of
the commit message (that is, directly before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines
at the bottom of the commit message (before the `---`, and also before
any "Co-authored-by" lines) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
