### PR TITLE
[Merged by Bors] - feat: behavior of the counting function under addition

### DIFF
--- a/Mathlib/Analysis/Complex/ValueDistribution/CountingFunction.lean
+++ b/Mathlib/Analysis/Complex/ValueDistribution/CountingFunction.lean
@@ -235,6 +235,20 @@ theorem log_counting_zero_sub_logCounting_top {f : 𝕜 → E} :
     (divisor f univ).logCounting = logCounting f 0 - logCounting f ⊤ := by
   rw [← posPart_sub_negPart (divisor f univ), logCounting_zero, logCounting_top, map_sub]
 
+/--
+The logarithmic counting function of a constant function is zero.
+-/
+@[simp] theorem logCounting_const {c : E} {e : WithTop E} :
+    logCounting (fun _ ↦ c : 𝕜 → E) e = 0 := by
+  simp [logCounting]
+
+/--
+The logarithmic counting function of the constant function zero is zero.
+-/
+@[simp] theorem logCounting_const_zero {e : WithTop E} :
+    logCounting (0 : 𝕜 → E) e = 0 := logCounting_const
+
+
 /-!
 ## Elementary Properties of the Counting Function
 -/
@@ -273,6 +287,56 @@ function counting poles.
 /-!
 ## Behaviour under Arithmetic Operations
 -/
+
+/--
+For `1 ≤ r`, the logarithmic counting function of `f + g` at `⊤` is less than or equal to
+the sum of the logarithmic counting functions of `f` and `g`, respectively.
+-/
+theorem logCounting_add_top_le {f₁ f₂ : 𝕜 → E} {r : ℝ} (h₁f₁ : MeromorphicOn f₁ Set.univ)
+    (h₁f₂ : MeromorphicOn f₂ Set.univ) (hr : 1 ≤ r) :
+    logCounting (f₁ + f₂) ⊤ r ≤ ((logCounting f₁ ⊤) + (logCounting f₂ ⊤)) r := by
+  simp only [logCounting, ↓reduceDIte]
+  rw [← Function.locallyFinsuppWithin.logCounting.map_add]
+  exact Function.locallyFinsuppWithin.logCounting_le (negPart_divisor_add_le_add h₁f₁ h₁f₂) hr
+
+/--
+Asymptotically, the logarithmic counting function of `f + g` at `⊤` is less than or equal to the sum
+of the logarithmic counting functions of `f` and `g`, respectively.
+-/
+theorem logCounting_add_top_eventuallyLE {f₁ f₂ : 𝕜 → E} (h₁f₁ : MeromorphicOn f₁ Set.univ)
+    (h₁f₂ : MeromorphicOn f₂ Set.univ) :
+    logCounting (f₁ + f₂) ⊤ ≤ᶠ[Filter.atTop] (logCounting f₁ ⊤) + (logCounting f₂ ⊤) := by
+  filter_upwards [Filter.eventually_ge_atTop 1]
+  exact fun _ hr ↦ logCounting_add_top_le h₁f₁ h₁f₂ hr
+
+/--
+For `1 ≤ r`, the logarithmic counting function of a sum `∑ a ∈ s, f a` at `⊤` is less than or equal
+to the sum of the logarithmic counting functions of `f ·`.
+-/
+theorem logCounting_sum_top_le {α : Type*} (s : Finset α) (f : α → 𝕜 → E) {r : ℝ}
+    (h₁f : ∀ a, MeromorphicOn (f a) Set.univ) (hr : 1 ≤ r) :
+    logCounting (∑ a ∈ s, f a) ⊤ r ≤ (∑ a ∈ s, (logCounting (f a) ⊤)) r := by
+  classical
+  induction s using Finset.induction with
+  | empty =>
+    simp
+  | insert a s ha hs =>
+    rw [Finset.sum_insert ha, Finset.sum_insert ha]
+    calc logCounting (f a + ∑ x ∈ s, f x) ⊤ r
+      _ ≤ (logCounting (f a) ⊤ + logCounting (∑ x ∈ s, f x) ⊤) r :=
+        logCounting_add_top_le (h₁f a) (MeromorphicOn.sum h₁f) hr
+      _ ≤ (logCounting (f a) ⊤ + ∑ x ∈ s, logCounting (f x) ⊤) r :=
+        add_le_add (by trivial) hs
+
+/--
+Asymptotically, the logarithmic counting function of a sum `∑ a ∈ s, f a` at `⊤` is less than or
+equal to the sum of the logarithmic counting functions of `f ·`.
+-/
+theorem logCounting_sum_top_eventuallyLE {α : Type*} (s : Finset α) (f : α → 𝕜 → E)
+    (h₁f : ∀ a, MeromorphicOn (f a) Set.univ) :
+    logCounting (∑ a ∈ s, f a) ⊤ ≤ᶠ[Filter.atTop] ∑ a ∈ s, (logCounting (f a) ⊤) := by
+  filter_upwards [Filter.eventually_ge_atTop 1]
+  exact fun _ hr ↦ logCounting_sum_top_le s f h₁f hr
 
 /--
 For `1 ≤ r`, the counting function counting zeros of `f * g` is less than or equal to the sum of the

