### PR TITLE
[Merged by Bors] - fix(ci): use bot token for discover-lean-pr-testing merges

### DIFF
--- a/.github/workflows/discover-lean-pr-testing.yml
+++ b/.github/workflows/discover-lean-pr-testing.yml
@@ -18,11 +18,12 @@ jobs:
       with:
         ref: nightly-testing
         fetch-depth: 0  # Fetch all branches
+        token: ${{ secrets.NIGHTLY_TESTING }}
 
     - name: Set up Git
       run: |
-        git config --global user.name "github-actions"
-        git config --global user.email "github-actions@github.com"
+        git config --global user.name "leanprover-community-mathlib4-bot"
+        git config --global user.email "leanprover-community-mathlib4-bot@users.noreply.github.com"
 
     - name: Configure Lean
       uses: leanprover/lean-action@434f25c2f80ded67bba02502ad3a86f25db50709 # v1.3.0


### PR DESCRIPTION
This PR fixes an issue where merge commits from `lean-pr-testing-NNNN` branches weren't triggering CI.

The `discover-lean-pr-testing.yml` workflow was using the default `GITHUB_TOKEN` and `github-actions` identity when pushing merge commits. Due to GitHub's "actions don't trigger actions" policy, these commits didn't trigger CI runs.

This aligns with how `nightly_bump_toolchain.yml` and `nightly_merge_master.yml` handle pushes - using the `NIGHTLY_TESTING` token and the `leanprover-community-mathlib4-bot` identity.

Discovered via https://leanprover.zulipchat.com/#narrow/channel/428973-nightly-testing/topic/Mathlib.20status.20updates/near/563147856

🤖 Prepared with Claude Code