### PR TITLE
feat: `unusedFactInType` linter

### DIFF
--- a/Mathlib/Init.lean
+++ b/Mathlib/Init.lean
@@ -91,6 +91,7 @@ register_linter_set linter.mathlibStandardSet :=
   linter.style.show
   linter.style.maxHeartbeats
   linter.unusedDecidableInType
+  linter.unusedFactInType
   -- The `docPrime` linter is disabled: https://github.com/leanprover-community/mathlib4/issues/20560
 
 /-- Define a set of linters that are used in the `nightly-testing` branch

--- a/Mathlib/Tactic/Linter/UnusedInstancesInType.lean
+++ b/Mathlib/Tactic/Linter/UnusedInstancesInType.lean
@@ -272,8 +272,13 @@ def unusedFactInType : Linter where
       fun _ thm unusedParams => do
         logLint linter.unusedFactInType (← getRef) m!"\
           {thm.name.unusedInstancesMsg unusedParams}\n\n\
-          Consider removing \
-          {if unusedParams.size = 1 then "this hypothesis" else "these hypotheses"}."
+          Consider replacing \
+          {
+          if unusedParams.size = 1 then
+            "this hypothesis with an ordinary, non-{.ofConstName `Fact} version of the assumption."
+          else
+            "these hypotheses with ordinary, non-{.ofConstName `Fact} versions of the assumptions."
+          }"
 
 initialize addLinter unusedFactInType
 

--- a/Mathlib/Tactic/Linter/UnusedInstancesInType.lean
+++ b/Mathlib/Tactic/Linter/UnusedInstancesInType.lean
@@ -233,4 +233,49 @@ initialize addLinter unusedDecidableInType
 
 end Decidable
 
+section Fact
+
+/--
+The `unusedFactInType` linter checks if a theorem's hypotheses include `Fact` instances
+which are not used in the remainder of the type. If so, it suggests removing the instances.
+
+This linter fires only on theorems. (This includes `lemma`s and `instance`s of `Prop` classes.)
+
+Note: `set_option linter.unusedFactInType _ in <command>` currently only works at the
+outermost level of a command due to working around [lean4#11313](https://github.com/leanprover/lean4/pull/11313).
+-/
+public register_option linter.unusedFactInType : Bool := {
+  defValue := false
+  descr := "enable the unused `Fact` instance linter, which lints against `Fact` \
+    instances in the hypotheses of theorems which are not used in the type, and can therefore be \
+    removed."
+}
+
+/-- Detects `Decidable*` instance hypotheses in the types of theorems which are not used in the
+remainder of the type, and suggests replacing them with a use of `classical` in the proof or
+`open scoped Classical in` at the term level. -/
+def unusedFactInType : Linter where
+  run := /- withSetOptionIn -/ fun cmd => do
+    /- `withSetOptionIn` currently breaks infotree searches, so do a cheap outermost check
+    until this is fixed in [lean4#11313](https://github.com/leanprover/lean4/pull/11313) -/
+    let mut override := false
+    if let `(command| set_option $opt:ident $val in $_:command) := cmd then
+      if opt.getId == `linter.unusedFactInType then
+        match val.raw with
+        | Syntax.atom _ "true" => override := true
+        | Syntax.atom _ "false" => return -- exit early
+        | _ => pure () -- invalid option value, should be caught during elaboration
+    unless override || getLinterValue linter.unusedFactInType (← getLinterOptions) do
+      return
+    cmd.logUnusedInstancesInTheoremsWhere (·.isAppOrForallOfConst `Fact)
+      fun _ thm unusedParams => do
+        logLint linter.unusedFactInType (← getRef) m!"\
+          {thm.name.unusedInstancesMsg unusedParams}\n\n\
+          Consider removing \
+          {if unusedParams.size = 1 then "this hypothesis" else "these hypotheses"}."
+
+initialize addLinter unusedFactInType
+
+end Fact
+
 end Mathlib.Linter.UnusedInstancesInType


### PR DESCRIPTION

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

When merging, all the commits will be squashed into a single commit
listing all co-authors.

Co-authors in the squash commit are gathered from two sources:

First, all authors of commits to this PR branch are included. Thus,
one way to add co-authors is to include at least one commit authored by
each co-author among the commits in the pull request. If necessary, you
may create empty commits to indicate co-authorship, using commands like so:

git commit --author="Author Name <author@email.com>" --allow-empty -m "add Author Name as coauthor"

Second, co-authors can also be listed in lines at the very bottom of
the commit message (that is, directly before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines
at the bottom of the commit message (before the `---`, and also before
any "Co-authored-by" lines) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
