### PR TITLE
[Merged by Bors] - feat(grw): support `grw (transparency := default)`

### DIFF
--- a/Mathlib/Tactic/GRewrite/Core.lean
+++ b/Mathlib/Tactic/GRewrite/Core.lean
@@ -122,12 +122,14 @@ def _root_.Lean.MVarId.grewrite (goal : MVarId) (e : Expr) (hrel : Expr)
         Possible solutions: use grewrite's 'occs' configuration option to limit which occurrences \
         are rewritten, or specify what the rewritten expression should be and use 'gcongr'."
     let eNew ← if rhs.hasBinderNameHint then eNew.resolveBinderNameHint else pure eNew
-    -- construct the implication proof using `gcongr`
+    -- Construct the implication proof using `gcongr`.
+    -- Although `e` and `e'` are defEq, they may not be defEq in the `reducible` transparency.
+    -- So, it is important to use `e'` in the `gcongr` goal.
+    let e' := eAbst.instantiate1 (GCongr.mkHoleAnnotation lhs)
     let mkImp (e₁ e₂ : Expr) : Expr := .forallE `_a e₁ e₂ .default
-    let eNew' := eAbst.instantiate1 (GCongr.mkHoleAnnotation rhs)
-    let imp := if forwardImp then mkImp e eNew' else mkImp eNew' e
+    let imp := if forwardImp then mkImp e' eNew else mkImp eNew e'
     let gcongrGoal ← mkFreshExprMVar imp
-    let (_, _, sideGoals) ← gcongrGoal.mvarId!.gcongr (!forwardImp) []
+    let (_, _, sideGoals) ← gcongrGoal.mvarId!.gcongr forwardImp []
       (mainGoalDischarger := GRewrite.dischargeMain hrel)
     -- post-process the metavariables
     postprocessAppMVars `grewrite goal newMVars binderInfos

--- a/Mathlib/Tactic/GRewrite/Elab.lean
+++ b/Mathlib/Tactic/GRewrite/Elab.lean
@@ -96,6 +96,8 @@ This is useful when `grw` tries to rewrite in a position that is not valid for t
 
 To be able to use `grw`, the relevant lemmas need to be tagged with `@[gcongr]`.
 To rewrite inside a transitive relation, you can also give it an `IsTrans` instance.
+
+To let `grw` unfold more aggressively, as in `erw`, use `grw (transparency := default)`.
 -/
 macro (name := grwSeq) "grw " c:optConfig s:rwRuleSeq l:(location)? : tactic =>
   match s with

--- a/MathlibTest/GRewrite.lean
+++ b/MathlibTest/GRewrite.lean
@@ -20,9 +20,9 @@ set_option linter.unusedVariables false
 
 private axiom test_sorry : ∀ {α}, α
 
-variable {α : Type*} [CommRing α] [LinearOrder α] [IsStrictOrderedRing α] (a b c d e : α)
-
 section inequalities
+
+variable {α : Type*} [CommRing α] [LinearOrder α] [IsStrictOrderedRing α] (a b c d e : α)
 
 example (h₁ : a ≤ b) (h₂ : b ≤ c) : a + 5 ≤ c + 6 := by
   grw [h₁, h₂]
@@ -216,11 +216,6 @@ the inequality goes in the wrong direction). -/
 error: Tactic `grewrite` failed: could not discharge x ≤ y using x ≥ y
 
 case h₁.hbc
-α : Type u_1
-inst✝² : CommRing α
-inst✝¹ : LinearOrder α
-inst✝ : IsStrictOrderedRing α
-a b✝ c d e : α
 x y b : ℚ
 h : x ≥ y
 ⊢ x ≤ y
