### PR TITLE
[Merged by Bors] - feat: divisibility lemmas for multivariate polynomials

### DIFF
--- a/Mathlib/Algebra/MvPolynomial/Basic.lean
+++ b/Mathlib/Algebra/MvPolynomial/Basic.lean
@@ -782,9 +782,11 @@ lemma support_nonempty {p : MvPolynomial σ R} : p.support.Nonempty ↔ p ≠ 0 
 theorem exists_coeff_ne_zero {p : MvPolynomial σ R} (h : p ≠ 0) : ∃ d, coeff d p ≠ 0 :=
   ne_zero_iff.mp h
 
-theorem monomial_mul_cancel_left {m : σ →₀ ℕ} {a : R}
-    (ha : IsRegular a) (h : monomial m a * p = monomial m a * q) :
-    p = q := by
+theorem _root_.IsRegular.monomial {m : σ →₀ ℕ} {a : R}
+    (ha : IsRegular a) :
+    IsRegular (monomial m a) := by
+  rw [← isLeftRegular_iff_isRegular]
+  intro p q h
   ext d
   have h' := congr_arg  (coeff (m + d)) h
   simp only [coeff_monomial_mul] at h'
@@ -800,10 +802,12 @@ theorem monomial_one_mul_cancel_left {m : σ →₀ ℕ}
     p = q :=
   monomial_mul_cancel_left isRegular_one h
 
+@[simp]
 theorem monomial_one_mul_cancel_left_iff {m : σ →₀ ℕ} :
     monomial m 1 * p = monomial m 1 * q ↔ p = q :=
   monomial_mul_cancel_left_iff isRegular_one
 
+@[simp]
 theorem X_mul_cancel_left_iff {i : σ} :
     X i * p = X i * q ↔ p = q :=
   monomial_one_mul_cancel_left_iff (m := Finsupp.single i 1)
@@ -824,10 +828,12 @@ theorem monomial_one_mul_cancel_right {m : σ →₀ ℕ}
     p = q :=
   monomial_mul_cancel_right isRegular_one h
 
+@[simp]
 theorem monomial_one_mul_cancel_right_iff {m : σ →₀ ℕ} :
     p * monomial m 1 = q * monomial m 1 ↔ p = q :=
   monomial_mul_cancel_right_iff isRegular_one
 
+@[simp]
 theorem X_mul_cancel_right_iff {i : σ} :
     p * X i = q * X i ↔ p = q :=
   monomial_one_mul_cancel_right_iff (m := Finsupp.single i 1)

--- a/Mathlib/Algebra/MvPolynomial/Basic.lean
+++ b/Mathlib/Algebra/MvPolynomial/Basic.lean
@@ -782,6 +782,56 @@ lemma support_nonempty {p : MvPolynomial σ R} : p.support.Nonempty ↔ p ≠ 0 
 theorem exists_coeff_ne_zero {p : MvPolynomial σ R} (h : p ≠ 0) : ∃ d, coeff d p ≠ 0 :=
   ne_zero_iff.mp h
 
