### PR TITLE
chore(MeasureTheory/Measure/Typeclasses): golf `ite_ae_eq_of_measure_compl_zero` using `grind`

### DIFF
--- a/Mathlib/MeasureTheory/Measure/Typeclasses/Finite.lean
+++ b/Mathlib/MeasureTheory/Measure/Typeclasses/Finite.lean
@@ -245,11 +245,8 @@ theorem ite_ae_eq_of_measure_zero {γ} (f : α → γ) (g : α → γ) (s : Set 
 theorem ite_ae_eq_of_measure_compl_zero {γ} (f : α → γ) (g : α → γ)
     (s : Set α) [DecidablePred (· ∈ s)] (hs_zero : μ sᶜ = 0) :
     (fun x => ite (x ∈ s) (f x) (g x)) =ᵐ[μ] f := by
-  rw [← mem_ae_iff] at hs_zero
   filter_upwards [hs_zero]
-  intros
-  split_ifs
-  rfl
+  grind
 
 namespace Measure
 


### PR DESCRIPTION
---
<details>
<summary>Show trace profiling of <code>ite_ae_eq_of_measure_compl_zero</code>: 180 ms before, 373 ms after </summary>

### Trace profiling of `ite_ae_eq_of_measure_compl_zero` before PR 32129
```diff
diff --git a/Mathlib/MeasureTheory/Measure/Typeclasses/Finite.lean b/Mathlib/MeasureTheory/Measure/Typeclasses/Finite.lean
index 4195ac1e91..8660b97255 100644
--- a/Mathlib/MeasureTheory/Measure/Typeclasses/Finite.lean
+++ b/Mathlib/MeasureTheory/Measure/Typeclasses/Finite.lean
@@ -242,6 +242,7 @@ theorem ite_ae_eq_of_measure_zero {γ} (f : α → γ) (g : α → γ) (s : Set
   conv_rhs => rw [← compl_compl s]
   rwa [Set.compl_subset_compl]
 
+set_option trace.profiler true in
 theorem ite_ae_eq_of_measure_compl_zero {γ} (f : α → γ) (g : α → γ)
     (s : Set α) [DecidablePred (· ∈ s)] (hs_zero : μ sᶜ = 0) :
     (fun x => ite (x ∈ s) (f x) (g x)) =ᵐ[μ] f := by
```
```
ℹ [1631/1631] Built Mathlib.MeasureTheory.Measure.Typeclasses.Finite (1.9s)
info: Mathlib/MeasureTheory/Measure/Typeclasses/Finite.lean:246:0: [Elab.async] [0.180845] elaborating proof of MeasureTheory.ite_ae_eq_of_measure_compl_zero
  [Elab.definition.value] [0.180442] MeasureTheory.ite_ae_eq_of_measure_compl_zero
    [Elab.step] [0.180233] 
          rw [← mem_ae_iff] at hs_zero
          filter_upwards [hs_zero]
          intros
          split_ifs
          rfl
      [Elab.step] [0.180228] 
            rw [← mem_ae_iff] at hs_zero
            filter_upwards [hs_zero]
            intros
            split_ifs
            rfl
        [Elab.step] [0.174099] split_ifs
Build completed successfully (1631 jobs).
```

### Trace profiling of `ite_ae_eq_of_measure_compl_zero` after PR 32129
```diff
diff --git a/Mathlib/MeasureTheory/Measure/Typeclasses/Finite.lean b/Mathlib/MeasureTheory/Measure/Typeclasses/Finite.lean
index 4195ac1e91..a0d877eaf7 100644
--- a/Mathlib/MeasureTheory/Measure/Typeclasses/Finite.lean
+++ b/Mathlib/MeasureTheory/Measure/Typeclasses/Finite.lean
@@ -242,14 +242,12 @@ theorem ite_ae_eq_of_measure_zero {γ} (f : α → γ) (g : α → γ) (s : Set
   conv_rhs => rw [← compl_compl s]
   rwa [Set.compl_subset_compl]
 
+set_option trace.profiler true in
 theorem ite_ae_eq_of_measure_compl_zero {γ} (f : α → γ) (g : α → γ)
     (s : Set α) [DecidablePred (· ∈ s)] (hs_zero : μ sᶜ = 0) :
     (fun x => ite (x ∈ s) (f x) (g x)) =ᵐ[μ] f := by
-  rw [← mem_ae_iff] at hs_zero
   filter_upwards [hs_zero]
-  intros
-  split_ifs
-  rfl
+  grind
 
 namespace Measure
 
```
```
ℹ [1631/1631] Built Mathlib.MeasureTheory.Measure.Typeclasses.Finite (2.1s)
info: Mathlib/MeasureTheory/Measure/Typeclasses/Finite.lean:246:0: [Elab.async] [0.373826] elaborating proof of MeasureTheory.ite_ae_eq_of_measure_compl_zero
  [Elab.definition.value] [0.373482] MeasureTheory.ite_ae_eq_of_measure_compl_zero
    [Elab.step] [0.373326] 
          filter_upwards [hs_zero]
          grind
      [Elab.step] [0.373321] 
            filter_upwards [hs_zero]
            grind
        [Elab.step] [0.369169] grind
          [Meta.synthInstance] [0.039875] ❌️ Lean.Grind.IsCharP (Lean.Grind.Ring.OfSemiring.Q ℝ≥0∞) ?m.67
          [Meta.synthInstance] [0.025917] ❌️ LE (Lean.Grind.IntModule.OfNatModule.Q ℝ≥0∞)
          [Meta.synthInstance] [0.025683] ❌️ LT (Lean.Grind.IntModule.OfNatModule.Q ℝ≥0∞)
          [Meta.synthInstance] [0.024955] ❌️ Lean.Grind.OrderedAdd ℝ≥0∞
Build completed successfully (1631 jobs).
```
</details>

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

When merging, all the commits will be squashed into a single commit
listing all co-authors.

Co-authors in the squash commit are gathered from two sources:

First, all authors of commits to this PR branch are included. Thus,
one way to add co-authors is to include at least one commit authored by
each co-author among the commits in the pull request. If necessary, you
may create empty commits to indicate co-authorship, using commands like so:

git commit --author="Author Name <author@email.com>" --allow-empty -m "add Author Name as coauthor"

Second, co-authors can also be listed in lines at the very bottom of
the commit message (that is, directly before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines
at the bottom of the commit message (before the `---`, and also before
any "Co-authored-by" lines) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
