### PR TITLE
[Merged by Bors] - chore(MeasureTheory/MeasurableSpace): golf `generateFrom_pi_eq` using `grind`

### DIFF
--- a/Mathlib/MeasureTheory/MeasurableSpace/Pi.lean
+++ b/Mathlib/MeasureTheory/MeasurableSpace/Pi.lean
@@ -84,10 +84,8 @@ theorem generateFrom_pi_eq {C : ∀ i, Set (Set (α i))} (hC : ∀ i, IsCountabl
     rw [this, ← iUnion_univ_pi]
     apply MeasurableSet.iUnion
     intro n; apply measurableSet_generateFrom
-    apply mem_image_of_mem; intro j _; dsimp only
-    by_cases h : j = i
-    · subst h; rwa [update_self]
-    · rw [update_of_ne h]; apply h1t
+    apply mem_image_of_mem
+    grind
   · apply generateFrom_le; rintro _ ⟨s, hs, rfl⟩
     rw [univ_pi_eq_iInter]; apply MeasurableSet.iInter; intro i
     apply @measurable_pi_apply _ _ (fun i => generateFrom (C i))


### PR DESCRIPTION
---
<details>
<summary>Show trace profiling of <code>generateFrom_pi_eq</code>: 60 ms before, 60 ms after  🎉</summary>

### Trace profiling of `generateFrom_pi_eq` before PR 32112
```diff
diff --git a/Mathlib/MeasureTheory/MeasurableSpace/Pi.lean b/Mathlib/MeasureTheory/MeasurableSpace/Pi.lean
index 9ac1896f53..fc5859a2c5 100644
--- a/Mathlib/MeasureTheory/MeasurableSpace/Pi.lean
+++ b/Mathlib/MeasureTheory/MeasurableSpace/Pi.lean
@@ -61,6 +61,7 @@ theorem IsCountablySpanning.pi {C : ∀ i, Set (Set (α i))} (hC : ∀ i, IsCoun
     [e, (surjective_decode_iget (ι → ℕ)).iUnion_comp fun x => Set.pi univ fun i => s i (x i),
     iUnion_univ_pi s, h2s, pi_univ]
 
+set_option trace.profiler true in
 /-- The product of generated σ-algebras is the one generated by boxes, if both generating sets
   are countably spanning. -/
 theorem generateFrom_pi_eq {C : ∀ i, Set (Set (α i))} (hC : ∀ i, IsCountablySpanning (C i)) :
```
```
ℹ [847/847] Built Mathlib.MeasureTheory.MeasurableSpace.Pi (1.0s)
info: Mathlib/MeasureTheory/MeasurableSpace/Pi.lean:65:0: [Elab.async] [0.062051] elaborating proof of generateFrom_pi_eq
  [Elab.definition.value] [0.060427] generateFrom_pi_eq
    [Elab.step] [0.058095] classical
          cases nonempty_encodable ι
          apply le_antisymm
          · refine iSup_le ?_; intro i; rw [comap_generateFrom]
            apply generateFrom_le; rintro _ ⟨s, hs, rfl⟩
            choose t h1t h2t using hC
            simp_rw [eval_preimage, ← h2t]
            rw [← @iUnion_const _ ℕ _ s]
            have :
              Set.pi univ (update (fun i' : ι => iUnion (t i')) i (⋃ _ : ℕ, s)) =
                Set.pi univ fun k => ⋃ j : ℕ, @update ι (fun i' => Set (α i')) _ (fun i' => t i' j) i s k :=
              by
              ext; simp_rw [mem_univ_pi]; apply forall_congr'; intro i'
              by_cases h : i' = i
              · subst h; simp
              · simp [h]
            rw [this, ← iUnion_univ_pi]
            apply MeasurableSet.iUnion
            intro n; apply measurableSet_generateFrom
            apply mem_image_of_mem; intro j _; dsimp only
            by_cases h : j = i
            · subst h; rwa [update_self]
            · rw [update_of_ne h]; apply h1t
          · apply generateFrom_le; rintro _ ⟨s, hs, rfl⟩
            rw [univ_pi_eq_iInter]; apply MeasurableSet.iInter; intro i
            apply @measurable_pi_apply _ _ (fun i => generateFrom (C i))
            exact measurableSet_generateFrom (hs i (mem_univ i))
      [Elab.step] [0.058089] classical
            cases nonempty_encodable ι
            apply le_antisymm
            · refine iSup_le ?_; intro i; rw [comap_generateFrom]
              apply generateFrom_le; rintro _ ⟨s, hs, rfl⟩
              choose t h1t h2t using hC
              simp_rw [eval_preimage, ← h2t]
              rw [← @iUnion_const _ ℕ _ s]
              have :
                Set.pi univ (update (fun i' : ι => iUnion (t i')) i (⋃ _ : ℕ, s)) =
                  Set.pi univ fun k => ⋃ j : ℕ, @update ι (fun i' => Set (α i')) _ (fun i' => t i' j) i s k :=
                by
                ext; simp_rw [mem_univ_pi]; apply forall_congr'; intro i'
                by_cases h : i' = i
                · subst h; simp
                · simp [h]
              rw [this, ← iUnion_univ_pi]
              apply MeasurableSet.iUnion
              intro n; apply measurableSet_generateFrom
              apply mem_image_of_mem; intro j _; dsimp only
              by_cases h : j = i
              · subst h; rwa [update_self]
              · rw [update_of_ne h]; apply h1t
            · apply generateFrom_le; rintro _ ⟨s, hs, rfl⟩
              rw [univ_pi_eq_iInter]; apply MeasurableSet.iInter; intro i
              apply @measurable_pi_apply _ _ (fun i => generateFrom (C i))
              exact measurableSet_generateFrom (hs i (mem_univ i))
        [Elab.step] [0.058084] classical
            cases nonempty_encodable ι
            apply le_antisymm
            · refine iSup_le ?_; intro i; rw [comap_generateFrom]
              apply generateFrom_le; rintro _ ⟨s, hs, rfl⟩
              choose t h1t h2t using hC
              simp_rw [eval_preimage, ← h2t]
              rw [← @iUnion_const _ ℕ _ s]
              have :
                Set.pi univ (update (fun i' : ι => iUnion (t i')) i (⋃ _ : ℕ, s)) =
                  Set.pi univ fun k => ⋃ j : ℕ, @update ι (fun i' => Set (α i')) _ (fun i' => t i' j) i s k :=
                by
                ext; simp_rw [mem_univ_pi]; apply forall_congr'; intro i'
                by_cases h : i' = i
                · subst h; simp
                · simp [h]
              rw [this, ← iUnion_univ_pi]
              apply MeasurableSet.iUnion
              intro n; apply measurableSet_generateFrom
              apply mem_image_of_mem; intro j _; dsimp only
              by_cases h : j = i
              · subst h; rwa [update_self]
              · rw [update_of_ne h]; apply h1t
            · apply generateFrom_le; rintro _ ⟨s, hs, rfl⟩
              rw [univ_pi_eq_iInter]; apply MeasurableSet.iInter; intro i
              apply @measurable_pi_apply _ _ (fun i => generateFrom (C i))
              exact measurableSet_generateFrom (hs i (mem_univ i))
          [Elab.step] [0.057931] 
                cases nonempty_encodable ι
                apply le_antisymm
                · refine iSup_le ?_; intro i; rw [comap_generateFrom]
                  apply generateFrom_le; rintro _ ⟨s, hs, rfl⟩
                  choose t h1t h2t using hC
                  simp_rw [eval_preimage, ← h2t]
                  rw [← @iUnion_const _ ℕ _ s]
                  have :
                    Set.pi univ (update (fun i' : ι => iUnion (t i')) i (⋃ _ : ℕ, s)) =
                      Set.pi univ fun k => ⋃ j : ℕ, @update ι (fun i' => Set (α i')) _ (fun i' => t i' j) i s k :=
                    by
                    ext; simp_rw [mem_univ_pi]; apply forall_congr'; intro i'
                    by_cases h : i' = i
                    · subst h; simp
                    · simp [h]
[… 92 lines omitted …]
                          · subst h; simp
                          · simp [h]
                        rw [this, ← iUnion_univ_pi]
                        apply MeasurableSet.iUnion
                        intro n; apply measurableSet_generateFrom
                        apply mem_image_of_mem; intro j _; dsimp only
                        by_cases h : j = i
                        · subst h; rwa [update_self]
                        · rw [update_of_ne h]; apply h1t
                    [Elab.step] [0.017084] simp_rw [eval_preimage, ← h2t]
                    [Elab.step] [0.018496] have :
                          Set.pi univ (update (fun i' : ι => iUnion (t i')) i (⋃ _ : ℕ, s)) =
                            Set.pi univ fun k => ⋃ j : ℕ, @update ι (fun i' => Set (α i')) _ (fun i' => t i' j) i s k :=
                          by
                          ext; simp_rw [mem_univ_pi]; apply forall_congr'; intro i'
                          by_cases h : i' = i
                          · subst h; simp
                          · simp [h]
                      [Elab.step] [0.018479] focus
                            refine
                              no_implicit_lambda%
                                (have :
                                  Set.pi univ (update (fun i' : ι => iUnion (t i')) i (⋃ _ : ℕ, s)) =
                                    Set.pi univ fun k =>
                                      ⋃ j : ℕ, @update ι (fun i' => Set (α i')) _ (fun i' => t i' j) i s k :=
                                  ?body✝;
                                ?_)
                            case body✝ =>
                              with_annotate_state"by"
                                ( ext; simp_rw [mem_univ_pi]; apply forall_congr'; intro i'
                                  by_cases h : i' = i
                                  · subst h; simp
                                  · simp [h])
                        [Elab.step] [0.018475] 
                              refine
                                no_implicit_lambda%
                                  (have :
                                    Set.pi univ (update (fun i' : ι => iUnion (t i')) i (⋃ _ : ℕ, s)) =
                                      Set.pi univ fun k =>
                                        ⋃ j : ℕ, @update ι (fun i' => Set (α i')) _ (fun i' => t i' j) i s k :=
                                    ?body✝;
                                  ?_)
                              case body✝ =>
                                with_annotate_state"by"
                                  ( ext; simp_rw [mem_univ_pi]; apply forall_congr'; intro i'
                                    by_cases h : i' = i
                                    · subst h; simp
                                    · simp [h])
                          [Elab.step] [0.018473] 
                                refine
                                  no_implicit_lambda%
                                    (have :
                                      Set.pi univ (update (fun i' : ι => iUnion (t i')) i (⋃ _ : ℕ, s)) =
                                        Set.pi univ fun k =>
                                          ⋃ j : ℕ, @update ι (fun i' => Set (α i')) _ (fun i' => t i' j) i s k :=
                                      ?body✝;
                                    ?_)
                                case body✝ =>
                                  with_annotate_state"by"
                                    ( ext; simp_rw [mem_univ_pi]; apply forall_congr'; intro i'
                                      by_cases h : i' = i
                                      · subst h; simp
                                      · simp [h])
                            [Elab.step] [0.014848] case body✝ =>
                                  with_annotate_state"by"
                                    ( ext; simp_rw [mem_univ_pi]; apply forall_congr'; intro i'
                                      by_cases h : i' = i
                                      · subst h; simp
                                      · simp [h])
                              [Elab.step] [0.014811] with_annotate_state"by"
                                      ( ext; simp_rw [mem_univ_pi]; apply forall_congr'; intro i'
                                        by_cases h : i' = i
                                        · subst h; simp
                                        · simp [h])
                                [Elab.step] [0.014808] with_annotate_state"by"
                                        ( ext; simp_rw [mem_univ_pi]; apply forall_congr'; intro i'
                                          by_cases h : i' = i
                                          · subst h; simp
                                          · simp [h])
                                  [Elab.step] [0.014806] with_annotate_state"by"
                                        ( ext; simp_rw [mem_univ_pi]; apply forall_congr'; intro i'
                                          by_cases h : i' = i
                                          · subst h; simp
                                          · simp [h])
                                    [Elab.step] [0.014803] (
                                          ext; simp_rw [mem_univ_pi]; apply forall_congr'; intro i'
                                          by_cases h : i' = i
                                          · subst h; simp
                                          · simp [h])
                                      [Elab.step] [0.014801] 
                                            ext; simp_rw [mem_univ_pi]; apply forall_congr'; intro i'
                                            by_cases h : i' = i
                                            · subst h; simp
                                            · simp [h]
                                        [Elab.step] [0.014797] 
                                              ext; simp_rw [mem_univ_pi]; apply forall_congr'; intro i'
                                              by_cases h : i' = i
                                              · subst h; simp
                                              · simp [h]
Build completed successfully (847 jobs).
```

### Trace profiling of `generateFrom_pi_eq` after PR 32112
```diff
diff --git a/Mathlib/MeasureTheory/MeasurableSpace/Pi.lean b/Mathlib/MeasureTheory/MeasurableSpace/Pi.lean
index 9ac1896f53..26e37c73b9 100644
--- a/Mathlib/MeasureTheory/MeasurableSpace/Pi.lean
+++ b/Mathlib/MeasureTheory/MeasurableSpace/Pi.lean
@@ -61,6 +61,7 @@ theorem IsCountablySpanning.pi {C : ∀ i, Set (Set (α i))} (hC : ∀ i, IsCoun
     [e, (surjective_decode_iget (ι → ℕ)).iUnion_comp fun x => Set.pi univ fun i => s i (x i),
     iUnion_univ_pi s, h2s, pi_univ]
 
+set_option trace.profiler true in
 /-- The product of generated σ-algebras is the one generated by boxes, if both generating sets
   are countably spanning. -/
 theorem generateFrom_pi_eq {C : ∀ i, Set (Set (α i))} (hC : ∀ i, IsCountablySpanning (C i)) :
@@ -84,10 +85,8 @@ theorem generateFrom_pi_eq {C : ∀ i, Set (Set (α i))} (hC : ∀ i, IsCountabl
     rw [this, ← iUnion_univ_pi]
     apply MeasurableSet.iUnion
     intro n; apply measurableSet_generateFrom
-    apply mem_image_of_mem; intro j _; dsimp only
-    by_cases h : j = i
-    · subst h; rwa [update_self]
-    · rw [update_of_ne h]; apply h1t
+    apply mem_image_of_mem
+    grind
   · apply generateFrom_le; rintro _ ⟨s, hs, rfl⟩
     rw [univ_pi_eq_iInter]; apply MeasurableSet.iInter; intro i
     apply @measurable_pi_apply _ _ (fun i => generateFrom (C i))
```
```
ℹ [847/847] Built Mathlib.MeasureTheory.MeasurableSpace.Pi (1.0s)
info: Mathlib/MeasureTheory/MeasurableSpace/Pi.lean:65:0: [Elab.async] [0.061781] elaborating proof of generateFrom_pi_eq
  [Elab.definition.value] [0.060351] generateFrom_pi_eq
    [Elab.step] [0.058500] classical
          cases nonempty_encodable ι
          apply le_antisymm
          · refine iSup_le ?_; intro i; rw [comap_generateFrom]
            apply generateFrom_le; rintro _ ⟨s, hs, rfl⟩
            choose t h1t h2t using hC
            simp_rw [eval_preimage, ← h2t]
            rw [← @iUnion_const _ ℕ _ s]
            have :
              Set.pi univ (update (fun i' : ι => iUnion (t i')) i (⋃ _ : ℕ, s)) =
                Set.pi univ fun k => ⋃ j : ℕ, @update ι (fun i' => Set (α i')) _ (fun i' => t i' j) i s k :=
              by
              ext; simp_rw [mem_univ_pi]; apply forall_congr'; intro i'
              by_cases h : i' = i
              · subst h; simp
              · simp [h]
            rw [this, ← iUnion_univ_pi]
            apply MeasurableSet.iUnion
            intro n; apply measurableSet_generateFrom
            apply mem_image_of_mem
            grind
          · apply generateFrom_le; rintro _ ⟨s, hs, rfl⟩
            rw [univ_pi_eq_iInter]; apply MeasurableSet.iInter; intro i
            apply @measurable_pi_apply _ _ (fun i => generateFrom (C i))
            exact measurableSet_generateFrom (hs i (mem_univ i))
      [Elab.step] [0.058494] classical
            cases nonempty_encodable ι
            apply le_antisymm
            · refine iSup_le ?_; intro i; rw [comap_generateFrom]
              apply generateFrom_le; rintro _ ⟨s, hs, rfl⟩
              choose t h1t h2t using hC
              simp_rw [eval_preimage, ← h2t]
              rw [← @iUnion_const _ ℕ _ s]
              have :
                Set.pi univ (update (fun i' : ι => iUnion (t i')) i (⋃ _ : ℕ, s)) =
                  Set.pi univ fun k => ⋃ j : ℕ, @update ι (fun i' => Set (α i')) _ (fun i' => t i' j) i s k :=
                by
                ext; simp_rw [mem_univ_pi]; apply forall_congr'; intro i'
                by_cases h : i' = i
                · subst h; simp
                · simp [h]
              rw [this, ← iUnion_univ_pi]
              apply MeasurableSet.iUnion
              intro n; apply measurableSet_generateFrom
              apply mem_image_of_mem
              grind
            · apply generateFrom_le; rintro _ ⟨s, hs, rfl⟩
              rw [univ_pi_eq_iInter]; apply MeasurableSet.iInter; intro i
              apply @measurable_pi_apply _ _ (fun i => generateFrom (C i))
              exact measurableSet_generateFrom (hs i (mem_univ i))
        [Elab.step] [0.058486] classical
            cases nonempty_encodable ι
            apply le_antisymm
            · refine iSup_le ?_; intro i; rw [comap_generateFrom]
              apply generateFrom_le; rintro _ ⟨s, hs, rfl⟩
              choose t h1t h2t using hC
              simp_rw [eval_preimage, ← h2t]
              rw [← @iUnion_const _ ℕ _ s]
              have :
                Set.pi univ (update (fun i' : ι => iUnion (t i')) i (⋃ _ : ℕ, s)) =
                  Set.pi univ fun k => ⋃ j : ℕ, @update ι (fun i' => Set (α i')) _ (fun i' => t i' j) i s k :=
                by
                ext; simp_rw [mem_univ_pi]; apply forall_congr'; intro i'
                by_cases h : i' = i
                · subst h; simp
                · simp [h]
              rw [this, ← iUnion_univ_pi]
              apply MeasurableSet.iUnion
              intro n; apply measurableSet_generateFrom
              apply mem_image_of_mem
              grind
            · apply generateFrom_le; rintro _ ⟨s, hs, rfl⟩
              rw [univ_pi_eq_iInter]; apply MeasurableSet.iInter; intro i
              apply @measurable_pi_apply _ _ (fun i => generateFrom (C i))
              exact measurableSet_generateFrom (hs i (mem_univ i))
          [Elab.step] [0.058353] 
                cases nonempty_encodable ι
                apply le_antisymm
                · refine iSup_le ?_; intro i; rw [comap_generateFrom]
                  apply generateFrom_le; rintro _ ⟨s, hs, rfl⟩
                  choose t h1t h2t using hC
                  simp_rw [eval_preimage, ← h2t]
                  rw [← @iUnion_const _ ℕ _ s]
                  have :
                    Set.pi univ (update (fun i' : ι => iUnion (t i')) i (⋃ _ : ℕ, s)) =
                      Set.pi univ fun k => ⋃ j : ℕ, @update ι (fun i' => Set (α i')) _ (fun i' => t i' j) i s k :=
                    by
                    ext; simp_rw [mem_univ_pi]; apply forall_congr'; intro i'
                    by_cases h : i' = i
                    · subst h; simp
                    · simp [h]
                  rw [this, ← iUnion_univ_pi]
                  apply MeasurableSet.iUnion
                  intro n; apply measurableSet_generateFrom
                  apply mem_image_of_mem
                  grind
                · apply generateFrom_le; rintro _ ⟨s, hs, rfl⟩
[… 77 lines omitted …]
                          by_cases h : i' = i
                          · subst h; simp
                          · simp [h]
                        rw [this, ← iUnion_univ_pi]
                        apply MeasurableSet.iUnion
                        intro n; apply measurableSet_generateFrom
                        apply mem_image_of_mem
                        grind
                    [Elab.step] [0.013029] simp_rw [eval_preimage, ← h2t]
                    [Elab.step] [0.017060] have :
                          Set.pi univ (update (fun i' : ι => iUnion (t i')) i (⋃ _ : ℕ, s)) =
                            Set.pi univ fun k => ⋃ j : ℕ, @update ι (fun i' => Set (α i')) _ (fun i' => t i' j) i s k :=
                          by
                          ext; simp_rw [mem_univ_pi]; apply forall_congr'; intro i'
                          by_cases h : i' = i
                          · subst h; simp
                          · simp [h]
                      [Elab.step] [0.017044] focus
                            refine
                              no_implicit_lambda%
                                (have :
                                  Set.pi univ (update (fun i' : ι => iUnion (t i')) i (⋃ _ : ℕ, s)) =
                                    Set.pi univ fun k =>
                                      ⋃ j : ℕ, @update ι (fun i' => Set (α i')) _ (fun i' => t i' j) i s k :=
                                  ?body✝;
                                ?_)
                            case body✝ =>
                              with_annotate_state"by"
                                ( ext; simp_rw [mem_univ_pi]; apply forall_congr'; intro i'
                                  by_cases h : i' = i
                                  · subst h; simp
                                  · simp [h])
                        [Elab.step] [0.017040] 
                              refine
                                no_implicit_lambda%
                                  (have :
                                    Set.pi univ (update (fun i' : ι => iUnion (t i')) i (⋃ _ : ℕ, s)) =
                                      Set.pi univ fun k =>
                                        ⋃ j : ℕ, @update ι (fun i' => Set (α i')) _ (fun i' => t i' j) i s k :=
                                    ?body✝;
                                  ?_)
                              case body✝ =>
                                with_annotate_state"by"
                                  ( ext; simp_rw [mem_univ_pi]; apply forall_congr'; intro i'
                                    by_cases h : i' = i
                                    · subst h; simp
                                    · simp [h])
                          [Elab.step] [0.017038] 
                                refine
                                  no_implicit_lambda%
                                    (have :
                                      Set.pi univ (update (fun i' : ι => iUnion (t i')) i (⋃ _ : ℕ, s)) =
                                        Set.pi univ fun k =>
                                          ⋃ j : ℕ, @update ι (fun i' => Set (α i')) _ (fun i' => t i' j) i s k :=
                                      ?body✝;
                                    ?_)
                                case body✝ =>
                                  with_annotate_state"by"
                                    ( ext; simp_rw [mem_univ_pi]; apply forall_congr'; intro i'
                                      by_cases h : i' = i
                                      · subst h; simp
                                      · simp [h])
                            [Elab.step] [0.014312] case body✝ =>
                                  with_annotate_state"by"
                                    ( ext; simp_rw [mem_univ_pi]; apply forall_congr'; intro i'
                                      by_cases h : i' = i
                                      · subst h; simp
                                      · simp [h])
                              [Elab.step] [0.014280] with_annotate_state"by"
                                      ( ext; simp_rw [mem_univ_pi]; apply forall_congr'; intro i'
                                        by_cases h : i' = i
                                        · subst h; simp
                                        · simp [h])
                                [Elab.step] [0.014277] with_annotate_state"by"
                                        ( ext; simp_rw [mem_univ_pi]; apply forall_congr'; intro i'
                                          by_cases h : i' = i
                                          · subst h; simp
                                          · simp [h])
                                  [Elab.step] [0.014275] with_annotate_state"by"
                                        ( ext; simp_rw [mem_univ_pi]; apply forall_congr'; intro i'
                                          by_cases h : i' = i
                                          · subst h; simp
                                          · simp [h])
                                    [Elab.step] [0.014273] (
                                          ext; simp_rw [mem_univ_pi]; apply forall_congr'; intro i'
                                          by_cases h : i' = i
                                          · subst h; simp
                                          · simp [h])
                                      [Elab.step] [0.014270] 
                                            ext; simp_rw [mem_univ_pi]; apply forall_congr'; intro i'
                                            by_cases h : i' = i
                                            · subst h; simp
                                            · simp [h]
                                        [Elab.step] [0.014264] 
                                              ext; simp_rw [mem_univ_pi]; apply forall_congr'; intro i'
                                              by_cases h : i' = i
                                              · subst h; simp
                                              · simp [h]
                    [Elab.step] [0.011757] grind
Build completed successfully (847 jobs).
```
</details>

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

When merging, all the commits will be squashed into a single commit
listing all co-authors.

Co-authors in the squash commit are gathered from two sources:

First, all authors of commits to this PR branch are included. Thus,
one way to add co-authors is to include at least one commit authored by
each co-author among the commits in the pull request. If necessary, you
may create empty commits to indicate co-authorship, using commands like so:

git commit --author="Author Name <author@email.com>" --allow-empty -m "add Author Name as coauthor"

Second, co-authors can also be listed in lines at the very bottom of
the commit message (that is, directly before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines
at the bottom of the commit message (before the `---`, and also before
any "Co-authored-by" lines) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
