### PR TITLE
[Merged by Bors] - chore: golf using `simpa`

### DIFF
--- a/Mathlib/Logic/Equiv/Fin/Rotate.lean
+++ b/Mathlib/Logic/Equiv/Fin/Rotate.lean
@@ -88,9 +88,7 @@ theorem coe_finRotate (i : Fin n.succ) :
 
 theorem lt_finRotate_iff_ne_last (i : Fin (n + 1)) :
     i < finRotate _ i ↔ i ≠ Fin.last n := by
-  refine ⟨fun hi hc ↦ ?_, fun hi ↦ ?_⟩
-  · simp only [hc, finRotate_succ_apply, Fin.last_add_one, Fin.not_lt_zero] at hi
-  · rw [Fin.lt_def, coe_finRotate_of_ne_last hi, Nat.lt_add_one_iff]
+  simpa using Fin.lt_last_iff_ne_last
 
 theorem lt_finRotate_iff_ne_neg_one [NeZero n] (i : Fin n) :
     i < finRotate _ i ↔ i ≠ -1 := by

--- a/Mathlib/Order/SuccPred/Basic.lean
+++ b/Mathlib/Order/SuccPred/Basic.lean
@@ -831,8 +831,7 @@ theorem Ici_pred (a : α) : Ici (pred a) = insert (pred a) (Ici a) :=
   ext fun _ => pred_le_iff_eq_or_le
 
 theorem Ioi_pred_eq_insert_of_not_isMin (ha : ¬IsMin a) : Ioi (pred a) = insert a (Ioi a) := by
-  ext x; simp only [insert, mem_setOf, @eq_comm _ x a, mem_Ioi, Set.insert]
-  exact pred_lt_iff_eq_or_lt_of_not_isMin ha
+  simpa using Ioi_pred_of_not_isMin ha
 
 theorem Icc_pred_left (h : pred a ≤ b) : Icc (pred a) b = insert (pred a) (Icc a b) := by
   simp_rw [← Ici_inter_Iic, Ici_pred, insert_inter_of_mem (mem_Iic.2 h)]

--- a/Mathlib/Probability/Kernel/Condexp.lean
+++ b/Mathlib/Probability/Kernel/Condexp.lean
@@ -49,9 +49,7 @@ theorem _root_.MeasureTheory.AEStronglyMeasurable.comp_snd_map_prod_id [Topologi
     (hm : m ≤ mΩ) (hf : AEStronglyMeasurable f μ) :
     AEStronglyMeasurable[m.prod mΩ] (fun x : Ω × Ω => f x.2)
       (@Measure.map Ω (Ω × Ω) mΩ (m.prod mΩ) (fun ω => (id ω, id ω)) μ) := by
-  rw [← aestronglyMeasurable_comp_snd_map_prodMk_iff (measurable_id'' hm)] at hf
-  simp_rw [id] at hf ⊢
-  exact hf
+  simpa using (aestronglyMeasurable_comp_snd_map_prodMk_iff hm).mpr hf
 
 theorem _root_.MeasureTheory.Integrable.comp_snd_map_prod_id [NormedAddCommGroup F] (hm : m ≤ mΩ)
     (hf : Integrable f μ) : Integrable (fun x : Ω × Ω => f x.2)

--- a/Mathlib/RingTheory/MvPowerSeries/Order.lean
+++ b/Mathlib/RingTheory/MvPowerSeries/Order.lean
@@ -131,9 +131,7 @@ variable (w : σ → ℕ) {f g : MvPowerSeries σ R}
 
 theorem ne_zero_iff_exists_coeff_ne_zero_and_weight :
     f ≠ 0 ↔ (∃ n : ℕ, ∃ d : σ →₀ ℕ, coeff d f ≠ 0 ∧ weight w d = n) := by
-  refine not_iff_not.mp ?_
-  simp only [ne_eq, not_not, not_exists, not_and, forall_apply_eq_imp_iff₂, imp_false]
-  exact MvPowerSeries.ext_iff
+  simpa using ne_zero_iff_exists_coeff_ne_zero f
 
 /-- The weighted order of a mv_power_series -/
 def weightedOrder (f : MvPowerSeries σ R) : ℕ∞ := by

--- a/Mathlib/Topology/MetricSpace/BundledFun.lean
+++ b/Mathlib/Topology/MetricSpace/BundledFun.lean
@@ -142,9 +142,7 @@ instance : OrderBot (PseudoMetric X R) where
 lemma coe_finsetSup [IsOrderedAddMonoid R] {Y : Type*} {f : Y → PseudoMetric X R} {s : Finset Y}
     (hs : s.Nonempty) :
     ⇑(s.sup f) = s.sup' hs (f ·) := by
-  induction hs using Finset.Nonempty.cons_induction with
-  | singleton i => simp
-  | cons a s ha hs ih => simp [hs, ih]
+  simpa using (Finset.sup'_eq_sup hs fun x ↦ f x).symm
 
 lemma finsetSup_apply [IsOrderedAddMonoid R] {Y : Type*} {f : Y → PseudoMetric X R}
     {s : Finset Y} (hs : s.Nonempty) (x y : X) :

--- a/Mathlib/Topology/MetricSpace/BundledFun.lean
+++ b/Mathlib/Topology/MetricSpace/BundledFun.lean
@@ -142,7 +142,7 @@ instance : OrderBot (PseudoMetric X R) where
 lemma coe_finsetSup [IsOrderedAddMonoid R] {Y : Type*} {f : Y → PseudoMetric X R} {s : Finset Y}
     (hs : s.Nonempty) :
     ⇑(s.sup f) = s.sup' hs (f ·) := by
-  simpa using (Finset.sup'_eq_sup hs fun x ↦ f x).symm
+  simpa using (Finset.sup'_eq_sup hs (f ·)).symm
 
 lemma finsetSup_apply [IsOrderedAddMonoid R] {Y : Type*} {f : Y → PseudoMetric X R}
     {s : Finset Y} (hs : s.Nonempty) (x y : X) :


### PR DESCRIPTION
---
Trace profiling results (shown if ≥10 ms before or after):
* `lt_finRotate_iff_ne_last`: <10 ms before, <10 ms after  🎉
* `Order.Ioi_pred_eq_insert_of_not_isMin`: <10 ms before, 21 ms after
* `MeasureTheory.AEStronglyMeasurable.comp_snd_map_prod_id`: <10 ms before, 22 ms after
* `MvPowerSeries.ne_zero_iff_exists_coeff_ne_zero_and_weight`: <10 ms before, 90 ms after
* `PseudoMetric.coe_finsetSup`: 145 ms before, 40 ms after  🎉

This golfing PR is batched under the following guidelines:
* Up to 5 changed files per PR
* Up to 25 changed declarations per PR
* Up to 100 changed lines per PR

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

When merging, all the commits will be squashed into a single commit
listing all co-authors.

Co-authors in the squash commit are gathered from two sources:

First, all authors of commits to this PR branch are included. Thus,
one way to add co-authors is to include at least one commit authored by
each co-author among the commits in the pull request. If necessary, you
may create empty commits to indicate co-authorship, using commands like so:

git commit --author="Author Name <author@email.com>" --allow-empty -m "add Author Name as coauthor"

Second, co-authors can also be listed in lines at the very bottom of
the commit message (that is, directly before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines
at the bottom of the commit message (before the `---`, and also before
any "Co-authored-by" lines) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
