### PR TITLE
[Merged by Bors] - feat: InfiniteGalois.normalAutEquivQuotient

### DIFF
--- a/Mathlib/FieldTheory/Galois/Infinite.lean
+++ b/Mathlib/FieldTheory/Galois/Infinite.lean
@@ -221,6 +221,23 @@ def GaloisCoinsertionIntermediateFieldSubgroup [IsGalois k K] :
   choice_eq _ _ := rfl
 
 open IntermediateField in
+/-- If `H` is a closed normal subgroup of `Gal(L / K)`,
+then `Gal(fixedField H / K)` is isomorphic to `Gal(L / K) ⧸ H`. -/
+noncomputable def normalAutEquivQuotient [IsGalois k K]
+    (H : ClosedSubgroup Gal(K/k)) [Subgroup.Normal H.1] :
+    Gal(K/k) ⧸ H.1 ≃* Gal(fixedField H.1/k) :=
+  (QuotientGroup.quotientMulEquivOfEq ((fixingSubgroup_fixedField H).symm.trans
+  (fixedField H.1).restrictNormalHom_ker.symm)).trans <|
+  QuotientGroup.quotientKerEquivOfSurjective
+    (restrictNormalHom (fixedField H.1)) <|
+    restrictNormalHom_surjective K
+
+open IntermediateField in
+lemma normalAutEquivQuotient_apply [IsGalois k K]
+    (H : ClosedSubgroup Gal(K/k)) [Subgroup.Normal H.1] (σ : Gal(K/k)) :
+    normalAutEquivQuotient H σ = (restrictNormalHom (fixedField H.1)) σ := rfl
+
+open IntermediateField in
 theorem isOpen_iff_finite (L : IntermediateField k K) [IsGalois k K] :
     IsOpen L.fixingSubgroup.carrier ↔ FiniteDimensional k L := by
   refine ⟨fun h ↦ ?_, fun h ↦ IntermediateField.fixingSubgroup_isOpen L⟩

--- a/Mathlib/FieldTheory/Galois/Infinite.lean
+++ b/Mathlib/FieldTheory/Galois/Infinite.lean
@@ -227,10 +227,8 @@ noncomputable def normalAutEquivQuotient [IsGalois k K]
     (H : ClosedSubgroup Gal(K/k)) [H.Normal] :
     Gal(K/k) ⧸ H.1 ≃* Gal(fixedField H.1/k) :=
   (QuotientGroup.quotientMulEquivOfEq ((fixingSubgroup_fixedField H).symm.trans
-  (fixedField H.1).restrictNormalHom_ker.symm)).trans <|
-  QuotientGroup.quotientKerEquivOfSurjective
-    (restrictNormalHom (fixedField H.1)) <|
-    restrictNormalHom_surjective K
+    (fixedField H.1).restrictNormalHom_ker.symm)).trans <|
+      QuotientGroup.quotientKerEquivOfSurjective _ <| restrictNormalHom_surjective K
 
 open IntermediateField in
 lemma normalAutEquivQuotient_apply [IsGalois k K]

--- a/Mathlib/FieldTheory/Galois/Infinite.lean
+++ b/Mathlib/FieldTheory/Galois/Infinite.lean
@@ -224,7 +224,7 @@ open IntermediateField in
 /-- If `H` is a closed normal subgroup of `Gal(K / k)`,
 then `Gal(fixedField H / k)` is isomorphic to `Gal(K / k) ⧸ H`. -/
 noncomputable def normalAutEquivQuotient [IsGalois k K]
-    (H : ClosedSubgroup Gal(K/k)) [Subgroup.Normal H.1] :
+    (H : ClosedSubgroup Gal(K/k)) [H.Normal] :
     Gal(K/k) ⧸ H.1 ≃* Gal(fixedField H.1/k) :=
   (QuotientGroup.quotientMulEquivOfEq ((fixingSubgroup_fixedField H).symm.trans
   (fixedField H.1).restrictNormalHom_ker.symm)).trans <|
@@ -234,7 +234,7 @@ noncomputable def normalAutEquivQuotient [IsGalois k K]
 
 open IntermediateField in
 lemma normalAutEquivQuotient_apply [IsGalois k K]
-    (H : ClosedSubgroup Gal(K/k)) [Subgroup.Normal H.1] (σ : Gal(K/k)) :
+    (H : ClosedSubgroup Gal(K/k)) [H.Normal] (σ : Gal(K/k)) :
     normalAutEquivQuotient H σ = (restrictNormalHom (fixedField H.1)) σ := rfl
 
 open IntermediateField in

--- a/Mathlib/FieldTheory/Galois/Infinite.lean
+++ b/Mathlib/FieldTheory/Galois/Infinite.lean
@@ -221,8 +221,8 @@ def GaloisCoinsertionIntermediateFieldSubgroup [IsGalois k K] :
   choice_eq _ _ := rfl
 
 open IntermediateField in
-/-- If `H` is a closed normal subgroup of `Gal(L / K)`,
-then `Gal(fixedField H / K)` is isomorphic to `Gal(L / K) ⧸ H`. -/
+/-- If `H` is a closed normal subgroup of `Gal(K / k)`,
+then `Gal(fixedField H / k)` is isomorphic to `Gal(K / k) ⧸ H`. -/
 noncomputable def normalAutEquivQuotient [IsGalois k K]
     (H : ClosedSubgroup Gal(K/k)) [Subgroup.Normal H.1] :
     Gal(K/k) ⧸ H.1 ≃* Gal(fixedField H.1/k) :=

--- a/Mathlib/FieldTheory/Galois/Infinite.lean
+++ b/Mathlib/FieldTheory/Galois/Infinite.lean
@@ -233,7 +233,7 @@ noncomputable def normalAutEquivQuotient [IsGalois k K]
 open IntermediateField in
 lemma normalAutEquivQuotient_apply [IsGalois k K]
     (H : ClosedSubgroup Gal(K/k)) [H.Normal] (σ : Gal(K/k)) :
-    normalAutEquivQuotient H σ = (restrictNormalHom (fixedField H.1)) σ := rfl
+    normalAutEquivQuotient H σ = restrictNormalHom (fixedField H.1) σ := rfl
 
 open IntermediateField in
 theorem isOpen_iff_finite (L : IntermediateField k K) [IsGalois k K] :


### PR DESCRIPTION
If `H` is a _closed_ normal subgroup of `Gal(K / k)`, then `Gal(fixedField H / k)` is isomorphic to `Gal(K / k) ⧸ H`.

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

When merging, all the commits will be squashed into a single commit
listing all co-authors.

Co-authors in the squash commit are gathered from two sources:

First, all authors of commits to this PR branch are included. Thus,
one way to add co-authors is to include at least one commit authored by
each co-author among the commits in the pull request. If necessary, you
may create empty commits to indicate co-authorship, using commands like so:

git commit --author="Author Name <author@email.com>" --allow-empty -m "add Author Name as coauthor"

Second, co-authors can also be listed in lines at the very bottom of
the commit message (that is, directly before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines
at the bottom of the commit message (before the `---`, and also before
any "Co-authored-by" lines) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
