### PR TITLE
[Merged by Bors] - chore(Topology/MetricSpace): golf `candidates_nonneg` and `candidates_lipschitz_aux` using `grind`

### DIFF
--- a/Mathlib/Topology/MetricSpace/GromovHausdorffRealized.lean
+++ b/Mathlib/Topology/MetricSpace/GromovHausdorffRealized.lean
@@ -115,7 +115,6 @@ private theorem maxVar_bound [CompactSpace X] [Nonempty X] [CompactSpace Y] [Non
 private theorem candidates_symm (fA : f ∈ candidates X Y) : f (x, y) = f (y, x) :=
   fA.1.1.1.2 x y
 
-@[local grind .]
 private theorem candidates_triangle (fA : f ∈ candidates X Y) : f (x, z) ≤ f (x, y) + f (y, z) :=
   fA.1.1.2 x y z
 
@@ -123,7 +122,7 @@ private theorem candidates_refl (fA : f ∈ candidates X Y) : f (x, x) = 0 :=
   fA.1.2 x
 
 private theorem candidates_nonneg (fA : f ∈ candidates X Y) : 0 ≤ f (x, y) := by
-  grind [candidates_symm]
+  grind [candidates_symm, candidates_triangle]
 
 private theorem candidates_dist_inl (fA : f ∈ candidates X Y) (x y : X) :
     f (inl x, inl y) = dist x y :=
@@ -170,7 +169,8 @@ private theorem candidates_dist_bound (fA : f ∈ candidates X Y) :
 private theorem candidates_lipschitz_aux (fA : f ∈ candidates X Y) :
     f (x, y) - f (z, t) ≤ 2 * maxVar X Y * dist (x, y) (z, t) :=
   calc
-    f (x, y) - f (z, t) ≤ f (x, z) + f (z, t) + f (t, y) - f (z, t) := by grind
+    f (x, y) - f (z, t) ≤ f (x, z) + f (z, t) + f (t, y) - f (z, t) := by
+      grind [candidates_triangle]
     _ = f (x, z) + f (t, y) := by simp [sub_eq_add_neg, add_assoc]
     _ ≤ maxVar X Y * dist x z + maxVar X Y * dist t y := by
       gcongr <;> apply candidates_dist_bound fA

--- a/Mathlib/Topology/MetricSpace/GromovHausdorffRealized.lean
+++ b/Mathlib/Topology/MetricSpace/GromovHausdorffRealized.lean
@@ -115,6 +115,7 @@ private theorem maxVar_bound [CompactSpace X] [Nonempty X] [CompactSpace Y] [Non
 private theorem candidates_symm (fA : f ∈ candidates X Y) : f (x, y) = f (y, x) :=
   fA.1.1.1.2 x y
 
+@[local grind .]
 private theorem candidates_triangle (fA : f ∈ candidates X Y) : f (x, z) ≤ f (x, y) + f (y, z) :=
   fA.1.1.2 x y z
 
@@ -122,13 +123,7 @@ private theorem candidates_refl (fA : f ∈ candidates X Y) : f (x, x) = 0 :=
   fA.1.2 x
 
 private theorem candidates_nonneg (fA : f ∈ candidates X Y) : 0 ≤ f (x, y) := by
-  have : 0 ≤ 2 * f (x, y) :=
-    calc
-      0 = f (x, x) := (candidates_refl fA).symm
-      _ ≤ f (x, y) + f (y, x) := candidates_triangle fA
-      _ = f (x, y) + f (x, y) := by rw [candidates_symm fA]
-      _ = 2 * f (x, y) := by ring
-  linarith
+  grind [candidates_symm]
 
 private theorem candidates_dist_inl (fA : f ∈ candidates X Y) (x y : X) :
     f (inl x, inl y) = dist x y :=
@@ -175,8 +170,7 @@ private theorem candidates_dist_bound (fA : f ∈ candidates X Y) :
 private theorem candidates_lipschitz_aux (fA : f ∈ candidates X Y) :
     f (x, y) - f (z, t) ≤ 2 * maxVar X Y * dist (x, y) (z, t) :=
   calc
-    f (x, y) - f (z, t) ≤ f (x, t) + f (t, y) - f (z, t) := by gcongr; exact candidates_triangle fA
-    _ ≤ f (x, z) + f (z, t) + f (t, y) - f (z, t) := by gcongr; exact candidates_triangle fA
+    f (x, y) - f (z, t) ≤ f (x, z) + f (z, t) + f (t, y) - f (z, t) := by grind
     _ = f (x, z) + f (t, y) := by simp [sub_eq_add_neg, add_assoc]
     _ ≤ maxVar X Y * dist x z + maxVar X Y * dist t y := by
       gcongr <;> apply candidates_dist_bound fA


### PR DESCRIPTION
---
<details>
<summary>Show trace profiling of <code>candidates_nonneg</code>: 56 ms before, 36 ms after  🎉</summary>

### Trace profiling of `candidates_nonneg` before PR 32051
```diff
diff --git a/Mathlib/Topology/MetricSpace/GromovHausdorffRealized.lean b/Mathlib/Topology/MetricSpace/GromovHausdorffRealized.lean
index 34b492bd19..6d74fd75c3 100644
--- a/Mathlib/Topology/MetricSpace/GromovHausdorffRealized.lean
+++ b/Mathlib/Topology/MetricSpace/GromovHausdorffRealized.lean
@@ -121,7 +121,8 @@ private theorem candidates_triangle (fA : f ∈ candidates X Y) : f (x, z) ≤ f
 private theorem candidates_refl (fA : f ∈ candidates X Y) : f (x, x) = 0 :=
   fA.1.2 x
 
-private theorem candidates_nonneg (fA : f ∈ candidates X Y) : 0 ≤ f (x, y) := by
+set_option trace.profiler true in
+theorem candidates_nonneg (fA : f ∈ candidates X Y) : 0 ≤ f (x, y) := by
   have : 0 ≤ 2 * f (x, y) :=
     calc
       0 = f (x, x) := (candidates_refl fA).symm
```
```
ℹ [1782/1782] Built Mathlib.Topology.MetricSpace.GromovHausdorffRealized (2.0s)
info: Mathlib/Topology/MetricSpace/GromovHausdorffRealized.lean:125:0: [Elab.async] [0.056451] elaborating proof of GromovHausdorff.candidates_nonneg
  [Elab.definition.value] [0.055573] GromovHausdorff.candidates_nonneg
    [Elab.step] [0.055140] 
          have : 0 ≤ 2 * f (x, y) :=
            calc
              0 = f (x, x) := (candidates_refl fA).symm
              _ ≤ f (x, y) + f (y, x) := (candidates_triangle fA)
              _ = f (x, y) + f (x, y) := by rw [candidates_symm fA]
              _ = 2 * f (x, y) := by ring
          linarith
      [Elab.step] [0.055131] 
            have : 0 ≤ 2 * f (x, y) :=
              calc
                0 = f (x, x) := (candidates_refl fA).symm
                _ ≤ f (x, y) + f (y, x) := (candidates_triangle fA)
                _ = f (x, y) + f (x, y) := by rw [candidates_symm fA]
                _ = 2 * f (x, y) := by ring
            linarith
        [Elab.step] [0.022881] have : 0 ≤ 2 * f (x, y) :=
              calc
                0 = f (x, x) := (candidates_refl fA).symm
                _ ≤ f (x, y) + f (y, x) := (candidates_triangle fA)
                _ = f (x, y) + f (x, y) := by rw [candidates_symm fA]
                _ = 2 * f (x, y) := by ring
          [Elab.step] [0.022866] refine_lift
                have : 0 ≤ 2 * f (x, y) :=
                  calc
                    0 = f (x, x) := (candidates_refl fA).symm
                    _ ≤ f (x, y) + f (y, x) := (candidates_triangle fA)
                    _ = f (x, y) + f (x, y) := by rw [candidates_symm fA]
                    _ = 2 * f (x, y) := by ring;
                ?_
            [Elab.step] [0.022861] focus
                  (refine
                      no_implicit_lambda%
                        (have : 0 ≤ 2 * f (x, y) :=
                          calc
                            0 = f (x, x) := (candidates_refl fA).symm
                            _ ≤ f (x, y) + f (y, x) := (candidates_triangle fA)
                            _ = f (x, y) + f (x, y) := by rw [candidates_symm fA]
                            _ = 2 * f (x, y) := by ring;
                        ?_);
                    rotate_right)
              [Elab.step] [0.022853] (refine
                        no_implicit_lambda%
                          (have : 0 ≤ 2 * f (x, y) :=
                            calc
                              0 = f (x, x) := (candidates_refl fA).symm
                              _ ≤ f (x, y) + f (y, x) := (candidates_triangle fA)
                              _ = f (x, y) + f (x, y) := by rw [candidates_symm fA]
                              _ = 2 * f (x, y) := by ring;
                          ?_);
                      rotate_right)
                [Elab.step] [0.022850] (refine
                          no_implicit_lambda%
                            (have : 0 ≤ 2 * f (x, y) :=
                              calc
                                0 = f (x, x) := (candidates_refl fA).symm
                                _ ≤ f (x, y) + f (y, x) := (candidates_triangle fA)
                                _ = f (x, y) + f (x, y) := by rw [candidates_symm fA]
                                _ = 2 * f (x, y) := by ring;
                            ?_);
                        rotate_right)
                  [Elab.step] [0.022846] (refine
                          no_implicit_lambda%
                            (have : 0 ≤ 2 * f (x, y) :=
                              calc
                                0 = f (x, x) := (candidates_refl fA).symm
                                _ ≤ f (x, y) + f (y, x) := (candidates_triangle fA)
                                _ = f (x, y) + f (x, y) := by rw [candidates_symm fA]
                                _ = 2 * f (x, y) := by ring;
                            ?_);
                        rotate_right)
                    [Elab.step] [0.022841] refine
                            no_implicit_lambda%
                              (have : 0 ≤ 2 * f (x, y) :=
                                calc
                                  0 = f (x, x) := (candidates_refl fA).symm
                                  _ ≤ f (x, y) + f (y, x) := (candidates_triangle fA)
                                  _ = f (x, y) + f (x, y) := by rw [candidates_symm fA]
                                  _ = 2 * f (x, y) := by ring;
                              ?_);
                          rotate_right
                      [Elab.step] [0.022836] refine
                              no_implicit_lambda%
                                (have : 0 ≤ 2 * f (x, y) :=
                                  calc
                                    0 = f (x, x) := (candidates_refl fA).symm
                                    _ ≤ f (x, y) + f (y, x) := (candidates_triangle fA)
                                    _ = f (x, y) + f (x, y) := by rw [candidates_symm fA]
                                    _ = 2 * f (x, y) := by ring;
                                ?_);
                            rotate_right
                        [Elab.step] [0.022816] refine
                              no_implicit_lambda%
                                (have : 0 ≤ 2 * f (x, y) :=
                                  calc
                                    0 = f (x, x) := (candidates_refl fA).symm
                                    _ ≤ f (x, y) + f (y, x) := (candidates_triangle fA)
                                    _ = f (x, y) + f (x, y) := by rw [candidates_symm fA]
                                    _ = 2 * f (x, y) := by ring;
                                ?_)
                          [Elab.step] [0.011338] ring
                            [Elab.step] [0.011333] ring
                              [Elab.step] [0.011327] ring
        [Elab.step] [0.032235] linarith
          [linarith] [0.023014] ✅️ running on preferred type ℝ
Build completed successfully (1782 jobs).
```

### Trace profiling of `candidates_nonneg` after PR 32051
```diff
diff --git a/Mathlib/Topology/MetricSpace/GromovHausdorffRealized.lean b/Mathlib/Topology/MetricSpace/GromovHausdorffRealized.lean
index 34b492bd19..aaf3029c83 100644
--- a/Mathlib/Topology/MetricSpace/GromovHausdorffRealized.lean
+++ b/Mathlib/Topology/MetricSpace/GromovHausdorffRealized.lean
@@ -115,20 +115,16 @@ private theorem maxVar_bound [CompactSpace X] [Nonempty X] [CompactSpace Y] [Non
 private theorem candidates_symm (fA : f ∈ candidates X Y) : f (x, y) = f (y, x) :=
   fA.1.1.1.2 x y
 
+@[local grind .]
 private theorem candidates_triangle (fA : f ∈ candidates X Y) : f (x, z) ≤ f (x, y) + f (y, z) :=
   fA.1.1.2 x y z
 
 private theorem candidates_refl (fA : f ∈ candidates X Y) : f (x, x) = 0 :=
   fA.1.2 x
 
+set_option trace.profiler true in
 private theorem candidates_nonneg (fA : f ∈ candidates X Y) : 0 ≤ f (x, y) := by
-  have : 0 ≤ 2 * f (x, y) :=
-    calc
-      0 = f (x, x) := (candidates_refl fA).symm
-      _ ≤ f (x, y) + f (y, x) := candidates_triangle fA
-      _ = f (x, y) + f (x, y) := by rw [candidates_symm fA]
-      _ = 2 * f (x, y) := by ring
-  linarith
+  grind [candidates_symm]
 
 private theorem candidates_dist_inl (fA : f ∈ candidates X Y) (x y : X) :
     f (inl x, inl y) = dist x y :=
@@ -175,8 +171,7 @@ private theorem candidates_dist_bound (fA : f ∈ candidates X Y) :
 private theorem candidates_lipschitz_aux (fA : f ∈ candidates X Y) :
     f (x, y) - f (z, t) ≤ 2 * maxVar X Y * dist (x, y) (z, t) :=
   calc
-    f (x, y) - f (z, t) ≤ f (x, t) + f (t, y) - f (z, t) := by gcongr; exact candidates_triangle fA
-    _ ≤ f (x, z) + f (z, t) + f (t, y) - f (z, t) := by gcongr; exact candidates_triangle fA
+    f (x, y) - f (z, t) ≤ f (x, z) + f (z, t) + f (t, y) - f (z, t) := by grind
     _ = f (x, z) + f (t, y) := by simp [sub_eq_add_neg, add_assoc]
     _ ≤ maxVar X Y * dist x z + maxVar X Y * dist t y := by
       gcongr <;> apply candidates_dist_bound fA
```
```
ℹ [1782/1782] Built Mathlib.Topology.MetricSpace.GromovHausdorffRealized (2.2s)
info: Mathlib/Topology/MetricSpace/GromovHausdorffRealized.lean:126:0: [Elab.async] [0.036501] elaborating proof of _private.Mathlib.Topology.MetricSpace.GromovHausdorffRealized.0.GromovHausdorff.candidates_nonneg
  [Elab.definition.value] [0.036268] _private.Mathlib.Topology.MetricSpace.GromovHausdorffRealized.0.GromovHausdorff.candidates_nonneg
    [Elab.step] [0.036159] grind [candidates_symm]
      [Elab.step] [0.036153] grind [candidates_symm]
        [Elab.step] [0.036146] grind [candidates_symm]
info: Mathlib/Topology/MetricSpace/GromovHausdorffRealized.lean:127:2: [Elab.async] [0.010387] Lean.addDecl
  [Kernel] [0.010362] ✅️ typechecking declarations [_private.Mathlib.Topology.MetricSpace.GromovHausdorffRealized.0.GromovHausdorff.candidates_nonneg._proof_1_1]
Build completed successfully (1782 jobs).
```
</details>

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

When merging, all the commits will be squashed into a single commit
listing all co-authors.

Co-authors in the squash commit are gathered from two sources:

First, all authors of commits to this PR branch are included. Thus,
one way to add co-authors is to include at least one commit authored by
each co-author among the commits in the pull request. If necessary, you
may create empty commits to indicate co-authorship, using commands like so:

git commit --author="Author Name <author@email.com>" --allow-empty -m "add Author Name as coauthor"

Second, co-authors can also be listed in lines at the very bottom of
the commit message (that is, directly before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines
at the bottom of the commit message (before the `---`, and also before
any "Co-authored-by" lines) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
