### PR TITLE
feat: grind annotations for sup/inf associativity and commutativity

### DIFF
--- a/Archive/Imo/Imo2001Q3.lean
+++ b/Archive/Imo/Imo2001Q3.lean
@@ -92,8 +92,7 @@ lemma card_not_easy_le_210 (hG : ∀ i, #(G i) ≤ 6) (hB : ∀ i j, ¬Disjoint 
 
 theorem result (h : Condition G B) : ∃ p, Easy G p ∧ Easy B p := by
   obtain ⟨G_le_6, B_le_6, G_inter_B⟩ := h
-  have B_inter_G : ∀ i j, ¬Disjoint (B i) (G j) := fun i j ↦ by
-    rw [disjoint_comm]; exact G_inter_B j i
+  have B_inter_G : ∀ i j, ¬Disjoint (B i) (G j) := by grind
   have cB := card_not_easy_le_210 G_le_6 G_inter_B
   have cG := card_not_easy_le_210 B_le_6 B_inter_G
   rw [← card_map ⟨_, Prod.swap_injective⟩] at cG

--- a/Mathlib/Data/Finset/Disjoint.lean
+++ b/Mathlib/Data/Finset/Disjoint.lean
@@ -180,7 +180,7 @@ section Insert
 
 variable [DecidableEq α] {s t u v : Finset α} {a b : α} {f : α → β}
 
-@[simp]
+@[simp, grind =]
 theorem disjoint_insert_left : Disjoint (insert a s) t ↔ a ∉ t ∧ Disjoint s t := by
   simp only [disjoint_left, mem_insert, or_imp, forall_and, forall_eq]
 

--- a/Mathlib/Data/Set/Disjoint.lean
+++ b/Mathlib/Data/Set/Disjoint.lean
@@ -37,6 +37,7 @@ theorem disjoint_iff_inter_eq_empty : Disjoint s t ↔ s ∩ t = ∅ :=
 theorem _root_.Disjoint.inter_eq : Disjoint s t → s ∩ t = ∅ :=
   Disjoint.eq_bot
 
+@[grind =]
 theorem disjoint_left : Disjoint s t ↔ ∀ ⦃a⦄, a ∈ s → a ∉ t :=
   disjoint_iff_inf_le.trans <| forall_congr' fun _ => not_and
 
@@ -52,8 +53,7 @@ alias ⟨_root_.Disjoint.notMem_of_mem_right, _⟩ := disjoint_right
 @[deprecated (since := "2025-05-23")]
 alias _root_.Disjoint.not_mem_of_mem_right := Disjoint.notMem_of_mem_right
 
-lemma not_disjoint_iff : ¬Disjoint s t ↔ ∃ x, x ∈ s ∧ x ∈ t :=
-  Set.disjoint_iff.not.trans <| not_forall.trans <| exists_congr fun _ ↦ not_not
+lemma not_disjoint_iff : ¬Disjoint s t ↔ ∃ x, x ∈ s ∧ x ∈ t := by grind
 
 lemma not_disjoint_iff_nonempty_inter : ¬ Disjoint s t ↔ (s ∩ t).Nonempty := not_disjoint_iff
 
@@ -62,8 +62,7 @@ alias ⟨_, Nonempty.not_disjoint⟩ := not_disjoint_iff_nonempty_inter
 lemma disjoint_or_nonempty_inter (s t : Set α) : Disjoint s t ∨ (s ∩ t).Nonempty :=
   (em _).imp_right not_disjoint_iff_nonempty_inter.1
 
-lemma disjoint_iff_forall_ne : Disjoint s t ↔ ∀ ⦃a⦄, a ∈ s → ∀ ⦃b⦄, b ∈ t → a ≠ b := by
-  simp only [Ne, disjoint_left, @imp_not_comm _ (_ = _), forall_eq']
+lemma disjoint_iff_forall_ne : Disjoint s t ↔ ∀ ⦃a⦄, a ∈ s → ∀ ⦃b⦄, b ∈ t → a ≠ b := by grind
 
 alias ⟨_root_.Disjoint.ne_of_mem, _⟩ := disjoint_iff_forall_ne
 
@@ -127,6 +126,6 @@ end Disjoint
 namespace Set
 
 theorem mem_union_of_disjoint (h : Disjoint s t) {x : α} : x ∈ s ∪ t ↔ Xor' (x ∈ s) (x ∈ t) := by
-  grind [Xor', Set.disjoint_left]
+  grind [Xor']
 
 end Set

--- a/Mathlib/Order/BooleanAlgebra/Basic.lean
+++ b/Mathlib/Order/BooleanAlgebra/Basic.lean
@@ -131,7 +131,7 @@ instance (priority := 100) GeneralizedBooleanAlgebra.toGeneralizedCoheytingAlgeb
             inf_sup_right]))
         (calc
           y ⊔ y \ x ≤ y \ x ⊔ x ⊔ z := by
-            grind [sup_of_le_left, sdiff_le', le_sup_left, sup_assoc, sdiff_sup_self']
+            grind [sup_of_le_left, sdiff_le', le_sup_left, sdiff_sup_self']
           _ = x ⊔ z ⊔ y \ x := by ac_rfl),
       fun h => le_of_inf_le_sup_le (inf_sdiff_self_left.trans_le bot_le) (calc
         y \ x ⊔ x = y ⊔ x := sdiff_sup_self'

--- a/Mathlib/Order/BoundedOrder/Basic.lean
+++ b/Mathlib/Order/BoundedOrder/Basic.lean
@@ -126,6 +126,7 @@ alias ⟨IsTop.eq_top, _⟩ := isTop_iff_eq_top
 theorem top_le_iff : ⊤ ≤ a ↔ a = ⊤ :=
   le_top.ge_iff_eq
 
+@[grind ←=, grind →] -- This tells grind that to prove `a = ⊤` it suffices to prove `⊤ ≤ a`.
 theorem top_unique (h : ⊤ ≤ a) : a = ⊤ :=
   le_top.antisymm h
 
@@ -291,6 +292,7 @@ alias ⟨IsBot.eq_bot, _⟩ := isBot_iff_eq_bot
 theorem le_bot_iff : a ≤ ⊥ ↔ a = ⊥ :=
   bot_le.ge_iff_eq'
 
+@[grind ←=, grind →] -- This tells grind that to prove `a = ⊥` it suffices to prove `a ≤ ⊥`.
 theorem bot_unique (h : a ≤ ⊥) : a = ⊥ :=
   h.antisymm bot_le
 

--- a/Mathlib/Order/BoundedOrder/Lattice.lean
+++ b/Mathlib/Order/BoundedOrder/Lattice.lean
@@ -56,7 +56,7 @@ theorem bot_sup_eq (a : α) : ⊥ ⊔ a = a :=
 theorem sup_bot_eq (a : α) : a ⊔ ⊥ = a :=
   sup_of_le_left bot_le
 
-@[simp]
+@[simp, grind =]
 theorem sup_eq_bot_iff : a ⊔ b = ⊥ ↔ a = ⊥ ∧ b = ⊥ := by rw [eq_bot_iff, sup_le_iff]; simp
 
 end SemilatticeSupBot
@@ -69,7 +69,7 @@ lemma top_inf_eq (a : α) : ⊤ ⊓ a = a := inf_of_le_right le_top
 
 lemma inf_top_eq (a : α) : a ⊓ ⊤ = a := inf_of_le_left le_top
 
-@[simp]
+@[simp, grind =]
 theorem inf_eq_top_iff : a ⊓ b = ⊤ ↔ a = ⊤ ∧ b = ⊤ :=
   @sup_eq_bot_iff αᵒᵈ _ _ _ _
 

--- a/Mathlib/Order/CompleteLattice/MulticoequalizerDiagram.lean
+++ b/Mathlib/Order/CompleteLattice/MulticoequalizerDiagram.lean
@@ -125,5 +125,4 @@ lemma Lattice.BicartSq.multicoequalizerDiagram {T : Type u} [CompleteLattice T]
       (fun i j ↦ bif i then bif j then x₃ else x₁
         else bif j then x₁ else x₂) where
   iSup_eq := by rw [← sq.sup_eq, sup_comm, sup_eq_iSup]
-  eq_inf i j := by
-    grind [inf_idem, inf_comm]
+  eq_inf i j := by grind

--- a/Mathlib/Order/Disjoint.lean
+++ b/Mathlib/Order/Disjoint.lean
@@ -48,6 +48,7 @@ def Disjoint (a b : α) : Prop :=
 theorem disjoint_of_subsingleton [Subsingleton α] : Disjoint a b :=
   fun x _ _ ↦ le_of_eq (Subsingleton.elim x ⊥)
 
+@[grind =]
 theorem disjoint_comm : Disjoint a b ↔ Disjoint b a :=
   forall_congr' fun _ ↦ forall_swap
 
@@ -58,7 +59,7 @@ theorem Disjoint.symm ⦃a b : α⦄ : Disjoint a b → Disjoint b a :=
 theorem symmetric_disjoint : Symmetric (Disjoint : α → α → Prop) :=
   Disjoint.symm
 
-@[simp]
+@[simp, grind ←]
 theorem disjoint_bot_left : Disjoint ⊥ a := fun _ hbot _ ↦ hbot
 
 @[simp]
@@ -70,10 +71,19 @@ theorem disjoint_bot_right : Disjoint a ⊥ := fun _ _ hbot ↦ hbot
 theorem Disjoint.mono_left (h : a ≤ b) : Disjoint b c → Disjoint a c :=
   Disjoint.mono h le_rfl
 
+grind_pattern Disjoint.mono_left => a ≤ b, Disjoint b c
+grind_pattern Disjoint.mono_left => a ≤ b, Disjoint a c
+
 theorem Disjoint.mono_right (h : b ≤ c) : Disjoint a c → Disjoint a b :=
   Disjoint.mono le_rfl h
 
-@[simp]
+-- Note: we don't need separate `grind` patterns for `Disjoint.mono_right` because `grind`
+-- will use `disjoint_comm`.
+
+theorem Disjoint.out (h : Disjoint a b) (x : α) : x ≤ a → x ≤ b → x = ⊥ :=
+  fun h₁ h₂ => by simpa using h h₁ h₂
+
+@[simp, grind =]
 theorem disjoint_self : Disjoint a a ↔ a = ⊥ :=
   ⟨fun hd ↦ bot_unique <| hd le_rfl le_rfl, fun h _ ha _ ↦ ha.trans_eq h⟩
 
@@ -87,16 +97,18 @@ theorem Disjoint.ne (ha : a ≠ ⊥) (hab : Disjoint a b) : a ≠ b :=
 theorem Disjoint.eq_bot_of_le (hab : Disjoint a b) (h : a ≤ b) : a = ⊥ :=
   eq_bot_iff.2 <| hab le_rfl h
 
+grind_pattern Disjoint.eq_bot_of_le => Disjoint a b, a ≤ b
+
 theorem Disjoint.eq_bot_of_ge (hab : Disjoint a b) : b ≤ a → b = ⊥ :=
   hab.symm.eq_bot_of_le
 
-lemma Disjoint.eq_iff (hab : Disjoint a b) : a = b ↔ a = ⊥ ∧ b = ⊥ := by aesop
-lemma Disjoint.ne_iff (hab : Disjoint a b) : a ≠ b ↔ a ≠ ⊥ ∨ b ≠ ⊥ :=
-  hab.eq_iff.not.trans not_and_or
+grind_pattern Disjoint.eq_bot_of_le => Disjoint a b, b ≤ a
+
+lemma Disjoint.eq_iff (hab : Disjoint a b) : a = b ↔ a = ⊥ ∧ b = ⊥ := by grind
+lemma Disjoint.ne_iff (hab : Disjoint a b) : a ≠ b ↔ a ≠ ⊥ ∨ b ≠ ⊥ := by grind
 
 theorem disjoint_of_le_iff_left_eq_bot (h : a ≤ b) :
-    Disjoint a b ↔ a = ⊥ :=
-  ⟨fun hd ↦ hd.eq_bot_of_le h, fun h ↦ h ▸ disjoint_bot_left⟩
+    Disjoint a b ↔ a = ⊥ := by grind
 
 end PartialOrderBot
 
@@ -104,11 +116,11 @@ section PartialBoundedOrder
 
 variable [PartialOrder α] [BoundedOrder α] {a : α}
 
-@[simp]
+@[simp, grind =]
 theorem disjoint_top : Disjoint a ⊤ ↔ a = ⊥ :=
   ⟨fun h ↦ bot_unique <| h le_rfl le_top, fun h _ ha _ ↦ ha.trans_eq h⟩
 
-@[simp]
+@[simp, grind =]
 theorem top_disjoint : Disjoint ⊤ a ↔ a = ⊥ :=
   ⟨fun h ↦ bot_unique <| h le_top le_rfl, fun h _ _ ha ↦ ha.trans_eq h⟩
 
@@ -118,6 +130,7 @@ section SemilatticeInfBot
 
 variable [SemilatticeInf α] [OrderBot α] {a b c : α}
 
+-- I would like to mark this as `@[grind =]`, but it results in excessive case splitting.
 theorem disjoint_iff_inf_le : Disjoint a b ↔ a ⊓ b ≤ ⊥ :=
   ⟨fun hd ↦ hd inf_le_left inf_le_right, fun h _ ha hb ↦ (le_inf ha hb).trans h⟩
 
@@ -131,13 +144,13 @@ theorem Disjoint.eq_bot : Disjoint a b → a ⊓ b = ⊥ :=
   bot_unique ∘ Disjoint.le_bot
 
 theorem disjoint_assoc : Disjoint (a ⊓ b) c ↔ Disjoint a (b ⊓ c) := by
-  rw [disjoint_iff_inf_le, disjoint_iff_inf_le, inf_assoc]
+  grind [disjoint_iff_inf_le]
 
 theorem disjoint_left_comm : Disjoint a (b ⊓ c) ↔ Disjoint b (a ⊓ c) := by
-  simp_rw [disjoint_iff_inf_le, inf_left_comm]
+  grind [disjoint_iff_inf_le]
 
 theorem disjoint_right_comm : Disjoint (a ⊓ b) c ↔ Disjoint (a ⊓ c) b := by
-  simp_rw [disjoint_iff_inf_le, inf_right_comm]
+  grind [disjoint_iff_inf_le]
 
 variable (c)
 
@@ -209,6 +222,7 @@ arguments. -/
 def Codisjoint (a b : α) : Prop :=
   ∀ ⦃x⦄, a ≤ x → b ≤ x → ⊤ ≤ x
 
+@[grind =]
 theorem codisjoint_comm : Codisjoint a b ↔ Codisjoint b a :=
   forall_congr' fun _ ↦ forall_swap
 
@@ -219,7 +233,7 @@ theorem Codisjoint.symm ⦃a b : α⦄ : Codisjoint a b → Codisjoint b a :=
 theorem symmetric_codisjoint : Symmetric (Codisjoint : α → α → Prop) :=
   Codisjoint.symm
 
-@[simp]
+@[simp, grind ←]
 theorem codisjoint_top_left : Codisjoint ⊤ a := fun _ htop _ ↦ htop
 
 @[simp]
@@ -231,10 +245,16 @@ theorem codisjoint_top_right : Codisjoint a ⊤ := fun _ _ htop ↦ htop
 theorem Codisjoint.mono_left (h : a ≤ b) : Codisjoint a c → Codisjoint b c :=
   Codisjoint.mono h le_rfl
 
+grind_pattern Codisjoint.mono_left => a ≤ b, Codisjoint a c
+grind_pattern Codisjoint.mono_left => a ≤ b, Codisjoint b c
+
 theorem Codisjoint.mono_right : b ≤ c → Codisjoint a b → Codisjoint a c :=
   Codisjoint.mono le_rfl
 
-@[simp]
+theorem Codisjoint.out (h : Codisjoint a b) (x : α) : a ≤ x → b ≤ x → ⊤ ≤ x :=
+  fun h₁ h₂ => by simpa using h h₁ h₂
+
+@[simp, grind =]
 theorem codisjoint_self : Codisjoint a a ↔ a = ⊤ :=
   ⟨fun hd ↦ top_unique <| hd le_rfl le_rfl, fun h _ ha _ ↦ h.symm.trans_le ha⟩
 
@@ -248,12 +268,15 @@ theorem Codisjoint.ne (ha : a ≠ ⊤) (hab : Codisjoint a b) : a ≠ b :=
 theorem Codisjoint.eq_top_of_le (hab : Codisjoint a b) (h : b ≤ a) : a = ⊤ :=
   eq_top_iff.2 <| hab le_rfl h
 
+grind_pattern Codisjoint.eq_top_of_le => Codisjoint a b, b ≤ a
+
 theorem Codisjoint.eq_top_of_ge (hab : Codisjoint a b) : a ≤ b → b = ⊤ :=
   hab.symm.eq_top_of_le
 
-lemma Codisjoint.eq_iff (hab : Codisjoint a b) : a = b ↔ a = ⊤ ∧ b = ⊤ := by aesop
-lemma Codisjoint.ne_iff (hab : Codisjoint a b) : a ≠ b ↔ a ≠ ⊤ ∨ b ≠ ⊤ :=
-  hab.eq_iff.not.trans not_and_or
+grind_pattern Codisjoint.eq_top_of_ge => Codisjoint a b, a ≤ b
+
+lemma Codisjoint.eq_iff (hab : Codisjoint a b) : a = b ↔ a = ⊤ ∧ b = ⊤ := by grind
+lemma Codisjoint.ne_iff (hab : Codisjoint a b) : a ≠ b ↔ a ≠ ⊤ ∨ b ≠ ⊤ := by grind
 
 end PartialOrderTop
 
@@ -261,11 +284,11 @@ section PartialBoundedOrder
 
 variable [PartialOrder α] [BoundedOrder α] {a b : α}
 
-@[simp]
+@[simp, grind =]
 theorem codisjoint_bot : Codisjoint a ⊥ ↔ a = ⊤ :=
   ⟨fun h ↦ top_unique <| h le_rfl bot_le, fun h _ ha _ ↦ h.symm.trans_le ha⟩
 
-@[simp]
+@[simp, grind =]
 theorem bot_codisjoint : Codisjoint ⊥ a ↔ a = ⊤ :=
   ⟨fun h ↦ top_unique <| h bot_le le_rfl, fun h _ _ ha ↦ h.symm.trans_le ha⟩
 
@@ -282,6 +305,7 @@ section SemilatticeSupTop
 
 variable [SemilatticeSup α] [OrderTop α] {a b c : α}
 
+-- I would like to mark this as `@[grind =]`, but it results in excessive case splitting.
 theorem codisjoint_iff_le_sup : Codisjoint a b ↔ ⊤ ≤ a ⊔ b :=
   @disjoint_iff_inf_le αᵒᵈ _ _ _ _
 
@@ -294,14 +318,14 @@ theorem Codisjoint.top_le : Codisjoint a b → ⊤ ≤ a ⊔ b :=
 theorem Codisjoint.eq_top : Codisjoint a b → a ⊔ b = ⊤ :=
   @Disjoint.eq_bot αᵒᵈ _ _ _ _
 
-theorem codisjoint_assoc : Codisjoint (a ⊔ b) c ↔ Codisjoint a (b ⊔ c) :=
-  @disjoint_assoc αᵒᵈ _ _ _ _ _
+theorem codisjoint_assoc : Codisjoint (a ⊔ b) c ↔ Codisjoint a (b ⊔ c) := by
+  grind [codisjoint_iff_le_sup]
 
-theorem codisjoint_left_comm : Codisjoint a (b ⊔ c) ↔ Codisjoint b (a ⊔ c) :=
-  @disjoint_left_comm αᵒᵈ _ _ _ _ _
+theorem codisjoint_left_comm : Codisjoint a (b ⊔ c) ↔ Codisjoint b (a ⊔ c) := by
+  grind [codisjoint_iff_le_sup]
 
-theorem codisjoint_right_comm : Codisjoint (a ⊔ b) c ↔ Codisjoint (a ⊔ c) b :=
-  @disjoint_right_comm αᵒᵈ _ _ _ _ _
+theorem codisjoint_right_comm : Codisjoint (a ⊔ b) c ↔ Codisjoint (a ⊔ c) b := by
+  grind [codisjoint_iff_le_sup]
 
 variable (c)
 
@@ -367,22 +391,22 @@ theorem Codisjoint.dual [PartialOrder α] [OrderTop α] {a b : α} :
     Codisjoint a b → Disjoint (toDual a) (toDual b) :=
   id
 
-@[simp]
+@[simp, grind =]
 theorem disjoint_toDual_iff [PartialOrder α] [OrderTop α] {a b : α} :
     Disjoint (toDual a) (toDual b) ↔ Codisjoint a b :=
   Iff.rfl
 
-@[simp]
+@[simp, grind =]
 theorem disjoint_ofDual_iff [PartialOrder α] [OrderBot α] {a b : αᵒᵈ} :
     Disjoint (ofDual a) (ofDual b) ↔ Codisjoint a b :=
   Iff.rfl
 
-@[simp]
+@[simp, grind =]
 theorem codisjoint_toDual_iff [PartialOrder α] [OrderBot α] {a b : α} :
     Codisjoint (toDual a) (toDual b) ↔ Disjoint a b :=
   Iff.rfl
 
-@[simp]
+@[simp, grind =]
 theorem codisjoint_ofDual_iff [PartialOrder α] [OrderTop α] {a b : αᵒᵈ} :
     Codisjoint (ofDual a) (ofDual b) ↔ Disjoint a b :=
   Iff.rfl
@@ -420,6 +444,7 @@ variable [PartialOrder α] [BoundedOrder α] {x y : α}
 protected theorem symm (h : IsCompl x y) : IsCompl y x :=
   ⟨h.1.symm, h.2.symm⟩
 
+@[grind =]
 lemma _root_.isCompl_comm : IsCompl x y ↔ IsCompl y x := ⟨IsCompl.symm, IsCompl.symm⟩
 
 theorem dual (h : IsCompl x y) : IsCompl (toDual x) (toDual y) :=
@@ -435,7 +460,7 @@ section BoundedLattice
 variable [Lattice α] [BoundedOrder α] {x y : α}
 
 theorem of_le (h₁ : x ⊓ y ≤ ⊥) (h₂ : ⊤ ≤ x ⊔ y) : IsCompl x y :=
-  ⟨disjoint_iff_inf_le.mpr h₁, codisjoint_iff_le_sup.mpr h₂⟩
+  ⟨by grind [disjoint_iff_inf_le], by grind [codisjoint_iff_le_sup]⟩
 
 theorem of_eq (h₁ : x ⊓ y = ⊥) (h₂ : x ⊔ y = ⊤) : IsCompl x y :=
   ⟨disjoint_iff.mpr h₁, codisjoint_iff.mpr h₂⟩
@@ -510,6 +535,7 @@ namespace Prod
 
 variable {β : Type*} [PartialOrder α] [PartialOrder β]
 
+@[grind =]
 protected theorem disjoint_iff [OrderBot α] [OrderBot β] {x y : α × β} :
     Disjoint x y ↔ Disjoint x.1 y.1 ∧ Disjoint x.2 y.2 := by
   constructor
@@ -520,10 +546,12 @@ protected theorem disjoint_iff [OrderBot α] [OrderBot β] {x y : α × β} :
   · rintro ⟨ha, hb⟩ z hza hzb
     exact ⟨ha hza.1 hzb.1, hb hza.2 hzb.2⟩
 
+@[grind =]
 protected theorem codisjoint_iff [OrderTop α] [OrderTop β] {x y : α × β} :
     Codisjoint x y ↔ Codisjoint x.1 y.1 ∧ Codisjoint x.2 y.2 :=
   @Prod.disjoint_iff αᵒᵈ βᵒᵈ _ _ _ _ _ _
 
+@[grind =]
 protected theorem isCompl_iff [BoundedOrder α] [BoundedOrder β] {x y : α × β} :
     IsCompl x y ↔ IsCompl x.1 y.1 ∧ IsCompl x.2 y.2 := by
   simp_rw [isCompl_iff, Prod.disjoint_iff, Prod.codisjoint_iff, and_and_and_comm]
@@ -534,11 +562,11 @@ section
 
 variable [Lattice α] [BoundedOrder α] {a b x : α}
 
-@[simp]
+@[simp, grind =]
 theorem isCompl_toDual_iff : IsCompl (toDual a) (toDual b) ↔ IsCompl a b :=
   ⟨IsCompl.ofDual, IsCompl.dual⟩
 
-@[simp]
+@[simp, grind =]
 theorem isCompl_ofDual_iff {a b : αᵒᵈ} : IsCompl (ofDual a) (ofDual b) ↔ IsCompl a b :=
   ⟨IsCompl.dual, IsCompl.ofDual⟩
 

--- a/Mathlib/Order/Lattice.lean
+++ b/Mathlib/Order/Lattice.lean
@@ -176,14 +176,17 @@ theorem sup_le_sup_left (h₁ : a ≤ b) (c) : c ⊔ a ≤ c ⊔ b :=
 theorem sup_le_sup_right (h₁ : a ≤ b) (c) : a ⊔ c ≤ b ⊔ c :=
   sup_le_sup h₁ le_rfl
 
+@[grind =]
 theorem sup_idem (a : α) : a ⊔ a = a := by simp
 
 instance : Std.IdempotentOp (α := α) (· ⊔ ·) := ⟨sup_idem⟩
 
+@[grind =]
 theorem sup_comm (a b : α) : a ⊔ b = b ⊔ a := by apply le_antisymm <;> simp
 
 instance : Std.Commutative (α := α) (· ⊔ ·) := ⟨sup_comm⟩
 
+@[grind _=_]
 theorem sup_assoc (a b c : α) : a ⊔ b ⊔ c = a ⊔ (b ⊔ c) :=
   eq_of_forall_ge_iff fun x => by simp only [sup_le_iff]; rw [and_assoc]
 
@@ -364,14 +367,17 @@ theorem inf_le_inf_right (a : α) {b c : α} (h : b ≤ c) : b ⊓ a ≤ c ⊓ a
 theorem inf_le_inf_left (a : α) {b c : α} (h : b ≤ c) : a ⊓ b ≤ a ⊓ c :=
   inf_le_inf le_rfl h
 
+@[grind =]
 theorem inf_idem (a : α) : a ⊓ a = a := by simp
 
 instance : Std.IdempotentOp (α := α) (· ⊓ ·) := ⟨inf_idem⟩
 
+@[grind =]
 theorem inf_comm (a b : α) : a ⊓ b = b ⊓ a := @sup_comm αᵒᵈ _ _ _
 
 instance : Std.Commutative (α := α) (· ⊓ ·) := ⟨inf_comm⟩
 
+@[grind _=_]
 theorem inf_assoc (a b c : α) : a ⊓ b ⊓ c = a ⊓ (b ⊓ c) := @sup_assoc αᵒᵈ _ _ _ _
 
 instance : Std.Associative (α := α) (· ⊓ ·) := ⟨inf_assoc⟩

--- a/Mathlib/Order/SupIndep.lean
+++ b/Mathlib/Order/SupIndep.lean
@@ -213,7 +213,7 @@ protected theorem SupIndep.disjoint_sup_sup {s : Finset ι} {f : ι → α} {u v
   induction u using Finset.induction generalizing v with
   | empty => simp
   | insert x u hx ih =>
-    grind [= SupIndep, = disjoint_comm, ← Disjoint.disjoint_sup_left_of_disjoint_sup_right]
+    grind [= SupIndep, Disjoint.disjoint_sup_left_of_disjoint_sup_right]
 
 theorem supIndep_sigma_iff' {β : ι → Type*} {s : Finset ι} {g : ∀ i, Finset (β i)}
     {f : Sigma β → α} : (s.sigma g).SupIndep f ↔ (s.SupIndep fun i => (g i).sup fun b => f ⟨i, b⟩)

--- a/MathlibTest/grind/pairwise_disjoint.lean
+++ b/MathlibTest/grind/pairwise_disjoint.lean
@@ -14,13 +14,6 @@ theorem LawfulSingleton.insert_empty_eq' [EmptyCollection β] [Insert α β] [Si
 
 attribute [grind _=_] LawfulSingleton.insert_empty_eq'
 
-attribute [grind =] Finset.mem_singleton
-
-attribute [grind =] Finset.disjoint_insert_left
-attribute [grind =] Finset.disjoint_insert_right
-attribute [grind ←] Finset.disjoint_empty_left
-attribute [grind ←] Finset.disjoint_empty_right
-
 attribute [grind] Pairwise
 
 example : Pairwise (Function.onFun Disjoint fun x ↦ S1 x) := by


### PR DESCRIPTION
## Summary

Add `grind` annotations for lattice sup/inf properties:
- `@[grind =]` on `sup_idem`, `sup_comm`, `inf_idem`, `inf_comm`
- `@[grind _=_]` on `sup_assoc`, `inf_assoc`

## Context

These annotations were originally part of the `grind_disjoint` PR but were removed because they cause a significant performance regression. For example, `Mathlib.Order.Interval.Set.LinearOrder` goes from **2.2s to 9.5s** (~4.3x slower) with these annotations present.

The slowdown occurs because these fundamental lattice lemmas get registered with grind's AC module, and since `⊔` and `⊓` are extremely pervasive (e.g., `max`/`min` expand to them), grind ends up doing excessive work on proofs that involve these operations.

## Status

This PR should remain as a draft until Leo adds the new AC matching module to grind, at which point these annotations may become unnecessary or the performance issue may be resolved.

🤖 Prepared with Claude Code