### PR TITLE
[Merged by Bors] - feat(Algebra/GroupWithZero/NonZeroDivisors): add some lemmas about multiplication

### DIFF
--- a/Mathlib/Algebra/GroupWithZero/NonZeroDivisors.lean
+++ b/Mathlib/Algebra/GroupWithZero/NonZeroDivisors.lean
@@ -130,6 +130,9 @@ alias nonZeroDivisorsRight_eq_nonZeroSMulDivisors := nonZeroDivisorsLeft_eq_nonZ
 theorem mem_nonZeroDivisors_iff :
     r ∈ M₀⁰ ↔ (∀ x, r * x = 0 → x = 0) ∧ ∀ x, x * r = 0 → x = 0 := Iff.rfl
 
+theorem mem_nonZeroDivisors_iff' :
+    r ∈ M₀⁰ ↔ r ∈ nonZeroDivisorsLeft _ ∧ r ∈ nonZeroDivisorsRight _ := Iff.rfl
+
 lemma notMem_nonZeroDivisors_iff :
     r ∉ M₀⁰ ↔ {s | r * s = 0 ∧ s ≠ 0}.Nonempty ∨ {s | s * r = 0 ∧ s ≠ 0}.Nonempty := by
   simp [-not_and, not_and_or, mem_nonZeroDivisors_iff, Set.nonempty_def]
@@ -156,6 +159,25 @@ lemma IsUnit.mem_nonZeroDivisors (hx : IsUnit x) : x ∈ M₀⁰ :=
 
 variable (M₀) in
 lemma isUnit_le_nonZeroDivisors : IsUnit.submonoid M₀ ≤ M₀⁰ := fun _ ↦ (·.mem_nonZeroDivisors)
+
+lemma mul_mem_nonZeroDivisorsLeft_of_mem_nonZeroDivisorsLeft (hx : x ∈ nonZeroDivisorsLeft _)
+    (hy : y ∈ nonZeroDivisorsLeft _) :
+    x * y ∈ nonZeroDivisorsLeft _ := by
+  rw [mem_nonZeroDivisorsLeft_iff] at ⊢ hx hy
+  intro _ h
+  exact hy _ <| hx _ <| mul_assoc x y _ ▸ h
+
+lemma mul_mem_nonZeroDivisorsRight_of_mem_nonZeroDivisorsRight (hx : x ∈ nonZeroDivisorsRight _)
+    (hy : y ∈ nonZeroDivisorsRight _) :
+    x * y ∈ nonZeroDivisorsRight _ := by
+  rw [mem_nonZeroDivisorsRight_iff] at ⊢ hx hy
+  intro _ h
+  exact hx _ <| hy _ <| mul_assoc _ x y ▸ h
+
+lemma mul_mem_nonZeroDivisors_of_mem_nonZeroDivisors (hx : x ∈ M₀⁰) (hy : y ∈ M₀⁰) :
+    x * y ∈ M₀⁰ := mem_nonZeroDivisors_iff'.mpr
+  ⟨mul_mem_nonZeroDivisorsLeft_of_mem_nonZeroDivisorsLeft hx.1 hy.1,
+    mul_mem_nonZeroDivisorsRight_of_mem_nonZeroDivisorsRight hx.2 hy.2⟩
 
 section Nontrivial
 variable [Nontrivial M₀]

--- a/Mathlib/Algebra/GroupWithZero/NonZeroDivisors.lean
+++ b/Mathlib/Algebra/GroupWithZero/NonZeroDivisors.lean
@@ -131,7 +131,7 @@ theorem mem_nonZeroDivisors_iff :
     r ∈ M₀⁰ ↔ (∀ x, r * x = 0 → x = 0) ∧ ∀ x, x * r = 0 → x = 0 := Iff.rfl
 
 theorem mem_nonZeroDivisors_iff' :
-    r ∈ M₀⁰ ↔ r ∈ nonZeroDivisorsLeft _ ∧ r ∈ nonZeroDivisorsRight _ := Iff.rfl
+    r ∈ M₀⁰ ↔ r ∈ nonZeroDivisorsLeft M₀ ∧ r ∈ nonZeroDivisorsRight M₀ := Iff.rfl
 
 lemma notMem_nonZeroDivisors_iff :
     r ∉ M₀⁰ ↔ {s | r * s = 0 ∧ s ≠ 0}.Nonempty ∨ {s | s * r = 0 ∧ s ≠ 0}.Nonempty := by
