### PR TITLE
[Merged by Bors] - feat(Algebra): add subsingleton of IsZero for `AddCommGrpCat`

### DIFF
--- a/Mathlib/Algebra/Category/Grp/Preadditive.lean
+++ b/Mathlib/Algebra/Category/Grp/Preadditive.lean
@@ -68,4 +68,10 @@ def homAddEquiv : (M ⟶ N) ≃+ (M →+ N) :=
   { ConcreteCategory.homEquiv (C := AddCommGrpCat) with
     map_add' _ _ := rfl }
 
+lemma subsingleton_of_isZero {G : AddCommGrpCat} (h : Limits.IsZero G) :
+    Subsingleton G := by
+  apply subsingleton_of_forall_eq 0 (fun g ↦ ?_)
+  rw [← AddMonoidHom.id_apply G g, ← AddCommGrpCat.hom_id]
+  simp [(CategoryTheory.Limits.IsZero.iff_id_eq_zero G).mp h]
+
 end AddCommGrpCat

--- a/Mathlib/Algebra/Category/Grp/Preadditive.lean
+++ b/Mathlib/Algebra/Category/Grp/Preadditive.lean
@@ -68,10 +68,4 @@ def homAddEquiv : (M ⟶ N) ≃+ (M →+ N) :=
   { ConcreteCategory.homEquiv (C := AddCommGrpCat) with
     map_add' _ _ := rfl }
 
-lemma subsingleton_of_isZero {G : AddCommGrpCat} (h : Limits.IsZero G) :
-    Subsingleton G := by
-  apply subsingleton_of_forall_eq 0 (fun g ↦ ?_)
-  rw [← AddMonoidHom.id_apply G g, ← AddCommGrpCat.hom_id]
-  simp [(CategoryTheory.Limits.IsZero.iff_id_eq_zero G).mp h]
-
 end AddCommGrpCat

--- a/Mathlib/Algebra/Category/Grp/Zero.lean
+++ b/Mathlib/Algebra/Category/Grp/Zero.lean
@@ -39,6 +39,20 @@ theorem isZero_of_subsingleton (G : GrpCat) [Subsingleton G] : IsZero G := by
 instance : HasZeroObject GrpCat :=
   ⟨⟨of PUnit, isZero_of_subsingleton _⟩⟩
 
+@[to_additive]
+lemma subsingleton_of_isZero {G : GrpCat} (h : Limits.IsZero G) :
+    Subsingleton G := by
+  apply subsingleton_of_forall_eq 1 (fun g ↦ ?_)
+  rcases h.1 (GrpCat.of (G × G)) with ⟨uniq⟩
+  have : ofHom (MonoidHom.inl G G) g = ofHom (MonoidHom.inr G G) g:= by
+    rw [IsZero.eq_of_src h (ofHom (MonoidHom.inl G G)) (ofHom (MonoidHom.inr G G))]
+  simp only [hom_ofHom, MonoidHom.inl_apply, MonoidHom.inr_apply, Prod.mk.injEq] at this
+  exact this.1
+
+@[to_additive]
+lemma isZero_iff_subsingleton {G : GrpCat} : Limits.IsZero G ↔ Subsingleton G :=
+    ⟨fun h ↦ subsingleton_of_isZero h, fun _ ↦ isZero_of_subsingleton G⟩
+
 end GrpCat
 
 namespace CommGrpCat
@@ -55,5 +69,19 @@ theorem isZero_of_subsingleton (G : CommGrpCat) [Subsingleton G] : IsZero G := b
 @[to_additive AddCommGrpCat.hasZeroObject]
 instance : HasZeroObject CommGrpCat :=
   ⟨⟨of PUnit, isZero_of_subsingleton _⟩⟩
+
+@[to_additive]
+lemma subsingleton_of_isZero {G : CommGrpCat} (h : Limits.IsZero G) :
+    Subsingleton G := by
+  apply subsingleton_of_forall_eq 1 (fun g ↦ ?_)
+  rcases h.1 (CommGrpCat.of (G × G)) with ⟨uniq⟩
+  have : ofHom (MonoidHom.inl G G) g= ofHom (MonoidHom.inr G G) g:= by
+    rw [IsZero.eq_of_src h (ofHom (MonoidHom.inl G G)) (ofHom (MonoidHom.inr G G))]
+  simp only [hom_ofHom, MonoidHom.inl_apply, MonoidHom.inr_apply, Prod.mk.injEq] at this
+  exact this.1
+
+@[to_additive]
+lemma isZero_iff_subsingleton {G : CommGrpCat} : Limits.IsZero G ↔ Subsingleton G :=
+    ⟨fun h ↦ subsingleton_of_isZero h, fun _ ↦ isZero_of_subsingleton G⟩
 
 end CommGrpCat

--- a/Mathlib/Algebra/Category/Grp/Zero.lean
+++ b/Mathlib/Algebra/Category/Grp/Zero.lean
@@ -73,12 +73,7 @@ instance : HasZeroObject CommGrpCat :=
 @[to_additive]
 lemma subsingleton_of_isZero {G : CommGrpCat} (h : Limits.IsZero G) :
     Subsingleton G := by
-  apply subsingleton_of_forall_eq 1 (fun g ↦ ?_)
-  rcases h.1 (CommGrpCat.of (G × G)) with ⟨uniq⟩
-  have : ofHom (MonoidHom.inl G G) g= ofHom (MonoidHom.inr G G) g:= by
-    rw [IsZero.eq_of_src h (ofHom (MonoidHom.inl G G)) (ofHom (MonoidHom.inr G G))]
-  simp only [hom_ofHom, MonoidHom.inl_apply, MonoidHom.inr_apply, Prod.mk.injEq] at this
-  exact this.1
+  (h.iso (isZero_of_subsingleton <| .of PUnit)).commGroupIsoToMulEquiv.subsingleton
 
 @[to_additive]
 lemma isZero_iff_subsingleton {G : CommGrpCat} : Limits.IsZero G ↔ Subsingleton G :=

--- a/Mathlib/Algebra/Category/Grp/Zero.lean
+++ b/Mathlib/Algebra/Category/Grp/Zero.lean
@@ -46,7 +46,7 @@ lemma subsingleton_of_isZero {G : GrpCat} (h : Limits.IsZero G) :
 
 @[to_additive]
 lemma isZero_iff_subsingleton {G : GrpCat} : Limits.IsZero G ↔ Subsingleton G :=
-    ⟨fun h ↦ subsingleton_of_isZero h, fun _ ↦ isZero_of_subsingleton G⟩
+  ⟨fun h ↦ subsingleton_of_isZero h, fun _ ↦ isZero_of_subsingleton G⟩
 
 end GrpCat
 
@@ -72,6 +72,6 @@ lemma subsingleton_of_isZero {G : CommGrpCat} (h : Limits.IsZero G) :
 
 @[to_additive]
 lemma isZero_iff_subsingleton {G : CommGrpCat} : Limits.IsZero G ↔ Subsingleton G :=
-    ⟨fun h ↦ subsingleton_of_isZero h, fun _ ↦ isZero_of_subsingleton G⟩
+  ⟨fun h ↦ subsingleton_of_isZero h, fun _ ↦ isZero_of_subsingleton G⟩
 
 end CommGrpCat

--- a/Mathlib/Algebra/Category/Grp/Zero.lean
+++ b/Mathlib/Algebra/Category/Grp/Zero.lean
@@ -41,7 +41,7 @@ instance : HasZeroObject GrpCat :=
 
 @[to_additive]
 lemma subsingleton_of_isZero {G : GrpCat} (h : Limits.IsZero G) :
-    Subsingleton G := by
+    Subsingleton G :=
   (h.iso (isZero_of_subsingleton <| .of PUnit)).groupIsoToMulEquiv.subsingleton
 
 @[to_additive]
@@ -67,7 +67,7 @@ instance : HasZeroObject CommGrpCat :=
 
 @[to_additive]
 lemma subsingleton_of_isZero {G : CommGrpCat} (h : Limits.IsZero G) :
-    Subsingleton G := by
+    Subsingleton G :=
   (h.iso (isZero_of_subsingleton <| .of PUnit)).commGroupIsoToMulEquiv.subsingleton
 
 @[to_additive]

--- a/Mathlib/Algebra/Category/Grp/Zero.lean
+++ b/Mathlib/Algebra/Category/Grp/Zero.lean
@@ -42,12 +42,7 @@ instance : HasZeroObject GrpCat :=
 @[to_additive]
 lemma subsingleton_of_isZero {G : GrpCat} (h : Limits.IsZero G) :
     Subsingleton G := by
-  apply subsingleton_of_forall_eq 1 (fun g ↦ ?_)
-  rcases h.1 (GrpCat.of (G × G)) with ⟨uniq⟩
-  have : ofHom (MonoidHom.inl G G) g = ofHom (MonoidHom.inr G G) g:= by
-    rw [IsZero.eq_of_src h (ofHom (MonoidHom.inl G G)) (ofHom (MonoidHom.inr G G))]
-  simp only [hom_ofHom, MonoidHom.inl_apply, MonoidHom.inr_apply, Prod.mk.injEq] at this
-  exact this.1
+  (h.iso (isZero_of_subsingleton <| .of PUnit)).groupIsoToMulEquiv.subsingleton
 
 @[to_additive]
 lemma isZero_iff_subsingleton {G : GrpCat} : Limits.IsZero G ↔ Subsingleton G :=


### PR DESCRIPTION
---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

When merging, all the commits will be squashed into a single commit
listing all co-authors.

Co-authors in the squash commit are gathered from two sources:

First, all authors of commits to this PR branch are included. Thus,
one way to add co-authors is to include at least one commit authored by
each co-author among the commits in the pull request. If necessary, you
may create empty commits to indicate co-authorship, using commands like so:

git commit --author="Author Name <author@email.com>" --allow-empty -m "add Author Name as coauthor"

Second, co-authors can also be listed in lines at the very bottom of
the commit message (that is, directly before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines
at the bottom of the commit message (before the `---`, and also before
any "Co-authored-by" lines) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
