### PR TITLE
[Merged by Bors] - chore(Order/Defs/Unbundled): use `to_dual`

### DIFF
--- a/Mathlib/Order/Defs/Unbundled.lean
+++ b/Mathlib/Order/Defs/Unbundled.lean
@@ -10,6 +10,7 @@ public import Mathlib.Tactic.ExtendDoc
 public import Mathlib.Tactic.Lemma
 public import Mathlib.Tactic.SplitIfs
 public import Mathlib.Tactic.TypeStar
+public import Mathlib.Tactic.ToDual
 
 /-!
 # Orders
@@ -227,22 +228,16 @@ section LE
 variable {α : Type*} [LE α] {P : α → Prop} {x y : α}
 
 /-- `Minimal P x` means that `x` is a minimal element satisfying `P`. -/
+@[to_dual /-- `Maximal P x` means that `x` is a maximal element satisfying `P`. -/]
 def Minimal (P : α → Prop) (x : α) : Prop := P x ∧ ∀ ⦃y⦄, P y → y ≤ x → x ≤ y
 
-/-- `Maximal P x` means that `x` is a maximal element satisfying `P`. -/
-def Maximal (P : α → Prop) (x : α) : Prop := P x ∧ ∀ ⦃y⦄, P y → x ≤ y → y ≤ x
-
+@[to_dual]
 lemma Minimal.prop (h : Minimal P x) : P x :=
   h.1
 
-lemma Maximal.prop (h : Maximal P x) : P x :=
-  h.1
-
+@[to_dual le_of_ge] -- TODO: improve this naming
 lemma Minimal.le_of_le (h : Minimal P x) (hy : P y) (hle : y ≤ x) : x ≤ y :=
   h.2 hy hle
-
-lemma Maximal.le_of_ge (h : Maximal P x) (hy : P y) (hge : x ≤ y) : y ≤ x :=
-  h.2 hy hge
 
 end LE
 
@@ -250,19 +245,15 @@ section LE
 variable {ι : Sort*} {α : Type*} [LE α] {P : ι → Prop} {f : ι → α} {i j : ι}
 
 /-- `MinimalFor P f i` means that `f i` is minimal over all `i` satisfying `P`. -/
+@[to_dual /-- `MaximalFor P f i` means that `f i` is maximal over all `i` satisfying `P`. -/]
 def MinimalFor (P : ι → Prop) (f : ι → α) (i : ι) : Prop := P i ∧ ∀ ⦃j⦄, P j → f j ≤ f i → f i ≤ f j
 
-/-- `MaximalFor P f i` means that `f i` is maximal over all `i` satisfying `P`. -/
-def MaximalFor (P : ι → Prop) (f : ι → α) (i : ι) : Prop := P i ∧ ∀ ⦃j⦄, P j → f i ≤ f j → f j ≤ f i
-
+@[to_dual]
 lemma MinimalFor.prop (h : MinimalFor P f i) : P i := h.1
-lemma MaximalFor.prop (h : MaximalFor P f i) : P i := h.1
 
+@[to_dual]
 lemma MinimalFor.le_of_le (h : MinimalFor P f i) (hj : P j) (hji : f j ≤ f i) : f i ≤ f j :=
   h.2 hj hji
-
-lemma MaximalFor.le_of_le (h : MaximalFor P f i) (hj : P j) (hij : f i ≤ f j) : f j ≤ f i :=
-  h.2 hj hij
 
 end LE
 
@@ -270,13 +261,10 @@ end LE
 
 /-- An upper set in an order `α` is a set such that any element greater than one of its members is
 also a member. Also called up-set, upward-closed set. -/
+@[to_dual /-- A lower set in an order `α` is a set such that any element less than one of its
+members is also a member. Also called down-set, downward-closed set. -/]
 def IsUpperSet {α : Type*} [LE α] (s : Set α) : Prop :=
   ∀ ⦃a b : α⦄, a ≤ b → a ∈ s → b ∈ s
