### PR TITLE
[Merged by Bors] - feat(Geometry/Euclidean/../TriangleInequality): one equality case of the vector triangle inequality

### DIFF
--- a/Mathlib/Geometry/Euclidean/Angle/Unoriented/TriangleInequality.lean
+++ b/Mathlib/Geometry/Euclidean/Angle/Unoriented/TriangleInequality.lean
@@ -150,9 +150,8 @@ public theorem angle_le_angle_add_angle (x y z : V) :
 
 /-- The triangle inequality is an equality if the middle vector is a nonnegative linear combination
 of the other two vectors. See `angle_add_angle_eq_pi_of_angle_eq_pi` for the other equality case. -/
-public theorem angle_eq_angle_add_add_angle_add_of_mem_span {x y z : V} (hy : y ≠ 0) (hz : z ≠ 0)
-    (h_mem : y ∈ (ℝ≥0 ∙ x) ⊔ (ℝ≥0 ∙ z)) :
-    angle x z = angle x y + angle y z := by
+public theorem angle_eq_angle_add_add_angle_add_of_mem_span {x y z : V} (hy : y ≠ 0)
+    (h_mem : y ∈ (ℝ≥0 ∙ x) ⊔ (ℝ≥0 ∙ z)) : angle x z = angle x y + angle y z := by
   simp only [Submodule.mem_sup, Submodule.mem_span_singleton] at h_mem
   obtain ⟨_, ⟨kx, rfl⟩, _, ⟨kz, rfl⟩, rfl⟩ := h_mem
   rcases (zero_le kx).eq_or_lt with rfl | hkx <;> rcases (zero_le kz).eq_or_lt with rfl | hkz
