### PR TITLE
[Merged by Bors] - feat(CategoryTheory): improve API for limits in preorders

### DIFF
--- a/Mathlib/CategoryTheory/Limits/Preorder.lean
+++ b/Mathlib/CategoryTheory/Limits/Preorder.lean
@@ -35,6 +35,7 @@ variable {J : Type u'} [Category.{v} J]
 variable (F : J ⥤ C)
 
 /-- The cone associated to a lower bound of a functor. -/
+@[simps]
 def coneOfLowerBound {x : C} (h : x ∈ lowerBounds (Set.range F.obj)) : Cone F where
   pt := x
   π := { app i := homOfLE (h (Set.mem_range_self _)) }
@@ -51,13 +52,24 @@ lemma isGLB_of_isLimit {c : Cone F} (h : IsLimit c) : IsGLB (Set.range F.obj) c.
 def isLimitOfIsGLB (c : Cone F) (h : IsGLB (Set.range F.obj) c.pt) : IsLimit c where
   lift d := (h.2 (conePt_mem_lowerBounds F d)).hom
 
+/-- The limit cone for a functor `F : J ⥤ C` to a preorder when `pt : C`
+is the greatest lower bound of `Set.range F.obj` -/
+@[simps]
+def limitConeOfIsGLB {pt : C} (h : IsGLB (Set.range F.obj) pt) :
+    LimitCone F where
+  cone := coneOfLowerBound _ h.1
+  isLimit := isLimitOfIsGLB _ _ h
+
 /-- A functor has a limit iff there exists a glb. -/
-lemma hasLimit_iff_hasGLB : HasLimit F ↔ ∃ x, IsGLB (Set.range F.obj) x := by
-  constructor <;> intro h
-  · let limitCone := getLimitCone F
-    exact ⟨limitCone.cone.pt, isGLB_of_isLimit F limitCone.isLimit⟩
-  · obtain ⟨l, isGLB⟩ := h
-    exact ⟨⟨⟨coneOfLowerBound F isGLB.1, isLimitOfIsGLB F _ isGLB⟩⟩⟩
+lemma hasLimit_iff_hasGLB : HasLimit F ↔ ∃ x, IsGLB (Set.range F.obj) x :=
+  ⟨fun _ ↦ ⟨_, isGLB_of_isLimit _ (limit.isLimit _)⟩,
+    fun ⟨_, h⟩ ↦ ⟨⟨limitConeOfIsGLB _ h⟩⟩⟩
+
+/-- The cocone associated to an upper bound of a functor. -/
+@[simps]
+def coconeOfUpperBound {x : C} (h : x ∈ upperBounds (Set.range F.obj)) : Cocone F where
+  pt := x
+  ι := { app i := homOfLE (h (Set.mem_range_self _)) }
 
 /-- The cocone associated to an upper bound of a functor -/
 def coconePt_mem_upperBounds {x : C} (h : x ∈ upperBounds (Set.range F.obj)) : Cocone F where
@@ -76,14 +88,19 @@ lemma isLUB_of_isColimit {c : Cocone F} (h : IsColimit c) : IsLUB (Set.range F.o
 def isColimitOfIsLUB (c : Cocone F) (h : IsLUB (Set.range F.obj) c.pt) : IsColimit c where
   desc d := (h.2 (upperBoundOfCocone F d)).hom
 
+/-- The colimit cocone for a functor `F : J ⥤ C` to a preorder when `pt : C`
+is the least upper bound of `Set.range F.obj` -/
+@[simps]
+def colimitCoconeOfIsLUB {pt : C} (h : IsLUB (Set.range F.obj) pt) :
+    ColimitCocone F where
+  cocone := coconeOfUpperBound _ h.1
+  isColimit := isColimitOfIsLUB _ _ h
+
 /-- A functor has a colimit iff there exists a lub. -/
 lemma hasColimit_iff_hasLUB :
-    HasColimit F ↔ ∃ x, IsLUB (Set.range F.obj) x := by
-  constructor <;> intro h
-  · let limitCocone := getColimitCocone F
-    exact ⟨limitCocone.cocone.pt, isLUB_of_isColimit F limitCocone.isColimit⟩
-  · obtain ⟨l, isLUB⟩ := h
-    exact ⟨⟨⟨coconePt_mem_upperBounds F isLUB.1, isColimitOfIsLUB F _ isLUB⟩⟩⟩
+    HasColimit F ↔ ∃ x, IsLUB (Set.range F.obj) x :=
+  ⟨fun _ ↦ ⟨_, isLUB_of_isColimit _ (colimit.isColimit _)⟩,
+    fun ⟨_, h⟩ ↦ ⟨⟨colimitCoconeOfIsLUB _ h⟩⟩⟩
 
 end
 

--- a/Mathlib/CategoryTheory/Limits/Preorder.lean
+++ b/Mathlib/CategoryTheory/Limits/Preorder.lean
@@ -77,7 +77,7 @@ lemma coconePt_mem_upperBounds (c : Cocone F) : c.pt ∈ upperBounds (Set.range 
 
 /-- If a cocone is a colimit, its point is a lub. -/
 lemma isLUB_of_isColimit {c : Cocone F} (h : IsColimit c) : IsLUB (Set.range F.obj) c.pt :=
-  ⟨(coconePt_mem_upperBounds F c), fun _ k ↦ (h.desc (coconePt_mem_upperBounds F k)).le⟩
+  ⟨(coconePt_mem_upperBounds F c), fun _ k ↦ (h.desc (coconeOfUpperBound F k)).le⟩
 
 /-- If the point of cocone is a lub, the cocone is a .colimit -/
 def isColimitOfIsLUB (c : Cocone F) (h : IsLUB (Set.range F.obj) c.pt) : IsColimit c where

--- a/Mathlib/CategoryTheory/Limits/Preorder.lean
+++ b/Mathlib/CategoryTheory/Limits/Preorder.lean
@@ -71,22 +71,17 @@ def coconeOfUpperBound {x : C} (h : x ∈ upperBounds (Set.range F.obj)) : Cocon
   pt := x
   ι := { app i := homOfLE (h (Set.mem_range_self _)) }
 
-/-- The cocone associated to an upper bound of a functor -/
-def coconePt_mem_upperBounds {x : C} (h : x ∈ upperBounds (Set.range F.obj)) : Cocone F where
-  pt := x
-  ι := { app i := homOfLE (h (Set.mem_range_self _)) }
-
 /-- The point of a cocone is an upper bound. -/
-lemma upperBoundOfCocone (c : Cocone F) : c.pt ∈ upperBounds (Set.range F.obj) := by
+lemma coconePt_mem_upperBounds (c : Cocone F) : c.pt ∈ upperBounds (Set.range F.obj) := by
   intro x ⟨i, p⟩; rw [← p]; exact (c.ι.app i).le
 
 /-- If a cocone is a colimit, its point is a lub. -/
 lemma isLUB_of_isColimit {c : Cocone F} (h : IsColimit c) : IsLUB (Set.range F.obj) c.pt :=
-  ⟨(upperBoundOfCocone F c), fun _ k ↦ (h.desc (coconePt_mem_upperBounds F k)).le⟩
+  ⟨(coconePt_mem_upperBounds F c), fun _ k ↦ (h.desc (coconePt_mem_upperBounds F k)).le⟩
 
 /-- If the point of cocone is a lub, the cocone is a .colimit -/
 def isColimitOfIsLUB (c : Cocone F) (h : IsLUB (Set.range F.obj) c.pt) : IsColimit c where
-  desc d := (h.2 (upperBoundOfCocone F d)).hom
+  desc d := (h.2 (coconePt_mem_upperBounds F d)).hom
 
 /-- The colimit cocone for a functor `F : J ⥤ C` to a preorder when `pt : C`
 is the least upper bound of `Set.range F.obj` -/


### PR DESCRIPTION
---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

When merging, all the commits will be squashed into a single commit
listing all co-authors.

Co-authors in the squash commit are gathered from two sources:

First, all authors of commits to this PR branch are included. Thus,
one way to add co-authors is to include at least one commit authored by
each co-author among the commits in the pull request. If necessary, you
may create empty commits to indicate co-authorship, using commands like so:

git commit --author="Author Name <author@email.com>" --allow-empty -m "add Author Name as coauthor"

Second, co-authors can also be listed in lines at the very bottom of
the commit message (that is, directly before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines
at the bottom of the commit message (before the `---`, and also before
any "Co-authored-by" lines) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
