### PR TITLE
[Merged by Bors] - fix(scripts): use explicit refspec in create-adaptation-pr.sh

### DIFF
--- a/scripts/create-adaptation-pr.sh
+++ b/scripts/create-adaptation-pr.sh
@@ -384,7 +384,7 @@ done
 
 echo "All conflicts resolved and committed."
 echo "Proceeding with git push..."
-git push $NIGHTLY_REMOTE nightly-testing
+git push $NIGHTLY_REMOTE nightly-testing:nightly-testing
 
 echo
 echo "### [auto] finished: checkout the original branch"


### PR DESCRIPTION
This PR fixes a bug in `create-adaptation-pr.sh` where `git push` fails with:

```
fatal: refs/remotes/nightly-testing/HEAD cannot be resolved to branch
```

This happens when the remote and branch share the same name (`nightly-testing`), causing git's ref resolution to get confused by the symbolic `refs/remotes/nightly-testing/HEAD` ref. Using an explicit `src:dst` refspec removes the ambiguity.

🤖 Prepared with Claude Code