### PR TITLE
[Merged by Bors] - feat(RingTheory): more ergonomic version of jacobi criterion for smoothness

### DIFF
--- a/Mathlib/RingTheory/Extension/Basic.lean
+++ b/Mathlib/RingTheory/Extension/Basic.lean
@@ -444,6 +444,31 @@ lemma Cotangent.finite (hP : P.ker.FG) :
     ← Submodule.map_top]
   exact ((Submodule.fg_top P.ker).mpr hP).map _
 
+variable (P) in
+/-- The cotangent is isomorphic to `S ⊗[P] I`. -/
+noncomputable def cotangentEquiv : S ⊗[P.Ring] P.ker ≃ₗ[S] P.Cotangent := by
+  refine .ofBijective (Cotangent.mk.liftBaseChange _) ⟨?_, ?_⟩
+  · refine (injective_iff_map_eq_zero _).mpr fun x hx ↦ ?_
+    obtain ⟨x, rfl⟩ := TensorProduct.mk_surjective P.Ring P.ker S P.algebraMap_surjective x
+    simp only [mk_apply, LinearMap.liftBaseChange_tmul, one_smul, Cotangent.mk_eq_zero_iff,
+      pow_two] at hx ⊢
+    refine Submodule.smul_induction_on' (p := fun x (hx : x ∈ P.ker * P.ker) ↦
+      (1 : S) ⊗ₜ[P.Ring] (⟨x, Ideal.mul_le_right hx⟩ : P.ker) = 0) (hx := hx) ?_ ?_
+    · intro r hr s hs
+      trans (r • 1) ⊗ₜ[P.Ring] ⟨s, hs⟩
+      · rw [smul_tmul]; rfl
+      · simp_all [Algebra.smul_def]
+    · intro a ha b hb ha' hb'
+      convert congr($ha' + $hb')
+      rw [← tmul_add]
+      rfl
+  · intro x
+    obtain ⟨x, rfl⟩ := Cotangent.mk_surjective x
+    exact ⟨1 ⊗ₜ x, by simp⟩
+
+@[simp]
+lemma contangentEquiv_tmul (s : S) (x : P.ker) : P.cotangentEquiv (s ⊗ₜ x) = s • .mk x := rfl
+
 end Cotangent
 
 end Algebra.Extension

--- a/Mathlib/RingTheory/Extension/Cotangent/Basic.lean
+++ b/Mathlib/RingTheory/Extension/Cotangent/Basic.lean
@@ -68,6 +68,52 @@ def cotangentComplex : P.Cotangent →ₗ[S] P.CotangentSpace :=
 lemma cotangentComplex_mk (x) : P.cotangentComplex (.mk x) = 1 ⊗ₜ .D _ _ x :=
   rfl
 
+section baseChange
+
+variable {A : Type*} [CommRing A] [Algebra S A] [Algebra P.Ring A] [IsScalarTower P.Ring S A]
+
+variable (R S) in
+/- This is (isomorphic to) the base change of the contangent complex to `A`, whose
+domain and codomain are more manageable. -/
+noncomputable
+def _root_.KaehlerDifferential.cotangentComplexBaseChange
+    (P A : Type*) [CommRing P] [CommRing A] [Algebra P S] [Algebra P A]
+    [Algebra R P] [Algebra S A] [IsScalarTower P S A] :
+    A ⊗[P] RingHom.ker (algebraMap P S) →ₗ[A] A ⊗[P] Ω[P⁄R] :=
+  LinearMap.liftBaseChange _ (KaehlerDifferential.kerToTensor _ _ _ ∘ₗ Submodule.inclusion
+    (by rw [IsScalarTower.algebraMap_eq P S A]; intro; aesop))
+
+omit [Algebra R S] in
+lemma _root_.KaehlerDifferential.cotangentComplexBaseChange_tmul
+    {P A : Type*} [CommRing P] [CommRing A] [Algebra P S]
+    [Algebra P A] [Algebra R P] [Algebra S A] [IsScalarTower P S A] (a b) :
+  cotangentComplexBaseChange R S P A (a ⊗ₜ b) =
+    a • kerToTensor R P A ⟨b.1, by rw [IsScalarTower.algebraMap_eq P S A]; aesop⟩ := rfl
+
+variable (A) in
+lemma cotangentComplexBaseChange_eq_lTensor_cotangentComplex :
+  cotangentComplexBaseChange R S P.Ring A =
+    AlgebraTensorModule.cancelBaseChange P.Ring S A A Ω[P.Ring⁄R] ∘ₗ
+      P.cotangentComplex.baseChange A ∘ₗ
+      ((AlgebraTensorModule.cancelBaseChange P.Ring S A A P.ker).symm ≪≫ₗ
+        P.cotangentEquiv.baseChange (A := A)) := by
+  ext x
+  simp [LinearEquiv.baseChange, cotangentComplexBaseChange_tmul]
+
+variable (A) in
+lemma lTensor_cotangentComplex_eq_cotangentComplexBaseChange :
+  P.cotangentComplex.baseChange A =
+    (AlgebraTensorModule.cancelBaseChange P.Ring S A A Ω[P.Ring⁄R]).symm ∘ₗ
+      cotangentComplexBaseChange R S P.Ring A ∘ₗ
+      ((AlgebraTensorModule.cancelBaseChange P.Ring S A A P.ker).symm ≪≫ₗ
+        P.cotangentEquiv.baseChange (A := A)).symm := by
+  apply LinearMap.coe_injective
+  dsimp
+  rw [LinearEquiv.eq_symm_comp, ← LinearEquiv.comp_symm_eq]
+  exact congr(($(cotangentComplexBaseChange_eq_lTensor_cotangentComplex P A) : _ → _)).symm
+
+end baseChange
+
 universe w' u' v'
 
 variable {R' : Type u'} {S' : Type v'} [CommRing R'] [CommRing S'] [Algebra R' S']

