### PR TITLE
[Merged by Bors] - feat(Algebra/Polynomial/Factors): Composition with negation of `X` is multiplicative

### DIFF
--- a/Mathlib/Algebra/Polynomial/Eval/Defs.lean
+++ b/Mathlib/Algebra/Polynomial/Eval/Defs.lean
@@ -451,6 +451,11 @@ theorem mul_comp {R : Type*} [CommSemiring R] (p q r : R[X]) :
   eval₂_mul _ _
 
 @[simp]
+theorem mul_comp_neg_X {R : Type*} [Ring R] (p q : R[X]) :
+    (p * q).comp (-X) = p.comp (-X) * q.comp (-X) :=
+  eval₂_mul_noncomm C (-X) fun _ ↦ Commute.symm (commute_X _).neg_left
+
+@[simp]
 theorem pow_comp {R : Type*} [CommSemiring R] (p q : R[X]) (n : ℕ) :
     (p ^ n).comp q = p.comp q ^ n :=
   (MonoidHom.mk (OneHom.mk (fun r : R[X] => r.comp q) one_comp) fun r s => mul_comp r s q).map_pow

--- a/Mathlib/Algebra/Polynomial/Factors.lean
+++ b/Mathlib/Algebra/Polynomial/Factors.lean
@@ -165,6 +165,14 @@ protected theorem Splits.neg {f : R[X]} (hf : Splits f) : Splits (-f) := by
 theorem splits_neg_iff {f : R[X]} : Splits (-f) ↔ Splits f :=
   ⟨fun hf ↦ neg_neg f ▸ hf.neg, .neg⟩
 
+theorem Splits.comp_neg_X {f : R[X]} (hf : f.Splits) : (f.comp (-X)).Splits := by
+  refine Submonoid.closure_induction ?_ (by simp)
+    (fun f g _ _ hf hg ↦ mul_comp_neg_X f g ▸ hf.mul hg) hf
+  · rintro f (⟨a, rfl⟩ | ⟨a, rfl⟩)
+    · simp
+    · rw [add_comp, X_comp, C_comp, neg_add_eq_sub, ← neg_sub]
+      exact (X_sub_C a).neg
+
 end Ring
 
 section CommRing

--- a/Mathlib/Algebra/Polynomial/Splits.lean
+++ b/Mathlib/Algebra/Polynomial/Splits.lean
@@ -145,9 +145,6 @@ theorem Splits.comp_X_add_C (a : L) {f : L[X]}
     (h : f.Splits) : (f.comp (X + C a)).Splits :=
   Splits.comp_of_degree_le_one (degree_X_add_C a).le h
 
-theorem Splits.comp_neg_X {f : L[X]} (h : f.Splits) : (f.comp (-X)).Splits :=
-  Splits.comp_of_degree_le_one (by rw [degree_neg, degree_X]) h
-
 variable (i)
 
 theorem exists_root_of_splits' {f : K[X]} (hs : Splits (f.map i)) (hf0 : degree (f.map i) ≠ 0) :


### PR DESCRIPTION
This PR proves `(p * q).comp (-X) = p.comp (-X) * q.comp (-X)` for rings (possibly noncommutative) and deduces that `f.Splits` implies `(f.comp (-X)).Splits`.

This generalizes the current theorem `Polynomial.Splits.comp_neg_X` so that the coefficients may be taken from a `Ring` instead of a `Field`

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

When merging, all the commits will be squashed into a single commit
listing all co-authors.

Co-authors in the squash commit are gathered from two sources:

First, all authors of commits to this PR branch are included. Thus,
one way to add co-authors is to include at least one commit authored by
each co-author among the commits in the pull request. If necessary, you
may create empty commits to indicate co-authorship, using commands like so:

git commit --author="Author Name <author@email.com>" --allow-empty -m "add Author Name as coauthor"

Second, co-authors can also be listed in lines at the very bottom of
the commit message (that is, directly before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines
at the bottom of the commit message (before the `---`, and also before
any "Co-authored-by" lines) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
