### PR TITLE
[Merged by Bors] - chore(Algebra/Homology): remove use of `erw` in `coneOfHasLimitEval` and `coconeOfHasColimitEval`

### DIFF
--- a/Mathlib/Algebra/Homology/HomologicalComplexLimits.lean
+++ b/Mathlib/Algebra/Homology/HomologicalComplexLimits.lean
@@ -72,10 +72,10 @@ noncomputable def coneOfHasLimitEval : Cone F where
   π :=
     { app := fun j => { f := fun _ => limit.π _ j }
       naturality := fun i j φ => by
-        ext n
+        ext
         dsimp
-        erw [limit.w]
-        rw [id_comp] }
+        simp only [Category.id_comp]
+        rw [← eval_map, ← Functor.comp_map, limit.w] }
 
 /-- The cone `coneOfHasLimitEval F` is limit. -/
 noncomputable def isLimitConeOfHasLimitEval : IsLimit (coneOfHasLimitEval F) :=
@@ -149,10 +149,10 @@ noncomputable def coconeOfHasColimitEval : Cocone F where
   ι :=
     { app := fun j => { f := fun n => colimit.ι (F ⋙ eval C c n) j }
       naturality := fun i j φ => by
-        ext n
+        ext
         dsimp
-        erw [colimit.w (F ⋙ eval C c n) φ]
-        rw [comp_id] }
+        simp only [Category.comp_id]
+        rw [← eval_map, ← Functor.comp_map, colimit.w] }
 
 /-- The cocone `coconeOfHasLimitEval F` is colimit. -/
 noncomputable def isColimitCoconeOfHasColimitEval : IsColimit (coconeOfHasColimitEval F) :=

--- a/Mathlib/Algebra/Homology/HomologicalComplexLimits.lean
+++ b/Mathlib/Algebra/Homology/HomologicalComplexLimits.lean
@@ -72,7 +72,7 @@ noncomputable def coneOfHasLimitEval : Cone F where
   π :=
     { app := fun j => { f := fun _ => limit.π _ j }
       naturality := fun i j φ => by
-        ext
+        ext n
         dsimp
         simp only [Category.id_comp]
         rw [← eval_map, ← Functor.comp_map, limit.w] }
@@ -149,7 +149,7 @@ noncomputable def coconeOfHasColimitEval : Cocone F where
   ι :=
     { app := fun j => { f := fun n => colimit.ι (F ⋙ eval C c n) j }
       naturality := fun i j φ => by
-        ext
+        ext n
         dsimp
         simp only [Category.comp_id]
         rw [← eval_map, ← Functor.comp_map, colimit.w] }


### PR DESCRIPTION
---
<!-- Your PR title will become the first line of the commit message.

In this box, the text above the `---` (if not empty) will be appended
to the commit message, and can be used to give additional context or
details. Please leave a blank newline before the `---`, otherwise GitHub
will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

When merging, all the commits will be squashed into a single commit
listing all co-authors.

Co-authors in the squash commit are gathered from two sources:

First, all authors of commits to this PR branch are included. Thus,
one way to add co-authors is to include at least one commit authored by
each co-author among the commits in the pull request. If necessary, you
may create empty commits to indicate co-authorship, using commands like so:

git commit --author="Author Name <author@email.com>" --allow-empty -m "add Author Name as coauthor"

Second, co-authors can also be listed in lines at the very bottom of
the commit message (that is, directly before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines
at the bottom of the commit message (before the `---`, and also before
any "Co-authored-by" lines) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
