### PR TITLE
[Merged by Bors] - chore: disable the flexible linter

### DIFF
--- a/Mathlib/Init.lean
+++ b/Mathlib/Init.lean
@@ -68,7 +68,6 @@ all these linters, or add the `weak.linter.mathlibStandardSet` option to their l
 register_linter_set linter.mathlibStandardSet :=
   -- linter.allScriptsDocumented -- disabled, let's not impose this requirement downstream.
   -- linter.checkInitImports -- disabled, not relevant downstream.
-  linter.flexible
   linter.hashCommand
   linter.oldObtain
   linter.privateModule

--- a/lakefile.lean
+++ b/lakefile.lean
@@ -34,6 +34,8 @@ abbrev mathlibOnlyLinters : Array LeanOption := #[
   ⟨`linter.allScriptsDocumented, true⟩,
   ⟨`linter.pythonStyle, true⟩,
   ⟨`linter.style.longFile, .ofNat 1500⟩,
+  -- Explicitly disable the flexible linter, as it gives non-actionable warnings.
+  ⟨`linter.flexible, false⟩,
   -- ⟨`linter.nightlyRegressionSet, true⟩,
   -- `latest_import.yml` uses this comment: if you edit it, make sure that the workflow still works
 ]


### PR DESCRIPTION
- Remove `linter.flexible` from the standard linter set in `Mathlib/Init.lean`
- Explicitly disable the flexible linter in `lakefile.lean` with a comment explaining why

The flexible linter gives non-actionable warnings and is not yet ready for use in Mathlib. This change disables it by default while keeping it available for downstream projects that may want to enable it explicitly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)