### PR TITLE
[Merged by Bors] - doc(GroupTheory/GroupAction/SubMulAction/OfStabilizer): fix documentation and add missing

### DIFF
--- a/Mathlib/GroupTheory/GroupAction/MultipleTransitivity.lean
+++ b/Mathlib/GroupTheory/GroupAction/MultipleTransitivity.lean
@@ -33,6 +33,20 @@ public import Mathlib.SetTheory.Cardinal.Arithmetic
   If an action is `n`-pretransitive, then it is `m`-pretransitive for all `m ≤ n`,
   provided `α` has at least `n` elements.
 
+## Results for `SubMulAction`.
+
+* `SubMulAction.ofStabilizer.isPretransitive_iff_conj` shows
+  that for `a`, `b` and `g` such that `g • a = b`, the actions
+  of `stabilizer G a` and of `stabilizer G b` are equivalently `n`-pretransitive for all `n : ℕ`.
+
+* `SubMulAction.ofStabilizer.isMultiplyPretransitive_iff_conj hg` shows the
+  same result for `n`-transitivity.
+
+
+* `SubMulAction.ofStabilizer.isMultiplyPretransitive_iff` : is the action of `G` on `α`
+  is pretransitive, then it is `n.succ` pretransitive if and only if
+  the action of `stabilizer G a` on `ofStabilizer G a` is `n`-pretransitive.
+
 ## Results for permutation groups
 
 * The permutation group is pretransitive, is multiply pretransitive,
@@ -307,6 +321,19 @@ namespace SubMulAction.ofStabilizer
 variable {G α : Type*} [Group G] [MulAction G α]
 
 open scoped BigOperators Pointwise Cardinal
+
+@[to_additive]
+theorem isPretransitive_iff_of_conj {a b : α} {g : G} (hg : b = g • a) :
+    IsPretransitive (stabilizer G a) (ofStabilizer G a) ↔
+      IsPretransitive (stabilizer G b) (ofStabilizer G b) :=
+  isPretransitive_congr (MulEquiv.surjective _) (ofStabilizer.conjMap_bijective hg)
+
+@[to_additive]
+theorem isPretransitive_iff [IsPretransitive G α] {a b : α} :
+    IsPretransitive (stabilizer G a) (ofStabilizer G a) ↔
+      IsPretransitive (stabilizer G b) (ofStabilizer G b) :=
+  let ⟨_, hg⟩ := exists_smul_eq G a b
+  isPretransitive_iff_of_conj hg.symm
 
 @[to_additive]
 theorem isMultiplyPretransitive_iff_of_conj

--- a/Mathlib/GroupTheory/GroupAction/SubMulAction/OfFixingSubgroup.lean
+++ b/Mathlib/GroupTheory/GroupAction/SubMulAction/OfFixingSubgroup.lean
@@ -14,27 +14,29 @@ public import Mathlib.Tactic.Group
 /-!
 # SubMulActions on complements of invariant subsets
 
-- We define `SubMulAction` of an invariant subset in various contexts,
-especially stabilizers and fixing subgroups : `SubMulAction_of_compl`,
-`SubMulAction_of_stabilizer`, `SubMulAction_of_fixingSubgroup`.
+Given a `MulAction` of `G` on `α` and `s : Set α`,
+
+* `SubMulAction.ofFixingSubgroup` is the action
+  of `FixingSubgroup G s` on the complement `sᶜ` of `s`.
 
 - We define equivariant maps that relate various of these `SubMulAction`s
 and permit to manipulate them in a relatively smooth way:
 
-  * `SubMulAction.ofFixingSubgroupEmpty_equivariantMap`:
-  the identity map, when the set is the empty set.
+  * `SubMulAction.ofFixingSubgroup_equivariantMap`:
+  the identity map from `sᶜ` to `α`, as an equivariant map
+  relative to the injection of `FixingSubgroup G s` into `G`.
 
   * `SubMulAction.fixingSubgroupInsertEquiv M a s` : the
   multiplicative equivalence between `fixingSubgroup M (insert a s)`
   and `fixingSubgroup (stabilizer M a) s`
 
   * `SubMulAction.ofFixingSubgroup_insert_map` : the equivariant
-  map between `SubMulAction.ofFixingSubgroup M (insert a s)`
-  and `SubMulAction.ofFixingSubgroup (stabilizer M a) s`.
+  map between `SubMulAction.ofFixingSubgroup M (Set.insert a s)`
+  and `SubMulAction.ofFixingSubgroup (MulAction.stabilizer M a) s`.
 
   * `SubMulAction.fixingSubgroupEquivFixingSubgroup`:
-  the multiplicative equivalence between `SubMulAction.fixingSubgroup M s`
-  and `SubMulAction.fixingSubgroup M t` induced by `g : M`
+  the multiplicative equivalence between `SubMulAction.ofFixingSubgroup M s`
+  and `SubMulAction.ofFixingSubgroup M t` induced by `g : M`
   such that `g • t = s`.
 
   * `SubMulAction.conjMap_ofFixingSubgroup`:

