### PR TITLE
perf(RingTheory): `attribute [irreducible] KaehlerDifferential`

### DIFF
--- a/Mathlib/Algebra/Category/ModuleCat/Differentials/Basic.lean
+++ b/Mathlib/Algebra/Category/ModuleCat/Differentials/Basic.lean
@@ -143,7 +143,7 @@ noncomputable def map :
   ModuleCat.ofHom (Y := (ModuleCat.restrictScalars g'.hom).obj (KaehlerDifferential f'))
   { toFun := fun x ↦ _root_.KaehlerDifferential.map A A' B B' x
     map_add' := by simp
-    map_smul' := by simp }
+    map_smul' _ _ := by simp; rfl }
 
 @[simp]
 lemma map_d (b : B) : map fac (d b) = d (g' b) := by

--- a/Mathlib/AlgebraicGeometry/Morphisms/FormallyUnramified.lean
+++ b/Mathlib/AlgebraicGeometry/Morphisms/FormallyUnramified.lean
@@ -30,6 +30,7 @@ universe v u
 
 open AlgebraicGeometry
 
+unseal KaehlerDifferential in
 /-- If `S` is a formally unramified `R`-algebra, essentially of finite type, the diagonal is an
 open immersion. -/
 instance Algebra.FormallyUnramified.isOpenImmersion_SpecMap_lmul {R S : Type u} [CommRing R]
@@ -63,6 +64,7 @@ instance : HasRingHomProperty @FormallyUnramified RingHom.FormallyUnramified whe
 instance : MorphismProperty.IsStableUnderComposition @FormallyUnramified :=
   HasRingHomProperty.stableUnderComposition RingHom.FormallyUnramified.stableUnderComposition
 
+unseal KaehlerDifferential in
 /-- `f : X ⟶ S` is formally unramified if `X ⟶ X ×ₛ X` is an open immersion.
 In particular, monomorphisms (e.g. immersions) are formally unramified.
 The converse is true if `f` is locally of finite type. -/

--- a/Mathlib/RingTheory/Kaehler/Basic.lean
+++ b/Mathlib/RingTheory/Kaehler/Basic.lean
@@ -399,6 +399,8 @@ noncomputable def KaehlerDifferential.endEquiv :
             (KaehlerDifferential.ideal R S).cotangentIdeal_square).trans <|
         KaehlerDifferential.endEquivAuxEquiv R S
 
+attribute [irreducible] KaehlerDifferential
+
 section Finiteness
 
 theorem KaehlerDifferential.ideal_fg [EssFiniteType R S] :


### PR DESCRIPTION

---
<!-- Your PR title will become the first line of the commit message.

In this box, the text above the `---` (if not empty) will be appended
to the commit message, and can be used to give additional context or
details. Please leave a blank newline before the `---`, otherwise GitHub
will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

When merging, all the commits will be squashed into a single commit
listing all co-authors.

Co-authors in the squash commit are gathered from two sources:

First, all authors of commits to this PR branch are included. Thus,
one way to add co-authors is to include at least one commit authored by
each co-author among the commits in the pull request. If necessary, you
may create empty commits to indicate co-authorship, using commands like so:

git commit --author="Author Name <author@email.com>" --allow-empty -m "add Author Name as coauthor"

Second, co-authors can also be listed in lines at the very bottom of
the commit message (that is, directly before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines
at the bottom of the commit message (before the `---`, and also before
any "Co-authored-by" lines) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
