### PR TITLE
[Merged by Bors] - perf: temporarily disable MathlibTest/propose

### DIFF
--- a/MathlibTest/propose.lean
+++ b/MathlibTest/propose.lean
@@ -15,8 +15,7 @@ set_option linter.unusedVariables false
 -- TODO make this test faster, or decide to delete `have?` and this test. Zulip discussion at
 -- https://leanprover.zulipchat.com/#narrow/channel/287929-mathlib4/topic/.22test.20mathlib.22.20step.20is.20slow.20in.20CI
 
-#exit
-
+/-
 theorem foo (L M : List α) (w : L.Disjoint M) (m : a ∈ L) : a ∉ M := fun h => w m h
 
 /--
@@ -130,3 +129,4 @@ theorem dvd_of_dvd_pow (hp : Prime p) {a : α} {n : ℕ} (h : p ∣ a ^ n) : p �
     obtain dvd_a | dvd_pow := dvd_or_dvd hp h
     · assumption
     exact ih dvd_pow
+-/

--- a/MathlibTest/propose.lean
+++ b/MathlibTest/propose.lean
@@ -10,6 +10,13 @@ import Batteries.Data.List.Lemmas
 set_option autoImplicit true
 set_option linter.unusedVariables false
 
+-- This test takes around five minutes on CI, making it by far the longest individual test
+-- and delaying the overall testing step.
+-- TODO make this test faster, or decide to delete `have?` and this test. Zulip discussion at
+-- https://leanprover.zulipchat.com/#narrow/channel/287929-mathlib4/topic/.22test.20mathlib.22.20step.20is.20slow.20in.20CI
+
+#exit
+
 theorem foo (L M : List α) (w : L.Disjoint M) (m : a ∈ L) : a ∉ M := fun h => w m h
 
 /--


### PR DESCRIPTION
This test takes about six minutes in CI, making it the slowest by far the longest individual test -- and delaying the overall testing step in CI. The proper fix is to either speed up the test, or decide that the functionality it is testing (have?) is not worth keeping. This is being discussed on zulip. Until then, disable the test to keep CI at reasonable speed.


---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

When merging, all the commits will be squashed into a single commit
listing all co-authors.

Co-authors in the squash commit are gathered from two sources:

First, all authors of commits to this PR branch are included. Thus,
one way to add co-authors is to include at least one commit authored by
each co-author among the commits in the pull request. If necessary, you
may create empty commits to indicate co-authorship, using commands like so:

git commit --author="Author Name <author@email.com>" --allow-empty -m "add Author Name as coauthor"

Second, co-authors can also be listed in lines at the very bottom of
the commit message (that is, directly before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines
at the bottom of the commit message (before the `---`, and also before
any "Co-authored-by" lines) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
