### PR TITLE
[Merged by Bors] - chore(NumberTheory/Real/GoldenRatio): integer version of Binet's formula

### DIFF
--- a/Mathlib/NumberTheory/Real/GoldenRatio.lean
+++ b/Mathlib/NumberTheory/Real/GoldenRatio.lean
@@ -48,68 +48,105 @@ open goldenRatio
 theorem inv_goldenRatio : φ⁻¹ = -ψ := by
   grind
 
+@[deprecated (since := "2025-08-23")] alias _root_.inv_gold := inv_goldenRatio
+
 /-- The opposite of the golden ratio is the inverse of its conjugate. -/
 theorem inv_goldenConj : ψ⁻¹ = -φ := by
   rw [inv_eq_iff_eq_inv, ← neg_inv, ← neg_eq_iff_eq_neg]
   exact inv_goldenRatio.symm
 
+@[deprecated (since := "2025-08-23")] alias _root_.inv_goldConj := inv_goldenConj
+
 @[simp]
 theorem goldenRatio_mul_goldenConj : φ * ψ = -1 := by
   grind
+
+@[deprecated (since := "2025-08-23")] alias _root_.gold_mul_goldConj := goldenRatio_mul_goldenConj
 
 @[simp]
 theorem goldenConj_mul_goldenRatio : ψ * φ = -1 := by
   rw [mul_comm]
   exact goldenRatio_mul_goldenConj
 
+@[deprecated (since := "2025-08-23")] alias _root_.goldConj_mul_gold := goldenConj_mul_goldenRatio
+
 @[simp]
 theorem goldenRatio_add_goldenConj : φ + ψ = 1 := by
   rw [goldenRatio, goldenConj]
   ring
 
+@[deprecated (since := "2025-08-23")] alias _root_.gold_add_goldConj := goldenRatio_add_goldenConj
+
 theorem one_sub_goldenConj : 1 - φ = ψ := by
   linarith [goldenRatio_add_goldenConj]
+
+@[deprecated (since := "2025-08-23")] alias _root_.one_sub_goldConj := one_sub_goldenConj
 
 theorem one_sub_goldenRatio : 1 - ψ = φ := by
   linarith [goldenRatio_add_goldenConj]
 
+@[deprecated (since := "2025-08-23")] alias _root_.one_sub_gold := one_sub_goldenRatio
+
 @[simp]
 theorem goldenRatio_sub_goldenConj : φ - ψ = √5 := by ring
 
+@[deprecated (since := "2025-08-23")] alias _root_.gold_sub_goldConj := goldenRatio_sub_goldenConj
+
 theorem goldenRatio_pow_sub_goldenRatio_pow (n : ℕ) : φ ^ (n + 2) - φ ^ (n + 1) = φ ^ n := by
   grind
+
+@[deprecated (since := "2025-08-23")]
+alias gold_pow_sub_gold_pow := goldenRatio_pow_sub_goldenRatio_pow
 
 @[simp 1200]
 theorem goldenRatio_sq : φ ^ 2 = φ + 1 := by
   grind
 
+@[deprecated (since := "2025-08-23")] alias _root_.gold_sq := goldenRatio_sq
+
 @[simp 1200]
 theorem goldenConj_sq : ψ ^ 2 = ψ + 1 := by
   grind
 
+@[deprecated (since := "2025-08-23")] alias _root_.goldConj_sq := goldenConj_sq
+
 theorem goldenRatio_pos : 0 < φ :=
   mul_pos (by apply add_pos <;> norm_num) <| inv_pos.2 zero_lt_two
 
+@[deprecated (since := "2025-08-23")] alias _root_.gold_pos := goldenRatio_pos
+
 theorem goldenRatio_ne_zero : φ ≠ 0 :=
   ne_of_gt goldenRatio_pos
