### PR TITLE
[Merged by Bors] - chore(CategoryTheory/GradedObject): golf `tensorHom_comp_tensorHom` using `ext; simp`

### DIFF
--- a/Mathlib/CategoryTheory/GradedObject/Monoidal.lean
+++ b/Mathlib/CategoryTheory/GradedObject/Monoidal.lean
@@ -129,9 +129,7 @@ lemma id_tensorHom_id (X Y : GradedObject I C) [HasTensor X Y] :
 lemma tensorHom_comp_tensorHom {X₁ X₂ X₃ Y₁ Y₂ Y₃ : GradedObject I C} (f₁ : X₁ ⟶ X₂) (f₂ : X₂ ⟶ X₃)
     (g₁ : Y₁ ⟶ Y₂) (g₂ : Y₂ ⟶ Y₃) [HasTensor X₁ Y₁] [HasTensor X₂ Y₂] [HasTensor X₃ Y₃] :
     tensorHom f₁ g₁ ≫ tensorHom f₂ g₂ = tensorHom (f₁ ≫ f₂) (g₁ ≫ g₂) := by
-  dsimp only [tensorHom, mapBifunctorMapMap]
-  rw [← mapMap_comp]
-  apply congr_mapMap
+  ext
   simp
 
 /-- The isomorphism `tensorObj X₁ Y₁ ≅ tensorObj X₂ Y₂` induced by isomorphisms of graded


### PR DESCRIPTION
---
<details>
<summary>Show trace profiling of <code>tensorHom_comp_tensorHom</code>: 23 ms before, 12 ms after  🎉</summary>

### Trace profiling of `tensorHom_comp_tensorHom` before PR 32114
```diff
diff --git a/Mathlib/CategoryTheory/GradedObject/Monoidal.lean b/Mathlib/CategoryTheory/GradedObject/Monoidal.lean
index ae1cb184b9..665df6b5fd 100644
--- a/Mathlib/CategoryTheory/GradedObject/Monoidal.lean
+++ b/Mathlib/CategoryTheory/GradedObject/Monoidal.lean
@@ -125,6 +125,7 @@ lemma id_tensorHom_id (X Y : GradedObject I C) [HasTensor X Y] :
 
 @[deprecated (since := "2025-07-14")] alias tensor_id := id_tensorHom_id
 
+set_option trace.profiler true in
 @[reassoc]
 lemma tensorHom_comp_tensorHom {X₁ X₂ X₃ Y₁ Y₂ Y₃ : GradedObject I C} (f₁ : X₁ ⟶ X₂) (f₂ : X₂ ⟶ X₃)
     (g₁ : Y₁ ⟶ Y₂) (g₂ : Y₂ ⟶ Y₃) [HasTensor X₁ Y₁] [HasTensor X₂ Y₂] [HasTensor X₃ Y₃] :
```
```
ℹ [787/787] Built Mathlib.CategoryTheory.GradedObject.Monoidal (4.1s)
info: Mathlib/CategoryTheory/GradedObject/Monoidal.lean:129:0: [Elab.command] [0.039159] @[reassoc]
    theorem tensorHom_comp_tensorHom {X₁ X₂ X₃ Y₁ Y₂ Y₃ : GradedObject I C} (f₁ : X₁ ⟶ X₂) (f₂ : X₂ ⟶ X₃) (g₁ : Y₁ ⟶ Y₂)
        (g₂ : Y₂ ⟶ Y₃) [HasTensor X₁ Y₁] [HasTensor X₂ Y₂] [HasTensor X₃ Y₃] :
        tensorHom f₁ g₁ ≫ tensorHom f₂ g₂ = tensorHom (f₁ ≫ f₂) (g₁ ≫ g₂) :=
      by
      dsimp only [tensorHom, mapBifunctorMapMap]
      rw [← mapMap_comp]
      apply congr_mapMap
      simp
  [Elab.definition.header] [0.011692] CategoryTheory.GradedObject.Monoidal.tensorHom_comp_tensorHom
  [Elab.attribute] [0.026993] applying [reassoc]
info: Mathlib/CategoryTheory/GradedObject/Monoidal.lean:129:0: [Elab.command] [0.039185] @[reassoc]
    lemma tensorHom_comp_tensorHom {X₁ X₂ X₃ Y₁ Y₂ Y₃ : GradedObject I C} (f₁ : X₁ ⟶ X₂) (f₂ : X₂ ⟶ X₃) (g₁ : Y₁ ⟶ Y₂)
        (g₂ : Y₂ ⟶ Y₃) [HasTensor X₁ Y₁] [HasTensor X₂ Y₂] [HasTensor X₃ Y₃] :
        tensorHom f₁ g₁ ≫ tensorHom f₂ g₂ = tensorHom (f₁ ≫ f₂) (g₁ ≫ g₂) :=
      by
      dsimp only [tensorHom, mapBifunctorMapMap]
      rw [← mapMap_comp]
      apply congr_mapMap
      simp
info: Mathlib/CategoryTheory/GradedObject/Monoidal.lean:129:0: [Elab.async] [0.023309] elaborating proof of CategoryTheory.GradedObject.Monoidal.tensorHom_comp_tensorHom
  [Elab.definition.value] [0.022564] CategoryTheory.GradedObject.Monoidal.tensorHom_comp_tensorHom
    [Elab.step] [0.022055] 
          dsimp only [tensorHom, mapBifunctorMapMap]
          rw [← mapMap_comp]
          apply congr_mapMap
          simp
      [Elab.step] [0.022051] 
            dsimp only [tensorHom, mapBifunctorMapMap]
            rw [← mapMap_comp]
            apply congr_mapMap
            simp
        [Elab.step] [0.011861] simp
Build completed successfully (787 jobs).
```

