### PR TITLE
[Merged by Bors] - fix(scripts): make missing local tag a warning in verify_version_tags.py

### DIFF
--- a/scripts/verify_version_tags.py
+++ b/scripts/verify_version_tags.py
@@ -230,7 +230,14 @@ def verify_local_remote_consistency(tag: str) -> VerificationResult:
     # Get local SHA
     code, stdout, _ = run_cmd(['git', 'rev-parse', tag])
     if code != 0:
-        return VerificationResult(False, f"Tag {tag} not found locally")
+        # Tag not found locally - this is expected when running from release_checklist.py
+        # which doesn't have a local mathlib4 checkout with tags fetched.
+        # The GitHub check below will verify the tag exists remotely.
+        return VerificationResult(
+            True,
+            f"Tag {tag} not found locally (not in a mathlib4 checkout?)",
+            warning=True
+        )
     local_sha = stdout.strip()
 
     # Get all remotes and their URLs


### PR DESCRIPTION
This PR fixes an issue where `verify_version_tags.py` fails when run from `release_checklist.py` because there's no local mathlib4 checkout with tags fetched.

The script was failing with "Tag not found locally" even though all real verification checks passed (GitHub tag exists, toolchain correct, cache works, build verification passes).

This change makes the missing local tag a warning instead of an error, since the GitHub API check already verifies the tag exists remotely.

🤖 Prepared with Claude Code