### PR TITLE
[Merged by Bors] - chore(Algebra/Order/Group/Unbundled): golf `abs_le_one_iff` (+ others) using `grind`

### DIFF
--- a/Mathlib/Algebra/Order/Group/Unbundled/Int.lean
+++ b/Mathlib/Algebra/Order/Group/Unbundled/Int.lean
@@ -43,7 +43,7 @@ theorem abs_eq_natAbs : ∀ a : ℤ, |a| = natAbs a
 
 @[norm_cast] lemma natCast_natAbs (n : ℤ) : (n.natAbs : ℤ) = |n| := n.abs_eq_natAbs.symm
 
-theorem natAbs_abs (a : ℤ) : natAbs |a| = natAbs a := by rw [abs_eq_natAbs]; rfl
+theorem natAbs_abs (a : ℤ) : natAbs |a| = natAbs a := by grind
 
 theorem sign_mul_abs (a : ℤ) : sign a * |a| = a := by
   rw [abs_eq_natAbs, sign_mul_natAbs a]
@@ -65,24 +65,17 @@ alias le_self_pow_two := le_self_sq
 @[norm_cast] lemma abs_natCast (n : ℕ) : |(n : ℤ)| = n := abs_of_nonneg (natCast_nonneg n)
 
 theorem natAbs_sub_pos_iff {i j : ℤ} : 0 < natAbs (i - j) ↔ i ≠ j := by
-  rw [natAbs_pos, ne_eq, sub_eq_zero]
+  grind
 
 theorem natAbs_sub_ne_zero_iff {i j : ℤ} : natAbs (i - j) ≠ 0 ↔ i ≠ j :=
   Nat.ne_zero_iff_zero_lt.trans natAbs_sub_pos_iff
 
 @[simp]
 theorem abs_lt_one_iff {a : ℤ} : |a| < 1 ↔ a = 0 := by
-  rw [← zero_add 1, lt_add_one_iff, abs_nonpos_iff]
+  grind
 
 theorem abs_le_one_iff {a : ℤ} : |a| ≤ 1 ↔ a = 0 ∨ a = 1 ∨ a = -1 := by
-  rw [le_iff_lt_or_eq, abs_lt_one_iff]
-  match a with
-  | (n : ℕ) => simp [abs_eq_natAbs]
-  | -[n+1] =>
-      simp only [negSucc_ne_zero, abs_eq_natAbs, natAbs_negSucc, succ_eq_add_one,
-        Int.natCast_add, cast_ofNat_Int, add_eq_right, natCast_eq_zero, false_or, reduceNeg]
-      rw [negSucc_eq]
-      cutsat
+  grind
 
 theorem one_le_abs {z : ℤ} (h₀ : z ≠ 0) : 1 ≤ |z| :=
   add_one_le_iff.mpr (abs_pos.mpr h₀)
@@ -94,7 +87,7 @@ lemma eq_zero_of_abs_lt_dvd {m x : ℤ} (h1 : m ∣ x) (h2 : |x| < m) : x = 0 :=
   cutsat
 
 lemma abs_sub_lt_of_lt_lt {m a b : ℕ} (ha : a < m) (hb : b < m) : |(b : ℤ) - a| < m := by
-  rw [abs_lt]; cutsat
+  grind
 
 /-! #### `/`  -/
 


### PR DESCRIPTION
---
<details>
<summary>Show trace profiling of <code>abs_le_one_iff</code>: 42 ms before, 29 ms after  🎉</summary>

