### PR TITLE
[Merged by Bors] - doc(Condensed): make ASCII art diagrams align more nicely in docs

### DIFF
--- a/Mathlib/Condensed/Light/InternallyProjective.lean
+++ b/Mathlib/Condensed/Light/InternallyProjective.lean
@@ -21,10 +21,10 @@ only if, for all `A B : LightCondMod R`, for all epimorphisms `e : A ⟶ B`, for
 `S : LightProfinite` and all morphisms `g : P ⊗ R[S] ⟶ B`, there exists a `S' : LightProfinite`
 with a surjeciton `π : S' ⟶ S` and a morphism `g' : P ⊗ R[S'] ⟶ A`, making the diagram
 ```
-P ⊗ R[S'] ⟶ A
-  |          |
-  v          v
-P ⊗ R[S]  ⟶ B
+P ⊗ R[S'] --> A
+  |           |
+  v           v
+P ⊗ R[S]  --> B
 ```
 commute.
 
@@ -93,10 +93,10 @@ only if, for all `A B : LightCondMod R`, for all epimorphisms `e : A ⟶ B`, for
 `S : LightProfinite` and all morphisms `g : P ⊗ R[S] ⟶ B`, there exists a `S' : LightProfinite`
 with a surjeciton `π : S' ⟶ S` and a morphism `g' : P ⊗ R[S'] ⟶ A`, making the diagram
 ```
-P ⊗ R[S'] ⟶ A
-  |          |
-  v          v
-P ⊗ R[S]  ⟶ B
+P ⊗ R[S'] --> A
+  |           |
+  v           v
+P ⊗ R[S]  --> B
 ```
 commute.
 -/
@@ -132,10 +132,10 @@ only if, for all `A B : LightCondMod R`, for all epimorphisms `e : A ⟶ B`, for
 `S : LightProfinite` and all morphisms `g : R[S] ⊗ P ⟶ B`, there exists a `S' : LightProfinite`
 with a surjeciton `π : S' ⟶ S` and a morphism `g' : R[S'] ⊗ P ⟶ A`, making the diagram
 ```
-R[S'] ⊗ P ⟶ A
-  |          |
-  v          v
-R[S] ⊗ P  ⟶ B
+R[S'] ⊗ P --> A
+  |           |
+  v           v
+R[S] ⊗ P  --> B
 ```
 commute.
 -/
@@ -161,10 +161,10 @@ and only if, for all `A B : LightCondMod R`, for all epimorphisms `e : A ⟶ B`,
 `S : LightProfinite` and all morphisms `g : R[P × S] ⟶ B`, there exists a `S' : LightProfinite`
 with a surjeciton `π : S' ⟶ S` and a morphism `g' : R[P × S'] ⟶ A`, making the diagram
 ```
-R[P × S'] ⟶ A
-  |          |
-  v          v
-R[P × S]  ⟶ B
+R[P × S'] --> A
+  |           |
+  v           v
+R[P × S]  --> B
 ```
 commute.
 -/
@@ -198,10 +198,10 @@ and only if, for all `A B : LightCondMod R`, for all epimorphisms `e : A ⟶ B`,
 `S : LightProfinite` and all morphisms `g : R[S × P] ⟶ B`, there exists a `S' : LightProfinite`
 with a surjeciton `π : S' ⟶ S` and a morphism `g' : R[S' × P] ⟶ A`, making the diagram
 ```
-R[S' × P] ⟶ A
-  |          |
-  v          v
-R[S × P]  ⟶ B
+R[S' × P] --> A
+  |           |
+  v           v
+R[S × P]  --> B
 ```
 commute.
 -/
@@ -234,10 +234,10 @@ if and only if, for all `A B : LightCondMod R`, for all epimorphisms `e : A ⟶ 
 `S : LightProfinite` and all morphisms `g : R[P × S] ⟶ B`, there exists a `S' : LightProfinite`
 with a surjeciton `π : S' ⟶ S` and a morphism `g' : R[P × S'] ⟶ A`, making the diagram
 ```
-R[P × S'] ⟶ A
-  |          |
-  v          v
-R[P × S]  ⟶ B
+R[P × S'] --> A
+  |           |
+  v           v
+R[P × S]  --> B
 ```
 commute.
 -/
@@ -268,10 +268,10 @@ if and only if, for all `A B : LightCondMod R`, for all epimorphisms `e : A ⟶ 
 `S : LightProfinite` and all morphisms `g : R[S × P] ⟶ B`, there exists a `S' : LightProfinite`
 with a surjeciton `π : S' ⟶ S` and a morphism `g' : R[S' × P] ⟶ A`, making the diagram
 ```
-R[S' × P] ⟶ A
-  |          |
-  v          v
-R[S × P]  ⟶ B
+R[S' × P] --> A
+  |           |
+  v           v
+R[S × P]  --> B
 ```
 commute.
 -/


### PR DESCRIPTION
Especially in the rendered docs the right vertical arrow was too far to the right. Hopefully this fixes it.

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

When merging, all the commits will be squashed into a single commit
listing all co-authors.

Co-authors in the squash commit are gathered from two sources:

First, all authors of commits to this PR branch are included. Thus,
one way to add co-authors is to include at least one commit authored by
each co-author among the commits in the pull request. If necessary, you
may create empty commits to indicate co-authorship, using commands like so:

git commit --author="Author Name <author@email.com>" --allow-empty -m "add Author Name as coauthor"

Second, co-authors can also be listed in lines at the very bottom of
the commit message (that is, directly before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines
at the bottom of the commit message (before the `---`, and also before
any "Co-authored-by" lines) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
