### PR TITLE
[Merged by Bors] - chore: make sure that `Nat.AtLeastTwo` instances are constructive

### DIFF
--- a/Mathlib/Data/Nat/Init.lean
+++ b/Mathlib/Data/Nat/Init.lean
@@ -464,7 +464,7 @@ use of typeclass inference for this purpose. -/
 class AtLeastTwo (n : ℕ) : Prop where
   prop : 2 ≤ n
 
--- Note: the following should stay axiom-free, since it is used whenever one uses the symbole
+-- Note: the following should stay axiom-free, since it is used whenever one writes the symbol
 -- `2` in an abstract additive monoid...
 instance (n : ℕ) [NeZero n] : (n + 1).AtLeastTwo :=
   ⟨add_le_add (one_le_iff_ne_zero.mpr (NeZero.ne n)) (Nat.le_refl 1)⟩

--- a/Mathlib/Data/Nat/Init.lean
+++ b/Mathlib/Data/Nat/Init.lean
@@ -464,6 +464,8 @@ use of typeclass inference for this purpose. -/
 class AtLeastTwo (n : ℕ) : Prop where
   prop : 2 ≤ n
 
+-- Note: the following should stay axiom-free, since it is used whenever one uses the symbole
+-- `2` in an abstract additive monoid...
 instance (n : ℕ) [NeZero n] : (n + 1).AtLeastTwo :=
   ⟨add_le_add (one_le_iff_ne_zero.mpr (NeZero.ne n)) (Nat.le_refl 1)⟩
 

--- a/Mathlib/Data/Nat/Init.lean
+++ b/Mathlib/Data/Nat/Init.lean
@@ -464,7 +464,8 @@ use of typeclass inference for this purpose. -/
 class AtLeastTwo (n : ℕ) : Prop where
   prop : 2 ≤ n
 
-instance (n : ℕ) [NeZero n] : (n + 1).AtLeastTwo := ⟨by have := NeZero.ne n; lia⟩
+instance (n : ℕ) [NeZero n] : (n + 1).AtLeastTwo :=
+  ⟨add_le_add (one_le_iff_ne_zero.mpr (NeZero.ne n)) (Nat.le_refl 1)⟩
 
 namespace AtLeastTwo
 


### PR DESCRIPTION
@riccardobrasca noticed a few weeks ago that you cannot *write* the symbol `2` in an abstract ring `R` without relying on the axiom of choice. After investigating a bit, we realized that this boiled down to the use of excluded midde (through `lia`) in [Nat.instAtLeastTwoHAddOfNat](https://leanprover-community.github.io/mathlib4_docs/Mathlib/Data/Nat/Init.html#Nat.instAtLeastTwoHAddOfNat).

While I am by no means advocating for widespread support of constructive users in Mathlib, I think this one is ridiculous enough that it needs fixing (and the fix is really easy). 

---
<!-- Your PR title will become the first line of the commit message.

In this box, the text above the `---` (if not empty) will be appended
to the commit message, and can be used to give additional context or
details. Please leave a blank newline before the `---`, otherwise GitHub
will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

When merging, all the commits will be squashed into a single commit
listing all co-authors.

Co-authors in the squash commit are gathered from two sources:

First, all authors of commits to this PR branch are included. Thus,
one way to add co-authors is to include at least one commit authored by
each co-author among the commits in the pull request. If necessary, you
may create empty commits to indicate co-authorship, using commands like so:

git commit --author="Author Name <author@email.com>" --allow-empty -m "add Author Name as coauthor"

Second, co-authors can also be listed in lines at the very bottom of
the commit message (that is, directly before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines
at the bottom of the commit message (before the `---`, and also before
any "Co-authored-by" lines) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
