### PR TITLE
[Merged by Bors] - doc: fix latex formatting

### DIFF
--- a/Mathlib/Algebra/Category/FGModuleCat/EssentiallySmall.lean
+++ b/Mathlib/Algebra/Category/FGModuleCat/EssentiallySmall.lean
@@ -40,7 +40,7 @@ variable (M : Type v) [AddCommGroup M] [Module R M] [Module.Finite R M]
 
 variable {R} in
 /-- The finite module represented by an object of the type `FGModuleRepr R`, which is the quotient
-of `Fin n → R` (i.e. $$R^n$$) by the submodule `S` provided. -/
+of `Fin n → R` (i.e. `Rⁿ`) by the submodule `S` provided. -/
 def repr (x : FGModuleRepr R) : Type u :=
   _ ⧸ x.S
 
@@ -56,7 +56,7 @@ instance (x : FGModuleRepr R) : Module R x := by
 instance (x : FGModuleRepr R) : Module.Finite R x := by
   unfold repr; infer_instance
 
-/-- A non-canonical representation of a finite module (as a quotient of $$R^n$$). -/
+/-- A non-canonical representation of a finite module (as a quotient of `Rⁿ`). -/
 noncomputable def ofFinite : FGModuleRepr R where
   n := (Module.Finite.exists_fin_quot_equiv R M).choose
   S := (Module.Finite.exists_fin_quot_equiv R M).choose_spec.choose

--- a/Mathlib/Analysis/Calculus/DifferentialForm/Basic.lean
+++ b/Mathlib/Analysis/Calculus/DifferentialForm/Basic.lean
@@ -29,7 +29,7 @@ $$
 dω(x; v_0, \dots, v_n) = \sum_{i=0}^n (-1)^i D_x ω(x; v_0, \dots, \widehat{v_i}, \dots, v_n) · v_i
 $$
 
-where $$\widehat{v_i}$$ means that we omit this element of the tuple, see `extDeriv_apply`.
+where $\widehat{v_i}$ means that we omit this element of the tuple, see `extDeriv_apply`.
 
 ## TODO
 
@@ -68,7 +68,7 @@ $$
 dω(x; v_0, \dots, v_n) = \sum_{i=0}^n (-1)^i D_x ω(x; v_0, \dots, \widehat{v_i}, \dots, v_n) · v_i
 $$
 
-where $$\widehat{v_i}$$ means that we omit this element of the tuple, see `extDeriv_apply`.
+where $\widehat{v_i}$ means that we omit this element of the tuple, see `extDeriv_apply`.
 -/
 noncomputable def extDeriv (ω : E → E [⋀^Fin n]→L[𝕜] F) (x : E) : E [⋀^Fin (n + 1)]→L[𝕜] F :=
   .alternatizeUncurryFin (fderiv 𝕜 ω x)
@@ -83,7 +83,7 @@ $$
 dω(x; v_0, \dots, v_n) = \sum_{i=0}^n (-1)^i D_x ω(x; v_0, \dots, \widehat{v_i}, \dots, v_n) · v_i
 $$
 
-where $$\widehat{v_i}$$ means that we omit this element of the tuple, see `extDerivWithin_apply`.
+where $\widehat{v_i}$ means that we omit this element of the tuple, see `extDerivWithin_apply`.
 -/
 noncomputable def extDerivWithin (ω : E → E [⋀^Fin n]→L[𝕜] F) (s : Set E) (x : E) :
     E [⋀^Fin (n + 1)]→L[𝕜] F :=

--- a/Mathlib/Analysis/Calculus/Implicit.lean
+++ b/Mathlib/Analysis/Calculus/Implicit.lean
@@ -74,9 +74,7 @@ Consider two functions `f : E → F` and `g : E → G` and a point `a` such that
 Note that the map `x ↦ (f x, g x)` has a bijective derivative, hence it is an open partial
 homeomorphism between `E` and `F × G`. We use this fact to define a function `φ : F → G → E`
 (see `ImplicitFunctionData.implicitFunction`) such that for `(y, z)` close enough to `(f a, g a)`
