### PR TITLE
[Merged by Bors] - chore: import Tactic.Attr.Register privately

### DIFF
--- a/Mathlib/Algebra/Free.lean
+++ b/Mathlib/Algebra/Free.lean
@@ -12,6 +12,8 @@ public import Mathlib.Control.Traversable.Basic
 public import Mathlib.Logic.Equiv.Defs
 public import Mathlib.Tactic.AdaptationNote
 
+import Mathlib.Tactic.Attr.Register
+
 /-!
 # Free constructions
 

--- a/Mathlib/Algebra/Group/Units/Basic.lean
+++ b/Mathlib/Algebra/Group/Units/Basic.lean
@@ -13,6 +13,8 @@ public import Mathlib.Tactic.Lift
 public import Mathlib.Tactic.Subsingleton
 public import Mathlib.Tactic.Attr.Core
 
+import Mathlib.Tactic.Attr.Register
+
 /-!
 # Units (i.e., invertible elements) of a monoid
 

--- a/Mathlib/CategoryTheory/Monoidal/Mon_.lean
+++ b/Mathlib/CategoryTheory/Monoidal/Mon_.lean
@@ -11,6 +11,8 @@ public import Mathlib.CategoryTheory.Monoidal.CoherenceLemmas
 public import Mathlib.CategoryTheory.Monoidal.Discrete
 public import Mathlib.CategoryTheory.Limits.Shapes.Terminal
 
+import Mathlib.Tactic.Attr.Register
+
 /-!
 # The category of monoids in a monoidal category.
 

--- a/Mathlib/Control/Applicative.lean
+++ b/Mathlib/Control/Applicative.lean
@@ -9,6 +9,8 @@ public import Mathlib.Algebra.Group.Defs
 public import Mathlib.Control.Functor
 public import Mathlib.Control.Basic
 
+import Mathlib.Tactic.Attr.Register
+
 /-!
 # `applicative` instances
 

--- a/Mathlib/Control/Basic.lean
+++ b/Mathlib/Control/Basic.lean
@@ -9,6 +9,8 @@ public import Mathlib.Control.Combinators
 public import Mathlib.Tactic.CasesM
 public import Mathlib.Tactic.Attr.Core
 
+import Mathlib.Tactic.Attr.Register
+
 /-!
 Extends the theory on functors, applicatives and monads.
 -/

--- a/Mathlib/Control/Functor.lean
+++ b/Mathlib/Control/Functor.lean
@@ -5,9 +5,10 @@ Authors: Simon Hudon
 -/
 module
 
-public import Mathlib.Tactic.Attr.Register
 public import Mathlib.Data.Set.Defs
 public import Mathlib.Tactic.TypeStar
+
+import Mathlib.Tactic.Attr.Register
 
 /-!
 # Functors

--- a/Mathlib/Control/Monad/Basic.lean
+++ b/Mathlib/Control/Monad/Basic.lean
@@ -8,6 +8,8 @@ module
 public import Mathlib.Logic.Equiv.Defs
 public import Batteries.Lean.Except
 
+import Mathlib.Tactic.Attr.Register
+
 /-!
 # Monad
 

--- a/Mathlib/Control/Traversable/Basic.lean
+++ b/Mathlib/Control/Traversable/Basic.lean
@@ -10,6 +10,8 @@ public import Mathlib.Control.Functor
 public import Batteries.Data.List.Basic
 public import Mathlib.Control.Basic
 
+import Mathlib.Tactic.Attr.Register
+
 /-!
 # Traversable type class
 

--- a/Mathlib/Control/Traversable/Equiv.lean
+++ b/Mathlib/Control/Traversable/Equiv.lean
@@ -9,6 +9,8 @@ public import Mathlib.Control.Traversable.Lemmas
 public import Mathlib.Logic.Equiv.Defs
 public import Batteries.Tactic.SeqFocus
 
+import Mathlib.Tactic.Attr.Register
+
 /-!
 # Transferring `Traversable` instances along isomorphisms
 

--- a/Mathlib/Control/Traversable/Lemmas.lean
+++ b/Mathlib/Control/Traversable/Lemmas.lean
@@ -8,6 +8,8 @@ module
 public import Mathlib.Control.Applicative
 public import Mathlib.Control.Traversable.Basic
 
+import Mathlib.Tactic.Attr.Register
+
 /-!
 # Traversing collections
 

--- a/Mathlib/Data/Prod/Basic.lean
+++ b/Mathlib/Data/Prod/Basic.lean
@@ -10,6 +10,8 @@ public import Mathlib.Logic.Function.Iterate
 public import Mathlib.Tactic.Inhabit
 public import Batteries.Tactic.Trans
 
+import Mathlib.Tactic.Attr.Register
+
 /-!
 # Extra facts about `Prod`
 

--- a/Mathlib/Data/Set/Operations.lean
+++ b/Mathlib/Data/Set/Operations.lean
@@ -13,6 +13,8 @@ public import Mathlib.Data.Subtype
 public import Mathlib.Order.Notation
 public import Mathlib.Tactic.Push.Attr
 
+import Mathlib.Tactic.Attr.Register
+
 /-!
 # Basic definitions about sets
 

