### PR TITLE
[Merged by Bors] - feat(SimpleGraph/Walks/Operations): expand basic drop/take/reverse API

### DIFF
--- a/Mathlib/Combinatorics/SimpleGraph/Walks/Operations.lean
+++ b/Mathlib/Combinatorics/SimpleGraph/Walks/Operations.lean
@@ -158,6 +158,9 @@ theorem reverse_singleton {u v : V} (h : G.Adj u v) : (cons h nil).reverse = con
   rfl
 
 @[simp]
+theorem reverse_toWalk {u v : V} (h : G.Adj u v) : h.toWalk.reverse = h.symm.toWalk := rfl
+
+@[simp]
 theorem cons_reverseAux {u v w x : V} (p : G.Walk u v) (q : G.Walk w x) (h : G.Adj w u) :
     (cons h p).reverseAux q = p.reverseAux (cons (G.symm h) q) := rfl
 
@@ -503,12 +506,33 @@ lemma drop_length (p : G.Walk u v) (n : ℕ) : (p.drop n).length = p.length - n 
 lemma drop_getVert (p : G.Walk u v) (n m : ℕ) : (p.drop n).getVert m = p.getVert (n + m) := by
   induction p generalizing n <;> cases n <;> simp [*, drop, add_right_comm]
 
+lemma drop_add_heq (p : G.Walk u v) (n m : ℕ) : p.drop (n + m) ≍ (p.drop n).drop m := by
+  rw [add_comm]
+  induction p generalizing n <;> cases n <;> simp [*, drop]
+
+lemma drop_add_eq (p : G.Walk u v) (n m : ℕ) :
+    p.drop (n + m) = ((p.drop n).drop m).copy (drop_getVert ..) rfl :=
+  eq_of_heq <| drop_add_heq .. |>.trans <| by simp [Walk.copy]
+
+lemma nil_drop_iff (p : G.Walk u v) (n : ℕ) : (p.drop n).Nil ↔ p.length ≤ n := by
+  induction p generalizing n <;> cases n <;> simp [*, drop]
+
+lemma darts_drop (p : G.Walk u v) (n : ℕ) : (p.drop n).darts = p.darts.drop n := by
+  induction p generalizing n <;> cases n <;> simp [*, drop]
+
+lemma edges_drop (p : G.Walk u v) (n : ℕ) : (p.drop n).edges = p.edges.drop n := by
+  induction p generalizing n <;> cases n <;> simp [*, drop]
+
 /-- The walk obtained by taking the first `n` darts of a walk. -/
 def take {u v : V} (p : G.Walk u v) (n : ℕ) : G.Walk u (p.getVert n) :=
   match p, n with
   | .nil, _ => .nil
   | p, 0 => nil.copy rfl (getVert_zero p).symm
   | .cons h q, (n + 1) => .cons h (q.take n)
+
+@[simp]
+lemma take_zero (p : G.Walk u v) : p.take 0 = nil.copy rfl p.getVert_zero.symm := by
+  cases p <;> simp [take]
 
 @[simp]
 lemma take_length (p : G.Walk u v) (n : ℕ) : (p.take n).length = n ⊓ p.length := by
@@ -518,8 +542,27 @@ lemma take_length (p : G.Walk u v) (n : ℕ) : (p.take n).length = n ⊓ p.lengt
 lemma take_getVert (p : G.Walk u v) (n m : ℕ) : (p.take n).getVert m = p.getVert (n ⊓ m) := by
   induction p generalizing n m <;> cases n <;> cases m <;> simp [*, take]
 
+lemma take_add_heq (p : G.Walk u v) (n m : ℕ) :
+    p.take (n + m) ≍ (p.take n).append ((p.drop n).take m) := by
+  rw [add_comm]
+  induction p generalizing n <;> cases n <;> simp [take, drop]
+  grind [drop_getVert]
+
+lemma take_add_eq (p : G.Walk u v) (n m : ℕ) :
+    p.take (n + m) = ((p.take n).append ((p.drop n).take m)).copy rfl (drop_getVert ..) :=
+  eq_of_heq <| take_add_heq .. |>.trans <| by simp [Walk.copy]
+
+lemma nil_take_iff (p : G.Walk u v) (n : ℕ) : (p.take n).Nil ↔ p.Nil ∨ n = 0 := by
+  cases p <;> cases n <;> simp [take]
+
 lemma take_support_eq_support_take_succ {u v} (p : G.Walk u v) (n : ℕ) :
     (p.take n).support = p.support.take (n + 1) := by
+  induction p generalizing n <;> cases n <;> simp [*, take]
+
+lemma darts_take (p : G.Walk u v) (n : ℕ) : (p.take n).darts = p.darts.take n := by
+  induction p generalizing n <;> cases n <;> simp [*, take]
+
+lemma edges_take (p : G.Walk u v) (n : ℕ) : (p.take n).edges = p.edges.take n := by
   induction p generalizing n <;> cases n <;> simp [*, take]
 
 @[simp]
@@ -537,6 +580,7 @@ lemma penultimate_reverse (p : G.Walk u v) : p.reverse.penultimate = p.snd := by
 /-- The walk obtained by removing the first dart of a walk. A nil walk stays nil. -/
 def tail (p : G.Walk u v) : G.Walk (p.snd) v := p.drop 1
 
+@[simp]
 lemma drop_zero {u v} (p : G.Walk u v) :
     p.drop 0 = p.copy (getVert_zero p).symm rfl := by
   cases p <;> simp [Walk.drop]


### PR DESCRIPTION
---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

When merging, all the commits will be squashed into a single commit
listing all co-authors.

Co-authors in the squash commit are gathered from two sources:

First, all authors of commits to this PR branch are included. Thus,
one way to add co-authors is to include at least one commit authored by
each co-author among the commits in the pull request. If necessary, you
may create empty commits to indicate co-authorship, using commands like so:

git commit --author="Author Name <author@email.com>" --allow-empty -m "add Author Name as coauthor"

Second, co-authors can also be listed in lines at the very bottom of
the commit message (that is, directly before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines
at the bottom of the commit message (before the `---`, and also before
any "Co-authored-by" lines) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
