### PR TITLE
[Merged by Bors] - chore(CategoryTheory/Limits): golf entire `ι_colimitLimitIso_limit_π` using `simp`

### DIFF
--- a/Mathlib/CategoryTheory/Limits/FilteredColimitCommutesFiniteLimit.lean
+++ b/Mathlib/CategoryTheory/Limits/FilteredColimitCommutesFiniteLimit.lean
@@ -377,16 +377,7 @@ noncomputable def colimitLimitIso (F : J ⥤ K ⥤ C) : colimit (limit F) ≅ li
 theorem ι_colimitLimitIso_limit_π (F : J ⥤ K ⥤ C) (a) (b) :
     colimit.ι (limit F) a ≫ (colimitLimitIso F).hom ≫ limit.π (colimit F.flip) b =
       (limit.π F b).app a ≫ (colimit.ι F.flip a).app b := by
-  dsimp [colimitLimitIso]
-  simp only [Functor.mapCone_π_app, Iso.symm_hom,
-    Limits.limit.conePointUniqueUpToIso_hom_comp_assoc, Limits.limit.cone_π,
-    Limits.colimit.ι_map_assoc, Limits.colimitFlipIsoCompColim_inv_app, assoc,
-    Limits.HasLimit.isoOfNatIso_hom_π]
-  congr 1
-  simp only [← Category.assoc, Iso.comp_inv_eq,
-    Limits.colimitObjIsoColimitCompEvaluation_ι_app_hom,
-    Limits.HasColimit.isoOfNatIso_ι_hom]
-  simp
+  simp [colimitLimitIso]
 
 end
 


### PR DESCRIPTION
---
<details>
<summary>Show trace profiling of <code>ι_colimitLimitIso_limit_π</code>: 29 ms before, 22 ms after  🎉</summary>

