### PR TITLE
[Merged by Bors] - chore: remove "non-breaking spaces"

### DIFF
--- a/Mathlib/Algebra/Lie/Semisimple/Lemmas.lean
+++ b/Mathlib/Algebra/Lie/Semisimple/Lemmas.lean
@@ -19,7 +19,7 @@ This file is a home for lemmas about semisimple and reductive Lie algebras.
 * `LieAlgebra.hasTrivialRadical_of_isIrreducible_of_isFaithful`: a finite-dimensional Lie
   algebra with an irreducible faithful finite-dimensional trace-free representation is semisimple.
 
-## TODO
+## TODO
 
 * Introduce a `Prop`-valued typeclass `LieModule.IsTracefree` stating
   `(toEnd R L M).range ≤ LieAlgebra.derivedSeries R (Module.End R M) 1`, prove

--- a/Mathlib/Analysis/Analytic/IsolatedZeros.lean
+++ b/Mathlib/Analysis/Analytic/IsolatedZeros.lean
@@ -270,7 +270,7 @@ theorem eq_of_frequently_eq [ConnectedSpace 𝕜] (hf : AnalyticOnNhd 𝕜 f uni
 
 section Mul
 /-!
-### Vanishing of products of analytic functions
+### Vanishing of products of analytic functions
 -/
 
 variable {A : Type*} [NormedRing A] [NormedAlgebra 𝕜 A]
@@ -312,7 +312,7 @@ end Mul
 end AnalyticOnNhd
 
 /-!
-### Preimages of codiscrete sets
+### Preimages of codiscrete sets
 -/
 
 section PreimgCodiscrete

--- a/Mathlib/CategoryTheory/Category/ReflQuiv.lean
+++ b/Mathlib/CategoryTheory/Category/ReflQuiv.lean
@@ -12,7 +12,7 @@ public import Mathlib.CategoryTheory.Category.Quiv
 /-!
 # The category of refl quivers
 
-The category `ReflQuiv` of (bundled) reflexive quivers, and the free/forgetful adjunction between
+The category `ReflQuiv` of (bundled) reflexive quivers, and the free/forgetful adjunction between
 `Cat` and `ReflQuiv`.
 -/
 

--- a/Mathlib/Condensed/Solid.lean
+++ b/Mathlib/Condensed/Solid.lean
@@ -76,7 +76,7 @@ end Condensed
 The predicate on condensed `R`-modules describing the property of being solid.
 
 TODO: This is not the correct definition of solid `R`-modules for a general `R`. The correct one is
-as follows: Use this to define solid modules over a finite type `ℤ`-algebra `R`. In particular this
+as follows: Use this to define solid modules over a finite type `ℤ`-algebra `R`. In particular this
 gives a definition of solid modules over `ℤ[X]` (polynomials in one variable). Then a solid
 `R`-module over a general ring `R` is the condition that for every `r ∈ R` and every ring
 homomorphism `ℤ[X] → R` such that `X` maps to `r`, the underlying `ℤ[X]`-module is solid.

--- a/Mathlib/GroupTheory/Perm/MaximalSubgroups.lean
+++ b/Mathlib/GroupTheory/Perm/MaximalSubgroups.lean
@@ -342,7 +342,7 @@ theorem isCoatom_stabilizer_of_ncard_lt_ncard_compl
        In the equality case, `Nat.card s` = Nat.card sᶜ`,
        it would be possible that `sᶜ` is a block,
        and then `G` would be a wreath product,
-       — this is case (b) of the O'Nan-Scott classification
+       — this is case (b) of the O'Nan-Scott classification
        of maximal subgroups of the symmetric group -/
   have not_isBlock_sc : ¬ IsBlock G sᶜ := fun hsc ↦ by
     rcases lt_or_ge (Nat.card α) (sᶜ.ncard * 2) with hB' | hB'

--- a/Mathlib/LinearAlgebra/Vandermonde.lean
+++ b/Mathlib/LinearAlgebra/Vandermonde.lean
@@ -50,7 +50,7 @@ coding theory, and representations of uniform matroids over finite fields.
 ## Implementation notes
 
 We derive the `det_vandermonde` formula from `det_projVandermonde`,
-which is proved using an induction argument involving row operations and division.
+which is proved using an induction argument involving row operations and division.
 To circumvent issues with non-invertible elements while still maintaining the generality of rings,
 we first prove it for fields using the private lemma `det_projVandermonde_of_field`,
 and then use an algebraic workaround to generalize to the ring case,

--- a/Mathlib/NumberTheory/Padics/AddChar.lean
+++ b/Mathlib/NumberTheory/Padics/AddChar.lean
@@ -21,7 +21,7 @@ Note that if the norm on `R` is not strictly multiplicative, then the condition 
 topologically nilpotent is strictly weaker than assuming `‖κ 1 - 1‖ < 1`, although they are
 equivalent if `NormMulClass R` holds.
 
-## Main definitions and theorems:
+## Main definitions and theorems:
 
 * `addChar_of_value_at_one`: given a topologically nilpotent `r : R`, construct a continuous
   additive character of `ℤ_[p]` mapping `1` to `1 + r`.
@@ -32,7 +32,7 @@ equivalent if `NormMulClass R` holds.
   sub-multiplicative), then `addChar_of_value_at_one` is a bijection between continuous additive
   characters `ℤ_[p] → R` and elements of `R` with `‖r‖ < 1`.
 
-## TODO:
+## TODO:
 
 * Show that the above equivalences are homeomorphisms, for appropriate choices of the topology.
 -/

--- a/Mathlib/RingTheory/PolynomialLaw/Basic.lean
+++ b/Mathlib/RingTheory/PolynomialLaw/Basic.lean
@@ -39,7 +39,7 @@ only assumes `R` is a commutative semiring.
 
 ## References
 
-* [Roby, Norbert. 1963. « Lois polynomes et lois formelles en théorie des modules ».
+* [Roby, Norbert. 1963. « Lois polynomes et lois formelles en théorie des modules ».
 Annales scientifiques de l’École Normale Supérieure 80 (3): 213‑348](Roby-1963)
 
 -/

--- a/Mathlib/RingTheory/PolynomialLaw/Basic.lean
+++ b/Mathlib/RingTheory/PolynomialLaw/Basic.lean
@@ -39,7 +39,7 @@ only assumes `R` is a commutative semiring.
 
 ## References
 
-* [Roby, Norbert. 1963. « Lois polynomes et lois formelles en théorie des modules ».
+* [Roby, Norbert. 1963. «Lois polynomes et lois formelles en théorie des modules».
 Annales scientifiques de l’École Normale Supérieure 80 (3): 213‑348](Roby-1963)
 
 -/

--- a/Mathlib/Topology/Algebra/InfiniteSum/UniformOn.lean
+++ b/Mathlib/Topology/Algebra/InfiniteSum/UniformOn.lean
@@ -137,7 +137,7 @@ end UniformlyOn
 
 section LocallyUniformlyOn
 /-!
-## Locally uniform convergence of sums and products
+## Locally uniform convergence of sums and products
 -/
 
 variable [TopologicalSpace β]
@@ -387,7 +387,7 @@ end Uniformly
 
 section LocallyUniformly
 /-!
-## Locally uniform convergence of sums and products
+## Locally uniform convergence of sums and products
 -/
 
 variable [TopologicalSpace β]


### PR DESCRIPTION
Several code files in mathlib have "non-breaking space" characters in them, which cause formatting errors in the docs; see [here](https://leanprover-community.github.io/mathlib4_docs/Mathlib/Analysis/Analytic/IsolatedZeros.html#AnalyticOnNhd.eq_zero_or_eq_zero_of_smul_eq_zero) for example. This PR kills them.

---
<!-- Your PR title will become the first line of the commit message.

In this box, the text above the `---` (if not empty) will be appended
to the commit message, and can be used to give additional context or
details. Please leave a blank newline before the `---`, otherwise GitHub
will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

When merging, all the commits will be squashed into a single commit
listing all co-authors.

Co-authors in the squash commit are gathered from two sources:

First, all authors of commits to this PR branch are included. Thus,
one way to add co-authors is to include at least one commit authored by
each co-author among the commits in the pull request. If necessary, you
may create empty commits to indicate co-authorship, using commands like so:

git commit --author="Author Name <author@email.com>" --allow-empty -m "add Author Name as coauthor"

Second, co-authors can also be listed in lines at the very bottom of
the commit message (that is, directly before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines
at the bottom of the commit message (before the `---`, and also before
any "Co-authored-by" lines) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
