### PR TITLE
[Merged by Bors] - feat: drop a measurability assumption

### DIFF
--- a/Mathlib/MeasureTheory/Measure/Typeclasses/Probability.lean
+++ b/Mathlib/MeasureTheory/Measure/Typeclasses/Probability.lean
@@ -114,7 +114,7 @@ theorem Measure.isProbabilityMeasure_map {f : α → β} (hf : AEMeasurable f μ
     IsProbabilityMeasure (map f μ) :=
   ⟨by simp [map_apply_of_aemeasurable, hf]⟩
 
-theorem Measure.isProbabilityMeasure_of_map {μ : Measure α} {f : α → β}
+theorem Measure.isProbabilityMeasure_of_map {μ : Measure α} (f : α → β)
     [IsProbabilityMeasure (μ.map f)] : IsProbabilityMeasure μ where
   measure_univ := by
     have hf : AEMeasurable f μ := AEMeasurable.of_map_ne_zero (IsProbabilityMeasure.ne_zero _)
@@ -123,7 +123,7 @@ theorem Measure.isProbabilityMeasure_of_map {μ : Measure α} {f : α → β}
 
 theorem Measure.isProbabilityMeasure_map_iff {μ : Measure α} {f : α → β}
     (hf : AEMeasurable f μ) : IsProbabilityMeasure (μ.map f) ↔ IsProbabilityMeasure μ :=
-  ⟨fun _ ↦ isProbabilityMeasure_of_map (f := f), fun _ ↦ isProbabilityMeasure_map hf⟩
+  ⟨fun _ ↦ isProbabilityMeasure_of_map f, fun _ ↦ isProbabilityMeasure_map hf⟩
 
 instance IsProbabilityMeasure_comap_equiv (f : β ≃ᵐ α) : IsProbabilityMeasure (μ.comap f) := by
   rw [← MeasurableEquiv.map_symm]; exact isProbabilityMeasure_map f.symm.measurable.aemeasurable

--- a/Mathlib/MeasureTheory/Measure/Typeclasses/Probability.lean
+++ b/Mathlib/MeasureTheory/Measure/Typeclasses/Probability.lean
@@ -115,14 +115,15 @@ theorem Measure.isProbabilityMeasure_map {f : α → β} (hf : AEMeasurable f μ
   ⟨by simp [map_apply_of_aemeasurable, hf]⟩
 
 theorem Measure.isProbabilityMeasure_of_map {μ : Measure α} {f : α → β}
-    (hf : AEMeasurable f μ) [IsProbabilityMeasure (μ.map f)] : IsProbabilityMeasure μ where
+    [IsProbabilityMeasure (μ.map f)] : IsProbabilityMeasure μ where
   measure_univ := by
+    have hf : AEMeasurable f μ := AEMeasurable.of_map_ne_zero (IsProbabilityMeasure.ne_zero _)
     rw [← Set.preimage_univ (f := f), ← map_apply_of_aemeasurable hf .univ]
     exact IsProbabilityMeasure.measure_univ
 
 theorem Measure.isProbabilityMeasure_map_iff {μ : Measure α} {f : α → β}
     (hf : AEMeasurable f μ) : IsProbabilityMeasure (μ.map f) ↔ IsProbabilityMeasure μ :=
-  ⟨fun _ ↦ isProbabilityMeasure_of_map hf, fun _ ↦ isProbabilityMeasure_map hf⟩
+  ⟨fun _ ↦ isProbabilityMeasure_of_map (f := f), fun _ ↦ isProbabilityMeasure_map hf⟩
 
 instance IsProbabilityMeasure_comap_equiv (f : β ≃ᵐ α) : IsProbabilityMeasure (μ.comap f) := by
   rw [← MeasurableEquiv.map_symm]; exact isProbabilityMeasure_map f.symm.measurable.aemeasurable


### PR DESCRIPTION
If `P.map f` is a probability measure, then so is `P`. There is no need to assume that `f` is aemeasurable because if it's not then `P.map f` is `0` so it can't be a probability measure.

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

When merging, all the commits will be squashed into a single commit
listing all co-authors.

Co-authors in the squash commit are gathered from two sources:

First, all authors of commits to this PR branch are included. Thus,
one way to add co-authors is to include at least one commit authored by
each co-author among the commits in the pull request. If necessary, you
may create empty commits to indicate co-authorship, using commands like so:

git commit --author="Author Name <author@email.com>" --allow-empty -m "add Author Name as coauthor"

Second, co-authors can also be listed in lines at the very bottom of
the commit message (that is, directly before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines
at the bottom of the commit message (before the `---`, and also before
any "Co-authored-by" lines) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
