### PR TITLE
[Merged by Bors] - feat(Topology): sandwich lemmas for profinite sets

### DIFF
--- a/Mathlib/Topology/Separation/Profinite.lean
+++ b/Mathlib/Topology/Separation/Profinite.lean
@@ -147,7 +147,7 @@ lemma exists_clopen_of_closed_subset_open {X : Type*}
 /-- Let `X` be a totally disconnected compact Hausdorff space, `D i ⊆ X` a finite family of clopens,
 and `Z i ⊆ D i` closed. Assume that the `Z i` are pairwise disjoint. Then there exist clopens
 `Z i ⊆ C i ⊆ D i` with the `C i` disjoint, and such that `∪ D i ⊆ ∪ C i`. -/
-lemma exists_clopen_partition_of_closed_partition
+lemma exists_clopen_partition_of_clopen_cover
     {X I : Type*} [TopologicalSpace X] [CompactSpace X] [T2Space X] [TotallyDisconnectedSpace X]
     [Finite I] {Z D : I → Set X}
     (Z_closed : ∀ i, IsClosed (Z i)) (D_clopen : ∀ i, IsClopen (D i))

--- a/Mathlib/Topology/Separation/Profinite.lean
+++ b/Mathlib/Topology/Separation/Profinite.lean
@@ -5,6 +5,7 @@ Authors: Johannes Hölzl, Mario Carneiro
 -/
 module
 
+public import Mathlib.Data.Fintype.Option
 public import Mathlib.Topology.Separation.Regular
 public import Mathlib.Topology.Connected.TotallyDisconnected
 
@@ -127,5 +128,98 @@ theorem loc_compact_t2_tot_disc_iff_tot_sep :
 /-- A totally disconnected compact Hausdorff space is totally separated. -/
 instance (priority := 100) [TotallyDisconnectedSpace H] : TotallySeparatedSpace H :=
   loc_compact_t2_tot_disc_iff_tot_sep.mp inferInstance
