### PR TITLE
[Merged by Bors] - chore(Order/ConditionallyCompleteLattice): use `where` notation 

### DIFF
--- a/Mathlib/Order/ConditionallyCompleteLattice/Basic.lean
+++ b/Mathlib/Order/ConditionallyCompleteLattice/Basic.lean
@@ -123,14 +123,14 @@ theorem WithBot.coe_sInf' [InfSet α] {s : Set α} (hs : BddBelow s) :
 end
 
 instance ConditionallyCompleteLinearOrder.toLinearOrder [h : ConditionallyCompleteLinearOrder α] :
-  LinearOrder α where
-  min_def := fun a b ↦ by
+    LinearOrder α where
+  min_def a b := by
     by_cases hab : a = b
     · simp [hab]
     · rcases ConditionallyCompleteLinearOrder.le_total a b with (h₁ | h₂)
       · simp [h₁]
       · simp [show ¬(a ≤ b) from fun h => hab (le_antisymm h h₂), h₂]
-  max_def := fun a b ↦ by
+  max_def a b := by
     by_cases hab : a = b
     · simp [hab]
     · rcases ConditionallyCompleteLinearOrder.le_total a b with (h₁ | h₂)
@@ -440,14 +440,12 @@ instance Pi.conditionallyCompleteLattice {ι : Type*} {α : ι → Type*}
     [∀ i, ConditionallyCompleteLattice (α i)] : ConditionallyCompleteLattice (∀ i, α i) where
   le_csSup := fun _ f ⟨g, hg⟩ hf i =>
     le_csSup ⟨g i, Set.forall_mem_range.2 fun ⟨_, hf'⟩ => hg hf' i⟩ ⟨⟨f, hf⟩, rfl⟩
-  csSup_le := fun s _ hs hf i =>
-    (csSup_le (by haveI := hs.to_subtype; apply range_nonempty)) fun _ ⟨⟨_, hg⟩, hb⟩ =>
-      hb ▸ hf hg i
+  csSup_le s _ hs hf i :=
+    (csSup_le (by have := hs.to_subtype; apply range_nonempty)) fun _ ⟨⟨_, hg⟩, hb⟩ => hb ▸ hf hg i
   csInf_le := fun _ f ⟨g, hg⟩ hf i =>
     csInf_le ⟨g i, Set.forall_mem_range.2 fun ⟨_, hf'⟩ => hg hf' i⟩ ⟨⟨f, hf⟩, rfl⟩
-  le_csInf := fun s _ hs hf i =>
-    (le_csInf (by haveI := hs.to_subtype; apply range_nonempty)) fun _ ⟨⟨_, hg⟩, hb⟩ =>
-      hb ▸ hf hg i
+  le_csInf s _ hs hf i :=
+    (le_csInf (by have := hs.to_subtype; apply range_nonempty)) fun _ ⟨⟨_, hg⟩, hb⟩ => hb ▸ hf hg i
 
 section ConditionallyCompleteLinearOrder
 
@@ -933,10 +931,10 @@ This result can be used to show that the extended reals `[-∞, ∞]` are a comp
 gives a conditionally complete lattice -/
 noncomputable instance WithTop.conditionallyCompleteLattice {α : Type*}
     [ConditionallyCompleteLattice α] : ConditionallyCompleteLattice (WithTop α) where
