### PR TITLE
[Merged by Bors] - fix: correct `RingEquiv.ofHomInv` so that it doesn't use `RingHomClass`

### DIFF
--- a/Mathlib/Algebra/Category/Ring/Basic.lean
+++ b/Mathlib/Algebra/Category/Ring/Basic.lean
@@ -668,19 +668,19 @@ namespace CategoryTheory.Iso
 
 /-- Build a `RingEquiv` from an isomorphism in the category `SemiRingCat`. -/
 def semiRingCatIsoToRingEquiv {R S : SemiRingCat.{u}} (e : R ≅ S) : R ≃+* S :=
-  RingEquiv.ofHomInv e.hom.hom e.inv.hom (by ext; simp) (by ext; simp)
+  RingEquiv.ofRingHom e.hom.hom e.inv.hom (by ext; simp) (by ext; simp)
 
 /-- Build a `RingEquiv` from an isomorphism in the category `RingCat`. -/
 def ringCatIsoToRingEquiv {R S : RingCat.{u}} (e : R ≅ S) : R ≃+* S :=
-  RingEquiv.ofHomInv e.hom.hom e.inv.hom (by ext; simp) (by ext; simp)
+  RingEquiv.ofRingHom e.hom.hom e.inv.hom (by ext; simp) (by ext; simp)
 
 /-- Build a `RingEquiv` from an isomorphism in the category `CommSemiRingCat`. -/
 def commSemiRingCatIsoToRingEquiv {R S : CommSemiRingCat.{u}} (e : R ≅ S) : R ≃+* S :=
-  RingEquiv.ofHomInv e.hom.hom e.inv.hom (by ext; simp) (by ext; simp)
+  RingEquiv.ofRingHom e.hom.hom e.inv.hom (by ext; simp) (by ext; simp)
 
 /-- Build a `RingEquiv` from an isomorphism in the category `CommRingCat`. -/
 def commRingCatIsoToRingEquiv {R S : CommRingCat.{u}} (e : R ≅ S) : R ≃+* S :=
-  RingEquiv.ofHomInv e.hom.hom e.inv.hom (by ext; simp) (by ext; simp)
+  RingEquiv.ofRingHom e.hom.hom e.inv.hom (by ext; simp) (by ext; simp)
 
 @[simp] lemma semiRingCatIsoToRingEquiv_toRingHom {R S : SemiRingCat.{u}} (e : R ≅ S) :
     (e.semiRingCatIsoToRingEquiv : R →+* S) = e.hom.hom := rfl

--- a/Mathlib/Algebra/Polynomial/Eval/Degree.lean
+++ b/Mathlib/Algebra/Polynomial/Eval/Degree.lean
@@ -129,7 +129,7 @@ variable (f) in
 /-- If `R` and `S` are isomorphic, then so are their polynomial rings. -/
 @[simps!]
 def mapEquiv (e : R ≃+* S) : R[X] ≃+* S[X] :=
-  RingEquiv.ofHomInv (mapRingHom (e : R →+* S)) (mapRingHom (e.symm : S →+* R)) (by ext; simp)
+  RingEquiv.ofRingHom (mapRingHom (e : R →+* S)) (mapRingHom (e.symm : S →+* R)) (by ext; simp)
     (by ext; simp)
 
 theorem map_monic_eq_zero_iff (hp : p.Monic) : p.map f = 0 ↔ ∀ x, f x = 0 :=

