### PR TITLE
[Merged by Bors] - feat(CategoryTheory/ObjectProperty): local object properties with respect to a precoverage

### DIFF
--- a/Mathlib.lean
+++ b/Mathlib.lean
@@ -2833,6 +2833,7 @@ public import Mathlib.CategoryTheory.ObjectProperty.Opposite
 public import Mathlib.CategoryTheory.ObjectProperty.Orthogonal
 public import Mathlib.CategoryTheory.ObjectProperty.Retract
 public import Mathlib.CategoryTheory.ObjectProperty.Shift
+public import Mathlib.CategoryTheory.ObjectProperty.SiteLocal
 public import Mathlib.CategoryTheory.ObjectProperty.Small
 public import Mathlib.CategoryTheory.Opposites
 public import Mathlib.CategoryTheory.PEmpty

--- a/Mathlib/CategoryTheory/ObjectProperty/CompleteLattice.lean
+++ b/Mathlib/CategoryTheory/ObjectProperty/CompleteLattice.lean
@@ -48,6 +48,13 @@ instance [P.IsClosedUnderIsomorphisms] [Q.IsClosedUnderIsomorphisms] :
     (P ⊔ Q).IsClosedUnderIsomorphisms := by
   simp only [isClosedUnderIsomorphisms_iff_isoClosure_eq_self, isoClosure_sup, isoClosure_eq_self]
 
+instance [P.IsClosedUnderIsomorphisms] [Q.IsClosedUnderIsomorphisms] :
+    IsClosedUnderIsomorphisms (P ⊓ Q) where
+  of_iso e h := ⟨IsClosedUnderIsomorphisms.of_iso e h.1, IsClosedUnderIsomorphisms.of_iso e h.2⟩
+
+instance : IsClosedUnderIsomorphisms (⊤ : ObjectProperty C) where
+  of_iso := by simp
+
 end
 
 section

--- a/Mathlib/CategoryTheory/ObjectProperty/SiteLocal.lean
+++ b/Mathlib/CategoryTheory/ObjectProperty/SiteLocal.lean
@@ -12,7 +12,7 @@ public import Mathlib.CategoryTheory.Sites.Hypercover.Zero
 # Locality conditions on object properties
 
 In this file we define locality conditions on object properties in a category. Let `K` be a
-precoverage in a category `C` and `P` be a morphism property on `C` that respects isomorphisms.
+precoverage in a category `C` and `P` be an object property that is closed under isomorphisms.
 
 We say that
 

