### PR TITLE
[Merged by Bors] - feat(RingTheory): universal factorization ring

### DIFF
--- a/Mathlib/RingTheory/Polynomial/UniversalFactorizationRing.lean
+++ b/Mathlib/RingTheory/Polynomial/UniversalFactorizationRing.lean
@@ -5,9 +5,12 @@ Authors: Andrew Yang
 -/
 module
 
-public import Mathlib.Algebra.MvPolynomial.CommRing
-public import Mathlib.Algebra.Polynomial.Monic
-public import Mathlib.RingTheory.TensorProduct.Maps
+public import Mathlib.RingTheory.Extension.Presentation.Submersive
+public import Mathlib.RingTheory.FiniteStability
+public import Mathlib.RingTheory.Flat.FaithfullyFlat.Basic
+public import Mathlib.RingTheory.Polynomial.IsIntegral
+public import Mathlib.RingTheory.Polynomial.Resultant.Basic
+
 
 /-!
 
@@ -18,7 +21,8 @@ We construct the universal ring of the following functors on `R-Alg`:
 - `S ↦ "monic polynomials over S of degree n"`:
   Represented by `R[X₁,...,Xₙ]`. See `MvPolynomial.mapEquivMonic`.
 - `S ↦ "factorizations of p into (monic deg m) * (monic deg k) in S"`:
-  Represented by an `R`-algebra that is finitely-presented as an `R`-module (TODO).
+  Represented by an `R`-algebra (`Polynomial.UniversalFactorizationRing`) that is finitely-presented
+  as an `R`-module. See `Polynomial.UniversalFactorizationRing.homEquiv`.
 - `S ↦ "factorizations of p into coprime (monic deg m) * (monic deg k) in S"`:
   Represented by an etale `R`-algebra (TODO).
 
@@ -174,4 +178,320 @@ def universalFactorizationMapLiftEquiv (p : MonicDegreeEq S n) :
   left_inv f := by ext <;> simp
   right_inv q := by ext <;> simp
 
