### PR TITLE
[Merged by Bors] - feat(LinearAlgebra/AffineSpace/Basis): spaces of coordinates

### DIFF
--- a/Mathlib/LinearAlgebra/AffineSpace/Basis.lean
+++ b/Mathlib/LinearAlgebra/AffineSpace/Basis.lean
@@ -28,6 +28,9 @@ barycentric coordinate of `q : P` is `1 - fᵢ (q -ᵥ p i)`.
 
 ## Main definitions
 
+* `fintypeAffineCoords`: the `AffineSubspace` of `ι → k` (for `Fintype ι`) where coordinates sum
+  to `1`.
+* `finsuppAffineCoords`: the `AffineSubspace of `ι →₀ k` where coordinates sum to `1`.
 * `AffineBasis`: a structure representing an affine basis of an affine space.
 * `AffineBasis.coord`: the map `P →ᵃ[k] k` corresponding to `i : ι`.
 * `AffineBasis.coord_apply_eq`: the behaviour of `AffineBasis.coord i` on `p i`.
@@ -38,7 +41,7 @@ barycentric coordinate of `q : P` is `1 - fᵢ (q -ᵥ p i)`.
 
 ## TODO
 
-* Construct the affine equivalence between `P` and `{ f : ι →₀ k | f.sum = 1 }`.
+* Construct the affine equivalence between `P` and `finsuppAffineCoords ι k`.
 
 -/
 
@@ -46,6 +49,36 @@ barycentric coordinate of `q : P` is `1 - fᵢ (q -ᵥ p i)`.
 
 open Affine Module Set
 open scoped Pointwise
+
+section Coordinates
+
+variable {ι k V P : Type*} [Ring k] [AddCommGroup V] [Module k V] [AffineSpace V P]
+
+variable (ι k) in
+/-- The space of coordinates for affine combinations indexed by a `Fintype`. -/
+def fintypeAffineCoords [Fintype ι] : AffineSubspace k (ι → k) :=
+  (affineSpan k {(1 : k)}).comap (Fintype.linearCombination k (1 : ι → k)).toAffineMap
+
+lemma mem_fintypeAffineCoords_iff_sum [Fintype ι] {w : ι → k} :
+    w ∈ fintypeAffineCoords ι k ↔ ∑ i, w i = 1 := by
+  simp [fintypeAffineCoords, Fintype.linearCombination_apply]
+
+lemma AffineIndependent.injOn_affineCombination_fintypeAffineCoords [Fintype ι] {p : ι → P}
+    (h : AffineIndependent k p) :
+    InjOn (Finset.univ.affineCombination k p) (fintypeAffineCoords ι k) :=
+  fun w₁ hw₁ w₂ hw₂ he ↦ (affineIndependent_iff_eq_of_fintype_affineCombination_eq k p).1
+    h w₁ w₂ (mem_fintypeAffineCoords_iff_sum.1 hw₁) (mem_fintypeAffineCoords_iff_sum.1 hw₂) he
+
+variable (ι k) in
+/-- The space of coordinates for affine combinations indexed by a general type. -/
+def finsuppAffineCoords : AffineSubspace k (ι →₀ k) :=
+  (affineSpan k {(1 : k)}).comap (Finsupp.linearCombination k (1 : ι → k)).toAffineMap
+
+lemma mem_finsuppAffineCoords_iff_linearCombination {w : ι →₀ k} :
+    w ∈ finsuppAffineCoords ι k ↔ Finsupp.linearCombination k (1 : ι → k) w = 1 := by
+  simp [finsuppAffineCoords]
+
+end Coordinates
 
 universe u₁ u₂ u₃ u₄
 


### PR DESCRIPTION
Define `fintypeAffineCoords`, the `AffineSubspace` of `ι → k` (for `Fintype ι`) where coordinates sum to `1`, and the analogous `finsuppAffineCoords` for a general `ι`. The `Finsupp` case was recently discussed in #30854 and is the subject of a TODO (not addressed) in this file. The `Fintype` case is intended for use in #31205 to refactor a proof based on review there.


---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

When merging, all the commits will be squashed into a single commit
listing all co-authors.

Co-authors in the squash commit are gathered from two sources:

First, all authors of commits to this PR branch are included. Thus,
one way to add co-authors is to include at least one commit authored by
each co-author among the commits in the pull request. If necessary, you
may create empty commits to indicate co-authorship, using commands like so:

git commit --author="Author Name <author@email.com>" --allow-empty -m "add Author Name as coauthor"

Second, co-authors can also be listed in lines at the very bottom of
the commit message (that is, directly before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines
at the bottom of the commit message (before the `---`, and also before
any "Co-authored-by" lines) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
