### PR TITLE
[Merged by Bors] - feat: covariance of a variable multiplied by a constant

### DIFF
--- a/Mathlib/Probability/Distributions/Gaussian/Basic.lean
+++ b/Mathlib/Probability/Distributions/Gaussian/Basic.lean
@@ -163,7 +163,8 @@ theorem isGaussian_iff_charFunDual_eq {μ : Measure E} [IsFiniteMeasure μ] :
     Real.coe_toNNReal']
   congr
   · rw [integral_const_mul, integral_complex_ofReal]
-  · rw [max_eq_left (variance_nonneg _ _), mul_comm, ← ofReal_pow, ← ofReal_mul, ← variance_mul]
+  · rw [max_eq_left (variance_nonneg _ _), mul_comm, ← ofReal_pow, ← ofReal_mul,
+      ← variance_const_mul]
     congr
 
 alias ⟨_, isGaussian_of_charFunDual_eq⟩ := isGaussian_iff_charFunDual_eq

--- a/Mathlib/Probability/Moments/Basic.lean
+++ b/Mathlib/Probability/Moments/Basic.lean
@@ -6,7 +6,6 @@ Authors: Rémy Degenne
 module
 
 public import Mathlib.Probability.IdentDistrib
-
 import Mathlib.Probability.Independence.Integration
 
 /-!

--- a/Mathlib/Probability/Moments/Basic.lean
+++ b/Mathlib/Probability/Moments/Basic.lean
@@ -7,6 +7,8 @@ module
 
 public import Mathlib.Probability.IdentDistrib
 
+import Mathlib.Probability.Independence.Integration
+
 /-!
 # Moments and moment-generating function
 

--- a/Mathlib/Probability/Moments/Covariance.lean
+++ b/Mathlib/Probability/Moments/Covariance.lean
@@ -7,7 +7,6 @@ module
 
 public import Mathlib.MeasureTheory.Integral.Bochner.Basic
 public import Mathlib.Probability.Independence.Basic
-
 import Mathlib.Probability.Independence.Integration
 
 /-!

--- a/Mathlib/Probability/Moments/Covariance.lean
+++ b/Mathlib/Probability/Moments/Covariance.lean
@@ -5,7 +5,10 @@ Authors: Rémy Degenne, Etienne Marion
 -/
 module
 
-public import Mathlib.Probability.Independence.Integration
+public import Mathlib.MeasureTheory.Integral.Bochner.Basic
+public import Mathlib.Probability.Independence.Basic
+
+import Mathlib.Probability.Independence.Integration
 
 /-!
 # Covariance
@@ -136,11 +139,11 @@ lemma covariance_const_mul_left (c : ℝ) : cov[fun ω ↦ c * X ω, Y; μ] = c 
 lemma covariance_const_mul_right (c : ℝ) : cov[X, fun ω ↦ c * Y ω; μ] = c * cov[X, Y; μ] :=
   covariance_smul_right c
 
-lemma covariance_mul_const_left (c : ℝ) : cov[fun ω ↦ X ω * c, Y; μ] = c * cov[X, Y; μ] :=
-  covariance_smul_left c
+lemma covariance_mul_const_left (c : ℝ) : cov[fun ω ↦ X ω * c, Y; μ] = c * cov[X, Y; μ] := by
+  simp [mul_comm, covariance_const_mul_left]
 
-lemma covariance_const_mul_right (c : ℝ) : cov[X, fun ω ↦ c * Y ω; μ] = c * cov[X, Y; μ] :=
-  covariance_smul_right c
+lemma covariance_mul_const_right (c : ℝ) : cov[X, fun ω ↦ Y ω * c; μ] = c * cov[X, Y; μ] := by
+  simp [mul_comm, covariance_const_mul_right]
 
 @[deprecated (since := "2025-11-29")] alias covariance_mul_left := covariance_const_mul_left
 @[deprecated (since := "2025-11-29")] alias covariance_mul_right := covariance_const_mul_right

--- a/Mathlib/Probability/Moments/Covariance.lean
+++ b/Mathlib/Probability/Moments/Covariance.lean
@@ -130,11 +130,20 @@ lemma covariance_smul_left (c : ℝ) : cov[c • X, Y; μ] = c * cov[X, Y; μ] :
 lemma covariance_smul_right (c : ℝ) : cov[X, c • Y; μ] = c * cov[X, Y; μ] := by
   rw [covariance_comm, covariance_smul_left, covariance_comm]
 
-lemma covariance_mul_left (c : ℝ) : cov[fun ω ↦ c * X ω, Y; μ] = c * cov[X, Y; μ] :=
+lemma covariance_const_mul_left (c : ℝ) : cov[fun ω ↦ c * X ω, Y; μ] = c * cov[X, Y; μ] :=
   covariance_smul_left c
 
