### PR TITLE
[Merged by Bors] - chore(GroupTheory/Torsion): delete deprecated declarations

### DIFF
--- a/Mathlib/GroupTheory/Torsion.lean
+++ b/Mathlib/GroupTheory/Torsion.lean
@@ -322,97 +322,7 @@ theorem primaryComponent.isPGroup : IsPGroup p <| primaryComponent G p := fun g 
 
 end CommGroup
 
-end CommGroup
-
-namespace Monoid
-section Monoid
-variable (G) [Monoid G]
-
-/-- A predicate on a monoid saying that only 1 is of finite order.
-
-This definition is mathematically incorrect for monoids which are not groups.
-Please use `IsMulTorsionFree` instead. -/
-@[to_additive /-- A predicate on an additive monoid saying that only 0 is of finite order.
-
-This definition is mathematically incorrect for monoids which are not groups.
-Please use `IsAddTorsionFree` instead. -/]
-def IsTorsionFree :=
-  ∀ g : G, g ≠ 1 → ¬IsOfFinOrder g
-
-attribute [deprecated IsMulTorsionFree (since := "2025-04-23")] Monoid.IsTorsionFree
-attribute [deprecated IsAddTorsionFree (since := "2025-04-23")] AddMonoid.IsTorsionFree
-
-variable {G}
-
-set_option linter.deprecated false in
-/-- A nontrivial monoid is not torsion-free if any nontrivial element has finite order. -/
-@[to_additive (attr := deprecated not_isMulTorsionFree_iff_isOfFinOrder (since := "2025-04-23"))
-/-- An additive monoid is not torsion free if any nontrivial element has finite order. -/]
-theorem not_isTorsionFree_iff : ¬IsTorsionFree G ↔ ∃ g : G, g ≠ 1 ∧ IsOfFinOrder g := by
-  simp_rw [IsTorsionFree, Ne, not_forall, Classical.not_not, exists_prop]
-
-set_option linter.deprecated false in
-@[to_additive (attr := deprecated Subsingleton.to_isMulTorsionFree (since := "2025-04-23"))]
-lemma isTorsionFree_of_subsingleton [Subsingleton G] : IsTorsionFree G :=
-  fun _a ha _ => ha <| Subsingleton.elim _ _
-
-set_option linter.deprecated false in
-@[to_additive
-  (attr := deprecated CommGroup.isMulTorsionFree_iff_torsion_eq_bot (since := "2025-04-23"))]
-lemma isTorsionFree_iff_torsion_eq_bot {G} [CommGroup G] :
-    IsTorsionFree G ↔ CommGroup.torsion G = ⊥ := by
-  rw [IsTorsionFree, eq_bot_iff, SetLike.le_def]
-  simp [not_imp_not, CommGroup.mem_torsion]
-
-end Monoid
-
-section Group
-variable [Group G]
-
-set_option linter.deprecated false in
-/-- A nontrivial torsion group is not torsion-free. -/
-@[to_additive (attr := deprecated not_isMulTorsionFree_of_isTorsion (since := "2025-04-23"))
-/-- A nontrivial additive torsion group is not torsion-free. -/]
-theorem IsTorsion.not_torsion_free [hN : Nontrivial G] : IsTorsion G → ¬IsTorsionFree G := fun tG =>
-  not_isTorsionFree_iff.mpr <| by
-    obtain ⟨x, hx⟩ := (nontrivial_iff_exists_ne (1 : G)).mp hN
-    exact ⟨x, hx, tG x⟩
-
-set_option linter.deprecated false in
-/-- A nontrivial torsion-free group is not torsion. -/
-@[to_additive (attr := deprecated not_isTorsion_of_isMulTorsionFree (since := "2025-04-23"))
-/-- A nontrivial torsion-free additive group is not torsion. -/]
-theorem IsTorsionFree.not_torsion [hN : Nontrivial G] : IsTorsionFree G → ¬IsTorsion G := fun tfG =>
-  (not_isTorsion_iff _).mpr <| by
-    obtain ⟨x, hx⟩ := (nontrivial_iff_exists_ne (1 : G)).mp hN
-    exact ⟨x, (tfG x) hx⟩
-
-set_option linter.deprecated false in
-/-- Subgroups of torsion-free groups are torsion-free. -/
-@[to_additive (attr := deprecated Subgroup.instIsMulTorsionFree (since := "2025-04-23"))
-/-- Subgroups of additive torsion-free groups are additively torsion-free. -/]
-theorem IsTorsionFree.subgroup (tG : IsTorsionFree G) (H : Subgroup G) : IsTorsionFree H :=
-  fun h hne ↦ Submonoid.isOfFinOrder_coe.not.1 <| tG h <| by norm_cast
-
-set_option linter.deprecated false in
-/-- Direct products of torsion free groups are torsion free. -/
-@[to_additive (attr := deprecated Pi.instIsMulTorsionFree (since := "2025-04-23"))
-  AddMonoid.IsTorsionFree.prod
-      /-- Direct products of additive torsion free groups are torsion free. -/]
-theorem IsTorsionFree.prod {η : Type*} {Gs : η → Type*} [∀ i, Group (Gs i)]
-    (tfGs : ∀ i, IsTorsionFree (Gs i)) : IsTorsionFree <| ∀ i, Gs i := fun w hne h =>
-  hne <|
-    funext fun i => Classical.not_not.mp <| mt (tfGs i (w i)) <| Classical.not_not.mpr <| h.apply i
-
-end Group
-
-section CommGroup
-
-open Monoid (IsTorsionFree)
-
 open CommGroup (torsion)
