### PR TITLE
[Merged by Bors] - chore: remove some redundant `@[measurability]` attributes

### DIFF
--- a/Mathlib/Analysis/SpecialFunctions/Trigonometric/Arctan.lean
+++ b/Mathlib/Analysis/SpecialFunctions/Trigonometric/Arctan.lean
@@ -353,7 +353,7 @@ theorem sin_arctan_nonneg : 0 ≤ sin (arctan x) ↔ 0 ≤ x := by
 theorem sin_arctan_le_zero : sin (arctan x) ≤ 0 ↔ x ≤ 0 := by
   simpa using sin_arctan_strictMono.le_iff_le (b := 0)
 
-@[continuity]
+@[continuity, fun_prop]
 theorem continuous_arctan : Continuous arctan :=
   continuous_subtype_val.comp tanOrderIso.toHomeomorph.continuous_invFun
 

--- a/Mathlib/MeasureTheory/Constructions/BorelSpace/ContinuousLinearMap.lean
+++ b/Mathlib/MeasureTheory/Constructions/BorelSpace/ContinuousLinearMap.lean
@@ -59,7 +59,6 @@ theorem measurable_apply' [MeasurableSpace E] [OpensMeasurableSpace E] [Measurab
     [BorelSpace F] : Measurable fun (x : E) (f : E →L[𝕜] F) => f x :=
   measurable_pi_lambda _ fun f => f.measurable
 
-@[measurability]
 theorem measurable_coe [MeasurableSpace F] [BorelSpace F] :
     Measurable fun (f : E →L[𝕜] F) (x : E) => f x :=
   measurable_pi_lambda _ measurable_apply

--- a/Mathlib/MeasureTheory/Constructions/BorelSpace/Metric.lean
+++ b/Mathlib/MeasureTheory/Constructions/BorelSpace/Metric.lean
@@ -50,7 +50,6 @@ theorem measurableSet_ball : MeasurableSet (Metric.ball x ε) :=
 theorem measurableSet_closedBall : MeasurableSet (Metric.closedBall x ε) :=
   Metric.isClosed_closedBall.measurableSet
 
-@[measurability]
 theorem measurable_infDist {s : Set α} : Measurable fun x => infDist x s :=
   (continuous_infDist_pt s).measurable
 
@@ -59,7 +58,6 @@ theorem Measurable.infDist {f : β → α} (hf : Measurable f) {s : Set α} :
     Measurable fun x => infDist (f x) s :=
   measurable_infDist.comp hf
 
-@[measurability]
 theorem measurable_infNndist {s : Set α} : Measurable fun x => infNndist x s :=
   (continuous_infNndist_pt s).measurable
 
@@ -72,7 +70,6 @@ section
 
 variable [SecondCountableTopology α]
 
-@[measurability]
 theorem measurable_dist : Measurable fun p : α × α => dist p.1 p.2 :=
   continuous_dist.measurable
 
@@ -87,7 +84,6 @@ lemma AEMeasurable.dist {f g : β → α} {μ : Measure β}
     AEMeasurable (fun b ↦ dist (f b) (g b)) μ :=
   continuous_dist.aemeasurable2 hf hg
 
-@[measurability]
 theorem measurable_nndist : Measurable fun p : α × α => nndist p.1 p.2 :=
   continuous_nndist.measurable
 
@@ -119,7 +115,6 @@ theorem measurable_edist_right : Measurable (edist x) :=
 theorem measurable_edist_left : Measurable fun y => edist y x :=
   (continuous_id.edist continuous_const).measurable
 
-@[measurability]
 theorem measurable_infEdist {s : Set α} : Measurable fun x => infEdist x s :=
   continuous_infEdist.measurable
 
@@ -174,7 +169,6 @@ theorem tendsto_measure_thickening_of_isClosed {μ : Measure α} {s : Set α}
 
 variable [SecondCountableTopology α]
 
-@[measurability]
 theorem measurable_edist : Measurable fun p : α × α => edist p.1 p.2 :=
   continuous_edist.measurable
 
