### PR TITLE
[Merged by Bors] - chore: clean up imports from #31746

### DIFF
--- a/Mathlib/Data/Int/Cast/Basic.lean
+++ b/Mathlib/Data/Int/Cast/Basic.lean
@@ -47,7 +47,14 @@ open Nat
 
 namespace Int
 
-variable {R : Type u} [AddGroupWithOne R]
+variable {R : Type u}
+
+@[simp, norm_cast]
+theorem cast_ite [IntCast R] (P : Prop) [Decidable P] (m n : ℤ) :
+    ((ite P m n : ℤ) : R) = ite P (m : R) (n : R) :=
+  apply_ite _ _ _ _
+
+variable [AddGroupWithOne R]
 
 -- TODO: I don't like that `norm_cast` is used here, because it results in `norm_cast`
 -- introducing the "implementation detail" `Int.negSucc`.

--- a/Mathlib/Data/Int/Cast/Lemmas.lean
+++ b/Mathlib/Data/Int/Cast/Lemmas.lean
@@ -39,11 +39,6 @@ def ofNatHom : ℕ →+* ℤ :=
 
 section cast
 
-@[simp, norm_cast]
-theorem cast_ite [IntCast α] (P : Prop) [Decidable P] (m n : ℤ) :
-    ((ite P m n : ℤ) : α) = ite P (m : α) (n : α) :=
-  apply_ite _ _ _ _
-
 /-- `coe : ℤ → α` as an `AddMonoidHom`. -/
 def castAddHom (α : Type*) [AddGroupWithOne α] : ℤ →+ α where
   toFun := Int.cast

--- a/Mathlib/Data/Matrix/Diagonal.lean
+++ b/Mathlib/Data/Matrix/Diagonal.lean
@@ -5,13 +5,11 @@ Authors: Ellen Arlt, Blair Shi, Sean Leather, Mario Carneiro, Johan Commelin, Lu
 -/
 module
 
-public import Mathlib.Data.Int.Cast.Basic
+public import Mathlib.Data.Int.Cast.Lemmas
 public import Mathlib.Data.Int.Cast.Pi
 public import Mathlib.Data.Nat.Cast.Basic
 public import Mathlib.LinearAlgebra.Matrix.Defs
 public import Mathlib.Logic.Embedding.Basic
-
-import Mathlib.Data.Int.Cast.Lemmas
 
 /-!
 # Diagonal matrices

--- a/Mathlib/Data/Matrix/Diagonal.lean
+++ b/Mathlib/Data/Matrix/Diagonal.lean
@@ -5,7 +5,7 @@ Authors: Ellen Arlt, Blair Shi, Sean Leather, Mario Carneiro, Johan Commelin, Lu
 -/
 module
 
-public import Mathlib.Data.Int.Cast.Lemmas
+public import Mathlib.Data.Int.Cast.Basic
 public import Mathlib.Data.Int.Cast.Pi
 public import Mathlib.Data.Nat.Cast.Basic
 public import Mathlib.LinearAlgebra.Matrix.Defs


### PR DESCRIPTION
#31746 added `Data.Int.Cast.Lemmas` as a new import to `LinearAlgebra.Matrix.Diagonal` to access `Int.cast_ite` but did not remove `Data.Int.Cast.Basic` and did not do a public import. Following `Nat.cast_ite`, we move `Data.Int.Cast.Basic` and remove the added import.

---
<!-- Your PR title will become the first line of the commit message.

In this box, the text above the `---` (if not empty) will be appended
to the commit message, and can be used to give additional context or
details. Please leave a blank newline before the `---`, otherwise GitHub
will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

When merging, all the commits will be squashed into a single commit
listing all co-authors.

Co-authors in the squash commit are gathered from two sources:

First, all authors of commits to this PR branch are included. Thus,
one way to add co-authors is to include at least one commit authored by
each co-author among the commits in the pull request. If necessary, you
may create empty commits to indicate co-authorship, using commands like so:

git commit --author="Author Name <author@email.com>" --allow-empty -m "add Author Name as coauthor"

Second, co-authors can also be listed in lines at the very bottom of
the commit message (that is, directly before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines
at the bottom of the commit message (before the `---`, and also before
any "Co-authored-by" lines) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
