### PR TITLE
[Merged by Bors] - chore(undergrad.yaml): `{LinearMap -> Matrix}.GeneralLinearGroup`

### DIFF
--- a/docs/undergrad.yaml
+++ b/docs/undergrad.yaml
@@ -102,7 +102,7 @@ Group Theory:
     signature: 'Equiv.Perm.sign'
     alternating group: 'alternatingGroup'
   Classical automorphism groups:
-    general linear group: 'LinearMap.GeneralLinearGroup'
+    general linear group: 'Matrix.GeneralLinearGroup'
     special linear group: 'Matrix.SpecialLinearGroup'
     orthogonal group: 'Matrix.orthogonalGroup'
     special orthogonal group: 'https://en.wikipedia.org/wiki/Orthogonal_group#SO(n)'


### PR DESCRIPTION
---
[When the undergrad page was created](https://github.com/leanprover-community/leanprover-community.github.io/commit/85682784b1d48ab38b6fb96ab73a8994261983f5#diff-a53acf6e3ec0988cc4162375a5c94e4028bae237eacfce3f8f32d076259e8633R105-R106) it contained:
```yaml
    general linear group: 'linear_map.general_linear_group'
    special linear group: 'matrix.special_linear_group'
```
and [a year later](https://github.com/leanprover-community/mathlib3/pull/8466) `matrix.general_linear_group` was created.

Since that section contains multiple `Matrix` reference and only one `LinearMap` reference, I switched to the matrix version.
It's also what I expected to see under group theory.

(btw all 4 versions now exist: [Matrix GLG](https://leanprover-community.github.io/mathlib4_docs/Mathlib/LinearAlgebra/Matrix/GeneralLinearGroup/Defs.html#Matrix.GeneralLinearGroup), [Matrix SLG](https://leanprover-community.github.io/mathlib4_docs/Mathlib/LinearAlgebra/Matrix/SpecialLinearGroup.html#Matrix.SpecialLinearGroup), [LinearMap GLG](https://leanprover-community.github.io/mathlib4_docs/Mathlib/LinearAlgebra/GeneralLinearGroup.html#LinearMap.GeneralLinearGroup), [LinearMap SLG](https://leanprover-community.github.io/mathlib4_docs/Mathlib/LinearAlgebra/SpecialLinearGroup.html#SpecialLinearGroup), although the 4th one is under the root namespace for some reason)

<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

When merging, all the commits will be squashed into a single commit
listing all co-authors.

Co-authors in the squash commit are gathered from two sources:

First, all authors of commits to this PR branch are included. Thus,
one way to add co-authors is to include at least one commit authored by
each co-author among the commits in the pull request. If necessary, you
may create empty commits to indicate co-authorship, using commands like so:

git commit --author="Author Name <author@email.com>" --allow-empty -m "add Author Name as coauthor"

Second, co-authors can also be listed in lines at the very bottom of
the commit message (that is, directly before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines
at the bottom of the commit message (before the `---`, and also before
any "Co-authored-by" lines) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