--- a/Mathlib/Algebra/Ring/Equiv.lean
+++ b/Mathlib/Algebra/Ring/Equiv.lean
@@ -892,6 +892,7 @@ theorem symm_ofNonUnitalRingHom (f : R →ₙ+* S) (g : S →ₙ+* R) (h₁ h₂
   rfl
 
 end NonUnital
+
 section Unital
 
 variable [NonAssocSemiring R] [NonAssocSemiring S]

--- a/Mathlib/Algebra/Ring/Equiv.lean
+++ b/Mathlib/Algebra/Ring/Equiv.lean
@@ -890,6 +890,8 @@ def ofNonUnitalRingHom (hom : R →ₙ+* S) (inv : S →ₙ+* R)
 attribute [simp] ofNonUnitalRingHom_apply
 
 @[deprecated (since := "2025-12-04")] alias ofHomInv' := ofNonUnitalRingHom
+@[deprecated (since := "2025-12-04")] alias ofHomInv'_apply := ofNonUnitalRingHom_apply
+@[deprecated (since := "2025-12-04")] alias ofHomInv'_symm_apply := ofNonUnitalRingHom_symm_apply
 
 @[simp]
 theorem symm_ofNonUnitalRingHom (f : R →ₙ+* S) (g : S →ₙ+* R) (h₁ h₂) :
@@ -915,6 +917,8 @@ def ofRingHom (f : R →+* S) (g : S →+* R) (h₁ : f.comp g = RingHom.id S)
 attribute [simp] ofRingHom_apply
 
 @[deprecated (since := "2025-12-04")] alias ofHomInv := ofRingHom
+@[deprecated (since := "2025-12-04")] alias ofHomInv_apply := ofRingHom_apply
+@[deprecated (since := "2025-12-04")] alias ofHomInv_symm_apply := ofRingHom_symm_apply
 
 theorem coe_ringHom_ofRingHom (f : R →+* S) (g : S →+* R) (h₁ h₂) : ofRingHom f g h₁ h₂ = f :=
   rfl

--- a/Mathlib/Algebra/Ring/Equiv.lean
+++ b/Mathlib/Algebra/Ring/Equiv.lean
@@ -822,34 +822,6 @@ theorem symm_toRingHom_comp_toRingHom (e : R ≃+* S) :
     e.symm.toRingHom.comp e.toRingHom = RingHom.id _ := by
   simp
 
-/-- Construct an equivalence of rings from homomorphisms in both directions, which are inverses.
--/
-@[simps]
-abbrev ofHomInv' {R S : Type*} [NonUnitalNonAssocSemiring R] [NonUnitalNonAssocSemiring S]
-    (hom : R →ₙ+* S) (inv : S →ₙ+* R) (hom_inv_id : inv.comp hom = .id R)
-    (inv_hom_id : hom.comp inv = .id S) :
-    R ≃+* S where
-  toFun := hom
-  invFun := inv
-  left_inv := DFunLike.congr_fun hom_inv_id
-  right_inv := DFunLike.congr_fun inv_hom_id
-  map_mul' := map_mul hom
-  map_add' := map_add hom
-
-/--
-Construct an equivalence of rings from unital homomorphisms in both directions, which are inverses.
--/
-@[simps]
-abbrev ofHomInv (hom : R →+* S) (inv : S →+* R)
-    (hom_inv_id : inv.comp hom = .id R) (inv_hom_id : hom.comp inv = .id S) :
-    R ≃+* S where
-  toFun := hom
-  invFun := inv
-  left_inv := DFunLike.congr_fun hom_inv_id
-  right_inv := DFunLike.congr_fun inv_hom_id
-  map_mul' := map_mul hom
-  map_add' := map_add hom
-
 end SemiringHom
 
 variable [Semiring R] [Semiring S]
@@ -899,6 +871,29 @@ end RingEquiv
 
 namespace RingEquiv
 
+section NonUnital
+
+variable [NonUnitalNonAssocSemiring R] [NonUnitalNonAssocSemiring S]
+
+/-- If a non-unital ring homomorphism has an inverse, it is a ring isomorphism. -/
+@[simps]
+def ofNonUnitalRingHom (hom : R →ₙ+* S) (inv : S →ₙ+* R)
+    (hom_inv_id : inv.comp hom = .id R) (inv_hom_id : hom.comp inv = .id S) :
+    R ≃+* S where
+  toFun := hom
+  invFun := inv
+  left_inv := DFunLike.congr_fun hom_inv_id
+  right_inv := DFunLike.congr_fun inv_hom_id
+  map_mul' := map_mul hom
+  map_add' := map_add hom
+
+theorem symm_ofNonUnitalRingHom (f : R →ₙ+* S) (g : S →ₙ+* R) (h₁ h₂) :
+    (ofNonUnitalRingHom f g h₁ h₂).symm = ofNonUnitalRingHom g f h₂ h₁ :=
+  rfl
+
+end NonUnital
+section Unital
+
 variable [NonAssocSemiring R] [NonAssocSemiring S]
 
 /-- If a ring homomorphism has an inverse, it is a ring isomorphism. -/
@@ -938,6 +933,8 @@ lemma sumArrowEquivProdArrow_apply (x) :
 @[simp low]
 lemma sumArrowEquivProdArrow_symm_apply (x : (α → R) × (β → R)) :
     (sumArrowEquivProdArrow α β R).symm x = (Equiv.sumArrowEquivProdArrow α β R).symm x := rfl
+
+end Unital
 
 end RingEquiv
 

--- a/Mathlib/Algebra/Ring/Equiv.lean
+++ b/Mathlib/Algebra/Ring/Equiv.lean
@@ -825,11 +825,9 @@ theorem symm_toRingHom_comp_toRingHom (e : R ≃+* S) :
 /-- Construct an equivalence of rings from homomorphisms in both directions, which are inverses.
 -/
 @[simps]
-def ofHomInv' {R S F G : Type*} [NonUnitalNonAssocSemiring R] [NonUnitalNonAssocSemiring S]
-    [FunLike F R S] [FunLike G S R]
-    [NonUnitalRingHomClass F R S] [NonUnitalRingHomClass G S R] (hom : F) (inv : G)
-    (hom_inv_id : (inv : S →ₙ+* R).comp (hom : R →ₙ+* S) = NonUnitalRingHom.id R)
-    (inv_hom_id : (hom : R →ₙ+* S).comp (inv : S →ₙ+* R) = NonUnitalRingHom.id S) :
+abbrev ofHomInv' {R S : Type*} [NonUnitalNonAssocSemiring R] [NonUnitalNonAssocSemiring S]
+    (hom : R →ₙ+* S) (inv : S →ₙ+* R) (hom_inv_id : inv.comp hom = .id R)
+    (inv_hom_id : hom.comp inv = .id S) :
     R ≃+* S where
   toFun := hom
   invFun := inv
@@ -842,11 +840,8 @@ def ofHomInv' {R S F G : Type*} [NonUnitalNonAssocSemiring R] [NonUnitalNonAssoc
 Construct an equivalence of rings from unital homomorphisms in both directions, which are inverses.
 -/
 @[simps]
-def ofHomInv {R S F G : Type*} [NonAssocSemiring R] [NonAssocSemiring S]
-    [FunLike F R S] [FunLike G S R] [RingHomClass F R S]
-    [RingHomClass G S R] (hom : F) (inv : G)
-    (hom_inv_id : (inv : S →+* R).comp (hom : R →+* S) = RingHom.id R)
-    (inv_hom_id : (hom : R →+* S).comp (inv : S →+* R) = RingHom.id S) :
+abbrev ofHomInv (hom : R →+* S) (inv : S →+* R)
+    (hom_inv_id : inv.comp hom = .id R) (inv_hom_id : hom.comp inv = .id S) :
     R ≃+* S where
   toFun := hom
   invFun := inv

--- a/Mathlib/Algebra/Ring/Equiv.lean
+++ b/Mathlib/Algebra/Ring/Equiv.lean
@@ -876,7 +876,7 @@ section NonUnital
 variable [NonUnitalNonAssocSemiring R] [NonUnitalNonAssocSemiring S]
 
 /-- If a non-unital ring homomorphism has an inverse, it is a ring isomorphism. -/
-@[simps]
+@[simps -isSimp]
 def ofNonUnitalRingHom (hom : R →ₙ+* S) (inv : S →ₙ+* R)
     (hom_inv_id : inv.comp hom = .id R) (inv_hom_id : hom.comp inv = .id S) :
     R ≃+* S where
@@ -887,6 +887,11 @@ def ofNonUnitalRingHom (hom : R →ₙ+* S) (inv : S →ₙ+* R)
   map_mul' := map_mul hom
   map_add' := map_add hom
 
+attribute [simp] ofNonUnitalRingHom_apply
+
+@[deprecated (since := "2025-12-04")] alias ofHomInv' := ofNonUnitalRingHom
+
+@[simp]
 theorem symm_ofNonUnitalRingHom (f : R →ₙ+* S) (g : S →ₙ+* R) (h₁ h₂) :
     (ofNonUnitalRingHom f g h₁ h₂).symm = ofNonUnitalRingHom g f h₂ h₁ :=
   rfl
@@ -897,7 +902,7 @@ section Unital
 variable [NonAssocSemiring R] [NonAssocSemiring S]
 
 /-- If a ring homomorphism has an inverse, it is a ring isomorphism. -/
-@[simps]
+@[simps -isSimp]
 def ofRingHom (f : R →+* S) (g : S →+* R) (h₁ : f.comp g = RingHom.id S)
     (h₂ : g.comp f = RingHom.id R) : R ≃+* S :=
   { f with
@@ -906,6 +911,10 @@ def ofRingHom (f : R →+* S) (g : S →+* R) (h₁ : f.comp g = RingHom.id S)
     left_inv := RingHom.ext_iff.1 h₂
     right_inv := RingHom.ext_iff.1 h₁ }
 
+attribute [simp] ofRingHom_apply
+
+@[deprecated (since := "2025-12-04")] alias ofHomInv := ofRingHom
+
 theorem coe_ringHom_ofRingHom (f : R →+* S) (g : S →+* R) (h₁ h₂) : ofRingHom f g h₁ h₂ = f :=
   rfl
 
@@ -913,6 +922,7 @@ theorem coe_ringHom_ofRingHom (f : R →+* S) (g : S →+* R) (h₁ h₂) : ofRi
 theorem ofRingHom_coe_ringHom (f : R ≃+* S) (g : S →+* R) (h₁ h₂) : ofRingHom (↑f) g h₁ h₂ = f :=
   ext fun _ ↦ rfl
 
+@[simp]
 theorem ofRingHom_symm (f : R →+* S) (g : S →+* R) (h₁ h₂) :
     (ofRingHom f g h₁ h₂).symm = ofRingHom g f h₂ h₁ :=
   rfl

--- a/Mathlib/Algebra/RingQuot.lean
+++ b/Mathlib/Algebra/RingQuot.lean
@@ -512,7 +512,7 @@ theorem idealQuotientToRingQuot_apply (r : B → B → Prop) (x : B) :
 /-- The ring equivalence between `RingQuot r` and `(Ideal.ofRel r).quotient`
 -/
 def ringQuotEquivIdealQuotient (r : B → B → Prop) : RingQuot r ≃+* B ⧸ Ideal.ofRel r :=
-  RingEquiv.ofHomInv (ringQuotToIdealQuotient r) (idealQuotientToRingQuot r)
+  RingEquiv.ofRingHom (ringQuotToIdealQuotient r) (idealQuotientToRingQuot r)
     (by
       ext x
       simp)

--- a/Mathlib/RingTheory/FreeCommRing.lean
+++ b/Mathlib/RingTheory/FreeCommRing.lean
@@ -392,9 +392,9 @@ end FreeRing
 /-- The free commutative ring on `α` is isomorphic to the polynomial ring over ℤ with
 variables in `α` -/
 def freeCommRingEquivMvPolynomialInt : FreeCommRing α ≃+* MvPolynomial α ℤ :=
-  RingEquiv.ofHomInv (FreeCommRing.lift <| (fun a => MvPolynomial.X a : α → MvPolynomial α ℤ))
+  RingEquiv.ofRingHom (FreeCommRing.lift <| (fun a => MvPolynomial.X a : α → MvPolynomial α ℤ))
     (MvPolynomial.eval₂Hom (Int.castRingHom (FreeCommRing α)) FreeCommRing.of)
-    (by ext; simp) (by ext <;> simp)
+    (by ext <;> simp) (by ext; simp)
 
 /-- The free commutative ring on the empty type is isomorphic to `ℤ`. -/
 def freeCommRingPemptyEquivInt : FreeCommRing PEmpty.{u + 1} ≃+* ℤ :=

--- a/Mathlib/RingTheory/Ideal/Quotient/Operations.lean
+++ b/Mathlib/RingTheory/Ideal/Quotient/Operations.lean
@@ -832,7 +832,7 @@ def liftSupQuotQuotMk (I J : Ideal R) : R ⧸ I ⊔ J →+* (R ⧸ I) ⧸ J.map 
 /-- `quotQuotToQuotSup` and `liftSupQuotQuotMk` are inverse isomorphisms. In the case where
 `I ≤ J`, this is the Third Isomorphism Theorem (see `quotQuotEquivQuotOfLe`). -/
 def quotQuotEquivQuotSup : (R ⧸ I) ⧸ J.map (Ideal.Quotient.mk I) ≃+* R ⧸ I ⊔ J :=
-  RingEquiv.ofHomInv (quotQuotToQuotSup I J) (liftSupQuotQuotMk I J)
+  RingEquiv.ofRingHom (quotQuotToQuotSup I J) (liftSupQuotQuotMk I J)
     (by
       repeat apply Ideal.Quotient.ringHom_ext
       rfl)


### PR DESCRIPTION
Per [#mathlib4 > Mathlib's morphism hierarchy](https://leanprover.zulipchat.com/#narrow/channel/287929-mathlib4/topic/Mathlib's.20morphism.20hierarchy/with/558812628), this removes the use of coercions from `RingHomClass` in the construction [RingEquiv.ofHomInv](https://leanprover-community.github.io/mathlib4_docs/Mathlib/Algebra/Ring/Equiv.html#RingEquiv.ofHomInv).

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

When merging, all the commits will be squashed into a single commit
listing all co-authors.

Co-authors in the squash commit are gathered from two sources:

First, all authors of commits to this PR branch are included. Thus,
one way to add co-authors is to include at least one commit authored by
each co-author among the commits in the pull request. If necessary, you
may create empty commits to indicate co-authorship, using commands like so:

git commit --author="Author Name <author@email.com>" --allow-empty -m "add Author Name as coauthor"

Second, co-authors can also be listed in lines at the very bottom of
the commit message (that is, directly before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines
at the bottom of the commit message (before the `---`, and also before
any "Co-authored-by" lines) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