--- a/Mathlib/Analysis/Complex/ValueDistribution/CountingFunction.lean
+++ b/Mathlib/Analysis/Complex/ValueDistribution/CountingFunction.lean
@@ -245,7 +245,7 @@ The logarithmic counting function of a constant function is zero.
 /--
 The logarithmic counting function of the constant function zero is zero.
 -/
-@[simp] theorem logCounting_const_zero {e : WithTop E} :
+@[simp] theorem logCounting_zero {e : WithTop E} :
     logCounting (0 : 𝕜 → E) e = 0 := logCounting_const
 
 

--- a/Mathlib/Analysis/Complex/ValueDistribution/CountingFunction.lean
+++ b/Mathlib/Analysis/Complex/ValueDistribution/CountingFunction.lean
@@ -245,7 +245,7 @@ The logarithmic counting function of a constant function is zero.
 /--
 The logarithmic counting function of the constant function zero is zero.
 -/
-@[simp] theorem logCounting_zero {e : WithTop E} :
+@[simp] theorem logCounting_const_zero {e : WithTop E} :
     logCounting (0 : 𝕜 → E) e = 0 := logCounting_const
 
 

--- a/Mathlib/Analysis/Meromorphic/Divisor.lean
+++ b/Mathlib/Analysis/Meromorphic/Divisor.lean
@@ -171,9 +171,8 @@ respectively.
 theorem min_divisor_le_divisor_add {f₁ f₂ : 𝕜 → E} {z : 𝕜} {U : Set 𝕜} (hf₁ : MeromorphicOn f₁ U)
     (hf₂ : MeromorphicOn f₂ U) (h₁z : z ∈ U) (h₃ : meromorphicOrderAt (f₁ + f₂) z ≠ ⊤) :
     min (divisor f₁ U z) (divisor f₂ U z) ≤ divisor (f₁ + f₂) U z := by
-  by_cases hz : z ∉ U
+  by_cases! hz : z ∉ U
   · simp_all
-  rw [not_not] at hz
   rw [divisor_apply hf₁ hz, divisor_apply hf₂ hz, divisor_apply (hf₁.add hf₂) hz]
   by_cases h₁ : meromorphicOrderAt f₁ z = ⊤
   · simp_all