-we have `f (φ y z) = y` and `g (φ y z) = z`.
-
-We also prove a formula for $$\frac{\partial\varphi}{\partial z}.$$
+we have `f (φ y z) = y` and `g (φ y z) = z`. We also prove a formula for `∂φ / ∂z`.
 
 Though this statement is almost symmetric with respect to `F`, `G`, we interpret it in the following
 way. Consider a family of surfaces `{x | f x = y}`, `y ∈ 𝓝 (f a)`. Each of these surfaces is

--- a/Mathlib/Analysis/Calculus/Taylor.lean
+++ b/Mathlib/Analysis/Calculus/Taylor.lean
@@ -316,7 +316,8 @@ set_option linter.unusedSimpArgs false in
 
 We assume that `f` is `n+1`-times continuously differentiable in the closed set `Icc x₀ x` and
 `n+1`-times differentiable on the open set `Ioo x₀ x`. Then there exists an `x' ∈ Ioo x₀ x` such
-that $$f(x) - (P_n f)(x₀, x) = \frac{f^{(n+1)}(x') (x - x₀)^{n+1}}{(n+1)!},$$
+that
+$$f(x) - (P_n f)(x₀, x) = \frac{f^{(n+1)}(x') (x - x₀)^{n+1}}{(n+1)!},$$
 where $P_n f$ denotes the Taylor polynomial of degree $n$ and $f^{(n+1)}$ is the $n+1$-th iterated
 derivative. -/
 theorem taylor_mean_remainder_lagrange {f : ℝ → ℝ} {x x₀ : ℝ} {n : ℕ} (hx : x₀ < x)
@@ -361,7 +362,8 @@ lemma taylor_mean_remainder_lagrange_iteratedDeriv {f : ℝ → ℝ} {x x₀ : �
 
 We assume that `f` is `n+1`-times continuously differentiable on the closed set `Icc x₀ x` and
 `n+1`-times differentiable on the open set `Ioo x₀ x`. Then there exists an `x' ∈ Ioo x₀ x` such
-that $$f(x) - (P_n f)(x₀, x) = \frac{f^{(n+1)}(x') (x - x')^n (x-x₀)}{n!},$$
+that
+$$f(x) - (P_n f)(x₀, x) = \frac{f^{(n+1)}(x') (x - x')^n (x-x₀)}{n!},$$
 where $P_n f$ denotes the Taylor polynomial of degree $n$ and $f^{(n+1)}$ is the $n+1$-th iterated
 derivative. -/
 theorem taylor_mean_remainder_cauchy {f : ℝ → ℝ} {x x₀ : ℝ} {n : ℕ} (hx : x₀ < x)

--- a/Mathlib/Analysis/Distribution/SchwartzSpace.lean
+++ b/Mathlib/Analysis/Distribution/SchwartzSpace.lean
@@ -20,8 +20,8 @@ public import Mathlib.MeasureTheory.Function.L2Space
 # Schwartz space
 
 This file defines the Schwartz space. Usually, the Schwartz space is defined as the set of smooth
-functions $f : ℝ^n → ℂ$ such that there exists $C_{αβ} > 0$ with $$|x^α ∂^β f(x)| < C_{αβ}$$ for
-all $x ∈ ℝ^n$ and for all multiindices $α, β$.
+functions `f : ℝ^n → ℂ` such that there exists `C_{αβ} > 0` with `|x^α ∂^β f(x)| < C_{αβ}` for
+all `x ∈ ℝ^n` and for all multiindices `α`, `β`.
 In mathlib, we use a slightly different approach and define the Schwartz space as all
 smooth functions `f : E → F`, where `E` and `F` are real normed vector spaces such that for all
 natural numbers `k` and `n` we have uniform bounds `‖x‖^k * ‖iteratedFDeriv ℝ n f x‖ < C`.

--- a/Mathlib/Analysis/Normed/Module/Alternating/Uncurry/Fin.lean
+++ b/Mathlib/Analysis/Normed/Module/Alternating/Uncurry/Fin.lean
@@ -176,7 +176,7 @@ f(v_j, v_i; v_0, \dots, \hat{v_i}, \dots, \hat{v_j}, \dots, v_{n+1})
 $$
 
 over all `(i j : Fin (n + 2))`, `i < j`, taken with appropriate signs.
-Here $$\hat{v_i}$$ and $$\hat{v_j}$$ mean that these vectors are removed from the tuple.
+Here $\hat{v_i}$ and $\hat{v_j}$ mean that these vectors are removed from the tuple.
 
 We use pairs of `i j : Fin (n + 1)`, `i ≤ j`,
 to encode pairs `(i.castSucc : Fin (n + 2), j.succ : Fin (n + 2))`,

--- a/Mathlib/Analysis/Normed/Operator/Mul.lean
+++ b/Mathlib/Analysis/Normed/Operator/Mul.lean
@@ -101,7 +101,7 @@ theorem opNorm_mulLeftRight_le :
 representation of the algebra on itself is isometric. Every unital normed algebra with `‖1‖ = 1` is
 a regular normed algebra (see `NormedAlgebra.instRegularNormedAlgebra`). In addition, so is every
 C⋆-algebra, non-unital included (see `CStarRing.instRegularNormedAlgebra`), but there are yet other
-examples. Any algebra with an approximate identity (e.g., $$L^1$$) is also regular.
+examples. Any algebra with an approximate identity (e.g., `L¹`) is also regular.
 
 This is a useful class because it gives rise to a nice norm on the unitization; in particular it is
 a C⋆-norm when the norm on `A` is a C⋆-norm. -/

--- a/Mathlib/Analysis/ODE/Gronwall.lean
+++ b/Mathlib/Analysis/ODE/Gronwall.lean
@@ -230,7 +230,7 @@ theorem dist_le_of_trajectories_ODE
   dist_le_of_trajectories_ODE_of_mem (fun t _ => (hv t).lipschitzOnWith) hf hf' hfs hg
     hg' (fun _ _ => trivial) ha
 
-/-- There exists only one solution of an ODE \(\dot x=v(t, x)\) in a set `s ⊆ ℝ × E` with
+/-- There exists only one solution of an ODE $\dot x=v(t, x)$ in a set `s ⊆ ℝ × E` with
 a given initial value provided that the RHS is Lipschitz continuous in `x` within `s`,
 and we consider only solutions included in `s`.
 
@@ -364,7 +364,7 @@ theorem ODE_solution_unique_of_eventually
     (Real.ball_eq_Ioo t₀ ε ▸ mem_ball_self hε)
     (fun _ ht ↦ (h _ ht).2.1) (fun _ ht ↦ (h _ ht).2.2) heq
 
-/-- There exists only one solution of an ODE \(\dot x=v(t, x)\) with
+/-- There exists only one solution of an ODE $\dot x=v(t, x)$ with
 a given initial value provided that the RHS is Lipschitz continuous in `x`. -/
 theorem ODE_solution_unique
     (hv : ∀ t, LipschitzWith K (v t))
@@ -378,7 +378,7 @@ theorem ODE_solution_unique
   ODE_solution_unique_of_mem_Icc_right (fun t _ => (hv t).lipschitzOnWith) hf hf' hfs hg hg'
     (fun _ _ => trivial) ha
 
-/-- There exists only one global solution to an ODE \(\dot x=v(t, x\) with a given initial value
+/-- There exists only one global solution to an ODE $\dot x=v(t, x)$ with a given initial value
 provided that the RHS is Lipschitz continuous. -/
 theorem ODE_solution_unique_univ
     (hv : ∀ t, LipschitzOnWith K (v t) (s t))

--- a/Mathlib/Analysis/Real/Pi/Chudnovsky.lean
+++ b/Mathlib/Analysis/Real/Pi/Chudnovsky.lean
@@ -26,7 +26,7 @@ but at present we are a long way off.
 * Prove the sum equals `π⁻¹`, as stated using `proof_wanted` below.
 * Show that each imaginary quadratic field of class number 1 (corresponding to Heegner numbers)
   gives a Ramanujan type formula, and that this is the formula coming from 163,
-  with $$j(\frac{1+\sqrt{-163}}{2}) = -640320^3$$, and the other magic constants coming from
+  with `j ((1 + √-163) / 2) = -640320^3`, and the other magic constants coming from
   Eisenstein series.
 
 ## References

--- a/Mathlib/Analysis/SpecialFunctions/OrdinaryHypergeometric.lean
+++ b/Mathlib/Analysis/SpecialFunctions/OrdinaryHypergeometric.lean
@@ -12,7 +12,8 @@ public import Mathlib.Analysis.RCLike.Basic
 # Ordinary hypergeometric function in a Banach algebra
 
 In this file, we define `ordinaryHypergeometric`, the _ordinary_ or _Gaussian_ hypergeometric
-function in a topological algebra `𝔸` over a field `𝕂` given by: $$
+function in a topological algebra `𝔸` over a field `𝕂` given by:
+$$
 _2\mathrm{F}_1(a\ b\ c : \mathbb{K}, x : \mathbb{A}) = \sum_{n=0}^{\infty}\frac{(a)_n(b)_n}{(c)_n}
 \frac{x^n}{n!}   \,,
 $$

--- a/Mathlib/CategoryTheory/InducedCategory.lean
+++ b/Mathlib/CategoryTheory/InducedCategory.lean
@@ -13,7 +13,7 @@ public import Mathlib.CategoryTheory.Functor.FullyFaithful
 Given a category `D` and a function `F : C → D` from a type `C` to the
 objects of `D`, there is an essentially unique way to give `C` a
 category structure such that `F` becomes a fully faithful functor,
-namely by taking $$ Hom_C(X, Y) = Hom_D(FX, FY) $$. We call this the
+namely by taking $ Hom_C(X, Y) = Hom_D(FX, FY) $. We call this the
 category induced from `D` along `F`.
 
 ## Implementation notes

--- a/Mathlib/CategoryTheory/Sites/Descent/IsPrestack.lean
+++ b/Mathlib/CategoryTheory/Sites/Descent/IsPrestack.lean
@@ -123,7 +123,7 @@ variable (F) {S : C} (M N : F.obj (.mk (op S)))
 /-- If `F` is a pseudofunctor from `Cᵒᵖ` to `Cat`, and `M` and `N` are objects in
 `F.obj (.mk (op S))`, this is the presheaf of morphisms from `M` to `N`: it sends
 an object `T : Over S` corresponding to a morphism `p : X ⟶ S` to the type
-of morphisms $$p^* M ⟶ p^* N$$. -/
+of morphisms $p^* M ⟶ p^* N$. -/
 @[simps]
 def presheafHom : (Over S)ᵒᵖ ⥤ Type v' where
   obj T := (F.map (.toLoc T.unop.hom.op)).obj M ⟶ (F.map (.toLoc T.unop.hom.op)).obj N
@@ -160,7 +160,7 @@ class IsPrestack (J : GrothendieckTopology C) : Prop where
 /-- If `F` is a prestack from `Cᵒᵖ` to `Cat` relatively to a Grothendieck topology `J`,
 and `M` and `N` are two objects in `F.obj (.mk (op S))`, this is the sheaf of
 morphisms from `M` to `N`: it sends an object `T : Over S` corresponding to
-a morphism `p : X ⟶ S` to the type of morphisms $$p^* M ⟶ p^* N$$. -/
+a morphism `p : X ⟶ S` to the type of morphisms $p^* M ⟶ p^* N$. -/
 @[simps]
 def sheafHom (J : GrothendieckTopology C) [F.IsPrestack J]
     {S : C} (M N : F.obj (.mk (op S))) :

--- a/Mathlib/Combinatorics/Additive/CauchyDavenport.lean
+++ b/Mathlib/Combinatorics/Additive/CauchyDavenport.lean
@@ -195,9 +195,9 @@ lemma cauchy_davenport_of_isMulTorsionFree [DecidableEq G] [Group G] [IsMulTorsi
 @[to_additive (attr := deprecated cauchy_davenport_of_isMulTorsionFree (since := "2025-04-23"))]
 alias cauchy_davenport_mul_of_isTorsionFree := cauchy_davenport_of_isMulTorsionFree
 
-/-! ### $$ℤ/nℤ$$ -/
+/-! ### $ℤ/nℤ$ -/
 
-/-- The **Cauchy-Davenport Theorem**. If `s`, `t` are nonempty sets in $$ℤ/pℤ$$, then the size of
+/-- The **Cauchy-Davenport Theorem**. If `s`, `t` are nonempty sets in `ℤ/pℤ`, then the size of
 `s + t` is lower-bounded by `|s| + |t| - 1`, unless this quantity is greater than `p`. -/
 lemma ZMod.cauchy_davenport {p : ℕ} (hp : p.Prime) {s t : Finset (ZMod p)} (hs : s.Nonempty)
     (ht : t.Nonempty) : min p (#s + #t - 1) ≤ #(s + t) := by

--- a/Mathlib/GroupTheory/CosetCover.lean
+++ b/Mathlib/GroupTheory/CosetCover.lean
@@ -12,7 +12,8 @@ public import Mathlib.LinearAlgebra.Basis.VectorSpace
 /-! # Lemma of B. H. Neumann on coverings of a group by cosets.
 
 Let the group $G$ be the union of finitely many, let us say $n$, left cosets
-of subgroups $C₁$, $C₂$, ..., $Cₙ$: $$ G = ⋃_{i = 1}^n C_i g_i. $$
+of subgroups $C₁$, $C₂$, ..., $Cₙ$:
+$$ G = ⋃_{i = 1}^n C_i g_i. $$
 
 * `Subgroup.exists_finiteIndex_of_leftCoset_cover`
   at least one subgroup $C_i$ has finite index in $G$.

--- a/Mathlib/GroupTheory/GroupAction/DomAct/Basic.lean
+++ b/Mathlib/GroupTheory/GroupAction/DomAct/Basic.lean
@@ -19,7 +19,7 @@ By default, `M` acts on `α → β` if it acts on `β`, and the action is given 
 
 In some cases, it is useful to consider another action: if `M` acts on `α` on the left, then it acts
 on `α → β` on the right so that `(c • f) a = f (c • a)`. E.g., this action is used to reformulate
-the Mean Ergodic Theorem in terms of an operator on \(L^2\).
+the Mean Ergodic Theorem in terms of an operator on `L²`.
 
 ## Main definitions
 

--- a/Mathlib/GroupTheory/Order/Min.lean
+++ b/Mathlib/GroupTheory/Order/Min.lean
@@ -18,7 +18,7 @@ This file defines the minimum order of an element of a monoid.
 
 * `Monoid.minOrder`: The minimum order of an element of a given monoid.
 * `Monoid.minOrder_eq_top`: The minimum order is infinite iff the monoid is torsion-free.
-* `ZMod.minOrder`: The minimum order of $$ℤ/nℤ$$ is the smallest factor of `n`, unless `n = 0, 1`.
+* `ZMod.minOrder`: The minimum order of $ℤ/nℤ$ is the smallest factor of `n`, unless `n = 0, 1`.
 -/
 
 @[expose] public section

--- a/Mathlib/LinearAlgebra/Alternating/Uncurry/Fin.lean
+++ b/Mathlib/LinearAlgebra/Alternating/Uncurry/Fin.lean
@@ -173,7 +173,7 @@ f(v_j, v_i; v_0, \dots, \hat{v_i}, \dots, \hat{v_j}-)
 $$
 
 over all `(i j : Fin (n + 2))`, `i < j`, taken with appropriate signs.
-Here $$\hat{v_i}$$ and $$\hat{v_j}$$ mean that these vectors are removed from the tuple.
+Here $\hat{v_i}$$ and $\hat{v_j}$$ mean that these vectors are removed from the tuple.
 
 We use pairs of `i j : Fin (n + 1)`, `i ≤ j`,
 to encode pairs `(i.castSucc : Fin (n + 2), j.succ : Fin (n + 2))`,

--- a/Mathlib/MeasureTheory/Integral/CurveIntegral/Poincare.lean
+++ b/Mathlib/MeasureTheory/Integral/CurveIntegral/Poincare.lean
@@ -225,7 +225,7 @@ private theorem curveIntegral_add_curveIntegral_eq_of_hasFDerivWithinAt_off_coun
 /-- The curve integral of a closed 1-form along the boundary of the image of a unit square
 under a smooth map is zero. We may ignore the behavior on a countable set.
 
-This theorem is stated in terms of a $$C^2$$ homotopy between two paths. -/
+This theorem is stated in terms of a `C^2` homotopy between two paths. -/
 theorem curveIntegral_add_curveIntegral_eq_of_hasFDerivWithinAt_off_countable
     {ω : E → E →L[𝕜] F} {dω : E → E →L[ℝ] E →L[𝕜] F}
     (φ : (γ₁ : C(I, E)).Homotopy γ₂)
@@ -250,7 +250,7 @@ theorem curveIntegral_add_curveIntegral_eq_of_hasFDerivWithinAt_off_countable
 /-- The curve integral of a closed 1-form along the boundary of the image of a unit square
 under a smooth map is zero.
 
-This theorem is stated in terms of a $$C^2$$ homotopy between two paths. -/
+This theorem is stated in terms of a `C^2` homotopy between two paths. -/
 theorem curveIntegral_add_curveIntegral_eq_of_hasFDerivWithinAt
     {ω : E → E →L[𝕜] F} {dω : E → E →L[ℝ] E →L[𝕜] F}
     (φ : (γ₁ : C(I, E)).Homotopy γ₂)
@@ -268,7 +268,7 @@ theorem curveIntegral_add_curveIntegral_eq_of_hasFDerivWithinAt
 /-- The curve integral of a closed 1-form along the boundary of the image of a unit square
 under a smooth map is zero, a version stated in terms of `DiffContOnC1`.
 
-This theorem is stated in terms of a $$C^2$$ homotopy between two paths. -/
+This theorem is stated in terms of a `C^2` homotopy between two paths. -/
 theorem curveIntegral_add_curveIntegral_eq_of_diffContOnCl
     {ω : E → E →L[𝕜] F} (φ : (γ₁ : C(I, E)).Homotopy γ₂)
     (hφt : ∀ a ∈ Ioo 0 1, ∀ b ∈ Ioo 0 1, φ (a, b) ∈ t)

--- a/Mathlib/NumberTheory/ArithmeticFunction.lean
+++ b/Mathlib/NumberTheory/ArithmeticFunction.lean
@@ -58,7 +58,7 @@ This notation is scpoed to the separate locales `ArithmeticFunction.zeta` for `�
 `ArithmeticFunction.Omega` for `Ω`, and `ArithmeticFunction.Moebius` for `μ`,
 to allow for selective access.
 
-The arithmetic function $$n \mapsto \prod_{p \mid n} f(p)$$ is given custom notation
+The arithmetic function $n \mapsto \prod_{p \mid n} f(p)$ is given custom notation
 `∏ᵖ p ∣ n, f p` when applied to `n`.
 
 ## Tags

--- a/Mathlib/NumberTheory/Bernoulli.lean
+++ b/Mathlib/NumberTheory/Bernoulli.lean
@@ -327,7 +327,8 @@ theorem sum_range_pow (n p : ℕ) :
   simp [field, factorial]
 
 /-- Alternate form of **Faulhaber's theorem**, relating the sum of p-th powers to the Bernoulli
-numbers: $$\sum_{k=1}^{n} k^p = \sum_{i=0}^p (-1)^iB_i\binom{p+1}{i}\frac{n^{p+1-i}}{p+1}.$$
+numbers:
+$$\sum_{k=1}^{n} k^p = \sum_{i=0}^p (-1)^iB_i\binom{p+1}{i}\frac{n^{p+1-i}}{p+1}.$$
 Deduced from `sum_range_pow`. -/
 theorem sum_Ico_pow (n p : ℕ) :
     (∑ k ∈ Ico 1 (n + 1), (k : ℚ) ^ p) =

--- a/Mathlib/NumberTheory/BernoulliPolynomials.lean
+++ b/Mathlib/NumberTheory/BernoulliPolynomials.lean
@@ -36,7 +36,7 @@ Bernoulli polynomials are defined using `bernoulli`, the Bernoulli numbers.
 
 ## TODO
 
-- `bernoulli_eval_one_neg` : $$ B_n(1 - x) = (-1)^n B_n(x) $$
+- `bernoulli_eval_one_neg` : $ B_n(1 - x) = (-1)^n B_n(x) $
 
 -/
 


### PR DESCRIPTION
Lots of docstrings use either `\( ... \)` or `$$ ... $$` for inline formulae; convert these to unicode math where possible, and otherwise to `$ ... $`.

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

When merging, all the commits will be squashed into a single commit
listing all co-authors.

Co-authors in the squash commit are gathered from two sources:

First, all authors of commits to this PR branch are included. Thus,
one way to add co-authors is to include at least one commit authored by
each co-author among the commits in the pull request. If necessary, you
may create empty commits to indicate co-authorship, using commands like so:

git commit --author="Author Name <author@email.com>" --allow-empty -m "add Author Name as coauthor"

Second, co-authors can also be listed in lines at the very bottom of
the commit message (that is, directly before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines
at the bottom of the commit message (before the `---`, and also before
any "Co-authored-by" lines) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