+
+@[deprecated (since := "2025-08-23")] alias _root_.gold_ne_zero := goldenRatio_ne_zero
 
 theorem one_lt_goldenRatio : 1 < φ := by
   refine lt_of_mul_lt_mul_left ?_ (le_of_lt goldenRatio_pos)
   simp [← sq, zero_lt_one]
 
+@[deprecated (since := "2025-08-23")] alias _root_.one_lt_gold := one_lt_goldenRatio
+
 theorem goldenRatio_lt_two : φ < 2 := by calc
   (1 + √5) / 2 < (1 + 3) / 2 := by gcongr; rw [sqrt_lt'] <;> norm_num
   _ = 2 := by norm_num
 
+@[deprecated (since := "2025-08-23")] alias _root_.gold_lt_two := goldenRatio_lt_two
+
 theorem goldenConj_neg : ψ < 0 := by
   linarith [one_sub_goldenConj, one_lt_goldenRatio]
+
+@[deprecated (since := "2025-08-23")] alias _root_.goldConj_neg := goldenConj_neg
 
 theorem goldenConj_ne_zero : ψ ≠ 0 :=
   ne_of_lt goldenConj_neg
 
+@[deprecated (since := "2025-08-23")] alias _root_.goldConj_ne_zero := goldenConj_ne_zero
+
 theorem neg_one_lt_goldenConj : -1 < ψ := by
   rw [neg_lt, ← inv_goldenRatio]
   exact inv_lt_one_of_one_lt₀ one_lt_goldenRatio
+
+@[deprecated (since := "2025-08-23")] alias _root_.neg_one_lt_goldConj := neg_one_lt_goldenConj
 
 /-!
 ## Irrationality
@@ -124,6 +161,8 @@ theorem goldenRatio_irrational : Irrational φ := by
   simp
   ring
 
+@[deprecated (since := "2025-08-23")] alias _root_.gold_irrational := goldenRatio_irrational
+
 /-- The conjugate of the golden ratio is irrational. -/
 theorem goldenConj_irrational : Irrational ψ := by
   have := Nat.Prime.irrational_sqrt (show Nat.Prime 5 by norm_num)
@@ -131,6 +170,8 @@ theorem goldenConj_irrational : Irrational ψ := by
   convert this.ratCast_mul (show (0.5 : ℚ) ≠ 0 by norm_num)
   simp
   ring
+
+@[deprecated (since := "2025-08-23")] alias _root_.goldConj_irrational := goldenConj_irrational
 
 /-!
 ## Links with Fibonacci sequence
@@ -170,10 +211,16 @@ theorem geom_goldenRatio_isSol_fibRec : fibRec.IsSolution (φ ^ ·) := by
   rw [fibRec.geom_sol_iff_root_charPoly, fibRec_charPoly_eq]
   simp
 
+@[deprecated (since := "2025-08-23")]
+alias _root_.geom_gold_isSol_fibRec := geom_goldenRatio_isSol_fibRec
+
 /-- The geometric sequence `fun n ↦ ψ^n` is a solution of `fibRec`. -/
 theorem geom_goldenConj_isSol_fibRec : fibRec.IsSolution (ψ ^ ·) := by
   rw [fibRec.geom_sol_iff_root_charPoly, fibRec_charPoly_eq]
   simp
+
+@[deprecated (since := "2025-08-23")]
+alias geom_goldConj_isSol_fibRec := geom_goldenConj_isSol_fibRec
 
 end Fibrec
 
@@ -219,6 +266,9 @@ theorem fib_succ_sub_goldenRatio_mul_fib (n : ℕ) : Nat.fib (n + 1) - φ * Nat.
   have nz : √5 ≠ 0 := by norm_num
   rw [← (mul_inv_cancel₀ nz).symm, one_mul]
 
+@[deprecated (since := "2025-08-23")]
+alias _root_.fib_golden_conj_exp := fib_succ_sub_goldenRatio_mul_fib
+
 /-- Relationship between the Fibonacci Sequence, the conjugate of the golden ratio,
 and its exponents. -/
 lemma goldenConj_mul_fib_succ_add_fib (n : ℕ) : ψ * Nat.fib (n + 1) + Nat.fib n = ψ ^ (n + 1) := by
@@ -235,6 +285,9 @@ lemma goldenRatio_mul_fib_succ_add_fib (n : ℕ) : φ * Nat.fib (n + 1) + Nat.fi
           Nat.cast_add, goldenRatio_sq]; ring
       _ = φ * ((Nat.fib n) + φ * (Nat.fib (n + 1))) := by ring
       _ = φ ^ (n + 2) := by rw [add_comm, ih]; ring
