### PR TITLE
[Merged by Bors] - refactor(Category Theory): change `RegularMono`/`Epi` from class to structure

### DIFF
--- a/Mathlib/Algebra/Homology/LeftResolution/Transport.lean
+++ b/Mathlib/Algebra/Homology/LeftResolution/Transport.lean
@@ -30,6 +30,8 @@ namespace LeftResolution
 
 open Functor
 
+-- TODO: figure out why this got slower and fix
+set_option synthInstance.maxHeartbeats 24000 in
 /-- Transport `LeftResolution` via equivalences of categories. -/
 def transport {ι : C ⥤ A} (Λ : LeftResolution ι) {ι' : C' ⥤ A'}
     (eA : A' ≌ A) (eC : C' ≌ C) (e : ι' ⋙ eA.functor ≅ eC.functor ⋙ ι) :
@@ -44,7 +46,9 @@ def transport {ι : C ⥤ A} (Λ : LeftResolution ι) {ι' : C' ⥤ A'}
       whiskerLeft Λ.F eC.counitIso.hom ≫ Λ.F.rightUnitor.hom)) _) _ ≫
         (whiskerRight ((associator _ _ _).hom ≫ whiskerLeft _ Λ.π ≫
           (rightUnitor _).hom) _) ≫ eA.unitIso.inv
-  epi_π_app _ := by dsimp; infer_instance
+  epi_π_app _ := by
+    dsimp
+    infer_instance
 
 /-- If we have an isomorphism `e : G ⋙ ι' ≅ ι`, then any `Λ : LeftResolution ι`
 induces `Λ.ofCompIso e : LeftResolution ι'`. -/

--- a/Mathlib/Algebra/Homology/LeftResolution/Transport.lean
+++ b/Mathlib/Algebra/Homology/LeftResolution/Transport.lean
@@ -31,7 +31,10 @@ namespace LeftResolution
 open Functor
 
 -- TODO: figure out why this got slower and fix
+-- It is a question of synthesizing `Epi (_ ≫ _ ≫ _ ≫ _ ≫ ...) for a big composition of (mostly?)
+-- isos.
 set_option synthInstance.maxHeartbeats 24000 in
+-- silence the linter
 /-- Transport `LeftResolution` via equivalences of categories. -/
 def transport {ι : C ⥤ A} (Λ : LeftResolution ι) {ι' : C' ⥤ A'}
     (eA : A' ≌ A) (eC : C' ≌ C) (e : ι' ⋙ eA.functor ≅ eC.functor ⋙ ι) :
@@ -46,9 +49,7 @@ def transport {ι : C ⥤ A} (Λ : LeftResolution ι) {ι' : C' ⥤ A'}
       whiskerLeft Λ.F eC.counitIso.hom ≫ Λ.F.rightUnitor.hom)) _) _ ≫
         (whiskerRight ((associator _ _ _).hom ≫ whiskerLeft _ Λ.π ≫
           (rightUnitor _).hom) _) ≫ eA.unitIso.inv
-  epi_π_app _ := by
-    dsimp
-    infer_instance
+  epi_π_app _ := by dsimp; infer_instance
 
 /-- If we have an isomorphism `e : G ⋙ ι' ≅ ι`, then any `Λ : LeftResolution ι`
 induces `Λ.ofCompIso e : LeftResolution ι'`. -/

--- a/Mathlib/Algebra/Homology/LeftResolution/Transport.lean
+++ b/Mathlib/Algebra/Homology/LeftResolution/Transport.lean
@@ -30,11 +30,6 @@ namespace LeftResolution
 
 open Functor
 
--- TODO: figure out why this got slower and fix
--- It is a question of synthesizing `Epi (_ ≫ _ ≫ _ ≫ _ ≫ ...) for a big composition of (mostly?)
--- isos.
-set_option synthInstance.maxHeartbeats 24000 in
--- silence the linter
 /-- Transport `LeftResolution` via equivalences of categories. -/
 def transport {ι : C ⥤ A} (Λ : LeftResolution ι) {ι' : C' ⥤ A'}
     (eA : A' ≌ A) (eC : C' ≌ C) (e : ι' ⋙ eA.functor ≅ eC.functor ⋙ ι) :

--- a/Mathlib/CategoryTheory/Adjunction/Lifting/Left.lean
+++ b/Mathlib/CategoryTheory/Adjunction/Lifting/Left.lean
@@ -78,19 +78,29 @@ variable (adj₁ : F ⊣ U) (adj₂ : F' ⊣ R ⋙ U)
 /-- To show that `ε_X` is a coequalizer for `(FUε_X, ε_FUX)`, it suffices to assume it's always a
 coequalizer of something (i.e. a regular epi).
 -/
-def counitCoequalises [∀ X : B, RegularEpi (adj₁.counit.app X)] (X : B) :
+def counitCoequalises (h : ∀ X : B, RegularEpi (adj₁.counit.app X)) (X : B) :
     IsColimit (Cofork.ofπ (adj₁.counit.app X) (adj₁.counit_naturality _)) :=
   Cofork.IsColimit.mk' _ fun s => by
-    refine ⟨(RegularEpi.desc' (adj₁.counit.app X) s.π ?_).1, ?_, ?_⟩
-    · rw [← cancel_epi (adj₁.counit.app (RegularEpi.W (adj₁.counit.app X)))]
-      rw [← adj₁.counit_naturality_assoc RegularEpi.left]
+    have := (h X).epi
+    have := (h (h X).W).epi
+    refine ⟨(RegularEpi.desc' (adj₁.counit.app X) (h _) s.π ?_).1, ?_, ?_⟩
+    · rw [← cancel_epi (adj₁.counit.app (h X).W)]
+      rw [← adj₁.counit_naturality_assoc (h X).left]
       dsimp only [Functor.comp_obj]
       rw [← s.condition, ← F.map_comp_assoc, ← U.map_comp, RegularEpi.w, U.map_comp,
-        F.map_comp_assoc, s.condition, ← adj₁.counit_naturality_assoc RegularEpi.right]
-    · apply (RegularEpi.desc' (adj₁.counit.app X) s.π _).2
+        F.map_comp_assoc, s.condition, ← adj₁.counit_naturality_assoc (h X).right]
+      simp
+    · apply (RegularEpi.desc' (adj₁.counit.app X) (h _) s.π _).2
     · intro m hm
       rw [← cancel_epi (adj₁.counit.app X)]
-      apply hm.trans (RegularEpi.desc' (adj₁.counit.app X) s.π _).2.symm
+      apply hm.trans (RegularEpi.desc' (adj₁.counit.app X) (h _) s.π _).2.symm
+
+/-- To show that `ε_X` is a coequalizer for `(FUε_X, ε_FUX)`, it suffices to assume it's always a
+coequalizer of something (i.e. a regular epi).
+-/
+noncomputable def counitCoequalises' [h : ∀ X : B, IsRegularEpi (adj₁.counit.app X)] (X : B) :
+    IsColimit (Cofork.ofπ (adj₁.counit.app X) (adj₁.counit_naturality _)) :=
+  counitCoequalises adj₁ (fun _ ↦ regularEpiOfIsRegularEpi _) X
 
 /-- (Implementation)
 To construct the left adjoint, we use the coequalizer of `F' U ε_Y` with the composite
