### PR TITLE
[Merged by Bors] - feat(SetTheory/Ordinal): Improve API for Ordinal.toType

### DIFF
--- a/Mathlib/SetTheory/Cardinal/Ordinal.lean
+++ b/Mathlib/SetTheory/Cardinal/Ordinal.lean
@@ -33,7 +33,7 @@ lemma mk_iUnion_Ordinal_lift_le_of_le {β : Type v} {o : Ordinal.{u}} {c : Cardi
   rw [mk_toType]
   refine mul_le_mul' ho (ciSup_le' ?_)
   intro i
-  simpa using hA _ i.get.prop
+  simpa using hA _ i.toOrd.prop
 
 lemma mk_iUnion_Ordinal_le_of_le {β : Type*} {o : Ordinal} {c : Cardinal}
     (ho : o.card ≤ c) (hc : ℵ₀ ≤ c) (A : Ordinal → Set β)
@@ -51,8 +51,8 @@ theorem lift_card_iSup_le_sum_card {ι : Type u} [Small.{v} ι] (f : ι → Ordi
     Cardinal.lift.{u} (⨆ i, f i).card ≤ Cardinal.sum fun i ↦ (f i).card := by
   simp_rw [← mk_toType]
   rw [← mk_sigma, ← Cardinal.lift_id'.{v} #(Σ _, _), ← Cardinal.lift_umax.{v, u}]
-  apply lift_mk_le_lift_mk_of_surjective (f := .mk ∘ (⟨·.2.get,
-    (mem_Iio.mp (toType.get _).2).trans_le (Ordinal.le_iSup _ _)⟩))
+  apply lift_mk_le_lift_mk_of_surjective (f := .mk ∘ (⟨·.2.toOrd,
+    (mem_Iio.mp (toType.toOrd _).2).trans_le (Ordinal.le_iSup _ _)⟩))
   rw [EquivLike.comp_surjective]
   rintro ⟨x, hx⟩
   obtain ⟨i, hi⟩ := Ordinal.lt_iSup_iff.mp hx
@@ -64,7 +64,7 @@ theorem card_iSup_le_sum_card {ι : Type u} (f : ι → Ordinal.{max u v}) :
   rwa [Cardinal.lift_id'] at this
 
 theorem card_iSup_Iio_le_sum_card {o : Ordinal.{u}} (f : Iio o → Ordinal.{max u v}) :
-    (⨆ a : Iio o, f a).card ≤ Cardinal.sum fun i : o.toType ↦ (f i.get).card := by
+    (⨆ a : Iio o, f a).card ≤ Cardinal.sum fun i : o.toType ↦ (f i.toOrd).card := by
   apply le_of_eq_of_le (congr_arg _ _).symm (card_iSup_le_sum_card _)
   simpa using toType.mk.symm.iSup_comp (g := fun x ↦ f x)
 

--- a/Mathlib/SetTheory/Cardinal/Ordinal.lean
+++ b/Mathlib/SetTheory/Cardinal/Ordinal.lean
@@ -33,7 +33,7 @@ lemma mk_iUnion_Ordinal_lift_le_of_le {β : Type v} {o : Ordinal.{u}} {c : Cardi
   rw [mk_toType]
   refine mul_le_mul' ho (ciSup_le' ?_)
   intro i
-  simpa using hA _ (toType.get i).2
+  simpa using hA _ i.get.prop
 
 lemma mk_iUnion_Ordinal_le_of_le {β : Type*} {o : Ordinal} {c : Cardinal}
     (ho : o.card ≤ c) (hc : ℵ₀ ≤ c) (A : Ordinal → Set β)
@@ -51,8 +51,8 @@ theorem lift_card_iSup_le_sum_card {ι : Type u} [Small.{v} ι] (f : ι → Ordi
     Cardinal.lift.{u} (⨆ i, f i).card ≤ Cardinal.sum fun i ↦ (f i).card := by
   simp_rw [← mk_toType]
   rw [← mk_sigma, ← Cardinal.lift_id'.{v} #(Σ _, _), ← Cardinal.lift_umax.{v, u}]
-  apply lift_mk_le_lift_mk_of_surjective (f := toType.mk ∘ (⟨toType.mk.symm ·.2,
-    (mem_Iio.mp (toType.mk.symm _).2).trans_le (Ordinal.le_iSup _ _)⟩))
+  apply lift_mk_le_lift_mk_of_surjective (f := .mk ∘ (⟨·.2.get,
+    (mem_Iio.mp (toType.get _).2).trans_le (Ordinal.le_iSup _ _)⟩))
   rw [EquivLike.comp_surjective]
   rintro ⟨x, hx⟩
   obtain ⟨i, hi⟩ := Ordinal.lt_iSup_iff.mp hx
@@ -64,7 +64,7 @@ theorem card_iSup_le_sum_card {ι : Type u} (f : ι → Ordinal.{max u v}) :
   rwa [Cardinal.lift_id'] at this
 
 theorem card_iSup_Iio_le_sum_card {o : Ordinal.{u}} (f : Iio o → Ordinal.{max u v}) :
-    (⨆ a : Iio o, f a).card ≤ Cardinal.sum fun i ↦ (f (toType.mk.symm i)).card := by
+    (⨆ a : Iio o, f a).card ≤ Cardinal.sum fun i : o.toType ↦ (f i.get).card := by
   apply le_of_eq_of_le (congr_arg _ _).symm (card_iSup_le_sum_card _)
   simpa using toType.mk.symm.iSup_comp (g := fun x ↦ f x)
 

--- a/Mathlib/SetTheory/Cardinal/Ordinal.lean
+++ b/Mathlib/SetTheory/Cardinal/Ordinal.lean
@@ -27,13 +27,13 @@ namespace Cardinal
 lemma mk_iUnion_Ordinal_lift_le_of_le {β : Type v} {o : Ordinal.{u}} {c : Cardinal.{v}}
     (ho : lift.{v} o.card ≤ lift.{u} c) (hc : ℵ₀ ≤ c) (A : Ordinal → Set β)
     (hA : ∀ j < o, #(A j) ≤ c) : #(⋃ j < o, A j) ≤ c := by
-  simp_rw [← mem_Iio, biUnion_eq_iUnion, iUnion, iSup, ← o.enumIsoToType.symm.surjective.range_comp]
+  simp_rw [← mem_Iio, biUnion_eq_iUnion, iUnion, iSup, ← toType.mk.symm.surjective.range_comp]
   rw [← lift_le.{u}]
   apply ((mk_iUnion_le_lift _).trans _).trans_eq (mul_eq_self (aleph0_le_lift.2 hc))
   rw [mk_toType]
   refine mul_le_mul' ho (ciSup_le' ?_)
   intro i
-  simpa using hA _ (o.enumIsoToType.symm i).2
+  simpa using hA _ (toType.get i).2
 
 lemma mk_iUnion_Ordinal_le_of_le {β : Type*} {o : Ordinal} {c : Cardinal}
     (ho : o.card ≤ c) (hc : ℵ₀ ≤ c) (A : Ordinal → Set β)
@@ -51,12 +51,12 @@ theorem lift_card_iSup_le_sum_card {ι : Type u} [Small.{v} ι] (f : ι → Ordi
     Cardinal.lift.{u} (⨆ i, f i).card ≤ Cardinal.sum fun i ↦ (f i).card := by
   simp_rw [← mk_toType]
   rw [← mk_sigma, ← Cardinal.lift_id'.{v} #(Σ _, _), ← Cardinal.lift_umax.{v, u}]
-  apply lift_mk_le_lift_mk_of_surjective (f := enumIsoToType _ ∘ (⟨(enumIsoToType _).symm ·.2,
-    (mem_Iio.mp ((enumIsoToType _).symm _).2).trans_le (Ordinal.le_iSup _ _)⟩))
+  apply lift_mk_le_lift_mk_of_surjective (f := toType.mk ∘ (⟨toType.mk.symm ·.2,
+    (mem_Iio.mp (toType.mk.symm _).2).trans_le (Ordinal.le_iSup _ _)⟩))
   rw [EquivLike.comp_surjective]
   rintro ⟨x, hx⟩
   obtain ⟨i, hi⟩ := Ordinal.lt_iSup_iff.mp hx
-  exact ⟨⟨i, enumIsoToType _ ⟨x, hi⟩⟩, by simp⟩
+  exact ⟨⟨i, .mk ⟨x, hi⟩⟩, by simp⟩
 
 theorem card_iSup_le_sum_card {ι : Type u} (f : ι → Ordinal.{max u v}) :
     (⨆ i, f i).card ≤ Cardinal.sum (fun i ↦ (f i).card) := by
@@ -64,16 +64,16 @@ theorem card_iSup_le_sum_card {ι : Type u} (f : ι → Ordinal.{max u v}) :
   rwa [Cardinal.lift_id'] at this
 
 theorem card_iSup_Iio_le_sum_card {o : Ordinal.{u}} (f : Iio o → Ordinal.{max u v}) :
-    (⨆ a : Iio o, f a).card ≤ Cardinal.sum fun i ↦ (f ((enumIsoToType o).symm i)).card := by
+    (⨆ a : Iio o, f a).card ≤ Cardinal.sum fun i ↦ (f (toType.mk.symm i)).card := by
   apply le_of_eq_of_le (congr_arg _ _).symm (card_iSup_le_sum_card _)
-  simpa using (enumIsoToType o).symm.iSup_comp (g := fun x ↦ f x)
+  simpa using toType.mk.symm.iSup_comp (g := fun x ↦ f x)
 
 theorem card_iSup_Iio_le_card_mul_iSup {o : Ordinal.{u}} (f : Iio o → Ordinal.{max u v}) :
     (⨆ a : Iio o, f a).card ≤ Cardinal.lift.{v} o.card * ⨆ a : Iio o, (f a).card := by
   apply (card_iSup_Iio_le_sum_card f).trans
   convert ← sum_le_lift_mk_mul_iSup _
   · exact mk_toType o
-  · exact (enumIsoToType o).symm.iSup_comp (g := fun x ↦ (f x).card)
+  · exact toType.mk.symm.iSup_comp (g := fun x ↦ (f x).card)
 
 theorem card_opow_le_of_omega0_le_left {a : Ordinal} (ha : ω ≤ a) (b : Ordinal) :
     (a ^ b).card ≤ max a.card b.card := by

--- a/Mathlib/SetTheory/Game/Nim.lean
+++ b/Mathlib/SetTheory/Game/Nim.lean
@@ -56,7 +56,7 @@ noncomputable def nim (o : Ordinal.{u}) : PGame.{u} :=
     fun x => nim x,
     fun x => nim x⟩
 termination_by o
-decreasing_by all_goals exact x.get.prop
+decreasing_by all_goals exact x.toOrd.prop
 
 theorem leftMoves_nim (o : Ordinal) : (nim o).LeftMoves = o.toType := by rw [nim]; rfl
 theorem rightMoves_nim (o : Ordinal) : (nim o).RightMoves = o.toType := by rw [nim]; rfl
@@ -167,7 +167,7 @@ def nimOneRelabelling : nim 1 ≡r star := by
   rw [nim]
   refine ⟨?_, ?_, fun i => ?_, fun j => ?_⟩
   any_goals dsimp; apply Equiv.ofUnique
-  all_goals simpa [toType.get, toType.mk] using nimZeroRelabelling
+  all_goals simpa [toType.toOrd, toType.mk] using nimZeroRelabelling
 
 theorem nim_one_equiv : nim 1 ≈ star :=
   nimOneRelabelling.equiv

--- a/Mathlib/SetTheory/Game/Nim.lean
+++ b/Mathlib/SetTheory/Game/Nim.lean
@@ -167,7 +167,7 @@ def nimOneRelabelling : nim 1 ≡r star := by
   rw [nim]
   refine ⟨?_, ?_, fun i => ?_, fun j => ?_⟩
   any_goals dsimp; apply Equiv.ofUnique
-  all_goals simpa [enumIsoToType] using nimZeroRelabelling
+  all_goals simpa [toType.mk] using nimZeroRelabelling
 
 theorem nim_one_equiv : nim 1 ≈ star :=
   nimOneRelabelling.equiv

--- a/Mathlib/SetTheory/Game/Nim.lean
+++ b/Mathlib/SetTheory/Game/Nim.lean
@@ -53,31 +53,31 @@ namespace PGame
   take a positive number of stones from it on their turn. -/
 noncomputable def nim (o : Ordinal.{u}) : PGame.{u} :=
   ⟨o.toType, o.toType,
-    fun x => nim ((enumIsoToType o).symm x).val,
-    fun x => nim ((enumIsoToType o).symm x).val⟩
+    fun x => nim x,
+    fun x => nim x⟩
 termination_by o
-decreasing_by all_goals exact ((enumIsoToType o).symm x).prop
+decreasing_by all_goals exact (toType.mk.symm x).prop
 
 theorem leftMoves_nim (o : Ordinal) : (nim o).LeftMoves = o.toType := by rw [nim]; rfl
 theorem rightMoves_nim (o : Ordinal) : (nim o).RightMoves = o.toType := by rw [nim]; rfl
 
 theorem moveLeft_nim_heq (o : Ordinal) :
-    (nim o).moveLeft ≍ fun i : o.toType => nim ((enumIsoToType o).symm i) := by rw [nim]; rfl
+    (nim o).moveLeft ≍ fun i : o.toType => nim i := by rw [nim]; rfl
 
 @[deprecated (since := "2025-07-05")] alias moveLeft_nim_hEq := moveLeft_nim_heq
 
 theorem moveRight_nim_heq (o : Ordinal) :
-    (nim o).moveRight ≍ fun i : o.toType => nim ((enumIsoToType o).symm i) := by rw [nim]; rfl
+    (nim o).moveRight ≍ fun i : o.toType => nim i := by rw [nim]; rfl
 
 @[deprecated (since := "2025-07-05")] alias moveRight_nim_hEq := moveRight_nim_heq
 
 /-- Turns an ordinal less than `o` into a left move for `nim o` and vice versa. -/
 noncomputable def toLeftMovesNim {o : Ordinal} : Set.Iio o ≃ (nim o).LeftMoves :=
-  (enumIsoToType o).toEquiv.trans (Equiv.cast (leftMoves_nim o).symm)
+  toType.mk.toEquiv.trans (Equiv.cast (leftMoves_nim o).symm)
 
 /-- Turns an ordinal less than `o` into a right move for `nim o` and vice versa. -/
 noncomputable def toRightMovesNim {o : Ordinal} : Set.Iio o ≃ (nim o).RightMoves :=
-  (enumIsoToType o).toEquiv.trans (Equiv.cast (rightMoves_nim o).symm)
+  toType.mk.toEquiv.trans (Equiv.cast (rightMoves_nim o).symm)
 
 @[simp]
 theorem toLeftMovesNim_symm_lt {o : Ordinal} (i : (nim o).LeftMoves) :
@@ -167,7 +167,7 @@ def nimOneRelabelling : nim 1 ≡r star := by
   rw [nim]
   refine ⟨?_, ?_, fun i => ?_, fun j => ?_⟩
   any_goals dsimp; apply Equiv.ofUnique
-  all_goals simpa [toType.mk] using nimZeroRelabelling
+  all_goals simpa [toType.mk, toType.get] using nimZeroRelabelling
 
 theorem nim_one_equiv : nim 1 ≈ star :=
   nimOneRelabelling.equiv

--- a/Mathlib/SetTheory/Game/Nim.lean
+++ b/Mathlib/SetTheory/Game/Nim.lean
@@ -56,7 +56,7 @@ noncomputable def nim (o : Ordinal.{u}) : PGame.{u} :=
     fun x => nim x,
     fun x => nim x⟩
 termination_by o
-decreasing_by all_goals exact (toType.mk.symm x).prop
+decreasing_by all_goals exact x.get.prop
 
 theorem leftMoves_nim (o : Ordinal) : (nim o).LeftMoves = o.toType := by rw [nim]; rfl
 theorem rightMoves_nim (o : Ordinal) : (nim o).RightMoves = o.toType := by rw [nim]; rfl
@@ -167,7 +167,7 @@ def nimOneRelabelling : nim 1 ≡r star := by
   rw [nim]
   refine ⟨?_, ?_, fun i => ?_, fun j => ?_⟩
   any_goals dsimp; apply Equiv.ofUnique
-  all_goals simpa [toType.mk, toType.get] using nimZeroRelabelling
+  all_goals simpa [toType.get, toType.mk] using nimZeroRelabelling
 
 theorem nim_one_equiv : nim 1 ≈ star :=
   nimOneRelabelling.equiv

--- a/Mathlib/SetTheory/Game/Ordinal.lean
+++ b/Mathlib/SetTheory/Game/Ordinal.lean
@@ -40,9 +40,9 @@ namespace Ordinal
 
 /-- Converts an ordinal into the corresponding pre-game. -/
 noncomputable def toPGame (o : Ordinal.{u}) : PGame.{u} :=
-  ⟨o.toType, PEmpty, fun x => ((enumIsoToType o).symm x).val.toPGame, PEmpty.elim⟩
+  ⟨o.toType, PEmpty, fun x => toPGame x, PEmpty.elim⟩
 termination_by o
-decreasing_by exact ((enumIsoToType o).symm x).prop
+decreasing_by exact (toType.mk.symm x).prop
 
 @[simp]
 theorem toPGame_leftMoves (o : Ordinal) : o.toPGame.LeftMoves = o.toType := by

--- a/Mathlib/SetTheory/Game/Ordinal.lean
+++ b/Mathlib/SetTheory/Game/Ordinal.lean
@@ -42,7 +42,7 @@ namespace Ordinal
 noncomputable def toPGame (o : Ordinal.{u}) : PGame.{u} :=
   ⟨o.toType, PEmpty, fun x => toPGame x, PEmpty.elim⟩
 termination_by o
-decreasing_by exact x.get.prop
+decreasing_by exact x.toOrd.prop
 
 @[simp]
 theorem toPGame_leftMoves (o : Ordinal) : o.toPGame.LeftMoves = o.toType := by

--- a/Mathlib/SetTheory/Game/Ordinal.lean
+++ b/Mathlib/SetTheory/Game/Ordinal.lean
@@ -42,7 +42,7 @@ namespace Ordinal
 noncomputable def toPGame (o : Ordinal.{u}) : PGame.{u} :=
   ⟨o.toType, PEmpty, fun x => toPGame x, PEmpty.elim⟩
 termination_by o
-decreasing_by exact (toType.mk.symm x).prop
+decreasing_by exact x.get.prop
 
 @[simp]
 theorem toPGame_leftMoves (o : Ordinal) : o.toPGame.LeftMoves = o.toType := by
@@ -61,7 +61,7 @@ instance isEmpty_toPGame_rightMoves (o : Ordinal) : IsEmpty o.toPGame.RightMoves
 /-- Converts an ordinal less than `o` into a move for the `PGame` corresponding to `o`, and vice
 versa. -/
 noncomputable def toLeftMovesToPGame {o : Ordinal} : Set.Iio o ≃ o.toPGame.LeftMoves :=
-  (enumIsoToType o).toEquiv.trans (Equiv.cast (toPGame_leftMoves o).symm)
+  toType.mk.toEquiv.trans (Equiv.cast (toPGame_leftMoves o).symm)
 
 @[simp]
 theorem toLeftMovesToPGame_symm_lt {o : Ordinal} (i : o.toPGame.LeftMoves) :
@@ -70,7 +70,7 @@ theorem toLeftMovesToPGame_symm_lt {o : Ordinal} (i : o.toPGame.LeftMoves) :
 
 @[nolint unusedHavesSuffices]
 theorem toPGame_moveLeft_hEq {o : Ordinal} :
-    o.toPGame.moveLeft ≍ fun x : o.toType => ((enumIsoToType o).symm x).val.toPGame := by
+    o.toPGame.moveLeft ≍ fun x : o.toType => toPGame x := by
   rw [toPGame]
   rfl
 

--- a/Mathlib/SetTheory/Nimber/Field.lean
+++ b/Mathlib/SetTheory/Nimber/Field.lean
@@ -275,14 +275,14 @@ theorem invSet_recOn {p : Nimber → Prop} (a : Nimber) (h0 : p 0)
 private def List.toNimber {a : Nimber} : List a.toOrdinal.toType → Nimber
   | [] => 0
   | x :: l =>
-    let a' := ∗((Ordinal.enumIsoToType a.toOrdinal).symm x)
+    let a' := ∗(x)
     invAux a' * (1 + (a + a') * toNimber l)
 
 instance (a : Nimber.{u}) : Small.{u} (invSet a) := by
   refine @small_subset.{u, u + 1} _ _ _ ?_ (small_range (@List.toNimber a))
   refine fun x hx ↦ invSet_recOn a ⟨[], rfl⟩ ?_ x hx
   rintro a' ha _ _ ⟨l, rfl⟩
-  use Ordinal.enumIsoToType _ ⟨toOrdinal a', ha⟩ :: l
+  use .mk ⟨toOrdinal a', ha⟩ :: l
   rw [List.toNimber]
   simp
 

--- a/Mathlib/SetTheory/Ordinal/Basic.lean
+++ b/Mathlib/SetTheory/Ordinal/Basic.lean
@@ -518,10 +518,10 @@ noncomputable
 abbrev toType.toOrd {o : Ordinal} (α : o.toType) : Set.Iio o := toType.mk.symm α
 
 noncomputable
-instance (o : Ordinal) : Coe (Ordinal.toType o) (Set.Iio o) where
+instance (o : Ordinal) : Coe o.toType (Set.Iio o) where
   coe := toType.toOrd
 noncomputable
-instance (o : Ordinal) : CoeOut (Ordinal.toType o) Ordinal where
+instance (o : Ordinal) : CoeOut o.toType Ordinal where
   coe x := x.toOrd
 
 @[deprecated (since := "2025-12-04")] alias enumIsoToType := toType.mk

--- a/Mathlib/SetTheory/Ordinal/Basic.lean
+++ b/Mathlib/SetTheory/Ordinal/Basic.lean
@@ -108,7 +108,13 @@ def Ordinal : Type (u + 1) :=
 /-- A "canonical" type order-isomorphic to the ordinal `o`, living in the same universe. This is
 defined through the axiom of choice.
 
-Use this over `Iio o` only when it is paramount to have a `Type u` rather than a `Type (u + 1)`. -/
+Use this over `Iio o` only when it is paramount to have a `Type u` rather than a `Type (u + 1)`,
+and convert using
+```
+Ordinal.toType.mk : Iio o → o.toType
+Ordinal.toType.toOrd : o.toType → Iio o
+```
+-/
 def Ordinal.toType (o : Ordinal.{u}) : Type u :=
   o.out.α
 

--- a/Mathlib/SetTheory/Ordinal/Basic.lean
+++ b/Mathlib/SetTheory/Ordinal/Basic.lean
@@ -513,6 +513,7 @@ noncomputable def toType.mk {o : Ordinal} : Set.Iio o ≃o o.toType where
   right_inv _ := enum_typein _ _
   map_rel_iff' := enum_le_enum' _
 
+/-- Convert an element of `α.toType` to the corresponding `Ordinal` -/
 noncomputable
 abbrev toType.get {o : Ordinal} (α : o.toType) : Set.Iio o := toType.mk.symm α
 
@@ -523,12 +524,10 @@ noncomputable
 instance (o : Ordinal) : CoeOut (Ordinal.toType o) Ordinal where
   coe x := x.get
 
- -- TODO: replace in Mathlib & add deprecation warning
-noncomputable
-abbrev enumIsoToType (o : Ordinal) : Set.Iio o ≃o o.toType := toType.mk
+@[deprecated (since := "2025-12-04")] alias enumIsoToType := toType.mk
 
 instance small_Iio (o : Ordinal.{u}) : Small.{u} (Iio o) :=
-  ⟨_, ⟨(enumIsoToType _).toEquiv⟩⟩
+  ⟨_, ⟨toType.mk.toEquiv⟩⟩
 
 instance small_Iic (o : Ordinal.{u}) : Small.{u} (Iic o) := by
   rw [← Iio_union_right]
@@ -926,7 +925,7 @@ theorem one_toType_eq (x : toType 1) : x = enum (· < ·) ⟨0, by simp⟩ :=
 
 /-! ### Extra properties of typein and enum -/
 
--- TODO: use `enumIsoToType` for lemmas on `toType` rather than `enum` and `typein`.
+-- TODO: use `toType.mk` for lemmas on `toType` rather than `enum` and `typein`.
 
 @[simp]
 theorem typein_one_toType (x : toType 1) : typein (α := toType 1) (· < ·) x = 0 := by

--- a/Mathlib/SetTheory/Ordinal/Basic.lean
+++ b/Mathlib/SetTheory/Ordinal/Basic.lean
@@ -515,14 +515,14 @@ noncomputable def toType.mk {o : Ordinal} : Set.Iio o ≃o o.toType where
 
 /-- Convert an element of `α.toType` to the corresponding `Ordinal` -/
 noncomputable
-abbrev toType.get {o : Ordinal} (α : o.toType) : Set.Iio o := toType.mk.symm α
+abbrev toType.toOrd {o : Ordinal} (α : o.toType) : Set.Iio o := toType.mk.symm α
 
 noncomputable
 instance (o : Ordinal) : Coe (Ordinal.toType o) (Set.Iio o) where
-  coe := toType.get
+  coe := toType.toOrd
 noncomputable
 instance (o : Ordinal) : CoeOut (Ordinal.toType o) Ordinal where
-  coe x := x.get
+  coe x := x.toOrd
 
 @[deprecated (since := "2025-12-04")] alias enumIsoToType := toType.mk
 

--- a/Mathlib/SetTheory/Ordinal/Basic.lean
+++ b/Mathlib/SetTheory/Ordinal/Basic.lean
@@ -110,6 +110,7 @@ defined through the axiom of choice.
 
 Use this over `Iio o` only when it is paramount to have a `Type u` rather than a `Type (u + 1)`,
 and convert using
+
 ```
 Ordinal.toType.mk : Iio o → o.toType
 Ordinal.toType.toOrd : o.toType → Iio o
@@ -512,25 +513,22 @@ theorem relIso_enum {α β : Type u} {r : α → α → Prop} {s : β → β →
 
 /-- The order isomorphism between ordinals less than `o` and `o.toType`. -/
 @[simps! -isSimp]
-noncomputable def toType.mk {o : Ordinal} : Set.Iio o ≃o o.toType where
+def toType.mk {o : Ordinal} : Set.Iio o ≃o o.toType where
   toFun x := enum (α := o.toType) (· < ·) ⟨x.1, type_toType _ ▸ x.2⟩
   invFun x := ⟨typein (α := o.toType) (· < ·) x, typein_lt_self x⟩
   left_inv _ := Subtype.ext (typein_enum _ _)
   right_inv _ := enum_typein _ _
   map_rel_iff' := enum_le_enum' _
 
+@[deprecated (since := "2025-12-04")] noncomputable alias enumIsoToType := toType.mk
+
 /-- Convert an element of `α.toType` to the corresponding `Ordinal` -/
-noncomputable
 abbrev toType.toOrd {o : Ordinal} (α : o.toType) : Set.Iio o := toType.mk.symm α
 
-noncomputable
 instance (o : Ordinal) : Coe o.toType (Set.Iio o) where
   coe := toType.toOrd
-noncomputable
 instance (o : Ordinal) : CoeOut o.toType Ordinal where
   coe x := x.toOrd
-
-@[deprecated (since := "2025-12-04")] alias enumIsoToType := toType.mk
 
 instance small_Iio (o : Ordinal.{u}) : Small.{u} (Iio o) :=
   ⟨_, ⟨toType.mk.toEquiv⟩⟩

--- a/Mathlib/SetTheory/Ordinal/Basic.lean
+++ b/Mathlib/SetTheory/Ordinal/Basic.lean
@@ -506,26 +506,26 @@ theorem relIso_enum {α β : Type u} {r : α → α → Prop} {s : β → β →
 
 /-- The order isomorphism between ordinals less than `o` and `o.toType`. -/
 @[simps! -isSimp]
-noncomputable def toType.mk {α : Ordinal} : Set.Iio α ≃o α.toType where
-  toFun x := enum (α := α.toType) (· < ·) ⟨x.1, type_toType _ ▸ x.2⟩
-  invFun x := ⟨typein (α := α.toType) (· < ·) x, typein_lt_self x⟩
+noncomputable def toType.mk {o : Ordinal} : Set.Iio o ≃o o.toType where
+  toFun x := enum (α := o.toType) (· < ·) ⟨x.1, type_toType _ ▸ x.2⟩
+  invFun x := ⟨typein (α := o.toType) (· < ·) x, typein_lt_self x⟩
   left_inv _ := Subtype.ext (typein_enum _ _)
   right_inv _ := enum_typein _ _
   map_rel_iff' := enum_le_enum' _
 
 noncomputable
-abbrev toType.get {α : Ordinal} (β : α.toType) : Set.Iio α := toType.mk.symm β
+abbrev toType.get {o : Ordinal} (α : o.toType) : Set.Iio o := toType.mk.symm α
 
 noncomputable
-instance (α : Ordinal) : Coe (Ordinal.toType α) (Set.Iio α) where
+instance (o : Ordinal) : Coe (Ordinal.toType o) (Set.Iio o) where
   coe := toType.get
 noncomputable
-instance (α : Ordinal) : CoeOut (Ordinal.toType α) Ordinal where
+instance (o : Ordinal) : CoeOut (Ordinal.toType o) Ordinal where
   coe x := x.get
 
  -- TODO: replace in Mathlib & add deprecation warning
 noncomputable
-abbrev enumIsoToType (α : Ordinal) : Set.Iio α ≃o α.toType := toType.mk
+abbrev enumIsoToType (o : Ordinal) : Set.Iio o ≃o o.toType := toType.mk
 
 instance small_Iio (o : Ordinal.{u}) : Small.{u} (Iio o) :=
   ⟨_, ⟨(enumIsoToType _).toEquiv⟩⟩

--- a/Mathlib/SetTheory/Ordinal/Basic.lean
+++ b/Mathlib/SetTheory/Ordinal/Basic.lean
@@ -506,12 +506,26 @@ theorem relIso_enum {α β : Type u} {r : α → α → Prop} {s : β → β →
 
 /-- The order isomorphism between ordinals less than `o` and `o.toType`. -/
 @[simps! -isSimp]
-noncomputable def enumIsoToType (o : Ordinal) : Set.Iio o ≃o o.toType where
-  toFun x := enum (α := o.toType) (· < ·) ⟨x.1, type_toType _ ▸ x.2⟩
-  invFun x := ⟨typein (α := o.toType) (· < ·) x, typein_lt_self x⟩
+noncomputable def toType.mk {α : Ordinal} : Set.Iio α ≃o α.toType where
+  toFun x := enum (α := α.toType) (· < ·) ⟨x.1, type_toType _ ▸ x.2⟩
+  invFun x := ⟨typein (α := α.toType) (· < ·) x, typein_lt_self x⟩
   left_inv _ := Subtype.ext (typein_enum _ _)
   right_inv _ := enum_typein _ _
   map_rel_iff' := enum_le_enum' _
+
+noncomputable
+abbrev toType.get {α : Ordinal} (β : α.toType) : Set.Iio α := toType.mk.symm β
+
+noncomputable
+instance (α : Ordinal) : Coe (Ordinal.toType α) (Set.Iio α) where
+  coe := toType.get
+noncomputable
+instance (α : Ordinal) : CoeOut (Ordinal.toType α) Ordinal where
+  coe x := x.get
+
+ -- TODO: replace in Mathlib & add deprecation warning
+noncomputable
+abbrev enumIsoToType (α : Ordinal) : Set.Iio α ≃o α.toType := toType.mk
 
 instance small_Iio (o : Ordinal.{u}) : Small.{u} (Iio o) :=
   ⟨_, ⟨(enumIsoToType _).toEquiv⟩⟩

--- a/Mathlib/SetTheory/ZFC/Ordinal.lean
+++ b/Mathlib/SetTheory/ZFC/Ordinal.lean
@@ -279,7 +279,7 @@ The elements of `o.toPSet` are all `a.toPSet` with `a < o`. -/
 noncomputable def toPSet (o : Ordinal.{u}) : PSet.{u} :=
   ⟨o.toType, fun a ↦ toPSet a⟩
 termination_by o
-decreasing_by exact a.get.prop
+decreasing_by exact a.toOrd.prop
 
 @[simp]
 theorem type_toPSet (o : Ordinal) : o.toPSet.Type = o.toType := by

--- a/Mathlib/SetTheory/ZFC/Ordinal.lean
+++ b/Mathlib/SetTheory/ZFC/Ordinal.lean
@@ -277,9 +277,9 @@ open ZFSet
 
 The elements of `o.toPSet` are all `a.toPSet` with `a < o`. -/
 noncomputable def toPSet (o : Ordinal.{u}) : PSet.{u} :=
-  ⟨o.toType, fun a ↦ toPSet ((enumIsoToType o).symm a)⟩
+  ⟨o.toType, fun a ↦ toPSet a⟩
 termination_by o
-decreasing_by exact ((enumIsoToType o).symm a).2
+decreasing_by exact a.get.prop
 
 @[simp]
 theorem type_toPSet (o : Ordinal) : o.toPSet.Type = o.toType := by
@@ -288,13 +288,13 @@ theorem type_toPSet (o : Ordinal) : o.toPSet.Type = o.toType := by
 
 theorem mem_toPSet_iff {o : Ordinal} {x : PSet} : x ∈ o.toPSet ↔ ∃ a < o, x.Equiv a.toPSet := by
   rw [toPSet, PSet.mem_def]
-  simpa using ((enumIsoToType o).exists_congr_left (p := fun y ↦ x.Equiv y.1.toPSet)).symm
+  simpa using ((@toType.mk o).exists_congr_left (p := fun y ↦ x.Equiv y.1.toPSet)).symm
 
 @[simp]
 theorem rank_toPSet (o : Ordinal) : o.toPSet.rank = o := by
   rw [toPSet, PSet.rank]
   conv_rhs => rw [← _root_.iSup_succ o]
-  convert (enumIsoToType o).symm.iSup_comp (g := fun x ↦ Order.succ x.1.toPSet.rank)
+  convert toType.mk.symm.iSup_comp (g := fun x ↦ Order.succ x.1.toPSet.rank)
   rw [rank_toPSet]
 termination_by o
 decreasing_by rename_i x; exact x.2


### PR DESCRIPTION
Zulip thread: https://leanprover.zulipchat.com/#narrow/channel/287929-mathlib4/topic/API.20for.20Ordinal.2EtoType/with/561739587

* Adds coercion from `Ordinal.toType` to `Ordinal` & `Set.Iio o`
* Renames `Ordinal.enumIsoToType` to `Ordinal.toType.mk` with an implicit parameter, so `(.mk ⟨α, h⟩)` can be used to build a `toType`. This prepares for deprecation of the name `Ordinal.enumIsoToType` (to be discussed).
---
<!-- Your PR title will become the first line of the commit message.

In this box, the text above the `---` (if not empty) will be appended
to the commit message, and can be used to give additional context or
details. Please leave a blank newline before the `---`, otherwise GitHub
will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

When merging, all the commits will be squashed into a single commit
listing all co-authors.

Co-authors in the squash commit are gathered from two sources:

First, all authors of commits to this PR branch are included. Thus,
one way to add co-authors is to include at least one commit authored by
each co-author among the commits in the pull request. If necessary, you
may create empty commits to indicate co-authorship, using commands like so:

git commit --author="Author Name <author@email.com>" --allow-empty -m "add Author Name as coauthor"

Second, co-authors can also be listed in lines at the very bottom of
the commit message (that is, directly before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines
at the bottom of the commit message (before the `---`, and also before
any "Co-authored-by" lines) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
