### PR TITLE
[Merged by Bors] - chore(MeasureTheory/Function/LpSpace): golf entire `ext` using `ext; assumption`

### DIFF
--- a/Mathlib/MeasureTheory/Function/LpSpace/Basic.lean
+++ b/Mathlib/MeasureTheory/Function/LpSpace/Basic.lean
@@ -142,7 +142,7 @@ instance instCoeFun : CoeFun (Lp E p μ) (fun _ => α → E) :=
 @[ext high]
 theorem ext {f g : Lp E p μ} (h : f =ᵐ[μ] g) : f = g := by
   ext
-  assumption
+  exact h
 
 theorem mem_Lp_iff_eLpNorm_lt_top {f : α →ₘ[μ] E} : f ∈ Lp E p μ ↔ eLpNorm f p μ < ∞ := Iff.rfl
 

--- a/Mathlib/MeasureTheory/Function/LpSpace/Basic.lean
+++ b/Mathlib/MeasureTheory/Function/LpSpace/Basic.lean
@@ -141,10 +141,8 @@ instance instCoeFun : CoeFun (Lp E p μ) (fun _ => α → E) :=
 
 @[ext high]
 theorem ext {f g : Lp E p μ} (h : f =ᵐ[μ] g) : f = g := by
-  cases f
-  cases g
-  simp only [Subtype.mk_eq_mk]
-  exact AEEqFun.ext h
+  ext
+  assumption
 
 theorem mem_Lp_iff_eLpNorm_lt_top {f : α →ₘ[μ] E} : f ∈ Lp E p μ ↔ eLpNorm f p μ < ∞ := Iff.rfl
 


### PR DESCRIPTION
---
<details>
<summary>Show trace profiling of <code>ext</code>: <10 ms before, <10 ms after  🎉</summary>

### Trace profiling of `ext` before PR 32130
```diff
diff --git a/Mathlib/MeasureTheory/Function/LpSpace/Basic.lean b/Mathlib/MeasureTheory/Function/LpSpace/Basic.lean
index 2fb91cf97c..0e98bfb2be 100644
--- a/Mathlib/MeasureTheory/Function/LpSpace/Basic.lean
+++ b/Mathlib/MeasureTheory/Function/LpSpace/Basic.lean
@@ -139,6 +139,7 @@ namespace Lp
 instance instCoeFun : CoeFun (Lp E p μ) (fun _ => α → E) :=
   ⟨fun f => ((f : α →ₘ[μ] E) : α → E)⟩
 
+set_option trace.profiler true in
 @[ext high]
 theorem ext {f g : Lp E p μ} (h : f =ᵐ[μ] g) : f = g := by
   cases f
```
```
ℹ [2091/2091] Built Mathlib.MeasureTheory.Function.LpSpace.Basic (5.7s)
info: Mathlib/MeasureTheory/Function/LpSpace/Basic.lean:143:0: [Elab.command] [0.011072] @[ext high]
    theorem ext {f g : Lp E p μ} (h : f =ᵐ[μ] g) : f = g :=
      by
      cases f
      cases g
      simp only [Subtype.mk_eq_mk]
      exact AEEqFun.ext h
Build completed successfully (2091 jobs).
```

### Trace profiling of `ext` after PR 32130
```diff
diff --git a/Mathlib/MeasureTheory/Function/LpSpace/Basic.lean b/Mathlib/MeasureTheory/Function/LpSpace/Basic.lean
index 2fb91cf97c..9f08e0fb5d 100644
--- a/Mathlib/MeasureTheory/Function/LpSpace/Basic.lean
+++ b/Mathlib/MeasureTheory/Function/LpSpace/Basic.lean
@@ -139,12 +139,11 @@ namespace Lp
 instance instCoeFun : CoeFun (Lp E p μ) (fun _ => α → E) :=
   ⟨fun f => ((f : α →ₘ[μ] E) : α → E)⟩
 
+set_option trace.profiler true in
 @[ext high]
 theorem ext {f g : Lp E p μ} (h : f =ᵐ[μ] g) : f = g := by
-  cases f
-  cases g
-  simp only [Subtype.mk_eq_mk]
-  exact AEEqFun.ext h
+  ext
+  assumption
 
 theorem mem_Lp_iff_eLpNorm_lt_top {f : α →ₘ[μ] E} : f ∈ Lp E p μ ↔ eLpNorm f p μ < ∞ := Iff.rfl
 
```
```
✔ [2091/2091] Built Mathlib.MeasureTheory.Function.LpSpace.Basic (5.6s)
Build completed successfully (2091 jobs).
```
</details>

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

When merging, all the commits will be squashed into a single commit
listing all co-authors.

Co-authors in the squash commit are gathered from two sources:

First, all authors of commits to this PR branch are included. Thus,
one way to add co-authors is to include at least one commit authored by
each co-author among the commits in the pull request. If necessary, you
may create empty commits to indicate co-authorship, using commands like so:

git commit --author="Author Name <author@email.com>" --allow-empty -m "add Author Name as coauthor"

Second, co-authors can also be listed in lines at the very bottom of
the commit message (that is, directly before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines
at the bottom of the commit message (before the `---`, and also before
any "Co-authored-by" lines) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
