### PR TITLE
[Merged by Bors] - feat(by_contra!): allow `rintro` patterns in `by_contra!`

### DIFF
--- a/Archive/Imo/Imo2008Q4.lean
+++ b/Archive/Imo/Imo2008Q4.lean
@@ -59,8 +59,7 @@ theorem imo2008_q4 (f : ℝ → ℝ) (H₁ : ∀ x > 0, f x > 0) :
     specialize H₂ 1 x (sqrt x) (sqrt x) zero_lt_one
     grind [sqrt_pos]
   have h₃ : ∀ x > 0, f x = x ∨ f x = 1 / x := by simpa [sub_eq_zero] using h₂
-  by_contra! h
-  rcases h with ⟨⟨b, hb, hfb₁⟩, ⟨a, ha, hfa₁⟩⟩
+  by_contra! ⟨⟨b, hb, hfb₁⟩, ⟨a, ha, hfa₁⟩⟩
   obtain hfa₂ := Or.resolve_right (h₃ a ha) hfa₁
   -- f(a) ≠ 1/a, f(a) = a
   obtain hfb₂ := Or.resolve_left (h₃ b hb) hfb₁

--- a/Counterexamples/AharoniKorman.lean
+++ b/Counterexamples/AharoniKorman.lean
@@ -1003,8 +1003,7 @@ lemma left_or_right_bias {n : ℕ} (a b : ℕ)
     (∀ i : ℕ, ∃ j ∈ C ∩ level n, h(a, i, n) ≤ j) ∨
     (∀ i : ℕ, ∃ j ∈ C ∩ level n, h(i, b, n) ≤ j) := by
   -- Suppose otherwise, and take `c` and `d` counterexamples to both alternatives
-  by_contra! h
-  obtain ⟨⟨c, hc⟩, d, hd⟩ := h
+  by_contra! ⟨⟨c, hc⟩, d, hd⟩
   -- Observe the set of points in `C ∩ level n` below `(d, c, n)` is finite, and aim to show that
   -- `C ∩ level n` is contained in this set, for a contradiction
   refine hCn (((Set.finite_Iic (d, c)).image (embed n)).subset ?_)

--- a/Mathlib/Algebra/Category/Grp/EpiMono.lean
+++ b/Mathlib/Algebra/Category/Grp/EpiMono.lean
@@ -290,7 +290,7 @@ end SurjectiveOfEpiAuxs
 
 theorem surjective_of_epi [Epi f] : Function.Surjective f := by
   dsimp [Function.Surjective]
-  by_contra! r; rcases r with ⟨b, hb⟩
+  by_contra! ⟨b, hb⟩
   exact
     SurjectiveOfEpiAuxs.g_ne_h f b (fun ⟨c, hc⟩ => hb _ hc)
       (congr_arg GrpCat.Hom.hom ((cancel_epi f).1 (SurjectiveOfEpiAuxs.comp_eq f)))

