### PR TITLE
feat: register mathlib tactics with try?

### DIFF
--- a/Mathlib/Tactic/Abel.lean
+++ b/Mathlib/Tactic/Abel.lean
@@ -549,3 +549,4 @@ We register `abel` with the `hint` tactic.
 -/
 
 register_hint 950 abel
+register_try?_tactic (priority := 950) abel

--- a/Mathlib/Tactic/Bound.lean
+++ b/Mathlib/Tactic/Bound.lean
@@ -258,3 +258,4 @@ We register `bound` with the `hint` tactic.
 -/
 
 register_hint 70 bound
+register_try?_tactic (priority := 70) bound

--- a/Mathlib/Tactic/Common.lean
+++ b/Mathlib/Tactic/Common.lean
@@ -151,3 +151,23 @@ register_hint 200 omega
 register_hint 200 fun_prop
 
 end Hint
+
+/-!
+# Register tactics with `try?`. Tactics with larger priority run first.
+-/
+
+section Try
+
+register_try?_tactic (priority := 200) grind
+register_try?_tactic (priority := 1000) trivial
+register_try?_tactic (priority := 500) tauto
+register_try?_tactic (priority := 1000) split
+register_try?_tactic (priority := 1000) intro
+register_try?_tactic (priority := 80) aesop
+register_try?_tactic (priority := 800) simp_all?
+register_try?_tactic (priority := 600) exact?
+register_try?_tactic (priority := 1000) decide
+register_try?_tactic (priority := 200) omega
+register_try?_tactic (priority := 200) fun_prop
+
+end Try

--- a/Mathlib/Tactic/ComputeDegree.lean
+++ b/Mathlib/Tactic/ComputeDegree.lean
@@ -529,3 +529,4 @@ end Mathlib.Tactic.ComputeDegree
  We register `compute_degree` with the `hint` tactic.
  -/
 register_hint 1000 compute_degree
+register_try?_tactic (priority := 1000) compute_degree

--- a/Mathlib/Tactic/Field.lean
+++ b/Mathlib/Tactic/Field.lean
@@ -82,3 +82,4 @@ end Mathlib.Tactic.FieldSimp
 
 /-! We register `field` with the `hint` tactic. -/
 register_hint 850 field
+register_try?_tactic (priority := 850) field

--- a/Mathlib/Tactic/FieldSimp.lean
+++ b/Mathlib/Tactic/FieldSimp.lean
@@ -792,3 +792,4 @@ attribute [field, inherit_doc FieldSimp.proc] fieldEq fieldLe fieldLt
  We register `field_simp` with the `hint` tactic.
  -/
 register_hint 1000 field_simp
+register_try?_tactic (priority := 1000) field_simp

--- a/Mathlib/Tactic/Finiteness.lean
+++ b/Mathlib/Tactic/Finiteness.lean
@@ -76,3 +76,4 @@ macro (name := finiteness_nonterminal) "finiteness_nonterminal" c:Aesop.tactic_c
  We register `finiteness` with the `hint` tactic.
  -/
 register_hint 1000 finiteness
+register_try?_tactic (priority := 1000) finiteness

--- a/Mathlib/Tactic/GCongr.lean
+++ b/Mathlib/Tactic/GCongr.lean
@@ -20,3 +20,4 @@ We register `gcongr` with the `hint` tactic.
 -/
 
 register_hint 1000 gcongr
+register_try?_tactic (priority := 1000) gcongr

--- a/Mathlib/Tactic/Group.lean
+++ b/Mathlib/Tactic/Group.lean
@@ -97,3 +97,4 @@ We register `group` with the `hint` tactic.
 -/
 
 register_hint 900 group
+register_try?_tactic (priority := 900) group

--- a/Mathlib/Tactic/Linarith.lean
+++ b/Mathlib/Tactic/Linarith.lean
@@ -16,3 +16,4 @@ We register `linarith` with the `hint` tactic.
 public meta section
 
 register_hint 100 linarith
+register_try?_tactic (priority := 100) linarith

--- a/Mathlib/Tactic/NoncommRing.lean
+++ b/Mathlib/Tactic/NoncommRing.lean
@@ -81,3 +81,4 @@ We register `noncomm_ring` with the `hint` tactic.
 -/
 
 register_hint 1000 noncomm_ring
+register_try?_tactic (priority := 1000) noncomm_ring

--- a/Mathlib/Tactic/NormNum/Core.lean
+++ b/Mathlib/Tactic/NormNum/Core.lean
@@ -313,3 +313,4 @@ We register `norm_num` with the `hint` tactic.
 -/
 
 register_hint 1000 norm_num
+register_try?_tactic (priority := 1000) norm_num

--- a/Mathlib/Tactic/Positivity/Core.lean
+++ b/Mathlib/Tactic/Positivity/Core.lean
@@ -536,3 +536,4 @@ We register `positivity` with the `hint` tactic.
 -/
 
 register_hint 1000 positivity
+register_try?_tactic (priority := 1000) positivity

--- a/Mathlib/Tactic/Ring/RingNF.lean
+++ b/Mathlib/Tactic/Ring/RingNF.lean
@@ -248,3 +248,4 @@ We register `ring` with the `hint` tactic.
 -/
 
 register_hint 1000 ring
+register_try?_tactic (priority := 1000) ring


### PR DESCRIPTION
This PR registers all mathlib tactics with the built-in `try?` tactic extension system (available in Lean 4.26.0+), alongside the existing `hint` registrations.

## Changes

Adds `register_try?_tactic` calls for all tactics currently registered with `register_hint`, using identical priority values:

**Common tactics** (Common.lean):
- grind (priority 200)
- trivial, split, intro, decide (priority 1000)
- tauto (priority 500)
- aesop (priority 80)
- simp_all? (priority 800)
- exact? (priority 600)
- omega, fun_prop (priority 200)

**Domain-specific tactics**:
- linarith (100), ring (1000), norm_num (1000), noncomm_ring (1000)
- abel (950), group (900), field (850), bound (70)
- gcongr (1000), finiteness (1000), compute_degree (1000), positivity (1000), field_simp (1000)

## Compatibility

The existing `hint` registrations are kept unchanged for backward compatibility. This is a pure addition with no breaking changes - users can immediately benefit from `try?` while the `hint` tactic continues to work as before.

## Future work

A follow-up PR will deprecate the `hint` tactic in favor of `try?`. This two-stage approach allows for a smooth migration:
1. This PR: Add `try?` registrations (non-breaking)
2. Future PR: Deprecate `hint` (with clear migration path)

🤖 Prepared with Claude Code