### PR TITLE
[Merged by Bors] - doc(Sphere.Power): add theorem to 1000.yaml and author credit

### DIFF
--- a/Mathlib/Geometry/Euclidean/Sphere/Power.lean
+++ b/Mathlib/Geometry/Euclidean/Sphere/Power.lean
@@ -1,7 +1,7 @@
 /-
 Copyright (c) 2021 Manuel Candales. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
-Authors: Manuel Candales, Benjamin Davidson
+Authors: Manuel Candales, Benjamin Davidson, Li Jiale
 -/
 module
 

--- a/docs/1000.yaml
+++ b/docs/1000.yaml
@@ -2079,6 +2079,9 @@ Q2266397:
 
 Q2267175:
   title: Tangent-secant theorem
+  decl: EuclideanGeometry.Sphere.dist_sq_eq_mul_dist_of_tangent_and_secant
+  authors: Li Jiale
+  date: 2025
 
 Q2269888:
   title: Cohn's irreducibility criterion


### PR DESCRIPTION
I contributed the `Sphere.power` section (lines 133-end) in PR #27040   #31496 

However, I forgot to add my name to the Authors line at that time. 
This PR adds my name to properly credit the contribution.