--- a/Mathlib/CategoryTheory/ObjectProperty/SiteLocal.lean
+++ b/Mathlib/CategoryTheory/ObjectProperty/SiteLocal.lean
@@ -1,0 +1,71 @@
+/-
+Copyright (c) 2025 Christian Merten. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Christian Merten
+-/
+module
+
+public import Mathlib.CategoryTheory.ObjectProperty.CompleteLattice
+public import Mathlib.CategoryTheory.Sites.Hypercover.Zero
+
+/-!
+# Locality conditions on object properties
+
+In this file we define locality conditions on object properties in a category. Let `K` be a
+precoverage in a category `C` and `P` be a morphism property on `C` that respects isomorphisms.
+
+We say that
+
+- `P` is local if for every `X : C`, `P` holds for `X` if and only if it holds for `Uᵢ` for a
+  `K`-cover `{Uᵢ}` of `X`.
+
+## Implementation details
+
+The covers appearing in the definitions have index type in the morphism universe of `C`.
+-/
+
+@[expose] public section
+
+universe v u
+
+namespace CategoryTheory.ObjectProperty
+
+variable {C : Type u} [Category.{v} C]
+
+/-- An object property is local if it holds for `X` if and only if it holds for all `Uᵢ` where
+`{Uᵢ}` is a `K`-cover of `X`. -/
+class IsLocal (P : ObjectProperty C) (K : Precoverage C) extends IsClosedUnderIsomorphisms P where
+  component {X : C} (𝒰 : Precoverage.ZeroHypercover.{v} K X) (i : 𝒰.I₀) : P X → P (𝒰.X i)
+  of_zeroHypercover {X : C} (𝒰 : Precoverage.ZeroHypercover.{v} K X) (h : ∀ i, P (𝒰.X i)) : P X
+
+variable {P : ObjectProperty C} {K L : Precoverage C}
+
+namespace IsLocal
+
+lemma of_le [IsLocal P L] (hle : K ≤ L) : IsLocal P K where
+  component 𝒰 i h := component (𝒰.weaken hle) i h
+  of_zeroHypercover 𝒰 := of_zeroHypercover (𝒰.weaken hle)
+
+instance top : IsLocal (⊤ : ObjectProperty C) K where
+  component := by simp
+  of_zeroHypercover := by simp
+
+variable [IsLocal P K] {X : C} (𝒰 : Precoverage.ZeroHypercover.{v} K X)
+
+instance inf (P Q : ObjectProperty C) [IsLocal P K] [IsLocal Q K] :
+    IsLocal (P ⊓ Q) K where
+  component _ i h := ⟨component _ i h.1, component _ i h.2⟩
+  of_zeroHypercover _ h :=
+    ⟨of_zeroHypercover _ fun i ↦ (h i).1, of_zeroHypercover _ fun i ↦ (h i).2⟩
+
+end IsLocal
+
+lemma of_zeroHypercover [P.IsLocal K] {X : C} (𝒰 : K.ZeroHypercover X)
+    [Precoverage.ZeroHypercover.Small.{v} 𝒰] (h : ∀ i, P (𝒰.X i)) : P X :=
+  IsLocal.of_zeroHypercover 𝒰.restrictIndexOfSmall fun _ ↦ h _
+
+lemma iff_of_zeroHypercover [P.IsLocal K] {X : C} (𝒰 : Precoverage.ZeroHypercover.{v} K X) :
+    P X ↔ ∀ i, P (𝒰.X i) :=
+  ⟨fun h _ ↦ IsLocal.component _ _ h, fun h ↦ of_zeroHypercover 𝒰 h⟩
+
+end CategoryTheory.ObjectProperty

--- a/Mathlib/CategoryTheory/ObjectProperty/SiteLocal.lean
+++ b/Mathlib/CategoryTheory/ObjectProperty/SiteLocal.lean
@@ -35,37 +35,56 @@ variable {C : Type u} [Category.{v} C]
 /-- An object property is local if it holds for `X` if and only if it holds for all `Uᵢ` where
 `{Uᵢ}` is a `K`-cover of `X`. -/
 class IsLocal (P : ObjectProperty C) (K : Precoverage C) extends IsClosedUnderIsomorphisms P where
-  component {X : C} (𝒰 : Precoverage.ZeroHypercover.{v} K X) (i : 𝒰.I₀) : P X → P (𝒰.X i)
-  of_zeroHypercover {X : C} (𝒰 : Precoverage.ZeroHypercover.{v} K X) (h : ∀ i, P (𝒰.X i)) : P X
+  component {X : C} {R : Presieve X} (hR : R ∈ K X) {Y : C} (f : Y ⟶ X) (hf : R f) : P X → P Y
+  of_presieve {X : C} {R : Presieve X} (hR : R ∈ K X) (H : ∀ ⦃Y : C⦄ ⦃f : Y ⟶ X⦄, R f → P Y) : P X
+
+export IsLocal (of_presieve)
 
 variable {P : ObjectProperty C} {K L : Precoverage C}
 
+lemma iff_of_presieve [P.IsLocal K] {X : C} {R : Presieve X} (hR : R ∈ K X) :
+    P X ↔ ∀ ⦃Y : C⦄ ⦃f : Y ⟶ X⦄, R f → P Y :=
+  ⟨fun h _ _ hf ↦ IsLocal.component hR _ hf h, fun h ↦ of_presieve hR h⟩
+
 namespace IsLocal
 
