### PR TITLE
[Merged by Bors] - feat(CategoryTheory): commutation of bifunctors with shifts in two variables

### DIFF
--- a/Mathlib.lean
+++ b/Mathlib.lean
@@ -2933,6 +2933,7 @@ public import Mathlib.CategoryTheory.Retract
 public import Mathlib.CategoryTheory.Shift.Adjunction
 public import Mathlib.CategoryTheory.Shift.Basic
 public import Mathlib.CategoryTheory.Shift.CommShift
+public import Mathlib.CategoryTheory.Shift.CommShiftTwo
 public import Mathlib.CategoryTheory.Shift.Induced
 public import Mathlib.CategoryTheory.Shift.InducedShiftSequence
 public import Mathlib.CategoryTheory.Shift.Linear

--- a/Mathlib.lean
+++ b/Mathlib.lean
@@ -2294,6 +2294,7 @@ public import Mathlib.CategoryTheory.Category.ULift
 public import Mathlib.CategoryTheory.Center.Basic
 public import Mathlib.CategoryTheory.Center.Linear
 public import Mathlib.CategoryTheory.Center.Localization
+public import Mathlib.CategoryTheory.Center.NegOnePow
 public import Mathlib.CategoryTheory.Center.Preadditive
 public import Mathlib.CategoryTheory.ChosenFiniteProducts
 public import Mathlib.CategoryTheory.ChosenFiniteProducts.Cat

--- a/Mathlib/CategoryTheory/Center/NegOnePow.lean
+++ b/Mathlib/CategoryTheory/Center/NegOnePow.lean
@@ -1,0 +1,31 @@
+/-
+Copyright (c) 2025 Joël Riou. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Joël Riou
+-/
+module
+
+public import Mathlib.CategoryTheory.Center.Preadditive
+
+/-!
+# Powers of `-1` in the center of a preadditive category
+
+-/
+
+@[expose] public section
+
+universe v u
+
+namespace CategoryTheory.CatCenter
+
+variable {C : Type u} [Category.{v} C] [Preadditive C]
+
+@[simp]
+lemma app_neg_one_zpow (n : ℤ) (X : C) :
+    ((-1) ^ n : (CatCenter C)ˣ).val.app X = n.negOnePow • 𝟙 X := by
+  obtain ⟨n, rfl⟩ | ⟨n, rfl⟩ := Int.even_or_odd n
+  · simp [zpow_add, ← mul_zpow, Int.negOnePow_even _ (Even.add_self n)]
+  · rw [Int.negOnePow_odd _ (by exact odd_two_mul_add_one n)]
+    simp [Units.smul_def, zpow_add, Int.two_mul, ← mul_zpow]
+
+end CategoryTheory.CatCenter

--- a/Mathlib/CategoryTheory/Center/NegOnePow.lean
+++ b/Mathlib/CategoryTheory/Center/NegOnePow.lean
@@ -6,6 +6,7 @@ Authors: Joël Riou
 module
 
 public import Mathlib.CategoryTheory.Center.Preadditive
+public import Mathlib.Algebra.Ring.NegOnePow
 
 /-!
 # Powers of `-1` in the center of a preadditive category

--- a/Mathlib/CategoryTheory/Center/Preadditive.lean
+++ b/Mathlib/CategoryTheory/Center/Preadditive.lean
@@ -36,14 +36,6 @@ lemma app_sub (z₁ z₂ : CatCenter C) (X : C) :
 lemma app_neg (z : CatCenter C) (X : C) :
     (-z).app X = - z.app X := rfl
 
-@[simp]
-lemma app_neg_one_zpow (n : ℤ) (X : C) :
-    ((-1) ^ n : (CatCenter C)ˣ).val.app X = n.negOnePow • 𝟙 X := by
-  obtain ⟨n, rfl⟩ | ⟨n, rfl⟩ := Int.even_or_odd n
-  · simp [zpow_add, ← mul_zpow, Int.negOnePow_even _ (Even.add_self n)]
-  · rw [Int.negOnePow_odd _ (by exact odd_two_mul_add_one n)]
-    simp [Units.smul_def, zpow_add, Int.two_mul, ← mul_zpow]
-
 end CatCenter
 
 end CategoryTheory

--- a/Mathlib/CategoryTheory/Center/Preadditive.lean
+++ b/Mathlib/CategoryTheory/Center/Preadditive.lean
@@ -7,7 +7,6 @@ module
 
 public import Mathlib.CategoryTheory.Preadditive.FunctorCategory
 public import Mathlib.CategoryTheory.Center.Basic
