### PR TITLE
[Merged by Bors] - chore: make `Associated.rfl` simp

### DIFF
--- a/Mathlib/Algebra/GroupWithZero/Associated.lean
+++ b/Mathlib/Algebra/GroupWithZero/Associated.lean
@@ -38,6 +38,7 @@ namespace Associated
 protected theorem refl [Monoid M] (x : M) : x ~ᵤ x :=
   ⟨1, by simp⟩
 
+@[simp]
 protected theorem rfl [Monoid M] {x : M} : x ~ᵤ x :=
   .refl x
 

--- a/Mathlib/RingTheory/UniqueFactorizationDomain/Kaplansky.lean
+++ b/Mathlib/RingTheory/UniqueFactorizationDomain/Kaplansky.lean
@@ -93,8 +93,8 @@ theorem of_exists_prime_mem_of_isPrime
   induction this using closure_induction with
   | mem z hz =>
       rcases hz with h | h
-      · exact ⟨∅, by simp, by simpa using (associated_one_iff_isUnit.2 h).symm⟩
-      · exact ⟨{z}, by simpa, by simpa using Associated.rfl⟩
+      · exact ⟨∅, by simpa using (associated_one_iff_isUnit.2 h).symm⟩
+      · exact ⟨{z}, by simpa⟩
   | one => exact ⟨∅, by simp⟩
   | mul z₁ z₂ hz₁ hz₂ h₁ h₂ =>
       obtain ⟨S₁, hS₁pri, hS₁⟩ := h₁


### PR DESCRIPTION
From Toric

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

When merging, all the commits will be squashed into a single commit
listing all co-authors.

Co-authors in the squash commit are gathered from two sources:

First, all authors of commits to this PR branch are included. Thus,
one way to add co-authors is to include at least one commit authored by
each co-author among the commits in the pull request. If necessary, you
may create empty commits to indicate co-authorship, using commands like so:

git commit --author="Author Name <author@email.com>" --allow-empty -m "add Author Name as coauthor"

Second, co-authors can also be listed in lines at the very bottom of
the commit message (that is, directly before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines
at the bottom of the commit message (before the `---`, and also before
any "Co-authored-by" lines) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
