### PR TITLE
[Merged by Bors] - refactor(Algebra/Polynomial/Splits): continue deprecation

### DIFF
--- a/Mathlib/Algebra/Polynomial/Factors.lean
+++ b/Mathlib/Algebra/Polynomial/Factors.lean
@@ -256,7 +256,7 @@ theorem Splits.exists_eval_eq_zero (hf : Splits f) (hf0 : degree f ≠ 0) :
   obtain ⟨m, rfl⟩ := Multiset.exists_cons_of_mem ha
   exact ⟨a, hm ▸ by simp⟩
 
-theorem Splits.comp_X_sub_C {f : R[X]} (hf : f.Splits) (a : R) : (f.comp (X - C a)).Splits :=
+theorem Splits.comp_X_sub_C (hf : f.Splits) (a : R) : (f.comp (X - C a)).Splits :=
   hf.comp_of_natDegree_le_one_of_monic (natDegree_sub_C.trans_le natDegree_X_le) (monic_X_sub_C a)
 
 variable [IsDomain R]
@@ -279,10 +279,14 @@ theorem Splits.degree_eq_card_roots (hf : Splits f) (hf0 : f ≠ 0) :
     f.degree = f.roots.card :=
   (degree_eq_iff_natDegree_eq hf0).mpr hf.natDegree_eq_card_roots
 
+/-- A polynomial splits if and only if it has as many roots as its degree. -/
+theorem splits_iff_card_roots : Splits f ↔ f.roots.card = f.natDegree :=
+  ⟨fun h ↦ h.natDegree_eq_card_roots.symm, fun h ↦ splits_iff_exists_multiset.mpr
+    ⟨f.roots, (C_leadingCoeff_mul_prod_multiset_X_sub_C h).symm⟩⟩
+
 theorem Splits.roots_ne_zero (hf : Splits f) (hf0 : natDegree f ≠ 0) :
     f.roots ≠ 0 := by
-  obtain ⟨a, ha⟩ := hf.exists_eval_eq_zero (degree_ne_of_natDegree_ne hf0)
-  exact mt (· ▸ (mem_roots (by aesop)).mpr ha) (Multiset.notMem_zero a)
+  simpa [hf.natDegree_eq_card_roots] using hf0
 
 theorem splits_X_sub_C_mul_iff {a : R} : Splits ((X - C a) * f) ↔ Splits f := by
   refine ⟨fun hf ↦ ?_, ((Splits.X_sub_C _).mul ·)⟩

--- a/Mathlib/Algebra/Polynomial/Factors.lean
+++ b/Mathlib/Algebra/Polynomial/Factors.lean
@@ -5,6 +5,7 @@ Authors: Thomas Browning
 -/
 module
 
+public import Mathlib.Algebra.Order.SuccPred.WithBot
 public import Mathlib.Algebra.Polynomial.FieldDivision
 public import Mathlib.Algebra.Polynomial.Taylor
 
@@ -173,6 +174,10 @@ theorem Splits.natDegree_le_one_of_irreducible {f : R[X]} (hf : Splits f)
     grw [hm, this, natDegree_mul_le]
     simp
 
+theorem Splits.degree_le_one_of_irreducible {f : R[X]} (hf : Splits f)
+    (h : Irreducible f) : degree f ≤ 1 :=
+  degree_le_of_natDegree_le (hf.natDegree_le_one_of_irreducible h)
+
 theorem Splits.comp_of_natDegree_le_one_of_invertible {f g : R[X]} (hf : f.Splits)
     (hg : g.natDegree ≤ 1) (h : Invertible g.leadingCoeff) : (f.comp g).Splits := by
   rcases lt_or_eq_of_le hg with hg | hg
@@ -270,6 +275,10 @@ theorem Splits.natDegree_eq_card_roots (hf : Splits f) :
   · simp [leadingCoeff_eq_zero.mp hf0]
   · conv_lhs => rw [hf.eq_prod_roots, natDegree_C_mul hf0, natDegree_multiset_prod_X_sub_C_eq_card]
 
