### PR TITLE
[Merged by Bors] - feat: add gronwallBound_mono

### DIFF
--- a/Mathlib/Analysis/ODE/Gronwall.lean
+++ b/Mathlib/Analysis/ODE/Gronwall.lean
@@ -89,17 +89,14 @@ theorem gronwallBound_continuous_ε (δ K x : ℝ) : Continuous fun ε => gronwa
   · simp only [gronwallBound_of_K_ne_0 hK]
     exact continuous_const.add ((continuous_id.mul continuous_const).mul continuous_const)
 
-/-- The Gronwall bound is monotone with respect to the time variable `x`.
-
-Given `0 ≤ δ`, `0 ≤ ε`, and `0 ≤ K`, if `x₁ ≤ x₂`,
-then `gronwallBound δ K ε x₁ ≤ gronwallBound δ K ε x₂`. -/
-lemma gronwallBound_mono (δ K ε : ℝ) (hδ : 0 ≤ δ) (hε : 0 ≤ ε) (hK : 0 ≤ K) :
+/-- The Gronwall bound is monotone with respect to the time variable `x`. -/
+lemma gronwallBound_mono {δ K ε : ℝ} (hδ : 0 ≤ δ) (hε : 0 ≤ ε) (hK : 0 ≤ K) :
     Monotone (gronwallBound δ K ε) := by
   intro x₁ x₂ hx
   unfold gronwallBound
   split_ifs with hK₀
   · gcongr
-  · have hK_pos : 0 < K := hK.lt_of_ne (Ne.symm hK₀)
+  · have hK_pos : 0 < K := by positivity
     gcongr
 
 /-! ### Inequality and corollaries -/

--- a/Mathlib/Analysis/ODE/Gronwall.lean
+++ b/Mathlib/Analysis/ODE/Gronwall.lean
@@ -89,6 +89,19 @@ theorem gronwallBound_continuous_ε (δ K x : ℝ) : Continuous fun ε => gronwa
   · simp only [gronwallBound_of_K_ne_0 hK]
     exact continuous_const.add ((continuous_id.mul continuous_const).mul continuous_const)
 
+/-- The Gronwall bound is monotone with respect to the time variable `x`.
+
+Given `0 ≤ δ`, `0 ≤ ε`, and `0 ≤ K`, if `x₁ ≤ x₂`,
+then `gronwallBound δ K ε x₁ ≤ gronwallBound δ K ε x₂`. -/
+lemma gronwallBound_mono (δ K ε : ℝ) (hδ : 0 ≤ δ) (hε : 0 ≤ ε) (hK : 0 ≤ K) :
+    Monotone (gronwallBound δ K ε) := by
+  intro x₁ x₂ hx
+  unfold gronwallBound
+  split_ifs with hK₀
+  · gcongr
+  · have hK_pos : 0 < K := hK.lt_of_ne (Ne.symm hK₀)
+    gcongr
+
 /-! ### Inequality and corollaries -/
 
 /-- A Grönwall-like inequality: if `f : ℝ → ℝ` is continuous on `[a, b]` and satisfies


### PR DESCRIPTION
This PR adds `gronwallBound_mono`, which proves that the `gronwallBound` function is monotone non-decreasing with respect to the time variable `x` (given non-negative parameters `δ`, `ε`, and `K`).

This lemma is useful for comparing Gronwall bounds over different time intervals or establishing upper bounds in ODE analysis.

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

When merging, all the commits will be squashed into a single commit
listing all co-authors.

Co-authors in the squash commit are gathered from two sources:

First, all authors of commits to this PR branch are included. Thus,
one way to add co-authors is to include at least one commit authored by
each co-author among the commits in the pull request. If necessary, you
may create empty commits to indicate co-authorship, using commands like so:

git commit --author="Author Name <author@email.com>" --allow-empty -m "add Author Name as coauthor"

Second, co-authors can also be listed in lines at the very bottom of
the commit message (that is, directly before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines
at the bottom of the commit message (before the `---`, and also before
any "Co-authored-by" lines) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
