### PR TITLE
[Merged by Bors] - feat(Algebra): characterise when a submodule constructor is equal to `⊥`

### DIFF
--- a/Mathlib/Algebra/Algebra/NonUnitalSubalgebra.lean
+++ b/Mathlib/Algebra/Algebra/NonUnitalSubalgebra.lean
@@ -72,9 +72,23 @@ variable [CommSemiring R]
 variable [NonUnitalNonAssocSemiring A] [NonUnitalNonAssocSemiring B] [NonUnitalNonAssocSemiring C]
 variable [Module R A] [Module R B] [Module R C]
 
+lemma toNonUnitalSubsemiring_injective :
+    (toNonUnitalSubsemiring : NonUnitalSubalgebra R A → NonUnitalSubsemiring A).Injective :=
+  fun ⟨s, hs⟩ t ↦ by congr!
+
+@[simp] lemma toNonUnitalSubsemiring_inj {s t : NonUnitalSubalgebra R A} :
+    s.toNonUnitalSubsemiring = t.toNonUnitalSubsemiring ↔ s = t :=
+  toNonUnitalSubsemiring_injective.eq_iff
+
 instance : SetLike (NonUnitalSubalgebra R A) A where
   coe s := s.carrier
-  coe_injective' p q h := by cases p; cases q; congr; exact SetLike.coe_injective h
+  coe_injective' := SetLike.coe_injective.comp toNonUnitalSubsemiring_injective
+
+lemma toSubmodule_injective : (toSubmodule : NonUnitalSubalgebra R A → Submodule R A).Injective :=
+  fun _ _ h ↦ SetLike.ext (SetLike.ext_iff.mp h :)
+
+lemma toSubmodule_inj {s t : NonUnitalSubalgebra R A} : s.toSubmodule = t.toSubmodule ↔ s = t :=
+  toSubmodule_injective.eq_iff
 
 /-- The actual `NonUnitalSubalgebra` obtained from an element of a type satisfying
 `NonUnitalSubsemiringClass` and `SMulMemClass`. -/
@@ -125,29 +139,12 @@ theorem coe_toNonUnitalSubsemiring (S : NonUnitalSubalgebra R A) :
     (↑S.toNonUnitalSubsemiring : Set A) = S :=
   rfl
 
-theorem toNonUnitalSubsemiring_injective :
-    Function.Injective
-      (toNonUnitalSubsemiring : NonUnitalSubalgebra R A → NonUnitalSubsemiring A) :=
-  fun S T h =>
-  ext fun x => by rw [← mem_toNonUnitalSubsemiring, ← mem_toNonUnitalSubsemiring, h]
-
-theorem toNonUnitalSubsemiring_inj {S U : NonUnitalSubalgebra R A} :
-    S.toNonUnitalSubsemiring = U.toNonUnitalSubsemiring ↔ S = U :=
-  toNonUnitalSubsemiring_injective.eq_iff
-
 theorem mem_toSubmodule (S : NonUnitalSubalgebra R A) {x} : x ∈ S.toSubmodule ↔ x ∈ S :=
   Iff.rfl
 
 @[simp]
 theorem coe_toSubmodule (S : NonUnitalSubalgebra R A) : (↑S.toSubmodule : Set A) = S :=
   rfl
-
-theorem toSubmodule_injective :
-    Function.Injective (toSubmodule : NonUnitalSubalgebra R A → Submodule R A) := fun S T h =>
-  ext fun x => by rw [← mem_toSubmodule, ← mem_toSubmodule, h]
-
-theorem toSubmodule_inj {S U : NonUnitalSubalgebra R A} : S.toSubmodule = U.toSubmodule ↔ S = U :=
-  toSubmodule_injective.eq_iff
 
 /-- Copy of a non-unital subalgebra with a new `carrier` equal to the old one.
 Useful to fix definitional equalities. -/