### Trace profiling of `ι_colimitLimitIso_limit_π` before PR 32132
```diff
diff --git a/Mathlib/CategoryTheory/Limits/FilteredColimitCommutesFiniteLimit.lean b/Mathlib/CategoryTheory/Limits/FilteredColimitCommutesFiniteLimit.lean
index dc67bc4c4f..5bf33208f1 100644
--- a/Mathlib/CategoryTheory/Limits/FilteredColimitCommutesFiniteLimit.lean
+++ b/Mathlib/CategoryTheory/Limits/FilteredColimitCommutesFiniteLimit.lean
@@ -373,6 +373,7 @@ noncomputable def colimitLimitIso (F : J ⥤ K ⥤ C) : colimit (limit F) ≅ li
   (isLimitOfPreserves colim (limit.isLimit _)).conePointUniqueUpToIso (limit.isLimit _) ≪≫
     HasLimit.isoOfNatIso (colimitFlipIsoCompColim _).symm
 
+set_option trace.profiler true in
 @[reassoc (attr := simp)]
 theorem ι_colimitLimitIso_limit_π (F : J ⥤ K ⥤ C) (a) (b) :
     colimit.ι (limit F) a ≫ (colimitLimitIso F).hom ≫ limit.π (colimit F.flip) b =
```
```
ℹ [819/819] Built Mathlib.CategoryTheory.Limits.FilteredColimitCommutesFiniteLimit (1.6s)
info: Mathlib/CategoryTheory/Limits/FilteredColimitCommutesFiniteLimit.lean:377:0: [Elab.command] [0.078530] @[reassoc (attr := simp)]
    theorem ι_colimitLimitIso_limit_π (F : J ⥤ K ⥤ C) (a) (b) :
        colimit.ι (limit F) a ≫ (colimitLimitIso F).hom ≫ limit.π (colimit F.flip) b =
          (limit.π F b).app a ≫ (colimit.ι F.flip a).app b :=
      by
      dsimp [colimitLimitIso]
      simp only [Functor.mapCone_π_app, Iso.symm_hom, Limits.limit.conePointUniqueUpToIso_hom_comp_assoc,
        Limits.limit.cone_π, Limits.colimit.ι_map_assoc, Limits.colimitFlipIsoCompColim_inv_app, assoc,
        Limits.HasLimit.isoOfNatIso_hom_π]
      congr 1
      simp only [← Category.assoc, Iso.comp_inv_eq, Limits.colimitObjIsoColimitCompEvaluation_ι_app_hom,
        Limits.HasColimit.isoOfNatIso_ι_hom]
      simp
  [Elab.definition.header] [0.035270] CategoryTheory.Limits.ι_colimitLimitIso_limit_π
    [Elab.step] [0.034559] expected type: Sort ?u.35202, term
        colimit.ι (limit F) a ≫ (colimitLimitIso F).hom ≫ limit.π (colimit F.flip) b =
          (limit.π F b).app a ≫ (colimit.ι F.flip a).app b
      [Elab.step] [0.034553] expected type: Sort ?u.35202, term
          binrel% Eq✝ (colimit.ι (limit F) a ≫ (colimitLimitIso F).hom ≫ limit.π (colimit F.flip) b)
            ((limit.π F b).app a ≫ (colimit.ι F.flip a).app b)
        [Elab.step] [0.021721] expected type: <not-available>, term
            CategoryStruct.comp✝ (colimit.ι (limit F) a) ((colimitLimitIso F).hom ≫ limit.π (colimit F.flip) b)
          [Elab.step] [0.010291] expected type: (limit F).obj a ⟶ colimit (limit F), term
              colimit.ι (limit F) a
          [Elab.step] [0.011292] expected type: colimit (limit F) ⟶ (colimit F.flip).obj b, term
              (colimitLimitIso F).hom ≫ limit.π (colimit F.flip) b
            [Elab.step] [0.011263] expected type: colimit (limit F) ⟶ (colimit F.flip).obj b, term
                CategoryStruct.comp✝ (colimitLimitIso F).hom (limit.π (colimit F.flip) b)
        [Elab.step] [0.011847] expected type: <not-available>, term
            CategoryStruct.comp✝ ((limit.π F b).app a) ((colimit.ι F.flip a).app b)
  [Elab.attribute] [0.040292] applying [reassoc (attr := simp)]
info: Mathlib/CategoryTheory/Limits/FilteredColimitCommutesFiniteLimit.lean:377:0: [Elab.async] [0.030820] elaborating proof of CategoryTheory.Limits.ι_colimitLimitIso_limit_π
  [Elab.definition.value] [0.029497] CategoryTheory.Limits.ι_colimitLimitIso_limit_π
    [Elab.step] [0.028797] 
          dsimp [colimitLimitIso]
          simp only [Functor.mapCone_π_app, Iso.symm_hom, Limits.limit.conePointUniqueUpToIso_hom_comp_assoc,
            Limits.limit.cone_π, Limits.colimit.ι_map_assoc, Limits.colimitFlipIsoCompColim_inv_app, assoc,
            Limits.HasLimit.isoOfNatIso_hom_π]
          congr 1
          simp only [← Category.assoc, Iso.comp_inv_eq, Limits.colimitObjIsoColimitCompEvaluation_ι_app_hom,
            Limits.HasColimit.isoOfNatIso_ι_hom]
          simp
      [Elab.step] [0.028787] 
            dsimp [colimitLimitIso]
            simp only [Functor.mapCone_π_app, Iso.symm_hom, Limits.limit.conePointUniqueUpToIso_hom_comp_assoc,
              Limits.limit.cone_π, Limits.colimit.ι_map_assoc, Limits.colimitFlipIsoCompColim_inv_app, assoc,
              Limits.HasLimit.isoOfNatIso_hom_π]
            congr 1
            simp only [← Category.assoc, Iso.comp_inv_eq, Limits.colimitObjIsoColimitCompEvaluation_ι_app_hom,
              Limits.HasColimit.isoOfNatIso_ι_hom]
            simp
        [Elab.step] [0.013495] simp only [Functor.mapCone_π_app, Iso.symm_hom,
              Limits.limit.conePointUniqueUpToIso_hom_comp_assoc, Limits.limit.cone_π, Limits.colimit.ι_map_assoc,
              Limits.colimitFlipIsoCompColim_inv_app, assoc, Limits.HasLimit.isoOfNatIso_hom_π]
Build completed successfully (819 jobs).
```