+
+@[deprecated (since := "2025-08-23")]
+alias _root_.fib_golden_exp' := goldenRatio_mul_fib_succ_add_fib
 
 /-- Relationship between the Fibonacci Sequence, exponents of the golden ratio,
 and its conjugate. -/

--- a/Mathlib/NumberTheory/Real/GoldenRatio.lean
+++ b/Mathlib/NumberTheory/Real/GoldenRatio.lean
@@ -8,7 +8,7 @@ module
 public import Mathlib.Algebra.EuclideanDomain.Basic
 public import Mathlib.Algebra.LinearRecurrence
 public import Mathlib.Data.Fin.VecNotation
-public import Mathlib.Data.Nat.Fib.Basic
+public import Mathlib.Data.Int.Fib.Basic
 public import Mathlib.NumberTheory.Real.Irrational
 public import Mathlib.Tactic.NormNum.NatFib
 public import Mathlib.Tactic.NormNum.Prime
@@ -48,105 +48,68 @@ open goldenRatio
 theorem inv_goldenRatio : φ⁻¹ = -ψ := by
   grind
 
-@[deprecated (since := "2025-08-23")] alias _root_.inv_gold := inv_goldenRatio
-
 /-- The opposite of the golden ratio is the inverse of its conjugate. -/
 theorem inv_goldenConj : ψ⁻¹ = -φ := by
   rw [inv_eq_iff_eq_inv, ← neg_inv, ← neg_eq_iff_eq_neg]
   exact inv_goldenRatio.symm
 
-@[deprecated (since := "2025-08-23")] alias _root_.inv_goldConj := inv_goldenConj
-
 @[simp]
 theorem goldenRatio_mul_goldenConj : φ * ψ = -1 := by
   grind
-
-@[deprecated (since := "2025-08-23")] alias _root_.gold_mul_goldConj := goldenRatio_mul_goldenConj
 
 @[simp]
 theorem goldenConj_mul_goldenRatio : ψ * φ = -1 := by
   rw [mul_comm]
   exact goldenRatio_mul_goldenConj
 
-@[deprecated (since := "2025-08-23")] alias _root_.goldConj_mul_gold := goldenConj_mul_goldenRatio
-
 @[simp]
 theorem goldenRatio_add_goldenConj : φ + ψ = 1 := by
   rw [goldenRatio, goldenConj]
   ring
 
-@[deprecated (since := "2025-08-23")] alias _root_.gold_add_goldConj := goldenRatio_add_goldenConj
-
 theorem one_sub_goldenConj : 1 - φ = ψ := by
   linarith [goldenRatio_add_goldenConj]
-
-@[deprecated (since := "2025-08-23")] alias _root_.one_sub_goldConj := one_sub_goldenConj
 
 theorem one_sub_goldenRatio : 1 - ψ = φ := by
   linarith [goldenRatio_add_goldenConj]
 
-@[deprecated (since := "2025-08-23")] alias _root_.one_sub_gold := one_sub_goldenRatio
-
 @[simp]
 theorem goldenRatio_sub_goldenConj : φ - ψ = √5 := by ring
 
-@[deprecated (since := "2025-08-23")] alias _root_.gold_sub_goldConj := goldenRatio_sub_goldenConj
-
 theorem goldenRatio_pow_sub_goldenRatio_pow (n : ℕ) : φ ^ (n + 2) - φ ^ (n + 1) = φ ^ n := by
   grind
