### PR TITLE
[Merged by Bors] - feat(RingTheory): residue field of `I[X]`

### DIFF
--- a/Mathlib.lean
+++ b/Mathlib.lean
@@ -6047,6 +6047,7 @@ public import Mathlib.RingTheory.LocalRing.ResidueField.Defs
 public import Mathlib.RingTheory.LocalRing.ResidueField.Fiber
 public import Mathlib.RingTheory.LocalRing.ResidueField.Ideal
 public import Mathlib.RingTheory.LocalRing.ResidueField.Instances
+public import Mathlib.RingTheory.LocalRing.ResidueField.Polynomial
 public import Mathlib.RingTheory.LocalRing.RingHom.Basic
 public import Mathlib.RingTheory.LocalRing.Subring
 public import Mathlib.RingTheory.Localization.Algebra

--- a/Mathlib/FieldTheory/RatFunc/AsPolynomial.lean
+++ b/Mathlib/FieldTheory/RatFunc/AsPolynomial.lean
@@ -87,6 +87,16 @@ theorem aeval_X_left_eq_algebraMap (p : K[X]) :
     p.aeval (X : RatFunc K) = algebraMap K[X] (RatFunc K) p := by
   induction p using Polynomial.induction_on' <;> simp_all
 
+@[simp]
+lemma liftRingHom_C {L : Type*} [Field L] (φ : K[X] →+* L) (hφ : K[X]⁰ ≤ L⁰.comap φ) (x : K) :
+    liftRingHom φ hφ (C x) = φ (.C x) :=
+  RatFunc.liftRingHom_algebraMap _ _ _
+
+@[simp]
+lemma liftRingHom_X {L : Type*} [Field L] (φ : K[X] →+* L) (hφ : K[X]⁰ ≤ L⁰.comap φ) :
+    RatFunc.liftRingHom φ hφ X = φ (.X) :=
+  RatFunc.liftRingHom_algebraMap _ _ _
+
 end Domain
 
 section Field

