### PR TITLE
chore: replace omega by lia

### DIFF
--- a/Mathlib/Algebra/BigOperators/Group/Finset/Interval.lean
+++ b/Mathlib/Algebra/BigOperators/Group/Finset/Interval.lean
@@ -27,7 +27,7 @@ lemma prod_Icc_of_even_eq_range {α : Type*} [CommGroup α] {f : ℤ → α} (hf
   induction N with
   | zero => simp [sq]
   | succ N ih =>
-    rw [Nat.cast_add, Nat.cast_one, Icc_succ_succ, prod_union (by simp), prod_pair (by omega), ih,
+    rw [Nat.cast_add, Nat.cast_one, Icc_succ_succ, prod_union (by simp), prod_pair (by lia), ih,
       prod_range_succ _ (N + 1), hf, ← pow_two, div_mul_eq_mul_div, ← mul_pow, Nat.cast_succ]
 
 @[to_additive]

--- a/Mathlib/Algebra/CharP/Lemmas.lean
+++ b/Mathlib/Algebra/CharP/Lemmas.lean
@@ -52,7 +52,7 @@ protected lemma add_pow_prime_pow_eq (h : Commute x y) (n : ℕ) :
   rw [h.add_pow_prime_pow_eq' hp, mul_assoc _ x, mul_assoc, mul_sum _ _ (_ * _)]
   congr! 3 with k hk
   obtain ⟨hk₀, hk⟩ := mem_Ioo.1 hk
-  rw [← mul_pow_sub_one (by omega), ← mul_pow_sub_one (n := p ^ n - k) (by omega)]
+  rw [← mul_pow_sub_one (by lia), ← mul_pow_sub_one (n := p ^ n - k) (by lia)]
   rw [(h.pow_left _).mul_mul_mul_comm, mul_assoc (x * y)]
 
 protected lemma add_pow_prime_eq' (h : Commute x y) :

--- a/Mathlib/Algebra/Homology/ComplexShapeSigns.lean
+++ b/Mathlib/Algebra/Homology/ComplexShapeSigns.lean
@@ -165,8 +165,8 @@ instance : TotalComplexShape c c c where
 
 instance : TensorSigns (ComplexShape.down ℕ) where
   ε' := MonoidHom.mk' (fun (i : ℕ) => (-1 : ℤˣ) ^ i) (pow_add (-1 : ℤˣ))
-  rel_add p q r (hpq : q + 1 = p) := by dsimp; omega
-  add_rel p q r (hpq : q + 1 = p) := by dsimp; omega
+  rel_add p q r (hpq : q + 1 = p) := by dsimp; lia
+  add_rel p q r (hpq : q + 1 = p) := by dsimp; lia
   ε'_succ := by
     rintro _ q rfl
     dsimp
@@ -177,8 +177,8 @@ lemma ε_down_ℕ (n : ℕ) : (ComplexShape.down ℕ).ε n = (-1 : ℤˣ) ^ n :=
 
 instance : TensorSigns (ComplexShape.up ℤ) where
   ε' := MonoidHom.mk' Int.negOnePow Int.negOnePow_add
-  rel_add p q r (hpq : p + 1 = q) := by dsimp; omega
-  add_rel p q r (hpq : p + 1 = q) := by dsimp; omega
+  rel_add p q r (hpq : p + 1 = q) := by dsimp; lia
+  add_rel p q r (hpq : p + 1 = q) := by dsimp; lia
   ε'_succ := by
     rintro p _ rfl
     dsimp

--- a/Mathlib/Algebra/Homology/DerivedCategory/Ext/Basic.lean
+++ b/Mathlib/Algebra/Homology/DerivedCategory/Ext/Basic.lean
@@ -416,7 +416,7 @@ noncomputable def extFunctorObj (X : C) (n : ℕ) : C ⥤ AddCommGrpCat.{w} wher
     rw [← Ext.mk₀_comp_mk₀]
     symm
     apply Ext.comp_assoc
-    omega
+    lia
 
 /-- The functor `Cᵒᵖ ⥤ C ⥤ AddCommGrpCat` which sends `X : C` and `Y : C`
 to `Ext X Y n`. -/
@@ -431,7 +431,7 @@ noncomputable def extFunctor (n : ℕ) : Cᵒᵖ ⥤ C ⥤ AddCommGrpCat.{w} whe
         dsimp
         symm
         apply Ext.comp_assoc
-        all_goals omega }
+        all_goals lia }
   map_comp {X₁ X₂ X₃} f f' := by
     ext Y α
     simp

--- a/Mathlib/Algebra/Homology/DerivedCategory/TStructure.lean
+++ b/Mathlib/Algebra/Homology/DerivedCategory/TStructure.lean
@@ -56,20 +56,20 @@ def TStructure.t : TStructure (DerivedCategory C) where
     apply (subsingleton_hom_of_isStrictlyLE_of_isStrictlyGE K L 0 1 (by simp)).elim
   le_zero_le := by
     rintro X ⟨K, e, _⟩
-    exact ⟨K, e, K.isStrictlyLE_of_le 0 1 (by omega)⟩
+    exact ⟨K, e, K.isStrictlyLE_of_le 0 1 (by lia)⟩
   ge_one_le := by
     rintro X ⟨K, e, _⟩
-    exact ⟨K, e, K.isStrictlyGE_of_ge 0 1 (by omega)⟩
+    exact ⟨K, e, K.isStrictlyGE_of_ge 0 1 (by lia)⟩
   exists_triangle_zero_one X := by
     obtain ⟨K, ⟨e₂⟩⟩ : ∃ K, Nonempty (Q.obj K ≅ X) := ⟨_, ⟨Q.objObjPreimageIso X⟩⟩
     have h := K.shortComplexTruncLE_shortExact 0
     refine ⟨Q.obj (K.truncLE 0), Q.obj (K.truncGE 1),
       ⟨_, Iso.refl _, inferInstance⟩, ⟨_, Iso.refl _, inferInstance⟩,
       Q.map (K.ιTruncLE 0) ≫ e₂.hom, e₂.inv ≫ Q.map (K.πTruncGE 1),
-      inv (Q.map (K.shortComplexTruncLEX₃ToTruncGE 0 1 (by omega))) ≫ (triangleOfSES h).mor₃,
+      inv (Q.map (K.shortComplexTruncLEX₃ToTruncGE 0 1 (by lia))) ≫ (triangleOfSES h).mor₃,
       isomorphic_distinguished _ (triangleOfSES_distinguished h) _ (Iso.symm ?_)⟩
     refine Triangle.isoMk _ _ (Iso.refl _) e₂
-      (asIso (Q.map (K.shortComplexTruncLEX₃ToTruncGE 0 1 (by omega)))) ?_ ?_ (by simp)
+      (asIso (Q.map (K.shortComplexTruncLEX₃ToTruncGE 0 1 (by lia)))) ?_ ?_ (by simp)
     · dsimp
       rw [id_comp]
       rfl

--- a/Mathlib/Algebra/Homology/Embedding/AreComplementary.lean
+++ b/Mathlib/Algebra/Homology/Embedding/AreComplementary.lean
@@ -280,12 +280,12 @@ end AreComplementary
 
 lemma embeddingUpInt_areComplementary (n₀ n₁ : ℤ) (h : n₀ + 1 = n₁) :
     AreComplementary (embeddingUpIntLE n₀) (embeddingUpIntGE n₁) where
-  disjoint i₁ i₂ := by dsimp; omega
+  disjoint i₁ i₂ := by dsimp; lia
   union i := by
     by_cases hi : i ≤ n₀
     · obtain ⟨k, rfl⟩ := Int.exists_add_of_le hi
-      exact Or.inl ⟨k, by dsimp; omega⟩
-    · obtain ⟨k, rfl⟩ := Int.exists_add_of_le (show n₁ ≤ i by omega)
+      exact Or.inl ⟨k, by dsimp; lia⟩
+    · obtain ⟨k, rfl⟩ := Int.exists_add_of_le (show n₁ ≤ i by lia)
       exact Or.inr ⟨k, rfl⟩
 
 end Embedding

--- a/Mathlib/Algebra/Homology/Embedding/Basic.lean
+++ b/Mathlib/Algebra/Homology/Embedding/Basic.lean
@@ -223,7 +223,7 @@ def embeddingDownNat : Embedding (down ℕ) (up ℤ) :=
 instance : embeddingDownNat.IsRelIff := by dsimp [embeddingDownNat]; infer_instance
 
 instance : embeddingDownNat.IsTruncLE where
-  mem_prev {i j} h := ⟨j + 1, by dsimp at h ⊢; omega⟩
+  mem_prev {i j} h := ⟨j + 1, by dsimp at h ⊢; lia⟩
 
 variable (p : ℤ)
 
@@ -237,7 +237,7 @@ def embeddingUpIntGE : Embedding (up ℕ) (up ℤ) :=
 instance : (embeddingUpIntGE p).IsRelIff := by dsimp [embeddingUpIntGE]; infer_instance
 
 instance : (embeddingUpIntGE p).IsTruncGE where
-  mem_next {j _} h := ⟨j + 1, by dsimp at h ⊢; omega⟩
+  mem_next {j _} h := ⟨j + 1, by dsimp at h ⊢; lia⟩
 
 /-- The embedding from `down ℕ` to `up ℤ` which sends `n : ℕ` to `p - n`. -/
 @[simps!]
@@ -249,7 +249,7 @@ def embeddingUpIntLE : Embedding (down ℕ) (up ℤ) :=
 instance : (embeddingUpIntLE p).IsRelIff := by dsimp [embeddingUpIntLE]; infer_instance
 
 instance : (embeddingUpIntLE p).IsTruncLE where
-  mem_prev {_ k} h := ⟨k + 1, by dsimp at h ⊢; omega⟩
+  mem_prev {_ k} h := ⟨k + 1, by dsimp at h ⊢; lia⟩
 
 lemma notMem_range_embeddingUpIntLE_iff (n : ℤ) :
     (∀ (i : ℕ), (embeddingUpIntLE p).f i ≠ n) ↔ p < n := by

--- a/Mathlib/Algebra/Homology/ExactSequence.lean
+++ b/Mathlib/Algebra/Homology/ExactSequence.lean
@@ -105,7 +105,7 @@ lemma isComplex₀ (S : ComposableArrows C 0) : S.IsComplex where
   zero i hi := by simp at hi
 
 lemma isComplex₁ (S : ComposableArrows C 1) : S.IsComplex where
-  zero i hi := by omega
+  zero i hi := by lia
 
 variable (S)
 
@@ -192,7 +192,7 @@ lemma exact₀ (S : ComposableArrows C 0) : S.Exact where
 
 lemma exact₁ (S : ComposableArrows C 1) : S.Exact where
   toIsComplex := S.isComplex₁
-  exact i hi := by exfalso; omega
+  exact i hi := by exfalso; lia
 
 lemma isComplex₂_iff (S : ComposableArrows C 2) :
     S.IsComplex ↔ S.map' 0 1 ≫ S.map' 1 2 = 0 := by

--- a/Mathlib/Algebra/Homology/HomotopyCategory/DegreewiseSplit.lean
+++ b/Mathlib/Algebra/Homology/HomotopyCategory/DegreewiseSplit.lean
@@ -87,8 +87,8 @@ noncomputable def mappingConeHomOfDegreewiseSplitXIso (p q : ℤ) (hpq : p + 1 =
     (mappingCone (homOfDegreewiseSplit S σ)).X p ≅ S.X₂.X q where
   hom := (mappingCone.fst (homOfDegreewiseSplit S σ)).1.v p q hpq ≫ (σ q).s -
     (mappingCone.snd (homOfDegreewiseSplit S σ)).v p p (add_zero p) ≫
-      by exact (Cochain.ofHom S.f).v (p + 1) q (by omega)
-  inv := S.g.f q ≫ (mappingCone.inl (homOfDegreewiseSplit S σ)).v q p (by omega) -
+      by exact (Cochain.ofHom S.f).v (p + 1) q (by lia)
+  inv := S.g.f q ≫ (mappingCone.inl (homOfDegreewiseSplit S σ)).v q p (by lia) -
     by exact (σ q).r ≫ (S.X₁.XIsoOfEq hpq.symm).hom ≫
       (mappingCone.inr (homOfDegreewiseSplit S σ)).f p
   hom_inv_id := by
@@ -196,7 +196,7 @@ cochain complexes. -/
 @[simps]
 noncomputable def triangleRotateShortComplexSplitting (n : ℤ) :
     ((triangleRotateShortComplex φ).map (eval _ _ n)).Splitting where
-  s := -(inl φ).v (n + 1) n (by omega)
+  s := -(inl φ).v (n + 1) n (by lia)
   r := (snd φ).v n n (add_zero n)
   id := by simp [ext_from_iff φ _ _ rfl]
 

--- a/Mathlib/Algebra/Homology/HomotopyCategory/HomComplex.lean
+++ b/Mathlib/Algebra/Homology/HomotopyCategory/HomComplex.lean
@@ -771,7 +771,7 @@ def equivHomotopy (φ₁ φ₂ : F ⟶ G) :
   toFun ho := ⟨Cochain.ofHomotopy ho, by simp only [δ_ofHomotopy, sub_add_cancel]⟩
   invFun z :=
     { hom := fun i j => if hij : i + (-1) = j then z.1.v i j hij else 0
-      zero := fun i j (hij : j + 1 ≠ i) => dif_neg (fun _ => hij (by omega))
+      zero := fun i j (hij : j + 1 ≠ i) => dif_neg (fun _ => hij (by lia))
       comm := fun p => by
         have eq := Cochain.congr_v z.2 p p (add_zero p)
         have h₁ : (ComplexShape.up ℤ).Rel (p - 1) p := by simp
@@ -784,7 +784,7 @@ def equivHomotopy (φ₁ φ₂ : F ⟶ G) :
     dsimp
     split_ifs with h
     · rfl
-    · rw [ho.zero i j (fun h' => h (by dsimp at h'; omega))]
+    · rw [ho.zero i j (fun h' => h (by dsimp at h'; lia))]
   right_inv := fun z => by
     ext p q hpq
     dsimp [Cochain.ofHomotopy]

--- a/Mathlib/Algebra/Homology/HomotopyCategory/Pretriangulated.lean
+++ b/Mathlib/Algebra/Homology/HomotopyCategory/Pretriangulated.lean
@@ -233,10 +233,10 @@ noncomputable def rotateHomotopyEquiv :
         Int.negOnePow_neg, Int.negOnePow_one, δ_snd, Cochain.neg_comp,
         Cochain.comp_assoc_of_second_is_zero_cochain, smul_neg, Units.neg_smul, one_smul,
         neg_neg, Cochain.comp_add, inr_snd_assoc, neg_add_rev, Cochain.add_v, Cochain.neg_v,
-        Cochain.comp_v _ _ (add_neg_cancel 1) n (n + 1) n rfl (by omega),
+        Cochain.comp_v _ _ (add_neg_cancel 1) n (n + 1) n rfl (by lia),
         Cochain.zero_cochain_comp_v, Cochain.ofHom_v, HomologicalComplex.id_f,
         ext_to_iff _ _ (n + 1) rfl, assoc, liftCochain_v_fst_v,
-        (Cochain.ofHom φ).leftShift_v 1 1 (zero_add 1) n (n + 1) rfl (n + 1) (by omega),
+        (Cochain.ofHom φ).leftShift_v 1 1 (zero_add 1) n (n + 1) rfl (n + 1) (by lia),
         shiftFunctor_obj_X, mul_one, sub_self, mul_zero, Int.zero_ediv, add_zero,
         shiftFunctorObjXIso, HomologicalComplex.XIsoOfEq_rfl, Iso.refl_hom, id_comp,
         Preadditive.add_comp, Preadditive.neg_comp, inl_v_fst_v, comp_id, inr_f_fst_v, comp_zero,
@@ -245,7 +245,7 @@ noncomputable def rotateHomotopyEquiv :
         inr_f_descCochain_v_assoc, inr_f_snd_v_assoc, inl_v_triangle_mor₃_f_assoc, triangle_obj₁,
         Iso.refl_inv, inl_v_fst_v_assoc, inr_f_triangle_mor₃_f_assoc, inr_f_fst_v_assoc, and_self,
         liftCochain_v_snd_v,
-        (inl φ).leftShift_v 1 0 (neg_add_cancel 1) n n (add_zero n) (n + 1) (by omega),
+        (inl φ).leftShift_v 1 0 (neg_add_cancel 1) n n (add_zero n) (n + 1) (by lia),
         Int.negOnePow_zero, inl_v_snd_v, inr_f_snd_v, zero_add, inl_v_descCochain_v,
         inr_f_descCochain_v, inl_v_triangle_mor₃_f, inr_f_triangle_mor₃_f, neg_add_cancel]⟩
 

