### PR TITLE
[Merged by Bors] - feat(Topology): prod/sum of UniformContinuous function is UniformContinuous

### DIFF
--- a/Mathlib/Topology/Algebra/IsUniformGroup/Defs.lean
+++ b/Mathlib/Topology/Algebra/IsUniformGroup/Defs.lean
@@ -226,6 +226,17 @@ theorem UniformContinuous.mul [UniformSpace β] {f : β → α} {g : β → α} 
   simp_all
 
 @[to_additive]
+theorem Finset.uniformContinuous_prod {α β ι : Type*} [UniformSpace α] [CommGroup α]
+    [IsUniformGroup α] [UniformSpace β] {f : ι → β → α} (s : Finset ι)
+    (h : ∀ i ∈ s, UniformContinuous (f i)) :
+    UniformContinuous (∏ i ∈ s, f i ·) := by
+  induction s using Finset.cons_induction with
+  | empty => simpa using uniformContinuous_const
+  | cons a s ha ih =>
+    simp_rw [Finset.mem_cons, forall_eq_or_imp] at h
+    simpa [Finset.prod_cons] using h.1.mul (ih h.2)
+
+@[to_additive]
 theorem uniformContinuous_mul : UniformContinuous fun p : α × α => p.1 * p.2 :=
   uniformContinuous_fst.mul uniformContinuous_snd
 


### PR DESCRIPTION
The big operator version of `UniformContinuous.mul`. 
This seems to be the only lemma that requires `[CommGroup α]` over `[Group α]` in the section, so I just declare all type variables ad-hoc to preserve the desired parameter order

<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

When merging, all the commits will be squashed into a single commit
listing all co-authors.

Co-authors in the squash commit are gathered from two sources:

First, all authors of commits to this PR branch are included. Thus,
one way to add co-authors is to include at least one commit authored by
each co-author among the commits in the pull request. If necessary, you
may create empty commits to indicate co-authorship, using commands like so:

git commit --author="Author Name <author@email.com>" --allow-empty -m "add Author Name as coauthor"

Second, co-authors can also be listed in lines at the very bottom of
the commit message (that is, directly before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines
at the bottom of the commit message (before the `---`, and also before
any "Co-authored-by" lines) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
