### PR TITLE
[Merged by Bors] - fix: remove compile_inductive% False

### DIFF
--- a/Mathlib/Util/CompileInductive.lean
+++ b/Mathlib/Util/CompileInductive.lean
@@ -247,7 +247,6 @@ compile_inductive% PEmpty
 compile_inductive% Sum
 compile_inductive% PSum
 compile_inductive% And
-compile_inductive% False
 compile_inductive% Empty
 compile_inductive% Bool
 compile_inductive% Sigma

--- a/MathlibTest/CompileInductive.lean
+++ b/MathlibTest/CompileInductive.lean
@@ -15,7 +15,6 @@ example := @Fin2.recOn
 example := @PUnit.recOn
 example := @PEmpty.recOn
 example := @And.recOn
-example := @False.recOn
 example := @Empty.recOn
 
 example := @Nat.brecOn


### PR DESCRIPTION
Per `hargoniX` [on Zulip](https://leanprover.zulipchat.com/#narrow/channel/287929-mathlib4/topic/Error.20when.20executing.20files.20with.20Mathlib.20import/near/560729156):

This issue occurs due to two factors. The first is the module system that changed the behavior of the inliner for, so far, unknown reasons. However, the behavior of compile_inductive% on False has always been wrong to begin with and so far merely been fixed by the inliner by chance. First things first, it is unnecessary to even compile_inductive% False because False.rec is the single recursor that the compiler has native support for. The reason that calling compile_inductive% on it causes an issue, is that it introduces a new constant False.rec' = unreach. This constant used to be inlined but with the new module system does not get inlined for some reason. Because of this, the compiler decides to closed term lift it and we end up executing an unreachable during initialization. This behavior is a known limitation/bug of the current closed term extraction feature.

The correct fix would be for mathlib to either stop calling compile_inductive% on False as it is actively harming compiler optimizations and unnecessary or to at least place a @[no_extract] attribute on the False.rec' that compile_inductive% generates. This attribute informs the closed term extractor that it is not supposed to pull the constant out and is also placed on other always crashing symbols like panic! or unreachable!.


---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

When merging, all the commits will be squashed into a single commit
listing all co-authors.

Co-authors in the squash commit are gathered from two sources:

First, all authors of commits to this PR branch are included. Thus,
one way to add co-authors is to include at least one commit authored by
each co-author among the commits in the pull request. If necessary, you
may create empty commits to indicate co-authorship, using commands like so:

git commit --author="Author Name <author@email.com>" --allow-empty -m "add Author Name as coauthor"

Second, co-authors can also be listed in lines at the very bottom of
the commit message (that is, directly before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines
at the bottom of the commit message (before the `---`, and also before
any "Co-authored-by" lines) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
