### PR TITLE
dev: investigate the private module linter not firing

### DIFF
--- a/Mathlib/Analysis/Calculus/BumpFunction/SmoothApprox.lean
+++ b/Mathlib/Analysis/Calculus/BumpFunction/SmoothApprox.lean
@@ -8,8 +8,6 @@ module
 public import Mathlib.Analysis.Calculus.BumpFunction.Convolution
 public import Mathlib.Analysis.Calculus.BumpFunction.FiniteDimension
 
-public import Mathlib.Tactic.Linter.PrivateModule
-
 /-!
 # Density of smooth functions in the space of continuous functions
 

--- a/Mathlib/Analysis/Calculus/BumpFunction/SmoothApprox.lean
+++ b/Mathlib/Analysis/Calculus/BumpFunction/SmoothApprox.lean
@@ -8,6 +8,8 @@ module
 public import Mathlib.Analysis.Calculus.BumpFunction.Convolution
 public import Mathlib.Analysis.Calculus.BumpFunction.FiniteDimension
 
+public import Mathlib.Tactic.Linter.PrivateModule
+
 /-!
 # Density of smooth functions in the space of continuous functions
 

--- a/Mathlib/Analysis/Normed/Lp/SmoothApprox.lean
+++ b/Mathlib/Analysis/Normed/Lp/SmoothApprox.lean
@@ -9,6 +9,8 @@ public import Mathlib.Geometry.Manifold.SmoothApprox
 public import Mathlib.MeasureTheory.Function.ContinuousMapDense
 public import Mathlib.Tactic.MoveAdd
 
+public import Mathlib.Tactic.Linter.PrivateModule
+
 /-!
 
 # Density of smooth compactly supported functions in `Lp`

--- a/Mathlib/Init.lean
+++ b/Mathlib/Init.lean
@@ -17,7 +17,7 @@ public import Mathlib.Tactic.Linter.FlexibleLinter
 public import Mathlib.Tactic.Linter.Lint
 public import Mathlib.Tactic.Linter.Multigoal
 public import Mathlib.Tactic.Linter.OldObtain
-public import Mathlib.Tactic.Linter.PrivateModule
+--public import Mathlib.Tactic.Linter.PrivateModule
 -- The following import contains the environment extension for the unused tactic linter.
 public import Mathlib.Tactic.Linter.UnusedTacticExtension
 public import Mathlib.Tactic.Linter.UnusedTactic
@@ -74,7 +74,6 @@ register_linter_set linter.mathlibStandardSet :=
   -- linter.checkInitImports -- disabled, not relevant downstream.
   linter.hashCommand
   linter.oldObtain
-  linter.privateModule
   linter.style.cases
   linter.style.induction
   linter.style.refine

--- a/Mathlib/Tactic/Linter.lean
+++ b/Mathlib/Tactic/Linter.lean
@@ -13,6 +13,5 @@ public meta import Mathlib.Tactic.Linter.DeprecatedModule
 public meta import Mathlib.Tactic.Linter.HaveLetLinter
 public meta import Mathlib.Tactic.Linter.MinImports
 public meta import Mathlib.Tactic.Linter.PPRoundtrip
-public meta import Mathlib.Tactic.Linter.PrivateModule
 public meta import Mathlib.Tactic.Linter.UnusedInstancesInType
 public meta import Mathlib.Tactic.Linter.UpstreamableDecl

--- a/Mathlib/Tactic/ToAdditive.lean
+++ b/Mathlib/Tactic/ToAdditive.lean
@@ -13,7 +13,7 @@ public meta import Mathlib.Tactic.Translate.ToAdditive
 
 public meta section
 
-set_option linter.privateModule false
+-- set_option linter.privateModule false
 
 attribute [to_additive_do_translate] Empty PEmpty Unit PUnit
 

--- a/Mathlib/Util/MemoFix.lean
+++ b/Mathlib/Util/MemoFix.lean
@@ -7,6 +7,7 @@ module
 
 public import Std.Data.HashMap.Basic
 public import Mathlib.Init
+import Lean.Util.PtrSet
 
 /-!
 # Fixpoint function with memoisation


### PR DESCRIPTION
Only for debugging.
(1) wait for CI to rebuild everything until separablyGenerated
(2) make any modifications to the linter to dump debugging state
(3) try to find the bug with it

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

When merging, all the commits will be squashed into a single commit
listing all co-authors.

Co-authors in the squash commit are gathered from two sources:

First, all authors of commits to this PR branch are included. Thus,
one way to add co-authors is to include at least one commit authored by
each co-author among the commits in the pull request. If necessary, you
may create empty commits to indicate co-authorship, using commands like so:

git commit --author="Author Name <author@email.com>" --allow-empty -m "add Author Name as coauthor"

Second, co-authors can also be listed in lines at the very bottom of
the commit message (that is, directly before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines
at the bottom of the commit message (before the `---`, and also before
any "Co-authored-by" lines) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
