### PR TITLE
[Merged by Bors] - doc(grw): explicitly mention backwards rewriting

### DIFF
--- a/Mathlib/Tactic/GRewrite/Elab.lean
+++ b/Mathlib/Tactic/GRewrite/Elab.lean
@@ -100,6 +100,9 @@ example (h₁ : a < b) (h₂ : b ≤ c) : a + d ≤ c + d := by
   grw [← h₂, ← h₁]
 ```
 
+The strict inequality `a < b` is turned into the non-strict inequality `a ≤ b` to rewrite with it.
+A future version of `grw` may get special support for making better use of strict inequalities.
+
 To rewrite only in the `n`-th position, use `nth_grw n`.
 This is useful when `grw` tries to rewrite in a position that is not valid for the given relation.
 

--- a/Mathlib/Tactic/GRewrite/Elab.lean
+++ b/Mathlib/Tactic/GRewrite/Elab.lean
@@ -77,7 +77,8 @@ syntax (name := grewriteSeq) "grewrite" optConfig rwRuleSeq (location)? : tactic
 /--
 `grw [e]` works just like `rw [e]`, but `e` can be a relation other than `=` or `↔`.
 
-For example,
+For example:
+
 ```lean
 variable {a b c d n : ℤ}
 
@@ -91,6 +92,14 @@ example (h₁ : a ∣ b) (h₂ : b ∣ a ^ 2 * c) : a ∣ b ^ 2 * c := by
   grw [h₁] at *
   exact h₂
 ```
+
+To replace the RHS with the LHS of the given relation, use the `←` notation (just like in `rw`):
+
+```
+example (h₁ : a < b) (h₂ : b ≤ c) : a + d ≤ c + d := by
+  grw [← h₂, ← h₁]
+```
+
 To rewrite only in the `n`-th position, use `nth_grw n`.
 This is useful when `grw` tries to rewrite in a position that is not valid for the given relation.
 


### PR DESCRIPTION
Multiple people have expressed confusion about the backwards rewriting in the `grw` tactic, so I've added it to the doc-string. Let me know if it can be explained more clearly.

---
<!-- Your PR title will become the first line of the commit message.

In this box, the text above the `---` (if not empty) will be appended
to the commit message, and can be used to give additional context or
details. Please leave a blank newline before the `---`, otherwise GitHub
will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

When merging, all the commits will be squashed into a single commit
listing all co-authors.

Co-authors in the squash commit are gathered from two sources:

First, all authors of commits to this PR branch are included. Thus,
one way to add co-authors is to include at least one commit authored by
each co-author among the commits in the pull request. If necessary, you
may create empty commits to indicate co-authorship, using commands like so:

git commit --author="Author Name <author@email.com>" --allow-empty -m "add Author Name as coauthor"

Second, co-authors can also be listed in lines at the very bottom of
the commit message (that is, directly before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines
at the bottom of the commit message (before the `---`, and also before
any "Co-authored-by" lines) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
