### PR TITLE
[Merged by Bors] - chore: fix performance regression in `normal_iSup`

### DIFF
--- a/Mathlib/FieldTheory/Normal/Basic.lean
+++ b/Mathlib/FieldTheory/Normal/Basic.lean
@@ -111,7 +111,7 @@ instance normal_iSup {ι : Type*} (t : ι → IntermediateField F K) [h : ∀ i,
     exact fun _ ⟨a, _, h⟩ => h ▸ a.2
   have := hF.splits ⟨x, hx⟩
   rw [minpoly_eq, Subtype.coe_mk, ← minpoly_eq] at this
-  have := this.map (inclusion hE).toRingHom
+  have := this.map (inclusion hE).toRingHom -- necessary for performance reasons
   rwa [Polynomial.map_map] at this
 
 /-- If a set of algebraic elements in a field extension `K/F` have minimal polynomials that

--- a/Mathlib/FieldTheory/Normal/Basic.lean
+++ b/Mathlib/FieldTheory/Normal/Basic.lean
@@ -111,7 +111,8 @@ instance normal_iSup {ι : Type*} (t : ι → IntermediateField F K) [h : ∀ i,
     exact fun _ ⟨a, _, h⟩ => h ▸ a.2
   have := hF.splits ⟨x, hx⟩
   rw [minpoly_eq, Subtype.coe_mk, ← minpoly_eq] at this
-  simpa [Polynomial.map_map] using this.map (inclusion hE).toRingHom
+  have := this.map (inclusion hE).toRingHom
+  rwa [Polynomial.map_map] at this
 
 /-- If a set of algebraic elements in a field extension `K/F` have minimal polynomials that
   split in another extension `L/F`, then all minimal polynomials in the intermediate field


### PR DESCRIPTION
PR #32574 inadvertently introduced a performance regression in `normal_iSup`. This PR aims to fix this.

---
<!-- Your PR title will become the first line of the commit message.

In this box, the text above the `---` (if not empty) will be appended
to the commit message, and can be used to give additional context or
details. Please leave a blank newline before the `---`, otherwise GitHub
will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

When merging, all the commits will be squashed into a single commit
listing all co-authors.

Co-authors in the squash commit are gathered from two sources:

First, all authors of commits to this PR branch are included. Thus,
one way to add co-authors is to include at least one commit authored by
each co-author among the commits in the pull request. If necessary, you
may create empty commits to indicate co-authorship, using commands like so:

git commit --author="Author Name <author@email.com>" --allow-empty -m "add Author Name as coauthor"

Second, co-authors can also be listed in lines at the very bottom of
the commit message (that is, directly before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines
at the bottom of the commit message (before the `---`, and also before
any "Co-authored-by" lines) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