### Trace profiling of `abs_le_one_iff` before PR 32175
```diff
diff --git a/Mathlib/Algebra/Order/Group/Unbundled/Int.lean b/Mathlib/Algebra/Order/Group/Unbundled/Int.lean
index 7366cd67e6..75e791e945 100644
--- a/Mathlib/Algebra/Order/Group/Unbundled/Int.lean
+++ b/Mathlib/Algebra/Order/Group/Unbundled/Int.lean
@@ -74,6 +74,7 @@ theorem natAbs_sub_ne_zero_iff {i j : ℤ} : natAbs (i - j) ≠ 0 ↔ i ≠ j :=
 theorem abs_lt_one_iff {a : ℤ} : |a| < 1 ↔ a = 0 := by
   rw [← zero_add 1, lt_add_one_iff, abs_nonpos_iff]
 
+set_option trace.profiler true in
 theorem abs_le_one_iff {a : ℤ} : |a| ≤ 1 ↔ a = 0 ∨ a = 1 ∨ a = -1 := by
   rw [le_iff_lt_or_eq, abs_lt_one_iff]
   match a with
```
```
ℹ [423/423] Built Mathlib.Algebra.Order.Group.Unbundled.Int (946ms)
info: Mathlib/Algebra/Order/Group/Unbundled/Int.lean:78:0: [Elab.async] [0.042182] elaborating proof of Int.abs_le_one_iff
  [Elab.definition.value] [0.041798] Int.abs_le_one_iff
    [Elab.step] [0.041663] 
          rw [le_iff_lt_or_eq, abs_lt_one_iff]
          match a with
          | (n : ℕ) => simp [abs_eq_natAbs]
          |
          -[n+1] =>
            simp only [negSucc_ne_zero, abs_eq_natAbs, natAbs_negSucc, succ_eq_add_one, Int.natCast_add, cast_ofNat_Int,
              add_eq_right, natCast_eq_zero, false_or, reduceNeg]
            rw [negSucc_eq]
            cutsat
      [Elab.step] [0.041657] 
            rw [le_iff_lt_or_eq, abs_lt_one_iff]
            match a with
            | (n : ℕ) => simp [abs_eq_natAbs]
            |
            -[n+1] =>
              simp only [negSucc_ne_zero, abs_eq_natAbs, natAbs_negSucc, succ_eq_add_one, Int.natCast_add,
                cast_ofNat_Int, add_eq_right, natCast_eq_zero, false_or, reduceNeg]
              rw [negSucc_eq]
              cutsat
        [Elab.step] [0.040159] match a with
            | (n : ℕ) => simp [abs_eq_natAbs]
            |
            -[n+1] =>
              simp only [negSucc_ne_zero, abs_eq_natAbs, natAbs_negSucc, succ_eq_add_one, Int.natCast_add,
                cast_ofNat_Int, add_eq_right, natCast_eq_zero, false_or, reduceNeg]
              rw [negSucc_eq]
              cutsat
          [Elab.step] [0.033109] case rhs✝ =>
                with_annotate_state["|" "=>"] skip
                  simp only [negSucc_ne_zero, abs_eq_natAbs, natAbs_negSucc, succ_eq_add_one, Int.natCast_add,
                    cast_ofNat_Int, add_eq_right, natCast_eq_zero, false_or, reduceNeg]
                  rw [negSucc_eq]
                  cutsat
            [Elab.step] [0.033080] 
                  with_annotate_state["|" "=>"] skip
                    simp only [negSucc_ne_zero, abs_eq_natAbs, natAbs_negSucc, succ_eq_add_one, Int.natCast_add,
                      cast_ofNat_Int, add_eq_right, natCast_eq_zero, false_or, reduceNeg]
                    rw [negSucc_eq]
                    cutsat
              [Elab.step] [0.033076] 
                    with_annotate_state["|" "=>"] skip
                      simp only [negSucc_ne_zero, abs_eq_natAbs, natAbs_negSucc, succ_eq_add_one, Int.natCast_add,
                        cast_ofNat_Int, add_eq_right, natCast_eq_zero, false_or, reduceNeg]
                      rw [negSucc_eq]
                      cutsat
                [Elab.step] [0.033067] 
                      simp only [negSucc_ne_zero, abs_eq_natAbs, natAbs_negSucc, succ_eq_add_one, Int.natCast_add,
                        cast_ofNat_Int, add_eq_right, natCast_eq_zero, false_or, reduceNeg]
                      rw [negSucc_eq]
                      cutsat
                  [Elab.step] [0.033063] 
                        simp only [negSucc_ne_zero, abs_eq_natAbs, natAbs_negSucc, succ_eq_add_one, Int.natCast_add,
                          cast_ofNat_Int, add_eq_right, natCast_eq_zero, false_or, reduceNeg]
                        rw [negSucc_eq]
                        cutsat
                    [Elab.step] [0.018329] simp only [negSucc_ne_zero, abs_eq_natAbs, natAbs_negSucc, succ_eq_add_one,
                          Int.natCast_add, cast_ofNat_Int, add_eq_right, natCast_eq_zero, false_or, reduceNeg]
                    [Elab.step] [0.014029] cutsat
Build completed successfully (423 jobs).
```

