### PR TITLE
[Merged by Bors] - refactor: turn `RootSystem` into a mixin rather than extending `RootPairing`

### DIFF
--- a/Mathlib/Algebra/Lie/Weights/IsSimple.lean
+++ b/Mathlib/Algebra/Lie/Weights/IsSimple.lean
@@ -130,7 +130,7 @@ private theorem chi_not_in_q_aux (h_chi_not_in_q : ↑χ ∉ q) :
   obtain ⟨i, hi⟩ := exists_root_index χ (Weight.coe_toLinear_ne_zero_iff.mp w_chi)
   obtain ⟨j, hj⟩ := exists_root_index α hα₀
   have h_pairing_zero : S.pairing i j = 0 := by
-    apply RootPairing.pairing_eq_zero_of_add_notMem_of_sub_notMem S.toRootPairing
+    apply RootPairing.pairing_eq_zero_of_add_notMem_of_sub_notMem S
     · intro h_eq; exact w_minus (by rw [← hi, ← hj, h_eq, sub_self])
     · intro h_eq; exact w_plus (by rw [← hi, ← hj, h_eq, neg_add_cancel])
     · intro ⟨idx, hidx⟩
@@ -420,8 +420,7 @@ lemma eq_top_of_invtSubmodule_ne_bot (q : Submodule K (Dual K H))
 
 instance : (rootSystem H).IsIrreducible := by
   have _i := nontrivial_of_isIrreducible K L L
-  exact RootPairing.IsIrreducible.mk' (rootSystem H).toRootPairing <|
-    eq_top_of_invtSubmodule_ne_bot
+  exact RootPairing.IsIrreducible.mk' (rootSystem H) <| eq_top_of_invtSubmodule_ne_bot
 
 end IsSimple
 

--- a/Mathlib/Algebra/Lie/Weights/RootSystem.lean
+++ b/Mathlib/Algebra/Lie/Weights/RootSystem.lean
@@ -382,8 +382,8 @@ variable (H)
 /-- The root system of a finite-dimensional Lie algebra with non-degenerate Killing form over a
 field of characteristic zero, relative to a splitting Cartan subalgebra. -/
 def rootSystem :
-    RootSystem H.root K (Dual K H) H :=
-  RootSystem.mk'
+    RootPairing H.root K (Dual K H) H :=
+  RootPairing.mk''
     .id
     { toFun := (↑)
       inj' := by
@@ -396,8 +396,10 @@ def rootSystem :
       simpa using
         ⟨reflectRoot α β, by simpa using reflectRoot_isNonZero α β <| by simpa using hβ, rfl⟩)
     (by convert span_weight_isNonZero_eq_top K L H; ext; simp)
-    (fun α β ↦
-      ⟨chainBotCoeff β.1 α.1 - chainTopCoeff β.1 α.1, by simp [apply_coroot_eq_cast β.1 α.1]⟩)
+
+instance : (rootSystem H).IsRootSystem :=
+  RootPairing.isRootSystem_mk'' fun α β ↦
+    ⟨chainBotCoeff β.1 α.1 - chainTopCoeff β.1 α.1, by simp [apply_coroot_eq_cast β.1 α.1]⟩
 
 @[simp]
 lemma corootForm_rootSystem_eq_killing :

--- a/Mathlib/LinearAlgebra/RootSystem/Base.lean
+++ b/Mathlib/LinearAlgebra/RootSystem/Base.lean
@@ -294,7 +294,7 @@ end RootPairing
 
 section RootSystem
 
-variable {P : RootSystem ι R M N} (b : P.Base)
+variable {P : RootPairing ι R M N} (b : P.Base) [P.IsRootSystem]
 
 /-- A base of a root system yields a basis of the root space. -/
 def toWeightBasis :

--- a/Mathlib/LinearAlgebra/RootSystem/BaseChange.lean
+++ b/Mathlib/LinearAlgebra/RootSystem/BaseChange.lean
@@ -46,7 +46,7 @@ class IsBalanced {ι R M N : Type*} [AddCommGroup M] [AddCommGroup N]
   isPerfectCompl : P.toLinearMap.IsPerfectCompl (P.rootSpan R) (P.corootSpan R)
 
 instance {ι R M N : Type*} [AddCommGroup M] [AddCommGroup N]
-    [CommRing R] [Module R M] [Module R N] (P : RootSystem ι R M N) :
+    [CommRing R] [Module R M] [Module R N] (P : RootPairing ι R M N) [P.IsRootSystem] :
     P.IsBalanced where
   isPerfectCompl := by simp
 
@@ -66,10 +66,9 @@ variable (hP : ∀ i j, P.pairing i j ∈ (algebraMap K L).range)
 
 /-- Restriction of scalars for a root pairing taking values in a subfield.
 
-Note that we obtain a root system (not just a root pairing). See also
-`RootPairing.restrictScalars`. -/
+See also `RootPairing.restrictScalars`. -/
 def restrictScalars' :
-    RootSystem ι K (span K (range P.root)) (span K (range P.coroot)) where
+    RootPairing ι K (span K (range P.root)) (span K (range P.coroot)) where
   toLinearMap := .restrictScalarsRange₂ (R := L)
     (span K (range P.root)).subtype (span K (range P.coroot)).subtype (Algebra.linearMap K L)
     (FaithfulSMul.algebraMap_injective K L) P.toLinearMap fun x y ↦