-  le_csSup := fun _ a _ haS => (WithTop.isLUB_sSup' ⟨a, haS⟩).1 haS
-  csSup_le := fun _ _ hS haS => (WithTop.isLUB_sSup' hS).2 haS
-  csInf_le := fun _ _ hS haS => (WithTop.isGLB_sInf' hS).1 haS
-  le_csInf := fun _ a _ haS => (WithTop.isGLB_sInf' ⟨a, haS⟩).2 haS
+  le_csSup _ a _ haS := (WithTop.isLUB_sSup' ⟨a, haS⟩).1 haS
+  csSup_le _ _ hS haS := (WithTop.isLUB_sSup' hS).2 haS
+  csInf_le _ _ hS haS := (WithTop.isGLB_sInf' hS).1 haS
+  le_csInf _ a _ haS := (WithTop.isGLB_sInf' ⟨a, haS⟩).2 haS
 
 /-- Adding a bottom element to a conditionally complete lattice
 gives a conditionally complete lattice -/
@@ -958,13 +956,13 @@ noncomputable instance [CompleteLattice α] : CompleteLattice (WithBot α) where
 open Classical in
 noncomputable instance WithTop.WithBot.completeLattice {α : Type*}
     [ConditionallyCompleteLattice α] : CompleteLattice (WithTop (WithBot α)) where
-  le_sSup := fun _ a haS => (WithTop.isLUB_sSup' ⟨a, haS⟩).1 haS
-  sSup_le := fun S a ha => by
+  le_sSup _ a haS := (WithTop.isLUB_sSup' ⟨a, haS⟩).1 haS
+  sSup_le S a ha := by
     rcases S.eq_empty_or_nonempty with h | h
     · change ite _ _ _ ≤ a
       simp [h]
     · exact (WithTop.isLUB_sSup' h).2 ha
-  sInf_le := fun S a haS =>
+  sInf_le S a haS :=
     show ite _ _ _ ≤ a by
       simp only [OrderBot.bddBelow, not_true_eq_false, or_false]
       split_ifs with h₁
@@ -978,7 +976,7 @@ noncomputable instance WithTop.WithBot.completeLattice {α : Type*}
           use ⊥
           intro b _
           exact bot_le
-  le_sInf := fun _ a haS => (WithTop.isGLB_sInf' ⟨a, haS⟩).2 haS
+  le_sInf _ a haS := (WithTop.isGLB_sInf' ⟨a, haS⟩).2 haS
 
 noncomputable instance WithTop.WithBot.completeLinearOrder {α : Type*}
     [ConditionallyCompleteLinearOrder α] : CompleteLinearOrder (WithTop (WithBot α)) where

--- a/Mathlib/Order/ConditionallyCompleteLattice/Basic.lean
+++ b/Mathlib/Order/ConditionallyCompleteLattice/Basic.lean
@@ -122,21 +122,21 @@ theorem WithBot.coe_sInf' [InfSet α] {s : Set α} (hs : BddBelow s) :
 
 end
 
-instance ConditionallyCompleteLinearOrder.toLinearOrder [ConditionallyCompleteLinearOrder α] :
-    LinearOrder α :=
-  { ‹ConditionallyCompleteLinearOrder α› with
-    min_def := fun a b ↦ by
-      by_cases hab : a = b
-      · simp [hab]
-      · rcases ConditionallyCompleteLinearOrder.le_total a b with (h₁ | h₂)
-        · simp [h₁]
-        · simp [show ¬(a ≤ b) from fun h => hab (le_antisymm h h₂), h₂]
-    max_def := fun a b ↦ by
-      by_cases hab : a = b
-      · simp [hab]
-      · rcases ConditionallyCompleteLinearOrder.le_total a b with (h₁ | h₂)
-        · simp [h₁]
-        · simp [show ¬(a ≤ b) from fun h => hab (le_antisymm h h₂), h₂] }
+instance ConditionallyCompleteLinearOrder.toLinearOrder [h : ConditionallyCompleteLinearOrder α] :
+  LinearOrder α where
+  min_def := fun a b ↦ by
+    by_cases hab : a = b
+    · simp [hab]
+    · rcases ConditionallyCompleteLinearOrder.le_total a b with (h₁ | h₂)
+      · simp [h₁]
+      · simp [show ¬(a ≤ b) from fun h => hab (le_antisymm h h₂), h₂]
+  max_def := fun a b ↦ by
+    by_cases hab : a = b
+    · simp [hab]
+    · rcases ConditionallyCompleteLinearOrder.le_total a b with (h₁ | h₂)
+      · simp [h₁]
+      · simp [show ¬(a ≤ b) from fun h => hab (le_antisymm h h₂), h₂]
+  __ := h
 
 -- see Note [lower instance priority]
 attribute [instance 100] ConditionallyCompleteLinearOrderBot.toOrderBot
@@ -145,35 +145,36 @@ attribute [instance 100] ConditionallyCompleteLinearOrderBot.toOrderBot
 /-- A complete lattice is a conditionally complete lattice, as there are no restrictions
 on the properties of sInf and sSup in a complete lattice. -/
 instance (priority := 100) CompleteLattice.toConditionallyCompleteLattice [CompleteLattice α] :
-    ConditionallyCompleteLattice α :=
-  { ‹CompleteLattice α› with
-    le_csSup := by intros; apply le_sSup; assumption
-    csSup_le := by intros; apply sSup_le; assumption
-    csInf_le := by intros; apply sInf_le; assumption
-    le_csInf := by intros; apply le_sInf; assumption }
+    ConditionallyCompleteLattice α where
+  le_csSup := by intros; apply le_sSup; assumption
+  csSup_le := by intros; apply sSup_le; assumption
+  csInf_le := by intros; apply sInf_le; assumption
+  le_csInf := by intros; apply le_sInf; assumption
 
 -- see Note [lower instance priority]
 instance (priority := 100) CompleteLinearOrder.toConditionallyCompleteLinearOrderBot {α : Type*}
-    [h : CompleteLinearOrder α] : ConditionallyCompleteLinearOrderBot α :=
-  { CompleteLattice.toConditionallyCompleteLattice, h with
-    csSup_empty := sSup_empty
-    csSup_of_not_bddAbove := fun s H ↦ (H (OrderTop.bddAbove s)).elim
-    csInf_of_not_bddBelow := fun s H ↦ (H (OrderBot.bddBelow s)).elim }
+    [h : CompleteLinearOrder α] : ConditionallyCompleteLinearOrderBot α where
+  csSup_empty := sSup_empty
+  csSup_of_not_bddAbove := fun s H ↦ (H (OrderTop.bddAbove s)).elim
+  csInf_of_not_bddBelow := fun s H ↦ (H (OrderBot.bddBelow s)).elim
+  __ := CompleteLattice.toConditionallyCompleteLattice
+  __ := h
 
 namespace OrderDual
 
 instance instConditionallyCompleteLattice (α : Type*) [ConditionallyCompleteLattice α] :
-    ConditionallyCompleteLattice αᵒᵈ :=
-  { OrderDual.instInf α, OrderDual.instSup α, OrderDual.instLattice α with
-    le_csSup := ConditionallyCompleteLattice.csInf_le (α := α)
-    csSup_le := ConditionallyCompleteLattice.le_csInf (α := α)
-    le_csInf := ConditionallyCompleteLattice.csSup_le (α := α)
-    csInf_le := ConditionallyCompleteLattice.le_csSup (α := α) }
+    ConditionallyCompleteLattice αᵒᵈ where
+  le_csSup := ConditionallyCompleteLattice.csInf_le (α := α)
+  csSup_le := ConditionallyCompleteLattice.le_csInf (α := α)
+  le_csInf := ConditionallyCompleteLattice.csSup_le (α := α)
+  csInf_le := ConditionallyCompleteLattice.le_csSup (α := α)
 
-instance (α : Type*) [ConditionallyCompleteLinearOrder α] : ConditionallyCompleteLinearOrder αᵒᵈ :=
-  { OrderDual.instConditionallyCompleteLattice α, OrderDual.instLinearOrder α with
-    csSup_of_not_bddAbove := ConditionallyCompleteLinearOrder.csInf_of_not_bddBelow (α := α)
-    csInf_of_not_bddBelow := ConditionallyCompleteLinearOrder.csSup_of_not_bddAbove (α := α) }
+instance (α : Type*) [ConditionallyCompleteLinearOrder α] :
+    ConditionallyCompleteLinearOrder αᵒᵈ where
+  csSup_of_not_bddAbove := ConditionallyCompleteLinearOrder.csInf_of_not_bddBelow (α := α)
+  csInf_of_not_bddBelow := ConditionallyCompleteLinearOrder.csSup_of_not_bddAbove (α := α)
+  __ := OrderDual.instConditionallyCompleteLattice α
+  __ := OrderDual.instLinearOrder α
 
 end OrderDual
 
@@ -436,18 +437,17 @@ lemma inf_eq_bot_of_bot_mem [OrderBot α] (h : ⊥ ∈ s) : sInf s = ⊥ :=
 end ConditionallyCompleteLattice
 
 instance Pi.conditionallyCompleteLattice {ι : Type*} {α : ι → Type*}
-    [∀ i, ConditionallyCompleteLattice (α i)] : ConditionallyCompleteLattice (∀ i, α i) :=
-  { Pi.instLattice, Pi.supSet, Pi.infSet with
-    le_csSup := fun _ f ⟨g, hg⟩ hf i =>
-      le_csSup ⟨g i, Set.forall_mem_range.2 fun ⟨_, hf'⟩ => hg hf' i⟩ ⟨⟨f, hf⟩, rfl⟩
-    csSup_le := fun s _ hs hf i =>
-      (csSup_le (by haveI := hs.to_subtype; apply range_nonempty)) fun _ ⟨⟨_, hg⟩, hb⟩ =>
-        hb ▸ hf hg i
-    csInf_le := fun _ f ⟨g, hg⟩ hf i =>
-      csInf_le ⟨g i, Set.forall_mem_range.2 fun ⟨_, hf'⟩ => hg hf' i⟩ ⟨⟨f, hf⟩, rfl⟩
-    le_csInf := fun s _ hs hf i =>
-      (le_csInf (by haveI := hs.to_subtype; apply range_nonempty)) fun _ ⟨⟨_, hg⟩, hb⟩ =>
-        hb ▸ hf hg i }
+    [∀ i, ConditionallyCompleteLattice (α i)] : ConditionallyCompleteLattice (∀ i, α i) where
+  le_csSup := fun _ f ⟨g, hg⟩ hf i =>
+    le_csSup ⟨g i, Set.forall_mem_range.2 fun ⟨_, hf'⟩ => hg hf' i⟩ ⟨⟨f, hf⟩, rfl⟩
+  csSup_le := fun s _ hs hf i =>
+    (csSup_le (by haveI := hs.to_subtype; apply range_nonempty)) fun _ ⟨⟨_, hg⟩, hb⟩ =>
+      hb ▸ hf hg i
+  csInf_le := fun _ f ⟨g, hg⟩ hf i =>
+    csInf_le ⟨g i, Set.forall_mem_range.2 fun ⟨_, hf'⟩ => hg hf' i⟩ ⟨⟨f, hf⟩, rfl⟩
+  le_csInf := fun s _ hs hf i =>
+    (le_csInf (by haveI := hs.to_subtype; apply range_nonempty)) fun _ ⟨⟨_, hg⟩, hb⟩ =>
+      hb ▸ hf hg i
 
 section ConditionallyCompleteLinearOrder
 
@@ -932,22 +932,20 @@ This result can be used to show that the extended reals `[-∞, ∞]` are a comp
 /-- Adding a top element to a conditionally complete lattice
 gives a conditionally complete lattice -/
 noncomputable instance WithTop.conditionallyCompleteLattice {α : Type*}
-    [ConditionallyCompleteLattice α] : ConditionallyCompleteLattice (WithTop α) :=
-  { lattice, instSupSet, instInfSet with
-    le_csSup := fun _ a _ haS => (WithTop.isLUB_sSup' ⟨a, haS⟩).1 haS
-    csSup_le := fun _ _ hS haS => (WithTop.isLUB_sSup' hS).2 haS
-    csInf_le := fun _ _ hS haS => (WithTop.isGLB_sInf' hS).1 haS
-    le_csInf := fun _ a _ haS => (WithTop.isGLB_sInf' ⟨a, haS⟩).2 haS }
+    [ConditionallyCompleteLattice α] : ConditionallyCompleteLattice (WithTop α) where
+  le_csSup := fun _ a _ haS => (WithTop.isLUB_sSup' ⟨a, haS⟩).1 haS
+  csSup_le := fun _ _ hS haS => (WithTop.isLUB_sSup' hS).2 haS
+  csInf_le := fun _ _ hS haS => (WithTop.isGLB_sInf' hS).1 haS
+  le_csInf := fun _ a _ haS => (WithTop.isGLB_sInf' ⟨a, haS⟩).2 haS
 
 /-- Adding a bottom element to a conditionally complete lattice
 gives a conditionally complete lattice -/
 noncomputable instance WithBot.conditionallyCompleteLattice {α : Type*}
-    [ConditionallyCompleteLattice α] : ConditionallyCompleteLattice (WithBot α) :=
-  { WithBot.lattice with
-    le_csSup := (WithTop.conditionallyCompleteLattice (α := αᵒᵈ)).csInf_le
-    csSup_le := (WithTop.conditionallyCompleteLattice (α := αᵒᵈ)).le_csInf
-    csInf_le := (WithTop.conditionallyCompleteLattice (α := αᵒᵈ)).le_csSup
-    le_csInf := (WithTop.conditionallyCompleteLattice (α := αᵒᵈ)).csSup_le }
+    [ConditionallyCompleteLattice α] : ConditionallyCompleteLattice (WithBot α) where
+  le_csSup := (WithTop.conditionallyCompleteLattice (α := αᵒᵈ)).csInf_le
+  csSup_le := (WithTop.conditionallyCompleteLattice (α := αᵒᵈ)).le_csInf
+  csInf_le := (WithTop.conditionallyCompleteLattice (α := αᵒᵈ)).le_csSup
+  le_csInf := (WithTop.conditionallyCompleteLattice (α := αᵒᵈ)).csSup_le
 
 noncomputable instance [CompleteLattice α] : CompleteLattice (WithBot α) where
   le_sSup s a has := le_csSup (OrderTop.bddAbove _) has
@@ -959,29 +957,28 @@ noncomputable instance [CompleteLattice α] : CompleteLattice (WithBot α) where
 
 open Classical in
 noncomputable instance WithTop.WithBot.completeLattice {α : Type*}
-    [ConditionallyCompleteLattice α] : CompleteLattice (WithTop (WithBot α)) :=
-  { instInfSet, instSupSet, boundedOrder, lattice with
-    le_sSup := fun _ a haS => (WithTop.isLUB_sSup' ⟨a, haS⟩).1 haS
-    sSup_le := fun S a ha => by
-      rcases S.eq_empty_or_nonempty with h | h
-      · change ite _ _ _ ≤ a
-        simp [h]
-      · exact (WithTop.isLUB_sSup' h).2 ha
-    sInf_le := fun S a haS =>
-      show ite _ _ _ ≤ a by
-        simp only [OrderBot.bddBelow, not_true_eq_false, or_false]
-        split_ifs with h₁
-        · cases a
-          · exact le_rfl
-          cases h₁ haS
-        · cases a
-          · exact le_top
-          · apply WithTop.coe_le_coe.2
-            refine csInf_le ?_ haS
-            use ⊥
-            intro b _
-            exact bot_le
-    le_sInf := fun _ a haS => (WithTop.isGLB_sInf' ⟨a, haS⟩).2 haS }
+    [ConditionallyCompleteLattice α] : CompleteLattice (WithTop (WithBot α)) where
+  le_sSup := fun _ a haS => (WithTop.isLUB_sSup' ⟨a, haS⟩).1 haS
+  sSup_le := fun S a ha => by
+    rcases S.eq_empty_or_nonempty with h | h
+    · change ite _ _ _ ≤ a
+      simp [h]
+    · exact (WithTop.isLUB_sSup' h).2 ha
+  sInf_le := fun S a haS =>
+    show ite _ _ _ ≤ a by
+      simp only [OrderBot.bddBelow, not_true_eq_false, or_false]
+      split_ifs with h₁
+      · cases a
+        · exact le_rfl
+        cases h₁ haS
+      · cases a
+        · exact le_top
+        · apply WithTop.coe_le_coe.2
+          refine csInf_le ?_ haS
+          use ⊥
+          intro b _
+          exact bot_le
+  le_sInf := fun _ a haS => (WithTop.isGLB_sInf' ⟨a, haS⟩).2 haS
 
 noncomputable instance WithTop.WithBot.completeLinearOrder {α : Type*}
     [ConditionallyCompleteLinearOrder α] : CompleteLinearOrder (WithTop (WithBot α)) where
@@ -990,12 +987,11 @@ noncomputable instance WithTop.WithBot.completeLinearOrder {α : Type*}
   __ := linearOrder.toBiheytingAlgebra
 
 noncomputable instance WithBot.WithTop.completeLattice {α : Type*}
-    [ConditionallyCompleteLattice α] : CompleteLattice (WithBot (WithTop α)) :=
-  { instInfSet, instSupSet, instBoundedOrder, lattice with
-    le_sSup := (WithTop.WithBot.completeLattice (α := αᵒᵈ)).sInf_le
-    sSup_le := (WithTop.WithBot.completeLattice (α := αᵒᵈ)).le_sInf
-    sInf_le := (WithTop.WithBot.completeLattice (α := αᵒᵈ)).le_sSup
-    le_sInf := (WithTop.WithBot.completeLattice (α := αᵒᵈ)).sSup_le }
+    [ConditionallyCompleteLattice α] : CompleteLattice (WithBot (WithTop α)) where
+  le_sSup := (WithTop.WithBot.completeLattice (α := αᵒᵈ)).sInf_le
+  sSup_le := (WithTop.WithBot.completeLattice (α := αᵒᵈ)).le_sInf
+  sInf_le := (WithTop.WithBot.completeLattice (α := αᵒᵈ)).le_sSup
+  le_sInf := (WithTop.WithBot.completeLattice (α := αᵒᵈ)).sSup_le
 
 noncomputable instance WithBot.WithTop.completeLinearOrder {α : Type*}
     [ConditionallyCompleteLinearOrder α] : CompleteLinearOrder (WithBot (WithTop α)) where


### PR DESCRIPTION
There are some equivalent instances in `OrderBot` and `OrderTop` with different names (see e.g. [`WithBot.instBoundedOrder`](https://leanprover-community.github.io/mathlib4_docs/Mathlib/Order/WithBot.html#WithBot.instBoundedOrder) vs [`WithTop.boundedOrder`](https://leanprover-community.github.io/mathlib4_docs/Mathlib/Order/WithBot.html#WithTop.boundedOrder)). This leads to some annoyance when adding `to_dual` attributes. So instead we try to avoid explicitly calling these instances altogether by using the newer `where` notation.

---
<!-- Your PR title will become the first line of the commit message.

In this box, the text above the `---` (if not empty) will be appended
to the commit message, and can be used to give additional context or
details. Please leave a blank newline before the `---`, otherwise GitHub
will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

When merging, all the commits will be squashed into a single commit
listing all co-authors.

Co-authors in the squash commit are gathered from two sources:

First, all authors of commits to this PR branch are included. Thus,
one way to add co-authors is to include at least one commit authored by
each co-author among the commits in the pull request. If necessary, you
may create empty commits to indicate co-authorship, using commands like so:

git commit --author="Author Name <author@email.com>" --allow-empty -m "add Author Name as coauthor"

Second, co-authors can also be listed in lines at the very bottom of
the commit message (that is, directly before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines
at the bottom of the commit message (before the `---`, and also before
any "Co-authored-by" lines) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
