### PR TITLE
[Merged by Bors] - chore: split operator monotonicity results to privately import integration results

### DIFF
--- a/Mathlib.lean
+++ b/Mathlib.lean
@@ -2080,6 +2080,7 @@ public import Mathlib.Analysis.SpecialFunctions.ContinuousFunctionalCalculus.Pos
 public import Mathlib.Analysis.SpecialFunctions.ContinuousFunctionalCalculus.Rpow.Basic
 public import Mathlib.Analysis.SpecialFunctions.ContinuousFunctionalCalculus.Rpow.IntegralRepresentation
 public import Mathlib.Analysis.SpecialFunctions.ContinuousFunctionalCalculus.Rpow.Isometric
+public import Mathlib.Analysis.SpecialFunctions.ContinuousFunctionalCalculus.Rpow.Order
 public import Mathlib.Analysis.SpecialFunctions.Elliptic.Weierstrass
 public import Mathlib.Analysis.SpecialFunctions.Exp
 public import Mathlib.Analysis.SpecialFunctions.ExpDeriv

--- a/Mathlib/Analysis/SpecialFunctions/ContinuousFunctionalCalculus/ExpLog/Order.lean
+++ b/Mathlib/Analysis/SpecialFunctions/ContinuousFunctionalCalculus/ExpLog/Order.lean
@@ -5,11 +5,12 @@ Authors: Frédéric Dupuis
 -/
 module
 
-public import Mathlib.Analysis.SpecialFunctions.Log.RpowTendsto
 public import Mathlib.Analysis.SpecialFunctions.ContinuousFunctionalCalculus.ExpLog.Basic
-public import
-  Mathlib.Analysis.SpecialFunctions.ContinuousFunctionalCalculus.Rpow.IntegralRepresentation
-public import Mathlib.Analysis.CStarAlgebra.ContinuousFunctionalCalculus.Continuity
+public import Mathlib.Analysis.CStarAlgebra.ContinuousFunctionalCalculus.Basic
+import Mathlib.Analysis.SpecialFunctions.ContinuousFunctionalCalculus.Rpow.Order
+import Mathlib.Analysis.CStarAlgebra.ContinuousFunctionalCalculus.Continuity
+import Mathlib.Analysis.CStarAlgebra.ContinuousFunctionalCalculus.Order
+import Mathlib.Analysis.SpecialFunctions.Log.RpowTendsto
 
 /-!
 # Order properties of the operator logarithm
