### PR TITLE
[Merged by Bors] - feat(RingTheory/PowerSeries): toSubring and ofSubring for MvPowerSeries

### DIFF
--- a/Mathlib/RingTheory/MvPowerSeries/Basic.lean
+++ b/Mathlib/RingTheory/MvPowerSeries/Basic.lean
@@ -549,6 +549,42 @@ theorem map_X (s : σ) : map f (X s) = X s := by simp [MvPowerSeries.X]
 
 end Map
 
+section toSubring
+
+variable [Ring R] (p : MvPowerSeries σ R) (T : Subring R) (hp : ∀ n, p.coeff n ∈ T)
+
+/-- Given a multivariate formal power series `p` and a subring `T` that contains the
+ coefficients of `p`,return the corresponding multivariate formal power series
+ whose coefficients are in `T`. -/
+def toSubring : MvPowerSeries σ T := fun n => ⟨p.coeff n, hp n⟩
+
+@[simp]
+theorem coeff_toSubring {n : σ →₀ ℕ} : (p.toSubring T hp).coeff n = p.coeff n := rfl
+
+@[simp]
+theorem constantCoeff_toSubring : (p.toSubring T hp).constantCoeff = p.constantCoeff := rfl
+
+@[simp]
+theorem map_toSubring : (p.toSubring T hp).map (Subring.subtype T) = p := rfl
+
+end toSubring
+
+section ofSubring
+
+variable [Ring R] (T : Subring R) (p : MvPowerSeries σ T)
+
+/-- Given a multivariate formal power series whose coefficients are in some subring, return
+the multivariate formal power series whose coefficients are in the ambient ring. -/
+def ofSubring : MvPowerSeries σ R := fun n => (p n : R)
+
+@[simp]
+theorem coeff_ofSubring {n : σ →₀ ℕ} : (ofSubring T p).coeff n = p.coeff n := rfl
+
+@[simp]
+theorem constantCoeff_ofSubring : (ofSubring T p).constantCoeff = p.constantCoeff := rfl
+
+end ofSubring
+
 @[simp]
 theorem map_eq_zero {S : Type*} [DivisionSemiring R] [Semiring S] [Nontrivial S]
     (φ : MvPowerSeries σ R) (f : R →+* S) : φ.map f = 0 ↔ φ = 0 := by

--- a/Mathlib/RingTheory/MvPowerSeries/Basic.lean
+++ b/Mathlib/RingTheory/MvPowerSeries/Basic.lean
@@ -565,25 +565,9 @@ theorem coeff_toSubring {n : σ →₀ ℕ} : (p.toSubring T hp).coeff n = p.coe
 theorem constantCoeff_toSubring : (p.toSubring T hp).constantCoeff = p.constantCoeff := rfl
 
 @[simp]
-theorem map_toSubring : (p.toSubring T hp).map (Subring.subtype T) = p := rfl
+theorem map_toSubring : (p.toSubring T hp).map T.subtype = p := rfl
 
 end toSubring
-
-section ofSubring
-
-variable [Ring R] (T : Subring R) (p : MvPowerSeries σ T)
-
-/-- Given a multivariate formal power series whose coefficients are in some subring, return
-the multivariate formal power series whose coefficients are in the ambient ring. -/
-def ofSubring : MvPowerSeries σ R := fun n => (p n : R)
-
-@[simp]
-theorem coeff_ofSubring {n : σ →₀ ℕ} : (ofSubring T p).coeff n = p.coeff n := rfl
-
-@[simp]
-theorem constantCoeff_ofSubring : (ofSubring T p).constantCoeff = p.constantCoeff := rfl
-
-end ofSubring
 
 @[simp]
 theorem map_eq_zero {S : Type*} [DivisionSemiring R] [Semiring S] [Nontrivial S]

--- a/Mathlib/RingTheory/MvPowerSeries/Basic.lean
+++ b/Mathlib/RingTheory/MvPowerSeries/Basic.lean
@@ -554,7 +554,7 @@ section toSubring
 variable [Ring R] (p : MvPowerSeries σ R) (T : Subring R) (hp : ∀ n, p.coeff n ∈ T)
 
 /-- Given a multivariate formal power series `p` and a subring `T` that contains the
- coefficients of `p`,return the corresponding multivariate formal power series
+ coefficients of `p`, return the corresponding multivariate formal power series
  whose coefficients are in `T`. -/
 def toSubring : MvPowerSeries σ T := fun n => ⟨p.coeff n, hp n⟩
 