+lemma mk_of_zeroHypercover [P.IsClosedUnderIsomorphisms]
+    (H : ∀ ⦃X : C⦄ (𝒰 : Precoverage.ZeroHypercover.{max u v} K X),
+      P X ↔ ∀ i, P (𝒰.X i)) :
+    P.IsLocal K where
+  component {X R} hR Y f hf hX := by
+    rw [CategoryTheory.Precoverage.mem_iff_exists_zeroHypercover] at hR
+    obtain ⟨𝒰, rfl⟩ := hR
+    rw [H 𝒰] at hX
+    obtain ⟨i⟩ := hf
+    exact hX i
+  of_presieve {X R} hR h := by
+    rw [CategoryTheory.Precoverage.mem_iff_exists_zeroHypercover] at hR
+    obtain ⟨𝒰, rfl⟩ := hR
+    rw [H 𝒰]
+    intro i
+    exact h ⟨i⟩
+
 lemma of_le [IsLocal P L] (hle : K ≤ L) : IsLocal P K where
-  component 𝒰 i h := component (𝒰.weaken hle) i h
-  of_zeroHypercover 𝒰 := of_zeroHypercover (𝒰.weaken hle)
+  component hR _ f hf hX := component (hle _ hR) f hf hX
+  of_presieve hR H := of_presieve (hle _ hR) H
 
 instance top : IsLocal (⊤ : ObjectProperty C) K where
   component := by simp
-  of_zeroHypercover := by simp
-
-variable [IsLocal P K] {X : C} (𝒰 : Precoverage.ZeroHypercover.{v} K X)
+  of_presieve := by simp
 
 instance inf (P Q : ObjectProperty C) [IsLocal P K] [IsLocal Q K] :
     IsLocal (P ⊓ Q) K where
-  component _ i h := ⟨component _ i h.1, component _ i h.2⟩
-  of_zeroHypercover _ h :=
-    ⟨of_zeroHypercover _ fun i ↦ (h i).1, of_zeroHypercover _ fun i ↦ (h i).2⟩
+  component hR _ _ hf h := ⟨component hR _ hf h.1, component hR _ hf h.2⟩
+  of_presieve hR h := ⟨of_presieve hR fun _ _ hf ↦ (h hf).1, of_presieve hR fun _ _ hf ↦ (h hf).2⟩
 
 end IsLocal
 
-lemma of_zeroHypercover [P.IsLocal K] {X : C} (𝒰 : K.ZeroHypercover X)
-    [Precoverage.ZeroHypercover.Small.{v} 𝒰] (h : ∀ i, P (𝒰.X i)) : P X :=
-  IsLocal.of_zeroHypercover 𝒰.restrictIndexOfSmall fun _ ↦ h _
+lemma of_zeroHypercover [P.IsLocal K] {X : C} (𝒰 : K.ZeroHypercover X) (h : ∀ i, P (𝒰.X i)) : P X :=
+  P.of_presieve 𝒰.mem₀ fun _ f ⟨i⟩ ↦ h i
 
-lemma iff_of_zeroHypercover [P.IsLocal K] {X : C} (𝒰 : Precoverage.ZeroHypercover.{v} K X) :
+lemma iff_of_zeroHypercover [P.IsLocal K] {X : C} (𝒰 : K.ZeroHypercover X) :
     P X ↔ ∀ i, P (𝒰.X i) :=
-  ⟨fun h _ ↦ IsLocal.component _ _ h, fun h ↦ of_zeroHypercover 𝒰 h⟩
+  ⟨fun h i ↦ IsLocal.component 𝒰.mem₀ _ ⟨i⟩ h, fun h ↦ of_zeroHypercover 𝒰 h⟩
 
 end CategoryTheory.ObjectProperty


### PR DESCRIPTION
An object property is `K`-local for a precoverage `K` if it holds for `X` if and only if it holds for all `Uᵢ` where `{Uᵢ}` is a `K`-cover of `X`.

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

When merging, all the commits will be squashed into a single commit
listing all co-authors.

Co-authors in the squash commit are gathered from two sources:

First, all authors of commits to this PR branch are included. Thus,
one way to add co-authors is to include at least one commit authored by
each co-author among the commits in the pull request. If necessary, you
may create empty commits to indicate co-authorship, using commands like so:

git commit --author="Author Name <author@email.com>" --allow-empty -m "add Author Name as coauthor"

Second, co-authors can also be listed in lines at the very bottom of
the commit message (that is, directly before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines
at the bottom of the commit message (before the `---`, and also before
any "Co-authored-by" lines) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