--- a/Mathlib/RingTheory/Extension/Cotangent/Basic.lean
+++ b/Mathlib/RingTheory/Extension/Cotangent/Basic.lean
@@ -73,8 +73,8 @@ section baseChange
 variable {A : Type*} [CommRing A] [Algebra S A] [Algebra P.Ring A] [IsScalarTower P.Ring S A]
 
 variable (R S) in
-/- This is (isomorphic to) the base change of the contangent complex to `A`, whose
-domain and codomain are more manageable. -/
+/-- This is (isomorphic to) the base change of the contangent complex to `A`, but
+the domain and codomains of this are more manageable. -/
 noncomputable
 def _root_.KaehlerDifferential.cotangentComplexBaseChange
     (P A : Type*) [CommRing P] [CommRing A] [Algebra P S] [Algebra P A]

--- a/Mathlib/RingTheory/Smooth/Local.lean
+++ b/Mathlib/RingTheory/Smooth/Local.lean
@@ -5,6 +5,7 @@ Authors: Andrew Yang
 -/
 module
 
+public import Mathlib.RingTheory.Flat.FaithfullyFlat.Basic
 public import Mathlib.RingTheory.LocalRing.Module
 public import Mathlib.RingTheory.Smooth.Basic
 public import Mathlib.RingTheory.TensorProduct.Free
@@ -17,6 +18,10 @@ public import Mathlib.RingTheory.TensorProduct.Free
 
 open TensorProduct IsLocalRing KaehlerDifferential
 
+variable {R S : Type*} [CommRing R] [CommRing S] [IsLocalRing S] [Algebra R S]
+
+namespace Algebra
+
 /--
 The **Jacobian criterion** for smoothness of local algebras.
 Suppose `S` is a local `R`-algebra, and `0 → I → P → S → 0` is a presentation such that
@@ -26,8 +31,8 @@ and `I` is finitely generated.
 Then `S` is formally smooth iff `k ⊗ₛ I/I² → k ⊗ₚ Ω[P/R]` is injective,
 where `k` is the residue field of `S`.
 -/
