### PR TITLE
[Merged by Bors] - feat(RingTheory): properties on `Algebra.TensorProduct.map`

### DIFF
--- a/Mathlib/RingTheory/Finiteness/Basic.lean
+++ b/Mathlib/RingTheory/Finiteness/Basic.lean
@@ -398,6 +398,9 @@ theorem of_surjective (f : A →+* B) (hf : Surjective f) : f.Finite :=
   letI := f.toAlgebra
   Module.Finite.of_surjective (Algebra.linearMap A B) hf
 
+lemma _root_.RingEquiv.finite (e : A ≃+* B) : e.toRingHom.Finite :=
+  .of_surjective _ e.surjective
+
 theorem comp {g : B →+* C} {f : A →+* B} (hg : g.Finite) (hf : f.Finite) : (g.comp f).Finite := by
   algebraize [f, g, g.comp f]
   exact Module.Finite.trans B C

--- a/Mathlib/RingTheory/TensorProduct/Finite.lean
+++ b/Mathlib/RingTheory/TensorProduct/Finite.lean
@@ -177,3 +177,33 @@ lemma RingHom.surjective_of_tmul_eq_tmul_of_finite {R S}
       have : R'.mkQ 1 = 0 := (Submodule.Quotient.mk_eq_zero R').mpr ⟨1, map_one (algebraMap R S)⟩
       rw [← map_tmul R'.mkQ R'.mkQ, ← hs, map_tmul, this, zero_tmul]
   cases false_of_nontrivial_of_subsingleton ((S ⧸ R') ⊗[R] (S ⧸ R'))
+
+-- Subsumed by `RingHom.Finite.tensorProductMap`.
+private lemma RingHom.Finite.tensorProductMap_id
+    {R S S' T : Type*} [CommRing R] [CommRing S] [CommRing T] [CommRing S']
+    [Algebra R S] [Algebra R T] [Algebra R S']
+    {f : S →ₐ[R] S'} (Hf : f.Finite) :
+    (Algebra.TensorProduct.map f (AlgHom.id R T)).toRingHom.Finite := by
+  letI := f.toRingHom.toAlgebra
+  have := IsScalarTower.of_algebraMap_eq' f.comp_algebraMap.symm
+  have : Module.Finite S S' := finite_algebraMap.mp Hf
+  change (Algebra.TensorProduct.map (Algebra.ofId S S') (AlgHom.id R T)).Finite
+  convert_to (((Algebra.TensorProduct.comm _ _ _).trans
+      (Algebra.TensorProduct.cancelBaseChange R S S S' T)).toAlgHom.comp
+    Algebra.TensorProduct.includeLeft).Finite
+  · ext; simp
+  exact (RingEquiv.finite _).comp (finite_algebraMap.mpr inferInstance)
+
+lemma RingHom.Finite.tensorProductMap
+    {R S S' T T' : Type*} [CommRing R] [CommRing S] [CommRing T] [CommRing S'] [CommRing T']
+    [Algebra R S] [Algebra R T] [Algebra R S'] [Algebra R T']
+    {f : S →ₐ[R] S'} (Hf : f.Finite) {g : T →ₐ[R] T'} (Hg : g.Finite) :
+    (Algebra.TensorProduct.map f g).toRingHom.Finite := by
+  convert RingHom.Finite.tensorProductMap_id (T := T') Hf |>.comp <|
+    (Algebra.TensorProduct.comm _ _ _).toRingEquiv.finite |>.comp <|
+    RingHom.Finite.tensorProductMap_id (T := S) Hg |>.comp <|
+    (Algebra.TensorProduct.comm _ _ _).toRingEquiv.finite
+  simp only [AlgHom.toRingHom_eq_coe, AlgEquiv.toRingEquiv_eq_coe, RingEquiv.toRingHom_eq_coe,
+    AlgEquiv.toRingEquiv_toRingHom, ← AlgEquiv.toAlgHom_toRingHom, ← AlgHom.comp_toRingHom]
+  congr
+  ext <;> simp


### PR DESCRIPTION

---
<!-- Your PR title will become the first line of the commit message.

In this box, the text above the `---` (if not empty) will be appended
to the commit message, and can be used to give additional context or
details. Please leave a blank newline before the `---`, otherwise GitHub
will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

When merging, all the commits will be squashed into a single commit
listing all co-authors.

Co-authors in the squash commit are gathered from two sources:

First, all authors of commits to this PR branch are included. Thus,
one way to add co-authors is to include at least one commit authored by
each co-author among the commits in the pull request. If necessary, you
may create empty commits to indicate co-authorship, using commands like so:

git commit --author="Author Name <author@email.com>" --allow-empty -m "add Author Name as coauthor"

Second, co-authors can also be listed in lines at the very bottom of
the commit message (that is, directly before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines
at the bottom of the commit message (before the `---`, and also before
any "Co-authored-by" lines) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
