### PR TITLE
chore(GroupTheory/GroupAction): golf `eq_top_of_isMultiplyPretransitive` using `grind`

### DIFF
--- a/Mathlib/GroupTheory/GroupAction/MultipleTransitivity.lean
+++ b/Mathlib/GroupTheory/GroupAction/MultipleTransitivity.lean
@@ -600,7 +600,7 @@ theorem eq_top_of_isMultiplyPretransitive [Finite α] {G : Subgroup (Equiv.Perm 
     Function.Embedding.ext_iff.mp hg' ⟨i.val, hi⟩
   have hgk (i : Fin (Fintype.card α)) : (g • x) i = (k • x) i := by
     obtain ⟨j, hxj : (k • x) j = (g • x) i⟩ := hx (k • x) ((g • x) i)
-    grind
+    grind only [!Function.Embedding.injective]
   ext a
   obtain ⟨i, rfl⟩ := (hx x) a
   specialize hgk i

--- a/Mathlib/GroupTheory/GroupAction/MultipleTransitivity.lean
+++ b/Mathlib/GroupTheory/GroupAction/MultipleTransitivity.lean
@@ -599,18 +599,8 @@ theorem eq_top_of_isMultiplyPretransitive [Finite α] {G : Subgroup (Equiv.Perm 
       (g • x) i = (k • x) i :=
     Function.Embedding.ext_iff.mp hg' ⟨i.val, hi⟩
   have hgk (i : Fin (Fintype.card α)) : (g • x) i = (k • x) i := by
-    rcases lt_or_eq_of_le (le_sub_one_of_lt i.prop) with hi | hi
-    · exact hgk' i hi
-    · obtain ⟨j, hxj : (k • x) j = (g • x) i⟩ := hx (k • x) ((g • x) i)
-      rcases lt_or_eq_of_le (le_sub_one_of_lt j.prop) with hj | hj
-      · suffices i = j by
-          rw [← this, ← hi] at hj
-          exact (lt_irrefl _ hj).elim
-        apply EmbeddingLike.injective (g • x)
-        rw [hgk' j hj, hxj]
-      · rw [← hxj]
-        apply congr_arg
-        rw [Fin.ext_iff, hi, hj]
+    obtain ⟨j, hxj : (k • x) j = (g • x) i⟩ := hx (k • x) ((g • x) i)
+    grind
   ext a
   obtain ⟨i, rfl⟩ := (hx x) a
   specialize hgk i


### PR DESCRIPTION
---
<details>
<summary>Show trace profiling of <code>eq_top_of_isMultiplyPretransitive</code>: 58 ms before, 237 ms after (after optimization attempt)</summary>

### Trace profiling of `eq_top_of_isMultiplyPretransitive` before PR 32067
```diff
diff --git a/Mathlib/GroupTheory/GroupAction/MultipleTransitivity.lean b/Mathlib/GroupTheory/GroupAction/MultipleTransitivity.lean
index b523d8d690..69fed78c79 100644
--- a/Mathlib/GroupTheory/GroupAction/MultipleTransitivity.lean
+++ b/Mathlib/GroupTheory/GroupAction/MultipleTransitivity.lean
@@ -578,6 +578,7 @@ instance : IsPreprimitive (Perm α) α :=
   isPreprimitive_of_is_two_pretransitive (isMultiplyPretransitive _ _)
 
 -- This is optimal, `AlternatingGroup α` is `Nat.card α - 2`-pretransitive.
+set_option trace.profiler true in
 /-- A subgroup of `Perm α` is `⊤` if(f) it is `(Nat.card α - 1)`-pretransitive. -/
 theorem eq_top_of_isMultiplyPretransitive [Finite α] {G : Subgroup (Equiv.Perm α)}
     (hmt : IsMultiplyPretransitive G α (Nat.card α - 1)) : G = ⊤ := by
```
```
ℹ [1252/1252] Built Mathlib.GroupTheory.GroupAction.MultipleTransitivity (2.6s)
info: Mathlib/GroupTheory/GroupAction/MultipleTransitivity.lean:582:0: [Elab.async] [0.059474] elaborating proof of Equiv.Perm.eq_top_of_isMultiplyPretransitive
  [Elab.definition.value] [0.057928] Equiv.Perm.eq_top_of_isMultiplyPretransitive
    [Elab.step] [0.056149] 
          have := Fintype.ofFinite α
          simp only [Nat.card_eq_fintype_card] at hmt
          let j : Fin (Fintype.card α - 1) ↪ Fin (Fintype.card α) := (Fin.castLEEmb ((Fintype.card α).sub_le 1))
          rw [eq_top_iff]
          intro k _
          let x : Fin (Fintype.card α) ↪ α := (Fintype.equivFinOfCardEq rfl).symm.toEmbedding
          let x' := j.trans x
          obtain ⟨g, hg'⟩ := exists_smul_eq G x' (k • x')
          suffices k = g by rw [this]; exact SetLike.coe_mem g
          have hx (x : Fin (Fintype.card α) ↪ α) : Function.Surjective x.toFun :=
            by
            apply Function.Bijective.surjective
            rw [Fintype.bijective_iff_injective_and_card]
            exact ⟨EmbeddingLike.injective x, Fintype.card_fin (Fintype.card α)⟩
          have hgk' (i : Fin (Fintype.card α)) (hi : i.val < Fintype.card α - 1) : (g • x) i = (k • x) i :=
            Function.Embedding.ext_iff.mp hg' ⟨i.val, hi⟩
          have hgk (i : Fin (Fintype.card α)) : (g • x) i = (k • x) i :=
            by
            rcases lt_or_eq_of_le (le_sub_one_of_lt i.prop) with hi | hi
            · exact hgk' i hi
            · obtain ⟨j, hxj : (k • x) j = (g • x) i⟩ := hx (k • x) ((g • x) i)
              rcases lt_or_eq_of_le (le_sub_one_of_lt j.prop) with hj | hj
              · suffices i = j by
                  rw [← this, ← hi] at hj
                  exact (lt_irrefl _ hj).elim
                apply EmbeddingLike.injective (g • x)
                rw [hgk' j hj, hxj]
              · rw [← hxj]
                apply congr_arg
                rw [Fin.ext_iff, hi, hj]
          ext a
          obtain ⟨i, rfl⟩ := (hx x) a
          specialize hgk i
          simp only [Function.Embedding.smul_apply, Equiv.Perm.smul_def] at hgk
          simp [← hgk, Subgroup.smul_def, Perm.smul_def]
      [Elab.step] [0.056142] 
            have := Fintype.ofFinite α
            simp only [Nat.card_eq_fintype_card] at hmt
            let j : Fin (Fintype.card α - 1) ↪ Fin (Fintype.card α) := (Fin.castLEEmb ((Fintype.card α).sub_le 1))
            rw [eq_top_iff]
            intro k _
            let x : Fin (Fintype.card α) ↪ α := (Fintype.equivFinOfCardEq rfl).symm.toEmbedding
            let x' := j.trans x
            obtain ⟨g, hg'⟩ := exists_smul_eq G x' (k • x')
            suffices k = g by rw [this]; exact SetLike.coe_mem g
            have hx (x : Fin (Fintype.card α) ↪ α) : Function.Surjective x.toFun :=
              by
              apply Function.Bijective.surjective
              rw [Fintype.bijective_iff_injective_and_card]
              exact ⟨EmbeddingLike.injective x, Fintype.card_fin (Fintype.card α)⟩
            have hgk' (i : Fin (Fintype.card α)) (hi : i.val < Fintype.card α - 1) : (g • x) i = (k • x) i :=
              Function.Embedding.ext_iff.mp hg' ⟨i.val, hi⟩
            have hgk (i : Fin (Fintype.card α)) : (g • x) i = (k • x) i :=
              by
              rcases lt_or_eq_of_le (le_sub_one_of_lt i.prop) with hi | hi
              · exact hgk' i hi
              · obtain ⟨j, hxj : (k • x) j = (g • x) i⟩ := hx (k • x) ((g • x) i)
                rcases lt_or_eq_of_le (le_sub_one_of_lt j.prop) with hj | hj
                · suffices i = j by
                    rw [← this, ← hi] at hj
                    exact (lt_irrefl _ hj).elim
                  apply EmbeddingLike.injective (g • x)
                  rw [hgk' j hj, hxj]
                · rw [← hxj]
                  apply congr_arg
                  rw [Fin.ext_iff, hi, hj]
            ext a
            obtain ⟨i, rfl⟩ := (hx x) a
            specialize hgk i
            simp only [Function.Embedding.smul_apply, Equiv.Perm.smul_def] at hgk
            simp [← hgk, Subgroup.smul_def, Perm.smul_def]
        [Elab.step] [0.013146] rw [eq_top_iff]
          [Elab.step] [0.013137] (rewrite [eq_top_iff]; with_annotate_state"]" (try (with_reducible rfl)))
            [Elab.step] [0.013134] rewrite [eq_top_iff]; with_annotate_state"]" (try (with_reducible rfl))
              [Elab.step] [0.013132] rewrite [eq_top_iff]; with_annotate_state"]" (try (with_reducible rfl))
                [Elab.step] [0.012806] rewrite [eq_top_iff]
        [Elab.step] [0.016136] have hgk (i : Fin (Fintype.card α)) : (g • x) i = (k • x) i :=
              by
              rcases lt_or_eq_of_le (le_sub_one_of_lt i.prop) with hi | hi
              · exact hgk' i hi
              · obtain ⟨j, hxj : (k • x) j = (g • x) i⟩ := hx (k • x) ((g • x) i)
                rcases lt_or_eq_of_le (le_sub_one_of_lt j.prop) with hj | hj
                · suffices i = j by
                    rw [← this, ← hi] at hj
                    exact (lt_irrefl _ hj).elim
                  apply EmbeddingLike.injective (g • x)
                  rw [hgk' j hj, hxj]
                · rw [← hxj]
                  apply congr_arg
                  rw [Fin.ext_iff, hi, hj]
          [Elab.step] [0.016034] focus
                refine
                  no_implicit_lambda%
                    (have hgk (i : Fin (Fintype.card α)) : (g • x) i = (k • x) i := ?body✝;
                    ?_)
                case body✝ =>
[… 77 lines omitted …]
                                rw [Fin.ext_iff, hi, hj])
                    [Elab.step] [0.013276] with_annotate_state"by"
                            ( rcases lt_or_eq_of_le (le_sub_one_of_lt i.prop) with hi | hi
                              · exact hgk' i hi
                              · obtain ⟨j, hxj : (k • x) j = (g • x) i⟩ := hx (k • x) ((g • x) i)
                                rcases lt_or_eq_of_le (le_sub_one_of_lt j.prop) with hj | hj
                                · suffices i = j by
                                    rw [← this, ← hi] at hj
                                    exact (lt_irrefl _ hj).elim
                                  apply EmbeddingLike.injective (g • x)
                                  rw [hgk' j hj, hxj]
                                · rw [← hxj]
                                  apply congr_arg
                                  rw [Fin.ext_iff, hi, hj])
                      [Elab.step] [0.013273] with_annotate_state"by"
                            ( rcases lt_or_eq_of_le (le_sub_one_of_lt i.prop) with hi | hi
                              · exact hgk' i hi
                              · obtain ⟨j, hxj : (k • x) j = (g • x) i⟩ := hx (k • x) ((g • x) i)
                                rcases lt_or_eq_of_le (le_sub_one_of_lt j.prop) with hj | hj
                                · suffices i = j by
                                    rw [← this, ← hi] at hj
                                    exact (lt_irrefl _ hj).elim
                                  apply EmbeddingLike.injective (g • x)
                                  rw [hgk' j hj, hxj]
                                · rw [← hxj]
                                  apply congr_arg
                                  rw [Fin.ext_iff, hi, hj])
                        [Elab.step] [0.013271] (
                              rcases lt_or_eq_of_le (le_sub_one_of_lt i.prop) with hi | hi
                              · exact hgk' i hi
                              · obtain ⟨j, hxj : (k • x) j = (g • x) i⟩ := hx (k • x) ((g • x) i)
                                rcases lt_or_eq_of_le (le_sub_one_of_lt j.prop) with hj | hj
                                · suffices i = j by
                                    rw [← this, ← hi] at hj
                                    exact (lt_irrefl _ hj).elim
                                  apply EmbeddingLike.injective (g • x)
                                  rw [hgk' j hj, hxj]
                                · rw [← hxj]
                                  apply congr_arg
                                  rw [Fin.ext_iff, hi, hj])
                          [Elab.step] [0.013268] 
                                rcases lt_or_eq_of_le (le_sub_one_of_lt i.prop) with hi | hi
                                · exact hgk' i hi
                                · obtain ⟨j, hxj : (k • x) j = (g • x) i⟩ := hx (k • x) ((g • x) i)
                                  rcases lt_or_eq_of_le (le_sub_one_of_lt j.prop) with hj | hj
                                  · suffices i = j by
                                      rw [← this, ← hi] at hj
                                      exact (lt_irrefl _ hj).elim
                                    apply EmbeddingLike.injective (g • x)
                                    rw [hgk' j hj, hxj]
                                  · rw [← hxj]
                                    apply congr_arg
                                    rw [Fin.ext_iff, hi, hj]
                            [Elab.step] [0.013265] 
                                  rcases lt_or_eq_of_le (le_sub_one_of_lt i.prop) with hi | hi
                                  · exact hgk' i hi
                                  · obtain ⟨j, hxj : (k • x) j = (g • x) i⟩ := hx (k • x) ((g • x) i)
                                    rcases lt_or_eq_of_le (le_sub_one_of_lt j.prop) with hj | hj
                                    · suffices i = j by
                                        rw [← this, ← hi] at hj
                                        exact (lt_irrefl _ hj).elim
                                      apply EmbeddingLike.injective (g • x)
                                      rw [hgk' j hj, hxj]
                                    · rw [← hxj]
                                      apply congr_arg
                                      rw [Fin.ext_iff, hi, hj]
                              [Elab.step] [0.011845] ·
                                    obtain ⟨j, hxj : (k • x) j = (g • x) i⟩ := hx (k • x) ((g • x) i)
                                    rcases lt_or_eq_of_le (le_sub_one_of_lt j.prop) with hj | hj
                                    · suffices i = j by
                                        rw [← this, ← hi] at hj
                                        exact (lt_irrefl _ hj).elim
                                      apply EmbeddingLike.injective (g • x)
                                      rw [hgk' j hj, hxj]
                                    · rw [← hxj]
                                      apply congr_arg
                                      rw [Fin.ext_iff, hi, hj]
                                [Elab.step] [0.011793] 
                                      obtain ⟨j, hxj : (k • x) j = (g • x) i⟩ := hx (k • x) ((g • x) i)
                                      rcases lt_or_eq_of_le (le_sub_one_of_lt j.prop) with hj | hj
                                      · suffices i = j by
                                          rw [← this, ← hi] at hj
                                          exact (lt_irrefl _ hj).elim
                                        apply EmbeddingLike.injective (g • x)
                                        rw [hgk' j hj, hxj]
                                      · rw [← hxj]
                                        apply congr_arg
                                        rw [Fin.ext_iff, hi, hj]
                                  [Elab.step] [0.011789] 
                                        obtain ⟨j, hxj : (k • x) j = (g • x) i⟩ := hx (k • x) ((g • x) i)
                                        rcases lt_or_eq_of_le (le_sub_one_of_lt j.prop) with hj | hj
                                        · suffices i = j by
                                            rw [← this, ← hi] at hj
                                            exact (lt_irrefl _ hj).elim
                                          apply EmbeddingLike.injective (g • x)
                                          rw [hgk' j hj, hxj]
                                        · rw [← hxj]
                                          apply congr_arg
                                          rw [Fin.ext_iff, hi, hj]
Build completed successfully (1252 jobs).
```

### Trace profiling of `eq_top_of_isMultiplyPretransitive` after PR 32067
```diff
diff --git a/Mathlib/GroupTheory/GroupAction/MultipleTransitivity.lean b/Mathlib/GroupTheory/GroupAction/MultipleTransitivity.lean
index b523d8d690..ac39c08599 100644
--- a/Mathlib/GroupTheory/GroupAction/MultipleTransitivity.lean
+++ b/Mathlib/GroupTheory/GroupAction/MultipleTransitivity.lean
@@ -578,6 +578,7 @@ instance : IsPreprimitive (Perm α) α :=
   isPreprimitive_of_is_two_pretransitive (isMultiplyPretransitive _ _)
 
 -- This is optimal, `AlternatingGroup α` is `Nat.card α - 2`-pretransitive.
+set_option trace.profiler true in
 /-- A subgroup of `Perm α` is `⊤` if(f) it is `(Nat.card α - 1)`-pretransitive. -/
 theorem eq_top_of_isMultiplyPretransitive [Finite α] {G : Subgroup (Equiv.Perm α)}
     (hmt : IsMultiplyPretransitive G α (Nat.card α - 1)) : G = ⊤ := by
@@ -599,18 +600,8 @@ theorem eq_top_of_isMultiplyPretransitive [Finite α] {G : Subgroup (Equiv.Perm
       (g • x) i = (k • x) i :=
     Function.Embedding.ext_iff.mp hg' ⟨i.val, hi⟩
   have hgk (i : Fin (Fintype.card α)) : (g • x) i = (k • x) i := by
-    rcases lt_or_eq_of_le (le_sub_one_of_lt i.prop) with hi | hi
-    · exact hgk' i hi
-    · obtain ⟨j, hxj : (k • x) j = (g • x) i⟩ := hx (k • x) ((g • x) i)
-      rcases lt_or_eq_of_le (le_sub_one_of_lt j.prop) with hj | hj
-      · suffices i = j by
-          rw [← this, ← hi] at hj
-          exact (lt_irrefl _ hj).elim
-        apply EmbeddingLike.injective (g • x)
-        rw [hgk' j hj, hxj]
-      · rw [← hxj]
-        apply congr_arg
-        rw [Fin.ext_iff, hi, hj]
+    obtain ⟨j, hxj : (k • x) j = (g • x) i⟩ := hx (k • x) ((g • x) i)
+    grind only [!Function.Embedding.injective]
   ext a
   obtain ⟨i, rfl⟩ := (hx x) a
   specialize hgk i
```
```
ℹ [1252/1252] Built Mathlib.GroupTheory.GroupAction.MultipleTransitivity (2.7s)
info: Mathlib/GroupTheory/GroupAction/MultipleTransitivity.lean:582:0: [Elab.async] [0.238089] elaborating proof of Equiv.Perm.eq_top_of_isMultiplyPretransitive
  [Elab.definition.value] [0.237037] Equiv.Perm.eq_top_of_isMultiplyPretransitive
    [Elab.step] [0.236022] 
          have := Fintype.ofFinite α
          simp only [Nat.card_eq_fintype_card] at hmt
          let j : Fin (Fintype.card α - 1) ↪ Fin (Fintype.card α) := (Fin.castLEEmb ((Fintype.card α).sub_le 1))
          rw [eq_top_iff]
          intro k _
          let x : Fin (Fintype.card α) ↪ α := (Fintype.equivFinOfCardEq rfl).symm.toEmbedding
          let x' := j.trans x
          obtain ⟨g, hg'⟩ := exists_smul_eq G x' (k • x')
          suffices k = g by rw [this]; exact SetLike.coe_mem g
          have hx (x : Fin (Fintype.card α) ↪ α) : Function.Surjective x.toFun :=
            by
            apply Function.Bijective.surjective
            rw [Fintype.bijective_iff_injective_and_card]
            exact ⟨EmbeddingLike.injective x, Fintype.card_fin (Fintype.card α)⟩
          have hgk' (i : Fin (Fintype.card α)) (hi : i.val < Fintype.card α - 1) : (g • x) i = (k • x) i :=
            Function.Embedding.ext_iff.mp hg' ⟨i.val, hi⟩
          have hgk (i : Fin (Fintype.card α)) : (g • x) i = (k • x) i :=
            by
            obtain ⟨j, hxj : (k • x) j = (g • x) i⟩ := hx (k • x) ((g • x) i)
            grind only [!Function.Embedding.injective]
          ext a
          obtain ⟨i, rfl⟩ := (hx x) a
          specialize hgk i
          simp only [Function.Embedding.smul_apply, Equiv.Perm.smul_def] at hgk
          simp [← hgk, Subgroup.smul_def, Perm.smul_def]
      [Elab.step] [0.236016] 
            have := Fintype.ofFinite α
            simp only [Nat.card_eq_fintype_card] at hmt
            let j : Fin (Fintype.card α - 1) ↪ Fin (Fintype.card α) := (Fin.castLEEmb ((Fintype.card α).sub_le 1))
            rw [eq_top_iff]
            intro k _
            let x : Fin (Fintype.card α) ↪ α := (Fintype.equivFinOfCardEq rfl).symm.toEmbedding
            let x' := j.trans x
            obtain ⟨g, hg'⟩ := exists_smul_eq G x' (k • x')
            suffices k = g by rw [this]; exact SetLike.coe_mem g
            have hx (x : Fin (Fintype.card α) ↪ α) : Function.Surjective x.toFun :=
              by
              apply Function.Bijective.surjective
              rw [Fintype.bijective_iff_injective_and_card]
              exact ⟨EmbeddingLike.injective x, Fintype.card_fin (Fintype.card α)⟩
            have hgk' (i : Fin (Fintype.card α)) (hi : i.val < Fintype.card α - 1) : (g • x) i = (k • x) i :=
              Function.Embedding.ext_iff.mp hg' ⟨i.val, hi⟩
            have hgk (i : Fin (Fintype.card α)) : (g • x) i = (k • x) i :=
              by
              obtain ⟨j, hxj : (k • x) j = (g • x) i⟩ := hx (k • x) ((g • x) i)
              grind only [!Function.Embedding.injective]
            ext a
            obtain ⟨i, rfl⟩ := (hx x) a
            specialize hgk i
            simp only [Function.Embedding.smul_apply, Equiv.Perm.smul_def] at hgk
            simp [← hgk, Subgroup.smul_def, Perm.smul_def]
        [Elab.step] [0.012958] rw [eq_top_iff]
          [Elab.step] [0.012950] (rewrite [eq_top_iff]; with_annotate_state"]" (try (with_reducible rfl)))
            [Elab.step] [0.012947] rewrite [eq_top_iff]; with_annotate_state"]" (try (with_reducible rfl))
              [Elab.step] [0.012944] rewrite [eq_top_iff]; with_annotate_state"]" (try (with_reducible rfl))
                [Elab.step] [0.012579] rewrite [eq_top_iff]
        [Elab.step] [0.197476] have hgk (i : Fin (Fintype.card α)) : (g • x) i = (k • x) i :=
              by
              obtain ⟨j, hxj : (k • x) j = (g • x) i⟩ := hx (k • x) ((g • x) i)
              grind only [!Function.Embedding.injective]
          [Elab.step] [0.197357] focus
                refine
                  no_implicit_lambda%
                    (have hgk (i : Fin (Fintype.card α)) : (g • x) i = (k • x) i := ?body✝;
                    ?_)
                case body✝ =>
                  with_annotate_state"by"
                    ( obtain ⟨j, hxj : (k • x) j = (g • x) i⟩ := hx (k • x) ((g • x) i)
                      grind only [!Function.Embedding.injective])
            [Elab.step] [0.197353] 
                  refine
                    no_implicit_lambda%
                      (have hgk (i : Fin (Fintype.card α)) : (g • x) i = (k • x) i := ?body✝;
                      ?_)
                  case body✝ =>
                    with_annotate_state"by"
                      ( obtain ⟨j, hxj : (k • x) j = (g • x) i⟩ := hx (k • x) ((g • x) i)
                        grind only [!Function.Embedding.injective])
              [Elab.step] [0.197350] 
                    refine
                      no_implicit_lambda%
                        (have hgk (i : Fin (Fintype.card α)) : (g • x) i = (k • x) i := ?body✝;
                        ?_)
                    case body✝ =>
                      with_annotate_state"by"
                        ( obtain ⟨j, hxj : (k • x) j = (g • x) i⟩ := hx (k • x) ((g • x) i)
                          grind only [!Function.Embedding.injective])
                [Elab.step] [0.194707] case body✝ =>
                      with_annotate_state"by"
                        ( obtain ⟨j, hxj : (k • x) j = (g • x) i⟩ := hx (k • x) ((g • x) i)
                          grind only [!Function.Embedding.injective])
                  [Elab.step] [0.194674] with_annotate_state"by"
                          ( obtain ⟨j, hxj : (k • x) j = (g • x) i⟩ := hx (k • x) ((g • x) i)
                            grind only [!Function.Embedding.injective])
                    [Elab.step] [0.194672] with_annotate_state"by"
                            ( obtain ⟨j, hxj : (k • x) j = (g • x) i⟩ := hx (k • x) ((g • x) i)
                              grind only [!Function.Embedding.injective])
                      [Elab.step] [0.194669] with_annotate_state"by"
                            ( obtain ⟨j, hxj : (k • x) j = (g • x) i⟩ := hx (k • x) ((g • x) i)
                              grind only [!Function.Embedding.injective])
                        [Elab.step] [0.194666] (
                              obtain ⟨j, hxj : (k • x) j = (g • x) i⟩ := hx (k • x) ((g • x) i)
                              grind only [!Function.Embedding.injective])
                          [Elab.step] [0.194663] 
                                obtain ⟨j, hxj : (k • x) j = (g • x) i⟩ := hx (k • x) ((g • x) i)
                                grind only [!Function.Embedding.injective]
                            [Elab.step] [0.194659] 
                                  obtain ⟨j, hxj : (k • x) j = (g • x) i⟩ := hx (k • x) ((g • x) i)
                                  grind only [!Function.Embedding.injective]
                              [Elab.step] [0.189129] grind only [!Function.Embedding.injective]
info: Mathlib/GroupTheory/GroupAction/MultipleTransitivity.lean:604:4: [Elab.async] [0.012351] Lean.addDecl
  [Kernel] [0.012318] ✅️ typechecking declarations [_private.Mathlib.GroupTheory.GroupAction.MultipleTransitivity.0.Equiv.Perm.eq_top_of_isMultiplyPretransitive._proof_1_4]
Build completed successfully (1252 jobs).
```
</details>

---
<details>
<summary>Show trace profiling of <code>eq_top_of_isMultiplyPretransitive</code>: 57 ms before, 244 ms after </summary>

### Trace profiling of `eq_top_of_isMultiplyPretransitive` before PR 32067
```diff
diff --git a/Mathlib/GroupTheory/GroupAction/MultipleTransitivity.lean b/Mathlib/GroupTheory/GroupAction/MultipleTransitivity.lean
index b523d8d690..69fed78c79 100644
--- a/Mathlib/GroupTheory/GroupAction/MultipleTransitivity.lean
+++ b/Mathlib/GroupTheory/GroupAction/MultipleTransitivity.lean
@@ -578,6 +578,7 @@ instance : IsPreprimitive (Perm α) α :=
   isPreprimitive_of_is_two_pretransitive (isMultiplyPretransitive _ _)
 
 -- This is optimal, `AlternatingGroup α` is `Nat.card α - 2`-pretransitive.
+set_option trace.profiler true in
 /-- A subgroup of `Perm α` is `⊤` if(f) it is `(Nat.card α - 1)`-pretransitive. -/
 theorem eq_top_of_isMultiplyPretransitive [Finite α] {G : Subgroup (Equiv.Perm α)}
     (hmt : IsMultiplyPretransitive G α (Nat.card α - 1)) : G = ⊤ := by
```
```
ℹ [1253/1253] Built Mathlib.GroupTheory.GroupAction.MultipleTransitivity (3.4s)
info: Mathlib/GroupTheory/GroupAction/MultipleTransitivity.lean:582:0: [Elab.async] [0.058457] elaborating proof of Equiv.Perm.eq_top_of_isMultiplyPretransitive
  [Elab.definition.value] [0.056911] Equiv.Perm.eq_top_of_isMultiplyPretransitive
    [Elab.step] [0.055150] 
          have := Fintype.ofFinite α
          simp only [Nat.card_eq_fintype_card] at hmt
          let j : Fin (Fintype.card α - 1) ↪ Fin (Fintype.card α) := (Fin.castLEEmb ((Fintype.card α).sub_le 1))
          rw [eq_top_iff]
          intro k _
          let x : Fin (Fintype.card α) ↪ α := (Fintype.equivFinOfCardEq rfl).symm.toEmbedding
          let x' := j.trans x
          obtain ⟨g, hg'⟩ := exists_smul_eq G x' (k • x')
          suffices k = g by rw [this]; exact SetLike.coe_mem g
          have hx (x : Fin (Fintype.card α) ↪ α) : Function.Surjective x.toFun :=
            by
            apply Function.Bijective.surjective
            rw [Fintype.bijective_iff_injective_and_card]
            exact ⟨EmbeddingLike.injective x, Fintype.card_fin (Fintype.card α)⟩
          have hgk' (i : Fin (Fintype.card α)) (hi : i.val < Fintype.card α - 1) : (g • x) i = (k • x) i :=
            Function.Embedding.ext_iff.mp hg' ⟨i.val, hi⟩
          have hgk (i : Fin (Fintype.card α)) : (g • x) i = (k • x) i :=
            by
            rcases lt_or_eq_of_le (le_sub_one_of_lt i.prop) with hi | hi
            · exact hgk' i hi
            · obtain ⟨j, hxj : (k • x) j = (g • x) i⟩ := hx (k • x) ((g • x) i)
              rcases lt_or_eq_of_le (le_sub_one_of_lt j.prop) with hj | hj
              · suffices i = j by
                  rw [← this, ← hi] at hj
                  exact (lt_irrefl _ hj).elim
                apply EmbeddingLike.injective (g • x)
                rw [hgk' j hj, hxj]
              · rw [← hxj]
                apply congr_arg
                rw [Fin.ext_iff, hi, hj]
          ext a
          obtain ⟨i, rfl⟩ := (hx x) a
          specialize hgk i
          simp only [Function.Embedding.smul_apply, Equiv.Perm.smul_def] at hgk
          simp [← hgk, Subgroup.smul_def, Perm.smul_def]
      [Elab.step] [0.055144] 
            have := Fintype.ofFinite α
            simp only [Nat.card_eq_fintype_card] at hmt
            let j : Fin (Fintype.card α - 1) ↪ Fin (Fintype.card α) := (Fin.castLEEmb ((Fintype.card α).sub_le 1))
            rw [eq_top_iff]
            intro k _
            let x : Fin (Fintype.card α) ↪ α := (Fintype.equivFinOfCardEq rfl).symm.toEmbedding
            let x' := j.trans x
            obtain ⟨g, hg'⟩ := exists_smul_eq G x' (k • x')
            suffices k = g by rw [this]; exact SetLike.coe_mem g
            have hx (x : Fin (Fintype.card α) ↪ α) : Function.Surjective x.toFun :=
              by
              apply Function.Bijective.surjective
              rw [Fintype.bijective_iff_injective_and_card]
              exact ⟨EmbeddingLike.injective x, Fintype.card_fin (Fintype.card α)⟩
            have hgk' (i : Fin (Fintype.card α)) (hi : i.val < Fintype.card α - 1) : (g • x) i = (k • x) i :=
              Function.Embedding.ext_iff.mp hg' ⟨i.val, hi⟩
            have hgk (i : Fin (Fintype.card α)) : (g • x) i = (k • x) i :=
              by
              rcases lt_or_eq_of_le (le_sub_one_of_lt i.prop) with hi | hi
              · exact hgk' i hi
              · obtain ⟨j, hxj : (k • x) j = (g • x) i⟩ := hx (k • x) ((g • x) i)
                rcases lt_or_eq_of_le (le_sub_one_of_lt j.prop) with hj | hj
                · suffices i = j by
                    rw [← this, ← hi] at hj
                    exact (lt_irrefl _ hj).elim
                  apply EmbeddingLike.injective (g • x)
                  rw [hgk' j hj, hxj]
                · rw [← hxj]
                  apply congr_arg
                  rw [Fin.ext_iff, hi, hj]
            ext a
            obtain ⟨i, rfl⟩ := (hx x) a
            specialize hgk i
            simp only [Function.Embedding.smul_apply, Equiv.Perm.smul_def] at hgk
            simp [← hgk, Subgroup.smul_def, Perm.smul_def]
        [Elab.step] [0.012945] rw [eq_top_iff]
          [Elab.step] [0.012937] (rewrite [eq_top_iff]; with_annotate_state"]" (try (with_reducible rfl)))
            [Elab.step] [0.012934] rewrite [eq_top_iff]; with_annotate_state"]" (try (with_reducible rfl))
              [Elab.step] [0.012931] rewrite [eq_top_iff]; with_annotate_state"]" (try (with_reducible rfl))
                [Elab.step] [0.012590] rewrite [eq_top_iff]
        [Elab.step] [0.015982] have hgk (i : Fin (Fintype.card α)) : (g • x) i = (k • x) i :=
              by
              rcases lt_or_eq_of_le (le_sub_one_of_lt i.prop) with hi | hi
              · exact hgk' i hi
              · obtain ⟨j, hxj : (k • x) j = (g • x) i⟩ := hx (k • x) ((g • x) i)
                rcases lt_or_eq_of_le (le_sub_one_of_lt j.prop) with hj | hj
                · suffices i = j by
                    rw [← this, ← hi] at hj
                    exact (lt_irrefl _ hj).elim
                  apply EmbeddingLike.injective (g • x)
                  rw [hgk' j hj, hxj]
                · rw [← hxj]
                  apply congr_arg
                  rw [Fin.ext_iff, hi, hj]
          [Elab.step] [0.015884] focus
                refine
                  no_implicit_lambda%
                    (have hgk (i : Fin (Fintype.card α)) : (g • x) i = (k • x) i := ?body✝;
                    ?_)
                case body✝ =>
[… 77 lines omitted …]
                                rw [Fin.ext_iff, hi, hj])
                    [Elab.step] [0.013242] with_annotate_state"by"
                            ( rcases lt_or_eq_of_le (le_sub_one_of_lt i.prop) with hi | hi
                              · exact hgk' i hi
                              · obtain ⟨j, hxj : (k • x) j = (g • x) i⟩ := hx (k • x) ((g • x) i)
                                rcases lt_or_eq_of_le (le_sub_one_of_lt j.prop) with hj | hj
                                · suffices i = j by
                                    rw [← this, ← hi] at hj
                                    exact (lt_irrefl _ hj).elim
                                  apply EmbeddingLike.injective (g • x)
                                  rw [hgk' j hj, hxj]
                                · rw [← hxj]
                                  apply congr_arg
                                  rw [Fin.ext_iff, hi, hj])
                      [Elab.step] [0.013239] with_annotate_state"by"
                            ( rcases lt_or_eq_of_le (le_sub_one_of_lt i.prop) with hi | hi
                              · exact hgk' i hi
                              · obtain ⟨j, hxj : (k • x) j = (g • x) i⟩ := hx (k • x) ((g • x) i)
                                rcases lt_or_eq_of_le (le_sub_one_of_lt j.prop) with hj | hj
                                · suffices i = j by
                                    rw [← this, ← hi] at hj
                                    exact (lt_irrefl _ hj).elim
                                  apply EmbeddingLike.injective (g • x)
                                  rw [hgk' j hj, hxj]
                                · rw [← hxj]
                                  apply congr_arg
                                  rw [Fin.ext_iff, hi, hj])
                        [Elab.step] [0.013237] (
                              rcases lt_or_eq_of_le (le_sub_one_of_lt i.prop) with hi | hi
                              · exact hgk' i hi
                              · obtain ⟨j, hxj : (k • x) j = (g • x) i⟩ := hx (k • x) ((g • x) i)
                                rcases lt_or_eq_of_le (le_sub_one_of_lt j.prop) with hj | hj
                                · suffices i = j by
                                    rw [← this, ← hi] at hj
                                    exact (lt_irrefl _ hj).elim
                                  apply EmbeddingLike.injective (g • x)
                                  rw [hgk' j hj, hxj]
                                · rw [← hxj]
                                  apply congr_arg
                                  rw [Fin.ext_iff, hi, hj])
                          [Elab.step] [0.013234] 
                                rcases lt_or_eq_of_le (le_sub_one_of_lt i.prop) with hi | hi
                                · exact hgk' i hi
                                · obtain ⟨j, hxj : (k • x) j = (g • x) i⟩ := hx (k • x) ((g • x) i)
                                  rcases lt_or_eq_of_le (le_sub_one_of_lt j.prop) with hj | hj
                                  · suffices i = j by
                                      rw [← this, ← hi] at hj
                                      exact (lt_irrefl _ hj).elim
                                    apply EmbeddingLike.injective (g • x)
                                    rw [hgk' j hj, hxj]
                                  · rw [← hxj]
                                    apply congr_arg
                                    rw [Fin.ext_iff, hi, hj]
                            [Elab.step] [0.013231] 
                                  rcases lt_or_eq_of_le (le_sub_one_of_lt i.prop) with hi | hi
                                  · exact hgk' i hi
                                  · obtain ⟨j, hxj : (k • x) j = (g • x) i⟩ := hx (k • x) ((g • x) i)
                                    rcases lt_or_eq_of_le (le_sub_one_of_lt j.prop) with hj | hj
                                    · suffices i = j by
                                        rw [← this, ← hi] at hj
                                        exact (lt_irrefl _ hj).elim
                                      apply EmbeddingLike.injective (g • x)
                                      rw [hgk' j hj, hxj]
                                    · rw [← hxj]
                                      apply congr_arg
                                      rw [Fin.ext_iff, hi, hj]
                              [Elab.step] [0.011872] ·
                                    obtain ⟨j, hxj : (k • x) j = (g • x) i⟩ := hx (k • x) ((g • x) i)
                                    rcases lt_or_eq_of_le (le_sub_one_of_lt j.prop) with hj | hj
                                    · suffices i = j by
                                        rw [← this, ← hi] at hj
                                        exact (lt_irrefl _ hj).elim
                                      apply EmbeddingLike.injective (g • x)
                                      rw [hgk' j hj, hxj]
                                    · rw [← hxj]
                                      apply congr_arg
                                      rw [Fin.ext_iff, hi, hj]
                                [Elab.step] [0.011834] 
                                      obtain ⟨j, hxj : (k • x) j = (g • x) i⟩ := hx (k • x) ((g • x) i)
                                      rcases lt_or_eq_of_le (le_sub_one_of_lt j.prop) with hj | hj
                                      · suffices i = j by
                                          rw [← this, ← hi] at hj
                                          exact (lt_irrefl _ hj).elim
                                        apply EmbeddingLike.injective (g • x)
                                        rw [hgk' j hj, hxj]
                                      · rw [← hxj]
                                        apply congr_arg
                                        rw [Fin.ext_iff, hi, hj]
                                  [Elab.step] [0.011830] 
                                        obtain ⟨j, hxj : (k • x) j = (g • x) i⟩ := hx (k • x) ((g • x) i)
                                        rcases lt_or_eq_of_le (le_sub_one_of_lt j.prop) with hj | hj
                                        · suffices i = j by
                                            rw [← this, ← hi] at hj
                                            exact (lt_irrefl _ hj).elim
                                          apply EmbeddingLike.injective (g • x)
                                          rw [hgk' j hj, hxj]
                                        · rw [← hxj]
                                          apply congr_arg
                                          rw [Fin.ext_iff, hi, hj]
Build completed successfully (1253 jobs).
```

### Trace profiling of `eq_top_of_isMultiplyPretransitive` after PR 32067
```diff
diff --git a/Mathlib/GroupTheory/GroupAction/MultipleTransitivity.lean b/Mathlib/GroupTheory/GroupAction/MultipleTransitivity.lean
index b523d8d690..a11736d11e 100644
--- a/Mathlib/GroupTheory/GroupAction/MultipleTransitivity.lean
+++ b/Mathlib/GroupTheory/GroupAction/MultipleTransitivity.lean
@@ -578,6 +578,7 @@ instance : IsPreprimitive (Perm α) α :=
   isPreprimitive_of_is_two_pretransitive (isMultiplyPretransitive _ _)
 
 -- This is optimal, `AlternatingGroup α` is `Nat.card α - 2`-pretransitive.
+set_option trace.profiler true in
 /-- A subgroup of `Perm α` is `⊤` if(f) it is `(Nat.card α - 1)`-pretransitive. -/
 theorem eq_top_of_isMultiplyPretransitive [Finite α] {G : Subgroup (Equiv.Perm α)}
     (hmt : IsMultiplyPretransitive G α (Nat.card α - 1)) : G = ⊤ := by
@@ -599,18 +600,8 @@ theorem eq_top_of_isMultiplyPretransitive [Finite α] {G : Subgroup (Equiv.Perm
       (g • x) i = (k • x) i :=
     Function.Embedding.ext_iff.mp hg' ⟨i.val, hi⟩
   have hgk (i : Fin (Fintype.card α)) : (g • x) i = (k • x) i := by
-    rcases lt_or_eq_of_le (le_sub_one_of_lt i.prop) with hi | hi
-    · exact hgk' i hi
-    · obtain ⟨j, hxj : (k • x) j = (g • x) i⟩ := hx (k • x) ((g • x) i)
-      rcases lt_or_eq_of_le (le_sub_one_of_lt j.prop) with hj | hj
-      · suffices i = j by
-          rw [← this, ← hi] at hj
-          exact (lt_irrefl _ hj).elim
-        apply EmbeddingLike.injective (g • x)
-        rw [hgk' j hj, hxj]
-      · rw [← hxj]
-        apply congr_arg
-        rw [Fin.ext_iff, hi, hj]
+    obtain ⟨j, hxj : (k • x) j = (g • x) i⟩ := hx (k • x) ((g • x) i)
+    grind
   ext a
   obtain ⟨i, rfl⟩ := (hx x) a
   specialize hgk i
```
```
ℹ [1253/1253] Built Mathlib.GroupTheory.GroupAction.MultipleTransitivity (2.9s)
info: Mathlib/GroupTheory/GroupAction/MultipleTransitivity.lean:582:0: [Elab.async] [0.244752] elaborating proof of Equiv.Perm.eq_top_of_isMultiplyPretransitive
  [Elab.definition.value] [0.243653] Equiv.Perm.eq_top_of_isMultiplyPretransitive
    [Elab.step] [0.242567] 
          have := Fintype.ofFinite α
          simp only [Nat.card_eq_fintype_card] at hmt
          let j : Fin (Fintype.card α - 1) ↪ Fin (Fintype.card α) := (Fin.castLEEmb ((Fintype.card α).sub_le 1))
          rw [eq_top_iff]
          intro k _
          let x : Fin (Fintype.card α) ↪ α := (Fintype.equivFinOfCardEq rfl).symm.toEmbedding
          let x' := j.trans x
          obtain ⟨g, hg'⟩ := exists_smul_eq G x' (k • x')
          suffices k = g by rw [this]; exact SetLike.coe_mem g
          have hx (x : Fin (Fintype.card α) ↪ α) : Function.Surjective x.toFun :=
            by
            apply Function.Bijective.surjective
            rw [Fintype.bijective_iff_injective_and_card]
            exact ⟨EmbeddingLike.injective x, Fintype.card_fin (Fintype.card α)⟩
          have hgk' (i : Fin (Fintype.card α)) (hi : i.val < Fintype.card α - 1) : (g • x) i = (k • x) i :=
            Function.Embedding.ext_iff.mp hg' ⟨i.val, hi⟩
          have hgk (i : Fin (Fintype.card α)) : (g • x) i = (k • x) i :=
            by
            obtain ⟨j, hxj : (k • x) j = (g • x) i⟩ := hx (k • x) ((g • x) i)
            grind
          ext a
          obtain ⟨i, rfl⟩ := (hx x) a
          specialize hgk i
          simp only [Function.Embedding.smul_apply, Equiv.Perm.smul_def] at hgk
          simp [← hgk, Subgroup.smul_def, Perm.smul_def]
      [Elab.step] [0.242561] 
            have := Fintype.ofFinite α
            simp only [Nat.card_eq_fintype_card] at hmt
            let j : Fin (Fintype.card α - 1) ↪ Fin (Fintype.card α) := (Fin.castLEEmb ((Fintype.card α).sub_le 1))
            rw [eq_top_iff]
            intro k _
            let x : Fin (Fintype.card α) ↪ α := (Fintype.equivFinOfCardEq rfl).symm.toEmbedding
            let x' := j.trans x
            obtain ⟨g, hg'⟩ := exists_smul_eq G x' (k • x')
            suffices k = g by rw [this]; exact SetLike.coe_mem g
            have hx (x : Fin (Fintype.card α) ↪ α) : Function.Surjective x.toFun :=
              by
              apply Function.Bijective.surjective
              rw [Fintype.bijective_iff_injective_and_card]
              exact ⟨EmbeddingLike.injective x, Fintype.card_fin (Fintype.card α)⟩
            have hgk' (i : Fin (Fintype.card α)) (hi : i.val < Fintype.card α - 1) : (g • x) i = (k • x) i :=
              Function.Embedding.ext_iff.mp hg' ⟨i.val, hi⟩
            have hgk (i : Fin (Fintype.card α)) : (g • x) i = (k • x) i :=
              by
              obtain ⟨j, hxj : (k • x) j = (g • x) i⟩ := hx (k • x) ((g • x) i)
              grind
            ext a
            obtain ⟨i, rfl⟩ := (hx x) a
            specialize hgk i
            simp only [Function.Embedding.smul_apply, Equiv.Perm.smul_def] at hgk
            simp [← hgk, Subgroup.smul_def, Perm.smul_def]
        [Elab.step] [0.014168] rw [eq_top_iff]
          [Elab.step] [0.014160] (rewrite [eq_top_iff]; with_annotate_state"]" (try (with_reducible rfl)))
            [Elab.step] [0.014158] rewrite [eq_top_iff]; with_annotate_state"]" (try (with_reducible rfl))
              [Elab.step] [0.014155] rewrite [eq_top_iff]; with_annotate_state"]" (try (with_reducible rfl))
                [Elab.step] [0.013785] rewrite [eq_top_iff]
        [Elab.step] [0.202508] have hgk (i : Fin (Fintype.card α)) : (g • x) i = (k • x) i :=
              by
              obtain ⟨j, hxj : (k • x) j = (g • x) i⟩ := hx (k • x) ((g • x) i)
              grind
          [Elab.step] [0.202343] focus
                refine
                  no_implicit_lambda%
                    (have hgk (i : Fin (Fintype.card α)) : (g • x) i = (k • x) i := ?body✝;
                    ?_)
                case body✝ =>
                  with_annotate_state"by"
                    ( obtain ⟨j, hxj : (k • x) j = (g • x) i⟩ := hx (k • x) ((g • x) i)
                      grind)
            [Elab.step] [0.202339] 
                  refine
                    no_implicit_lambda%
                      (have hgk (i : Fin (Fintype.card α)) : (g • x) i = (k • x) i := ?body✝;
                      ?_)
                  case body✝ =>
                    with_annotate_state"by"
                      ( obtain ⟨j, hxj : (k • x) j = (g • x) i⟩ := hx (k • x) ((g • x) i)
                        grind)
              [Elab.step] [0.202337] 
                    refine
                      no_implicit_lambda%
                        (have hgk (i : Fin (Fintype.card α)) : (g • x) i = (k • x) i := ?body✝;
                        ?_)
                    case body✝ =>
                      with_annotate_state"by"
                        ( obtain ⟨j, hxj : (k • x) j = (g • x) i⟩ := hx (k • x) ((g • x) i)
                          grind)
                [Elab.step] [0.199669] case body✝ =>
                      with_annotate_state"by"
                        ( obtain ⟨j, hxj : (k • x) j = (g • x) i⟩ := hx (k • x) ((g • x) i)
                          grind)
                  [Elab.step] [0.199624] with_annotate_state"by"
                          ( obtain ⟨j, hxj : (k • x) j = (g • x) i⟩ := hx (k • x) ((g • x) i)
                            grind)
                    [Elab.step] [0.199621] with_annotate_state"by"
                            ( obtain ⟨j, hxj : (k • x) j = (g • x) i⟩ := hx (k • x) ((g • x) i)
                              grind)
                      [Elab.step] [0.199618] with_annotate_state"by"
                            ( obtain ⟨j, hxj : (k • x) j = (g • x) i⟩ := hx (k • x) ((g • x) i)
                              grind)
                        [Elab.step] [0.199614] (
                              obtain ⟨j, hxj : (k • x) j = (g • x) i⟩ := hx (k • x) ((g • x) i)
                              grind)
                          [Elab.step] [0.199611] 
                                obtain ⟨j, hxj : (k • x) j = (g • x) i⟩ := hx (k • x) ((g • x) i)
                                grind
                            [Elab.step] [0.199608] 
                                  obtain ⟨j, hxj : (k • x) j = (g • x) i⟩ := hx (k • x) ((g • x) i)
                                  grind
                              [Elab.step] [0.194188] grind
info: Mathlib/GroupTheory/GroupAction/MultipleTransitivity.lean:604:4: [Elab.async] [0.012583] Lean.addDecl
  [Kernel] [0.012539] ✅️ typechecking declarations [_private.Mathlib.GroupTheory.GroupAction.MultipleTransitivity.0.Equiv.Perm.eq_top_of_isMultiplyPretransitive._proof_1_4]
Build completed successfully (1253 jobs).
```
</details>

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

When merging, all the commits will be squashed into a single commit
listing all co-authors.

Co-authors in the squash commit are gathered from two sources:

First, all authors of commits to this PR branch are included. Thus,
one way to add co-authors is to include at least one commit authored by
each co-author among the commits in the pull request. If necessary, you
may create empty commits to indicate co-authorship, using commands like so:

git commit --author="Author Name <author@email.com>" --allow-empty -m "add Author Name as coauthor"

Second, co-authors can also be listed in lines at the very bottom of
the commit message (that is, directly before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines
at the bottom of the commit message (before the `---`, and also before
any "Co-authored-by" lines) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
