### PR TITLE
[Merged by Bors] - chore(Order/ULift): use `@[to_dual]`

### DIFF
--- a/Mathlib/Order/ULift.lean
+++ b/Mathlib/Order/ULift.lean
@@ -26,13 +26,13 @@ variable {α : Type u}
 
 instance [LE α] : LE (ULift.{v} α) where le x y := x.down ≤ y.down
 
-@[simp] theorem up_le [LE α] {a b : α} : up a ≤ up b ↔ a ≤ b := Iff.rfl
-@[simp] theorem down_le [LE α] {a b : ULift α} : down a ≤ down b ↔ a ≤ b := Iff.rfl
+@[simp, to_dual self] theorem up_le [LE α] {a b : α} : up a ≤ up b ↔ a ≤ b := Iff.rfl
+@[simp, to_dual self] theorem down_le [LE α] {a b : ULift α} : down a ≤ down b ↔ a ≤ b := Iff.rfl
 
 instance [LT α] : LT (ULift.{v} α) where lt x y := x.down < y.down
 
-@[simp] theorem up_lt [LT α] {a b : α} : up a < up b ↔ a < b := Iff.rfl
-@[simp] theorem down_lt [LT α] {a b : ULift α} : down a < down b ↔ a < b := Iff.rfl
+@[simp, to_dual self] theorem up_lt [LT α] {a b : α} : up a < up b ↔ a < b := Iff.rfl
+@[simp, to_dual self] theorem down_lt [LT α] {a b : ULift α} : down a < down b ↔ a < b := Iff.rfl
 
 instance [BEq α] : BEq (ULift.{v} α) where beq x y := x.down == y.down
 
@@ -45,15 +45,14 @@ instance [Ord α] : Ord (ULift.{v} α) where compare x y := compare x.down y.dow
 @[simp] theorem down_compare [Ord α] (a b : ULift α) : compare (down a) (down b) = compare a b :=
   rfl
 
+@[to_dual]
 instance [Max α] : Max (ULift.{v} α) where max x y := up <| x.down ⊔ y.down
 
-@[simp] theorem up_sup [Max α] (a b : α) : up (a ⊔ b) = up a ⊔ up b := rfl
-@[simp] theorem down_sup [Max α] (a b : ULift α) : down (a ⊔ b) = down a ⊔ down b := rfl
+@[to_dual (attr := simp)]
+theorem up_sup [Max α] (a b : α) : up (a ⊔ b) = up a ⊔ up b := rfl
 
-instance [Min α] : Min (ULift.{v} α) where min x y := up <| x.down ⊓ y.down
-
-@[simp] theorem up_inf [Min α] (a b : α) : up (a ⊓ b) = up a ⊓ up b := rfl
-@[simp] theorem down_inf [Min α] (a b : ULift α) : down (a ⊓ b) = down a ⊓ down b := rfl
+@[to_dual (attr := simp)]
+theorem down_sup [Max α] (a b : ULift α) : down (a ⊔ b) = down a ⊔ down b := rfl
 
 instance [SDiff α] : SDiff (ULift.{v} α) where sdiff x y := up <| x.down \ y.down
 


### PR DESCRIPTION

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

When merging, all the commits will be squashed into a single commit
listing all co-authors.

Co-authors in the squash commit are gathered from two sources:

First, all authors of commits to this PR branch are included. Thus,
one way to add co-authors is to include at least one commit authored by
each co-author among the commits in the pull request. If necessary, you
may create empty commits to indicate co-authorship, using commands like so:

git commit --author="Author Name <author@email.com>" --allow-empty -m "add Author Name as coauthor"

Second, co-authors can also be listed in lines at the very bottom of
the commit message (that is, directly before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines
at the bottom of the commit message (before the `---`, and also before
any "Co-authored-by" lines) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
