### PR TITLE
[Merged by Bors] - feat(GroupTheory/SpecificGroups/Cyclic): generalize the proof of prime_card by not assuming Finite

### DIFF
--- a/Mathlib/GroupTheory/OrderOfElement.lean
+++ b/Mathlib/GroupTheory/OrderOfElement.lean
@@ -17,7 +17,6 @@ public import Mathlib.Dynamics.PeriodicPts.Lemmas
 public import Mathlib.GroupTheory.Index
 public import Mathlib.NumberTheory.Divisors
 public import Mathlib.Order.Interval.Set.Infinite
-public import Mathlib.Algebra.EuclideanDomain.Defs
 
 /-!
 # Order of an element
@@ -916,8 +915,8 @@ lemma Subgroup.zpowers_eq_zpowers_iff {x y : G} (hx : ¬IsOfFinOrder x) :
   rcases (Int.mul_eq_one_iff_eq_one_or_neg_one).mp h1 with (h | h) <;> simp [h.1]
 
 @[to_additive]
-theorem mem_zpowers_pow_iff {g : G} {k : ℤ} :
-    g ∈ Subgroup.zpowers (g ^ k) ↔ k.gcd (↑(orderOf g) : ℤ) = 1 := by
+theorem mem_zpowers_zpow_iff {g : G} {k : ℤ} :
+    g ∈ Subgroup.zpowers (g ^ k) ↔ k.gcd (orderOf g) = 1 := by
   apply Iff.intro
   · intro hgk
     rcases (by simpa [Subgroup.zpowers] using hgk) with ⟨m, hm⟩