@@ -90,16 +89,18 @@ def restrictScalars' :
     ext; simpa [algebra_compatible_smul L] using P.reflectionPerm_root i j
   reflectionPerm_coroot i j := by
     ext; simpa [algebra_compatible_smul L] using P.reflectionPerm_coroot i j
+
+instance : (P.restrictScalars' K hP).IsRootSystem where
   span_root_eq_top := by
     rw [← span_setOf_mem_eq_top]
     congr
     ext ⟨x, hx⟩
-    simp
+    simp [restrictScalars']
   span_coroot_eq_top := by
     rw [← span_setOf_mem_eq_top]
     congr
     ext ⟨x, hx⟩
-    simp
+    simp [restrictScalars']
 
 @[simp] lemma restrictScalars_toLinearMap_apply_apply
     (x : span K (range P.root)) (y : span K (range P.coroot)) :
@@ -123,7 +124,7 @@ end SubfieldValued
 
 /-- Restriction of scalars for a crystallographic root pairing. -/
 abbrev restrictScalars [P.IsCrystallographic] :
-    RootSystem ι K (span K (range P.root)) (span K (range P.coroot)) :=
+    RootPairing ι K (span K (range P.root)) (span K (range P.coroot)) :=
   P.restrictScalars' K (IsValuedIn.trans P K ℤ).exists_value
 
 /-- Restriction of scalars to `ℚ` for a crystallographic root pairing in characteristic zero. -/

--- a/Mathlib/LinearAlgebra/RootSystem/Basic.lean
+++ b/Mathlib/LinearAlgebra/RootSystem/Basic.lean
@@ -178,35 +178,25 @@ def mk' [CharZero R] [NoZeroSMulDivisors R M]
     refine (coroot_eq_coreflection_of_root_eq' p root coroot hp hr hc ?_).symm
     rw [equiv_of_mapsTo_apply, (exist_eq_reflection_of_mapsTo p root coroot i j hr).choose_spec]
 
-end RootPairing
-
-namespace RootSystem
-
-open RootPairing
-
-variable [Finite ι] (P : RootSystem ι R M N)
+variable [P.IsRootSystem]
 
 /-- In characteristic zero if there is no torsion, a finite root system is determined entirely by
 its roots. -/
-@[ext]
-protected lemma ext [CharZero R] [NoZeroSMulDivisors R M]
-    {P₁ P₂ : RootSystem ι R M N}
+protected lemma IsRootSystem.ext [CharZero R] [NoZeroSMulDivisors R M]
+    {P₁ P₂ : RootPairing ι R M N} [P₁.IsRootSystem] [P₂.IsRootSystem]
     (he : P₁.toLinearMap = P₂.toLinearMap)
     (hr : P₁.root = P₂.root) :
     P₁ = P₂ := by
-  suffices ∀ P₁ P₂ : RootSystem ι R M N, P₁.toLinearMap = P₂.toLinearMap →
-      P₁.root = P₂.root → range P₁.coroot ⊆ range P₂.coroot by
+  suffices ∀ (P₁ P₂ : RootPairing ι R M N) [P₁.IsRootSystem] [P₂.IsRootSystem],
+      P₁.toLinearMap = P₂.toLinearMap → P₁.root = P₂.root → range P₁.coroot ⊆ range P₂.coroot by
     have h₁ := this P₁ P₂ he hr
     have h₂ := this P₂ P₁ he.symm hr.symm
-    obtain ⟨P₁⟩ := P₁
-    obtain ⟨P₂⟩ := P₂
-    congr
     exact RootPairing.ext he hr (le_antisymm h₁ h₂)
   clear! P₁ P₂
-  rintro P₁ P₂ he hr - ⟨i, rfl⟩
+  rintro P₁ P₂ hP₁ hP₂ he hr - ⟨i, rfl⟩
   use i
   apply P₁.flip.toPerfPair.injective
-  apply Dual.eq_of_preReflection_mapsTo (finite_range P₁.root) P₁.span_root_eq_top
+  apply Dual.eq_of_preReflection_mapsTo (finite_range P₁.root) IsRootSystem.span_root_eq_top
   · exact hr ▸ he ▸ P₂.coroot_root_two i
   · change MapsTo (preReflection _ (P₁.toLinearMap.flip.toPerfPair _)) _ _
     simp_rw [hr, he]
@@ -243,28 +233,37 @@ private lemma coroot_eq_coreflection_of_root_eq_of_span_eq_top [CharZero R] [NoZ
   · rw [hk, LinearMap.toLinearMap_toPerfPair, hij]
     exact (hs i).comp <| (hs j).comp (hs i)
 
+section
+
+variable {k : Type*} [Field k] [CharZero k] [Module k M] [Module k N]
+  (p : M →ₗ[k] N →ₗ[k] k) [p.IsPerfPair]
+  (root : ι ↪ M)
+  (coroot : ι ↪ N)
+  (hp : ∀ i, p (root i) (coroot i) = 2)
+  (hs : ∀ i, MapsTo (preReflection (root i) (p.flip (coroot i))) (range root) (range root))
+  (hsp : span k (range root) = ⊤)
+
 /-- Over a field of characteristic zero, to check that a finite family of roots form a
 crystallographic root system, we do not need to check that the coroots are stable under reflections
 since this follows from the corresponding property for the roots. Likewise, we do not need to
 check that the coroots span. -/
-def mk' {k : Type*} [Field k] [CharZero k] [Module k M] [Module k N]
-    (p : M →ₗ[k] N →ₗ[k] k) [p.IsPerfPair]
-    (root : ι ↪ M)
-    (coroot : ι ↪ N)
-    (hp : ∀ i, p (root i) (coroot i) = 2)
-    (hs : ∀ i, MapsTo (preReflection (root i) (p.flip (coroot i))) (range root) (range root))
-    (hsp : span k (range root) = ⊤)
-    (h_int : ∀ i j, ∃ z : ℤ, z = p (root i) (coroot j)) :
-    RootSystem ι k M N :=
-  let P := RootPairing.mk' p root coroot hp hs <| by
+def mk'' :
+    RootPairing ι k M N :=
+  .mk' p root coroot hp hs <| by
     rintro i - ⟨j, rfl⟩
     use RootPairing.equiv_of_mapsTo p root coroot i hs hp j
     refine (coroot_eq_coreflection_of_root_eq_of_span_eq_top p root coroot hp hs hsp ?_)
     rw [equiv_of_mapsTo_apply, (exist_eq_reflection_of_mapsTo  p root coroot i j hs).choose_spec]
-  have _i : P.IsCrystallographic := ⟨h_int⟩
-  have _i : Fintype ι := Fintype.ofFinite ι
-  { toRootPairing := P,
-    span_root_eq_top := hsp,
-    span_coroot_eq_top := P.rootSpan_eq_top_iff.mp hsp }
 
-end RootSystem
+variable {p root coroot hp hs hsp} in
+lemma isRootSystem_mk'' (h_int : ∀ i j, ∃ z : ℤ, z = p (root i) (coroot j)) :
+    (mk'' p root coroot hp hs hsp).IsRootSystem where
+  span_root_eq_top := hsp
+  span_coroot_eq_top :=
+    have _i : (mk'' p root coroot hp hs hsp).IsCrystallographic := ⟨h_int⟩
+    have _i : Fintype ι := Fintype.ofFinite ι
+    (rootSpan_eq_top_iff _).mp hsp
+
+end
+
+end RootPairing

--- a/Mathlib/LinearAlgebra/RootSystem/Basic.lean
+++ b/Mathlib/LinearAlgebra/RootSystem/Basic.lean
@@ -204,6 +204,8 @@ protected lemma IsRootSystem.ext [CharZero R] [NoZeroSMulDivisors R M]
   · exact P₁.coroot_root_two i
   · exact P₁.mapsTo_reflection_root i
 
+@[deprecated (since := "2025-12-14")] alias _root_.RootSystem.ext := IsRootSystem.ext
+
 private lemma coroot_eq_coreflection_of_root_eq_of_span_eq_top [CharZero R] [NoZeroSMulDivisors R M]
     (p : M →ₗ[R] N →ₗ[R] R) [p.IsPerfPair]
     (root : ι ↪ M)
@@ -254,6 +256,8 @@ def mk'' :
     use RootPairing.equiv_of_mapsTo p root coroot i hs hp j
     refine (coroot_eq_coreflection_of_root_eq_of_span_eq_top p root coroot hp hs hsp ?_)
     rw [equiv_of_mapsTo_apply, (exist_eq_reflection_of_mapsTo  p root coroot i j hs).choose_spec]
+
+@[deprecated (since := "2025-12-14")] noncomputable alias _root_.RootSystem.mk' := mk''
 
 variable {p root coroot hp hs hsp} in
 lemma isRootSystem_mk'' (h_int : ∀ i j, ∃ z : ℤ, z = p (root i) (coroot j)) :

--- a/Mathlib/LinearAlgebra/RootSystem/CartanMatrix.lean
+++ b/Mathlib/LinearAlgebra/RootSystem/CartanMatrix.lean
@@ -67,7 +67,7 @@ lemma cartanMatrixIn_apply_same [FaithfulSMul S R] (i : b.support) :
 /- If we generalised the notion of `RootPairing.Base` to work relative to an assumption
 `[P.IsValuedIn S]` then such a base would provide basis of `P.rootSpan S` and we could avoid
 using `Matrix.map` below. -/
-lemma cartanMatrixIn_mul_diagonal_eq {P : RootSystem ι R M N} [P.IsValuedIn S]
+lemma cartanMatrixIn_mul_diagonal_eq {P : RootPairing ι R M N} [P.IsRootSystem] [P.IsValuedIn S]
     (B : P.InvariantForm) (b : P.Base) [DecidableEq ι] :
     (b.cartanMatrixIn S).map (algebraMap S R) *
       (Matrix.diagonal fun i : b.support ↦ B.form (P.root i) (P.root i)) =
@@ -76,7 +76,8 @@ lemma cartanMatrixIn_mul_diagonal_eq {P : RootSystem ι R M N} [P.IsValuedIn S]
   simp [B.two_mul_apply_root_root]
 
 lemma cartanMatrixIn_nondegenerate [IsDomain R] [NeZero (2 : R)] [FaithfulSMul S R] [IsDomain S]
-    {P : RootSystem ι R M N} [P.IsValuedIn S] [Fintype ι] [P.IsAnisotropic] (b : P.Base) :
+    {P : RootPairing ι R M N} [P.IsRootSystem] [P.IsValuedIn S] [Fintype ι] [P.IsAnisotropic]
+    (b : P.Base) :
     (b.cartanMatrixIn S).Nondegenerate := by
   classical
   obtain ⟨B, hB⟩ : ∃ B : P.InvariantForm, B.form.Nondegenerate :=
@@ -163,7 +164,7 @@ lemma cartanMatrix_map_abs [DecidableEq ι] :
   ext; simp [abs_cartanMatrix_apply, Matrix.ofNat_apply]
 
 lemma cartanMatrix_nondegenerate
-    {P : RootSystem ι R M N} [P.IsCrystallographic] (b : P.Base) :
+    {P : RootPairing ι R M N} [P.IsRootSystem] [P.IsCrystallographic] (b : P.Base) :
     b.cartanMatrix.Nondegenerate :=
   let _i : Fintype ι := Fintype.ofFinite ι
   cartanMatrixIn_nondegenerate ℤ b
@@ -206,7 +207,8 @@ lemma induction_on_cartanMatrix [P.IsReduced] [P.IsIrreducible]
   simp [← hq_mem, IsIrreducible.eq_top_of_invtSubmodule_reflection q hq hq₀]
 
 open scoped Matrix in
-lemma injective_pairingIn {P : RootSystem ι R M N} [P.IsCrystallographic] (b : P.Base) :
+lemma injective_pairingIn {P : RootPairing ι R M N} [P.IsRootSystem] [P.IsCrystallographic]
+    (b : P.Base) :
     Injective (fun i (k : b.support) ↦ P.pairingIn ℤ i k) := by
   classical
   intro i j hij
@@ -241,7 +243,7 @@ lemma injective_pairingIn {P : RootSystem ι R M N} [P.IsCrystallographic] (b : 
 
 lemma exists_mem_span_pairingIn_ne_zero_and_pairwise_ne
     {K : Type*} [Field K] [CharZero K] [Module K M] [Module K N]
-    {P : RootSystem ι K M N} [P.IsCrystallographic] (b : P.Base) :
+    {P : RootPairing ι K M N} [P.IsRootSystem] [P.IsCrystallographic] (b : P.Base) :
     ∃ d ∈ span K (range fun (i : b.support) j ↦ (P.pairingIn ℤ j i : K)),
       (∀ i, d i ≠ 0) ∧ Pairwise ((· ≠ ·) on d) := by
   set p := span K (range fun (i : b.support) j ↦ (P.pairingIn ℤ j i : K))
@@ -266,8 +268,8 @@ lemma exists_mem_span_pairingIn_ne_zero_and_pairwise_ne
 section Uniqueness
 
 variable {ι₂ M₂ N₂ : Type*} [AddCommGroup M₂] [Module R M₂] [AddCommGroup N₂] [Module R N₂]
-  {P : RootSystem ι R M N} [P.IsCrystallographic] [P.IsReduced] (b : P.Base)
-  {P₂ : RootSystem ι₂ R M₂ N₂} [P₂.IsCrystallographic] (b₂ : P₂.Base)
+  {P : RootPairing ι R M N} [P.IsRootSystem] [P.IsCrystallographic] [P.IsReduced] (b : P.Base)
+  {P₂ : RootPairing ι₂ R M₂ N₂} [P₂.IsCrystallographic] (b₂ : P₂.Base)
   (e : b.support ≃ b₂.support)
 
 lemma apply_mem_range_root_of_cartanMatrixEq
@@ -294,9 +296,9 @@ lemma apply_mem_range_root_of_cartanMatrixEq
     exact mem_range_self _
 
 /-- A root system is determined by its Cartan matrix. -/
-def equivOfCartanMatrixEq [Finite ι₂] [P₂.IsReduced]
+def equivOfCartanMatrixEq [Finite ι₂] [P₂.IsRootSystem] [P₂.IsReduced]
     (he : ∀ i j, b₂.cartanMatrix (e i) (e j) = b.cartanMatrix i j) :
-    P.Equiv P₂.toRootPairing :=
+    P.Equiv P₂ :=
   let f : M ≃ₗ[R] M₂ := b.toWeightBasis.equiv b₂.toWeightBasis e
   have hf : ∀ m, f m ∈ range P₂.root ↔ m ∈ range P.root := by
     refine fun m ↦ ⟨fun h ↦ ?_, fun h ↦ ?_⟩

--- a/Mathlib/LinearAlgebra/RootSystem/Defs.lean
+++ b/Mathlib/LinearAlgebra/RootSystem/Defs.lean
@@ -107,21 +107,18 @@ are necessarily free. Moreover Lean knows this, e.g., via `PerfectPairing.reflex
 `Module.instNoZeroSMulDivisorsOfIsDomain`, `Module.free_of_finite_type_torsion_free'`. -/
 abbrev RootDatum (X₁ X₂ : Type*) [AddCommGroup X₁] [AddCommGroup X₂] := RootPairing ι ℤ X₁ X₂
 
-/-- A root system is a root pairing for which the roots and coroots span their ambient modules.
-
-Note that this is slightly more general than the usual definition in the sense that `N` is not
-required to be the dual of `M`. -/
-structure RootSystem extends RootPairing ι R M N where
-  span_root_eq_top : span R (range root) = ⊤
-  span_coroot_eq_top : span R (range coroot) = ⊤
-
-attribute [simp] RootSystem.span_root_eq_top
-attribute [simp] RootSystem.span_coroot_eq_top
-
 namespace RootPairing
 
 variable {ι R M N}
 variable (P : RootPairing ι R M N) (i j : ι)
+
+/-- A root system is a root pairing for which the roots and coroots span their ambient modules. -/
+class IsRootSystem : Prop where
+  span_root_eq_top : span R (range P.root) = ⊤
+  span_coroot_eq_top : span R (range P.coroot) = ⊤
+
+attribute [simp] IsRootSystem.span_root_eq_top
+attribute [simp] IsRootSystem.span_coroot_eq_top
 
 @[deprecated "Now a syntactic equality" (since := "2025-07-05"), nolint synTaut]
 lemma toLinearMap_eq_toPerfectPairing (x : M) (y : N) :
@@ -148,22 +145,9 @@ variable (ι R M N) in
   toFun P := P.flip
   invFun P := P.flip
 
-/-- If we interchange the roles of `M` and `N`, we still have a root system. -/
-protected def _root_.RootSystem.flip (P : RootSystem ι R M N) : RootSystem ι R N M :=
-  { toRootPairing := P.toRootPairing.flip
-    span_root_eq_top := P.span_coroot_eq_top
-    span_coroot_eq_top := P.span_root_eq_top }
-
-@[simp]
-protected lemma _root_.RootSystem.flip_flip (P : RootSystem ι R M N) :
-    P.flip.flip = P :=
-  rfl
-
-variable (ι R M N) in
-/-- `RootSystem.flip` as an equivalence. -/
-@[simps] def _root_.RootSystem.flipEquiv : RootSystem ι R N M ≃ RootSystem ι R M N where
-  toFun P := P.flip
-  invFun P := P.flip
+instance [P.IsRootSystem] : P.flip.IsRootSystem where
+    span_root_eq_top := IsRootSystem.span_coroot_eq_top
+    span_coroot_eq_top := IsRootSystem.span_root_eq_top
 
 lemma ne_zero [NeZero (2 : R)] : (P.root i : M) ≠ 0 :=
   fun h ↦ NeZero.ne' (2 : R) <| by simpa [h] using P.root_coroot_two i
@@ -590,15 +574,15 @@ lemma reflectionPerm_eq_reflectionPerm_iff_of_span :
 @[deprecated (since := "2025-05-28")]
 alias reflection_perm_eq_reflection_perm_iff_of_span := reflectionPerm_eq_reflectionPerm_iff_of_span
 
-lemma _root_.RootSystem.reflectionPerm_eq_reflectionPerm_iff (P : RootSystem ι R M N) (i j : ι) :
+lemma reflectionPerm_eq_reflectionPerm_iff [P.IsRootSystem] (i j : ι) :
     P.reflectionPerm i = P.reflectionPerm j ↔ P.reflection i = P.reflection j := by
   refine ⟨fun h ↦ ?_, fun h ↦ Equiv.ext fun k ↦ P.root.injective <| by simp [h]⟩
   ext x
   exact (P.reflectionPerm_eq_reflectionPerm_iff_of_span i j).mp h x <| by simp
 
-@[deprecated (since := "2025-05-28")]
-alias _root_.RootSystem.reflection_perm_eq_reflection_perm_iff :=
-  _root_.RootSystem.reflectionPerm_eq_reflectionPerm_iff
+-- @[deprecated (since := "2025-05-28")]
+-- alias _root_.RootSystem.reflection_perm_eq_reflection_perm_iff :=
+--   _root_.RootSystem.reflectionPerm_eq_reflectionPerm_iff
 
 @[simp] lemma toPerfPair_comp_root : P.toPerfPair ∘ P.root = P.root' := rfl
 
@@ -741,11 +725,8 @@ protected def map (e : ι ≃ ι₂) (f : M ≃ₗ[R] M₂) (g : N ≃ₗ[R] N�
   reflectionPerm_root i j := by simp [reflection_apply]
   reflectionPerm_coroot i j := by simp [coreflection_apply]
 
-/-- Push forward a root system along linear equivalences, also reindexing the (co)roots. -/
-protected def _root_.RootSystem.map {P : RootSystem ι R M N}
-    (e : ι ≃ ι₂) (f : M ≃ₗ[R] M₂) (g : N ≃ₗ[R] N₂) :
-    RootSystem ι₂ R M₂ N₂ where
-  __ := P.toRootPairing.map e f g
+instance [P.IsRootSystem] (e : ι ≃ ι₂) (f : M ≃ₗ[R] M₂) (g : N ≃ₗ[R] N₂) :
+    (P.map e f g).IsRootSystem where
   span_root_eq_top := by simp [Embedding.coe_trans, range_comp, span_image, RootPairing.map]
   span_coroot_eq_top := by simp [Embedding.coe_trans, range_comp, span_image, RootPairing.map]
 

--- a/Mathlib/LinearAlgebra/RootSystem/Defs.lean
+++ b/Mathlib/LinearAlgebra/RootSystem/Defs.lean
@@ -117,6 +117,8 @@ class IsRootSystem : Prop where
   span_root_eq_top : span R (range P.root) = ⊤
   span_coroot_eq_top : span R (range P.coroot) = ⊤
 
+@[deprecated (since := "2025-12-14")] alias RootSystem := IsRootSystem
+
 attribute [simp] IsRootSystem.span_root_eq_top
 attribute [simp] IsRootSystem.span_coroot_eq_top
 
@@ -580,9 +582,12 @@ lemma reflectionPerm_eq_reflectionPerm_iff [P.IsRootSystem] (i j : ι) :
   ext x
   exact (P.reflectionPerm_eq_reflectionPerm_iff_of_span i j).mp h x <| by simp
 
--- @[deprecated (since := "2025-05-28")]
--- alias _root_.RootSystem.reflection_perm_eq_reflection_perm_iff :=
---   _root_.RootSystem.reflectionPerm_eq_reflectionPerm_iff
+@[deprecated (since := "2025-12-14")]
+alias _root_.RootSystem.reflectionPerm_eq_reflectionPerm_iff := reflectionPerm_eq_reflectionPerm_iff
+
+@[deprecated (since := "2025-05-28")]
+alias _root_.RootSystem.reflection_perm_eq_reflection_perm_iff :=
+  _root_.RootSystem.reflectionPerm_eq_reflectionPerm_iff
 
 @[simp] lemma toPerfPair_comp_root : P.toPerfPair ∘ P.root = P.root' := rfl
 

--- a/Mathlib/LinearAlgebra/RootSystem/Finite/G2.lean
+++ b/Mathlib/LinearAlgebra/RootSystem/Finite/G2.lean
@@ -608,7 +608,7 @@ variable [P.IsG2] (b : P.Base) [Finite ι] [CharZero R] [IsDomain R]
   have _i : P.EmbeddedG2 := toEmbeddedG2 P
   have _i : Nonempty ι := IsG2.nonempty P
   rw [← Fintype.card_fin 2, ← Module.finrank_eq_card_basis (EmbeddedG2.basis P),
-    Module.finrank_eq_card_basis (b.toWeightBasis (P := P.toRootSystem)), Fintype.card_coe]
+    Module.finrank_eq_card_basis b.toWeightBasis, Fintype.card_coe]
 
 variable {b} in
 lemma span_eq_rootSpan_int {i j : ι} (hi : i ∈ b.support) (hj : j ∈ b.support) (h_ne : i ≠ j) :

--- a/Mathlib/LinearAlgebra/RootSystem/Finite/Nondegenerate.lean
+++ b/Mathlib/LinearAlgebra/RootSystem/Finite/Nondegenerate.lean
@@ -260,6 +260,9 @@ lemma rootForm_nondegenerate [P.IsRootSystem] :
   LinearMap.BilinForm.nondegenerate_iff_ker_eq_bot.mpr <| by
     simpa using P.disjoint_rootSpan_ker_rootForm
 
+@[deprecated (since := "2025-12-14")]
+alias _root_.RootSystem.rootForm_nondegenerate := rootForm_nondegenerate
+
 end IsDomain
 
 section Field
@@ -380,6 +383,9 @@ lemma rootForm_pos_of_ne_zero {x : M} (hx : x ∈ P.rootSpan R) (h : x ≠ 0) :
 lemma rootForm_anisotropic [P.IsRootSystem] :
     P.RootForm.toQuadraticMap.Anisotropic :=
   fun x ↦ P.eq_zero_of_mem_rootSpan_of_rootForm_self_eq_zero <| by simp
+
+@[deprecated (since := "2025-12-14")]
+alias _root_.RootSystem.rootForm_anisotropic := rootForm_anisotropic
 
 end LinearOrderedCommRing
 

--- a/Mathlib/LinearAlgebra/RootSystem/Finite/Nondegenerate.lean
+++ b/Mathlib/LinearAlgebra/RootSystem/Finite/Nondegenerate.lean
@@ -255,7 +255,7 @@ lemma disjoint_corootSpan_ker_corootForm :
     Disjoint (P.corootSpan R) (LinearMap.ker P.CorootForm) :=
   P.flip.disjoint_rootSpan_ker_rootForm
 
-lemma _root_.RootSystem.rootForm_nondegenerate (P : RootSystem ι R M N) [P.IsAnisotropic] :
+lemma rootForm_nondegenerate [P.IsRootSystem] :
     P.RootForm.Nondegenerate :=
   LinearMap.BilinForm.nondegenerate_iff_ker_eq_bot.mpr <| by
     simpa using P.disjoint_rootSpan_ker_rootForm
@@ -377,10 +377,9 @@ lemma rootForm_pos_of_ne_zero {x : M} (hx : x ∈ P.rootSpan R) (h : x ≠ 0) :
   contrapose! h
   exact P.eq_zero_of_mem_rootSpan_of_rootForm_self_eq_zero hx h.symm
 
-lemma _root_.RootSystem.rootForm_anisotropic (P : RootSystem ι R M N) :
+lemma rootForm_anisotropic [P.IsRootSystem] :
     P.RootForm.toQuadraticMap.Anisotropic :=
-  fun x ↦ P.eq_zero_of_mem_rootSpan_of_rootForm_self_eq_zero <| by
-    simpa only [rootSpan, P.span_root_eq_top] using Submodule.mem_top
+  fun x ↦ P.eq_zero_of_mem_rootSpan_of_rootForm_self_eq_zero <| by simp
 
 end LinearOrderedCommRing
 

--- a/Mathlib/LinearAlgebra/RootSystem/GeckConstruction/Relations.lean
+++ b/Mathlib/LinearAlgebra/RootSystem/GeckConstruction/Relations.lean
@@ -36,7 +36,7 @@ open Set hiding diagonal
 
 variable {ι R M N : Type*} [Finite ι] [CommRing R] [IsDomain R] [CharZero R]
   [AddCommGroup M] [Module R M] [AddCommGroup N] [Module R N]
-  {P : RootSystem ι R M N} [P.IsCrystallographic] {b : P.Base} [Fintype ι]
+  {P : RootPairing ι R M N} [P.IsCrystallographic] {b : P.Base} [Fintype ι]
   (i j : b.support)
 
 attribute [local simp] Ring.lie_def Matrix.mul_apply Matrix.one_apply Matrix.diagonal_apply

--- a/Mathlib/LinearAlgebra/RootSystem/GeckConstruction/Semisimple.lean
+++ b/Mathlib/LinearAlgebra/RootSystem/GeckConstruction/Semisimple.lean
@@ -179,7 +179,7 @@ section Field
 
 variable {ι K M N : Type*} [Field K] [CharZero K] [DecidableEq ι] [Fintype ι]
   [AddCommGroup M] [Module K M] [AddCommGroup N] [Module K N]
-  {P : RootSystem ι K M N} [P.IsCrystallographic] {b : P.Base}
+  {P : RootPairing ι K M N} [P.IsRootSystem] [P.IsCrystallographic] {b : P.Base}
 
 open LieModule Matrix
 
@@ -264,6 +264,7 @@ private lemma instIsIrreducible_aux₁ (U : LieSubmodule K H (b.support ⊕ ι �
   have : ⨆ (χ : H → K), ⨆ (_ : χ ≠ 0), (⊥ : LieSubmodule K H U) = ⊥ := biSup_const ⟨1, one_ne_zero⟩
   rw [← iSup_genWeightSpace_eq_top K H U, iSup_split_single _ 0, biSup_congr hU, this, sup_bot_eq]
 
+omit [P.IsRootSystem] in
 private lemma instIsIrreducible_aux₂ [P.IsReduced] [P.IsIrreducible]
     {U : LieSubmodule K (lieAlgebra b) (b.support ⊕ ι → K)} {i : ι} (hi : v b i ∈ U) :
     U = ⊤ := by
@@ -330,6 +331,7 @@ private lemma instIsIrreducible_aux₂ [P.IsReduced] [P.IsIrreducible]
       exact U.lie_mem (hk aux)
     exact (U.smul_mem_iff (by norm_cast)).mp this
 
+omit [P.IsRootSystem] in
 lemma coe_genWeightSpace_zero_eq_span_range_u :
     genWeightSpace (b.support ⊕ ι → K) (0 : H → K) = span K (range <| u (b := b)) := by
   refine le_antisymm (fun w hw ↦ Pi.mem_span_range_single_inl_iff.mpr fun i ↦ ?_) ?_

--- a/Mathlib/LinearAlgebra/RootSystem/Hom.lean
+++ b/Mathlib/LinearAlgebra/RootSystem/Hom.lean
@@ -484,13 +484,13 @@ instance (P : RootPairing ι R M N) : Group (RootPairing.Equiv P P) where
 /-- For finite roots systems in characteristic zero, a linear equivalence preserving roots, also
 preserves coroots, and is thus an equivalence of root systems. -/
 def mk' [CharZero R] [NoZeroSMulDivisors R M₂] [Finite ι₂]
-    (P : RootSystem ι R M N) (Q : RootSystem ι₂ R M₂ N₂)
+    (P : RootPairing ι R M N) [P.IsRootSystem] (Q : RootPairing ι₂ R M₂ N₂) [Q.IsRootSystem]
     (f : M ≃ₗ[R] M₂) (e : ι ≃ ι₂) (hf : ∀ i, f (P.root i) = Q.root (e i)) :
-    P.Equiv Q.toRootPairing where
+    P.Equiv Q where
   weightMap := f
   coweightMap := Q.flip.toPerfPair.trans (f.dualMap.trans P.flip.toPerfPair.symm)
   indexEquiv := e
-  weight_coweight_transpose := by ext; simp [RootSystem.flip]
+  weight_coweight_transpose := by ext; simp
   root_weightMap := by ext; simp [hf]
   coroot_coweightMap := by
     let g : N ≃ₗ[R] N₂ := P.flip.toPerfPair.trans <| f.symm.dualMap.trans Q.flip.toPerfPair.symm
@@ -499,9 +499,9 @@ def mk' [CharZero R] [NoZeroSMulDivisors R M₂] [Finite ι₂]
       rw [LinearEquiv.coe_coe, comp_apply, ← LinearEquiv.eq_symm_apply]
       conv_lhs => rw [this]
       rfl
-    ext m n
-    · simp [RootSystem.map, RootPairing.map, RootSystem.flip, g]
-    · simp [hf, RootSystem.map, RootPairing.map]
+    apply IsRootSystem.ext <;> ext
+    · simp [RootPairing.map, RootPairing.map, g]
+    · simp [hf, RootPairing.map, RootPairing.map]
   bijective_weightMap := LinearEquiv.bijective _
   bijective_coweightMap := LinearEquiv.bijective _
 

--- a/Mathlib/LinearAlgebra/RootSystem/Irreducible.lean
+++ b/Mathlib/LinearAlgebra/RootSystem/Irreducible.lean
@@ -103,12 +103,11 @@ lemma isSimpleModule_weylGroupRootRep [P.IsIrreducible] :
   P.isSimpleModule_weylGroupRootRep_iff.mpr IsIrreducible.eq_top_of_invtSubmodule_reflection
 
 /-- A nonempty irreducible root pairing is a root system. -/
-def toRootSystem [Nonempty ι] [NeZero (2 : R)] [P.IsIrreducible] : RootSystem ι R M N :=
-  { toRootPairing := P
-    span_root_eq_top := IsIrreducible.eq_top_of_invtSubmodule_reflection
-      (P.rootSpan R) P.rootSpan_mem_invtSubmodule_reflection (P.rootSpan_ne_bot R)
-    span_coroot_eq_top := IsIrreducible.eq_top_of_invtSubmodule_coreflection
-      (P.corootSpan R) P.corootSpan_mem_invtSubmodule_coreflection (P.corootSpan_ne_bot R) }
+instance [Nonempty ι] [NeZero (2 : R)] [P.IsIrreducible] : P.IsRootSystem where
+  span_root_eq_top := IsIrreducible.eq_top_of_invtSubmodule_reflection
+    (P.rootSpan R) P.rootSpan_mem_invtSubmodule_reflection (P.rootSpan_ne_bot R)
+  span_coroot_eq_top := IsIrreducible.eq_top_of_invtSubmodule_coreflection
+    (P.corootSpan R) P.corootSpan_mem_invtSubmodule_coreflection (P.corootSpan_ne_bot R)
 
 lemma invtSubmodule_reflection_of_invtSubmodule_coreflection (i : ι) (q : Submodule R N)
     (hq : q ∈ invtSubmodule (P.coreflection i)) :
@@ -189,10 +188,6 @@ lemma span_root_image_eq_top_of_forall_orthogonal (s : Set ι)
   apply IsIrreducible.eq_top_of_invtSubmodule_reflection _ hq
   simpa using ⟨hne.choose, hne.choose_spec, P.ne_zero _⟩
 
-end RootPairing
-
-namespace RootSystem
-
 /-
 Note that this actually holds for `RootPairing` provided we:
 * assume `RootPairing.IsBalanced`,
@@ -201,7 +196,7 @@ Note that this actually holds for `RootPairing` provided we:
 -/
 lemma eq_top_of_mem_invtSubmodule_of_forall_eq_univ
     {K : Type*} [Field K] [NeZero (2 : K)] [Module K M] [Module K N]
-    (P : RootSystem ι K M N)
+    (P : RootPairing ι K M N) [P.IsRootSystem]
     (q : Submodule K M)
     (h₀ : q ≠ ⊥)
     (h₁ : ∀ i, q ∈ invtSubmodule (P.reflection i))
@@ -215,4 +210,4 @@ lemma eq_top_of_mem_invtSubmodule_of_forall_eq_univ
       simpa [Submodule.disjoint_span_singleton' (P.ne_zero _)] using b
     simpa [h₂ Φ hΦ b c, ← span_le] using b
 
-end RootSystem
+end RootPairing

--- a/Mathlib/LinearAlgebra/RootSystem/IsValuedIn.lean
+++ b/Mathlib/LinearAlgebra/RootSystem/IsValuedIn.lean
@@ -286,11 +286,11 @@ lemma iInf_ker_coroot'_eq :
     (P.corootSpan R).map P.toLinearMap.flip.toPerfPair = span R (range P.coroot') :=
   P.flip.rootSpan_map_toPerfPair
 
-@[simp] lemma span_root'_eq_top (P : RootSystem ι R M N) :
+@[simp] lemma span_root'_eq_top [P.IsRootSystem] :
     span R (range P.root') = ⊤ := by
   simp [← rootSpan_map_toPerfPair]
 
-@[simp] lemma span_coroot'_eq_top (P : RootSystem ι R M N) :
+@[simp] lemma span_coroot'_eq_top [P.IsRootSystem] :
     span R (range P.coroot') = ⊤ :=
   span_root'_eq_top P.flip
 


### PR DESCRIPTION
The motivating benefits are:

- Saving us from having to duplicate instances
- Solving namespace issues such where to put lemmas about `RootPairing.Base` which are true only for `RootSystem`s
- Allowing us to drop a few `.toRootPairing`

I see no downsides.

---
<!-- Your PR title will become the first line of the commit message.

In this box, the text above the `---` (if not empty) will be appended
to the commit message, and can be used to give additional context or
details. Please leave a blank newline before the `---`, otherwise GitHub
will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

When merging, all the commits will be squashed into a single commit
listing all co-authors.

Co-authors in the squash commit are gathered from two sources:

First, all authors of commits to this PR branch are included. Thus,
one way to add co-authors is to include at least one commit authored by
each co-author among the commits in the pull request. If necessary, you
may create empty commits to indicate co-authorship, using commands like so:

git commit --author="Author Name <author@email.com>" --allow-empty -m "add Author Name as coauthor"

Second, co-authors can also be listed in lines at the very bottom of
the commit message (that is, directly before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines
at the bottom of the commit message (before the `---`, and also before
any "Co-authored-by" lines) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
