### PR TITLE
[Merged by Bors] - feat(Algebra/MonoidAlgebra): complete the map API

### DIFF
--- a/Mathlib/Algebra/MonoidAlgebra/Basic.lean
+++ b/Mathlib/Algebra/MonoidAlgebra/Basic.lean
@@ -263,28 +263,25 @@ variable (k A)
 @[to_additive (dont_translate := A)
 /-- If `e : G ≃+ H` is an additive equivalence between two additive monoids, then
 `AddMonoidAlgebra.domCongr e` is an algebra equivalence between their additive monoid algebras. -/]
-def domCongr (e : G ≃* H) : A[G] ≃ₐ[k] A[H] :=
-  .ofLinearEquiv
-    (Finsupp.domLCongr e)
-    (by ext; simp [one_def, MonoidAlgebra])
-    (fun f g ↦ by
-      classical ext; simp [mul_def]; simp [MonoidAlgebra, Finsupp.single_apply, e.eq_symm_apply])
+def domCongr (e : G ≃* H) : A[G] ≃ₐ[k] A[H] where
+  toRingEquiv := mapDomainRingEquiv A e
+  __ := Finsupp.domLCongr (R := k) (M := A) e.toEquiv
+  commutes' _ := by ext; simp
+
+@[to_additive (attr := simp)]
+lemma domCongr_apply (e : G ≃* H) (x : A[G]) (h : H) : domCongr k A e x h = x (e.symm h) := by
+  simp [domCongr]
 
 @[to_additive]
-theorem domCongr_toAlgHom (e : G ≃* H) : (domCongr k A e).toAlgHom = mapDomainAlgHom k A e :=
-  AlgHom.ext fun _ => equivMapDomain_eq_mapDomain _ _
+theorem domCongr_toAlgHom (e : G ≃* H) : (domCongr k A e).toAlgHom = mapDomainAlgHom k A e := rfl
 
 @[to_additive (attr := simp)]
-theorem domCongr_apply (e : G ≃* H) (f : A[G]) (h : H) : domCongr k A e f h = f (e.symm h) := rfl
-
-@[to_additive (attr := simp)]
-theorem domCongr_support (e : G ≃* H) (f : A[G]) : (domCongr k A e f).support = f.support.map e :=
-  rfl
+lemma domCongr_support (e : G ≃* H) (f : A[G]) : (domCongr k A e f).support = f.support.map e := by
+  ext; simp
 
 @[to_additive (attr := simp)]
 theorem domCongr_single (e : G ≃* H) (g : G) (a : A) :
-    domCongr k A e (single g a) = single (e g) a :=
-  Finsupp.equivMapDomain_single _ _ _
+    domCongr k A e (single g a) = single (e g) a := by simp [domCongr]
 
 @[to_additive (attr := simp)]
 lemma domCongr_comp_lsingle (e : G ≃* H) (g : G) :

