### PR TITLE
[Merged by Bors] - chore(Data/Sum): golf `Data.Sum.Basic` using `grind`

### DIFF
--- a/Mathlib/Data/Sum/Basic.lean
+++ b/Mathlib/Data/Sum/Basic.lean
@@ -28,10 +28,7 @@ namespace Sum
 @[simp]
 theorem elim_swap {α β γ : Type*} {f : α → γ} {g : β → γ} :
     Sum.elim f g ∘ Sum.swap = Sum.elim g f := by
-  ext x
-  cases x with
-  | inl x => simp
-  | inr x => simp
+  grind
 
 -- Lean has removed the `@[simp]` attribute on these. For now Mathlib adds it back.
 attribute [simp] Sum.forall Sum.exists
@@ -47,29 +44,29 @@ theorem inr_injective : Function.Injective (inr : β → α ⊕ β) := fun _ _ �
 
 theorem sum_rec_congr (P : α ⊕ β → Sort*) (f : ∀ i, P (inl i)) (g : ∀ i, P (inr i))
     {x y : α ⊕ β} (h : x = y) :
-    @Sum.rec _ _ _ f g x = cast (congr_arg P h.symm) (@Sum.rec _ _ _ f g y) := by cases h; rfl
+    @Sum.rec _ _ _ f g x = cast (congr_arg P h.symm) (@Sum.rec _ _ _ f g y) := by grind
 
 section get
 
 variable {x : α ⊕ β}
 
 theorem eq_left_iff_getLeft_eq {a : α} : x = inl a ↔ ∃ h, x.getLeft h = a := by
-  cases x <;> simp
+  grind
 
 theorem eq_right_iff_getRight_eq {b : β} : x = inr b ↔ ∃ h, x.getRight h = b := by
-  cases x <;> simp
+  grind
 
 theorem getLeft_eq_getLeft? (h₁ : x.isLeft) (h₂ : x.getLeft?.isSome) :
-    x.getLeft h₁ = x.getLeft?.get h₂ := by simp [← getLeft?_eq_some_iff]
+    x.getLeft h₁ = x.getLeft?.get h₂ := by grind
 
 theorem getRight_eq_getRight? (h₁ : x.isRight) (h₂ : x.getRight?.isSome) :
-    x.getRight h₁ = x.getRight?.get h₂ := by simp [← getRight?_eq_some_iff]
+    x.getRight h₁ = x.getRight?.get h₂ := by grind
 
 @[simp] theorem isSome_getLeft?_iff_isLeft : x.getLeft?.isSome ↔ x.isLeft := by
-  rw [isLeft_iff, Option.isSome_iff_exists]; simp
+  grind
 
 @[simp] theorem isSome_getRight?_iff_isRight : x.getRight?.isSome ↔ x.isRight := by
-  rw [isRight_iff, Option.isSome_iff_exists]; simp
+  grind
 
 end get
 