-
-@[deprecated (since := "2025-08-23")]
-alias gold_pow_sub_gold_pow := goldenRatio_pow_sub_goldenRatio_pow
 
 @[simp 1200]
 theorem goldenRatio_sq : φ ^ 2 = φ + 1 := by
   grind
 
-@[deprecated (since := "2025-08-23")] alias _root_.gold_sq := goldenRatio_sq
-
 @[simp 1200]
 theorem goldenConj_sq : ψ ^ 2 = ψ + 1 := by
   grind
 
-@[deprecated (since := "2025-08-23")] alias _root_.goldConj_sq := goldenConj_sq
-
 theorem goldenRatio_pos : 0 < φ :=
   mul_pos (by apply add_pos <;> norm_num) <| inv_pos.2 zero_lt_two
 
-@[deprecated (since := "2025-08-23")] alias _root_.gold_pos := goldenRatio_pos
-
 theorem goldenRatio_ne_zero : φ ≠ 0 :=
   ne_of_gt goldenRatio_pos
-
-@[deprecated (since := "2025-08-23")] alias _root_.gold_ne_zero := goldenRatio_ne_zero
 
 theorem one_lt_goldenRatio : 1 < φ := by
   refine lt_of_mul_lt_mul_left ?_ (le_of_lt goldenRatio_pos)
   simp [← sq, zero_lt_one]
 
