### PR TITLE
chore(Algebra/Order/Group): golf `abs_max_sub_max_le_max` (+ others) using `grind`

### DIFF
--- a/Mathlib/Algebra/Order/Group/MinMax.lean
+++ b/Mathlib/Algebra/Order/Group/MinMax.lean
@@ -72,17 +72,12 @@ theorem max_sub_max_le_max (a b c d : α) : max a b - max c d ≤ max (a - c) (b
   grind
 
 theorem abs_max_sub_max_le_max (a b c d : α) : |max a b - max c d| ≤ max |a - c| |b - d| := by
-  refine abs_sub_le_iff.2 ⟨?_, ?_⟩
-  · exact (max_sub_max_le_max _ _ _ _).trans (max_le_max (le_abs_self _) (le_abs_self _))
-  · rw [abs_sub_comm a c, abs_sub_comm b d]
-    exact (max_sub_max_le_max _ _ _ _).trans (max_le_max (le_abs_self _) (le_abs_self _))
+  grind
 
 theorem abs_min_sub_min_le_max (a b c d : α) : |min a b - min c d| ≤ max |a - c| |b - d| := by
-  simpa only [max_neg_neg, neg_sub_neg, abs_sub_comm] using
-    abs_max_sub_max_le_max (-a) (-b) (-c) (-d)
+  grind
 
 theorem abs_max_sub_max_le_abs (a b c : α) : |max a c - max b c| ≤ |a - b| := by
-  simpa only [sub_self, abs_zero, max_eq_left (abs_nonneg (a - b))]
-    using abs_max_sub_max_le_max a c b c
+  grind
 
 end LinearOrderedAddCommGroup


### PR DESCRIPTION
---
<details>
<summary>Show trace profiling of <code>abs_max_sub_max_le_max</code>: <10 ms before, 107 ms after </summary>

### Trace profiling of `abs_max_sub_max_le_max` before PR 32184
```diff
diff --git a/Mathlib/Algebra/Order/Group/MinMax.lean b/Mathlib/Algebra/Order/Group/MinMax.lean
index 0e0d491022..aff1dd669f 100644
--- a/Mathlib/Algebra/Order/Group/MinMax.lean
+++ b/Mathlib/Algebra/Order/Group/MinMax.lean
@@ -71,6 +71,7 @@ variable {α : Type*} [AddCommGroup α] [LinearOrder α] [IsOrderedAddMonoid α]
 theorem max_sub_max_le_max (a b c d : α) : max a b - max c d ≤ max (a - c) (b - d) := by
   grind
 
+set_option trace.profiler true in
 theorem abs_max_sub_max_le_max (a b c d : α) : |max a b - max c d| ≤ max |a - c| |b - d| := by
   refine abs_sub_le_iff.2 ⟨?_, ?_⟩
   · exact (max_sub_max_le_max _ _ _ _).trans (max_le_max (le_abs_self _) (le_abs_self _))
```
```
✔ [428/428] Built Mathlib.Algebra.Order.Group.MinMax (906ms)
Build completed successfully (428 jobs).
```

### Trace profiling of `abs_max_sub_max_le_max` after PR 32184
```diff
diff --git a/Mathlib/Algebra/Order/Group/MinMax.lean b/Mathlib/Algebra/Order/Group/MinMax.lean
index 0e0d491022..dc55e69d65 100644
--- a/Mathlib/Algebra/Order/Group/MinMax.lean
+++ b/Mathlib/Algebra/Order/Group/MinMax.lean
@@ -71,18 +71,14 @@ variable {α : Type*} [AddCommGroup α] [LinearOrder α] [IsOrderedAddMonoid α]
 theorem max_sub_max_le_max (a b c d : α) : max a b - max c d ≤ max (a - c) (b - d) := by
   grind
 
+set_option trace.profiler true in
 theorem abs_max_sub_max_le_max (a b c d : α) : |max a b - max c d| ≤ max |a - c| |b - d| := by
-  refine abs_sub_le_iff.2 ⟨?_, ?_⟩
-  · exact (max_sub_max_le_max _ _ _ _).trans (max_le_max (le_abs_self _) (le_abs_self _))
-  · rw [abs_sub_comm a c, abs_sub_comm b d]
-    exact (max_sub_max_le_max _ _ _ _).trans (max_le_max (le_abs_self _) (le_abs_self _))
+  grind
 
 theorem abs_min_sub_min_le_max (a b c d : α) : |min a b - min c d| ≤ max |a - c| |b - d| := by
-  simpa only [max_neg_neg, neg_sub_neg, abs_sub_comm] using
-    abs_max_sub_max_le_max (-a) (-b) (-c) (-d)
+  grind
 
 theorem abs_max_sub_max_le_abs (a b c : α) : |max a c - max b c| ≤ |a - b| := by
-  simpa only [sub_self, abs_zero, max_eq_left (abs_nonneg (a - b))]
-    using abs_max_sub_max_le_max a c b c
+  grind
 
 end LinearOrderedAddCommGroup
```
```
ℹ [428/428] Built Mathlib.Algebra.Order.Group.MinMax (1.4s)
info: Mathlib/Algebra/Order/Group/MinMax.lean:75:0: [Elab.async] [0.107014] elaborating proof of abs_max_sub_max_le_max
  [Elab.definition.value] [0.106740] abs_max_sub_max_le_max
    [Elab.step] [0.106623] grind
      [Elab.step] [0.106618] grind
        [Elab.step] [0.106611] grind
info: Mathlib/Algebra/Order/Group/MinMax.lean:76:2: [Elab.async] [0.144062] Lean.addDecl
  [Kernel] [0.144023] ✅️ typechecking declarations [_private.Mathlib.Algebra.Order.Group.MinMax.0.abs_max_sub_max_le_max._proof_1_1]
Build completed successfully (428 jobs).
```
</details>

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

When merging, all the commits will be squashed into a single commit
listing all co-authors.

Co-authors in the squash commit are gathered from two sources:

First, all authors of commits to this PR branch are included. Thus,
one way to add co-authors is to include at least one commit authored by
each co-author among the commits in the pull request. If necessary, you
may create empty commits to indicate co-authorship, using commands like so:

git commit --author="Author Name <author@email.com>" --allow-empty -m "add Author Name as coauthor"

Second, co-authors can also be listed in lines at the very bottom of
the commit message (that is, directly before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines
at the bottom of the commit message (before the `---`, and also before
any "Co-authored-by" lines) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
