### PR TITLE
[Merged by Bors] - doc(RingTheory): fix typos

### DIFF
--- a/Mathlib/RingTheory/AdicCompletion/AsTensorProduct.lean
+++ b/Mathlib/RingTheory/AdicCompletion/AsTensorProduct.lean
@@ -33,7 +33,8 @@ As a corollary we obtain
 ## TODO
 
 - Show that `ofTensorProduct` is an isomorphism for any finite free `R`-module over an arbitrary
-  ring. This is mostly composing with the isomorphism to `R^n` and checking that the diagram commutes.
+  ring. This is mostly composing with the isomorphism to `R^n` and checking that the diagram
+  commutes.
 
 -/
 

--- a/Mathlib/RingTheory/AdicCompletion/AsTensorProduct.lean
+++ b/Mathlib/RingTheory/AdicCompletion/AsTensorProduct.lean
@@ -33,7 +33,7 @@ As a corollary we obtain
 ## TODO
 
 - Show that `ofTensorProduct` is an isomorphism for any finite free `R`-module over an arbitrary
-  ring. This is mostly composing with the isomorphism to `R^n` and checking that a diagram commutes.
+  ring. This is mostly composing with the isomorphism to `R^n` and checking that the diagram commutes.
 
 -/
 

--- a/Mathlib/RingTheory/AdicCompletion/Basic.lean
+++ b/Mathlib/RingTheory/AdicCompletion/Basic.lean
@@ -720,7 +720,7 @@ theorem mk_lift {f : (n : ℕ) → M →ₗ[R] N ⧸ (I ^ n • ⊤)}
 
 /--
 The composition of lift linear map `lift I f h : M →ₗ[R] N` with the canonical
-projection `N →ₗ[R] N ⧸ (I ^ n • ⊤)` is `f n` .
+projection `N →ₗ[R] N ⧸ (I ^ n • ⊤)` is `f n`.
 -/
 @[simp]
 theorem mkQ_comp_lift {f : (n : ℕ) → M →ₗ[R] N ⧸ (I ^ n • ⊤)}
@@ -731,7 +731,7 @@ theorem mkQ_comp_lift {f : (n : ℕ) → M →ₗ[R] N ⧸ (I ^ n • ⊤)}
 /--
 Uniqueness of the lift.
 Given a compatible family of linear maps `f n : M →ₗ[R] N ⧸ (I ^ n • ⊤)`.
-If `F : M →ₗ[R] N` makes the following diagram commutes
+If `F : M →ₗ[R] N` makes the following diagram commute
 ```
   N
   | \

--- a/Mathlib/RingTheory/AdicCompletion/RingHom.lean
+++ b/Mathlib/RingTheory/AdicCompletion/RingHom.lean
@@ -78,7 +78,7 @@ theorem mk_comp_liftRingHom (n : ℕ) :
 /--
 Uniqueness of the lift.
 Given a compatible family of linear maps `f n : R →ₗ[R] S ⧸ (I ^ n)`.
-If `F : R →+* S` makes the following diagram commutes
+If `F : R →+* S` makes the following diagram commute
 ```
   R
   | \

--- a/Mathlib/RingTheory/Conductor.lean
+++ b/Mathlib/RingTheory/Conductor.lean
@@ -82,7 +82,7 @@ lemma mem_coeSubmodule_conductor {L} [CommRing L] [Algebra S L] [Algebra R L]
 
 variable {I : Ideal R}
 
