### PR TITLE
[Merged by Bors] - chore(Data/Finset): golf entire `mem_finset_image` and `image_erase` using `grind`

### DIFF
--- a/Mathlib/Data/Finset/Image.lean
+++ b/Mathlib/Data/Finset/Image.lean
@@ -318,9 +318,7 @@ theorem image_congr (h : (s : Set α).EqOn f g) : Finset.image f s = Finset.imag
 
 theorem _root_.Function.Injective.mem_finset_image (hf : Injective f) :
     f a ∈ s.image f ↔ a ∈ s := by
-  refine ⟨fun h => ?_, Finset.mem_image_of_mem f⟩
-  obtain ⟨y, hy, heq⟩ := mem_image.1 h
-  exact hf heq ▸ hy
+  grind
 
 
 @[simp, norm_cast]
@@ -432,8 +430,7 @@ theorem erase_image_subset_image_erase [DecidableEq α] (f : α → β) (s : Fin
 
 @[simp]
 theorem image_erase [DecidableEq α] {f : α → β} (hf : Injective f) (s : Finset α) (a : α) :
-    (s.erase a).image f = (s.image f).erase (f a) :=
-  coe_injective <| by push_cast [Set.image_diff hf, Set.image_singleton]; rfl
+    (s.erase a).image f = (s.image f).erase (f a) := by grind
 
 @[simp]
 theorem image_eq_empty : s.image f = ∅ ↔ s = ∅ := mod_cast Set.image_eq_empty (f := f) (s := s)


### PR DESCRIPTION
---
<details>
<summary>Show trace profiling of <code>_root_.Function.Injective.mem_finset_image</code>: <10 ms before, 11 ms after </summary>

### Trace profiling of `_root_.Function.Injective.mem_finset_image` before PR 32189
```diff
diff --git a/Mathlib/Data/Finset/Image.lean b/Mathlib/Data/Finset/Image.lean
index 2a52fef1c8..63b61cb70b 100644
--- a/Mathlib/Data/Finset/Image.lean
+++ b/Mathlib/Data/Finset/Image.lean
@@ -316,6 +316,7 @@ theorem image_congr (h : (s : Set α).EqOn f g) : Finset.image f s = Finset.imag
   simp_rw [mem_image, ← bex_def]
   exact exists₂_congr fun x hx => by rw [h hx]
 
+set_option trace.profiler true in
 theorem _root_.Function.Injective.mem_finset_image (hf : Injective f) :
     f a ∈ s.image f ↔ a ∈ s := by
   refine ⟨fun h => ?_, Finset.mem_image_of_mem f⟩
```
```
✔ [578/578] Built Mathlib.Data.Finset.Image (1.6s)
Build completed successfully (578 jobs).
```

### Trace profiling of `_root_.Function.Injective.mem_finset_image` after PR 32189
```diff
diff --git a/Mathlib/Data/Finset/Image.lean b/Mathlib/Data/Finset/Image.lean
index 2a52fef1c8..daae3b2d1d 100644
--- a/Mathlib/Data/Finset/Image.lean
+++ b/Mathlib/Data/Finset/Image.lean
@@ -316,11 +316,10 @@ theorem image_congr (h : (s : Set α).EqOn f g) : Finset.image f s = Finset.imag
   simp_rw [mem_image, ← bex_def]
   exact exists₂_congr fun x hx => by rw [h hx]
 
+set_option trace.profiler true in
 theorem _root_.Function.Injective.mem_finset_image (hf : Injective f) :
     f a ∈ s.image f ↔ a ∈ s := by
-  refine ⟨fun h => ?_, Finset.mem_image_of_mem f⟩
-  obtain ⟨y, hy, heq⟩ := mem_image.1 h
-  exact hf heq ▸ hy
+  grind
 
 
 @[simp, norm_cast]
@@ -432,8 +431,7 @@ theorem erase_image_subset_image_erase [DecidableEq α] (f : α → β) (s : Fin
 
 @[simp]
 theorem image_erase [DecidableEq α] {f : α → β} (hf : Injective f) (s : Finset α) (a : α) :
-    (s.erase a).image f = (s.image f).erase (f a) :=
-  coe_injective <| by push_cast [Set.image_diff hf, Set.image_singleton]; rfl
+    (s.erase a).image f = (s.image f).erase (f a) := by grind
 
 @[simp]
 theorem image_eq_empty : s.image f = ∅ ↔ s = ∅ := mod_cast Set.image_eq_empty (f := f) (s := s)
```
```
ℹ [578/578] Built Mathlib.Data.Finset.Image (1.6s)
info: Mathlib/Data/Finset/Image.lean:320:0: [Elab.async] [0.010939] elaborating proof of Function.Injective.mem_finset_image
  [Elab.definition.value] [0.010793] Function.Injective.mem_finset_image
    [Elab.step] [0.010704] grind
      [Elab.step] [0.010699] grind
        [Elab.step] [0.010693] grind
Build completed successfully (578 jobs).
```
</details>

---
<details>
<summary>Show trace profiling of <code>image_erase</code>: <10 ms before, 67 ms after </summary>

### Trace profiling of `image_erase` before PR 32189
```diff
diff --git a/Mathlib/Data/Finset/Image.lean b/Mathlib/Data/Finset/Image.lean
index 2a52fef1c8..2e6451c969 100644
--- a/Mathlib/Data/Finset/Image.lean
+++ b/Mathlib/Data/Finset/Image.lean
@@ -430,6 +430,7 @@ theorem image_insert [DecidableEq α] (f : α → β) (a : α) (s : Finset α) :
 theorem erase_image_subset_image_erase [DecidableEq α] (f : α → β) (s : Finset α) (a : α) :
     (s.image f).erase (f a) ⊆ (s.erase a).image f := by grind
 
+set_option trace.profiler true in
 @[simp]
 theorem image_erase [DecidableEq α] {f : α → β} (hf : Injective f) (s : Finset α) (a : α) :
     (s.erase a).image f = (s.image f).erase (f a) :=
```
```
✔ [578/578] Built Mathlib.Data.Finset.Image (1.6s)
Build completed successfully (578 jobs).
```

### Trace profiling of `image_erase` after PR 32189
```diff
diff --git a/Mathlib/Data/Finset/Image.lean b/Mathlib/Data/Finset/Image.lean
index 2a52fef1c8..38f809aa39 100644
--- a/Mathlib/Data/Finset/Image.lean
+++ b/Mathlib/Data/Finset/Image.lean
@@ -318,9 +318,7 @@ theorem image_congr (h : (s : Set α).EqOn f g) : Finset.image f s = Finset.imag
 
 theorem _root_.Function.Injective.mem_finset_image (hf : Injective f) :
     f a ∈ s.image f ↔ a ∈ s := by
-  refine ⟨fun h => ?_, Finset.mem_image_of_mem f⟩
-  obtain ⟨y, hy, heq⟩ := mem_image.1 h
-  exact hf heq ▸ hy
+  grind
 
 
 @[simp, norm_cast]
@@ -430,10 +428,10 @@ theorem image_insert [DecidableEq α] (f : α → β) (a : α) (s : Finset α) :
 theorem erase_image_subset_image_erase [DecidableEq α] (f : α → β) (s : Finset α) (a : α) :
     (s.image f).erase (f a) ⊆ (s.erase a).image f := by grind
 
+set_option trace.profiler true in
 @[simp]
 theorem image_erase [DecidableEq α] {f : α → β} (hf : Injective f) (s : Finset α) (a : α) :
-    (s.erase a).image f = (s.image f).erase (f a) :=
-  coe_injective <| by push_cast [Set.image_diff hf, Set.image_singleton]; rfl
+    (s.erase a).image f = (s.image f).erase (f a) := by grind
 
 @[simp]
 theorem image_eq_empty : s.image f = ∅ ↔ s = ∅ := mod_cast Set.image_eq_empty (f := f) (s := s)
```
```
ℹ [578/578] Built Mathlib.Data.Finset.Image (1.6s)
info: Mathlib/Data/Finset/Image.lean:432:0: [Elab.async] [0.066826] elaborating proof of Finset.image_erase
  [Elab.definition.value] [0.066657] Finset.image_erase
    [Elab.step] [0.066567] grind
      [Elab.step] [0.066563] grind
        [Elab.step] [0.066557] grind
Build completed successfully (578 jobs).
```
</details>

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

When merging, all the commits will be squashed into a single commit
listing all co-authors.

Co-authors in the squash commit are gathered from two sources:

First, all authors of commits to this PR branch are included. Thus,
one way to add co-authors is to include at least one commit authored by
each co-author among the commits in the pull request. If necessary, you
may create empty commits to indicate co-authorship, using commands like so:

git commit --author="Author Name <author@email.com>" --allow-empty -m "add Author Name as coauthor"

Second, co-authors can also be listed in lines at the very bottom of
the commit message (that is, directly before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines
at the bottom of the commit message (before the `---`, and also before
any "Co-authored-by" lines) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
