### PR TITLE
[Merged by Bors] - feat(TacticAnalysis): add generic env var-based tryAtEachStep linter

### DIFF
--- a/Mathlib/Init.lean
+++ b/Mathlib/Init.lean
@@ -28,6 +28,7 @@ public import Mathlib.Tactic.MinImports
 public import Mathlib.Tactic.TacticAnalysis.Declarations
 -- This is a redundant import, but it is needed so that
 -- the linter doesn't complain about `ParseCommand` not importing `Header`.
+-- This can be removed after https://github.com/leanprover-community/mathlib4/pull/32419
 public import Mathlib.Util.ParseCommand
 
 /-!

--- a/Mathlib/Init.lean
+++ b/Mathlib/Init.lean
@@ -26,6 +26,9 @@ public import Mathlib.Tactic.Linter.Style
 -- This import makes the `#min_imports` command available globally.
 public import Mathlib.Tactic.MinImports
 public import Mathlib.Tactic.TacticAnalysis.Declarations
+-- This is a redundant import, but it is needed so that
+-- the linter doesn't complain about `ParseCommand` not importing `Header`.
+public import Mathlib.Util.ParseCommand
 
 /-!
 This is the root file in Mathlib: it is imported by virtually *all* Mathlib files.

--- a/Mathlib/Tactic/TacticAnalysis/Declarations.lean
+++ b/Mathlib/Tactic/TacticAnalysis/Declarations.lean
@@ -373,8 +373,12 @@ def Mathlib.TacticAnalysis.tryAtEachStepFromStrings
   run seq := do
     -- Parse using `tacticSeq.fn` directly since `tacticSeq` is not a parser category.
     -- See https://leanprover.zulipchat.com/#narrow/channel/113488-general/topic/piggy.20back.20off.20of.20the.20lean4.20parser
-    let tacSeq ← ofExcept <|
-      Mathlib.GuardExceptions.captureException (← getEnv) Parser.Tactic.tacticSeq.fn tacticStr
+    let tacSeq ← try
+      ofExcept <|
+        Mathlib.GuardExceptions.captureException (← getEnv) Parser.Tactic.tacticSeq.fn tacticStr
+    catch _ =>
+      -- Tactic not available (e.g., `aesop` before Aesop is imported) - skip silently
+      return
     let tac : TSyntax `tactic := ⟨mkNode ``Lean.Parser.Tactic.tacticSeq1Indented #[tacSeq]⟩
     (tryAtEachStepCore (fun _ _ => pure tac) label).run seq
 

--- a/Mathlib/Tactic/TacticAnalysis/Declarations.lean
+++ b/Mathlib/Tactic/TacticAnalysis/Declarations.lean
@@ -328,7 +328,8 @@ def Mathlib.TacticAnalysis.tryAtEachStepCore
     let fraction := linter.tacticAnalysis.tryAtEachStep.fraction.get opts
     let showTiming := linter.tacticAnalysis.tryAtEachStep.showTiming.get opts
     let selfReplacements := linter.tacticAnalysis.tryAtEachStep.selfReplacements.get opts
-    for i in seq do
+    for h : idx in [:seq.size] do
+      let i := seq[idx]
       if let [goal] := i.tacI.goalsBefore then
         if (hash goal) % fraction = 0 then
           let tac ← tac i.tacI.stx goal
@@ -345,10 +346,12 @@ def Mathlib.TacticAnalysis.tryAtEachStepCore
             -- Check if this is a self-replacement (tactic replacing itself)
             if !selfReplacements && oldTacticPP == newTacticPP then
               continue
+            let laterSteps := seq.size - 1 - idx
+            let laterMsg := if laterSteps > 0 then s!" (+{laterSteps} later steps)" else ""
             if showTiming then
-              logInfoAt i.tacI.stx m!"`{oldTacticPP}` can be replaced with `{newTacticPP}` ({elapsedMs}ms)"
+              logInfoAt i.tacI.stx m!"`{oldTacticPP}`{laterMsg} can be replaced with `{newTacticPP}` ({elapsedMs}ms)"
             else
-              logInfoAt i.tacI.stx m!"`{oldTacticPP}` can be replaced with `{newTacticPP}`"
+              logInfoAt i.tacI.stx m!"`{oldTacticPP}`{laterMsg} can be replaced with `{newTacticPP}`"
 
 /-- Run a tactic at each proof step. See `tryAtEachStepCore` for details. -/
 def Mathlib.TacticAnalysis.tryAtEachStep

--- a/Mathlib/Tactic/TacticAnalysis/Declarations.lean
+++ b/Mathlib/Tactic/TacticAnalysis/Declarations.lean
@@ -291,7 +291,6 @@ register_option linter.tacticAnalysis.tryAtEachStep.fraction : Nat := {
 /-- Run a tactic at each proof step, with timing.
 
 Reports elapsed time in milliseconds for each successful replacement.
-To limit tactic runtime, use `set_option maxHeartbeats N` in the build command.
 -/
 def Mathlib.TacticAnalysis.tryAtEachStep (tac : Syntax → MVarId → CommandElabM (TSyntax `tactic)) : TacticAnalysis.Config where
   run seq := do

