### PR TITLE
[Merged by Bors] - feat(Analysis/Normed/Group): add `grind` annotation for `norm_nonneg`

### DIFF
--- a/Mathlib/Analysis/Normed/Group/Basic.lean
+++ b/Mathlib/Analysis/Normed/Group/Basic.lean
@@ -509,6 +509,7 @@ theorem norm_nonneg' (a : E) : 0 ≤ ‖a‖ := by
   exact dist_nonneg
 
 attribute [bound] norm_nonneg
+attribute [grind .] norm_nonneg
 
 @[to_additive (attr := simp) abs_norm]
 theorem abs_norm' (z : E) : |‖z‖| = ‖z‖ := abs_of_nonneg <| norm_nonneg' _

--- a/Mathlib/Analysis/SpecialFunctions/Log/RpowTendsto.lean
+++ b/Mathlib/Analysis/SpecialFunctions/Log/RpowTendsto.lean
@@ -54,10 +54,10 @@ lemma Real.tendstoLocallyUniformlyOn_rpow_sub_one_log :
   have hxs : ∀ x ∈ s, x ≠ 0 := by grind
   have sSup_nonneg : 0 ≤ sSup ((fun x => ‖log x‖ ^ 2) '' s) := by
     refine Real.sSup_nonneg ?_
-    grind [norm_nonneg, ← sq_nonneg]
+    grind [← sq_nonneg]
   have sSup_nonneg' : 0 ≤ sSup ((fun x => ‖log x‖) '' s) := by
     refine Real.sSup_nonneg ?_
-    grind [norm_nonneg, ← sq_nonneg]
+    grind [← sq_nonneg]
   have pbound_pos : 0 < pbound := by positivity
   have h₁ : ∀ᶠ p : ℝ in 𝓝[>] 0, 0 < p ∧ p < pbound := nhdsGT_basis 0 |>.mem_of_mem pbound_pos
   have h₂ : ∀ᶠ p : ℝ in 𝓝[>] 0, p ≤ 1 / (sSup ((fun x => ‖log x‖) '' s) + 1) :=


### PR DESCRIPTION
---
Note that the lemma being annotated is
1. already actively used with `grind` via explicit `grind [lemma]` invocations in Mathlib, and
2. already tagged with `@[simp]`.

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

When merging, all the commits will be squashed into a single commit
listing all co-authors.

Co-authors in the squash commit are gathered from two sources:

First, all authors of commits to this PR branch are included. Thus,
one way to add co-authors is to include at least one commit authored by
each co-author among the commits in the pull request. If necessary, you
may create empty commits to indicate co-authorship, using commands like so:

git commit --author="Author Name <author@email.com>" --allow-empty -m "add Author Name as coauthor"

Second, co-authors can also be listed in lines at the very bottom of
the commit message (that is, directly before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines
at the bottom of the commit message (before the `---`, and also before
any "Co-authored-by" lines) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
