### PR TITLE
[Merged by Bors] - chore(Algebra/Order): deprecate `not_neg` in favour of `not_lt_zero`

### DIFF
--- a/Mathlib/Algebra/Order/Monoid/Canonical/Defs.lean
+++ b/Mathlib/Algebra/Order/Monoid/Canonical/Defs.lean
@@ -137,7 +137,9 @@ end LE
 section Preorder
 variable [Preorder α] [CanonicallyOrderedMul α] {a b : α}
 
-@[to_additive (attr := simp)] lemma not_lt_one : ¬ a < 1 := (one_le a).not_gt
+@[to_additive (attr := simp) not_lt_zero] lemma not_lt_one : ¬ a < 1 := (one_le a).not_gt
+
+@[deprecated (since := "2025-12-03")] alias not_neg := not_lt_one
 
 @[to_additive] -- `(attr := simp)` cannot be used here because `a` cannot be inferred by `simp`.
 theorem one_lt_of_gt (h : a < b) : 1 < b :=

--- a/Mathlib/Analysis/BoxIntegral/Basic.lean
+++ b/Mathlib/Analysis/BoxIntegral/Basic.lean
@@ -646,7 +646,8 @@ theorem integrable_of_bounded_and_ae_continuousWithinAt [CompleteSpace E] {I : B
   let μ' := μ.restrict (Box.Icc I)
   have μ'D : μ' D = 0 := by
     rcases eventually_iff_exists_mem.1 hc with ⟨V, ae, hV⟩
-    exact eq_of_le_of_not_lt (mem_ae_iff.1 ae ▸ (μ'.mono <| fun x h xV ↦ h.2 (hV x xV))) not_lt_zero
+    exact eq_of_le_of_not_lt (mem_ae_iff.1 ae ▸ (μ'.mono <| fun x h xV ↦ h.2 (hV x xV)))
+      _root_.not_lt_zero
   obtain ⟨U, UD, Uopen, hU⟩ := Set.exists_isOpen_lt_add D (show μ' D ≠ ⊤ by simp [μ'D]) ε₂0'
   rw [μ'D, zero_add] at hU
   /- Box.Icc I \ U is compact and avoids discontinuities of f, so there exists r > 0 such that for

--- a/Mathlib/RingTheory/Spectrum/Prime/LTSeries.lean
+++ b/Mathlib/RingTheory/Spectrum/Prime/LTSeries.lean
@@ -47,7 +47,7 @@ theorem exist_mem_one_of_mem_maximal_ideal [IsLocalRing R] {p₁ p₀ : PrimeSpe
   simp_rw [show q = closedPoint R from PrimeSpectrum.ext hqm] at h
   have hph : (e ⟨p₁, h₀.le⟩).1.height ≤ 0 :=
     Order.lt_one_iff_nonpos.mp (height_le_iff.mp h _ inferInstance (by simpa using h₁))
-  refine not_neg (a := (e ⟨p₀, le_refl p₀⟩).1.height) (height_le_iff.mp hph _ inferInstance ?_)
+  refine not_lt_zero (a := (e ⟨p₀, le_refl p₀⟩).1.height) (height_le_iff.mp hph _ inferInstance ?_)
   simpa using h₀
 
 theorem exist_mem_one_of_mem_two {p₁ p₀ p₂ : PrimeSpectrum R}

--- a/Mathlib/SetTheory/Cardinal/Cofinality.lean
+++ b/Mathlib/SetTheory/Cardinal/Cofinality.lean
@@ -463,7 +463,7 @@ theorem id_of_le_cof (h : o ≤ o.cof.ord) : IsFundamentalSequence o o fun a _ =
   ⟨h, @fun _ _ _ _ => id, blsub_id o⟩
 
 protected theorem zero {f : ∀ b < (0 : Ordinal), Ordinal} : IsFundamentalSequence 0 0 f :=
-  ⟨by rw [cof_zero, ord_zero], @fun i _ hi => (not_neg hi).elim, blsub_zero f⟩
+  ⟨by rw [cof_zero, ord_zero], @fun i _ hi => (not_lt_zero hi).elim, blsub_zero f⟩
 
 protected theorem succ : IsFundamentalSequence (succ o) 1 fun _ _ => o := by
   refine ⟨?_, @fun i j hi hj h => ?_, blsub_const Ordinal.one_ne_zero o⟩

--- a/Mathlib/SetTheory/Game/Birthday.lean
+++ b/Mathlib/SetTheory/Game/Birthday.lean
@@ -284,7 +284,7 @@ theorem small_setOf_birthday_lt (o : Ordinal) : Small.{u} {x : Game.{u} // birth
   let S := ⋃ a ∈ Set.Iio o, {x : Game.{u} | birthday x < a}
   let H : Small.{u} S := @small_biUnion _ _ _ _ _ IH
   obtain rfl | ⟨a, rfl⟩ | ho := zero_or_succ_or_isSuccLimit o
-  · simp_rw [not_neg]
+  · simp_rw [not_lt_zero]
     exact small_empty
   · simp_rw [Order.lt_succ_iff, le_iff_lt_or_eq]
     convert small_union.{u} {x | birthday x < a} {x | birthday x = a}

--- a/Mathlib/SetTheory/Nimber/Basic.lean
+++ b/Mathlib/SetTheory/Nimber/Basic.lean
@@ -142,7 +142,7 @@ protected theorem le_zero {a : Nimber} : a ≤ 0 ↔ a = 0 :=
   nonpos_iff_eq_zero (α := Ordinal)
 
 protected theorem not_lt_zero (a : Nimber) : ¬ a < 0 :=
-  not_neg (α := Ordinal)
+  not_lt_zero (α := Ordinal)
 
 protected theorem pos_iff_ne_zero {a : Nimber} : 0 < a ↔ a ≠ 0 :=
   pos_iff_ne_zero (α := Ordinal)

--- a/Mathlib/SetTheory/Ordinal/Family.lean
+++ b/Mathlib/SetTheory/Ordinal/Family.lean
@@ -404,7 +404,7 @@ theorem bsup_succ_of_mono {o : Ordinal} {f : ∀ a < succ o, Ordinal}
 
 @[simp]
 theorem bsup_zero (f : ∀ a < (0 : Ordinal), Ordinal) : bsup 0 f = 0 :=
-  bsup_eq_zero_iff.2 fun _i hi => (not_neg hi).elim
+  bsup_eq_zero_iff.2 fun _i hi => (not_lt_zero hi).elim
 
 theorem bsup_const {o : Ordinal.{u}} (ho : o ≠ 0) (a : Ordinal.{max u v}) :
     (bsup.{_, v} o fun _ _ => a) = a :=

--- a/Mathlib/SetTheory/Ordinal/NaturalOps.lean
+++ b/Mathlib/SetTheory/Ordinal/NaturalOps.lean
@@ -119,7 +119,7 @@ protected theorem zero_le (o : NatOrdinal) : 0 ≤ o :=
   _root_.zero_le (α := Ordinal) o
 
 theorem not_lt_zero (o : NatOrdinal) : ¬ o < 0 :=
-  not_neg (α := Ordinal)
+  not_lt_zero (α := Ordinal)
 
 @[simp]
 theorem lt_one_iff_zero {o : NatOrdinal} : o < 1 ↔ o = 0 :=

--- a/Mathlib/SetTheory/Ordinal/NaturalOps.lean
+++ b/Mathlib/SetTheory/Ordinal/NaturalOps.lean
@@ -119,7 +119,7 @@ protected theorem zero_le (o : NatOrdinal) : 0 ≤ o :=
   _root_.zero_le (α := Ordinal) o
 
 theorem not_lt_zero (o : NatOrdinal) : ¬ o < 0 :=
-  not_lt_zero (α := Ordinal)
+  _root_.not_lt_zero (α := Ordinal)
 
 @[simp]
 theorem lt_one_iff_zero {o : NatOrdinal} : o < 1 ↔ o = 0 :=

--- a/Mathlib/SetTheory/Ordinal/Principal.lean
+++ b/Mathlib/SetTheory/Ordinal/Principal.lean
@@ -166,7 +166,7 @@ theorem principal_add_iff_add_left_eq_self : Principal (· + ·) o ↔ ∀ a < o
     · exact op_eq_self_of_principal hao (isNormal_add_right a) ho
         (isSuccLimit_of_principal_add ho₁ ho)
     · rcases le_one_iff.1 ho₁ with (rfl | rfl)
-      · exact (not_neg hao).elim
+      · exact (not_lt_zero hao).elim
       · rw [lt_one_iff_zero] at hao
         rw [hao, zero_add]
   · rw [← h a hao]
@@ -378,7 +378,7 @@ theorem principal_mul_iff_le_two_or_omega0_opow_opow :
     · exact Or.inl ho₂
     · rcases principal_add_iff_zero_or_omega0_opow.1 (principal_add_of_principal_mul ho ho₂.ne')
         with (rfl | ⟨a, rfl⟩)
-      · exact (not_neg ho₂).elim
+      · exact (not_lt_zero ho₂).elim
       · rcases principal_add_iff_zero_or_omega0_opow.1
           (principal_add_of_principal_mul_opow one_lt_omega0 ho) with (rfl | ⟨b, rfl⟩)
         · simp

--- a/Mathlib/Topology/Category/Profinite/Nobeling/Induction.lean
+++ b/Mathlib/Topology/Category/Profinite/Nobeling/Induction.lean
@@ -56,7 +56,7 @@ We also define
 
 theorem GoodProducts.P0 : P I 0 := fun _ C _ hsC ↦ by
   have : C ⊆ {(fun _ ↦ false)} := fun c hc ↦ by
-    ext x; exact Bool.eq_false_iff.mpr (fun ht ↦ not_neg (hsC c hc x ht))
+    ext x; exact Bool.eq_false_iff.mpr (fun ht ↦ not_lt_zero (hsC c hc x ht))
   rw [Set.subset_singleton_iff_eq] at this
   cases this
   · subst C


### PR DESCRIPTION
Since almost every other instance of `¬_ < 0` is named using `_lt_zero`, we fix the week-old name of `not_neg` to `not_lt_zero`.

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