@@ -160,16 +160,16 @@ lemma IsUnit.mem_nonZeroDivisors (hx : IsUnit x) : x ∈ M₀⁰ :=
 variable (M₀) in
 lemma isUnit_le_nonZeroDivisors : IsUnit.submonoid M₀ ≤ M₀⁰ := fun _ ↦ (·.mem_nonZeroDivisors)
 
-lemma mul_mem_nonZeroDivisorsLeft_of_mem_nonZeroDivisorsLeft (hx : x ∈ nonZeroDivisorsLeft _)
-    (hy : y ∈ nonZeroDivisorsLeft _) :
-    x * y ∈ nonZeroDivisorsLeft _ := by
+lemma mul_mem_nonZeroDivisorsLeft_of_mem_nonZeroDivisorsLeft (hx : x ∈ nonZeroDivisorsLeft M₀)
+    (hy : y ∈ nonZeroDivisorsLeft M₀) :
+    x * y ∈ nonZeroDivisorsLeft M₀ := by
   rw [mem_nonZeroDivisorsLeft_iff] at ⊢ hx hy
   intro _ h
   exact hy _ <| hx _ <| mul_assoc x y _ ▸ h
 
-lemma mul_mem_nonZeroDivisorsRight_of_mem_nonZeroDivisorsRight (hx : x ∈ nonZeroDivisorsRight _)
-    (hy : y ∈ nonZeroDivisorsRight _) :
-    x * y ∈ nonZeroDivisorsRight _ := by
+lemma mul_mem_nonZeroDivisorsRight_of_mem_nonZeroDivisorsRight (hx : x ∈ nonZeroDivisorsRight M₀)
+    (hy : y ∈ nonZeroDivisorsRight M₀) :
+    x * y ∈ nonZeroDivisorsRight M₀ := by
   rw [mem_nonZeroDivisorsRight_iff] at ⊢ hx hy
   intro _ h
   exact hx _ <| hy _ <| mul_assoc _ x y ▸ h

--- a/Mathlib/Algebra/GroupWithZero/NonZeroDivisors.lean
+++ b/Mathlib/Algebra/GroupWithZero/NonZeroDivisors.lean
@@ -175,9 +175,10 @@ lemma mul_mem_nonZeroDivisorsRight_of_mem_nonZeroDivisorsRight (hx : x ∈ nonZe
   exact hx _ <| hy _ <| mul_assoc _ x y ▸ h
 
 lemma mul_mem_nonZeroDivisors_of_mem_nonZeroDivisors (hx : x ∈ M₀⁰) (hy : y ∈ M₀⁰) :
-    x * y ∈ M₀⁰ := mem_nonZeroDivisors_iff'.mpr
-  ⟨mul_mem_nonZeroDivisorsLeft_of_mem_nonZeroDivisorsLeft hx.1 hy.1,
-    mul_mem_nonZeroDivisorsRight_of_mem_nonZeroDivisorsRight hx.2 hy.2⟩
+    x * y ∈ M₀⁰ :=
+  mem_nonZeroDivisors_iff'.mpr
+    ⟨mul_mem_nonZeroDivisorsLeft_of_mem_nonZeroDivisorsLeft hx.1 hy.1,
+      mul_mem_nonZeroDivisorsRight_of_mem_nonZeroDivisorsRight hx.2 hy.2⟩
 
 section Nontrivial
 variable [Nontrivial M₀]


### PR DESCRIPTION
Similar to `Is{Left,Right,}Regular.mul`.

---
<!-- Your PR title will become the first line of the commit message.

In this box, the text above the `---` (if not empty) will be appended
to the commit message, and can be used to give additional context or
details. Please leave a blank newline before the `---`, otherwise GitHub
will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

When merging, all the commits will be squashed into a single commit
listing all co-authors.

Co-authors in the squash commit are gathered from two sources:

First, all authors of commits to this PR branch are included. Thus,
one way to add co-authors is to include at least one commit authored by
each co-author among the commits in the pull request. If necessary, you
may create empty commits to indicate co-authorship, using commands like so:

git commit --author="Author Name <author@email.com>" --allow-empty -m "add Author Name as coauthor"

Second, co-authors can also be listed in lines at the very bottom of
the commit message (that is, directly before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines
at the bottom of the commit message (before the `---`, and also before
any "Co-authored-by" lines) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

`Is{Left,Right,}Regular.mul`: https://github.com/leanprover-community/mathlib4/blob/c671bc4215d64bd9cc8a84fdec9a12bd33fdcd26/Mathlib/Algebra/Regular/Basic.lean#L59-L76

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
