### PR TITLE
[Merged by Bors] - chore: notation `R⟦Γ⟧ = HahnSeries Γ R`

### DIFF
--- a/Mathlib/Algebra/Order/Module/HahnEmbedding.lean
+++ b/Mathlib/Algebra/Order/Module/HahnEmbedding.lean
@@ -58,7 +58,7 @@ If `ArchimedeanClass M` is finite, the direct sum is the entire `M` and we are d
 following steps.
 -/
 
-open ArchimedeanClass DirectSum
+open ArchimedeanClass DirectSum HahnSeries
 
 variable {K : Type*} [DivisionRing K] [LinearOrder K] [IsOrderedRing K] [Archimedean K]
 variable {M : Type*} [AddCommGroup M] [LinearOrder M] [IsOrderedAddMonoid M]

--- a/Mathlib/Algebra/Order/Module/HahnEmbedding.lean
+++ b/Mathlib/Algebra/Order/Module/HahnEmbedding.lean
@@ -21,7 +21,7 @@ This file proves a variant of the Hahn embedding theorem:
 
 For a linearly ordered module `M` over an Archimedean division ring `K`,
 there exists a strictly monotone linear map to lexicographically ordered
-`HahnSeries (FiniteArchimedeanClass M) R` with an archimedean `K`-module `R`,
+`R⟦FiniteArchimedeanClass M⟧` with an archimedean `K`-module `R`,
 as long as there are embeddings from a certain family of Archimedean submodules to `R`.
 
 The family of Archimedean submodules `HahnEmbedding.ArchimedeanStrata K M` is indexed by