-public import Mathlib.Algebra.Ring.NegOnePow
 
 /-!
 # The center of an additive category

--- a/Mathlib/CategoryTheory/Center/Preadditive.lean
+++ b/Mathlib/CategoryTheory/Center/Preadditive.lean
@@ -7,6 +7,7 @@ module
 
 public import Mathlib.CategoryTheory.Preadditive.FunctorCategory
 public import Mathlib.CategoryTheory.Center.Basic
+public import Mathlib.Algebra.Ring.NegOnePow
 
 /-!
 # The center of an additive category
@@ -34,6 +35,14 @@ lemma app_sub (z₁ z₂ : CatCenter C) (X : C) :
 @[simp]
 lemma app_neg (z : CatCenter C) (X : C) :
     (-z).app X = - z.app X := rfl
+
+@[simp]
+lemma app_neg_one_zpow (n : ℤ) (X : C) :
+    ((-1) ^ n : (CatCenter C)ˣ).val.app X = n.negOnePow • 𝟙 X := by
+  obtain ⟨n, rfl⟩ | ⟨n, rfl⟩ := Int.even_or_odd n
+  · simp [zpow_add, ← mul_zpow, Int.negOnePow_even _ (Even.add_self n)]
+  · rw [Int.negOnePow_odd _ (by exact odd_two_mul_add_one n)]
+    simp [Units.smul_def, zpow_add, Int.two_mul, ← mul_zpow]
 
 end CatCenter
 

--- a/Mathlib/CategoryTheory/Shift/CommShiftTwo.lean
+++ b/Mathlib/CategoryTheory/Shift/CommShiftTwo.lean
@@ -11,7 +11,7 @@ public import Mathlib.CategoryTheory.Shift.Twist
 public import Mathlib.CategoryTheory.Shift.Pullback
 
 /-!
-# Commutation to shifts of functors in two variables
+# Commutation with shifts of functors in two variables
 
 We introduce a typeclass `Functor.CommShift₂Int` for a bifunctor `G : C₁ ⥤ C₂ ⥤ D`
 (with `D` a preadditive category) as the two variable analogue of `Functor.CommShift`.

--- a/Mathlib/CategoryTheory/Shift/CommShiftTwo.lean
+++ b/Mathlib/CategoryTheory/Shift/CommShiftTwo.lean
@@ -64,7 +64,6 @@ noncomputable def CommShift₂Setup.int [Preadditive D] [HasShift D ℤ]
   assoc _ _ _ := by
     dsimp
     rw [← zpow_add, ← zpow_add]
-    congr 1
     cutsat
   commShift _ _ := ⟨by cat_disch⟩
   ε p q := (-1) ^ (p * q)

--- a/Mathlib/CategoryTheory/Shift/CommShiftTwo.lean
+++ b/Mathlib/CategoryTheory/Shift/CommShiftTwo.lean
@@ -61,7 +61,7 @@ noncomputable def CommShift₂Setup.int [Preadditive D] [HasShift D ℤ]
     [∀ (n : ℤ), (shiftFunctor D n).Additive] :
     CommShift₂Setup D ℤ where
   z m n := (-1) ^ (m.1 * n.2)
-  assoc _ _ _:= by
+  assoc _ _ _ := by
     dsimp
     rw [← zpow_add, ← zpow_add]
     congr 1

--- a/Mathlib/CategoryTheory/Shift/CommShiftTwo.lean
+++ b/Mathlib/CategoryTheory/Shift/CommShiftTwo.lean
@@ -104,6 +104,8 @@ namespace CommShift₂
 
 attribute [instance] commShiftObj commShiftFlipObj commShift_map commShift_flip_map
 
+attribute [reassoc] comm
+
 end CommShift₂
 
 end Functor

--- a/Mathlib/CategoryTheory/Shift/CommShiftTwo.lean
+++ b/Mathlib/CategoryTheory/Shift/CommShiftTwo.lean
@@ -5,7 +5,7 @@ Authors: Joël Riou
 -/
 module
 
-public import Mathlib.CategoryTheory.Center.Preadditive
+public import Mathlib.CategoryTheory.Center.NegOnePow
 public import Mathlib.CategoryTheory.Linear.LinearFunctor
 public import Mathlib.CategoryTheory.Shift.Twist
 public import Mathlib.CategoryTheory.Shift.Pullback

