### PR TITLE
experiment(Algebra): measure the impact of removing redundant tactic invocations (WIP)

### DIFF
--- a/Mathlib/Algebra/Algebra/Bilinear.lean
+++ b/Mathlib/Algebra/Algebra/Bilinear.lean
@@ -125,7 +125,6 @@ variable {M : Type*} [AddCommMonoid M] [Module R M]
 theorem lift_lsmul_mul_eq_lsmul_lift_lsmul {r : R} :
     lift (lsmul R M ∘ₗ mul R R r) = lsmul R M r ∘ₗ lift (lsmul R M) := by
   apply TensorProduct.ext'
-  intro x a
   simp [← mul_smul, mul_comm]
 
 end NonUnitalNonAssoc

--- a/Mathlib/Algebra/Algebra/Subalgebra/Rank.lean
+++ b/Mathlib/Algebra/Algebra/Subalgebra/Rank.lean
@@ -37,6 +37,10 @@ theorem rank_sup_eq_rank_left_mul_rank_of_free :
   rcases subsingleton_or_nontrivial R with _ | _
   · haveI := Module.subsingleton R S; simp
   nontriviality S using rank_subsingleton'
+  letI : Algebra A (Algebra.adjoin A (B : Set S)) := Subalgebra.algebra _
+  letI : SMul A (Algebra.adjoin A (B : Set S)) := Algebra.toSMul
+  haveI : IsScalarTower R A (Algebra.adjoin A (B : Set S)) :=
+    IsScalarTower.of_algebraMap_eq (congrFun rfl)
   rw [rank_mul_rank R A (Algebra.adjoin A (B : Set S))]
   change _ = Module.rank R ((Algebra.adjoin A (B : Set S)).restrictScalars R)
   rw [Algebra.restrictScalars_adjoin]; rfl

--- a/Mathlib/Algebra/Algebra/Subalgebra/Rank.lean
+++ b/Mathlib/Algebra/Algebra/Subalgebra/Rank.lean
@@ -37,10 +37,6 @@ theorem rank_sup_eq_rank_left_mul_rank_of_free :
   rcases subsingleton_or_nontrivial R with _ | _
   · haveI := Module.subsingleton R S; simp
   nontriviality S using rank_subsingleton'
-  letI : Algebra A (Algebra.adjoin A (B : Set S)) := Subalgebra.algebra _
-  letI : SMul A (Algebra.adjoin A (B : Set S)) := Algebra.toSMul
-  haveI : IsScalarTower R A (Algebra.adjoin A (B : Set S)) :=
-    IsScalarTower.of_algebraMap_eq (congrFun rfl)
   rw [rank_mul_rank R A (Algebra.adjoin A (B : Set S))]
   change _ = Module.rank R ((Algebra.adjoin A (B : Set S)).restrictScalars R)
   rw [Algebra.restrictScalars_adjoin]; rfl

--- a/Mathlib/Algebra/BigOperators/Finsupp/Basic.lean
+++ b/Mathlib/Algebra/BigOperators/Finsupp/Basic.lean
@@ -408,9 +408,7 @@ theorem univ_sum_single_apply [AddCommMonoid M] [Fintype α] (i : α) (m : M) :
 @[simp]
 theorem univ_sum_single_apply' [AddCommMonoid M] [Fintype α] (i : α) (m : M) :
     ∑ j : α, single j m i = m := by
-  simp_rw [single, coe_mk]
-  classical rw [Finset.sum_pi_single]
-  simp
+  simp [single]
 
 lemma sum_single_add_single (f₁ f₂ : ι) (g₁ g₂ : A) (F : ι → A → B) (H : f₁ ≠ f₂)
     (HF : ∀ f, F f 0 = 0) :

--- a/Mathlib/Algebra/BigOperators/Group/Finset/Defs.lean
+++ b/Mathlib/Algebra/BigOperators/Group/Finset/Defs.lean
@@ -534,7 +534,6 @@ end bij
 theorem prod_hom_rel [CommMonoid N] {r : M → N → Prop} {f : ι → M} {g : ι → N} {s : Finset ι}
     (h₁ : r 1 1) (h₂ : ∀ a b c, r b c → r (f a * b) (g a * c)) :
     r (∏ x ∈ s, f x) (∏ x ∈ s, g x) := by
-  delta Finset.prod
   apply Multiset.prod_hom_rel <;> assumption
 
 variable (f s)

--- a/Mathlib/Algebra/Category/Grp/EpiMono.lean
+++ b/Mathlib/Algebra/Category/Grp/EpiMono.lean
@@ -311,7 +311,6 @@ variable {A B : AddGrpCat.{u}} (f : A ⟶ B)
 theorem epi_iff_surjective : Epi f ↔ Function.Surjective f := by
   have i1 : Epi f ↔ Epi (groupAddGroupEquivalence.inverse.map f) := by
     refine ⟨?_, groupAddGroupEquivalence.inverse.epi_of_epi_map⟩
-    intro e'
     apply groupAddGroupEquivalence.inverse.map_epi
   rwa [GrpCat.epi_iff_surjective] at i1
 

