### PR TITLE
[Merged by Bors] - feat(Topology/UniformSpace/Closeds): continuity of closure

### DIFF
--- a/Mathlib/Topology/UniformSpace/Closeds.lean
+++ b/Mathlib/Topology/UniformSpace/Closeds.lean
@@ -182,6 +182,36 @@ theorem uniformContinuous_union : UniformContinuous (fun x : Set α × Set α =>
   filter_upwards [entourageProd_mem_uniformity (Filter.mem_lift' hU) (Filter.mem_lift' hU)]
     with _ ⟨h₁, h₂⟩ using union_mem_hausdorffEntourage U h₁ h₂
 
+theorem uniformContinuous_closure : UniformContinuous (closure (X := α)) := by
+  simp_rw [UniformContinuous, (𝓤 α).basis_sets.uniformity_hausdorff.tendsto_iff
+    (𝓤 α).basis_sets.uniformity_hausdorff, Function.comp_id, mem_hausdorffEntourage]
+  intro U hU
+  obtain ⟨V : SetRel α α, hV, hVU⟩ := comp_mem_uniformity_sets hU
+  refine ⟨V, hV, fun ⟨s, t⟩ ⟨hst, hts⟩ => ?_⟩
+  simp only at *
+  constructor
+  · grw [closure_subset_preimage hV s, hst, ← subset_closure, ← hVU, SetRel.preimage_comp]
+  · grw [closure_subset_image hV t, hts, ← subset_closure, ← hVU, SetRel.image_comp]
+
+@[fun_prop]
+theorem continuous_closure : Continuous (closure (X := α)) :=
+  uniformContinuous_closure.continuous
+
+theorem isUniformInducing_closure : IsUniformInducing (closure (X := α)) := by
+  refine ⟨le_antisymm ?_ <| Filter.map_le_iff_le_comap.mp uniformContinuous_closure⟩
+  rw [(𝓤 α).basis_sets.uniformity_hausdorff.comap _ |>.le_basis_iff
+    (𝓤 α).basis_sets.uniformity_hausdorff, Function.comp_id]
+  intro U hU
+  obtain ⟨V : SetRel α α, hV, hVU⟩ := comp_mem_uniformity_sets hU
+  refine ⟨V, hV, fun ⟨s, t⟩ ⟨hst, hts⟩ => ?_⟩
+  simp only [mem_hausdorffEntourage] at *
+  constructor
+  · grw [subset_closure (s := s), hst, closure_subset_preimage hV t, ← hVU, SetRel.preimage_comp]
+  · grw [subset_closure (s := t), hts, closure_subset_image hV s, ← hVU, SetRel.image_comp]
+
+theorem nhds_closure (s : Set α) : 𝓝 (closure s) = 𝓝 s := by
+  simp_rw +singlePass [isUniformInducing_closure.isInducing.nhds_eq_comap, closure_closure]
+
 end UniformSpace.hausdorff
 
 /-- When `Set` is equipped with the Hausdorff uniformity, taking the image under a uniformly
@@ -309,6 +339,17 @@ instance : T0Space (Closeds α) := by
     mem_of_mem_nhds <| h.nhds_le_uniformity <| Filter.preimage_mem_comap <| Filter.mem_lift' hU
   obtain ⟨y, hy, hxy⟩ := h hx₁
   exact ⟨(x, y), hxy, y, rfl, hy⟩
+
+theorem isUniformInducing_closure : IsUniformInducing (Closeds.closure (α := α)) :=
+  isUniformEmbedding_coe.isUniformInducing_comp_iff.mp
+    UniformSpace.hausdorff.isUniformInducing_closure
+
+theorem uniformContinuous_closure : UniformContinuous (Closeds.closure (α := α)) :=
+  isUniformInducing_closure.uniformContinuous
+
+@[fun_prop]
+theorem continuous_closure : Continuous (Closeds.closure (α := α)) :=
+  uniformContinuous_closure.continuous
 
 end TopologicalSpace.Closeds
 

--- a/Mathlib/Topology/UniformSpace/Defs.lean
+++ b/Mathlib/Topology/UniformSpace/Defs.lean
@@ -733,6 +733,16 @@ theorem UniformSpace.mem_closure_iff_ball {s : Set α} {x} :
     x ∈ closure s ↔ ∀ {V}, V ∈ 𝓤 α → (ball x V ∩ s).Nonempty := by
   simp [mem_closure_iff_nhds_basis' (nhds_basis_uniformity' (𝓤 α).basis_sets)]
 
+theorem UniformSpace.closure_subset_preimage
+    {U : SetRel α α} (hU : U ∈ 𝓤 α) (s : Set α) : closure s ⊆ U.preimage s := by
+  intro x hx
+  obtain ⟨y, hxy, hy⟩ := mem_closure_iff_ball.mp hx hU
+  exact ⟨y, hy, hxy⟩
+
+theorem UniformSpace.closure_subset_image
+    {U : SetRel α α} (hU : U ∈ 𝓤 α) (s : Set α) : closure s ⊆ U.image s :=
+  closure_subset_preimage (symm_le_uniformity hU) s
+
 theorem nhds_eq_uniformity {x : α} : 𝓝 x = (𝓤 α).lift' (ball x) :=
   (nhds_basis_uniformity' (𝓤 α).basis_sets).eq_biInf
 


### PR DESCRIPTION
---
<!-- Your PR title will become the first line of the commit message.

In this box, the text above the `---` (if not empty) will be appended
to the commit message, and can be used to give additional context or
details. Please leave a blank newline before the `---`, otherwise GitHub
will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

When merging, all the commits will be squashed into a single commit
listing all co-authors.

Co-authors in the squash commit are gathered from two sources:

First, all authors of commits to this PR branch are included. Thus,
one way to add co-authors is to include at least one commit authored by
each co-author among the commits in the pull request. If necessary, you
may create empty commits to indicate co-authorship, using commands like so:

git commit --author="Author Name <author@email.com>" --allow-empty -m "add Author Name as coauthor"

Second, co-authors can also be listed in lines at the very bottom of
the commit message (that is, directly before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines
at the bottom of the commit message (before the `---`, and also before
any "Co-authored-by" lines) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
