### PR TITLE
[Merged by Bors] - chore: golf using `simpa`

### DIFF
--- a/Mathlib/Algebra/Polynomial/Derivation.lean
+++ b/Mathlib/Algebra/Polynomial/Derivation.lean
@@ -135,10 +135,7 @@ For the same equation in `M`, see `Derivation.compAEval_eq`.
 -/
 theorem compAEval_eq (d : Derivation R A M) (f : R[X]) :
     d.compAEval a f = derivative f • (AEval.of R M a (d a)) := by
-  rw [← mkDerivation_apply]
-  congr
-  apply derivation_ext
-  simp
+  simpa using AEval.of_aeval_smul _ _ _
 
 /--
 A form of the chain rule: if `f` is a polynomial over `R`

--- a/Mathlib/Algebra/Polynomial/RingDivision.lean
+++ b/Mathlib/Algebra/Polynomial/RingDivision.lean
@@ -265,9 +265,7 @@ theorem exists_multiset_roots [DecidableEq R] :
         degree_divByMonic_lt _ (monic_X_sub_C x) hp ((degree_X_sub_C x).symm ▸ by decide)
       let ⟨t, htd, htr⟩ := @exists_multiset_roots _ (p /ₘ (X - C x)) hd0
       have hdeg : degree (X - C x) ≤ degree p := by
-        rw [degree_X_sub_C, degree_eq_natDegree hp]
-        rw [degree_eq_natDegree hp] at hpd
-        exact WithBot.coe_le_coe.2 (WithBot.coe_lt_coe.1 hpd)
+        simpa using Nat.WithBot.one_le_iff_zero_lt.mpr hpd
       have hdiv0 : p /ₘ (X - C x) ≠ 0 :=
         mt (divByMonic_eq_zero_iff (monic_X_sub_C x)).1 <| not_lt.2 hdeg
       ⟨x ::ₘ t,

--- a/Mathlib/Combinatorics/SimpleGraph/Basic.lean
+++ b/Mathlib/Combinatorics/SimpleGraph/Basic.lean
@@ -625,10 +625,7 @@ theorem fromEdgeSet_sdiff (s t : Set (Sym2 V)) :
 
 @[gcongr, mono]
 theorem fromEdgeSet_mono {s t : Set (Sym2 V)} (h : s ⊆ t) : fromEdgeSet s ≤ fromEdgeSet t := by
-  rintro v w
-  simp +contextual only [fromEdgeSet_adj, Ne, not_false_iff,
-    and_true, and_imp]
-  exact fun vws _ => h vws
+  simpa using Set.diff_subset_diff h fun _ a ↦ a
 
 @[simp] lemma disjoint_fromEdgeSet : Disjoint G (fromEdgeSet s) ↔ Disjoint G.edgeSet s := by
   conv_rhs => rw [← Set.diff_union_inter s Sym2.diagSet]

--- a/Mathlib/FieldTheory/IntermediateField/Adjoin/Defs.lean
+++ b/Mathlib/FieldTheory/IntermediateField/Adjoin/Defs.lean
@@ -353,9 +353,7 @@ theorem adjoin_univ (F E : Type*) [Field F] [Field E] [Algebra F E] :
 /-- If `K` is a field with `F ⊆ K` and `S ⊆ K` then `adjoin F S ≤ K`. -/
 theorem adjoin_le_subfield {K : Subfield E} (HF : Set.range (algebraMap F E) ⊆ K) (HS : S ⊆ K) :
     (adjoin F S).toSubfield ≤ K := by
-  apply Subfield.closure_le.mpr
-  rw [Set.union_subset_iff]
-  exact ⟨HF, HS⟩
+  simpa using ⟨HF, HS⟩
 
 theorem adjoin_subset_adjoin_iff {F' : Type*} [Field F'] [Algebra F' E] {S S' : Set E} :
     (adjoin F S : Set E) ⊆ adjoin F' S' ↔

--- a/Mathlib/Geometry/Euclidean/Projection.lean
+++ b/Mathlib/Geometry/Euclidean/Projection.lean
@@ -275,10 +275,7 @@ part of the orthogonal projection. -/
 theorem orthogonalProjection_vsub_orthogonalProjection (s : AffineSubspace ℝ P) [Nonempty s]
     [s.direction.HasOrthogonalProjection] (p : P) :
     s.direction.orthogonalProjection (p -ᵥ orthogonalProjection s p) = 0 := by
-  apply Submodule.orthogonalProjection_mem_subspace_orthogonalComplement_eq_zero
-  intro c hc
-  rw [← neg_vsub_eq_vsub_rev, inner_neg_right,
-    orthogonalProjection_vsub_mem_direction_orthogonal s p c hc, neg_zero]
+  simpa using vsub_orthogonalProjection_mem_direction_orthogonal _ _
 
 /-- The characteristic property of the orthogonal projection, for a point given in the underlying
 space. This form is typically more convenient to use than


### PR DESCRIPTION
---
Trace profiling results (shown if ≥10 ms before or after):
* `Derivation.compAEval_eq`: 26 ms before, 60 ms after
* `Polynomial.exists_multiset_roots`: 142 ms before, 142 ms after  🎉
* `CategoryTheory.Mod_.scalarRestriction_hom`: 23 ms before, 20 ms after  🎉
* `SimpleGraph.fromEdgeSet_mono`: <10 ms before, <10 ms after  🎉
* `IntermediateField.adjoin_le_subfield`: <10 ms before, <10 ms after  🎉
* `EuclideanGeometry.orthogonalProjection_vsub_orthogonalProjection`: 11 ms before, 34 ms after

This golfing PR is batched under the following guidelines:
* Up to 5 changed files per PR
* Up to 25 changed declarations per PR
* Up to 100 changed lines per PR

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

When merging, all the commits will be squashed into a single commit
listing all co-authors.

Co-authors in the squash commit are gathered from two sources:

First, all authors of commits to this PR branch are included. Thus,
one way to add co-authors is to include at least one commit authored by
each co-author among the commits in the pull request. If necessary, you
may create empty commits to indicate co-authorship, using commands like so:

git commit --author="Author Name <author@email.com>" --allow-empty -m "add Author Name as coauthor"

Second, co-authors can also be listed in lines at the very bottom of
the commit message (that is, directly before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines
at the bottom of the commit message (before the `---`, and also before
any "Co-authored-by" lines) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
