### PR TITLE
feat(Algebra/Order/Ring/Ordering): ring ordering constructions

### DIFF
--- a/Mathlib/Algebra/Order/Ring/Ordering/Basic.lean
+++ b/Mathlib/Algebra/Order/Ring/Ordering/Basic.lean
@@ -189,10 +189,12 @@ theorem isOrdering_iff :
 ### Supports
 -/
 
+@[gcongr]
 theorem supportAddSubgroup_mono {Q : RingPreordering R} (h : P ≤ Q) :
     P.supportAddSubgroup ≤ Q.supportAddSubgroup :=
   fun _ ↦ by aesop (add simp mem_supportAddSubgroup)
 
+@[gcongr]
 theorem support_mono {Q : RingPreordering R} [P.HasIdealSupport] [Q.HasIdealSupport] (h : P ≤ Q) :
     P.support ≤ Q.support := fun _ ↦ by aesop (add simp mem_support)
 

--- a/Mathlib/Algebra/Order/Ring/Ordering/Basic.lean
+++ b/Mathlib/Algebra/Order/Ring/Ordering/Basic.lean
@@ -285,8 +285,9 @@ def comap : RingPreordering A where
 @[simp]
 theorem coe_comap : (P.comap f : Set A) = f ⁻¹' P := rfl
 
+variable {f P} in
 @[simp]
-theorem mem_comap (x) : x ∈ P.comap f ↔ f x ∈ P := .rfl
+theorem mem_comap {x} : x ∈ P.comap f ↔ f x ∈ P := .rfl
 
 theorem comap_comap (Q : RingPreordering C) (g : B →+* C) :
     (Q.comap g).comap f = Q.comap (g.comp f) := rfl
@@ -294,7 +295,8 @@ theorem comap_comap (Q : RingPreordering C) (g : B →+* C) :
 instance [HasMemOrNegMem P] : HasMemOrNegMem (P.comap f) where
   mem_or_neg_mem x := by have := mem_or_neg_mem P (f x); aesop
 
-theorem mem_comap_supportAddSubgroup (x) :
+variable {f P} in
+theorem mem_comap_supportAddSubgroup {x} :
     x ∈ (P.comap f).supportAddSubgroup ↔ f x ∈ P.supportAddSubgroup := by
   simp [mem_supportAddSubgroup]
 
@@ -306,9 +308,10 @@ theorem comap_supportAddSubgroup :
 instance [P.HasIdealSupport] : HasIdealSupport (P.comap f) where
   smul_mem_support x a ha := by have := smul_mem_support P (f x) (by simpa using ha); simp_all
 
-theorem mem_comap_support [P.HasIdealSupport] (x) :
+variable {f P} in
+theorem mem_comap_support [P.HasIdealSupport] {x} :
     x ∈ (P.comap f).support ↔ f x ∈ P.support := by
-  simpa using mem_comap_supportAddSubgroup _ P _
+  simpa using mem_comap_supportAddSubgroup (P := P)
 
 @[simp]
 theorem comap_support [P.HasIdealSupport] :
@@ -342,8 +345,9 @@ def map : RingPreordering B where
 @[simp]
 theorem coe_map : (map f P hf hsupp : Set B) = f '' P := rfl
 
+variable {hf hsupp} in
 @[simp]
-theorem mem_map (y) : y ∈ map f P hf hsupp ↔ ∃ x ∈ P, f x = y := .rfl
+theorem mem_map {x} : x ∈ map f P hf hsupp ↔ ∃ y ∈ P, f y = x := .rfl
 
 instance [HasMemOrNegMem P] : HasMemOrNegMem (map f P hf hsupp) where
   mem_or_neg_mem x := by
@@ -351,7 +355,8 @@ instance [HasMemOrNegMem P] : HasMemOrNegMem (map f P hf hsupp) where
     have := mem_or_neg_mem P x'
     aesop
 
-theorem mem_map_supportAddSubgroup (x) :
+variable {hf hsupp} in
+theorem mem_map_supportAddSubgroup {x} :
     x ∈ (map f P hf hsupp).supportAddSubgroup ↔ ∃ y ∈ P.supportAddSubgroup, f y = x := by
   refine ⟨fun ⟨⟨a, ⟨ha₁, ha₂⟩⟩, ⟨b, ⟨hb₁, hb₂⟩⟩⟩ => ?_, by aesop (add simp mem_supportAddSubgroup)⟩
   have : -(a + b) + b ∈ P := by exact add_mem (hsupp (show f (a + b) = 0 by simp_all)).2 hb₁
@@ -370,7 +375,8 @@ instance [P.HasIdealSupport] : HasIdealSupport <| map f P hf hsupp where
     have := smul_mem_support P x' ha'
     aesop
 
-theorem mem_map_support [P.HasIdealSupport] (x) :
+variable {hf hsupp} in
+theorem mem_map_support [P.HasIdealSupport] {x} :
     x ∈ (map f P hf hsupp).support ↔ ∃ y ∈ P.support, f y = x := by
   simpa using mem_map_supportAddSubgroup ..
 

--- a/Mathlib/Algebra/Order/Ring/Ordering/Basic.lean
+++ b/Mathlib/Algebra/Order/Ring/Ordering/Basic.lean
@@ -304,8 +304,22 @@ instance : OrderBot (RingPreordering R) where
 
 end Bot
 
+theorem nonempty_ringPreordering_iff_isSemireal : Nonempty (RingPreordering R) ↔ IsSemireal R where
+  mp h := Nonempty.elim h fun P ↦ by
+    refine ⟨fun {x} hx hx₂ ↦ ?_⟩
+    apply P.neg_one_notMem
+    rw [show -1 = x by linear_combination -hx₂]
+    aesop
+  mpr h := ⟨⊥⟩
+
+theorem isSemireal (P : RingPreordering R) : IsSemireal R :=
+  nonempty_ringPreordering_iff_isSemireal.mp ⟨P⟩
+
 section sSup
 variable {S : Set (RingPreordering R)} (hS : S.Nonempty) (hSd : DirectedOn (· ≤ ·) S)
+
+-- TODO : define under `isSemireal` and add dummy valued when not directed
+--        use class `CompletePartialOrder`
 
 variable (S) in
 /-- The union of a directed set of preorderings is a preordering. -/

--- a/Mathlib/Algebra/Order/Ring/Ordering/Basic.lean
+++ b/Mathlib/Algebra/Order/Ring/Ordering/Basic.lean
@@ -282,7 +282,7 @@ def comap : RingPreordering A where
   __ := P.toSubsemiring.comap f
   mem_of_isSquare' := by aesop
 
-@[simp]
+@[simp, norm_cast]
 theorem coe_comap : (P.comap f : Set A) = f ⁻¹' P := rfl
 
 variable {f P} in
@@ -295,27 +295,21 @@ theorem comap_comap (Q : RingPreordering C) (g : B →+* C) :
 instance [HasMemOrNegMem P] : HasMemOrNegMem (P.comap f) where
   mem_or_neg_mem x := by have := mem_or_neg_mem P (f x); aesop
 
-variable {f P} in
-theorem mem_comap_supportAddSubgroup {x} :
-    x ∈ (P.comap f).supportAddSubgroup ↔ f x ∈ P.supportAddSubgroup := by
-  simp [mem_supportAddSubgroup]
-
 @[simp]
 theorem comap_supportAddSubgroup :
     (P.comap f).supportAddSubgroup = (P.supportAddSubgroup).comap f := by