+lemma ker_eval₂Hom_universalFactorizationMap :
+    RingHom.ker (eval₂Hom (S₁ := MvPolynomial (Fin m) R ⊗[R] MvPolynomial (Fin k) R)
+      (universalFactorizationMap R n m k hn) (Sum.elim (.X · ⊗ₜ 1) (1 ⊗ₜ .X ·))) =
+    Ideal.span (Set.range fun i ↦ C (X i) - map C (tensorEquivSum _ _ _ _
+      (universalFactorizationMap R n m k hn (X i)))) := by
+  set f := eval₂Hom (R := MvPolynomial (Fin n) R)
+    (S₁ := MvPolynomial (Fin m) R ⊗[R] MvPolynomial (Fin k) R)
+    (universalFactorizationMap R n m k hn) (Sum.elim (.X · ⊗ₜ 1) (1 ⊗ₜ .X ·))
+  have H (i : _) : tensorEquivSum _ _ _ _ (f (.X i)) = .X i := by aesop
+  apply le_antisymm
+  · intro x hx
+    convert_to x - (tensorEquivSum _ _ _ _ (f x)).map C ∈ Ideal.span _ using 1
+    · simp_all only [RingHom.mem_ker, map_zero, sub_zero]
+    clear hx
+    induction x using MvPolynomial.induction_on with
+    | add p q _ _ => simp only [map_add, add_sub_add_comm]; exact add_mem ‹_› ‹_›
+    | mul_X p i _ => simp only [map_mul, H, map_X, ← sub_mul]; exact Ideal.mul_mem_right _ _ ‹_›
+    | C x =>
+    induction x using MvPolynomial.induction_on with
+    | C a => simp [f]
+    | add p q _ _ => simp only [map_add, add_sub_add_comm]; exact add_mem ‹_› ‹_›
+    | mul_X p i IH =>
+      simp only [map_mul]
+      exact Ideal.mul_sub_mul_mem _ IH (Ideal.subset_span ⟨i, by simp [f]⟩)
+  · simp only [Ideal.span_le, Set.range_subset_iff, SetLike.mem_coe, RingHom.mem_ker, map_sub,
+      eval₂Hom_C, RingHom.coe_coe, eval₂Hom_map_hom, coe_eval₂Hom, sub_eq_zero, f]
+    simp only [← algebraMap_eq, AlgHom.comp_algebraMap_of_tower, ← aeval_def]
+    intro i
+    generalize universalFactorizationMap R n m k hn (X i) = p
+    change AlgHom.id R _ p = ((aeval _).comp (tensorEquivSum R _ _ R).toAlgHom) p
+    congr 1
+    ext <;> simp
+
+/-- The canonical presentation of `universalFactorizationMap`. -/
+@[simps] def universalFactorizationMapPresentation :
+    letI := (universalFactorizationMap R n m k hn).toAlgebra
+    Algebra.PreSubmersivePresentation (MvPolynomial (Fin n) R)
+      (MvPolynomial (Fin m) R ⊗[R] MvPolynomial (Fin k) R) (Fin m ⊕ Fin k) (Fin n) :=
+  letI := (universalFactorizationMap R n m k hn).toAlgebra
+  { val := Sum.elim (.X · ⊗ₜ 1) (1 ⊗ₜ .X ·)
+    σ' f := (tensorEquivSum _ _ _ _ f).map C
+    aeval_val_σ' s := by
+      change ((aeval _).restrictScalars R |>.comp (mapAlgHom (Algebra.ofId _ _)) |>.comp
+          (tensorEquivSum R (Fin m) (Fin k) R).toAlgHom) s = AlgHom.id R _ s
+      congr 1
+      ext <;> simp
+    algebra := (aeval _).toAlgebra
+    algebraMap_eq := rfl
+    relation i := .C (.X i) - (tensorEquivSum R (Fin m) (Fin k) R
+      (universalFactorizationMap R n m k hn (.X i))).map C
+    span_range_relation_eq_ker := by
+      exact (ker_eval₂Hom_universalFactorizationMap R n m k hn).symm,
+    map := finSumFinEquiv.symm ∘ finCongr hn
+    map_inj := finSumFinEquiv.symm.injective.comp (finCongr hn).injective }
+
+lemma pderiv_inl_universalFactorizationMap_X (i j) :
+    pderiv (Sum.inl i) (tensorEquivSum R (Fin m) (Fin k) R
+      (universalFactorizationMap R n m k hn (X j))) =
+    if ↑j < (i : ℕ) then 0 else if h : ↑j - ↑i < k then X (.inr ⟨↑j - ↑i, h⟩)
+      else if ↑j - ↑i = k then 1 else 0 := by
+  classical
+  trans ∑ x ∈ Finset.antidiagonal ↑j,
+    if h : x.2 < k then if x.1 < m ∧ x.1 = ↑i then X (Sum.inr ⟨x.2, h⟩) else 0
+    else if x.2 = k ∧ x.1 < m ∧ x.1 = ↑i then 1 else 0
+  · simp [universalFactorizationMap, mapEquivMonic, Polynomial.coeff_mul, coeff_freeMonic,
+      apply_dite, apply_ite, ← Algebra.TensorProduct.one_def,
+      Pi.single_apply, Fin.ext_iff, ← ite_and]
+  · obtain h | h := lt_or_ge j.1 i.1
+    · rw [Finset.sum_eq_zero, if_pos h]
+      simp only [Finset.mem_antidiagonal, Prod.forall]
+      intro a b hab
+      simp [show a ≠ i by omega]
+    rw [Finset.sum_eq_single ⟨i.1, j.1 - i.1⟩, if_neg h.not_gt]
+    · simp
+    · simp only [Finset.mem_antidiagonal, ne_eq, Prod.forall, Prod.mk.injEq, not_and]
+      intro a b e h
+      simp [show a ≠ i by omega]
+    · simp [h]
+
+lemma pderiv_inr_universalFactorizationMap_X (i j) :
+    pderiv (Sum.inr i) (tensorEquivSum R (Fin m) (Fin k) R
+      (universalFactorizationMap R n m k hn (X j))) =
+    if ↑j < (i : ℕ) then 0 else if h : ↑j - ↑i < m then
+      X (.inl ⟨↑j - ↑i, h⟩) else if ↑j - ↑i = m then 1 else 0 := by
+  classical
+  trans ∑ x ∈ Finset.antidiagonal ↑j, if x.2 < k then if h : x.1 < m then if x.2 = ↑i then
+    X (Sum.inl ⟨x.1, h⟩) else 0 else if x.1 = m ∧ x.2 = ↑i then 1 else 0 else 0
+  · simp [universalFactorizationMap, mapEquivMonic, Polynomial.coeff_mul, coeff_freeMonic,
+      apply_dite, apply_ite, ← Algebra.TensorProduct.one_def,
+      Pi.single_apply, Fin.ext_iff, ← ite_and]
+  · obtain h | h := lt_or_ge j.1 i.1
+    · rw [Finset.sum_eq_zero, if_pos h]
+      simp only [Finset.mem_antidiagonal, Prod.forall]
+      intro a b hab
+      simp [show b ≠ i by omega]
+    rw [Finset.sum_eq_single ⟨j.1 - i.1, i.1⟩, if_neg h.not_gt]
+    · simp
+    · simp only [Finset.mem_antidiagonal, ne_eq, ite_eq_right_iff, Prod.forall, Prod.mk.injEq]
+      intro a b _ _ _
+      simp [show b ≠ i by omega]
+    · simp [h]
+
+lemma universalFactorizationMapPresentation_jacobiMatrix :
+    letI := (universalFactorizationMap R n m k hn).toAlgebra
+    (universalFactorizationMapPresentation R n m k hn).jacobiMatrix =
+    -((Polynomial.sylvester
+      ((freeMonic R m).map (((mapAlgHom (Algebra.ofId _ _)).comp (rename Sum.inl)).toRingHom))
+      ((freeMonic R k).map (((mapAlgHom (Algebra.ofId _ _)).comp (rename Sum.inr)).toRingHom))
+      m k).reindex (finCongr (by omega)) (finCongr (by omega))).transpose := by
+  letI := (universalFactorizationMap R n m k hn).toAlgebra
+  subst hn
+  ext i j : 1
+  dsimp [Polynomial.sylvester]
+  rw [Algebra.PreSubmersivePresentation.jacobiMatrix_apply]
+  obtain ⟨i | i, rfl⟩ := finSumFinEquiv.surjective i <;>
+    induction j using Fin.addCases <;>
+      simp [pderiv_map, coeff_freeMonic, apply_dite (DFunLike.coe _), apply_ite (DFunLike.coe _),
+        pderiv_inl_universalFactorizationMap_X, pderiv_inr_universalFactorizationMap_X] <;> grind
+
+lemma universalFactorizationMapPresentation_jacobian :
+    letI := (universalFactorizationMap R n m k hn).toAlgebra
+    (universalFactorizationMapPresentation R n m k hn).jacobian =
+    (-1) ^ n * (Polynomial.resultant
+      ((freeMonic R m).map Algebra.TensorProduct.includeLeftRingHom)
+      ((freeMonic R k).map Algebra.TensorProduct.includeRight.toRingHom)) := by
+  cases subsingleton_or_nontrivial R
+  · exact Subsingleton.elim _ _
+  letI := (universalFactorizationMap R n m k hn).toAlgebra
+  rw [Algebra.PreSubmersivePresentation.jacobian_eq_jacobiMatrix_det,
+    MvPolynomial.universalFactorizationMapPresentation_jacobiMatrix]
+  simp only [AlgHom.toRingHom_eq_coe, Matrix.det_neg, Matrix.det_transpose, Matrix.det_reindex_self,
+    Algebra.Generators.algebraMap_apply, ← Polynomial.resultant.eq_def,
+    Fintype.card_fin, map_mul, map_pow, map_neg, map_one]
+  congr 1
+  rw [← (aeval _).coe_toRingHom, ← Polynomial.resultant_map_map,
+    Polynomial.map_map, Polynomial.map_map]
+  congr 2
+  · ext <;> simp [- algebraMap_apply, ← algebraMap_eq]
+  · ext <;> simp [- algebraMap_apply, ← algebraMap_eq]
+  · rw [(monic_freeMonic ..).natDegree_map, natDegree_freeMonic]
+  · rw [(monic_freeMonic ..).natDegree_map, natDegree_freeMonic]
+
+lemma finitePresentation_universalFactorizationMap :
+    (universalFactorizationMap R n m k hn).FinitePresentation :=
+  letI := (universalFactorizationMap R n m k hn).toAlgebra
+  (universalFactorizationMapPresentation R n m k hn).finitePresentation_of_isFinite
+
+lemma finite_universalFactorizationMap :
+    (universalFactorizationMap R n m k hn).Finite := by
+  refine RingHom.IsIntegral.to_finite ?_
+    (.of_finitePresentation (finitePresentation_universalFactorizationMap R n m k hn))
+  letI := (universalFactorizationMap R n m k hn).toAlgebra
+  have : IsDomain (MvPolynomial (Fin m) ℤ ⊗[ℤ] MvPolynomial (Fin k) ℤ) :=
+    (MvPolynomial.tensorEquivSum ℤ (Fin m) (Fin k) ℤ).toRingEquiv.isDomain_iff.mpr inferInstance
+  letI := (universalFactorizationMap ℤ n m k hn).toAlgebra
+  let F : MvPolynomial (Fin m) ℤ ⊗[ℤ] MvPolynomial (Fin k) ℤ →ₐ[ℤ]
+      MvPolynomial (Fin m) R ⊗[R] MvPolynomial (Fin k) R :=
+    Algebra.TensorProduct.lift
+      (Algebra.TensorProduct.includeLeft.comp (mapAlgHom (Algebra.ofId ℤ R)))
+      ((Algebra.TensorProduct.includeRight.restrictScalars ℤ).comp (mapAlgHom (Algebra.ofId ℤ R)))
+      fun _ _ ↦ .all _ _
+  have H₁ (i : _) : (universalFactorizationMap R n m k hn).IsIntegralElem (.X i ⊗ₜ 1) := by
+    obtain ⟨p, hp, hp'⟩ : (universalFactorizationMap ℤ n m k hn).IsIntegralElem (.X i ⊗ₜ 1) := by
+      simpa [coeff_freeMonic] using Polynomial.isIntegral_coeff_of_dvd _ _ (monic_freeMonic _ _)
+        (by simp [((monic_freeMonic _ _).map _).leadingCoeff, isIntegral_one])
+        ⟨_, universalFactorizationMap_freeMonic ℤ n m k hn⟩ i
+    refine ⟨p.map (MvPolynomial.map (algebraMap ℤ R)), hp.map _, ?_⟩
+    apply_fun F.toRingHom at hp'
+    rw [Polynomial.hom_eval₂, ← MvPolynomial.universalFactorizationMap_comp_map] at hp'
+    simpa [← Polynomial.eval₂_map, F] using hp'
+  have H₂ (i : _) : (universalFactorizationMap R n m k hn).IsIntegralElem (1 ⊗ₜ .X i) := by
+    obtain ⟨p, hp, hp'⟩ : (universalFactorizationMap ℤ n m k hn).IsIntegralElem (1 ⊗ₜ .X i) := by
+      simpa [coeff_freeMonic] using Polynomial.isIntegral_coeff_of_dvd _ _ (monic_freeMonic _ _)
+        (by simp [((monic_freeMonic _ _).map _).leadingCoeff, isIntegral_one])
+        ⟨_, (universalFactorizationMap_freeMonic ℤ n m k hn).trans (mul_comm _ _)⟩ i
+    refine ⟨p.map (MvPolynomial.map (algebraMap ℤ R)), hp.map _, ?_⟩
+    apply_fun F.toRingHom at hp'
+    rw [Polynomial.hom_eval₂, ← MvPolynomial.universalFactorizationMap_comp_map] at hp'
+    simpa [← Polynomial.eval₂_map, F] using hp'
+  intro x
+  induction x with
+  | zero => exact RingHom.isIntegralElem_zero _
+  | add x y _ _ => exact RingHom.IsIntegralElem.add _ ‹_› ‹_›
+  | tmul x y =>
+    suffices (universalFactorizationMap R n m k hn).IsIntegralElem (x ⊗ₜ 1 * 1 ⊗ₜ y) by simpa
+    refine RingHom.IsIntegralElem.mul _ ?_ ?_
+    · induction x using MvPolynomial.induction_on with
+      | C a => simpa using (universalFactorizationMap R n m k hn).isIntegralElem_map (x := .C a)
+      | add p q _ _ => simp only [TensorProduct.add_tmul, RingHom.IsIntegralElem.add, *]
+      | mul_X p i IH => simpa [← map_mul] using IH.mul _ (H₁ i)
+    · induction y using MvPolynomial.induction_on with
+      | C a => simpa [← algebraMap_eq, ← algebraMap_apply, Algebra.algebraMap_eq_smul_one] using
+          (universalFactorizationMap R n m k hn).isIntegralElem_map (x := .C a)
+      | add p q _ _ => simp only [TensorProduct.tmul_add, RingHom.IsIntegralElem.add, *]
+      | mul_X p i IH => simpa [← map_mul] using IH.mul _ (H₂ i)
+
 end MvPolynomial