--- a/Mathlib/FieldTheory/RatFunc/Basic.lean
+++ b/Mathlib/FieldTheory/RatFunc/Basic.lean
@@ -590,7 +590,6 @@ theorem liftRingHom_apply_div {L : Type*} [Field L] (φ : K[X] →+* L) (hφ : K
     (p q : K[X]) : liftRingHom φ hφ (algebraMap _ _ p / algebraMap _ _ q) = φ p / φ q :=
   liftMonoidWithZeroHom_apply_div _ hφ _ _
 
-@[simp]
 theorem liftRingHom_apply_div' {L : Type*} [Field L] (φ : K[X] →+* L) (hφ : K[X]⁰ ≤ L⁰.comap φ)
     (p q : K[X]) : liftRingHom φ hφ (algebraMap _ _ p) / liftRingHom φ hφ (algebraMap _ _ q) =
       φ p / φ q :=

--- a/Mathlib/FieldTheory/RatFunc/Basic.lean
+++ b/Mathlib/FieldTheory/RatFunc/Basic.lean
@@ -456,6 +456,13 @@ theorem liftRingHom_apply_ofFractionRing_mk (φ : R[X] →+* L) (hφ : R[X]⁰ �
     (d : R[X]⁰) : liftRingHom φ hφ (ofFractionRing (Localization.mk n d)) = φ n / φ d :=
   liftMonoidWithZeroHom_apply_ofFractionRing_mk _ hφ _ _
 
+@[simp]
+lemma liftRingHom_ofFractionRing_algebraMap
+    (φ : R[X] →+* L) (hφ : R[X]⁰ ≤ L⁰.comap φ) (x : R[X]) :
+    RatFunc.liftRingHom φ hφ (ofFractionRing <| algebraMap R[X] _ x) = φ x := by
+  rw [← Localization.mk_one_eq_algebraMap, liftRingHom_apply_ofFractionRing_mk]
+  simp
+
 theorem liftRingHom_injective [Nontrivial R] (φ : R[X] →+* L) (hφ : Function.Injective φ)
     (hφ' : R[X]⁰ ≤ L⁰.comap φ := nonZeroDivisors_le_comap_nonZeroDivisors_of_injective _ hφ) :
     Function.Injective (liftRingHom φ hφ') :=
@@ -588,6 +595,16 @@ theorem liftRingHom_apply_div' {L : Type*} [Field L] (φ : K[X] →+* L) (hφ : 
     (p q : K[X]) : liftRingHom φ hφ (algebraMap _ _ p) / liftRingHom φ hφ (algebraMap _ _ q) =
       φ p / φ q :=
   liftMonoidWithZeroHom_apply_div' _ hφ _ _
+
+@[simp]
+lemma liftRingHom_algebraMap {L : Type*} [Field L] (φ : K[X] →+* L) (hφ : K[X]⁰ ≤ L⁰.comap φ)
+    (x : K[X]) : liftRingHom φ hφ (algebraMap K[X] _ x) = φ x := by
+  simpa using liftRingHom_apply_div' φ hφ x 1
+
+@[simp]
+lemma liftRingHom_comp_algebraMap {L : Type*} [Field L] (φ : K[X] →+* L) (hφ : K[X]⁰ ≤ L⁰.comap φ) :
+    (liftRingHom φ hφ).comp (algebraMap K[X] _) = φ :=
+  RingHom.ext fun _ ↦ liftRingHom_algebraMap _ hφ _
 
 variable (K)
 

--- a/Mathlib/RingTheory/Ideal/Quotient/Operations.lean
+++ b/Mathlib/RingTheory/Ideal/Quotient/Operations.lean
@@ -540,6 +540,37 @@ lemma quotientKerAlgEquivOfSurjective_symm_apply {f : A →ₐ[R₁] B} (hf : Fu
   apply (Ideal.quotientKerAlgEquivOfSurjective hf).injective
   simp
 
+section liftOfSurjective
+
+variable {R A B C : Type*} [CommRing R] [CommRing A] [CommRing B] [CommRing C]
+    [Algebra R A] [Algebra R B] [Algebra R C]
+
+noncomputable
+def _root_.AlgHom.liftOfSurjective (f : A →ₐ[R] B) (hf : Function.Surjective f)
+    (g : A →ₐ[R] C) (H : RingHom.ker f.toRingHom ≤ RingHom.ker g.toRingHom) : B →ₐ[R] C :=
+  .comp (Ideal.Quotient.liftₐ _ g H) (Ideal.quotientKerAlgEquivOfSurjective hf).symm.toAlgHom
+
+@[simp]
+lemma _root_.AlgHom.liftOfSurjective_apply (f : A →ₐ[R] B) (hf : Function.Surjective f)
+    (g : A →ₐ[R] C) (H : RingHom.ker f.toRingHom ≤ RingHom.ker g.toRingHom) (x) :
+    AlgHom.liftOfSurjective f hf g H (f x) = g x := by
+  dsimp [AlgHom.liftOfSurjective]
+  erw [AlgEquiv.coe_algHom] -- fixed after #21031
+  rw [Ideal.quotientKerAlgEquivOfSurjective_symm_apply]
+  rfl
+
+lemma _root_.AlgHom.liftOfSurjective_comp (f : A →ₐ[R] B) (hf : Function.Surjective f)
+    (g : A →ₐ[R] C) (H : RingHom.ker f.toRingHom ≤ RingHom.ker g.toRingHom) :
+    (AlgHom.liftOfSurjective f hf g H).comp f = g := by
+  ext; simp
+
+lemma _root_.AlgHom.liftOfSurjective_surjective (f : A →ₐ[R] B) (hf : Function.Surjective f)
+    (g : A →ₐ[R] C) (H : RingHom.ker f.toRingHom ≤ RingHom.ker g.toRingHom)
+    (hg : Function.Surjective g) : Function.Surjective (AlgHom.liftOfSurjective f hf g H) :=
+  .of_comp (g := f) (by convert hg; ext; simp)
+
+end liftOfSurjective
+
 end
 
 section Ring_Ring

--- a/Mathlib/RingTheory/Ideal/Quotient/Operations.lean
+++ b/Mathlib/RingTheory/Ideal/Quotient/Operations.lean
@@ -545,6 +545,8 @@ section liftOfSurjective
 variable {R A B C : Type*} [CommRing R] [CommRing A] [CommRing B] [CommRing C]
     [Algebra R A] [Algebra R B] [Algebra R C]
 
+/-- `AlgHom` version of `RingHom.liftOfSurjective` that descends an algebra homomorphism
+along a surjection. -/
 noncomputable
 def _root_.AlgHom.liftOfSurjective (f : A →ₐ[R] B) (hf : Function.Surjective f)
     (g : A →ₐ[R] C) (H : RingHom.ker f.toRingHom ≤ RingHom.ker g.toRingHom) : B →ₐ[R] C :=

--- a/Mathlib/RingTheory/LocalRing/ResidueField/Polynomial.lean
+++ b/Mathlib/RingTheory/LocalRing/ResidueField/Polynomial.lean
@@ -18,6 +18,8 @@ public import Mathlib.RingTheory.TensorProduct.Quotient
 
 -/
 
+@[expose] public section
+
 namespace Polynomial
 
 open scoped nonZeroDivisors TensorProduct

--- a/Mathlib/RingTheory/LocalRing/ResidueField/Polynomial.lean
+++ b/Mathlib/RingTheory/LocalRing/ResidueField/Polynomial.lean
@@ -1,0 +1,116 @@
+/-
+Copyright (c) 2025 Andrew Yang. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Andrew Yang
+-/
+module
+
+public import Mathlib.FieldTheory.RatFunc.AsPolynomial
+public import Mathlib.RingTheory.LocalRing.ResidueField.Fiber
+public import Mathlib.RingTheory.TensorProduct.Quotient
+
+/-!
+# Residue field of primes in polynomial algebras
+
+## Main results
+- `Polynomial.residueFieldMapCAlgEquiv`: `κ(I[X]) ≃ₐ[κ(I)] κ(I)(X)`
+- `Polynomial.fiberEquivQuotient`: `κ(p) ⊗[R] (R[X] ⧸ I) = κ(p)[X] / I`
+
+-/
+
+namespace Polynomial
+
+open scoped nonZeroDivisors TensorProduct
+
+variable {R S : Type*} [CommRing R] [CommRing S] [Algebra R S]
+variable (I : Ideal R) [I.IsPrime] (J : Ideal R[X]) [J.IsPrime]
+
+/-- `κ(I[X]) ≃ₐ[κ(I)] κ(I)(X)`. -/
+noncomputable
+def residueFieldMapCAlgEquiv [J.LiesOver I] (hJ : J = I.map C) :
+    J.ResidueField ≃ₐ[I.ResidueField] RatFunc I.ResidueField := by
+  letI f : J.ResidueField →+* RatFunc I.ResidueField := by
+    refine Ideal.ResidueField.lift _
+        ((algebraMap I.ResidueField[X] _).comp (mapRingHom (algebraMap _ _))) ?_ ?_
+    · simp [hJ, Ideal.map_le_iff_le_comap, RingHom.comap_ker _ C, mapRingHom_comp_C,
+        RingHom.ker_comp_of_injective, C_injective,
+        FaithfulSMul.algebraMap_injective I.ResidueField[X] (RatFunc I.ResidueField)]
+    · rintro x (hx : x ∉ J)
+      suffices ∃ i, x.coeff i ∉ I by simpa [IsUnit.mem_submonoid_iff, Polynomial.ext_iff]
+      contrapose! hx
+      rwa [hJ, Ideal.mem_map_C_iff]
+  haveI hf : f.comp (algebraMap I.ResidueField _) = algebraMap _ _ := by
+    ext
+    simp [f, ← IsScalarTower.algebraMap_apply, IsScalarTower.algebraMap_apply R R[X] J.ResidueField]
+  refine .ofAlgHom ⟨f, fun r ↦ congr($hf r)⟩
+      (RatFunc.liftAlgHom (aeval (algebraMap R[X] _ X)) fun x ↦ ?_) ?_ ?_
+  · suffices Function.Injective (aeval (R := I.ResidueField) (algebraMap R[X] J.ResidueField X)) by
+      simp [← this.eq_iff]
+    rw [injective_iff_map_eq_zero]
+    intro x hx
+    obtain ⟨r, hr⟩ := map_surjective _ Ideal.Quotient.mk_surjective
+      (IsLocalization.integerNormalization (R ⧸ I)⁰ x)
+    obtain ⟨s, hs, hr⟩ : ∃ s ∉ I, r.map (algebraMap _ _) = s • x := by
+      obtain ⟨⟨b, hb0⟩, hb⟩ := IsLocalization.integerNormalization_map_to_map (R ⧸ I)⁰ x
+      obtain ⟨s, rfl⟩ := Ideal.Quotient.mk_surjective b
+      refine ⟨s, by simpa [Ideal.Quotient.eq_zero_iff_mem] using hb0, ?_⟩
+      simpa [← hr, map_map, ← Ideal.Quotient.algebraMap_eq] using hb
+    replace hx : r ∈ J := by
+      apply_fun aeval (algebraMap R[X] J.ResidueField X) at hr
+      simpa [hx, aeval_map_algebraMap, aeval_algebraMap_apply, Algebra.smul_def] using hr
+    refine ((IsUnit.mk0 (algebraMap R I.ResidueField s) (by simpa)).map C).mul_right_injective ?_
+    simp only [← algebraMap_eq, ← Algebra.smul_def, algebraMap_smul, ← hr]
+    simpa [Polynomial.ext_iff, Ideal.mem_map_C_iff] using hJ.le hx
+  · apply AlgHom.coe_ringHom_injective
+    apply IsFractionRing.injective_comp_algebraMap (A := I.ResidueField[X])
+    dsimp [RatFunc.liftAlgHom]
+    simp only [AlgHom.comp_toRingHom, AlgHom.coe_ringHom_mk, RingHom.comp_assoc,
+      RatFunc.liftRingHom_comp_algebraMap, RingHomCompTriple.comp_eq, f]
+    ext <;> simp [← IsScalarTower.algebraMap_apply,
+      IsScalarTower.algebraMap_apply R R[X] J.ResidueField]
+  · apply AlgHom.coe_ringHom_injective
+    ext
+    · simp [f, RatFunc.liftAlgHom, ← IsScalarTower.algebraMap_apply]; rfl
+    · simp [f, RatFunc.liftAlgHom]
+
+@[simp]
+lemma residueFieldMapCAlgEquiv_algebraMap [J.LiesOver I] (hJ : J = I.map C) (p : R[X]) :
+    residueFieldMapCAlgEquiv I J hJ (algebraMap _ _ p) =
+      algebraMap _ _ (p.map (algebraMap R I.ResidueField)) := by
+  simp [residueFieldMapCAlgEquiv]
+
+@[simp]
+lemma residueFieldMapCAlgEquiv_symm_C [J.LiesOver I] (hJ : J = I.map C) (r) :
+    (residueFieldMapCAlgEquiv I J hJ).symm (.C r) = algebraMap _ _ r :=
+  (residueFieldMapCAlgEquiv I J hJ).symm.commutes r
+
+@[simp]
+lemma residueFieldMapCAlgEquiv_symm_X [J.LiesOver I] (hJ : J = I.map C) :
+    (residueFieldMapCAlgEquiv I J hJ).symm .X = algebraMap R[X] _ .X :=
+  (residueFieldMapCAlgEquiv I J hJ).injective (by simp)
+
+/-- `κ(p) ⊗[R] (R[X] ⧸ I) = κ(p)[X] / I` -/
+noncomputable
+def fiberEquivQuotient (f : R[X] →ₐ[R] S) (hf : Function.Surjective f)
+    (P : Ideal S) [P.IsPrime] (p : Ideal R) [P.LiesOver p] [p.IsPrime] :
+    p.Fiber S ≃ₐ[p.ResidueField] p.ResidueField[X] ⧸
+      ((RingHom.ker (f : R[X] →+* S)).map (mapRingHom (algebraMap R p.ResidueField))) := by
+  refine .ofAlgHom (Algebra.TensorProduct.lift (Algebra.ofId _ _) (AlgHom.liftOfSurjective _ hf
+    ((Ideal.Quotient.mkₐ _ _).comp (mapAlgHom (Algebra.ofId _ _))) ?_) fun _ _ ↦ .all _ _)
+    (Ideal.Quotient.liftₐ _ (aeval (1 ⊗ₜ f .X)) ?_) ?_ ?_
+  · simp [AlgHom.comp_toRingHom, ← RingHom.comap_ker, ← Ideal.map_le_iff_le_comap]
+  · change Ideal.map _ _ ≤ RingHom.ker (aeval _).toRingHom
+    rw [Ideal.map_le_iff_le_comap, RingHom.comap_ker]
+    have : ((aeval (1 ⊗ₜ[R] f X : p.Fiber S)).restrictScalars R).comp
+        (mapAlgHom (Algebra.ofId R p.ResidueField)) =
+        Algebra.TensorProduct.includeRight.comp f := by ext; simp
+    exact .trans_eq (by intro; aesop) congr(RingHom.ker $this).symm
+  · apply Ideal.Quotient.algHom_ext
+    ext
+    simp
+  · ext x
+    obtain ⟨x, rfl⟩ := hf x
+    simpa using aeval_algHom_apply
+      ((Algebra.TensorProduct.includeRight : S →ₐ[_] p.Fiber S).comp f) X x
+
+end Polynomial

--- a/Mathlib/RingTheory/LocalRing/ResidueField/Polynomial.lean
+++ b/Mathlib/RingTheory/LocalRing/ResidueField/Polynomial.lean
@@ -93,8 +93,7 @@ lemma residueFieldMapCAlgEquiv_symm_X [J.LiesOver I] (hJ : J = I.map C) :
 
 /-- `κ(p) ⊗[R] (R[X] ⧸ I) = κ(p)[X] / I` -/
 noncomputable
-def fiberEquivQuotient (f : R[X] →ₐ[R] S) (hf : Function.Surjective f)
-    (P : Ideal S) [P.IsPrime] (p : Ideal R) [P.LiesOver p] [p.IsPrime] :
+def fiberEquivQuotient (f : R[X] →ₐ[R] S) (hf : Function.Surjective f) (p : Ideal R) [p.IsPrime] :
     p.Fiber S ≃ₐ[p.ResidueField] p.ResidueField[X] ⧸
       ((RingHom.ker (f : R[X] →+* S)).map (mapRingHom (algebraMap R p.ResidueField))) := by
   refine .ofAlgHom (Algebra.TensorProduct.lift (Algebra.ofId _ _) (AlgHom.liftOfSurjective _ hf


### PR DESCRIPTION

---
<!-- Your PR title will become the first line of the commit message.

In this box, the text above the `---` (if not empty) will be appended
to the commit message, and can be used to give additional context or
details. Please leave a blank newline before the `---`, otherwise GitHub
will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

When merging, all the commits will be squashed into a single commit
listing all co-authors.

Co-authors in the squash commit are gathered from two sources:

First, all authors of commits to this PR branch are included. Thus,
one way to add co-authors is to include at least one commit authored by
each co-author among the commits in the pull request. If necessary, you
may create empty commits to indicate co-authorship, using commands like so:

git commit --author="Author Name <author@email.com>" --allow-empty -m "add Author Name as coauthor"

Second, co-authors can also be listed in lines at the very bottom of
the commit message (that is, directly before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines
at the bottom of the commit message (before the `---`, and also before
any "Co-authored-by" lines) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
