### PR TITLE
[Merged by Bors] - fix(TacticAnalysis): handle ppTactic failure on pseudo-antiquotations

### DIFF
--- a/Mathlib/Tactic/TacticAnalysis/Declarations.lean
+++ b/Mathlib/Tactic/TacticAnalysis/Declarations.lean
@@ -361,7 +361,10 @@ def Mathlib.TacticAnalysis.tryAtEachStepCore
               return ((← liftCoreM <| PrettyPrinter.ppTactic ⟨i.tacI.stx⟩).pretty.splitOn "\n")[0]!.trim
             catch _ =>
               return i.tacI.stx.reprint.getD "???")
-            let newTacticPP ← label.getDM (return ((← liftCoreM <| PrettyPrinter.ppTactic tac).pretty.splitOn "\n")[0]!.trim)
+            let newTacticPP := (← try
+              return ((← liftCoreM <| PrettyPrinter.ppTactic tac).pretty.splitOn "\n")[0]!.trim
+            catch _ =>
+              return tac.reprint.getD "???")
             -- Check if this is a self-replacement (tactic replacing itself)
             if !selfReplacements && oldTacticPP == newTacticPP then
               continue

--- a/Mathlib/Tactic/TacticAnalysis/Declarations.lean
+++ b/Mathlib/Tactic/TacticAnalysis/Declarations.lean
@@ -356,7 +356,11 @@ def Mathlib.TacticAnalysis.tryAtEachStepCore
           let elapsedMs := (← IO.monoMsNow) - startTime
           if goalsAfter.isEmpty then
             -- Extract just the tactic name, ignoring trailing comments/whitespace
-            let oldTacticPP := ((← liftCoreM <| PrettyPrinter.ppTactic ⟨i.tacI.stx⟩).pretty.splitOn "\n")[0]!.trim
+            -- Use try/catch because ppTactic can fail on certain syntax (e.g., `congr($h x)`)
+            let oldTacticPP := (← try
+              return ((← liftCoreM <| PrettyPrinter.ppTactic ⟨i.tacI.stx⟩).pretty.splitOn "\n")[0]!.trim
+            catch _ =>
+              return i.tacI.stx.reprint.getD "???")
             let newTacticPP ← label.getDM (return ((← liftCoreM <| PrettyPrinter.ppTactic tac).pretty.splitOn "\n")[0]!.trim)
             -- Check if this is a self-replacement (tactic replacing itself)
             if !selfReplacements && oldTacticPP == newTacticPP then

--- a/Mathlib/Tactic/TacticAnalysis/Declarations.lean
+++ b/Mathlib/Tactic/TacticAnalysis/Declarations.lean
@@ -364,7 +364,7 @@ def Mathlib.TacticAnalysis.tryAtEachStepCore
             let newTacticPP := (← try
               return ((← liftCoreM <| PrettyPrinter.ppTactic tac).pretty.splitOn "\n")[0]!.trim
             catch _ =>
-              return tac.reprint.getD "???")
+              return tac.stx.reprint.getD "???")
             -- Check if this is a self-replacement (tactic replacing itself)
             if !selfReplacements && oldTacticPP == newTacticPP then
               continue

--- a/Mathlib/Tactic/TacticAnalysis/Declarations.lean
+++ b/Mathlib/Tactic/TacticAnalysis/Declarations.lean
@@ -364,7 +364,7 @@ def Mathlib.TacticAnalysis.tryAtEachStepCore
             let newTacticPP := (← try
               return ((← liftCoreM <| PrettyPrinter.ppTactic tac).pretty.splitOn "\n")[0]!.trim
             catch _ =>
-              return tac.stx.reprint.getD "???")
+              return tac.raw.reprint.getD "???")
             -- Check if this is a self-replacement (tactic replacing itself)
             if !selfReplacements && oldTacticPP == newTacticPP then
               continue

--- a/Mathlib/Tactic/TacticAnalysis/Declarations.lean
+++ b/Mathlib/Tactic/TacticAnalysis/Declarations.lean
@@ -361,7 +361,7 @@ def Mathlib.TacticAnalysis.tryAtEachStepCore
               return ((← liftCoreM <| PrettyPrinter.ppTactic ⟨i.tacI.stx⟩).pretty.splitOn "\n")[0]!.trim
             catch _ =>
               return i.tacI.stx.reprint.getD "???")
-            let newTacticPP := (← try
+            let newTacticPP ← label.getDM (try
               return ((← liftCoreM <| PrettyPrinter.ppTactic tac).pretty.splitOn "\n")[0]!.trim
             catch _ =>
               return tac.raw.reprint.getD "???")


### PR DESCRIPTION
This PR the wraps `PrettyPrinter.ppTactic` call in the tactic analysis linter in try/catch in `tryAtEachStepCore`

`PrettyPrinter.ppTactic` can fail on certain syntax nodes like `congr($h x)` which use `term.pseudo.antiquot`. This causes the tactic analysis linter to crash with:
```
error: Mathlib/Algebra/Module/LinearMap/Defs.lean:812:0: linter Mathlib.TacticAnalysis.tacticAnalysis failed: Unknown constant `term.pseudo.antiquot`
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)