### PR TITLE
[Merged by Bors] - chore(Logic/Function): golf `Injective.dite` and `rec_update` (+ others) using `grind`

### DIFF
--- a/Mathlib/Logic/Function/Basic.lean
+++ b/Mathlib/Logic/Function/Basic.lean
@@ -131,12 +131,7 @@ lemma Injective.dite (p : α → Prop) [DecidablePred p]
     (hf : Injective f) (hf' : Injective f')
     (im_disj : ∀ {x x' : α} {hx : p x} {hx' : ¬ p x'}, f ⟨x, hx⟩ ≠ f' ⟨x', hx'⟩) :
     Function.Injective (fun x ↦ if h : p x then f ⟨x, h⟩ else f' ⟨x, h⟩) := fun x₁ x₂ h => by
-  dsimp only at h
-  by_cases h₁ : p x₁ <;> by_cases h₂ : p x₂
-  · rw [dif_pos h₁, dif_pos h₂] at h; injection (hf h)
-  · rw [dif_pos h₁, dif_neg h₂] at h; exact (im_disj h).elim
-  · rw [dif_neg h₁, dif_pos h₂] at h; exact (im_disj h.symm).elim
-  · rw [dif_neg h₁, dif_neg h₂] at h; injection (hf' h)
+  grind
 
 theorem Surjective.of_comp {g : γ → α} (S : Surjective (f ∘ g)) : Surjective f := fun y ↦
   let ⟨x, h⟩ := S y
@@ -587,22 +582,13 @@ such as `(Sum.rec · g)`.
 In future, we should build some automation to generate applications like `Option.rec_update` for all
 inductive types. -/
 lemma rec_update {ι κ : Sort*} {α : κ → Sort*} [DecidableEq ι] [DecidableEq κ]
-    {ctor : ι → κ} (hctor : Function.Injective ctor)
+    {ctor : ι → κ} (_ : Function.Injective ctor)
     (recursor : ((i : ι) → α (ctor i)) → ((i : κ) → α i))
     (h : ∀ f i, recursor f (ctor i) = f i)
     (h2 : ∀ f₁ f₂ k, (∀ i, ctor i ≠ k) → recursor f₁ k = recursor f₂ k)
     (f : (i : ι) → α (ctor i)) (i : ι) (x : α (ctor i)) :
     recursor (update f i x) = update (recursor f) (ctor i) x := by
-  ext k
-  by_cases h : ∃ i, ctor i = k
-  · obtain ⟨i', rfl⟩ := h
-    obtain rfl | hi := eq_or_ne i' i
-    · simp [h]
-    · have hk := hctor.ne hi
-      simp [h, hi, hk, Function.update_of_ne]
-  · rw [not_exists] at h
-    rw [h2 _ f _ h]
-    rw [Function.update_of_ne (Ne.symm <| h i)]
+  grind
 
 @[simp]
 lemma _root_.Option.rec_update {α : Type*} {β : Option α → Sort*} [DecidableEq α]
@@ -615,22 +601,16 @@ lemma _root_.Option.rec_update {α : Type*} {β : Option α → Sort*} [Decidabl
 theorem apply_update {ι : Sort*} [DecidableEq ι] {α β : ι → Sort*} (f : ∀ i, α i → β i)
     (g : ∀ i, α i) (i : ι) (v : α i) (j : ι) :
     f j (update g i v j) = update (fun k ↦ f k (g k)) i (f i v) j := by
-  by_cases h : j = i
-  · subst j
-    simp
-  · simp [h]
+  grind
 
 theorem apply_update₂ {ι : Sort*} [DecidableEq ι] {α β γ : ι → Sort*} (f : ∀ i, α i → β i → γ i)
     (g : ∀ i, α i) (h : ∀ i, β i) (i : ι) (v : α i) (w : β i) (j : ι) :
     f j (update g i v j) (update h i w j) = update (fun k ↦ f k (g k) (h k)) i (f i v w) j := by
-  by_cases h : j = i
-  · subst j
-    simp
-  · simp [h]
+  grind
 
 theorem pred_update (P : ∀ ⦃a⦄, β a → Prop) (f : ∀ a, β a) (a' : α) (v : β a') (a : α) :
     P (update f a' v a) ↔ a = a' ∧ P v ∨ a ≠ a' ∧ P (f a) := by
-  rw [apply_update P, update_apply, ite_prop_iff_or]
+  grind
 
 theorem comp_update {α' : Sort*} {β : Sort*} (f : α' → β) (g : α → α') (i : α) (v : α') :
     f ∘ update g i v = update (f ∘ g) i (f v) :=
@@ -638,20 +618,12 @@ theorem comp_update {α' : Sort*} {β : Sort*} (f : α' → β) (g : α → α')
 
 theorem update_comm {α} [DecidableEq α] {β : α → Sort*} {a b : α} (h : a ≠ b) (v : β a) (w : β b)
     (f : ∀ a, β a) : update (update f a v) b w = update (update f b w) a v := by
-  funext c
-  simp only [update]
-  by_cases h₁ : c = b <;> by_cases h₂ : c = a
-  · rw [dif_pos h₁, dif_pos h₂]
-    cases h (h₂.symm.trans h₁)
-  · rw [dif_pos h₁, dif_pos h₁, dif_neg h₂]
-  · rw [dif_neg h₁, dif_neg h₁]
-  · rw [dif_neg h₁, dif_neg h₁]
+  grind
 
 @[simp]
 theorem update_idem {α} [DecidableEq α] {β : α → Sort*} {a : α} (v w : β a) (f : ∀ a, β a) :
     update (update f a v) a w = update f a w := by
-  funext b
-  by_cases h : b = a <;> simp [update, h]
+  grind
 
 @[simp]
 theorem _root_.Pi.map_update {ι : Sort*} [DecidableEq ι] {α β : ι → Sort*}
@@ -1094,7 +1066,7 @@ theorem Function.LeftInverse.eq_rec_on_eq {γ : β → Sort v} {f : α → β} {
 theorem Function.LeftInverse.cast_eq {γ : β → Sort v} {f : α → β} {g : β → α}
     (h : Function.LeftInverse g f) (C : ∀ a : α, γ (f a)) (a : α) :
     cast (congr_arg (fun a ↦ γ (f a)) (h a)) (C (g (f a))) = C a := by
-  rw [cast_eq_iff_heq, h]
+  grind
 
 /-- A set of functions "separates points"
 if for each pair of distinct points there is a function taking different values on them. -/

--- a/Mathlib/Logic/Function/Basic.lean
+++ b/Mathlib/Logic/Function/Basic.lean
@@ -573,6 +573,7 @@ theorem update_comp_eq_of_injective {β : Sort*} (g : α' → β) {f : α → α
     Function.update g (f i) a ∘ f = Function.update (g ∘ f) i a :=
   update_comp_eq_of_injective' g hf i a
 
+
 /-- Recursors can be pushed inside `Function.update`.
 
 The `ctor` argument should be a one-argument constructor like `Sum.inl`,
@@ -581,6 +582,7 @@ such as `(Sum.rec · g)`.
 
 In future, we should build some automation to generate applications like `Option.rec_update` for all
 inductive types. -/
+@[nolint unusedArguments]
 lemma rec_update {ι κ : Sort*} {α : κ → Sort*} [DecidableEq ι] [DecidableEq κ]
     {ctor : ι → κ} (_ : Function.Injective ctor)
     (recursor : ((i : ι) → α (ctor i)) → ((i : κ) → α i))

--- a/Mathlib/Logic/Function/Basic.lean
+++ b/Mathlib/Logic/Function/Basic.lean
@@ -573,7 +573,6 @@ theorem update_comp_eq_of_injective {β : Sort*} (g : α' → β) {f : α → α
     Function.update g (f i) a ∘ f = Function.update (g ∘ f) i a :=
   update_comp_eq_of_injective' g hf i a
 
-
 /-- Recursors can be pushed inside `Function.update`.
 
 The `ctor` argument should be a one-argument constructor like `Sum.inl`,


### PR DESCRIPTION
---
<details>
<summary>Show trace profiling of <code>Injective.dite</code>: <10 ms before, 27 ms after </summary>

### Trace profiling of `Injective.dite` before PR 32068
```diff
diff --git a/Mathlib/Logic/Function/Basic.lean b/Mathlib/Logic/Function/Basic.lean
index acf88a0e83..9d2ea62869 100644
--- a/Mathlib/Logic/Function/Basic.lean
+++ b/Mathlib/Logic/Function/Basic.lean
@@ -126,6 +126,7 @@ theorem injective_comp_left_iff [Nonempty α] {g : β → γ} :
 @[nontriviality] theorem bijective_of_subsingleton [Subsingleton α] (f : α → α) : Bijective f :=
   ⟨injective_of_subsingleton f, fun a ↦ ⟨a, Subsingleton.elim ..⟩⟩
 
+set_option trace.profiler true in
 lemma Injective.dite (p : α → Prop) [DecidablePred p]
     {f : {a : α // p a} → β} {f' : {a : α // ¬ p a} → β}
     (hf : Injective f) (hf' : Injective f')
```
```
✔ [85/85] Built Mathlib.Logic.Function.Basic (1.1s)
Build completed successfully (85 jobs).
```

### Trace profiling of `Injective.dite` after PR 32068
```diff
diff --git a/Mathlib/Logic/Function/Basic.lean b/Mathlib/Logic/Function/Basic.lean
index acf88a0e83..963e38c8f7 100644
--- a/Mathlib/Logic/Function/Basic.lean
+++ b/Mathlib/Logic/Function/Basic.lean
@@ -126,17 +126,13 @@ theorem injective_comp_left_iff [Nonempty α] {g : β → γ} :
 @[nontriviality] theorem bijective_of_subsingleton [Subsingleton α] (f : α → α) : Bijective f :=
   ⟨injective_of_subsingleton f, fun a ↦ ⟨a, Subsingleton.elim ..⟩⟩
 
+set_option trace.profiler true in
 lemma Injective.dite (p : α → Prop) [DecidablePred p]
     {f : {a : α // p a} → β} {f' : {a : α // ¬ p a} → β}
     (hf : Injective f) (hf' : Injective f')
     (im_disj : ∀ {x x' : α} {hx : p x} {hx' : ¬ p x'}, f ⟨x, hx⟩ ≠ f' ⟨x', hx'⟩) :
     Function.Injective (fun x ↦ if h : p x then f ⟨x, h⟩ else f' ⟨x, h⟩) := fun x₁ x₂ h => by
-  dsimp only at h
-  by_cases h₁ : p x₁ <;> by_cases h₂ : p x₂
-  · rw [dif_pos h₁, dif_pos h₂] at h; injection (hf h)
-  · rw [dif_pos h₁, dif_neg h₂] at h; exact (im_disj h).elim
-  · rw [dif_neg h₁, dif_pos h₂] at h; exact (im_disj h.symm).elim
-  · rw [dif_neg h₁, dif_neg h₂] at h; injection (hf' h)
+  grind
 
 theorem Surjective.of_comp {g : γ → α} (S : Surjective (f ∘ g)) : Surjective f := fun y ↦
   let ⟨x, h⟩ := S y
@@ -587,22 +583,13 @@ such as `(Sum.rec · g)`.
 In future, we should build some automation to generate applications like `Option.rec_update` for all
 inductive types. -/
 lemma rec_update {ι κ : Sort*} {α : κ → Sort*} [DecidableEq ι] [DecidableEq κ]
-    {ctor : ι → κ} (hctor : Function.Injective ctor)
+    {ctor : ι → κ} (_ : Function.Injective ctor)
     (recursor : ((i : ι) → α (ctor i)) → ((i : κ) → α i))
     (h : ∀ f i, recursor f (ctor i) = f i)
     (h2 : ∀ f₁ f₂ k, (∀ i, ctor i ≠ k) → recursor f₁ k = recursor f₂ k)
     (f : (i : ι) → α (ctor i)) (i : ι) (x : α (ctor i)) :
     recursor (update f i x) = update (recursor f) (ctor i) x := by
-  ext k
-  by_cases h : ∃ i, ctor i = k
-  · obtain ⟨i', rfl⟩ := h
-    obtain rfl | hi := eq_or_ne i' i
-    · simp [h]
-    · have hk := hctor.ne hi
-      simp [h, hi, hk, Function.update_of_ne]
-  · rw [not_exists] at h
-    rw [h2 _ f _ h]
-    rw [Function.update_of_ne (Ne.symm <| h i)]
+  grind
 
 @[simp]
 lemma _root_.Option.rec_update {α : Type*} {β : Option α → Sort*} [DecidableEq α]
@@ -615,22 +602,16 @@ lemma _root_.Option.rec_update {α : Type*} {β : Option α → Sort*} [Decidabl
 theorem apply_update {ι : Sort*} [DecidableEq ι] {α β : ι → Sort*} (f : ∀ i, α i → β i)
     (g : ∀ i, α i) (i : ι) (v : α i) (j : ι) :
     f j (update g i v j) = update (fun k ↦ f k (g k)) i (f i v) j := by
-  by_cases h : j = i
-  · subst j
-    simp
-  · simp [h]
+  grind
 
 theorem apply_update₂ {ι : Sort*} [DecidableEq ι] {α β γ : ι → Sort*} (f : ∀ i, α i → β i → γ i)
     (g : ∀ i, α i) (h : ∀ i, β i) (i : ι) (v : α i) (w : β i) (j : ι) :
     f j (update g i v j) (update h i w j) = update (fun k ↦ f k (g k) (h k)) i (f i v w) j := by
-  by_cases h : j = i
-  · subst j
-    simp
-  · simp [h]
+  grind
 
 theorem pred_update (P : ∀ ⦃a⦄, β a → Prop) (f : ∀ a, β a) (a' : α) (v : β a') (a : α) :
     P (update f a' v a) ↔ a = a' ∧ P v ∨ a ≠ a' ∧ P (f a) := by
-  rw [apply_update P, update_apply, ite_prop_iff_or]
+  grind
 
 theorem comp_update {α' : Sort*} {β : Sort*} (f : α' → β) (g : α → α') (i : α) (v : α') :
     f ∘ update g i v = update (f ∘ g) i (f v) :=
@@ -638,20 +619,12 @@ theorem comp_update {α' : Sort*} {β : Sort*} (f : α' → β) (g : α → α')
 
 theorem update_comm {α} [DecidableEq α] {β : α → Sort*} {a b : α} (h : a ≠ b) (v : β a) (w : β b)
     (f : ∀ a, β a) : update (update f a v) b w = update (update f b w) a v := by
-  funext c
-  simp only [update]
-  by_cases h₁ : c = b <;> by_cases h₂ : c = a
-  · rw [dif_pos h₁, dif_pos h₂]
-    cases h (h₂.symm.trans h₁)
-  · rw [dif_pos h₁, dif_pos h₁, dif_neg h₂]
-  · rw [dif_neg h₁, dif_neg h₁]
-  · rw [dif_neg h₁, dif_neg h₁]
+  grind
 
 @[simp]
 theorem update_idem {α} [DecidableEq α] {β : α → Sort*} {a : α} (v w : β a) (f : ∀ a, β a) :
     update (update f a v) a w = update f a w := by
-  funext b
-  by_cases h : b = a <;> simp [update, h]
+  grind
 
 @[simp]
 theorem _root_.Pi.map_update {ι : Sort*} [DecidableEq ι] {α β : ι → Sort*}
@@ -1094,7 +1067,7 @@ theorem Function.LeftInverse.eq_rec_on_eq {γ : β → Sort v} {f : α → β} {
 theorem Function.LeftInverse.cast_eq {γ : β → Sort v} {f : α → β} {g : β → α}
     (h : Function.LeftInverse g f) (C : ∀ a : α, γ (f a)) (a : α) :
     cast (congr_arg (fun a ↦ γ (f a)) (h a)) (C (g (f a))) = C a := by
-  rw [cast_eq_iff_heq, h]
+  grind
 
 /-- A set of functions "separates points"
 if for each pair of distinct points there is a function taking different values on them. -/
```
```
ℹ [85/85] Built Mathlib.Logic.Function.Basic (1.1s)
info: Mathlib/Logic/Function/Basic.lean:130:0: [Elab.async] [0.027740] elaborating proof of Function.Injective.dite
  [Elab.definition.value] [0.027449] Function.Injective.dite
    [Elab.step] [0.027161] grind
      [Elab.step] [0.027155] grind
        [Elab.step] [0.027148] grind
Build completed successfully (85 jobs).
```
</details>

---
<details>
<summary>Show trace profiling of <code>update_comm</code>: 12 ms before, 57 ms after </summary>

### Trace profiling of `update_comm` before PR 32068
```diff
diff --git a/Mathlib/Logic/Function/Basic.lean b/Mathlib/Logic/Function/Basic.lean
index acf88a0e83..e6aa75c3e4 100644
--- a/Mathlib/Logic/Function/Basic.lean
+++ b/Mathlib/Logic/Function/Basic.lean
@@ -636,6 +636,7 @@ theorem comp_update {α' : Sort*} {β : Sort*} (f : α' → β) (g : α → α')
     f ∘ update g i v = update (f ∘ g) i (f v) :=
   funext <| apply_update _ _ _ _
 
+set_option trace.profiler true in
 theorem update_comm {α} [DecidableEq α] {β : α → Sort*} {a b : α} (h : a ≠ b) (v : β a) (w : β b)
     (f : ∀ a, β a) : update (update f a v) b w = update (update f b w) a v := by
   funext c
```
```
ℹ [85/85] Built Mathlib.Logic.Function.Basic (1.1s)
info: Mathlib/Logic/Function/Basic.lean:640:0: [Elab.async] [0.013042] elaborating proof of Function.update_comm
  [Elab.definition.value] [0.012492] Function.update_comm
    [Elab.step] [0.012066] 
          funext c
          simp only [update]
          by_cases h₁ : c = b <;> by_cases h₂ : c = a
          · rw [dif_pos h₁, dif_pos h₂]
            cases h (h₂.symm.trans h₁)
          · rw [dif_pos h₁, dif_pos h₁, dif_neg h₂]
          · rw [dif_neg h₁, dif_neg h₁]
          · rw [dif_neg h₁, dif_neg h₁]
      [Elab.step] [0.012061] 
            funext c
            simp only [update]
            by_cases h₁ : c = b <;> by_cases h₂ : c = a
            · rw [dif_pos h₁, dif_pos h₂]
              cases h (h₂.symm.trans h₁)
            · rw [dif_pos h₁, dif_pos h₁, dif_neg h₂]
            · rw [dif_neg h₁, dif_neg h₁]
            · rw [dif_neg h₁, dif_neg h₁]
Build completed successfully (85 jobs).
```

### Trace profiling of `update_comm` after PR 32068
```diff
diff --git a/Mathlib/Logic/Function/Basic.lean b/Mathlib/Logic/Function/Basic.lean
index acf88a0e83..8c7c789cbd 100644
--- a/Mathlib/Logic/Function/Basic.lean
+++ b/Mathlib/Logic/Function/Basic.lean
@@ -131,12 +131,7 @@ lemma Injective.dite (p : α → Prop) [DecidablePred p]
     (hf : Injective f) (hf' : Injective f')
     (im_disj : ∀ {x x' : α} {hx : p x} {hx' : ¬ p x'}, f ⟨x, hx⟩ ≠ f' ⟨x', hx'⟩) :
     Function.Injective (fun x ↦ if h : p x then f ⟨x, h⟩ else f' ⟨x, h⟩) := fun x₁ x₂ h => by
-  dsimp only at h
-  by_cases h₁ : p x₁ <;> by_cases h₂ : p x₂
-  · rw [dif_pos h₁, dif_pos h₂] at h; injection (hf h)
-  · rw [dif_pos h₁, dif_neg h₂] at h; exact (im_disj h).elim
-  · rw [dif_neg h₁, dif_pos h₂] at h; exact (im_disj h.symm).elim
-  · rw [dif_neg h₁, dif_neg h₂] at h; injection (hf' h)
+  grind
 
 theorem Surjective.of_comp {g : γ → α} (S : Surjective (f ∘ g)) : Surjective f := fun y ↦
   let ⟨x, h⟩ := S y
@@ -587,22 +582,13 @@ such as `(Sum.rec · g)`.
 In future, we should build some automation to generate applications like `Option.rec_update` for all
 inductive types. -/
 lemma rec_update {ι κ : Sort*} {α : κ → Sort*} [DecidableEq ι] [DecidableEq κ]
-    {ctor : ι → κ} (hctor : Function.Injective ctor)
+    {ctor : ι → κ} (_ : Function.Injective ctor)
     (recursor : ((i : ι) → α (ctor i)) → ((i : κ) → α i))
     (h : ∀ f i, recursor f (ctor i) = f i)
     (h2 : ∀ f₁ f₂ k, (∀ i, ctor i ≠ k) → recursor f₁ k = recursor f₂ k)
     (f : (i : ι) → α (ctor i)) (i : ι) (x : α (ctor i)) :
     recursor (update f i x) = update (recursor f) (ctor i) x := by
-  ext k
-  by_cases h : ∃ i, ctor i = k
-  · obtain ⟨i', rfl⟩ := h
-    obtain rfl | hi := eq_or_ne i' i
-    · simp [h]
-    · have hk := hctor.ne hi
-      simp [h, hi, hk, Function.update_of_ne]
-  · rw [not_exists] at h
-    rw [h2 _ f _ h]
-    rw [Function.update_of_ne (Ne.symm <| h i)]
+  grind
 
 @[simp]
 lemma _root_.Option.rec_update {α : Type*} {β : Option α → Sort*} [DecidableEq α]
@@ -615,43 +601,30 @@ lemma _root_.Option.rec_update {α : Type*} {β : Option α → Sort*} [Decidabl
 theorem apply_update {ι : Sort*} [DecidableEq ι] {α β : ι → Sort*} (f : ∀ i, α i → β i)
     (g : ∀ i, α i) (i : ι) (v : α i) (j : ι) :
     f j (update g i v j) = update (fun k ↦ f k (g k)) i (f i v) j := by
-  by_cases h : j = i
-  · subst j
-    simp
-  · simp [h]
+  grind
 
 theorem apply_update₂ {ι : Sort*} [DecidableEq ι] {α β γ : ι → Sort*} (f : ∀ i, α i → β i → γ i)
     (g : ∀ i, α i) (h : ∀ i, β i) (i : ι) (v : α i) (w : β i) (j : ι) :
     f j (update g i v j) (update h i w j) = update (fun k ↦ f k (g k) (h k)) i (f i v w) j := by
-  by_cases h : j = i
-  · subst j
-    simp
-  · simp [h]
+  grind
 
 theorem pred_update (P : ∀ ⦃a⦄, β a → Prop) (f : ∀ a, β a) (a' : α) (v : β a') (a : α) :
     P (update f a' v a) ↔ a = a' ∧ P v ∨ a ≠ a' ∧ P (f a) := by
-  rw [apply_update P, update_apply, ite_prop_iff_or]
+  grind
 
 theorem comp_update {α' : Sort*} {β : Sort*} (f : α' → β) (g : α → α') (i : α) (v : α') :
     f ∘ update g i v = update (f ∘ g) i (f v) :=
   funext <| apply_update _ _ _ _
 
+set_option trace.profiler true in
 theorem update_comm {α} [DecidableEq α] {β : α → Sort*} {a b : α} (h : a ≠ b) (v : β a) (w : β b)
     (f : ∀ a, β a) : update (update f a v) b w = update (update f b w) a v := by
-  funext c
-  simp only [update]
-  by_cases h₁ : c = b <;> by_cases h₂ : c = a
-  · rw [dif_pos h₁, dif_pos h₂]
-    cases h (h₂.symm.trans h₁)
-  · rw [dif_pos h₁, dif_pos h₁, dif_neg h₂]
-  · rw [dif_neg h₁, dif_neg h₁]
-  · rw [dif_neg h₁, dif_neg h₁]
+  grind
 
 @[simp]
 theorem update_idem {α} [DecidableEq α] {β : α → Sort*} {a : α} (v w : β a) (f : ∀ a, β a) :
     update (update f a v) a w = update f a w := by
-  funext b
-  by_cases h : b = a <;> simp [update, h]
+  grind
 
 @[simp]
 theorem _root_.Pi.map_update {ι : Sort*} [DecidableEq ι] {α β : ι → Sort*}
@@ -1094,7 +1067,7 @@ theorem Function.LeftInverse.eq_rec_on_eq {γ : β → Sort v} {f : α → β} {
 theorem Function.LeftInverse.cast_eq {γ : β → Sort v} {f : α → β} {g : β → α}
     (h : Function.LeftInverse g f) (C : ∀ a : α, γ (f a)) (a : α) :
     cast (congr_arg (fun a ↦ γ (f a)) (h a)) (C (g (f a))) = C a := by
-  rw [cast_eq_iff_heq, h]
+  grind
 
 /-- A set of functions "separates points"
 if for each pair of distinct points there is a function taking different values on them. -/
```
```
ℹ [85/85] Built Mathlib.Logic.Function.Basic (1.1s)
info: Mathlib/Logic/Function/Basic.lean:620:0: [Elab.async] [0.057392] elaborating proof of Function.update_comm
  [Elab.definition.value] [0.057238] Function.update_comm
    [Elab.step] [0.057126] grind
      [Elab.step] [0.057121] grind
        [Elab.step] [0.057114] grind
Build completed successfully (85 jobs).
```
</details>

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

When merging, all the commits will be squashed into a single commit
listing all co-authors.

Co-authors in the squash commit are gathered from two sources:

First, all authors of commits to this PR branch are included. Thus,
one way to add co-authors is to include at least one commit authored by
each co-author among the commits in the pull request. If necessary, you
may create empty commits to indicate co-authorship, using commands like so:

git commit --author="Author Name <author@email.com>" --allow-empty -m "add Author Name as coauthor"

Second, co-authors can also be listed in lines at the very bottom of
the commit message (that is, directly before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines
at the bottom of the commit message (before the `---`, and also before
any "Co-authored-by" lines) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