@@ -263,20 +258,16 @@ example {Prime : ℕ → Prop} {a a' : ℕ} (h₁ : Prime (a + 1)) (h₂ : a = a
 error: Tactic `grewrite` failed: could not discharge b ≤ a using a ≤ b
 
 case h₂.hbc
-α : Type u_1
-inst✝² : CommRing α
-inst✝¹ : LinearOrder α
-inst✝ : IsStrictOrderedRing α
-a b c d e : α
+a b c : ℚ
 h₁ : a ≤ b
 h₂ : 0 ≤ c
 ⊢ b ≤ a
 -/
 #guard_msgs in
-example (h₁ : a ≤ b) (h₂ : 0 ≤ c) : a * c ≥ 100 + a := by
+example {a b c : ℚ} (h₁ : a ≤ b) (h₂ : 0 ≤ c) : a * c ≥ 100 + a := by
   grw [h₁]
 
-example (h₁ : a ≤ b) (h₂ : 0 ≤ c) : a * c ≥ 100 + a + a := by
+example {a b c : ℚ} (h₁ : a ≤ b) (h₂ : 0 ≤ c) : a * c ≥ 100 + a + a := by
   nth_grw 2 3 [h₁]
   guard_target =ₛ a * c ≥ 100 + b + b
   exact test_sorry
@@ -313,6 +304,8 @@ example : ∃ n, n < 2 := by
   exact 0
   refine zero_lt_one
 
+section zmod
+
 variable {a b c d n : ℤ}
 
 example (h : a ≡ b [ZMOD n]) : a ^ 2 ≡ b ^ 2 [ZMOD n] := by
@@ -321,6 +314,8 @@ example (h : a ≡ b [ZMOD n]) : a ^ 2 ≡ b ^ 2 [ZMOD n] := by
 example (h₁ : a ∣ b) (h₂ : b ∣ a * d) : a ∣ b * d := by
   grw [h₁] at h₂ ⊢
   exact h₂
+
+end zmod
 
 namespace AntiSymmRelTest
 
@@ -349,7 +344,30 @@ example (a b : Nat) (h : Nat → no_index (a ≤ b)) : a ≤ b := by
 example (a b : Nat) (h : Nat → no_index (a ≤ b)) : a ≤ b := by
   grw [h 0]
 
--- Test the `erw` version of `grw`.
+section erw
+
 example (h : 2 + 1 ≤ (3 : Int)) : 1 + 2 ≤ (4 : Int) := by
   grw (transparency := default) [h]
+  guard_target = (3 : Int) ≤ 4
   simp
+
+def double (x : Int) := x + x
+
+example (h : double (double 2) ≤ 10) : double 4 ≤ 20 := by
+  grw (transparency := default) [h]
+  guard_target = (10 : Int) ≤ 20
+  simp
+
+-- `rw`/`grw` index based on the head constant, so the following fails.
+/--
+error: Tactic `grewrite` failed: did not find instance of the pattern in the target expression
+  double 2
+
+h : double 2 ≤ 10
+⊢ 4 ≤ 20
+-/
+#guard_msgs in
+example (h : double 2 ≤ 10) : 4 ≤ 20 := by
+  grw (transparency := default) [h]
+
+end erw

--- a/MathlibTest/GRewrite.lean
+++ b/MathlibTest/GRewrite.lean
@@ -348,3 +348,8 @@ example (a b : Nat) (h : Nat → no_index (a ≤ b)) : a ≤ b := by
 
 example (a b : Nat) (h : Nat → no_index (a ≤ b)) : a ≤ b := by
   grw [h 0]
+
+-- Test the `erw` version of `grw`.
+example (h : 2 + 1 ≤ (3 : Int)) : 1 + 2 ≤ (4 : Int) := by
+  grw (transparency := default) [h]
+  simp


### PR DESCRIPTION
This PR modifies the `grw` implementation so that it supports `erw`-like behaviour.

I haven't added a separate `egrw` tactic (because I think the name gets a bit ridiculous), instead it should be used as `grw (transparency := default)`.

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

When merging, all the commits will be squashed into a single commit
listing all co-authors.

Co-authors in the squash commit are gathered from two sources:

First, all authors of commits to this PR branch are included. Thus,
one way to add co-authors is to include at least one commit authored by
each co-author among the commits in the pull request. If necessary, you
may create empty commits to indicate co-authorship, using commands like so:

git commit --author="Author Name <author@email.com>" --allow-empty -m "add Author Name as coauthor"

Second, co-authors can also be listed in lines at the very bottom of
the commit message (that is, directly before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines
at the bottom of the commit message (before the `---`, and also before
any "Co-authored-by" lines) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
