### PR TITLE
[Merged by Bors] - chore(Data/Finset): golf `restrict_preimage` using `ext; simp_all`

### DIFF
--- a/Mathlib/Data/Finset/Pi.lean
+++ b/Mathlib/Data/Finset/Pi.lean
@@ -191,12 +191,8 @@ lemma dependsOn_restrict (s : Finset ι) : DependsOn (s.restrict (π := π)) s :
 lemma restrict_preimage [DecidablePred (· ∈ s)] (t : (i : s) → Set (π i)) :
     s.restrict ⁻¹' (Set.univ.pi t) =
       Set.pi s (fun i ↦ if h : i ∈ s then t ⟨i, h⟩ else Set.univ) := by
-  ext x
-  simp only [Set.mem_preimage, Set.mem_pi, Set.mem_univ, restrict, forall_const, Subtype.forall,
-    mem_coe]
-  refine ⟨fun h i hi ↦ by simpa [hi] using h i hi, fun h i hi ↦ ?_⟩
-  convert h i hi
-  rw [dif_pos hi]
+  ext
+  simp_all
 
 lemma restrict₂_preimage [DecidablePred (· ∈ s)] (hst : s ⊆ t) (u : (i : s) → Set (π i)) :
     (restrict₂ hst) ⁻¹' (Set.univ.pi u) =


### PR DESCRIPTION
---
<details>
<summary>Show trace profiling of <code>restrict_preimage</code>: 52 ms before, 47 ms after  🎉</summary>

### Trace profiling of `restrict_preimage` before PR 32208
```diff
diff --git a/Mathlib/Data/Finset/Pi.lean b/Mathlib/Data/Finset/Pi.lean
index dba035dadf..955f99dce5 100644
--- a/Mathlib/Data/Finset/Pi.lean
+++ b/Mathlib/Data/Finset/Pi.lean
@@ -188,6 +188,7 @@ theorem restrict₂_comp_restrict₂ (hst : s ⊆ t) (htu : t ⊆ u) :
 lemma dependsOn_restrict (s : Finset ι) : DependsOn (s.restrict (π := π)) s :=
   (s : Set ι).dependsOn_restrict
 
+set_option trace.profiler true in
 lemma restrict_preimage [DecidablePred (· ∈ s)] (t : (i : s) → Set (π i)) :
     s.restrict ⁻¹' (Set.univ.pi t) =
       Set.pi s (fun i ↦ if h : i ∈ s then t ⟨i, h⟩ else Set.univ) := by
```
```
ℹ [639/639] Built Mathlib.Data.Finset.Pi (1.1s)
info: Mathlib/Data/Finset/Pi.lean:192:0: [Elab.async] [0.052442] elaborating proof of Finset.restrict_preimage
  [Elab.definition.value] [0.051712] Finset.restrict_preimage
    [Elab.step] [0.051317] 
          ext x
          simp only [Set.mem_preimage, Set.mem_pi, Set.mem_univ, restrict, forall_const, Subtype.forall, mem_coe]
          refine ⟨fun h i hi ↦ by simpa [hi] using h i hi, fun h i hi ↦ ?_⟩
          convert h i hi
          rw [dif_pos hi]
      [Elab.step] [0.051310] 
            ext x
            simp only [Set.mem_preimage, Set.mem_pi, Set.mem_univ, restrict, forall_const, Subtype.forall, mem_coe]
            refine ⟨fun h i hi ↦ by simpa [hi] using h i hi, fun h i hi ↦ ?_⟩
            convert h i hi
            rw [dif_pos hi]
        [Elab.step] [0.037821] convert h i hi
Build completed successfully (639 jobs).
```

### Trace profiling of `restrict_preimage` after PR 32208
```diff
diff --git a/Mathlib/Data/Finset/Pi.lean b/Mathlib/Data/Finset/Pi.lean
index dba035dadf..d28feb7cb0 100644
--- a/Mathlib/Data/Finset/Pi.lean
+++ b/Mathlib/Data/Finset/Pi.lean
@@ -188,15 +188,12 @@ theorem restrict₂_comp_restrict₂ (hst : s ⊆ t) (htu : t ⊆ u) :
 lemma dependsOn_restrict (s : Finset ι) : DependsOn (s.restrict (π := π)) s :=
   (s : Set ι).dependsOn_restrict
 
+set_option trace.profiler true in
 lemma restrict_preimage [DecidablePred (· ∈ s)] (t : (i : s) → Set (π i)) :
     s.restrict ⁻¹' (Set.univ.pi t) =
       Set.pi s (fun i ↦ if h : i ∈ s then t ⟨i, h⟩ else Set.univ) := by
-  ext x
-  simp only [Set.mem_preimage, Set.mem_pi, Set.mem_univ, restrict, forall_const, Subtype.forall,
-    mem_coe]
-  refine ⟨fun h i hi ↦ by simpa [hi] using h i hi, fun h i hi ↦ ?_⟩
-  convert h i hi
-  rw [dif_pos hi]
+  ext
+  simp_all
 
 lemma restrict₂_preimage [DecidablePred (· ∈ s)] (hst : s ⊆ t) (u : (i : s) → Set (π i)) :
     (restrict₂ hst) ⁻¹' (Set.univ.pi u) =
```
```
ℹ [639/639] Built Mathlib.Data.Finset.Pi (1.1s)
info: Mathlib/Data/Finset/Pi.lean:192:0: [Elab.async] [0.047462] elaborating proof of Finset.restrict_preimage
  [Elab.definition.value] [0.046922] Finset.restrict_preimage
    [Elab.step] [0.046645] 
          ext
          simp_all
      [Elab.step] [0.046639] 
            ext
            simp_all
        [Elab.step] [0.046406] simp_all
          [Meta.Tactic.simp.discharge] [0.010080] IsEmpty.forall_iff discharge ❌️
                IsEmpty ↥s
Build completed successfully (639 jobs).
```
</details>

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

When merging, all the commits will be squashed into a single commit
listing all co-authors.

Co-authors in the squash commit are gathered from two sources:

First, all authors of commits to this PR branch are included. Thus,
one way to add co-authors is to include at least one commit authored by
each co-author among the commits in the pull request. If necessary, you
may create empty commits to indicate co-authorship, using commands like so:

git commit --author="Author Name <author@email.com>" --allow-empty -m "add Author Name as coauthor"

Second, co-authors can also be listed in lines at the very bottom of
the commit message (that is, directly before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines
at the bottom of the commit message (before the `---`, and also before
any "Co-authored-by" lines) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
