### PR TITLE
[Merged by Bors] - chore(AlgebraicTopology/SimplicialSet): golf `toNerve₂.ext`

### DIFF
--- a/Mathlib/AlgebraicTopology/SimplicialSet/NerveAdjunction.lean
+++ b/Mathlib/AlgebraicTopology/SimplicialSet/NerveAdjunction.lean
@@ -300,24 +300,9 @@ end
 underlying refl prefunctors. -/
 theorem toNerve₂.ext (F G : X ⟶ nerveFunctor₂.obj (Cat.of C))
     (hyp : SSet.oneTruncation₂.map F = SSet.oneTruncation₂.map G) : F = G := by
-  have eq₀ (x : X _⦋0⦌₂) : F.app (op ⦋0⦌₂) x = G.app (op ⦋0⦌₂) x := congr(($hyp).obj x)
   have eq₁ (x : X _⦋1⦌₂) : F.app (op ⦋1⦌₂) x = G.app (op ⦋1⦌₂) x :=
     congr((($hyp).map ⟨x, rfl, rfl⟩).1)
-  ext ⟨⟨n, hn⟩⟩ x
-  induction n using SimplexCategory.rec with | _ n
-  match n with
-  | 0 => apply eq₀
-  | 1 => apply eq₁
-  | 2 =>
-    apply Functor.hext (fun i : Fin 3 => ?_) (fun (i j : Fin 3) k => ?_)
-    · let pt : ⦋0⦌₂ ⟶ ⦋2⦌₂ := SimplexCategory.const _ _ i
-      refine congr(($(F.naturality pt.op) x).obj 0).symm.trans ?_
-      refine .trans ?_ congr(($(G.naturality pt.op) x).obj 0)
-      exact congr($(eq₀ _).obj 0)
-    · let ar : ⦋1⦌₂ ⟶ ⦋2⦌₂ := mkOfLe _ _ k.le
-      have h1 := congr_arg_heq (fun x => x.map' 0 1) (congr_fun (F.naturality (op ar)) x)
-      have h2 := congr_arg_heq (fun x => x.map' 0 1) (congr_fun (G.naturality (op ar)) x)
-      exact h1.symm.trans <| .trans (congr_arg_heq (fun x => x.map' 0 1) (eq₁ _)) h2
+  exact IsStrictSegal.hom_ext eq₁
 
 /-- The components of the 2-truncated nerve adjunction unit. -/
 def nerve₂Adj.unit.app (X : SSet.Truncated.{u} 2) :


### PR DESCRIPTION
---
<details>
<summary>Show trace profiling of <code>toNerve₂.ext</code>: 205 ms before, 55 ms after  🎉</summary>

### Trace profiling of `toNerve₂.ext` before PR 32047
```diff
diff --git a/Mathlib/AlgebraicTopology/SimplicialSet/NerveAdjunction.lean b/Mathlib/AlgebraicTopology/SimplicialSet/NerveAdjunction.lean
index 88c762b8c2..de8f1042a3 100644
--- a/Mathlib/AlgebraicTopology/SimplicialSet/NerveAdjunction.lean
+++ b/Mathlib/AlgebraicTopology/SimplicialSet/NerveAdjunction.lean
@@ -296,6 +296,7 @@ theorem oneTruncation₂_toNerve₂Mk' : oneTruncation₂.map (toNerve₂.mk' F
 
 end
 
+set_option trace.profiler true in
 /-- An equality between maps into the 2-truncated nerve is detected by an equality between their
 underlying refl prefunctors. -/
 theorem toNerve₂.ext (F G : X ⟶ nerveFunctor₂.obj (Cat.of C))
```
```
ℹ [1143/1143] Built Mathlib.AlgebraicTopology.SimplicialSet.NerveAdjunction (4.6s)
info: Mathlib/AlgebraicTopology/SimplicialSet/NerveAdjunction.lean:300:0: [Elab.async] [0.207261] elaborating proof of CategoryTheory.toNerve₂.ext
  [Elab.definition.value] [0.205379] CategoryTheory.toNerve₂.ext
    [Elab.step] [0.204251] failed to pretty print term (use 'set_option pp.rawOnError true' for raw representation)
      [Elab.step] [0.204246] failed to pretty print term (use 'set_option pp.rawOnError true' for raw representation)
        [Elab.step] [0.037298] have eq₀ (x : X _⦋0⦌₂) : F.app (op ⦋0⦌₂) x = G.app (op ⦋0⦌₂) x := congr(($hyp).obj x)
          [Elab.step] [0.037292] refine_lift
                have eq₀ (x : X _⦋0⦌₂) : F.app (op ⦋0⦌₂) x = G.app (op ⦋0⦌₂) x := congr(($hyp).obj x);
                ?_
            [Elab.step] [0.037288] focus
                  (refine
                      no_implicit_lambda%
                        (have eq₀ (x : X _⦋0⦌₂) : F.app (op ⦋0⦌₂) x = G.app (op ⦋0⦌₂) x := congr(($hyp).obj x);
                        ?_);
                    rotate_right)
              [Elab.step] [0.037284] (refine
                        no_implicit_lambda%
                          (have eq₀ (x : X _⦋0⦌₂) : F.app (op ⦋0⦌₂) x = G.app (op ⦋0⦌₂) x := congr(($hyp).obj x);
                          ?_);
                      rotate_right)
                [Elab.step] [0.037282] (refine
                          no_implicit_lambda%
                            (have eq₀ (x : X _⦋0⦌₂) : F.app (op ⦋0⦌₂) x = G.app (op ⦋0⦌₂) x := congr(($hyp).obj x);
                            ?_);
                        rotate_right)
                  [Elab.step] [0.037279] (refine
                          no_implicit_lambda%
                            (have eq₀ (x : X _⦋0⦌₂) : F.app (op ⦋0⦌₂) x = G.app (op ⦋0⦌₂) x := congr(($hyp).obj x);
                            ?_);
                        rotate_right)
                    [Elab.step] [0.037277] refine
                            no_implicit_lambda%
                              (have eq₀ (x : X _⦋0⦌₂) : F.app (op ⦋0⦌₂) x = G.app (op ⦋0⦌₂) x := congr(($hyp).obj x);
                              ?_);
                          rotate_right
                      [Elab.step] [0.037275] refine
                              no_implicit_lambda%
                                (have eq₀ (x : X _⦋0⦌₂) : F.app (op ⦋0⦌₂) x = G.app (op ⦋0⦌₂) x := congr(($hyp).obj x);
                                ?_);
                            rotate_right
                        [Elab.step] [0.037267] refine
                              no_implicit_lambda%
                                (have eq₀ (x : X _⦋0⦌₂) : F.app (op ⦋0⦌₂) x = G.app (op ⦋0⦌₂) x := congr(($hyp).obj x);
                                ?_)
                          [Elab.step] [0.013613] expected type: F = G, term
                              no_implicit_lambda%
                                (have eq₀ (x : X _⦋0⦌₂) : F.app (op ⦋0⦌₂) x = G.app (op ⦋0⦌₂) x := congr(($hyp).obj x);
                                ?_)
                            [Elab.step] [0.013608] expected type: F = G, term
                                have eq₀ (x : X _⦋0⦌₂) : F.app (op ⦋0⦌₂) x = G.app (op ⦋0⦌₂) x := congr(($hyp).obj x);
                                ?_
                          [Elab.step] [0.023485] first
                                | get_elem_tactic
                                | fail "Failed to prove truncation property. Try writing `X _⦋m, by ...⦌ₙ`."
                            [Elab.step] [0.023482] first
                                  | get_elem_tactic
                                  | fail "Failed to prove truncation property. Try writing `X _⦋m, by ...⦌ₙ`."
                              [Elab.step] [0.023479] first
                                  | get_elem_tactic
                                  | fail "Failed to prove truncation property. Try writing `X _⦋m, by ...⦌ₙ`."
                                [Elab.step] [0.023476] get_elem_tactic
                                  [Elab.step] [0.023474] get_elem_tactic
                                    [Elab.step] [0.023472] get_elem_tactic
                                      [Elab.step] [0.023466] first
                                          | done
                                          | assumption
                                          | get_elem_tactic_extensible
                                          |
                                            fail "failed to prove index is valid, possible solutions:
                                                - Use `have`-expressions to prove the index is valid
                                                - Use `a[i]!` notation instead, runtime check is performed, and 'Panic' error message is produced if index is not valid
                                                - Use `a[i]?` notation instead, result is an `Option` type
                                                - Use `a[i]'h` notation instead, where `h` is a proof that index is valid"
                                        [Elab.step] [0.023191] get_elem_tactic_extensible
                                          [Elab.step] [0.023188] get_elem_tactic_extensible
                                            [Elab.step] [0.023185] get_elem_tactic_extensible
                                              [Elab.step] [0.020162] first
                                                  | try rw [Std.Rcc.mem_iff✝] at *
                                                    try rw [Std.Rco.mem_iff✝] at *
                                                    try rw [Std.Rci.mem_iff✝] at *
                                                    try rw [Std.Roc.mem_iff✝] at *
                                                    try rw [Std.Roo.mem_iff✝] at *
                                                    try rw [Std.Roi.mem_iff✝] at *
                                                    try rw [Std.Ric.mem_iff✝] at *
                                                    try rw [Std.Rio.mem_iff✝] at *
                                                    try rw [Std.Rii.mem_iff✝] at *
                                                    dsimp +zetaDelta✝ only [Vector.size✝] at *
                                                    omega
                                                  | done
                                                [Elab.step] [0.020137] 
                                                      try rw [Std.Rcc.mem_iff✝] at *
                                                      try rw [Std.Rco.mem_iff✝] at *
                                                      try rw [Std.Rci.mem_iff✝] at *
                                                      try rw [Std.Roc.mem_iff✝] at *
                                                      try rw [Std.Roo.mem_iff✝] at *
                                                      try rw [Std.Roi.mem_iff✝] at *
                                                      try rw [Std.Ric.mem_iff✝] at *
                                                      try rw [Std.Rio.mem_iff✝] at *
                                                      try rw [Std.Rii.mem_iff✝] at *
                                                      dsimp +zetaDelta✝ only [Vector.size✝] at *
[… 174 lines omitted …]
                                            ?_);
                                        rotate_right)
                                  [Elab.step] [0.034802] (refine
                                            no_implicit_lambda%
                                              (have h1 :=
                                                congr_arg_heq (fun x => x.map' 0 1)
                                                  (congr_fun (F.naturality (op ar)) x);
                                              ?_);
                                          rotate_right)
                                    [Elab.step] [0.034800] (refine
                                            no_implicit_lambda%
                                              (have h1 :=
                                                congr_arg_heq (fun x => x.map' 0 1)
                                                  (congr_fun (F.naturality (op ar)) x);
                                              ?_);
                                          rotate_right)
                                      [Elab.step] [0.034797] refine
                                              no_implicit_lambda%
                                                (have h1 :=
                                                  congr_arg_heq (fun x => x.map' 0 1)
                                                    (congr_fun (F.naturality (op ar)) x);
                                                ?_);
                                            rotate_right
                                        [Elab.step] [0.034794] refine
                                                no_implicit_lambda%
                                                  (have h1 :=
                                                    congr_arg_heq (fun x => x.map' 0 1)
                                                      (congr_fun (F.naturality (op ar)) x);
                                                  ?_);
                                              rotate_right
                                          [Elab.step] [0.034781] refine
                                                no_implicit_lambda%
                                                  (have h1 :=
                                                    congr_arg_heq (fun x => x.map' 0 1)
                                                      (congr_fun (F.naturality (op ar)) x);
                                                  ?_)
                                            [Elab.step] [0.024222] expected type: x.obj ⟨0, ⋯⟩ ⟶ x.obj ⟨1, ⋯⟩, term
                                                x.map' 0 1
                          [Elab.step] [0.010663] have h2 :=
                                congr_arg_heq (fun x => x.map' 0 1) (congr_fun (G.naturality (op ar)) x)
                            [Elab.step] [0.010653] refine_lift
                                  have h2 := congr_arg_heq (fun x => x.map' 0 1) (congr_fun (G.naturality (op ar)) x);
                                  ?_
                              [Elab.step] [0.010650] focus
                                    (refine
                                        no_implicit_lambda%
                                          (have h2 :=
                                            congr_arg_heq (fun x => x.map' 0 1) (congr_fun (G.naturality (op ar)) x);
                                          ?_);
                                      rotate_right)
                                [Elab.step] [0.010647] (refine
                                          no_implicit_lambda%
                                            (have h2 :=
                                              congr_arg_heq (fun x => x.map' 0 1) (congr_fun (G.naturality (op ar)) x);
                                            ?_);
                                        rotate_right)
                                  [Elab.step] [0.010645] (refine
                                            no_implicit_lambda%
                                              (have h2 :=
                                                congr_arg_heq (fun x => x.map' 0 1)
                                                  (congr_fun (G.naturality (op ar)) x);
                                              ?_);
                                          rotate_right)
                                    [Elab.step] [0.010642] (refine
                                            no_implicit_lambda%
                                              (have h2 :=
                                                congr_arg_heq (fun x => x.map' 0 1)
                                                  (congr_fun (G.naturality (op ar)) x);
                                              ?_);
                                          rotate_right)
                                      [Elab.step] [0.010640] refine
                                              no_implicit_lambda%
                                                (have h2 :=
                                                  congr_arg_heq (fun x => x.map' 0 1)
                                                    (congr_fun (G.naturality (op ar)) x);
                                                ?_);
                                            rotate_right
                                        [Elab.step] [0.010638] refine
                                                no_implicit_lambda%
                                                  (have h2 :=
                                                    congr_arg_heq (fun x => x.map' 0 1)
                                                      (congr_fun (G.naturality (op ar)) x);
                                                  ?_);
                                              rotate_right
                                          [Elab.step] [0.010631] refine
                                                no_implicit_lambda%
                                                  (have h2 :=
                                                    congr_arg_heq (fun x => x.map' 0 1)
                                                      (congr_fun (G.naturality (op ar)) x);
                                                  ?_)
                          [Elab.step] [0.024422] exact
                                h1.symm.trans <| .trans (congr_arg_heq (fun x => x.map' 0 1) (eq₁ _)) h2
                            [Elab.step] [0.011822] expected type: (F.app (op { obj := ⦋2⦌, property := hn }) x).map k ≍
                                  (G.app (op { obj := ⦋2⦌, property := hn }) x).map k, term
                                h1.symm.trans <| .trans (congr_arg_heq (fun x => x.map' 0 1) (eq₁ _)) h2
                              [Elab.step] [0.011816] expected type: (F.app (op { obj := ⦋2⦌, property := hn }) x).map
                                      k ≍
                                    (G.app (op { obj := ⦋2⦌, property := hn }) x).map k, term
                                  h1.symm.trans (.trans (congr_arg_heq (fun x => x.map' 0 1) (eq₁ _)) h2)
Build completed successfully (1143 jobs).
```

### Trace profiling of `toNerve₂.ext` after PR 32047
```diff
diff --git a/Mathlib/AlgebraicTopology/SimplicialSet/NerveAdjunction.lean b/Mathlib/AlgebraicTopology/SimplicialSet/NerveAdjunction.lean
index 88c762b8c2..0362e42a7a 100644
--- a/Mathlib/AlgebraicTopology/SimplicialSet/NerveAdjunction.lean
+++ b/Mathlib/AlgebraicTopology/SimplicialSet/NerveAdjunction.lean
@@ -296,28 +296,14 @@ theorem oneTruncation₂_toNerve₂Mk' : oneTruncation₂.map (toNerve₂.mk' F
 
 end
 
+set_option trace.profiler true in
 /-- An equality between maps into the 2-truncated nerve is detected by an equality between their
 underlying refl prefunctors. -/
 theorem toNerve₂.ext (F G : X ⟶ nerveFunctor₂.obj (Cat.of C))
     (hyp : SSet.oneTruncation₂.map F = SSet.oneTruncation₂.map G) : F = G := by
-  have eq₀ (x : X _⦋0⦌₂) : F.app (op ⦋0⦌₂) x = G.app (op ⦋0⦌₂) x := congr(($hyp).obj x)
   have eq₁ (x : X _⦋1⦌₂) : F.app (op ⦋1⦌₂) x = G.app (op ⦋1⦌₂) x :=
     congr((($hyp).map ⟨x, rfl, rfl⟩).1)
-  ext ⟨⟨n, hn⟩⟩ x
-  induction n using SimplexCategory.rec with | _ n
-  match n with
-  | 0 => apply eq₀
-  | 1 => apply eq₁
-  | 2 =>
-    apply Functor.hext (fun i : Fin 3 => ?_) (fun (i j : Fin 3) k => ?_)
-    · let pt : ⦋0⦌₂ ⟶ ⦋2⦌₂ := SimplexCategory.const _ _ i
-      refine congr(($(F.naturality pt.op) x).obj 0).symm.trans ?_
-      refine .trans ?_ congr(($(G.naturality pt.op) x).obj 0)
-      exact congr($(eq₀ _).obj 0)
-    · let ar : ⦋1⦌₂ ⟶ ⦋2⦌₂ := mkOfLe _ _ k.le
-      have h1 := congr_arg_heq (fun x => x.map' 0 1) (congr_fun (F.naturality (op ar)) x)
-      have h2 := congr_arg_heq (fun x => x.map' 0 1) (congr_fun (G.naturality (op ar)) x)
-      exact h1.symm.trans <| .trans (congr_arg_heq (fun x => x.map' 0 1) (eq₁ _)) h2
+  exact IsStrictSegal.hom_ext eq₁
 
 /-- The components of the 2-truncated nerve adjunction unit. -/
 def nerve₂Adj.unit.app (X : SSet.Truncated.{u} 2) :
```
```
ℹ [1143/1143] Built Mathlib.AlgebraicTopology.SimplicialSet.NerveAdjunction (4.2s)
info: Mathlib/AlgebraicTopology/SimplicialSet/NerveAdjunction.lean:300:0: [Elab.async] [0.056013] elaborating proof of CategoryTheory.toNerve₂.ext
  [Elab.definition.value] [0.055149] CategoryTheory.toNerve₂.ext
    [Elab.step] [0.054721] 
          have eq₁ (x : X _⦋1⦌₂) : F.app (op ⦋1⦌₂) x = G.app (op ⦋1⦌₂) x := congr((($hyp).map ⟨x, rfl, rfl⟩).1)
          exact IsStrictSegal.hom_ext eq₁
      [Elab.step] [0.054715] 
            have eq₁ (x : X _⦋1⦌₂) : F.app (op ⦋1⦌₂) x = G.app (op ⦋1⦌₂) x := congr((($hyp).map ⟨x, rfl, rfl⟩).1)
            exact IsStrictSegal.hom_ext eq₁
        [Elab.step] [0.051940] have eq₁ (x : X _⦋1⦌₂) : F.app (op ⦋1⦌₂) x = G.app (op ⦋1⦌₂) x :=
              congr((($hyp).map ⟨x, rfl, rfl⟩).1)
          [Elab.step] [0.051934] refine_lift
                have eq₁ (x : X _⦋1⦌₂) : F.app (op ⦋1⦌₂) x = G.app (op ⦋1⦌₂) x := congr((($hyp).map ⟨x, rfl, rfl⟩).1);
                ?_
            [Elab.step] [0.051930] focus
                  (refine
                      no_implicit_lambda%
                        (have eq₁ (x : X _⦋1⦌₂) : F.app (op ⦋1⦌₂) x = G.app (op ⦋1⦌₂) x :=
                          congr((($hyp).map ⟨x, rfl, rfl⟩).1);
                        ?_);
                    rotate_right)
              [Elab.step] [0.051925] (refine
                        no_implicit_lambda%
                          (have eq₁ (x : X _⦋1⦌₂) : F.app (op ⦋1⦌₂) x = G.app (op ⦋1⦌₂) x :=
                            congr((($hyp).map ⟨x, rfl, rfl⟩).1);
                          ?_);
                      rotate_right)
                [Elab.step] [0.051923] (refine
                          no_implicit_lambda%
                            (have eq₁ (x : X _⦋1⦌₂) : F.app (op ⦋1⦌₂) x = G.app (op ⦋1⦌₂) x :=
                              congr((($hyp).map ⟨x, rfl, rfl⟩).1);
                            ?_);
                        rotate_right)
                  [Elab.step] [0.051920] (refine
                          no_implicit_lambda%
                            (have eq₁ (x : X _⦋1⦌₂) : F.app (op ⦋1⦌₂) x = G.app (op ⦋1⦌₂) x :=
                              congr((($hyp).map ⟨x, rfl, rfl⟩).1);
                            ?_);
                        rotate_right)
                    [Elab.step] [0.051918] refine
                            no_implicit_lambda%
                              (have eq₁ (x : X _⦋1⦌₂) : F.app (op ⦋1⦌₂) x = G.app (op ⦋1⦌₂) x :=
                                congr((($hyp).map ⟨x, rfl, rfl⟩).1);
                              ?_);
                          rotate_right
                      [Elab.step] [0.051916] refine
                              no_implicit_lambda%
                                (have eq₁ (x : X _⦋1⦌₂) : F.app (op ⦋1⦌₂) x = G.app (op ⦋1⦌₂) x :=
                                  congr((($hyp).map ⟨x, rfl, rfl⟩).1);
                                ?_);
                            rotate_right
                        [Elab.step] [0.051908] refine
                              no_implicit_lambda%
                                (have eq₁ (x : X _⦋1⦌₂) : F.app (op ⦋1⦌₂) x = G.app (op ⦋1⦌₂) x :=
                                  congr((($hyp).map ⟨x, rfl, rfl⟩).1);
                                ?_)
                          [Elab.step] [0.028437] expected type: F = G, term
                              no_implicit_lambda%
                                (have eq₁ (x : X _⦋1⦌₂) : F.app (op ⦋1⦌₂) x = G.app (op ⦋1⦌₂) x :=
                                  congr((($hyp).map ⟨x, rfl, rfl⟩).1);
                                ?_)
                            [Elab.step] [0.028429] expected type: F = G, term
                                have eq₁ (x : X _⦋1⦌₂) : F.app (op ⦋1⦌₂) x = G.app (op ⦋1⦌₂) x :=
                                  congr((($hyp).map ⟨x, rfl, rfl⟩).1);
                                ?_
                              [Elab.step] [0.019671] expected type: F.app (op { obj := ⦋1⦌, property := ⋯ }) x =
                                    G.app (op { obj := ⦋1⦌, property := ⋯ }) x, term
                                  congr((($hyp).map ⟨x, rfl, rfl⟩).1)
                          [Elab.step] [0.023226] first
                                | get_elem_tactic
                                | fail "Failed to prove truncation property. Try writing `X _⦋m, by ...⦌ₙ`."
                            [Elab.step] [0.023222] first
                                  | get_elem_tactic
                                  | fail "Failed to prove truncation property. Try writing `X _⦋m, by ...⦌ₙ`."
                              [Elab.step] [0.023219] first
                                  | get_elem_tactic
                                  | fail "Failed to prove truncation property. Try writing `X _⦋m, by ...⦌ₙ`."
                                [Elab.step] [0.023215] get_elem_tactic
                                  [Elab.step] [0.023213] get_elem_tactic
                                    [Elab.step] [0.023211] get_elem_tactic
                                      [Elab.step] [0.023205] first
                                          | done
                                          | assumption
                                          | get_elem_tactic_extensible
                                          |
                                            fail "failed to prove index is valid, possible solutions:
                                                - Use `have`-expressions to prove the index is valid
                                                - Use `a[i]!` notation instead, runtime check is performed, and 'Panic' error message is produced if index is not valid
                                                - Use `a[i]?` notation instead, result is an `Option` type
                                                - Use `a[i]'h` notation instead, where `h` is a proof that index is valid"
                                        [Elab.step] [0.022922] get_elem_tactic_extensible
                                          [Elab.step] [0.022919] get_elem_tactic_extensible
                                            [Elab.step] [0.022916] get_elem_tactic_extensible
                                              [Elab.step] [0.019663] first
                                                  | try rw [Std.Rcc.mem_iff✝] at *
                                                    try rw [Std.Rco.mem_iff✝] at *
                                                    try rw [Std.Rci.mem_iff✝] at *
                                                    try rw [Std.Roc.mem_iff✝] at *
                                                    try rw [Std.Roo.mem_iff✝] at *
                                                    try rw [Std.Roi.mem_iff✝] at *
                                                    try rw [Std.Ric.mem_iff✝] at *
                                                    try rw [Std.Rio.mem_iff✝] at *
                                                    try rw [Std.Rii.mem_iff✝] at *
                                                    dsimp +zetaDelta✝ only [Vector.size✝] at *
                                                    omega
                                                  | done
                                                [Elab.step] [0.019640] 
                                                      try rw [Std.Rcc.mem_iff✝] at *
                                                      try rw [Std.Rco.mem_iff✝] at *
                                                      try rw [Std.Rci.mem_iff✝] at *
                                                      try rw [Std.Roc.mem_iff✝] at *
                                                      try rw [Std.Roo.mem_iff✝] at *
                                                      try rw [Std.Roi.mem_iff✝] at *
                                                      try rw [Std.Ric.mem_iff✝] at *
                                                      try rw [Std.Rio.mem_iff✝] at *
                                                      try rw [Std.Rii.mem_iff✝] at *
                                                      dsimp +zetaDelta✝ only [Vector.size✝] at *
                                                      omega
                                                  [Elab.step] [0.019636] 
                                                        try rw [Std.Rcc.mem_iff✝] at *
                                                        try rw [Std.Rco.mem_iff✝] at *
                                                        try rw [Std.Rci.mem_iff✝] at *
                                                        try rw [Std.Roc.mem_iff✝] at *
                                                        try rw [Std.Roo.mem_iff✝] at *
                                                        try rw [Std.Roi.mem_iff✝] at *
                                                        try rw [Std.Ric.mem_iff✝] at *
                                                        try rw [Std.Rio.mem_iff✝] at *
                                                        try rw [Std.Rii.mem_iff✝] at *
                                                        dsimp +zetaDelta✝ only [Vector.size✝] at *
                                                        omega
Build completed successfully (1143 jobs).
```
</details>

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

When merging, all the commits will be squashed into a single commit
listing all co-authors.

Co-authors in the squash commit are gathered from two sources:

First, all authors of commits to this PR branch are included. Thus,
one way to add co-authors is to include at least one commit authored by
each co-author among the commits in the pull request. If necessary, you
may create empty commits to indicate co-authorship, using commands like so:

git commit --author="Author Name <author@email.com>" --allow-empty -m "add Author Name as coauthor"

Second, co-authors can also be listed in lines at the very bottom of
the commit message (that is, directly before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines
at the bottom of the commit message (before the `---`, and also before
any "Co-authored-by" lines) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
