### PR TITLE
[Merged by Bors] - chore(GroupTheory/QuotientGroup): golf `subsingleton_quotient_top` using `simp`

### DIFF
--- a/Mathlib/GroupTheory/QuotientGroup/Basic.lean
+++ b/Mathlib/GroupTheory/QuotientGroup/Basic.lean
@@ -374,9 +374,7 @@ section trivial
 
 @[to_additive]
 theorem subsingleton_quotient_top : Subsingleton (G ⧸ (⊤ : Subgroup G)) := by
-  dsimp [HasQuotient.Quotient, QuotientGroup.instHasQuotientSubgroup, Quotient]
-  rw [leftRel_eq]
-  exact Trunc.instSubsingletonTrunc
+  simp
 
 /-- If the quotient by a subgroup gives a singleton then the subgroup is the whole group. -/
 @[to_additive /-- If the quotient by an additive subgroup gives a singleton then the additive


### PR DESCRIPTION
---
<details>
<summary>Show trace profiling of <code>subsingleton_quotient_top</code>: <10 ms before, <10 ms after  🎉</summary>

### Trace profiling of `subsingleton_quotient_top` before PR 32174
```diff
diff --git a/Mathlib/GroupTheory/QuotientGroup/Basic.lean b/Mathlib/GroupTheory/QuotientGroup/Basic.lean
index 9853b12188..ad45deb864 100644
--- a/Mathlib/GroupTheory/QuotientGroup/Basic.lean
+++ b/Mathlib/GroupTheory/QuotientGroup/Basic.lean
@@ -372,6 +372,7 @@ end CorrespTheorem
 
 section trivial
 
+set_option trace.profiler true in
 @[to_additive]
 theorem subsingleton_quotient_top : Subsingleton (G ⧸ (⊤ : Subgroup G)) := by
   dsimp [HasQuotient.Quotient, QuotientGroup.instHasQuotientSubgroup, Quotient]
```
```
ℹ [878/878] Built Mathlib.GroupTheory.QuotientGroup.Basic (2.2s)
info: Mathlib/GroupTheory/QuotientGroup/Basic.lean:376:0: [Elab.command] [0.010689] @[to_additive]
    theorem subsingleton_quotient_top : Subsingleton (G ⧸ (⊤ : Subgroup G)) :=
      by
      dsimp [HasQuotient.Quotient, QuotientGroup.instHasQuotientSubgroup, Quotient]
      rw [leftRel_eq]
      exact Trunc.instSubsingletonTrunc
Build completed successfully (878 jobs).
```

### Trace profiling of `subsingleton_quotient_top` after PR 32174
```diff
diff --git a/Mathlib/GroupTheory/QuotientGroup/Basic.lean b/Mathlib/GroupTheory/QuotientGroup/Basic.lean
index 9853b12188..171016870f 100644
--- a/Mathlib/GroupTheory/QuotientGroup/Basic.lean
+++ b/Mathlib/GroupTheory/QuotientGroup/Basic.lean
@@ -372,11 +372,10 @@ end CorrespTheorem
 
 section trivial
 
+set_option trace.profiler true in
 @[to_additive]
 theorem subsingleton_quotient_top : Subsingleton (G ⧸ (⊤ : Subgroup G)) := by
-  dsimp [HasQuotient.Quotient, QuotientGroup.instHasQuotientSubgroup, Quotient]
-  rw [leftRel_eq]
-  exact Trunc.instSubsingletonTrunc
+  simp
 
 /-- If the quotient by a subgroup gives a singleton then the subgroup is the whole group. -/
 @[to_additive /-- If the quotient by an additive subgroup gives a singleton then the additive
```
```
✔ [878/878] Built Mathlib.GroupTheory.QuotientGroup.Basic (2.2s)
Build completed successfully (878 jobs).
```
</details>

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

When merging, all the commits will be squashed into a single commit
listing all co-authors.

Co-authors in the squash commit are gathered from two sources:

First, all authors of commits to this PR branch are included. Thus,
one way to add co-authors is to include at least one commit authored by
each co-author among the commits in the pull request. If necessary, you
may create empty commits to indicate co-authorship, using commands like so:

git commit --author="Author Name <author@email.com>" --allow-empty -m "add Author Name as coauthor"

Second, co-authors can also be listed in lines at the very bottom of
the commit message (that is, directly before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines
at the bottom of the commit message (before the `---`, and also before
any "Co-authored-by" lines) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