-lemma covariance_mul_right (c : ℝ) : cov[X, fun ω ↦ c * Y ω; μ] = c * cov[X, Y; μ] :=
+lemma covariance_const_mul_right (c : ℝ) : cov[X, fun ω ↦ c * Y ω; μ] = c * cov[X, Y; μ] :=
   covariance_smul_right c
+
+lemma covariance_mul_const_left (c : ℝ) : cov[fun ω ↦ X ω * c, Y; μ] = c * cov[X, Y; μ] :=
+  covariance_smul_left c
+
+lemma covariance_const_mul_right (c : ℝ) : cov[X, fun ω ↦ c * Y ω; μ] = c * cov[X, Y; μ] :=
+  covariance_smul_right c
+
+@[deprecated (since := "2025-11-29")] alias covariance_mul_left := covariance_const_mul_left
+@[deprecated (since := "2025-11-29")] alias covariance_mul_right := covariance_const_mul_right
 
 @[simp]
 lemma covariance_neg_left : cov[-X, Y; μ] = -cov[X, Y; μ] := by

--- a/Mathlib/Probability/Moments/Covariance.lean
+++ b/Mathlib/Probability/Moments/Covariance.lean
@@ -139,10 +139,10 @@ lemma covariance_const_mul_left (c : ℝ) : cov[fun ω ↦ c * X ω, Y; μ] = c 
 lemma covariance_const_mul_right (c : ℝ) : cov[X, fun ω ↦ c * Y ω; μ] = c * cov[X, Y; μ] :=
   covariance_smul_right c
 
-lemma covariance_mul_const_left (c : ℝ) : cov[fun ω ↦ X ω * c, Y; μ] = c * cov[X, Y; μ] := by
+lemma covariance_mul_const_left (c : ℝ) : cov[fun ω ↦ X ω * c, Y; μ] = cov[X, Y; μ] * c := by
   simp [mul_comm, covariance_const_mul_left]
 
-lemma covariance_mul_const_right (c : ℝ) : cov[X, fun ω ↦ Y ω * c; μ] = c * cov[X, Y; μ] := by
+lemma covariance_mul_const_right (c : ℝ) : cov[X, fun ω ↦ Y ω * c; μ] = cov[X, Y; μ] * c := by
   simp [mul_comm, covariance_const_mul_right]
 
 @[deprecated (since := "2025-11-29")] alias covariance_mul_left := covariance_const_mul_left

--- a/Mathlib/Probability/Moments/CovarianceBilin.lean
+++ b/Mathlib/Probability/Moments/CovarianceBilin.lean
@@ -89,7 +89,8 @@ lemma covarianceBilin_real {μ : Measure ℝ} [IsFiniteMeasure μ] (x y : ℝ) :
     covarianceBilin μ x y = x * y * Var[id; μ] := by
   by_cases h : MemLp id 2 μ
   · simp only [covarianceBilin_apply_eq_cov h, RCLike.inner_apply, conj_trivial, mul_comm]
