### PR TITLE
[Merged by Bors] - chore(Order/Iterate): avoid `to_dual existing`

### DIFF
--- a/Mathlib/Order/Iterate.lean
+++ b/Mathlib/Order/Iterate.lean
@@ -41,6 +41,7 @@ lemmas in this section formalize this fact for different inequalities made stric
 -/
 
 
+@[to_dual self (reorder := x y, hx hy)]
 theorem seq_le_seq (hf : Monotone f) (n : ℕ) (h₀ : x 0 ≤ y 0) (hx : ∀ k < n, x (k + 1) ≤ f (x k))
     (hy : ∀ k < n, f (y k) ≤ y (k + 1)) : x n ≤ y n := by
   induction n with
@@ -90,23 +91,16 @@ variable {β : Type*} {g : β → β} {h : β → α}
 
 open Function
 
+@[to_dual iterate_comp_le_of_le]
 theorem le_iterate_comp_of_le (hf : Monotone f) (H : h ∘ g ≤ f ∘ h) (n : ℕ) :
     h ∘ g^[n] ≤ f^[n] ∘ h := fun x => by
   apply hf.seq_le_seq n <;>
     aesop (add simp [iterate_succ']) (erase simp [iterate_succ])
 
-theorem iterate_comp_le_of_le (hf : Monotone f) (H : f ∘ h ≤ h ∘ g) (n : ℕ) :
-    f^[n] ∘ h ≤ h ∘ g^[n] :=
-  hf.dual.le_iterate_comp_of_le H n
-
 /-- If `f ≤ g` and `f` is monotone, then `f^[n] ≤ g^[n]`. -/
+@[to_dual le_iterate_of_le /-- If `f ≤ g` and `g` is monotone, then `f^[n] ≤ g^[n]`. -/]
 theorem iterate_le_of_le {g : α → α} (hf : Monotone f) (h : f ≤ g) (n : ℕ) : f^[n] ≤ g^[n] :=
   hf.iterate_comp_le_of_le h n
-
-/-- If `f ≤ g` and `g` is monotone, then `f^[n] ≤ g^[n]`. -/
-@[to_dual existing iterate_le_of_le]
-theorem le_iterate_of_le {g : α → α} (hg : Monotone g) (h : f ≤ g) (n : ℕ) : f^[n] ≤ g^[n] :=
-  hg.dual.iterate_le_of_le h n
 
 end Monotone
 


### PR DESCRIPTION
This PR adds a few uses of `to_dual`. Unfortunately many declarations cannot yet really be handled by `to_dual` because `Monotone` isn't supported yet.

---
<!-- Your PR title will become the first line of the commit message.

In this box, the text above the `---` (if not empty) will be appended
to the commit message, and can be used to give additional context or
details. Please leave a blank newline before the `---`, otherwise GitHub
will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

When merging, all the commits will be squashed into a single commit
listing all co-authors.

Co-authors in the squash commit are gathered from two sources:

First, all authors of commits to this PR branch are included. Thus,
one way to add co-authors is to include at least one commit authored by
each co-author among the commits in the pull request. If necessary, you
may create empty commits to indicate co-authorship, using commands like so:

git commit --author="Author Name <author@email.com>" --allow-empty -m "add Author Name as coauthor"

Second, co-authors can also be listed in lines at the very bottom of
the commit message (that is, directly before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines
at the bottom of the commit message (before the `---`, and also before
any "Co-authored-by" lines) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
