### PR TITLE
[Merged by Bors] - feat(Combinatorics/SimpleGraph): Probe that all trees are bipartite

### DIFF
--- a/Mathlib/Combinatorics/SimpleGraph/Acyclic.lean
+++ b/Mathlib/Combinatorics/SimpleGraph/Acyclic.lean
@@ -417,21 +417,20 @@ lemma IsTree.dist_ne_of_adj (hG : G.IsTree) (u : V) {v w : V} (hadj : G.Adj v w)
     rw [hG.IsAcyclic.path_concat hp hq hadj hv, p.length_concat]
     exact p.length.ne_add_one
 
-lemma IsTree.diff_dist_adj (hG : G.IsTree) (u v w : V) (hadj : SimpleGraph.Adj G v w) :
+lemma IsTree.diff_dist_adj (hG : G.IsTree) (u : V) {v w : V} (hadj : SimpleGraph.Adj G v w) :
     G.dist u v = G.dist u w + 1 ∨ G.dist u v + 1 = G.dist u w := by
   grind [dist_ne_of_adj, Connected.diff_dist_adj, IsTree]
 
 /-- The unique two-coloring of a tree that colors the given vertex with zero -/
-noncomputable def IsTree.coloring_two_of_elem (hG : G.IsTree) (u : V) : G.Coloring (Fin 2) :=
+noncomputable def IsTree.coloringTwoOfVert (hG : G.IsTree) (u : V) : G.Coloring (Fin 2) :=
   Coloring.mk (fun v ↦ ⟨G.dist u v % 2, Nat.mod_lt (G.dist u v) Nat.zero_lt_two⟩) <| by
     grind [diff_dist_adj]
 
 /-- Arbitrary coloring with two colors for a tree -/
-noncomputable def IsTree.coloring_two (hG : G.IsTree) : G.Coloring (Fin 2) :=
-  let u : V := Classical.choice hG.isConnected.nonempty
-  hG.coloring_two_of_elem u
+noncomputable def IsTree.coloringTwo (hG : G.IsTree) : G.Coloring (Fin 2) :=
+  hG.coloringTwoOfVert hG.isConnected.nonempty.some
 
 lemma IsTree.isBipartite (hG : G.IsTree) : G.IsBipartite :=
-  .intro hG.coloring_two
+  ⟨hG.coloringTwo⟩
 
 end SimpleGraph

--- a/Mathlib/Combinatorics/SimpleGraph/Acyclic.lean
+++ b/Mathlib/Combinatorics/SimpleGraph/Acyclic.lean
@@ -419,37 +419,12 @@ lemma IsTree.dist_ne_of_adj (hG : G.IsTree) (u : V) {v w : V} (hadj : G.Adj v w)
 
 lemma IsTree.diff_dist_adj (hG : G.IsTree) (u v w : V) (hadj : SimpleGraph.Adj G v w) :
     G.dist u v = G.dist u w + 1 ∨ G.dist u v + 1 = G.dist u w := by
-  have h := hG.isConnected.diff_dist_adj (u := u) hadj
-  have hne := hG.dist_ne_of_adj u hadj
-  rcases h with h₁ | h₂ | h₃
-  · exfalso
-    apply hne
-    rw [h₁]
-  · right
-    exact h₂.symm
-  · left
-    rw [h₃]
-    have : 0 < G.dist u v := hG.isConnected.pos_dist_of_ne (by
-      intro h
-      subst h
-      have h₁ := dist_eq_one_iff_adj.mpr hadj
-      rw [dist_self] at h₃
-      simp only [Nat.zero_sub] at h₃
-      rw [h₃] at h₁
-      exact absurd h₁ Nat.zero_ne_one)
-    exact Eq.symm (Nat.sub_add_cancel this)
+  grind [dist_ne_of_adj, Connected.diff_dist_adj, IsTree]
 
 /-- The unique two-coloring of a tree that colors the given vertex with zero -/
 noncomputable def IsTree.coloring_two_of_elem (hG : G.IsTree) (u : V) : G.Coloring (Fin 2) :=
   Coloring.mk (fun v ↦ ⟨G.dist u v % 2, Nat.mod_lt (G.dist u v) Nat.zero_lt_two⟩) <| by
-  intro v w hadj h
-  simp only [Fin.mk.injEq] at h
-  have := hG.diff_dist_adj u v w hadj
-  obtain hA | hB := hG.diff_dist_adj u v w hadj
-  · rw [hA] at h
-    omega
-  · rw [← hB] at h
-    omega
+    grind [diff_dist_adj]
 
 /-- Arbitrary coloring with two colors for a tree -/
 noncomputable def IsTree.coloring_two (hG : G.IsTree) : G.Coloring (Fin 2) :=
