### PR TITLE
[Merged by Bors] - chore: fix the statement of `Fin.orderPred_eq`

### DIFF
--- a/Mathlib/Data/Fin/SuccPredOrder.lean
+++ b/Mathlib/Data/Fin/SuccPredOrder.lean
@@ -62,7 +62,7 @@ instance : ∀ {n : ℕ}, PredOrder (Fin n)
         rfl)
 
 lemma orderPred_eq {n : ℕ} :
-    Order.succ = Fin.lastCases (Fin.last n) Fin.succ := rfl
+    Order.pred = Fin.cases 0 Fin.castSucc (n := n) := rfl
 
 lemma orderPred_apply {n : ℕ} (i : Fin (n + 1)) :
     Order.pred i = Fin.cases 0 Fin.castSucc i := rfl


### PR DESCRIPTION
The current statement is identical to `Fin.orderSucc_eq` (and about `Order.succ` instead of `Order.pred`). I think it makes more sense to just fix the statement than to deprecate to something wrong, but one could instead deprecate and call the correct statement `Fin.orderPred_eq'`.

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

When merging, all the commits will be squashed into a single commit
listing all co-authors.

Co-authors in the squash commit are gathered from two sources:

First, all authors of commits to this PR branch are included. Thus,
one way to add co-authors is to include at least one commit authored by
each co-author among the commits in the pull request. If necessary, you
may create empty commits to indicate co-authorship, using commands like so:

git commit --author="Author Name <author@email.com>" --allow-empty -m "add Author Name as coauthor"

Second, co-authors can also be listed in lines at the very bottom of
the commit message (that is, directly before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines
at the bottom of the commit message (before the `---`, and also before
any "Co-authored-by" lines) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