+
+/-- In a totally disconnected compact Hausdorff space `X`, if `Z ⊆ U` are subsets with `Z` closed
+and `U` open, there exists a clopen `C` with `Z ⊆ C ⊆ U`. -/
+lemma exists_clopen_of_closed_subset_open {X : Type*}
+    [TopologicalSpace X] [CompactSpace X] [T2Space X] [TotallyDisconnectedSpace X]
+    {Z U : Set X} (hZ : IsClosed Z) (hU : IsOpen U) (hZU : Z ⊆ U) :
+    ∃ C : Set X, IsClopen C ∧ Z ⊆ C ∧ C ⊆ U := by
+  -- every `z ∈ Z` has clopen neighborhood `V z ⊆ U`
+  choose V hV using fun (z : Z) ↦ compact_exists_isClopen_in_isOpen hU (hZU z.property)
+  -- the `V z` cover `Z`
+  have V_cover : Z ⊆ ⋃ z, V z := fun z hz ↦ mem_iUnion.mpr ⟨⟨z, hz⟩, (hV ⟨z, hz⟩).2.1⟩
+  -- choose a finite subcover
+  choose I hI using hZ.isCompact.elim_finite_subcover V (fun z ↦ (hV z).1.isOpen) V_cover
+  -- the union of this finite subcover does the job
+  exact ⟨⋃ (i ∈ I), V i, I.finite_toSet.isClopen_biUnion (fun i _ ↦ (hV i).1), hI, by simp_all⟩
+
+/-- Let `X` be a totally disconnected compact Hausdorff space, `D i ⊆ X` a finite family of clopens,
+and `Z i ⊆ D i` closed. Assume that the `Z i` are pairwise disjoint. Then there exist clopens
+`Z i ⊆ C i ⊆ D i` with the `C i` disjoint, and such that `∪ D i ⊆ ∪ C i`. -/
+lemma exists_clopen_partition_of_closed_partition
+    {X I : Type*} [TopologicalSpace X] [CompactSpace X] [T2Space X] [TotallyDisconnectedSpace X]
+    [Finite I] {Z D : I → Set X}
+    (Z_closed : ∀ i, IsClosed (Z i)) (D_clopen : ∀ i, IsClopen (D i))
+    (Z_subset_D : ∀ i, Z i ⊆ D i) (Z_disj : univ.PairwiseDisjoint Z) :
+    ∃ C : I → Set X, (∀ i, IsClopen (C i)) ∧ (∀ i, Z i ⊆ C i) ∧ (∀ i, C i ⊆ D i) ∧
+    (⋃ i, D i) ⊆ (⋃ i, C i) ∧ (univ.PairwiseDisjoint C) := by
+  induction I using Finite.induction_empty_option with
+  | of_equiv e IH =>
+    obtain ⟨C, h1, h2, h3, h4, h5⟩ := IH (Z := Z ∘ e) (D := D ∘ e)
+      (fun i ↦ Z_closed (e i)) (fun i ↦ D_clopen (e i))
+      (fun i ↦ Z_subset_D (e i)) (by simpa [← e.injective.injOn.pairwiseDisjoint_image])
+    refine ⟨C ∘ e.symm, fun i ↦ h1 (e.symm i), fun i ↦ by simpa using h2 (e.symm i),
+      fun i ↦ by simpa using h3 (e.symm i), ?_,
+      by simpa [← e.symm.injective.injOn.pairwiseDisjoint_image]⟩
+    simp only [Function.comp_apply, iUnion_subset_iff] at h4
+    simpa [e.symm.surjective.iUnion_comp C] using fun i ↦ h4 (e.symm i)
+  | h_empty => exact ⟨fun _ ↦ univ, by simp, by simp, by simp, by simp, fun i ↦ PEmpty.elim i⟩
+  | @h_option I _ IH =>
+    -- let `Z'` be the restriction of `Z` along `some : I → Option I`
+    let Z' : I → Set X := fun i ↦ Z (some i)
+    have Z'_closed (i : I) : IsClosed (Z (some i)) := Z_closed (some i)
+    have Z'_disj : univ.PairwiseDisjoint (Z ∘ some) := by
+      rw [← (Option.some_injective _).injOn.pairwiseDisjoint_image]
+      exact PairwiseDisjoint.subset Z_disj (by simp)
+    -- find `Z none ⊆ V ⊆ D none \ ⋃ Z'` using `exists_clopen_of_closed_subset_open`
+    let U : Set X := D none \ ⋃ i, Z (some i)
+    have U_open : IsOpen U := IsOpen.sdiff (D_clopen none).2
+      (isClosed_iUnion_of_finite (fun i ↦ Z_closed (some i)))
+    have Z0_subset_U : Z none ⊆ U := by
+      rw [subset_diff]
+      simpa using ⟨Z_subset_D none, fun i ↦ (by apply Z_disj; all_goals simp)⟩
+    obtain ⟨V, V_clopen, Z0_subset_V, V_subset_U⟩ :=
+      exists_clopen_of_closed_subset_open (Z_closed none) U_open Z0_subset_U
+    have V_subset_D0 : V ⊆ D none := subset_trans V_subset_U diff_subset
+    -- choose `Z' i ⊆ C' i ⊆ D' i = D i.succ \ V` using the inductive hypothesis
+    let D' : I → Set X := fun i ↦ D (some i) \ V
+    have D'_clopen (i : I): IsClopen (D' i) := (D_clopen (some i)).diff V_clopen
+    have Z'_subset_D' (i : I) : Z' i ⊆ D' i := by
+      rw [subset_diff]
+      refine ⟨by grind, Disjoint.mono_right V_subset_U ?_⟩
+      exact Disjoint.mono_left (subset_iUnion_of_subset i fun _ h ↦ h) (by grind)
+    obtain ⟨C', C'_clopen, Z'_subset_C', C'_subset_D', C'_cover_D', C'_disj⟩ :=
+      IH Z'_closed D'_clopen Z'_subset_D' Z'_disj
+    -- now choose `C0 = D none \ ⋃ C' i`
+    let C0 : Set X := D none \ ⋃ i, C' i
+    have : IsClopen C0 := (D_clopen none).diff (isClopen_iUnion_of_finite C'_clopen)
+    have : Z none ⊆ C0 := by
+      simp only [C0, subset_diff]
+      exact ⟨by grind, Disjoint.mono_left Z0_subset_V (by simpa using by grind)⟩
+    -- patch together to define `C none := C0`, `C (some i) := C' i`
+    -- and verify the needed properties
+    let C : Option I → Set X := fun i ↦ Option.casesOn i C0 C'
+    refine ⟨C, ?_, ?_, ?_, ?_, ?_⟩
+    all_goals try rintro (_ | i); all_goals grind
+    · intro x hx
+      rw [mem_iUnion] at hx ⊢
+      by_cases hx0 : x ∈ C0; { exact ⟨none, hx0⟩ }
+      by_cases hxD : x ∈ D none
+      · have hxC' : x ∈ ⋃ i, C' i := by grind
+        obtain ⟨i, hi⟩ := mem_iUnion.mp hxC'
+        exact ⟨some i, hi⟩
+      · obtain ⟨none | j, hi⟩ := hx; {grind}
+        have hxD' : x ∈ ⋃ i, D' i := mem_iUnion.mpr ⟨j, by grind⟩
+        obtain ⟨k, hk⟩ := mem_iUnion.mp <| C'_cover_D' hxD'
+        exact ⟨some k, hk⟩
+    · rw [Set.pairwiseDisjoint_iff]
+      rintro (_ | i) _ (_ | j) _
+      · simp
+      · simpa [C, C0, Set.not_nonempty_iff_eq_empty, ← Set.disjoint_iff_inter_eq_empty] using
+          Disjoint.mono_right (subset_iUnion C' j) disjoint_sdiff_left
+      · simpa [C, C0, Set.not_nonempty_iff_eq_empty, ← Set.disjoint_iff_inter_eq_empty] using
+          Disjoint.mono_left (subset_iUnion C' i) disjoint_sdiff_right
+      · simpa using (Set.pairwiseDisjoint_iff.mp C'_disj) (by trivial) (by trivial)
 
 end LocallyCompact


### PR DESCRIPTION
We add two lemmas: 
- `exists_clopen_of_closed_subset_open`: in a totally disconnected compact Hausdorff space `X`, if `Z ⊆ U` are subsets with `Z` closed and `U` open, there exists a clopen `C` with `Z ⊆ C ⊆ U`.
- `exists_clopen_partition_of_clopen_cover`: Let `X` be a totally disconnected compact Hausdorff space, `D i ⊆ X` a finite family of clopens, and `Z i ⊆ D i` closed. Assume that the `Z i` are pairwise disjoint. Then there exist clopens `Z i ⊆ C i ⊆ D i` with the `C i` disjoint, and such that `∪ D i ⊆ ∪ C i`.

These are required to prove injectivity of light profinite sets, see #31754

---
<!-- Your PR title will become the first line of the commit message.

In this box, the text above the `---` (if not empty) will be appended
to the commit message, and can be used to give additional context or
details. Please leave a blank newline before the `---`, otherwise GitHub
will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

When merging, all the commits will be squashed into a single commit
listing all co-authors.

Co-authors in the squash commit are gathered from two sources:

First, all authors of commits to this PR branch are included. Thus,
one way to add co-authors is to include at least one commit authored by
each co-author among the commits in the pull request. If necessary, you
may create empty commits to indicate co-authorship, using commands like so:

git commit --author="Author Name <author@email.com>" --allow-empty -m "add Author Name as coauthor"

Second, co-authors can also be listed in lines at the very bottom of
the commit message (that is, directly before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines
at the bottom of the commit message (before the `---`, and also before
any "Co-authored-by" lines) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
