### PR TITLE
[Merged by Bors] - chore(RingTheory): rename `RingHom.specComap` to `PrimeSpectrum.comap`

### DIFF
--- a/Mathlib/AlgebraicGeometry/GammaSpecAdjunction.lean
+++ b/Mathlib/AlgebraicGeometry/GammaSpecAdjunction.lean
@@ -282,7 +282,7 @@ def identityToΓSpec : 𝟭 LocallyRingedSpace.{u} ⟶ Γ.rightOp ⋙ Spec.toLoc
       rw [← IsLocalRing.comap_closedPoint (f.stalkMap x).hom, ←
         PrimeSpectrum.comap_comp_apply, ← PrimeSpectrum.comap_comp_apply,
         ← CommRingCat.hom_comp, ← CommRingCat.hom_comp]
-      congr 3
+      congr 2
       exact (PresheafedSpace.stalkMap_germ f.1 ⊤ x trivial).symm
     · intro r
       rw [LocallyRingedSpace.comp_c_app, ← Category.assoc]

--- a/Mathlib/AlgebraicGeometry/IdealSheaf/Basic.lean
+++ b/Mathlib/AlgebraicGeometry/IdealSheaf/Basic.lean
@@ -757,7 +757,7 @@ lemma Hom.support_ker (f : X ⟶ Y) [QuasiCompact f] :
     rw [ker_of_isAffine, coe_support_ofIdealTop, Spec_zeroLocus, ← Ideal.coe_comap,
       RingHom.comap_ker, ← PrimeSpectrum.closure_range_comap, ← CommRingCat.hom_comp,
       ← Scheme.ΓSpecIso_inv_naturality]
-    simp only [CommRingCat.hom_comp, PrimeSpectrum.comap_comp, ContinuousMap.coe_comp]
+    simp only [CommRingCat.hom_comp, PrimeSpectrum.comap_comp]
     exact closure_mono (Set.range_comp_subset_range _ (Spec.map φ))
   · rw [(support _).isClosed.closure_subset_iff]
     exact f.range_subset_ker_support

--- a/Mathlib/AlgebraicGeometry/Morphisms/OpenImmersion.lean
+++ b/Mathlib/AlgebraicGeometry/Morphisms/OpenImmersion.lean
@@ -47,7 +47,7 @@ lemma isOpenImmersion_SpecMap_iff_of_surjective {R S : CommRingCat}
         IsLocalization.away_of_isIdempotentElem he.one_sub (by simp) Ideal.Quotient.mk_surjective
       IsOpenImmersion.of_isLocalization (1 - e)
     have H : Set.range (Spec.map φ) = Set.range (Spec.map f) :=
-      ((PrimeSpectrum.range_comap_of_surjective _ _
+      ((range_comap_of_surjective _ _
         Ideal.Quotient.mk_surjective).trans (by simp)).trans he'.symm
     let i : S ≅ .of _ := (Scheme.Spec.preimageIso
       (IsOpenImmersion.isoOfRangeEq (Spec.map φ) (Spec.map f) H)).unop

--- a/Mathlib/AlgebraicGeometry/Morphisms/UniversallyClosed.lean
+++ b/Mathlib/AlgebraicGeometry/Morphisms/UniversallyClosed.lean
@@ -142,7 +142,8 @@ lemma compactSpace_of_universallyClosed
   contrapose! h
   obtain ⟨x, hx⟩ := h
   obtain ⟨z, rfl, hzr⟩ := exists_preimage_pullback x t' (Subsingleton.elim (f x) (q t'))
-  suffices ∀ i, t ∈ (Ti i).comap (comap φ) → p z ∉ U i from ⟨z, by simpa [Z, p, fT, hzr], hzr⟩
+  suffices ∀ i, t ∈ (Ti i).comap ⟨_, continuous_comap φ⟩ → p z ∉ U i from
+    ⟨z, by simpa [Z, p, fT, hzr], hzr⟩
   intro i hi₁ hi₂
   rw [comap_basicOpen, show φ (.X i) = 0 by simpa [φ] using (hx i · hi₂), basicOpen_zero] at hi₁
   cases hi₁

--- a/Mathlib/AlgebraicGeometry/Scheme.lean
+++ b/Mathlib/AlgebraicGeometry/Scheme.lean
@@ -523,7 +523,7 @@ variable {R S : CommRingCat.{u}} (f : R ⟶ S)
 lemma Spec_carrier (R : CommRingCat.{u}) : (Spec R).carrier = PrimeSpectrum R := rfl
 lemma Spec_sheaf (R : CommRingCat.{u}) : (Spec R).sheaf = Spec.structureSheaf R := rfl
 lemma Spec_presheaf (R : CommRingCat.{u}) : (Spec R).presheaf = (Spec.structureSheaf R).1 := rfl
-lemma Spec.map_base : (Spec.map f).base = ofHom (PrimeSpectrum.comap f.hom) := rfl
+lemma Spec.map_base : (Spec.map f).base = ofHom ⟨_, PrimeSpectrum.continuous_comap f.hom⟩ := rfl
 lemma Spec.map_apply (x : Spec S) : Spec.map f x = PrimeSpectrum.comap f.hom x := rfl
 
 @[deprecated (since := "2025-10-07")] alias Spec.map_base_apply := Spec.map_apply

--- a/Mathlib/AlgebraicGeometry/Spec.lean
+++ b/Mathlib/AlgebraicGeometry/Spec.lean
@@ -64,7 +64,7 @@ def Spec.topObj (R : CommRingCat.{u}) : TopCat :=
 /-- The induced map of a ring homomorphism on the ring spectra, as a morphism of topological spaces.
 -/
 def Spec.topMap {R S : CommRingCat.{u}} (f : R ⟶ S) : Spec.topObj S ⟶ Spec.topObj R :=
-  TopCat.ofHom (PrimeSpectrum.comap f.hom)
+  TopCat.ofHom ⟨_, PrimeSpectrum.continuous_comap f.hom⟩
 
 @[simp]
 theorem Spec.topMap_id (R : CommRingCat.{u}) : Spec.topMap (𝟙 R) = 𝟙 (Spec.topObj R) :=

