### PR TITLE
[Merged by Bors] - fix(scripts/lint-style): improve Mathlib.Init import error messages

### DIFF
--- a/lake-manifest.json
+++ b/lake-manifest.json
@@ -25,7 +25,7 @@
    "type": "git",
    "subDir": null,
    "scope": "leanprover-community",
-   "rev": "6e3bb4bf31f731ab28891fe229eb347ec7d5dad3",
+   "rev": "55071afabe2966180b96a6a01f7fdc6661bf7bb4",
    "name": "importGraph",
    "manifestFile": "lake-manifest.json",
    "inputRev": "main",


### PR DESCRIPTION
Improve the `checkInitImports` linter by:
1. Accepting transitive imports (not just direct) for the `Mathlib.Init` check
2. Removing hardcoded exceptions for transitively imported files
3. Making error messages actionable with specific advice

### Two cases with different advice

1. **Transitively imported by `Mathlib.Init`** → add `import Mathlib.Tactic.Linter.Header`
2. **NOT imported by `Mathlib.Init`** → add `import Mathlib.Init`

### Example output

**Case 1: Transitively imported by Init**
```
  • `Mathlib.Util.SomeFile` is transitively imported by `Mathlib.Init`.
    Please add `import Mathlib.Tactic.Linter.Header` to `Mathlib.Util.SomeFile`.
```

**Case 2: Not imported by Init**
```
  • `Mathlib.Util.TestFile` is NOT imported by `Mathlib.Init`.
    Please add `import Mathlib.Init` to `Mathlib.Util.TestFile`.
```

Prompted by confusion when working on https://github.com/leanprover-community/mathlib4/pull/32416 - the old error message just said files didn't import `Mathlib.Init` without explaining what to do when adding that import would create a cycle.

Discussion: https://leanprover.zulipchat.com/#narrow/channel/287929-mathlib4/topic/Mathlib.2EInit.20linter.20error

🤖 Prepared with Claude Code