### PR TITLE
[Merged by Bors] - feat(VitaliFamily): prove `filterAt_enlarge`

### DIFF
--- a/Mathlib/MeasureTheory/Covering/VitaliFamily.lean
+++ b/Mathlib/MeasureTheory/Covering/VitaliFamily.lean
@@ -248,11 +248,24 @@ theorem eventually_filterAt_subset_of_nhds {x : X} {o : Set X} (hx : o ∈ 𝓝 
     ∀ᶠ t in v.filterAt x, t ⊆ o :=
   (eventually_smallSets_subset.2 hx).filter_mono inf_le_left
 
+@[simp]
+theorem filterAt_enlarge (v : VitaliFamily μ) {δ : ℝ} (δpos : 0 < δ) :
+    (v.enlarge δ δpos).filterAt = v.filterAt := by
+  ext1 x
+  suffices {t | MeasurableSet t → (interior t).Nonempty → ¬t ⊆ closedBall x δ →
+      t ∈ v.setsAt x} ∈ (𝓝 x).smallSets by
+    simpa [VitaliFamily.filterAt, VitaliFamily.enlarge, ← sup_principal, inf_sup_left,
+      mem_inf_principal]
+  filter_upwards [eventually_smallSets_subset.mpr (closedBall_mem_nhds _ δpos)]
+  simp +contextual
+
+theorem fineSubfamilyOn_iff_frequently (v : VitaliFamily μ) {f : X → Set (Set X)} {s : Set X} :
+    v.FineSubfamilyOn f s ↔ ∀ x ∈ s, ∃ᶠ t in v.filterAt x, t ∈ f x := by
+  refine forall₂_congr fun x hx ↦ ?_
+  simp [frequently_filterAt_iff, ← and_assoc, and_right_comm]
+
 theorem fineSubfamilyOn_of_frequently (v : VitaliFamily μ) (f : X → Set (Set X)) (s : Set X)
     (h : ∀ x ∈ s, ∃ᶠ t in v.filterAt x, t ∈ f x) : v.FineSubfamilyOn f s := by
-  intro x hx ε εpos
-  obtain ⟨t, tv, ht, tf⟩ : ∃ t ∈ v.setsAt x, t ⊆ closedBall x ε ∧ t ∈ f x :=
-    v.frequently_filterAt_iff.1 (h x hx) ε εpos
-  exact ⟨t, ⟨tv, tf⟩, ht⟩
+  rwa [fineSubfamilyOn_iff_frequently]
 
 end VitaliFamily


### PR DESCRIPTION
From https://github.com/urkud/SardMoreira

---
<!-- Your PR title will become the first line of the commit message.

In this box, the text above the `---` (if not empty) will be appended
to the commit message, and can be used to give additional context or
details. Please leave a blank newline before the `---`, otherwise GitHub
will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

When merging, all the commits will be squashed into a single commit
listing all co-authors.

Co-authors in the squash commit are gathered from two sources:

First, all authors of commits to this PR branch are included. Thus,
one way to add co-authors is to include at least one commit authored by
each co-author among the commits in the pull request. If necessary, you
may create empty commits to indicate co-authorship, using commands like so:

git commit --author="Author Name <author@email.com>" --allow-empty -m "add Author Name as coauthor"

Second, co-authors can also be listed in lines at the very bottom of
the commit message (that is, directly before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines
at the bottom of the commit message (before the `---`, and also before
any "Co-authored-by" lines) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
