### PR TITLE
[Merged by Bors] - chore: replace some `@[measurability]` attributes by `@[fun_prop]`

### DIFF
--- a/Mathlib/Analysis/Calculus/FDeriv/Measurable.lean
+++ b/Mathlib/Analysis/Calculus/FDeriv/Measurable.lean
@@ -376,7 +376,7 @@ theorem measurableSet_of_differentiableAt : MeasurableSet { x | DifferentiableAt
   convert measurableSet_of_differentiableAt_of_isComplete 𝕜 f this
   simp
 
-@[measurability, fun_prop]
+@[fun_prop]
 theorem measurable_fderiv : Measurable (fderiv 𝕜 f) := by
   refine measurable_of_isClosed fun s hs => ?_
   have :
@@ -389,14 +389,14 @@ theorem measurable_fderiv : Measurable (fderiv 𝕜 f) := by
     (measurableSet_of_differentiableAt_of_isComplete _ _ hs.isComplete).union
       ((measurableSet_of_differentiableAt _ _).compl.inter (MeasurableSet.const _))
 
-@[measurability, fun_prop]
+@[fun_prop]
 theorem measurable_fderiv_apply_const [MeasurableSpace F] [BorelSpace F] (y : E) :
     Measurable fun x => fderiv 𝕜 f x y :=
   (ContinuousLinearMap.measurable_apply y).comp (measurable_fderiv 𝕜 f)
 
 variable {𝕜}
 
-@[measurability, fun_prop]
+@[fun_prop]
 theorem measurable_deriv [MeasurableSpace 𝕜] [OpensMeasurableSpace 𝕜] [MeasurableSpace F]
     [BorelSpace F] (f : 𝕜 → F) : Measurable (deriv f) := by
   simpa only [fderiv_deriv] using measurable_fderiv_apply_const 𝕜 f 1
@@ -704,7 +704,7 @@ theorem measurableSet_of_differentiableWithinAt_Ici :
   convert measurableSet_of_differentiableWithinAt_Ici_of_isComplete f this
   simp
 
-@[measurability, fun_prop]
+@[fun_prop]
 theorem measurable_derivWithin_Ici [MeasurableSpace F] [BorelSpace F] :
     Measurable fun x => derivWithin f (Ici x) x := by
   refine measurable_of_isClosed fun s hs => ?_
@@ -752,7 +752,7 @@ theorem measurableSet_of_differentiableWithinAt_Ioi :
     MeasurableSet { x | DifferentiableWithinAt ℝ f (Ioi x) x } := by
   simpa [differentiableWithinAt_Ioi_iff_Ici] using measurableSet_of_differentiableWithinAt_Ici f
 
-@[measurability, fun_prop]
+@[fun_prop]
 theorem measurable_derivWithin_Ioi [MeasurableSpace F] [BorelSpace F] :
     Measurable fun x => derivWithin f (Ioi x) x := by
   simpa [derivWithin_Ioi_eq_Ici] using measurable_derivWithin_Ici f

--- a/Mathlib/Analysis/LConvolution.lean
+++ b/Mathlib/Analysis/LConvolution.lean
@@ -85,7 +85,7 @@ section Measurable
 variable [MeasurableMul₂ G] [MeasurableInv G]
 
 /-- The convolution of measurable functions is measurable. -/
-@[to_additive (attr := measurability, fun_prop)
+@[to_additive (attr := fun_prop)
 /-- The convolution of measurable functions is measurable. -/]
 theorem measurable_mlconvolution {f g : G → ℝ≥0∞} (μ : Measure G) [SFinite μ]
     (hf : Measurable f) (hg : Measurable g) : Measurable (f ⋆ₘₗ[μ] g) := by
@@ -103,7 +103,7 @@ variable [Group G] [MeasurableMul₂ G] [MeasurableInv G]
 variable {μ : Measure G} [IsMulLeftInvariant μ] [SFinite μ]
 
 /-- The convolution of `AEMeasurable` functions is `AEMeasurable`. -/
-@[to_additive (attr := measurability, fun_prop)
+@[to_additive (attr := fun_prop)
 /-- The convolution of `AEMeasurable` functions is `AEMeasurable`. -/]
 theorem aemeasurable_mlconvolution {f g : G → ℝ≥0∞}
     (hf : AEMeasurable f μ) (hg : AEMeasurable g μ) :

--- a/Mathlib/Analysis/Normed/Lp/MeasurableSpace.lean
+++ b/Mathlib/Analysis/Normed/Lp/MeasurableSpace.lean
@@ -26,10 +26,10 @@ namespace WithLp
 instance measurableSpace : MeasurableSpace (WithLp p X) :=
   MeasurableSpace.comap ofLp inferInstance
 
-@[fun_prop, measurability]
+@[fun_prop]
 lemma measurable_ofLp : Measurable (@ofLp p X) := comap_measurable _
 
-@[fun_prop, measurability]
+@[fun_prop]
 lemma measurable_toLp : Measurable (@toLp p X) := fun s hs ↦ by
   obtain ⟨t, ht, rfl⟩ := hs
   simpa [Set.preimage_preimage]

--- a/Mathlib/Analysis/SpecialFunctions/Log/ENNRealLogExp.lean
+++ b/Mathlib/Analysis/SpecialFunctions/Log/ENNRealLogExp.lean
@@ -163,18 +163,18 @@ end Continuity
 
 section Measurability
 
-@[measurability, fun_prop]
+@[fun_prop]
 lemma measurable_log : Measurable log := continuous_log.measurable
 
-@[measurability, fun_prop]
+@[fun_prop]
 lemma _root_.EReal.measurable_exp : Measurable exp := continuous_exp.measurable
 
-@[measurability, fun_prop]
+@[fun_prop]
 lemma _root_.Measurable.ennreal_log {α : Type*} {_ : MeasurableSpace α}
     {f : α → ℝ≥0∞} (hf : Measurable f) :
     Measurable fun x ↦ log (f x) := measurable_log.comp hf
 
-@[measurability, fun_prop]
+@[fun_prop]
 lemma _root_.Measurable.ereal_exp {α : Type*} {_ : MeasurableSpace α}
     {f : α → EReal} (hf : Measurable f) :
     Measurable fun x ↦ exp (f x) := measurable_exp.comp hf

--- a/Mathlib/InformationTheory/KullbackLeibler/KLFun.lean
+++ b/Mathlib/InformationTheory/KullbackLeibler/KLFun.lean
@@ -76,11 +76,11 @@ lemma convexOn_Ioi_klFun : ConvexOn ℝ (Ioi 0) klFun :=
 lemma continuous_klFun : Continuous klFun := by unfold klFun; fun_prop
 
 /-- `klFun` is measurable. -/
-@[measurability, fun_prop]
+@[fun_prop]
 lemma measurable_klFun : Measurable klFun := continuous_klFun.measurable
 
 /-- `klFun` is strongly measurable. -/
-@[measurability]
+@[fun_prop]
 lemma stronglyMeasurable_klFun : StronglyMeasurable klFun := measurable_klFun.stronglyMeasurable
 
 section Derivatives

--- a/Mathlib/MeasureTheory/Constructions/BorelSpace/Basic.lean
+++ b/Mathlib/MeasureTheory/Constructions/BorelSpace/Basic.lean
@@ -545,7 +545,7 @@ instance (priority := 100) ContinuousSMul.toMeasurableSMul {M α} [TopologicalSp
 
 section Homeomorph
 
-@[measurability]
+@[fun_prop]
 protected theorem Homeomorph.measurable (h : α ≃ₜ γ) : Measurable h :=
   h.continuous.measurable
 
@@ -569,7 +569,7 @@ theorem Homeomorph.toMeasurableEquiv_symm_coe (h : γ ≃ₜ γ₂) :
 
 end Homeomorph
 
-@[measurability]
+@[fun_prop]
 theorem ContinuousMap.measurable (f : C(α, γ)) : Measurable f :=
   f.continuous.measurable
 

--- a/Mathlib/MeasureTheory/Constructions/BorelSpace/ContinuousLinearMap.lean
+++ b/Mathlib/MeasureTheory/Constructions/BorelSpace/ContinuousLinearMap.lean
@@ -27,7 +27,7 @@ variable {R E F : Type*} [Semiring R]
   [SeminormedAddCommGroup E] [Module R E] [MeasurableSpace E] [OpensMeasurableSpace E]
   [SeminormedAddCommGroup F] [Module R F] [MeasurableSpace F] [BorelSpace F]
 
-@[fun_prop, measurability]
+@[fun_prop]
 protected theorem measurable (L : E →L[R] F) : Measurable L :=
   L.continuous.measurable
 
@@ -50,7 +50,7 @@ instance instMeasurableSpace : MeasurableSpace (E →L[𝕜] F) :=
 instance instBorelSpace : BorelSpace (E →L[𝕜] F) :=
   ⟨rfl⟩
 
-@[fun_prop, measurability]
+@[fun_prop]
 theorem measurable_apply [MeasurableSpace F] [BorelSpace F] (x : E) :
     Measurable fun f : E →L[𝕜] F => f x :=
   (apply 𝕜 F x).continuous.measurable
@@ -71,12 +71,12 @@ variable {𝕜 : Type*} [NontriviallyNormedField 𝕜]
 variable {E : Type*} [NormedAddCommGroup E] [NormedSpace 𝕜 E] [MeasurableSpace E] [BorelSpace E]
   {F : Type*} [NormedAddCommGroup F] [NormedSpace 𝕜 F]
 
-@[fun_prop, measurability]
+@[fun_prop]
 theorem Measurable.apply_continuousLinearMap {φ : α → F →L[𝕜] E} (hφ : Measurable φ) (v : F) :
     Measurable fun a => φ a v :=
   (ContinuousLinearMap.apply 𝕜 E v).measurable.comp hφ
 
-@[measurability]
+@[fun_prop]
 theorem AEMeasurable.apply_continuousLinearMap {φ : α → F →L[𝕜] E} {μ : Measure α}
     (hφ : AEMeasurable φ μ) (v : F) : AEMeasurable (fun a => φ a v) μ :=
   (ContinuousLinearMap.apply 𝕜 E v).measurable.comp_aemeasurable hφ

--- a/Mathlib/MeasureTheory/Constructions/BorelSpace/Metric.lean
+++ b/Mathlib/MeasureTheory/Constructions/BorelSpace/Metric.lean
@@ -53,7 +53,7 @@ theorem measurableSet_closedBall : MeasurableSet (Metric.closedBall x ε) :=
 theorem measurable_infDist {s : Set α} : Measurable fun x => infDist x s :=
   (continuous_infDist_pt s).measurable
 
-@[measurability, fun_prop]
+@[fun_prop]
 theorem Measurable.infDist {f : β → α} (hf : Measurable f) {s : Set α} :
     Measurable fun x => infDist (f x) s :=
   measurable_infDist.comp hf
@@ -61,7 +61,7 @@ theorem Measurable.infDist {f : β → α} (hf : Measurable f) {s : Set α} :
 theorem measurable_infNndist {s : Set α} : Measurable fun x => infNndist x s :=
   (continuous_infNndist_pt s).measurable
 
-@[measurability, fun_prop]
+@[fun_prop]
 theorem Measurable.infNndist {f : β → α} (hf : Measurable f) {s : Set α} :
     Measurable fun x => infNndist (f x) s :=
   measurable_infNndist.comp hf
@@ -73,12 +73,12 @@ variable [SecondCountableTopology α]
 theorem measurable_dist : Measurable fun p : α × α => dist p.1 p.2 :=
   continuous_dist.measurable
 
-@[measurability, fun_prop]
+@[fun_prop]
 theorem Measurable.dist {f g : β → α} (hf : Measurable f) (hg : Measurable g) :
     Measurable fun b => dist (f b) (g b) :=
   continuous_dist.measurable2 hf hg
 
-@[fun_prop, measurability]
+@[fun_prop]
 lemma AEMeasurable.dist {f g : β → α} {μ : Measure β}
     (hf : AEMeasurable f μ) (hg : AEMeasurable g μ) :
     AEMeasurable (fun b ↦ dist (f b) (g b)) μ :=
@@ -87,7 +87,7 @@ lemma AEMeasurable.dist {f g : β → α} {μ : Measure β}
 theorem measurable_nndist : Measurable fun p : α × α => nndist p.1 p.2 :=
   continuous_nndist.measurable
 
-@[measurability, fun_prop]
+@[fun_prop]
 theorem Measurable.nndist {f g : β → α} (hf : Measurable f) (hg : Measurable g) :
     Measurable fun b => nndist (f b) (g b) :=
   continuous_nndist.measurable2 hf hg
@@ -107,18 +107,18 @@ open EMetric
 theorem measurableSet_eball : MeasurableSet (EMetric.ball x ε) :=
   EMetric.isOpen_ball.measurableSet
 
-@[measurability, fun_prop]
+@[fun_prop]
 theorem measurable_edist_right : Measurable (edist x) :=
   (continuous_const.edist continuous_id).measurable
 
-@[measurability, fun_prop]
+@[fun_prop]
 theorem measurable_edist_left : Measurable fun y => edist y x :=
   (continuous_id.edist continuous_const).measurable
 
 theorem measurable_infEdist {s : Set α} : Measurable fun x => infEdist x s :=
   continuous_infEdist.measurable
 
-@[measurability, fun_prop]
+@[fun_prop]
 theorem Measurable.infEdist {f : β → α} (hf : Measurable f) {s : Set α} :
     Measurable fun x => infEdist (f x) s :=
   measurable_infEdist.comp hf
@@ -172,12 +172,12 @@ variable [SecondCountableTopology α]
 theorem measurable_edist : Measurable fun p : α × α => edist p.1 p.2 :=
   continuous_edist.measurable
 
-@[measurability, fun_prop]
+@[fun_prop]
 theorem Measurable.edist {f g : β → α} (hf : Measurable f) (hg : Measurable g) :
     Measurable fun b => edist (f b) (g b) :=
   continuous_edist.measurable2 hf hg
 
-@[measurability, fun_prop]
+@[fun_prop]
 theorem AEMeasurable.edist {f g : β → α} {μ : Measure β} (hf : AEMeasurable f μ)
     (hg : AEMeasurable g μ) : AEMeasurable (fun a => edist (f a) (g a)) μ :=
   continuous_edist.aemeasurable2 hf hg
@@ -220,14 +220,14 @@ section ContinuousENorm
 variable {ε : Type*} [MeasurableSpace ε] [TopologicalSpace ε] [ContinuousENorm ε]
   [OpensMeasurableSpace ε] [MeasurableSpace β]
 
-@[measurability, fun_prop]
+@[fun_prop]
 lemma measurable_enorm : Measurable (enorm : ε → ℝ≥0∞) := continuous_enorm.measurable
 
-@[measurability, fun_prop]
+@[fun_prop]
 protected lemma Measurable.enorm {f : β → ε} (hf : Measurable f) : Measurable (‖f ·‖ₑ) :=
   measurable_enorm.comp hf
 
-@[measurability, fun_prop]
+@[fun_prop]
 protected lemma AEMeasurable.enorm {f : β → ε} {μ : Measure β} (hf : AEMeasurable f μ) :
     AEMeasurable (‖f ·‖ₑ) μ :=
   measurable_enorm.comp_aemeasurable hf
@@ -238,15 +238,15 @@ section NormedAddCommGroup
 
 variable [MeasurableSpace α] [NormedAddCommGroup α] [OpensMeasurableSpace α] [MeasurableSpace β]
 
-@[fun_prop, measurability]
+@[fun_prop]
 theorem measurable_norm : Measurable (norm : α → ℝ) :=
   continuous_norm.measurable
 
-@[measurability, fun_prop]
+@[fun_prop]
 theorem Measurable.norm {f : β → α} (hf : Measurable f) : Measurable fun a => norm (f a) :=
   measurable_norm.comp hf
 
-@[measurability, fun_prop]
+@[fun_prop]
 theorem AEMeasurable.norm {f : β → α} {μ : Measure β} (hf : AEMeasurable f μ) :
     AEMeasurable (fun a => norm (f a)) μ :=
   measurable_norm.comp_aemeasurable hf
@@ -254,11 +254,11 @@ theorem AEMeasurable.norm {f : β → α} {μ : Measure β} (hf : AEMeasurable f
 theorem measurable_nnnorm : Measurable (nnnorm : α → ℝ≥0) :=
   continuous_nnnorm.measurable
 
-@[measurability, fun_prop]
+@[fun_prop]
 protected theorem Measurable.nnnorm {f : β → α} (hf : Measurable f) : Measurable fun a => ‖f a‖₊ :=
   measurable_nnnorm.comp hf
 
-@[measurability, fun_prop]
+@[fun_prop]
 protected lemma AEMeasurable.nnnorm {f : β → α} {μ : Measure β} (hf : AEMeasurable f μ) :
     AEMeasurable (fun a => ‖f a‖₊) μ :=
   measurable_nnnorm.comp_aemeasurable hf

--- a/Mathlib/MeasureTheory/Constructions/BorelSpace/Order.lean
+++ b/Mathlib/MeasureTheory/Constructions/BorelSpace/Order.lean
@@ -450,23 +450,23 @@ theorem measurableSet_uIoc : MeasurableSet (uIoc a b) :=
 
 variable [SecondCountableTopology α]
 
-@[measurability, fun_prop]
+@[fun_prop]
 theorem Measurable.max {f g : δ → α} (hf : Measurable f) (hg : Measurable g) :
     Measurable fun a => max (f a) (g a) := by
   simpa only [max_def'] using hf.piecewise (measurableSet_le hg hf) hg
 
-@[measurability, fun_prop]
+@[fun_prop]
 nonrec theorem AEMeasurable.max {f g : δ → α} {μ : Measure δ} (hf : AEMeasurable f μ)
     (hg : AEMeasurable g μ) : AEMeasurable (fun a => max (f a) (g a)) μ :=
   ⟨fun a => max (hf.mk f a) (hg.mk g a), hf.measurable_mk.max hg.measurable_mk,
     EventuallyEq.comp₂ hf.ae_eq_mk _ hg.ae_eq_mk⟩
 
-@[measurability, fun_prop]
+@[fun_prop]
 theorem Measurable.min {f g : δ → α} (hf : Measurable f) (hg : Measurable g) :
     Measurable fun a => min (f a) (g a) := by
   simpa only [min_def] using hf.piecewise (measurableSet_le hf hg) hg
 
-@[measurability, fun_prop]
+@[fun_prop]
 nonrec theorem AEMeasurable.min {f g : δ → α} {μ : Measure δ} (hf : AEMeasurable f μ)
     (hg : AEMeasurable g μ) : AEMeasurable (fun a => min (f a) (g a)) μ :=
   ⟨fun a => min (hf.mk f a) (hg.mk g a), hf.measurable_mk.min hg.measurable_mk,
@@ -722,7 +722,7 @@ end LinearOrder
 
 section ConditionallyCompleteLattice
 
-@[measurability, fun_prop]
+@[fun_prop]
 theorem Measurable.iSup_Prop {α} {mα : MeasurableSpace α} [ConditionallyCompleteLattice α]
     (p : Prop) {f : δ → α} (hf : Measurable f) : Measurable fun b => ⨆ _ : p, f b := by
   classical
@@ -731,7 +731,7 @@ theorem Measurable.iSup_Prop {α} {mα : MeasurableSpace α} [ConditionallyCompl
   · exact hf
   · exact measurable_const
 
-@[measurability, fun_prop]
+@[fun_prop]
 theorem Measurable.iInf_Prop {α} {mα : MeasurableSpace α} [ConditionallyCompleteLattice α]
     (p : Prop) {f : δ → α} (hf : Measurable f) : Measurable fun b => ⨅ _ : p, f b := by
   classical
@@ -746,7 +746,7 @@ section ConditionallyCompleteLinearOrder
 
 variable [ConditionallyCompleteLinearOrder α] [OrderTopology α] [SecondCountableTopology α]
 
-@[measurability, fun_prop]
+@[fun_prop]
 protected theorem Measurable.iSup {ι} [Countable ι] {f : ι → δ → α} (hf : ∀ i, Measurable (f i)) :
     Measurable (fun b ↦ ⨆ i, f i b) := by
   rcases isEmpty_or_nonempty ι with hι|hι
@@ -771,18 +771,18 @@ protected theorem Measurable.iSup {ι} [Countable ι] {f : ι → δ → α} (hf
 --   simp_rw [iSup_apply]
 --   exact .iSup fun i ↦ by fun_prop
 
-@[measurability, fun_prop]
+@[fun_prop]
 protected theorem AEMeasurable.iSup {ι} {μ : Measure δ} [Countable ι] {f : ι → δ → α}
     (hf : ∀ i, AEMeasurable (f i) μ) : AEMeasurable (fun b => ⨆ i, f i b) μ := by
   refine ⟨fun b ↦ ⨆ i, (hf i).mk (f i) b, .iSup (fun i ↦ (hf i).measurable_mk), ?_⟩
   filter_upwards [ae_all_iff.2 (fun i ↦ (hf i).ae_eq_mk)] with b hb using by simp [hb]
 
-@[measurability, fun_prop]
+@[fun_prop]
 protected theorem Measurable.iInf {ι} [Countable ι] {f : ι → δ → α} (hf : ∀ i, Measurable (f i)) :
     Measurable fun b => ⨅ i, f i b :=
   .iSup (α := αᵒᵈ) hf
 
-@[measurability, fun_prop]
+@[fun_prop]
 protected theorem AEMeasurable.iInf {ι} {μ : Measure δ} [Countable ι] {f : ι → δ → α}
     (hf : ∀ i, AEMeasurable (f i) μ) : AEMeasurable (fun b => ⨅ i, f i b) μ :=
   .iSup (α := αᵒᵈ) hf
@@ -895,14 +895,14 @@ theorem Measurable.limsup' {ι ι'} {f : ι → δ → α} {u : Filter ι} (hf :
 
 /-- `liminf` over `ℕ` is measurable. See `Measurable.liminf'` for a version with a general filter.
 -/
-@[measurability, fun_prop]
+@[fun_prop]
 theorem Measurable.liminf {f : ℕ → δ → α} (hf : ∀ i, Measurable (f i)) :
     Measurable fun x => liminf (fun i => f i x) atTop :=
   .liminf' hf atTop_countable_basis fun _ => to_countable _
 
 /-- `limsup` over `ℕ` is measurable. See `Measurable.limsup'` for a version with a general filter.
 -/
-@[measurability, fun_prop]
+@[fun_prop]
 theorem Measurable.limsup {f : ℕ → δ → α} (hf : ∀ i, Measurable (f i)) :
     Measurable fun x => limsup (fun i => f i x) atTop :=
   .limsup' hf atTop_countable_basis fun _ => to_countable _

--- a/Mathlib/MeasureTheory/Constructions/BorelSpace/Real.lean
+++ b/Mathlib/MeasureTheory/Constructions/BorelSpace/Real.lean
@@ -139,16 +139,16 @@ end Real
 
 variable {mα : MeasurableSpace α}
 
-@[measurability, fun_prop]
+@[fun_prop]
 theorem measurable_real_toNNReal : Measurable Real.toNNReal :=
   continuous_real_toNNReal.measurable
 
-@[measurability, fun_prop]
+@[fun_prop]
 theorem Measurable.real_toNNReal {f : α → ℝ} (hf : Measurable f) :
     Measurable fun x => Real.toNNReal (f x) :=
   measurable_real_toNNReal.comp hf
 
-@[measurability, fun_prop]
+@[fun_prop]
 theorem AEMeasurable.real_toNNReal {f : α → ℝ} {μ : Measure α} (hf : AEMeasurable f μ) :
     AEMeasurable (fun x => Real.toNNReal (f x)) μ :=
   measurable_real_toNNReal.comp_aemeasurable hf
@@ -156,12 +156,12 @@ theorem AEMeasurable.real_toNNReal {f : α → ℝ} {μ : Measure α} (hf : AEMe
 theorem measurable_coe_nnreal_real : Measurable ((↑) : ℝ≥0 → ℝ) :=
   NNReal.continuous_coe.measurable
 
-@[measurability, fun_prop]
+@[fun_prop]
 theorem Measurable.coe_nnreal_real {f : α → ℝ≥0} (hf : Measurable f) :
     Measurable fun x => (f x : ℝ) :=
   measurable_coe_nnreal_real.comp hf
 
-@[measurability, fun_prop]
+@[fun_prop]
 theorem AEMeasurable.coe_nnreal_real {f : α → ℝ≥0} {μ : Measure α} (hf : AEMeasurable f μ) :
     AEMeasurable (fun x => (f x : ℝ)) μ :=
   measurable_coe_nnreal_real.comp_aemeasurable hf
@@ -169,22 +169,22 @@ theorem AEMeasurable.coe_nnreal_real {f : α → ℝ≥0} {μ : Measure α} (hf 
 theorem measurable_coe_nnreal_ennreal : Measurable ((↑) : ℝ≥0 → ℝ≥0∞) :=
   ENNReal.continuous_coe.measurable
 
-@[measurability, fun_prop]
+@[fun_prop]
 theorem Measurable.coe_nnreal_ennreal {f : α → ℝ≥0} (hf : Measurable f) :
     Measurable fun x => (f x : ℝ≥0∞) :=
   ENNReal.continuous_coe.measurable.comp hf
 
-@[measurability, fun_prop]
+@[fun_prop]
 theorem AEMeasurable.coe_nnreal_ennreal {f : α → ℝ≥0} {μ : Measure α} (hf : AEMeasurable f μ) :
     AEMeasurable (fun x => (f x : ℝ≥0∞)) μ :=
   ENNReal.continuous_coe.measurable.comp_aemeasurable hf
 
-@[measurability, fun_prop]
+@[fun_prop]
 theorem Measurable.ennreal_ofReal {f : α → ℝ} (hf : Measurable f) :
     Measurable fun x => ENNReal.ofReal (f x) :=
   ENNReal.continuous_ofReal.measurable.comp hf
 
-@[measurability, fun_prop]
+@[fun_prop]
 lemma AEMeasurable.ennreal_ofReal {f : α → ℝ} {μ : Measure α} (hf : AEMeasurable f μ) :
     AEMeasurable (fun x ↦ ENNReal.ofReal (f x)) μ :=
   ENNReal.continuous_ofReal.measurable.comp_aemeasurable hf
@@ -318,12 +318,12 @@ lemma aemeasurable_of_tendsto {f : ℕ → α → ℝ≥0∞} {g : α → ℝ≥
 
 end ENNReal
 
-@[measurability, fun_prop]
+@[fun_prop]
 theorem Measurable.ennreal_toNNReal {f : α → ℝ≥0∞} (hf : Measurable f) :
     Measurable fun x => (f x).toNNReal :=
   ENNReal.measurable_toNNReal.comp hf
 
-@[measurability, fun_prop]
+@[fun_prop]
 theorem AEMeasurable.ennreal_toNNReal {f : α → ℝ≥0∞} {μ : Measure α} (hf : AEMeasurable f μ) :
     AEMeasurable (fun x => (f x).toNNReal) μ :=
   ENNReal.measurable_toNNReal.comp_aemeasurable hf
@@ -338,49 +338,49 @@ theorem aemeasurable_coe_nnreal_ennreal_iff {f : α → ℝ≥0} {μ : Measure �
     AEMeasurable (fun x => (f x : ℝ≥0∞)) μ ↔ AEMeasurable f μ :=
   ⟨fun h => h.ennreal_toNNReal, fun h => h.coe_nnreal_ennreal⟩
 
-@[measurability, fun_prop]
+@[fun_prop]
 theorem Measurable.ennreal_toReal {f : α → ℝ≥0∞} (hf : Measurable f) :
     Measurable fun x => ENNReal.toReal (f x) :=
   ENNReal.measurable_toReal.comp hf
 
-@[measurability, fun_prop]
+@[fun_prop]
 theorem AEMeasurable.ennreal_toReal {f : α → ℝ≥0∞} {μ : Measure α} (hf : AEMeasurable f μ) :
     AEMeasurable (fun x => ENNReal.toReal (f x)) μ :=
   ENNReal.measurable_toReal.comp_aemeasurable hf
 
 /-- note: `ℝ≥0∞` can probably be generalized in a future version of this lemma. -/
-@[measurability, fun_prop]
+@[fun_prop]
 theorem Measurable.ennreal_tsum {ι} [Countable ι] {f : ι → α → ℝ≥0∞} (h : ∀ i, Measurable (f i)) :
     Measurable fun x => ∑' i, f i x := by
   simp_rw [ENNReal.tsum_eq_iSup_sum]
   exact .iSup fun s ↦ s.measurable_fun_sum fun i _ => h i
 
-@[measurability, fun_prop]
+@[fun_prop]
 theorem Measurable.ennreal_tsum' {ι} [Countable ι] {f : ι → α → ℝ≥0∞} (h : ∀ i, Measurable (f i)) :
     Measurable (∑' i, f i) := by
   convert Measurable.ennreal_tsum h with x
   exact tsum_apply (Pi.summable.2 fun _ => ENNReal.summable)
 
-@[measurability, fun_prop]
+@[fun_prop]
 theorem Measurable.nnreal_tsum {ι} [Countable ι] {f : ι → α → ℝ≥0} (h : ∀ i, Measurable (f i)) :
     Measurable fun x => ∑' i, f i x := by
   simp_rw [NNReal.tsum_eq_toNNReal_tsum]
   exact (Measurable.ennreal_tsum fun i => (h i).coe_nnreal_ennreal).ennreal_toNNReal
 
-@[measurability, fun_prop]
+@[fun_prop]
 theorem AEMeasurable.ennreal_tsum {ι} [Countable ι] {f : ι → α → ℝ≥0∞} {μ : Measure α}
     (h : ∀ i, AEMeasurable (f i) μ) : AEMeasurable (fun x => ∑' i, f i x) μ := by
   simp_rw [ENNReal.tsum_eq_iSup_sum]
   exact .iSup fun s ↦ Finset.aemeasurable_fun_sum s fun i _ => h i
 
-@[measurability, fun_prop]
+@[fun_prop]
 theorem AEMeasurable.nnreal_tsum {α : Type*} {_ : MeasurableSpace α} {ι : Type*} [Countable ι]
     {f : ι → α → NNReal} {μ : Measure α} (h : ∀ i : ι, AEMeasurable (f i) μ) :
     AEMeasurable (fun x : α => ∑' i : ι, f i x) μ := by
   simp_rw [NNReal.tsum_eq_toNNReal_tsum]
   exact (AEMeasurable.ennreal_tsum fun i => (h i).coe_nnreal_ennreal).ennreal_toNNReal
 
-@[measurability, fun_prop]
+@[fun_prop]
 theorem measurable_coe_real_ereal : Measurable ((↑) : ℝ → EReal) :=
   continuous_coe_real_ereal.measurable
 
@@ -388,7 +388,7 @@ theorem Measurable.coe_real_ereal {f : α → ℝ} (hf : Measurable f) :
     Measurable fun x => (f x : EReal) :=
   measurable_coe_real_ereal.comp hf
 
-@[measurability]
+@[fun_prop]
 theorem AEMeasurable.coe_real_ereal {f : α → ℝ} {μ : Measure α} (hf : AEMeasurable f μ) :
     AEMeasurable (fun x => (f x : EReal)) μ :=
   measurable_coe_real_ereal.comp_aemeasurable hf
@@ -405,12 +405,12 @@ theorem EReal.measurable_of_measurable_real {f : EReal → α} (h : Measurable f
 theorem measurable_ereal_toReal : Measurable EReal.toReal :=
   EReal.measurable_of_measurable_real (by simpa using measurable_id)
 
-@[measurability, fun_prop]
+@[fun_prop]
 theorem Measurable.ereal_toReal {f : α → EReal} (hf : Measurable f) :
     Measurable fun x => (f x).toReal :=
   measurable_ereal_toReal.comp hf
 
-@[measurability, fun_prop]
+@[fun_prop]
 theorem AEMeasurable.ereal_toReal {f : α → EReal} {μ : Measure α} (hf : AEMeasurable f μ) :
     AEMeasurable (fun x => (f x).toReal) μ :=
   measurable_ereal_toReal.comp_aemeasurable hf
@@ -418,12 +418,12 @@ theorem AEMeasurable.ereal_toReal {f : α → EReal} {μ : Measure α} (hf : AEM
 theorem measurable_coe_ennreal_ereal : Measurable ((↑) : ℝ≥0∞ → EReal) :=
   continuous_coe_ennreal_ereal.measurable
 
-@[measurability, fun_prop]
+@[fun_prop]
 theorem Measurable.coe_ereal_ennreal {f : α → ℝ≥0∞} (hf : Measurable f) :
     Measurable fun x => (f x : EReal) :=
   measurable_coe_ennreal_ereal.comp hf
 
-@[measurability, fun_prop]
+@[fun_prop]
 theorem AEMeasurable.coe_ereal_ennreal {f : α → ℝ≥0∞} {μ : Measure α} (hf : AEMeasurable f μ) :
     AEMeasurable (fun x => (f x : EReal)) μ :=
   measurable_coe_ennreal_ereal.comp_aemeasurable hf
@@ -431,12 +431,12 @@ theorem AEMeasurable.coe_ereal_ennreal {f : α → ℝ≥0∞} {μ : Measure α}
 theorem measurable_ereal_toENNReal : Measurable EReal.toENNReal :=
   EReal.measurable_of_measurable_real (by simpa using ENNReal.measurable_ofReal)
 
-@[measurability, fun_prop]
+@[fun_prop]
 theorem Measurable.ereal_toENNReal {f : α → EReal} (hf : Measurable f) :
     Measurable fun x => (f x).toENNReal :=
   measurable_ereal_toENNReal.comp hf
 
-@[measurability, fun_prop]
+@[fun_prop]
 theorem AEMeasurable.ereal_toENNReal {f : α → EReal} {μ : Measure α} (hf : AEMeasurable f μ) :
     AEMeasurable (fun x => (f x).toENNReal) μ :=
   measurable_ereal_toENNReal.comp_aemeasurable hf

--- a/Mathlib/MeasureTheory/Constructions/Cylinders.lean
+++ b/Mathlib/MeasureTheory/Constructions/Cylinders.lean
@@ -440,7 +440,7 @@ lemma measurable_uniqueElim_cylinderEvents [Unique ι] :
 /-- The function `update f a : X a → Π a, X a` is always measurable.
 This doesn't require `f` to be measurable.
 This should not be confused with the statement that `update f a x` is measurable. -/
-@[measurability]
+@[fun_prop]
 lemma measurable_update_cylinderEvents (f : ∀ a : ι, X a) {a : ι} [DecidableEq ι] :
     @Measurable _ _ _ (cylinderEvents Δ) (update f a) :=
   measurable_update_cylinderEvents'.comp measurable_prodMk_left

--- a/Mathlib/MeasureTheory/Constructions/UnitInterval.lean
+++ b/Mathlib/MeasureTheory/Constructions/UnitInterval.lean
@@ -46,7 +46,7 @@ lemma measurePreserving_coe : MeasurePreserving ((↑) : I → ℝ) volume (volu
 instance : NoAtoms (volume : Measure I) where
   measure_singleton x := by simp [volume_apply]
 
-@[fun_prop, measurability]
+@[fun_prop]
 theorem measurable_symm : Measurable σ := continuous_symm.measurable
 
 /-- `unitInterval.symm` bundled as a measurable equivalence. -/

--- a/Mathlib/MeasureTheory/Function/Floor.lean
+++ b/Mathlib/MeasureTheory/Function/Floor.lean
@@ -28,7 +28,7 @@ theorem Int.measurable_floor [OpensMeasurableSpace R] : Measurable (Int.floor : 
   measurable_to_countable fun x => by
     simpa only [Int.preimage_floor_singleton] using measurableSet_Ico
 
-@[measurability, fun_prop]
+@[fun_prop]
 theorem Measurable.floor [OpensMeasurableSpace R] {f : α → R} (hf : Measurable f) :
     Measurable fun x => ⌊f x⌋ :=
   Int.measurable_floor.comp hf
@@ -37,7 +37,7 @@ theorem Int.measurable_ceil [OpensMeasurableSpace R] : Measurable (Int.ceil : R 
   measurable_to_countable fun x => by
     simpa only [Int.preimage_ceil_singleton] using measurableSet_Ioc
 
-@[measurability, fun_prop]
+@[fun_prop]
 theorem Measurable.ceil [OpensMeasurableSpace R] {f : α → R} (hf : Measurable f) :
     Measurable fun x => ⌈f x⌉ :=
   Int.measurable_ceil.comp hf
@@ -48,7 +48,7 @@ theorem measurable_fract [IsStrictOrderedRing R] [BorelSpace R] :
   rw [Int.preimage_fract]
   exact MeasurableSet.iUnion fun z => measurable_id.sub_const _ (hs.inter measurableSet_Ico)
 
-@[measurability, fun_prop]
+@[fun_prop]
 theorem Measurable.fract [IsStrictOrderedRing R] [BorelSpace R] {f : α → R} (hf : Measurable f) :
     Measurable fun x => Int.fract (f x) :=
   measurable_fract.comp hf
@@ -70,7 +70,7 @@ theorem Nat.measurable_floor [IsStrictOrderedRing R] : Measurable (Nat.floor : R
   measurable_to_countable fun n => by
     rcases eq_or_ne ⌊n⌋₊ 0 with h | h <;> simp [h, Nat.preimage_floor_of_ne_zero, -floor_eq_zero]
 
-@[measurability, fun_prop]
+@[fun_prop]
 theorem Measurable.nat_floor [IsStrictOrderedRing R] (hf : Measurable f) :
     Measurable fun x => ⌊f x⌋₊ :=
   Nat.measurable_floor.comp hf
@@ -79,7 +79,7 @@ theorem Nat.measurable_ceil : Measurable (Nat.ceil : R → ℕ) :=
   measurable_to_countable fun n => by
     rcases eq_or_ne ⌈n⌉₊ 0 with h | h <;> simp_all [Nat.preimage_ceil_of_ne_zero, -ceil_eq_zero]
 
-@[measurability, fun_prop]
+@[fun_prop]
 theorem Measurable.nat_ceil (hf : Measurable f) : Measurable fun x => ⌈f x⌉₊ :=
   Nat.measurable_ceil.comp hf
 

--- a/Mathlib/MeasureTheory/Function/LpSpace/Basic.lean
+++ b/Mathlib/MeasureTheory/Function/LpSpace/Basic.lean
@@ -171,11 +171,11 @@ theorem eLpNorm_lt_top (f : Lp E p μ) : eLpNorm f p μ < ∞ :=
 theorem eLpNorm_ne_top (f : Lp E p μ) : eLpNorm f p μ ≠ ∞ :=
   (eLpNorm_lt_top f).ne
 
-@[fun_prop, measurability]
+@[fun_prop]
 protected theorem stronglyMeasurable (f : Lp E p μ) : StronglyMeasurable f :=
   f.val.stronglyMeasurable
 
-@[fun_prop, measurability]
+@[fun_prop]
 protected theorem aestronglyMeasurable (f : Lp E p μ) : AEStronglyMeasurable f μ :=
   f.val.aestronglyMeasurable
 

--- a/Mathlib/MeasureTheory/Function/SimpleFunc.lean
+++ b/Mathlib/MeasureTheory/Function/SimpleFunc.lean
@@ -166,11 +166,11 @@ theorem measurableSet_preimage (f : α →ₛ β) (s) : MeasurableSet (f ⁻¹' 
   measurableSet_cut (fun _ b => b ∈ s) f fun b => MeasurableSet.const (b ∈ s)
 
 /-- A simple function is measurable -/
-@[measurability, fun_prop]
+@[fun_prop]
 protected theorem measurable [MeasurableSpace β] (f : α →ₛ β) : Measurable f := fun s _ =>
   measurableSet_preimage f s
 
-@[measurability]
+@[fun_prop]
 protected theorem aemeasurable [MeasurableSpace β] {μ : Measure α} (f : α →ₛ β) :
     AEMeasurable f μ :=
   f.measurable.aemeasurable

--- a/Mathlib/MeasureTheory/Function/SimpleFuncDenseLp.lean
+++ b/Mathlib/MeasureTheory/Function/SimpleFuncDenseLp.lean
@@ -510,7 +510,7 @@ def toSimpleFunc (f : Lp.simpleFunc E p μ) : α →ₛ E :=
   Classical.choose f.2
 
 /-- `(toSimpleFunc f)` is measurable. -/
-@[measurability]
+@[fun_prop]
 protected theorem measurable [MeasurableSpace E] (f : Lp.simpleFunc E p μ) :
     Measurable (toSimpleFunc f) :=
   (toSimpleFunc f).measurable
@@ -519,7 +519,7 @@ protected theorem stronglyMeasurable (f : Lp.simpleFunc E p μ) :
     StronglyMeasurable (toSimpleFunc f) :=
   (toSimpleFunc f).stronglyMeasurable
 
-@[measurability]
+@[fun_prop]
 protected theorem aemeasurable [MeasurableSpace E] (f : Lp.simpleFunc E p μ) :
     AEMeasurable (toSimpleFunc f) μ :=
   (simpleFunc.measurable f).aemeasurable

--- a/Mathlib/MeasureTheory/Function/SpecialFunctions/Arctan.lean
+++ b/Mathlib/MeasureTheory/Function/SpecialFunctions/Arctan.lean
@@ -29,7 +29,7 @@ open Real
 
 variable {α : Type*} {m : MeasurableSpace α} {f : α → ℝ}
 
-@[measurability, fun_prop]
+@[fun_prop]
 theorem Measurable.arctan (hf : Measurable f) : Measurable fun x => arctan (f x) :=
   measurable_arctan.comp hf
 

--- a/Mathlib/MeasureTheory/Function/SpecialFunctions/Basic.lean
+++ b/Mathlib/MeasureTheory/Function/SpecialFunctions/Basic.lean
@@ -70,11 +70,11 @@ theorem measurable_sinh : Measurable sinh :=
 theorem measurable_cosh : Measurable cosh :=
   continuous_cosh.measurable
 
-@[measurability]
+@[fun_prop]
 theorem measurable_arcsin : Measurable arcsin :=
   continuous_arcsin.measurable
 
-@[measurability]
+@[fun_prop]
 theorem measurable_arccos : Measurable arccos :=
   continuous_arccos.measurable
 
@@ -82,11 +82,11 @@ end Real
 
 namespace Complex
 
-@[measurability]
+@[fun_prop]
 theorem measurable_re : Measurable re :=
   continuous_re.measurable
 
-@[measurability]
+@[fun_prop]
 theorem measurable_im : Measurable im :=
   continuous_im.measurable
 
@@ -130,27 +130,27 @@ open Real
 variable {α : Type*} {m : MeasurableSpace α} {f : α → ℝ} (hf : Measurable f)
 include hf
 
-@[measurability, fun_prop]
+@[fun_prop]
 protected theorem Measurable.exp : Measurable fun x => Real.exp (f x) :=
   Real.measurable_exp.comp hf
 
-@[measurability, fun_prop]
+@[fun_prop]
 protected theorem Measurable.log : Measurable fun x => log (f x) :=
   measurable_log.comp hf
 
-@[measurability, fun_prop]
+@[fun_prop]
 protected theorem Measurable.cos : Measurable fun x ↦ cos (f x) := measurable_cos.comp hf
 
-@[measurability, fun_prop]
+@[fun_prop]
 protected theorem Measurable.sin : Measurable fun x ↦ sin (f x) := measurable_sin.comp hf
 
-@[measurability, fun_prop]
+@[fun_prop]
 protected theorem Measurable.cosh : Measurable fun x ↦ cosh (f x) := measurable_cosh.comp hf
 
-@[measurability, fun_prop]
+@[fun_prop]
 protected theorem Measurable.sinh : Measurable fun x ↦ sinh (f x) := measurable_sinh.comp hf
 
-@[measurability, fun_prop]
+@[fun_prop]
 protected theorem Measurable.sqrt : Measurable fun x => √(f x) := continuous_sqrt.measurable.comp hf
 
 end RealComposition
@@ -162,31 +162,31 @@ open Real
 variable {α : Type*} {m : MeasurableSpace α} {μ : Measure α} {f : α → ℝ} (hf : AEMeasurable f μ)
 include hf
 
-@[measurability, fun_prop]
+@[fun_prop]
 protected lemma AEMeasurable.exp : AEMeasurable (fun x ↦ exp (f x)) μ :=
   measurable_exp.comp_aemeasurable hf
 
-@[measurability, fun_prop]
+@[fun_prop]
 protected lemma AEMeasurable.log : AEMeasurable (fun x ↦ log (f x)) μ :=
   measurable_log.comp_aemeasurable hf
 
-@[measurability, fun_prop]
+@[fun_prop]
 protected lemma AEMeasurable.cos : AEMeasurable (fun x ↦ cos (f x)) μ :=
   measurable_cos.comp_aemeasurable hf
 
-@[measurability, fun_prop]
+@[fun_prop]
 protected lemma AEMeasurable.sin : AEMeasurable (fun x ↦ sin (f x)) μ :=
   measurable_sin.comp_aemeasurable hf
 
-@[measurability, fun_prop]
+@[fun_prop]
 protected lemma AEMeasurable.cosh : AEMeasurable (fun x ↦ cosh (f x)) μ :=
   measurable_cosh.comp_aemeasurable hf
 
-@[measurability, fun_prop]
+@[fun_prop]
 protected lemma AEMeasurable.sinh : AEMeasurable (fun x ↦ sinh (f x)) μ :=
   measurable_sinh.comp_aemeasurable hf
 
-@[measurability, fun_prop]
+@[fun_prop]
 protected lemma AEMeasurable.sqrt : AEMeasurable (fun x ↦ √(f x)) μ :=
   continuous_sqrt.measurable.comp_aemeasurable hf
 
@@ -199,31 +199,31 @@ open Complex
 variable {α : Type*} {m : MeasurableSpace α} {f : α → ℂ} (hf : Measurable f)
 include hf
 
-@[measurability, fun_prop]
+@[fun_prop]
 protected theorem Measurable.cexp : Measurable fun x => Complex.exp (f x) :=
   Complex.measurable_exp.comp hf
 
-@[measurability, fun_prop]
+@[fun_prop]
 protected theorem Measurable.ccos : Measurable fun x => Complex.cos (f x) :=
   Complex.measurable_cos.comp hf
 
-@[measurability, fun_prop]
+@[fun_prop]
 protected theorem Measurable.csin : Measurable fun x => Complex.sin (f x) :=
   Complex.measurable_sin.comp hf
 
-@[measurability, fun_prop]
+@[fun_prop]
 protected theorem Measurable.ccosh : Measurable fun x => Complex.cosh (f x) :=
   Complex.measurable_cosh.comp hf
 
-@[measurability, fun_prop]
+@[fun_prop]
 protected theorem Measurable.csinh : Measurable fun x => Complex.sinh (f x) :=
   Complex.measurable_sinh.comp hf
 
-@[measurability, fun_prop]
+@[fun_prop]
 protected theorem Measurable.carg : Measurable fun x => arg (f x) :=
   measurable_arg.comp hf
 
-@[measurability, fun_prop]
+@[fun_prop]
 protected theorem Measurable.clog : Measurable fun x => Complex.log (f x) :=
   measurable_log.comp hf
 
@@ -236,43 +236,43 @@ open Complex
 variable {α : Type*} {m : MeasurableSpace α} {μ : Measure α} {f : α → ℂ} (hf : AEMeasurable f μ)
 include hf
 
-@[measurability, fun_prop]
+@[fun_prop]
 protected lemma AEMeasurable.cexp : AEMeasurable (fun x ↦ exp (f x)) μ :=
   measurable_exp.comp_aemeasurable hf
 
-@[measurability, fun_prop]
+@[fun_prop]
 protected lemma AEMeasurable.ccos : AEMeasurable (fun x ↦ cos (f x)) μ :=
   measurable_cos.comp_aemeasurable hf
 
-@[measurability, fun_prop]
+@[fun_prop]
 protected lemma AEMeasurable.csin : AEMeasurable (fun x ↦ sin (f x)) μ :=
   measurable_sin.comp_aemeasurable hf
 
-@[measurability, fun_prop]
+@[fun_prop]
 protected lemma AEMeasurable.ccosh : AEMeasurable (fun x ↦ cosh (f x)) μ :=
   measurable_cosh.comp_aemeasurable hf
 
-@[measurability, fun_prop]
+@[fun_prop]
 protected lemma AEMeasurable.csinh : AEMeasurable (fun x ↦ sinh (f x)) μ :=
   measurable_sinh.comp_aemeasurable hf
 
-@[measurability, fun_prop]
+@[fun_prop]
 protected lemma AEMeasurable.carg : AEMeasurable (fun x ↦ arg (f x)) μ :=
   measurable_arg.comp_aemeasurable hf
 
-@[measurability, fun_prop]
+@[fun_prop]
 protected lemma AEMeasurable.clog : AEMeasurable (fun x ↦ log (f x)) μ :=
   measurable_log.comp_aemeasurable hf
 
 end ComplexComposition
 
-@[measurability, fun_prop]
+@[fun_prop]
 protected theorem Measurable.complex_ofReal {α : Type*} {m : MeasurableSpace α} {f : α → ℝ}
     (hf : Measurable f) :
     Measurable fun x ↦ (f x : ℂ) :=
   Complex.measurable_ofReal.comp hf
 
-@[measurability, fun_prop]
+@[fun_prop]
 protected theorem AEMeasurable.complex_ofReal {α : Type*} {m : MeasurableSpace α} {μ : Measure α}
     {f : α → ℝ} (hf : AEMeasurable f μ) :
     AEMeasurable (fun x ↦ (f x : ℂ)) μ :=

--- a/Mathlib/MeasureTheory/Function/SpecialFunctions/Inner.lean
+++ b/Mathlib/MeasureTheory/Function/SpecialFunctions/Inner.lean
@@ -26,13 +26,13 @@ theorem Measurable.inner {_ : MeasurableSpace α} [MeasurableSpace E] [OpensMeas
     (hg : Measurable g) : Measurable fun t => ⟪f t, g t⟫ :=
   Continuous.measurable2 continuous_inner hf hg
 
-@[measurability, fun_prop]
+@[fun_prop]
 theorem Measurable.const_inner {_ : MeasurableSpace α} [MeasurableSpace E] [OpensMeasurableSpace E]
     [SecondCountableTopology E] {c : E} {f : α → E} (hf : Measurable f) :
     Measurable fun t => ⟪c, f t⟫ :=
   Measurable.inner measurable_const hf
 
-@[measurability, fun_prop]
+@[fun_prop]
 theorem Measurable.inner_const {_ : MeasurableSpace α} [MeasurableSpace E] [OpensMeasurableSpace E]
     [SecondCountableTopology E] {c : E} {f : α → E} (hf : Measurable f) :
     Measurable fun t => ⟪f t, c⟫ :=
@@ -44,14 +44,14 @@ theorem AEMeasurable.inner {m : MeasurableSpace α} [MeasurableSpace E] [OpensMe
     (hf : AEMeasurable f μ) (hg : AEMeasurable g μ) : AEMeasurable (fun x => ⟪f x, g x⟫) μ := by
   fun_prop
 
-@[measurability, fun_prop]
+@[fun_prop]
 theorem AEMeasurable.const_inner {m : MeasurableSpace α} [MeasurableSpace E]
     [OpensMeasurableSpace E] [SecondCountableTopology E]
     {μ : MeasureTheory.Measure α} {f : α → E} {c : E} (hf : AEMeasurable f μ) :
     AEMeasurable (fun x => ⟪c, f x⟫) μ :=
   AEMeasurable.inner aemeasurable_const hf
 
-@[measurability, fun_prop]
+@[fun_prop]
 theorem AEMeasurable.inner_const {m : MeasurableSpace α} [MeasurableSpace E]
     [OpensMeasurableSpace E] [SecondCountableTopology E]
     {μ : MeasureTheory.Measure α} {f : α → E} {c : E} (hf : AEMeasurable f μ) :

--- a/Mathlib/MeasureTheory/Function/SpecialFunctions/RCLike.lean
+++ b/Mathlib/MeasureTheory/Function/SpecialFunctions/RCLike.lean
@@ -37,19 +37,19 @@ section RCLikeComposition
 variable {α 𝕜 : Type*} [RCLike 𝕜] {m : MeasurableSpace α} {f : α → 𝕜}
   {μ : MeasureTheory.Measure α}
 
-@[measurability, fun_prop]
+@[fun_prop]
 theorem Measurable.re (hf : Measurable f) : Measurable fun x => RCLike.re (f x) :=
   RCLike.measurable_re.comp hf
 
-@[measurability, fun_prop]
+@[fun_prop]
 theorem AEMeasurable.re (hf : AEMeasurable f μ) : AEMeasurable (fun x => RCLike.re (f x)) μ :=
   RCLike.measurable_re.comp_aemeasurable hf
 
-@[measurability, fun_prop]
+@[fun_prop]
 theorem Measurable.im (hf : Measurable f) : Measurable fun x => RCLike.im (f x) :=
   RCLike.measurable_im.comp hf
 
-@[measurability, fun_prop]
+@[fun_prop]
 theorem AEMeasurable.im (hf : AEMeasurable f μ) : AEMeasurable (fun x => RCLike.im (f x)) μ :=
   RCLike.measurable_im.comp_aemeasurable hf
 
@@ -59,7 +59,7 @@ section
 
 variable {α 𝕜 : Type*} [RCLike 𝕜] [MeasurableSpace α] {f : α → 𝕜} {μ : MeasureTheory.Measure α}
 
-@[measurability]
+@[fun_prop]
 theorem RCLike.measurable_ofReal : Measurable ((↑) : ℝ → 𝕜) :=
   RCLike.continuous_ofReal.measurable
 

--- a/Mathlib/MeasureTheory/Function/SpecialFunctions/Sinc.lean
+++ b/Mathlib/MeasureTheory/Function/SpecialFunctions/Sinc.lean
@@ -27,10 +27,10 @@ variable {α : Type*} {_ : MeasurableSpace α} {f : α → ℝ} {μ : Measure α
 
 namespace Real
 
-@[fun_prop, measurability]
+@[fun_prop]
 lemma measurable_sinc : Measurable sinc := continuous_sinc.measurable
 
-@[fun_prop, measurability]
+@[fun_prop]
 lemma stronglyMeasurable_sinc : StronglyMeasurable sinc := measurable_sinc.stronglyMeasurable
 
 @[fun_prop]
@@ -44,20 +44,20 @@ end Real
 
 open Real
 
-@[fun_prop, measurability]
+@[fun_prop]
 protected theorem Measurable.sinc (hf : Measurable f) : Measurable fun x ↦ sinc (f x) :=
   Real.measurable_sinc.comp hf
 
-@[fun_prop, measurability]
+@[fun_prop]
 protected theorem AEMeasurable.sinc (hf : AEMeasurable f μ) : AEMeasurable (fun x ↦ sinc (f x)) μ :=
   Real.measurable_sinc.comp_aemeasurable hf
 
-@[fun_prop, measurability]
+@[fun_prop]
 protected theorem MeasureTheory.StronglyMeasurable.sinc (hf : StronglyMeasurable f) :
     StronglyMeasurable fun x ↦ sinc (f x) :=
   Real.stronglyMeasurable_sinc.comp_measurable hf.measurable
 
-@[fun_prop, measurability]
+@[fun_prop]
 protected theorem MeasureTheory.AEStronglyMeasurable.sinc (hf : AEStronglyMeasurable f μ) :
     AEStronglyMeasurable (fun x ↦ sinc (f x)) μ := by
   rw [aestronglyMeasurable_iff_aemeasurable] at hf ⊢

--- a/Mathlib/MeasureTheory/Function/StronglyMeasurable/AEStronglyMeasurable.lean
+++ b/Mathlib/MeasureTheory/Function/StronglyMeasurable/AEStronglyMeasurable.lean
@@ -108,11 +108,11 @@ variable [TopologicalSpace β] [TopologicalSpace γ] {m m₀ : MeasurableSpace �
 protected theorem StronglyMeasurable.aestronglyMeasurable (hf : StronglyMeasurable[m] f) :
     AEStronglyMeasurable[m] f μ := ⟨f, hf, EventuallyEq.refl _ _⟩
 
-@[fun_prop, measurability]
+@[fun_prop]
 theorem aestronglyMeasurable_const {b : β} : AEStronglyMeasurable[m] (fun _ : α => b) μ :=
   stronglyMeasurable_const.aestronglyMeasurable
 
-@[to_additive (attr := fun_prop, measurability)]
+@[to_additive (attr := fun_prop)]
 theorem aestronglyMeasurable_one [One β] : AEStronglyMeasurable[m] (1 : α → β) μ :=
   stronglyMeasurable_one.aestronglyMeasurable
 
@@ -131,7 +131,7 @@ theorem aestronglyMeasurable_zero_measure (f : α → β) :
   inhabit α
   exact ⟨fun _ => f default, stronglyMeasurable_const, rfl⟩
 
-@[fun_prop, measurability]
+@[fun_prop]
 theorem SimpleFunc.aestronglyMeasurable (f : α →ₛ β) : AEStronglyMeasurable f μ :=
   f.stronglyMeasurable.aestronglyMeasurable
 
@@ -277,17 +277,17 @@ protected theorem mul [Mul β] [ContinuousMul β] (hf : AEStronglyMeasurable[m] 
     (hg : AEStronglyMeasurable[m] g μ) : AEStronglyMeasurable[m] (f * g) μ :=
   ⟨hf.mk f * hg.mk g, by fun_prop, hf.ae_eq_mk.mul hg.ae_eq_mk⟩
 
-@[to_additive (attr := fun_prop, measurability)]
+@[to_additive (attr := fun_prop)]
 protected theorem mul_const [Mul β] [ContinuousMul β] (hf : AEStronglyMeasurable[m] f μ) (c : β) :
     AEStronglyMeasurable[m] (fun x => f x * c) μ :=
   hf.mul aestronglyMeasurable_const
 
-@[to_additive (attr := fun_prop, measurability)]
+@[to_additive (attr := fun_prop)]
 protected theorem const_mul [Mul β] [ContinuousMul β] (hf : AEStronglyMeasurable[m] f μ) (c : β) :
     AEStronglyMeasurable[m] (fun x => c * f x) μ :=
   aestronglyMeasurable_const.mul hf
 
-@[to_additive (attr := fun_prop, measurability)]
+@[to_additive (attr := fun_prop)]
 protected theorem inv [Inv β] [ContinuousInv β] (hf : AEStronglyMeasurable[m] f μ) :
     AEStronglyMeasurable[m] f⁻¹ μ :=
   ⟨(hf.mk f)⁻¹, hf.stronglyMeasurable_mk.inv, hf.ae_eq_mk.inv⟩
@@ -320,17 +320,17 @@ protected theorem pow [Monoid β] [ContinuousMul β] (hf : AEStronglyMeasurable[
     AEStronglyMeasurable[m] (f ^ n) μ :=
   ⟨hf.mk f ^ n, hf.stronglyMeasurable_mk.pow _, hf.ae_eq_mk.pow_const _⟩
 
-@[to_additive (attr := fun_prop, measurability)]
+@[to_additive (attr := fun_prop)]
 protected theorem const_smul {𝕜} [SMul 𝕜 β] [ContinuousConstSMul 𝕜 β]
     (hf : AEStronglyMeasurable[m] f μ) (c : 𝕜) : AEStronglyMeasurable[m] (c • f) μ :=
   ⟨c • hf.mk f, hf.stronglyMeasurable_mk.const_smul c, hf.ae_eq_mk.const_smul c⟩
 
-@[to_additive (attr := fun_prop, measurability)]
+@[to_additive (attr := fun_prop)]
 protected theorem const_smul' {𝕜} [SMul 𝕜 β] [ContinuousConstSMul 𝕜 β]
     (hf : AEStronglyMeasurable[m] f μ) (c : 𝕜) : AEStronglyMeasurable[m] (fun x => c • f x) μ :=
   hf.const_smul c
 
-@[to_additive (attr := fun_prop, measurability)]
+@[to_additive (attr := fun_prop)]
 protected theorem smul_const {𝕜} [TopologicalSpace 𝕜] [SMul 𝕜 β] [ContinuousSMul 𝕜 β] {f : α → 𝕜}
     (hf : AEStronglyMeasurable[m] f μ) (c : β) : AEStronglyMeasurable[m] (fun x => f x • c) μ :=
   continuous_smul.comp_aestronglyMeasurable (hf.prodMk aestronglyMeasurable_const)
@@ -339,7 +339,7 @@ end Arithmetic
 
 section Star
 
-@[fun_prop, measurability]
+@[fun_prop]
 protected theorem star {R : Type*} [TopologicalSpace R] [Star R] [ContinuousStar R] {f : α → R}
     (hf : AEStronglyMeasurable f μ) : AEStronglyMeasurable (star f) μ :=
   ⟨star (hf.mk f), hf.stronglyMeasurable_mk.star, hf.ae_eq_mk.star⟩
@@ -445,7 +445,7 @@ theorem _root_.AEMeasurable.aestronglyMeasurable [PseudoMetrizableSpace β] [Ope
     [SecondCountableTopology β] (hf : AEMeasurable f μ) : AEStronglyMeasurable f μ :=
   ⟨hf.mk f, hf.measurable_mk.stronglyMeasurable, hf.ae_eq_mk⟩
 
-@[fun_prop, measurability]
+@[fun_prop]
 theorem _root_.aestronglyMeasurable_id {α : Type*} [TopologicalSpace α] [PseudoMetrizableSpace α]
     {_ : MeasurableSpace α} [OpensMeasurableSpace α] [SecondCountableTopology α] {μ : Measure α} :
     AEStronglyMeasurable (id : α → α) μ :=
@@ -464,12 +464,12 @@ protected theorem dist {β : Type*} [PseudoMetricSpace β] {f g : α → β}
     AEStronglyMeasurable (fun x => dist (f x) (g x)) μ :=
   continuous_dist.comp_aestronglyMeasurable (hf.prodMk hg)
 
-@[fun_prop, measurability]
+@[fun_prop]
 protected theorem norm {β : Type*} [SeminormedAddCommGroup β] {f : α → β}
     (hf : AEStronglyMeasurable f μ) : AEStronglyMeasurable (fun x => ‖f x‖) μ :=
   continuous_norm.comp_aestronglyMeasurable hf
 
-@[fun_prop, measurability]
+@[fun_prop]
 protected theorem nnnorm {β : Type*} [SeminormedAddCommGroup β] {f : α → β}
     (hf : AEStronglyMeasurable f μ) : AEStronglyMeasurable (fun x => ‖f x‖₊) μ :=
   continuous_nnnorm.comp_aestronglyMeasurable hf
@@ -480,7 +480,7 @@ Note that unlike `AEStronglyMeasurable.norm` and `AEStronglyMeasurable.nnnorm`, 
 a.e. measurability, **not** a.e. strong measurability. This is an intentional decision:
 for functions taking values in `ℝ≥0∞`, a.e. measurability is much more useful than
 a.e. strong measurability. -/
-@[fun_prop, measurability]
+@[fun_prop]
 protected theorem enorm {β : Type*} [TopologicalSpace β] [ContinuousENorm β] {f : α → β}
     (hf : AEStronglyMeasurable f μ) : AEMeasurable (‖f ·‖ₑ) μ :=
   (continuous_enorm.comp_aestronglyMeasurable hf).aemeasurable
@@ -496,7 +496,7 @@ protected theorem edist {β : Type*} [PseudoMetricSpace β] {f g : α → β}
     AEMeasurable (fun a => edist (f a) (g a)) μ :=
   (continuous_edist.comp_aestronglyMeasurable (hf.prodMk hg)).aemeasurable
 
-@[fun_prop, measurability]
+@[fun_prop]
 protected theorem real_toNNReal {f : α → ℝ} (hf : AEStronglyMeasurable f μ) :
     AEStronglyMeasurable (fun x => (f x).toNNReal) μ :=
   continuous_real_toNNReal.comp_aestronglyMeasurable hf
@@ -521,12 +521,12 @@ theorem _root_.aestronglyMeasurable_indicator_iff₀
     aestronglyMeasurable_indicator_iff (measurableSet_toMeasurable ..),
     restrict_congr_set hs.toMeasurable_ae_eq]
 
-@[fun_prop, measurability]
+@[fun_prop]
 protected theorem indicator [Zero β] (hfm : AEStronglyMeasurable f μ) {s : Set α}
     (hs : MeasurableSet s) : AEStronglyMeasurable (s.indicator f) μ :=
   (aestronglyMeasurable_indicator_iff hs).mpr hfm.restrict
 
-@[fun_prop, measurability]
+@[fun_prop]
 protected theorem indicator₀ [Zero β] (hfm : AEStronglyMeasurable f μ) {s : Set α}
     (hs : NullMeasurableSet s μ) : AEStronglyMeasurable (s.indicator f) μ :=
   (aestronglyMeasurable_indicator_iff₀ hs).2 hfm.restrict

--- a/Mathlib/MeasureTheory/Function/StronglyMeasurable/Basic.lean
+++ b/Mathlib/MeasureTheory/Function/StronglyMeasurable/Basic.lean
@@ -397,12 +397,12 @@ protected theorem mul [Mul β] [ContinuousMul β] (hf : StronglyMeasurable f)
     (hg : StronglyMeasurable g) : StronglyMeasurable (f * g) :=
   ⟨fun n => hf.approx n * hg.approx n, fun x => (hf.tendsto_approx x).mul (hg.tendsto_approx x)⟩
 
-@[to_additive (attr := fun_prop, measurability)]
+@[to_additive (attr := fun_prop)]
 theorem mul_const [Mul β] [ContinuousMul β] (hf : StronglyMeasurable f) (c : β) :
     StronglyMeasurable fun x => f x * c :=
   hf.mul stronglyMeasurable_const
 
-@[to_additive (attr := fun_prop, measurability)]
+@[to_additive (attr := fun_prop)]
 theorem const_mul [Mul β] [ContinuousMul β] (hf : StronglyMeasurable f) (c : β) :
     StronglyMeasurable fun x => c * f x :=
   stronglyMeasurable_const.mul hf
@@ -412,7 +412,7 @@ protected theorem pow [Monoid β] [ContinuousMul β] (hf : StronglyMeasurable f)
     StronglyMeasurable (f ^ n) :=
   ⟨fun k => hf.approx k ^ n, fun x => (hf.tendsto_approx x).pow n⟩
 
-@[to_additive (attr := fun_prop, measurability)]
+@[to_additive (attr := fun_prop)]
 protected theorem inv [Inv β] [ContinuousInv β] (hf : StronglyMeasurable f) :
     StronglyMeasurable f⁻¹ :=
   ⟨fun n => (hf.approx n)⁻¹, fun x => (hf.tendsto_approx x).inv⟩
@@ -439,23 +439,23 @@ protected theorem smul {𝕜} [TopologicalSpace 𝕜] [SMul 𝕜 β] [Continuous
     StronglyMeasurable fun x => f x • g x :=
   continuous_smul.comp_stronglyMeasurable (hf.prodMk hg)
 
-@[to_additive (attr := fun_prop, measurability)]
+@[to_additive (attr := fun_prop)]
 protected theorem const_smul {𝕜} [SMul 𝕜 β] [ContinuousConstSMul 𝕜 β] (hf : StronglyMeasurable f)
     (c : 𝕜) : StronglyMeasurable (c • f) :=
   ⟨fun n => c • hf.approx n, fun x => (hf.tendsto_approx x).const_smul c⟩
 
-@[to_additive (attr := fun_prop, measurability)]
+@[to_additive (attr := fun_prop)]
 protected theorem const_smul' {𝕜} [SMul 𝕜 β] [ContinuousConstSMul 𝕜 β] (hf : StronglyMeasurable f)
     (c : 𝕜) : StronglyMeasurable fun x => c • f x :=
   hf.const_smul c
 
-@[to_additive (attr := fun_prop, measurability)]
+@[to_additive (attr := fun_prop)]
 protected theorem smul_const {𝕜} [TopologicalSpace 𝕜] [SMul 𝕜 β] [ContinuousSMul 𝕜 β] {f : α → 𝕜}
     (hf : StronglyMeasurable f) (c : β) : StronglyMeasurable fun x => f x • c :=
   continuous_smul.comp_stronglyMeasurable (hf.prodMk stronglyMeasurable_const)
 
 /-- Pointwise star on functions induced from continuous star preserves strong measurability. -/
-@[measurability]
+@[fun_prop]
 protected theorem star {R : Type*} [MeasurableSpace α] [Star R] [TopologicalSpace R]
     [ContinuousStar R] (f : α → R) (hf : StronglyMeasurable f) : StronglyMeasurable (star f) :=
   ⟨fun n => star (hf.approx n), fun x => (hf.tendsto_approx x).star⟩
@@ -662,7 +662,7 @@ theorem _root_.stronglyMeasurable_iff_measurable [TopologicalSpace β] [Metrizab
     [BorelSpace β] [SecondCountableTopology β] : StronglyMeasurable f ↔ Measurable f :=
   ⟨fun h => h.measurable, fun h => Measurable.stronglyMeasurable h⟩
 
-@[fun_prop, measurability]
+@[fun_prop]
 theorem _root_.stronglyMeasurable_id [TopologicalSpace α] [PseudoMetrizableSpace α]
     [OpensMeasurableSpace α] [SecondCountableTopology α] : StronglyMeasurable (id : α → α) :=
   measurable_id.stronglyMeasurable
@@ -784,7 +784,7 @@ protected theorem ite {_ : MeasurableSpace α} [TopologicalSpace β] {p : α →
     (hg : StronglyMeasurable g) : StronglyMeasurable fun x => ite (p x) (f x) (g x) :=
   StronglyMeasurable.piecewise hp hf hg
 
-@[measurability]
+@[fun_prop]
 theorem _root_.MeasurableEmbedding.stronglyMeasurable_extend {f : α → β} {g : α → γ} {g' : γ → β}
     {mα : MeasurableSpace α} {mγ : MeasurableSpace γ} [TopologicalSpace β]
     (hg : MeasurableEmbedding g) (hf : StronglyMeasurable f) (hg' : StronglyMeasurable g') :
@@ -830,7 +830,7 @@ theorem _root_.stronglyMeasurable_of_restrict_of_restrict_compl {_ : MeasurableS
   stronglyMeasurable_of_stronglyMeasurable_union_cover s sᶜ hs hs.compl (union_compl_self s).ge h₁
     h₂
 
-@[measurability]
+@[fun_prop]
 protected theorem indicator {_ : MeasurableSpace α} [TopologicalSpace β] [Zero β]
     (hf : StronglyMeasurable f) {s : Set α} (hs : MeasurableSet s) :
     StronglyMeasurable (s.indicator f) :=
@@ -898,12 +898,12 @@ protected theorem edist {_ : MeasurableSpace α} {β : Type*} [PseudoEMetricSpac
     StronglyMeasurable fun x => edist (f x) (g x) :=
   continuous_edist.comp_stronglyMeasurable (hf.prodMk hg)
 
-@[fun_prop, measurability]
+@[fun_prop]
 protected theorem norm {_ : MeasurableSpace α} {β : Type*} [SeminormedAddCommGroup β] {f : α → β}
     (hf : StronglyMeasurable f) : StronglyMeasurable fun x => ‖f x‖ :=
   continuous_norm.comp_stronglyMeasurable hf
 
-@[fun_prop, measurability]
+@[fun_prop]
 protected theorem nnnorm {_ : MeasurableSpace α} {β : Type*} [SeminormedAddCommGroup β] {f : α → β}
     (hf : StronglyMeasurable f) : StronglyMeasurable fun x => ‖f x‖₊ :=
   continuous_nnnorm.comp_stronglyMeasurable hf
@@ -913,12 +913,12 @@ protected theorem nnnorm {_ : MeasurableSpace α} {β : Type*} [SeminormedAddCom
 Unlike `StrongMeasurable.norm` and `StronglyMeasurable.nnnorm`, this lemma proves measurability,
 **not** strong measurability. This is an intentional decision: for functions taking values in
 ℝ≥0∞, measurability is much more useful than strong measurability. -/
-@[fun_prop, measurability]
+@[fun_prop]
 protected theorem enorm {_ : MeasurableSpace α} {ε : Type*} [TopologicalSpace ε] [ContinuousENorm ε]
     {f : α → ε} (hf : StronglyMeasurable f) : Measurable (‖f ·‖ₑ) :=
   (continuous_enorm.comp_stronglyMeasurable hf).measurable
 
-@[fun_prop, measurability]
+@[fun_prop]
 protected theorem real_toNNReal {_ : MeasurableSpace α} {f : α → ℝ} (hf : StronglyMeasurable f) :
     StronglyMeasurable fun x => (f x).toNNReal :=
   continuous_real_toNNReal.comp_stronglyMeasurable hf

--- a/Mathlib/MeasureTheory/Function/StronglyMeasurable/Lemmas.lean
+++ b/Mathlib/MeasureTheory/Function/StronglyMeasurable/Lemmas.lean
@@ -71,7 +71,7 @@ theorem StronglyMeasurable.apply_continuousLinearMap
     StronglyMeasurable fun a => φ a v :=
   (ContinuousLinearMap.apply 𝕜 E v).continuous.comp_stronglyMeasurable hφ
 
-@[measurability]
+@[fun_prop]
 theorem MeasureTheory.AEStronglyMeasurable.apply_continuousLinearMap {φ : α → F →L[𝕜] E}
     (hφ : AEStronglyMeasurable φ μ) (v : F) :
     AEStronglyMeasurable (fun a => φ a v) μ :=

--- a/Mathlib/MeasureTheory/Group/Arithmetic.lean
+++ b/Mathlib/MeasureTheory/Group/Arithmetic.lean
@@ -94,22 +94,22 @@ section Mul
 variable {M α β : Type*} [MeasurableSpace M] [Mul M] {m : MeasurableSpace α}
   {mβ : MeasurableSpace β} {f g : α → M} {μ : Measure α}
 
-@[to_additive (attr := fun_prop, measurability)]
+@[to_additive (attr := fun_prop)]
 theorem Measurable.const_mul [MeasurableMul M] (hf : Measurable f) (c : M) :
     Measurable fun x => c * f x :=
   (measurable_const_mul c).comp hf
 
-@[to_additive (attr := fun_prop, measurability)]
+@[to_additive (attr := fun_prop)]
 theorem AEMeasurable.const_mul [MeasurableMul M] (hf : AEMeasurable f μ) (c : M) :
     AEMeasurable (fun x => c * f x) μ :=
   (MeasurableMul.measurable_const_mul c).comp_aemeasurable hf
 
-@[to_additive (attr := fun_prop, measurability)]
+@[to_additive (attr := fun_prop)]
 theorem Measurable.mul_const [MeasurableMul M] (hf : Measurable f) (c : M) :
     Measurable fun x => f x * c :=
   (measurable_mul_const c).comp hf
 
-@[to_additive (attr := fun_prop, measurability)]
+@[to_additive (attr := fun_prop)]
 theorem AEMeasurable.mul_const [MeasurableMul M] (hf : AEMeasurable f μ) (c : M) :
     AEMeasurable (fun x => f x * c) μ :=
   (measurable_mul_const c).comp_aemeasurable hf
@@ -191,20 +191,20 @@ theorem AEMeasurable.pow (hf : AEMeasurable f μ) (hg : AEMeasurable g μ) :
     AEMeasurable (fun x => f x ^ g x) μ :=
   measurable_pow.comp_aemeasurable (hf.prodMk hg)
 
-@[fun_prop, measurability]
+@[fun_prop]
 theorem Measurable.pow_const (hf : Measurable f) (c : γ) : Measurable fun x => f x ^ c :=
   hf.pow measurable_const
 
-@[fun_prop, measurability]
+@[fun_prop]
 theorem AEMeasurable.pow_const (hf : AEMeasurable f μ) (c : γ) :
     AEMeasurable (fun x => f x ^ c) μ :=
   hf.pow aemeasurable_const
 
-@[fun_prop, measurability]
+@[fun_prop]
 theorem Measurable.const_pow (hg : Measurable g) (c : β) : Measurable fun x => c ^ g x :=
   measurable_const.pow hg
 
-@[fun_prop, measurability]
+@[fun_prop]
 theorem AEMeasurable.const_pow (hg : AEMeasurable g μ) (c : β) :
     AEMeasurable (fun x => c ^ g x) μ :=
   aemeasurable_const.pow hg
@@ -248,22 +248,22 @@ section Div
 variable {G α β : Type*} [MeasurableSpace G] [Div G] {m : MeasurableSpace α}
   {mβ : MeasurableSpace β} {f g : α → G} {μ : Measure α}
 
-@[to_additive (attr := fun_prop, measurability)]
+@[to_additive (attr := fun_prop)]
 theorem Measurable.const_div [MeasurableDiv G] (hf : Measurable f) (c : G) :
     Measurable fun x => c / f x :=
   (MeasurableDiv.measurable_const_div c).comp hf
 
-@[to_additive (attr := fun_prop, measurability)]
+@[to_additive (attr := fun_prop)]
 theorem AEMeasurable.const_div [MeasurableDiv G] (hf : AEMeasurable f μ) (c : G) :
     AEMeasurable (fun x => c / f x) μ :=
   (MeasurableDiv.measurable_const_div c).comp_aemeasurable hf
 
-@[to_additive (attr := fun_prop, measurability)]
+@[to_additive (attr := fun_prop)]
 theorem Measurable.div_const [MeasurableDiv G] (hf : Measurable f) (c : G) :
     Measurable fun x => f x / c :=
   (MeasurableDiv.measurable_div_const c).comp hf
 
-@[to_additive (attr := fun_prop, measurability)]
+@[to_additive (attr := fun_prop)]
 theorem AEMeasurable.div_const [MeasurableDiv G] (hf : AEMeasurable f μ) (c : G) :
     AEMeasurable (fun x => f x / c) μ :=
   (MeasurableDiv.measurable_div_const c).comp_aemeasurable hf
@@ -356,11 +356,11 @@ section Inv
 variable {G α : Type*} [Inv G] [MeasurableSpace G] [MeasurableInv G] {m : MeasurableSpace α}
   {f : α → G} {μ : Measure α}
 
-@[to_additive (attr := fun_prop, measurability)]
+@[to_additive (attr := fun_prop)]
 theorem Measurable.inv (hf : Measurable f) : Measurable fun x => (f x)⁻¹ :=
   measurable_inv.comp hf
 
-@[to_additive (attr := fun_prop, measurability)]
+@[to_additive (attr := fun_prop)]
 theorem AEMeasurable.inv (hf : AEMeasurable f μ) : AEMeasurable (fun x => (f x)⁻¹) μ :=
   measurable_inv.comp_aemeasurable hf
 
@@ -520,7 +520,7 @@ variable {M X α β : Type*} [MeasurableSpace X] [SMul M X]
 section MeasurableConstSMul
 variable [MeasurableConstSMul M X]
 
-@[to_additive (attr := fun_prop, measurability)]
+@[to_additive (attr := fun_prop)]
 lemma Measurable.const_smul (hg : Measurable g) (c : M) : Measurable (c • g) :=
   (measurable_const_smul c).comp hg
 
@@ -533,13 +533,13 @@ lemma Measurable.fun_const_smul {g : α → β → X} {h : α → β} (hg : Meas
 
 @[deprecated (since := "2025-04-23")] alias Measurable.const_smul' := Measurable.fun_const_smul
 
-@[to_additive (attr := fun_prop, measurability)]
+@[to_additive (attr := fun_prop)]
 lemma AEMeasurable.fun_const_smul (hg : AEMeasurable g μ) (c : M) : AEMeasurable (c • g ·) μ :=
   (measurable_const_smul c).comp_aemeasurable hg
 
 @[deprecated (since := "2025-04-23")] alias AEMeasurable.const_smul' := AEMeasurable.fun_const_smul
 
-@[to_additive (attr := fun_prop, measurability)]
+@[to_additive (attr := fun_prop)]
 lemma AEMeasurable.const_smul (hf : AEMeasurable g μ) (c : M) : AEMeasurable (c • g) μ :=
   hf.fun_const_smul c
 
@@ -584,11 +584,11 @@ instance (priority := 100) MeasurableSMul₂.toMeasurableSMul [MeasurableSMul₂
 
 variable [MeasurableSMul M X]
 
-@[to_additive (attr := fun_prop, measurability)]
+@[to_additive (attr := fun_prop)]
 theorem Measurable.smul_const (hf : Measurable f) (y : X) : Measurable fun x => f x • y :=
   (MeasurableSMul.measurable_smul_const y).comp hf
 
-@[to_additive (attr := fun_prop, measurability)]
+@[to_additive (attr := fun_prop)]
 theorem AEMeasurable.smul_const (hf : AEMeasurable f μ) (y : X) :
     AEMeasurable (fun x => f x • y) μ :=
   (MeasurableSMul.measurable_smul_const y).comp_aemeasurable hf

--- a/Mathlib/MeasureTheory/Integral/CircleIntegral.lean
+++ b/Mathlib/MeasureTheory/Integral/CircleIntegral.lean
@@ -120,7 +120,7 @@ theorem contDiff_circleMap (c : ℂ) (R : ℝ) {n : WithTop ℕ∞} :
 theorem continuous_circleMap (c : ℂ) (R : ℝ) : Continuous (circleMap c R) :=
   (differentiable_circleMap c R).continuous
 
-@[fun_prop, measurability]
+@[fun_prop]
 theorem measurable_circleMap (c : ℂ) (R : ℝ) : Measurable (circleMap c R) :=
   (continuous_circleMap c R).measurable
 

--- a/Mathlib/MeasureTheory/Integral/IntervalIntegral/Periodic.lean
+++ b/Mathlib/MeasureTheory/Integral/IntervalIntegral/Periodic.lean
@@ -36,7 +36,7 @@ open scoped MeasureTheory NNReal ENNReal
 ## Measures and integrability on ℝ and on the circle
 -/
 
-@[measurability]
+@[fun_prop]
 protected theorem AddCircle.measurable_mk' {a : ℝ} :
     Measurable (β := AddCircle a) ((↑) : ℝ → AddCircle a) :=
   Continuous.measurable <| AddCircle.continuous_mk' a

--- a/Mathlib/MeasureTheory/MeasurableSpace/Basic.lean
+++ b/Mathlib/MeasureTheory/MeasurableSpace/Basic.lean
@@ -230,7 +230,7 @@ theorem Subsingleton.measurable [Subsingleton α] : Measurable f := fun _ _ =>
 theorem measurable_of_subsingleton_codomain [Subsingleton β] (f : α → β) : Measurable f :=
   fun s _ => Subsingleton.set_cases MeasurableSet.empty MeasurableSet.univ s
 
-@[to_additive (attr := measurability, fun_prop)]
+@[to_additive (attr := fun_prop)]
 theorem measurable_one [One α] : Measurable (1 : β → α) :=
   @measurable_const _ _ _ _ 1
 
@@ -248,11 +248,11 @@ theorem measurable_const' {f : β → α} (hf : ∀ x y, f x = f y) : Measurable
   convert @measurable_const α β _ _ (f default) using 2
   apply hf
 
-@[measurability]
+@[fun_prop]
 theorem measurable_natCast [NatCast α] (n : ℕ) : Measurable (n : β → α) :=
   @measurable_const α _ _ _ n
 
-@[measurability]
+@[fun_prop]
 theorem measurable_intCast [IntCast α] (n : ℤ) : Measurable (n : β → α) :=
   @measurable_const α _ _ _ n
 
@@ -267,7 +267,7 @@ end TypeclassMeasurableSpace
 
 variable {m : MeasurableSpace α}
 
-@[measurability]
+@[fun_prop]
 theorem Measurable.iterate {f : α → α} (hf : Measurable f) : ∀ n, Measurable f^[n]
   | 0 => measurable_id
   | n + 1 => (Measurable.iterate hf n).comp hf
@@ -283,7 +283,7 @@ protected theorem MeasurableSet.preimage {t : Set β} (ht : MeasurableSet t) (hf
     MeasurableSet (f ⁻¹' t) :=
   hf ht
 
-@[measurability, fun_prop]
+@[fun_prop]
 protected theorem Measurable.piecewise {_ : DecidablePred (· ∈ s)} (hs : MeasurableSet s)
     (hf : Measurable f) (hg : Measurable g) : Measurable (piecewise s f g) := by
   intro t ht
@@ -298,7 +298,7 @@ theorem Measurable.ite {p : α → Prop} {_ : DecidablePred p} (hp : MeasurableS
     (hf : Measurable f) (hg : Measurable g) : Measurable fun x => ite (p x) (f x) (g x) :=
   Measurable.piecewise hp hf hg
 
-@[measurability, fun_prop]
+@[fun_prop]
 theorem Measurable.indicator [Zero β] (hf : Measurable f) (hs : MeasurableSet s) :
     Measurable (s.indicator f) :=
   hf.piecewise hs measurable_const

--- a/Mathlib/MeasureTheory/MeasurableSpace/Constructions.lean
+++ b/Mathlib/MeasureTheory/MeasurableSpace/Constructions.lean
@@ -148,18 +148,18 @@ theorem measurable_from_quotient {s : Setoid α} {f : Quotient s → β} :
     Measurable f ↔ Measurable (f ∘ Quotient.mk'') :=
   Iff.rfl
 
-@[measurability]
+@[fun_prop]
 theorem measurable_quotient_mk' [s : Setoid α] : Measurable (Quotient.mk' : α → Quotient s) :=
   fun _ => id
 
-@[measurability]
+@[fun_prop]
 theorem measurable_quotient_mk'' {s : Setoid α} : Measurable (Quotient.mk'' : α → Quotient s) :=
   fun _ => id
 
-@[measurability]
+@[fun_prop]
 theorem measurable_quot_mk {r : α → α → Prop} : Measurable (Quot.mk r) := fun _ => id
 
-@[to_additive (attr := measurability)]
+@[to_additive (attr := fun_prop)]
 theorem QuotientGroup.measurable_coe {G} [Group G] [MeasurableSpace G] {S : Subgroup G} :
     Measurable ((↑) : G → G ⧸ S) :=
   measurable_quotient_mk''
@@ -213,19 +213,19 @@ theorem MeasurableSet.subtype_image {s : Set α} {t : Set s} (hs : MeasurableSet
   rw [Subtype.image_preimage_coe]
   exact hs.inter hu
 
-@[measurability]
+@[fun_prop]
 theorem Measurable.subtype_coe {p : β → Prop} {f : α → Subtype p} (hf : Measurable f) :
     Measurable fun a : α => (f a : β) :=
   measurable_subtype_coe.comp hf
 
 alias Measurable.subtype_val := Measurable.subtype_coe
 
-@[measurability]
+@[fun_prop]
 theorem Measurable.subtype_mk {p : β → Prop} {f : α → β} (hf : Measurable f) {h : ∀ x, p (f x)} :
     Measurable fun x => (⟨f x, h x⟩ : Subtype p) := fun t ⟨s, hs⟩ =>
   hs.2 ▸ by simp only [← preimage_comp, Function.comp_def, hf hs.1]
 
-@[measurability]
+@[fun_prop]
 protected theorem Measurable.rangeFactorization {f : α → β} (hf : Measurable f) :
     Measurable (rangeFactorization f) :=
   hf.subtype_mk
@@ -425,7 +425,7 @@ theorem measurable_fun_prod {f : α → β × γ} :
     Measurable f ↔ (Measurable fun a => (f a).1) ∧ Measurable fun a => (f a).2 :=
   ⟨fun hf => ⟨measurable_fst.comp hf, measurable_snd.comp hf⟩, fun h => Measurable.prod h.1 h.2⟩
 
-@[fun_prop, measurability]
+@[fun_prop]
 theorem measurable_swap : Measurable (Prod.swap : α × β → β × α) :=
   Measurable.prod measurable_snd measurable_fst
 
@@ -582,7 +582,7 @@ theorem measurable_pi_lambda (f : α → ∀ a, X a) (hf : ∀ a, Measurable fun
   measurable_pi_iff.mpr hf
 
 /-- The function `(f, x) ↦ update f a x : (Π a, X a) × X a → Π a, X a` is measurable. -/
-@[measurability, fun_prop]
+@[fun_prop]
 theorem measurable_update' {a : δ} [DecidableEq δ] :
     Measurable (fun p : (∀ i, X i) × X a ↦ update p.1 a p.2) := by
   rw [measurable_pi_iff]
@@ -594,24 +594,24 @@ theorem measurable_update' {a : δ} [DecidableEq δ] :
     exact measurable_snd
   · exact measurable_pi_iff.1 measurable_fst _
 
-@[measurability, fun_prop]
+@[fun_prop]
 theorem measurable_uniqueElim [Unique δ] :
     Measurable (uniqueElim : X (default : δ) → ∀ i, X i) := by
   simp_rw [measurable_pi_iff, Unique.forall_iff, uniqueElim_default]; exact measurable_id
 
-@[measurability, fun_prop]
+@[fun_prop]
 theorem measurable_updateFinset' [DecidableEq δ] {s : Finset δ} :
     Measurable (fun p : (Π i, X i) × (Π i : s, X i) ↦ updateFinset p.1 s p.2) := by
   simp only [updateFinset, measurable_pi_iff]
   intro i
   by_cases h : i ∈ s <;> simp [h, Measurable.eval, measurable_fst, measurable_snd]
 
-@[measurability, fun_prop]
+@[fun_prop]
 theorem measurable_updateFinset [DecidableEq δ] {s : Finset δ} {x : Π i, X i} :
     Measurable (updateFinset x s) :=
   measurable_updateFinset'.comp measurable_prodMk_left
 
-@[measurability, fun_prop]
+@[fun_prop]
 theorem measurable_updateFinset_left [DecidableEq δ] {s : Finset δ} {x : Π i : s, X i} :
     Measurable (updateFinset · s x) :=
   measurable_updateFinset'.comp measurable_prodMk_right
@@ -619,47 +619,47 @@ theorem measurable_updateFinset_left [DecidableEq δ] {s : Finset δ} {x : Π i 
 /-- The function `update f a : X a → Π a, X a` is always measurable.
   This doesn't require `f` to be measurable.
   This should not be confused with the statement that `update f a x` is measurable. -/
-@[measurability, fun_prop]
+@[fun_prop]
 theorem measurable_update (f : ∀ a : δ, X a) {a : δ} [DecidableEq δ] : Measurable (update f a) :=
   measurable_update'.comp measurable_prodMk_left
 
-@[measurability, fun_prop]
+@[fun_prop]
 theorem measurable_update_left {a : δ} [DecidableEq δ] {x : X a} :
     Measurable (update · a x) :=
   measurable_update'.comp measurable_prodMk_right
 
-@[measurability, fun_prop]
+@[fun_prop]
 theorem Set.measurable_restrict (s : Set δ) : Measurable (s.restrict (π := X)) :=
   measurable_pi_lambda _ fun _ ↦ measurable_pi_apply _
 
-@[measurability, fun_prop]
+@[fun_prop]
 theorem Set.measurable_restrict₂ {s t : Set δ} (hst : s ⊆ t) :
     Measurable (restrict₂ (π := X) hst) :=
   measurable_pi_lambda _ fun _ ↦ measurable_pi_apply _
 
-@[measurability, fun_prop]
+@[fun_prop]
 theorem Finset.measurable_restrict (s : Finset δ) : Measurable (s.restrict (π := X)) :=
   measurable_pi_lambda _ fun _ ↦ measurable_pi_apply _
 
-@[measurability, fun_prop]
+@[fun_prop]
 theorem Finset.measurable_restrict₂ {s t : Finset δ} (hst : s ⊆ t) :
     Measurable (Finset.restrict₂ (π := X) hst) :=
   measurable_pi_lambda _ fun _ ↦ measurable_pi_apply _
 
-@[measurability, fun_prop]
+@[fun_prop]
 theorem Set.measurable_restrict_apply (s : Set α) {f : α → γ} (hf : Measurable f) :
     Measurable (s.restrict f) := hf.comp measurable_subtype_coe
 
-@[measurability, fun_prop]
+@[fun_prop]
 theorem Set.measurable_restrict₂_apply {s t : Set α} (hst : s ⊆ t)
     {f : t → γ} (hf : Measurable f) :
     Measurable (restrict₂ (π := fun _ ↦ γ) hst f) := hf.comp (measurable_inclusion hst)
 
-@[measurability, fun_prop]
+@[fun_prop]
 theorem Finset.measurable_restrict_apply (s : Finset α) {f : α → γ} (hf : Measurable f) :
     Measurable (s.restrict f) := hf.comp measurable_subtype_coe
 
-@[measurability, fun_prop]
+@[fun_prop]
 theorem Finset.measurable_restrict₂_apply {s t : Finset α} (hst : s ⊆ t)
     {f : t → γ} (hf : Measurable f) :
     Measurable (restrict₂ (π := fun _ ↦ γ) hst f) := hf.comp (measurable_inclusion hst)
@@ -674,7 +674,7 @@ theorem Measurable.eq_mp {β} [MeasurableSpace β] {i i' : δ} (h : i = i') {f :
     (hf : Measurable f) : Measurable fun x => (congr_arg X h).mp (f x) :=
   (measurable_eq_mp X h).comp hf
 
-@[measurability, fun_prop]
+@[fun_prop]
 theorem measurable_piCongrLeft (f : δ' ≃ δ) : Measurable (Equiv.piCongrLeft X f) := by
   rw [measurable_pi_iff]
   intro i
@@ -714,7 +714,7 @@ instance Pi.instMeasurableSingletonClass [Countable δ] [∀ a, MeasurableSingle
 
 variable (X)
 
-@[measurability]
+@[fun_prop]
 theorem measurable_piEquivPiSubtypeProd_symm (p : δ → Prop) [DecidablePred p] :
     Measurable (Equiv.piEquivPiSubtypeProd p X).symm := by
   refine measurable_pi_iff.2 fun j => ?_
@@ -728,7 +728,7 @@ theorem measurable_piEquivPiSubtypeProd_symm (p : δ → Prop) [DecidablePred p]
       measurable_pi_apply (X := fun i : {x // ¬p x} => X i.1) ⟨j, hj⟩
     exact Measurable.comp this measurable_snd
 
-@[measurability]
+@[fun_prop]
 theorem measurable_piEquivPiSubtypeProd (p : δ → Prop) [DecidablePred p] :
     Measurable (Equiv.piEquivPiSubtypeProd p X) :=
   (measurable_pi_iff.2 fun _ => measurable_pi_apply _).prodMk
@@ -780,11 +780,11 @@ instance Sum.instMeasurableSpace {α β} [m₁ : MeasurableSpace α] [m₂ : Mea
 
 section Sum
 
-@[measurability]
+@[fun_prop]
 theorem measurable_inl [MeasurableSpace α] [MeasurableSpace β] : Measurable (@Sum.inl α β) :=
   Measurable.of_le_map inf_le_left
 
-@[measurability]
+@[fun_prop]
 theorem measurable_inr [MeasurableSpace α] [MeasurableSpace β] : Measurable (@Sum.inr α β) :=
   Measurable.of_le_map inf_le_right
 
@@ -800,7 +800,7 @@ theorem measurable_fun_sum {_ : MeasurableSpace γ} {f : α ⊕ β → γ} (hl :
     le_inf (MeasurableSpace.comap_le_iff_le_map.2 <| hl)
       (MeasurableSpace.comap_le_iff_le_map.2 <| hr)
 
-@[measurability]
+@[fun_prop]
 theorem Measurable.sumElim {_ : MeasurableSpace γ} {f : α → γ} {g : β → γ} (hf : Measurable f)
     (hg : Measurable g) : Measurable (Sum.elim f g) :=
   measurable_fun_sum hf hg
@@ -958,17 +958,17 @@ section Function
 
 variable {κ X : Type*} [MeasurableSpace X]
 
-@[fun_prop, measurability]
+@[fun_prop]
 lemma measurable_curry : Measurable (@curry ι κ X) :=
   measurable_pi_lambda _ fun _ ↦ measurable_pi_lambda _ fun _ ↦ measurable_pi_apply _
 
 -- This cannot be tagged with `fun_prop` because `fun_prop` can see through `Function.uncurry`.
 lemma measurable_uncurry : Measurable (@uncurry ι κ X) := by fun_prop
 
-@[fun_prop, measurability]
+@[fun_prop]
 lemma measurable_equivCurry : Measurable (Equiv.curry ι κ X) := measurable_curry
 
-@[fun_prop, measurability]
+@[fun_prop]
 lemma measurable_equivCurry_symm : Measurable (Equiv.curry ι κ X).symm := measurable_uncurry
 
 end Function
@@ -977,20 +977,20 @@ section Sigma
 
 variable {κ : ι → Type*} {X : (i : ι) → κ i → Type*} [∀ i j, MeasurableSpace (X i j)]
 
-@[fun_prop, measurability]
+@[fun_prop]
 lemma measurable_sigmaCurry : Measurable (Sigma.curry (γ := X)) :=
     measurable_pi_lambda _ fun _ ↦ measurable_pi_lambda _ fun _ ↦ measurable_pi_apply _
 
-@[fun_prop, measurability]
+@[fun_prop]
 lemma measurable_sigmaUncurry : Measurable (Sigma.uncurry (γ := X)) := by
   refine measurable_pi_lambda _ fun _ ↦ ?_
   simp only [Sigma.uncurry]
   fun_prop
 
-@[fun_prop, measurability]
+@[fun_prop]
 lemma measurable_piCurry : Measurable (Equiv.piCurry X) := measurable_sigmaCurry
 
-@[fun_prop, measurability]
+@[fun_prop]
 lemma measurable_piCurry_symm : Measurable (Equiv.piCurry X).symm := measurable_sigmaUncurry
 
 end Sigma

--- a/Mathlib/MeasureTheory/MeasurableSpace/Defs.lean
+++ b/Mathlib/MeasureTheory/MeasurableSpace/Defs.lean
@@ -508,7 +508,7 @@ section MeasurableFunctions
 
 theorem measurable_id {_ : MeasurableSpace α} : Measurable (@id α) := fun _ => id
 
-@[fun_prop, measurability]
+@[fun_prop]
 theorem measurable_id' {_ : MeasurableSpace α} : Measurable fun a : α => a := measurable_id
 
 protected theorem Measurable.comp {_ : MeasurableSpace α} {_ : MeasurableSpace β}
@@ -521,7 +521,7 @@ protected theorem Measurable.comp' {_ : MeasurableSpace α} {_ : MeasurableSpace
     {_ : MeasurableSpace γ} {g : β → γ} {f : α → β} (hg : Measurable g) (hf : Measurable f) :
     Measurable (fun x => g (f x)) := Measurable.comp hg hf
 
-@[simp, fun_prop, measurability]
+@[simp, fun_prop]
 theorem measurable_const {_ : MeasurableSpace α} {_ : MeasurableSpace β} {a : α} :
     Measurable fun _ : β => a := fun s _ => .const (a ∈ s)
 
@@ -549,7 +549,7 @@ variable [MeasurableSpace α] [MeasurableSpace β] [DiscreteMeasurableSpace α] 
 @[measurability] lemma MeasurableSet.of_discrete : MeasurableSet s :=
   DiscreteMeasurableSpace.forall_measurableSet _
 
-@[measurability, fun_prop] lemma Measurable.of_discrete : Measurable f := fun _ _ ↦ .of_discrete
+@[fun_prop] lemma Measurable.of_discrete : Measurable f := fun _ _ ↦ .of_discrete
 
 /-- Warning: Creates a typeclass loop with `MeasurableSingletonClass.toDiscreteMeasurableSpace`.
 To be monitored. -/

--- a/Mathlib/MeasureTheory/MeasurableSpace/Embedding.lean
+++ b/Mathlib/MeasureTheory/MeasurableSpace/Embedding.lean
@@ -194,7 +194,7 @@ instance instEquivLike : EquivLike (α ≃ᵐ β) α β where
 theorem coe_toEquiv (e : α ≃ᵐ β) : (e.toEquiv : α → β) = e :=
   rfl
 
-@[measurability, fun_prop]
+@[fun_prop]
 protected theorem measurable (e : α ≃ᵐ β) : Measurable (e : α → β) :=
   e.measurable_toFun
 
@@ -775,7 +775,7 @@ def invFun [Nonempty α] (hf : MeasurableEmbedding f) (x : β) : α :=
   open Classical in
   if hx : x ∈ range f then hf.equivRange.symm ⟨x, hx⟩ else (Nonempty.some inferInstance)
 
-@[fun_prop, measurability]
+@[fun_prop]
 lemma measurable_invFun [Nonempty α] (hf : MeasurableEmbedding f) :
     Measurable (hf.invFun : β → α) :=
   open Classical in

--- a/Mathlib/MeasureTheory/MeasurableSpace/NCard.lean
+++ b/Mathlib/MeasureTheory/MeasurableSpace/NCard.lean
@@ -21,11 +21,11 @@ open Set
 
 variable {α : Type*} [Countable α]
 
-@[measurability]
+@[fun_prop]
 theorem measurable_encard : Measurable (Set.encard : Set α → ℕ∞) :=
   ENat.measurable_iff.2 fun _n ↦ Countable.measurableSet <| Countable.setOf_finite.mono fun _s hs ↦
     finite_of_encard_eq_coe hs
 
-@[measurability]
+@[fun_prop]
 theorem measurable_ncard : Measurable (Set.ncard : Set α → ℕ) :=
   Measurable.of_discrete.comp measurable_encard

--- a/Mathlib/MeasureTheory/MeasurableSpace/PreorderRestrict.lean
+++ b/Mathlib/MeasureTheory/MeasurableSpace/PreorderRestrict.lean
@@ -23,21 +23,21 @@ namespace Preorder
 
 variable {α : Type*} [Preorder α] {X : α → Type*} [∀ a, MeasurableSpace (X a)]
 
-@[measurability, fun_prop]
+@[fun_prop]
 theorem measurable_restrictLe (a : α) : Measurable (restrictLe (π := X) a) :=
     Set.measurable_restrict _
 
-@[measurability, fun_prop]
+@[fun_prop]
 theorem measurable_restrictLe₂ {a b : α} (hab : a ≤ b) : Measurable (restrictLe₂ (π := X) hab) :=
   Set.measurable_restrict₂ _
 
 variable [LocallyFiniteOrderBot α]
 
-@[measurability, fun_prop]
+@[fun_prop]
 theorem measurable_frestrictLe (a : α) : Measurable (frestrictLe (π := X) a) :=
   Finset.measurable_restrict _
 
-@[measurability, fun_prop]
+@[fun_prop]
 theorem measurable_frestrictLe₂ {a b : α} (hab : a ≤ b) : Measurable (frestrictLe₂ (π := X) hab) :=
   Finset.measurable_restrict₂ _
 

--- a/Mathlib/MeasureTheory/Measure/AEMeasurable.lean
+++ b/Mathlib/MeasureTheory/Measure/AEMeasurable.lean
@@ -172,17 +172,17 @@ theorem map_map_of_aemeasurable {g : β → γ} {f : α → β} (hg : AEMeasurab
   rw [map_apply_of_aemeasurable hg hs, map_apply₀ hf (hg.nullMeasurable hs),
     map_apply_of_aemeasurable (hg.comp_aemeasurable hf) hs, preimage_comp]
 
-@[fun_prop, measurability]
+@[fun_prop]
 protected theorem fst {f : α → β × γ} (hf : AEMeasurable f μ) :
     AEMeasurable (fun x ↦ (f x).1) μ :=
   measurable_fst.comp_aemeasurable hf
 
-@[fun_prop, measurability]
+@[fun_prop]
 protected theorem snd {f : α → β × γ} (hf : AEMeasurable f μ) :
     AEMeasurable (fun x ↦ (f x).2) μ :=
   measurable_snd.comp_aemeasurable hf
 
-@[fun_prop, measurability]
+@[fun_prop]
 theorem prodMk {f : α → β} {g : α → γ} (hf : AEMeasurable f μ) (hg : AEMeasurable g μ) :
     AEMeasurable (fun x => (f x, g x)) μ :=
   ⟨fun a => (hf.mk f a, hg.mk g a), hf.measurable_mk.prodMk hg.measurable_mk,
@@ -345,7 +345,7 @@ lemma aemeasurable_indicator_const_iff {s} [MeasurableSingletonClass β] (b : β
     simp [NeZero.ne b]
   · exact (aemeasurable_indicator_iff₀ h).mpr aemeasurable_const
 
-@[measurability]
+@[fun_prop]
 theorem AEMeasurable.indicator (hfm : AEMeasurable f μ) {s} (hs : MeasurableSet s) :
     AEMeasurable (s.indicator f) μ :=
   (aemeasurable_indicator_iff hs).mpr hfm.restrict

--- a/Mathlib/MeasureTheory/Measure/CharacteristicFunction.lean
+++ b/Mathlib/MeasureTheory/Measure/CharacteristicFunction.lean
@@ -182,12 +182,12 @@ lemma norm_one_sub_charFun_le_two [IsProbabilityMeasure μ] : ‖1 - charFun μ 
   _ ≤ 1 + 1 := by simp [norm_charFun_le_one]
   _ = 2 := by norm_num
 
-@[fun_prop, measurability]
+@[fun_prop]
 lemma stronglyMeasurable_charFun [OpensMeasurableSpace E] [SecondCountableTopology E] [SFinite μ] :
     StronglyMeasurable (charFun μ) :=
   (Measurable.stronglyMeasurable (by fun_prop)).integral_prod_left
 
-@[fun_prop, measurability]
+@[fun_prop]
 lemma measurable_charFun [OpensMeasurableSpace E] [SecondCountableTopology E] [SFinite μ] :
     Measurable (charFun μ) :=
   stronglyMeasurable_charFun.measurable

--- a/Mathlib/MeasureTheory/Measure/Decomposition/Lebesgue.lean
+++ b/Mathlib/MeasureTheory/Measure/Decomposition/Lebesgue.lean
@@ -96,7 +96,7 @@ lemma singularPart_of_not_haveLebesgueDecomposition (h : ¬ HaveLebesgueDecompos
     μ.singularPart ν = 0 := by
   rw [singularPart, dif_neg h]
 
-@[measurability, fun_prop]
+@[fun_prop]
 theorem measurable_rnDeriv (μ ν : Measure α) : Measurable <| μ.rnDeriv ν := by
   by_cases h : HaveLebesgueDecomposition μ ν
   · exact (haveLebesgueDecomposition_spec μ ν).1

--- a/Mathlib/MeasureTheory/Measure/LogLikelihoodRatio.lean
+++ b/Mathlib/MeasureTheory/Measure/LogLikelihoodRatio.lean
@@ -79,11 +79,11 @@ lemma exp_neg_llr' [SigmaFinite μ] [SigmaFinite ν] (hμν : ν ≪ μ) :
   rw [Pi.neg_apply, neg_eq_iff_eq_neg] at hx
   rw [← hx, hx_exp_log]
 
-@[measurability, fun_prop]
+@[fun_prop]
 lemma measurable_llr (μ ν : Measure α) : Measurable (llr μ ν) :=
   (Measure.measurable_rnDeriv μ ν).ennreal_toReal.log
 
-@[measurability]
+@[fun_prop]
 lemma stronglyMeasurable_llr (μ ν : Measure α) : StronglyMeasurable (llr μ ν) :=
   (measurable_llr μ ν).stronglyMeasurable
 

--- a/Mathlib/MeasureTheory/Measure/MeasureSpaceDef.lean
+++ b/Mathlib/MeasureTheory/Measure/MeasureSpaceDef.lean
@@ -430,7 +430,7 @@ it shows in pretty-printing. -/
 def mk (f : α → β) (h : AEMeasurable f μ) : α → β :=
   Classical.choose h
 
-@[measurability]
+@[fun_prop]
 theorem measurable_mk (h : AEMeasurable f μ) : Measurable (h.mk f) :=
   (Classical.choose_spec h).1
 
@@ -445,15 +445,15 @@ end AEMeasurable
 theorem aemeasurable_congr (h : f =ᵐ[μ] g) : AEMeasurable f μ ↔ AEMeasurable g μ :=
   ⟨fun hf => AEMeasurable.congr hf h, fun hg => AEMeasurable.congr hg h.symm⟩
 
-@[simp, fun_prop, measurability]
+@[simp, fun_prop]
 theorem aemeasurable_const {b : β} : AEMeasurable (fun _a : α => b) μ :=
   measurable_const.aemeasurable
 
-@[fun_prop, measurability]
+@[fun_prop]
 theorem aemeasurable_id : AEMeasurable id μ :=
   measurable_id.aemeasurable
 
-@[fun_prop, measurability]
+@[fun_prop]
 theorem aemeasurable_id' : AEMeasurable (fun x => x) μ :=
   measurable_id.aemeasurable
 
@@ -461,7 +461,7 @@ theorem Measurable.comp_aemeasurable [MeasurableSpace δ] {f : α → δ} {g : �
     (hf : AEMeasurable f μ) : AEMeasurable (g ∘ f) μ :=
   ⟨g ∘ hf.mk f, hg.comp hf.measurable_mk, EventuallyEq.fun_comp hf.ae_eq_mk _⟩
 
-@[fun_prop, measurability]
+@[fun_prop]
 theorem Measurable.comp_aemeasurable' [MeasurableSpace δ] {f : α → δ} {g : δ → β}
     (hg : Measurable g) (hf : AEMeasurable f μ) : AEMeasurable (fun x ↦ g (f x)) μ :=
   Measurable.comp_aemeasurable hg hf

--- a/Mathlib/MeasureTheory/Order/Group/Lattice.lean
+++ b/Mathlib/MeasureTheory/Order/Group/Lattice.lean
@@ -22,37 +22,37 @@ measurable function, group, lattice operation
 variable {α β : Type*} [Lattice α] [Group α] [MeasurableSpace α]
   [MeasurableSpace β] {f : β → α}
 
-@[to_additive (attr := measurability)]
+@[to_additive]
 theorem measurable_oneLePart [MeasurableSup α] : Measurable (oneLePart : α → α) :=
   measurable_sup_const _
 
-@[to_additive (attr := measurability)]
+@[to_additive (attr := fun_prop)]
 protected theorem Measurable.oneLePart [MeasurableSup α] (hf : Measurable f) :
     Measurable fun x ↦ oneLePart (f x) :=
   measurable_oneLePart.comp hf
 
 variable [MeasurableInv α]
 
-@[to_additive (attr := measurability)]
+@[to_additive]
 theorem measurable_leOnePart [MeasurableSup α] : Measurable (leOnePart : α → α) :=
   (measurable_sup_const _).comp measurable_inv
 
-@[to_additive (attr := measurability)]
+@[to_additive (attr := fun_prop)]
 protected theorem Measurable.leOnePart [MeasurableSup α] (hf : Measurable f) :
     Measurable fun x ↦ leOnePart (f x) :=
   measurable_leOnePart.comp hf
 
 variable [MeasurableSup₂ α]
 
-@[to_additive (attr := measurability)]
+@[to_additive]
 theorem measurable_mabs : Measurable (mabs : α → α) :=
   measurable_id'.sup measurable_inv
 
-@[to_additive (attr := measurability, fun_prop)]
+@[to_additive (attr := fun_prop)]
 protected theorem Measurable.mabs (hf : Measurable f) : Measurable fun x ↦ mabs (f x) :=
   measurable_mabs.comp hf
 
-@[to_additive (attr := measurability, fun_prop)]
+@[to_additive (attr := fun_prop)]
 protected theorem AEMeasurable.mabs {μ : MeasureTheory.Measure β} (hf : AEMeasurable f μ) :
     AEMeasurable (fun x ↦ mabs (f x)) μ :=
   measurable_mabs.comp_aemeasurable hf

--- a/Mathlib/MeasureTheory/Order/Lattice.lean
+++ b/Mathlib/MeasureTheory/Order/Lattice.lean
@@ -96,20 +96,20 @@ section MeasurableSup
 
 variable [MeasurableSup M]
 
-@[measurability]
+@[fun_prop]
 theorem Measurable.const_sup (hf : Measurable f) (c : M) : Measurable fun x => c ⊔ f x :=
   (measurable_const_sup c).comp hf
 
-@[measurability]
+@[fun_prop]
 theorem AEMeasurable.const_sup (hf : AEMeasurable f μ) (c : M) :
     AEMeasurable (fun x => c ⊔ f x) μ :=
   (MeasurableSup.measurable_const_sup c).comp_aemeasurable hf
 
-@[measurability]
+@[fun_prop]
 theorem Measurable.sup_const (hf : Measurable f) (c : M) : Measurable fun x => f x ⊔ c :=
   (measurable_sup_const c).comp hf
 
-@[measurability]
+@[fun_prop]
 theorem AEMeasurable.sup_const (hf : AEMeasurable f μ) (c : M) :
     AEMeasurable (fun x => f x ⊔ c) μ :=
   (measurable_sup_const c).comp_aemeasurable hf
@@ -120,20 +120,20 @@ section MeasurableSup₂
 
 variable [MeasurableSup₂ M]
 
-@[measurability]
+@[fun_prop]
 theorem Measurable.sup' (hf : Measurable f) (hg : Measurable g) : Measurable (f ⊔ g) :=
   measurable_sup.comp (hf.prodMk hg)
 
-@[measurability]
+@[fun_prop]
 theorem Measurable.sup (hf : Measurable f) (hg : Measurable g) : Measurable fun a => f a ⊔ g a :=
   measurable_sup.comp (hf.prodMk hg)
 
-@[measurability]
+@[fun_prop]
 theorem AEMeasurable.sup' (hf : AEMeasurable f μ) (hg : AEMeasurable g μ) :
     AEMeasurable (f ⊔ g) μ :=
   measurable_sup.comp_aemeasurable (hf.prodMk hg)
 
-@[measurability]
+@[fun_prop]
 theorem AEMeasurable.sup (hf : AEMeasurable f μ) (hg : AEMeasurable g μ) :
     AEMeasurable (fun a => f a ⊔ g a) μ :=
   measurable_sup.comp_aemeasurable (hf.prodMk hg)
@@ -153,20 +153,20 @@ section MeasurableInf
 
 variable [MeasurableInf M]
 
-@[measurability]
+@[fun_prop]
 theorem Measurable.const_inf (hf : Measurable f) (c : M) : Measurable fun x => c ⊓ f x :=
   (measurable_const_inf c).comp hf
 
-@[measurability]
+@[fun_prop]
 theorem AEMeasurable.const_inf (hf : AEMeasurable f μ) (c : M) :
     AEMeasurable (fun x => c ⊓ f x) μ :=
   (MeasurableInf.measurable_const_inf c).comp_aemeasurable hf
 
-@[measurability]
+@[fun_prop]
 theorem Measurable.inf_const (hf : Measurable f) (c : M) : Measurable fun x => f x ⊓ c :=
   (measurable_inf_const c).comp hf
 
-@[measurability]
+@[fun_prop]
 theorem AEMeasurable.inf_const (hf : AEMeasurable f μ) (c : M) :
     AEMeasurable (fun x => f x ⊓ c) μ :=
   (measurable_inf_const c).comp_aemeasurable hf
@@ -177,20 +177,20 @@ section MeasurableInf₂
 
 variable [MeasurableInf₂ M]
 
-@[measurability]
+@[fun_prop]
 theorem Measurable.inf' (hf : Measurable f) (hg : Measurable g) : Measurable (f ⊓ g) :=
   measurable_inf.comp (hf.prodMk hg)
 
-@[measurability]
+@[fun_prop]
 theorem Measurable.inf (hf : Measurable f) (hg : Measurable g) : Measurable fun a => f a ⊓ g a :=
   measurable_inf.comp (hf.prodMk hg)
 
-@[measurability]
+@[fun_prop]
 theorem AEMeasurable.inf' (hf : AEMeasurable f μ) (hg : AEMeasurable g μ) :
     AEMeasurable (f ⊓ g) μ :=
   measurable_inf.comp_aemeasurable (hf.prodMk hg)
 
-@[measurability]
+@[fun_prop]
 theorem AEMeasurable.inf (hf : AEMeasurable f μ) (hg : AEMeasurable g μ) :
     AEMeasurable (fun a => f a ⊓ g a) μ :=
   measurable_inf.comp_aemeasurable (hf.prodMk hg)

--- a/Mathlib/MeasureTheory/VectorMeasure/Decomposition/Lebesgue.lean
+++ b/Mathlib/MeasureTheory/VectorMeasure/Decomposition/Lebesgue.lean
@@ -176,7 +176,7 @@ theorem rnDeriv_def (s : SignedMeasure α) (μ : Measure α) : rnDeriv s μ = fu
 
 variable {s t : SignedMeasure α}
 
-@[measurability]
+@[fun_prop]
 theorem measurable_rnDeriv (s : SignedMeasure α) (μ : Measure α) : Measurable (rnDeriv s μ) := by
   rw [rnDeriv_def]
   fun_prop

--- a/Mathlib/Probability/Density.lean
+++ b/Mathlib/Probability/Density.lean
@@ -150,7 +150,7 @@ theorem hasPDF_of_pdf_ne_zero {m : MeasurableSpace Ω} {ℙ : Measure Ω} {μ : 
     have := pdf_of_not_haveLebesgueDecomposition hpdf
     filter_upwards using congrFun this
 
-@[measurability]
+@[fun_prop]
 theorem measurable_pdf {m : MeasurableSpace Ω} (X : Ω → E) (ℙ : Measure Ω)
     (μ : Measure E := by volume_tac) : Measurable (pdf X ℙ μ) := by
   exact measurable_rnDeriv _ _

--- a/Mathlib/Probability/Distributions/Beta.lean
+++ b/Mathlib/Probability/Distributions/Beta.lean
@@ -94,12 +94,12 @@ lemma betaPDFReal_pos {α β x : ℝ} (hx1 : 0 < x) (hx2 : x < 1) (hα : 0 < α)
     (Real.rpow_pos_of_pos (by linarith) (β - 1))
 
 /-- The beta pdf is measurable. -/
-@[fun_prop, measurability]
+@[fun_prop]
 lemma measurable_betaPDFReal (α β : ℝ) : Measurable (betaPDFReal α β) :=
   Measurable.ite measurableSet_Ioo (by fun_prop) (by fun_prop)
 
 /-- The beta pdf is strongly measurable. -/
-@[measurability]
+@[fun_prop]
 lemma stronglyMeasurable_betaPDFReal (α β : ℝ) :
     StronglyMeasurable (betaPDFReal α β) := (measurable_betaPDFReal α β).stronglyMeasurable
 

--- a/Mathlib/Probability/Distributions/Exponential.lean
+++ b/Mathlib/Probability/Distributions/Exponential.lean
@@ -62,12 +62,12 @@ lemma lintegral_exponentialPDF_of_nonpos {x r : ℝ} (hx : x ≤ 0) :
     ∫⁻ y in Iio x, exponentialPDF r y = 0 := lintegral_gammaPDF_of_nonpos hx
 
 /-- The exponential pdf is measurable. -/
-@[fun_prop, measurability]
+@[fun_prop]
 lemma measurable_exponentialPDFReal (r : ℝ) : Measurable (exponentialPDFReal r) :=
   measurable_gammaPDFReal 1 r
 
 -- The exponential pdf is strongly measurable -/
-@[fun_prop, measurability]
+@[fun_prop]
 lemma stronglyMeasurable_exponentialPDFReal (r : ℝ) :
     StronglyMeasurable (exponentialPDFReal r) := stronglyMeasurable_gammaPDFReal 1 r
 

--- a/Mathlib/Probability/Distributions/Gamma.lean
+++ b/Mathlib/Probability/Distributions/Gamma.lean
@@ -73,13 +73,13 @@ lemma lintegral_gammaPDF_of_nonpos {x a r : ℝ} (hx : x ≤ 0) :
     rw [if_neg (by linarith)]
 
 /-- The gamma pdf is measurable. -/
-@[fun_prop, measurability]
+@[fun_prop]
 lemma measurable_gammaPDFReal (a r : ℝ) : Measurable (gammaPDFReal a r) :=
   Measurable.ite measurableSet_Ici (((measurable_id'.pow_const _).const_mul _).mul
     (measurable_id'.const_mul _).neg.exp) measurable_const
 
 /-- The gamma pdf is strongly measurable -/
-@[fun_prop, measurability]
+@[fun_prop]
 lemma stronglyMeasurable_gammaPDFReal (a r : ℝ) :
     StronglyMeasurable (gammaPDFReal a r) :=
   (measurable_gammaPDFReal a r).stronglyMeasurable

--- a/Mathlib/Probability/Distributions/Gaussian/Real.lean
+++ b/Mathlib/Probability/Distributions/Gaussian/Real.lean
@@ -182,7 +182,7 @@ lemma support_gaussianPDF {μ : ℝ} {v : ℝ≥0} (hv : v ≠ 0) :
   simp only [Set.mem_univ, iff_true]
   exact (gaussianPDF_pos _ hv x).ne'
 
-@[measurability, fun_prop]
+@[fun_prop]
 lemma measurable_gaussianPDF (μ : ℝ) (v : ℝ≥0) : Measurable (gaussianPDF μ v) :=
   (measurable_gaussianPDFReal _ _).ennreal_ofReal
 

--- a/Mathlib/Probability/Distributions/Geometric.lean
+++ b/Mathlib/Probability/Distributions/Geometric.lean
@@ -67,11 +67,11 @@ def geometricPMF (hp_pos : 0 < p) (hp_le_one : p ≤ 1) : PMF ℕ :=
       (fun n ↦ geometricPMFReal_nonneg hp_pos hp_le_one)⟩
 
 /-- The geometric pmf is measurable. -/
-@[fun_prop, measurability]
+@[fun_prop]
 lemma measurable_geometricPMFReal : Measurable (geometricPMFReal p) := by
   fun_prop
 
-@[fun_prop, measurability]
+@[fun_prop]
 lemma stronglyMeasurable_geometricPMFReal : StronglyMeasurable (geometricPMFReal p) :=
   stronglyMeasurable_iff_measurable.mpr measurable_geometricPMFReal
 

--- a/Mathlib/Probability/Distributions/Pareto.lean
+++ b/Mathlib/Probability/Distributions/Pareto.lean
@@ -62,12 +62,12 @@ lemma lintegral_paretoPDF_of_le (hx : x ≤ t) :
     rw [if_neg (by linarith)]
 
 /-- The Pareto pdf is measurable. -/
-@[measurability, fun_prop]
+@[fun_prop]
 lemma measurable_paretoPDFReal (t r : ℝ) : Measurable (paretoPDFReal t r) :=
   Measurable.ite measurableSet_Ici ((measurable_id.pow_const _).const_mul _) measurable_const
 
 /-- The Pareto pdf is strongly measurable. -/
-@[fun_prop, measurability]
+@[fun_prop]
 lemma stronglyMeasurable_paretoPDFReal (t r : ℝ) :
     StronglyMeasurable (paretoPDFReal t r) :=
   (measurable_paretoPDFReal t r).stronglyMeasurable

--- a/Mathlib/Probability/Distributions/Poisson.lean
+++ b/Mathlib/Probability/Distributions/Poisson.lean
@@ -66,10 +66,10 @@ def poissonPMF (r : ℝ≥0) : PMF ℕ := by
   exact (poissonPMFRealSum r).toNNReal (fun n ↦ poissonPMFReal_nonneg)
 
 /-- The Poisson pmf is measurable. -/
-@[fun_prop, measurability]
+@[fun_prop]
 lemma measurable_poissonPMFReal (r : ℝ≥0) : Measurable (poissonPMFReal r) := by fun_prop
 
-@[fun_prop, measurability]
+@[fun_prop]
 lemma stronglyMeasurable_poissonPMFReal (r : ℝ≥0) : StronglyMeasurable (poissonPMFReal r) :=
   stronglyMeasurable_iff_measurable.mpr (measurable_poissonPMFReal r)
 

--- a/Mathlib/Probability/Kernel/IonescuTulcea/Maps.lean
+++ b/Mathlib/Probability/Kernel/IonescuTulcea/Maps.lean
@@ -29,7 +29,7 @@ def IocProdIoc (a b c : ι) (x : (Π i : Ioc a b, X i) × (Π i : Ioc b c, X i))
     then x.1 ⟨i, mem_Ioc.2 ⟨(mem_Ioc.1 i.2).1, h⟩⟩
     else x.2 ⟨i, mem_Ioc.2 ⟨not_le.1 h, (mem_Ioc.1 i.2).2⟩⟩
 
-@[measurability, fun_prop]
+@[fun_prop]
 lemma measurable_IocProdIoc [∀ i, MeasurableSpace (X i)] {a b c : ι} :
     Measurable (IocProdIoc (X := X) a b c) := by
   refine measurable_pi_lambda _ (fun i ↦ ?_)
@@ -80,7 +80,7 @@ lemma IicProdIoc_comp_restrict₂ {a b : ι} :
 
 variable [∀ i, MeasurableSpace (X i)]
 
-@[measurability, fun_prop]
+@[fun_prop]
 lemma measurable_IicProdIoc {m n : ι} : Measurable (IicProdIoc (X := X) m n) := by
   refine measurable_pi_lambda _ (fun i ↦ ?_)
   by_cases h : i ≤ m

--- a/Mathlib/Probability/Kernel/IonescuTulcea/PartialTraj.lean
+++ b/Mathlib/Probability/Kernel/IonescuTulcea/PartialTraj.lean
@@ -338,7 +338,7 @@ lemma lmarginalPartialTraj_succ [∀ n, IsSFiniteKernel (κ n)] (a : ℕ)
     all_goals cutsat
   all_goals fun_prop
 
-@[measurability, fun_prop]
+@[fun_prop]
 lemma measurable_lmarginalPartialTraj (a b : ℕ) {f : (Π n, X n) → ℝ≥0∞} (hf : Measurable f) :
     Measurable (lmarginalPartialTraj κ a b f) := by
   unfold lmarginalPartialTraj


### PR DESCRIPTION
Since #30511, the `@[measurability]` attribute applies `@[fun_prop]` when applied to statements about `Measurable`. This PR cleans up some of these attributes.

There are two types of change in this PR, neither of which change the behavior of tactics:
- Changing `@[measurability]` to `@[fun_prop]`: this has no effect.
- Changing `@[fun_prop, measurability]` to `@[fun_prop]`: this just removes a duplicate `fun_prop` theorem.

Note that this PR does not change the attributes of lemmas where it was unclear whether they should be tagged with `fun_prop`.


---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

When merging, all the commits will be squashed into a single commit
listing all co-authors.

Co-authors in the squash commit are gathered from two sources:

First, all authors of commits to this PR branch are included. Thus,
one way to add co-authors is to include at least one commit authored by
each co-author among the commits in the pull request. If necessary, you
may create empty commits to indicate co-authorship, using commands like so:

git commit --author="Author Name <author@email.com>" --allow-empty -m "add Author Name as coauthor"

Second, co-authors can also be listed in lines at the very bottom of
the commit message (that is, directly before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines
at the bottom of the commit message (before the `---`, and also before
any "Co-authored-by" lines) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