-
-variable (G) [CommGroup G]
 
 /-- Quotienting a group by its torsion subgroup yields a torsion-free group. -/
 @[to_additive
@@ -425,52 +335,7 @@ instance _root_.QuotientGroup.instIsMulTorsionFree : IsMulTorsionFree <| G ⧸ t
   exact (QuotientGroup.eq_one_iff g).mpr
     (isOfFinOrder_iff_pow_eq_one.mpr ⟨m * n, mul_pos mpos npos, (pow_mul g m n).symm ▸ hn⟩)
 
-set_option linter.deprecated false in
-/-- Quotienting a group by its torsion subgroup yields a torsion free group. -/
-@[to_additive
-  (attr := deprecated QuotientGroup.instIsMulTorsionFree (since := "2025-04-23"))
-/-- Quotienting a group by its additive torsion subgroup yields an additive torsion free group. -/]
-theorem IsTorsionFree.quotient_torsion : IsTorsionFree <| G ⧸ torsion G := fun g hne hfin =>
-  hne <| by
-    obtain ⟨g⟩ := g
-    obtain ⟨m, mpos, hm⟩ := hfin.exists_pow_eq_one
-    obtain ⟨n, npos, hn⟩ := ((QuotientGroup.eq_one_iff _).mp hm).exists_pow_eq_one
-    exact
-      (QuotientGroup.eq_one_iff g).mpr
-        (isOfFinOrder_iff_pow_eq_one.mpr ⟨m * n, mul_pos mpos npos, (pow_mul g m n).symm ▸ hn⟩)
-
 end CommGroup
-end Monoid
-
-namespace AddMonoid
-
-set_option linter.deprecated false in
-@[deprecated noZeroSMulDivisors_nat_iff_isAddTorsionFree (since := "2025-04-23")]
-lemma isTorsionFree_iff_noZeroSMulDivisors_nat {M : Type*} [AddMonoid M] :
-    IsTorsionFree M ↔ NoZeroSMulDivisors ℕ M := by
-  simp_rw [AddMonoid.IsTorsionFree, isOfFinAddOrder_iff_nsmul_eq_zero, not_exists, not_and,
-    pos_iff_ne_zero, noZeroSMulDivisors_iff, forall_swap (β := ℕ)]
-  exact forall₂_congr fun _ _ ↦ by tauto
-
-set_option linter.deprecated false in
-@[deprecated noZeroSMulDivisors_int_iff_isAddTorsionFree (since := "2025-04-23")]
-lemma isTorsionFree_iff_noZeroSMulDivisors_int [SubtractionMonoid G] :
-    IsTorsionFree G ↔ NoZeroSMulDivisors ℤ G := by
-  simp_rw [AddMonoid.IsTorsionFree, isOfFinAddOrder_iff_zsmul_eq_zero, not_exists, not_and,
-    noZeroSMulDivisors_iff, forall_swap (β := ℤ)]
-  exact forall₂_congr fun _ _ ↦ by tauto
-
-set_option linter.deprecated false in
-@[deprecated IsAddTorsionFree.of_noZeroSMulDivisors_nat (since := "2025-04-23")]
-lemma IsTorsionFree.of_noZeroSMulDivisors {M : Type*} [AddMonoid M] [NoZeroSMulDivisors ℕ M] :
-    IsTorsionFree M := isTorsionFree_iff_noZeroSMulDivisors_nat.2 ‹_›
-
-@[deprecated IsAddTorsionFree.to_noZeroSMulDivisors_nat (since := "2025-04-23")]
-alias ⟨IsTorsionFree.noZeroSMulDivisors_nat, _⟩ := isTorsionFree_iff_noZeroSMulDivisors_nat
-@[deprecated IsAddTorsionFree.to_noZeroSMulDivisors_int (since := "2025-04-23")]
-alias ⟨IsTorsionFree.noZeroSMulDivisors_int, _⟩ := isTorsionFree_iff_noZeroSMulDivisors_int
-
-end AddMonoid
 
 section AddCommGroup
 


### PR DESCRIPTION
These are on my way for #30563.


---
<!-- Your PR title will become the first line of the commit message.

In this box, the text above the `---` (if not empty) will be appended
to the commit message, and can be used to give additional context or
details. Please leave a blank newline before the `---`, otherwise GitHub
will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

When merging, all the commits will be squashed into a single commit
listing all co-authors.

Co-authors in the squash commit are gathered from two sources:

First, all authors of commits to this PR branch are included. Thus,
one way to add co-authors is to include at least one commit authored by
each co-author among the commits in the pull request. If necessary, you
may create empty commits to indicate co-authorship, using commands like so:

git commit --author="Author Name <author@email.com>" --allow-empty -m "add Author Name as coauthor"

Second, co-authors can also be listed in lines at the very bottom of
the commit message (that is, directly before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines
at the bottom of the commit message (before the `---`, and also before
any "Co-authored-by" lines) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
