### PR TITLE
[Merged by Bors] - chore: generalize `Subring.toIsOrderedRing` to `SubringClass`

### DIFF
--- a/Mathlib/Algebra/Ring/Subring/Order.lean
+++ b/Mathlib/Algebra/Ring/Subring/Order.lean
@@ -10,42 +10,36 @@ public import Mathlib.Algebra.Order.Ring.InjSurj
 public import Mathlib.Algebra.Ring.Subring.Defs
 
 /-!
-
 # Subrings of ordered rings
 
 We study subrings of ordered rings and prove their basic properties.
 
 ## Main definitions and results
-* `Subring.orderedSubtype`: the inclusion `S → R` of a subring as an ordered ring homomorphism
-* various ordered instances: a subring of an `OrderedRing`, `OrderedCommRing`, `LinearOrderedRing`,
-  `toLinearOrderedCommRing` is again an ordering ring
 
+* `Subring.orderedSubtype`: the inclusion `S → R` of a subring as an ordered ring homomorphism
+* various ordered instances: a subring of an `IsOrderedRing` or an `IsStrictOrderRing` is again
+  the respective kind of ordered ring.
 -/
 
 @[expose] public section
 
 namespace Subring
 
-variable {R : Type*}
+variable {R S : Type*} [Ring R] [PartialOrder R] [SetLike S R] [SubringClass S R]
 
 /-- A subring of an ordered ring is an ordered ring. -/
-instance toIsOrderedRing [Ring R] [PartialOrder R] [IsOrderedRing R] (s : Subring R) :
-    IsOrderedRing s :=
+instance toIsOrderedRing [IsOrderedRing R] (s : S) : IsOrderedRing s :=
   Function.Injective.isOrderedRing Subtype.val rfl rfl (fun _ _ => rfl) (fun _ _ => rfl) .rfl
 
 /-- A subring of a strict ordered ring is a strict ordered ring. -/
-instance toIsStrictOrderedRing [Ring R] [PartialOrder R] [IsStrictOrderedRing R]
-    (s : Subring R) : IsStrictOrderedRing s :=
+instance toIsStrictOrderedRing [IsStrictOrderedRing R] (s : S) : IsStrictOrderedRing s :=
   Function.Injective.isStrictOrderedRing Subtype.val
     rfl rfl (fun _ _ => rfl) (fun _ _ => rfl) .rfl .rfl
 
 /-- The inclusion `S → R` of a subring, as an ordered ring homomorphism. -/
-def orderedSubtype {R : Type*} [Ring R] [PartialOrder R] (s : Subring R) :
-    s →+*o R where
+def orderedSubtype (s : Subring R) : s →+*o R where
   __ := s.subtype
   monotone' := fun _ _ h ↦ h
-
-variable {R : Type*} [Ring R] [PartialOrder R]
 
 lemma orderedSubtype_coe (s : Subring R) : Subring.orderedSubtype s = Subring.subtype s := rfl
 


### PR DESCRIPTION
---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

When merging, all the commits will be squashed into a single commit
listing all co-authors.

Co-authors in the squash commit are gathered from two sources:

First, all authors of commits to this PR branch are included. Thus,
one way to add co-authors is to include at least one commit authored by
each co-author among the commits in the pull request. If necessary, you
may create empty commits to indicate co-authorship, using commands like so:

git commit --author="Author Name <author@email.com>" --allow-empty -m "add Author Name as coauthor"

Second, co-authors can also be listed in lines at the very bottom of
the commit message (that is, directly before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines
at the bottom of the commit message (before the `---`, and also before
any "Co-authored-by" lines) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
