### PR TITLE
chore(Analysis): deprecate isometry extension in favour of general construction

### DIFF
--- a/Mathlib/Analysis/InnerProductSpace/PiL2.lean
+++ b/Mathlib/Analysis/InnerProductSpace/PiL2.lean
@@ -1078,7 +1078,7 @@ section LinearIsometry
 alias LinearIsometry.extend := LinearMap.extendOfIsometry
 
 @[deprecated (since := "2025-12-11")]
-alias LinearIsometry.extend_apply := LinearMap.extendOfIsometry_apply
+alias LinearIsometry.extend_apply := LinearMap.extendOfIsometry_eq
 
 end LinearIsometry
 

--- a/Mathlib/Analysis/InnerProductSpace/PiL2.lean
+++ b/Mathlib/Analysis/InnerProductSpace/PiL2.lean
@@ -7,6 +7,7 @@ module
 
 public import Mathlib.Analysis.InnerProductSpace.Projection.FiniteDimensional
 public import Mathlib.Analysis.Normed.Lp.PiLp
+public import Mathlib.Analysis.Normed.Operator.Extend
 public import Mathlib.LinearAlgebra.FiniteDimensional.Lemmas
 public import Mathlib.LinearAlgebra.UnitaryGroup
 public import Mathlib.Util.Superscript
