### PR TITLE
[Merged by Bors] - chore(CyclotomicField): add missing deprecated aliases for #30010

### DIFF
--- a/Mathlib/NumberTheory/NumberField/Cyclotomic/Basic.lean
+++ b/Mathlib/NumberTheory/NumberField/Cyclotomic/Basic.lean
@@ -814,11 +814,6 @@ theorem cyclotomicRing_isIntegralClosure :
   · rintro ⟨y, rfl⟩
     exact IsIntegral.algebraMap ((IsCyclotomicExtension.integral {n} ℤ _).isIntegral _)
 
-
-
-
-
-
 end IsCyclotomicExtension.Rat
 
 namespace IsPrimitiveRoot

--- a/Mathlib/NumberTheory/NumberField/Cyclotomic/Basic.lean
+++ b/Mathlib/NumberTheory/NumberField/Cyclotomic/Basic.lean
@@ -814,6 +814,11 @@ theorem cyclotomicRing_isIntegralClosure :
   · rintro ⟨y, rfl⟩
     exact IsIntegral.algebraMap ((IsCyclotomicExtension.integral {n} ℤ _).isIntegral _)
 
+
+
+
+
+
 end IsCyclotomicExtension.Rat
 
 namespace IsPrimitiveRoot
@@ -834,6 +839,9 @@ instance _root_.IsCyclotomicExtension.ringOfIntegers [IsCyclotomicExtension {n} 
     IsCyclotomicExtension {n} ℤ (𝓞 K) :=
   let _ := (zeta_spec (n) ℚ K).adjoin_isCyclotomicExtension ℤ
   IsCyclotomicExtension.equiv _ ℤ _ (zeta_spec n ℚ K).adjoinEquivRingOfIntegers
+
+@[deprecated (since := "2025-11-26")] alias _root_.IsCyclotomicExtension.ring_of_integers' :=
+  _root_.IsCyclotomicExtension.ringOfIntegers
 
 /-- The integral `PowerBasis` of `𝓞 K` given by a primitive root of unity, where `K` is a `n`-th
 cyclotomic extension of `ℚ`. -/
@@ -870,6 +878,17 @@ theorem subOneIntegralPowerBasis_gen [IsCyclotomicExtension {n} ℚ K]
     hζ.subOneIntegralPowerBasis.gen =
       ⟨ζ - 1, Subalgebra.sub_mem _ (hζ.isIntegral (NeZero.pos _)) (Subalgebra.one_mem _)⟩ := by
   simp [subOneIntegralPowerBasis]
+
+@[deprecated (since := "2025-11-26")] alias integralPowerBasis' := integralPowerBasis
+@[deprecated (since := "2025-11-26")] alias integralPowerBasis'_gen := integralPowerBasis_gen
+@[deprecated (since := "2025-11-26")] alias power_basis_int'_dim := integralPowerBasis_dim
+@[deprecated (since := "2025-11-26")] alias subOneIntegralPowerBasis' := subOneIntegralPowerBasis
+@[deprecated (since := "2025-11-26")] alias subOneIntegralPowerBasis'_gen :=
+  subOneIntegralPowerBasis_gen
+@[deprecated (since := "2025-11-26")] alias subOneIntegralPowerBasis'_gen_prime :=
+  subOneIntegralPowerBasis_gen
+@[deprecated (since := "2025-11-26")] alias subOneIntegralPowerBasis_gen_prime :=
+  subOneIntegralPowerBasis_gen
 
 end IsPrimitiveRoot
 


### PR DESCRIPTION
These results were removed since they were not needed anymore but I forgot to add the deprecated aliases. 


---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

When merging, all the commits will be squashed into a single commit
listing all co-authors.

Co-authors in the squash commit are gathered from two sources:

First, all authors of commits to this PR branch are included. Thus,
one way to add co-authors is to include at least one commit authored by
each co-author among the commits in the pull request. If necessary, you
may create empty commits to indicate co-authorship, using commands like so:

git commit --author="Author Name <author@email.com>" --allow-empty -m "add Author Name as coauthor"

Second, co-authors can also be listed in lines at the very bottom of
the commit message (that is, directly before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines
at the bottom of the commit message (before the `---`, and also before
any "Co-authored-by" lines) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
