### PR TITLE
[Merged by Bors] - feat(OpenPartialHomeomorph): add missing `simp` lemmas

### DIFF
--- a/Mathlib/Topology/OpenPartialHomeomorph.lean
+++ b/Mathlib/Topology/OpenPartialHomeomorph.lean
@@ -616,7 +616,7 @@ theorem coe_ofContinuousOpenRestrict (e : PartialEquiv X Y) (hc : ContinuousOn e
   rfl
 
 @[simp]
-theorem coe_symm_ofContinuousOpenRestrict (e : PartialEquiv X Y) (hc : ContinuousOn e e.source)
+theorem coe_ofContinuousOpenRestrict_symm (e : PartialEquiv X Y) (hc : ContinuousOn e e.source)
     (ho : IsOpenMap (e.source.restrict e)) (hs : IsOpen e.source) :
     ⇑(ofContinuousOpenRestrict e hc ho hs).symm = e.symm :=
   rfl
@@ -635,7 +635,7 @@ theorem coe_ofContinuousOpen (e : PartialEquiv X Y) (hc : ContinuousOn e e.sourc
   rfl
 
 @[simp]
-theorem coe_symm_ofContinuousOpen (e : PartialEquiv X Y) (hc : ContinuousOn e e.source)
+theorem coe_ofContinuousOpen_symm (e : PartialEquiv X Y) (hc : ContinuousOn e e.source)
     (ho : IsOpenMap e) (hs : IsOpen e.source) :
     ⇑(ofContinuousOpen e hc ho hs).symm = e.symm :=
   rfl
@@ -659,7 +659,7 @@ theorem restrOpen_source (s : Set X) (hs : IsOpen s) : (e.restrOpen s hs).source
 @[simp] theorem coe_restrOpen {s : Set X} (hs : IsOpen s) : ⇑(e.restrOpen s hs) = e := rfl
 
 @[simp]
-theorem coe_symm_restrOpen {s : Set X} (hs : IsOpen s) : ⇑(e.restrOpen s hs).symm = e.symm := rfl
+theorem coe_restrOpen_symm {s : Set X} (hs : IsOpen s) : ⇑(e.restrOpen s hs).symm = e.symm := rfl
 
 /-- Restricting an open partial homeomorphism `e` to `e.source ∩ interior s`. We use the interior to
 make sure that the restriction is well defined whatever the set s, since open partial homeomorphisms

--- a/Mathlib/Topology/OpenPartialHomeomorph.lean
+++ b/Mathlib/Topology/OpenPartialHomeomorph.lean
@@ -565,7 +565,7 @@ theorem isOpen_iff (h : e.IsImage s t) : IsOpen (e.source ∩ s) ↔ IsOpen (e.t
     h.preimage_eq' ▸ e.isOpen_inter_preimage hs⟩
 
 /-- Restrict an `OpenPartialHomeomorph` to a pair of corresponding open sets. -/
-@[simps toPartialEquiv]
+@[simps! -fullyApplied apply symm_apply toPartialEquiv]
 def restr (h : e.IsImage s t) (hs : IsOpen (e.source ∩ s)) : OpenPartialHomeomorph X Y where
   toPartialEquiv := h.toPartialEquiv.restr
   open_source := hs
@@ -600,6 +600,7 @@ end IsImage
 
 /-- A `PartialEquiv` with continuous open forward map and open source is a
 `OpenPartialHomeomorph`. -/
+@[simps toPartialEquiv]
 def ofContinuousOpenRestrict (e : PartialEquiv X Y) (hc : ContinuousOn e e.source)
     (ho : IsOpenMap (e.source.restrict e)) (hs : IsOpen e.source) : OpenPartialHomeomorph X Y where
   toPartialEquiv := e
@@ -608,11 +609,36 @@ def ofContinuousOpenRestrict (e : PartialEquiv X Y) (hc : ContinuousOn e e.sourc
   continuousOn_toFun := hc
   continuousOn_invFun := e.image_source_eq_target ▸ ho.continuousOn_image_of_leftInvOn e.leftInvOn
 
+@[simp]
+theorem coe_ofContinuousOpenRestrict (e : PartialEquiv X Y) (hc : ContinuousOn e e.source)
+    (ho : IsOpenMap (e.source.restrict e)) (hs : IsOpen e.source) :
+    ⇑(ofContinuousOpenRestrict e hc ho hs) = e :=
+  rfl
+
+@[simp]
+theorem coe_symm_ofContinuousOpenRestrict (e : PartialEquiv X Y) (hc : ContinuousOn e e.source)
+    (ho : IsOpenMap (e.source.restrict e)) (hs : IsOpen e.source) :
+    ⇑(ofContinuousOpenRestrict e hc ho hs).symm = e.symm :=
+  rfl
+
 /-- A `PartialEquiv` with continuous open forward map and open source is a
 `OpenPartialHomeomorph`. -/
+@[simps! toPartialEquiv]
 def ofContinuousOpen (e : PartialEquiv X Y) (hc : ContinuousOn e e.source) (ho : IsOpenMap e)
     (hs : IsOpen e.source) : OpenPartialHomeomorph X Y :=
   ofContinuousOpenRestrict e hc (ho.restrict hs) hs
+
+@[simp]
+theorem coe_ofContinuousOpen (e : PartialEquiv X Y) (hc : ContinuousOn e e.source)
+    (ho : IsOpenMap e) (hs : IsOpen e.source) :
+    ⇑(ofContinuousOpen e hc ho hs) = e :=
+  rfl
+
+@[simp]
+theorem coe_symm_ofContinuousOpen (e : PartialEquiv X Y) (hc : ContinuousOn e e.source)
+    (ho : IsOpenMap e) (hs : IsOpen e.source) :
+    ⇑(ofContinuousOpen e hc ho hs).symm = e.symm :=
+  rfl
 
 /-- Restricting an open partial homeomorphism `e` to `e.source ∩ s` when `s` is open.
 This is sometimes hard to use because of the openness assumption, but it has the advantage that
@@ -629,6 +655,11 @@ theorem restrOpen_toPartialEquiv (s : Set X) (hs : IsOpen s) :
 -- Already simp via `PartialEquiv`
 theorem restrOpen_source (s : Set X) (hs : IsOpen s) : (e.restrOpen s hs).source = e.source ∩ s :=
   rfl
+
+@[simp] theorem coe_restrOpen {s : Set X} (hs : IsOpen s) : ⇑(e.restrOpen s hs) = e := rfl
+
+@[simp]
+theorem coe_symm_restrOpen {s : Set X} (hs : IsOpen s) : ⇑(e.restrOpen s hs).symm = e.symm := rfl
 
 /-- Restricting an open partial homeomorphism `e` to `e.source ∩ interior s`. We use the interior to
 make sure that the restriction is well defined whatever the set s, since open partial homeomorphisms


### PR DESCRIPTION
I found missing lemmas about `restrOpen` while working on https://github.com/urkud/SardMoreira.

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

When merging, all the commits will be squashed into a single commit
listing all co-authors.

Co-authors in the squash commit are gathered from two sources:

First, all authors of commits to this PR branch are included. Thus,
one way to add co-authors is to include at least one commit authored by
each co-author among the commits in the pull request. If necessary, you
may create empty commits to indicate co-authorship, using commands like so:

git commit --author="Author Name <author@email.com>" --allow-empty -m "add Author Name as coauthor"

Second, co-authors can also be listed in lines at the very bottom of
the commit message (that is, directly before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines
at the bottom of the commit message (before the `---`, and also before
any "Co-authored-by" lines) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
