### PR TITLE
[Merged by Bors] - feat(CategoryTheory): Ext-groups in Grothendieck abelian categories

### DIFF
--- a/Mathlib.lean
+++ b/Mathlib.lean
@@ -2174,6 +2174,7 @@ public import Mathlib.CategoryTheory.Abelian.GrothendieckCategory.Basic
 public import Mathlib.CategoryTheory.Abelian.GrothendieckCategory.ColimCoyoneda
 public import Mathlib.CategoryTheory.Abelian.GrothendieckCategory.Coseparator
 public import Mathlib.CategoryTheory.Abelian.GrothendieckCategory.EnoughInjectives
+public import Mathlib.CategoryTheory.Abelian.GrothendieckCategory.HasExt
 public import Mathlib.CategoryTheory.Abelian.GrothendieckCategory.ModuleEmbedding.GabrielPopescu
 public import Mathlib.CategoryTheory.Abelian.GrothendieckCategory.ModuleEmbedding.Opposite
 public import Mathlib.CategoryTheory.Abelian.GrothendieckCategory.Monomorphisms

--- a/Mathlib/CategoryTheory/Abelian/GrothendieckCategory/HasExt.lean
+++ b/Mathlib/CategoryTheory/Abelian/GrothendieckCategory/HasExt.lean
@@ -1,0 +1,41 @@
+/-
+Copyright (c) 2025 Joël Riou. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Joël Riou
+-/
+module
+
+public import Mathlib.Algebra.Homology.DerivedCategory.Ext.EnoughInjectives
+public import Mathlib.CategoryTheory.Abelian.GrothendieckCategory.EnoughInjectives
+
+/-!
+# Ext in Grothendieck abelian categories
+
+Let `C : Type u` be an abelian category (with `Category.{v} C`).
+If `C` is a Grothendieck abelian category relatively to a universe `w`,
+the morphisms in `C` must be `w`-small, and as `C` has enough injectives,
+the `Ext`-groups are also `w`-small. If `C` is a nonzero category,
+it is possible to show that any `w`-small type `T` injects in a type
+of morphisms in `C` (consider the various inclusions
+`X ⟶ ∐ (fun (_ : T) ↦ X)` for a nonzero object `X : C`). It follows that it
+is reasonable to think that the universe `w` is unique, and is the best
+choice for the universe where the `Ext`-groups in `C` shall be defined.
+
+In this situation, we make `HasExt.{w} C` an instance.
+As result, when `X` and `Y` are objects in `C` and `n : ℕ`,
+we have `Ext X Y n : Type w`.
+
+-/
+
+@[expose] public section
+
+namespace CategoryTheory
+
+universe w v u
+
+instance IsGrothendieckAbelian.hasExt
+    (C : Type u) [Category.{v} C] [Abelian C] [IsGrothendieckAbelian.{w} C] :
+    HasExt.{w} C :=
+  hasExt_of_enoughInjectives _
+
+end CategoryTheory


### PR DESCRIPTION
If an abelian category `C` satisfies `IsGrothendieckAbelian.{w} C`, we define a `HasExt.{w} C` instance (which follows from the existence of enough injectives in `C`). The consequence is that `Ext X Y n : Type w` when `X` and `Y` are objects in `C`.
As it can be argued that the universe `w` must be unique (when `C` is nonzero), this is the best choice of universe for the definition of `Ext`-groups.

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

When merging, all the commits will be squashed into a single commit
listing all co-authors.

Co-authors in the squash commit are gathered from two sources:

First, all authors of commits to this PR branch are included. Thus,
one way to add co-authors is to include at least one commit authored by
each co-author among the commits in the pull request. If necessary, you
may create empty commits to indicate co-authorship, using commands like so:

git commit --author="Author Name <author@email.com>" --allow-empty -m "add Author Name as coauthor"

Second, co-authors can also be listed in lines at the very bottom of
the commit message (that is, directly before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines
at the bottom of the commit message (before the `---`, and also before
any "Co-authored-by" lines) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
