### PR TITLE
feat(LinearAlgebra/ExteriorPower): interactions between `TensorProduct` and `exteriorPower`

### DIFF
--- a/Mathlib/LinearAlgebra/ExteriorPower/TensorPower.lean
+++ b/Mathlib/LinearAlgebra/ExteriorPower/TensorPower.lean
@@ -1,0 +1,155 @@
+/-
+Copyright (c) 2025 Daniel Morrison. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Sophie Morel, Daniel Morrison
+-/
+module
+
+public import Mathlib.LinearAlgebra.ExteriorPower.Basic
+public import Mathlib.LinearAlgebra.TensorPower.Basic
+
+/-!
+# Interactions of exterior powers and tensor powers.
+-/
+
+@[expose] public section
+
+open scoped TensorProduct
+
+universe u
+
+variable (R : Type u) [CommRing R] (n : ℕ) {M N N' : Type*}
+  [AddCommGroup M] [Module R M] [AddCommGroup N] [Module R N]
+  [AddCommGroup N'] [Module R N']
+
+namespace exteriorPower
+
+/-! Map to the tensor power. -/
+
+variable (M)
+
+/-- The linear map from the `n`th exterior power to the `n`th tensor power induced by
+`MultilinearMap.alternarization`. -/
+noncomputable def toTensorPower : ⋀[R]^n M →ₗ[R] (⨂[R]^n) M :=
+  alternatingMapLinearEquiv <|
+    MultilinearMap.alternatization (PiTensorProduct.tprod R (s := fun (_ : Fin n) => M))
+
+variable {M}
+
+open Equiv in
+@[simp]
+lemma toTensorPower_apply_ιMulti (v : Fin n → M) :
+    toTensorPower R n M (ιMulti R n v) =
+      ∑ σ : Perm (Fin n), Perm.sign σ • PiTensorProduct.tprod R (fun i => v (σ i)) := by
+  unfold toTensorPower
+  simp only [alternatingMapLinearEquiv_apply_ιMulti, alternatingMapLinearEquiv_apply_ιMulti]
+  rw [MultilinearMap.alternatization_apply]
+  simp only [MultilinearMap.domDomCongr_apply]
+
+/-! Linear form on the exterior power induced by a family of linear forms on the module. This
+is used to prove the linear independence of some families in the exterior power, cf.
+`exteriorPower.linearFormOfBasis` and `exteriorPower.ιMulti_family_linearIndependent_ofBasis`. -/
+
+/-- A family `f` indexed by `Fin n` of linear forms on `M` defines a linear form on the `n`th
+exterior power of `M`, by composing the map `exteriorPower.toTensorPower` to the `n`th tensor
+power and then applying `TensorPower.linearFormOfFamily` (which takes the product of the
+components of `f`). -/
+noncomputable def linearFormOfFamily (f : (_ : Fin n) → (M →ₗ[R] R)) :
+    ⋀[R]^n M →ₗ[R] R :=
+  TensorPower.linearFormOfFamily f ∘ₗ toTensorPower R n M
+
+@[simp]
+lemma linearFormOfFamily_apply (f : (_ : Fin n) → (M →ₗ[R] R)) (x : ⋀[R]^n M) :
+    linearFormOfFamily R n f x = TensorPower.linearFormOfFamily f (toTensorPower R n M x) :=
+  rfl
+
+lemma linearFormOfFamily_apply_ιMulti (f : (_ : Fin n) → (M →ₗ[R] R)) (m : Fin n → M) :
+    linearFormOfFamily R n f (ιMulti R n m) =
+    ∑ σ : Equiv.Perm (Fin n), Equiv.Perm.sign σ • ∏ i, f i (m (σ i)) := by
+  simp only [linearFormOfFamily_apply, toTensorPower_apply_ιMulti, map_sum,
+    LinearMap.map_smul_of_tower, TensorPower.linearFormOfFamily_apply_tprod]
+
+/-- If `f` is a family of linear forms on `M` (index by `Fin n`) and `p` is a linear map
+from `N` to `M`, then the composition of `exteriorPower.linearFormOfFamily R n f` and
+of `exteriorPower.map p` is equal to the linear form induced by the family
+`fun i ↦ (f i).comp p`.. -/
+lemma linearFormOfFamily_comp_map (f : (_ : Fin n) → (M →ₗ[R] R)) (p : N →ₗ[R] M) :
+    (linearFormOfFamily R n f).comp (map n p) =
+    linearFormOfFamily R n (fun (i : Fin n) => (f i).comp p) := by
+  apply LinearMap.ext_on (ιMulti_span R n (M := N))
+  intro x hx
+  obtain ⟨y, h⟩ := Set.mem_range.mp hx
+  simp only [← h, LinearMap.coe_comp, Function.comp_apply, map_apply_ιMulti,
+    linearFormOfFamily_apply, toTensorPower_apply_ιMulti, map_sum, LinearMap.map_smul_of_tower,
+    TensorPower.linearFormOfFamily_apply_tprod]
+
+lemma linearFormOfFamily_comp_map_apply (f : (_ : Fin n) → (M →ₗ[R] R))
+    (p : N →ₗ[R] M) (x : ⋀[R]^n N) :
+    (linearFormOfFamily R n f) (map n p x) =
+    linearFormOfFamily R n (fun (i : Fin n) => (f i).comp p) x := by
+  rw [← LinearMap.comp_apply, linearFormOfFamily_comp_map]
+
+/-- A family `f` of linear forms on `M` indexed by `Fin n` defines an `n`-fold alternating form
+on `M`, by composing the linear form on `⋀[R]^n M` indeuced by `f` (defined in
+`exteriorPower.linearFormOfFamily`) with the canonical `n`-fold alternating map from `M` to its
+`n`th exterior power. -/
+noncomputable def alternatingFormOfFamily (f : (_ : Fin n) → (M →ₗ[R] R)) :
+    M [⋀^Fin n]→ₗ[R] R :=
+  (linearFormOfFamily R n f).compAlternatingMap (ιMulti R n)
+
+@[simp]
+lemma alternatingFormOfFamily_apply (f : (_ : Fin n) → (M →ₗ[R] R)) (m : Fin n → M) :
+    alternatingFormOfFamily R n f m = linearFormOfFamily R n f (ιMulti R n m) :=
+  rfl
+
+variable {R}
+variable {N'' : Type*} [AddCommGroup N''] [Module R N'']
+
+lemma sum_range_map (f : N →ₗ[R] M) (f' : N' →ₗ[R] M) (f'' : N'' →ₗ[R] M)
+    (hf : ∃ (g : N →ₗ[R] N''), f''.comp g = f) (hf' : ∃ (g' : N' →ₗ[R] N''), f''.comp g' = f') :
+    LinearMap.range (map n f) ⊔ LinearMap.range (map n f') ≤ LinearMap.range (map n f'') := by
+  let ⟨g, hg⟩ := hf
+  let ⟨g', hg'⟩ := hf'
+  intro x
+  simp only [Submodule.mem_sup, LinearMap.mem_range]
+  intro ⟨x₁, ⟨⟨y, hy⟩, ⟨x₂, ⟨⟨y', hy'⟩, hx⟩⟩⟩⟩
+  existsi map n g y + map n g' y'
+  rw [← hx, ← hy, ← hy', ← hg, ← hg', map_comp, ← map_comp, map_add]
+  simp
+
+/-- Every element of `⋀[R]^n M` is in the image of `⋀[R]^n P` for some finitely generated
+submodule `P` of `M`. -/
+lemma mem_exteriorPower_is_mem_finite (x : ⋀[R]^n M) :
+    ∃ (P : Submodule R M), Submodule.FG P ∧ x ∈ LinearMap.range (map n (Submodule.subtype P)) := by
+  have hx : x ∈ (⊤ : Submodule R (⋀[R]^n M)) := by simp only [Submodule.mem_top]
+  rw [← ιMulti_span] at hx
+  refine Submodule.span_induction (R := R) (p := fun x _ => ∃ (P : Submodule R M),
+    P.FG ∧ x ∈ LinearMap.range (map n P.subtype)) ?_ ?_ ?_ ?_ hx
+  · intro y hy
+    obtain ⟨z, hz⟩ := hy
+    use Submodule.span R (Set.range z)
+    constructor
+    · apply Submodule.fg_span
+      exact Set.finite_range z
+    · use ιMulti R n (fun i => ⟨z i, by simp [Submodule.mem_span_of_mem]⟩)
+      simp only [map_apply_ιMulti, Submodule.coe_subtype, ← hz]
+      congr
+  · use ⊥
+    simp [Submodule.fg_bot]
+  · rintro y z _ _ ⟨Py, PyFG, y_mem⟩ ⟨Pz, PzFG, z_mem⟩
+    use Py ⊔ Pz
+    refine ⟨Submodule.FG.sup PyFG PzFG, ?_⟩
+    apply sum_range_map n Py.subtype Pz.subtype
+    · use Submodule.inclusion le_sup_left
+      exact Submodule.subtype_comp_inclusion Py _ le_sup_left
+    · use Submodule.inclusion le_sup_right
+      exact Submodule.subtype_comp_inclusion Pz _ le_sup_right
+    · exact Submodule.add_mem_sup y_mem z_mem
+  · intro c y _ ⟨Py, PyFG, y_mem⟩
+    use Py
+    refine ⟨PyFG, ?_⟩
+    obtain ⟨y₁, hy₁⟩ := y_mem
+    use c • y₁
+    rw [map_smul, hy₁]
+
+end exteriorPower

--- a/Mathlib/LinearAlgebra/ExteriorPower/TensorPower.lean
+++ b/Mathlib/LinearAlgebra/ExteriorPower/TensorPower.lean
@@ -31,7 +31,7 @@ variable (M)
 /-- The linear map from the `n`th exterior power to the `n`th tensor power induced by
 `MultilinearMap.alternarization`. -/
 noncomputable def toTensorPower : ⋀[R]^n M →ₗ[R] (⨂[R]^n) M :=
-  alternatingMapLinearEquiv <|
+    alternatingMapLinearEquiv <|
     MultilinearMap.alternatization (PiTensorProduct.tprod R (s := fun (_ : Fin n) => M))
 
 variable {M}
@@ -41,10 +41,7 @@ open Equiv in
 lemma toTensorPower_apply_ιMulti (v : Fin n → M) :
     toTensorPower R n M (ιMulti R n v) =
       ∑ σ : Perm (Fin n), Perm.sign σ • PiTensorProduct.tprod R (fun i => v (σ i)) := by
-  unfold toTensorPower
-  simp only [alternatingMapLinearEquiv_apply_ιMulti, alternatingMapLinearEquiv_apply_ιMulti]
-  rw [MultilinearMap.alternatization_apply]
-  simp only [MultilinearMap.domDomCongr_apply]
+  simp [toTensorPower, MultilinearMap.alternatization_apply]
 
 /-! Linear form on the exterior power induced by a family of linear forms on the module. This
 is used to prove the linear independence of some families in the exterior power, cf.
@@ -56,18 +53,18 @@ power and then applying `TensorPower.linearFormOfFamily` (which takes the produc
 components of `f`). -/
 noncomputable def linearFormOfFamily (f : (_ : Fin n) → (M →ₗ[R] R)) :
     ⋀[R]^n M →ₗ[R] R :=
-  TensorPower.linearFormOfFamily f ∘ₗ toTensorPower R n M
+  TensorPower.dprod f ∘ₗ toTensorPower R n M
 
 @[simp]
 lemma linearFormOfFamily_apply (f : (_ : Fin n) → (M →ₗ[R] R)) (x : ⋀[R]^n M) :
-    linearFormOfFamily R n f x = TensorPower.linearFormOfFamily f (toTensorPower R n M x) :=
+    linearFormOfFamily R n f x = TensorPower.dprod f (toTensorPower R n M x) :=
   rfl
 
 lemma linearFormOfFamily_apply_ιMulti (f : (_ : Fin n) → (M →ₗ[R] R)) (m : Fin n → M) :
     linearFormOfFamily R n f (ιMulti R n m) =
     ∑ σ : Equiv.Perm (Fin n), Equiv.Perm.sign σ • ∏ i, f i (m (σ i)) := by
   simp only [linearFormOfFamily_apply, toTensorPower_apply_ιMulti, map_sum,
-    LinearMap.map_smul_of_tower, TensorPower.linearFormOfFamily_apply_tprod]
+    LinearMap.map_smul_of_tower, TensorPower.dprod_apply]
 
 /-- If `f` is a family of linear forms on `M` (index by `Fin n`) and `p` is a linear map
 from `N` to `M`, then the composition of `exteriorPower.linearFormOfFamily R n f` and
@@ -81,7 +78,7 @@ lemma linearFormOfFamily_comp_map (f : (_ : Fin n) → (M →ₗ[R] R)) (p : N �
   obtain ⟨y, h⟩ := Set.mem_range.mp hx
   simp only [← h, LinearMap.coe_comp, Function.comp_apply, map_apply_ιMulti,
     linearFormOfFamily_apply, toTensorPower_apply_ιMulti, map_sum, LinearMap.map_smul_of_tower,
-    TensorPower.linearFormOfFamily_apply_tprod]
+    TensorPower.dprod_apply]
 
 lemma linearFormOfFamily_comp_map_apply (f : (_ : Fin n) → (M →ₗ[R] R))
     (p : N →ₗ[R] M) (x : ⋀[R]^n N) :

--- a/Mathlib/LinearAlgebra/ExteriorPower/TensorPower.lean
+++ b/Mathlib/LinearAlgebra/ExteriorPower/TensorPower.lean
@@ -18,23 +18,19 @@ open scoped TensorProduct
 
 universe u
 
-variable (R : Type u) [CommRing R] (n : ℕ) {M N N' : Type*}
+variable (R : Type u) [CommRing R] (n : ℕ) {M N : Type*}
   [AddCommGroup M] [Module R M] [AddCommGroup N] [Module R N]
-  [AddCommGroup N'] [Module R N']
 
 namespace exteriorPower
 
 /-! Map to the tensor power. -/
 
-variable (M)
-
+variable (M) in
 /-- The linear map from the `n`th exterior power to the `n`th tensor power induced by
 `MultilinearMap.alternarization`. -/
 noncomputable def toTensorPower : ⋀[R]^n M →ₗ[R] (⨂[R]^n) M :=
     alternatingMapLinearEquiv <|
-    MultilinearMap.alternatization (PiTensorProduct.tprod R (s := fun (_ : Fin n) => M))
-
-variable {M}
+    MultilinearMap.alternatization (PiTensorProduct.tprod R)
 
 open Equiv in
 @[simp]
@@ -43,110 +39,53 @@ lemma toTensorPower_apply_ιMulti (v : Fin n → M) :
       ∑ σ : Perm (Fin n), Perm.sign σ • PiTensorProduct.tprod R (fun i => v (σ i)) := by
   simp [toTensorPower, MultilinearMap.alternatization_apply]
 
-/-! Linear form on the exterior power induced by a family of linear forms on the module. This
-is used to prove the linear independence of some families in the exterior power, cf.
-`exteriorPower.linearFormOfBasis` and `exteriorPower.ιMulti_family_linearIndependent_ofBasis`. -/
+/-! Linear form on the exterior power induced by a family of linear forms on the module. -/
 
 /-- A family `f` indexed by `Fin n` of linear forms on `M` defines a linear form on the `n`th
 exterior power of `M`, by composing the map `exteriorPower.toTensorPower` to the `n`th tensor
-power and then applying `TensorPower.linearFormOfFamily` (which takes the product of the
-components of `f`). -/
-noncomputable def linearFormOfFamily (f : (_ : Fin n) → (M →ₗ[R] R)) :
-    ⋀[R]^n M →ₗ[R] R :=
+power and then applying `TensorPower.dprod`. -/
+noncomputable def dprod (f : Fin n → Module.Dual R M) :
+    Module.Dual R (⋀[R]^n M) :=
   TensorPower.dprod f ∘ₗ toTensorPower R n M
 
 @[simp]
-lemma linearFormOfFamily_apply (f : (_ : Fin n) → (M →ₗ[R] R)) (x : ⋀[R]^n M) :
-    linearFormOfFamily R n f x = TensorPower.dprod f (toTensorPower R n M x) :=
+lemma dprod_apply (f : Fin n → Module.Dual R M) (x : ⋀[R]^n M) :
+    dprod R n f x = TensorPower.dprod f (toTensorPower R n M x) :=
   rfl
 
-lemma linearFormOfFamily_apply_ιMulti (f : (_ : Fin n) → (M →ₗ[R] R)) (m : Fin n → M) :
-    linearFormOfFamily R n f (ιMulti R n m) =
+lemma dprod_apply_ιMulti (f : Fin n → Module.Dual R M) (m : Fin n → M) :
+    dprod R n f (ιMulti R n m) =
     ∑ σ : Equiv.Perm (Fin n), Equiv.Perm.sign σ • ∏ i, f i (m (σ i)) := by
-  simp only [linearFormOfFamily_apply, toTensorPower_apply_ιMulti, map_sum,
-    LinearMap.map_smul_of_tower, TensorPower.dprod_apply]
+  simp
 
 /-- If `f` is a family of linear forms on `M` (index by `Fin n`) and `p` is a linear map
-from `N` to `M`, then the composition of `exteriorPower.linearFormOfFamily R n f` and
+from `N` to `M`, then the composition of `exteriorPower.dprod R n f` and
 of `exteriorPower.map p` is equal to the linear form induced by the family
-`fun i ↦ (f i).comp p`.. -/
-lemma linearFormOfFamily_comp_map (f : (_ : Fin n) → (M →ₗ[R] R)) (p : N →ₗ[R] M) :
-    (linearFormOfFamily R n f).comp (map n p) =
-    linearFormOfFamily R n (fun (i : Fin n) => (f i).comp p) := by
+`fun i ↦ (f i).comp p`. -/
+lemma dprod_comp_map (f : Fin n → Module.Dual R M) (p : N →ₗ[R] M) :
+    (dprod R n f).comp (map n p) =
+    dprod R n (fun (i : Fin n) => (f i).comp p) := by
   apply LinearMap.ext_on (ιMulti_span R n (M := N))
-  intro x hx
-  obtain ⟨y, h⟩ := Set.mem_range.mp hx
-  simp only [← h, LinearMap.coe_comp, Function.comp_apply, map_apply_ιMulti,
-    linearFormOfFamily_apply, toTensorPower_apply_ιMulti, map_sum, LinearMap.map_smul_of_tower,
-    TensorPower.dprod_apply]
+  rintro x ⟨y, h⟩
+  simp [← h]
 
-lemma linearFormOfFamily_comp_map_apply (f : (_ : Fin n) → (M →ₗ[R] R))
+lemma dprod_comp_map_apply (f : Fin n → Module.Dual R M)
     (p : N →ₗ[R] M) (x : ⋀[R]^n N) :
-    (linearFormOfFamily R n f) (map n p x) =
-    linearFormOfFamily R n (fun (i : Fin n) => (f i).comp p) x := by
-  rw [← LinearMap.comp_apply, linearFormOfFamily_comp_map]
+    (dprod R n f) (map n p x) =
+    dprod R n (fun (i : Fin n) => (f i).comp p) x := by
+  rw [← LinearMap.comp_apply, dprod_comp_map]
 
 /-- A family `f` of linear forms on `M` indexed by `Fin n` defines an `n`-fold alternating form
 on `M`, by composing the linear form on `⋀[R]^n M` indeuced by `f` (defined in
-`exteriorPower.linearFormOfFamily`) with the canonical `n`-fold alternating map from `M` to its
+`exteriorPower.dprod`) with the canonical `n`-fold alternating map from `M` to its
 `n`th exterior power. -/
-noncomputable def alternatingFormOfFamily (f : (_ : Fin n) → (M →ₗ[R] R)) :
+noncomputable def altForm (f : Fin n → Module.Dual R M) :
     M [⋀^Fin n]→ₗ[R] R :=
-  (linearFormOfFamily R n f).compAlternatingMap (ιMulti R n)
+  (dprod R n f).compAlternatingMap (ιMulti R n)
 
 @[simp]
-lemma alternatingFormOfFamily_apply (f : (_ : Fin n) → (M →ₗ[R] R)) (m : Fin n → M) :
-    alternatingFormOfFamily R n f m = linearFormOfFamily R n f (ιMulti R n m) :=
+lemma altForm_apply (f : Fin n → Module.Dual R M) (m : Fin n → M) :
+    altForm R n f m = dprod R n f (ιMulti R n m) :=
   rfl
-
-variable {R}
-variable {N'' : Type*} [AddCommGroup N''] [Module R N'']
-
-lemma sum_range_map (f : N →ₗ[R] M) (f' : N' →ₗ[R] M) (f'' : N'' →ₗ[R] M)
-    (hf : ∃ (g : N →ₗ[R] N''), f''.comp g = f) (hf' : ∃ (g' : N' →ₗ[R] N''), f''.comp g' = f') :
-    LinearMap.range (map n f) ⊔ LinearMap.range (map n f') ≤ LinearMap.range (map n f'') := by
-  let ⟨g, hg⟩ := hf
-  let ⟨g', hg'⟩ := hf'
-  intro x
-  simp only [Submodule.mem_sup, LinearMap.mem_range]
-  intro ⟨x₁, ⟨⟨y, hy⟩, ⟨x₂, ⟨⟨y', hy'⟩, hx⟩⟩⟩⟩
-  existsi map n g y + map n g' y'
-  rw [← hx, ← hy, ← hy', ← hg, ← hg', map_comp, ← map_comp, map_add]
-  simp
-
-/-- Every element of `⋀[R]^n M` is in the image of `⋀[R]^n P` for some finitely generated
-submodule `P` of `M`. -/
-lemma mem_exteriorPower_is_mem_finite (x : ⋀[R]^n M) :
-    ∃ (P : Submodule R M), Submodule.FG P ∧ x ∈ LinearMap.range (map n (Submodule.subtype P)) := by
-  have hx : x ∈ (⊤ : Submodule R (⋀[R]^n M)) := by simp only [Submodule.mem_top]
-  rw [← ιMulti_span] at hx
-  refine Submodule.span_induction (R := R) (p := fun x _ => ∃ (P : Submodule R M),
-    P.FG ∧ x ∈ LinearMap.range (map n P.subtype)) ?_ ?_ ?_ ?_ hx
-  · intro y hy
-    obtain ⟨z, hz⟩ := hy
-    use Submodule.span R (Set.range z)
-    constructor
-    · apply Submodule.fg_span
-      exact Set.finite_range z
-    · use ιMulti R n (fun i => ⟨z i, by simp [Submodule.mem_span_of_mem]⟩)
-      simp only [map_apply_ιMulti, Submodule.coe_subtype, ← hz]
-      congr
-  · use ⊥
-    simp [Submodule.fg_bot]
-  · rintro y z _ _ ⟨Py, PyFG, y_mem⟩ ⟨Pz, PzFG, z_mem⟩
-    use Py ⊔ Pz
-    refine ⟨Submodule.FG.sup PyFG PzFG, ?_⟩
-    apply sum_range_map n Py.subtype Pz.subtype
-    · use Submodule.inclusion le_sup_left
-      exact Submodule.subtype_comp_inclusion Py _ le_sup_left
-    · use Submodule.inclusion le_sup_right
-      exact Submodule.subtype_comp_inclusion Pz _ le_sup_right
-    · exact Submodule.add_mem_sup y_mem z_mem
-  · intro c y _ ⟨Py, PyFG, y_mem⟩
-    use Py
-    refine ⟨PyFG, ?_⟩
-    obtain ⟨y₁, hy₁⟩ := y_mem
-    use c • y₁
-    rw [map_smul, hy₁]
 
 end exteriorPower

--- a/Mathlib/LinearAlgebra/TensorPower/Basic.lean
+++ b/Mathlib/LinearAlgebra/TensorPower/Basic.lean
@@ -5,7 +5,7 @@ Authors: Eric Wieser
 -/
 module
 
-public import Mathlib.LinearAlgebra.PiTensorProduct
+public import Mathlib.LinearAlgebra.PiTensorProduct.Dual
 public import Mathlib.Logic.Equiv.Fin.Basic
 public import Mathlib.Algebra.DirectSum.Algebra
 
@@ -261,5 +261,16 @@ theorem galgebra_toFun_def (r : R) :
   rfl
 
 example : Algebra R (⨁ n : ℕ, ⨂[R]^n M) := by infer_instance
+
+/-! `TensorPower` of a `Dual` space. -/
+
+/-- A version of `tprod` specific to constructing elements of the dual space of a `TensorPower`. -/
+noncomputable def dprod {n : ℕ} :
+    MultilinearMap R (fun (_ : Fin n) => Module.Dual R M) (Module.Dual R (⨂[R]^n M)) :=
+  dualDistrib.compMultilinearMap (tprod R)
+
+lemma dprod_apply {n : ℕ} (f : Fin n → Module.Dual R M) (x : Fin n → M) :
+    dprod f (tprod R x) = ∏ i, (f i) (x i) := by
+  simp [dprod]
 
 end TensorPower

--- a/Mathlib/LinearAlgebra/TensorPower/Basic.lean
+++ b/Mathlib/LinearAlgebra/TensorPower/Basic.lean
@@ -269,6 +269,7 @@ noncomputable def dprod {n : ℕ} :
     MultilinearMap R (fun (_ : Fin n) => Module.Dual R M) (Module.Dual R (⨂[R]^n M)) :=
   dualDistrib.compMultilinearMap (tprod R)
 
+@[simp]
 lemma dprod_apply {n : ℕ} (f : Fin n → Module.Dual R M) (x : Fin n → M) :
     dprod f (tprod R x) = ∏ i, (f i) (x i) := by
   simp [dprod]


### PR DESCRIPTION
WIP

---
<!-- Your PR title will become the first line of the commit message.

In this box, the text above the `---` (if not empty) will be appended
to the commit message, and can be used to give additional context or
details. Please leave a blank newline before the `---`, otherwise GitHub
will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

When merging, all the commits will be squashed into a single commit
listing all co-authors.

Co-authors in the squash commit are gathered from two sources:

First, all authors of commits to this PR branch are included. Thus,
one way to add co-authors is to include at least one commit authored by
each co-author among the commits in the pull request. If necessary, you
may create empty commits to indicate co-authorship, using commands like so:

git commit --author="Author Name <author@email.com>" --allow-empty -m "add Author Name as coauthor"

Second, co-authors can also be listed in lines at the very bottom of
the commit message (that is, directly before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines
at the bottom of the commit message (before the `---`, and also before
any "Co-authored-by" lines) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
