### PR TITLE
[Merged by Bors] - feat: `Finsupp.sum` in opposite monoid

### DIFF
--- a/Mathlib/Algebra/BigOperators/Finsupp/Basic.lean
+++ b/Mathlib/Algebra/BigOperators/Finsupp/Basic.lean
@@ -628,3 +628,25 @@ theorem prod_pow_pos_of_zero_notMem_support {f : ℕ →₀ ℕ} (nhf : 0 ∉ f.
 alias prod_pow_pos_of_zero_not_mem_support := prod_pow_pos_of_zero_notMem_support
 
 end Nat
+
+namespace MulOpposite
+variable {ι M N : Type*} [AddCommMonoid M] [Zero N]
+
+@[simp] lemma op_finsuppSum (f : ι →₀ N) (g : ι → N → M) :
+    op (f.sum g) = f.sum fun i n ↦ op (g i n) := op_sum ..
+
+@[simp] lemma unop_finsuppSum (f : ι →₀ N) (g : ι → N → Mᵐᵒᵖ) :
+    unop (f.sum g) = f.sum fun i n ↦ unop (g i n) := unop_sum ..
+
+end MulOpposite
+
+namespace AddOpposite
+variable {ι M N : Type*} [CommMonoid M] [Zero N]
+
+@[simp] lemma op_finsuppProd (f : ι →₀ N) (g : ι → N → M) :
+    op (f.prod g) = f.prod fun i n ↦ op (g i n) := op_prod ..
+
+@[simp] lemma unop_finsuppProd (f : ι →₀ N) (g : ι → N → Mᵐᵒᵖ) :
+    unop (f.prod g) = f.prod fun i n ↦ unop (g i n) := unop_prod ..
+
+end AddOpposite

--- a/Mathlib/Algebra/BigOperators/Group/Finset/Defs.lean
+++ b/Mathlib/Algebra/BigOperators/Group/Finset/Defs.lean
@@ -642,7 +642,6 @@ open AddOpposite
 
 @[simp] lemma op_prod (f : ι → M) : op (∏ i ∈ s, f i) = ∏ i ∈ s, op (f i) := map_prod opMulEquiv ..
 
-open AddOpposite in
 @[simp] lemma unop_prod (f : ι → Mᵐᵒᵖ) : unop (∏ i ∈ s, f i) = ∏ i ∈ s, unop (f i) :=
   map_prod opMulEquiv.symm ..
 

--- a/Mathlib/Algebra/BigOperators/Group/Finset/Defs.lean
+++ b/Mathlib/Algebra/BigOperators/Group/Finset/Defs.lean
@@ -622,22 +622,31 @@ theorem prod_dvd_prod_of_subset {ι M : Type*} [CommMonoid M] (s t : Finset ι) 
 
 end CommMonoid
 
-section Opposite
+section MulOpposite
+variable [AddCommMonoid M] (s : Finset ι)
 
 open MulOpposite
 
 /-- Moving to the opposite additive commutative monoid commutes with summing. -/
-@[simp]
-theorem op_sum [AddCommMonoid M] {s : Finset ι} (f : ι → M) :
-    op (∑ x ∈ s, f x) = ∑ x ∈ s, op (f x) :=
-  map_sum (opAddEquiv : M ≃+ Mᵐᵒᵖ) _ _
+@[simp] lemma op_sum (f : ι → M) : op (∑ x ∈ s, f x) = ∑ x ∈ s, op (f x) := map_sum opAddEquiv ..
 
-@[simp]
-theorem unop_sum [AddCommMonoid M] {s : Finset ι} (f : ι → Mᵐᵒᵖ) :
-    unop (∑ x ∈ s, f x) = ∑ x ∈ s, unop (f x) :=
-  map_sum (opAddEquiv : M ≃+ Mᵐᵒᵖ).symm _ _
+@[simp] lemma unop_sum (f : ι → Mᵐᵒᵖ) : unop (∑ x ∈ s, f x) = ∑ x ∈ s, unop (f x) :=
+  map_sum opAddEquiv.symm ..
 
-end Opposite
+end MulOpposite
+
+section AddOpposite
+variable [CommMonoid M] (s : Finset ι)
+
+open AddOpposite
+
+@[simp] lemma op_prod (f : ι → M) : op (∏ i ∈ s, f i) = ∏ i ∈ s, op (f i) := map_prod opMulEquiv ..
+
+open AddOpposite in
+@[simp] lemma unop_prod (f : ι → Mᵐᵒᵖ) : unop (∏ i ∈ s, f i) = ∏ i ∈ s, unop (f i) :=
+  map_prod opMulEquiv.symm ..
+
+end AddOpposite
 
 section DivisionCommMonoid
 


### PR DESCRIPTION
---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

When merging, all the commits will be squashed into a single commit
listing all co-authors.

Co-authors in the squash commit are gathered from two sources:

First, all authors of commits to this PR branch are included. Thus,
one way to add co-authors is to include at least one commit authored by
each co-author among the commits in the pull request. If necessary, you
may create empty commits to indicate co-authorship, using commands like so:

git commit --author="Author Name <author@email.com>" --allow-empty -m "add Author Name as coauthor"

Second, co-authors can also be listed in lines at the very bottom of
the commit message (that is, directly before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines
at the bottom of the commit message (before the `---`, and also before
any "Co-authored-by" lines) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
