### PR TITLE
[Merged by Bors] - feat(Algebra/GroupWithZero/NonZeroDivisors): add a lemma about product

### DIFF
--- a/Mathlib/Algebra/GroupWithZero/NonZeroDivisors.lean
+++ b/Mathlib/Algebra/GroupWithZero/NonZeroDivisors.lean
@@ -334,8 +334,8 @@ theorem nonZeroDivisors_dvd_iff_dvd_coe {a b : M₀⁰} :
     by simp_rw [Subtype.ext_iff, Submonoid.coe_mul, hc]⟩⟩
 
 lemma prod_mem_nonZeroDivisors_of_mem_nonZeroDivisors
-    {ι : Type*} {s : Finset ι} {f : ι → M₀} (h : ∀ i ∈ s, f i ∈ nonZeroDivisors _) :
-    ∏ i ∈ s, f i ∈ nonZeroDivisors _ :=
+    {ι : Type*} {s : Finset ι} {f : ι → M₀} (h : ∀ i ∈ s, f i ∈ M₀⁰) :
+    ∏ i ∈ s, f i ∈ M₀⁰ :=
   s.prod_induction _ _ (fun _ _ ↦ and_imp.mp mul_mem_nonZeroDivisors.mpr) (one_mem _) h
 
 end CommMonoidWithZero

--- a/Mathlib/Algebra/GroupWithZero/NonZeroDivisors.lean
+++ b/Mathlib/Algebra/GroupWithZero/NonZeroDivisors.lean
@@ -10,6 +10,7 @@ public import Mathlib.Algebra.GroupWithZero.Associated
 public import Mathlib.Algebra.GroupWithZero.Regular
 public import Mathlib.Algebra.NoZeroSMulDivisors.Defs
 public import Mathlib.Algebra.Regular.SMul
+public import Mathlib.Algebra.BigOperators.Group.Finset.Defs
 
 /-!
 # Non-zero divisors and smul-divisors
@@ -331,6 +332,11 @@ theorem nonZeroDivisors_dvd_iff_dvd_coe {a b : M₀⁰} :
   ⟨fun ⟨c, hc⟩ ↦ by simp_rw [hc, Submonoid.coe_mul, dvd_mul_right],
   fun ⟨c, hc⟩ ↦ ⟨⟨c, (mul_mem_nonZeroDivisors.mp (hc ▸ b.prop)).2⟩,
     by simp_rw [Subtype.ext_iff, Submonoid.coe_mul, hc]⟩⟩
+
+lemma prod_mem_nonZeroDivisors_of_mem_nonZeroDivisors
+    {ι : Type*} {s : Finset ι} {f : ι → M₀} (h : ∀ i ∈ s, f i ∈ nonZeroDivisors _) :
+    ∏ i ∈ s, f i ∈ nonZeroDivisors _ :=
+  s.prod_induction _ _ (fun _ _ ↦ and_imp.mp mul_mem_nonZeroDivisors.mpr) (one_mem _) h
 
 end CommMonoidWithZero
 


### PR DESCRIPTION
Product of non-zero divisors is also a non-zero divisors.

It's similar with `IsRegular.prod`, while requiring non-zero divisors instead of regular elements.


---
<!-- Your PR title will become the first line of the commit message.

In this box, the text above the `---` (if not empty) will be appended
to the commit message, and can be used to give additional context or
details. Please leave a blank newline before the `---`, otherwise GitHub
will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

When merging, all the commits will be squashed into a single commit
listing all co-authors.

Co-authors in the squash commit are gathered from two sources:

First, all authors of commits to this PR branch are included. Thus,
one way to add co-authors is to include at least one commit authored by
each co-author among the commits in the pull request. If necessary, you
may create empty commits to indicate co-authorship, using commands like so:

git commit --author="Author Name <author@email.com>" --allow-empty -m "add Author Name as coauthor"

Second, co-authors can also be listed in lines at the very bottom of
the commit message (that is, directly before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines
at the bottom of the commit message (before the `---`, and also before
any "Co-authored-by" lines) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->
`IsRegular.prod`:
https://github.com/leanprover-community/mathlib4/blob/c671bc4215d64bd9cc8a84fdec9a12bd33fdcd26/Mathlib/Algebra/Regular/Pow.lean#L36-L37

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
