### PR TITLE
[Merged by Bors] - chore(Algebra/Order/AddGroupWithTop): golf

### DIFF
--- a/Mathlib/Algebra/Order/AddGroupWithTop.lean
+++ b/Mathlib/Algebra/Order/AddGroupWithTop.lean
@@ -5,10 +5,12 @@ Authors: Jeremy Avigad, Leonardo de Moura, Mario Carneiro, Johannes Hölzl
 -/
 module
 
-public import Mathlib.Algebra.Order.Monoid.WithTop
-public import Mathlib.Algebra.Group.Hom.Defs
 public import Mathlib.Algebra.CharZero.Defs
+public import Mathlib.Algebra.Group.Hom.Defs
 public import Mathlib.Algebra.Order.Monoid.Canonical.Defs
+public import Mathlib.Algebra.Order.Monoid.WithTop
+
+import Mathlib.Tactic.TermCongr
 
 /-!
 # Linearly ordered commutative additive groups and monoids with a top element adjoined
@@ -27,7 +29,7 @@ The solutions is to use a typeclass, and that is exactly what we do in this file
 
 @[expose] public section
 
-variable {α : Type*}
+variable {G α : Type*}
 
 /-- A linearly ordered commutative monoid with an additively absorbing `⊤` element.
   Instances should include number systems with an infinite element adjoined. -/
@@ -40,13 +42,8 @@ class LinearOrderedAddCommMonoidWithTop (α : Type*) extends
   Instances should include number systems with an infinite element adjoined. -/
 class LinearOrderedAddCommGroupWithTop (α : Type*) extends LinearOrderedAddCommMonoidWithTop α,
   SubNegMonoid α, Nontrivial α where