+
+namespace Polynomial
+
+open TensorProduct
+
+variable {R n} (p : Polynomial.MonicDegreeEq R n)
+
+attribute [-instance] leftModule in
+/-- The universal factorization ring of a monic polynomial `p` of degree `n`.
+This is the representing object of the functor
+`S ↦ "factorizations of p into (monic deg m) * (monic deg k) in S"`.
+See `UniversalFactorizationRing.homEquiv`. -/
+def UniversalFactorizationRing : Type _ :=
+  letI := (MvPolynomial.universalFactorizationMap R n m k hn).toAlgebra
+  letI := ((MvPolynomial.mapEquivMonic R _ n).symm p).toAlgebra
+  R ⊗[MvPolynomial (Fin n) R] (MvPolynomial (Fin m) R ⊗[R] MvPolynomial (Fin k) R)
+  deriving CommRing, Algebra R
+
+local notation "𝓡" => UniversalFactorizationRing m k hn p
+
+/-- The canonical map `R[X₁,...,Xₘ] ⊗ R[X₁,...,Xₙ] → UniversalFactorizationRing`. -/
+def UniversalFactorizationRing.fromTensor :
+    (MvPolynomial (Fin m) R ⊗[R] MvPolynomial (Fin k) R) →ₐ[R] 𝓡 :=
+  letI := (MvPolynomial.universalFactorizationMap R n m k hn).toAlgebra
+  letI := ((MvPolynomial.mapEquivMonic R _ n).symm p).toAlgebra
+  Algebra.TensorProduct.includeRight.restrictScalars _
+
+/-- The image of `p` in the universal factorization ring of `p`. -/
+@[simps] def UniversalFactorizationRing.monicDegreeEq :
+    MonicDegreeEq 𝓡 n :=
+  ⟨p.1.map (algebraMap _ _), by simp +contextual only [Polynomial.coeff_map, p.2,
+    map_one, map_zero, gt_iff_lt, implies_true, and_self]⟩
+
+lemma UniversalFactorizationRing.fromTensor_comp_universalFactorizationMap :
+  (fromTensor m k hn p).comp (MvPolynomial.universalFactorizationMap R n m k hn) =
+    (Algebra.ofId R _).comp ((MvPolynomial.mapEquivMonic R _ n).symm p) := by
+  letI := (MvPolynomial.universalFactorizationMap R n m k hn).toAlgebra
+  letI := ((MvPolynomial.mapEquivMonic R _ n).symm p).toAlgebra
+  exact AlgHom.ext fun x ↦ (Algebra.TensorProduct.tmul_one_eq_one_tmul x).symm
+
+lemma UniversalFactorizationRing.fromTensor_comp_universalFactorizationMap' :
+  (fromTensor m k hn p).comp (MvPolynomial.universalFactorizationMap R n m k hn) =
+    ((MvPolynomial.mapEquivMonic _ _ n).symm (monicDegreeEq m k hn p)) := by
+  rw [UniversalFactorizationRing.fromTensor_comp_universalFactorizationMap, Equiv.eq_symm_apply]
+  ext1
+  simp [MvPolynomial.coe_mapEquivMonic_comp, monicDegreeEq]
+
+/-- The first factor of `p` in the universal factorization ring of `p`. -/
+def UniversalFactorizationRing.factor₁ : MonicDegreeEq 𝓡 m :=
+  (MvPolynomial.universalFactorizationMapLiftEquiv _ _ n m k hn _
+    ⟨fromTensor m k hn p, fromTensor_comp_universalFactorizationMap' m k hn p⟩).1.1
+
+/-- The second factor of `p` in the universal factorization ring of `p`. -/
+def UniversalFactorizationRing.factor₂ : MonicDegreeEq 𝓡 k :=
+  (MvPolynomial.universalFactorizationMapLiftEquiv _ _ n m k hn _
+    ⟨fromTensor m k hn p, fromTensor_comp_universalFactorizationMap' m k hn p⟩).1.2
+
+lemma UniversalFactorizationRing.factor₁_mul_factor₂ :
+    (factor₁ m k hn p).1 * (factor₂ m k hn p).1 = (monicDegreeEq m k hn p).1 :=
+  (MvPolynomial.universalFactorizationMapLiftEquiv _ _ n m k hn _
+    ⟨fromTensor m k hn p, fromTensor_comp_universalFactorizationMap' m k hn p⟩).2
+
+attribute [-instance] leftModule in
+/-- The universal factorization ring that represents
+`S ↦ "factorizations of p into (monic deg m) * (monic deg k) in S"`. -/
+def UniversalFactorizationRing.homEquiv :
+    (𝓡 →ₐ[R] S) ≃ { q : MonicDegreeEq S m × MonicDegreeEq S k //
+      q.1.1 * q.2.1 = p.1.map (algebraMap R S) } where
+  toFun f := ⟨((factor₁ m k hn p).map f, (factor₂ m k hn p).map f), by
+    simp [← Polynomial.map_mul, factor₁_mul_factor₂ m k hn p, Polynomial.map_map]⟩
+  invFun q :=
+    letI := (MvPolynomial.universalFactorizationMap R n m k hn).toAlgebra
+    letI := ((MvPolynomial.mapEquivMonic R _ n).symm p).toAlgebra
+    letI := Algebra.compHom S ((MvPolynomial.mapEquivMonic R _ n).symm p).toRingHom
+    haveI : IsScalarTower (MvPolynomial (Fin n) R) R S := .of_algebraMap_eq' rfl
+    letI f := ((MvPolynomial.universalFactorizationMapLiftEquiv R _ n m k hn
+          (p.map (algebraMap R S))).symm q)
+    Algebra.TensorProduct.lift (R := MvPolynomial (Fin n) R) (S := R) (A := R)
+      (B := MvPolynomial (Fin m) R ⊗[R] MvPolynomial (Fin k) R) (C := S) (Algebra.ofId R S)
+      { toRingHom := f.1.toRingHom
+        commutes' r := congr($(f.2) r).trans
+          (by simp [MvPolynomial.mapEquivMonic_symm_map_algebraMap]; rfl) } fun _ _ ↦ .all _ _
+  left_inv f := by
+    letI := (MvPolynomial.universalFactorizationMap R n m k hn).toAlgebra
+    letI := ((MvPolynomial.mapEquivMonic R _ n).symm p).toAlgebra
+    letI := Algebra.compHom S ((MvPolynomial.mapEquivMonic R _ n).symm p).toRingHom
+    haveI : IsScalarTower (MvPolynomial (Fin n) R) R S := .of_algebraMap_eq' rfl
+    have : IsScalarTower R (MvPolynomial (Fin n) R) S := .of_algebraMap_eq fun r ↦ by
+      simp [Algebra.compHom_algebraMap_apply]
+    refine Algebra.TensorProduct.ext (by ext) ?_
+    refine AlgHom.restrictScalars_injective R (Algebra.TensorProduct.ext ?_ ?_)
+    · ext; simp [MvPolynomial.universalFactorizationMapLiftEquiv, MvPolynomial.mapEquivMonic,
+        UniversalFactorizationRing.factor₁, coeff_freeMonic]; rfl
+    · ext; simp [MvPolynomial.universalFactorizationMapLiftEquiv, MvPolynomial.mapEquivMonic,
+        UniversalFactorizationRing.factor₂, coeff_freeMonic]; rfl
+  right_inv q := by
+    letI := (MvPolynomial.universalFactorizationMap R n m k hn).toAlgebra
+    letI := ((MvPolynomial.mapEquivMonic R _ n).symm p).toAlgebra
+    simp only [UniversalFactorizationRing, MvPolynomial.mapEquivMonic, AlgHom.toRingHom_eq_coe,
+      Equiv.coe_fn_symm_mk, MvPolynomial.coe_aeval_eq_eval, factor₁, monicDegreeEq_coe,
+      MvPolynomial.universalFactorizationMapLiftEquiv, Equiv.coe_fn_mk, fromTensor,
+      MonicDegreeEq.map_coe, factor₂]
+    ext <;> simp +contextual [coeff_freeMonic, apply_dite, MonicDegreeEq.coeff_of_ge]
+
+attribute [-instance] leftModule in
+instance : Module.Finite R 𝓡 :=
+  letI := (MvPolynomial.universalFactorizationMap R n m k hn).toAlgebra
+  letI := ((MvPolynomial.mapEquivMonic R _ n).symm p).toAlgebra
+  letI : Module.Finite _ _ := MvPolynomial.finite_universalFactorizationMap R n m k hn
+  inferInstanceAs (Module.Finite R (R ⊗[_] _))
+
+attribute [-instance] leftModule in
+instance : Algebra.FinitePresentation R 𝓡 :=
+  letI := (MvPolynomial.universalFactorizationMap R n m k hn).toAlgebra
+  letI := ((MvPolynomial.mapEquivMonic R _ n).symm p).toAlgebra
+  letI : Algebra.FinitePresentation _ _ :=
+    MvPolynomial.finitePresentation_universalFactorizationMap R n m k hn
+  inferInstanceAs (Algebra.FinitePresentation R (R ⊗[_] _))
+
+end Polynomial


### PR DESCRIPTION

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

When merging, all the commits will be squashed into a single commit
listing all co-authors.

Co-authors in the squash commit are gathered from two sources:

First, all authors of commits to this PR branch are included. Thus,
one way to add co-authors is to include at least one commit authored by
each co-author among the commits in the pull request. If necessary, you
may create empty commits to indicate co-authorship, using commands like so:

git commit --author="Author Name <author@email.com>" --allow-empty -m "add Author Name as coauthor"

Second, co-authors can also be listed in lines at the very bottom of
the commit message (that is, directly before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines
at the bottom of the commit message (before the `---`, and also before
any "Co-authored-by" lines) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