--- a/Mathlib/Util/ParseCommand.lean
+++ b/Mathlib/Util/ParseCommand.lean
@@ -6,7 +6,6 @@ Authors: Matthew Robert Ballard, Damiano Testa
 module
 
 public meta import Lean.Elab.Command
-public import Mathlib.Init
 
 /-!
 # `#parse` -- a command to parse text and log outputs

--- a/Mathlib/Util/ParseCommand.lean
+++ b/Mathlib/Util/ParseCommand.lean
@@ -6,6 +6,9 @@ Authors: Matthew Robert Ballard, Damiano Testa
 module
 
 public meta import Lean.Elab.Command
+-- Import this linter explicitly to ensure that
+-- this file has a valid copyright header and module docstring.
+public meta import Mathlib.Tactic.Linter.Header
 
 /-!
 # `#parse` -- a command to parse text and log outputs

--- a/MathlibTest/TacticAnalysis.lean
+++ b/MathlibTest/TacticAnalysis.lean
@@ -213,6 +213,9 @@ end introMerge
 
 section tryAtEachStep
 
+-- Disable timing in tests to avoid non-deterministic output
+set_option linter.tacticAnalysis.tryAtEachStep.showTiming false
+
 section
 set_option linter.tacticAnalysis.tryAtEachStepGrind true
 

--- a/MathlibTest/TacticAnalysis.lean
+++ b/MathlibTest/TacticAnalysis.lean
@@ -346,3 +346,23 @@ example : x = y := by
   rfl
 
 end grindReplacement
+
+section unknownTactic
+
+-- Test that tryAtEachStepFromStrings gracefully handles unknown tactics
+-- (e.g., trying to run `aesop` before Aesop is imported)
+
+register_option linter.tacticAnalysis.unknownTacticTest : Bool := {
+  defValue := false
+}
+
+@[tacticAnalysis linter.tacticAnalysis.unknownTacticTest]
+def unknownTacticTest :=
+  Mathlib.TacticAnalysis.tryAtEachStepFromStrings "nonexistent" "nonexistent_tactic_xyz"
+
+-- This should not crash - the unknown tactic should be silently skipped
+set_option linter.tacticAnalysis.unknownTacticTest true in
+#guard_msgs in
+example : 1 + 1 = 2 := by rfl
+
+end unknownTactic

--- a/MathlibTest/TacticAnalysis.lean
+++ b/MathlibTest/TacticAnalysis.lean
@@ -281,6 +281,35 @@ end
 
 end tryAtEachStep
 
+section selfReplacements
+
+set_option linter.tacticAnalysis.tryAtEachStep.showTiming false
+set_option linter.tacticAnalysis.tryAtEachStepGrind true
+
+-- With selfReplacements true (default), grind replacing grind is reported
+/-- info: `grind` can be replaced with `grind` -/
+#guard_msgs in
+example : 1 + 1 = 2 := by
+  grind
+
+section
+set_option linter.tacticAnalysis.tryAtEachStep.selfReplacements false
+
+-- With selfReplacements false, grind replacing grind is NOT reported
+#guard_msgs in
+example : 1 + 1 = 2 := by
+  grind
+
+-- Non-self replacements are still reported when selfReplacements is false
+/-- info: `rfl` can be replaced with `grind` -/
+#guard_msgs in
+example : 1 + 1 = 2 := by
+  rfl
+
+end
+
+end selfReplacements
+
 section grindReplacement
 
 set_option linter.tacticAnalysis.regressions.omegaToCutsat true