-/-- This technical lemma tell us that if `C` is the conductor of `R<x>` and `I` is an ideal of `R`
+/-- This technical lemma tells us that if `C` is the conductor of `R<x>` and `I` is an ideal of `R`
   then `p * (I * S) ⊆ I * R<x>` for any `p` in `C ∩ R` -/
 theorem prod_mem_ideal_map_of_mem_conductor {p : R} {z : S}
     (hp : p ∈ Ideal.comap (algebraMap R S) (conductor R x)) (hz' : z ∈ I.map (algebraMap R S)) :

--- a/Mathlib/RingTheory/Congruence/Hom.lean
+++ b/Mathlib/RingTheory/Congruence/Hom.lean
@@ -193,21 +193,21 @@ theorem lift_unique (H : c ≤ ker f) (g : c.Quotient →+* P) (Hg : g.comp c.mk
     g = c.lift f H :=
   Quotient.hom_ext (by aesop)
 
-/-- Surjective ring homomorphisms constant on a the equivalence classes
+/-- Surjective ring homomorphisms constant on the equivalence classes
 of a ring congruence relation induce a surjective homomorphism on the quotient. -/
 theorem lift_surjective_iff {h : c ≤ ker f} :
     Surjective (c.lift f h) ↔ Surjective f := by
   refine ⟨fun H ↦ (Quot.surjective_lift fun x x_1 h_1 ↦ h h_1).mp H,
     fun H ↦ AddCon.lift_surjective_of_surjective h H⟩
 
-/-- Surjective ring homomorphisms constant on a the equivalence classes
+/-- Surjective ring homomorphisms constant on the equivalence classes
 of a ring congruence relation induce a surjective homomorphism on the quotient. -/
 theorem lift_surjective_of_surjective (h : c ≤ ker f) (hf : Surjective f) :
     Surjective (c.lift f h) :=
   lift_surjective_iff.mpr hf
 
 /-- Given a ring homomorphism `f` from `M` to `P` whose kernel contains `c`,
-the lift of `M`to `N` is injective iff `ker f = c`. -/
+the lift of `M` to `P` is injective iff `ker f = c`. -/
 theorem lift_injective_iff {h : c ≤ ker f} :
     Function.Injective (c.lift f h) ↔ c = ker f := by
   refine ⟨fun H ↦ ext'' (Setoid.ker_eq_lift_of_injective f h H).symm, ?_⟩
@@ -314,7 +314,7 @@ noncomputable def quotientKerEquivOfSurjective (f : M →+* P) (hf : Surjective 
 @[simp] theorem quotientKerEquivOfSurjective_mk (f : M →+* P) (hf : Surjective f) (x : M) :
     quotientKerEquivOfSurjective f hf x = f x := rfl
 
-/-- A surjective ring homomorphisms`f : M →+* N` induces
+/-- A surjective ring homomorphism `f : M →+* N` induces
 a ring equivalence `d.Quotient ≃+* c.Quotient`,
 whenever `c : RingCon M` and `d : RingCon N` are such that `d = c.comap f`. -/
 noncomputable def comapQuotientEquivOfSurj

--- a/Mathlib/RingTheory/DedekindDomain/Factorization.lean
+++ b/Mathlib/RingTheory/DedekindDomain/Factorization.lean
@@ -37,7 +37,7 @@ prove some of its properties. If `I = 0`, we define `val_v(I) = 0`.
   the fractional ideal `(k)` is equal to the product `∏_v v^(val_v(r) - val_v(s))`.
 - `FractionalIdeal.finite_factors` : If `I ≠ 0`, then `val_v(I) = 0` for all but finitely many
   maximal ideals of `R`.
-- `IsDedekindDomain.exists_sup_span_eq`: For every ideal `0 < I ≤ J`,
+- `IsDedekindDomain.exists_sup_span_eq`: For all ideals `0 < I ≤ J`,
   there exists `a` such that `J = I + ⟨a⟩`.
 - `Ideal.map_algebraMap_eq_finset_prod_pow`: if `p` is a maximal ideal, then the lift of `p`
   in an extension is the product of the primes over `p` to the power the ramification index.

--- a/Mathlib/RingTheory/DedekindDomain/Factorization.lean
+++ b/Mathlib/RingTheory/DedekindDomain/Factorization.lean
@@ -37,7 +37,7 @@ prove some of its properties. If `I = 0`, we define `val_v(I) = 0`.
   the fractional ideal `(k)` is equal to the product `∏_v v^(val_v(r) - val_v(s))`.
 - `FractionalIdeal.finite_factors` : If `I ≠ 0`, then `val_v(I) = 0` for all but finitely many
   maximal ideals of `R`.
-- `IsDedekindDomain.exists_sup_span_eq`: For every ideals `0 < I ≤ J`,
+- `IsDedekindDomain.exists_sup_span_eq`: For every ideal `0 < I ≤ J`,
   there exists `a` such that `J = I + ⟨a⟩`.
 - `Ideal.map_algebraMap_eq_finset_prod_pow`: if `p` is a maximal ideal, then the lift of `p`
   in an extension is the product of the primes over `p` to the power the ramification index.

--- a/Mathlib/RingTheory/DividedPowers/Basic.lean
+++ b/Mathlib/RingTheory/DividedPowers/Basic.lean
@@ -73,7 +73,7 @@ section DividedPowersDefinition
 
 variable {A : Type*} [CommSemiring A] (I : Ideal A)
 
-/-- The divided power structure on an ideal I of a commutative ring A -/
+/-- The divided power structure on an ideal `I` of a commutative ring `A`. -/
 structure DividedPowers where
   /-- The divided power function underlying a divided power structure -/
   dpow : ℕ → A → A

--- a/Mathlib/RingTheory/Etale/StandardEtale.lean
+++ b/Mathlib/RingTheory/Etale/StandardEtale.lean
@@ -15,7 +15,7 @@ public import Mathlib.RingTheory.Ideal.IdempotentFG
 
 # Standard etale maps
 
-# Main definitions
+## Main definitions
 - `StandardEtalePair`:
   A pair `f g : R[X]` such that `f` is monic and `f'` is invertible in `R[X][1/g]`.
 - `StandardEtalePair`: The standard etale algebra corresponding to a `StandardEtalePair`.

--- a/Mathlib/RingTheory/Extension/Generators.lean
+++ b/Mathlib/RingTheory/Extension/Generators.lean
@@ -83,7 +83,7 @@ abbrev Ring (P : Generators R S ι) : Type (max w u) := MvPolynomial ι R
 
 instance : Algebra P.Ring S := P.algebra
 
-/-- The designated section of w.r.t. a family of generators. -/
+/-- The designated section w.r.t. a family of generators. -/
 def σ : S → P.Ring := P.σ'
 
 /-- See Note [custom simps projection] -/

--- a/Mathlib/RingTheory/Extension/Presentation/Basic.lean
+++ b/Mathlib/RingTheory/Extension/Presentation/Basic.lean
@@ -24,7 +24,7 @@ A presentation of an `R`-algebra `S` is a distinguished family of generators and
   1. `rels`: The type of relations.
   2. `relation : relations → MvPolynomial vars R`: The assignment of
      each relation to a polynomial in the generators.
-- `Algebra.Presentation.IsFinite`: A presentation is called finite, if both variables and relations
+- `Algebra.Presentation.IsFinite`: A presentation is called finite if both variables and relations
   are finite.
 - `Algebra.Presentation.dimension`: The dimension of a presentation is the number of generators
   minus the number of relations.

--- a/Mathlib/RingTheory/FiniteType.lean
+++ b/Mathlib/RingTheory/FiniteType.lean
@@ -19,7 +19,7 @@ In this file we define a notion of finiteness that is common in commutative alge
 ## Main declarations
 
 - `Algebra.FiniteType`, `RingHom.FiniteType`, `AlgHom.FiniteType`
-  all of these express that some object is finitely generated *as algebra* over some base ring.
+  all of these express that some object is finitely generated *as an algebra* over some base ring.
 
 -/
 
@@ -681,7 +681,7 @@ This is a consequence of Noetherian case
 (`IsNoetherian.injective_of_surjective_of_injective`), which requires that `M` is a
 Noetherian module, but allows `R` to be non-commutative. The reduction of this result to
 Noetherian case is adapted from <https://math.stackexchange.com/a/1066110>:
-suppose `{ m_j }` is a finite set of generator of `M`, for any `n : N` one can write
+suppose `{ m_j }` is a finite set of generators of `M`, for any `n : N` one can write
 `i n = ∑ j, b_j * m_j` for `{ b_j }` in `R`, here `i : N →ₗ[R] M` is the standard inclusion.
 We can choose `{ n_j }` which are preimages of `{ m_j }` under `f`, and can choose
 `{ c_jl }` in `R` such that `i n_j = ∑ l, c_jl * m_l` for each `j`.

--- a/Mathlib/RingTheory/Flat/Basic.lean
+++ b/Mathlib/RingTheory/Flat/Basic.lean
@@ -39,7 +39,7 @@ the current `Module.Flat` to `Module.MonoFlat`.
 ## Main theorems
 
 * `Module.Flat.of_retract`: retracts of flat modules are flat
-* `Module.Flat.of_linearEquiv`: modules linearly equivalent to a flat modules are flat
+* `Module.Flat.of_linearEquiv`: modules linearly equivalent to a flat module are flat
 * `Module.Flat.directSum`: arbitrary direct sums of flat modules are flat
 * `Module.Flat.of_free`: free modules are flat
 * `Module.Flat.of_projective`: projective modules are flat
@@ -47,7 +47,7 @@ the current `Module.Flat` to `Module.MonoFlat`.
   preserves injectivity of linear maps. This lemma is fully universally polymorphic in all
   arguments, i.e. `R`, `M` and linear maps `N → N'` can all have different universe levels.
 * `Module.Flat.iff_rTensor_preserves_injective_linearMap`: a module is flat iff tensoring modules
-  in the higher universe preserves injectivity .
+  in the higher universe preserves injectivity.
 * `Module.Flat.lTensor_exact`: If `M` is a flat module then tensoring with `M` is an exact
   functor. This lemma is fully universally polymorphic in all arguments, i.e.
   `R`, `M` and linear maps `N → N' → N''` can all have different universe levels.

--- a/Mathlib/RingTheory/Ideal/Over.lean
+++ b/Mathlib/RingTheory/Ideal/Over.lean
@@ -41,7 +41,7 @@ variable {S : Type*} [CommRing S] {f : R →+* S} {I J : Ideal S}
 
 variable {p : Ideal R} {P : Ideal S}
 
-/-- If there is an injective map `R/p → S/P` such that following diagram commutes:
+/-- If there is an injective map `R/p → S/P` such that the following diagram commutes:
 ```
 R   → S
 ↓     ↓

--- a/Mathlib/RingTheory/Ideal/Quotient/Operations.lean
+++ b/Mathlib/RingTheory/Ideal/Quotient/Operations.lean
@@ -20,8 +20,6 @@ public import Mathlib.RingTheory.Ideal.Quotient.Basic
   for a morphism from a commutative ring to a semiring.
 - `AlgHom.quotientKerEquivRange` : the **first isomorphism theorem**
   for a morphism of algebras (over a commutative semiring)
-- `RingHom.quotientKerEquivRangeS` : the **first isomorphism theorem**
-  for a morphism from a commutative ring to a semiring.
 - `Ideal.quotientInfRingEquivPiQuotient`: the **Chinese Remainder Theorem**, version for coprime
   ideals (see also `ZMod.prodEquivPi` in `Data.ZMod.Quotient` for elementary versions about
   `ZMod`).

--- a/Mathlib/RingTheory/Localization/LocalizationLocalization.lean
+++ b/Mathlib/RingTheory/Localization/LocalizationLocalization.lean
@@ -41,7 +41,7 @@ variable [Algebra S T] [IsScalarTower R S T]
 
 -- This should only be defined when `S` is the localization `M⁻¹R`, hence the nolint.
 /-- Localizing w.r.t. `M ⊆ R` and then w.r.t. `N ⊆ S = M⁻¹R` is equal to the localization of `R`
-w.r.t. this module. See `localization_localization_isLocalization`.
+w.r.t. this submonoid. See `localization_localization_isLocalization`.
 -/
 @[nolint unusedArguments]
 def localizationLocalizationSubmodule : Submonoid R :=

--- a/Mathlib/RingTheory/MvPolynomial/MonomialOrder.lean
+++ b/Mathlib/RingTheory/MvPolynomial/MonomialOrder.lean
@@ -120,7 +120,7 @@ def Monic (f : MvPolynomial σ R) : Prop :=
   m.leadingCoeff f = 1
 
 variable (m) in
-/-- The leading term of of a multivariate polynomial with respect to a monomial ordering. -/
+/-- The leading term of a multivariate polynomial with respect to a monomial ordering. -/
 noncomputable def leadingTerm (f : MvPolynomial σ R) : MvPolynomial σ R :=
   monomial (m.degree f) (m.leadingCoeff f)
 

--- a/Mathlib/RingTheory/MvPowerSeries/Trunc.lean
+++ b/Mathlib/RingTheory/MvPowerSeries/Trunc.lean
@@ -36,7 +36,7 @@ public import Mathlib.Algebra.MvPolynomial.Eval
 * `MvPowerSeries.coeff_mul_eq_coeff_trunc'_mul_trunc'` : compares the coefficients
   of a product with those of the product of truncations.
 
-* `MvPowerSeries.trunc'_one` : truncation of a the unit power series.
+* `MvPowerSeries.trunc'_one` : truncation of the unit power series.
 
 * `MvPowerSeries.trunc'_C` : truncation of a constant.
 

--- a/Mathlib/RingTheory/NonUnitalSubring/Basic.lean
+++ b/Mathlib/RingTheory/NonUnitalSubring/Basic.lean
@@ -225,7 +225,7 @@ theorem mem_range_self (f : R →ₙ+* S) (x : R) : f x ∈ f.range :=
 theorem map_range : f.range.map g = (g.comp f).range := by
   simpa only [range_eq_map] using (⊤ : NonUnitalSubring R).map_map g f
 
-/-- The range of a ring homomorphism is a fintype, if the domain is a fintype.
+/-- The range of a ring homomorphism is a fintype if the domain is a fintype.
 Note: this instance can form a diamond with `Subtype.fintype` in the
   presence of `Fintype S`. -/
 instance fintypeRange [Fintype R] [DecidableEq S] (f : R →ₙ+* S) : Fintype (range f) :=

--- a/Mathlib/RingTheory/NonUnitalSubsemiring/Basic.lean
+++ b/Mathlib/RingTheory/NonUnitalSubsemiring/Basic.lean
@@ -159,7 +159,7 @@ theorem mem_srange_self (f : F) (x : R) : f x ∈ srange f :=
 theorem map_srange (g : S →ₙ+* T) (f : R →ₙ+* S) : map g (srange f) = srange (g.comp f) := by
   simpa only [srange_eq_map] using (⊤ : NonUnitalSubsemiring R).map_map g f
 
-/-- The range of a morphism of non-unital semirings is finite if the domain is a finite. -/
+/-- The range of a morphism of non-unital semirings is finite if the domain is finite. -/
 instance finite_srange [Finite R] (f : F) : Finite (srange f : NonUnitalSubsemiring S) :=
   (Set.finite_range f).to_subtype
 

--- a/Mathlib/RingTheory/Polynomial/Cyclotomic/Basic.lean
+++ b/Mathlib/RingTheory/Polynomial/Cyclotomic/Basic.lean
@@ -16,7 +16,7 @@ public import Mathlib.RingTheory.RootsOfUnity.Complex
 For `n : ℕ` and an integral domain `R`, we define a modified version of the `n`-th cyclotomic
 polynomial with coefficients in `R`, denoted `cyclotomic' n R`, as `∏ (X - μ)`, where `μ` varies
 over the primitive `n`th roots of unity. If there is a primitive `n`th root of unity in `R` then
-this the standard definition. We then define the standard cyclotomic polynomial `cyclotomic n R`
+this is the standard definition. We then define the standard cyclotomic polynomial `cyclotomic n R`
 with coefficients in any ring `R`.
 
 ## Main definition

--- a/Mathlib/RingTheory/SimpleRing/Congr.lean
+++ b/Mathlib/RingTheory/SimpleRing/Congr.lean
@@ -9,7 +9,7 @@ public import Mathlib.RingTheory.SimpleRing.Basic
 public import Mathlib.RingTheory.TwoSidedIdeal.Operations
 
 /-!
-# Simpleness is preserved by ring isomorphism/surjective ring homomorphisms
+# Simplicity is preserved by ring isomorphisms/surjective ring homomorphisms
 
 If `R` is a simple (non-assoc) ring and there exists surjective `f : R →+* S` where `S` is
 nontrivial, then `S` is also simple.

--- a/Mathlib/RingTheory/Valuation/Basic.lean
+++ b/Mathlib/RingTheory/Valuation/Basic.lean
@@ -56,7 +56,7 @@ In the `WithZero` locale, `Mᵐ⁰` is a shorthand for `WithZero (Multiplicative
 
 ## TODO
 
-If ever someone extends `Valuation`, we should fully comply to the `DFunLike` by migrating the
+If ever someone extends `Valuation`, we should fully comply with `DFunLike` by migrating the
 boilerplate lemmas to `ValuationClass`.
 -/
 

--- a/Mathlib/RingTheory/Valuation/ValuativeRel/Basic.lean
+++ b/Mathlib/RingTheory/Valuation/ValuativeRel/Basic.lean
@@ -92,7 +92,7 @@ variable {R Γ : Type*} [CommRing R] [LinearOrderedCommMonoidWithZero Γ]
   (v : Valuation R Γ)
 
 /-- We say that a valuation `v` is `Compatible` if the relation `x ≤ᵥ y`
-is equivalent to `v x ≤ x y`. -/
+is equivalent to `v x ≤ v y`. -/
 class Compatible [ValuativeRel R] where
   rel_iff_le (x y : R) : x ≤ᵥ y ↔ v x ≤ v y
 


### PR DESCRIPTION
Typos found and fixed by Codex.

---
<!-- Your PR title will become the first line of the commit message.

In this box, the text above the `---` (if not empty) will be appended
to the commit message, and can be used to give additional context or
details. Please leave a blank newline before the `---`, otherwise GitHub
will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

When merging, all the commits will be squashed into a single commit
listing all co-authors.

Co-authors in the squash commit are gathered from two sources:

First, all authors of commits to this PR branch are included. Thus,
one way to add co-authors is to include at least one commit authored by
each co-author among the commits in the pull request. If necessary, you
may create empty commits to indicate co-authorship, using commands like so:

git commit --author="Author Name <author@email.com>" --allow-empty -m "add Author Name as coauthor"

Second, co-authors can also be listed in lines at the very bottom of
the commit message (that is, directly before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines
at the bottom of the commit message (before the `---`, and also before
any "Co-authored-by" lines) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