@@ -191,9 +190,8 @@ theorem negPart_divisor_add_le_max {f₁ f₂ : 𝕜 → E} {U : Set 𝕜} (hf�
     (hf₂ : MeromorphicOn f₂ U) :
     (divisor (f₁ + f₂) U)⁻ ≤ max (divisor f₁ U)⁻ (divisor f₂ U)⁻ := by
   intro z
-  by_cases hz : z ∉ U
+  by_cases! hz : z ∉ U
   · simp [hz]
-  rw [not_not] at hz
   simp only [Function.locallyFinsuppWithin.negPart_apply, Function.locallyFinsuppWithin.max_apply]
   by_cases hf₁₂ : meromorphicOrderAt (f₁ + f₂) z = ⊤
   · simp [divisor_apply (hf₁.add hf₂) hz, hf₁₂, negPart_nonneg]

--- a/Mathlib/Analysis/Meromorphic/Divisor.lean
+++ b/Mathlib/Analysis/Meromorphic/Divisor.lean
@@ -165,6 +165,56 @@ The divisor of a constant function is `0`.
 -/
 
 /--
+The divisor of `f₁ + f₂` is larger than or equal to the minimum of the divisors of `f₁` and `f₂`,
+respectively.
+-/
+theorem min_divisor_le_divisor_add {f₁ f₂ : 𝕜 → E} {z : 𝕜} {U : Set 𝕜} (hf₁ : MeromorphicOn f₁ U)
+    (hf₂ : MeromorphicOn f₂ U) (h₁z : z ∈ U) (h₃ : meromorphicOrderAt (f₁ + f₂) z ≠ ⊤) :
+    min (divisor f₁ U z) (divisor f₂ U z) ≤ divisor (f₁ + f₂) U z := by
+  by_cases hz : z ∉ U
+  · simp_all
+  rw [not_not] at hz
+  rw [divisor_apply hf₁ hz, divisor_apply hf₂ hz, divisor_apply (hf₁.add hf₂) hz]
+  by_cases h₁ : meromorphicOrderAt f₁ z = ⊤
+  · simp_all
+  by_cases h₂ : meromorphicOrderAt f₂ z = ⊤
+  · simp_all
+  rw [← WithTop.untop₀_min h₁ h₂]
+  apply WithTop.untop₀_le_untop₀ h₃
+  exact meromorphicOrderAt_add (hf₁ z hz) (hf₂ z hz)
+
+/--
+The pole divisor of `f₁ + f₂` is smaller than or equal to the maximum of the pole divisors of `f₁`
+and `f₂`, respectively.
+-/
+theorem negPart_divisor_add_le_max {f₁ f₂ : 𝕜 → E} {U : Set 𝕜} (hf₁ : MeromorphicOn f₁ U)
+    (hf₂ : MeromorphicOn f₂ U) :
+    (divisor (f₁ + f₂) U)⁻ ≤ max (divisor f₁ U)⁻ (divisor f₂ U)⁻ := by
+  intro z
+  by_cases hz : z ∉ U
+  · simp [hz]
+  rw [not_not] at hz
+  simp only [Function.locallyFinsuppWithin.negPart_apply, Function.locallyFinsuppWithin.max_apply]
+  by_cases hf₁₂ : meromorphicOrderAt (f₁ + f₂) z = ⊤
+  · simp [divisor_apply (hf₁.add hf₂) hz, hf₁₂, negPart_nonneg]
+  rw [← negPart_min]
+  apply ((le_iff_posPart_negPart _ _).1 (min_divisor_le_divisor_add hf₁ hf₂ hz hf₁₂)).2
+
+/--
+The pole divisor of `f₁ + f₂` is smaller than or equal to the sum of the pole divisors of `f₁` and
+`f₂`, respectively.
+-/
+theorem negPart_divisor_add_le_add {f₁ f₂ : 𝕜 → E} {U : Set 𝕜} (hf₁ : MeromorphicOn f₁ U)
+    (hf₂ : MeromorphicOn f₂ U) :
+    (divisor (f₁ + f₂) U)⁻ ≤ (divisor f₁ U)⁻ + (divisor f₂ U)⁻ := by
+  calc (divisor (f₁ + f₂) U)⁻
+    _ ≤ max (divisor f₁ U)⁻ (divisor f₂ U)⁻ :=
+      negPart_divisor_add_le_max hf₁ hf₂
+    _ ≤ (divisor f₁ U)⁻ + (divisor f₂ U)⁻ := by
+      by_cases h : (divisor f₁ U)⁻ ≤ (divisor f₂ U)⁻
+      <;> simp_all [negPart_nonneg]
+
+/--
 If orders are finite, the divisor of the scalar product of two meromorphic functions is the sum of
 the divisors.
 

--- a/Mathlib/Analysis/Meromorphic/Order.lean
+++ b/Mathlib/Analysis/Meromorphic/Order.lean
@@ -513,6 +513,26 @@ theorem meromorphicOrderAt_inv {f : 𝕜 → 𝕜} :
 alias MeromorphicAt.order_inv := meromorphicOrderAt_inv
 
 /--
+Adding a locally vanishing function does not change the order.
+-/
+@[simp]
+theorem meromorphicOrderAt_add_of_top_left
+    {f₁ f₂ : 𝕜 → E} {x : 𝕜} (hf₁ : meromorphicOrderAt f₁ x = ⊤) :
+    meromorphicOrderAt (f₁ + f₂) x = meromorphicOrderAt f₂ x := by
+  rw [meromorphicOrderAt_congr]
+  filter_upwards [meromorphicOrderAt_eq_top_iff.1 hf₁] with z hz
+  simp_all
+
+/--
+Adding a locally vanishing function does not change the order.
+-/
+@[simp]
+theorem meromorphicOrderAt_add_of_top_right
+    {f₁ f₂ : 𝕜 → E} {x : 𝕜} (hf₂ : meromorphicOrderAt f₂ x = ⊤) :
+    meromorphicOrderAt (f₁ + f₂) x = meromorphicOrderAt f₁ x := by
+  rw [add_comm, meromorphicOrderAt_add_of_top_left hf₂]
+
+/--
 The order of a sum is at least the minimum of the orders of the summands.
 -/
 theorem meromorphicOrderAt_add (hf₁ : MeromorphicAt f₁ x) (hf₂ : MeromorphicAt f₂ x) :


### PR DESCRIPTION
Establish the behavior of the "Proximity Function" of Value Distribution theory with respect to addition.

This material is used in [Project VD](https://github.com/kebekus/ProjectVD), which aims to formalize Value Distribution Theory for meromorphic functions on the complex plane. The formula established here is part of a larger package discussing the behavior of the Nenvanlinna height under algebraic manipulations of the functions.

---

This is Mark II of the PR. See #31581 for the first attempt.

<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

When merging, all the commits will be squashed into a single commit
listing all co-authors.

Co-authors in the squash commit are gathered from two sources:

First, all authors of commits to this PR branch are included. Thus,
one way to add co-authors is to include at least one commit authored by
each co-author among the commits in the pull request. If necessary, you
may create empty commits to indicate co-authorship, using commands like so:

git commit --author="Author Name <author@email.com>" --allow-empty -m "add Author Name as coauthor"

Second, co-authors can also be listed in lines at the very bottom of
the commit message (that is, directly before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines
at the bottom of the commit message (before the `---`, and also before
any "Co-authored-by" lines) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
