### PR TITLE
[Merged by Bors] - feat(Int): Shift{Left,Right} instance spec on how it interacts with Nat

### DIFF
--- a/Mathlib/Data/Int/Bitwise.lean
+++ b/Mathlib/Data/Int/Bitwise.lean
@@ -366,6 +366,21 @@ theorem shiftRight_add' : ∀ (m : ℤ) (n k : ℕ), m >>> (n + k : ℤ) = (m >>
 
 /-! ### bitwise ops -/
 
+/-- Connection of `HShiftLeft Int Int Int` and `HShiftLeft Int Nat Int`. -/
+lemma shiftLeft_natCast_right (m : ℤ) (n : ℕ) :
+    m <<< (n : ℤ) = m <<< n := by
+  rw [Int.shiftLeft_eq']
+  unfold_projs; cases m <;> simp only [Nat.shiftLeft'_false, natCast_shiftLeft, ofNat_eq_natCast,
+    Nat.pow_eq, Int.natCast_pow, Nat.cast_ofNat, mul_def]
+  · grind [Int.shiftLeft_eq']
+  · simp only [negSucc_eq, ← natCast_add_one, Nat.shiftLeft'_tt_eq_mul_pow]
+    grind
+
+/-- Connection of `HShiftRight Int Int Int` and `HShiftRight Int Nat Int`. -/
+lemma shiftRight_natCast_right (m : ℤ) (n : ℕ) :
+    m >>> (n : ℤ) = m >>> n := by
+  cases m <;> simp
+
 theorem shiftLeft_add' : ∀ (m : ℤ) (n : ℕ) (k : ℤ), m <<< (n + k) = (m <<< (n : ℤ)) <<< k
   | (m : ℕ), n, (k : ℕ) =>
     congr_arg ofNat (by simp [Nat.shiftLeft_eq, Nat.pow_add, mul_assoc])


### PR DESCRIPTION
replaces #28884

We have:
```
Int.shiftLeft_neg
Int.shiftRight_neg
Int.shiftLeft_natCast
Int.shiftRight_natCast
Int.shiftLeft_negSucc
Int.shiftRight_negSucc
```

and we were missing a connection to the `HShiftLeft Int Nat Int` instance in core. This rectifies the missing API with
```
Int.shiftLeft_natCast_right
Int.shiftRight_natCast_right
```
the negations are handled by existing simp lemmas


---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

When merging, all the commits will be squashed into a single commit
listing all co-authors.

Co-authors in the squash commit are gathered from two sources:

First, all authors of commits to this PR branch are included. Thus,
one way to add co-authors is to include at least one commit authored by
each co-author among the commits in the pull request. If necessary, you
may create empty commits to indicate co-authorship, using commands like so:

git commit --author="Author Name <author@email.com>" --allow-empty -m "add Author Name as coauthor"

Second, co-authors can also be listed in lines at the very bottom of
the commit message (that is, directly before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines
at the bottom of the commit message (before the `---`, and also before
any "Co-authored-by" lines) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
