### PR TITLE
[Merged by Bors] - feat(RingTheory): improved linearity of `Derivation.compDer`

### DIFF
--- a/Mathlib/RingTheory/Derivation/Basic.lean
+++ b/Mathlib/RingTheory/Derivation/Basic.lean
@@ -322,11 +322,11 @@ def compAlgebraMap [Algebra A B] [IsScalarTower R A B] [IsScalarTower A B M]
 
 variable (R A B M) in
 /-- For a tower `R → A → B → M`, the precomposition defined in `compAlgebraMap`
-is an `A`-linear map. -/
+is a `B`-linear map. -/
 @[simps!]
 def compAlgebraMapL [Algebra A B] [IsScalarTower R A B] [IsScalarTower A B M]
-    [IsScalarTower R A M] :
-    Derivation R B M →ₗ[A] Derivation R A M where
+    [IsScalarTower R B M] :
+    Derivation R B M →ₗ[B] Derivation R A M where
   toFun d := d.compAlgebraMap A
   map_add' _ _ := rfl
   map_smul' _ _ := rfl


### PR DESCRIPTION
Given a scalar tower $$R\to A \to B \to M$$, we have the natural map $Der_R(B, M)\to Der_R(A, M)$. It was stated to be $$A$$-linear, but is in fact even $$B$$-linear.

To be able to phrase this, I needed to change `[IsScalarTower R A M]` to `[IsScalarTower R B M]`. Those should be factually equivalent, due to `IsScalarTower.to₁₃₄`, however the inference of  `IsScalarTower R B M` from  `IsScalarTower R A M` does not seem to be automatic.

---
<!-- Your PR title will become the first line of the commit message.

In this box, the text above the `---` (if not empty) will be appended
to the commit message, and can be used to give additional context or
details. Please leave a blank newline before the `---`, otherwise GitHub
will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

When merging, all the commits will be squashed into a single commit
listing all co-authors.

Co-authors in the squash commit are gathered from two sources:

First, all authors of commits to this PR branch are included. Thus,
one way to add co-authors is to include at least one commit authored by
each co-author among the commits in the pull request. If necessary, you
may create empty commits to indicate co-authorship, using commands like so:

git commit --author="Author Name <author@email.com>" --allow-empty -m "add Author Name as coauthor"

Second, co-authors can also be listed in lines at the very bottom of
the commit message (that is, directly before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines
at the bottom of the commit message (before the `---`, and also before
any "Co-authored-by" lines) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