@@ -128,7 +138,7 @@ noncomputable def constructLeftAdjointObj (Y : B) : A :=
 
 /-- The homset equivalence which helps show that `R` is a right adjoint. -/
 @[simps!]
-noncomputable def constructLeftAdjointEquiv [∀ X : B, RegularEpi (adj₁.counit.app X)] (Y : A)
+noncomputable def constructLeftAdjointEquiv (h : ∀ X : B, RegularEpi (adj₁.counit.app X)) (Y : A)
     (X : B) : (constructLeftAdjointObj _ _ adj₁ adj₂ X ⟶ Y) ≃ (X ⟶ R.obj Y) :=
   calc
     (constructLeftAdjointObj _ _ adj₁ adj₂ X ⟶ Y) ≃
@@ -152,13 +162,13 @@ noncomputable def constructLeftAdjointEquiv [∀ X : B, RegularEpi (adj₁.couni
         adj₁.homEquiv_counit, adj₁.homEquiv_counit, F.map_comp, assoc, U.map_comp, F.map_comp,
         assoc, adj₁.counit_naturality, adj₁.counit_naturality_assoc]
       apply eq_comm
-    _ ≃ (X ⟶ R.obj Y) := (Cofork.IsColimit.homIso (counitCoequalises adj₁ X) _).symm
+    _ ≃ (X ⟶ R.obj Y) := (Cofork.IsColimit.homIso (counitCoequalises adj₁ h X) _).symm
 
 attribute [local simp] Adjunction.homEquiv_counit
 
 /-- Construct the left adjoint to `R`, with object map `constructLeftAdjointObj`. -/
-noncomputable def constructLeftAdjoint [∀ X : B, RegularEpi (adj₁.counit.app X)] : B ⥤ A := by
-  refine Adjunction.leftAdjointOfEquiv (fun X Y => constructLeftAdjointEquiv R _ adj₁ adj₂ Y X) ?_
+noncomputable def constructLeftAdjoint (h : ∀ X : B, RegularEpi (adj₁.counit.app X)) : B ⥤ A := by
+  refine Adjunction.leftAdjointOfEquiv (fun X Y => constructLeftAdjointEquiv R _ adj₁ adj₂ h Y X) ?_
   intro X Y Y' g h
   rw [constructLeftAdjointEquiv_apply, constructLeftAdjointEquiv_apply,
     Equiv.symm_apply_eq, Subtype.ext_iff]
@@ -180,10 +190,10 @@ Note the converse is true (with weaker assumptions), by `Adjunction.comp`.
 See https://ncatlab.org/nlab/show/adjoint+triangle+theorem
 -/
 lemma isRightAdjoint_triangle_lift {U : B ⥤ C} {F : C ⥤ B} (R : A ⥤ B) (adj₁ : F ⊣ U)
-    [∀ X : B, RegularEpi (adj₁.counit.app X)] [HasReflexiveCoequalizers A]
+    (h : ∀ X : B, RegularEpi (adj₁.counit.app X)) [HasReflexiveCoequalizers A]
     [(R ⋙ U).IsRightAdjoint ] : R.IsRightAdjoint where
   exists_leftAdjoint :=
-    ⟨LiftLeftAdjoint.constructLeftAdjoint R _ adj₁ (Adjunction.ofIsRightAdjoint _),
+    ⟨LiftLeftAdjoint.constructLeftAdjoint R _ adj₁ (Adjunction.ofIsRightAdjoint _) h,
       ⟨Adjunction.adjunctionOfEquivLeft _ _⟩⟩
 
 /-- If `R ⋙ U` has a left adjoint, the domain of `R` has reflexive coequalizers and `U` is a monadic
@@ -206,7 +216,7 @@ lemma isRightAdjoint_triangle_lift_monadic (U : B ⥤ C) [MonadicRightAdjoint U]
     intro X
     simp only [Monad.adj_counit]
     exact ⟨_, _, _, _, Monad.beckAlgebraCoequalizer X⟩
-  exact isRightAdjoint_triangle_lift R' (Monad.adj _)
+  exact isRightAdjoint_triangle_lift R' (Monad.adj _) this
 
 variable {D : Type u₄}
 variable [Category.{v₄} D]
@@ -229,10 +239,11 @@ See https://ncatlab.org/nlab/show/adjoint+lifting+theorem
 -/
 lemma isRightAdjoint_square_lift (Q : A ⥤ B) (V : B ⥤ D) (U : A ⥤ C) (R : C ⥤ D)
     (comm : U ⋙ R ≅ Q ⋙ V) [U.IsRightAdjoint] [V.IsRightAdjoint] [R.IsRightAdjoint]
-    [∀ X, RegularEpi ((Adjunction.ofIsRightAdjoint V).counit.app X)] [HasReflexiveCoequalizers A] :
+    (h : ∀ X, RegularEpi ((Adjunction.ofIsRightAdjoint V).counit.app X))
+    [HasReflexiveCoequalizers A] :
     Q.IsRightAdjoint :=
   have := ((Adjunction.ofIsRightAdjoint (U ⋙ R)).ofNatIsoRight comm).isRightAdjoint
-  isRightAdjoint_triangle_lift Q (Adjunction.ofIsRightAdjoint V)
+  isRightAdjoint_triangle_lift Q (Adjunction.ofIsRightAdjoint V) h
 
 /-- Suppose we have a commutative square of functors
 

--- a/Mathlib/CategoryTheory/Adjunction/Lifting/Left.lean
+++ b/Mathlib/CategoryTheory/Adjunction/Lifting/Left.lean
@@ -81,19 +81,18 @@ coequalizer of something (i.e. a regular epi).
 def counitCoequalises (h : ∀ X : B, RegularEpi (adj₁.counit.app X)) (X : B) :
     IsColimit (Cofork.ofπ (adj₁.counit.app X) (adj₁.counit_naturality _)) :=
   Cofork.IsColimit.mk' _ fun s => by
-    have := (h X).epi
-    have := (h (h X).W).epi
-    refine ⟨(RegularEpi.desc' (adj₁.counit.app X) (h _) s.π ?_).1, ?_, ?_⟩
+    have := fun Y ↦ h Y |>.epi
+    refine ⟨((h X).desc' s.π ?_).1, ?_, ?_⟩
     · rw [← cancel_epi (adj₁.counit.app (h X).W)]
       rw [← adj₁.counit_naturality_assoc (h X).left]
       dsimp only [Functor.comp_obj]
       rw [← s.condition, ← F.map_comp_assoc, ← U.map_comp, RegularEpi.w, U.map_comp,
         F.map_comp_assoc, s.condition, ← adj₁.counit_naturality_assoc (h X).right]
       simp
-    · apply (RegularEpi.desc' (adj₁.counit.app X) (h _) s.π _).2
+    · apply ((h X).desc' s.π _).2
     · intro m hm
       rw [← cancel_epi (adj₁.counit.app X)]
-      apply hm.trans (RegularEpi.desc' (adj₁.counit.app X) (h _) s.π _).2.symm
+      apply hm.trans ((h _).desc' s.π _).2.symm
 
 /-- To show that `ε_X` is a coequalizer for `(FUε_X, ε_FUX)`, it suffices to assume it's always a
 coequalizer of something (i.e. a regular epi).

--- a/Mathlib/CategoryTheory/Adjunction/Lifting/Right.lean
+++ b/Mathlib/CategoryTheory/Adjunction/Lifting/Right.lean
@@ -79,20 +79,21 @@ variable (adj₁ : F ⊣ U) (adj₂ : L ⋙ F ⊣ U')
 /-- To show that `η_X` is an equalizer for `(UFη_X, η_UFX)`, it suffices to assume it's always an
 equalizer of something (i.e. a regular mono).
 -/
-def unitEqualises [∀ X : B, RegularMono (adj₁.unit.app X)] (X : B) :
+def unitEqualises (h : ∀ X : B, RegularMono (adj₁.unit.app X)) (X : B) :
     IsLimit (Fork.ofι (adj₁.unit.app X) (adj₁.unit_naturality _)) :=
   Fork.IsLimit.mk' _ fun s => by
-    refine ⟨(RegularMono.lift' (adj₁.unit.app X) s.ι ?_).1, ?_, ?_⟩
-    · rw [← cancel_mono (adj₁.unit.app (RegularMono.Z (adj₁.unit.app X)))]
-      rw [assoc, ← adj₁.unit_naturality RegularMono.left]
+    have := fun Y ↦ h Y |>.mono
+    refine ⟨((h X).lift' s.ι ?_).1, ?_, ?_⟩
+    · rw [← cancel_mono (adj₁.unit.app ((h X).Z)), assoc, ← adj₁.unit_naturality (h _).left]
       dsimp only [Functor.comp_obj]
-      erw [← assoc, ← s.condition, assoc, ← U.map_comp, ← F.map_comp, RegularMono.w, F.map_comp,
-        U.map_comp, s.condition_assoc, assoc, ← adj₁.unit_naturality RegularMono.right]
-      rfl
-    · apply (RegularMono.lift' (adj₁.unit.app X) s.ι _).2
+      have := s.condition
+      dsimp at this
+      rw [← assoc, ← this, assoc, ← U.map_comp, ← F.map_comp, RegularMono.w, F.map_comp,
+        U.map_comp, s.condition_assoc, assoc, ← adj₁.unit_naturality (h _).right]
+    · apply ((h X).lift' s.ι _).2
     · intro m hm
       rw [← cancel_mono (adj₁.unit.app X)]
-      apply hm.trans (RegularMono.lift' (adj₁.unit.app X) s.ι _).2.symm
+      apply hm.trans ((h X).lift' s.ι _).2.symm
 
 /-- (Implementation)
 To construct the right adjoint, we use the equalizer of `U' F η_X` with the composite
@@ -124,7 +125,7 @@ noncomputable def constructRightAdjointObj (Y : B) : C :=
 
 /-- The homset equivalence which helps show that `L` is a left adjoint. -/
 @[simps!]
-noncomputable def constructRightAdjointEquiv [∀ X : B, RegularMono (adj₁.unit.app X)] (Y : C)
+noncomputable def constructRightAdjointEquiv (h : ∀ X : B, RegularMono (adj₁.unit.app X)) (Y : C)
     (X : B) : (Y ⟶ constructRightAdjointObj _ _ adj₁ adj₂ X) ≃ (L.obj Y ⟶ X) :=
   calc
     (Y ⟶ constructRightAdjointObj _ _ adj₁ adj₂ X) ≃
@@ -146,12 +147,12 @@ noncomputable def constructRightAdjointEquiv [∀ X : B, RegularMono (adj₁.uni
       rw [← (adj₁.homEquiv _ _).injective.eq_iff, adj₁.homEquiv_unit,
         adj₁.homEquiv_unit, adj₁.homEquiv_unit, eq_comm]
       simp
-    _ ≃ (L.obj Y ⟶ X) := (Fork.IsLimit.homIso (unitEqualises adj₁ X) _).symm
+    _ ≃ (L.obj Y ⟶ X) := (Fork.IsLimit.homIso (unitEqualises adj₁ h X) _).symm
 
 /-- Construct the right adjoint to `L`, with object map `constructRightAdjointObj`. -/
-noncomputable def constructRightAdjoint [∀ X : B, RegularMono (adj₁.unit.app X)] : B ⥤ C := by
+noncomputable def constructRightAdjoint (h : ∀ X : B, RegularMono (adj₁.unit.app X)) : B ⥤ C := by
   refine Adjunction.rightAdjointOfEquiv
-    (fun X Y => (constructRightAdjointEquiv L _ adj₁ adj₂ X Y).symm) ?_
+    (fun X Y => (constructRightAdjointEquiv L _ adj₁ adj₂ h X Y).symm) ?_
   intro X Y Y' g h
   rw [constructRightAdjointEquiv_symm_apply, constructRightAdjointEquiv_symm_apply,
     Equiv.symm_apply_eq, Subtype.ext_iff]
@@ -172,10 +173,10 @@ Note the converse is true (with weaker assumptions), by `Adjunction.comp`.
 See https://ncatlab.org/nlab/show/adjoint+triangle+theorem
 -/
 lemma isLeftAdjoint_triangle_lift {U : A ⥤ B} {F : B ⥤ A} (L : C ⥤ B) (adj₁ : F ⊣ U)
-    [∀ X, RegularMono (adj₁.unit.app X)] [HasCoreflexiveEqualizers C]
+    (h : ∀ X, RegularMono (adj₁.unit.app X)) [HasCoreflexiveEqualizers C]
     [(L ⋙ F).IsLeftAdjoint] : L.IsLeftAdjoint where
   exists_rightAdjoint :=
-    ⟨LiftRightAdjoint.constructRightAdjoint L _ adj₁ (Adjunction.ofIsLeftAdjoint _),
+    ⟨LiftRightAdjoint.constructRightAdjoint L _ adj₁ (Adjunction.ofIsLeftAdjoint _) h,
       ⟨Adjunction.adjunctionOfEquivRight _ _⟩⟩
 
 /-- If `L ⋙ F` has a right adjoint, the domain of `L` has coreflexive equalizers and `F` is a
@@ -198,7 +199,7 @@ lemma isLeftAdjoint_triangle_lift_comonadic (F : B ⥤ A) [ComonadicLeftAdjoint 
     intro X
     simp only [Comonad.adj_unit]
     exact ⟨_, _, _, _, Comonad.beckCoalgebraEqualizer X⟩
-  exact isLeftAdjoint_triangle_lift L' (Comonad.adj _)
+  exact isLeftAdjoint_triangle_lift L' (Comonad.adj _) this
 
 variable {D : Type u₄}
 variable [Category.{v₄} D]
@@ -221,10 +222,10 @@ See https://ncatlab.org/nlab/show/adjoint+lifting+theorem
 -/
 lemma isLeftAdjoint_square_lift (Q : A ⥤ B) (V : B ⥤ D) (U : A ⥤ C) (L : C ⥤ D)
     (comm : U ⋙ L ≅ Q ⋙ V) [U.IsLeftAdjoint] [V.IsLeftAdjoint] [L.IsLeftAdjoint]
-    [∀ X, RegularMono ((Adjunction.ofIsLeftAdjoint V).unit.app X)] [HasCoreflexiveEqualizers A] :
-    Q.IsLeftAdjoint :=
+    (h : ∀ X, RegularMono ((Adjunction.ofIsLeftAdjoint V).unit.app X))
+    [HasCoreflexiveEqualizers A] : Q.IsLeftAdjoint :=
   have := ((Adjunction.ofIsLeftAdjoint (U ⋙ L)).ofNatIsoLeft comm).isLeftAdjoint
-  isLeftAdjoint_triangle_lift Q (Adjunction.ofIsLeftAdjoint V)
+  isLeftAdjoint_triangle_lift Q (Adjunction.ofIsLeftAdjoint V) h
 
 /-- Suppose we have a commutative square of functors
 

--- a/Mathlib/CategoryTheory/Adjunction/Lifting/Right.lean
+++ b/Mathlib/CategoryTheory/Adjunction/Lifting/Right.lean
@@ -87,7 +87,7 @@ def unitEqualises (h : ∀ X : B, RegularMono (adj₁.unit.app X)) (X : B) :
     · rw [← cancel_mono (adj₁.unit.app ((h X).Z)), assoc, ← adj₁.unit_naturality (h _).left]
       dsimp only [Functor.comp_obj]
       have := s.condition
-      dsimp at this
+      dsimp only [Functor.comp_obj] at this
       rw [← assoc, ← this, assoc, ← U.map_comp, ← F.map_comp, RegularMono.w, F.map_comp,
         U.map_comp, s.condition_assoc, assoc, ← adj₁.unit_naturality (h _).right]
     · apply ((h X).lift' s.ι _).2

--- a/Mathlib/CategoryTheory/Limits/Shapes/KernelPair.lean
+++ b/Mathlib/CategoryTheory/Limits/Shapes/KernelPair.lean
@@ -146,7 +146,7 @@ theorem comp_of_mono {f₁ : X ⟶ Y} {f₂ : Y ⟶ Z} [Mono f₂] (small_k : Is
 If `(a,b)` is the kernel pair of `f`, and `f` is a coequalizer morphism for some parallel pair, then
 `f` is a coequalizer morphism of `a` and `b`.
 -/
-def toCoequalizer (k : IsKernelPair f a b) [r : RegularEpi f] : IsColimit (Cofork.ofπ f k.w) := by
+def toCoequalizer (k : IsKernelPair f a b) (r : RegularEpi f) : IsColimit (Cofork.ofπ f k.w) := by
   let t := k.isLimit.lift (PullbackCone.mk _ _ r.w)
   have ht : t ≫ a = r.left := k.isLimit.fac _ WalkingCospan.left
   have kt : t ≫ b = r.right := k.isLimit.fac _ WalkingCospan.right
@@ -157,6 +157,14 @@ def toCoequalizer (k : IsKernelPair f a b) [r : RegularEpi f] : IsColimit (Cofor
   · apply Cofork.IsColimit.π_desc' r.isColimit
   · apply Cofork.IsColimit.hom_ext r.isColimit
     exact w.trans (Cofork.IsColimit.π_desc' r.isColimit _ _).symm
+
+/--
+If `(a,b)` is the kernel pair of `f`, and `f` is a regular epimorphism, then
+`f` is a coequalizer morphism of `a` and `b`.
+-/
+noncomputable def toCoequalizer' (k : IsKernelPair f a b) [IsRegularEpi f] :
+    IsColimit (Cofork.ofπ f k.w) :=
+  toCoequalizer k <| regularEpiOfIsRegularEpi f
 
 /-- If `a₁ a₂ : A ⟶ Y` is a kernel pair for `g : Y ⟶ Z`, then `a₁ ×[Z] X` and `a₂ ×[Z] X`
 (`A ×[Z] X ⟶ Y ×[Z] X`) is a kernel pair for `Y ×[Z] X ⟶ X`. -/

--- a/Mathlib/CategoryTheory/Limits/Shapes/NormalMono/Basic.lean
+++ b/Mathlib/CategoryTheory/Limits/Shapes/NormalMono/Basic.lean
@@ -78,7 +78,7 @@ def NormalMono.regularMono (f : X ⟶ Y) [I : NormalMono f] : RegularMono f :=
     right := 0
     w := by simpa using I.w }
 
-instance (priority := 100)  (f : X ⟶ Y) [I : NormalMono f] : IsRegularMono f := ⟨I.regularMono⟩
+instance (priority := 100) (f : X ⟶ Y) [I : NormalMono f] : IsRegularMono f := ⟨I.regularMono⟩
 
 /-- If `f` is a normal mono, then any map `k : W ⟶ Y` such that `k ≫ normal_mono.g = 0` induces
 a morphism `l : W ⟶ X` such that `l ≫ f = k`. -/

--- a/Mathlib/CategoryTheory/Limits/Shapes/NormalMono/Basic.lean
+++ b/Mathlib/CategoryTheory/Limits/Shapes/NormalMono/Basic.lean
@@ -72,11 +72,13 @@ def equivalenceReflectsNormalMono {D : Type u₂} [Category.{v₁} D] [HasZeroMo
 end
 
 /-- Every normal monomorphism is a regular monomorphism. -/
-instance (priority := 100) NormalMono.regularMono (f : X ⟶ Y) [I : NormalMono f] : RegularMono f :=
+def NormalMono.regularMono (f : X ⟶ Y) [I : NormalMono f] : RegularMono f :=
   { I with
     left := I.g
     right := 0
     w := by simpa using I.w }
+
+instance (priority := 100)  (f : X ⟶ Y) [I : NormalMono f] : IsRegularMono f := ⟨I.regularMono⟩
 
 /-- If `f` is a normal mono, then any map `k : W ⟶ Y` such that `k ≫ normal_mono.g = 0` induces
 a morphism `l : W ⟶ X` such that `l ≫ f = k`. -/
@@ -99,7 +101,7 @@ def normalOfIsPullbackSndOfNormal {P Q R S : C} {f : P ⟶ Q} {g : P ⟶ R} {h :
       simp only [← Category.assoc, eq_whisker comm]
     rw [← reassoc', hn.w, HasZeroMorphisms.comp_zero]
   isLimit := by
-    letI gr := regularOfIsPullbackSndOfRegular comm t
+    letI gr := regularOfIsPullbackSndOfRegular hn.regularMono comm t
     have q := (HasZeroMorphisms.comp_zero k hn.Z).symm
     convert gr.isLimit
 
@@ -132,9 +134,9 @@ def normalMonoOfMono [IsNormalMonoCategory C] (f : X ⟶ Y) [Mono f] : NormalMon
 
 instance (priority := 100) regularMonoCategoryOfNormalMonoCategory [IsNormalMonoCategory C] :
     IsRegularMonoCategory C where
-  regularMonoOfMono f _ := ⟨by
+  regularMonoOfMono f _ := by
     haveI := normalMonoOfMono f
-    infer_instance⟩
+    infer_instance
 
 end
 
@@ -168,11 +170,13 @@ def equivalenceReflectsNormalEpi {D : Type u₂} [Category.{v₁} D] [HasZeroMor
 end
 
 /-- Every normal epimorphism is a regular epimorphism. -/
-instance (priority := 100) NormalEpi.regularEpi (f : X ⟶ Y) [I : NormalEpi f] : RegularEpi f :=
+def NormalEpi.regularEpi (f : X ⟶ Y) [I : NormalEpi f] : RegularEpi f :=
   { I with
     left := I.g
     right := 0
     w := by simpa using I.w }
+
+instance (priority := 100) (f : X ⟶ Y) [I : NormalEpi f] : IsRegularEpi f := ⟨I.regularEpi⟩
 
 /-- If `f` is a normal epi, then every morphism `k : X ⟶ W` satisfying `NormalEpi.g ≫ k = 0`
 induces `l : Y ⟶ W` such that `f ≫ l = k`. -/
@@ -195,7 +199,7 @@ def normalOfIsPushoutSndOfNormal {P Q R S : C} {f : P ⟶ Q} {g : P ⟶ R} {h : 
       rw [← Category.assoc, eq_whisker gn.w]
     rw [Category.assoc, comm, reassoc', zero_comp]
   isColimit := by
-    letI hn := regularOfIsPushoutSndOfRegular comm t
+    letI hn := regularOfIsPushoutSndOfRegular gn.regularEpi comm t
     have q := (@zero_comp _ _ _ gn.W _ _ f).symm
     convert hn.isColimit
 
@@ -270,8 +274,8 @@ def normalEpiOfEpi [IsNormalEpiCategory C] (f : X ⟶ Y) [Epi f] : NormalEpi f :
 
 instance (priority := 100) regularEpiCategoryOfNormalEpiCategory [IsNormalEpiCategory C] :
     IsRegularEpiCategory C where
-  regularEpiOfEpi f _ := ⟨by
+  regularEpiOfEpi f _ := by
     haveI := normalEpiOfEpi f
-    infer_instance⟩
+    infer_instance
 
 end CategoryTheory

--- a/Mathlib/CategoryTheory/Limits/Shapes/RegularMono.lean
+++ b/Mathlib/CategoryTheory/Limits/Shapes/RegularMono.lean
@@ -196,7 +196,7 @@ def regularOfIsPullbackFstOfRegular {P Q R S : C} {f : P ⟶ Q} {g : P ⟶ R} {h
   regularOfIsPullbackSndOfRegular hk comm.symm (PullbackCone.flipIsLimit t)
 
 /-- Any regular monomorphism is a strong monomorphism. -/
-def RegularMono.strongMono {f : X ⟶ Y} (h : RegularMono f) : StrongMono f :=
+lemma RegularMono.strongMono {f : X ⟶ Y} (h : RegularMono f) : StrongMono f :=
   have := h.mono
   StrongMono.mk' (by
       intro A B z hz u v sq
@@ -435,8 +435,8 @@ def regularOfIsPushoutFstOfRegular {P Q R S : C} {f : P ⟶ Q} {g : P ⟶ R} {h 
     RegularEpi k :=
   regularOfIsPushoutSndOfRegular hf comm.symm (PushoutCocone.flipIsColimit t)
 
-@[deprecated "No replacement" (since := "2025-11-20")]
-instance (priority := 100) strongEpi_of_regularEpi (f : X ⟶ Y) (h : RegularEpi f) : StrongEpi f :=
+@[deprecated "No replacement" (since := "2025-11-20")] -- ?
+lemma strongEpi_of_regularEpi (f : X ⟶ Y) (h : RegularEpi f) : StrongEpi f :=
   have := isRegularEpi_of_regularEpi h
   inferInstance
 

--- a/Mathlib/CategoryTheory/Limits/Shapes/RegularMono.lean
+++ b/Mathlib/CategoryTheory/Limits/Shapes/RegularMono.lean
@@ -68,7 +68,7 @@ structure RegularMono (f : X ⟶ Y) where
 attribute [reassoc] RegularMono.w
 
 /-- Every regular monomorphism is a monomorphism. -/
-def RegularMono.mono {f : X ⟶ Y} (h : RegularMono f) : Mono f :=
+lemma RegularMono.mono {f : X ⟶ Y} (h : RegularMono f) : Mono f :=
   mono_of_isLimit_fork h.isLimit
 
 /-- Every isomorphism is a regular monomorphism. -/
@@ -120,7 +120,7 @@ def regularMonoOfIsRegularMono (f : X ⟶ Y) [h : IsRegularMono f] :
   h.some
 
 /-- The chosen equalizer of a parallel pair is a regular monomorphism. -/
-def equalizerRegular (g h : X ⟶ Y) [HasLimit (parallelPair g h)] :
+def RegularMono.equalizer (g h : X ⟶ Y) [HasLimit (parallelPair g h)] :
     RegularMono (equalizer.ι g h) where
   Z := Y
   left := g
@@ -133,7 +133,7 @@ def equalizerRegular (g h : X ⟶ Y) [HasLimit (parallelPair g h)] :
 
 instance (g h : X ⟶ Y) [HasLimit (parallelPair g h)] :
     IsRegularMono (equalizer.ι g h) :=
-  isRegularMono_of_regularMono <| equalizerRegular g h
+  isRegularMono_of_regularMono <| RegularMono.equalizer g h
 
 /-- Every split monomorphism is a regular monomorphism. -/
 def RegularMono.ofIsSplitMono (f : X ⟶ Y) [IsSplitMono f] :
@@ -196,7 +196,7 @@ def regularOfIsPullbackFstOfRegular {P Q R S : C} {f : P ⟶ Q} {g : P ⟶ R} {h
   regularOfIsPullbackSndOfRegular hk comm.symm (PullbackCone.flipIsLimit t)
 
 /-- Any regular monomorphism is a strong monomorphism. -/
-def strongMono_of_regularMono {f : X ⟶ Y} (h : RegularMono f) : StrongMono f :=
+def RegularMono.strongMono {f : X ⟶ Y} (h : RegularMono f) : StrongMono f :=
   have := h.mono
   StrongMono.mk' (by
       intro A B z hz u v sq
@@ -209,11 +209,11 @@ def strongMono_of_regularMono {f : X ⟶ Y} (h : RegularMono f) : StrongMono f :
       simp only [Category.assoc, ht, sq.w])
 
 instance (priority := 100) (f : X ⟶ Y) [IsRegularMono f] : StrongMono f :=
-  strongMono_of_regularMono <| regularMonoOfIsRegularMono f
+  RegularMono.strongMono <| regularMonoOfIsRegularMono f
 
 /-- A regular monomorphism is an isomorphism if it is an epimorphism. -/
 theorem isIso_of_regularMono_of_epi (f : X ⟶ Y) (h : RegularMono f) [Epi f] : IsIso f :=
-  have := strongMono_of_regularMono h
+  have := RegularMono.strongMono h
   isIso_of_epi_of_strongMono _
 
 section
@@ -241,7 +241,7 @@ instance (priority := 100) regularMonoCategoryOfSplitMonoCategory [SplitMonoCate
 instance (priority := 100) strongMonoCategory_of_regularMonoCategory [IsRegularMonoCategory C] :
     StrongMonoCategory C where
   strongMono_of_mono f _ :=
-    strongMono_of_regularMono <| regularMonoOfMono f
+    RegularMono.strongMono <| regularMonoOfMono f
 
 /-- A regular epimorphism is a morphism which is the coequalizer of some parallel pair. -/
 structure RegularEpi (f : X ⟶ Y) where
@@ -257,7 +257,7 @@ structure RegularEpi (f : X ⟶ Y) where
 attribute [reassoc] RegularEpi.w
 
 /-- Every regular epimorphism is an epimorphism. -/
-def RegularEpi.epi (f : X ⟶ Y) (h : RegularEpi f) : Epi f :=
+lemma RegularEpi.epi (f : X ⟶ Y) (h : RegularEpi f) : Epi f :=
   epi_of_isColimit_cofork h.isColimit
 
 /-- Every isomorphism is a regular epimorphism. -/
@@ -337,16 +337,16 @@ def effectiveEpiStructOfRegularEpi {B X : C} {f : X ⟶ B} (hf : RegularEpi f) :
   uniq _ _ _ hg := Cofork.IsColimit.hom_ext hf.isColimit (hg.trans
     (Cofork.IsColimit.π_desc' _ _ _).symm)
 
-lemma effectiveEpi_of_regularEpi {B X : C} {f : X ⟶ B} (h : RegularEpi f) : EffectiveEpi f :=
+lemma RegularEpi.effectiveEpi {B X : C} {f : X ⟶ B} (h : RegularEpi f) : EffectiveEpi f :=
   ⟨⟨effectiveEpiStructOfRegularEpi h⟩⟩
 
 instance {B X : C} {f : X ⟶ B} [h : IsRegularEpi f] : EffectiveEpi f :=
-  effectiveEpi_of_regularEpi <| regularEpiOfIsRegularEpi f
+  RegularEpi.effectiveEpi <| regularEpiOfIsRegularEpi f
 
 /-- A morphism which is a coequalizer for its kernel pair is an effective epi. -/
 theorem effectiveEpi_of_kernelPair {B X : C} (f : X ⟶ B) [HasPullback f f]
     (hc : IsColimit (Cofork.ofπ f pullback.condition)) : EffectiveEpi f :=
-  effectiveEpi_of_regularEpi <| regularEpiOfKernelPair f hc
+  RegularEpi.effectiveEpi <| regularEpiOfKernelPair f hc
 
 @[deprecated (since := "2025-11-20")] alias effectiveEpiOfKernelPair := effectiveEpi_of_kernelPair
 

--- a/Mathlib/CategoryTheory/Limits/Shapes/RegularMono.lean
+++ b/Mathlib/CategoryTheory/Limits/Shapes/RegularMono.lean
@@ -68,7 +68,7 @@ structure RegularMono (f : X ⟶ Y) where
 attribute [reassoc] RegularMono.w
 
 /-- Every regular monomorphism is a monomorphism. -/
-def RegularMono.mono (f : X ⟶ Y) (h : RegularMono f) : Mono f :=
+def RegularMono.mono {f : X ⟶ Y} (h : RegularMono f) : Mono f :=
   mono_of_isLimit_fork h.isLimit
 
 /-- Every isomorphism is a regular monomorphism. -/

--- a/Mathlib/CategoryTheory/Limits/Shapes/RegularMono.lean
+++ b/Mathlib/CategoryTheory/Limits/Shapes/RegularMono.lean
@@ -390,7 +390,7 @@ instance (priority := 100) (f : X ⟶ Y) [IsSplitEpi f] : IsRegularEpi f :=
 
 /-- If `f` is a regular epi, then every morphism `k : X ⟶ W` coequalizing `RegularEpi.left` and
 `RegularEpi.right` induces `l : Y ⟶ W` such that `f ≫ l = k`. -/
-def RegularEpi.desc' {W : C} (f : X ⟶ Y) (hf : RegularEpi f) (k : X ⟶ W)
+def RegularEpi.desc' {W : C} {f : X ⟶ Y} (hf : RegularEpi f) (k : X ⟶ W)
     (h : hf.left ≫ k = hf.right ≫ k) :
     { l : Y ⟶ W // f ≫ l = k } :=
   Cofork.IsColimit.desc' hf.isColimit _ h

--- a/Mathlib/CategoryTheory/Limits/Shapes/RegularMono.lean
+++ b/Mathlib/CategoryTheory/Limits/Shapes/RegularMono.lean
@@ -340,8 +340,8 @@ def effectiveEpiStructOfRegularEpi {B X : C} {f : X ⟶ B} (hf : RegularEpi f) :
 lemma RegularEpi.effectiveEpi {B X : C} {f : X ⟶ B} (h : RegularEpi f) : EffectiveEpi f :=
   ⟨⟨effectiveEpiStructOfRegularEpi h⟩⟩
 
-instance {B X : C} {f : X ⟶ B} [h : IsRegularEpi f] : EffectiveEpi f :=
-  RegularEpi.effectiveEpi <| regularEpiOfIsRegularEpi f
+instance (priority := 100) {B X : C} {f : X ⟶ B} [h : IsRegularEpi f] : EffectiveEpi f :=
+  (regularEpiOfIsRegularEpi f).effectiveEpi
 
 /-- A morphism which is a coequalizer for its kernel pair is an effective epi. -/
 theorem effectiveEpi_of_kernelPair {B X : C} (f : X ⟶ B) [HasPullback f f]

--- a/Mathlib/CategoryTheory/Limits/Shapes/RegularMono.lean
+++ b/Mathlib/CategoryTheory/Limits/Shapes/RegularMono.lean
@@ -131,6 +131,10 @@ def equalizerRegular (g h : X ⟶ Y) [HasLimit (parallelPair g h)] :
       apply equalizer.hom_ext
       simp [← w]
 
+instance (g h : X ⟶ Y) [HasLimit (parallelPair g h)] :
+    IsRegularMono (equalizer.ι g h) :=
+  isRegularMono_of_regularMono <| equalizerRegular g h
+
 /-- Every split monomorphism is a regular monomorphism. -/
 def RegularMono.ofIsSplitMono (f : X ⟶ Y) [IsSplitMono f] :
     RegularMono f where
@@ -138,6 +142,10 @@ def RegularMono.ofIsSplitMono (f : X ⟶ Y) [IsSplitMono f] :
   left := 𝟙 Y
   right := retraction f ≫ f
   isLimit := isSplitMonoEqualizes f
+
+instance (priority := 100) (f : X ⟶ Y) [IsSplitMono f] :
+    IsRegularMono f :=
+  isRegularMono_of_regularMono <| .ofIsSplitMono f
 
 /-- If `f` is a regular mono, then any map `k : W ⟶ Y` equalizing `RegularMono.left` and
 `RegularMono.right` induces a morphism `l : W ⟶ X` such that `l ≫ f = k`. -/

--- a/Mathlib/CategoryTheory/Topos/Classifier.lean
+++ b/Mathlib/CategoryTheory/Topos/Classifier.lean
@@ -203,8 +203,10 @@ instance truthIsSplitMono : IsSplitMono (truth C) :=
   Classifier.isTerminalΩ₀.isSplitMono_from _
 
 /-- `truth C` is a regular monomorphism (because it is split). -/
-noncomputable instance truthIsRegularMono : RegularMono (truth C) :=
+noncomputable def truthIsRegularMono : RegularMono (truth C) :=
   RegularMono.ofIsSplitMono (truth C)
+
+instance : IsRegularMono (truth C) := ⟨truthIsRegularMono⟩
 
 /-- The following diagram
 ```
@@ -223,7 +225,8 @@ It also follows that `C` is a balanced category.
 -/
 instance isRegularMonoCategory : IsRegularMonoCategory C where
   regularMonoOfMono :=
-    fun m => ⟨regularOfIsPullbackFstOfRegular (isPullback_χ m).w (isPullback_χ m).isLimit⟩
+    fun m => ⟨regularOfIsPullbackFstOfRegular truthIsRegularMono
+      (isPullback_χ m).w (isPullback_χ m).isLimit⟩
 
 /-- If the source of a faithful functor has a subobject classifier, the functor reflects
   isomorphisms. This holds for any balanced category.

--- a/Mathlib/Topology/Category/TopCat/EffectiveEpi.lean
+++ b/Mathlib/Topology/Category/TopCat/EffectiveEpi.lean
@@ -67,7 +67,7 @@ theorem effectiveEpi_iff_isQuotientMap {B X : TopCat.{u}} (π : X ⟶ B) :
   /- Since `TopCat` has pullbacks, `π` is in fact a `RegularEpi`. This means that it exhibits `B` as
     a coequalizer of two maps into `X`. It suffices to prove that `π` followed by the isomorphism to
     an arbitrary coequalizer is a quotient map. -/
-  have hπ : RegularEpi π := inferInstance
-  exact isQuotientMap_of_isColimit_cofork _ hπ.isColimit
+  have hπ : IsRegularEpi π := inferInstance
+  exact isQuotientMap_of_isColimit_cofork _ hπ.some.isColimit
 
 end TopCat


### PR DESCRIPTION
Refactors `RegularEpi` to be a structure. See [zulip](https://leanprover.zulipchat.com/#narrow/channel/287929-mathlib4/topic/.60RegularEpi.60.20vs.20.60IsRegularEpi.60/with/560474249).

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
