### PR TITLE
[Merged by Bors] - refactor(Algebra/Polynomial/Splits): continue deprecation

### DIFF
--- a/Archive/Wiedijk100Theorems/AbelRuffini.lean
+++ b/Archive/Wiedijk100Theorems/AbelRuffini.lean
@@ -168,8 +168,8 @@ theorem not_solvable_by_rad' (x : ℂ) (hx : aeval x (Φ ℚ 4 2) = 0) : ¬IsSol
 
 /-- **Abel-Ruffini Theorem** -/
 theorem exists_not_solvable_by_rad : ∃ x : ℂ, IsAlgebraic ℚ x ∧ ¬IsSolvableByRad ℚ x := by
-  obtain ⟨x, hx⟩ := exists_root_of_splits (algebraMap ℚ ℂ) (IsAlgClosed.splits_codomain (Φ ℚ 4 2))
-    (ne_of_eq_of_ne (degree_Phi 4 2) (mt WithBot.coe_eq_coe.mp (show 5 ≠ 0 by simp)))
+  obtain ⟨x, hx⟩ := (IsAlgClosed.splits (Φ ℂ 4 2)).exists_eval_eq_zero (by simp [degree_Phi])
+  rw [← map_Phi 4 2 (algebraMap ℚ ℂ), eval_map] at hx
   exact ⟨x, ⟨Φ ℚ 4 2, (monic_Phi 4 2).ne_zero, hx⟩, not_solvable_by_rad' x hx⟩
 
 end AbelRuffini

--- a/Mathlib/Algebra/Polynomial/Factors.lean
+++ b/Mathlib/Algebra/Polynomial/Factors.lean
@@ -256,6 +256,15 @@ theorem Splits.exists_eval_eq_zero (hf : Splits f) (hf0 : degree f ≠ 0) :
   obtain ⟨m, rfl⟩ := Multiset.exists_cons_of_mem ha
   exact ⟨a, hm ▸ by simp⟩
 
+/-- Pick a root of a polynomial that splits. -/
+noncomputable def rootOfSplits (hf : f.Splits) (hfd : f.degree ≠ 0) : R :=
+  Classical.choose <| hf.exists_eval_eq_zero hfd
+
+@[simp]
+theorem eval_rootOfSplits (hf : f.Splits) (hfd : f.degree ≠ 0) :
+    f.eval (rootOfSplits hf hfd) = 0 :=
+  Classical.choose_spec <| hf.exists_eval_eq_zero hfd
+
 theorem Splits.comp_X_sub_C (hf : f.Splits) (a : R) : (f.comp (X - C a)).Splits :=
   hf.comp_of_natDegree_le_one_of_monic (natDegree_sub_C.trans_le natDegree_X_le) (monic_X_sub_C a)
 

--- a/Mathlib/Algebra/Polynomial/Splits.lean
+++ b/Mathlib/Algebra/Polynomial/Splits.lean
@@ -107,30 +107,23 @@ alias Splits.comp_of_map_degree_le_one := Splits.comp_of_degree_le_one
 
 variable (i)
 
-theorem exists_root_of_splits' {f : K[X]} (hs : Splits (f.map i)) (hf0 : degree (f.map i) ≠ 0) :
-    ∃ x, eval₂ i x f = 0 := by
-  simpa only [eval_map] using hs.exists_eval_eq_zero hf0
+@[deprecated (since := "2025-12-01")]
+alias exists_root_of_splits' := Splits.exists_eval_eq_zero
 
-theorem roots_ne_zero_of_splits' {f : K[X]} (hs : Splits (f.map i))
-    (hf0 : natDegree (f.map i) ≠ 0) : (f.map i).roots ≠ 0 :=
-  hs.roots_ne_zero hf0
+@[deprecated (since := "2025-12-01")]
+alias roots_ne_zero_of_splits' := Splits.roots_ne_zero
 
