### PR TITLE
[Merged by Bors] - fix: respect visibility in `notation3`

### DIFF
--- a/Mathlib/Util/Notation3.lean
+++ b/Mathlib/Util/Notation3.lean
@@ -523,7 +523,7 @@ This command can be used in mathlib4 but it has an uncertain future and was crea
 for backward compatibility.
 -/
 elab (name := notation3) doc:(docComment)? attrs?:(Parser.Term.attributes)? attrKind:Term.attrKind
-    vis:(visibility)? "notation3" prec?:(precedence)? name?:(namedName)? prio?:(namedPrio)?
+    "notation3" prec?:(precedence)? name?:(namedName)? prio?:(namedPrio)?
     pp?:(ppSpace prettyPrintOpt)? items:(ppSpace notation3Item)+ " => " val:term : command => do
   -- We use raw `Name`s for variables. This maps variable names back to the
   -- identifiers that appear in `items`
@@ -652,7 +652,7 @@ elab (name := notation3) doc:(docComment)? attrs?:(Parser.Term.attributes)? attr
       if hasBindersItem then
         result ← `(`(extBinders| $$(MatchState.getBinders s)*) >>= fun binders => $result)
       let delabKeys : List DelabKey := ms.foldr (·.1 ++ ·) []
-      let vis ← vis.getDM do if isPrivateName (← getDeclNGen).namePrefix then
+      let vis ← if let `(attrKind| local) := attrKind then
         `(visibility| private) else `(visibility| public)
       for key in delabKeys do
         trace[notation3] "Creating delaborator for key {repr key}"

--- a/Mathlib/Util/Notation3.lean
+++ b/Mathlib/Util/Notation3.lean
@@ -621,7 +621,7 @@ elab (name := notation3) doc:(docComment)? attrs?:(Parser.Term.attributes)? attr
   trace[notation3] "syntax declaration has name {fullName}"
   let pat : Term := ⟨mkNode fullName pattArgs⟩
   let val' ← val.replaceM fun s => pure boundValues[s.getId]?
-  let mut macroDecl ← `(macro_rules | `($pat) => `($val'))
+  let mut macroDecl ← `($attrKind:attrKind macro_rules | `($pat) => `($val'))
   if isLocalAttrKind attrKind then
     -- For local notation, take section variables into account
     macroDecl ← `(section set_option quotPrecheck.allowSectionVars true $macroDecl end)

--- a/Mathlib/Util/Notation3.lean
+++ b/Mathlib/Util/Notation3.lean
@@ -624,7 +624,7 @@ elab (name := notation3) doc:(docComment)? attrs?:(Parser.Term.attributes)? attr
   let mut macroDecl ← `($attrKind:attrKind macro_rules | `($pat) => `($val'))
   if isLocalAttrKind attrKind then
     -- For local notation, take section variables into account
-    macroDecl ← `(section set_option quotPrecheck.allowSectionVars true $macroDecl end)
+    macroDecl ← `(command| set_option quotPrecheck.allowSectionVars true in $macroDecl)
   elabCommand macroDecl
 
   -- 3. Create a delaborator

--- a/MathlibTest/PrivateModuleLinter/notation3.lean
+++ b/MathlibTest/PrivateModuleLinter/notation3.lean
@@ -8,9 +8,6 @@ import Mathlib.Util.Whatsnew
 
 open Lean
 
-open scoped Lean.Elab.Command
-
-
 local notation3 "MyList[" (x", "* => foldr (a b => List.cons a b) List.nil) "]" => x
 
 /- Check that we have indeed created declarations, and aren't not linting just due to being an
@@ -25,8 +22,7 @@ info: [_private.MathlibTest.PrivateModuleLinter.notation3.0.«_aux_MathlibTest_P
 run_cmd do
   logInfo m!"{(← getEnv).constants.map₂.toArray.map (·.1)}"
 
-
--- The linter should fire despite the public name `foo.eq_1` being present
+-- The linter should fire despite since the `notation` is local
 -- Run the linter on artificial `eoi` syntax so that we can actually guard the message
 set_option linter.mathlibStandardSet true in
 open Mathlib.Linter Parser in

--- a/MathlibTest/PrivateModuleLinter/notation3.lean
+++ b/MathlibTest/PrivateModuleLinter/notation3.lean
@@ -1,0 +1,43 @@
+module
+
+import Mathlib.Init
+import all Mathlib.Tactic.Linter.PrivateModule
+import Mathlib.Util.Notation3
+public import Lean.Elab.AuxDef
+import Mathlib.Util.Whatsnew
+
+open Lean
+
+open scoped Lean.Elab.Command
+
+
+local notation3 "MyList[" (x", "* => foldr (a b => List.cons a b) List.nil) "]" => x
+
+/- Check that we have indeed created declarations, and aren't not linting just due to being an
+empty file: -/
+/--
+info: [_private.MathlibTest.PrivateModuleLinter.notation3.0.«_aux_MathlibTest_PrivateModuleLinter_notation3___delab_app__private_MathlibTest_PrivateModuleLinter_notation3_0_termMyList[_,]_2»,
+ _private.MathlibTest.PrivateModuleLinter.notation3.0.«termMyList[_,]»,
+ _private.MathlibTest.PrivateModuleLinter.notation3.0.«_aux_MathlibTest_PrivateModuleLinter_notation3___delab_app__private_MathlibTest_PrivateModuleLinter_notation3_0_termMyList[_,]_1»,
+ _private.MathlibTest.PrivateModuleLinter.notation3.0.«_aux_MathlibTest_PrivateModuleLinter_notation3___macroRules__private_MathlibTest_PrivateModuleLinter_notation3_0_termMyList[_,]_1»]
+-/
+#guard_msgs in
+run_cmd do
+  logInfo m!"{(← getEnv).constants.map₂.toArray.map (·.1)}"
+
+
+-- The linter should fire despite the public name `foo.eq_1` being present
+-- Run the linter on artificial `eoi` syntax so that we can actually guard the message
+set_option linter.mathlibStandardSet true in
+open Mathlib.Linter Parser in
+/--
+warning: The current module only contains private declarations.
+
+Consider adding `@[expose] public section` at the beginning of the module, or selectively marking declarations as `public`.
+
+Note: This linter can be disabled with `set_option linter.privateModule false`
+-/
+#guard_msgs in
+run_cmd do
+  let eoi := mkNode ``Command.eoi #[mkAtom .none ""]
+  privateModule.run eoi

--- a/MathlibTest/PrivateModuleLinter/notation3.lean
+++ b/MathlibTest/PrivateModuleLinter/notation3.lean
@@ -3,8 +3,6 @@ module
 import Mathlib.Init
 import all Mathlib.Tactic.Linter.PrivateModule
 import Mathlib.Util.Notation3
-public import Lean.Elab.AuxDef
-import Mathlib.Util.Whatsnew
 
 open Lean
 
@@ -22,7 +20,7 @@ info: [_private.MathlibTest.PrivateModuleLinter.notation3.0.«_aux_MathlibTest_P
 run_cmd do
   logInfo m!"{(← getEnv).constants.map₂.toArray.map (·.1)}"
 
--- The linter should fire despite since the `notation` is local
+-- The linter should fire since the `notation3` is local
 -- Run the linter on artificial `eoi` syntax so that we can actually guard the message
 set_option linter.mathlibStandardSet true in
 open Mathlib.Linter Parser in

--- a/MathlibTest/PrivateModuleLinter/notation3.lean
+++ b/MathlibTest/PrivateModuleLinter/notation3.lean
@@ -1,6 +1,5 @@
 module
 
-import Mathlib.Init
 import all Mathlib.Tactic.Linter.PrivateModule
 import Mathlib.Util.Notation3
 


### PR DESCRIPTION
This PR makes sure that `notation3` respects visibility and does not introduce public declarations when preceded by `local`. In particular:
* we pass along the `attrKind` to `macro_rules`, thereby making them `local` when the `notation3` is (and therefore making sure their associated declaration under the hood is private)
* we use a `private aux_def` when the `attrKind` is `local` (and `public` otherwise, for `scoped` or none)

Note that, like `syntax` and `notation`, the declarations created by `notation3` will be `public` even when not in `public section`. Visibility for meta commands like these is controlled by `local`.

This was discovered because `local notation3` introduced public declarations which wrongly silenced the private module linter. We therefore include a test for the private module linter.

---
<!-- Your PR title will become the first line of the commit message.

In this box, the text above the `---` (if not empty) will be appended
to the commit message, and can be used to give additional context or
details. Please leave a blank newline before the `---`, otherwise GitHub
will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

When merging, all the commits will be squashed into a single commit
listing all co-authors.

Co-authors in the squash commit are gathered from two sources:

First, all authors of commits to this PR branch are included. Thus,
one way to add co-authors is to include at least one commit authored by
each co-author among the commits in the pull request. If necessary, you
may create empty commits to indicate co-authorship, using commands like so:

git commit --author="Author Name <author@email.com>" --allow-empty -m "add Author Name as coauthor"

Second, co-authors can also be listed in lines at the very bottom of
the commit message (that is, directly before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines
at the bottom of the commit message (before the `---`, and also before
any "Co-authored-by" lines) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
