### PR TITLE
[Merged by Bors] - chore: permit metadata tags in lake-manifest.json

### DIFF
--- a/.github/build.in.yml
+++ b/.github/build.in.yml
@@ -223,7 +223,7 @@ jobs:
 
           # Extract all inputRevs from the manifest
           invalid_revs=$(jq -r '.packages[].inputRev // empty' lake-manifest.json | \
-            grep -v -E '^(main|master|v[0-9]+\.[0-9]+\.[0-9]+(-[a-zA-Z0-9.-]+)?)$' || true)
+            grep -v -E '^(main|master|v[0-9]+\.[0-9]+\.[0-9]+(-[a-zA-Z0-9.-]+)?(\+[a-zA-Z0-9.-]+)?)$' || true)
 
           if [ -n "$invalid_revs" ]; then
             echo "❌ Error: Found invalid inputRevs in lake-manifest.json:"
@@ -232,7 +232,7 @@ jobs:
             echo "All inputRevs must be one of:"
             echo "  - 'main'"
             echo "  - 'master'"
-            echo "  - 'vX.Y.Z' (semantic version, e.g., v1.2.3 or v1.2.3-pre)"
+            echo "  - 'vX.Y.Z' (semantic version, e.g., v1.2.3, v1.2.3-pre, or v1.2.3+build)"
             exit 1
           else
             echo "✅ All inputRevs in lake-manifest.json are valid"

--- a/.github/workflows/bors.yml
+++ b/.github/workflows/bors.yml
@@ -233,7 +233,7 @@ jobs:
 
           # Extract all inputRevs from the manifest
           invalid_revs=$(jq -r '.packages[].inputRev // empty' lake-manifest.json | \
-            grep -v -E '^(main|master|v[0-9]+\.[0-9]+\.[0-9]+(-[a-zA-Z0-9.-]+)?)$' || true)
+            grep -v -E '^(main|master|v[0-9]+\.[0-9]+\.[0-9]+(-[a-zA-Z0-9.-]+)?(\+[a-zA-Z0-9.-]+)?)$' || true)
 
           if [ -n "$invalid_revs" ]; then
             echo "❌ Error: Found invalid inputRevs in lake-manifest.json:"
@@ -242,7 +242,7 @@ jobs:
             echo "All inputRevs must be one of:"
             echo "  - 'main'"
             echo "  - 'master'"
-            echo "  - 'vX.Y.Z' (semantic version, e.g., v1.2.3 or v1.2.3-pre)"
+            echo "  - 'vX.Y.Z' (semantic version, e.g., v1.2.3, v1.2.3-pre, or v1.2.3+build)"
             exit 1
           else
             echo "✅ All inputRevs in lake-manifest.json are valid"

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -239,7 +239,7 @@ jobs:
 
           # Extract all inputRevs from the manifest
           invalid_revs=$(jq -r '.packages[].inputRev // empty' lake-manifest.json | \
-            grep -v -E '^(main|master|v[0-9]+\.[0-9]+\.[0-9]+(-[a-zA-Z0-9.-]+)?)$' || true)
+            grep -v -E '^(main|master|v[0-9]+\.[0-9]+\.[0-9]+(-[a-zA-Z0-9.-]+)?(\+[a-zA-Z0-9.-]+)?)$' || true)
 
           if [ -n "$invalid_revs" ]; then
             echo "❌ Error: Found invalid inputRevs in lake-manifest.json:"
@@ -248,7 +248,7 @@ jobs:
             echo "All inputRevs must be one of:"
             echo "  - 'main'"
             echo "  - 'master'"
-            echo "  - 'vX.Y.Z' (semantic version, e.g., v1.2.3 or v1.2.3-pre)"
+            echo "  - 'vX.Y.Z' (semantic version, e.g., v1.2.3, v1.2.3-pre, or v1.2.3+build)"
             exit 1
           else
             echo "✅ All inputRevs in lake-manifest.json are valid"

--- a/.github/workflows/build_fork.yml
+++ b/.github/workflows/build_fork.yml
@@ -237,7 +237,7 @@ jobs:
 
           # Extract all inputRevs from the manifest
           invalid_revs=$(jq -r '.packages[].inputRev // empty' lake-manifest.json | \
-            grep -v -E '^(main|master|v[0-9]+\.[0-9]+\.[0-9]+(-[a-zA-Z0-9.-]+)?)$' || true)
+            grep -v -E '^(main|master|v[0-9]+\.[0-9]+\.[0-9]+(-[a-zA-Z0-9.-]+)?(\+[a-zA-Z0-9.-]+)?)$' || true)
 
           if [ -n "$invalid_revs" ]; then
             echo "❌ Error: Found invalid inputRevs in lake-manifest.json:"
@@ -246,7 +246,7 @@ jobs:
             echo "All inputRevs must be one of:"
             echo "  - 'main'"
             echo "  - 'master'"
-            echo "  - 'vX.Y.Z' (semantic version, e.g., v1.2.3 or v1.2.3-pre)"
+            echo "  - 'vX.Y.Z' (semantic version, e.g., v1.2.3, v1.2.3-pre, or v1.2.3+build)"
             exit 1
           else
             echo "✅ All inputRevs in lake-manifest.json are valid"


### PR DESCRIPTION
I needed this in order to make the `v4.25.2` tag of Mathlib, as it needed a special version tag of ProofWidgets now that we demand the toolchains agree between Mathlib and ProofWidgets.

This is not urgent, as I've already made this change on the `release/v4.25` branch, but we should get this on master before someone has to deal with this again.