### PR TITLE
[Merged by Bors] - chore(Data/Set): golf entire `Injective.compl_image_eq` using `grind`

### DIFF
--- a/Mathlib/Data/Set/Image.lean
+++ b/Mathlib/Data/Set/Image.lean
@@ -1104,10 +1104,7 @@ alias ⟨Injective.existsUnique_of_mem_range, _⟩ := Injective.mem_range_iff_ex
 
 theorem Injective.compl_image_eq (hf : Injective f) (s : Set α) :
     (f '' s)ᶜ = f '' sᶜ ∪ (range f)ᶜ := by
-  ext y
-  rcases em (y ∈ range f) with (⟨x, rfl⟩ | hx)
-  · simp [hf.eq_iff]
-  · grind
+  grind
 
 theorem LeftInverse.image_image {g : β → α} (h : LeftInverse g f) (s : Set α) :
     g '' (f '' s) = s := by rw [← image_comp, h.comp_eq_id, image_id]


### PR DESCRIPTION
---
<details>
<summary>Show trace profiling of <code>Injective.compl_image_eq</code>: 193 ms before, 210 ms after </summary>

### Trace profiling of `Injective.compl_image_eq` before PR 32115
```diff
diff --git a/Mathlib/Data/Set/Image.lean b/Mathlib/Data/Set/Image.lean
index c7c483f62a..209b673ed7 100644
--- a/Mathlib/Data/Set/Image.lean
+++ b/Mathlib/Data/Set/Image.lean
@@ -1102,6 +1102,7 @@ theorem Injective.mem_range_iff_existsUnique (hf : Injective f) {b : β} :
 
 alias ⟨Injective.existsUnique_of_mem_range, _⟩ := Injective.mem_range_iff_existsUnique
 
+set_option trace.profiler true in
 theorem Injective.compl_image_eq (hf : Injective f) (s : Set α) :
     (f '' s)ᶜ = f '' sᶜ ∪ (range f)ᶜ := by
   ext y
```
```
ℹ [392/392] Built Mathlib.Data.Set.Image (2.2s)
info: Mathlib/Data/Set/Image.lean:1106:0: [Elab.async] [0.193744] elaborating proof of Function.Injective.compl_image_eq
  [Elab.definition.value] [0.193184] Function.Injective.compl_image_eq
    [Elab.step] [0.192867] 
          ext y
          rcases em (y ∈ range f) with (⟨x, rfl⟩ | hx)
          · simp [hf.eq_iff]
          · grind
      [Elab.step] [0.192860] 
            ext y
            rcases em (y ∈ range f) with (⟨x, rfl⟩ | hx)
            · simp [hf.eq_iff]
            · grind
        [Elab.step] [0.012563] · simp [hf.eq_iff]
          [Elab.step] [0.012542] simp [hf.eq_iff]
            [Elab.step] [0.012539] simp [hf.eq_iff]
              [Elab.step] [0.012534] simp [hf.eq_iff]
        [Elab.step] [0.179126] · grind
          [Elab.step] [0.179046] grind
            [Elab.step] [0.179042] grind
              [Elab.step] [0.179035] grind
Build completed successfully (392 jobs).
```

### Trace profiling of `Injective.compl_image_eq` after PR 32115
```diff
diff --git a/Mathlib/Data/Set/Image.lean b/Mathlib/Data/Set/Image.lean
index c7c483f62a..6c79196116 100644
--- a/Mathlib/Data/Set/Image.lean
+++ b/Mathlib/Data/Set/Image.lean
@@ -1102,12 +1102,10 @@ theorem Injective.mem_range_iff_existsUnique (hf : Injective f) {b : β} :
 
 alias ⟨Injective.existsUnique_of_mem_range, _⟩ := Injective.mem_range_iff_existsUnique
 
+set_option trace.profiler true in
 theorem Injective.compl_image_eq (hf : Injective f) (s : Set α) :
     (f '' s)ᶜ = f '' sᶜ ∪ (range f)ᶜ := by
-  ext y
-  rcases em (y ∈ range f) with (⟨x, rfl⟩ | hx)
-  · simp [hf.eq_iff]
-  · grind
+  grind
 
 theorem LeftInverse.image_image {g : β → α} (h : LeftInverse g f) (s : Set α) :
     g '' (f '' s) = s := by rw [← image_comp, h.comp_eq_id, image_id]
```
```
ℹ [392/392] Built Mathlib.Data.Set.Image (2.2s)
info: Mathlib/Data/Set/Image.lean:1106:0: [Elab.async] [0.209991] elaborating proof of Function.Injective.compl_image_eq
  [Elab.definition.value] [0.209776] Function.Injective.compl_image_eq
    [Elab.step] [0.209667] grind
      [Elab.step] [0.209661] grind
        [Elab.step] [0.209652] grind
Build completed successfully (392 jobs).
```
</details>

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

When merging, all the commits will be squashed into a single commit
listing all co-authors.

Co-authors in the squash commit are gathered from two sources:

First, all authors of commits to this PR branch are included. Thus,
one way to add co-authors is to include at least one commit authored by
each co-author among the commits in the pull request. If necessary, you
may create empty commits to indicate co-authorship, using commands like so:

git commit --author="Author Name <author@email.com>" --allow-empty -m "add Author Name as coauthor"

Second, co-authors can also be listed in lines at the very bottom of
the commit message (that is, directly before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines
at the bottom of the commit message (before the `---`, and also before
any "Co-authored-by" lines) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
