### PR TITLE
[Merged by Bors] - feat: show that `Accumulate` and `partialSups` coincide

### DIFF
--- a/Mathlib/Algebra/Order/Disjointed.lean
+++ b/Mathlib/Algebra/Order/Disjointed.lean
@@ -34,6 +34,19 @@ theorem disjointed_add_one [NoMaxOrder ι] (f : ι → α) (i : ι) :
     disjointed f (i + 1) = f (i + 1) \ partialSups f i := by
   simpa only [succ_eq_add_one] using disjointed_succ f (not_isMax i)
 
+lemma partialSups_add_one_eq_sup_disjointed (f : ι → α) (i : ι) :
+    partialSups f (i + 1) = partialSups f i ⊔ disjointed f (i + 1) := by
+  by_cases hi : IsMax i
+  · have : i + 1 = i := by
+      have h : i ≤ i + 1 := by
+        rw [← Order.succ_eq_add_one]
+        apply Order.le_succ
+      exact le_antisymm (hi h) h
+    simp only [this, left_eq_sup, ge_iff_le, disjointed, sdiff_le_iff]
+    apply le_trans (le_partialSups _ _) le_sup_right
+  · rw [← Order.succ_eq_add_one, disjointed_succ _ hi]
+    simp
+
 protected lemma Monotone.disjointed_add_one_sup {f : ι → α} (hf : Monotone f) (i : ι) :
     disjointed f (i + 1) ⊔ f i = f (i + 1) := by
   simpa only [succ_eq_add_one i] using hf.disjointed_succ_sup i

--- a/Mathlib/Data/Nat/Lattice.lean
+++ b/Mathlib/Data/Nat/Lattice.lean
@@ -5,7 +5,6 @@ Authors: Johannes Hölzl, Floris van Doorn, Gabriel Ebner, Yury Kudryashov
 -/
 module
 
-public import Mathlib.Data.Set.Accumulate
 public import Mathlib.Order.ConditionallyCompleteLattice.Finset
 public import Mathlib.Order.Interval.Finset.Nat
 
@@ -239,8 +238,5 @@ theorem biInter_le_succ (u : ℕ → Set α) (n : ℕ) : ⋂ k ≤ n + 1, u k = 
 
 theorem biInter_le_succ' (u : ℕ → Set α) (n : ℕ) : ⋂ k ≤ n + 1, u k = u 0 ∩ ⋂ k ≤ n, u (k + 1) :=
   Nat.iInf_le_succ' u n
-
-theorem accumulate_succ (u : ℕ → Set α) (n : ℕ) :
-    Accumulate u (n + 1) = Accumulate u n ∪ u (n + 1) := biUnion_le_succ u n
 
 end Set

--- a/Mathlib/Data/Set/Accumulate.lean
+++ b/Mathlib/Data/Set/Accumulate.lean
@@ -5,12 +5,18 @@ Authors: Floris van Doorn
 -/
 module
 
+public import Mathlib.Data.Nat.Lattice
 public import Mathlib.Data.Set.Lattice
+public import Mathlib.Order.PartialSups
 
 /-!
 # Accumulate
 
 The function `Accumulate` takes a set `s` and returns `⋃ y ≤ x, s y`.
+
+This is closely related to the function `partialSups`, although these two functions have
+slightly different typeclass assumptions and API. `partialSups_eq_accumulate` shows
+that they coincide on `ℕ`.
 -/
 
 @[expose] public section
@@ -71,5 +77,13 @@ theorem disjoint_accumulate [Preorder α] (hs : Pairwise (Disjoint on s)) {i j :
   simp only [Accumulate, mem_iUnion, exists_prop] at hx
   rcases hx with ⟨k, hk, hx⟩
   exact disjoint_left.1 (hs (hk.trans_lt hij).ne) hx
+
+theorem accumulate_succ (u : ℕ → Set α) (n : ℕ) :
+    Accumulate u (n + 1) = Accumulate u n ∪ u (n + 1) := biUnion_le_succ u n
+
+lemma partialSups_eq_accumulate (f : ℕ → Set α) :
+    partialSups f = Accumulate f := by
+  ext n
+  simp [partialSups_eq_sup_range, Accumulate, Nat.lt_succ_iff]
 
 end Set


### PR DESCRIPTION
I need to shuffle a little bit the imports to let Accumulate import partialSups. As Accumulate is only used in advanced parts of the library, this looks reasonable to me.

---
<!-- Your PR title will become the first line of the commit message.

In this box, the text above the `---` (if not empty) will be appended
to the commit message, and can be used to give additional context or
details. Please leave a blank newline before the `---`, otherwise GitHub
will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

When merging, all the commits will be squashed into a single commit
listing all co-authors.

Co-authors in the squash commit are gathered from two sources:

First, all authors of commits to this PR branch are included. Thus,
one way to add co-authors is to include at least one commit authored by
each co-author among the commits in the pull request. If necessary, you
may create empty commits to indicate co-authorship, using commands like so:

git commit --author="Author Name <author@email.com>" --allow-empty -m "add Author Name as coauthor"

Second, co-authors can also be listed in lines at the very bottom of
the commit message (that is, directly before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines
at the bottom of the commit message (before the `---`, and also before
any "Co-authored-by" lines) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
