### PR TITLE
[Merged by Bors] - feat: add `DifferentiableAt.lineDifferentiableAt`

### DIFF
--- a/Mathlib/Analysis/Calculus/LineDeriv/Basic.lean
+++ b/Mathlib/Analysis/Calculus/LineDeriv/Basic.lean
@@ -268,7 +268,7 @@ lemma HasFDerivWithinAt.hasLineDerivWithinAt (hf : HasFDerivWithinAt f L s x) (v
 
 theorem DifferentiableWithinAt.lineDifferentiableWithinAt
     (hf : DifferentiableWithinAt 𝕜 f s x) :
-    LineDifferentiableAt 𝕜 f x s v :=
+    LineDifferentiableWithinAt 𝕜 f s x v :=
   hf.hasFDerivWithinAt.hasLineDerivWithinAt _ |>.lineDifferentiableWithinAt
 
 lemma HasFDerivAt.hasLineDerivAt (hf : HasFDerivAt f L x) (v : E) :

--- a/Mathlib/Analysis/Calculus/LineDeriv/Basic.lean
+++ b/Mathlib/Analysis/Calculus/LineDeriv/Basic.lean
@@ -266,10 +266,19 @@ lemma HasFDerivWithinAt.hasLineDerivWithinAt (hf : HasFDerivWithinAt f L s x) (v
   simp only [one_smul, zero_add] at A
   exact hf.comp_hasDerivWithinAt (x := (0 : 𝕜)) A (mapsTo_preimage F s)
 
+theorem DifferentiableWithinAt.lineDifferentiableWithinAt
+    (hf : DifferentiableWithinAt 𝕜 f s x) :
+    LineDifferentiableAt 𝕜 f x s v :=
+  hf.hasFDerivWithinAt.hasLineDerivWithinAt _ |>.lineDifferentiableWithinAt
+
 lemma HasFDerivAt.hasLineDerivAt (hf : HasFDerivAt f L x) (v : E) :
     HasLineDerivAt 𝕜 f (L v) x v := by
   rw [← hasLineDerivWithinAt_univ]
   exact hf.hasFDerivWithinAt.hasLineDerivWithinAt v
+
+theorem DifferentiableAt.lineDifferentiableAt (hf : DifferentiableAt 𝕜 f x) :
+    LineDifferentiableAt 𝕜 f x v :=
+  hf.hasFDerivAt.hasLineDerivAt _ |>.lineDifferentiableAt
 
 lemma DifferentiableAt.lineDeriv_eq_fderiv (hf : DifferentiableAt 𝕜 f x) :
     lineDeriv 𝕜 f x v = fderiv 𝕜 f x v :=


### PR DESCRIPTION
---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

When merging, all the commits will be squashed into a single commit
listing all co-authors.

Co-authors in the squash commit are gathered from two sources:

First, all authors of commits to this PR branch are included. Thus,
one way to add co-authors is to include at least one commit authored by
each co-author among the commits in the pull request. If necessary, you
may create empty commits to indicate co-authorship, using commands like so:

git commit --author="Author Name <author@email.com>" --allow-empty -m "add Author Name as coauthor"

Second, co-authors can also be listed in lines at the very bottom of
the commit message (that is, directly before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines
at the bottom of the commit message (before the `---`, and also before
any "Co-authored-by" lines) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