--- a/Mathlib/Algebra/MonoidAlgebra/Lift.lean
+++ b/Mathlib/Algebra/MonoidAlgebra/Lift.lean
@@ -98,32 +98,6 @@ lemma liftNCRingHom_single (f : k →+* R) (g : G →* R) (h_comm) (a : G) (b : 
     liftNCRingHom f g h_comm (single a b) = f b * g a :=
   liftNC_single _ _ _ _
 
-variable (M) in
-/-- The ring homomorphism of monoid algebras induced by a homomorphism of the base rings. -/
-noncomputable def mapRangeRingHom (f : R →+* S) : R[M] →+* S[M] :=
-  liftNCRingHom (singleOneRingHom.comp f) (of S M) fun x y ↦ by simp [commute_iff_eq]
-
-@[simp]
-lemma mapRangeRingHom_apply (f : R →+* S) (x : R[M]) (m : M) :
-    mapRangeRingHom M f x m = f (x m) := by
-  classical
-  induction x using induction_linear
-  · simp
-  · simp [*]
-  · simp [mapRangeRingHom, single_apply, apply_ite (f := f)]
-
-@[simp]
-lemma mapRangeRingHom_single (f : R →+* S) (a : M) (b : R) :
-    mapRangeRingHom M f (single a b) = single a (f b) := by
-  classical ext; simp [single_apply, apply_ite f]
-
-@[simp] lemma mapRangeRingHom_id : mapRangeRingHom M (.id R) = .id R[M] := by
-  ext <;> simp
-
-@[simp] lemma mapRangeRingHom_comp (f : S →+* T) (g : R →+* S) :
-    mapRangeRingHom M (f.comp g) = (mapRangeRingHom M f).comp (mapRangeRingHom M g) := by
-  ext <;> simp
-
 end Semiring
 
 end MonoidAlgebra
@@ -195,40 +169,6 @@ def liftNCRingHom (f : k →+* R) (g : Multiplicative G →* R) (h_comm : ∀ x 
 lemma liftNCRingHom_single (f : k →+* R) (g : Multiplicative G →* R) (h_comm) (a : G) (b : k) :
     liftNCRingHom f g h_comm (single a b) = f b * g (.ofAdd a) :=
   liftNC_single _ _ _ _
-
-variable (M) in
-/-- The ring homomorphism of monoid algebras induced by a homomorphism of the base rings. -/
-noncomputable def mapRangeRingHom (f : R →+* S) : R[M] →+* S[M] :=
-  liftNCRingHom (singleZeroRingHom.comp f) (of S M) fun x y ↦ by simp [commute_iff_eq]
-
-@[simp]
-lemma mapRangeRingHom_apply (f : R →+* S) (x : R[M]) (m : M) :
-    mapRangeRingHom M f x m = f (x m) := by
-  classical
-  induction x using induction_linear
-  · simp
-  · simp [*]
-  · simp [mapRangeRingHom, single_apply, apply_ite (f := f)]
-
-@[simp]
-lemma mapRangeRingHom_single (f : R →+* S) (a : M) (b : R) :
-    mapRangeRingHom M f (single a b) = single a (f b) := by
-  classical ext; simp [single_apply, apply_ite f]
-
-@[simp] lemma mapRangeRingHom_id : mapRangeRingHom M (.id R) = .id R[M] := by
-  ext <;> simp
-
-@[simp] lemma mapRangeRingHom_comp (f : S →+* T) (g : R →+* S) :
-    mapRangeRingHom M (f.comp g) = (mapRangeRingHom M f).comp (mapRangeRingHom M g) := by
-  ext <;> simp
-
--- `MonoidAlgebra.of` doesn't translate with `to_additive`, so instead
--- we have to tag these declarations with `to_additive existing`
-set_option linter.existingAttributeWarning false in
-attribute [to_additive existing]
-  MonoidAlgebra.mapRangeRingHom MonoidAlgebra.mapRangeRingHom_apply
-  MonoidAlgebra.mapRangeRingHom_single MonoidAlgebra.mapRangeRingHom_id
-  MonoidAlgebra.mapRangeRingHom_comp
 
 end Semiring
 

--- a/Mathlib/Algebra/MonoidAlgebra/MapDomain.lean
+++ b/Mathlib/Algebra/MonoidAlgebra/MapDomain.lean
@@ -5,11 +5,12 @@ Authors: Johannes Hölzl, Yury Kudryashov, Kim Morrison
 -/
 module
 
-public import Mathlib.Algebra.MonoidAlgebra.Lift
+public import Mathlib.Algebra.MonoidAlgebra.Defs
 
 /-!
-# MonoidAlgebra.mapDomain
+# Maps of monoid algebras
 
+This file defines maps of monoid algebras along both the ring and monoid arguments.
 -/
 
 @[expose] public section
@@ -21,26 +22,33 @@ open Finsupp hiding single mapDomain
 
 noncomputable section
 
-variable {R S M N O : Type*}
+variable {F R S T M N O : Type*}
 
 /-! ### Multiplicative monoids -/
 
 namespace MonoidAlgebra
-variable [Semiring R] [Semiring S] {f : M → N} {a : M} {r : R}
+variable [Semiring R] [Semiring S] [Semiring T] {f : M → N} {a : M} {r : R}
 
 /-- Given a function `f : M → N` between magmas, return the corresponding map `R[M] → R[N]` obtained
 by summing the coefficients along each fiber of `f`. -/
 @[to_additive /--
 Given a function `f : M → N` between magmas, return the corresponding map `R[M] → R[N]` obtained
 by summing the coefficients along each fiber of `f`. -/]
-abbrev mapDomain (f : M → N) (v : R[M]) : R[N] := Finsupp.mapDomain f v
+abbrev mapDomain (f : M → N) (x : R[M]) : R[N] := Finsupp.mapDomain f x
 
 @[to_additive]
-lemma mapDomain_sum (f : M → N) (s : S[M]) (v : M → S → R[M]) :
-    mapDomain f (s.sum v) = s.sum fun a b ↦ mapDomain f (v a b) := Finsupp.mapDomain_sum
+lemma mapDomain_zero (f : M → N) : mapDomain f (0 : R[M]) = 0 := Finsupp.mapDomain_zero ..
 
 @[to_additive]
-lemma mapDomain_single : mapDomain f (single a r) = single (f a) r := Finsupp.mapDomain_single
+lemma mapDomain_add (f : M → N) (x y : R[M]) :
+    mapDomain f (x + y) = mapDomain f x + mapDomain f y := Finsupp.mapDomain_add ..
+
+@[to_additive]
+lemma mapDomain_sum (f : M → N) (x : S[M]) (v : M → S → R[M]) :
+    mapDomain f (x.sum v) = x.sum fun a b ↦ mapDomain f (v a b) := Finsupp.mapDomain_sum
+
+@[to_additive (relevant_arg := M)]
+lemma mapDomain_single : mapDomain f (single a r) = single (f a) r := by ext; simp
 
 @[to_additive]
 lemma mapDomain_injective (hf : Injective f) : Injective (mapDomain (R := R) f) :=
@@ -51,40 +59,192 @@ theorem mapDomain_one [One M] [One N] {F : Type*} [FunLike F M N] [OneHomClass F
     mapDomain f (1 : R[M]) = (1 : R[N]) := by
   simp [one_def]
 
+section Mul
+variable [Mul M] [Mul N] [Mul O] [FunLike F M N] [MulHomClass F M N]
+
 @[to_additive (dont_translate := R) mapDomain_mul]
-theorem mapDomain_mul [Mul M] [Mul N] {F : Type*} [FunLike F M N] [MulHomClass F M N] (f : F)
-    (x y : R[M]) : mapDomain f (x * y) = mapDomain f x * mapDomain f y := by
+lemma mapDomain_mul (f : F) (x y : R[M]) : mapDomain f (x * y) = mapDomain f x * mapDomain f y := by
   simp [mul_def, mapDomain_sum, add_mul, mul_add, sum_mapDomain_index]
+
+variable (R) in
+/-- If `f : G → H` is a multiplicative homomorphism between two monoids, then
+`MonoidAlgebra.mapDomain f` is a ring homomorphism between their monoid algebras.
+
+See also `MulEquiv.monoidAlgebraCongrRight`. -/
+@[to_additive (attr := simps) /--
+If `f : G → H` is a multiplicative homomorphism between two additive monoids, then
+`AddMonoidAlgebra.mapDomain f` is a ring homomorphism between their additive monoid algebras. -/]
+def mapDomainNonUnitalRingHom (f : M →ₙ* N) : R[M] →ₙ+* R[N] where
+  toFun := mapDomain f
+  map_zero' := mapDomain_zero _
+  map_add' := mapDomain_add _
+  map_mul' := mapDomain_mul f
+
+@[to_additive (dont_translate := R) (attr := simp)]
+lemma mapDomainNonUnitalRingHom_id : mapDomainNonUnitalRingHom R (.id M) = .id R[M] := by ext; simp
+
+@[to_additive (dont_translate := R) (attr := simp)]
+lemma mapDomainNonUnitalRingHom_comp (f : N →ₙ* O) (g : M →ₙ* N) :
+    mapDomainNonUnitalRingHom R (f.comp g) =
+      (mapDomainNonUnitalRingHom R f).comp (mapDomainNonUnitalRingHom R g) := by
+  ext; simp [Finsupp.mapDomain_comp]
+
+variable (R) in
+/-- Equivalent monoids have additively isomorphic monoid algebras.
+
+`MonoidAlgebra.mapDomain` as an `AddEquiv`. -/
+@[to_additive (dont_translate := R) (attr := simps apply symm_apply)
+/-- Equivalent additive monoids have additively isomorphic additive monoid algebras.
+
+`AddMonoidAlgebra.mapDomain` as an `AddEquiv`. -/]
+def mapDomainAddEquiv (e : M ≃ N) : R[M] ≃+ R[N] where
+  toFun x := x.mapDomain e
+  invFun x := x.mapDomain e.symm
+  left_inv x := by ext; simp
+  right_inv x := by ext; simp
+  map_add' x y := by ext; simp
+
+@[to_additive (attr := simp)]
+lemma symm_mapDomainAddEquiv (e : M ≃ N) :
+    (mapDomainAddEquiv R e).symm = mapDomainAddEquiv R e.symm := rfl
+
+@[to_additive (attr := simp)]
+lemma mapDomainAddEquiv_trans (e₁ : M ≃ N) (e₂ : N ≃ O) :
+    mapDomainAddEquiv R (e₁.trans e₂) =
+      (mapDomainAddEquiv R e₁).trans (mapDomainAddEquiv R e₂) := by
+  ext; simp [Finsupp.mapDomain_comp]
+
+variable (M) in
+/-- Additively isomorphic rings have additively isomorphic monoid algebras.
+
+`Finsupp.mapRange` as an `AddEquiv`. -/
+@[to_additive (dont_translate := R S) (attr := simps)
+/-- Additively isomorphic rings have additively isomorphic additive monoid algebras.
+
+`Finsupp.mapRange` as an `AddEquiv`. -/]
+def mapRangeAddEquiv (e : R ≃+ S) : R[M] ≃+ S[M] where
+  toFun x := .mapRange e e.map_zero x
+  invFun x := .mapRange e.symm e.symm.map_zero x
+  left_inv x := by ext; simp
+  right_inv x := by ext; simp
+  map_add' x y := by ext; simp
+
+@[to_additive (attr := simp)]
+lemma symm_mapRangeAddEquiv (e : R ≃+ S) :
+    (mapRangeAddEquiv M e).symm = mapRangeAddEquiv M e.symm := rfl
+
+@[to_additive (attr := simp)]
+lemma mapRangeAddEquiv_trans (e₁ : R ≃+ S) (e₂ : S ≃+ T) :
+    mapRangeAddEquiv M (e₁.trans e₂) = (mapRangeAddEquiv M e₁).trans (mapRangeAddEquiv M e₂) := by
+  ext; simp
+
+end Mul
 
 variable [Monoid M] [Monoid N] [Monoid O]
 
 variable (R) in
 /-- If `f : G → H` is a multiplicative homomorphism between two monoids, then
-`Finsupp.mapDomain f` is a ring homomorphism between their monoid algebras. -/
+`MonoidAlgebra.mapDomain f` is a ring homomorphism between their monoid algebras. -/
 @[to_additive (attr := simps) /--
-If `f : G → H` is a multiplicative homomorphism between two monoids, then
-`Finsupp.mapDomain f` is a ring homomorphism between their monoid algebras. -/]
-def mapDomainRingHom {F : Type*} [FunLike F M N] [MonoidHomClass F M N] (f : F) :
-    R[M] →+* R[N] where
-  __ : R[M] →+ R[N] := Finsupp.mapDomain.addMonoidHom f
+If `f : G → H` is a multiplicative homomorphism between two additive monoids, then
+`AddMonoidAlgebra.mapDomain f` is a ring homomorphism between their additive monoid algebras. -/]
+def mapDomainRingHom (f : M →* N) : R[M] →+* R[N] where
+  toFun := mapDomain f
+  map_zero' := mapDomain_zero _
+  map_add' := mapDomain_add _
   map_one' := mapDomain_one f
   map_mul' := mapDomain_mul f
 
 attribute [local ext high] ringHom_ext
 
 @[to_additive (dont_translate := R) (attr := simp)]
-lemma mapDomainRingHom_id :
-    mapDomainRingHom R (MonoidHom.id M) = .id R[M] := by ext <;> simp
+lemma mapDomainRingHom_id : mapDomainRingHom R (.id M) = .id R[M] := by ext <;> simp
 
 @[to_additive (dont_translate := R) (attr := simp)]
 lemma mapDomainRingHom_comp (f : N →* O) (g : M →* N) :
     mapDomainRingHom R (f.comp g) = (mapDomainRingHom R f).comp (mapDomainRingHom R g) := by
   ext <;> simp
 
+variable (M) in
+/-- The ring homomorphism of monoid algebras induced by a homomorphism of the base rings. -/
+@[to_additive (dont_translate := R S)
+/-- The ring homomorphism of additive monoid algebras induced by a homomorphism of the base rings.
+-/]
+noncomputable def mapRangeRingHom (f : R →+* S) : R[M] →+* S[M] where
+  toFun := mapRange f f.map_zero
+  map_zero' := mapRange_zero
+  map_add' := mapRange_add f.map_add
+  map_one' := by ext; simp [one_def]
+  map_mul' _ _ := by
+    classical
+    ext
+    simp [mul_def]
+    simp [MonoidAlgebra, sum_mapRange_index, map_finsuppSum, single_apply, apply_ite]
+
+@[to_additive (attr := simp)]
+lemma mapRangeRingHom_apply (f : R →+* S) (x : R[M]) (m : M) :
+    mapRangeRingHom M f x m = f (x m) := by simp [mapRangeRingHom]
+
+@[to_additive (attr := simp)]
+lemma mapRangeRingHom_single (f : R →+* S) (a : M) (b : R) :
+    mapRangeRingHom M f (single a b) = single a (f b) := by
+  classical ext; simp [single_apply, apply_ite f]
+
+@[to_additive (dont_translate := R) (attr := simp)]
+lemma mapRangeRingHom_id : mapRangeRingHom M (.id R) = .id R[M] := by ext <;> simp
+
+@[to_additive (dont_translate := R S T) (attr := simp)]
+lemma mapRangeRingHom_comp (f : S →+* T) (g : R →+* S) :
+    mapRangeRingHom M (f.comp g) = (mapRangeRingHom M f).comp (mapRangeRingHom M g) := by
+  ext <;> simp
+
 @[to_additive (dont_translate := R S)]
 lemma mapRangeRingHom_comp_mapDomainRingHom (f : R →+* S) (g : M →* N) :
     (mapRangeRingHom N f).comp (mapDomainRingHom R g) =
       (mapDomainRingHom S g).comp (mapRangeRingHom M f) := by aesop
+
+variable (R) in
+/-- Isomorphic monoids have isomorphic monoid algebras. -/
+@[to_additive (dont_translate := R) (attr := simps! apply symm_apply)
+/-- Isomorphic monoids have isomorphic additive monoid algebras. -/]
+def mapDomainRingEquiv (e : M ≃* N) : R[M] ≃+* R[N] :=
+  .ofRingHom (MonoidAlgebra.mapDomainRingHom R e) (MonoidAlgebra.mapDomainRingHom R e.symm)
+    (by apply MonoidAlgebra.ringHom_ext <;> simp) (by apply MonoidAlgebra.ringHom_ext <;> simp)
+
+@[to_additive]
+lemma toRingHom_mapDomainRingEquiv (e : M ≃* N) :
+    (mapDomainRingEquiv R e).toRingHom = mapDomainRingHom R e := rfl
+
+@[to_additive (attr := simp)]
+lemma symm_mapDomainRingEquiv (e : M ≃* N) :
+    (mapDomainRingEquiv R e).symm = mapDomainRingEquiv R e.symm := rfl
+
+@[to_additive (attr := simp)]
+lemma mapDomainRingEquiv_trans (e₁ : M ≃* N) (e₂ : N ≃* O) :
+    mapDomainRingEquiv R (e₁.trans e₂) =
+      (mapDomainRingEquiv R e₁).trans (mapDomainRingEquiv R e₂) := by
+  ext; simp [Finsupp.mapDomain_comp]
+
+variable (M) in
+/-- Isomorphic rings have isomorphic monoid algebras. -/
+@[to_additive (dont_translate := R S) (attr := simps! apply symm_apply)
+/-- Isomorphic rings have isomorphic additive monoid algebras. -/]
+def mapRangeRingEquiv (e : R ≃+* S) : R[M] ≃+* S[M] :=
+  .ofRingHom (MonoidAlgebra.mapRangeRingHom M e) (MonoidAlgebra.mapRangeRingHom M e.symm)
+    (by apply MonoidAlgebra.ringHom_ext <;> simp) (by apply MonoidAlgebra.ringHom_ext <;> simp)
+
+@[to_additive]
+lemma toRingHom_mapRangeRingEquiv (e : R ≃+* S) :
+    (mapRangeRingEquiv M e).toRingHom = mapRangeRingHom M e := rfl
+
+@[to_additive (attr := simp)]
+lemma symm_mapRangeRingEquiv (e : R ≃+* S) :
+    (mapRangeRingEquiv M e).symm = mapRangeRingEquiv M e.symm := rfl
+
+@[to_additive (attr := simp)]
+lemma mapRangeRingEquiv_trans (e₁ : R ≃+* S) (e₂ : S ≃+* T) :
+    mapRangeRingEquiv M (e₁.trans e₂) =
+      (mapRangeRingEquiv M e₁).trans (mapRangeRingEquiv M e₂) := by ext; simp
 
 end MonoidAlgebra
 
@@ -102,10 +262,12 @@ variable (k G) in
 `Multiplicative` -/
 protected def AddMonoidAlgebra.toMultiplicative [Semiring k] [Add G] :
     AddMonoidAlgebra k G ≃+* MonoidAlgebra k (Multiplicative G) where
-  __ := Finsupp.domCongr Multiplicative.ofAdd
-  toFun := equivMapDomain Multiplicative.ofAdd
+  toFun x := x.mapDomain .ofAdd
+  invFun x := x.mapDomain Multiplicative.toAdd
+  left_inv x := by ext; simp
+  right_inv x := by ext; simp
+  map_add' := mapDomain_add _
   map_mul' x y := by
-    repeat' rw [equivMapDomain_eq_mapDomain (M := k)]
     dsimp [Multiplicative.ofAdd]
     exact MonoidAlgebra.mapDomain_mul (M := Multiplicative G) (MulHom.id (Multiplicative G)) x y
 
@@ -113,9 +275,9 @@ variable (k G) in
 /-- The equivalence between `MonoidAlgebra` and `AddMonoidAlgebra` in terms of `Additive` -/
 protected def MonoidAlgebra.toAdditive [Semiring k] [Mul G] :
     MonoidAlgebra k G ≃+* AddMonoidAlgebra k (Additive G) where
-  __ := Finsupp.domCongr Additive.ofMul
-  toFun := equivMapDomain Additive.ofMul
-  map_mul' x y := by
-    repeat' rw [equivMapDomain_eq_mapDomain (M := k)]
-    dsimp [Additive.ofMul]
-    convert MonoidAlgebra.mapDomain_mul (MulHom.id G) x y
+  toFun x := x.mapDomain .ofMul
+  invFun x := x.mapDomain Additive.toMul
+  left_inv x := by ext; simp
+  right_inv x := by ext; simp
+  map_add' := mapDomain_add _
+  map_mul' := MonoidAlgebra.mapDomain_mul (MulHom.id G)

--- a/Mathlib/Algebra/MonoidAlgebra/MapDomain.lean
+++ b/Mathlib/Algebra/MonoidAlgebra/MapDomain.lean
@@ -93,7 +93,7 @@ variable (R) in
 /-- Equivalent monoids have additively isomorphic monoid algebras.
 
 `MonoidAlgebra.mapDomain` as an `AddEquiv`. -/
-@[to_additive (dont_translate := R) (attr := simps apply symm_apply)
+@[to_additive (dont_translate := R)
 /-- Equivalent additive monoids have additively isomorphic additive monoid algebras.
 
 `AddMonoidAlgebra.mapDomain` as an `AddEquiv`. -/]
@@ -105,20 +105,27 @@ def mapDomainAddEquiv (e : M ≃ N) : R[M] ≃+ R[N] where
   map_add' x y := by ext; simp
 
 @[to_additive (attr := simp)]
+lemma mapDomainAddEquiv_apply (e : M ≃ N) (x : R[M]) (n : N) :
+    mapDomainAddEquiv R e x n = x (e.symm n) := by simp [mapDomainAddEquiv]
+
+@[to_additive (attr := simp)]
+lemma mapDomainAddEquiv_single (e : M ≃ N) (r : R) (m : M) :
+    mapDomainAddEquiv R e (single m r) = single (e m) r := by simp [mapDomainAddEquiv]
+
+@[to_additive (attr := simp)]
 lemma symm_mapDomainAddEquiv (e : M ≃ N) :
     (mapDomainAddEquiv R e).symm = mapDomainAddEquiv R e.symm := rfl
 
 @[to_additive (attr := simp)]
 lemma mapDomainAddEquiv_trans (e₁ : M ≃ N) (e₂ : N ≃ O) :
     mapDomainAddEquiv R (e₁.trans e₂) =
-      (mapDomainAddEquiv R e₁).trans (mapDomainAddEquiv R e₂) := by
-  ext; simp [Finsupp.mapDomain_comp]
+      (mapDomainAddEquiv R e₁).trans (mapDomainAddEquiv R e₂) := by ext; simp
 
 variable (M) in
 /-- Additively isomorphic rings have additively isomorphic monoid algebras.
 
 `Finsupp.mapRange` as an `AddEquiv`. -/
-@[to_additive (dont_translate := R S) (attr := simps)
+@[to_additive (dont_translate := R S)
 /-- Additively isomorphic rings have additively isomorphic additive monoid algebras.
 
 `Finsupp.mapRange` as an `AddEquiv`. -/]
@@ -128,6 +135,14 @@ def mapRangeAddEquiv (e : R ≃+ S) : R[M] ≃+ S[M] where
   left_inv x := by ext; simp
   right_inv x := by ext; simp
   map_add' x y := by ext; simp
+
+@[to_additive (attr := simp)]
+lemma mapRangeAddEquiv_apply (e : R ≃+ S) (x : R[M]) (m : M) :
+    mapRangeAddEquiv M e x m = e (x m) := by simp [mapRangeAddEquiv]
+
+@[to_additive (attr := simp)]
+lemma mapRangeAddEquiv_single (e : R ≃+ S) (r : R) (m : M) :
+    mapRangeAddEquiv M e (single m r) = single m (e r) := by simp [mapRangeAddEquiv]
 
 @[to_additive (attr := simp)]
 lemma symm_mapRangeAddEquiv (e : R ≃+ S) :
@@ -205,11 +220,19 @@ lemma mapRangeRingHom_comp_mapDomainRingHom (f : R →+* S) (g : M →* N) :
 
 variable (R) in
 /-- Isomorphic monoids have isomorphic monoid algebras. -/
-@[to_additive (dont_translate := R) (attr := simps! apply symm_apply)
+@[to_additive (dont_translate := R)
 /-- Isomorphic monoids have isomorphic additive monoid algebras. -/]
 def mapDomainRingEquiv (e : M ≃* N) : R[M] ≃+* R[N] :=
   .ofRingHom (MonoidAlgebra.mapDomainRingHom R e) (MonoidAlgebra.mapDomainRingHom R e.symm)
     (by apply MonoidAlgebra.ringHom_ext <;> simp) (by apply MonoidAlgebra.ringHom_ext <;> simp)
+
+@[to_additive (attr := simp)]
+lemma mapDomainRingEquiv_apply (e : M ≃* N) (x : R[M]) (n : N) :
+    mapDomainRingEquiv R e x n = x (e.symm n) := mapDomainAddEquiv_apply ..
+
+@[to_additive (attr := simp)]
+lemma mapDomainRingEquiv_single (e : M ≃* N) (r : R) (m : M) :
+    mapDomainRingEquiv R e (single m r) = single (e m) r := by simp [mapDomainRingEquiv]
 
 @[to_additive]
 lemma toRingHom_mapDomainRingEquiv (e : M ≃* N) :
@@ -222,16 +245,23 @@ lemma symm_mapDomainRingEquiv (e : M ≃* N) :
 @[to_additive (attr := simp)]
 lemma mapDomainRingEquiv_trans (e₁ : M ≃* N) (e₂ : N ≃* O) :
     mapDomainRingEquiv R (e₁.trans e₂) =
-      (mapDomainRingEquiv R e₁).trans (mapDomainRingEquiv R e₂) := by
-  ext; simp [Finsupp.mapDomain_comp]
+      (mapDomainRingEquiv R e₁).trans (mapDomainRingEquiv R e₂) := by ext; simp
 
 variable (M) in
 /-- Isomorphic rings have isomorphic monoid algebras. -/
-@[to_additive (dont_translate := R S) (attr := simps! apply symm_apply)
+@[to_additive (dont_translate := R S)
 /-- Isomorphic rings have isomorphic additive monoid algebras. -/]
 def mapRangeRingEquiv (e : R ≃+* S) : R[M] ≃+* S[M] :=
   .ofRingHom (MonoidAlgebra.mapRangeRingHom M e) (MonoidAlgebra.mapRangeRingHom M e.symm)
     (by apply MonoidAlgebra.ringHom_ext <;> simp) (by apply MonoidAlgebra.ringHom_ext <;> simp)
+
+@[to_additive (attr := simp)]
+lemma mapRangeRingEquiv_apply (e : R ≃+* S) (x : R[M]) (m : M) :
+    mapRangeRingEquiv M e x m = e (x m) := by simp [mapRangeRingEquiv]
+
+@[to_additive (attr := simp)]
+lemma mapRangeRingEquiv_single (e : R ≃+* S) (r : R) (m : M) :
+    mapRangeRingEquiv M e (single m r) = single m (e r) := by simp [mapRangeRingEquiv]
 
 @[to_additive]
 lemma toRingHom_mapRangeRingEquiv (e : R ≃+* S) :

--- a/Mathlib/Algebra/Polynomial/Laurent.lean
+++ b/Mathlib/Algebra/Polynomial/Laurent.lean
@@ -96,7 +96,7 @@ theorem LaurentPolynomial.ext [Semiring R] {p q : R[T;T⁻¹]} (h : ∀ a, p a =
 /-- The ring homomorphism, taking a polynomial with coefficients in `R` to a Laurent polynomial
 with coefficients in `R`. -/
 def Polynomial.toLaurent [Semiring R] : R[X] →+* R[T;T⁻¹] :=
-  (mapDomainRingHom R Int.ofNatHom).comp (toFinsuppIso R)
+  (mapDomainRingHom R Int.ofNatHom).comp (toFinsuppIso R).toRingHom
 
 /-- This is not a simp lemma, as it is usually preferable to use the lemmas about `C` and `X`
 instead. -/

--- a/Mathlib/Algebra/Polynomial/Laurent.lean
+++ b/Mathlib/Algebra/Polynomial/Laurent.lean
@@ -592,7 +592,7 @@ def invert : R[T;T⁻¹] ≃ₐ[R] R[T;T⁻¹] := AddMonoidAlgebra.domCongr R R 
 @[simp] lemma invert_T (n : ℤ) : invert (T n : R[T;T⁻¹]) = T (-n) :=
   AddMonoidAlgebra.domCongr_single _ _ _ _ _
 
-@[simp] lemma invert_apply (f : R[T;T⁻¹]) (n : ℤ) : invert f n = f (-n) := rfl
+@[simp] lemma invert_apply (f : R[T;T⁻¹]) (n : ℤ) : invert f n = f (-n) := by simp [invert]
 
 @[simp] lemma invert_comp_C : invert ∘ (@C R _) = C := by ext; simp
 

--- a/Mathlib/RingTheory/Polynomial/Opposites.lean
+++ b/Mathlib/RingTheory/Polynomial/Opposites.lean
@@ -80,8 +80,7 @@ theorem opRingEquiv_symm_C_mul_X_pow (r : Rᵐᵒᵖ) (n : ℕ) :
 
 @[simp]
 theorem coeff_opRingEquiv (p : R[X]ᵐᵒᵖ) (n : ℕ) :
-    (opRingEquiv R p).coeff n = op ((unop p).coeff n) := by
-  simp [opRingEquiv, coeff, Finsupp.equivMapDomain_eq_mapDomain, ← Finsupp.mapDomain_comp]
+    (opRingEquiv R p).coeff n = op ((unop p).coeff n) := by simp [opRingEquiv, coeff]
 
 @[simp]
 theorem support_opRingEquiv (p : R[X]ᵐᵒᵖ) : (opRingEquiv R p).support = (unop p).support := by

--- a/Mathlib/RingTheory/Polynomial/Opposites.lean
+++ b/Mathlib/RingTheory/Polynomial/Opposites.lean
@@ -31,18 +31,8 @@ namespace Polynomial
 /-- Ring isomorphism between `R[X]ᵐᵒᵖ` and `Rᵐᵒᵖ[X]` sending each coefficient of a polynomial
 to the corresponding element of the opposite ring. -/
 def opRingEquiv (R : Type*) [Semiring R] : R[X]ᵐᵒᵖ ≃+* Rᵐᵒᵖ[X] :=
-  ((toFinsuppIso R).op.trans <| AddMonoidAlgebra.opRingEquiv.trans {
-    -- TODO(Yaël): Clean up after https://github.com/leanprover-community/mathlib4/pull/32254
-    -- The term should be `AddOpposite.opAddEquiv.addMonoidAlgebraCongrRight`.
-      toFun := AddMonoidAlgebra.mapDomain AddOpposite.unop
-      invFun := AddMonoidAlgebra.mapDomain .op
-      left_inv x := by ext; simp [← Finsupp.mapDomain_comp]
-      right_inv x := by ext; simp [← Finsupp.mapDomain_comp]
-      map_add' x y := Finsupp.mapDomain_add ..
-      map_mul' x y := by
-        simp [AddMonoidAlgebra.mul_def, AddMonoidAlgebra.mapDomain_sum, add_mul, mul_add,
-          Finsupp.sum_mapDomain_index, add_comm]
-    }).trans (toFinsuppIso _).symm
+  ((toFinsuppIso R).op.trans <| AddMonoidAlgebra.opRingEquiv.trans <|
+    AddMonoidAlgebra.mapDomainRingEquiv _ AddOpposite.opAddEquiv.symm).trans (toFinsuppIso _).symm
 
 /-!  Lemmas to get started, using `opRingEquiv R` on the various expressions of
 `Finsupp.single`: `monomial`, `C a`, `X`, `C a * X ^ n`. -/


### PR DESCRIPTION
Add congruence isomorphisms in both the ring and monoid arguments. Move `mapRangeRingHom` from `Algebra.MonoidAlgebra.Lift` to `Algebra.MonoidAlgebra.MapDomain` and make its proofs additivisable (by not using `lift`). Make `mapDomainRingHom` take a `MonoidHom` rather than `MonoidHomClass`.

---
- [x] depends on: #32486

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