-  ext; simp [mem_comap_supportAddSubgroup]
+  ext; simp [mem_supportAddSubgroup]
 
 instance [P.HasIdealSupport] : HasIdealSupport (P.comap f) where
   smul_mem_support x a ha := by have := smul_mem_support P (f x) (by simpa using ha); simp_all
 
-variable {f P} in
-theorem mem_comap_support [P.HasIdealSupport] {x} :
-    x ∈ (P.comap f).support ↔ f x ∈ P.support := by
-  simpa using mem_comap_supportAddSubgroup (P := P)
-
 @[simp]
 theorem comap_support [P.HasIdealSupport] :
-    (P.comap f).support = (P.support).comap f := by ext; simp [mem_comap_support]
+    (P.comap f).support = (P.support).comap f := by
+  ext x
+  have := comap_supportAddSubgroup f P
+  apply_fun (x ∈ ·) at this
+  simpa
 
 /-- The preimage of an ordering along a ring homomorphism is an ordering. -/
 instance [P.IsOrdering] : IsOrdering (comap f P) where
@@ -342,7 +336,7 @@ def map : RingPreordering B where
     have : -(x' + 1) + x' ∈ P := add_mem (hsupp (show f (x' + 1) = 0 by simp_all)).2 hx'
     aesop
 
-@[simp]
+@[simp, norm_cast]
 theorem coe_map : (map f P hf hsupp : Set B) = f '' P := rfl
 
 variable {hf hsupp} in
@@ -355,35 +349,29 @@ instance [HasMemOrNegMem P] : HasMemOrNegMem (map f P hf hsupp) where
     have := mem_or_neg_mem P x'
     aesop
 
-variable {hf hsupp} in
-theorem mem_map_supportAddSubgroup {x} :
-    x ∈ (map f P hf hsupp).supportAddSubgroup ↔ ∃ y ∈ P.supportAddSubgroup, f y = x := by
+@[simp]
+theorem map_supportAddSubgroup :
+    (map f P hf hsupp).supportAddSubgroup = (P.supportAddSubgroup).map f := by
+  ext
   refine ⟨fun ⟨⟨a, ⟨ha₁, ha₂⟩⟩, ⟨b, ⟨hb₁, hb₂⟩⟩⟩ => ?_, by aesop (add simp mem_supportAddSubgroup)⟩
   have : -(a + b) + b ∈ P := by exact add_mem (hsupp (show f (a + b) = 0 by simp_all)).2 hb₁
   aesop (add simp mem_supportAddSubgroup)
 
-@[simp]
-theorem map_supportAddSubgroup :
-    (map f P hf hsupp).supportAddSubgroup = (P.supportAddSubgroup).map f := by
-  ext; simp [mem_map_supportAddSubgroup]
-
 instance [P.HasIdealSupport] : HasIdealSupport <| map f P hf hsupp where
   smul_mem_support x a ha := by
-    rw [mem_map_supportAddSubgroup] at ha
+    rw [map_supportAddSubgroup] at ha
     rcases ha with ⟨a', ha', rfl⟩
     rcases hf x with ⟨x', rfl⟩
     have := smul_mem_support P x' ha'
     aesop
 
-variable {hf hsupp} in
-theorem mem_map_support [P.HasIdealSupport] {x} :
-    x ∈ (map f P hf hsupp).support ↔ ∃ y ∈ P.support, f y = x := by
-  simpa using mem_map_supportAddSubgroup ..
-
 @[simp]
 theorem map_support [P.HasIdealSupport] :
     (map f P hf hsupp).support = (P.support).map f := by
-  ext; simp [mem_map_support, Ideal.mem_map_iff_of_surjective f hf]
+  ext x
+  have := map_supportAddSubgroup hf hsupp
+  apply_fun (x ∈ ·) at this
+  simpa [Ideal.mem_map_iff_of_surjective f hf]
 
 /-- The image of an ordering `P` along a surjective ring homomorphism
 with kernel contained in the support of `P` is an ordering. -/

--- a/Mathlib/Algebra/Order/Ring/Ordering/Basic.lean
+++ b/Mathlib/Algebra/Order/Ring/Ordering/Basic.lean
@@ -278,6 +278,7 @@ section comap
 variable (f : A →+* B) (P : RingPreordering B)
 
 /-- The preimage of a preordering along a ring homomorphism is a preordering. -/
+@[simps toSubsemiring]
 def comap : RingPreordering A where
   __ := P.toSubsemiring.comap f
   mem_of_isSquare' := by aesop
@@ -327,6 +328,7 @@ variable {f : A →+* B} {P : RingPreordering A} (hf : Function.Surjective f)
 variable (f P) in
 /-- The image of a preordering `P` along a surjective ring homomorphism
 with kernel contained in the support of `P` is a preordering. -/
+@[simps toSubsemiring]
 def map : RingPreordering B where
   __ := P.toSubsemiring.map f
   mem_of_isSquare' hx := by

--- a/Mathlib/Algebra/Order/Ring/Ordering/Basic.lean
+++ b/Mathlib/Algebra/Order/Ring/Ordering/Basic.lean
@@ -9,7 +9,6 @@ public import Mathlib.Algebra.Order.Ring.Ordering.Defs
 public import Mathlib.Algebra.Ring.Semireal.Defs
 public import Mathlib.RingTheory.Ideal.Maps
 
-import Mathlib.Order.CompletePartialOrder
 import Mathlib.Tactic.FieldSimp
 import Mathlib.Tactic.LinearCombination
 

--- a/Mathlib/Algebra/Order/Ring/Ordering/Basic.lean
+++ b/Mathlib/Algebra/Order/Ring/Ordering/Basic.lean
@@ -7,10 +7,11 @@ module
 
 public import Mathlib.Algebra.Order.Ring.Ordering.Defs
 public import Mathlib.Algebra.Ring.Semireal.Defs
-public import Mathlib.Order.CompletePartialOrder
 public import Mathlib.RingTheory.Ideal.Maps
-public import Mathlib.Tactic.FieldSimp
-public import Mathlib.Tactic.LinearCombination
+
+import Mathlib.Order.CompletePartialOrder
+import Mathlib.Tactic.FieldSimp
+import Mathlib.Tactic.LinearCombination
 
 /-!
 # Ring orderings

--- a/Mathlib/Algebra/Order/Ring/Ordering/Basic.lean
+++ b/Mathlib/Algebra/Order/Ring/Ordering/Basic.lean
@@ -5,9 +5,9 @@ Authors: Florent Schaffhauser, Artie Khovanov
 -/
 module
 
-public import Mathlib.Algebra.Field.IsField
 public import Mathlib.Algebra.Order.Ring.Ordering.Defs
-public import Mathlib.Algebra.Ring.SumsOfSquares
+public import Mathlib.Algebra.Ring.Semireal.Defs
+public import Mathlib.RingTheory.Ideal.Maps
 public import Mathlib.Tactic.FieldSimp
 public import Mathlib.Tactic.LinearCombination
 
@@ -184,4 +184,338 @@ theorem isOrdering_iff :
     have := h x y
     have := h x (-y)
     cases (by aesop : x ∈ P ∨ -x ∈ P) <;> simp_all [mem_support]
+
+/-!
+### Supports
+-/
+
+theorem supportAddSubgroup_mono {Q : RingPreordering R} (h : P ≤ Q) :
+    P.supportAddSubgroup ≤ Q.supportAddSubgroup :=
+  fun _ ↦ by aesop (add simp mem_supportAddSubgroup)
+
+theorem support_mono {Q : RingPreordering R} [P.HasIdealSupport] [Q.HasIdealSupport] (h : P ≤ Q) :
+    P.support ≤ Q.support := fun _ ↦ by aesop (add simp mem_support)
+
+/-! ## Order operations -/
+
+section Inf
+variable {P₁ P₂ : RingPreordering R}
+
+instance : Min (RingPreordering R) where
+  min P₁ P₂ := { toSubsemiring := min P₁.toSubsemiring P₂.toSubsemiring }
+
+@[simp]
+theorem inf_toSubsemiring : (P₁ ⊓ P₂).toSubsemiring = P₁.toSubsemiring ⊓ P₂.toSubsemiring := rfl
+@[simp] theorem mem_inf {x : R} : x ∈ P₁ ⊓ P₂ ↔ x ∈ P₁ ∧ x ∈ P₂ := .rfl
+@[simp, norm_cast] theorem coe_inf : ↑(P₁ ⊓ P₂) = (P₁ ∩ P₂ : Set R) := rfl
+
+@[simp]
+theorem supportAddSubgroup_inf :
+    (P₁ ⊓ P₂).supportAddSubgroup = P₁.supportAddSubgroup ⊓ P₂.supportAddSubgroup := by
+  aesop (add simp mem_supportAddSubgroup)
+
+instance [P₁.HasIdealSupport] [P₂.HasIdealSupport] : (P₁ ⊓ P₂).HasIdealSupport := by
+  simp_all [hasIdealSupport_iff]
+
+@[simp]
+theorem support_inf [P₁.HasIdealSupport] [P₂.HasIdealSupport] :
+    (P₁ ⊓ P₂).support = P₁.support ⊓ P₂.support := by
+  apply_fun Submodule.toAddSubgroup using Submodule.toAddSubgroup_injective
+  simpa [-Submodule.toAddSubgroup_inj] using supportAddSubgroup_inf (P₁ := P₁) (P₂ := P₂)
+
+instance : SemilatticeInf (RingPreordering R) where
+  inf := (· ⊓ ·)
+  inf_le_left _ _ := by simp_all [← SetLike.coe_subset_coe]
+  inf_le_right _ _ := by simp_all [← SetLike.coe_subset_coe]
+  le_inf _ _ _ _ _ := by simp_all [← SetLike.coe_subset_coe]
+
+end Inf
+
+section sInf
+variable {S : Set (RingPreordering R)} {hS : S.Nonempty}
+
+variable (hS) in
+def sInf {S : Set (RingPreordering R)} (hS : S.Nonempty) : RingPreordering R where
+  __ := InfSet.sInf (RingPreordering.toSubsemiring '' S)
+  mem_of_isSquare' x := by aesop (add simp Submonoid.mem_iInf)
+  neg_one_notMem' := by simpa [Submonoid.mem_iInf] using
+    ⟨_, Set.Nonempty.some_mem hS, RingPreordering.neg_one_notMem _⟩
+
+@[simp]
+theorem sInf_toSubsemiring :
+  (sInf hS).toSubsemiring = InfSet.sInf (RingPreordering.toSubsemiring '' S) := rfl
+
+@[simp, norm_cast]
+theorem coe_sInf : (sInf hS : Set R) = ⋂ P ∈ S, P := by
+  have : (sInf hS : Set R) = ⋂ P ∈ (RingPreordering.toSubsemiring '' S), P := rfl
+  simp_all
+
+@[simp]
+theorem mem_sInf {x : R} : x ∈ sInf hS ↔ ∀ p ∈ S, x ∈ p := by
+  rw [show x ∈ sInf hS ↔ x ∈ (sInf hS : Set R) by simp [-coe_sInf]]
+  simp_all
+
+@[simp]
+theorem supportAddSubgroup_sInf :
+    (sInf hS).supportAddSubgroup = InfSet.sInf (supportAddSubgroup '' S) := by
+  aesop (add simp mem_supportAddSubgroup)
+
+theorem hasIdealSupport_sInf (h : ∀ P ∈ S, P.HasIdealSupport) : (sInf hS).HasIdealSupport := by
+  simp_all [hasIdealSupport_iff]
+
+@[simp]
+theorem support_sInf (h : ∀ P ∈ S, P.HasIdealSupport) :
+    letI _ := hasIdealSupport_sInf h
+    (sInf hS).support = InfSet.sInf {s | ∃ P, ∃ hP : P ∈ S, letI _ := h _ hP; s = P.support} := by
+  aesop (add simp mem_support)
+
+variable (hS) in
+theorem sInf_le {P} (hP : P ∈ S) : sInf hS ≤ P := by
+  rw [← SetLike.coe_subset_coe]
+  simpa using Set.biInter_subset_of_mem hP
+
+variable (hS) in
+theorem le_sInf {P} (hP : ∀ Q ∈ S, P ≤ Q) : P ≤ sInf hS := by
+  rw [← SetLike.coe_subset_coe]
+  simpa using Set.subset_iInter₂ hP
+
+end sInf
+
+section Bot
+variable [IsSemireal R]
+
+instance : Bot (RingPreordering R) where
+  bot := { toSubsemiring := Subsemiring.sumSq R
+           neg_one_notMem' := by simpa using IsSemireal.not_isSumSq_neg_one }
+
+@[simp] theorem bot_toSubsemiring : (⊥ : RingPreordering R).toSubsemiring = .sumSq R := rfl
+
+@[simp] theorem mem_bot {a} : a ∈ (⊥ : RingPreordering R) ↔ IsSumSq a :=
+  show a ∈ Subsemiring.sumSq R ↔ IsSumSq a by simp
+
+@[simp, norm_cast] theorem coe_bot : (⊥ : RingPreordering R) = {x : R | IsSumSq x} :=
+  show Subsemiring.sumSq R = {x : R | IsSumSq x} by simp
+
+instance : OrderBot (RingPreordering R) where
+  bot := ⊥
+  bot_le P a := by aesop
+
+end Bot
+
+section sSup
+variable {S : Set (RingPreordering R)} {hS : S.Nonempty} {hSd : DirectedOn (· ≤ ·) S}
+
+variable (hS) (hSd) in
+def sSup : RingPreordering R where
+  __ := SupSet.sSup (toSubsemiring '' S)
+  mem_of_isSquare' x := by
+    have : DirectedOn (· ≤ ·) (toSubsemiring '' S) := directedOn_image.mpr hSd
+    aesop (add simp Subsemiring.mem_sSup_of_directedOn,
+               unsafe forward (Set.Nonempty.some_mem hS))
+  neg_one_notMem' := by
+    have : DirectedOn (· ≤ ·) (toSubsemiring '' S) := directedOn_image.mpr hSd
+    aesop (add simp Subsemiring.mem_sSup_of_directedOn,
+               unsafe forward (Set.Nonempty.some_mem hS))
+
+@[simp]
+theorem sSup_toSubsemiring :
+  (sSup hS hSd).toSubsemiring = SupSet.sSup (RingPreordering.toSubsemiring '' S) := rfl
+
+@[simp, norm_cast]
+theorem coe_sSup : (sSup hS hSd : Set R) = ⋃ P ∈ S, P := by
+  have : (sSup hS hSd : Set R) = SupSet.sSup (toSubsemiring '' S) := rfl
+  simp_all [Subsemiring.coe_sSup_of_directedOn (by aesop) <| directedOn_image.mpr hSd]
+
+@[simp]
+theorem mem_sSup {x : R} : x ∈ sSup hS hSd ↔ ∃ p ∈ S, x ∈ p := by
+  rw [show x ∈ sSup hS hSd ↔ x ∈ (sSup hS hSd : Set R) by simp [-coe_sSup]]
+  simp_all
+
+variable (hS) (hSd) in
+theorem le_sSup {P} (hP : P ∈ S) : P ≤ sSup hS hSd := by
+  rw [← SetLike.coe_subset_coe]
+  simpa using Set.subset_biUnion_of_mem hP
+
+variable (hS) (hSd) in
+theorem sSup_le {P} (hP : ∀ Q ∈ S, Q ≤ P) : sSup hS hSd ≤ P := by
+  rw [← SetLike.coe_subset_coe]
+  simpa using Set.iUnion₂_subset hP
+
+include hSd in
+variable (hSd) in
+theorem directedOn_image_supportAddSubgroup :
+    DirectedOn (fun x1 x2 ↦ x1 ≤ x2) (supportAddSubgroup '' S) := by
+  rw [directedOn_image]
+  intro _ hx _ hy
+  rcases hSd _ hx _ hy with ⟨z, _⟩
+  exact ⟨z, by aesop (add safe apply supportAddSubgroup_mono)⟩
+
+@[simp]
+theorem supportAddSubgroup_sSup :
+    (sSup hS hSd).supportAddSubgroup = SupSet.sSup (supportAddSubgroup '' S) := by
+  ext x
+  rw [AddSubgroup.mem_sSup_of_directedOn (by simp_all) (directedOn_image_supportAddSubgroup hSd)]
+  simp only [mem_supportAddSubgroup, mem_sSup, Set.mem_image, exists_exists_and_eq_and]
+  refine ⟨?_, by aesop⟩
+  rintro ⟨⟨_, hs₁, _⟩, ⟨_, hs₂, _⟩⟩
+  rcases hSd _ hs₁ _ hs₂ with ⟨s, hs⟩
+  exact ⟨s, by aesop⟩
+
+theorem hasIdealSupport_sSup (h : ∀ P ∈ S, P.HasIdealSupport) : (sSup hS hSd).HasIdealSupport := by
+  simp_rw [hasIdealSupport_iff, mem_sSup] at *
+  rintro x a ⟨P, hP, hP'⟩ ⟨Q, hQ, hQ'⟩
+  rcases hSd _ hP _ hQ with ⟨R, hR, hPR, hQR⟩
+  have := h _ hR x a (hPR hP') (hQR hQ')
+  aesop
+
+@[simp]
+theorem support_sSup (h : ∀ P ∈ S, P.HasIdealSupport) :
+    letI _ : (sSup hS hSd).HasIdealSupport := hasIdealSupport_sSup h
+    (sSup hS hSd).support =
+    SupSet.sSup {s | ∃ P, ∃ hP : P ∈ S, letI _ := h _ hP; s = P.support} := by
+  generalize_proofs
+  ext x
+  have : x ∈ (sSup hS hSd).support ↔ x ∈ SupSet.sSup (supportAddSubgroup '' S) := by
+    simp [← supportAddSubgroup_sSup (hS := hS) (hSd := hSd)]
+  rw [this,
+      AddSubgroup.mem_sSup_of_directedOn (by simp_all) (directedOn_image_supportAddSubgroup hSd),
+      Submodule.mem_sSup_of_directed]
+  · aesop
+  · rcases hS with ⟨P, hP⟩
+    exact ⟨let _ := h P hP; P.support, by aesop⟩
+  · rintro _ ⟨x, hx, rfl⟩ _ ⟨y, hy, rfl⟩
+    rcases hSd _ hx _ hy with ⟨z, hz, _, _⟩
+    let _ := h _ hx
+    let _ := h _ hy
+    let _ := h _ hz
+    exact ⟨z.support, by aesop (add safe apply support_mono)⟩
+
+end sSup
+
+theorem nonempty_chain_bddAbove {S : Set (RingPreordering R)}
+    (hS : S.Nonempty) (hSc : IsChain (· ≤ ·) S) : BddAbove S :=
+  ⟨sSup hS <| IsChain.directedOn hSc, fun _ => le_sSup hS <| IsChain.directedOn hSc⟩
+
+variable {A B C : Type*} [CommRing A] [CommRing B] [CommRing C]
+
+/-! ## comap -/
+
+/-- The preimage of a preordering along a ring homomorphism is a preordering. -/
+def comap (f : A →+* B) (P : RingPreordering B) : RingPreordering A where
+  __ := P.toSubsemiring.comap f
+  mem_of_isSquare' := by aesop
+
+@[simp]
+theorem coe_comap (P : RingPreordering B) {f : A →+* B} : (P.comap f : Set A) = f ⁻¹' P := rfl
+
+@[simp]
+theorem mem_comap {P : RingPreordering B} {f : A →+* B} {x : A} : x ∈ P.comap f ↔ f x ∈ P :=
+  .rfl
+
+theorem comap_comap (P : RingPreordering C) (g : B →+* C) (f : A →+* B) :
+    (P.comap g).comap f = P.comap (g.comp f) := rfl
+
+instance (P : RingPreordering B) [HasMemOrNegMem P] (f : A →+* B) : HasMemOrNegMem (comap f P) where
+  mem_or_neg_mem x := by have := mem_or_neg_mem P (f x); aesop
+
+@[simp]
+theorem mem_comap_supportAddSubgroup {P : RingPreordering B} {f : A →+* B} {x : A} :
+    x ∈ supportAddSubgroup (P.comap f) ↔ f x ∈ P.supportAddSubgroup := by
+  simp [mem_supportAddSubgroup]
+
+@[simp]
+theorem comap_supportAddSubgroup {P : RingPreordering B} {f : A →+* B} :
+    supportAddSubgroup (P.comap f) = (P.supportAddSubgroup).comap f := by ext; simp
+
+instance (P : RingPreordering B) [P.HasIdealSupport] (f : A →+* B) :
+    HasIdealSupport (P.comap f) where
+  smul_mem_support x a ha := by have := smul_mem_support P (f x) (by simpa using ha); simp_all
+
+@[simp]
+theorem mem_comap_support {P : RingPreordering B} [P.HasIdealSupport] {f : A →+* B} {x : A} :
+    x ∈ (P.comap f).support ↔ f x ∈ P.support := by
+  simpa using mem_comap_supportAddSubgroup (P := P)
+
+@[simp]
+theorem comap_support {P : RingPreordering B} [P.HasIdealSupport] {f : A →+* B} :
+    (P.comap f).support = (P.support).comap f := by ext; simp
+
+/-- The preimage of an ordering along a ring homomorphism is an ordering. -/
+instance (P : RingPreordering B) [P.IsOrdering] (f : A →+* B) : IsOrdering (comap f P) where
+  __ : (P.comap f).support.IsPrime := by rw [comap_support]; infer_instance
+
+/-! ## map -/
+
+/-- The image of a preordering `P` along a surjective ring homomorphism
+  with kernel contained in the support of `P` is a preordering. -/
+def map {f : A →+* B} {P : RingPreordering A} (hf : Function.Surjective f)
+    (hsupp : (RingHom.ker f : Set A) ⊆ P.supportAddSubgroup) : RingPreordering B where
+  __ := P.toSubsemiring.map f
+  mem_of_isSquare' hx := by
+    rcases isSquare_subset_image_isSquare hf hx with ⟨x, hx, hfx⟩
+    exact ⟨x, by aesop⟩
+  neg_one_notMem' := fun ⟨x', hx', _⟩ => by
+    have : -(x' + 1) + x' ∈ P := add_mem (hsupp (show f (x' + 1) = 0 by simp_all)).2 hx'
+    aesop
+
+@[simp]
+theorem coe_map {f : A →+* B} {P : RingPreordering A} (hf : Function.Surjective f)
+    (hsupp : (RingHom.ker f : Set A) ⊆ P.supportAddSubgroup) :
+    (map hf hsupp : Set B) = f '' P := rfl
+
+@[simp]
+theorem mem_map {f : A →+* B} {P : RingPreordering A} (hf : Function.Surjective f)
+    (hsupp : (RingHom.ker f : Set A) ⊆ P.supportAddSubgroup) {y} :
+    y ∈ map hf hsupp ↔ ∃ x ∈ P, f x = y := .rfl
+
+instance {f : A →+* B} {P : RingPreordering A} [HasMemOrNegMem P] (hf : Function.Surjective f)
+    (hsupp : (RingHom.ker f : Set A) ⊆ P.supportAddSubgroup) : HasMemOrNegMem (map hf hsupp) where
+  mem_or_neg_mem x := by
+    obtain ⟨x', rfl⟩ := hf x
+    have := mem_or_neg_mem P x'
+    aesop
+
+@[simp]
+theorem mem_map_supportAddSubgroup {f : A →+* B} {P : RingPreordering A}
+    {hf : Function.Surjective f} {hsupp : (RingHom.ker f : Set A) ⊆ P.supportAddSubgroup} {x : B} :
+    x ∈ supportAddSubgroup (map hf hsupp) ↔ ∃ y ∈ P.supportAddSubgroup, f y = x := by
+  refine ⟨fun ⟨⟨a, ⟨ha₁, ha₂⟩⟩, ⟨b, ⟨hb₁, hb₂⟩⟩⟩ => ?_, by aesop (add simp mem_supportAddSubgroup)⟩
+  have : -(a + b) + b ∈ P := by exact add_mem (hsupp (show f (a + b) = 0 by simp_all)).2 hb₁
+  aesop (add simp mem_supportAddSubgroup)
+
+@[simp]
+theorem map_supportAddSubgroup {f : A →+* B} {P : RingPreordering A} {hf : Function.Surjective f}
+    {hsupp : (RingHom.ker f : Set A) ⊆ P.supportAddSubgroup} :
+    supportAddSubgroup (map hf hsupp) = (P.supportAddSubgroup).map f := by ext; simp
+
+instance {f : A →+* B} {P : RingPreordering A} [P.HasIdealSupport] (hf : Function.Surjective f)
+    (hsupp : (RingHom.ker f : Set A) ⊆ P.supportAddSubgroup) :
+    HasIdealSupport <| map hf hsupp where
+  smul_mem_support x a ha := by
+    rw [mem_map_supportAddSubgroup] at ha
+    rcases ha with ⟨a', ha', rfl⟩
+    rcases hf x with ⟨x', rfl⟩
+    have := smul_mem_support P x' ha'
+    aesop
+
+@[simp]
+theorem mem_map_support {f : A →+* B} {P : RingPreordering A} [P.HasIdealSupport]
+    {hf : Function.Surjective f}
+    {hsupp : RingHom.ker f ≤ P.support} {x : B} :
+    x ∈ (map hf hsupp).support ↔ ∃ y ∈ P.support, f y = x := by
+  simpa using mem_map_supportAddSubgroup
+
+@[simp]
+theorem map_support {f : A →+* B} {P : RingPreordering A} [P.HasIdealSupport]
+    {hf : Function.Surjective f} {hsupp : RingHom.ker f ≤ P.support} :
+    (map hf hsupp).support = (P.support).map f := by
+  ext; simp [Ideal.mem_map_iff_of_surjective f hf]
+
+/-- The image of an ordering `P` along a surjective ring homomorphism
+  with kernel contained in the support of `P` is an ordering. -/
+instance {f : A →+* B} {P : RingPreordering A} [P.IsOrdering] (hf : Function.Surjective f)
+    (hsupp : RingHom.ker f ≤ P.support) : IsOrdering <| map hf hsupp where
+  __ : (map hf hsupp).support.IsPrime := by
+    simpa using Ideal.map_isPrime_of_surjective hf hsupp
+
 end RingPreordering

--- a/Mathlib/Algebra/Order/Ring/Ordering/Basic.lean
+++ b/Mathlib/Algebra/Order/Ring/Ordering/Basic.lean
@@ -199,14 +199,14 @@ theorem support_mono {Q : RingPreordering R} [P.HasIdealSupport] [Q.HasIdealSupp
 /-! ## Order operations -/
 
 section Inf
-variable {P₁ P₂ : RingPreordering R}
+variable (P₁ P₂ : RingPreordering R)
 
 instance : Min (RingPreordering R) where
   min P₁ P₂ := { toSubsemiring := min P₁.toSubsemiring P₂.toSubsemiring }
 
 @[simp]
 theorem toSubsemiring_inf : (P₁ ⊓ P₂).toSubsemiring = P₁.toSubsemiring ⊓ P₂.toSubsemiring := rfl
-@[simp] theorem mem_inf {x : R} : x ∈ P₁ ⊓ P₂ ↔ x ∈ P₁ ∧ x ∈ P₂ := .rfl
+@[simp] theorem mem_inf (x : R) : x ∈ P₁ ⊓ P₂ ↔ x ∈ P₁ ∧ x ∈ P₂ := .rfl
 @[simp, norm_cast] theorem coe_inf : ↑(P₁ ⊓ P₂) = (P₁ ∩ P₂ : Set R) := rfl
 
 @[simp]
@@ -232,9 +232,9 @@ instance : SemilatticeInf (RingPreordering R) where
 end Inf
 
 section sInf
-variable {S : Set (RingPreordering R)} {hS : S.Nonempty}
+variable {S : Set (RingPreordering R)} (hS : S.Nonempty)
 
-variable (S hS) in
+variable (S) in
 /-- The intersection of a nonempty set of preorderings is a ring preordering. -/
 def sInf : RingPreordering R where
   __ := InfSet.sInf (RingPreordering.toSubsemiring '' S)
@@ -252,7 +252,7 @@ theorem coe_sInf : (sInf S hS : Set R) = ⋂ P ∈ S, P := by
   simp_all
 
 @[simp]
-theorem mem_sInf {x : R} : x ∈ sInf S hS ↔ ∀ p ∈ S, x ∈ p := by
+theorem mem_sInf (x : R) : x ∈ sInf S hS ↔ ∀ p ∈ S, x ∈ p := by
   rw [show x ∈ sInf S hS ↔ x ∈ (sInf S hS : Set R) by simp [-coe_sInf]]
   simp_all
 
@@ -267,17 +267,15 @@ protected theorem HasIdealSupport.sInf (h : ∀ P ∈ S, P.HasIdealSupport) :
 
 @[simp]
 theorem support_sInf (h : ∀ P ∈ S, P.HasIdealSupport) :
-    letI _ := HasIdealSupport.sInf h
+    letI _ := HasIdealSupport.sInf hS h
     (sInf S hS).support =
     InfSet.sInf {s | ∃ P, ∃ hP : P ∈ S, letI _ := h _ hP; s = P.support} := by
   aesop (add simp mem_support)
 
-variable (hS) in
 theorem sInf_le {P} (hP : P ∈ S) : sInf S hS ≤ P := by
   rw [← SetLike.coe_subset_coe]
   simpa using Set.biInter_subset_of_mem hP
 
-variable (hS) in
 theorem le_sInf {P} (hP : ∀ Q ∈ S, P ≤ Q) : P ≤ sInf S hS := by
   rw [← SetLike.coe_subset_coe]
   simpa using Set.subset_iInter₂ hP
@@ -293,7 +291,7 @@ instance : Bot (RingPreordering R) where
 
 @[simp] theorem bot_toSubsemiring : (⊥ : RingPreordering R).toSubsemiring = .sumSq R := rfl
 
-@[simp] theorem mem_bot {a} : a ∈ (⊥ : RingPreordering R) ↔ IsSumSq a :=
+@[simp] theorem mem_bot (a) : a ∈ (⊥ : RingPreordering R) ↔ IsSumSq a :=
   show a ∈ Subsemiring.sumSq R ↔ IsSumSq a by simp
 
 @[simp, norm_cast] theorem coe_bot : (⊥ : RingPreordering R) = {x : R | IsSumSq x} :=
@@ -305,9 +303,9 @@ instance : OrderBot (RingPreordering R) where
 end Bot
 
 section sSup
-variable {S : Set (RingPreordering R)} {hS : S.Nonempty} {hSd : DirectedOn (· ≤ ·) S}
+variable {S : Set (RingPreordering R)} (hS : S.Nonempty) (hSd : DirectedOn (· ≤ ·) S)
 
-variable (S hS hSd) in
+variable (S) in
 /-- The union of a directed set of preorderings is a preordering. -/
 def sSup : RingPreordering R where
   __ := SupSet.sSup (toSubsemiring '' S)
@@ -334,18 +332,15 @@ theorem mem_sSup {x : R} : x ∈ sSup S hS hSd ↔ ∃ p ∈ S, x ∈ p := by
   rw [show x ∈ sSup S hS hSd ↔ x ∈ (sSup S hS hSd : Set R) by simp [-coe_sSup]]
   simp_all
 
-variable (hS) (hSd) in
 theorem le_sSup {P} (hP : P ∈ S) : P ≤ sSup S hS hSd := by
   rw [← SetLike.coe_subset_coe]
   simpa using Set.subset_biUnion_of_mem hP
 
-variable (hS) (hSd) in
 theorem sSup_le {P} (hP : ∀ Q ∈ S, Q ≤ P) : sSup S hS hSd ≤ P := by
   rw [← SetLike.coe_subset_coe]
   simpa using Set.iUnion₂_subset hP
 
 include hSd in
-variable (hSd) in
 theorem directedOn_image_supportAddSubgroup :
     DirectedOn (fun x1 x2 ↦ x1 ≤ x2) (supportAddSubgroup '' S) := by
   rw [directedOn_image]
@@ -374,7 +369,7 @@ protected theorem HasIdealSupport.sSup (h : ∀ P ∈ S, P.HasIdealSupport) :
 
 @[simp]
 theorem support_sSup (h : ∀ P ∈ S, P.HasIdealSupport) :
-    letI _ : (sSup S hS hSd).HasIdealSupport := HasIdealSupport.sSup h
+    letI _ := HasIdealSupport.sSup hS hSd h
     (sSup S hS hSd).support =
     SupSet.sSup {s | ∃ P, ∃ hP : P ∈ S, letI _ := h _ hP; s = P.support} := by
   generalize_proofs
@@ -404,55 +399,64 @@ variable {A B C : Type*} [CommRing A] [CommRing B] [CommRing C]
 
 /-! ## comap -/
 
+section comap
+
+variable (f : A →+* B) (P : RingPreordering B)
+
 /-- The preimage of a preordering along a ring homomorphism is a preordering. -/
-def comap (f : A →+* B) (P : RingPreordering B) : RingPreordering A where
+def comap : RingPreordering A where
   __ := P.toSubsemiring.comap f
   mem_of_isSquare' := by aesop
 
 @[simp]
-theorem coe_comap (P : RingPreordering B) {f : A →+* B} : (P.comap f : Set A) = f ⁻¹' P := rfl
+theorem coe_comap : (P.comap f : Set A) = f ⁻¹' P := rfl
 
 @[simp]
-theorem mem_comap {P : RingPreordering B} {f : A →+* B} {x : A} : x ∈ P.comap f ↔ f x ∈ P :=
-  .rfl
+theorem mem_comap (x) : x ∈ P.comap f ↔ f x ∈ P := .rfl
 
-theorem comap_comap (P : RingPreordering C) (g : B →+* C) (f : A →+* B) :
-    (P.comap g).comap f = P.comap (g.comp f) := rfl
+theorem comap_comap (Q : RingPreordering C) (g : B →+* C) :
+    (Q.comap g).comap f = Q.comap (g.comp f) := rfl
 
-instance (P : RingPreordering B) [HasMemOrNegMem P] (f : A →+* B) : HasMemOrNegMem (comap f P) where
+instance [HasMemOrNegMem P] : HasMemOrNegMem (P.comap f) where
   mem_or_neg_mem x := by have := mem_or_neg_mem P (f x); aesop
 
-theorem mem_comap_supportAddSubgroup {P : RingPreordering B} {f : A →+* B} {x : A} :
-    x ∈ supportAddSubgroup (P.comap f) ↔ f x ∈ P.supportAddSubgroup := by
+theorem mem_comap_supportAddSubgroup (x) :
+    x ∈ (P.comap f).supportAddSubgroup ↔ f x ∈ P.supportAddSubgroup := by
   simp [mem_supportAddSubgroup]
 
 @[simp]
-theorem comap_supportAddSubgroup {P : RingPreordering B} {f : A →+* B} :
-    supportAddSubgroup (P.comap f) = (P.supportAddSubgroup).comap f := by
+theorem comap_supportAddSubgroup :
+    (P.comap f).supportAddSubgroup = (P.supportAddSubgroup).comap f := by
   ext; simp [mem_comap_supportAddSubgroup]
 
-instance (P : RingPreordering B) [P.HasIdealSupport] (f : A →+* B) :
-    HasIdealSupport (P.comap f) where
+instance [P.HasIdealSupport] : HasIdealSupport (P.comap f) where
   smul_mem_support x a ha := by have := smul_mem_support P (f x) (by simpa using ha); simp_all
 
-theorem mem_comap_support {P : RingPreordering B} [P.HasIdealSupport] {f : A →+* B} {x : A} :
+theorem mem_comap_support [P.HasIdealSupport] (x) :
     x ∈ (P.comap f).support ↔ f x ∈ P.support := by
-  simpa using mem_comap_supportAddSubgroup (P := P)
+  simpa using mem_comap_supportAddSubgroup _ P _
 
 @[simp]
-theorem comap_support {P : RingPreordering B} [P.HasIdealSupport] {f : A →+* B} :
+theorem comap_support [P.HasIdealSupport] :
     (P.comap f).support = (P.support).comap f := by ext; simp [mem_comap_support]
 
 /-- The preimage of an ordering along a ring homomorphism is an ordering. -/
-instance (P : RingPreordering B) [P.IsOrdering] (f : A →+* B) : IsOrdering (comap f P) where
+instance [P.IsOrdering] : IsOrdering (comap f P) where
   __ : (P.comap f).support.IsPrime := by rw [comap_support]; infer_instance
+
+end comap
 
 /-! ## map -/
 
+section map
+
+variable {f : A →+* B} {P : RingPreordering A} (hf : Function.Surjective f)
+    (hsupp : (RingHom.ker f : Set A) ⊆ P.supportAddSubgroup)
+
+variable (f P) in
 /-- The image of a preordering `P` along a surjective ring homomorphism
 with kernel contained in the support of `P` is a preordering. -/
-def map {f : A →+* B} {P : RingPreordering A} (hf : Function.Surjective f)
-    (hsupp : (RingHom.ker f : Set A) ⊆ P.supportAddSubgroup) : RingPreordering B where
+def map : RingPreordering B where
   __ := P.toSubsemiring.map f
   mem_of_isSquare' hx := by
     rcases isSquare_subset_image_isSquare hf hx with ⟨x, hx, hfx⟩
@@ -462,38 +466,29 @@ def map {f : A →+* B} {P : RingPreordering A} (hf : Function.Surjective f)
     aesop
 
 @[simp]
-theorem coe_map {f : A →+* B} {P : RingPreordering A} (hf : Function.Surjective f)
-    (hsupp : (RingHom.ker f : Set A) ⊆ P.supportAddSubgroup) :
-    (map hf hsupp : Set B) = f '' P := rfl
+theorem coe_map : (map f P hf hsupp : Set B) = f '' P := rfl
 
 @[simp]
-theorem mem_map {f : A →+* B} {P : RingPreordering A} (hf : Function.Surjective f)
-    (hsupp : (RingHom.ker f : Set A) ⊆ P.supportAddSubgroup) {y} :
-    y ∈ map hf hsupp ↔ ∃ x ∈ P, f x = y := .rfl
+theorem mem_map (y) : y ∈ map f P hf hsupp ↔ ∃ x ∈ P, f x = y := .rfl
 
-instance {f : A →+* B} {P : RingPreordering A} [HasMemOrNegMem P] (hf : Function.Surjective f)
-    (hsupp : (RingHom.ker f : Set A) ⊆ P.supportAddSubgroup) : HasMemOrNegMem (map hf hsupp) where
+instance [HasMemOrNegMem P] : HasMemOrNegMem (map f P hf hsupp) where
   mem_or_neg_mem x := by
     obtain ⟨x', rfl⟩ := hf x
     have := mem_or_neg_mem P x'
     aesop
 
-theorem mem_map_supportAddSubgroup {f : A →+* B} {P : RingPreordering A}
-    {hf : Function.Surjective f} {hsupp : (RingHom.ker f : Set A) ⊆ P.supportAddSubgroup} {x : B} :
-    x ∈ supportAddSubgroup (map hf hsupp) ↔ ∃ y ∈ P.supportAddSubgroup, f y = x := by
+theorem mem_map_supportAddSubgroup (x) :
+    x ∈ (map f P hf hsupp).supportAddSubgroup ↔ ∃ y ∈ P.supportAddSubgroup, f y = x := by
   refine ⟨fun ⟨⟨a, ⟨ha₁, ha₂⟩⟩, ⟨b, ⟨hb₁, hb₂⟩⟩⟩ => ?_, by aesop (add simp mem_supportAddSubgroup)⟩
   have : -(a + b) + b ∈ P := by exact add_mem (hsupp (show f (a + b) = 0 by simp_all)).2 hb₁
   aesop (add simp mem_supportAddSubgroup)
 
 @[simp]
-theorem map_supportAddSubgroup {f : A →+* B} {P : RingPreordering A} {hf : Function.Surjective f}
-    {hsupp : (RingHom.ker f : Set A) ⊆ P.supportAddSubgroup} :
-    supportAddSubgroup (map hf hsupp) = (P.supportAddSubgroup).map f := by
+theorem map_supportAddSubgroup :
+    (map f P hf hsupp).supportAddSubgroup = (P.supportAddSubgroup).map f := by
   ext; simp [mem_map_supportAddSubgroup]
 
-instance {f : A →+* B} {P : RingPreordering A} [P.HasIdealSupport] (hf : Function.Surjective f)
-    (hsupp : (RingHom.ker f : Set A) ⊆ P.supportAddSubgroup) :
-    HasIdealSupport <| map hf hsupp where
+instance [P.HasIdealSupport] : HasIdealSupport <| map f P hf hsupp where
   smul_mem_support x a ha := by
     rw [mem_map_supportAddSubgroup] at ha
     rcases ha with ⟨a', ha', rfl⟩
@@ -501,23 +496,21 @@ instance {f : A →+* B} {P : RingPreordering A} [P.HasIdealSupport] (hf : Funct
     have := smul_mem_support P x' ha'
     aesop
 
-theorem mem_map_support {f : A →+* B} {P : RingPreordering A} [P.HasIdealSupport]
-    {hf : Function.Surjective f}
-    {hsupp : RingHom.ker f ≤ P.support} {x : B} :
-    x ∈ (map hf hsupp).support ↔ ∃ y ∈ P.support, f y = x := by
-  simpa using mem_map_supportAddSubgroup
+theorem mem_map_support [P.HasIdealSupport] (x) :
+    x ∈ (map f P hf hsupp).support ↔ ∃ y ∈ P.support, f y = x := by
+  simpa using mem_map_supportAddSubgroup ..
 
 @[simp]
-theorem map_support {f : A →+* B} {P : RingPreordering A} [P.HasIdealSupport]
-    {hf : Function.Surjective f} {hsupp : RingHom.ker f ≤ P.support} :
-    (map hf hsupp).support = (P.support).map f := by
+theorem map_support [P.HasIdealSupport] :
+    (map f P hf hsupp).support = (P.support).map f := by
   ext; simp [mem_map_support, Ideal.mem_map_iff_of_surjective f hf]
 
 /-- The image of an ordering `P` along a surjective ring homomorphism
 with kernel contained in the support of `P` is an ordering. -/
-instance {f : A →+* B} {P : RingPreordering A} [P.IsOrdering] (hf : Function.Surjective f)
-    (hsupp : RingHom.ker f ≤ P.support) : IsOrdering <| map hf hsupp where
-  __ : (map hf hsupp).support.IsPrime := by
+instance [P.IsOrdering] : IsOrdering <| map f P hf hsupp where
+  __ : (map f P hf hsupp).support.IsPrime := by
     simpa using Ideal.map_isPrime_of_surjective hf hsupp
+
+end map
 
 end RingPreordering

--- a/Mathlib/Algebra/Order/Ring/Ordering/Basic.lean
+++ b/Mathlib/Algebra/Order/Ring/Ordering/Basic.lean
@@ -418,27 +418,26 @@ theorem comap_comap (P : RingPreordering C) (g : B →+* C) (f : A →+* B) :
 instance (P : RingPreordering B) [HasMemOrNegMem P] (f : A →+* B) : HasMemOrNegMem (comap f P) where
   mem_or_neg_mem x := by have := mem_or_neg_mem P (f x); aesop
 
-@[simp]
 theorem mem_comap_supportAddSubgroup {P : RingPreordering B} {f : A →+* B} {x : A} :
     x ∈ supportAddSubgroup (P.comap f) ↔ f x ∈ P.supportAddSubgroup := by
   simp [mem_supportAddSubgroup]
 
 @[simp]
 theorem comap_supportAddSubgroup {P : RingPreordering B} {f : A →+* B} :
-    supportAddSubgroup (P.comap f) = (P.supportAddSubgroup).comap f := by ext; simp
+    supportAddSubgroup (P.comap f) = (P.supportAddSubgroup).comap f := by
+  ext; simp [mem_comap_supportAddSubgroup]
 
 instance (P : RingPreordering B) [P.HasIdealSupport] (f : A →+* B) :
     HasIdealSupport (P.comap f) where
   smul_mem_support x a ha := by have := smul_mem_support P (f x) (by simpa using ha); simp_all
 
-@[simp]
 theorem mem_comap_support {P : RingPreordering B} [P.HasIdealSupport] {f : A →+* B} {x : A} :
     x ∈ (P.comap f).support ↔ f x ∈ P.support := by
   simpa using mem_comap_supportAddSubgroup (P := P)
 
 @[simp]
 theorem comap_support {P : RingPreordering B} [P.HasIdealSupport] {f : A →+* B} :
-    (P.comap f).support = (P.support).comap f := by ext; simp
+    (P.comap f).support = (P.support).comap f := by ext; simp [mem_comap_support]
 
 /-- The preimage of an ordering along a ring homomorphism is an ordering. -/
 instance (P : RingPreordering B) [P.IsOrdering] (f : A →+* B) : IsOrdering (comap f P) where
@@ -475,7 +474,6 @@ instance {f : A →+* B} {P : RingPreordering A} [HasMemOrNegMem P] (hf : Functi
     have := mem_or_neg_mem P x'
     aesop
 
-@[simp]
 theorem mem_map_supportAddSubgroup {f : A →+* B} {P : RingPreordering A}
     {hf : Function.Surjective f} {hsupp : (RingHom.ker f : Set A) ⊆ P.supportAddSubgroup} {x : B} :
     x ∈ supportAddSubgroup (map hf hsupp) ↔ ∃ y ∈ P.supportAddSubgroup, f y = x := by
@@ -486,7 +484,8 @@ theorem mem_map_supportAddSubgroup {f : A →+* B} {P : RingPreordering A}
 @[simp]
 theorem map_supportAddSubgroup {f : A →+* B} {P : RingPreordering A} {hf : Function.Surjective f}
     {hsupp : (RingHom.ker f : Set A) ⊆ P.supportAddSubgroup} :
-    supportAddSubgroup (map hf hsupp) = (P.supportAddSubgroup).map f := by ext; simp
+    supportAddSubgroup (map hf hsupp) = (P.supportAddSubgroup).map f := by
+  ext; simp [mem_map_supportAddSubgroup]
 
 instance {f : A →+* B} {P : RingPreordering A} [P.HasIdealSupport] (hf : Function.Surjective f)
     (hsupp : (RingHom.ker f : Set A) ⊆ P.supportAddSubgroup) :
@@ -498,7 +497,6 @@ instance {f : A →+* B} {P : RingPreordering A} [P.HasIdealSupport] (hf : Funct
     have := smul_mem_support P x' ha'
     aesop
 
-@[simp]
 theorem mem_map_support {f : A →+* B} {P : RingPreordering A} [P.HasIdealSupport]
     {hf : Function.Surjective f}
     {hsupp : RingHom.ker f ≤ P.support} {x : B} :
@@ -509,7 +507,7 @@ theorem mem_map_support {f : A →+* B} {P : RingPreordering A} [P.HasIdealSuppo
 theorem map_support {f : A →+* B} {P : RingPreordering A} [P.HasIdealSupport]
     {hf : Function.Surjective f} {hsupp : RingHom.ker f ≤ P.support} :
     (map hf hsupp).support = (P.support).map f := by
-  ext; simp [Ideal.mem_map_iff_of_surjective f hf]
+  ext; simp [mem_map_support, Ideal.mem_map_iff_of_surjective f hf]
 
 /-- The image of an ordering `P` along a surjective ring homomorphism
   with kernel contained in the support of `P` is an ordering. -/

--- a/Mathlib/Algebra/Order/Ring/Ordering/Basic.lean
+++ b/Mathlib/Algebra/Order/Ring/Ordering/Basic.lean
@@ -235,6 +235,7 @@ section sInf
 variable {S : Set (RingPreordering R)} {hS : S.Nonempty}
 
 variable (hS) in
+/-- The intersection of a nonempty set of preorderings is a ring preordering. -/
 def sInf {S : Set (RingPreordering R)} (hS : S.Nonempty) : RingPreordering R where
   __ := InfSet.sInf (RingPreordering.toSubsemiring '' S)
   mem_of_isSquare' x := by aesop (add simp Submonoid.mem_iInf)
@@ -306,6 +307,7 @@ section sSup
 variable {S : Set (RingPreordering R)} {hS : S.Nonempty} {hSd : DirectedOn (· ≤ ·) S}
 
 variable (hS) (hSd) in
+/-- The union of a directed set of preorderings is a preordering. -/
 def sSup : RingPreordering R where
   __ := SupSet.sSup (toSubsemiring '' S)
   mem_of_isSquare' x := by

--- a/Mathlib/Algebra/Ring/Semireal/Defs.lean
+++ b/Mathlib/Algebra/Ring/Semireal/Defs.lean
@@ -43,6 +43,13 @@ class IsSemireal [Add R] [Mul R] [One R] [Zero R] : Prop where
 theorem IsSemireal.not_isSumSq_neg_one [AddGroup R] [One R] [Mul R] [IsSemireal R] :
     ¬ IsSumSq (-1 : R) := (by simpa using one_add_ne_zero ·)
 
+theorem isSemireal_iff_not_isSumSq_neg_one [AddGroup R] [One R] [Mul R] :
+    IsSemireal R ↔ ¬ IsSumSq (-1 : R) where
+  mp _ := IsSemireal.not_isSumSq_neg_one
+  mpr h := ⟨by aesop (add simp add_eq_zero_iff_neg_eq)⟩
+
+alias ⟨_, IsSemireal.of_not_isSumSq_neg_one⟩ := isSemireal_iff_not_isSumSq_neg_one
+
 /--
 Linearly ordered semirings with the property `a ≤ b → ∃ c, a + c = b` (e.g. `ℕ`)
 are semireal.


### PR DESCRIPTION
* add operations on ring preorderings: intersection, bottom element, map, comap
* prove how being an ordering and the support interact with each of these operations

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

When merging, all the commits will be squashed into a single commit
listing all co-authors.

Co-authors in the squash commit are gathered from two sources:

First, all authors of commits to this PR branch are included. Thus,
one way to add co-authors is to include at least one commit authored by
each co-author among the commits in the pull request. If necessary, you
may create empty commits to indicate co-authorship, using commands like so:

git commit --author="Author Name <author@email.com>" --allow-empty -m "add Author Name as coauthor"

Second, co-authors can also be listed in lines at the very bottom of
the commit message (that is, directly before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines
at the bottom of the commit message (before the `---`, and also before
any "Co-authored-by" lines) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
