### PR TITLE
[Merged by Bors] - feat(LinearAlgebra/Lagrange): Formula for leading coefficient of a polynomial

### DIFF
--- a/Mathlib/LinearAlgebra/Lagrange.lean
+++ b/Mathlib/LinearAlgebra/Lagrange.lean
@@ -472,14 +472,8 @@ theorem leadingCoeff_eq_sum
     case bot => rw [h] at hP; simp at hP
     case coe d => rw [h] at hP; simp [ENat.coe_inj.mp hP]; rfl
   have P_natDegree : P.natDegree = s.card - 1 := natDegree_eq_of_degree_eq_some P_degree
-  have s_card : s.card > 0 := by
-    by_contra! h
-    have : s.card = 0 := by omega
-    rw [this, P_degree] at hP
-    have := ENat.coe_inj.mp hP
-    dsimp at this
-    omega
-  have hP' : P.degree < s.card := by rw [P_degree, Nat.cast_lt]; omega
+  have s_card : s.card > 0 := by by_contra! h; simp_all
+  have hP' : P.degree < s.card := by grind [Nat.cast_lt]
   rw [leadingCoeff, P_natDegree]
   rw (occs := [1]) [← interpolate_poly_eq_self hvs hP']
   rw [interpolate_apply, finset_sum_coeff]

--- a/Mathlib/LinearAlgebra/Lagrange.lean
+++ b/Mathlib/LinearAlgebra/Lagrange.lean
@@ -276,6 +276,17 @@ theorem basisDivisor_add_symm {x y : F} (hxy : x ≠ y) :
     sum_insert (notMem_singleton.mpr hxy), sum_singleton, basis_pair_left hxy,
     basis_pair_right hxy, id, id]
 
+theorem leadingCoeff_basis (hvs : Set.InjOn v s) (hi : i ∈ s) :
+    (Lagrange.basis s v i).leadingCoeff = (∏ j ∈ s.erase i, ((v i) - (v j)))⁻¹ := by
+  rw [leadingCoeff, natDegree_basis hvs hi, Lagrange.basis]
+  unfold basisDivisor
+  rw [Finset.prod_mul_distrib, ← Finset.prod_inv_distrib, ←map_prod, coeff_C_mul]
+  rw [← Finset.card_erase_of_mem hi]
+  have : (∏ j ∈ s.erase i, (X - C (v j))).Monic := monic_prod_X_sub_C _ _
+  have := this.coeff_natDegree
+  rw [natDegree_finset_prod_X_sub_C_eq_card] at this
+  rw [this, mul_one]
+
 end Basis
 
 section Interpolate
@@ -441,6 +452,45 @@ theorem interpolate_eq_add_interpolate_erase (hvs : Set.InjOn v s) (hi : i ∈ s
     sdiff_insert_insert_of_mem_of_notMem hj (notMem_singleton.mpr hij.symm),
     sdiff_singleton_eq_erase]
   exact insert_subset_iff.mpr ⟨hi, singleton_subset_iff.mpr hj⟩
