### PR TITLE
feat: `SuccOrder` and `PredOrder` instances for `SignType`

### DIFF
--- a/Mathlib.lean
+++ b/Mathlib.lean
@@ -3951,6 +3951,7 @@ public import Mathlib.Data.Sigma.Order
 public import Mathlib.Data.Sign
 public import Mathlib.Data.Sign.Basic
 public import Mathlib.Data.Sign.Defs
+public import Mathlib.Data.Sign.SuccPred
 public import Mathlib.Data.Stream.Defs
 public import Mathlib.Data.Stream.Init
 public import Mathlib.Data.String.Basic

--- a/Mathlib/Data/Sign/SuccPred.lean
+++ b/Mathlib/Data/Sign/SuccPred.lean
@@ -28,9 +28,9 @@ instance : SuccOrder SignType where
   max_of_succ_le := by unfold IsMax; decide
   succ_le_of_lt := by decide
 
-@[simp] theorem succ_neg_one : succ (-1) = 0 := rfl
-@[simp] theorem succ_zero : succ 0 = 1 := rfl
-@[simp] theorem succ_one : succ 1 = 1 := rfl
+@[simp] theorem succ_neg_one : succ (-1 : SignType) = 0 := rfl
+@[simp] theorem succ_zero : succ (0 : SignType) = 1 := rfl
+@[simp] theorem succ_one : succ (1 : SignType) = 1 := rfl
 
 -- TODO: use `to_dual`
 instance : PredOrder SignType where
@@ -41,8 +41,8 @@ instance : PredOrder SignType where
   min_of_le_pred := by unfold IsMin; decide
   le_pred_of_lt := by decide
 
-@[simp] theorem pred_neg_one : pred (-1) = -1 := rfl
-@[simp] theorem pred_zero : pred 0 = -1 := rfl
-@[simp] theorem pred_one : pred 1 = 0 := rfl
+@[simp] theorem pred_neg_one : pred (-1 : SignType) = -1 := rfl
+@[simp] theorem pred_zero : pred (0 : SignType) = -1 := rfl
+@[simp] theorem pred_one : pred (1 : SignType) = 0 := rfl
 
 end SignType

--- a/Mathlib/Data/Sign/SuccPred.lean
+++ b/Mathlib/Data/Sign/SuccPred.lean
@@ -16,6 +16,10 @@ This file defines the `SuccOrder` and `PredOrder` instances for `SignType`.
 
 @[expose] public section
 
+open Order
+
+namespace SignType
+
 instance : SuccOrder SignType where
   succ
   | -1 => 0
@@ -23,6 +27,10 @@ instance : SuccOrder SignType where
   le_succ := by decide
   max_of_succ_le := by unfold IsMax; decide
   succ_le_of_lt := by decide
+
+@[simp] theorem succ_neg_one : succ -1 = 0 := rfl
+@[simp] theorem succ_zero : succ 0 = 1 := rfl
+@[simp] theorem succ_one : succ 1 = 1 := rfl
 
 -- TODO: use `to_dual`
 instance : PredOrder SignType where
@@ -32,3 +40,9 @@ instance : PredOrder SignType where
   pred_le := by decide
   min_of_le_pred := by unfold IsMin; decide
   le_pred_of_lt := by decide
+
+@[simp] theorem pred_neg_one : pred -1 = -1 := rfl
+@[simp] theorem pred_zero : pred 0 = -1 := rfl
+@[simp] theorem pred_one : pred 1 = 0 := rfl
+
+end SignType

--- a/Mathlib/Data/Sign/SuccPred.lean
+++ b/Mathlib/Data/Sign/SuccPred.lean
@@ -1,0 +1,34 @@
+/-
+Copyright (c) 2025 Violeta Hernández Palacios. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Violeta Hernández Palacios
+-/
+module
+
+public import Mathlib.Data.Sign.Defs
+public import Mathlib.Order.SuccPred.Basic
+
+/-!
+# Successor and predecessor order instances
+
+This file defines the `SuccOrder` and `PredOrder` instances for `SignType`.
+-/
+
+@[expose] public section
+
+instance : SuccOrder SignType where
+  succ
+  | -1 => 0
+  | _ => 1
+  le_succ := by decide
+  max_of_succ_le := by unfold IsMax; decide
+  succ_le_of_lt := by decide
+
+-- TODO: use `to_dual`
+instance : PredOrder SignType where
+  pred
+  | 1 => 0
+  | _ => -1
+  pred_le := by decide
+  min_of_le_pred := by unfold IsMin; decide
+  le_pred_of_lt := by decide

--- a/Mathlib/Data/Sign/SuccPred.lean
+++ b/Mathlib/Data/Sign/SuccPred.lean
@@ -28,7 +28,7 @@ instance : SuccOrder SignType where
   max_of_succ_le := by unfold IsMax; decide
   succ_le_of_lt := by decide
 
-@[simp] theorem succ_neg_one : succ -1 = 0 := rfl
+@[simp] theorem succ_neg_one : succ (-1) = 0 := rfl
 @[simp] theorem succ_zero : succ 0 = 1 := rfl
 @[simp] theorem succ_one : succ 1 = 1 := rfl
 
@@ -41,7 +41,7 @@ instance : PredOrder SignType where
   min_of_le_pred := by unfold IsMin; decide
   le_pred_of_lt := by decide
 
-@[simp] theorem pred_neg_one : pred -1 = -1 := rfl
+@[simp] theorem pred_neg_one : pred (-1) = -1 := rfl
 @[simp] theorem pred_zero : pred 0 = -1 := rfl
 @[simp] theorem pred_one : pred 1 = 0 := rfl
 


### PR DESCRIPTION
Used in the CGT repo.

---
<!-- Your PR title will become the first line of the commit message.

In this box, the text above the `---` (if not empty) will be appended
to the commit message, and can be used to give additional context or
details. Please leave a blank newline before the `---`, otherwise GitHub
will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

When merging, all the commits will be squashed into a single commit
listing all co-authors.

Co-authors in the squash commit are gathered from two sources:

First, all authors of commits to this PR branch are included. Thus,
one way to add co-authors is to include at least one commit authored by
each co-author among the commits in the pull request. If necessary, you
may create empty commits to indicate co-authorship, using commands like so:

git commit --author="Author Name <author@email.com>" --allow-empty -m "add Author Name as coauthor"

Second, co-authors can also be listed in lines at the very bottom of
the commit message (that is, directly before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines
at the bottom of the commit message (before the `---`, and also before
any "Co-authored-by" lines) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

A future to-do might be to pull out `SuccOrder` and `PredOrder` into a `Defs` file, so that this can be defined within the `Defs` file as well.

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
