### PR TITLE
[Merged by Bors] - feat(tauto): better error message on failure

### DIFF
--- a/Mathlib/Lean/Elab/Tactic/Basic.lean
+++ b/Mathlib/Lean/Elab/Tactic/Basic.lean
@@ -22,27 +22,4 @@ Remark: note that `MVarId.getType'` uses `whnf` instead of `cleanupAnnotations`,
 def getMainTarget'' : TacticM Expr := do
   (← getMainGoal).getType''
 
-/--
-Like `done` but takes a scope (e.g. a tactic name) as an argument
-to produce more detailed error messages.
--/
-def doneWithScope (scope : MessageData) : TacticM Unit := do
-  let gs ← getUnsolvedGoals
-  unless gs.isEmpty do
-    logError m!"{scope} failed to solve some goals.\n"
-    Term.reportUnsolvedGoals gs
-    throwAbortTactic
-
-/--
-Like `focusAndDone` but takes a scope (e.g. tactic name) as an argument to
-produce more detailed error messages.
--/
-def focusAndDoneWithScope {α : Type} (scope : MessageData) (tactic : TacticM α) : TacticM α :=
-  focus do
-    let a ← try tactic catch e =>
-      if isAbortTacticException e then throw e
-      else throwError "{scope} failed.\n{← nestedExceptionToMessageData e}"
-    doneWithScope scope
-    pure a
-
 end Lean.Elab.Tactic

--- a/Mathlib/Tactic/Tauto.lean
+++ b/Mathlib/Tactic/Tauto.lean
@@ -201,14 +201,15 @@ def finishingConstructorMatcher (e : Q(Prop)) : MetaM Bool :=
 
 /-- Implementation of the `tauto` tactic. -/
 def tautology : TacticM Unit := focus do
-  let g ← getMainGoal
-  tautoCore
-  allGoals (iterateUntilFailure
-    (evalTactic (← `(tactic| rfl)) <|>
-    evalTactic (← `(tactic| solve_by_elim)) <|>
-    liftMetaTactic (constructorMatching · finishingConstructorMatcher)))
-  unless (← getUnsolvedGoals).isEmpty do
-    throwTacticEx `tauto g
+  classical do
+    let g ← getMainGoal
+    tautoCore
+    allGoals (iterateUntilFailure
+      (evalTactic (← `(tactic| rfl)) <|>
+      evalTactic (← `(tactic| solve_by_elim)) <|>
+      liftMetaTactic (constructorMatching · finishingConstructorMatcher)))
+    unless (← getUnsolvedGoals).isEmpty do
+      throwTacticEx `tauto g
 
 /--
 `tauto` breaks down assumptions of the form `_ ∧ _`, `_ ∨ _`, `_ ↔ _` and `∃ _, _`

--- a/Mathlib/Tactic/Tauto.lean
+++ b/Mathlib/Tactic/Tauto.lean
@@ -200,13 +200,15 @@ def finishingConstructorMatcher (e : Q(Prop)) : MetaM Bool :=
   | _ => pure false
 
 /-- Implementation of the `tauto` tactic. -/
-def tautology : TacticM Unit := focusAndDoneWithScope "tauto" do
-  classical do
-    tautoCore
-    allGoals (iterateUntilFailure
-      (evalTactic (← `(tactic| rfl)) <|>
-      evalTactic (← `(tactic| solve_by_elim)) <|>
-      liftMetaTactic (constructorMatching · finishingConstructorMatcher)))
+def tautology : TacticM Unit := focus do
+  let g ← getMainGoal
+  tautoCore
+  allGoals (iterateUntilFailure
+    (evalTactic (← `(tactic| rfl)) <|>
+    evalTactic (← `(tactic| solve_by_elim)) <|>
+    liftMetaTactic (constructorMatching · finishingConstructorMatcher)))
+  unless (← getUnsolvedGoals).isEmpty do
+    throwTacticEx `tauto g
 
 /--
 `tauto` breaks down assumptions of the form `_ ∧ _`, `_ ∨ _`, `_ ↔ _` and `∃ _, _`


### PR DESCRIPTION
This PR improves the `tauto` error message. Previously, it said "tauto failed to solve some goals.", and then a separate message reported on the unsolved goals. But I think these unsolved goals are implementation details of `tauto`. So instead, the error message now says "Tactic `tauto` failed", followed by the goal on which `tauto` was run.

This change is so that `tauto` can be used as part of the `by_contra!` tactic.

---
<!-- Your PR title will become the first line of the commit message.

In this box, the text above the `---` (if not empty) will be appended
to the commit message, and can be used to give additional context or
details. Please leave a blank newline before the `---`, otherwise GitHub
will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

When merging, all the commits will be squashed into a single commit
listing all co-authors.

Co-authors in the squash commit are gathered from two sources:

First, all authors of commits to this PR branch are included. Thus,
one way to add co-authors is to include at least one commit authored by
each co-author among the commits in the pull request. If necessary, you
may create empty commits to indicate co-authorship, using commands like so:

git commit --author="Author Name <author@email.com>" --allow-empty -m "add Author Name as coauthor"

Second, co-authors can also be listed in lines at the very bottom of
the commit message (that is, directly before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines
at the bottom of the commit message (before the `---`, and also before
any "Co-authored-by" lines) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
