### PR TITLE
[Merged by Bors] - chore: additivise `MulOpposite.op_finsuppSum` to itself

### DIFF
--- a/Mathlib/Algebra/BigOperators/Finsupp/Basic.lean
+++ b/Mathlib/Algebra/BigOperators/Finsupp/Basic.lean
@@ -629,11 +629,11 @@ alias prod_pow_pos_of_zero_not_mem_support := prod_pow_pos_of_zero_notMem_suppor
 
 end Nat
 
--- We additivise the following lemmas to themselves to avoid `to_additive` getting confused.
--- TODO(Jovan): Remove the annotations once unnecessary again.
-
 namespace MulOpposite
 variable {ι M N : Type*} [AddCommMonoid M] [Zero N]
+
+-- We additivise the following lemmas to themselves to avoid `to_additive` getting confused.
+-- TODO(Jovan): Remove the annotations once unnecessary again.
 
 @[to_additive self (dont_translate := M), simp]
 lemma op_finsuppSum (f : ι →₀ N) (g : ι → N → M) :

--- a/Mathlib/Algebra/BigOperators/Finsupp/Basic.lean
+++ b/Mathlib/Algebra/BigOperators/Finsupp/Basic.lean
@@ -629,13 +629,18 @@ alias prod_pow_pos_of_zero_not_mem_support := prod_pow_pos_of_zero_notMem_suppor
 
 end Nat
 
+-- We additivise the following lemmas to themselves to avoid `to_additive` getting confused.
+-- TODO(Jovan): Remove the annotations once unnecessary again.
+
 namespace MulOpposite
 variable {ι M N : Type*} [AddCommMonoid M] [Zero N]
 
-@[simp] lemma op_finsuppSum (f : ι →₀ N) (g : ι → N → M) :
+@[to_additive self (dont_translate := M), simp]
+lemma op_finsuppSum (f : ι →₀ N) (g : ι → N → M) :
     op (f.sum g) = f.sum fun i n ↦ op (g i n) := op_sum ..
 
-@[simp] lemma unop_finsuppSum (f : ι →₀ N) (g : ι → N → Mᵐᵒᵖ) :
+@[to_additive self (dont_translate := M), simp]
+lemma unop_finsuppSum (f : ι →₀ N) (g : ι → N → Mᵐᵒᵖ) :
     unop (f.sum g) = f.sum fun i n ↦ unop (g i n) := unop_sum ..
 
 end MulOpposite
@@ -643,10 +648,12 @@ end MulOpposite
 namespace AddOpposite
 variable {ι M N : Type*} [CommMonoid M] [Zero N]
 
-@[simp] lemma op_finsuppProd (f : ι →₀ N) (g : ι → N → M) :
+@[to_additive self (dont_translate := M), simp]
+lemma op_finsuppProd (f : ι →₀ N) (g : ι → N → M) :
     op (f.prod g) = f.prod fun i n ↦ op (g i n) := op_prod ..
 
-@[simp] lemma unop_finsuppProd (f : ι →₀ N) (g : ι → N → Mᵐᵒᵖ) :
+@[to_additive self (dont_translate := M), simp]
+lemma unop_finsuppProd (f : ι →₀ N) (g : ι → N → Mᵐᵒᵖ) :
     unop (f.prod g) = f.prod fun i n ↦ unop (g i n) := unop_prod ..
 
 end AddOpposite

--- a/Mathlib/Algebra/BigOperators/Finsupp/Basic.lean
+++ b/Mathlib/Algebra/BigOperators/Finsupp/Basic.lean
@@ -648,12 +648,10 @@ end MulOpposite
 namespace AddOpposite
 variable {ι M N : Type*} [CommMonoid M] [Zero N]
 
-@[to_additive self (dont_translate := M), simp]
-lemma op_finsuppProd (f : ι →₀ N) (g : ι → N → M) :
+@[simp] lemma op_finsuppProd (f : ι →₀ N) (g : ι → N → M) :
     op (f.prod g) = f.prod fun i n ↦ op (g i n) := op_prod ..
 
-@[to_additive self (dont_translate := M), simp]
-lemma unop_finsuppProd (f : ι →₀ N) (g : ι → N → Mᵐᵒᵖ) :
+@[simp] lemma unop_finsuppProd (f : ι →₀ N) (g : ι → N → Mᵐᵒᵖ) :
     unop (f.prod g) = f.prod fun i n ↦ unop (g i n) := unop_prod ..
 
 end AddOpposite


### PR DESCRIPTION
In `to_additive` there is this weird quirk about the implementation that when translating `A.B`, it looks for a translation of `A.B` and otherwise for a translation of just `A`, and tries that. This behavior causes trouble in #25273 and I must therefore tag `MulOpposite.op_finsuppSum` and a few other lemmas with `to_additive self` to make sure `to_additive` doesn't try to additivise them.


---
<!-- Your PR title will become the first line of the commit message.

In this box, the text above the `---` (if not empty) will be appended
to the commit message, and can be used to give additional context or
details. Please leave a blank newline before the `---`, otherwise GitHub
will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

When merging, all the commits will be squashed into a single commit
listing all co-authors.

Co-authors in the squash commit are gathered from two sources:

First, all authors of commits to this PR branch are included. Thus,
one way to add co-authors is to include at least one commit authored by
each co-author among the commits in the pull request. If necessary, you
may create empty commits to indicate co-authorship, using commands like so:

git commit --author="Author Name <author@email.com>" --allow-empty -m "add Author Name as coauthor"

Second, co-authors can also be listed in lines at the very bottom of
the commit message (that is, directly before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines
at the bottom of the commit message (before the `---`, and also before
any "Co-authored-by" lines) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