+theorem Splits.degree_eq_card_roots (hf : Splits f) (hf0 : f ≠ 0) :
+    f.degree = f.roots.card :=
+  (degree_eq_iff_natDegree_eq hf0).mpr hf.natDegree_eq_card_roots
+
 theorem Splits.roots_ne_zero (hf : Splits f) (hf0 : natDegree f ≠ 0) :
     f.roots ≠ 0 := by
   obtain ⟨a, ha⟩ := hf.exists_eval_eq_zero (degree_ne_of_natDegree_ne hf0)
@@ -314,6 +323,11 @@ theorem Splits.splits_of_dvd (hg : Splits g) (hg₀ : g ≠ 0) (hfg : f ∣ g) :
 
 @[deprecated (since := "2025-11-27")]
 alias Splits.of_dvd := Splits.splits_of_dvd
+
+theorem splits_prod_iff {ι : Type*} {f : ι → R[X]} {s : Finset ι} (hf : ∀ i ∈ s, f i ≠ 0) :
+    (∏ x ∈ s, f x).Splits ↔ ∀ x ∈ s, (f x).Splits :=
+  ⟨fun h _ hx ↦ h.splits_of_dvd (Finset.prod_ne_zero_iff.mpr hf) (Finset.dvd_prod_of_mem f hx),
+    Splits.prod⟩
 
 -- Todo: Remove or fix name once `Splits` is gone.
 theorem Splits.splits (hf : Splits f) :