--- a/Mathlib/Algebra/DirectSum/Internal.lean
+++ b/Mathlib/Algebra/DirectSum/Internal.lean
@@ -452,8 +452,7 @@ theorem mul_apply_eq_zero {r r' : ⨁ i, A i} {m n : ι}
   rw [Subtype.ext_iff, ZeroMemClass.coe_zero, coe_mul_apply]
   apply Finset.sum_eq_zero fun x hx ↦ ?_
   obtain (hx | hx) : x.1 < m ∨ x.2 < n := by
-    by_contra! h
-    obtain ⟨hm, hn⟩ := h
+    by_contra! ⟨hm, hn⟩
     obtain rfl : x.1 + x.2 = k := by simp_all
     apply lt_irrefl (m + n) <| lt_of_le_of_lt (by gcongr) hk
   all_goals simp [hr, hr', hx]

--- a/Mathlib/Algebra/Lie/Submodule.lean
+++ b/Mathlib/Algebra/Lie/Submodule.lean
@@ -532,7 +532,7 @@ instance [Nontrivial M] : Nontrivial (LieSubmodule R L M) :=
 theorem nontrivial_iff_ne_bot {N : LieSubmodule R L M} : Nontrivial N ↔ N ≠ ⊥ := by
   constructor <;> contrapose!
   · rintro rfl
-    by_contra! h; rcases h with
+    by_contra!
       ⟨⟨m₁, h₁ : m₁ ∈ (⊥ : LieSubmodule R L M)⟩, ⟨m₂, h₂ : m₂ ∈ (⊥ : LieSubmodule R L M)⟩, h₁₂⟩
     simp [(LieSubmodule.mem_bot _).mp h₁, (LieSubmodule.mem_bot _).mp h₂] at h₁₂
   · rw [LieSubmodule.eq_bot_iff]

--- a/Mathlib/Algebra/Order/CompleteField.lean
+++ b/Mathlib/Algebra/Order/CompleteField.lean
@@ -64,8 +64,7 @@ instance (priority := 100) ConditionallyCompleteLinearOrderedField.to_archimedea
     [ConditionallyCompleteLinearOrderedField α] : Archimedean α :=
   archimedean_iff_nat_lt.2
     (by
-      by_contra! h
-      obtain ⟨x, h⟩ := h
+      by_contra! ⟨x, h⟩
       have := csSup_le (range_nonempty Nat.cast)
         (forall_mem_range.2 fun m =>
           le_sub_iff_add_le.2 <| le_csSup ⟨x, forall_mem_range.2 h⟩ ⟨m+1, Nat.cast_succ m⟩)

--- a/Mathlib/Algebra/Order/CompleteField.lean
+++ b/Mathlib/Algebra/Order/CompleteField.lean
@@ -62,13 +62,12 @@ class ConditionallyCompleteLinearOrderedField (α : Type*) extends
 /-- Any conditionally complete linearly ordered field is archimedean. -/
 instance (priority := 100) ConditionallyCompleteLinearOrderedField.to_archimedean
     [ConditionallyCompleteLinearOrderedField α] : Archimedean α :=
-  archimedean_iff_nat_lt.2
-    (by
-      by_contra! ⟨x, h⟩
-      have := csSup_le (range_nonempty Nat.cast)
-        (forall_mem_range.2 fun m =>
-          le_sub_iff_add_le.2 <| le_csSup ⟨x, forall_mem_range.2 h⟩ ⟨m+1, Nat.cast_succ m⟩)
-      linarith)
+  archimedean_iff_nat_lt.2 <| by
+    by_contra! ⟨x, h⟩
+    have := csSup_le (range_nonempty Nat.cast)
+      (forall_mem_range.2 fun m =>
+        le_sub_iff_add_le.2 <| le_csSup ⟨x, forall_mem_range.2 h⟩ ⟨m+1, Nat.cast_succ m⟩)
+    linarith
 
 namespace LinearOrderedField
 

--- a/Mathlib/Algebra/Order/Module/HahnEmbedding.lean
+++ b/Mathlib/Algebra/Order/Module/HahnEmbedding.lean
@@ -568,8 +568,7 @@ theorem evalCoeff_eq_zero {x : M} {c : FiniteArchimedeanClass M}
 theorem isWF_support_evalCoeff [IsOrderedAddMonoid R] [Archimedean R] (x : M) :
     (evalCoeff f x).support.IsWF := by
   rw [Set.isWF_iff_no_descending_seq]
-  by_contra!
-  obtain ⟨seq, ⟨hanti, hmem⟩⟩ := this
+  by_contra! ⟨seq, ⟨hanti, hmem⟩⟩
   have hnonempty : ∃ y : f.val.domain, y.val - x ∈ ball K (seq 0) := by
     specialize hmem 0
     contrapose hmem with hempty

--- a/Mathlib/Algebra/Polynomial/RingDivision.lean
+++ b/Mathlib/Algebra/Polynomial/RingDivision.lean
@@ -223,10 +223,10 @@ theorem Monic.irreducible_of_degree_eq_one (hp1 : degree p = 1) (hm : Monic p) :
 
 lemma aeval_ne_zero_of_isCoprime {R} [CommSemiring R] [Nontrivial S] [Semiring S] [Algebra R S]
     {p q : R[X]} (h : IsCoprime p q) (s : S) : aeval s p ≠ 0 ∨ aeval s q ≠ 0 := by
-  by_contra! hpq
+  by_contra! ⟨hp, hq⟩
   rcases h with ⟨_, _, h⟩
   apply_fun aeval s at h
-  simp only [map_add, map_mul, map_one, hpq.left, hpq.right, mul_zero, add_zero, zero_ne_one] at h
+  simp only [map_add, map_mul, map_one, hp, hq, mul_zero, add_zero, zero_ne_one] at h
 
 theorem isCoprime_X_sub_C_of_isUnit_sub {R} [CommRing R] {a b : R} (h : IsUnit (a - b)) :
     IsCoprime (X - C a) (X - C b) :=

--- a/Mathlib/Analysis/ConstantSpeed.lean
+++ b/Mathlib/Analysis/ConstantSpeed.lean
@@ -154,8 +154,7 @@ theorem hasConstantSpeedOnWith_zero_iff :
   dsimp [HasConstantSpeedOnWith]
   simp only [zero_mul, ENNReal.ofReal_zero, ← eVariationOn.eq_zero_iff]
   constructor
-  · by_contra!
-    obtain ⟨h, hfs⟩ := this
+  · by_contra! ⟨h, hfs⟩
     simp_rw [ne_eq, eVariationOn.eq_zero_iff] at hfs h
     push_neg at hfs
     obtain ⟨x, xs, y, ys, hxy⟩ := hfs

--- a/Mathlib/Analysis/LocallyConvex/Bounded.lean
+++ b/Mathlib/Analysis/LocallyConvex/Bounded.lean
@@ -222,8 +222,7 @@ theorem isVonNBounded_of_smul_tendsto_zero {ε : ι → 𝕜} {l : Filter ι} [l
     (hε : ∀ᶠ n in l, ε n ≠ 0) {S : Set E}
     (H : ∀ x : ι → E, (∀ n, x n ∈ S) → Tendsto (ε • x) l (𝓝 0)) : IsVonNBounded 𝕜 S := by
   rw [(nhds_basis_balanced 𝕜 E).isVonNBounded_iff]
-  by_contra! H'
-  rcases H' with ⟨V, ⟨hV, hVb⟩, hVS⟩
+  by_contra! ⟨V, ⟨hV, hVb⟩, hVS⟩
   have : ∀ᶠ n in l, ∃ x : S, ε n • (x : E) ∉ V := by
     filter_upwards [hε] with n hn
     rw [absorbs_iff_norm] at hVS

--- a/Mathlib/Analysis/MeanInequalities.lean
+++ b/Mathlib/Analysis/MeanInequalities.lean
@@ -240,8 +240,7 @@ theorem geom_mean_eq_arith_mean_weighted_iff (w z : ι → ℝ) (hw : ∀ i ∈ 
     ∏ i ∈ s, z i ^ w i = ∑ i ∈ s, w i * z i ↔ ∀ j ∈ s, w j ≠ 0 → z j = ∑ i ∈ s, w i * z i := by
   have h (i) (_ : i ∈ s) : w i * z i ≠ 0 → w i ≠ 0 := by apply left_ne_zero_of_mul
   have h' (i) (_ : i ∈ s) : z i ^ w i ≠ 1 → w i ≠ 0 := by
-    by_contra!
-    obtain ⟨h1, h2⟩ := this
+    by_contra! ⟨h1, h2⟩
     simp only [h2, rpow_zero, ne_self_iff_false] at h1
   rw [← sum_filter_of_ne h, ← prod_filter_of_ne h', geom_mean_eq_arith_mean_weighted_iff']
   · simp

--- a/Mathlib/Analysis/SpecialFunctions/Trigonometric/Arctan.lean
+++ b/Mathlib/Analysis/SpecialFunctions/Trigonometric/Arctan.lean
@@ -257,8 +257,7 @@ theorem arctan_inv_of_neg (h : x < 0) : arctan x⁻¹ = -(π / 2) - arctan x := 
 section ArctanAdd
 
 lemma arctan_ne_mul_pi_div_two : ∀ (k : ℤ), arctan x ≠ (2 * k + 1) * π / 2 := by
-  by_contra!
-  obtain ⟨k, h⟩ := this
+  by_contra! ⟨k, h⟩
   obtain ⟨lb, ub⟩ := arctan_mem_Ioo x
   rw [h, neg_eq_neg_one_mul, mul_div_assoc, mul_lt_mul_iff_left₀ (by positivity)] at lb
   rw [h, ← one_mul (π / 2), mul_div_assoc, mul_lt_mul_iff_left₀ (by positivity)] at ub

--- a/Mathlib/CategoryTheory/Preadditive/Biproducts.lean
+++ b/Mathlib/CategoryTheory/Preadditive/Biproducts.lean
@@ -785,8 +785,7 @@ def Biprod.isoElim (f : X₁ ⊞ X₂ ≅ Y₁ ⊞ Y₂) [IsIso (biprod.inl ≫ 
 
 theorem Biprod.column_nonzero_of_iso {W X Y Z : C} (f : W ⊞ X ⟶ Y ⊞ Z) [IsIso f] :
     𝟙 W = 0 ∨ biprod.inl ≫ f ≫ biprod.fst ≠ 0 ∨ biprod.inl ≫ f ≫ biprod.snd ≠ 0 := by
-  by_contra! h
-  rcases h with ⟨nz, a₁, a₂⟩
+  by_contra! ⟨nz, a₁, a₂⟩
   set x := biprod.inl ≫ f ≫ inv f ≫ biprod.fst
   have h₁ : x = 𝟙 W := by simp [x]
   have h₀ : x = 0 := by

--- a/Mathlib/Combinatorics/Graph/Basic.lean
+++ b/Mathlib/Combinatorics/Graph/Basic.lean
@@ -222,11 +222,11 @@ lemma Inc.inc_other (h : G.Inc e x) : G.Inc e h.other :=
 
 lemma Inc.eq_or_eq_or_eq (hx : G.Inc e x) (hy : G.Inc e y) (hz : G.Inc e z) :
     x = y ∨ x = z ∨ y = z := by
-  by_contra! hcon
+  by_contra! ⟨hxy, hxz, hyz⟩
   obtain ⟨x', hx'⟩ := hx
-  obtain rfl := hy.eq_of_isLink_of_ne_left hx' hcon.1.symm
-  obtain rfl := hz.eq_of_isLink_of_ne_left hx' hcon.2.1.symm
-  exact hcon.2.2 rfl
+  obtain rfl := hy.eq_of_isLink_of_ne_left hx' hxy.symm
+  obtain rfl := hz.eq_of_isLink_of_ne_left hx' hxz.symm
+  exact hyz rfl
 
 /-- `G.IsLoopAt e x` means that both ends of the edge `e` are equal to the vertex `x`. -/
 def IsLoopAt (G : Graph α β) (e : β) (x : α) : Prop := G.IsLink e x x

--- a/Mathlib/Combinatorics/Matroid/IndepAxioms.lean
+++ b/Mathlib/Combinatorics/Matroid/IndepAxioms.lean
@@ -228,8 +228,7 @@ provided independence is determined by its behaviour on finite sets. -/
     (indep_aug := by
       have htofin : ∀ I e, Indep I → ¬ Indep (insert e I) →
         ∃ I₀, I₀ ⊆ I ∧ I₀.Finite ∧ ¬ Indep (insert e I₀) := by
-        by_contra! h
-        obtain ⟨I, e, -, hIe, h⟩ := h
+        by_contra! ⟨I, e, -, hIe, h⟩
         refine hIe <| indep_compact _ fun J hJss hJfin ↦ ?_
         exact indep_subset (h (J \ {e}) (by rwa [diff_subset_iff]) hJfin.diff) (by simp)
       intro I B hI hImax hBmax

--- a/Mathlib/Combinatorics/SimpleGraph/Extremal/Turan.lean
+++ b/Mathlib/Combinatorics/SimpleGraph/Extremal/Turan.lean
@@ -84,8 +84,7 @@ theorem turanGraph_eq_top : turanGraph n r = ⊤ ↔ r = 0 ∨ n ≤ r := by
 
 theorem turanGraph_cliqueFree (hr : 0 < r) : (turanGraph n r).CliqueFree (r + 1) := by
   rw [cliqueFree_iff]
-  by_contra! h
-  obtain ⟨f, ha⟩ := h
+  by_contra! ⟨f, ha⟩
   simp_rw [turanGraph_adj] at ha
   obtain ⟨x, y, d, c⟩ := exists_ne_map_eq_of_card_lt (fun x ↦
     (⟨(f x).1 % r, Nat.mod_lt _ hr⟩ : Fin r)) (by simp)

--- a/Mathlib/Dynamics/TopologicalEntropy/CoverEntropy.lean
+++ b/Mathlib/Dynamics/TopologicalEntropy/CoverEntropy.lean
@@ -339,8 +339,7 @@ lemma nonempty_inter_of_coverMincard {T : X → X} {F : Set X} {U : SetRel X X} 
     ∀ x ∈ s, (F ∩ ball x (dynEntourage T U n)).Nonempty := by
   -- Otherwise, there is a ball which does not intersect `F`. Removing it yields a smaller cover.
   classical
-  by_contra! hypo
-  obtain ⟨x, x_s, ball_empt⟩ := hypo
+  by_contra! ⟨x, x_s, ball_empt⟩
   have smaller_cover : IsDynCoverOf T F U n (s.erase x) := by
     intro y y_F
     specialize h y_F

--- a/Mathlib/GroupTheory/Exponent.lean
+++ b/Mathlib/GroupTheory/Exponent.lean
@@ -436,8 +436,7 @@ theorem exists_orderOf_eq_exponent (hG : ExponentExists G) : ∃ g : G, orderOf 
   apply Nat.dvd_antisymm (order_dvd_exponent _)
   refine Nat.dvd_of_primeFactorsList_subperm he ?_
   rw [List.subperm_ext_iff]
-  by_contra! h
-  obtain ⟨p, hp, hpe⟩ := h
+  by_contra! ⟨p, hp, hpe⟩
   replace hp := Nat.prime_of_mem_primeFactorsList hp
   simp only [Nat.primeFactorsList_count_eq] at hpe
   set k := (orderOf t).factorization p with hk

--- a/Mathlib/GroupTheory/Perm/Cycle/Factors.lean
+++ b/Mathlib/GroupTheory/Perm/Cycle/Factors.lean
@@ -405,8 +405,7 @@ where
         refine ⟨?_, fun g' hg' ↦ ?_, fun g' hg' y ↦ ?_, hm₃⟩
         · simp [List.prod_cons, hm₁]
         · exact ((List.mem_cons).1 hg').elim (fun hg' => hg'.symm ▸ isCycle_cycleOf _ hx) (hm₂ g')
-        by_contra!
-        obtain ⟨hgy, hg'y⟩ := this
+        by_contra! ⟨hgy, hg'y⟩
         have hxy : SameCycle g x y := not_imp_comm.1 cycleOf_apply_of_not_sameCycle hgy
         have hg'm : g' :: m.erase g' ~ m := List.cons_perm_iff_perm_erase.2 ⟨hg', .refl _⟩
         have : ∀ h ∈ m.erase g', Disjoint g' h :=

--- a/Mathlib/GroupTheory/SpecificGroups/Alternating/Centralizer.lean
+++ b/Mathlib/GroupTheory/SpecificGroups/Alternating/Centralizer.lean
@@ -154,8 +154,7 @@ theorem count_le_one_of_centralizer_le_alternating
   rw [← Multiset.nodup_iff_count_le_one, Equiv.Perm.cycleType_def]
   rw [Multiset.nodup_map_iff_inj_on g.cycleFactorsFinset.nodup]
   simp only [Function.comp_apply, ← Finset.mem_def]
-  by_contra! hm
-  obtain ⟨c, hc, d, hd, hm, hm'⟩ := hm
+  by_contra! ⟨c, hc, d, hd, hm, hm'⟩
   let τ : Equiv.Perm g.cycleFactorsFinset := Equiv.swap ⟨c, hc⟩ ⟨d, hd⟩
   obtain ⟨a⟩ := Equiv.Perm.Basis.nonempty g
   have hτ : τ ∈ range_toPermHom' g := fun x ↦ by

--- a/Mathlib/LinearAlgebra/RootSystem/Finite/Lemmas.lean
+++ b/Mathlib/LinearAlgebra/RootSystem/Finite/Lemmas.lean
@@ -322,8 +322,7 @@ lemma exists_apply_eq_or [Nonempty ι] : ∃ i j, ∀ k,
   · refine ⟨i, i, fun j ↦ by simp [h j]⟩
   · obtain ⟨j, hji_ne⟩ := h
     refine ⟨i, j, fun k ↦ ?_⟩
-    by_contra! hk
-    obtain ⟨hki_ne, hkj_ne⟩ := hk
+    by_contra! ⟨hki_ne, hkj_ne⟩
     have hij := (B.apply_eq_or i j).resolve_left hji_ne.symm
     have hik := (B.apply_eq_or i k).resolve_left hki_ne.symm
     have hjk := (B.apply_eq_or j k).resolve_left hkj_ne.symm

--- a/Mathlib/MeasureTheory/Function/ConvergenceInMeasure.lean
+++ b/Mathlib/MeasureTheory/Function/ConvergenceInMeasure.lean
@@ -337,7 +337,7 @@ theorem exists_seq_tendstoInMeasure_atTop_iff [IsFiniteMeasure μ]
         ∀ᵐ (ω : α) ∂μ, Tendsto (fun i ↦ f (ns (ns' i)) ω) atTop (𝓝 (g ω)) := by
   refine ⟨fun hfg _ hns ↦ (hfg.comp hns.tendsto_atTop).exists_seq_tendsto_ae, fun h1 ↦ ?_⟩
   rw [tendstoInMeasure_iff_tendsto_toNNReal]
-  by_contra! h; rcases h with ⟨ε, hε, h2⟩
+  by_contra! ⟨ε, hε, h2⟩
   obtain ⟨δ, ns, hδ, hns, h3⟩ : ∃ (δ : ℝ≥0) (ns : ℕ → ℕ), 0 < δ ∧ StrictMono ns ∧
       ∀ n, δ ≤ (μ {x | ε ≤ edist (f (ns n) x) (g x)}).toNNReal := by
     obtain ⟨s, hs, h4⟩ := not_tendsto_iff_exists_frequently_notMem.1 h2

--- a/Mathlib/ModelTheory/Satisfiability.lean
+++ b/Mathlib/ModelTheory/Satisfiability.lean
@@ -475,8 +475,7 @@ theorem Categorical.isComplete (h : κ.Categorical T) (h1 : ℵ₀ ≤ κ)
   ⟨hS, fun φ => by
     obtain ⟨_, _⟩ := Theory.exists_model_card_eq ⟨hS.some, hT hS.some⟩ κ h1 h2
     rw [Theory.models_sentence_iff, Theory.models_sentence_iff]
-    by_contra! con
-    obtain ⟨⟨MF, hMF⟩, MT, hMT⟩ := con
+    by_contra! ⟨⟨MF, hMF⟩, MT, hMT⟩
     rw [Sentence.realize_not, Classical.not_not] at hMT
     refine hMF ?_
     haveI := hT MT

--- a/Mathlib/NumberTheory/FLT/Three.lean
+++ b/Mathlib/NumberTheory/FLT/Three.lean
@@ -322,8 +322,7 @@ variable [NumberField K] [IsCyclotomicExtension {3} ℚ K]
 `S'.a + η * S'.b` and `S'.a + η ^ 2 * S'.b`. -/
 lemma lambda_sq_dvd_or_dvd_or_dvd :
     λ ^ 2 ∣ S'.a + S'.b ∨ λ ^ 2 ∣ S'.a + η * S'.b ∨ λ ^ 2 ∣ S'.a + η ^ 2 * S'.b := by
-  by_contra! h
-  rcases h with ⟨h1, h2, h3⟩
+  by_contra! ⟨h1, h2, h3⟩
   rw [← emultiplicity_lt_iff_not_dvd] at h1 h2 h3
   have h1' : FiniteMultiplicity (hζ.toInteger - 1) (S'.a + S'.b) :=
     finiteMultiplicity_iff_emultiplicity_ne_top.2 (fun ht ↦ by simp [ht] at h1)

--- a/Mathlib/NumberTheory/LSeries/Basic.lean
+++ b/Mathlib/NumberTheory/LSeries/Basic.lean
@@ -320,8 +320,8 @@ by a constant times `n^(re s)`. -/
 lemma LSeriesSummable.le_const_mul_rpow {f : ℕ → ℂ} {s : ℂ} (h : LSeriesSummable f s) :
     ∃ C, ∀ n ≠ 0, ‖f n‖ ≤ C * n ^ s.re := by
   replace h := h.norm
-  by_contra! H
-  obtain ⟨n, hn₀, hn⟩ := H (tsum fun n ↦ ‖term f s n‖)
+  use tsum fun n ↦ ‖term f s n‖
+  by_contra! ⟨n, hn₀, hn⟩
   have := h.le_tsum n fun _ _ ↦ norm_nonneg _
   rw [norm_term_eq, if_neg hn₀,
     div_le_iff₀ <| Real.rpow_pos_of_pos (Nat.cast_pos.mpr <| Nat.pos_of_ne_zero hn₀) _] at this

--- a/Mathlib/NumberTheory/Ostrowski.lean
+++ b/Mathlib/NumberTheory/Ostrowski.lean
@@ -161,8 +161,7 @@ lemma is_prime_of_minimal_nat_zero_lt_and_lt_one : p.Prime := by
     simp only [Nat.cast_one, map_one, lt_self_iff_false] at hp1
   · rintro a b rfl
     rw [Nat.isUnit_iff, Nat.isUnit_iff]
-    by_contra! con
-    obtain ⟨ha₁, hb₁⟩ := con
+    by_contra! ⟨ha₁, hb₁⟩
     obtain ⟨ha₀, hb₀⟩ : a ≠ 0 ∧ b ≠ 0 := by
       refine mul_ne_zero_iff.mp fun h ↦ ?_
       rwa [h, Nat.cast_zero, map_zero, lt_self_iff_false] at hp0

--- a/Mathlib/Order/Category/NonemptyFinLinOrd.lean
+++ b/Mathlib/Order/Category/NonemptyFinLinOrd.lean
@@ -140,8 +140,7 @@ theorem epi_iff_surjective {A B : NonemptyFinLinOrd.{u}} (f : A ⟶ B) :
   constructor
   · intro
     dsimp only [Function.Surjective]
-    by_contra! hf'
-    rcases hf' with ⟨m, hm⟩
+    by_contra! ⟨m, hm⟩
     let Y := of (ULift (Fin 2))
     let p₁ : B ⟶ Y := ofHom
       ⟨fun b => if b < m then ULift.up 0 else ULift.up 1, fun x₁ x₂ h => by

--- a/Mathlib/Probability/Process/HittingTime.lean
+++ b/Mathlib/Probability/Process/HittingTime.lean
@@ -376,8 +376,7 @@ theorem hittingBtwn_mono_right (u : ι → Ω → β) (s : Set β) (n : ι) :
     split_ifs with h'
     · obtain ⟨j, hj₁, hj₂⟩ := h'
       refine le_csInf ⟨j, hj₁, hj₂⟩ ?_
-      by_contra! hneg
-      obtain ⟨i, hi₁, hi₂⟩ := hneg
+      by_contra! ⟨i, hi₁, hi₂⟩
       exact h ⟨i, ⟨hi₁.1.1, hi₂.le⟩, hi₁.2⟩
     · exact hm
 

--- a/Mathlib/RingTheory/DiscreteValuationRing/Basic.lean
+++ b/Mathlib/RingTheory/DiscreteValuationRing/Basic.lean
@@ -78,8 +78,7 @@ theorem irreducible_of_span_eq_maximalIdeal {R : Type*} [CommSemiring R] [IsLoca
   have h2 : ¬IsUnit ϖ := show ϖ ∈ maximalIdeal R from h.symm ▸ Submodule.mem_span_singleton_self ϖ
   refine ⟨h2, ?_⟩
   intro a b hab
-  by_contra! h
-  obtain ⟨ha : a ∈ maximalIdeal R, hb : b ∈ maximalIdeal R⟩ := h
+  by_contra! ⟨ha : a ∈ maximalIdeal R, hb : b ∈ maximalIdeal R⟩
   rw [h, mem_span_singleton'] at ha hb
   rcases ha with ⟨a, rfl⟩
   rcases hb with ⟨b, rfl⟩

--- a/Mathlib/RingTheory/DiscreteValuationRing/TFAE.lean
+++ b/Mathlib/RingTheory/DiscreteValuationRing/TFAE.lean
@@ -80,8 +80,7 @@ theorem exists_maximalIdeal_pow_eq_of_principal [IsNoetherianRing R] [IsLocalRin
   use Nat.find this
   apply le_antisymm
   · change ∀ s ∈ I, s ∈ _
-    by_contra! hI''
-    obtain ⟨s, hs₁, hs₂⟩ := hI''
+    by_contra! ⟨s, hs₁, hs₂⟩
     apply hs₂
     by_cases hs₃ : s = 0; · rw [hs₃]; exact zero_mem _
     obtain ⟨n, u, rfl⟩ := H' s hs₃ (le_maximalIdeal hI' hs₁)

--- a/Mathlib/RingTheory/GradedAlgebra/Radical.lean
+++ b/Mathlib/RingTheory/GradedAlgebra/Radical.lean
@@ -52,8 +52,7 @@ theorem Ideal.IsHomogeneous.isPrime_of_homogeneous_mem_or_mem {I : Ideal A} (hI 
     Ideal.IsPrime I :=
   ⟨I_ne_top, by
     intro x y hxy
-    by_contra! rid
-    obtain ⟨rid₁, rid₂⟩ := rid
+    by_contra! ⟨rid₁, rid₂⟩
     classical
       /-
         The idea of the proof is the following :

--- a/Mathlib/RingTheory/Ideal/Height.lean
+++ b/Mathlib/RingTheory/Ideal/Height.lean
@@ -179,8 +179,8 @@ lemma Ideal.primeHeight_eq_zero_iff {I : Ideal R} [I.IsPrime] :
   simp only [bot_le, and_true, Set.mem_setOf_eq, Minimal, IsMin]
   constructor
   · intro h
-    by_contra! h'
-    obtain ⟨P, ⟨hP₁, ⟨hP₂, hP₃⟩⟩⟩ := h' (inferInstance)
+    refine ⟨inferInstance, ?_⟩
+    by_contra! ⟨P, ⟨hP₁, ⟨hP₂, hP₃⟩⟩⟩
     exact hP₃ (h (b := ⟨P, hP₁⟩) hP₂)
   · rintro ⟨hI, hI'⟩ b hb
     exact hI' (y := b.asIdeal) b.isPrime hb

--- a/Mathlib/RingTheory/Ideal/Oka.lean
+++ b/Mathlib/RingTheory/Ideal/Oka.lean
@@ -49,8 +49,7 @@ include hP
 theorem isPrime_of_maximal_not {I : Ideal R} (hI : Maximal (¬P ·) I) : I.IsPrime where
   ne_top' hI' := hI.prop (hI' ▸ hP.top)
   mem_or_mem' := by
-    by_contra!
-    obtain ⟨a, b, hab, ha, hb⟩ := this
+    by_contra! ⟨a, b, hab, ha, hb⟩
     have h₁ : P (I ⊔ span {a}) := of_not_not <| hI.not_prop_of_gt (Submodule.lt_sup_iff_notMem.2 ha)
     have h₂ : P (I.colon (span {a})) := of_not_not <| hI.not_prop_of_gt <| lt_of_le_of_ne le_colon
       (fun H ↦ hb <| H ▸ mem_colon_singleton.2 (mul_comm a b ▸ hab))

--- a/Mathlib/RingTheory/Localization/FractionRing.lean
+++ b/Mathlib/RingTheory/Localization/FractionRing.lean
@@ -538,8 +538,7 @@ theorem isFractionRing_iff_of_base_ringEquiv (h : R ≃+* P) :
 variable (R S : Type*) [CommSemiring R] [CommSemiring S] [Algebra R S] [h : IsFractionRing R S]
 
 theorem nontrivial_iff_nontrivial : Nontrivial R ↔ Nontrivial S := by
-  by_contra! h'
-  rcases h' with ⟨_, _⟩ | ⟨_, _⟩
+  by_contra! ⟨_, _⟩ | ⟨_, _⟩
   · obtain ⟨c, hc⟩ := h.exists_of_eq (x := 1) (y := 0) (Subsingleton.elim _ _)
     simp at hc
   · apply (h.map_units 1).ne_zero

--- a/Mathlib/RingTheory/MvPolynomial/Symmetric/FundamentalTheorem.lean
+++ b/Mathlib/RingTheory/MvPolynomial/Symmetric/FundamentalTheorem.lean
@@ -246,8 +246,7 @@ lemma IsSymmetric.antitone_supDegree [LinearOrder σ] {p : MvPolynomial σ R} (h
   · rw [supDegree_zero, Finsupp.bot_eq_zero]
     exact Pi.zero_mono
   rw [Antitone]
-  by_contra! h
-  obtain ⟨i, j, hle, hlt⟩ := h
+  by_contra! ⟨i, j, hle, hlt⟩
   apply (le_sup (s := p.support) (f := toLex) _).not_gt
   pick_goal 3
   · rw [← hp (Equiv.swap i j), mem_support_iff, coeff_rename_mapDomain _ (Equiv.injective _)]

--- a/Mathlib/RingTheory/WittVector/TeichmullerSeries.lean
+++ b/Mathlib/RingTheory/WittVector/TeichmullerSeries.lean
@@ -57,8 +57,7 @@ theorem sum_coeff_eq_coeff_sum {α : Type*} {S : Finset α} (x : α → 𝕎 R)
     simp only [ha, not_false_eq_true, Finset.sum_insert]
     have : ∀ (n : ℕ), (x a).coeff n = 0 ∨ (∑ s ∈ S', x s).coeff n = 0 := by
       simp only [hind]
-      by_contra! h
-      obtain ⟨m, hma, hmS'⟩ := h
+      by_contra! ⟨m, hma, hmS'⟩
       have := Finset.sum_eq_zero.mt hmS'
       push_neg at this
       choose b hb hb' using this

--- a/Mathlib/Tactic/ByContra.lean
+++ b/Mathlib/Tactic/ByContra.lean
@@ -47,6 +47,8 @@ macro_rules
 | `(tactic| by_contra! $[$pat?]? $[: $ty?]?) => do
   let pat ← pat?.getDM `(rcasesPatMed| $(mkIdent `this):ident)
   let replaceTac ← match ty? with
-    | some ty => `(tactic| replace h : $ty := by (try push_neg); exact h)
+    | some ty => `(tactic| replace h : $ty := by (try push_neg); exact h) -- Let `h` have type `ty`.
     | none => `(tactic| skip)
+  -- We have to use `revert h; rintro $pat` instead of `obtain $pat := h`,
+  -- because if `$pat` is a variable, `obtain $pat := h` doesn't do anything.
   `(tactic| (by_contra h; (try push_neg at h); $replaceTac; revert h; rintro ($pat:rcasesPatMed)))

--- a/Mathlib/Tactic/ByContra.lean
+++ b/Mathlib/Tactic/ByContra.lean
@@ -22,8 +22,11 @@ open Lean Parser.Tactic
 If the target of the main goal is a proposition `p`,
 `by_contra!` reduces the goal to proving `False` using the additional hypothesis `this : ¬ p`.
 `by_contra! h` can be used to name the hypothesis `h : ¬ p`.
-The hypothesis `¬ p` will be negation normalized using `push_neg`.
+The hypothesis `¬ p` will be normalized using `push_neg`.
 For instance, `¬ a < b` will be changed to `b ≤ a`.
+`by_contra!` can be used with `rcases` patterns.
+For instance, `by_contra! rfl` on `⊢ s.Nonempty` will substitute the equality `s = ∅`,
+and `by_contra! ⟨hp, hq⟩` on `⊢ ¬ p ∨ ¬ q` will introduce `hp : p` and `hq : q`.
 `by_contra! h : q` will normalize negations in `¬ p`, normalize negations in `q`,
 and then check that the two normalized forms are equal.
 The resulting hypothesis is the pre-normalized form, `q`.

--- a/Mathlib/Topology/Algebra/Nonarchimedean/TotallyDisconnected.lean
+++ b/Mathlib/Topology/Algebra/Nonarchimedean/TotallyDisconnected.lean
@@ -45,8 +45,7 @@ lemma exists_openSubgroup_separating {a b : G} (h : a ≠ b) :
   use V
   simp only [Disjoint, Set.le_eq_subset, Set.bot_eq_empty, Set.subset_empty_iff]
   intro x mem_aV mem_bV
-  by_contra! con
-  obtain ⟨s, hs⟩ := con
+  by_contra! ⟨s, hs⟩
   have hsa : s ∈ a • (V : Set G) := mem_aV hs
   have hsb : s ∈ b • (V : Set G) := mem_bV hs
   rw [mem_leftCoset_iff] at hsa hsb

--- a/Mathlib/Topology/Connected/Clopen.lean
+++ b/Mathlib/Topology/Connected/Clopen.lean
@@ -543,8 +543,7 @@ continuous on a set `s`, is constant on s, then s is preconnected -/
 theorem isPreconnected_of_forall_constant {s : Set α}
     (hs : ∀ f : α → Bool, ContinuousOn f s → ∀ x ∈ s, ∀ y ∈ s, f x = f y) : IsPreconnected s := by
   unfold IsPreconnected
-  by_contra!
-  rcases this with ⟨u, v, u_op, v_op, hsuv, ⟨x, x_in_s, x_in_u⟩, ⟨y, y_in_s, y_in_v⟩, H⟩
+  by_contra! ⟨u, v, u_op, v_op, hsuv, ⟨x, x_in_s, x_in_u⟩, ⟨y, y_in_s, y_in_v⟩, H⟩
   have hy : y ∉ u := fun y_in_u => eq_empty_iff_forall_notMem.mp H y ⟨y_in_s, ⟨y_in_u, y_in_v⟩⟩
   have : ContinuousOn u.boolIndicator s := by
     apply (continuousOn_boolIndicator_iff_isClopen _ _).mpr ⟨_, _⟩

--- a/Mathlib/Topology/Separation/Connected.lean
+++ b/Mathlib/Topology/Separation/Connected.lean
@@ -29,8 +29,7 @@ instance (priority := 100) TotallyDisconnectedSpace.t1Space [h : TotallyDisconne
 
 theorem PreconnectedSpace.trivial_of_discrete [PreconnectedSpace X] [DiscreteTopology X] :
     Subsingleton X := by
-  by_contra! h
-  rcases h with ⟨x, y, hxy⟩
+  by_contra! ⟨x, y, hxy⟩
   rw [Ne, ← mem_singleton_iff, (isClopen_discrete _).eq_univ <| singleton_nonempty y] at hxy
   exact hxy (mem_univ x)
 

--- a/MathlibTest/byContra.lean
+++ b/MathlibTest/byContra.lean
@@ -79,14 +79,14 @@ example (x : α) (f : False) : x ≤ 1 := by
 end order
 
 example (n : ℕ) (h : n ≠ 0) : n ≠ 0 := by
-  by_contra rfl
+  by_contra! rfl
   simp only [Ne, not_true_eq_false] at h
 
-example (p q : Prop) (hnp : ¬ p) : ¬ (p ∧ q) := by
-  by_contra ⟨hp, _⟩
+example (p q : Prop) (hnp : ¬ p) : ¬ p ∨ ¬ q := by
+  by_contra! ⟨hp, _⟩
   exact hnp hp
 
 example (p q : Prop) (hnp : ¬ p) (hnq : ¬ q) : ¬ (p ∨ q) := by
-  by_contra hp | hq
+  by_contra! hp | hq
   · exact hnp hp
   · exact hnq hq

--- a/MathlibTest/byContra.lean
+++ b/MathlibTest/byContra.lean
@@ -6,7 +6,6 @@ import Mathlib.Algebra.Notation.Defs
 import Mathlib.Data.Nat.Basic
 import Mathlib.Order.Basic
 
-set_option autoImplicit true
 example (a b : ℕ) (foo : False) : a < b := by
   by_contra!
   guard_hyp this : b ≤ a
@@ -27,14 +26,14 @@ example : 1 < 2 := by
   guard_hyp this : 2 ≤ 1
   contradiction
 
-example (_p : Prop) (bar : False) : ¬ ¬ ¬ ¬ ¬ ¬ P := by
-  by_contra! foo : ¬ ¬ ¬ P -- normalises to ¬ P, as does ¬ (goal).
-  guard_hyp foo : ¬ ¬ ¬ P
+example (p : Prop) (bar : False) : ¬ ¬ ¬ ¬ ¬ ¬ p := by
+  by_contra! foo : ¬ ¬ ¬ p -- normalises to ¬ p, as does ¬ (goal).
+  guard_hyp foo : ¬ ¬ ¬ p
   exact bar
 
-example (_p : Prop) (bar : False) : ¬ ¬ ¬ ¬ ¬ ¬ P := by
-  by_contra! : ¬ ¬ ¬ P
-  guard_hyp this : ¬ ¬ ¬ P
+example (p : Prop) (bar : False) : ¬ ¬ ¬ ¬ ¬ ¬ p := by
+  by_contra! : ¬ ¬ ¬ p
+  guard_hyp this : ¬ ¬ ¬ p
   exact bar
 
 /--
@@ -54,7 +53,9 @@ this : a ≤ b
 example (a b : ℕ) : a < b := by
   by_contra! : a ≤ b
 
-variable [LinearOrder α] [One α] [Mul α]
+section order
+
+variable {α} [LinearOrder α] [One α] [Mul α]
 
 example (x : α) (f : False) : x ≤ 1 := by
   set a := x * x
@@ -74,3 +75,18 @@ example (x : α) (f : False) : x ≤ 1 := by
   by_contra! h
   guard_hyp h : 1 < x
   assumption
+
+end order
+
+example (n : ℕ) (h : n ≠ 0) : n ≠ 0 := by
+  by_contra rfl
+  simp only [Ne, not_true_eq_false] at h
+
+example (p q : Prop) (hnp : ¬ p) : ¬ (p ∧ q) := by
+  by_contra ⟨hp, _⟩
+  exact hnp hp
+
+example (p q : Prop) (hnp : ¬ p) (hnq : ¬ q) : ¬ (p ∨ q) := by
+  by_contra hp | hq
+  · exact hnp hp
+  · exact hnq hq

--- a/MathlibTest/byContra.lean
+++ b/MathlibTest/byContra.lean
@@ -7,7 +7,7 @@ import Mathlib.Data.Nat.Basic
 import Mathlib.Order.Basic
 
 set_option autoImplicit true
-example (a b : ℕ) (foo : False)  : a < b := by
+example (a b : ℕ) (foo : False) : a < b := by
   by_contra!
   guard_hyp this : b ≤ a
   exact foo
@@ -36,6 +36,23 @@ example (_p : Prop) (bar : False) : ¬ ¬ ¬ ¬ ¬ ¬ P := by
   by_contra! : ¬ ¬ ¬ P
   guard_hyp this : ¬ ¬ ¬ P
   exact bar
+
+/--
+error: Type mismatch
+  h✝
+has type
+  b ≤ a
+but is expected to have type
+  a ≤ b
+---
+error: unsolved goals
+a b : ℕ
+this : a ≤ b
+⊢ False
+-/
+#guard_msgs in
+example (a b : ℕ) : a < b := by
+  by_contra! : a ≤ b
 
 variable [LinearOrder α] [One α] [Mul α]
 


### PR DESCRIPTION
This PR adds the feature to `by_cases!` that it case use `rintro` patterns.

The test that I added to the test file is to show that that error message didn't change.

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

When merging, all the commits will be squashed into a single commit
listing all co-authors.

Co-authors in the squash commit are gathered from two sources:

First, all authors of commits to this PR branch are included. Thus,
one way to add co-authors is to include at least one commit authored by
each co-author among the commits in the pull request. If necessary, you
may create empty commits to indicate co-authorship, using commands like so:

git commit --author="Author Name <author@email.com>" --allow-empty -m "add Author Name as coauthor"

Second, co-authors can also be listed in lines at the very bottom of
the commit message (that is, directly before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines
at the bottom of the commit message (before the `---`, and also before
any "Co-authored-by" lines) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
