### PR TITLE
[Merged by Bors] - chore(RingTheory/DividedPowers/Padic): rename lemma

### DIFF
--- a/Mathlib/RingTheory/DividedPowers/Padic.lean
+++ b/Mathlib/RingTheory/DividedPowers/Padic.lean
@@ -26,11 +26,7 @@ TODO: If `K` is a `p`-adic local field with ring of integers `R` and uniformizer
 
 @[expose] public section
 
-namespace PadicInt
-
 open DividedPowers DividedPowers.OfInvertibleFactorial Nat Ring
-
-variable (p : ℕ) [hp : Fact p.Prime]
 
 section Injective
 
@@ -41,7 +37,7 @@ variable {A B : Type*} [CommSemiring A] [CommSemiring B] (I : Ideal A) (J : Idea
 /-- Given a divided power algebra `(B, J, δ)` and an injective ring morphism `f : A →+* B`, if `I`
 is an `A`-ideal such that `I.map f = J` and such that for all `n : ℕ`, `x ∈ I`, the preimage of
 `hJ.dpow n (f x)` under `f` belongs to `I`, this is the induced divided power structure on `I`. -/
-noncomputable def dividedPowers_of_injective (f : A →+* B) (hf : Injective f)
+noncomputable def DividedPowers.ofInjective (f : A →+* B) (hf : Injective f)
     (hJ : DividedPowers J) (hIJ : I.map f = J)
     (hmem : ∀ (n : ℕ) {x : A} (_ : x ∈ I), ∃ (y : A) (_ : n ≠ 0 → y ∈ I), f y = hJ.dpow n (f x)) :
     DividedPowers I where
@@ -77,7 +73,11 @@ noncomputable def dividedPowers_of_injective (f : A →+* B) (hf : Injective f)
 
 end Injective
 
+namespace PadicInt
+
 section Padic
+
+variable (p : ℕ) [hp : Fact p.Prime]
 
 /-- The family `ℕ → ℚ_[p] → ℚ_[p]` given by `dpow n x = x ^ n / n!`. -/
 private noncomputable def dpow' : ℕ → ℚ_[p] → ℚ_[p] := fun m x => inverse (m ! : ℚ_[p]) * x ^ m
@@ -131,7 +131,7 @@ private theorem dpow'_mem {n : ℕ} {x : ℤ_[p]} (hm : n ≠ 0) (hx : x ∈ Ide
   divided power structure on the `ℤ_[p]`-ideal `(p)`. -/
 noncomputable def dividedPowers : DividedPowers (Ideal.span {(p : ℤ_[p])}) := by
   classical
-  refine dividedPowers_of_injective (Ideal.span {(p : ℤ_[p])}) (⊤)
+  refine ofInjective (Ideal.span {(p : ℤ_[p])}) (⊤)
     PadicInt.Coe.ringHom ((Set.injective_codRestrict Subtype.property).mp fun ⦃a₁ a₂⦄ a ↦ a)
     (RatAlgebra.dividedPowers (⊤ : Ideal ℚ_[p])) ?_ ?_
   · rw [Ideal.map_span, Set.image_singleton, map_natCast]
@@ -147,7 +147,7 @@ open Function
 private lemma dividedPowers_eq (n : ℕ) (x : ℤ_[p]) :
     (dividedPowers p).dpow n x = open Classical in
       if hx : x ∈ Ideal.span {(p : ℤ_[p])} then ⟨dpow' p n x, dpow'_int p n hx⟩ else 0 := by
-  simp only [dividedPowers, dividedPowers_of_injective]
+  simp only [dividedPowers, ofInjective]
   split_ifs with hx
   · have hinj : Injective (PadicInt.Coe.ringHom (p := p)) :=
       (Set.injective_codRestrict Subtype.property).mp fun ⦃a₁ a₂⦄ a ↦ a


### PR DESCRIPTION
The definition `PadicInt.divided_powers_of_injective` was incorrectly named, as it is not specific to the p-adic integers. I rename it to `DividedPowers.ofInjective`.

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

When merging, all the commits will be squashed into a single commit
listing all co-authors.

Co-authors in the squash commit are gathered from two sources:

First, all authors of commits to this PR branch are included. Thus,
one way to add co-authors is to include at least one commit authored by
each co-author among the commits in the pull request. If necessary, you
may create empty commits to indicate co-authorship, using commands like so:

git commit --author="Author Name <author@email.com>" --allow-empty -m "add Author Name as coauthor"

Second, co-authors can also be listed in lines at the very bottom of
the commit message (that is, directly before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines
at the bottom of the commit message (before the `---`, and also before
any "Co-authored-by" lines) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
