### PR TITLE
[Merged by Bors] - chore(Data/Part): golf entire `assert_pos` and `assert_neg` using `ext; simp_all`

### DIFF
--- a/Mathlib/Data/Part.lean
+++ b/Mathlib/Data/Part.lean
@@ -413,19 +413,12 @@ theorem mem_assert_iff {p : Prop} {f : p → Part α} {a} : a ∈ assert p f ↔
     fun ⟨_, h⟩ => mem_assert _ h⟩
 
 theorem assert_pos {p : Prop} {f : p → Part α} (h : p) : assert p f = f h := by
-  dsimp [assert]
-  cases h' : f h
-  simp only [h', mk.injEq, h, exists_prop_of_true, true_and]
-  apply Function.hfunext
-  · simp only [h, h', exists_prop_of_true]
-  · simp
+  ext
+  simp_all
 
 theorem assert_neg {p : Prop} {f : p → Part α} (h : ¬p) : assert p f = none := by
-  dsimp [assert, none]; congr
-  · simp only [h, not_false_iff, exists_prop_of_false]
-  · apply Function.hfunext
-    · simp only [h, not_false_iff, exists_prop_of_false]
-    simp at *
+  ext
+  simp_all
 
 theorem mem_bind {f : Part α} {g : α → Part β} : ∀ {a b}, a ∈ f → b ∈ g a → b ∈ f.bind g
   | _, _, ⟨h, rfl⟩, ⟨h₂, rfl⟩ => ⟨⟨h, h₂⟩, rfl⟩


### PR DESCRIPTION
---
<details>
<summary>Show trace profiling of <code>assert_neg</code>: <10 ms before, <10 ms after  🎉</summary>

### Trace profiling of `assert_neg` before PR 32139
```diff
diff --git a/Mathlib/Data/Part.lean b/Mathlib/Data/Part.lean
index 687e158a18..2be735092d 100644
--- a/Mathlib/Data/Part.lean
+++ b/Mathlib/Data/Part.lean
@@ -420,6 +420,7 @@ theorem assert_pos {p : Prop} {f : p → Part α} (h : p) : assert p f = f h :=
   · simp only [h, h', exists_prop_of_true]
   · simp
 
+set_option trace.profiler true in
 theorem assert_neg {p : Prop} {f : p → Part α} (h : ¬p) : assert p f = none := by
   dsimp [assert, none]; congr
   · simp only [h, not_false_iff, exists_prop_of_false]
```
```
ℹ [375/375] Built Mathlib.Data.Part (1.6s)
info: Mathlib/Data/Part.lean:424:0: [Elab.async] [0.010135] elaborating proof of Part.assert_neg
Build completed successfully (375 jobs).
```

### Trace profiling of `assert_neg` after PR 32139
```diff
diff --git a/Mathlib/Data/Part.lean b/Mathlib/Data/Part.lean
index 687e158a18..19ab5bd219 100644
--- a/Mathlib/Data/Part.lean
+++ b/Mathlib/Data/Part.lean
@@ -413,19 +413,13 @@ theorem mem_assert_iff {p : Prop} {f : p → Part α} {a} : a ∈ assert p f ↔
     fun ⟨_, h⟩ => mem_assert _ h⟩
 
 theorem assert_pos {p : Prop} {f : p → Part α} (h : p) : assert p f = f h := by
-  dsimp [assert]
-  cases h' : f h
-  simp only [h', mk.injEq, h, exists_prop_of_true, true_and]
-  apply Function.hfunext
-  · simp only [h, h', exists_prop_of_true]
-  · simp
+  ext
+  simp_all
 
+set_option trace.profiler true in
 theorem assert_neg {p : Prop} {f : p → Part α} (h : ¬p) : assert p f = none := by
-  dsimp [assert, none]; congr
-  · simp only [h, not_false_iff, exists_prop_of_false]
-  · apply Function.hfunext
-    · simp only [h, not_false_iff, exists_prop_of_false]
-    simp at *
+  ext
+  simp_all
 
 theorem mem_bind {f : Part α} {g : α → Part β} : ∀ {a b}, a ∈ f → b ∈ g a → b ∈ f.bind g
   | _, _, ⟨h, rfl⟩, ⟨h₂, rfl⟩ => ⟨⟨h, h₂⟩, rfl⟩
```
```
✔ [375/375] Built Mathlib.Data.Part (1.6s)
Build completed successfully (375 jobs).
```
</details>

---
<details>
<summary>Show trace profiling of <code>assert_pos</code>: <10 ms before, <10 ms after  🎉</summary>

### Trace profiling of `assert_pos` before PR 32139
```diff
diff --git a/Mathlib/Data/Part.lean b/Mathlib/Data/Part.lean
index 687e158a18..1114546ac8 100644
--- a/Mathlib/Data/Part.lean
+++ b/Mathlib/Data/Part.lean
@@ -412,6 +412,7 @@ theorem mem_assert_iff {p : Prop} {f : p → Part α} {a} : a ∈ assert p f ↔
     | _, ⟨_, rfl⟩ => ⟨_, ⟨_, rfl⟩⟩,
     fun ⟨_, h⟩ => mem_assert _ h⟩
 
+set_option trace.profiler true in
 theorem assert_pos {p : Prop} {f : p → Part α} (h : p) : assert p f = f h := by
   dsimp [assert]
   cases h' : f h
```
```
✔ [375/375] Built Mathlib.Data.Part (1.6s)
Build completed successfully (375 jobs).
```

### Trace profiling of `assert_pos` after PR 32139
```diff
diff --git a/Mathlib/Data/Part.lean b/Mathlib/Data/Part.lean
index 687e158a18..211eeb77a9 100644
--- a/Mathlib/Data/Part.lean
+++ b/Mathlib/Data/Part.lean
@@ -412,20 +412,14 @@ theorem mem_assert_iff {p : Prop} {f : p → Part α} {a} : a ∈ assert p f ↔
     | _, ⟨_, rfl⟩ => ⟨_, ⟨_, rfl⟩⟩,
     fun ⟨_, h⟩ => mem_assert _ h⟩
 
+set_option trace.profiler true in
 theorem assert_pos {p : Prop} {f : p → Part α} (h : p) : assert p f = f h := by
-  dsimp [assert]
-  cases h' : f h
-  simp only [h', mk.injEq, h, exists_prop_of_true, true_and]
-  apply Function.hfunext
-  · simp only [h, h', exists_prop_of_true]
-  · simp
+  ext
+  simp_all
 
 theorem assert_neg {p : Prop} {f : p → Part α} (h : ¬p) : assert p f = none := by
-  dsimp [assert, none]; congr
-  · simp only [h, not_false_iff, exists_prop_of_false]
-  · apply Function.hfunext
-    · simp only [h, not_false_iff, exists_prop_of_false]
-    simp at *
+  ext
+  simp_all
 
 theorem mem_bind {f : Part α} {g : α → Part β} : ∀ {a b}, a ∈ f → b ∈ g a → b ∈ f.bind g
   | _, _, ⟨h, rfl⟩, ⟨h₂, rfl⟩ => ⟨⟨h, h₂⟩, rfl⟩
```
```
✔ [375/375] Built Mathlib.Data.Part (1.6s)
Build completed successfully (375 jobs).
```
</details>

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

When merging, all the commits will be squashed into a single commit
listing all co-authors.

Co-authors in the squash commit are gathered from two sources:

First, all authors of commits to this PR branch are included. Thus,
one way to add co-authors is to include at least one commit authored by
each co-author among the commits in the pull request. If necessary, you
may create empty commits to indicate co-authorship, using commands like so:

git commit --author="Author Name <author@email.com>" --allow-empty -m "add Author Name as coauthor"

Second, co-authors can also be listed in lines at the very bottom of
the commit message (that is, directly before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines
at the bottom of the commit message (before the `---`, and also before
any "Co-authored-by" lines) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