--- a/Mathlib/Algebra/Algebra/NonUnitalSubalgebra.lean
+++ b/Mathlib/Algebra/Algebra/NonUnitalSubalgebra.lean
@@ -730,8 +730,7 @@ theorem toNonUnitalSubring_top {R A : Type*} [CommRing R] [NonUnitalNonAssocRing
 @[simp] lemma toNonUnitalSubsemiring_eq_top {S : NonUnitalSubalgebra R A} :
     S.toNonUnitalSubsemiring = ⊤ ↔ S = ⊤ := by simp [← SetLike.coe_set_eq]
 
--- This lemma isn't simp because `NonUnitalSubalgebra.toSubmodule` is a "fake" projection,
--- which is syntactically a constructor application.
+-- This lemma isn't simp because `NonUnitalSubalgebra.toSubmodule` is reducible.
 lemma toSubmodule_eq_top {S : NonUnitalSubalgebra R A} : S.toSubmodule = ⊤ ↔ S = ⊤ := by simp
 
 @[simp]

--- a/Mathlib/Algebra/Algebra/NonUnitalSubalgebra.lean
+++ b/Mathlib/Algebra/Algebra/NonUnitalSubalgebra.lean
@@ -720,10 +720,12 @@ theorem top_toNonUnitalSubsemiring : (⊤ : NonUnitalSubalgebra R A).toNonUnital
   rfl
 
 @[simp]
-theorem top_toSubring {R A : Type*} [CommRing R] [NonUnitalNonAssocRing A] [Module R A]
+theorem toNonUnitalSubring_top {R A : Type*} [CommRing R] [NonUnitalNonAssocRing A] [Module R A]
     [IsScalarTower R A A] [SMulCommClass R A A] :
     (⊤ : NonUnitalSubalgebra R A).toNonUnitalSubring = ⊤ :=
   rfl
+
+@[deprecated (since := "2026-01-03")] alias top_toSubring := toNonUnitalSubring_top
 
 @[simp] lemma toNonUnitalSubsemiring_eq_top {S : NonUnitalSubalgebra R A} :
     S.toNonUnitalSubsemiring = ⊤ ↔ S = ⊤ := by simp [← SetLike.coe_set_eq]
@@ -734,8 +736,8 @@ lemma toSubmodule_eq_top {S : NonUnitalSubalgebra R A} : S.toSubmodule = ⊤ ↔
 
 @[simp]
 theorem toNonUnitalSubring_eq_top {R A : Type*} [CommRing R] [Ring A] [Algebra R A]
-    {S : NonUnitalSubalgebra R A} : S.toNonUnitalSubring = ⊤ ↔ S = ⊤ :=
-  NonUnitalSubalgebra.toNonUnitalSubring_injective.eq_iff' top_toSubring
+    {S : NonUnitalSubalgebra R A} : S.toNonUnitalSubring = ⊤ ↔ S = ⊤ := by
+  simp [← SetLike.coe_set_eq]
 
 @[deprecated (since := "2026-01-01")] alias to_subring_eq_top := toNonUnitalSubring_eq_top
 

--- a/Mathlib/Algebra/Algebra/NonUnitalSubalgebra.lean
+++ b/Mathlib/Algebra/Algebra/NonUnitalSubalgebra.lean
@@ -731,7 +731,7 @@ theorem toNonUnitalSubring_top {R A : Type*} [CommRing R] [NonUnitalNonAssocRing
     S.toNonUnitalSubsemiring = ⊤ ↔ S = ⊤ := by simp [← SetLike.coe_set_eq]
 
 -- This lemma isn't simp because `NonUnitalSubalgebra.toSubmodule` is a "fake" projection,
--- which is syntactically a composition of two other projections.
+-- which is syntactically a constructor application.
 lemma toSubmodule_eq_top {S : NonUnitalSubalgebra R A} : S.toSubmodule = ⊤ ↔ S = ⊤ := by simp
 
 @[simp]

--- a/Mathlib/Algebra/Algebra/NonUnitalSubalgebra.lean
+++ b/Mathlib/Algebra/Algebra/NonUnitalSubalgebra.lean
@@ -726,8 +726,10 @@ theorem top_toSubring {R A : Type*} [CommRing R] [NonUnitalNonAssocRing A] [Modu
   rfl
 
 @[simp]
-theorem toSubmodule_eq_top {S : NonUnitalSubalgebra R A} : S.toSubmodule = ⊤ ↔ S = ⊤ :=
-  NonUnitalSubalgebra.toSubmodule'.injective.eq_iff' top_toSubmodule
+lemma toAddSubmonoid_eq_top {S : NonUnitalSubalgebra R A} : S.toAddSubmonoid = ⊤ ↔ S = ⊤ := by
+  simp [← SetLike.coe_set_eq]
+
+lemma toSubmodule_eq_top {S : NonUnitalSubalgebra R A} : S.toSubmodule = ⊤ ↔ S = ⊤ := by simp
 
 @[simp]
 theorem toNonUnitalSubsemiring_eq_top {S : NonUnitalSubalgebra R A} :

--- a/Mathlib/Algebra/Algebra/NonUnitalSubalgebra.lean
+++ b/Mathlib/Algebra/Algebra/NonUnitalSubalgebra.lean
@@ -725,21 +725,17 @@ theorem top_toSubring {R A : Type*} [CommRing R] [NonUnitalNonAssocRing A] [Modu
     (⊤ : NonUnitalSubalgebra R A).toNonUnitalSubring = ⊤ :=
   rfl
 
-@[simp]
-lemma toAddSubmonoid_eq_top {S : NonUnitalSubalgebra R A} : S.toAddSubmonoid = ⊤ ↔ S = ⊤ := by
-  simp [← SetLike.coe_set_eq]
+@[simp] lemma toNonUnitalSubsemiring_eq_top {S : NonUnitalSubalgebra R A} :
+    S.toNonUnitalSubsemiring = ⊤ ↔ S = ⊤ := by simp [← SetLike.coe_set_eq]
 
 lemma toSubmodule_eq_top {S : NonUnitalSubalgebra R A} : S.toSubmodule = ⊤ ↔ S = ⊤ := by simp
 
 @[simp]
-theorem toNonUnitalSubsemiring_eq_top {S : NonUnitalSubalgebra R A} :
-    S.toNonUnitalSubsemiring = ⊤ ↔ S = ⊤ :=
-  NonUnitalSubalgebra.toNonUnitalSubsemiring_injective.eq_iff' top_toNonUnitalSubsemiring
-
-@[simp]
-theorem to_subring_eq_top {R A : Type*} [CommRing R] [Ring A] [Algebra R A]
+theorem toSubring_eq_top {R A : Type*} [CommRing R] [Ring A] [Algebra R A]
     {S : NonUnitalSubalgebra R A} : S.toNonUnitalSubring = ⊤ ↔ S = ⊤ :=
   NonUnitalSubalgebra.toNonUnitalSubring_injective.eq_iff' top_toSubring
+
+@[deprecated (since := "2026-01-01")] alias to_subring_eq_top := toSubring_eq_top
 
 theorem mem_sup_left {S T : NonUnitalSubalgebra R A} : ∀ {x : A}, x ∈ S → x ∈ S ⊔ T := by
   rw [← SetLike.le_def]

--- a/Mathlib/Algebra/Algebra/NonUnitalSubalgebra.lean
+++ b/Mathlib/Algebra/Algebra/NonUnitalSubalgebra.lean
@@ -728,14 +728,16 @@ theorem top_toSubring {R A : Type*} [CommRing R] [NonUnitalNonAssocRing A] [Modu
 @[simp] lemma toNonUnitalSubsemiring_eq_top {S : NonUnitalSubalgebra R A} :
     S.toNonUnitalSubsemiring = ⊤ ↔ S = ⊤ := by simp [← SetLike.coe_set_eq]
 
+-- This lemma isn't simp because `NonUnitalSubalgebra.toSubmodule` is a "fake" projection,
+-- which is syntactically a composition of two other projections.
 lemma toSubmodule_eq_top {S : NonUnitalSubalgebra R A} : S.toSubmodule = ⊤ ↔ S = ⊤ := by simp
 
 @[simp]
-theorem toSubring_eq_top {R A : Type*} [CommRing R] [Ring A] [Algebra R A]
+theorem toNonUnitalSubring_eq_top {R A : Type*} [CommRing R] [Ring A] [Algebra R A]
     {S : NonUnitalSubalgebra R A} : S.toNonUnitalSubring = ⊤ ↔ S = ⊤ :=
   NonUnitalSubalgebra.toNonUnitalSubring_injective.eq_iff' top_toSubring
 
-@[deprecated (since := "2026-01-01")] alias to_subring_eq_top := toSubring_eq_top
+@[deprecated (since := "2026-01-01")] alias to_subring_eq_top := toNonUnitalSubring_eq_top
 
 theorem mem_sup_left {S T : NonUnitalSubalgebra R A} : ∀ {x : A}, x ∈ S → x ∈ S ⊔ T := by
   rw [← SetLike.le_def]

--- a/Mathlib/Algebra/Group/Submonoid/Defs.lean
+++ b/Mathlib/Algebra/Group/Submonoid/Defs.lean
@@ -249,6 +249,10 @@ theorem coe_bot : ((⊥ : Submonoid M) : Set M) = {1} :=
   rfl
 
 @[to_additive (attr := simp)]
+lemma mk_eq_top (toSubsemigroup : Subsemigroup M) (one_mem') :
+    mk toSubsemigroup one_mem' = ⊤ ↔ toSubsemigroup = ⊤ := by simp [← SetLike.coe_injective'.eq_iff]
+
+@[to_additive (attr := simp)]
 lemma mk_eq_bot (toSubsemigroup : Subsemigroup M) (one_mem') :
     mk toSubsemigroup one_mem' = ⊥ ↔ (toSubsemigroup : Set M) = {1} := by
   simp [← SetLike.coe_injective'.eq_iff]

--- a/Mathlib/Algebra/Group/Submonoid/Defs.lean
+++ b/Mathlib/Algebra/Group/Submonoid/Defs.lean
@@ -127,9 +127,17 @@ theorem pow_mem {M A} [Monoid M] [SetLike A M] [SubmonoidClass A M] {S : A} {x :
 namespace Submonoid
 
 @[to_additive]
+lemma toSubsemigroup_injective : (toSubsemigroup : Submonoid M → Subsemigroup M).Injective :=
+  fun ⟨s, hs⟩ ⟨t, ht⟩ ↦ by congr!
+
+@[to_additive (attr := simp)]
+lemma toSubsemigroup_inj {s t : Submonoid M} : s.toSubsemigroup = t.toSubsemigroup ↔ s = t :=
+  toSubsemigroup_injective.eq_iff
+
+@[to_additive]
 instance : SetLike (Submonoid M) M where
   coe s := s.carrier
-  coe_injective' p q h := by cases p; cases q; congr; exact SetLike.coe_injective' h
+  coe_injective' := SetLike.coe_injective.comp toSubsemigroup_injective
 
 initialize_simps_projections Submonoid (carrier → coe, as_prefix coe)
 initialize_simps_projections AddSubmonoid (carrier → coe, as_prefix coe)
@@ -239,6 +247,11 @@ theorem coe_top : ((⊤ : Submonoid M) : Set M) = Set.univ :=
 @[to_additive (attr := simp, norm_cast)]
 theorem coe_bot : ((⊥ : Submonoid M) : Set M) = {1} :=
   rfl
+
+@[to_additive (attr := simp)]
+lemma mk_eq_bot (toSubsemigroup : Subsemigroup M) (one_mem') :
+    mk toSubsemigroup one_mem' = ⊥ ↔ (toSubsemigroup : Set M) = {1} := by
+  simp [← SetLike.coe_injective'.eq_iff]
 
 /-- The inf of two submonoids is their intersection. -/
 @[to_additive /-- The inf of two `AddSubmonoid`s is their intersection. -/]

--- a/Mathlib/Algebra/Group/Submonoid/Defs.lean
+++ b/Mathlib/Algebra/Group/Submonoid/Defs.lean
@@ -250,12 +250,12 @@ theorem coe_bot : ((⊥ : Submonoid M) : Set M) = {1} :=
 
 @[to_additive (attr := simp)]
 lemma mk_eq_top (toSubsemigroup : Subsemigroup M) (one_mem') :
-    mk toSubsemigroup one_mem' = ⊤ ↔ toSubsemigroup = ⊤ := by simp [← SetLike.coe_injective'.eq_iff]
+    mk toSubsemigroup one_mem' = ⊤ ↔ toSubsemigroup = ⊤ := by simp [← SetLike.coe_set_eq]
 
 @[to_additive (attr := simp)]
 lemma mk_eq_bot (toSubsemigroup : Subsemigroup M) (one_mem') :
     mk toSubsemigroup one_mem' = ⊥ ↔ (toSubsemigroup : Set M) = {1} := by
-  simp [← SetLike.coe_injective'.eq_iff]
+  simp [← SetLike.coe_set_eq]
 
 /-- The inf of two submonoids is their intersection. -/
 @[to_additive /-- The inf of two `AddSubmonoid`s is their intersection. -/]

--- a/Mathlib/Algebra/Group/Subsemigroup/Defs.lean
+++ b/Mathlib/Algebra/Group/Subsemigroup/Defs.lean
@@ -198,6 +198,14 @@ theorem coe_top : ((⊤ : Subsemigroup M) : Set M) = Set.univ :=
 theorem coe_bot : ((⊥ : Subsemigroup M) : Set M) = ∅ :=
   rfl
 
+@[to_additive (attr := simp)]
+lemma mk_eq_top (carrier : Set M) (mul_mem') : mk carrier mul_mem' = ⊤ ↔ carrier = .univ := by
+  simp [← SetLike.coe_injective'.eq_iff]
+
+@[to_additive (attr := simp)]
+lemma mk_eq_bot (carrier : Set M) (mul_mem') : mk carrier mul_mem' = ⊥ ↔ carrier = ∅ := by
+  simp [← SetLike.coe_injective'.eq_iff]
+
 /-- The inf of two subsemigroups is their intersection. -/
 @[to_additive /-- The inf of two `AddSubsemigroup`s is their intersection. -/]
 instance : Min (Subsemigroup M) :=

--- a/Mathlib/Algebra/Group/Subsemigroup/Defs.lean
+++ b/Mathlib/Algebra/Group/Subsemigroup/Defs.lean
@@ -200,11 +200,11 @@ theorem coe_bot : ((⊥ : Subsemigroup M) : Set M) = ∅ :=
 
 @[to_additive (attr := simp)]
 lemma mk_eq_top (carrier : Set M) (mul_mem') : mk carrier mul_mem' = ⊤ ↔ carrier = .univ := by
-  simp [← SetLike.coe_injective'.eq_iff]
+  simp [← SetLike.coe_set_eq]
 
 @[to_additive (attr := simp)]
 lemma mk_eq_bot (carrier : Set M) (mul_mem') : mk carrier mul_mem' = ⊥ ↔ carrier = ∅ := by
-  simp [← SetLike.coe_injective'.eq_iff]
+  simp [← SetLike.coe_set_eq]
 
 /-- The inf of two subsemigroups is their intersection. -/
 @[to_additive /-- The inf of two `AddSubsemigroup`s is their intersection. -/]

--- a/Mathlib/Algebra/Module/Submodule/Lattice.lean
+++ b/Mathlib/Algebra/Module/Submodule/Lattice.lean
@@ -76,6 +76,9 @@ variable (R) in
 theorem mem_bot {x : M} : x ∈ (⊥ : Submodule R M) ↔ x = 0 :=
   Set.mem_singleton_iff
 
+@[simp] lemma mk_eq_bot (carrier : AddSubmonoid M) (smul_mem') :
+    mk carrier smul_mem' = (⊥ : Submodule R M) ↔ carrier = ⊥ := by simp [← toAddSubmonoid_inj]
+
 instance uniqueBot : Unique (⊥ : Submodule R M) :=
   ⟨inferInstance, fun x ↦ Subtype.ext <| (mem_bot R).1 x.mem⟩
 

--- a/Mathlib/Algebra/Module/Submodule/Lattice.lean
+++ b/Mathlib/Algebra/Module/Submodule/Lattice.lean
@@ -152,6 +152,9 @@ lemma top_toAddSubgroup {R M : Type*} [Ring R] [AddCommGroup M] [Module R M] :
 lemma toAddSubgroup_eq_top {R M : Type*} [Ring R] [AddCommGroup M] [Module R M]
     {p : Submodule R M} : p.toAddSubgroup = ⊤ ↔ p = ⊤ := by simp [← toAddSubgroup_inj]
 
+@[simp] lemma mk_eq_top (carrier : AddSubmonoid M) (smul_mem') :
+    mk carrier smul_mem' = (⊤ : Submodule R M) ↔ carrier = ⊤ := by simp [← toAddSubmonoid_inj]
+
 instance : OrderTop (Submodule R M) where
   le_top _ _ _ := trivial
 

--- a/Mathlib/Algebra/Ring/Subring/Basic.lean
+++ b/Mathlib/Algebra/Ring/Subring/Basic.lean
@@ -160,6 +160,15 @@ theorem mem_top (x : R) : x ∈ (⊤ : Subring R) :=
 theorem coe_top : ((⊤ : Subring R) : Set R) = Set.univ :=
   rfl
 
+@[simp] lemma toSubsemiring_top : (⊤ : Subring R).toSubsemiring = ⊤ := rfl
+@[simp] lemma toAddSubgroup_top : (⊤ : Subring R).toAddSubgroup = ⊤ := rfl
+
+@[simp] lemma toSubsemiring_eq_top {S : Subring R} : S.toSubsemiring = ⊤ ↔ S = ⊤ := by
+  simp [← SetLike.coe_set_eq]
+
+@[simp] lemma toAddSubgroup_eq_top {S : Subring R} : S.toAddSubgroup = ⊤ ↔ S = ⊤ := by
+  simp [← SetLike.coe_set_eq]
+
 /-- The ring equiv between the top element of `Subring R` and `R`. -/
 @[simps!]
 def topEquiv : (⊤ : Subring R) ≃+* R :=

--- a/Mathlib/Algebra/Ring/Subring/Defs.lean
+++ b/Mathlib/Algebra/Ring/Subring/Defs.lean
@@ -158,9 +158,21 @@ add_decl_doc Subring.toAddSubgroup
 
 namespace Subring
 
+lemma toSubsemiring_injective : (toSubsemiring : Subring R → Subsemiring R).Injective :=
+  fun ⟨s, hs⟩ t ↦ by congr!
+
+@[simp] lemma toSubsemiring_inj {s t : Subring R} : s.toSubsemiring = t.toSubsemiring ↔ s = t :=
+  toSubsemiring_injective.eq_iff
+
 instance : SetLike (Subring R) R where
   coe s := s.carrier
-  coe_injective' p q h := by cases p; cases q; congr; exact SetLike.ext' h
+  coe_injective' := SetLike.coe_injective.comp toSubsemiring_injective
+
+lemma toAddSubgroup_injective : (toAddSubgroup : Subring R → AddSubgroup R).Injective :=
+  fun _ _ h ↦ SetLike.ext (SetLike.ext_iff.mp h :)
+
+lemma toSubmonoid_injective : (fun s : Subring R => s.toSubmonoid).Injective :=
+  fun _ _ h ↦ SetLike.ext (SetLike.ext_iff.mp h :)
 
 initialize_simps_projections Subring (carrier → coe, as_prefix coe)
 
@@ -230,15 +242,6 @@ protected def copy (S : Subring R) (s : Set R) (hs : s = ↑S) : Subring R :=
 
 theorem copy_eq (S : Subring R) (s : Set R) (hs : s = ↑S) : S.copy s hs = S :=
   SetLike.coe_injective hs
-
-theorem toSubsemiring_injective : Function.Injective (toSubsemiring : Subring R → Subsemiring R)
-  | _, _, h => ext (SetLike.ext_iff.mp h :)
-
-theorem toAddSubgroup_injective : Function.Injective (toAddSubgroup : Subring R → AddSubgroup R)
-  | _, _, h => ext (SetLike.ext_iff.mp h :)
-
-theorem toSubmonoid_injective : Function.Injective (fun s : Subring R => s.toSubmonoid)
-  | _, _, h => ext (SetLike.ext_iff.mp h :)
 
 /-- Construct a `Subring R` from a set `s`, a submonoid `sm`, and an additive
 subgroup `sa` such that `x ∈ s ↔ x ∈ sm ↔ x ∈ sa`. -/

--- a/Mathlib/RingTheory/NonUnitalSubring/Basic.lean
+++ b/Mathlib/RingTheory/NonUnitalSubring/Basic.lean
@@ -109,6 +109,18 @@ theorem mem_top (x : R) : x ∈ (⊤ : NonUnitalSubring R) :=
 theorem coe_top : ((⊤ : NonUnitalSubring R) : Set R) = Set.univ :=
   rfl
 
+@[simp]
+lemma toNonUnitalSubsemiring_top : (⊤ : NonUnitalSubring R).toNonUnitalSubsemiring = ⊤ := rfl
+
+@[simp] lemma toAddSubgroup_top : (⊤ : NonUnitalSubring R).toAddSubgroup = ⊤ := rfl
+
+@[simp]
+lemma toNonUnitalSubsemiring_eq_top {S : NonUnitalSubring R} :
+    S.toNonUnitalSubsemiring = ⊤ ↔ S = ⊤ := by simp [← SetLike.coe_set_eq]
+
+@[simp] lemma toAddSubgroup_eq_top {S : NonUnitalSubring R} : S.toAddSubgroup = ⊤ ↔ S = ⊤ := by
+  simp [← SetLike.coe_set_eq]
+
 /-- The ring equiv between the top element of `NonUnitalSubring R` and `R`. -/
 @[simps!]
 def topEquiv : (⊤ : NonUnitalSubring R) ≃+* R := NonUnitalSubsemiring.topEquiv

--- a/Mathlib/RingTheory/NonUnitalSubsemiring/Defs.lean
+++ b/Mathlib/RingTheory/NonUnitalSubsemiring/Defs.lean
@@ -123,9 +123,20 @@ add_decl_doc NonUnitalSubsemiring.toAddSubmonoid
 
 namespace NonUnitalSubsemiring
 
+lemma toAddSubmonoid_injective :
+    (toAddSubmonoid : NonUnitalSubsemiring R → AddSubmonoid R).Injective :=
+  fun ⟨s, hs⟩ t ↦ by congr!
+
+@[simp] lemma toAddSubmonoid_inj {s t : NonUnitalSubsemiring R} :
+    s.toAddSubmonoid = t.toAddSubmonoid ↔ s = t := toAddSubmonoid_injective.eq_iff
+
 instance : SetLike (NonUnitalSubsemiring R) R where
   coe s := s.carrier
-  coe_injective' p q h := by cases p; cases q; congr; exact SetLike.coe_injective' h
+  coe_injective' := SetLike.coe_injective.comp toAddSubmonoid_injective
+
+lemma toSubsemigroup_injective :
+    Function.Injective (toSubsemigroup : NonUnitalSubsemiring R → Subsemigroup R)
+  | _, _, h => SetLike.ext (SetLike.ext_iff.mp h :)
 
 /-- The actual `NonUnitalSubsemiring` obtained from an element of a `NonUnitalSubsemiringClass`. -/
 @[simps]
@@ -172,14 +183,6 @@ theorem coe_copy (S : NonUnitalSubsemiring R) (s : Set R) (hs : s = ↑S) :
 
 theorem copy_eq (S : NonUnitalSubsemiring R) (s : Set R) (hs : s = ↑S) : S.copy s hs = S :=
   SetLike.coe_injective hs
-
-theorem toSubsemigroup_injective :
-    Function.Injective (toSubsemigroup : NonUnitalSubsemiring R → Subsemigroup R)
-  | _, _, h => ext (SetLike.ext_iff.mp h :)
-
-theorem toAddSubmonoid_injective :
-    Function.Injective (toAddSubmonoid : NonUnitalSubsemiring R → AddSubmonoid R)
-  | _, _, h => ext (SetLike.ext_iff.mp h :)
 
 /-- Construct a `NonUnitalSubsemiring R` from a set `s`, a subsemigroup `sg`, and an additive
 submonoid `sa` such that `x ∈ s ↔ x ∈ sg ↔ x ∈ sa`. -/

--- a/Mathlib/RingTheory/NonUnitalSubsemiring/Defs.lean
+++ b/Mathlib/RingTheory/NonUnitalSubsemiring/Defs.lean
@@ -260,6 +260,12 @@ theorem mem_top (x : R) : x ∈ (⊤ : NonUnitalSubsemiring R) :=
 theorem coe_top : ((⊤ : NonUnitalSubsemiring R) : Set R) = Set.univ :=
   rfl
 
+@[simp] lemma toAddSubmonoid_top : (⊤ : NonUnitalSubsemiring R) = ⊤ := rfl
+
+@[simp]
+lemma toAddSubmonoid_eq_top {S : NonUnitalSubsemiring R} : S.toAddSubmonoid = ⊤ ↔ S = ⊤ := by
+  simp [← SetLike.coe_set_eq]
+
 end NonUnitalSubsemiring
 
 namespace NonUnitalRingHom

--- a/Mathlib/RingTheory/NonUnitalSubsemiring/Defs.lean
+++ b/Mathlib/RingTheory/NonUnitalSubsemiring/Defs.lean
@@ -260,7 +260,7 @@ theorem mem_top (x : R) : x ∈ (⊤ : NonUnitalSubsemiring R) :=
 theorem coe_top : ((⊤ : NonUnitalSubsemiring R) : Set R) = Set.univ :=
   rfl
 
-@[simp] lemma toAddSubmonoid_top : (⊤ : NonUnitalSubsemiring R) = ⊤ := rfl
+@[simp] lemma toAddSubmonoid_top : (⊤ : NonUnitalSubsemiring R).toAddSubmonoid = ⊤ := rfl
 
 @[simp]
 lemma toAddSubmonoid_eq_top {S : NonUnitalSubsemiring R} : S.toAddSubmonoid = ⊤ ↔ S = ⊤ := by


### PR DESCRIPTION
---
<!-- Your PR title will become the first line of the commit message.

In this box, the text above the `---` (if not empty) will be appended
to the commit message, and can be used to give additional context or
details. Please leave a blank newline before the `---`, otherwise GitHub
will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

When merging, all the commits will be squashed into a single commit
listing all co-authors.

Co-authors in the squash commit are gathered from two sources:

First, all authors of commits to this PR branch are included. Thus,
one way to add co-authors is to include at least one commit authored by
each co-author among the commits in the pull request. If necessary, you
may create empty commits to indicate co-authorship, using commands like so:

git commit --author="Author Name <author@email.com>" --allow-empty -m "add Author Name as coauthor"

Second, co-authors can also be listed in lines at the very bottom of
the commit message (that is, directly before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines
at the bottom of the commit message (before the `---`, and also before
any "Co-authored-by" lines) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