@@ -160,8 +159,13 @@ public theorem angle_eq_angle_add_add_angle_add_of_mem_span {x y z : V} (hy : y 
   · simp_all [NNReal.smul_def]
   · simp_all [NNReal.smul_def]
   · rw [angle_comm (_ + _) z]
-    simpa [hkx, hkz, NNReal.smul_def] using
-      angle_eq_angle_add_add_angle_add (kx • x) (smul_ne_zero hkz.ne' hz)
+    by_cases! hz : z ≠ 0
+    · simpa [hkx, hkz, NNReal.smul_def] using
+        angle_eq_angle_add_add_angle_add (kx • x) (smul_ne_zero hkz.ne' hz)
+    · have hx : x ≠ 0 := by simp_all
+      rw [angle_comm, add_comm, add_comm (kx • x)]
+      simpa [hkx, hkz, NNReal.smul_def] using
+        angle_eq_angle_add_add_angle_add (kz • z) (smul_ne_zero hkx.ne' hx)
 
 /-- The triangle inequality on vectors `x`, `y`, `z` is an equality if and only if
 `angle x z = π`, or `y` is a nonnegative linear combination of `x` and `z`. -/

--- a/Mathlib/Geometry/Euclidean/Angle/Unoriented/TriangleInequality.lean
+++ b/Mathlib/Geometry/Euclidean/Angle/Unoriented/TriangleInequality.lean
@@ -169,7 +169,7 @@ public theorem angle_eq_angle_add_add_angle_add_of_mem_span {x y z : V} (hy : y 
 
 /-- The triangle inequality on vectors `x`, `y`, `z` is an equality if and only if
 `angle x z = π`, or `y` is a nonnegative linear combination of `x` and `z`. -/
-proof_wanted angle_eq_angle_add_angle_iff {x y z : V} (hx : x ≠ 0) (hy : y ≠ 0) (hz : z ≠ 0) :
+proof_wanted angle_eq_angle_add_angle_iff {x y z : V} (hy : y ≠ 0) :
     angle x z = angle x y + angle y z ↔ angle x z = π ∨ y ∈ (ℝ≥0 ∙ x) ⊔ (ℝ≥0 ∙ z)
 
 end InnerProductGeometry

--- a/Mathlib/Geometry/Euclidean/Angle/Unoriented/TriangleInequality.lean
+++ b/Mathlib/Geometry/Euclidean/Angle/Unoriented/TriangleInequality.lean
@@ -151,9 +151,9 @@ public theorem angle_le_angle_add_angle (x y z : V) :
 /-- The triangle inequality is an equality if the middle vector is a nonnegative linear combination
 of the other two vectors. See `angle_add_angle_eq_pi_of_angle_eq_pi` for the other equality case. -/
 public theorem angle_eq_angle_add_add_angle_add_of_mem_span {x y z : V} (hy : y ≠ 0)
-    (h_mem : y ∈ (ℝ≥0 ∙ x) ⊔ (ℝ≥0 ∙ z)) : angle x z = angle x y + angle y z := by
-  simp only [Submodule.mem_sup, Submodule.mem_span_singleton] at h_mem
-  obtain ⟨_, ⟨kx, rfl⟩, _, ⟨kz, rfl⟩, rfl⟩ := h_mem
+    (h_mem : y ∈ Submodule.span ℝ≥0 {x, z}) : angle x z = angle x y + angle y z := by
+  rw [Submodule.mem_span_pair] at h_mem
+  obtain ⟨kx, kz, rfl⟩ := h_mem
   rcases (zero_le kx).eq_or_lt with rfl | hkx <;> rcases (zero_le kz).eq_or_lt with rfl | hkz
   · simp at hy
   · simp_all [NNReal.smul_def]
@@ -170,7 +170,7 @@ public theorem angle_eq_angle_add_add_angle_add_of_mem_span {x y z : V} (hy : y 
 /-- The triangle inequality on vectors `x`, `y`, `z` is an equality if and only if
 `angle x z = π`, or `y` is a nonnegative linear combination of `x` and `z`. -/
 proof_wanted angle_eq_angle_add_angle_iff {x y z : V} (hy : y ≠ 0) :
-    angle x z = angle x y + angle y z ↔ angle x z = π ∨ y ∈ (ℝ≥0 ∙ x) ⊔ (ℝ≥0 ∙ z)
+    angle x z = angle x y + angle y z ↔ angle x z = π ∨ y ∈ Submodule.span ℝ≥0 {x, z}
 
 end InnerProductGeometry
 

--- a/Mathlib/Geometry/Euclidean/Angle/Unoriented/TriangleInequality.lean
+++ b/Mathlib/Geometry/Euclidean/Angle/Unoriented/TriangleInequality.lean
@@ -1,14 +1,14 @@
 /-
 Copyright (c) 2025 Ilmārs Cīrulis. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
-Authors: Ilmārs Cīrulis, Alex Meiburg
+Authors: Ilmārs Cīrulis, Alex Meiburg, Jovan Gerbscheid
 -/
 module
 
-public import Mathlib.Analysis.InnerProductSpace.Projection.Basic
 public import Mathlib.Analysis.NormedSpace.Normalize
 public import Mathlib.Geometry.Euclidean.Angle.Unoriented.Affine
-public import Mathlib.Geometry.Euclidean.Angle.Unoriented.Basic
+
+import Mathlib.Geometry.Euclidean.Triangle
 
 /-!
 # The Triangle Inequality for Angles
@@ -19,9 +19,11 @@ This file contains the proof that angles obey the triangle inequality.
 open InnerProductGeometry
 open NormedSpace
 
-open scoped RealInnerProductSpace
+open scoped Real NNReal RealInnerProductSpace
 
 variable {V : Type*} [NormedAddCommGroup V] [InnerProductSpace ℝ V]
+
+namespace InnerProductGeometry
 
 section UnitVectorAngles
 
@@ -135,7 +137,7 @@ end UnitVectorAngles
 
 
 /-- **Triangle inequality** for angles between vectors. -/
-public theorem InnerProductGeometry.angle_le_angle_add_angle (x y z : V) :
+public theorem angle_le_angle_add_angle (x y z : V) :
     angle x z ≤ angle x y + angle y z := by
   by_cases hx : x = 0
   · simpa [hx] using angle_nonneg y z
@@ -145,6 +147,28 @@ public theorem InnerProductGeometry.angle_le_angle_add_angle (x y z : V) :
   · simpa [hz] using angle_nonneg x y
   simpa using angle_le_angle_add_angle_of_norm_eq_one (norm_normalize_eq_one_iff.mpr hx)
     (norm_normalize_eq_one_iff.mpr hy) (norm_normalize_eq_one_iff.mpr hz)
+
+/-- The triangle inequality is an equality if the middle vector is a nonnegative linear combination
+of the other two vectors. See `angle_add_angle_eq_pi_of_angle_eq_pi` for the other equality case. -/
+public theorem angle_eq_angle_add_add_angle_add_of_mem_span {x y z : V} (hy : y ≠ 0) (hz : z ≠ 0)
+    (h_mem : y ∈ (ℝ≥0 ∙ x) ⊔ (ℝ≥0 ∙ z)) :
+    angle x z = angle x y + angle y z := by
+  simp only [Submodule.mem_sup, Submodule.mem_span_singleton] at h_mem
+  obtain ⟨_, ⟨kx, rfl⟩, _, ⟨kz, rfl⟩, rfl⟩ := h_mem
+  rcases (zero_le kx).eq_or_lt with rfl | hkx <;> rcases (zero_le kz).eq_or_lt with rfl | hkz
+  · simp at hy
+  · simp_all [NNReal.smul_def]
+  · simp_all [NNReal.smul_def]
+  · rw [angle_comm (_ + _) z]
+    simpa [hkx, hkz, NNReal.smul_def] using
+      angle_eq_angle_add_add_angle_add (kx • x) (smul_ne_zero hkz.ne' hz)
+
+/-- The triangle inequality on vectors `x`, `y`, `z` is an equality if and only if
+`angle x z = π`, or `y` is a nonnegative linear combination of `x` and `z`. -/
+proof_wanted angle_eq_angle_add_angle_iff {x y z : V} (hx : x ≠ 0) (hy : y ≠ 0) (hz : z ≠ 0) :
+    angle x z = angle x y + angle y z ↔ angle x z = π ∨ y ∈ (ℝ≥0 ∙ x) ⊔ (ℝ≥0 ∙ z)
+
+end InnerProductGeometry
 
 namespace EuclideanGeometry
 


### PR DESCRIPTION
This PR proves one equality case of the triangle inequality for angles. It also adds a `proof_wanted` for the bidirectional version.

[#new members > Criterion for equality in the triangle inequality for angles @ 💬](https://leanprover.zulipchat.com/#narrow/channel/113489-new-members/topic/Criterion.20for.20equality.20in.20the.20triangle.20inequality.20for.20angles/near/560161005)

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

When merging, all the commits will be squashed into a single commit
listing all co-authors.

Co-authors in the squash commit are gathered from two sources:

First, all authors of commits to this PR branch are included. Thus,
one way to add co-authors is to include at least one commit authored by
each co-author among the commits in the pull request. If necessary, you
may create empty commits to indicate co-authorship, using commands like so:

git commit --author="Author Name <author@email.com>" --allow-empty -m "add Author Name as coauthor"

Second, co-authors can also be listed in lines at the very bottom of
the commit message (that is, directly before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines
at the bottom of the commit message (before the `---`, and also before
any "Co-authored-by" lines) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
