### PR TITLE
[Merged by Bors] - chore(Tactic): use the convenient `addConstInfo` more

### DIFF
--- a/Mathlib/Tactic/HigherOrder.lean
+++ b/Mathlib/Tactic/HigherOrder.lean
@@ -95,7 +95,7 @@ def higherOrderGetParam (thm : Name) (stx : Syntax) : AttrM Name := do
           type := hot
           value := prf }
       addDeclarationRangesFromSyntax hothmName (← getRef) ref
-      _ ← addTermInfo (isBinder := true) ref <| ← mkConstWithLevelParams hothmName
+      addConstInfo ref hothmName
       let hsm := simpExtension.getState (← getEnv) |>.lemmaNames.contains (.decl thm)
       if hsm then
         addSimpTheorem simpExtension hothmName true false .global 1000

--- a/Mathlib/Tactic/Recall.lean
+++ b/Mathlib/Tactic/Recall.lean
@@ -45,8 +45,7 @@ elab_rules : command
   | `(recall $id $sig:optDeclSig $[$val?]?) => withoutModifyingEnv do
     let declName := id.getId
     addConstInfo id declName
-    let some info := (← getEnv).find? declName
-      | throwError "unknown constant '{declName}'"
+    let info ← getConstInfo declName
     let declConst : Expr := mkConst declName <| info.levelParams.map Level.param
     let newId := ({ namePrefix := declName : DeclNameGenerator }.mkUniqueName (← getEnv) `recall).1
     let newId := mkIdentFrom id newId

--- a/Mathlib/Tactic/Recall.lean
+++ b/Mathlib/Tactic/Recall.lean
@@ -44,10 +44,10 @@ open Lean Meta Elab Command Term
 elab_rules : command
   | `(recall $id $sig:optDeclSig $[$val?]?) => withoutModifyingEnv do
     let declName := id.getId
+    addConstInfo id declName
     let some info := (← getEnv).find? declName
       | throwError "unknown constant '{declName}'"
     let declConst : Expr := mkConst declName <| info.levelParams.map Level.param
-    discard <| liftTermElabM <| addTermInfo id declConst
     let newId := ({ namePrefix := declName : DeclNameGenerator }.mkUniqueName (← getEnv) `recall).1
     let newId := mkIdentFrom id newId
     if let some val := val? then

--- a/Mathlib/Tactic/Sat/FromLRAT.lean
+++ b/Mathlib/Tactic/Sat/FromLRAT.lean
@@ -626,8 +626,7 @@ elab "lrat_proof " n:(ident <|> "example")
     let lrat ← unsafe evalTerm String (mkConst ``String) lrat
     let go := do
       fromLRAT cnf lrat name
-      withSaveInfoContext do
-        Term.addTermInfo' n (mkConst name) (isBinder := true)
+      addConstInfo n name
     if n.1.isIdent then go else withoutModifyingEnv go
 
 lrat_proof example

--- a/Mathlib/Tactic/Simps/Basic.lean
+++ b/Mathlib/Tactic/Simps/Basic.lean
@@ -1002,10 +1002,10 @@ def addProjection (declName : Name) (type lhs rhs : Expr) (args : Array Expr)
   inferDefEqAttr declName
   -- add term info and apply attributes
   addDeclarationRangesFromSyntax declName (← getRef) ref
+  addConstInfo ref declName
+  if cfg.isSimp then
+    addSimpTheorem simpExtension declName true false .global <| eval_prio default
   TermElabM.run' do
-    _ ← addTermInfo (isBinder := true) ref <| ← mkConstWithLevelParams declName
-    if cfg.isSimp then
-      addSimpTheorem simpExtension declName true false .global <| eval_prio default
     let attrs ← elabAttrs cfg.attrs
     Elab.Term.applyAttributes declName attrs
 

--- a/Mathlib/Tactic/Translate/Core.lean
+++ b/Mathlib/Tactic/Translate/Core.lean
@@ -1217,9 +1217,7 @@ partial def addTranslationAttr (t : TranslateData) (src : Name) (cfg : Config)
       transformDecl t cfg src tgt argInfo
   -- add pop-up information when mousing over the given translated name
   -- (the information will be over the attribute if no translated name is given)
-  pushInfoLeaf <| .ofTermInfo {
-    elaborator := .anonymous, lctx := {}, expectedType? := none, isBinder := !alreadyExists,
-    stx := cfg.ref, expr := ← mkConstWithLevelParams tgt }
+  addConstInfo cfg.ref tgt
   if let some doc := cfg.doc then
     addDocStringCore tgt doc
   return nestedNames.push tgt

--- a/MathlibTest/Recall.lean
+++ b/MathlibTest/Recall.lean
@@ -85,7 +85,7 @@ recall Nat.add_comm {n m : Nat} : n + m = m + n
 recall add_assoc {G : Type _} [AddSemigroup G] (a b c : G) : a + b + c = a + (b + c)
 recall add_assoc
 
-/-- error: unknown constant 'nonexistent' -/
+/-- error: Unknown constant `nonexistent` -/
 #guard_msgs in recall nonexistent
 
 axiom bar : Nat


### PR DESCRIPTION
I discovered that `addConstInfo` is the API for adding hover information of a constant. Different tactics use different less convenient APIs for doing exactly the same thing. This PR replaces all of those with `addConstInfo`.

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

When merging, all the commits will be squashed into a single commit
listing all co-authors.

Co-authors in the squash commit are gathered from two sources:

First, all authors of commits to this PR branch are included. Thus,
one way to add co-authors is to include at least one commit authored by
each co-author among the commits in the pull request. If necessary, you
may create empty commits to indicate co-authorship, using commands like so:

git commit --author="Author Name <author@email.com>" --allow-empty -m "add Author Name as coauthor"

Second, co-authors can also be listed in lines at the very bottom of
the commit message (that is, directly before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines
at the bottom of the commit message (before the `---`, and also before
any "Co-authored-by" lines) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