### Trace profiling of `abs_le_one_iff` after PR 32175
```diff
diff --git a/Mathlib/Algebra/Order/Group/Unbundled/Int.lean b/Mathlib/Algebra/Order/Group/Unbundled/Int.lean
index 7366cd67e6..7f61175856 100644
--- a/Mathlib/Algebra/Order/Group/Unbundled/Int.lean
+++ b/Mathlib/Algebra/Order/Group/Unbundled/Int.lean
@@ -43,7 +43,7 @@ theorem abs_eq_natAbs : ∀ a : ℤ, |a| = natAbs a
 
 @[norm_cast] lemma natCast_natAbs (n : ℤ) : (n.natAbs : ℤ) = |n| := n.abs_eq_natAbs.symm
 
-theorem natAbs_abs (a : ℤ) : natAbs |a| = natAbs a := by rw [abs_eq_natAbs]; rfl
+theorem natAbs_abs (a : ℤ) : natAbs |a| = natAbs a := by grind
 
 theorem sign_mul_abs (a : ℤ) : sign a * |a| = a := by
   rw [abs_eq_natAbs, sign_mul_natAbs a]
@@ -65,24 +65,18 @@ alias le_self_pow_two := le_self_sq
 @[norm_cast] lemma abs_natCast (n : ℕ) : |(n : ℤ)| = n := abs_of_nonneg (natCast_nonneg n)
 
 theorem natAbs_sub_pos_iff {i j : ℤ} : 0 < natAbs (i - j) ↔ i ≠ j := by
-  rw [natAbs_pos, ne_eq, sub_eq_zero]
+  grind
 
 theorem natAbs_sub_ne_zero_iff {i j : ℤ} : natAbs (i - j) ≠ 0 ↔ i ≠ j :=
   Nat.ne_zero_iff_zero_lt.trans natAbs_sub_pos_iff
 
 @[simp]
 theorem abs_lt_one_iff {a : ℤ} : |a| < 1 ↔ a = 0 := by
-  rw [← zero_add 1, lt_add_one_iff, abs_nonpos_iff]
+  grind
 
+set_option trace.profiler true in
 theorem abs_le_one_iff {a : ℤ} : |a| ≤ 1 ↔ a = 0 ∨ a = 1 ∨ a = -1 := by
-  rw [le_iff_lt_or_eq, abs_lt_one_iff]
-  match a with
-  | (n : ℕ) => simp [abs_eq_natAbs]
-  | -[n+1] =>
-      simp only [negSucc_ne_zero, abs_eq_natAbs, natAbs_negSucc, succ_eq_add_one,
-        Int.natCast_add, cast_ofNat_Int, add_eq_right, natCast_eq_zero, false_or, reduceNeg]
-      rw [negSucc_eq]
-      cutsat
+  grind
 
 theorem one_le_abs {z : ℤ} (h₀ : z ≠ 0) : 1 ≤ |z| :=
   add_one_le_iff.mpr (abs_pos.mpr h₀)
@@ -94,7 +88,7 @@ lemma eq_zero_of_abs_lt_dvd {m x : ℤ} (h1 : m ∣ x) (h2 : |x| < m) : x = 0 :=
   cutsat
 
 lemma abs_sub_lt_of_lt_lt {m a b : ℕ} (ha : a < m) (hb : b < m) : |(b : ℤ) - a| < m := by
-  rw [abs_lt]; cutsat
+  grind
 
 /-! #### `/`  -/
 
```
```
ℹ [423/423] Built Mathlib.Algebra.Order.Group.Unbundled.Int (871ms)
info: Mathlib/Algebra/Order/Group/Unbundled/Int.lean:78:0: [Elab.async] [0.029469] elaborating proof of Int.abs_le_one_iff
  [Elab.definition.value] [0.029347] Int.abs_le_one_iff
    [Elab.step] [0.029287] grind
      [Elab.step] [0.029282] grind
        [Elab.step] [0.029275] grind
info: Mathlib/Algebra/Order/Group/Unbundled/Int.lean:79:2: [Elab.async] [0.014502] Lean.addDecl
  [Kernel] [0.014484] ✅️ typechecking declarations [_private.Mathlib.Algebra.Order.Group.Unbundled.Int.0.Int.abs_le_one_iff._proof_1_1]
Build completed successfully (423 jobs).
```
</details>

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

When merging, all the commits will be squashed into a single commit
listing all co-authors.

Co-authors in the squash commit are gathered from two sources:

First, all authors of commits to this PR branch are included. Thus,
one way to add co-authors is to include at least one commit authored by
each co-author among the commits in the pull request. If necessary, you
may create empty commits to indicate co-authorship, using commands like so:

git commit --author="Author Name <author@email.com>" --allow-empty -m "add Author Name as coauthor"

Second, co-authors can also be listed in lines at the very bottom of
the commit message (that is, directly before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines
at the bottom of the commit message (before the `---`, and also before
any "Co-authored-by" lines) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
