### PR TITLE
[Merged by Bors] - feat(RingTheory): ann(I) ≠ ⊥ from ∀ r ∈ I, ann(r) ≠ ⊥

### DIFF
--- a/Mathlib/LinearAlgebra/Span/Basic.lean
+++ b/Mathlib/LinearAlgebra/Span/Basic.lean
@@ -809,7 +809,7 @@ variable [Semiring R] [AddCommMonoid M] [Module R M] [NoZeroSMulDivisors R M]
 theorem ker_toSpanSingleton {x : M} (h : x ≠ 0) : LinearMap.ker (toSpanSingleton R M x) = ⊥ :=
   SetLike.ext fun _ => smul_eq_zero.trans <| or_iff_left_of_imp fun h' => (h h').elim
 
-theorem ker_toSpanSingleton_eq_bot_iff {x : R} :
+@[simp] theorem ker_toSpanSingleton_eq_bot_iff {x : R} :
     ker (toSpanSingleton R R x) = ⊥ ↔ x ∈ nonZeroDivisorsRight R :=
   le_bot_iff.symm
 

--- a/Mathlib/LinearAlgebra/Span/Basic.lean
+++ b/Mathlib/LinearAlgebra/Span/Basic.lean
@@ -7,6 +7,7 @@ Authors: Johannes Hölzl, Mario Carneiro, Kevin Buzzard, Yury Kudryashov, Fréd�
 module
 
 public import Mathlib.Algebra.Group.Action.Pointwise.Set.Basic
+public import Mathlib.Algebra.GroupWithZero.NonZeroDivisors
 public import Mathlib.Algebra.Module.Prod
 public import Mathlib.Algebra.Module.Submodule.EqLocus
 public import Mathlib.Algebra.Module.Submodule.Equiv
@@ -803,10 +804,14 @@ end AddCommMonoid
 section NoZeroDivisors
 
 variable (R M)
-variable [Ring R] [AddCommGroup M] [Module R M] [NoZeroSMulDivisors R M]
+variable [Semiring R] [AddCommMonoid M] [Module R M] [NoZeroSMulDivisors R M]
 
 theorem ker_toSpanSingleton {x : M} (h : x ≠ 0) : LinearMap.ker (toSpanSingleton R M x) = ⊥ :=
   SetLike.ext fun _ => smul_eq_zero.trans <| or_iff_left_of_imp fun h' => (h h').elim
+
+theorem ker_toSpanSingleton_eq_bot_iff {x : R} :
+    ker (toSpanSingleton R R x) = ⊥ ↔ x ∈ nonZeroDivisorsRight R :=
+  le_bot_iff.symm
 
 end NoZeroDivisors
 

--- a/Mathlib/RingTheory/Ideal/AssociatedPrime/Finiteness.lean
+++ b/Mathlib/RingTheory/Ideal/AssociatedPrime/Finiteness.lean
@@ -180,7 +180,7 @@ instance [IsFractionRing A A] : Finite (MaximalSpectrum A) :=
 
 variable {A}
 
