### PR TITLE
[Merged by Bors] - chore(CategoryTheory): make the construction effective epi -> regular epi use general pullback cones

### DIFF
--- a/Mathlib/CategoryTheory/Limits/Shapes/RegularMono.lean
+++ b/Mathlib/CategoryTheory/Limits/Shapes/RegularMono.lean
@@ -332,6 +332,27 @@ theorem effectiveEpi_of_kernelPair {B X : C} (f : X ⟶ B) [HasPullback f f]
 
 @[deprecated (since := "2025-11-20")] alias effectiveEpiOfKernelPair := effectiveEpi_of_kernelPair
 
+/--
+Given a kernel pair of an effective epimorphism `f : X ⟶ B`, the induced cofork is a coequalizer.
+-/
+def isColimitCoforkOfEffectiveEpi {B X : C} (f : X ⟶ B) [EffectiveEpi f]
+    (c : PullbackCone f f) (hc : IsLimit c) :
+    IsColimit (Cofork.ofπ f c.condition) where
+  desc s := EffectiveEpi.desc f (s.ι.app WalkingParallelPair.one) fun g₁ g₂ hg ↦ (by
+      simp only [Cofork.app_one_eq_π]
+      rw [← PullbackCone.IsLimit.lift_snd hc g₁ g₂ hg, Category.assoc,
+        ← Cofork.app_zero_eq_comp_π_right]
+      simp)
+  fac s := by
+    have := EffectiveEpi.fac f (s.ι.app WalkingParallelPair.one) fun g₁ g₂ hg ↦ (by
+      simp only [Cofork.app_one_eq_π]
+      rw [← PullbackCone.IsLimit.lift_snd hc g₁ g₂ hg,
+        Category.assoc, ← Cofork.app_zero_eq_comp_π_right]
+      simp)
+    rintro (_ | _)
+    all_goals simp_all
+  uniq _ _ h := EffectiveEpi.uniq f _ _ _ (h WalkingParallelPair.one)
+
 /-- An effective epi which has a kernel pair is a regular epi. -/
 noncomputable instance regularEpiOfEffectiveEpi {B X : C} (f : X ⟶ B) [HasPullback f f]
     [EffectiveEpi f] : RegularEpi f where
@@ -339,22 +360,7 @@ noncomputable instance regularEpiOfEffectiveEpi {B X : C} (f : X ⟶ B) [HasPull
   left := pullback.fst f f
   right := pullback.snd f f
   w := pullback.condition
-  isColimit := {
-    desc := fun s ↦ EffectiveEpi.desc f (s.ι.app WalkingParallelPair.one) fun g₁ g₂ hg ↦ (by
-      simp only [Cofork.app_one_eq_π]
-      rw [← pullback.lift_snd g₁ g₂ hg, Category.assoc, ← Cofork.app_zero_eq_comp_π_right]
-      simp)
-    fac := by
-      intro s j
-      have := EffectiveEpi.fac f (s.ι.app WalkingParallelPair.one) fun g₁ g₂ hg ↦ (by
-          simp only [Cofork.app_one_eq_π]
-          rw [← pullback.lift_snd g₁ g₂ hg, Category.assoc, ← Cofork.app_zero_eq_comp_π_right]
-          simp)
-      simp only [Functor.const_obj_obj, Cofork.app_one_eq_π] at this
-      cases j with
-      | zero => simp [this]
-      | one => simp [this]
-    uniq := fun _ _ h ↦ EffectiveEpi.uniq f _ _ _ (h WalkingParallelPair.one) }
+  isColimit := isColimitCoforkOfEffectiveEpi f _ (pullback.isLimit _ _)
 
 /-- Every split epimorphism is a regular epimorphism. -/
 instance (priority := 100) RegularEpi.ofSplitEpi (f : X ⟶ Y) [IsSplitEpi f] : RegularEpi f where


### PR DESCRIPTION



---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

When merging, all the commits will be squashed into a single commit
listing all co-authors.

Co-authors in the squash commit are gathered from two sources:

First, all authors of commits to this PR branch are included. Thus,
one way to add co-authors is to include at least one commit authored by
each co-author among the commits in the pull request. If necessary, you
may create empty commits to indicate co-authorship, using commands like so:

git commit --author="Author Name <author@email.com>" --allow-empty -m "add Author Name as coauthor"

Second, co-authors can also be listed in lines at the very bottom of
the commit message (that is, directly before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines
at the bottom of the commit message (before the `---`, and also before
any "Co-authored-by" lines) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