--- a/Mathlib/CategoryTheory/Shift/CommShiftTwo.lean
+++ b/Mathlib/CategoryTheory/Shift/CommShiftTwo.lean
@@ -1,0 +1,111 @@
+/-
+Copyright (c) 2025 Joël Riou. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Joël Riou
+-/
+module
+
+public import Mathlib.CategoryTheory.Center.Preadditive
+public import Mathlib.CategoryTheory.Linear.LinearFunctor
+public import Mathlib.CategoryTheory.Shift.Twist
+public import Mathlib.CategoryTheory.Shift.Pullback
+
+/-!
+# Commutation to shifts of functors in two variables
+
+We introduce a typeclass `Functor.CommShift₂Int` for a bifunctor `G : C₁ ⥤ C₂ ⥤ D`
+(with `D` a preadditive category) as the two variable analogue of `Functor.CommShift`.
+We require that `G` commutes with the shifts in both variables and that the two
+ways to identify `(G.obj (X₁⟦p⟧)).obj (X₂⟦q⟧)` to `((G.obj X₁).obj X₂)⟦p + q⟧`
+differ by the sign `(-1) ^ (p + q)`.
+
+This is implemented using a structure `Functor.CommShift₂` which does not depend
+on the preadditive structure on `D`: instead of signs, elements in `(CatCenter D)ˣ`
+are used. These elements are part of a `CommShift₂Setup` structure which extends
+a `TwistShiftData` structure (see the file `CategoryTheory.Shift.Twist`).
+
+## TODO (@joelriou)
+* Show that `G : C₁ ⥤ C₂ ⥤ D` satisfies `Functor.CommShift₂Int` iff the uncurried
+functor `C₁ × C₂ ⥤ D` commutes with the shift by `ℤ × ℤ`, where `C₁ × C₂` is
+equipped with the obvious product shift, and `D` is equipped with
+the twisted shift.
+
+-/
+
+@[expose] public section
+
+namespace CategoryTheory
+
+variable {C C₁ C₂ D : Type*} [Category C] [Category C₁] [Category C₂] [Category D]
+
+variable (D) in
+/-- Given a category `D` equipped with a shift by an additive monoid `M`, this
+structure `CommShift₂Setup D M` allows to define what it means for a bifunctor
+`C₁ ⥤ C₂ ⥤ D` to commute with shifts by `M` with respect to both variables.
+This structure consists of a `TwistShiftData` for the shift by `M × M` on `D`
+obtained by pulling back the addition map `M × M →+ M`, with two axioms `z_zero₁`
+and `z_zero₂`. We also require an additional data of `ε m n : (CatCenter D)ˣ`
+for `m` and `n`: even though this is determined by the `z` field of `TwistShiftData`,
+we make it a separate field so as to have control on its definitional properties. -/
+structure CommShift₂Setup (M : Type*) [AddCommMonoid M] [HasShift D M] extends
+    TwistShiftData (PullbackShift D (AddMonoidHom.fst M M + AddMonoidHom.snd _ _)) (M × M) where
+  z_zero₁ (m₁ m₂ : M) : z (0, m₁) (0, m₂) = 1 := by aesop
+  z_zero₂ (m₁ m₂ : M) : z (m₁, 0) (m₂, 0) = 1 := by aesop
+  /-- The invertible elements in the center of `D` that are equal
+  to `(z (0, n) (m, 0))⁻¹ * z (m, 0) (0, n)`. -/
+  ε (m n : M) : (CatCenter D)ˣ
+  hε (m n : M) : ε m n = (z (0, n) (m, 0))⁻¹ * z (m, 0) (0, n) := by aesop
+
+/-- The standard setup for the commutation of bifunctors with shifts by `ℤ`. -/
+noncomputable def CommShift₂Setup.int [Preadditive D] [HasShift D ℤ]
+    [∀ (n : ℤ), (shiftFunctor D n).Additive] :
+    CommShift₂Setup D ℤ where
+  z m n := (-1) ^ (m.1 * n.2)
+  assoc _ _ _:= by
+    dsimp
+    rw [← zpow_add, ← zpow_add]
+    congr 1
+    cutsat
+  commShift _ _ := ⟨by cat_disch⟩
+  ε p q := (-1) ^ (p * q)
+
+namespace Functor
+
+/-- A bifunctor `G : C₁ ⥤ C₂ ⥤ D` commutes with the shifts by `M` if all functors
+`G.obj X₁` and `G.flip X₂` are equipped with `Functor.CommShift` structures, in a way
+that is natural in `X₁` and `X₂`, and that these isomorphisms commute up to
+the multiplication with an element in `(CatCenter D)ˣ` which is determined by
+a `CommShift₂Setup D M` structure. (In most cases, one should use the
+abbreviation `CommShift₂Int`.) -/
+class CommShift₂ {M : Type*} [AddCommMonoid M] [HasShift C₁ M] [HasShift C₂ M] [HasShift D M]
+    (G : C₁ ⥤ C₂ ⥤ D) (h : CommShift₂Setup D M) where
+  commShiftObj (X₁ : C₁) : (G.obj X₁).CommShift M := by infer_instance
+  commShift_map {X₁ Y₁ : C₁} (f : X₁ ⟶ Y₁) : NatTrans.CommShift (G.map f) M := by infer_instance
+  commShiftFlipObj (X₂ : C₂) : (G.flip.obj X₂).CommShift M := by infer_instance
+  commShift_flip_map {X₂ Y₂ : C₂} (g : X₂ ⟶ Y₂) : NatTrans.CommShift (G.flip.map g) M := by
+    infer_instance
+  comm (G h) (X₁ : C₁) (X₂ : C₂) (m n : M) :
+    ((G.obj (X₁⟦m⟧)).commShiftIso n).hom.app X₂ ≫
+      (((G.flip.obj X₂).commShiftIso m).hom.app X₁)⟦n⟧' =
+        ((G.flip.obj (X₂⟦n⟧)).commShiftIso m).hom.app X₁ ≫
+          (((G.obj X₁).commShiftIso n).hom.app X₂)⟦m⟧' ≫
+            (shiftComm ((G.obj X₁).obj X₂) m n).inv ≫ (h.ε m n).val.app _
+
+/-- A bifunctor `G : C₁ ⥤ C₂ ⥤ D` commutes with the shifts by `ℤ` if all functors
+`G.obj X₁` and `G.flip X₂` are equipped with `Functor.CommShift` structures, in a way
+that is natural in `X₁` and `X₂`, and that these isomorphisms for the shift by `p`
+on the first variable and the shift by `q` on the second variable commute up
+to the sign `(-1) ^ (p * q)`. -/
+abbrev CommShift₂Int [HasShift C₁ ℤ] [HasShift C₂ ℤ] [HasShift D ℤ] [Preadditive D]
+    [∀ (n : ℤ), (shiftFunctor D n).Additive] (G : C₁ ⥤ C₂ ⥤ D) : Type _ :=
+  G.CommShift₂ .int
+
+namespace CommShift₂
+
+attribute [instance] commShiftObj commShiftFlipObj commShift_map commShift_flip_map
+
+end CommShift₂
+
+end Functor
+
+end CategoryTheory

