### PR TITLE
[Merged by Bors] - feat(RIngTheory): more-linear version of `tensorKaehlerEquiv`

### DIFF
--- a/Mathlib/RingTheory/Kaehler/TensorProduct.lean
+++ b/Mathlib/RingTheory/Kaehler/TensorProduct.lean
@@ -13,6 +13,7 @@ public import Mathlib.RingTheory.Localization.BaseChange
 
 ## Main results
 - `KaehlerDifferential.tensorKaehlerEquiv`: `(S ⊗[R] Ω[A⁄R]) ≃ₗ[S] Ω[B⁄S]` for `B = S ⊗[R] A`.
+- `KaehlerDifferential.tensorKaehlerEquiv'`: `(B ⊗[A] Ω[A⁄R]) ≃ₗ[B] Ω[B⁄S]` for `B = S ⊗[R] A`.
 - `KaehlerDifferential.isLocalizedModule_of_isLocalizedModule`:
   `Ω[Aₚ/Rₚ]` is the localization of `Ω[A/R]` at `p`.
 
@@ -27,6 +28,8 @@ variable [Algebra A B] [Algebra S B] [IsScalarTower R A B] [IsScalarTower R S B]
 open TensorProduct
 
 attribute [local instance] SMulCommClass.of_commMonoid
+
+attribute [local irreducible] KaehlerDifferential
 
 namespace KaehlerDifferential
 
