### PR TITLE
[Merged by Bors] - chore(Tactic): copy docs to undocumented tactics

### DIFF
--- a/Mathlib/LinearAlgebra/Dual/Basis.lean
+++ b/Mathlib/LinearAlgebra/Dual/Basis.lean
@@ -216,6 +216,7 @@ open Lean.Elab.Tactic in
 meta def evalUseFiniteInstance : TacticM Unit := do
   evalTactic (← `(tactic| intros; apply Set.toFinite))
 
+@[inherit_doc evalUseFiniteInstance]
 elab "use_finite_instance" : tactic => evalUseFiniteInstance
 
 /-- `e` and `ε` have characteristic properties of a basis and its dual -/

--- a/Mathlib/Tactic/CancelDenoms/Core.lean
+++ b/Mathlib/Tactic/CancelDenoms/Core.lean
@@ -341,6 +341,7 @@ def cancelDenominators (loc : Location) : TacticM Unit := do
   withLocation loc cancelDenominatorsAt cancelDenominatorsTarget
     (fun _ ↦ throwError "Failed to cancel any denominators")
 
+@[tactic_alt cancelDenoms]
 elab "cancel_denoms" loc?:(location)? : tactic => do
   cancelDenominators (expandOptLocation (Lean.mkOptionalNode loc?))
   Lean.Elab.Tactic.evalTactic (← `(tactic| try norm_num [← mul_assoc] $[$loc?]?))

--- a/Mathlib/Tactic/Find.lean
+++ b/Mathlib/Tactic/Find.lean
@@ -89,7 +89,7 @@ def findType (t : Expr) : TermElabM Unit := withReducible do
       logInfo m!"{n}: {cTy}"
 
 open Lean.Elab.Command in
-/-
+/--
 The `#find` command finds definitions & lemmas using pattern matching on the type. For instance:
 ```lean
 #find _ + _ = _ + _
@@ -118,7 +118,7 @@ but they will work fine in a new file!) -/
 -- #find ?n ≤ ?m → ?n + _ ≤ ?m + _
 
 open Lean.Elab.Tactic
-/-
+/--
 Display theorems (and definitions) whose result type matches the current goal,
 i.e. which should be `apply`able.
 ```lean

--- a/Mathlib/Tactic/Have.lean
+++ b/Mathlib/Tactic/Have.lean
@@ -53,8 +53,11 @@ def haveIdLhs' : Parser :=
   optBinderIdent >> many (ppSpace >>
     checkColGt "expected to be indented" >> letIdBinder) >> optType
 
+@[tactic_alt Lean.Parser.Tactic.tacticHave__]
 syntax "have" haveIdLhs' : tactic
+@[tactic_alt Lean.Parser.Tactic.tacticLet__]
 syntax "let " haveIdLhs' : tactic
+@[tactic_alt Lean.Parser.Tactic.tacticSuffices_]
 syntax "suffices" haveIdLhs' : tactic
 
 open Elab Term in

--- a/Mathlib/Tactic/Linter/FlexibleLinter.lean
+++ b/Mathlib/Tactic/Linter/FlexibleLinter.lean
@@ -336,7 +336,7 @@ def flexible : Std.HashSet Name :=
     `cfcContTac,
     -- `continuity` and `measurability` also use `aesop` under the hood.
     `tacticContinuity,
-    `tacticMeasurability,
+    `Mathlib.Tactic.measurability,
     `finiteness,
     `finiteness?,
     `Mathlib.Tactic.Tauto.tauto,

--- a/Mathlib/Tactic/Measurability.lean
+++ b/Mathlib/Tactic/Measurability.lean
@@ -61,7 +61,7 @@ about `Measurable`, `AEMeasurable`, `StronglyMeasurable` and `AEStronglyMeasurab
 with `fun_prop` rather that `measurability`. The `measurability` attribute is equivalent to
 `fun_prop` in these cases for backward compatibility with the earlier implementation.
 -/
-macro "measurability" : tactic =>
+macro (name := Mathlib.Tactic.measurability) "measurability" : tactic =>
   `(tactic| aesop (config := { terminal := true })
     (rule_sets := [$(Lean.mkIdent `Measurable):ident]))
 
@@ -70,11 +70,13 @@ The tactic `measurability?` solves goals of the form `Measurable f`, `AEMeasurab
 `StronglyMeasurable f`, `AEStronglyMeasurable f μ`, or `MeasurableSet s` by applying lemmas tagged
 with the `measurability` user attribute, and suggests a faster proof script that can be substituted
 for the tactic call in case of success. -/
-macro "measurability?" : tactic =>
+macro (name := Mathlib.Tactic.measurability?) "measurability?" : tactic =>
   `(tactic| aesop? (config := { terminal := true })
     (rule_sets := [$(Lean.mkIdent `Measurable):ident]))
 
 -- Todo: implement `measurability!` and `measurability!?` and add configuration,
 -- original syntax was (same for the missing `measurability` variants):
+@[tactic_alt Mathlib.Tactic.measurability]
 syntax (name := measurability!) "measurability!" : tactic
+@[tactic_alt Mathlib.Tactic.measurability?]
 syntax (name := measurability!?) "measurability!?" : tactic

--- a/Mathlib/Tactic/Set.lean
+++ b/Mathlib/Tactic/Set.lean
@@ -26,12 +26,6 @@ open Lean Elab Elab.Tactic Meta
 
 syntax setArgsRest := ppSpace ident (" : " term)? " := " term (" with " "← "? ident)?
 
--- This is called `setTactic` rather than `set`
--- as we sometimes refer to `MonadStateOf.set` from inside `Mathlib.Tactic`.
-syntax (name := setTactic) "set" "!"? setArgsRest : tactic
-
-macro "set!" rest:setArgsRest : tactic => `(tactic| set ! $rest:setArgsRest)
-
 /--
 `set a := t with h` is a variant of `let a := t`. It adds the hypothesis `h : a = t` to
 the local context and replaces `t` with `a` everywhere it can.
@@ -53,6 +47,13 @@ h2 : x = y
 -/
 ```
 -/
+-- This is called `setTactic` rather than `set`
+-- as we sometimes refer to `MonadStateOf.set` from inside `Mathlib.Tactic`.
+syntax (name := setTactic) "set" "!"? setArgsRest : tactic
+
+@[tactic_alt setTactic]
+macro "set!" rest:setArgsRest : tactic => `(tactic| set ! $rest:setArgsRest)
+
 elab_rules : tactic
 | `(tactic| set%$tk $[!%$rw]? $a:ident $[: $ty:term]? := $val:term $[with $[←%$rev]? $h:ident]?) =>
   withMainContext do


### PR DESCRIPTION
This PR adds the `@[tactic_alt]` or `@[inherit_doc]` attribute to add docstrings to undocumented tactics. These changes should fix about a third of the 33 currently undocumented tactics, and two thirds of the undocumented tactics in all of Mathlib. (For a precise number, ask me once Mathlib finishes building.)


---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

When merging, all the commits will be squashed into a single commit
listing all co-authors.

Co-authors in the squash commit are gathered from two sources:

First, all authors of commits to this PR branch are included. Thus,
one way to add co-authors is to include at least one commit authored by
each co-author among the commits in the pull request. If necessary, you
may create empty commits to indicate co-authorship, using commands like so:

git commit --author="Author Name <author@email.com>" --allow-empty -m "add Author Name as coauthor"

Second, co-authors can also be listed in lines at the very bottom of
the commit message (that is, directly before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines
at the bottom of the commit message (before the `---`, and also before
any "Co-authored-by" lines) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