@@ -457,6 +432,6 @@ noncomputable def IsTree.coloring_two (hG : G.IsTree) : G.Coloring (Fin 2) :=
   hG.coloring_two_of_elem u
 
 lemma IsTree.isBipartite (hG : G.IsTree) : G.IsBipartite :=
-  Nonempty.intro hG.coloring_two
+  .intro hG.coloring_two
 
 end SimpleGraph

--- a/Mathlib/Combinatorics/SimpleGraph/Acyclic.lean
+++ b/Mathlib/Combinatorics/SimpleGraph/Acyclic.lean
@@ -450,7 +450,7 @@ noncomputable def IsTree.coloring_two_of_elem (hG : G.IsTree) (u : V) : G.Colori
   · rw [← hB] at h
     omega
 
-/- Arbitrary coloring with two colors for a tree -/
+/-- Arbitrary coloring with two colors for a tree -/
 noncomputable def IsTree.coloring_two (hG : G.IsTree) : G.Coloring (Fin 2) :=
   let u : V := Classical.choice hG.isConnected.nonempty
   hG.coloring_two_of_elem u

--- a/Mathlib/Combinatorics/SimpleGraph/Acyclic.lean
+++ b/Mathlib/Combinatorics/SimpleGraph/Acyclic.lean
@@ -450,6 +450,7 @@ noncomputable def IsTree.coloring_two_of_elem (hG : G.IsTree) (u : V) : G.Colori
   · rw [← hB] at h
     omega
 
+/- Arbitrary coloring with two colors for a tree -/
 noncomputable def IsTree.coloring_two (hG : G.IsTree) : G.Coloring (Fin 2) :=
   let u : V := Classical.choice hG.isConnected.nonempty
   hG.coloring_two_of_elem u

--- a/Mathlib/Combinatorics/SimpleGraph/Acyclic.lean
+++ b/Mathlib/Combinatorics/SimpleGraph/Acyclic.lean
@@ -439,6 +439,7 @@ lemma IsTree.diff_dist_adj (hG : G.IsTree) (u v w : V) (hadj : SimpleGraph.Adj G
       exact absurd h₁ Nat.zero_ne_one)
     exact Eq.symm (Nat.sub_add_cancel this)
 
+/-- The unique two-coloring of a tree that colors the given vertex with zero -/
 noncomputable def IsTree.coloring_two_of_elem (hG : G.IsTree) (u : V) : G.Coloring (Fin 2) :=
   Coloring.mk (fun v ↦ ⟨G.dist u v % 2, Nat.mod_lt (G.dist u v) Nat.zero_lt_two⟩) <| by
   intro v w hadj h

--- a/Mathlib/Combinatorics/SimpleGraph/Acyclic.lean
+++ b/Mathlib/Combinatorics/SimpleGraph/Acyclic.lean
@@ -5,7 +5,7 @@ Authors: Kyle Miller
 -/
 module
 
-public import Mathlib.Combinatorics.SimpleGraph.Coloring
+public import Mathlib.Combinatorics.SimpleGraph.Bipartite
 public import Mathlib.Combinatorics.SimpleGraph.Connectivity.Connected
 public import Mathlib.Combinatorics.SimpleGraph.DegreeSum
 public import Mathlib.Combinatorics.SimpleGraph.Metric
@@ -456,7 +456,7 @@ noncomputable def IsTree.coloring_two (hG : G.IsTree) : G.Coloring (Fin 2) :=
   let u : V := Classical.choice hG.isConnected.nonempty
   hG.coloring_two_of_elem u
 
-lemma IsTree.colorable_two (hG : G.IsTree) : G.Colorable 2 :=
+lemma IsTree.isBipartite (hG : G.IsTree) : G.IsBipartite :=
   Nonempty.intro hG.coloring_two
 
 end SimpleGraph


### PR DESCRIPTION
This contribution was created as part of the Utrecht Summerschool "Formalizing Mathematics in Lean" in July 2025.

Co-authored-by: M Hidalgo <guelmispaick@gmail.com>
---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

When merging, all the commits will be squashed into a single commit
listing all co-authors.

Co-authors in the squash commit are gathered from two sources:

First, all authors of commits to this PR branch are included. Thus,
one way to add co-authors is to include at least one commit authored by
each co-author among the commits in the pull request. If necessary, you
may create empty commits to indicate co-authorship, using commands like so:

git commit --author="Author Name <author@email.com>" --allow-empty -m "add Author Name as coauthor"

Second, co-authors can also be listed in lines at the very bottom of
the commit message (that is, directly before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines
at the bottom of the commit message (before the `---`, and also before
any "Co-authored-by" lines) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