--- a/Mathlib/CategoryTheory/Shift/Twist.lean
+++ b/Mathlib/CategoryTheory/Shift/Twist.lean
@@ -31,7 +31,7 @@ variable (C : Type u) [Category.{v} C] (A : Type w) [AddMonoid A] [HasShift C A]
 /-- Given a category `C` equipped with a shift by a monoid `A` -/
 structure TwistShiftData where
   /-- The invertible elements in the center of `C` which are used to
-  modify the `shiftFunctorAdd` isomorphisms . -/
+  modify the `shiftFunctorAdd` isomorphisms. -/
   z (a b : A) : (CatCenter C)ˣ
   z_zero_zero : z 0 0 = 1 := by cat_disch
   assoc (a b c : A) : z (a + b) c * z a b = z a (b + c) * z b c := by cat_disch


### PR DESCRIPTION
This will be used when formalising triangulated bifunctors.

---

<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

When merging, all the commits will be squashed into a single commit
listing all co-authors.

Co-authors in the squash commit are gathered from two sources:

First, all authors of commits to this PR branch are included. Thus,
one way to add co-authors is to include at least one commit authored by
each co-author among the commits in the pull request. If necessary, you
may create empty commits to indicate co-authorship, using commands like so:

git commit --author="Author Name <author@email.com>" --allow-empty -m "add Author Name as coauthor"

Second, co-authors can also be listed in lines at the very bottom of
the commit message (that is, directly before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines
at the bottom of the commit message (before the `---`, and also before
any "Co-authored-by" lines) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
