### PR TITLE
[Merged by Bors] - chore(Logic/Equiv): golf entire `Function.Injective.map_swap` using `grind`

### DIFF
--- a/Mathlib/Logic/Equiv/Basic.lean
+++ b/Mathlib/Logic/Equiv/Basic.lean
@@ -776,12 +776,7 @@ theorem PLift.eq_up_iff_down_eq {x : PLift α} {y : α} : x = PLift.up y ↔ x.d
 theorem Function.Injective.map_swap [DecidableEq α] [DecidableEq β] {f : α → β}
     (hf : Function.Injective f) (x y z : α) :
     f (Equiv.swap x y z) = Equiv.swap (f x) (f y) (f z) := by
-  conv_rhs => rw [Equiv.swap_apply_def]
-  split_ifs with h₁ h₂
-  · -- We can't yet use `grind` here because of https://github.com/leanprover/lean4/issues/11088
-    rw [hf h₁, Equiv.swap_apply_left]
-  · rw [hf h₂, Equiv.swap_apply_right]
-  · grind
+  grind
 
 namespace Equiv
 


### PR DESCRIPTION
---
<details>
<summary>Show trace profiling of <code>Function.Injective.map_swap</code>: 144 ms before, 137 ms after  🎉</summary>

### Trace profiling of `Function.Injective.map_swap` before PR 32110
```diff
diff --git a/Mathlib/Logic/Equiv/Basic.lean b/Mathlib/Logic/Equiv/Basic.lean
index 730944120b..9cebc12ae5 100644
--- a/Mathlib/Logic/Equiv/Basic.lean
+++ b/Mathlib/Logic/Equiv/Basic.lean
@@ -773,6 +773,7 @@ end Function.Involutive
 theorem PLift.eq_up_iff_down_eq {x : PLift α} {y : α} : x = PLift.up y ↔ x.down = y :=
   Equiv.plift.eq_symm_apply
 
+set_option trace.profiler true in
 theorem Function.Injective.map_swap [DecidableEq α] [DecidableEq β] {f : α → β}
     (hf : Function.Injective f) (x y z : α) :
     f (Equiv.swap x y z) = Equiv.swap (f x) (f y) (f z) := by
```
```
ℹ [318/318] Built Mathlib.Logic.Equiv.Basic (1.7s)
info: Mathlib/Logic/Equiv/Basic.lean:777:0: [Elab.async] [0.144697] elaborating proof of Function.Injective.map_swap
  [Elab.definition.value] [0.144220] Function.Injective.map_swap
    [Elab.step] [0.143996] 
          conv_rhs => rw [Equiv.swap_apply_def]
          split_ifs with h₁ h₂
          · -- We can't yet use `grind` here because of https://github.com/leanprover/lean4/issues/11088
            rw [hf h₁, Equiv.swap_apply_left]
          · rw [hf h₂, Equiv.swap_apply_right]
          · grind
      [Elab.step] [0.143988] 
            conv_rhs => rw [Equiv.swap_apply_def]
            split_ifs with h₁ h₂
            · -- We can't yet use `grind` here because of https://github.com/leanprover/lean4/issues/11088
              rw [hf h₁, Equiv.swap_apply_left]
            · rw [hf h₂, Equiv.swap_apply_right]
            · grind
        [Elab.step] [0.137044] split_ifs with h₁ h₂
Build completed successfully (318 jobs).
```

### Trace profiling of `Function.Injective.map_swap` after PR 32110
```diff
diff --git a/Mathlib/Logic/Equiv/Basic.lean b/Mathlib/Logic/Equiv/Basic.lean
index 730944120b..cad69c21c4 100644
--- a/Mathlib/Logic/Equiv/Basic.lean
+++ b/Mathlib/Logic/Equiv/Basic.lean
@@ -773,15 +773,11 @@ end Function.Involutive
 theorem PLift.eq_up_iff_down_eq {x : PLift α} {y : α} : x = PLift.up y ↔ x.down = y :=
   Equiv.plift.eq_symm_apply
 
+set_option trace.profiler true in
 theorem Function.Injective.map_swap [DecidableEq α] [DecidableEq β] {f : α → β}
     (hf : Function.Injective f) (x y z : α) :
     f (Equiv.swap x y z) = Equiv.swap (f x) (f y) (f z) := by
-  conv_rhs => rw [Equiv.swap_apply_def]
-  split_ifs with h₁ h₂
-  · -- We can't yet use `grind` here because of https://github.com/leanprover/lean4/issues/11088
-    rw [hf h₁, Equiv.swap_apply_left]
-  · rw [hf h₂, Equiv.swap_apply_right]
-  · grind
+  grind
 
 namespace Equiv
 
```
```
ℹ [318/318] Built Mathlib.Logic.Equiv.Basic (1.7s)
info: Mathlib/Logic/Equiv/Basic.lean:777:0: [Elab.async] [0.137378] elaborating proof of Function.Injective.map_swap
  [Elab.definition.value] [0.137222] Function.Injective.map_swap
    [Elab.step] [0.137104] grind
      [Elab.step] [0.137098] grind
        [Elab.step] [0.137091] grind
Build completed successfully (318 jobs).
```
</details>

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

When merging, all the commits will be squashed into a single commit
listing all co-authors.

Co-authors in the squash commit are gathered from two sources:

First, all authors of commits to this PR branch are included. Thus,
one way to add co-authors is to include at least one commit authored by
each co-author among the commits in the pull request. If necessary, you
may create empty commits to indicate co-authorship, using commands like so:

git commit --author="Author Name <author@email.com>" --allow-empty -m "add Author Name as coauthor"

Second, co-authors can also be listed in lines at the very bottom of
the commit message (that is, directly before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines
at the bottom of the commit message (before the `---`, and also before
any "Co-authored-by" lines) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