@@ -236,5 +239,76 @@ instance isLocalizedModule_of_isLocalizedModule (p : Submonoid R) [IsLocalizatio
   have : IsLocalization (Algebra.algebraMapSubmonoid A p) B :=
     isLocalizedModule_iff_isLocalization.mp inferInstance
   inferInstance
+
+/-- The canonical isomorphism `(B ⊗[A] Ω[A⁄R]) ≃ₗ[B] Ω[B⁄S]` for `B = S ⊗[R] A`.
+This is more linear than `KaehlerDifferential.tensorKaehlerEquiv`. -/
+noncomputable
+def tensorKaehlerEquiv' [h : Algebra.IsPushout R S A B] :
+    B ⊗[A] Ω[A⁄R] ≃ₗ[B] Ω[B⁄S] := by
+  have : Algebra.IsPushout R A S B := .symm inferInstance
+  let e₁ : B ⊗[A] Ω[A⁄R] ≃ₗ[A] Ω[A⁄R] ⊗[R] S :=
+    AlgebraTensorModule.congr (Algebra.IsPushout.equiv R A S B).symm.toLinearEquiv (.refl _ _)
+      ≪≫ₗ _root_.TensorProduct.comm _ _ _ ≪≫ₗ AlgebraTensorModule.cancelBaseChange ..
+  let e₂ : B ⊗[A] Ω[A⁄R] ≃ₗ[R] Ω[B⁄S] :=
+    e₁.restrictScalars R ≪≫ₗ _root_.TensorProduct.comm _ _ _ ≪≫ₗ
+      (KaehlerDifferential.tensorKaehlerEquiv R S A B).restrictScalars R
+  refine { __ := e₂, map_smul' := ?_ }
+  intro m x
+  obtain ⟨m, rfl⟩ := (Algebra.IsPushout.equiv R A S B).surjective m
+  dsimp
+  induction m with
+  | zero => simp
+  | add x y _ _ => simp only [add_smul, map_add, *]
+  | tmul a b =>
+  induction x with
+  | zero => simp
+  | add x y _ _ => simp only [smul_add, map_add, *]
+  | tmul x y =>
+  obtain ⟨x, rfl⟩ := (Algebra.IsPushout.equiv R A S B).surjective x
+  induction x with
+  | zero => simp
+  | add x y _ _ => simp only [smul_add, map_add, *, add_tmul]
+  | tmul x z =>
+  suffices b • z • a • x • KaehlerDifferential.map R S A B y =
+      (algebraMap A B a * algebraMap S B b) • z • x • KaehlerDifferential.map R S A B y by
+    simpa [e₂, e₁, smul_tmul', Algebra.IsPushout.equiv_tmul, ← mul_smul,
+      Algebra.IsPushout.equiv_symm_algebraMap_left, Algebra.IsPushout.equiv_symm_algebraMap_right]
+  simp only [← mul_smul, ← @algebraMap_smul S _ B, ← @algebraMap_smul A _ B]
+  ring_nf
+
+@[simp]
+lemma tensorKaehlerEquiv'_tmul_D [Algebra.IsPushout R S A B] (b a) :
+    tensorKaehlerEquiv' R S A B (b ⊗ₜ D _ _ a) = b • D S B (algebraMap A B a) := by
+  have : Algebra.IsPushout R A S B := .symm inferInstance
+  obtain ⟨b, rfl⟩ := (Algebra.IsPushout.equiv R A S B).surjective b
+  induction b with
+  | zero => simp
+  | add x y _ _ => simp only [map_add, *, add_tmul, add_smul]
+  | tmul a' s =>
+  trans s • a' • D S B (algebraMap A B a)
+  · dsimp [tensorKaehlerEquiv']; simp
+  · simp [Algebra.IsPushout.equiv_tmul, mul_smul, smul_comm]
+
+attribute [local instance] Algebra.TensorProduct.rightAlgebra in
+@[simp]
+lemma tensorKaehlerEquiv'_symm_D_tmul (s a) :
+    (tensorKaehlerEquiv' R S A (S ⊗[R] A)).symm (D _ _ (s ⊗ₜ a)) = algebraMap _ _ s ⊗ₜ D _ _ a := by
+  apply (tensorKaehlerEquiv' R S A _).symm_apply_eq.mpr ?_
+  simp only [Algebra.TensorProduct.algebraMap_apply, Algebra.algebraMap_self, RingHom.id_apply,
+    tensorKaehlerEquiv'_tmul_D]
+  change _ = algebraMap S (S ⊗[R] A) s • D S (S ⊗[R] A) (1 ⊗ₜ a)
+  rw [algebraMap_smul, ← Derivation.map_smul, smul_tmul', smul_eq_mul, mul_one]
+
+attribute [local instance] Algebra.TensorProduct.rightAlgebra in
+@[simp]
+lemma tensorKaehlerEquiv'_symm_D_tmul' (s a) :
+    (tensorKaehlerEquiv' R S A (A ⊗[R] S)).symm (D _ _ (a ⊗ₜ s)) = algebraMap _ _ s ⊗ₜ D _ _ a := by
+  apply (tensorKaehlerEquiv' R S A _).symm_apply_eq.mpr ?_
+  simp only [Algebra.TensorProduct.algebraMap_apply, Algebra.algebraMap_self, RingHom.id_apply,
+    tensorKaehlerEquiv'_tmul_D]
+  change _ = algebraMap S (A ⊗[R] S) s • D S (A ⊗[R] S) (a ⊗ₜ 1)
+  rw [algebraMap_smul, ← Derivation.map_smul, Algebra.smul_def,
+    Algebra.TensorProduct.right_algebraMap_apply]
+  simp only [Algebra.TensorProduct.tmul_mul_tmul, one_mul, mul_one]
 
 end KaehlerDifferential

--- a/Mathlib/RingTheory/Kaehler/TensorProduct.lean
+++ b/Mathlib/RingTheory/Kaehler/TensorProduct.lean
@@ -12,8 +12,8 @@ public import Mathlib.RingTheory.Localization.BaseChange
 # Kähler differential module under base change
 
 ## Main results
-- `KaehlerDifferential.tensorKaehlerEquiv`: `(S ⊗[R] Ω[A⁄R]) ≃ₗ[S] Ω[B⁄S]` for `B = S ⊗[R] A`.
-- `KaehlerDifferential.tensorKaehlerEquiv'`: `(B ⊗[A] Ω[A⁄R]) ≃ₗ[B] Ω[B⁄S]` for `B = S ⊗[R] A`.
+- `KaehlerDifferential.tensorKaehlerEquivBase`: `(S ⊗[R] Ω[A⁄R]) ≃ₗ[S] Ω[B⁄S]` for `B = S ⊗[R] A`.
+- `KaehlerDifferential.tensorKaehlerEquiv`: `(B ⊗[A] Ω[A⁄R]) ≃ₗ[B] Ω[B⁄S]` for `B = S ⊗[R] A`.
 - `KaehlerDifferential.isLocalizedModule_of_isLocalizedModule`:
   `Ω[Aₚ/Rₚ]` is the localization of `Ω[A/R]` at `p`.
 
@@ -183,9 +183,10 @@ lemma tensorKaehlerEquiv_left_inv [Algebra.IsPushout R S A B] :
     rfl
   · simp only [map_add, TensorProduct.tmul_add, *]
 
-/-- The canonical isomorphism `(S ⊗[R] Ω[A⁄R]) ≃ₗ[S] Ω[B⁄S]` for `B = S ⊗[R] A`. -/
+/-- The canonical isomorphism `(S ⊗[R] Ω[A⁄R]) ≃ₗ[S] Ω[B⁄S]` for `B = S ⊗[R] A`.
+Also see `KaehlerDifferential.tensorKaehlerEquiv` for the version with `B ⊗[A] Ω[A⁄R]`. -/
 @[simps! symm_apply] noncomputable
-def tensorKaehlerEquiv [h : Algebra.IsPushout R S A B] :
+def tensorKaehlerEquivBase [h : Algebra.IsPushout R S A B] :
     (S ⊗[R] Ω[A⁄R]) ≃ₗ[S] Ω[B⁄S] where
   __ := ((map R S A B).restrictScalars R).liftBaseChange S
   invFun := (derivationTensorProduct R S A B).liftKaehlerDifferential
@@ -211,8 +212,8 @@ def tensorKaehlerEquiv [h : Algebra.IsPushout R S A B] :
       · simp only [map_add, smul_add, *]
 
 @[simp]
-lemma tensorKaehlerEquiv_tmul [Algebra.IsPushout R S A B] (a b) :
-    tensorKaehlerEquiv R S A B (a ⊗ₜ b) = a • map R S A B b :=
+lemma tensorKaehlerEquivBase_tmul [Algebra.IsPushout R S A B] (a b) :
+    tensorKaehlerEquivBase R S A B (a ⊗ₜ b) = a • map R S A B b :=
   LinearMap.liftBaseChange_tmul _ _ _ _
 
 /--
@@ -222,10 +223,10 @@ then `Ω[B⁄S]` is the base change of `Ω[A⁄R]` along `R → S`.
 lemma isBaseChange [h : Algebra.IsPushout R S A B] :
     IsBaseChange S ((map R S A B).restrictScalars R) := by
   convert (TensorProduct.isBaseChange R Ω[A⁄R] S).comp
-    (IsBaseChange.ofEquiv (tensorKaehlerEquiv R S A B))
+    (IsBaseChange.ofEquiv (tensorKaehlerEquivBase R S A B))
   refine LinearMap.ext fun x ↦ ?_
   simp only [LinearMap.coe_restrictScalars, LinearMap.coe_comp, LinearEquiv.coe_coe,
-    Function.comp_apply, mk_apply, tensorKaehlerEquiv_tmul, one_smul]
+    Function.comp_apply, mk_apply, tensorKaehlerEquivBase_tmul, one_smul]
 
 instance isLocalizedModule (p : Submonoid R) [IsLocalization p S]
       [IsLocalization (Algebra.algebraMapSubmonoid A p) B] :
@@ -241,9 +242,9 @@ instance isLocalizedModule_of_isLocalizedModule (p : Submonoid R) [IsLocalizatio
   inferInstance
 
 /-- The canonical isomorphism `(B ⊗[A] Ω[A⁄R]) ≃ₗ[B] Ω[B⁄S]` for `B = S ⊗[R] A`.
-This is more linear than `KaehlerDifferential.tensorKaehlerEquiv`. -/
+Also see `KaehlerDifferential.tensorKaehlerEquiv` for the version with `S ⊗[R] Ω[A⁄R]`. -/
 noncomputable
-def tensorKaehlerEquiv' [h : Algebra.IsPushout R S A B] :
+def tensorKaehlerEquiv [h : Algebra.IsPushout R S A B] :
     B ⊗[A] Ω[A⁄R] ≃ₗ[B] Ω[B⁄S] := by
   have : Algebra.IsPushout R A S B := .symm inferInstance
   let e₁ : B ⊗[A] Ω[A⁄R] ≃ₗ[A] Ω[A⁄R] ⊗[R] S :=
@@ -251,7 +252,7 @@ def tensorKaehlerEquiv' [h : Algebra.IsPushout R S A B] :
       ≪≫ₗ _root_.TensorProduct.comm _ _ _ ≪≫ₗ AlgebraTensorModule.cancelBaseChange ..
   let e₂ : B ⊗[A] Ω[A⁄R] ≃ₗ[R] Ω[B⁄S] :=
     e₁.restrictScalars R ≪≫ₗ _root_.TensorProduct.comm _ _ _ ≪≫ₗ
-      (KaehlerDifferential.tensorKaehlerEquiv R S A B).restrictScalars R
+      (KaehlerDifferential.tensorKaehlerEquivBase R S A B).restrictScalars R
   refine { __ := e₂, map_smul' := ?_ }
   intro m x
   obtain ⟨m, rfl⟩ := (Algebra.IsPushout.equiv R A S B).surjective m
@@ -277,8 +278,8 @@ def tensorKaehlerEquiv' [h : Algebra.IsPushout R S A B] :
   ring_nf
 
 @[simp]
-lemma tensorKaehlerEquiv'_tmul_D [Algebra.IsPushout R S A B] (b a) :
-    tensorKaehlerEquiv' R S A B (b ⊗ₜ D _ _ a) = b • D S B (algebraMap A B a) := by
+lemma tensorKaehlerEquiv_tmul_D [Algebra.IsPushout R S A B] (b a) :
+    tensorKaehlerEquiv R S A B (b ⊗ₜ D _ _ a) = b • D S B (algebraMap A B a) := by
   have : Algebra.IsPushout R A S B := .symm inferInstance
   obtain ⟨b, rfl⟩ := (Algebra.IsPushout.equiv R A S B).surjective b
   induction b with
@@ -286,27 +287,26 @@ lemma tensorKaehlerEquiv'_tmul_D [Algebra.IsPushout R S A B] (b a) :
   | add x y _ _ => simp only [map_add, *, add_tmul, add_smul]
   | tmul a' s =>
   trans s • a' • D S B (algebraMap A B a)
-  · dsimp [tensorKaehlerEquiv']; simp
+  · simp [tensorKaehlerEquiv]
   · simp [Algebra.IsPushout.equiv_tmul, mul_smul, smul_comm]
 
 attribute [local instance] Algebra.TensorProduct.rightAlgebra in
 @[simp]
-lemma tensorKaehlerEquiv'_symm_D_tmul (s a) :
-    (tensorKaehlerEquiv' R S A (S ⊗[R] A)).symm (D _ _ (s ⊗ₜ a)) = algebraMap _ _ s ⊗ₜ D _ _ a := by
-  apply (tensorKaehlerEquiv' R S A _).symm_apply_eq.mpr ?_
+lemma tensorKaehlerEquiv_symm_D_tmul (s a) :
+    (tensorKaehlerEquiv R S A (S ⊗[R] A)).symm (D _ _ (s ⊗ₜ a)) = algebraMap _ _ s ⊗ₜ D _ _ a := by
+  apply (tensorKaehlerEquiv R S A _).symm_apply_eq.mpr ?_
   simp only [Algebra.TensorProduct.algebraMap_apply, Algebra.algebraMap_self, RingHom.id_apply,
-    tensorKaehlerEquiv'_tmul_D]
-  change _ = algebraMap S (S ⊗[R] A) s • D S (S ⊗[R] A) (1 ⊗ₜ a)
-  rw [algebraMap_smul, ← Derivation.map_smul, smul_tmul', smul_eq_mul, mul_one]
+    tensorKaehlerEquiv_tmul_D]
+  rw [show s ⊗ₜ 1 = algebraMap S (S ⊗ A) s by rfl, show algebraMap A (S ⊗ A) a = 1 ⊗ₜ a by rfl,
+    algebraMap_smul, ← Derivation.map_smul, smul_tmul', smul_eq_mul, mul_one]
 
 attribute [local instance] Algebra.TensorProduct.rightAlgebra in
 @[simp]
-lemma tensorKaehlerEquiv'_symm_D_tmul' (s a) :
-    (tensorKaehlerEquiv' R S A (A ⊗[R] S)).symm (D _ _ (a ⊗ₜ s)) = algebraMap _ _ s ⊗ₜ D _ _ a := by
-  apply (tensorKaehlerEquiv' R S A _).symm_apply_eq.mpr ?_
+lemma tensorKaehlerEquiv_symm_D_tmul' (s a) :
+    (tensorKaehlerEquiv R S A (A ⊗[R] S)).symm (D _ _ (a ⊗ₜ s)) = algebraMap _ _ s ⊗ₜ D _ _ a := by
+  apply (tensorKaehlerEquiv R S A _).symm_apply_eq.mpr ?_
   simp only [Algebra.TensorProduct.algebraMap_apply, Algebra.algebraMap_self, RingHom.id_apply,
-    tensorKaehlerEquiv'_tmul_D]
-  change _ = algebraMap S (A ⊗[R] S) s • D S (A ⊗[R] S) (a ⊗ₜ 1)
+    tensorKaehlerEquiv_tmul_D]
   rw [algebraMap_smul, ← Derivation.map_smul, Algebra.smul_def,
     Algebra.TensorProduct.right_algebraMap_apply]
   simp only [Algebra.TensorProduct.tmul_mul_tmul, one_mul, mul_one]

--- a/Mathlib/RingTheory/Kaehler/TensorProduct.lean
+++ b/Mathlib/RingTheory/Kaehler/TensorProduct.lean
@@ -216,6 +216,8 @@ lemma tensorKaehlerEquivBase_tmul [Algebra.IsPushout R S A B] (a b) :
     tensorKaehlerEquivBase R S A B (a ⊗ₜ b) = a • map R S A B b :=
   LinearMap.liftBaseChange_tmul _ _ _ _
 
+@[deprecated (since := "2026-01-01")] alias tensorKaehlerEquiv_tmul := tensorKaehlerEquivBase_tmul
+
 /--
 If `B` is the tensor product of `S` and `A` over `R`,
 then `Ω[B⁄S]` is the base change of `Ω[A⁄R]` along `R → S`.
@@ -242,7 +244,7 @@ instance isLocalizedModule_of_isLocalizedModule (p : Submonoid R) [IsLocalizatio
   inferInstance
 
 /-- The canonical isomorphism `(B ⊗[A] Ω[A⁄R]) ≃ₗ[B] Ω[B⁄S]` for `B = S ⊗[R] A`.
-Also see `KaehlerDifferential.tensorKaehlerEquiv` for the version with `S ⊗[R] Ω[A⁄R]`. -/
+Also see `KaehlerDifferential.tensorKaehlerEquivBase` for the version with `S ⊗[R] Ω[A⁄R]`. -/
 noncomputable
 def tensorKaehlerEquiv [h : Algebra.IsPushout R S A B] :
     B ⊗[A] Ω[A⁄R] ≃ₗ[B] Ω[B⁄S] := by
@@ -297,7 +299,7 @@ lemma tensorKaehlerEquiv_symm_D_tmul (s a) :
   apply (tensorKaehlerEquiv R S A _).symm_apply_eq.mpr ?_
   simp only [Algebra.TensorProduct.algebraMap_apply, Algebra.algebraMap_self, RingHom.id_apply,
     tensorKaehlerEquiv_tmul_D]
-  rw [show s ⊗ₜ 1 = algebraMap S (S ⊗ A) s by rfl, show algebraMap A (S ⊗ A) a = 1 ⊗ₜ a by rfl,
+  rw [show s ⊗ₜ 1 = algebraMap S (S ⊗ A) s by simp, Algebra.TensorProduct.right_algebraMap_apply,
     algebraMap_smul, ← Derivation.map_smul, smul_tmul', smul_eq_mul, mul_one]
 
 attribute [local instance] Algebra.TensorProduct.rightAlgebra in


### PR DESCRIPTION

---
<!-- Your PR title will become the first line of the commit message.

In this box, the text above the `---` (if not empty) will be appended
to the commit message, and can be used to give additional context or
details. Please leave a blank newline before the `---`, otherwise GitHub
will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

When merging, all the commits will be squashed into a single commit
listing all co-authors.

Co-authors in the squash commit are gathered from two sources:

First, all authors of commits to this PR branch are included. Thus,
one way to add co-authors is to include at least one commit authored by
each co-author among the commits in the pull request. If necessary, you
may create empty commits to indicate co-authorship, using commands like so:

git commit --author="Author Name <author@email.com>" --allow-empty -m "add Author Name as coauthor"

Second, co-authors can also be listed in lines at the very bottom of
the commit message (that is, directly before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines
at the bottom of the commit message (before the `---`, and also before
any "Co-authored-by" lines) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
