### PR TITLE
[Merged by Bors] - chore(RingTheory): golf `liftAlgHom_eq_algHom` and `quotient_mk_maps_eq` using `ext; simp`

### DIFF
--- a/Mathlib/RingTheory/AdjoinRoot.lean
+++ b/Mathlib/RingTheory/AdjoinRoot.lean
@@ -343,10 +343,8 @@ theorem aeval_algHom_eq_zero (ϕ : AdjoinRoot f →ₐ[R] S) : aeval (ϕ (root f
 @[simp]
 theorem liftAlgHom_eq_algHom (ϕ : AdjoinRoot f →ₐ[R] S) :
     liftAlgHom f (Algebra.ofId R S) (ϕ (root f)) (aeval_algHom_eq_zero f ϕ) = ϕ := by
-  suffices AlgHom.equalizer ϕ (liftAlgHom f _ (ϕ (root f)) (aeval_algHom_eq_zero f ϕ)) = ⊤ by
-    exact (AlgHom.ext fun x => (SetLike.ext_iff.mp this x).mpr Algebra.mem_top).symm
-  rw [eq_top_iff, ← adjoinRoot_eq_top, Algebra.adjoin_le_iff, Set.singleton_subset_iff]
-  exact (@lift_root _ _ _ _ _ _ _ (aeval_algHom_eq_zero f ϕ)).symm
+  ext
+  simp
 
 set_option linter.deprecated false in
 @[deprecated liftAlgHom_eq_algHom (since := "2025-10-10")]

--- a/Mathlib/RingTheory/Ideal/GoingUp.lean
+++ b/Mathlib/RingTheory/Ideal/GoingUp.lean
@@ -95,9 +95,8 @@ theorem quotient_mk_maps_eq (P : Ideal R[X]) :
       (Ideal.quotientMap (map (mapRingHom (Quotient.mk (P.comap (C : R →+* R[X])))) P)
             (mapRingHom (Quotient.mk (P.comap (C : R →+* R[X])))) le_comap_map).comp
         ((Quotient.mk P).comp C) := by
-  refine RingHom.ext fun x => ?_
-  repeat' rw [RingHom.coe_comp, Function.comp_apply]
-  rw [quotientMap_mk, coe_mapRingHom, map_C]
+  ext
+  simp
 
 /-- This technical lemma asserts the existence of a polynomial `p` in an ideal `P ⊂ R[x]`
 that is non-zero in the quotient `R / (P ∩ R) [x]`.  The assumptions are equivalent to


### PR DESCRIPTION
---
<details>
<summary>Show trace profiling of <code>liftAlgHom_eq_algHom</code>: 37 ms before, <10 ms after  🎉</summary>

### Trace profiling of `liftAlgHom_eq_algHom` before PR 32209
```diff
diff --git a/Mathlib/RingTheory/AdjoinRoot.lean b/Mathlib/RingTheory/AdjoinRoot.lean
index ee7b88afa2..7e98824cfe 100644
--- a/Mathlib/RingTheory/AdjoinRoot.lean
+++ b/Mathlib/RingTheory/AdjoinRoot.lean
@@ -340,6 +340,7 @@ theorem aeval_algHom_eq_zero (ϕ : AdjoinRoot f →ₐ[R] S) : aeval (ϕ (root f
   rw [aeval_def, ← h, ← map_zero ϕ.toRingHom, ← eval₂_root f, hom_eval₂]
   rfl
 
+set_option trace.profiler true in
 @[simp]
 theorem liftAlgHom_eq_algHom (ϕ : AdjoinRoot f →ₐ[R] S) :
     liftAlgHom f (Algebra.ofId R S) (ϕ (root f)) (aeval_algHom_eq_zero f ϕ) = ϕ := by
```
```
ℹ [1751/1751] Built Mathlib.RingTheory.AdjoinRoot (5.5s)
info: Mathlib/RingTheory/AdjoinRoot.lean:344:0: [Elab.command] [0.010215] @[simp]
    theorem liftAlgHom_eq_algHom (ϕ : AdjoinRoot f →ₐ[R] S) :
        liftAlgHom f (Algebra.ofId R S) (ϕ (root f)) (aeval_algHom_eq_zero f ϕ) = ϕ :=
      by
      suffices AlgHom.equalizer ϕ (liftAlgHom f _ (ϕ (root f)) (aeval_algHom_eq_zero f ϕ)) = ⊤ by
        exact (AlgHom.ext fun x => (SetLike.ext_iff.mp this x).mpr Algebra.mem_top).symm
      rw [eq_top_iff, ← adjoinRoot_eq_top, Algebra.adjoin_le_iff, Set.singleton_subset_iff]
      exact (@lift_root _ _ _ _ _ _ _ (aeval_algHom_eq_zero f ϕ)).symm
info: Mathlib/RingTheory/AdjoinRoot.lean:344:0: [Elab.async] [0.038233] elaborating proof of AdjoinRoot.liftAlgHom_eq_algHom
  [Elab.definition.value] [0.037369] AdjoinRoot.liftAlgHom_eq_algHom
    [Elab.step] [0.036774] 
          suffices AlgHom.equalizer ϕ (liftAlgHom f _ (ϕ (root f)) (aeval_algHom_eq_zero f ϕ)) = ⊤ by
            exact (AlgHom.ext fun x => (SetLike.ext_iff.mp this x).mpr Algebra.mem_top).symm
          rw [eq_top_iff, ← adjoinRoot_eq_top, Algebra.adjoin_le_iff, Set.singleton_subset_iff]
          exact (@lift_root _ _ _ _ _ _ _ (aeval_algHom_eq_zero f ϕ)).symm
      [Elab.step] [0.036767] 
            suffices AlgHom.equalizer ϕ (liftAlgHom f _ (ϕ (root f)) (aeval_algHom_eq_zero f ϕ)) = ⊤ by
              exact (AlgHom.ext fun x => (SetLike.ext_iff.mp this x).mpr Algebra.mem_top).symm
            rw [eq_top_iff, ← adjoinRoot_eq_top, Algebra.adjoin_le_iff, Set.singleton_subset_iff]
            exact (@lift_root _ _ _ _ _ _ _ (aeval_algHom_eq_zero f ϕ)).symm
        [Elab.step] [0.015892] suffices AlgHom.equalizer ϕ (liftAlgHom f _ (ϕ (root f)) (aeval_algHom_eq_zero f ϕ)) = ⊤
              by exact (AlgHom.ext fun x => (SetLike.ext_iff.mp this x).mpr Algebra.mem_top).symm
          [Elab.step] [0.015885] refine_lift
                suffices AlgHom.equalizer ϕ (liftAlgHom f _ (ϕ (root f)) (aeval_algHom_eq_zero f ϕ)) = ⊤ by
                  exact (AlgHom.ext fun x => (SetLike.ext_iff.mp this x).mpr Algebra.mem_top).symm;
                ?_
            [Elab.step] [0.015881] focus
                  (refine
                      no_implicit_lambda%
                        (suffices AlgHom.equalizer ϕ (liftAlgHom f _ (ϕ (root f)) (aeval_algHom_eq_zero f ϕ)) = ⊤ by
                          exact (AlgHom.ext fun x => (SetLike.ext_iff.mp this x).mpr Algebra.mem_top).symm;
                        ?_);
                    rotate_right)
              [Elab.step] [0.015877] (refine
                        no_implicit_lambda%
                          (suffices AlgHom.equalizer ϕ (liftAlgHom f _ (ϕ (root f)) (aeval_algHom_eq_zero f ϕ)) = ⊤ by
                            exact (AlgHom.ext fun x => (SetLike.ext_iff.mp this x).mpr Algebra.mem_top).symm;
                          ?_);
                      rotate_right)
                [Elab.step] [0.015875] (refine
                          no_implicit_lambda%
                            (suffices AlgHom.equalizer ϕ (liftAlgHom f _ (ϕ (root f)) (aeval_algHom_eq_zero f ϕ)) = ⊤ by
                              exact (AlgHom.ext fun x => (SetLike.ext_iff.mp this x).mpr Algebra.mem_top).symm;
                            ?_);
                        rotate_right)
                  [Elab.step] [0.015872] (refine
                          no_implicit_lambda%
                            (suffices AlgHom.equalizer ϕ (liftAlgHom f _ (ϕ (root f)) (aeval_algHom_eq_zero f ϕ)) = ⊤ by
                              exact (AlgHom.ext fun x => (SetLike.ext_iff.mp this x).mpr Algebra.mem_top).symm;
                            ?_);
                        rotate_right)
                    [Elab.step] [0.015869] refine
                            no_implicit_lambda%
                              (suffices AlgHom.equalizer ϕ (liftAlgHom f _ (ϕ (root f)) (aeval_algHom_eq_zero f ϕ)) = ⊤
                                by exact (AlgHom.ext fun x => (SetLike.ext_iff.mp this x).mpr Algebra.mem_top).symm;
                              ?_);
                          rotate_right
                      [Elab.step] [0.015866] refine
                              no_implicit_lambda%
                                (suffices
                                  AlgHom.equalizer ϕ (liftAlgHom f _ (ϕ (root f)) (aeval_algHom_eq_zero f ϕ)) = ⊤ by
                                  exact (AlgHom.ext fun x => (SetLike.ext_iff.mp this x).mpr Algebra.mem_top).symm;
                                ?_);
                            rotate_right
                        [Elab.step] [0.015853] refine
                              no_implicit_lambda%
                                (suffices
                                  AlgHom.equalizer ϕ (liftAlgHom f _ (ϕ (root f)) (aeval_algHom_eq_zero f ϕ)) = ⊤ by
                                  exact (AlgHom.ext fun x => (SetLike.ext_iff.mp this x).mpr Algebra.mem_top).symm;
                                ?_)
        [Elab.step] [0.017398] rw [eq_top_iff, ← adjoinRoot_eq_top, Algebra.adjoin_le_iff, Set.singleton_subset_iff]
          [Elab.step] [0.017389] (rewrite [eq_top_iff, ← adjoinRoot_eq_top, Algebra.adjoin_le_iff,
                  Set.singleton_subset_iff];
                with_annotate_state"]" (try (with_reducible rfl)))
            [Elab.step] [0.017386] rewrite [eq_top_iff, ← adjoinRoot_eq_top, Algebra.adjoin_le_iff,
                    Set.singleton_subset_iff];
                  with_annotate_state"]" (try (with_reducible rfl))
              [Elab.step] [0.017383] rewrite [eq_top_iff, ← adjoinRoot_eq_top, Algebra.adjoin_le_iff,
                      Set.singleton_subset_iff];
                    with_annotate_state"]" (try (with_reducible rfl))
                [Elab.step] [0.017065] rewrite [eq_top_iff, ← adjoinRoot_eq_top, Algebra.adjoin_le_iff,
                      Set.singleton_subset_iff]
Build completed successfully (1751 jobs).
```

### Trace profiling of `liftAlgHom_eq_algHom` after PR 32209
```diff
diff --git a/Mathlib/RingTheory/AdjoinRoot.lean b/Mathlib/RingTheory/AdjoinRoot.lean
index ee7b88afa2..93e2dbce59 100644
--- a/Mathlib/RingTheory/AdjoinRoot.lean
+++ b/Mathlib/RingTheory/AdjoinRoot.lean
@@ -340,13 +340,12 @@ theorem aeval_algHom_eq_zero (ϕ : AdjoinRoot f →ₐ[R] S) : aeval (ϕ (root f
   rw [aeval_def, ← h, ← map_zero ϕ.toRingHom, ← eval₂_root f, hom_eval₂]
   rfl
 
+set_option trace.profiler true in
 @[simp]
 theorem liftAlgHom_eq_algHom (ϕ : AdjoinRoot f →ₐ[R] S) :
     liftAlgHom f (Algebra.ofId R S) (ϕ (root f)) (aeval_algHom_eq_zero f ϕ) = ϕ := by
-  suffices AlgHom.equalizer ϕ (liftAlgHom f _ (ϕ (root f)) (aeval_algHom_eq_zero f ϕ)) = ⊤ by
-    exact (AlgHom.ext fun x => (SetLike.ext_iff.mp this x).mpr Algebra.mem_top).symm
-  rw [eq_top_iff, ← adjoinRoot_eq_top, Algebra.adjoin_le_iff, Set.singleton_subset_iff]
-  exact (@lift_root _ _ _ _ _ _ _ (aeval_algHom_eq_zero f ϕ)).symm
+  ext
+  simp
 
 set_option linter.deprecated false in
 @[deprecated liftAlgHom_eq_algHom (since := "2025-10-10")]
diff --git a/Mathlib/RingTheory/Ideal/GoingUp.lean b/Mathlib/RingTheory/Ideal/GoingUp.lean
index fddf52c9a0..6278b05639 100644
--- a/Mathlib/RingTheory/Ideal/GoingUp.lean
+++ b/Mathlib/RingTheory/Ideal/GoingUp.lean
@@ -95,9 +95,8 @@ theorem quotient_mk_maps_eq (P : Ideal R[X]) :
       (Ideal.quotientMap (map (mapRingHom (Quotient.mk (P.comap (C : R →+* R[X])))) P)
             (mapRingHom (Quotient.mk (P.comap (C : R →+* R[X])))) le_comap_map).comp
         ((Quotient.mk P).comp C) := by
-  refine RingHom.ext fun x => ?_
-  repeat' rw [RingHom.coe_comp, Function.comp_apply]
-  rw [quotientMap_mk, coe_mapRingHom, map_C]
+  ext
+  simp
 
 /-- This technical lemma asserts the existence of a polynomial `p` in an ideal `P ⊂ R[x]`
 that is non-zero in the quotient `R / (P ∩ R) [x]`.  The assumptions are equivalent to
```
```
✔ [1751/1751] Built Mathlib.RingTheory.AdjoinRoot (5.3s)
Build completed successfully (1751 jobs).
```
</details>

---
<details>
<summary>Show trace profiling of <code>quotient_mk_maps_eq</code>: 280 ms before, 72 ms after  🎉</summary>

### Trace profiling of `quotient_mk_maps_eq` before PR 32209
```diff
diff --git a/Mathlib/RingTheory/Ideal/GoingUp.lean b/Mathlib/RingTheory/Ideal/GoingUp.lean
index fddf52c9a0..ff2064cdac 100644
--- a/Mathlib/RingTheory/Ideal/GoingUp.lean
+++ b/Mathlib/RingTheory/Ideal/GoingUp.lean
@@ -80,6 +80,7 @@ theorem injective_quotient_le_comap_map (P : Ideal R[X]) :
     polynomial_mem_ideal_of_coeff_mem_ideal P p fun n => Ideal.Quotient.eq_zero_iff_mem.mp ?_
   simpa only [coeff_map, coe_mapRingHom] using ext_iff.mp (Ideal.mem_bot.mp (mem_comap.mp hp)) n
 
+set_option trace.profiler true in
 /-- The identity in this lemma asserts that the "obvious" square
 ```
     R    → (R / (P ∩ R))
```
```
ℹ [1756/1756] Built Mathlib.RingTheory.Ideal.GoingUp (2.0s)
info: Mathlib/RingTheory/Ideal/GoingUp.lean:84:0: [Elab.command] [0.055073] /-- The identity in this lemma asserts that the "obvious" square
    ```
        R    → (R / (P ∩ R))
        ↓          ↓
    R[x] / P → (R / (P ∩ R))[x] / (P / (P ∩ R))
    ```
    commutes.  It is used, for instance, in the proof of `quotient_mk_comp_C_is_integral_of_jacobson`,
    in the file `Mathlib/RingTheory/Jacobson/Polynomial.lean`.
    -/
    theorem quotient_mk_maps_eq (P : Ideal R[X]) :
        ((Quotient.mk (map (mapRingHom (Quotient.mk (P.comap (C : R →+* R[X])))) P)).comp C).comp
            (Quotient.mk (P.comap (C : R →+* R[X]))) =
          (Ideal.quotientMap (map (mapRingHom (Quotient.mk (P.comap (C : R →+* R[X])))) P)
                (mapRingHom (Quotient.mk (P.comap (C : R →+* R[X])))) le_comap_map).comp
            ((Quotient.mk P).comp C) :=
      by
      refine RingHom.ext fun x => ?_
      repeat' rw [RingHom.coe_comp, Function.comp_apply]
      rw [quotientMap_mk, coe_mapRingHom, map_C]
  [Elab.definition.header] [0.052687] Ideal.quotient_mk_maps_eq
    [Elab.step] [0.051955] expected type: Sort ?u.9597, term
        ((Quotient.mk (map (mapRingHom (Quotient.mk (P.comap (C : R →+* R[X])))) P)).comp C).comp
            (Quotient.mk (P.comap (C : R →+* R[X]))) =
          (Ideal.quotientMap (map (mapRingHom (Quotient.mk (P.comap (C : R →+* R[X])))) P)
                (mapRingHom (Quotient.mk (P.comap (C : R →+* R[X])))) le_comap_map).comp
            ((Quotient.mk P).comp C)
      [Elab.step] [0.051947] expected type: Sort ?u.9597, term
          binrel% Eq✝
            (((Quotient.mk (map (mapRingHom (Quotient.mk (P.comap (C : R →+* R[X])))) P)).comp C).comp
              (Quotient.mk (P.comap (C : R →+* R[X]))))
            ((Ideal.quotientMap (map (mapRingHom (Quotient.mk (P.comap (C : R →+* R[X])))) P)
                  (mapRingHom (Quotient.mk (P.comap (C : R →+* R[X])))) le_comap_map).comp
              ((Quotient.mk P).comp C))
        [Elab.step] [0.016147] expected type: <not-available>, term
            ((Quotient.mk (map (mapRingHom (Quotient.mk (P.comap (C : R →+* R[X])))) P)).comp C).comp
              (Quotient.mk (P.comap (C : R →+* R[X])))
          [Elab.step] [0.014560] expected type: <not-available>, term
              ((Quotient.mk (map (mapRingHom (Quotient.mk (P.comap (C : R →+* R[X])))) P)).comp C)
            [Elab.step] [0.014557] expected type: <not-available>, term
                (Quotient.mk (map (mapRingHom (Quotient.mk (P.comap (C : R →+* R[X])))) P)).comp C
              [Elab.step] [0.012541] expected type: <not-available>, term
                  (Quotient.mk (map (mapRingHom (Quotient.mk (P.comap (C : R →+* R[X])))) P))
                [Elab.step] [0.012538] expected type: <not-available>, term
                    Quotient.mk (map (mapRingHom (Quotient.mk (P.comap (C : R →+* R[X])))) P)
        [Elab.step] [0.035102] expected type: <not-available>, term
            (Ideal.quotientMap (map (mapRingHom (Quotient.mk (P.comap (C : R →+* R[X])))) P)
                  (mapRingHom (Quotient.mk (P.comap (C : R →+* R[X])))) le_comap_map).comp
              ((Quotient.mk P).comp C)
          [Elab.step] [0.024271] expected type: <not-available>, term
              (Ideal.quotientMap (map (mapRingHom (Quotient.mk (P.comap (C : R →+* R[X])))) P)
                (mapRingHom (Quotient.mk (P.comap (C : R →+* R[X])))) le_comap_map)
            [Elab.step] [0.024268] expected type: <not-available>, term
                Ideal.quotientMap (map (mapRingHom (Quotient.mk (P.comap (C : R →+* R[X])))) P)
                  (mapRingHom (Quotient.mk (P.comap (C : R →+* R[X])))) le_comap_map
              [Elab.step] [0.010980] expected type: R[X] →+* (R ⧸ comap C P)[X], term
                  (mapRingHom (Quotient.mk (P.comap (C : R →+* R[X]))))
                [Elab.step] [0.010978] expected type: R[X] →+* (R ⧸ comap C P)[X], term
                    mapRingHom (Quotient.mk (P.comap (C : R →+* R[X])))
info: Mathlib/RingTheory/Ideal/GoingUp.lean:84:0: [Elab.async] [0.281501] elaborating proof of Ideal.quotient_mk_maps_eq
  [Elab.definition.value] [0.280127] Ideal.quotient_mk_maps_eq
    [Elab.step] [0.279120] 
          refine RingHom.ext fun x => ?_
          repeat' rw [RingHom.coe_comp, Function.comp_apply]
          rw [quotientMap_mk, coe_mapRingHom, map_C]
      [Elab.step] [0.279115] 
            refine RingHom.ext fun x => ?_
            repeat' rw [RingHom.coe_comp, Function.comp_apply]
            rw [quotientMap_mk, coe_mapRingHom, map_C]
        [Elab.step] [0.205918] repeat' rw [RingHom.coe_comp, Function.comp_apply]
          [Elab.step] [0.059211] rw [RingHom.coe_comp, Function.comp_apply]
            [Elab.step] [0.059207] rw [RingHom.coe_comp, Function.comp_apply]
              [Elab.step] [0.059204] rw [RingHom.coe_comp, Function.comp_apply]
                [Elab.step] [0.059199] (rewrite [RingHom.coe_comp, Function.comp_apply];
                      with_annotate_state"]" (try (with_reducible rfl)))
                  [Elab.step] [0.059196] rewrite [RingHom.coe_comp, Function.comp_apply];
                        with_annotate_state"]" (try (with_reducible rfl))
                    [Elab.step] [0.059193] rewrite [RingHom.coe_comp, Function.comp_apply];
                          with_annotate_state"]" (try (with_reducible rfl))
                      [Elab.step] [0.058775] rewrite [RingHom.coe_comp, Function.comp_apply]
                        [Meta.check] [0.022616] ✅️ fun _a ↦
                              _a x =
                                ((quotientMap (map (mapRingHom (Quotient.mk (comap C P))) P)
                                        (mapRingHom (Quotient.mk (comap C P))) ⋯).comp
                                    ((Quotient.mk P).comp C))
                                  x
                        [Meta.check] [0.020886] ✅️ fun _a ↦
                              _a =
                                ((quotientMap (map (mapRingHom (Quotient.mk (comap C P))) P)
                                        (mapRingHom (Quotient.mk (comap C P))) ⋯).comp
                                    ((Quotient.mk P).comp C))
                                  x
          [Elab.step] [0.060467] rw [RingHom.coe_comp, Function.comp_apply]
            [Elab.step] [0.060464] rw [RingHom.coe_comp, Function.comp_apply]
              [Elab.step] [0.060460] rw [RingHom.coe_comp, Function.comp_apply]
                [Elab.step] [0.060454] (rewrite [RingHom.coe_comp, Function.comp_apply];
                      with_annotate_state"]" (try (with_reducible rfl)))
                  [Elab.step] [0.060452] rewrite [RingHom.coe_comp, Function.comp_apply];
                        with_annotate_state"]" (try (with_reducible rfl))
                    [Elab.step] [0.060449] rewrite [RingHom.coe_comp, Function.comp_apply];
                          with_annotate_state"]" (try (with_reducible rfl))
                      [Elab.step] [0.060101] rewrite [RingHom.coe_comp, Function.comp_apply]
                        [Meta.check] [0.024059] ✅️ fun _a ↦
                              _a ((Quotient.mk (comap C P)) x) =
                                ((quotientMap (map (mapRingHom (Quotient.mk (comap C P))) P)
                                        (mapRingHom (Quotient.mk (comap C P))) ⋯).comp
                                    ((Quotient.mk P).comp C))
                                  x
                        [Meta.check] [0.019641] ✅️ fun _a ↦
                              _a =
                                ((quotientMap (map (mapRingHom (Quotient.mk (comap C P))) P)
                                        (mapRingHom (Quotient.mk (comap C P))) ⋯).comp
                                    ((Quotient.mk P).comp C))
                                  x
          [Elab.step] [0.023207] rw [RingHom.coe_comp, Function.comp_apply]
            [Elab.step] [0.023204] rw [RingHom.coe_comp, Function.comp_apply]
              [Elab.step] [0.023201] rw [RingHom.coe_comp, Function.comp_apply]
                [Elab.step] [0.023196] (rewrite [RingHom.coe_comp, Function.comp_apply];
                      with_annotate_state"]" (try (with_reducible rfl)))
                  [Elab.step] [0.023193] rewrite [RingHom.coe_comp, Function.comp_apply];
                        with_annotate_state"]" (try (with_reducible rfl))
                    [Elab.step] [0.023190] rewrite [RingHom.coe_comp, Function.comp_apply];
                          with_annotate_state"]" (try (with_reducible rfl))
                      [Elab.step] [0.022897] rewrite [RingHom.coe_comp, Function.comp_apply]
          [Elab.step] [0.051444] rw [RingHom.coe_comp, Function.comp_apply]
            [Elab.step] [0.051441] rw [RingHom.coe_comp, Function.comp_apply]
              [Elab.step] [0.051438] rw [RingHom.coe_comp, Function.comp_apply]
                [Elab.step] [0.051434] (rewrite [RingHom.coe_comp, Function.comp_apply];
                      with_annotate_state"]" (try (with_reducible rfl)))
                  [Elab.step] [0.051432] rewrite [RingHom.coe_comp, Function.comp_apply];
                        with_annotate_state"]" (try (with_reducible rfl))
                    [Elab.step] [0.051429] rewrite [RingHom.coe_comp, Function.comp_apply];
                          with_annotate_state"]" (try (with_reducible rfl))
                      [Elab.step] [0.051113] rewrite [RingHom.coe_comp, Function.comp_apply]
                        [Meta.check] [0.013926] ✅️ fun _a ↦
                              (Quotient.mk (map (mapRingHom (Quotient.mk (comap C P))) P))
                                  (C ((Quotient.mk (comap C P)) x)) =
                                (quotientMap (map (mapRingHom (Quotient.mk (comap C P))) P)
                                    (mapRingHom (Quotient.mk (comap C P))) ⋯)
                                  (_a x)
                        [Meta.check] [0.012645] ✅️ fun _a ↦
                              (Quotient.mk (map (mapRingHom (Quotient.mk (comap C P))) P))
                                  (C ((Quotient.mk (comap C P)) x)) =
                                (quotientMap (map (mapRingHom (Quotient.mk (comap C P))) P)
                                    (mapRingHom (Quotient.mk (comap C P))) ⋯)
                                  _a
          [Elab.step] [0.011493] rw [RingHom.coe_comp, Function.comp_apply]
            [Elab.step] [0.011490] rw [RingHom.coe_comp, Function.comp_apply]
              [Elab.step] [0.011486] rw [RingHom.coe_comp, Function.comp_apply]
                [Elab.step] [0.011481] (rewrite [RingHom.coe_comp, Function.comp_apply];
                      with_annotate_state"]" (try (with_reducible rfl)))
                  [Elab.step] [0.011478] rewrite [RingHom.coe_comp, Function.comp_apply];
                        with_annotate_state"]" (try (with_reducible rfl))
                    [Elab.step] [0.011476] rewrite [RingHom.coe_comp, Function.comp_apply];
                          with_annotate_state"]" (try (with_reducible rfl))
                      [Elab.step] [0.011471] rewrite [RingHom.coe_comp, Function.comp_apply]
        [Elab.step] [0.072582] rw [quotientMap_mk, coe_mapRingHom, map_C]
          [Elab.step] [0.072534] (rewrite [quotientMap_mk, coe_mapRingHom, map_C];
                with_annotate_state"]" (try (with_reducible rfl)))
            [Elab.step] [0.072530] rewrite [quotientMap_mk, coe_mapRingHom, map_C];
                  with_annotate_state"]" (try (with_reducible rfl))
              [Elab.step] [0.072526] rewrite [quotientMap_mk, coe_mapRingHom, map_C];
                    with_annotate_state"]" (try (with_reducible rfl))
                [Elab.step] [0.070791] rewrite [quotientMap_mk, coe_mapRingHom, map_C]
Build completed successfully (1756 jobs).
```

### Trace profiling of `quotient_mk_maps_eq` after PR 32209
```diff
diff --git a/Mathlib/RingTheory/AdjoinRoot.lean b/Mathlib/RingTheory/AdjoinRoot.lean
index ee7b88afa2..f59870948e 100644
--- a/Mathlib/RingTheory/AdjoinRoot.lean
+++ b/Mathlib/RingTheory/AdjoinRoot.lean
@@ -343,10 +343,8 @@ theorem aeval_algHom_eq_zero (ϕ : AdjoinRoot f →ₐ[R] S) : aeval (ϕ (root f
 @[simp]
 theorem liftAlgHom_eq_algHom (ϕ : AdjoinRoot f →ₐ[R] S) :
     liftAlgHom f (Algebra.ofId R S) (ϕ (root f)) (aeval_algHom_eq_zero f ϕ) = ϕ := by
-  suffices AlgHom.equalizer ϕ (liftAlgHom f _ (ϕ (root f)) (aeval_algHom_eq_zero f ϕ)) = ⊤ by
-    exact (AlgHom.ext fun x => (SetLike.ext_iff.mp this x).mpr Algebra.mem_top).symm
-  rw [eq_top_iff, ← adjoinRoot_eq_top, Algebra.adjoin_le_iff, Set.singleton_subset_iff]
-  exact (@lift_root _ _ _ _ _ _ _ (aeval_algHom_eq_zero f ϕ)).symm
+  ext
+  simp
 
 set_option linter.deprecated false in
 @[deprecated liftAlgHom_eq_algHom (since := "2025-10-10")]
diff --git a/Mathlib/RingTheory/Ideal/GoingUp.lean b/Mathlib/RingTheory/Ideal/GoingUp.lean
index fddf52c9a0..41bc696b8f 100644
--- a/Mathlib/RingTheory/Ideal/GoingUp.lean
+++ b/Mathlib/RingTheory/Ideal/GoingUp.lean
@@ -80,6 +80,7 @@ theorem injective_quotient_le_comap_map (P : Ideal R[X]) :
     polynomial_mem_ideal_of_coeff_mem_ideal P p fun n => Ideal.Quotient.eq_zero_iff_mem.mp ?_
   simpa only [coeff_map, coe_mapRingHom] using ext_iff.mp (Ideal.mem_bot.mp (mem_comap.mp hp)) n
 
+set_option trace.profiler true in
 /-- The identity in this lemma asserts that the "obvious" square
 ```
     R    → (R / (P ∩ R))
@@ -95,9 +96,8 @@ theorem quotient_mk_maps_eq (P : Ideal R[X]) :
       (Ideal.quotientMap (map (mapRingHom (Quotient.mk (P.comap (C : R →+* R[X])))) P)
             (mapRingHom (Quotient.mk (P.comap (C : R →+* R[X])))) le_comap_map).comp
         ((Quotient.mk P).comp C) := by
-  refine RingHom.ext fun x => ?_
-  repeat' rw [RingHom.coe_comp, Function.comp_apply]
-  rw [quotientMap_mk, coe_mapRingHom, map_C]
+  ext
+  simp
 
 /-- This technical lemma asserts the existence of a polynomial `p` in an ideal `P ⊂ R[x]`
 that is non-zero in the quotient `R / (P ∩ R) [x]`.  The assumptions are equivalent to
```
```
ℹ [1756/1756] Built Mathlib.RingTheory.Ideal.GoingUp (2.0s)
info: Mathlib/RingTheory/Ideal/GoingUp.lean:84:0: [Elab.command] [0.056152] /-- The identity in this lemma asserts that the "obvious" square
    ```
        R    → (R / (P ∩ R))
        ↓          ↓
    R[x] / P → (R / (P ∩ R))[x] / (P / (P ∩ R))
    ```
    commutes.  It is used, for instance, in the proof of `quotient_mk_comp_C_is_integral_of_jacobson`,
    in the file `Mathlib/RingTheory/Jacobson/Polynomial.lean`.
    -/
    theorem quotient_mk_maps_eq (P : Ideal R[X]) :
        ((Quotient.mk (map (mapRingHom (Quotient.mk (P.comap (C : R →+* R[X])))) P)).comp C).comp
            (Quotient.mk (P.comap (C : R →+* R[X]))) =
          (Ideal.quotientMap (map (mapRingHom (Quotient.mk (P.comap (C : R →+* R[X])))) P)
                (mapRingHom (Quotient.mk (P.comap (C : R →+* R[X])))) le_comap_map).comp
            ((Quotient.mk P).comp C) :=
      by
      ext
      simp
  [Elab.definition.header] [0.053784] Ideal.quotient_mk_maps_eq
    [Elab.step] [0.053061] expected type: Sort ?u.9597, term
        ((Quotient.mk (map (mapRingHom (Quotient.mk (P.comap (C : R →+* R[X])))) P)).comp C).comp
            (Quotient.mk (P.comap (C : R →+* R[X]))) =
          (Ideal.quotientMap (map (mapRingHom (Quotient.mk (P.comap (C : R →+* R[X])))) P)
                (mapRingHom (Quotient.mk (P.comap (C : R →+* R[X])))) le_comap_map).comp
            ((Quotient.mk P).comp C)
      [Elab.step] [0.053056] expected type: Sort ?u.9597, term
          binrel% Eq✝
            (((Quotient.mk (map (mapRingHom (Quotient.mk (P.comap (C : R →+* R[X])))) P)).comp C).comp
              (Quotient.mk (P.comap (C : R →+* R[X]))))
            ((Ideal.quotientMap (map (mapRingHom (Quotient.mk (P.comap (C : R →+* R[X])))) P)
                  (mapRingHom (Quotient.mk (P.comap (C : R →+* R[X])))) le_comap_map).comp
              ((Quotient.mk P).comp C))
        [Elab.step] [0.016406] expected type: <not-available>, term
            ((Quotient.mk (map (mapRingHom (Quotient.mk (P.comap (C : R →+* R[X])))) P)).comp C).comp
              (Quotient.mk (P.comap (C : R →+* R[X])))
          [Elab.step] [0.014787] expected type: <not-available>, term
              ((Quotient.mk (map (mapRingHom (Quotient.mk (P.comap (C : R →+* R[X])))) P)).comp C)
            [Elab.step] [0.014784] expected type: <not-available>, term
                (Quotient.mk (map (mapRingHom (Quotient.mk (P.comap (C : R →+* R[X])))) P)).comp C
              [Elab.step] [0.012714] expected type: <not-available>, term
                  (Quotient.mk (map (mapRingHom (Quotient.mk (P.comap (C : R →+* R[X])))) P))
                [Elab.step] [0.012711] expected type: <not-available>, term
                    Quotient.mk (map (mapRingHom (Quotient.mk (P.comap (C : R →+* R[X])))) P)
        [Elab.step] [0.035907] expected type: <not-available>, term
            (Ideal.quotientMap (map (mapRingHom (Quotient.mk (P.comap (C : R →+* R[X])))) P)
                  (mapRingHom (Quotient.mk (P.comap (C : R →+* R[X])))) le_comap_map).comp
              ((Quotient.mk P).comp C)
          [Elab.step] [0.024854] expected type: <not-available>, term
              (Ideal.quotientMap (map (mapRingHom (Quotient.mk (P.comap (C : R →+* R[X])))) P)
                (mapRingHom (Quotient.mk (P.comap (C : R →+* R[X])))) le_comap_map)
            [Elab.step] [0.024851] expected type: <not-available>, term
                Ideal.quotientMap (map (mapRingHom (Quotient.mk (P.comap (C : R →+* R[X])))) P)
                  (mapRingHom (Quotient.mk (P.comap (C : R →+* R[X])))) le_comap_map
              [Elab.step] [0.011201] expected type: R[X] →+* (R ⧸ comap C P)[X], term
                  (mapRingHom (Quotient.mk (P.comap (C : R →+* R[X]))))
                [Elab.step] [0.011198] expected type: R[X] →+* (R ⧸ comap C P)[X], term
                    mapRingHom (Quotient.mk (P.comap (C : R →+* R[X])))
info: Mathlib/RingTheory/Ideal/GoingUp.lean:84:0: [Elab.async] [0.073283] elaborating proof of Ideal.quotient_mk_maps_eq
  [Elab.definition.value] [0.072397] Ideal.quotient_mk_maps_eq
    [Elab.step] [0.071741] 
          ext
          simp
      [Elab.step] [0.071735] 
            ext
            simp
        [Elab.step] [0.070810] simp
Build completed successfully (1756 jobs).
```
</details>

---
<details>
<summary>Show trace profiling of <code>liftAlgHom_eq_algHom</code>: 37 ms before, <10 ms after  🎉</summary>

### Trace profiling of `liftAlgHom_eq_algHom` before PR 32209
```diff
diff --git a/Mathlib/RingTheory/AdjoinRoot.lean b/Mathlib/RingTheory/AdjoinRoot.lean
index ee7b88afa2..7e98824cfe 100644
--- a/Mathlib/RingTheory/AdjoinRoot.lean
+++ b/Mathlib/RingTheory/AdjoinRoot.lean
@@ -340,6 +340,7 @@ theorem aeval_algHom_eq_zero (ϕ : AdjoinRoot f →ₐ[R] S) : aeval (ϕ (root f
   rw [aeval_def, ← h, ← map_zero ϕ.toRingHom, ← eval₂_root f, hom_eval₂]
   rfl
 
+set_option trace.profiler true in
 @[simp]
 theorem liftAlgHom_eq_algHom (ϕ : AdjoinRoot f →ₐ[R] S) :
     liftAlgHom f (Algebra.ofId R S) (ϕ (root f)) (aeval_algHom_eq_zero f ϕ) = ϕ := by
```
```
ℹ [1751/1751] Built Mathlib.RingTheory.AdjoinRoot (5.5s)
info: Mathlib/RingTheory/AdjoinRoot.lean:344:0: [Elab.command] [0.010215] @[simp]
    theorem liftAlgHom_eq_algHom (ϕ : AdjoinRoot f →ₐ[R] S) :
        liftAlgHom f (Algebra.ofId R S) (ϕ (root f)) (aeval_algHom_eq_zero f ϕ) = ϕ :=
      by
      suffices AlgHom.equalizer ϕ (liftAlgHom f _ (ϕ (root f)) (aeval_algHom_eq_zero f ϕ)) = ⊤ by
        exact (AlgHom.ext fun x => (SetLike.ext_iff.mp this x).mpr Algebra.mem_top).symm
      rw [eq_top_iff, ← adjoinRoot_eq_top, Algebra.adjoin_le_iff, Set.singleton_subset_iff]
      exact (@lift_root _ _ _ _ _ _ _ (aeval_algHom_eq_zero f ϕ)).symm
info: Mathlib/RingTheory/AdjoinRoot.lean:344:0: [Elab.async] [0.038233] elaborating proof of AdjoinRoot.liftAlgHom_eq_algHom
  [Elab.definition.value] [0.037369] AdjoinRoot.liftAlgHom_eq_algHom
    [Elab.step] [0.036774] 
          suffices AlgHom.equalizer ϕ (liftAlgHom f _ (ϕ (root f)) (aeval_algHom_eq_zero f ϕ)) = ⊤ by
            exact (AlgHom.ext fun x => (SetLike.ext_iff.mp this x).mpr Algebra.mem_top).symm
          rw [eq_top_iff, ← adjoinRoot_eq_top, Algebra.adjoin_le_iff, Set.singleton_subset_iff]
          exact (@lift_root _ _ _ _ _ _ _ (aeval_algHom_eq_zero f ϕ)).symm
      [Elab.step] [0.036767] 
            suffices AlgHom.equalizer ϕ (liftAlgHom f _ (ϕ (root f)) (aeval_algHom_eq_zero f ϕ)) = ⊤ by
              exact (AlgHom.ext fun x => (SetLike.ext_iff.mp this x).mpr Algebra.mem_top).symm
            rw [eq_top_iff, ← adjoinRoot_eq_top, Algebra.adjoin_le_iff, Set.singleton_subset_iff]
            exact (@lift_root _ _ _ _ _ _ _ (aeval_algHom_eq_zero f ϕ)).symm
        [Elab.step] [0.015892] suffices AlgHom.equalizer ϕ (liftAlgHom f _ (ϕ (root f)) (aeval_algHom_eq_zero f ϕ)) = ⊤
              by exact (AlgHom.ext fun x => (SetLike.ext_iff.mp this x).mpr Algebra.mem_top).symm
          [Elab.step] [0.015885] refine_lift
                suffices AlgHom.equalizer ϕ (liftAlgHom f _ (ϕ (root f)) (aeval_algHom_eq_zero f ϕ)) = ⊤ by
                  exact (AlgHom.ext fun x => (SetLike.ext_iff.mp this x).mpr Algebra.mem_top).symm;
                ?_
            [Elab.step] [0.015881] focus
                  (refine
                      no_implicit_lambda%
                        (suffices AlgHom.equalizer ϕ (liftAlgHom f _ (ϕ (root f)) (aeval_algHom_eq_zero f ϕ)) = ⊤ by
                          exact (AlgHom.ext fun x => (SetLike.ext_iff.mp this x).mpr Algebra.mem_top).symm;
                        ?_);
                    rotate_right)
              [Elab.step] [0.015877] (refine
                        no_implicit_lambda%
                          (suffices AlgHom.equalizer ϕ (liftAlgHom f _ (ϕ (root f)) (aeval_algHom_eq_zero f ϕ)) = ⊤ by
                            exact (AlgHom.ext fun x => (SetLike.ext_iff.mp this x).mpr Algebra.mem_top).symm;
                          ?_);
                      rotate_right)
                [Elab.step] [0.015875] (refine
                          no_implicit_lambda%
                            (suffices AlgHom.equalizer ϕ (liftAlgHom f _ (ϕ (root f)) (aeval_algHom_eq_zero f ϕ)) = ⊤ by
                              exact (AlgHom.ext fun x => (SetLike.ext_iff.mp this x).mpr Algebra.mem_top).symm;
                            ?_);
                        rotate_right)
                  [Elab.step] [0.015872] (refine
                          no_implicit_lambda%
                            (suffices AlgHom.equalizer ϕ (liftAlgHom f _ (ϕ (root f)) (aeval_algHom_eq_zero f ϕ)) = ⊤ by
                              exact (AlgHom.ext fun x => (SetLike.ext_iff.mp this x).mpr Algebra.mem_top).symm;
                            ?_);
                        rotate_right)
                    [Elab.step] [0.015869] refine
                            no_implicit_lambda%
                              (suffices AlgHom.equalizer ϕ (liftAlgHom f _ (ϕ (root f)) (aeval_algHom_eq_zero f ϕ)) = ⊤
                                by exact (AlgHom.ext fun x => (SetLike.ext_iff.mp this x).mpr Algebra.mem_top).symm;
                              ?_);
                          rotate_right
                      [Elab.step] [0.015866] refine
                              no_implicit_lambda%
                                (suffices
                                  AlgHom.equalizer ϕ (liftAlgHom f _ (ϕ (root f)) (aeval_algHom_eq_zero f ϕ)) = ⊤ by
                                  exact (AlgHom.ext fun x => (SetLike.ext_iff.mp this x).mpr Algebra.mem_top).symm;
                                ?_);
                            rotate_right
                        [Elab.step] [0.015853] refine
                              no_implicit_lambda%
                                (suffices
                                  AlgHom.equalizer ϕ (liftAlgHom f _ (ϕ (root f)) (aeval_algHom_eq_zero f ϕ)) = ⊤ by
                                  exact (AlgHom.ext fun x => (SetLike.ext_iff.mp this x).mpr Algebra.mem_top).symm;
                                ?_)
        [Elab.step] [0.017398] rw [eq_top_iff, ← adjoinRoot_eq_top, Algebra.adjoin_le_iff, Set.singleton_subset_iff]
          [Elab.step] [0.017389] (rewrite [eq_top_iff, ← adjoinRoot_eq_top, Algebra.adjoin_le_iff,
                  Set.singleton_subset_iff];
                with_annotate_state"]" (try (with_reducible rfl)))
            [Elab.step] [0.017386] rewrite [eq_top_iff, ← adjoinRoot_eq_top, Algebra.adjoin_le_iff,
                    Set.singleton_subset_iff];
                  with_annotate_state"]" (try (with_reducible rfl))
              [Elab.step] [0.017383] rewrite [eq_top_iff, ← adjoinRoot_eq_top, Algebra.adjoin_le_iff,
                      Set.singleton_subset_iff];
                    with_annotate_state"]" (try (with_reducible rfl))
                [Elab.step] [0.017065] rewrite [eq_top_iff, ← adjoinRoot_eq_top, Algebra.adjoin_le_iff,
                      Set.singleton_subset_iff]
Build completed successfully (1751 jobs).
```

### Trace profiling of `liftAlgHom_eq_algHom` after PR 32209
```diff
diff --git a/Mathlib/RingTheory/AdjoinRoot.lean b/Mathlib/RingTheory/AdjoinRoot.lean
index ee7b88afa2..93e2dbce59 100644
--- a/Mathlib/RingTheory/AdjoinRoot.lean
+++ b/Mathlib/RingTheory/AdjoinRoot.lean
@@ -340,13 +340,12 @@ theorem aeval_algHom_eq_zero (ϕ : AdjoinRoot f →ₐ[R] S) : aeval (ϕ (root f
   rw [aeval_def, ← h, ← map_zero ϕ.toRingHom, ← eval₂_root f, hom_eval₂]
   rfl
 
+set_option trace.profiler true in
 @[simp]
 theorem liftAlgHom_eq_algHom (ϕ : AdjoinRoot f →ₐ[R] S) :
     liftAlgHom f (Algebra.ofId R S) (ϕ (root f)) (aeval_algHom_eq_zero f ϕ) = ϕ := by
-  suffices AlgHom.equalizer ϕ (liftAlgHom f _ (ϕ (root f)) (aeval_algHom_eq_zero f ϕ)) = ⊤ by
-    exact (AlgHom.ext fun x => (SetLike.ext_iff.mp this x).mpr Algebra.mem_top).symm
-  rw [eq_top_iff, ← adjoinRoot_eq_top, Algebra.adjoin_le_iff, Set.singleton_subset_iff]
-  exact (@lift_root _ _ _ _ _ _ _ (aeval_algHom_eq_zero f ϕ)).symm
+  ext
+  simp
 
 set_option linter.deprecated false in
 @[deprecated liftAlgHom_eq_algHom (since := "2025-10-10")]
diff --git a/Mathlib/RingTheory/Ideal/GoingUp.lean b/Mathlib/RingTheory/Ideal/GoingUp.lean
index fddf52c9a0..6278b05639 100644
--- a/Mathlib/RingTheory/Ideal/GoingUp.lean
+++ b/Mathlib/RingTheory/Ideal/GoingUp.lean
@@ -95,9 +95,8 @@ theorem quotient_mk_maps_eq (P : Ideal R[X]) :
       (Ideal.quotientMap (map (mapRingHom (Quotient.mk (P.comap (C : R →+* R[X])))) P)
             (mapRingHom (Quotient.mk (P.comap (C : R →+* R[X])))) le_comap_map).comp
         ((Quotient.mk P).comp C) := by
-  refine RingHom.ext fun x => ?_
-  repeat' rw [RingHom.coe_comp, Function.comp_apply]
-  rw [quotientMap_mk, coe_mapRingHom, map_C]
+  ext
+  simp
 
 /-- This technical lemma asserts the existence of a polynomial `p` in an ideal `P ⊂ R[x]`
 that is non-zero in the quotient `R / (P ∩ R) [x]`.  The assumptions are equivalent to
```
```
✔ [1751/1751] Built Mathlib.RingTheory.AdjoinRoot (5.3s)
Build completed successfully (1751 jobs).
```
</details>

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

When merging, all the commits will be squashed into a single commit
listing all co-authors.

Co-authors in the squash commit are gathered from two sources:

First, all authors of commits to this PR branch are included. Thus,
one way to add co-authors is to include at least one commit authored by
each co-author among the commits in the pull request. If necessary, you
may create empty commits to indicate co-authorship, using commands like so:

git commit --author="Author Name <author@email.com>" --allow-empty -m "add Author Name as coauthor"

Second, co-authors can also be listed in lines at the very bottom of
the commit message (that is, directly before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines
at the bottom of the commit message (before the `---`, and also before
any "Co-authored-by" lines) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
