### PR TITLE
[Merged by Bors] - feat(Topology/Sets): range of `(Nonempty)Compacts.map`

### DIFF
--- a/Mathlib/Topology/Sets/Compacts.lean
+++ b/Mathlib/Topology/Sets/Compacts.lean
@@ -202,6 +202,15 @@ theorem map_injective_iff {f : α → β} (hf : Continuous f) :
   simp_rw [Function.comp_def, ← map_singleton hf]
   exact h.comp singleton_injective
 
+theorem range_map {f : α → β} (hf : Topology.IsInducing f) :
+    range (Compacts.map f hf.continuous) = {K : Compacts β | ↑K ⊆ range f} :=
+  subset_antisymm
+    (range_subset_iff.mpr fun _ => image_subset_range _ _)
+    (fun L hL => ⟨
+      { carrier := f ⁻¹' L
+        isCompact' := hf.isCompact_preimage' L.isCompact hL },
+      Compacts.ext (image_preimage_eq_of_subset hL)⟩)
+
 /-- A homeomorphism induces an equivalence on compact sets, by taking the image. -/
 @[simps]
 protected def equiv (f : α ≃ₜ β) : Compacts α ≃ Compacts β where
@@ -434,6 +443,16 @@ theorem map_injective_iff {f : α → β} (hf : Continuous f) :
     Function.Injective (NonemptyCompacts.map f hf) ↔ Function.Injective f :=
   ⟨fun h => .of_comp (f := ({·} : β → NonemptyCompacts β)) fun _ _ _ ↦
     singleton_injective (h (by simp_all)), map_injective hf⟩
+
+theorem range_map {f : α → β} (hf : Topology.IsInducing f) :
+    range (NonemptyCompacts.map f hf.continuous) = {K : NonemptyCompacts β | ↑K ⊆ range f} :=
+  subset_antisymm
+    (range_subset_iff.mpr fun _ => image_subset_range _ _)
+    (fun L hL => ⟨
+      { carrier := f ⁻¹' L
+        isCompact' := hf.isCompact_preimage' L.isCompact hL
+        nonempty' := L.nonempty.preimage' hL },
+      NonemptyCompacts.ext (image_preimage_eq_of_subset hL)⟩)
 
 instance toCompactSpace {s : NonemptyCompacts α} : CompactSpace s :=
   isCompact_iff_compactSpace.1 s.isCompact


### PR DESCRIPTION
---
<!-- Your PR title will become the first line of the commit message.

In this box, the text above the `---` (if not empty) will be appended
to the commit message, and can be used to give additional context or
details. Please leave a blank newline before the `---`, otherwise GitHub
will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

When merging, all the commits will be squashed into a single commit
listing all co-authors.

Co-authors in the squash commit are gathered from two sources:

First, all authors of commits to this PR branch are included. Thus,
one way to add co-authors is to include at least one commit authored by
each co-author among the commits in the pull request. If necessary, you
may create empty commits to indicate co-authorship, using commands like so:

git commit --author="Author Name <author@email.com>" --allow-empty -m "add Author Name as coauthor"

Second, co-authors can also be listed in lines at the very bottom of
the commit message (that is, directly before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines
at the bottom of the commit message (before the `---`, and also before
any "Co-authored-by" lines) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
