### PR TITLE
[Merged by Bors] - doc(FieldTheory): fix typos

### DIFF
--- a/Mathlib/FieldTheory/Finite/Extension.lean
+++ b/Mathlib/FieldTheory/Finite/Extension.lean
@@ -43,7 +43,7 @@ open Polynomial
 
 namespace FiniteField
 
-/-- Given a finite field `k` of characteristic `p`, we have a non-canoncailly chosen extension
+/-- Given a finite field `k` of characteristic `p`, we have a non-canonically chosen extension
 of any given degree `n > 0`. -/
 def Extension [CharP k p] : Type :=
   letI := ZMod.algebra k p

--- a/Mathlib/FieldTheory/Finite/Trace.lean
+++ b/Mathlib/FieldTheory/Finite/Trace.lean
@@ -33,7 +33,7 @@ namespace FiniteField
 
 open Fintype
 
-/-- The trace map from a finite field to its prime field is nongedenerate. -/
+/-- The trace map from a finite field to its prime field is nondegenerate. -/
 theorem trace_to_zmod_nondegenerate (F : Type*) [Field F] [Finite F]
     [Algebra (ZMod (ringChar F)) F] {a : F} (ha : a ≠ 0) :
     ∃ b : F, Algebra.trace (ZMod (ringChar F)) F (a * b) ≠ 0 := by

--- a/Mathlib/FieldTheory/IsAlgClosed/Spectrum.lean
+++ b/Mathlib/FieldTheory/IsAlgClosed/Spectrum.lean
@@ -11,7 +11,7 @@ public import Mathlib.FieldTheory.IsAlgClosed.Basic
 /-!
 # Spectrum mapping theorem
 
-This file develops proves the spectral mapping theorem for polynomials over algebraically closed
+This file develops and proves the spectral mapping theorem for polynomials over algebraically closed
 fields. In particular, if `a` is an element of a `𝕜`-algebra `A` where `𝕜` is a field, and
 `p : 𝕜[X]` is a polynomial, then the spectrum of `Polynomial.aeval a p` contains the image of the
 spectrum of `a` under `(fun k ↦ Polynomial.eval k p)`. When `𝕜` is algebraically closed,

--- a/Mathlib/FieldTheory/IsPerfectClosure.lean
+++ b/Mathlib/FieldTheory/IsPerfectClosure.lean
@@ -38,8 +38,8 @@ ring homomorphism `i : K →+* L`, as well as its basic properties.
   then any ring homomorphism `K →+* M` can be lifted to `L →+* M`.
   This is similar to `IsAlgClosed.lift` and `IsSepClosed.lift`.
 
-- `PerfectRing.liftEquiv`: `K →+* M` is one-to-one correspondence to `L →+* M`,
-  given by `PerfectRing.lift`. This is a generalization to `PerfectClosure.lift`.
+- `PerfectRing.liftEquiv`: `K →+* M` is in one-to-one correspondence with `L →+* M`,
+  given by `PerfectRing.lift`. This generalizes `PerfectClosure.lift`.
 
 - `IsPerfectClosure.equiv`: perfect closures of a ring are isomorphic.
 
@@ -254,7 +254,7 @@ variable [CommRing K] [CommRing L] [CommRing M] [CommRing N]
 
 namespace IsPRadical
 
-/-- If `i : K →+* L` is `p`-radical, then for any ring `M` of exponential charactistic `p` whose
+/-- If `i : K →+* L` is `p`-radical, then for any ring `M` of exponential characteristic `p` whose
 `p`-nilradical is zero, the map `(L →+* M) → (K →+* M)` induced by `i` is injective. -/
 theorem injective_comp_of_pNilradical_eq_bot [IsPRadical i p] (h : pNilradical M p = ⊥) :
     Function.Injective fun f : L →+* M ↦ f.comp i := fun f g heq ↦ by
