### PR TITLE
[Merged by Bors] - feat: t2Space_iff_of_isOpenQuotientMap

### DIFF
--- a/Mathlib/Topology/Separation/Hausdorff.lean
+++ b/Mathlib/Topology/Separation/Hausdorff.lean
@@ -170,11 +170,12 @@ theorem isClosed_diagonal [T2Space X] : IsClosed (diagonal X) :=
 theorem t2Space_iff_of_isOpenQuotientMap [TopologicalSpace Y] {π : X → Y}
     (h : IsOpenQuotientMap π) : T2Space Y ↔ IsClosed {q : X × X | π q.1 = π q.2} := by
   rw [t2_iff_isClosed_diagonal]
+  replace h := IsOpenQuotientMap.prodMap h h
   constructor <;> intro H
-  · exact H.preimage (h.continuous.prodMap h.continuous)
+  · exact H.preimage h.continuous
   · simp_rw [← isOpen_compl_iff] at H ⊢
-    convert h.isOpenMap.prodMap h.isOpenMap _ H
-    exact ((h.surjective.prodMap h.surjective).image_preimage _).symm
+    convert h.isOpenMap _ H
+    exact (h.surjective.image_preimage _).symm
 
 theorem tendsto_nhds_unique [T2Space X] {f : Y → X} {l : Filter Y} {a b : X} [NeBot l]
     (ha : Tendsto f l (𝓝 a)) (hb : Tendsto f l (𝓝 b)) : a = b :=

--- a/Mathlib/Topology/Separation/Hausdorff.lean
+++ b/Mathlib/Topology/Separation/Hausdorff.lean
@@ -167,15 +167,14 @@ theorem t2_iff_isClosed_diagonal : T2Space X ↔ IsClosed (diagonal X) := by
 theorem isClosed_diagonal [T2Space X] : IsClosed (diagonal X) :=
   t2_iff_isClosed_diagonal.mp ‹_›
 
-theorem t2Space_iff_of_continuous_of_surjective_of_isOpenMap [TopologicalSpace Y] {π : X → Y}
-    (hcont : Continuous π) (hsurj : Surjective π) (hop : IsOpenMap π) :
-    T2Space Y ↔ IsClosed {q : X × X | π q.1 = π q.2} := by
+theorem t2Space_iff_of_isOpenQuotientMap [TopologicalSpace Y] {π : X → Y}
+    (h : IsOpenQuotientMap π) : T2Space Y ↔ IsClosed {q : X × X | π q.1 = π q.2} := by
   rw [t2_iff_isClosed_diagonal]
   constructor <;> intro H
-  · exact H.preimage (hcont.prodMap hcont)
+  · exact H.preimage (h.continuous.prodMap h.continuous)
   · simp_rw [← isOpen_compl_iff] at H ⊢
-    convert hop.prodMap hop _ H
-    exact ((hsurj.prodMap hsurj).image_preimage _).symm
+    convert h.isOpenMap.prodMap h.isOpenMap _ H
+    exact ((h.surjective.prodMap h.surjective).image_preimage _).symm
 
 theorem tendsto_nhds_unique [T2Space X] {f : Y → X} {l : Filter Y} {a b : X} [NeBot l]
     (ha : Tendsto f l (𝓝 a)) (hb : Tendsto f l (𝓝 b)) : a = b :=

--- a/Mathlib/Topology/Separation/Hausdorff.lean
+++ b/Mathlib/Topology/Separation/Hausdorff.lean
@@ -167,6 +167,16 @@ theorem t2_iff_isClosed_diagonal : T2Space X ↔ IsClosed (diagonal X) := by
 theorem isClosed_diagonal [T2Space X] : IsClosed (diagonal X) :=
   t2_iff_isClosed_diagonal.mp ‹_›
 
+theorem t2Space_iff_of_continuous_of_surjective_of_isOpenMap [TopologicalSpace Y] {π : X → Y}
+    (hcont : Continuous π) (hsurj : Surjective π) (hop : IsOpenMap π) :
+    T2Space Y ↔ IsClosed {q : X × X | π q.1 = π q.2} := by
+  rw [t2_iff_isClosed_diagonal]
+  constructor <;> intro H
+  · exact H.preimage (hcont.prodMap hcont)
+  · simp_rw [← isOpen_compl_iff] at H ⊢
+    convert hop.prodMap hop _ H
+    exact ((hsurj.prodMap hsurj).image_preimage _).symm
+
 theorem tendsto_nhds_unique [T2Space X] {f : Y → X} {l : Filter Y} {a b : X} [NeBot l]
     (ha : Tendsto f l (𝓝 a)) (hb : Tendsto f l (𝓝 b)) : a = b :=
   (tendsto_nhds_unique_inseparable ha hb).eq

--- a/Mathlib/Topology/Separation/Hausdorff.lean
+++ b/Mathlib/Topology/Separation/Hausdorff.lean
@@ -171,11 +171,10 @@ theorem t2Space_iff_of_isOpenQuotientMap [TopologicalSpace Y] {π : X → Y}
     (h : IsOpenQuotientMap π) : T2Space Y ↔ IsClosed {q : X × X | π q.1 = π q.2} := by
   rw [t2_iff_isClosed_diagonal]
   replace h := IsOpenQuotientMap.prodMap h h
-  constructor <;> intro H
-  · exact H.preimage h.continuous
-  · simp_rw [← isOpen_compl_iff] at H ⊢
-    convert h.isOpenMap _ H
-    exact (h.surjective.image_preimage _).symm
+  refine ⟨fun H ↦ H.preimage h.continuous, fun H ↦ ?_⟩
+  simp_rw [← isOpen_compl_iff] at H ⊢
+  convert h.isOpenMap _ H
+  exact (h.surjective.image_preimage _).symm
 
 theorem tendsto_nhds_unique [T2Space X] {f : Y → X} {l : Filter Y} {a b : X} [NeBot l]
     (ha : Tendsto f l (𝓝 a)) (hb : Tendsto f l (𝓝 b)) : a = b :=


### PR DESCRIPTION
From sphere-eversion.

---
<!-- Your PR title will become the first line of the commit message.

In this box, the text above the `---` (if not empty) will be appended
to the commit message, and can be used to give additional context or
details. Please leave a blank newline before the `---`, otherwise GitHub
will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

When merging, all the commits will be squashed into a single commit
listing all co-authors.

Co-authors in the squash commit are gathered from two sources:

First, all authors of commits to this PR branch are included. Thus,
one way to add co-authors is to include at least one commit authored by
each co-author among the commits in the pull request. If necessary, you
may create empty commits to indicate co-authorship, using commands like so:

git commit --author="Author Name <author@email.com>" --allow-empty -m "add Author Name as coauthor"

Second, co-authors can also be listed in lines at the very bottom of
the commit message (that is, directly before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines
at the bottom of the commit message (before the `---`, and also before
any "Co-authored-by" lines) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
