### PR TITLE
[Merged by Bors] - feat(Geometry/Convex/Cone): define and characterize generating convex cone

### DIFF
--- a/Mathlib/Geometry/Convex/Cone/Basic.lean
+++ b/Mathlib/Geometry/Convex/Cone/Basic.lean
@@ -392,7 +392,7 @@ See `IsReproducing.isGenerating` and `IsGenerating.isReproducing` for details. -
   Submodule.span R (C : Set M) = ⊤
 
 /-- The whole `R`-module `M` (viewed as the top convex cone) is generating. -/
-@[simp] theorem isGenerating_top : (⊤ : ConvexCone R M).IsGenerating := by
+theorem isGenerating_top : (⊤ : ConvexCone R M).IsGenerating := by
   simp
 
 /-- A convex cone containing a generating cone is also a generating cone. -/

--- a/Mathlib/Geometry/Convex/Cone/Basic.lean
+++ b/Mathlib/Geometry/Convex/Cone/Basic.lean
@@ -391,6 +391,22 @@ See `IsReproducing.isGenerating` and `IsGenerating.isReproducing` for details. -
 @[simp] def IsGenerating (C : ConvexCone R M) : Prop :=
   Submodule.span R (C : Set M) = ⊤
 
+/-- A sufficient criteria for a convex cone `C` to be generating is that top is less than or equal
+to the linear span of `C`. -/
+theorem IsGenerating.of_top_le_span {C : ConvexCone R M} (h : ⊤ ≤ Submodule.span R (C : Set M)) :
+    C.IsGenerating :=
+  eq_top_iff.mpr h
+
+/-- The linear span of a generating convex cone equals top. -/
+lemma IsGenerating.span_eq_top {C : ConvexCone R M} (hC : C.IsGenerating) :
+    Submodule.span R (C : Set M) = ⊤ :=
+  hC
+
+/-- Top is less than or equal to the linear span of a generating convex cone. -/
+lemma IsGenerating.top_le_span {C : ConvexCone R M} (hC : C.IsGenerating) :
+    ⊤ ≤ Submodule.span R (C : Set M) :=
+  hC.span_eq_top.ge
+
 /-- The whole `R`-module `M` (viewed as the top convex cone) is generating. -/
 theorem isGenerating_top : (⊤ : ConvexCone R M).IsGenerating := by
   simp
@@ -416,6 +432,22 @@ i.e., every element of `M` can be written as a difference of two elements of `C`
 See also (`IsGenerating`). -/
 def IsReproducing [AddCommGroup M] (C : ConvexCone R M) : Prop :=
   (C : Set M) - (C : Set M) = Set.univ
+
+/-- A sufficient criteria for a convex cone `C` to be reproducing is that `Set.univ` is a subset
+of `C - C`. -/
+theorem IsReproducing.of_univ_subset [AddCommGroup M] {C : ConvexCone R M}
+    (h : Set.univ ⊆ (C : Set M) - (C : Set M)) : C.IsReproducing :=
+  Set.eq_univ_iff_forall.mpr fun _ ↦ h trivial
+
+/-- The set difference of a reproducing cone with itself equals `Set.univ`. -/
+lemma IsReproducing.sub_eq_univ [AddCommGroup M] {C : ConvexCone R M} (hC : C.IsReproducing) :
+    (C : Set M) - (C : Set M) = Set.univ :=
+  hC
+
+/-- `Set.univ` is a subset of the set difference of a reproducing cone with itself. -/
+lemma IsReproducing.univ_subset_sub [AddCommGroup M] {C : ConvexCone R M} (hC : C.IsReproducing) :
+    Set.univ ⊆ (C : Set M) - (C : Set M) :=
+  hC.sub_eq_univ.ge
 
 /-- A reproducing cone is generating. -/
 theorem IsReproducing.isGenerating {R : Type*} {M : Type*} [Ring R] [PartialOrder R]