--- a/MathlibTest/TacticAnalysis.lean
+++ b/MathlibTest/TacticAnalysis.lean
@@ -225,7 +225,7 @@ example : 1 + 1 = 2 := by
   rfl
 
 /--
-info: `skip` can be replaced with `grind`
+info: `skip` (+1 later steps) can be replaced with `grind`
 ---
 info: `rfl` can be replaced with `grind`
 ---
@@ -309,6 +309,31 @@ example : 1 + 1 = 2 := by
 end
 
 end selfReplacements
+
+section laterSteps
+
+set_option linter.tacticAnalysis.tryAtEachStep.showTiming false
+set_option linter.tacticAnalysis.tryAtEachStepGrind true
+set_option linter.unusedTactic false
+
+-- Test that later steps are counted correctly
+/--
+info: `skip` (+3 later steps) can be replaced with `grind`
+---
+info: `skip` (+2 later steps) can be replaced with `grind`
+---
+info: `skip` (+1 later steps) can be replaced with `grind`
+---
+info: `rfl` can be replaced with `grind`
+-/
+#guard_msgs in
+example : 1 + 1 = 2 := by
+  skip
+  skip
+  skip
+  rfl
+
+end laterSteps
 
 section grindReplacement
 

--- a/MathlibTest/tryAtEachStep.lean
+++ b/MathlibTest/tryAtEachStep.lean
@@ -1,6 +1,8 @@
 import Mathlib.Tactic.Common
 import Mathlib.Tactic.TacticAnalysis.Declarations
 
+-- Disable timing in tests to avoid non-deterministic output
+set_option linter.tacticAnalysis.tryAtEachStep.showTiming false
 set_option linter.tacticAnalysis.tryAtEachStepAesop true
 
 /-- info: `rfl` can be replaced with `aesop` -/

--- a/scripts/lint-style.lean
+++ b/scripts/lint-style.lean
@@ -142,8 +142,6 @@ def missingInitImports (opts : LinterOptions) : IO Nat := do
   let missing := modulesWithoutMathlibImports.erase `Mathlib.Tactic.Linter.Header
     -- This file is imported by `Mathlib/Tactic/Linter/Header.lean`.
     |>.erase `Mathlib.Tactic.Linter.DirectoryDependency
-    -- This file only imports `Lean.Elab.Command` to avoid import cycles.
-    |>.erase `Mathlib.Util.ParseCommand
   if missing.size > 0 then
     IO.eprintln s!"error: the following {missing.size} module(s) do not import Mathlib.Init: \
       {missing}"

--- a/scripts/lint-style.lean
+++ b/scripts/lint-style.lean
@@ -142,6 +142,8 @@ def missingInitImports (opts : LinterOptions) : IO Nat := do
   let missing := modulesWithoutMathlibImports.erase `Mathlib.Tactic.Linter.Header
     -- This file is imported by `Mathlib/Tactic/Linter/Header.lean`.
     |>.erase `Mathlib.Tactic.Linter.DirectoryDependency
+    -- This file only imports `Lean.Elab.Command` to avoid import cycles.
+    |>.erase `Mathlib.Util.ParseCommand
   if missing.size > 0 then
     IO.eprintln s!"error: the following {missing.size} module(s) do not import Mathlib.Init: \
       {missing}"


### PR DESCRIPTION
## Summary

Adds a generic `tryAtEachStepFromEnv` tactic analysis linter that reads the tactic to try from environment variables. This allows hammer-bench and similar tools to test arbitrary tactics without requiring Mathlib code changes.

- `TRY_AT_EACH_STEP_TACTIC`: The tactic syntax to try (e.g., "grind +suggestions")
- `TRY_AT_EACH_STEP_LABEL`: Human-readable label for output (optional)

Uses `captureException` with `tacticSeq.fn` to parse tactic strings, following Kenny Lau's suggestion from [Zulip](https://leanprover.zulipchat.com/#narrow/channel/113488-general/topic/piggy.20back.20off.20of.20the.20lean4.20parser). This enables support for tactic sequences like "simp; grind".

Also removes the unnecessary `Mathlib.Init` import from `ParseCommand.lean` to avoid import cycles.

🤖 Prepared with Claude Code