--- a/Mathlib/RingTheory/MvPowerSeries/Order.lean
+++ b/Mathlib/RingTheory/MvPowerSeries/Order.lean
@@ -342,6 +342,15 @@ theorem weightedOrder_neg (f : MvPowerSeries σ R) : (-f).weightedOrder w = f.we
   have : f = 0 := by simpa using (weightedOrder_add_of_weightedOrder_ne w h).symm
   simp [this] at h
 
+@[simp]
+theorem weightedOrder_toSubring (p : MvPowerSeries σ R) (T : Subring R) (hp : ∀ n, p.coeff n ∈ T) :
+    (p.toSubring T hp).weightedOrder w = p.weightedOrder w := by
+  refine eq_of_le_of_ge ?_ ?_
+  · refine le_weightedOrder w fun d hd => by
+      simp [coeff_eq_zero_of_lt_weightedOrder w hd, ←p.coeff_toSubring T hp]
+  · refine le_weightedOrder w fun d hd => by
+      exact_mod_cast (coeff_toSubring p T hp) ▸ (coeff_eq_zero_of_lt_weightedOrder w hd)
+
 end Ring
 
 end WeightedOrder
@@ -486,6 +495,13 @@ theorem coeff_mul_prod_one_sub_of_lt_order {R ι : Type*} [CommRing R] (d : σ �
 
 @[simp]
 theorem order_neg (f : MvPowerSeries σ R) : (-f).order = f.order := weightedOrder_neg _ f
+
+@[simp]
+theorem order_toSubring (p : MvPowerSeries σ R) (T : Subring R) (hp : ∀ n, p.coeff n ∈ T) :
+    (p.toSubring T hp).order = p.order := by
+  refine eq_of_le_of_ge ?_ ?_
+  · exact le_order fun d hd => by simp [coeff_of_lt_order hd, ←p.coeff_toSubring T hp]
+  · exact le_order fun d hd => by exact_mod_cast (coeff_toSubring p T hp) ▸ (coeff_of_lt_order hd)
 
 end Ring
 

--- a/Mathlib/RingTheory/PowerSeries/Basic.lean
+++ b/Mathlib/RingTheory/PowerSeries/Basic.lean
@@ -567,7 +567,7 @@ variable [Ring R] (p : PowerSeries R) (T : Subring R) (hp : ∀ n, p.coeff n ∈
 /-- Given a formal power series `p` and a subring `T` that contains the
  coefficients of `p`,return the corresponding formal power series
  whose coefficients are in `T`. -/
-def toSubring : PowerSeries T := mk (fun n => ⟨p.coeff n, hp n⟩)
+def toSubring : PowerSeries T := mk fun n => ⟨p.coeff n, hp n⟩
 
 @[simp]
 theorem coeff_toSubring {n : ℕ} : (p.toSubring T hp).coeff n = p.coeff n := by
@@ -578,26 +578,9 @@ theorem constantCoeff_toSubring : (p.toSubring T hp).constantCoeff = p.constantC
   coeff_zero_eq_constantCoeff_apply p
 
 @[simp]
-theorem map_toSubring : (p.toSubring T hp).map (Subring.subtype T) = p := by
-  ext n; simp
+theorem map_toSubring : (p.toSubring T hp).map T.subtype = p := ext fun n => by simp
 
 end toSubring
-
-section ofSubring
-
-variable [Ring R] (T : Subring R) (p : PowerSeries T)
-
-/-- Given a formal power series whose coefficients are in some subring, return
-the formal power series whose coefficients are in the ambient ring. -/
-def ofSubring : PowerSeries R := fun n => (p n : R)
-
-@[simp]
-theorem coeff_ofSubring {n : ℕ} : (ofSubring T p).coeff n = p.coeff n := rfl
-
-@[simp]
-theorem constantCoeff_ofSubring : (ofSubring T p).constantCoeff = p.constantCoeff := rfl
-
-end ofSubring
 
 section CommSemiring
 

--- a/Mathlib/RingTheory/PowerSeries/Basic.lean
+++ b/Mathlib/RingTheory/PowerSeries/Basic.lean
@@ -560,6 +560,45 @@ theorem X_dvd_iff {φ : R⟦X⟧} : (X : R⟦X⟧) ∣ φ ↔ constantCoeff φ =
 
 end Semiring
 
+section toSubring
+
+variable [Ring R] (p : PowerSeries R) (T : Subring R) (hp : ∀ n, p.coeff n ∈ T)
+
+/-- Given a formal power series `p` and a subring `T` that contains the
+ coefficients of `p`,return the corresponding formal power series
+ whose coefficients are in `T`. -/
+def toSubring : PowerSeries T := mk (fun n => ⟨p.coeff n, hp n⟩)
+
+@[simp]
+theorem coeff_toSubring {n : ℕ} : (p.toSubring T hp).coeff n = p.coeff n := by
+  rw [toSubring, coeff_mk]
+
+@[simp]
+theorem constantCoeff_toSubring : (p.toSubring T hp).constantCoeff = p.constantCoeff :=
+  coeff_zero_eq_constantCoeff_apply p
+
+@[simp]
+theorem map_toSubring : (p.toSubring T hp).map (Subring.subtype T) = p := by
+  ext n; simp
+
+end toSubring
+
+section ofSubring
+
+variable [Ring R] (T : Subring R) (p : PowerSeries T)
+
+/-- Given a formal power series whose coefficients are in some subring, return
+the formal power series whose coefficients are in the ambient ring. -/
+def ofSubring : PowerSeries R := fun n => (p n : R)
+
+@[simp]
+theorem coeff_ofSubring {n : ℕ} : (ofSubring T p).coeff n = p.coeff n := rfl
+
+@[simp]
+theorem constantCoeff_ofSubring : (ofSubring T p).constantCoeff = p.constantCoeff := rfl
+
+end ofSubring
+
 section CommSemiring
 
 variable [CommSemiring R]

--- a/Mathlib/RingTheory/PowerSeries/Basic.lean
+++ b/Mathlib/RingTheory/PowerSeries/Basic.lean
@@ -565,7 +565,7 @@ section toSubring
 variable [Ring R] (p : PowerSeries R) (T : Subring R) (hp : ∀ n, p.coeff n ∈ T)
 
 /-- Given a formal power series `p` and a subring `T` that contains the
- coefficients of `p`,return the corresponding formal power series
+ coefficients of `p`, return the corresponding formal power series
  whose coefficients are in `T`. -/
 def toSubring : PowerSeries T := mk fun n => ⟨p.coeff n, hp n⟩
 

--- a/Mathlib/RingTheory/PowerSeries/Order.lean
+++ b/Mathlib/RingTheory/PowerSeries/Order.lean
@@ -446,6 +446,20 @@ theorem divXPowOrder_prod {R : Type*} [CommSemiring R] [NoZeroDivisors R] [Nontr
 
 end NoZeroDivisors
 
+section Ring
+
+variable [Ring R] (p : PowerSeries R) (T : Subring R) (hp : ∀ n, p.coeff n ∈ T)
+
+@[simp]
+theorem order_toSubring :
+    (p.toSubring T hp).order = p.order := by
+  refine eq_of_le_of_ge ?_ ?_
+  · refine le_order _ _  fun d hd => by simp [coeff_of_lt_order d hd, ←coeff_toSubring p T hp]
+  · exact le_order _ _ fun d hd => by
+      exact_mod_cast (coeff_toSubring p T hp) ▸ (coeff_of_lt_order d hd)
+
+end Ring
+
 end PowerSeries
 
 end

--- a/Mathlib/RingTheory/PowerSeries/Order.lean
+++ b/Mathlib/RingTheory/PowerSeries/Order.lean
@@ -451,8 +451,7 @@ section Ring
 variable [Ring R] (p : PowerSeries R) (T : Subring R) (hp : ∀ n, p.coeff n ∈ T)
 
 @[simp]
-theorem order_toSubring :
-    (p.toSubring T hp).order = p.order := by
+theorem order_toSubring : (p.toSubring T hp).order = p.order := by
   refine eq_of_le_of_ge ?_ ?_
   · refine le_order _ _  fun d hd => by simp [coeff_of_lt_order d hd, ←coeff_toSubring p T hp]
   · exact le_order _ _ fun d hd => by


### PR DESCRIPTION
define MvPowerSeries.toSubring and MvPowerSeries.ofSubring, and prove their order and weighted order are equal. (same for PowerSeries.)

---
<!-- Your PR title will become the first line of the commit message.

In this box, the text above the `---` (if not empty) will be appended
to the commit message, and can be used to give additional context or
details. Please leave a blank newline before the `---`, otherwise GitHub
will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

When merging, all the commits will be squashed into a single commit
listing all co-authors.

Co-authors in the squash commit are gathered from two sources:

First, all authors of commits to this PR branch are included. Thus,
one way to add co-authors is to include at least one commit authored by
each co-author among the commits in the pull request. If necessary, you
may create empty commits to indicate co-authorship, using commands like so:

git commit --author="Author Name <author@email.com>" --allow-empty -m "add Author Name as coauthor"

Second, co-authors can also be listed in lines at the very bottom of
the commit message (that is, directly before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines
at the bottom of the commit message (before the `---`, and also before
any "Co-authored-by" lines) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