### Trace profiling of `ι_colimitLimitIso_limit_π` after PR 32132
```diff
diff --git a/Mathlib/CategoryTheory/Limits/FilteredColimitCommutesFiniteLimit.lean b/Mathlib/CategoryTheory/Limits/FilteredColimitCommutesFiniteLimit.lean
index dc67bc4c4f..b7d7711bdb 100644
--- a/Mathlib/CategoryTheory/Limits/FilteredColimitCommutesFiniteLimit.lean
+++ b/Mathlib/CategoryTheory/Limits/FilteredColimitCommutesFiniteLimit.lean
@@ -373,20 +373,12 @@ noncomputable def colimitLimitIso (F : J ⥤ K ⥤ C) : colimit (limit F) ≅ li
   (isLimitOfPreserves colim (limit.isLimit _)).conePointUniqueUpToIso (limit.isLimit _) ≪≫
     HasLimit.isoOfNatIso (colimitFlipIsoCompColim _).symm
 
+set_option trace.profiler true in
 @[reassoc (attr := simp)]
 theorem ι_colimitLimitIso_limit_π (F : J ⥤ K ⥤ C) (a) (b) :
     colimit.ι (limit F) a ≫ (colimitLimitIso F).hom ≫ limit.π (colimit F.flip) b =
       (limit.π F b).app a ≫ (colimit.ι F.flip a).app b := by
-  dsimp [colimitLimitIso]
-  simp only [Functor.mapCone_π_app, Iso.symm_hom,
-    Limits.limit.conePointUniqueUpToIso_hom_comp_assoc, Limits.limit.cone_π,
-    Limits.colimit.ι_map_assoc, Limits.colimitFlipIsoCompColim_inv_app, assoc,
-    Limits.HasLimit.isoOfNatIso_hom_π]
-  congr 1
-  simp only [← Category.assoc, Iso.comp_inv_eq,
-    Limits.colimitObjIsoColimitCompEvaluation_ι_app_hom,
-    Limits.HasColimit.isoOfNatIso_ι_hom]
-  simp
+  simp [colimitLimitIso]
 
 end
 
```
```
ℹ [819/819] Built Mathlib.CategoryTheory.Limits.FilteredColimitCommutesFiniteLimit (1.6s)
info: Mathlib/CategoryTheory/Limits/FilteredColimitCommutesFiniteLimit.lean:377:0: [Elab.command] [0.070191] @[reassoc (attr := simp)]
    theorem ι_colimitLimitIso_limit_π (F : J ⥤ K ⥤ C) (a) (b) :
        colimit.ι (limit F) a ≫ (colimitLimitIso F).hom ≫ limit.π (colimit F.flip) b =
          (limit.π F b).app a ≫ (colimit.ι F.flip a).app b :=
      by simp [colimitLimitIso]
  [Elab.definition.header] [0.035373] CategoryTheory.Limits.ι_colimitLimitIso_limit_π
    [Elab.step] [0.034695] expected type: Sort ?u.35202, term
        colimit.ι (limit F) a ≫ (colimitLimitIso F).hom ≫ limit.π (colimit F.flip) b =
          (limit.π F b).app a ≫ (colimit.ι F.flip a).app b
      [Elab.step] [0.034690] expected type: Sort ?u.35202, term
          binrel% Eq✝ (colimit.ι (limit F) a ≫ (colimitLimitIso F).hom ≫ limit.π (colimit F.flip) b)
            ((limit.π F b).app a ≫ (colimit.ι F.flip a).app b)
        [Elab.step] [0.021827] expected type: <not-available>, term
            CategoryStruct.comp✝ (colimit.ι (limit F) a) ((colimitLimitIso F).hom ≫ limit.π (colimit F.flip) b)
          [Elab.step] [0.010307] expected type: (limit F).obj a ⟶ colimit (limit F), term
              colimit.ι (limit F) a
          [Elab.step] [0.011386] expected type: colimit (limit F) ⟶ (colimit F.flip).obj b, term
              (colimitLimitIso F).hom ≫ limit.π (colimit F.flip) b
            [Elab.step] [0.011358] expected type: colimit (limit F) ⟶ (colimit F.flip).obj b, term
                CategoryStruct.comp✝ (colimitLimitIso F).hom (limit.π (colimit F.flip) b)
        [Elab.step] [0.011899] expected type: <not-available>, term
            CategoryStruct.comp✝ ((limit.π F b).app a) ((colimit.ι F.flip a).app b)
  [Elab.attribute] [0.031937] applying [reassoc (attr := simp)]
info: Mathlib/CategoryTheory/Limits/FilteredColimitCommutesFiniteLimit.lean:377:0: [Elab.async] [0.022726] elaborating proof of CategoryTheory.Limits.ι_colimitLimitIso_limit_π
  [Elab.definition.value] [0.021682] CategoryTheory.Limits.ι_colimitLimitIso_limit_π
    [Elab.step] [0.020997] simp [colimitLimitIso]
      [Elab.step] [0.020991] simp [colimitLimitIso]
        [Elab.step] [0.020985] simp [colimitLimitIso]
Build completed successfully (819 jobs).
```
</details>

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

When merging, all the commits will be squashed into a single commit
listing all co-authors.

Co-authors in the squash commit are gathered from two sources:

First, all authors of commits to this PR branch are included. Thus,
one way to add co-authors is to include at least one commit authored by
each co-author among the commits in the pull request. If necessary, you
may create empty commits to indicate co-authorship, using commands like so:

git commit --author="Author Name <author@email.com>" --allow-empty -m "add Author Name as coauthor"

Second, co-authors can also be listed in lines at the very bottom of
the commit message (that is, directly before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines
at the bottom of the commit message (before the `---`, and also before
any "Co-authored-by" lines) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
