### PR TITLE
[Merged by Bors] - feat(Combinatorics/SimpleGraph): add simp lemma `getVert_map` for `Walk.map`

### DIFF
--- a/Mathlib/Combinatorics/SimpleGraph/Walks/Maps.lean
+++ b/Mathlib/Combinatorics/SimpleGraph/Walks/Maps.lean
@@ -101,10 +101,8 @@ theorem edges_map : (p.map f).edges = p.edges.map (Sym2.map f) := by
 theorem edgeSet_map : (p.map f).edgeSet = Sym2.map f '' p.edgeSet := by ext; simp
 
 @[simp]
-theorem getVert_map (i : ℕ) : (p.map f).getVert i = f (p.getVert i) := by
-  revert u; induction i with
-  | zero => simp
-  | succ => intro _ p; cases p <;> simp [*]
+theorem getVert_map (n : ℕ) : (p.map f).getVert n = f (p.getVert n) := by
+  induction p generalizing n <;> cases n <;> simp [*]
 
 theorem map_injective_of_injective {f : G →g G'} (hinj : Function.Injective f) (u v : V) :
     Function.Injective (Walk.map f : G.Walk u v → G'.Walk (f u) (f v)) := by

--- a/Mathlib/Combinatorics/SimpleGraph/Walks/Maps.lean
+++ b/Mathlib/Combinatorics/SimpleGraph/Walks/Maps.lean
@@ -100,6 +100,12 @@ theorem edges_map : (p.map f).edges = p.edges.map (Sym2.map f) := by
 @[simp]
 theorem edgeSet_map : (p.map f).edgeSet = Sym2.map f '' p.edgeSet := by ext; simp
 
+@[simp]
+theorem getVert_map (i : ℕ) : (p.map f).getVert i = f (p.getVert i) := by
+  revert u; induction i with
+  | zero => simp
+  | succ => intro _ p; cases p <;> simp [*]
+
 theorem map_injective_of_injective {f : G →g G'} (hinj : Function.Injective f) (u v : V) :
     Function.Injective (Walk.map f : G.Walk u v → G'.Walk (f u) (f v)) := by
   intro p p' h


### PR DESCRIPTION

---
- in concept similar to `List.getElem_map` 
- deserve a simp lemma (useful when pushing walks between Subgraphs)

lemma getVert_map (i : ℕ) : (p.map f).getVert i = f (p.getVert i) := by
  revert u; induction i with
  | zero => simp
  | succ => intro _ p; cases p <;> simp [*]
  
 can not just use simp to prove this fact