### PR TITLE
chore: add `grind` attribute to `Nat.cast_id`

### DIFF
--- a/Mathlib/Data/Nat/Cast/Basic.lean
+++ b/Mathlib/Data/Nat/Cast/Basic.lean
@@ -166,7 +166,7 @@ theorem eq_natCast' {R} [NonAssocSemiring R] (f : ℕ →+* R) : f = Nat.castRin
 
 end RingHom
 
-@[simp, norm_cast]
+@[simp, norm_cast, grind =]
 theorem Nat.cast_id (n : ℕ) : n.cast = n :=
   rfl
 


### PR DESCRIPTION
This PR adds `grind =` to `Nat.cast_id` so `grind` can use it for rewriting. This resolves some `linarith`/`grind` regressions.

🤖 Prepared with Claude Code