### PR TITLE
[Merged by Bors] - chore(CategoryTheory/Limits): more API for wide pullbacks

### DIFF
--- a/Mathlib/CategoryTheory/Limits/Shapes/WidePullbacks.lean
+++ b/Mathlib/CategoryTheory/Limits/Shapes/WidePullbacks.lean
@@ -445,8 +445,8 @@ of their cone points. -/
 def ext {ι : Type*}
     {X : C} {Y : ι → C} {f : ∀ i, Y i ⟶ X} {s t : WidePullbackCone f}
     (e : s.pt ≅ t.pt)
-    (base : e.hom ≫ t.base = s.base)
-    (π : ∀ i, e.hom ≫ t.π i = s.π i) :
+    (base : e.hom ≫ t.base = s.base := by cat_disch)
+    (π : ∀ i, e.hom ≫ t.π i = s.π i := by cat_disch) :
     s ≅ t :=
   Cones.ext e <| by
     rintro (_ | _)

--- a/Mathlib/CategoryTheory/Limits/Shapes/WidePullbacks.lean
+++ b/Mathlib/CategoryTheory/Limits/Shapes/WidePullbacks.lean
@@ -140,12 +140,37 @@ def equivalenceOfEquiv (J' : Type w') (h : J ≃ J') :
   unitIso := NatIso.ofComponents (fun j => by cases j <;> exact eqToIso (by simp))
   counitIso := NatIso.ofComponents (fun j => by cases j <;> exact eqToIso (by simp))
 
+@[simp]
+lemma equivalenceOfEquiv_functor_obj_none {ι ι' : Type*} (e : ι ≃ ι') :
+    (WidePullbackShape.equivalenceOfEquiv _ e).functor.obj none = none := rfl
+
+@[simp]
+lemma equivalenceOfEquiv_functor_obj_some {ι ι' : Type*} (e : ι ≃ ι') (i) :
+    (WidePullbackShape.equivalenceOfEquiv _ e).functor.obj (some i) = some (e i) := rfl
+
+@[simp]
+lemma equivalenceOfEquiv_functor_map_term {ι ι' : Type*} (e : ι ≃ ι') (i) :
+    (WidePullbackShape.equivalenceOfEquiv _ e).functor.map (.term i) = .term (e i) := rfl
+
 attribute [local instance] uliftCategory in
 /-- Lifting universe and morphism levels preserves wide pullback diagrams. -/
 def uliftEquivalence :
     ULiftHom.{w'} (ULift.{w'} (WidePullbackShape J)) ≌ WidePullbackShape (ULift J) :=
   (ULiftHomULiftCategory.equiv.{w', w', w, w} (WidePullbackShape J)).symm.trans
     (equivalenceOfEquiv _ (Equiv.ulift.{w', w}.symm : J ≃ ULift.{w'} J))
+
+/-- Show two functors out of a wide pullback shape are isomorphic by showing their components are
+isomorphic. -/
+@[simps!]
+def functorExt {ι : Type*} {F G : WidePullbackShape ι ⥤ C}
+    (base : F.obj none ≅ G.obj none) (comp : ∀ i, F.obj (some i) ≅ G.obj (some i))
+    (w : ∀ i, F.map (.term i) ≫ base.hom = (comp i).hom ≫ G.map (.term i) := by cat_disch) :
+    F ≅ G :=
+  NatIso.ofComponents
+    (fun i ↦ match i with
+      | none => base
+      | some i => comp i)
+    (fun f ↦ by rcases f <;> simp [w])
 
 end WidePullbackShape
 