@@ -265,7 +265,7 @@ theorem injective_comp_of_pNilradical_eq_bot [IsPRadical i p] (h : pNilradical M
 
 variable (M)
 
-/-- If `i : K →+* L` is `p`-radical, then for any reduced ring `M` of exponential charactistic `p`,
+/-- If `i : K →+* L` is `p`-radical, then for any reduced ring `M` of exponential characteristic `p`,
 the map `(L →+* M) → (K →+* M)` induced by `i` is injective.
 A special case of `IsPRadical.injective_comp_of_pNilradical_eq_bot`
 and a generalization of `IsPurelyInseparable.injective_comp_algebraMap`. -/
@@ -274,7 +274,7 @@ theorem injective_comp [IsPRadical i p] [IsReduced M] :
   injective_comp_of_pNilradical_eq_bot i p <| bot_unique <|
     pNilradical_le_nilradical.trans (nilradical_eq_zero M).le
 
-/-- If `i : K →+* L` is `p`-radical, then for any perfect ring `M` of exponential charactistic `p`,
+/-- If `i : K →+* L` is `p`-radical, then for any perfect ring `M` of exponential characteristic `p`,
 the map `(L →+* M) → (K →+* M)` induced by `i` is injective.
 A special case of `IsPRadical.injective_comp_of_pNilradical_eq_bot`. -/
 theorem injective_comp_of_perfect [IsPRadical i p] [PerfectRing M p] :
@@ -367,10 +367,10 @@ theorem comp_lift : lift i (f.comp i) p = f :=
 theorem comp_lift_apply (x : L) : lift i (f.comp i) p x = f x := congr($(comp_lift i f p) x)
 
 variable (M) in
-/-- If `i : K →+* L` is a homomorphisms of characteristic `p` rings, such that
+/-- If `i : K →+* L` is a homomorphism of characteristic `p` rings, such that
 `i` is `p`-radical, and `M` is a perfect ring of characteristic `p`,
-then `K →+* M` is one-to-one correspondence to
-`L →+* M`, given by `PerfectRing.lift`. This is a generalization to `PerfectClosure.lift`. -/
+then `K →+* M` is in one-to-one correspondence with
+`L →+* M`, given by `PerfectRing.lift`. This generalizes `PerfectClosure.lift`. -/
 def liftEquiv : (K →+* M) ≃ (L →+* M) where
   toFun j := lift i j p
   invFun f := f.comp i

--- a/Mathlib/FieldTheory/IsPerfectClosure.lean
+++ b/Mathlib/FieldTheory/IsPerfectClosure.lean
@@ -265,8 +265,8 @@ theorem injective_comp_of_pNilradical_eq_bot [IsPRadical i p] (h : pNilradical M
 
 variable (M)
 
-/-- If `i : K →+* L` is `p`-radical, then for any reduced ring `M` of exponential characteristic `p`,
-the map `(L →+* M) → (K →+* M)` induced by `i` is injective.
+/-- If `i : K →+* L` is `p`-radical, then for any reduced ring `M` of exponential characteristic
+`p`, the map `(L →+* M) → (K →+* M)` induced by `i` is injective.
 A special case of `IsPRadical.injective_comp_of_pNilradical_eq_bot`
 and a generalization of `IsPurelyInseparable.injective_comp_algebraMap`. -/
 theorem injective_comp [IsPRadical i p] [IsReduced M] :
@@ -274,8 +274,8 @@ theorem injective_comp [IsPRadical i p] [IsReduced M] :
   injective_comp_of_pNilradical_eq_bot i p <| bot_unique <|
     pNilradical_le_nilradical.trans (nilradical_eq_zero M).le
 
-/-- If `i : K →+* L` is `p`-radical, then for any perfect ring `M` of exponential characteristic `p`,
-the map `(L →+* M) → (K →+* M)` induced by `i` is injective.
+/-- If `i : K →+* L` is `p`-radical, then for any perfect ring `M` of exponential characteristic
+`p`, the map `(L →+* M) → (K →+* M)` induced by `i` is injective.
 A special case of `IsPRadical.injective_comp_of_pNilradical_eq_bot`. -/
 theorem injective_comp_of_perfect [IsPRadical i p] [PerfectRing M p] :
     Function.Injective fun f : L →+* M ↦ f.comp i :=

--- a/Mathlib/FieldTheory/Normal/Defs.lean
+++ b/Mathlib/FieldTheory/Normal/Defs.lean
@@ -226,7 +226,7 @@ theorem AlgEquiv.restrictNormalHom_id (F K : Type*)
 namespace IsScalarTower
 
 /-- In a scalar tower `K₃/K₂/K₁/F` with `K₁` and `K₂` normal over `F`, the group homomorphism
-given by restricting algebra isomorphisms of `K₃` to `K₁` is equal to the composition of
+which restricts algebra isomorphisms of `K₃` to `K₁` is equal to the composition of
 the group homomorphism given by restricting an algebra isomorphism of `K₃` to `K₂` and
 the group homomorphism given by restricting an algebra isomorphism of `K₂` to `K₁`. -/
 theorem AlgEquiv.restrictNormalHom_comp (F K₁ K₂ K₃ : Type*)

--- a/Mathlib/FieldTheory/Normal/Defs.lean
+++ b/Mathlib/FieldTheory/Normal/Defs.lean
@@ -225,10 +225,10 @@ theorem AlgEquiv.restrictNormalHom_id (F K : Type*)
 
 namespace IsScalarTower
 
-/-- In a scalar tower `K₃/K₂/K₁/F` with `K₁` and `K₂` are normal over `F`, the group homomorphism
-given by the restriction of algebra isomorphisms of `K₃` to `K₁` is equal to the composition of
-the group homomorphism given by the restricting an algebra isomorphism of `K₃` to `K₂` and
-the group homomorphism given by the restricting an algebra isomorphism of `K₂` to `K₁` -/
+/-- In a scalar tower `K₃/K₂/K₁/F` with `K₁` and `K₂` normal over `F`, the group homomorphism
+given by restricting algebra isomorphisms of `K₃` to `K₁` is equal to the composition of
+the group homomorphism given by restricting an algebra isomorphism of `K₃` to `K₂` and
+the group homomorphism given by restricting an algebra isomorphism of `K₂` to `K₁`. -/
 theorem AlgEquiv.restrictNormalHom_comp (F K₁ K₂ K₃ : Type*)
     [Field F] [Field K₁] [Field K₂] [Field K₃]
     [Algebra F K₁] [Algebra F K₂] [Algebra F K₃] [Algebra K₁ K₂] [Algebra K₁ K₃] [Algebra K₂ K₃]


### PR DESCRIPTION
Found and fixed by Codex.

---
<!-- Your PR title will become the first line of the commit message.

In this box, the text above the `---` (if not empty) will be appended
to the commit message, and can be used to give additional context or
details. Please leave a blank newline before the `---`, otherwise GitHub
will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

When merging, all the commits will be squashed into a single commit
listing all co-authors.

Co-authors in the squash commit are gathered from two sources:

First, all authors of commits to this PR branch are included. Thus,
one way to add co-authors is to include at least one commit authored by
each co-author among the commits in the pull request. If necessary, you
may create empty commits to indicate co-authorship, using commands like so:

git commit --author="Author Name <author@email.com>" --allow-empty -m "add Author Name as coauthor"

Second, co-authors can also be listed in lines at the very bottom of
the commit message (that is, directly before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines
at the bottom of the commit message (before the `---`, and also before
any "Co-authored-by" lines) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
