### PR TITLE
[Merged by Bors] - doc(RingTheory/Perfectoid): fix documentations of B_dR

### DIFF
--- a/Mathlib/RingTheory/Perfectoid/BDeRham.lean
+++ b/Mathlib/RingTheory/Perfectoid/BDeRham.lean
@@ -11,22 +11,22 @@ public import Mathlib.RingTheory.Perfectoid.FontaineTheta
 
 /-!
 
-# The de Rham Period Ring \(\mathbb{B}_dR^+\) and \(\mathbb{B}_dR\)
+# The de Rham Period Ring $\mathbb{B}_{dR}^+$ and $\mathbb{B}_{dR}$
 
-In this file, we define the de Rham period ring \(\mathbb{B}_dR^+\) and
-the de Rham ring \(\mathbb{B}_dR\). We define a generalized version of
+In this file, we define the de Rham period ring $\mathbb{B}_{dR}^+$ and
+the de Rham ring $\mathbb{B}_{dR}$. We define a generalized version of
 these period rings following Scholze. When `R` is the ring of integers
 of `ℂₚ` (`PadicComplexInt`), they coincide with the classical de Rham period rings.
 
 ## Main definitions
 
-* `BDeRhamPlus` : The period ring \(\mathbb{B}_dR^+\).
-* `BDeRham` : The period ring \(\mathbb{B}_dR\).
+* `BDeRhamPlus` : The period ring $\mathbb{B}_{dR}^+$.
+* `BDeRham` : The period ring $\mathbb{B}_{dR}$.
 
 ## TODO
 
-1. Extend the θ map to \(\mathbb{B}_dR^+\)
-2. Show that \(\mathbb{B}_dR^+\) is a discrete valuation ring.
+1. Extend the θ map to $\mathbb{B}_{dR}^+$
+2. Show that $\mathbb{B}_{dR}^+$ is a discrete valuation ring.
 3. Show that ker θ is principal when the base ring is integral perfectoid.
 
 Currently, the period ring `BDeRhamPlus` takes the ring of integers `R` as the input.
@@ -67,9 +67,9 @@ def fontaineThetaInvertP :
       (by simpa using IsLocalization.Away.algebraMap_isUnit (p : R))
 
 /--
-The de Rham period ring \(\mathbb{B}_dR^+\) for general perfectoid ring.
+The de Rham period ring $\mathbb{B}_{dR}^+$ for general perfectoid ring.
 It is the completion of `𝕎 R♭` inverting `p` with respect to the kernel of
-the Fontaine's θ map. When \(R = \mathcal{O}_{\mathbb{C}_p}\), it coincides
+the Fontaine's θ map. When $R = \mathcal{O}_{\mathbb{C}_p}$, it coincides
 with the classical de Rham period ring. Note that if `p = 0` in `R`,
 then this
 definition is the zero ring.
@@ -80,11 +80,11 @@ def BDeRhamPlus : Type u :=
 instance : CommRing (BDeRhamPlus R p) := AdicCompletion.instCommRing _
 
 /--
-The de Rham period ring \(\mathbb{B}_dR\) for general perfectoid ring.
-It is defined as \(\mathbb{B}_dR^+\) inverting the generators of the ideal `ker θ`.
+The de Rham period ring $\mathbb{B}_{dR}$ for general perfectoid ring.
+It is defined as $\mathbb{B}_{dR}^+$ inverting the generators of the ideal `ker θ`.
 Mathematically, this is equivalent to inverting *a* generator of the ideal `ker θ`
 after we show that it is principal.
-When \(R = \mathcal{O}_{\mathbb{C}_p}\), it coincides
+When $R = \mathcal{O}_{\mathbb{C}_p}$, it coincides
 with the classical de Rham period ring.
 Note that if `p = 0` in `R`, then this definition is the zero ring.
 -/

--- a/Mathlib/RingTheory/Perfectoid/FontaineTheta.lean
+++ b/Mathlib/RingTheory/Perfectoid/FontaineTheta.lean
@@ -22,8 +22,8 @@ We only need `R` to be `p`-adically complete.
 ## TODO
 Establish that our definition (explicit construction of `θ mod p ^ n`) agrees with the
 deformation-theoretic approach via the cotangent complex, as in
-[Bhatt, *Lecture notes for a class on perfectoid spaces*. Remark 6.1.7]
-(https://www.math.ias.edu/~bhatt/teaching/mat679w17/lectures.pdf).
+[Bhatt, *Lecture notes for a class on perfectoid spaces*.
+Remark 6.1.7](https://www.math.ias.edu/~bhatt/teaching/mat679w17/lectures.pdf).
 
 ## Tags
 Fontaine's theta map, perfectoid theory, p-adic Hodge theory
@@ -62,15 +62,15 @@ ring homomorphism `fontaineTheta : 𝕎 R♭ →+* R`.
 To prove this, we define `fontaineThetaModPPow` as a composition of the following ring
 homomorphisms.
 
-`𝕎 R♭ --𝕎(Frob^-n)-> 𝕎 R♭ --𝕎(coeff 0)-> 𝕎(R/p) --gh_n-> R/p^(n+1)`
+`𝕎 R♭ --𝕎(Frob^-n)-> 𝕎 R♭ --𝕎(coeff 0)-> 𝕎(R/𝔭) --gh_n-> R/𝔭^(n+1)`
 
 Here, the ring map `gh_n` fits in the following diagram.
 
 ```
-𝕎(A)  --ghost_n->   A
+𝕎(R)  --ghost_n->   R
 |                   |
 v                   v
-𝕎(A/p) --gh_n-> A/p^(n+1)
+𝕎(R/𝔭) --gh_n-> R/𝔭^(n+1)
 ```
 -/
 
@@ -89,8 +89,8 @@ theorem ker_map_le_ker_mk_comp_ghostComponent (n : ℕ) :
   exact pow_dvd_ghostComponent_of_dvd_coeff (fun _ _ ↦ h _)
 
 /--
-The lift ring map `gh_n : 𝕎(A/p) →+* A/p^(n+1)` of the `n`-th ghost component
-`𝕎(A) →+* A` along the surjective ring map `𝕎(A) →+* 𝕎(A/p)`.
+The lift ring map `gh_n : 𝕎(R/𝔭) →+* R/𝔭^(n+1)` of the `n`-th ghost component
+`𝕎(R) →+* R` along the surjective ring map `𝕎(R) →+* 𝕎(R/𝔭)`.
 -/
 def ghostComponentModPPow (n : ℕ) : 𝕎 (R ⧸ 𝔭) →+* R ⧸ 𝔭 ^ (n + 1) :=
   RingHom.liftOfSurjective (WittVector.map (Ideal.Quotient.mk 𝔭))


### PR DESCRIPTION
Changed `\(...\)` to `$...$`.

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

When merging, all the commits will be squashed into a single commit
listing all co-authors.

Co-authors in the squash commit are gathered from two sources:

First, all authors of commits to this PR branch are included. Thus,
one way to add co-authors is to include at least one commit authored by
each co-author among the commits in the pull request. If necessary, you
may create empty commits to indicate co-authorship, using commands like so:

git commit --author="Author Name <author@email.com>" --allow-empty -m "add Author Name as coauthor"

Second, co-authors can also be listed in lines at the very bottom of
the commit message (that is, directly before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines
at the bottom of the commit message (before the `---`, and also before
any "Co-authored-by" lines) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