-/-- An ideal in a commutative Noetherian ring consisting of zero divisors is annihilated by
+/-- An ideal consisting of zero divisors in a commutative Noetherian ring is annihilated by
 some nonzero element. This is not true in general for finitely generated modules in commutative
 rings, see https://math.stackexchange.com/q/1189814 and http://dx.doi.org/10.2140/pjm.1979.83.375
 (keywords: Property (A), Quentel's Condition (C)).
@@ -190,14 +190,13 @@ is annihilated by some nonzero element if each element is annihilated by some no
 see https://math.stackexchange.com/a/3187153. -/
 theorem Ideal.bot_lt_annihilator_of_disjoint_nonZeroDivisors {I : Ideal A}
     (h : Disjoint (I : Set A) (nonZeroDivisors A)) : ⊥ < Module.annihilator A I := by
-  obtain ⟨P, ⟨prime, x, rfl⟩, hP⟩ := (I.subset_union_prime_finite
-    (associatedPrimes.finite A A) (f := id) 0 0 fun _ h _ _ ↦ h.isPrime).1 <|
+  obtain ⟨P, ⟨prime, x, rfl⟩, hP⟩ : ∃ P ∈ associatedPrimes A A, I ≤ P :=
+    (I.subset_union_prime_finite (associatedPrimes.finite ..) (f := id) 0 0 fun _ h _ _ ↦ h.1).1 <|
     biUnion_associatedPrimes_eq_compl_nonZeroDivisors A ▸ h.subset_compl_right
   exact SetLike.lt_iff_le_and_exists.mpr ⟨bot_le, x, Submodule.mem_annihilator.mpr <| by
-    simpa only [smul_eq_mul, mul_comm x] using hP, fun (h : x = 0) ↦ prime.ne_top <| by simp [h]⟩
+    simpa only [smul_eq_mul, mul_comm x] using hP, fun h : x = 0 ↦ prime.ne_top <| by simp [h]⟩
 
-open LinearMap in
-theorem Ideal.exists_mem_ker_toSpanSingleton_eq_bot {I : Ideal A} [FaithfulSMul A I] :
+theorem Ideal.nonempty_inter_nonZeroDivisors_of_faithfulSMul {I : Ideal A} [FaithfulSMul A I] :
     ((I : Set A) ∩ nonZeroDivisors A).Nonempty := by
   by_contra!
   exact (bot_lt_annihilator_of_disjoint_nonZeroDivisors

--- a/Mathlib/RingTheory/Ideal/AssociatedPrime/Finiteness.lean
+++ b/Mathlib/RingTheory/Ideal/AssociatedPrime/Finiteness.lean
@@ -193,7 +193,7 @@ theorem Ideal.bot_lt_annihilator_of_disjoint_nonZeroDivisors {I : Ideal A}
   obtain ⟨P, ⟨prime, x, rfl⟩, hP⟩ := (I.subset_union_prime_finite
     (associatedPrimes.finite A A) (f := id) 0 0 fun _ h _ _ ↦ h.isPrime).1 <|
     biUnion_associatedPrimes_eq_compl_nonZeroDivisors A ▸ h.subset_compl_right
-  exact SetLike.lt_iff_le_and_exists.mpr ⟨bot_le, r, Submodule.mem_annihilator.mpr <| by
+  exact SetLike.lt_iff_le_and_exists.mpr ⟨bot_le, x, Submodule.mem_annihilator.mpr <| by
     simpa only [smul_eq_mul, mul_comm x] using hP, fun (h : x = 0) ↦ prime.ne_top <| by simp [h]⟩
 
 open LinearMap in

--- a/Mathlib/RingTheory/Ideal/AssociatedPrime/Finiteness.lean
+++ b/Mathlib/RingTheory/Ideal/AssociatedPrime/Finiteness.lean
@@ -178,14 +178,27 @@ instance [IsFractionRing A A] : Finite (MaximalSpectrum A) :=
   (MaximalSpectrum.equivSubtype A).finite_iff.mpr <| Set.finite_coe_iff.mpr <|
     (associatedPrimes.finite A A).subset fun _ ↦ (·.mem_associatedPrimes_of_isFractionRing)
 
+variable {A}
+
 /-- An ideal in a commutative Noetherian ring consisting of zero divisors is annihilated by
 some nonzero element. This is not true in general for finitely generated modules in commutative
 rings, see https://math.stackexchange.com/q/1189814 and http://dx.doi.org/10.2140/pjm.1979.83.375
-(keywords: Property (A), Quentel's Condition (C)). -/
+(keywords: Property (A), Quentel's Condition (C)).
+
+It is also not true that every finitely generated module over every commutative Noetherian ring
+is annihilated by some nonzero element if each element is annihilated by some nonzero element,
+see https://math.stackexchange.com/a/3187153. -/
 theorem Ideal.bot_lt_annihilator_of_disjoint_nonZeroDivisors {I : Ideal A}
     (h : Disjoint (I : Set A) (nonZeroDivisors A)) : ⊥ < Module.annihilator A I := by
-  obtain ⟨P, ⟨prime, r, rfl⟩, hP⟩ := (I.subset_union_prime_finite
+  obtain ⟨P, ⟨prime, x, rfl⟩, hP⟩ := (I.subset_union_prime_finite
     (associatedPrimes.finite A A) (f := id) 0 0 fun _ h _ _ ↦ h.isPrime).1 <|
     biUnion_associatedPrimes_eq_compl_nonZeroDivisors A ▸ h.subset_compl_right
   exact SetLike.lt_iff_le_and_exists.mpr ⟨bot_le, r, Submodule.mem_annihilator.mpr <| by
-    simpa only [smul_eq_mul, mul_comm r] using hP, fun (h : r = 0) ↦ prime.ne_top <| by simp [h]⟩
+    simpa only [smul_eq_mul, mul_comm x] using hP, fun (h : x = 0) ↦ prime.ne_top <| by simp [h]⟩
+
+open LinearMap in
+theorem Ideal.exists_mem_ker_toSpanSingleton_eq_bot {I : Ideal A} [FaithfulSMul A I] :
+    ((I : Set A) ∩ nonZeroDivisors A).Nonempty := by
+  by_contra!
+  exact (bot_lt_annihilator_of_disjoint_nonZeroDivisors
+    (Set.disjoint_iff_inter_eq_empty.mpr this)).ne' <| by rwa [Module.annihilator_eq_bot]

--- a/Mathlib/RingTheory/Ideal/AssociatedPrime/Finiteness.lean
+++ b/Mathlib/RingTheory/Ideal/AssociatedPrime/Finiteness.lean
@@ -177,3 +177,15 @@ theorem Ideal.IsMaximal.mem_associatedPrimes_of_isFractionRing [IsFractionRing A
 instance [IsFractionRing A A] : Finite (MaximalSpectrum A) :=
   (MaximalSpectrum.equivSubtype A).finite_iff.mpr <| Set.finite_coe_iff.mpr <|
     (associatedPrimes.finite A A).subset fun _ ↦ (·.mem_associatedPrimes_of_isFractionRing)
+
+/-- An ideal in a commutative Noetherian ring consisting of zero divisors is annihilated by
+some nonzero element. This is not true in general for finitely generated modules in commutative
+rings, see https://math.stackexchange.com/q/1189814 and http://dx.doi.org/10.2140/pjm.1979.83.375
+(keywords: Property (A), Quentel's Condition (C)). -/
+theorem Ideal.bot_lt_annihilator_of_disjoint_nonZeroDivisors {I : Ideal A}
+    (h : Disjoint (I : Set A) (nonZeroDivisors A)) : ⊥ < Module.annihilator A I := by
+  obtain ⟨P, ⟨prime, r, rfl⟩, hP⟩ := (I.subset_union_prime_finite
+    (associatedPrimes.finite A A) (f := id) 0 0 fun _ h _ _ ↦ h.isPrime).1 <|
+    biUnion_associatedPrimes_eq_compl_nonZeroDivisors A ▸ h.subset_compl_right
+  exact SetLike.lt_iff_le_and_exists.mpr ⟨bot_le, r, Submodule.mem_annihilator.mpr <| by
+    simpa only [smul_eq_mul, mul_comm r] using hP, fun (h : r = 0) ↦ prime.ne_top <| by simp [h]⟩


### PR DESCRIPTION
---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

When merging, all the commits will be squashed into a single commit
listing all co-authors.

Co-authors in the squash commit are gathered from two sources:

First, all authors of commits to this PR branch are included. Thus,
one way to add co-authors is to include at least one commit authored by
each co-author among the commits in the pull request. If necessary, you
may create empty commits to indicate co-authorship, using commands like so:

git commit --author="Author Name <author@email.com>" --allow-empty -m "add Author Name as coauthor"

Second, co-authors can also be listed in lines at the very bottom of
the commit message (that is, directly before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines
at the bottom of the commit message (before the `---`, and also before
any "Co-authored-by" lines) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
