### PR TITLE
[Merged by Bors] - fix(translate): only generate equation lemmas when generating new decls

### DIFF
--- a/MathlibTest/ToDual.lean
+++ b/MathlibTest/ToDual.lean
@@ -19,6 +19,10 @@ lemma SemilatticeInf.le_inf' {α : Type} [SemilatticeInf α] (a b c : α) : a �
 lemma SemilatticeSup.sup_le' {α : Type} [SemilatticeSup α] (a b c : α) : a ≤ c → b ≤ c → a ⊔ b ≤ c :=
   SemilatticeSup.sup_le a b c
 
+structure Lattice (α : Type) extends SemilatticeInf α, SemilatticeSup α
+
+attribute [to_dual existing] Lattice.toSemilatticeInf
+
 -- we still cannot reorder arguments of arguments, so `SemilatticeInf.mk` is not tranlatable
 /--
 error: @[to_dual] failed. The translated value is not type correct. For help, see the docstring of `to_additive`, section `Troubleshooting`. Failed to add declaration


### PR DESCRIPTION
This PR avoids calling `getEqnsFor?` unneccessarily. Due to a bug(?), `getEqnsFor?` sometimes throws an error, but that only occurrs in a case where we aren't actually interested in its result

Zulip: [#metaprogramming / tactics > to_dual and structure projections](https://leanprover.zulipchat.com/#narrow/channel/239415-metaprogramming-.2F-tactics/topic/to_dual.20and.20structure.20projections/with/561654296)

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

When merging, all the commits will be squashed into a single commit
listing all co-authors.

Co-authors in the squash commit are gathered from two sources:

First, all authors of commits to this PR branch are included. Thus,
one way to add co-authors is to include at least one commit authored by
each co-author among the commits in the pull request. If necessary, you
may create empty commits to indicate co-authorship, using commands like so:

git commit --author="Author Name <author@email.com>" --allow-empty -m "add Author Name as coauthor"

Second, co-authors can also be listed in lines at the very bottom of
the commit message (that is, directly before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines
at the bottom of the commit message (before the `---`, and also before
any "Co-authored-by" lines) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