-  protected neg_top : -(⊤ : α) = ⊤
-  protected add_neg_cancel : ∀ a : α, a ≠ ⊤ → a + -a = 0
-
-instance WithTop.linearOrderedAddCommMonoidWithTop
-    [AddCommMonoid α] [LinearOrder α] [IsOrderedAddMonoid α] :
-    LinearOrderedAddCommMonoidWithTop (WithTop α) :=
-  { top_add' := WithTop.top_add }
+  neg_top : -(⊤ : α) = ⊤
+  add_neg_cancel_of_ne_top ⦃x : α⦄ : x ≠ ⊤ → x + -x = 0
 
 section LinearOrderedAddCommMonoidWithTop
 variable [LinearOrderedAddCommMonoidWithTop α]
@@ -61,148 +58,75 @@ theorem add_top (a : α) : a + ⊤ = ⊤ :=
 
 end LinearOrderedAddCommMonoidWithTop
 
-namespace WithTop
-
-open Function
-
-namespace LinearOrderedAddCommGroup
-
-instance instNeg [AddCommGroup α] : Neg (WithTop α) where
-  neg := WithTop.map fun a : α => -a
-
-/-- If `α` has subtraction, we can extend the subtraction to `WithTop α`, by
-setting `x - ⊤ = ⊤` and `⊤ - x = ⊤`. This definition is only registered as an instance on linearly
-ordered additive commutative groups, to avoid conflicting with the instance `WithTop.instSub` on
-types with a bottom element. -/
-protected def sub [AddCommGroup α] :
-    WithTop α → WithTop α → WithTop α
-  | _, ⊤ => ⊤
-  | ⊤, (x : α) => ⊤
-  | (x : α), (y : α) => (x - y : α)
-
-instance instSub [AddCommGroup α] : Sub (WithTop α) where
-  sub := WithTop.LinearOrderedAddCommGroup.sub
-
-variable [AddCommGroup α]
-
-@[simp, norm_cast]
-theorem coe_neg (a : α) : ((-a : α) : WithTop α) = -a :=
-  rfl
-
-@[simp]
-theorem neg_top : -(⊤ : WithTop α) = ⊤ := rfl
-
-@[simp, norm_cast]
-theorem coe_sub {a b : α} : (↑(a - b) : WithTop α) = ↑a - ↑b := rfl
-
-@[simp]
-theorem top_sub {a : WithTop α} : (⊤ : WithTop α) - a = ⊤ := by
-  cases a <;> rfl
-
-@[simp]
-theorem sub_top {a : WithTop α} : a - ⊤ = ⊤ := by cases a <;> rfl
-
-@[simp]
-lemma sub_eq_top_iff {a b : WithTop α} : a - b = ⊤ ↔ (a = ⊤ ∨ b = ⊤) := by
-  cases a <;> cases b <;> simp [← coe_sub]
-
-instance [LinearOrder α] [IsOrderedAddMonoid α] : LinearOrderedAddCommGroupWithTop (WithTop α) where
-  __ := WithTop.linearOrderedAddCommMonoidWithTop
-  __ := WithTop.nontrivial
-  sub_eq_add_neg a b := by
-    cases a <;> cases b <;> simp [← coe_sub, ← coe_neg, sub_eq_add_neg]
-  neg_top := WithTop.map_top _
-  zsmul := zsmulRec
-  add_neg_cancel := by
-    rintro (a | a) ha
-    · exact (ha rfl).elim
-    · exact (WithTop.coe_add ..).symm.trans (WithTop.coe_eq_coe.2 (add_neg_cancel a))
-
-end LinearOrderedAddCommGroup
-
-end WithTop
-
 namespace LinearOrderedAddCommGroupWithTop
 
 variable [LinearOrderedAddCommGroupWithTop α] {a b : α}
 
 attribute [simp] LinearOrderedAddCommGroupWithTop.neg_top
 
-lemma add_neg_cancel_of_ne_top {α : Type*} [LinearOrderedAddCommGroupWithTop α]
-    {a : α} (h : a ≠ ⊤) :
-    a + -a = 0 :=
-  LinearOrderedAddCommGroupWithTop.add_neg_cancel a h
+/-! Note: The following lemmas are special cases of the corresponding `IsAddUnit` lemmas. -/
 
-@[simp]
-lemma add_eq_top : a + b = ⊤ ↔ a = ⊤ ∨ b = ⊤ := by
-  constructor
-  · intro h
-    by_contra nh
-    rw [not_or] at nh
-    replace h := congrArg (-a + ·) h
-    dsimp only at h
-    rw [add_top, ← add_assoc, add_comm (-a), add_neg_cancel_of_ne_top,
-      zero_add] at h
-    · exact nh.2 h
-    · exact nh.1
-  · rintro (rfl | rfl)
-    · simp
-    · simp
+lemma neg_add_cancel_of_ne_top (ha : a ≠ ⊤) : -a + a = 0 := by
+  simp [add_comm, add_neg_cancel_of_ne_top ha]
 
-@[simp]
-lemma top_ne_zero :
-    (⊤ : α) ≠ 0 := by
-  intro nh
-  have ⟨a, b, h⟩ := Nontrivial.exists_pair_ne (α := α)
-  have : a + 0 ≠ b + 0 := by simpa
-  rw [← nh] at this
-  simp at this
+lemma add_neg_cancel_left_of_ne_top (ha : a ≠ ⊤) (b : α) : a + (-a + b) = b := by
+  simp [← add_assoc, add_neg_cancel_of_ne_top ha]
 
-@[simp] lemma neg_eq_top {a : α} : -a = ⊤ ↔ a = ⊤ where
-  mp h := by
-    by_contra nh
-    replace nh := add_neg_cancel_of_ne_top nh
-    rw [h, add_top] at nh
-    exact top_ne_zero nh
+lemma neg_add_cancel_left_of_ne_top (ha : a ≠ ⊤) (b : α) : -a + (a + b) = b := by
+  simp [← add_assoc, neg_add_cancel_of_ne_top ha]
+
+lemma add_neg_cancel_right_of_ne_top (hb : b ≠ ⊤) (a : α) : a + b + -b = a := by
+  simp [add_assoc, add_neg_cancel_of_ne_top hb]
+
+lemma neg_add_cancel_right_of_ne_top (hb : b ≠ ⊤) (a : α) : a + -b + b = a := by
+  simp [add_assoc, neg_add_cancel_of_ne_top hb]
+
+@[simp] lemma top_ne_zero : (⊤ : α) ≠ 0 := by
+  intro h
+  obtain ⟨a, ha⟩ := exists_ne (0 : α)
+  rw [← zero_add a] at ha
+  simp [top_add, -zero_add, ← h] at ha
+
+@[simp] lemma top_pos : (0 : α) < ⊤ := lt_top_iff_ne_top.2 top_ne_zero.symm
+
+@[simp] lemma isAddUnit_iff : IsAddUnit a ↔ a ≠ ⊤ where
+  mp := by rintro ⟨⟨b, c, hbc, -⟩, rfl⟩ rfl; simp [top_add] at hbc
+  mpr ha := .of_add_eq_zero (-a) <| by simp [ha, add_neg_cancel_of_ne_top]
+
+instance : LinearOrderedAddCommMonoidWithTop α where
+  top_add' := top_add
+
+lemma add_ne_top : a + b ≠ ⊤ ↔ a ≠ ⊤ ∧ b ≠ ⊤ := by simp [← isAddUnit_iff]
+
+@[simp] lemma add_eq_top : a + b = ⊤ ↔ a = ⊤ ∨ b = ⊤ := by
+  rw [← not_iff_not, not_or]; exact add_ne_top
+
+@[simp] lemma add_lt_top : a + b < ⊤ ↔ a < ⊤ ∧ b < ⊤ := by simp [lt_top_iff_ne_top]
+
+@[simp] lemma neg_eq_top : -a = ⊤ ↔ a = ⊤ where
+  mp h := by simpa [h] using add_neg_cancel_of_ne_top (x := a)
   mpr h := by simp [h]
+
+@[simp] lemma sub_top : a - ⊤ = ⊤ := by simp [sub_eq_add_neg]
 
 instance (priority := 100) toSubtractionMonoid : SubtractionMonoid α where
   neg_neg a := by
-    by_cases h : a = ⊤
-    · simp [h]
-    · have h2 : ¬ -a = ⊤ := fun nh ↦ h <| neg_eq_top.mp nh
-      replace h2 : a + (-a + - -a) = a + 0 := congrArg (a + ·) (add_neg_cancel_of_ne_top h2)
-      rw [← add_assoc, add_neg_cancel_of_ne_top h] at h2
-      simp only [zero_add, add_zero] at h2
-      exact h2
+    obtain rfl | ha := eq_or_ne a ⊤
+    · simp
+    · apply left_neg_eq_right_neg (a := -a) <;> simp [add_comm, add_neg_cancel_of_ne_top, ha]
   neg_add_rev a b := by
-    by_cases ha : a = ⊤
-    · simp [ha]
-    by_cases hb : b = ⊤
-    · simp [hb]
-    apply (_ : Function.Injective (a + b + ·))
-    · dsimp
-      rw [add_neg_cancel_of_ne_top, ← add_assoc, add_assoc a,
-        add_neg_cancel_of_ne_top hb, add_zero,
-        add_neg_cancel_of_ne_top ha]
-      simp [ha, hb]
-    · apply Function.LeftInverse.injective (g := (-(a + b) + ·))
-      intro x
-      dsimp only
-      rw [← add_assoc, add_comm (-(a + b)), add_neg_cancel_of_ne_top, zero_add]
-      simp [ha, hb]
+    obtain rfl | ha := eq_or_ne a ⊤
+    · simp
+    obtain rfl | hb := eq_or_ne b ⊤
+    · simp
+    · exact left_neg_eq_right_neg (a := a + b) (by simp [neg_add_cancel_of_ne_top, *])
+        (by simp [add_assoc, add_neg_cancel_of_ne_top, add_neg_cancel_left_of_ne_top, *])
   neg_eq_of_add a b h := by
-    have oh := congrArg (-a + ·) h
-    dsimp only at oh
-    rw [add_zero, ← add_assoc, add_comm (-a), add_neg_cancel_of_ne_top, zero_add] at oh
-    · exact oh.symm
-    intro v
-    simp [v] at h
+    have ha : a ≠ ⊤ := by rintro rfl; simp at h
+    exact left_neg_eq_right_neg (a := a) (by simp [neg_add_cancel_of_ne_top, *]) h
 
-lemma injective_add_left_of_ne_top (b : α) (h : b ≠ ⊤) : Function.Injective (fun x ↦ x + b) := by
-  intro x y h2
-  replace h2 : x + (b + -b) = y + (b + -b) := by simp [← add_assoc, h2]
-  simpa only [LinearOrderedAddCommGroupWithTop.add_neg_cancel _ h, add_zero] using h2
+lemma injective_add_left_of_ne_top (b : α) (h : b ≠ ⊤) : Function.Injective (fun x ↦ x + b) :=
+  fun x y hxy ↦ by simpa [h] using congr($hxy - b)
 
 lemma injective_add_right_of_ne_top (b : α) (h : b ≠ ⊤) : Function.Injective (fun x ↦ b + x) := by
   simpa [add_comm] using injective_add_left_of_ne_top b h
@@ -216,21 +140,52 @@ lemma strictMono_add_right_of_ne_top (b : α) (h : b ≠ ⊤) : StrictMono (fun 
   simpa [add_comm] using strictMono_add_left_of_ne_top b h
 
 lemma sub_pos (a b : α) : 0 < a - b ↔ b < a ∨ b = ⊤ where
-  mp h := by
-    refine or_iff_not_imp_right.mpr fun h2 ↦ ?_
-    replace h := strictMono_add_left_of_ne_top _ h2 h
-    simp only [zero_add] at h
-    rw [sub_eq_add_neg, add_assoc, add_comm (-b),
-      add_neg_cancel_of_ne_top h2, add_zero] at h
-    exact h
-  mpr h := by
-    rcases h with h | h
-    · convert strictMono_add_left_of_ne_top (-b) (by simp [h.ne_top]) h using 1
-      · simp [add_neg_cancel_of_ne_top h.ne_top]
-      · simp [sub_eq_add_neg]
-    · rw [h]
-      simp only [sub_eq_add_neg, LinearOrderedAddCommGroupWithTop.neg_top, add_top]
-      apply lt_of_le_of_ne le_top
-      exact Ne.symm top_ne_zero
+  mp h := or_iff_not_imp_right.mpr fun hb ↦ by
+    simpa [sub_eq_add_neg, add_assoc, hb] using strictMono_add_left_of_ne_top _ hb h
+  mpr := by
+    rintro (h | rfl)
+    · simpa [sub_eq_add_neg, h.ne_top]
+        using strictMono_add_left_of_ne_top (-b) (by simp [h.ne_top]) h
+    · simp
 
 end LinearOrderedAddCommGroupWithTop
+
+namespace WithTop
+
+instance linearOrderedAddCommMonoidWithTop [AddCommMonoid α] [LinearOrder α]
+    [IsOrderedAddMonoid α] : LinearOrderedAddCommMonoidWithTop (WithTop α) where
+  top_add' := WithTop.top_add
+
+namespace LinearOrderedAddCommGroup
+variable [AddCommGroup G] {x y : WithTop G}
+
+instance instNeg : Neg (WithTop G) where
+  neg := .map fun a ↦ -a
+
+/-- If `G` has subtraction, we can extend the subtraction to `WithTop G`, by setting `x - ⊤ = ⊤` and
+`⊤ - x = ⊤`. This definition is only registered as an instance on additive commutative groups, to
+avoid conflicting with the instance `WithTop.instSub` on types with a bottom element. -/
+instance instSub : Sub (WithTop G) where
+  sub
+  | _, ⊤ => ⊤
+  | ⊤, (b : G) => ⊤
+  | (a : G), (b : G) => (a - b : G)
+
+@[simp, norm_cast] lemma coe_neg (a : G) : (↑(-a) : WithTop G) = -a := rfl
+@[simp, norm_cast] lemma coe_sub (a b : G) : (↑(a - b) : WithTop G) = ↑a - ↑b := rfl
+
+@[simp] lemma neg_top : -(⊤ : WithTop G) = ⊤ := rfl
+
+@[simp] lemma top_sub (x : WithTop G) : ⊤ - x = ⊤ := by cases x <;> rfl
+@[simp] lemma sub_top (x : WithTop G) : x - ⊤ = ⊤ := by cases x <;> rfl
+
+@[simp] lemma sub_eq_top_iff : x - y = ⊤ ↔ x = ⊤ ∨ y = ⊤ := by
+  cases x <;> cases y <;> simp [← coe_sub]
+
+instance [LinearOrder G] [IsOrderedAddMonoid G] : LinearOrderedAddCommGroupWithTop (WithTop G) where
+  sub_eq_add_neg a b := by cases a <;> cases b <;> simp [← coe_sub, ← coe_neg, sub_eq_add_neg]
+  neg_top := WithTop.map_top _
+  zsmul := zsmulRec
+  add_neg_cancel_of_ne_top | (a : G), _ => mod_cast add_neg_cancel a
+
+end WithTop.LinearOrderedAddCommGroup

--- a/Mathlib/Algebra/Order/AddGroupWithTop.lean
+++ b/Mathlib/Algebra/Order/AddGroupWithTop.lean
@@ -64,6 +64,8 @@ variable [LinearOrderedAddCommGroupWithTop α] {a b : α}
 
 attribute [simp] LinearOrderedAddCommGroupWithTop.neg_top
 
+@[deprecated (since := "2025-12-14")] protected alias add_neg_cancel := add_neg_cancel_of_ne_top
+
 /-! Note: The following lemmas are special cases of the corresponding `IsAddUnit` lemmas. -/
 
 lemma neg_add_cancel_of_ne_top (ha : a ≠ ⊤) : -a + a = 0 := by

--- a/Mathlib/Algebra/Order/GroupWithZero/Canonical.lean
+++ b/Mathlib/Algebra/Order/GroupWithZero/Canonical.lean
@@ -160,11 +160,11 @@ theorem lt_of_mul_lt_mul_of_le₀ (h : a * b < c * d) (hc : 0 < c) (hh : c ≤ a
 
 instance : LinearOrderedAddCommGroupWithTop (Additive αᵒᵈ) where
   neg_top := inv_zero (G₀ := α)
-  add_neg_cancel := fun a ha ↦ mul_inv_cancel₀ (G₀ := α) (id ha : a.toMul ≠ 0)
+  add_neg_cancel_of_ne_top _a := mul_inv_cancel₀ (G₀ := α)
 
 instance : LinearOrderedAddCommGroupWithTop (Additive α)ᵒᵈ where
   neg_top := inv_zero (G₀ := α)
-  add_neg_cancel := fun a ha ↦ mul_inv_cancel₀ (G₀ := α) (id ha : a.toMul ≠ 0)
+  add_neg_cancel_of_ne_top _a := mul_inv_cancel₀ (G₀ := α)
 
 -- Counterexample with monoid for the backward direction:
 -- Take `Mᵐ⁰` where `M := ℚ ×ₗ ℕ`.
@@ -227,11 +227,9 @@ theorem ofDual_toAdd_zero [LinearOrderedAddCommMonoidWithTop α] :
     OrderDual.ofDual (0 : Multiplicative αᵒᵈ).toAdd = ⊤ := rfl
 
 instance [LinearOrderedAddCommGroupWithTop α] :
-    LinearOrderedCommGroupWithZero (Multiplicative αᵒᵈ) :=
-  { Multiplicative.divInvMonoid, instLinearOrderedCommMonoidWithZeroMultiplicativeOrderDual,
-    Multiplicative.instNontrivial with
-    inv_zero := @LinearOrderedAddCommGroupWithTop.neg_top _ (_)
-    mul_inv_cancel := @LinearOrderedAddCommGroupWithTop.add_neg_cancel _ (_) }
+    LinearOrderedCommGroupWithZero (Multiplicative αᵒᵈ) where
+  inv_zero := LinearOrderedAddCommGroupWithTop.neg_top (α := α)
+  mul_inv_cancel := LinearOrderedAddCommGroupWithTop.add_neg_cancel_of_ne_top (α := α)
 
 namespace WithZero
 

--- a/Mathlib/Algebra/Order/Ring/Archimedean.lean
+++ b/Mathlib/Algebra/Order/Ring/Archimedean.lean
@@ -238,7 +238,7 @@ private theorem zsmul_succ' (n : ℕ) (x : ArchimedeanClass R) :
 
 noncomputable instance : LinearOrderedAddCommGroupWithTop (ArchimedeanClass R) where
   neg_top := by simp [← mk_zero, ← mk_inv]
-  add_neg_cancel x h := by
+  add_neg_cancel_of_ne_top x h := by
     induction x with | mk x
     simp [← mk_inv, ← mk_mul, mul_inv_cancel₀ (mk_eq_top_iff.not.1 h)]
   zsmul n x := n • x


### PR DESCRIPTION
---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

When merging, all the commits will be squashed into a single commit
listing all co-authors.

Co-authors in the squash commit are gathered from two sources:

First, all authors of commits to this PR branch are included. Thus,
one way to add co-authors is to include at least one commit authored by
each co-author among the commits in the pull request. If necessary, you
may create empty commits to indicate co-authorship, using commands like so:

git commit --author="Author Name <author@email.com>" --allow-empty -m "add Author Name as coauthor"

Second, co-authors can also be listed in lines at the very bottom of
the commit message (that is, directly before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines
at the bottom of the commit message (before the `---`, and also before
any "Co-authored-by" lines) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