--- a/Mathlib/Algebra/ContinuedFractions/Computation/CorrectnessTerminating.lean
+++ b/Mathlib/Algebra/ContinuedFractions/Computation/CorrectnessTerminating.lean
@@ -167,20 +167,12 @@ theorem compExactValue_correctness_of_stream_eq_some :
       let ppB := ppconts.b
       let pA := pconts.a
       let pB := pconts.b
-      have : compExactValue ppconts pconts ifp_n.fr =
-          (ppA + ifp_n.fr⁻¹ * pA) / (ppB + ifp_n.fr⁻¹ * pB) := by
-        -- unfold compExactValue and the convergent computation once
-        simp only [compExactValue, ifp_n_fract_ne_zero, ↓reduceIte, nextConts, nextNum, one_mul,
-          nextDen, ppA, ppB]
-        ac_rfl
-      rw [this]
       -- two calculations needed to show the claim
       have tmp_calc :=
         compExactValue_correctness_of_stream_eq_some_aux_comp pA ppA ifp_succ_n_fr_ne_zero
       have tmp_calc' :=
         compExactValue_correctness_of_stream_eq_some_aux_comp pB ppB ifp_succ_n_fr_ne_zero
       let f := Int.fract (1 / ifp_n.fr)
-      have f_ne_zero : f ≠ 0 := by simpa [f] using ifp_succ_n_fr_ne_zero
       -- now unfold the recurrence one step and simplify both sides to arrive at the conclusion
       dsimp only [conts, pconts, ppconts]
       have hfr : (IntFractPair.of (1 / ifp_n.fr)).fr = f := rfl

--- a/Mathlib/Algebra/ContinuedFractions/Computation/TerminatesIffRat.lean
+++ b/Mathlib/Algebra/ContinuedFractions/Computation/TerminatesIffRat.lean
@@ -104,12 +104,10 @@ theorem exists_gcf_pair_rat_eq_nth_conts :
 
 theorem exists_rat_eq_nth_num : ∃ q : ℚ, (of v).nums n = (q : K) := by
   rcases exists_gcf_pair_rat_eq_nth_conts v n with ⟨⟨a, _⟩, nth_cont_eq⟩
-  use a
   simp [num_eq_conts_a, nth_cont_eq]
 
 theorem exists_rat_eq_nth_den : ∃ q : ℚ, (of v).dens n = (q : K) := by
   rcases exists_gcf_pair_rat_eq_nth_conts v n with ⟨⟨_, b⟩, nth_cont_eq⟩
-  use b
   simp [den_eq_conts_b, nth_cont_eq]
 
 /-- Every finite convergent corresponds to a rational number. -/

--- a/Mathlib/Algebra/Group/Nat/Range.lean
+++ b/Mathlib/Algebra/Group/Nat/Range.lean
@@ -23,7 +23,6 @@ namespace Finset
 theorem disjoint_range_addLeftEmbedding (a : ℕ) (s : Finset ℕ) :
     Disjoint (range a) (map (addLeftEmbedding a) s) := by
   simp_rw [disjoint_left, mem_map, mem_range, addLeftEmbedding_apply]
-  rintro _ h ⟨l, -, rfl⟩
   lia
 
 theorem disjoint_range_addRightEmbedding (a : ℕ) (s : Finset ℕ) :

--- a/Mathlib/Algebra/Homology/DerivedCategory/Ext/Basic.lean
+++ b/Mathlib/Algebra/Homology/DerivedCategory/Ext/Basic.lean
@@ -193,7 +193,6 @@ lemma mk₀_bijective : Function.Bijective (mk₀ (X := X) (Y := Y)) := by
     (h.homEquiv.trans (ShiftedHom.homEquiv _ (by simp))).trans homEquiv.symm
   have he : e.toFun = mk₀ := by
     ext f : 1
-    dsimp [e]
     apply homEquiv.injective
     apply (Equiv.apply_symm_apply _ _).trans
     symm

