### PR TITLE
[Merged by Bors] - feat(LinearAlgebra): rank of commutative semiring over itself

### DIFF
--- a/Mathlib/LinearAlgebra/Dimension/Basic.lean
+++ b/Mathlib/LinearAlgebra/Dimension/Basic.lean
@@ -229,6 +229,11 @@ theorem rank_eq_of_equiv_equiv (i : R → R') (j : M ≃+ M₁)
 end
 end Semiring
 
+/-- TODO: prove that nontrivial commutative semirings satisfy the strong rank condition,
+following *Free sets and free subsemimodules in a semimodule* by Yi-Jia Tan, Theorem 3.2.
+
+Rings `R` that fail the strong rank condition but satisfy `rank R R = 1` are expected to exist, see
+https://mathoverflow.net/questions/317422/rings-that-fail-to-satisfy-the-strong-rank-condition. -/
 theorem CommSemiring.rank_self (R) [CommSemiring R] : Module.rank R R = 1 := by
   nontriviality R
   rw [le_antisymm_iff, ← not_lt, ← Order.succ_le_iff, ← Nat.cast_one, ← nat_succ,

--- a/Mathlib/LinearAlgebra/Dimension/Basic.lean
+++ b/Mathlib/LinearAlgebra/Dimension/Basic.lean
@@ -6,7 +6,7 @@ Authors: Mario Carneiro, Johannes Hölzl, Sander Dahmen, Kim Morrison
 module
 
 public import Mathlib.Algebra.Algebra.Tower
-public import Mathlib.LinearAlgebra.LinearIndependent.Basic
+public import Mathlib.LinearAlgebra.Basis.Basic
 public import Mathlib.Data.Set.Card
 
 /-!
@@ -106,10 +106,60 @@ theorem _root_.LinearIndepOn.encard_le_toENat_rank {ι : Type*} {v : ι → M} {
 
 end LinearIndependent
 
+namespace Module
+
+variable [Semiring R] [AddCommMonoid M] [Module R M] [Nontrivial R]
+
+/-- Note: if the rank of a module is infinite, it may not contain a linear independent subset
+with cardinality equal to the rank, see
+https://mathoverflow.net/questions/263020/maximum-cardinal-of-a-set-of-linearly-independent-vectors-in-a-module. -/
+theorem le_rank_iff_exists_finset {n : ℕ} :
+    n ≤ Module.rank R M ↔ ∃ s : Finset M, s.card = n ∧ LinearIndepOn R id (s : Set M) where
+  mp le := by
+    contrapose! le
+    obtain _ | n := n; · simp at le
+    rw [Module.rank, nat_succ, Order.lt_succ_iff, ciSup_le_iff (bddAbove_range _)]
+    intro s
+    contrapose! le
+    rw [← Order.succ_le_iff, ← nat_succ] at le
+    have ⟨t, ht⟩ := exists_finset_eq_card le
+    exact ⟨t.map (.subtype _), by simpa using ht.symm, s.2.mono <| by simp⟩
+  mpr := fun ⟨s, card_s, ind_s⟩ ↦ ind_s.cardinal_le_rank'.trans_eq' <| by simpa using card_s.symm
+
+theorem le_rank_iff {n : ℕ} : n ≤ Module.rank R M ↔ ∃ v : Fin n → M, LinearIndependent R v := by
+  refine le_rank_iff_exists_finset.trans ⟨fun ⟨s, s_card, s_ind⟩ ↦ ?_, fun ⟨v, v_ind⟩ ↦ ?_⟩
+  · exact ⟨_, s_ind.comp _ (s.equivFinOfCardEq s_card).symm.injective⟩
+  · refine ⟨.map ⟨_, v_ind.injective⟩ .univ, by simp, ?_⟩
+    simpa using (linearIndepOn_id_range_iff v_ind.injective).mpr v_ind
+
+theorem le_rank_iff_exists_linearMap {n : ℕ} :
+    n ≤ Module.rank R M ↔ ∃ f : (Fin n → R) →ₗ[R] M, Injective f := by
+  refine le_rank_iff.trans ⟨fun ⟨v, v_ind⟩ ↦ ?_, fun ⟨f, f_inj⟩ ↦
+    ⟨_, (Module.Basis.ofEquivFun <| .refl ..).linearIndependent.map_injOn f f_inj.injOn⟩⟩
+  have := Injective.comp v_ind (Finsupp.linearEquivFunOnFinite R ..).symm.injective
+  exact ⟨Finsupp.linearCombination .. ∘ₗ _, this⟩
+
+end Module
+
 section SurjectiveInjective
 
 section Semiring
 variable [Semiring R] [AddCommMonoid M] [Module R M] [Semiring R']
+
+variable (R M) in
+@[nontriviality, simp]
+theorem rank_subsingleton [Subsingleton R] : Module.rank R M = 1 := by
+  rw [Module.rank_def, ciSup_eq_of_forall_le_of_forall_lt_exists_gt]
+  · have := Module.subsingleton R M
+    simp [Set.subsingleton_of_subsingleton]
+  · intro w hw
+    exact ⟨⟨{0}, LinearIndepOn.of_subsingleton⟩, hw.trans_eq (Cardinal.mk_singleton _).symm⟩
+
+theorem Module.one_le_rank_iff : 1 ≤ Module.rank R M ↔ ∃ f : R →ₗ[R] M, Injective f := by
+  nontriviality R
+  refine le_rank_iff_exists_linearMap.trans ⟨fun ⟨f, hf⟩ ↦ ?_, fun ⟨f, hf⟩ ↦ ?_⟩
+  · exact ⟨f ∘ₗ _, by apply hf.comp (LinearEquiv.piUnique R ..).symm.injective⟩
+  · exact ⟨f ∘ₗ _, hf.comp (LinearEquiv.piUnique R ..).injective⟩
 
 section
 variable [AddCommMonoid M'] [Module R' M']
@@ -178,6 +228,17 @@ theorem rank_eq_of_equiv_equiv (i : R → R') (j : M ≃+ M₁)
 
 end
 end Semiring
+
+theorem CommSemiring.rank_self (R) [CommSemiring R] : Module.rank R R = 1 := by
+  nontriviality R
+  rw [le_antisymm_iff, ← not_lt, ← Order.succ_le_iff, ← Nat.cast_one, ← nat_succ,
+    Module.le_rank_iff_exists_linearMap, Nat.cast_one, Module.one_le_rank_iff]
+  refine ⟨fun ⟨f, inj⟩ ↦ ?_, _, (LinearEquiv.refl ..).injective⟩
+  have := inj (a₁ := f ![0, 1] • ![1, 0]) (a₂ := f ![1, 0] • ![0, 1]) <| by
+    simp_rw [map_smul, smul_eq_mul]; apply mul_comm
+  have h₁ : f ![0, 1] = 0 := by simpa using congr($this 0)
+  have h₂ : 0 = f ![1, 0] := by simpa using congr($this 1)
+  exact zero_ne_one (α := R) (by simpa using congr($(inj (h₁.trans h₂)) 1))
 
 section Ring
 variable [Ring R] [AddCommGroup M] [Module R M] [Ring R']

--- a/Mathlib/LinearAlgebra/Dimension/Finrank.lean
+++ b/Mathlib/LinearAlgebra/Dimension/Finrank.lean
@@ -68,6 +68,9 @@ noncomputable def finrank (R M : Type*) [Semiring R] [AddCommMonoid M] [Module R
 theorem finrank_eq_of_rank_eq {n : ℕ} (h : Module.rank R M = ↑n) : finrank R M = n := by
   simp [finrank, h]
 
+theorem CommSemiring.finrank_self (R) [CommSemiring R] : Module.finrank R R = 1 :=
+  finrank_eq_of_rank_eq (rank_self R)
+
 lemma rank_eq_one_iff_finrank_eq_one : Module.rank R M = 1 ↔ finrank R M = 1 :=
   Cardinal.toNat_eq_one.symm
 

--- a/Mathlib/LinearAlgebra/Dimension/Finrank.lean
+++ b/Mathlib/LinearAlgebra/Dimension/Finrank.lean
@@ -68,9 +68,6 @@ noncomputable def finrank (R M : Type*) [Semiring R] [AddCommMonoid M] [Module R
 theorem finrank_eq_of_rank_eq {n : ℕ} (h : Module.rank R M = ↑n) : finrank R M = n := by
   simp [finrank, h]
 
-theorem CommSemiring.finrank_self (R) [CommSemiring R] : Module.finrank R R = 1 :=
-  finrank_eq_of_rank_eq (rank_self R)
-
 lemma rank_eq_one_iff_finrank_eq_one : Module.rank R M = 1 ↔ finrank R M = 1 :=
   Cardinal.toNat_eq_one.symm
 
@@ -107,6 +104,9 @@ theorem finrank_le_finrank_of_rank_le_rank
 end Semiring
 
 end Module
+
+theorem CommSemiring.finrank_self (R) [CommSemiring R] : Module.finrank R R = 1 :=
+  finrank_eq_of_rank_eq (rank_self R)
 
 open Module
 

--- a/Mathlib/LinearAlgebra/Dimension/Subsingleton.lean
+++ b/Mathlib/LinearAlgebra/Dimension/Subsingleton.lean
@@ -29,14 +29,3 @@ theorem rank_punit : Module.rank R PUnit = 0 := rank_subsingleton' _ _
 theorem rank_bot : Module.rank R (⊥ : Submodule R M) = 0 := rank_subsingleton' _ _
 
 end
-
-@[nontriviality, simp]
-theorem rank_subsingleton [Subsingleton R] : Module.rank R M = 1 := by
-  haveI := Module.subsingleton R M
-  have : Nonempty { s : Set M // LinearIndepOn R id s} := ⟨⟨∅, linearIndepOn_empty _ _⟩⟩
-  rw [Module.rank_def, ciSup_eq_of_forall_le_of_forall_lt_exists_gt]
-  · rintro ⟨s, hs⟩
-    rw [Cardinal.mk_le_one_iff_set_subsingleton]
-    apply Set.subsingleton_of_subsingleton
-  intro w hw
-  exact ⟨⟨{0}, LinearIndepOn.of_subsingleton⟩, hw.trans_eq (Cardinal.mk_singleton _).symm⟩

--- a/Mathlib/SetTheory/Cardinal/Basic.lean
+++ b/Mathlib/SetTheory/Cardinal/Basic.lean
@@ -292,14 +292,19 @@ theorem succ_zero : succ (0 : Cardinal) = 1 := by norm_cast
 -- This works generally to prove inequalities between numeric cardinals.
 theorem one_lt_two : (1 : Cardinal) < 2 := by norm_cast
 
-theorem exists_finset_le_card (α : Type*) (n : ℕ) (h : n ≤ #α) :
-    ∃ s : Finset α, n ≤ s.card := by
+theorem exists_finset_eq_card {α} {n : ℕ} (h : n ≤ #α) :
+    ∃ s : Finset α, n = s.card := by
   obtain hα|hα := finite_or_infinite α
   · let hα := Fintype.ofFinite α
-    use Finset.univ
-    simpa only [mk_fintype, Nat.cast_le] using h
+    obtain ⟨t, -, rfl⟩ := @Finset.exists_subset_card_eq α .univ n <| by simpa using h
+    exact ⟨t, rfl⟩
   · obtain ⟨s, hs⟩ := Infinite.exists_subset_card_eq α n
-    exact ⟨s, hs.ge⟩
+    exact ⟨s, hs.symm⟩
+
+theorem exists_finset_le_card (α : Type*) (n : ℕ) (h : n ≤ #α) :
+    ∃ s : Finset α, n ≤ s.card :=
+  have ⟨s, eq⟩ := exists_finset_eq_card h
+  ⟨s, eq.le⟩
 
 theorem card_le_of {α : Type u} {n : ℕ} (H : ∀ s : Finset α, s.card ≤ n) : #α ≤ n := by
   contrapose! H


### PR DESCRIPTION
---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

When merging, all the commits will be squashed into a single commit
listing all co-authors.

Co-authors in the squash commit are gathered from two sources:

First, all authors of commits to this PR branch are included. Thus,
one way to add co-authors is to include at least one commit authored by
each co-author among the commits in the pull request. If necessary, you
may create empty commits to indicate co-authorship, using commands like so:

git commit --author="Author Name <author@email.com>" --allow-empty -m "add Author Name as coauthor"

Second, co-authors can also be listed in lines at the very bottom of
the commit message (that is, directly before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines
at the bottom of the commit message (before the `---`, and also before
any "Co-authored-by" lines) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
