### PR TITLE
[Merged by Bors] - feat(Analysis): generalize `Real.deriv_rpow_const` and prove iteration version

### DIFF
--- a/Mathlib/Analysis/Distribution/TemperateGrowth.lean
+++ b/Mathlib/Analysis/Distribution/TemperateGrowth.lean
@@ -155,59 +155,6 @@ variable [NontriviallyNormedField 𝕜] [NormedAlgebra ℝ 𝕜]
   [NormedAddCommGroup G] [NormedSpace ℝ G]
   [NormedSpace 𝕜 F] [NormedSpace 𝕜 G]
 
-#check iter_deriv_pow
-
-variable (r : ℝ) (x : ℝ) (k : ℕ)
-#check x ^ r
-#check (ascPochhammer ℝ k).eval x
-
---theorem differentiableWithinAt_rpow
-
-theorem differentiableAt_rpow (r x : ℝ) : DifferentiableAt ℝ (fun x ↦ x ^ r) x ↔ x ≠ 0 ∨ 0 ≤ r := by
-  sorry
-  --⟨fun H => NormedField.continuousAt_zpow.1 H.continuousAt, fun H =>
-    --(hasDerivAt_zpow m x H).differentiableAt⟩
-
-theorem deriv_rpow (r x : ℝ) : deriv (fun x ↦ x ^ r) x = r * x ^ (r - 1) := by
-  by_cases h : ∃ k : ℤ, r = k
-  · obtain ⟨k, hk⟩ := h
-    rw [hk]
-    norm_cast
-    apply deriv_zpow
-  push_neg at h
-  by_cases h' : x ≠ 0 ∨ 0 ≤ r
-  ·
-    apply (Real.hasDerivAt_rpow_const h').deriv
-  push_neg at h'
-  simp [h']
-  rw [deriv_zero_of_not_differentiableAt]
-  · simp only [zero_eq_mul]
-    right
-    refine Real.zero_rpow ?_
-    specialize h 1
-    grind
-  rw [differentiableAt_rpow]
-  simp [h'.2]
-
-
-theorem iter_deriv_rpow (r x : ℝ) (k : ℕ) :
-    deriv^[k] (fun (x : ℝ) ↦ x ^ r) x = (descPochhammer ℝ k).eval r * x ^ (r - k) := by
-  apply funext_iff.mp
-  induction k with
-  | zero =>
-    simp
-  | succ k IH =>
-    simp only [iterate_succ', comp_apply, Nat.cast_add, Nat.cast_one]
-    rw [IH]
-    ext y
-    rw [deriv_const_mul_field, deriv_rpow, ← mul_assoc]
-    congr 2
-    · simp [descPochhammer_succ_right]
-    · grind
-
-#exit
-
-
 /-- The product of two functions of temperate growth is again of temperate growth.
 
 Version for bilinear maps. -/

--- a/Mathlib/Analysis/Distribution/TemperateGrowth.lean
+++ b/Mathlib/Analysis/Distribution/TemperateGrowth.lean
@@ -155,6 +155,59 @@ variable [NontriviallyNormedField 𝕜] [NormedAlgebra ℝ 𝕜]
   [NormedAddCommGroup G] [NormedSpace ℝ G]
   [NormedSpace 𝕜 F] [NormedSpace 𝕜 G]
 
+#check iter_deriv_pow
+
+variable (r : ℝ) (x : ℝ) (k : ℕ)
+#check x ^ r
+#check (ascPochhammer ℝ k).eval x
+
+--theorem differentiableWithinAt_rpow
+
+theorem differentiableAt_rpow (r x : ℝ) : DifferentiableAt ℝ (fun x ↦ x ^ r) x ↔ x ≠ 0 ∨ 0 ≤ r := by
+  sorry
+  --⟨fun H => NormedField.continuousAt_zpow.1 H.continuousAt, fun H =>
+    --(hasDerivAt_zpow m x H).differentiableAt⟩
+
+theorem deriv_rpow (r x : ℝ) : deriv (fun x ↦ x ^ r) x = r * x ^ (r - 1) := by
+  by_cases h : ∃ k : ℤ, r = k
+  · obtain ⟨k, hk⟩ := h
+    rw [hk]
+    norm_cast
+    apply deriv_zpow
+  push_neg at h
+  by_cases h' : x ≠ 0 ∨ 0 ≤ r
+  ·
+    apply (Real.hasDerivAt_rpow_const h').deriv
+  push_neg at h'
+  simp [h']
+  rw [deriv_zero_of_not_differentiableAt]
+  · simp only [zero_eq_mul]
+    right
+    refine Real.zero_rpow ?_
+    specialize h 1
+    grind
+  rw [differentiableAt_rpow]
+  simp [h'.2]
+
+
+theorem iter_deriv_rpow (r x : ℝ) (k : ℕ) :
+    deriv^[k] (fun (x : ℝ) ↦ x ^ r) x = (descPochhammer ℝ k).eval r * x ^ (r - k) := by
+  apply funext_iff.mp
+  induction k with
+  | zero =>
+    simp
+  | succ k IH =>
+    simp only [iterate_succ', comp_apply, Nat.cast_add, Nat.cast_one]
+    rw [IH]
+    ext y
+    rw [deriv_const_mul_field, deriv_rpow, ← mul_assoc]
+    congr 2
+    · simp [descPochhammer_succ_right]
+    · grind
+
+#exit
+
+
 /-- The product of two functions of temperate growth is again of temperate growth.
 
 Version for bilinear maps. -/

--- a/Mathlib/Analysis/SpecialFunctions/Pow/Asymptotics.lean
+++ b/Mathlib/Analysis/SpecialFunctions/Pow/Asymptotics.lean
@@ -39,6 +39,11 @@ theorem tendsto_rpow_atTop {y : ℝ} (hy : 0 < y) : Tendsto (fun x : ℝ => x ^ 
   filter_upwards [eventually_ge_atTop 0, eventually_ge_atTop (b ^ (1 / y))] with x hx₀ hx
   simpa (disch := positivity) [Real.rpow_inv_le_iff_of_pos] using hx
 
+theorem tendsto_rpow_neg_nhdsGT_zero {y : ℝ} (hr : y < 0) :
+    Tendsto (fun (x : ℝ) ↦ x ^ y) (𝓝[>] 0) atTop := by
+  simp_rw +singlePass [← neg_neg y, Real.rpow_neg_eq_inv_rpow]
+  exact (tendsto_rpow_atTop <| neg_pos.mpr hr).comp tendsto_inv_nhdsGT_zero
+
 /-- The function `x ^ (-y)` tends to `0` at `+∞` for any positive real `y`. -/
 theorem tendsto_rpow_neg_atTop {y : ℝ} (hy : 0 < y) : Tendsto (fun x : ℝ => x ^ (-y)) atTop (𝓝 0) :=
   Tendsto.congr' (eventuallyEq_of_mem (Ioi_mem_atTop 0) fun _ hx => (rpow_neg (le_of_lt hx) y).symm)

--- a/Mathlib/Analysis/SpecialFunctions/Pow/Deriv.lean
+++ b/Mathlib/Analysis/SpecialFunctions/Pow/Deriv.lean
@@ -388,6 +388,20 @@ lemma differentiableAt_rpow_const_of_ne (p : ℝ) {x : ℝ} (hx : x ≠ 0) :
     DifferentiableAt ℝ (fun x => x ^ p) x :=
   (hasStrictDerivAt_rpow_const_of_ne hx p).differentiableAt
 
+theorem not_differentiableAt_rpow_const_zero {r : ℝ} (hr : r < 1) (hr' : r ≠ 0) :
+    ¬ DifferentiableAt ℝ (fun x ↦ x ^ r) (0 : ℝ) := by
+  by_contra h
+  set y := deriv (fun x ↦ x ^ r) (0 : ℝ)
+  -- If `x ^ r` was differentiable at `0`, then `x ^ (r - 1)` would have a finite limit at `0`.
+  have h : Filter.Tendsto (fun t ↦ t ^ (r - 1)) (nhdsWithin 0 (Set.Ioi 0)) (nhds y) := by
+    apply tendsto_nhdsWithin_congr _ h.hasDerivAt.tendsto_slope_zero_right
+    intro x (hx : 0 < x)
+    simp only [zero_add, ne_eq, hr', not_false_eq_true, Real.zero_rpow, sub_zero, smul_eq_mul]
+    field_simp
+    nth_rw 1 [← add_sub_cancel 1 r, Real.rpow_add hx]
+    simp
+  exact not_tendsto_nhds_of_tendsto_atTop (tendsto_rpow_neg_nhdsGT_zero (by simp [hr])) y h
+
 lemma differentiableOn_rpow_const (p : ℝ) :
     DifferentiableOn ℝ (fun x => (x : ℝ) ^ p) {0}ᶜ :=
   fun _ hx => (Real.differentiableAt_rpow_const_of_ne p hx).differentiableWithinAt
@@ -419,13 +433,17 @@ theorem hasDerivAt_rpow_const {x p : ℝ} (h : x ≠ 0 ∨ 1 ≤ p) :
 theorem differentiable_rpow_const {p : ℝ} (hp : 1 ≤ p) : Differentiable ℝ fun x : ℝ => x ^ p :=
   fun _ => (hasDerivAt_rpow_const (Or.inr hp)).differentiableAt
 
-theorem deriv_rpow_const {x p : ℝ} (h : x ≠ 0 ∨ 1 ≤ p) :
-    deriv (fun x : ℝ => x ^ p) x = p * x ^ (p - 1) :=
-  (hasDerivAt_rpow_const h).deriv
+theorem deriv_rpow_const (x p : ℝ) : deriv (fun x ↦ x ^ p) x = p * x ^ (p - 1) := by
+  by_cases! h : p = 0
+  · simp [h]
+  by_cases! h' : x ≠ 0 ∨ 1 ≤ p
+  · apply (Real.hasDerivAt_rpow_const h').deriv
+  have h'' := deriv_zero_of_not_differentiableAt (not_differentiableAt_rpow_const_zero h'.2 h ·)
+  grind [Real.zero_rpow]
 
-theorem deriv_rpow_const' {p : ℝ} (h : 1 ≤ p) :
+theorem deriv_rpow_const' (p : ℝ) :
     (deriv fun x : ℝ => x ^ p) = fun x => p * x ^ (p - 1) :=
-  funext fun _ => deriv_rpow_const (Or.inr h)
+  funext (deriv_rpow_const · p)
 
 theorem contDiffAt_rpow_const_of_ne {x p : ℝ} {n : WithTop ℕ∞} (h : x ≠ 0) :
     ContDiffAt ℝ n (fun x => x ^ p) x :=
@@ -439,7 +457,7 @@ theorem contDiff_rpow_const_of_le {p : ℝ} {n : ℕ} (h : ↑n ≤ p) :
     have h1 : 1 ≤ p := le_trans (by simp) h
     rw [Nat.cast_succ, ← le_sub_iff_add_le] at h
     rw [show ((n + 1 : ℕ) : WithTop ℕ∞) = n + 1 from rfl,
-      contDiff_succ_iff_deriv, deriv_rpow_const' h1]
+      contDiff_succ_iff_deriv, deriv_rpow_const' p]
     simp only [WithTop.natCast_ne_top, analyticOn_univ, IsEmpty.forall_iff, true_and]
     exact ⟨differentiable_rpow_const h1, contDiff_const.mul (ihn h)⟩
 
@@ -450,6 +468,19 @@ theorem contDiffAt_rpow_const_of_le {x p : ℝ} {n : ℕ} (h : ↑n ≤ p) :
 theorem contDiffAt_rpow_const {x p : ℝ} {n : ℕ} (h : x ≠ 0 ∨ ↑n ≤ p) :
     ContDiffAt ℝ n (fun x : ℝ => x ^ p) x :=
   h.elim contDiffAt_rpow_const_of_ne contDiffAt_rpow_const_of_le
+
+theorem iter_deriv_rpow (r x : ℝ) (k : ℕ) :
+    deriv^[k] (fun (x : ℝ) ↦ x ^ r) x = (descPochhammer ℝ k).eval r * x ^ (r - k) := by
+  apply funext_iff.mp
+  induction k with
+  | zero => simp
+  | succ k IH =>
+    simp only [Function.iterate_succ', Function.comp_apply, Nat.cast_add, Nat.cast_one, IH]
+    ext y
+    simp only [deriv_const_mul_field, deriv_rpow_const, ← mul_assoc, descPochhammer_succ_right,
+      Polynomial.eval_mul, Polynomial.eval_sub, Polynomial.eval_X, Polynomial.eval_natCast,
+      mul_eq_mul_left_iff, mul_eq_zero]
+    grind
 
 theorem hasStrictDerivAt_rpow_const {x p : ℝ} (hx : x ≠ 0 ∨ 1 ≤ p) :
     HasStrictDerivAt (fun x => x ^ p) (p * x ^ (p - 1)) x :=
@@ -652,15 +683,14 @@ theorem deriv_rpow_const (hf : DifferentiableAt ℝ f x) (hx : f x ≠ 0 ∨ 1 �
 theorem deriv_norm_ofReal_cpow (c : ℂ) {t : ℝ} (ht : 0 < t) :
     (deriv fun x : ℝ ↦ ‖(x : ℂ) ^ c‖) t = c.re * t ^ (c.re - 1) := by
   rw [EventuallyEq.deriv_eq (f := fun x ↦ x ^ c.re)]
-  · rw [Real.deriv_rpow_const (Or.inl ht.ne')]
+  · rw [Real.deriv_rpow_const t]
   · filter_upwards [eventually_gt_nhds ht] with x hx
     rw [Complex.norm_cpow_eq_rpow_re_of_pos hx]
 
 lemma isTheta_deriv_rpow_const_atTop {p : ℝ} (hp : p ≠ 0) :
     deriv (fun (x : ℝ) => x ^ p) =Θ[atTop] fun x => x ^ (p-1) := by
   calc deriv (fun (x : ℝ) => x ^ p) =ᶠ[atTop] fun x => p * x ^ (p - 1) := by
-              filter_upwards [eventually_ne_atTop 0] with x hx
-              rw [Real.deriv_rpow_const (Or.inl hx)]
+              rw [Real.deriv_rpow_const' p]
        _ =Θ[atTop] fun x => x ^ (p-1) :=
               Asymptotics.IsTheta.const_mul_left hp Asymptotics.isTheta_rfl
 

--- a/Mathlib/Analysis/SpecialFunctions/Pow/Deriv.lean
+++ b/Mathlib/Analysis/SpecialFunctions/Pow/Deriv.lean
@@ -469,7 +469,7 @@ theorem contDiffAt_rpow_const {x p : ℝ} {n : ℕ} (h : x ≠ 0 ∨ ↑n ≤ p)
     ContDiffAt ℝ n (fun x : ℝ => x ^ p) x :=
   h.elim contDiffAt_rpow_const_of_ne contDiffAt_rpow_const_of_le
 
-theorem iter_deriv_rpow (r x : ℝ) (k : ℕ) :
+theorem iter_deriv_rpow_const (r x : ℝ) (k : ℕ) :
     deriv^[k] (fun (x : ℝ) ↦ x ^ r) x = (descPochhammer ℝ k).eval r * x ^ (r - k) := by
   apply funext_iff.mp
   induction k with

--- a/Mathlib/Analysis/SpecialFunctions/Pow/Deriv.lean
+++ b/Mathlib/Analysis/SpecialFunctions/Pow/Deriv.lean
@@ -688,11 +688,10 @@ theorem deriv_norm_ofReal_cpow (c : ℂ) {t : ℝ} (ht : 0 < t) :
     rw [Complex.norm_cpow_eq_rpow_re_of_pos hx]
 
 lemma isTheta_deriv_rpow_const_atTop {p : ℝ} (hp : p ≠ 0) :
-    deriv (fun (x : ℝ) => x ^ p) =Θ[atTop] fun x => x ^ (p-1) := by
-  calc deriv (fun (x : ℝ) => x ^ p) =ᶠ[atTop] fun x => p * x ^ (p - 1) := by
-              rw [Real.deriv_rpow_const' p]
-       _ =Θ[atTop] fun x => x ^ (p-1) :=
-              Asymptotics.IsTheta.const_mul_left hp Asymptotics.isTheta_rfl
+    deriv (fun (x : ℝ) ↦ x ^ p) =Θ[atTop] fun x => x ^ (p - 1) := by
+  calc deriv (fun (x : ℝ) ↦ x ^ p) = fun x => p * x ^ (p - 1) := Real.deriv_rpow_const' p
+    _ =Θ[atTop] fun x ↦ x ^ (p - 1) :=
+      Asymptotics.IsTheta.const_mul_left hp Asymptotics.isTheta_rfl
 
 lemma isBigO_deriv_rpow_const_atTop (p : ℝ) :
     deriv (fun (x : ℝ) => x ^ p) =O[atTop] fun x => x ^ (p-1) := by

--- a/Mathlib/Analysis/SpecialFunctions/Pow/Deriv.lean
+++ b/Mathlib/Analysis/SpecialFunctions/Pow/Deriv.lean
@@ -393,7 +393,7 @@ theorem not_differentiableAt_rpow_const_zero {r : ℝ} (hr : r < 1) (hr' : r ≠
   by_contra h
   set y := deriv (fun x ↦ x ^ r) (0 : ℝ)
   -- If `x ^ r` was differentiable at `0`, then `x ^ (r - 1)` would have a finite limit at `0`.
-  have h : Filter.Tendsto (fun t ↦ t ^ (r - 1)) (nhdsWithin 0 (Set.Ioi 0)) (nhds y) := by
+  have h : Filter.Tendsto (fun t ↦ t ^ (r - 1)) (𝓝[>] 0) (𝓝 y) := by
     apply tendsto_nhdsWithin_congr _ h.hasDerivAt.tendsto_slope_zero_right
     intro x (hx : 0 < x)
     simp only [zero_add, ne_eq, hr', not_false_eq_true, Real.zero_rpow, sub_zero, smul_eq_mul]

--- a/Mathlib/Computability/AkraBazzi/AkraBazzi.lean
+++ b/Mathlib/Computability/AkraBazzi/AkraBazzi.lean
@@ -92,7 +92,7 @@ lemma eventually_deriv_rpow_p_mul_one_sub_smoothingFn (p : ℝ) :
   _ =ᶠ[atTop] fun x => p * x ^ (p - 1) * (1 - ε x) + x ^ p * (x⁻¹ / (log x ^ 2)) := by
     filter_upwards [eventually_gt_atTop 1, eventually_deriv_one_sub_smoothingFn]
       with x hx hderiv
-    rw [hderiv, Real.deriv_rpow_const (Or.inl <| by positivity)]
+    rw [hderiv, Real.deriv_rpow_const]
   _ =ᶠ[atTop] fun x => p * x ^ (p - 1) * (1 - ε x) + x ^ (p - 1) / (log x ^ 2) := by
     filter_upwards [eventually_gt_atTop 0] with x hx
     rw [mul_div, ← Real.rpow_neg_one, ← Real.rpow_add (by positivity), sub_eq_add_neg]
@@ -109,7 +109,7 @@ lemma eventually_deriv_rpow_p_mul_one_add_smoothingFn (p : ℝ) :
     _ =ᶠ[atTop] fun x => p * x ^ (p - 1) * (1 + ε x) - x ^ p * (x⁻¹ / (log x ^ 2)) := by
       filter_upwards [eventually_gt_atTop 1, eventually_deriv_one_add_smoothingFn]
         with x hx hderiv
-      simp [hderiv, Real.deriv_rpow_const (Or.inl <| by positivity), neg_div, sub_eq_add_neg]
+      simp [hderiv, Real.deriv_rpow_const, neg_div, sub_eq_add_neg]
     _ =ᶠ[atTop] fun x => p * x ^ (p - 1) * (1 + ε x) - x ^ (p - 1) / (log x ^ 2) := by
       filter_upwards [eventually_gt_atTop 0] with x hx
       simp [mul_div, ← Real.rpow_neg_one, ← Real.rpow_add (by positivity), sub_eq_add_neg]


### PR DESCRIPTION
We prove that for calculating the derivative of `Real.rpow` it is not necessary to check any conditions, since the junk values align. This makes it easy to calculate the iterated derivative.

Co-authored-by: Floris van Doorn <fpvdoorn@gmail.com>

---

`tendsto_rpow_neg_nhdsGT_zero` by Floris, see [#Is there code for X? > &#96;Real.rpow&#96; tendsto &#96;atTop&#96; for negative exponents @ 💬](https://leanprover.zulipchat.com/#narrow/channel/217875-Is-there-code-for-X.3F/topic/.60Real.2Erpow.60.20tendsto.20.60atTop.60.20for.20negative.20exponents/near/560623279)

<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

When merging, all the commits will be squashed into a single commit
listing all co-authors.

Co-authors in the squash commit are gathered from two sources:

First, all authors of commits to this PR branch are included. Thus,
one way to add co-authors is to include at least one commit authored by
each co-author among the commits in the pull request. If necessary, you
may create empty commits to indicate co-authorship, using commands like so:

git commit --author="Author Name <author@email.com>" --allow-empty -m "add Author Name as coauthor"

Second, co-authors can also be listed in lines at the very bottom of
the commit message (that is, directly before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines
at the bottom of the commit message (before the `---`, and also before
any "Co-authored-by" lines) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