-/-- Pick a root of a polynomial that splits. See `rootOfSplits` for polynomials over a field
-which has simpler assumptions. -/
-def rootOfSplits' {f : K[X]} (hf : (f.map i).Splits) (hfd : (f.map i).degree ≠ 0) : L :=
-  Classical.choose <| exists_root_of_splits' i hf hfd
+@[deprecated (since := "2025-12-01")]
+alias rootOfSplits' := rootOfSplits
 
-theorem map_rootOfSplits' {f : K[X]} (hf : (f.map i).Splits) (hfd) :
-    f.eval₂ i (rootOfSplits' i hf hfd) = 0 :=
-  Classical.choose_spec <| exists_root_of_splits' i hf hfd
+@[deprecated (since := "2025-12-01")]
+alias map_rootOfSplits' := eval_rootOfSplits
 
-theorem natDegree_eq_card_roots' {p : K[X]} {i : K →+* L} (hsplit : Splits (p.map i)) :
-    (p.map i).natDegree = Multiset.card (p.map i).roots :=
-  hsplit.natDegree_eq_card_roots
+@[deprecated (since := "2025-12-01")]
+alias natDegree_eq_card_roots' := Splits.natDegree_eq_card_roots
 
-theorem degree_eq_card_roots' {p : K[X]} {i : K →+* L} (p_ne_zero : p.map i ≠ 0)
-    (hsplit : Splits (p.map i)) : (p.map i).degree = Multiset.card (p.map i).roots := by
-  simp [degree_eq_natDegree p_ne_zero, natDegree_eq_card_roots' hsplit]
+@[deprecated (since := "2025-12-01")]
+alias degree_eq_card_roots' := Splits.degree_eq_card_roots
 
 end CommRing
 
@@ -171,27 +164,20 @@ theorem splits_of_splits_gcd_right [DecidableEq K] {f g : K[X]} (hg0 : g ≠ 0)
 @[deprecated (since := "2025-11-30")]
 alias degree_eq_one_of_irreducible_of_splits := Splits.degree_eq_one_of_irreducible
 
-theorem exists_root_of_splits {f : K[X]} (hs : Splits (f.map i)) (hf0 : degree f ≠ 0) :
-    ∃ x, eval₂ i x f = 0 :=
-  exists_root_of_splits' i hs ((f.degree_map i).symm ▸ hf0)
+@[deprecated (since := "2025-12-01")]
+alias exists_root_of_splits := Splits.exists_eval_eq_zero
 
-theorem roots_ne_zero_of_splits {f : K[X]} (hs : Splits (f.map i)) (hf0 : natDegree f ≠ 0) :
-    (f.map i).roots ≠ 0 :=
-  roots_ne_zero_of_splits' i hs (ne_of_eq_of_ne (natDegree_map i) hf0)
+@[deprecated (since := "2025-12-01")]
+alias roots_ne_zero_of_splits := Splits.roots_ne_zero
 
-/-- Pick a root of a polynomial that splits. This version is for polynomials over a field and has
-simpler assumptions. -/
-def rootOfSplits {f : K[X]} (hf : (f.map i).Splits) (hfd : f.degree ≠ 0) : L :=
-  rootOfSplits' i hf ((f.degree_map i).symm ▸ hfd)
+@[deprecated (since := "2025-12-01")]
+alias map_rootOfSplits := eval_rootOfSplits
 
 /-- `rootOfSplits'` is definitionally equal to `rootOfSplits`. -/
+@[deprecated "`rootOfSplits'` is now deprecated." (since := "2025-12-01")]
 theorem rootOfSplits'_eq_rootOfSplits {f : K[X]} (hf : (f.map i).Splits) (hfd) :
-    rootOfSplits' i hf hfd = rootOfSplits i hf (f.degree_map i ▸ hfd) :=
+    rootOfSplits hf hfd = rootOfSplits hf (f.degree_map i ▸ hfd) :=
   rfl
-
-theorem map_rootOfSplits {f : K[X]} (hf : (f.map i).Splits) (hfd) :
-    f.eval₂ i (rootOfSplits i hf hfd) = 0 :=
-  map_rootOfSplits' i hf (ne_of_eq_of_ne (degree_map f i) hfd)
 
 @[deprecated (since := "2025-11-30")]
 alias natDegree_eq_card_roots := Splits.natDegree_eq_card_roots

--- a/Mathlib/Analysis/Complex/Polynomial/GaussLucas.lean
+++ b/Mathlib/Analysis/Complex/Polynomial/GaussLucas.lean
@@ -47,8 +47,8 @@ theorem sum_derivRootWeight_pos (hP : 0 < degree P) (z : ℂ) :
       suffices z ≠ w by simpa [sq_pos_iff, sub_eq_zero]
       rintro rfl
       simp_all
-    · rw [Multiset.toFinset_nonempty, ← P.map_id]
-      apply P.roots_ne_zero_of_splits _ (IsAlgClosed.splits _)
+    · rw [Multiset.toFinset_nonempty]
+      apply Splits.roots_ne_zero (IsAlgClosed.splits _)
       rwa [← pos_iff_ne_zero, natDegree_pos_iff_degree_pos]
 
 /-- *Gauss-Lucas Theorem*: if $P$ is a nonconstant polynomial with complex coefficients,

--- a/Mathlib/FieldTheory/AbelRuffini.lean
+++ b/Mathlib/FieldTheory/AbelRuffini.lean
@@ -145,8 +145,8 @@ theorem splits_X_pow_sub_one_of_X_pow_sub_C {F : Type*} [Field F] {E : Type*} [F
   have hn' : 0 < n := pos_iff_ne_zero.mpr hn
   have hn'' : (X ^ n - C a).degree ≠ 0 :=
     ne_of_eq_of_ne (degree_X_pow_sub_C hn' a) (mt WithBot.coe_eq_coe.mp hn)
-  obtain ⟨b, hb⟩ := exists_root_of_splits i h hn''
-  rw [eval₂_sub, eval₂_X_pow, eval₂_C, sub_eq_zero] at hb
+  obtain ⟨b, hb⟩ := Splits.exists_eval_eq_zero h (by rwa [degree_map])
+  rw [eval_map, eval₂_sub, eval₂_X_pow, eval₂_C, sub_eq_zero] at hb
   have hb' : b ≠ 0 := by
     intro hb'
     rw [hb', zero_pow hn] at hb

--- a/Mathlib/FieldTheory/Extension.lean
+++ b/Mathlib/FieldTheory/Extension.lean
@@ -211,9 +211,9 @@ theorem exists_lift_of_splits' (x : Lifts F E K) {s : E} (h1 : IsIntegral x.carr
   let carrier := x.carrier⟮s⟯.restrictScalars F
   letI : Algebra x.carrier carrier := x.carrier⟮s⟯.toSubalgebra.algebra
   let φ : carrier →ₐ[x.carrier] K := ((algHomAdjoinIntegralEquiv x.carrier h1).symm
-    ⟨rootOfSplits x.emb.toRingHom h2 I2, by
+    ⟨rootOfSplits h2 (by rwa [degree_map]), by
       rw [mem_aroots, and_iff_right (minpoly.ne_zero h1)]
-      exact map_rootOfSplits x.emb.toRingHom h2 I2⟩)
+      exact (eval_map _ _).symm.trans (eval_rootOfSplits _ _)⟩)
   ⟨⟨carrier, (@algHomEquivSigma F x.carrier carrier K _ _ _ _ _ _ _ _
       (IsScalarTower.of_algebraMap_eq fun _ ↦ rfl)).symm ⟨x.emb, φ⟩⟩,
     ⟨fun z hz ↦ algebraMap_mem x.carrier⟮s⟯ ⟨z, hz⟩, φ.commutes⟩,

--- a/Mathlib/FieldTheory/IsAlgClosed/Basic.lean
+++ b/Mathlib/FieldTheory/IsAlgClosed/Basic.lean
@@ -88,7 +88,7 @@ If `k` is algebraically closed, then every nonconstant polynomial has a root.
 -/
 @[stacks 09GR "(4) ⟹ (3)"]
 theorem exists_root [IsAlgClosed k] (p : k[X]) (hp : p.degree ≠ 0) : ∃ x, IsRoot p x :=
-  exists_root_of_splits _ ((IsAlgClosed.splits p).map <| .id k) hp
+  (IsAlgClosed.splits p).exists_eval_eq_zero hp
 
 theorem exists_pow_nat_eq [IsAlgClosed k] (x : k) {n : ℕ} (hn : 0 < n) : ∃ z, z ^ n = x := by
   have : degree (X ^ n - C x) ≠ 0 := by

--- a/Mathlib/FieldTheory/IsSepClosed.lean
+++ b/Mathlib/FieldTheory/IsSepClosed.lean
@@ -93,7 +93,7 @@ namespace IsSepClosed
 
 theorem exists_root [IsSepClosed k] (p : k[X]) (hp : p.degree ≠ 0) (hsep : p.Separable) :
     ∃ x, IsRoot p x :=
-  exists_root_of_splits _ ((IsSepClosed.splits_of_separable p hsep).map (RingHom.id k)) hp
+  (IsSepClosed.splits_of_separable p hsep).exists_eval_eq_zero hp
 
 /-- If `n ≥ 2` equals zero in a separably closed field `k`, `b ≠ 0`,
 then there exists `x` in `k` such that `a * x ^ n + b * x + c = 0`. -/

--- a/Mathlib/FieldTheory/KummerExtension.lean
+++ b/Mathlib/FieldTheory/KummerExtension.lean
@@ -360,14 +360,14 @@ variable (a) (L)
 noncomputable
 abbrev rootOfSplitsXPowSubC (hn : 0 < n) (a : K)
     (L) [Field L] [Algebra K L] [IsSplittingField K L (X ^ n - C a)] : L :=
-  (rootOfSplits _ (IsSplittingField.splits L (X ^ n - C a))
+  (rootOfSplits (IsSplittingField.splits L (X ^ n - C a))
       (by simpa [degree_X_pow_sub_C hn] using Nat.pos_iff_ne_zero.mp hn))
 
 lemma rootOfSplitsXPowSubC_pow [NeZero n] :
     (rootOfSplitsXPowSubC (NeZero.pos n) a L) ^ n = algebraMap K L a := by
-  have := map_rootOfSplits _ (IsSplittingField.splits L (X ^ n - C a))
-  simp only [eval₂_sub, eval₂_X_pow, eval₂_C, sub_eq_zero] at this
-  exact this _
+  have := eval_rootOfSplits (IsSplittingField.splits L (X ^ n - C a))
+    (by simp [degree_X_pow_sub_C (NeZero.pos n), NeZero.ne n])
+  simpa only [eval_map, eval₂_sub, eval₂_X_pow, eval₂_C, sub_eq_zero] using this
 
 variable {a}
 

--- a/Mathlib/FieldTheory/PolynomialGaloisGroup.lean
+++ b/Mathlib/FieldTheory/PolynomialGaloisGroup.lean
@@ -304,12 +304,10 @@ theorem splits_in_splittingField_of_comp (hq : q.natDegree ≠ 0) :
     by_cases hr' : natDegree r = 0
     · exact Splits.of_natDegree_le_one <| natDegree_map_le.trans (hr'.trans_le zero_le_one)
     obtain ⟨x, hx⟩ :=
-      exists_root_of_splits _ (SplittingField.splits (r.comp q)) fun h =>
-        hr'
-          ((mul_eq_zero.mp
-                (natDegree_comp.symm.trans (natDegree_eq_of_degree_eq_some h))).resolve_right
-            hq)
-    rw [← aeval_def, aeval_comp] at hx
+      Splits.exists_eval_eq_zero (SplittingField.splits (r.comp q)) fun h =>
+        hr' ((mul_eq_zero.mp (natDegree_comp.symm.trans (natDegree_eq_of_degree_eq_some
+          (by rwa [degree_map] at h)))).resolve_right hq)
+    rw [eval_map, ← aeval_def, aeval_comp] at hx
     have h_normal : Normal F (r.comp q).SplittingField := SplittingField.instNormal (r.comp q)
     have qx_int := Normal.isIntegral h_normal (aeval x q)
     exact (h_normal.splits _).splits_of_dvd (map_ne_zero (minpoly.ne_zero (h_normal.isIntegral _)))
@@ -359,7 +357,7 @@ theorem prime_degree_dvd_card [CharZero F] (p_irr : Irreducible p) (p_deg : p.na
   have hp : p.degree ≠ 0 := fun h =>
     Nat.Prime.ne_zero p_deg (natDegree_eq_zero_iff_degree_le_zero.mpr (le_of_eq h))
   let α : p.SplittingField :=
-    rootOfSplits (algebraMap F p.SplittingField) (SplittingField.splits p) hp
+    rootOfSplits (SplittingField.splits p) (by rwa [degree_map])
   have hα : IsIntegral F α := .of_finite F α
   use Module.finrank F⟮α⟯ p.SplittingField
   suffices (minpoly F α).natDegree = p.natDegree by
@@ -372,7 +370,7 @@ theorem prime_degree_dvd_card [CharZero F] (p_irr : Irreducible p) (p_deg : p.na
     · exact natDegree_le_of_dvd this p_irr.ne_zero
     · exact natDegree_le_of_dvd key (minpoly.ne_zero hα)
   apply minpoly.dvd F α
-  rw [aeval_def, map_rootOfSplits _ (SplittingField.splits p) hp]
+  rw [aeval_def, ← eval_map, eval_rootOfSplits]
 
 end Gal
 

--- a/Mathlib/FieldTheory/SeparableDegree.lean
+++ b/Mathlib/FieldTheory/SeparableDegree.lean
@@ -333,10 +333,10 @@ theorem natSepDegree_one : (1 : F[X]).natSepDegree = 0 := by
 /-- A non-constant polynomial has non-zero separable degree. -/
 theorem natSepDegree_ne_zero (h : f.natDegree ≠ 0) : f.natSepDegree ≠ 0 := by
   rw [natSepDegree, ne_eq, Finset.card_eq_zero, ← ne_eq, ← Finset.nonempty_iff_ne_empty]
-  use rootOfSplits _ (SplittingField.splits f) (ne_of_apply_ne _ h)
+  use rootOfSplits (SplittingField.splits f) (degree_ne_of_natDegree_ne (by rwa [natDegree_map]))
   classical
   rw [Multiset.mem_toFinset, mem_aroots]
-  exact ⟨ne_of_apply_ne _ h, map_rootOfSplits _ (SplittingField.splits f) (ne_of_apply_ne _ h)⟩
+  exact ⟨ne_of_apply_ne _ h, by simp only [aeval_def, ← eval_map, eval_rootOfSplits]⟩
 
 /-- A polynomial has zero separable degree if and only if it is constant. -/
 theorem natSepDegree_eq_zero_iff : f.natSepDegree = 0 ↔ f.natDegree = 0 :=

--- a/Mathlib/NumberTheory/Cyclotomic/Basic.lean
+++ b/Mathlib/NumberTheory/Cyclotomic/Basic.lean
@@ -686,10 +686,10 @@ instance isCyclotomicExtension [NeZero (n : K)] :
   have : NeZero (n : CyclotomicField n K) :=
     NeZero.nat_of_injective (algebraMap K _).injective
   letI := Classical.decEq (CyclotomicField n K)
+  have := (degree_cyclotomic_pos n K (NeZero.pos n)).ne'
   obtain ⟨ζ, hζ⟩ :=
-    exists_root_of_splits (algebraMap K (CyclotomicField n K)) (SplittingField.splits _)
-      (degree_cyclotomic_pos n K (NeZero.pos n)).ne'
-  rw [← eval_map, ← IsRoot.def, map_cyclotomic, isRoot_cyclotomic_iff] at hζ
+    Splits.exists_eval_eq_zero (SplittingField.splits (cyclotomic n K)) (by rwa [degree_map])
+  rw [eval_map, ← eval_map, ← IsRoot.def, map_cyclotomic, isRoot_cyclotomic_iff] at hζ
   refine ⟨?_, ?_⟩
   · simp only [mem_singleton_iff, forall_eq]
     exact fun _ ↦ ⟨ζ, hζ⟩

--- a/Mathlib/RingTheory/Adjoin/Field.lean
+++ b/Mathlib/RingTheory/Adjoin/Field.lean
@@ -87,7 +87,8 @@ theorem Polynomial.lift_of_splits {F K L : Type*} [Field F] [Field K] [Field L] 
       refine Splits.splits_of_dvd H2 (map_ne_zero (minpoly.ne_zero H1)) ?_
       rw [IsScalarTower.algebraMap_eq F Ks L, ← map_map, map_dvd_map']
       exact minpoly.dvd_map_of_isScalarTower F Ks a
-    obtain ⟨y, hy⟩ := Polynomial.exists_root_of_splits _ H6 (minpoly.degree_pos H5).ne'
+    obtain ⟨y, hy⟩ := H6.exists_eval_eq_zero (by simp [(minpoly.degree_pos H5).ne'])
+    rw [eval_map] at hy
     exact ⟨Subalgebra.ofRestrictScalars F _ <| Algebra.adjoin.liftSingleton Ks a y hy⟩
 
 end Embeddings

--- a/Mathlib/Topology/Algebra/Polynomial.lean
+++ b/Mathlib/Topology/Algebra/Polynomial.lean
@@ -150,7 +150,7 @@ theorem eq_one_of_roots_le {p : F[X]} {f : F →+* K} {B : ℝ} (hB : B < 0) (h1
     (h2 : Splits (p.map f)) (h3 : ∀ z ∈ (map f p).roots, ‖z‖ ≤ B) : p = 1 :=
   h1.natDegree_eq_zero.mp (by
     contrapose! hB
-    rw [← h1.natDegree_map f, natDegree_eq_card_roots' h2] at hB
+    rw [← h1.natDegree_map f, Splits.natDegree_eq_card_roots h2] at hB
     obtain ⟨z, hz⟩ := card_pos_iff_exists_mem.mp (zero_lt_iff.mpr hB)
     exact le_trans (norm_nonneg _) (h3 z hz))
 
@@ -168,7 +168,7 @@ theorem coeff_le_of_roots_le {p : F[X]} {f : F →+* K} {B : ℝ} (i : ℕ) (h1 
   rw [coeff_eq_esymm_roots_of_splits h2 hi, (h1.map _).leadingCoeff,
     one_mul, norm_mul, norm_pow, norm_neg, norm_one, one_pow, one_mul]
   apply ((norm_multiset_sum_le _).trans <| sum_le_card_nsmul _ _ fun r hr => _).trans
-  · rw [Multiset.map_map, card_map, card_powersetCard, ← natDegree_eq_card_roots' h2,
+  · rw [Multiset.map_map, card_map, card_powersetCard, ← Splits.natDegree_eq_card_roots h2,
       Nat.choose_symm hi, mul_comm, nsmul_eq_mul]
   intro r hr
   simp_rw [Multiset.mem_map] at hr


### PR DESCRIPTION
This PR continues the deprecation in `Splits.lean` as we move over to the new API in `Factors.lean`.

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

When merging, all the commits will be squashed into a single commit
listing all co-authors.

Co-authors in the squash commit are gathered from two sources:

First, all authors of commits to this PR branch are included. Thus,
one way to add co-authors is to include at least one commit authored by
each co-author among the commits in the pull request. If necessary, you
may create empty commits to indicate co-authorship, using commands like so:

git commit --author="Author Name <author@email.com>" --allow-empty -m "add Author Name as coauthor"

Second, co-authors can also be listed in lines at the very bottom of
the commit message (that is, directly before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines
at the bottom of the commit message (before the `---`, and also before
any "Co-authored-by" lines) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