--- a/Mathlib/GroupTheory/GroupAction/SubMulAction/OfStabilizer.lean
+++ b/Mathlib/GroupTheory/GroupAction/SubMulAction/OfStabilizer.lean
@@ -28,7 +28,7 @@ and permit to manipulate them in a relatively smooth way.
 
 * `SubMulAction.ofStabilizer a` : the action of `stabilizer G a` on `{a}ᶜ`
 
-* `SubMulAction.Enat_card_ofStabilizer_eq_add_one` and `SubMulAction.nat_card_ofStabilizer_eq`
+* `SubMulAction.ENat_card_ofStabilizer_add_one_eq` and `SubMulAction.nat_card_ofStabilizer_eq`
   compute the cardinality of the `carrier` of that action.
 
 Consider `a b : α` and `g : G` such that `hg : g • b = a`.

--- a/Mathlib/GroupTheory/GroupAction/SubMulAction/OfStabilizer.lean
+++ b/Mathlib/GroupTheory/GroupAction/SubMulAction/OfStabilizer.lean
@@ -16,34 +16,27 @@ public import Mathlib.Data.Fin.Tuple.Embedding
 When a group `G` acts on a type `α`, the stabilizer of a point `a : α`
 acts naturally on the complement of that point.
 
-Such actions (as the similar one for the fixator of a set acting on the complement
-of that set, defined in `Mathlib.GroupTheory.GroupAction.SubMulAction.OfFixingSubgroup`)
+Such actions
+(as the similar one, `SubMulAction.ofFixingSubgroup`,
+for the fixing subgroup of a set acting on the complement of that set)
 are useful to study the multiple transitivity of the group `G`,
 since `n`-transitivity of `G` on `α` is equivalent to `n - 1`-transitivity
-of `stabilizer G a` on the complement of `a`.
+of `MulAction.stabilizer G a` on the complement of `a`.
 
-We define equivariant maps that relate various of these sub_mul_actions
+We define equivariant maps that relate various of these `SubMulAction`s
 and permit to manipulate them in a relatively smooth way.
 
 * `SubMulAction.ofStabilizer a` : the action of `stabilizer G a` on `{a}ᶜ`
 
-* `SubMulAction.Enat_card_ofStabilizer_eq_add_one`, `SubMulAction.nat_card_ofStabilizer_eq`
+* `SubMulAction.Enat_card_ofStabilizer_eq_add_one` and `SubMulAction.nat_card_ofStabilizer_eq`
   compute the cardinality of the `carrier` of that action.
 
 Consider `a b : α` and `g : G` such that `hg : g • b = a`.
 
-* `SubMulAction.conjMap hg` is the equivariant map
+* `SubMulAction.ofStabilizer.conjMap hg` is the equivariant map
   from `SubMulAction.ofStabilizer G a` to `SubMulAction.ofStabilizer G b`.
-* `SubMulAction.ofStabilizer.isPretransitive_iff_conj hg` shows
-  that this actions are equivalently pretransitive or
-* `SubMulAction.ofStabilizer.isMultiplyPretransitive_iff_conj hg` shows
-  that this actions are equivalently `n`-pretransitive for all `n : ℕ`.
-* `SubMulAction.ofStabilizer.append` : given `x : Fin n ↪ ofStabilizer G a`,
+* `SubMulAction.ofStabilizer.snoc` : given `x : Fin n ↪ ofStabilizer G a`,
   append `a` to obtain `y : Fin n.succ ↪ α`
-* `SubMulAction.ofStabilizer.isMultiplyPretransitive_iff` : is the action of `G` on `α`
-  is pretransitive, then it is `n.succ` pretransitive if and only if
-  the action of `stabilizer G a` on `ofStabilizer G a` is `n`-pretransitive.
-
 -/
 
 @[expose] public section


### PR DESCRIPTION
As noticed by @harahu , the documentation of `GroupTheory.GroupAction.SubMulAction.OfStabilizer` was not fully aligned with the definitions in the file, one lemma was actually missing, another one was in another file.

We fix that.

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

When merging, all the commits will be squashed into a single commit
listing all co-authors.

Co-authors in the squash commit are gathered from two sources:

First, all authors of commits to this PR branch are included. Thus,
one way to add co-authors is to include at least one commit authored by
each co-author among the commits in the pull request. If necessary, you
may create empty commits to indicate co-authorship, using commands like so:

git commit --author="Author Name <author@email.com>" --allow-empty -m "add Author Name as coauthor"

Second, co-authors can also be listed in lines at the very bottom of
the commit message (that is, directly before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines
at the bottom of the commit message (before the `---`, and also before
any "Co-authored-by" lines) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
