### PR TITLE
[Merged by Bors] - feat: topological version of `support_comp_eq`

### DIFF
--- a/Mathlib/Topology/Algebra/Support.lean
+++ b/Mathlib/Topology/Algebra/Support.lean
@@ -75,6 +75,39 @@ theorem mulTSupport_binop_subset [One β] [One γ] (op : α → β → γ)
   closure_mono (mulSupport_binop_subset op op1 f g) |>.trans closure_union.subset
 
 @[to_additive]
+lemma mulTSupport_comp_subset [One β] {g : α → β} (hg : g 1 = 1) (f : X → α) :
+    mulTSupport (g ∘ f) ⊆ mulTSupport f :=
+  closure_mono (mulSupport_comp_subset hg f)
+
+@[to_additive]
+lemma mulTSupport_subset_comp [One β] {g : α → β} (hg : ∀ {x}, g x = 1 → x = 1) (f : X → α) :
+    mulTSupport f ⊆ mulTSupport (g ∘ f) :=
+  closure_mono (mulSupport_subset_comp hg f)
+
+@[to_additive]
+lemma mulTSupport_comp_eq [One β] {g : α → β} (hg : ∀ {x}, g x = 1 ↔ x = 1) (f : X → α) :
+    mulTSupport (g ∘ f) = mulTSupport f := by
+  rw [mulTSupport, mulTSupport, mulSupport_comp_eq g hg]
+
+@[to_additive]
+lemma mulTSupport_comp_eq_of_range_subset [One β] {g : α → β} {f : X → α}
+    (hg : ∀ {x}, x ∈ range f → (g x = 1 ↔ x = 1)) :
+    mulTSupport (g ∘ f) = mulTSupport f := by
+  rw [mulTSupport, mulTSupport, mulSupport_comp_eq_of_range_subset hg]
+
+@[to_additive]
+lemma mulTSupport_comp_subset_preimage {Y : Type*} [TopologicalSpace Y] (g : Y → α) {f : X → Y}
+    (hf : Continuous f) :
+    mulTSupport (g ∘ f) ⊆ f ⁻¹' mulTSupport g := by
+  rw [mulTSupport, mulTSupport, mulSupport_comp_eq_preimage]
+  exact hf.closure_preimage_subset _
+
+@[to_additive]
+lemma mulTSupport_comp_eq_preimage {Y : Type*} [TopologicalSpace Y] (g : Y → α) (f : X ≃ₜ Y) :
+    mulTSupport (g ∘ f) = f ⁻¹' mulTSupport g := by
+  rw [mulTSupport, mulTSupport, mulSupport_comp_eq_preimage, Homeomorph.preimage_closure]
+
+@[to_additive]
 theorem image_eq_one_of_notMem_mulTSupport {f : X → α} {x : X} (hx : x ∉ mulTSupport f) : f x = 1 :=
   mulSupport_subset_iff'.mp (subset_mulTSupport f) x hx
 


### PR DESCRIPTION
And other related lemmas (the API is copy-pasted from the algebraic one)

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

When merging, all the commits will be squashed into a single commit
listing all co-authors.

Co-authors in the squash commit are gathered from two sources:

First, all authors of commits to this PR branch are included. Thus,
one way to add co-authors is to include at least one commit authored by
each co-author among the commits in the pull request. If necessary, you
may create empty commits to indicate co-authorship, using commands like so:

git commit --author="Author Name <author@email.com>" --allow-empty -m "add Author Name as coauthor"

Second, co-authors can also be listed in lines at the very bottom of
the commit message (that is, directly before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines
at the bottom of the commit message (before the `---`, and also before
any "Co-authored-by" lines) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
