### PR TITLE
[Merged by Bors] - chore(Tactic): deprecate `match_target`

### DIFF
--- a/Mathlib/Tactic/Basic.lean
+++ b/Mathlib/Tactic/Basic.lean
@@ -113,7 +113,11 @@ where
 /-- Try calling `assumption` on all goals; succeeds if it closes at least one goal. -/
 macro "assumption'" : tactic => `(tactic| any_goals assumption)
 
+/-- Deprecated: use `guard_target =~ t` instead. -/
+@[deprecated "Use `guard_target =~` instead." (since := "2025-12-11")]
 elab "match_target " t:term : tactic => do
+  logWarningAt t <|
+    m!"deprecation warning: replace `match_target {t}` with `guard_target =~ {t}`."
   withMainContext do
     let (val) ← elabTerm t (← inferType (← getMainTarget))
     if not (← isDefEq val (← getMainTarget)) then

--- a/MathlibTest/MonCat.lean
+++ b/MathlibTest/MonCat.lean
@@ -14,7 +14,7 @@ example {R S : CommMonCat} (i : R ⟶ S) (r : R) (h : r = 1) : i r = 1 := by sim
 -- when we construct the `toFun` field, the types are presented as `↑R`.
 example (R : CommMonCat.{u}) : R ⟶ R := CommMonCat.ofHom
   { toFun := fun x => by
-      match_target (R : Type u)
+      guard_target =~ (R : Type u)
       guard_hyp x : (R : Type u)
       exact x * x
     map_one' := by simp


### PR DESCRIPTION
`match_target t` does exactly the same as `guard_target =~ t`. `guard_target` is defined in core Lean, has more functionality and is used everywhere, whereas `match_target` only has one use.

Spotted while looking for un(der)documented tactics.

---
<!-- Your PR title will become the first line of the commit message.

In this box, the text above the `---` (if not empty) will be appended
to the commit message, and can be used to give additional context or
details. Please leave a blank newline before the `---`, otherwise GitHub
will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

When merging, all the commits will be squashed into a single commit
listing all co-authors.

Co-authors in the squash commit are gathered from two sources:

First, all authors of commits to this PR branch are included. Thus,
one way to add co-authors is to include at least one commit authored by
each co-author among the commits in the pull request. If necessary, you
may create empty commits to indicate co-authorship, using commands like so:

git commit --author="Author Name <author@email.com>" --allow-empty -m "add Author Name as coauthor"

Second, co-authors can also be listed in lines at the very bottom of
the commit message (that is, directly before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines
at the bottom of the commit message (before the `---`, and also before
any "Co-authored-by" lines) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