### Trace profiling of `tensorHom_comp_tensorHom` after PR 32114
```diff
diff --git a/Mathlib/CategoryTheory/GradedObject/Monoidal.lean b/Mathlib/CategoryTheory/GradedObject/Monoidal.lean
index ae1cb184b9..6a58ba7490 100644
--- a/Mathlib/CategoryTheory/GradedObject/Monoidal.lean
+++ b/Mathlib/CategoryTheory/GradedObject/Monoidal.lean
@@ -125,13 +125,12 @@ lemma id_tensorHom_id (X Y : GradedObject I C) [HasTensor X Y] :
 
 @[deprecated (since := "2025-07-14")] alias tensor_id := id_tensorHom_id
 
+set_option trace.profiler true in
 @[reassoc]
 lemma tensorHom_comp_tensorHom {X₁ X₂ X₃ Y₁ Y₂ Y₃ : GradedObject I C} (f₁ : X₁ ⟶ X₂) (f₂ : X₂ ⟶ X₃)
     (g₁ : Y₁ ⟶ Y₂) (g₂ : Y₂ ⟶ Y₃) [HasTensor X₁ Y₁] [HasTensor X₂ Y₂] [HasTensor X₃ Y₃] :
     tensorHom f₁ g₁ ≫ tensorHom f₂ g₂ = tensorHom (f₁ ≫ f₂) (g₁ ≫ g₂) := by
-  dsimp only [tensorHom, mapBifunctorMapMap]
-  rw [← mapMap_comp]
-  apply congr_mapMap
+  ext
   simp
 
 /-- The isomorphism `tensorObj X₁ Y₁ ≅ tensorObj X₂ Y₂` induced by isomorphisms of graded
```
```
ℹ [787/787] Built Mathlib.CategoryTheory.GradedObject.Monoidal (4.3s)
info: Mathlib/CategoryTheory/GradedObject/Monoidal.lean:129:0: [Elab.command] [0.029001] @[reassoc]
    theorem tensorHom_comp_tensorHom {X₁ X₂ X₃ Y₁ Y₂ Y₃ : GradedObject I C} (f₁ : X₁ ⟶ X₂) (f₂ : X₂ ⟶ X₃) (g₁ : Y₁ ⟶ Y₂)
        (g₂ : Y₂ ⟶ Y₃) [HasTensor X₁ Y₁] [HasTensor X₂ Y₂] [HasTensor X₃ Y₃] :
        tensorHom f₁ g₁ ≫ tensorHom f₂ g₂ = tensorHom (f₁ ≫ f₂) (g₁ ≫ g₂) :=
      by
      ext
      simp
  [Elab.definition.header] [0.011786] CategoryTheory.GradedObject.Monoidal.tensorHom_comp_tensorHom
  [Elab.attribute] [0.016709] applying [reassoc]
info: Mathlib/CategoryTheory/GradedObject/Monoidal.lean:129:0: [Elab.command] [0.029023] @[reassoc]
    lemma tensorHom_comp_tensorHom {X₁ X₂ X₃ Y₁ Y₂ Y₃ : GradedObject I C} (f₁ : X₁ ⟶ X₂) (f₂ : X₂ ⟶ X₃) (g₁ : Y₁ ⟶ Y₂)
        (g₂ : Y₂ ⟶ Y₃) [HasTensor X₁ Y₁] [HasTensor X₂ Y₂] [HasTensor X₃ Y₃] :
        tensorHom f₁ g₁ ≫ tensorHom f₂ g₂ = tensorHom (f₁ ≫ f₂) (g₁ ≫ g₂) :=
      by
      ext
      simp
info: Mathlib/CategoryTheory/GradedObject/Monoidal.lean:129:0: [Elab.async] [0.012717] elaborating proof of CategoryTheory.GradedObject.Monoidal.tensorHom_comp_tensorHom
  [Elab.definition.value] [0.012146] CategoryTheory.GradedObject.Monoidal.tensorHom_comp_tensorHom
    [Elab.step] [0.011634] 
          ext
          simp
      [Elab.step] [0.011625] 
            ext
            simp
Build completed successfully (787 jobs).
```
</details>

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

When merging, all the commits will be squashed into a single commit
listing all co-authors.

Co-authors in the squash commit are gathered from two sources:

First, all authors of commits to this PR branch are included. Thus,
one way to add co-authors is to include at least one commit authored by
each co-author among the commits in the pull request. If necessary, you
may create empty commits to indicate co-authorship, using commands like so:

git commit --author="Author Name <author@email.com>" --allow-empty -m "add Author Name as coauthor"

Second, co-authors can also be listed in lines at the very bottom of
the commit message (that is, directly before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines
at the bottom of the commit message (before the `---`, and also before
any "Co-authored-by" lines) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