--- a/Mathlib/Algebra/Homology/HomotopyCategory/Shift.lean
+++ b/Mathlib/Algebra/Homology/HomotopyCategory/Shift.lean
@@ -55,7 +55,7 @@ def shiftFunctor (n : ℤ) : CochainComplex C ℤ ⥤ CochainComplex C ℤ where
         intro hij'
         apply hij
         dsimp at hij' ⊢
-        omega }
+        lia }
   map φ :=
     { f := fun _ => φ.f _
       comm' := by
@@ -281,15 +281,15 @@ def shift {K L : CochainComplex C ℤ} {φ₁ φ₂ : K ⟶ L} (h : Homotopy φ�
     rw [h.zero, smul_zero]
     intro hij'
     dsimp at hij hij'
-    omega
+    lia
   comm := fun i => by
     rw [dNext_eq _ (show (ComplexShape.up ℤ).Rel i (i + 1) by simp),
       prevD_eq _ (show (ComplexShape.up ℤ).Rel (i - 1) i by simp)]
     dsimp
     simpa only [Linear.units_smul_comp, Linear.comp_units_smul, smul_smul,
       Int.units_mul_self, one_smul,
-      dNext_eq _ (show (ComplexShape.up ℤ).Rel (i + n) (i + 1 + n) by dsimp; omega),
-      prevD_eq _ (show (ComplexShape.up ℤ).Rel (i - 1 + n) (i + n) by dsimp; omega)]
+      dNext_eq _ (show (ComplexShape.up ℤ).Rel (i + n) (i + 1 + n) by dsimp; lia),
+      prevD_eq _ (show (ComplexShape.up ℤ).Rel (i - 1 + n) (i + n) by dsimp; lia)]
         using h.comm (i + n)
 
 end Homotopy

--- a/Mathlib/Algebra/Homology/HomotopyCategory/SingleFunctors.lean
+++ b/Mathlib/Algebra/Homology/HomotopyCategory/SingleFunctors.lean
@@ -42,14 +42,14 @@ noncomputable def singleFunctors : SingleFunctors C (CochainComplex C ℤ) ℤ w
   shiftIso n a a' ha' := NatIso.ofComponents
     (fun X => Hom.isoOfComponents
       (fun i => eqToIso (by
-        obtain rfl : a' = a + n := by omega
+        obtain rfl : a' = a + n := by lia
         by_cases h : i = a
         · subst h
           simp only [Functor.comp_obj, shiftFunctor_obj_X', single_obj_X_self]
         · dsimp [single]
-          rw [if_neg h, if_neg (fun h' => h (by omega))])))
+          rw [if_neg h, if_neg (fun h' => h (by lia))])))
     (fun {X Y} f => by
-      obtain rfl : a' = a + n := by omega
+      obtain rfl : a' = a + n := by lia
       ext
       simp [single])
   shiftIso_zero a := by

--- a/Mathlib/Algebra/Homology/LeftResolution/Basic.lean
+++ b/Mathlib/Algebra/Homology/LeftResolution/Basic.lean
@@ -99,7 +99,7 @@ attribute [irreducible] chainComplex
 lemma exactAt_map_chainComplex_succ (n : ℕ) :
     ((ι.mapHomologicalComplex _).obj (Λ.chainComplex X)).ExactAt (n + 1) := by
   rw [HomologicalComplex.exactAt_iff' _ (n + 2) (n + 1) n
-    (ComplexShape.prev_eq' _ (by dsimp; omega)) (by simp),
+    (ComplexShape.prev_eq' _ (by dsimp; lia)) (by simp),
     ShortComplex.exact_iff_epi_kernel_lift]
   convert epi_comp (ι.map (Λ.chainComplexXIso X n).hom) (Λ.π.app _)
   rw [← cancel_mono (kernel.ι _), kernel.lift_ι]

--- a/Mathlib/Algebra/Homology/TotalComplexShift.lean
+++ b/Mathlib/Algebra/Homology/TotalComplexShift.lean
@@ -123,16 +123,16 @@ instance : ((shiftFunctor₁ C x ⋙ shiftFunctor₂ C y).obj K).HasTotal (up �
 /-- Auxiliary definition for `totalShift₁Iso`. -/
 noncomputable def totalShift₁XIso (n n' : ℤ) (h : n + x = n') :
     (((shiftFunctor₁ C x).obj K).total (up ℤ)).X n ≅ (K.total (up ℤ)).X n' where
-  hom := totalDesc _ (fun p q hpq => K.ιTotal (up ℤ) (p + x) q n' (by dsimp at hpq ⊢; omega))
+  hom := totalDesc _ (fun p q hpq => K.ιTotal (up ℤ) (p + x) q n' (by dsimp at hpq ⊢; lia))
   inv := totalDesc _ (fun p q hpq =>
     (K.XXIsoOfEq _ _ _ (Int.sub_add_cancel p x) rfl).inv ≫
       ((shiftFunctor₁ C x).obj K).ιTotal (up ℤ) (p - x) q n
-        (by dsimp at hpq ⊢; omega))
+        (by dsimp at hpq ⊢; lia))
   hom_inv_id := by
     ext p q h
     dsimp
     simp only [ι_totalDesc_assoc, CochainComplex.shiftFunctor_obj_X', ι_totalDesc, comp_id]
-    exact ((shiftFunctor₁ C x).obj K).XXIsoOfEq_inv_ιTotal _ (by omega) rfl _ _
+    exact ((shiftFunctor₁ C x).obj K).XXIsoOfEq_inv_ιTotal _ (by lia) rfl _ _
   inv_hom_id := by
     ext
     dsimp
@@ -225,16 +225,16 @@ lemma totalShift₁Iso_hom_naturality [L.HasTotal (up ℤ)] :
 noncomputable def totalShift₂XIso (n n' : ℤ) (h : n + y = n') :
     (((shiftFunctor₂ C y).obj K).total (up ℤ)).X n ≅ (K.total (up ℤ)).X n' where
   hom := totalDesc _ (fun p q hpq => (p * y).negOnePow • K.ιTotal (up ℤ) p (q + y) n'
-    (by dsimp at hpq ⊢; omega))
+    (by dsimp at hpq ⊢; lia))
   inv := totalDesc _ (fun p q hpq => (p * y).negOnePow •
     (K.XXIsoOfEq _ _ _ rfl (Int.sub_add_cancel q y)).inv ≫
-      ((shiftFunctor₂ C y).obj K).ιTotal (up ℤ) p (q - y) n (by dsimp at hpq ⊢; omega))
+      ((shiftFunctor₂ C y).obj K).ιTotal (up ℤ) p (q - y) n (by dsimp at hpq ⊢; lia))
   hom_inv_id := by
     ext p q h
     dsimp
     simp only [ι_totalDesc_assoc, Linear.units_smul_comp, ι_totalDesc, smul_smul,
       Int.units_mul_self, one_smul, comp_id]
-    exact ((shiftFunctor₂ C y).obj K).XXIsoOfEq_inv_ιTotal _ rfl (by omega) _ _
+    exact ((shiftFunctor₂ C y).obj K).XXIsoOfEq_inv_ιTotal _ rfl (by lia) _ _
   inv_hom_id := by
     ext
     dsimp

--- a/Mathlib/Algebra/Lie/Weights/RootSystem.lean
+++ b/Mathlib/Algebra/Lie/Weights/RootSystem.lean
@@ -365,7 +365,7 @@ def reflectRoot (α β : Weight K H L) : Weight K H L where
     · simpa [hα.eq] using β.genWeightSpace_ne_bot
     rw [sub_eq_neg_add, apply_coroot_eq_cast α β, ← neg_smul, ← Int.cast_neg,
       Int.cast_smul_eq_zsmul, rootSpace_zsmul_add_ne_bot_iff α β hα]
-    omega
+    lia
 
 lemma reflectRoot_isNonZero (α β : Weight K H L) (hβ : β.IsNonZero) :
     (reflectRoot α β).IsNonZero := by

--- a/Mathlib/Algebra/LinearRecurrence.lean
+++ b/Mathlib/Algebra/LinearRecurrence.lean
@@ -75,7 +75,7 @@ def mkSol (init : Fin E.order → R) : ℕ → R
     if h : n < E.order then init ⟨n, h⟩
     else
       ∑ k : Fin E.order,
-        have _ : n - E.order + k < n := by omega
+        have _ : n - E.order + k < n := by lia
         E.coeffs k * mkSol init (n - E.order + k)
 
 /-- `E.mkSol` indeed gives solutions to `E`. -/

--- a/Mathlib/Algebra/Module/ZLattice/Summable.lean
+++ b/Mathlib/Algebra/Module/ZLattice/Summable.lean
@@ -123,9 +123,9 @@ lemma sum_piFinset_Icc_rpow_le {ι : Type*} [Fintype ι] [DecidableEq ι]
       norm_num at this
       zify
       convert this using 3
-      · rw [abs_eq_self.mpr (sub_nonneg.mpr (by gcongr; omega)), Nat.cast_sub (by gcongr; omega)]
+      · rw [abs_eq_self.mpr (sub_nonneg.mpr (by gcongr; lia)), Nat.cast_sub (by gcongr; lia)]
         simp
-      · rw [max_eq_left (by gcongr; omega), abs_eq_self.mpr (by positivity)]
+      · rw [max_eq_left (by gcongr; lia), abs_eq_self.mpr (by positivity)]
   let ε := normBound b
   have hε : 0 < ε := normBound_pos b
   calc ∑ p ∈ s n, ‖∑ i, p i • b i‖ ^ r
@@ -146,7 +146,7 @@ lemma sum_piFinset_Icc_rpow_le {ι : Type*} [Fintype ι] [DecidableEq ι]
         gcongr with k hk
         refine (this _).trans ?_
         gcongr
-        omega
+        lia
     _ = 2 * d * 3 ^ (d - 1) * ε ^ r * ∑ k ∈ range n, (k + 1) ^ (d - 1) * (k + 1 : ℝ) ^ r := by
         simp_rw [Finset.mul_sum]
         congr with k

--- a/Mathlib/Algebra/Order/Group/Int/Sum.lean
+++ b/Mathlib/Algebra/Order/Group/Int/Sum.lean
@@ -33,7 +33,7 @@ lemma sum_le_sum_Ioc {s : Finset ℤ} {c : ℤ} (hs : ∀ x ∈ s, x ≤ c) :
       gcongr
       refine sum_le_card_nsmul _ _ _ fun x mx ↦ ?_
       rw [mem_sdiff, mem_Ioc, not_and'] at mx
-      have := mx.2 (hs _ mx.1); omega
+      have := mx.2 (hs _ mx.1); lia
     _ = ∑ x ∈ r ∩ s, x + #(r \ s) • (c - #s) := by
       rw [inter_comm, card_sdiff_comm]
       rw [Int.card_Ioc, sub_sub_cancel, Int.toNat_natCast]
@@ -68,7 +68,7 @@ lemma sum_Ico_le_sum {s : Finset ℤ} {c : ℤ} (hs : ∀ x ∈ s, c ≤ x) :
     _ ≤ _ := by
       grw [← sum_inter_add_sum_diff s r, card_nsmul_le_sum _ _ _ fun x mx ↦ ?_]
       rw [mem_sdiff, mem_Ico, not_and] at mx
-      have := mx.2 (hs _ mx.1); omega
+      have := mx.2 (hs _ mx.1); lia
 
 /-- Sharp lower bound for the sum of a finset of integers that is bounded below, `range` version. -/
 lemma sum_range_le_sum {s : Finset ℤ} {c : ℤ} (hs : ∀ x ∈ s, c ≤ x) :
@@ -79,6 +79,6 @@ lemma sum_range_le_sum {s : Finset ℤ} {c : ℤ} (hs : ∀ x ∈ s, c ≤ x) :
   · intro x mx y my (h : c + x = c + y); lia
   · intro x mx; simp_rw [coe_range, Set.mem_image, Set.mem_Iio]
     rw [mem_coe, mem_Ico] at mx
-    use (x - c).toNat; omega
+    use (x - c).toNat; lia
 
 end Finset

--- a/Mathlib/Algebra/Polynomial/EraseLead.lean
+++ b/Mathlib/Algebra/Polynomial/EraseLead.lean
@@ -299,13 +299,13 @@ lemma eraseLead_mul_eq_mul_eraseLead_of_nextCoeff_zero {R : Type*} [Ring R] [NoZ
     have hd₁ : n < ((X - C x) * P).eraseLead.natDegree := by
       linarith [natDegree_eraseLead_add_one h₂]
     rw [← self_sub_monomial_natDegree_leadingCoeff, coeff_sub, coeff_monomial, if_neg hd₁.ne']
-    rw [← self_sub_monomial_natDegree_leadingCoeff, coeff_sub, coeff_monomial, if_neg (by omega)]
+    rw [← self_sub_monomial_natDegree_leadingCoeff, coeff_sub, coeff_monomial, if_neg (by lia)]
     rw [← self_sub_monomial_natDegree_leadingCoeff, mul_sub, coeff_sub,
       sub_zero, sub_zero, eq_sub_iff_add_eq, add_eq_left]
     rcases hn₂ : n
-    · simpa [coeff_monomial, hp] using fun _ ↦ by omega
-    · rw [coeff_X_sub_C_mul, coeff_monomial, coeff_monomial, if_neg (by omega),
-        if_neg (by omega), mul_zero, sub_zero]
+    · simpa [coeff_monomial, hp] using fun _ ↦ by lia
+    · rw [coeff_X_sub_C_mul, coeff_monomial, coeff_monomial, if_neg (by lia),
+        if_neg (by lia), mul_zero, sub_zero]
   · --n ≥ P.natDegree, so all the coefficients are zero.
     trans 0 <;> rw [coeff_eq_zero_of_natDegree_lt]
     · grw [eraseLead_natDegree_le, eraseLead_natDegree_le]

--- a/Mathlib/AlgebraicTopology/DoldKan/Projections.lean
+++ b/Mathlib/AlgebraicTopology/DoldKan/Projections.lean
@@ -92,7 +92,7 @@ namespace HigherFacesVanish
 /-- This lemma expresses the vanishing of
 `(P q).f (n+1) ≫ X.δ k : X _⦋n+1⦌ ⟶ X _⦋n⦌` when `k≠0` and `k≥n-q+2` -/
 theorem of_P : ∀ q n : ℕ, HigherFacesVanish q ((P q).f (n + 1) : X _⦋n + 1⦌ ⟶ X _⦋n + 1⦌)
-  | 0 => fun n j hj₁ => by omega
+  | 0 => fun n j hj₁ => by lia
   | q + 1 => fun n => by
     simp only [P_succ]
     exact (of_P q n).induction

--- a/Mathlib/AlgebraicTopology/SimplexCategory/Augmented/Monoidal.lean
+++ b/Mathlib/AlgebraicTopology/SimplexCategory/Augmented/Monoidal.lean
@@ -75,8 +75,8 @@ def tensorHomOf {x₁ y₁ x₂ y₂ : SimplexCategory} (f₁ : x₁ ⟶ y₁) (
         simp [Fin.coe_castAdd, Fin.coe_natAdd, Fin.addCases_left,
           Fin.addCases_right] at h ⊢
         · case left.left i j => exact f₁.toOrderHom.monotone h
-        · case left.right i j => omega
-        · case right.left i j => omega
+        · case left.right i j => lia
+        · case right.left i j => lia
         · case right.right i j => exact f₂.toOrderHom.monotone h }
   (eqToHom (congrArg _ (Nat.succ_add _ _)).symm ≫ (SimplexCategory.mkHom f₁) ≫
     eqToHom (congrArg _ (Nat.succ_add _ _)) : _ ⟶ ⦋y₁.len + y₂.len + 1⦌)

--- a/Mathlib/AlgebraicTopology/SimplicialSet/Dimension.lean
+++ b/Mathlib/AlgebraicTopology/SimplicialSet/Dimension.lean
@@ -53,7 +53,7 @@ lemma dim_le_of_nonDegenerate {n : ℕ} (x : X.nonDegenerate n) (d : ℕ)
     [X.HasDimensionLE d] : n ≤ d :=
   Nat.le_of_lt_succ (X.dim_lt_of_nonDegenerate x (d + 1))
 
-lemma hasDimensionLT_of_le (hn : d ≤ n := by cutsat) : HasDimensionLT X n where
+lemma hasDimensionLT_of_le (hn : d ≤ n := by lia) : HasDimensionLT X n where
   degenerate_eq_top i hi :=
     X.degenerate_eq_top_of_hasDimensionLT d i (hn.trans hi)
 

--- a/Mathlib/AlgebraicTopology/SimplicialSet/Nerve.lean
+++ b/Mathlib/AlgebraicTopology/SimplicialSet/Nerve.lean
@@ -73,7 +73,7 @@ def nerveFunctor : Cat.{v, u} ⥤ SSet where
 
 /-- The 0-simplices of the nerve of a category are equivalent to the objects of the category. -/
 def nerveEquiv {C : Type u} [Category.{v} C] : ComposableArrows C 0 ≃ C where
-  toFun f := f.obj ⟨0, by omega⟩
+  toFun f := f.obj ⟨0, by lia⟩
   invFun f := ComposableArrows.mk₀ f
   left_inv f := ComposableArrows.ext₀ rfl
 

--- a/Mathlib/AlgebraicTopology/SimplicialSet/NerveAdjunction.lean
+++ b/Mathlib/AlgebraicTopology/SimplicialSet/NerveAdjunction.lean
@@ -160,14 +160,14 @@ lemma naturalityProperty_eq_top :
       · ext; apply hδ'₀ f₀ f₁ hδ₁ hδ₀ hY
       · ext; apply hδ'₁ f₀ f₁ hδ₁ hδ₀ H hY
       · ext; apply hδ'₂ f₀ f₁ hδ₁ hδ₀ hY
-    · cutsat
+    · lia
   · obtain _ | _ | n := n
     · fin_cases i
       ext; apply hσ
     · fin_cases i
       · ext; apply hσ'₀ f₀ f₁ hδ₁ hδ₀ hσ hY
       · ext; apply hσ'₁ f₀ f₁ hδ₁ hδ₀ hσ hY
-    · cutsat
+    · lia
 
 end liftOfStrictSegal
 

--- a/Mathlib/AlgebraicTopology/SimplicialSet/Path.lean
+++ b/Mathlib/AlgebraicTopology/SimplicialSet/Path.lean
@@ -105,10 +105,10 @@ def mk₂ {n : ℕ} {X : Truncated.{u} (n + 1)} (p q : X.Path 1)
 /-- For `j + l ≤ m`, a path of length `m` restricts to a path of length `l`, namely
 the subpath spanned by the vertices `j ≤ i ≤ j + l` and edges `j ≤ i < j + l`. -/
 def interval (f : Path X m) (j l : ℕ) (h : j + l ≤ m := by omega) : Path X l where
-  vertex i := f.vertex ⟨j + i, by omega⟩
-  arrow i := f.arrow ⟨j + i, by omega⟩
-  arrow_src i := f.arrow_src ⟨j + i, by omega⟩
-  arrow_tgt i := f.arrow_tgt ⟨j + i, by omega⟩
+  vertex i := f.vertex ⟨j + i, by lia⟩
+  arrow i := f.arrow ⟨j + i, by lia⟩
+  arrow_src i := f.arrow_src ⟨j + i, by lia⟩
+  arrow_tgt i := f.arrow_tgt ⟨j + i, by lia⟩
 
 variable {X Y : SSet.Truncated.{u} (n + 1)} {m : ℕ}
 

--- a/Mathlib/Analysis/Calculus/ContDiff/FaaDiBruno.lean
+++ b/Mathlib/Analysis/Calculus/ContDiff/FaaDiBruno.lean
@@ -551,7 +551,7 @@ def eraseMiddle (c : OrderedFinpartition (n + 1)) (hc : range (c.emb 0) ≠ {0})
       · simp only [↓reduceDIte, update_self, succ_mk, cast_mk, coe_pred]
         have A := c.one_lt_partSize_index_zero hc
         rw [Nat.sub_add_cancel]
-        · congr; omega
+        · congr; lia
         · rw [Order.one_le_iff_pos]
           conv_lhs => rw [show (0 : ℕ) = c.emb (c.index 0) 0 by simp [emb_zero]]
           rw [← lt_def]
@@ -562,12 +562,12 @@ def eraseMiddle (c : OrderedFinpartition (n + 1)) (hc : range (c.emb 0) ≠ {0})
         have : c.emb i ⟨c.partSize i - 1, Nat.sub_one_lt_of_lt (c.partSize_pos i)⟩
             ≠ c.emb (c.index 0) 0 := c.emb_ne_emb_of_ne hi
         simp only [c.emb_zero, ne_eq, ← val_eq_val, val_zero] at this
-        omega
+        lia
     · rcases eq_or_ne j (c.index 0) with rfl | hj
       · simp only [↓reduceDIte, update_self, succ_mk, cast_mk, coe_pred]
         have A := c.one_lt_partSize_index_zero hc
         rw [Nat.sub_add_cancel]
-        · congr; omega
+        · congr; lia
         · rw [Order.one_le_iff_pos]
           conv_lhs => rw [show (0 : ℕ) = c.emb (c.index 0) 0 by simp [emb_zero]]
           rw [← lt_def]
@@ -578,7 +578,7 @@ def eraseMiddle (c : OrderedFinpartition (n + 1)) (hc : range (c.emb 0) ≠ {0})
         have : c.emb j ⟨c.partSize j - 1, Nat.sub_one_lt_of_lt (c.partSize_pos j)⟩
             ≠ c.emb (c.index 0) 0 := c.emb_ne_emb_of_ne hj
         simp only [c.emb_zero, ne_eq, ← val_eq_val, val_zero] at this
-        omega
+        lia
   disjoint i _ j _ hij := by
     wlog h : i ≠ c.index 0 generalizing i j
     · apply Disjoint.symm
@@ -620,7 +620,7 @@ def eraseMiddle (c : OrderedFinpartition (n + 1)) (hc : range (c.emb 0) ≠ {0})
         congr 1
         rw [← val_eq_val]
         simp only [coe_cast, val_succ, coe_pred]
-        omega
+        lia
     · have A : update c.partSize (c.index 0) (c.partSize (c.index 0) - 1) i = c.partSize i := by
         simp [hi]
       exact ⟨i, Fin.cast A.symm j, by simp [hi, hij]⟩

--- a/Mathlib/Analysis/Complex/Polynomial/Basic.lean
+++ b/Mathlib/Analysis/Complex/Polynomial/Basic.lean
@@ -167,7 +167,7 @@ theorem galActionHom_bijective_of_prime_degree' {p : ℚ[X]} (p_irr : Irreducibl
           map_one, map_one])
   have key := card_complex_roots_eq_card_real_add_card_not_gal_inv p
   simp_rw [Set.toFinset_card] at key
-  omega
+  lia
 
 end Rationals
 

--- a/Mathlib/Analysis/Convex/Between.lean
+++ b/Mathlib/Analysis/Convex/Between.lean
@@ -665,10 +665,10 @@ lemma closedInterior_face_eq_affineSegment {n : ℕ} (s : Simplex R P n) {i j : 
   congr 2
   · convert Finset.orderEmbOfFin_zero _ _
     · exact (Finset.min'_pair i j).symm
-    · omega
+    · lia
   · convert Finset.orderEmbOfFin_last _ _
     · exact (Finset.max'_pair i j).symm
-    · omega
+    · lia
 
 /-- A point lies in the closed interior of a 1-dimensional face of a simplex if and only if it lies
 weakly between its vertices. -/
@@ -719,10 +719,10 @@ lemma mem_interior_face_iff_sbtw [Nontrivial R] [NoZeroSMulDivisors R V] {n : �
   congr! 4
   · convert Finset.orderEmbOfFin_zero _ _
     · exact (Finset.min'_pair i j).symm
-    · omega
+    · lia
   · convert Finset.orderEmbOfFin_last _ _
     · exact (Finset.max'_pair i j).symm
-    · omega
+    · lia
 
 end Simplex
 

--- a/Mathlib/Analysis/Normed/Unbundled/SeminormFromConst.lean
+++ b/Mathlib/Analysis/Normed/Unbundled/SeminormFromConst.lean
@@ -151,7 +151,7 @@ def seminormFromConst : RingSeminorm R where
       apply (seminormFromConst_isLimit hf1 hc hpm (x * y)).comp
         (tendsto_atTop_atTop_of_monotone (fun _ _ hnm ↦ by
           simp only [mul_le_mul_iff_right₀, Nat.succ_pos', hnm]) _)
-      · rintro n; use n; omega
+      · rintro n; use n; lia
     refine le_of_tendsto_of_tendsto' hlim ((seminormFromConst_isLimit hf1 hc hpm x).mul
       (seminormFromConst_isLimit hf1 hc hpm y)) (fun n ↦ ?_)
     simp only [seminormFromConst_seq]

--- a/Mathlib/CategoryTheory/Functor/OfSequence.lean
+++ b/Mathlib/CategoryTheory/Functor/OfSequence.lean
@@ -48,9 +48,9 @@ the form `X n ⟶ X (n + 1)` when `i ≤ j`. -/
 def map : ∀ {X : ℕ → C} (_ : ∀ n, X n ⟶ X (n + 1)) (i j : ℕ), i ≤ j → (X i ⟶ X j)
   | _, _, 0, 0 => fun _ ↦ 𝟙 _
   | _, f, 0, 1 => fun _ ↦ f 0
-  | _, f, 0, l + 1 => fun _ ↦ f 0 ≫ map (fun n ↦ f (n + 1)) 0 l (by omega)
+  | _, f, 0, l + 1 => fun _ ↦ f 0 ≫ map (fun n ↦ f (n + 1)) 0 l (by lia)
   | _, _, _ + 1, 0 => nofun
-  | _, f, k + 1, l + 1 => fun _ ↦ map (fun n ↦ f (n + 1)) k l (by omega)
+  | _, f, k + 1, l + 1 => fun _ ↦ map (fun n ↦ f (n + 1)) k l (by lia)
 
 lemma map_id (i : ℕ) : map f i i (by lia) = 𝟙 _ := by
   revert X f
@@ -130,16 +130,16 @@ def ofSequence : F ⟶ G where
   naturality := by
     intro i j φ
     obtain ⟨k, hk⟩ := Nat.exists_eq_add_of_le (leOfHom φ)
-    obtain rfl := Subsingleton.elim φ (homOfLE (by omega))
+    obtain rfl := Subsingleton.elim φ (homOfLE (by lia))
     revert i j
     induction k with
     | zero =>
         intro i j hk
-        obtain rfl : j = i := by omega
+        obtain rfl : j = i := by lia
         simp
     | succ k hk =>
         intro i j hk'
-        obtain rfl : j = i + k + 1 := by omega
+        obtain rfl : j = i + k + 1 := by lia
         simp only [← homOfLE_comp (show i ≤ i + k by omega) (show i + k ≤ i + k + 1 by omega),
           Functor.map_comp, assoc, naturality, reassoc_of% (hk rfl)]
 

--- a/Mathlib/CategoryTheory/Limits/Shapes/SequentialProduct.lean
+++ b/Mathlib/CategoryTheory/Limits/Shapes/SequentialProduct.lean
@@ -130,7 +130,7 @@ noncomputable def cone : Cone (Functor.ofOpSequence (functorMap f)) where
       Discrete.natTrans_app, Functor.ofOpSequence_map_homOfLE_succ, functorMap, Category.assoc,
       limMap_π_assoc]
     split
-    · simp [dif_pos (by omega : m < n + 1)]
+    · simp [dif_pos (by lia : m < n + 1)]
     · split
       all_goals simp
 
@@ -163,7 +163,7 @@ with cone point `∏ M` is indeed a limit cone.
 noncomputable def isLimit : IsLimit (cone f) where
   lift s := Pi.lift fun m ↦
     s.π.app ⟨m + 1⟩ ≫ Pi.π (fun i ↦ if _ : i < m + 1 then M i else N i) m ≫
-      eqToHom (dif_pos (by omega : m < m + 1))
+      eqToHom (dif_pos (by lia : m < m + 1))
   fac s := by
     intro ⟨n⟩
     apply Pi.hom_ext
@@ -185,15 +185,15 @@ noncomputable def isLimit : IsLimit (cone f) where
         simp only [Functor.ofOpSequence_obj, Nat.succ_eq_add_one, homOfLE_leOfHom,
           Functor.ofOpSequence_map_homOfLE_succ, Category.assoc]
         have h₁ : (if _ : m < m + 1 then M m else N m) = if _ : m < n then M m else N m := by
-          rw [dif_pos (by omega), dif_pos (by omega)]
+          rw [dif_pos (by lia), dif_pos (by lia)]
         have h₂ : (if _ : m < n then M m else N m) = if _ : m < n + 1 then M m else N m := by
-          rw [dif_pos h, dif_pos (by omega)]
+          rw [dif_pos h, dif_pos (by lia)]
         rw [← eqToHom_trans h₁ h₂]
-        slice_lhs 2 4 => rw [ih (by omega)]
+        slice_lhs 2 4 => rw [ih (by lia)]
         simp only [functorMap, dite_eq_ite, Pi.π, limMap_π_assoc, Discrete.functor_obj_eq_as,
           Discrete.natTrans_app]
         split_ifs
-        rw [dif_pos (by omega)]
+        rw [dif_pos (by lia)]
         simp
     · simp only [Category.assoc]
       rw [cone_π_app_comp_Pi_π_neg f _ _ h]
@@ -206,7 +206,7 @@ noncomputable def isLimit : IsLimit (cone f) where
     intro n
     simp only [Functor.ofOpSequence_obj, dite_eq_ite, limit.lift_π, Fan.mk_pt,
       Fan.mk_π_app, ← h ⟨n + 1⟩, Category.assoc]
-    slice_rhs 2 3 => erw [cone_π_app_comp_Pi_π_pos f (n + 1) _ (by omega)]
+    slice_rhs 2 3 => erw [cone_π_app_comp_Pi_π_pos f (n + 1) _ (by lia)]
     simp
 
 section

--- a/Mathlib/Combinatorics/Additive/ApproximateSubgroup.lean
+++ b/Mathlib/Combinatorics/Additive/ApproximateSubgroup.lean
@@ -131,7 +131,7 @@ lemma of_small_tripling [DecidableEq G] {A : Finset G} (hA₁ : 1 ∈ A) (hAsymm
   sq_covBySMul := by
     replace hA := calc (#(A ^ 4 * A) : ℝ)
       _ = #(A ^ 5) := by rw [← pow_succ]
-      _ ≤ K ^ 3 * #A := small_pow_of_small_tripling (by omega) hA hAsymm
+      _ ≤ K ^ 3 * #A := small_pow_of_small_tripling (by lia) hA hAsymm
     have hA₀ : A.Nonempty := ⟨1, hA₁⟩
     obtain ⟨F, -, hF, hAF⟩ := ruzsa_covering_mul hA₀ hA
     exact ⟨F, hF, by norm_cast; simpa [div_eq_mul_inv, pow_succ, mul_assoc, hAsymm] using hAF⟩
@@ -172,7 +172,7 @@ lemma pow_inter_pow (hA : IsApproximateSubgroup K A) (hB : IsApproximateSubgroup
   one_mem := ⟨Set.one_mem_pow hA.one_mem, Set.one_mem_pow hB.one_mem⟩
   inv_eq_self := by simp_rw [inter_inv, ← inv_pow, hA.inv_eq_self, hB.inv_eq_self]
   sq_covBySMul := by
-    refine (hA.pow_inter_pow_covBySMul_sq_inter_sq hB (by omega) (by omega)).subset ?_
+    refine (hA.pow_inter_pow_covBySMul_sq_inter_sq hB (by lia) (by lia)).subset ?_
       (by gcongr; exacts [hA.one_mem, hB.one_mem])
     calc
       (A ^ m ∩ B ^ n) ^ 2 ⊆ (A ^ m) ^ 2 ∩ (B ^ n) ^ 2 := Set.inter_pow_subset

--- a/Mathlib/Combinatorics/Enumerative/Composition.lean
+++ b/Mathlib/Combinatorics/Enumerative/Composition.lean
@@ -812,7 +812,7 @@ considering the restriction of the subset to `{1, ..., n-1}` and shifting to the
 def compositionAsSetEquiv (n : ℕ) : CompositionAsSet n ≃ Finset (Fin (n - 1)) where
   toFun c :=
     { i : Fin (n - 1) |
-        (⟨1 + (i : ℕ), by omega⟩ : Fin n.succ) ∈ c.boundaries }.toFinset
+        (⟨1 + (i : ℕ), by lia⟩ : Fin n.succ) ∈ c.boundaries }.toFinset
   invFun s :=
     { boundaries :=
         { i : Fin n.succ |

--- a/Mathlib/Combinatorics/Enumerative/DyckWord.lean
+++ b/Mathlib/Combinatorics/Enumerative/DyckWord.lean
@@ -154,7 +154,7 @@ def drop (i : ℕ) (hi : (p.toList.take i).count U = (p.toList.take i).count D) 
   count_U_eq_count_D := by
     have := p.count_U_eq_count_D
     rw [← take_append_drop i p.toList, count_append, count_append] at this
-    omega
+    lia
   count_D_le_count_U k := by
     rw [show i = min i (i + k) by omega, ← take_take] at hi
     rw [take_drop, ← add_le_add_iff_left (((p.toList.take (i + k)).take i).count U),
@@ -216,9 +216,9 @@ def denest (hn : p.IsNested) : DyckWord where
     have eq := hn.2 lb ub
     set j := min (1 + i) (p.toList.length - 1)
     rw [← (p.toList.take j).take_append_drop 1, count_append, count_append, take_take,
-      min_eq_left (by omega), l1, head_eq_U] at eq
+      min_eq_left (by lia), l1, head_eq_U] at eq
     simp only [count_singleton', ite_true] at eq
-    omega
+    lia
 
 variable (p) in
 lemma nest_denest (hn) : (p.denest hn).nest = p := by

--- a/Mathlib/Combinatorics/SimpleGraph/Metric.lean
+++ b/Mathlib/Combinatorics/SimpleGraph/Metric.lean
@@ -257,7 +257,7 @@ theorem Connected.diff_dist_adj (hG : G.Connected) (hadj : G.Adj v w) :
   have : G.dist w v = 1 := dist_eq_one_iff_adj.mpr hadj.symm
   have : G.dist u w ≤ G.dist u v + G.dist v w := hG.dist_triangle
   have : G.dist u v ≤ G.dist u w + G.dist w v := hG.dist_triangle
-  omega
+  lia
 
 theorem Walk.isPath_of_length_eq_dist (p : G.Walk u v) (hp : p.length = G.dist u v) :
     p.IsPath := by

--- a/Mathlib/Combinatorics/SimpleGraph/Paths.lean
+++ b/Mathlib/Combinatorics/SimpleGraph/Paths.lean
@@ -396,7 +396,7 @@ lemma IsPath.getVert_injOn_iff (p : G.Walk u v) : Set.InjOn p.getVert {i | i ≤
       (by rw [length_cons]; lia : (n + 1) ≤ (q.cons h).length)
       (by lia : 0 ≤ (q.cons h).length)
       (by rwa [getVert_cons _ _ n.add_one_ne_zero, getVert_zero])
-    omega
+    lia
 
 theorem IsPath.eq_snd_of_mem_edges {p : G.Walk u v} (hp : p.IsPath) (hmem : s(u, w) ∈ p.edges) :
     w = p.snd := by
@@ -421,7 +421,7 @@ lemma IsCycle.getVert_injOn {p : G.Walk u u} (hpc : p.IsCycle) :
   have := ((Walk.cons_isCycle_iff _ _).mp hpc).1.getVert_injOn
     (by lia : n - 1 ≤ p.tail.length) (by lia : m - 1 ≤ p.tail.length)
     (by simp_all [SimpleGraph.Walk.getVert_tail, Nat.sub_add_cancel hn.1, Nat.sub_add_cancel hm.1])
-  omega
+  lia
 
 lemma IsCycle.getVert_injOn' {p : G.Walk u u} (hpc : p.IsCycle) :
     Set.InjOn p.getVert {i |  i ≤ p.length - 1} := by

--- a/Mathlib/Computability/Ackermann.lean
+++ b/Mathlib/Computability/Ackermann.lean
@@ -157,7 +157,7 @@ theorem add_lt_ack : ∀ m n, m + n < ack m n
   | m + 1, 0 => by simpa using add_lt_ack m 1
   | m + 1, n + 1 =>
     calc
-      m + 1 + n + 1 ≤ m + (m + n + 2) := by omega
+      m + 1 + n + 1 ≤ m + (m + n + 2) := by lia
       _ < ack m (m + n + 2) := add_lt_ack _ _
       _ ≤ ack m (ack (m + 1) n) :=
         ack_mono_right m <| le_of_eq_of_le (by rw [succ_eq_add_one]; ring_nf)
@@ -180,7 +180,7 @@ private theorem ack_strict_mono_left' : ∀ {m₁ m₂} (n), m₁ < m₂ → ack
   | 0, m + 1, n + 1 => fun h => by
     rw [ack_zero, ack_succ_succ]
     calc
-      n + 1 + 1 ≤ m + (m + 1 + n + 1) := by omega
+      n + 1 + 1 ≤ m + (m + 1 + n + 1) := by lia
       _ ≤ m + ack (m + 1) n := by gcongr; exact add_add_one_le_ack ..
       _ < ack m (ack (m + 1) n) := add_lt_ack ..
   | m₁ + 1, m₂ + 1, 0 => fun h => by

--- a/Mathlib/Data/Finset/Card.lean
+++ b/Mathlib/Data/Finset/Card.lean
@@ -867,7 +867,7 @@ def strongDownwardInduction {p : Finset α → Sort*} {n : ℕ}
   | s =>
     H s fun {t} ht h =>
       have := Finset.card_lt_card h
-      have : n - #t < n - #s := by omega
+      have : n - #t < n - #s := by lia
       strongDownwardInduction H t ht
   termination_by s => n - #s
 

--- a/Mathlib/Data/Int/GCD.lean
+++ b/Mathlib/Data/Int/GCD.lean
@@ -146,10 +146,10 @@ theorem exists_mul_mod_eq_one_of_coprime {k n : ℕ} (hkn : Coprime n k) (hk : 1
 
 theorem exists_mul_mod_eq_of_coprime {k n : ℕ} (r : ℕ) (hkn : Coprime n k) (hk : k ≠ 0) :
     ∃ m < k, n * m % k = r % k := by
-  obtain rfl | hk : k = 1 ∨ 1 < k := by omega
+  obtain rfl | hk : k = 1 ∨ 1 < k := by lia
   · simp [mod_one]
   obtain ⟨m, -, hm⟩ := exists_mul_mod_eq_one_of_coprime hkn hk
-  use (m * r) % k, mod_lt _ (by omega)
+  use (m * r) % k, mod_lt _ (by lia)
   rw [mul_mod, mod_mod, ← mul_mod, ← mul_assoc, mul_mod, hm, one_mul, mod_mod]
 
 end Nat

--- a/Mathlib/Data/Int/Interval.lean
+++ b/Mathlib/Data/Int/Interval.lean
@@ -38,7 +38,7 @@ instance instLocallyFiniteOrder : LocallyFiniteOrder ℤ where
     simp_rw [mem_map, mem_range, Function.Embedding.trans_apply, Nat.castEmbedding_apply,
       addLeftEmbedding_apply]
     constructor
-    · omega
+    · lia
     · intro
       use (x - a).toNat
       omega
@@ -46,7 +46,7 @@ instance instLocallyFiniteOrder : LocallyFiniteOrder ℤ where
     simp_rw [mem_map, mem_range, Function.Embedding.trans_apply, Nat.castEmbedding_apply,
       addLeftEmbedding_apply]
     constructor
-    · omega
+    · lia
     · intro
       use (x - a).toNat
       omega
@@ -54,7 +54,7 @@ instance instLocallyFiniteOrder : LocallyFiniteOrder ℤ where
     simp_rw [mem_map, mem_range, Function.Embedding.trans_apply, Nat.castEmbedding_apply,
       addLeftEmbedding_apply]
     constructor
-    · omega
+    · lia
     · intro
       use (x - (a + 1)).toNat
       omega
@@ -62,10 +62,10 @@ instance instLocallyFiniteOrder : LocallyFiniteOrder ℤ where
     simp_rw [mem_map, mem_range, Function.Embedding.trans_apply, Nat.castEmbedding_apply,
       addLeftEmbedding_apply]
     constructor
-    · omega
+    · lia
     · intro
       use (x - (a + 1)).toNat
-      omega
+      lia
 
 variable (a b : ℤ)
 
@@ -189,12 +189,12 @@ lemma Finset.Ioc_succ_succ (m n : ℕ) :
     Ioc (-(m + 1) : ℤ) (n + 1) = Ioc (-m : ℤ) n ∪ {-(m : ℤ), (n + 1 : ℤ)} := by
   ext
   simp only [mem_Ioc, union_insert, union_singleton, mem_insert]
-  omega
+  lia
 
 lemma Finset.Ioo_succ_succ (m n : ℕ) :
     Ioo (-(m + 1) : ℤ) (n + 1) = Ioo (-m : ℤ) n ∪ {-(m : ℤ), (n : ℤ)} := by
   ext
   simp only [mem_Ioo, union_insert, union_singleton, mem_insert]
-  omega
+  lia
 
 end Nat

--- a/Mathlib/Data/List/Basic.lean
+++ b/Mathlib/Data/List/Basic.lean
@@ -662,7 +662,7 @@ theorem get_reverse' (l : List α) (n) (hn') :
     l.reverse.get n = l.get ⟨l.length - 1 - n, hn'⟩ := by
   simp
 
-theorem eq_cons_of_length_one {l : List α} (h : l.length = 1) : l = [l.get ⟨0, by omega⟩] := by
+theorem eq_cons_of_length_one {l : List α} (h : l.length = 1) : l = [l.get ⟨0, by lia⟩] := by
   refine ext_get (by convert h) (by grind)
 
 end deprecated

--- a/Mathlib/Data/Nat/Factorial/Basic.lean
+++ b/Mathlib/Data/Nat/Factorial/Basic.lean
@@ -446,7 +446,7 @@ theorem descFactorial_lt_pow {n : ℕ} (hn : n ≠ 0) : ∀ {k : ℕ}, 2 ≤ k �
   | 1 => by intro; contradiction
   | k + 2 => fun _ => by
     rw [descFactorial_succ, pow_succ', Nat.mul_comm, Nat.mul_comm n]
-    exact Nat.mul_lt_mul_of_le_of_lt (descFactorial_le_pow _ _) (by omega) (Nat.pow_pos <| by omega)
+    exact Nat.mul_lt_mul_of_le_of_lt (descFactorial_le_pow _ _) (by lia) (Nat.pow_pos <| by lia)
 
 end DescFactorial
 

--- a/Mathlib/Data/Num/Prime.lean
+++ b/Mathlib/Data/Num/Prime.lean
@@ -99,7 +99,7 @@ instance decidablePrime : DecidablePred PosNum.Prime
         refine Nat.prime_def_minFac.trans ((and_iff_right ?_).trans ?_)
         · simp only [cast_bit1]
           have := to_nat_pos n
-          omega
+          lia
         rw [← minFac_to_nat, to_nat_inj]; rfl
 
 end PosNum

--- a/Mathlib/Data/Num/ZNum.lean
+++ b/Mathlib/Data/Num/ZNum.lean
@@ -546,7 +546,7 @@ theorem divMod_to_nat (d n : PosNum) :
     simp only at IH ⊢
     apply divMod_to_nat_aux <;> simp only [Num.cast_bit1, cast_bit1]
     · rw [← two_mul, ← two_mul, add_right_comm, mul_left_comm, ← mul_add, IH.1]
-    · omega
+    · lia
   | bit0 n IH =>
     unfold divMod
     -- Porting note: `cases'` didn't rewrite at `this`, so `revert` & `intro` are required.

--- a/Mathlib/Data/Seq/Basic.lean
+++ b/Mathlib/Data/Seq/Basic.lean
@@ -535,7 +535,7 @@ theorem drop_length' {n : ℕ} {s : Seq α} :
       convert drop_length' using 1
       generalize s.length' = m
       enat_to_nat
-      omega
+      lia
 
 theorem take_drop {s : Seq α} {n m : ℕ} :
     (s.take n).drop m = (s.drop m).take (n - m) := by
@@ -829,16 +829,16 @@ theorem Pairwise.cons {R : α → α → Prop} {hd : α} {tl : Seq α}
     | zero =>
       simp only [get?_cons_zero, Option.mem_def, Option.some.injEq] at hx
       exact hx ▸ all_get h_hd hy
-    | succ n => exact h_tl n k (by omega) x hx y hy
+    | succ n => exact h_tl n k (by lia) x hx y hy
 
 theorem Pairwise.cons_elim {R : α → α → Prop} {hd : α} {tl : Seq α}
     (h : Pairwise R (.cons hd tl)) : (∀ x ∈ tl, R hd x) ∧ Pairwise R tl := by
   simp only [Pairwise] at *
-  refine ⟨?_, fun i j h_ij ↦ h (i + 1) (j + 1) (by omega)⟩
+  refine ⟨?_, fun i j h_ij ↦ h (i + 1) (j + 1) (by lia)⟩
   intro x hx
   rw [mem_iff_exists_get?] at hx
   obtain ⟨n, hx⟩ := hx
-  simpa [← hx] using h 0 (n + 1) (by omega)
+  simpa [← hx] using h 0 (n + 1) (by lia)
 
 @[simp]
 theorem Pairwise_cons_nil {R : α → α → Prop} {hd : α} : Pairwise R (cons hd nil) := by
@@ -893,7 +893,7 @@ theorem Pairwise.coind_trans {R : α → α → Prop} [IsTrans α R] {s : Seq α
   induction k generalizing y with
   | zero => exact h_succ hx hy
   | succ k ih =>
-    obtain ⟨z, hz⟩ := ge_stable (m := i + k + 1) _ (by omega) hy
+    obtain ⟨z, hz⟩ := ge_stable (m := i + k + 1) _ (by lia) hy
     exact _root_.trans (ih z hz) <| h_succ hz hy
 
 theorem Pairwise_tail {R : α → α → Prop} {s : Seq α} (h : s.Pairwise R) :
@@ -947,7 +947,7 @@ theorem at_least_as_long_as_coind {a : Seq α} {b : Seq β}
     simp only [drop_length', length'_of_terminates ha, tsub_self, length'_cons] at ha'
     generalize a_tl.length' = u at ha'
     enat_to_nat
-    omega
+    lia
 
 instance : Functor Seq where map := @map
 

--- a/Mathlib/Geometry/Euclidean/Incenter.lean
+++ b/Mathlib/Geometry/Euclidean/Incenter.lean
@@ -699,7 +699,7 @@ lemma ExcenterExists.affineSpan_faceOpposite_eq_orthRadius [hf : Fact (Module.fi
   rw [direction_affineSpan, (s.faceOpposite i).independent.finrank_vectorSpan_add_one,
     Fintype.card_fin, hf.out]
   have := NeZero.ne n
-  cutsat
+  lia
 
 lemma affineSpan_faceOpposite_eq_orthRadius_insphere [Fact (Module.finrank ℝ V = n)]
     (i : Fin (n + 1)) :

--- a/Mathlib/GroupTheory/MonoidLocalization/Basic.lean
+++ b/Mathlib/GroupTheory/MonoidLocalization/Basic.lean
@@ -1449,10 +1449,10 @@ theorem AddSubmonoid.isLocalizationMap_nat_int (S : AddSubmonoid ℕ) (hS : S �
     S.IsLocalizationMap ((↑) : ℕ → ℤ) :=
   S.isLocalizationMap_of_addGroup (fun _ _ ↦ Int.natCast_inj.mp) fun z ↦ by
     obtain ⟨z, rfl | rfl⟩ := z.eq_nat_or_neg
-    · exact ⟨z, 0, zero_mem _, by cutsat⟩
+    · exact ⟨z, 0, zero_mem _, by lia⟩
     have ⟨n, hnS, hn0⟩ := S.bot_or_exists_ne_zero.resolve_left hS
     have key : z < n * (z / n + 1) := Nat.lt_mul_div_succ _ <| Nat.pos_of_ne_zero hn0
-    exact ⟨(z / n + 1) * n - z, (z / n + 1) * n, nsmul_mem hnS _, by cutsat⟩
+    exact ⟨(z / n + 1) * n - z, (z / n + 1) * n, nsmul_mem hnS _, by lia⟩
 
 theorem AddSubmonoid.isLocalizationMap_top_nat_int :
     (⊤ : AddSubmonoid ℕ).IsLocalizationMap ((↑) : ℕ → ℤ) :=

--- a/Mathlib/GroupTheory/OrderOfElement.lean
+++ b/Mathlib/GroupTheory/OrderOfElement.lean
@@ -302,7 +302,7 @@ theorem exists_pow_eq_self_of_coprime (h : n.Coprime (orderOf x)) : ∃ m : ℕ,
     exact ⟨1, by rw [h, pow_one, pow_one]⟩
   by_cases h1 : orderOf x = 1
   · exact ⟨0, by rw [orderOf_eq_one_iff.mp h1, one_pow, one_pow]⟩
-  obtain ⟨m, -, h⟩ := exists_mul_mod_eq_one_of_coprime h (by omega)
+  obtain ⟨m, -, h⟩ := exists_mul_mod_eq_one_of_coprime h (by lia)
   exact ⟨m, by rw [← pow_mul, ← pow_mod_orderOf, h, pow_one]⟩
 
 /-- If `x^n = 1`, but `x^(n/p) ≠ 1` for all prime factors `p` of `n`,

--- a/Mathlib/LinearAlgebra/BilinearForm/Orthogonal.lean
+++ b/Mathlib/LinearAlgebra/BilinearForm/Orthogonal.lean
@@ -332,7 +332,7 @@ lemma orthogonal_orthogonal (hB : B.Nondegenerate) (hB₀ : B.IsRefl) (W : Submo
     B.orthogonal (B.orthogonal W) = W := by
   apply (eq_of_le_of_finrank_le (LinearMap.BilinForm.le_orthogonal_orthogonal hB₀) _).symm
   simp only [finrank_orthogonal hB hB₀]
-  omega
+  lia
 
 variable {W : Submodule K V}
 

--- a/Mathlib/LinearAlgebra/Dimension/RankNullity.lean
+++ b/Mathlib/LinearAlgebra/Dimension/RankNullity.lean
@@ -228,7 +228,7 @@ lemma Submodule.disjoint_ker_of_finrank_le [NoZeroSMulDivisors R M] {N : Type*} 
   rw [← LinearMap.range_domRestrict] at h
   have := (LinearMap.ker (f.domRestrict L)).finrank_quotient_add_finrank
   rw [LinearEquiv.finrank_eq (f.domRestrict L).quotKerEquivRange] at this
-  omega
+  lia
 
 end Finrank
 

--- a/Mathlib/LinearAlgebra/Matrix/Irreducible/Defs.lean
+++ b/Mathlib/LinearAlgebra/Matrix/Irreducible/Defs.lean
@@ -98,7 +98,7 @@ lemma IsIrreducible.exists_pos [Nontrivial n]
   have h_le : 1 ≤ p.length := Nat.succ_le_of_lt hp_pos
   have ⟨v, p₁, p₂, _hp_eq, hp₁_len⟩ := p.exists_eq_comp_of_le_length (n := 1) h_le
   have hlen_ne : p₁.length ≠ 0 := by simp [hp₁_len]
-  obtain ⟨c, p', e, rfl⟩ := (Quiver.Path.length_ne_zero_iff_eq_cons (p := p₁)).1 (by omega)
+  obtain ⟨c, p', e, rfl⟩ := (Quiver.Path.length_ne_zero_iff_eq_cons (p := p₁)).1 (by lia)
   obtain ⟨rfl⟩ : i = c := Quiver.Path.eq_of_length_zero p' (by aesop)
   exact (no_out _).false e
 

--- a/Mathlib/LinearAlgebra/RootSystem/Chain.lean
+++ b/Mathlib/LinearAlgebra/RootSystem/Chain.lean
@@ -190,7 +190,7 @@ lemma root_sub_zsmul_mem_range_iff {z : ℤ} :
     P.root j - z • P.root i ∈ range P.root ↔
       z ∈ Icc (-P.chainTopCoeff i j : ℤ) (P.chainBotCoeff i j) := by
   rw [sub_eq_add_neg, ← neg_smul, P.root_add_zsmul_mem_range_iff h, mem_Icc, mem_Icc]
-  omega
+  lia
 
 lemma setOf_root_add_zsmul_mem_eq_Icc :
     {k : ℤ | P.root j + k • P.root i ∈ range P.root} =
@@ -232,7 +232,7 @@ private lemma chainCoeff_reflectionPerm_left_aux :
     ext z
     rw [← P.root_add_zsmul_mem_range_iff h', indexNeg_neg, root_reflectionPerm, mem_Icc,
       reflection_apply_self, smul_neg, ← neg_smul, P.root_add_zsmul_mem_range_iff h, mem_Icc]
-    omega
+    lia
   · have h' : ¬ LinearIndependent R ![P.root (-i), P.root j] := by simpa
     simp only [chainTopCoeff_of_not_linearIndependent h, chainTopCoeff_of_not_linearIndependent h',
       chainBotCoeff_of_not_linearIndependent h, chainBotCoeff_of_not_linearIndependent h']
@@ -428,7 +428,7 @@ lemma chainBotCoeff_sub_chainTopCoeff :
     rw [← root_reflectionPerm]
     exact mem_range_self _
   rw [h₁, root_add_zsmul_mem_range_iff h, mem_Icc] at h₂
-  omega
+  lia
 
 lemma chainTopCoeff_sub_chainBotCoeff :
     P.chainTopCoeff i j - P.chainBotCoeff i j = -P.pairingIn ℤ j i := by

--- a/Mathlib/LinearAlgebra/RootSystem/Finite/Nondegenerate.lean
+++ b/Mathlib/LinearAlgebra/RootSystem/Finite/Nondegenerate.lean
@@ -294,7 +294,7 @@ lemma ker_rootForm_eq_dualAnnihilator :
   have aux0 := Subspace.finrank_add_finrank_dualAnnihilator_eq (P.corootSpan R)
   have aux1 := Submodule.finrank_add_eq_of_isCompl P.isCompl_rootSpan_ker_rootForm
   rw [← P.finrank_corootSpan_eq', P.toPerfPair.finrank_eq, Subspace.dual_finrank_eq] at aux1
-  omega
+  lia
 
 lemma ker_corootForm_eq_dualAnnihilator :
     LinearMap.ker P.CorootForm = (P.rootSpan R).dualAnnihilator.map P.flip.toPerfPair.symm :=

--- a/Mathlib/Logic/Equiv/Finset.lean
+++ b/Mathlib/Logic/Equiv/Finset.lean
@@ -88,7 +88,7 @@ theorem raise_lower' : ∀ {l n}, (∀ m ∈ l, n ≤ m) → List.SortedLT l →
 theorem isChain_raise' : ∀ (l) (n), List.IsChain (· < ·) (raise' l n)
   | [], _ => .nil
   | [_], _ => .singleton _
-  | _ :: _ :: _, _ => .cons_cons (by omega) (isChain_raise' (_ :: _) _)
+  | _ :: _ :: _, _ => .cons_cons (by lia) (isChain_raise' (_ :: _) _)
 
 theorem isChain_cons_raise' (l m) : List.IsChain (· < ·) (m :: raise' l (m + 1)) :=
   isChain_raise' (m :: l) 0

--- a/Mathlib/MeasureTheory/Function/AbsolutelyContinuous.lean
+++ b/Mathlib/MeasureTheory/Function/AbsolutelyContinuous.lean
@@ -335,13 +335,13 @@ theorem boundedVariationOn (hf : AbsolutelyContinuousOnInterval f a b) :
           constructor <;> exact this (hp₂ _)
         · rw [PairwiseDisjoint]
           convert hp₁.pairwise_disjoint_on_Ioc_succ.set_pairwise (Finset.range p.1) using 3
-          rw [uIoc_of_le (hp₁ (by omega)), Nat.succ_eq_succ]
+          rw [uIoc_of_le (hp₁ (by lia)), Nat.succ_eq_succ]
       · suffices p.2.val p.1 - p.2.val 0 < δ by
           convert this
           rw [← Finset.sum_range_sub]
           congr; ext i
           rw [dist_comm, Real.dist_eq, abs_eq_self.mpr]
-          linarith [@hp₁ i (i + 1) (by omega)]
+          linarith [@hp₁ i (i + 1) (by lia)]
         linarith [mem_Icc.mp (hp₂ p.1), mem_Icc.mp (hp₂ 0)]
     -- Reduce edist in the goal to dist and clear up
     have veq: (∑ i ∈ Finset.range p.1, edist (f (p.2.val (i + 1))) (f (p.2.val i))).toReal =
@@ -362,10 +362,10 @@ theorem boundedVariationOn (hf : AbsolutelyContinuousOnInterval f a b) :
     fun hC ↦ by simp [hC] at this
   -- Verify that `[a + i * δ', a + (i + 1) * δ']` is indeed a subinterval of `[a, b]`
   apply v_each
-  · convert h_mono (show 0 ≤ i by omega); simp
-  · convert h_mono (show i ≤ i + 1 by omega); norm_cast
+  · convert h_mono (show 0 ≤ i by lia); simp
+  · convert h_mono (show i ≤ i + 1 by lia); norm_cast
   · rw [add_mul, ← add_assoc]; simpa
-  · convert h_mono (show i + 1 ≤ n + 1 by omega)
+  · convert h_mono (show i + 1 ≤ n + 1 by lia)
     · norm_cast
     · simp only [Nat.cast_add, Nat.cast_one, δ']; field
 

--- a/Mathlib/NumberTheory/FrobeniusNumber.lean
+++ b/Mathlib/NumberTheory/FrobeniusNumber.lean
@@ -215,7 +215,7 @@ theorem exists_frobeniusNumber_iff {s : Set ℕ} :
   mp := fun ⟨n, hn⟩ ↦ by
     rw [frobeniusNumber_iff] at hn
     exact ⟨dvd_one.mp <| Nat.dvd_add_iff_right (setGcd_dvd_of_mem_closure (hn.2 (n + 1)
-      (by omega))) (n := 1) |>.mpr (setGcd_dvd_of_mem_closure (hn.2 (n + 2) (by omega))),
+      (by lia))) (n := 1) |>.mpr (setGcd_dvd_of_mem_closure (hn.2 (n + 2) (by lia))),
       fun h ↦ hn.1 <| AddSubmonoid.closure_mono (Set.singleton_subset_iff.mpr h)
         (addSubmonoidClosure_one.ge ⟨⟩)⟩
   mpr h := by

--- a/Mathlib/NumberTheory/RamificationInertia/Basic.lean
+++ b/Mathlib/NumberTheory/RamificationInertia/Basic.lean
@@ -163,13 +163,13 @@ lemma ramificationIdx_ne_one_iff (hp : map f p ≤ P) :
   constructor
   · intro he
     have : 1 ≤ Nat.find H := Nat.find_spec H 1 (by simpa)
-    have := Nat.find_min H (m := 1) (by omega)
+    have := Nat.find_min H (m := 1) (by lia)
     push_neg at this
     obtain ⟨k, hk, h1k⟩ := this
     exact hk.trans (Ideal.pow_le_pow_right (Nat.succ_le_iff.mpr h1k))
   · intro he
     have := Nat.find_spec H 2 he
-    omega
+    lia
 
 open IsLocalRing in
 /-- The converse is true when `S` is a Dedekind domain.

--- a/Mathlib/Order/Interval/Finset/Nat.lean
+++ b/Mathlib/Order/Interval/Finset/Nat.lean
@@ -36,10 +36,10 @@ instance instLocallyFiniteOrder : LocallyFiniteOrder ℕ where
   finsetIco a b := ⟨List.range' a (b - a), List.nodup_range'⟩
   finsetIoc a b := ⟨List.range' (a + 1) (b - a), List.nodup_range'⟩
   finsetIoo a b := ⟨List.range' (a + 1) (b - a - 1), List.nodup_range'⟩
-  finset_mem_Icc a b x := by rw [Finset.mem_mk, Multiset.mem_coe, List.mem_range'_1]; omega
-  finset_mem_Ico a b x := by rw [Finset.mem_mk, Multiset.mem_coe, List.mem_range'_1]; omega
-  finset_mem_Ioc a b x := by rw [Finset.mem_mk, Multiset.mem_coe, List.mem_range'_1]; omega
-  finset_mem_Ioo a b x := by rw [Finset.mem_mk, Multiset.mem_coe, List.mem_range'_1]; omega
+  finset_mem_Icc a b x := by rw [Finset.mem_mk, Multiset.mem_coe, List.mem_range'_1]; lia
+  finset_mem_Ico a b x := by rw [Finset.mem_mk, Multiset.mem_coe, List.mem_range'_1]; lia
+  finset_mem_Ioc a b x := by rw [Finset.mem_mk, Multiset.mem_coe, List.mem_range'_1]; lia
+  finset_mem_Ioo a b x := by rw [Finset.mem_mk, Multiset.mem_coe, List.mem_range'_1]; lia
 
 theorem Icc_eq_range' : Icc a b = ⟨List.range' a (b + 1 - a), List.nodup_range'⟩ :=
   rfl
@@ -185,7 +185,7 @@ theorem mod_injOn_Ico (n a : ℕ) : Set.InjOn (· % a) (Finset.Ico n (n + a)) :=
     rwa [mod_eq_of_lt hk, mod_eq_of_lt hl] at hkl
   | succ n ih =>
     rw [Ico_succ_left_eq_erase_Ico, succ_add, succ_eq_add_one,
-      Ico_succ_right_eq_insert_Ico (by omega)]
+      Ico_succ_right_eq_insert_Ico (by lia)]
     rintro k hk l hl (hkl : k % a = l % a)
     have ha : 0 < a := Nat.pos_iff_ne_zero.2 <| by rintro rfl; simp at hk
     simp only [Finset.mem_coe, Finset.mem_insert, Finset.mem_erase] at hk hl

--- a/Mathlib/Order/KrullDimension.lean
+++ b/Mathlib/Order/KrullDimension.lean
@@ -470,8 +470,8 @@ lemma coe_lt_height_iff {x : α} {n : ℕ} (hfin : height x < ⊤) :
     constructor
     · rw [← hp]
       apply LTSeries.strictMono
-      simp [Fin.last]; omega
-    · exact height_eq_index_of_length_eq_height_last (by simp [hlen, hp, hx]) ⟨n, by omega⟩
+      simp [Fin.last]; lia
+    · exact height_eq_index_of_length_eq_height_last (by simp [hlen, hp, hx]) ⟨n, by lia⟩
   mpr := fun ⟨y, hyx, hy⟩ =>
     hy ▸ height_strictMono hyx (lt_of_le_of_lt (height_mono hyx.le) hfin)
 

--- a/Mathlib/Order/RelSeries.lean
+++ b/Mathlib/Order/RelSeries.lean
@@ -300,10 +300,10 @@ such that `r aₙ b₀`, then there is a chain of length `n + m + 1` given by
 @[simps]
 def append (p q : RelSeries r) (connect : p.last ~[r] q.head) : RelSeries r where
   length := p.length + q.length + 1
-  toFun := Fin.append p q ∘ Fin.cast (by omega)
+  toFun := Fin.append p q ∘ Fin.cast (by lia)
   step i := by
     obtain hi | rfl | hi :=
-      lt_trichotomy i (Fin.castLE (by omega) (Fin.last _ : Fin (p.length + 1)))
+      lt_trichotomy i (Fin.castLE (by lia) (Fin.last _ : Fin (p.length + 1)))
     · convert p.step ⟨i.1, hi⟩ <;> convert Fin.append_left p q _ <;> rfl
     · convert connect
       · convert Fin.append_left p q _
@@ -311,7 +311,7 @@ def append (p q : RelSeries r) (connect : p.last ~[r] q.head) : RelSeries r wher
     · set x := _; set y := _
       change Fin.append p q x ~[r] Fin.append p q y
       have hx : x = Fin.natAdd _ ⟨i - (p.length + 1), Nat.sub_lt_left_of_lt_add hi <|
-          i.2.trans <| by omega⟩ := by
+          i.2.trans <| by lia⟩ := by
         ext; dsimp [x, y]; rw [Nat.add_sub_cancel']; exact hi
       have hy : y = Fin.natAdd _ ⟨i - p.length, Nat.sub_lt_left_of_lt_add (le_of_lt hi)
           (by exact i.2)⟩ := by
@@ -321,7 +321,7 @@ def append (p q : RelSeries r) (connect : p.last ~[r] q.head) : RelSeries r wher
           Nat.add_sub_cancel' <| le_of_lt (show p.length < i.1 from hi), add_comm]
         rfl
       rw [hx, Fin.append_right, hy, Fin.append_right]
-      convert q.step ⟨i - (p.length + 1), Nat.sub_lt_left_of_lt_add hi <| by omega⟩
+      convert q.step ⟨i - (p.length + 1), Nat.sub_lt_left_of_lt_add hi <| by lia⟩
       rw [Fin.succ_mk, Nat.sub_eq_iff_eq_add (le_of_lt hi : p.length ≤ i),
         Nat.add_assoc _ 1, add_comm 1, Nat.sub_add_cancel]
       exact hi
@@ -352,7 +352,7 @@ lemma append_apply_right (p q : RelSeries r) (connect : p.last ~[r] q.head)
   convert append_apply_right p q connect (Fin.last _)
   ext1
   dsimp
-  omega
+  lia
 
 lemma append_assoc (p q w : RelSeries r) (hpq : p.last ~[r] q.head) (hqw : q.last ~[r] w.head) :
     (p.append q hpq).append w (by simpa) = p.append (q.append w hqw) (by simpa) := by
@@ -422,7 +422,7 @@ def insertNth (p : RelSeries r) (i : Fin p.length) (a : α)
           Fin.insertNth_apply_same]
     · rw [Nat.lt_iff_add_one_le, le_iff_lt_or_eq] at hm
       obtain hm | hm := hm
-      · convert p.step ⟨m.1 - 1, Nat.sub_lt_right_of_lt_add (by omega) m.2⟩
+      · convert p.step ⟨m.1 - 1, Nat.sub_lt_right_of_lt_add (by lia) m.2⟩
         · change Fin.insertNth _ _ _ _ = _
           rw [Fin.insertNth_apply_above (h := hm)]
           aesop
@@ -439,7 +439,7 @@ def insertNth (p : RelSeries r) (i : Fin p.length) (a : α)
         · change Fin.insertNth _ _ _ _ = _
           rw [Fin.insertNth_apply_above]
           swap
-          · change i.1 + 1 < m.1 + 1; omega
+          · change i.1 + 1 < m.1 + 1; lia
           simp only [Fin.pred_succ, eq_rec_constant]
           congr; ext; exact hm.symm
 
@@ -453,12 +453,12 @@ def reverse (p : RelSeries r) : RelSeries r.inv where
   toFun := p ∘ Fin.rev
   step i := by
     rw [Function.comp_apply, Function.comp_apply, SetRel.mem_inv]
-    have hi : i.1 + 1 ≤ p.length := by omega
-    convert p.step ⟨p.length - (i.1 + 1), Nat.sub_lt_self (by omega) hi⟩
+    have hi : i.1 + 1 ≤ p.length := by lia
+    convert p.step ⟨p.length - (i.1 + 1), Nat.sub_lt_self (by lia) hi⟩
     · ext; simp
     · ext
       simp only [Fin.val_rev, Fin.coe_castSucc, Fin.val_succ]
-      omega
+      lia
 
 @[simp] lemma reverse_apply (p : RelSeries r) (i : Fin (p.length + 1)) :
     p.reverse i = p i.rev := rfl
@@ -589,7 +589,7 @@ def tail (p : RelSeries r) (len_pos : p.length ≠ 0) : RelSeries r where
 lemma toList_tail {p : RelSeries r} (hp : p.length ≠ 0) : (p.tail hp).toList = p.toList.tail := by
   refine List.ext_getElem ?_ fun i h1 h2 ↦ ?_
   · simp
-    cutsat
+    lia
   · simp [Fin.tail]
 
 @[simp]
@@ -752,8 +752,8 @@ lemma smash_succ_natAdd {p q : RelSeries r} (h : p.last = q.head) (i : Fin q.len
 @[simps! length]
 def take {r : SetRel α α} (p : RelSeries r) (i : Fin (p.length + 1)) : RelSeries r where
   length := i
-  toFun := fun ⟨j, h⟩ => p.toFun ⟨j, by omega⟩
-  step := fun ⟨j, h⟩ => p.step ⟨j, by omega⟩
+  toFun := fun ⟨j, h⟩ => p.toFun ⟨j, by lia⟩
+  step := fun ⟨j, h⟩ => p.step ⟨j, by lia⟩
 
 @[simp]
 lemma head_take (p : RelSeries r) (i : Fin (p.length + 1)) :
@@ -767,10 +767,10 @@ lemma last_take (p : RelSeries r) (i : Fin (p.length + 1)) :
 @[simps! length]
 def drop (p : RelSeries r) (i : Fin (p.length + 1)) : RelSeries r where
   length := p.length - i
-  toFun := fun ⟨j, h⟩ => p.toFun ⟨j+i, by omega⟩
+  toFun := fun ⟨j, h⟩ => p.toFun ⟨j+i, by lia⟩
   step := fun ⟨j, h⟩ => by
-    convert p.step ⟨j+i.1, by omega⟩
-    simp only [Fin.succ_mk]; omega
+    convert p.step ⟨j+i.1, by lia⟩
+    simp only [Fin.succ_mk]; lia
 
 @[simp]
 lemma head_drop (p : RelSeries r) (i : Fin (p.length + 1)) : (p.drop i).head = p.toFun i := by
@@ -858,7 +858,7 @@ instance FiniteDimensionalOrder.ofUnique (γ : Type*) [Preorder γ] [Unique γ] 
     FiniteDimensionalOrder γ where
   exists_longest_relSeries := ⟨.singleton _ default, fun x ↦ by
     by_contra! r
-    exact (x.step ⟨0, by omega⟩).ne <| Subsingleton.elim _ _⟩
+    exact (x.step ⟨0, by lia⟩).ne <| Subsingleton.elim _ _⟩
 
 /-- A type is infinite dimensional if it has `LTSeries` of at least arbitrary length -/
 abbrev InfiniteDimensionalOrder (γ : Type*) [Preorder γ] :=

--- a/Mathlib/Probability/Martingale/BorelCantelli.lean
+++ b/Mathlib/Probability/Martingale/BorelCantelli.lean
@@ -89,7 +89,7 @@ theorem stoppedAbove_le (hr : 0 ≤ r) (hf0 : f 0 = 0)
       ne_top_of_le_ne_top (by simp) (min_le_left _ _)
     lift min (i : ℕ∞) (leastGE f r ω) to ℕ using h_top with p
     simp only [untopD_coe_enat, Nat.cast_lt, gt_iff_lt] at *
-    omega
+    lia
 
 @[deprecated (since := "2025-10-25")] alias norm_stoppedValue_leastGE_le := stoppedAbove_le
 

--- a/Mathlib/Probability/Process/Predictable.lean
+++ b/Mathlib/Probability/Process/Predictable.lean
@@ -188,7 +188,7 @@ lemma measurableSet_predictable_singleton_prod
   · exact measurableSet_predictable_Ioc_prod _ _ hs
   · ext m
     simp only [Set.mem_singleton_iff, Set.mem_Ioc]
-    omega
+    lia
 
 lemma isPredictable_of_measurable_add_one [SecondCountableTopology E]
     {𝓕 : Filtration ℕ m} {u : ℕ → Ω → E}

--- a/Mathlib/Probability/Process/Stopping.lean
+++ b/Mathlib/Probability/Process/Stopping.lean
@@ -351,7 +351,7 @@ theorem add {f : Filtration ℕ m} {τ π : Ω → WithTop ℕ}
       | coe b =>
         simp only [ENat.some_eq_coe, Nat.cast_inj, exists_eq_left', iff_and_self]
         norm_cast
-        omega
+        lia
   rw [h]
   exact MeasurableSet.iUnion fun k =>
     MeasurableSet.iUnion fun hk => (hπ.measurableSet_eq_le hk).inter (hτ.add_const_nat i)

--- a/Mathlib/RingTheory/LaurentSeries.lean
+++ b/Mathlib/RingTheory/LaurentSeries.lean
@@ -539,7 +539,7 @@ theorem coeff_zero_of_lt_valuation {n D : ℤ} {f : K⸨X⸩}
       ← ofPowerSeries_X_pow s, PowerSeries.coe_pow, valuation_X_pow K s]
     gcongr
   · obtain ⟨s, hs⟩ := Int.exists_eq_neg_ofNat (Int.neg_nonpos_of_nonneg (le_of_lt ord_nonpos))
-    obtain ⟨m, hm⟩ := Int.eq_ofNat_of_zero_le (a := n - s) (by omega)
+    obtain ⟨m, hm⟩ := Int.eq_ofNat_of_zero_le (a := n - s) (by lia)
     obtain ⟨d, hd⟩ := Int.eq_ofNat_of_zero_le (a := D - s) (by lia)
     rw [(sub_eq_iff_eq_add).mp hm, add_comm, ← neg_neg (s : ℤ), ← hs, neg_neg,
       ← powerSeriesPart_coeff]

--- a/Mathlib/RingTheory/Polynomial/Cyclotomic/Factorization.lean
+++ b/Mathlib/RingTheory/Polynomial/Cyclotomic/Factorization.lean
@@ -158,7 +158,7 @@ theorem normalizedFactors_cyclotomic_card : (normalizedFactors (cyclotomic n K))
     exact hp.out.coprime_iff_not_dvd.mp ((coprime_pow_left_iff
       (pos_of_ne_zero <| f_ne_zero hK) _ _).mp (hn.pow_left f))
         ((CharP.cast_eq_zero_iff K p _).mp H)
-  have hP : P ∈ normalizedFactors (cyclotomic n K) := count_pos.mp (by omega)
+  have hP : P ∈ normalizedFactors (cyclotomic n K) := count_pos.mp (by lia)
   refine (prime_of_normalized_factor _ hP).not_unit (squarefree_cyclotomic n K P ?_)
   have : {P, P} ≤ normalizedFactors (cyclotomic n K) := by
     refine le_iff_count.mpr (fun Q ↦ ?_)

--- a/Mathlib/RingTheory/Polynomial/Resultant/Basic.lean
+++ b/Mathlib/RingTheory/Polynomial/Resultant/Basic.lean
@@ -206,7 +206,7 @@ private lemma resultant_add_mul_monomial_right (hk : k + m ≤ n) (hf : f.natDeg
     | zero => simp [M]; rfl
     | succ i IH =>
       rw [← IH (by lia), ← Matrix.det_updateCol_add_smul_self (i := ⟨i, by lia⟩)
-        (j := ⟨i + k + m, by lia⟩) (c := -r) (M (i + 1)) (by simp; omega)]
+        (j := ⟨i + k + m, by lia⟩) (c := -r) (M (i + 1)) (by simp; lia)]
       congr 1
       ext j₁ j₂
       simp only [Matrix.of_apply, lt_add_iff_pos_right, zero_lt_one, ↓reduceIte, add_assoc,
@@ -219,7 +219,7 @@ private lemma resultant_add_mul_monomial_right (hk : k + m ≤ n) (hf : f.natDeg
         | left j₂ =>
           dsimp at hi
           have : Fin.mk (n := m + n) (↑j₂ + (k + m)) (by lia) = .natAdd m ⟨j₂ + k, by lia⟩ :=
-            Fin.ext (by simp; omega)
+            Fin.ext (by simp; lia)
           simp only [Fin.addCases_left, Fin.coe_castAdd, this, Fin.addCases_right, mul_ite,
             mul_zero, ← C_mul_X_pow_eq_monomial, ← mul_assoc, coeff_mul_X_pow', ite_add_zero,
             coeff_mul_C, add_assoc, add_eq_left, ← ite_and, ← mul_comm r, tsub_add_eq_tsub_tsub,
@@ -227,15 +227,15 @@ private lemma resultant_add_mul_monomial_right (hk : k + m ≤ n) (hf : f.natDeg
           split_ifs with h₁ h₂ h₂ <;> try rfl
           · rw [coeff_eq_zero_of_natDegree_lt, mul_zero]
             exact hf.trans_lt (by lia)
-          · omega
+          · lia
         | right i =>
           simp only [Fin.coe_natAdd] at hi
           have : Fin.mk (n := m + n) (m + ↑i + (k + m)) (by lia) =
-              Fin.natAdd m ⟨↑i + (k + m), by lia⟩ := Fin.ext (by simp; omega)
+              Fin.natAdd m ⟨↑i + (k + m), by lia⟩ := Fin.ext (by simp; lia)
           simp only [Fin.addCases_right, Fin.coe_natAdd, sub_eq_self, this]
           rw [if_neg, mul_zero]
-          omega
-      split_ifs with h₁ h₂ h₃ h₄ h₅ <;> try first | omega | rfl
+          lia
+      split_ifs with h₁ h₂ h₃ h₄ h₅ <;> lia
   rw [resultant, resultant, ← this m le_rfl]
   congr 1
   ext i j
@@ -287,8 +287,8 @@ lemma resultant_C_mul_right (r : R) :
           lt_add_iff_pos_right, zero_lt_one, coeff_C_mul, M₁]
         induction j₂ using Fin.addCases with
         | left j₂ => simp
-        | right i => simp at hi; omega
-      split_ifs with h₁ h₂ h₃ h₄ h₅ <;> try first | omega | rfl
+        | right i => simp at hi; lia
+      split_ifs with h₁ h₂ h₃ h₄ h₅ <;> lia
   rw [resultant, resultant, ← this m le_rfl]
   congr 1
   ext i j
@@ -311,7 +311,7 @@ lemma resultant_succ_left_deg (hf : f.natDegree ≤ m) :
       Matrix.reindex_apply, finCongr_symm, Matrix.submatrix_submatrix]
     congr 2
     · trans (-1) ^ (2 * m + (n + 1))
-      · congr 1; omega
+      · congr 1; lia
       · simp [pow_add]
     · simp only [sylvester, Set.mem_Icc, Matrix.of_apply, Fin.val_last, Fin.addCases_left]
       rw [if_pos (by lia)]
@@ -328,7 +328,7 @@ lemma resultant_succ_left_deg (hf : f.natDegree ≤ m) :
         have : ((Fin.last m).castAdd (n + 1)).succAbove ((j.natAdd m).cast (by grind)) =
           j.natAdd _ := by ext; simp [Fin.succAbove, Fin.lt_def, add_right_comm]
         simp only [ite_and, this, Fin.addCases_right]
-        split_ifs with h₁ h₂ h₃ h₃ <;> try first | omega | rfl
+        split_ifs with h₁ h₂ h₃ h₃ <;> try first | lia | rfl
         exact coeff_eq_zero_of_natDegree_lt (by lia)
   · rintro (b : Fin ((m + 1) + (n + 1))) - hb
     suffices f.sylvester g (m + 1) (n + 1) (.last (m + 1 + n)) b = 0 by simp [this]
@@ -339,7 +339,7 @@ lemma resultant_succ_left_deg (hf : f.natDegree ≤ m) :
       simp only [sylvester, Set.mem_Icc, Matrix.of_apply, Fin.val_last, Fin.addCases_left,
         ite_eq_right_iff, and_imp]
       intros
-      omega
+      lia
     | right i => simpa [sylvester] using fun _ _ ↦ coeff_eq_zero_of_natDegree_lt (by lia)
 
 lemma resultant_add_left_deg (hf : f.natDegree ≤ m) :
@@ -358,8 +358,8 @@ lemma resultant_add_right_deg (k : ℕ) (hg : g.natDegree ≤ n) :
 
 lemma resultant_eq_zero_of_lt_lt (hf : f.natDegree < m) (hg : g.natDegree < n) :
     resultant f g m n = 0 := by
-  obtain _ | m := m; · omega
-  obtain _ | n := n; · omega
+  obtain _ | m := m; · lia
+  obtain _ | n := n; · lia
   rw [resultant_add_left_deg _ _ _ _ _ (by lia), resultant_add_right_deg _ _ _ _ _ (by lia)]
   simp [coeff_eq_zero_of_natDegree_lt hg]
 
@@ -390,7 +390,7 @@ theorem resultant_C_left (r : R) :
   rw [resultant_add_mul_right _ _ _ _ _ _ (natDegree_X_sub_C_le _), modByMonic_X_sub_C_eq_C_eval]
   · simp
   · rw [natDegree_divByMonic g (monic_X_sub_C r), natDegree_sub_C, natDegree_X]
-    omega
+    lia
 
 /-- `Res(X + r, g) = g(-r)` -/
 @[simp] lemma resultant_X_add_C_left (r : R) (hg : g.natDegree ≤ n) :
@@ -989,7 +989,7 @@ lemma resultant_deriv {f : R[X]} (hf : 0 < f.degree) :
   rw [resultant_comm, resultant, ← sylvesterDeriv_updateRow f hf, Matrix.det_updateRow_smul,
     Matrix.updateRow_eq_self, discr, mul_comm f.natDegree]
   ring_nf
-  rw [Nat.div_mul_cancel (by convert Nat.two_dvd_mul_add_one (f.natDegree - 1) using 2; omega)]
+  rw [Nat.div_mul_cancel (by convert Nat.two_dvd_mul_add_one (f.natDegree - 1) using 2; lia)]
 
 private lemma sylvesterDeriv_of_natDegree_eq_three {f : R[X]} (hf : f.natDegree = 3) :
     f.sylvesterDeriv.reindex (finCongr <| by rw [hf]) (finCongr <| by rw [hf]) =

--- a/Mathlib/RingTheory/PowerSeries/Restricted.lean
+++ b/Mathlib/RingTheory/PowerSeries/Restricted.lean
@@ -48,7 +48,7 @@ lemma one : IsRestricted c (1 : PowerSeries R) := by
   simp only [isRestricted_iff, coeff_one, norm_mul, norm_pow, Real.norm_eq_abs]
   refine fun _ _ ↦ ⟨1, fun n hn ↦ ?_ ⟩
   split
-  · omega
+  · lia
   · simpa
 
 lemma monomial (n : ℕ) (a : R) : IsRestricted c (monomial n a) := by
@@ -56,7 +56,7 @@ lemma monomial (n : ℕ) (a : R) : IsRestricted c (monomial n a) := by
     Real.norm_eq_abs, abs_norm]
   refine fun _ _ ↦ ⟨n + 1, fun _ _ ↦ ?_⟩
   split
-  · omega
+  · lia
   · simpa
 
 lemma C (a : R) : IsRestricted c (C a) := by
@@ -106,7 +106,7 @@ lemma convergenceSet_BddAbove {f : PowerSeries R} (hf : IsRestricted c f) :
   · right
     apply le_max'
     simp only [mem_image, mem_range]
-    exact ⟨i, by omega, rfl⟩
+    exact ⟨i, by lia, rfl⟩
   · left
     calc _ ≤ ‖(coeff i) f‖ * |c ^ i| := by bound
          _ ≤ 1 := by simpa using (hf i h).le

--- a/Mathlib/RingTheory/RootsOfUnity/CyclotomicUnits.lean
+++ b/Mathlib/RingTheory/RootsOfUnity/CyclotomicUnits.lean
@@ -51,7 +51,7 @@ theorem associated_sub_one_pow_sub_one_of_coprime (hζ : IsPrimitiveRoot ζ n) (
   | 0 => simp_all
   | 1 => simp_all
   | n + 2 =>
-      obtain ⟨m, -, hm⟩ := exists_mul_mod_eq_one_of_coprime hj (by omega)
+      obtain ⟨m, -, hm⟩ := exists_mul_mod_eq_one_of_coprime hj (by lia)
       use ∑ i ∈ range m, (ζ ^ j) ^ i
       rw [mul_geom_sum, ← pow_mul, ← pow_mod_orderOf, ← hζ.eq_orderOf, hm, pow_one]
 
@@ -111,7 +111,7 @@ theorem pow_sub_one_eq_geom_sum_mul_geom_sum_inv_mul_pow_sub_one (hζ : IsPrimit
   unit. -/
 theorem associated_pow_add_sub_sub_one (hζ : IsPrimitiveRoot ζ n) (hn : 2 ≤ n) (i : ℕ)
     (hjn : j.Coprime n) : Associated (ζ - 1) (ζ ^ (i + j) - ζ ^ i) := by
-  use (hζ.isUnit (by omega)).unit ^ i * (hζ.geom_sum_isUnit hn hjn).unit
+  use (hζ.isUnit (by lia)).unit ^ i * (hζ.geom_sum_isUnit hn hjn).unit
   suffices (ζ - 1) * ζ ^ i * ∑ i ∈ range j, ζ ^ i = (ζ ^ (i + j) - ζ ^ i) by
     simp [← this, mul_assoc]
   grind [mul_geom_sum]
@@ -128,7 +128,7 @@ lemma ntRootsFinset_pairwise_associated_sub_one_sub_of_prime (hζ : IsPrimitiveR
   obtain ⟨j, hj, rfl⟩ :=
     hζ.eq_pow_of_pow_eq_one ((Polynomial.mem_nthRootsFinset hp.pos 1).1 hη₂)
   wlog hij : j ≤ i
-  · simpa using (this hζ ‹_› ‹_› _ hj ‹_› _ hi ‹_› e.symm (by omega)).neg_right
+  · simpa using (this hζ ‹_› ‹_› _ hj ‹_› _ hi ‹_› e.symm (by lia)).neg_right
   have H : (i - j).Coprime p := (coprime_of_lt_prime (by grind) (by grind) hp).symm
   obtain ⟨u, h⟩ := hζ.associated_pow_add_sub_sub_one hp.two_le j H
   simp only [hij, add_tsub_cancel_of_le] at h

--- a/Mathlib/RingTheory/WittVector/Basic.lean
+++ b/Mathlib/RingTheory/WittVector/Basic.lean
@@ -301,7 +301,7 @@ theorem pow_dvd_ghostComponent_of_dvd_coeff {x : 𝕎 R} {n : ℕ}
   have : (MvPolynomial.aeval x.coeff) ((MvPolynomial.monomial (R := ℤ)
       (Finsupp.single i (p ^ (n - i)))) (p ^ i)) = ((p : R) ^ i) * (x.coeff i) ^ (p ^ (n - i)) := by
     simp [MvPolynomial.aeval_monomial, map_pow]
-  rw [this, show n + 1 = (n - i) + 1 + i by omega, pow_add, mul_comm]
+  rw [this, show n + 1 = (n - i) + 1 + i by lia, pow_add, mul_comm]
   gcongr
   · exact hx i (Nat.le_of_lt_succ hi)
   · exact ((n - i).lt_two_pow_self).succ_le.trans

--- a/Mathlib/Tactic/DeriveEncodable.lean
+++ b/Mathlib/Tactic/DeriveEncodable.lean
@@ -127,8 +127,8 @@ private def S_equiv : S ≃ ℕ where
       · exact nat_unpair_lt_2 h
       · obtain _ | n' := n
         · exact False.elim (h rfl)
-        · have := Nat.unpair_lt (by omega : 1 ≤ n' + 1)
-          omega
+        · have := Nat.unpair_lt (by lia : 1 ≤ n' + 1)
+          lia
 
 private instance : Encodable S := Encodable.ofEquiv ℕ S_equiv
 

--- a/Mathlib/Topology/Algebra/InfiniteSum/ConditionalInt.lean
+++ b/Mathlib/Topology/Algebra/InfiniteSum/ConditionalInt.lean
@@ -128,7 +128,7 @@ lemma HasProd.hasProd_symmetricIco_of_hasProd_symmetricIcc {a : α}
   simp only [HasProd, tendsto_map'_iff, symmetricIcc_eq_map_Icc_nat,
     ← Nat.map_cast_int_atTop, symmetricIco] at *
   apply tendsto_of_div_tendsto_one _ hf
-  simpa [Pi.div_def, fun N : ℕ ↦ prod_Icc_eq_prod_Ico_mul f (show (-N : ℤ) ≤ N by omega)]
+  simpa [Pi.div_def, fun N : ℕ ↦ prod_Icc_eq_prod_Ico_mul f (show (-N : ℤ) ≤ N by lia)]
     using hf2
 
 @[to_additive]

--- a/Mathlib/Topology/Algebra/InfiniteSum/SummationFilter.lean
+++ b/Mathlib/Topology/Algebra/InfiniteSum/SummationFilter.lean
@@ -252,8 +252,8 @@ lemma conditional_filter_eq_map_range : (conditional ℕ).filter = atTop.map Fin
       rw [← Tendsto] <;>
       simp only [tendsto_atTop', mem_map, mem_atTop_sets, mem_preimage] <;>
       rintro s ⟨a, ha⟩
-  · exact ⟨a + 1, fun b hb ↦ ha (b + 1) (by omega)⟩
-  · exact ⟨a + 1, fun b hb ↦ by convert ha (b - 1) (by omega); omega⟩
+  · exact ⟨a + 1, fun b hb ↦ ha (b + 1) (by lia)⟩
+  · exact ⟨a + 1, fun b hb ↦ by convert ha (b - 1) (by lia); lia⟩
 
 end conditionalTop
 

--- a/Mathlib/Topology/Algebra/Order/ArchimedeanDiscrete.lean
+++ b/Mathlib/Topology/Algebra/Order/ArchimedeanDiscrete.lean
@@ -44,7 +44,7 @@ instance instDiscreteTopologyZMultiples (g : G) : DiscreteTopology (zpowers g) :
   · simp only [Set.mem_preimage, Set.mem_Ioo, Set.mem_singleton_iff, and_imp]
     intro hn hn'
     rw [zpow_lt_zpow_iff_right ha] at hn hn'
-    simp only [Subtype.ext_iff, show n = 0 by omega, zpow_zero, coe_one]
+    simp only [Subtype.ext_iff, show n = 0 by lia, zpow_zero, coe_one]
   · simp_all
 
 variable [MulArchimedean G]

--- a/Mathlib/Topology/EMetricSpace/BoundedVariation.lean
+++ b/Mathlib/Topology/EMetricSpace/BoundedVariation.lean
@@ -448,17 +448,17 @@ theorem sum (f : α → E) {s : Set α} {E : ℕ → α} (hE : Monotone E) {n : 
     · simp [hn₀]
     rw [← Icc_add_Icc (b := E n)]
     · rw [← ih (by intros; apply hn <;> omega), Finset.sum_range_succ]
-    · apply hE; omega
-    · apply hE; omega
+    · apply hE; lia
+    · apply hE; lia
     · apply hn <;> omega
 
 theorem sum' (f : α → E) {I : ℕ → α} (hI : Monotone I) {n : ℕ} :
     ∑ i ∈ Finset.range n, eVariationOn f (Icc (I i) (I (i + 1)))
      = eVariationOn f (Icc (I 0) (I n)) := by
   convert sum f hI (s := Icc (I 0) (I n)) (n := n)
-    (hn := by intros; rw [mem_Icc]; constructor <;> (apply hI; omega)) with i hi
+    (hn := by intros; rw [mem_Icc]; constructor <;> (apply hI; lia)) with i hi
   · simp only [right_eq_inter]
-    gcongr <;> (apply hI; rw [Finset.mem_range] at hi; omega)
+    gcongr <;> (apply hI; rw [Finset.mem_range] at hi; lia)
   · simp
 
 section Monotone

--- a/Mathlib/Topology/EMetricSpace/PairReduction.lean
+++ b/Mathlib/Topology/EMetricSpace/PairReduction.lean
@@ -146,7 +146,7 @@ lemma pow_logSizeRadius_le_card_le_logSizeRadius (ha : 1 < a) (ht : t ∈ V) :
     simp
   have h := Nat.find_min (exists_radius_le t V ha c) this
   simp only [ENNReal.natCast_sub, Nat.cast_one, not_and, not_le] at h
-  exact (h (by omega)).le
+  exact (h (by lia)).le
 
 /-- A structure for carrying the data of `logSizeBallSeq` -/
 structure logSizeBallStruct (T : Type*) where
@@ -285,7 +285,7 @@ lemma card_finset_logSizeBallSeq_le (hJ : J.Nonempty) (i : ℕ) :
   | succ i ih =>
     by_cases h : (logSizeBallSeq J hJ a c i).finset.Nonempty
     · have := card_finset_logSizeBallSeq_add_one_lt hJ i h
-      omega
+      lia
     apply le_trans <| Finset.card_le_card (finset_logSizeBallSeq_add_one_subset hJ i)
     suffices #(logSizeBallSeq J hJ a c i).finset = 0 by simp [this]
     rwa [← not_ne_iff, Finset.card_ne_zero.not]


### PR DESCRIPTION
And a few `cutsat` as well. In preparation for the next lean version bump.

---
<!-- Your PR title will become the first line of the commit message.

In this box, the text above the `---` (if not empty) will be appended
to the commit message, and can be used to give additional context or
details. Please leave a blank newline before the `---`, otherwise GitHub
will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

When merging, all the commits will be squashed into a single commit
listing all co-authors.

Co-authors in the squash commit are gathered from two sources:

First, all authors of commits to this PR branch are included. Thus,
one way to add co-authors is to include at least one commit authored by
each co-author among the commits in the pull request. If necessary, you
may create empty commits to indicate co-authorship, using commands like so:

git commit --author="Author Name <author@email.com>" --allow-empty -m "add Author Name as coauthor"

Second, co-authors can also be listed in lines at the very bottom of
the commit message (that is, directly before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines
at the bottom of the commit message (before the `---`, and also before
any "Co-authored-by" lines) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