--- a/Mathlib/Geometry/Convex/Cone/Basic.lean
+++ b/Mathlib/Geometry/Convex/Cone/Basic.lean
@@ -469,7 +469,7 @@ Specifically, this requires strengthening the assumptions (beyond those of `IsGe
 `C` must be non-empty (to cover the degenerate case)
 and `[Semiring R] [PartialOrder R]` is replaced by `[Ring R] [LinearOrder R] [AddLeftStrictMono R]`,
 and `[AddCommMonoid M]`  is replaced by  `[AddCommGroup M]` for subtraction. -/
-theorem isGenerating_iff_isReproducing' {R : Type*} {M : Type*} [Ring R] [LinearOrder R]
+theorem isGenerating_iff_isReproducing {R : Type*} {M : Type*} [Ring R] [LinearOrder R]
     [AddLeftStrictMono R] [AddCommGroup M] [Module R M] {C : ConvexCone R M}
     (hne : (C : Set M).Nonempty) :
     C.IsGenerating ↔ C.IsReproducing :=

--- a/Mathlib/Geometry/Convex/Cone/Basic.lean
+++ b/Mathlib/Geometry/Convex/Cone/Basic.lean
@@ -382,6 +382,24 @@ instance instAddCommSemigroup : AddCommSemigroup (ConvexCone R M) where
   add_assoc _ _ _ := SetLike.coe_injective <| add_assoc _ _ _
   add_comm _ _ := SetLike.coe_injective <| add_comm _ _
 
+section Generating
+
+/-- A convex cone `C` is generating if its linear span is the entire `R`-module `M`. -/
+def Generating (C : ConvexCone R M) : Prop :=
+  Submodule.span R (C : Set M) = ⊤
+
+/-- The whole `R`-module `M` (viewed as the top convex cone) is generating. -/
+@[simp]
+theorem generating_top : (⊤ : ConvexCone R M).Generating := by
+  simp [Generating]
+
+/-- A convex cone containing a generating cone is also a generating cone. -/
+theorem Generating.mono (h : C₁ ≤ C₂) (hgen : C₁.Generating) : C₂.Generating := by
+  rw [Generating, ← top_le_iff] at hgen ⊢
+  exact hgen.trans (Submodule.span_mono h)
+
+end Generating
+
 end Module
 
 end OrderedSemiring

--- a/Mathlib/Geometry/Convex/Cone/Basic.lean
+++ b/Mathlib/Geometry/Convex/Cone/Basic.lean
@@ -444,11 +444,6 @@ lemma IsReproducing.sub_eq_univ [AddCommGroup M] {C : ConvexCone R M} (hC : C.Is
     (C : Set M) - (C : Set M) = Set.univ :=
   hC
 
-/-- `Set.univ` is a subset of the set difference of a reproducing cone with itself. -/
-lemma IsReproducing.univ_subset_sub [AddCommGroup M] {C : ConvexCone R M} (hC : C.IsReproducing) :
-    Set.univ ⊆ (C : Set M) - (C : Set M) :=
-  hC.sub_eq_univ.ge
-
 /-- A reproducing cone is generating. -/
 theorem IsReproducing.isGenerating {R : Type*} {M : Type*} [Ring R] [PartialOrder R]
     [AddCommGroup M] [Module R M] {C : ConvexCone R M} (h : C.IsReproducing) :

--- a/Mathlib/Geometry/Convex/Cone/TensorProduct.lean
+++ b/Mathlib/Geometry/Convex/Cone/TensorProduct.lean
@@ -105,3 +105,17 @@ theorem minTensorProduct_le_maxTensorProduct (C₁ : PointedCone R G) (C₂ : Po
   exact Submodule.span_le.mpr (tmul_subset_maxTensorProduct C₁ C₂)
 
 end PointedCone
+
+section Generating
+variable (C : ConvexCone R G)
+/- generating -/
+/-- A convex cone is generating if the linear span of `C` is the whole space. -/
+def ConvexCone.Generating : Prop :=
+  Submodule.span R (C : Set G) = ⊤
+
+omit [IsStrictOrderedRing R]
+/-- A convex cone is generating iff the linear span of `C` is the whole space. -/
+lemma ConvexCone.generating_iff_span_eq_top :
+    C.Generating ↔ Submodule.span R (C : Set G) = ⊤ :=
+  Iff.rfl
+end Generating

--- a/Mathlib/Geometry/Convex/Cone/TensorProduct.lean
+++ b/Mathlib/Geometry/Convex/Cone/TensorProduct.lean
@@ -105,17 +105,3 @@ theorem minTensorProduct_le_maxTensorProduct (C₁ : PointedCone R G) (C₂ : Po
   exact Submodule.span_le.mpr (tmul_subset_maxTensorProduct C₁ C₂)
 
 end PointedCone
-
-section Generating
-variable (C : ConvexCone R G)
-/- generating -/
-/-- A convex cone is generating if the linear span of `C` is the whole space. -/
-def ConvexCone.Generating : Prop :=
-  Submodule.span R (C : Set G) = ⊤
-
-omit [IsStrictOrderedRing R]
-/-- A convex cone is generating iff the linear span of `C` is the whole space. -/
-lemma ConvexCone.generating_iff_span_eq_top :
-    C.Generating ↔ Submodule.span R (C : Set G) = ⊤ :=
-  Iff.rfl
-end Generating


### PR DESCRIPTION
Define the notion of a generating convex cone.
Prove some initial simple lemmas about generating cones.

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

When merging, all the commits will be squashed into a single commit
listing all co-authors.

Co-authors in the squash commit are gathered from two sources:

First, all authors of commits to this PR branch are included. Thus,
one way to add co-authors is to include at least one commit authored by
each co-author among the commits in the pull request. If necessary, you
may create empty commits to indicate co-authorship, using commands like so:

git commit --author="Author Name <author@email.com>" --allow-empty -m "add Author Name as coauthor"

Second, co-authors can also be listed in lines at the very bottom of
the commit message (that is, directly before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines
at the bottom of the commit message (before the `---`, and also before
any "Co-authored-by" lines) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