@@ -981,6 +980,11 @@ theorem mem_zpowers_pow_iff {g : G} {k : ℤ} :
           simp [this]
         _   = g ^ (a * k + b * n) := by simp [zpow_add]
         _   = g := by simp [hab1']
+
+@[to_additive]
+theorem mem_zpowers_pow_iff {g : G} {k : ℕ} :
+    g ∈ Subgroup.zpowers (g ^ k) ↔ k.gcd (orderOf g) = 1 := by
+  rw [← zpow_natCast g k, mem_zpowers_zpow_iff, Int.gcd_natCast_natCast]
 
 section Finite
 variable [Finite G]

--- a/Mathlib/GroupTheory/OrderOfElement.lean
+++ b/Mathlib/GroupTheory/OrderOfElement.lean
@@ -917,69 +917,8 @@ lemma Subgroup.zpowers_eq_zpowers_iff {x y : G} (hx : ¬IsOfFinOrder x) :
 @[to_additive]
 theorem mem_zpowers_zpow_iff {g : G} {k : ℤ} :
     g ∈ Subgroup.zpowers (g ^ k) ↔ k.gcd (orderOf g) = 1 := by
-  apply Iff.intro
-  · intro hgk
-    rcases (Subgroup.mem_zpowers_iff.mp hgk) with ⟨m, hm⟩
-    have hm' : g ^ (k * m) = g := by simpa [zpow_mul] using hm
-    have h1 : g ^ (k * m - 1) = 1 := by simp[zpow_sub, hm']
-    have hdiv : (↑(orderOf g) : ℤ) ∣ (k * m - 1) := orderOf_dvd_iff_zpow_eq_one.mpr h1
-    rcases hdiv with ⟨t, ht⟩
-    let d : ℤ := k.gcd (↑(orderOf g) : ℤ)
-    have dk : d ∣ k := Int.gcd_dvd_left k (↑(orderOf g) : ℤ)
-    have dn : d ∣ (↑(orderOf g) : ℤ) := Int.gcd_dvd_right k (↑(orderOf g) : ℤ)
-    have dkm : d ∣ k * m := dk.mul_right m
-    have dnt : d ∣ (↑(orderOf g) : ℤ) * t := dn.mul_right t
-    have hlin : k * m - (↑(orderOf g) : ℤ) * t = 1 := by omega
-    have d1 : d ∣ 1 := by
-      have : d ∣ k * m - (↑(orderOf g) : ℤ) * t := Int.dvd_sub dkm dnt
-      simpa [hlin] using this
-    have hd1: d = 1 := by
-      have habs : (Int.natAbs d : ℕ) ∣ 1 := by
-        rcases d1 with ⟨c, hc⟩
-        refine ⟨Int.natAbs c, ?_⟩
-        have := congrArg Int.natAbs hc
-        simpa [Int.natAbs_mul] using this
-      have habs1 : Int.natAbs d = 1 := Nat.dvd_one.mp habs
-      have hdpm : d = 1 ∨ d = -1 := by omega
-      cases hdpm with
-      | inl h => exact h
-      | inr h =>
-        exfalso
-        have : (0 : ℤ) ≤ -1 := by simp_all only [Int.reduceNeg, IsUnit.neg_iff, isUnit_one,
-          IsUnit.dvd, Int.natAbs_of_isUnit,reduceCtorEq]
-        omega
-    simpa [d] using hd1
-  · intro kgcd
-    by_cases h : orderOf g = 0
-    · rw [h] at kgcd
-      simp only [CharP.cast_eq_zero, Int.gcd_zero] at kgcd
-      have hk : k = 1 ∨ k = -1 := Int.natAbs_eq_natAbs_iff.mp kgcd
-      cases hk <;> simp_all
-    · let n : ℤ := (↑(orderOf g) : ℤ)
-      have hbez :
-          (k.gcd n : ℤ) = k * Int.gcdA k n + n * Int.gcdB k n :=
-        Int.gcd_eq_gcd_ab k n
-      have hab1 : k * Int.gcdA k n + n * Int.gcdB k n = 1 := by
-        have : k.gcd n = 1 := by exact kgcd
-        simpa [this] using hbez.symm
-      let a : ℤ := Int.gcdA k n
-      let b : ℤ := Int.gcdB k n
-      have hab1' : a * k + b * n = 1 := by
-        simpa [a, b, n, mul_comm, mul_left_comm, mul_assoc, add_comm, add_left_comm, add_assoc]
-      have hn : g ^ n = 1 := by simp only [zpow_natCast, pow_orderOf_eq_one, n]
-      refine ⟨a, ?_⟩
-      calc
-        (g ^ k) ^ a = g ^ (k * a) := by simpa using (zpow_mul g k a).symm
-        _   = g ^ (a * k) * 1:= by simp [mul_comm]
-        _   = g ^ (a * k) * g ^ (b * n) := by
-          have : g ^ (b * n) = 1 := by
-            calc
-              g ^ (b * n) = g ^ (n * b) := by simp [mul_comm]
-              _ = (g ^ n) ^ b := by simpa using (zpow_mul g n b)
-              _ = 1 := by simp [hn]
-          simp [this]
-        _   = g ^ (a * k + b * n) := by simp [zpow_add]
-        _   = g := by simp [hab1']
+  simp_rw [← Nat.dvd_one, Int.gcd_dvd_iff, Nat.cast_one, ← Int.sub_eq_iff_eq_add', ← dvd_def,
+    ← Int.modEq_iff_dvd, ← zpow_eq_zpow_iff_modEq, zpow_one, zpow_mul, ← mem_zpowers_iff]
 
 @[to_additive]
 theorem mem_zpowers_pow_iff {g : G} {k : ℕ} :

--- a/Mathlib/GroupTheory/OrderOfElement.lean
+++ b/Mathlib/GroupTheory/OrderOfElement.lean
@@ -919,7 +919,7 @@ theorem mem_zpowers_zpow_iff {g : G} {k : ℤ} :
     g ∈ Subgroup.zpowers (g ^ k) ↔ k.gcd (orderOf g) = 1 := by
   apply Iff.intro
   · intro hgk
-    rcases (by simpa [Subgroup.zpowers] using hgk) with ⟨m, hm⟩
+    rcases (Subgroup.mem_zpowers_iff.mp hgk) with ⟨m, hm⟩
     have hm' : g ^ (k * m) = g := by simpa [zpow_mul] using hm
     have h1 : g ^ (k * m - 1) = 1 := by simp[zpow_sub, hm']
     have hdiv : (↑(orderOf g) : ℤ) ∣ (k * m - 1) := orderOf_dvd_iff_zpow_eq_one.mpr h1
@@ -952,7 +952,7 @@ theorem mem_zpowers_zpow_iff {g : G} {k : ℤ} :
   · intro kgcd
     by_cases h : orderOf g = 0
     · rw [h] at kgcd
-      simp at kgcd
+      simp only [CharP.cast_eq_zero, Int.gcd_zero] at kgcd
       have hk : k = 1 ∨ k = -1 := Int.natAbs_eq_natAbs_iff.mp kgcd
       cases hk <;> simp_all
     · let n : ℤ := (↑(orderOf g) : ℤ)

--- a/Mathlib/GroupTheory/SpecificGroups/Cyclic.lean
+++ b/Mathlib/GroupTheory/SpecificGroups/Cyclic.lean
@@ -15,7 +15,6 @@ public import Mathlib.GroupTheory.Subgroup.Simple
 public import Mathlib.Tactic.Group
 
 /-!
-
 # Cyclic groups
 
 A group `G` is called cyclic if there exists an element `g : G` such that every element of `G` is of
@@ -639,6 +638,7 @@ theorem prime_card : (Nat.card α).Prime := by
 /-- A commutative simple group is a finite group. -/
 @[to_additive /-- A commutative simple group is a finite group. -/]
 theorem finite : Finite α := Nat.finite_of_card_ne_zero prime_card.ne_zero
+
 end CommSimpleGroup
 
 end IsSimpleGroup

--- a/Mathlib/GroupTheory/SpecificGroups/Cyclic.lean
+++ b/Mathlib/GroupTheory/SpecificGroups/Cyclic.lean
@@ -15,6 +15,7 @@ public import Mathlib.GroupTheory.Subgroup.Simple
 public import Mathlib.Tactic.Group
 
 /-!
+
 # Cyclic groups
 
 A group `G` is called cyclic if there exists an element `g : G` such that every element of `G` is of
@@ -602,6 +603,7 @@ section CommGroup
 
 variable [CommGroup α]
 
+@[to_additive]
 theorem not_mem_pow_of_order_two {g : α} (horder : orderOf g = 0) :
     g ∉ (Subgroup.zpowers (g ^ 2)) := by
   rintro ⟨z, hz⟩
@@ -630,6 +632,7 @@ instance (priority := 100) isCyclic : IsCyclic α := by
   exact ⟨⟨g, (Subgroup.eq_top_iff' _).1 this⟩⟩
 
 /-- A commutative simple group is a finite group. -/
+@[to_additive /-- A commutative simple group is a finite group. -/]
 theorem CommSimple_is_Finite : Finite α := by
   obtain ⟨g, hg⟩ :=
     (isCyclic_iff_exists_zpowers_eq_top : IsCyclic α  ↔ _).mp (by infer_instance)
@@ -684,7 +687,7 @@ theorem prime_card_of_Finite [Finite α] : (Nat.card α).Prime := by
     rw [← Subgroup.mem_bot, ← h]
     exact Subgroup.mem_zpowers _
 
-/-- a new `prime_card` theorem which dosen't assume the finiteness -/
+@[to_additive]
 theorem prime_card : (Nat.card α).Prime := by
   letI := CommSimple_is_Finite (α := α)
   apply IsSimpleGroup.prime_card_of_Finite
@@ -694,12 +697,12 @@ end CommSimpleGroup
 end IsSimpleGroup
 
 @[to_additive]
-theorem Group.is_simple_iff_prime_card [Finite α] [Group α] [IsMulCommutative α] :
+theorem Group.is_simple_iff_prime_card [Group α] [IsMulCommutative α] :
     IsSimpleGroup α ↔ (Nat.card α).Prime :=
-  ⟨fun h ↦ h.prime_card_of_Finite, fun h ↦ isSimpleGroup_of_prime_card (hp := ⟨h⟩) rfl⟩
+  ⟨fun h ↦ h.prime_card, fun h ↦ isSimpleGroup_of_prime_card (hp := ⟨h⟩) rfl⟩
 
 @[to_additive]
-theorem CommGroup.is_simple_iff_prime_card [Finite α] [CommGroup α] :
+theorem CommGroup.is_simple_iff_prime_card [CommGroup α] :
     IsSimpleGroup α ↔ (Nat.card α).Prime :=
   have : IsMulCommutative α := ⟨⟨mul_comm⟩⟩
   Group.is_simple_iff_prime_card
@@ -843,19 +846,19 @@ noncomputable def zmodAddCyclicAddEquiv [AddGroup G] (h : IsAddCyclic G) :
     |>.symm.trans <| QuotientAddGroup.quotientAddEquivOfEq kereq
     |>.symm.trans <| QuotientAddGroup.quotientKerEquivOfSurjective (zmultiplesHom G g) surj
 
-/-- The isomprphism from `ZMod p` with `p` a prime number to any commutative simple group. -/
-theorem CommSimple_iso_ZMod_p [CommGroup α] [IsSimpleGroup α] :
-    ∃ p : ℕ , Nonempty (Additive α ≃+ ZMod p) := by
-  have hcyc : IsCyclic α  := by infer_instance
+/-- The isomprphism from `ZMod p` with `p` is a prime number to any commutative simple group. -/
+theorem CommSimple_iso_ZMod_p [CommGroup G] [IsSimpleGroup G] :
+    ∃ p : ℕ , (Nat.Prime p) ∧ Nonempty (Additive G ≃+ ZMod p) := by
+  have hcyc : IsCyclic G  := by infer_instance
   rcases (isCyclic_iff_exists_zpowers_eq_top.mp hcyc) with ⟨g, hg⟩
   let p : ℕ := orderOf g
-  have orderG : Nat.card α  = p := by exact Eq.symm (orderOf_eq_card_of_zpowers_eq_top hg)
-  have FinG : Finite α  := by exact IsSimpleGroup.CommSimple_is_Finite
-  have hp : Nat.Prime p := by rw [← orderG]; apply IsSimpleGroup.prime_card
-  use p ; refine Nonempty.intro ?_ ; rw [← orderG]
-  have e : ZMod (Nat.card α) ≃+ Additive α := by
-    simpa using zmodAddCyclicAddEquiv (G := Additive α ) (by infer_instance)
-  exact e.symm
+  have orderG : Nat.card G = p := Eq.symm (orderOf_eq_card_of_zpowers_eq_top hg)
+  have FinG : Finite G := IsSimpleGroup.CommSimple_is_Finite
+  use p; rw [← orderG]
+  constructor
+  · exact IsSimpleGroup.prime_card
+  · refine Nonempty.intro ?_
+    exact (zmodAddCyclicAddEquiv (G := Additive G) (by infer_instance)).symm
 
 /-- The isomorphism from `Multiplicative (ZMod n)` to any cyclic group of `Nat.card` equal to `n`.
 -/

--- a/Mathlib/GroupTheory/SpecificGroups/Cyclic.lean
+++ b/Mathlib/GroupTheory/SpecificGroups/Cyclic.lean
@@ -611,7 +611,7 @@ lemma finite_finOrder_zpow (g : α) (hp : ¬orderOf g = 0) :
     Finite (Subgroup.zpowers g) := by
   simp_all only [orderOf_eq_zero_iff, not_not, finiteCyclic_iff_finiteCarrier, finite_zpowers]
 
-lemma not_mem_zpowers_sq_of_orderOf_zero {g : α} (horder : orderOf g = 0) :
+theorem odd_not_mem_of_g_two {g : α} (horder : orderOf g = 0) :
     g ∉ (Subgroup.zpowers (g ^ 2)) := by
   intro hgmem
   rcases hgmem with ⟨z, hz⟩
@@ -664,7 +664,7 @@ theorem comm_simple_is_finite : Finite α := by
     intro htop
     have h1 : g ^ 1 ∈ Subgroup.zpowers g := by exact Subgroup.npow_mem_zpowers g 1
     have hn1 : g ^ 1 ∉ H := by
-      simpa [H] using not_mem_zpowers_sq_of_orderOf_zero (g := g) horder
+      simpa [H] using odd_not_mem_of_g_two (g := g) horder
     simp_all only [Subgroup.mem_top]
   have hneq_bot : H ≠ ⊥ := by
     intro hbot
@@ -878,9 +878,7 @@ theorem comm_simple_iso_ZMod_prime [CommGroup α] [IsSimpleGroup α] :
   have orderG : Nat.card α  = p := by exact Eq.symm (orderOf_eq_card_of_zpowers_eq_top hg)
   have FinG : Finite α  := by exact IsSimpleGroup.comm_simple_is_finite
   have hp : Nat.Prime p := by rw [← orderG]; apply IsSimpleGroup.prime_card
-  use p
-  refine Nonempty.intro ?_
-  rw [← orderG]
+  use p ; refine Nonempty.intro ?_ ; rw [← orderG]
   have e : ZMod (Nat.card α) ≃+ Additive α := by
     simpa using zmodAddCyclicAddEquiv (G := Additive α ) (by infer_instance)
   exact e.symm

--- a/Mathlib/GroupTheory/SpecificGroups/Cyclic.lean
+++ b/Mathlib/GroupTheory/SpecificGroups/Cyclic.lean
@@ -626,7 +626,7 @@ theorem prime_card : (Nat.card α).Prime := by
       have hgn_int : g ∈ Subgroup.zpowers (g ^ (n : ℤ)) := by simpa [zpow_natCast]
       have hgcd_int :
           (n : ℤ).gcd (↑(orderOf g) : ℤ) = 1 :=
-        (mem_zpowers_pow_iff (g := g) (k := (n : ℤ))).1 hgn_int
+        (mem_zpowers_zpow_iff (g := g) (k := (n : ℤ))).1 hgn_int
       simp_all only [ne_eq, orderOf_eq_one_iff, Subgroup.mem_top, zpow_natCast,
         Int.gcd_natCast_natCast]
   apply Nat.prime_of_coprime

--- a/Mathlib/GroupTheory/SpecificGroups/Cyclic.lean
+++ b/Mathlib/GroupTheory/SpecificGroups/Cyclic.lean
@@ -660,7 +660,7 @@ theorem CommSimple_is_Finite : Finite α := by
     have hmemg2 : g ^ 2 ∈ H := by
       refine (Subgroup.mem_zpowers_iff).mpr ?_
       exact ⟨1 , by simp⟩
-    rw [hbot] at hmemg2 ; exact hng hmemg2
+    rw [hbot] at hmemg2; exact hng hmemg2
   have := IsSimpleGroup.eq_bot_or_eq_top_of_normal (H := H) (by exact Subgroup.normal_of_comm H)
   rcases this <;> contradiction
 

--- a/Mathlib/GroupTheory/SpecificGroups/Cyclic.lean
+++ b/Mathlib/GroupTheory/SpecificGroups/Cyclic.lean
@@ -636,7 +636,7 @@ instance (priority := 100) isCyclic : IsCyclic α := by
 
 /-- A commutative simple group is a finite group. -/
 @[to_additive /-- A commutative simple group is a finite group. -/]
-instance : Finite α := by
+scoped instance : Finite α := by
   obtain ⟨g, hg⟩ := isCyclic_iff_exists_zpowers_eq_top.mp (inferInstance : IsCyclic α)
   by_contra hnf
   have horder : ¬IsOfFinOrder g := by


### PR DESCRIPTION
previously the proof of prime_card assumes `Finite`, which could derived from the premises of `CommGroup` and `IsSimpleGroup`.
This PR adds a theorem of finiteness of commutative simple group, a theorem of `prime_card` which dosen't assume `Finite`, and a theorem of isomorphism from any commutative simple group to `ZMod p`, where `p` is a prime number.

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

When merging, all the commits will be squashed into a single commit
listing all co-authors.

Co-authors in the squash commit are gathered from two sources:

First, all authors of commits to this PR branch are included. Thus,
one way to add co-authors is to include at least one commit authored by
each co-author among the commits in the pull request. If necessary, you
may create empty commits to indicate co-authorship, using commands like so:

git commit --author="Author Name <author@email.com>" --allow-empty -m "add Author Name as coauthor"

Second, co-authors can also be listed in lines at the very bottom of
the commit message (that is, directly before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines
at the bottom of the commit message (before the `---`, and also before
any "Co-authored-by" lines) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
