### PR TITLE
[Merged by Bors] - feat(MeasureTheory): subsetness is measurable

### DIFF
--- a/Mathlib/MeasureTheory/MeasurableSpace/Constructions.lean
+++ b/Mathlib/MeasureTheory/MeasurableSpace/Constructions.lean
@@ -919,19 +919,26 @@ lemma measurableSet_notMem (a : α) : MeasurableSet {s : Set α | a ∉ s} :=
 lemma measurable_compl : Measurable ((·ᶜ) : Set α → Set α) :=
   measurable_set_iff.2 fun _ ↦ measurable_set_notMem _
 
-lemma MeasurableSet.setOf_finite [Countable α] : MeasurableSet {s : Set α | s.Finite} :=
+variable [Countable α] {s t : β → Set α}
+
+lemma MeasurableSet.setOf_finite : MeasurableSet {s : Set α | s.Finite} :=
   Countable.setOf_finite.measurableSet
 
-lemma MeasurableSet.setOf_infinite [Countable α] : MeasurableSet {s : Set α | s.Infinite} :=
+lemma MeasurableSet.setOf_infinite : MeasurableSet {s : Set α | s.Infinite} :=
   .setOf_finite |> .compl
 
-lemma MeasurableSet.sep_finite [Countable α] {S : Set (Set α)} (hS : MeasurableSet S) :
+lemma MeasurableSet.sep_finite {S : Set (Set α)} (hS : MeasurableSet S) :
     MeasurableSet {s ∈ S | s.Finite} :=
   hS.inter .setOf_finite
 
-lemma MeasurableSet.sep_infinite [Countable α] {S : Set (Set α)} (hS : MeasurableSet S) :
+lemma MeasurableSet.sep_infinite {S : Set (Set α)} (hS : MeasurableSet S) :
     MeasurableSet {s ∈ S | s.Infinite} :=
   hS.inter .setOf_infinite
+
+@[fun_prop]
+protected lemma Measurable.subset (hs : Measurable s) (hs : Measurable t) :
+    Measurable fun a ↦ s a ⊆ t a :=
+  .forall fun i ↦ .imp (by fun_prop) (by fun_prop)
 
 end Set
 

--- a/Mathlib/MeasureTheory/MeasurableSpace/Constructions.lean
+++ b/Mathlib/MeasureTheory/MeasurableSpace/Constructions.lean
@@ -919,7 +919,7 @@ lemma measurableSet_notMem (a : α) : MeasurableSet {s : Set α | a ∉ s} :=
 lemma measurable_compl : Measurable ((·ᶜ) : Set α → Set α) :=
   measurable_set_iff.2 fun _ ↦ measurable_set_notMem _
 
-variable [Countable α] {s t : β → Set α}
+variable [Countable α]
 
 lemma MeasurableSet.setOf_finite : MeasurableSet {s : Set α | s.Finite} :=
   Countable.setOf_finite.measurableSet
@@ -936,7 +936,7 @@ lemma MeasurableSet.sep_infinite {S : Set (Set α)} (hS : MeasurableSet S) :
   hS.inter .setOf_infinite
 
 @[fun_prop]
-protected lemma Measurable.subset (hs : Measurable s) (hs : Measurable t) :
+protected lemma Measurable.subset {s t : β → Set α} (hs : Measurable s) (hs : Measurable t) :
     Measurable fun a ↦ s a ⊆ t a :=
   .forall fun i ↦ .imp (by fun_prop) (by fun_prop)
 


### PR DESCRIPTION
---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

When merging, all the commits will be squashed into a single commit
listing all co-authors.

Co-authors in the squash commit are gathered from two sources:

First, all authors of commits to this PR branch are included. Thus,
one way to add co-authors is to include at least one commit authored by
each co-author among the commits in the pull request. If necessary, you
may create empty commits to indicate co-authorship, using commands like so:

git commit --author="Author Name <author@email.com>" --allow-empty -m "add Author Name as coauthor"

Second, co-authors can also be listed in lines at the very bottom of
the commit message (that is, directly before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines
at the bottom of the commit message (before the `---`, and also before
any "Co-authored-by" lines) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