@@ -78,12 +75,12 @@ open Function (update update_eq_iff update_comp_eq_of_injective update_comp_eq_o
 @[simp]
 theorem update_elim_inl [DecidableEq α] [DecidableEq (α ⊕ β)] {f : α → γ} {g : β → γ} {i : α}
     {x : γ} : update (Sum.elim f g) (inl i) x = Sum.elim (update f i x) g :=
-  update_eq_iff.2 ⟨by simp, by simp +contextual⟩
+  update_eq_iff.2 ⟨by simp, by grind⟩
 
 @[simp]
 theorem update_elim_inr [DecidableEq β] [DecidableEq (α ⊕ β)] {f : α → γ} {g : β → γ} {i : β}
     {x : γ} : update (Sum.elim f g) (inr i) x = Sum.elim f (update g i x) :=
-  update_eq_iff.2 ⟨by simp, by simp +contextual⟩
+  update_eq_iff.2 ⟨by simp, by grind⟩
 
 @[simp]
 theorem update_inl_comp_inl [DecidableEq α] [DecidableEq (α ⊕ β)] {f : α ⊕ β → γ} {i : α}
@@ -93,7 +90,7 @@ theorem update_inl_comp_inl [DecidableEq α] [DecidableEq (α ⊕ β)] {f : α �
 @[simp]
 theorem update_inl_apply_inl [DecidableEq α] [DecidableEq (α ⊕ β)] {f : α ⊕ β → γ} {i j : α}
     {x : γ} : update f (inl i) x (inl j) = update (f ∘ inl) i x j := by
-  rw [← update_inl_comp_inl, Function.comp_apply]
+  grind
 
 @[simp]
 theorem update_inl_comp_inr [DecidableEq (α ⊕ β)] {f : α ⊕ β → γ} {i : α} {x : γ} :
@@ -178,28 +175,24 @@ namespace LiftRel
 variable {r : α → γ → Prop} {s : β → δ → Prop} {x : α ⊕ β} {y : γ ⊕ δ}
   {a : α} {b : β} {c : γ} {d : δ}
 
-theorem isLeft_congr (h : LiftRel r s x y) : x.isLeft ↔ y.isLeft := by cases h <;> rfl
-theorem isRight_congr (h : LiftRel r s x y) : x.isRight ↔ y.isRight := by cases h <;> rfl
+theorem isLeft_congr (h : LiftRel r s x y) : x.isLeft ↔ y.isLeft := by grind
+theorem isRight_congr (h : LiftRel r s x y) : x.isRight ↔ y.isRight := by grind
 
-theorem isLeft_left (h : LiftRel r s x (inl c)) : x.isLeft := by cases h; rfl
-theorem isLeft_right (h : LiftRel r s (inl a) y) : y.isLeft := by cases h; rfl
-theorem isRight_left (h : LiftRel r s x (inr d)) : x.isRight := by cases h; rfl
-theorem isRight_right (h : LiftRel r s (inr b) y) : y.isRight := by cases h; rfl
+theorem isLeft_left (h : LiftRel r s x (inl c)) : x.isLeft := by grind
+theorem isLeft_right (h : LiftRel r s (inl a) y) : y.isLeft := by grind
+theorem isRight_left (h : LiftRel r s x (inr d)) : x.isRight := by grind
+theorem isRight_right (h : LiftRel r s (inr b) y) : y.isRight := by grind
 
 theorem exists_of_isLeft_left (h₁ : LiftRel r s x y) (h₂ : x.isLeft) :
     ∃ a c, r a c ∧ x = inl a ∧ y = inl c := by
-  rcases isLeft_iff.mp h₂ with ⟨_, rfl⟩
-  simp only [liftRel_iff, false_and, and_false, exists_false, or_false, reduceCtorEq] at h₁
-  exact h₁
+  grind
 
 theorem exists_of_isLeft_right (h₁ : LiftRel r s x y) (h₂ : y.isLeft) :
     ∃ a c, r a c ∧ x = inl a ∧ y = inl c := exists_of_isLeft_left h₁ ((isLeft_congr h₁).mpr h₂)
 
 theorem exists_of_isRight_left (h₁ : LiftRel r s x y) (h₂ : x.isRight) :
     ∃ b d, s b d ∧ x = inr b ∧ y = inr d := by
-  rcases isRight_iff.mp h₂ with ⟨_, rfl⟩
-  simp only [liftRel_iff, false_and, and_false, exists_false, false_or, reduceCtorEq] at h₁
-  exact h₁
+  grind
 
 theorem exists_of_isRight_right (h₁ : LiftRel r s x y) (h₂ : y.isRight) :
     ∃ b d, s b d ∧ x = inr b ∧ y = inr d :=

--- a/Mathlib/Data/Sum/Basic.lean
+++ b/Mathlib/Data/Sum/Basic.lean
@@ -44,17 +44,17 @@ theorem inr_injective : Function.Injective (inr : β → α ⊕ β) := fun _ _ �
 
 theorem sum_rec_congr (P : α ⊕ β → Sort*) (f : ∀ i, P (inl i)) (g : ∀ i, P (inr i))
     {x y : α ⊕ β} (h : x = y) :
-    @Sum.rec _ _ _ f g x = cast (congr_arg P h.symm) (@Sum.rec _ _ _ f g y) := by grind
+    @Sum.rec _ _ _ f g x = cast (congr_arg P h.symm) (@Sum.rec _ _ _ f g y) := by cases h; rfl
 
 section get
 
 variable {x : α ⊕ β}
 
 theorem eq_left_iff_getLeft_eq {a : α} : x = inl a ↔ ∃ h, x.getLeft h = a := by
-  grind
+  cases x <;> simp
 
 theorem eq_right_iff_getRight_eq {b : β} : x = inr b ↔ ∃ h, x.getRight h = b := by
-  grind
+  cases x <;> simp
 
 theorem getLeft_eq_getLeft? (h₁ : x.isLeft) (h₂ : x.getLeft?.isSome) :
     x.getLeft h₁ = x.getLeft?.get h₂ := by grind
@@ -75,12 +75,12 @@ open Function (update update_eq_iff update_comp_eq_of_injective update_comp_eq_o
 @[simp]
 theorem update_elim_inl [DecidableEq α] [DecidableEq (α ⊕ β)] {f : α → γ} {g : β → γ} {i : α}
     {x : γ} : update (Sum.elim f g) (inl i) x = Sum.elim (update f i x) g :=
-  update_eq_iff.2 ⟨by simp, by grind⟩
+  update_eq_iff.2 ⟨by simp, by simp +contextual⟩
 
 @[simp]
 theorem update_elim_inr [DecidableEq β] [DecidableEq (α ⊕ β)] {f : α → γ} {g : β → γ} {i : β}
     {x : γ} : update (Sum.elim f g) (inr i) x = Sum.elim f (update g i x) :=
-  update_eq_iff.2 ⟨by simp, by grind⟩
+  update_eq_iff.2 ⟨by simp, by simp +contextual⟩
 
 @[simp]
 theorem update_inl_comp_inl [DecidableEq α] [DecidableEq (α ⊕ β)] {f : α ⊕ β → γ} {i : α}

--- a/Mathlib/Data/Sum/Basic.lean
+++ b/Mathlib/Data/Sum/Basic.lean
@@ -175,13 +175,13 @@ namespace LiftRel
 variable {r : α → γ → Prop} {s : β → δ → Prop} {x : α ⊕ β} {y : γ ⊕ δ}
   {a : α} {b : β} {c : γ} {d : δ}
 
-theorem isLeft_congr (h : LiftRel r s x y) : x.isLeft ↔ y.isLeft := by grind
-theorem isRight_congr (h : LiftRel r s x y) : x.isRight ↔ y.isRight := by grind
+theorem isLeft_congr (h : LiftRel r s x y) : x.isLeft ↔ y.isLeft := by cases h <;> rfl
+theorem isRight_congr (h : LiftRel r s x y) : x.isRight ↔ y.isRight := by cases h <;> rfl
 
-theorem isLeft_left (h : LiftRel r s x (inl c)) : x.isLeft := by grind
-theorem isLeft_right (h : LiftRel r s (inl a) y) : y.isLeft := by grind
-theorem isRight_left (h : LiftRel r s x (inr d)) : x.isRight := by grind
-theorem isRight_right (h : LiftRel r s (inr b) y) : y.isRight := by grind
+theorem isLeft_left (h : LiftRel r s x (inl c)) : x.isLeft := by cases h; rfl
+theorem isLeft_right (h : LiftRel r s (inl a) y) : y.isLeft := by cases h; rfl
+theorem isRight_left (h : LiftRel r s x (inr d)) : x.isRight := by cases h; rfl
+theorem isRight_right (h : LiftRel r s (inr b) y) : y.isRight := by cases h; rfl
 
 theorem exists_of_isLeft_left (h₁ : LiftRel r s x y) (h₂ : x.isLeft) :
     ∃ a c, r a c ∧ x = inl a ∧ y = inl c := by


### PR DESCRIPTION
---
<details>
<summary>Show trace profiling of <code>elim_swap</code>: <10 ms before, <10 ms after  🎉</summary>

### Trace profiling of `elim_swap` before PR 32141
```diff
diff --git a/Mathlib/Data/Sum/Basic.lean b/Mathlib/Data/Sum/Basic.lean
index 0f66aea251..4fee7f4832 100644
--- a/Mathlib/Data/Sum/Basic.lean
+++ b/Mathlib/Data/Sum/Basic.lean
@@ -25,6 +25,7 @@ lemma not_isLeft_and_isRight {x : α ⊕ β} : ¬(x.isLeft ∧ x.isRight) := by
 
 namespace Sum
 
+set_option trace.profiler true in
 @[simp]
 theorem elim_swap {α β γ : Type*} {f : α → γ} {g : β → γ} :
     Sum.elim f g ∘ Sum.swap = Sum.elim g f := by
```
```
✔ [113/113] Built Mathlib.Data.Sum.Basic (811ms)
Build completed successfully (113 jobs).
```

### Trace profiling of `elim_swap` after PR 32141
```diff
diff --git a/Mathlib/Data/Sum/Basic.lean b/Mathlib/Data/Sum/Basic.lean
index 0f66aea251..7683affae3 100644
--- a/Mathlib/Data/Sum/Basic.lean
+++ b/Mathlib/Data/Sum/Basic.lean
@@ -25,13 +25,11 @@ lemma not_isLeft_and_isRight {x : α ⊕ β} : ¬(x.isLeft ∧ x.isRight) := by
 
 namespace Sum
 
+set_option trace.profiler true in
 @[simp]
 theorem elim_swap {α β γ : Type*} {f : α → γ} {g : β → γ} :
     Sum.elim f g ∘ Sum.swap = Sum.elim g f := by
-  ext x
-  cases x with
-  | inl x => simp
-  | inr x => simp
+  grind
 
 -- Lean has removed the `@[simp]` attribute on these. For now Mathlib adds it back.
 attribute [simp] Sum.forall Sum.exists
@@ -47,29 +45,29 @@ theorem inr_injective : Function.Injective (inr : β → α ⊕ β) := fun _ _ 
 
 theorem sum_rec_congr (P : α ⊕ β → Sort*) (f : ∀ i, P (inl i)) (g : ∀ i, P (inr i))
     {x y : α ⊕ β} (h : x = y) :
-    @Sum.rec _ _ _ f g x = cast (congr_arg P h.symm) (@Sum.rec _ _ _ f g y) := by cases h; rfl
+    @Sum.rec _ _ _ f g x = cast (congr_arg P h.symm) (@Sum.rec _ _ _ f g y) := by grind
 
 section get
 
 variable {x : α ⊕ β}
 
 theorem eq_left_iff_getLeft_eq {a : α} : x = inl a ↔ ∃ h, x.getLeft h = a := by
-  cases x <;> simp
+  grind
 
 theorem eq_right_iff_getRight_eq {b : β} : x = inr b ↔ ∃ h, x.getRight h = b := by
-  cases x <;> simp
+  grind
 
 theorem getLeft_eq_getLeft? (h₁ : x.isLeft) (h₂ : x.getLeft?.isSome) :
-    x.getLeft h₁ = x.getLeft?.get h₂ := by simp [← getLeft?_eq_some_iff]
+    x.getLeft h₁ = x.getLeft?.get h₂ := by grind
 
 theorem getRight_eq_getRight? (h₁ : x.isRight) (h₂ : x.getRight?.isSome) :
-    x.getRight h₁ = x.getRight?.get h₂ := by simp [← getRight?_eq_some_iff]
+    x.getRight h₁ = x.getRight?.get h₂ := by grind
 
 @[simp] theorem isSome_getLeft?_iff_isLeft : x.getLeft?.isSome ↔ x.isLeft := by
-  rw [isLeft_iff, Option.isSome_iff_exists]; simp
+  grind
 
 @[simp] theorem isSome_getRight?_iff_isRight : x.getRight?.isSome ↔ x.isRight := by
-  rw [isRight_iff, Option.isSome_iff_exists]; simp
+  grind
 
 end get
 
@@ -78,12 +76,12 @@ open Function (update update_eq_iff update_comp_eq_of_injective update_comp_eq_o
 @[simp]
 theorem update_elim_inl [DecidableEq α] [DecidableEq (α ⊕ β)] {f : α → γ} {g : β → γ} {i : α}
     {x : γ} : update (Sum.elim f g) (inl i) x = Sum.elim (update f i x) g :=
-  update_eq_iff.2 ⟨by simp, by simp +contextual⟩
+  update_eq_iff.2 ⟨by simp, by grind⟩
 
 @[simp]
 theorem update_elim_inr [DecidableEq β] [DecidableEq (α ⊕ β)] {f : α → γ} {g : β → γ} {i : β}
     {x : γ} : update (Sum.elim f g) (inr i) x = Sum.elim f (update g i x) :=
-  update_eq_iff.2 ⟨by simp, by simp +contextual⟩
+  update_eq_iff.2 ⟨by simp, by grind⟩
 
 @[simp]
 theorem update_inl_comp_inl [DecidableEq α] [DecidableEq (α ⊕ β)] {f : α ⊕ β → γ} {i : α}
@@ -93,7 +91,7 @@ theorem update_inl_comp_inl [DecidableEq α] [DecidableEq (α ⊕ β)] {f : α 
 @[simp]
 theorem update_inl_apply_inl [DecidableEq α] [DecidableEq (α ⊕ β)] {f : α ⊕ β → γ} {i j : α}
     {x : γ} : update f (inl i) x (inl j) = update (f ∘ inl) i x j := by
-  rw [← update_inl_comp_inl, Function.comp_apply]
+  grind
 
 @[simp]
 theorem update_inl_comp_inr [DecidableEq (α ⊕ β)] {f : α ⊕ β → γ} {i : α} {x : γ} :
@@ -178,28 +176,24 @@ namespace LiftRel
 variable {r : α → γ → Prop} {s : β → δ → Prop} {x : α ⊕ β} {y : γ ⊕ δ}
   {a : α} {b : β} {c : γ} {d : δ}
 
-theorem isLeft_congr (h : LiftRel r s x y) : x.isLeft ↔ y.isLeft := by cases h <;> rfl
-theorem isRight_congr (h : LiftRel r s x y) : x.isRight ↔ y.isRight := by cases h <;> rfl
+theorem isLeft_congr (h : LiftRel r s x y) : x.isLeft ↔ y.isLeft := by grind
+theorem isRight_congr (h : LiftRel r s x y) : x.isRight ↔ y.isRight := by grind
 
-theorem isLeft_left (h : LiftRel r s x (inl c)) : x.isLeft := by cases h; rfl
-theorem isLeft_right (h : LiftRel r s (inl a) y) : y.isLeft := by cases h; rfl
-theorem isRight_left (h : LiftRel r s x (inr d)) : x.isRight := by cases h; rfl
-theorem isRight_right (h : LiftRel r s (inr b) y) : y.isRight := by cases h; rfl
+theorem isLeft_left (h : LiftRel r s x (inl c)) : x.isLeft := by grind
+theorem isLeft_right (h : LiftRel r s (inl a) y) : y.isLeft := by grind
+theorem isRight_left (h : LiftRel r s x (inr d)) : x.isRight := by grind
+theorem isRight_right (h : LiftRel r s (inr b) y) : y.isRight := by grind
 
 theorem exists_of_isLeft_left (h₁ : LiftRel r s x y) (h₂ : x.isLeft) :
     ∃ a c, r a c ∧ x = inl a ∧ y = inl c := by
-  rcases isLeft_iff.mp h₂ with ⟨_, rfl⟩
-  simp only [liftRel_iff, false_and, and_false, exists_false, or_false, reduceCtorEq] at h₁
-  exact h₁
+  grind
 
 theorem exists_of_isLeft_right (h₁ : LiftRel r s x y) (h₂ : y.isLeft) :
     ∃ a c, r a c ∧ x = inl a ∧ y = inl c := exists_of_isLeft_left h₁ ((isLeft_congr h₁).mpr h₂)
 
 theorem exists_of_isRight_left (h₁ : LiftRel r s x y) (h₂ : x.isRight) :
     ∃ b d, s b d ∧ x = inr b ∧ y = inr d := by
-  rcases isRight_iff.mp h₂ with ⟨_, rfl⟩
-  simp only [liftRel_iff, false_and, and_false, exists_false, false_or, reduceCtorEq] at h₁
-  exact h₁
+  grind
 
 theorem exists_of_isRight_right (h₁ : LiftRel r s x y) (h₂ : y.isRight) :
     ∃ b d, s b d ∧ x = inr b ∧ y = inr d :=
```
```
✔ [113/113] Built Mathlib.Data.Sum.Basic (825ms)
Build completed successfully (113 jobs).
```
</details>

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

When merging, all the commits will be squashed into a single commit
listing all co-authors.

Co-authors in the squash commit are gathered from two sources:

First, all authors of commits to this PR branch are included. Thus,
one way to add co-authors is to include at least one commit authored by
each co-author among the commits in the pull request. If necessary, you
may create empty commits to indicate co-authorship, using commands like so:

git commit --author="Author Name <author@email.com>" --allow-empty -m "add Author Name as coauthor"

Second, co-authors can also be listed in lines at the very bottom of
the commit message (that is, directly before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines
at the bottom of the commit message (before the `---`, and also before
any "Co-authored-by" lines) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
