### PR TITLE
[Merged by Bors] - feat: another version of mapping Gaussian measures

### DIFF
--- a/Mathlib/Probability/Distributions/Gaussian/Basic.lean
+++ b/Mathlib/Probability/Distributions/Gaussian/Basic.lean
@@ -89,6 +89,14 @@ lemma isGaussian_of_map_eq_gaussianReal {E : Type*} [TopologicalSpace E] [AddCom
   rw [h]
   infer_instance
 
+lemma isGaussian_map_of_measurable {E F : Type*} [TopologicalSpace E] [AddCommMonoid E]
+    [Module ℝ E] {mE : MeasurableSpace E} [TopologicalSpace F] [AddCommMonoid F]
+    [Module ℝ F] {mF : MeasurableSpace F} [OpensMeasurableSpace F] {μ : Measure E}
+    {L : E →L[ℝ] F} [IsGaussian μ] (hL : Measurable L) : IsGaussian (μ.map L) := by
+  refine isGaussian_of_map_eq_gaussianReal fun L' ↦ ⟨μ[L' ∘L L], Var[L' ∘L L; μ].toNNReal, ?_⟩
+  rw [Measure.map_map (by fun_prop) hL, ← ContinuousLinearMap.coe_comp',
+    IsGaussian.map_eq_gaussianReal]
+
 variable {E F : Type*} [NormedAddCommGroup E] [NormedSpace ℝ E] [MeasurableSpace E] [BorelSpace E]
   [NormedAddCommGroup F] [NormedSpace ℝ F] [MeasurableSpace F] [BorelSpace F]
   {μ : Measure E} [IsGaussian μ]

--- a/Mathlib/Probability/Distributions/Gaussian/Basic.lean
+++ b/Mathlib/Probability/Distributions/Gaussian/Basic.lean
@@ -89,6 +89,11 @@ lemma isGaussian_of_map_eq_gaussianReal {E : Type*} [TopologicalSpace E] [AddCom
   rw [h]
   infer_instance
 
+/-- Mapping a Gaussian measure by a measurable and continuous linear map yields a Gaussian
+measure. See also `isGaussian_map`, which does not assume measurability but has stronger hypotheses
+on `E`. In particular, it requires `E` to be a Borel space, which requires some second countability
+hypotheses if `E` is a product space. This version does not, which can be useful for instance
+if `L := Prod.fst`, which is always measurable. -/
 lemma isGaussian_map_of_measurable {E F : Type*} [TopologicalSpace E] [AddCommMonoid E]
     [Module ℝ E] {mE : MeasurableSpace E} [TopologicalSpace F] [AddCommMonoid F]
     [Module ℝ F] {mF : MeasurableSpace F} [OpensMeasurableSpace F] {μ : Measure E}
@@ -120,18 +125,8 @@ lemma IsGaussian.integrable_dual (μ : Measure E) [IsGaussian μ] (L : StrongDua
   exact IsGaussian.memLp_dual μ L 1 (by simp)
 
 /-- The map of a Gaussian measure by a continuous linear map is Gaussian. -/
-instance isGaussian_map (L : E →L[ℝ] F) : IsGaussian (μ.map L) where
-  map_eq_gaussianReal L' := by
-    rw [Measure.map_map (by fun_prop) (by fun_prop)]
-    change Measure.map (L'.comp L) μ = _
-    rw [IsGaussian.map_eq_gaussianReal (L'.comp L)]
-    congr
-    · rw [integral_map (by fun_prop) (by fun_prop)]
-      simp
-    · rw [← variance_id_map (by fun_prop)]
-      conv_rhs => rw [← variance_id_map (by fun_prop)]
-      rw [Measure.map_map (by fun_prop) (by fun_prop)]
-      simp
+instance isGaussian_map (L : E →L[ℝ] F) : IsGaussian (μ.map L) :=
+    isGaussian_map_of_measurable (by fun_prop)
 
 instance isGaussian_map_equiv (L : E ≃L[ℝ] F) : IsGaussian (μ.map L) :=
   isGaussian_map (L : E →L[ℝ] F)


### PR DESCRIPTION
Mathlib has [ProbabilityTheory.isGaussian_map](https://leanprover-community.github.io/mathlib4_docs/Mathlib/Probability/Distributions/Gaussian/Basic.html#ProbabilityTheory.isGaussian_map) which states that mapping a Gaussian measure by a continuous linear map yields a Gaussian measure. However this requires the domain of the linear map to be Borel, which in turns requires some second countability assumption if said domain is a product space. This Borel assumption is only needed to ensure that the continuous linear map is measurable, but for instance `Prod.fst` and `Prod.snd` are measurable regardless of Borel considerations. We thus provide a new version which much less assumptions on the space and with the extra assumption that the map is measurable. This avoids some second countability assumptions in #32144.

---
<!-- Your PR title will become the first line of the commit message.

In this box, the text above the `---` (if not empty) will be appended
to the commit message, and can be used to give additional context or
details. Please leave a blank newline before the `---`, otherwise GitHub
will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

When merging, all the commits will be squashed into a single commit
listing all co-authors.

Co-authors in the squash commit are gathered from two sources:

First, all authors of commits to this PR branch are included. Thus,
one way to add co-authors is to include at least one commit authored by
each co-author among the commits in the pull request. If necessary, you
may create empty commits to indicate co-authorship, using commands like so:

git commit --author="Author Name <author@email.com>" --allow-empty -m "add Author Name as coauthor"

Second, co-authors can also be listed in lines at the very bottom of
the commit message (that is, directly before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines
at the bottom of the commit message (before the `---`, and also before
any "Co-authored-by" lines) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