--- a/Mathlib/Logic/Basic.lean
+++ b/Mathlib/Logic/Basic.lean
@@ -5,11 +5,12 @@ Authors: Jeremy Avigad, Leonardo de Moura
 -/
 module
 
-public import Mathlib.Tactic.Attr.Register
 public import Mathlib.Tactic.AdaptationNote
 public import Mathlib.Tactic.Basic
 public import Batteries.Logic
 public import Batteries.Util.LibraryNote
+
+import Mathlib.Tactic.Attr.Register
 
 /-!
 # Basic logic properties

--- a/Mathlib/Logic/Equiv/Defs.lean
+++ b/Mathlib/Logic/Equiv/Defs.lean
@@ -12,6 +12,8 @@ public import Mathlib.Logic.Unique
 public import Mathlib.Tactic.Simps.Basic
 public import Mathlib.Tactic.Substs
 
+import Mathlib.Tactic.Attr.Register
+
 /-!
 # Equivalence between types
 

--- a/Mathlib/Logic/Function/Basic.lean
+++ b/Mathlib/Logic/Function/Basic.lean
@@ -14,6 +14,8 @@ public import Mathlib.Logic.Nontrivial.Defs
 public import Batteries.Tactic.Init
 public import Mathlib.Order.Defs.Unbundled
 
+import Mathlib.Tactic.Attr.Register
+
 /-!
 # Miscellaneous function constructions and lemmas
 -/

--- a/Mathlib/Logic/Function/Defs.lean
+++ b/Mathlib/Logic/Function/Defs.lean
@@ -5,9 +5,10 @@ Authors: Leonardo de Moura, Jeremy Avigad, Haitao Zhang
 -/
 module
 
-public import Mathlib.Tactic.Attr.Register
 public import Mathlib.Tactic.Lemma
 public import Mathlib.Tactic.TypeStar
+
+import Mathlib.Tactic.Attr.Register
 
 /-!
 # General operations on functions

--- a/Mathlib/Logic/Nontrivial/Basic.lean
+++ b/Mathlib/Logic/Nontrivial/Basic.lean
@@ -10,7 +10,8 @@ public import Mathlib.Logic.Function.Basic
 public import Mathlib.Logic.Nontrivial.Defs
 public import Mathlib.Logic.Unique
 public import Mathlib.Order.Defs.LinearOrder
-public import Mathlib.Tactic.Attr.Register
+
+import Mathlib.Tactic.Attr.Register
 
 /-!
 # Nontrivial types

--- a/Mathlib/Tactic/Attr/Core.lean
+++ b/Mathlib/Tactic/Attr/Core.lean
@@ -5,7 +5,7 @@ Authors: Yury Kudryashov
 -/
 module
 
-public import Mathlib.Tactic.Attr.Register
+import Mathlib.Tactic.Attr.Register
 
 /-!
 # Simp tags for core lemmas

--- a/Mathlib/Tactic/HigherOrder.lean
+++ b/Mathlib/Tactic/HigherOrder.lean
@@ -13,6 +13,8 @@ public meta import Lean.Elab.DeclarationRange
 public import Lean.Meta.Tactic.Simp
 public import Mathlib.Init
 
+import Mathlib.Tactic.Attr.Register
+
 /-!
 # HigherOrder attribute
 

--- a/Mathlib/Tactic/Zify.lean
+++ b/Mathlib/Tactic/Zify.lean
@@ -6,12 +6,13 @@ Authors: Moritz Doll, Mario Carneiro, Robert Y. Lewis
 module
 
 public meta import Mathlib.Tactic.Basic
-public meta import Mathlib.Tactic.Attr.Register
 public meta import Aesop
 public import Mathlib.Data.Int.Cast.Basic
 public import Mathlib.Order.Basic
 public meta import Mathlib.Tactic.ToAdditive
 public meta import Mathlib.Tactic.ToDual
+
+meta import Mathlib.Tactic.Attr.Register
 
 /-!
 # `zify` tactic


### PR DESCRIPTION
This is mostly to start a discussion: Should basic tactic files like this one be re-exported by all files out of them being basic, or whether they should be explicitly imported by the few files that actually need it.

Eg in #32245 Andrew and I are adding a new simp attribute, and it's a bit silly that we have to rebuild all of mathlib because that file is re-exported everywhere.


---
<!-- Your PR title will become the first line of the commit message.

In this box, the text above the `---` (if not empty) will be appended
to the commit message, and can be used to give additional context or
details. Please leave a blank newline before the `---`, otherwise GitHub
will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

When merging, all the commits will be squashed into a single commit
listing all co-authors.

Co-authors in the squash commit are gathered from two sources:

First, all authors of commits to this PR branch are included. Thus,
one way to add co-authors is to include at least one commit authored by
each co-author among the commits in the pull request. If necessary, you
may create empty commits to indicate co-authorship, using commands like so:

git commit --author="Author Name <author@email.com>" --allow-empty -m "add Author Name as coauthor"

Second, co-authors can also be listed in lines at the very bottom of
the commit message (that is, directly before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines
at the bottom of the commit message (before the `---`, and also before
any "Co-authored-by" lines) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
