### PR TITLE
[Merged by Bors] - feat(RingTheory): `IsStandardEtale`

### DIFF
--- a/Mathlib/Algebra/Polynomial/Bivariate.lean
+++ b/Mathlib/Algebra/Polynomial/Bivariate.lean
@@ -293,7 +293,7 @@ lemma equivMvPolynomial_symm_X_1 : (equivMvPolynomial R).symm (.X 1) = X := by
 lemma equivMvPolynomial_symm_C (a : R) : (equivMvPolynomial R).symm (.C a) = C (C a) := by
   simp [equivMvPolynomial]
 
-lemma Polynomial.Bivariate.pderiv_zero_equivMvPolynomial {R : Type*} [CommRing R] (p : R[X][Y]) :
+lemma pderiv_zero_equivMvPolynomial {R : Type*} [CommRing R] (p : R[X][Y]) :
     (equivMvPolynomial R p).pderiv 0 = equivMvPolynomial R
       (PolynomialModule.equivPolynomialSelf (derivative'.mapCoeffs p)) := by
   induction p using Polynomial.induction_on' with
@@ -305,7 +305,7 @@ lemma Polynomial.Bivariate.pderiv_zero_equivMvPolynomial {R : Type*} [CommRing R
     simp_rw [← Polynomial.C_mul_X_pow_eq_monomial]
     simp [map_nsmul]
 
-lemma Polynomial.Bivariate.pderiv_one_equivMvPolynomial (p : R[X][Y]) :
+lemma pderiv_one_equivMvPolynomial (p : R[X][Y]) :
     (equivMvPolynomial R p).pderiv 1 = equivMvPolynomial R (derivative p) := by
   induction p using Polynomial.induction_on' with
   | add p q _ _ => aesop

--- a/Mathlib/RingTheory/Etale/Basic.lean
+++ b/Mathlib/RingTheory/Etale/Basic.lean
@@ -120,7 +120,7 @@ theorem comp [FormallyEtale R A] [FormallyEtale A B] :
   FormallyEtale.iff_formallyUnramified_and_formallySmooth.mpr
     ⟨FormallyUnramified.comp R A B, FormallySmooth.comp R A B⟩
 
-lemma Algebra.FormallyEtale.of_restrictScalars [FormallyUnramified R A] [FormallyEtale R B] :
+lemma of_restrictScalars [FormallyUnramified R A] [FormallyEtale R B] :
     FormallyEtale A B :=
   have := FormallyUnramified.of_restrictScalars R A B
   have := FormallySmooth.of_restrictScalars R A B
@@ -128,8 +128,8 @@ lemma Algebra.FormallyEtale.of_restrictScalars [FormallyUnramified R A] [Formall
 
 end Comp
 
-lemma Algebra.FormallyEtale.iff_of_surjective
-    {R S : Type u} [CommRing R] [CommRing S]
+lemma iff_of_surjective
+    {R S : Type*} [CommRing R] [CommRing S]
     [Algebra R S] (h : Function.Surjective (algebraMap R S)) :
     Algebra.FormallyEtale R S ↔ IsIdempotentElem (RingHom.ker (algebraMap R S)) := by
   rw [FormallyEtale.iff_formallyUnramified_and_formallySmooth, ← FormallySmooth.iff_of_surjective h,

--- a/Mathlib/RingTheory/Etale/StandardEtale.lean
+++ b/Mathlib/RingTheory/Etale/StandardEtale.lean
@@ -8,6 +8,8 @@ module
 public import Mathlib.Algebra.Polynomial.Bivariate
 public import Mathlib.Algebra.Polynomial.Taylor
 public import Mathlib.RingTheory.Etale.Basic
+public import Mathlib.RingTheory.Extension.Presentation.Submersive
+public import Mathlib.RingTheory.Ideal.IdempotentFG
 
 /-!
 
@@ -24,6 +26,8 @@ public import Mathlib.RingTheory.Etale.Basic
 - `StandardEtalePair.homEquiv`:
   Maps out of `P.Ring` corresponds to `x` such that `f(x) = 0` and `g(x)` is invertible.
 - We also provide the instance that `P.Ring` is etale over `R`.
+
+- `Algebra.IsStandardEtale`: The class of standard etale algebras.
 
 -/
 
@@ -235,3 +239,176 @@ lemma equivMvPolynomialQuotient_symm_apply :
   simp [equivMvPolynomialQuotient, StandardEtalePair.Ring]; rfl
 
 end StandardEtalePair
+
+variable (R S) in
+/-- An isomorphism to the standard etale algebra of a standard etale pair. -/
+structure StandardEtalePresentation extends P : StandardEtalePair R where
+  x : S
+  hasMap : P.HasMap x
+  lift_bijective : Function.Bijective (P.lift x hasMap)
+
+variable (P : StandardEtalePresentation R S)
+
+/-- The isomorphism to the standard etale algebra given a `StandardEtalePresentation`. -/
+def StandardEtalePresentation.equivRing : S ≃ₐ[R] P.Ring :=
+  .symm <| .ofBijective _ P.lift_bijective
+
+@[simp]
+lemma StandardEtalePresentation.equivRing_symm_X : P.equivRing.symm P.X = P.x :=
+  P.lift_X _ P.hasMap
+
+@[simp]
+lemma StandardEtalePresentation.equivRing_x : P.equivRing P.x = P.X :=
+  (P.equivRing.symm_apply_eq.mp P.equivRing_symm_X).symm
+
+/-- The `Algebra.Presentation` associated to a standard etale presentation. -/
+@[simps!]
+def StandardEtalePresentation.toPresentation : Algebra.Presentation R S (Fin 2) (Fin 2) where
+  __ := Algebra.Generators.ofAlgHom ((P.lift _ P.hasMap).comp
+      (P.equivMvPolynomialQuotient.symm.toAlgHom.comp (Ideal.Quotient.mkₐ _ _)))
+    (P.lift_bijective.surjective.comp
+      (P.equivMvPolynomialQuotient.symm.surjective.comp Ideal.Quotient.mk_surjective))
+  relation := ![Bivariate.equivMvPolynomial R (C P.f),
+    Bivariate.equivMvPolynomial R (.X * C P.g - 1)]
+  span_range_relation_eq_ker := by
+    rw [Algebra.Generators.ker_ofAlgHom, AlgHom.toRingHom_eq_coe, AlgHom.comp_toRingHom,
+      AlgHom.comp_toRingHom,
+      RingHom.ker_comp_of_injective _ (by exact P.lift_bijective.injective),
+      RingHom.ker_comp_of_injective _ (by exact P.equivMvPolynomialQuotient.symm.injective)]
+    simp [Set.pair_comm]
+
+lemma StandardEtalePresentation.aeval_val_equivMvPolynomial (p : R[X]) :
+    MvPolynomial.aeval P.toPresentation.val
+    (Bivariate.equivMvPolynomial R (.C p)) = p.aeval P.x := by
+  change (((MvPolynomial.aeval _).comp (Bivariate.equivMvPolynomial R).toAlgHom).comp CAlgHom) _ = _
+  congr 1
+  ext
+  simp
+
+/-- The `Algebra.SubmersivePresentation` associated to a standard etale presentation. -/
+def StandardEtalePresentation.toSubmersivePresentation :
+    Algebra.SubmersivePresentation R S (Fin 2) (Fin 2) where
+  __ := P.toPresentation
+  map := id
+  map_inj := Function.injective_id
+  jacobian_isUnit := by
+    simp [Algebra.PreSubmersivePresentation.jacobian_eq_jacobiMatrix_det,
+      Matrix.det_fin_two, Algebra.PreSubmersivePresentation.jacobiMatrix_apply,
+      Polynomial.Bivariate.pderiv_zero_equivMvPolynomial,
+      Polynomial.Bivariate.pderiv_one_equivMvPolynomial,
+      aeval_val_equivMvPolynomial, P.hasMap.2, P.hasMap.isUnit_derivative_f]
+
+lemma StandardEtalePresentation.toSubmersivePresentation_jacobian :
+    P.toSubmersivePresentation.jacobian = aeval P.x P.f.derivative * aeval P.x P.g := by
+  simp [StandardEtalePresentation.toSubmersivePresentation,
+    Algebra.PreSubmersivePresentation.jacobian_eq_jacobiMatrix_det,
+    Matrix.det_fin_two, Algebra.PreSubmersivePresentation.jacobiMatrix_apply,
+    Polynomial.Bivariate.pderiv_zero_equivMvPolynomial,
+    Polynomial.Bivariate.pderiv_one_equivMvPolynomial,
+    aeval_val_equivMvPolynomial]
+
+lemma StandardEtalePresentation.exists_mul_aeval_x_g_pow_eq_aeval_x (x : S) :
+    ∃ p : R[X], ∃ n, x * P.g.aeval P.x ^ n = p.aeval P.x := by
+  obtain ⟨x, rfl⟩ := (P.equivRing.trans P.P.equivAwayAdjoinRoot).symm.surjective x
+  obtain ⟨⟨p, ⟨_, n, rfl⟩⟩, e⟩ := IsLocalization.surj (.powers (AdjoinRoot.mk P.f P.g)) x
+  obtain ⟨p, rfl⟩ := AdjoinRoot.mk_surjective p
+  refine ⟨p, n, P.equivRing.injective ?_⟩
+  simpa [← aeval_algHom_apply, StandardEtalePair.equivAwayAdjoinRoot, ← aeval_def] using
+    congr(P.equivAwayAdjoinRoot.symm $e)
+
+/-- Mapping `StandardEtalePresentation` under `AlgEquiv`s. -/
+def StandardEtalePresentation.mapEquiv (e : S ≃ₐ[R] T) : StandardEtalePresentation R T where
+  P := P.P
+  x := e P.x
+  hasMap := P.hasMap.map e.toAlgHom
+  lift_bijective := (show P.lift (e P.x) (P.hasMap.map e.toAlgHom) = e.toAlgHom.comp
+    (P.lift _ P.hasMap) from P.hom_ext (by simp)) ▸ e.bijective.comp P.lift_bijective
+
+namespace Algebra
+
+variable (R S) in
+/-- The class of standard etale algebras,
+defined to be the existence of a `StandardEtalePresentation`. -/
+class IsStandardEtale where
+  nonempty_standardEtalePresentation : Nonempty (StandardEtalePresentation R S)
+
+attribute [instance] IsStandardEtale.nonempty_standardEtalePresentation
+
+instance (priority := low) [IsStandardEtale R S] : Algebra.FinitePresentation R S :=
+  IsStandardEtale.nonempty_standardEtalePresentation
+    |>.some.toPresentation.finitePresentation_of_isFinite
+
+instance (P : StandardEtalePair R) : IsStandardEtale R P.Ring :=
+  ⟨⟨P, P.X, P.hasMap_X, by simpa [StandardEtalePair.lift_X_left] using Function.bijective_id⟩⟩
+
+instance (priority := low) [IsStandardEtale R S] : Algebra.FinitePresentation R S :=
+  IsStandardEtale.nonempty_standardEtalePresentation
+    |>.some.toPresentation.finitePresentation_of_isFinite
+
+instance (priority := low) [IsStandardEtale R S] : Algebra.FormallyEtale R S :=
+  .of_equiv IsStandardEtale.nonempty_standardEtalePresentation.some.equivRing.symm
+
+instance (priority := low) [IsStandardEtale R S] : Algebra.Etale R S where
+
+lemma IsStandardEtale.of_equiv (e : S ≃ₐ[R] T) [IsStandardEtale R S] : IsStandardEtale R T :=
+  ⟨⟨IsStandardEtale.nonempty_standardEtalePresentation.some.mapEquiv e⟩⟩
+
+instance : IsStandardEtale R R :=
+  ⟨⟨⟨⟨.X, by simp, 1, 1, 0, 0, by simp⟩, 0, ⟨by simp, by simp⟩, by
+    set P : StandardEtalePair R := ⟨.X, by simp, 1, 1, 0, 0, by simp⟩
+    have : P.X = 0 := Ideal.Quotient.eq_zero_iff_mem.mpr (Ideal.subset_span (Set.mem_insert _ _))
+    let e := AlgEquiv.ofAlgHom (P.lift (0 : R) ⟨by simp [P], by simp [P]⟩) (Algebra.ofId _ _)
+      (by ext) (by ext; simp [this])
+    exact e.bijective⟩⟩⟩
+
+lemma IsStandardEtale.of_isLocalizationAway [IsStandardEtale R S]
+    {Sₛ : Type*} [CommRing Sₛ] [Algebra S Sₛ]
+    [Algebra R Sₛ] [IsScalarTower R S Sₛ] (s : S) [IsLocalization.Away s Sₛ] :
+    IsStandardEtale R Sₛ := by
+  have P : StandardEtalePresentation R S := IsStandardEtale.nonempty_standardEtalePresentation.some
+  obtain ⟨p, n, hp⟩ := P.exists_mul_aeval_x_g_pow_eq_aeval_x s
+  let P' : StandardEtalePair R := ⟨P.f, P.monic_f, p * P.g, have ⟨p₁, p₂, m, e⟩ := P.cond;
+    ⟨p₁ * p ^ m, p₂ * p ^ m, m, by linear_combination e * p ^ m⟩⟩
+  let S' := Localization.Away (AdjoinRoot.mk P.f P.g)
+  let e : S ≃ₐ[R] S' := P.equivRing.trans P.P.equivAwayAdjoinRoot
+  have := IsLocalization.Away.mul S' (Localization.Away (algebraMap _ S' (AdjoinRoot.mk P.f p)))
+    (AdjoinRoot.mk P.f P.g) (.mk _ p)
+  rw [← map_mul] at this
+  have H : Submonoid.map e.symm.toRingEquiv.toMonoidHom (.powers
+      (algebraMap _ S' (AdjoinRoot.mk P.f p))) = .powers (aeval P.x p) := by
+    rw [Submonoid.map_powers]
+    congr 1
+    change ((e.symm.toAlgHom.comp (IsScalarTower.toAlgHom R (AdjoinRoot P.f) S')).comp
+      (AdjoinRoot.mkₐ P.f)) p = _
+    congr 1
+    ext
+    simp [e, StandardEtalePair.equivAwayAdjoinRoot]
+  have : IsLocalization.Away (aeval P.x p) Sₛ :=
+    IsLocalization.Away.of_associated (r := s) ⟨(P.hasMap.2.pow n).unit, hp⟩
+  let e₁ : P'.Ring ≃ₐ[R]
+      Localization.Away (algebraMap _ S' (AdjoinRoot.mk P.f p)) :=
+    P'.equivAwayAdjoinRoot.trans ((IsLocalization.algEquiv (.powers (AdjoinRoot.mk P.f (p * P.g)))
+      (Localization.Away (AdjoinRoot.mk P.f (p * P.g))) _).restrictScalars R)
+  let e₂ : Localization.Away (algebraMap _ S' (AdjoinRoot.mk P.f p)) ≃ₐ[R] Sₛ :=
+    { __ := IsLocalization.ringEquivOfRingEquiv _ _ _ H,
+      commutes' r := by
+        simp [IsScalarTower.algebraMap_apply R S' (Localization.Away _),
+          - AlgEquiv.symm_toRingEquiv, IsScalarTower.algebraMap_eq R S Sₛ] }
+  exact .of_equiv (e₁.trans e₂)
+
+/-- If `T` is an etale algebra, and a standard etale algebra surjects onto `T`, then
+  `T` is also standard etale. -/
+lemma IsStandardEtale.of_surjective
+    (R S T : Type*) [CommRing R] [CommRing S] [CommRing T]
+    [Algebra R S] [Algebra R T]
+    [IsStandardEtale R S] [Algebra.Etale R T] (f : S →ₐ[R] T) (hf : Function.Surjective f) :
+    IsStandardEtale R T := by
+  letI := f.toAlgebra
+  have : IsScalarTower R S T := .of_algebraMap_eq' f.comp_algebraMap.symm
+  obtain ⟨e, he, hfe⟩ :=
+    (Ideal.isIdempotentElem_iff_of_fg _ (Algebra.FinitePresentation.ker_fG_of_surjective f hf)).mp
+      ((Algebra.FormallyEtale.iff_of_surjective hf).mp (.of_restrictScalars (R := R)))
+  have := IsLocalization.away_of_isIdempotentElem he.one_sub (hfe.trans (by simp)) hf
+  exact .of_isLocalizationAway (1 - e)
+
+end Algebra

--- a/Mathlib/RingTheory/Etale/StandardEtale.lean
+++ b/Mathlib/RingTheory/Etale/StandardEtale.lean
@@ -281,13 +281,18 @@ def StandardEtalePresentation.toPresentation : Algebra.Presentation R S (Fin 2) 
       RingHom.ker_comp_of_injective _ (by exact P.equivMvPolynomialQuotient.symm.injective)]
     simp [Set.pair_comm]
 
-lemma StandardEtalePresentation.aeval_val_equivMvPolynomial (p : R[X]) :
+@[simp] lemma StandardEtalePresentation.aeval_val_equivMvPolynomial (p : R[X]) :
     MvPolynomial.aeval P.toPresentation.val
     (Bivariate.equivMvPolynomial R (.C p)) = p.aeval P.x := by
   change (((MvPolynomial.aeval _).comp (Bivariate.equivMvPolynomial R).toAlgHom).comp CAlgHom) _ = _
   congr 1
   ext
   simp
+
+attribute [local simp] Algebra.PreSubmersivePresentation.jacobian_eq_jacobiMatrix_det
+  Matrix.det_fin_two Algebra.PreSubmersivePresentation.jacobiMatrix_apply
+  Polynomial.Bivariate.pderiv_zero_equivMvPolynomial
+  Polynomial.Bivariate.pderiv_one_equivMvPolynomial
 
 /-- The `Algebra.SubmersivePresentation` associated to a standard etale presentation. -/
 @[simps map toPreSubmersivePresentation_toPresentation]
@@ -296,21 +301,11 @@ def StandardEtalePresentation.toSubmersivePresentation :
   __ := P.toPresentation
   map := id
   map_inj := Function.injective_id
-  jacobian_isUnit := by
-    simp [Algebra.PreSubmersivePresentation.jacobian_eq_jacobiMatrix_det,
-      Matrix.det_fin_two, Algebra.PreSubmersivePresentation.jacobiMatrix_apply,
-      Polynomial.Bivariate.pderiv_zero_equivMvPolynomial,
-      Polynomial.Bivariate.pderiv_one_equivMvPolynomial,
-      aeval_val_equivMvPolynomial, P.hasMap.2, P.hasMap.isUnit_derivative_f]
+  jacobian_isUnit := by simp [P.hasMap.2, P.hasMap.isUnit_derivative_f]
 
 lemma StandardEtalePresentation.toSubmersivePresentation_jacobian :
     P.toSubmersivePresentation.jacobian = aeval P.x P.f.derivative * aeval P.x P.g := by
-  simp [StandardEtalePresentation.toSubmersivePresentation,
-    Algebra.PreSubmersivePresentation.jacobian_eq_jacobiMatrix_det,
-    Matrix.det_fin_two, Algebra.PreSubmersivePresentation.jacobiMatrix_apply,
-    Polynomial.Bivariate.pderiv_zero_equivMvPolynomial,
-    Polynomial.Bivariate.pderiv_one_equivMvPolynomial,
-    aeval_val_equivMvPolynomial]
+  simp [StandardEtalePresentation.toSubmersivePresentation]
 
 lemma StandardEtalePresentation.exists_mul_aeval_x_g_pow_eq_aeval_x (x : S) :
     ∃ p : R[X], ∃ n, x * P.g.aeval P.x ^ n = p.aeval P.x := by
@@ -370,13 +365,10 @@ lemma IsStandardEtale.of_isLocalizationAway [IsStandardEtale R S]
   rw [← map_mul] at this
   have H : Submonoid.map e.symm.toRingEquiv.toMonoidHom (.powers
       (algebraMap _ S' (AdjoinRoot.mk P.f p))) = .powers (aeval P.x p) := by
+    have : ((e.symm.toAlgHom.comp (IsScalarTower.toAlgHom R _ S')).comp (AdjoinRoot.mkₐ P.f)) =
+      aeval P.x := by ext; simp [e, StandardEtalePair.equivAwayAdjoinRoot]
     rw [Submonoid.map_powers]
-    congr 1
-    change ((e.symm.toAlgHom.comp (IsScalarTower.toAlgHom R (AdjoinRoot P.f) S')).comp
-      (AdjoinRoot.mkₐ P.f)) p = _
-    congr 1
-    ext
-    simp [e, StandardEtalePair.equivAwayAdjoinRoot]
+    exact congr(Submonoid.powers ($this p))
   have : IsLocalization.Away (aeval P.x p) Sₛ :=
     IsLocalization.Away.of_associated (r := s) ⟨(P.hasMap.2.pow n).unit, hp⟩
   let e₁ : P'.Ring ≃ₐ[R]

--- a/Mathlib/RingTheory/Etale/StandardEtale.lean
+++ b/Mathlib/RingTheory/Etale/StandardEtale.lean
@@ -243,6 +243,7 @@ end StandardEtalePair
 variable (R S) in
 /-- An isomorphism to the standard etale algebra of a standard etale pair. -/
 structure StandardEtalePresentation extends P : StandardEtalePair R where
+  /-- The image of X in a `StandardEtalePresentation`. -/
   x : S
   hasMap : P.HasMap x
   lift_bijective : Function.Bijective (P.lift x hasMap)

--- a/Mathlib/RingTheory/Etale/StandardEtale.lean
+++ b/Mathlib/RingTheory/Etale/StandardEtale.lean
@@ -184,6 +184,9 @@ instance : Algebra.FormallyEtale R P.Ring := by
   exact ⟨⟨x + ε, hε⟩, by simpa, fun y hy ↦
     Subtype.ext (sub_eq_iff_eq_add'.mp (H _ ⟨hy, by simpa using y.2⟩))⟩
 
+instance : Algebra.Etale R P.Ring where
+  finitePresentation := .quotient (Submodule.fg_span (by simp))
+
 /-- An `AlgEquiv` between `P.Ring` and `R[X][Y]/⟨f, Yg-1⟩`,
 to not abuse the defeq between the two. -/
 def equivPolynomialQuotient :
@@ -240,9 +243,9 @@ lemma equivMvPolynomialQuotient_symm_apply :
 
 end StandardEtalePair
 
-variable (R S) in
 /-- An isomorphism to the standard etale algebra of a standard etale pair. -/
-structure StandardEtalePresentation extends P : StandardEtalePair R where
+structure StandardEtalePresentation (R S : Type*) [CommRing R] [CommRing S] [Algebra R S] extends
+    P : StandardEtalePair R where
   /-- The image of X in a `StandardEtalePresentation`. -/
   x : S
   hasMap : P.HasMap x
@@ -287,6 +290,7 @@ lemma StandardEtalePresentation.aeval_val_equivMvPolynomial (p : R[X]) :
   simp
 
 /-- The `Algebra.SubmersivePresentation` associated to a standard etale presentation. -/
+@[simps map toPreSubmersivePresentation_toPresentation]
 def StandardEtalePresentation.toSubmersivePresentation :
     Algebra.SubmersivePresentation R S (Fin 2) (Fin 2) where
   __ := P.toPresentation
@@ -327,29 +331,18 @@ def StandardEtalePresentation.mapEquiv (e : S ≃ₐ[R] T) : StandardEtalePresen
 
 namespace Algebra
 
-variable (R S) in
 /-- The class of standard etale algebras,
 defined to be the existence of a `StandardEtalePresentation`. -/
-class IsStandardEtale where
+class IsStandardEtale (R S : Type*) [CommRing R] [CommRing S] [Algebra R S] where
   nonempty_standardEtalePresentation : Nonempty (StandardEtalePresentation R S)
 
 attribute [instance] IsStandardEtale.nonempty_standardEtalePresentation
 
-instance (priority := low) [IsStandardEtale R S] : Algebra.FinitePresentation R S :=
-  IsStandardEtale.nonempty_standardEtalePresentation
-    |>.some.toPresentation.finitePresentation_of_isFinite
-
 instance (P : StandardEtalePair R) : IsStandardEtale R P.Ring :=
   ⟨⟨P, P.X, P.hasMap_X, by simpa [StandardEtalePair.lift_X_left] using Function.bijective_id⟩⟩
 
-instance (priority := low) [IsStandardEtale R S] : Algebra.FinitePresentation R S :=
-  IsStandardEtale.nonempty_standardEtalePresentation
-    |>.some.toPresentation.finitePresentation_of_isFinite
-
-instance (priority := low) [IsStandardEtale R S] : Algebra.FormallyEtale R S :=
+instance (priority := low) [IsStandardEtale R S] : Algebra.Etale R S :=
   .of_equiv IsStandardEtale.nonempty_standardEtalePresentation.some.equivRing.symm
-
-instance (priority := low) [IsStandardEtale R S] : Algebra.Etale R S where
 
 lemma IsStandardEtale.of_equiv (e : S ≃ₐ[R] T) [IsStandardEtale R S] : IsStandardEtale R T :=
   ⟨⟨IsStandardEtale.nonempty_standardEtalePresentation.some.mapEquiv e⟩⟩

--- a/Mathlib/RingTheory/Extension/Generators.lean
+++ b/Mathlib/RingTheory/Extension/Generators.lean
@@ -543,6 +543,13 @@ lemma ker_naive {σ : Type*} {I : Ideal (MvPolynomial σ R)}
     (Generators.naive s hs).ker = I :=
   I.mk_ker
 
+@[simp]
+lemma ker_ofAlgHom {I : Type*} (f : MvPolynomial I R →ₐ[R] S) (h : Function.Surjective ⇑f) :
+    (ofAlgHom f h).ker = RingHom.ker f.toRingHom := by
+  change RingHom.ker _ = _
+  congr
+  exact MvPolynomial.ringHom_ext (by simp) (by simp [ofAlgHom])
+
 lemma map_toComp_ker (Q : Generators S T ι') (P : Generators R S ι) :
     P.ker.map (Q.toComp P).toAlgHom = RingHom.ker (Q.ofComp P).toAlgHom := by
   letI : DecidableEq (ι' →₀ ℕ) := Classical.decEq _


### PR DESCRIPTION

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

When merging, all the commits will be squashed into a single commit
listing all co-authors.

Co-authors in the squash commit are gathered from two sources:

First, all authors of commits to this PR branch are included. Thus,
one way to add co-authors is to include at least one commit authored by
each co-author among the commits in the pull request. If necessary, you
may create empty commits to indicate co-authorship, using commands like so:

git commit --author="Author Name <author@email.com>" --allow-empty -m "add Author Name as coauthor"

Second, co-authors can also be listed in lines at the very bottom of
the commit message (that is, directly before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines
at the bottom of the commit message (before the `---`, and also before
any "Co-authored-by" lines) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
