### PR TITLE
[Merged by Bors] - feat(FieldTheory): X^n - t separable iff n nonzero

### DIFF
--- a/Mathlib/FieldTheory/Separable.lean
+++ b/Mathlib/FieldTheory/Separable.lean
@@ -446,6 +446,17 @@ theorem X_pow_sub_one_separable_iff {n : ℕ} : (X ^ n - 1 : F[X]).Separable ↔
   rw [hn', C_0, zero_mul, isCoprime_zero_right] at h
   exact not_isUnit_X_pow_sub_one F n h
 
+/-- In a field `F`, for any `t ∈ F` and `n > 0`, the polynomial `X ^ n - t` is separable
+    iff `↑n ≠ 0`. -/
+theorem X_pow_sub_C_separable_iff {n : ℕ} (x : F) (hn : n > 0)
+    (hx : IsUnit x) : (X ^ n - C x : F[X]).Separable ↔ (n : F) ≠ 0 := by
+  refine ⟨?_, fun h => separable_X_pow_sub_C_unit hx.unit (IsUnit.mk0 _ h)⟩
+  rw [separable_def', derivative_sub, derivative_X_pow, derivative_C, sub_zero]
+  rintro (h : IsCoprime _ _) hn'
+  rw [hn', C_0, zero_mul, isCoprime_zero_right] at h
+  have hDeg : (X ^ n - C x).natDegree = n := by simp
+  exact not_isUnit_of_natDegree_pos (X ^ n - C x) (hDeg.symm ▸ hn) h
+
 section Splits
 
 theorem card_rootSet_eq_natDegree [Algebra F K] {p : F[X]} (hsep : p.Separable)

--- a/Mathlib/FieldTheory/Separable.lean
+++ b/Mathlib/FieldTheory/Separable.lean
@@ -449,9 +449,9 @@ theorem X_pow_sub_one_separable_iff {n : ℕ} : (X ^ n - 1 : F[X]).Separable ↔
 /-- In a field `F`, for any `t ∈ F` and `n > 0`, the polynomial `X ^ n - t` is separable
     iff `↑n ≠ 0`. The assumption `n > 0` is needed, since for `n = 0` the polynomial `X ^ n - t`
     is separable iff `t ≠ 1`. -/
-theorem X_pow_sub_C_separable_iff {n : ℕ} (x : F) (hn : n > 0) (hx : IsUnit x) :
+theorem X_pow_sub_C_separable_iff {n : ℕ} (x : F) (hn : 0 < n) (hx : x ≠ 0) :
     (X ^ n - C x : F[X]).Separable ↔ (n : F) ≠ 0 := by
-  refine ⟨?_, fun h => separable_X_pow_sub_C_unit hx.unit (IsUnit.mk0 _ h)⟩
+  refine ⟨?_, fun h => separable_X_pow_sub_C_unit (Units.mk0 x hx) (IsUnit.mk0 _ h)⟩
   rw [separable_def', derivative_sub, derivative_X_pow, derivative_C, sub_zero]
   -- Suppose `(n : F) = 0`, then the derivative is `0`, so `X ^ n - 1` is a unit, contradiction.
   rintro (h : IsCoprime _ _) hn'

--- a/Mathlib/FieldTheory/Separable.lean
+++ b/Mathlib/FieldTheory/Separable.lean
@@ -447,11 +447,13 @@ theorem X_pow_sub_one_separable_iff {n : ℕ} : (X ^ n - 1 : F[X]).Separable ↔
   exact not_isUnit_X_pow_sub_one F n h
 
 /-- In a field `F`, for any `t ∈ F` and `n > 0`, the polynomial `X ^ n - t` is separable
-    iff `↑n ≠ 0`. -/
-theorem X_pow_sub_C_separable_iff {n : ℕ} (x : F) (hn : n > 0)
-    (hx : IsUnit x) : (X ^ n - C x : F[X]).Separable ↔ (n : F) ≠ 0 := by
+    iff `↑n ≠ 0`. The assumption `n > 0` is needed, since for `n = 0` the polynomial `X ^ n - t`
+    is separable iff `t ≠ 1`. -/
+theorem X_pow_sub_C_separable_iff {n : ℕ} (x : F) (hn : n > 0) (hx : IsUnit x) :
+    (X ^ n - C x : F[X]).Separable ↔ (n : F) ≠ 0 := by
   refine ⟨?_, fun h => separable_X_pow_sub_C_unit hx.unit (IsUnit.mk0 _ h)⟩
   rw [separable_def', derivative_sub, derivative_X_pow, derivative_C, sub_zero]
+  -- Suppose `(n : F) = 0`, then the derivative is `0`, so `X ^ n - 1` is a unit, contradiction.
   rintro (h : IsCoprime _ _) hn'
   rw [hn', C_0, zero_mul, isCoprime_zero_right] at h
   have hDeg : (X ^ n - C x).natDegree = n := by simp

--- a/Mathlib/FieldTheory/Separable.lean
+++ b/Mathlib/FieldTheory/Separable.lean
@@ -435,29 +435,22 @@ theorem separable_X_pow_sub_C' (p n : ℕ) (a : F) [CharP F p] (hn : ¬p ∣ n) 
     Separable (X ^ n - C a) :=
   separable_X_pow_sub_C a (by rwa [← CharP.cast_eq_zero_iff F p n] at hn) ha
 
+/-- In a field `F`, for any `t ∈ F` and `n > 0`, the polynomial `X ^ n - t` is separable
+    iff `↑n ≠ 0`. The assumption `n > 0` is needed, since for `n = 0` the polynomial `X ^ n - t`
+    is separable iff `t ≠ 1`. -/
+theorem X_pow_sub_C_separable_iff {n : ℕ} {x : F} (hn : 0 < n) (hx : x ≠ 0) :
+    (X ^ n - C x : F[X]).Separable ↔ (n : F) ≠ 0 := by
+  refine ⟨fun h hn' ↦ ?_, fun h => separable_X_pow_sub_C x h hx⟩
+  exact not_isUnit_of_natDegree_pos (X ^ n - C x) (by simp [hn]) <| by
+    simpa [separable_def, derivative_X_pow, hn', isCoprime_zero_right] using h
+
 -- this can possibly be strengthened to making `separable_X_pow_sub_C_unit` a
 -- bi-implication, but it is nontrivial!
 /-- In a field `F`, `X ^ n - 1` is separable iff `↑n ≠ 0`. -/
 theorem X_pow_sub_one_separable_iff {n : ℕ} : (X ^ n - 1 : F[X]).Separable ↔ (n : F) ≠ 0 := by
-  refine ⟨?_, fun h => separable_X_pow_sub_C_unit 1 (IsUnit.mk0 _ h)⟩
-  rw [separable_def', derivative_sub, derivative_X_pow, derivative_one, sub_zero]
-  -- Suppose `(n : F) = 0`, then the derivative is `0`, so `X ^ n - 1` is a unit, contradiction.
-  rintro (h : IsCoprime _ _) hn'
-  rw [hn', C_0, zero_mul, isCoprime_zero_right] at h
-  exact not_isUnit_X_pow_sub_one F n h
-
-/-- In a field `F`, for any `t ∈ F` and `n > 0`, the polynomial `X ^ n - t` is separable
-    iff `↑n ≠ 0`. The assumption `n > 0` is needed, since for `n = 0` the polynomial `X ^ n - t`
-    is separable iff `t ≠ 1`. -/
-theorem X_pow_sub_C_separable_iff {n : ℕ} (x : F) (hn : 0 < n) (hx : x ≠ 0) :
-    (X ^ n - C x : F[X]).Separable ↔ (n : F) ≠ 0 := by
-  refine ⟨?_, fun h => separable_X_pow_sub_C_unit (Units.mk0 x hx) (IsUnit.mk0 _ h)⟩
-  rw [separable_def', derivative_sub, derivative_X_pow, derivative_C, sub_zero]
-  -- Suppose `(n : F) = 0`, then the derivative is `0`, so `X ^ n - 1` is a unit, contradiction.
-  rintro (h : IsCoprime _ _) hn'
-  rw [hn', C_0, zero_mul, isCoprime_zero_right] at h
-  have hDeg : (X ^ n - C x).natDegree = n := by simp
-  exact not_isUnit_of_natDegree_pos (X ^ n - C x) (hDeg.symm ▸ hn) h
+  rcases (Nat.eq_zero_or_pos n) with (hz | hpos)
+  · simp_all [not_separable_zero]
+  · exact X_pow_sub_C_separable_iff hpos one_ne_zero
 
 section Splits
 

--- a/Mathlib/FieldTheory/Separable.lean
+++ b/Mathlib/FieldTheory/Separable.lean
@@ -436,8 +436,8 @@ theorem separable_X_pow_sub_C' (p n : ℕ) (a : F) [CharP F p] (hn : ¬p ∣ n) 
   separable_X_pow_sub_C a (by rwa [← CharP.cast_eq_zero_iff F p n] at hn) ha
 
 /-- In a field `F`, for any `t ∈ F` and `n > 0`, the polynomial `X ^ n - t` is separable
-    iff `↑n ≠ 0`. The assumption `n > 0` is needed, since for `n = 0` the polynomial `X ^ n - t`
-    is separable iff `t ≠ 1`. -/
+iff `↑n ≠ 0`. The assumption `n > 0` is needed, since for `n = 0` the polynomial `X ^ n - t`
+is separable iff `t ≠ 1`. -/
 theorem X_pow_sub_C_separable_iff {n : ℕ} {x : F} (hn : 0 < n) (hx : x ≠ 0) :
     (X ^ n - C x : F[X]).Separable ↔ (n : F) ≠ 0 := by
   refine ⟨fun h hn' ↦ ?_, fun h => separable_X_pow_sub_C x h hx⟩


### PR DESCRIPTION
In a field `F`, for `t : F` and `n > 0`, we prove that the polynomial `X ^ n - t` is separable if and only if `n` is nonzero in `F`. This generalizes `X_pow_sub_one_separable_iff`, but the extra assumption that `n > 0` is needed (for `n = 0`, the polynomial `X ^ n - t` is separable iff `t` is not `1`).

---
<!-- Your PR title will become the first line of the commit message.

In this box, the text above the `---` (if not empty) will be appended
to the commit message, and can be used to give additional context or
details. Please leave a blank newline before the `---`, otherwise GitHub
will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

When merging, all the commits will be squashed into a single commit
listing all co-authors.

Co-authors in the squash commit are gathered from two sources:

First, all authors of commits to this PR branch are included. Thus,
one way to add co-authors is to include at least one commit authored by
each co-author among the commits in the pull request. If necessary, you
may create empty commits to indicate co-authorship, using commands like so:

git commit --author="Author Name <author@email.com>" --allow-empty -m "add Author Name as coauthor"

Second, co-authors can also be listed in lines at the very bottom of
the commit message (that is, directly before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines
at the bottom of the commit message (before the `---`, and also before
any "Co-authored-by" lines) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