--- a/Mathlib/AlgebraicGeometry/StructureSheaf.lean
+++ b/Mathlib/AlgebraicGeometry/StructureSheaf.lean
@@ -965,7 +965,8 @@ theorem comapFunIsLocallyFraction (f : R →+* S) (U : Opens (PrimeSpectrum.Top 
   rcases hs ⟨PrimeSpectrum.comap f p, hUV hpV⟩ with ⟨W, m, iWU, a, b, h_frac⟩
   -- We claim that we can write our new section as the fraction `f a / f b` on the neighborhood
   -- `(comap f) ⁻¹ W ⊓ V` of `p`.
-  refine ⟨Opens.comap (PrimeSpectrum.comap f) W ⊓ V, ⟨m, hpV⟩, Opens.infLERight _ _, f a, f b, ?_⟩
+  refine ⟨⟨_, (PrimeSpectrum.continuous_comap f).isOpen_preimage _ W.2⟩ ⊓ V,
+    ⟨m, hpV⟩, Opens.infLERight _ _, f a, f b, ?_⟩
   rintro ⟨q, ⟨hqW, hqV⟩⟩
   specialize h_frac ⟨PrimeSpectrum.comap f q, hqW⟩
   refine ⟨h_frac.1, ?_⟩
@@ -1080,7 +1081,7 @@ theorem comap_comp (f : R →+* S) (g : S →+* P) (U : Opens (PrimeSpectrum.Top
 
 @[elementwise, reassoc]
 theorem toOpen_comp_comap (f : R →+* S) (U : Opens (PrimeSpectrum.Top R)) :
-    (toOpen R U ≫ CommRingCat.ofHom (comap f U (Opens.comap (PrimeSpectrum.comap f) U)
+    (toOpen R U ≫ CommRingCat.ofHom (comap f U (Opens.comap ⟨_, PrimeSpectrum.continuous_comap f⟩ U)
         fun _ => id)) =
       CommRingCat.ofHom f ≫ toOpen S _ :=
   CommRingCat.hom_ext <| RingHom.ext fun _ => Subtype.ext <| funext fun _ =>

--- a/Mathlib/RingTheory/Flat/FaithfullyFlat/Algebra.lean
+++ b/Mathlib/RingTheory/Flat/FaithfullyFlat/Algebra.lean
@@ -25,14 +25,14 @@ Let `B` be a faithfully flat `A`-algebra:
   `A` to `B` is the ideal itself.
 - `Module.FaithfullyFlat.tensorProduct_mk_injective`: The natural map `M →ₗ[A] B ⊗[A] M` is
   injective for any `A`-module `M`.
-- `PrimeSpectrum.specComap_surjective_of_faithfullyFlat`: The map on prime spectra induced by
+- `PrimeSpectrum.comap_surjective_of_faithfullyFlat`: The map on prime spectra induced by
   a faithfully flat ring map is surjective. See also
   `Ideal.exists_isPrime_liesOver_of_faithfullyFlat` for a version stated in terms of
   `Ideal.LiesOver`.
 
 Conversely, let `B` be a flat `A`-algebra:
 
-- `Module.FaithfullyFlat.of_specComap_surjective`: `B` is faithfully flat over `A`,
+- `Module.FaithfullyFlat.of_comap_surjective`: `B` is faithfully flat over `A`,
   if the induced map on prime spectra is surjective.
 - `Module.FaithfullyFlat.of_flat_of_isLocalHom`: flat + local implies faithfully flat
 
@@ -47,13 +47,13 @@ variable {A B : Type*} [CommRing A] [CommRing B] [Algebra A B]
 open TensorProduct LinearMap
 
 /-- If `A →+* B` is flat and surjective on prime spectra, `B` is a faithfully flat `A`-algebra. -/
-lemma Module.FaithfullyFlat.of_specComap_surjective [Flat A B]
-    (h : Function.Surjective ((algebraMap A B).specComap)) :
+lemma Module.FaithfullyFlat.of_comap_surjective [Flat A B]
+    (h : Function.Surjective (PrimeSpectrum.comap (algebraMap A B))) :
     Module.FaithfullyFlat A B := by
   refine ⟨fun m hm ↦ ?_⟩
   obtain ⟨m', hm'⟩ := h ⟨m, hm.isPrime⟩
   have : m = Ideal.comap (algebraMap A B) m'.asIdeal := by
-    rw [← PrimeSpectrum.specComap_asIdeal (algebraMap A B) m', hm']
+    rw [← PrimeSpectrum.comap_asIdeal (algebraMap A B) m', hm']
   rw [Ideal.smul_top_eq_map, this]
   exact (Submodule.restrictScalars_eq_top_iff _ _ _).ne.mpr
     fun top ↦ m'.isPrime.ne_top <| top_le_iff.mp <| top ▸ Ideal.map_comap_le
@@ -129,7 +129,7 @@ lemma Ideal.exists_isPrime_liesOver_of_faithfullyFlat (p : Ideal A) [p.IsPrime] 
 
 /-- If `B` is a faithfully flat `A`-algebra, the induced map on the prime spectrum is
 surjective. -/
-lemma PrimeSpectrum.specComap_surjective_of_faithfullyFlat :
-    Function.Surjective (algebraMap A B).specComap := fun I ↦
+lemma PrimeSpectrum.comap_surjective_of_faithfullyFlat :
+    Function.Surjective (comap (algebraMap A B)) := fun I ↦
   (PrimeSpectrum.mem_range_comap_iff (algebraMap A B)).mpr
     I.asIdeal.comap_map_eq_self_of_faithfullyFlat

--- a/Mathlib/RingTheory/Flat/FaithfullyFlat/Algebra.lean
+++ b/Mathlib/RingTheory/Flat/FaithfullyFlat/Algebra.lean
@@ -58,6 +58,9 @@ lemma Module.FaithfullyFlat.of_comap_surjective [Flat A B]
   exact (Submodule.restrictScalars_eq_top_iff _ _ _).ne.mpr
     fun top ↦ m'.isPrime.ne_top <| top_le_iff.mp <| top ▸ Ideal.map_comap_le
 
+@[deprecated (since := "2025-12-10")]
+alias Module.FaithfullyFlat.of_specComap_surjective := Module.FaithfullyFlat.of_comap_surjective
+
 /-- If `A` is local and `B` is a local and flat `A`-algebra, then `B` is faithfully flat. -/
 lemma Module.FaithfullyFlat.of_flat_of_isLocalHom [IsLocalRing A] [IsLocalRing B] [Flat A B]
     [IsLocalHom (algebraMap A B)] : Module.FaithfullyFlat A B := by
@@ -133,3 +136,7 @@ lemma PrimeSpectrum.comap_surjective_of_faithfullyFlat :
     Function.Surjective (comap (algebraMap A B)) := fun I ↦
   (PrimeSpectrum.mem_range_comap_iff (algebraMap A B)).mpr
     I.asIdeal.comap_map_eq_self_of_faithfullyFlat
+
+@[deprecated (since := "2025-12-10")]
+alias PrimeSpectrum.specComap_surjective_of_faithfullyFlat :=
+  PrimeSpectrum.comap_surjective_of_faithfullyFlat

--- a/Mathlib/RingTheory/Ideal/GoingDown.lean
+++ b/Mathlib/RingTheory/Ideal/GoingDown.lean
@@ -72,7 +72,7 @@ lemma Ideal.exists_ltSeries_of_hasGoingDown [Algebra.HasGoingDown R S]
     ∃ (L : LTSeries (PrimeSpectrum S)),
       L.length = l.length ∧
       L.last = ⟨P, inferInstance⟩ ∧
-      List.map (algebraMap R S).specComap L.toList = l.toList := by
+      List.map (PrimeSpectrum.comap (algebraMap R S)) L.toList = l.toList := by
   induction l using RelSeries.inductionOn generalizing P with
   | singleton q =>
     use RelSeries.singleton _ ⟨P, inferInstance⟩
@@ -86,9 +86,10 @@ lemma Ideal.exists_ltSeries_of_hasGoingDown [Algebra.HasGoingDown R S]
     have : L.head.asIdeal.LiesOver l.head.asIdeal := by
       constructor
       rw [← L.toList_getElem_zero_eq_head, ← l.toList_getElem_zero_eq_head, Ideal.under_def]
-      have : l.toList[0] = (algebraMap R S).specComap L.toList[0] := by
-        rw [List.getElem_map_rev (algebraMap R S).specComap, List.getElem_of_eq spec.symm _]
-      rwa [RingHom.specComap, PrimeSpectrum.ext_iff] at this
+      have : l.toList[0] = (PrimeSpectrum.comap (algebraMap R S)) L.toList[0] := by
+        rw [List.getElem_map_rev (PrimeSpectrum.comap (algebraMap R S)),
+          List.getElem_of_eq spec.symm _]
+      rwa [PrimeSpectrum.ext_iff] at this
     obtain ⟨Q, Qlt, hQ, Qlo⟩ := Ideal.exists_ideal_lt_liesOver_of_lt L.head.asIdeal lt
     use L.cons ⟨Q, hQ⟩ Qlt
     simp only [RelSeries.cons_length, add_left_inj, RelSeries.last_cons]
@@ -124,16 +125,16 @@ lemma trans (T : Type*) [CommRing T] [Algebra R T] [Algebra S T] [IsScalarTower 
     [Algebra.HasGoingDown R S] [Algebra.HasGoingDown S T] :
     Algebra.HasGoingDown R T := by
   rw [iff_generalizingMap_primeSpectrumComap, IsScalarTower.algebraMap_eq R S T]
-  simp only [PrimeSpectrum.comap_comp, ContinuousMap.coe_comp]
+  simp only [PrimeSpectrum.comap_comp]
   apply GeneralizingMap.comp
   · rwa [← iff_generalizingMap_primeSpectrumComap]
   · rwa [← iff_generalizingMap_primeSpectrumComap]
 
 /-- If for every prime of `S`, the map `Spec Sₚ → Spec Rₚ` is surjective,
 the algebra satisfies going down. -/
-lemma of_specComap_localRingHom_surjective
+lemma of_comap_localRingHom_surjective
     (H : ∀ (P : Ideal S) [P.IsPrime], Function.Surjective
-      (Localization.localRingHom (P.under R) P (algebraMap R S) rfl).specComap) :
+      (PrimeSpectrum.comap <| Localization.localRingHom (P.under R) P (algebraMap R S) rfl)) :
     Algebra.HasGoingDown R S where
   exists_ideal_le_liesOver_of_lt {p} _ Q _ hlt := by
     let pl : Ideal (Localization.AtPrime <| Q.under R) := p.map (algebraMap R _)
@@ -142,20 +143,20 @@ lemma of_specComap_localRingHom_surjective
     obtain ⟨⟨Pl, _⟩, hl⟩ := H Q ⟨pl, inferInstance⟩
     refine ⟨Pl.under S, ?_, Ideal.IsPrime.under S Pl, ⟨?_⟩⟩
     · exact (IsLocalization.AtPrime.orderIsoOfPrime _ Q ⟨Pl, inferInstance⟩).2.2
-    · replace hl : Pl.under _ = pl := by simpa using hl
+    · replace hl : Pl.under _ = pl := by simpa [PrimeSpectrum.ext_iff] using hl
       rw [Ideal.under_under, ← Ideal.under_under (B := (Localization.AtPrime <| Q.under R)) Pl, hl,
         Ideal.under_map_of_isLocalizationAtPrime (Q.under R) hlt.le]
 
 /-- Flat algebras satisfy the going down property. -/
 @[stacks 00HS]
 instance of_flat [Module.Flat R S] : Algebra.HasGoingDown R S := by
-  apply of_specComap_localRingHom_surjective
+  apply of_comap_localRingHom_surjective
   intro P hP
   have : IsLocalHom (algebraMap (Localization.AtPrime <| P.under R) (Localization.AtPrime P)) := by
     rw [RingHom.algebraMap_toAlgebra]
     exact Localization.isLocalHom_localRingHom (P.under R) P (algebraMap R S) Ideal.LiesOver.over
   have : Module.FaithfullyFlat (Localization.AtPrime (P.under R)) (Localization.AtPrime P) :=
     Module.FaithfullyFlat.of_flat_of_isLocalHom
-  apply PrimeSpectrum.specComap_surjective_of_faithfullyFlat
+  apply PrimeSpectrum.comap_surjective_of_faithfullyFlat
 
 end Algebra.HasGoingDown

--- a/Mathlib/RingTheory/Ideal/KrullsHeightTheorem.lean
+++ b/Mathlib/RingTheory/Ideal/KrullsHeightTheorem.lean
@@ -365,13 +365,14 @@ lemma Ideal.height_eq_height_add_of_liesOver_of_hasGoingDown [IsNoetherianRing S
   obtain ⟨lp, hlp, hlenp⟩ := p.exists_ltSeries_length_eq_height
   obtain ⟨lq, hlq, hlenq⟩ :=
     (P.map (Quotient.mk (p.map (algebraMap R S)))).exists_ltSeries_length_eq_height
-  let l' : LTSeries (PrimeSpectrum S) := lq.map ((Quotient.mk (p.map (algebraMap R S))).specComap)
-    (RingHom.strictMono_specComap_of_surjective Quotient.mk_surjective)
+  let l' : LTSeries (PrimeSpectrum S) :=
+    lq.map (PrimeSpectrum.comap (Quotient.mk (p.map (algebraMap R S))))
+      (RingHom.strictMono_comap_of_surjective Quotient.mk_surjective)
   have : l'.head.asIdeal.LiesOver lp.last.asIdeal := by
     simp only [LTSeries.head_map, hlp, l']
     refine ⟨?_⟩
     refine le_antisymm ?_ ?_
-    · rw [← map_le_iff_le_comap, ← map_le_iff_le_comap]
+    · rw [← map_le_iff_le_comap, PrimeSpectrum.comap_asIdeal, ← map_le_iff_le_comap]
       simp
     · conv_rhs => rw [LiesOver.over (p := p) (P := P), under_def]
       refine comap_mono (le_trans (comap_mono (lq.head_le_last)) ?_)

--- a/Mathlib/RingTheory/KrullDimension/Polynomial.lean
+++ b/Mathlib/RingTheory/KrullDimension/Polynomial.lean
@@ -25,7 +25,7 @@ This file proves properties of the krull dimension of the polynomial ring over a
 theorem Polynomial.ringKrullDim_le {R : Type*} [CommRing R] :
     ringKrullDim (Polynomial R) ≤ 2 * (ringKrullDim R) + 1 := by
   rw [ringKrullDim, ringKrullDim]
-  apply Order.krullDim_le_of_krullDim_preimage_le' C.specComap ?_ (fun p ↦ ?_)
+  apply Order.krullDim_le_of_krullDim_preimage_le' (PrimeSpectrum.comap C) ?_ (fun p ↦ ?_)
   · exact fun {a b} h ↦ Ideal.comap_mono h
   · rw [show C = (algebraMap R (Polynomial R)) from rfl, Order.krullDim_eq_of_orderIso
       (PrimeSpectrum.preimageOrderIsoFiber R (Polynomial R) p), ← ringKrullDim,

--- a/Mathlib/RingTheory/LocalRing/ResidueField/Fiber.lean
+++ b/Mathlib/RingTheory/LocalRing/ResidueField/Fiber.lean
@@ -59,14 +59,14 @@ variable (R S) in
 `p : PrimeSpectrum R` is in bijection with the prime spectrum of `κ(p) ⊗[R] S`. -/
 @[simps]
 noncomputable def PrimeSpectrum.preimageEquivFiber (p : PrimeSpectrum R) :
-    (algebraMap R S).specComap ⁻¹' {p} ≃ PrimeSpectrum (p.asIdeal.Fiber S) where
+    comap (algebraMap R S) ⁻¹' {p} ≃ PrimeSpectrum (p.asIdeal.Fiber S) where
   toFun q := ⟨RingHom.ker (Algebra.TensorProduct.lift
     (Ideal.ResidueField.mapₐ p.asIdeal q.1.asIdeal (Algebra.ofId _ _) congr($(q.2.symm).asIdeal))
       (IsScalarTower.toAlgHom _ _ _) fun _ _ ↦ .all _ _).toRingHom, RingHom.ker_isPrime _⟩
-  invFun q := ⟨Algebra.TensorProduct.includeRight.toRingHom.specComap q, by
-    simp only [AlgHom.toRingHom_eq_coe, Set.mem_preimage, ← specComap_comp_apply,
+  invFun q := ⟨q.comap Algebra.TensorProduct.includeRight.toRingHom, by
+    simp only [AlgHom.toRingHom_eq_coe, Set.mem_preimage, ← comap_comp_apply,
       AlgHom.comp_algebraMap_of_tower]
-    exact (residueField_specComap _).le ⟨(algebraMap _ _).specComap q, rfl⟩⟩
+    exact (residueField_comap _).le ⟨q.comap (algebraMap _ _), rfl⟩⟩
   left_inv q := by ext x; simp
   right_inv q := by
     ext x
@@ -75,9 +75,9 @@ noncomputable def PrimeSpectrum.preimageEquivFiber (p : PrimeSpectrum R) :
     rw [← Ideal.IsPrime.mul_mem_left_iff (x := algebraMap _ _ r), iff_comm,
       ← Ideal.IsPrime.mul_mem_left_iff (x := algebraMap _ _ r), ← Algebra.smul_def, e]
     · simp
-    · rw [← Ideal.mem_comap, ← PrimeSpectrum.specComap_asIdeal]
+    · rw [← Ideal.mem_comap, ← PrimeSpectrum.comap_asIdeal]
       convert hr
-      exact (residueField_specComap _).le ⟨(algebraMap _ _).specComap q, rfl⟩
+      exact (residueField_comap _).le ⟨q.comap (algebraMap _ _), rfl⟩
     · simpa [-Algebra.algebraMap_self, -AlgHom.commutes, -AlgHom.map_algebraMap,
         -Ideal.ResidueField.map_algebraMap]
 
@@ -86,7 +86,7 @@ variable (R S) in
 ideal `p : PrimeSpectrum R` and the prime spectrum of `κ(p) ⊗[R] S`. -/
 @[simps!]
 noncomputable def PrimeSpectrum.preimageOrderIsoFiber (p : PrimeSpectrum R) :
-    (algebraMap R S).specComap ⁻¹' {p} ≃o PrimeSpectrum (p.asIdeal.Fiber S) where
+    comap (algebraMap R S) ⁻¹' {p} ≃o PrimeSpectrum (p.asIdeal.Fiber S) where
   toEquiv := preimageEquivFiber R S p
   map_rel_iff' {q₁ q₂} := by
     constructor
@@ -120,7 +120,7 @@ at a prime ideal `p : PrimeSpectrum R` and the prime spectrum of `κ(p) ⊗[R] S
 @[simps!]
 noncomputable def PrimeSpectrum.preimageHomeomorphFiber (R S : Type*) [CommRing R]
     [CommRing S] [Algebra R S] (p : PrimeSpectrum R) :
-    (algebraMap R S).specComap ⁻¹' {p} ≃ₜ PrimeSpectrum (p.asIdeal.Fiber S) := by
+    comap (algebraMap R S) ⁻¹' {p} ≃ₜ PrimeSpectrum (p.asIdeal.Fiber S) := by
   letI H : Topology.IsEmbedding (preimageOrderIsoFiber R S p).symm := by
     refine (Topology.IsEmbedding.of_comp_iff .subtypeVal).mp ?_
     have := PrimeSpectrum.isEmbedding_tensorProductTo_of_surjectiveOnStalks _ S _

--- a/Mathlib/RingTheory/RingHom/FaithfullyFlat.lean
+++ b/Mathlib/RingTheory/RingHom/FaithfullyFlat.lean
@@ -39,14 +39,14 @@ lemma flat (hf : f.FaithfullyFlat) : f.Flat := by
   exact inferInstanceAs <| Module.Flat R S
 
 lemma iff_flat_and_comap_surjective :
-    f.FaithfullyFlat ↔ f.Flat ∧ Function.Surjective f.specComap := by
+    f.FaithfullyFlat ↔ f.Flat ∧ Function.Surjective (PrimeSpectrum.comap f) := by
   algebraize [f]
   rw [← algebraMap_toAlgebra f, faithfullyFlat_algebraMap_iff, flat_algebraMap_iff]
-  exact ⟨fun h ↦ ⟨inferInstance, PrimeSpectrum.specComap_surjective_of_faithfullyFlat⟩,
-    fun ⟨h, hf⟩ ↦ .of_specComap_surjective hf⟩
+  exact ⟨fun h ↦ ⟨inferInstance, PrimeSpectrum.comap_surjective_of_faithfullyFlat⟩,
+    fun ⟨h, hf⟩ ↦ .of_comap_surjective hf⟩
 
 lemma eq_and : FaithfullyFlat =
-      fun (f : R →+* S) ↦ f.Flat ∧ Function.Surjective f.specComap := by
+      fun (f : R →+* S) ↦ f.Flat ∧ Function.Surjective (PrimeSpectrum.comap f) := by
   ext
   rw [iff_flat_and_comap_surjective]
 
@@ -59,11 +59,11 @@ lemma stableUnderComposition : StableUnderComposition FaithfullyFlat := by
 lemma of_bijective (hf : Function.Bijective f) : f.FaithfullyFlat := by
   rw [iff_flat_and_comap_surjective]
   refine ⟨.of_bijective hf, fun p ↦ ?_⟩
-  use ((RingEquiv.ofBijective f hf).symm : _ →+* _).specComap p
+  use p.comap ((RingEquiv.ofBijective f hf).symm : _ →+* _)
   have : ((RingEquiv.ofBijective f hf).symm : _ →+* _).comp f = id R := by
     ext
     exact (RingEquiv.ofBijective f hf).injective (by simp)
-  rw [← PrimeSpectrum.specComap_comp_apply, this, PrimeSpectrum.specComap_id]
+  rw [← PrimeSpectrum.comap_comp_apply, this, PrimeSpectrum.comap_id]
 
 lemma injective (hf : f.FaithfullyFlat) : Function.Injective ⇑f := by
   algebraize [f]

--- a/Mathlib/RingTheory/Spectrum/Maximal/Localization.lean
+++ b/Mathlib/RingTheory/Spectrum/Maximal/Localization.lean
@@ -215,7 +215,7 @@ variable (f : R →+* S)
 
 /-- A ring homomorphism induces a homomorphism between the products of localizations at primes. -/
 noncomputable def mapPiLocalization : PiLocalization R →+* PiLocalization S :=
-  Pi.ringHom fun I ↦ (Localization.localRingHom _ I.1 f rfl).comp (Pi.evalRingHom _ (f.specComap I))
+  Pi.ringHom fun I ↦ (Localization.localRingHom _ I.1 f rfl).comp (Pi.evalRingHom _ (comap f I))
 
 theorem mapPiLocalization_naturality :
     (mapPiLocalization f).comp (toPiLocalization R) = (toPiLocalization S).comp f := by

--- a/Mathlib/RingTheory/Spectrum/Prime/Chevalley.lean
+++ b/Mathlib/RingTheory/Spectrum/Prime/Chevalley.lean
@@ -47,7 +47,7 @@ lemma isConstructible_comap_image
     rw [range_comap_of_surjective _ f hf]
     exact isRetrocompact_zeroLocus_compl_of_fg hf'
   · intro R _ S _ T _ f g H₁ H₂ s hs
-    simp only [comap_comp, ContinuousMap.coe_comp, Set.image_comp]
+    simp only [comap_comp, Set.image_comp]
     exact H₁ _ (H₂ _ hs)
 
 lemma isConstructible_range_comap {f : R →+* S} (hf : f.FinitePresentation) :

--- a/Mathlib/RingTheory/Spectrum/Prime/ChevalleyComplexity.lean
+++ b/Mathlib/RingTheory/Spectrum/Prime/ChevalleyComplexity.lean
@@ -367,7 +367,7 @@ private lemma induction_aux (R : Type*) [CommRing R] [Algebra R₀ R]
         · exact Set.image_subset_range ..
         · rw [BasicConstructibleSetData.toSet, BasicConstructibleSetData.toSet, Set.preimage_diff,
             preimage_comap_zeroLocus, preimage_comap_zeroLocus, Set.preimage_image_eq]
-          swap; · exact localization_specComap_injective _ (.powers c)
+          swap; · exact localization_comap_injective _ (.powers c)
           simp only [AlgHom.toLinearMap_apply] at hq₁g₁
           simp only [← Set.range_comp, comp_def, AlgHom.toRingHom_eq_coe, RingHom.coe_coe,
             hq₁g₁ _ hxT₁, Set.image_singleton, map_mul, ← hf₁, mul_comm x.1, ← mul_assoc,
@@ -755,11 +755,11 @@ lemma chevalley_mvPolynomialC
   refine ⟨U, ?_, fun C hCU ↦ ⟨(hU₂ C hCU).1.trans ?_,
     fun i ↦ pow_le_pow_right' h1M ?_ <| (hU₂ C hCU).2 i⟩⟩
   · unfold S' at hT₁
-    rw [← hU₁, ← hT₁, ← Set.image_comp, ← ContinuousMap.coe_comp, ← comap_comp,
+    rw [← hU₁, ← hT₁, ← Set.image_comp, ← comap_comp,
       ConstructibleSetData.toSet_map]
     change _ = _ '' ((comapEquiv e.toRingEquiv).symm ⁻¹' _)
     rw [← OrderIso.image_eq_preimage_symm, Set.image_image]
-    simp only [comapEquiv_apply, ← comap_apply, ← comap_comp_apply]
+    simp only [comapEquiv_apply, ← comap_comp_apply]
     congr!
     exact e.symm.toAlgHom.comp_algebraMap.symm
   · refine (numBound_mono hS' _ fun _ _ ↦ ?_).trans
@@ -854,8 +854,8 @@ lemma chevalley_mvPolynomial_mvPolynomial
     · simp [hs]
     · rw [Set.preimage_image_eq _ (comap_injective_of_surjective g hg'),
         Set.preimage_inter, hs, Set.preimage_range, Set.inter_univ,
-        ← Set.preimage_comp, ← ContinuousMap.coe_comp, ← comap_comp, hσ]
-      simp only [comap_id, ContinuousMap.coe_id, Set.preimage_id_eq, id_eq]
+        ← Set.preimage_comp, ← comap_comp, hσ]
+      simp only [comap_id, Set.preimage_id']
   have hS' : comap g '' S.toSet = S'.toSet := by
     simp only [S', BasicConstructibleSetData.toSet, ConstructibleSetData.toSet, Set.image_iUnion₂,
       Finset.set_biUnion_finset_image, ← comp_def (g := finSumFinEquiv.symm), Set.range_comp,
@@ -891,7 +891,7 @@ lemma chevalley_mvPolynomial_mvPolynomial
           simp only [degrees_C, Multiset.zero_union]
           exact degrees_map_le.trans (hf _))
   refine ⟨T, ?_, fun C hCT ↦ ⟨(hT' C hCT).1, fun i j ↦ ?_⟩⟩
-  · rwa [← hg, comap_comp, ContinuousMap.coe_comp, Set.image_comp, hS']
+  · rwa [← hg, comap_comp, Set.image_comp, hS']
   · have := (hT' C hCT).2 i
     rw [← Submodule.restrictScalars_pow (MvPolynomialC.degBound_pos ..).ne', ← degreesLE_nsmul,
       Submodule.restrictScalars_mem, mem_degreesLE,

--- a/Mathlib/RingTheory/Spectrum/Prime/ConstructibleSet.lean
+++ b/Mathlib/RingTheory/Spectrum/Prime/ConstructibleSet.lean
@@ -145,7 +145,7 @@ lemma exists_range_eq_of_isConstructible {R : Type u} [CommRing R]
   obtain ⟨s, rfl⟩ := exists_constructibleSetData_iff.mpr hs
   refine ⟨Π i : s, Localization.Away (Ideal.Quotient.mk (Ideal.span (Set.range i.1.g)) i.1.f),
     inferInstance, algebraMap _ _, ?_⟩
-  rw [coe_comap, ← iUnion_range_specComap_comp_evalRingHom, ConstructibleSetData.toSet]
+  rw [← iUnion_range_comap_comp_evalRingHom, ConstructibleSetData.toSet]
   simp_rw [← Finset.mem_coe, Set.biUnion_eq_iUnion]
   congr! with _ _ C
   let I := Ideal.span (Set.range C.1.g)
@@ -153,9 +153,9 @@ lemma exists_range_eq_of_isConstructible {R : Type u} [CommRing R]
   trans comap (Ideal.Quotient.mk I) '' (Set.range (comap (algebraMap _ (Localization.Away f))))
   · rw [← Set.range_comp]; rfl
   · rw [localization_away_comap_range _ f, ← comap_basicOpen, TopologicalSpace.Opens.coe_comap,
-      Set.image_preimage_eq_inter_range, range_comap_of_surjective _ _ Ideal.Quotient.mk_surjective,
-      BasicConstructibleSetData.toSet, Set.diff_eq_compl_inter, basicOpen_eq_zeroLocus_compl,
-      Ideal.mk_ker, zeroLocus_span]
+      ContinuousMap.coe_mk, Set.image_preimage_eq_inter_range,
+      range_comap_of_surjective _ _ Ideal.Quotient.mk_surjective, BasicConstructibleSetData.toSet,
+      Set.diff_eq_compl_inter, basicOpen_eq_zeroLocus_compl, Ideal.mk_ker, zeroLocus_span]
 
 @[stacks 00I0 "(1)"]
 lemma isClosed_of_stableUnderSpecialization_of_isConstructible {R : Type*} [CommRing R]

--- a/Mathlib/RingTheory/Spectrum/Prime/FreeLocus.lean
+++ b/Mathlib/RingTheory/Spectrum/Prime/FreeLocus.lean
@@ -323,8 +323,8 @@ lemma rankAtStalk_prod (N : Type*) [AddCommGroup N] [Module R N]
   simp [rankAtStalk, e.finrank_eq]
 
 lemma rankAtStalk_baseChange {S : Type*} [CommRing S] [Algebra R S] (p : PrimeSpectrum S) :
-    rankAtStalk (S ⊗[R] M) p = rankAtStalk M ((algebraMap R S).specComap p) := by
-  let q : PrimeSpectrum R := (algebraMap R S).specComap p
+    rankAtStalk (S ⊗[R] M) p = rankAtStalk M (p.comap (algebraMap R S)) := by
+  let q : PrimeSpectrum R := p.comap (algebraMap R S)
   let e : LocalizedModule p.asIdeal.primeCompl (S ⊗[R] M) ≃ₗ[Localization.AtPrime p.asIdeal]
       Localization.AtPrime p.asIdeal ⊗[Localization.AtPrime q.asIdeal]
         LocalizedModule q.asIdeal.primeCompl M :=
@@ -351,7 +351,7 @@ lemma rankAtStalk_tensorProduct (N : Type*) [AddCommGroup N] [Module R N] [Modul
 lemma rankAtStalk_tensorProduct_of_isScalarTower {S : Type*} [CommRing S] [Algebra R S]
     (N : Type*) [AddCommGroup N] [Module R N] [Module S N] [IsScalarTower R S N]
     [Module.Finite S N] [Module.Flat S N] (p : PrimeSpectrum S) :
-    rankAtStalk (N ⊗[R] M) p = rankAtStalk N p * rankAtStalk M ((algebraMap R S).specComap p) := by
+    rankAtStalk (N ⊗[R] M) p = rankAtStalk N p * rankAtStalk M (p.comap (algebraMap R S)) := by
   simp [rankAtStalk_eq_of_equiv (AlgebraTensorModule.cancelBaseChange R S S N M).symm,
     rankAtStalk_tensorProduct, rankAtStalk_baseChange]
 

--- a/Mathlib/RingTheory/Spectrum/Prime/Homeomorph.lean
+++ b/Mathlib/RingTheory/Spectrum/Prime/Homeomorph.lean
@@ -51,8 +51,8 @@ lemma PrimeSpectrum.isHomeomorph_comap (f : R →+* S) (H : ∀ (x : S), ∃ n >
     IsIntegral.of_pow hn (hy ▸ f.kerLift.isIntegralElem_map (x := ⟦y⟧))
   have hbij : Function.Bijective (comap f) :=
     ⟨h1, (comap_quotientMk_bijective_of_le_nilradical hker).2.comp <|
-      hint.specComap_surjective f.kerLift_injective⟩
-  refine ⟨(comap f).continuous, ?_, h1, hbij.2⟩
+      hint.comap_surjective f.kerLift_injective⟩
+  refine ⟨continuous_comap f, ?_, h1, hbij.2⟩
   rw [isTopologicalBasis_basic_opens.isOpenMap_iff]
   rintro - ⟨s, rfl⟩
   obtain ⟨n, hn, r, hr⟩ := H s
@@ -85,7 +85,7 @@ lemma PrimeSpectrum.isHomeomorph_comap_tensorProductMap_of_isPurelyInseparable [
     ext; simp [e, e2]
   rw [heq]
   simp only [AlgEquiv.toAlgHom_eq_coe, AlgHom.toRingHom_eq_coe, AlgHom.comp_toRingHom,
-    AlgEquiv.toAlgHom_toRingHom, IsScalarTower.coe_toAlgHom, comap_comp, ContinuousMap.coe_comp]
+    AlgEquiv.toAlgHom_toRingHom, IsScalarTower.coe_toAlgHom, comap_comp]
   exact (isHomeomorph_comap_of_isPurelyInseparable K L (K ⊗[R] S)).comp <|
     (isHomeomorph_comap_of_bijective e2.symm.bijective).comp <|
     isHomeomorph_comap_of_bijective e.symm.bijective

--- a/Mathlib/RingTheory/Spectrum/Prime/Polynomial.lean
+++ b/Mathlib/RingTheory/Spectrum/Prime/Polynomial.lean
@@ -169,7 +169,7 @@ lemma comap_C_surjective : Function.Surjective (comap (R := R) C) := by
   intro x
   refine ⟨comap (evalRingHom 0) x, ?_⟩
   rw [← comap_comp_apply, (show (evalRingHom 0).comp C = .id R by ext; simp),
-    comap_id, ContinuousMap.id_apply]
+    comap_id]
 
 lemma exists_image_comap_of_monic (f g : R[X]) (hg : g.Monic) :
     ∃ t : Finset R, comap C '' (zeroLocus {g} \ zeroLocus {f}) = (zeroLocus t)ᶜ := by
@@ -232,6 +232,6 @@ lemma comap_C_surjective : Function.Surjective (comap (R := R) (C (σ := σ))) :
   intro x
   refine ⟨comap (eval₂Hom (.id _) 0) x, ?_⟩
   rw [← comap_comp_apply, (show (eval₂Hom (.id _) 0).comp C = .id R by ext; simp),
-    comap_id, ContinuousMap.id_apply]
+    comap_id]
 
 end MvPolynomial

--- a/Mathlib/RingTheory/Spectrum/Prime/RingHom.lean
+++ b/Mathlib/RingTheory/Spectrum/Prime/RingHom.lean
@@ -35,8 +35,7 @@ def PrimeSpectrum.comap {R S : Type*} [CommSemiring R] [CommSemiring S] (f : R �
     (p : PrimeSpectrum S) : PrimeSpectrum R :=
   ⟨Ideal.comap f p.asIdeal, inferInstance⟩
 
-@[deprecated (since := "2025-12-10")]
-alias RingHom.specComap := PrimeSpectrum.comap
+@[deprecated (since := "2025-12-10")] alias RingHom.specComap := PrimeSpectrum.comap
 
 namespace PrimeSpectrum
 
@@ -51,18 +50,26 @@ theorem comap_asIdeal (y : PrimeSpectrum S) :
     (comap f y).asIdeal = Ideal.comap f y.asIdeal :=
   rfl
 
+@[deprecated (since := "2025-12-10")] alias specComap_asIdeal := comap_asIdeal
+
 @[simp]
 theorem comap_id : comap (RingHom.id R) = fun x => x :=
   rfl
+
+@[deprecated (since := "2025-12-10")] alias specComap_id := comap_id
 
 @[simp]
 theorem comap_comp (f : R →+* S) (g : S →+* S') :
     comap (g.comp f) = (comap f).comp (comap g) :=
   rfl
 
+@[deprecated (since := "2025-12-10")] alias specComap_comp := comap_comp
+
 theorem comap_comp_apply (f : R →+* S) (g : S →+* S') (x : PrimeSpectrum S') :
     comap (g.comp f) x = comap f (comap g x) :=
   rfl
+
+@[deprecated (since := "2025-12-10")] alias specComap_comp_apply := comap_comp_apply
 
 theorem preimage_comap_zeroLocus_aux (f : R →+* S) (s : Set R) :
     comap f ⁻¹' zeroLocus s = zeroLocus (f '' s) := by
@@ -74,11 +81,16 @@ theorem preimage_comap_zeroLocus (s : Set R) :
     comap f ⁻¹' zeroLocus s = zeroLocus (f '' s) :=
   preimage_comap_zeroLocus_aux f s
 
+@[deprecated (since := "2025-12-10")] alias preimage_specComap_zeroLocus := preimage_comap_zeroLocus
+
 theorem comap_injective_of_surjective (f : R →+* S) (hf : Function.Surjective f) :
     Function.Injective (comap f) := fun x y h =>
   PrimeSpectrum.ext
     (Ideal.comap_injective_of_surjective f hf
       (congr_arg PrimeSpectrum.asIdeal h : (comap f x).asIdeal = (comap f y).asIdeal))
+
+@[deprecated (since := "2025-12-10")]
+alias specComap_injective_of_surjective := comap_injective_of_surjective
 
 instance [Algebra R S] (p : PrimeSpectrum S) :
     p.asIdeal.LiesOver (p.comap <| algebraMap R S).asIdeal where
@@ -229,11 +241,17 @@ theorem image_comap_zeroLocus_eq_zeroLocus_comap (hf : Surjective f) (I : Ideal 
       refine p.asIdeal.sub_mem hx' (hp ?_)
       rwa [mem_ker, map_sub, sub_eq_zero]
 
+@[deprecated (since := "2025-12-10")]
+alias image_specComap_zeroLocus_eq_zeroLocus_comap := image_comap_zeroLocus_eq_zeroLocus_comap
+
 theorem range_comap_of_surjective (hf : Surjective f) :
     Set.range (comap f) = zeroLocus (ker f) := by
   rw [← Set.image_univ]
   convert image_comap_zeroLocus_eq_zeroLocus_comap _ _ hf _
   rw [zeroLocus_bot]
+
+@[deprecated (since := "2025-12-10")]
+alias range_specComap_of_surjective := range_comap_of_surjective
 
 variable {S}
 
@@ -294,6 +312,9 @@ lemma RingHom.strictMono_comap_of_surjective {S : Type*} [CommRing S]
     {f : R →+* S} (hf : Function.Surjective f) : StrictMono (comap f) :=
   fun _ _ h ↦ (Ideal.relIsoOfSurjective _ hf).strictMono h
 
+@[deprecated (since := "2025-12-10")]
+alias RingHom.strictMono_specComap_of_surjective := RingHom.strictMono_comap_of_surjective
+
 end SpecOfSurjective
 
 section ResidueField
@@ -304,6 +325,9 @@ lemma PrimeSpectrum.residueField_comap (I : PrimeSpectrum R) :
     Set.range (comap (algebraMap R I.asIdeal.ResidueField)) = {I} := by
   rw [Set.range_unique, Set.singleton_eq_singleton_iff]
   exact PrimeSpectrum.ext (Ideal.ext fun x ↦ Ideal.algebraMap_residueField_eq_zero)
+
+@[deprecated (since := "2025-12-10")]
+alias PrimeSpectrum.residueField_specComap := PrimeSpectrum.residueField_comap
 
 end ResidueField
 
@@ -316,3 +340,6 @@ theorem IsLocalHom.of_comap_surjective [CommSemiring R] [CommSemiring S] (f : R 
     obtain ⟨⟨q, hqp⟩, hq⟩ := hf ⟨p, hp.isPrime⟩
     simp only [PrimeSpectrum.ext_iff, comap_asIdeal] at hq
     exact hqp.ne_top (q.eq_top_of_isUnit_mem (q.mem_comap.mp (by rwa [hq])) hfx)
+
+@[deprecated (since := "2025-12-10")]
+alias IsLocalHom.of_specComap_surjective := IsLocalHom.of_comap_surjective

--- a/Mathlib/RingTheory/Spectrum/Prime/RingHom.lean
+++ b/Mathlib/RingTheory/Spectrum/Prime/RingHom.lean
@@ -16,8 +16,8 @@ In this file we define the induced map on prime spectra induced by a ring homomo
 
 ## Main definitions
 
-* `RingHom.specComap`: The induced map on prime spectra by a ring homomorphism. The bundled
-  continuous version is `PrimeSpectrum.comap` in `Mathlib/RingTheory/Spectrum/Prime/Topology.lean`.
+* `PrimeSpectrum.comap`: The induced map on prime spectra by a ring homomorphism. The proof that
+  it is continuous is in `Mathlib/RingTheory/Spectrum/Prime/Topology.lean`.
 
 -/
 
@@ -31,9 +31,12 @@ open PrimeSpectrum
 
 /-- The pullback of an element of `PrimeSpectrum S` along a ring homomorphism `f : R →+* S`.
 The bundled continuous version is `PrimeSpectrum.comap`. -/
-abbrev RingHom.specComap {R S : Type*} [CommSemiring R] [CommSemiring S] (f : R →+* S) :
-    PrimeSpectrum S → PrimeSpectrum R :=
-  fun y => ⟨Ideal.comap f y.asIdeal, inferInstance⟩
+def PrimeSpectrum.comap {R S : Type*} [CommSemiring R] [CommSemiring S] (f : R →+* S)
+    (p : PrimeSpectrum S) : PrimeSpectrum R :=
+  ⟨Ideal.comap f p.asIdeal, inferInstance⟩
+
+@[deprecated (since := "2025-12-10")]
+alias RingHom.specComap := PrimeSpectrum.comap
 
 namespace PrimeSpectrum
 
@@ -41,53 +44,57 @@ open RingHom
 
 variable {R S} {S' : Type*} [CommSemiring R] [CommSemiring S] [CommSemiring S']
 
-theorem preimage_specComap_zeroLocus_aux (f : R →+* S) (s : Set R) :
-    f.specComap ⁻¹' zeroLocus s = zeroLocus (f '' s) := by
-  ext x
-  simp only [mem_zeroLocus, Set.image_subset_iff, Set.mem_preimage, mem_zeroLocus, Ideal.coe_comap]
-
 variable (f : R →+* S)
 
 @[simp]
-theorem specComap_asIdeal (y : PrimeSpectrum S) :
-    (f.specComap y).asIdeal = Ideal.comap f y.asIdeal :=
+theorem comap_asIdeal (y : PrimeSpectrum S) :
+    (comap f y).asIdeal = Ideal.comap f y.asIdeal :=
   rfl
 
 @[simp]
-theorem specComap_id : (RingHom.id R).specComap = fun x => x :=
+theorem comap_id : comap (RingHom.id R) = fun x => x :=
   rfl
 
 @[simp]
-theorem specComap_comp (f : R →+* S) (g : S →+* S') :
-    (g.comp f).specComap = f.specComap.comp g.specComap :=
+theorem comap_comp (f : R →+* S) (g : S →+* S') :
+    comap (g.comp f) = (comap f).comp (comap g) :=
   rfl
 
-theorem specComap_comp_apply (f : R →+* S) (g : S →+* S') (x : PrimeSpectrum S') :
-    (g.comp f).specComap x = f.specComap (g.specComap x) :=
+theorem comap_comp_apply (f : R →+* S) (g : S →+* S') (x : PrimeSpectrum S') :
+    comap (g.comp f) x = comap f (comap g x) :=
   rfl
+
+theorem preimage_comap_zeroLocus_aux (f : R →+* S) (s : Set R) :
+    comap f ⁻¹' zeroLocus s = zeroLocus (f '' s) := by
+  ext x
+  simp [mem_zeroLocus, Set.image_subset_iff, Set.mem_preimage, mem_zeroLocus]
 
 @[simp]
-theorem preimage_specComap_zeroLocus (s : Set R) :
-    f.specComap ⁻¹' zeroLocus s = zeroLocus (f '' s) :=
-  preimage_specComap_zeroLocus_aux f s
+theorem preimage_comap_zeroLocus (s : Set R) :
+    comap f ⁻¹' zeroLocus s = zeroLocus (f '' s) :=
+  preimage_comap_zeroLocus_aux f s
 
-theorem specComap_injective_of_surjective (f : R →+* S) (hf : Function.Surjective f) :
-    Function.Injective f.specComap := fun x y h =>
+theorem comap_injective_of_surjective (f : R →+* S) (hf : Function.Surjective f) :
+    Function.Injective (comap f) := fun x y h =>
   PrimeSpectrum.ext
     (Ideal.comap_injective_of_surjective f hf
-      (congr_arg PrimeSpectrum.asIdeal h : (f.specComap x).asIdeal = (f.specComap y).asIdeal))
+      (congr_arg PrimeSpectrum.asIdeal h : (comap f x).asIdeal = (comap f y).asIdeal))
 
-/-- `RingHom.specComap` of an isomorphism of rings as an equivalence of their prime spectra. -/
+instance [Algebra R S] (p : PrimeSpectrum S) :
+    p.asIdeal.LiesOver (p.comap <| algebraMap R S).asIdeal where
+  over := rfl
+
+/-- `RingHom.comap` of an isomorphism of rings as an equivalence of their prime spectra. -/
 @[simps apply symm_apply]
 def comapEquiv (e : R ≃+* S) : PrimeSpectrum R ≃o PrimeSpectrum S where
-  toFun := e.symm.toRingHom.specComap
-  invFun := e.toRingHom.specComap
+  toFun := comap e.symm.toRingHom
+  invFun := comap e.toRingHom
   left_inv x := by
-    rw [← specComap_comp_apply, RingEquiv.toRingHom_eq_coe,
+    rw [← comap_comp_apply, RingEquiv.toRingHom_eq_coe,
       RingEquiv.toRingHom_eq_coe, RingEquiv.symm_comp]
     rfl
   right_inv x := by
-    rw [← specComap_comp_apply, RingEquiv.toRingHom_eq_coe,
+    rw [← comap_comp_apply, RingEquiv.toRingHom_eq_coe,
       RingEquiv.toRingHom_eq_coe, RingEquiv.comp_symm]
     rfl
   map_rel_iff' {I J} := Ideal.comap_le_comap_iff_of_surjective _ e.symm.surjective ..
@@ -100,8 +107,8 @@ variable {ι} (R : ι → Type*) [∀ i, CommSemiring (R i)]
 the prime spectrum of the product semiring. -/
 /- TODO: show this is always a topological embedding (even when ι is infinite)
 and is a homeomorphism when ι is finite. -/
-@[simps] def sigmaToPi : (Σ i, PrimeSpectrum (R i)) → PrimeSpectrum (Π i, R i)
-  | ⟨i, p⟩ => (Pi.evalRingHom R i).specComap p
+@[simps! asIdeal] def sigmaToPi : (Σ i, PrimeSpectrum (R i)) → PrimeSpectrum (Π i, R i)
+  | ⟨i, p⟩ => comap (Pi.evalRingHom R i) p
 
 theorem sigmaToPi_injective : (sigmaToPi R).Injective := fun ⟨i, p⟩ ⟨j, q⟩ eq ↦ by
   classical
@@ -152,7 +159,7 @@ theorem sigmaToPi_not_surjective_of_infinite : ¬ (sigmaToPi R).Surjective := fu
 lemma exists_comap_evalRingHom_eq
     {ι : Type*} {R : ι → Type*} [∀ i, CommRing (R i)] [Finite ι]
     (p : PrimeSpectrum (Π i, R i)) :
-    ∃ (i : ι) (q : PrimeSpectrum (R i)), (Pi.evalRingHom R i).specComap q = p := by
+    ∃ (i : ι) (q : PrimeSpectrum (R i)), comap (Pi.evalRingHom R i) q = p := by
   classical
   cases nonempty_fintype ι
   let e (i) : Π i, R i := Function.update 1 i 0
@@ -181,11 +188,11 @@ lemma sigmaToPi_bijective {ι : Type*} (R : ι → Type*) [∀ i, CommRing (R i)
   obtain ⟨i, q, rfl⟩ := exists_comap_evalRingHom_eq q
   exact ⟨⟨i, q⟩, rfl⟩
 
-lemma iUnion_range_specComap_comp_evalRingHom
+lemma iUnion_range_comap_comp_evalRingHom
     {ι : Type*} {R : ι → Type*} [∀ i, CommRing (R i)] [Finite ι]
     {S : Type*} [CommRing S] (f : S →+* Π i, R i) :
-    ⋃ i, Set.range ((Pi.evalRingHom R i).comp f).specComap = Set.range f.specComap := by
-  simp_rw [specComap_comp]
+    ⋃ i, Set.range (comap ((Pi.evalRingHom R i).comp f)) = Set.range (comap f) := by
+  simp_rw [comap_comp]
   apply subset_antisymm
   · exact Set.iUnion_subset fun _ ↦ Set.range_comp_subset_range _ _
   · rintro _ ⟨p, rfl⟩
@@ -204,8 +211,8 @@ variable [CommRing R] [CommRing S]
 variable (f : R →+* S)
 variable {R}
 
-theorem image_specComap_zeroLocus_eq_zeroLocus_comap (hf : Surjective f) (I : Ideal S) :
-    f.specComap '' zeroLocus I = zeroLocus (I.comap f) := by
+theorem image_comap_zeroLocus_eq_zeroLocus_comap (hf : Surjective f) (I : Ideal S) :
+    comap f '' zeroLocus I = zeroLocus (I.comap f) := by
   simp only [Set.ext_iff, Set.mem_image, mem_zeroLocus, SetLike.coe_subset_coe]
   refine fun p => ⟨?_, fun h_I_p => ?_⟩
   · rintro ⟨p, hp, rfl⟩ a ha
@@ -215,17 +222,17 @@ theorem image_specComap_zeroLocus_eq_zeroLocus_comap (hf : Surjective f) (I : Id
     · obtain ⟨x', rfl⟩ := hf x
       exact Ideal.mem_map_of_mem f (h_I_p hx)
     · ext x
-      rw [specComap_asIdeal, Ideal.mem_comap, Ideal.mem_map_iff_of_surjective f hf]
+      rw [comap_asIdeal, Ideal.mem_comap, Ideal.mem_map_iff_of_surjective f hf]
       refine ⟨?_, fun hx => ⟨x, hx, rfl⟩⟩
       rintro ⟨x', hx', heq⟩
       rw [← sub_sub_cancel x' x]
       refine p.asIdeal.sub_mem hx' (hp ?_)
       rwa [mem_ker, map_sub, sub_eq_zero]
 
-theorem range_specComap_of_surjective (hf : Surjective f) :
-    Set.range f.specComap = zeroLocus (ker f) := by
+theorem range_comap_of_surjective (hf : Surjective f) :
+    Set.range (comap f) = zeroLocus (ker f) := by
   rw [← Set.image_univ]
-  convert image_specComap_zeroLocus_eq_zeroLocus_comap _ _ hf _
+  convert image_comap_zeroLocus_eq_zeroLocus_comap _ _ hf _
   rw [zeroLocus_bot]
 
 variable {S}
@@ -234,7 +241,7 @@ variable {S}
   where `I = ker f`. -/
 noncomputable def Ideal.primeSpectrumOrderIsoZeroLocusOfSurj (hf : Surjective f) {I : Ideal R}
     (hI : RingHom.ker f = I) : PrimeSpectrum S ≃o (PrimeSpectrum.zeroLocus (R := R) I) where
-  toFun p := ⟨f.specComap p, hI.symm.trans_le (Ideal.ker_le_comap f)⟩
+  toFun p := ⟨p.comap f, hI.symm.trans_le (Ideal.ker_le_comap f)⟩
   invFun := fun ⟨⟨p, _⟩, hp⟩ ↦ ⟨p.map f, p.map_isPrime_of_surjective hf (hI.trans_le hp)⟩
   left_inv := by
     intro ⟨p, _⟩
@@ -242,7 +249,7 @@ noncomputable def Ideal.primeSpectrumOrderIsoZeroLocusOfSurj (hf : Surjective f)
     exact p.map_comap_of_surjective f hf
   right_inv := by
     intro ⟨⟨p, _⟩, hp⟩
-    simp only [Subtype.mk.injEq, PrimeSpectrum.mk.injEq]
+    simp only [Subtype.mk.injEq, PrimeSpectrum.ext_iff, comap_asIdeal]
     exact (p.comap_map_of_surjective f hf).trans <| sup_eq_left.mpr (hI.trans_le hp)
   map_rel_iff' {a b} := by
     change a.asIdeal.comap _ ≤ b.asIdeal.comap _ ↔ a ≤ b
@@ -257,7 +264,7 @@ noncomputable def Ideal.primeSpectrumQuotientOrderIsoZeroLocus (I : Ideal R) :
 /-- `p` is in the image of `Spec S → Spec R` if and only if `p` extended to `S` and
 restricted back to `R` is `p`. -/
 lemma PrimeSpectrum.mem_range_comap_iff {p : PrimeSpectrum R} :
-    p ∈ Set.range f.specComap ↔ (p.asIdeal.map f).comap f = p.asIdeal := by
+    p ∈ Set.range (comap f) ↔ (p.asIdeal.map f).comap f = p.asIdeal := by
   refine ⟨fun ⟨q, hq⟩ ↦ by simp [← hq], ?_⟩
   rw [Ideal.comap_map_eq_self_iff_of_isPrime]
   rintro ⟨q, _, hq⟩
@@ -268,14 +275,14 @@ open TensorProduct
 /-- A prime `p` is in the range of `Spec S → Spec R` if the fiber over `p` is nontrivial. -/
 lemma PrimeSpectrum.nontrivial_iff_mem_rangeComap {S : Type*} [CommRing S]
     [Algebra R S] (p : PrimeSpectrum R) :
-    Nontrivial (p.asIdeal.ResidueField ⊗[R] S) ↔ p ∈ Set.range (algebraMap R S).specComap := by
+    Nontrivial (p.asIdeal.ResidueField ⊗[R] S) ↔ p ∈ Set.range (comap (algebraMap R S)) := by
   let k := p.asIdeal.ResidueField
   refine ⟨fun h ↦ ?_, fun h ↦ ?_⟩
   · obtain ⟨m, hm⟩ := Ideal.exists_maximal (k ⊗[R] S)
-    use (Algebra.TensorProduct.includeRight).specComap ⟨m, hm.isPrime⟩
+    use PrimeSpectrum.comap (Algebra.TensorProduct.includeRight).toRingHom ⟨m, hm.isPrime⟩
     ext : 1
-    rw [← PrimeSpectrum.specComap_comp_apply,
-      ← Algebra.TensorProduct.includeLeftRingHom_comp_algebraMap, specComap_comp_apply]
+    rw [← PrimeSpectrum.comap_comp_apply,
+      ← Algebra.TensorProduct.includeLeftRingHom_comp_algebraMap, comap_comp_apply]
     simp [Ideal.eq_bot_of_prime, k, ← RingHom.ker_eq_comap_bot]
   · obtain ⟨q, rfl⟩ := h
     let f : k ⊗[R] S →ₐ[R] q.asIdeal.ResidueField :=
@@ -283,8 +290,8 @@ lemma PrimeSpectrum.nontrivial_iff_mem_rangeComap {S : Type*} [CommRing S]
         (IsScalarTower.toAlgHom _ _ _) (fun _ _ ↦ Commute.all ..)
     exact RingHom.domain_nontrivial f.toRingHom
 
-lemma RingHom.strictMono_specComap_of_surjective {S : Type*} [CommRing S]
-    {f : R →+* S} (hf : Function.Surjective f) : StrictMono f.specComap :=
+lemma RingHom.strictMono_comap_of_surjective {S : Type*} [CommRing S]
+    {f : R →+* S} (hf : Function.Surjective f) : StrictMono (comap f) :=
   fun _ _ h ↦ (Ideal.relIsoOfSurjective _ hf).strictMono h
 
 end SpecOfSurjective
@@ -293,19 +300,19 @@ section ResidueField
 
 variable {R : Type*} [CommRing R]
 
-lemma PrimeSpectrum.residueField_specComap (I : PrimeSpectrum R) :
-    Set.range (algebraMap R I.asIdeal.ResidueField).specComap = {I} := by
+lemma PrimeSpectrum.residueField_comap (I : PrimeSpectrum R) :
+    Set.range (comap (algebraMap R I.asIdeal.ResidueField)) = {I} := by
   rw [Set.range_unique, Set.singleton_eq_singleton_iff]
   exact PrimeSpectrum.ext (Ideal.ext fun x ↦ Ideal.algebraMap_residueField_eq_zero)
 
 end ResidueField
 
 variable {R S} in
-theorem IsLocalHom.of_specComap_surjective [CommSemiring R] [CommSemiring S] (f : R →+* S)
-    (hf : Function.Surjective f.specComap) : IsLocalHom f where
+theorem IsLocalHom.of_comap_surjective [CommSemiring R] [CommSemiring S] (f : R →+* S)
+    (hf : Function.Surjective (comap f)) : IsLocalHom f where
   map_nonunit x hfx := by
     by_contra hx
     obtain ⟨p, hp, _⟩ := exists_max_ideal_of_mem_nonunits hx
     obtain ⟨⟨q, hqp⟩, hq⟩ := hf ⟨p, hp.isPrime⟩
-    simp only [PrimeSpectrum.mk.injEq] at hq
+    simp only [PrimeSpectrum.ext_iff, comap_asIdeal] at hq
     exact hqp.ne_top (q.eq_top_of_isUnit_mem (q.mem_comap.mp (by rwa [hq])) hfx)

--- a/Mathlib/RingTheory/Spectrum/Prime/RingHom.lean
+++ b/Mathlib/RingTheory/Spectrum/Prime/RingHom.lean
@@ -211,6 +211,9 @@ lemma iUnion_range_comap_comp_evalRingHom
     obtain ⟨i, p, rfl⟩ := exists_comap_evalRingHom_eq p
     exact Set.mem_iUnion_of_mem i ⟨p, rfl⟩
 
+@[deprecated (since := "2025-12-11")]
+alias iUnion_range_specComap_comp_evalRingHom := iUnion_range_comap_comp_evalRingHom
+
 end Pi
 
 end PrimeSpectrum

--- a/Mathlib/RingTheory/Spectrum/Prime/TensorProduct.lean
+++ b/Mathlib/RingTheory/Spectrum/Prime/TensorProduct.lean
@@ -34,7 +34,7 @@ def PrimeSpectrum.tensorProductTo (x : PrimeSpectrum (S ⊗[R] T)) :
 
 @[fun_prop]
 lemma PrimeSpectrum.continuous_tensorProductTo : Continuous (tensorProductTo R S T) :=
-  (comap _).2.prodMk (comap _).2
+  (continuous_comap _).prodMk (continuous_comap _)
 
 variable (hRT : (algebraMap R T).SurjectiveOnStalks)
 include hRT

--- a/Mathlib/RingTheory/Spectrum/Prime/Topology.lean
+++ b/Mathlib/RingTheory/Spectrum/Prime/Topology.lean
@@ -324,58 +324,27 @@ section Comap
 
 variable {S' : Type*} [CommSemiring S']
 
-/-- The continuous function between prime spectra of commutative (semi)rings induced by a ring
-homomorphism. -/
-def comap (f : R →+* S) : C(PrimeSpectrum S, PrimeSpectrum R) where
-  toFun := f.specComap
-  continuous_toFun := by
-    simp only [continuous_iff_isClosed, isClosed_iff_zeroLocus]
-    rintro _ ⟨s, rfl⟩
-    exact ⟨_, preimage_specComap_zeroLocus_aux f s⟩
-
-lemma coe_comap (f : R →+* S) : comap f = f.specComap := rfl
-
-lemma comap_apply (f : R →+* S) (x) : comap f x = f.specComap x := rfl
+@[fun_prop]
+lemma continuous_comap (f : R →+* S) : Continuous (comap f) := by
+  simp only [continuous_iff_isClosed, isClosed_iff_zeroLocus]
+  rintro _ ⟨s, rfl⟩
+  exact ⟨_, preimage_comap_zeroLocus_aux f s⟩
 
 variable (f : R →+* S)
 
-@[simp]
-theorem comap_asIdeal (y : PrimeSpectrum S) : (comap f y).asIdeal = Ideal.comap f y.asIdeal :=
-  rfl
-
-@[simp]
-theorem comap_id : comap (RingHom.id R) = ContinuousMap.id _ := by
-  ext
-  rfl
-
-@[simp]
-theorem comap_comp (f : R →+* S) (g : S →+* S') : comap (g.comp f) = (comap f).comp (comap g) :=
-  rfl
-
-theorem comap_comp_apply (f : R →+* S) (g : S →+* S') (x : PrimeSpectrum S') :
-    PrimeSpectrum.comap (g.comp f) x = (PrimeSpectrum.comap f) (PrimeSpectrum.comap g x) :=
-  rfl
-
-@[simp]
-theorem preimage_comap_zeroLocus (s : Set R) : comap f ⁻¹' zeroLocus s = zeroLocus (f '' s) :=
-  preimage_specComap_zeroLocus_aux f s
-
-theorem comap_injective_of_surjective (f : R →+* S) (hf : Function.Surjective f) :
-    Function.Injective (comap f) := fun _ _ h => specComap_injective_of_surjective _ hf h
-
 variable (S)
 
-theorem localization_specComap_injective [Algebra R S] (M : Submonoid R) [IsLocalization M S] :
-    Function.Injective (algebraMap R S).specComap := by
+theorem localization_comap_injective [Algebra R S] (M : Submonoid R) [IsLocalization M S] :
+    Function.Injective (comap (algebraMap R S)) := by
   intro p q h
   replace h := _root_.congr_arg (fun x : PrimeSpectrum R => Ideal.map (algebraMap R S) x.asIdeal) h
-  dsimp only [RingHom.specComap] at h
+  dsimp only [comap] at h
   rw [IsLocalization.map_comap M S, IsLocalization.map_comap M S] at h
   ext1
   exact h
 
-theorem localization_specComap_range [Algebra R S] (M : Submonoid R) [IsLocalization M S] :
-    Set.range (algebraMap R S).specComap = { p | Disjoint (M : Set R) p.asIdeal } := by
+theorem localization_comap_range [Algebra R S] (M : Submonoid R) [IsLocalization M S] :
+    Set.range (comap (algebraMap R S)) = { p | Disjoint (M : Set R) p.asIdeal } := by
   refine Set.ext fun x ↦ ⟨?_, fun h ↦ ?_⟩
   · rintro ⟨p, rfl⟩
     exact ((IsLocalization.isPrime_iff_isPrime_disjoint ..).mp p.2).2
@@ -395,17 +364,9 @@ theorem localization_comap_isInducing [Algebra R S] (M : Submonoid R) [IsLocaliz
   · rintro ⟨s, rfl⟩
     exact ⟨_, rfl⟩
 
-theorem localization_comap_injective [Algebra R S] (M : Submonoid R) [IsLocalization M S] :
-    Function.Injective (comap (algebraMap R S)) :=
-  fun _ _ h => localization_specComap_injective S M h
-
 theorem localization_comap_isEmbedding [Algebra R S] (M : Submonoid R) [IsLocalization M S] :
     IsEmbedding (comap (algebraMap R S)) :=
   ⟨localization_comap_isInducing S M, localization_comap_injective S M⟩
-
-theorem localization_comap_range [Algebra R S] (M : Submonoid R) [IsLocalization M S] :
-    Set.range (comap (algebraMap R S)) = { p | Disjoint (M : Set R) p.asIdeal } :=
-  localization_specComap_range ..
 
 open Function RingHom
 
@@ -457,14 +418,6 @@ theorem comap_singleton_isClosed_of_surjective (f : R →+* S) (hf : Function.Su
     IsClosed ({comap f x} : Set (PrimeSpectrum R)) :=
   haveI : x.asIdeal.IsMaximal := (isClosed_singleton_iff_isMaximal x).1 hx
   (isClosed_singleton_iff_isMaximal _).2 (Ideal.comap_isMaximal_of_surjective f hf)
-
-theorem image_comap_zeroLocus_eq_zeroLocus_comap (hf : Surjective f) (I : Ideal S) :
-    comap f '' zeroLocus I = zeroLocus (I.comap f) :=
-  image_specComap_zeroLocus_eq_zeroLocus_comap _ f hf I
-
-theorem range_comap_of_surjective (hf : Surjective f) :
-    Set.range (comap f) = zeroLocus (ker f) :=
-  range_specComap_of_surjective _ f hf
 
 lemma comap_quotientMk_bijective_of_le_nilradical {I : Ideal R} (hle : I ≤ nilradical R) :
     Function.Bijective (comap <| Ideal.Quotient.mk I) := by
@@ -532,7 +485,7 @@ def primeSpectrumProdHomeo :
     (Equiv.injective _) ?_).isInducing
   · rw [continuous_sum_dom]
     simp only [Function.comp_def, primeSpectrumProd_symm_inl, primeSpectrumProd_symm_inr]
-    exact ⟨(comap _).2, (comap _).2⟩
+    exact ⟨continuous_comap _, continuous_comap _⟩
   · simp_rw [isClosedMap_sum, primeSpectrumProd_symm_inl, primeSpectrumProd_symm_inr]
     exact ⟨isClosedEmbedding_comap_fst.isClosedMap, isClosedEmbedding_comap_snd.isClosedMap⟩
 
@@ -647,10 +600,10 @@ theorem localization_away_isOpenEmbedding (S : Type v) [CommSemiring S] [Algebra
 
 theorem isCompact_basicOpen (f : R) : IsCompact (basicOpen f : Set (PrimeSpectrum R)) := by
   rw [← localization_away_comap_range (Localization (Submonoid.powers f))]
-  exact isCompact_range (map_continuous _)
+  exact isCompact_range (continuous_comap _)
 
 lemma comap_basicOpen (f : R →+* S) (x : R) :
-    TopologicalSpace.Opens.comap (comap f) (basicOpen x) = basicOpen (f x) :=
+    TopologicalSpace.Opens.comap ⟨comap f, continuous_comap f⟩ (basicOpen x) = basicOpen (f x) :=
   rfl
 
 open TopologicalSpace in
@@ -854,7 +807,7 @@ quotient topology induced by `f`. -/
 lemma isQuotientMap_of_specializingMap (h₂ : SpecializingMap (comap f)) :
     Topology.IsQuotientMap (comap f) := by
   rw [Topology.isQuotientMap_iff_isClosed]
-  exact ⟨h₁, fun s ↦ ⟨fun hs ↦ hs.preimage (comap f).continuous,
+  exact ⟨h₁, fun s ↦ ⟨fun hs ↦ hs.preimage (continuous_comap f),
     fun hsc ↦ Set.image_preimage_eq s h₁ ▸ isClosed_image_of_stableUnderSpecialization _ _ hsc
       (h₂.stableUnderSpecialization_image hsc.stableUnderSpecialization)⟩⟩
 
@@ -863,7 +816,7 @@ quotient topology induced by `f`. -/
 lemma isQuotientMap_of_generalizingMap (h₂ : GeneralizingMap (comap f)) :
     Topology.IsQuotientMap (comap f) := by
   rw [Topology.isQuotientMap_iff_isClosed]
-  refine ⟨h₁, fun s ↦ ⟨fun hs ↦ hs.preimage (comap f).continuous,
+  refine ⟨h₁, fun s ↦ ⟨fun hs ↦ hs.preimage (continuous_comap f),
     fun hsc ↦ Set.image_preimage_eq s h₁ ▸ ?_⟩⟩
   apply isClosed_image_of_stableUnderSpecialization _ _ hsc
   rw [Set.image_preimage_eq s h₁, ← stableUnderGeneralization_compl_iff]
@@ -1152,8 +1105,8 @@ lemma isIntegral_of_isClosedMap_comap_mapRingHom (h : IsClosedMap (comap (mapRin
       eval_mul, reflect_sub, reflect_mul _ _ (by simp) (by simp)]
     simp [← pow_succ']
 
-lemma _root_.RingHom.IsIntegral.specComap_surjective {f : R →+* S} (hf : f.IsIntegral)
-    (hinj : Function.Injective f) : Function.Surjective f.specComap := by
+lemma _root_.RingHom.IsIntegral.comap_surjective {f : R →+* S} (hf : f.IsIntegral)
+    (hinj : Function.Injective f) : Function.Surjective (comap f) := by
   algebraize [f]
   intro ⟨p, hp⟩
   obtain ⟨Q, _, hQ, rfl⟩ := Ideal.exists_ideal_over_prime_of_isIntegral p (⊥ : Ideal S)

--- a/Mathlib/RingTheory/Spectrum/Prime/Topology.lean
+++ b/Mathlib/RingTheory/Spectrum/Prime/Topology.lean
@@ -330,7 +330,9 @@ lemma continuous_comap (f : R →+* S) : Continuous (comap f) := by
   rintro _ ⟨s, rfl⟩
   exact ⟨_, preimage_comap_zeroLocus_aux f s⟩
 
-@[deprecated (since := "2025-12-10")] alias comap_apply := continuous_comap
+@[deprecated "RingHom.specComap and PrimeSpectrum.comap were unified,\
+so this lemma is now a no-op." (since := "2025-12-10")]
+lemma comap_apply (f : R →+* S) (x : PrimeSpectrum S) : comap f x = comap f x := rfl
 
 variable (f : R →+* S)
 

--- a/Mathlib/RingTheory/Spectrum/Prime/Topology.lean
+++ b/Mathlib/RingTheory/Spectrum/Prime/Topology.lean
@@ -331,7 +331,7 @@ lemma continuous_comap (f : R →+* S) : Continuous (comap f) := by
   exact ⟨_, preimage_comap_zeroLocus_aux f s⟩
 
 @[deprecated "RingHom.specComap and PrimeSpectrum.comap were unified,\
-so this lemma is now a no-op." (since := "2025-12-10")]
+so this lemma is now a no-op." (since := "2025-12-10"), nolint synTaut]
 lemma comap_apply (f : R →+* S) (x : PrimeSpectrum S) : comap f x = comap f x := rfl
 
 variable (f : R →+* S)

--- a/Mathlib/RingTheory/Spectrum/Prime/Topology.lean
+++ b/Mathlib/RingTheory/Spectrum/Prime/Topology.lean
@@ -330,6 +330,8 @@ lemma continuous_comap (f : R →+* S) : Continuous (comap f) := by
   rintro _ ⟨s, rfl⟩
   exact ⟨_, preimage_comap_zeroLocus_aux f s⟩
 
+@[deprecated (since := "2025-12-10")] alias comap_apply := continuous_comap
+
 variable (f : R →+* S)
 
 variable (S)
@@ -343,6 +345,9 @@ theorem localization_comap_injective [Algebra R S] (M : Submonoid R) [IsLocaliza
   ext1
   exact h
 
+@[deprecated (since := "2025-12-10")]
+alias localization_specComap_injective := localization_comap_injective
+
 theorem localization_comap_range [Algebra R S] (M : Submonoid R) [IsLocalization M S] :
     Set.range (comap (algebraMap R S)) = { p | Disjoint (M : Set R) p.asIdeal } := by
   refine Set.ext fun x ↦ ⟨?_, fun h ↦ ?_⟩
@@ -351,6 +356,8 @@ theorem localization_comap_range [Algebra R S] (M : Submonoid R) [IsLocalization
   · use ⟨x.asIdeal.map (algebraMap R S), IsLocalization.isPrime_of_isPrime_disjoint M S _ x.2 h⟩
     ext1
     exact IsLocalization.comap_map_of_isPrime_disjoint M S _ x.2 h
+
+@[deprecated (since := "2025-12-10")] alias localization_specComap_range := localization_comap_range
 
 theorem localization_comap_isInducing [Algebra R S] (M : Submonoid R) [IsLocalization M S] :
     IsInducing (comap (algebraMap R S)) := by
@@ -1112,6 +1119,9 @@ lemma _root_.RingHom.IsIntegral.comap_surjective {f : R →+* S} (hf : f.IsInteg
   obtain ⟨Q, _, hQ, rfl⟩ := Ideal.exists_ideal_over_prime_of_isIntegral p (⊥ : Ideal S)
     (by simp [Ideal.comap_bot_of_injective (algebraMap R S) hinj])
   exact ⟨⟨Q, hQ⟩, rfl⟩
+
+@[deprecated (since := "2025-12-10")]
+alias _root_.RingHom.IsIntegral.specComap_surjective := _root_.RingHom.IsIntegral.comap_surjective
 
 end IsIntegral
 

--- a/docs/1000.yaml
+++ b/docs/1000.yaml
@@ -2138,7 +2138,7 @@ Q2379132:
     - Ideal.exists_ideal_over_prime_of_isIntegral_of_isDomain
     - Ideal.exists_ideal_over_prime_of_isIntegral_of_isPrime
     - Algebra.HasGoingDown.iff_generalizingMap_primeSpectrumComap
-    - Algebra.HasGoingDown.of_specComap_localRingHom_surjective
+    - Algebra.HasGoingDown.of_comap_localRingHom_surjective
   date: 2025
 
 Q2394548:


### PR DESCRIPTION
and remove the old `PrimeSpectrum.comap`, which was `RingHom.specComap` bundled as a continuous map.

Having both `RingHom.specComap` and `PrimeSpectrum.comap` leads to two ways of writing the same thing, with every lemma written before the topology-on-`PrimeSpectrum`-barrier stated in terms of `RingHom.specComap` and most lemmas after it stated in terms of `PrimeSpectrum.comap`. Since the bundled continuous map version is not useful, because the topology library rarely takes continuous maps as input, we remove the bundled version, but keep the name `PrimeSpectrum.comap` for the unbundled one.

---
<!-- Your PR title will become the first line of the commit message.

In this box, the text above the `---` (if not empty) will be appended
to the commit message, and can be used to give additional context or
details. Please leave a blank newline before the `---`, otherwise GitHub
will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

When merging, all the commits will be squashed into a single commit
listing all co-authors.

Co-authors in the squash commit are gathered from two sources:

First, all authors of commits to this PR branch are included. Thus,
one way to add co-authors is to include at least one commit authored by
each co-author among the commits in the pull request. If necessary, you
may create empty commits to indicate co-authorship, using commands like so:

git commit --author="Author Name <author@email.com>" --allow-empty -m "add Author Name as coauthor"

Second, co-authors can also be listed in lines at the very bottom of
the commit message (that is, directly before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines
at the bottom of the commit message (before the `---`, and also before
any "Co-authored-by" lines) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