--- a/Mathlib/Algebra/Homology/TotalComplexShift.lean
+++ b/Mathlib/Algebra/Homology/TotalComplexShift.lean
@@ -279,7 +279,6 @@ lemma D₂_totalShift₂XIso_hom (n₀ n₁ n₀' n₁' : ℤ) (h₀ : n₀ + y 
     rw [Linear.units_smul_comp, Linear.comp_units_smul, smul_smul, smul_smul,
       ← Int.negOnePow_add, ← Int.negOnePow_add, ← Int.negOnePow_add,
       ← Int.negOnePow_add]
-    congr 2
     lia
   · rw [D₂_shape _ _ _ _ h, zero_comp, D₂_shape, comp_zero, smul_zero]
     simp_all only [up_Rel]

--- a/Mathlib/Algebra/Lie/Weights/RootSystem.lean
+++ b/Mathlib/Algebra/Lie/Weights/RootSystem.lean
@@ -130,7 +130,6 @@ lemma rootSpace_neg_nsmul_add_chainTop_of_lt (hα : α.IsNonZero) {n : ℕ} (hn 
       (chainTopCoeff α β + 1) • α + β := by
     simp only [Weight.coe_neg, ← Nat.cast_smul_eq_nsmul ℤ, Nat.cast_add, Nat.cast_one, coe_chainTop,
       smul_neg, ← neg_smul, hW, ← add_assoc, ← add_smul, ← sub_eq_add_neg]
-    congr 2
     ring
   have := rootSpace_neg_nsmul_add_chainTop_of_le (-α) W H₁
   rw [Weight.coe_neg, ← smul_neg, neg_neg, ← Weight.coe_neg, H₂] at this

--- a/Mathlib/Algebra/Module/LinearMap/Polynomial.lean
+++ b/Mathlib/Algebra/Module/LinearMap/Polynomial.lean
@@ -294,13 +294,11 @@ lemma polyCharpolyAux_eval_eq_toMatrix_charpoly_coeff (x : L) (i : ℕ) :
 lemma polyCharpolyAux_map_eq_charpoly [Module.Finite R M] [Module.Free R M]
     (x : L) :
     (polyCharpolyAux φ b bₘ).map (MvPolynomial.eval (b.repr x)) = (φ x).charpoly := by
-  nontriviality R
   rw [polyCharpolyAux_map_eq_toMatrix_charpoly, LinearMap.charpoly_toMatrix]
 
 @[simp]
 lemma polyCharpolyAux_coeff_eval [Module.Finite R M] [Module.Free R M] (x : L) (i : ℕ) :
     MvPolynomial.eval (b.repr x) ((polyCharpolyAux φ b bₘ).coeff i) = (φ x).charpoly.coeff i := by
-  nontriviality R
   rw [← polyCharpolyAux_map_eq_charpoly φ b bₘ x, Polynomial.coeff_map]
 
 lemma polyCharpolyAux_map_eval [Module.Finite R M] [Module.Free R M]

--- a/Mathlib/Algebra/Order/Module/HahnEmbedding.lean
+++ b/Mathlib/Algebra/Order/Module/HahnEmbedding.lean
@@ -884,7 +884,6 @@ theorem lt_extend [IsOrderedAddMonoid R] [Archimedean R] {x : M} (hx : x ∉ f.v
   · change f.val ≤ (f.extend hx).val
     simpa [extend, extendFun] using LinearPMap.left_le_sup _ _ _
   by_contra!
-  have : f.val.domain = (f.extend hx).val.domain := by congr
   rw [this] at hx
   contrapose! hx with h
   simpa using Submodule.mem_sup_right (by simp)

--- a/Mathlib/Algebra/Polynomial/Eval/Defs.lean
+++ b/Mathlib/Algebra/Polynomial/Eval/Defs.lean
@@ -80,7 +80,6 @@ theorem eval₂_monomial {n : ℕ} {r : R} : (monomial n r).eval₂ f x = f r * 
 @[simp]
 theorem eval₂_X_pow {n : ℕ} : (X ^ n).eval₂ f x = x ^ n := by
   rw [X_pow_eq_monomial]
-  convert eval₂_monomial f x (n := n) (r := 1)
   simp
 
 @[simp]

--- a/Mathlib/Algebra/Polynomial/Eval/Irreducible.lean
+++ b/Mathlib/Algebra/Polynomial/Eval/Irreducible.lean
@@ -44,7 +44,6 @@ it is monic and irreducible over `ℤ/pℤ` for some prime `p`.
 lemma Monic.irreducible_of_irreducible_map (f : R[X]) (h_mon : Monic f)
     (h_irr : Irreducible (f.map φ)) : Irreducible f := by
   refine ⟨h_irr.not_isUnit ∘ IsUnit.map (mapRingHom φ), fun a b h => ?_⟩
-  dsimp [Monic] at h_mon
   have q := (leadingCoeff_mul a b).symm
   rw [← h, h_mon] at q
   refine (h_irr.isUnit_or_isUnit <|


### PR DESCRIPTION
---
**Note: WIP. Do not merge.**

This PR benchmarks the impact of removing tactic invocations that appear to be "technically redundant". 

Note: A tactic invocation being technically redundant does not necessarily mean that we want to remove it.

The following tactics were blacklisted and therefore not removed even when they were detected as technically redundant:
* `change`
* `clear`
* `convert`
* `refine`
* `replace`
* `rw`
* `simp_rw`
* `simp`

If you think any tactics should be added to (or removed from) this blacklist, please let me know.

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

When merging, all the commits will be squashed into a single commit
listing all co-authors.

Co-authors in the squash commit are gathered from two sources:

First, all authors of commits to this PR branch are included. Thus,
one way to add co-authors is to include at least one commit authored by
each co-author among the commits in the pull request. If necessary, you
may create empty commits to indicate co-authorship, using commands like so:

git commit --author="Author Name <author@email.com>" --allow-empty -m "add Author Name as coauthor"

Second, co-authors can also be listed in lines at the very bottom of
the commit message (that is, directly before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines
at the bottom of the commit message (before the `---`, and also before
any "Co-authored-by" lines) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