@@ -35,7 +35,7 @@ to a proof of the classic Hahn embedding theorem. (See `hahnEmbedding_isOrderedA
 ## Main theorem
 
 * `hahnEmbedding_isOrderedModule`:
-  there exists a strictly monotone `M →ₗ[K] Lex (HahnSeries (FiniteArchimedeanClass M) R)` that maps
+  there exists a strictly monotone `M →ₗ[K] Lex R⟦FiniteArchimedeanClass M⟧` that maps
   `ArchimedeanClass M` to `HahnSeries.orderTop` in the expected way, as long as
   `HahnEmbedding.Seed K M R` is nonempty.
 
@@ -52,7 +52,7 @@ We start with `HahnEmbedding.ArchimedeanStrata` that gives a family of Archimede
 and a "seed" `HahnEmbedding.Seed` that specifies how to embed each
 `HahnEmbedding.ArchimedeanStrata.stratum` into `R`.
 
-From these, we create a partial map from the direct sum of all `stratum` to `HahnSeries Γ R`.
+From these, we create a partial map from the direct sum of all `stratum` to `R⟦Γ⟧`.
 If `ArchimedeanClass M` is finite, the direct sum is the entire `M` and we are done
 (though we don't handle this case separately). Otherwise, we will extend the map to `M` in the
 following steps.
@@ -237,7 +237,7 @@ theorem hahnCoeff_apply {x : seed.baseDomain} {f : Π₀ c, seed.stratum c}
 /-- Combining all `HahnEmbedding.Seed.coeff` as
 a partial linear map from `HahnEmbedding.Seed.baseDomain` to `HahnSeries`. -/
 noncomputable
-def baseEmbedding : M →ₗ.[K] Lex (HahnSeries (FiniteArchimedeanClass M) R) where
+def baseEmbedding : M →ₗ.[K] Lex R⟦FiniteArchimedeanClass M⟧ where
   domain := seed.baseDomain
   toFun := (toLexLinearEquiv _ _).toLinearMap ∘ₗ (HahnSeries.ofFinsuppLinearMap _) ∘ₗ
     (Finsupp.lcomapDomain _ Subtype.val_injective) ∘ₗ
@@ -268,7 +268,7 @@ transferring `ArchimedeanClass` to `HahnEmbedding.orderTop`, and being "truncati
 
 /-- A partial linear map is called a "partial Hahn embedding" if it extends
 `HahnEmbedding.Seed.baseEmbedding`, is strictly monotone, and is truncation-closed. -/
-structure IsPartial (f : M →ₗ.[K] Lex (HahnSeries (FiniteArchimedeanClass M) R)) : Prop where
+structure IsPartial (f : M →ₗ.[K] Lex R⟦FiniteArchimedeanClass M⟧) : Prop where
   /-- A partial Hahn embedding is strictly monotone. -/
   strictMono : StrictMono f
   /-- A partial Hahn embedding always extends `baseEmbedding`. -/
@@ -395,7 +395,7 @@ theorem isPartial_baseEmbedding [IsOrderedAddMonoid R] : IsPartial seed seed.bas
 end Seed
 
 /-- The type of all partial Hahn embeddings. -/
-abbrev Partial := {f : M →ₗ.[K] Lex (HahnSeries (FiniteArchimedeanClass M) R) // IsPartial seed f}
+abbrev Partial := {f : M →ₗ.[K] Lex R⟦FiniteArchimedeanClass M⟧ // IsPartial seed f}
 
 namespace Partial
 variable {seed} (f : Partial seed)
@@ -405,7 +405,7 @@ instance [IsOrderedAddMonoid R] : Inhabited (Partial seed) where
   default := ⟨seed.baseEmbedding, seed.isPartial_baseEmbedding⟩
 
 /-- `HahnEmbedding.Partial` as an `OrderedAddMonoidHom`. -/
-def toOrderAddMonoidHom : f.val.domain →+o Lex (HahnSeries (FiniteArchimedeanClass M) R) where
+def toOrderAddMonoidHom : f.val.domain →+o Lex R⟦FiniteArchimedeanClass M⟧ where
   __ := f.val.toFun
   map_zero' := by simp
   monotone' := f.prop.strictMono.monotone
@@ -586,7 +586,7 @@ theorem isWF_support_evalCoeff [IsOrderedAddMonoid R] [Archimedean R] (x : M) :
 /-- Promote `HahnEmbedding.Partial.evalCoeff`'s output to a new `HahnSeries`. -/
 noncomputable
 def eval [IsOrderedAddMonoid R] [Archimedean R] (x : M) :
-    Lex (HahnSeries (FiniteArchimedeanClass M) R) :=
+    Lex R⟦FiniteArchimedeanClass M⟧ :=
   toLex { coeff := f.evalCoeff x
           isPWO_support' := (f.isWF_support_evalCoeff x).isPWO }
 
@@ -772,7 +772,7 @@ theorem eval_lt [IsOrderedAddMonoid R] [Archimedean R] {x : M} (hx : x ∉ f.val
 /-- Extend `f` to a larger partial linear map by adding a new `x`. -/
 noncomputable
 def extendFun [IsOrderedAddMonoid R] [Archimedean R] {x : M} (hx : x ∉ f.val.domain) :
-    M →ₗ.[K] Lex (HahnSeries (FiniteArchimedeanClass M) R) :=
+    M →ₗ.[K] Lex R⟦FiniteArchimedeanClass M⟧ :=
   .supSpanSingleton f.val x (eval f x) hx
 
 theorem extendFun_strictMono [IsOrderedAddMonoid R] [Archimedean R] {x : M}
@@ -898,7 +898,7 @@ embeddings by adding new elements, the maximal embedding must have the maximal d
 `HahnEmbedding.Partial`. -/
 noncomputable
 def sSupFun {c : Set (Partial seed)} (hc : DirectedOn (· ≤ ·) c) :
-    M →ₗ.[K] Lex (HahnSeries (FiniteArchimedeanClass M) R) :=
+    M →ₗ.[K] Lex R⟦FiniteArchimedeanClass M⟧ :=
   LinearPMap.sSup ((·.val) '' c) (hc.mono_comp (by simp))
 
 theorem sSupFun_strictMono [IsOrderedAddMonoid R] {c : Set (Partial seed)}
@@ -988,13 +988,13 @@ end HahnEmbedding
 
 /-- **Hahn embedding theorem for an ordered module**
 
-There exists a strictly monotone `M →ₗ[K] Lex (HahnSeries (FiniteArchimedeanClass M) R)` that maps
+There exists a strictly monotone `M →ₗ[K] Lex R⟦FiniteArchimedeanClass M⟧` that maps
 `ArchimedeanClass M` to `HahnSeries.orderTop` in the expected way, as long as
 `HahnEmbedding.Seed K M R` is nonempty. The `HahnEmbedding.Partial` with maximal domain is the
 desired embedding. -/
 theorem hahnEmbedding_isOrderedModule [IsOrderedAddMonoid R] [Archimedean R]
     [h : Nonempty (HahnEmbedding.Seed K M R)] :
-    ∃ f : M →ₗ[K] Lex (HahnSeries (FiniteArchimedeanClass M) R), StrictMono f ∧
+    ∃ f : M →ₗ[K] Lex R⟦FiniteArchimedeanClass M⟧, StrictMono f ∧
       ∀ (a : M), mk a = FiniteArchimedeanClass.withTopOrderIso M (ofLex (f a)).orderTop := by
   obtain ⟨e, hdomain⟩ := HahnEmbedding.Partial.exists_domain_eq_top h.some
   obtain harch := e.orderTop_eq_archimedeanClassMk

--- a/Mathlib/Algebra/Order/Ring/Archimedean.lean
+++ b/Mathlib/Algebra/Order/Ring/Archimedean.lean
@@ -33,7 +33,7 @@ reasons:
 
 * In the ring version of Hahn embedding theorem, the subtype `FiniteArchimedeanClass R` of non-top
   elements in `ArchimedeanClass R` naturally becomes the additive abelian group for the ring
-  `HahnSeries (FiniteArchimedeanClass R) ℝ`.
+  `ℝ⟦FiniteArchimedeanClass R⟧`.
 * The order we defined on `ArchimedeanClass R` matches the order on `AddValuation`, rather than the
   one on `Valuation`.
 -/

--- a/Mathlib/RingTheory/HahnSeries/Addition.lean
+++ b/Mathlib/RingTheory/HahnSeries/Addition.lean
@@ -56,12 +56,10 @@ theorem coeff_smul' (r : R) (x : HahnSeries Γ V) : (r • x).coeff = r • x.co
 theorem coeff_smul {r : R} {x : HahnSeries Γ V} {a : Γ} : (r • x).coeff a = r • x.coeff a :=
   rfl
 
-instance : SMulZeroClass R (HahnSeries Γ V) :=
-  { inferInstanceAs (SMul R (HahnSeries Γ V)) with
-    smul_zero := by
-      intro
-      ext
-      simp only [coeff_smul, coeff_zero, smul_zero]}
+instance : SMulZeroClass R (HahnSeries Γ V) where
+  smul_zero _ := by
+    ext
+    simp only [coeff_smul, coeff_zero, smul_zero]
 
 theorem orderTop_smul_not_lt (r : R) (x : HahnSeries Γ V) : ¬ (r • x).orderTop < x.orderTop := by
   by_cases hrx : r • x = 0
@@ -320,11 +318,10 @@ section AddCommMonoid
 
 variable [AddCommMonoid R]
 
-instance : AddCommMonoid (HahnSeries Γ R) :=
-  { inferInstanceAs (AddMonoid (HahnSeries Γ R)) with
-    add_comm := fun x y => by
-      ext
-      apply add_comm }
+instance : AddCommMonoid (HahnSeries Γ R) where
+  add_comm x y := by
+    ext
+    apply add_comm
 
 @[simp]
 theorem coeff_sum {s : Finset α} {x : α → HahnSeries Γ R} (g : Γ) :
@@ -442,9 +439,7 @@ theorem le_orderTop_of_leadingCoeff_eq {Γ} [LinearOrder Γ] {x y : HahnSeries �
 
 end AddGroup
 
-instance [AddCommGroup R] : AddCommGroup (HahnSeries Γ R) :=
-  { inferInstanceAs (AddCommMonoid (HahnSeries Γ R)),
-    inferInstanceAs (AddGroup (HahnSeries Γ R)) with }
+instance [AddCommGroup R] : AddCommGroup (HahnSeries Γ R) where
 
 end Addition
 
@@ -484,14 +479,13 @@ section Module
 
 variable [PartialOrder Γ] [Semiring R] [AddCommMonoid V] [Module R V]
 
-instance : Module R (HahnSeries Γ V) :=
-  { inferInstanceAs (DistribMulAction R (HahnSeries Γ V)) with
-    zero_smul := fun _ => by
-      ext
-      simp
-    add_smul := fun _ _ _ => by
-      ext
-      simp [add_smul] }
+instance : Module R (HahnSeries Γ V) where
+  zero_smul _ := by
+    ext
+    simp
+  add_smul _ _ _ := by
+    ext
+    simp [add_smul]
 
 /-- `single` as a linear map -/
 @[simps]

--- a/Mathlib/RingTheory/HahnSeries/Addition.lean
+++ b/Mathlib/RingTheory/HahnSeries/Addition.lean
@@ -16,13 +16,13 @@ public import Mathlib.Tactic.FastInstance
 
 /-!
 # Additive properties of Hahn series
-If `Γ` is ordered and `R` has zero, then `HahnSeries Γ R` consists of formal series over `Γ` with
-coefficients in `R`, whose supports are partially well-ordered. With further structure on `R` and
-`Γ`, we can add further structure on `HahnSeries Γ R`.  When `R` has an addition operation,
-`HahnSeries Γ R` also has addition by adding coefficients.
+If `Γ` is ordered and `R` has zero, then `R⟦Γ⟧` consists of formal series over `Γ` with coefficients
+in `R`, whose supports are partially well-ordered. With further structure on `R` and `Γ`, we can add
+further structure on `R⟦Γ⟧`.  When `R` has an addition operation, `R⟦Γ⟧` also has addition by adding
+coefficients.
 
 ## Main Definitions
-* If `R` is a (commutative) additive monoid or group, then so is `HahnSeries Γ R`.
+* If `R` is a (commutative) additive monoid or group, then so is `R⟦Γ⟧`.
 
 ## References
 - [J. van der Hoeven, *Operators on Generalized Power Series*][van_der_hoeven]
@@ -43,27 +43,27 @@ section SMulZeroClass
 
 variable [PartialOrder Γ] {V : Type*} [Zero V] [SMulZeroClass R V]
 
-instance : SMul R (HahnSeries Γ V) :=
+instance : SMul R V⟦Γ⟧ :=
   ⟨fun r x =>
     { coeff := r • x.coeff
       isPWO_support' := x.isPWO_support.mono (Function.support_const_smul_subset r x.coeff) }⟩
 
 @[simp]
-theorem coeff_smul' (r : R) (x : HahnSeries Γ V) : (r • x).coeff = r • x.coeff :=
+theorem coeff_smul' (r : R) (x : V⟦Γ⟧) : (r • x).coeff = r • x.coeff :=
   rfl
 
 @[simp]
-theorem coeff_smul {r : R} {x : HahnSeries Γ V} {a : Γ} : (r • x).coeff a = r • x.coeff a :=
+theorem coeff_smul {r : R} {x : V⟦Γ⟧} {a : Γ} : (r • x).coeff a = r • x.coeff a :=
   rfl
 
-instance : SMulZeroClass R (HahnSeries Γ V) :=
-  { inferInstanceAs (SMul R (HahnSeries Γ V)) with
+instance : SMulZeroClass R V⟦Γ⟧ :=
+  { inferInstanceAs (SMul R V⟦Γ⟧) with
     smul_zero := by
       intro
       ext
       simp only [coeff_smul, coeff_zero, smul_zero]}
 
-theorem orderTop_smul_not_lt (r : R) (x : HahnSeries Γ V) : ¬ (r • x).orderTop < x.orderTop := by
+theorem orderTop_smul_not_lt (r : R) (x : V⟦Γ⟧) : ¬ (r • x).orderTop < x.orderTop := by
   by_cases hrx : r • x = 0
   · rw [hrx, orderTop_zero]
     exact not_top_lt
@@ -72,21 +72,21 @@ theorem orderTop_smul_not_lt (r : R) (x : HahnSeries Γ V) : ¬ (r • x).orderT
     exact Set.IsWF.min_of_subset_not_lt_min
       (Function.support_smul_subset_right (fun _ => r) x.coeff)
 
-theorem orderTop_le_orderTop_smul {Γ} [LinearOrder Γ] (r : R) (x : HahnSeries Γ V) :
+theorem orderTop_le_orderTop_smul {Γ} [LinearOrder Γ] (r : R) (x : V⟦Γ⟧) :
     x.orderTop ≤ (r • x).orderTop :=
   le_of_not_gt <| orderTop_smul_not_lt r x
 
-theorem order_smul_not_lt [Zero Γ] (r : R) (x : HahnSeries Γ V) (h : r • x ≠ 0) :
+theorem order_smul_not_lt [Zero Γ] (r : R) (x : V⟦Γ⟧) (h : r • x ≠ 0) :
     ¬ (r • x).order < x.order := by
   have hx : x ≠ 0 := right_ne_zero_of_smul h
   simp_all only [order, dite_false]
   exact Set.IsWF.min_of_subset_not_lt_min (Function.support_smul_subset_right (fun _ => r) x.coeff)
 
-theorem le_order_smul {Γ} [Zero Γ] [LinearOrder Γ] (r : R) (x : HahnSeries Γ V) (h : r • x ≠ 0) :
+theorem le_order_smul {Γ} [Zero Γ] [LinearOrder Γ] (r : R) (x : V⟦Γ⟧) (h : r • x ≠ 0) :
     x.order ≤ (r • x).order :=
   le_of_not_gt (order_smul_not_lt r x h)
 
-theorem truncLT_smul [DecidableLT Γ] (c : Γ) (r : R) (x : HahnSeries Γ V) :
+theorem truncLT_smul [DecidableLT Γ] (c : Γ) (r : R) (x : V⟦Γ⟧) :
     truncLT c (r • x) = r • truncLT c x := by ext; simp
 
 end SMulZeroClass
@@ -99,31 +99,31 @@ section AddMonoid
 
 variable [AddMonoid R]
 
-instance : Add (HahnSeries Γ R) where
+instance : Add R⟦Γ⟧ where
   add x y :=
     { coeff := x.coeff + y.coeff
       isPWO_support' := (x.isPWO_support.union y.isPWO_support).mono (Function.support_add _ _) }
 
 @[simp]
-theorem coeff_add' (x y : HahnSeries Γ R) : (x + y).coeff = x.coeff + y.coeff :=
+theorem coeff_add' (x y : R⟦Γ⟧) : (x + y).coeff = x.coeff + y.coeff :=
   rfl
 
-theorem coeff_add {x y : HahnSeries Γ R} {a : Γ} : (x + y).coeff a = x.coeff a + y.coeff a :=
+theorem coeff_add {x y : R⟦Γ⟧} {a : Γ} : (x + y).coeff a = x.coeff a + y.coeff a :=
   rfl
 
 @[simp] theorem single_add (a : Γ) (r s : R) : single a (r + s) = single a r + single a s := by
   classical
   ext : 1; exact Pi.single_add (f := fun _ => R) a r s
 
-instance : AddMonoid (HahnSeries Γ R) := fast_instance%
+instance : AddMonoid R⟦Γ⟧ := fast_instance%
   coeff_injective.addMonoid _
     coeff_zero' coeff_add' (fun _ _ => coeff_smul' _ _)
 
-theorem coeff_nsmul {x : HahnSeries Γ R} {n : ℕ} : (n • x).coeff = n • x.coeff := coeff_smul' _ _
+theorem coeff_nsmul {x : R⟦Γ⟧} {n : ℕ} : (n • x).coeff = n • x.coeff := coeff_smul' _ _
 
 @[simp]
-protected lemma map_add [AddMonoid S] (f : R →+ S) {x y : HahnSeries Γ R} :
-    ((x + y).map f : HahnSeries Γ S) = x.map f + y.map f := by
+protected lemma map_add [AddMonoid S] (f : R →+ S) {x y : R⟦Γ⟧} :
+    ((x + y).map f : S⟦Γ⟧) = x.map f + y.map f := by
   ext; simp
 /--
 `addOppositeEquiv` is an additive monoid isomorphism between
@@ -131,7 +131,7 @@ Hahn series over `Γ` with coefficients in the opposite additive monoid `Rᵃᵒ
 and the additive opposite of Hahn series over `Γ` with coefficients `R`.
 -/
 @[simps -isSimp]
-def addOppositeEquiv : HahnSeries Γ Rᵃᵒᵖ ≃+ (HahnSeries Γ R)ᵃᵒᵖ where
+def addOppositeEquiv : R⟦Γ⟧ᵃᵒᵖ ≃+ R⟦Γ⟧ᵃᵒᵖ where
   toFun x := .op ⟨fun a ↦ (x.coeff a).unop, by convert x.isPWO_support; ext; simp⟩
   invFun x := ⟨fun a ↦ .op (x.unop.coeff a), by convert x.unop.isPWO_support; ext; simp⟩
   left_inv x := by simp
@@ -144,18 +144,18 @@ def addOppositeEquiv : HahnSeries Γ Rᵃᵒᵖ ≃+ (HahnSeries Γ R)ᵃᵒᵖ 
     simp
 
 @[simp]
-lemma addOppositeEquiv_support (x : HahnSeries Γ Rᵃᵒᵖ) :
+lemma addOppositeEquiv_support (x : R⟦Γ⟧ᵃᵒᵖ) :
     (addOppositeEquiv x).unop.support = x.support := by
   ext
   simp [addOppositeEquiv_apply]
 
 @[simp]
-lemma addOppositeEquiv_symm_support (x : (HahnSeries Γ R)ᵃᵒᵖ) :
+lemma addOppositeEquiv_symm_support (x : R⟦Γ⟧ᵃᵒᵖ) :
     (addOppositeEquiv.symm x).support = x.unop.support := by
   rw [← addOppositeEquiv_support, AddEquiv.apply_symm_apply]
 
 @[simp]
-lemma addOppositeEquiv_orderTop (x : HahnSeries Γ Rᵃᵒᵖ) :
+lemma addOppositeEquiv_orderTop (x : R⟦Γ⟧ᵃᵒᵖ) :
     (addOppositeEquiv x).unop.orderTop = x.orderTop := by
   classical
   simp only [orderTop,
@@ -165,12 +165,12 @@ lemma addOppositeEquiv_orderTop (x : HahnSeries Γ Rᵃᵒᵖ) :
   simp only [Pi.zero_apply, AddOpposite.unop_eq_zero_iff, coeff_zero]
 
 @[simp]
-lemma addOppositeEquiv_symm_orderTop (x : (HahnSeries Γ R)ᵃᵒᵖ) :
+lemma addOppositeEquiv_symm_orderTop (x : R⟦Γ⟧ᵃᵒᵖ) :
     (addOppositeEquiv.symm x).orderTop = x.unop.orderTop := by
   rw [← addOppositeEquiv_orderTop, AddEquiv.apply_symm_apply]
 
 @[simp]
-lemma addOppositeEquiv_leadingCoeff (x : HahnSeries Γ Rᵃᵒᵖ) :
+lemma addOppositeEquiv_leadingCoeff (x : R⟦Γ⟧ᵃᵒᵖ) :
     (addOppositeEquiv x).unop.leadingCoeff = x.leadingCoeff.unop := by
   classical
   obtain rfl | hx := eq_or_ne x 0
@@ -180,19 +180,19 @@ lemma addOppositeEquiv_leadingCoeff (x : HahnSeries Γ Rᵃᵒᵖ) :
   simp [addOppositeEquiv]
 
 @[simp]
-lemma addOppositeEquiv_symm_leadingCoeff (x : (HahnSeries Γ R)ᵃᵒᵖ) :
+lemma addOppositeEquiv_symm_leadingCoeff (x : R⟦Γ⟧ᵃᵒᵖ) :
     (addOppositeEquiv.symm x).leadingCoeff = .op x.unop.leadingCoeff := by
   apply AddOpposite.unop_injective
   rw [← addOppositeEquiv_leadingCoeff, AddEquiv.apply_symm_apply, AddOpposite.unop_op]
 
-theorem support_add_subset {x y : HahnSeries Γ R} : support (x + y) ⊆ support x ∪ support y :=
+theorem support_add_subset {x y : R⟦Γ⟧} : support (x + y) ⊆ support x ∪ support y :=
   fun a ha => by
   rw [mem_support, coeff_add] at ha
   rw [Set.mem_union, mem_support, mem_support]
   contrapose! ha
   rw [ha.1, ha.2, add_zero]
 
-protected theorem min_le_min_add {Γ} [LinearOrder Γ] {x y : HahnSeries Γ R} (hx : x ≠ 0)
+protected theorem min_le_min_add {Γ} [LinearOrder Γ] {x y : R⟦Γ⟧} (hx : x ≠ 0)
     (hy : y ≠ 0) (hxy : x + y ≠ 0) :
     min (Set.IsWF.min x.isWF_support (support_nonempty_iff.2 hx))
       (Set.IsWF.min y.isWF_support (support_nonempty_iff.2 hy)) ≤
@@ -200,7 +200,7 @@ protected theorem min_le_min_add {Γ} [LinearOrder Γ] {x y : HahnSeries Γ R} (
   rw [← Set.IsWF.min_union]
   exact Set.IsWF.min_le_min_of_subset (support_add_subset (x := x) (y := y))
 
-theorem min_orderTop_le_orderTop_add {Γ} [LinearOrder Γ] {x y : HahnSeries Γ R} :
+theorem min_orderTop_le_orderTop_add {Γ} [LinearOrder Γ] {x y : R⟦Γ⟧} :
     min x.orderTop y.orderTop ≤ (x + y).orderTop := by
   by_cases hx : x = 0; · simp [hx]
   by_cases hy : y = 0; · simp [hy]
@@ -209,14 +209,14 @@ theorem min_orderTop_le_orderTop_add {Γ} [LinearOrder Γ] {x y : HahnSeries Γ 
     WithTop.coe_le_coe]
   exact HahnSeries.min_le_min_add hx hy hxy
 
-theorem min_order_le_order_add {Γ} [Zero Γ] [LinearOrder Γ] {x y : HahnSeries Γ R}
+theorem min_order_le_order_add {Γ} [Zero Γ] [LinearOrder Γ] {x y : R⟦Γ⟧}
     (hxy : x + y ≠ 0) : min x.order y.order ≤ (x + y).order := by
   by_cases hx : x = 0; · simp [hx]
   by_cases hy : y = 0; · simp [hy]
   rw [order_of_ne hx, order_of_ne hy, order_of_ne hxy]
   exact HahnSeries.min_le_min_add hx hy hxy
 
-theorem orderTop_add_eq_left {Γ} [LinearOrder Γ] {x y : HahnSeries Γ R}
+theorem orderTop_add_eq_left {Γ} [LinearOrder Γ] {x y : R⟦Γ⟧}
     (hxy : x.orderTop < y.orderTop) : (x + y).orderTop = x.orderTop := by
   have hx : x ≠ 0 := orderTop_ne_top.1 hxy.ne_top
   let g : Γ := Set.IsWF.min x.isWF_support (support_nonempty_iff.2 hx)
@@ -229,13 +229,13 @@ theorem orderTop_add_eq_left {Γ} [LinearOrder Γ] {x y : HahnSeries Γ R}
     exact orderTop_le_of_coeff_ne_zero hcxyne
   exact le_antisymm hxyx (le_of_eq_of_le (min_eq_left_of_lt hxy).symm min_orderTop_le_orderTop_add)
 
-theorem orderTop_add_eq_right {Γ} [LinearOrder Γ] {x y : HahnSeries Γ R}
+theorem orderTop_add_eq_right {Γ} [LinearOrder Γ] {x y : R⟦Γ⟧}
     (hxy : y.orderTop < x.orderTop) : (x + y).orderTop = y.orderTop := by
   simpa [← map_add, ← AddOpposite.op_add, hxy] using orderTop_add_eq_left
     (x := addOppositeEquiv.symm (.op y))
     (y := addOppositeEquiv.symm (.op x))
 
-theorem leadingCoeff_add_eq_left {Γ} [LinearOrder Γ] {x y : HahnSeries Γ R}
+theorem leadingCoeff_add_eq_left {Γ} [LinearOrder Γ] {x y : R⟦Γ⟧}
     (hxy : x.orderTop < y.orderTop) : (x + y).leadingCoeff = x.leadingCoeff := by
   have hx : x ≠ 0 := orderTop_ne_top.1 hxy.ne_top
   have ho : (x + y).orderTop = x.orderTop := orderTop_add_eq_left hxy
@@ -245,24 +245,24 @@ theorem leadingCoeff_add_eq_left {Γ} [LinearOrder Γ] {x y : HahnSeries Γ R}
   · simp_rw [leadingCoeff_of_ne_zero h, leadingCoeff_of_ne_zero hx, ho, coeff_add]
     rw [coeff_eq_zero_of_lt_orderTop (x := y) (by simpa using hxy), add_zero]
 
-theorem leadingCoeff_add_eq_right {Γ} [LinearOrder Γ] {x y : HahnSeries Γ R}
+theorem leadingCoeff_add_eq_right {Γ} [LinearOrder Γ] {x y : R⟦Γ⟧}
     (hxy : y.orderTop < x.orderTop) : (x + y).leadingCoeff = y.leadingCoeff := by
   simpa [← map_add, ← AddOpposite.op_add, hxy] using leadingCoeff_add_eq_left
     (x := addOppositeEquiv.symm (.op y))
     (y := addOppositeEquiv.symm (.op x))
 
-theorem ne_zero_of_eq_add_single [Zero Γ] {x y : HahnSeries Γ R}
+theorem ne_zero_of_eq_add_single [Zero Γ] {x y : R⟦Γ⟧}
     (hxy : x = y + single x.order x.leadingCoeff) (hy : y ≠ 0) : x ≠ 0 := by
   by_contra h
   simp only [h, order_zero, leadingCoeff_zero, map_zero, add_zero] at hxy
   exact hy hxy.symm
 
-theorem coeff_order_of_eq_add_single {R} [AddCancelCommMonoid R] [Zero Γ] {x y : HahnSeries Γ R}
+theorem coeff_order_of_eq_add_single {R} [AddCancelCommMonoid R] [Zero Γ] {x y : R⟦Γ⟧}
     (hxy : x = y + single x.order x.leadingCoeff) : y.coeff x.order = 0 := by
   simpa [← leadingCoeff_eq] using congr(($hxy).coeff x.order)
 
 theorem order_lt_order_of_eq_add_single {R} {Γ} [LinearOrder Γ] [Zero Γ] [AddCancelCommMonoid R]
-    {x y : HahnSeries Γ R} (hxy : x = y + single x.order x.leadingCoeff) (hy : y ≠ 0) :
+    {x y : R⟦Γ⟧} (hxy : x = y + single x.order x.leadingCoeff) (hy : y ≠ 0) :
     x.order < y.order := by
   have : x.order ≠ y.order := by
     intro h
@@ -284,13 +284,13 @@ theorem order_lt_order_of_eq_add_single {R} {Γ} [LinearOrder Γ] [Zero Γ] [Add
 
 /-- `single` as an additive monoid/group homomorphism -/
 @[simps!]
-def single.addMonoidHom (a : Γ) : R →+ HahnSeries Γ R :=
+def single.addMonoidHom (a : Γ) : R →+ R⟦Γ⟧ :=
   { single a with
     map_add' := single_add _ }
 
 /-- `coeff g` as an additive monoid/group homomorphism -/
 @[simps]
-def coeff.addMonoidHom (g : Γ) : HahnSeries Γ R →+ R where
+def coeff.addMonoidHom (g : Γ) : R⟦Γ⟧ →+ R where
   toFun f := f.coeff g
   map_zero' := coeff_zero
   map_add' _ _ := coeff_add
@@ -299,7 +299,7 @@ section Domain
 
 variable [PartialOrder Γ']
 
-theorem embDomain_add (f : Γ ↪o Γ') (x y : HahnSeries Γ R) :
+theorem embDomain_add (f : Γ ↪o Γ') (x y : R⟦Γ⟧) :
     embDomain f (x + y) = embDomain f x + embDomain f y := by
   ext g
   by_cases hg : g ∈ Set.range f
@@ -309,7 +309,7 @@ theorem embDomain_add (f : Γ ↪o Γ') (x y : HahnSeries Γ R) :
 
 end Domain
 
-theorem truncLT_add [DecidableLT Γ] (c : Γ) (x y : HahnSeries Γ R) :
+theorem truncLT_add [DecidableLT Γ] (c : Γ) (x y : R⟦Γ⟧) :
     truncLT c (x + y) = truncLT c x + truncLT c y := by
   ext i
   by_cases h : i < c <;> simp [h]
@@ -320,14 +320,14 @@ section AddCommMonoid
 
 variable [AddCommMonoid R]
 
-instance : AddCommMonoid (HahnSeries Γ R) :=
-  { inferInstanceAs (AddMonoid (HahnSeries Γ R)) with
+instance : AddCommMonoid R⟦Γ⟧ :=
+  { inferInstanceAs (AddMonoid R⟦Γ⟧) with
     add_comm := fun x y => by
       ext
       apply add_comm }
 
 @[simp]
-theorem coeff_sum {s : Finset α} {x : α → HahnSeries Γ R} (g : Γ) :
+theorem coeff_sum {s : Finset α} {x : α → R⟦Γ⟧} (g : Γ) :
     (∑ i ∈ s, x i).coeff g = ∑ i ∈ s, (x i).coeff g :=
   cons_induction rfl (fun i s his hsum => by rw [sum_cons, sum_cons, coeff_add, hsum]) s
 
@@ -337,7 +337,7 @@ section AddGroup
 
 variable [AddGroup R]
 
-instance : Neg (HahnSeries Γ R) where
+instance : Neg R⟦Γ⟧ where
   neg x :=
     { coeff := fun a => -x.coeff a
       isPWO_support' := by
@@ -345,25 +345,25 @@ instance : Neg (HahnSeries Γ R) where
         exact x.isPWO_support }
 
 @[simp]
-theorem coeff_neg' (x : HahnSeries Γ R) : (-x).coeff = -x.coeff :=
+theorem coeff_neg' (x : R⟦Γ⟧) : (-x).coeff = -x.coeff :=
   rfl
 
-theorem coeff_neg {x : HahnSeries Γ R} {a : Γ} : (-x).coeff a = -x.coeff a :=
+theorem coeff_neg {x : R⟦Γ⟧} {a : Γ} : (-x).coeff a = -x.coeff a :=
   rfl
 
-instance : Sub (HahnSeries Γ R) where
+instance : Sub R⟦Γ⟧ where
   sub x y :=
     { coeff := x.coeff - y.coeff
       isPWO_support' := (x.isPWO_support.union y.isPWO_support).mono (Function.support_sub _ _) }
 
 @[simp]
-theorem coeff_sub' (x y : HahnSeries Γ R) : (x - y).coeff = x.coeff - y.coeff :=
+theorem coeff_sub' (x y : R⟦Γ⟧) : (x - y).coeff = x.coeff - y.coeff :=
   rfl
 
-theorem coeff_sub {x y : HahnSeries Γ R} {a : Γ} : (x - y).coeff a = x.coeff a - y.coeff a :=
+theorem coeff_sub {x y : R⟦Γ⟧} {a : Γ} : (x - y).coeff a = x.coeff a - y.coeff a :=
   rfl
 
-instance : AddGroup (HahnSeries Γ R) := fast_instance%
+instance : AddGroup R⟦Γ⟧ := fast_instance%
   coeff_injective.addGroup _
     coeff_zero' coeff_add' (coeff_neg') (coeff_sub')
     (fun _ _ => coeff_smul' _ _) (fun _ _ => coeff_smul' _ _)
@@ -377,52 +377,52 @@ theorem single_neg (a : Γ) (r : R) : single a (-r) = -single a r :=
   map_neg (single.addMonoidHom a) _
 
 @[simp]
-theorem support_neg {x : HahnSeries Γ R} : (-x).support = x.support := by
+theorem support_neg {x : R⟦Γ⟧} : (-x).support = x.support := by
   ext
   simp
 
 @[simp]
-protected lemma map_neg [AddGroup S] (f : R →+ S) {x : HahnSeries Γ R} :
-    ((-x).map f : HahnSeries Γ S) = -(x.map f) := by
+protected lemma map_neg [AddGroup S] (f : R →+ S) {x : R⟦Γ⟧} :
+    ((-x).map f : S⟦Γ⟧) = -(x.map f) := by
   ext; simp
 
 @[simp]
-theorem orderTop_neg {x : HahnSeries Γ R} : (-x).orderTop = x.orderTop := by
+theorem orderTop_neg {x : R⟦Γ⟧} : (-x).orderTop = x.orderTop := by
   classical simp only [orderTop, support_neg, neg_eq_zero]
 
 @[simp]
-theorem order_neg [Zero Γ] {f : HahnSeries Γ R} : (-f).order = f.order := by
+theorem order_neg [Zero Γ] {f : R⟦Γ⟧} : (-f).order = f.order := by
   classical
   by_cases hf : f = 0
   · simp only [hf, neg_zero]
   simp only [order, support_neg, neg_eq_zero]
 
-theorem leadingCoeff_neg {x : HahnSeries Γ R} : (-x).leadingCoeff = -x.leadingCoeff := by
+theorem leadingCoeff_neg {x : R⟦Γ⟧} : (-x).leadingCoeff = -x.leadingCoeff := by
   obtain rfl | hx := eq_or_ne x 0 <;> simp [leadingCoeff_of_ne_zero, *]
 
 @[simp]
-protected lemma map_sub [AddGroup S] (f : R →+ S) {x y : HahnSeries Γ R} :
-    ((x - y).map f : HahnSeries Γ S) = x.map f - y.map f := by
+protected lemma map_sub [AddGroup S] (f : R →+ S) {x y : R⟦Γ⟧} :
+    ((x - y).map f : S⟦Γ⟧) = x.map f - y.map f := by
   ext; simp
 
-theorem min_orderTop_le_orderTop_sub {Γ} [LinearOrder Γ] {x y : HahnSeries Γ R} :
+theorem min_orderTop_le_orderTop_sub {Γ} [LinearOrder Γ] {x y : R⟦Γ⟧} :
     min x.orderTop y.orderTop ≤ (x - y).orderTop := by
   rw [sub_eq_add_neg, ← orderTop_neg (x := y)]
   exact min_orderTop_le_orderTop_add
 
-theorem orderTop_sub {Γ} [LinearOrder Γ] {x y : HahnSeries Γ R}
+theorem orderTop_sub {Γ} [LinearOrder Γ] {x y : R⟦Γ⟧}
     (hxy : x.orderTop < y.orderTop) : (x - y).orderTop = x.orderTop := by
   rw [sub_eq_add_neg]
   rw [← orderTop_neg (x := y)] at hxy
   exact orderTop_add_eq_left hxy
 
-theorem leadingCoeff_sub {Γ} [LinearOrder Γ] {x y : HahnSeries Γ R}
+theorem leadingCoeff_sub {Γ} [LinearOrder Γ] {x y : R⟦Γ⟧}
     (hxy : x.orderTop < y.orderTop) : (x - y).leadingCoeff = x.leadingCoeff := by
   rw [sub_eq_add_neg]
   rw [← orderTop_neg (x := y)] at hxy
   exact leadingCoeff_add_eq_left hxy
 
-theorem orderTop_sub_ne {x y : HahnSeries Γ R} {g : Γ}
+theorem orderTop_sub_ne {x y : R⟦Γ⟧} {g : Γ}
     (hxg : x.orderTop = g) (hyg : y.orderTop = g) (hxyc : x.leadingCoeff = y.leadingCoeff) :
     (x - y).orderTop ≠ g := by
   refine orderTop_ne_of_coeff_eq_zero ?_
@@ -434,7 +434,7 @@ theorem orderTop_sub_ne {x y : HahnSeries Γ R} {g : Γ}
     untop_orderTop_of_ne_zero hy, hxg, hyg] at hxyc
   rwa [coeff_sub, sub_eq_zero]
 
-theorem le_orderTop_of_leadingCoeff_eq {Γ} [LinearOrder Γ] {x y : HahnSeries Γ R} {g : Γ}
+theorem le_orderTop_of_leadingCoeff_eq {Γ} [LinearOrder Γ] {x y : R⟦Γ⟧} {g : Γ}
     (hxg : x.orderTop = g) (hyg : y.orderTop = g) (hxyc : x.leadingCoeff = y.leadingCoeff) :
     g < (x - y).orderTop :=
   lt_of_le_of_ne (le_of_eq_of_le (by rw [hxg, hyg, inf_idem]) min_orderTop_le_orderTop_sub)
@@ -442,9 +442,7 @@ theorem le_orderTop_of_leadingCoeff_eq {Γ} [LinearOrder Γ] {x y : HahnSeries �
 
 end AddGroup
 
-instance [AddCommGroup R] : AddCommGroup (HahnSeries Γ R) :=
-  { inferInstanceAs (AddCommMonoid (HahnSeries Γ R)),
-    inferInstanceAs (AddGroup (HahnSeries Γ R)) with }
+instance [AddCommGroup R] : AddCommGroup R⟦Γ⟧ where
 
 end Addition
 
@@ -452,7 +450,7 @@ section DistribMulAction
 
 variable [PartialOrder Γ] {V : Type*} [Monoid R] [AddMonoid V] [DistribMulAction R V]
 
-instance : DistribMulAction R (HahnSeries Γ V) where
+instance : DistribMulAction R V⟦Γ⟧ where
   one_smul _ := by
     ext
     simp
@@ -468,12 +466,12 @@ instance : DistribMulAction R (HahnSeries Γ V) where
 
 variable {S : Type*} [Monoid S] [DistribMulAction S V]
 
-instance [SMul R S] [IsScalarTower R S V] : IsScalarTower R S (HahnSeries Γ V) :=
+instance [SMul R S] [IsScalarTower R S V] : IsScalarTower R S V⟦Γ⟧ :=
   ⟨fun r s a => by
     ext
     simp⟩
 
-instance [SMulCommClass R S V] : SMulCommClass R S (HahnSeries Γ V) :=
+instance [SMulCommClass R S V] : SMulCommClass R S V⟦Γ⟧ :=
   ⟨fun r s a => by
     ext
     simp [smul_comm]⟩
@@ -484,8 +482,8 @@ section Module
 
 variable [PartialOrder Γ] [Semiring R] [AddCommMonoid V] [Module R V]
 
-instance : Module R (HahnSeries Γ V) :=
-  { inferInstanceAs (DistribMulAction R (HahnSeries Γ V)) with
+instance : Module R V⟦Γ⟧ :=
+  { inferInstanceAs (DistribMulAction R V⟦Γ⟧) with
     zero_smul := fun _ => by
       ext
       simp
@@ -495,7 +493,7 @@ instance : Module R (HahnSeries Γ V) :=
 
 /-- `single` as a linear map -/
 @[simps]
-def single.linearMap (a : Γ) : V →ₗ[R] HahnSeries Γ V :=
+def single.linearMap (a : Γ) : V →ₗ[R] V⟦Γ⟧ :=
   { single.addMonoidHom a with
     map_smul' := fun r s => by
       ext b
@@ -503,19 +501,19 @@ def single.linearMap (a : Γ) : V →ₗ[R] HahnSeries Γ V :=
 
 /-- `coeff g` as a linear map -/
 @[simps]
-def coeff.linearMap (g : Γ) : HahnSeries Γ V →ₗ[R] V :=
+def coeff.linearMap (g : Γ) : V⟦Γ⟧ →ₗ[R] V :=
   { coeff.addMonoidHom g with map_smul' := fun _ _ => rfl }
 
 @[simp]
 protected lemma map_smul [AddCommMonoid U] [Module R U] (f : U →ₗ[R] V) {r : R}
-    {x : HahnSeries Γ U} : (r • x).map f = r • ((x.map f) : HahnSeries Γ V) := by
+    {x : HahnSeries Γ U} : (r • x).map f = r • ((x.map f) : V⟦Γ⟧) := by
   ext; simp
 
 section Finsupp
 
 variable (R) in
 /-- `ofFinsupp` as a linear map. -/
-def ofFinsuppLinearMap : (Γ →₀ V) →ₗ[R] HahnSeries Γ V where
+def ofFinsuppLinearMap : (Γ →₀ V) →ₗ[R] V⟦Γ⟧ where
   toFun := ofFinsupp
   map_add' _ _ := by
     ext
@@ -535,7 +533,7 @@ section Domain
 
 variable [PartialOrder Γ']
 
-theorem embDomain_smul (f : Γ ↪o Γ') (r : R) (x : HahnSeries Γ R) :
+theorem embDomain_smul (f : Γ ↪o Γ') (r : R) (x : R⟦Γ⟧) :
     embDomain f (r • x) = r • embDomain f x := by
   ext g
   by_cases hg : g ∈ Set.range f
@@ -545,7 +543,7 @@ theorem embDomain_smul (f : Γ ↪o Γ') (r : R) (x : HahnSeries Γ R) :
 
 /-- Extending the domain of Hahn series is a linear map. -/
 @[simps]
-def embDomainLinearMap (f : Γ ↪o Γ') : HahnSeries Γ R →ₗ[R] HahnSeries Γ' R where
+def embDomainLinearMap (f : Γ ↪o Γ') : R⟦Γ⟧ →ₗ[R] R⟦Γ'⟧ where
   toFun := embDomain f
   map_add' := embDomain_add f
   map_smul' := embDomain_smul f
@@ -554,7 +552,7 @@ end Domain
 
 variable (R) in
 /-- `HahnSeries.truncLT` as a linear map. -/
-def truncLTLinearMap [DecidableLT Γ] (c : Γ) : HahnSeries Γ V →ₗ[R] HahnSeries Γ V where
+def truncLTLinearMap [DecidableLT Γ] (c : Γ) : V⟦Γ⟧ →ₗ[R] V⟦Γ⟧ where
   toFun := truncLT c
   map_add' := truncLT_add c
   map_smul' := truncLT_smul c
@@ -562,7 +560,7 @@ def truncLTLinearMap [DecidableLT Γ] (c : Γ) : HahnSeries Γ V →ₗ[R] HahnS
 variable (R) in
 @[simp]
 theorem coe_truncLTLinearMap [DecidableLT Γ] (c : Γ) :
-    (truncLTLinearMap R c : HahnSeries Γ V → HahnSeries Γ V) = truncLT c := by rfl
+    (truncLTLinearMap R c : V⟦Γ⟧ → V⟦Γ⟧) = truncLT c := by rfl
 
 end Module
 

--- a/Mathlib/RingTheory/HahnSeries/Addition.lean
+++ b/Mathlib/RingTheory/HahnSeries/Addition.lean
@@ -129,7 +129,7 @@ Hahn series over `Γ` with coefficients in the opposite additive monoid `Rᵃᵒ
 and the additive opposite of Hahn series over `Γ` with coefficients `R`.
 -/
 @[simps -isSimp]
-def addOppositeEquiv : R⟦Γ⟧ᵃᵒᵖ ≃+ R⟦Γ⟧ᵃᵒᵖ where
+def addOppositeEquiv : Rᵃᵒᵖ⟦Γ⟧ ≃+ R⟦Γ⟧ᵃᵒᵖ where
   toFun x := .op ⟨fun a ↦ (x.coeff a).unop, by convert x.isPWO_support; ext; simp⟩
   invFun x := ⟨fun a ↦ .op (x.unop.coeff a), by convert x.unop.isPWO_support; ext; simp⟩
   left_inv x := by simp
@@ -142,7 +142,7 @@ def addOppositeEquiv : R⟦Γ⟧ᵃᵒᵖ ≃+ R⟦Γ⟧ᵃᵒᵖ where
     simp
 
 @[simp]
-lemma addOppositeEquiv_support (x : R⟦Γ⟧ᵃᵒᵖ) :
+lemma addOppositeEquiv_support (x : Rᵃᵒᵖ⟦Γ⟧) :
     (addOppositeEquiv x).unop.support = x.support := by
   ext
   simp [addOppositeEquiv_apply]
@@ -153,7 +153,7 @@ lemma addOppositeEquiv_symm_support (x : R⟦Γ⟧ᵃᵒᵖ) :
   rw [← addOppositeEquiv_support, AddEquiv.apply_symm_apply]
 
 @[simp]
-lemma addOppositeEquiv_orderTop (x : R⟦Γ⟧ᵃᵒᵖ) :
+lemma addOppositeEquiv_orderTop (x : Rᵃᵒᵖ⟦Γ⟧) :
     (addOppositeEquiv x).unop.orderTop = x.orderTop := by
   classical
   simp only [orderTop,
@@ -168,7 +168,7 @@ lemma addOppositeEquiv_symm_orderTop (x : R⟦Γ⟧ᵃᵒᵖ) :
   rw [← addOppositeEquiv_orderTop, AddEquiv.apply_symm_apply]
 
 @[simp]
-lemma addOppositeEquiv_leadingCoeff (x : R⟦Γ⟧ᵃᵒᵖ) :
+lemma addOppositeEquiv_leadingCoeff (x : Rᵃᵒᵖ⟦Γ⟧) :
     (addOppositeEquiv x).unop.leadingCoeff = x.leadingCoeff.unop := by
   classical
   obtain rfl | hx := eq_or_ne x 0

--- a/Mathlib/RingTheory/HahnSeries/Addition.lean
+++ b/Mathlib/RingTheory/HahnSeries/Addition.lean
@@ -501,8 +501,8 @@ def coeff.linearMap (g : Γ) : V⟦Γ⟧ →ₗ[R] V :=
   { coeff.addMonoidHom g with map_smul' := fun _ _ => rfl }
 
 @[simp]
-protected lemma map_smul [AddCommMonoid U] [Module R U] (f : U →ₗ[R] V) {r : R}
-    {x : HahnSeries Γ U} : (r • x).map f = r • ((x.map f) : V⟦Γ⟧) := by
+protected lemma map_smul [AddCommMonoid U] [Module R U] (f : U →ₗ[R] V) {r : R} {x : U⟦Γ⟧} :
+    (r • x).map f = r • (x.map f : V⟦Γ⟧) := by
   ext; simp
 
 section Finsupp

--- a/Mathlib/RingTheory/HahnSeries/Basic.lean
+++ b/Mathlib/RingTheory/HahnSeries/Basic.lean
@@ -63,7 +63,7 @@ macro_rules | `($R⟦$M⟧) => `(HahnSeries $M $R)
 /-- Unexpander for `HahnSeries`. -/
 @[scoped app_unexpander HahnSeries]
 meta def unexpander : Lean.PrettyPrinter.Unexpander
-  | `($_ $R $M) => `($R[$M])
+  | `($_ $M $R) => `($R[$M])
   | _ => throw ()
 
 section Zero

--- a/Mathlib/RingTheory/HahnSeries/Basic.lean
+++ b/Mathlib/RingTheory/HahnSeries/Basic.lean
@@ -140,7 +140,7 @@ def map [Zero S] (x : R⟦Γ⟧) {F : Type*} [FunLike F R S] [ZeroHomClass F R S
 protected lemma map_zero [Zero S] (f : ZeroHom R S) : (0 : R⟦Γ⟧).map f = 0 := by
   ext; simp
 
-/-- Change a HahnSeries with coefficients in HahnSeries to a HahnSeries on the Lex product. -/
+/-- Change a `HahnSeries` with coefficients in a `HahnSeries` to a `HahnSeries` on a Lex product. -/
 def ofIterate [PartialOrder Γ'] (x : R⟦Γ'⟧⟦Γ⟧) : R⟦Γ ×ₗ Γ'⟧ where
   coeff := fun g => coeff (coeff x g.1) g.2
   isPWO_support' := by
@@ -154,7 +154,7 @@ def ofIterate [PartialOrder Γ'] (x : R⟦Γ'⟧⟦Γ⟧) : R⟦Γ ×ₗ Γ'⟧ 
 lemma mk_eq_zero (f : Γ → R) (h) : HahnSeries.mk f h = 0 ↔ f = 0 := by
   simp_rw [HahnSeries.ext_iff, funext_iff, coeff_zero, Pi.zero_apply]
 
-/-- Change a `HahnSeries` on a lex product to a `HahnSeries` with coefficients in a `HahnSeries`. -/
+/-- Change a `HahnSeries` on a Lex product to a `HahnSeries` with coefficients in a `HahnSeries`. -/
 def toIterate [PartialOrder Γ'] (x : R⟦Γ ×ₗ Γ'⟧) : R⟦Γ'⟧⟦Γ⟧ where
   coeff := fun g => {
     coeff := fun g' => coeff x (g, g')

--- a/Mathlib/RingTheory/HahnSeries/Basic.lean
+++ b/Mathlib/RingTheory/HahnSeries/Basic.lean
@@ -12,15 +12,18 @@ public import Mathlib.Order.WellFoundedSet
 
 /-!
 # Hahn Series
-If `Γ` is ordered and `R` has zero, then `R⟦Γ⟧` consists of formal series over `Γ` with
-coefficients in `R`, whose supports are partially well-ordered. With further structure on `R` and
-`Γ`, we can add further structure on `R⟦Γ⟧`, with the most studied case being when `Γ` is
-a linearly ordered abelian group and `R` is a field, in which case `R⟦Γ⟧` is a
-valued field, with value group `Γ`.
+
+If `Γ` is ordered and `R` has zero, then the type `HahnSeries Γ R`, which we denote as `R⟦Γ⟧`,
+consists of formal series over `Γ` with coefficients in `R`, whose supports are partially
+well-ordered. With further structure on `R` and `Γ`, we can add further structure on `R⟦Γ⟧`, with
+the most studied case being when `Γ` is a linearly ordered abelian group and `R` is a field, in
+which case `R⟦Γ⟧` is a valued field, with value group `Γ`.
+
 These generalize Laurent series (with value group `ℤ`), and Laurent series are implemented that way
 in the file `Mathlib/RingTheory/LaurentSeries.lean`.
 
 ## Main Definitions
+
 * If `Γ` is ordered and `R` has zero, then `R⟦Γ⟧` consists of
   formal series over `Γ` with coefficients in `R`, whose supports are partially well-ordered.
 * `support x` is the subset of `Γ` whose coefficients are nonzero.
@@ -33,6 +36,7 @@ in the file `Mathlib/RingTheory/LaurentSeries.lean`.
 * `embDomain` preserves coefficients, but embeds the index set `Γ` in a larger poset.
 
 ## References
+
 - [J. van der Hoeven, *Operators on Generalized Power Series*][van_der_hoeven]
 -/
 

--- a/Mathlib/RingTheory/HahnSeries/Basic.lean
+++ b/Mathlib/RingTheory/HahnSeries/Basic.lean
@@ -12,16 +12,16 @@ public import Mathlib.Order.WellFoundedSet
 
 /-!
 # Hahn Series
-If `Γ` is ordered and `R` has zero, then `HahnSeries Γ R` consists of formal series over `Γ` with
+If `Γ` is ordered and `R` has zero, then `R⟦Γ⟧` consists of formal series over `Γ` with
 coefficients in `R`, whose supports are partially well-ordered. With further structure on `R` and
-`Γ`, we can add further structure on `HahnSeries Γ R`, with the most studied case being when `Γ` is
-a linearly ordered abelian group and `R` is a field, in which case `HahnSeries Γ R` is a
+`Γ`, we can add further structure on `R⟦Γ⟧`, with the most studied case being when `Γ` is
+a linearly ordered abelian group and `R` is a field, in which case `R⟦Γ⟧` is a
 valued field, with value group `Γ`.
 These generalize Laurent series (with value group `ℤ`), and Laurent series are implemented that way
 in the file `Mathlib/RingTheory/LaurentSeries.lean`.
 
 ## Main Definitions
-* If `Γ` is ordered and `R` has zero, then `HahnSeries Γ R` consists of
+* If `Γ` is ordered and `R` has zero, then `R⟦Γ⟧` consists of
   formal series over `Γ` with coefficients in `R`, whose supports are partially well-ordered.
 * `support x` is the subset of `Γ` whose coefficients are nonzero.
 * `single a r` is the Hahn series which has coefficient `r` at `a` and zero otherwise.
@@ -43,7 +43,7 @@ open Finset Function
 
 noncomputable section
 
-/-- If `Γ` is linearly ordered and `R` has zero, then `HahnSeries Γ R` consists of
+/-- If `Γ` is linearly ordered and `R` has zero, then `R⟦Γ⟧` consists of
   formal series over `Γ` with coefficients in `R`, whose supports are well-founded. -/
 @[ext]
 structure HahnSeries (Γ : Type*) (R : Type*) [PartialOrder Γ] [Zero R] where
@@ -55,85 +55,93 @@ variable {Γ Γ' R S : Type*}
 
 namespace HahnSeries
 
+@[inherit_doc HahnSeries]
+scoped syntax:max (priority := high) term noWs "⟦" term "⟧" : term
+
+macro_rules | `($R⟦$M⟧) => `(HahnSeries $M $R)
+
+/-- Unexpander for `HahnSeries`. -/
+@[scoped app_unexpander HahnSeries]
+meta def unexpander : Lean.PrettyPrinter.Unexpander
+  | `($_ $R $M) => `($R[$M])
+  | _ => throw ()
+
 section Zero
 
 variable [PartialOrder Γ] [Zero R]
 
-theorem coeff_injective : Injective (coeff : HahnSeries Γ R → Γ → R) :=
+theorem coeff_injective : Injective (coeff : R⟦Γ⟧ → Γ → R) :=
   fun _ _ => HahnSeries.ext
 
 @[simp]
-theorem coeff_inj {x y : HahnSeries Γ R} : x.coeff = y.coeff ↔ x = y :=
+theorem coeff_inj {x y : R⟦Γ⟧} : x.coeff = y.coeff ↔ x = y :=
   coeff_injective.eq_iff
 
 /-- The support of a Hahn series is just the set of indices whose coefficients are nonzero.
   Notably, it is well-founded. -/
-nonrec def support (x : HahnSeries Γ R) : Set Γ :=
+nonrec def support (x : R⟦Γ⟧) : Set Γ :=
   support x.coeff
 
 @[simp]
-theorem isPWO_support (x : HahnSeries Γ R) : x.support.IsPWO :=
+theorem isPWO_support (x : R⟦Γ⟧) : x.support.IsPWO :=
   x.isPWO_support'
 
 @[simp]
-theorem isWF_support (x : HahnSeries Γ R) : x.support.IsWF :=
+theorem isWF_support (x : R⟦Γ⟧) : x.support.IsWF :=
   x.isPWO_support.isWF
 
 @[simp]
-theorem mem_support (x : HahnSeries Γ R) (a : Γ) : a ∈ x.support ↔ x.coeff a ≠ 0 :=
+theorem mem_support (x : R⟦Γ⟧) (a : Γ) : a ∈ x.support ↔ x.coeff a ≠ 0 :=
   Iff.refl _
 
-instance : Zero (HahnSeries Γ R) :=
+instance : Zero R⟦Γ⟧ :=
   ⟨{  coeff := 0
       isPWO_support' := by simp }⟩
 
-instance : Inhabited (HahnSeries Γ R) :=
+instance : Inhabited R⟦Γ⟧ :=
   ⟨0⟩
 
-instance [Subsingleton R] : Subsingleton (HahnSeries Γ R) :=
+instance [Subsingleton R] : Subsingleton R⟦Γ⟧ :=
   ⟨fun _ _ => HahnSeries.ext (by subsingleton)⟩
 
-theorem coeff_zero' : (0 : HahnSeries Γ R).coeff = 0 :=
+theorem coeff_zero' : (0 : R⟦Γ⟧).coeff = 0 :=
   rfl
 
 @[simp]
-theorem coeff_zero {a : Γ} : (0 : HahnSeries Γ R).coeff a = 0 :=
+theorem coeff_zero {a : Γ} : (0 : R⟦Γ⟧).coeff a = 0 :=
   rfl
 
 @[simp]
-theorem coeff_fun_eq_zero_iff {x : HahnSeries Γ R} : x.coeff = 0 ↔ x = 0 :=
+theorem coeff_fun_eq_zero_iff {x : R⟦Γ⟧} : x.coeff = 0 ↔ x = 0 :=
   coeff_injective.eq_iff' rfl
 
-theorem ne_zero_of_coeff_ne_zero {x : HahnSeries Γ R} {g : Γ} (h : x.coeff g ≠ 0) : x ≠ 0 :=
+theorem ne_zero_of_coeff_ne_zero {x : R⟦Γ⟧} {g : Γ} (h : x.coeff g ≠ 0) : x ≠ 0 :=
   mt (fun x0 => (x0.symm ▸ coeff_zero : x.coeff g = 0)) h
 
 @[simp]
-theorem support_zero : support (0 : HahnSeries Γ R) = ∅ :=
+theorem support_zero : support (0 : R⟦Γ⟧) = ∅ :=
   Function.support_zero
 
 @[simp]
-nonrec theorem support_nonempty_iff {x : HahnSeries Γ R} : x.support.Nonempty ↔ x ≠ 0 := by
+nonrec theorem support_nonempty_iff {x : R⟦Γ⟧} : x.support.Nonempty ↔ x ≠ 0 := by
   rw [support, support_nonempty_iff, Ne, coeff_fun_eq_zero_iff]
 
 @[simp]
-theorem support_eq_empty_iff {x : HahnSeries Γ R} : x.support = ∅ ↔ x = 0 :=
+theorem support_eq_empty_iff {x : R⟦Γ⟧} : x.support = ∅ ↔ x = 0 :=
   Function.support_eq_empty_iff.trans coeff_fun_eq_zero_iff
 
 /-- The map of Hahn series induced by applying a zero-preserving map to each coefficient. -/
 @[simps]
-def map [Zero S] (x : HahnSeries Γ R) {F : Type*} [FunLike F R S] [ZeroHomClass F R S] (f : F) :
-    HahnSeries Γ S where
+def map [Zero S] (x : R⟦Γ⟧) {F : Type*} [FunLike F R S] [ZeroHomClass F R S] (f : F) : S⟦Γ⟧ where
   coeff g := f (x.coeff g)
   isPWO_support' := x.isPWO_support.mono <| Function.support_comp_subset (ZeroHomClass.map_zero f) _
 
 @[simp]
-protected lemma map_zero [Zero S] (f : ZeroHom R S) :
-    (0 : HahnSeries Γ R).map f = 0 := by
+protected lemma map_zero [Zero S] (f : ZeroHom R S) : (0 : R⟦Γ⟧).map f = 0 := by
   ext; simp
 
 /-- Change a HahnSeries with coefficients in HahnSeries to a HahnSeries on the Lex product. -/
-def ofIterate [PartialOrder Γ'] (x : HahnSeries Γ (HahnSeries Γ' R)) :
-    HahnSeries (Γ ×ₗ Γ') R where
+def ofIterate [PartialOrder Γ'] (x : R⟦Γ'⟧⟦Γ⟧) : R⟦Γ ×ₗ Γ'⟧ where
   coeff := fun g => coeff (coeff x g.1) g.2
   isPWO_support' := by
     refine Set.PartiallyWellOrderedOn.subsetProdLex ?_ ?_
@@ -146,9 +154,8 @@ def ofIterate [PartialOrder Γ'] (x : HahnSeries Γ (HahnSeries Γ' R)) :
 lemma mk_eq_zero (f : Γ → R) (h) : HahnSeries.mk f h = 0 ↔ f = 0 := by
   simp_rw [HahnSeries.ext_iff, funext_iff, coeff_zero, Pi.zero_apply]
 
-/-- Change a Hahn series on a lex product to a Hahn series with coefficients in a Hahn series. -/
-def toIterate [PartialOrder Γ'] (x : HahnSeries (Γ ×ₗ Γ') R) :
-    HahnSeries Γ (HahnSeries Γ' R) where
+/-- Change a `HahnSeries` on a lex product to a `HahnSeries` with coefficients in a `HahnSeries`. -/
+def toIterate [PartialOrder Γ'] (x : R⟦Γ ×ₗ Γ'⟧) : R⟦Γ'⟧⟦Γ⟧ where
   coeff := fun g => {
     coeff := fun g' => coeff x (g, g')
     isPWO_support' := Set.PartiallyWellOrderedOn.fiberProdLex x.isPWO_support' g
@@ -163,8 +170,7 @@ def toIterate [PartialOrder Γ'] (x : HahnSeries (Γ ×ₗ Γ') R) :
 
 /-- The equivalence between iterated Hahn series and Hahn series on the lex product. -/
 @[simps]
-def iterateEquiv [PartialOrder Γ'] :
-    HahnSeries Γ (HahnSeries Γ' R) ≃ HahnSeries (Γ ×ₗ Γ') R where
+def iterateEquiv [PartialOrder Γ'] : R⟦Γ'⟧⟦Γ⟧ ≃ R⟦Γ ×ₗ Γ'⟧ where
   toFun := ofIterate
   invFun := toIterate
   left_inv := congrFun rfl
@@ -172,7 +178,7 @@ def iterateEquiv [PartialOrder Γ'] :
 
 open Classical in
 /-- `single a r` is the Hahn series which has coefficient `r` at `a` and zero otherwise. -/
-def single (a : Γ) : ZeroHom R (HahnSeries Γ R) where
+def single (a : Γ) : ZeroHom R R⟦Γ⟧ where
   toFun r :=
     { coeff := Pi.single a r
       isPWO_support' := (Set.isPWO_singleton a).mono Pi.support_single_subset }
@@ -205,7 +211,7 @@ theorem eq_of_mem_support_single {b : Γ} (h : b ∈ support (single a r)) : b =
 theorem single_eq_zero : single a (0 : R) = 0 :=
   (single a).map_zero
 
-theorem single_injective (a : Γ) : Function.Injective (single a : R → HahnSeries Γ R) :=
+theorem single_injective (a : Γ) : Function.Injective (single a : R → R⟦Γ⟧) :=
   fun r s rs => by rw [← coeff_single_same a r, ← coeff_single_same a s, rs]
 
 theorem single_ne_zero (h : r ≠ 0) : single a r ≠ 0 := fun con =>
@@ -220,7 +226,7 @@ protected lemma map_single [Zero S] (f : ZeroHom R S) : (single a r).map f = sin
   ext g
   by_cases h : g = a <;> simp [h]
 
-instance [Nonempty Γ] [Nontrivial R] : Nontrivial (HahnSeries Γ R) :=
+instance [Nonempty Γ] [Nontrivial R] : Nontrivial R⟦Γ⟧ :=
   ⟨by
     obtain ⟨r, s, rs⟩ := exists_pair_ne R
     inhabit Γ
@@ -228,16 +234,16 @@ instance [Nonempty Γ] [Nontrivial R] : Nontrivial (HahnSeries Γ R) :=
     rw [← coeff_single_same (default : Γ) r, con, coeff_single_same]⟩
 
 section Order
-variable {x : HahnSeries Γ R}
+variable {x : R⟦Γ⟧}
 
 open Classical in
 /-- The orderTop of a Hahn series `x` is a minimal element of `WithTop Γ` where `x` has a nonzero
 coefficient if `x ≠ 0`, and is `⊤` when `x = 0`. -/
-def orderTop (x : HahnSeries Γ R) : WithTop Γ :=
+def orderTop (x : R⟦Γ⟧) : WithTop Γ :=
   if h : x = 0 then ⊤ else x.isWF_support.min (support_nonempty_iff.2 h)
 
 @[simp]
-theorem orderTop_zero : orderTop (0 : HahnSeries Γ R) = ⊤ :=
+theorem orderTop_zero : orderTop (0 : R⟦Γ⟧) = ⊤ :=
   dif_pos rfl
 
 @[simp]
@@ -261,18 +267,18 @@ lemma orderTop_ne_top : orderTop x ≠ ⊤ ↔ x ≠ 0 := orderTop_eq_top.not
 @[deprecated orderTop_ne_top (since := "2025-08-19")]
 lemma ne_zero_iff_orderTop : x ≠ 0 ↔ orderTop x ≠ ⊤ := orderTop_ne_top.symm
 
-theorem orderTop_eq_of_le {x : HahnSeries Γ R} {g : Γ} (hg : g ∈ x.support)
+theorem orderTop_eq_of_le {x : R⟦Γ⟧} {g : Γ} (hg : g ∈ x.support)
     (hx : ∀ g' ∈ x.support, g ≤ g') : orderTop x = g := by
   rw [orderTop_of_ne_zero <| support_nonempty_iff.mp <| Set.nonempty_of_mem hg,
     x.isWF_support.min_eq_of_le hg hx]
 
-theorem untop_orderTop_of_ne_zero {x : HahnSeries Γ R} (hx : x ≠ 0) :
+theorem untop_orderTop_of_ne_zero {x : R⟦Γ⟧} (hx : x ≠ 0) :
     WithTop.untop x.orderTop (orderTop_ne_top.2 hx) =
       x.isWF_support.min (support_nonempty_iff.2 hx) :=
   WithTop.coe_inj.mp ((WithTop.coe_untop (orderTop x) (orderTop_ne_top.2 hx)).trans
     (orderTop_of_ne_zero hx))
 
-theorem coeff_orderTop_ne {x : HahnSeries Γ R} {g : Γ} (hg : x.orderTop = g) :
+theorem coeff_orderTop_ne {x : R⟦Γ⟧} {g : Γ} (hg : x.orderTop = g) :
     x.coeff g ≠ 0 := by
   have h : orderTop x ≠ ⊤ := by simp_all only [ne_eq, WithTop.coe_ne_top, not_false_eq_true]
   have hx : x ≠ 0 := orderTop_ne_top.1 h
@@ -280,11 +286,11 @@ theorem coeff_orderTop_ne {x : HahnSeries Γ R} {g : Γ} (hg : x.orderTop = g) :
   rw [← hg]
   exact x.isWF_support.min_mem (support_nonempty_iff.2 hx)
 
-theorem orderTop_ne_of_coeff_eq_zero {x : HahnSeries Γ R} {i : Γ} (hx : x.coeff i = 0) :
+theorem orderTop_ne_of_coeff_eq_zero {x : R⟦Γ⟧} {i : Γ} (hx : x.coeff i = 0) :
     x.orderTop ≠ i :=
   fun h ↦ coeff_orderTop_ne h hx
 
-theorem orderTop_le_of_coeff_ne_zero {Γ} [LinearOrder Γ] {x : HahnSeries Γ R}
+theorem orderTop_le_of_coeff_ne_zero {Γ} [LinearOrder Γ] {x : R⟦Γ⟧}
     {g : Γ} (h : x.coeff g ≠ 0) : x.orderTop ≤ g := by
   rw [orderTop_of_ne_zero (ne_zero_of_coeff_ne_zero h), WithTop.coe_le_coe]
   exact Set.IsWF.min_le _ _ ((mem_support _ _).2 h)
@@ -303,7 +309,7 @@ theorem orderTop_single_le : a ≤ (single a r).orderTop := by
 theorem lt_orderTop_single {g g' : Γ} (hgg' : g < g') : g < (single g' r).orderTop :=
   lt_of_lt_of_le (WithTop.coe_lt_coe.mpr hgg') orderTop_single_le
 
-theorem coeff_eq_zero_of_lt_orderTop {x : HahnSeries Γ R} {i : Γ} (hi : i < x.orderTop) :
+theorem coeff_eq_zero_of_lt_orderTop {x : R⟦Γ⟧} {i : Γ} (hi : i < x.orderTop) :
     x.coeff i = 0 := by
   rcases eq_or_ne x 0 with (rfl | hx)
   · exact coeff_zero
@@ -315,22 +321,22 @@ theorem coeff_eq_zero_of_lt_orderTop {x : HahnSeries Γ R} {i : Γ} (hi : i < x.
 open Classical in
 /-- A leading coefficient of a Hahn series is the coefficient of a lowest-order nonzero term, or
 zero if the series vanishes. -/
-def leadingCoeff (x : HahnSeries Γ R) : R := x.orderTop.recTopCoe 0 x.coeff
+def leadingCoeff (x : R⟦Γ⟧) : R := x.orderTop.recTopCoe 0 x.coeff
 
 @[simp]
-theorem leadingCoeff_zero : leadingCoeff (0 : HahnSeries Γ R) = 0 := by simp [leadingCoeff]
+theorem leadingCoeff_zero : leadingCoeff (0 : R⟦Γ⟧) = 0 := by simp [leadingCoeff]
 
-theorem leadingCoeff_of_ne_zero {x : HahnSeries Γ R} (hx : x ≠ 0) :
+theorem leadingCoeff_of_ne_zero {x : R⟦Γ⟧} (hx : x ≠ 0) :
     x.leadingCoeff = x.coeff (x.orderTop.untop <| orderTop_ne_top.2 hx) := by
   simp [leadingCoeff, orderTop, hx]
 
 @[deprecated (since := "2025-08-19")] alias leadingCoeff_of_ne := leadingCoeff_of_ne_zero
 
 @[simp]
-theorem leadingCoeff_eq_zero {x : HahnSeries Γ R} : x.leadingCoeff = 0 ↔ x = 0 := by
+theorem leadingCoeff_eq_zero {x : R⟦Γ⟧} : x.leadingCoeff = 0 ↔ x = 0 := by
   obtain rfl | hx := eq_or_ne x 0 <;> simp [leadingCoeff_of_ne_zero, coeff_orderTop_ne, *]
 
-theorem leadingCoeff_ne_zero {x : HahnSeries Γ R} : x.leadingCoeff ≠ 0 ↔ x ≠ 0 :=
+theorem leadingCoeff_ne_zero {x : R⟦Γ⟧} : x.leadingCoeff ≠ 0 ↔ x ≠ 0 :=
   leadingCoeff_eq_zero.not
 
 @[deprecated (since := "2025-08-19")] alias leadingCoeff_eq_iff := leadingCoeff_eq_zero
@@ -340,7 +346,7 @@ theorem leadingCoeff_ne_zero {x : HahnSeries Γ R} : x.leadingCoeff ≠ 0 ↔ x 
 theorem leadingCoeff_of_single {a : Γ} {r : R} : leadingCoeff (single a r) = r := by
   by_cases h : r = 0 <;> simp [leadingCoeff, h]
 
-theorem coeff_untop_eq_leadingCoeff {x : HahnSeries Γ R} (hx) :
+theorem coeff_untop_eq_leadingCoeff {x : R⟦Γ⟧} (hx) :
     x.coeff (x.orderTop.untop hx) = x.leadingCoeff := by
   rw [orderTop_ne_top] at hx
   rw [leadingCoeff_of_ne_zero hx, (WithTop.untop_eq_iff _).mpr (orderTop_of_ne_zero hx)]
@@ -350,14 +356,14 @@ variable [Zero Γ]
 open Classical in
 /-- The order of a nonzero Hahn series `x` is a minimal element of `Γ` where `x` has a
   nonzero coefficient, the order of 0 is 0. -/
-def order (x : HahnSeries Γ R) : Γ :=
+def order (x : R⟦Γ⟧) : Γ :=
   if h : x = 0 then 0 else x.isWF_support.min (support_nonempty_iff.2 h)
 
 @[simp]
-theorem order_zero : order (0 : HahnSeries Γ R) = 0 :=
+theorem order_zero : order (0 : R⟦Γ⟧) = 0 :=
   dif_pos rfl
 
-theorem order_of_ne {x : HahnSeries Γ R} (hx : x ≠ 0) :
+theorem order_of_ne {x : R⟦Γ⟧} (hx : x ≠ 0) :
     order x = x.isWF_support.min (support_nonempty_iff.2 hx) :=
   dif_neg hx
 
@@ -366,11 +372,11 @@ theorem order_eq_orderTop_of_ne_zero (hx : x ≠ 0) : order x = orderTop x := by
 
 @[deprecated (since := "2025-08-19")] alias order_eq_orderTop_of_ne := order_eq_orderTop_of_ne_zero
 
-theorem coeff_order_ne_zero {x : HahnSeries Γ R} (hx : x ≠ 0) : x.coeff x.order ≠ 0 := by
+theorem coeff_order_ne_zero {x : R⟦Γ⟧} (hx : x ≠ 0) : x.coeff x.order ≠ 0 := by
   rw [order_of_ne hx]
   exact x.isWF_support.min_mem (support_nonempty_iff.2 hx)
 
-theorem order_le_of_coeff_ne_zero {Γ} [Zero Γ] [LinearOrder Γ] {x : HahnSeries Γ R}
+theorem order_le_of_coeff_ne_zero {Γ} [Zero Γ] [LinearOrder Γ] {x : R⟦Γ⟧}
     {g : Γ} (h : x.coeff g ≠ 0) : x.order ≤ g :=
   le_trans (le_of_eq (order_of_ne (ne_zero_of_coeff_ne_zero h)))
     (Set.IsWF.min_le _ _ ((mem_support _ _).2 h))
@@ -381,8 +387,7 @@ theorem order_single (h : r ≠ 0) : (single a r).order = a :=
     (support_single_subset
       ((single a r).isWF_support.min_mem (support_nonempty_iff.2 (single_ne_zero h))))
 
-theorem coeff_eq_zero_of_lt_order {x : HahnSeries Γ R} {i : Γ} (hi : i < x.order) :
-    x.coeff i = 0 := by
+theorem coeff_eq_zero_of_lt_order {x : R⟦Γ⟧} {i : Γ} (hi : i < x.order) : x.coeff i = 0 := by
   rcases eq_or_ne x 0 with (rfl | hx)
   · simp
   contrapose! hi
@@ -390,21 +395,21 @@ theorem coeff_eq_zero_of_lt_order {x : HahnSeries Γ R} {i : Γ} (hi : i < x.ord
   rw [order_of_ne hx]
   exact Set.IsWF.not_lt_min _ _ hi
 
-theorem zero_lt_orderTop_iff {x : HahnSeries Γ R} (hx : x ≠ 0) :
+theorem zero_lt_orderTop_iff {x : R⟦Γ⟧} (hx : x ≠ 0) :
     0 < x.orderTop ↔ 0 < x.order := by
   simp_all [orderTop_of_ne_zero hx, order_of_ne hx]
 
-theorem zero_lt_orderTop_of_order {x : HahnSeries Γ R} (hx : 0 < x.order) : 0 < x.orderTop := by
+theorem zero_lt_orderTop_of_order {x : R⟦Γ⟧} (hx : 0 < x.order) : 0 < x.orderTop := by
   by_cases h : x = 0
   · simp_all only [order_zero, lt_self_iff_false]
   · exact (zero_lt_orderTop_iff h).mpr hx
 
-theorem zero_le_orderTop_iff {x : HahnSeries Γ R} : 0 ≤ x.orderTop ↔ 0 ≤ x.order := by
+theorem zero_le_orderTop_iff {x : R⟦Γ⟧} : 0 ≤ x.orderTop ↔ 0 ≤ x.order := by
   by_cases h : x = 0
   · simp_all
   · simp_all [order_of_ne h, orderTop_of_ne_zero h]
 
-theorem leadingCoeff_eq {x : HahnSeries Γ R} : x.leadingCoeff = x.coeff x.order := by
+theorem leadingCoeff_eq {x : R⟦Γ⟧} : x.leadingCoeff = x.coeff x.order := by
   by_cases h : x = 0
   · rw [h, leadingCoeff_zero, coeff_zero]
   · simp [leadingCoeff_of_ne_zero, orderTop_of_ne_zero, order_of_ne, h]
@@ -414,7 +419,7 @@ end Order
 section Finsupp
 
 /-- Create a `HahnSeries` with a `Finsupp` as coefficients. -/
-def ofFinsupp : ZeroHom (Γ →₀ R) (HahnSeries Γ R) where
+def ofFinsupp : ZeroHom (Γ →₀ R) R⟦Γ⟧ where
   toFun f := { coeff := f, isPWO_support' := f.finite_support.isPWO }
   map_zero' := by simp
 
@@ -429,7 +434,7 @@ variable [PartialOrder Γ']
 
 open Classical in
 /-- Extends the domain of a `HahnSeries` by an `OrderEmbedding`. -/
-def embDomain (f : Γ ↪o Γ') : HahnSeries Γ R → HahnSeries Γ' R := fun x =>
+def embDomain (f : Γ ↪o Γ') : R⟦Γ⟧ → R⟦Γ'⟧ := fun x =>
   { coeff := fun b : Γ' => if h : b ∈ f '' x.support then x.coeff (Classical.choose h) else 0
     isPWO_support' :=
       (x.isPWO_support.image_of_monotone f.monotone).mono fun b hb => by
@@ -437,7 +442,7 @@ def embDomain (f : Γ ↪o Γ') : HahnSeries Γ R → HahnSeries Γ' R := fun x 
         rw [Function.mem_support, dif_neg hb, Classical.not_not] }
 
 @[simp]
-theorem embDomain_coeff {f : Γ ↪o Γ'} {x : HahnSeries Γ R} {a : Γ} :
+theorem embDomain_coeff {f : Γ ↪o Γ'} {x : R⟦Γ⟧} {a : Γ} :
     (embDomain f x).coeff (f a) = x.coeff a := by
   rw [embDomain]
   dsimp only
@@ -451,26 +456,26 @@ theorem embDomain_coeff {f : Γ ↪o Γ'} {x : HahnSeries Γ R} {a : Γ} :
 
 @[simp]
 theorem embDomain_mk_coeff {f : Γ → Γ'} (hfi : Function.Injective f)
-    (hf : ∀ g g' : Γ, f g ≤ f g' ↔ g ≤ g') {x : HahnSeries Γ R} {a : Γ} :
+    (hf : ∀ g g' : Γ, f g ≤ f g' ↔ g ≤ g') {x : R⟦Γ⟧} {a : Γ} :
     (embDomain ⟨⟨f, hfi⟩, hf _ _⟩ x).coeff (f a) = x.coeff a :=
   embDomain_coeff
 
-theorem embDomain_notin_image_support {f : Γ ↪o Γ'} {x : HahnSeries Γ R} {b : Γ'}
+theorem embDomain_notin_image_support {f : Γ ↪o Γ'} {x : R⟦Γ⟧} {b : Γ'}
     (hb : b ∉ f '' x.support) : (embDomain f x).coeff b = 0 :=
   dif_neg hb
 
-theorem support_embDomain_subset {f : Γ ↪o Γ'} {x : HahnSeries Γ R} :
+theorem support_embDomain_subset {f : Γ ↪o Γ'} {x : R⟦Γ⟧} :
     support (embDomain f x) ⊆ f '' x.support := by
   intro g hg
   contrapose! hg
   rw [mem_support, embDomain_notin_image_support hg, Classical.not_not]
 
-theorem embDomain_notin_range {f : Γ ↪o Γ'} {x : HahnSeries Γ R} {b : Γ'} (hb : b ∉ Set.range f) :
+theorem embDomain_notin_range {f : Γ ↪o Γ'} {x : R⟦Γ⟧} {b : Γ'} (hb : b ∉ Set.range f) :
     (embDomain f x).coeff b = 0 :=
   embDomain_notin_image_support fun con => hb (Set.image_subset_range _ _ con)
 
 @[simp]
-theorem embDomain_zero {f : Γ ↪o Γ'} : embDomain f (0 : HahnSeries Γ R) = 0 := by
+theorem embDomain_zero {f : Γ ↪o Γ'} : embDomain f (0 : R⟦Γ⟧) = 0 := by
   ext
   simp [embDomain_notin_image_support]
 
@@ -486,14 +491,14 @@ theorem embDomain_single {f : Γ ↪o Γ'} {g : Γ} {r : R} :
   rwa [support_single_of_ne hr, Set.image_singleton, Set.mem_singleton_iff]
 
 theorem embDomain_injective {f : Γ ↪o Γ'} :
-    Function.Injective (embDomain f : HahnSeries Γ R → HahnSeries Γ' R) := fun x y xy => by
+    Function.Injective (embDomain f : R⟦Γ⟧ → R⟦Γ'⟧) := fun x y xy => by
   ext g
   rw [HahnSeries.ext_iff, funext_iff] at xy
   have xyg := xy (f g)
   rwa [embDomain_coeff, embDomain_coeff] at xyg
 
 @[simp]
-theorem orderTop_embDomain {Γ : Type*} [LinearOrder Γ] {f : Γ ↪o Γ'} {x : HahnSeries Γ R} :
+theorem orderTop_embDomain {Γ : Type*} [LinearOrder Γ] {f : Γ ↪o Γ'} {x : R⟦Γ⟧} :
     (embDomain f x).orderTop = WithTop.map f x.orderTop := by
   obtain rfl | hx := eq_or_ne x 0
   · simp
@@ -534,12 +539,12 @@ theorem suppBddBelow_supp_PWO (f : Γ → R) (hf : BddBelow (Function.support f)
 
 /-- Construct a Hahn series from any function whose support is bounded below. -/
 @[simps]
-def ofSuppBddBelow (f : Γ → R) (hf : BddBelow (Function.support f)) : HahnSeries Γ R where
+def ofSuppBddBelow (f : Γ → R) (hf : BddBelow (Function.support f)) : R⟦Γ⟧ where
   coeff := f
   isPWO_support' := suppBddBelow_supp_PWO f hf
 
 @[simp]
-theorem zero_ofSuppBddBelow [Nonempty Γ] : ofSuppBddBelow 0 BddBelow_zero = (0 : HahnSeries Γ R) :=
+theorem zero_ofSuppBddBelow [Nonempty Γ] : ofSuppBddBelow 0 BddBelow_zero = (0 : R⟦Γ⟧) :=
   rfl
 
 theorem order_ofForallLtEqZero [Zero Γ] (f : Γ → R) (hf : f ≠ 0) (n : Γ)
@@ -561,24 +566,21 @@ section Truncate
 variable [Zero R]
 
 /-- Zeroes out coefficients of a `HahnSeries` at indices not less than `c`. -/
-def truncLT [PartialOrder Γ] [DecidableLT Γ] (c : Γ) :
-    ZeroHom (HahnSeries Γ R) (HahnSeries Γ R) where
+def truncLT [PartialOrder Γ] [DecidableLT Γ] (c : Γ) : ZeroHom R⟦Γ⟧ R⟦Γ⟧ where
   toFun x :=
     { coeff i := if i < c then x.coeff i else 0
       isPWO_support' := Set.IsPWO.mono x.isPWO_support (by simp) }
   map_zero' := by ext; simp
 
 @[simp]
-protected theorem coeff_truncLT [PartialOrder Γ] [DecidableLT Γ]
-    (c : Γ) (x : HahnSeries Γ R) (i : Γ) :
+protected theorem coeff_truncLT [PartialOrder Γ] [DecidableLT Γ] (c : Γ) (x : R⟦Γ⟧) (i : Γ) :
     (truncLT c x).coeff i = if i < c then x.coeff i else 0  := rfl
 
-theorem coeff_truncLT_of_lt [PartialOrder Γ] [DecidableLT Γ]
-    {c i : Γ} (h : i < c) (x : HahnSeries Γ R) : (truncLT c x).coeff i = x.coeff i := by
+theorem coeff_truncLT_of_lt [PartialOrder Γ] [DecidableLT Γ] {c i : Γ} (h : i < c) (x : R⟦Γ⟧) :
+    (truncLT c x).coeff i = x.coeff i := by
   simp [h]
 
-theorem coeff_truncLT_of_le [LinearOrder Γ]
-    {c i : Γ} (h : c ≤ i) (x : HahnSeries Γ R) :
+theorem coeff_truncLT_of_le [LinearOrder Γ] {c i : Γ} (h : c ≤ i) (x : R⟦Γ⟧) :
     (truncLT c x).coeff i = 0 := by
   simp [h]
 

--- a/Mathlib/RingTheory/HahnSeries/Binomial.lean
+++ b/Mathlib/RingTheory/HahnSeries/Binomial.lean
@@ -38,23 +38,23 @@ variable [CommRing A] [Algebra R A]
 /-- A summable family of Hahn series, whose `n`th term is `Ring.choose r n • (x - 1) ^ n` when
 `x` is close to `1` (more precisely, when `0 < (x - 1).orderTop`), and `0 ^ n` otherwise. These
 terms give a formal expansion of `x ^ r` as `(1 + (x - 1)) ^ r`. -/
-def binomialFamily (x : HahnSeries Γ A) (r : R) :
+def binomialFamily (x : A⟦Γ⟧) (r : R) :
     SummableFamily Γ A ℕ :=
   powerSeriesFamily (x - 1) (PowerSeries.binomialSeries A r)
 
 @[simp]
-theorem binomialFamily_apply {x : HahnSeries Γ A} (hx : 0 < (x - 1).orderTop) (r : R) (n : ℕ) :
+theorem binomialFamily_apply {x : A⟦Γ⟧} (hx : 0 < (x - 1).orderTop) (r : R) (n : ℕ) :
     binomialFamily x r n = Ring.choose r n • (x - 1) ^ n := by
   simp [hx, binomialFamily]
 
 @[simp]
-theorem binomialFamily_apply_of_orderTop_nonpos {x : HahnSeries Γ A} (hx : ¬ 0 < (x - 1).orderTop)
+theorem binomialFamily_apply_of_orderTop_nonpos {x : A⟦Γ⟧} (hx : ¬ 0 < (x - 1).orderTop)
     (r : R) (n : ℕ) :
     binomialFamily x r n = 0 ^ n := by
   rw [binomialFamily, powerSeriesFamily_of_not_orderTop_pos hx]
   by_cases hn : n = 0 <;> simp [hn]
 
-theorem binomialFamily_orderTop_pos {x : HahnSeries Γ A} (hx : 0 < (x - 1).orderTop) (r : R) {n : ℕ}
+theorem binomialFamily_orderTop_pos {x : A⟦Γ⟧} (hx : 0 < (x - 1).orderTop) (r : R) {n : ℕ}
     (hn : 0 < n) :
     0 < (binomialFamily x r n).orderTop := by
   simp only [binomialFamily, smulFamily_toFun, PowerSeries.binomialSeries_coeff, powers_toFun, hx,
@@ -66,14 +66,14 @@ theorem binomialFamily_orderTop_pos {x : HahnSeries Γ A} (hx : 0 < (x - 1).orde
     ((x - 1) ^ n).orderTop ≤ ((Ring.choose r n) • ((x - 1) ^ n)).orderTop :=
       orderTop_le_orderTop_smul (Ring.choose r n) ((x - 1) ^ n)
 
-theorem binomialFamily_mem_support {x : HahnSeries Γ A}
+theorem binomialFamily_mem_support {x : A⟦Γ⟧}
     (hx : 0 < (x - 1).orderTop) (r : R) (n : ℕ) {g : Γ}
     (hg : g ∈ (binomialFamily x r n).support) : 0 ≤ g := by
   by_cases hn : n = 0; · simp_all
   exact le_of_lt (WithTop.coe_pos.mp (lt_of_lt_of_le (binomialFamily_orderTop_pos hx r
     (Nat.pos_of_ne_zero hn)) (orderTop_le_of_coeff_ne_zero hg)))
 
-theorem orderTop_hsum_binomialFamily_pos {x : HahnSeries Γ A} (hx : 0 < (x - 1).orderTop)
+theorem orderTop_hsum_binomialFamily_pos {x : A⟦Γ⟧} (hx : 0 < (x - 1).orderTop)
     (r : R) : (0 : WithTop Γ) < (SummableFamily.hsum (binomialFamily x r) - 1).orderTop := by
   obtain (_|_) := subsingleton_or_nontrivial A
   · simp [Subsingleton.eq_zero ((binomialFamily x r).hsum - 1)]

--- a/Mathlib/RingTheory/HahnSeries/HEval.lean
+++ b/Mathlib/RingTheory/HahnSeries/HEval.lean
@@ -18,11 +18,11 @@ given by substitution of the generating variable to an element of strictly posit
 * `HahnSeries.SummableFamily.powerSeriesFamily`: A summable family of Hahn series whose elements
   are non-negative powers of a fixed positive-order Hahn series multiplied by the coefficients of a
   formal power series.
-* `PowerSeries.heval`: The `R`-algebra homomorphism from `PowerSeries σ R` to `HahnSeries Γ R` that
+* `PowerSeries.heval`: The `R`-algebra homomorphism from `PowerSeries σ R` to `R⟦Γ⟧` that
   takes `X` to a fixed positive-order Hahn Series and extends to formal infinite sums.
 
 ## TODO
-* `MvPowerSeries.heval`: An `R`-algebra homomorphism from `MvPowerSeries σ R` to `HahnSeries Γ R`
+* `MvPowerSeries.heval`: An `R`-algebra homomorphism from `MvPowerSeries σ R` to `R⟦Γ⟧`
   (for finite σ) taking each `X i` to a positive order Hahn Series.
 
 -/
@@ -48,22 +48,22 @@ variable [CommRing V] [Algebra R V]
 /-- A summable family given by scalar multiples of powers of a positive order Hahn series.
 
 The scalar multiples are given by the coefficients of a power series. -/
-abbrev powerSeriesFamily (x : HahnSeries Γ V) (f : PowerSeries R) : SummableFamily Γ V ℕ :=
+abbrev powerSeriesFamily (x : V⟦Γ⟧) (f : PowerSeries R) : SummableFamily Γ V ℕ :=
   smulFamily (fun n => f.coeff n) (powers x)
 
-theorem powerSeriesFamily_of_not_orderTop_pos {x : HahnSeries Γ V} (hx : ¬ 0 < x.orderTop)
+theorem powerSeriesFamily_of_not_orderTop_pos {x : V⟦Γ⟧} (hx : ¬ 0 < x.orderTop)
     (f : PowerSeries R) :
     powerSeriesFamily x f = powerSeriesFamily 0 f := by
   ext n g
   obtain rfl | hn := eq_or_ne n 0 <;> simp [*]
 
-theorem powerSeriesFamily_of_orderTop_pos {x : HahnSeries Γ V} (hx : 0 < x.orderTop)
+theorem powerSeriesFamily_of_orderTop_pos {x : V⟦Γ⟧} (hx : 0 < x.orderTop)
     (f : PowerSeries R) (n : ℕ) :
     powerSeriesFamily x f n = f.coeff n • x ^ n := by
   simp [hx]
 
 theorem powerSeriesFamily_hsum_zero (f : PowerSeries R) :
-    (powerSeriesFamily 0 f).hsum = f.constantCoeff • (1 : HahnSeries Γ V) := by
+    (powerSeriesFamily 0 f).hsum = f.constantCoeff • (1 : V⟦Γ⟧) := by
   ext g
   by_cases hg : g = 0
   · simp only [hg, coeff_hsum]
@@ -73,17 +73,17 @@ theorem powerSeriesFamily_hsum_zero (f : PowerSeries R) :
       fun n ↦ (by by_cases hn : n = 0 <;> simp [hg, hn])]
     simp [hg]
 
-theorem powerSeriesFamily_add {x : HahnSeries Γ V} (f g : PowerSeries R) :
+theorem powerSeriesFamily_add {x : V⟦Γ⟧} (f g : PowerSeries R) :
     powerSeriesFamily x (f + g) = powerSeriesFamily x f + powerSeriesFamily x g := by
   ext1 n
   by_cases hx : 0 < x.orderTop <;> · simp [hx, add_smul]
 
-theorem powerSeriesFamily_smul {x : HahnSeries Γ V} (f : PowerSeries R) (r : R) :
+theorem powerSeriesFamily_smul {x : V⟦Γ⟧} (f : PowerSeries R) (r : R) :
     powerSeriesFamily x (r • f) = HahnSeries.single (0 : Γ) r • powerSeriesFamily x f := by
   ext1 n
   simp [mul_smul]
 
-theorem support_powerSeriesFamily_subset {x : HahnSeries Γ V} (a b : PowerSeries R) (g : Γ) :
+theorem support_powerSeriesFamily_subset {x : V⟦Γ⟧} (a b : PowerSeries R) (g : Γ) :
     ((powerSeriesFamily x (a * b)).coeff g).support ⊆
     (((powerSeriesFamily x a).mul (powerSeriesFamily x b)).coeff g).support.image
       fun i => i.1 + i.2 := by
@@ -113,7 +113,7 @@ theorem support_powerSeriesFamily_subset {x : HahnSeries Γ V} (a b : PowerSerie
       simp [this.2, this.1, h, hz, smul_smul, mul_comm]
     · simp [h, hz] at hn
 
-theorem hsum_powerSeriesFamily_mul {x : HahnSeries Γ V} (a b : PowerSeries R) :
+theorem hsum_powerSeriesFamily_mul {x : V⟦Γ⟧} (a b : PowerSeries R) :
     (powerSeriesFamily x (a * b)).hsum =
     ((powerSeriesFamily x a).mul (powerSeriesFamily x b)).hsum := by
   by_cases h : 0 < x.orderTop;
@@ -158,12 +158,12 @@ namespace PowerSeries
 open HahnSeries SummableFamily
 
 variable [AddCommMonoid Γ] [LinearOrder Γ] [IsOrderedCancelAddMonoid Γ]
-  [CommRing R] (x : HahnSeries Γ R)
+  [CommRing R] (x : R⟦Γ⟧)
 
-/-- The `R`-algebra homomorphism from `R[[X]]` to `HahnSeries Γ R` given by sending the power series
+/-- The `R`-algebra homomorphism from `R⟦X⟧` to `R⟦Γ⟧` given by sending the power series
 variable `X` to a positive order element `x` and extending to infinite sums. -/
 @[simps]
-def heval : PowerSeries R →ₐ[R] HahnSeries Γ R where
+def heval : PowerSeries R →ₐ[R] R⟦Γ⟧ where
   toFun f := (powerSeriesFamily x f).hsum
   map_one' := by
     simp only [hsum, smulFamily_toFun, coeff_one, powers_toFun, ite_smul, one_smul, zero_smul]
@@ -185,8 +185,7 @@ def heval : PowerSeries R →ₐ[R] HahnSeries Γ R where
     rw [finsum_eq_single _ 0 fun n hn => by simp [hn]]
     by_cases hg : g = 0 <;> simp [hg, Algebra.algebraMap_eq_smul_one]
 
-theorem heval_mul {a b : PowerSeries R} :
-    heval x (a * b) = heval x a * heval x b :=
+theorem heval_mul {a b : PowerSeries R} : heval x (a * b) = heval x a * heval x b :=
   map_mul (heval x) a b
 
 theorem heval_C (r : R) : heval x (C r) = r • 1 := by

--- a/Mathlib/RingTheory/HahnSeries/HahnEmbedding.lean
+++ b/Mathlib/RingTheory/HahnSeries/HahnEmbedding.lean
@@ -45,7 +45,7 @@ instance : Nonempty (HahnEmbedding.Seed ℚ M ℝ) := by
 
 theorem hahnEmbedding_isOrderedModule_rat :
     ∃ f : M →ₗ[ℚ] Lex ℝ⟦FiniteArchimedeanClass M⟧, StrictMono f ∧
-      ∀ a, mk a = FiniteArchimedeanClass.withTopOrderIso M (ofLex (f a)).orderTop := by
+      ∀ a, .mk a = FiniteArchimedeanClass.withTopOrderIso M (ofLex (f a)).orderTop := by
   apply hahnEmbedding_isOrderedModule
 
 end Module
@@ -59,7 +59,7 @@ of the Hahn series.
 -/
 theorem hahnEmbedding_isOrderedAddMonoid :
     ∃ f : M →+o Lex ℝ⟦FiniteArchimedeanClass M⟧, Function.Injective f ∧
-      ∀ a, mk a = FiniteArchimedeanClass.withTopOrderIso M (ofLex (f a)).orderTop := by
+      ∀ a, .mk a = FiniteArchimedeanClass.withTopOrderIso M (ofLex (f a)).orderTop := by
   /-
   The desired embedding is the composition of three functions:
 

--- a/Mathlib/RingTheory/HahnSeries/HahnEmbedding.lean
+++ b/Mathlib/RingTheory/HahnSeries/HahnEmbedding.lean
@@ -28,7 +28,7 @@ Archimedean classes of the group. The theorem is stated as `hahnEmbedding_isOrde
 
 @[expose] public section
 
-open ArchimedeanClass
+open ArchimedeanClass HahnSeries
 
 variable (M : Type*) [AddCommGroup M] [LinearOrder M] [IsOrderedAddMonoid M]
 

--- a/Mathlib/RingTheory/HahnSeries/HahnEmbedding.lean
+++ b/Mathlib/RingTheory/HahnSeries/HahnEmbedding.lean
@@ -17,7 +17,7 @@ public import Mathlib.GroupTheory.DivisibleHull
 # Hahn embedding theorem
 
 In this file, we prove the Hahn embedding theorem: every linearly ordered abelian group
-can be embedded as an ordered subgroup of `Lex (HahnSeries Ω ℝ)`, where `Ω` is the finite
+can be embedded as an ordered subgroup of `Lex ℝ⟦Ω⟧`, where `Ω` is the type of finite
 Archimedean classes of the group. The theorem is stated as `hahnEmbedding_isOrderedAddMonoid`.
 
 ## References
@@ -44,7 +44,7 @@ instance : Nonempty (HahnEmbedding.Seed ℚ M ℝ) := by
   · simpa using hf c
 
 theorem hahnEmbedding_isOrderedModule_rat :
-    ∃ f : M →ₗ[ℚ] Lex (HahnSeries (FiniteArchimedeanClass M) ℝ), StrictMono f ∧
+    ∃ f : M →ₗ[ℚ] Lex ℝ⟦FiniteArchimedeanClass M⟧, StrictMono f ∧
       ∀ a, mk a = FiniteArchimedeanClass.withTopOrderIso M (ofLex (f a)).orderTop := by
   apply hahnEmbedding_isOrderedModule
 
@@ -54,11 +54,11 @@ end Module
 **Hahn embedding theorem**
 
 For a linearly ordered additive group `M`, there exists an injective `OrderAddMonoidHom` from `M` to
-`Lex (HahnSeries (FiniteArchimedeanClass M) ℝ)` that sends each `a : M` to an element of the
-`a`-Archimedean class of the Hahn series.
+`Lex ℝ⟦FiniteArchimedeanClass M⟧` that sends each `a : M` to an element of the `a`-Archimedean class
+of the Hahn series.
 -/
 theorem hahnEmbedding_isOrderedAddMonoid :
-    ∃ f : M →+o Lex (HahnSeries (FiniteArchimedeanClass M) ℝ), Function.Injective f ∧
+    ∃ f : M →+o Lex ℝ⟦FiniteArchimedeanClass M⟧, Function.Injective f ∧
       ∀ a, mk a = FiniteArchimedeanClass.withTopOrderIso M (ofLex (f a)).orderTop := by
   /-
   The desired embedding is the composition of three functions:
@@ -69,9 +69,9 @@ theorem hahnEmbedding_isOrderedAddMonoid :
   `f₁` ↓+o                                           ↓o~
       `D-Hull M`                                    `ArchimedeanClass (D-Hull M)`
   `f₂` ↓+o                                           ↓o~
-      `Lex (HahnSeries (F-A-Class (D-Hull M)) ℝ)`   `WithTop (F-A-Class (D-Hull M))`
+      `Lex ℝ⟦F-A-Class (D-Hull M)⟧`                 `WithTop (F-A-Class (D-Hull M))`
   `f₃` ↓+o(~)                                        ↓o~
-      `Lex (HahnSeries (F-A-Class M) ℝ)`            `WithTop (F-A-Class M)`
+      `Lex ℝ⟦F-A-Class M⟧`                          `WithTop (F-A-Class M)`
   -/
   let f₁ := DivisibleHull.coeOrderAddMonoidHom M
   have hf₁ : Function.Injective f₁ := DivisibleHull.coe_injective
@@ -83,12 +83,11 @@ theorem hahnEmbedding_isOrderedAddMonoid :
   have hf₂class (a : DivisibleHull M) :
       mk a = (FiniteArchimedeanClass.withTopOrderIso (DivisibleHull M)) (ofLex (f₂ a)).orderTop :=
     hf₂class' a
-  let f₃ : Lex (HahnSeries (FiniteArchimedeanClass (DivisibleHull M)) ℝ) →+o
-      Lex (HahnSeries (FiniteArchimedeanClass M) ℝ) :=
+  let f₃ : Lex ℝ⟦FiniteArchimedeanClass (DivisibleHull M)⟧ →+o Lex ℝ⟦FiniteArchimedeanClass M⟧ :=
     HahnSeries.embDomainOrderAddMonoidHom
     (FiniteArchimedeanClass.congrOrderIso (DivisibleHull.archimedeanClassOrderIso M).symm)
   have hf₃ : Function.Injective f₃ := HahnSeries.embDomainOrderAddMonoidHom_injective _
-  have hf₃class (a : Lex (HahnSeries (FiniteArchimedeanClass (DivisibleHull M)) ℝ)) :
+  have hf₃class (a : Lex ℝ⟦FiniteArchimedeanClass (DivisibleHull M)⟧) :
       (ofLex a).orderTop = OrderIso.withTopCongr
       ((FiniteArchimedeanClass.congrOrderIso (DivisibleHull.archimedeanClassOrderIso M)))
       (ofLex (f₃ a)).orderTop := by

--- a/Mathlib/RingTheory/HahnSeries/Lex.lean
+++ b/Mathlib/RingTheory/HahnSeries/Lex.lean
@@ -14,13 +14,13 @@ public import Mathlib.RingTheory.HahnSeries.Addition
 
 # Lexicographical order on Hahn series
 
-In this file, we define lexicographical ordered `Lex (HahnSeries Γ R)`, and show this
+In this file, we define lexicographical ordered `Lex R⟦Γ⟧`, and show this
 is a `LinearOrder` when `Γ` and `R` themselves are linearly ordered. Additionally,
 it is an ordered group when `R` is.
 
 ## Main definitions
 
-* `HahnSeries.finiteArchimedeanClassOrderIsoLex`: `FiniteArchimedeanClass` of `Lex (HahnSeries Γ R)`
+* `HahnSeries.finiteArchimedeanClassOrderIsoLex`: `FiniteArchimedeanClass` of `Lex R⟦Γ⟧`
   can be decomposed by `Γ`.
 
 -/
@@ -34,10 +34,10 @@ variable {Γ R : Type*} [LinearOrder Γ]
 section PartialOrder
 variable [Zero R] [PartialOrder R]
 
-instance : PartialOrder (Lex (HahnSeries Γ R)) :=
+instance : PartialOrder (Lex R⟦Γ⟧) :=
   PartialOrder.lift (toLex <| ofLex · |>.coeff) fun x y ↦ by simp
 
-theorem lt_iff (a b : Lex (HahnSeries Γ R)) :
+theorem lt_iff (a b : Lex R⟦Γ⟧) :
     a < b ↔ ∃ (i : Γ), (∀ (j : Γ), j < i → (ofLex a).coeff j = (ofLex b).coeff j)
     ∧ (ofLex a).coeff i < (ofLex b).coeff i := by rfl
 
@@ -47,7 +47,7 @@ section LinearOrder
 variable [Zero R] [LinearOrder R]
 
 noncomputable
-instance : LinearOrder (Lex (HahnSeries Γ R)) where
+instance : LinearOrder (Lex R⟦Γ⟧) where
   le_total a b := by
     rcases eq_or_ne a b with hab | hab
     · exact Or.inl hab.le
@@ -71,7 +71,7 @@ instance : LinearOrder (Lex (HahnSeries Γ R)) where
   toDecidableLE := Classical.decRel _
 
 @[simp]
-theorem leadingCoeff_pos_iff {x : Lex (HahnSeries Γ R)} : 0 < (ofLex x).leadingCoeff ↔ 0 < x := by
+theorem leadingCoeff_pos_iff {x : Lex R⟦Γ⟧} : 0 < (ofLex x).leadingCoeff ↔ 0 < x := by
   rw [lt_iff]
   constructor
   · intro hpos
@@ -93,7 +93,7 @@ theorem leadingCoeff_pos_iff {x : Lex (HahnSeries Γ R)} : 0 < (ofLex x).leading
     rw [leadingCoeff_of_ne_zero hne, horder']
     simpa using hi
 
-theorem leadingCoeff_nonneg_iff {x : Lex (HahnSeries Γ R)} :
+theorem leadingCoeff_nonneg_iff {x : Lex R⟦Γ⟧} :
     0 ≤ (ofLex x).leadingCoeff ↔ 0 ≤ x := by
   constructor
   · intro h
@@ -105,10 +105,10 @@ theorem leadingCoeff_nonneg_iff {x : Lex (HahnSeries Γ R)} :
     · simp
     · exact (leadingCoeff_pos_iff.mpr hlt).le
 
-theorem leadingCoeff_neg_iff {x : Lex (HahnSeries Γ R)} : (ofLex x).leadingCoeff < 0 ↔ x < 0 := by
+theorem leadingCoeff_neg_iff {x : Lex R⟦Γ⟧} : (ofLex x).leadingCoeff < 0 ↔ x < 0 := by
   simpa using (leadingCoeff_nonneg_iff (x := x)).not
 
-theorem leadingCoeff_nonpos_iff {x : Lex (HahnSeries Γ R)} :
+theorem leadingCoeff_nonpos_iff {x : Lex R⟦Γ⟧} :
     (ofLex x).leadingCoeff ≤ 0 ↔ x ≤ 0 := by
   simp [← not_lt]
 
@@ -118,7 +118,7 @@ section OrderedMonoid
 variable [PartialOrder R] [AddCommMonoid R] [AddLeftStrictMono R] [IsOrderedAddMonoid R]
 
 set_option linter.flexible false in -- simp followed by gcongr
-instance : IsOrderedAddMonoid (Lex (HahnSeries Γ R)) where
+instance : IsOrderedAddMonoid (Lex R⟦Γ⟧) where
   add_le_add_left a b hab c := by
     obtain rfl | hlt := hab.eq_or_lt
     · simp
@@ -134,19 +134,19 @@ section OrderedGroup
 variable [LinearOrder R] [AddCommGroup R] [IsOrderedAddMonoid R]
 
 @[simp]
-theorem support_abs (x : Lex (HahnSeries Γ R)) : (ofLex |x|).support = (ofLex x).support := by
+theorem support_abs (x : Lex R⟦Γ⟧) : (ofLex |x|).support = (ofLex x).support := by
   obtain hle | hge := le_total x 0
   · rw [abs_eq_neg_self.mpr hle]
     simp
   · rw [abs_eq_self.mpr hge]
 
 @[simp]
-theorem orderTop_abs (x : Lex (HahnSeries Γ R)) : (ofLex |x|).orderTop = (ofLex x).orderTop := by
+theorem orderTop_abs (x : Lex R⟦Γ⟧) : (ofLex |x|).orderTop = (ofLex x).orderTop := by
   obtain hle | hge := le_total x 0
   · rw [abs_eq_neg_self.mpr hle, ofLex_neg, orderTop_neg]
   · rw [abs_eq_self.mpr hge]
 
-theorem order_abs [Zero Γ] (x : Lex (HahnSeries Γ R)) : (ofLex |x|).order = (ofLex x).order := by
+theorem order_abs [Zero Γ] (x : Lex R⟦Γ⟧) : (ofLex |x|).order = (ofLex x).order := by
   obtain rfl | hne := eq_or_ne x 0
   · simp
   · have hne' : ofLex x ≠ 0 := hne
@@ -155,7 +155,7 @@ theorem order_abs [Zero Γ] (x : Lex (HahnSeries Γ R)) : (ofLex |x|).order = (o
     rw [order_eq_orderTop_of_ne_zero habs, order_eq_orderTop_of_ne_zero hne']
     apply orderTop_abs
 
-theorem leadingCoeff_abs (x : Lex (HahnSeries Γ R)) :
+theorem leadingCoeff_abs (x : Lex R⟦Γ⟧) :
     (ofLex |x|).leadingCoeff = |(ofLex x).leadingCoeff| := by
   obtain hlt | rfl | hgt := lt_trichotomy x 0
   · obtain hlt' := leadingCoeff_neg_iff.mpr hlt
@@ -164,7 +164,7 @@ theorem leadingCoeff_abs (x : Lex (HahnSeries Γ R)) :
   · obtain hgt' := leadingCoeff_pos_iff.mpr hgt
     rw [abs_eq_self.mpr hgt.le, abs_eq_self.mpr hgt'.le]
 
-theorem abs_lt_abs_of_orderTop_ofLex {x y : Lex (HahnSeries Γ R)}
+theorem abs_lt_abs_of_orderTop_ofLex {x y : Lex R⟦Γ⟧}
     (h : (ofLex y).orderTop < (ofLex x).orderTop) : |x| < |y| := by
   rw [← orderTop_abs x, ← orderTop_abs y] at h
   refine (lt_iff _ _).mpr ⟨(ofLex |y|).orderTop.untop h.ne_top, ?_, ?_⟩
@@ -172,7 +172,7 @@ theorem abs_lt_abs_of_orderTop_ofLex {x y : Lex (HahnSeries Γ R)}
   · simpa [-orderTop_abs, coeff_eq_zero_of_lt_orderTop, coeff_untop_eq_leadingCoeff, h]
       using h.ne_top
 
-theorem archimedeanClassMk_le_archimedeanClassMk_iff_of_orderTop_ofLex {x y : Lex (HahnSeries Γ R)}
+theorem archimedeanClassMk_le_archimedeanClassMk_iff_of_orderTop_ofLex {x y : Lex R⟦Γ⟧}
     (h : (ofLex x).orderTop = (ofLex y).orderTop) :
     ArchimedeanClass.mk x ≤ .mk y ↔
       ArchimedeanClass.mk (ofLex x).leadingCoeff ≤ .mk (ofLex y).leadingCoeff := by
@@ -222,7 +222,7 @@ theorem archimedeanClassMk_le_archimedeanClassMk_iff_of_orderTop_ofLex {x y : Le
     refine lt_of_le_of_lt hn <| nsmul_lt_nsmul_left ?_ (by simp)
     rwa [abs_pos, leadingCoeff_ne_zero]
 
-theorem archimedeanClassMk_le_archimedeanClassMk_iff {x y : Lex (HahnSeries Γ R)} :
+theorem archimedeanClassMk_le_archimedeanClassMk_iff {x y : Lex R⟦Γ⟧} :
     ArchimedeanClass.mk x ≤ .mk y ↔
       (ofLex x).orderTop < (ofLex y).orderTop ∨
         (ofLex x).orderTop = (ofLex y).orderTop ∧
@@ -245,7 +245,7 @@ theorem archimedeanClassMk_le_archimedeanClassMk_iff {x y : Lex (HahnSeries Γ R
     simpa using orderTop_smul_not_lt n (ofLex x)
   exact abs_lt_abs_of_orderTop_ofLex hgt'
 
-theorem archimedeanClassMk_eq_archimedeanClassMk_iff {x y : Lex (HahnSeries Γ R)} :
+theorem archimedeanClassMk_eq_archimedeanClassMk_iff {x y : Lex R⟦Γ⟧} :
     ArchimedeanClass.mk x = ArchimedeanClass.mk y ↔
     (ofLex x).orderTop = (ofLex y).orderTop ∧
     ArchimedeanClass.mk (ofLex x).leadingCoeff = ArchimedeanClass.mk (ofLex y).leadingCoeff := by
@@ -257,10 +257,10 @@ theorem archimedeanClassMk_eq_archimedeanClassMk_iff {x y : Lex (HahnSeries Γ R
     exact ⟨.inr ⟨horder, hcoeff.le⟩, .inr ⟨horder.symm, hcoeff.ge⟩⟩
 
 variable (Γ R) in
-/-- Finite archimedean classes of `Lex (HahnSeries Γ R)` decompose into lexicographical pairs
+/-- Finite archimedean classes of `Lex R⟦Γ⟧` decompose into lexicographical pairs
 of `order` and the finite archimedean class of `leadingCoeff`. -/
 noncomputable def finiteArchimedeanClassOrderHomLex :
-    FiniteArchimedeanClass (Lex (HahnSeries Γ R)) →o Γ ×ₗ FiniteArchimedeanClass R :=
+    FiniteArchimedeanClass (Lex R⟦Γ⟧) →o Γ ×ₗ FiniteArchimedeanClass R :=
   FiniteArchimedeanClass.liftOrderHom
     (fun ⟨x, hx⟩ ↦ toLex
       ⟨(ofLex x).orderTop.untop (by simp [orderTop_of_ne_zero (show ofLex x ≠ 0 by exact hx)]),
@@ -275,7 +275,7 @@ noncomputable def finiteArchimedeanClassOrderHomLex :
 variable (Γ R) in
 /-- The inverse of `finiteArchimedeanClassOrderHomLex`. -/
 noncomputable def finiteArchimedeanClassOrderHomInvLex :
-    Γ ×ₗ FiniteArchimedeanClass R →o FiniteArchimedeanClass (Lex (HahnSeries Γ R)) where
+    Γ ×ₗ FiniteArchimedeanClass R →o FiniteArchimedeanClass (Lex R⟦Γ⟧) where
   toFun x := (ofLex x).2.liftOrderHom
     (fun a ↦ FiniteArchimedeanClass.mk (toLex (single (ofLex x).1 a.val)) (by
       simpa using a.prop))
@@ -292,11 +292,11 @@ noncomputable def finiteArchimedeanClassOrderHomInvLex :
     · exact OrderHom.monotone _ hle
 
 variable (Γ R) in
-/-- The correspondence between finite archimedean classes of `Lex (HahnSeries Γ R)`
+/-- The correspondence between finite archimedean classes of `Lex R⟦Γ⟧`
 and lexicographical pairs of `HahnSeries.orderTop` and the finite archimedean class of
 `HahnSeries.leadingCoeff`. -/
 noncomputable def finiteArchimedeanClassOrderIsoLex :
-    FiniteArchimedeanClass (Lex (HahnSeries Γ R)) ≃o Γ ×ₗ FiniteArchimedeanClass R := by
+    FiniteArchimedeanClass (Lex R⟦Γ⟧) ≃o Γ ×ₗ FiniteArchimedeanClass R := by
   apply OrderIso.ofHomInv (finiteArchimedeanClassOrderHomLex Γ R)
     (finiteArchimedeanClassOrderHomInvLex Γ R)
   · ext x
@@ -310,13 +310,13 @@ noncomputable def finiteArchimedeanClassOrderIsoLex :
       archimedeanClassMk_eq_archimedeanClassMk_iff, ha]
 
 @[simp]
-theorem finiteArchimedeanClassOrderIsoLex_apply_fst {x : Lex (HahnSeries Γ R)} (h : x ≠ 0) :
+theorem finiteArchimedeanClassOrderIsoLex_apply_fst {x : Lex R⟦Γ⟧} (h : x ≠ 0) :
     (ofLex (finiteArchimedeanClassOrderIsoLex Γ R (FiniteArchimedeanClass.mk x h))).1 =
     (ofLex x).orderTop := by
   simp [finiteArchimedeanClassOrderIsoLex, finiteArchimedeanClassOrderHomLex]
 
 @[simp]
-theorem finiteArchimedeanClassOrderIsoLex_apply_snd {x : Lex (HahnSeries Γ R)} (h : x ≠ 0) :
+theorem finiteArchimedeanClassOrderIsoLex_apply_snd {x : Lex R⟦Γ⟧} (h : x ≠ 0) :
     (ofLex (finiteArchimedeanClassOrderIsoLex Γ R (FiniteArchimedeanClass.mk x h))).2.val =
     ArchimedeanClass.mk (ofLex x).leadingCoeff := by
   simp [finiteArchimedeanClassOrderIsoLex, finiteArchimedeanClassOrderHomLex]
@@ -328,12 +328,12 @@ variable (Γ R) in
 /-- For `Archimedean` coefficients, there is a correspondence between finite
 archimedean classes and `HahnSeries.orderTop` without the top element. -/
 noncomputable def finiteArchimedeanClassOrderIso :
-    FiniteArchimedeanClass (Lex (HahnSeries Γ R)) ≃o Γ :=
+    FiniteArchimedeanClass (Lex R⟦Γ⟧) ≃o Γ :=
   have : Unique (FiniteArchimedeanClass R) := (nonempty_unique _).some
   (finiteArchimedeanClassOrderIsoLex Γ R).trans (Prod.Lex.prodUnique _ _)
 
 @[simp]
-theorem finiteArchimedeanClassOrderIso_apply {x : Lex (HahnSeries Γ R)} (h : x ≠ 0) :
+theorem finiteArchimedeanClassOrderIso_apply {x : Lex R⟦Γ⟧} (h : x ≠ 0) :
     finiteArchimedeanClassOrderIso Γ R (FiniteArchimedeanClass.mk x h) = (ofLex x).orderTop := by
   simp [finiteArchimedeanClassOrderIso]
 
@@ -341,12 +341,12 @@ variable (Γ R) in
 /-- For `Archimedean` coefficients, there is a correspondence between
 archimedean classes (with top) and `HahnSeries.orderTop`. -/
 noncomputable def archimedeanClassOrderIsoWithTop :
-    ArchimedeanClass (Lex (HahnSeries Γ R)) ≃o WithTop Γ :=
+    ArchimedeanClass (Lex R⟦Γ⟧) ≃o WithTop Γ :=
   (FiniteArchimedeanClass.withTopOrderIso _).symm.trans
   (finiteArchimedeanClassOrderIso _ _).withTopCongr
 
 @[simp]
-theorem archimedeanClassOrderIsoWithTop_apply (x : Lex (HahnSeries Γ R)) :
+theorem archimedeanClassOrderIsoWithTop_apply (x : Lex R⟦Γ⟧) :
     archimedeanClassOrderIsoWithTop Γ R (ArchimedeanClass.mk x) = (ofLex x).orderTop := by
   unfold archimedeanClassOrderIsoWithTop
   obtain rfl | h := eq_or_ne x 0 <;>
@@ -362,7 +362,7 @@ variable [PartialOrder R] {Γ' : Type*} [LinearOrder Γ'] (f : Γ ↪o Γ')
 /-- `HahnSeries.embDomain` as an `OrderEmbedding`. -/
 @[simps]
 noncomputable
-def embDomainOrderEmbedding [Zero R] : Lex (HahnSeries Γ R) ↪o Lex (HahnSeries Γ' R) where
+def embDomainOrderEmbedding [Zero R] : Lex R⟦Γ⟧ ↪o Lex R⟦Γ'⟧ where
   toFun a := toLex (embDomain f (ofLex a))
   inj' := toLex.injective.comp (embDomain_injective.comp (ofLex.injective))
   map_rel_iff' {a b} := by
@@ -388,7 +388,7 @@ def embDomainOrderEmbedding [Zero R] : Lex (HahnSeries Γ R) ↪o Lex (HahnSerie
 /-- `HahnSeries.embDomain` as an `OrderAddMonoidHom`. -/
 @[simps]
 noncomputable
-def embDomainOrderAddMonoidHom [AddMonoid R] : Lex (HahnSeries Γ R) →+o Lex (HahnSeries Γ' R) where
+def embDomainOrderAddMonoidHom [AddMonoid R] : Lex R⟦Γ⟧ →+o Lex R⟦Γ'⟧ where
   __ := (embDomainOrderEmbedding f).toOrderHom
   map_zero' := by simp
   map_add' := by simp [embDomainOrderEmbedding, embDomain_add]

--- a/Mathlib/RingTheory/HahnSeries/Multiplication.lean
+++ b/Mathlib/RingTheory/HahnSeries/Multiplication.lean
@@ -914,7 +914,7 @@ section Algebra
 
 variable [CommSemiring R] {A : Type*} [Semiring A] [Algebra R A]
 
-instance : Algebra R (HahnSeries Γ A) where
+instance : Algebra R A⟦Γ⟧ where
   algebraMap := C.comp (algebraMap R A)
   smul_def' r x := by
     ext
@@ -928,7 +928,7 @@ instance : Algebra R (HahnSeries Γ A) where
 theorem C_eq_algebraMap : C = algebraMap R R⟦Γ⟧ :=
   rfl
 
-theorem algebraMap_apply {r : R} : algebraMap R (HahnSeries Γ A) r = C (algebraMap R A r) :=
+theorem algebraMap_apply {r : R} : algebraMap R A⟦Γ⟧ r = C (algebraMap R A r) :=
   rfl
 
 instance [Nontrivial Γ] [Nontrivial R] : Nontrivial (Subalgebra R R⟦Γ⟧) :=
@@ -950,7 +950,7 @@ variable {Γ' : Type*} [AddCommMonoid Γ'] [PartialOrder Γ'] [IsOrderedCancelAd
 /-- Extending the domain of Hahn series is an algebra homomorphism. -/
 @[simps!]
 def embDomainAlgHom (f : Γ →+ Γ') (hfi : Function.Injective f)
-    (hf : ∀ g g' : Γ, f g ≤ f g' ↔ g ≤ g') : HahnSeries Γ A →ₐ[R] HahnSeries Γ' A :=
+    (hf : ∀ g g' : Γ, f g ≤ f g' ↔ g ≤ g') : A⟦Γ⟧ →ₐ[R] A⟦Γ'⟧ :=
   { embDomainRingHom f hfi hf with commutes' := fun _ => embDomainRingHom_C (hf := hf) }
 
 end Domain

--- a/Mathlib/RingTheory/HahnSeries/Multiplication.lean
+++ b/Mathlib/RingTheory/HahnSeries/Multiplication.lean
@@ -436,17 +436,15 @@ theorem coeff_mul_right' [NonUnitalNonAssocSemiring R] {x y : HahnSeries Γ R} {
       ∑ ij ∈ addAntidiagonal x.isPWO_support hs a, x.coeff ij.fst * y.coeff ij.snd :=
   HahnModule.coeff_smul_right hs hys
 
-instance [NonUnitalNonAssocSemiring R] : Distrib (HahnSeries Γ R) :=
-  { inferInstanceAs (Mul (HahnSeries Γ R)),
-    inferInstanceAs (Add (HahnSeries Γ R)) with
-    left_distrib := fun x y z => by
-      simp only [← of_symm_smul_of_eq_mul]
-      exact HahnModule.smul_add x y z
-    right_distrib := fun x y z => by
-      simp only [← of_symm_smul_of_eq_mul]
-      refine HahnModule.add_smul ?_
-      simp only [smul_eq_mul]
-      exact add_mul }
+instance [NonUnitalNonAssocSemiring R] : Distrib (HahnSeries Γ R) where
+  left_distrib := fun x y z => by
+    simp only [← of_symm_smul_of_eq_mul]
+    exact HahnModule.smul_add x y z
+  right_distrib := fun x y z => by
+    simp only [← of_symm_smul_of_eq_mul]
+    refine HahnModule.add_smul ?_
+    simp only [smul_eq_mul]
+    exact add_mul
 
 theorem coeff_single_mul_add [NonUnitalNonAssocSemiring R] {r : R} {x : HahnSeries Γ R} {a : Γ}
     {b : Γ} : (single b r * x).coeff (a + b) = r * x.coeff a := by
@@ -497,15 +495,13 @@ theorem support_mul_subset_add_support [NonUnitalNonAssocSemiring R] {x y : Hahn
   rw [← of_symm_smul_of_eq_mul, ← vadd_eq_add]
   exact HahnModule.support_smul_subset_vadd_support
 
-instance [NonUnitalNonAssocSemiring R] : NonUnitalNonAssocSemiring (HahnSeries Γ R) :=
-  { inferInstanceAs (AddCommMonoid (HahnSeries Γ R)),
-    inferInstanceAs (Distrib (HahnSeries Γ R)) with
-    zero_mul := fun _ => by
-      ext
-      simp [coeff_mul]
-    mul_zero := fun _ => by
-      ext
-      simp [coeff_mul] }
+instance [NonUnitalNonAssocSemiring R] : NonUnitalNonAssocSemiring (HahnSeries Γ R) where
+  zero_mul _ := by
+    ext
+    simp [coeff_mul]
+  mul_zero _ := by
+    ext
+    simp [coeff_mul]
 
 end mul
 
@@ -564,7 +560,7 @@ theorem order_single_mul_of_isRegular {g : Γ} {r : R} (hr : IsRegular r)
 
 end orderLemmas
 
-section ring
+section Ring
 
 variable [AddCommMonoid Γ] [PartialOrder Γ] [IsOrderedCancelAddMonoid Γ]
 
@@ -578,61 +574,34 @@ private theorem mul_assoc' [NonUnitalSemiring R] (x y z : HahnSeries Γ R) :
     (fun ⟨⟨i, _j⟩, ⟨k, l⟩⟩ ↦ ⟨(i + k, l), (i, k)⟩) <;>
     aesop (add safe Set.add_mem_add) (add simp [add_assoc, mul_assoc])
 
-instance [NonUnitalSemiring R] : NonUnitalSemiring (HahnSeries Γ R) :=
-  { inferInstanceAs (NonUnitalNonAssocSemiring (HahnSeries Γ R)) with
-    mul_assoc := mul_assoc' }
+instance [NonUnitalSemiring R] : NonUnitalSemiring (HahnSeries Γ R) where
+  mul_assoc := mul_assoc'
 
-instance [NonAssocSemiring R] : NonAssocSemiring (HahnSeries Γ R) :=
-  { inferInstanceAs (AddMonoidWithOne (HahnSeries Γ R)),
-    inferInstanceAs (NonUnitalNonAssocSemiring (HahnSeries Γ R)) with
-    one_mul := fun x => by
-      ext
-      exact coeff_single_zero_mul.trans (one_mul _)
-    mul_one := fun x => by
-      ext
-      exact coeff_mul_single_zero.trans (mul_one _) }
+instance [NonAssocSemiring R] : NonAssocSemiring (HahnSeries Γ R) where
+  one_mul x := by
+    ext
+    exact coeff_single_zero_mul.trans (one_mul _)
+  mul_one x := by
+    ext
+    exact coeff_mul_single_zero.trans (mul_one _)
 
-instance [Semiring R] : Semiring (HahnSeries Γ R) :=
-  { inferInstanceAs (NonAssocSemiring (HahnSeries Γ R)),
-    inferInstanceAs (NonUnitalSemiring (HahnSeries Γ R)) with }
+instance [Semiring R] : Semiring (HahnSeries Γ R) where
 
 instance [NonUnitalCommSemiring R] : NonUnitalCommSemiring (HahnSeries Γ R) where
-  __ : NonUnitalSemiring (HahnSeries Γ R) := inferInstance
   mul_comm x y := by
     ext
     simp_rw [coeff_mul, mul_comm]
     exact Finset.sum_equiv (Equiv.prodComm _ _) (fun _ ↦ swap_mem_addAntidiagonal.symm) <| by simp
 
-instance [CommSemiring R] : CommSemiring (HahnSeries Γ R) :=
-  { inferInstanceAs (NonUnitalCommSemiring (HahnSeries Γ R)),
-    inferInstanceAs (Semiring (HahnSeries Γ R)) with }
+instance [CommSemiring R] : CommSemiring (HahnSeries Γ R) where
+instance [NonUnitalNonAssocRing R] : NonUnitalNonAssocRing (HahnSeries Γ R) where
+instance [NonUnitalRing R] : NonUnitalRing (HahnSeries Γ R) where
+instance [NonAssocRing R] : NonAssocRing (HahnSeries Γ R) where
+instance [Ring R] : Ring (HahnSeries Γ R) where
+instance [NonUnitalCommRing R] : NonUnitalCommRing (HahnSeries Γ R) where
+instance [CommRing R] : CommRing (HahnSeries Γ R) where
 
-instance [NonUnitalNonAssocRing R] : NonUnitalNonAssocRing (HahnSeries Γ R) :=
-  { inferInstanceAs (NonUnitalNonAssocSemiring (HahnSeries Γ R)),
-    inferInstanceAs (AddGroup (HahnSeries Γ R)) with }
-
-instance [NonUnitalRing R] : NonUnitalRing (HahnSeries Γ R) :=
-  { inferInstanceAs (NonUnitalNonAssocRing (HahnSeries Γ R)),
-    inferInstanceAs (NonUnitalSemiring (HahnSeries Γ R)) with }
-
-instance [NonAssocRing R] : NonAssocRing (HahnSeries Γ R) :=
-  { inferInstanceAs (NonUnitalNonAssocRing (HahnSeries Γ R)),
-    inferInstanceAs (NonAssocSemiring (HahnSeries Γ R)),
-    inferInstanceAs (AddGroupWithOne (HahnSeries Γ R)) with }
-
-instance [Ring R] : Ring (HahnSeries Γ R) :=
-  { inferInstanceAs (Semiring (HahnSeries Γ R)),
-    inferInstanceAs (AddCommGroupWithOne (HahnSeries Γ R)) with }
-
-instance [NonUnitalCommRing R] : NonUnitalCommRing (HahnSeries Γ R) :=
-  { inferInstanceAs (NonUnitalCommSemiring (HahnSeries Γ R)),
-    inferInstanceAs (NonUnitalRing (HahnSeries Γ R)) with }
-
-instance [CommRing R] : CommRing (HahnSeries Γ R) :=
-  { inferInstanceAs (CommSemiring (HahnSeries Γ R)),
-    inferInstanceAs (Ring (HahnSeries Γ R)) with }
-
-end ring
+end Ring
 
 theorem orderTop_nsmul_le_orderTop_pow [AddCommMonoid Γ] [LinearOrder Γ]
     [IsOrderedCancelAddMonoid Γ] [Semiring R] {x : HahnSeries Γ R} {n : ℕ} :

--- a/Mathlib/RingTheory/HahnSeries/Multiplication.lean
+++ b/Mathlib/RingTheory/HahnSeries/Multiplication.lean
@@ -437,10 +437,10 @@ theorem coeff_mul_right' [NonUnitalNonAssocSemiring R] {x y : HahnSeries Γ R} {
   HahnModule.coeff_smul_right hs hys
 
 instance [NonUnitalNonAssocSemiring R] : Distrib (HahnSeries Γ R) where
-  left_distrib := fun x y z => by
+  left_distrib x y z := by
     simp only [← of_symm_smul_of_eq_mul]
     exact HahnModule.smul_add x y z
-  right_distrib := fun x y z => by
+  right_distrib x y z := by
     simp only [← of_symm_smul_of_eq_mul]
     refine HahnModule.add_smul ?_
     simp only [smul_eq_mul]

--- a/Mathlib/RingTheory/HahnSeries/Multiplication.lean
+++ b/Mathlib/RingTheory/HahnSeries/Multiplication.lean
@@ -51,7 +51,7 @@ The following may be useful for composing vertex operators, but they seem to tak
 
 @[expose] public section
 
-open Finset Function Pointwise
+open Finset Function HahnSeries Pointwise
 
 noncomputable section
 

--- a/Mathlib/RingTheory/HahnSeries/Multiplication.lean
+++ b/Mathlib/RingTheory/HahnSeries/Multiplication.lean
@@ -15,30 +15,30 @@ public import Mathlib.RingTheory.HahnSeries.Addition
 
 /-!
 # Multiplicative properties of Hahn series
-If `Γ` is ordered and `R` has zero, then `HahnSeries Γ R` consists of formal series over `Γ` with
+If `Γ` is ordered and `R` has zero, then `R⟦Γ⟧` consists of formal series over `Γ` with
 coefficients in `R`, whose supports are partially well-ordered. This module introduces
 multiplication and scalar multiplication on Hahn series. If `Γ` is an ordered cancellative
 commutative additive monoid and `R` is a semiring, then we get a semiring structure on
-`HahnSeries Γ R`. If `Γ` has an ordered vector-addition on `Γ'` and `R` has a scalar multiplication
-on `V`, we define `HahnModule Γ' R V` as a type alias for `HahnSeries Γ' V` that admits a scalar
-multiplication from `HahnSeries Γ R`. The scalar action of `R` on `HahnSeries Γ R` is compatible
-with the action of `HahnSeries Γ R` on `HahnModule Γ' R V`.
+`R⟦Γ⟧`. If `Γ` has an ordered vector-addition on `Γ'` and `R` has a scalar multiplication
+on `V`, we define `HahnModule Γ' R V` as a type alias for `V⟦Γ'⟧` that admits a scalar
+multiplication from `R⟦Γ⟧`. The scalar action of `R` on `R⟦Γ⟧` is compatible
+with the action of `R⟦Γ⟧` on `HahnModule Γ' R V`.
 
 ## Main Definitions
 * `HahnModule` is a type alias for `HahnSeries`, which we use for defining scalar multiplication
-  of `HahnSeries Γ R` on `HahnModule Γ' R V` for an `R`-module `V`, where `Γ'` admits an ordered
+  of `R⟦Γ⟧` on `HahnModule Γ' R V` for an `R`-module `V`, where `Γ'` admits an ordered
   cancellative vector addition operation from `Γ`. The type alias allows us to avoid a potential
   instance diamond.
-* `HahnModule.of` is the isomorphism from `HahnSeries Γ V` to `HahnModule Γ R V`.
-* `HahnSeries.C` is the `constant term` ring homomorphism `R →+* HahnSeries Γ R`.
-* `HahnSeries.embDomainRingHom` is the ring homomorphism `HahnSeries Γ R →+* HahnSeries Γ' R`
+* `HahnModule.of` is the isomorphism from `V⟦Γ⟧` to `HahnModule Γ R V`.
+* `HahnSeries.C` is the `constant term` ring homomorphism `R →+* R⟦Γ⟧`.
+* `HahnSeries.embDomainRingHom` is the ring homomorphism `R⟦Γ⟧ →+* R⟦Γ'⟧`
   induced by an order embedding `Γ ↪o Γ'`.
 * `HahnSeries.orderTopSubOnePos` is the group of invertible Hahn series close to 1, i.e., those
   series such that subtracting one yields a series with strictly positive `orderTop`.
 
 ## Main results
-* If `R` is a (commutative) (semi-)ring, then so is `HahnSeries Γ R`.
-* If `V` is an `R`-module, then `HahnModule Γ' R V` is a `HahnSeries Γ R`-module.
+* If `R` is a (commutative) (semi-)ring, then so is `R⟦Γ⟧`.
+* If `V` is an `R`-module, then `HahnModule Γ' R V` is a `R⟦Γ⟧`-module.
 
 ## TODO
 The following may be useful for composing vertex operators, but they seem to take time.
@@ -61,16 +61,15 @@ namespace HahnSeries
 
 variable [Zero Γ] [PartialOrder Γ]
 
-instance [Zero R] [One R] : One (HahnSeries Γ R) where one := single 0 1
-instance [Zero R] [NatCast R] : NatCast (HahnSeries Γ R) where natCast n := single 0 n
-instance [Zero R] [IntCast R] : IntCast (HahnSeries Γ R) where intCast z := single 0 z
-instance [Zero R] [NNRatCast R] : NNRatCast (HahnSeries Γ R) where nnratCast q := single 0 q
-instance [Zero R] [RatCast R] : RatCast (HahnSeries Γ R) where ratCast q := single 0 q
+instance [Zero R] [One R] : One R⟦Γ⟧ where one := single 0 1
+instance [Zero R] [NatCast R] : NatCast R⟦Γ⟧ where natCast n := single 0 n
+instance [Zero R] [IntCast R] : IntCast R⟦Γ⟧ where intCast z := single 0 z
+instance [Zero R] [NNRatCast R] : NNRatCast R⟦Γ⟧ where nnratCast q := single 0 q
+instance [Zero R] [RatCast R] : RatCast R⟦Γ⟧ where ratCast q := single 0 q
 
 open Classical in
 @[simp]
-theorem coeff_one [Zero R] [One R] {a : Γ} :
-    (1 : HahnSeries Γ R).coeff a = if a = 0 then 1 else 0 :=
+theorem coeff_one [Zero R] [One R] {a : Γ} : (1 : R⟦Γ⟧).coeff a = if a = 0 then 1 else 0 :=
   coeff_single
 
 @[simp] theorem single_zero_one [Zero R] [One R] : single (0 : Γ) (1 : R) = 1 := rfl
@@ -83,45 +82,45 @@ theorem single_zero_ofNat [Zero R] [NatCast R] (n : ℕ) [n.AtLeastTwo] :
     single (0 : Γ) (ofNat(n) : R) = ofNat(n) := rfl
 
 @[simp]
-theorem support_one [MulZeroOneClass R] [Nontrivial R] : support (1 : HahnSeries Γ R) = {0} :=
+theorem support_one [MulZeroOneClass R] [Nontrivial R] : support (1 : R⟦Γ⟧) = {0} :=
   support_single_of_ne one_ne_zero
 
 @[simp]
-theorem orderTop_one [Zero R] [One R] [NeZero (1 : R)] : orderTop (1 : HahnSeries Γ R) = 0 := by
+theorem orderTop_one [Zero R] [One R] [NeZero (1 : R)] : orderTop (1 : R⟦Γ⟧) = 0 := by
   rw [← single_zero_one, orderTop_single one_ne_zero, WithTop.coe_eq_zero]
 
 @[simp]
-theorem order_one [MulZeroOneClass R] : order (1 : HahnSeries Γ R) = 0 := by
+theorem order_one [MulZeroOneClass R] : order (1 : R⟦Γ⟧) = 0 := by
   cases subsingleton_or_nontrivial R
-  · rw [Subsingleton.elim (1 : HahnSeries Γ R) 0, order_zero]
+  · rw [Subsingleton.elim (1 : R⟦Γ⟧) 0, order_zero]
   · exact order_single one_ne_zero
 
 @[simp]
-theorem leadingCoeff_one [MulZeroOneClass R] : (1 : HahnSeries Γ R).leadingCoeff = 1 := by
+theorem leadingCoeff_one [MulZeroOneClass R] : (1 : R⟦Γ⟧).leadingCoeff = 1 := by
   simp [leadingCoeff_eq]
 
 @[simp]
 protected lemma map_one [MonoidWithZero R] [MonoidWithZero S] (f : R →*₀ S) :
-    (1 : HahnSeries Γ R).map f = (1 : HahnSeries Γ S) :=
+    (1 : R⟦Γ⟧).map f = (1 : S⟦Γ⟧) :=
   HahnSeries.map_single (a := (0 : Γ)) f.toZeroHom |>.trans <| congrArg _ <| f.map_one
 
-instance [AddCommMonoidWithOne R] : AddCommMonoidWithOne (HahnSeries Γ R) where
+instance [AddCommMonoidWithOne R] : AddCommMonoidWithOne R⟦Γ⟧ where
   natCast_zero := by simp [← single_zero_natCast]
   natCast_succ n := by simp [← single_zero_natCast]
 
-instance [AddCommGroupWithOne R] : AddCommGroupWithOne (HahnSeries Γ R) where
+instance [AddCommGroupWithOne R] : AddCommGroupWithOne R⟦Γ⟧ where
   intCast_ofNat n := by simp [← single_zero_natCast, ← single_zero_intCast]
   intCast_negSucc n := by simp [← single_zero_natCast, ← single_zero_intCast]
 
 end HahnSeries
 
 /-- We introduce a type alias for `HahnSeries` in order to work with scalar multiplication by
-series. If we wrote a `SMul (HahnSeries Γ R) (HahnSeries Γ V)` instance, then when
-`V = HahnSeries Γ R`, we would have two different actions of `HahnSeries Γ R` on `HahnSeries Γ V`.
+series. If we wrote a `SMul R⟦Γ⟧ V⟦Γ⟧` instance, then when
+`V = R⟦Γ⟧`, we would have two different actions of `R⟦Γ⟧` on `V⟦Γ⟧`.
 See `Mathlib/Algebra/Polynomial/Module.lean` for more discussion on this problem. -/
 @[nolint unusedArguments]
 def HahnModule (Γ R V : Type*) [PartialOrder Γ] [Zero V] [SMul R V] :=
-  HahnSeries Γ V
+  V⟦Γ⟧
 
 namespace HahnModule
 
@@ -130,12 +129,12 @@ section
 variable [PartialOrder Γ] [Zero V] [SMul R V]
 
 /-- The casting function to the type synonym. -/
-def of (R : Type*) [SMul R V] : HahnSeries Γ V ≃ HahnModule Γ R V :=
+def of (R : Type*) [SMul R V] : V⟦Γ⟧ ≃ HahnModule Γ R V :=
   Equiv.refl _
 
 /-- Recursion principle to reduce a result about the synonym to the original type. -/
 @[elab_as_elim]
-def rec {motive : HahnModule Γ R V → Sort*} (h : ∀ x : HahnSeries Γ V, motive (of R x)) :
+def rec {motive : HahnModule Γ R V → Sort*} (h : ∀ x : V⟦Γ⟧, motive (of R x)) :
     ∀ x, motive x :=
   fun x => h <| (of R).symm x
 
@@ -150,19 +149,19 @@ section SMul
 variable [PartialOrder Γ] [SMul R V]
 
 instance instZero [Zero V] : Zero (HahnModule Γ R V) :=
-  inferInstanceAs <| Zero (HahnSeries Γ V)
+  inferInstanceAs <| Zero V⟦Γ⟧
 instance instAddCommMonoid [AddCommMonoid V] : AddCommMonoid (HahnModule Γ R V) :=
-  inferInstanceAs <| AddCommMonoid (HahnSeries Γ V)
+  inferInstanceAs <| AddCommMonoid V⟦Γ⟧
 instance instAddCommGroup [AddCommGroup V] : AddCommGroup (HahnModule Γ R V) :=
-  inferInstanceAs <| AddCommGroup (HahnSeries Γ V)
+  inferInstanceAs <| AddCommGroup V⟦Γ⟧
 instance instBaseSMul {V} [Monoid R] [AddMonoid V] [DistribMulAction R V] :
     SMul R (HahnModule Γ R V) :=
-  inferInstanceAs <| SMul R (HahnSeries Γ V)
+  inferInstanceAs <| SMul R V⟦Γ⟧
 
-@[simp] theorem of_zero [Zero V] : of R (0 : HahnSeries Γ V) = 0 := rfl
-@[simp] theorem of_add [AddCommMonoid V] (x y : HahnSeries Γ V) :
+@[simp] theorem of_zero [Zero V] : of R (0 : V⟦Γ⟧) = 0 := rfl
+@[simp] theorem of_add [AddCommMonoid V] (x y : V⟦Γ⟧) :
     of R (x + y) = of R x + of R y := rfl
-@[simp] theorem of_sub [AddCommGroup V] (x y : HahnSeries Γ V) :
+@[simp] theorem of_sub [AddCommGroup V] (x y : V⟦Γ⟧) :
     of R (x - y) = of R x - of R y := rfl
 
 @[simp] theorem of_symm_zero [Zero V] : (of R).symm (0 : HahnModule Γ R V) = 0 := rfl
@@ -173,7 +172,7 @@ instance instBaseSMul {V} [Monoid R] [AddMonoid V] [DistribMulAction R V] :
 
 variable [PartialOrder Γ'] [VAdd Γ Γ'] [IsOrderedCancelVAdd Γ Γ'] [Zero R] [AddCommMonoid V]
 
-instance instSMul : SMul (HahnSeries Γ R) (HahnModule Γ' R V) where
+instance instSMul : SMul R⟦Γ⟧ (HahnModule Γ' R V) where
   smul x y := (of R) {
     coeff := fun a =>
       ∑ ij ∈ VAddAntidiagonal x.isPWO_support ((of R).symm y).isPWO_support a,
@@ -191,7 +190,7 @@ instance instSMul : SMul (HahnSeries Γ R) (HahnModule Γ' R V) where
           simp [ha]
         isPWO_support_vaddAntidiagonal.mono h }
 
-theorem coeff_smul (x : HahnSeries Γ R) (y : HahnModule Γ' R V) (a : Γ') :
+theorem coeff_smul (x : R⟦Γ⟧) (y : HahnModule Γ' R V) (a : Γ') :
     ((of R).symm <| x • y).coeff a =
       ∑ ij ∈ VAddAntidiagonal x.isPWO_support ((of R).symm y).isPWO_support a,
         x.coeff ij.fst • ((of R).symm y).coeff ij.snd :=
@@ -206,9 +205,9 @@ variable [PartialOrder Γ] [PartialOrder Γ'] [VAdd Γ Γ'] [IsOrderedCancelVAdd
 
 instance instBaseSMulZeroClass [SMulZeroClass R V] :
     SMulZeroClass R (HahnModule Γ R V) :=
-  inferInstanceAs <| SMulZeroClass R (HahnSeries Γ V)
+  inferInstanceAs <| SMulZeroClass R V⟦Γ⟧
 
-@[simp] theorem of_smul [SMulZeroClass R V] (r : R) (x : HahnSeries Γ V) :
+@[simp] theorem of_smul [SMulZeroClass R V] (r : R) (x : V⟦Γ⟧) :
     (of R) (r • x) = r • (of R) x := rfl
 @[simp] theorem of_symm_smul [SMulZeroClass R V] (r : R) (x : HahnModule Γ R V) :
     (of R).symm (r • x) = r • (of R).symm x := rfl
@@ -216,12 +215,12 @@ instance instBaseSMulZeroClass [SMulZeroClass R V] :
 variable [Zero R]
 
 instance instSMulZeroClass [SMulZeroClass R V] :
-    SMulZeroClass (HahnSeries Γ R) (HahnModule Γ' R V) where
+    SMulZeroClass R⟦Γ⟧ (HahnModule Γ' R V) where
   smul_zero x := by
     ext
     simp [coeff_smul]
 
-theorem coeff_smul_right [SMulZeroClass R V] {x : HahnSeries Γ R} {y : HahnModule Γ' R V} {a : Γ'}
+theorem coeff_smul_right [SMulZeroClass R V] {x : R⟦Γ⟧} {y : HahnModule Γ' R V} {a : Γ'}
     {s : Set Γ'} (hs : s.IsPWO) (hys : ((of R).symm y).support ⊆ s) :
     ((of R).symm <| x • y).coeff a =
       ∑ ij ∈ VAddAntidiagonal x.isPWO_support hs a,
@@ -233,7 +232,7 @@ theorem coeff_smul_right [SMulZeroClass R V] {x : HahnSeries Γ R} {y : HahnModu
   simp only [not_and, mem_sdiff, mem_vaddAntidiagonal, HahnSeries.mem_support, not_imp_not] at hb
   rw [hb.2 hb.1.1 hb.1.2.2, smul_zero]
 
-theorem coeff_smul_left [SMulWithZero R V] {x : HahnSeries Γ R}
+theorem coeff_smul_left [SMulWithZero R V] {x : R⟦Γ⟧}
     {y : HahnModule Γ' R V} {a : Γ'} {s : Set Γ}
     (hs : s.IsPWO) (hxs : x.support ⊆ s) :
     ((of R).symm <| x • y).coeff a =
@@ -252,7 +251,7 @@ section DistribSMul
 
 variable [PartialOrder Γ] [PartialOrder Γ'] [VAdd Γ Γ'] [IsOrderedCancelVAdd Γ Γ'] [AddCommMonoid V]
 
-theorem smul_add [Zero R] [DistribSMul R V] (x : HahnSeries Γ R) (y z : HahnModule Γ' R V) :
+theorem smul_add [Zero R] [DistribSMul R V] (x : R⟦Γ⟧) (y z : HahnModule Γ' R V) :
     x • (y + z) = x • y + x • z := by
   ext k
   have hwf := ((of R).symm y).isPWO_support.union ((of R).symm z).isPWO_support
@@ -268,11 +267,11 @@ theorem smul_add [Zero R] [DistribSMul R V] (x : HahnSeries Γ R) (y z : HahnMod
     intro h
     rw [h.1, h.2, add_zero]
 
-instance instDistribSMul [MonoidWithZero R] [DistribSMul R V] : DistribSMul (HahnSeries Γ R)
+instance instDistribSMul [MonoidWithZero R] [DistribSMul R V] : DistribSMul R⟦Γ⟧
     (HahnModule Γ' R V) where
   smul_add := smul_add
 
-theorem add_smul [AddCommMonoid R] [SMulWithZero R V] {x y : HahnSeries Γ R}
+theorem add_smul [AddCommMonoid R] [SMulWithZero R V] {x y : R⟦Γ⟧}
     {z : HahnModule Γ' R V} (h : ∀ (r s : R) (u : V), (r + s) • u = r • u + s • u) :
     (x + y) • z = x • z + y • z := by
   ext a
@@ -320,7 +319,7 @@ theorem coeff_single_smul_vadd [MulZeroClass R] [SMulWithZero R V] {r : R} {x : 
 theorem coeff_single_zero_smul {Γ} [AddCommMonoid Γ] [PartialOrder Γ] [AddAction Γ Γ']
     [IsOrderedCancelVAdd Γ Γ'] [MulZeroClass R] [SMulWithZero R V] {r : R}
     {x : HahnModule Γ' R V} {a : Γ'} :
-    ((of R).symm ((HahnSeries.single 0 r : HahnSeries Γ R) • x)).coeff a =
+    ((of R).symm ((HahnSeries.single 0 r : R⟦Γ⟧) • x)).coeff a =
     r • ((of R).symm x).coeff a := by
   nth_rw 1 [← zero_vadd Γ a]
   exact coeff_single_smul_vadd
@@ -334,19 +333,17 @@ theorem single_zero_smul_eq_smul (Γ) [AddCommMonoid Γ] [PartialOrder Γ] [AddA
   exact coeff_single_zero_smul
 
 @[simp]
-theorem zero_smul' [Zero R] [SMulWithZero R V] {x : HahnModule Γ' R V} :
-    (0 : HahnSeries Γ R) • x = 0 := by
+theorem zero_smul' [Zero R] [SMulWithZero R V] {x : HahnModule Γ' R V} : (0 : R⟦Γ⟧) • x = 0 := by
   ext
   simp [coeff_smul]
 
 @[simp]
 theorem one_smul' {Γ} [AddCommMonoid Γ] [PartialOrder Γ] [AddAction Γ Γ'] [IsOrderedCancelVAdd Γ Γ']
-    [MonoidWithZero R] [MulActionWithZero R V] {x : HahnModule Γ' R V} :
-    (1 : HahnSeries Γ R) • x = x := by
+    [MonoidWithZero R] [MulActionWithZero R V] {x : HahnModule Γ' R V} : (1 : R⟦Γ⟧) • x = x := by
   ext g
   exact coeff_single_zero_smul.trans (one_smul R (x.coeff g))
 
-theorem support_smul_subset_vadd_support' [MulZeroClass R] [SMulWithZero R V] {x : HahnSeries Γ R}
+theorem support_smul_subset_vadd_support' [MulZeroClass R] [SMulWithZero R V] {x : R⟦Γ⟧}
     {y : HahnModule Γ' R V} :
     ((of R).symm (x • y)).support ⊆ x.support +ᵥ ((of R).symm y).support := by
   apply Set.Subset.trans (fun x hx => _) support_vaddAntidiagonal_subset_vadd
@@ -357,13 +354,13 @@ theorem support_smul_subset_vadd_support' [MulZeroClass R] [SMulWithZero R V] {x
   contrapose! hx
   simp [hx, coeff_smul]
 
-theorem support_smul_subset_vadd_support [MulZeroClass R] [SMulWithZero R V] {x : HahnSeries Γ R}
+theorem support_smul_subset_vadd_support [MulZeroClass R] [SMulWithZero R V] {x : R⟦Γ⟧}
     {y : HahnModule Γ' R V} :
     ((of R).symm (x • y)).support ⊆ x.support +ᵥ ((of R).symm y).support := by
   exact support_smul_subset_vadd_support'
 
 theorem orderTop_vAdd_le_orderTop_smul {Γ Γ'} [LinearOrder Γ] [LinearOrder Γ'] [VAdd Γ Γ']
-    [IsOrderedCancelVAdd Γ Γ'] [MulZeroClass R] [SMulWithZero R V] {x : HahnSeries Γ R}
+    [IsOrderedCancelVAdd Γ Γ'] [MulZeroClass R] [SMulWithZero R V] {x : R⟦Γ⟧}
     [VAdd (WithTop Γ) (WithTop Γ')] {y : HahnModule Γ' R V}
     (h : ∀ (γ : Γ) (γ' : Γ'), γ +ᵥ γ' = (γ : WithTop Γ) +ᵥ (γ' : WithTop Γ')) :
     x.orderTop +ᵥ ((of R).symm y).orderTop ≤ ((of R).symm (x • y)).orderTop := by
@@ -380,10 +377,10 @@ theorem orderTop_vAdd_le_orderTop_smul {Γ Γ'} [LinearOrder Γ] [LinearOrder Γ
 
 theorem coeff_smul_order_add_order {Γ}
     [AddCommMonoid Γ] [LinearOrder Γ] [IsOrderedCancelAddMonoid Γ] [Zero R]
-    [SMulWithZero R V] (x : HahnSeries Γ R) (y : HahnModule Γ R V) :
+    [SMulWithZero R V] (x : R⟦Γ⟧) (y : HahnModule Γ R V) :
     ((of R).symm (x • y)).coeff (x.order + ((of R).symm y).order) =
     x.leadingCoeff • ((of R).symm y).leadingCoeff := by
-  by_cases hx : x = (0 : HahnSeries Γ R); · simp [HahnSeries.coeff_zero, hx]
+  by_cases hx : x = (0 : R⟦Γ⟧); · simp [HahnSeries.coeff_zero, hx]
   by_cases hy : (of R).symm y = 0; · simp [hy, coeff_smul]
   rw [HahnSeries.order_of_ne hx, HahnSeries.order_of_ne hy, coeff_smul,
     HahnSeries.leadingCoeff_of_ne_zero hx, HahnSeries.leadingCoeff_of_ne_zero hy, ← vadd_eq_add,
@@ -400,19 +397,19 @@ section mul
 
 variable [AddCommMonoid Γ] [PartialOrder Γ] [IsOrderedCancelAddMonoid Γ]
 
-instance [NonUnitalNonAssocSemiring R] : Mul (HahnSeries Γ R) where
+instance [NonUnitalNonAssocSemiring R] : Mul R⟦Γ⟧ where
   mul x y := (HahnModule.of R).symm (x • HahnModule.of R y)
 
-theorem of_symm_smul_of_eq_mul [NonUnitalNonAssocSemiring R] {x y : HahnSeries Γ R} :
+theorem of_symm_smul_of_eq_mul [NonUnitalNonAssocSemiring R] {x y : R⟦Γ⟧} :
     (HahnModule.of R).symm (x • HahnModule.of R y) = x * y := rfl
 
-theorem coeff_mul [NonUnitalNonAssocSemiring R] {x y : HahnSeries Γ R} {a : Γ} :
+theorem coeff_mul [NonUnitalNonAssocSemiring R] {x y : R⟦Γ⟧} {a : Γ} :
     (x * y).coeff a =
       ∑ ij ∈ addAntidiagonal x.isPWO_support y.isPWO_support a, x.coeff ij.fst * y.coeff ij.snd :=
   rfl
 
 protected lemma map_mul [NonUnitalNonAssocSemiring R] [NonUnitalNonAssocSemiring S] (f : R →ₙ+* S)
-    {x y : HahnSeries Γ R} : (x * y).map f = (x.map f : HahnSeries Γ S) * (y.map f) := by
+    {x y : R⟦Γ⟧} : (x * y).map f = (x.map f : S⟦Γ⟧) * (y.map f) := by
   ext
   simp only [map_coeff, coeff_mul, map_sum, map_mul]
   refine Eq.symm (sum_subset (fun gh hgh => ?_) (fun gh hgh hz => ?_))
@@ -424,21 +421,21 @@ protected lemma map_mul [NonUnitalNonAssocSemiring R] [NonUnitalNonAssocSemiring
     · exact mul_eq_zero_of_left h (f (y.coeff gh.2))
     · exact mul_eq_zero_of_right (f (x.coeff gh.1)) (hz h)
 
-theorem coeff_mul_left' [NonUnitalNonAssocSemiring R] {x y : HahnSeries Γ R} {a : Γ} {s : Set Γ}
+theorem coeff_mul_left' [NonUnitalNonAssocSemiring R] {x y : R⟦Γ⟧} {a : Γ} {s : Set Γ}
     (hs : s.IsPWO) (hxs : x.support ⊆ s) :
     (x * y).coeff a =
       ∑ ij ∈ addAntidiagonal hs y.isPWO_support a, x.coeff ij.fst * y.coeff ij.snd :=
   HahnModule.coeff_smul_left hs hxs
 
-theorem coeff_mul_right' [NonUnitalNonAssocSemiring R] {x y : HahnSeries Γ R} {a : Γ} {s : Set Γ}
+theorem coeff_mul_right' [NonUnitalNonAssocSemiring R] {x y : R⟦Γ⟧} {a : Γ} {s : Set Γ}
     (hs : s.IsPWO) (hys : y.support ⊆ s) :
     (x * y).coeff a =
       ∑ ij ∈ addAntidiagonal x.isPWO_support hs a, x.coeff ij.fst * y.coeff ij.snd :=
   HahnModule.coeff_smul_right hs hys
 
-instance [NonUnitalNonAssocSemiring R] : Distrib (HahnSeries Γ R) :=
-  { inferInstanceAs (Mul (HahnSeries Γ R)),
-    inferInstanceAs (Add (HahnSeries Γ R)) with
+instance [NonUnitalNonAssocSemiring R] : Distrib R⟦Γ⟧ :=
+  { inferInstanceAs (Mul R⟦Γ⟧),
+    inferInstanceAs (Add R⟦Γ⟧) with
     left_distrib := fun x y z => by
       simp only [← of_symm_smul_of_eq_mul]
       exact HahnModule.smul_add x y z
@@ -448,12 +445,12 @@ instance [NonUnitalNonAssocSemiring R] : Distrib (HahnSeries Γ R) :=
       simp only [smul_eq_mul]
       exact add_mul }
 
-theorem coeff_single_mul_add [NonUnitalNonAssocSemiring R] {r : R} {x : HahnSeries Γ R} {a : Γ}
+theorem coeff_single_mul_add [NonUnitalNonAssocSemiring R] {r : R} {x : R⟦Γ⟧} {a : Γ}
     {b : Γ} : (single b r * x).coeff (a + b) = r * x.coeff a := by
   rw [← of_symm_smul_of_eq_mul, add_comm, ← vadd_eq_add]
   exact HahnModule.coeff_single_smul_vadd
 
-theorem coeff_mul_single_add [NonUnitalNonAssocSemiring R] {r : R} {x : HahnSeries Γ R} {a : Γ}
+theorem coeff_mul_single_add [NonUnitalNonAssocSemiring R] {r : R} {x : R⟦Γ⟧} {a : Γ}
     {b : Γ} : (x * single b r).coeff (a + b) = x.coeff a * r := by
   by_cases hr : r = 0
   · simp [hr, coeff_mul]
@@ -479,33 +476,30 @@ theorem coeff_mul_single_add [NonUnitalNonAssocSemiring R] {r : R} {x : HahnSeri
   · simp
 
 @[simp]
-theorem coeff_mul_single_zero [NonUnitalNonAssocSemiring R] {r : R} {x : HahnSeries Γ R} {a : Γ} :
+theorem coeff_mul_single_zero [NonUnitalNonAssocSemiring R] {r : R} {x : R⟦Γ⟧} {a : Γ} :
     (x * single 0 r).coeff a = x.coeff a * r := by rw [← add_zero a, coeff_mul_single_add, add_zero]
 
-theorem coeff_single_zero_mul [NonUnitalNonAssocSemiring R] {r : R} {x : HahnSeries Γ R} {a : Γ} :
-    ((single 0 r : HahnSeries Γ R) * x).coeff a = r * x.coeff a := by
+theorem coeff_single_zero_mul [NonUnitalNonAssocSemiring R] {r : R} {x : R⟦Γ⟧} {a : Γ} :
+    ((single 0 r : R⟦Γ⟧) * x).coeff a = r * x.coeff a := by
   rw [← add_zero a, coeff_single_mul_add, add_zero]
 
 @[simp]
-theorem single_zero_mul_eq_smul [Semiring R] {r : R} {x : HahnSeries Γ R} :
-    single 0 r * x = r • x := by
+theorem single_zero_mul_eq_smul [Semiring R] {r : R} {x : R⟦Γ⟧} : single 0 r * x = r • x := by
   ext
   exact coeff_single_zero_mul
 
-theorem support_mul_subset_add_support [NonUnitalNonAssocSemiring R] {x y : HahnSeries Γ R} :
+theorem support_mul_subset_add_support [NonUnitalNonAssocSemiring R] {x y : R⟦Γ⟧} :
     support (x * y) ⊆ support x + support y := by
   rw [← of_symm_smul_of_eq_mul, ← vadd_eq_add]
   exact HahnModule.support_smul_subset_vadd_support
 
-instance [NonUnitalNonAssocSemiring R] : NonUnitalNonAssocSemiring (HahnSeries Γ R) :=
-  { inferInstanceAs (AddCommMonoid (HahnSeries Γ R)),
-    inferInstanceAs (Distrib (HahnSeries Γ R)) with
-    zero_mul := fun _ => by
-      ext
-      simp [coeff_mul]
-    mul_zero := fun _ => by
-      ext
-      simp [coeff_mul] }
+instance [NonUnitalNonAssocSemiring R] : NonUnitalNonAssocSemiring R⟦Γ⟧ where
+  zero_mul _ := by
+    ext
+    simp [coeff_mul]
+  mul_zero _ := by
+    ext
+    simp [coeff_mul]
 
 end mul
 
@@ -514,12 +508,12 @@ section orderLemmas
 variable [AddCommMonoid Γ] [LinearOrder Γ] [IsOrderedCancelAddMonoid Γ]
   [NonUnitalNonAssocSemiring R]
 
-theorem coeff_mul_order_add_order (x y : HahnSeries Γ R) :
+theorem coeff_mul_order_add_order (x y : R⟦Γ⟧) :
     (x * y).coeff (x.order + y.order) = x.leadingCoeff * y.leadingCoeff := by
   simp only [← of_symm_smul_of_eq_mul]
   exact HahnModule.coeff_smul_order_add_order x y
 
-theorem orderTop_mul_of_nonzero {x y : HahnSeries Γ R} (h : x.leadingCoeff * y.leadingCoeff ≠ 0) :
+theorem orderTop_mul_of_nonzero {x y : R⟦Γ⟧} (h : x.leadingCoeff * y.leadingCoeff ≠ 0) :
     (x * y).orderTop = x.orderTop + y.orderTop := by
   by_cases hx : x = 0; · simp [hx]
   by_cases hy : y = 0; · simp [hy]
@@ -532,12 +526,11 @@ theorem orderTop_mul_of_nonzero {x y : HahnSeries Γ R} (h : x.leadingCoeff * y.
     ← Set.IsWF.min_add]
   exact Set.IsWF.min_le_min_of_subset support_mul_subset_add_support
 
-theorem orderTop_add_le_mul {x y : HahnSeries Γ R} :
-    x.orderTop + y.orderTop ≤ (x * y).orderTop := by
+theorem orderTop_add_le_mul {x y : R⟦Γ⟧} : x.orderTop + y.orderTop ≤ (x * y).orderTop := by
   rw [← smul_eq_mul]
   exact HahnModule.orderTop_vAdd_le_orderTop_smul fun i j ↦ rfl
 
-theorem order_mul_of_nonzero {x y : HahnSeries Γ R}
+theorem order_mul_of_nonzero {x y : R⟦Γ⟧}
     (h : x.leadingCoeff * y.leadingCoeff ≠ 0) : (x * y).order = x.order + y.order := by
   have hx : x.leadingCoeff ≠ 0 := by aesop
   have hy : y.leadingCoeff ≠ 0 := by aesop
@@ -549,13 +542,12 @@ theorem order_mul_of_nonzero {x y : HahnSeries Γ R}
     order_of_ne <| ne_zero_of_coeff_ne_zero hxy, ← Set.IsWF.min_add]
   exact Set.IsWF.min_le_min_of_subset support_mul_subset_add_support
 
-theorem leadingCoeff_mul_of_nonzero {x y : HahnSeries Γ R}
-    (h : x.leadingCoeff * y.leadingCoeff ≠ 0) :
+theorem leadingCoeff_mul_of_nonzero {x y : R⟦Γ⟧} (h : x.leadingCoeff * y.leadingCoeff ≠ 0) :
     (x * y).leadingCoeff = x.leadingCoeff * y.leadingCoeff := by
   simp only [leadingCoeff_eq, order_mul_of_nonzero h, coeff_mul_order_add_order]
 
 theorem order_single_mul_of_isRegular {g : Γ} {r : R} (hr : IsRegular r)
-    {x : HahnSeries Γ R} (hx : x ≠ 0) : (((single g) r) * x).order = g + x.order := by
+    {x : R⟦Γ⟧} (hx : x ≠ 0) : (((single g) r) * x).order = g + x.order := by
   obtain _ | _ := subsingleton_or_nontrivial R
   · exact (hx <| Subsingleton.eq_zero x).elim
   have hrx : ((single g) r).leadingCoeff * x.leadingCoeff ≠ 0 := by
@@ -568,8 +560,7 @@ section ring
 
 variable [AddCommMonoid Γ] [PartialOrder Γ] [IsOrderedCancelAddMonoid Γ]
 
-private theorem mul_assoc' [NonUnitalSemiring R] (x y z : HahnSeries Γ R) :
-    x * y * z = x * (y * z) := by
+private theorem mul_assoc' [NonUnitalSemiring R] (x y z : R⟦Γ⟧) : x * y * z = x * (y * z) := by
   ext b
   rw [coeff_mul_left' (x.isPWO_support.add y.isPWO_support) support_mul_subset_add_support,
     coeff_mul_right' (y.isPWO_support.add z.isPWO_support) support_mul_subset_add_support]
@@ -578,64 +569,59 @@ private theorem mul_assoc' [NonUnitalSemiring R] (x y z : HahnSeries Γ R) :
     (fun ⟨⟨i, _j⟩, ⟨k, l⟩⟩ ↦ ⟨(i + k, l), (i, k)⟩) <;>
     aesop (add safe Set.add_mem_add) (add simp [add_assoc, mul_assoc])
 
-instance [NonUnitalSemiring R] : NonUnitalSemiring (HahnSeries Γ R) :=
-  { inferInstanceAs (NonUnitalNonAssocSemiring (HahnSeries Γ R)) with
-    mul_assoc := mul_assoc' }
+instance [NonUnitalSemiring R] : NonUnitalSemiring R⟦Γ⟧ where
+  mul_assoc := mul_assoc'
 
-instance [NonAssocSemiring R] : NonAssocSemiring (HahnSeries Γ R) :=
-  { inferInstanceAs (AddMonoidWithOne (HahnSeries Γ R)),
-    inferInstanceAs (NonUnitalNonAssocSemiring (HahnSeries Γ R)) with
-    one_mul := fun x => by
-      ext
-      exact coeff_single_zero_mul.trans (one_mul _)
-    mul_one := fun x => by
-      ext
-      exact coeff_mul_single_zero.trans (mul_one _) }
+instance [NonAssocSemiring R] : NonAssocSemiring R⟦Γ⟧ where
+  one_mul x := by
+    ext
+    exact coeff_single_zero_mul.trans (one_mul _)
+  mul_one x := by
+    ext
+    exact coeff_mul_single_zero.trans (mul_one _)
 
-instance [Semiring R] : Semiring (HahnSeries Γ R) :=
-  { inferInstanceAs (NonAssocSemiring (HahnSeries Γ R)),
-    inferInstanceAs (NonUnitalSemiring (HahnSeries Γ R)) with }
+instance [Semiring R] : Semiring R⟦Γ⟧ where
 
-instance [NonUnitalCommSemiring R] : NonUnitalCommSemiring (HahnSeries Γ R) where
-  __ : NonUnitalSemiring (HahnSeries Γ R) := inferInstance
+instance [NonUnitalCommSemiring R] : NonUnitalCommSemiring R⟦Γ⟧ where
+  __ : NonUnitalSemiring R⟦Γ⟧ := inferInstance
   mul_comm x y := by
     ext
     simp_rw [coeff_mul, mul_comm]
     exact Finset.sum_equiv (Equiv.prodComm _ _) (fun _ ↦ swap_mem_addAntidiagonal.symm) <| by simp
 
-instance [CommSemiring R] : CommSemiring (HahnSeries Γ R) :=
-  { inferInstanceAs (NonUnitalCommSemiring (HahnSeries Γ R)),
-    inferInstanceAs (Semiring (HahnSeries Γ R)) with }
+instance [CommSemiring R] : CommSemiring R⟦Γ⟧ :=
+  { inferInstanceAs (NonUnitalCommSemiring R⟦Γ⟧),
+    inferInstanceAs (Semiring R⟦Γ⟧) with }
 
-instance [NonUnitalNonAssocRing R] : NonUnitalNonAssocRing (HahnSeries Γ R) :=
-  { inferInstanceAs (NonUnitalNonAssocSemiring (HahnSeries Γ R)),
-    inferInstanceAs (AddGroup (HahnSeries Γ R)) with }
+instance [NonUnitalNonAssocRing R] : NonUnitalNonAssocRing R⟦Γ⟧ :=
+  { inferInstanceAs (NonUnitalNonAssocSemiring R⟦Γ⟧),
+    inferInstanceAs (AddGroup R⟦Γ⟧) with }
 
-instance [NonUnitalRing R] : NonUnitalRing (HahnSeries Γ R) :=
-  { inferInstanceAs (NonUnitalNonAssocRing (HahnSeries Γ R)),
-    inferInstanceAs (NonUnitalSemiring (HahnSeries Γ R)) with }
+instance [NonUnitalRing R] : NonUnitalRing R⟦Γ⟧ :=
+  { inferInstanceAs (NonUnitalNonAssocRing R⟦Γ⟧),
+    inferInstanceAs (NonUnitalSemiring R⟦Γ⟧) with }
 
-instance [NonAssocRing R] : NonAssocRing (HahnSeries Γ R) :=
-  { inferInstanceAs (NonUnitalNonAssocRing (HahnSeries Γ R)),
-    inferInstanceAs (NonAssocSemiring (HahnSeries Γ R)),
-    inferInstanceAs (AddGroupWithOne (HahnSeries Γ R)) with }
+instance [NonAssocRing R] : NonAssocRing R⟦Γ⟧ :=
+  { inferInstanceAs (NonUnitalNonAssocRing R⟦Γ⟧),
+    inferInstanceAs (NonAssocSemiring R⟦Γ⟧),
+    inferInstanceAs (AddGroupWithOne R⟦Γ⟧) with }
 
-instance [Ring R] : Ring (HahnSeries Γ R) :=
-  { inferInstanceAs (Semiring (HahnSeries Γ R)),
-    inferInstanceAs (AddCommGroupWithOne (HahnSeries Γ R)) with }
+instance [Ring R] : Ring R⟦Γ⟧ :=
+  { inferInstanceAs (Semiring R⟦Γ⟧),
+    inferInstanceAs (AddCommGroupWithOne R⟦Γ⟧) with }
 
-instance [NonUnitalCommRing R] : NonUnitalCommRing (HahnSeries Γ R) :=
-  { inferInstanceAs (NonUnitalCommSemiring (HahnSeries Γ R)),
-    inferInstanceAs (NonUnitalRing (HahnSeries Γ R)) with }
+instance [NonUnitalCommRing R] : NonUnitalCommRing R⟦Γ⟧ :=
+  { inferInstanceAs (NonUnitalCommSemiring R⟦Γ⟧),
+    inferInstanceAs (NonUnitalRing R⟦Γ⟧) with }
 
-instance [CommRing R] : CommRing (HahnSeries Γ R) :=
-  { inferInstanceAs (CommSemiring (HahnSeries Γ R)),
-    inferInstanceAs (Ring (HahnSeries Γ R)) with }
+instance [CommRing R] : CommRing R⟦Γ⟧ :=
+  { inferInstanceAs (CommSemiring R⟦Γ⟧),
+    inferInstanceAs (Ring R⟦Γ⟧) with }
 
 end ring
 
 theorem orderTop_nsmul_le_orderTop_pow [AddCommMonoid Γ] [LinearOrder Γ]
-    [IsOrderedCancelAddMonoid Γ] [Semiring R] {x : HahnSeries Γ R} {n : ℕ} :
+    [IsOrderedCancelAddMonoid Γ] [Semiring R] {x : R⟦Γ⟧} {n : ℕ} :
     n • x.orderTop ≤ (x ^ n).orderTop := by
   induction n with
   | zero =>
@@ -653,7 +639,7 @@ theorem orderTop_nsmul_le_orderTop_pow [AddCommMonoid Γ] [LinearOrder Γ]
       (x ^ n * x).orderTop ≤ (x ^ n * x ^ 1).orderTop := by rw [pow_one]
 
 theorem orderTop_self_sub_one_pos_iff [LinearOrder Γ] [Zero Γ] [NonAssocRing R] [Nontrivial R]
-    (x : HahnSeries Γ R) :
+    (x : R⟦Γ⟧) :
     0 < (x - 1).orderTop ↔ x.orderTop = 0 ∧ x.leadingCoeff = 1 := by
   constructor
   · intro hx
@@ -676,8 +662,8 @@ theorem orderTop_sub_pos [PartialOrder Γ] [Zero Γ] [AddCommGroup R] [One R] {g
 /-- The group of invertible Hahn series close to 1, i.e., those series such that subtracting 1
   yields a series with strictly positive `orderTop`. -/
 def orderTopSubOnePos (Γ R) [LinearOrder Γ] [AddCommMonoid Γ] [IsOrderedCancelAddMonoid Γ]
-    [CommRing R] : Subgroup (HahnSeries Γ R)ˣ where
-  carrier := { x : (HahnSeries Γ R)ˣ | 0 < (x.val - 1).orderTop}
+    [CommRing R] : Subgroup R⟦Γ⟧ˣ where
+  carrier := { x : R⟦Γ⟧ˣ | 0 < (x.val - 1).orderTop}
   mul_mem' := by
     intro x y hx hy
     obtain (_|_) := subsingleton_or_nontrivial R
@@ -703,7 +689,7 @@ def orderTopSubOnePos (Γ R) [LinearOrder Γ] [AddCommMonoid Γ] [IsOrderedCance
 
 @[simp]
 theorem mem_orderTopSubOnePos_iff [LinearOrder Γ] [AddCommMonoid Γ] [IsOrderedCancelAddMonoid Γ]
-    [CommRing R] (x : (HahnSeries Γ R)ˣ) :
+    [CommRing R] (x : R⟦Γ⟧ˣ) :
     x ∈ orderTopSubOnePos Γ R ↔ 0 < (x.val - 1).orderTop := .rfl
 
 end HahnSeries
@@ -714,7 +700,7 @@ namespace HahnModule
 
 variable [PartialOrder Γ'] [AddAction Γ Γ'] [IsOrderedCancelVAdd Γ Γ'] [AddCommMonoid V]
 
-private theorem mul_smul' [Semiring R] [Module R V] (x y : HahnSeries Γ R)
+private theorem mul_smul' [Semiring R] [Module R V] (x y : R⟦Γ⟧)
     (z : HahnModule Γ' R V) : (x * y) • z = x • (y • z) := by
   ext b
   rw [coeff_smul_left (x.isPWO_support.add y.isPWO_support)
@@ -726,34 +712,34 @@ private theorem mul_smul' [Semiring R] [Module R V] (x y : HahnSeries Γ R)
     aesop (add safe [Set.vadd_mem_vadd, Set.add_mem_add]) (add simp [add_vadd, mul_smul])
 
 instance instBaseModule [Semiring R] [Module R V] : Module R (HahnModule Γ' R V) :=
-  inferInstanceAs <| Module R (HahnSeries Γ' V)
+  inferInstanceAs <| Module R V⟦Γ'⟧
 
-instance instModule [Semiring R] [Module R V] : Module (HahnSeries Γ R)
+instance instModule [Semiring R] [Module R V] : Module R⟦Γ⟧
     (HahnModule Γ' R V) := {
-  inferInstanceAs (DistribSMul (HahnSeries Γ R) (HahnModule Γ' R V)) with
+  inferInstanceAs (DistribSMul R⟦Γ⟧ (HahnModule Γ' R V)) with
   mul_smul := mul_smul'
   one_smul := fun _ => one_smul'
   add_smul := fun _ _ _ => add_smul Module.add_smul
   zero_smul := fun _ => zero_smul' }
 
 instance [Zero R] {S : Type*} [Zero S] [SMul R S] [SMulWithZero R V] [SMulWithZero S V]
-    [IsScalarTower R S V] : IsScalarTower R S (HahnSeries Γ V) where
+    [IsScalarTower R S V] : IsScalarTower R S V⟦Γ⟧ where
   smul_assoc r s a := by
     ext
     simp
 
-instance [Semiring R] [Module R V] : IsScalarTower R (HahnSeries Γ R) (HahnModule Γ' R V) where
+instance [Semiring R] [Module R V] : IsScalarTower R R⟦Γ⟧ (HahnModule Γ' R V) where
   smul_assoc r x a := by
     rw [← HahnSeries.single_zero_mul_eq_smul, mul_smul', ← single_zero_smul_eq_smul Γ]
 
 instance SMulCommClass [CommSemiring R] [Module R V] :
-    SMulCommClass R (HahnSeries Γ R) (HahnModule Γ' R V) where
+    SMulCommClass R R⟦Γ⟧ (HahnModule Γ' R V) where
   smul_comm r x y := by
     rw [← single_zero_smul_eq_smul Γ, ← mul_smul', mul_comm, mul_smul', single_zero_smul_eq_smul Γ]
 
 instance instNoZeroSMulDivisors {Γ} [AddCommMonoid Γ] [LinearOrder Γ] [IsOrderedCancelAddMonoid Γ]
     [Zero R] [SMulWithZero R V] [NoZeroSMulDivisors R V] :
-    NoZeroSMulDivisors (HahnSeries Γ R) (HahnModule Γ R V) where
+    NoZeroSMulDivisors R⟦Γ⟧ (HahnModule Γ R V) where
   eq_zero_or_eq_zero_of_smul_eq_zero {x y} hxy := by
     contrapose! hxy
     simp only [ne_eq]
@@ -770,14 +756,14 @@ namespace HahnSeries
 
 instance {Γ} [AddCommMonoid Γ] [LinearOrder Γ] [IsOrderedCancelAddMonoid Γ]
     [NonUnitalNonAssocSemiring R] [NoZeroDivisors R] :
-    NoZeroDivisors (HahnSeries Γ R) where
+    NoZeroDivisors R⟦Γ⟧ where
   eq_zero_or_eq_zero_of_mul_eq_zero {x y} xy := by
-    haveI : NoZeroSMulDivisors (HahnSeries Γ R) (HahnSeries Γ R) :=
+    haveI : NoZeroSMulDivisors R⟦Γ⟧ R⟦Γ⟧ :=
       HahnModule.instNoZeroSMulDivisors
     exact eq_zero_or_eq_zero_of_smul_eq_zero xy
 
 instance {Γ} [AddCommMonoid Γ] [LinearOrder Γ] [IsOrderedCancelAddMonoid Γ] [Ring R] [IsDomain R] :
-    IsDomain (HahnSeries Γ R) :=
+    IsDomain R⟦Γ⟧ :=
   NoZeroDivisors.to_isDomain _
 
 @[deprecated (since := "2025-08-11")] alias orderTop_add_orderTop_le_orderTop_mul :=
@@ -786,7 +772,7 @@ instance {Γ} [AddCommMonoid Γ] [LinearOrder Γ] [IsOrderedCancelAddMonoid Γ] 
 @[simp]
 theorem order_mul {Γ} [AddCommMonoid Γ] [LinearOrder Γ] [IsOrderedCancelAddMonoid Γ]
     [NonUnitalNonAssocSemiring R]
-    [NoZeroDivisors R] {x y : HahnSeries Γ R} (hx : x ≠ 0) (hy : y ≠ 0) :
+    [NoZeroDivisors R] {x y : R⟦Γ⟧} (hx : x ≠ 0) (hy : y ≠ 0) :
     (x * y).order = x.order + y.order := by
   apply le_antisymm
   · apply order_le_of_coeff_ne_zero
@@ -798,7 +784,7 @@ theorem order_mul {Γ} [AddCommMonoid Γ] [LinearOrder Γ] [IsOrderedCancelAddMo
 @[simp]
 theorem order_pow {Γ} [AddCommMonoid Γ] [LinearOrder Γ] [IsOrderedCancelAddMonoid Γ]
     [Semiring R] [NoZeroDivisors R]
-    (x : HahnSeries Γ R) (n : ℕ) : (x ^ n).order = n • x.order := by
+    (x : R⟦Γ⟧) (n : ℕ) : (x ^ n).order = n • x.order := by
   induction n with
   | zero => simp
   | succ h IH =>
@@ -842,7 +828,7 @@ variable [NonAssocSemiring R]
 
 /-- `C a` is the constant Hahn Series `a`. `C` is provided as a ring homomorphism. -/
 @[simps]
-def C : R →+* HahnSeries Γ R where
+def C : R →+* R⟦Γ⟧ where
   toFun := single 0
   map_zero' := single_eq_zero
   map_one' := rfl
@@ -851,27 +837,27 @@ def C : R →+* HahnSeries Γ R where
     by_cases h : a = 0 <;> simp [h]
   map_mul' x y := by rw [single_mul_single, zero_add]
 
-theorem C_zero : C (0 : R) = (0 : HahnSeries Γ R) :=
+theorem C_zero : C (0 : R) = (0 : R⟦Γ⟧) :=
   C.map_zero
 
-theorem C_one : C (1 : R) = (1 : HahnSeries Γ R) :=
+theorem C_one : C (1 : R) = (1 : R⟦Γ⟧) :=
   C.map_one
 
 theorem map_C [NonAssocSemiring S] (a : R) (f : R →+* S) :
-    ((C a).map f : HahnSeries Γ S) = C (f a) := by
+    ((C a).map f : S⟦Γ⟧) = C (f a) := by
   ext g
   by_cases h : g = 0 <;> simp [h]
 
-theorem C_injective : Function.Injective (C : R → HahnSeries Γ R) := by
+theorem C_injective : Function.Injective (C : R → R⟦Γ⟧) := by
   intro r s rs
   rw [HahnSeries.ext_iff, funext_iff] at rs
   have h := rs 0
   rwa [C_apply, coeff_single_same, C_apply, coeff_single_same] at h
 
-theorem C_ne_zero {r : R} (h : r ≠ 0) : (C r : HahnSeries Γ R) ≠ 0 :=
+theorem C_ne_zero {r : R} (h : r ≠ 0) : (C r : R⟦Γ⟧) ≠ 0 :=
   C_injective.ne_iff' C_zero |>.mpr h
 
-theorem order_C {r : R} : order (C r : HahnSeries Γ R) = 0 := by
+theorem order_C {r : R} : order (C r : R⟦Γ⟧) = 0 := by
   by_cases h : r = 0
   · rw [h, C_zero, order_zero]
   · exact order_single h
@@ -882,7 +868,7 @@ section Semiring
 
 variable [Semiring R]
 
-theorem C_mul_eq_smul {r : R} {x : HahnSeries Γ R} : C r * x = r • x :=
+theorem C_mul_eq_smul {r : R} {x : R⟦Γ⟧} : C r * x = r • x :=
   single_zero_mul_eq_smul
 
 end Semiring
@@ -892,7 +878,7 @@ section Domain
 variable {Γ' : Type*} [AddCommMonoid Γ'] [PartialOrder Γ'] [IsOrderedCancelAddMonoid Γ']
 
 theorem embDomain_mul [NonUnitalNonAssocSemiring R] (f : Γ ↪o Γ')
-    (hf : ∀ x y, f (x + y) = f x + f y) (x y : HahnSeries Γ R) :
+    (hf : ∀ x y, f (x + y) = f x + f y) (x y : R⟦Γ⟧) :
     embDomain f (x * y) = embDomain f x * embDomain f y := by
   ext g
   by_cases hg : g ∈ Set.range f
@@ -928,13 +914,13 @@ theorem embDomain_mul [NonUnitalNonAssocSemiring R] (f : Γ ↪o Γ')
 
 omit [IsOrderedCancelAddMonoid Γ] [IsOrderedCancelAddMonoid Γ'] in
 theorem embDomain_one [NonAssocSemiring R] (f : Γ ↪o Γ') (hf : f 0 = 0) :
-    embDomain f (1 : HahnSeries Γ R) = (1 : HahnSeries Γ' R) :=
+    embDomain f (1 : R⟦Γ⟧) = (1 : R⟦Γ'⟧) :=
   embDomain_single.trans <| hf.symm ▸ rfl
 
 /-- Extending the domain of Hahn series is a ring homomorphism. -/
 @[simps]
 def embDomainRingHom [NonAssocSemiring R] (f : Γ →+ Γ') (hfi : Function.Injective f)
-    (hf : ∀ g g' : Γ, f g ≤ f g' ↔ g ≤ g') : HahnSeries Γ R →+* HahnSeries Γ' R where
+    (hf : ∀ g g' : Γ, f g ≤ f g' ↔ g ≤ g') : R⟦Γ⟧ →+* R⟦Γ'⟧ where
   toFun := embDomain ⟨⟨f, hfi⟩, hf _ _⟩
   map_one' := embDomain_one _ f.map_zero
   map_mul' := embDomain_mul _ f.map_add
@@ -962,13 +948,13 @@ instance : Algebra R (HahnSeries Γ A) where
       Function.comp_apply, algebraMap_smul, coeff_mul_single_zero]
     rw [← Algebra.commutes, Algebra.smul_def]
 
-theorem C_eq_algebraMap : C = algebraMap R (HahnSeries Γ R) :=
+theorem C_eq_algebraMap : C = algebraMap R R⟦Γ⟧ :=
   rfl
 
 theorem algebraMap_apply {r : R} : algebraMap R (HahnSeries Γ A) r = C (algebraMap R A r) :=
   rfl
 
-instance [Nontrivial Γ] [Nontrivial R] : Nontrivial (Subalgebra R (HahnSeries Γ R)) :=
+instance [Nontrivial Γ] [Nontrivial R] : Nontrivial (Subalgebra R R⟦Γ⟧) :=
   ⟨⟨⊥, ⊤, by
       rw [Ne, SetLike.ext_iff, not_forall]
       obtain ⟨a, ha⟩ := exists_ne (0 : Γ)

--- a/Mathlib/RingTheory/HahnSeries/PowerSeries.lean
+++ b/Mathlib/RingTheory/HahnSeries/PowerSeries.lean
@@ -12,22 +12,22 @@ public import Mathlib.Data.Finsupp.PWO
 
 /-!
 # Comparison between Hahn series and power series
-If `Γ` is ordered and `R` has zero, then `HahnSeries Γ R` consists of formal series over `Γ` with
+If `Γ` is ordered and `R` has zero, then `R⟦Γ⟧` consists of formal series over `Γ` with
 coefficients in `R`, whose supports are partially well-ordered. With further structure on `R` and
-`Γ`, we can add further structure on `HahnSeries Γ R`.  When `R` is a semiring and `Γ = ℕ`, then
+`Γ`, we can add further structure on `R⟦Γ⟧`.  When `R` is a semiring and `Γ = ℕ`, then
 we get the more familiar semiring of formal power series with coefficients in `R`.
 
 ## Main Definitions
-* `toPowerSeries` the isomorphism from `HahnSeries ℕ R` to `PowerSeries R`.
-* `ofPowerSeries` the inverse, casting a `PowerSeries R` to a `HahnSeries ℕ R`.
+* `toPowerSeries` the isomorphism from `R⟦ℕ⟧` to `PowerSeries R`.
+* `ofPowerSeries` the inverse, casting a `PowerSeries R` to a `R⟦ℕ⟧`.
 
 ## Instances
-* For `Finite σ`, the instance `NoZeroDivisors (HahnSeries (σ →₀ ℕ) R)`,
+* For `Finite σ`, the instance `NoZeroDivisors R⟦σ →₀ ℕ⟧`,
   deduced from the case of `MvPowerSeries`
-  The case of `HahnSeries ℕ R` is taken care of by `instNoZeroDivisors`.
+  The case of `R⟦ℕ⟧` is taken care of by `instNoZeroDivisors`.
 
 ## TODO
-* Build an API for the variable `X` (defined to be `single 1 1 : HahnSeries Γ R`) in analogy to
+* Build an API for the variable `X` (defined to be `single 1 1 : R⟦Γ⟧`) in analogy to
   `X : R[X]` and `X : PowerSeries R`
 
 ## References
@@ -49,9 +49,9 @@ section Semiring
 
 variable [Semiring R]
 
-/-- The ring `HahnSeries ℕ R` is isomorphic to `PowerSeries R`. -/
+/-- The ring `R⟦ℕ⟧` is isomorphic to `PowerSeries R`. -/
 @[simps]
-def toPowerSeries : HahnSeries ℕ R ≃+* PowerSeries R where
+def toPowerSeries : R⟦ℕ⟧ ≃+* PowerSeries R where
   toFun f := PowerSeries.mk f.coeff
   invFun f := ⟨fun n => PowerSeries.coeff n f, .of_linearOrder _⟩
   left_inv f := by
@@ -75,7 +75,7 @@ def toPowerSeries : HahnSeries ℕ R ≃+* PowerSeries R where
     rintro h
     rw [and_iff_right (left_ne_zero_of_mul h), and_iff_right (right_ne_zero_of_mul h)]
 
-theorem coeff_toPowerSeries {f : HahnSeries ℕ R} {n : ℕ} :
+theorem coeff_toPowerSeries {f : R⟦ℕ⟧} {n : ℕ} :
     PowerSeries.coeff n (toPowerSeries f) = f.coeff n :=
   PowerSeries.coeff_mk _ _
 
@@ -86,12 +86,12 @@ theorem coeff_toPowerSeries_symm {f : PowerSeries R} {n : ℕ} :
 variable (Γ R) [Semiring Γ] [PartialOrder Γ] [IsStrictOrderedRing Γ]
 
 /-- Casts a power series as a Hahn series with coefficients from a `StrictOrderedSemiring`. -/
-def ofPowerSeries : PowerSeries R →+* HahnSeries Γ R :=
+def ofPowerSeries : PowerSeries R →+* R⟦Γ⟧ :=
   (HahnSeries.embDomainRingHom (Nat.castAddMonoidHom Γ) Nat.strictMono_cast.injective fun _ _ =>
         Nat.cast_le).comp
     (RingEquiv.toRingHom toPowerSeries.symm)
 
-variable {Γ} {R}
+variable {Γ R}
 
 theorem ofPowerSeries_injective : Function.Injective (ofPowerSeries Γ R) :=
   embDomain_injective.comp toPowerSeries.symm.injective
@@ -141,14 +141,14 @@ theorem ofPowerSeries_X_pow {R} [Semiring R] (n : ℕ) :
   simp
 
 -- Lemmas about converting hahn_series over fintype to and from mv_power_series
-/-- The ring `HahnSeries (σ →₀ ℕ) R` is isomorphic to `MvPowerSeries σ R` for a `Finite` `σ`.
+/-- The ring `R⟦σ →₀ ℕ⟧` is isomorphic to `MvPowerSeries σ R` for a `Finite` `σ`.
 We take the index set of the hahn series to be `Finsupp` rather than `pi`,
 even though we assume `Finite σ` as this is more natural for alignment with `MvPowerSeries`.
-After importing `Mathlib/Algebra/Order/Pi.lean` the ring `HahnSeries (σ → ℕ) R` could be constructed
+After importing `Mathlib/Algebra/Order/Pi.lean` the ring `R⟦σ → ℕ⟧` could be constructed
 instead.
 -/
 @[simps]
-def toMvPowerSeries {σ : Type*} [Finite σ] : HahnSeries (σ →₀ ℕ) R ≃+* MvPowerSeries σ R where
+def toMvPowerSeries {σ : Type*} [Finite σ] : R⟦σ →₀ ℕ⟧ ≃+* MvPowerSeries σ R where
   toFun f := f.coeff
   invFun f := ⟨(f : (σ →₀ ℕ) → R), Set.isPWO_of_wellQuasiOrderedLE _⟩
   left_inv f := by
@@ -177,11 +177,11 @@ variable {σ : Type*} [Finite σ]
 
 -- TODO : generalize to all (?) rings of Hahn Series
 /-- If R has no zero divisors and `σ` is finite,
-then `HahnSeries (σ →₀ ℕ) R` has no zero divisors -/
-instance [NoZeroDivisors R] : NoZeroDivisors (HahnSeries (σ →₀ ℕ) R) :=
-  toMvPowerSeries.toMulEquiv.noZeroDivisors (A := HahnSeries (σ →₀ ℕ) R) (MvPowerSeries σ R)
+then `R⟦σ →₀ ℕ⟧` has no zero divisors -/
+instance [NoZeroDivisors R] : NoZeroDivisors (R⟦σ →₀ ℕ⟧) :=
+  toMvPowerSeries.toMulEquiv.noZeroDivisors (A := R⟦σ →₀ ℕ⟧) (MvPowerSeries σ R)
 
-theorem coeff_toMvPowerSeries {f : HahnSeries (σ →₀ ℕ) R} {n : σ →₀ ℕ} :
+theorem coeff_toMvPowerSeries {f : R⟦σ →₀ ℕ⟧} {n : σ →₀ ℕ} :
     MvPowerSeries.coeff n (toMvPowerSeries f) = f.coeff n :=
   rfl
 
@@ -195,9 +195,9 @@ section Algebra
 
 variable (R) [CommSemiring R] {A : Type*} [Semiring A] [Algebra R A]
 
-/-- The `R`-algebra `HahnSeries ℕ A` is isomorphic to `PowerSeries A`. -/
+/-- The `R`-algebra `A⟦ℕ⟧` is isomorphic to `PowerSeries A`. -/
 @[simps!]
-def toPowerSeriesAlg : HahnSeries ℕ A ≃ₐ[R] PowerSeries A :=
+def toPowerSeriesAlg : A⟦ℕ⟧ ≃ₐ[R] PowerSeries A :=
   { toPowerSeries with
     commutes' := fun r => by
       ext n
@@ -208,29 +208,29 @@ variable (Γ) [Semiring Γ] [PartialOrder Γ] [IsStrictOrderedRing Γ]
 /-- Casting a power series as a Hahn series with coefficients from a `StrictOrderedSemiring`
   is an algebra homomorphism. -/
 @[simps!]
-def ofPowerSeriesAlg : PowerSeries A →ₐ[R] HahnSeries Γ A :=
+def ofPowerSeriesAlg : PowerSeries A →ₐ[R] A⟦Γ⟧ :=
   (HahnSeries.embDomainAlgHom (Nat.castAddMonoidHom Γ) Nat.strictMono_cast.injective fun _ _ =>
         Nat.cast_le).comp
     (AlgEquiv.toAlgHom (toPowerSeriesAlg R).symm)
 
 instance powerSeriesAlgebra {S : Type*} [CommSemiring S] [Algebra S (PowerSeries R)] :
-    Algebra S (HahnSeries Γ R) :=
+    Algebra S R⟦Γ⟧ :=
   RingHom.toAlgebra <| (ofPowerSeries Γ R).comp (algebraMap S (PowerSeries R))
 
 variable {R}
 variable {S : Type*} [CommSemiring S] [Algebra S (PowerSeries R)]
 
 theorem algebraMap_apply' (x : S) :
-    algebraMap S (HahnSeries Γ R) x = ofPowerSeries Γ R (algebraMap S (PowerSeries R) x) :=
+    algebraMap S R⟦Γ⟧ x = ofPowerSeries Γ R (algebraMap S (PowerSeries R) x) :=
   rfl
 
 @[simp]
 theorem _root_.Polynomial.algebraMap_hahnSeries_apply (f : R[X]) :
-    algebraMap R[X] (HahnSeries Γ R) f = ofPowerSeries Γ R f :=
+    algebraMap R[X] R⟦Γ⟧ f = ofPowerSeries Γ R f :=
   rfl
 
 theorem _root_.Polynomial.algebraMap_hahnSeries_injective :
-    Function.Injective (algebraMap R[X] (HahnSeries Γ R)) :=
+    Function.Injective (algebraMap R[X] R⟦Γ⟧) :=
   ofPowerSeries_injective.comp (Polynomial.coe_injective R)
 
 end Algebra

--- a/Mathlib/RingTheory/HahnSeries/Summable.lean
+++ b/Mathlib/RingTheory/HahnSeries/Summable.lean
@@ -63,9 +63,9 @@ section
 coefficient of the sum to be well-defined, we require that only finitely many series are nonzero at
 any given coefficient.  For the formal sum to be a Hahn series, we require that the union of the
 supports of the constituent series is partially well-ordered. -/
-structure SummableFamily (Γ) (R) [PartialOrder Γ] [AddCommMonoid R] (α : Type*) where
+structure SummableFamily (Γ R) [PartialOrder Γ] [AddCommMonoid R] (α : Type*) where
   /-- A parametrized family of Hahn series. -/
-  toFun : α → HahnSeries Γ R
+  toFun : α → R⟦Γ⟧
   isPWO_iUnion_support' : Set.IsPWO (⋃ a : α, (toFun a).support)
   finite_co_support' : ∀ g : Γ, { a | (toFun a).coeff g ≠ 0 }.Finite
 
@@ -77,12 +77,12 @@ section AddCommMonoid
 
 variable [PartialOrder Γ] [AddCommMonoid R]
 
-instance : FunLike (SummableFamily Γ R α) α (HahnSeries Γ R) where
+instance : FunLike (SummableFamily Γ R α) α R⟦Γ⟧ where
   coe := toFun
   coe_injective' | ⟨_, _, _⟩, ⟨_, _, _⟩, rfl => rfl
 
 @[simp]
-theorem coe_mk (toFun : α → HahnSeries Γ R) (h1 h2) :
+theorem coe_mk (toFun : α → R⟦Γ⟧) (h1 h2) :
     (⟨toFun, h1, h2⟩ : SummableFamily Γ R α) = toFun :=
   rfl
 
@@ -93,7 +93,7 @@ theorem finite_co_support (s : SummableFamily Γ R α) (g : Γ) :
     (Function.support fun a => (s a).coeff g).Finite :=
   s.finite_co_support' g
 
-theorem coe_injective : @Function.Injective (SummableFamily Γ R α) (α → HahnSeries Γ R) (⇑) :=
+theorem coe_injective : @Function.Injective (SummableFamily Γ R α) (α → R⟦Γ⟧) (⇑) :=
   DFunLike.coe_injective
 
 @[ext]
@@ -131,7 +131,7 @@ theorem add_apply {s t : SummableFamily Γ R α} {a : α} : (s + t) a = s a + t 
   rfl
 
 @[simp]
-theorem coe_zero : ((0 : SummableFamily Γ R α) : α → HahnSeries Γ R) = 0 :=
+theorem coe_zero : ((0 : SummableFamily Γ R α) : α → R⟦Γ⟧) = 0 :=
   rfl
 
 theorem zero_apply {a : α} : (0 : SummableFamily Γ R α) a = 0 :=
@@ -179,7 +179,7 @@ theorem coeff_def (s : SummableFamily Γ R α) (a : α) (g : Γ) : s.coeff g a =
   rfl
 
 /-- The infinite sum of a `SummableFamily` of Hahn series. -/
-def hsum (s : SummableFamily Γ R α) : HahnSeries Γ R where
+def hsum (s : SummableFamily Γ R α) : R⟦Γ⟧ where
   coeff g := ∑ᶠ i, (s i).coeff g
   isPWO_support' :=
     s.isPWO_iUnion_support.mono fun g => by
@@ -222,10 +222,10 @@ theorem coeff_hsum_eq_sum {s : SummableFamily Γ R α} {g : Γ} :
 
 /-- The summable family made of a single Hahn series. -/
 @[simps]
-def single {ι} [DecidableEq ι] (i : ι) (x : HahnSeries Γ R) : SummableFamily Γ R ι where
+def single {ι} [DecidableEq ι] (i : ι) (x : R⟦Γ⟧) : SummableFamily Γ R ι where
   toFun := Pi.single i x
   isPWO_iUnion_support' := by
-    have : (Pi.single (M := fun _ ↦ HahnSeries Γ R) i x i).support.IsPWO := by simp
+    have : (Pi.single (M := fun _ ↦ R⟦Γ⟧) i x i).support.IsPWO := by simp
     refine this.mono <| Set.iUnion_subset fun a => ?_
     obtain rfl | ha := eq_or_ne a i
     · rfl
@@ -234,14 +234,14 @@ def single {ι} [DecidableEq ι] (i : ι) (x : HahnSeries Γ R) : SummableFamily
     obtain rfl | ha := eq_or_ne j i <;> simp [*]
 
 @[simp]
-theorem hsum_single {ι} [DecidableEq ι] (i : ι) (x : HahnSeries Γ R) : (single i x).hsum = x := by
+theorem hsum_single {ι} [DecidableEq ι] (i : ι) (x : R⟦Γ⟧) : (single i x).hsum = x := by
   ext g
   rw [coeff_hsum, finsum_eq_single _ i, single_toFun, Pi.single_eq_same]
   simp +contextual
 
 /-- The summable family made of a constant Hahn series. -/
 @[simps]
-def const (ι) [Finite ι] (x : HahnSeries Γ R) : SummableFamily Γ R ι where
+def const (ι) [Finite ι] (x : R⟦Γ⟧) : SummableFamily Γ R ι where
   toFun _ := x
   isPWO_iUnion_support' := by
     cases isEmpty_or_nonempty ι
@@ -387,7 +387,7 @@ variable [VAdd Γ Γ'] [IsOrderedCancelVAdd Γ Γ']
 
 open HahnModule
 
-theorem isPWO_iUnion_support_prod_smul {s : α → HahnSeries Γ R} {t : β → HahnSeries Γ' V}
+theorem isPWO_iUnion_support_prod_smul {s : α → R⟦Γ⟧} {t : β → V⟦Γ'⟧}
     (hs : (⋃ a, (s a).support).IsPWO) (ht : (⋃ b, (t b).support).IsPWO) :
     (⋃ (a : α × β), ((fun a ↦ (of R).symm
       ((s a.1) • (of R) (t a.2))) a).support).IsPWO := by
@@ -475,20 +475,20 @@ theorem smul_hsum {R} {V} [Semiring R] [AddCommMonoid V] [Module R V]
     · exact smul_eq_zero_of_left h (t.hsum.coeff gh.2)
     · simp_all
 
-instance [AddCommMonoid R] [SMulWithZero R V] : SMul (HahnSeries Γ R) (SummableFamily Γ' V β) where
+instance [AddCommMonoid R] [SMulWithZero R V] : SMul R⟦Γ⟧ (SummableFamily Γ' V β) where
   smul x t := Equiv (Equiv.punitProd β) <| smul (const Unit x) t
 
-theorem smul_eq {x : HahnSeries Γ R} {t : SummableFamily Γ' V β} :
+theorem smul_eq {x : R⟦Γ⟧} {t : SummableFamily Γ' V β} :
     x • t = Equiv (Equiv.punitProd β) (smul (const Unit x) t) :=
   rfl
 
 @[simp]
-theorem smul_apply {x : HahnSeries Γ R} {s : SummableFamily Γ' V α} {a : α} :
+theorem smul_apply {x : R⟦Γ⟧} {s : SummableFamily Γ' V α} {a : α} :
     (x • s) a = (of R).symm (x • of R (s a)) :=
   rfl
 
 @[simp]
-theorem hsum_smul_module {R} {V} [Semiring R] [AddCommMonoid V] [Module R V] {x : HahnSeries Γ R}
+theorem hsum_smul_module {R} {V} [Semiring R] [AddCommMonoid V] [Module R V] {x : R⟦Γ⟧}
     {s : SummableFamily Γ' V α} :
     (x • s).hsum = (of R).symm (x • of R s.hsum) := by
   rw [smul_eq, hsum_equiv, smul_hsum, hsum_unique, const_toFun]
@@ -500,7 +500,7 @@ section Semiring
 variable [AddCommMonoid Γ] [PartialOrder Γ] [IsOrderedCancelAddMonoid Γ]
   [PartialOrder Γ'] [AddAction Γ Γ'] [IsOrderedCancelVAdd Γ Γ'] [Semiring R]
 
-instance [AddCommMonoid V] [Module R V] : Module (HahnSeries Γ R) (SummableFamily Γ' V α) where
+instance [AddCommMonoid V] [Module R V] : Module R⟦Γ⟧ (SummableFamily Γ' V α) where
   smul_zero _ := ext fun _ => by simp
   zero_smul _ := ext fun _ => by simp
   one_smul _ := ext fun _ => by rw [smul_apply, HahnModule.one_smul', Equiv.symm_apply_apply]
@@ -508,13 +508,13 @@ instance [AddCommMonoid V] [Module R V] : Module (HahnSeries Γ R) (SummableFami
   smul_add _ _ _ := ext fun _ => by simp
   mul_smul _ _ _ := ext fun _ => by simp [HahnModule.instModule.mul_smul]
 
-theorem hsum_smul {x : HahnSeries Γ R} {s : SummableFamily Γ R α} :
+theorem hsum_smul {x : R⟦Γ⟧} {s : SummableFamily Γ R α} :
     (x • s).hsum = x * s.hsum := by
   rw [hsum_smul_module, of_symm_smul_of_eq_mul]
 
 /-- The summation of a `summable_family` as a `LinearMap`. -/
 @[simps]
-def lsum : SummableFamily Γ R α →ₗ[HahnSeries Γ R] HahnSeries Γ R where
+def lsum : SummableFamily Γ R α →ₗ[R⟦Γ⟧] R⟦Γ⟧ where
   toFun := hsum
   map_add' _ _ := hsum_add
   map_smul' _ _ := hsum_smul
@@ -524,7 +524,7 @@ theorem hsum_sub {R : Type*} [Ring R] {s t : SummableFamily Γ R α} :
     (s - t).hsum = s.hsum - t.hsum := by
   rw [← lsum_apply, map_sub, lsum_apply, lsum_apply]
 
-theorem isPWO_iUnion_support_prod_mul {s : α → HahnSeries Γ R} {t : β → HahnSeries Γ R}
+theorem isPWO_iUnion_support_prod_mul {s : α → R⟦Γ⟧} {t : β → R⟦Γ⟧}
     (hs : (⋃ a, (s a).support).IsPWO) (ht : (⋃ b, (t b).support).IsPWO) :
     (⋃ (a : α × β), ((fun a ↦ ((s a.1) * (t a.2))) a).support).IsPWO :=
   isPWO_iUnion_support_prod_smul hs ht
@@ -565,7 +565,7 @@ section OfFinsupp
 variable [PartialOrder Γ] [AddCommMonoid R]
 
 /-- A family with only finitely many nonzero elements is summable. -/
-def ofFinsupp (f : α →₀ HahnSeries Γ R) : SummableFamily Γ R α where
+def ofFinsupp (f : α →₀ R⟦Γ⟧) : SummableFamily Γ R α where
   toFun := f
   isPWO_iUnion_support' := by
     apply (f.support.isPWO_bUnion.2 fun a _ => (f a).isPWO_support).mono
@@ -581,11 +581,11 @@ def ofFinsupp (f : α →₀ HahnSeries Γ R) : SummableFamily Γ R α where
     simp [ha]
 
 @[simp]
-theorem coe_ofFinsupp {f : α →₀ HahnSeries Γ R} : ⇑(SummableFamily.ofFinsupp f) = f :=
+theorem coe_ofFinsupp {f : α →₀ R⟦Γ⟧} : ⇑(SummableFamily.ofFinsupp f) = f :=
   rfl
 
 @[simp]
-theorem hsum_ofFinsupp {f : α →₀ HahnSeries Γ R} : (ofFinsupp f).hsum = f.sum fun _ => id := by
+theorem hsum_ofFinsupp {f : α →₀ R⟦Γ⟧} : (ofFinsupp f).hsum = f.sum fun _ => id := by
   ext g
   simp only [coeff_hsum, coe_ofFinsupp, Finsupp.sum]
   simp_rw [← coeff.addMonoidHom_apply, id]
@@ -648,7 +648,7 @@ end EmbDomain
 section powers
 
 theorem support_pow_subset_closure [AddCommMonoid Γ] [PartialOrder Γ] [IsOrderedCancelAddMonoid Γ]
-    [Semiring R] (x : HahnSeries Γ R)
+    [Semiring R] (x : R⟦Γ⟧)
     (n : ℕ) : support (x ^ n) ⊆ AddSubmonoid.closure (support x) := by
   intro g hn
   induction n generalizing g with
@@ -662,7 +662,7 @@ theorem support_pow_subset_closure [AddCommMonoid Γ] [PartialOrder Γ] [IsOrder
 
 theorem isPWO_iUnion_support_powers [AddCommMonoid Γ] [LinearOrder Γ] [IsOrderedCancelAddMonoid Γ]
     [Semiring R]
-    {x : HahnSeries Γ R} (hx : 0 ≤ x.order) :
+    {x : R⟦Γ⟧} (hx : 0 ≤ x.order) :
     (⋃ n : ℕ, (x ^ n).support).IsPWO :=
   (x.isPWO_support'.addSubmonoid_closure
     fun _ hg => le_trans hx (order_le_of_coeff_ne_zero (Function.mem_support.mp hg))).mono
@@ -670,7 +670,7 @@ theorem isPWO_iUnion_support_powers [AddCommMonoid Γ] [LinearOrder Γ] [IsOrder
 
 theorem co_support_zero [AddCommMonoid Γ] [PartialOrder Γ] [IsOrderedCancelAddMonoid Γ]
     [Semiring R] (g : Γ) :
-    {a | ¬((0 : HahnSeries Γ R) ^ a).coeff g = 0} ⊆ {0} := by
+    {a | ¬((0 : R⟦Γ⟧) ^ a).coeff g = 0} ⊆ {0} := by
   simp only [Set.subset_singleton_iff, Set.mem_setOf_eq]
   intro n hn
   by_contra h'
@@ -678,7 +678,7 @@ theorem co_support_zero [AddCommMonoid Γ] [PartialOrder Γ] [IsOrderedCancelAdd
 
 variable [AddCommMonoid Γ] [LinearOrder Γ] [IsOrderedCancelAddMonoid Γ] [CommRing R]
 
-theorem pow_finite_co_support {x : HahnSeries Γ R} (hx : 0 < x.orderTop) (g : Γ) :
+theorem pow_finite_co_support {x : R⟦Γ⟧} (hx : 0 < x.orderTop) (g : Γ) :
     Set.Finite {a | ((fun n ↦ x ^ n) a).coeff g ≠ 0} := by
   have hpwo : Set.IsPWO (⋃ n, support (x ^ n)) :=
     isPWO_iUnion_support_powers (zero_le_orderTop_iff.mp <| le_of_lt hx)
@@ -703,7 +703,7 @@ theorem pow_finite_co_support {x : HahnSeries Γ R} (hx : 0 < x.orderTop) (g : �
 /-- A summable family of powers of a Hahn series `x`. If `x` has non-positive `orderTop`, then
 return a junk value given by pretending `x = 0`. -/
 @[simps]
-def powers (x : HahnSeries Γ R) : SummableFamily Γ R ℕ where
+def powers (x : R⟦Γ⟧) : SummableFamily Γ R ℕ where
   toFun n := (if 0 < x.orderTop then x else 0) ^ n
   isPWO_iUnion_support' := by
     by_cases h : 0 < x.orderTop
@@ -719,22 +719,22 @@ def powers (x : HahnSeries Γ R) : SummableFamily Γ R ℕ where
     · simp only [h, ↓reduceIte]
       exact pow_finite_co_support (orderTop_zero (R := R) (Γ := Γ) ▸ WithTop.top_pos) g
 
-theorem powers_of_orderTop_pos {x : HahnSeries Γ R} (hx : 0 < x.orderTop) (n : ℕ) :
+theorem powers_of_orderTop_pos {x : R⟦Γ⟧} (hx : 0 < x.orderTop) (n : ℕ) :
     powers x n = x ^ n := by
   simp [hx]
 
-theorem powers_of_not_orderTop_pos {x : HahnSeries Γ R} (hx : ¬ 0 < x.orderTop) :
+theorem powers_of_not_orderTop_pos {x : R⟦Γ⟧} (hx : ¬ 0 < x.orderTop) :
     powers x = .single 0 1 := by
   ext a
   obtain rfl | ha := eq_or_ne a 0 <;> simp [powers, *]
 
 @[simp]
-theorem powers_zero : powers (0 : HahnSeries Γ R) = .single 0 1 := by
+theorem powers_zero : powers (0 : R⟦Γ⟧) = .single 0 1 := by
   ext n
   rw [powers_of_orderTop_pos (by simp)]
   obtain rfl | ha := eq_or_ne n 0 <;> simp [*]
 
-variable {x : HahnSeries Γ R} (hx : 0 < x.orderTop)
+variable {x : R⟦Γ⟧} (hx : 0 < x.orderTop)
 
 include hx in
 @[simp]
@@ -769,14 +769,14 @@ section CommRing
 
 variable [AddCommMonoid Γ] [LinearOrder Γ] [IsOrderedCancelAddMonoid Γ] [CommRing R]
 
-theorem one_minus_single_neg_mul {x y : HahnSeries Γ R} {r : R} (hr : r * x.leadingCoeff = 1)
+theorem one_minus_single_neg_mul {x y : R⟦Γ⟧} {r : R} (hr : r * x.leadingCoeff = 1)
     (hxy : x = y + single x.order x.leadingCoeff) (oinv : Γ) (hxo : oinv + x.order = 0) :
     1 - single oinv r * x = -(single oinv r * y) := by
   nth_rw 1 [hxy]
   rw [mul_add, single_mul_single, hr, hxo,
     sub_add_eq_sub_sub_swap, sub_eq_neg_self, sub_eq_zero_of_eq single_zero_one.symm]
 
-theorem unit_aux (x : HahnSeries Γ R) {r : R} (hr : r * x.leadingCoeff = 1)
+theorem unit_aux (x : R⟦Γ⟧) {r : R} (hr : r * x.leadingCoeff = 1)
     (oinv : Γ) (hxo : oinv + x.order = 0) :
     0 < (1 - single oinv r * x).orderTop := by
   let y := (x - single x.order x.leadingCoeff)
@@ -793,7 +793,7 @@ theorem unit_aux (x : HahnSeries Γ R) {r : R} (hr : r * x.leadingCoeff = 1)
     rw [one_minus_single_neg_mul hr (sub_add_cancel x _).symm _ hxo, orderTop_neg]
     exact zero_lt_orderTop_of_order hy'
 
-theorem isUnit_of_isUnit_leadingCoeff_AddUnitOrder {x : HahnSeries Γ R} (hx : IsUnit x.leadingCoeff)
+theorem isUnit_of_isUnit_leadingCoeff_AddUnitOrder {x : R⟦Γ⟧} (hx : IsUnit x.leadingCoeff)
     (hxo : IsAddUnit x.order) : IsUnit x := by
   let ⟨⟨u, i, ui, iu⟩, h⟩ := hx
   rw [Units.val_mk] at h
@@ -802,7 +802,7 @@ theorem isUnit_of_isUnit_leadingCoeff_AddUnitOrder {x : HahnSeries Γ R} (hx : I
   rw [sub_sub_cancel] at h'
   exact isUnit_of_mul_isUnit_right (.of_mul_eq_one _ h')
 
-theorem isUnit_of_orderTop_pos {x : HahnSeries Γ R} (h : 0 < (x - 1).orderTop) :
+theorem isUnit_of_orderTop_pos {x : R⟦Γ⟧} (h : 0 < (x - 1).orderTop) :
     IsUnit x := by
   obtain _ | _ := subsingleton_or_nontrivial R
   · exact isUnit_of_subsingleton x
@@ -817,7 +817,7 @@ theorem isUnit_of_orderTop_pos {x : HahnSeries Γ R} (h : 0 < (x - 1).orderTop) 
 
 /-- Make an element of `orderTopSubOnePos` -/
 @[simps]
-def toOrderTopSubOnePos {x : HahnSeries Γ R} (h : 0 < (x - 1).orderTop) :
+def toOrderTopSubOnePos {x : R⟦Γ⟧} (h : 0 < (x - 1).orderTop) :
     orderTopSubOnePos Γ R where
   val := ⟨x, (isUnit_of_orderTop_pos h).unit.inv, IsUnit.mul_val_inv (isUnit_of_orderTop_pos h),
     IsUnit.val_inv_mul (isUnit_of_orderTop_pos h)⟩
@@ -829,7 +829,7 @@ section IsDomain
 
 variable [AddCommGroup Γ] [LinearOrder Γ] [IsOrderedAddMonoid Γ] [CommRing R] [IsDomain R]
 
-theorem isUnit_iff {x : HahnSeries Γ R} : IsUnit x ↔ IsUnit (x.leadingCoeff) := by
+theorem isUnit_iff {x : R⟦Γ⟧} : IsUnit x ↔ IsUnit (x.leadingCoeff) := by
   constructor
   · rintro ⟨⟨u, i, ui, iu⟩, rfl⟩
     refine
@@ -852,7 +852,7 @@ section Field
 variable [AddCommGroup Γ] [LinearOrder Γ] [IsOrderedAddMonoid Γ] [Field R]
 
 @[simps -isSimp inv]
-instance : DivInvMonoid (HahnSeries Γ R) where
+instance : DivInvMonoid R⟦Γ⟧ where
   inv x :=
     single (-x.order) (x.leadingCoeff)⁻¹ *
       (SummableFamily.powers <| 1 - single (-x.order) (x.leadingCoeff)⁻¹ * x).hsum
@@ -868,7 +868,7 @@ theorem single_div_single (a b : Γ) (r s : R) :
     single a r / single b s = single (a - b) (r / s) := by
   rw [div_eq_mul_inv, sub_eq_add_neg, div_eq_mul_inv, inv_single, single_mul_single]
 
-instance instField : Field (HahnSeries Γ R) where
+instance instField : Field R⟦Γ⟧ where
   inv_zero := by simp [inv_def]
   mul_inv_cancel x x0 := by
     have h :=
@@ -885,8 +885,8 @@ instance instField : Field (HahnSeries Γ R) where
   ratCast_def q := by
     simp [← single_zero_ratCast, ← single_zero_intCast, ← single_zero_natCast, Rat.cast_def]
 
-example : (instSMul : SMul NNRat (HahnSeries Γ R)) = NNRat.smulDivisionSemiring := rfl
-example : (instSMul : SMul ℚ (HahnSeries Γ R)) = Rat.smulDivisionRing := rfl
+example : (instSMul : SMul NNRat R⟦Γ⟧) = NNRat.smulDivisionSemiring := rfl
+example : (instSMul : SMul ℚ R⟦Γ⟧) = Rat.smulDivisionRing := rfl
 
 theorem single_zero_ofScientific (m e s) :
     single (0 : Γ) (OfScientific.ofScientific m e s : R) = OfScientific.ofScientific m e s := by

--- a/Mathlib/RingTheory/HahnSeries/Valuation.lean
+++ b/Mathlib/RingTheory/HahnSeries/Valuation.lean
@@ -10,11 +10,11 @@ public import Mathlib.RingTheory.Valuation.Basic
 
 /-!
 # Valuations on Hahn Series rings
-If `Γ` is a `LinearOrderedCancelAddCommMonoid` and `R` is a domain, then the domain `HahnSeries Γ R`
+If `Γ` is a `LinearOrderedCancelAddCommMonoid` and `R` is a domain, then the domain `R⟦Γ⟧`
 admits an additive valuation given by `orderTop`.
 
 ## Main Definitions
-* `HahnSeries.addVal Γ R` defines an `AddValuation` on `HahnSeries Γ R` when `Γ` is linearly
+* `HahnSeries.addVal Γ R` defines an `AddValuation` on `R⟦Γ⟧` when `Γ` is linearly
   ordered.
 
 ## TODO
@@ -38,9 +38,9 @@ section Valuation
 
 variable (Γ R) [AddCommMonoid Γ] [LinearOrder Γ] [IsOrderedCancelAddMonoid Γ] [Ring R] [IsDomain R]
 
-/-- The additive valuation on `HahnSeries Γ R`, returning the smallest index at which
+/-- The additive valuation on `R⟦Γ⟧`, returning the smallest index at which
   a Hahn Series has a nonzero coefficient, or `⊤` for the 0 series. -/
-def addVal : AddValuation (HahnSeries Γ R) (WithTop Γ) :=
+def addVal : AddValuation R⟦Γ⟧ (WithTop Γ) :=
   AddValuation.of orderTop orderTop_zero (orderTop_one) (fun _ _ => min_orderTop_le_orderTop_add)
   fun x y => by
     by_cases hx : x = 0; · simp [hx]
@@ -49,18 +49,16 @@ def addVal : AddValuation (HahnSeries Γ R) (WithTop Γ) :=
       ← order_eq_orderTop_of_ne_zero (mul_ne_zero hx hy), ← WithTop.coe_add, WithTop.coe_eq_coe,
       order_mul hx hy]
 
-variable {Γ} {R}
+variable {Γ R}
 
-theorem addVal_apply {x : HahnSeries Γ R} :
-    addVal Γ R x = x.orderTop :=
+theorem addVal_apply {x : R⟦Γ⟧} : addVal Γ R x = x.orderTop :=
   AddValuation.of_apply _
 
 @[simp]
-theorem addVal_apply_of_ne {x : HahnSeries Γ R} (hx : x ≠ 0) : addVal Γ R x = x.order :=
+theorem addVal_apply_of_ne {x : R⟦Γ⟧} (hx : x ≠ 0) : addVal Γ R x = x.order :=
   addVal_apply.trans (order_eq_orderTop_of_ne_zero hx).symm
 
-theorem addVal_le_of_coeff_ne_zero {x : HahnSeries Γ R} {g : Γ} (h : x.coeff g ≠ 0) :
-    addVal Γ R x ≤ g :=
+theorem addVal_le_of_coeff_ne_zero {x : R⟦Γ⟧} {g : Γ} (h : x.coeff g ≠ 0) : addVal Γ R x ≤ g :=
   orderTop_le_of_coeff_ne_zero h
 
 end Valuation

--- a/Mathlib/RingTheory/LaurentSeries.lean
+++ b/Mathlib/RingTheory/LaurentSeries.lean
@@ -67,9 +67,9 @@ type with a zero. They are denoted `R⸨X⸩`.
 
 ## Implementation details
 
-* Since `LaurentSeries` is just an abbreviation of `HahnSeries ℤ R`, the definition of the
+* Since `LaurentSeries` is just an abbreviation of `HahnSeries ℤ`, the definition of the
   coefficients is given in terms of `HahnSeries.coeff` and this forces sometimes to go
-  back-and-forth from `X : R⸨X⸩` to `single 1 1 : HahnSeries ℤ R`.
+  back-and-forth from `X : R⸨X⸩` to `single 1 1 : R⟦ℤ⟧`.
 * To prove the isomorphism between the `X`-adic completion of `RatFunc K` and `K⸨X⸩` we construct
   two completions of `RatFunc K`: the first (`LaurentSeries.ratfuncAdicComplPkg`) is its abstract
   uniform completion; the second (`LaurentSeries.LaurentSeriesPkg`) is simply `K⸨X⸩`, once we prove
@@ -98,8 +98,7 @@ noncomputable section
 
   It is implemented as a `HahnSeries` with value group `ℤ`.
 -/
-abbrev LaurentSeries (R : Type u) [Zero R] :=
-  HahnSeries ℤ R
+abbrev LaurentSeries (R : Type u) [Zero R] := R⟦ℤ⟧
 
 variable {R : Type*}
 


### PR DESCRIPTION
As proposed on [Zulip](https://leanprover.zulipchat.com/#narrow/channel/287929-mathlib4/topic/Notation.20for.20Hahn.20series/with/562859530). This technically clashes with `R⟦X⟧` for power series, but a similar clash already exists between `R[G]` for `MonoidAlgebra` and `R[X]` for `Polynomial`, so it should be fine.

---
<!-- Your PR title will become the first line of the commit message.

In this box, the text above the `---` (if not empty) will be appended
to the commit message, and can be used to give additional context or
details. Please leave a blank newline before the `---`, otherwise GitHub
will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

When merging, all the commits will be squashed into a single commit
listing all co-authors.

Co-authors in the squash commit are gathered from two sources:

First, all authors of commits to this PR branch are included. Thus,
one way to add co-authors is to include at least one commit authored by
each co-author among the commits in the pull request. If necessary, you
may create empty commits to indicate co-authorship, using commands like so:

git commit --author="Author Name <author@email.com>" --allow-empty -m "add Author Name as coauthor"

Second, co-authors can also be listed in lines at the very bottom of
the commit message (that is, directly before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines
at the bottom of the commit message (before the `---`, and also before
any "Co-authored-by" lines) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

- [x] depends on: #32669

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
