### PR TITLE
[Merged by Bors] - feat(Data/Finite/Defs): add `@[push]` tag for `Set.not_finite` and `Set.not_infinite`

### DIFF
--- a/Archive/Imo/Imo2024Q3.lean
+++ b/Archive/Imo/Imo2024Q3.lean
@@ -161,22 +161,20 @@ lemma apply_add_one_ne_of_apply_eq {i j : ℕ} (hi : N ≤ i) (hj : N ≤ j) (hi
     (hc.apply_add_one_lt_of_apply_eq hj h ha.symm).ne'
 
 lemma exists_infinite_setOf_apply_eq : ∃ m, {i | a i = m}.Infinite := by
-  by_contra hi
+  by_contra! hi
   have hr : (Set.range a).Infinite := by
     contrapose! hi with hr
-    rw [Set.not_infinite, ← Set.finite_coe_iff] at hr
+    rw [← Set.finite_coe_iff] at hr
     obtain ⟨n, hn⟩ := Finite.exists_infinite_fiber (Set.rangeFactorization a)
     rw [Set.infinite_coe_iff, Set.preimage] at hn
     simp only [Set.mem_singleton_iff, Set.rangeFactorization, Subtype.ext_iff] at hn
     exact ⟨↑n, hn⟩
-  simp only [not_exists, Set.not_infinite] at hi
   have hinj : Set.InjOn (fun i ↦ Nat.nth (a · = i) 0 + 1) (Set.range a \ Set.Ico 0 (M a N)) := by
     rintro _ ⟨⟨_, rfl⟩, hi⟩ _ ⟨⟨_, rfl⟩, hj⟩ h
     simp only [Set.mem_Ico, zero_le, true_and, not_lt] at hi hj
     simp only [add_left_inj] at h
     convert congr(a $h) using 1 <;> simp [apply_nth_zero]
-  refine Set.not_infinite.2 (hi 1) (Set.infinite_of_injOn_mapsTo hinj (fun i hi ↦ ?_)
-    (hr.diff (Set.finite_Ico _ _)))
+  refine (Set.infinite_of_injOn_mapsTo hinj (fun i hi ↦ ?_) (hr.diff (Set.finite_Ico _ _))) (hi 1)
   simp only [Set.mem_diff, Set.mem_range, Set.mem_Ico, zero_le, true_and, not_lt] at hi
   rcases hi with ⟨⟨_, rfl⟩, hi⟩
   exact hc.apply_nth_add_one_eq toFinset_card_pos
@@ -313,7 +311,7 @@ lemma infinite_setOf_apply_eq_iff_small {j : ℕ} (hj : 0 < j) :
 
 lemma finite_setOf_apply_eq_iff_not_small {j : ℕ} (hj : 0 < j) :
     {i | a i = j}.Finite ↔ ¬Small a j := by
-  simpa only [Set.not_infinite] using (hc.infinite_setOf_apply_eq_iff_small hj).not
+  contrapose!; exact hc.infinite_setOf_apply_eq_iff_small hj
 
 lemma finite_setOf_apply_eq_k_add_one : {i | a i = k a + 1}.Finite := by
   rw [hc.finite_setOf_apply_eq_iff_not_small (by omega), Small]

--- a/Counterexamples/AharoniKorman.lean
+++ b/Counterexamples/AharoniKorman.lean
@@ -354,8 +354,7 @@ theorem no_infinite_antichain {A : Set Hollom} (hC : IsAntichain (· ≤ ·) A) 
     intro x hx
     exact no_infinite_antichain_level (this _) (hC.subset Set.inter_subset_left)
   case himage =>
-    rw [← Set.not_infinite]
-    intro h
+    by_contra! h
     obtain ⟨n, hn⟩ := h.nonempty
     suffices f '' A ⊆ Set.Iio (n + 2) from h ((Set.finite_Iio _).subset this)
     intro m
@@ -385,7 +384,6 @@ theorem exists_finite_intersection (hC : IsChain (· ≤ ·) C) :
   rw [frequently_atTop]
   intro n₀
   by_contra! hC'
-  simp only [← Set.not_infinite, not_not] at hC'
   -- Define `m n` to be the smallest value of `min x y` as `(x, y, n)` ranges over `C`.
   let m (n : ℕ) : ℕ := sInf {min (ofHollom x).1 (ofHollom x).2.1 | x ∈ C ∩ level n}
   -- `m n` is well-defined above `n₀`, since the set in question is nonempty (it's infinite).

--- a/Mathlib/Algebra/Order/Archimedean/IndicatorCard.lean
+++ b/Mathlib/Algebra/Order/Archimedean/IndicatorCard.lean
@@ -60,9 +60,8 @@ lemma infinite_iff_tendsto_sum_indicator_atTop {R : Type*}
       rw [Finset.mem_range]
       exact (hm i_t).trans_lt (lt_add_one m)
     rw [sum_indicator_subset (fun _ ↦ r) h, sum_eq_card_nsmul (fun _ _ ↦ rfl), t_card]
-  · contrapose
+  · contrapose!
     intro hs
-    rw [not_infinite] at hs
     rw [tendsto_congr' (sum_indicator_eventually_eq_card r hs), tendsto_atTop_atTop]
     push_neg
     obtain ⟨m, hm⟩ := exists_lt_nsmul h (Nat.card s • r)

--- a/Mathlib/Combinatorics/Matroid/Basic.lean
+++ b/Mathlib/Combinatorics/Matroid/Basic.lean
@@ -421,15 +421,15 @@ theorem IsBase.finite_of_finite {B' : Set α}
   (finite_iff_finite_of_encard_eq_encard (hB.encard_eq_encard_of_isBase hB')).mp h
 
 theorem IsBase.infinite_of_infinite (hB : M.IsBase B) (h : B.Infinite) (hB₁ : M.IsBase B₁) :
-    B₁.Infinite :=
-  by_contra (fun hB_inf ↦ (hB₁.finite_of_finite (not_infinite.mp hB_inf) hB).not_infinite h)
+    B₁.Infinite := by
+  contrapose! h; exact hB₁.finite_of_finite h hB
 
 theorem IsBase.finite [RankFinite M] (hB : M.IsBase B) : B.Finite :=
-  let ⟨_,hB₀⟩ := ‹RankFinite M›.exists_finite_isBase
+  let ⟨_, hB₀⟩ := ‹RankFinite M›.exists_finite_isBase
   hB₀.1.finite_of_finite hB₀.2 hB
 
 theorem IsBase.infinite [RankInfinite M] (hB : M.IsBase B) : B.Infinite :=
-  let ⟨_,hB₀⟩ := ‹RankInfinite M›.exists_infinite_isBase
+  let ⟨_, hB₀⟩ := ‹RankInfinite M›.exists_infinite_isBase
   hB₀.1.infinite_of_infinite hB₀.2 hB
 
 theorem empty_not_isBase [h : RankPos M] : ¬M.IsBase ∅ :=

--- a/Mathlib/Data/ENat/Lattice.lean
+++ b/Mathlib/Data/ENat/Lattice.lean
@@ -87,7 +87,6 @@ lemma sSup_eq_top_of_infinite (h : s.Infinite) : sSup s = ⊤ := by
   | top => simp at hx
   | coe x =>
     contrapose! h
-    simp only [not_infinite]
     apply Finite.subset <| Finite.Set.finite_image {n : ℕ | n ≤ x} (fun (n : ℕ) => (n : ℕ∞))
     intro y hy
     specialize h y hy

--- a/Mathlib/Data/Finite/Defs.lean
+++ b/Mathlib/Data/Finite/Defs.lean
@@ -206,7 +206,10 @@ This is protected so that it does not conflict with global `Infinite`. -/
 protected def Infinite (s : Set α) : Prop :=
   ¬s.Finite
 
-@[simp]
+@[push]
+theorem not_finite {s : Set α} : ¬s.Finite ↔ s.Infinite := Iff.rfl
+
+@[simp, push]
 theorem not_infinite {s : Set α} : ¬s.Infinite ↔ s.Finite :=
   not_not
 

--- a/Mathlib/Data/Finite/Prod.lean
+++ b/Mathlib/Data/Finite/Prod.lean
@@ -178,7 +178,8 @@ protected theorem infinite_prod :
     · exact h.1.prod_right h.2
 
 theorem finite_prod : (s ×ˢ t).Finite ↔ (s.Finite ∨ t = ∅) ∧ (t.Finite ∨ s = ∅) := by
-  simp only [← not_infinite, Set.infinite_prod, not_or, not_and_or, not_nonempty_iff_eq_empty]
+  set_option push_neg.use_distrib true in
+  contrapose!; exact Set.infinite_prod
 
 protected theorem Finite.offDiag {s : Set α} (hs : s.Finite) : s.offDiag.Finite :=
   (hs.prod hs).subset s.offDiag_subset_prod
@@ -235,9 +236,9 @@ theorem infinite_image2 (hfs : ∀ b ∈ t, InjOn (fun a => f a b) s) (hft : ∀
 
 lemma finite_image2 (hfs : ∀ b ∈ t, InjOn (f · b) s) (hft : ∀ a ∈ s, InjOn (f a) t) :
     (image2 f s t).Finite ↔ s.Finite ∧ t.Finite ∨ s = ∅ ∨ t = ∅ := by
-  rw [← not_infinite, infinite_image2 hfs hft]
-  simp [not_or, -not_and, not_and_or, not_nonempty_iff_eq_empty]
-  aesop
+  set_option push_neg.use_distrib true in contrapose!
+  rw [Set.infinite_image2 hfs hft]
+  grind only [Set.Infinite.nonempty]
 
 end Image2
 

--- a/Mathlib/Data/Set/Card.lean
+++ b/Mathlib/Data/Set/Card.lean
@@ -157,7 +157,8 @@ theorem Finite.exists_encard_eq_coe (h : s.Finite) : ∃ (n : ℕ), s.encard = n
   ⟨fun h ↦ by_contra fun h' ↦ h.ne (Infinite.encard_eq h'), Finite.encard_lt_top⟩
 
 @[simp] theorem encard_eq_top_iff : s.encard = ⊤ ↔ s.Infinite := by
-  rw [← not_iff_not, ← Ne, ← lt_top_iff_ne_top, encard_lt_top_iff, not_infinite]
+  contrapose!
+  rw [← lt_top_iff_ne_top, encard_lt_top_iff]
 
 alias ⟨_, encard_eq_top⟩ := encard_eq_top_iff
 

--- a/Mathlib/Data/Set/MulAntidiagonal.lean
+++ b/Mathlib/Data/Set/MulAntidiagonal.lean
@@ -103,7 +103,7 @@ variable {s t}
 
 @[to_additive Set.AddAntidiagonal.finite_of_isPWO]
 theorem finite_of_isPWO (hs : s.IsPWO) (ht : t.IsPWO) (a) : (mulAntidiagonal s t a).Finite := by
-  refine not_infinite.1 fun h => ?_
+  by_contra! h
   have h1 : (mulAntidiagonal s t a).PartiallyWellOrderedOn (Prod.fst ⁻¹'o (· ≤ ·)) :=
     fun f ↦ hs fun n ↦ ⟨_, (mem_mulAntidiagonal.1 (f n).2).1⟩
   have h2 : (mulAntidiagonal s t a).PartiallyWellOrderedOn (Prod.snd ⁻¹'o (· ≤ ·)) :=

--- a/Mathlib/Data/Set/SMulAntidiagonal.lean
+++ b/Mathlib/Data/Set/SMulAntidiagonal.lean
@@ -99,7 +99,7 @@ theorem eq_of_fst_le_fst_of_snd_le_snd (h₁ : (x : G × P).1 ≤ (y : G × P).1
 
 @[to_additive VAddAntidiagonal.finite_of_isPWO]
 theorem finite_of_isPWO (hs : s.IsPWO) (ht : t.IsPWO) (a) : (smulAntidiagonal s t a).Finite := by
-  refine Set.not_infinite.1 fun h => ?_
+  by_contra! h
   have h1 : (smulAntidiagonal s t a).PartiallyWellOrderedOn (Prod.fst ⁻¹'o (· ≤ ·)) :=
     fun f ↦ hs fun n ↦ ⟨_, (mem_smulAntidiagonal.1 (f n).2).1⟩
   have h2 : (smulAntidiagonal s t a).PartiallyWellOrderedOn (Prod.snd ⁻¹'o (· ≤ ·)) :=

--- a/Mathlib/GroupTheory/OrderOfElement.lean
+++ b/Mathlib/GroupTheory/OrderOfElement.lean
@@ -578,7 +578,7 @@ theorem infinite_not_isOfFinOrder {x : G} (h : ¬IsOfFinOrder x) :
   suffices s.Infinite by exact this.mono hs
   contrapose! h
   have : ¬Injective fun n : ℕ => x ^ n := by
-    have := Set.not_injOn_infinite_finite_image (Set.Ioi_infinite 0) (Set.not_infinite.mp h)
+    have := Set.not_injOn_infinite_finite_image (Set.Ioi_infinite 0) h
     contrapose! this
     exact Set.injOn_of_injective this
   rwa [injective_pow_iff_not_isOfFinOrder, Classical.not_not] at this

--- a/Mathlib/LinearAlgebra/Reflection.lean
+++ b/Mathlib/LinearAlgebra/Reflection.lean
@@ -431,7 +431,6 @@ lemma eq_of_mapsTo_reflection_of_mem [IsAddTorsionFree M] {Φ : Set M} (hΦ : Φ
   suffices h : f y • x = (2 : R) • y by
     rw [hfy, two_smul R x, two_smul R y, ← two_zsmul, ← two_zsmul] at h
     exact smul_right_injective _ two_ne_zero h
-  rw [← not_infinite] at hΦ
   contrapose! hΦ
   apply ((infinite_range_reflection_reflection_iterate_iff hfx hgy
     (by rw [hfy, hgx]; norm_cast)).mpr hΦ).mono

--- a/Mathlib/NumberTheory/DiophantineApproximation/Basic.lean
+++ b/Mathlib/NumberTheory/DiophantineApproximation/Basic.lean
@@ -277,10 +277,11 @@ end Rat
 theorem Real.infinite_rat_abs_sub_lt_one_div_den_sq_iff_irrational (ξ : ℝ) :
     {q : ℚ | |ξ - q| < 1 / (q.den : ℝ) ^ 2}.Infinite ↔ Irrational ξ := by
   refine
-    ⟨fun h => (irrational_iff_ne_rational ξ).mpr fun a b _ H => Set.not_infinite.mpr ?_ h,
+    ⟨fun h => (irrational_iff_ne_rational ξ).mpr fun a b _ => ?_,
       Real.infinite_rat_abs_sub_lt_one_div_den_sq_of_irrational⟩
+  contrapose! h
   convert Rat.finite_rat_abs_sub_lt_one_div_den_sq ((a : ℚ) / b) with q
-  rw [H, (by (push_cast; rfl) : (1 : ℝ) / (q.den : ℝ) ^ 2 = (1 / (q.den : ℚ) ^ 2 : ℚ))]
+  rw [h, (by (push_cast; rfl) : (1 : ℝ) / (q.den : ℝ) ^ 2 = (1 / (q.den : ℚ) ^ 2 : ℚ))]
   norm_cast
 
 /-!

--- a/Mathlib/NumberTheory/LSeries/PrimesInAP.lean
+++ b/Mathlib/NumberTheory/LSeries/PrimesInAP.lean
@@ -475,8 +475,7 @@ integer and `a : ZMod q` is a unit, then there are infinitely many prime numbers
 such that `(p : ZMod q) = a`. -/
 theorem infinite_setOf_prime_and_eq_mod (ha : IsUnit a) :
     {p : ℕ | p.Prime ∧ (p : ZMod q) = a}.Infinite := by
-  by_contra H
-  rw [Set.not_infinite] at H
+  by_contra! H
   exact not_summable_residueClass_prime_div ha <|
     summable_of_finite_support <| support_residueClass_prime_div a ▸ H
 

--- a/Mathlib/NumberTheory/Pell.lean
+++ b/Mathlib/NumberTheory/Pell.lean
@@ -346,7 +346,6 @@ theorem exists_of_not_isSquare (h₀ : 0 < d) (hd : ¬IsSquare d) :
     exact q.pos
   obtain ⟨m, hm⟩ : ∃ m : ℤ, {q : ℚ | q.1 ^ 2 - d * (q.den : ℤ) ^ 2 = m}.Infinite := by
     contrapose! hM
-    simp only [not_infinite] at hM ⊢
     refine (congr_arg _ (ext fun x => ?_)).mp (Finite.biUnion (finite_Ioo (-M) M) fun m _ => hM m)
     simp only [abs_lt, mem_setOf, mem_Ioo, mem_iUnion, exists_prop, exists_eq_right']
   have hm₀ : m ≠ 0 := by

--- a/Mathlib/Order/CompactlyGenerated/Basic.lean
+++ b/Mathlib/Order/CompactlyGenerated/Basic.lean
@@ -283,7 +283,7 @@ end CompleteLattice
 theorem WellFoundedGT.finite_of_sSupIndep [WellFoundedGT α] {s : Set α}
     (hs : sSupIndep s) : s.Finite := by
   classical
-    refine Set.not_infinite.mp fun contra => ?_
+    by_contra! contra
     obtain ⟨t, ht₁, ht₂⟩ := CompleteLattice.WellFoundedGT.isSupFiniteCompact α s
     replace contra : ∃ x : α, x ∈ s ∧ x ≠ ⊥ ∧ x ∉ t := by
       have : (s \ (insert ⊥ t : Finset α)).Infinite := contra.diff (Finset.finite_toSet _)

--- a/Mathlib/Order/WellFoundedSet.lean
+++ b/Mathlib/Order/WellFoundedSet.lean
@@ -305,7 +305,7 @@ theorem PartiallyWellOrderedOn.image_of_monotone_on (hs : s.PartiallyWellOrdered
 -- TODO: prove this in terms of `IsAntichain.finite_of_wellQuasiOrdered`
 theorem _root_.IsAntichain.finite_of_partiallyWellOrderedOn (ha : IsAntichain r s)
     (hp : s.PartiallyWellOrderedOn r) : s.Finite := by
-  refine not_infinite.1 fun hi => ?_
+  by_contra! hi
   obtain ⟨m, n, hmn, h⟩ := hp (hi.natEmbedding _)
   exact hmn.ne ((hi.natEmbedding _).injective <| Subtype.val_injective <|
     ha.eq (hi.natEmbedding _ m).2 (hi.natEmbedding _ n).2 h)

--- a/Mathlib/Order/WellQuasiOrder.lean
+++ b/Mathlib/Order/WellQuasiOrder.lean
@@ -47,7 +47,7 @@ theorem wellQuasiOrdered_of_isEmpty [IsEmpty α] (r : α → α → Prop) : Well
 
 theorem IsAntichain.finite_of_wellQuasiOrdered {s : Set α} (hs : IsAntichain r s)
     (hr : WellQuasiOrdered r) : s.Finite := by
-  refine Set.not_infinite.1 fun hi => ?_
+  by_contra! hi
   obtain ⟨m, n, hmn, h⟩ := hr fun n => hi.natEmbedding _ n
   exact hmn.ne ((hi.natEmbedding _).injective <| Subtype.val_injective <|
     hs.eq (hi.natEmbedding _ m).2 (hi.natEmbedding _ n).2 h)


### PR DESCRIPTION
This PR extends `push_neg` with the two lemmas about `Set.Infinite`/`Set.Finite`.

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

When merging, all the commits will be squashed into a single commit
listing all co-authors.

Co-authors in the squash commit are gathered from two sources:

First, all authors of commits to this PR branch are included. Thus,
one way to add co-authors is to include at least one commit authored by
each co-author among the commits in the pull request. If necessary, you
may create empty commits to indicate co-authorship, using commands like so:

git commit --author="Author Name <author@email.com>" --allow-empty -m "add Author Name as coauthor"

Second, co-authors can also be listed in lines at the very bottom of
the commit message (that is, directly before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines
at the bottom of the commit message (before the `---`, and also before
any "Co-authored-by" lines) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
