### PR TITLE
[Merged by Bors] - chore(Data/Fintype): golf entire `piFinset_update_eq_filter_piFinset_mem` (+ others) using `grind`. `grind` annotate `mem_piFinset`

### DIFF
--- a/Mathlib/Data/Fintype/Pi.lean
+++ b/Mathlib/Data/Fintype/Pi.lean
@@ -33,7 +33,7 @@ def piFinset (t : ∀ a, Finset (δ a)) : Finset (∀ a, δ a) :=
   (Finset.univ.pi t).map ⟨fun f a => f a (mem_univ a), fun _ _ =>
     by simp +contextual [funext_iff]⟩
 
-@[simp]
+@[simp, grind =]
 theorem mem_piFinset {t : ∀ a, Finset (δ a)} {f : ∀ a, δ a} : f ∈ piFinset t ↔ ∀ a, f a ∈ t a := by
   constructor
   · simp only [piFinset, mem_map, and_imp, forall_prop_of_true, mem_univ, exists_imp,
@@ -75,7 +75,7 @@ lemma piFinset_of_isEmpty [IsEmpty α] (s : ∀ a, Finset (γ a)) : piFinset s =
 
 @[simp]
 theorem piFinset_singleton (f : ∀ i, δ i) : piFinset (fun i => {f i} : ∀ i, Finset (δ i)) = {f} :=
-  ext fun _ => by simp only [funext_iff, Fintype.mem_piFinset, mem_singleton]
+  ext fun _ => by grind
 
 theorem piFinset_subsingleton {f : ∀ i, Finset (δ i)} (hf : ∀ i, (f i : Set (δ i)).Subsingleton) :
     (Fintype.piFinset f : Set (∀ i, δ i)).Subsingleton := fun _ ha _ hb =>
@@ -111,29 +111,18 @@ variable [∀ a, DecidableEq (δ a)]
 
 lemma filter_piFinset_of_notMem (t : ∀ a, Finset (δ a)) (a : α) (x : δ a) (hx : x ∉ t a) :
     {f ∈ piFinset t | f a = x} = ∅ := by
-  simp only [filter_eq_empty_iff, mem_piFinset]; rintro f hf rfl; exact hx (hf _)
+  grind
 
 @[deprecated (since := "2025-05-23")] alias filter_piFinset_of_not_mem := filter_piFinset_of_notMem
 
--- TODO: This proof looks like a good example of something that `aesop` can't do but should
 lemma piFinset_update_eq_filter_piFinset_mem (s : ∀ i, Finset (δ i)) (i : α) {t : Finset (δ i)}
     (hts : t ⊆ s i) : piFinset (Function.update s i t) = {f ∈ piFinset s | f i ∈ t} := by
-  ext f
-  simp only [mem_piFinset, mem_filter]
-  refine ⟨fun h ↦ ?_, fun h j ↦ ?_⟩
-  · have := by simpa using h i
-    refine ⟨fun j ↦ ?_, this⟩
-    obtain rfl | hji := eq_or_ne j i
-    · exact hts this
-    · simpa [hji] using h j
-  · obtain rfl | hji := eq_or_ne j i
-    · simpa using h.2
-    · simpa [hji] using h.1 j
+  grind
 
 lemma piFinset_update_singleton_eq_filter_piFinset_eq (s : ∀ i, Finset (δ i)) (i : α) {a : δ i}
     (ha : a ∈ s i) :
     piFinset (Function.update s i {a}) = {f ∈ piFinset s | f i = a} := by
-  simp [piFinset_update_eq_filter_piFinset_mem, ha]
+  grind
 
 end Fintype
 


### PR DESCRIPTION
---
<details>
<summary>Show trace profiling of <code>piFinset_update_eq_filter_piFinset_mem</code>: <10 ms before, 21 ms after </summary>

### Trace profiling of `piFinset_update_eq_filter_piFinset_mem` before PR 32065
```diff
diff --git a/Mathlib/Data/Fintype/Pi.lean b/Mathlib/Data/Fintype/Pi.lean
index 7fd7ade9dd..dc1d70d327 100644
--- a/Mathlib/Data/Fintype/Pi.lean
+++ b/Mathlib/Data/Fintype/Pi.lean
@@ -116,6 +116,7 @@ lemma filter_piFinset_of_notMem (t : ∀ a, Finset (δ a)) (a : α) (x : δ a) (
 @[deprecated (since := "2025-05-23")] alias filter_piFinset_of_not_mem := filter_piFinset_of_notMem
 
 -- TODO: This proof looks like a good example of something that `aesop` can't do but should
+set_option trace.profiler true in
 lemma piFinset_update_eq_filter_piFinset_mem (s : ∀ i, Finset (δ i)) (i : α) {t : Finset (δ i)}
     (hts : t ⊆ s i) : piFinset (Function.update s i t) = {f ∈ piFinset s | f i ∈ t} := by
   ext f
```
```
ℹ [663/663] Built Mathlib.Data.Fintype.Pi (1.1s)
info: Mathlib/Data/Fintype/Pi.lean:120:0: [Elab.command] [0.010791] theorem piFinset_update_eq_filter_piFinset_mem (s : ∀ i, Finset (δ i)) (i : α)
        {t : Finset (δ i)} (hts : t ⊆ s i) : piFinset (Function.update s i t) = {f ∈ piFinset s | f i ∈ t} :=
      by
      ext f
      simp only [mem_piFinset, mem_filter]
      refine ⟨fun h ↦ ?_, fun h j ↦ ?_⟩
      · have := by simpa using h i
        refine ⟨fun j ↦ ?_, this⟩
        obtain rfl | hji := eq_or_ne j i
        · exact hts this
        · simpa [hji] using h j
      · obtain rfl | hji := eq_or_ne j i
        · simpa using h.2
        · simpa [hji] using h.1 j
info: Mathlib/Data/Fintype/Pi.lean:120:0: [Elab.command] [0.010998] lemma piFinset_update_eq_filter_piFinset_mem (s : ∀ i, Finset (δ i)) (i : α)
        {t : Finset (δ i)} (hts : t ⊆ s i) : piFinset (Function.update s i t) = {f ∈ piFinset s | f i ∈ t} :=
      by
      ext f
      simp only [mem_piFinset, mem_filter]
      refine ⟨fun h ↦ ?_, fun h j ↦ ?_⟩
      · have := by simpa using h i
        refine ⟨fun j ↦ ?_, this⟩
        obtain rfl | hji := eq_or_ne j i
        · exact hts this
        · simpa [hji] using h j
      · obtain rfl | hji := eq_or_ne j i
        · simpa using h.2
        · simpa [hji] using h.1 j
Build completed successfully (663 jobs).
```

### Trace profiling of `piFinset_update_eq_filter_piFinset_mem` after PR 32065
```diff
diff --git a/Mathlib/Data/Fintype/Pi.lean b/Mathlib/Data/Fintype/Pi.lean
index 7fd7ade9dd..f898a5e045 100644
--- a/Mathlib/Data/Fintype/Pi.lean
+++ b/Mathlib/Data/Fintype/Pi.lean
@@ -33,7 +33,7 @@ def piFinset (t : ∀ a, Finset (δ a)) : Finset (∀ a, δ a) :=
   (Finset.univ.pi t).map ⟨fun f a => f a (mem_univ a), fun _ _ =>
     by simp +contextual [funext_iff]⟩
 
-@[simp]
+@[simp, grind =]
 theorem mem_piFinset {t : ∀ a, Finset (δ a)} {f : ∀ a, δ a} : f ∈ piFinset t ↔ ∀ a, f a ∈ t a := by
   constructor
   · simp only [piFinset, mem_map, and_imp, forall_prop_of_true, mem_univ, exists_imp,
@@ -75,7 +75,7 @@ lemma piFinset_of_isEmpty [IsEmpty α] (s : ∀ a, Finset (γ a)) : piFinset s =
 
 @[simp]
 theorem piFinset_singleton (f : ∀ i, δ i) : piFinset (fun i => {f i} : ∀ i, Finset (δ i)) = {f} :=
-  ext fun _ => by simp only [funext_iff, Fintype.mem_piFinset, mem_singleton]
+  ext fun _ => by grind
 
 theorem piFinset_subsingleton {f : ∀ i, Finset (δ i)} (hf : ∀ i, (f i : Set (δ i)).Subsingleton) :
     (Fintype.piFinset f : Set (∀ i, δ i)).Subsingleton := fun _ ha _ hb =>
@@ -111,29 +111,19 @@ variable [∀ a, DecidableEq (δ a)]
 
 lemma filter_piFinset_of_notMem (t : ∀ a, Finset (δ a)) (a : α) (x : δ a) (hx : x ∉ t a) :
     {f ∈ piFinset t | f a = x} = ∅ := by
-  simp only [filter_eq_empty_iff, mem_piFinset]; rintro f hf rfl; exact hx (hf _)
+  grind
 
 @[deprecated (since := "2025-05-23")] alias filter_piFinset_of_not_mem := filter_piFinset_of_notMem
 
--- TODO: This proof looks like a good example of something that `aesop` can't do but should
+set_option trace.profiler true in
 lemma piFinset_update_eq_filter_piFinset_mem (s : ∀ i, Finset (δ i)) (i : α) {t : Finset (δ i)}
     (hts : t ⊆ s i) : piFinset (Function.update s i t) = {f ∈ piFinset s | f i ∈ t} := by
-  ext f
-  simp only [mem_piFinset, mem_filter]
-  refine ⟨fun h ↦ ?_, fun h j ↦ ?_⟩
-  · have := by simpa using h i
-    refine ⟨fun j ↦ ?_, this⟩
-    obtain rfl | hji := eq_or_ne j i
-    · exact hts this
-    · simpa [hji] using h j
-  · obtain rfl | hji := eq_or_ne j i
-    · simpa using h.2
-    · simpa [hji] using h.1 j
+  grind
 
 lemma piFinset_update_singleton_eq_filter_piFinset_eq (s : ∀ i, Finset (δ i)) (i : α) {a : δ i}
     (ha : a ∈ s i) :
     piFinset (Function.update s i {a}) = {f ∈ piFinset s | f i = a} := by
-  simp [piFinset_update_eq_filter_piFinset_mem, ha]
+  grind
 
 end Fintype
 
```
```
ℹ [663/663] Built Mathlib.Data.Fintype.Pi (1.1s)
info: Mathlib/Data/Fintype/Pi.lean:119:0: [Elab.async] [0.021005] elaborating proof of Fintype.piFinset_update_eq_filter_piFinset_mem
  [Elab.definition.value] [0.020812] Fintype.piFinset_update_eq_filter_piFinset_mem
    [Elab.step] [0.020690] grind
      [Elab.step] [0.020684] grind
        [Elab.step] [0.020678] grind
Build completed successfully (663 jobs).
```
</details>

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

When merging, all the commits will be squashed into a single commit
listing all co-authors.

Co-authors in the squash commit are gathered from two sources:

First, all authors of commits to this PR branch are included. Thus,
one way to add co-authors is to include at least one commit authored by
each co-author among the commits in the pull request. If necessary, you
may create empty commits to indicate co-authorship, using commands like so:

git commit --author="Author Name <author@email.com>" --allow-empty -m "add Author Name as coauthor"

Second, co-authors can also be listed in lines at the very bottom of
the commit message (that is, directly before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines
at the bottom of the commit message (before the `---`, and also before
any "Co-authored-by" lines) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