@@ -1073,74 +1074,11 @@ def OrthonormalBasis.fromOrthogonalSpanSingleton (n : ℕ) [Fact (finrank 𝕜 E
 
 section LinearIsometry
 
-variable {V : Type*} [NormedAddCommGroup V] [InnerProductSpace 𝕜 V] [FiniteDimensional 𝕜 V]
-variable {S : Submodule 𝕜 V} {L : S →ₗᵢ[𝕜] V}
+@[deprecated (since := "2025-12-11")]
+alias LinearIsometry.extend := LinearMap.extendOfIsometry
 
-open Module
-
-/-- Let `S` be a subspace of a finite-dimensional complex inner product space `V`.  A linear
-isometry mapping `S` into `V` can be extended to a full isometry of `V`.
-
-TODO:  The case when `S` is a finite-dimensional subspace of an infinite-dimensional `V`. -/
-noncomputable def LinearIsometry.extend (L : S →ₗᵢ[𝕜] V) : V →ₗᵢ[𝕜] V := by
-  -- Build an isometry from Sᗮ to L(S)ᗮ through `EuclideanSpace`
-  let d := finrank 𝕜 Sᗮ
-  let LS := LinearMap.range L.toLinearMap
-  have E : Sᗮ ≃ₗᵢ[𝕜] LSᗮ := by
-    have dim_LS_perp : finrank 𝕜 LSᗮ = d :=
-      calc
-        finrank 𝕜 LSᗮ = finrank 𝕜 V - finrank 𝕜 LS := by
-          simp only [← LS.finrank_add_finrank_orthogonal, add_tsub_cancel_left]
-        _ = finrank 𝕜 V - finrank 𝕜 S := by
-          simp only [LS, LinearMap.finrank_range_of_inj L.injective]
-        _ = finrank 𝕜 Sᗮ := by simp only [← S.finrank_add_finrank_orthogonal, add_tsub_cancel_left]
-    exact
-      (stdOrthonormalBasis 𝕜 Sᗮ).repr.trans
-        ((stdOrthonormalBasis 𝕜 LSᗮ).reindex <| finCongr dim_LS_perp).repr.symm
-  let L3 := LSᗮ.subtypeₗᵢ.comp E.toLinearIsometry
-  -- Project onto S and Sᗮ
-  haveI : CompleteSpace S := FiniteDimensional.complete 𝕜 S
-  haveI : CompleteSpace V := FiniteDimensional.complete 𝕜 V
-  let p1 := S.orthogonalProjection.toLinearMap
-  let p2 := Sᗮ.orthogonalProjection.toLinearMap
-  -- Build a linear map from the isometries on S and Sᗮ
-  let M := L.toLinearMap.comp p1 + L3.toLinearMap.comp p2
-  -- Prove that M is an isometry
-  have M_norm_map : ∀ x : V, ‖M x‖ = ‖x‖ := by
-    intro x
-    -- Apply M to the orthogonal decomposition of x
-    have Mx_decomp : M x = L (p1 x) + L3 (p2 x) := by
-      simp only [M, LinearMap.add_apply, LinearMap.comp_apply, LinearMap.comp_apply,
-        LinearIsometry.coe_toLinearMap]
-    -- Mx_decomp is the orthogonal decomposition of M x
-    have Mx_orth : ⟪L (p1 x), L3 (p2 x)⟫ = 0 := by
-      have Lp1x : L (p1 x) ∈ LinearMap.range L.toLinearMap :=
-        LinearMap.mem_range_self L.toLinearMap (p1 x)
-      have Lp2x : L3 (p2 x) ∈ (LinearMap.range L.toLinearMap)ᗮ := by
-        simp only [LS,
-          ← Submodule.range_subtype LSᗮ]
-        apply LinearMap.mem_range_self
-      apply Submodule.inner_right_of_mem_orthogonal Lp1x Lp2x
-    -- Apply the Pythagorean theorem and simplify
-    rw [← sq_eq_sq₀ (norm_nonneg _) (norm_nonneg _), norm_sq_eq_add_norm_sq_projection x S]
-    simp only [sq, Mx_decomp]
-    rw [norm_add_sq_eq_norm_sq_add_norm_sq_of_inner_eq_zero (L (p1 x)) (L3 (p2 x)) Mx_orth]
-    simp only [p1, p2, LinearIsometry.norm_map,
-      ContinuousLinearMap.coe_coe, Submodule.coe_norm]
-  exact
-    { toLinearMap := M
-      norm_map' := M_norm_map }
-
-theorem LinearIsometry.extend_apply (L : S →ₗᵢ[𝕜] V) (s : S) : L.extend s = L s := by
-  haveI : CompleteSpace S := FiniteDimensional.complete 𝕜 S
-  simp only [LinearIsometry.extend, ← LinearIsometry.coe_toLinearMap]
-  simp only [add_eq_left, LinearIsometry.coe_toLinearMap,
-    LinearIsometryEquiv.coe_toLinearIsometry, LinearIsometry.coe_comp, Function.comp_apply,
-    orthogonalProjection_mem_subspace_eq_self, LinearMap.coe_comp, ContinuousLinearMap.coe_coe,
-    Submodule.coe_subtype, LinearMap.add_apply, Submodule.coe_eq_zero,
-    LinearIsometryEquiv.map_eq_zero_iff, Submodule.coe_subtypeₗᵢ,
-    orthogonalProjection_mem_subspace_orthogonalComplement_eq_zero, Submodule.orthogonal_orthogonal,
-    Submodule.coe_mem]
+@[deprecated (since := "2025-12-11")]
+alias LinearIsometry.extend_apply := LinearMap.extendOfIsometry_apply
 
 end LinearIsometry
 

--- a/Mathlib/Analysis/Normed/Operator/Extend.lean
+++ b/Mathlib/Analysis/Normed/Operator/Extend.lean
@@ -20,6 +20,8 @@ subspace to the entire Banach space.
 * `LinearMap.extendOfNorm`: Extend `f : E →ₛₗ[σ₁₂] F` to a continuous linear map
 `Eₗ →SL[σ₁₂] F`, where `e : E →ₗ[𝕜] Eₗ` is a dense map and we have the norm estimate
 `‖f x‖ ≤ C * ‖e x‖` for all `x : E`.
+* `LinearMap.extendOfIsometry`: Extend `f : E →ₛₗ[σ₁₂] F` to a linear isometry `Eₗ →ₛₗᵢ[σ₁₂] F`,
+where `e : E →ₗ[𝕜] Eₗ` is a dense map and we have that `‖f x‖ = ‖e x‖` for all `x : E`.
 
 Moreover, we can extend a linear equivalence:
 * `LinearEquiv.extend`: Extend a linear equivalence between normed spaces to a continuous linear

--- a/Mathlib/Analysis/Normed/Operator/Extend.lean
+++ b/Mathlib/Analysis/Normed/Operator/Extend.lean
@@ -233,6 +233,39 @@ theorem opNorm_extendOfNorm_le (h_dense : DenseRange e) {C : ℝ} (hC : 0 ≤ C)
 
 end NormedField
 
+section LinearIsometry
+
+variable [NormedField 𝕜] [NormedField 𝕜₂]
+  [AddCommGroup E] [Module 𝕜 E]
+  [NormedAddCommGroup F] [NormedSpace 𝕜₂ F] [CompleteSpace F]
+  [NormedAddCommGroup Eₗ] [NormedSpace 𝕜 Eₗ]
+
+variable {σ₁₂ : 𝕜 →+* 𝕜₂} {σ₂₁ : 𝕜₂ →+* 𝕜} [RingHomInvPair σ₁₂ σ₂₁] [RingHomInvPair σ₂₁ σ₁₂]
+variable (f : E →ₛₗ[σ₁₂] F) (e : E →ₗ[𝕜] Eₗ)
+
+/-- Extend a densely defined operator that preserves the norm to a linear isometry. -/
+def extendOfIsometry (h_dense : DenseRange e) (h_norm : ∀ x, ‖f x‖ = ‖e x‖) :
+    Eₗ →ₛₗᵢ[σ₁₂] F where
+  __ := f.extendOfNorm e
+  norm_map' := by
+    refine h_dense.induction ?_ ?_
+    · rintro x ⟨y, rfl⟩
+      convert h_norm y
+      apply LinearMap.extendOfNorm_eq h_dense (by use 1; simp [h_norm])
+    · apply isClosed_eq ?_ (by fun_prop)
+      simp only [ContinuousLinearMap.coe_coe]
+      fun_prop
+
+theorem extendOfIsometry_apply (h_dense : DenseRange e) (h_norm : ∀ x, ‖f x‖ = ‖e x‖) (x : Eₗ) :
+    (f.extendOfIsometry e h_dense h_norm) x = f.extendOfNorm e x := rfl
+
+@[simp]
+theorem extendOfIsometry_eq (h_dense : DenseRange e) (h_norm : ∀ x, ‖f x‖ = ‖e x‖) (x : E) :
+    f.extendOfIsometry e h_dense h_norm (e x) = f x :=
+  LinearMap.extendOfNorm_eq h_dense ⟨1, fun x ↦ by simp [h_norm x]⟩ x
+
+end LinearIsometry
+
 end LinearMap
 
 namespace LinearEquiv


### PR DESCRIPTION
The construction in `PiLp` only works for finite dimensional inner product spaces, whereas the general construct works in arbitrary Banach spaces. Moreover, the general construction works without taking a concrete subspace, but more generally an injection from a linear space into the normed space and the norm equality is checked using that injection.

---
<!-- Your PR title will become the first line of the commit message.

In this box, the text above the `---` (if not empty) will be appended
to the commit message, and can be used to give additional context or
details. Please leave a blank newline before the `---`, otherwise GitHub
will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

When merging, all the commits will be squashed into a single commit
listing all co-authors.

Co-authors in the squash commit are gathered from two sources:

First, all authors of commits to this PR branch are included. Thus,
one way to add co-authors is to include at least one commit authored by
each co-author among the commits in the pull request. If necessary, you
may create empty commits to indicate co-authorship, using commands like so:

git commit --author="Author Name <author@email.com>" --allow-empty -m "add Author Name as coauthor"

Second, co-authors can also be listed in lines at the very bottom of
the commit message (that is, directly before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines
at the bottom of the commit message (before the `---`, and also before
any "Co-authored-by" lines) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
