### PR TITLE
[Merged by Bors] - chore: replace `omega` with `lia` where possible

### DIFF
--- a/Archive/Imo/Imo1960Q1.lean
+++ b/Archive/Imo/Imo1960Q1.lean
@@ -45,14 +45,14 @@ theorem ge_100 {n : ℕ} (h1 : ProblemPredicate n) : 100 ≤ n := by
     rw [← h1.left]
     refine Nat.base_pow_length_digits_le 10 n ?_ (not_zero h1)
     simp
-  omega
+  lia
 
 theorem lt_1000 {n : ℕ} (h1 : ProblemPredicate n) : n < 1000 := by
   have h2 : n < 10 ^ 3 := by
     rw [← h1.left]
     refine Nat.lt_base_pow_length_digits ?_
     simp
-  omega
+  lia
 
 /-
 We do an exhaustive search to show that all results are covered by `SolutionPredicate`.

--- a/Archive/Imo/Imo1960Q1.lean
+++ b/Archive/Imo/Imo1960Q1.lean
@@ -70,7 +70,7 @@ theorem searchUpTo_step {c n} (H : SearchUpTo c n) {c' n'} (ec : c + 1 = c') (en
   refine ⟨by ring, fun m l p => ?_⟩
   obtain ⟨h₁, ⟨m, rfl⟩, h₂⟩ := id p
   by_cases h : 11 * m < c * 11; · exact H _ h p
-  obtain rfl : m = c := by omega
+  obtain rfl : m = c := by lia
   rw [Nat.mul_div_cancel_left _ (by simp : 11 > 0), mul_comm] at h₂
   refine (H' h₂).imp ?_ ?_ <;> · rintro rfl; norm_num
 

--- a/Archive/Imo/Imo1962Q1.lean
+++ b/Archive/Imo/Imo1962Q1.lean
@@ -53,31 +53,31 @@ Now we can eliminate possibilities for `(digits 10 c).length` until we get to th
 lemma case_0_digits {c n : ℕ} (hc : (digits 10 c).length = 0) : ¬ProblemPredicate' c n := by
   intro hpp
   have hpow : 6 * 10 ^ 0 = 6 * 10 ^ (digits 10 c).length := by rw [hc]
-  omega
+  lia
 
 lemma case_1_digits {c n : ℕ} (hc : (digits 10 c).length = 1) : ¬ProblemPredicate' c n := by
   intro hpp
   have hpow : 6 * 10 ^ 1 = 6 * 10 ^ (digits 10 c).length := by rw [hc]
-  omega
+  lia
 
 lemma case_2_digits {c n : ℕ} (hc : (digits 10 c).length = 2) : ¬ProblemPredicate' c n := by
   intro hpp
   have hpow : 6 * 10 ^ 2 = 6 * 10 ^ (digits 10 c).length := by rw [hc]
-  omega
+  lia
 
 lemma case_3_digits {c n : ℕ} (hc : (digits 10 c).length = 3) : ¬ProblemPredicate' c n := by
   intro hpp
   have hpow : 6 * 10 ^ 3 = 6 * 10 ^ (digits 10 c).length := by rw [hc]
-  omega
+  lia
 
 lemma case_4_digits {c n : ℕ} (hc : (digits 10 c).length = 4) : ¬ProblemPredicate' c n := by
   intro hpp
   have hpow : 6 * 10 ^ 4 = 6 * 10 ^ (digits 10 c).length := by rw [hc]
-  omega
+  lia
 
 /-- Putting this inline causes a deep recursion error, so we separate it out. -/
 private lemma helper_5_digits {c : ℤ} (hc : 6 * 10 ^ 5 + c = 4 * (10 * c + 6)) : c = 15384 := by
-  omega
+  lia
 
 lemma case_5_digits {c n : ℕ} (hc : (digits 10 c).length = 5) (hpp : ProblemPredicate' c n) :
     c = 15384 := by

--- a/Archive/Imo/Imo1985Q2.lean
+++ b/Archive/Imo/Imo1985Q2.lean
@@ -52,12 +52,12 @@ lemma C_mul_mod {n j : ℕ} (hn : 3 ≤ n) (hj : j ∈ Set.Ico 1 n) (cpj : Nat.C
       by_contra! h; nth_rw 2 [← Nat.mod_eq_of_lt hj.2, ← one_mul j] at h
       replace h : (k + 1) % n = 1 % n := Nat.ModEq.cancel_right_of_coprime cpj h
       rw [Nat.mod_eq_of_lt hk.2, Nat.mod_eq_of_lt (by lia)] at h
-      omega
+      lia
     have b₁ : (k + 1) * j % n ∈ Set.Ico 1 n := by
       refine ⟨?_, Nat.mod_lt _ (by lia)⟩
       by_contra! h; rw [Nat.lt_one_iff, ← Nat.dvd_iff_mod_eq_zero] at h
       have ek := Nat.eq_zero_of_dvd_of_lt (cpj.dvd_of_dvd_mul_right h) hk.2
-      omega
+      lia
     rw [← ih ⟨hk₁, Nat.lt_of_succ_lt hk.2⟩, hC.2 _ b₁ nej]
     rcases nej.lt_or_gt with h | h
     · rw [Int.natAbs_natCast_sub_natCast_of_ge h.le]

--- a/Archive/Imo/Imo1985Q2.lean
+++ b/Archive/Imo/Imo1985Q2.lean
@@ -51,10 +51,10 @@ lemma C_mul_mod {n j : ℕ} (hn : 3 ≤ n) (hj : j ∈ Set.Ico 1 n) (cpj : Nat.C
     have nej : (k + 1) * j % n ≠ j := by
       by_contra! h; nth_rw 2 [← Nat.mod_eq_of_lt hj.2, ← one_mul j] at h
       replace h : (k + 1) % n = 1 % n := Nat.ModEq.cancel_right_of_coprime cpj h
-      rw [Nat.mod_eq_of_lt hk.2, Nat.mod_eq_of_lt (by omega)] at h
+      rw [Nat.mod_eq_of_lt hk.2, Nat.mod_eq_of_lt (by lia)] at h
       omega
     have b₁ : (k + 1) * j % n ∈ Set.Ico 1 n := by
-      refine ⟨?_, Nat.mod_lt _ (by omega)⟩
+      refine ⟨?_, Nat.mod_lt _ (by lia)⟩
       by_contra! h; rw [Nat.lt_one_iff, ← Nat.dvd_iff_mod_eq_zero] at h
       have ek := Nat.eq_zero_of_dvd_of_lt (cpj.dvd_of_dvd_mul_right h) hk.2
       omega
@@ -65,8 +65,8 @@ lemma C_mul_mod {n j : ℕ} (hn : 3 ≤ n) (hj : j ∈ Set.Ico 1 n) (cpj : Nat.C
         ⟨Nat.sub_pos_iff_lt.mpr h, (Nat.sub_le ..).trans_lt hj.2⟩
       have q : n - (j - (k + 1) * j % n) = (k + 1) * j % n + (n - j) % n := by
         rw [tsub_tsub_eq_add_tsub_of_le h.le, add_comm, Nat.add_sub_assoc hj.2.le,
-          Nat.mod_eq_of_lt (show n - j < n by omega)]
-      rw [hC.1 _ b₂, q, ← Nat.add_mod_of_add_mod_lt (by omega), ← Nat.add_sub_assoc hj.2.le,
+          Nat.mod_eq_of_lt (show n - j < n by lia)]
+      rw [hC.1 _ b₂, q, ← Nat.add_mod_of_add_mod_lt (by lia), ← Nat.add_sub_assoc hj.2.le,
         add_comm, Nat.add_sub_assoc (Nat.le_mul_of_pos_left _ hk.1), ← tsub_one_mul,
         Nat.add_mod_left, add_tsub_cancel_right]
     · rw [Int.natAbs_natCast_sub_natCast_of_le h.le, Nat.mod_sub_of_le h.le]
@@ -75,13 +75,13 @@ lemma C_mul_mod {n j : ℕ} (hn : 3 ≤ n) (hj : j ∈ Set.Ico 1 n) (cpj : Nat.C
 theorem result {n j : ℕ} (hn : 3 ≤ n) (hj : j ∈ Set.Ico 1 n) (cpj : Coprime n j)
     {C : ℕ → Fin 2} (hC : Condition n j C) {i : ℕ} (hi : i ∈ Set.Ico 1 n) :
     C i = C j := by
-  obtain ⟨v, -, hv⟩ := exists_mul_mod_eq_one_of_coprime cpj.symm (by omega)
+  obtain ⟨v, -, hv⟩ := exists_mul_mod_eq_one_of_coprime cpj.symm (by lia)
   have hvi : i = (v * i % n) * j % n := by
     rw [mod_mul_mod, ← mul_rotate, ← mod_mul_mod, hv, one_mul, mod_eq_of_lt hi.2]
   have vib : v * i % n ∈ Set.Ico 1 n := by
-    refine ⟨(?_ : 0 < _), mod_lt _ (by omega)⟩
+    refine ⟨(?_ : 0 < _), mod_lt _ (by lia)⟩
     by_contra! h; rw [le_zero, ← dvd_iff_mod_eq_zero] at h
-    rw [mul_comm, ← mod_eq_of_lt (show 1 < n by omega)] at hv
+    rw [mul_comm, ← mod_eq_of_lt (show 1 < n by lia)] at hv
     have i0 := eq_zero_of_dvd_of_lt
       ((coprime_of_mul_modEq_one _ hv).symm.dvd_of_dvd_mul_left h) hi.2
     subst i; simp at hi

--- a/Archive/Imo/Imo1988Q6.lean
+++ b/Archive/Imo/Imo1988Q6.lean
@@ -239,7 +239,7 @@ theorem imo1988_q6 {a b : ℕ} (h : a * b + 1 ∣ a ^ 2 + b ^ 2) :
     · contrapose! hV₀ with x_lt_z
       apply ne_of_gt
       calc
-        z * y > x * x := by apply mul_lt_mul' <;> omega
+        z * y > x * x := by apply mul_lt_mul' <;> lia
         _ ≥ x * x - k := sub_le_self _ (Int.natCast_nonneg k)
   · -- There is no base case in this application of Vieta jumping.
     simp
@@ -276,16 +276,16 @@ example {a b : ℕ} (h : a * b ∣ a ^ 2 + b ^ 2 + 1) : 3 * a * b = a ^ 2 + b ^ 
     constructor
     · have zy_pos : z * y ≥ 0 := by rw [hV₀]; exact mod_cast Nat.zero_le _
       apply nonneg_of_mul_nonneg_left zy_pos
-      omega
+      lia
     · contrapose! hV₀ with x_lt_z
       apply ne_of_gt
       push_neg at h_base
       calc
-        z * y > x * y := by apply mul_lt_mul_of_pos_right <;> omega
-        _ ≥ x * (x + 1) := by apply mul_le_mul <;> omega
+        z * y > x * y := by apply mul_lt_mul_of_pos_right <;> lia
+        _ ≥ x * (x + 1) := by apply mul_le_mul <;> lia
         _ > x * x + 1 := by
           rw [mul_add]
-          omega
+          lia
   · -- Show the base case.
     intro x y h h_base
     obtain rfl | rfl : x = 0 ∨ x = 1 := by rwa [Nat.le_add_one_iff, Nat.le_zero] at h_base

--- a/Archive/Imo/Imo1994Q1.lean
+++ b/Archive/Imo/Imo1994Q1.lean
@@ -37,7 +37,7 @@ theorem tedious (m : ℕ) (k : Fin (m + 1)) : m - ((m + 1 - ↑k) + m) % (m + 1)
   rcases hk with ⟨c, rfl⟩
   have : (k + c + 1 - k) + (k + c) = c + (k + c + 1) := by lia
   rw [Fin.val_mk, this, Nat.add_mod_right, Nat.mod_eq_of_lt, Nat.add_sub_cancel]
-  omega
+  lia
 
 end Imo1994Q1
 

--- a/Archive/Imo/Imo1997Q3.lean
+++ b/Archive/Imo/Imo1997Q3.lean
@@ -74,7 +74,7 @@ lemma sign_eq_of_contra
   | one => rfl
   | mul_right p s sform ih =>
     suffices |S x p - S x (p * s)| ≤ (n + 1 : ℕ) + 1 by
-      rw [ih]; exact sign_eq_of_abs_sub_le (h _) (h _) (by norm_cast; omega) this
+      rw [ih]; exact sign_eq_of_abs_sub_le (h _) (h _) (by norm_cast; lia) this
     rw [Set.mem_range] at sform; obtain ⟨i, hi⟩ := sform
     iterate 2 rw [S, ← sum_add_sum_compl {i.castSucc, i.succ}]
     have cg : ∑ j ∈ {i.castSucc, i.succ}ᶜ, (j + 1) * x ((p * s) j) =
@@ -99,8 +99,8 @@ lemma S_one_add_S_revPerm
   nth_rw 2 [S]; rw [← revPerm.sum_comp _ _ (by simp)]
   simp_rw [revPerm_apply, val_rev, rev_rev, S, Perm.one_apply, ← sum_add_distrib, ← add_mul]
   have cg : ∑ i : Fin n, (i + 1 + ((n - (i + 1) : ℕ) + 1)) * x i = ∑ i, (n + 1) * x i := by
-    congr! 2 with i; norm_cast; omega
-  rw [cg, ← mul_sum, abs_mul, hx₁, mul_one]; exact abs_of_nonneg (by norm_cast; omega)
+    congr! 2 with i; norm_cast; lia
+  rw [cg, ← mul_sum, abs_mul, hx₁, mul_one]; exact abs_of_nonneg (by norm_cast; lia)
 
 theorem result {x : Fin n → ℝ} (hx₁ : |∑ i, x i| = 1) (hx₂ : ∀ i, |x i| ≤ (n + 1) / 2) :
     ∃ p, |S x p| ≤ (n + 1) / 2 := by
@@ -108,7 +108,7 @@ theorem result {x : Fin n → ℝ} (hx₁ : |∑ i, x i| = 1) (hx₂ : ∀ i, |x
   | 0 => simp [S]
   | n + 1 =>
     by_contra! h
-    exact (lt_abs_add_of_sign_eq (h _) (h _) (by norm_cast; omega)
+    exact (lt_abs_add_of_sign_eq (h _) (h _) (by norm_cast; lia)
       (sign_eq_of_contra hx₂ h _)).ne' (S_one_add_S_revPerm hx₁)
 
 end Imo1997Q3

--- a/Archive/Imo/Imo2001Q3.lean
+++ b/Archive/Imo/Imo2001Q3.lean
@@ -66,7 +66,7 @@ lemma card_not_easy_le_five {i : Fin 21} (hG : #(G i) ≤ 6) (hB : ∀ j, ¬Disj
     _ = #((G i).biUnion fun p ↦ {j | p ∈ B j}) := by congr 1; ext j; simp [not_disjoint_iff]
     _ ≤ ∑ p ∈ G i, #{j | p ∈ B j} := card_biUnion_le
     _ ≤ ∑ p ∈ G i, 2 := sum_le_sum fun p mp ↦ Nat.le_of_lt_succ (h p mp)
-    _ ≤ _ := by rw [sum_const, smul_eq_mul]; omega
+    _ ≤ _ := by rw [sum_const, smul_eq_mul]; lia
 
 open Classical in
 /-- There are at most 210 girl-boy pairs who solved some problem in common that was not easy for

--- a/Archive/Imo/Imo2001Q6.lean
+++ b/Archive/Imo/Imo2001Q6.lean
@@ -22,9 +22,9 @@ variable {a b c d : ℤ}
 theorem imo2001_q6 (hd : 0 < d) (hdc : d < c) (hcb : c < b) (hba : b < a)
     (h : a * c + b * d = (a + b - c + d) * (-a + b + c + d)) : ¬Prime (a * b + c * d) := by
   intro (h0 : Prime (a * b + c * d))
-  have ha : 0 < a := by omega
-  have hb : 0 < b := by omega
-  have hc : 0 < c := by omega
+  have ha : 0 < a := by lia
+  have hb : 0 < b := by lia
+  have hc : 0 < c := by lia
   -- the key step is to show that `a*c + b*d` divides the product `(a*b + c*d) * (a*d + b*c)`
   have dvd_mul : a * c + b * d ∣ (a * b + c * d) * (a * d + b * c) := by
     use b ^ 2 + b * d + d ^ 2

--- a/Archive/Imo/Imo2008Q3.lean
+++ b/Archive/Imo/Imo2008Q3.lean
@@ -45,7 +45,7 @@ theorem p_lemma (p : ℕ) (hpp : Nat.Prime p) (hp_mod_4_eq_1 : p ≡ 1 [MOD 4]) 
     simp only [m, Int.cast_pow, Int.cast_add, Int.cast_one, ZMod.coe_valMinAbs]
     rw [pow_two, ← hy]; exact neg_add_cancel 1
   have hnat₂ : n ≤ p / 2 := ZMod.natAbs_valMinAbs_le y
-  have hnat₃ : p ≥ 2 * n := by omega
+  have hnat₃ : p ≥ 2 * n := by lia
   set k : ℕ := p - 2 * n with hnat₄
   have hnat₅ : p ∣ k ^ 2 + 4 := by
     obtain ⟨x, hx⟩ := hnat₁

--- a/Archive/Imo/Imo2015Q6.lean
+++ b/Archive/Imo/Imo2015Q6.lean
@@ -73,9 +73,9 @@ lemma exists_add_eq_of_mem_pool {z : ℤ} (hz : z ∈ pool a t) : ∃ u < t, u +
     simp_rw [pool, mem_map, Equiv.coe_toEmbedding, Equiv.subRight_apply] at hz
     obtain ⟨y, my, ey⟩ := hz
     rw [mem_insert, mem_erase] at my; rcases my with h | h
-    · use t; omega
+    · use t; lia
     · obtain ⟨u, lu, hu⟩ := ih h.2
-      use u; omega
+      use u; lia
 
 include ha
 
@@ -86,10 +86,10 @@ lemma pool_subset_Icc : ∀ {t}, pool a t ⊆ Icc 0 2014
     intro x hx
     simp_rw [pool, mem_map, Equiv.coe_toEmbedding, Equiv.subRight_apply] at hx
     obtain ⟨y, my, ey⟩ := hx
-    suffices y ∈ Icc 1 2015 by rw [mem_Icc] at this ⊢; omega
+    suffices y ∈ Icc 1 2015 by rw [mem_Icc] at this ⊢; lia
     rw [mem_insert, mem_erase] at my; rcases my with h | ⟨h₁, h₂⟩
     · exact h ▸ ha.1 t
-    · have := pool_subset_Icc h₂; rw [mem_Icc] at this ⊢; omega
+    · have := pool_subset_Icc h₂; rw [mem_Icc] at this ⊢; lia
 
 lemma notMem_pool_self : a t ∉ pool a t := by
   by_contra h
@@ -105,12 +105,12 @@ lemma card_pool_succ : #(pool a (t + 1)) = #(pool a t) + if 0 ∈ pool a t then 
     rw [mem_erase, not_and_or]; exact .inr (notMem_pool_self ha)
   rw [pool, card_map, card_insert_of_notMem nms, card_erase_eq_ite]
   split_ifs with h
-  · have := card_pos.mpr ⟨0, h⟩; omega
+  · have := card_pos.mpr ⟨0, h⟩; lia
   · rfl
 
 lemma monotone_card_pool : Monotone fun t ↦ #(pool a t) := by
   refine monotone_nat_of_le_succ fun t ↦ ?_
-  have := card_pool_succ (t := t) ha; omega
+  have := card_pool_succ (t := t) ha; lia
 
 /-- There exists a point where the number of balls reaches a maximum (which follows from its
 monotonicity and boundedness). We take its coordinates for the problem's `b` and `N`. -/
@@ -135,7 +135,7 @@ lemma b_pos : 0 < b := by
     · exact hbN _ h.le
   have cp1 : #(pool a 1) = 1 := by
     simp_rw [card_pool_succ ha, pool, card_empty, notMem_empty, ite_false]
-  apply absurd (hbN 1); omega
+  apply absurd (hbN 1); lia
 
 include ht in
 lemma zero_mem_pool : 0 ∈ pool a t := by
@@ -151,14 +151,14 @@ lemma sum_sub_sum_eq_sub : ∑ x ∈ pool a (t + 1), x - ∑ x ∈ pool a t, x =
     rw [mem_erase, not_and_or]; exact .inr (notMem_pool_self ha)
   rw [sum_insert nms, sum_erase_eq_sub (h := zero_mem_pool ha hbN ht), sum_sub_distrib, sum_const,
     nsmul_one, hbN _ ht]
-  omega
+  lia
 
 /-- The telescoping sum giving the part of the problem's expression within the modulus signs. -/
 lemma sum_telescope {m n : ℕ} (hm : N ≤ m) (hn : m < n) :
     ∑ j ∈ Ico m n, (a j - b) = ∑ x ∈ pool a n, x - ∑ x ∈ pool a m, x :=
   calc
     _ = ∑ j ∈ Ico m n, (∑ x ∈ pool a (j + 1), x - ∑ x ∈ pool a j, x) := by
-      congr! 1 with j hj; rw [sum_sub_sum_eq_sub ha hbN]; simp at hj; omega
+      congr! 1 with j hj; rw [sum_sub_sum_eq_sub ha hbN]; simp at hj; lia
     _ = _ := sum_Ico_sub (∑ x ∈ pool a ·, x) hn.le
 
 include ht in
@@ -190,7 +190,7 @@ theorem result (ha : Condition a) :
       nth_rw 2 [← Nat.sub_one_add_one_eq_of_pos bp]
       rw [← sum_flip, sum_range_succ, tsub_self, Nat.cast_zero, add_zero, ← sum_sub_distrib]
       have sc : ∀ x ∈ range (b - 1), (2014 - x - (b - 1 - x : ℕ)) = (2015 - b : ℤ) := fun x mx ↦ by
-        rw [mem_range] at mx; omega
+        rw [mem_range] at mx; lia
       rw [sum_congr rfl sc, sum_const, card_range, nsmul_eq_mul, Nat.cast_pred bp]
     _ ≤ _ := by
       rw [← mul_le_mul_iff_right₀ zero_lt_four, ← mul_assoc,

--- a/Archive/Imo/Imo2015Q6.lean
+++ b/Archive/Imo/Imo2015Q6.lean
@@ -140,7 +140,7 @@ lemma b_pos : 0 < b := by
 include ht in
 lemma zero_mem_pool : 0 ∈ pool a t := by
   have := card_pool_succ (t := t) ha
-  have := hbN (t + 1) (by omega)
+  have := hbN (t + 1) (by lia)
   simp_all
 
 include ht in

--- a/Archive/Imo/Imo2021Q1.lean
+++ b/Archive/Imo/Imo2021Q1.lean
@@ -52,7 +52,7 @@ lemma exists_numbers_in_interval {n : ℕ} (hn : 100 ≤ n) :
   have h₂ := Nat.succ_le_succ_sqrt' (n + 1)
   have h₃ : 10 ≤ (n + 1).sqrt := by
     rw [Nat.le_sqrt]
-    omega
+    lia
   rw [← Nat.sub_add_cancel hn'] at h₁ h₂ h₃
   set l := (n + 1).sqrt - 1
   refine ⟨l, ?_, ?_⟩

--- a/Archive/Imo/Imo2021Q1.lean
+++ b/Archive/Imo/Imo2021Q1.lean
@@ -65,8 +65,8 @@ lemma exists_triplet_summing_to_squares {n : ℕ} (hn : 100 ≤ n) :
       IsSquare (a + b) ∧ IsSquare (c + a) ∧ IsSquare (b + c) := by
   obtain ⟨l, hl1, hl2⟩ := exists_numbers_in_interval hn
   have hl : 1 < l := by contrapose! hl1; interval_cases l <;> linarith
-  have h₁ : 4 * l ≤ 2 * l ^ 2 := by omega
-  have h₂ : 1 ≤ 2 * l := by omega
+  have h₁ : 4 * l ≤ 2 * l ^ 2 := by lia
+  have h₂ : 1 ≤ 2 * l := by lia
   refine ⟨2 * l ^ 2 - 4 * l, 2 * l ^ 2 + 1, 2 * l ^ 2 + 4 * l, ?_, ?_, ?_,
     ⟨?_, ⟨2 * l - 1, ?_⟩, ⟨2 * l, ?_⟩, 2 * l + 1, ?_⟩⟩
   all_goals zify [h₁, h₂]; linarith

--- a/Archive/Imo/Imo2024Q1.lean
+++ b/Archive/Imo/Imo2024Q1.lean
@@ -111,7 +111,7 @@ lemma mem_Ico_n_of_mem_Ioo (h : α ∈ Set.Ioo 0 2) {n : ℕ} (hn : 0 < n) :
          ⌊(k + 1 : ℕ) * α⌋ + ((k : ℕ) : ℤ) ^ 2 := by
       have hn11 : k + 1 ∉ Finset.Icc 1 k := by
         rw [Finset.mem_Icc]
-        omega
+        lia
       rw [← insert_Icc_right_eq_Icc_add_one (Nat.le_add_left 1 k), sum_insert hn11, hks]
     specialize hc (k + 1) k.succ_pos
     rw [hs] at hc ⊢
@@ -133,13 +133,13 @@ lemma mem_Ico_n_of_mem_Ioo (h : α ∈ Set.Ioo 0 2) {n : ℕ} (hn : 0 < n) :
         push_cast
         ring
       rw [dvd_sub_right (dvd_mul_right _ _), ← isUnit_iff_dvd_one, Int.isUnit_iff] at hc'
-      omega
+      lia
     rw [hk']
     refine ⟨?_, ?_, h.2⟩
     · push_cast
       ring
     · rw [Int.floor_eq_iff] at hk'
-      rw [div_le_iff₀ (by norm_cast; omega), mul_comm α]
+      rw [div_le_iff₀ (by norm_cast; lia), mul_comm α]
       convert hk'.1
       push_cast
       ring

--- a/Archive/Imo/Imo2024Q1.lean
+++ b/Archive/Imo/Imo2024Q1.lean
@@ -127,7 +127,7 @@ lemma mem_Ico_n_of_mem_Ioo (h : α ∈ Set.Ioo 0 2) {n : ℕ} (hn : 0 < n) :
       gcongr
     have hk' : ⌊(k + 1 : ℕ) * α⌋ = 2 * k + 1 := by
       by_contra
-      rw [show ⌊(k + 1 : ℕ) * α⌋ = 2 * k by omega] at hc
+      rw [show ⌊(k + 1 : ℕ) * α⌋ = 2 * k by lia] at hc
       have hc' : ((k + 1 : ℕ) : ℤ) ∣ ((k + 1 : ℕ) : ℤ) * ((k + 1 : ℕ) : ℤ) - 1 := by
         convert hc using 1
         push_cast
@@ -149,7 +149,7 @@ end Condition
 lemma not_condition_of_mem_Ioo {α : ℝ} (h : α ∈ Set.Ioo 0 2) : ¬Condition α := by
   intro hc
   let n : ℕ := ⌊(2 - α)⁻¹⌋₊ + 1
-  have hn : 0 < n := by omega
+  have hn : 0 < n := by lia
   have hna := (hc.mem_Ico_n_of_mem_Ioo h hn).1
   rcases h with ⟨-, h2⟩
   have hna' : 2 - (n : ℝ)⁻¹ ≤ α := by

--- a/Archive/Imo/Imo2024Q2.lean
+++ b/Archive/Imo/Imo2024Q2.lean
@@ -168,7 +168,7 @@ lemma ab_add_one_dvd_b_add_one : a * b + 1 ∣ b + 1 := by
   exact h.ab_add_one_dvd_a_pow_large_n_0_add_b
 
 lemma a_eq_one : a = 1 := by
-  have hle : a * b + 1 ≤ b + 1 := Nat.le_of_dvd (by omega) h.ab_add_one_dvd_b_add_one
+  have hle : a * b + 1 ≤ b + 1 := Nat.le_of_dvd (by lia) h.ab_add_one_dvd_b_add_one
   rw [add_le_add_iff_right] at hle
   suffices a ≤ 1 by
     have hp := h.a_pos

--- a/Archive/Imo/Imo2024Q2.lean
+++ b/Archive/Imo/Imo2024Q2.lean
@@ -172,7 +172,7 @@ lemma a_eq_one : a = 1 := by
   rw [add_le_add_iff_right] at hle
   suffices a ≤ 1 by
     have hp := h.a_pos
-    omega
+    lia
   have hle' : a * b ≤ 1 * b := by
     simpa using hle
   exact Nat.le_of_mul_le_mul_right hle' h.b_pos

--- a/Archive/Imo/Imo2024Q3.lean
+++ b/Archive/Imo/Imo2024Q3.lean
@@ -144,12 +144,12 @@ lemma lt_toFinset_card {j : ℕ} (h : M a N ≤ a (j + 1)) (hf : {i | a i = a j}
 
 lemma nth_ne_zero_of_M_le_of_lt {i k : ℕ} (hi : M a N ≤ a i) (hk : k < a (i + 1)) :
     Nat.nth (a · = a i) k ≠ 0 :=
-  Nat.nth_ne_zero_anti (apply_ne_of_M_le_apply hi (Nat.zero_le _)) (by omega)
+  Nat.nth_ne_zero_anti (apply_ne_of_M_le_apply hi (Nat.zero_le _)) (by lia)
     (hc.nth_apply_add_one_eq (N_lt_of_M_le_apply hi).le ▸ ne_zero_of_M_le_apply hi)
 
 lemma apply_add_one_lt_of_apply_eq {i j : ℕ} (hi : N ≤ i) (hij : i < j) (ha : a i = a j) :
     a (i + 1) < a (j + 1) := by
-  rw [hc.apply_add_one_eq_card hi, hc.apply_add_one_eq_card (by omega), ha]
+  rw [hc.apply_add_one_eq_card hi, hc.apply_add_one_eq_card (by lia), ha]
   refine Finset.card_lt_card (Finset.ssubset_def.mp ⟨Finset.filter_subset_filter _
     (by simp [hij.le]), Finset.not_subset.mpr ⟨j, ?_⟩⟩)
   simp only [Finset.mem_filter, Finset.mem_range, lt_add_iff_pos_right, and_true]
@@ -264,7 +264,7 @@ lemma infinite_setOf_apply_eq_anti {j k : ℕ} (hj : 0 < j) (hk : {i | a i = k}.
     · rintro ⟨j, rfl, rfl⟩
       simp
     · rintro ⟨rfl, h⟩
-      exact ⟨i - 1, by simp [(by omega : i - 1 + 1 = i)]⟩
+      exact ⟨i - 1, by simp [(by lia : i - 1 + 1 = i)]⟩
   have hinj : Set.InjOn (fun x ↦ Nat.nth (a · = a x) (j - 1) + 1)
       ({i | a (i + 1) = k} \ Set.Ico 0 N) := by
     intro x hx y hy h
@@ -274,7 +274,7 @@ lemma infinite_setOf_apply_eq_anti {j k : ℕ} (hj : 0 < j) (hk : {i | a i = k}.
     simp only [add_left_inj] at h
     have hxk' : Nat.nth (a · = a x) (k - 1) = x := by rw [← hxk, hc.nth_apply_add_one_eq hNx]
     have hyk' : Nat.nth (a · = a y) (k - 1) = y := by rw [← hyk, hc.nth_apply_add_one_eq hNy]
-    have hjk' : j - 1 ≤ k - 1 := by omega
+    have hjk' : j - 1 ≤ k - 1 := by lia
     apply_fun a at hxk' hyk'
     have hyj : a (Nat.nth (a · = a y) (j - 1)) = a y :=
       Nat.nth_mem_anti (p := (a · = a y)) hjk' hyk'
@@ -287,7 +287,7 @@ lemma infinite_setOf_apply_eq_anti {j k : ℕ} (hj : 0 < j) (hk : {i | a i = k}.
   simp only [Set.mem_image, Set.mem_diff, Set.mem_setOf_eq, Set.mem_Ico, zero_le, true_and,
     not_lt] at hi
   rcases hi with ⟨⟨x, -, rfl⟩, _⟩
-  rw [Set.mem_setOf_eq, hc.apply_nth_add_one_eq_of_lt (by omega), Nat.sub_add_cancel hj]
+  rw [Set.mem_setOf_eq, hc.apply_nth_add_one_eq_of_lt (by lia), Nat.sub_add_cancel hj]
 
 /-! ### The definitions of small, medium and big numbers and the eventual alternation -/
 
@@ -314,7 +314,7 @@ lemma finite_setOf_apply_eq_iff_not_small {j : ℕ} (hj : 0 < j) :
   contrapose!; exact hc.infinite_setOf_apply_eq_iff_small hj
 
 lemma finite_setOf_apply_eq_k_add_one : {i | a i = k a + 1}.Finite := by
-  rw [hc.finite_setOf_apply_eq_iff_not_small (by omega), Small]
+  rw [hc.finite_setOf_apply_eq_iff_not_small (by lia), Small]
   omega
 
 /-- There are only finitely many `m` that appear more than `k` times. -/
@@ -324,7 +324,7 @@ lemma finite_setOf_k_lt_card : {m | ∀ hf : {i | a i = m}.Finite, k a < #hf.toF
       (Set.finite_Iic N)
     simp only [Set.mem_diff, Set.mem_image, Set.mem_setOf_eq, Set.mem_Iic, not_le] at hi
     rcases hi with ⟨⟨j, hjf, rfl⟩, hNi⟩
-    rw [Set.mem_setOf_eq, hc.apply_nth_add_one_eq hjf (by omega)]
+    rw [Set.mem_setOf_eq, hc.apply_nth_add_one_eq hjf (by lia)]
   · intro i hi j hj hij
     simp only [add_left_inj] at hij
     apply_fun a at hij
@@ -401,7 +401,7 @@ lemma not_medium_of_N'aux_lt {j : ℕ} (h : N'aux a N < j) : ¬Medium a (a j) :=
   have hf : s.Finite := by
     refine (Set.finite_Ioc _ _).biUnion ?_
     rintro i ⟨hk, -⟩
-    rwa [hc.finite_setOf_apply_eq_iff_not_small (by omega), Small, not_le]
+    rwa [hc.finite_setOf_apply_eq_iff_not_small (by lia), Small, not_le]
   exact fun hm ↦ notMem_of_csSup_lt (le_sup_left.trans_lt h)
     (hf.subset fun i hi ↦ (by simpa [s] using hi)).bddAbove hm
 
@@ -469,7 +469,7 @@ lemma N_add_one_lt_card_filter_eq_of_small_of_N'_le {i j : ℕ} (hj0 : 0 < j) (h
 
 lemma apply_add_one_big_of_apply_small_of_N'aux_le {i : ℕ} (h : Small a (a i))
     (hN'aux : N'aux a N ≤ i) : Big a (a (i + 1)) := by
-  have hN'' : N'aux a N < i + 1 := by omega
+  have hN'' : N'aux a N < i + 1 := by lia
   suffices ¬Small a (a (i + 1)) by simpa [this] using hc.small_or_big_of_N'aux_lt hN''
   rw [hc.apply_add_one_eq_card (hc.N_lt_N'aux.le.trans hN'aux), Small, not_le]
   exact hc.k_lt_card_filter_eq_of_small_of_N'aux_le (hc.pos _) h hN''
@@ -491,7 +491,7 @@ lemma apply_add_one_small_of_apply_big_of_N'_le {i : ℕ} (h : Big a (a i)) (hN'
 lemma apply_add_two_small_of_apply_small_of_N'_le {i : ℕ} (h : Small a (a i)) (hN' : N' a N ≤ i) :
     Small a (a (i + 2)) :=
   hc.apply_add_one_small_of_apply_big_of_N'_le (hc.apply_add_one_big_of_apply_small_of_N'_le h hN')
-    (by omega)
+    (by lia)
 
 /-- `a (N' a N)` is a small number. -/
 lemma small_apply_N' : Small a (a (N' a N)) := by
@@ -500,7 +500,7 @@ lemma small_apply_N' : Small a (a (N' a N)) := by
   · exact hi
   · have hb : Big a (a (N'aux a N + 1)) := by
       simpa [hi] using hc.small_or_big_of_N'aux_lt (Nat.lt_add_one (N'aux a N))
-    exact hc.apply_add_one_small_of_apply_big_of_N'aux_le hb (by omega)
+    exact hc.apply_add_one_small_of_apply_big_of_N'aux_le hb (by lia)
 
 lemma small_apply_N'_add_iff_even {n : ℕ} : Small a (a (N' a N + n)) ↔ Even n := by
   induction n with
@@ -509,14 +509,14 @@ lemma small_apply_N'_add_iff_even {n : ℕ} : Small a (a (N' a N + n)) ↔ Even 
     by_cases he : Even n <;> rw [← add_assoc] <;> simp only [he, iff_true, iff_false] at ih
     · have hne : ¬ Even (n + 1) := by simp [Nat.not_even_iff_odd, he]
       simp only [hne, iff_false]
-      exact hc.not_small_of_big (hc.apply_add_one_big_of_apply_small_of_N'_le ih (by omega))
+      exact hc.not_small_of_big (hc.apply_add_one_big_of_apply_small_of_N'_le ih (by lia))
     · have hb : Big a (a (N' a N + n)) := by
-        simpa [ih] using hc.small_or_big_of_N'_le (j := N' a N + n) (by omega)
-      simp [hc.apply_add_one_small_of_apply_big_of_N'_le hb (by omega), Nat.not_even_iff_odd.mp he]
+        simpa [ih] using hc.small_or_big_of_N'_le (j := N' a N + n) (by lia)
+      simp [hc.apply_add_one_small_of_apply_big_of_N'_le hb (by lia), Nat.not_even_iff_odd.mp he]
 
 lemma small_apply_add_two_mul_iff_small {n : ℕ} (m : ℕ) (hN' : N' a N ≤ n) :
     Small a (a (n + 2 * m)) ↔ Small a (a n) := by
-  rw [show n = N' a N + (n - N' a N) by omega, add_assoc, hc.small_apply_N'_add_iff_even,
+  rw [show n = N' a N + (n - N' a N) by lia, add_assoc, hc.small_apply_N'_add_iff_even,
     hc.small_apply_N'_add_iff_even]
   simp [Nat.even_add]
 
@@ -527,7 +527,7 @@ lemma apply_sub_one_small_of_apply_big_of_N'_le {i : ℕ} (h : Big a (a i)) (hN'
     omega
   have h' : N' a N ≤ i - 1 := by
     by_contra hi
-    have hi' : i = N' a N := by omega
+    have hi' : i = N' a N := by lia
     exact hc.not_small_of_big (hi' ▸ h) hc.small_apply_N'
   exact (hc.small_or_big_of_N'_le h').elim id fun hb ↦
     False.elim (hc.not_small_of_big h (Nat.sub_add_cancel h0i ▸
@@ -535,15 +535,15 @@ lemma apply_sub_one_small_of_apply_big_of_N'_le {i : ℕ} (h : Big a (a i)) (hN'
 
 lemma apply_sub_one_big_of_apply_small_of_N'_lt {i : ℕ} (h : Small a (a i)) (hN' : N' a N < i) :
     Big a (a (i - 1)) := by
-  have h0i : 1 ≤ i := by omega
-  have h' : N' a N ≤ i - 1 := by omega
+  have h0i : 1 ≤ i := by lia
+  have h' : N' a N ≤ i - 1 := by lia
   exact (hc.small_or_big_of_N'_le h').elim (fun hs ↦ False.elim (hc.not_small_of_big
     (Nat.sub_add_cancel h0i ▸ hc.apply_add_one_big_of_apply_small_of_N'_le hs h') h)) id
 
 lemma apply_sub_two_small_of_apply_small_of_N'_lt {i : ℕ} (h : Small a (a i)) (hN' : N' a N < i) :
     Small a (a (i - 2)) := by
   convert hc.apply_sub_one_small_of_apply_big_of_N'_le
-    (hc.apply_sub_one_big_of_apply_small_of_N'_lt h hN') (by omega) using 1
+    (hc.apply_sub_one_big_of_apply_small_of_N'_lt h hN') (by lia) using 1
 
 lemma N_add_one_lt_apply_of_apply_big_of_N'_le {i : ℕ} (h : Big a (a i)) (hN' : N' a N ≤ i) :
     N + 1 < a i := by
@@ -551,7 +551,7 @@ lemma N_add_one_lt_apply_of_apply_big_of_N'_le {i : ℕ} (h : Big a (a i)) (hN' 
     hc.N_add_one_lt_card_filter_eq_of_small_of_N'_le (hc.pos _)
       (hc.apply_sub_one_small_of_apply_big_of_N'_le h hN') ?_
   by_contra
-  exact hc.not_small_of_big ((by omega : i = N' a N) ▸ h) hc.small_apply_N'
+  exact hc.not_small_of_big ((by lia : i = N' a N) ▸ h) hc.small_apply_N'
 
 lemma setOf_apply_eq_of_apply_big_of_N'_le {i : ℕ} (h : Big a (a i)) (hN' : N' a N ≤ i) :
     {j | a j = a i} = {j | N < j ∧ Small a (a (j - 1)) ∧
@@ -571,7 +571,7 @@ lemma setOf_apply_eq_of_apply_big_of_N'_le {i : ℕ} (h : Big a (a i)) (hN' : N'
     · simp only [Nat.card_Icc, add_tsub_cancel_right]
     · simp only [add_left_inj] at htu
       simp only [Finset.coe_Icc, Set.mem_Icc] at ht hu
-      rw [← Small, ← hc.infinite_setOf_apply_eq_iff_small (by omega)] at ht hu
+      rw [← Small, ← hc.infinite_setOf_apply_eq_iff_small (by lia)] at ht hu
       apply_fun a at htu
       rwa [Nat.nth_mem_of_infinite ht.2, Nat.nth_mem_of_infinite hu.2] at htu
   refine hs ▸ Finset.card_le_card (Finset.subset_iff.2 fun j hj ↦ ?_)
@@ -584,7 +584,7 @@ lemma setOf_apply_eq_of_apply_big_of_N'_le {i : ℕ} (h : Big a (a i)) (hN' : N'
   simp only [add_tsub_cancel_right]
   rw [← Small] at htk
   have htki := htk
-  rw [← hc.infinite_setOf_apply_eq_iff_small (by omega)] at htki
+  rw [← hc.infinite_setOf_apply_eq_iff_small (by lia)] at htki
   rw [Nat.nth_mem_of_infinite htki]
   simp only [htk, true_and]
   refine ⟨Nat.lt_add_one_iff.mpr ((Nat.le_nth (fun hf ↦ absurd hf htki)).trans
@@ -617,11 +617,11 @@ lemma apply_add_one_eq_card_small_le_card_eq {i : ℕ} (hi : N' a N < i) (hib : 
       refine ⟨⟨Nat.lt_add_one_iff.mpr (hc.small_apply_sub_one_of_apply_eq_of_apply_big_of_N'_le
         hji hib hi.le), ?_⟩, ?_⟩
       · rw [hc.apply_eq_card hjN]
-        have : j ≤ i := by omega
+        have : j ≤ i := by lia
         gcongr
-      · have hj1 : j = j - 1 + 1 := by omega
+      · have hj1 : j = j - 1 + 1 := by lia
         nth_rw 2 [hj1]
-        rw [hc.nth_apply_add_one_eq (by omega), hj1.symm]
+        rw [hc.nth_apply_add_one_eq (by lia), hj1.symm]
     · subst ht
       rw [Nat.lt_add_one_iff, ← Small] at hts
       have ht0 : 0 < t := by
@@ -659,9 +659,9 @@ and considering a range one larger (the form needed for Lemma 2). -/
 lemma apply_eq_card_small_le_card_eq_of_small {i : ℕ} (hi : N' a N + 1 < i)
     (his : Small a (a i)) :
     a i = #{m ∈ Finset.range (k a + 1) | a (i - 1) ≤ #{j ∈ Finset.range i | a j = m}} := by
-  have hib : Big a (a (i - 1)) := hc.apply_sub_one_big_of_apply_small_of_N'_lt his (by omega)
-  nth_rw 1 [show i = i - 1 + 1 by omega]
-  rw [hc.apply_add_one_eq_card_small_le_card_eq (by omega) hib]
+  have hib : Big a (a (i - 1)) := hc.apply_sub_one_big_of_apply_small_of_N'_lt his (by lia)
+  nth_rw 1 [show i = i - 1 + 1 by lia]
+  rw [hc.apply_add_one_eq_card_small_le_card_eq (by lia) hib]
   congr 1
   ext j
   simp only [Finset.mem_filter, Finset.mem_range, and_congr_right_iff]
@@ -670,9 +670,9 @@ lemma apply_eq_card_small_le_card_eq_of_small {i : ℕ} (hi : N' a N + 1 < i)
   congr 1
   ext t
   simp only [Finset.mem_filter, Finset.mem_range]
-  refine ⟨fun ⟨hti, rfl⟩ ↦ ⟨?_, rfl⟩, fun ⟨_, rfl⟩ ↦ ⟨by omega, rfl⟩⟩
+  refine ⟨fun ⟨hti, rfl⟩ ↦ ⟨?_, rfl⟩, fun ⟨_, rfl⟩ ↦ ⟨by lia, rfl⟩⟩
   by_contra hti1
-  have htieq : t = i - 1 := by omega
+  have htieq : t = i - 1 := by lia
   subst htieq
   exact hc.not_small_of_big hib (Nat.lt_add_one_iff.mp hj)
 
@@ -683,24 +683,24 @@ lemma exists_apply_sub_two_eq_of_apply_eq {i j : ℕ} (hi : N' a N + 2 < i) (hij
     ∃ t, t ∈ Finset.Ico i j ∧ a (i - 2) = a t := by
   let I : Finset ℕ := {t ∈ Finset.range (k a + 1) | a (i - 1) ≤ #{u ∈ Finset.range i | a u = t}}
   let J : Finset ℕ := {t ∈ Finset.range (k a + 1) | a (j - 1) ≤ #{u ∈ Finset.range j | a u = t}}
-  have hIc : a i = #I := hc.apply_eq_card_small_le_card_eq_of_small (by omega) his
-  have hJc : a j = #J := hc.apply_eq_card_small_le_card_eq_of_small (by omega) (hijeq ▸ his)
+  have hIc : a i = #I := hc.apply_eq_card_small_le_card_eq_of_small (by lia) his
+  have hJc : a j = #J := hc.apply_eq_card_small_le_card_eq_of_small (by lia) (hijeq ▸ his)
   have hIJc : #I = #J := hIc ▸ hJc ▸ hijeq
   have := hc.N_lt_N'
   have hiju : Finset.range i ∪ Finset.Ico i j = Finset.range j := by
-    rw [Finset.range_eq_Ico, Finset.Ico_union_Ico' (by omega) (by omega)]
+    rw [Finset.range_eq_Ico, Finset.Ico_union_Ico' (by lia) (by lia)]
     simp [hijlt.le]
   have hi2s : a (i - 2) < k a + 1 :=
-    Nat.lt_add_one_iff.mpr (hc.apply_sub_two_small_of_apply_small_of_N'_lt his (by omega))
+    Nat.lt_add_one_iff.mpr (hc.apply_sub_two_small_of_apply_small_of_N'_lt his (by lia))
   have hiI : a (i - 2) ∈ I := by
     simp only [I, Finset.mem_filter, Finset.mem_range, hi2s, true_and]
-    rw [hc.apply_eq_card (by omega), show i - 1 - 1 = i - 2 by omega]
+    rw [hc.apply_eq_card (by lia), show i - 1 - 1 = i - 2 by lia]
     exact Finset.card_le_card (Finset.filter_subset_filter _  (by simp))
   have hj2s : a (j - 2) < k a + 1 :=
-    Nat.lt_add_one_iff.mpr (hc.apply_sub_two_small_of_apply_small_of_N'_lt (hijeq ▸ his) (by omega))
+    Nat.lt_add_one_iff.mpr (hc.apply_sub_two_small_of_apply_small_of_N'_lt (hijeq ▸ his) (by lia))
   have hjJ : a (j - 2) ∈ J := by
     simp only [J, Finset.mem_filter, Finset.mem_range, hj2s, true_and]
-    rw [hc.apply_eq_card (by omega), show j - 1 - 1 = j - 2 by omega]
+    rw [hc.apply_eq_card (by lia), show j - 1 - 1 = j - 2 by lia]
     exact Finset.card_le_card (Finset.filter_subset_filter _  (by simp))
   have hjI : a (j - 2) ∈ I := by
     by_contra hjI
@@ -732,11 +732,11 @@ lemma exists_apply_sub_two_eq_of_apply_eq {i j : ℕ} (hi : N' a N + 2 < i) (hij
           simp only [Finset.one_le_card]
           refine ⟨j - 2, ?_⟩
           simp only [Finset.mem_filter, Finset.mem_Ico, and_true]
-          refine ⟨?_, by omega⟩
+          refine ⟨?_, by lia⟩
           by_contra hj
-          have hj' : j = i + 1 := by omega
+          have hj' : j = i + 1 := by lia
           subst hj'
-          exact hc.not_small_of_big (hc.apply_add_one_big_of_apply_small_of_N'_le his (by omega))
+          exact hc.not_small_of_big (hc.apply_add_one_big_of_apply_small_of_N'_le his (by lia))
             (hijeq ▸ his)
       _ = #({u ∈ Finset.range i | a u = a (j - 2)} ∪ {u ∈ Finset.Ico i j | a u = a (j - 2)}) := by
           refine (Finset.card_union_of_disjoint ?_).symm
@@ -747,18 +747,18 @@ lemma exists_apply_sub_two_eq_of_apply_eq {i j : ℕ} (hi : N' a N + 2 < i) (hij
       _ = #{u ∈ Finset.range j | a u = a (j - 2)} := by
           rw [← Finset.filter_union, hiju]
       _ = a (j - 1) := by
-          rw [hc.apply_eq_card (show N < j - 1 by omega)]
+          rw [hc.apply_eq_card (show N < j - 1 by lia)]
           congr 1
           ext t
           simp only [Finset.mem_filter, Finset.mem_range]
           refine ⟨fun ⟨htj, htj'⟩ ↦ ⟨?_, by convert htj' using 1⟩,
-            fun ⟨htj, htj'⟩ ↦ ⟨by omega, by convert htj' using 1⟩⟩
+            fun ⟨htj, htj'⟩ ↦ ⟨by lia, by convert htj' using 1⟩⟩
           by_contra htj''
-          have ht1 : t = j - 1 := by omega
+          have ht1 : t = j - 1 := by lia
           subst ht1
           exact hc.not_small_of_big (htj' ▸ hc.apply_sub_one_big_of_apply_small_of_N'_lt
-            (hijeq ▸ his) (by omega)) (hc.apply_sub_two_small_of_apply_small_of_N'_lt
-            (hijeq ▸ his) (by omega))
+            (hijeq ▸ his) (by lia)) (hc.apply_sub_two_small_of_apply_small_of_N'_lt
+            (hijeq ▸ his) (by lia))
   have hIJ : I = J := by
     refine (Finset.eq_of_subset_of_card_le (Finset.subset_iff.mp fun x hxJ ↦ ?_) hIJc.le).symm
     simp only [Finset.mem_filter, Finset.mem_range, I, J, Nat.lt_add_one_iff] at *
@@ -774,17 +774,17 @@ lemma exists_apply_sub_two_eq_of_apply_eq {i j : ℕ} (hi : N' a N + 2 < i) (hij
            exact hij1 _ hxJ.1
   simp only [hIJ, J, Finset.mem_filter] at hiI
   have hiI' := hi1j1.trans hiI.2
-  rw [hc.apply_eq_card (by omega), show i - 1 - 1 = i - 2 by omega, Nat.add_one_le_iff,
+  rw [hc.apply_eq_card (by lia), show i - 1 - 1 = i - 2 by lia, Nat.add_one_le_iff,
      ← not_le] at hiI'
   rcases Finset.not_subset.mp (mt Finset.card_le_card hiI') with ⟨t, htj, hti⟩
   simp only [Finset.mem_filter, Finset.mem_range] at htj hti
   simp only [htj.2, and_true, not_lt, tsub_le_iff_right] at hti
   refine ⟨t, Finset.mem_Ico.mpr ⟨?_, htj.1⟩, htj.2.symm⟩
   by_contra
-  have hti' : t = i - 1 := by omega
+  have hti' : t = i - 1 := by lia
   subst hti'
-  exact hc.not_small_of_big (hc.apply_sub_one_big_of_apply_small_of_N'_lt his (by omega)) (htj.2 ▸
-    (hc.apply_sub_two_small_of_apply_small_of_N'_lt his (by omega)))
+  exact hc.not_small_of_big (hc.apply_sub_one_big_of_apply_small_of_N'_lt his (by lia)) (htj.2 ▸
+    (hc.apply_sub_two_small_of_apply_small_of_N'_lt his (by lia)))
 
 variable (a)
 
@@ -803,7 +803,7 @@ lemma nonempty_pSet (n : ℕ) : (pSet a n).Nonempty := by
   rcases hc.infinite_setOf_apply_eq_one.exists_gt i with ⟨j, hj1, hij⟩
   refine ⟨j - n, ?_⟩
   simp only [pSet, Finset.mem_Ico, Set.mem_setOf_eq]
-  exact ⟨i, ⟨hni.le, by omega⟩, hi1 ▸ ⟨hc.small_one, hj1 ▸ (by congr; omega)⟩⟩
+  exact ⟨i, ⟨hni.le, by lia⟩, hi1 ▸ ⟨hc.small_one, hj1 ▸ (by congr; omega)⟩⟩
 
 lemma exists_mem_Ico_small_and_apply_add_p_eq (n : ℕ) :
     ∃ i ∈ Finset.Ico n (n + p a n), Small a (a i) ∧ a (n + p a n) = a i :=
@@ -823,12 +823,12 @@ lemma card_filter_apply_eq_Ico_add_p_le_one (n : ℕ) {j : ℕ} (hjs : Small a j
   intro x y hx hy
   simp only [Finset.mem_filter, Finset.mem_Ico] at hx hy
   rcases lt_trichotomy x y with hxy | rfl | hxy
-  · replace h := h.2 (y - n) x hx.1.1 (by omega) (hx.2 ▸ hjs)
-    rw [show n + (y - n) = y by omega, hx.2, hy.2] at h
+  · replace h := h.2 (y - n) x hx.1.1 (by lia) (hx.2 ▸ hjs)
+    rw [show n + (y - n) = y by lia, hx.2, hy.2] at h
     omega
   · rfl
-  · replace h := h.2 (x - n) y hy.1.1 (by omega) (hy.2 ▸ hjs)
-    rw [show n + (x - n) = x by omega, hx.2, hy.2] at h
+  · replace h := h.2 (x - n) y hy.1.1 (by lia) (hy.2 ▸ hjs)
+    rw [show n + (x - n) = x by lia, hx.2, hy.2] at h
     omega
 
 lemma apply_add_p_eq {n : ℕ} (hn : N' a N + 2 < n) (hs : Small a (a n)) : a (n + p a n) = a n := by
@@ -840,22 +840,22 @@ lemma apply_add_p_eq {n : ℕ} (hn : N' a N + 2 < n) (hs : Small a (a n)) : a (n
     calc #{x ∈ Finset.Ico i (n + p a n) | a x = t} ≤ #{x ∈ Finset.Ico n (n + p a n) | a x = t} :=
         Finset.card_le_card (Finset.filter_subset_filter _ (Finset.Ico_subset_Ico hiIco.1 le_rfl))
       _ ≤ 1 := hc.card_filter_apply_eq_Ico_add_p_le_one _ hts
-  obtain ⟨t, hti, hi2t⟩ := hc.exists_apply_sub_two_eq_of_apply_eq (j := n + p a n) (by omega)
-    (by omega) his hin.symm hf
+  obtain ⟨t, hti, hi2t⟩ := hc.exists_apply_sub_two_eq_of_apply_eq (j := n + p a n) (by lia)
+    (by lia) his hin.symm hf
   have h1 := hc.card_filter_apply_eq_Ico_add_p_le_one n
-    (hi2t ▸ hc.apply_sub_two_small_of_apply_small_of_N'_lt his (by omega))
+    (hi2t ▸ hc.apply_sub_two_small_of_apply_small_of_N'_lt his (by lia))
   revert h1
   simp only [imp_false, not_le, Finset.one_lt_card_iff, Finset.mem_filter, Finset.mem_Ico, ne_eq,
     exists_and_left]
   simp only [Finset.mem_Ico] at hti
-  refine ⟨i - 2, ⟨⟨?_, by omega⟩, hi2t⟩, t, by omega⟩
+  refine ⟨i - 2, ⟨⟨?_, by lia⟩, hi2t⟩, t, by lia⟩
   by_contra hi2
-  have hi1 : n = i - 1 := by omega
+  have hi1 : n = i - 1 := by lia
   subst hi1
-  exact hc.not_small_of_big (hc.apply_sub_one_big_of_apply_small_of_N'_lt his (by omega)) hs
+  exact hc.not_small_of_big (hc.apply_sub_one_big_of_apply_small_of_N'_lt his (by lia)) hs
 
 lemma even_p {n : ℕ} (hn : N' a N + 2 < n) (hs : Small a (a n)) : Even (p a n) := by
-  have hna : n = N' a N + (n - (N' a N)) := by omega
+  have hna : n = N' a N + (n - (N' a N)) := by lia
   have hs' := hc.apply_add_p_eq hn hs ▸ hs
   rw [hna, hc.small_apply_N'_add_iff_even] at hs
   nth_rw 1 [hna] at hs'
@@ -870,38 +870,38 @@ lemma p_le_two_mul_k {n : ℕ} (hn : N' a N + 2 < n) (hs : Small a (a n)) : p a 
     · simp
     · rintro i -
       simp only [Finset.coe_Icc, Set.mem_Icc]
-      rw [← Small, hc.small_apply_add_two_mul_iff_small i (by omega)]
+      rw [← Small, hc.small_apply_add_two_mul_iff_small i (by lia)]
       simp [hs, hc.one_le_apply]
-  have hs' : Small a (a (n + 2 * x)) := by rwa [hc.small_apply_add_two_mul_iff_small x (by omega)]
+  have hs' : Small a (a (n + 2 * x)) := by rwa [hc.small_apply_add_two_mul_iff_small x (by lia)]
   have hj := hc.card_filter_apply_eq_Ico_add_p_le_one n hs'
   revert hj
   simp only [imp_false, not_le, Finset.one_lt_card_iff, Finset.mem_filter, Finset.mem_Ico, ne_eq,
     exists_and_left]
   simp only [Finset.mem_range] at hx hy
-  exact ⟨n + 2 * x, by omega, n + 2 * y, by omega⟩
+  exact ⟨n + 2 * x, by lia, n + 2 * y, by lia⟩
 
 lemma p_apply_sub_two_le_p_apply {n : ℕ} (hn : N' a N + 4 < n) (hs : Small a (a n)) :
     p a (n - 2) ≤ p a n := by
-  obtain ⟨t, hti, _⟩ := hc.exists_apply_sub_two_eq_of_apply_eq (j := n + p a n) (by omega)
+  obtain ⟨t, hti, _⟩ := hc.exists_apply_sub_two_eq_of_apply_eq (j := n + p a n) (by lia)
     ((lt_add_iff_pos_right n).mpr (hc.p_pos n)) hs
-    (hc.apply_add_p_eq (by omega) hs).symm (fun _ ↦ hc.card_filter_apply_eq_Ico_add_p_le_one _)
+    (hc.apply_add_p_eq (by lia) hs).symm (fun _ ↦ hc.card_filter_apply_eq_Ico_add_p_le_one _)
   by_contra
-  have hn2 := (hc.apply_sub_two_small_of_apply_small_of_N'_lt hs (by omega))
+  have hn2 := (hc.apply_sub_two_small_of_apply_small_of_N'_lt hs (by lia))
   have : p a n ≤ p a (n - 2) - 2 := by
-    obtain ⟨_, _⟩ := hc.even_p (by omega) hs
-    obtain ⟨_, _⟩ := hc.even_p (by omega) hn2
+    obtain ⟨_, _⟩ := hc.even_p (by lia) hs
+    obtain ⟨_, _⟩ := hc.even_p (by lia) hn2
     omega
   have h := hc.card_filter_apply_eq_Ico_add_p_le_one (n - 2) hn2
   revert h
   simp only [imp_false, not_le, Finset.one_lt_card_iff, Finset.mem_filter, Finset.mem_Ico,
     ne_eq, exists_and_left]
   simp only [Finset.mem_Ico] at hti
-  exact ⟨n - 2, ⟨⟨le_rfl, by omega⟩, rfl⟩, t, by omega⟩
+  exact ⟨n - 2, ⟨⟨le_rfl, by lia⟩, rfl⟩, t, by lia⟩
 
 lemma p_apply_le_p_apply_add_two {n : ℕ} (hn : N' a N + 2 < n) (hs : Small a (a n)) :
     p a n ≤ p a (n + 2) :=
-  hc.p_apply_sub_two_le_p_apply (n := n + 2) (by omega)
-    (hc.apply_add_two_small_of_apply_small_of_N'_le hs (by omega))
+  hc.p_apply_sub_two_le_p_apply (n := n + 2) (by lia)
+    (hc.apply_add_two_small_of_apply_small_of_N'_le hs (by lia))
 
 variable (a N)
 
@@ -909,7 +909,7 @@ lemma exists_p_eq : ∃ b c, ∀ n, b < n → p a (N' a N + 2 * n) = c := by
   let c : ℕ := sSup (Set.range (fun i ↦ p a (N' a N + 2 * (2 + i))))
   have hk : 2 * k a ∈ upperBounds (Set.range (fun i ↦ p a (N' a N + 2 * (2 + i)))) := by
     simp only [mem_upperBounds, Set.mem_range, forall_exists_index, forall_apply_eq_imp_iff]
-    exact fun i ↦ hc.p_le_two_mul_k (by omega) (hc.small_apply_N'_add_iff_even.mpr (by simp))
+    exact fun i ↦ hc.p_le_two_mul_k (by lia) (hc.small_apply_N'_add_iff_even.mpr (by simp))
   have hlec : ∀ j ∈ Set.range (fun i ↦ p a (N' a N + 2 * (2 + i))), j ≤ c :=
     fun _ hj ↦ le_csSup ⟨_, hk⟩ hj
   obtain ⟨t, ht⟩ := Set.Nonempty.csSup_mem (Set.range_nonempty _) (BddAbove.finite ⟨2 * k a, hk⟩)
@@ -923,22 +923,22 @@ lemma exists_p_eq : ∃ b c, ∀ n, b < n → p a (N' a N + 2 * n) = c := by
       · have hs : Small a (a (N' a N + 2 * (2 + t + u))) := by
           rw [hc.small_apply_N'_add_iff_even]
           simp
-        convert hc.p_apply_le_p_apply_add_two (by omega) hs using 1
+        convert hc.p_apply_le_p_apply_add_two (by lia) hs using 1
   refine ⟨1 + t, c, fun n hn ↦ ?_⟩
-  rw [show n = 2 + t + (n - (2 + t)) by omega]
+  rw [show n = 2 + t + (n - (2 + t)) by lia]
   exact heqc _
 
 lemma exists_a_apply_add_eq : ∃ b c, 0 < c ∧ ∀ n, b < n →
     a (N' a N + 2 * n + 2 * c) = a (N' a N + 2 * n) := by
   obtain ⟨b, c', hbc'⟩ := hc.exists_p_eq a N
   have hs (n : ℕ) : Small a (a (N' a N + 2 * n)) := hc.small_apply_N'_add_iff_even.mpr (by simp)
-  refine ⟨b + 2, c' / 2, ?_, fun n hbn ↦ hbc' n (by omega) ▸ ?_⟩
-  · have := hbc' (b + 2) (by omega)
+  refine ⟨b + 2, c' / 2, ?_, fun n hbn ↦ hbc' n (by lia) ▸ ?_⟩
+  · have := hbc' (b + 2) (by lia)
     have := hc.p_pos (N' a N + 2 * (b + 2))
-    rcases hc.even_p (by omega) (hs (b + 2)) with ⟨_, _⟩
+    rcases hc.even_p (by lia) (hs (b + 2)) with ⟨_, _⟩
     omega
-  · convert hc.apply_add_p_eq (by omega) (hs n) using 3
-    rcases hc.even_p (by omega) (hs n) with ⟨_, ht⟩
+  · convert hc.apply_add_p_eq (by lia) (hs n) using 3
+    rcases hc.even_p (by lia) (hs n) with ⟨_, ht⟩
     simp [ht, ← two_mul]
 
 variable {a N}
@@ -950,8 +950,8 @@ theorem result {a : ℕ → ℕ} {N : ℕ} (h : Condition a N) :
   obtain ⟨b, c, hc, hbc⟩ := h.exists_a_apply_add_eq a N
   obtain ⟨t, _⟩ | ⟨t, _⟩ := Nat.even_or_odd (Condition.N' a N)
   · refine .inl ⟨c, Condition.N' a N / 2 + b + 1, hc, fun m hm ↦ ?_⟩
-    convert hbc (m - t) (by omega) using 1 <;> dsimp only <;> congr <;> omega
+    convert hbc (m - t) (by lia) using 1 <;> dsimp only <;> congr <;> omega
   · refine .inr ⟨c, Condition.N' a N / 2 + b + 1, hc, fun m hm ↦ ?_⟩
-    convert hbc (m - t) (by omega) using 1 <;> dsimp only <;> congr 1 <;> omega
+    convert hbc (m - t) (by lia) using 1 <;> dsimp only <;> congr 1 <;> omega
 
 end Imo2024Q3

--- a/Archive/Imo/Imo2024Q3.lean
+++ b/Archive/Imo/Imo2024Q3.lean
@@ -135,7 +135,7 @@ lemma apply_nth_add_one_eq_of_lt {m n : ℕ} (hn : N < Nat.nth (a · = m) n) :
   refine hc.apply_nth_add_one_eq ?_ hn.le
   by_contra! hf
   have := Nat.nth_eq_zero.2 (.inr hf)
-  omega
+  lia
 
 lemma lt_toFinset_card {j : ℕ} (h : M a N ≤ a (j + 1)) (hf : {i | a i = a j}.Finite) :
     M a N - 1 < #hf.toFinset := by
@@ -153,7 +153,7 @@ lemma apply_add_one_lt_of_apply_eq {i j : ℕ} (hi : N ≤ i) (hij : i < j) (ha 
   refine Finset.card_lt_card (Finset.ssubset_def.mp ⟨Finset.filter_subset_filter _
     (by simp [hij.le]), Finset.not_subset.mpr ⟨j, ?_⟩⟩)
   simp only [Finset.mem_filter, Finset.mem_range, lt_add_iff_pos_right, and_true]
-  omega
+  lia
 
 lemma apply_add_one_ne_of_apply_eq {i j : ℕ} (hi : N ≤ i) (hj : N ≤ j) (hij : i ≠ j)
     (ha : a i = a j) : a (i + 1) ≠ a (j + 1) :=
@@ -209,7 +209,7 @@ lemma empty_consecutive_apply_ge_M : {i | M a N ≤ a i ∧ M a N ≤ a (i + 1)}
     intro H
     rw [←H, M] at hi1
     have a0_le : a 0 ≤ (Finset.range (N + 1)).sup a := Finset.le_sup (by simp)
-    omega
+    lia
   have card_t_eq_card_t' : #t = #t' := by simp [← t_map_eq_t', t]
   have htM : ∀ j ∈ t, a j < M a N := by
     intro j hj
@@ -218,9 +218,9 @@ lemma empty_consecutive_apply_ge_M : {i | M a N ≤ a i ∧ M a N ≤ a (i + 1)}
   have N_le_i : N ≤ i := by
     unfold M at hi1
     by_contra! HH
-    have i_in_range : i ∈ Finset.range (N + 1) := by rw [Finset.mem_range]; omega
+    have i_in_range : i ∈ Finset.range (N + 1) := by rw [Finset.mem_range]; lia
     have ai_le_sup : a i ≤ (Finset.range (N + 1)).sup a := Finset.le_sup i_in_range
-    omega
+    lia
   have ht' : a (i + 1) = #t' := hc.apply_add_one_eq_card N_le_i
   rw [← card_t_eq_card_t'] at ht'
   have ht'inj : Set.InjOn a t := by
@@ -233,7 +233,7 @@ lemma empty_consecutive_apply_ge_M : {i | M a N ≤ a i ∧ M a N ≤ a (i + 1)}
                  forall_apply_eq_imp_iff₂]
       exact fun j hj ↦ ⟨hc.pos _, htM j hj⟩
     · simpa using M_pos a N
-  omega
+  lia
 
 lemma card_lt_M_of_M_le {n : ℕ} (h : M a N ≤ n) :
     ∃ hf : {i | a i = n}.Finite, #hf.toFinset < M a N := by
@@ -315,7 +315,7 @@ lemma finite_setOf_apply_eq_iff_not_small {j : ℕ} (hj : 0 < j) :
 
 lemma finite_setOf_apply_eq_k_add_one : {i | a i = k a + 1}.Finite := by
   rw [hc.finite_setOf_apply_eq_iff_not_small (by lia), Small]
-  omega
+  lia
 
 /-- There are only finitely many `m` that appear more than `k` times. -/
 lemma finite_setOf_k_lt_card : {m | ∀ hf : {i | a i = m}.Finite, k a < #hf.toFinset}.Finite := by
@@ -408,12 +408,12 @@ lemma not_medium_of_N'aux_lt {j : ℕ} (h : N'aux a N < j) : ¬Medium a (a j) :=
 lemma small_or_big_of_N'aux_lt {j : ℕ} (h : N'aux a N < j) : Small a (a j) ∨ Big a (a j) := by
   have _ := hc.not_medium_of_N'aux_lt h
   rw [Small, Medium, Big] at *
-  omega
+  lia
 
 lemma small_or_big_of_N'_le {j : ℕ} (h : N' a N ≤ j) : Small a (a j) ∨ Big a (a j) := by
   refine hc.small_or_big_of_N'aux_lt ?_
   rw [N'] at h
-  split_ifs at h <;> omega
+  split_ifs at h <;> lia
 
 omit hc
 
@@ -465,7 +465,7 @@ lemma N_add_one_lt_card_filter_eq_of_small_of_N'_le {i j : ℕ} (hj0 : 0 < j) (h
     (hN' : N' a N < i) : N + 1 < #{m ∈ Finset.range i | a m = j} := by
   refine hc.N_add_one_lt_card_filter_eq_of_small_of_N'aux_le hj0 h ?_
   rw [N'] at hN'
-  split_ifs at hN' <;> omega
+  split_ifs at hN' <;> lia
 
 lemma apply_add_one_big_of_apply_small_of_N'aux_le {i : ℕ} (h : Small a (a i))
     (hN'aux : N'aux a N ≤ i) : Big a (a (i + 1)) := by
@@ -524,7 +524,7 @@ lemma apply_sub_one_small_of_apply_big_of_N'_le {i : ℕ} (h : Big a (a i)) (hN'
     Small a (a (i - 1)) := by
   have h0i : 1 ≤ i := by
     have := hc.N_lt_N'
-    omega
+    lia
   have h' : N' a N ≤ i - 1 := by
     by_contra hi
     have hi' : i = N' a N := by lia
@@ -580,7 +580,7 @@ lemma setOf_apply_eq_of_apply_big_of_N'_le {i : ℕ} (h : Big a (a i)) (hN' : N'
   rcases hj with ⟨t, ⟨ht1, htk⟩, rfl⟩
   have hN1 : N < a i - 1 := by
     have := hc.N_add_one_lt_apply_of_apply_big_of_N'_le h hN'
-    omega
+    lia
   simp only [add_tsub_cancel_right]
   rw [← Small] at htk
   have htki := htk
@@ -590,7 +590,7 @@ lemma setOf_apply_eq_of_apply_big_of_N'_le {i : ℕ} (h : Big a (a i)) (hN' : N'
   refine ⟨Nat.lt_add_one_iff.mpr ((Nat.le_nth (fun hf ↦ absurd hf htki)).trans
     ((Nat.nth_le_nth htki).2 hN1.le)), ?_⟩
   rw [← Nat.count_eq_card_filter_range, Nat.count_nth_succ_of_infinite htki]
-  omega
+  lia
 
 lemma N_lt_of_apply_eq_of_apply_big_of_N'_le {i j : ℕ} (hj : a j = a i) (h : Big a (a i))
     (hN' : N' a N ≤ i) : N < j :=
@@ -636,7 +636,7 @@ lemma apply_add_one_eq_card_small_le_card_eq {i : ℕ} (hi : N' a N < i) (hib : 
         · exact Nat.sub_add_cancel (hc.one_le_apply _)
         · refine (Nat.le_nth fun hf ↦ absurd hf hts).trans ((Nat.nth_le_nth hts).2 ?_)
           have := hc.N_add_one_lt_apply_of_apply_big_of_N'_le hib hi.le
-          omega
+          lia
   · intro t ht u hu htu
     simp only [Finset.coe_filter, Finset.mem_range, Set.mem_setOf_eq, Nat.lt_add_one_iff] at ht hu
     rw [← Small] at ht hu
@@ -743,7 +743,7 @@ lemma exists_apply_sub_two_eq_of_apply_eq {i j : ℕ} (hi : N' a N + 2 < i) (hij
           simp only [Finset.disjoint_iff_ne, Finset.mem_filter, Finset.mem_range, Finset.mem_Ico,
             and_imp]
           rintro t hti - u hiu - -
-          omega
+          lia
       _ = #{u ∈ Finset.range j | a u = a (j - 2)} := by
           rw [← Finset.filter_union, hiju]
       _ = a (j - 1) := by
@@ -803,7 +803,7 @@ lemma nonempty_pSet (n : ℕ) : (pSet a n).Nonempty := by
   rcases hc.infinite_setOf_apply_eq_one.exists_gt i with ⟨j, hj1, hij⟩
   refine ⟨j - n, ?_⟩
   simp only [pSet, Finset.mem_Ico, Set.mem_setOf_eq]
-  exact ⟨i, ⟨hni.le, by lia⟩, hi1 ▸ ⟨hc.small_one, hj1 ▸ (by congr; omega)⟩⟩
+  exact ⟨i, ⟨hni.le, by lia⟩, hi1 ▸ ⟨hc.small_one, hj1 ▸ (by congr; lia)⟩⟩
 
 lemma exists_mem_Ico_small_and_apply_add_p_eq (n : ℕ) :
     ∃ i ∈ Finset.Ico n (n + p a n), Small a (a i) ∧ a (n + p a n) = a i :=
@@ -825,11 +825,11 @@ lemma card_filter_apply_eq_Ico_add_p_le_one (n : ℕ) {j : ℕ} (hjs : Small a j
   rcases lt_trichotomy x y with hxy | rfl | hxy
   · replace h := h.2 (y - n) x hx.1.1 (by lia) (hx.2 ▸ hjs)
     rw [show n + (y - n) = y by lia, hx.2, hy.2] at h
-    omega
+    lia
   · rfl
   · replace h := h.2 (x - n) y hy.1.1 (by lia) (hy.2 ▸ hjs)
     rw [show n + (x - n) = x by lia, hx.2, hy.2] at h
-    omega
+    lia
 
 lemma apply_add_p_eq {n : ℕ} (hn : N' a N + 2 < n) (hs : Small a (a n)) : a (n + p a n) = a n := by
   rcases hc.exists_mem_Ico_small_and_apply_add_p_eq n with ⟨i, hiIco, his, hin⟩
@@ -890,7 +890,7 @@ lemma p_apply_sub_two_le_p_apply {n : ℕ} (hn : N' a N + 4 < n) (hs : Small a (
   have : p a n ≤ p a (n - 2) - 2 := by
     obtain ⟨_, _⟩ := hc.even_p (by lia) hs
     obtain ⟨_, _⟩ := hc.even_p (by lia) hn2
-    omega
+    lia
   have h := hc.card_filter_apply_eq_Ico_add_p_le_one (n - 2) hn2
   revert h
   simp only [imp_false, not_le, Finset.one_lt_card_iff, Finset.mem_filter, Finset.mem_Ico,
@@ -936,7 +936,7 @@ lemma exists_a_apply_add_eq : ∃ b c, 0 < c ∧ ∀ n, b < n →
   · have := hbc' (b + 2) (by lia)
     have := hc.p_pos (N' a N + 2 * (b + 2))
     rcases hc.even_p (by lia) (hs (b + 2)) with ⟨_, _⟩
-    omega
+    lia
   · convert hc.apply_add_p_eq (by lia) (hs n) using 3
     rcases hc.even_p (by lia) (hs n) with ⟨_, ht⟩
     simp [ht, ← two_mul]
@@ -950,8 +950,8 @@ theorem result {a : ℕ → ℕ} {N : ℕ} (h : Condition a N) :
   obtain ⟨b, c, hc, hbc⟩ := h.exists_a_apply_add_eq a N
   obtain ⟨t, _⟩ | ⟨t, _⟩ := Nat.even_or_odd (Condition.N' a N)
   · refine .inl ⟨c, Condition.N' a N / 2 + b + 1, hc, fun m hm ↦ ?_⟩
-    convert hbc (m - t) (by lia) using 1 <;> dsimp only <;> congr <;> omega
+    convert hbc (m - t) (by lia) using 1 <;> dsimp only <;> congr <;> lia
   · refine .inr ⟨c, Condition.N' a N / 2 + b + 1, hc, fun m hm ↦ ?_⟩
-    convert hbc (m - t) (by lia) using 1 <;> dsimp only <;> congr 1 <;> omega
+    convert hbc (m - t) (by lia) using 1 <;> dsimp only <;> congr 1 <;> lia
 
 end Imo2024Q3

--- a/Archive/Imo/Imo2024Q5.lean
+++ b/Archive/Imo/Imo2024Q5.lean
@@ -109,7 +109,7 @@ def row1 (hN : 2 ≤ N) : InteriorRow N :=
   ⟨1, ⟨by lia, by
     rw [Fin.le_def]
     simp
-    omega⟩⟩
+    lia⟩⟩
 
 lemma coe_coe_row1 (hN : 2 ≤ N) : (((row1 hN) : Fin (N + 2)) : ℕ) = 1 :=
   rfl
@@ -118,9 +118,9 @@ lemma coe_coe_row1 (hN : 2 ≤ N) : (((row1 hN) : Fin (N + 2)) : ℕ) = 1 :=
 def row2 (hN : 2 ≤ N) : InteriorRow N :=
   ⟨⟨2, by lia⟩, ⟨by
     simp only [Fin.le_def, Fin.val_one]
-    omega, by
+    lia, by
     simp only [Fin.le_def]
-    omega⟩⟩
+    lia⟩⟩
 
 /-- Reflecting monster data. -/
 def MonsterData.reflect (m : MonsterData N) : MonsterData N where
@@ -175,7 +175,7 @@ lemma MonsterData.mk_mem_monsterCells_iff {m : MonsterData N} {r : Fin (N + 2)}
 lemma Adjacent.le_of_lt {x y : Cell N} (ha : Adjacent x y) {r : Fin (N + 2)} (hr : r < y.1) :
     r ≤ x.1 := by
   rw [Adjacent, Nat.dist] at ha
-  omega
+  lia
 
 /-! ### API definitions and lemmas about `Path` -/
 
@@ -199,7 +199,7 @@ lemma Path.exists_mem_fst_eq (p : Path N) (r : Fin (N + 2)) : ∃ c ∈ p.cells,
     have ha : Adjacent p.cells[i - 1] p.cells[i] := by
       convert List.isChain_iff_getElem.1 p.valid_move_seq (i - 1) ?_
       · simp [Nat.sub_add_cancel hi]
-      · omega
+      · lia
     exact ha.le_of_lt h
 
 lemma Path.exists_mem_le_fst (p : Path N) (r : Fin (N + 2)) : ∃ c ∈ p.cells, r ≤ c.1 := by
@@ -240,7 +240,7 @@ lemma find?_eq_eq_find?_le {l : List (Cell N)} {r : Fin (N + 2)} (hne : l ≠ []
         simp only [ne_eq, reduceCtorEq, not_false_eq_true, List.head_cons, ha2, true_implies] at hi
         refine hi ?_
         simp only [Adjacent, Nat.dist] at ha1
-        omega
+        lia
 
 lemma Path.findFstEq_eq_find?_le (p : Path N) (r : Fin (N + 2)) : p.findFstEq r =
     (p.cells.find? (fun c ↦ r ≤ c.1)).get
@@ -399,7 +399,7 @@ lemma Path.findFstEq_fst_sub_one_mem (p : Path N) {r : Fin (N + 2)} (hr : r ≠ 
   simp only [Adjacent, Nat.dist] at ha
   have hrm : N + 1 + (r : ℕ) = N + 2 + (r - 1) := by lia
   simp only [Prod.ext_iff, Fin.ext_iff]
-  omega
+  lia
 
 lemma Path.mem_of_firstMonster_eq_some {p : Path N} {m : MonsterData N} {c : Cell N}
     (h : p.firstMonster m = some c) : c ∈ p.cells ∧ c ∈ m.monsterCells := by
@@ -450,7 +450,7 @@ def Path.reflect (p : Path N) : Path N where
     refine List.isChain_map_of_isChain _ ?_ p.valid_move_seq
     intro x y h
     simp_rw [Adjacent, Nat.dist, Cell.reflect, Fin.rev] at h ⊢
-    omega
+    lia
 
 lemma Path.firstMonster_reflect (p : Path N) (m : MonsterData N) :
     p.reflect.firstMonster m.reflect = (p.firstMonster m).map Cell.reflect := by
@@ -548,7 +548,7 @@ lemma monsterData12_apply_row2 (hN : 2 ≤ N) {c₁ c₂ : Fin (N + 1)} (h : c�
   · exact Function.Embedding.setValue_eq _ _ _
   · simp only [row1, row2, ne_eq, Subtype.mk.injEq]
     simp only [Fin.ext_iff, Fin.val_one]
-    omega
+    lia
   · rw [Function.Embedding.setValue_eq]
     exact h.symm
 
@@ -608,15 +608,15 @@ def fn0 (N : ℕ) : Fin (2 * N + 2) → Cell N :=
 lemma injective_fn0 (N : ℕ) : Function.Injective (fn0 N) := by
   intro ⟨a₁, _⟩ ⟨a₂, _⟩
   simp_rw [fn0]
-  split_ifs <;> simp [Prod.ext_iff] at * <;> omega
+  split_ifs <;> simp [Prod.ext_iff] at * <;> lia
 
 /-- The first attempt in a winning strategy, as a `Path`. -/
 def path0 (hN : 2 ≤ N) : Path N := Path.ofFn (fn0 N) (by lia) (by simp [fn0])
-  (by simp only [fn0]; split_ifs with h <;> simp at h ⊢ <;> omega)
+  (by simp only [fn0]; split_ifs with h <;> simp at h ⊢ <;> lia)
   (by
     simp only [fn0]
     intro i hi
-    split_ifs <;> simp [Adjacent, Nat.dist] at * <;> omega)
+    split_ifs <;> simp [Adjacent, Nat.dist] at * <;> lia)
 
 /-- The second attempt in a winning strategy, as a function, if the monster in the second row
 is not at an edge: pass to the left of that monster then along its column. -/
@@ -628,13 +628,13 @@ def fn1OfNotEdge {c₁ : Fin (N + 1)} (hc₁ : c₁ ≠ 0) : Fin (N + 3) → Cel
 is not at an edge. -/
 def path1OfNotEdge {c₁ : Fin (N + 1)} (hc₁ : c₁ ≠ 0) : Path N := Path.ofFn (fn1OfNotEdge hc₁)
     (by lia) (by simp [fn1OfNotEdge])
-    (by simp only [fn1OfNotEdge]; split_ifs <;> simp; omega)
+    (by simp only [fn1OfNotEdge]; split_ifs <;> simp; lia)
     (by
       simp only [fn1OfNotEdge]
       intro i hi
       rcases c₁ with ⟨c₁, hc₁N⟩
       rw [← Fin.val_ne_iff] at hc₁
-      split_ifs <;> simp [Adjacent, Nat.dist] at * <;> omega)
+      split_ifs <;> simp [Adjacent, Nat.dist] at * <;> lia)
 
 /-- The third attempt in a winning strategy, as a function, if the monster in the second row
 is not at an edge: pass to the right of that monster then along its column. -/
@@ -646,11 +646,11 @@ def fn2OfNotEdge {c₁ : Fin (N + 1)} (hc₁ : (c₁ : ℕ) ≠ N) : Fin (N + 3)
 is not at an edge. -/
 def path2OfNotEdge {c₁ : Fin (N + 1)} (hc₁ : (c₁ : ℕ) ≠ N) : Path N := Path.ofFn (fn2OfNotEdge hc₁)
     (by lia) (by simp [fn2OfNotEdge])
-    (by simp only [fn2OfNotEdge]; split_ifs <;> simp; omega)
+    (by simp only [fn2OfNotEdge]; split_ifs <;> simp; lia)
     (by
       simp only [fn2OfNotEdge]
       intro i hi
-      split_ifs <;> simp [Adjacent, Nat.dist] at * <;> omega)
+      split_ifs <;> simp [Adjacent, Nat.dist] at * <;> lia)
 
 /-- The second attempt in a winning strategy, as a function, if the monster in the second row
 is at the left edge: zigzag across the board so that, if we encounter a monster, we have a third
@@ -662,12 +662,12 @@ def fn1OfEdge0 (N : ℕ) : Fin (2 * N + 1) → Cell N :=
 /-- The second attempt in a winning strategy, as a `Path`, if the monster in the second row
 is at the left edge. -/
 def path1OfEdge0 (hN : 2 ≤ N) : Path N := Path.ofFn (fn1OfEdge0 N) (by lia)
-    (by simp only [fn1OfEdge0]; split_ifs <;> simp; omega)
+    (by simp only [fn1OfEdge0]; split_ifs <;> simp; lia)
     (by simp [fn1OfEdge0])
     (by
       simp only [fn1OfEdge0]
       intro i hi
-      split_ifs <;> simp [Adjacent, Nat.dist] at * <;> omega)
+      split_ifs <;> simp [Adjacent, Nat.dist] at * <;> lia)
 
 /-- The second attempt in a winning strategy, as a `Path`, if the monster in the second row
 is at the right edge. -/
@@ -686,18 +686,18 @@ def fn2OfEdge0 {r : Fin (N + 2)} (hr : (r : ℕ) ≤ N) : Fin (N + 2 * r - 1) �
 lemma fn2OfEdge0_apply_eq_fn1OfEdge0_apply_of_lt {r : Fin (N + 2)} (hr : (r : ℕ) ≤ N) {i : ℕ}
     (h : i + 2 < 2 * (r : ℕ)) : fn2OfEdge0 hr ⟨i, by lia⟩ = fn1OfEdge0 N ⟨i, by lia⟩ := by
   rw [fn1OfEdge0, fn2OfEdge0]
-  split_ifs with h₁ h₂ <;> simp [Prod.ext_iff] at * <;> omega
+  split_ifs with h₁ h₂ <;> simp [Prod.ext_iff] at * <;> lia
 
 /-- The third attempt in a winning strategy, as a `Path`, if the monster in the second row
 is at the left edge and the second (zigzag) attempt encountered a monster. -/
 def path2OfEdge0 (hN : 2 ≤ N) {r : Fin (N + 2)} (hr2 : 2 ≤ (r : ℕ)) (hrN : (r : ℕ) ≤ N) : Path N :=
   Path.ofFn (fn2OfEdge0 hrN) (by lia)
-    (by simp only [fn2OfEdge0]; split_ifs <;> simp <;> omega)
-    (by simp only [fn2OfEdge0]; split_ifs <;> simp <;> omega)
+    (by simp only [fn2OfEdge0]; split_ifs <;> simp <;> lia)
+    (by simp only [fn2OfEdge0]; split_ifs <;> simp <;> lia)
     (by
       simp only [fn2OfEdge0]
       intro i hi
-      split_ifs <;> simp [Adjacent, Nat.dist] at * <;> omega)
+      split_ifs <;> simp [Adjacent, Nat.dist] at * <;> lia)
 
 /-- The third attempt in a winning strategy, as a `Path`, if the monster in the second row
 is at the left edge and the second (zigzag) attempt encountered a monster, version that works
@@ -737,7 +737,7 @@ lemma path0_firstMonster_eq_apply_row1 (hN : 2 ≤ N) (m : MonsterData N) :
   simp_rw [path0, Path.firstMonster, Path.ofFn]
   have h : (1, m (row1 hN)) = fn0 N ⟨(m (row1 hN) : ℕ) + 1, by lia⟩ := by
     simp_rw [fn0]
-    split_ifs <;> simp [Prod.ext_iff] at *; omega
+    split_ifs <;> simp [Prod.ext_iff] at *; lia
   rw [h, List.find?_ofFn_eq_some_of_injective (injective_fn0 N)]
   refine ⟨?_, fun j hj ↦ ?_⟩
   · rw [fn0]
@@ -814,7 +814,7 @@ lemma path1_firstMonster_of_not_edge (hN : 2 ≤ N) {m : MonsterData N} (hc₁0 
   · refine .inl ?_
     simp only [MonsterData.monsterCells, Set.mem_range, Prod.mk.injEq, Fin.ext_iff,
       EmbeddingLike.apply_eq_iff_eq, exists_eq_right, coe_coe_row1]
-    omega
+    lia
 
 lemma path2_firstMonster_of_not_edge (hN : 2 ≤ N) {m : MonsterData N} (hc₁0 : m (row1 hN) ≠ 0)
     (hc₁N : (m (row1 hN) : ℕ) ≠ N) (r : Fin (N + 2)) :
@@ -852,7 +852,7 @@ lemma path2_firstMonster_of_not_edge (hN : 2 ≤ N) {m : MonsterData N} (hc₁0 
   · refine .inl ?_
     simp only [MonsterData.monsterCells, Set.mem_range, Prod.mk.injEq, Fin.ext_iff,
       EmbeddingLike.apply_eq_iff_eq, exists_eq_right, coe_coe_row1]
-    omega
+    lia
 
 lemma winningStrategy_play_one_eq_none_or_play_two_eq_none_of_not_edge (hN : 2 ≤ N)
     {m : MonsterData N} (hc₁0 : m (row1 hN) ≠ 0) (hc₁N : (m (row1 hN) : ℕ) ≠ N) :
@@ -885,7 +885,7 @@ lemma path2OfEdge0_firstMonster_eq_none_of_path1OfEdge0_firstMonster_eq_some (hN
   rcases hx with ⟨hx, i, hix, hnm⟩
   have hi : (x.1 : ℕ) = ((i : ℕ) + 1) / 2 := by
     rw [fn1OfEdge0] at hix
-    split_ifs at hix <;> simp [Prod.ext_iff, Fin.ext_iff] at hix <;> omega
+    split_ifs at hix <;> simp [Prod.ext_iff, Fin.ext_iff] at hix <;> lia
   have hi' : (i : ℕ) ≠ 2 * N := by
     intro h
     rw [← hix, fn1OfEdge0, dif_pos h] at hx
@@ -897,16 +897,16 @@ lemma path2OfEdge0_firstMonster_eq_none_of_path1OfEdge0_firstMonster_eq_some (hN
     simp_rw [Fin.lt_def] at hnm
     refine hnm _ ?_
     simp only
-    omega
+    lia
   · rw [fn2OfEdge0, dif_neg h]
     split_ifs with h'
     · have hx1 : 1 ≤ x.1 := by
         rw [Fin.le_def, Fin.val_one]
-        omega
+        lia
       rw [MonsterData.mk_mem_monsterCells_iff_of_le hx1 hxN]
       rw [MonsterData.mem_monsterCells_iff_of_le hx1 hxN] at hx
       simp_rw [hx, ← hix, fn1OfEdge0]
-      split_ifs <;> simp <;> omega
+      split_ifs <;> simp <;> lia
     · rw [MonsterData.mk_mem_monsterCells_iff]
       simp only [not_exists]
       intro h1 hN'
@@ -914,7 +914,7 @@ lemma path2OfEdge0_firstMonster_eq_none_of_path1OfEdge0_firstMonster_eq_some (hN
       refine m.injective.ne ?_
       rw [← Subtype.coe_ne_coe, ← Fin.val_ne_iff, coe_coe_row1]
       simp only
-      omega
+      lia
 
 set_option linter.flexible false in
 lemma winningStrategy_play_one_eq_none_or_play_two_eq_none_of_edge_zero (hN : 2 ≤ N)
@@ -938,18 +938,18 @@ lemma winningStrategy_play_one_eq_none_or_play_two_eq_none_of_edge_zero (hN : 2 
       by_contra hi
       interval_cases i <;> rw [fn1OfEdge0] at hm <;> split_ifs at hm with h
       · simp at h
-        omega
+        lia
       · simp at hm
         exact m.notMem_monsterCells_of_fst_eq_zero rfl hm
       · simp at h
-        omega
+        lia
       · dsimp only [Nat.reduceAdd, Nat.reduceDiv, Fin.mk_one] at hm
         have h1N : 1 ≤ N := by lia
         rw [m.mk_mem_monsterCells_iff_of_le (le_refl _) h1N] at hm
         rw [row1, hm, Fin.ext_iff] at hc₁0
         simp at hc₁0
       · simp at h
-        omega
+        lia
       · simp only at hm
         norm_num at hm
         have h1N : 1 ≤ N := by lia
@@ -957,7 +957,7 @@ lemma winningStrategy_play_one_eq_none_or_play_two_eq_none_of_edge_zero (hN : 2 
         rw [row1, hm] at hc₁0
         simp at hc₁0
     rw [fn1OfEdge0]
-    split_ifs <;> simp <;> omega
+    split_ifs <;> simp <;> lia
   rw [path2, if_pos hc₁0, path2OfEdge0Def, dif_pos hx2N]
   exact path2OfEdge0_firstMonster_eq_none_of_path1OfEdge0_firstMonster_eq_some hN hx2N.1
     hx2N.2 hc₁0 hx.symm
@@ -967,7 +967,7 @@ lemma winningStrategy_play_one_of_edge_N (hN : 2 ≤ N) {m : MonsterData N}
       ((winningStrategy hN).play m.reflect 3 ⟨1, by simp⟩).map Cell.reflect := by
   have hc₁0 : m (row1 hN) ≠ 0 := by
     rw [← Fin.val_ne_iff, hc₁N, Fin.val_zero]
-    omega
+    lia
   have hc₁r0 : m.reflect (row1 hN) = 0 := by
     simp only [MonsterData.reflect, Function.Embedding.coeFn_mk, Function.comp_apply,
       ← Fin.rev_last, Fin.rev_inj]
@@ -981,7 +981,7 @@ lemma winningStrategy_play_two_of_edge_N (hN : 2 ≤ N) {m : MonsterData N}
       ((winningStrategy hN).play m.reflect 3 ⟨2, by simp⟩).map Cell.reflect := by
   have hc₁0 : m (row1 hN) ≠ 0 := by
     rw [← Fin.val_ne_iff, hc₁N, Fin.val_zero]
-    omega
+    lia
   have hc₁r0 : m.reflect (row1 hN) = 0 := by
     simp only [MonsterData.reflect, Function.Embedding.coeFn_mk, Function.comp_apply,
       ← Fin.rev_last, Fin.rev_inj]

--- a/Archive/Imo/Imo2024Q5.lean
+++ b/Archive/Imo/Imo2024Q5.lean
@@ -52,7 +52,7 @@ variable {N : ℕ}
 abbrev Cell (N : ℕ) : Type := Fin (N + 2) × Fin (N + 1)
 
 /-- A row that is neither the first nor the last (and thus contains a monster). -/
-abbrev InteriorRow (N : ℕ) : Type := (Set.Icc 1 ⟨N, by omega⟩ : Set (Fin (N + 2)))
+abbrev InteriorRow (N : ℕ) : Type := (Set.Icc 1 ⟨N, by lia⟩ : Set (Fin (N + 2)))
 
 /-- Data for valid positions of the monsters. -/
 abbrev MonsterData (N : ℕ) : Type := InteriorRow N ↪ Fin (N + 1)
@@ -106,7 +106,7 @@ def Cell.reflect (c : Cell N) : Cell N := (c.1, c.2.rev)
 
 /-- The row 1, in the form required for MonsterData. -/
 def row1 (hN : 2 ≤ N) : InteriorRow N :=
-  ⟨1, ⟨by omega, by
+  ⟨1, ⟨by lia, by
     rw [Fin.le_def]
     simp
     omega⟩⟩
@@ -116,7 +116,7 @@ lemma coe_coe_row1 (hN : 2 ≤ N) : (((row1 hN) : Fin (N + 2)) : ℕ) = 1 :=
 
 /-- The row 2, in the form required for MonsterData. -/
 def row2 (hN : 2 ≤ N) : InteriorRow N :=
-  ⟨⟨2, by omega⟩, ⟨by
+  ⟨⟨2, by lia⟩, ⟨by
     simp only [Fin.le_def, Fin.val_one]
     omega, by
     simp only [Fin.le_def]
@@ -147,7 +147,7 @@ lemma MonsterData.le_N_of_mem_monsterCells {m : MonsterData N} {c : Cell N}
   exact hN
 
 lemma MonsterData.mk_mem_monsterCells_iff_of_le {m : MonsterData N} {r : Fin (N + 2)}
-    (hr1 : 1 ≤ r) (hrN : r ≤ ⟨N, by omega⟩) {c : Fin (N + 1)} :
+    (hr1 : 1 ≤ r) (hrN : r ≤ ⟨N, by lia⟩) {c : Fin (N + 1)} :
     (r, c) ∈ m.monsterCells ↔ m ⟨r, hr1, hrN⟩ = c := by
   simp only [monsterCells, Set.mem_range, Prod.mk.injEq]
   refine ⟨?_, ?_⟩
@@ -157,13 +157,13 @@ lemma MonsterData.mk_mem_monsterCells_iff_of_le {m : MonsterData N} {r : Fin (N 
     exact ⟨⟨r, hr1, hrN⟩, rfl, rfl⟩
 
 lemma MonsterData.mem_monsterCells_iff_of_le {m : MonsterData N} {x : Cell N}
-    (hr1 : 1 ≤ x.1) (hrN : x.1 ≤ ⟨N, by omega⟩) :
+    (hr1 : 1 ≤ x.1) (hrN : x.1 ≤ ⟨N, by lia⟩) :
     x ∈ m.monsterCells ↔ m ⟨x.1, hr1, hrN⟩ = x.2 :=
   MonsterData.mk_mem_monsterCells_iff_of_le hr1 hrN
 
 lemma MonsterData.mk_mem_monsterCells_iff {m : MonsterData N} {r : Fin (N + 2)}
     {c : Fin (N + 1)} :
-    (r, c) ∈ m.monsterCells ↔ ∃ (hr1 : 1 ≤ r) (hrN : r ≤ ⟨N, by omega⟩), m ⟨r, hr1, hrN⟩ = c := by
+    (r, c) ∈ m.monsterCells ↔ ∃ (hr1 : 1 ≤ r) (hrN : r ≤ ⟨N, by lia⟩), m ⟨r, hr1, hrN⟩ = c := by
   refine ⟨fun h ↦ ?_, fun ⟨hr1, hrN, h⟩ ↦ (mem_monsterCells_iff_of_le hr1 hrN).2 h⟩
   rcases h with ⟨⟨mr, hr1, hrN⟩, h⟩
   simp only [Prod.mk.injEq] at h
@@ -194,7 +194,7 @@ lemma Path.exists_mem_fst_eq (p : Path N) (r : Fin (N + 2)) : ∃ c ∈ p.cells,
   rcases Nat.eq_zero_or_pos i with hi | hi
   · simp only [hi, List.getElem_zero, p.head_first_row, Fin.not_lt_zero] at h
   · suffices r ≤ p.cells[i - 1].1 by
-      have hi' : i - 1 < i := by omega
+      have hi' : i - 1 < i := by lia
       exact of_decide_eq_false (List.not_of_lt_findIdx hi') this
     have ha : Adjacent p.cells[i - 1] p.cells[i] := by
       convert List.isChain_iff_getElem.1 p.valid_move_seq (i - 1) ?_
@@ -262,7 +262,7 @@ lemma Path.firstMonster_eq_none {p : Path N} {m : MonsterData N} :
 
 lemma Path.one_lt_length_cells (p : Path N) : 1 < p.cells.length := by
   by_contra hl
-  have h : p.cells.length = 0 ∨ p.cells.length = 1 := by omega
+  have h : p.cells.length = 0 ∨ p.cells.length = 1 := by lia
   rcases h with h | h
   · rw [List.length_eq_zero_iff] at h
     exact p.nonempty h
@@ -339,13 +339,13 @@ lemma Path.firstMonster_eq_of_findFstEq_mem {p : Path N} {m : MonsterData N}
   case base p h0 =>
     have hl := p.one_lt_length_cells
     have adj : Adjacent p.cells[0] p.cells[1] :=
-      List.isChain_iff_getElem.1 p.valid_move_seq 0 (by omega)
+      List.isChain_iff_getElem.1 p.valid_move_seq 0 (by lia)
     simp_rw [Adjacent, Nat.dist] at adj
     have hc0 : (p.cells[0].1 : ℕ) = 0 := by
       convert Fin.ext_iff.1 p.head_first_row
       exact List.getElem_zero _
     have hc1 : (p.cells[1].1 : ℕ) ≠ 0 := Fin.val_ne_iff.2 h0
-    have h1 : (p.cells[1].1 : ℕ) = 1 := by omega
+    have h1 : (p.cells[1].1 : ℕ) = 1 := by lia
     simp_rw [firstMonster, findFstEq]
     rcases p with ⟨cells, nonempty, head_first_row, last_last_row, valid_move_seq⟩
     rcases cells with ⟨⟩ | ⟨head, tail⟩
@@ -370,7 +370,7 @@ lemma Path.firstMonster_eq_of_findFstEq_mem {p : Path N} {m : MonsterData N}
     exact ht h
 
 lemma Path.findFstEq_fst_sub_one_mem (p : Path N) {r : Fin (N + 2)} (hr : r ≠ 0) :
-    (⟨(r : ℕ) - 1, by omega⟩, (p.findFstEq r).2) ∈ p.cells := by
+    (⟨(r : ℕ) - 1, by lia⟩, (p.findFstEq r).2) ∈ p.cells := by
   rw [findFstEq_eq_find?_le]
   have h1 := p.one_lt_length_cells
   obtain ⟨cr, hcrc, hcrr⟩ := p.exists_mem_fst_eq r
@@ -381,7 +381,7 @@ lemma Path.findFstEq_fst_sub_one_mem (p : Path N) {r : Fin (N + 2)} (hr : r ≠ 
   have ht : cells.takeWhile (fun c ↦ ! decide (r ≤ c.1)) ≠ [] := by
     intro h
     rw [List.takeWhile_eq_nil_iff] at h
-    replace h := h (by omega)
+    replace h := h (by lia)
     simp [List.getElem_zero, head_first_row, hr] at h
   simp_rw [cells.find?_eq_head_dropWhile_not hd, Option.get_some]
   rw [← cells.takeWhile_append_dropWhile (p := fun c ↦ ! decide (r ≤ c.1)),
@@ -397,7 +397,7 @@ lemma Path.findFstEq_fst_sub_one_mem (p : Path N) {r : Fin (N + 2)} (hr : r ≠ 
   have hdr : r ≤ ((List.dropWhile (fun c ↦ !decide (r ≤ c.1)) cells).head hd').1 := by
     simpa using cells.head_dropWhile_not (fun c ↦ !decide (r ≤ c.1)) hd'
   simp only [Adjacent, Nat.dist] at ha
-  have hrm : N + 1 + (r : ℕ) = N + 2 + (r - 1) := by omega
+  have hrm : N + 1 + (r : ℕ) = N + 2 + (r - 1) := by lia
   simp only [Prod.ext_iff, Fin.ext_iff]
   omega
 
@@ -412,7 +412,7 @@ lemma Path.mem_of_firstMonster_eq_some {p : Path N} {m : MonsterData N} {c : Cel
 /-- Convert a function giving the cells of a path to a `Path`. -/
 def Path.ofFn {m : ℕ} (f : Fin m → Cell N) (hm : m ≠ 0)
     (hf : (f ⟨0, Nat.pos_of_ne_zero hm⟩).1 = 0)
-    (hl : (f ⟨m - 1, Nat.sub_one_lt hm⟩).1 = ⟨N + 1, by omega⟩)
+    (hl : (f ⟨m - 1, Nat.sub_one_lt hm⟩).1 = ⟨N + 1, by lia⟩)
     (ha : ∀ (i : ℕ) (hi : i + 1 < m), Adjacent (f ⟨i, Nat.lt_of_succ_lt hi⟩) (f ⟨i + 1, hi⟩)) :
     Path N where
   cells := List.ofFn f
@@ -426,7 +426,7 @@ def Path.ofFn {m : ℕ} (f : Fin m → Cell N) (hm : m ≠ 0)
 
 lemma Path.ofFn_cells {m : ℕ} (f : Fin m → Cell N) (hm : m ≠ 0)
     (hf : (f ⟨0, Nat.pos_of_ne_zero hm⟩).1 = 0)
-    (hl : (f ⟨m - 1, Nat.sub_one_lt hm⟩).1 = ⟨N + 1, by omega⟩)
+    (hl : (f ⟨m - 1, Nat.sub_one_lt hm⟩).1 = ⟨N + 1, by lia⟩)
     (ha : ∀ (i : ℕ) (hi : i + 1 < m), Adjacent (f ⟨i, Nat.lt_of_succ_lt hi⟩) (f ⟨i + 1, hi⟩)) :
     (Path.ofFn f hm hf hl ha).cells = List.ofFn f :=
   rfl
@@ -483,13 +483,13 @@ lemma Strategy.play_apply_of_le (s : Strategy N) (m : MonsterData N) {i k₁ k�
 
 lemma Strategy.play_zero (s : Strategy N) (m : MonsterData N) {k : ℕ} (hk : 0 < k) :
     s.play m k ⟨0, hk⟩ = (s Fin.elim0).firstMonster m := by
-  have hk' : 1 ≤ k := by omega
+  have hk' : 1 ≤ k := by lia
   rw [s.play_apply_of_le m zero_lt_one hk']
   rfl
 
 lemma Strategy.play_one (s : Strategy N) (m : MonsterData N) {k : ℕ} (hk : 1 < k) :
     s.play m k ⟨1, hk⟩ = (s ![(s Fin.elim0).firstMonster m]).firstMonster m := by
-  have hk' : 2 ≤ k := by omega
+  have hk' : 2 ≤ k := by lia
   rw [s.play_apply_of_le m one_lt_two hk']
   simp only [play, Fin.snoc, lt_self_iff_false, ↓reduceDIte, Nat.reduceAdd,
     Fin.mk_one, Fin.isValue, cast_eq, Nat.succ_eq_add_one]
@@ -501,7 +501,7 @@ lemma Strategy.play_one (s : Strategy N) (m : MonsterData N) {k : ℕ} (hk : 1 <
 lemma Strategy.play_two (s : Strategy N) (m : MonsterData N) {k : ℕ} (hk : 2 < k) :
     s.play m k ⟨2, hk⟩ = (s ![(s Fin.elim0).firstMonster m,
       (s ![(s Fin.elim0).firstMonster m]).firstMonster m]).firstMonster m := by
-  have hk' : 3 ≤ k := by omega
+  have hk' : 3 ≤ k := by lia
   rw [s.play_apply_of_le m (by simp : 2 < 3) hk']
   simp only [play, Fin.snoc, lt_self_iff_false, ↓reduceDIte, Nat.reduceAdd, cast_eq,
     Nat.succ_eq_add_one]
@@ -557,13 +557,13 @@ lemma row1_mem_monsterCells_monsterData12 (hN : 2 ≤ N) (c₁ c₂ : Fin (N + 1
   exact Set.mem_range_self (row1 hN)
 
 lemma row2_mem_monsterCells_monsterData12 (hN : 2 ≤ N) {c₁ c₂ : Fin (N + 1)} (h : c₁ ≠ c₂) :
-    (⟨2, by omega⟩, c₂) ∈ (monsterData12 hN c₁ c₂).monsterCells := by
+    (⟨2, by lia⟩, c₂) ∈ (monsterData12 hN c₁ c₂).monsterCells := by
   convert Set.mem_range_self (row2 hN)
   exact (monsterData12_apply_row2 hN h).symm
 
 lemma Strategy.not_forcesWinIn_two (s : Strategy N) (hN : 2 ≤ N) : ¬ s.ForcesWinIn 2 := by
-  have : NeZero N := ⟨by omega⟩
-  have : 0 < N := by omega
+  have : NeZero N := ⟨by lia⟩
+  have : 0 < N := by lia
   simp only [ForcesWinIn, WinsIn, Set.mem_range, not_forall, not_exists, Option.ne_none_iff_isSome]
   let m1 : Cell N := (s Fin.elim0).findFstEq 1
   let m2 : Cell N := (s ![m1]).findFstEq 2
@@ -594,7 +594,7 @@ lemma Strategy.not_forcesWinIn_two (s : Strategy N) (hN : 2 ≤ N) : ¬ s.Forces
 lemma Strategy.ForcesWinIn.three_le {s : Strategy N} {k : ℕ} (hf : s.ForcesWinIn k)
     (hN : 2 ≤ N) : 3 ≤ k := by
   by_contra hk
-  exact s.not_forcesWinIn_two hN (Strategy.ForcesWinIn.mono s hf (by omega))
+  exact s.not_forcesWinIn_two hN (Strategy.ForcesWinIn.mono s hf (by lia))
 
 /-! ### Proof of upper bound and constructions used therein -/
 
@@ -602,8 +602,8 @@ lemma Strategy.ForcesWinIn.three_le {s : Strategy N} {k : ℕ} (hf : s.ForcesWin
 locate the monster there. -/
 def fn0 (N : ℕ) : Fin (2 * N + 2) → Cell N :=
   fun i ↦ if i = 0 then (0, 0) else
-    if h : (i : ℕ) < N + 2 then (1, ⟨(i : ℕ) - 1, by omega⟩) else
-    (⟨i - N, by omega⟩, ⟨N, by omega⟩)
+    if h : (i : ℕ) < N + 2 then (1, ⟨(i : ℕ) - 1, by lia⟩) else
+    (⟨i - N, by lia⟩, ⟨N, by lia⟩)
 
 lemma injective_fn0 (N : ℕ) : Function.Injective (fn0 N) := by
   intro ⟨a₁, _⟩ ⟨a₂, _⟩
@@ -611,7 +611,7 @@ lemma injective_fn0 (N : ℕ) : Function.Injective (fn0 N) := by
   split_ifs <;> simp [Prod.ext_iff] at * <;> omega
 
 /-- The first attempt in a winning strategy, as a `Path`. -/
-def path0 (hN : 2 ≤ N) : Path N := Path.ofFn (fn0 N) (by omega) (by simp [fn0])
+def path0 (hN : 2 ≤ N) : Path N := Path.ofFn (fn0 N) (by lia) (by simp [fn0])
   (by simp only [fn0]; split_ifs with h <;> simp at h ⊢ <;> omega)
   (by
     simp only [fn0]
@@ -621,13 +621,13 @@ def path0 (hN : 2 ≤ N) : Path N := Path.ofFn (fn0 N) (by omega) (by simp [fn0]
 /-- The second attempt in a winning strategy, as a function, if the monster in the second row
 is not at an edge: pass to the left of that monster then along its column. -/
 def fn1OfNotEdge {c₁ : Fin (N + 1)} (hc₁ : c₁ ≠ 0) : Fin (N + 3) → Cell N :=
-  fun i ↦ if h : (i : ℕ) ≤ 2 then (⟨(i : ℕ), by omega⟩, ⟨(c₁ : ℕ) - 1, by omega⟩) else
-    (⟨(i : ℕ) - 1, by omega⟩, c₁)
+  fun i ↦ if h : (i : ℕ) ≤ 2 then (⟨(i : ℕ), by lia⟩, ⟨(c₁ : ℕ) - 1, by lia⟩) else
+    (⟨(i : ℕ) - 1, by lia⟩, c₁)
 
 /-- The second attempt in a winning strategy, as a function, if the monster in the second row
 is not at an edge. -/
 def path1OfNotEdge {c₁ : Fin (N + 1)} (hc₁ : c₁ ≠ 0) : Path N := Path.ofFn (fn1OfNotEdge hc₁)
-    (by omega) (by simp [fn1OfNotEdge])
+    (by lia) (by simp [fn1OfNotEdge])
     (by simp only [fn1OfNotEdge]; split_ifs <;> simp; omega)
     (by
       simp only [fn1OfNotEdge]
@@ -639,13 +639,13 @@ def path1OfNotEdge {c₁ : Fin (N + 1)} (hc₁ : c₁ ≠ 0) : Path N := Path.of
 /-- The third attempt in a winning strategy, as a function, if the monster in the second row
 is not at an edge: pass to the right of that monster then along its column. -/
 def fn2OfNotEdge {c₁ : Fin (N + 1)} (hc₁ : (c₁ : ℕ) ≠ N) : Fin (N + 3) → Cell N :=
-  fun i ↦ if h : (i : ℕ) ≤ 2 then (⟨(i : ℕ), by omega⟩, ⟨(c₁ : ℕ) + 1, by omega⟩) else
-    (⟨(i : ℕ) - 1, by omega⟩, c₁)
+  fun i ↦ if h : (i : ℕ) ≤ 2 then (⟨(i : ℕ), by lia⟩, ⟨(c₁ : ℕ) + 1, by lia⟩) else
+    (⟨(i : ℕ) - 1, by lia⟩, c₁)
 
 /-- The third attempt in a winning strategy, as a function, if the monster in the second row
 is not at an edge. -/
 def path2OfNotEdge {c₁ : Fin (N + 1)} (hc₁ : (c₁ : ℕ) ≠ N) : Path N := Path.ofFn (fn2OfNotEdge hc₁)
-    (by omega) (by simp [fn2OfNotEdge])
+    (by lia) (by simp [fn2OfNotEdge])
     (by simp only [fn2OfNotEdge]; split_ifs <;> simp; omega)
     (by
       simp only [fn2OfNotEdge]
@@ -656,12 +656,12 @@ def path2OfNotEdge {c₁ : Fin (N + 1)} (hc₁ : (c₁ : ℕ) ≠ N) : Path N :=
 is at the left edge: zigzag across the board so that, if we encounter a monster, we have a third
 path we know will not encounter a monster. -/
 def fn1OfEdge0 (N : ℕ) : Fin (2 * N + 1) → Cell N :=
-  fun i ↦ if h : (i : ℕ) = 2 * N then (⟨N + 1, by omega⟩, ⟨N, by omega⟩) else
-    (⟨((i : ℕ) + 1) / 2, by omega⟩, ⟨(i : ℕ) / 2 + 1, by omega⟩)
+  fun i ↦ if h : (i : ℕ) = 2 * N then (⟨N + 1, by lia⟩, ⟨N, by lia⟩) else
+    (⟨((i : ℕ) + 1) / 2, by lia⟩, ⟨(i : ℕ) / 2 + 1, by lia⟩)
 
 /-- The second attempt in a winning strategy, as a `Path`, if the monster in the second row
 is at the left edge. -/
-def path1OfEdge0 (hN : 2 ≤ N) : Path N := Path.ofFn (fn1OfEdge0 N) (by omega)
+def path1OfEdge0 (hN : 2 ≤ N) : Path N := Path.ofFn (fn1OfEdge0 N) (by lia)
     (by simp only [fn1OfEdge0]; split_ifs <;> simp; omega)
     (by simp [fn1OfEdge0])
     (by
@@ -679,19 +679,19 @@ the monster was encountered, move to the following row one place earlier, procee
 edge and then along that column. -/
 def fn2OfEdge0 {r : Fin (N + 2)} (hr : (r : ℕ) ≤ N) : Fin (N + 2 * r - 1) → Cell N :=
   fun i ↦ if h₁ : (i : ℕ) + 2 < 2 * (r : ℕ) then
-    (⟨((i : ℕ) + 1) / 2, by omega⟩, ⟨(i : ℕ) / 2 + 1, by omega⟩) else
-    if h₂ : (i : ℕ) + 2 < 3 * (r : ℕ) then (r, ⟨3 * (r : ℕ) - 3 - (i : ℕ), by omega⟩) else
-    (⟨i + 3 - 2 * r, by omega⟩, 0)
+    (⟨((i : ℕ) + 1) / 2, by lia⟩, ⟨(i : ℕ) / 2 + 1, by lia⟩) else
+    if h₂ : (i : ℕ) + 2 < 3 * (r : ℕ) then (r, ⟨3 * (r : ℕ) - 3 - (i : ℕ), by lia⟩) else
+    (⟨i + 3 - 2 * r, by lia⟩, 0)
 
 lemma fn2OfEdge0_apply_eq_fn1OfEdge0_apply_of_lt {r : Fin (N + 2)} (hr : (r : ℕ) ≤ N) {i : ℕ}
-    (h : i + 2 < 2 * (r : ℕ)) : fn2OfEdge0 hr ⟨i, by omega⟩ = fn1OfEdge0 N ⟨i, by omega⟩ := by
+    (h : i + 2 < 2 * (r : ℕ)) : fn2OfEdge0 hr ⟨i, by lia⟩ = fn1OfEdge0 N ⟨i, by lia⟩ := by
   rw [fn1OfEdge0, fn2OfEdge0]
   split_ifs with h₁ h₂ <;> simp [Prod.ext_iff] at * <;> omega
 
 /-- The third attempt in a winning strategy, as a `Path`, if the monster in the second row
 is at the left edge and the second (zigzag) attempt encountered a monster. -/
 def path2OfEdge0 (hN : 2 ≤ N) {r : Fin (N + 2)} (hr2 : 2 ≤ (r : ℕ)) (hrN : (r : ℕ) ≤ N) : Path N :=
-  Path.ofFn (fn2OfEdge0 hrN) (by omega)
+  Path.ofFn (fn2OfEdge0 hrN) (by lia)
     (by simp only [fn2OfEdge0]; split_ifs <;> simp <;> omega)
     (by simp only [fn2OfEdge0]; split_ifs <;> simp <;> omega)
     (by
@@ -705,7 +705,7 @@ with junk values of `r` for convenience in defining the strategy before needing 
 about exactly where it can encounter monsters. -/
 def path2OfEdge0Def (hN : 2 ≤ N) (r : Fin (N + 2)) : Path N :=
   if h : 2 ≤ (r : ℕ) ∧ (r : ℕ) ≤ N then path2OfEdge0 hN h.1 h.2 else
-    path2OfEdge0 hN (r := ⟨2, by omega⟩) (le_refl _) hN
+    path2OfEdge0 hN (r := ⟨2, by lia⟩) (le_refl _) hN
 
 /-- The third attempt in a winning strategy, as a `Path`, if the monster in the second row
 is at the right edge and the second (zigzag) attempt encountered a monster. -/
@@ -735,7 +735,7 @@ def winningStrategy (hN : 2 ≤ N) : Strategy N
 lemma path0_firstMonster_eq_apply_row1 (hN : 2 ≤ N) (m : MonsterData N) :
     (path0 hN).firstMonster m = some (1, m (row1 hN)) := by
   simp_rw [path0, Path.firstMonster, Path.ofFn]
-  have h : (1, m (row1 hN)) = fn0 N ⟨(m (row1 hN) : ℕ) + 1, by omega⟩ := by
+  have h : (1, m (row1 hN)) = fn0 N ⟨(m (row1 hN) : ℕ) + 1, by lia⟩ := by
     simp_rw [fn0]
     split_ifs <;> simp [Prod.ext_iff] at *; omega
   rw [h, List.find?_ofFn_eq_some_of_injective (injective_fn0 N)]
@@ -757,7 +757,7 @@ lemma path0_firstMonster_eq_apply_row1 (hN : 2 ≤ N) (m : MonsterData N) :
         decide_eq_true_eq, not_exists, not_and]
       rintro i hi hix hij
       simp only [Fin.ext_iff, Fin.val_zero] at h₁
-      rw [eq_comm, Nat.sub_eq_iff_eq_add (by omega)] at hij
+      rw [eq_comm, Nat.sub_eq_iff_eq_add (by lia)] at hij
       have hr : row1 hN = ⟨↑i, hix⟩ := by
         simp_rw [Subtype.ext_iff, Fin.ext_iff, hi]
         rfl
@@ -781,9 +781,9 @@ lemma path1_firstMonster_of_not_edge (hN : 2 ≤ N) {m : MonsterData N} (hc₁0 
     (hc₁N : (m (row1 hN) : ℕ) ≠ N) :
     (path1 hN (m (row1 hN))).firstMonster m = none ∨
       (path1 hN (m (row1 hN))).firstMonster m =
-        some (⟨2, by omega⟩, ⟨(m (row1 hN) : ℕ) - 1, by omega⟩) := by
+        some (⟨2, by lia⟩, ⟨(m (row1 hN) : ℕ) - 1, by lia⟩) := by
   suffices h : ∀ c ∈ (path1 hN (m (row1 hN))).cells, c ∉ m.monsterCells ∨
-      c = (⟨2, by omega⟩, ⟨(m (row1 hN) : ℕ) - 1, by omega⟩) by
+      c = (⟨2, by lia⟩, ⟨(m (row1 hN) : ℕ) - 1, by lia⟩) by
     simp only [Path.firstMonster]
     by_cases hn : List.find? (fun x ↦ decide (x ∈ m.monsterCells))
                              (path1 hN (m (row1 hN))).cells = none
@@ -806,7 +806,7 @@ lemma path1_firstMonster_of_not_edge (hN : 2 ≤ N) {m : MonsterData N} (hc₁0 
     · exact .inl (m.notMem_monsterCells_of_fst_eq_zero rfl)
     · simp only [Fin.mk_one, Prod.mk.injEq, Fin.ext_iff, Fin.val_one, OfNat.one_ne_ofNat,
         and_true, or_false]
-      have hN' : 1 ≤ N := by omega
+      have hN' : 1 ≤ N := by lia
       rw [m.mk_mem_monsterCells_iff_of_le (le_refl _) hN', ← ne_eq, ← Fin.val_ne_iff]
       rw [← Fin.val_ne_iff] at hc₁0
       exact (Nat.sub_one_lt hc₁0).ne'
@@ -820,9 +820,9 @@ lemma path2_firstMonster_of_not_edge (hN : 2 ≤ N) {m : MonsterData N} (hc₁0 
     (hc₁N : (m (row1 hN) : ℕ) ≠ N) (r : Fin (N + 2)) :
     (path2 hN (m (row1 hN)) r).firstMonster m = none ∨
       (path2 hN (m (row1 hN)) r).firstMonster m =
-        some (⟨2, by omega⟩, ⟨(m (row1 hN) : ℕ) + 1, by omega⟩) := by
+        some (⟨2, by lia⟩, ⟨(m (row1 hN) : ℕ) + 1, by lia⟩) := by
   suffices h : ∀ c ∈ (path2 hN (m (row1 hN)) r).cells, c ∉ m.monsterCells ∨
-      c = (⟨2, by omega⟩, ⟨(m (row1 hN) : ℕ) + 1, by omega⟩) by
+      c = (⟨2, by lia⟩, ⟨(m (row1 hN) : ℕ) + 1, by lia⟩) by
     simp only [Path.firstMonster]
     by_cases hn : List.find? (fun x ↦ decide (x ∈ m.monsterCells))
                              (path2 hN (m (row1 hN)) r).cells = none
@@ -845,7 +845,7 @@ lemma path2_firstMonster_of_not_edge (hN : 2 ≤ N) {m : MonsterData N} (hc₁0 
     · exact .inl (m.notMem_monsterCells_of_fst_eq_zero rfl)
     · simp only [Fin.mk_one, Prod.mk.injEq, Fin.ext_iff, Fin.val_one, OfNat.one_ne_ofNat,
         and_true, or_false]
-      have hN' : 1 ≤ N := by omega
+      have hN' : 1 ≤ N := by lia
       rw [m.mk_mem_monsterCells_iff_of_le (le_refl _) hN', ← ne_eq, ← Fin.val_ne_iff]
       exact Nat.ne_add_one _
     · exact .inr rfl
@@ -868,7 +868,7 @@ lemma winningStrategy_play_one_eq_none_or_play_two_eq_none_of_not_edge (hN : 2 �
     · exact h2r
     · have h1' := (Path.mem_of_firstMonster_eq_some h1).2
       have h2' := (Path.mem_of_firstMonster_eq_some h2r).2
-      have h12 : 1 ≤ (⟨2, by omega⟩ : Fin (N + 2)) := by
+      have h12 : 1 ≤ (⟨2, by lia⟩ : Fin (N + 2)) := by
         rw [Fin.le_def]
         norm_num
       rw [m.mk_mem_monsterCells_iff_of_le h12 hN] at h1' h2'
@@ -944,7 +944,7 @@ lemma winningStrategy_play_one_eq_none_or_play_two_eq_none_of_edge_zero (hN : 2 
       · simp at h
         omega
       · dsimp only [Nat.reduceAdd, Nat.reduceDiv, Fin.mk_one] at hm
-        have h1N : 1 ≤ N := by omega
+        have h1N : 1 ≤ N := by lia
         rw [m.mk_mem_monsterCells_iff_of_le (le_refl _) h1N] at hm
         rw [row1, hm, Fin.ext_iff] at hc₁0
         simp at hc₁0
@@ -952,7 +952,7 @@ lemma winningStrategy_play_one_eq_none_or_play_two_eq_none_of_edge_zero (hN : 2 
         omega
       · simp only at hm
         norm_num at hm
-        have h1N : 1 ≤ N := by omega
+        have h1N : 1 ≤ N := by lia
         rw [m.mk_mem_monsterCells_iff_of_le (le_refl _) h1N] at hm
         rw [row1, hm] at hc₁0
         simp at hc₁0

--- a/Archive/Wiedijk100Theorems/FriendshipGraphs.lean
+++ b/Archive/Wiedijk100Theorems/FriendshipGraphs.lean
@@ -246,9 +246,9 @@ theorem false_of_three_le_degree (hd : G.IsRegularOfDegree d) (h : 3 ≤ d) : Fa
   -- get a prime factor of d - 1
   let p : ℕ := (d - 1).minFac
   have p_dvd_d_pred := (ZMod.natCast_eq_zero_iff _ _).mpr (d - 1).minFac_dvd
-  have dpos : 1 ≤ d := by omega
+  have dpos : 1 ≤ d := by lia
   have d_cast : ↑(d - 1) = (d : ℤ) - 1 := by norm_cast
-  haveI : Fact p.Prime := ⟨Nat.minFac_prime (by omega)⟩
+  haveI : Fact p.Prime := ⟨Nat.minFac_prime (by lia)⟩
   have hp2 : 2 ≤ p := (Fact.out (p := p.Prime)).two_le
   have dmod : (d : ZMod p) = 1 := by
     rw [← Nat.succ_pred_eq_of_pos dpos, Nat.succ_eq_add_one, Nat.pred_eq_sub_one]

--- a/Archive/Wiedijk100Theorems/FriendshipGraphs.lean
+++ b/Archive/Wiedijk100Theorems/FriendshipGraphs.lean
@@ -267,7 +267,7 @@ theorem false_of_three_le_degree (hd : G.IsRegularOfDegree d) (h : 3 ≤ d) : Fa
     of_apply, Ne]
   rw [Vmod, ← Nat.cast_one (R := ZMod (Nat.minFac (d - 1))), ZMod.natCast_eq_zero_iff,
     Nat.dvd_one, Nat.minFac_eq_one_iff]
-  omega
+  lia
 
 open scoped Classical in
 include hG in
@@ -281,7 +281,7 @@ theorem existsPolitician_of_degree_le_one (hd : G.IsRegularOfDegree d) (hd1 : d 
   have : Fintype.card V ≤ 1 := by
     cases hn : Fintype.card V with
     | zero => exact zero_le _
-    | succ n => omega
+    | succ n => lia
   use Classical.arbitrary V
   intro w h; exfalso
   apply h
@@ -301,7 +301,7 @@ theorem neighborFinset_eq_of_degree_eq_two (hd : G.IsRegularOfDegree 2) (v : V) 
   convert_to 2 ≤ _
   · convert_to _ = Fintype.card V - 1
     · have hfr := card_of_regular hG hd
-      omega
+      lia
     · exact Finset.card_erase_of_mem (Finset.mem_univ _)
   · dsimp only [IsRegularOfDegree, degree] at hd
     rw [hd]

--- a/Counterexamples/AharoniKorman.lean
+++ b/Counterexamples/AharoniKorman.lean
@@ -157,7 +157,7 @@ instance : PartialOrder Hollom where
   | _, _, .twice _, .next_min _ => by lia
   | _, _, .twice _, .next_add _ => by lia
   | _, _, .within _ _, .twice _ => by lia
-  | _, _, .within _ _, .within _ _ => by congr 3 <;> omega
+  | _, _, .within _ _, .within _ _ => by congr 3 <;> lia
   | _, _, .next_min _, .twice _ => by lia
   | _, _, .next_add _, .twice _ => by lia
 
@@ -165,8 +165,8 @@ instance : PartialOrder Hollom where
     h(a, b, n) ≤ h(c, d, n) ↔ a ≤ c ∧ b ≤ d := by
   refine ⟨?_, ?_⟩
   · rintro (_ | _)
-    · omega
-    · omega
+    · lia
+    · lia
   · rintro ⟨h₁, h₂⟩
     exact .within h₁ h₂
 
@@ -279,7 +279,7 @@ lemma line_mapsTo {x y : Hollom} (hxy : (ofHollom x).2.2 = (ofHollom y).2.2) :
   rintro p q r h₁ h₂ rfl
   obtain rfl := (le_of_toHollom_le_toHollom h₁).antisymm (le_of_toHollom_le_toHollom h₂)
   simp only [toHollom_le_toHollom_iff_fixed_right] at h₁ h₂
-  omega
+  lia
 
 lemma embed_image_Icc {a b c d n : ℕ} :
     embed n '' Set.Icc (a, b) (c, d) = Set.Icc h(a, b, n) h(c, d, n) := by
@@ -363,7 +363,7 @@ theorem no_infinite_antichain {A : Set Hollom} (hC : IsAntichain (· ≤ ·) A) 
     obtain ⟨a, b, hab⟩ := hn
     intro c d hcd
     by_contra!
-    exact hC hcd hab (by simp; omega) (HollomOrder.twice this)
+    exact hC hcd hab (by simp; lia) (HollomOrder.twice this)
 
 private lemma triangle_finite (n : ℕ) : {x : ℕ × ℕ | x.1 + x.2 ≤ n}.Finite :=
   (Set.finite_Iic (n, n)).subset <| by aesop
@@ -424,8 +424,8 @@ theorem exists_finite_intersection (hC : IsChain (· ≤ ·) C) :
   -- Whereas if `(x, y, n + 1) ≤ (u, v, n)`, as `2 * (u + v) < x + y`, we must have
   -- `min x y + 1 ≤ min u v`, which finishes the proof.
   · cases h3
-    case twice => omega
-    case next_add => omega
+    case twice => lia
+    case next_add => lia
     case next_min h3 =>
       rw [← Nat.add_one_le_iff]
       refine h3.trans' ?_
@@ -571,7 +571,7 @@ lemma chainBetween_isChain {a b c d : ℕ} :
   split_ifs
   · rintro ⟨v, w⟩ hvw ⟨x, y⟩ hxy
     simp_all
-    omega
+    lia
   · simp
 
 lemma image_chainBetween_isChain {a b c d n : ℕ} :
@@ -586,10 +586,10 @@ lemma card_chainBetween {a b c d : ℕ} (hac : a ≤ c) (hbd : b ≤ d) :
   rw [chainBetween, if_pos ⟨hac, hbd⟩, card_union_of_disjoint, Finset.card_Icc_prod]
   · simp only [Icc_self, card_singleton, Nat.card_Icc]
     rw [← Finset.Ico_map_sectR, card_map, Nat.card_Ico]
-    omega
+    lia
   · rw [disjoint_left]
     simp
-    omega
+    lia
 
 lemma chainBetween_subset {a b c d : ℕ} :
     chainBetween a b c d ⊆ Finset.Icc (a, b) (c, d) := by
@@ -696,9 +696,9 @@ lemma apply_eq_of_line_eq_step (f : SpinalMap C) {n xl yl xh yh : ℕ}
   have cB : #B = xh + yh - (xl + yl) := by
     rw [card_image_of_injective _ (embed n).injective, card_union_of_disjoint,
       card_chainBetween h₂l.1 h₁l.2, card_chainBetween h₁h.1 h₂h.2]
-    · omega
+    · lia
     · simp [disjoint_left, chainBetween, *]
-      omega
+      lia
   -- It is easy to see that our chain `B` lives entirely within `int`
   have hB : B ⊆ int := by
     refine Finset.image_subset_image ?_
@@ -719,11 +719,11 @@ lemma apply_eq_of_line_eq_step (f : SpinalMap C) {n xl yl xh yh : ℕ}
     rw [coe_union, isChain_union]
     refine ⟨chainBetween_isChain, chainBetween_isChain, ?_⟩
     simp [chainBetween, *]
-    omega
+    lia
   -- Thus the image of `B` under `f` is all of `I`, except for exactly one element.
   have card_eq : (I \ B.image f).card = 1 := by
     rw [card_sdiff_of_subset, cI, card_image_of_injOn f_inj, cB]
-    · omega
+    · lia
     · rw [← coe_subset, coe_image]
       exact f_maps.image_subset
   -- After applying `f`, both `(x + 1, y, n)` and `(x, y + 1, n)` are omitted from the image of `B`
@@ -770,11 +770,11 @@ lemma apply_eq_of_line_eq_aux (f : SpinalMap C) {n xl yl xh yh : ℕ}
         refine apply_eq_of_line_eq_step f hC hlo hhi hx hy h₁l ?_ h₁h ?_
         all_goals
           simp only [toHollom_le_toHollom_iff_fixed_right] at h₁l h₁h h₂l h₂h ⊢
-          omega
+          lia
       rw [this, ih, add_right_comm, add_assoc]
       all_goals
         simp only [toHollom_le_toHollom_iff_fixed_right] at h₁l h₁h h₂l h₂h ⊢
-        omega
+        lia
 
 /--
 For two points of `C` in the same level, and two points `(a, b, n)` and `(c, d, n)` between them,
@@ -847,10 +847,10 @@ lemma square_subset_above (h : (C ∩ level n).Finite) :
   constructor
   · rintro c d n hcd rfl
     specialize hab c d hcd
-    omega
+    lia
   · intro hfg
     specialize hab _ _ hfg
-    omega
+    lia
 
 lemma square_subset_R (h : (C ∩ level n).Finite) :
     ∀ᶠ a in atTop, embed n '' Set.Ici (a, a) ⊆ R n C \ (C ∩ level n) := by
@@ -963,7 +963,7 @@ lemma square_subset_S_case_1 (h : (C ∩ level n).Finite) (h' : (C ∩ level (n 
     apply toHollom_le_toHollom _ (by simp)
     have := hab _ _ hgh
     simp only [Prod.mk_le_mk] at this ⊢
-    omega
+    lia
   -- Combined with the fact that sufficiently large `a` have
   -- `{(x, y, n) | x ≥ a ∧ y ≥ a} ⊆ R \ (C ∩ level n)`, we can easily finish.
   filter_upwards [square_subset_R h, this] with a h₁ h₂
@@ -1055,13 +1055,13 @@ theorem not_S_hits_next (f : SpinalMap C) (hC : IsChain (· ≤ ·) C)
         intro h
         have : c + d < a + b := add_lt_add_of_lt h
         simp only [toHollom_le_toHollom_iff_fixed_right] at hj
-        omega
+        lia
       -- ...and `(x0, y0, n + 1) ≤ j`.
       have h0j : h(x0 n C, y0 n C, n + 1) ≤ j := hj'.trans' (by simp [ha, hb])
-      have : line h(a, b, n + 1) = line h(x0 n C, a + b - x0 n C, n + 1) := by simp; omega
+      have : line h(a, b, n + 1) = line h(x0 n C, a + b - x0 n C, n + 1) := by simp; lia
       -- Then we have `f(a, b, n + 1) = f(x0, a + b - x0, n + 1)` since they are at the same line
       have : f h(a, b, n + 1) = f h(x0 n C, a + b - x0 n C, n + 1) := apply_eq_of_line_eq f hC
-        ⟨x0_y0_mem h.nonempty, by simp⟩ hjCn ‹_› this (x0_y0_min hC hp.1) (by simp; omega) hj' hj
+        ⟨x0_y0_mem h.nonempty, by simp⟩ hjCn ‹_› this (x0_y0_min hC hp.1) (by simp; lia) hj' hj
       -- so `f(x, y, n) = (a, b, n + 1) = f(a, b, n + 1) = f(x0, a + b - x0, n + 1)`
       have : f h(x, y, n) = f h(x0 n C, a + b - x0 n C, n + 1) := by
         rw [← this, ← hfp, f.eq_self_of_mem hp.1]
@@ -1076,11 +1076,11 @@ theorem not_S_hits_next (f : SpinalMap C) (hC : IsChain (· ≤ ·) C)
         intro h
         have : c + d < a + b := add_lt_add_of_lt h
         simp only [toHollom_le_toHollom_iff_fixed_right] at hj
-        omega
+        lia
       have h0j : h(x0 n C, y0 n C, n + 1) ≤ j := hj'.trans' (by simp [ha, hb])
-      have : line h(a, b, n + 1) = line h(a + b - y0 n C, y0 n C, n + 1) := by simp; omega
+      have : line h(a, b, n + 1) = line h(a + b - y0 n C, y0 n C, n + 1) := by simp; lia
       have := apply_eq_of_line_eq f hC ⟨x0_y0_mem h.nonempty, by simp⟩ hjCn ‹_› this
-        (x0_y0_min hC hp.1) (by simp; omega) hj' hj
+        (x0_y0_min hC hp.1) (by simp; lia) hj' hj
       have : f h(x, y, n) = f h(a + b - y0 n C, y0 n C, n + 1) := by
         rw [← this, ← hfp, f.eq_self_of_mem hp.1]
       exact f.not_le_of_eq this.symm (by simp) (.next_min (hx.2.trans' (by simp)))
@@ -1118,15 +1118,15 @@ lemma S_mapsTo_previous (f : SpinalMap C) (hC : IsChain (· ≤ ·) C) (hn : n �
     intro h
     have := f.eq_of_le hp'.symm (.twice h)
     simp only [Prod.mk.injEq, Hollom.ext_iff] at this
-    omega
+    lia
   -- and `(a, b, m) ≤ (x, y, n)` if `n + 2 ≤ m`, so this cannot hold either
   have : ¬ n + 2 ≤ m := by
     intro h
     have := f.eq_of_le hp' (.twice h)
     simp only [Prod.mk.injEq, Hollom.ext_iff] at this
-    omega
+    lia
   -- So the only remaining option is that `m = n - 1`.
-  omega
+  lia
 
 open Finset in
 /--
@@ -1151,7 +1151,7 @@ theorem not_S_mapsTo_previous (hC : IsChain (· ≤ ·) C)
   have card_F : #F = 2 * a + 1 := by
     rw [Finset.card_image_of_injective _ (embed n).injective,
       card_chainBetween (by lia) (by simp)]
-    omega
+    lia
   let T := {x ∈ C ∩ level (n - 1) | line x < 2 * a}
   -- Therefore, the image of `F` is within `C ∩ level (n - 1)`, and each of its points must be
   -- within `{(x, y, n - 1) | x + y < 2 * a}`. That is, the image of `F` under `f` is within `T`.
@@ -1175,7 +1175,7 @@ theorem not_S_mapsTo_previous (hC : IsChain (· ≤ ·) C)
           apply HollomOrder.next_add (by lia)
     have : f h(u, v, n - 1) = f h(b, a, n) := by rw [f.eq_self_of_mem hc'.1, hc]
     have := le_of_toHollom_le_toHollom (f.eq_of_le this.symm le).ge
-    omega
+    lia
   -- And `f` acts injectively on `F`, as it is a chain.
   have F_inj : Set.InjOn f F := f.injOn_of_isChain image_chainBetween_isChain
   -- By definition of `T`, the `line` map sends it to the interval `[0, 2a)`
@@ -1192,7 +1192,7 @@ theorem not_S_mapsTo_previous (hC : IsChain (· ≤ ·) C)
   -- which is a contradiction by cardinality arguments.
   have := card_le_card_of_injOn _ line_F_mapsTo (line_inj.comp F_inj F_mapsTo)
   simp only [Finset.card_range] at this
-  omega
+  lia
 
 /-- The Hollom partial order has no spinal maps. -/
 theorem no_spinalMap (hC : IsChain (· ≤ ·) C) (f : SpinalMap C) : False := by

--- a/Counterexamples/AharoniKorman.lean
+++ b/Counterexamples/AharoniKorman.lean
@@ -130,36 +130,36 @@ painfully slow to compile.
 -/
 lemma HollomOrder.trans :
     (x y z : ℕ × ℕ × ℕ) → (h₁ : HollomOrder x y) → (h₂ : HollomOrder y z) → HollomOrder x z
-  | _, _, _, .twice _, .twice _ => .twice (by omega)
-  | _, _, _, .twice _, .within _ _ => .twice (by omega)
-  | _, _, _, .twice _, .next_min _ => .twice (by omega)
-  | _, _, _, .twice _, .next_add _ => .twice (by omega)
-  | _, _, _, .within _ _, .twice _ => .twice (by omega)
-  | _, _, _, .within _ _, .within _ _ => .within (by omega) (by omega)
+  | _, _, _, .twice _, .twice _ => .twice (by lia)
+  | _, _, _, .twice _, .within _ _ => .twice (by lia)
+  | _, _, _, .twice _, .next_min _ => .twice (by lia)
+  | _, _, _, .twice _, .next_add _ => .twice (by lia)
+  | _, _, _, .within _ _, .twice _ => .twice (by lia)
+  | _, _, _, .within _ _, .within _ _ => .within (by lia) (by lia)
   | _, _, _, .within _ _, .next_min _ => .next_min (by omega)
-  | _, _, _, .within _ _, .next_add _ => .next_add (by omega)
-  | _, _, _, .next_min _, .twice _ => .twice (by omega)
+  | _, _, _, .within _ _, .next_add _ => .next_add (by lia)
+  | _, _, _, .next_min _, .twice _ => .twice (by lia)
   | _, _, _, .next_min _, .within _ _ => .next_min (by omega)
-  | _, _, _, .next_min _, .next_min _ => .twice (by omega)
-  | _, _, _, .next_min _, .next_add _ => .twice (by omega)
-  | _, _, _, .next_add _, .twice _ => .twice (by omega)
-  | _, _, _, .next_add _, .within _ _ => .next_add (by omega)
-  | _, _, _, .next_add _, .next_min _ => .twice (by omega)
-  | _, _, _, .next_add _, .next_add _ => .twice (by omega)
+  | _, _, _, .next_min _, .next_min _ => .twice (by lia)
+  | _, _, _, .next_min _, .next_add _ => .twice (by lia)
+  | _, _, _, .next_add _, .twice _ => .twice (by lia)
+  | _, _, _, .next_add _, .within _ _ => .next_add (by lia)
+  | _, _, _, .next_add _, .next_min _ => .twice (by lia)
+  | _, _, _, .next_add _, .next_add _ => .twice (by lia)
 
 instance : PartialOrder Hollom where
   le x y := HollomOrder (ofHollom x) (ofHollom y)
   le_refl _ := .within le_rfl le_rfl
   le_trans := «forall₃».2 HollomOrder.trans
   le_antisymm := «forall₂».2 fun
-  | _, _, .twice _, .twice _ => by omega
-  | _, (_, _, _), .twice _, .within _ _ => by omega -- see https://github.com/leanprover/lean4/issues/6416 about the `(_, _, _)`
-  | _, _, .twice _, .next_min _ => by omega
-  | _, _, .twice _, .next_add _ => by omega
-  | _, _, .within _ _, .twice _ => by omega
+  | _, _, .twice _, .twice _ => by lia
+  | _, (_, _, _), .twice _, .within _ _ => by lia -- see https://github.com/leanprover/lean4/issues/6416 about the `(_, _, _)`
+  | _, _, .twice _, .next_min _ => by lia
+  | _, _, .twice _, .next_add _ => by lia
+  | _, _, .within _ _, .twice _ => by lia
   | _, _, .within _ _, .within _ _ => by congr 3 <;> omega
-  | _, _, .next_min _, .twice _ => by omega
-  | _, _, .next_add _, .twice _ => by omega
+  | _, _, .next_min _, .twice _ => by lia
+  | _, _, .next_add _, .twice _ => by lia
 
 @[simp] lemma toHollom_le_toHollom_iff_fixed_right {a b c d n : ℕ} :
     h(a, b, n) ≤ h(c, d, n) ↔ a ≤ c ∧ b ≤ d := by
@@ -172,17 +172,17 @@ instance : PartialOrder Hollom where
 
 lemma le_of_toHollom_le_toHollom {a b c d e f : ℕ} :
     h(a, b, c) ≤ h(d, e, f) → f ≤ c
-  | .twice _ => by omega
-  | .within _ _ => by omega
-  | .next_add _ => by omega
-  | .next_min _ => by omega
+  | .twice _ => by lia
+  | .within _ _ => by lia
+  | .next_add _ => by lia
+  | .next_min _ => by lia
 
 lemma toHollom_le_toHollom {a b c d e f : ℕ} (h : (a, b) ≤ (d, e)) (hcf : f ≤ c) :
     h(a, b, c) ≤ h(d, e, f) := by
   simp only [Prod.mk_le_mk] at h
-  obtain rfl | rfl | hc : f = c ∨ f + 1 = c ∨ f + 2 ≤ c := by omega
+  obtain rfl | rfl | hc : f = c ∨ f + 1 = c ∨ f + 2 ≤ c := by lia
   · simpa using h
-  · exact .next_add (by omega)
+  · exact .next_add (by lia)
   · exact .twice hc
 
 /--
@@ -407,7 +407,7 @@ theorem exists_finite_intersection (hC : IsChain (· ≤ ·) C) :
       refine .subset (.image (embed (n + 1)) (triangle_finite (2 * (u + v)))) ?_
       simp +contextual [Set.subset_def, D, embed_apply]
     -- ...and `C ∩ level (n + 1)` is infinite (by assumption).
-    specialize hC' (n + 1) (by omega)
+    specialize hC' (n + 1) (by lia)
     rw [← (C ∩ level (n + 1)).inter_union_diff D, Set.infinite_union] at hC'
     refine hC'.resolve_left ?_
     simpa using this
@@ -794,7 +794,7 @@ theorem apply_eq_of_line_eq (f : SpinalMap C) {n : ℕ} (hC : IsChain (· ≤ ·
   simp only [] at hxy
   simp only [line_toHollom] at h
   obtain ⟨k, rfl⟩ := exists_add_of_le hxy
-  obtain rfl : y₂ = y₁ + k := by omega
+  obtain rfl : y₂ = y₁ + k := by lia
   induction hlo.2 using induction_on_level with | h xlo ylo =>
   induction hhi.2 using induction_on_level with | h xhi yhi =>
   exact apply_eq_of_line_eq_aux f hC hlo.1 hhi.1 (by simp_all) (by simp_all) h₁l h₂l h₁h h₂h
@@ -1150,7 +1150,7 @@ theorem not_S_mapsTo_previous (hC : IsChain (· ≤ ·) C)
   -- ...and it has length `2a+1`.
   have card_F : #F = 2 * a + 1 := by
     rw [Finset.card_image_of_injective _ (embed n).injective,
-      card_chainBetween (by omega) (by simp)]
+      card_chainBetween (by lia) (by simp)]
     omega
   let T := {x ∈ C ∩ level (n - 1) | line x < 2 * a}
   -- Therefore, the image of `F` is within `C ∩ level (n - 1)`, and each of its points must be
@@ -1161,7 +1161,7 @@ theorem not_S_mapsTo_previous (hC : IsChain (· ≤ ·) C)
     set c := f x with hc
     have hc' : c ∈ C ∩ level (n - 1) := h _ (F_subs hx)
     clear_value c
-    rw [coe_image, chainBetween, Ico_self, if_pos (by omega), empty_union, ← Icc_map_sectL] at hx
+    rw [coe_image, chainBetween, Ico_self, if_pos (by lia), empty_union, ← Icc_map_sectL] at hx
     simp only [embed_apply, coe_map, Function.Embedding.sectL_apply, coe_Icc,
       Set.mem_image, Set.mem_Icc, exists_exists_and_eq_and] at hx
     obtain ⟨b, ⟨hab, hba⟩, rfl⟩ := hx
@@ -1172,7 +1172,7 @@ theorem not_S_mapsTo_previous (hC : IsChain (· ≤ ·) C)
       match n, hn with
       | n + 1, _ =>
           simp only [add_tsub_cancel_right]
-          apply HollomOrder.next_add (by omega)
+          apply HollomOrder.next_add (by lia)
     have : f h(u, v, n - 1) = f h(b, a, n) := by rw [f.eq_self_of_mem hc'.1, hc]
     have := le_of_toHollom_le_toHollom (f.eq_of_le this.symm le).ge
     omega
@@ -1198,7 +1198,7 @@ theorem not_S_mapsTo_previous (hC : IsChain (· ≤ ·) C)
 theorem no_spinalMap (hC : IsChain (· ≤ ·) C) (f : SpinalMap C) : False := by
   obtain ⟨n, hn, hn'⟩ : ∃ n, n ≠ 0 ∧ (C ∩ Hollom.level n).Finite := by
     obtain ⟨n, hn, hn'⟩ := Filter.frequently_atTop.1 (Hollom.exists_finite_intersection hC) 1
-    exact ⟨n, by omega, hn'⟩
+    exact ⟨n, by lia, hn'⟩
   exact Hollom.not_S_mapsTo_previous hC hn' hn (Hollom.S_mapsTo_previous f hC hn)
 
 end Hollom

--- a/Counterexamples/DiscreteTopologyNonDiscreteUniformity.lean
+++ b/Counterexamples/DiscreteTopologyNonDiscreteUniformity.lean
@@ -235,7 +235,7 @@ def counterCoreUniformity : UniformSpace.Core ℕ := by
     simp only [fundamentalEntourage_ext, iUnion_singleton_eq_range] at hn
     simp only [hn, mem_union, mem_range, Prod.mk.injEq, and_self, Subtype.exists, mem_Icc, zero_le,
       true_and, exists_prop', nonempty_prop, exists_eq_right, mem_Ici, Prod.mk_le_mk]
-    omega
+    lia
   · refine ⟨S, hS, ?_⟩
     obtain ⟨n, hn⟩ := hS
     simp only [fundamentalEntourage_ext, iUnion_singleton_eq_range] at hn

--- a/Mathlib/Algebra/AffineMonoid/Irreducible.lean
+++ b/Mathlib/Algebra/AffineMonoid/Irreducible.lean
@@ -120,7 +120,7 @@ lemma Submonoid.closure_irreducible [Monoid.FG M] :
     -- `∏ s ∈ S \ {r}, s ^ m s = ∏ s ∈ S \ {r}, s ^ n s = 1`.
     -- Furthermore, `m r + n r = 1` implies that one of `m r` or `n r` is zero.
     -- Therefore one of `a` or `b` is `1`, contradicting the fact that they are non-units.
-    obtain h | h : m r = 0 ∨ n r = 0 := by omega
+    obtain h | h : m r = 0 ∨ n r = 0 := by lia
     · obtain rfl : a = 1 := by simpa [h, Finset.prod_eq_one hr'.1] using hm
       simp at ha
     · obtain rfl : b = 1 := by simpa [h, Finset.prod_eq_one hr'.2] using hn

--- a/Mathlib/Algebra/BigOperators/Fin.lean
+++ b/Mathlib/Algebra/BigOperators/Fin.lean
@@ -528,15 +528,15 @@ lemma partialProd_contractNth {G : Type*} [Monoid G] {n : ℕ}
     · rw [succAbove_of_castSucc_lt, contractNth_apply_of_lt _ _ _ _ h,
         succAbove_of_castSucc_lt] <;>
       simp only [lt_def, coe_castSucc, val_succ] <;>
-      omega
+      lia
     · rw [succAbove_of_castSucc_lt, contractNth_apply_of_eq _ _ _ _ h,
         succAbove_of_le_castSucc, castSucc_succ, partialProd_succ, mul_assoc] <;>
       simp only [castSucc_lt_succ_iff, le_def, coe_castSucc] <;>
-      omega
+      lia
     · rw [succAbove_of_le_castSucc, succAbove_of_le_castSucc, contractNth_apply_of_gt _ _ _ _ h,
         castSucc_succ] <;>
       simp only [le_def, val_succ, coe_castSucc] <;>
-      omega
+      lia
 
 /-- Let `(g₀, g₁, ..., gₙ)` be a tuple of elements in `Gⁿ⁺¹`.
 Then if `k < j`, this says `(g₀g₁...gₖ₋₁)⁻¹ * g₀g₁...gₖ = gₖ`.

--- a/Mathlib/Algebra/BigOperators/Group/Finset/Interval.lean
+++ b/Mathlib/Algebra/BigOperators/Group/Finset/Interval.lean
@@ -27,7 +27,7 @@ lemma prod_Icc_of_even_eq_range {α : Type*} [CommGroup α] {f : ℤ → α} (hf
   induction N with
   | zero => simp [sq]
   | succ N ih =>
-    rw [Nat.cast_add, Nat.cast_one, Icc_succ_succ, prod_union (by simp), prod_pair (by omega), ih,
+    rw [Nat.cast_add, Nat.cast_one, Icc_succ_succ, prod_union (by simp), prod_pair (by lia), ih,
       prod_range_succ _ (N + 1), hf, ← pow_two, div_mul_eq_mul_div, ← mul_pow, Nat.cast_succ]
 
 @[to_additive]

--- a/Mathlib/Algebra/BigOperators/Intervals.lean
+++ b/Mathlib/Algebra/BigOperators/Intervals.lean
@@ -112,7 +112,7 @@ theorem sum_Ico_Ico_comm {M : Type*} [AddCommMonoid M] (a b : ℕ) (f : ℕ → 
   refine sum_nbij' (fun x ↦ ⟨x.2, x.1⟩) (fun x ↦ ⟨x.2, x.1⟩) ?_ ?_ (fun _ _ ↦ rfl) (fun _ _ ↦ rfl)
     (fun _ _ ↦ rfl) <;>
   simp only [Finset.mem_Ico, Sigma.forall, Finset.mem_sigma] <;>
-  omega
+  lia
 
 /-- The two ways of summing over `(i, j)` in the range `a ≤ i < j < b` are equal. -/
 theorem sum_Ico_Ico_comm' {M : Type*} [AddCommMonoid M] (a b : ℕ) (f : ℕ → ℕ → M) :
@@ -122,7 +122,7 @@ theorem sum_Ico_Ico_comm' {M : Type*} [AddCommMonoid M] (a b : ℕ) (f : ℕ →
   refine sum_nbij' (fun x ↦ ⟨x.2, x.1⟩) (fun x ↦ ⟨x.2, x.1⟩) ?_ ?_ (fun _ _ ↦ rfl) (fun _ _ ↦ rfl)
     (fun _ _ ↦ rfl) <;>
   simp only [Finset.mem_Ico, Sigma.forall, Finset.mem_sigma] <;>
-  omega
+  lia
 
 @[to_additive]
 theorem prod_Ico_eq_prod_range (f : ℕ → M) (m n : ℕ) :

--- a/Mathlib/Algebra/CharP/Lemmas.lean
+++ b/Mathlib/Algebra/CharP/Lemmas.lean
@@ -42,7 +42,7 @@ protected lemma add_pow_prime_pow_eq' (h : Commute x y) (n : ℕ) :
     -- The maths is over now. We just commute things to their place.
     rw [Nat.cast_comm, mul_assoc (_ * _)]
     norm_cast
-    rw [Nat.div_mul_cancel (hp.dvd_choose_pow _ _)] <;> omega
+    rw [Nat.div_mul_cancel (hp.dvd_choose_pow _ _)] <;> lia
 
 protected lemma add_pow_prime_pow_eq (h : Commute x y) (n : ℕ) :
     (x + y) ^ p ^ n =

--- a/Mathlib/Algebra/CharP/Lemmas.lean
+++ b/Mathlib/Algebra/CharP/Lemmas.lean
@@ -52,7 +52,7 @@ protected lemma add_pow_prime_pow_eq (h : Commute x y) (n : ℕ) :
   rw [h.add_pow_prime_pow_eq' hp, mul_assoc _ x, mul_assoc, mul_sum _ _ (_ * _)]
   congr! 3 with k hk
   obtain ⟨hk₀, hk⟩ := mem_Ioo.1 hk
-  rw [← mul_pow_sub_one (by omega), ← mul_pow_sub_one (n := p ^ n - k) (by omega)]
+  rw [← mul_pow_sub_one (by lia), ← mul_pow_sub_one (n := p ^ n - k) (by lia)]
   rw [(h.pow_left _).mul_mul_mul_comm, mul_assoc (x * y)]
 
 protected lemma add_pow_prime_eq' (h : Commute x y) :

--- a/Mathlib/Algebra/ContinuedFractions/Computation/Approximations.lean
+++ b/Mathlib/Algebra/ContinuedFractions/Computation/Approximations.lean
@@ -215,7 +215,7 @@ theorem fib_le_of_contsAux_b :
       · simp [contsAux] -- case n = 0
       · simp [contsAux] -- case n = 1
       · let g := of v -- case 2 ≤ n
-        have : ¬n + 2 ≤ 1 := by omega
+        have : ¬n + 2 ≤ 1 := by lia
         have not_terminatedAt_n : ¬g.TerminatedAt n := Or.resolve_left hyp this
         obtain ⟨gp, s_ppred_nth_eq⟩ : ∃ gp, g.s.get? n = some gp :=
           Option.ne_none_iff_exists'.mp not_terminatedAt_n

--- a/Mathlib/Algebra/Group/Defs.lean
+++ b/Mathlib/Algebra/Group/Defs.lean
@@ -524,7 +524,7 @@ theorem npowBinRec.go_spec {M : Type*} [Semigroup M] [One M] (k : ℕ) (m n : M)
     npowBinRec.go (k + 1) m n = m * npowRec' (k + 1) n := by
   unfold go
   generalize hk : k + 1 = k'
-  replace hk : k' ≠ 0 := by omega
+  replace hk : k' ≠ 0 := by lia
   induction k' using Nat.binaryRecFromOne generalizing n m with
   | zero => simp at hk
   | one => simp [npowRec']

--- a/Mathlib/Algebra/Group/Fin/Basic.lean
+++ b/Mathlib/Algebra/Group/Fin/Basic.lean
@@ -129,7 +129,7 @@ lemma lt_sub_iff {n : ℕ} {a b : Fin n} : a < a - b ↔ a < b := by
       simp_rw [hk, Nat.add_assoc, Nat.add_sub_cancel_left]
       -- simp_rw because, otherwise, rw tries to rewrite inside `b : Fin (n + 1)`
     rw [this, Nat.mod_eq_of_lt (hk.ge.trans_lt' ?_), Nat.lt_add_left_iff_pos] <;>
-    omega
+    lia
 
 @[simp]
 lemma sub_le_iff {n : ℕ} {a b : Fin n} : a - b ≤ a ↔ b ≤ a := by

--- a/Mathlib/Algebra/Homology/ComplexShapeSigns.lean
+++ b/Mathlib/Algebra/Homology/ComplexShapeSigns.lean
@@ -165,8 +165,8 @@ instance : TotalComplexShape c c c where
 
 instance : TensorSigns (ComplexShape.down ℕ) where
   ε' := MonoidHom.mk' (fun (i : ℕ) => (-1 : ℤˣ) ^ i) (pow_add (-1 : ℤˣ))
-  rel_add p q r (hpq : q + 1 = p) := by dsimp; omega
-  add_rel p q r (hpq : q + 1 = p) := by dsimp; omega
+  rel_add p q r (hpq : q + 1 = p) := by dsimp; lia
+  add_rel p q r (hpq : q + 1 = p) := by dsimp; lia
   ε'_succ := by
     rintro _ q rfl
     dsimp
@@ -177,8 +177,8 @@ lemma ε_down_ℕ (n : ℕ) : (ComplexShape.down ℕ).ε n = (-1 : ℤˣ) ^ n :=
 
 instance : TensorSigns (ComplexShape.up ℤ) where
   ε' := MonoidHom.mk' Int.negOnePow Int.negOnePow_add
-  rel_add p q r (hpq : p + 1 = q) := by dsimp; omega
-  add_rel p q r (hpq : p + 1 = q) := by dsimp; omega
+  rel_add p q r (hpq : p + 1 = q) := by dsimp; lia
+  add_rel p q r (hpq : p + 1 = q) := by dsimp; lia
   ε'_succ := by
     rintro p _ rfl
     dsimp

--- a/Mathlib/Algebra/Homology/DerivedCategory/Ext/Basic.lean
+++ b/Mathlib/Algebra/Homology/DerivedCategory/Ext/Basic.lean
@@ -416,7 +416,7 @@ noncomputable def extFunctorObj (X : C) (n : ℕ) : C ⥤ AddCommGrpCat.{w} wher
     rw [← Ext.mk₀_comp_mk₀]
     symm
     apply Ext.comp_assoc
-    omega
+    lia
 
 /-- The functor `Cᵒᵖ ⥤ C ⥤ AddCommGrpCat` which sends `X : C` and `Y : C`
 to `Ext X Y n`. -/

--- a/Mathlib/Algebra/Homology/DerivedCategory/TStructure.lean
+++ b/Mathlib/Algebra/Homology/DerivedCategory/TStructure.lean
@@ -56,20 +56,20 @@ def TStructure.t : TStructure (DerivedCategory C) where
     apply (subsingleton_hom_of_isStrictlyLE_of_isStrictlyGE K L 0 1 (by simp)).elim
   le_zero_le := by
     rintro X ⟨K, e, _⟩
-    exact ⟨K, e, K.isStrictlyLE_of_le 0 1 (by omega)⟩
+    exact ⟨K, e, K.isStrictlyLE_of_le 0 1 (by lia)⟩
   ge_one_le := by
     rintro X ⟨K, e, _⟩
-    exact ⟨K, e, K.isStrictlyGE_of_ge 0 1 (by omega)⟩
+    exact ⟨K, e, K.isStrictlyGE_of_ge 0 1 (by lia)⟩
   exists_triangle_zero_one X := by
     obtain ⟨K, ⟨e₂⟩⟩ : ∃ K, Nonempty (Q.obj K ≅ X) := ⟨_, ⟨Q.objObjPreimageIso X⟩⟩
     have h := K.shortComplexTruncLE_shortExact 0
     refine ⟨Q.obj (K.truncLE 0), Q.obj (K.truncGE 1),
       ⟨_, Iso.refl _, inferInstance⟩, ⟨_, Iso.refl _, inferInstance⟩,
       Q.map (K.ιTruncLE 0) ≫ e₂.hom, e₂.inv ≫ Q.map (K.πTruncGE 1),
-      inv (Q.map (K.shortComplexTruncLEX₃ToTruncGE 0 1 (by omega))) ≫ (triangleOfSES h).mor₃,
+      inv (Q.map (K.shortComplexTruncLEX₃ToTruncGE 0 1 (by lia))) ≫ (triangleOfSES h).mor₃,
       isomorphic_distinguished _ (triangleOfSES_distinguished h) _ (Iso.symm ?_)⟩
     refine Triangle.isoMk _ _ (Iso.refl _) e₂
-      (asIso (Q.map (K.shortComplexTruncLEX₃ToTruncGE 0 1 (by omega)))) ?_ ?_ (by simp)
+      (asIso (Q.map (K.shortComplexTruncLEX₃ToTruncGE 0 1 (by lia)))) ?_ ?_ (by simp)
     · dsimp
       rw [id_comp]
       rfl

--- a/Mathlib/Algebra/Homology/Embedding/AreComplementary.lean
+++ b/Mathlib/Algebra/Homology/Embedding/AreComplementary.lean
@@ -280,11 +280,11 @@ end AreComplementary
 
 lemma embeddingUpInt_areComplementary (n₀ n₁ : ℤ) (h : n₀ + 1 = n₁) :
     AreComplementary (embeddingUpIntLE n₀) (embeddingUpIntGE n₁) where
-  disjoint i₁ i₂ := by dsimp; omega
+  disjoint i₁ i₂ := by dsimp; lia
   union i := by
     by_cases hi : i ≤ n₀
     · obtain ⟨k, rfl⟩ := Int.exists_add_of_le hi
-      exact Or.inl ⟨k, by dsimp; omega⟩
+      exact Or.inl ⟨k, by dsimp; lia⟩
     · obtain ⟨k, rfl⟩ := Int.exists_add_of_le (show n₁ ≤ i by lia)
       exact Or.inr ⟨k, rfl⟩
 

--- a/Mathlib/Algebra/Homology/Embedding/AreComplementary.lean
+++ b/Mathlib/Algebra/Homology/Embedding/AreComplementary.lean
@@ -285,7 +285,7 @@ lemma embeddingUpInt_areComplementary (n₀ n₁ : ℤ) (h : n₀ + 1 = n₁) :
     by_cases hi : i ≤ n₀
     · obtain ⟨k, rfl⟩ := Int.exists_add_of_le hi
       exact Or.inl ⟨k, by dsimp; omega⟩
-    · obtain ⟨k, rfl⟩ := Int.exists_add_of_le (show n₁ ≤ i by omega)
+    · obtain ⟨k, rfl⟩ := Int.exists_add_of_le (show n₁ ≤ i by lia)
       exact Or.inr ⟨k, rfl⟩
 
 end Embedding

--- a/Mathlib/Algebra/Homology/Embedding/Basic.lean
+++ b/Mathlib/Algebra/Homology/Embedding/Basic.lean
@@ -223,7 +223,7 @@ def embeddingDownNat : Embedding (down ℕ) (up ℤ) :=
 instance : embeddingDownNat.IsRelIff := by dsimp [embeddingDownNat]; infer_instance
 
 instance : embeddingDownNat.IsTruncLE where
-  mem_prev {i j} h := ⟨j + 1, by dsimp at h ⊢; omega⟩
+  mem_prev {i j} h := ⟨j + 1, by dsimp at h ⊢; lia⟩
 
 variable (p : ℤ)
 
@@ -237,7 +237,7 @@ def embeddingUpIntGE : Embedding (up ℕ) (up ℤ) :=
 instance : (embeddingUpIntGE p).IsRelIff := by dsimp [embeddingUpIntGE]; infer_instance
 
 instance : (embeddingUpIntGE p).IsTruncGE where
-  mem_next {j _} h := ⟨j + 1, by dsimp at h ⊢; omega⟩
+  mem_next {j _} h := ⟨j + 1, by dsimp at h ⊢; lia⟩
 
 /-- The embedding from `down ℕ` to `up ℤ` which sends `n : ℕ` to `p - n`. -/
 @[simps!]
@@ -249,7 +249,7 @@ def embeddingUpIntLE : Embedding (down ℕ) (up ℤ) :=
 instance : (embeddingUpIntLE p).IsRelIff := by dsimp [embeddingUpIntLE]; infer_instance
 
 instance : (embeddingUpIntLE p).IsTruncLE where
-  mem_prev {_ k} h := ⟨k + 1, by dsimp at h ⊢; omega⟩
+  mem_prev {_ k} h := ⟨k + 1, by dsimp at h ⊢; lia⟩
 
 lemma notMem_range_embeddingUpIntLE_iff (n : ℤ) :
     (∀ (i : ℕ), (embeddingUpIntLE p).f i ≠ n) ↔ p < n := by

--- a/Mathlib/Algebra/Homology/ExactSequence.lean
+++ b/Mathlib/Algebra/Homology/ExactSequence.lean
@@ -72,11 +72,12 @@ namespace ComposableArrows
 
 variable {n : ℕ} (S : ComposableArrows C n)
 
+-- We do not yet replace `omega` with `lia` here, as it is measurably slower.
 /-- `F : ComposableArrows C n` is a complex if all compositions of
 two consecutive arrows are zero. -/
 structure IsComplex : Prop where
   /-- the composition of two consecutive arrows is zero -/
-  zero (i : ℕ) (hi : i + 2 ≤ n := by lia) :
+  zero (i : ℕ) (hi : i + 2 ≤ n := by omega) :
     S.map' i (i + 1) ≫ S.map' (i + 1) (i + 2) = 0
 
 attribute [reassoc] IsComplex.zero
@@ -84,8 +85,8 @@ attribute [reassoc] IsComplex.zero
 variable {S}
 
 @[reassoc]
-lemma IsComplex.zero' (hS : S.IsComplex) (i j k : ℕ) (hij : i + 1 = j := by lia)
-    (hjk : j + 1 = k := by lia) (hk : k ≤ n := by lia) :
+lemma IsComplex.zero' (hS : S.IsComplex) (i j k : ℕ) (hij : i + 1 = j := by omega)
+    (hjk : j + 1 = k := by omega) (hk : k ≤ n := by omega) :
     S.map' i j ≫ S.map' j k = 0 := by
   subst hij hjk
   exact hS.zero i hk
@@ -105,32 +106,32 @@ lemma isComplex₀ (S : ComposableArrows C 0) : S.IsComplex where
   zero i hi := by simp at hi
 
 lemma isComplex₁ (S : ComposableArrows C 1) : S.IsComplex where
-  zero i hi := by lia
+  zero i hi := by omega
 
 variable (S)
 
 /-- The short complex consisting of maps `S.map' i j` and `S.map' j k` when we know
 that `S : ComposableArrows C n` satisfies `S.IsComplex`. -/
-abbrev sc' (hS : S.IsComplex) (i j k : ℕ) (hij : i + 1 = j := by lia)
-    (hjk : j + 1 = k := by lia) (hk : k ≤ n := by lia) :
+abbrev sc' (hS : S.IsComplex) (i j k : ℕ) (hij : i + 1 = j := by omega)
+    (hjk : j + 1 = k := by omega) (hk : k ≤ n := by omega) :
     ShortComplex C :=
   ShortComplex.mk (S.map' i j) (S.map' j k) (hS.zero' i j k)
 
 /-- The short complex consisting of maps `S.map' i (i + 1)` and `S.map' (i + 1) (i + 2)`
 when we know that `S : ComposableArrows C n` satisfies `S.IsComplex`. -/
-abbrev sc (hS : S.IsComplex) (i : ℕ) (hi : i + 2 ≤ n := by lia) :
+abbrev sc (hS : S.IsComplex) (i : ℕ) (hi : i + 2 ≤ n := by omega) :
     ShortComplex C :=
   S.sc' hS i (i + 1) (i + 2)
 
 /-- `F : ComposableArrows C n` is exact if it is a complex and that all short
 complexes consisting of two consecutive arrows are exact. -/
 structure Exact : Prop extends S.IsComplex where
-  exact (i : ℕ) (hi : i + 2 ≤ n := by lia) : (S.sc toIsComplex i).Exact
+  exact (i : ℕ) (hi : i + 2 ≤ n := by omega) : (S.sc toIsComplex i).Exact
 
 variable {S}
 
-lemma Exact.exact' (hS : S.Exact) (i j k : ℕ) (hij : i + 1 = j := by lia)
-    (hjk : j + 1 = k := by lia) (hk : k ≤ n := by lia) :
+lemma Exact.exact' (hS : S.Exact) (i j k : ℕ) (hij : i + 1 = j := by omega)
+    (hjk : j + 1 = k := by omega) (hk : k ≤ n := by omega) :
     (S.sc' hS.toIsComplex i j k).Exact := by
   subst hij hjk
   exact hS.exact i hk
@@ -138,8 +139,8 @@ lemma Exact.exact' (hS : S.Exact) (i j k : ℕ) (hij : i + 1 = j := by lia)
 /-- Functoriality maps for `ComposableArrows.sc'`. -/
 @[simps]
 def sc'Map {S₁ S₂ : ComposableArrows C n} (φ : S₁ ⟶ S₂) (h₁ : S₁.IsComplex) (h₂ : S₂.IsComplex)
-    (i j k : ℕ) (hij : i + 1 = j := by lia)
-    (hjk : j + 1 = k := by lia) (hk : k ≤ n := by lia) :
+    (i j k : ℕ) (hij : i + 1 = j := by omega)
+    (hjk : j + 1 = k := by omega) (hk : k ≤ n := by omega) :
     S₁.sc' h₁ i j k ⟶ S₂.sc' h₂ i j k where
   τ₁ := φ.app _
   τ₂ := φ.app _
@@ -148,7 +149,7 @@ def sc'Map {S₁ S₂ : ComposableArrows C n} (φ : S₁ ⟶ S₂) (h₁ : S₁.
 /-- Functoriality maps for `ComposableArrows.sc`. -/
 @[simps!]
 def scMap {S₁ S₂ : ComposableArrows C n} (φ : S₁ ⟶ S₂) (h₁ : S₁.IsComplex) (h₂ : S₂.IsComplex)
-    (i : ℕ) (hi : i + 2 ≤ n := by lia) :
+    (i : ℕ) (hi : i + 2 ≤ n := by omega) :
     S₁.sc h₁ i ⟶ S₂.sc h₂ i :=
   sc'Map φ h₁ h₂ i (i + 1) (i + 2)
 
@@ -156,8 +157,8 @@ def scMap {S₁ S₂ : ComposableArrows C n} (φ : S₁ ⟶ S₂) (h₁ : S₁.I
 in `ComposableArrows C n`. -/
 @[simps]
 def sc'MapIso {S₁ S₂ : ComposableArrows C n} (e : S₁ ≅ S₂)
-    (h₁ : S₁.IsComplex) (h₂ : S₂.IsComplex) (i j k : ℕ) (hij : i + 1 = j := by lia)
-    (hjk : j + 1 = k := by lia) (hk : k ≤ n := by lia) :
+    (h₁ : S₁.IsComplex) (h₂ : S₂.IsComplex) (i j k : ℕ) (hij : i + 1 = j := by omega)
+    (hjk : j + 1 = k := by omega) (hk : k ≤ n := by omega) :
     S₁.sc' h₁ i j k ≅ S₂.sc' h₂ i j k where
   hom := sc'Map e.hom h₁ h₂ i j k
   inv := sc'Map e.inv h₂ h₁ i j k
@@ -169,7 +170,7 @@ in `ComposableArrows C n`. -/
 @[simps]
 def scMapIso {S₁ S₂ : ComposableArrows C n} (e : S₁ ≅ S₂)
     (h₁ : S₁.IsComplex) (h₂ : S₂.IsComplex)
-    (i : ℕ) (hi : i + 2 ≤ n := by lia) :
+    (i : ℕ) (hi : i + 2 ≤ n := by omega) :
     S₁.sc h₁ i ≅ S₂.sc h₂ i where
   hom := scMap e.hom h₁ h₂ i
   inv := scMap e.inv h₂ h₁ i
@@ -192,7 +193,7 @@ lemma exact₀ (S : ComposableArrows C 0) : S.Exact where
 
 lemma exact₁ (S : ComposableArrows C 1) : S.Exact where
   toIsComplex := S.isComplex₁
-  exact i hi := by exfalso; lia
+  exact i hi := by exfalso; omega
 
 lemma isComplex₂_iff (S : ComposableArrows C 2) :
     S.IsComplex ↔ S.map' 0 1 ≫ S.map' 1 2 = 0 := by

--- a/Mathlib/Algebra/Homology/ExactSequence.lean
+++ b/Mathlib/Algebra/Homology/ExactSequence.lean
@@ -76,7 +76,7 @@ variable {n : ℕ} (S : ComposableArrows C n)
 two consecutive arrows are zero. -/
 structure IsComplex : Prop where
   /-- the composition of two consecutive arrows is zero -/
-  zero (i : ℕ) (hi : i + 2 ≤ n := by omega) :
+  zero (i : ℕ) (hi : i + 2 ≤ n := by lia) :
     S.map' i (i + 1) ≫ S.map' (i + 1) (i + 2) = 0
 
 attribute [reassoc] IsComplex.zero
@@ -84,8 +84,8 @@ attribute [reassoc] IsComplex.zero
 variable {S}
 
 @[reassoc]
-lemma IsComplex.zero' (hS : S.IsComplex) (i j k : ℕ) (hij : i + 1 = j := by omega)
-    (hjk : j + 1 = k := by omega) (hk : k ≤ n := by omega) :
+lemma IsComplex.zero' (hS : S.IsComplex) (i j k : ℕ) (hij : i + 1 = j := by lia)
+    (hjk : j + 1 = k := by lia) (hk : k ≤ n := by lia) :
     S.map' i j ≫ S.map' j k = 0 := by
   subst hij hjk
   exact hS.zero i hk
@@ -105,32 +105,32 @@ lemma isComplex₀ (S : ComposableArrows C 0) : S.IsComplex where
   zero i hi := by simp at hi
 
 lemma isComplex₁ (S : ComposableArrows C 1) : S.IsComplex where
-  zero i hi := by omega
+  zero i hi := by lia
 
 variable (S)
 
 /-- The short complex consisting of maps `S.map' i j` and `S.map' j k` when we know
 that `S : ComposableArrows C n` satisfies `S.IsComplex`. -/
-abbrev sc' (hS : S.IsComplex) (i j k : ℕ) (hij : i + 1 = j := by omega)
-    (hjk : j + 1 = k := by omega) (hk : k ≤ n := by omega) :
+abbrev sc' (hS : S.IsComplex) (i j k : ℕ) (hij : i + 1 = j := by lia)
+    (hjk : j + 1 = k := by lia) (hk : k ≤ n := by lia) :
     ShortComplex C :=
   ShortComplex.mk (S.map' i j) (S.map' j k) (hS.zero' i j k)
 
 /-- The short complex consisting of maps `S.map' i (i + 1)` and `S.map' (i + 1) (i + 2)`
 when we know that `S : ComposableArrows C n` satisfies `S.IsComplex`. -/
-abbrev sc (hS : S.IsComplex) (i : ℕ) (hi : i + 2 ≤ n := by omega) :
+abbrev sc (hS : S.IsComplex) (i : ℕ) (hi : i + 2 ≤ n := by lia) :
     ShortComplex C :=
   S.sc' hS i (i + 1) (i + 2)
 
 /-- `F : ComposableArrows C n` is exact if it is a complex and that all short
 complexes consisting of two consecutive arrows are exact. -/
 structure Exact : Prop extends S.IsComplex where
-  exact (i : ℕ) (hi : i + 2 ≤ n := by omega) : (S.sc toIsComplex i).Exact
+  exact (i : ℕ) (hi : i + 2 ≤ n := by lia) : (S.sc toIsComplex i).Exact
 
 variable {S}
 
-lemma Exact.exact' (hS : S.Exact) (i j k : ℕ) (hij : i + 1 = j := by omega)
-    (hjk : j + 1 = k := by omega) (hk : k ≤ n := by omega) :
+lemma Exact.exact' (hS : S.Exact) (i j k : ℕ) (hij : i + 1 = j := by lia)
+    (hjk : j + 1 = k := by lia) (hk : k ≤ n := by lia) :
     (S.sc' hS.toIsComplex i j k).Exact := by
   subst hij hjk
   exact hS.exact i hk
@@ -138,8 +138,8 @@ lemma Exact.exact' (hS : S.Exact) (i j k : ℕ) (hij : i + 1 = j := by omega)
 /-- Functoriality maps for `ComposableArrows.sc'`. -/
 @[simps]
 def sc'Map {S₁ S₂ : ComposableArrows C n} (φ : S₁ ⟶ S₂) (h₁ : S₁.IsComplex) (h₂ : S₂.IsComplex)
-    (i j k : ℕ) (hij : i + 1 = j := by omega)
-    (hjk : j + 1 = k := by omega) (hk : k ≤ n := by omega) :
+    (i j k : ℕ) (hij : i + 1 = j := by lia)
+    (hjk : j + 1 = k := by lia) (hk : k ≤ n := by lia) :
     S₁.sc' h₁ i j k ⟶ S₂.sc' h₂ i j k where
   τ₁ := φ.app _
   τ₂ := φ.app _
@@ -148,7 +148,7 @@ def sc'Map {S₁ S₂ : ComposableArrows C n} (φ : S₁ ⟶ S₂) (h₁ : S₁.
 /-- Functoriality maps for `ComposableArrows.sc`. -/
 @[simps!]
 def scMap {S₁ S₂ : ComposableArrows C n} (φ : S₁ ⟶ S₂) (h₁ : S₁.IsComplex) (h₂ : S₂.IsComplex)
-    (i : ℕ) (hi : i + 2 ≤ n := by omega) :
+    (i : ℕ) (hi : i + 2 ≤ n := by lia) :
     S₁.sc h₁ i ⟶ S₂.sc h₂ i :=
   sc'Map φ h₁ h₂ i (i + 1) (i + 2)
 
@@ -156,8 +156,8 @@ def scMap {S₁ S₂ : ComposableArrows C n} (φ : S₁ ⟶ S₂) (h₁ : S₁.I
 in `ComposableArrows C n`. -/
 @[simps]
 def sc'MapIso {S₁ S₂ : ComposableArrows C n} (e : S₁ ≅ S₂)
-    (h₁ : S₁.IsComplex) (h₂ : S₂.IsComplex) (i j k : ℕ) (hij : i + 1 = j := by omega)
-    (hjk : j + 1 = k := by omega) (hk : k ≤ n := by omega) :
+    (h₁ : S₁.IsComplex) (h₂ : S₂.IsComplex) (i j k : ℕ) (hij : i + 1 = j := by lia)
+    (hjk : j + 1 = k := by lia) (hk : k ≤ n := by lia) :
     S₁.sc' h₁ i j k ≅ S₂.sc' h₂ i j k where
   hom := sc'Map e.hom h₁ h₂ i j k
   inv := sc'Map e.inv h₂ h₁ i j k
@@ -169,7 +169,7 @@ in `ComposableArrows C n`. -/
 @[simps]
 def scMapIso {S₁ S₂ : ComposableArrows C n} (e : S₁ ≅ S₂)
     (h₁ : S₁.IsComplex) (h₂ : S₂.IsComplex)
-    (i : ℕ) (hi : i + 2 ≤ n := by omega) :
+    (i : ℕ) (hi : i + 2 ≤ n := by lia) :
     S₁.sc h₁ i ≅ S₂.sc h₂ i where
   hom := scMap e.hom h₁ h₂ i
   inv := scMap e.inv h₂ h₁ i

--- a/Mathlib/Algebra/Homology/ExactSequence.lean
+++ b/Mathlib/Algebra/Homology/ExactSequence.lean
@@ -192,7 +192,7 @@ lemma exact₀ (S : ComposableArrows C 0) : S.Exact where
 
 lemma exact₁ (S : ComposableArrows C 1) : S.Exact where
   toIsComplex := S.isComplex₁
-  exact i hi := by exfalso; omega
+  exact i hi := by exfalso; lia
 
 lemma isComplex₂_iff (S : ComposableArrows C 2) :
     S.IsComplex ↔ S.map' 0 1 ≫ S.map' 1 2 = 0 := by

--- a/Mathlib/Algebra/Homology/HomotopyCategory/DegreewiseSplit.lean
+++ b/Mathlib/Algebra/Homology/HomotopyCategory/DegreewiseSplit.lean
@@ -87,8 +87,8 @@ noncomputable def mappingConeHomOfDegreewiseSplitXIso (p q : ℤ) (hpq : p + 1 =
     (mappingCone (homOfDegreewiseSplit S σ)).X p ≅ S.X₂.X q where
   hom := (mappingCone.fst (homOfDegreewiseSplit S σ)).1.v p q hpq ≫ (σ q).s -
     (mappingCone.snd (homOfDegreewiseSplit S σ)).v p p (add_zero p) ≫
-      by exact (Cochain.ofHom S.f).v (p + 1) q (by omega)
-  inv := S.g.f q ≫ (mappingCone.inl (homOfDegreewiseSplit S σ)).v q p (by omega) -
+      by exact (Cochain.ofHom S.f).v (p + 1) q (by lia)
+  inv := S.g.f q ≫ (mappingCone.inl (homOfDegreewiseSplit S σ)).v q p (by lia) -
     by exact (σ q).r ≫ (S.X₁.XIsoOfEq hpq.symm).hom ≫
       (mappingCone.inr (homOfDegreewiseSplit S σ)).f p
   hom_inv_id := by
@@ -196,7 +196,7 @@ cochain complexes. -/
 @[simps]
 noncomputable def triangleRotateShortComplexSplitting (n : ℤ) :
     ((triangleRotateShortComplex φ).map (eval _ _ n)).Splitting where
-  s := -(inl φ).v (n + 1) n (by omega)
+  s := -(inl φ).v (n + 1) n (by lia)
   r := (snd φ).v n n (add_zero n)
   id := by simp [ext_from_iff φ _ _ rfl]
 

--- a/Mathlib/Algebra/Homology/HomotopyCategory/HomComplex.lean
+++ b/Mathlib/Algebra/Homology/HomotopyCategory/HomComplex.lean
@@ -784,7 +784,7 @@ def equivHomotopy (φ₁ φ₂ : F ⟶ G) :
     dsimp
     split_ifs with h
     · rfl
-    · rw [ho.zero i j (fun h' => h (by dsimp at h'; omega))]
+    · rw [ho.zero i j (fun h' => h (by dsimp at h'; lia))]
   right_inv := fun z => by
     ext p q hpq
     dsimp [Cochain.ofHomotopy]

--- a/Mathlib/Algebra/Homology/HomotopyCategory/HomComplex.lean
+++ b/Mathlib/Algebra/Homology/HomotopyCategory/HomComplex.lean
@@ -771,7 +771,7 @@ def equivHomotopy (φ₁ φ₂ : F ⟶ G) :
   toFun ho := ⟨Cochain.ofHomotopy ho, by simp only [δ_ofHomotopy, sub_add_cancel]⟩
   invFun z :=
     { hom := fun i j => if hij : i + (-1) = j then z.1.v i j hij else 0
-      zero := fun i j (hij : j + 1 ≠ i) => dif_neg (fun _ => hij (by omega))
+      zero := fun i j (hij : j + 1 ≠ i) => dif_neg (fun _ => hij (by lia))
       comm := fun p => by
         have eq := Cochain.congr_v z.2 p p (add_zero p)
         have h₁ : (ComplexShape.up ℤ).Rel (p - 1) p := by simp

--- a/Mathlib/Algebra/Homology/HomotopyCategory/HomComplexShift.lean
+++ b/Mathlib/Algebra/Homology/HomotopyCategory/HomComplexShift.lean
@@ -380,7 +380,7 @@ lemma leftShift_comp (a n' : ℤ) (hn' : n + a = n') {m t t' : ℤ} (γ' : Cocha
     (γ.comp γ' h).leftShift a t' ht' = (a * m).negOnePow • (γ.leftShift a n' hn').comp γ'
       (by rw [← ht', ← h, ← hn', add_assoc, add_comm a, add_assoc]) := by
   ext p q hpq
-  have h' : n' + m = t' := by omega
+  have h' : n' + m = t' := by lia
   dsimp
   simp only [Cochain.comp_v _ _ h' p (p + n') q rfl (by lia),
     γ.leftShift_v a n' hn' p (p + n') rfl (p + a) (by lia),
@@ -399,7 +399,7 @@ lemma leftShift_comp_zero_cochain (a n' : ℤ) (hn' : n + a = n') (γ' : Cochain
 lemma δ_rightShift (a n' m' : ℤ) (hn' : n' + a = n) (m : ℤ) (hm' : m' + a = m) :
     δ n' m' (γ.rightShift a n' hn') = a.negOnePow • (δ n m γ).rightShift a m' hm' := by
   by_cases hnm : n + 1 = m
-  · have hnm' : n' + 1 = m' := by omega
+  · have hnm' : n' + 1 = m' := by lia
     ext p q hpq
     dsimp
     rw [(δ n m γ).rightShift_v a m' hm' p q hpq _ rfl,
@@ -427,7 +427,7 @@ lemma δ_rightUnshift {a n' : ℤ} (γ : Cochain K (L⟦a⟧) n') (n : ℤ) (hn 
 lemma δ_leftShift (a n' m' : ℤ) (hn' : n + a = n') (m : ℤ) (hm' : m + a = m') :
     δ n' m' (γ.leftShift a n' hn') = a.negOnePow • (δ n m γ).leftShift a m' hm' := by
   by_cases hnm : n + 1 = m
-  · have hnm' : n' + 1 = m' := by omega
+  · have hnm' : n' + 1 = m' := by lia
     ext p q hpq
     dsimp
     rw [(δ n m γ).leftShift_v a m' hm' p q hpq (p+a) (by lia),

--- a/Mathlib/Algebra/Homology/HomotopyCategory/MappingCone.lean
+++ b/Mathlib/Algebra/Homology/HomotopyCategory/MappingCone.lean
@@ -583,12 +583,12 @@ definitional properties. See also the equational lemma `mapHomologicalComplexXIs
 noncomputable def mapHomologicalComplexXIso' (n m : ℤ) (hnm : n + 1 = m) :
     ((H.mapHomologicalComplex (ComplexShape.up ℤ)).obj (mappingCone φ)).X n ≅
       (mappingCone ((H.mapHomologicalComplex (ComplexShape.up ℤ)).map φ)).X n where
-  hom := H.map ((fst φ).1.v n m (by omega)) ≫
-      (inl ((H.mapHomologicalComplex (ComplexShape.up ℤ)).map φ)).v m n (by omega) +
+  hom := H.map ((fst φ).1.v n m (by lia)) ≫
+      (inl ((H.mapHomologicalComplex (ComplexShape.up ℤ)).map φ)).v m n (by lia) +
       H.map ((snd φ).v n n (add_zero n)) ≫
         (inr ((H.mapHomologicalComplex (ComplexShape.up ℤ)).map φ)).f n
-  inv := (fst ((H.mapHomologicalComplex (ComplexShape.up ℤ)).map φ)).1.v n m (by omega) ≫
-      H.map ((inl φ).v m n (by omega)) +
+  inv := (fst ((H.mapHomologicalComplex (ComplexShape.up ℤ)).map φ)).1.v n m (by lia) ≫
+      H.map ((inl φ).v m n (by lia)) +
       (snd ((H.mapHomologicalComplex (ComplexShape.up ℤ)).map φ)).v n n (add_zero n) ≫
         H.map ((inr φ).f n)
   hom_inv_id := by

--- a/Mathlib/Algebra/Homology/HomotopyCategory/Pretriangulated.lean
+++ b/Mathlib/Algebra/Homology/HomotopyCategory/Pretriangulated.lean
@@ -60,7 +60,7 @@ lemma inl_v_triangle_mor₃_f (p q : ℤ) (hpq : p + (-1) = q) :
       -(K.shiftFunctorObjXIso 1 q p (by rw [← hpq, neg_add_cancel_right])).inv := by
   dsimp [triangle]
   -- the following list of lemmas was obtained by doing
-  -- simp? [Cochain.rightShift_v _ 1 0 (zero_add 1) q q (add_zero q) p (by omega)]
+  -- simp? [Cochain.rightShift_v _ 1 0 (zero_add 1) q q (add_zero q) p (by lia)]
   simp only [Int.reduceNeg, Cochain.rightShift_neg, Cochain.neg_v, shiftFunctor_obj_X',
     Cochain.rightShift_v _ 1 0 (zero_add 1) q q (add_zero q) p (by lia), shiftFunctor_obj_X,
     shiftFunctorObjXIso, Preadditive.comp_neg, inl_v_fst_v_assoc]
@@ -224,19 +224,19 @@ noncomputable def rotateHomotopyEquiv :
       -- the following list of lemmas has been obtained by doing
       -- simp? [ext_to_iff _ _ (n + 1) rfl, ext_from_iff _ (n + 1) _ rfl,
       --   δ_zero_cochain_comp _ _ _ (neg_add_cancel 1),
-      --   (inl φ).leftShift_v 1 0 (neg_add_cancel 1) n n (add_zero n) (n + 1) (by omega),
-      --   (Cochain.ofHom φ).leftShift_v 1 1 (zero_add 1) n (n + 1) rfl (n + 1) (by omega),
-      --   Cochain.comp_v _ _ (add_neg_cancel 1) n (n + 1) n rfl (by omega)]
+      --   (inl φ).leftShift_v 1 0 (neg_add_cancel 1) n n (add_zero n) (n + 1) (by lia),
+      --   (Cochain.ofHom φ).leftShift_v 1 1 (zero_add 1) n (n + 1) rfl (n + 1) (by lia),
+      --   Cochain.comp_v _ _ (add_neg_cancel 1) n (n + 1) n rfl (by lia)]
       simp only [Int.reduceNeg, Cochain.ofHom_comp, ofHom_desc, ofHom_lift, Cocycle.coe_neg,
         Cocycle.leftShift_coe, Cocycle.ofHom_coe, Cochain.comp_zero_cochain_v,
         shiftFunctor_obj_X', δ_neg, δ_zero_cochain_comp _ _ _ (neg_add_cancel 1), δ_inl,
         Int.negOnePow_neg, Int.negOnePow_one, δ_snd, Cochain.neg_comp,
         Cochain.comp_assoc_of_second_is_zero_cochain, smul_neg, Units.neg_smul, one_smul,
         neg_neg, Cochain.comp_add, inr_snd_assoc, neg_add_rev, Cochain.add_v, Cochain.neg_v,
-        Cochain.comp_v _ _ (add_neg_cancel 1) n (n + 1) n rfl (by omega),
+        Cochain.comp_v _ _ (add_neg_cancel 1) n (n + 1) n rfl (by lia),
         Cochain.zero_cochain_comp_v, Cochain.ofHom_v, HomologicalComplex.id_f,
         ext_to_iff _ _ (n + 1) rfl, assoc, liftCochain_v_fst_v,
-        (Cochain.ofHom φ).leftShift_v 1 1 (zero_add 1) n (n + 1) rfl (n + 1) (by omega),
+        (Cochain.ofHom φ).leftShift_v 1 1 (zero_add 1) n (n + 1) rfl (n + 1) (by lia),
         shiftFunctor_obj_X, mul_one, sub_self, mul_zero, Int.zero_ediv, add_zero,
         shiftFunctorObjXIso, HomologicalComplex.XIsoOfEq_rfl, Iso.refl_hom, id_comp,
         Preadditive.add_comp, Preadditive.neg_comp, inl_v_fst_v, comp_id, inr_f_fst_v, comp_zero,
@@ -245,7 +245,7 @@ noncomputable def rotateHomotopyEquiv :
         inr_f_descCochain_v_assoc, inr_f_snd_v_assoc, inl_v_triangle_mor₃_f_assoc, triangle_obj₁,
         Iso.refl_inv, inl_v_fst_v_assoc, inr_f_triangle_mor₃_f_assoc, inr_f_fst_v_assoc, and_self,
         liftCochain_v_snd_v,
-        (inl φ).leftShift_v 1 0 (neg_add_cancel 1) n n (add_zero n) (n + 1) (by omega),
+        (inl φ).leftShift_v 1 0 (neg_add_cancel 1) n n (add_zero n) (n + 1) (by lia),
         Int.negOnePow_zero, inl_v_snd_v, inr_f_snd_v, zero_add, inl_v_descCochain_v,
         inr_f_descCochain_v, inl_v_triangle_mor₃_f, inr_f_triangle_mor₃_f, neg_add_cancel]⟩
 
@@ -258,10 +258,10 @@ noncomputable def rotateHomotopyEquivComm₂Homotopy :
         dsimp [rotateHomotopyEquiv]
         -- the following list of lemmas has been obtained by doing
         -- simp? [ext_from_iff _ _ _ rfl, ext_to_iff _ _ _ rfl,
-        --  (inl φ).leftShift_v 1 0 (neg_add_cancel 1) p p (add_zero p) (p + 1) (by omega),
+        --  (inl φ).leftShift_v 1 0 (neg_add_cancel 1) p p (add_zero p) (p + 1) (by lia),
         --  δ_zero_cochain_comp _ _ _ (neg_add_cancel 1),
-        --  Cochain.comp_v _ _ (add_neg_cancel 1) p (p + 1) p rfl (by omega),
-        --  (Cochain.ofHom φ).leftShift_v 1 1 (zero_add 1) p (p + 1) rfl (p + 1) (by omega)]⟩
+        --  Cochain.comp_v _ _ (add_neg_cancel 1) p (p + 1) p rfl (by lia),
+        --  (Cochain.ofHom φ).leftShift_v 1 1 (zero_add 1) p (p + 1) rfl (p + 1) (by lia)]⟩
         simp only [Int.reduceNeg, Cochain.ofHom_comp, ofHom_lift, Cocycle.coe_neg,
           Cocycle.leftShift_coe, Cocycle.ofHom_coe, Cochain.comp_zero_cochain_v,
           shiftFunctor_obj_X', Cochain.ofHom_v, δ_neg, δ_zero_cochain_comp _ _ _ (neg_add_cancel 1),
@@ -296,7 +296,7 @@ lemma rotateHomotopyEquiv_comm₃ :
   dsimp [rotateHomotopyEquiv]
   -- the following list of lemmas has been obtained by doing
   -- simp? [lift_f _ _ _ _ _ (p + 1) rfl,
-  --   (Cochain.ofHom φ).leftShift_v 1 1 (zero_add 1) p (p + 1) rfl (p + 1) (by omega)]
+  --   (Cochain.ofHom φ).leftShift_v 1 1 (zero_add 1) p (p + 1) rfl (p + 1) (by lia)]
   simp only [Int.reduceNeg, lift_f _ _ _ _ _ (p + 1) rfl, shiftFunctor_obj_X', Cocycle.coe_neg,
     Cocycle.leftShift_coe, Cocycle.ofHom_coe, Cochain.neg_v,
     (Cochain.ofHom φ).leftShift_v 1 1 (zero_add 1) p (p + 1) rfl (p + 1) (by lia),

--- a/Mathlib/Algebra/Homology/HomotopyCategory/Shift.lean
+++ b/Mathlib/Algebra/Homology/HomotopyCategory/Shift.lean
@@ -55,7 +55,7 @@ def shiftFunctor (n : ℤ) : CochainComplex C ℤ ⥤ CochainComplex C ℤ where
         intro hij'
         apply hij
         dsimp at hij' ⊢
-        omega }
+        lia }
   map φ :=
     { f := fun _ => φ.f _
       comm' := by
@@ -281,15 +281,15 @@ def shift {K L : CochainComplex C ℤ} {φ₁ φ₂ : K ⟶ L} (h : Homotopy φ�
     rw [h.zero, smul_zero]
     intro hij'
     dsimp at hij hij'
-    omega
+    lia
   comm := fun i => by
     rw [dNext_eq _ (show (ComplexShape.up ℤ).Rel i (i + 1) by simp),
       prevD_eq _ (show (ComplexShape.up ℤ).Rel (i - 1) i by simp)]
     dsimp
     simpa only [Linear.units_smul_comp, Linear.comp_units_smul, smul_smul,
       Int.units_mul_self, one_smul,
-      dNext_eq _ (show (ComplexShape.up ℤ).Rel (i + n) (i + 1 + n) by dsimp; omega),
-      prevD_eq _ (show (ComplexShape.up ℤ).Rel (i - 1 + n) (i + n) by dsimp; omega)]
+      dNext_eq _ (show (ComplexShape.up ℤ).Rel (i + n) (i + 1 + n) by dsimp; lia),
+      prevD_eq _ (show (ComplexShape.up ℤ).Rel (i - 1 + n) (i + n) by dsimp; lia)]
         using h.comm (i + n)
 
 end Homotopy

--- a/Mathlib/Algebra/Homology/HomotopyCategory/SingleFunctors.lean
+++ b/Mathlib/Algebra/Homology/HomotopyCategory/SingleFunctors.lean
@@ -42,14 +42,14 @@ noncomputable def singleFunctors : SingleFunctors C (CochainComplex C ℤ) ℤ w
   shiftIso n a a' ha' := NatIso.ofComponents
     (fun X => Hom.isoOfComponents
       (fun i => eqToIso (by
-        obtain rfl : a' = a + n := by omega
+        obtain rfl : a' = a + n := by lia
         by_cases h : i = a
         · subst h
           simp only [Functor.comp_obj, shiftFunctor_obj_X', single_obj_X_self]
         · dsimp [single]
-          rw [if_neg h, if_neg (fun h' => h (by omega))])))
+          rw [if_neg h, if_neg (fun h' => h (by lia))])))
     (fun {X Y} f => by
-      obtain rfl : a' = a + n := by omega
+      obtain rfl : a' = a + n := by lia
       ext
       simp [single])
   shiftIso_zero a := by

--- a/Mathlib/Algebra/Homology/LeftResolution/Basic.lean
+++ b/Mathlib/Algebra/Homology/LeftResolution/Basic.lean
@@ -99,7 +99,7 @@ attribute [irreducible] chainComplex
 lemma exactAt_map_chainComplex_succ (n : ℕ) :
     ((ι.mapHomologicalComplex _).obj (Λ.chainComplex X)).ExactAt (n + 1) := by
   rw [HomologicalComplex.exactAt_iff' _ (n + 2) (n + 1) n
-    (ComplexShape.prev_eq' _ (by dsimp; omega)) (by simp),
+    (ComplexShape.prev_eq' _ (by dsimp; lia)) (by simp),
     ShortComplex.exact_iff_epi_kernel_lift]
   convert epi_comp (ι.map (Λ.chainComplexXIso X n).hom) (Λ.π.app _)
   rw [← cancel_mono (kernel.ι _), kernel.lift_ι]

--- a/Mathlib/Algebra/Homology/TotalComplexShift.lean
+++ b/Mathlib/Algebra/Homology/TotalComplexShift.lean
@@ -123,11 +123,11 @@ instance : ((shiftFunctor₁ C x ⋙ shiftFunctor₂ C y).obj K).HasTotal (up �
 /-- Auxiliary definition for `totalShift₁Iso`. -/
 noncomputable def totalShift₁XIso (n n' : ℤ) (h : n + x = n') :
     (((shiftFunctor₁ C x).obj K).total (up ℤ)).X n ≅ (K.total (up ℤ)).X n' where
-  hom := totalDesc _ (fun p q hpq => K.ιTotal (up ℤ) (p + x) q n' (by dsimp at hpq ⊢; omega))
+  hom := totalDesc _ (fun p q hpq => K.ιTotal (up ℤ) (p + x) q n' (by dsimp at hpq ⊢; lia))
   inv := totalDesc _ (fun p q hpq =>
     (K.XXIsoOfEq _ _ _ (Int.sub_add_cancel p x) rfl).inv ≫
       ((shiftFunctor₁ C x).obj K).ιTotal (up ℤ) (p - x) q n
-        (by dsimp at hpq ⊢; omega))
+        (by dsimp at hpq ⊢; lia))
   hom_inv_id := by
     ext p q h
     dsimp
@@ -225,10 +225,10 @@ lemma totalShift₁Iso_hom_naturality [L.HasTotal (up ℤ)] :
 noncomputable def totalShift₂XIso (n n' : ℤ) (h : n + y = n') :
     (((shiftFunctor₂ C y).obj K).total (up ℤ)).X n ≅ (K.total (up ℤ)).X n' where
   hom := totalDesc _ (fun p q hpq => (p * y).negOnePow • K.ιTotal (up ℤ) p (q + y) n'
-    (by dsimp at hpq ⊢; omega))
+    (by dsimp at hpq ⊢; lia))
   inv := totalDesc _ (fun p q hpq => (p * y).negOnePow •
     (K.XXIsoOfEq _ _ _ rfl (Int.sub_add_cancel q y)).inv ≫
-      ((shiftFunctor₂ C y).obj K).ιTotal (up ℤ) p (q - y) n (by dsimp at hpq ⊢; omega))
+      ((shiftFunctor₂ C y).obj K).ιTotal (up ℤ) p (q - y) n (by dsimp at hpq ⊢; lia))
   hom_inv_id := by
     ext p q h
     dsimp

--- a/Mathlib/Algebra/Homology/TotalComplexShift.lean
+++ b/Mathlib/Algebra/Homology/TotalComplexShift.lean
@@ -132,7 +132,7 @@ noncomputable def totalShift₁XIso (n n' : ℤ) (h : n + x = n') :
     ext p q h
     dsimp
     simp only [ι_totalDesc_assoc, CochainComplex.shiftFunctor_obj_X', ι_totalDesc, comp_id]
-    exact ((shiftFunctor₁ C x).obj K).XXIsoOfEq_inv_ιTotal _ (by omega) rfl _ _
+    exact ((shiftFunctor₁ C x).obj K).XXIsoOfEq_inv_ιTotal _ (by lia) rfl _ _
   inv_hom_id := by
     ext
     dsimp
@@ -234,7 +234,7 @@ noncomputable def totalShift₂XIso (n n' : ℤ) (h : n + y = n') :
     dsimp
     simp only [ι_totalDesc_assoc, Linear.units_smul_comp, ι_totalDesc, smul_smul,
       Int.units_mul_self, one_smul, comp_id]
-    exact ((shiftFunctor₂ C y).obj K).XXIsoOfEq_inv_ιTotal _ rfl (by omega) _ _
+    exact ((shiftFunctor₂ C y).obj K).XXIsoOfEq_inv_ιTotal _ rfl (by lia) _ _
   inv_hom_id := by
     ext
     dsimp

--- a/Mathlib/Algebra/Lie/Sl2.lean
+++ b/Mathlib/Algebra/Lie/Sl2.lean
@@ -223,7 +223,7 @@ lemma pow_toEnd_f_eq_zero_of_eq_nat
       lie_h := (P.lie_h_pow_toEnd_f _).trans (by simp [hn])
       lie_e := (P.lie_e_pow_succ_toEnd_f _).trans (by simp [hn]) }
   obtain ⟨m, hm⟩ := this.exists_nat
-  have : (n : ℤ) < m + 2 * (n + 1) := by omega
+  have : (n : ℤ) < m + 2 * (n + 1) := by lia
   exact this.ne (Int.cast_injective (α := R) <| by simpa [sub_eq_iff_eq_add] using hm)
 
 end HasPrimitiveVectorWith

--- a/Mathlib/Algebra/Lie/Weights/Chain.lean
+++ b/Mathlib/Algebra/Lie/Weights/Chain.lean
@@ -331,7 +331,7 @@ lemma genWeightSpace_zsmul_add_ne_bot {n : ℤ}
 
 lemma genWeightSpace_neg_zsmul_add_ne_bot {n : ℕ} (hn : n ≤ chainBotCoeff α β) :
     genWeightSpace M ((-n : ℤ) • α + β : L → R) ≠ ⊥ := by
-  apply genWeightSpace_zsmul_add_ne_bot α β <;> omega
+  apply genWeightSpace_zsmul_add_ne_bot α β <;> lia
 
 /-- The last weight in an `α`-chain through `β`. -/
 noncomputable

--- a/Mathlib/Algebra/Lie/Weights/RootSystem.lean
+++ b/Mathlib/Algebra/Lie/Weights/RootSystem.lean
@@ -125,7 +125,7 @@ lemma rootSpace_neg_nsmul_add_chainTop_of_lt (hα : α.IsNonZero) {n : ℕ} (hn 
       apply_coroot_eq_cast' α β, Int.cast_sub, Int.cast_mul, Int.cast_ofNat, mul_comm (2 : K),
       add_sub_cancel, add_sub, Nat.cast_inj, eq_sub_iff_add_eq, ← Nat.cast_add, ← sub_eq_neg_add,
       sub_eq_iff_eq_add] at this
-    omega
+    lia
   have H₂ : ((1 + n + chainTopCoeff (-α) W) • α + chainTop (-α) W : H → K) =
       (chainTopCoeff α β + 1) • α + β := by
     simp only [Weight.coe_neg, ← Nat.cast_smul_eq_nsmul ℤ, Nat.cast_add, Nat.cast_one, coe_chainTop,
@@ -365,7 +365,7 @@ def reflectRoot (α β : Weight K H L) : Weight K H L where
     · simpa [hα.eq] using β.genWeightSpace_ne_bot
     rw [sub_eq_neg_add, apply_coroot_eq_cast α β, ← neg_smul, ← Int.cast_neg,
       Int.cast_smul_eq_zsmul, rootSpace_zsmul_add_ne_bot_iff α β hα]
-    omega
+    lia
 
 lemma reflectRoot_isNonZero (α β : Weight K H L) (hβ : β.IsNonZero) :
     (reflectRoot α β).IsNonZero := by

--- a/Mathlib/Algebra/LinearRecurrence.lean
+++ b/Mathlib/Algebra/LinearRecurrence.lean
@@ -75,7 +75,7 @@ def mkSol (init : Fin E.order → R) : ℕ → R
     if h : n < E.order then init ⟨n, h⟩
     else
       ∑ k : Fin E.order,
-        have _ : n - E.order + k < n := by omega
+        have _ : n - E.order + k < n := by lia
         E.coeffs k * mkSol init (n - E.order + k)
 
 /-- `E.mkSol` indeed gives solutions to `E`. -/

--- a/Mathlib/Algebra/Module/ZLattice/Summable.lean
+++ b/Mathlib/Algebra/Module/ZLattice/Summable.lean
@@ -115,17 +115,18 @@ lemma sum_piFinset_Icc_rpow_le {ι : Type*} [Fintype ι] [DecidableEq ι]
     simp only [Fintype.mem_piFinset, s] at hx ⊢
     exact fun i ↦ Icc_subset_Icc (by simpa) (by simpa) (hx i)
   have (k : ℕ) : #(s (k + 1) \ s k) ≤ 2 * d * (2 * k + 3) ^ (d - 1) := by
+    -- We do not yet replace `omega` with `lia` here, as it is measurably slower.
     trans (2 * k + 3) ^ d - (2 * k + 1) ^ d
     · simp only [le_add_iff_nonneg_right, zero_le, hs, card_sdiff_of_subset, s]
       simp only [Fintype.card_piFinset, Int.card_Icc, sub_neg_eq_add, prod_const, card_univ]
-      gcongr <;> norm_cast <;> lia
+      gcongr <;> norm_cast <;> omega
     · have := abs_pow_sub_pow_le (α := ℤ) ↑(2 * k + 3) ↑(2 * k + 1) d
       norm_num at this
       zify
       convert this using 3
-      · rw [abs_eq_self.mpr (sub_nonneg.mpr (by gcongr; lia)), Nat.cast_sub (by gcongr; lia)]
+      · rw [abs_eq_self.mpr (sub_nonneg.mpr (by gcongr; omega)), Nat.cast_sub (by gcongr; omega)]
         simp
-      · rw [max_eq_left (by gcongr; lia), abs_eq_self.mpr (by positivity)]
+      · rw [max_eq_left (by gcongr; omega), abs_eq_self.mpr (by positivity)]
   let ε := normBound b
   have hε : 0 < ε := normBound_pos b
   calc ∑ p ∈ s n, ‖∑ i, p i • b i‖ ^ r
@@ -146,7 +147,7 @@ lemma sum_piFinset_Icc_rpow_le {ι : Type*} [Fintype ι] [DecidableEq ι]
         gcongr with k hk
         refine (this _).trans ?_
         gcongr
-        lia
+        omega
     _ = 2 * d * 3 ^ (d - 1) * ε ^ r * ∑ k ∈ range n, (k + 1) ^ (d - 1) * (k + 1 : ℝ) ^ r := by
         simp_rw [Finset.mul_sum]
         congr with k

--- a/Mathlib/Algebra/Module/ZLattice/Summable.lean
+++ b/Mathlib/Algebra/Module/ZLattice/Summable.lean
@@ -118,14 +118,14 @@ lemma sum_piFinset_Icc_rpow_le {ι : Type*} [Fintype ι] [DecidableEq ι]
     trans (2 * k + 3) ^ d - (2 * k + 1) ^ d
     · simp only [le_add_iff_nonneg_right, zero_le, hs, card_sdiff_of_subset, s]
       simp only [Fintype.card_piFinset, Int.card_Icc, sub_neg_eq_add, prod_const, card_univ]
-      gcongr <;> norm_cast <;> omega
+      gcongr <;> norm_cast <;> lia
     · have := abs_pow_sub_pow_le (α := ℤ) ↑(2 * k + 3) ↑(2 * k + 1) d
       norm_num at this
       zify
       convert this using 3
-      · rw [abs_eq_self.mpr (sub_nonneg.mpr (by gcongr; omega)), Nat.cast_sub (by gcongr; omega)]
+      · rw [abs_eq_self.mpr (sub_nonneg.mpr (by gcongr; lia)), Nat.cast_sub (by gcongr; lia)]
         simp
-      · rw [max_eq_left (by gcongr; omega), abs_eq_self.mpr (by positivity)]
+      · rw [max_eq_left (by gcongr; lia), abs_eq_self.mpr (by positivity)]
   let ε := normBound b
   have hε : 0 < ε := normBound_pos b
   calc ∑ p ∈ s n, ‖∑ i, p i • b i‖ ^ r
@@ -146,7 +146,7 @@ lemma sum_piFinset_Icc_rpow_le {ι : Type*} [Fintype ι] [DecidableEq ι]
         gcongr with k hk
         refine (this _).trans ?_
         gcongr
-        omega
+        lia
     _ = 2 * d * 3 ^ (d - 1) * ε ^ r * ∑ k ∈ range n, (k + 1) ^ (d - 1) * (k + 1 : ℝ) ^ r := by
         simp_rw [Finset.mul_sum]
         congr with k

--- a/Mathlib/Algebra/Order/Antidiag/Nat.lean
+++ b/Mathlib/Algebra/Order/Antidiag/Nat.lean
@@ -137,7 +137,7 @@ lemma image_apply_finMulAntidiag {d n : ℕ} {i : Fin d} (hd : d ≠ 1) :
       rw [Fin.nontrivial_iff_two_le]
       obtain rfl | hd' := eq_or_ne d 0
       · exact i.elim0
-      omega
+      lia
     obtain ⟨i', hi_ne⟩ := exists_ne i
     use fun j => if j = i then k else if j = i' then r else 1
     simp only [ite_true, and_true]

--- a/Mathlib/Algebra/Order/Group/Int/Sum.lean
+++ b/Mathlib/Algebra/Order/Group/Int/Sum.lean
@@ -33,7 +33,7 @@ lemma sum_le_sum_Ioc {s : Finset ℤ} {c : ℤ} (hs : ∀ x ∈ s, x ≤ c) :
       gcongr
       refine sum_le_card_nsmul _ _ _ fun x mx ↦ ?_
       rw [mem_sdiff, mem_Ioc, not_and'] at mx
-      have := mx.2 (hs _ mx.1); omega
+      have := mx.2 (hs _ mx.1); lia
     _ = ∑ x ∈ r ∩ s, x + #(r \ s) • (c - #s) := by
       rw [inter_comm, card_sdiff_comm]
       rw [Int.card_Ioc, sub_sub_cancel, Int.toNat_natCast]
@@ -68,7 +68,7 @@ lemma sum_Ico_le_sum {s : Finset ℤ} {c : ℤ} (hs : ∀ x ∈ s, c ≤ x) :
     _ ≤ _ := by
       grw [← sum_inter_add_sum_diff s r, card_nsmul_le_sum _ _ _ fun x mx ↦ ?_]
       rw [mem_sdiff, mem_Ico, not_and] at mx
-      have := mx.2 (hs _ mx.1); omega
+      have := mx.2 (hs _ mx.1); lia
 
 /-- Sharp lower bound for the sum of a finset of integers that is bounded below, `range` version. -/
 lemma sum_range_le_sum {s : Finset ℤ} {c : ℤ} (hs : ∀ x ∈ s, c ≤ x) :
@@ -79,6 +79,6 @@ lemma sum_range_le_sum {s : Finset ℤ} {c : ℤ} (hs : ∀ x ∈ s, c ≤ x) :
   · intro x mx y my (h : c + x = c + y); lia
   · intro x mx; simp_rw [coe_range, Set.mem_image, Set.mem_Iio]
     rw [mem_coe, mem_Ico] at mx
-    use (x - c).toNat; omega
+    use (x - c).toNat; lia
 
 end Finset

--- a/Mathlib/Algebra/Order/Ring/Int.lean
+++ b/Mathlib/Algebra/Order/Ring/Int.lean
@@ -84,7 +84,7 @@ theorem Nat.exists_add_mul_eq_of_gcd_dvd_of_mul_pred_le (p q n : ℕ) (dvd : p.g
     (Int.emod_nonneg _ <| by lia), Int.natCast_toNat_eq_self.mpr, this]
   -- show b ≥ 0 by contradiction
   by_contra hb
-  replace hb : b ≤ -1 := by omega
+  replace hb : b ≤ -1 := by lia
   apply lt_irrefl (n : ℤ)
   have ha := Int.emod_lt a_n (by lia : (q.succ : ℤ) ≠ 0)
   rw [p.pred_succ, q.pred_succ] at le

--- a/Mathlib/Algebra/Order/Ring/Int.lean
+++ b/Mathlib/Algebra/Order/Ring/Int.lean
@@ -89,7 +89,7 @@ theorem Nat.exists_add_mul_eq_of_gcd_dvd_of_mul_pred_le (p q n : ℕ) (dvd : p.g
   have ha := Int.emod_lt a_n (by lia : (q.succ : ℤ) ≠ 0)
   rw [p.pred_succ, q.pred_succ] at le
   calc n = a * p.succ + b * q.succ := this.symm
-       _ ≤ q * p.succ + -1 * q.succ := by gcongr <;> omega
+       _ ≤ q * p.succ + -1 * q.succ := by gcongr <;> lia
        _ = p * q - 1 := by simp_rw [Nat.cast_succ, mul_add, mul_comm]; lia
        _ ≤ n - 1 := by rwa [sub_le_sub_iff_right, ← Nat.cast_mul, Nat.cast_le]
        _ < n := by lia

--- a/Mathlib/Algebra/Polynomial/AlgebraMap.lean
+++ b/Mathlib/Algebra/Polynomial/AlgebraMap.lean
@@ -741,7 +741,7 @@ theorem eq_zero_of_mul_eq_zero_of_smul (P : R[X]) (h : ∀ r : R, r • P = 0 �
   simp only [Finset.mem_antidiagonal, ne_eq, Prod.forall, Prod.mk.injEq, not_and]
   intro i j hij H
   obtain hi | rfl | hi := lt_trichotomy i l
-  · have hj : m < j := by omega
+  · have hj : m < j := by lia
     rw [coeff_eq_zero_of_natDegree_lt hj, mul_zero]
   · lia
   · rw [← coeff_C_mul, ← smul_eq_C_mul, IH _ hi, coeff_zero]

--- a/Mathlib/Algebra/Polynomial/EraseLead.lean
+++ b/Mathlib/Algebra/Polynomial/EraseLead.lean
@@ -299,13 +299,13 @@ lemma eraseLead_mul_eq_mul_eraseLead_of_nextCoeff_zero {R : Type*} [Ring R] [NoZ
     have hd₁ : n < ((X - C x) * P).eraseLead.natDegree := by
       linarith [natDegree_eraseLead_add_one h₂]
     rw [← self_sub_monomial_natDegree_leadingCoeff, coeff_sub, coeff_monomial, if_neg hd₁.ne']
-    rw [← self_sub_monomial_natDegree_leadingCoeff, coeff_sub, coeff_monomial, if_neg (by omega)]
+    rw [← self_sub_monomial_natDegree_leadingCoeff, coeff_sub, coeff_monomial, if_neg (by lia)]
     rw [← self_sub_monomial_natDegree_leadingCoeff, mul_sub, coeff_sub,
       sub_zero, sub_zero, eq_sub_iff_add_eq, add_eq_left]
     rcases hn₂ : n
-    · simpa [coeff_monomial, hp] using fun _ ↦ by omega
-    · rw [coeff_X_sub_C_mul, coeff_monomial, coeff_monomial, if_neg (by omega),
-        if_neg (by omega), mul_zero, sub_zero]
+    · simpa [coeff_monomial, hp] using fun _ ↦ by lia
+    · rw [coeff_X_sub_C_mul, coeff_monomial, coeff_monomial, if_neg (by lia),
+        if_neg (by lia), mul_zero, sub_zero]
   · --n ≥ P.natDegree, so all the coefficients are zero.
     trans 0 <;> rw [coeff_eq_zero_of_natDegree_lt]
     · grw [eraseLead_natDegree_le, eraseLead_natDegree_le]

--- a/Mathlib/Algebra/Polynomial/Laurent.lean
+++ b/Mathlib/Algebra/Polynomial/Laurent.lean
@@ -311,7 +311,7 @@ theorem trunc_C_mul_T (n : ℤ) (r : R) : trunc (C r * T n) = ite (0 ≤ n) (mon
     apply comapDomain_single
   · rw [toFinsupp_inj]
     ext a
-    have : a ≠ n := by omega
+    have : a ≠ n := by lia
     simp only [coeff_ofFinsupp, comapDomain_apply, Int.ofNat_eq_natCast, coeff_zero,
       single_eq_of_ne this]
 

--- a/Mathlib/Algebra/Polynomial/RuleOfSigns.lean
+++ b/Mathlib/Algebra/Polynomial/RuleOfSigns.lean
@@ -192,7 +192,7 @@ lemma signVariations_eraseLead_mul_X_sub_C (hη : 0 < η) (hP₀ : 0 < leadingCo
     suffices (coeffList (eraseLead ((X - C η) * P))).map SignType.sign =
       (coeffList ((X - C η) * P.eraseLead)).map SignType.sign by
         rw [signVariations, signVariations, this]
-    have : 0 < natDegree ((X - C η) * P.eraseLead) := by omega
+    have : 0 < natDegree ((X - C η) * P.eraseLead) := by lia
     grind [leadingCoeff_mul, leadingCoeff_X_sub_C, one_mul, leadingCoeff_eraseLead_eq_nextCoeff,
       LT.lt.ne, sign_neg, coeffList_eraseLead, ne_zero_of_natDegree_gt,
       nextCoeff_eq_zero_of_eraseLead_eq_zero]

--- a/Mathlib/Algebra/Ring/GeomSum.lean
+++ b/Mathlib/Algebra/Ring/GeomSum.lean
@@ -255,7 +255,7 @@ protected lemma Commute.mul_geom_sum₂_Ico (h : Commute x y) {m n : ℕ}
     rw [← pow_add]
     congr
     rw [mem_range] at j_in
-    omega
+    lia
   rw [this]
   simp_rw [pow_mul_comm y (n - m) _]
   simp_rw [← mul_assoc]

--- a/Mathlib/Algebra/Squarefree/Basic.lean
+++ b/Mathlib/Algebra/Squarefree/Basic.lean
@@ -86,7 +86,7 @@ theorem Squarefree.eq_zero_or_one_of_pow_of_not_isUnit [Monoid R] {x : R} {n : �
     (h : Squarefree (x ^ n)) (h' : ¬ IsUnit x) :
     n = 0 ∨ n = 1 := by
   contrapose! h'
-  replace h' : 2 ≤ n := by omega
+  replace h' : 2 ≤ n := by lia
   have : x * x ∣ x ^ n := by rw [← sq]; exact pow_dvd_pow x h'
   exact h.squarefree_of_dvd this x (refl _)
 

--- a/Mathlib/AlgebraicTopology/DoldKan/Decomposition.lean
+++ b/Mathlib/AlgebraicTopology/DoldKan/Decomposition.lean
@@ -72,7 +72,7 @@ theorem decomposition_Q (n q : ℕ) :
       let q' : Fin (n + 1) := ⟨q, Nat.lt_succ_of_le hqn⟩
       rw [← @Finset.add_sum_erase _ _ _ _ _ _ q' (by simp [q'])]
       congr
-      · have hnaq' : n = a + q := by omega
+      · have hnaq' : n = a + q := by lia
         simp only [(HigherFacesVanish.of_P q n).comp_Hσ_eq hnaq', q'.rev_eq hnaq', neg_neg]
         rfl
       · ext ⟨i, hi⟩

--- a/Mathlib/AlgebraicTopology/DoldKan/Degeneracies.lean
+++ b/Mathlib/AlgebraicTopology/DoldKan/Degeneracies.lean
@@ -62,7 +62,7 @@ theorem σ_comp_P_eq_zero (X : SimplicialObject C) {n q : ℕ} (i : Fin (n + 1))
   | succ q hq =>
     by_cases h : n + 1 ≤ (i : ℕ) + q
     · rw [P_succ, HomologicalComplex.comp_f, ← assoc, hq i h, zero_comp]
-    · replace hi : n = i + q := by omega
+    · replace hi : n = i + q := by lia
       rcases n with _ | n
       · fin_cases i
         dsimp at h hi

--- a/Mathlib/AlgebraicTopology/DoldKan/Faces.lean
+++ b/Mathlib/AlgebraicTopology/DoldKan/Faces.lean
@@ -67,7 +67,7 @@ theorem of_comp {Y Z : C} {q n : ℕ} {φ : Y ⟶ X _⦋n + 1⦌} (v : HigherFac
 theorem comp_Hσ_eq {Y : C} {n a q : ℕ} {φ : Y ⟶ X _⦋n + 1⦌} (v : HigherFacesVanish q φ)
     (hnaq : n = a + q) :
     φ ≫ (Hσ q).f (n + 1) = -φ ≫ X.δ ⟨a + 1, by lia⟩ ≫ X.σ ⟨a, by lia⟩ := by
-  have hnaq_shift (d : ℕ) : n + d = a + d + q := by omega
+  have hnaq_shift (d : ℕ) : n + d = a + d + q := by lia
   rw [Hσ, Homotopy.nullHomotopicMap'_f (c_mk (n + 2) (n + 1) rfl) (c_mk (n + 1) n rfl),
     hσ'_eq hnaq (c_mk (n + 1) n rfl), hσ'_eq (hnaq_shift 1) (c_mk (n + 2) (n + 1) rfl)]
   simp only [AlternatingFaceMapComplex.obj_d_eq, eqToHom_refl, comp_id, comp_sum, sum_comp,
@@ -177,7 +177,7 @@ theorem induction {Y : C} {n q : ℕ} {φ : Y ⟶ X _⦋n + 1⦌} (v : HigherFac
     rfl
   -- now, we assume j ≠ a (i.e. a < j)
   have haj : a < j := (Ne.le_iff_lt hj₂).mp (by lia)
-  have ham : a ≤ m := by omega
+  have ham : a ≤ m := by lia
   rw [X.δ_comp_σ_of_gt', j.pred_succ]
   swap
   · rw [Fin.lt_def]

--- a/Mathlib/AlgebraicTopology/DoldKan/Faces.lean
+++ b/Mathlib/AlgebraicTopology/DoldKan/Faces.lean
@@ -126,7 +126,7 @@ theorem comp_Hσ_eq {Y : C} {n a q : ℕ} {φ : Y ⟶ X _⦋n + 1⦌} (v : Highe
         Fin.castSucc (⟨a, by lia⟩ : Fin (n + 1)) := by
       rw [Fin.le_iff_val_le_val]
       dsimp
-      omega
+      lia
     generalize_proofs
     rw [← Fin.succ_mk (n + 1) a ‹_›, ← Fin.castSucc_mk (n + 2) i ‹_›,
       δ_comp_σ_of_le X hia, add_eq_zero_iff_eq_neg, ← neg_zsmul]

--- a/Mathlib/AlgebraicTopology/DoldKan/FunctorGamma.lean
+++ b/Mathlib/AlgebraicTopology/DoldKan/FunctorGamma.lean
@@ -146,7 +146,7 @@ theorem mapMono_comp (i' : Δ'' ⟶ Δ') (i : Δ' ⟶ Δ) [Mono i'] [Mono i] :
   -- then the RHS is always zero
   obtain ⟨k, hk⟩ := Nat.exists_eq_add_of_lt (len_lt_of_mono i h₁)
   obtain ⟨k', hk'⟩ := Nat.exists_eq_add_of_lt (len_lt_of_mono i' h₂)
-  have eq : Δ.len = Δ''.len + (k + k' + 2) := by omega
+  have eq : Δ.len = Δ''.len + (k + k' + 2) := by lia
   rw [mapMono_eq_zero K (i' ≫ i) _ _]; rotate_left
   · by_contra h
     simp only [left_eq_add, h, add_eq_zero, and_false, reduceCtorEq] at eq

--- a/Mathlib/AlgebraicTopology/DoldKan/Projections.lean
+++ b/Mathlib/AlgebraicTopology/DoldKan/Projections.lean
@@ -92,7 +92,7 @@ namespace HigherFacesVanish
 /-- This lemma expresses the vanishing of
 `(P q).f (n+1) ≫ X.δ k : X _⦋n+1⦌ ⟶ X _⦋n⦌` when `k≠0` and `k≥n-q+2` -/
 theorem of_P : ∀ q n : ℕ, HigherFacesVanish q ((P q).f (n + 1) : X _⦋n + 1⦌ ⟶ X _⦋n + 1⦌)
-  | 0 => fun n j hj₁ => by omega
+  | 0 => fun n j hj₁ => by lia
   | q + 1 => fun n => by
     simp only [P_succ]
     exact (of_P q n).induction
@@ -110,7 +110,7 @@ theorem comp_P_eq_self {Y : C} {n q : ℕ} {φ : Y ⟶ X _⦋n + 1⦌} (v : High
     by_cases! hqn : n < q
     · exact v.of_succ.comp_Hσ_eq_zero hqn
     · obtain ⟨a, ha⟩ := Nat.le.dest hqn
-      have hnaq : n = a + q := by omega
+      have hnaq : n = a + q := by lia
       simp only [v.of_succ.comp_Hσ_eq hnaq, neg_eq_zero, ← assoc]
       have eq := v ⟨a, by lia⟩ (by
         simp only [hnaq, add_assoc]

--- a/Mathlib/AlgebraicTopology/SimplexCategory/Augmented/Monoidal.lean
+++ b/Mathlib/AlgebraicTopology/SimplexCategory/Augmented/Monoidal.lean
@@ -75,8 +75,8 @@ def tensorHomOf {x₁ y₁ x₂ y₂ : SimplexCategory} (f₁ : x₁ ⟶ y₁) (
         simp [Fin.coe_castAdd, Fin.coe_natAdd, Fin.addCases_left,
           Fin.addCases_right] at h ⊢
         · case left.left i j => exact f₁.toOrderHom.monotone h
-        · case left.right i j => omega
-        · case right.left i j => omega
+        · case left.right i j => lia
+        · case right.left i j => lia
         · case right.right i j => exact f₂.toOrderHom.monotone h }
   (eqToHom (congrArg _ (Nat.succ_add _ _)).symm ≫ (SimplexCategory.mkHom f₁) ≫
     eqToHom (congrArg _ (Nat.succ_add _ _)) : _ ⟶ ⦋y₁.len + y₂.len + 1⦌)

--- a/Mathlib/AlgebraicTopology/SimplexCategory/Basic.lean
+++ b/Mathlib/AlgebraicTopology/SimplexCategory/Basic.lean
@@ -198,7 +198,7 @@ lemma diag_subinterval_eq {n} (j l : ℕ) (hjl : j + l ≤ n) :
     diag l ≫ subinterval j l hjl = intervalEdge j l hjl := by
   unfold subinterval intervalEdge diag mkOfLe
   ext (i : Fin 2)
-  match i with | 0 | 1 => simp <;> omega
+  match i with | 0 | 1 => simp <;> lia
 
 instance (Δ : SimplexCategory) : Subsingleton (Δ ⟶ ⦋0⦌) where
   allEq f g := by ext : 3; apply Subsingleton.elim (α := Fin 1)
@@ -240,7 +240,7 @@ theorem δ_comp_δ {n} {i j : Fin (n + 2)} (H : i ≤ j) :
   rcases i with ⟨i, _⟩
   rcases j with ⟨j, _⟩
   rcases k with ⟨k, _⟩
-  split_ifs <;> · simp at * <;> omega
+  split_ifs <;> · simp at * <;> lia
 
 theorem δ_comp_δ' {n} {i : Fin (n + 2)} {j : Fin (n + 3)} (H : i.castSucc < j) :
     δ i ≫ δ j =
@@ -316,7 +316,7 @@ theorem δ_comp_σ_succ {n} {i : Fin (n + 1)} : δ i.succ ≫ σ i = 𝟙 ⦋n�
   rcases i with ⟨i, _⟩
   rcases j with ⟨j, _⟩
   dsimp [δ, σ, Fin.succAbove, Fin.predAbove]
-  split_ifs <;> simp <;> simp at * <;> omega
+  split_ifs <;> simp <;> simp at * <;> lia
 
 @[reassoc]
 theorem δ_comp_σ_succ' {n} {j : Fin (n + 2)} {i : Fin (n + 1)} (H : j = i.succ) :

--- a/Mathlib/AlgebraicTopology/SimplexCategory/Defs.lean
+++ b/Mathlib/AlgebraicTopology/SimplexCategory/Defs.lean
@@ -227,7 +227,7 @@ lemma Hom.tr_comp {n : ℕ} {a b c : SimplexCategory} (f : a ⟶ b) (g : b ⟶ c
   rfl
 
 /-- The inclusion of `Truncated n` into `Truncated m` when `n ≤ m`. -/
-def incl (n m : ℕ) (h : n ≤ m := by omega) : Truncated n ⥤ Truncated m where
+def incl (n m : ℕ) (h : n ≤ m := by lia) : Truncated n ⥤ Truncated m where
   obj a := ⟨a.1, a.2.trans h⟩
   map := id
 

--- a/Mathlib/AlgebraicTopology/SimplexCategory/Defs.lean
+++ b/Mathlib/AlgebraicTopology/SimplexCategory/Defs.lean
@@ -193,7 +193,7 @@ theorem Hom.ext {n} {a b : Truncated n} (f g : a ⟶ b) :
 
 /-- A quick attempt to prove that `⦋m⦌` is `n`-truncated (`⦋m⦌.len ≤ n`). -/
 scoped macro "trunc" : tactic =>
-  `(tactic| first | assumption | dsimp only [SimplexCategory.len_mk] <;> omega)
+  `(tactic| first | assumption | dsimp only [SimplexCategory.len_mk] <;> lia)
 
 open Mathlib.Tactic (subscriptTerm) in
 /-- For `m ≤ n`, `⦋m⦌ₙ` is the `m`-dimensional simplex in `Truncated n`. The

--- a/Mathlib/AlgebraicTopology/SimplexCategory/Truncated.lean
+++ b/Mathlib/AlgebraicTopology/SimplexCategory/Truncated.lean
@@ -51,7 +51,7 @@ instance initial_inclusion {n : ℕ} [NeZero n] : (inclusion n).Initial := by
 `m`-truncated simplex category is initial. -/
 theorem initial_incl {n m : ℕ} [NeZero n] (hm : n ≤ m) : (incl n m).Initial := by
   have : (incl n m hm ⋙ inclusion m).Initial :=
-    Functor.initial_of_natIso (inclCompInclusion _).symm
+    Functor.initial_of_natIso (inclCompInclusion (by lia)).symm
   apply Functor.initial_of_comp_full_faithful _ (inclusion m)
 
 /-- Abbreviation for face maps in the `n`-truncated simplex category. -/

--- a/Mathlib/AlgebraicTopology/SimplicialObject/Basic.lean
+++ b/Mathlib/AlgebraicTopology/SimplicialObject/Basic.lean
@@ -274,7 +274,7 @@ scoped macro_rules
 variable (C) in
 /-- Further truncation of truncated simplicial objects. -/
 @[simps!]
-def trunc (n m : ℕ) (h : m ≤ n := by omega) : Truncated C n ⥤ Truncated C m :=
+def trunc (n m : ℕ) (h : m ≤ n := by lia) : Truncated C n ⥤ Truncated C m :=
   (whiskeringLeft _ _ _).obj (SimplexCategory.Truncated.incl m n).op
 
 end Truncated
@@ -736,7 +736,7 @@ scoped macro_rules
 
 variable (C) in
 /-- Further truncation of truncated cosimplicial objects. -/
-def trunc (n m : ℕ) (h : m ≤ n := by omega) : Truncated C n ⥤ Truncated C m :=
+def trunc (n m : ℕ) (h : m ≤ n := by lia) : Truncated C n ⥤ Truncated C m :=
   (whiskeringLeft _ _ _).obj <| SimplexCategory.Truncated.incl m n
 
 end Truncated

--- a/Mathlib/AlgebraicTopology/SimplicialSet/AnodyneExtensions/Rank.lean
+++ b/Mathlib/AlgebraicTopology/SimplicialSet/AnodyneExtensions/Rank.lean
@@ -92,7 +92,7 @@ lemma wf_ancestralRel : WellFounded P.AncestralRel := by
   refine not_strictAnti_of_wellFoundedLT (fun n ↦ f.rank (g (n₀ + n)))
     (strictAnti_nat_of_succ_lt (fun n ↦ ?_))
   rw [← add_assoc]
-  exact f.lt (hg _) (by rw [← hn₀ (n₀ + n + 1) (by omega), ← hn₀ (n₀ + n) (by omega)])
+  exact f.lt (hg _) (by rw [← hn₀ (n₀ + n + 1) (by lia), ← hn₀ (n₀ + n) (by lia)])
 
 lemma isRegular : P.IsRegular where
   wf := f.wf_ancestralRel

--- a/Mathlib/AlgebraicTopology/SimplicialSet/Basic.lean
+++ b/Mathlib/AlgebraicTopology/SimplicialSet/Basic.lean
@@ -115,7 +115,7 @@ lemma hom_ext {n : ℕ} {X Y : Truncated n} {f g : X ⟶ Y} (w : ∀ n, f.app n 
   NatTrans.ext (funext w)
 
 /-- Further truncation of truncated simplicial sets. -/
-abbrev trunc (n m : ℕ) (h : m ≤ n := by omega) :
+abbrev trunc (n m : ℕ) (h : m ≤ n := by lia) :
     SSet.Truncated n ⥤ SSet.Truncated m :=
   SimplicialObject.Truncated.trunc (Type u) n m
 

--- a/Mathlib/AlgebraicTopology/SimplicialSet/Coskeletal.lean
+++ b/Mathlib/AlgebraicTopology/SimplicialSet/Coskeletal.lean
@@ -56,7 +56,7 @@ namespace isPointwiseRightKanExtensionAt
 
 /-- A morphism in `SimplexCategory` with domain `⦋0⦌`, `⦋1⦌`, or `⦋2⦌` defines an object in the
 comma category `StructuredArrow (op ⦋n⦌) (Truncated.inclusion (n := 2)).op`. -/
-abbrev strArrowMk₂ {i : ℕ} {n : ℕ} (φ : ⦋i⦌ ⟶ ⦋n⦌) (hi : i ≤ 2 := by omega) :
+abbrev strArrowMk₂ {i : ℕ} {n : ℕ} (φ : ⦋i⦌ ⟶ ⦋n⦌) (hi : i ≤ 2 := by lia) :
     StructuredArrow (op ⦋n⦌) (Truncated.inclusion 2).op :=
   StructuredArrow.mk (Y := op ⦋i⦌₂) φ.op
 

--- a/Mathlib/AlgebraicTopology/SimplicialSet/Nerve.lean
+++ b/Mathlib/AlgebraicTopology/SimplicialSet/Nerve.lean
@@ -73,7 +73,7 @@ def nerveFunctor : Cat.{v, u} ⥤ SSet where
 
 /-- The 0-simplices of the nerve of a category are equivalent to the objects of the category. -/
 def nerveEquiv {C : Type u} [Category.{v} C] : ComposableArrows C 0 ≃ C where
-  toFun f := f.obj ⟨0, by omega⟩
+  toFun f := f.obj ⟨0, by lia⟩
   invFun f := ComposableArrows.mk₀ f
   left_inv f := ComposableArrows.ext₀ rfl
 

--- a/Mathlib/AlgebraicTopology/SimplicialSet/Path.lean
+++ b/Mathlib/AlgebraicTopology/SimplicialSet/Path.lean
@@ -104,11 +104,11 @@ def mk₂ {n : ℕ} {X : Truncated.{u} (n + 1)} (p q : X.Path 1)
 
 /-- For `j + l ≤ m`, a path of length `m` restricts to a path of length `l`, namely
 the subpath spanned by the vertices `j ≤ i ≤ j + l` and edges `j ≤ i < j + l`. -/
-def interval (f : Path X m) (j l : ℕ) (h : j + l ≤ m := by omega) : Path X l where
-  vertex i := f.vertex ⟨j + i, by omega⟩
-  arrow i := f.arrow ⟨j + i, by omega⟩
-  arrow_src i := f.arrow_src ⟨j + i, by omega⟩
-  arrow_tgt i := f.arrow_tgt ⟨j + i, by omega⟩
+def interval (f : Path X m) (j l : ℕ) (h : j + l ≤ m := by lia) : Path X l where
+  vertex i := f.vertex ⟨j + i, by lia⟩
+  arrow i := f.arrow ⟨j + i, by lia⟩
+  arrow_src i := f.arrow_src ⟨j + i, by lia⟩
+  arrow_tgt i := f.arrow_tgt ⟨j + i, by lia⟩
 
 variable {X Y : SSet.Truncated.{u} (n + 1)} {m : ℕ}
 
@@ -255,7 +255,7 @@ def interval (f : Path X n) (j l : ℕ) (h : j + l ≤ n := by grind) : Path X l
   Truncated.Path.interval f j l h
 
 lemma arrow_interval (f : Path X n) (j l : ℕ) (k' : Fin l) (k : Fin n)
-    (h : j + l ≤ n := by omega) (hkk' : j + k' = k := by grind) :
+    (h : j + l ≤ n := by lia) (hkk' : j + k' = k := by grind) :
     (f.interval j l h).arrow k' = f.arrow k := by
   dsimp [interval, arrow, Truncated.Path.interval, Truncated.Path.arrow]
   congr

--- a/Mathlib/AlgebraicTopology/SimplicialSet/StrictSegal.lean
+++ b/Mathlib/AlgebraicTopology/SimplicialSet/StrictSegal.lean
@@ -42,7 +42,7 @@ variable {n : ℕ} (X : SSet.Truncated.{u} (n + 1))
 its `m`-simplices are uniquely determined by their spine for all `m ≤ n + 1`. -/
 structure StrictSegal where
   /-- The inverse to `spine X m`. -/
-  spineToSimplex (m : ℕ) (h : m ≤ n + 1 := by omega) : Path X m → X _⦋m⦌ₙ₊₁
+  spineToSimplex (m : ℕ) (h : m ≤ n + 1 := by lia) : Path X m → X _⦋m⦌ₙ₊₁
   /-- `spineToSimplex` is a right inverse to `spine X m`. -/
   spine_spineToSimplex (m : ℕ) (h : m ≤ n + 1) :
     spine X m ∘ spineToSimplex m = id
@@ -120,7 +120,7 @@ lemma spineToSimplex_spine_apply (m : ℕ) (h : m ≤ n + 1) (Δ : X _⦋m⦌ₙ
 
 section autoParam
 
-variable (m : ℕ) (h : m ≤ n + 1 := by omega)
+variable (m : ℕ) (h : m ≤ n + 1 := by lia)
 
 /-- The fields of `StrictSegal` define an equivalence between `X _⦋m⦌ₙ₊₁`
 and `Path X m`. -/

--- a/Mathlib/Analysis/Analytic/Composition.lean
+++ b/Mathlib/Analysis/Analytic/Composition.lean
@@ -418,7 +418,7 @@ theorem id_comp (p : FormalMultilinearSeries 𝕜 E F) (v0 : Fin 0 → E) :
       have A : 1 < b.length := by
         have : b.length ≠ 1 := by simpa [Composition.eq_single_iff_length] using hb
         have : 0 < b.length := Composition.length_pos_of_pos b n_pos
-        omega
+        lia
       ext v
       rw [compAlongComposition_apply, id_apply_of_one_lt _ _ _ A,
         ContinuousMultilinearMap.zero_apply, ContinuousMultilinearMap.zero_apply]

--- a/Mathlib/Analysis/Analytic/Inverse.lean
+++ b/Mathlib/Analysis/Analytic/Inverse.lean
@@ -515,7 +515,7 @@ theorem radius_rightInv_pos_of_radius_pos
       rw [Ico_eq_empty_of_le (le_refl 1), sum_empty]
       exact mul_nonneg (add_nonneg (norm_nonneg _) zero_le_one) apos.le
     · intro n one_le_n hn
-      have In : 2 ≤ n + 1 := by omega
+      have In : 2 ≤ n + 1 := by lia
       have rSn : r * S n ≤ 1 / 2 :=
         calc
           r * S n ≤ r * ((I + 1) * a) := by gcongr

--- a/Mathlib/Analysis/Analytic/IteratedFDeriv.lean
+++ b/Mathlib/Analysis/Analytic/IteratedFDeriv.lean
@@ -164,7 +164,7 @@ private lemma HasFPowerSeriesWithinOnBall.iteratedFDerivWithin_eq_sum_of_subset
       · intro i hi h'i
         simp [q, h'i.symm]
     · intro m hm
-      have : n ≠ m := by omega
+      have : n ≠ m := by lia
       simp [q, this]
   have B : HasFPowerSeriesWithinOnBall g q s x r :=
     A.toHasFPowerSeriesOnBall.hasFPowerSeriesWithinOnBall

--- a/Mathlib/Analysis/Calculus/BumpFunction/FiniteDimension.lean
+++ b/Mathlib/Analysis/Calculus/BumpFunction/FiniteDimension.lean
@@ -142,7 +142,7 @@ theorem IsOpen.exists_smooth_support_eq {s : Set E} (hs : IsOpen s) :
       apply Finset.le_max'
       apply Finset.mem_image_of_mem
       simp only [Finset.mem_range]
-      omega
+      lia
     refine ⟨M⁻¹ * δ n, by positivity, fun i hi x => ?_⟩
     calc
       ‖iteratedFDeriv ℝ i ((M⁻¹ * δ n) • g n) x‖ = ‖(M⁻¹ * δ n) • iteratedFDeriv ℝ i (g n) x‖ := by

--- a/Mathlib/Analysis/Calculus/ContDiff/FaaDiBruno.lean
+++ b/Mathlib/Analysis/Calculus/ContDiff/FaaDiBruno.lean
@@ -551,7 +551,7 @@ def eraseMiddle (c : OrderedFinpartition (n + 1)) (hc : range (c.emb 0) ≠ {0})
       · simp only [↓reduceDIte, update_self, succ_mk, cast_mk, coe_pred]
         have A := c.one_lt_partSize_index_zero hc
         rw [Nat.sub_add_cancel]
-        · congr; omega
+        · congr; lia
         · rw [Order.one_le_iff_pos]
           conv_lhs => rw [show (0 : ℕ) = c.emb (c.index 0) 0 by simp [emb_zero]]
           rw [← lt_def]
@@ -562,12 +562,12 @@ def eraseMiddle (c : OrderedFinpartition (n + 1)) (hc : range (c.emb 0) ≠ {0})
         have : c.emb i ⟨c.partSize i - 1, Nat.sub_one_lt_of_lt (c.partSize_pos i)⟩
             ≠ c.emb (c.index 0) 0 := c.emb_ne_emb_of_ne hi
         simp only [c.emb_zero, ne_eq, ← val_eq_val, val_zero] at this
-        omega
+        lia
     · rcases eq_or_ne j (c.index 0) with rfl | hj
       · simp only [↓reduceDIte, update_self, succ_mk, cast_mk, coe_pred]
         have A := c.one_lt_partSize_index_zero hc
         rw [Nat.sub_add_cancel]
-        · congr; omega
+        · congr; lia
         · rw [Order.one_le_iff_pos]
           conv_lhs => rw [show (0 : ℕ) = c.emb (c.index 0) 0 by simp [emb_zero]]
           rw [← lt_def]
@@ -578,7 +578,7 @@ def eraseMiddle (c : OrderedFinpartition (n + 1)) (hc : range (c.emb 0) ≠ {0})
         have : c.emb j ⟨c.partSize j - 1, Nat.sub_one_lt_of_lt (c.partSize_pos j)⟩
             ≠ c.emb (c.index 0) 0 := c.emb_ne_emb_of_ne hj
         simp only [c.emb_zero, ne_eq, ← val_eq_val, val_zero] at this
-        omega
+        lia
   disjoint i _ j _ hij := by
     wlog h : i ≠ c.index 0 generalizing i j
     · apply Disjoint.symm
@@ -620,7 +620,7 @@ def eraseMiddle (c : OrderedFinpartition (n + 1)) (hc : range (c.emb 0) ≠ {0})
         congr 1
         rw [← val_eq_val]
         simp only [coe_cast, val_succ, coe_pred]
-        omega
+        lia
     · have A : update c.partSize (c.index 0) (c.partSize (c.index 0) - 1) i = c.partSize i := by
         simp [hi]
       exact ⟨i, Fin.cast A.symm j, by simp [hi, hij]⟩

--- a/Mathlib/Analysis/Calculus/ContDiff/FaaDiBruno.lean
+++ b/Mathlib/Analysis/Calculus/ContDiff/FaaDiBruno.lean
@@ -548,10 +548,11 @@ def eraseMiddle (c : OrderedFinpartition (n + 1)) (hc : range (c.emb 0) ≠ {0})
     rw [← Nat.add_lt_add_iff_right (k := 1)]
     convert Fin.lt_def.1 (c.parts_strictMono hij)
     · rcases eq_or_ne i (c.index 0) with rfl | hi
+      -- We do not yet replace `omega` with `lia` here, as it is measurably slower.
       · simp only [↓reduceDIte, update_self, succ_mk, cast_mk, coe_pred]
         have A := c.one_lt_partSize_index_zero hc
         rw [Nat.sub_add_cancel]
-        · congr; lia
+        · congr; omega
         · rw [Order.one_le_iff_pos]
           conv_lhs => rw [show (0 : ℕ) = c.emb (c.index 0) 0 by simp [emb_zero]]
           rw [← lt_def]
@@ -562,12 +563,12 @@ def eraseMiddle (c : OrderedFinpartition (n + 1)) (hc : range (c.emb 0) ≠ {0})
         have : c.emb i ⟨c.partSize i - 1, Nat.sub_one_lt_of_lt (c.partSize_pos i)⟩
             ≠ c.emb (c.index 0) 0 := c.emb_ne_emb_of_ne hi
         simp only [c.emb_zero, ne_eq, ← val_eq_val, val_zero] at this
-        lia
+        omega
     · rcases eq_or_ne j (c.index 0) with rfl | hj
       · simp only [↓reduceDIte, update_self, succ_mk, cast_mk, coe_pred]
         have A := c.one_lt_partSize_index_zero hc
         rw [Nat.sub_add_cancel]
-        · congr; lia
+        · congr; omega
         · rw [Order.one_le_iff_pos]
           conv_lhs => rw [show (0 : ℕ) = c.emb (c.index 0) 0 by simp [emb_zero]]
           rw [← lt_def]
@@ -578,7 +579,7 @@ def eraseMiddle (c : OrderedFinpartition (n + 1)) (hc : range (c.emb 0) ≠ {0})
         have : c.emb j ⟨c.partSize j - 1, Nat.sub_one_lt_of_lt (c.partSize_pos j)⟩
             ≠ c.emb (c.index 0) 0 := c.emb_ne_emb_of_ne hj
         simp only [c.emb_zero, ne_eq, ← val_eq_val, val_zero] at this
-        lia
+        omega
   disjoint i _ j _ hij := by
     wlog h : i ≠ c.index 0 generalizing i j
     · apply Disjoint.symm
@@ -620,7 +621,7 @@ def eraseMiddle (c : OrderedFinpartition (n + 1)) (hc : range (c.emb 0) ≠ {0})
         congr 1
         rw [← val_eq_val]
         simp only [coe_cast, val_succ, coe_pred]
-        lia
+        omega
     · have A : update c.partSize (c.index 0) (c.partSize (c.index 0) - 1) i = c.partSize i := by
         simp [hi]
       exact ⟨i, Fin.cast A.symm j, by simp [hi, hij]⟩

--- a/Mathlib/Analysis/Calculus/FDeriv/Measurable.lean
+++ b/Mathlib/Analysis/Calculus/FDeriv/Measurable.lean
@@ -316,7 +316,7 @@ theorem D_subset_differentiable_set {K : Set (E →L[𝕜] F)} (hK : IsComplete 
     have k_gt : n e < k := by
       have : ((1 : ℝ) / 2) ^ (k + 1) < (1 / 2) ^ (n e + 1) := lt_trans hk y_lt
       rw [pow_lt_pow_iff_right_of_lt_one₀ (by norm_num : (0 : ℝ) < 1 / 2) (by norm_num)] at this
-      omega
+      lia
     set m := k - 1
     have m_ge : n e ≤ m := Nat.le_sub_one_of_lt k_gt
     have km : k = m + 1 := (Nat.succ_pred_eq_of_pos (lt_of_le_of_lt (zero_le _) k_gt)).symm
@@ -643,7 +643,7 @@ theorem D_subset_differentiable_set {K : Set F} (hK : IsComplete K) :
     have k_gt : n e < k := by
       have : ((1 : ℝ) / 2) ^ (k + 1) < (1 / 2) ^ (n e + 1) := lt_of_lt_of_le hk y_le
       rw [pow_lt_pow_iff_right_of_lt_one₀ (by norm_num : (0 : ℝ) < 1 / 2) (by norm_num)] at this
-      omega
+      lia
     set m := k - 1
     have m_ge : n e ≤ m := Nat.le_sub_one_of_lt k_gt
     have km : k = m + 1 := (Nat.succ_pred_eq_of_pos (lt_of_le_of_lt (zero_le _) k_gt)).symm

--- a/Mathlib/Analysis/Complex/Polynomial/Basic.lean
+++ b/Mathlib/Analysis/Complex/Polynomial/Basic.lean
@@ -167,7 +167,7 @@ theorem galActionHom_bijective_of_prime_degree' {p : ℚ[X]} (p_irr : Irreducibl
           map_one, map_one])
   have key := card_complex_roots_eq_card_real_add_card_not_gal_inv p
   simp_rw [Set.toFinset_card] at key
-  omega
+  lia
 
 end Rationals
 

--- a/Mathlib/Analysis/Convex/Between.lean
+++ b/Mathlib/Analysis/Convex/Between.lean
@@ -776,7 +776,7 @@ theorem sbtw_of_sbtw_of_sbtw_of_mem_affineSpan_pair [NoZeroSMulDivisors R V]
   have h₂₃ : i₂ ≠ i₃ := by
     rintro rfl
     simp at h₁
-  have h3 : ∀ i : Fin 3, i = i₁ ∨ i = i₂ ∨ i = i₃ := by omega
+  have h3 : ∀ i : Fin 3, i = i₁ ∨ i = i₂ ∨ i = i₃ := by lia
   have hu : (Finset.univ : Finset (Fin 3)) = {i₁, i₂, i₃} := by
     clear h₁ h₂ h₁' h₂'
     #adaptation_note /--

--- a/Mathlib/Analysis/Convex/Between.lean
+++ b/Mathlib/Analysis/Convex/Between.lean
@@ -665,10 +665,10 @@ lemma closedInterior_face_eq_affineSegment {n : ℕ} (s : Simplex R P n) {i j : 
   congr 2
   · convert Finset.orderEmbOfFin_zero _ _
     · exact (Finset.min'_pair i j).symm
-    · omega
+    · lia
   · convert Finset.orderEmbOfFin_last _ _
     · exact (Finset.max'_pair i j).symm
-    · omega
+    · lia
 
 /-- A point lies in the closed interior of a 1-dimensional face of a simplex if and only if it lies
 weakly between its vertices. -/
@@ -719,10 +719,10 @@ lemma mem_interior_face_iff_sbtw [Nontrivial R] [NoZeroSMulDivisors R V] {n : �
   congr! 4
   · convert Finset.orderEmbOfFin_zero _ _
     · exact (Finset.min'_pair i j).symm
-    · omega
+    · lia
   · convert Finset.orderEmbOfFin_last _ _
     · exact (Finset.max'_pair i j).symm
-    · omega
+    · lia
 
 end Simplex
 

--- a/Mathlib/Analysis/Distribution/FourierSchwartz.lean
+++ b/Mathlib/Analysis/Distribution/FourierSchwartz.lean
@@ -81,7 +81,7 @@ def fourierTransformCLM : 𝓢(V, E) →L[𝕜] 𝓢(V, E) := by
         have : (p.1 + integrablePower (volume : Measure V), p.2) ∈ (Finset.range
             (n + integrablePower (volume : Measure V) + 1) ×ˢ Finset.range (k + 1)) := by
           simp [hp.2]
-          omega
+          lia
         apply Finset.le_sup this (f := fun p ↦ SchwartzMap.seminorm 𝕜 p.1 p.2 (E := V) (F := E))
     _ = _ := by simp [mul_assoc]
 

--- a/Mathlib/Analysis/InnerProductSpace/Projection/FiniteDimensional.lean
+++ b/Mathlib/Analysis/InnerProductSpace/Projection/FiniteDimensional.lean
@@ -202,7 +202,7 @@ theorem LinearIsometryEquiv.reflections_generate_dim_aux [FiniteDimensional ℝ 
         finrank_lt_finrank_of_lt (SetLike.lt_iff_le_and_exists.2 ⟨H₂V, v, H₁V, hv'⟩)
       have : finrank ℝ V + finrank ℝ Vᗮ = finrank ℝ F := V.finrank_add_finrank_orthogonal
       have : finrank ℝ W + finrank ℝ Wᗮ = finrank ℝ F := W.finrank_add_finrank_orthogonal
-      omega
+      lia
     -- So apply the inductive hypothesis to `φ.trans ρ`
     obtain ⟨l, hl, hφl⟩ := IH (ρ * φ) this
     -- Prepend `ρ` to the factorization into reflections obtained for `φ.trans ρ`; this gives a

--- a/Mathlib/Analysis/InnerProductSpace/TwoDim.lean
+++ b/Mathlib/Analysis/InnerProductSpace/TwoDim.lean
@@ -206,7 +206,7 @@ def rightAngleRotationAux₂ : E →ₗᵢ[ℝ] E :=
           have : Finset.card {x} = 1 := Finset.card_singleton x
           have : finrank ℝ K + finrank ℝ Kᗮ = finrank ℝ E := K.finrank_add_finrank_orthogonal
           have : finrank ℝ E = 2 := Fact.out
-          omega
+          lia
         obtain ⟨w, hw₀⟩ : ∃ w : Kᗮ, w ≠ 0 := exists_ne 0
         have hw' : ⟪x, (w : E)⟫ = 0 := Submodule.mem_orthogonal_singleton_iff_inner_right.mp w.2
         have hw : (w : E) ≠ 0 := fun h => hw₀ (Submodule.coe_eq_zero.mp h)

--- a/Mathlib/Analysis/Normed/Affine/Simplex.lean
+++ b/Mathlib/Analysis/Normed/Affine/Simplex.lean
@@ -124,7 +124,7 @@ def Regular (s : Simplex R P n) : Prop :=
 
 lemma Regular.equilateral {s : Simplex R P n} (hr : s.Regular) : s.Equilateral := by
   refine ⟨dist (s.points 0) (s.points 1), fun i j hij ↦ ?_⟩
-  have hn : n ≠ 0 := by omega
+  have hn : n ≠ 0 := by lia
   by_cases hi : i = 1
   · rw [hi, dist_comm]
     rcases hr (Equiv.swap 0 j) with ⟨x, hx⟩

--- a/Mathlib/Analysis/Normed/Unbundled/SeminormFromConst.lean
+++ b/Mathlib/Analysis/Normed/Unbundled/SeminormFromConst.lean
@@ -151,7 +151,7 @@ def seminormFromConst : RingSeminorm R where
       apply (seminormFromConst_isLimit hf1 hc hpm (x * y)).comp
         (tendsto_atTop_atTop_of_monotone (fun _ _ hnm ↦ by
           simp only [mul_le_mul_iff_right₀, Nat.succ_pos', hnm]) _)
-      · rintro n; use n; omega
+      · rintro n; use n; lia
     refine le_of_tendsto_of_tendsto' hlim ((seminormFromConst_isLimit hf1 hc hpm x).mul
       (seminormFromConst_isLimit hf1 hc hpm y)) (fun n ↦ ?_)
     simp only [seminormFromConst_seq]
@@ -252,7 +252,7 @@ theorem seminormFromConst_const_mul (x : R) :
       (𝓝 (seminormFromConst' hf1 hc hpm x)) := by
     apply (seminormFromConst_isLimit hf1 hc hpm x).comp
       (tendsto_atTop_atTop_of_monotone add_left_mono _)
-    rintro n; use n; omega
+    rintro n; use n; lia
   rw [seminormFromConst_apply_c hf1 hc hpm]
   apply tendsto_nhds_unique (seminormFromConst_isLimit hf1 hc hpm (c * x))
   have hterm : seminormFromConst_seq c f (c * x) =

--- a/Mathlib/Analysis/SpecialFunctions/Gamma/BohrMollerup.lean
+++ b/Mathlib/Analysis/SpecialFunctions/Gamma/BohrMollerup.lean
@@ -182,7 +182,7 @@ theorem f_add_nat_le (hf_conv : ConvexOn ℝ (Ioi 0) f)
 theorem f_add_nat_ge (hf_conv : ConvexOn ℝ (Ioi 0) f)
     (hf_feq : ∀ {y : ℝ}, 0 < y → f (y + 1) = f y + log y) (hn : 2 ≤ n) (hx : 0 < x) :
     f n + x * log (n - 1) ≤ f (n + x) := by
-  have npos : 0 < (n : ℝ) - 1 := by rw [← Nat.cast_one, sub_pos, Nat.cast_lt]; omega
+  have npos : 0 < (n : ℝ) - 1 := by rw [← Nat.cast_one, sub_pos, Nat.cast_lt]; lia
   have c :=
     (convexOn_iff_slope_mono_adjacent.mp <| hf_conv).2 npos (by linarith : 0 < (n : ℝ) + x)
       (by linarith : (n : ℝ) - 1 < (n : ℝ)) (by linarith)

--- a/Mathlib/Analysis/SpecialFunctions/Integrals/Basic.lean
+++ b/Mathlib/Analysis/SpecialFunctions/Integrals/Basic.lean
@@ -470,7 +470,7 @@ theorem integral_sin_pow_pos : 0 < ∫ x in 0..π, sin x ^ n := by
   simp only [integral_sin_pow_even, integral_sin_pow_odd] <;>
   refine mul_pos (by simp [pi_pos]) (prod_pos fun n _ => div_pos ?_ ?_) <;>
   norm_cast <;>
-  omega
+  lia
 
 theorem integral_sin_pow_succ_le : (∫ x in 0..π, sin x ^ (n + 1)) ≤ ∫ x in 0..π, sin x ^ n := by
   let H x h := pow_le_pow_of_le_one (sin_nonneg_of_mem_Icc h) (sin_le_one x) (n.le_add_right 1)

--- a/Mathlib/Analysis/SpecialFunctions/Trigonometric/Basic.lean
+++ b/Mathlib/Analysis/SpecialFunctions/Trigonometric/Basic.lean
@@ -828,7 +828,7 @@ theorem quadratic_root_cos_pi_div_five :
     push_neg
     intro n hn
     replace hn : n * 5 = 1 := by field_simp at hn; norm_cast at hn
-    omega
+    lia
   suffices s * (2 * c) = s * (4 * c ^ 2 - 1) from mul_left_cancel₀ hs this
   calc s * (2 * c) = 2 * s * c := by rw [← mul_assoc, mul_comm 2]
                  _ = sin (2 * θ) := by rw [sin_two_mul]

--- a/Mathlib/Analysis/SpecificLimits/Normed.lean
+++ b/Mathlib/Analysis/SpecificLimits/Normed.lean
@@ -493,7 +493,7 @@ theorem summable_pow_mul_geometric_of_norm_lt_one (k : ℕ) {r : R} (hr : ‖r�
     have dP : P.natDegree = k := by
       simp only [P, natDegree_comp, ascPochhammer_natDegree, mul_one, natDegree_X_add_C]
     have A : (n + k).descFactorial k = P.eval n := by
-      have : n + 1 + k - 1 = n + k := by omega
+      have : n + 1 + k - 1 = n + k := by lia
       simp [P, ascPochhammer_nat_eq_descFactorial, this]
     conv_lhs => rw [A, mP.as_sum, dP]
     simp [eval_finset_sum]

--- a/Mathlib/Analysis/SumIntegralComparisons.lean
+++ b/Mathlib/Analysis/SumIntegralComparisons.lean
@@ -207,14 +207,14 @@ lemma sum_mul_Ico_le_integral_of_monotone_antitone
     have I0 : (i : ℝ) ≤ b - 1 := by
       simp only [le_sub_iff_add_le]
       norm_cast
-      omega
+      lia
     have I1 : (i : ℝ) ∈ Icc (a - 1 : ℝ) (b - 1) := by
       simp only [mem_Icc, tsub_le_iff_right]
       exact ⟨by norm_cast; lia, I0⟩
     have I2 : x ∈ Icc (a : ℝ) b := by
       refine ⟨le_trans (mod_cast hi.1) hx.1, hx.2.le.trans ?_⟩
       norm_cast
-      omega
+      lia
     apply mul_le_mul
     · apply hf
       · simp only [mem_Icc, Nat.cast_le]
@@ -253,14 +253,14 @@ lemma integral_le_sum_mul_Ico_of_antitone_monotone
     have I0 : (i : ℝ) ≤ b - 1 := by
       simp only [le_sub_iff_add_le]
       norm_cast
-      omega
+      lia
     have I1 : (i : ℝ) ∈ Icc (a - 1 : ℝ) (b - 1) := by
       simp only [mem_Icc, tsub_le_iff_right]
       exact ⟨by norm_cast; lia, I0⟩
     have I2 : x ∈ Icc (a : ℝ) b := by
       refine ⟨le_trans (mod_cast hi.1) hx.1, hx.2.le.trans ?_⟩
       norm_cast
-      omega
+      lia
     apply mul_le_mul
     · apply hf
       · simp only [mem_Icc, Nat.cast_le]

--- a/Mathlib/CategoryTheory/ComposableArrows/Basic.lean
+++ b/Mathlib/CategoryTheory/ComposableArrows/Basic.lean
@@ -70,10 +70,10 @@ namespace ComposableArrows
 variable {C} {n m : ℕ}
 variable (F G : ComposableArrows C n)
 
-/-- A wrapper for `lia` which prefaces it with some quick and useful attempts -/
--- TODO: see what can be removed, now that we've changed the terminal step from `omega` to `lia`
+-- We do not yet replace `omega` with `lia` here, as it is measurably slower.
+/-- A wrapper for `omega` which prefaces it with some quick and useful attempts -/
 macro "valid" : tactic =>
-  `(tactic| first | assumption | apply zero_le | apply le_rfl | transitivity <;> assumption | lia)
+  `(tactic| first | assumption | apply zero_le | apply le_rfl | transitivity <;> assumption | omega)
 
 /-- The `i`th object (with `i : ℕ` such that `i ≤ n`) of `F : ComposableArrows C n`. -/
 @[simp]

--- a/Mathlib/CategoryTheory/ComposableArrows/Basic.lean
+++ b/Mathlib/CategoryTheory/ComposableArrows/Basic.lean
@@ -70,9 +70,10 @@ namespace ComposableArrows
 variable {C} {n m : ℕ}
 variable (F G : ComposableArrows C n)
 
-/-- A wrapper for `omega` which prefaces it with some quick and useful attempts -/
+/-- A wrapper for `lia` which prefaces it with some quick and useful attempts -/
+-- TODO: see what can be removed, now that we've changed the terminal step from `omega` to `lia`
 macro "valid" : tactic =>
-  `(tactic| first | assumption | apply zero_le | apply le_rfl | transitivity <;> assumption | omega)
+  `(tactic| first | assumption | apply zero_le | apply le_rfl | transitivity <;> assumption | lia)
 
 /-- The `i`th object (with `i : ℕ` such that `i ≤ n`) of `F : ComposableArrows C n`. -/
 @[simp]

--- a/Mathlib/CategoryTheory/Functor/OfSequence.lean
+++ b/Mathlib/CategoryTheory/Functor/OfSequence.lean
@@ -48,9 +48,9 @@ the form `X n ⟶ X (n + 1)` when `i ≤ j`. -/
 def map : ∀ {X : ℕ → C} (_ : ∀ n, X n ⟶ X (n + 1)) (i j : ℕ), i ≤ j → (X i ⟶ X j)
   | _, _, 0, 0 => fun _ ↦ 𝟙 _
   | _, f, 0, 1 => fun _ ↦ f 0
-  | _, f, 0, l + 1 => fun _ ↦ f 0 ≫ map (fun n ↦ f (n + 1)) 0 l (by omega)
+  | _, f, 0, l + 1 => fun _ ↦ f 0 ≫ map (fun n ↦ f (n + 1)) 0 l (by lia)
   | _, _, _ + 1, 0 => nofun
-  | _, f, k + 1, l + 1 => fun _ ↦ map (fun n ↦ f (n + 1)) k l (by omega)
+  | _, f, k + 1, l + 1 => fun _ ↦ map (fun n ↦ f (n + 1)) k l (by lia)
 
 lemma map_id (i : ℕ) : map f i i (by lia) = 𝟙 _ := by
   revert X f
@@ -130,16 +130,16 @@ def ofSequence : F ⟶ G where
   naturality := by
     intro i j φ
     obtain ⟨k, hk⟩ := Nat.exists_eq_add_of_le (leOfHom φ)
-    obtain rfl := Subsingleton.elim φ (homOfLE (by omega))
+    obtain rfl := Subsingleton.elim φ (homOfLE (by lia))
     revert i j
     induction k with
     | zero =>
         intro i j hk
-        obtain rfl : j = i := by omega
+        obtain rfl : j = i := by lia
         simp
     | succ k hk =>
         intro i j hk'
-        obtain rfl : j = i + k + 1 := by omega
+        obtain rfl : j = i + k + 1 := by lia
         simp only [← homOfLE_comp (show i ≤ i + k by omega) (show i + k ≤ i + k + 1 by omega),
           Functor.map_comp, assoc, naturality, reassoc_of% (hk rfl)]
 

--- a/Mathlib/CategoryTheory/Limits/Shapes/SequentialProduct.lean
+++ b/Mathlib/CategoryTheory/Limits/Shapes/SequentialProduct.lean
@@ -95,7 +95,7 @@ lemma functorMap_commSq {n m : ℕ} (h : ¬(m < n)) :
           eqToHom (functorObj_eq_pos (by lia)) ≫ f m := by
   cases m with
   | zero =>
-      have : n = 0 := by omega
+      have : n = 0 := by lia
       subst this
       simp [functorMap]
   | succ m =>
@@ -130,7 +130,7 @@ noncomputable def cone : Cone (Functor.ofOpSequence (functorMap f)) where
       Discrete.natTrans_app, Functor.ofOpSequence_map_homOfLE_succ, functorMap, Category.assoc,
       limMap_π_assoc]
     split
-    · simp [dif_pos (by omega : m < n + 1)]
+    · simp [dif_pos (by lia : m < n + 1)]
     · split
       all_goals simp
 
@@ -163,7 +163,7 @@ with cone point `∏ M` is indeed a limit cone.
 noncomputable def isLimit : IsLimit (cone f) where
   lift s := Pi.lift fun m ↦
     s.π.app ⟨m + 1⟩ ≫ Pi.π (fun i ↦ if _ : i < m + 1 then M i else N i) m ≫
-      eqToHom (dif_pos (by omega : m < m + 1))
+      eqToHom (dif_pos (by lia : m < m + 1))
   fac s := by
     intro ⟨n⟩
     apply Pi.hom_ext
@@ -172,7 +172,7 @@ noncomputable def isLimit : IsLimit (cone f) where
     · simp only [Category.assoc, cone_π_app_comp_Pi_π_pos f _ _ h]
       simp only [dite_eq_ite, Functor.ofOpSequence_obj, limit.lift_π_assoc, Fan.mk_pt,
         Discrete.functor_obj_eq_as, Fan.mk_π_app, Category.assoc, eqToHom_trans]
-      have hh : m + 1 ≤ n := by omega
+      have hh : m + 1 ≤ n := by lia
       rw [← s.w (homOfLE hh).op]
       simp only [Functor.const_obj_obj, Functor.ofOpSequence_obj, homOfLE_leOfHom,
         Category.assoc]
@@ -185,15 +185,15 @@ noncomputable def isLimit : IsLimit (cone f) where
         simp only [Functor.ofOpSequence_obj, Nat.succ_eq_add_one, homOfLE_leOfHom,
           Functor.ofOpSequence_map_homOfLE_succ, Category.assoc]
         have h₁ : (if _ : m < m + 1 then M m else N m) = if _ : m < n then M m else N m := by
-          rw [dif_pos (by omega), dif_pos (by omega)]
+          rw [dif_pos (by lia), dif_pos (by lia)]
         have h₂ : (if _ : m < n then M m else N m) = if _ : m < n + 1 then M m else N m := by
-          rw [dif_pos h, dif_pos (by omega)]
+          rw [dif_pos h, dif_pos (by lia)]
         rw [← eqToHom_trans h₁ h₂]
-        slice_lhs 2 4 => rw [ih (by omega)]
+        slice_lhs 2 4 => rw [ih (by lia)]
         simp only [functorMap, dite_eq_ite, Pi.π, limMap_π_assoc, Discrete.functor_obj_eq_as,
           Discrete.natTrans_app]
         split_ifs
-        rw [dif_pos (by omega)]
+        rw [dif_pos (by lia)]
         simp
     · simp only [Category.assoc]
       rw [cone_π_app_comp_Pi_π_neg f _ _ h]
@@ -206,7 +206,7 @@ noncomputable def isLimit : IsLimit (cone f) where
     intro n
     simp only [Functor.ofOpSequence_obj, dite_eq_ite, limit.lift_π, Fan.mk_pt,
       Fan.mk_π_app, ← h ⟨n + 1⟩, Category.assoc]
-    slice_rhs 2 3 => erw [cone_π_app_comp_Pi_π_pos f (n + 1) _ (by omega)]
+    slice_rhs 2 3 => erw [cone_π_app_comp_Pi_π_pos f (n + 1) _ (by lia)]
     simp
 
 section

--- a/Mathlib/Combinatorics/Additive/ApproximateSubgroup.lean
+++ b/Mathlib/Combinatorics/Additive/ApproximateSubgroup.lean
@@ -131,7 +131,7 @@ lemma of_small_tripling [DecidableEq G] {A : Finset G} (hA₁ : 1 ∈ A) (hAsymm
   sq_covBySMul := by
     replace hA := calc (#(A ^ 4 * A) : ℝ)
       _ = #(A ^ 5) := by rw [← pow_succ]
-      _ ≤ K ^ 3 * #A := small_pow_of_small_tripling (by omega) hA hAsymm
+      _ ≤ K ^ 3 * #A := small_pow_of_small_tripling (by lia) hA hAsymm
     have hA₀ : A.Nonempty := ⟨1, hA₁⟩
     obtain ⟨F, -, hF, hAF⟩ := ruzsa_covering_mul hA₀ hA
     exact ⟨F, hF, by norm_cast; simpa [div_eq_mul_inv, pow_succ, mul_assoc, hAsymm] using hAF⟩
@@ -172,7 +172,7 @@ lemma pow_inter_pow (hA : IsApproximateSubgroup K A) (hB : IsApproximateSubgroup
   one_mem := ⟨Set.one_mem_pow hA.one_mem, Set.one_mem_pow hB.one_mem⟩
   inv_eq_self := by simp_rw [inter_inv, ← inv_pow, hA.inv_eq_self, hB.inv_eq_self]
   sq_covBySMul := by
-    refine (hA.pow_inter_pow_covBySMul_sq_inter_sq hB (by omega) (by omega)).subset ?_
+    refine (hA.pow_inter_pow_covBySMul_sq_inter_sq hB (by lia) (by lia)).subset ?_
       (by gcongr; exacts [hA.one_mem, hB.one_mem])
     calc
       (A ^ m ∩ B ^ n) ^ 2 ⊆ (A ^ m) ^ 2 ∩ (B ^ n) ^ 2 := Set.inter_pow_subset

--- a/Mathlib/Combinatorics/Additive/ApproximateSubgroup.lean
+++ b/Mathlib/Combinatorics/Additive/ApproximateSubgroup.lean
@@ -154,7 +154,7 @@ lemma pow_inter_pow_covBySMul_sq_inter_sq
       _ ≤ K ^ (m - 1) * L ^ (n - 1) := by gcongr
   · calc
       A ^ m ∩ B ^ n ⊆ (F₁ ^ (m - 1) * A) ∩ (F₂ ^ (n - 1) * B) := by
-        gcongr <;> apply pow_subset_pow_mul_of_sq_subset_mul <;> norm_cast <;> omega
+        gcongr <;> apply pow_subset_pow_mul_of_sq_subset_mul <;> norm_cast <;> lia
       _ = ⋃ (a ∈ F₁ ^ (m - 1)) (b ∈ F₂ ^ (n - 1)), a • A ∩ b • B := by
         simp_rw [← smul_eq_mul, ← iUnion_smul_set, iUnion₂_inter_iUnion₂]; norm_cast
       _ ⊆ ⋃ (a ∈ F₁ ^ (m - 1)) (b ∈ F₂ ^ (n - 1)), f a b • (A⁻¹ * A ∩ (B⁻¹ * B)) := by

--- a/Mathlib/Combinatorics/Additive/Corner/Roth.lean
+++ b/Mathlib/Combinatorics/Additive/Corner/Roth.lean
@@ -118,7 +118,7 @@ theorem corners_theorem_nat (hε : 0 < ε) (hn : cornersTheoremBound (ε / 9) �
     rintro a b hab
     have := hAn hab
     simp at this
-    omega
+    lia
   rw [this] at hA
   have := Fin.isAddFreimanIso_Iio two_ne_zero (le_refl (2 * n))
   have := hA.of_image this.isAddFreimanHom Fin.val_injective.injOn <| by
@@ -177,7 +177,7 @@ theorem roth_3ap_theorem_nat (ε : ℝ) (hε : 0 < ε) (hG : cornersTheoremBound
     rintro a ha
     have := hAn ha
     simp at this
-    omega
+    lia
   rw [this] at hA
   have := Fin.isAddFreimanIso_Iio two_ne_zero (le_refl (2 * n))
   have := hA.of_image this.isAddFreimanHom Fin.val_injective.injOn <| Set.image_subset_iff.2 <|

--- a/Mathlib/Combinatorics/Additive/ErdosGinzburgZiv.lean
+++ b/Mathlib/Combinatorics/Additive/ErdosGinzburgZiv.lean
@@ -169,7 +169,7 @@ theorem Int.erdos_ginzburg_ziv (a : ι → ℤ) (hs : 2 * n - 1 ≤ #s) :
       rintro h
       obtain rfl : n = 0 := by
         simpa [← card_eq_zero, ht₀card] using sdiff_disjoint.mono ht₀ <| subset_biUnion_of_mem id h
-      omega
+      lia
     refine ⟨𝒜.cons t₀ this, by rw [card_cons, h𝒜card], ?_, ?_⟩
     · simp only [cons_eq_insert, coe_insert, Set.pairwise_insert_of_symmetric symmetric_disjoint,
         mem_coe, ne_eq]

--- a/Mathlib/Combinatorics/Derangements/Finite.lean
+++ b/Mathlib/Combinatorics/Derangements/Finite.lean
@@ -100,7 +100,7 @@ theorem card_derangements_fin_eq_numDerangements {n : ℕ} :
   · rfl
   -- now we have n ≥ 2. rewrite everything in terms of card_derangements, so that we can use
   -- `card_derangements_fin_add_two`
-  rw [numDerangements_add_two, card_derangements_fin_add_two, mul_add, hyp, hyp] <;> omega
+  rw [numDerangements_add_two, card_derangements_fin_add_two, mul_add, hyp, hyp] <;> lia
 
 theorem card_derangements_eq_numDerangements (α : Type*) [Fintype α] [DecidableEq α] :
     card (derangements α) = numDerangements (card α) := by

--- a/Mathlib/Combinatorics/Enumerative/Catalan.lean
+++ b/Mathlib/Combinatorics/Enumerative/Catalan.lean
@@ -117,7 +117,7 @@ theorem catalan_eq_centralBinom_div (n : ℕ) : catalan n = n.centralBinom / (n 
                             (Nat.centralBinom (d - i) / (d - i + 1)) : ℚ)
     · congr
       ext1 x
-      have m_le_d : x.val ≤ d := by omega
+      have m_le_d : x.val ≤ d := by lia
       have d_minus_x_le_d : (d - x.val) ≤ d := tsub_le_self
       rw [hd _ m_le_d, hd _ d_minus_x_le_d]
       norm_cast

--- a/Mathlib/Combinatorics/Enumerative/Composition.lean
+++ b/Mathlib/Combinatorics/Enumerative/Composition.lean
@@ -812,7 +812,7 @@ considering the restriction of the subset to `{1, ..., n-1}` and shifting to the
 def compositionAsSetEquiv (n : ℕ) : CompositionAsSet n ≃ Finset (Fin (n - 1)) where
   toFun c :=
     { i : Fin (n - 1) |
-        (⟨1 + (i : ℕ), by omega⟩ : Fin n.succ) ∈ c.boundaries }.toFinset
+        (⟨1 + (i : ℕ), by lia⟩ : Fin n.succ) ∈ c.boundaries }.toFinset
   invFun s :=
     { boundaries :=
         { i : Fin n.succ |

--- a/Mathlib/Combinatorics/Enumerative/DyckWord.lean
+++ b/Mathlib/Combinatorics/Enumerative/DyckWord.lean
@@ -154,7 +154,7 @@ def drop (i : ℕ) (hi : (p.toList.take i).count U = (p.toList.take i).count D) 
   count_U_eq_count_D := by
     have := p.count_U_eq_count_D
     rw [← take_append_drop i p.toList, count_append, count_append] at this
-    omega
+    lia
   count_D_le_count_U k := by
     rw [show i = min i (i + k) by omega, ← take_take] at hi
     rw [take_drop, ← add_le_add_iff_left (((p.toList.take (i + k)).take i).count U),
@@ -218,7 +218,7 @@ def denest (hn : p.IsNested) : DyckWord where
     rw [← (p.toList.take j).take_append_drop 1, count_append, count_append, take_take,
       min_eq_left (by lia), l1, head_eq_U] at eq
     simp only [count_singleton', ite_true] at eq
-    omega
+    lia
 
 variable (p) in
 lemma nest_denest (hn) : (p.denest hn).nest = p := by

--- a/Mathlib/Combinatorics/Enumerative/DyckWord.lean
+++ b/Mathlib/Combinatorics/Enumerative/DyckWord.lean
@@ -216,7 +216,7 @@ def denest (hn : p.IsNested) : DyckWord where
     have eq := hn.2 lb ub
     set j := min (1 + i) (p.toList.length - 1)
     rw [← (p.toList.take j).take_append_drop 1, count_append, count_append, take_take,
-      min_eq_left (by omega), l1, head_eq_U] at eq
+      min_eq_left (by lia), l1, head_eq_U] at eq
     simp only [count_singleton', ite_true] at eq
     omega
 

--- a/Mathlib/Combinatorics/Quiver/Path.lean
+++ b/Mathlib/Combinatorics/Quiver/Path.lean
@@ -175,7 +175,7 @@ lemma length_ne_zero_iff_eq_comp (p : Path a b) :
     p.length ≠ 0 ↔ ∃ (c : V) (e : a ⟶ c) (p' : Path c b),
       p = e.toPath.comp p' ∧ p.length = p'.length + 1 := by
   refine ⟨fun h ↦ ?_, ?_⟩
-  · have h_len : p.length = (p.length - 1) + 1 := by omega
+  · have h_len : p.length = (p.length - 1) + 1 := by lia
     obtain ⟨c, e, p', hp', rfl⟩ := Path.eq_toPath_comp_of_length_eq_succ p h_len
     exact ⟨c, e, p', rfl, by lia⟩
   · rintro ⟨c, p', e, rfl, h⟩

--- a/Mathlib/Combinatorics/SetFamily/KruskalKatona.lean
+++ b/Mathlib/Combinatorics/SetFamily/KruskalKatona.lean
@@ -369,7 +369,7 @@ theorem erdos_ko_rado {𝒜 : Finset (Finset (Fin n))} {r : ℕ}
   -- We can use the Lovasz form of Kruskal-Katona to get |∂^[n-2k] 𝒜ᶜˢ| ≥ (n-1) choose r
   have kk := kruskal_katona_lovasz_form (i := n - 2 * r) (by lia)
     ((tsub_le_tsub_iff_left ‹1 ≤ n›).2 h1r) tsub_le_self h𝒜bar z.le
-  have : n - r - (n - 2 * r) = r := by omega
+  have : n - r - (n - 2 * r) = r := by lia
   rw [this] at kk
   -- But this gives a contradiction: `n choose r < |𝒜| + |∂^[n-2k] 𝒜ᶜˢ|`
   have := calc

--- a/Mathlib/Combinatorics/SimpleGraph/ConcreteColorings.lean
+++ b/Mathlib/Combinatorics/SimpleGraph/ConcreteColorings.lean
@@ -123,7 +123,7 @@ theorem chromaticNumber_cycleGraph_of_even (n : ℕ) (h : 2 ≤ n) (hEven : Even
 
 /-- Tricoloring of a cycle graph -/
 def cycleGraph.tricoloring (n : ℕ) (h : 2 ≤ n) : Coloring (cycleGraph n)
-    (Fin 3) := Coloring.mk (fun u ↦ if u.val = n - 1 then 2 else ⟨u.val % 2, by fin_omega⟩) <| by
+    (Fin 3) := Coloring.mk (fun u ↦ if u.val = n - 1 then 2 else ⟨u.val % 2, by lia⟩) <| by
     intro u v hadj
     match n with
     | 0 => exact u.elim0

--- a/Mathlib/Combinatorics/SimpleGraph/Connectivity/Connected.lean
+++ b/Mathlib/Combinatorics/SimpleGraph/Connectivity/Connected.lean
@@ -159,7 +159,7 @@ lemma Reachable.mem_subgraphVerts {u v} {H : G.Subgraph} (hr : G.Reachable u v)
   termination_by p.length
   decreasing_by {
     rw [← Walk.length_tail_add_one hnp]
-    omega
+    lia
   }
   exact aux hu hr.some
 

--- a/Mathlib/Combinatorics/SimpleGraph/Connectivity/Subgraph.lean
+++ b/Mathlib/Combinatorics/SimpleGraph/Connectivity/Subgraph.lean
@@ -385,7 +385,7 @@ lemma ncard_neighborSet_toSubgraph_internal_eq_two {u} {i : ℕ} {p : G.Walk u v
   have : p.getVert (i - 1) ≠ p.getVert (i + 1) := by
     intro h
     have := hp.getVert_injOn (by rw [Set.mem_setOf_eq]; lia) (by rw [Set.mem_setOf_eq]; lia) h
-    omega
+    lia
   simp_all
 
 lemma snd_of_toSubgraph_adj {u v v'} {p : G.Walk u v} (hp : p.IsPath)
@@ -487,7 +487,7 @@ lemma exists_mem_support_mem_erase_mem_support_takeUntil_eq_empty (s : Finset V)
   have : (p.takeUntil x hx).length + #(s.erase x) < n := by
     rw [← card_erase_add_one hxs] at hp
     have := p.length_takeUntil_le hx
-    omega
+    lia
   obtain ⟨y, hys, hyp, h⟩ := ih _ this (s.erase x) h rfl
   use y, mem_of_mem_erase hys, support_takeUntil_subset p hx hyp
   rwa [takeUntil_takeUntil, erase_right_comm, filter_erase, erase_eq_of_notMem] at h

--- a/Mathlib/Combinatorics/SimpleGraph/Extremal/Turan.lean
+++ b/Mathlib/Combinatorics/SimpleGraph/Extremal/Turan.lean
@@ -356,7 +356,7 @@ theorem card_edgeFinset_turanGraph {n r : ℕ} :
       rw [Fintype.card_fin] at this; convert this
       rw [turanGraph_eq_top]; exact .inr h.le
     · let n' := n - r
-      have n'r : n = n' + r := by omega
+      have n'r : n = n' + r := by lia
       rw [n'r, card_edgeFinset_turanGraph_add, card_edgeFinset_turanGraph, ring₁, ring₁,
         add_rotate, ← add_assoc, Nat.add_mod_right, Nat.add_div_right _ hr]
       congr 1

--- a/Mathlib/Combinatorics/SimpleGraph/Extremal/Turan.lean
+++ b/Mathlib/Combinatorics/SimpleGraph/Extremal/Turan.lean
@@ -208,7 +208,7 @@ theorem isEquipartition [DecidableEq V] : h.finpartition.IsEquipartition := by
   have small_eq := fp.part_eq_of_mem hs hv
   have ha : G.Adj v w := by
     by_contra hn; rw [h.not_adj_iff_part_eq, small_eq, large_eq] at hn
-    rw [hn] at ineq; omega
+    rw [hn] at ineq; lia
   rw [G.card_edgeFinset_replaceVertex_of_adj ha,
     degree_eq_card_sub_part_card h, small_eq, degree_eq_card_sub_part_card h, large_eq]
   have : #large ≤ card V := by simpa using card_le_card large.subset_univ

--- a/Mathlib/Combinatorics/SimpleGraph/FiveWheelLike.lean
+++ b/Mathlib/Combinatorics/SimpleGraph/FiveWheelLike.lean
@@ -405,7 +405,7 @@ lemma minDegree_le_of_cliqueFree_fiveWheelLikeFree_succ [Fintype α]
           simp [Xu, Wc, mul_comm]
         have w3 : 3 ≤ #W := two_lt_card.2 ⟨_, mem_insert_self .., _, by simp [W], _, by simp [W],
           hw.isPathGraph3Compl.ne_fst, hw.isPathGraph3Compl.ne_snd, hw.isPathGraph3Compl.fst_ne_snd⟩
-        have hap : #W - 1 + 2 * (k - 1) = #W - 3 + 2 * k := by omega
+        have hap : #W - 1 + 2 * (k - 1) = #W - 3 + 2 * k := by lia
         rw [hap, ← add_mul, card_add_card_compl, mul_comm, two_mul, ← add_assoc]
         gcongr
         lia

--- a/Mathlib/Combinatorics/SimpleGraph/Matching.lean
+++ b/Mathlib/Combinatorics/SimpleGraph/Matching.lean
@@ -516,7 +516,7 @@ lemma IsCycles.exists_cycle_toSubgraph_verts_eq_connectedComponentSupp [Finite V
         rw [Walk.mem_verts_toSubgraph] at hv
         refine (Set.nonempty_of_ncard_ne_zero ?_).mono (p.toSubgraph.neighborSet_subset v)
         rw [hp.1.ncard_neighborSet_toSubgraph_eq_two hv]
-        omega
+        lia
       refine @Classical.ofNonempty _ ?_
       rw [← Cardinal.eq, ← Set.cast_ncard (Set.toFinite _), ← Set.cast_ncard (Set.toFinite _),
         h this, hp.1.ncard_neighborSet_toSubgraph_eq_two (p.mem_verts_toSubgraph.mp hv)])

--- a/Mathlib/Combinatorics/SimpleGraph/Metric.lean
+++ b/Mathlib/Combinatorics/SimpleGraph/Metric.lean
@@ -257,7 +257,7 @@ theorem Connected.diff_dist_adj (hG : G.Connected) (hadj : G.Adj v w) :
   have : G.dist w v = 1 := dist_eq_one_iff_adj.mpr hadj.symm
   have : G.dist u w ≤ G.dist u v + G.dist v w := hG.dist_triangle
   have : G.dist u v ≤ G.dist u w + G.dist w v := hG.dist_triangle
-  omega
+  lia
 
 theorem Walk.isPath_of_length_eq_dist (p : G.Walk u v) (hp : p.length = G.dist u v) :
     p.IsPath := by
@@ -319,8 +319,8 @@ lemma Walk.exists_adj_adj_not_adj_ne {p : G.Walk v w} (hp : p.length = G.dist v 
     rw [← p.tail.length_tail_add_one (by
       simp only [not_nil_iff_lt_length, ← p.length_tail_add_one hnp] at hp ⊢
       lia)]
-    omega
-  have : p.tail.length < p.length := by rw [← p.length_tail_add_one hnp]; omega
+    lia
+  have : p.tail.length < p.length := by rw [← p.length_tail_add_one hnp]; lia
   by_cases hv : v = p.getVert 2
   · have : G.dist v w ≤ p.tail.tail.length := by
       simpa [hv, p.getVert_tail] using dist_le p.tail.tail

--- a/Mathlib/Combinatorics/SimpleGraph/Paths.lean
+++ b/Mathlib/Combinatorics/SimpleGraph/Paths.lean
@@ -396,7 +396,7 @@ lemma IsPath.getVert_injOn_iff (p : G.Walk u v) : Set.InjOn p.getVert {i | i ≤
       (by rw [length_cons]; lia : (n + 1) ≤ (q.cons h).length)
       (by lia : 0 ≤ (q.cons h).length)
       (by rwa [getVert_cons _ _ n.add_one_ne_zero, getVert_zero])
-    omega
+    lia
 
 theorem IsPath.eq_snd_of_mem_edges {p : G.Walk u v} (hp : p.IsPath) (hnil : ¬p.Nil)
     (hmem : s(u, w) ∈ p.edges) : w = p.snd := by
@@ -420,7 +420,7 @@ lemma IsCycle.getVert_injOn {p : G.Walk u u} (hpc : p.IsCycle) :
   have := ((Walk.cons_isCycle_iff _ _).mp hpc).1.getVert_injOn
     (by lia : n - 1 ≤ p.tail.length) (by lia : m - 1 ≤ p.tail.length)
     (by simp_all [SimpleGraph.Walk.getVert_tail, Nat.sub_add_cancel hn.1, Nat.sub_add_cancel hm.1])
-  omega
+  lia
 
 lemma IsCycle.getVert_injOn' {p : G.Walk u u} (hpc : p.IsCycle) :
     Set.InjOn p.getVert {i |  i ≤ p.length - 1} := by

--- a/Mathlib/Combinatorics/SimpleGraph/Walks/Traversal.lean
+++ b/Mathlib/Combinatorics/SimpleGraph/Walks/Traversal.lean
@@ -162,7 +162,7 @@ lemma adj_penultimate {p : G.Walk v w} (hp : ¬ p.Nil) :
     G.Adj p.penultimate w := by
   conv => rhs; rw [← getVert_length p]
   rw [nil_iff_length_eq] at hp
-  convert adj_getVert_succ _ _ <;> omega
+  convert adj_getVert_succ _ _ <;> lia
 
 /-- The first dart of a walk. -/
 @[simps]

--- a/Mathlib/Computability/Ackermann.lean
+++ b/Mathlib/Computability/Ackermann.lean
@@ -157,7 +157,7 @@ theorem add_lt_ack : ∀ m n, m + n < ack m n
   | m + 1, 0 => by simpa using add_lt_ack m 1
   | m + 1, n + 1 =>
     calc
-      m + 1 + n + 1 ≤ m + (m + n + 2) := by omega
+      m + 1 + n + 1 ≤ m + (m + n + 2) := by lia
       _ < ack m (m + n + 2) := add_lt_ack _ _
       _ ≤ ack m (ack (m + 1) n) :=
         ack_mono_right m <| le_of_eq_of_le (by rw [succ_eq_add_one]; ring_nf)
@@ -180,7 +180,7 @@ private theorem ack_strict_mono_left' : ∀ {m₁ m₂} (n), m₁ < m₂ → ack
   | 0, m + 1, n + 1 => fun h => by
     rw [ack_zero, ack_succ_succ]
     calc
-      n + 1 + 1 ≤ m + (m + 1 + n + 1) := by omega
+      n + 1 + 1 ≤ m + (m + 1 + n + 1) := by lia
       _ ≤ m + ack (m + 1) n := by gcongr; exact add_add_one_le_ack ..
       _ < ack m (ack (m + 1) n) := add_lt_ack ..
   | m₁ + 1, m₂ + 1, 0 => fun h => by

--- a/Mathlib/Computability/Ackermann.lean
+++ b/Mathlib/Computability/Ackermann.lean
@@ -97,7 +97,7 @@ theorem ack_three (n : ℕ) : ack 3 n = 2 ^ (n + 3) - 3 := by
         Nat.mul_sub_left_distrib, ← Nat.sub_add_comm, two_mul 3, Nat.add_sub_add_right]
     calc  2 * 3
       _ ≤ 2 * 2 ^ 3 := by simp
-      _ ≤ 2 * 2 ^ (n + 3) := by gcongr <;> omega
+      _ ≤ 2 * 2 ^ (n + 3) := by gcongr <;> lia
 
 theorem ack_pos : ∀ m n, 0 < ack m n
   | 0, n => by simp

--- a/Mathlib/Computability/RegularExpressions.lean
+++ b/Mathlib/Computability/RegularExpressions.lean
@@ -266,7 +266,7 @@ theorem star_rmatch_iff (P : RegularExpression α) :
         rintro ⟨t, u, hs, ht, hu⟩
         have hwf : u.length < (List.cons a x).length := by
           rw [hs, List.length_cons, List.length_append]
-          omega
+          lia
         rw [IH _ hwf] at hu
         rcases hu with ⟨S', hsum, helem⟩
         use (a :: t) :: S'

--- a/Mathlib/Control/Fix.lean
+++ b/Mathlib/Control/Fix.lean
@@ -98,7 +98,7 @@ protected theorem fix_def {x : α} (h' : ∃ i, (Fix.approx f i x).Dom) :
     ext : 1
     have hh : ¬(Fix.approx f z.val x).Dom := by
       apply Nat.find_min h'
-      omega
+      lia
     rw [succ_add_eq_add_succ] at _this hk
     rw [assert_pos hh, n_ih (Upto.succ z hh) _this hk]
 

--- a/Mathlib/Data/Fin/Basic.lean
+++ b/Mathlib/Data/Fin/Basic.lean
@@ -455,7 +455,7 @@ section AddGroup
 
 theorem eq_zero (n : Fin 1) : n = 0 := Subsingleton.elim _ _
 
-lemma eq_one_of_ne_zero (i : Fin 2) (hi : i ≠ 0) : i = 1 := by fin_omega
+lemma eq_one_of_ne_zero (i : Fin 2) (hi : i ≠ 0) : i = 1 := by lia
 
 @[deprecated (since := "2025-04-27")]
 alias eq_one_of_neq_zero := eq_one_of_ne_zero

--- a/Mathlib/Data/Fin/Basic.lean
+++ b/Mathlib/Data/Fin/Basic.lean
@@ -475,7 +475,7 @@ theorem add_one_le_of_lt {n : ℕ} {a b : Fin (n + 1)} (h : a < b) : a + 1 ≤ b
 
 theorem exists_eq_add_of_le {n : ℕ} {a b : Fin n} (h : a ≤ b) : ∃ k ≤ b, b = a + k := by
   obtain ⟨k, hk⟩ : ∃ k : ℕ, (b : ℕ) = a + k := Nat.exists_eq_add_of_le h
-  have hkb : k ≤ b := by omega
+  have hkb : k ≤ b := by lia
   refine ⟨⟨k, hkb.trans_lt b.is_lt⟩, hkb, ?_⟩
   simp [Fin.ext_iff, Fin.val_add, ← hk, Nat.mod_eq_of_lt b.is_lt]
 
@@ -484,7 +484,7 @@ theorem exists_eq_add_of_lt {n : ℕ} {a b : Fin (n + 1)} (h : a < b) :
   cases n
   · lia
   obtain ⟨k, hk⟩ : ∃ k : ℕ, (b : ℕ) = a + k + 1 := Nat.exists_eq_add_of_lt h
-  have hkb : k < b := by omega
+  have hkb : k < b := by lia
   refine ⟨⟨k, hkb.trans b.is_lt⟩, hkb, by fin_omega, ?_⟩
   simp [Fin.ext_iff, Fin.val_add, ← hk, Nat.mod_eq_of_lt b.is_lt]
 

--- a/Mathlib/Data/Fin/Basic.lean
+++ b/Mathlib/Data/Fin/Basic.lean
@@ -235,8 +235,8 @@ theorem coe_int_add_eq_ite {n : Nat} (u v : Fin n) :
     ((u + v : Fin n) : Int) = if (u + v : ℕ) < n then (u + v : Int) else (u + v : Int) - n := by
   rw [Fin.add_def]
   split
-  · rw [natCast_emod, Int.emod_eq_of_lt] <;> omega
-  · rw [natCast_emod, Int.emod_eq_sub_self_emod, Int.emod_eq_of_lt] <;> omega
+  · rw [natCast_emod, Int.emod_eq_of_lt] <;> lia
+  · rw [natCast_emod, Int.emod_eq_sub_self_emod, Int.emod_eq_of_lt] <;> lia
 
 theorem coe_int_add_eq_mod {n : Nat} (u v : Fin n) :
     ((u + v : Fin n) : Int) = ((u : Int) + (v : Int)) % n := by

--- a/Mathlib/Data/Fin/SuccPred.lean
+++ b/Mathlib/Data/Fin/SuccPred.lean
@@ -914,7 +914,7 @@ theorem succAbove_succAbove_succAbove_predAbove {n : ℕ}
   simp? [succAbove, predAbove, lt_def, apply_dite Fin.val, apply_ite Fin.val] says
     simp only [succAbove, predAbove, lt_def, coe_castSucc, apply_dite Fin.val, coe_pred,
       coe_castPred, dite_eq_ite, apply_ite Fin.val, val_succ]
-  split_ifs <;> omega
+  split_ifs <;> lia
 
 end PredAbove
 

--- a/Mathlib/Data/Fin/Tuple/Sort.lean
+++ b/Mathlib/Data/Fin/Tuple/Sort.lean
@@ -121,7 +121,7 @@ theorem lt_card_le_iff_apply_le_of_monotone [Preorder α] [DecidableLE α]
     apply hw.ne'
     have he := Fintype.card_congr <| Equiv.sumCompl <| q'
     have h4 := (Fintype.card_congr (@Equiv.subtypeSubtypeEquivSubtype _ p q (h1 _)))
-    have h_le : Fintype.card { i // f i ≤ a } ≤ m := by omega
+    have h_le : Fintype.card { i // f i ≤ a } ≤ m := by lia
     rwa [Fintype.card_sum, h4, Fintype.card_fin_lt_of_le h_le, add_eq_left] at he
   intro _ h
   contrapose! h

--- a/Mathlib/Data/Finset/Card.lean
+++ b/Mathlib/Data/Finset/Card.lean
@@ -867,7 +867,7 @@ def strongDownwardInduction {p : Finset α → Sort*} {n : ℕ}
   | s =>
     H s fun {t} ht h =>
       have := Finset.card_lt_card h
-      have : n - #t < n - #s := by omega
+      have : n - #t < n - #s := by lia
       strongDownwardInduction H t ht
   termination_by s => n - #s
 

--- a/Mathlib/Data/Int/Basic.lean
+++ b/Mathlib/Data/Int/Basic.lean
@@ -48,7 +48,7 @@ lemma inductionOn'_add_one (hz : b ≤ z) :
   apply cast_eq_iff_heq.mpr
   lift z - b to ℕ using Int.sub_nonneg.mpr hz with zb hzb
   rw [show z + 1 - b = zb + 1 by lia]
-  have : b + zb = z := by omega
+  have : b + zb = z := by lia
   subst this
   convert cast_heq _ _
   rw [Int.inductionOn', cast_eq_iff_heq, ← hzb]

--- a/Mathlib/Data/Int/GCD.lean
+++ b/Mathlib/Data/Int/GCD.lean
@@ -146,10 +146,10 @@ theorem exists_mul_mod_eq_one_of_coprime {k n : ℕ} (hkn : Coprime n k) (hk : 1
 
 theorem exists_mul_mod_eq_of_coprime {k n : ℕ} (r : ℕ) (hkn : Coprime n k) (hk : k ≠ 0) :
     ∃ m < k, n * m % k = r % k := by
-  obtain rfl | hk : k = 1 ∨ 1 < k := by omega
+  obtain rfl | hk : k = 1 ∨ 1 < k := by lia
   · simp [mod_one]
   obtain ⟨m, -, hm⟩ := exists_mul_mod_eq_one_of_coprime hkn hk
-  use (m * r) % k, mod_lt _ (by omega)
+  use (m * r) % k, mod_lt _ (by lia)
   rw [mul_mod, mod_mod, ← mul_mod, ← mul_assoc, mul_mod, hm, one_mul, mod_mod]
 
 end Nat

--- a/Mathlib/Data/Int/Init.lean
+++ b/Mathlib/Data/Int/Init.lean
@@ -124,7 +124,7 @@ lemma inductionOn'_sub_one (hz : z ≤ b) :
   rw [hn]
   obtain _ | n := n
   · change _ = -1 at hn
-    have : z = b := by omega
+    have : z = b := by lia
     subst this; rw [inductionOn'_self]; exact heq_of_eq rfl
   · have : z = b + -[n+1] := by rw [Int.negSucc_eq] at hn ⊢; omega
     subst this

--- a/Mathlib/Data/Int/Init.lean
+++ b/Mathlib/Data/Int/Init.lean
@@ -126,7 +126,7 @@ lemma inductionOn'_sub_one (hz : z ≤ b) :
   · change _ = -1 at hn
     have : z = b := by lia
     subst this; rw [inductionOn'_self]; exact heq_of_eq rfl
-  · have : z = b + -[n+1] := by rw [Int.negSucc_eq] at hn ⊢; omega
+  · have : z = b + -[n+1] := by rw [Int.negSucc_eq] at hn ⊢; lia
     subst this
     refine (cast_heq _ _).trans ?_
     congr
@@ -301,7 +301,7 @@ lemma le_add_iff_lt_of_dvd_sub (ha : 0 < a) (hab : a ∣ c - b) : a + b ≤ c �
 
 lemma sign_add_eq_of_sign_eq : ∀ {m n : ℤ}, m.sign = n.sign → (m + n).sign = n.sign := by
   have : (1 : ℤ) ≠ -1 := by decide
-  rintro ((_ | m) | m) ((_ | n) | n) <;> simp [this, this.symm] <;> omega
+  rintro ((_ | m) | m) ((_ | n) | n) <;> simp [this, this.symm] <;> lia
 
 /-! ### toNat -/
 

--- a/Mathlib/Data/Int/Interval.lean
+++ b/Mathlib/Data/Int/Interval.lean
@@ -38,7 +38,7 @@ instance instLocallyFiniteOrder : LocallyFiniteOrder ℤ where
     simp_rw [mem_map, mem_range, Function.Embedding.trans_apply, Nat.castEmbedding_apply,
       addLeftEmbedding_apply]
     constructor
-    · omega
+    · lia
     · intro
       use (x - a).toNat
       omega
@@ -46,7 +46,7 @@ instance instLocallyFiniteOrder : LocallyFiniteOrder ℤ where
     simp_rw [mem_map, mem_range, Function.Embedding.trans_apply, Nat.castEmbedding_apply,
       addLeftEmbedding_apply]
     constructor
-    · omega
+    · lia
     · intro
       use (x - a).toNat
       omega
@@ -54,18 +54,18 @@ instance instLocallyFiniteOrder : LocallyFiniteOrder ℤ where
     simp_rw [mem_map, mem_range, Function.Embedding.trans_apply, Nat.castEmbedding_apply,
       addLeftEmbedding_apply]
     constructor
-    · omega
+    · lia
     · intro
       use (x - (a + 1)).toNat
-      omega
+      lia
   finset_mem_Ioo a b x := by
     simp_rw [mem_map, mem_range, Function.Embedding.trans_apply, Nat.castEmbedding_apply,
       addLeftEmbedding_apply]
     constructor
-    · omega
+    · lia
     · intro
       use (x - (a + 1)).toNat
-      omega
+      lia
 
 variable (a b : ℤ)
 
@@ -189,12 +189,12 @@ lemma Finset.Ioc_succ_succ (m n : ℕ) :
     Ioc (-(m + 1) : ℤ) (n + 1) = Ioc (-m : ℤ) n ∪ {-(m : ℤ), (n + 1 : ℤ)} := by
   ext
   simp only [mem_Ioc, union_insert, union_singleton, mem_insert]
-  omega
+  lia
 
 lemma Finset.Ioo_succ_succ (m n : ℕ) :
     Ioo (-(m + 1) : ℤ) (n + 1) = Ioo (-m : ℤ) n ∪ {-(m : ℤ), (n : ℤ)} := by
   ext
   simp only [mem_Ioo, union_insert, union_singleton, mem_insert]
-  omega
+  lia
 
 end Nat

--- a/Mathlib/Data/List/Basic.lean
+++ b/Mathlib/Data/List/Basic.lean
@@ -662,7 +662,7 @@ theorem get_reverse' (l : List α) (n) (hn') :
     l.reverse.get n = l.get ⟨l.length - 1 - n, hn'⟩ := by
   simp
 
-theorem eq_cons_of_length_one {l : List α} (h : l.length = 1) : l = [l.get ⟨0, by omega⟩] := by
+theorem eq_cons_of_length_one {l : List α} (h : l.length = 1) : l = [l.get ⟨0, by lia⟩] := by
   refine ext_get (by convert h) (by grind)
 
 end deprecated

--- a/Mathlib/Data/List/Cycle.lean
+++ b/Mathlib/Data/List/Cycle.lean
@@ -385,7 +385,7 @@ theorem prev_reverse_eq_next (l : List α) (h : Nodup l) (x : α) (hx : x ∈ l)
     prev l.reverse x (mem_reverse.mpr hx) = next l x hx := by
   obtain ⟨k, hk, rfl⟩ := getElem_of_mem hx
   have lpos : 0 < l.length := k.zero_le.trans_lt hk
-  have key : l.length - 1 - k < l.length := by omega
+  have key : l.length - 1 - k < l.length := by lia
   rw [← getElem_pmap l.next (fun _ h => h) (by simpa using hk)]
   simp_rw [getElem_eq_getElem_reverse (l := l), pmap_next_eq_rotate_one _ h]
   rw [← getElem_pmap l.reverse.prev fun _ h => h]

--- a/Mathlib/Data/Matrix/Mul.lean
+++ b/Mathlib/Data/Matrix/Mul.lean
@@ -1063,14 +1063,14 @@ lemma vecMul_injective_of_isUnit [Fintype m] [DecidableEq m] {A : Matrix m m R}
 lemma pow_row_eq_zero_of_le [Fintype n] [DecidableEq n] {M : Matrix n n R} {k l : ℕ} {i : n}
     (h : (M ^ k).row i = 0) (h' : k ≤ l) :
     (M ^ l).row i = 0 := by
-  replace h' : l = k + (l - k) := by omega
+  replace h' : l = k + (l - k) := by lia
   rw [← single_one_vecMul] at h ⊢
   rw [h', pow_add, ← vecMul_vecMul, h, zero_vecMul]
 
 lemma pow_col_eq_zero_of_le [Fintype n] [DecidableEq n] {M : Matrix n n R} {k l : ℕ} {i : n}
     (h : (M ^ k).col i = 0) (h' : k ≤ l) :
     (M ^ l).col i = 0 := by
-  replace h' : l = (l - k) + k := by omega
+  replace h' : l = (l - k) + k := by lia
   rw [← mulVec_single_one] at h ⊢
   rw [h', pow_add, ← mulVec_mulVec, h, mulVec_zero]
 

--- a/Mathlib/Data/Nat/Bits.lean
+++ b/Mathlib/Data/Nat/Bits.lean
@@ -228,7 +228,7 @@ theorem bit_add' : ∀ (b : Bool) (n m : ℕ), bit b (n + m) = bit b n + bit fal
   | false, _, _ => by dsimp [bit]; lia
 
 theorem bit_ne_zero (b) {n} (h : n ≠ 0) : bit b n ≠ 0 := by
-  cases b <;> dsimp [bit] <;> omega
+  cases b <;> dsimp [bit] <;> lia
 
 @[simp]
 theorem bitCasesOn_bit0 {motive : ℕ → Sort u} (H : ∀ b n, motive (bit b n)) (n : ℕ) :
@@ -256,8 +256,8 @@ lemma bit_le : ∀ (b : Bool) {m n : ℕ}, m ≤ n → bit b m ≤ bit b n
   | false, _, _, h => by dsimp [bit]; lia
 
 lemma bit_lt_bit (a b) (h : m < n) : bit a m < bit b n := calc
-  bit a m < 2 * n := by cases a <;> dsimp [bit] <;> omega
-        _ ≤ bit b n := by cases b <;> dsimp [bit] <;> omega
+  bit a m < 2 * n := by cases a <;> dsimp [bit] <;> lia
+        _ ≤ bit b n := by cases b <;> dsimp [bit] <;> lia
 
 @[simp]
 theorem zero_bits : bits 0 = [] := by simp [Nat.bits]

--- a/Mathlib/Data/Nat/Bitwise.lean
+++ b/Mathlib/Data/Nat/Bitwise.lean
@@ -390,7 +390,7 @@ theorem xor_range (n : ℕ) : (List.range (n + 1)).foldl (· ^^^ ·) 0 =
       apply zero_xor
 
 @[simp] theorem bit_lt_two_pow_succ_iff {b x n} : bit b x < 2 ^ (n + 1) ↔ x < 2 ^ n := by
-  cases b <;> simp <;> omega
+  cases b <;> simp <;> lia
 
 lemma shiftLeft_lt {x n m : ℕ} (h : x < 2 ^ n) : x <<< m < 2 ^ (n + m) := by
   simp only [Nat.pow_add, shiftLeft_eq, Nat.mul_lt_mul_right (Nat.two_pow_pos _), h]

--- a/Mathlib/Data/Nat/Choose/Factorization.lean
+++ b/Mathlib/Data/Nat/Choose/Factorization.lean
@@ -70,7 +70,7 @@ theorem factorization_factorial_mul_succ {n p : ℕ} (hp : p.Prime) :
   have h0 : 2 ≤ p := hp.two_le
   have h1 : 1 ≤ p * n + 1 := Nat.le_add_left _ _
   have h2 : p * n + 1 ≤ p * (n + 1) := by linarith
-  have h3 : p * n + 1 ≤ p * (n + 1) + 1 := by omega
+  have h3 : p * n + 1 ≤ p * (n + 1) + 1 := by lia
   have h4 m (hm : m ∈ Ico (p * n + 1) (p * (n + 1))) : m.factorization p = 0 := by
     apply factorization_eq_zero_of_not_dvd
     exact not_dvd_of_lt_of_lt_mul_succ (mem_Ico.mp hm).left (mem_Ico.mp hm).right

--- a/Mathlib/Data/Nat/Digits/Defs.lean
+++ b/Mathlib/Data/Nat/Digits/Defs.lean
@@ -358,7 +358,7 @@ theorem digits_lt_base' {b m : ℕ} : ∀ {d}, d ∈ digits (b + 2) m → d < b 
   cases hd
   · exact n.succ.mod_lt (by linarith)
   · apply IH ((n + 1) / (b + 2))
-    · apply Nat.div_lt_self <;> omega
+    · apply Nat.div_lt_self <;> lia
     · assumption
 
 -- TODO: find a good way to fix the linter error; simp_all is called on three goals, one remains

--- a/Mathlib/Data/Nat/Factorial/Basic.lean
+++ b/Mathlib/Data/Nat/Factorial/Basic.lean
@@ -144,7 +144,7 @@ theorem add_factorial_succ_lt_factorial_add_succ {i : ℕ} (n : ℕ) (hi : 2 ≤
   rw [factorial_succ (i + _), Nat.add_mul, Nat.one_mul]
   have := (i + n).self_le_factorial
   refine Nat.add_lt_add_of_lt_of_le (Nat.lt_of_le_of_lt ?_ ((Nat.lt_mul_iff_one_lt_right ?_).2 ?_))
-    (factorial_le ?_) <;> omega
+    (factorial_le ?_) <;> lia
 
 theorem add_factorial_lt_factorial_add {i n : ℕ} (hi : 2 ≤ i) (hn : 1 ≤ n) :
     i + n ! < (i + n)! := by

--- a/Mathlib/Data/Nat/Factorial/Basic.lean
+++ b/Mathlib/Data/Nat/Factorial/Basic.lean
@@ -133,7 +133,7 @@ theorem self_le_factorial : ∀ n : ℕ, n ≤ n !
   | k + 1 => Nat.le_mul_of_pos_right _ (Nat.one_le_of_lt k.factorial_pos)
 
 theorem lt_factorial_self {n : ℕ} (hi : 3 ≤ n) : n < n ! := by
-  have : 0 < n := by omega
+  have : 0 < n := by lia
   have hn : 1 < pred n := le_pred_of_lt (succ_le_iff.mp hi)
   rw [← succ_pred_eq_of_pos ‹0 < n›, factorial_succ]
   exact (Nat.lt_mul_iff_one_lt_right (pred n).succ_pos).2
@@ -446,7 +446,7 @@ theorem descFactorial_lt_pow {n : ℕ} (hn : n ≠ 0) : ∀ {k : ℕ}, 2 ≤ k �
   | 1 => by intro; contradiction
   | k + 2 => fun _ => by
     rw [descFactorial_succ, pow_succ', Nat.mul_comm, Nat.mul_comm n]
-    exact Nat.mul_lt_mul_of_le_of_lt (descFactorial_le_pow _ _) (by omega) (Nat.pow_pos <| by omega)
+    exact Nat.mul_lt_mul_of_le_of_lt (descFactorial_le_pow _ _) (by lia) (Nat.pow_pos <| by lia)
 
 end DescFactorial
 

--- a/Mathlib/Data/Nat/Init.lean
+++ b/Mathlib/Data/Nat/Init.lean
@@ -392,7 +392,7 @@ theorem diag_induction (P : ℕ → ℕ → Prop) (ha : ∀ a, P (a + 1) (a + 1)
   | 0, _ + 1, _ => hb _
   | a + 1, b + 1, h => by
     apply hd _ _ (Nat.add_lt_add_iff_right.1 h)
-    · have this : a + 1 = b ∨ a + 1 < b := by omega
+    · have this : a + 1 = b ∨ a + 1 < b := by lia
       rcases this with (rfl | h)
       · exact ha _
       apply diag_induction P ha hb hd (a + 1) b h

--- a/Mathlib/Data/Nat/Log.lean
+++ b/Mathlib/Data/Nat/Log.lean
@@ -217,7 +217,7 @@ theorem log_eq_iff {b m n : ℕ} (h : m ≠ 0 ∨ 1 < b ∧ n ≠ 0) :
     any_goals
       simp only [ne_eq, lt_self_iff_false, not_lt_zero, false_and, or_false]
         at h
-      simp [h, eq_comm (a := 0), Nat.zero_pow (Nat.pos_iff_ne_zero.2 _)] <;> omega
+      simp [h, eq_comm (a := 0), Nat.zero_pow (Nat.pos_iff_ne_zero.2 _)] <;> lia
   · simp [@eq_comm _ 0, hm]
 
 theorem log_eq_of_pow_le_of_lt_pow {b m n : ℕ} (h₁ : b ^ m ≤ n) (h₂ : n < b ^ (m + 1)) :
@@ -428,7 +428,7 @@ theorem clog_of_two_le {b n : ℕ} (hb : 1 < b) (hn : 2 ≤ n) :
 
 theorem clog_eq_one {b n : ℕ} (hn : 2 ≤ n) (h : n ≤ b) : clog b n = 1 := by
   rw [clog_of_two_le (hn.trans h) hn, clog_of_right_le_one]
-  rw [← Nat.lt_succ_iff, Nat.div_lt_iff_lt_mul] <;> omega
+  rw [← Nat.lt_succ_iff, Nat.div_lt_iff_lt_mul] <;> lia
 
 theorem clog_le_of_le_pow {b x y : ℕ} (h : x ≤ b ^ y) : clog b x ≤ y := by
   rcases Nat.lt_or_ge 1 b with hb | hb

--- a/Mathlib/Data/Nat/Log.lean
+++ b/Mathlib/Data/Nat/Log.lean
@@ -36,7 +36,7 @@ Note a tail-recursive version of `Nat.log` is also possible:
 def logTR (b n : ℕ) : ℕ :=
   let rec go : ℕ → ℕ → ℕ | n, acc => if h : b ≤ n ∧ 1 < b then go (n / b) (acc + 1) else acc
   decreasing_by
-    have : n / b < n := Nat.div_lt_self (by omega) h.2
+    have : n / b < n := Nat.div_lt_self (by lia) h.2
     decreasing_trivial
   go n 0
 ```

--- a/Mathlib/Data/Nat/MaxPowDiv.lean
+++ b/Mathlib/Data/Nat/MaxPowDiv.lean
@@ -106,7 +106,7 @@ theorem le_of_dvd {p n pow : ℕ} (hp : 1 < p) (hn : n ≠ 0) (h : p ^ pow ∣ n
     apply Nat.pos_of_ne_zero
     intro h'
     rw [h',mul_zero] at hc
-    omega
+    lia
   simp [hc, base_pow_mul hp this]
 
 end maxPowDiv

--- a/Mathlib/Data/Nat/Multiplicity.lean
+++ b/Mathlib/Data/Nat/Multiplicity.lean
@@ -133,7 +133,7 @@ theorem emultiplicity_factorial_mul_succ {n p : ℕ} (hp : p.Prime) :
   have h0 : 2 ≤ p := hp.two_le
   have h1 : 1 ≤ p * n + 1 := Nat.le_add_left _ _
   have h2 : p * n + 1 ≤ p * (n + 1) := by linarith
-  have h3 : p * n + 1 ≤ p * (n + 1) + 1 := by omega
+  have h3 : p * n + 1 ≤ p * (n + 1) + 1 := by lia
   have hm : emultiplicity p (p * n)! ≠ ⊤ := by
     rw [Ne, emultiplicity_eq_top, Classical.not_not, Nat.finiteMultiplicity_iff]
     exact ⟨hp.ne_one, factorial_pos _⟩

--- a/Mathlib/Data/Nat/Pairing.lean
+++ b/Mathlib/Data/Nat/Pairing.lean
@@ -138,7 +138,7 @@ theorem pair_lt_pair_right (a) {b₁ b₂} (h : b₁ < b₂) : pair a b₁ < pai
 
 theorem pair_lt_max_add_one_sq (m n : ℕ) : pair m n < (max m n + 1) ^ 2 := by
   simp only [pair, Nat.pow_two, Nat.mul_add, Nat.add_mul, Nat.mul_one, Nat.one_mul, Nat.add_assoc]
-  split_ifs <;> simp [Nat.le_of_lt, not_lt.1, *] <;> omega
+  split_ifs <;> simp [Nat.le_of_lt, not_lt.1, *] <;> lia
 
 theorem max_sq_add_min_le_pair (m n : ℕ) : max m n ^ 2 + min m n ≤ pair m n := by
   rw [pair]

--- a/Mathlib/Data/Nat/Size.lean
+++ b/Mathlib/Data/Nat/Size.lean
@@ -110,7 +110,7 @@ theorem size_le {m n : ℕ} : size m ≤ n ↔ m < 2 ^ n :=
         apply Nat.lt_of_mul_lt_mul_left (a := 2)
         simp only [shiftLeft_succ] at *
         refine lt_of_le_of_lt ?_ h
-        cases b <;> dsimp [bit] <;> omega⟩
+        cases b <;> dsimp [bit] <;> lia⟩
 
 theorem lt_size {m n : ℕ} : m < size n ↔ 2 ^ m ≤ n := by
   rw [← not_lt, Decidable.iff_not_comm, not_lt, size_le]

--- a/Mathlib/Data/Nat/Sqrt.lean
+++ b/Mathlib/Data/Nat/Sqrt.lean
@@ -73,7 +73,7 @@ lemma sqrt.lt_iter_succ_sq (n guess : ℕ) (hn : n < (guess + 1) * (guess + 1)) 
     refine Nat.mul_self_lt_mul_self (?_ : _ < _ * ((_ / 2) + 1))
     rw [← add_div_right _ (by decide), Nat.mul_comm 2, Nat.mul_assoc,
       show guess + n / guess + 2 = (guess + n / guess + 1) + 1 from rfl]
-    have aux_lemma {a : ℕ} : a ≤ 2 * ((a + 1) / 2) := by omega
+    have aux_lemma {a : ℕ} : a ≤ 2 * ((a + 1) / 2) := by lia
     refine lt_of_lt_of_le ?_ (Nat.mul_le_mul_left _ aux_lemma)
     rw [Nat.add_assoc, Nat.mul_add]
     exact Nat.add_lt_add_left (lt_mul_div_succ _ (lt_of_le_of_lt (Nat.zero_le m) h)) _

--- a/Mathlib/Data/Nat/Squarefree.lean
+++ b/Mathlib/Data/Nat/Squarefree.lean
@@ -158,7 +158,7 @@ theorem minSqFacAux_has_prop {n : ℕ} (k) (n0 : 0 < n) (i) (e : k = 2 * i + 3)
     have := ih p pp (dvd_trans ⟨_, rfl⟩ d)
     have := Nat.mul_le_mul this this
     exact not_le_of_gt h (le_trans this (le_of_dvd n0 d))
-  have k2 : 2 ≤ k := by omega
+  have k2 : 2 ≤ k := by lia
   have k0 : 0 < k := lt_of_lt_of_le (by decide) k2
   have IH : ∀ n', n' ∣ n → ¬k ∣ n' → MinSqFacProp n' (n'.minSqFacAux (k + 2)) := by
     intro n' nd' nk

--- a/Mathlib/Data/Num/Lemmas.lean
+++ b/Mathlib/Data/Num/Lemmas.lean
@@ -833,7 +833,7 @@ theorem castNum_shiftRight (m : Num) (n : Nat) : ↑(m >>> n) = (m : ℕ) >>> (n
   induction n generalizing m with
   | zero => cases m <;> rfl
   | succ n IH => ?_
-  have hdiv2 : ∀ m, Nat.div2 (m + m) = m := by intro; rw [Nat.div2_val]; omega
+  have hdiv2 : ∀ m, Nat.div2 (m + m) = m := by intro; rw [Nat.div2_val]; lia
   obtain - | m | m := m <;> dsimp only [PosNum.shiftr, ← PosNum.shiftr_eq_shiftRight]
   · rw [Nat.shiftRight_eq_div_pow]
     symm

--- a/Mathlib/Data/Num/Prime.lean
+++ b/Mathlib/Data/Num/Prime.lean
@@ -99,7 +99,7 @@ instance decidablePrime : DecidablePred PosNum.Prime
         refine Nat.prime_def_minFac.trans ((and_iff_right ?_).trans ?_)
         · simp only [cast_bit1]
           have := to_nat_pos n
-          omega
+          lia
         rw [← minFac_to_nat, to_nat_inj]; rfl
 
 end PosNum

--- a/Mathlib/Data/Num/ZNum.lean
+++ b/Mathlib/Data/Num/ZNum.lean
@@ -546,7 +546,7 @@ theorem divMod_to_nat (d n : PosNum) :
     simp only at IH ⊢
     apply divMod_to_nat_aux <;> simp only [Num.cast_bit1, cast_bit1]
     · rw [← two_mul, ← two_mul, add_right_comm, mul_left_comm, ← mul_add, IH.1]
-    · omega
+    · lia
   | bit0 n IH =>
     unfold divMod
     -- Porting note: `cases'` didn't rewrite at `this`, so `revert` & `intro` are required.

--- a/Mathlib/Data/Ordmap/Ordset.lean
+++ b/Mathlib/Data/Ordmap/Ordset.lean
@@ -188,8 +188,8 @@ theorem Valid'.node4L {l} {x : α} {m} {y : α} {r o₁ o₂} (hl : Valid' o₁ 
     rw [hm.2.size_eq] at lr₁ lr₂ mr₁ mr₂
     by_cases mm : size ml + size mr ≤ 1
     · dsimp [delta, ratio] at lr₁ mr₁
-      have r1 : r.size = 1 := by omega
-      have l1 : l.size = 1 := by omega
+      have r1 : r.size = 1 := by lia
+      have l1 : l.size = 1 := by lia
       rw [r1, add_assoc] at lr₁
       rw [l1, r1]
       revert mm; cases size ml <;> cases size mr <;> intro mm
@@ -239,10 +239,10 @@ theorem Valid'.rotateL {l} {x : α} {r o₁ o₂} (hl : Valid' o₁ l x) (hr : V
   rw [hr.2.size_eq] at H3
   replace H3 : 2 * (size rl + size rr) ≤ 9 * size l + 3 ∨ size rl + size rr ≤ 2 :=
     H3.imp (@Nat.le_of_add_le_add_right _ 2 _) Nat.le_of_succ_le_succ
-  have H3_0 (l0 : size l = 0) : size rl + size rr ≤ 2 := by omega
+  have H3_0 (l0 : size l = 0) : size rl + size rr ≤ 2 := by lia
   have H3p : size l > 0 → 2 * (size rl + size rr) ≤ 9 * size l + 3 := fun l0 : 1 ≤ size l =>
     (or_iff_left_of_imp <| by lia).1 H3
-  have ablem : ∀ {a b : ℕ}, 1 ≤ a → a + b ≤ 2 → b ≤ 1 := by omega
+  have ablem : ∀ {a b : ℕ}, 1 ≤ a → a + b ≤ 2 → b ≤ 1 := by lia
   have hlp : size l > 0 → ¬size rl + size rr ≤ 1 := fun l0 hb =>
     absurd (le_trans (le_trans (Nat.mul_le_mul_left _ l0) H2) hb) (by decide)
   rw [Ordnode.rotateL_node]; split_ifs with h

--- a/Mathlib/Data/PNat/Xgcd.lean
+++ b/Mathlib/Data/PNat/Xgcd.lean
@@ -234,7 +234,7 @@ theorem start_v (a b : ℕ+) : (start a b).v = ⟨a, b⟩ := by
   rw [one_mul, one_mul, zero_mul, zero_mul]
   have := a.pos
   have := b.pos
-  congr <;> omega
+  congr <;> lia
 
 /-- `finish` happens when the reducing process ends. -/
 def finish : XgcdType :=

--- a/Mathlib/Data/Rat/Defs.lean
+++ b/Mathlib/Data/Rat/Defs.lean
@@ -152,7 +152,7 @@ variable (a b c : ℚ)
 lemma divInt_one_one : 1 /. 1 = 1 := by rw [divInt_one, Rat.intCast_one]
 
 protected theorem zero_ne_one : 0 ≠ (1 : ℚ) := by
-  rw [ne_comm, ← divInt_one_one, divInt_ne_zero] <;> omega
+  rw [ne_comm, ← divInt_one_one, divInt_ne_zero] <;> lia
 
 attribute [simp] mkRat_eq_zero
 

--- a/Mathlib/Data/Seq/Basic.lean
+++ b/Mathlib/Data/Seq/Basic.lean
@@ -535,7 +535,7 @@ theorem drop_length' {n : ℕ} {s : Seq α} :
       convert drop_length' using 1
       generalize s.length' = m
       enat_to_nat
-      omega
+      lia
 
 theorem take_drop {s : Seq α} {n m : ℕ} :
     (s.take n).drop m = (s.drop m).take (n - m) := by
@@ -947,7 +947,7 @@ theorem at_least_as_long_as_coind {a : Seq α} {b : Seq β}
     simp only [drop_length', length'_of_terminates ha, tsub_self, length'_cons] at ha'
     generalize a_tl.length' = u at ha'
     enat_to_nat
-    omega
+    lia
 
 instance : Functor Seq where map := @map
 

--- a/Mathlib/Data/Seq/Basic.lean
+++ b/Mathlib/Data/Seq/Basic.lean
@@ -829,16 +829,16 @@ theorem Pairwise.cons {R : α → α → Prop} {hd : α} {tl : Seq α}
     | zero =>
       simp only [get?_cons_zero, Option.mem_def, Option.some.injEq] at hx
       exact hx ▸ all_get h_hd hy
-    | succ n => exact h_tl n k (by omega) x hx y hy
+    | succ n => exact h_tl n k (by lia) x hx y hy
 
 theorem Pairwise.cons_elim {R : α → α → Prop} {hd : α} {tl : Seq α}
     (h : Pairwise R (.cons hd tl)) : (∀ x ∈ tl, R hd x) ∧ Pairwise R tl := by
   simp only [Pairwise] at *
-  refine ⟨?_, fun i j h_ij ↦ h (i + 1) (j + 1) (by omega)⟩
+  refine ⟨?_, fun i j h_ij ↦ h (i + 1) (j + 1) (by lia)⟩
   intro x hx
   rw [mem_iff_exists_get?] at hx
   obtain ⟨n, hx⟩ := hx
-  simpa [← hx] using h 0 (n + 1) (by omega)
+  simpa [← hx] using h 0 (n + 1) (by lia)
 
 @[simp]
 theorem Pairwise_cons_nil {R : α → α → Prop} {hd : α} : Pairwise R (cons hd nil) := by
@@ -893,7 +893,7 @@ theorem Pairwise.coind_trans {R : α → α → Prop} [IsTrans α R] {s : Seq α
   induction k generalizing y with
   | zero => exact h_succ hx hy
   | succ k ih =>
-    obtain ⟨z, hz⟩ := ge_stable (m := i + k + 1) _ (by omega) hy
+    obtain ⟨z, hz⟩ := ge_stable (m := i + k + 1) _ (by lia) hy
     exact _root_.trans (ih z hz) <| h_succ hz hy
 
 theorem Pairwise_tail {R : α → α → Prop} {s : Seq α} (h : s.Pairwise R) :

--- a/Mathlib/Data/Vector/Basic.lean
+++ b/Mathlib/Data/Vector/Basic.lean
@@ -530,7 +530,7 @@ variable {a : α}
 def insertIdx (a : α) (i : Fin (n + 1)) (v : Vector α n) : Vector α (n + 1) :=
   ⟨v.1.insertIdx i a, by
     rw [List.length_insertIdx, v.2]
-    split <;> omega⟩
+    split <;> lia⟩
 
 theorem insertIdx_val {i : Fin (n + 1)} {v : Vector α n} :
     (v.insertIdx a i).val = v.val.insertIdx i.1 a :=

--- a/Mathlib/Data/Vector3.lean
+++ b/Mathlib/Data/Vector3.lean
@@ -180,7 +180,7 @@ theorem append_insert (a : α) (t : Vector3 α m) (v : Vector3 α n) (i : Fin2 (
     insert a (t +-+ v) (Eq.recOn e (i.add m)) = Eq.recOn e (t +-+ insert a v i) := by
   refine Vector3.recOn t (fun e => ?_) (@fun k b t IH _ => ?_) e
   · rfl
-  have e' : (n + 1) + k = (n + k) + 1 := by omega
+  have e' : (n + 1) + k = (n + k) + 1 := by lia
   change
     insert a (b :: t +-+ v)
       (Eq.recOn (congr_arg (· + 1) e' : _ + 1 = _) (fs (add i k))) =

--- a/Mathlib/Geometry/Euclidean/Altitude.lean
+++ b/Mathlib/Geometry/Euclidean/Altitude.lean
@@ -98,7 +98,7 @@ theorem finrank_direction_altitude {n : ℕ} [NeZero n] (s : Simplex ℝ P n) (i
     (vectorSpan_mono ℝ (Set.image_subset_range s.points {i}ᶜ))
   have hn : (n - 1) + 1 = n := by
     have := NeZero.ne n
-    cases n <;> omega
+    cases n <;> lia
   have hc : #({i}ᶜ) = (n - 1) + 1 := by
     rw [card_compl, card_singleton, Fintype.card_fin, hn, add_tsub_cancel_right]
   refine add_left_cancel (_root_.trans h ?_)

--- a/Mathlib/GroupTheory/Coxeter/Basic.lean
+++ b/Mathlib/GroupTheory/Coxeter/Basic.lean
@@ -442,7 +442,7 @@ lemma listTake_alternatingWord (i j : B) (p k : ℕ) (h : k < 2 * p) :
     | zero =>
       simp only [take_zero, Even.zero, ↓reduceIte, alternatingWord]
     | succ k h' =>
-      have hk : k < 2 * p := by omega
+      have hk : k < 2 * p := by lia
       apply h' at hk
       by_cases h_even : Even k
       · simp only [h_even, ↓reduceIte] at hk

--- a/Mathlib/GroupTheory/Coxeter/Length.lean
+++ b/Mathlib/GroupTheory/Coxeter/Length.lean
@@ -252,7 +252,7 @@ theorem not_isReduced_alternatingWord (i i' : B) {m : ℕ} (hM : M i i' ≠ 0) (
       lia
     have : M i i' + 1 ≤ M i i' * 2 := by linarith [Nat.one_le_iff_ne_zero.mpr hM]
     rw [cs.prod_alternatingWord_eq_prod_alternatingWord_sub i i' _ this]
-    have : M i i' * 2 - (M i i' + 1) = M i i' - 1 := by omega
+    have : M i i' * 2 - (M i i' + 1) = M i i' - 1 := by lia
     rw [this]
     calc
       ℓ (π (alternatingWord i' i (M i i' - 1)))

--- a/Mathlib/GroupTheory/OrderOfElement.lean
+++ b/Mathlib/GroupTheory/OrderOfElement.lean
@@ -302,7 +302,7 @@ theorem exists_pow_eq_self_of_coprime (h : n.Coprime (orderOf x)) : ∃ m : ℕ,
     exact ⟨1, by rw [h, pow_one, pow_one]⟩
   by_cases h1 : orderOf x = 1
   · exact ⟨0, by rw [orderOf_eq_one_iff.mp h1, one_pow, one_pow]⟩
-  obtain ⟨m, -, h⟩ := exists_mul_mod_eq_one_of_coprime h (by omega)
+  obtain ⟨m, -, h⟩ := exists_mul_mod_eq_one_of_coprime h (by lia)
   exact ⟨m, by rw [← pow_mul, ← pow_mod_orderOf, h, pow_one]⟩
 
 /-- If `x^n = 1`, but `x^(n/p) ≠ 1` for all prime factors `p` of `n`,

--- a/Mathlib/GroupTheory/Perm/Centralizer.lean
+++ b/Mathlib/GroupTheory/Perm/Centralizer.lean
@@ -708,7 +708,7 @@ variable {α} in
 /-- The number of cycles of given length -/
 lemma card_of_cycleType_singleton {n : ℕ} (hn' : 2 ≤ n) (hα : n ≤ card α) :
     #({g | g.cycleType = {n}} : Finset (Perm α)) = (n - 1)! * (choose (card α) n) := by
-  have hn₀ : n ≠ 0 := by omega
+  have hn₀ : n ≠ 0 := by lia
   have aux : n ! = (n - 1)! * n := by rw [mul_comm, mul_factorial_pred hn₀]
   rw [mul_comm, ← Nat.mul_left_inj hn₀, mul_assoc, ← aux, ← Nat.mul_left_inj (factorial_ne_zero _),
     Nat.choose_mul_factorial_mul_factorial hα, mul_assoc]

--- a/Mathlib/GroupTheory/Perm/Cycle/Type.lean
+++ b/Mathlib/GroupTheory/Perm/Cycle/Type.lean
@@ -640,7 +640,7 @@ theorem _root_.card_support_eq_three_iff : #σ.support = 3 ↔ σ.IsThreeCycle :
     rw [IsThreeCycle, ← cons_erase hn, h1, h, ← cons_zero]
   obtain ⟨m, hm⟩ := exists_mem_of_ne_zero h1
   rw [← sum_cycleType, ← cons_erase hn, ← cons_erase hm, Multiset.sum_cons, Multiset.sum_cons] at h
-  have : ∀ {k}, 2 ≤ m → 2 ≤ n → n + (m + k) = 3 → False := by omega
+  have : ∀ {k}, 2 ≤ m → 2 ≤ n → n + (m + k) = 3 → False := by lia
   cases this (two_le_of_mem_cycleType (mem_of_mem_erase hm)) (two_le_of_mem_cycleType hn) h
 
 theorem isCycle (h : IsThreeCycle σ) : IsCycle σ := by

--- a/Mathlib/GroupTheory/SpecificGroups/Alternating/Centralizer.lean
+++ b/Mathlib/GroupTheory/SpecificGroups/Alternating/Centralizer.lean
@@ -138,7 +138,7 @@ open Basis OnCycleFactors
 theorem card_le_of_centralizer_le_alternating (h : Subgroup.centralizer {g} ≤ alternatingGroup α) :
     Fintype.card α ≤ g.cycleType.sum + 1 := by
   by_contra! hm
-  replace hm : 2 + g.cycleType.sum ≤ Fintype.card α := by omega
+  replace hm : 2 + g.cycleType.sum ≤ Fintype.card α := by lia
   suffices 1 < Fintype.card (Function.fixedPoints g) by
     obtain ⟨a, b, hab⟩ := Fintype.exists_pair_of_one_lt_card this
     suffices sign (kerParam g ⟨swap a b, 1⟩) ≠ 1 from

--- a/Mathlib/LinearAlgebra/BilinearForm/Orthogonal.lean
+++ b/Mathlib/LinearAlgebra/BilinearForm/Orthogonal.lean
@@ -332,7 +332,7 @@ lemma orthogonal_orthogonal (hB : B.Nondegenerate) (hB₀ : B.IsRefl) (W : Submo
     B.orthogonal (B.orthogonal W) = W := by
   apply (eq_of_le_of_finrank_le (LinearMap.BilinForm.le_orthogonal_orthogonal hB₀) _).symm
   simp only [finrank_orthogonal hB hB₀]
-  omega
+  lia
 
 variable {W : Submodule K V}
 

--- a/Mathlib/LinearAlgebra/Dimension/RankNullity.lean
+++ b/Mathlib/LinearAlgebra/Dimension/RankNullity.lean
@@ -228,7 +228,7 @@ lemma Submodule.disjoint_ker_of_finrank_le [NoZeroSMulDivisors R M] {N : Type*} 
   rw [← LinearMap.range_domRestrict] at h
   have := (LinearMap.ker (f.domRestrict L)).finrank_quotient_add_finrank
   rw [LinearEquiv.finrank_eq (f.domRestrict L).quotKerEquivRange] at this
-  omega
+  lia
 
 end Finrank
 

--- a/Mathlib/LinearAlgebra/Eigenspace/Basic.lean
+++ b/Mathlib/LinearAlgebra/Eigenspace/Basic.lean
@@ -249,7 +249,7 @@ lemma genEigenrange_nat {f : End R M} {μ : R} {k : ℕ} :
   · intro h
     exact h _ le_rfl
   · rintro ⟨x, rfl⟩ i hi
-    have : k = i + (k - i) := by omega
+    have : k = i + (k - i) := by lia
     rw [this, pow_add]
     exact ⟨_, rfl⟩
 

--- a/Mathlib/LinearAlgebra/Eigenspace/Triangularizable.lean
+++ b/Mathlib/LinearAlgebra/Eigenspace/Triangularizable.lean
@@ -106,7 +106,7 @@ theorem iSup_maxGenEigenspace_eq_top [IsAlgClosed K] [FiniteDimensional K V] (f 
       rw [Module.End.genEigenspace_nat, Module.End.genEigenrange_nat]
       apply LinearMap.finrank_range_add_finrank_ker
     -- Therefore the dimension `ER` mus be smaller than `finrank K V`.
-    have h_dim_ER : finrank K ER < n.succ := by omega
+    have h_dim_ER : finrank K ER < n.succ := by lia
     -- This allows us to apply the induction hypothesis on `ER`:
     have ih_ER : ⨆ (μ : K), f'.maxGenEigenspace μ = ⊤ :=
       ih (finrank K ER) h_dim_ER f' rfl

--- a/Mathlib/LinearAlgebra/Matrix/Charpoly/Coeff.lean
+++ b/Mathlib/LinearAlgebra/Matrix/Charpoly/Coeff.lean
@@ -209,7 +209,7 @@ lemma det_one_add_smul (r : R) (M : Matrix n n R) :
 
 lemma charpoly_of_card_eq_two [Nontrivial R] (hn : Fintype.card n = 2) :
     M.charpoly = X ^ 2 - C M.trace * X + C M.det := by
-  have : Nonempty n := by rw [← Fintype.card_pos_iff]; omega
+  have : Nonempty n := by rw [← Fintype.card_pos_iff]; lia
   ext i
   by_cases hi : i ∈ Finset.range 3
   · fin_cases hi

--- a/Mathlib/LinearAlgebra/Matrix/Irreducible/Defs.lean
+++ b/Mathlib/LinearAlgebra/Matrix/Irreducible/Defs.lean
@@ -98,7 +98,7 @@ lemma IsIrreducible.exists_pos [Nontrivial n]
   have h_le : 1 ≤ p.length := Nat.succ_le_of_lt hp_pos
   have ⟨v, p₁, p₂, _hp_eq, hp₁_len⟩ := p.exists_eq_comp_of_le_length (n := 1) h_le
   have hlen_ne : p₁.length ≠ 0 := by simp [hp₁_len]
-  obtain ⟨c, p', e, rfl⟩ := (Quiver.Path.length_ne_zero_iff_eq_cons (p := p₁)).1 (by omega)
+  obtain ⟨c, p', e, rfl⟩ := (Quiver.Path.length_ne_zero_iff_eq_cons (p := p₁)).1 (by lia)
   obtain ⟨rfl⟩ : i = c := Quiver.Path.eq_of_length_zero p' (by aesop)
   exact (no_out _).false e
 

--- a/Mathlib/LinearAlgebra/Reflection.lean
+++ b/Mathlib/LinearAlgebra/Reflection.lean
@@ -210,7 +210,7 @@ lemma reflection_mul_reflection_pow_apply (m : ℕ) (z : M)
     set e : ℤ := m % 2
     simp_rw [add_assoc (2 * k), add_sub_assoc (2 * k), add_comm (2 * k),
       add_mul_ediv_left _ k (by simp : (2 : ℤ) ≠ 0)]
-    have he : e = 0 ∨ e = 1 := by omega
+    have he : e = 0 ∨ e = 1 := by lia
     clear_value e
     /- Now, equate the coefficients on both sides. These linear combinations were
     found using `polyrith`. -/
@@ -254,7 +254,7 @@ lemma reflection_mul_reflection_zpow_apply (m : ℤ) (z : M)
     have ht' : t = g x * f y - 2 := by rwa [mul_comm (g x)]
     rw [zpow_neg, ← inv_zpow, mul_inv_rev, reflection_inv, reflection_inv, zpow_natCast,
       reflection_mul_reflection_pow_apply hg hf m z t ht', add_right_comm z]
-    have aux (a b : ℤ) (hab : a + b = -3 := by omega) : a / 2 = -(b / 2) - 2 := by omega
+    have aux (a b : ℤ) (hab : a + b = -3 := by lia) : a / 2 = -(b / 2) - 2 := by lia
     rw [aux (-m - 3) m, aux (-m - 2) (m - 1), aux (-m - 1) (m - 2), aux (-m) (m - 3)]
     simp only [S_neg_sub_two, Polynomial.eval_neg]
     ring_nf

--- a/Mathlib/LinearAlgebra/RootSystem/Base.lean
+++ b/Mathlib/LinearAlgebra/RootSystem/Base.lean
@@ -535,7 +535,7 @@ lemma IsPos.add_zsmul {i j k : ι} {z : ℤ} (hij : i ≠ j)
     letI := P.indexNeg
     replace contra : i = -j := by rw [eq_comm, neg_eq_iff_eq_neg]; simpa using contra
     rw [contra, isPos_iff, height_reflectionPerm_self, height_one_of_mem_support hj] at hi
-    omega
+    lia
   induction z generalizing i k with
   | zero => simp_all
   | succ w hw =>
@@ -575,8 +575,8 @@ lemma IsPos.induction_on_add
     rw [P.zero_lt_pairingIn_iff'] at hj'
     rcases eq_or_ne i j with rfl | hij; · exact h₁ i hj
     obtain ⟨k, hk⟩ := P.root_sub_root_mem_of_pairingIn_pos hj' hij
-    have hkn : b.height k = n := by rw [b.height_sub hk, height_one_of_mem_support hj]; omega
-    have hkpos : b.IsPos k := by rw [isPos_iff']; omega
+    have hkn : b.height k = n := by rw [b.height_sub hk, height_one_of_mem_support hj]; lia
+    have hkpos : b.IsPos k := by rw [isPos_iff']; lia
     exact h₂ k j i (by rw [hk]; module) (ih hkpos hkn) hj
   | pred n ih =>
     rw [isPos_iff] at h₀

--- a/Mathlib/LinearAlgebra/RootSystem/Base.lean
+++ b/Mathlib/LinearAlgebra/RootSystem/Base.lean
@@ -599,7 +599,7 @@ lemma exists_eq_sum_and_forall_sum_mem_of_isPos {i : ι} (hi : b.IsPos i) :
     · have : m = (⟨m, hm⟩ : Fin n).castSucc := rfl
       rw [this, Fin.sum_Iic_castSucc]
       simp only [Fin.snoc_castSucc, h₄]
-    · replace hm : m = n := by omega
+    · replace hm : m = n := by lia
       replace hm : Finset.Iic m = Finset.univ := by ext; simp [hm, Fin.le_def, Fin.is_le]
       simp [hm, Fin.sum_univ_castSucc, ← h₃, ← h₁]
 

--- a/Mathlib/LinearAlgebra/RootSystem/Chain.lean
+++ b/Mathlib/LinearAlgebra/RootSystem/Chain.lean
@@ -190,7 +190,7 @@ lemma root_sub_zsmul_mem_range_iff {z : ℤ} :
     P.root j - z • P.root i ∈ range P.root ↔
       z ∈ Icc (-P.chainTopCoeff i j : ℤ) (P.chainBotCoeff i j) := by
   rw [sub_eq_add_neg, ← neg_smul, P.root_add_zsmul_mem_range_iff h, mem_Icc, mem_Icc]
-  omega
+  lia
 
 lemma setOf_root_add_zsmul_mem_eq_Icc :
     {k : ℤ | P.root j + k • P.root i ∈ range P.root} =
@@ -232,7 +232,7 @@ private lemma chainCoeff_reflectionPerm_left_aux :
     ext z
     rw [← P.root_add_zsmul_mem_range_iff h', indexNeg_neg, root_reflectionPerm, mem_Icc,
       reflection_apply_self, smul_neg, ← neg_smul, P.root_add_zsmul_mem_range_iff h, mem_Icc]
-    omega
+    lia
   · have h' : ¬ LinearIndependent R ![P.root (-i), P.root j] := by simpa
     simp only [chainTopCoeff_of_not_linearIndependent h, chainTopCoeff_of_not_linearIndependent h',
       chainBotCoeff_of_not_linearIndependent h, chainBotCoeff_of_not_linearIndependent h']
@@ -428,7 +428,7 @@ lemma chainBotCoeff_sub_chainTopCoeff :
     rw [← root_reflectionPerm]
     exact mem_range_self _
   rw [h₁, root_add_zsmul_mem_range_iff h, mem_Icc] at h₂
-  omega
+  lia
 
 lemma chainTopCoeff_sub_chainBotCoeff :
     P.chainTopCoeff i j - P.chainBotCoeff i j = -P.pairingIn ℤ j i := by

--- a/Mathlib/LinearAlgebra/RootSystem/Finite/G2.lean
+++ b/Mathlib/LinearAlgebra/RootSystem/Finite/G2.lean
@@ -185,7 +185,7 @@ lemma chainBotCoeff_if_one_zero [P.IsNotG2] (h : P.root i + P.root j ∈ range P
   rcases eq_or_ne (P.chainBotCoeff i j) (P.chainTopCoeff i j) with aux₄ | aux₄ <;>
   simp_rw [P.pairingIn_eq_zero_iff (i := i) (j := j), ← P.chainBotCoeff_sub_chainTopCoeff aux₁,
     sub_eq_zero, Nat.cast_inj, aux₄, reduceIte] <;>
-  omega
+  lia
 
 lemma chainTopCoeff_if_one_zero [P.IsNotG2] (h : P.root i - P.root j ∈ range P.root) :
     P.chainTopCoeff i j = if P.pairingIn ℤ i j = 0 then 1 else 0 := by

--- a/Mathlib/LinearAlgebra/RootSystem/Finite/Lemmas.lean
+++ b/Mathlib/LinearAlgebra/RootSystem/Finite/Lemmas.lean
@@ -137,7 +137,7 @@ lemma RootPositiveForm.rootLength_le_of_pairingIn_eq (B : P.RootPositiveForm ℤ
   have h' := B.pairingIn_mul_eq_pairingIn_mul_swap i j
   have hi := B.rootLength_pos i
   rcases h with hij' | hij' | hij' | hij' | hij' | hij' | hij' | hij' <;>
-  rw [hij'.1, hij'.2] at h' <;> omega
+  rw [hij'.1, hij'.2] at h' <;> lia
 
 variable {P} in
 lemma RootPositiveForm.rootLength_lt_of_pairingIn_notMem
@@ -156,7 +156,7 @@ lemma RootPositiveForm.rootLength_lt_of_pairingIn_notMem
   have aux₂ := B.pairingIn_mul_eq_pairingIn_mul_swap i j
   have hi := B.rootLength_pos i
   rcases aux₁ with hji | hji <;> rcases hij' with hij' | hij' | hij' | hij' | hij' | hij' <;>
-  rw [hji, hij'] at aux₂ <;> omega
+  rw [hji, hij'] at aux₂ <;> lia
 
 @[deprecated (since := "2025-05-23")]
 alias RootPositiveForm.rootLength_lt_of_pairingIn_nmem :=

--- a/Mathlib/LinearAlgebra/RootSystem/Finite/Nondegenerate.lean
+++ b/Mathlib/LinearAlgebra/RootSystem/Finite/Nondegenerate.lean
@@ -294,7 +294,7 @@ lemma ker_rootForm_eq_dualAnnihilator :
   have aux0 := Subspace.finrank_add_finrank_dualAnnihilator_eq (P.corootSpan R)
   have aux1 := Submodule.finrank_add_eq_of_isCompl P.isCompl_rootSpan_ker_rootForm
   rw [← P.finrank_corootSpan_eq', P.toPerfPair.finrank_eq, Subspace.dual_finrank_eq] at aux1
-  omega
+  lia
 
 lemma ker_corootForm_eq_dualAnnihilator :
     LinearMap.ker P.CorootForm = (P.rootSpan R).dualAnnihilator.map P.flip.toPerfPair.symm :=

--- a/Mathlib/LinearAlgebra/RootSystem/GeckConstruction/Lemmas.lean
+++ b/Mathlib/LinearAlgebra/RootSystem/GeckConstruction/Lemmas.lean
@@ -196,7 +196,7 @@ lemma chainBotCoeff_mul_chainTopCoeff.isNotG2 : P.IsNotG2 := by
     (b.root_ne_neg_of_ne hj hi hij.symm)
   subst s
   simp only [mem_insert_iff, mem_singleton_iff] at h₀ h₁ h₂ h₃ hA
-  rcases hA with hA | hA | hA | hA | hA <;> rw [hA] at h₀ h₁ h₂ h₃ <;> omega
+  rcases hA with hA | hA | hA | hA | hA <;> rw [hA] at h₀ h₁ h₂ h₃ <;> lia
 
 /- An auxiliary result en route to `RootPairing.chainBotCoeff_mul_chainTopCoeff`. -/
 private lemma chainBotCoeff_mul_chainTopCoeff.aux_1
@@ -243,7 +243,7 @@ private lemma chainBotCoeff_mul_chainTopCoeff.aux_1
       simp
     have hn₂ : P.pairingIn ℤ n k ≤ 0 := by
       by_contra! contra; exact hnk_notMem <| P.root_sub_root_mem_of_pairingIn_pos contra hnk_ne
-    omega
+    lia
   have key₄ : P.pairingIn ℤ l j = 1 := by
     have hij : P.pairing i j = 0 := by
       rw [pairing_eq_zero_iff, ← P.algebraMap_pairingIn ℤ, aux₁, map_zero]
@@ -254,7 +254,7 @@ private lemma chainBotCoeff_mul_chainTopCoeff.aux_1
     apply algebraMap_injective ℤ R
     rw [algebraMap_pairingIn, ← root_coroot_eq_pairing, ← h₁]
     simp [hkj, hij]
-  replace key₄ : P.pairingIn ℤ j l ≠ 0 := by rw [ne_eq, P.pairingIn_eq_zero_iff]; omega
+  replace key₄ : P.pairingIn ℤ j l ≠ 0 := by rw [ne_eq, P.pairingIn_eq_zero_iff]; lia
   /- Calculate the value of each of the four terms in the goal. -/
   have hik_mem : P.root i + P.root k ∈ range P.root := ⟨l, by rw [← h₁, add_comm]⟩
   simp only [P.chainBotCoeff_if_one_zero, hik_mem, him_mem, hjl_mem, hjk_mem]

--- a/Mathlib/Logic/Equiv/Finset.lean
+++ b/Mathlib/Logic/Equiv/Finset.lean
@@ -88,7 +88,7 @@ theorem raise_lower' : ∀ {l n}, (∀ m ∈ l, n ≤ m) → List.SortedLT l →
 theorem isChain_raise' : ∀ (l) (n), List.IsChain (· < ·) (raise' l n)
   | [], _ => .nil
   | [_], _ => .singleton _
-  | _ :: _ :: _, _ => .cons_cons (by omega) (isChain_raise' (_ :: _) _)
+  | _ :: _ :: _, _ => .cons_cons (by lia) (isChain_raise' (_ :: _) _)
 
 theorem isChain_cons_raise' (l m) : List.IsChain (· < ·) (m :: raise' l (m + 1)) :=
   isChain_raise' (m :: l) 0

--- a/Mathlib/MeasureTheory/Function/AbsolutelyContinuous.lean
+++ b/Mathlib/MeasureTheory/Function/AbsolutelyContinuous.lean
@@ -335,13 +335,13 @@ theorem boundedVariationOn (hf : AbsolutelyContinuousOnInterval f a b) :
           constructor <;> exact this (hp₂ _)
         · rw [PairwiseDisjoint]
           convert hp₁.pairwise_disjoint_on_Ioc_succ.set_pairwise (Finset.range p.1) using 3
-          rw [uIoc_of_le (hp₁ (by omega)), Nat.succ_eq_succ]
+          rw [uIoc_of_le (hp₁ (by lia)), Nat.succ_eq_succ]
       · suffices p.2.val p.1 - p.2.val 0 < δ by
           convert this
           rw [← Finset.sum_range_sub]
           congr; ext i
           rw [dist_comm, Real.dist_eq, abs_eq_self.mpr]
-          linarith [@hp₁ i (i + 1) (by omega)]
+          linarith [@hp₁ i (i + 1) (by lia)]
         linarith [mem_Icc.mp (hp₂ p.1), mem_Icc.mp (hp₂ 0)]
     -- Reduce edist in the goal to dist and clear up
     have veq: (∑ i ∈ Finset.range p.1, edist (f (p.2.val (i + 1))) (f (p.2.val i))).toReal =
@@ -362,10 +362,10 @@ theorem boundedVariationOn (hf : AbsolutelyContinuousOnInterval f a b) :
     fun hC ↦ by simp [hC] at this
   -- Verify that `[a + i * δ', a + (i + 1) * δ']` is indeed a subinterval of `[a, b]`
   apply v_each
-  · convert h_mono (show 0 ≤ i by omega); simp
-  · convert h_mono (show i ≤ i + 1 by omega); norm_cast
+  · convert h_mono (show 0 ≤ i by lia); simp
+  · convert h_mono (show i ≤ i + 1 by lia); norm_cast
   · rw [add_mul, ← add_assoc]; simpa
-  · convert h_mono (show i + 1 ≤ n + 1 by omega)
+  · convert h_mono (show i + 1 ≤ n + 1 by lia)
     · norm_cast
     · simp only [Nat.cast_add, Nat.cast_one, δ']; field
 

--- a/Mathlib/MeasureTheory/Measure/Hausdorff.lean
+++ b/Mathlib/MeasureTheory/Measure/Hausdorff.lean
@@ -214,7 +214,7 @@ theorem borel_le_caratheodory (hm : IsMetric μ) : borel X ≤ μ.caratheodory :
       fun h => (this j i h).symm.mono (fun x hx => by exact ⟨hx.1.1, hx.2⟩) inter_subset_left
   intro i j hj
   have A : ((↑(2 * j + r))⁻¹ : ℝ≥0∞) < (↑(2 * i + 1 + r))⁻¹ := by
-    rw [ENNReal.inv_lt_inv, Nat.cast_lt]; omega
+    rw [ENNReal.inv_lt_inv, Nat.cast_lt]; lia
   refine ⟨(↑(2 * i + 1 + r))⁻¹ - (↑(2 * j + r))⁻¹, by simpa [tsub_eq_zero_iff_le] using A,
     fun x hx y hy => ?_⟩
   have : infEdist y t < (↑(2 * j + r))⁻¹ := not_le.1 fun hle => hy.2 ⟨hy.1, hle⟩

--- a/Mathlib/MeasureTheory/OuterMeasure/Basic.lean
+++ b/Mathlib/MeasureTheory/OuterMeasure/Basic.lean
@@ -192,7 +192,7 @@ theorem iUnion_nat_of_monotone_of_tsum_ne_top (m : OuterMeasure α) {s : ℕ →
   clear hx i
   rcases le_or_gt j n with hjn | hnj
   · exact Or.inl (h' hjn hj)
-  have : j - (n + 1) + n + 1 = j := by omega
+  have : j - (n + 1) + n + 1 = j := by lia
   refine Or.inr (mem_iUnion.2 ⟨j - (n + 1), ?_, hlt _ ?_⟩)
   · rwa [this]
   · rw [← Nat.succ_le_iff, Nat.succ_eq_add_one, this]

--- a/Mathlib/NumberTheory/ArithmeticFunction/Misc.lean
+++ b/Mathlib/NumberTheory/ArithmeticFunction/Misc.lean
@@ -407,7 +407,7 @@ theorem sum_Ioc_mul_eq_sum_sum (f g : ArithmeticFunction R) (N : ℕ) :
   intro _
   constructor
   · intro ⟨_, h⟩
-    grw [← h, Nat.mul_div_cancel_left _ (by omega)]
+    grw [← h, Nat.mul_div_cancel_left _ (by lia)]
   · intro hm
     grw [hm]
     simp [mul_div_le, div_le_self]

--- a/Mathlib/NumberTheory/ClassNumber/AdmissibleCardPowDegree.lean
+++ b/Mathlib/NumberTheory/ClassNumber/AdmissibleCardPowDegree.lean
@@ -107,7 +107,7 @@ theorem exists_approx_polynomial {b : Fq[X]} (hb : b ≠ 0) {ε : ℝ} (hε : 0 
     exact mul_pos (Int.cast_pos.mpr (AbsoluteValue.pos _ hb)) hε
   have one_lt_q : 1 < Fintype.card Fq := Fintype.one_lt_card
   have one_lt_q' : (1 : ℝ) < Fintype.card Fq := by assumption_mod_cast
-  have q_pos : 0 < Fintype.card Fq := by omega
+  have q_pos : 0 < Fintype.card Fq := by lia
   have q_pos' : (0 : ℝ) < Fintype.card Fq := by assumption_mod_cast
   -- If `b` is already small enough, then the remainders are equal and we are done.
   by_cases! le_b : b.natDegree ≤ ⌈-log ε / log (Fintype.card Fq)⌉₊

--- a/Mathlib/NumberTheory/DiophantineApproximation/Basic.lean
+++ b/Mathlib/NumberTheory/DiophantineApproximation/Basic.lean
@@ -396,7 +396,7 @@ private theorem aux₁ : 0 < fract ξ := by
     norm_cast
     rw [← zero_add (1 : ℤ), add_one_le_iff, abs_pos, sub_ne_zero]
     rintro rfl
-    cases isUnit_iff.mp (isCoprime_self.mp (IsCoprime.mul_left_iff.mp hcop).2) <;> omega
+    cases isUnit_iff.mp (isCoprime_self.mp (IsCoprime.mul_left_iff.mp hcop).2) <;> lia
   norm_cast at H
   linarith only [hv, H]
 

--- a/Mathlib/NumberTheory/FLT/Four.lean
+++ b/Mathlib/NumberTheory/FLT/Four.lean
@@ -189,7 +189,7 @@ theorem not_minimal {a b c : ℤ} (h : Minimal a b c) (ha2 : a % 2 = 1) (hc : 0 
   have h4 : 0 < m := by
     apply lt_of_le_of_ne ht6
     rintro rfl
-    omega
+    lia
   obtain ⟨r, s, _, htt2, htt3, htt4, htt5, htt6⟩ := htt.coprime_classification' h3 ha2 h4
   -- Now use the fact that (b / 2) ^ 2 = m * r * s, and m, r and s are pairwise coprime to obtain
   -- i, j and k such that m = i ^ 2, r = j ^ 2 and s = k ^ 2.

--- a/Mathlib/NumberTheory/FLT/Polynomial.lean
+++ b/Mathlib/NumberTheory/FLT/Polynomial.lean
@@ -185,7 +185,7 @@ private theorem Polynomial.flt_catalan_aux
       · apply (isCoprime_expand chn0).mp
         rwa [← eq_a, ← eq_b]
       · have _ : ch ≠ 1 := CharP.ringChar_ne_one
-        have hch2 : 2 ≤ ch := by omega
+        have hch2 : 2 ≤ ch := by lia
         rw [← add_le_add_iff_right 1, ← eq_d, eq_deg_a]
         grw [← hch2]
         lia
@@ -247,7 +247,7 @@ theorem fermatLastTheoremWith'_polynomial {n : ℕ} (hn : 3 ≤ n) (chn : (n : k
   rw [eq_a, eq_b, mul_pow, mul_pow, ← mul_add] at heq
   have hdc : d ∣ c := by
     -- TODO: This is basically reproving `IsIntegrallyClosed.pow_dvd_pow_iff`
-    have hn : 0 < n := by omega
+    have hn : 0 < n := by lia
     have hdncn : d ^ n ∣ c ^ n := ⟨_, heq.symm⟩
     simpa [dvd_iff_normalizedFactors_le_normalizedFactors, Multiset.le_iff_count, *] using hdncn
   obtain ⟨c', eq_c⟩ := hdc

--- a/Mathlib/NumberTheory/FLT/Three.lean
+++ b/Mathlib/NumberTheory/FLT/Three.lean
@@ -652,7 +652,7 @@ private lemma formula2 :
   simp only [zero_mul, add_mul]
   rw [← formula1 S]
   congrm ?_ + ?_ + ?_
-  · have : (S.multiplicity-1)*3+1 = 3*S.multiplicity-2 := by have := S.two_le_multiplicity; omega
+  · have : (S.multiplicity-1)*3+1 = 3*S.multiplicity-2 := by have := S.two_le_multiplicity; lia
     calc _ = S.X^3 *(S.u₂*S.u₂⁻¹)*(η^3*S.u₁)*(λ^((S.multiplicity-1)*3)*λ) := by push_cast; ring
     _ = S.X^3*S.u₁*λ^(3*S.multiplicity-2) := by simp [hζ.toInteger_cube_eq_one, ← pow_succ, this]
   · ring
@@ -664,7 +664,7 @@ private lemma formula2 :
 set_option linter.style.commandStart false in
 private lemma lambda_sq_div_u₅_mul : λ ^ 2 ∣ S.u₅ * (λ ^ (S.multiplicity - 1) * S.X) ^ 3 := by
   use λ^(3*S.multiplicity-5)*S.u₅*(S.X^3)
-  have : 3*(S.multiplicity-1) = 2+(3*S.multiplicity-5) := by have := S.two_le_multiplicity; omega
+  have : 3*(S.multiplicity-1) = 2+(3*S.multiplicity-5) := by have := S.two_le_multiplicity; lia
   calc _ = λ^(3*(S.multiplicity-1))*S.u₅*S.X^3 := by ring
   _ = λ^2*λ^(3*S.multiplicity-5)*S.u₅*S.X^3 := by rw [this, pow_add]
   _ = λ^2*(λ^(3*S.multiplicity-5)*S.u₅*S.X^3) := by ring

--- a/Mathlib/NumberTheory/FermatPsp.lean
+++ b/Mathlib/NumberTheory/FermatPsp.lean
@@ -199,7 +199,7 @@ private theorem psp_from_prime_psp {b : ℕ} (b_ge_two : 2 ≤ b) {p : ℕ} (p_p
   have hi_A : 1 < A := a_id_helper (Nat.succ_le_iff.mp b_ge_two) (Nat.Prime.one_lt p_prime)
   have hi_B : 1 < B := b_id_helper (Nat.succ_le_iff.mp b_ge_two) p_gt_two
   have hi_AB : 1 < A * B := one_lt_mul'' hi_A hi_B
-  have hi_b : 0 < b := by omega
+  have hi_b : 0 < b := by lia
   have hi_p : 1 ≤ p := Nat.one_le_of_lt p_gt_two
   have hi_bsquared : 0 < b ^ 2 - 1 := by
     have := Nat.pow_le_pow_left b_ge_two 2
@@ -313,7 +313,7 @@ private theorem psp_from_prime_gt_p {b : ℕ} (b_ge_two : 2 ≤ b) {p : ℕ} (p_
   suffices h : p < (b ^ 2) ^ (p - 1) by gcongr
   rw [← pow_mul, Nat.mul_sub_left_distrib, mul_one]
   have : 2 ≤ 2 * p - 2 := le_tsub_of_add_le_left (show 4 ≤ 2 * p by lia)
-  have : 2 + p ≤ 2 * p := by omega
+  have : 2 + p ≤ 2 * p := by lia
   have : p ≤ 2 * p - 2 := le_tsub_of_add_le_left this
   exact this.trans_lt (Nat.lt_pow_self b_ge_two)
 
@@ -336,7 +336,7 @@ theorem exists_infinite_pseudoprimes {b : ℕ} (h : 1 ≤ b) (m : ℕ) :
     have h₂ : 4 ≤ b ^ 2 := pow_le_pow_left' b_ge_two 2
     have h₃ : 0 < b ^ 2 - 1 := tsub_pos_of_lt (lt_of_lt_of_le (by simp) h₂)
     have h₄ : 0 < b * (b ^ 2 - 1) := mul_pos h₁ h₃
-    have h₅ : b * (b ^ 2 - 1) < p := by omega
+    have h₅ : b * (b ^ 2 - 1) < p := by lia
     have h₆ : ¬p ∣ b * (b ^ 2 - 1) := Nat.not_dvd_of_pos_of_lt h₄ h₅
     have h₇ : b ≤ b * (b ^ 2 - 1) := Nat.le_mul_of_pos_right _ h₃
     have h₈ : 2 ≤ b * (b ^ 2 - 1) := le_trans b_ge_two h₇
@@ -349,7 +349,7 @@ theorem exists_infinite_pseudoprimes {b : ℕ} (h : 1 ≤ b) (m : ℕ) :
   -- If `¬2 ≤ b`, then `b = 1`. Since all composite numbers are pseudoprimes to base 1, we can pick
   -- any composite number greater than m. We choose `2 * (m + 2)` because it is greater than `m` and
   -- is composite for all natural numbers `m`.
-  · have h₁ : b = 1 := by omega
+  · have h₁ : b = 1 := by lia
     rw [h₁]
     use 2 * (m + 2)
     have : ¬Nat.Prime (2 * (m + 2)) := Nat.not_prime_mul (by lia) (by lia)

--- a/Mathlib/NumberTheory/FermatPsp.lean
+++ b/Mathlib/NumberTheory/FermatPsp.lean
@@ -203,7 +203,7 @@ private theorem psp_from_prime_psp {b : ℕ} (b_ge_two : 2 ≤ b) {p : ℕ} (p_p
   have hi_p : 1 ≤ p := Nat.one_le_of_lt p_gt_two
   have hi_bsquared : 0 < b ^ 2 - 1 := by
     have := Nat.pow_le_pow_left b_ge_two 2
-    omega
+    lia
   have hi_bpowtwop : 1 ≤ b ^ (2 * p) := Nat.one_le_pow (2 * p) b hi_b
   have hi_bpowpsubone : 1 ≤ b ^ (p - 1) := Nat.one_le_pow (p - 1) b hi_b
   -- Other useful facts

--- a/Mathlib/NumberTheory/FrobeniusNumber.lean
+++ b/Mathlib/NumberTheory/FrobeniusNumber.lean
@@ -215,7 +215,7 @@ theorem exists_frobeniusNumber_iff {s : Set ℕ} :
   mp := fun ⟨n, hn⟩ ↦ by
     rw [frobeniusNumber_iff] at hn
     exact ⟨dvd_one.mp <| Nat.dvd_add_iff_right (setGcd_dvd_of_mem_closure (hn.2 (n + 1)
-      (by omega))) (n := 1) |>.mpr (setGcd_dvd_of_mem_closure (hn.2 (n + 2) (by omega))),
+      (by lia))) (n := 1) |>.mpr (setGcd_dvd_of_mem_closure (hn.2 (n + 2) (by lia))),
       fun h ↦ hn.1 <| AddSubmonoid.closure_mono (Set.singleton_subset_iff.mpr h)
         (addSubmonoidClosure_one.ge ⟨⟩)⟩
   mpr h := by

--- a/Mathlib/NumberTheory/LSeries/HurwitzZetaValues.lean
+++ b/Mathlib/NumberTheory/LSeries/HurwitzZetaValues.lean
@@ -101,7 +101,7 @@ theorem cosZeta_two_mul_nat' (hk : k ≠ 0) (hx : x ∈ Icc (0 : ℝ) 1) :
   rw [cosZeta_two_mul_nat hk hx]
   congr 1
   have : (2 * k)! = (2 * k) * Complex.Gamma (2 * k) := by
-    rw [(by { norm_cast; omega } : 2 * (k : ℂ) = ↑(2 * k - 1) + 1), Complex.Gamma_nat_eq_factorial,
+    rw [(by { norm_cast; lia } : 2 * (k : ℂ) = ↑(2 * k - 1) + 1), Complex.Gamma_nat_eq_factorial,
       ← Nat.cast_add_one, ← Nat.cast_mul, ← Nat.factorial_succ, Nat.sub_add_cancel (by lia)]
   simp_rw [this, Gammaℂ, cpow_neg, ← div_div, div_inv_eq_mul, div_mul_eq_mul_div, div_div,
     mul_right_comm (2 : ℂ) (k : ℂ)]

--- a/Mathlib/NumberTheory/LSeries/RiemannZeta.lean
+++ b/Mathlib/NumberTheory/LSeries/RiemannZeta.lean
@@ -205,7 +205,7 @@ lemma two_mul_riemannZeta_eq_tsum_int_inv_pow_of_even {k : ℕ} (hk : 2 ≤ k) (
     2 * riemannZeta k = ∑' (n : ℤ), ((n : ℂ) ^ k)⁻¹ := by
   have hkk : 1 < k := by linarith
   rw [tsum_int_eq_zero_add_two_mul_tsum_pnat]
-  · have h0 : (0 ^ k : ℂ)⁻¹ = 0 := by simp; omega
+  · have h0 : (0 ^ k : ℂ)⁻¹ = 0 := by simp; lia
     norm_cast
     simp [h0, zeta_eq_tsum_one_div_nat_add_one_cpow (s := k) (by simp [hkk]),
       tsum_pnat_eq_tsum_succ (f := fun n => ((n : ℂ) ^ k)⁻¹)]

--- a/Mathlib/NumberTheory/LucasLehmer.lean
+++ b/Mathlib/NumberTheory/LucasLehmer.lean
@@ -110,7 +110,7 @@ lemma mersenne_mod_four {n : ℕ} (h : 2 ≤ n) : mersenne n % 4 = 3 := by
 
 lemma mersenne_mod_three {n : ℕ} (odd : Odd n) (h : 3 ≤ n) : mersenne n % 3 = 1 := by
   obtain ⟨k, rfl⟩ := odd
-  replace h : 1 ≤ k := by omega
+  replace h : 1 ≤ k := by lia
   induction k, h using Nat.le_induction with
   | base => rfl
   | succ j _ _ =>
@@ -644,7 +644,7 @@ theorem sModNat_eq_sMod (p k : ℕ) (hp : 2 ≤ p) : (sModNat (2 ^ p - 1) k : �
   have h1 := calc
     4 = 2 ^ 2 := by simp
     _ ≤ 2 ^ p := Nat.pow_le_pow_right (by simp) hp
-  have h2 : 1 ≤ 2 ^ p := by omega
+  have h2 : 1 ≤ 2 ^ p := by lia
   induction k with
   | zero =>
     rw [sModNat, sMod, Int.natCast_emod]

--- a/Mathlib/NumberTheory/LucasLehmer.lean
+++ b/Mathlib/NumberTheory/LucasLehmer.lean
@@ -466,7 +466,7 @@ lemma ω_pow_trace [Fact q.Prime] (odd : Odd q)
   have : (ω : X q) ^ ((q + 1) / 2) * ωb ^ ((q + 1) / 4) = -ωb ^ ((q + 1) / 4) := by
     rw [pow_ω odd leg3 leg2]
     ring
-  have div4 : (q + 1) / 2 = (q + 1) / 4 + (q + 1) / 4 := by rcases hq4 with ⟨k, hk⟩; omega
+  have div4 : (q + 1) / 2 = (q + 1) / 4 + (q + 1) / 4 := by rcases hq4 with ⟨k, hk⟩; lia
   rw [div4, pow_add, mul_assoc, ← mul_pow, ω_mul_ωb, one_pow, mul_one] at this
   rw [this]
   ring

--- a/Mathlib/NumberTheory/Modular.lean
+++ b/Mathlib/NumberTheory/Modular.lean
@@ -326,7 +326,7 @@ variable {z}
 theorem exists_eq_T_zpow_of_c_eq_zero (hc : g 1 0 = 0) :
     ∃ n : ℤ, ∀ z : ℍ, g • z = T ^ n • z := by
   have had := g.det_coe
-  replace had : g 0 0 * g 1 1 = 1 := by rw [det_fin_two, hc] at had; omega
+  replace had : g 0 0 * g 1 1 = 1 := by rw [det_fin_two, hc] at had; lia
   rcases Int.eq_one_or_neg_one_of_mul_eq_one' had with (⟨ha, hd⟩ | ⟨ha, hd⟩)
   · use g 0 1
     suffices g = T ^ g 0 1 by intro z; conv_lhs => rw [this]
@@ -340,7 +340,7 @@ theorem exists_eq_T_zpow_of_c_eq_zero (hc : g 1 0 = 0) :
 -- If `c = 1`, then `g` factorises into a product terms involving only `T` and `S`.
 theorem g_eq_of_c_eq_one (hc : g 1 0 = 1) : g = T ^ g 0 0 * S * T ^ g 1 1 := by
   have hg := g.det_coe.symm
-  replace hg : g 0 1 = g 0 0 * g 1 1 - 1 := by rw [det_fin_two, hc] at hg; omega
+  replace hg : g 0 1 = g 0 0 * g 1 1 - 1 := by rw [det_fin_two, hc] at hg; lia
   refine Subtype.ext ?_
   conv_lhs => rw [(g : Matrix _ _ ℤ).eta_fin_two]
   simp only [hg, sub_eq_add_neg, hc, coe_mul, coe_T_zpow, coe_S, mul_fin_two, mul_zero, mul_one,

--- a/Mathlib/NumberTheory/Modular.lean
+++ b/Mathlib/NumberTheory/Modular.lean
@@ -451,7 +451,7 @@ theorem abs_c_le_one (hz : z ∈ 𝒟ᵒ) (hg : g • z ∈ 𝒟ᵒ) : |g 1 0| �
   let c := (c' : ℝ)
   suffices 3 * c ^ 2 < 4 by
     rw [← Int.cast_pow, ← Int.cast_three, ← Int.cast_four, ← Int.cast_mul, Int.cast_lt] at this
-    replace this : c' ^ 2 ≤ 1 ^ 2 := by omega
+    replace this : c' ^ 2 ≤ 1 ^ 2 := by lia
     rwa [sq_le_sq, abs_one] at this
   suffices c ≠ 0 → 9 * c ^ 4 < 16 by
     rcases eq_or_ne c 0 with (hc | hc)

--- a/Mathlib/NumberTheory/PellMatiyasevic.lean
+++ b/Mathlib/NumberTheory/PellMatiyasevic.lean
@@ -836,7 +836,7 @@ theorem eq_pow_of_pell_lem {a y k : ℕ} (hy0 : y ≠ 0) (hk0 : k ≠ 0) (hyk : 
       exact lt_of_le_of_lt (Nat.succ_le_of_lt (Nat.pos_of_ne_zero hy0)) hya
     _ ≤ (a : ℤ) ^ 2 - (a - y : ℤ) ^ 2 - 1 := by
       have := hya.le
-      gcongr <;> norm_cast <;> omega
+      gcongr <;> norm_cast <;> lia
     _ = 2 * a * y - y * y - 1 := by ring
 
 theorem eq_pow_of_pell {m n k} :
@@ -874,7 +874,7 @@ theorem eq_pow_of_pell {m n k} :
       exact x_sub_y_dvd_pow a1 n k
     have ta : 2 * a * n = t + (n * n + 1) := by
       zify
-      omega
+      lia
     have zp : a * a - ((w + 1) * (w + 1) - 1) * (w * z) * (w * z) = 1 := ze ▸ pell_eq w1 w
     exact ⟨w, a, t, z, a1, tm, ta, Nat.cast_lt.1 nt, nw, kw, zp⟩
   · rintro (⟨rfl, rfl⟩ | ⟨hk0, ⟨rfl, rfl⟩ | ⟨hn0, w, a, t, z, a1, tm, ta, mt, nw, kw, zp⟩⟩)

--- a/Mathlib/NumberTheory/RamificationInertia/Basic.lean
+++ b/Mathlib/NumberTheory/RamificationInertia/Basic.lean
@@ -169,7 +169,7 @@ lemma ramificationIdx_ne_one_iff (hp : map f p ≤ P) :
     exact hk.trans (Ideal.pow_le_pow_right (Nat.succ_le_iff.mpr h1k))
   · intro he
     have := Nat.find_spec H 2 he
-    omega
+    lia
 
 open IsLocalRing in
 /-- The converse is true when `S` is a Dedekind domain.

--- a/Mathlib/NumberTheory/RamificationInertia/Basic.lean
+++ b/Mathlib/NumberTheory/RamificationInertia/Basic.lean
@@ -163,7 +163,7 @@ lemma ramificationIdx_ne_one_iff (hp : map f p ≤ P) :
   constructor
   · intro he
     have : 1 ≤ Nat.find H := Nat.find_spec H 1 (by simpa)
-    have := Nat.find_min H (m := 1) (by omega)
+    have := Nat.find_min H (m := 1) (by lia)
     push_neg at this
     obtain ⟨k, hk, h1k⟩ := this
     exact hk.trans (Ideal.pow_le_pow_right (Nat.succ_le_iff.mpr h1k))

--- a/Mathlib/NumberTheory/ZetaValues.lean
+++ b/Mathlib/NumberTheory/ZetaValues.lean
@@ -174,7 +174,7 @@ theorem bernoulliFun_mul (k : ℕ) {m : ℕ} (m0 : m ≠ 0) (x : ℝ) :
     have i : ∫ x in (0 : ℝ)..m⁻¹, f (k + 1) x = 0 := by
       simp only [f]
       rw [intervalIntegral.integral_sub, intervalIntegral.integral_comp_mul_left _ m0', mul_zero,
-        mul_inv_cancel₀ m0', integral_bernoulliFun_eq_zero (by omega), smul_zero, sub_eq_zero,
+        mul_inv_cancel₀ m0', integral_bernoulliFun_eq_zero (by lia), smul_zero, sub_eq_zero,
         intervalIntegral.integral_const_mul, eq_comm (a := 0), mul_eq_zero]
       · right
         rw [intervalIntegral.integral_finset_sum]

--- a/Mathlib/NumberTheory/ZetaValues.lean
+++ b/Mathlib/NumberTheory/ZetaValues.lean
@@ -447,7 +447,7 @@ theorem hasSum_zeta_nat {k : ℕ} (hk : k ≠ 0) :
       · skip
       · rw [← pow_one (2 : ℝ)]
     rw [← pow_add, Nat.sub_add_cancel]
-    omega
+    lia
   rw [this, mul_pow]
   ring
 

--- a/Mathlib/Order/Interval/Finset/Nat.lean
+++ b/Mathlib/Order/Interval/Finset/Nat.lean
@@ -36,10 +36,10 @@ instance instLocallyFiniteOrder : LocallyFiniteOrder ℕ where
   finsetIco a b := ⟨List.range' a (b - a), List.nodup_range'⟩
   finsetIoc a b := ⟨List.range' (a + 1) (b - a), List.nodup_range'⟩
   finsetIoo a b := ⟨List.range' (a + 1) (b - a - 1), List.nodup_range'⟩
-  finset_mem_Icc a b x := by rw [Finset.mem_mk, Multiset.mem_coe, List.mem_range'_1]; omega
-  finset_mem_Ico a b x := by rw [Finset.mem_mk, Multiset.mem_coe, List.mem_range'_1]; omega
-  finset_mem_Ioc a b x := by rw [Finset.mem_mk, Multiset.mem_coe, List.mem_range'_1]; omega
-  finset_mem_Ioo a b x := by rw [Finset.mem_mk, Multiset.mem_coe, List.mem_range'_1]; omega
+  finset_mem_Icc a b x := by rw [Finset.mem_mk, Multiset.mem_coe, List.mem_range'_1]; lia
+  finset_mem_Ico a b x := by rw [Finset.mem_mk, Multiset.mem_coe, List.mem_range'_1]; lia
+  finset_mem_Ioc a b x := by rw [Finset.mem_mk, Multiset.mem_coe, List.mem_range'_1]; lia
+  finset_mem_Ioo a b x := by rw [Finset.mem_mk, Multiset.mem_coe, List.mem_range'_1]; lia
 
 theorem Icc_eq_range' : Icc a b = ⟨List.range' a (b + 1 - a), List.nodup_range'⟩ :=
   rfl

--- a/Mathlib/Order/Interval/Finset/Nat.lean
+++ b/Mathlib/Order/Interval/Finset/Nat.lean
@@ -185,7 +185,7 @@ theorem mod_injOn_Ico (n a : ℕ) : Set.InjOn (· % a) (Finset.Ico n (n + a)) :=
     rwa [mod_eq_of_lt hk, mod_eq_of_lt hl] at hkl
   | succ n ih =>
     rw [Ico_succ_left_eq_erase_Ico, succ_add, succ_eq_add_one,
-      Ico_succ_right_eq_insert_Ico (by omega)]
+      Ico_succ_right_eq_insert_Ico (by lia)]
     rintro k hk l hl (hkl : k % a = l % a)
     have ha : 0 < a := Nat.pos_iff_ne_zero.2 <| by rintro rfl; simp at hk
     simp only [Finset.mem_coe, Finset.mem_insert, Finset.mem_erase] at hk hl

--- a/Mathlib/Order/Interval/Set/Fin.lean
+++ b/Mathlib/Order/Interval/Set/Fin.lean
@@ -646,7 +646,7 @@ theorem image_addNat_Ici (m) (i : Fin n) : (addNat · m) '' Ici i = Ici (i.addNa
   intro j hj
   have : (i : ℕ) + m ≤ j := hj
   refine ⟨⟨j - m, by lia⟩, ?_⟩
-  simp (disch := omega)
+  simp (disch := lia)
 
 @[simp]
 theorem image_addNat_Ioi (m) (i : Fin n) : (addNat · m) '' Ioi i = Ioi (i.addNat m) := by

--- a/Mathlib/Order/JordanHolder.lean
+++ b/Mathlib/Order/JordanHolder.lean
@@ -211,7 +211,7 @@ theorem mem_eraseLast {s : CompositionSeries X} {x : X} (h : 0 < s.length) :
   simp only [RelSeries.mem_def, eraseLast]
   constructor
   · rintro ⟨i, rfl⟩
-    have hi : (i : ℕ) < s.length := by omega
+    have hi : (i : ℕ) < s.length := by lia
     simp [last, Fin.ext_iff, ne_of_lt hi, -Set.mem_range, Set.mem_range_self]
   · intro h
     exact mem_eraseLast_of_ne_of_mem h.1 h.2

--- a/Mathlib/Order/KrullDimension.lean
+++ b/Mathlib/Order/KrullDimension.lean
@@ -471,7 +471,7 @@ lemma coe_lt_height_iff {x : α} {n : ℕ} (hfin : height x < ⊤) :
     · rw [← hp]
       apply LTSeries.strictMono
       simp [Fin.last]; omega
-    · exact height_eq_index_of_length_eq_height_last (by simp [hlen, hp, hx]) ⟨n, by omega⟩
+    · exact height_eq_index_of_length_eq_height_last (by simp [hlen, hp, hx]) ⟨n, by lia⟩
   mpr := fun ⟨y, hyx, hy⟩ =>
     hy ▸ height_strictMono hyx (lt_of_le_of_lt (height_mono hyx.le) hfin)
 

--- a/Mathlib/Order/KrullDimension.lean
+++ b/Mathlib/Order/KrullDimension.lean
@@ -470,7 +470,7 @@ lemma coe_lt_height_iff {x : α} {n : ℕ} (hfin : height x < ⊤) :
     constructor
     · rw [← hp]
       apply LTSeries.strictMono
-      simp [Fin.last]; omega
+      simp [Fin.last]; lia
     · exact height_eq_index_of_length_eq_height_last (by simp [hlen, hp, hx]) ⟨n, by lia⟩
   mpr := fun ⟨y, hyx, hy⟩ =>
     hy ▸ height_strictMono hyx (lt_of_le_of_lt (height_mono hyx.le) hfin)
@@ -982,7 +982,7 @@ lemma krullDim_int : krullDim ℤ = ⊤ := krullDim_of_noMaxOrder ..
     have hlast' : p'.last = x := by
       simp only [p', RelSeries.last, WithBot.unbot_eq_iff, ← hlast, Fin.last]
       congr
-      omega
+      lia
     suffices p'.length ≤ height p'.last by
       simpa [p', hlast'] using this
     apply length_le_height_last

--- a/Mathlib/Order/Monotone/Basic.lean
+++ b/Mathlib/Order/Monotone/Basic.lean
@@ -747,6 +747,6 @@ lemma converges_of_monotone_of_bounded {f : ℕ → ℕ} (mono_f : Monotone f)
     by_cases! h : ∀ n, f n ≤ c
     · exact ih h
     · obtain ⟨N, hN⟩ := h
-      replace hN : f N = c + 1 := by specialize hc N; omega
+      replace hN : f N = c + 1 := by specialize hc N; lia
       use c + 1, N; intro n hn
       specialize mono_f hn; specialize hc n; lia

--- a/Mathlib/Order/OrderIsoNat.lean
+++ b/Mathlib/Order/OrderIsoNat.lean
@@ -181,7 +181,7 @@ theorem exists_increasing_or_nonincreasing_subseq' (r : α → α → Prop) (f :
         obtain ⟨n', hn1, hn2⟩ := h
         refine ⟨n + n' - n - m, by lia, ?_⟩
         convert hn2
-        omega
+        lia
       let g' : ℕ → ℕ := @Nat.rec (fun _ => ℕ) m fun n gn => Nat.find (h gn)
       exact
         ⟨(RelEmbedding.natLT (fun n => g' n + m) fun n =>

--- a/Mathlib/Order/RelSeries.lean
+++ b/Mathlib/Order/RelSeries.lean
@@ -300,10 +300,10 @@ such that `r aₙ b₀`, then there is a chain of length `n + m + 1` given by
 @[simps]
 def append (p q : RelSeries r) (connect : p.last ~[r] q.head) : RelSeries r where
   length := p.length + q.length + 1
-  toFun := Fin.append p q ∘ Fin.cast (by omega)
+  toFun := Fin.append p q ∘ Fin.cast (by lia)
   step i := by
     obtain hi | rfl | hi :=
-      lt_trichotomy i (Fin.castLE (by omega) (Fin.last _ : Fin (p.length + 1)))
+      lt_trichotomy i (Fin.castLE (by lia) (Fin.last _ : Fin (p.length + 1)))
     · convert p.step ⟨i.1, hi⟩ <;> convert Fin.append_left p q _ <;> rfl
     · convert connect
       · convert Fin.append_left p q _
@@ -311,7 +311,7 @@ def append (p q : RelSeries r) (connect : p.last ~[r] q.head) : RelSeries r wher
     · set x := _; set y := _
       change Fin.append p q x ~[r] Fin.append p q y
       have hx : x = Fin.natAdd _ ⟨i - (p.length + 1), Nat.sub_lt_left_of_lt_add hi <|
-          i.2.trans <| by omega⟩ := by
+          i.2.trans <| by lia⟩ := by
         ext; dsimp [x, y]; rw [Nat.add_sub_cancel']; exact hi
       have hy : y = Fin.natAdd _ ⟨i - p.length, Nat.sub_lt_left_of_lt_add (le_of_lt hi)
           (by exact i.2)⟩ := by
@@ -321,7 +321,7 @@ def append (p q : RelSeries r) (connect : p.last ~[r] q.head) : RelSeries r wher
           Nat.add_sub_cancel' <| le_of_lt (show p.length < i.1 from hi), add_comm]
         rfl
       rw [hx, Fin.append_right, hy, Fin.append_right]
-      convert q.step ⟨i - (p.length + 1), Nat.sub_lt_left_of_lt_add hi <| by omega⟩
+      convert q.step ⟨i - (p.length + 1), Nat.sub_lt_left_of_lt_add hi <| by lia⟩
       rw [Fin.succ_mk, Nat.sub_eq_iff_eq_add (le_of_lt hi : p.length ≤ i),
         Nat.add_assoc _ 1, add_comm 1, Nat.sub_add_cancel]
       exact hi
@@ -422,7 +422,7 @@ def insertNth (p : RelSeries r) (i : Fin p.length) (a : α)
           Fin.insertNth_apply_same]
     · rw [Nat.lt_iff_add_one_le, le_iff_lt_or_eq] at hm
       obtain hm | hm := hm
-      · convert p.step ⟨m.1 - 1, Nat.sub_lt_right_of_lt_add (by omega) m.2⟩
+      · convert p.step ⟨m.1 - 1, Nat.sub_lt_right_of_lt_add (by lia) m.2⟩
         · change Fin.insertNth _ _ _ _ = _
           rw [Fin.insertNth_apply_above (h := hm)]
           aesop
@@ -453,8 +453,8 @@ def reverse (p : RelSeries r) : RelSeries r.inv where
   toFun := p ∘ Fin.rev
   step i := by
     rw [Function.comp_apply, Function.comp_apply, SetRel.mem_inv]
-    have hi : i.1 + 1 ≤ p.length := by omega
-    convert p.step ⟨p.length - (i.1 + 1), Nat.sub_lt_self (by omega) hi⟩
+    have hi : i.1 + 1 ≤ p.length := by lia
+    convert p.step ⟨p.length - (i.1 + 1), Nat.sub_lt_self (by lia) hi⟩
     · ext; simp
     · ext
       simp only [Fin.val_rev, Fin.coe_castSucc, Fin.val_succ]
@@ -752,8 +752,8 @@ lemma smash_succ_natAdd {p q : RelSeries r} (h : p.last = q.head) (i : Fin q.len
 @[simps! length]
 def take {r : SetRel α α} (p : RelSeries r) (i : Fin (p.length + 1)) : RelSeries r where
   length := i
-  toFun := fun ⟨j, h⟩ => p.toFun ⟨j, by omega⟩
-  step := fun ⟨j, h⟩ => p.step ⟨j, by omega⟩
+  toFun := fun ⟨j, h⟩ => p.toFun ⟨j, by lia⟩
+  step := fun ⟨j, h⟩ => p.step ⟨j, by lia⟩
 
 @[simp]
 lemma head_take (p : RelSeries r) (i : Fin (p.length + 1)) :
@@ -767,9 +767,9 @@ lemma last_take (p : RelSeries r) (i : Fin (p.length + 1)) :
 @[simps! length]
 def drop (p : RelSeries r) (i : Fin (p.length + 1)) : RelSeries r where
   length := p.length - i
-  toFun := fun ⟨j, h⟩ => p.toFun ⟨j+i, by omega⟩
+  toFun := fun ⟨j, h⟩ => p.toFun ⟨j+i, by lia⟩
   step := fun ⟨j, h⟩ => by
-    convert p.step ⟨j+i.1, by omega⟩
+    convert p.step ⟨j+i.1, by lia⟩
     simp only [Fin.succ_mk]; omega
 
 @[simp]
@@ -858,7 +858,7 @@ instance FiniteDimensionalOrder.ofUnique (γ : Type*) [Preorder γ] [Unique γ] 
     FiniteDimensionalOrder γ where
   exists_longest_relSeries := ⟨.singleton _ default, fun x ↦ by
     by_contra! r
-    exact (x.step ⟨0, by omega⟩).ne <| Subsingleton.elim _ _⟩
+    exact (x.step ⟨0, by lia⟩).ne <| Subsingleton.elim _ _⟩
 
 /-- A type is infinite dimensional if it has `LTSeries` of at least arbitrary length -/
 abbrev InfiniteDimensionalOrder (γ : Type*) [Preorder γ] :=

--- a/Mathlib/Order/RelSeries.lean
+++ b/Mathlib/Order/RelSeries.lean
@@ -352,7 +352,7 @@ lemma append_apply_right (p q : RelSeries r) (connect : p.last ~[r] q.head)
   convert append_apply_right p q connect (Fin.last _)
   ext1
   dsimp
-  omega
+  lia
 
 lemma append_assoc (p q w : RelSeries r) (hpq : p.last ~[r] q.head) (hqw : q.last ~[r] w.head) :
     (p.append q hpq).append w (by simpa) = p.append (q.append w hqw) (by simpa) := by
@@ -439,7 +439,7 @@ def insertNth (p : RelSeries r) (i : Fin p.length) (a : α)
         · change Fin.insertNth _ _ _ _ = _
           rw [Fin.insertNth_apply_above]
           swap
-          · change i.1 + 1 < m.1 + 1; omega
+          · change i.1 + 1 < m.1 + 1; lia
           simp only [Fin.pred_succ, eq_rec_constant]
           congr; ext; exact hm.symm
 
@@ -458,7 +458,7 @@ def reverse (p : RelSeries r) : RelSeries r.inv where
     · ext; simp
     · ext
       simp only [Fin.val_rev, Fin.coe_castSucc, Fin.val_succ]
-      omega
+      lia
 
 @[simp] lemma reverse_apply (p : RelSeries r) (i : Fin (p.length + 1)) :
     p.reverse i = p i.rev := rfl
@@ -770,7 +770,7 @@ def drop (p : RelSeries r) (i : Fin (p.length + 1)) : RelSeries r where
   toFun := fun ⟨j, h⟩ => p.toFun ⟨j+i, by lia⟩
   step := fun ⟨j, h⟩ => by
     convert p.step ⟨j+i.1, by lia⟩
-    simp only [Fin.succ_mk]; omega
+    simp only [Fin.succ_mk]; lia
 
 @[simp]
 lemma head_drop (p : RelSeries r) (i : Fin (p.length + 1)) : (p.drop i).head = p.toFun i := by

--- a/Mathlib/Order/SuccPred/Tree.lean
+++ b/Mathlib/Order/SuccPred/Tree.lean
@@ -66,7 +66,7 @@ lemma findAtom_eq_bot {r : α} :
   mp h := by
     unfold findAtom at h
     have := Nat.find_min' (bot_le (a := r)).exists_pred_iterate h
-    replace : Nat.find (bot_le (a := r)).exists_pred_iterate = 0 := by omega
+    replace : Nat.find (bot_le (a := r)).exists_pred_iterate = 0 := by lia
     simpa [this] using h
   mpr h := by simp [h]
 

--- a/Mathlib/Probability/Kernel/IonescuTulcea/PartialTraj.lean
+++ b/Mathlib/Probability/Kernel/IonescuTulcea/PartialTraj.lean
@@ -226,7 +226,7 @@ lemma partialTraj_eq_prod [∀ n, IsSFiniteKernel (κ n)] (a b : ℕ) :
         Equiv.coe_fn_mk, Function.comp_apply, Prod.map_fst, Prod.map_snd, id_eq,
         Nat.succ_eq_add_one, IocProdIoc]
       split_ifs <;> try rfl
-      omega
+      lia
     nth_rw 1 [← partialTraj_comp_partialTraj h k.le_succ, hk, partialTraj_succ_self, comp_map,
       comap_map_comm, comap_prod, id_comap, ← id_map, map_prod_eq, ← map_comp_right, this,
       map_comp_right, id_prod_eq, prodAssoc_prod, map_comp_right, ← map_prod_map, map_id,

--- a/Mathlib/Probability/Martingale/BorelCantelli.lean
+++ b/Mathlib/Probability/Martingale/BorelCantelli.lean
@@ -89,7 +89,7 @@ theorem stoppedAbove_le (hr : 0 ≤ r) (hf0 : f 0 = 0)
       ne_top_of_le_ne_top (by simp) (min_le_left _ _)
     lift min (i : ℕ∞) (leastGE f r ω) to ℕ using h_top with p
     simp only [untopD_coe_enat, Nat.cast_lt, gt_iff_lt] at *
-    omega
+    lia
 
 @[deprecated (since := "2025-10-25")] alias norm_stoppedValue_leastGE_le := stoppedAbove_le
 

--- a/Mathlib/Probability/Process/Predictable.lean
+++ b/Mathlib/Probability/Process/Predictable.lean
@@ -188,7 +188,7 @@ lemma measurableSet_predictable_singleton_prod
   · exact measurableSet_predictable_Ioc_prod _ _ hs
   · ext m
     simp only [Set.mem_singleton_iff, Set.mem_Ioc]
-    omega
+    lia
 
 lemma isPredictable_of_measurable_add_one [SecondCountableTopology E]
     {𝓕 : Filtration ℕ m} {u : ℕ → Ω → E}

--- a/Mathlib/Probability/Process/Stopping.lean
+++ b/Mathlib/Probability/Process/Stopping.lean
@@ -351,7 +351,7 @@ theorem add {f : Filtration ℕ m} {τ π : Ω → WithTop ℕ}
       | coe b =>
         simp only [ENat.some_eq_coe, Nat.cast_inj, exists_eq_left', iff_and_self]
         norm_cast
-        omega
+        lia
   rw [h]
   exact MeasurableSet.iUnion fun k =>
     MeasurableSet.iUnion fun hk => (hπ.measurableSet_eq_le hk).inter (hτ.add_const_nat i)

--- a/Mathlib/RingTheory/Filtration.lean
+++ b/Mathlib/RingTheory/Filtration.lean
@@ -302,7 +302,7 @@ theorem submodule_eq_span_le_iff_stable_ge (n₀ : ℕ) :
     rintro ⟨_, _, ⟨n', rfl⟩, _, ⟨hn', rfl⟩, m, hm, rfl⟩ -
     dsimp only [Subtype.coe_mk]
     rw [Subalgebra.smul_def, smul_single_apply, if_pos (show n' ≤ n + 1 by lia)]
-    have e : n' ≤ n := by omega
+    have e : n' ≤ n := by lia
     have := F.pow_smul_le_pow_smul (n - n') n' 1
     rw [tsub_add_cancel_of_le e, pow_one, add_comm _ 1, ← add_tsub_assoc_of_le e, add_comm] at this
     exact this (Submodule.smul_mem_smul ((l _).2 <| n + 1 - n') hm)

--- a/Mathlib/RingTheory/Ideal/NatInt.lean
+++ b/Mathlib/RingTheory/Ideal/NatInt.lean
@@ -29,7 +29,7 @@ public import Mathlib.RingTheory.PrincipalIdealDomain
 /-- The natural numbers form a local semiring. -/
 instance : IsLocalRing ℕ where
   isUnit_or_isUnit_of_add_one {a b} hab := by
-    have h : a = 1 ∨ b = 1 := by omega
+    have h : a = 1 ∨ b = 1 := by lia
     apply h.imp <;> simp +contextual
 
 open IsLocalRing Ideal

--- a/Mathlib/RingTheory/LaurentSeries.lean
+++ b/Mathlib/RingTheory/LaurentSeries.lean
@@ -539,7 +539,7 @@ theorem coeff_zero_of_lt_valuation {n D : ℤ} {f : K⸨X⸩}
       ← ofPowerSeries_X_pow s, PowerSeries.coe_pow, valuation_X_pow K s]
     gcongr
   · obtain ⟨s, hs⟩ := Int.exists_eq_neg_ofNat (Int.neg_nonpos_of_nonneg (le_of_lt ord_nonpos))
-    obtain ⟨m, hm⟩ := Int.eq_ofNat_of_zero_le (a := n - s) (by omega)
+    obtain ⟨m, hm⟩ := Int.eq_ofNat_of_zero_le (a := n - s) (by lia)
     obtain ⟨d, hd⟩ := Int.eq_ofNat_of_zero_le (a := D - s) (by lia)
     rw [(sub_eq_iff_eq_add).mp hm, add_comm, ← neg_neg (s : ℤ), ← hs, neg_neg,
       ← powerSeriesPart_coeff]

--- a/Mathlib/RingTheory/Polynomial/Bernstein.lean
+++ b/Mathlib/RingTheory/Polynomial/Bernstein.lean
@@ -175,7 +175,7 @@ theorem iterate_derivative_at_0 (n ν : ℕ) :
         eval_natCast, Function.comp_apply, Function.iterate_succ, ascPochhammer_succ_left]
       obtain rfl | h'' := ν.eq_zero_or_pos
       · simp
-      · have : n - 1 - (ν - 1) = n - ν := by omega
+      · have : n - 1 - (ν - 1) = n - ν := by lia
         rw [this, ascPochhammer_eval_succ]
         rw_mod_cast [tsub_add_cancel_of_le (h'.trans n.pred_le)]
   · rw [tsub_eq_zero_iff_le.mpr (Nat.le_sub_one_of_lt h), eq_zero_of_lt R h]

--- a/Mathlib/RingTheory/Polynomial/Cyclotomic/Factorization.lean
+++ b/Mathlib/RingTheory/Polynomial/Cyclotomic/Factorization.lean
@@ -158,7 +158,7 @@ theorem normalizedFactors_cyclotomic_card : (normalizedFactors (cyclotomic n K))
     exact hp.out.coprime_iff_not_dvd.mp ((coprime_pow_left_iff
       (pos_of_ne_zero <| f_ne_zero hK) _ _).mp (hn.pow_left f))
         ((CharP.cast_eq_zero_iff K p _).mp H)
-  have hP : P ∈ normalizedFactors (cyclotomic n K) := count_pos.mp (by omega)
+  have hP : P ∈ normalizedFactors (cyclotomic n K) := count_pos.mp (by lia)
   refine (prime_of_normalized_factor _ hP).not_unit (squarefree_cyclotomic n K P ?_)
   have : {P, P} ≤ normalizedFactors (cyclotomic n K) := by
     refine le_iff_count.mpr (fun Q ↦ ?_)

--- a/Mathlib/RingTheory/Polynomial/Resultant/Basic.lean
+++ b/Mathlib/RingTheory/Polynomial/Resultant/Basic.lean
@@ -206,7 +206,7 @@ private lemma resultant_add_mul_monomial_right (hk : k + m ≤ n) (hf : f.natDeg
     | zero => simp [M]; rfl
     | succ i IH =>
       rw [← IH (by lia), ← Matrix.det_updateCol_add_smul_self (i := ⟨i, by lia⟩)
-        (j := ⟨i + k + m, by lia⟩) (c := -r) (M (i + 1)) (by simp; omega)]
+        (j := ⟨i + k + m, by lia⟩) (c := -r) (M (i + 1)) (by simp; lia)]
       congr 1
       ext j₁ j₂
       simp only [Matrix.of_apply, lt_add_iff_pos_right, zero_lt_one, ↓reduceIte, add_assoc,
@@ -219,7 +219,7 @@ private lemma resultant_add_mul_monomial_right (hk : k + m ≤ n) (hf : f.natDeg
         | left j₂ =>
           dsimp at hi
           have : Fin.mk (n := m + n) (↑j₂ + (k + m)) (by lia) = .natAdd m ⟨j₂ + k, by lia⟩ :=
-            Fin.ext (by simp; omega)
+            Fin.ext (by simp; lia)
           simp only [Fin.addCases_left, Fin.coe_castAdd, this, Fin.addCases_right, mul_ite,
             mul_zero, ← C_mul_X_pow_eq_monomial, ← mul_assoc, coeff_mul_X_pow', ite_add_zero,
             coeff_mul_C, add_assoc, add_eq_left, ← ite_and, ← mul_comm r, tsub_add_eq_tsub_tsub,
@@ -227,15 +227,15 @@ private lemma resultant_add_mul_monomial_right (hk : k + m ≤ n) (hf : f.natDeg
           split_ifs with h₁ h₂ h₂ <;> try rfl
           · rw [coeff_eq_zero_of_natDegree_lt, mul_zero]
             exact hf.trans_lt (by lia)
-          · omega
+          · lia
         | right i =>
           simp only [Fin.coe_natAdd] at hi
           have : Fin.mk (n := m + n) (m + ↑i + (k + m)) (by lia) =
-              Fin.natAdd m ⟨↑i + (k + m), by lia⟩ := Fin.ext (by simp; omega)
+              Fin.natAdd m ⟨↑i + (k + m), by lia⟩ := Fin.ext (by simp; lia)
           simp only [Fin.addCases_right, Fin.coe_natAdd, sub_eq_self, this]
           rw [if_neg, mul_zero]
-          omega
-      split_ifs with h₁ h₂ h₃ h₄ h₅ <;> try first | omega | rfl
+          lia
+      lia
   rw [resultant, resultant, ← this m le_rfl]
   congr 1
   ext i j
@@ -256,7 +256,7 @@ lemma resultant_add_mul_right (hp : p.natDegree + m ≤ n) (hf : f.natDegree ≤
     simp only [Finset.range_zero, Finset.sum_empty]
     rw [mul_zero, add_zero]
   | succ k IH =>
-    rw [Finset.sum_range_succ, mul_add, ← add_assoc, resultant_add_mul_monomial_right, IH] <;> omega
+    rw [Finset.sum_range_succ, mul_add, ← add_assoc, resultant_add_mul_monomial_right, IH] <;> lia
 
 /-- `Res(f + gp, g) = Res(f, g)` if `deg g + deg p ≤ deg f`. -/
 lemma resultant_add_mul_left (hk : p.natDegree + n ≤ m) (hg : g.natDegree ≤ n) :
@@ -287,8 +287,8 @@ lemma resultant_C_mul_right (r : R) :
           lt_add_iff_pos_right, zero_lt_one, coeff_C_mul, M₁]
         induction j₂ using Fin.addCases with
         | left j₂ => simp
-        | right i => simp at hi; omega
-      split_ifs with h₁ h₂ h₃ h₄ h₅ <;> try first | omega | rfl
+        | right i => simp at hi; lia
+      lia
   rw [resultant, resultant, ← this m le_rfl]
   congr 1
   ext i j
@@ -311,7 +311,7 @@ lemma resultant_succ_left_deg (hf : f.natDegree ≤ m) :
       Matrix.reindex_apply, finCongr_symm, Matrix.submatrix_submatrix]
     congr 2
     · trans (-1) ^ (2 * m + (n + 1))
-      · congr 1; omega
+      · congr 1; lia
       · simp [pow_add]
     · simp only [sylvester, Set.mem_Icc, Matrix.of_apply, Fin.val_last, Fin.addCases_left]
       rw [if_pos (by lia)]
@@ -328,7 +328,7 @@ lemma resultant_succ_left_deg (hf : f.natDegree ≤ m) :
         have : ((Fin.last m).castAdd (n + 1)).succAbove ((j.natAdd m).cast (by grind)) =
           j.natAdd _ := by ext; simp [Fin.succAbove, Fin.lt_def, add_right_comm]
         simp only [ite_and, this, Fin.addCases_right]
-        split_ifs with h₁ h₂ h₃ h₃ <;> try first | omega | rfl
+        split_ifs with h₁ h₂ h₃ h₃ <;> try lia
         exact coeff_eq_zero_of_natDegree_lt (by lia)
   · rintro (b : Fin ((m + 1) + (n + 1))) - hb
     suffices f.sylvester g (m + 1) (n + 1) (.last (m + 1 + n)) b = 0 by simp [this]
@@ -339,7 +339,7 @@ lemma resultant_succ_left_deg (hf : f.natDegree ≤ m) :
       simp only [sylvester, Set.mem_Icc, Matrix.of_apply, Fin.val_last, Fin.addCases_left,
         ite_eq_right_iff, and_imp]
       intros
-      omega
+      lia
     | right i => simpa [sylvester] using fun _ _ ↦ coeff_eq_zero_of_natDegree_lt (by lia)
 
 lemma resultant_add_left_deg (hf : f.natDegree ≤ m) :
@@ -358,8 +358,8 @@ lemma resultant_add_right_deg (k : ℕ) (hg : g.natDegree ≤ n) :
 
 lemma resultant_eq_zero_of_lt_lt (hf : f.natDegree < m) (hg : g.natDegree < n) :
     resultant f g m n = 0 := by
-  obtain _ | m := m; · omega
-  obtain _ | n := n; · omega
+  obtain _ | m := m; · lia
+  obtain _ | n := n; · lia
   rw [resultant_add_left_deg _ _ _ _ _ (by lia), resultant_add_right_deg _ _ _ _ _ (by lia)]
   simp [coeff_eq_zero_of_natDegree_lt hg]
 
@@ -390,7 +390,7 @@ theorem resultant_C_left (r : R) :
   rw [resultant_add_mul_right _ _ _ _ _ _ (natDegree_X_sub_C_le _), modByMonic_X_sub_C_eq_C_eval]
   · simp
   · rw [natDegree_divByMonic g (monic_X_sub_C r), natDegree_sub_C, natDegree_X]
-    omega
+    lia
 
 /-- `Res(X + r, g) = g(-r)` -/
 @[simp] lemma resultant_X_add_C_left (r : R) (hg : g.natDegree ≤ n) :
@@ -989,7 +989,7 @@ lemma resultant_deriv {f : R[X]} (hf : 0 < f.degree) :
   rw [resultant_comm, resultant, ← sylvesterDeriv_updateRow f hf, Matrix.det_updateRow_smul,
     Matrix.updateRow_eq_self, discr, mul_comm f.natDegree]
   ring_nf
-  rw [Nat.div_mul_cancel (by convert Nat.two_dvd_mul_add_one (f.natDegree - 1) using 2; omega)]
+  rw [Nat.div_mul_cancel (by convert Nat.two_dvd_mul_add_one (f.natDegree - 1) using 2; lia)]
 
 private lemma sylvesterDeriv_of_natDegree_eq_three {f : R[X]} (hf : f.natDegree = 3) :
     f.sylvesterDeriv.reindex (finCongr <| by rw [hf]) (finCongr <| by rw [hf]) =

--- a/Mathlib/RingTheory/Polynomial/UniversalFactorizationRing.lean
+++ b/Mathlib/RingTheory/Polynomial/UniversalFactorizationRing.lean
@@ -55,7 +55,7 @@ lemma coeff_freeMonic :
   by_cases h : k < n
   · simp +contextual [Finset.sum_eq_single (ι := Fin n) (a := ⟨k, h⟩),
       Fin.ext_iff, @eq_comm _ k, h, h.ne']
-  ·rw [Finset.sum_eq_zero fun x _ ↦ if_neg (by cases x; omega), add_zero, dif_neg h]
+  ·rw [Finset.sum_eq_zero fun x _ ↦ if_neg (by cases x; lia), add_zero, dif_neg h]
 
 lemma degree_freeMonic [Nontrivial R] : (freeMonic R n).degree = n :=
   Polynomial.degree_eq_of_le_of_coeff_ne_zero ((Polynomial.degree_le_iff_coeff_zero _ _).mpr

--- a/Mathlib/RingTheory/Polynomial/UniversalFactorizationRing.lean
+++ b/Mathlib/RingTheory/Polynomial/UniversalFactorizationRing.lean
@@ -252,12 +252,12 @@ lemma pderiv_inl_universalFactorizationMap_X (i j) :
     · rw [Finset.sum_eq_zero, if_pos h]
       simp only [Finset.mem_antidiagonal, Prod.forall]
       intro a b hab
-      simp [show a ≠ i by omega]
+      simp [show a ≠ i by lia]
     rw [Finset.sum_eq_single ⟨i.1, j.1 - i.1⟩, if_neg h.not_gt]
     · simp
     · simp only [Finset.mem_antidiagonal, ne_eq, Prod.forall, Prod.mk.injEq, not_and]
       intro a b e h
-      simp [show a ≠ i by omega]
+      simp [show a ≠ i by lia]
     · simp [h]
 
 lemma pderiv_inr_universalFactorizationMap_X (i j) :
@@ -275,12 +275,12 @@ lemma pderiv_inr_universalFactorizationMap_X (i j) :
     · rw [Finset.sum_eq_zero, if_pos h]
       simp only [Finset.mem_antidiagonal, Prod.forall]
       intro a b hab
-      simp [show b ≠ i by omega]
+      simp [show b ≠ i by lia]
     rw [Finset.sum_eq_single ⟨j.1 - i.1, i.1⟩, if_neg h.not_gt]
     · simp
     · simp only [Finset.mem_antidiagonal, ne_eq, ite_eq_right_iff, Prod.forall, Prod.mk.injEq]
       intro a b _ _ _
-      simp [show b ≠ i by omega]
+      simp [show b ≠ i by lia]
     · simp [h]
 
 lemma universalFactorizationMapPresentation_jacobiMatrix :
@@ -289,7 +289,7 @@ lemma universalFactorizationMapPresentation_jacobiMatrix :
     -((Polynomial.sylvester
       ((freeMonic R m).map (((mapAlgHom (Algebra.ofId _ _)).comp (rename Sum.inl)).toRingHom))
       ((freeMonic R k).map (((mapAlgHom (Algebra.ofId _ _)).comp (rename Sum.inr)).toRingHom))
-      m k).reindex (finCongr (by omega)) (finCongr (by omega))).transpose := by
+      m k).reindex (finCongr (by lia)) (finCongr (by lia))).transpose := by
   letI := (universalFactorizationMap R n m k hn).toAlgebra
   subst hn
   ext i j : 1

--- a/Mathlib/RingTheory/PowerSeries/Basic.lean
+++ b/Mathlib/RingTheory/PowerSeries/Basic.lean
@@ -684,7 +684,7 @@ lemma coeff_one_pow (n : ℕ) (φ : R⟦X⟧) :
       rw [h₁, coeff_mul, h₂, Finset.sum_insert, Finset.sum_singleton]
       · simp only [coeff_zero_eq_constantCoeff, map_pow, Nat.cast_add, Nat.cast_one,
           add_tsub_cancel_right]
-        have h₀ : n' = 0 ∨ 1 ≤ n' := by omega
+        have h₀ : n' = 0 ∨ 1 ≤ n' := by lia
         rcases h₀ with h' | h'
         · by_contra h''
           rw [h'] at h''

--- a/Mathlib/RingTheory/PowerSeries/Restricted.lean
+++ b/Mathlib/RingTheory/PowerSeries/Restricted.lean
@@ -48,7 +48,7 @@ lemma one : IsRestricted c (1 : PowerSeries R) := by
   simp only [isRestricted_iff, coeff_one, norm_mul, norm_pow, Real.norm_eq_abs]
   refine fun _ _ ↦ ⟨1, fun n hn ↦ ?_ ⟩
   split
-  · omega
+  · lia
   · simpa
 
 lemma monomial (n : ℕ) (a : R) : IsRestricted c (monomial n a) := by
@@ -56,7 +56,7 @@ lemma monomial (n : ℕ) (a : R) : IsRestricted c (monomial n a) := by
     Real.norm_eq_abs, abs_norm]
   refine fun _ _ ↦ ⟨n + 1, fun _ _ ↦ ?_⟩
   split
-  · omega
+  · lia
   · simpa
 
 lemma C (a : R) : IsRestricted c (C a) := by

--- a/Mathlib/RingTheory/PowerSeries/Restricted.lean
+++ b/Mathlib/RingTheory/PowerSeries/Restricted.lean
@@ -106,7 +106,7 @@ lemma convergenceSet_BddAbove {f : PowerSeries R} (hf : IsRestricted c f) :
   · right
     apply le_max'
     simp only [mem_image, mem_range]
-    exact ⟨i, by omega, rfl⟩
+    exact ⟨i, by lia, rfl⟩
   · left
     calc _ ≤ ‖(coeff i) f‖ * |c ^ i| := by bound
          _ ≤ 1 := by simpa using (hf i h).le
@@ -142,7 +142,7 @@ lemma mul {f g : PowerSeries R} (hf : IsRestricted c f) (hg : IsRestricted c g) 
         -/
         rw [pow_add]
         grind
-  have : max Nf Ng ≤ fst ∨ max Nf Ng ≤ snd := by omega
+  have : max Nf Ng ≤ fst ∨ max Nf Ng ≤ snd := by lia
   rcases this with this | this
   · calc _ < ε / max a b * b := by
           grw [gBound1 snd]

--- a/Mathlib/RingTheory/RootsOfUnity/CyclotomicUnits.lean
+++ b/Mathlib/RingTheory/RootsOfUnity/CyclotomicUnits.lean
@@ -51,7 +51,7 @@ theorem associated_sub_one_pow_sub_one_of_coprime (hζ : IsPrimitiveRoot ζ n) (
   | 0 => simp_all
   | 1 => simp_all
   | n + 2 =>
-      obtain ⟨m, -, hm⟩ := exists_mul_mod_eq_one_of_coprime hj (by omega)
+      obtain ⟨m, -, hm⟩ := exists_mul_mod_eq_one_of_coprime hj (by lia)
       use ∑ i ∈ range m, (ζ ^ j) ^ i
       rw [mul_geom_sum, ← pow_mul, ← pow_mod_orderOf, ← hζ.eq_orderOf, hm, pow_one]
 
@@ -111,7 +111,7 @@ theorem pow_sub_one_eq_geom_sum_mul_geom_sum_inv_mul_pow_sub_one (hζ : IsPrimit
   unit. -/
 theorem associated_pow_add_sub_sub_one (hζ : IsPrimitiveRoot ζ n) (hn : 2 ≤ n) (i : ℕ)
     (hjn : j.Coprime n) : Associated (ζ - 1) (ζ ^ (i + j) - ζ ^ i) := by
-  use (hζ.isUnit (by omega)).unit ^ i * (hζ.geom_sum_isUnit hn hjn).unit
+  use (hζ.isUnit (by lia)).unit ^ i * (hζ.geom_sum_isUnit hn hjn).unit
   suffices (ζ - 1) * ζ ^ i * ∑ i ∈ range j, ζ ^ i = (ζ ^ (i + j) - ζ ^ i) by
     simp [← this, mul_assoc]
   grind [mul_geom_sum]
@@ -128,7 +128,7 @@ lemma ntRootsFinset_pairwise_associated_sub_one_sub_of_prime (hζ : IsPrimitiveR
   obtain ⟨j, hj, rfl⟩ :=
     hζ.eq_pow_of_pow_eq_one ((Polynomial.mem_nthRootsFinset hp.pos 1).1 hη₂)
   wlog hij : j ≤ i
-  · simpa using (this hζ ‹_› ‹_› _ hj ‹_› _ hi ‹_› e.symm (by omega)).neg_right
+  · simpa using (this hζ ‹_› ‹_› _ hj ‹_› _ hi ‹_› e.symm (by lia)).neg_right
   have H : (i - j).Coprime p := (coprime_of_lt_prime (by grind) (by grind) hp).symm
   obtain ⟨u, h⟩ := hζ.associated_pow_add_sub_sub_one hp.two_le j H
   simp only [hij, add_tsub_cancel_of_le] at h

--- a/Mathlib/RingTheory/Spectrum/Prime/ChevalleyComplexity.lean
+++ b/Mathlib/RingTheory/Spectrum/Prime/ChevalleyComplexity.lean
@@ -514,7 +514,7 @@ private lemma statement : ∀ S : InductionObj R n, Statement R₀ R n S := by
             exact Finset.single_le_sum (f := fun i ↦ (c.val i).degree.succ)
               (by intros; positivity) (Finset.mem_univ _)
           _ = c.degBound ^ (c'.degBound + 1) := by rw [pow_succ']
-          _ ≤ c.degBound ^ c.degBound := by gcongr <;> omega
+          _ ≤ c.degBound ^ c.degBound := by gcongr <;> lia
       rw [coeffSubmodule]
       simp only [Submodule.span_le, Set.union_subset_iff, Set.singleton_subset_iff, SetLike.mem_coe,
         Set.iUnion_subset_iff, Set.range_subset_iff, c']

--- a/Mathlib/RingTheory/WittVector/Basic.lean
+++ b/Mathlib/RingTheory/WittVector/Basic.lean
@@ -301,7 +301,7 @@ theorem pow_dvd_ghostComponent_of_dvd_coeff {x : 𝕎 R} {n : ℕ}
   have : (MvPolynomial.aeval x.coeff) ((MvPolynomial.monomial (R := ℤ)
       (Finsupp.single i (p ^ (n - i)))) (p ^ i)) = ((p : R) ^ i) * (x.coeff i) ^ (p ^ (n - i)) := by
     simp [MvPolynomial.aeval_monomial, map_pow]
-  rw [this, show n + 1 = (n - i) + 1 + i by omega, pow_add, mul_comm]
+  rw [this, show n + 1 = (n - i) + 1 + i by lia, pow_add, mul_comm]
   gcongr
   · exact hx i (Nat.le_of_lt_succ hi)
   · exact ((n - i).lt_two_pow_self).succ_le.trans

--- a/Mathlib/RingTheory/WittVector/InitTail.lean
+++ b/Mathlib/RingTheory/WittVector/InitTail.lean
@@ -175,7 +175,7 @@ elab_rules : tactic
       rintro ⟨b, k⟩ h -
       replace h := $e:term p _ h
       simp only [Finset.mem_range, Finset.mem_product, true_and, Finset.mem_univ] at h
-      have hk : k < n := by omega
+      have hk : k < n := by lia
       fin_cases b <;> simp only [Function.uncurry, Matrix.cons_val_zero, Matrix.head_cons,
         WittVector.coeff_mk, Matrix.cons_val_one, WittVector.mk, Fin.mk_zero, Matrix.cons_val',
         Matrix.empty_val', Matrix.cons_val_fin_one, Matrix.cons_val_zero,

--- a/Mathlib/RingTheory/WittVector/MulCoeff.lean
+++ b/Mathlib/RingTheory/WittVector/MulCoeff.lean
@@ -244,7 +244,7 @@ theorem nth_mul_coeff' (n : ℕ) :
     let S : Set (Fin 2 × ℕ) := { a | a.2 = n ∨ a.2 < n }
     have ha' : a ∈ S := by grind
     refine ⟨a.fst, ⟨a.snd, ?_⟩⟩
-    obtain ⟨ha, ha⟩ := ha' <;> omega
+    obtain ⟨ha, ha⟩ := ha' <;> lia
   use f
   intro x y
   dsimp [f, peval]

--- a/Mathlib/RingTheory/ZMod/UnitsCyclic.lean
+++ b/Mathlib/RingTheory/ZMod/UnitsCyclic.lean
@@ -113,7 +113,7 @@ lemma exists_one_add_mul_pow_prime_eq
   congr 1
   · congr! 1 with i hi
     simp only [Finset.mem_erase, ne_eq, Finset.mem_range] at hi
-    have hi' : 2 ≤ i := by omega
+    have hi' : 2 ≤ i := by lia
     calc
       (u * x) ^ i * p.choose i =
         (u * x) ^ (2 + (i - 2)) * p.choose i := by rw [Nat.add_sub_of_le hi']

--- a/Mathlib/Tactic/Bound.lean
+++ b/Mathlib/Tactic/Bound.lean
@@ -179,7 +179,7 @@ end Guessing
 /-!
 ### Closing tactics
 
-TODO: Kim Morrison noted that we could check for `ℕ` or `ℤ` and try `omega` as well.
+TODO: Kim Morrison noted that we could check for `ℕ` or `ℤ` and try `lia` as well.
 -/
 
 /-- Close numerical goals with `norm_num` -/

--- a/Mathlib/Tactic/DeriveEncodable.lean
+++ b/Mathlib/Tactic/DeriveEncodable.lean
@@ -127,7 +127,7 @@ private def S_equiv : S ≃ ℕ where
       · exact nat_unpair_lt_2 h
       · obtain _ | n' := n
         · exact False.elim (h rfl)
-        · have := Nat.unpair_lt (by omega : 1 ≤ n' + 1)
+        · have := Nat.unpair_lt (by lia : 1 ≤ n' + 1)
           omega
 
 private instance : Encodable S := Encodable.ofEquiv ℕ S_equiv

--- a/Mathlib/Tactic/DeriveEncodable.lean
+++ b/Mathlib/Tactic/DeriveEncodable.lean
@@ -89,7 +89,7 @@ private lemma nat_unpair_lt_2 {n : ℕ} (h : (Nat.unpair n).1 ≠ 0) : (Nat.unpa
   unfold Nat.pair
   have := Nat.le_mul_self a
   have := Nat.le_mul_self b
-  split <;> omega
+  split <;> lia
 
 private def S.decode (n : ℕ) : S :=
   let p := Nat.unpair n
@@ -128,7 +128,7 @@ private def S_equiv : S ≃ ℕ where
       · obtain _ | n' := n
         · exact False.elim (h rfl)
         · have := Nat.unpair_lt (by lia : 1 ≤ n' + 1)
-          omega
+          lia
 
 private instance : Encodable S := Encodable.ofEquiv ℕ S_equiv
 

--- a/Mathlib/Tactic/ENatToNat.lean
+++ b/Mathlib/Tactic/ENatToNat.lean
@@ -77,7 +77,7 @@ elab "cases_first_enat" : tactic => focus do
     evalTactic (← `(tactic| all_goals try simp only [enat_to_nat_top] at *))
 
 /-- `enat_to_nat` shifts all `ENat`s in the context to `Nat`, rewriting propositions about them.
-A typical use case is `enat_to_nat; omega`. -/
+A typical use case is `enat_to_nat; lia`. -/
 macro "enat_to_nat" : tactic => `(tactic| focus (
     (repeat' cases_first_enat) <;>
     (try simp only [enat_to_nat_top, enat_to_nat_coe] at *)

--- a/Mathlib/Tactic/NormNum/Irrational.lean
+++ b/Mathlib/Tactic/NormNum/Irrational.lean
@@ -177,7 +177,7 @@ private theorem irrational_rpow_rat_rat_of_num {x y : ℝ} {x_num x_den y_num y_
     by_contra! h
     simp only [nonpos_iff_eq_zero] at h
     simp only [h, pow_zero, Nat.lt_one_iff] at hn1 hn2
-    omega
+    lia
   rcases hx_isNNRat with ⟨hx_inv, hx_eq⟩
   rcases hy_isNNRat with ⟨hy_inv, hy_eq⟩
   rw [hy_eq, hx_eq]

--- a/Mathlib/Tactic/Order/ToInt.lean
+++ b/Mathlib/Tactic/Order/ToInt.lean
@@ -14,13 +14,13 @@ public meta import Mathlib.Util.Qq
 # Translating linear orders to ℤ
 
 In this file we implement the translation of a problem in any linearly ordered type to a problem in
-`ℤ`. This allows us to use the `omega` tactic to solve it.
+`ℤ`. This allows us to use the `lia` tactic to solve it.
 
 While the core algorithm of the `order` tactic is complete for the theory of linear orders in the
 signature (`<`, `≤`),
 it becomes incomplete in the signature with lattice operations `⊓` and `⊔`. With these operations,
 the problem becomes NP-hard, and the idea is to reuse a smart and efficient procedure, such as
-`omega`.
+`lia`.
 
 ## TODO
 

--- a/Mathlib/Tactic/PNatToNat.lean
+++ b/Mathlib/Tactic/PNatToNat.lean
@@ -61,10 +61,10 @@ lemma sub_coe (a b : PNat) : ((a - b : PNat) : Nat) = a.val - 1 - b.val + 1 := b
   cases a
   cases b
   simp only [PNat.mk_coe, _root_.PNat.sub_coe, ← _root_.PNat.coe_lt_coe]
-  split_ifs <;> omega
+  split_ifs <;> lia
 
 /-- `pnat_to_nat` shifts all `PNat`s in the context to `Nat`, rewriting propositions about them.
-A typical use case is `pnat_to_nat; omega`. -/
+A typical use case is `pnat_to_nat; lia`. -/
 macro "pnat_to_nat" : tactic => `(tactic| focus (
   pnat_positivity;
   simp only [pnat_to_nat_coe] at *)

--- a/Mathlib/Topology/Algebra/InfiniteSum/ConditionalInt.lean
+++ b/Mathlib/Topology/Algebra/InfiniteSum/ConditionalInt.lean
@@ -128,7 +128,7 @@ lemma HasProd.hasProd_symmetricIco_of_hasProd_symmetricIcc {a : α}
   simp only [HasProd, tendsto_map'_iff, symmetricIcc_eq_map_Icc_nat,
     ← Nat.map_cast_int_atTop, symmetricIco] at *
   apply tendsto_of_div_tendsto_one _ hf
-  simpa [Pi.div_def, fun N : ℕ ↦ prod_Icc_eq_prod_Ico_mul f (show (-N : ℤ) ≤ N by omega)]
+  simpa [Pi.div_def, fun N : ℕ ↦ prod_Icc_eq_prod_Ico_mul f (show (-N : ℤ) ≤ N by lia)]
     using hf2
 
 @[to_additive]

--- a/Mathlib/Topology/Algebra/InfiniteSum/SummationFilter.lean
+++ b/Mathlib/Topology/Algebra/InfiniteSum/SummationFilter.lean
@@ -252,8 +252,8 @@ lemma conditional_filter_eq_map_range : (conditional ℕ).filter = atTop.map Fin
       rw [← Tendsto] <;>
       simp only [tendsto_atTop', mem_map, mem_atTop_sets, mem_preimage] <;>
       rintro s ⟨a, ha⟩
-  · exact ⟨a + 1, fun b hb ↦ ha (b + 1) (by omega)⟩
-  · exact ⟨a + 1, fun b hb ↦ by convert ha (b - 1) (by omega); omega⟩
+  · exact ⟨a + 1, fun b hb ↦ ha (b + 1) (by lia)⟩
+  · exact ⟨a + 1, fun b hb ↦ by convert ha (b - 1) (by lia); omega⟩
 
 end conditionalTop
 

--- a/Mathlib/Topology/Algebra/InfiniteSum/SummationFilter.lean
+++ b/Mathlib/Topology/Algebra/InfiniteSum/SummationFilter.lean
@@ -253,7 +253,7 @@ lemma conditional_filter_eq_map_range : (conditional ℕ).filter = atTop.map Fin
       simp only [tendsto_atTop', mem_map, mem_atTop_sets, mem_preimage] <;>
       rintro s ⟨a, ha⟩
   · exact ⟨a + 1, fun b hb ↦ ha (b + 1) (by lia)⟩
-  · exact ⟨a + 1, fun b hb ↦ by convert ha (b - 1) (by lia); omega⟩
+  · exact ⟨a + 1, fun b hb ↦ by convert ha (b - 1) (by lia); lia⟩
 
 end conditionalTop
 

--- a/Mathlib/Topology/Algebra/Order/ArchimedeanDiscrete.lean
+++ b/Mathlib/Topology/Algebra/Order/ArchimedeanDiscrete.lean
@@ -44,7 +44,7 @@ instance instDiscreteTopologyZMultiples (g : G) : DiscreteTopology (zpowers g) :
   · simp only [Set.mem_preimage, Set.mem_Ioo, Set.mem_singleton_iff, and_imp]
     intro hn hn'
     rw [zpow_lt_zpow_iff_right ha] at hn hn'
-    simp only [Subtype.ext_iff, show n = 0 by omega, zpow_zero, coe_one]
+    simp only [Subtype.ext_iff, show n = 0 by lia, zpow_zero, coe_one]
   · simp_all
 
 variable [MulArchimedean G]

--- a/Mathlib/Topology/EMetricSpace/BoundedVariation.lean
+++ b/Mathlib/Topology/EMetricSpace/BoundedVariation.lean
@@ -447,18 +447,18 @@ theorem sum (f : α → E) {s : Set α} {E : ℕ → α} (hE : Monotone E) {n : 
     by_cases hn₀ : n = 0
     · simp [hn₀]
     rw [← Icc_add_Icc (b := E n)]
-    · rw [← ih (by intros; apply hn <;> omega), Finset.sum_range_succ]
-    · apply hE; omega
-    · apply hE; omega
-    · apply hn <;> omega
+    · rw [← ih (by intros; apply hn <;> lia), Finset.sum_range_succ]
+    · apply hE; lia
+    · apply hE; lia
+    · apply hn <;> lia
 
 theorem sum' (f : α → E) {I : ℕ → α} (hI : Monotone I) {n : ℕ} :
     ∑ i ∈ Finset.range n, eVariationOn f (Icc (I i) (I (i + 1)))
      = eVariationOn f (Icc (I 0) (I n)) := by
   convert sum f hI (s := Icc (I 0) (I n)) (n := n)
-    (hn := by intros; rw [mem_Icc]; constructor <;> (apply hI; omega)) with i hi
+    (hn := by intros; rw [mem_Icc]; constructor <;> (apply hI; lia)) with i hi
   · simp only [right_eq_inter]
-    gcongr <;> (apply hI; rw [Finset.mem_range] at hi; omega)
+    gcongr <;> (apply hI; rw [Finset.mem_range] at hi; lia)
   · simp
 
 section Monotone
@@ -482,7 +482,7 @@ theorem comp_le_of_antitoneOn (f : α → E) {s : Set α} {t : Set β} (φ : β 
   rw [Finset.mem_range] at hx
   dsimp only [Subtype.coe_mk, Function.comp_apply]
   rw [edist_comm]
-  congr 4 <;> omega
+  congr 4 <;> lia
 
 theorem comp_eq_of_monotoneOn (f : α → E) {t : Set β} (φ : β → α) (hφ : MonotoneOn φ t) :
     eVariationOn (f ∘ φ) t = eVariationOn f (φ '' t) := by

--- a/Mathlib/Topology/EMetricSpace/PairReduction.lean
+++ b/Mathlib/Topology/EMetricSpace/PairReduction.lean
@@ -146,7 +146,7 @@ lemma pow_logSizeRadius_le_card_le_logSizeRadius (ha : 1 < a) (ht : t ∈ V) :
     simp
   have h := Nat.find_min (exists_radius_le t V ha c) this
   simp only [ENNReal.natCast_sub, Nat.cast_one, not_and, not_le] at h
-  exact (h (by omega)).le
+  exact (h (by lia)).le
 
 /-- A structure for carrying the data of `logSizeBallSeq` -/
 structure logSizeBallStruct (T : Type*) where

--- a/Mathlib/Topology/EMetricSpace/PairReduction.lean
+++ b/Mathlib/Topology/EMetricSpace/PairReduction.lean
@@ -285,7 +285,7 @@ lemma card_finset_logSizeBallSeq_le (hJ : J.Nonempty) (i : ℕ) :
   | succ i ih =>
     by_cases h : (logSizeBallSeq J hJ a c i).finset.Nonempty
     · have := card_finset_logSizeBallSeq_add_one_lt hJ i h
-      omega
+      lia
     apply le_trans <| Finset.card_le_card (finset_logSizeBallSeq_add_one_subset hJ i)
     suffices #(logSizeBallSeq J hJ a c i).finset = 0 by simp [this]
     rwa [← not_ne_iff, Finset.card_ne_zero.not]

--- a/Mathlib/Topology/UniformSpace/Cauchy.lean
+++ b/Mathlib/Topology/UniformSpace/Cauchy.lean
@@ -279,7 +279,7 @@ theorem cauchySeq_shift {u : ℕ → α} (k : ℕ) : CauchySeq (fun n ↦ u (n +
     obtain ⟨N, h⟩ := h V mV
     use N + k
     intro a ha b hb
-    convert h (a - k) (Nat.le_sub_of_add_le ha) (b - k) (Nat.le_sub_of_add_le hb) <;> omega
+    convert h (a - k) (Nat.le_sub_of_add_le ha) (b - k) (Nat.le_sub_of_add_le hb) <;> lia
   · exact h.comp_tendsto (tendsto_add_atTop_nat k)
 
 theorem Filter.HasBasis.cauchySeq_iff {γ} [Nonempty β] [SemilatticeSup β] {u : β → α} {p : γ → Prop}

--- a/MathlibTest/FlexibleLinter.lean
+++ b/MathlibTest/FlexibleLinter.lean
@@ -111,9 +111,9 @@ example (h : 0 = 1 ∨ 0 = 1) : 0 = 1 ∧ 0 = 1 := by
   on_goal 2 => · contradiction
   · contradiction
 
--- `omega` is a follower and `all_goals` is a `combinatorLike`
+-- `lia` is a follower and `all_goals` is a `combinatorLike`
 #guard_msgs in
-example {a : Nat} : a + 1 + 0 = 1 + a := by simp; all_goals omega
+example {a : Nat} : a + 1 + 0 = 1 + a := by simp; all_goals lia
 
 /--
 warning: 'simp' is a flexible tactic modifying '⊢'. Try 'simp?' and use the suggested 'simp only [...]'. Alternatively, use `suffices` to explicitly state the simplified form.
@@ -226,7 +226,7 @@ example (h : 0 = 1 ∨ 0 = 1) : 0 = 1 ∧ 0 = 1 := by
 example (n : Nat) : n + 1 = 1 + n := by
   by_cases 0 = 0
   · simp_all
-    omega
+    lia
   · have : 0 ≠ 1 := by
       intro h
       -- should not flag `cases`!

--- a/MathlibTest/TacticAnalysis.lean
+++ b/MathlibTest/TacticAnalysis.lean
@@ -349,7 +349,7 @@ example : x = y := by
   try
     symm
     symm
-    omega
+    lia
   rfl
 
 set_option linter.unusedVariables false in
@@ -367,7 +367,7 @@ example : x = y := by
   any_goals
     symm
     symm
-    omega
+    lia
   rfl
 
 end grindReplacement

--- a/MathlibTest/enat_to_nat.lean
+++ b/MathlibTest/enat_to_nat.lean
@@ -2,23 +2,23 @@ import Mathlib.Tactic.ENatToNat
 
 example (a b : ENat) (h : a = b) : a - b = b - a := by
   enat_to_nat
-  omega
+  lia
 
 example (a b : ENat) (h : a ≤ b) : a - b < b + 1 := by
   enat_to_nat
-  omega
+  lia
 
 example (a b : ENat) (h : a ≤ b) : a - 2 * b ≤ b + 1 := by
   enat_to_nat
-  omega
+  lia
 
 example (a b c : ENat) (hab : a ≥ b) (hbc : b ≥ c) : a ≥ c := by
   enat_to_nat
-  omega
+  lia
 
 example (a b : ENat) (h : a = b) : a - b = b - a := by
   -- to test if the tactic works with inaccessible names
   let a : ℤ := 42
   let b : ℤ := 32
   enat_to_nat
-  omega
+  lia

--- a/MathlibTest/observe.lean
+++ b/MathlibTest/observe.lean
@@ -11,7 +11,7 @@ theorem euclid (n : ℕ) : ∃ N, n < N ∧ N.Prime := by
   have prime : p.Prime := by
     apply minFac_prime
     observe : n.factorial > 0
-    omega
+    lia
   constructor
   · by_contra!
     observe : p ∣ n.factorial

--- a/MathlibTest/pnat_to_nat.lean
+++ b/MathlibTest/pnat_to_nat.lean
@@ -2,15 +2,15 @@ import Mathlib.Tactic.PNatToNat
 
 example (a b : PNat) (h : a < b) : 1 < b := by
   pnat_to_nat
-  omega
+  lia
 
 example (a b : PNat) (h : a = b) : b = a := by
   -- to test if the tactic works with inaccessible names
   let a : ℤ := 42
   pnat_to_nat
-  omega
+  lia
 
 example (a b : PNat) (h : a < b) : 1 < b := by
   have := a.pos
   pnat_to_nat
-  omega
+  lia


### PR DESCRIPTION
As previously discussed, we'd like to move users off `omega` and on to `lia` (which is the linear integer arithmetic module from `grind`, plus a controlled set of instantiated lemmas).

This does not yet remove all uses of `omega` in Mathlib.