### PR TITLE
[Merged by Bors] - feat: import Lean.LibrarySuggestions.Default in Mathlib.Init

### DIFF
--- a/Mathlib/Init.lean
+++ b/Mathlib/Init.lean
@@ -1,6 +1,7 @@
 module
 
 public import Lean.Linter.Sets -- for the definition of linter sets
+public import Lean.LibrarySuggestions.Default -- for `+suggestions` modes in tactics
 public import Mathlib.Tactic.Linter.CommandStart
 public import Mathlib.Tactic.Linter.DeprecatedSyntaxLinter
 public import Mathlib.Tactic.Linter.DirectoryDependency


### PR DESCRIPTION
This PR adds `public import Lean.LibrarySuggestions.Default` to `Mathlib/Init.lean`, to enable the `+suggestions` modes in tactics (like `grind +suggestions` and `simp +suggestions`) to work throughout Mathlib without requiring explicit imports

🤖 Generated with [Claude Code](https://claude.com/claude-code)