-@[deprecated (since := "2025-08-23")] alias _root_.one_lt_gold := one_lt_goldenRatio
-
 theorem goldenRatio_lt_two : φ < 2 := by calc
   (1 + √5) / 2 < (1 + 3) / 2 := by gcongr; rw [sqrt_lt'] <;> norm_num
   _ = 2 := by norm_num
 
-@[deprecated (since := "2025-08-23")] alias _root_.gold_lt_two := goldenRatio_lt_two
-
 theorem goldenConj_neg : ψ < 0 := by
   linarith [one_sub_goldenConj, one_lt_goldenRatio]
-
-@[deprecated (since := "2025-08-23")] alias _root_.goldConj_neg := goldenConj_neg
 
 theorem goldenConj_ne_zero : ψ ≠ 0 :=
   ne_of_lt goldenConj_neg
 
-@[deprecated (since := "2025-08-23")] alias _root_.goldConj_ne_zero := goldenConj_ne_zero
-
 theorem neg_one_lt_goldenConj : -1 < ψ := by
   rw [neg_lt, ← inv_goldenRatio]
   exact inv_lt_one_of_one_lt₀ one_lt_goldenRatio
-
-@[deprecated (since := "2025-08-23")] alias _root_.neg_one_lt_goldConj := neg_one_lt_goldenConj
 
 /-!
 ## Irrationality
@@ -161,8 +124,6 @@ theorem goldenRatio_irrational : Irrational φ := by
   simp
   ring
 
-@[deprecated (since := "2025-08-23")] alias _root_.gold_irrational := goldenRatio_irrational
-
 /-- The conjugate of the golden ratio is irrational. -/
 theorem goldenConj_irrational : Irrational ψ := by
   have := Nat.Prime.irrational_sqrt (show Nat.Prime 5 by norm_num)
@@ -170,8 +131,6 @@ theorem goldenConj_irrational : Irrational ψ := by
   convert this.ratCast_mul (show (0.5 : ℚ) ≠ 0 by norm_num)
   simp
   ring
-
-@[deprecated (since := "2025-08-23")] alias _root_.goldConj_irrational := goldenConj_irrational
 
 /-!
 ## Links with Fibonacci sequence
@@ -211,16 +170,10 @@ theorem geom_goldenRatio_isSol_fibRec : fibRec.IsSolution (φ ^ ·) := by
   rw [fibRec.geom_sol_iff_root_charPoly, fibRec_charPoly_eq]
   simp
 
-@[deprecated (since := "2025-08-23")]
-alias _root_.geom_gold_isSol_fibRec := geom_goldenRatio_isSol_fibRec
-
 /-- The geometric sequence `fun n ↦ ψ^n` is a solution of `fibRec`. -/
 theorem geom_goldenConj_isSol_fibRec : fibRec.IsSolution (ψ ^ ·) := by
   rw [fibRec.geom_sol_iff_root_charPoly, fibRec_charPoly_eq]
   simp
-
-@[deprecated (since := "2025-08-23")]
-alias geom_goldConj_isSol_fibRec := geom_goldenConj_isSol_fibRec
 
 end Fibrec
 
@@ -249,6 +202,15 @@ theorem coe_fib_eq' :
 theorem coe_fib_eq : ∀ n, (Nat.fib n : ℝ) = (φ ^ n - ψ ^ n) / √5 := by
   rw [← funext_iff, Real.coe_fib_eq']
 
+/-- **Binet's formula** for integer values. -/
+theorem coe_intFib_eq (n : ℤ) : (Int.fib n : ℝ) = (φ ^ n - ψ ^ n) / √5 := by
+  obtain ⟨n, (rfl | rfl)⟩ := n.eq_nat_or_neg
+  · exact coe_fib_eq n
+  · simp only [Int.fib_neg, Int.even_coe_nat, Int.fib_natCast, Int.cast_ite, Int.cast_neg,
+      Int.cast_natCast, zpow_neg, zpow_natCast, ← inv_pow, inv_goldenRatio, inv_goldenConj,
+      ← neg_one_mul ψ, ← neg_one_mul φ, mul_pow, neg_one_pow_eq_ite]
+    grind [coe_fib_eq]
+
 /-- Relationship between the Fibonacci Sequence, the golden ratio, and its conjugate's exponents. -/
 theorem fib_succ_sub_goldenRatio_mul_fib (n : ℕ) : Nat.fib (n + 1) - φ * Nat.fib n = ψ ^ n := by
   repeat rw [coe_fib_eq]
@@ -256,9 +218,6 @@ theorem fib_succ_sub_goldenRatio_mul_fib (n : ℕ) : Nat.fib (n + 1) - φ * Nat.
   ring_nf
   have nz : √5 ≠ 0 := by norm_num
   rw [← (mul_inv_cancel₀ nz).symm, one_mul]
-
-@[deprecated (since := "2025-08-23")]
-alias _root_.fib_golden_conj_exp := fib_succ_sub_goldenRatio_mul_fib
 
 /-- Relationship between the Fibonacci Sequence, the conjugate of the golden ratio,
 and its exponents. -/
@@ -276,9 +235,6 @@ lemma goldenRatio_mul_fib_succ_add_fib (n : ℕ) : φ * Nat.fib (n + 1) + Nat.fi
           Nat.cast_add, goldenRatio_sq]; ring
       _ = φ * ((Nat.fib n) + φ * (Nat.fib (n + 1))) := by ring
       _ = φ ^ (n + 2) := by rw [add_comm, ih]; ring
-
-@[deprecated (since := "2025-08-23")]
-alias _root_.fib_golden_exp' := goldenRatio_mul_fib_succ_add_fib
 
 /-- Relationship between the Fibonacci Sequence, exponents of the golden ratio,
 and its conjugate. -/


### PR DESCRIPTION
---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

When merging, all the commits will be squashed into a single commit
listing all co-authors.

Co-authors in the squash commit are gathered from two sources:

First, all authors of commits to this PR branch are included. Thus,
one way to add co-authors is to include at least one commit authored by
each co-author among the commits in the pull request. If necessary, you
may create empty commits to indicate co-authorship, using commands like so:

git commit --author="Author Name <author@email.com>" --allow-empty -m "add Author Name as coauthor"

Second, co-authors can also be listed in lines at the very bottom of
the commit message (that is, directly before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines
at the bottom of the commit message (before the `---`, and also before
any "Co-authored-by" lines) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
