### PR TITLE
[Merged by Bors] - feat(Linter/FlexibleLinter): add actionable fix suggestion to warning

### DIFF
--- a/Mathlib/Tactic/Linter/FlexibleLinter.lean
+++ b/Mathlib/Tactic/Linter/FlexibleLinter.lean
@@ -457,13 +457,23 @@ def flexibleLinter : Linter where run := withSetOptionIn fun _stx => do
       stains := new
 
   for (s, stainStx, d) in msgs do
-    let (tac, tacOnly) := if stainStx.getKind == ``Lean.Parser.Tactic.simpAll
-      then ("simp_all?", "simp_all only [...]")
-      else ("simp?", "simp only [...]")
-    Linter.logLint linter.flexible stainStx
-      m!"'{stainStx}' is a flexible tactic modifying '{d}'. \
-        Try '{tac}' and use the suggested '{tacOnly}'."
-    logInfoAt s m!"… and '{s}' uses '{d}'!"
+    let stainStr := (stainStx.reprint.getD s!"{stainStx}").trim
+    let msg := match stainStx.getKind with
+      | ``Lean.Parser.Tactic.simp =>
+        m!"'{stainStr}' is a flexible tactic modifying '{d}'. \
+          Try 'simp?' and use the suggested 'simp only [...]'. \
+          Alternatively, use `suffices` to explicitly state the simplified form."
+      | ``Lean.Parser.Tactic.simpAll =>
+        m!"'{stainStr}' is a flexible tactic modifying '{d}'. \
+          Try 'simp_all?' and use the suggested 'simp_all only [...]'. \
+          Alternatively, use `suffices` to explicitly state the simplified form."
+      | `Aesop.Frontend.Parser.aesopTactic =>
+        m!"'{stainStr}' is a flexible tactic modifying '{d}'. \
+          Try 'aesop?' and use the suggested proof."
+      | _ =>
+        m!"'{stainStr}' is a flexible tactic modifying '{d}'."
+    Linter.logLint linter.flexible stainStx msg
+    logInfoAt s m!"'{s}' uses '{d}'!"
 
 initialize addLinter flexibleLinter
 

--- a/Mathlib/Tactic/Linter/FlexibleLinter.lean
+++ b/Mathlib/Tactic/Linter/FlexibleLinter.lean
@@ -457,7 +457,12 @@ def flexibleLinter : Linter where run := withSetOptionIn fun _stx => do
       stains := new
 
   for (s, stainStx, d) in msgs do
-    Linter.logLint linter.flexible stainStx m!"'{stainStx}' is a flexible tactic modifying '{d}'…"
+    let (tac, tacOnly) := if stainStx.getKind == ``Lean.Parser.Tactic.simpAll
+      then ("simp_all?", "simp_all only [...]")
+      else ("simp?", "simp only [...]")
+    Linter.logLint linter.flexible stainStx
+      m!"'{stainStx}' is a flexible tactic modifying '{d}'. \
+        Try '{tac}' and use the suggested '{tacOnly}'."
     logInfoAt s m!"… and '{s}' uses '{d}'!"
 
 initialize addLinter flexibleLinter

--- a/MathlibTest/FlexibleLinter.lean
+++ b/MathlibTest/FlexibleLinter.lean
@@ -15,11 +15,11 @@ tests for these can be found in `MathlibTest/ImportHeavyFlexibleLinter.lean`
 -/
 
 /--
-warning: 'simp at h' is a flexible tactic modifying 'h'. Try 'simp?' and use the suggested 'simp only [...]'.
+warning: 'simp at h' is a flexible tactic modifying 'h'. Try 'simp?' and use the suggested 'simp only [...]'. Alternatively, use `suffices` to explicitly state the simplified form.
 
 Note: This linter can be disabled with `set_option linter.flexible false`
 ---
-info: … and 'exact h' uses 'h'!
+info: 'exact h' uses 'h'!
 -/
 #guard_msgs in
 example (h : 0 + 0 = 0) : True := by
@@ -27,11 +27,11 @@ example (h : 0 + 0 = 0) : True := by
   try exact h
 
 /--
-warning: 'simp_all' is a flexible tactic modifying '⊢'. Try 'simp_all?' and use the suggested 'simp_all only [...]'.
+warning: 'simp_all' is a flexible tactic modifying '⊢'. Try 'simp_all?' and use the suggested 'simp_all only [...]'. Alternatively, use `suffices` to explicitly state the simplified form.
 
 Note: This linter can be disabled with `set_option linter.flexible false`
 ---
-info: … and 'exact Nat.le_succ_of_le h' uses '⊢'!
+info: 'exact Nat.le_succ_of_le h' uses '⊢'!
 -/
 #guard_msgs in
 example {a b : Nat} (h : a ≤ b) : a + 0 ≤ b + 1 := by
@@ -55,17 +55,17 @@ example {a b : Nat} (h : a = b) : a + 0 = b := by
 
 -- `induction` does not use the goal
 /--
-warning: 'simp' is a flexible tactic modifying '⊢'. Try 'simp?' and use the suggested 'simp only [...]'.
+warning: 'simp' is a flexible tactic modifying '⊢'. Try 'simp?' and use the suggested 'simp only [...]'. Alternatively, use `suffices` to explicitly state the simplified form.
 
 Note: This linter can be disabled with `set_option linter.flexible false`
 ---
-info: … and 'assumption' uses '⊢'!
+info: 'assumption' uses '⊢'!
 ---
-warning: 'simp' is a flexible tactic modifying '⊢'. Try 'simp?' and use the suggested 'simp only [...]'.
+warning: 'simp' is a flexible tactic modifying '⊢'. Try 'simp?' and use the suggested 'simp only [...]'. Alternatively, use `suffices` to explicitly state the simplified form.
 
 Note: This linter can be disabled with `set_option linter.flexible false`
 ---
-info: … and 'assumption' uses '⊢'!
+info: 'assumption' uses '⊢'!
 -/
 #guard_msgs in
 example {a b : Nat} (h : a = b) : a + 0 = b := by
@@ -74,11 +74,11 @@ example {a b : Nat} (h : a = b) : a + 0 = b := by
 
 
 /--
-warning: 'simp at h' is a flexible tactic modifying 'h'. Try 'simp?' and use the suggested 'simp only [...]'.
+warning: 'simp at h' is a flexible tactic modifying 'h'. Try 'simp?' and use the suggested 'simp only [...]'. Alternatively, use `suffices` to explicitly state the simplified form.
 
 Note: This linter can be disabled with `set_option linter.flexible false`
 ---
-info: … and 'exact h' uses 'h'!
+info: 'exact h' uses 'h'!
 -/
 #guard_msgs in
 example (h : 0 = 0 ∨ 0 = 0) : True := by
@@ -89,17 +89,17 @@ example (h : 0 = 0 ∨ 0 = 0) : True := by
   · assumption --exact h
 
 /--
-warning: 'simp' is a flexible tactic modifying '⊢'. Try 'simp?' and use the suggested 'simp only [...]'.
+warning: 'simp' is a flexible tactic modifying '⊢'. Try 'simp?' and use the suggested 'simp only [...]'. Alternatively, use `suffices` to explicitly state the simplified form.
 
 Note: This linter can be disabled with `set_option linter.flexible false`
 ---
-info: … and 'on_goal 2 => · contradiction' uses '⊢'!
+info: 'on_goal 2 => · contradiction' uses '⊢'!
 ---
-warning: 'simp' is a flexible tactic modifying '⊢'. Try 'simp?' and use the suggested 'simp only [...]'.
+warning: 'simp' is a flexible tactic modifying '⊢'. Try 'simp?' and use the suggested 'simp only [...]'. Alternatively, use `suffices` to explicitly state the simplified form.
 
 Note: This linter can be disabled with `set_option linter.flexible false`
 ---
-info: … and 'contradiction' uses '⊢'!
+info: 'contradiction' uses '⊢'!
 -/
 #guard_msgs in
 example (h : 0 = 1 ∨ 0 = 1) : 0 = 1 ∧ 0 = 1 := by
@@ -112,17 +112,17 @@ example (h : 0 = 1 ∨ 0 = 1) : 0 = 1 ∧ 0 = 1 := by
 example {a : Nat} : a + 1 + 0 = 1 + a := by simp; all_goals omega
 
 /--
-warning: 'simp' is a flexible tactic modifying '⊢'. Try 'simp?' and use the suggested 'simp only [...]'.
+warning: 'simp' is a flexible tactic modifying '⊢'. Try 'simp?' and use the suggested 'simp only [...]'. Alternatively, use `suffices` to explicitly state the simplified form.
 
 Note: This linter can be disabled with `set_option linter.flexible false`
 ---
-info: … and 'contradiction' uses '⊢'!
+info: 'contradiction' uses '⊢'!
 ---
-warning: 'simp' is a flexible tactic modifying '⊢'. Try 'simp?' and use the suggested 'simp only [...]'.
+warning: 'simp' is a flexible tactic modifying '⊢'. Try 'simp?' and use the suggested 'simp only [...]'. Alternatively, use `suffices` to explicitly state the simplified form.
 
 Note: This linter can be disabled with `set_option linter.flexible false`
 ---
-info: … and 'contradiction' uses '⊢'!
+info: 'contradiction' uses '⊢'!
 -/
 #guard_msgs in
 example (h : 0 = 1 ∨ 0 = 1) : 0 = 1 ∧ 0 = 1 := by
@@ -131,17 +131,17 @@ example (h : 0 = 1 ∨ 0 = 1) : 0 = 1 ∧ 0 = 1 := by
   · contradiction
 
 /--
-warning: 'simp at h k' is a flexible tactic modifying 'k'. Try 'simp?' and use the suggested 'simp only [...]'.
+warning: 'simp at h k' is a flexible tactic modifying 'k'. Try 'simp?' and use the suggested 'simp only [...]'. Alternatively, use `suffices` to explicitly state the simplified form.
 
 Note: This linter can be disabled with `set_option linter.flexible false`
 ---
-info: … and 'rw [← Classical.not_not (a := True)] at k' uses 'k'!
+info: 'rw [← Classical.not_not (a := True)] at k' uses 'k'!
 ---
-warning: 'simp at h k' is a flexible tactic modifying 'h'. Try 'simp?' and use the suggested 'simp only [...]'.
+warning: 'simp at h k' is a flexible tactic modifying 'h'. Try 'simp?' and use the suggested 'simp only [...]'. Alternatively, use `suffices` to explicitly state the simplified form.
 
 Note: This linter can be disabled with `set_option linter.flexible false`
 ---
-info: … and 'rw [← Classical.not_not (a := True)] at h' uses 'h'!
+info: 'rw [← Classical.not_not (a := True)] at h' uses 'h'!
 -/
 #guard_msgs in
 -- `simp at h` stains `h` but not other locations
@@ -161,11 +161,11 @@ example {a b : Nat} (h : ∀ c, c + a + b = a + c) : (0 + 2 + 1 + a + b) = a + 3
   simp_all
 
 /--
-warning: 'simp' is a flexible tactic modifying '⊢'. Try 'simp?' and use the suggested 'simp only [...]'.
+warning: 'simp' is a flexible tactic modifying '⊢'. Try 'simp?' and use the suggested 'simp only [...]'. Alternatively, use `suffices` to explicitly state the simplified form.
 
 Note: This linter can be disabled with `set_option linter.flexible false`
 ---
-info: … and 'exact h.symm' uses '⊢'!
+info: 'exact h.symm' uses '⊢'!
 -/
 #guard_msgs in
 -- `congr` is allowed after `simp`, but "passes along the stain".
@@ -205,11 +205,11 @@ example {x y : Nat} : 0 + x + (y + x) = x + x + y := by
   cutsat
 
 /--
-warning: 'simp' is a flexible tactic modifying '⊢'. Try 'simp?' and use the suggested 'simp only [...]'.
+warning: 'simp' is a flexible tactic modifying '⊢'. Try 'simp?' and use the suggested 'simp only [...]'. Alternatively, use `suffices` to explicitly state the simplified form.
 
 Note: This linter can be disabled with `set_option linter.flexible false`
 ---
-info: … and 'contradiction' uses '⊢'!
+info: 'contradiction' uses '⊢'!
 -/
 #guard_msgs in
 example (h : 0 = 1 ∨ 0 = 1) : 0 = 1 ∧ 0 = 1 := by
@@ -231,11 +231,11 @@ example (n : Nat) : n + 1 = 1 + n := by
     exact Nat.add_comm ..
 
 /--
-warning: 'simp at h' is a flexible tactic modifying 'h'. Try 'simp?' and use the suggested 'simp only [...]'.
+warning: 'simp at h' is a flexible tactic modifying 'h'. Try 'simp?' and use the suggested 'simp only [...]'. Alternatively, use `suffices` to explicitly state the simplified form.
 
 Note: This linter can be disabled with `set_option linter.flexible false`
 ---
-info: … and 'rw [← Classical.not_not (a := True)] at h' uses 'h'!
+info: 'rw [← Classical.not_not (a := True)] at h' uses 'h'!
 -/
 #guard_msgs in
 -- `simp at h` stains `h` but not other locations
@@ -248,17 +248,17 @@ example {h : 0 = 0} {k : 1 = 1} : ¬ ¬ True := by
   assumption
 
 /--
-warning: 'simp at h k' is a flexible tactic modifying 'k'. Try 'simp?' and use the suggested 'simp only [...]'.
+warning: 'simp at h k' is a flexible tactic modifying 'k'. Try 'simp?' and use the suggested 'simp only [...]'. Alternatively, use `suffices` to explicitly state the simplified form.
 
 Note: This linter can be disabled with `set_option linter.flexible false`
 ---
-info: … and 'rw [← Classical.not_not (a := True)] at k' uses 'k'!
+info: 'rw [← Classical.not_not (a := True)] at k' uses 'k'!
 ---
-warning: 'simp at h k' is a flexible tactic modifying 'h'. Try 'simp?' and use the suggested 'simp only [...]'.
+warning: 'simp at h k' is a flexible tactic modifying 'h'. Try 'simp?' and use the suggested 'simp only [...]'. Alternatively, use `suffices` to explicitly state the simplified form.
 
 Note: This linter can be disabled with `set_option linter.flexible false`
 ---
-info: … and 'rw [← Classical.not_not (a := True)] at h' uses 'h'!
+info: 'rw [← Classical.not_not (a := True)] at h' uses 'h'!
 -/
 #guard_msgs in
 -- `simp at h` stains `h` but not other locations
@@ -271,11 +271,11 @@ example {h : 0 = 0} {k : 1 = 1} : True := by
   assumption
 
 /--
-warning: 'simp at h' is a flexible tactic modifying 'h'. Try 'simp?' and use the suggested 'simp only [...]'.
+warning: 'simp at h' is a flexible tactic modifying 'h'. Try 'simp?' and use the suggested 'simp only [...]'. Alternatively, use `suffices` to explicitly state the simplified form.
 
 Note: This linter can be disabled with `set_option linter.flexible false`
 ---
-info: … and 'rw [← Classical.not_not (a := True)] at h' uses 'h'!
+info: 'rw [← Classical.not_not (a := True)] at h' uses 'h'!
 -/
 #guard_msgs in
 -- `simp at h` stains `h` but not other locations
@@ -287,11 +287,11 @@ example {h : 0 = 0} : True := by
   assumption
 
 /--
-warning: 'simp' is a flexible tactic modifying '⊢'. Try 'simp?' and use the suggested 'simp only [...]'.
+warning: 'simp' is a flexible tactic modifying '⊢'. Try 'simp?' and use the suggested 'simp only [...]'. Alternatively, use `suffices` to explicitly state the simplified form.
 
 Note: This linter can be disabled with `set_option linter.flexible false`
 ---
-info: … and 'rwa [← Classical.not_not (a := False)]' uses '⊢'!
+info: 'rwa [← Classical.not_not (a := False)]' uses '⊢'!
 -/
 #guard_msgs in
 example {h : False} : 0 = 1 := by
@@ -301,11 +301,11 @@ example {h : False} : 0 = 1 := by
   rwa [← Classical.not_not (a := False)]
 
 /--
-warning: 'simp' is a flexible tactic modifying '⊢'. Try 'simp?' and use the suggested 'simp only [...]'.
+warning: 'simp' is a flexible tactic modifying '⊢'. Try 'simp?' and use the suggested 'simp only [...]'. Alternatively, use `suffices` to explicitly state the simplified form.
 
 Note: This linter can be disabled with `set_option linter.flexible false`
 ---
-info: … and 'rwa [← Classical.not_not (a := False)]' uses '⊢'!
+info: 'rwa [← Classical.not_not (a := False)]' uses '⊢'!
 -/
 #guard_msgs in
 example {h : False} : 0 = 1 ∧ 0 = 1 := by

--- a/MathlibTest/FlexibleLinter.lean
+++ b/MathlibTest/FlexibleLinter.lean
@@ -15,7 +15,7 @@ tests for these can be found in `MathlibTest/ImportHeavyFlexibleLinter.lean`
 -/
 
 /--
-warning: 'simp at h' is a flexible tactic modifying 'h'…
+warning: 'simp at h' is a flexible tactic modifying 'h'. Try 'simp?' and use the suggested 'simp only [...]'.
 
 Note: This linter can be disabled with `set_option linter.flexible false`
 ---
@@ -25,6 +25,18 @@ info: … and 'exact h' uses 'h'!
 example (h : 0 + 0 = 0) : True := by
   simp at h
   try exact h
+
+/--
+warning: 'simp_all' is a flexible tactic modifying '⊢'. Try 'simp_all?' and use the suggested 'simp_all only [...]'.
+
+Note: This linter can be disabled with `set_option linter.flexible false`
+---
+info: … and 'exact Nat.le_succ_of_le h' uses '⊢'!
+-/
+#guard_msgs in
+example {a b : Nat} (h : a ≤ b) : a + 0 ≤ b + 1 := by
+  simp_all
+  exact Nat.le_succ_of_le h
 
 -- `subst` does not use the goal
 #guard_msgs in
@@ -43,13 +55,13 @@ example {a b : Nat} (h : a = b) : a + 0 = b := by
 
 -- `induction` does not use the goal
 /--
-warning: 'simp' is a flexible tactic modifying '⊢'…
+warning: 'simp' is a flexible tactic modifying '⊢'. Try 'simp?' and use the suggested 'simp only [...]'.
 
 Note: This linter can be disabled with `set_option linter.flexible false`
 ---
 info: … and 'assumption' uses '⊢'!
 ---
-warning: 'simp' is a flexible tactic modifying '⊢'…
+warning: 'simp' is a flexible tactic modifying '⊢'. Try 'simp?' and use the suggested 'simp only [...]'.
 
 Note: This linter can be disabled with `set_option linter.flexible false`
 ---
@@ -62,7 +74,7 @@ example {a b : Nat} (h : a = b) : a + 0 = b := by
 
 
 /--
-warning: 'simp at h' is a flexible tactic modifying 'h'…
+warning: 'simp at h' is a flexible tactic modifying 'h'. Try 'simp?' and use the suggested 'simp only [...]'.
 
 Note: This linter can be disabled with `set_option linter.flexible false`
 ---
@@ -77,13 +89,13 @@ example (h : 0 = 0 ∨ 0 = 0) : True := by
   · assumption --exact h
 
 /--
-warning: 'simp' is a flexible tactic modifying '⊢'…
+warning: 'simp' is a flexible tactic modifying '⊢'. Try 'simp?' and use the suggested 'simp only [...]'.
 
 Note: This linter can be disabled with `set_option linter.flexible false`
 ---
 info: … and 'on_goal 2 => · contradiction' uses '⊢'!
 ---
-warning: 'simp' is a flexible tactic modifying '⊢'…
+warning: 'simp' is a flexible tactic modifying '⊢'. Try 'simp?' and use the suggested 'simp only [...]'.
 
 Note: This linter can be disabled with `set_option linter.flexible false`
 ---
@@ -100,13 +112,13 @@ example (h : 0 = 1 ∨ 0 = 1) : 0 = 1 ∧ 0 = 1 := by
 example {a : Nat} : a + 1 + 0 = 1 + a := by simp; all_goals omega
 
 /--
-warning: 'simp' is a flexible tactic modifying '⊢'…
+warning: 'simp' is a flexible tactic modifying '⊢'. Try 'simp?' and use the suggested 'simp only [...]'.
 
 Note: This linter can be disabled with `set_option linter.flexible false`
 ---
 info: … and 'contradiction' uses '⊢'!
 ---
-warning: 'simp' is a flexible tactic modifying '⊢'…
+warning: 'simp' is a flexible tactic modifying '⊢'. Try 'simp?' and use the suggested 'simp only [...]'.
 
 Note: This linter can be disabled with `set_option linter.flexible false`
 ---
@@ -119,13 +131,13 @@ example (h : 0 = 1 ∨ 0 = 1) : 0 = 1 ∧ 0 = 1 := by
   · contradiction
 
 /--
-warning: 'simp at h k' is a flexible tactic modifying 'k'…
+warning: 'simp at h k' is a flexible tactic modifying 'k'. Try 'simp?' and use the suggested 'simp only [...]'.
 
 Note: This linter can be disabled with `set_option linter.flexible false`
 ---
 info: … and 'rw [← Classical.not_not (a := True)] at k' uses 'k'!
 ---
-warning: 'simp at h k' is a flexible tactic modifying 'h'…
+warning: 'simp at h k' is a flexible tactic modifying 'h'. Try 'simp?' and use the suggested 'simp only [...]'.
 
 Note: This linter can be disabled with `set_option linter.flexible false`
 ---
@@ -149,7 +161,7 @@ example {a b : Nat} (h : ∀ c, c + a + b = a + c) : (0 + 2 + 1 + a + b) = a + 3
   simp_all
 
 /--
-warning: 'simp' is a flexible tactic modifying '⊢'…
+warning: 'simp' is a flexible tactic modifying '⊢'. Try 'simp?' and use the suggested 'simp only [...]'.
 
 Note: This linter can be disabled with `set_option linter.flexible false`
 ---
@@ -193,7 +205,7 @@ example {x y : Nat} : 0 + x + (y + x) = x + x + y := by
   cutsat
 
 /--
-warning: 'simp' is a flexible tactic modifying '⊢'…
+warning: 'simp' is a flexible tactic modifying '⊢'. Try 'simp?' and use the suggested 'simp only [...]'.
 
 Note: This linter can be disabled with `set_option linter.flexible false`
 ---
@@ -219,7 +231,7 @@ example (n : Nat) : n + 1 = 1 + n := by
     exact Nat.add_comm ..
 
 /--
-warning: 'simp at h' is a flexible tactic modifying 'h'…
+warning: 'simp at h' is a flexible tactic modifying 'h'. Try 'simp?' and use the suggested 'simp only [...]'.
 
 Note: This linter can be disabled with `set_option linter.flexible false`
 ---
@@ -236,13 +248,13 @@ example {h : 0 = 0} {k : 1 = 1} : ¬ ¬ True := by
   assumption
 
 /--
-warning: 'simp at h k' is a flexible tactic modifying 'k'…
+warning: 'simp at h k' is a flexible tactic modifying 'k'. Try 'simp?' and use the suggested 'simp only [...]'.
 
 Note: This linter can be disabled with `set_option linter.flexible false`
 ---
 info: … and 'rw [← Classical.not_not (a := True)] at k' uses 'k'!
 ---
-warning: 'simp at h k' is a flexible tactic modifying 'h'…
+warning: 'simp at h k' is a flexible tactic modifying 'h'. Try 'simp?' and use the suggested 'simp only [...]'.
 
 Note: This linter can be disabled with `set_option linter.flexible false`
 ---
@@ -259,7 +271,7 @@ example {h : 0 = 0} {k : 1 = 1} : True := by
   assumption
 
 /--
-warning: 'simp at h' is a flexible tactic modifying 'h'…
+warning: 'simp at h' is a flexible tactic modifying 'h'. Try 'simp?' and use the suggested 'simp only [...]'.
 
 Note: This linter can be disabled with `set_option linter.flexible false`
 ---
@@ -275,7 +287,7 @@ example {h : 0 = 0} : True := by
   assumption
 
 /--
-warning: 'simp' is a flexible tactic modifying '⊢'…
+warning: 'simp' is a flexible tactic modifying '⊢'. Try 'simp?' and use the suggested 'simp only [...]'.
 
 Note: This linter can be disabled with `set_option linter.flexible false`
 ---
@@ -289,7 +301,7 @@ example {h : False} : 0 = 1 := by
   rwa [← Classical.not_not (a := False)]
 
 /--
-warning: 'simp' is a flexible tactic modifying '⊢'…
+warning: 'simp' is a flexible tactic modifying '⊢'. Try 'simp?' and use the suggested 'simp only [...]'.
 
 Note: This linter can be disabled with `set_option linter.flexible false`
 ---

--- a/MathlibTest/ImportHeavyFlexibleLinter.lean
+++ b/MathlibTest/ImportHeavyFlexibleLinter.lean
@@ -39,11 +39,11 @@ example : (0 + 2 : Rat) + 1 = 3 := by
 /-! ## further flexible tactics -/
 
 /--
-warning: 'simp' is a flexible tactic modifying '⊢'. Try 'simp?' and use the suggested 'simp only [...]'.
+warning: 'simp' is a flexible tactic modifying '⊢'. Try 'simp?' and use the suggested 'simp only [...]'. Alternatively, use `suffices` to explicitly state the simplified form.
 
 Note: This linter can be disabled with `set_option linter.flexible false`
 ---
-info: … and 'rw [add_comm]' uses '⊢'!
+info: 'rw [add_comm]' uses '⊢'!
 
 -/
 #guard_msgs in
@@ -72,11 +72,11 @@ example (h : False) : False ∧ True := by
 -- Currently, `positivity` is not marked as flexible (as it only applies to goals in a very
 -- particular shape). We use this test to record the current behaviour.
 /--
-warning: 'simp' is a flexible tactic modifying '⊢'. Try 'simp?' and use the suggested 'simp only [...]'.
+warning: 'simp' is a flexible tactic modifying '⊢'. Try 'simp?' and use the suggested 'simp only [...]'. Alternatively, use `suffices` to explicitly state the simplified form.
 
 Note: This linter can be disabled with `set_option linter.flexible false`
 ---
-info: … and 'positivity' uses '⊢'!
+info: 'positivity' uses '⊢'!
 -/
 #guard_msgs in
 example {k l : ℤ} : 0 ≤ k ^ 2 + 4 * l * 0 := by
@@ -112,11 +112,11 @@ example {X : Type*} [TopologicalSpace X] {f : X → ℕ} {g : ℕ → X}
 -- shape of the goal, and e.g. changing the goal to a defeq one could break the proof).
 -- This test documents this behaviour.
 /--
-warning: 'simp' is a flexible tactic modifying '⊢'. Try 'simp?' and use the suggested 'simp only [...]'.
+warning: 'simp' is a flexible tactic modifying '⊢'. Try 'simp?' and use the suggested 'simp only [...]'. Alternatively, use `suffices` to explicitly state the simplified form.
 
 Note: This linter can be disabled with `set_option linter.flexible false`
 ---
-info: … and 'fun_prop' uses '⊢'!
+info: 'fun_prop' uses '⊢'!
 -/
 #guard_msgs in
 example {X : Type*} [TopologicalSpace X] {f : X → ℕ} {g : ℕ → X}

--- a/MathlibTest/ImportHeavyFlexibleLinter.lean
+++ b/MathlibTest/ImportHeavyFlexibleLinter.lean
@@ -39,7 +39,7 @@ example : (0 + 2 : Rat) + 1 = 3 := by
 /-! ## further flexible tactics -/
 
 /--
-warning: 'simp' is a flexible tactic modifying '⊢'…
+warning: 'simp' is a flexible tactic modifying '⊢'. Try 'simp?' and use the suggested 'simp only [...]'.
 
 Note: This linter can be disabled with `set_option linter.flexible false`
 ---
@@ -72,7 +72,7 @@ example (h : False) : False ∧ True := by
 -- Currently, `positivity` is not marked as flexible (as it only applies to goals in a very
 -- particular shape). We use this test to record the current behaviour.
 /--
-warning: 'simp' is a flexible tactic modifying '⊢'…
+warning: 'simp' is a flexible tactic modifying '⊢'. Try 'simp?' and use the suggested 'simp only [...]'.
 
 Note: This linter can be disabled with `set_option linter.flexible false`
 ---
@@ -112,7 +112,7 @@ example {X : Type*} [TopologicalSpace X] {f : X → ℕ} {g : ℕ → X}
 -- shape of the goal, and e.g. changing the goal to a defeq one could break the proof).
 -- This test documents this behaviour.
 /--
-warning: 'simp' is a flexible tactic modifying '⊢'…
+warning: 'simp' is a flexible tactic modifying '⊢'. Try 'simp?' and use the suggested 'simp only [...]'.
 
 Note: This linter can be disabled with `set_option linter.flexible false`
 ---


### PR DESCRIPTION
## Summary

The flexible linter warning now includes actionable guidance on how to fix the issue:

- For `simp`: "Try 'simp?' and use the suggested 'simp only [...]'."
- For `simp_all`: "Try 'simp_all?' and use the suggested 'simp_all only [...]'."

This addresses [user feedback on Zulip](https://leanprover.zulipchat.com/#narrow/channel/113488-general/topic/advice.20on.20fixing.20.22simp.20at.20.2E.2E.2E.22.20is.20a.20flexible.20tactic.20modifyin/near/561806999) that the warning was non-actionable, leading to the linter being disabled in #32420.

**Before:**
```
'simp at h' is a flexible tactic modifying 'h'…
```

**After:**
```
'simp at h' is a flexible tactic modifying 'h'. Try 'simp?' and use the suggested 'simp only [...]'.
```

🤖 Prepared with Claude Code