### PR TITLE
[Merged by Bors] - doc(Geometry): fix typos

### DIFF
--- a/Mathlib/Geometry/Manifold/Bordism.lean
+++ b/Mathlib/Geometry/Manifold/Bordism.lean
@@ -25,7 +25,7 @@ and is called the `n`-th (unoriented) bordism group.
 
 This construction can be generalised one step further, to produce an extraordinary homology theory.
 Given a topological space `X`, a **singular manifold** on `X` is a closed smooth manifold `M`
-together with a continuous map `M → F`. (The word *singular* does not refer to singularities,
+together with a continuous map `M → X`. (The word *singular* does not refer to singularities,
 but is by analogy to singular chains in the definition of singular homology.)
 
 Given two `n`-dimensional singular manifolds `s` and `t`, an (oriented) bordism between `s` and `t`

--- a/Mathlib/Geometry/Manifold/Immersion.lean
+++ b/Mathlib/Geometry/Manifold/Immersion.lean
@@ -87,7 +87,7 @@ This shortens the overall argument, as the definition of submersions has the sam
 
 ## References
 
-* [Juan Margalef-Roig and Enrique Outerelo Dominguez, *Differential topology*][roigdomingues2012]
+* [Juan Margalef-Roig and Enrique Outerelo Dominguez, *Differential topology*][roigdomingues1992]
 
 -/
 
@@ -279,7 +279,7 @@ between the targets of the local charts: using mathlib's formalisation conventio
 is *slightly* weaker than `source_subset_preimage_source`: the latter implies that
 `h.codChart.extend J ∘ f` maps `h.domChart.source` to
 `(h.codChart.extend J).target = (h.codChart.extend I) '' h.codChart.source`,
-but that does *not* imply `f` maps `h.domChart.source` to `h.codChartSource`;
+but that does *not* imply `f` maps `h.domChart.source` to `h.codChart.source`;
 a priori `f` could map some point `f ∘ h.domChart.extend I x ∉ h.codChart.source` into the target.
 Note that this difference only occurs because of our design using junk values;
 this is not a mathematically meaningful difference.
@@ -521,7 +521,7 @@ between the targets of the local charts: using mathlib's formalisation conventio
 is *slightly* weaker than `source_subset_preimage_source`: the latter implies that
 `h.codChart.extend J ∘ f` maps `h.domChart.source` to
 `(h.codChart.extend J).target = (h.codChart.extend I) '' h.codChart.source`,
-but that does *not* imply `f` maps `h.domChart.source` to `h.codChartSource`;
+but that does *not* imply `f` maps `h.domChart.source` to `h.codChart.source`;
 a priori `f` could map some point `f ∘ h.domChart.extend I x ∉ h.codChart.source` into the target.
 Note that this difference only occurs because of our design using junk values;
 this is not a mathematically meaningful difference.

--- a/Mathlib/Geometry/Manifold/MFDeriv/Defs.lean
+++ b/Mathlib/Geometry/Manifold/MFDeriv/Defs.lean
@@ -33,7 +33,7 @@ Let `f` be a map between manifolds. The following definitions follow the `fderiv
   from the tangent space at `x` to the tangent space at `f x`. If the map is not differentiable
   within `s`, this is `0`.
 * `MDifferentiableAt I I' f x` : Prop expressing whether `f` is differentiable at `x`.
-* `MDifferentiableWithinAt 𝕜 f s x` : Prop expressing whether `f` is differentiable within `s`
+* `MDifferentiableWithinAt I I' f s x` : Prop expressing whether `f` is differentiable within `s`
   at `x`.
 * `HasMFDerivAt I I' f s x f'` : Prop expressing whether `f` has `f'` as a derivative at `x`.
 * `HasMFDerivWithinAt I I' f s x f'` : Prop expressing whether `f` has `f'` as a derivative

--- a/Mathlib/Geometry/Manifold/PartitionOfUnity.lean
+++ b/Mathlib/Geometry/Manifold/PartitionOfUnity.lean
@@ -213,7 +213,7 @@ section finsupport
 variable {s : Set M} (ρ : SmoothPartitionOfUnity ι I M s) (x₀ : M)
 
 /-- The support of a smooth partition of unity at a point `x₀` as a `Finset`.
-This is the set of `i : ι` such that `x₀ ∈ support f i`, i.e. `f i ≠ x₀`. -/
+This is the set of `i : ι` such that `x₀ ∈ support f i`, i.e. `f i x₀ ≠ 0`. -/
 def finsupport : Finset ι := ρ.toPartitionOfUnity.finsupport x₀
 
 @[simp]

--- a/Mathlib/Geometry/Manifold/Riemannian/Basic.lean
+++ b/Mathlib/Geometry/Manifold/Riemannian/Basic.lean
@@ -39,7 +39,7 @@ variable
   [IsContMDiffRiemannianBundle I ∞ E (fun (x : M) ↦ TangentSpace I x)]
   [IsRiemannianManifold I M]
 ```
-To register a `C^n` manifold for a general `n`, one should replace `[IsManifold ∞ I M]` with
+To register a `C^n` manifold for a general `n`, one should replace `[IsManifold I ∞ M]` with
 `[IsManifold I n M] [IsManifold I 1 M]`, where the second one is needed to ensure that the
 tangent bundle is well behaved (not necessary when `n` is concrete like 2 or 3 as there are
 automatic instances for these cases). One can require whatever regularity one wants in the

--- a/Mathlib/Geometry/Manifold/VectorBundle/Hom.lean
+++ b/Mathlib/Geometry/Manifold/VectorBundle/Hom.lean
@@ -162,7 +162,7 @@ variable {𝕜 F₁ F₂ B₁ B₂ M : Type*} {E₁ : B₁ → Type*} {E₂ : B�
 
 /-- Consider a `C^n` map `v : M → E₁` to a vector bundle, over a base map `b₁ : M → B₁`, and
 another base map `b₂ : M → B₂`. Given linear maps `ϕ m : E₁ (b₁ m) → E₂ (b₂ m)` depending smoothly
-on `m`, one can apply `ϕ m` to `g m`, and the resulting map is `C^n`.
+on `m`, one can apply `ϕ m` to `v m`, and the resulting map is `C^n`.
 
 Note that the smoothness of `ϕ` cannot always be stated as smoothness of a map into a manifold,
 as the pullback bundles `b₁ *ᵖ E₁` and `b₂ *ᵖ E₂` are smooth manifolds only when `b₁` and `b₂` are
@@ -203,7 +203,7 @@ lemma ContMDiffWithinAt.clm_apply_of_inCoordinates
 
 /-- Consider a `C^n` map `v : M → E₁` to a vector bundle, over a base map `b₁ : M → B₁`, and
 another base map `b₂ : M → B₂`. Given linear maps `ϕ m : E₁ (b₁ m) → E₂ (b₂ m)` depending smoothly
-on `m`, one can apply `ϕ m` to `g m`, and the resulting map is `C^n`.
+on `m`, one can apply `ϕ m` to `v m`, and the resulting map is `C^n`.
 
 Note that the smoothness of `ϕ` cannot always be stated as smoothness of a map into a manifold,
 as the pullback bundles `b₁ *ᵖ E₁` and `b₂ *ᵖ E₂` are smooth manifolds only when `b₁` and `b₂` are

--- a/Mathlib/Geometry/RingedSpace/PresheafedSpace/Gluing.lean
+++ b/Mathlib/Geometry/RingedSpace/PresheafedSpace/Gluing.lean
@@ -82,8 +82,8 @@ namespace PresheafedSpace
 3. A presheafed space `V i j` for each `i j : J`.
   (Note that this is `J × J → PresheafedSpace C` rather than `J → J → PresheafedSpace C` to
   connect to the limits library more easily.)
-4. An open immersion `f i j : V i j ⟶ U i` for each `i j : ι`.
-5. A transition map `t i j : V i j ⟶ V j i` for each `i j : ι`.
+4. An open immersion `f i j : V i j ⟶ U i` for each `i j : J`.
+5. A transition map `t i j : V i j ⟶ V j i` for each `i j : J`.
 such that
 6. `f i i` is an isomorphism.
 7. `t i i` is the identity.
@@ -521,8 +521,8 @@ namespace SheafedSpace
 3. A sheafed space `V i j` for each `i j : J`.
   (Note that this is `J × J → SheafedSpace C` rather than `J → J → SheafedSpace C` to
   connect to the limits library more easily.)
-4. An open immersion `f i j : V i j ⟶ U i` for each `i j : ι`.
-5. A transition map `t i j : V i j ⟶ V j i` for each `i j : ι`.
+4. An open immersion `f i j : V i j ⟶ U i` for each `i j : J`.
+5. A transition map `t i j : V i j ⟶ V j i` for each `i j : J`.
 such that
 6. `f i i` is an isomorphism.
 7. `t i i` is the identity.
@@ -593,8 +593,8 @@ namespace LocallyRingedSpace
 3. A locally ringed space `V i j` for each `i j : J`.
   (Note that this is `J × J → LocallyRingedSpace` rather than `J → J → LocallyRingedSpace` to
   connect to the limits library more easily.)
-4. An open immersion `f i j : V i j ⟶ U i` for each `i j : ι`.
-5. A transition map `t i j : V i j ⟶ V j i` for each `i j : ι`.
+4. An open immersion `f i j : V i j ⟶ U i` for each `i j : J`.
+5. A transition map `t i j : V i j ⟶ V j i` for each `i j : J`.
 such that
 6. `f i i` is an isomorphism.
 7. `t i i` is the identity.

--- a/docs/references.bib
+++ b/docs/references.bib
@@ -4409,7 +4409,7 @@
   pages         = {75--91}
 }
 
-@Book{            roigdomingues2012,
+@Book{            roigdomingues1992,
   author        = {Margalef-Roig, Juan and Outerelo Dominguez, Enrique},
   title         = {Differential topology. {Transl}. from the {Spanish}},
   fseries       = {North-Holland Mathematics Studies},


### PR DESCRIPTION
Typos found and fixed by Codex.

---

## Reviewer Guide

### `Mathlib/Geometry/Manifold/MFDeriv/Defs.lean`:
1. View https://github.com/leanprover-community/mathlib4/blob/82d02046396588be84bb6a6e116c2dfd9abfe368/Mathlib/Geometry/Manifold/MFDeriv/Defs.lean#L211 to confirm the definition docstring is consistent with our update.
2. View https://github.com/leanprover-community/mathlib4/blob/82d02046396588be84bb6a6e116c2dfd9abfe368/Mathlib/Geometry/Manifold/MFDeriv/Defs.lean#L223 to confirm that usage in code is consistent with our update.
3. See that 𝕜 does not appear in the type of `MDifferentiableWithinAt` in code.

### `Mathlib/Geometry/Manifold/Riemannian/Basic.lean`:
  1. View https://github.com/leanprover-community/mathlib4/blob/82d02046396588be84bb6a6e116c2dfd9abfe368/Mathlib/Geometry/Manifold/Riemannian/Basic.lean#L37 This is the code being referenced in the updated sentence. Confirm this reads `[IsManifold I ∞ M]`.
  2. View e.g. https://github.com/leanprover-community/mathlib4/blob/d59d8f5af76e0845049c8f57b77c85d80895bfde/Mathlib/Geometry/Manifold/IsManifold/Basic.lean#L846 to verify that the update reflects usage in code.

### `Mathlib/Geometry/Manifold/VectorBundle/Hom.lean`:
1. View https://github.com/leanprover-community/mathlib4/blob/d59d8f5af76e0845049c8f57b77c85d80895bfde/Mathlib/Geometry/Manifold/VectorBundle/Hom.lean#L184 to confirm `ϕ m` is applied to `v m` in `ContMDiffWithinAt.clm_apply_of_inCoordinates`, matching our update.
2. Likewise, view https://github.com/leanprover-community/mathlib4/blob/d59d8f5af76e0845049c8f57b77c85d80895bfde/Mathlib/Geometry/Manifold/VectorBundle/Hom.lean#L225 to confirm `ϕ m` is applied to `v m` in `ContMDiffAt.clm_apply_of_inCoordinates`, matching our update.

### `Mathlib/Geometry/Manifold/Bordism.lean`:
1. View https://github.com/leanprover-community/mathlib4/blob/d59d8f5af76e0845049c8f57b77c85d80895bfde/Mathlib/Geometry/Manifold/Bordism.lean#L44-L45 to confirm our update aligns with the description under Main definitions.
2. View https://github.com/leanprover-community/mathlib4/blob/d59d8f5af76e0845049c8f57b77c85d80895bfde/Mathlib/Geometry/Manifold/Bordism.lean#L102-L103 to confirm our update aligns with the docstring of the structure.
3. Notice that `F` is undefined in the updated text.

### `Mathlib/Geometry/Manifold/Immersion.lean`:

Reference update:
1. View https://github.com/leanprover-community/mathlib4/blob/d59d8f5af76e0845049c8f57b77c85d80895bfde/docs/references.bib#L4412 to confirm that `roigdomingues2012` is defined. Also note that this reference was published in 1992.
2. Search for `roigdomingues1992` to confirm it does not exist.

`codChartSource` -> `codChart.source`:
1. Notice that the name `codChartSource` is not defined in Mathlib at all.
2. `codChart.source`, on the other hand, is extensively used in the file. Reading the context, it seems clear this must have been the intended meaning.

### `Mathlib/Geometry/Manifold/PartitionOfUnity.lean`:
1. View https://github.com/leanprover-community/mathlib4/blob/622f41abb60ba23b0c4866b6ebb75a5629932070/Mathlib/Algebra/Notation/Support.lean#L31 to see that the support of a function is defined as the set of points `x` such that `f x ≠ 0`.
2. View https://github.com/leanprover-community/mathlib4/blob/622f41abb60ba23b0c4866b6ebb75a5629932070/Mathlib/Geometry/Manifold/PartitionOfUnity.lean#L24 to confirm that `f i` is understood to be a function.
3. Based on this, conclude that `x₀ ∈ support f i ↔ f i x₀≠ 0`, which means the latter must be what is meant.

<!-- Your PR title will become the first line of the commit message.

In this box, the text above the `---` (if not empty) will be appended
to the commit message, and can be used to give additional context or
details. Please leave a blank newline before the `---`, otherwise GitHub
will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

When merging, all the commits will be squashed into a single commit
listing all co-authors.

Co-authors in the squash commit are gathered from two sources:

First, all authors of commits to this PR branch are included. Thus,
one way to add co-authors is to include at least one commit authored by
each co-author among the commits in the pull request. If necessary, you
may create empty commits to indicate co-authorship, using commands like so:

git commit --author="Author Name <author@email.com>" --allow-empty -m "add Author Name as coauthor"

Second, co-authors can also be listed in lines at the very bottom of
the commit message (that is, directly before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines
at the bottom of the commit message (before the `---`, and also before
any "Co-authored-by" lines) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
