### PR TITLE
[Merged by Bors] - feat(Algebra/MvPolynomial/Basic): add `MvPolynomial.support_C`

### DIFF
--- a/Mathlib/Algebra/MvPolynomial/Basic.lean
+++ b/Mathlib/Algebra/MvPolynomial/Basic.lean
@@ -510,9 +510,8 @@ theorem support_monomial [h : Decidable (a = 0)] :
   rfl
 
 lemma support_C (c : R) [h : Decidable (c = 0)] :
-    (C (σ := σ) c).support = if c = 0 then ∅ else {0} := by
-  rw [← Subsingleton.elim (Classical.decEq R c 0) h]
-  rfl
+    (C (σ := σ) c).support = if c = 0 then ∅ else {0} :=
+  support_monomial
 
 theorem support_monomial_subset : (monomial s a).support ⊆ {s} :=
   support_single_subset

--- a/Mathlib/Algebra/MvPolynomial/Basic.lean
+++ b/Mathlib/Algebra/MvPolynomial/Basic.lean
@@ -509,6 +509,11 @@ theorem support_monomial [h : Decidable (a = 0)] :
   rw [← Subsingleton.elim (Classical.decEq R a 0) h]
   rfl
 
+lemma support_C (c : R) [h : Decidable (c = 0)] :
+    (C (σ := σ) c).support = if c = 0 then ∅ else {0} := by
+  rw [← Subsingleton.elim (Classical.decEq R c 0) h]
+  rfl
+
 theorem support_monomial_subset : (monomial s a).support ⊆ {s} :=
   support_single_subset
 


### PR DESCRIPTION
Similar with `MvPolynomial.support_monomial`, while for `MvPolynomial.C`.

---
<!-- Your PR title will become the first line of the commit message.

In this box, the text above the `---` (if not empty) will be appended
to the commit message, and can be used to give additional context or
details. Please leave a blank newline before the `---`, otherwise GitHub
will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

When merging, all the commits will be squashed into a single commit
listing all co-authors.

Co-authors in the squash commit are gathered from two sources:

First, all authors of commits to this PR branch are included. Thus,
one way to add co-authors is to include at least one commit authored by
each co-author among the commits in the pull request. If necessary, you
may create empty commits to indicate co-authorship, using commands like so:

git commit --author="Author Name <author@email.com>" --allow-empty -m "add Author Name as coauthor"

Second, co-authors can also be listed in lines at the very bottom of
the commit message (that is, directly before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines
at the bottom of the commit message (before the `---`, and also before
any "Co-authored-by" lines) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

The proof is copied from `support_monomial`. I tried to follow it (and other theorems) in this file, using `Decidable` instance argument (instead of classical) in the statement.

https://github.com/leanprover-community/mathlib4/blob/c5457e028692b75afc3adc02bf13408d0a4da371/Mathlib/Algebra/MvPolynomial/Basic.lean#L507-L515

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
