### PR TITLE
[Merged by Bors] - feat(RingTheory): universal coprime factorization ring

### DIFF
--- a/Mathlib/RingTheory/Polynomial/Resultant/Basic.lean
+++ b/Mathlib/RingTheory/Polynomial/Resultant/Basic.lean
@@ -902,7 +902,6 @@ lemma isUnit_resultant_iff_isCoprime {f g : R[X]} (hf : f.Monic) :
     have := resultant_mul_right f b g _ le_rfl
     obtain rfl | hb0 := eq_or_ne a 0
     · rw [show b * g = 1 by simpa using e, resultant_one_right] at this
-      simp at this
       simpa [hf.leadingCoeff] using this
     · rw [← resultant_add_mul_right _ _ a _ _ _ le_rfl, add_comm, mul_comm, e, ← C.map_one] at this
       · simpa [hf.leadingCoeff] using this

--- a/Mathlib/RingTheory/Polynomial/Resultant/Basic.lean
+++ b/Mathlib/RingTheory/Polynomial/Resultant/Basic.lean
@@ -889,6 +889,43 @@ lemma exists_mul_add_mul_eq_C_resultant
   refine ⟨X.2, X.1, by simpa [-SetLike.coe_mem] using X.2.2,
     by simpa [-SetLike.coe_mem] using X.1.2, by simpa [Algebra.smul_def] using this⟩
 
+lemma isUnit_resultant_iff_isCoprime {f g : R[X]} (hf : f.Monic) :
+    IsUnit (resultant f g) ↔ IsCoprime f g := by
+  by_cases hf0 : f.natDegree = 0
+  · obtain rfl := eq_one_of_monic_natDegree_zero hf hf0; simp [isCoprime_one_left]
+  refine ⟨fun H ↦ ?_, ?_⟩
+  · obtain ⟨p, q, hp, hq, e⟩ := exists_mul_add_mul_eq_C_resultant f g le_rfl le_rfl (by simp [hf0])
+    exact ⟨C (H.unit⁻¹).1 * p, C (H.unit⁻¹).1 * q, by simp only [mul_assoc, ← mul_add, mul_comm p,
+      mul_comm q, e, ← map_mul, IsUnit.val_inv_mul, map_one]⟩
+  · intro ⟨a, b, e⟩
+    suffices 1 = f.resultant b * f.resultant g from isUnit_iff_exists_inv'.mpr ⟨_, this.symm⟩
+    have := resultant_mul_right f b g _ le_rfl
+    obtain rfl | hb0 := eq_or_ne a 0
+    · rw [show b * g = 1 by simpa using e, resultant_one_right] at this
+      simp at this
+      simpa [hf.leadingCoeff] using this
+    · rw [← resultant_add_mul_right _ _ a _ _ _ le_rfl, add_comm, mul_comm, e, ← C.map_one] at this
+      · simpa [hf.leadingCoeff] using this
+      · by_contra! H
+        replace H := natDegree_mul_le.trans_lt H
+        rw [add_comm, ← hf.natDegree_mul' hb0, mul_comm f] at H
+        have := natDegree_add_eq_left_of_natDegree_lt H
+        simp only [e, natDegree_one] at this
+        cutsat
+
+lemma resultant_eq_zero_iff {K : Type*} [Field K] {f g : K[X]} :
+    resultant f g = 0 ↔ (f ≠ 0 ∨ g ≠ 0) ∧ ¬ IsCoprime f g := by
+  obtain rfl | hf := eq_or_ne f 0
+  · obtain rfl | hg := eq_or_ne g 0; · simp
+    simpa [isCoprime_zero_left, isUnit_iff, hg, natDegree_eq_zero] using
+      show (∀ x, C x ≠ g) ↔ ∀ x ≠ 0, C x ≠ g by aesop
+  have H : (C f.leadingCoeff⁻¹ * f).Monic := by
+    rw [Monic, ← coeff_natDegree, natDegree_C_mul (by simpa), coeff_C_mul]; simp [hf]
+  have := isUnit_resultant_iff_isCoprime (f := C f.leadingCoeff⁻¹ * f) (g := g) H
+  rw [resultant_C_mul_left, IsUnit.mul_iff, natDegree_C_mul (by simp [hf]),
+    isCoprime_mul_unit_left_left (isUnit_C.mpr (by simp [hf]))] at this
+  simp [← this, hf]
+
 end sylvesterMap
 
 section disc


### PR DESCRIPTION
---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

When merging, all the commits will be squashed into a single commit
listing all co-authors.

Co-authors in the squash commit are gathered from two sources:

First, all authors of commits to this PR branch are included. Thus,
one way to add co-authors is to include at least one commit authored by
each co-author among the commits in the pull request. If necessary, you
may create empty commits to indicate co-authorship, using commands like so:

git commit --author="Author Name <author@email.com>" --allow-empty -m "add Author Name as coauthor"

Second, co-authors can also be listed in lines at the very bottom of
the commit message (that is, directly before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines
at the bottom of the commit message (before the `---`, and also before
any "Co-authored-by" lines) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
