### PR TITLE
[Merged by Bors] - doc: fix instances of "the the"

### DIFF
--- a/Mathlib/AlgebraicGeometry/Sites/Pretopology.lean
+++ b/Mathlib/AlgebraicGeometry/Sites/Pretopology.lean
@@ -119,7 +119,7 @@ variable (P)
 
 /--
 The pretopology defined by `P`-covers agrees with the
-the intersection of the pretopology of surjective families with the pretopology defined by `P`.
+intersection of the pretopology of surjective families with the pretopology defined by `P`.
 -/
 lemma pretopology_eq_inf : pretopology P = jointlySurjectivePretopology ⊓ P.pretopology := rfl
 

--- a/Mathlib/CategoryTheory/Monad/Comonadicity.lean
+++ b/Mathlib/CategoryTheory/Monad/Comonadicity.lean
@@ -168,7 +168,7 @@ theorem comparisonAdjunction_counit_f
 variable (adj)
 
 /-- The fork which describes the unit of the adjunction: the morphism from this fork to the
-the equalizer of this pair is the unit.
+equalizer of this pair is the unit.
 -/
 @[simps!]
 def unitFork (B : C) :

--- a/Mathlib/CategoryTheory/Triangulated/Pretriangulated.lean
+++ b/Mathlib/CategoryTheory/Triangulated/Pretriangulated.lean
@@ -420,7 +420,7 @@ instance : SplitMonoCategory C where
     exact ⟨r, hr.symm⟩
 
 /-- If the first and third components of a morphism of distinguished triangles are
-isomorphisms, the the second component is as well. This can be thought of as a
+isomorphisms, the second component is as well. This can be thought of as a
 pretriangulated category theoretical version of the five lemma. -/
 lemma isIso₂_of_isIso₁₃ {T T' : Triangle C} (φ : T ⟶ T') (hT : T ∈ distTriang C)
     (hT' : T' ∈ distTriang C) (h₁ : IsIso φ.hom₁) (h₃ : IsIso φ.hom₃) : IsIso φ.hom₂ := by
@@ -455,7 +455,7 @@ lemma isIso₂_of_isIso₁₃ {T T' : Triangle C} (φ : T ⟶ T') (hT : T ∈ di
     rw [add_comp, assoc, φ.comm₁, reassoc_of% hx₁, ← hy₁, add_sub_cancel]
 
 /-- If the first and second components of a morphism of distinguished triangles are
-isomorphisms, the the third component is as well. This can be thought of as a
+isomorphisms, the third component is as well. This can be thought of as a
 pretriangulated category theoretical version of the five lemma. -/
 lemma isIso₃_of_isIso₁₂ {T T' : Triangle C} (φ : T ⟶ T') (hT : T ∈ distTriang C)
     (hT' : T' ∈ distTriang C) (h₁ : IsIso φ.hom₁) (h₂ : IsIso φ.hom₂) : IsIso φ.hom₃ :=
@@ -463,7 +463,7 @@ lemma isIso₃_of_isIso₁₂ {T T' : Triangle C} (φ : T ⟶ T') (hT : T ∈ di
     (rot_of_distTriang _ hT') h₂ (by dsimp; infer_instance)
 
 /-- If the second and third components of a morphism of distinguished triangles are
-isomorphisms, the the first component is as well. This can be thought of as a
+isomorphisms, the first component is as well. This can be thought of as a
 pretriangulated category theoretical version of the five lemma. -/
 lemma isIso₁_of_isIso₂₃ {T T' : Triangle C} (φ : T ⟶ T') (hT : T ∈ distTriang C)
     (hT' : T' ∈ distTriang C) (h₂ : IsIso φ.hom₂) (h₃ : IsIso φ.hom₃) : IsIso φ.hom₁ :=

--- a/Mathlib/MeasureTheory/Integral/IntervalIntegral/Periodic.lean
+++ b/Mathlib/MeasureTheory/Integral/IntervalIntegral/Periodic.lean
@@ -208,7 +208,7 @@ protected theorem intervalIntegral_preimage (t : ℝ) (f : AddCircle T → E) :
   linarith [hT.out]
 
 /-- The integral of a function lifted to AddCircle from an interval `(t, t + T]` to `AddCircle T`
-is equal the the intervalIntegral over the interval. -/
+is equal to the intervalIntegral over the interval. -/
 lemma integral_liftIoc_eq_intervalIntegral {t : ℝ} {f : ℝ → E} :
     ∫ a, liftIoc T t f a = ∫ a in t..t + T, f a := by
   rw [← AddCircle.intervalIntegral_preimage T t]

--- a/Mathlib/RingTheory/GradedAlgebra/Homogeneous/Submodule.lean
+++ b/Mathlib/RingTheory/GradedAlgebra/Homogeneous/Submodule.lean
@@ -24,7 +24,7 @@ For any `p : Submodule A M`:
 ## Implementation notes
 
 The **notion** of homogeneous submodule does not rely on a graded ring, only a decomposition of the
-the module. However, most interesting properties of homogeneous submodules do rely on the base ring
+module. However, most interesting properties of homogeneous submodules do rely on the base ring
 being a graded ring. For technical reasons, we make `HomogeneousSubmodule` depend on a graded ring.
 For example, if the definition of a homogeneous submodule does not depend on a graded ring, the
 instance that `HomogeneousSubmodule` is a complete lattice cannot be synthesized due to

--- a/Mathlib/RingTheory/Smooth/Basic.lean
+++ b/Mathlib/RingTheory/Smooth/Basic.lean
@@ -66,7 +66,7 @@ An `R`-algebra `A` is formally smooth if `Ω[A⁄R]` is `A`-projective and `H¹(
 For the infinitesimal lifting definition,
 see `FormallySmooth.lift` and `FormallySmooth.iff_comp_surjective`.
 -/
-@[stacks 00TI "Also see 031J (6) for the the equivalence with the definition given here.", mk_iff]
+@[stacks 00TI "Also see 031J (6) for the equivalence with the definition given here.", mk_iff]
 class FormallySmooth : Prop where
   projective_kaehlerDifferential : Module.Projective A Ω[A⁄R]
   subsingleton_h1Cotangent : Subsingleton (H1Cotangent R A)


### PR DESCRIPTION
---
<!-- Your PR title will become the first line of the commit message.

In this box, the text above the `---` (if not empty) will be appended
to the commit message, and can be used to give additional context or
details. Please leave a blank newline before the `---`, otherwise GitHub
will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

When merging, all the commits will be squashed into a single commit
listing all co-authors.

Co-authors in the squash commit are gathered from two sources:

First, all authors of commits to this PR branch are included. Thus,
one way to add co-authors is to include at least one commit authored by
each co-author among the commits in the pull request. If necessary, you
may create empty commits to indicate co-authorship, using commands like so:

git commit --author="Author Name <author@email.com>" --allow-empty -m "add Author Name as coauthor"

Second, co-authors can also be listed in lines at the very bottom of
the commit message (that is, directly before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines
at the bottom of the commit message (before the `---`, and also before
any "Co-authored-by" lines) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