@@ -257,7 +251,6 @@ theorem AEMeasurable.norm {f : β → α} {μ : Measure β} (hf : AEMeasurable f
     AEMeasurable (fun a => norm (f a)) μ :=
   measurable_norm.comp_aemeasurable hf
 
-@[measurability]
 theorem measurable_nnnorm : Measurable (nnnorm : α → ℝ≥0) :=
   continuous_nnnorm.measurable
 

--- a/Mathlib/MeasureTheory/Constructions/BorelSpace/Real.lean
+++ b/Mathlib/MeasureTheory/Constructions/BorelSpace/Real.lean
@@ -153,7 +153,6 @@ theorem AEMeasurable.real_toNNReal {f : α → ℝ} {μ : Measure α} (hf : AEMe
     AEMeasurable (fun x => Real.toNNReal (f x)) μ :=
   measurable_real_toNNReal.comp_aemeasurable hf
 
-@[measurability]
 theorem measurable_coe_nnreal_real : Measurable ((↑) : ℝ≥0 → ℝ) :=
   NNReal.continuous_coe.measurable
 
@@ -167,7 +166,6 @@ theorem AEMeasurable.coe_nnreal_real {f : α → ℝ≥0} {μ : Measure α} (hf 
     AEMeasurable (fun x => (f x : ℝ)) μ :=
   measurable_coe_nnreal_real.comp_aemeasurable hf
 
-@[measurability]
 theorem measurable_coe_nnreal_ennreal : Measurable ((↑) : ℝ≥0 → ℝ≥0∞) :=
   ENNReal.continuous_coe.measurable
 
@@ -236,15 +234,12 @@ theorem measurable_of_measurable_nnreal_nnreal {_ : MeasurableSpace β} {f : ℝ
     (measurable_swap_iff.1 <| measurable_of_measurable_nnreal_prod (h₁.comp measurable_swap) h₃)
     (measurable_of_measurable_nnreal h₂)
 
-@[measurability]
 theorem measurable_ofReal : Measurable ENNReal.ofReal :=
   ENNReal.continuous_ofReal.measurable
 
-@[measurability]
 theorem measurable_toReal : Measurable ENNReal.toReal :=
   ENNReal.measurable_of_measurable_nnreal measurable_coe_nnreal_real
 
-@[measurability]
 theorem measurable_toNNReal : Measurable ENNReal.toNNReal :=
   ENNReal.measurable_of_measurable_nnreal measurable_id
 
@@ -387,7 +382,6 @@ theorem AEMeasurable.nnreal_tsum {α : Type*} {_ : MeasurableSpace α} {ι : Typ
 theorem measurable_coe_real_ereal : Measurable ((↑) : ℝ → EReal) :=
   continuous_coe_real_ereal.measurable
 
-@[measurability]
 theorem Measurable.coe_real_ereal {f : α → ℝ} (hf : Measurable f) :
     Measurable fun x => (f x : EReal) :=
   measurable_coe_real_ereal.comp hf
@@ -406,7 +400,6 @@ theorem EReal.measurable_of_measurable_real {f : EReal → α} (h : Measurable f
   measurable_of_measurable_on_compl_finite {⊥, ⊤} (by simp)
     (MeasurableEquiv.erealEquivReal.symm.measurable_comp_iff.1 h)
 
-@[measurability]
 theorem measurable_ereal_toReal : Measurable EReal.toReal :=
   EReal.measurable_of_measurable_real (by simpa using measurable_id)
 
@@ -420,7 +413,6 @@ theorem AEMeasurable.ereal_toReal {f : α → EReal} {μ : Measure α} (hf : AEM
     AEMeasurable (fun x => (f x).toReal) μ :=
   measurable_ereal_toReal.comp_aemeasurable hf
 
-@[measurability]
 theorem measurable_coe_ennreal_ereal : Measurable ((↑) : ℝ≥0∞ → EReal) :=
   continuous_coe_ennreal_ereal.measurable
 
@@ -434,7 +426,6 @@ theorem AEMeasurable.coe_ereal_ennreal {f : α → ℝ≥0∞} {μ : Measure α}
     AEMeasurable (fun x => (f x : EReal)) μ :=
   measurable_coe_ennreal_ereal.comp_aemeasurable hf
 
-@[measurability]
 theorem measurable_ereal_toENNReal : Measurable EReal.toENNReal :=
   EReal.measurable_of_measurable_real (by simpa using ENNReal.measurable_ofReal)
 

--- a/Mathlib/MeasureTheory/Function/SpecialFunctions/Arctan.lean
+++ b/Mathlib/MeasureTheory/Function/SpecialFunctions/Arctan.lean
@@ -18,7 +18,6 @@ public import Mathlib.MeasureTheory.Constructions.BorelSpace.Basic
 
 namespace Real
 
-@[measurability]
 theorem measurable_arctan : Measurable arctan :=
   continuous_arctan.measurable
 

--- a/Mathlib/MeasureTheory/Function/SpecialFunctions/Basic.lean
+++ b/Mathlib/MeasureTheory/Function/SpecialFunctions/Basic.lean
@@ -33,11 +33,9 @@ namespace Real
 
 variable {α : Type*} {_ : MeasurableSpace α} {f : α → ℝ} {μ : MeasureTheory.Measure α}
 
-@[measurability]
 theorem measurable_exp : Measurable exp :=
   continuous_exp.measurable
 
-@[measurability]
 theorem measurable_log : Measurable log :=
   measurable_of_measurable_on_compl_singleton 0 <|
     Continuous.measurable <| continuousOn_iff_continuous_restrict.1 continuousOn_log
@@ -60,19 +58,15 @@ lemma aemeasurable_of_aemeasurable_exp_mul {t : ℝ}
   simpa only [mul_div_cancel_left₀ _ ht]
     using (aemeasurable_of_aemeasurable_exp hf).div (aemeasurable_const (b := t))
 
-@[measurability]
 theorem measurable_sin : Measurable sin :=
   continuous_sin.measurable
 
-@[measurability]
 theorem measurable_cos : Measurable cos :=
   continuous_cos.measurable
 
-@[measurability]
 theorem measurable_sinh : Measurable sinh :=
   continuous_sinh.measurable
 
-@[measurability]
 theorem measurable_cosh : Measurable cosh :=
   continuous_cosh.measurable
 
@@ -96,31 +90,24 @@ theorem measurable_re : Measurable re :=
 theorem measurable_im : Measurable im :=
   continuous_im.measurable
 
-@[measurability]
 theorem measurable_ofReal : Measurable ((↑) : ℝ → ℂ) :=
   continuous_ofReal.measurable
 
-@[measurability]
 theorem measurable_exp : Measurable exp :=
   continuous_exp.measurable
 
-@[measurability]
 theorem measurable_sin : Measurable sin :=
   continuous_sin.measurable
 
-@[measurability]
 theorem measurable_cos : Measurable cos :=
   continuous_cos.measurable
 
-@[measurability]
 theorem measurable_sinh : Measurable sinh :=
   continuous_sinh.measurable
 
-@[measurability]
 theorem measurable_cosh : Measurable cosh :=
   continuous_cosh.measurable
 
-@[measurability]
 theorem measurable_arg : Measurable arg :=
   have A : Measurable fun x : ℂ => Real.arcsin (x.im / ‖x‖) :=
     Real.measurable_arcsin.comp (measurable_im.div measurable_norm)
@@ -130,7 +117,6 @@ theorem measurable_arg : Measurable arg :=
     Measurable.ite (isClosed_le continuous_const continuous_im).measurableSet (B.add_const _)
       (B.sub_const _)
 
-@[measurability]
 theorem measurable_log : Measurable log :=
   (measurable_ofReal.comp <| Real.measurable_log.comp measurable_norm).add <|
     (measurable_ofReal.comp measurable_arg).mul_const I

--- a/Mathlib/MeasureTheory/Function/SpecialFunctions/RCLike.lean
+++ b/Mathlib/MeasureTheory/Function/SpecialFunctions/RCLike.lean
@@ -24,11 +24,9 @@ namespace RCLike
 
 variable {𝕜 : Type*} [RCLike 𝕜]
 
-@[measurability]
 theorem measurable_re : Measurable (re : 𝕜 → ℝ) :=
   continuous_re.measurable
 
-@[measurability]
 theorem measurable_im : Measurable (im : 𝕜 → ℝ) :=
   continuous_im.measurable
 

--- a/Mathlib/MeasureTheory/MeasurableSpace/Constructions.lean
+++ b/Mathlib/MeasureTheory/MeasurableSpace/Constructions.lean
@@ -190,7 +190,6 @@ section
 
 variable [MeasurableSpace α]
 
-@[measurability]
 theorem measurable_subtype_coe {p : α → Prop} : Measurable ((↑) : Subtype p → α) :=
   MeasurableSpace.le_map_comap
 
@@ -368,12 +367,10 @@ instance Prod.instMeasurableSpace {α β} [m₁ : MeasurableSpace α] [m₂ : Me
     MeasurableSpace (α × β) :=
   m₁.prod m₂
 
-@[measurability]
 theorem measurable_fst {_ : MeasurableSpace α} {_ : MeasurableSpace β} :
     Measurable (Prod.fst : α × β → α) :=
   Measurable.of_comap_le le_sup_left
 
-@[measurability]
 theorem measurable_snd {_ : MeasurableSpace α} {_ : MeasurableSpace β} :
     Measurable (Prod.snd : α × β → β) :=
   Measurable.of_comap_le le_sup_right

--- a/Mathlib/MeasureTheory/MeasurableSpace/Defs.lean
+++ b/Mathlib/MeasureTheory/MeasurableSpace/Defs.lean
@@ -506,7 +506,6 @@ end MeasureTheory
 
 section MeasurableFunctions
 
-@[measurability]
 theorem measurable_id {_ : MeasurableSpace α} : Measurable (@id α) := fun _ => id
 
 @[fun_prop, measurability]


### PR DESCRIPTION
This PR removes the `@[measurability]` attribute from some lemmas when another form of the lemma is already tagged with `@[fun_prop]`.


---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

When merging, all the commits will be squashed into a single commit
listing all co-authors.

Co-authors in the squash commit are gathered from two sources:

First, all authors of commits to this PR branch are included. Thus,
one way to add co-authors is to include at least one commit authored by
each co-author among the commits in the pull request. If necessary, you
may create empty commits to indicate co-authorship, using commands like so:

git commit --author="Author Name <author@email.com>" --allow-empty -m "add Author Name as coauthor"

Second, co-authors can also be listed in lines at the very bottom of
the commit message (that is, directly before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines
at the bottom of the commit message (before the `---`, and also before
any "Co-authored-by" lines) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
