### PR TITLE
[Merged by Bors] - feat(Cyclotomic): compute the torsion order of a cyclotomic field 

### DIFF
--- a/Mathlib/Data/Nat/Totient.lean
+++ b/Mathlib/Data/Nat/Totient.lean
@@ -374,6 +374,43 @@ theorem totient_mul_of_prime_of_not_dvd {p n : ℕ} (hp : p.Prime) (h : ¬p ∣ 
   rw [totient_mul _, totient_prime hp]
   simpa [h] using coprime_or_dvd_of_prime hp n
 
+theorem eq_or_eq_of_totient_eq_totient {a b : ℕ} (h : a ∣ b) (h' : a.totient = b.totient) :
+    a = b ∨ 2 * a = b := by
+  by_cases ha : a = 0
+  · rw [ha, totient_zero, eq_comm, totient_eq_zero] at h'
+    simp [ha, h']
+  by_cases hb : b = 0
+  · rw [hb, totient_zero, totient_eq_zero] at h'
+    exact False.elim (ha h')
+  obtain ⟨c, rfl⟩ := h
+  suffices a.Coprime c by
+    rw [totient_mul this, eq_comm, mul_eq_left (totient_eq_zero.not.mpr ha),
+      totient_eq_one_iff] at h'
+    obtain rfl | rfl := h'
+    · simp
+    · simp [mul_comm]
+  refine coprime_of_dvd fun p hp hap ↦ ?_
+  rintro ⟨d, rfl⟩
+  suffices a.totient < (p * a * d).totient by
+    rw [← mul_assoc, mul_comm a] at h'
+    exact h'.not_lt this
+  rw [mul_comm p]
+  refine lt_of_lt_of_le ?_ (Nat.le_of_dvd ?_ (totient_dvd_of_dvd ⟨d, rfl⟩))
+  · rw [mul_comm, totient_mul_of_prime_of_dvd hp hap, Nat.lt_mul_iff_one_lt_left]
+    · exact hp.one_lt
+    · exact totient_pos.mpr <| pos_of_ne_zero ha
+  · exact totient_pos.mpr <| zero_lt_of_ne_zero (by rwa [mul_assoc])
+
+theorem eq_of_totient_eq_totient {a b : ℕ} (h : a ∣ b) (ha : Even a)
+    (h' : a.totient = b.totient) : a = b := by
+  by_cases ha' : a = 0
+  · rw [ha', totient_zero, eq_comm, totient_eq_zero] at h'
+    rw [h', ha']
+  refine (eq_or_eq_of_totient_eq_totient h h').resolve_right fun h ↦ ?_
+  rw [← h, totient_mul_of_prime_of_dvd (prime_two) (even_iff_two_dvd.mp ha), eq_comm,
+    mul_eq_right (totient_eq_zero.not.mpr ha')] at h'
+  cutsat
+
 theorem prime_pow_pow_totient_ediv_prod {p k : ℕ} (hp : p.Prime) (hk : 0 < k) :
       (p ^ k : ℕ) ^ φ (p ^ k) / ∏ q ∈ (p ^ k).primeFactors, q ^ (φ (p ^ k) / (q - 1)) =
         p ^ (p ^ (k - 1) * ((p - 1) * k - 1)) := by

--- a/Mathlib/Data/Nat/Totient.lean
+++ b/Mathlib/Data/Nat/Totient.lean
@@ -401,7 +401,7 @@ theorem eq_or_eq_of_totient_eq_totient {a b : ℕ} (h : a ∣ b) (h' : a.totient
     · exact totient_pos.mpr <| pos_of_ne_zero ha
   · exact totient_pos.mpr <| zero_lt_of_ne_zero (by rwa [mul_assoc])
 
-theorem eq_of_totient_eq_totient {a b : ℕ} (h : a ∣ b) (ha : Even a)
+theorem _root_.Even.eq_of_totient_eq_totient {a b : ℕ} (h : a ∣ b) (ha : Even a)
     (h' : a.totient = b.totient) : a = b := by
   by_cases ha' : a = 0
   · rw [ha', totient_zero, eq_comm, totient_eq_zero] at h'
@@ -409,7 +409,7 @@ theorem eq_of_totient_eq_totient {a b : ℕ} (h : a ∣ b) (ha : Even a)
   refine (eq_or_eq_of_totient_eq_totient h h').resolve_right fun h ↦ ?_
   rw [← h, totient_mul_of_prime_of_dvd (prime_two) (even_iff_two_dvd.mp ha), eq_comm,
     mul_eq_right (totient_eq_zero.not.mpr ha')] at h'
-  cutsat
+  lia
 
 theorem prime_pow_pow_totient_ediv_prod {p k : ℕ} (hp : p.Prime) (hk : 0 < k) :
       (p ^ k : ℕ) ^ φ (p ^ k) / ∏ q ∈ (p ^ k).primeFactors, q ^ (φ (p ^ k) / (q - 1)) =

--- a/Mathlib/NumberTheory/Cyclotomic/Basic.lean
+++ b/Mathlib/NumberTheory/Cyclotomic/Basic.lean
@@ -205,7 +205,24 @@ theorem union_left [h : IsCyclotomicExtension T A B] (hS : S ⊆ T) :
     rw [← adjoin_adjoin_coe_preimage, preimage_setOf_eq]
     norm_cast
 
-variable {n S}
+variable {n}
+
+/-- If there exists a primitive root of unity of order `n` in `B`, then
+`IsCyclotomicExtension S A B` implies `IsCyclotomicExtension (S ∪ {n}) A B`. -/
+theorem union_of_isPrimitiveRoot [hB : IsCyclotomicExtension S A B] {r : B}
+    (hr : IsPrimitiveRoot r n) :
+    IsCyclotomicExtension (S ∪ {n}) A B := by
+  by_cases hn : n = 0
+  · rwa [hn, eq_self_sdiff_zero, Set.union_diff_right, ← eq_self_sdiff_zero]
+  rw [iff_adjoin_eq_top]
+  refine ⟨fun m hm₁ hm₂ ↦ ?_, le_antisymm (by aesop) ?_⟩
+  · obtain hm₁ | rfl := hm₁
+    · exact exists_isPrimitiveRoot A B hm₁ hm₂
+    · use r
+  · rw [← ((iff_adjoin_eq_top _ _ _).mp hB).2]
+    exact Algebra.adjoin_mono (by aesop)
+
+variable {S}
 
 /-- If there exists a nonzero `s ∈ S` such that `n ∣ s`, then `IsCyclotomicExtension S A B`
 implies `IsCyclotomicExtension (S ∪ {n}) A B`. -/

--- a/Mathlib/NumberTheory/NumberField/Cyclotomic/Basic.lean
+++ b/Mathlib/NumberTheory/NumberField/Cyclotomic/Basic.lean
@@ -896,8 +896,7 @@ section NumberField
 open Units
 
 theorem NumberField.Units.dvd_torsionOrder_of_isPrimitiveRoot [NeZero n] [NumberField K] {ζ : K}
-    (hζ : IsPrimitiveRoot ζ n) :
-    n ∣ torsionOrder K := by
+    (hζ : IsPrimitiveRoot ζ n) : n ∣ torsionOrder K := by
   rw [torsionOrder, Fintype.card_eq_nat_card]
   replace hζ := (hζ.toInteger_isPrimitiveRoot).isUnit_unit (NeZero.ne n)
   convert orderOf_dvd_natCard (⟨(hζ.isUnit (NeZero.ne n)).unit, ?_⟩ : torsion K)
@@ -923,7 +922,7 @@ theorem IsCyclotomicExtension.Rat.torsionOrder_eq [NeZero n] [NumberField K]
     ← IsPrimitiveRoot.coe_units_iff] at hμ
   replace hμ := hμ.map_of_injective (FaithfulSMul.algebraMap_injective (𝓞 K) K)
   -- Thus, `K` contains a primitive root of order `l = lcm (n, torsionOrder K)`.
-  have h := IsPrimitiveRoot.pow_mul_pow_lcm hζ hμ (NeZero.ne _) (torsionOrder_ne_zero K)
+  have h := hζ.pow_mul_pow_lcm hμ (NeZero.ne _) (torsionOrder_ne_zero K)
   have : NeZero (n.lcm (torsionOrder K)) :=
     NeZero.of_pos <| Nat.lcm_pos_iff.mpr ⟨NeZero.pos n, torsionOrder_pos K⟩
   -- and therefore `K` is the `l`-th cyclotomic field
@@ -937,7 +936,7 @@ theorem IsCyclotomicExtension.Rat.torsionOrder_eq [NeZero n] [NumberField K]
   obtain hn | hn := Nat.even_or_odd n
   · rw [if_pos hn]
     apply dvd_antisymm
-    · have := Nat.eq_of_totient_eq_totient (Nat.dvd_lcm_left _ _) hn h_main
+    · have := hn.eq_of_totient_eq_totient (Nat.dvd_lcm_left _ _) h_main
       rwa [eq_comm, Nat.lcm_eq_left_iff_dvd] at this
     · exact dvd_torsionOrder_of_isPrimitiveRoot hζ
   · rw [if_neg (Nat.not_even_iff_odd.mpr hn)]

--- a/Mathlib/NumberTheory/NumberField/Cyclotomic/Basic.lean
+++ b/Mathlib/NumberTheory/NumberField/Cyclotomic/Basic.lean
@@ -890,3 +890,61 @@ end IsPrimitiveRoot
 end discr
 
 end PowerBasis
+
+section NumberField
+
+open Units
+
+theorem NumberField.Units.dvd_torsionOrder_of_isPrimitiveRoot [NeZero n] [NumberField K] {ζ : K}
+    (hζ : IsPrimitiveRoot ζ n) :
+    n ∣ torsionOrder K := by
+  rw [torsionOrder, Fintype.card_eq_nat_card]
+  replace hζ := (hζ.toInteger_isPrimitiveRoot).isUnit_unit (NeZero.ne n)
+  convert orderOf_dvd_natCard (⟨(hζ.isUnit (NeZero.ne n)).unit, ?_⟩ : torsion K)
+  · rw [Subgroup.orderOf_mk]
+    exact hζ.eq_orderOf
+  · refine (CommGroup.mem_torsion _ _).mpr ⟨n, NeZero.pos n, ?_⟩
+    rw [isPeriodicPt_mul_iff_pow_eq_one]
+    exact hζ.pow_eq_one
+
+/--
+The order of the torsion group of the `n`-th cyclotomic field is `n` if `n` is even and
+`2n` if `n` is odd.
+-/
+theorem IsCyclotomicExtension.Rat.torsionOrder_eq [NeZero n] [NumberField K]
+    [hK : IsCyclotomicExtension {n} ℚ K] :
+    torsionOrder K = if Even n then n else 2 * n := by
+  have hζ := hK.zeta_spec
+  -- We first prove that `K` contains a primitive root of order `torsionOrder K`
+  obtain ⟨μ, hμ⟩ : ∃ μ : torsion K, orderOf μ = torsionOrder K := by
+    rw [torsionOrder, Fintype.card_eq_nat_card]
+    exact IsCyclic.exists_ofOrder_eq_natCard
+  rw [← IsPrimitiveRoot.iff_orderOf, ← IsPrimitiveRoot.coe_submonoidClass_iff,
+    ← IsPrimitiveRoot.coe_units_iff] at hμ
+  replace hμ := hμ.map_of_injective (FaithfulSMul.algebraMap_injective (𝓞 K) K)
+  -- Thus, `K` contains a primitive root of order `l = lcm (n, torsionOrder K)`.
+  have h := IsPrimitiveRoot.pow_mul_pow_lcm hζ hμ (NeZero.ne _) (torsionOrder_ne_zero K)
+  have : NeZero (n.lcm (torsionOrder K)) :=
+    NeZero.of_pos <| Nat.lcm_pos_iff.mpr ⟨NeZero.pos n, torsionOrder_pos K⟩
+  -- and therefore `K` is the `l`-th cyclotomic field
+  have : IsCyclotomicExtension {n.lcm (torsionOrder K)} ℚ K := by
+    have := hK.union_of_isPrimitiveRoot _ _ _ h
+    rwa [Set.union_comm, ← IsCyclotomicExtension.iff_union_of_dvd] at this
+    exact ⟨n.lcm (torsionOrder K), by simp, NeZero.ne _, Nat.dvd_lcm_left _ _⟩
+  -- We deduce the identity `φ(n) = φ(lcm (n, torsionOrder K))`.
+  have h_main := (IsCyclotomicExtension.Rat.finrank n K).symm.trans <|
+    (IsCyclotomicExtension.Rat.finrank (n.lcm (torsionOrder K)) K)
+  obtain hn | hn := Nat.even_or_odd n
+  · rw [if_pos hn]
+    apply dvd_antisymm
+    · have := Nat.eq_of_totient_eq_totient (Nat.dvd_lcm_left _ _) hn h_main
+      rwa [eq_comm, Nat.lcm_eq_left_iff_dvd] at this
+    · exact dvd_torsionOrder_of_isPrimitiveRoot hζ
+  · rw [if_neg (Nat.not_even_iff_odd.mpr hn)]
+    have := (Nat.eq_or_eq_of_totient_eq_totient (Nat.dvd_lcm_left _ _) h_main).resolve_left ?_
+    · rw [this, eq_comm, Nat.lcm_eq_right_iff_dvd]
+      exact dvd_torsionOrder_of_isPrimitiveRoot hζ
+    · rw [eq_comm, Nat.lcm_eq_left_iff_dvd]
+      exact fun h ↦ Nat.not_even_iff_odd.mpr (Odd.of_dvd_nat hn h) (even_torsionOrder K)
+
+end NumberField


### PR DESCRIPTION
The order of the torsion group of the `n`-th cyclotomic field is `n` if `n` is even and `2n` if `n` is odd.

---
<!-- Your PR title will become the first line of the commit message.

In this box, the text above the `---` (if not empty) will be appended
to the commit message, and can be used to give additional context or
details. Please leave a blank newline before the `---`, otherwise GitHub
will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

When merging, all the commits will be squashed into a single commit
listing all co-authors.

Co-authors in the squash commit are gathered from two sources:

First, all authors of commits to this PR branch are included. Thus,
one way to add co-authors is to include at least one commit authored by
each co-author among the commits in the pull request. If necessary, you
may create empty commits to indicate co-authorship, using commands like so:

git commit --author="Author Name <author@email.com>" --allow-empty -m "add Author Name as coauthor"

Second, co-authors can also be listed in lines at the very bottom of
the commit message (that is, directly before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines
at the bottom of the commit message (before the `---`, and also before
any "Co-authored-by" lines) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
