### PR TITLE
[Merged by Bors] - chore(Data/DFinsupp): golf entire `mapRange_def` using `ext; simp_all`

### DIFF
--- a/Mathlib/Data/DFinsupp/Defs.lean
+++ b/Mathlib/Data/DFinsupp/Defs.lean
@@ -897,8 +897,8 @@ variable [∀ i, Zero (β₁ i)] [∀ i, Zero (β₂ i)]
 theorem mapRange_def [∀ (i) (x : β₁ i), Decidable (x ≠ 0)] {f : ∀ i, β₁ i → β₂ i}
     {hf : ∀ i, f i 0 = 0} {g : Π₀ i, β₁ i} :
     mapRange f hf g = mk g.support fun i => f i.1 (g i.1) := by
-  ext i
-  by_cases h : g i ≠ 0 <;> simp at h <;> simp [h, hf]
+  ext
+  simp_all
 
 @[simp]
 theorem mapRange_single {f : ∀ i, β₁ i → β₂ i} {hf : ∀ i, f i 0 = 0} {i : ι} {b : β₁ i} :


### PR DESCRIPTION

<details>
<summary>Show trace profiling of <code>mapRange_def</code>: 11 ms before, 12 ms after </summary>

### Trace profiling of `mapRange_def` before PR 32136
```diff
diff --git a/Mathlib/Data/DFinsupp/Defs.lean b/Mathlib/Data/DFinsupp/Defs.lean
index 7d7269bf51..db05c94165 100644
--- a/Mathlib/Data/DFinsupp/Defs.lean
+++ b/Mathlib/Data/DFinsupp/Defs.lean
@@ -920,6 +920,7 @@ section MapRangeAndZipWith
 
 variable [∀ i, Zero (β₁ i)] [∀ i, Zero (β₂ i)]
 
+set_option trace.profiler true in
 theorem mapRange_def [∀ (i) (x : β₁ i), Decidable (x ≠ 0)] {f : ∀ i, β₁ i → β₂ i}
     {hf : ∀ i, f i 0 = 0} {g : Π₀ i, β₁ i} :
     mapRange f hf g = mk g.support fun i => f i.1 (g i.1) := by
```
```
ℹ [626/626] Built Mathlib.Data.DFinsupp.Defs (2.1s)
info: Mathlib/Data/DFinsupp/Defs.lean:924:0: [Elab.async] [0.011616] elaborating proof of DFinsupp.mapRange_def
  [Elab.definition.value] [0.011082] DFinsupp.mapRange_def
    [Elab.step] [0.010785] 
          ext i
          by_cases h : g i ≠ 0 <;> simp at h <;> simp [h, hf]
      [Elab.step] [0.010780] 
            ext i
            by_cases h : g i ≠ 0 <;> simp at h <;> simp [h, hf]
        [Elab.step] [0.010394] (by_cases h : g i ≠ 0) <;> simp at h <;> simp [h, hf]
          [Elab.step] [0.010381] focus
                by_cases h : g i ≠ 0 <;> simp at h
                with_annotate_state"<;>" skip
                all_goals simp [h, hf]
            [Elab.step] [0.010376] 
                  by_cases h : g i ≠ 0 <;> simp at h
                  with_annotate_state"<;>" skip
                  all_goals simp [h, hf]
              [Elab.step] [0.010372] 
                    by_cases h : g i ≠ 0 <;> simp at h
                    with_annotate_state"<;>" skip
                    all_goals simp [h, hf]
Build completed successfully (626 jobs).
```

### Trace profiling of `mapRange_def` after PR 32136
```diff
diff --git a/Mathlib/Data/DFinsupp/Defs.lean b/Mathlib/Data/DFinsupp/Defs.lean
index 7d7269bf51..34236086e1 100644
--- a/Mathlib/Data/DFinsupp/Defs.lean
+++ b/Mathlib/Data/DFinsupp/Defs.lean
@@ -920,11 +920,12 @@ section MapRangeAndZipWith
 
 variable [∀ i, Zero (β₁ i)] [∀ i, Zero (β₂ i)]
 
+set_option trace.profiler true in
 theorem mapRange_def [∀ (i) (x : β₁ i), Decidable (x ≠ 0)] {f : ∀ i, β₁ i → β₂ i}
     {hf : ∀ i, f i 0 = 0} {g : Π₀ i, β₁ i} :
     mapRange f hf g = mk g.support fun i => f i.1 (g i.1) := by
-  ext i
-  by_cases h : g i ≠ 0 <;> simp at h <;> simp [h, hf]
+  ext
+  simp_all
 
 @[simp]
 theorem mapRange_single {f : ∀ i, β₁ i → β₂ i} {hf : ∀ i, f i 0 = 0} {i : ι} {b : β₁ i} :
@@ -970,9 +971,8 @@ theorem zipWith_def {ι : Type u} {β : ι → Type v} {β₁ : ι → Type v₁
     [∀ (i : ι) (x : β₁ i), Decidable (x ≠ 0)] [∀ (i : ι) (x : β₂ i), Decidable (x ≠ 0)]
     {f : ∀ i, β₁ i → β₂ i → β i} {hf : ∀ i, f i 0 0 = 0} {g₁ : Π₀ i, β₁ i} {g₂ : Π₀ i, β₂ i} :
     zipWith f hf g₁ g₂ = mk (g₁.support ∪ g₂.support) fun i => f i.1 (g₁ i.1) (g₂ i.1) := by
-  ext i
-  by_cases h1 : g₁ i ≠ 0 <;> by_cases h2 : g₂ i ≠ 0 <;> simp only [not_not, Ne] at h1 h2 <;>
-    simp [h1, h2, hf]
+  ext
+  simp_all
 
 theorem support_zipWith {f : ∀ i, β₁ i → β₂ i → β i} {hf : ∀ i, f i 0 0 = 0} {g₁ : Π₀ i, β₁ i}
     {g₂ : Π₀ i, β₂ i} : (zipWith f hf g₁ g₂).support ⊆ g₁.support ∪ g₂.support := by
```
```
ℹ [626/626] Built Mathlib.Data.DFinsupp.Defs (2.1s)
info: Mathlib/Data/DFinsupp/Defs.lean:924:0: [Elab.async] [0.012028] elaborating proof of DFinsupp.mapRange_def
  [Elab.definition.value] [0.011534] DFinsupp.mapRange_def
    [Elab.step] [0.011284] 
          ext
          simp_all
      [Elab.step] [0.011276] 
            ext
            simp_all
        [Elab.step] [0.010884] simp_all
Build completed successfully (626 jobs).
```
</details>

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

When merging, all the commits will be squashed into a single commit
listing all co-authors.

Co-authors in the squash commit are gathered from two sources:

First, all authors of commits to this PR branch are included. Thus,
one way to add co-authors is to include at least one commit authored by
each co-author among the commits in the pull request. If necessary, you
may create empty commits to indicate co-authorship, using commands like so:

git commit --author="Author Name <author@email.com>" --allow-empty -m "add Author Name as coauthor"

Second, co-authors can also be listed in lines at the very bottom of
the commit message (that is, directly before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines
at the bottom of the commit message (before the `---`, and also before
any "Co-authored-by" lines) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