-    rw [covariance_mul_left, covariance_mul_right, ← mul_assoc, covariance_self aemeasurable_id']
+    rw [covariance_const_mul_left, covariance_const_mul_right, ← mul_assoc,
+      covariance_self aemeasurable_id']
     rfl
   · simp [h, variance_of_not_memLp, aestronglyMeasurable_id]
 
@@ -170,7 +171,7 @@ lemma covarianceBilin_apply_pi {ι Ω : Type*} [Fintype ι] {mΩ : MeasurableSpa
   · simp_rw [sum_inner, real_inner_smul_left, basisFun_inner]
     rw [covariance_fun_sum_fun_sum]
     · refine Finset.sum_congr rfl fun i _ ↦ Finset.sum_congr rfl fun j _ ↦ ?_
-      rw [covariance_mul_left, covariance_mul_right]
+      rw [covariance_const_mul_left, covariance_const_mul_right]
       ring
     all_goals exact fun i ↦ (hX i).const_mul _
   any_goals exact Measurable.aestronglyMeasurable (by fun_prop)

--- a/Mathlib/Probability/Moments/Variance.lean
+++ b/Mathlib/Probability/Moments/Variance.lean
@@ -7,7 +7,6 @@ module
 
 public import Mathlib.Probability.Moments.Covariance
 public import Mathlib.Probability.Notation
-
 import Mathlib.MeasureTheory.Function.LpSeminorm.Prod
 import Mathlib.Probability.Independence.Integrable
 

--- a/Mathlib/Probability/Moments/Variance.lean
+++ b/Mathlib/Probability/Moments/Variance.lean
@@ -6,10 +6,10 @@ Authors: Sébastien Gouëzel, Kexing Ying
 module
 
 public import Mathlib.Probability.Moments.Covariance
+public import Mathlib.Probability.Notation
 
 import Mathlib.MeasureTheory.Function.LpSeminorm.Prod
 import Mathlib.Probability.Independence.Integrable
-import Mathlib.Probability.Notation
 
 /-!
 # Variance of random variables

--- a/Mathlib/Probability/Moments/Variance.lean
+++ b/Mathlib/Probability/Moments/Variance.lean
@@ -187,7 +187,7 @@ theorem variance_const_mul (c : ℝ) (X : Ω → ℝ) (μ : Measure Ω) :
   rfl
 
 theorem variance_mul_const (c : ℝ) (X : Ω → ℝ) (μ : Measure Ω) :
-    variance (fun ω => X ω * c) μ = c ^ 2 * variance X μ := by
+    variance (fun ω => X ω * c) μ = variance X μ * c ^ 2 := by
   simp [mul_comm, variance_const_mul]
 
 @[deprecated (since := "2025-11-29")] alias variance_mul := variance_const_mul

--- a/Mathlib/Probability/Moments/Variance.lean
+++ b/Mathlib/Probability/Moments/Variance.lean
@@ -7,6 +7,10 @@ module
 
 public import Mathlib.Probability.Moments.Covariance
 
+import Mathlib.MeasureTheory.Function.LpSeminorm.Prod
+import Mathlib.Probability.Independence.Integrable
+import Mathlib.Probability.Notation
+
 /-!
 # Variance of random variables
 
@@ -177,14 +181,20 @@ lemma covariance_self {X : Ω → ℝ} (hX : AEMeasurable X μ) :
 theorem variance_nonneg (X : Ω → ℝ) (μ : Measure Ω) : 0 ≤ variance X μ :=
   ENNReal.toReal_nonneg
 
-theorem variance_mul (c : ℝ) (X : Ω → ℝ) (μ : Measure Ω) :
+theorem variance_const_mul (c : ℝ) (X : Ω → ℝ) (μ : Measure Ω) :
     variance (fun ω => c * X ω) μ = c ^ 2 * variance X μ := by
   rw [variance, evariance_mul, ENNReal.toReal_mul, ENNReal.toReal_ofReal (sq_nonneg _)]
   rfl
 
+theorem variance_mul_const (c : ℝ) (X : Ω → ℝ) (μ : Measure Ω) :
+    variance (fun ω => X ω * c) μ = c ^ 2 * variance X μ := by
+  simp [mul_comm, variance_const_mul]
+
+@[deprecated (since := "2025-11-29")] alias variance_mul := variance_const_mul
+
 theorem variance_smul (c : ℝ) (X : Ω → ℝ) (μ : Measure Ω) :
     variance (c • X) μ = c ^ 2 * variance X μ :=
-  variance_mul c X μ
+  variance_const_mul c X μ
 
 theorem variance_smul' {A : Type*} [CommSemiring A] [Algebra A ℝ] (c : A) (X : Ω → ℝ)
     (μ : Measure Ω) : variance (c • X) μ = c ^ 2 • variance X μ := by
@@ -216,7 +226,7 @@ lemma variance_const_add [IsProbabilityMeasure μ] (hX : AEStronglyMeasurable X 
   simp_rw [add_comm c, variance_add_const hX c]
 
 lemma variance_fun_neg : Var[fun ω ↦ -X ω; μ] = Var[X; μ] := by
-  convert variance_mul (-1) X μ
+  convert variance_const_mul (-1) X μ
   · ext; ring
   · simp
 


### PR DESCRIPTION
Rename `covariance_mul_left : cov[fun ω ↦ c * X ω, Y; μ] = c * cov[X, Y; μ]` to `covariance_const_mul_left` and add `covariance_mul_const_left : cov[fun ω ↦ X ω * c, Y; μ] = cov[X, Y; μ] * c`. Same for `right` and variance. Also minimize the `public import`s in the `Covariance` file.

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

When merging, all the commits will be squashed into a single commit
listing all co-authors.

Co-authors in the squash commit are gathered from two sources:

First, all authors of commits to this PR branch are included. Thus,
one way to add co-authors is to include at least one commit authored by
each co-author among the commits in the pull request. If necessary, you
may create empty commits to indicate co-authorship, using commands like so:

git commit --author="Author Name <author@email.com>" --allow-empty -m "add Author Name as coauthor"

Second, co-authors can also be listed in lines at the very bottom of
the commit message (that is, directly before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines
at the bottom of the commit message (before the `---`, and also before
any "Co-authored-by" lines) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
