### PR TITLE
[Merged by Bors] - chore(Logic/Equiv): golf `dite_comp_equiv_update` using `grind`

### DIFF
--- a/Mathlib/Logic/Equiv/Set.lean
+++ b/Mathlib/Logic/Equiv/Set.lean
@@ -623,18 +623,7 @@ theorem dite_comp_equiv_update {α : Type*} {β : Sort*} {γ : Sort*} {p : α �
     [∀ j, Decidable (p j)] :
     (fun i : α => if h : p i then (Function.update v j x) (e.symm ⟨i, h⟩) else w i) =
       Function.update (fun i : α => if h : p i then v (e.symm ⟨i, h⟩) else w i) (e j) x := by
-  ext i
-  by_cases h : p i
-  · rw [dif_pos h, Function.update_apply_equiv_apply, Equiv.symm_symm,
-      Function.update_apply, Function.update_apply, dif_pos h]
-    have h_coe : (⟨i, h⟩ : Subtype p) = e j ↔ i = e j :=
-      Subtype.ext_iff.trans (by rw [Subtype.coe_mk])
-    simp [h_coe]
-  · have : i ≠ e j := by
-      contrapose! h
-      have : p (e j : α) := (e j).2
-      rwa [← h] at this
-    simp [h, this]
+  grind
 
 section Swap
 


### PR DESCRIPTION
---
<details>
<summary>Show trace profiling of <code>dite_comp_equiv_update</code>: 24 ms before, 27 ms after </summary>

### Trace profiling of `dite_comp_equiv_update` before PR 32069
```diff
diff --git a/Mathlib/Logic/Equiv/Set.lean b/Mathlib/Logic/Equiv/Set.lean
index c216b81459..3bf5a51cb1 100644
--- a/Mathlib/Logic/Equiv/Set.lean
+++ b/Mathlib/Logic/Equiv/Set.lean
@@ -615,6 +615,7 @@ noncomputable def Set.BijOn.equiv {α : Type*} {β : Type*} {s : Set α} {t : Se
     (h : BijOn f s t) : s ≃ t :=
   Equiv.ofBijective _ h.bijective
 
+set_option trace.profiler true in
 /-- The composition of an updated function with an equiv on a subtype can be expressed as an
 updated function. -/
 theorem dite_comp_equiv_update {α : Type*} {β : Sort*} {γ : Sort*} {p : α → Prop}
```
```
ℹ [399/399] Built Mathlib.Logic.Equiv.Set (1.5s)
info: Mathlib/Logic/Equiv/Set.lean:619:0: [Elab.async] [0.024543] elaborating proof of dite_comp_equiv_update
  [Elab.definition.value] [0.023846] dite_comp_equiv_update
    [Elab.step] [0.023377] 
          ext i
          by_cases h : p i
          · rw [dif_pos h, Function.update_apply_equiv_apply, Equiv.symm_symm, Function.update_apply,
              Function.update_apply, dif_pos h]
            have h_coe : (⟨i, h⟩ : Subtype p) = e j ↔ i = e j := Subtype.ext_iff.trans (by rw [Subtype.coe_mk])
            simp [h_coe]
          · have : i ≠ e j := by
              contrapose! h
              have : p (e j : α) := (e j).2
              rwa [← h] at this
            simp [h, this]
      [Elab.step] [0.023371] 
            ext i
            by_cases h : p i
            · rw [dif_pos h, Function.update_apply_equiv_apply, Equiv.symm_symm, Function.update_apply,
                Function.update_apply, dif_pos h]
              have h_coe : (⟨i, h⟩ : Subtype p) = e j ↔ i = e j := Subtype.ext_iff.trans (by rw [Subtype.coe_mk])
              simp [h_coe]
            · have : i ≠ e j := by
                contrapose! h
                have : p (e j : α) := (e j).2
                rwa [← h] at this
              simp [h, this]
        [Elab.step] [0.014208] ·
              rw [dif_pos h, Function.update_apply_equiv_apply, Equiv.symm_symm, Function.update_apply,
                Function.update_apply, dif_pos h]
              have h_coe : (⟨i, h⟩ : Subtype p) = e j ↔ i = e j := Subtype.ext_iff.trans (by rw [Subtype.coe_mk])
              simp [h_coe]
          [Elab.step] [0.014199] 
                rw [dif_pos h, Function.update_apply_equiv_apply, Equiv.symm_symm, Function.update_apply,
                  Function.update_apply, dif_pos h]
                have h_coe : (⟨i, h⟩ : Subtype p) = e j ↔ i = e j := Subtype.ext_iff.trans (by rw [Subtype.coe_mk])
                simp [h_coe]
            [Elab.step] [0.014194] 
                  rw [dif_pos h, Function.update_apply_equiv_apply, Equiv.symm_symm, Function.update_apply,
                    Function.update_apply, dif_pos h]
                  have h_coe : (⟨i, h⟩ : Subtype p) = e j ↔ i = e j := Subtype.ext_iff.trans (by rw [Subtype.coe_mk])
                  simp [h_coe]
Build completed successfully (399 jobs).
```

### Trace profiling of `dite_comp_equiv_update` after PR 32069
```diff
diff --git a/Mathlib/Logic/Equiv/Set.lean b/Mathlib/Logic/Equiv/Set.lean
index c216b81459..181e861f39 100644
--- a/Mathlib/Logic/Equiv/Set.lean
+++ b/Mathlib/Logic/Equiv/Set.lean
@@ -615,6 +615,7 @@ noncomputable def Set.BijOn.equiv {α : Type*} {β : Type*} {s : Set α} {t : Se
     (h : BijOn f s t) : s ≃ t :=
   Equiv.ofBijective _ h.bijective
 
+set_option trace.profiler true in
 /-- The composition of an updated function with an equiv on a subtype can be expressed as an
 updated function. -/
 theorem dite_comp_equiv_update {α : Type*} {β : Sort*} {γ : Sort*} {p : α → Prop}
@@ -623,18 +624,7 @@ theorem dite_comp_equiv_update {α : Type*} {β : Sort*} {γ : Sort*} {p : α 
     [∀ j, Decidable (p j)] :
     (fun i : α => if h : p i then (Function.update v j x) (e.symm ⟨i, h⟩) else w i) =
       Function.update (fun i : α => if h : p i then v (e.symm ⟨i, h⟩) else w i) (e j) x := by
-  ext i
-  by_cases h : p i
-  · rw [dif_pos h, Function.update_apply_equiv_apply, Equiv.symm_symm,
-      Function.update_apply, Function.update_apply, dif_pos h]
-    have h_coe : (⟨i, h⟩ : Subtype p) = e j ↔ i = e j :=
-      Subtype.ext_iff.trans (by rw [Subtype.coe_mk])
-    simp [h_coe]
-  · have : i ≠ e j := by
-      contrapose! h
-      have : p (e j : α) := (e j).2
-      rwa [← h] at this
-    simp [h, this]
+  grind
 
 section Swap
 
```
```
ℹ [399/399] Built Mathlib.Logic.Equiv.Set (1.5s)
info: Mathlib/Logic/Equiv/Set.lean:619:0: [Elab.async] [0.027553] elaborating proof of dite_comp_equiv_update
  [Elab.definition.value] [0.027346] dite_comp_equiv_update
    [Elab.step] [0.027190] grind
      [Elab.step] [0.027184] grind
        [Elab.step] [0.027176] grind
Build completed successfully (399 jobs).
```
</details>

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

When merging, all the commits will be squashed into a single commit
listing all co-authors.

Co-authors in the squash commit are gathered from two sources:

First, all authors of commits to this PR branch are included. Thus,
one way to add co-authors is to include at least one commit authored by
each co-author among the commits in the pull request. If necessary, you
may create empty commits to indicate co-authorship, using commands like so:

git commit --author="Author Name <author@email.com>" --allow-empty -m "add Author Name as coauthor"

Second, co-authors can also be listed in lines at the very bottom of
the commit message (that is, directly before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines
at the bottom of the commit message (before the `---`, and also before
any "Co-authored-by" lines) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
