### PR TITLE
[Merged by Bors] - chore(Data/Finsupp): golf `embSigma_apply_of_ne` and `embSigma_single` using `grind`

### DIFF
--- a/Mathlib/Data/Finsupp/Sigma.lean
+++ b/Mathlib/Data/Finsupp/Sigma.lean
@@ -66,9 +66,7 @@ theorem embSigma_apply_self {k : κ} (f : ι k →₀ M) (i : ι k) :
 theorem embSigma_apply_of_ne {k k' : κ} (f : ι k →₀ M) (hk : k' ≠ k) (i : ι k') :
     embSigma f ⟨k', i⟩ = 0 := by
   apply embDomain_notin_range
-  intro ⟨j, hj⟩
-  simp only [Embedding.sigmaMk, Embedding.coeFn_mk, Sigma.mk.injEq] at hj
-  exact hk hj.1.symm
+  grind
 
 @[simp, grind =]
 theorem support_embSigma {k : κ} (f : ι k →₀ M) :
@@ -120,11 +118,7 @@ section EmbSigmaSingle
 theorem embSigma_single [Zero M] {k : κ} (i : ι k) (m : M) :
     embSigma (single i m) = single ⟨k, i⟩ m := by
   classical
-  ext ⟨k', j⟩
-  by_cases hk : k' = k
-  · subst hk
-    simp [single_apply]
-  · simp [embSigma_apply_of_ne _ hk, hk]
+  grind
 
 end EmbSigmaSingle
 


### PR DESCRIPTION
---
<details>
<summary>Show trace profiling of <code>embSigma_apply_of_ne</code>: <10 ms before, 11 ms after </summary>

### Trace profiling of `embSigma_apply_of_ne` before PR 32177
```diff
diff --git a/Mathlib/Data/Finsupp/Sigma.lean b/Mathlib/Data/Finsupp/Sigma.lean
index f478577be3..16cdf4ef9a 100644
--- a/Mathlib/Data/Finsupp/Sigma.lean
+++ b/Mathlib/Data/Finsupp/Sigma.lean
@@ -62,6 +62,7 @@ theorem embSigma_apply_self {k : κ} (f : ι k →₀ M) (i : ι k) :
   rw [embSigma]
   exact embDomain_apply (Embedding.sigmaMk k) f i
 
+set_option trace.profiler true in
 /-- Values of `embSigma f` at indices outside the `k`-th summand are zero. -/
 theorem embSigma_apply_of_ne {k k' : κ} (f : ι k →₀ M) (hk : k' ≠ k) (i : ι k') :
     embSigma f ⟨k', i⟩ = 0 := by
```
```
✔ [849/849] Built Mathlib.Data.Finsupp.Sigma (926ms)
Build completed successfully (849 jobs).
```

### Trace profiling of `embSigma_apply_of_ne` after PR 32177
```diff
diff --git a/Mathlib/Data/Finsupp/Sigma.lean b/Mathlib/Data/Finsupp/Sigma.lean
index f478577be3..f28dbce8bb 100644
--- a/Mathlib/Data/Finsupp/Sigma.lean
+++ b/Mathlib/Data/Finsupp/Sigma.lean
@@ -62,13 +62,12 @@ theorem embSigma_apply_self {k : κ} (f : ι k →₀ M) (i : ι k) :
   rw [embSigma]
   exact embDomain_apply (Embedding.sigmaMk k) f i
 
+set_option trace.profiler true in
 /-- Values of `embSigma f` at indices outside the `k`-th summand are zero. -/
 theorem embSigma_apply_of_ne {k k' : κ} (f : ι k →₀ M) (hk : k' ≠ k) (i : ι k') :
     embSigma f ⟨k', i⟩ = 0 := by
   apply embDomain_notin_range
-  intro ⟨j, hj⟩
-  simp [Embedding.sigmaMk] at hj
-  exact hk hj.1.symm
+  grind
 
 @[simp, grind =]
 theorem support_embSigma {k : κ} (f : ι k →₀ M) :
@@ -120,11 +119,7 @@ section EmbSigmaSingle
 theorem embSigma_single [Zero M] {k : κ} (i : ι k) (m : M) :
     embSigma (single i m) = single ⟨k, i⟩ m := by
   classical
-  ext ⟨k', j⟩
-  by_cases hk : k' = k
-  · subst hk
-    simp [single_apply]
-  · simp [embSigma_apply_of_ne _ hk, hk]
+  grind
 
 end EmbSigmaSingle
 
```
```
ℹ [849/849] Built Mathlib.Data.Finsupp.Sigma (948ms)
info: Mathlib/Data/Finsupp/Sigma.lean:66:0: [Elab.async] [0.011068] elaborating proof of Finsupp.embSigma_apply_of_ne
  [Elab.definition.value] [0.010830] Finsupp.embSigma_apply_of_ne
    [Elab.step] [0.010655] 
          apply embDomain_notin_range
          grind
      [Elab.step] [0.010648] 
            apply embDomain_notin_range
            grind
        [Elab.step] [0.010062] grind
Build completed successfully (849 jobs).
```
</details>

---
<details>
<summary>Show trace profiling of <code>embSigma_single</code>: 12 ms before, 32 ms after </summary>

### Trace profiling of `embSigma_single` before PR 32177
```diff
diff --git a/Mathlib/Data/Finsupp/Sigma.lean b/Mathlib/Data/Finsupp/Sigma.lean
index f478577be3..880d9e2ab6 100644
--- a/Mathlib/Data/Finsupp/Sigma.lean
+++ b/Mathlib/Data/Finsupp/Sigma.lean
@@ -116,6 +116,7 @@ end EmbSigmaAdd
 
 section EmbSigmaSingle
 
+set_option trace.profiler true in
 @[simp]
 theorem embSigma_single [Zero M] {k : κ} (i : ι k) (m : M) :
     embSigma (single i m) = single ⟨k, i⟩ m := by
```
```
ℹ [849/849] Built Mathlib.Data.Finsupp.Sigma (892ms)
info: Mathlib/Data/Finsupp/Sigma.lean:120:0: [Elab.async] [0.012892] elaborating proof of Finsupp.embSigma_single
  [Elab.definition.value] [0.012394] Finsupp.embSigma_single
    [Elab.step] [0.012128] classical
          ext ⟨k', j⟩
          by_cases hk : k' = k
          · subst hk
            simp [single_apply]
          · simp [embSigma_apply_of_ne _ hk, hk]
      [Elab.step] [0.012125] classical
            ext ⟨k', j⟩
            by_cases hk : k' = k
            · subst hk
              simp [single_apply]
            · simp [embSigma_apply_of_ne _ hk, hk]
        [Elab.step] [0.012121] classical
            ext ⟨k', j⟩
            by_cases hk : k' = k
            · subst hk
              simp [single_apply]
            · simp [embSigma_apply_of_ne _ hk, hk]
          [Elab.step] [0.012040] 
                ext ⟨k', j⟩
                by_cases hk : k' = k
                · subst hk
                  simp [single_apply]
                · simp [embSigma_apply_of_ne _ hk, hk]
            [Elab.step] [0.012031] 
                  ext ⟨k', j⟩
                  by_cases hk : k' = k
                  · subst hk
                    simp [single_apply]
                  · simp [embSigma_apply_of_ne _ hk, hk]
Build completed successfully (849 jobs).
```

### Trace profiling of `embSigma_single` after PR 32177
```diff
diff --git a/Mathlib/Data/Finsupp/Sigma.lean b/Mathlib/Data/Finsupp/Sigma.lean
index f478577be3..3417a4e415 100644
--- a/Mathlib/Data/Finsupp/Sigma.lean
+++ b/Mathlib/Data/Finsupp/Sigma.lean
@@ -66,9 +66,7 @@ theorem embSigma_apply_self {k : κ} (f : ι k →₀ M) (i : ι k) :
 theorem embSigma_apply_of_ne {k k' : κ} (f : ι k →₀ M) (hk : k' ≠ k) (i : ι k') :
     embSigma f ⟨k', i⟩ = 0 := by
   apply embDomain_notin_range
-  intro ⟨j, hj⟩
-  simp [Embedding.sigmaMk] at hj
-  exact hk hj.1.symm
+  grind
 
 @[simp, grind =]
 theorem support_embSigma {k : κ} (f : ι k →₀ M) :
@@ -116,15 +114,12 @@ end EmbSigmaAdd
 
 section EmbSigmaSingle
 
+set_option trace.profiler true in
 @[simp]
 theorem embSigma_single [Zero M] {k : κ} (i : ι k) (m : M) :
     embSigma (single i m) = single ⟨k, i⟩ m := by
   classical
-  ext ⟨k', j⟩
-  by_cases hk : k' = k
-  · subst hk
-    simp [single_apply]
-  · simp [embSigma_apply_of_ne _ hk, hk]
+  grind
 
 end EmbSigmaSingle
 
```
```
ℹ [849/849] Built Mathlib.Data.Finsupp.Sigma (917ms)
info: Mathlib/Data/Finsupp/Sigma.lean:118:0: [Elab.async] [0.032285] elaborating proof of Finsupp.embSigma_single
  [Elab.definition.value] [0.032144] Finsupp.embSigma_single
    [Elab.step] [0.032064] classical grind
      [Elab.step] [0.032060] classical grind
        [Elab.step] [0.032057] classical grind
          [Elab.step] [0.032000] grind
            [Elab.step] [0.031993] grind
              [Elab.step] [0.031987] grind
Build completed successfully (849 jobs).
```
</details>

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

When merging, all the commits will be squashed into a single commit
listing all co-authors.

Co-authors in the squash commit are gathered from two sources:

First, all authors of commits to this PR branch are included. Thus,
one way to add co-authors is to include at least one commit authored by
each co-author among the commits in the pull request. If necessary, you
may create empty commits to indicate co-authorship, using commands like so:

git commit --author="Author Name <author@email.com>" --allow-empty -m "add Author Name as coauthor"

Second, co-authors can also be listed in lines at the very bottom of
the commit message (that is, directly before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines
at the bottom of the commit message (before the `---`, and also before
any "Co-authored-by" lines) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