@@ -392,6 +406,15 @@ theorem splits_iff_comp_splits_of_natDegree_eq_one {f g : R[X]} (hg : g.natDegre
 theorem splits_iff_comp_splits_of_degree_eq_one {f g : R[X]} (hg : g.degree = 1) :
     f.Splits ↔ (f.comp g).Splits :=
   splits_iff_comp_splits_of_natDegree_eq_one (natDegree_eq_of_degree_eq_some hg)
+
+theorem Splits.degree_eq_one_of_irreducible {f : R[X]} (hf : Splits f)
+    (h : Irreducible f) : degree f = 1 :=
+  le_antisymm (hf.degree_le_one_of_irreducible h)
+    ((WithBot.one_le_iff_pos _).mpr (degree_pos_of_irreducible h))
+
+theorem Splits.natDegree_eq_one_of_irreducible {f : R[X]} (hf : Splits f)
+    (h : Irreducible f) : natDegree f = 1 :=
+  natDegree_eq_of_degree_eq_some (hf.degree_eq_one_of_irreducible h)
 
 open UniqueFactorizationMonoid in
 -- Todo: Remove or fix name.

--- a/Mathlib/Algebra/Polynomial/Splits.lean
+++ b/Mathlib/Algebra/Polynomial/Splits.lean
@@ -345,17 +345,6 @@ theorem splits_of_isScalarTower {f : R[X]} [Algebra K L] [IsScalarTower R K L]
     (h : Splits (f.map (algebraMap R K))) : Splits (f.map (algebraMap R L)) :=
   splits_of_algHom h (IsScalarTower.toAlgHom R K L)
 
-/-- A polynomial splits if and only if it has as many roots as its degree. -/
-theorem splits_iff_card_roots {p : K[X]} :
-    Splits p ↔ Multiset.card p.roots = p.natDegree := by
-  constructor
-  · intro H
-    rw [H.natDegree_eq_card_roots]
-  · intro hroots
-    rw [splits_iff_exists_multiset]
-    use p.roots
-    exact (C_leadingCoeff_mul_prod_multiset_X_sub_C hroots).symm
-
 theorem eval₂_derivative_of_splits [DecidableEq L] {P : K[X]} {f : K →+* L} (hP : (P.map f).Splits)
     (x : L) :
     eval₂ f x P.derivative = f (P.leadingCoeff) *

--- a/Mathlib/Algebra/Polynomial/Splits.lean
+++ b/Mathlib/Algebra/Polynomial/Splits.lean
@@ -158,10 +158,12 @@ alias splits_of_splits_mul := splits_mul_iff
 @[deprecated (since := "2025-11-25")]
 alias splits_of_splits_of_dvd := Splits.splits_of_dvd
 
+@[deprecated "Use `Splits.splits_of_dvd` directly." (since := "2025-11-30")]
 theorem splits_of_splits_gcd_left [DecidableEq K] {f g : K[X]} (hf0 : f ≠ 0)
     (hf : Splits f) : Splits (EuclideanDomain.gcd f g) :=
   Splits.splits_of_dvd hf hf0 <| EuclideanDomain.gcd_dvd_left f g
 
+@[deprecated "Use `Splits.splits_of_dvd` directly." (since := "2025-11-30")]
 theorem splits_of_splits_gcd_right [DecidableEq K] {f g : K[X]} (hg0 : g ≠ 0)
     (hg : Splits g) : Splits (EuclideanDomain.gcd f g) :=
   Splits.splits_of_dvd hg hg0 <| EuclideanDomain.gcd_dvd_right f g

--- a/Mathlib/Algebra/Polynomial/Splits.lean
+++ b/Mathlib/Algebra/Polynomial/Splits.lean
@@ -145,14 +145,12 @@ variable [CommRing R] [Field K] [Field L] [Field F]
 variable (i : K →+* L)
 
 /-- This lemma is for polynomials over a field. -/
-theorem splits_iff (f : K[X]) :
-    Splits (f.map i) ↔ f = 0 ∨ ∀ {g : L[X]}, Irreducible g → g ∣ f.map i → degree g = 1 := by
-  rw [splits_iff_splits, Polynomial.map_eq_zero]
+@[deprecated (since := "2025-11-30")]
+alias splits_iff := splits_iff_splits
 
 /-- This lemma is for polynomials over a field. -/
-theorem Splits.def {i : K →+* L} {f : K[X]} (h : Splits (f.map i)) :
-    f = 0 ∨ ∀ {g : L[X]}, Irreducible g → g ∣ f.map i → degree g = 1 :=
-  (splits_iff i f).mp h
+@[deprecated (since := "2025-11-30")]
+alias Splits.def := splits_iff_splits
 
 @[deprecated (since := "2025-11-25")]
 alias splits_of_splits_mul := splits_mul_iff
@@ -161,32 +159,15 @@ alias splits_of_splits_mul := splits_mul_iff
 alias splits_of_splits_of_dvd := Splits.splits_of_dvd
 
 theorem splits_of_splits_gcd_left [DecidableEq K] {f g : K[X]} (hf0 : f ≠ 0)
-    (hf : Splits (f.map i)) : Splits ((EuclideanDomain.gcd f g).map i) :=
-  Splits.splits_of_dvd hf (map_ne_zero hf0) <| map_dvd i <| EuclideanDomain.gcd_dvd_left f g
+    (hf : Splits f) : Splits (EuclideanDomain.gcd f g) :=
+  Splits.splits_of_dvd hf hf0 <| EuclideanDomain.gcd_dvd_left f g
 
 theorem splits_of_splits_gcd_right [DecidableEq K] {f g : K[X]} (hg0 : g ≠ 0)
-    (hg : Splits (g.map i)) : Splits ((EuclideanDomain.gcd f g).map i) :=
-  Splits.splits_of_dvd hg (map_ne_zero hg0) <| map_dvd i <| EuclideanDomain.gcd_dvd_right f g
+    (hg : Splits g) : Splits (EuclideanDomain.gcd f g) :=
+  Splits.splits_of_dvd hg hg0 <| EuclideanDomain.gcd_dvd_right f g
 
-theorem splits_prod_iff {ι : Type u} {s : ι → K[X]} {t : Finset ι} :
-    (∀ j ∈ t, s j ≠ 0) → (((∏ x ∈ t, s x).map i).Splits ↔ ∀ j ∈ t, ((s j).map i).Splits) := by
-  classical
-  refine
-    Finset.induction_on t (fun _ =>
-        ⟨fun _ _ h => by simp only [Finset.notMem_empty] at h, by simp⟩)
-      fun a t hat ih ht => ?_
-  rw [Finset.forall_mem_insert] at ht ⊢
-  rw [Finset.prod_insert hat, Polynomial.map_mul, splits_mul_iff (map_ne_zero ht.1)
-    (map_ne_zero (Finset.prod_ne_zero_iff.2 ht.2)), ih ht.2]
-
-theorem degree_eq_one_of_irreducible_of_splits {p : K[X]} (hp : Irreducible p)
-    (hp_splits : Splits (p.map (RingHom.id K))) : p.degree = 1 := by
-  rw [splits_iff_splits] at hp_splits
-  rcases hp_splits with ⟨⟩ | hp_splits
-  · exfalso
-    simp_all
-  · apply hp_splits hp
-    simp
+@[deprecated (since := "2025-11-30")]
+alias degree_eq_one_of_irreducible_of_splits := Splits.degree_eq_one_of_irreducible
 
 theorem exists_root_of_splits {f : K[X]} (hs : Splits (f.map i)) (hf0 : degree f ≠ 0) :
     ∃ x, eval₂ i x f = 0 :=
@@ -210,18 +191,14 @@ theorem map_rootOfSplits {f : K[X]} (hf : (f.map i).Splits) (hfd) :
     f.eval₂ i (rootOfSplits i hf hfd) = 0 :=
   map_rootOfSplits' i hf (ne_of_eq_of_ne (degree_map f i) hfd)
 
-theorem natDegree_eq_card_roots {p : K[X]} {i : K →+* L} (hsplit : Splits (p.map i)) :
-    p.natDegree = Multiset.card (p.map i).roots :=
-  (natDegree_map i).symm.trans <| natDegree_eq_card_roots' hsplit
+@[deprecated (since := "2025-11-30")]
+alias natDegree_eq_card_roots := Splits.natDegree_eq_card_roots
 
-theorem degree_eq_card_roots {p : K[X]} {i : K →+* L} (p_ne_zero : p ≠ 0)
-    (hsplit : Splits (p.map i)) : p.degree = Multiset.card (p.map i).roots := by
-  rw [degree_eq_natDegree p_ne_zero, natDegree_eq_card_roots hsplit]
+@[deprecated (since := "2025-11-30")]
+alias degree_eq_card_roots := Splits.degree_eq_card_roots
 
 theorem roots_map {f : K[X]} (hf : f.Splits) : (f.map i).roots = f.roots.map i :=
-  (roots_map_of_injective_of_card_eq_natDegree i.injective <| by
-      convert (natDegree_eq_card_roots (hf.map <| .id K)).symm
-      rw [map_id]).symm
+  (roots_map_of_injective_of_card_eq_natDegree i.injective hf.natDegree_eq_card_roots.symm).symm
 
 theorem Splits.mem_subfield_of_isRoot (F : Subfield K) {f : F[X]} (hnz : f ≠ 0)
     (hf : Splits f) {x : K} (hx : (f.map F.subtype).IsRoot x) :
@@ -332,8 +309,8 @@ theorem splits_of_exists_multiset {f : K[X]} {s : Multiset L}
     (hs : f.map i = C (i f.leadingCoeff) * (s.map fun a : L => X - C a).prod) : Splits (f.map i) :=
   splits_iff_exists_multiset.mpr ⟨s, leadingCoeff_map i ▸ hs⟩
 
-theorem splits_of_splits_id {f : K[X]} (h : Splits (f.map (RingHom.id K))) : Splits (f.map i) := by
-  simpa using h.map i
+@[deprecated (since := "2025-11-30")]
+alias splits_of_splits_id := Splits.map
 
 end UFD
 

--- a/Mathlib/Analysis/Complex/Polynomial/Basic.lean
+++ b/Mathlib/Analysis/Complex/Polynomial/Basic.lean
@@ -130,7 +130,7 @@ theorem galActionHom_bijective_of_prime_degree {p : ℚ[X]} (p_irr : Irreducible
   classical
   have h1 : Fintype.card (p.rootSet ℂ) = p.natDegree := by
     simp_rw [rootSet_def, Finset.coe_sort_coe, Fintype.card_coe]
-    rw [Multiset.toFinset_card_of_nodup, ← natDegree_eq_card_roots]
+    rw [Multiset.toFinset_card_of_nodup, ← Splits.natDegree_eq_card_roots, natDegree_map]
     · exact IsAlgClosed.splits_codomain p
     · exact nodup_roots ((separable_map (algebraMap ℚ ℂ)).mpr p_irr.separable)
   let conj' := restrict p ℂ (Complex.conjAe.restrictScalars ℚ)

--- a/Mathlib/FieldTheory/AbelRuffini.lean
+++ b/Mathlib/FieldTheory/AbelRuffini.lean
@@ -113,7 +113,8 @@ theorem gal_X_pow_sub_C_isSolvable_aux (n : ℕ) (a : F)
   have hn''' : (X ^ n - 1 : F[X]) ≠ 0 := X_pow_sub_C_ne_zero hn' 1
   have mem_range : ∀ {c : (X ^ n - C a).SplittingField},
       (c ^ n = 1 → (∃ d, algebraMap F (X ^ n - C a).SplittingField d = c)) := fun {c} hc =>
-    RingHom.mem_range.mp (minpoly.mem_range_of_degree_eq_one F c (h.def.resolve_left hn'''
+    RingHom.mem_range.mp (minpoly.mem_range_of_degree_eq_one F c
+      ((splits_iff_splits.mp h).resolve_left (map_ne_zero hn''')
       (minpoly.irreducible ((SplittingField.instNormal (X ^ n - C a)).isIntegral c))
       (minpoly.dvd F c (by rwa [map_id, map_sub, sub_eq_zero, aeval_X_pow, aeval_one]))))
   apply isSolvable_of_comm

--- a/Mathlib/FieldTheory/AbelRuffini.lean
+++ b/Mathlib/FieldTheory/AbelRuffini.lean
@@ -154,7 +154,8 @@ theorem splits_X_pow_sub_one_of_X_pow_sub_C {F : Type*} [Field F] {E : Type*} [F
   let s := ((X ^ n - C a).map i).roots
   have hs : _ = _ * (s.map _).prod := h.eq_prod_roots
   rw [leadingCoeff_map, leadingCoeff_X_pow_sub_C hn', RingHom.map_one, C_1, one_mul] at hs
-  have hs' : Multiset.card s = n := (natDegree_eq_card_roots h).symm.trans natDegree_X_pow_sub_C
+  have hs' : Multiset.card s = n := by
+    rw [← h.natDegree_eq_card_roots, natDegree_map, natDegree_X_pow_sub_C]
   apply @splits_of_exists_multiset F E _ _ i (X ^ n - 1) (s.map fun c : E => c / b)
   rw [leadingCoeff_X_pow_sub_one hn', map_one, C_1, one_mul, Multiset.map_map]
   have C_mul_C : C (i a⁻¹) * C (i a) = 1 := by

--- a/Mathlib/FieldTheory/IsAlgClosed/AlgebraicClosure.lean
+++ b/Mathlib/FieldTheory/IsAlgClosed/AlgebraicClosure.lean
@@ -70,7 +70,8 @@ def finEquivRoots {K} [Field K] [DecidableEq K] {i : k →+* K} {f : Monics k}
 
 lemma Monics.splits_finsetProd {s : Finset (Monics k)} {f : Monics k} (hf : f ∈ s) :
     (f.1.map (algebraMap k (SplittingField (∏ f ∈ s, f.1)))).Splits :=
-  (splits_prod_iff _ fun j _ ↦ j.2.ne_zero).1 (SplittingField.splits _) _ hf
+  (splits_prod_iff fun j _ ↦ map_ne_zero j.2.ne_zero).mp
+    (by simpa [Polynomial.map_prod] using SplittingField.splits (∏ f ∈ s, f.1)) f hf
 
 open Classical in
 /-- Given a finite set of monic polynomials, construct an algebra homomorphism

--- a/Mathlib/FieldTheory/IsAlgClosed/Basic.lean
+++ b/Mathlib/FieldTheory/IsAlgClosed/Basic.lean
@@ -223,7 +223,7 @@ If `k` is algebraically closed, then every irreducible polynomial over `k` is li
 @[stacks 09GR "(4) ⟹ (2)"]
 theorem degree_eq_one_of_irreducible [IsAlgClosed k] {p : k[X]} (hp : Irreducible p) :
     p.degree = 1 :=
-  degree_eq_one_of_irreducible_of_splits hp (IsAlgClosed.splits_codomain _)
+  (IsAlgClosed.splits p).degree_eq_one_of_irreducible hp
 
 theorem algebraMap_bijective_of_isIntegral {k K : Type*} [Field k] [Ring K] [IsDomain K]
     [hk : IsAlgClosed k] [Algebra k K] [Algebra.IsIntegral k K] :

--- a/Mathlib/FieldTheory/IsSepClosed.lean
+++ b/Mathlib/FieldTheory/IsSepClosed.lean
@@ -195,7 +195,7 @@ theorem of_exists_root (H : ∀ p : k[X], p.Monic → Irreducible p → Separabl
 
 theorem degree_eq_one_of_irreducible [IsSepClosed k] {p : k[X]}
     (hp : Irreducible p) (hsep : p.Separable) : p.degree = 1 :=
-  degree_eq_one_of_irreducible_of_splits hp (IsSepClosed.splits_codomain p hsep)
+  (IsSepClosed.splits_of_separable p hsep).degree_eq_one_of_irreducible hp
 
 variable (K)
 

--- a/Mathlib/FieldTheory/Normal/Defs.lean
+++ b/Mathlib/FieldTheory/Normal/Defs.lean
@@ -131,7 +131,8 @@ def AlgHom.restrictNormalAux [h : Normal F E] :
       rw [← hx, ← hy]
       apply minpoly.mem_range_of_degree_eq_one E
       refine
-        Or.resolve_left (h.splits z).def (minpoly.ne_zero (h.isIntegral z)) (minpoly.irreducible ?_)
+        Or.resolve_left (splits_iff_splits.mp (h.splits z))
+          (map_ne_zero (minpoly.ne_zero (h.isIntegral z))) (minpoly.irreducible ?_)
           (minpoly.dvd E _ (by simp [aeval_algHom_apply]))
       simp only [AlgHom.toRingHom_eq_coe, AlgHom.coe_toRingHom]
       suffices IsIntegral F _ by exact this.tower_top

--- a/Mathlib/FieldTheory/PrimitiveElement.lean
+++ b/Mathlib/FieldTheory/PrimitiveElement.lean
@@ -143,8 +143,10 @@ theorem primitive_element_inf_aux [Algebra.IsSeparable F E] : ∃ γ : E, F⟮α
     · rw [eval_comp, eval_sub, eval_mul, eval_C, eval_C, eval_X, eval_map, ← aeval_def, ←
         Algebra.smul_def, add_sub_cancel_right, minpoly.aeval]
     · rw [eval_map, ← aeval_def, minpoly.aeval]
-  have h_splits : Splits (h.map ιEE') :=
-    splits_of_splits_gcd_right ιEE' map_g_ne_zero (SplittingField.splits _)
+  have h_splits : Splits (h.map ιEE') := by
+    rw [← Polynomial.gcd_map]
+    exact (SplittingField.splits _).splits_of_dvd (map_ne_zero map_g_ne_zero)
+      (EuclideanDomain.gcd_dvd_right _ _)
   have h_roots : ∀ x ∈ (h.map ιEE').roots, x = ιEE' β := by
     intro x hx
     rw [mem_roots_map h_ne_zero] at hx

--- a/Mathlib/FieldTheory/Separable.lean
+++ b/Mathlib/FieldTheory/Separable.lean
@@ -452,7 +452,8 @@ theorem card_rootSet_eq_natDegree [Algebra F K] {p : F[X]} (hsep : p.Separable)
     (hsplit : Splits (p.map (algebraMap F K))) : Fintype.card (p.rootSet K) = p.natDegree := by
   classical
   simp_rw [rootSet_def, Finset.coe_sort_coe, Fintype.card_coe]
-  rw [Multiset.toFinset_card_of_nodup (nodup_roots hsep.map), ← natDegree_eq_card_roots hsplit]
+  rw [Multiset.toFinset_card_of_nodup (nodup_roots hsep.map), ← hsplit.natDegree_eq_card_roots,
+    natDegree_map]
 
 /-- If a non-zero polynomial splits, then it has no repeated roots on that field
 if and only if it is separable. -/
@@ -476,7 +477,8 @@ theorem card_rootSet_eq_natDegree_iff_of_splits [Algebra F K] {f : F[X]} (hf : f
     (h : (f.map (algebraMap F K)).Splits) :
     Fintype.card (f.rootSet K) = f.natDegree ↔ f.Separable := by
   classical
-  simp_rw [rootSet_def, Finset.coe_sort_coe, Fintype.card_coe, natDegree_eq_card_roots h,
+  simp_rw [rootSet_def, Finset.coe_sort_coe, Fintype.card_coe,
+    ← natDegree_map (algebraMap F K), h.natDegree_eq_card_roots,
     Multiset.toFinset_card_eq_card_iff_nodup, nodup_aroots_iff_of_splits hf h]
 
 variable {i : F →+* K}
@@ -769,7 +771,8 @@ theorem AlgHom.natCard_of_powerBasis (pb : PowerBasis K S) (h_sep : IsSeparable 
     Nat.card (S →ₐ[K] L) = pb.dim := by
   classical
   rw [Nat.card_congr pb.liftEquiv', Nat.subtype_card _ (fun x => Multiset.mem_toFinset),
-    ← pb.natDegree_minpoly, natDegree_eq_card_roots h_splits, Multiset.toFinset_card_of_nodup]
+    ← pb.natDegree_minpoly, ← natDegree_map (algebraMap K L), h_splits.natDegree_eq_card_roots,
+    Multiset.toFinset_card_of_nodup]
   exact nodup_roots ((separable_map (algebraMap K L)).mpr h_sep)
 
 theorem AlgHom.card_of_powerBasis (pb : PowerBasis K S) (h_sep : IsSeparable K pb.gen)


### PR DESCRIPTION
This PR continues the deprecation in `Splits.lean` as we move over to the new API in `Factors.lean`.

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

When merging, all the commits will be squashed into a single commit
listing all co-authors.

Co-authors in the squash commit are gathered from two sources:

First, all authors of commits to this PR branch are included. Thus,
one way to add co-authors is to include at least one commit authored by
each co-author among the commits in the pull request. If necessary, you
may create empty commits to indicate co-authorship, using commands like so:

git commit --author="Author Name <author@email.com>" --allow-empty -m "add Author Name as coauthor"

Second, co-authors can also be listed in lines at the very bottom of
the commit message (that is, directly before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines
at the bottom of the commit message (before the `---`, and also before
any "Co-authored-by" lines) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