-
-/-- A lower set in an order `α` is a set such that any element less than one of its members is also
-a member. Also called down-set, downward-closed set. -/
-def IsLowerSet {α : Type*} [LE α] (s : Set α) : Prop :=
-  ∀ ⦃a b : α⦄, b ≤ a → a ∈ s → b ∈ s
 
 @[inherit_doc IsUpperSet]
 structure UpperSet (α : Type*) [LE α] where
@@ -287,7 +275,7 @@ structure UpperSet (α : Type*) [LE α] where
 
 extend_docs UpperSet before "The type of upper sets of an order."
 
-@[inherit_doc IsLowerSet]
+@[inherit_doc IsLowerSet, to_dual]
 structure LowerSet (α : Type*) [LE α] where
   /-- The carrier of a `LowerSet`. -/
   carrier : Set α
@@ -298,13 +286,10 @@ extend_docs LowerSet before "The type of lower sets of an order."
 
 /-- An upper set relative to a predicate `P` is a set such that all elements satisfy `P` and
 any element greater than one of its members and satisfying `P` is also a member. -/
+@[to_dual /-- A lower set relative to a predicate `P` is a set such that all elements satisfy `P`
+and any element less than one of its members and satisfying `P` is also a member. -/]
 def IsRelUpperSet {α : Type*} [LE α] (s : Set α) (P : α → Prop) : Prop :=
   ∀ ⦃a : α⦄, a ∈ s → P a ∧ ∀ ⦃b : α⦄, a ≤ b → P b → b ∈ s
-
-/-- A lower set relative to a predicate `P` is a set such that all elements satisfy `P` and
-any element less than one of its members and satisfying `P` is also a member. -/
-def IsRelLowerSet {α : Type*} [LE α] (s : Set α) (P : α → Prop) : Prop :=
-  ∀ ⦃a : α⦄, a ∈ s → P a ∧ ∀ ⦃b : α⦄, b ≤ a → P b → b ∈ s
 
 @[inherit_doc IsRelUpperSet]
 structure RelUpperSet {α : Type*} [LE α] (P : α → Prop) where
@@ -317,7 +302,7 @@ structure RelUpperSet {α : Type*} [LE α] (P : α → Prop) where
 
 extend_docs RelUpperSet before "The type of upper sets of an order relative to `P`."
 
-@[inherit_doc IsRelLowerSet]
+@[inherit_doc IsRelLowerSet, to_dual]
 structure RelLowerSet {α : Type*} [LE α] (P : α → Prop) where
   /-- The carrier of a `RelLowerSet`. -/
   carrier : Set α

--- a/Mathlib/Tactic/Translate/ToDual.lean
+++ b/Mathlib/Tactic/Translate/ToDual.lean
@@ -134,6 +134,10 @@ def nameDict : Std.HashMap String (List String) := .ofList [
   ("max", ["Min"]),
   ("untop", ["Unbot"]),
   ("unbot", ["Untop"]),
+  ("minimal", ["Maximal"]),
+  ("maximal", ["Minimal"]),
+  ("lower", ["Upper"]),
+  ("upper", ["Lower"]),
 
   ("epi", ["Mono"]),
   /- `mono` can also refer to monotone, so we don't translate it. -/


### PR DESCRIPTION
Note:
- The name translations upper ↔ lower, and minimal ↔ maximal have been added.

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

When merging, all the commits will be squashed into a single commit
listing all co-authors.

Co-authors in the squash commit are gathered from two sources:

First, all authors of commits to this PR branch are included. Thus,
one way to add co-authors is to include at least one commit authored by
each co-author among the commits in the pull request. If necessary, you
may create empty commits to indicate co-authorship, using commands like so:

git commit --author="Author Name <author@email.com>" --allow-empty -m "add Author Name as coauthor"

Second, co-authors can also be listed in lines at the very bottom of
the commit message (that is, directly before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines
at the bottom of the commit message (before the `---`, and also before
any "Co-authored-by" lines) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
