### PR TITLE
[Merged by Bors] - feat: `UniformSpace.subset_countable_closure_of_almost_dense_set`

### DIFF
--- a/Mathlib/Topology/EMetricSpace/Basic.lean
+++ b/Mathlib/Topology/EMetricSpace/Basic.lean
@@ -189,6 +189,19 @@ theorem totallyBounded_iff' {s : Set α} :
 
 section Compact
 
+-- TODO: generalize to a uniform space with metrizable uniformity
+/-- For a set `s` in a pseudo emetric space, if for every `ε > 0` there exists a countable
+set that is `ε`-dense in `s`, then there exists a countable subset `t ⊆ s` that is dense in `s`. -/
+theorem subset_countable_closure_of_almost_dense_set (s : Set α)
+    (hs : ∀ ε > 0, ∃ t : Set α, t.Countable ∧ s ⊆ ⋃ x ∈ t, closedBall x ε) :
+    ∃ t, t ⊆ s ∧ t.Countable ∧ s ⊆ closure t := by
+  apply UniformSpace.subset_countable_closure_of_almost_dense_set
+  intro U hU
+  obtain ⟨ε, hε, hεU⟩ := uniformity_basis_edist_le.mem_iff.1 hU
+  obtain ⟨t, tC, ht⟩ := hs ε hε
+  refine ⟨t, tC, ht.trans (iUnion₂_mono fun x hx y hy => UniformSpace.ball_mono hεU x ?_)⟩
+  rwa [mem_closedBall, edist_comm] at hy
+
 -- TODO: generalize to metrizable spaces
 /-- A compact set in a pseudo emetric space is separable, i.e., it is a subset of the closure of a
 countable set. -/
@@ -287,38 +300,6 @@ instance [PseudoEMetricSpace X] : EMetricSpace (SeparationQuotient X) :=
       toUniformSpace := inferInstance,
       uniformity_edist := comap_injective (surjective_mk.prodMap surjective_mk) <| by
         simp [comap_mk_uniformity, PseudoEMetricSpace.uniformity_edist] } _
-
-namespace TopologicalSpace
-
-section Compact
-
-open Topology
-
-/-- If a set `s` is separable in a (pseudo extended) metric space, then it admits a countable dense
-subset. This is not obvious, as the countable set whose closure covers `s` given by the definition
-of separability does not need in general to be contained in `s`. -/
-theorem IsSeparable.exists_countable_dense_subset
-    {s : Set α} (hs : IsSeparable s) : ∃ t, t ⊆ s ∧ t.Countable ∧ s ⊆ closure t := by
-  have : ∀ ε > 0, ∃ t : Set α, t.Countable ∧ s ⊆ ⋃ x ∈ t, closedBall x ε := fun ε ε0 => by
-    rcases hs with ⟨t, htc, hst⟩
-    refine ⟨t, htc, hst.trans fun x hx => ?_⟩
-    rcases mem_closure_iff.1 hx ε ε0 with ⟨y, hyt, hxy⟩
-    exact mem_iUnion₂.2 ⟨y, hyt, mem_closedBall.2 hxy.le⟩
-  exact subset_countable_closure_of_almost_dense_set _ this
-
-/-- If a set `s` is separable, then the corresponding subtype is separable in a (pseudo extended)
-metric space.  This is not obvious, as the countable set whose closure covers `s` does not need in
-general to be contained in `s`. -/
-theorem IsSeparable.separableSpace {s : Set α} (hs : IsSeparable s) :
-    SeparableSpace s := by
-  rcases hs.exists_countable_dense_subset with ⟨t, hts, htc, hst⟩
-  lift t to Set s using hts
-  refine ⟨⟨t, countable_of_injective_of_countable_image Subtype.coe_injective.injOn htc, ?_⟩⟩
-  rwa [IsInducing.subtypeVal.dense_iff, Subtype.forall]
-
-end Compact
-
-end TopologicalSpace
 
 section LebesgueNumberLemma
 

--- a/Mathlib/Topology/EMetricSpace/Basic.lean
+++ b/Mathlib/Topology/EMetricSpace/Basic.lean
@@ -189,7 +189,6 @@ theorem totallyBounded_iff' {s : Set α} :
 
 section Compact
 