-theorem Algebra.FormallySmooth.iff_injective_lTensor_residueField.{u} {R S : Type*} [CommRing R]
-    [CommRing S] [IsLocalRing S] [Algebra R S] (P : Algebra.Extension.{u} R S)
+theorem FormallySmooth.iff_injective_lTensor_residueField.{u}
+    (P : Algebra.Extension.{u} R S)
     [FormallySmooth R P.Ring]
     [Module.Free P.Ring Ω[P.Ring⁄R]] [Module.Finite P.Ring Ω[P.Ring⁄R]]
     (h' : P.ker.FG) :
@@ -39,3 +44,50 @@ theorem Algebra.FormallySmooth.iff_injective_lTensor_residueField.{u} {R S : Typ
   have : Module.Finite S P.Cotangent := Module.Finite.of_restrictScalars_finite P.Ring _ _
   rw [← IsLocalRing.split_injective_iff_lTensor_residueField_injective,
     P.formallySmooth_iff_split_injection]
+
+theorem FormallySmooth.iff_injective_cotangentComplexBaseChange_residueField
+    (P : Type*) [CommRing P] [Algebra R P] [Algebra P S]
+    [IsScalarTower R P S] [FormallySmooth R P] [Module.Free P Ω[P⁄R]] [Module.Finite P Ω[P⁄R]]
+    (h₁ : Function.Surjective (algebraMap P S)) (h₂ : (RingHom.ker (algebraMap P S)).FG) :
+    Algebra.FormallySmooth R S ↔
+      Function.Injective (cotangentComplexBaseChange R S P (ResidueField S)) := by
+  let P' : Extension R S := { Ring := P, σ := _, algebraMap_σ := Function.surjInv_eq h₁ }
+  rw [Algebra.FormallySmooth.iff_injective_lTensor_residueField P' h₂]
+  rw [P'.cotangentComplexBaseChange_eq_lTensor_cotangentComplex (ResidueField S)]
+  refine .trans ?_ ((AlgebraTensorModule.cancelBaseChange P'.Ring S _ _
+    Ω[P'.Ring⁄R]).comp_injective _).symm
+  exact (((AlgebraTensorModule.cancelBaseChange P'.Ring S _ _ P'.ker).symm ≪≫ₗ
+    P'.cotangentEquiv.baseChange (A := _)).injective_comp _).symm
+
+/--
+The **Jacobian criterion** for smoothness of local algebras.
+Suppose `S` is a local `R`-algebra, and `0 → I → P → S → 0` is a presentation such that
+`P` is formally-smooth over `R`, `Ω[P⁄R]` is finite free over `P`,
+(typically satisfied when `P` is the localization of a polynomial ring of finite type)
+and `I` is finitely generated.
+Then `S` is formally smooth iff `k ⊗ₛ I → k ⊗ₚ Ω[P/R]` is injective,
+where `k` any field extension of the residue field of `S`.
+-/
+theorem FormallySmooth.iff_injective_cotangentComplexBaseChange
+    (P K : Type*) [Field K] [CommRing P] [Algebra R P] [Algebra P S]
+    [IsScalarTower R P S] [Algebra S K] [Algebra P K] [IsScalarTower P S K]
+    [FormallySmooth R P] [Module.Free P Ω[P⁄R]] [Module.Finite P Ω[P⁄R]]
+    (h₁ : Function.Surjective (algebraMap P S)) (h₂ : (RingHom.ker (algebraMap P S)).FG)
+    (h₃ : maximalIdeal S ≤ RingHom.ker (algebraMap S K)) :
+    Algebra.FormallySmooth R S ↔ Function.Injective (cotangentComplexBaseChange R S P K) := by
+  let f : ResidueField S →ₐ[S] K := Ideal.Quotient.liftₐ _ (Algebra.ofId _ _) h₃
+  let := f.toAlgebra
+  have := IsScalarTower.of_algebraMap_eq' f.comp_algebraMap.symm
+  have : IsScalarTower P (ResidueField S) K := .to₁₃₄ _ S _ _
+  rw [FormallySmooth.iff_injective_cotangentComplexBaseChange_residueField P h₁ h₂,
+    ← Module.FaithfullyFlat.lTensor_injective_iff_injective _ K]
+  have : (AlgebraTensorModule.cancelBaseChange _ _ _ _ _).toLinearMap ∘ₗ
+      (cotangentComplexBaseChange R S P (ResidueField S)).baseChange K ∘ₗ
+      (AlgebraTensorModule.cancelBaseChange _ _ _ _ _).symm.toLinearMap =
+      (cotangentComplexBaseChange R S P K) := by
+    ext; simp [cotangentComplexBaseChange_tmul]
+  rw [← this]
+  refine .trans ?_ ((AlgebraTensorModule.cancelBaseChange _ _ _ _ _).comp_injective _).symm
+  exact ((AlgebraTensorModule.cancelBaseChange _ _ _ _ _).symm.injective_comp _).symm
+
+end Algebra


### PR DESCRIPTION

---
<!-- Your PR title will become the first line of the commit message.

In this box, the text above the `---` (if not empty) will be appended
to the commit message, and can be used to give additional context or
details. Please leave a blank newline before the `---`, otherwise GitHub
will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

When merging, all the commits will be squashed into a single commit
listing all co-authors.

Co-authors in the squash commit are gathered from two sources:

First, all authors of commits to this PR branch are included. Thus,
one way to add co-authors is to include at least one commit authored by
each co-author among the commits in the pull request. If necessary, you
may create empty commits to indicate co-authorship, using commands like so:

git commit --author="Author Name <author@email.com>" --allow-empty -m "add Author Name as coauthor"

Second, co-authors can also be listed in lines at the very bottom of
the commit message (that is, directly before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines
at the bottom of the commit message (before the `---`, and also before
any "Co-authored-by" lines) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
