### PR TITLE
[Merged by Bors] - feat(CategoryTheory/ObjectProperty): predicates for being inherited along morphisms satisfying a morphism property

### DIFF
--- a/Mathlib.lean
+++ b/Mathlib.lean
@@ -2826,6 +2826,7 @@ public import Mathlib.CategoryTheory.ObjectProperty.FullSubcategory
 public import Mathlib.CategoryTheory.ObjectProperty.FunctorCategory.PreservesLimits
 public import Mathlib.CategoryTheory.ObjectProperty.HasCardinalLT
 public import Mathlib.CategoryTheory.ObjectProperty.Ind
+public import Mathlib.CategoryTheory.ObjectProperty.InheritedFromHom
 public import Mathlib.CategoryTheory.ObjectProperty.LimitsClosure
 public import Mathlib.CategoryTheory.ObjectProperty.LimitsOfShape
 public import Mathlib.CategoryTheory.ObjectProperty.Local

--- a/Mathlib/CategoryTheory/ObjectProperty/InheritedFromHom.lean
+++ b/Mathlib/CategoryTheory/ObjectProperty/InheritedFromHom.lean
@@ -1,0 +1,89 @@
+/-
+Copyright (c) 2025 Christian Merten. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Christian Merten
+-/
+module
+
+public import Mathlib.CategoryTheory.MorphismProperty.Composition
+public import Mathlib.CategoryTheory.ObjectProperty.Opposite
+
+/-!
+# Object properties transported along morphisms
+
+In this file we define the predicates `InheritedFromSource` and `InheritedFromTarget`
+for an object property `P` along a morphism property `Q`.
+`P` is inherited from the source (resp. target) along `Q` if for every morphism
+`f : X ⟶ Y` with `Q f`, `P X` implies `P Y` (resp. `P Y` implies `P X`).
+-/
+
+@[expose] public section
+
+namespace CategoryTheory
+
+variable {C : Type*} [Category C]
+
+namespace ObjectProperty
+
+variable (P P' : ObjectProperty C) (Q Q' : MorphismProperty C)
+
+/-- A property of objects `P` is inherited from the source of morphisms satisfying `Q` if
+whenever `P` holds for `X` and `f : X ⟶ Y` is a `Q`-morphism, then `P` holds for `Y`. -/
+class InheritedFromSource (P : ObjectProperty C) (Q : MorphismProperty C) : Prop where
+  of_hom_of_source {X Y : C} (f : X ⟶ Y) (hf : Q f) : P X → P Y
+
+/-- A property of objects `P` is inherited from the target of morphisms satisfying `Q` if
+whenever `P` holds for `Y` and `f : X ⟶ Y` is a `Q`-morphism, then `P` holds for `X`. -/
+class InheritedFromTarget (P : ObjectProperty C) (Q : MorphismProperty C) : Prop where
+  of_hom_of_target {X Y : C} (f : X ⟶ Y) (hf : Q f) : P Y → P X
+
+export InheritedFromSource (of_hom_of_source)
+export InheritedFromTarget (of_hom_of_target)
+
+namespace InheritedFromSource
+
+instance [P.IsClosedUnderIsomorphisms] :
+    P.InheritedFromSource (MorphismProperty.isomorphisms C) where
+  of_hom_of_source f (_ : IsIso f) h := P.prop_of_iso (asIso f) h
+
+instance op [P.InheritedFromSource Q] : P.op.InheritedFromTarget Q.op where
+  of_hom_of_target f hf h := P.of_hom_of_source f.unop hf h
+
+instance [P.InheritedFromSource Q] [P'.InheritedFromSource Q] :
+    (P ⊓ P').InheritedFromSource Q where
+  of_hom_of_source f hf h := ⟨P.of_hom_of_source f hf h.1, P'.of_hom_of_source f hf h.2⟩
+
+lemma of_le (hQ : Q ≤ Q') [P.InheritedFromSource Q'] : P.InheritedFromSource Q where
+  of_hom_of_source f hf h := P.of_hom_of_source f (hQ _ hf) h
+
+end InheritedFromSource
+
+namespace InheritedFromTarget
+
+instance [P.IsClosedUnderIsomorphisms] :
+    P.InheritedFromTarget (MorphismProperty.isomorphisms C) where
+  of_hom_of_target f (_ : IsIso f) h := P.prop_of_iso (asIso f).symm h
+
+instance op [P.InheritedFromTarget Q] : P.op.InheritedFromSource Q.op where
+  of_hom_of_source f hf h := P.of_hom_of_target f.unop hf h
+
+instance [P.InheritedFromTarget Q] [P'.InheritedFromTarget Q] :
+    (P ⊓ P').InheritedFromTarget Q where
+  of_hom_of_target f hf h := ⟨P.of_hom_of_target f hf h.1, P'.of_hom_of_target f hf h.2⟩
+
+lemma of_le (hQ : Q ≤ Q') [P.InheritedFromTarget Q'] : P.InheritedFromTarget Q where
+  of_hom_of_target f hf h := P.of_hom_of_target f (hQ _ hf) h
+
+end InheritedFromTarget
+
+lemma IsClosedUnderIsomorphisms.of_inheritedFromSource [P.InheritedFromSource Q] [Q.RespectsIso]
+    [Q.ContainsIdentities] : P.IsClosedUnderIsomorphisms where
+  of_iso e h := P.of_hom_of_source e.hom (Q.of_isIso e.hom) h
+
+lemma IsClosedUnderIsomorphisms.of_inheritedFromTarget [P.InheritedFromTarget Q] [Q.RespectsIso]
+    [Q.ContainsIdentities] : P.IsClosedUnderIsomorphisms where
+  of_iso e h := P.of_hom_of_target e.inv (Q.of_isIso e.inv) h
+
+end ObjectProperty
+
+end CategoryTheory


### PR DESCRIPTION
We define the predicates `InheritedFromSource` and `InheritedFromTarget` for an object property `P` along a
morphism property `Q`. `P` is inherited from the source (resp. target) along `Q` if for every morphism `f : X ⟶ Y`
with `Q f`, `P X` implies `P Y` (resp. `P Y` implies `P X`).

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

When merging, all the commits will be squashed into a single commit
listing all co-authors.

Co-authors in the squash commit are gathered from two sources:

First, all authors of commits to this PR branch are included. Thus,
one way to add co-authors is to include at least one commit authored by
each co-author among the commits in the pull request. If necessary, you
may create empty commits to indicate co-authorship, using commands like so:

git commit --author="Author Name <author@email.com>" --allow-empty -m "add Author Name as coauthor"

Second, co-authors can also be listed in lines at the very bottom of
the commit message (that is, directly before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines
at the bottom of the commit message (before the `---`, and also before
any "Co-authored-by" lines) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