+theorem monomial_mul_cancel_left {m : σ →₀ ℕ} {a : R}
+    (ha : IsRegular a) (h : monomial m a * p = monomial m a * q) :
+    p = q := by
+  ext d
+  have h' := congr_arg  (coeff (m + d)) h
+  simp only [coeff_monomial_mul] at h'
+  rw [← ha.left.eq_iff, h']
+
+theorem monomial_mul_cancel_left_iff {m : σ →₀ ℕ} {a : R}
+    (ha : IsRegular a) :
+    monomial m a * p = monomial m a * q ↔ p = q := by
+  refine ⟨monomial_mul_cancel_left ha, fun h ↦ by simp [h]⟩
+
+theorem monomial_one_mul_cancel_left {m : σ →₀ ℕ}
+    (h : monomial m 1 * p = monomial m 1 * q) :
+    p = q :=
+  monomial_mul_cancel_left isRegular_one h
+
+theorem monomial_one_mul_cancel_left_iff {m : σ →₀ ℕ} :
+    monomial m 1 * p = monomial m 1 * q ↔ p = q :=
+  monomial_mul_cancel_left_iff isRegular_one
+
+theorem X_mul_cancel_left_iff {i : σ} :
+    X i * p = X i * q ↔ p = q :=
+  monomial_one_mul_cancel_left_iff (m := Finsupp.single i 1)
+
+theorem monomial_mul_cancel_right {m : σ →₀ ℕ} {a : R}
+    (ha : IsRegular a) (h : p * monomial m a = q * monomial m a) :
+    p = q := by
+  simp only [mul_comm _ (monomial m a)] at h
+  apply monomial_mul_cancel_left ha h
+
+theorem monomial_mul_cancel_right_iff {m : σ →₀ ℕ} {a : R}
+    (ha : IsRegular a) :
+    p * monomial m a = q * monomial m a ↔ p = q := by
+  refine ⟨monomial_mul_cancel_right ha, fun h ↦ by simp [h]⟩
+
+theorem monomial_one_mul_cancel_right {m : σ →₀ ℕ}
+    (h : p * monomial m 1 = q * monomial m 1) :
+    p = q :=
+  monomial_mul_cancel_right isRegular_one h
+
+theorem monomial_one_mul_cancel_right_iff {m : σ →₀ ℕ} :
+    p * monomial m 1 = q * monomial m 1 ↔ p = q :=
+  monomial_mul_cancel_right_iff isRegular_one
+
+theorem X_mul_cancel_right_iff {i : σ} :
+    p * X i = q * X i ↔ p = q :=
+  monomial_one_mul_cancel_right_iff (m := Finsupp.single i 1)
+
 theorem C_dvd_iff_dvd_coeff (r : R) (φ : MvPolynomial σ R) : C r ∣ φ ↔ ∀ i, r ∣ φ.coeff i := by
   constructor
   · rintro ⟨φ, rfl⟩ c

--- a/Mathlib/Algebra/MvPolynomial/Basic.lean
+++ b/Mathlib/Algebra/MvPolynomial/Basic.lean
@@ -792,51 +792,25 @@ theorem _root_.IsRegular.monomial {m : σ →₀ ℕ} {a : R}
   simp only [coeff_monomial_mul] at h'
   rw [← ha.left.eq_iff, h']
 
-theorem monomial_mul_cancel_left_iff {m : σ →₀ ℕ} {a : R}
-    (ha : IsRegular a) :
-    monomial m a * p = monomial m a * q ↔ p = q := by
-  refine ⟨monomial_mul_cancel_left ha, fun h ↦ by simp [h]⟩
-
-theorem monomial_one_mul_cancel_left {m : σ →₀ ℕ}
-    (h : monomial m 1 * p = monomial m 1 * q) :
-    p = q :=
-  monomial_mul_cancel_left isRegular_one h
-
 @[simp]
 theorem monomial_one_mul_cancel_left_iff {m : σ →₀ ℕ} :
     monomial m 1 * p = monomial m 1 * q ↔ p = q :=
-  monomial_mul_cancel_left_iff isRegular_one
+  isRegular_one.monomial.left.eq_iff
 
 @[simp]
 theorem X_mul_cancel_left_iff {i : σ} :
     X i * p = X i * q ↔ p = q :=
-  monomial_one_mul_cancel_left_iff (m := Finsupp.single i 1)
-
-theorem monomial_mul_cancel_right {m : σ →₀ ℕ} {a : R}
-    (ha : IsRegular a) (h : p * monomial m a = q * monomial m a) :
-    p = q := by
-  simp only [mul_comm _ (monomial m a)] at h
-  apply monomial_mul_cancel_left ha h
-
-theorem monomial_mul_cancel_right_iff {m : σ →₀ ℕ} {a : R}
-    (ha : IsRegular a) :
-    p * monomial m a = q * monomial m a ↔ p = q := by
-  refine ⟨monomial_mul_cancel_right ha, fun h ↦ by simp [h]⟩
-
-theorem monomial_one_mul_cancel_right {m : σ →₀ ℕ}
-    (h : p * monomial m 1 = q * monomial m 1) :
-    p = q :=
-  monomial_mul_cancel_right isRegular_one h
+  monomial_one_mul_cancel_left_iff
 
 @[simp]
 theorem monomial_one_mul_cancel_right_iff {m : σ →₀ ℕ} :
     p * monomial m 1 = q * monomial m 1 ↔ p = q :=
-  monomial_mul_cancel_right_iff isRegular_one
+  isRegular_one.monomial.right.eq_iff
 
 @[simp]
 theorem X_mul_cancel_right_iff {i : σ} :
     p * X i = q * X i ↔ p = q :=
-  monomial_one_mul_cancel_right_iff (m := Finsupp.single i 1)
+  monomial_one_mul_cancel_right_iff
 
 theorem C_dvd_iff_dvd_coeff (r : R) (φ : MvPolynomial σ R) : C r ∣ φ ↔ ∀ i, r ∣ φ.coeff i := by
   constructor

--- a/Mathlib/Algebra/MvPolynomial/Division.lean
+++ b/Mathlib/Algebra/MvPolynomial/Division.lean
@@ -233,10 +233,12 @@ theorem eq_divMonomial_single [IsLeftCancelAdd R]
   simpa using hr _ hn
 
 instance [IsLeftCancelAdd R] :
-    IsLeftCancelAdd (MvPolynomial σ R) where
-  add_left_cancel := fun f g h H ↦ by
-    ext d
-    simpa using congr_arg (coeff d) H
+    IsCancelAdd (MvPolynomial σ R) := by
+  suffices IsLeftCancelAdd (MvPolynomial σ R) from
+    AddCommMagma.IsLeftCancelAdd.toIsCancelAdd _
+  refine { add_left_cancel := fun f g h H ↦ ?_ }
+  ext d
+  simpa using congr_arg (coeff d) H
 
 theorem eq_modMonomial_single [IsLeftCancelAdd R]
     {σ : Type*} {i : σ} {p q r : MvPolynomial σ R}
@@ -249,6 +251,7 @@ theorem eq_modMonomial_single [IsLeftCancelAdd R]
 section CommRing
 
 variable {R : Type*} [CommRing R] {i : σ} {p q r : MvPolynomial σ R}
+
 theorem eq_modMonomial_single_iff (h : X i ∣ p - r) :
     r = p.modMonomial (Finsupp.single i 1) ↔
       ∀ n ∈ r.support, n i = 0 := by
@@ -300,6 +303,14 @@ theorem X_dvd_mul_iff [IsCancelMulZero R] :
     rcases h with h | h
     · exact dvd_mul_of_dvd_left h q
     · exact dvd_mul_of_dvd_right h p
+
+theorem X_prime [IsCancelMulZero R] [Nontrivial R] : Prime (X i : MvPolynomial σ R) := by
+  refine ⟨X_ne_zero i, ?_, fun p q ↦ X_dvd_mul_iff.mp⟩
+  intro h
+  rw [isUnit_iff_exists] at h
+  rcases h with ⟨u, hu, -⟩
+  apply_fun constantCoeff at hu
+  simp at hu
 
 theorem dvd_X_mul_iff [IsCancelMulZero R] :
     p ∣ X i * q ↔ p ∣ q ∨ (X i ∣ p ∧ p.divMonomial (Finsupp.single i 1) ∣ q) := by

--- a/Mathlib/Algebra/MvPolynomial/Division.lean
+++ b/Mathlib/Algebra/MvPolynomial/Division.lean
@@ -6,7 +6,8 @@ Authors: Eric Wieser
 module
 
 public import Mathlib.Algebra.MonoidAlgebra.Division
-public import Mathlib.Algebra.MvPolynomial.Basic
+public import Mathlib.Algebra.MvPolynomial.CommRing
+public import Mathlib.Data.Finsupp.Weight
 
 /-!
 # Division of `MvPolynomial` by monomials
@@ -221,5 +222,163 @@ theorem X_dvd_monomial {i : σ} {j : σ →₀ ℕ} {r : R} :
     (X i : MvPolynomial σ R) ∣ monomial j r ↔ r = 0 ∨ j i ≠ 0 := by
   refine monomial_dvd_monomial.trans ?_
   simp_rw [one_dvd, and_true, Finsupp.single_le_iff, Nat.one_le_iff_ne_zero]
+
+theorem eq_divMonomial_single [IsLeftCancelAdd R]
+    {i : σ} {p q r : MvPolynomial σ R} (h : p = X i * q + r)
+    (hr : ∀ n ∈ r.support, n i = 0) :
+    q = p.divMonomial (Finsupp.single i 1) := by
+  ext n
+  rw [coeff_divMonomial, h, coeff_add, coeff_X_mul, left_eq_add, ← notMem_support_iff]
+  intro hn
+  simpa using hr _ hn
+
+instance [IsLeftCancelAdd R] :
+    IsLeftCancelAdd (MvPolynomial σ R) where
+  add_left_cancel := fun f g h H ↦ by
+    ext d
+    simpa using congr_arg (coeff d) H
+
+theorem eq_modMonomial_single [IsLeftCancelAdd R]
+    {σ : Type*} {i : σ} {p q r : MvPolynomial σ R}
+    (h : p = X i * q + r) (hr : ∀ n ∈ r.support, n i = 0) :
+    r = p.modMonomial (Finsupp.single i 1) := by
+  have h' := id h
+  rwa [← p.divMonomial_add_modMonomial_single i,
+    eq_divMonomial_single h hr, add_right_inj, eq_comm] at h'
+
+section CommRing
+
+variable {R : Type*} [CommRing R] {i : σ} {p q r : MvPolynomial σ R}
+theorem eq_modMonomial_single_iff (h : X i ∣ p - r) :
+    r = p.modMonomial (Finsupp.single i 1) ↔
+      ∀ n ∈ r.support, n i = 0 := by
+  refine ⟨fun h n ↦ ?_, fun hr ↦ ?_⟩
+  · contrapose!
+    intro hn
+    rw [h, notMem_support_iff]
+    apply coeff_modMonomial_of_le
+    simpa [Nat.one_le_iff_ne_zero]
+  · obtain ⟨q, hq⟩ := h
+    apply eq_modMonomial_single (q := q) _ hr
+    rwa [← sub_eq_iff_eq_add]
+
+theorem X_dvd_mul_iff [IsCancelMulZero R] :
+    X i ∣ p * q ↔ X i ∣ p ∨ X i ∣ q := by
+  nontriviality R
+  have _ : NoZeroDivisors (MvPolynomial σ R) :=
+    IsLeftCancelMulZero.to_noZeroDivisors (MvPolynomial σ R)
+  constructor
+  · intro h
+    suffices (p.modMonomial (Finsupp.single i 1)) * (q.modMonomial (Finsupp.single i 1)) =
+          (p * q).modMonomial (Finsupp.single i 1) by
+      simp only [X_dvd_iff_modMonomial_eq_zero] at h ⊢
+      rwa [h, mul_eq_zero] at this
+    have hp := p.modMonomial_add_divMonomial_single i
+    have hq := q.modMonomial_add_divMonomial_single i
+    rw [eq_modMonomial_single_iff]
+    · intro n
+      contrapose
+      intro hn
+      classical
+      rw [notMem_support_iff, coeff_mul]
+      apply Finset.sum_eq_zero
+      intro x hx
+      simp only [Finset.mem_antidiagonal] at hx
+      simp only [← hx, Finsupp.coe_add, Pi.add_apply, Nat.add_eq_zero_iff, not_and_or] at hn
+      rcases hn with hn | hn
+      · rw [coeff_modMonomial_of_le, zero_mul]
+        simpa [← Nat.one_le_iff_ne_zero] using hn
+      · rw [mul_comm, coeff_modMonomial_of_le, zero_mul]
+        simpa [← Nat.one_le_iff_ne_zero] using hn
+    · nth_rewrite 1 [← hp]
+      nth_rewrite 1 [← hq]
+      simp  only [add_mul, mul_add, add_assoc, add_sub_cancel_left]
+      simp only [← mul_assoc, mul_comm _ (X i)]
+      simp only [mul_assoc, ← mul_add (X i)]
+      apply dvd_mul_right
+  · intro h
+    rcases h with h | h
+    · exact dvd_mul_of_dvd_left h q
+    · exact dvd_mul_of_dvd_right h p
+
+theorem dvd_X_mul_iff [IsCancelMulZero R] :
+    p ∣ X i * q ↔ p ∣ q ∨ (X i ∣ p ∧ p.divMonomial (Finsupp.single i 1) ∣ q) := by
+  constructor
+  · intro hp
+    obtain ⟨r, hp⟩ := hp
+    have := p.modMonomial_add_divMonomial_single i
+    have : X i ∣ p ∨ X i ∣ r := by simp [← X_dvd_mul_iff, ← hp]
+    rcases this with hip | hir
+    · right
+      refine ⟨hip, ?_⟩
+      rw [X_dvd_iff_modMonomial_eq_zero] at hip
+      rw [hip, zero_add] at this
+      rw [← this, mul_assoc, X_mul_cancel_left_iff] at hp
+      use r
+    · obtain ⟨r, rfl⟩ := hir
+      replace hp : q = p * r := by
+        rwa [← mul_assoc, mul_comm p, mul_assoc, X_mul_cancel_left_iff] at hp
+      left
+      rw [hp]
+      exact dvd_mul_right p r
+  · rintro hp
+    rcases hp with hp | ⟨hi, hq⟩
+    · exact dvd_mul_of_dvd_right hp (X i)
+    · suffices p = X i * p.divMonomial (Finsupp.single i 1) by
+        rw [this]
+        exact mul_dvd_mul_left (X i) hq
+      conv_lhs => rw [← p.modMonomial_add_divMonomial (Finsupp.single i 1)]
+      simpa only [← C_mul_X_eq_monomial, C_1, one_mul, add_eq_right,
+        ← X_dvd_iff_modMonomial_eq_zero]
+
+theorem dvd_monomial_mul_iff_exists [IsCancelMulZero R] {n : σ →₀ ℕ} :
+    p ∣ monomial n 1 * q ↔ ∃ m r, m ≤ n ∧ r ∣ q ∧ p = monomial m 1 * r := by
+  rcases subsingleton_or_nontrivial R with hR | hR
+  · have : Subsingleton (MvPolynomial σ R) := by
+      exact Unique.instSubsingleton
+    simp only [this.allEq _ p, dvd_refl, and_self, and_true, exists_const, true_iff]
+    refine ⟨n, le_refl n⟩
+  suffices ∀ (d) (n : σ →₀ ℕ) (hd : n.degree = d) (p q : MvPolynomial σ R),
+    p ∣ monomial n 1 * q ↔ ∃ m r, m ≤ n ∧ r ∣ q ∧ p = monomial m 1 * r by
+    apply this n.degree n rfl
+  classical
+  intro d
+  induction d with
+  | zero =>
+    intro n hn p
+    rw [Finsupp.degree_eq_zero_iff] at hn
+    simp only [hn, monomial_zero', C_1, one_mul, nonpos_iff_eq_zero, exists_and_left,
+      exists_eq_left, exists_eq_right', implies_true]
+  | succ d hd =>
+    intro n hn p q
+    refine ⟨fun hp ↦ ?_, fun ⟨m, r, hmn, hrq, hp⟩ ↦ ?_⟩
+    · have : n.support.Nonempty := by
+        rw [Finsupp.support_nonempty_iff]
+        intro hn'
+        simp [hn'] at hn
+      obtain ⟨i, hi⟩ := this
+      let n' := n - Finsupp.single i 1
+      have hn' : n' + Finsupp.single i 1 = n := by
+        apply Finsupp.sub_add_single_one_cancel
+        rwa [← Finsupp.mem_support_iff]
+      have hnn' : n' ≤ n := by simp [← hn']
+      have hd' : n'.degree = d := by
+        rw [← add_left_inj, ← hn, ← hn']
+        simp
+      rw [← hn', monomial_add_single, pow_one, mul_comm _ (X i), mul_assoc, dvd_X_mul_iff] at hp
+      rcases hp with hp | hp
+      · obtain ⟨m, r, hm, hr, hp⟩ := (hd n' hd' p q).mp hp
+        exact ⟨m, r, le_trans hm hnn', hr, hp⟩
+      · obtain ⟨p', hp'⟩ := hp.1
+        obtain ⟨m, r, hm, hr, hp⟩ := (hd n' hd' _ _).mp hp.2
+        use m + Finsupp.single i 1, r, ?_, hr
+        · simp [monomial_add_single, pow_one, mul_comm _ (X i), mul_assoc, ← hp,
+          hp']
+        · simpa [← hn'] using hm
+    · rw [hp, ← add_tsub_cancel_of_le hmn, ← mul_one 1, ← monomial_mul, mul_one, mul_assoc]
+      apply mul_dvd_mul dvd_rfl
+      apply dvd_mul_of_dvd_right hrq
+
+end CommRing
 
 end MvPolynomial

--- a/Mathlib/RingTheory/MvPolynomial/MonomialOrder/DegLex.lean
+++ b/Mathlib/RingTheory/MvPolynomial/MonomialOrder/DegLex.lean
@@ -109,8 +109,7 @@ theorem dvd_monomial_iff_exists {n : σ →₀ ℕ} {a : R} (ha : a ≠ 0) :
 theorem dvd_monomial_one_iff_exists {n : σ →₀ ℕ} :
     p ∣ monomial n 1 ↔ ∃ m u, m ≤ n ∧ IsUnit u ∧ p = monomial m u := by
   rcases subsingleton_or_nontrivial R with hR | hR
-  · simp only [Subsingleton.allEq _ p, dvd_refl, isUnit_iff_eq_one, and_true, exists_eq_right,
-      true_iff]
+  · suffices ∃ m, m ≤ n by simpa [Subsingleton.elim _ p]
     use n
   rw [dvd_monomial_iff_exists (one_ne_zero' R)]
   apply exists_congr
@@ -123,28 +122,27 @@ theorem dvd_X_iff_exists {i : σ} :
   apply exists_congr
   intro b
   constructor
-  · rintro ⟨m, hmn, hb, hp⟩
+  · rintro ⟨m, hmn, hb, rfl⟩
     simp only [hb, true_and]
     suffices m = 0 ∨ m = Finsupp.single i 1 by
-      rcases this with hm | hm
-      · left; simp [hp, hm]
-      · right; rw [hp, hm, smul_monomial, smul_eq_mul, mul_one]
+      apply this.imp <;> simp +contextual [smul_monomial, smul_eq_mul, mul_one]
     by_cases hm : m i = 0
     · left
       ext j
       simp only [Finsupp.coe_zero, Pi.zero_apply, ← Nat.le_zero]
       by_cases hj : j = i
       · rw [← hm, hj]
-      · rw [← ne_eq] at hj; convert hmn j; rw [Finsupp.single_eq_of_ne hj]
+      · exact (hmn j).trans (Finsupp.single_eq_of_ne hj).le
     · right
       ext j
       apply le_antisymm (hmn j)
       by_cases hj : j = i
       · simpa [hj, Nat.one_le_iff_ne_zero]
-      · rw [← ne_eq] at hj; simp [Finsupp.single_eq_of_ne hj]
+      · simp [Finsupp.single_eq_of_ne hj]
   · rintro ⟨hb, hp | hp⟩
     · use 0; simp [hb, hp]
-    · use Finsupp.single i 1, le_refl _, hb, by simp [hp, smul_monomial]
+    · use Finsupp.single i 1, le_rfl, hb
+      simp [hp, smul_monomial]
 
 end CommRing
 

--- a/Mathlib/RingTheory/MvPolynomial/MonomialOrder/DegLex.lean
+++ b/Mathlib/RingTheory/MvPolynomial/MonomialOrder/DegLex.lean
@@ -19,7 +19,11 @@ open MonomialOrder Finsupp
 
 open scoped MonomialOrder
 
-variable {σ : Type*} {R : Type*} [CommSemiring R] {f g : MvPolynomial σ R}
+variable {σ : Type*} {R : Type*}
+
+section CommSemiring
+
+variable [CommSemiring R] {f g : MvPolynomial σ R}
 
 section LinearOrder
 
@@ -42,14 +46,18 @@ theorem degLex_totalDegree_monotone (h : degLex.degree f ≼[degLex] degLex.degr
 
 end LinearOrder
 
-theorem totalDegree_mul_of_isDomain [IsCancelMulZero R] (hf : f ≠ 0) (hg : g ≠ 0) :
+section IsCancelMulZero
+
+variable [IsCancelMulZero R]
+
+theorem totalDegree_mul_of_isDomain (hf : f ≠ 0) (hg : g ≠ 0) :
     totalDegree (f * g) = totalDegree f + totalDegree g := by
   cases exists_wellOrder σ
   rw [← degree_degLexDegree (σ := σᵒᵈ), ← degree_degLexDegree (σ := σᵒᵈ),
     ← degree_degLexDegree (σ := σᵒᵈ), MonomialOrder.degree_mul hf hg]
   simp
 
-theorem totalDegree_le_of_dvd_of_isDomain [IsCancelMulZero R] (h : f ∣ g) (hg : g ≠ 0) :
+theorem totalDegree_le_of_dvd_of_isDomain (h : f ∣ g) (hg : g ≠ 0) :
     f.totalDegree ≤ g.totalDegree := by
   obtain ⟨r, rfl⟩ := h
   rw [totalDegree_mul_of_isDomain]
@@ -57,15 +65,15 @@ theorem totalDegree_le_of_dvd_of_isDomain [IsCancelMulZero R] (h : f ∣ g) (hg 
   · exact fun h ↦ hg (by simp [h])
   · exact fun h ↦ hg (by simp [h])
 
-theorem dvd_C_iff_exists [IsCancelMulZero R] {a : R} (ha : a ≠ 0) :
-    f ∣ MvPolynomial.C a ↔ ∃ b, b ∣ a ∧ f = MvPolynomial.C b := by
+theorem dvd_C_iff_exists {a : R} (ha : a ≠ 0) :
+    f ∣ C a ↔ ∃ b, b ∣ a ∧ f = C b := by
   constructor
   · intro hf
     use MvPolynomial.coeff 0 f
     suffices f.totalDegree = 0 by
       rw [totalDegree_eq_zero_iff_eq_C] at this
       refine ⟨?_, this⟩
-      rw [this, MvPolynomial.C_dvd_iff_dvd_coeff] at hf
+      rw [this, C_dvd_iff_dvd_coeff] at hf
       convert hf 0
       simp
     apply Nat.eq_zero_of_le_zero
@@ -74,10 +82,15 @@ theorem dvd_C_iff_exists [IsCancelMulZero R] {a : R} (ha : a ≠ 0) :
   · rintro ⟨b, hab, rfl⟩
     exact _root_.map_dvd MvPolynomial.C hab
 
-variable {R : Type*} [CommRing R]
-  {p q r : MvPolynomial σ R}
+end IsCancelMulZero
 
-theorem dvd_monomial_iff_exists [IsCancelMulZero R] {n : σ →₀ ℕ} {a : R} (ha : a ≠ 0) :
+end CommSemiring
+
+section CommRing
+
+variable [CommRing R] [IsCancelMulZero R] {p q r : MvPolynomial σ R}
+
+theorem dvd_monomial_iff_exists {n : σ →₀ ℕ} {a : R} (ha : a ≠ 0) :
     p ∣ monomial n a ↔ ∃ m b, m ≤ n ∧ b ∣ a ∧ p = monomial m b := by
   rw [show monomial n a = monomial n 1 * C a from by
     rw [mul_comm, C_mul_monomial, mul_one],
@@ -94,7 +107,7 @@ theorem dvd_monomial_iff_exists [IsCancelMulZero R] {n : σ →₀ ℕ} {a : R} 
     use C b, hmn, map_dvd C hb
     rwa [mul_comm, C_mul_monomial, mul_one]
 
-theorem dvd_monomial_one_iff_exists [IsCancelMulZero R] {n : σ →₀ ℕ} :
+theorem dvd_monomial_one_iff_exists {n : σ →₀ ℕ} :
     p ∣ monomial n 1 ↔ ∃ m u, m ≤ n ∧ IsUnit u ∧ p = monomial m u := by
   rcases subsingleton_or_nontrivial R with hR | hR
   · simp only [Subsingleton.allEq _ p, dvd_refl, isUnit_iff_eq_one, and_true, exists_eq_right,
@@ -105,7 +118,7 @@ theorem dvd_monomial_one_iff_exists [IsCancelMulZero R] {n : σ →₀ ℕ} :
   intro m
   simp_rw [isUnit_iff_dvd_one]
 
-theorem dvd_X_iff_exists [IsCancelMulZero R] {i : σ} :
+theorem dvd_X_iff_exists {i : σ} :
     p ∣ X i ↔ ∃ r, IsUnit r ∧ (p = C r ∨ p = r • X i) := by
   rw [show (X i : MvPolynomial σ R) = monomial (Finsupp.single i 1) 1 from
     by rfl]
@@ -135,5 +148,7 @@ theorem dvd_X_iff_exists [IsCancelMulZero R] {i : σ} :
   · rintro ⟨hb, hp | hp⟩
     · use 0; simp [hb, hp]
     · use Finsupp.single i 1, le_refl _, hb, by simp [hp, smul_monomial]
+
+end CommRing
 
 end MvPolynomial

--- a/Mathlib/RingTheory/MvPolynomial/MonomialOrder/DegLex.lean
+++ b/Mathlib/RingTheory/MvPolynomial/MonomialOrder/DegLex.lean
@@ -92,8 +92,7 @@ variable [CommRing R] [IsCancelMulZero R] {p q r : MvPolynomial σ R}
 
 theorem dvd_monomial_iff_exists {n : σ →₀ ℕ} {a : R} (ha : a ≠ 0) :
     p ∣ monomial n a ↔ ∃ m b, m ≤ n ∧ b ∣ a ∧ p = monomial m b := by
-  rw [show monomial n a = monomial n 1 * C a from by
-    rw [mul_comm, C_mul_monomial, mul_one],
+  rw [show monomial n a = monomial n 1 * C a by rw [mul_comm, C_mul_monomial, mul_one],
     dvd_monomial_mul_iff_exists]
   apply exists_congr
   intro m
@@ -111,7 +110,7 @@ theorem dvd_monomial_one_iff_exists {n : σ →₀ ℕ} :
     p ∣ monomial n 1 ↔ ∃ m u, m ≤ n ∧ IsUnit u ∧ p = monomial m u := by
   rcases subsingleton_or_nontrivial R with hR | hR
   · simp only [Subsingleton.allEq _ p, dvd_refl, isUnit_iff_eq_one, and_true, exists_eq_right,
-    true_iff]
+      true_iff]
     use n
   rw [dvd_monomial_iff_exists (one_ne_zero' R)]
   apply exists_congr
@@ -120,9 +119,7 @@ theorem dvd_monomial_one_iff_exists {n : σ →₀ ℕ} :
 
 theorem dvd_X_iff_exists {i : σ} :
     p ∣ X i ↔ ∃ r, IsUnit r ∧ (p = C r ∨ p = r • X i) := by
-  rw [show (X i : MvPolynomial σ R) = monomial (Finsupp.single i 1) 1 from
-    by rfl]
-  rw [dvd_monomial_one_iff_exists, exists_comm]
+  rw [X, dvd_monomial_one_iff_exists, exists_comm]
   apply exists_congr
   intro b
   constructor


### PR DESCRIPTION
Prove several divisibility lemmas for multivariate polynomials, of the form:
if $$p$$ divides $$X ^ n * q$$, then there exists $$m\leq n$$ and $$p'$$ dividing $$q$$ such that $$p = X^m * p'$$.

They come from a particular case that was proven in #31161 .

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

When merging, all the commits will be squashed into a single commit
listing all co-authors.

Co-authors in the squash commit are gathered from two sources:

First, all authors of commits to this PR branch are included. Thus,
one way to add co-authors is to include at least one commit authored by
each co-author among the commits in the pull request. If necessary, you
may create empty commits to indicate co-authorship, using commands like so:

git commit --author="Author Name <author@email.com>" --allow-empty -m "add Author Name as coauthor"

Second, co-authors can also be listed in lines at the very bottom of
the commit message (that is, directly before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines
at the bottom of the commit message (before the `---`, and also before
any "Co-authored-by" lines) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