@@ -38,7 +39,10 @@ lemma CFC.tendsto_cfc_rpow_sub_one_log {a : A} (ha : IsStrictlyPositive a := by 
     Tendsto (fun p : ℝ => cfc (fun x => p⁻¹ * (x ^ p - 1)) a) (𝓝[>] 0) (𝓝 (CFC.log a)) := by
   refine tendsto_cfc_fun ?tendsto ?cont
   case cont =>
-    exact .of_forall fun p ↦ by fun_prop (disch := grind -abstractProof)
+    exact .of_forall fun p ↦ by
+      refine ContinuousOn.mul (by fun_prop) ?_
+      exact ContinuousOn.sub (ContinuousOn.rpow (by fun_prop) (by fun_prop) (by grind))
+        (by fun_prop)
   case tendsto =>
     let s := {a : A | IsStrictlyPositive a}
     let f (p : ℝ) (x : ℝ) := if p > 0 then p⁻¹ * (x ^ p - 1) else Real.log x

--- a/Mathlib/Analysis/SpecialFunctions/ContinuousFunctionalCalculus/ExpLog/Order.lean
+++ b/Mathlib/Analysis/SpecialFunctions/ContinuousFunctionalCalculus/ExpLog/Order.lean
@@ -5,12 +5,13 @@ Authors: Frédéric Dupuis
 -/
 module
 
-public import Mathlib.Analysis.SpecialFunctions.ContinuousFunctionalCalculus.ExpLog.Basic
 public import Mathlib.Analysis.CStarAlgebra.ContinuousFunctionalCalculus.Basic
-import Mathlib.Analysis.SpecialFunctions.ContinuousFunctionalCalculus.Rpow.Order
+public import Mathlib.Analysis.SpecialFunctions.ContinuousFunctionalCalculus.ExpLog.Basic
 import Mathlib.Analysis.CStarAlgebra.ContinuousFunctionalCalculus.Continuity
 import Mathlib.Analysis.CStarAlgebra.ContinuousFunctionalCalculus.Order
+import Mathlib.Analysis.SpecialFunctions.ContinuousFunctionalCalculus.Rpow.Order
 import Mathlib.Analysis.SpecialFunctions.Log.RpowTendsto
+import Mathlib.Analysis.SpecialFunctions.Pow.Deriv
 
 /-!
 # Order properties of the operator logarithm
@@ -39,10 +40,7 @@ lemma CFC.tendsto_cfc_rpow_sub_one_log {a : A} (ha : IsStrictlyPositive a := by 
     Tendsto (fun p : ℝ => cfc (fun x => p⁻¹ * (x ^ p - 1)) a) (𝓝[>] 0) (𝓝 (CFC.log a)) := by
   refine tendsto_cfc_fun ?tendsto ?cont
   case cont =>
-    exact .of_forall fun p ↦ by
-      refine ContinuousOn.mul (by fun_prop) ?_
-      exact ContinuousOn.sub (ContinuousOn.rpow (by fun_prop) (by fun_prop) (by grind))
-        (by fun_prop)
+    exact .of_forall fun p ↦ by fun_prop (disch := grind -abstractProof)
   case tendsto =>
     let s := {a : A | IsStrictlyPositive a}
     let f (p : ℝ) (x : ℝ) := if p > 0 then p⁻¹ * (x ^ p - 1) else Real.log x

--- a/Mathlib/Analysis/SpecialFunctions/ContinuousFunctionalCalculus/Rpow/IntegralRepresentation.lean
+++ b/Mathlib/Analysis/SpecialFunctions/ContinuousFunctionalCalculus/Rpow/IntegralRepresentation.lean
@@ -5,9 +5,9 @@ Authors: Frédéric Dupuis
 -/
 module
 
-public import Mathlib.Analysis.SpecialFunctions.ImproperIntegrals
 public import Mathlib.Analysis.CStarAlgebra.ContinuousFunctionalCalculus.Integral
 public import Mathlib.Analysis.CStarAlgebra.ApproximateUnit
+import Mathlib.Analysis.SpecialFunctions.ImproperIntegrals
 
 /-!
 # Integral representations of `rpow`
@@ -446,75 +446,6 @@ lemma monotoneOn_cfcₙ_rpowIntegrand₀₁ {p : ℝ} {t : ℝ} (hp : p ∈ Ioo 
     _ = cfcₙ (rpowIntegrand₀₁ p t) b := by
       rw [cfcₙ_rpowIntegrand₀₁_eq_cfcₙ_rpowIntegrand₀₁_one hp ht b hb]
 
-/-- This is an intermediate result; use the more general `CFC.monotone_nnrpow` instead. -/
-private lemma monotoneOn_nnrpow_Ioo {p : ℝ≥0} (hp : p ∈ Ioo 0 1) :
-    MonotoneOn (fun a : A => a ^ p) (Ici 0) := by
-  obtain ⟨μ, hμ⟩ := exists_measure_nnrpow_eq_integral_cfcₙ_rpowIntegrand₀₁ A hp
-  have h₃' : (Ici 0).EqOn (fun a : A => a ^ p)
-      (fun a : A => ∫ t in Ioi 0, cfcₙ (rpowIntegrand₀₁ p t) a ∂μ) :=
-    fun a ha => (hμ a ha).2
-  refine MonotoneOn.congr ?_ h₃'.symm
-  refine integral_monotoneOn_of_integrand_ae ?_ fun a ha => (hμ a ha).1
-  filter_upwards [ae_restrict_mem measurableSet_Ioi] with t ht
-  exact monotoneOn_cfcₙ_rpowIntegrand₀₁ hp ht
-
-/-- `a ↦ a ^ p` is operator monotone for `p ∈ [0,1]`. -/
-lemma monotone_nnrpow {p : ℝ≥0} (hp : p ∈ Icc 0 1) :
-    Monotone (fun a : A => a ^ p) := by
-  intro a b hab
-  by_cases ha : 0 ≤ a
-  · have hb : 0 ≤ b := ha.trans hab
-    have hIcc : Icc (0 : ℝ≥0) 1 = Ioo 0 1 ∪ {0} ∪ {1} := by ext; simp
-    rw [hIcc] at hp
-    obtain (hp|hp)|hp := hp
-    · exact monotoneOn_nnrpow_Ioo hp ha hb hab
-    · simp_all [mem_singleton_iff]
-    · simp_all [mem_singleton_iff, nnrpow_one a, nnrpow_one b]
-  · have : a ^ p = 0 := cfcₙ_apply_of_not_predicate a ha
-    simp [this]
-
-/-- `CFC.sqrt` is operator monotone. -/
-lemma monotone_sqrt : Monotone (sqrt : A → A) := by
-  intro a b hab
-  rw [CFC.sqrt_eq_nnrpow a, CFC.sqrt_eq_nnrpow b]
-  refine (monotone_nnrpow (A := A) ?_) hab
-  constructor <;> norm_num
-
-@[gcongr]
-lemma nnrpow_le_nnrpow {p : ℝ≥0} (hp : p ∈ Icc 0 1) {a b : A} (hab : a ≤ b) :
-    a ^ p ≤ b ^ p := monotone_nnrpow hp hab
-
-@[gcongr]
-lemma sqrt_le_sqrt (a b : A) (hab : a ≤ b) : sqrt a ≤ sqrt b :=
-  monotone_sqrt hab
-
 end NonUnitalCStarAlgebra
-
-section UnitalCStarAlgebra
-
-variable {A : Type*} [CStarAlgebra A] [PartialOrder A] [StarOrderedRing A]
-
-/-- `a ↦ a ^ p` is operator monotone for `p ∈ [0,1]`. -/
-lemma monotone_rpow {p : ℝ} (hp : p ∈ Icc 0 1) : Monotone (fun a : A => a ^ p) := by
-  let q : ℝ≥0 := ⟨p, hp.1⟩
-  change Monotone (fun a : A => a ^ (q : ℝ))
-  cases (zero_le q).lt_or_eq' with
-  | inl hq =>
-    simp_rw [← CFC.nnrpow_eq_rpow hq]
-    exact monotone_nnrpow hp
-  | inr hq =>
-    simp only [hq, NNReal.coe_zero]
-    intro a b hab
-    by_cases ha : 0 ≤ a
-    · have hb : 0 ≤ b := ha.trans hab
-      simp [CFC.rpow_zero a, CFC.rpow_zero b]
-    · have : a ^ (0 : ℝ) = 0 := cfc_apply_of_not_predicate a ha
-      simp [this]
-
-@[gcongr]
-lemma rpow_le_rpow {p : ℝ} (hp : p ∈ Icc 0 1) {a b : A} (hab : a ≤ b) :
-    a ^ p ≤ b ^ p := monotone_rpow hp hab
-
-end UnitalCStarAlgebra
 
 end CFC

--- a/Mathlib/Analysis/SpecialFunctions/ContinuousFunctionalCalculus/Rpow/IntegralRepresentation.lean
+++ b/Mathlib/Analysis/SpecialFunctions/ContinuousFunctionalCalculus/Rpow/IntegralRepresentation.lean
@@ -19,7 +19,8 @@ the integrand `rpowIntegrand₀₁ p t x := t ^ p * (t⁻¹ - (t + x)⁻¹)`.
 This representation is useful for showing that `rpow` is operator monotone and operator concave
 in this range; that is, `cfc rpow` is monotone/concave. The integrand can be shown to be
 operator monotone and concave through direct means, and this integral lifts these properties
-to `rpow`.
+to `rpow`. These results can be found in
+`Mathlib.Analysis.SpecialFunctions.ContinuousFunctionalCalculus.Rpow.Order`.
 
 ## Notes
 
@@ -34,12 +35,9 @@ relevant in applications, and would needlessly complicate the proof.
   `x ^ p = ∫ t, rpowIntegrand₀₁ p t x ∂μ`
 + `CFC.exists_measure_nnrpow_eq_integral_cfcₙ_rpowIntegrand₀₁`: the corresponding statement where
   `x ^ p` is defined via the CFC.
-+ `CFC.monotone_nnrpow`, `CFC.monotone_rpow`: `a ↦ a ^ p` is operator monotone for `p ∈ [0,1]`
-+ `CFC.monotone_sqrt`: `CFC.sqrt` is operator monotone
 
 ## TODO
 
-+ Show operator concavity of `rpow` over `Icc 0 1`
 + Give analogous representations for the ranges `Ioo (-1) 0` and `Ioo 1 2`.
 
 ## References

--- a/Mathlib/Analysis/SpecialFunctions/ContinuousFunctionalCalculus/Rpow/Order.lean
+++ b/Mathlib/Analysis/SpecialFunctions/ContinuousFunctionalCalculus/Rpow/Order.lean
@@ -1,0 +1,135 @@
+/-
+Copyright (c) 2025 Frédéric Dupuis. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Frédéric Dupuis
+-/
+module
+
+public import Mathlib.Analysis.CStarAlgebra.ContinuousFunctionalCalculus.Basic
+public import Mathlib.Analysis.SpecialFunctions.ContinuousFunctionalCalculus.Rpow.Basic
+import Mathlib.Analysis.SpecialFunctions.ContinuousFunctionalCalculus.Rpow.IntegralRepresentation
+
+/-!
+# Integral representations of `rpow`
+
+This file contains an integral representation of the `rpow` function between 0 and 1: we show
+that there exists a measure on ℝ such that `x ^ p = ∫ t, rpowIntegrand₀₁ p t x ∂μ` for
+the integrand `rpowIntegrand₀₁ p t x := t ^ p * (t⁻¹ - (t + x)⁻¹)`.
+
+This representation is useful for showing that `rpow` is operator monotone and operator concave
+in this range; that is, `cfc rpow` is monotone/concave. The integrand can be shown to be
+operator monotone and concave through direct means, and this integral lifts these properties
+to `rpow`.
+
+## Notes
+
+Here we only compute the integral up to a constant, even though the actual constant can be
+computed via contour integration. We chose to avoid this, as the constant is seldom if ever
+relevant in applications, and would needlessly complicate the proof.
+
+## Main declarations
+
++ `rpowIntegrand₀₁ p t x := t ^ p * (t⁻¹ - (t + x)⁻¹)`
++ `exists_measure_rpow_eq_integral`: there exists a measure on `ℝ` such that
+  `x ^ p = ∫ t, rpowIntegrand₀₁ p t x ∂μ`
++ `CFC.exists_measure_nnrpow_eq_integral_cfcₙ_rpowIntegrand₀₁`: the corresponding statement where
+  `x ^ p` is defined via the CFC.
++ `CFC.monotone_nnrpow`, `CFC.monotone_rpow`: `a ↦ a ^ p` is operator monotone for `p ∈ [0,1]`
++ `CFC.monotone_sqrt`: `CFC.sqrt` is operator monotone
+
+## TODO
+
++ Show operator concavity of `rpow` over `Icc 0 1`
++ Give analogous representations for the ranges `Ioo (-1) 0` and `Ioo 1 2`.
+
+## References
+
++ [carlen2010] Eric A. Carlen, "Trace inequalities and quantum entropies: An introductory course"
+  (see Lemma 2.8)
+-/
+
+@[expose] public section
+
+open Set
+open scoped NNReal
+
+namespace CFC
+
+section NonUnitalCStarAlgebra
+
+variable {A : Type*} [NonUnitalCStarAlgebra A] [PartialOrder A] [StarOrderedRing A]
+
+open Real MeasureTheory
+
+/-- This is an intermediate result; use the more general `CFC.monotone_nnrpow` instead. -/
+private lemma monotoneOn_nnrpow_Ioo {p : ℝ≥0} (hp : p ∈ Ioo 0 1) :
+    MonotoneOn (fun a : A => a ^ p) (Ici 0) := by
+  obtain ⟨μ, hμ⟩ := CFC.exists_measure_nnrpow_eq_integral_cfcₙ_rpowIntegrand₀₁ A hp
+  have h₃' : (Ici 0).EqOn (fun a : A => a ^ p)
+      (fun a : A => ∫ t in Ioi 0, cfcₙ (rpowIntegrand₀₁ p t) a ∂μ) :=
+    fun a ha => (hμ a ha).2
+  refine MonotoneOn.congr ?_ h₃'.symm
+  refine integral_monotoneOn_of_integrand_ae ?_ fun a ha => (hμ a ha).1
+  filter_upwards [ae_restrict_mem measurableSet_Ioi] with t ht
+  exact monotoneOn_cfcₙ_rpowIntegrand₀₁ hp ht
+
+/-- `a ↦ a ^ p` is operator monotone for `p ∈ [0,1]`. -/
+lemma monotone_nnrpow {p : ℝ≥0} (hp : p ∈ Icc 0 1) :
+    Monotone (fun a : A => a ^ p) := by
+  intro a b hab
+  by_cases ha : 0 ≤ a
+  · have hb : 0 ≤ b := ha.trans hab
+    have hIcc : Icc (0 : ℝ≥0) 1 = Ioo 0 1 ∪ {0} ∪ {1} := by ext; simp
+    rw [hIcc] at hp
+    obtain (hp|hp)|hp := hp
+    · exact monotoneOn_nnrpow_Ioo hp ha hb hab
+    · simp_all [mem_singleton_iff]
+    · simp_all [mem_singleton_iff, nnrpow_one a, nnrpow_one b]
+  · have : a ^ p = 0 := cfcₙ_apply_of_not_predicate a ha
+    simp [this]
+
+/-- `CFC.sqrt` is operator monotone. -/
+lemma monotone_sqrt : Monotone (sqrt : A → A) := by
+  intro a b hab
+  rw [CFC.sqrt_eq_nnrpow a, CFC.sqrt_eq_nnrpow b]
+  refine (monotone_nnrpow (A := A) ?_) hab
+  constructor <;> norm_num
+
+@[gcongr]
+lemma nnrpow_le_nnrpow {p : ℝ≥0} (hp : p ∈ Icc 0 1) {a b : A} (hab : a ≤ b) :
+    a ^ p ≤ b ^ p := monotone_nnrpow hp hab
+
+@[gcongr]
+lemma sqrt_le_sqrt (a b : A) (hab : a ≤ b) : sqrt a ≤ sqrt b :=
+  monotone_sqrt hab
+
+end NonUnitalCStarAlgebra
+
+section UnitalCStarAlgebra
+
+variable {A : Type*} [CStarAlgebra A] [PartialOrder A] [StarOrderedRing A]
+
+/-- `a ↦ a ^ p` is operator monotone for `p ∈ [0,1]`. -/
+lemma monotone_rpow {p : ℝ} (hp : p ∈ Icc 0 1) : Monotone (fun a : A => a ^ p) := by
+  let q : ℝ≥0 := ⟨p, hp.1⟩
+  change Monotone (fun a : A => a ^ (q : ℝ))
+  cases (zero_le q).lt_or_eq' with
+  | inl hq =>
+    simp_rw [← CFC.nnrpow_eq_rpow hq]
+    exact monotone_nnrpow hp
+  | inr hq =>
+    simp only [hq, NNReal.coe_zero]
+    intro a b hab
+    by_cases ha : 0 ≤ a
+    · have hb : 0 ≤ b := ha.trans hab
+      simp [CFC.rpow_zero a, CFC.rpow_zero b]
+    · have : a ^ (0 : ℝ) = 0 := cfc_apply_of_not_predicate a ha
+      simp [this]
+
+@[gcongr]
+lemma rpow_le_rpow {p : ℝ} (hp : p ∈ Icc 0 1) {a b : A} (hab : a ≤ b) :
+    a ^ p ≤ b ^ p := monotone_rpow hp hab
+
+end UnitalCStarAlgebra
+
+end CFC

--- a/Mathlib/Analysis/SpecialFunctions/ContinuousFunctionalCalculus/Rpow/Order.lean
+++ b/Mathlib/Analysis/SpecialFunctions/ContinuousFunctionalCalculus/Rpow/Order.lean
@@ -10,16 +10,11 @@ public import Mathlib.Analysis.SpecialFunctions.ContinuousFunctionalCalculus.Rpo
 import Mathlib.Analysis.SpecialFunctions.ContinuousFunctionalCalculus.Rpow.IntegralRepresentation
 
 /-!
-# Integral representations of `rpow`
+# Operator monotonicity/concavity/convexity of `rpow`
 
-This file contains an integral representation of the `rpow` function between 0 and 1: we show
-that there exists a measure on ℝ such that `x ^ p = ∫ t, rpowIntegrand₀₁ p t x ∂μ` for
-the integrand `rpowIntegrand₀₁ p t x := t ^ p * (t⁻¹ - (t + x)⁻¹)`.
-
-This representation is useful for showing that `rpow` is operator monotone and operator concave
-in this range; that is, `cfc rpow` is monotone/concave. The integrand can be shown to be
-operator monotone and concave through direct means, and this integral lifts these properties
-to `rpow`.
+This file shows that `a ↦ a ^ p` is monotone for `p ∈ [0, 1]`, where `a` is an element of a
+C⋆-algebra. The proof makes use of the integral representation of `rpow` in
+`Mathlib.Analysis.SpecialFunctions.ContinuousFunctionalCalculus.Rpow.IntegralRepresentation`.
 
 ## Notes
 
@@ -29,18 +24,12 @@ relevant in applications, and would needlessly complicate the proof.
 
 ## Main declarations
 
-+ `rpowIntegrand₀₁ p t x := t ^ p * (t⁻¹ - (t + x)⁻¹)`
-+ `exists_measure_rpow_eq_integral`: there exists a measure on `ℝ` such that
-  `x ^ p = ∫ t, rpowIntegrand₀₁ p t x ∂μ`
-+ `CFC.exists_measure_nnrpow_eq_integral_cfcₙ_rpowIntegrand₀₁`: the corresponding statement where
-  `x ^ p` is defined via the CFC.
 + `CFC.monotone_nnrpow`, `CFC.monotone_rpow`: `a ↦ a ^ p` is operator monotone for `p ∈ [0,1]`
 + `CFC.monotone_sqrt`: `CFC.sqrt` is operator monotone
 
 ## TODO
 
 + Show operator concavity of `rpow` over `Icc 0 1`
-+ Give analogous representations for the ranges `Ioo (-1) 0` and `Ioo 1 2`.
 
 ## References
 

--- a/Mathlib/Analysis/SpecialFunctions/ContinuousFunctionalCalculus/Rpow/Order.lean
+++ b/Mathlib/Analysis/SpecialFunctions/ContinuousFunctionalCalculus/Rpow/Order.lean
@@ -10,7 +10,7 @@ public import Mathlib.Analysis.SpecialFunctions.ContinuousFunctionalCalculus.Rpo
 import Mathlib.Analysis.SpecialFunctions.ContinuousFunctionalCalculus.Rpow.IntegralRepresentation
 
 /-!
-# Operator monotonicity/concavity/convexity of `rpow`
+# Order properties of `CFC.rpow`
 
 This file shows that `a ↦ a ^ p` is monotone for `p ∈ [0, 1]`, where `a` is an element of a
 C⋆-algebra. The proof makes use of the integral representation of `rpow` in
@@ -30,6 +30,8 @@ relevant in applications, and would needlessly complicate the proof.
 ## TODO
 
 + Show operator concavity of `rpow` over `Icc 0 1`
++ Show that `rpow` over `Icc (-1) 0` is operator antitone and operator convex
++ Show operator convexity of `rpow` over `Icc 1 2`
 
 ## References
 

--- a/Mathlib/Analysis/SpecialFunctions/ContinuousFunctionalCalculus/Rpow/Order.lean
+++ b/Mathlib/Analysis/SpecialFunctions/ContinuousFunctionalCalculus/Rpow/Order.lean
@@ -16,12 +16,6 @@ This file shows that `a ↦ a ^ p` is monotone for `p ∈ [0, 1]`, where `a` is 
 C⋆-algebra. The proof makes use of the integral representation of `rpow` in
 `Mathlib.Analysis.SpecialFunctions.ContinuousFunctionalCalculus.Rpow.IntegralRepresentation`.
 
-## Notes
-
-Here we only compute the integral up to a constant, even though the actual constant can be
-computed via contour integration. We chose to avoid this, as the constant is seldom if ever
-relevant in applications, and would needlessly complicate the proof.
-
 ## Main declarations
 
 + `CFC.monotone_nnrpow`, `CFC.monotone_rpow`: `a ↦ a ^ p` is operator monotone for `p ∈ [0,1]`


### PR DESCRIPTION
This PR splits the file `Mathlib.Analysis.SpecialFunctions.ContinuousFunctionalCalculus.Rpow.IntegralRepresentation` to split off operator monotonicity results into their own file (called `Order`). This allows us to privately
import the results about CFC integration since they are rather heavy and only used as a proof technique.

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

When merging, all the commits will be squashed into a single commit
listing all co-authors.

Co-authors in the squash commit are gathered from two sources:

First, all authors of commits to this PR branch are included. Thus,
one way to add co-authors is to include at least one commit authored by
each co-author among the commits in the pull request. If necessary, you
may create empty commits to indicate co-authorship, using commands like so:

git commit --author="Author Name <author@email.com>" --allow-empty -m "add Author Name as coauthor"

Second, co-authors can also be listed in lines at the very bottom of
the commit message (that is, directly before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines
at the bottom of the commit message (before the `---`, and also before
any "Co-authored-by" lines) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