+
+open scoped Classical in
+theorem interpolate_poly_eq_poly
+    (hvs : Set.InjOn v s) {P : Polynomial F} (hP : P.degree < s.card) :
+    (interpolate s v) (fun (i : ι) => P.eval (v i)) = P := by
+  let t : Finset F := s.image v
+  have ht : t.card = s.card := Finset.card_image_iff.mpr hvs
+  apply eq_of_degrees_lt_of_eval_finset_eq t
+  · rw [ht]
+    apply degree_interpolate_lt _ hvs
+  · rw [ht]
+    exact hP
+  · intro x hx
+    obtain ⟨i, hi, hx⟩ := Finset.mem_image.mp hx
+    rw [← hx, eval_interpolate_at_node _ hvs hi]
+
+open scoped Classical in
+theorem leadingCoeff_interpolate
+    (hvs : Set.InjOn v s) {P : Polynomial F} (hP : s.card = P.degree + 1) :
+    P.leadingCoeff = ∑ i ∈ s, (P.eval (v i)) / ∏ j ∈ s.erase i, ((v i) - (v j)) := by
+  have P_degree : P.degree = ↑(s.card - 1) := by
+    cases h : P.degree
+    case bot => rw [h] at hP; simp at hP
+    case coe d => rw [h] at hP; simp [ENat.coe_inj.mp hP]; rfl
+  have P_natDegree : P.natDegree = s.card - 1 := natDegree_eq_of_degree_eq_some P_degree
+  have s_card : s.card > 0 := by
+    by_contra! h
+    have : s.card = 0 := by omega
+    rw [this, P_degree] at hP
+    have := ENat.coe_inj.mp hP
+    dsimp at this
+    omega
+  have hP' : P.degree < s.card := by rw [P_degree, Nat.cast_lt]; omega
+  rw [leadingCoeff, P_natDegree]
+  rw (occs := [1]) [← interpolate_poly_eq_poly hvs hP']
+  rw [interpolate_apply, finset_sum_coeff]
+  congr! with i hi
+  rw [coeff_C_mul, ← natDegree_basis hvs hi, ← leadingCoeff, leadingCoeff_basis hvs hi]
+  field_simp
 
 end Interpolate
 

--- a/Mathlib/LinearAlgebra/Lagrange.lean
+++ b/Mathlib/LinearAlgebra/Lagrange.lean
@@ -469,8 +469,12 @@ theorem leadingCoeff_eq_sum
     P.leadingCoeff = ∑ i ∈ s, (P.eval (v i)) / ∏ j ∈ s.erase i, ((v i) - (v j)) := by
   have P_degree : P.degree = ↑(s.card - 1) := by
     cases h : P.degree
-    case bot => rw [h] at hP; simp at hP
-    case coe d => rw [h] at hP; simp [ENat.coe_inj.mp hP]; rfl
+    case bot => simp_all
+    case coe d =>
+      rw [Nat.cast_withBot] at hP ⊢
+      suffices #s = d + 1 by grind
+      rw [h] at hP
+      simp [← WithBot.coe_inj, hP]
   have P_natDegree : P.natDegree = s.card - 1 := natDegree_eq_of_degree_eq_some P_degree
   have s_card : s.card > 0 := by by_contra! h; simp_all
   have hP' : P.degree < s.card := by grind [Nat.cast_lt]

--- a/Mathlib/LinearAlgebra/Lagrange.lean
+++ b/Mathlib/LinearAlgebra/Lagrange.lean
@@ -456,7 +456,7 @@ theorem interpolate_eq_add_interpolate_erase (hvs : Set.InjOn v s) (hi : i ∈ s
 open scoped Classical in
 theorem interpolate_poly_eq_poly
     (hvs : Set.InjOn v s) {P : Polynomial F} (hP : P.degree < s.card) :
-    (interpolate s v) (fun (i : ι) => P.eval (v i)) = P := by
+    interpolate s v (fun i => P.eval (v i)) = P := by
   let t : Finset F := s.image v
   have ht : t.card = s.card := Finset.card_image_iff.mpr hvs
   apply eq_of_degrees_lt_of_eval_finset_eq t

--- a/Mathlib/LinearAlgebra/Lagrange.lean
+++ b/Mathlib/LinearAlgebra/Lagrange.lean
@@ -459,11 +459,10 @@ theorem interpolate_poly_eq_self
   apply eq_of_degrees_lt_of_eval_finset_eq t
   · rw [ht]
     apply degree_interpolate_lt _ hvs
-  · rw [ht]
-    exact hP
+  · rwa [ht]
   · intro x hx
-    obtain ⟨i, hi, hx⟩ := Finset.mem_image.mp hx
-    rw [← hx, eval_interpolate_at_node _ hvs hi]
+    obtain ⟨i, hi, rfl⟩ := Finset.mem_image.mp hx
+    rw [eval_interpolate_at_node _ hvs hi]
 
 theorem leadingCoeff_eq_sum
     (hvs : Set.InjOn v s) {P : Polynomial F} (hP : s.card = P.degree + 1) :

--- a/Mathlib/LinearAlgebra/Lagrange.lean
+++ b/Mathlib/LinearAlgebra/Lagrange.lean
@@ -454,9 +454,10 @@ theorem interpolate_eq_add_interpolate_erase (hvs : Set.InjOn v s) (hi : i ∈ s
   exact insert_subset_iff.mpr ⟨hi, singleton_subset_iff.mpr hj⟩
 
 open scoped Classical in
-theorem interpolate_poly_eq_poly
+theorem interpolate_poly_eq_self
     (hvs : Set.InjOn v s) {P : Polynomial F} (hP : P.degree < s.card) :
     interpolate s v (fun i => P.eval (v i)) = P := by
+  classical
   let t : Finset F := s.image v
   have ht : t.card = s.card := Finset.card_image_iff.mpr hvs
   apply eq_of_degrees_lt_of_eval_finset_eq t
@@ -468,8 +469,7 @@ theorem interpolate_poly_eq_poly
     obtain ⟨i, hi, hx⟩ := Finset.mem_image.mp hx
     rw [← hx, eval_interpolate_at_node _ hvs hi]
 
-open scoped Classical in
-theorem leadingCoeff_interpolate
+theorem leadingCoeff_eq_sum
     (hvs : Set.InjOn v s) {P : Polynomial F} (hP : s.card = P.degree + 1) :
     P.leadingCoeff = ∑ i ∈ s, (P.eval (v i)) / ∏ j ∈ s.erase i, ((v i) - (v j)) := by
   have P_degree : P.degree = ↑(s.card - 1) := by
@@ -486,7 +486,7 @@ theorem leadingCoeff_interpolate
     omega
   have hP' : P.degree < s.card := by rw [P_degree, Nat.cast_lt]; omega
   rw [leadingCoeff, P_natDegree]
-  rw (occs := [1]) [← interpolate_poly_eq_poly hvs hP']
+  rw (occs := [1]) [← interpolate_poly_eq_self hvs hP']
   rw [interpolate_apply, finset_sum_coeff]
   congr! with i hi
   rw [coeff_C_mul, ← natDegree_basis hvs hi, ← leadingCoeff, leadingCoeff_basis hvs hi]

--- a/Mathlib/LinearAlgebra/Lagrange.lean
+++ b/Mathlib/LinearAlgebra/Lagrange.lean
@@ -278,14 +278,10 @@ theorem basisDivisor_add_symm {x y : F} (hxy : x ≠ y) :
 
 theorem leadingCoeff_basis (hvs : Set.InjOn v s) (hi : i ∈ s) :
     (Lagrange.basis s v i).leadingCoeff = (∏ j ∈ s.erase i, ((v i) - (v j)))⁻¹ := by
-  rw [leadingCoeff, natDegree_basis hvs hi, Lagrange.basis]
-  unfold basisDivisor
-  rw [Finset.prod_mul_distrib, ← Finset.prod_inv_distrib, ←map_prod, coeff_C_mul]
-  rw [← Finset.card_erase_of_mem hi]
-  have : (∏ j ∈ s.erase i, (X - C (v j))).Monic := monic_prod_X_sub_C _ _
-  have := this.coeff_natDegree
-  rw [natDegree_finset_prod_X_sub_C_eq_card] at this
-  rw [this, mul_one]
+  have : (∏ j ∈ s.erase i, (X - C (v j))).coeff (#s - 1) = 1 := by
+    simpa [hi] using (monic_prod_X_sub_C v (s.erase i)).coeff_natDegree
+  simp_rw [leadingCoeff, natDegree_basis hvs hi, Lagrange.basis]
+  simp [basisDivisor, Finset.prod_mul_distrib, ← map_prod, this]
 
 end Basis
 


### PR DESCRIPTION
Added `leadingCoeff_interpolate`, which gives a formula for the leading coefficient of a polynomial that follows from Lagrange interpolation.

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

When merging, all the commits will be squashed into a single commit
listing all co-authors.

Co-authors in the squash commit are gathered from two sources:

First, all authors of commits to this PR branch are included. Thus,
one way to add co-authors is to include at least one commit authored by
each co-author among the commits in the pull request. If necessary, you
may create empty commits to indicate co-authorship, using commands like so:

git commit --author="Author Name <author@email.com>" --allow-empty -m "add Author Name as coauthor"

Second, co-authors can also be listed in lines at the very bottom of
the commit message (that is, directly before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines
at the bottom of the commit message (before the `---`, and also before
any "Co-authored-by" lines) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
