### PR TITLE
[Merged by Bors] - feat(Analysis): `tendsto_zpow_nhdsNE_zero_cobounded`

### DIFF
--- a/Mathlib/Analysis/Meromorphic/Order.lean
+++ b/Mathlib/Analysis/Meromorphic/Order.lean
@@ -174,7 +174,7 @@ lemma tendsto_cobounded_of_meromorphicOrderAt_neg (ho : meromorphicOrderAt f x <
         simpa using this.tendsto
       · filter_upwards [self_mem_nhdsWithin] with y hy
         simpa [sub_eq_zero] using hy
-    apply Tendsto.comp (NormedField.tendsto_norm_zpow_nhdsNE_zero_atTop m_neg) this
+    exact (tendsto_norm_cobounded_atTop.comp (tendsto_zpow_nhdsNE_zero_cobounded m_neg)).comp this
   apply A.congr'
   filter_upwards [hg] with z hz using by simp [hz]
 

--- a/Mathlib/Analysis/Normed/Field/Lemmas.lean
+++ b/Mathlib/Analysis/Normed/Field/Lemmas.lean
@@ -135,8 +135,8 @@ lemma tendsto_zpow_nhdsNE_zero_atTop {m : ℤ} (hm : m < 0) :
     Tendsto (· ^ m) (𝓝[≠] 0) (cobounded α) := by
   obtain ⟨m, rfl⟩ := neg_surjective m
   lift m to ℕ using by cutsat
-  simpa [Function.comp_def] using (SeminormedRing.tendsto_pow_cobounded_cobounded
-    (by cutsat)).comp tendsto_inv₀_nhdsNE_zero
+  simpa [Function.comp_def] using
+    (tendsto_pow_cobounded_cobounded (by cutsat)).comp tendsto_inv₀_nhdsNE_zero
 
 @[deprecated tendsto_zpow_nhdsNE_zero_atTop (since := "2025-11-26")]
 lemma NormedField.tendsto_norm_zpow_nhdsNE_zero_atTop {m : ℤ} (hm : m < 0) :

--- a/Mathlib/Analysis/Normed/Field/Lemmas.lean
+++ b/Mathlib/Analysis/Normed/Field/Lemmas.lean
@@ -80,8 +80,10 @@ lemma inv_cobounded₀ : (cobounded α)⁻¹ = 𝓝[≠] 0 := by
   simp only [comap_comap, Function.comp_def, norm_inv]
 
 @[simp]
-lemma inv_nhdsWithin_ne_zero : (𝓝[≠] (0 : α))⁻¹ = cobounded α := by
+lemma inv_nhdsNE_zero : (𝓝[≠] (0 : α))⁻¹ = cobounded α := by
   rw [← inv_cobounded₀, inv_inv]
+
+@[deprecated (since := "2025-11-26")] alias inv_nhdsWithin_ne_zero := inv_nhdsNE_zero
 
 lemma tendsto_inv₀_cobounded' : Tendsto Inv.inv (cobounded α) (𝓝[≠] 0) :=
   inv_cobounded₀.le
@@ -89,8 +91,11 @@ lemma tendsto_inv₀_cobounded' : Tendsto Inv.inv (cobounded α) (𝓝[≠] 0) :
 theorem tendsto_inv₀_cobounded : Tendsto Inv.inv (cobounded α) (𝓝 0) :=
   tendsto_inv₀_cobounded'.mono_right inf_le_left
 
-lemma tendsto_inv₀_nhdsWithin_ne_zero : Tendsto Inv.inv (𝓝[≠] 0) (cobounded α) :=
-  inv_nhdsWithin_ne_zero.le
+lemma tendsto_inv₀_nhdsNE_zero : Tendsto Inv.inv (𝓝[≠] 0) (cobounded α) :=
+  inv_nhdsNE_zero.le
+
+@[deprecated (since := "2025-11-26")]
+alias tendsto_inv₀_nhdsWithin_ne_zero := tendsto_inv₀_nhdsNE_zero
 
 end Filter
 
@@ -121,16 +126,18 @@ instance (priority := 100) NormedDivisionRing.to_isTopologicalDivisionRing :
     IsTopologicalDivisionRing α where
 
 lemma NormedField.tendsto_norm_inv_nhdsNE_zero_atTop : Tendsto (fun x : α ↦ ‖x⁻¹‖) (𝓝[≠] 0) atTop :=
-  (tendsto_inv_nhdsGT_zero.comp tendsto_norm_nhdsNE_zero).congr fun x ↦ (norm_inv x).symm
+  tendsto_norm_cobounded_atTop.comp tendsto_inv₀_nhdsNE_zero
+
+lemma NormedField.tendsto_zpow_nhdsNE_zero_atTop {m : ℤ} (hm : m < 0) :
+    Tendsto (· ^ m) (𝓝[≠] 0) (Bornology.cobounded α) := by
+  obtain ⟨m, rfl⟩ := neg_surjective m
+  lift m to ℕ using by cutsat
+  simpa [Function.comp_def] using (SeminormedRing.tendsto_pow_cobounded_cobounded
+    (by cutsat)).comp tendsto_inv₀_nhdsNE_zero
 
 lemma NormedField.tendsto_norm_zpow_nhdsNE_zero_atTop {m : ℤ} (hm : m < 0) :
-    Tendsto (fun x : α ↦ ‖x ^ m‖) (𝓝[≠] 0) atTop := by
-  obtain ⟨m, rfl⟩ := neg_surjective m
-  rw [neg_lt_zero] at hm
-  lift m to ℕ using hm.le
-  rw [Int.natCast_pos] at hm
-  simp only [norm_pow, zpow_neg, zpow_natCast, ← inv_pow]
-  exact (tendsto_pow_atTop hm.ne').comp NormedField.tendsto_norm_inv_nhdsNE_zero_atTop
+    Tendsto (fun x : α ↦ ‖x ^ m‖) (𝓝[≠] 0) atTop :=
+  tendsto_norm_cobounded_atTop.comp (tendsto_zpow_nhdsNE_zero_atTop hm)
 
 end NormedDivisionRing
 

--- a/Mathlib/Analysis/Normed/Field/Lemmas.lean
+++ b/Mathlib/Analysis/Normed/Field/Lemmas.lean
@@ -131,17 +131,17 @@ lemma tendsto_norm_inv_nhdsNE_zero_atTop : Tendsto (fun x : α ↦ ‖x⁻¹‖)
 @[deprecated (since := "2025-11-26")]
 alias NormedField.tendsto_norm_inv_nhdsNE_zero_atTop := tendsto_norm_inv_nhdsNE_zero_atTop
 
-lemma tendsto_zpow_nhdsNE_zero_atTop {m : ℤ} (hm : m < 0) :
+lemma tendsto_zpow_nhdsNE_zero_cobounded {m : ℤ} (hm : m < 0) :
     Tendsto (· ^ m) (𝓝[≠] 0) (cobounded α) := by
   obtain ⟨m, rfl⟩ := neg_surjective m
   lift m to ℕ using by cutsat
   simpa [Function.comp_def] using
     (tendsto_pow_cobounded_cobounded (by cutsat)).comp tendsto_inv₀_nhdsNE_zero
 
-@[deprecated tendsto_zpow_nhdsNE_zero_atTop (since := "2025-11-26")]
+@[deprecated tendsto_zpow_nhdsNE_zero_cobounded (since := "2025-11-26")]
 lemma NormedField.tendsto_norm_zpow_nhdsNE_zero_atTop {m : ℤ} (hm : m < 0) :
     Tendsto (fun x : α ↦ ‖x ^ m‖) (𝓝[≠] 0) atTop :=
-  tendsto_norm_cobounded_atTop.comp (tendsto_zpow_nhdsNE_zero_atTop hm)
+  tendsto_norm_cobounded_atTop.comp (tendsto_zpow_nhdsNE_zero_cobounded hm)
 
 end NormedDivisionRing
 
@@ -193,7 +193,7 @@ protected lemma continuousAt_zpow : ContinuousAt (fun x ↦ x ^ n) x ↔ x ≠ 0
   contrapose!
   rintro ⟨rfl, hm⟩ hc
   exact not_tendsto_atTop_of_tendsto_nhds (hc.tendsto.mono_left nhdsWithin_le_nhds).norm
-    (NormedField.tendsto_norm_zpow_nhdsNE_zero_atTop hm)
+    (tendsto_norm_cobounded_atTop.comp <| tendsto_zpow_nhdsNE_zero_cobounded hm)
 
 @[simp]
 protected lemma continuousAt_inv : ContinuousAt Inv.inv x ↔ x ≠ 0 := by

--- a/Mathlib/Analysis/Normed/Field/Lemmas.lean
+++ b/Mathlib/Analysis/Normed/Field/Lemmas.lean
@@ -125,16 +125,20 @@ instance (priority := 100) NormedDivisionRing.to_continuousInv₀ : ContinuousIn
 instance (priority := 100) NormedDivisionRing.to_isTopologicalDivisionRing :
     IsTopologicalDivisionRing α where
 
-lemma NormedField.tendsto_norm_inv_nhdsNE_zero_atTop : Tendsto (fun x : α ↦ ‖x⁻¹‖) (𝓝[≠] 0) atTop :=
+lemma tendsto_norm_inv_nhdsNE_zero_atTop : Tendsto (fun x : α ↦ ‖x⁻¹‖) (𝓝[≠] 0) atTop :=
   tendsto_norm_cobounded_atTop.comp tendsto_inv₀_nhdsNE_zero
 
-lemma NormedField.tendsto_zpow_nhdsNE_zero_atTop {m : ℤ} (hm : m < 0) :
-    Tendsto (· ^ m) (𝓝[≠] 0) (Bornology.cobounded α) := by
+@[deprecated (since := "2025-11-26")]
+alias NormedField.tendsto_norm_inv_nhdsNE_zero_atTop := tendsto_norm_inv_nhdsNE_zero_atTop
+
+lemma tendsto_zpow_nhdsNE_zero_atTop {m : ℤ} (hm : m < 0) :
+    Tendsto (· ^ m) (𝓝[≠] 0) (cobounded α) := by
   obtain ⟨m, rfl⟩ := neg_surjective m
   lift m to ℕ using by cutsat
   simpa [Function.comp_def] using (SeminormedRing.tendsto_pow_cobounded_cobounded
     (by cutsat)).comp tendsto_inv₀_nhdsNE_zero
 
+@[deprecated tendsto_zpow_nhdsNE_zero_atTop (since := "2025-11-26")]
 lemma NormedField.tendsto_norm_zpow_nhdsNE_zero_atTop {m : ℤ} (hm : m < 0) :
     Tendsto (fun x : α ↦ ‖x ^ m‖) (𝓝[≠] 0) atTop :=
   tendsto_norm_cobounded_atTop.comp (tendsto_zpow_nhdsNE_zero_atTop hm)

--- a/Mathlib/Analysis/Normed/Field/Lemmas.lean
+++ b/Mathlib/Analysis/Normed/Field/Lemmas.lean
@@ -192,8 +192,8 @@ protected lemma continuousAt_zpow : ContinuousAt (fun x ↦ x ^ n) x ↔ x ≠ 0
   refine ⟨?_, continuousAt_zpow₀ _ _⟩
   contrapose!
   rintro ⟨rfl, hm⟩ hc
-  exact not_tendsto_atTop_of_tendsto_nhds (hc.tendsto.mono_left nhdsWithin_le_nhds).norm
-    (tendsto_norm_cobounded_atTop.comp <| tendsto_zpow_nhdsNE_zero_cobounded hm)
+  exact (hc.tendsto.mono_left nhdsWithin_le_nhds).not_tendsto (Metric.disjoint_nhds_cobounded _)
+    (tendsto_zpow_nhdsNE_zero_cobounded hm)
 
 @[simp]
 protected lemma continuousAt_inv : ContinuousAt Inv.inv x ↔ x ≠ 0 := by

--- a/Mathlib/Analysis/Normed/Ring/Lemmas.lean
+++ b/Mathlib/Analysis/Normed/Ring/Lemmas.lean
@@ -75,6 +75,12 @@ lemma RingHomIsometric.inv {𝕜₁ 𝕜₂ : Type*} [SeminormedRing 𝕜₁] [S
     RingHomIsometric σ' :=
   ⟨fun {x} ↦ by rw [← RingHomIsometric.norm_map (σ := σ), RingHomInvPair.comp_apply_eq₂]⟩
 
+lemma SeminormedRing.tendsto_pow_cobounded_cobounded
+    [NormOneClass α] [NormMulClass α] {m : ℕ} (hm : m ≠ 0) :
+    Tendsto (· ^ m) (Bornology.cobounded α) (Bornology.cobounded α) := by
+  simpa [← tendsto_norm_atTop_iff_cobounded] using
+    (tendsto_pow_atTop hm).comp (tendsto_norm_cobounded_atTop (E := α))
+
 end SeminormedRing
 
 section NonUnitalNormedRing

--- a/Mathlib/Analysis/Normed/Ring/Lemmas.lean
+++ b/Mathlib/Analysis/Normed/Ring/Lemmas.lean
@@ -75,9 +75,9 @@ lemma RingHomIsometric.inv {𝕜₁ 𝕜₂ : Type*} [SeminormedRing 𝕜₁] [S
     RingHomIsometric σ' :=
   ⟨fun {x} ↦ by rw [← RingHomIsometric.norm_map (σ := σ), RingHomInvPair.comp_apply_eq₂]⟩
 
-lemma SeminormedRing.tendsto_pow_cobounded_cobounded
+lemma tendsto_pow_cobounded_cobounded
     [NormOneClass α] [NormMulClass α] {m : ℕ} (hm : m ≠ 0) :
-    Tendsto (· ^ m) (Bornology.cobounded α) (Bornology.cobounded α) := by
+    Tendsto (· ^ m) (cobounded α) (cobounded α) := by
   simpa [← tendsto_norm_atTop_iff_cobounded] using
     (tendsto_pow_atTop hm).comp (tendsto_norm_cobounded_atTop (E := α))
 


### PR DESCRIPTION

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

When merging, all the commits will be squashed into a single commit
listing all co-authors.

Co-authors in the squash commit are gathered from two sources:

First, all authors of commits to this PR branch are included. Thus,
one way to add co-authors is to include at least one commit authored by
each co-author among the commits in the pull request. If necessary, you
may create empty commits to indicate co-authorship, using commands like so:

git commit --author="Author Name <author@email.com>" --allow-empty -m "add Author Name as coauthor"

Second, co-authors can also be listed in lines at the very bottom of
the commit message (that is, directly before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines
at the bottom of the commit message (before the `---`, and also before
any "Co-authored-by" lines) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
