### PR TITLE
feat(Nat): Add `padicValNat_eq_primeFactorsList_count`

### DIFF
--- a/Mathlib/Data/Nat/Factorization/Defs.lean
+++ b/Mathlib/Data/Nat/Factorization/Defs.lean
@@ -93,7 +93,7 @@ theorem multiplicity_eq_factorization {n p : ℕ} (pp : p.Prime) (hn : n ≠ 0) 
 theorem padicValNat_eq_primeFactorsList_count {m p : ℕ} [hp : Fact p.Prime] :
     padicValNat p m = m.primeFactorsList.count p := by
   by_cases hm : m = 0
-  . simp [hm]
+  · simp [hm]
   · rw [primeFactorsList_count_eq, padicValNat_def hm, multiplicity_eq_factorization hp.out hm]
 
 /-! ### Basic facts about factorization -/

--- a/Mathlib/Data/Nat/Factorization/Defs.lean
+++ b/Mathlib/Data/Nat/Factorization/Defs.lean
@@ -92,9 +92,7 @@ theorem multiplicity_eq_factorization {n p : ℕ} (pp : p.Prime) (hn : n ≠ 0) 
 
 theorem padicValNat_eq_primeFactorsList_count {m p : ℕ} [hp : Fact p.Prime] :
     padicValNat p m = m.primeFactorsList.count p := by
-  by_cases hm : m = 0
-  · simp [hm]
-  · rw [primeFactorsList_count_eq, padicValNat_def hm, multiplicity_eq_factorization hp.out hm]
+  cases m <;> simp [primeFactorsList_count_eq, padicValNat_def, multiplicity_eq_factorization hp.out]
 
 /-! ### Basic facts about factorization -/
 

--- a/Mathlib/Data/Nat/Factorization/Defs.lean
+++ b/Mathlib/Data/Nat/Factorization/Defs.lean
@@ -92,7 +92,8 @@ theorem multiplicity_eq_factorization {n p : ℕ} (pp : p.Prime) (hn : n ≠ 0) 
 
 theorem padicValNat_eq_primeFactorsList_count {m p : ℕ} [hp : Fact p.Prime] :
     padicValNat p m = m.primeFactorsList.count p := by
-  cases m <;> simp [primeFactorsList_count_eq, padicValNat_def, multiplicity_eq_factorization hp.out]
+  cases m <;>
+    simp [primeFactorsList_count_eq, padicValNat_def, multiplicity_eq_factorization hp.out]
 
 /-! ### Basic facts about factorization -/
 

--- a/Mathlib/Data/Nat/Factorization/Defs.lean
+++ b/Mathlib/Data/Nat/Factorization/Defs.lean
@@ -77,12 +77,6 @@ theorem primeFactorsList_count_eq {n p : ℕ} : n.primeFactorsList.count p = n.f
     have := h.count_le p
     simp at this
 
-theorem padicValNat_eq_primeFactorsList_count {m p : ℕ} [hp : Fact p.Prime] :
-    padicValNat p m = m.primeFactorsList.count p := by
-  by_cases hm : m = 0
-  . simp [hm]
-  · rw [primeFactorsList_count_eq, padicValNat_def hm, multiplicity_eq_factorization hp.out hm]
-
 theorem factorization_eq_primeFactorsList_multiset (n : ℕ) :
     n.factorization = Multiset.toFinsupp (n.primeFactorsList : Multiset ℕ) := by
   ext p
@@ -95,6 +89,12 @@ theorem Prime.factorization_pos_of_dvd {n p : ℕ} (hp : p.Prime) (hn : n ≠ 0)
 theorem multiplicity_eq_factorization {n p : ℕ} (pp : p.Prime) (hn : n ≠ 0) :
     multiplicity p n = n.factorization p := by
   simp [factorization, pp, padicValNat_def' pp.ne_one hn]
+
+theorem padicValNat_eq_primeFactorsList_count {m p : ℕ} [hp : Fact p.Prime] :
+    padicValNat p m = m.primeFactorsList.count p := by
+  by_cases hm : m = 0
+  . simp [hm]
+  · rw [primeFactorsList_count_eq, padicValNat_def hm, multiplicity_eq_factorization hp.out hm]
 
 /-! ### Basic facts about factorization -/
 

--- a/Mathlib/Data/Nat/Factorization/Defs.lean
+++ b/Mathlib/Data/Nat/Factorization/Defs.lean
@@ -77,6 +77,12 @@ theorem primeFactorsList_count_eq {n p : ℕ} : n.primeFactorsList.count p = n.f
     have := h.count_le p
     simp at this
 
+theorem padicValNat_eq_primeFactorsList_count {m p : ℕ} [hp : Fact p.Prime] :
+    padicValNat p m = m.primeFactorsList.count p := by
+  by_cases hm : m = 0
+  . simp [hm]
+  · rw [primeFactorsList_count_eq, padicValNat_def hm, multiplicity_eq_factorization hp.out hm]
+
 theorem factorization_eq_primeFactorsList_multiset (n : ℕ) :
     n.factorization = Multiset.toFinsupp (n.primeFactorsList : Multiset ℕ) := by
   ext p


### PR DESCRIPTION
---
<!-- Your PR title will become the first line of the commit message.

In this box, the text above the `---` (if not empty) will be appended
to the commit message, and can be used to give additional context or
details. Please leave a blank newline before the `---`, otherwise GitHub
will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

When merging, all the commits will be squashed into a single commit
listing all co-authors.

Co-authors in the squash commit are gathered from two sources:

First, all authors of commits to this PR branch are included. Thus,
one way to add co-authors is to include at least one commit authored by
each co-author among the commits in the pull request. If necessary, you
may create empty commits to indicate co-authorship, using commands like so:

git commit --author="Author Name <author@email.com>" --allow-empty -m "add Author Name as coauthor"

Second, co-authors can also be listed in lines at the very bottom of
the commit message (that is, directly before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines
at the bottom of the commit message (before the `---`, and also before
any "Co-authored-by" lines) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