--- TODO: generalize to a uniform space with metrizable uniformity
 /-- For a set `s` in a pseudo emetric space, if for every `ε > 0` there exists a countable
 set that is `ε`-dense in `s`, then there exists a countable subset `t ⊆ s` that is dense in `s`. -/
 theorem subset_countable_closure_of_almost_dense_set (s : Set α)

--- a/Mathlib/Topology/EMetricSpace/Defs.lean
+++ b/Mathlib/Topology/EMetricSpace/Defs.lean
@@ -535,41 +535,6 @@ theorem tendsto_atTop [Nonempty β] [SemilatticeSup β] {u : β → α} {a : α}
   (atTop_basis.tendsto_iff nhds_basis_eball).trans <| by
     simp only [true_and, mem_Ici, mem_ball]
 
-section Compact
-
--- TODO: generalize to a uniform space with metrizable uniformity
-/-- For a set `s` in a pseudo emetric space, if for every `ε > 0` there exists a countable
-set that is `ε`-dense in `s`, then there exists a countable subset `t ⊆ s` that is dense in `s`. -/
-theorem subset_countable_closure_of_almost_dense_set (s : Set α)
-    (hs : ∀ ε > 0, ∃ t : Set α, t.Countable ∧ s ⊆ ⋃ x ∈ t, closedBall x ε) :
-    ∃ t, t ⊆ s ∧ t.Countable ∧ s ⊆ closure t := by
-  rcases s.eq_empty_or_nonempty with (rfl | ⟨x₀, hx₀⟩)
-  · exact ⟨∅, empty_subset _, countable_empty, empty_subset _⟩
-  choose! T hTc hsT using fun n : ℕ => hs n⁻¹ (by simp)
-  have : ∀ r x, ∃ y ∈ s, closedBall x r ∩ s ⊆ closedBall y (r * 2) := fun r x => by
-    rcases (closedBall x r ∩ s).eq_empty_or_nonempty with (he | ⟨y, hxy, hys⟩)
-    · refine ⟨x₀, hx₀, ?_⟩
-      rw [he]
-      exact empty_subset _
-    · refine ⟨y, hys, fun z hz => ?_⟩
-      calc
-        edist z y ≤ edist z x + edist y x := edist_triangle_right _ _ _
-        _ ≤ r + r := add_le_add hz.1 hxy
-        _ = r * 2 := (mul_two r).symm
-  choose f hfs hf using this
-  refine
-    ⟨⋃ n : ℕ, f n⁻¹ '' T n, iUnion_subset fun n => image_subset_iff.2 fun z _ => hfs _ _,
-      countable_iUnion fun n => (hTc n).image _, ?_⟩
-  refine fun x hx => mem_closure_iff.2 fun ε ε0 => ?_
-  rcases ENNReal.exists_inv_nat_lt (ENNReal.half_pos ε0.lt.ne').ne' with ⟨n, hn⟩
-  rcases mem_iUnion₂.1 (hsT n hx) with ⟨y, hyn, hyx⟩
-  refine ⟨f n⁻¹ y, mem_iUnion.2 ⟨n, mem_image_of_mem _ hyn⟩, ?_⟩
-  calc
-    edist x (f n⁻¹ y) ≤ (n : ℝ≥0∞)⁻¹ * 2 := hf _ _ ⟨hyx, hx⟩
-    _ < ε := ENNReal.mul_lt_of_lt_div hn
-
-end Compact
-
 end EMetric
 
 namespace Subtype

--- a/Mathlib/Topology/MetricSpace/Pseudo/Basic.lean
+++ b/Mathlib/Topology/MetricSpace/Pseudo/Basic.lean
@@ -10,6 +10,8 @@ public import Mathlib.Tactic.Bound.Attribute
 public import Mathlib.Topology.EMetricSpace.Basic
 public import Mathlib.Topology.MetricSpace.Pseudo.Defs
 
+import Mathlib.Topology.Metrizable.Basic
+
 /-!
 ## Pseudo-metric spaces
 

--- a/Mathlib/Topology/Metrizable/Basic.lean
+++ b/Mathlib/Topology/Metrizable/Basic.lean
@@ -22,7 +22,7 @@ assert_not_exists AddMonoidWithOne
 
 @[expose] public section
 
-open Filter Set Topology Uniformity
+open Filter Set Topology Uniformity UniformSpace SetRel
 
 namespace TopologicalSpace
 
@@ -153,24 +153,49 @@ theorem IsSeparable.secondCountableTopology [PseudoMetrizableSpace X] {s : Set X
       Subtype.dense_iff.2 <| by rw [← Set.range_comp, Set.val_comp_inclusion, Subtype.range_coe]⟩
   let := pseudoMetrizableSpaceUniformity (closure u)
   have := pseudoMetrizableSpaceUniformity_countably_generated (closure u)
-  have := UniformSpace.secondCountable_of_separable (closure u)
+  have := secondCountable_of_separable (closure u)
   (Topology.IsEmbedding.inclusion hs).secondCountableTopology
 
 instance (X : Type*) [TopologicalSpace X] [LindelofSpace X] [PseudoMetrizableSpace X] :
     SecondCountableTopology X := by
   let := pseudoMetrizableSpaceUniformity X
   have := pseudoMetrizableSpaceUniformity_countably_generated X
-  suffices _ : SeparableSpace X from UniformSpace.secondCountable_of_separable X
-  obtain ⟨V, hVb, hVs⟩ := UniformSpace.has_seq_basis X
+  suffices _ : SeparableSpace X from secondCountable_of_separable X
+  obtain ⟨V, hVb, hVs⟩ := has_seq_basis X
   choose U hUc hUu using fun n =>
-    LindelofSpace.elim_nhds_subcover (fun x => UniformSpace.ball x (V n))
-      (fun x => UniformSpace.ball_mem_nhds x (hVb.mem n))
+    LindelofSpace.elim_nhds_subcover (fun x => ball x (V n))
+      (fun x => ball_mem_nhds x (hVb.mem n))
   refine ⟨Set.iUnion U, Set.countable_iUnion hUc, fun x => ?_⟩
   rw [mem_closure_iff_frequently, nhds_eq_comap_uniformity, frequently_comap, hVb.frequently_iff]
   intro n _
   obtain ⟨i, hi, hx⟩ := Set.mem_iUnion₂.1 (Set.eq_univ_iff_forall.1 (hUu n) x)
-  rw [UniformSpace.ball_eq_of_symmetry] at hx
+  rw [ball_eq_of_symmetry] at hx
   exact ⟨(x, i), hx, i, rfl, Set.mem_iUnion_of_mem n hi⟩
+
+/-- If a set `s` is separable in a pseudo metrizable space, then it admits a countable dense
+subset. This is not obvious, as the countable set whose closure covers `s` given by the definition
+of separability does not need in general to be contained in `s`. -/
+theorem IsSeparable.exists_countable_dense_subset [PseudoMetrizableSpace X]
+    {s : Set X} (hs : IsSeparable s) : ∃ t, t ⊆ s ∧ t.Countable ∧ s ⊆ closure t := by
+  let := pseudoMetrizableSpaceUniformity X
+  have := pseudoMetrizableSpaceUniformity_countably_generated X
+  apply subset_countable_closure_of_almost_dense_set
+  intro U hU
+  obtain ⟨t, htc, hst⟩ := hs
+  refine ⟨t, htc, fun x hx => ?_⟩
+  obtain ⟨y, hyx, hyt⟩ := mem_closure_iff_ball.1 (hst hx) (symmetrize_mem_uniformity hU)
+  exact mem_biUnion hyt (ball_mono SetRel.symmetrize_subset_inv x hyx)
+
+/-- If a set `s` is separable, then the corresponding subtype is separable in a
+pseudo metrizable space.
+This is not obvious, as the countable set whose closure covers `s` does not need in
+general to be contained in `s`. -/
+theorem IsSeparable.separableSpace [PseudoMetrizableSpace X] {s : Set X} (hs : IsSeparable s) :
+    SeparableSpace s := by
+  rcases hs.exists_countable_dense_subset with ⟨t, hts, htc, hst⟩
+  lift t to Set s using hts
+  refine ⟨⟨t, countable_of_injective_of_countable_image Subtype.coe_injective.injOn htc, ?_⟩⟩
+  rwa [IsInducing.subtypeVal.dense_iff, Subtype.forall]
 
 instance (priority := 100) DiscreteTopology.metrizableSpace [DiscreteTopology X] :
     MetrizableSpace X where

--- a/Mathlib/Topology/Metrizable/Uniformity.lean
+++ b/Mathlib/Topology/Metrizable/Uniformity.lean
@@ -283,21 +283,6 @@ example {X : Type*} [t : TopologicalSpace X] [t.MetrizableSpace] :
     t.metrizableSpaceMetric.toPseudoMetricSpace = t.pseudoMetrizableSpacePseudoMetric := by
   with_reducible_and_instances rfl
 
-/-- A totally bounded set is separable in countably generated uniform spaces. This can be obtained
-from the more general `EMetric.subset_countable_closure_of_almost_dense_set`. -/
-lemma TotallyBounded.isSeparable [UniformSpace X] [i : IsCountablyGenerated (𝓤 X)]
-    {s : Set X} (h : TotallyBounded s) : TopologicalSpace.IsSeparable s := by
-  letI := (UniformSpace.pseudoMetricSpace (X := X)).toPseudoEMetricSpace
-  rw [EMetric.totallyBounded_iff] at h
-  have h' : ∀ ε > 0, ∃ t, Set.Countable t ∧ s ⊆ ⋃ y ∈ t, EMetric.closedBall y ε := by
-    intro ε hε
-    obtain ⟨t, ht⟩ := h ε hε
-    refine ⟨t, ht.1.countable, subset_trans ht.2 ?_⟩
-    gcongr
-    exact EMetric.ball_subset_closedBall
-  obtain ⟨t, _, htc, hts⟩ := EMetric.subset_countable_closure_of_almost_dense_set s h'
-  exact ⟨t, htc, hts⟩
-
 variable {α : Type*}
 open TopologicalSpace
 

--- a/Mathlib/Topology/UniformSpace/Basic.lean
+++ b/Mathlib/Topology/UniformSpace/Basic.lean
@@ -666,6 +666,9 @@ theorem UniformContinuousOn.continuousOn [UniformSpace α] [UniformSpace β] {f 
   rw [continuousOn_iff_continuous_restrict]
   exact h.continuous
 
+instance [UniformSpace α] [(𝓤 α).IsCountablyGenerated] (s : Set α) : (𝓤 s).IsCountablyGenerated :=
+  Filter.comap.isCountablyGenerated _ _
+
 @[to_additive]
 instance [UniformSpace α] : UniformSpace αᵐᵒᵖ :=
   UniformSpace.comap MulOpposite.unop ‹_›

--- a/Mathlib/Topology/UniformSpace/Cauchy.lean
+++ b/Mathlib/Topology/UniformSpace/Cauchy.lean
@@ -846,4 +846,47 @@ instance secondCountable_of_separable [SeparableSpace α] : SecondCountableTopol
     refine ⟨_, ⟨y, hys, k, rfl⟩, (t k).symm hxy, fun z hz => ?_⟩
     exact hUV (ball_subset_of_comp_subset (hk hxy) hUU' (hk hz))
 
+variable {α}
+
+theorem subset_countable_closure_of_almost_dense_set (s : Set α)
+    (hs : ∀ U ∈ 𝓤 α, ∃ t : Set α, t.Countable ∧ s ⊆ ⋃ x ∈ t, ball x U) :
+    ∃ t, t ⊆ s ∧ t.Countable ∧ s ⊆ closure t := by
+  obtain ⟨B, hB, _⟩ := has_seq_basis α
+  replace hs (n : ℕ) := hs (B n) (hB.mem n)
+  choose t tC ht using hs
+  have := fun n => (tC n).to_subtype
+  choose o hox hos using fun (n : ℕ) (x : t n) (hx : (ball x.1 (B n) ∩ s).Nonempty) => hx
+  refine ⟨⋃ (n) (x), range (o n x), iUnion₂_subset fun _ _ => range_subset_iff.2 (hos _ _),
+    countable_iUnion fun _ => countable_iUnion fun _ => countable_range _, fun x hx => ?_⟩
+  rw [mem_closure_iff_ball]
+  intro U hU
+  obtain ⟨V, hV, hVU⟩ := comp_mem_uniformity_sets hU
+  obtain ⟨n, hn⟩ := hB.mem_iff.1 hV
+  specialize ht n hx
+  rw [mem_iUnion₂] at ht
+  obtain ⟨y, hy, hyx⟩ := ht
+  refine ⟨o n ⟨y, hy⟩ ⟨x, hyx, hx⟩, ?_, ?_⟩
+  · apply ball_mono ((SetRel.comp_subset_comp hn hn).trans hVU)
+    exact mem_ball_comp (mem_ball_symmetry.2 hyx) (hox n ⟨y, hy⟩ ⟨x, hyx, hx⟩)
+  · exact mem_iUnion₂_of_mem ⟨y, hy⟩ (mem_range_self ⟨x, hyx, hx⟩)
+
+theorem secondCountable_of_almost_dense_set
+    (hs : ∀ U ∈ 𝓤 α, ∃ t : Set α, t.Countable ∧ ⋃ x ∈ t, ball x U = univ) :
+    SecondCountableTopology α := by
+  suffices SeparableSpace α from UniformSpace.secondCountable_of_separable α
+  have : ∀ U ∈ 𝓤 α, ∃ t : Set α, Set.Countable t ∧ univ ⊆ ⋃ x ∈ t, ball x U := by
+    simpa only [univ_subset_iff] using hs
+  rcases subset_countable_closure_of_almost_dense_set (univ : Set α) this with ⟨t, -, htc, ht⟩
+  exact ⟨⟨t, htc, fun x => ht (mem_univ x)⟩⟩
+
+/-- A totally bounded set is separable in countably generated uniform spaces. This can be obtained
+from the more general `UniformSpace.subset_countable_closure_of_almost_dense_set`. -/
+lemma TotallyBounded.isSeparable {s : Set α} (h : TotallyBounded s) :
+    TopologicalSpace.IsSeparable s := by
+  obtain ⟨t, -, htc, hts⟩ := subset_countable_closure_of_almost_dense_set s fun U hU => by
+    obtain ⟨t, ht, hst⟩ := h (SetRel.inv U)
+      (mem_of_superset (symmetrize_mem_uniformity hU) SetRel.symmetrize_subset_inv)
+    exact ⟨t, ht.countable, hst⟩
+  exact ⟨t, htc, hts⟩
+
 end UniformSpace

--- a/Mathlib/Topology/UniformSpace/Cauchy.lean
+++ b/Mathlib/Topology/UniformSpace/Cauchy.lean
@@ -881,7 +881,7 @@ theorem secondCountable_of_almost_dense_set
 
 /-- A totally bounded set is separable in countably generated uniform spaces. This can be obtained
 from the more general `UniformSpace.subset_countable_closure_of_almost_dense_set`. -/
-lemma TotallyBounded.isSeparable {s : Set α} (h : TotallyBounded s) :
+lemma _root_.TotallyBounded.isSeparable {s : Set α} (h : TotallyBounded s) :
     TopologicalSpace.IsSeparable s := by
   obtain ⟨t, -, htc, hts⟩ := subset_countable_closure_of_almost_dense_set s fun U hU => by
     obtain ⟨t, ht, hst⟩ := h (SetRel.inv U)


### PR DESCRIPTION
Add the new theorem `UniformSpace.subset_countable_closure_of_almost_dense_set` and golf the `PseudoEMetricSpace` version with it. Move some stuff around:
- `IsSeparable.exists_countable_dense_subset` and `IsSeparable.separableSpace` are generalized to pseudometrizable spaces and moved to `Metrizable/Basic`.
- `TotallyBounded.isSeparable` is moved to `UniformSpace/Cauchy`
- `EMetric.subset_countable_closure_of_almost_dense_set` is moved to `EMetric/Basic`

---
<!-- Your PR title will become the first line of the commit message.

In this box, the text above the `---` (if not empty) will be appended
to the commit message, and can be used to give additional context or
details. Please leave a blank newline before the `---`, otherwise GitHub
will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

When merging, all the commits will be squashed into a single commit
listing all co-authors.

Co-authors in the squash commit are gathered from two sources:

First, all authors of commits to this PR branch are included. Thus,
one way to add co-authors is to include at least one commit authored by
each co-author among the commits in the pull request. If necessary, you
may create empty commits to indicate co-authorship, using commands like so:

git commit --author="Author Name <author@email.com>" --allow-empty -m "add Author Name as coauthor"

Second, co-authors can also be listed in lines at the very bottom of
the commit message (that is, directly before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines
at the bottom of the commit message (before the `---`, and also before
any "Co-authored-by" lines) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