@@ -341,6 +366,121 @@ theorem hom_ext (g1 g2 : X ⟶ widePullback _ _ arrows) : (∀ j : J,
   · apply h1
 
 end WidePullback
+
+/-- A wide pullback cone is a cone on the wide cospan formed by a family of morphisms. -/
+abbrev WidePullbackCone {ι : Type*} {X : C} {Y : ι → C} (f : ∀ i, Y i ⟶ X) :=
+  Cone (WidePullbackShape.wideCospan X Y f)
+
+namespace WidePullbackCone
+
+variable {ι : Type*} {X : C} {Y : ι → C} {f : ∀ i, Y i ⟶ X}
+
+/-- The projection on the components of a wide pullback cone. -/
+abbrev π (s : WidePullbackCone f) (i : ι) : s.pt ⟶ Y i :=
+  (Cone.π s).app (some i)
+
+/-- The projection to the base of a wide pullback cone. -/
+abbrev base (s : WidePullbackCone f) : s.pt ⟶ X :=
+  (Cone.π s).app none
+
+@[reassoc (attr := simp)]
+lemma condition (s : WidePullbackCone f) (i : ι) : s.π i ≫ f i = s.base := by
+  simpa using ((Cone.π s).naturality (.term i)).symm
+
+/-- Construct a wide pullback cone from the projections. -/
+@[simps! pt]
+def mk {W : C} (b : W ⟶ X) (π : ∀ i, W ⟶ Y i) (h : ∀ i, π i ≫ f i = b) :
+    WidePullbackCone f :=
+  WidePullbackShape.mkCone b π h
+
+@[simp]
+lemma mk_base {W : C} (b : W ⟶ X) (π : ∀ i, W ⟶ Y i) (h : ∀ i, π i ≫ f i = b) :
+    (WidePullbackCone.mk b π h).base = b := rfl
+
+@[simp]
+lemma mk_π {W : C} (b : W ⟶ X) (π : ∀ i, W ⟶ Y i) (h : ∀ i, π i ≫ f i = b) (i : ι) :
+    (WidePullbackCone.mk b π h).π i = π i := rfl
+
+/-- Constructor to show a wide pullback cone is limiting. -/
+def IsLimit.mk (s : WidePullbackCone f) (lift : ∀ t : WidePullbackCone f, t.pt ⟶ s.pt)
+    (facbase : ∀ t, lift t ≫ s.base = t.base) (facπ : ∀ t i, lift t ≫ s.π i = t.π i)
+    (uniq : ∀ (t) (m : t.pt ⟶ s.pt), m ≫ s.base = t.base → (∀ i, m ≫ s.π i = t.π i) → m = lift t) :
+    IsLimit s where
+  lift := lift
+  fac t j := by
+    cases j
+    · exact facbase t
+    · exact facπ t _
+  uniq t m hm := uniq _ _ (hm none) fun _ ↦ hm (some _)
+
+lemma IsLimit.hom_ext {s : WidePullbackCone f} (hs : IsLimit s)
+    {W : C} {k l : W ⟶ s.pt} (hbase : k ≫ s.base = l ≫ s.base)
+    (hπ : ∀ i, k ≫ s.π i = l ≫ s.π i) :
+    k = l := by
+  apply hs.hom_ext
+  rintro (_ | j)
+  · exact hbase
+  · exact hπ j
+
+/-- Lift a family of morphisms to a limiting wide pullback cone. -/
+def IsLimit.lift {s : WidePullbackCone f} (hs : IsLimit s)
+    {W : C} (b : W ⟶ X) (a : ∀ i, W ⟶ Y i) (w : ∀ i, a i ≫ f i = b) :
+    W ⟶ s.pt :=
+  hs.lift (WidePullbackCone.mk b a w)
+
+@[reassoc (attr := simp)]
+lemma IsLimit.lift_base {s : WidePullbackCone f} (hs : IsLimit s)
+    {W : C} (b : W ⟶ X) (a : ∀ i, W ⟶ Y i) (w : ∀ i, a i ≫ f i = b) :
+    IsLimit.lift hs b a w ≫ s.base = b := by
+  simp [lift]
+
+@[reassoc (attr := simp)]
+lemma IsLimit.lift_π {s : WidePullbackCone f} (hs : IsLimit s)
+    {W : C} (b : W ⟶ X) (a : ∀ i, W ⟶ Y i) (w : ∀ i, a i ≫ f i = b) (i : ι) :
+    IsLimit.lift hs b a w ≫ s.π i = a i := by
+  simp [lift]
+
+/-- To show two wide pullback cones are isomorphic, it suffices to given a compatible isomorphism
+of their cone points. -/
+def ext {ι : Type*}
+    {X : C} {Y : ι → C} {f : ∀ i, Y i ⟶ X} {s t : WidePullbackCone f}
+    (e : s.pt ≅ t.pt)
+    (base : e.hom ≫ t.base = s.base)
+    (π : ∀ i, e.hom ≫ t.π i = s.π i) :
+    s ≅ t :=
+  Cones.ext e <| by rintro (_ | _) <;> simp [base, π]
+
+/-- Reindex a wide pullback cone. -/
+@[simps! pt]
+def reindex {ι : Type*} {X : C} {Y : ι → C} {f : ∀ i, Y i ⟶ X} (s : WidePullbackCone f)
+    {ι' : Type*} (e : ι' ≃ ι) :
+    WidePullbackCone (fun i ↦ f (e i)) :=
+  .mk s.base (fun i ↦ s.π _) (by simp)
+
+@[simp]
+lemma reindex_base {ι : Type*} {X : C} {Y : ι → C} {f : ∀ i, Y i ⟶ X} (s : WidePullbackCone f)
+    {ι' : Type*} (e : ι' ≃ ι) :
+    (s.reindex e).base = s.base := rfl
+
+@[simp]
+lemma reindex_π {ι : Type*} {X : C} {Y : ι → C} {f : ∀ i, Y i ⟶ X} (s : WidePullbackCone f)
+    {ι' : Type*} (e : ι' ≃ ι) (i : ι') :
+    (s.reindex e).π i = s.π (e i) := rfl
+
+/-- Reindexing a pullback cone preserves being limiting. -/
+def reindexIsLimitEquiv {ι : Type*} {X : C} {Y : ι → C} {f : ∀ i, Y i ⟶ X}
+    (s : WidePullbackCone f) {ι' : Type*} (e : ι' ≃ ι) :
+    IsLimit (s.reindex e) ≃ IsLimit s :=
+  (IsLimit.whiskerEquivalenceEquiv <| WidePullbackShape.equivalenceOfEquiv _ e.symm).trans <|
+    IsLimit.equivOfNatIsoOfIso
+      (WidePullbackShape.functorExt (Iso.refl X) (fun i ↦ eqToIso (by simp))
+        fun i ↦ by simp [← eqToHom_naturality]) _ _
+      (WidePullbackCone.ext (Iso.refl _) (by simp [WidePullbackCone.base, WidePullbackCone.reindex])
+        (fun i ↦ by
+          simp [WidePullbackCone.π, WidePullbackCone.reindex,
+            eqToHom_naturality (fun i ↦ (Cone.π s).app (some i)) (e.apply_symm_apply i)]))
+
+end WidePullbackCone
 
 namespace WidePushout
 

--- a/Mathlib/CategoryTheory/Limits/Shapes/WidePullbacks.lean
+++ b/Mathlib/CategoryTheory/Limits/Shapes/WidePullbacks.lean
@@ -376,11 +376,11 @@ namespace WidePullbackCone
 variable {ι : Type*} {X : C} {Y : ι → C} {f : ∀ i, Y i ⟶ X}
 
 /-- The projection on the components of a wide pullback cone. -/
-abbrev π (s : WidePullbackCone f) (i : ι) : s.pt ⟶ Y i :=
+def π (s : WidePullbackCone f) (i : ι) : s.pt ⟶ Y i :=
   (Cone.π s).app (some i)
 
 /-- The projection to the base of a wide pullback cone. -/
-abbrev base (s : WidePullbackCone f) : s.pt ⟶ X :=
+def base (s : WidePullbackCone f) : s.pt ⟶ X :=
   (Cone.π s).app none
 
 @[reassoc (attr := simp)]
@@ -431,14 +431,14 @@ def IsLimit.lift {s : WidePullbackCone f} (hs : IsLimit s)
 @[reassoc (attr := simp)]
 lemma IsLimit.lift_base {s : WidePullbackCone f} (hs : IsLimit s)
     {W : C} (b : W ⟶ X) (a : ∀ i, W ⟶ Y i) (w : ∀ i, a i ≫ f i = b) :
-    IsLimit.lift hs b a w ≫ s.base = b := by
-  simp [lift]
+    IsLimit.lift hs b a w ≫ s.base = b :=
+  hs.fac _ _
 
 @[reassoc (attr := simp)]
 lemma IsLimit.lift_π {s : WidePullbackCone f} (hs : IsLimit s)
     {W : C} (b : W ⟶ X) (a : ∀ i, W ⟶ Y i) (w : ∀ i, a i ≫ f i = b) (i : ι) :
-    IsLimit.lift hs b a w ≫ s.π i = a i := by
-  simp [lift]
+    IsLimit.lift hs b a w ≫ s.π i = a i :=
+  hs.fac _ _
 
 /-- To show two wide pullback cones are isomorphic, it suffices to given a compatible isomorphism
 of their cone points. -/
@@ -448,7 +448,10 @@ def ext {ι : Type*}
     (base : e.hom ≫ t.base = s.base)
     (π : ∀ i, e.hom ≫ t.π i = s.π i) :
     s ≅ t :=
-  Cones.ext e <| by rintro (_ | _) <;> simp [base, π]
+  Cones.ext e <| by
+    rintro (_ | _)
+    · exact base.symm
+    · exact (π _).symm
 
 /-- Reindex a wide pullback cone. -/
 @[simps! pt]
@@ -475,9 +478,9 @@ def reindexIsLimitEquiv {ι : Type*} {X : C} {Y : ι → C} {f : ∀ i, Y i ⟶ 
     IsLimit.equivOfNatIsoOfIso
       (WidePullbackShape.functorExt (Iso.refl X) (fun i ↦ eqToIso (by simp))
         fun i ↦ by simp [← eqToHom_naturality]) _ _
-      (WidePullbackCone.ext (Iso.refl _) (by simp [WidePullbackCone.base, WidePullbackCone.reindex])
+      (WidePullbackCone.ext (Iso.refl _) (by simp [base, reindex, mk])
         (fun i ↦ by
-          simp [WidePullbackCone.π, WidePullbackCone.reindex,
+          simp [π, reindex, mk,
             eqToHom_naturality (fun i ↦ (Cone.π s).app (some i)) (e.apply_symm_apply i)]))
 
 end WidePullbackCone


### PR DESCRIPTION
Analogous to `PullbackCone`, we add a `WidePullbackCone` with API to construct them and to show they are limiting.

---
<!-- Your PR title will become the first line of the commit message.

In this box, the text above the `---` (if not empty) will be appended
to the commit message, and can be used to give additional context or
details. Please leave a blank newline before the `---`, otherwise GitHub
will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

When merging, all the commits will be squashed into a single commit
listing all co-authors.

Co-authors in the squash commit are gathered from two sources:

First, all authors of commits to this PR branch are included. Thus,
one way to add co-authors is to include at least one commit authored by
each co-author among the commits in the pull request. If necessary, you
may create empty commits to indicate co-authorship, using commands like so:

git commit --author="Author Name <author@email.com>" --allow-empty -m "add Author Name as coauthor"

Second, co-authors can also be listed in lines at the very bottom of
the commit message (that is, directly before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines
at the bottom of the commit message (before the `---`, and also before
any "Co-authored-by" lines) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
