### PR TITLE
[Merged by Bors] - chore: smaller imports in `IonescuTulcea.traj`

### DIFF
--- a/Mathlib/MeasureTheory/Measure/ProbabilityMeasure.lean
+++ b/Mathlib/MeasureTheory/Measure/ProbabilityMeasure.lean
@@ -211,12 +211,8 @@ protected lemma tendsto_measure_iUnion_accumulate {ι : Type*} [Preorder ι]
 @[simp] theorem apply_le_one (μ : ProbabilityMeasure Ω) (s : Set Ω) : μ s ≤ 1 := by
   simpa using apply_mono μ (subset_univ s)
 
-theorem nonempty (μ : ProbabilityMeasure Ω) : Nonempty Ω := by
-  by_contra maybe_empty
-  have zero : (μ : Measure Ω) univ = 0 := by
-    rw [univ_eq_empty_iff.mpr (not_nonempty_iff.mp maybe_empty), measure_empty]
-  rw [measure_univ] at zero
-  exact zero_ne_one zero.symm
+theorem nonempty (μ : ProbabilityMeasure Ω) : Nonempty Ω :=
+  nonempty_of_isProbabilityMeasure μ
 
 @[ext]
 theorem eq_of_forall_toMeasure_apply_eq (μ ν : ProbabilityMeasure Ω)

--- a/Mathlib/MeasureTheory/Measure/Typeclasses/Probability.lean
+++ b/Mathlib/MeasureTheory/Measure/Typeclasses/Probability.lean
@@ -74,6 +74,12 @@ instance (priority := 100) (μ : Measure α) [IsProbabilityMeasure μ] :
     IsZeroOrProbabilityMeasure μ :=
   ⟨Or.inr measure_univ⟩
 
+theorem nonempty_of_isProbabilityMeasure (μ : Measure α) [IsProbabilityMeasure μ] : Nonempty α := by
+  by_contra! maybe_empty
+  have : μ Set.univ = 0 := by
+    rw [Set.univ_eq_empty_iff.mpr maybe_empty, measure_empty]
+  simp at this
+
 theorem IsProbabilityMeasure.ne_zero (μ : Measure α) [IsProbabilityMeasure μ] : μ ≠ 0 :=
   mt measure_univ_eq_zero.2 <| by simp [measure_univ]
 

--- a/Mathlib/Probability/Kernel/IonescuTulcea/Traj.lean
+++ b/Mathlib/Probability/Kernel/IonescuTulcea/Traj.lean
@@ -7,7 +7,7 @@ module
 
 public import Mathlib.MeasureTheory.Constructions.ProjectiveFamilyContent
 public import Mathlib.MeasureTheory.Function.FactorsThrough
-public import Mathlib.MeasureTheory.Measure.ProbabilityMeasure
+public import Mathlib.MeasureTheory.Integral.Average
 public import Mathlib.MeasureTheory.OuterMeasure.OfAddContent
 public import Mathlib.Probability.Kernel.CondDistrib
 public import Mathlib.Probability.Kernel.IonescuTulcea.PartialTraj
@@ -256,6 +256,13 @@ lemma trajContent_ne_top {a : ℕ} {x : Π i : Iic a, X i} {s : Set (Π n, X n)}
     trajContent κ x s ≠ ∞ :=
   projectiveFamilyContent_ne_top (isProjectiveMeasureFamily_partialTraj κ x)
 
+theorem nonempty_of_isProbabilityMeasure {α : Type*} {m : MeasurableSpace α} (μ : Measure α)
+    [IsProbabilityMeasure μ] : Nonempty α := by
+  by_contra! maybe_empty
+  have : μ Set.univ = 0 := by
+    rw [Set.univ_eq_empty_iff.mpr maybe_empty, measure_empty]
+  simp at this
+
 /-- This is an auxiliary result for `trajContent_tendsto_zero`. Consider `f` a sequence of bounded
 measurable functions such that `f n` depends only on the first coordinates up to `a n`.
 Assume that when integrating `f n` against `partialTraj (k + 1) (a n)`, one gets a non-increasing
@@ -281,7 +288,7 @@ theorem le_lmarginalPartialTraj_succ {f : ℕ → (Π n, X n) → ℝ≥0∞} {a
     | hi m hm =>
       have : Nonempty (Π i : Iic m, X i) :=
         ⟨fun i ↦ @Classical.ofNonempty _ (hm i.1 (mem_Iic.1 i.2))⟩
-      exact ProbabilityMeasure.nonempty ⟨κ m Classical.ofNonempty, inferInstance⟩
+      exact nonempty_of_isProbabilityMeasure (κ m Classical.ofNonempty)
   -- `Fₙ` is the integral of `fₙ` from time `k + 1` to `aₙ`.
   let F n : (Π n, X n) → ℝ≥0∞ := lmarginalPartialTraj κ (k + 1) (a n) (f n)
   -- `Fₙ` converges to `l` by hypothesis.
@@ -353,7 +360,7 @@ theorem trajContent_tendsto_zero {A : ℕ → Set (Π n, X n)}
     | hi m hm =>
       have : Nonempty (Π i : Iic m, X i) :=
         ⟨fun i ↦ @Classical.ofNonempty _ (hm i.1 (mem_Iic.1 i.2))⟩
-      exact ProbabilityMeasure.nonempty ⟨κ m Classical.ofNonempty, inferInstance⟩
+      exact nonempty_of_isProbabilityMeasure (κ m Classical.ofNonempty)
   -- `Aₙ` is a cylinder, it can be written as `cylinder (Iic (a n)) Sₙ`.
   have A_cyl n : ∃ a S, MeasurableSet S ∧ A n = cylinder (Iic a) S := by
     simpa [measurableCylinders_nat] using A_mem n

--- a/Mathlib/Probability/Kernel/IonescuTulcea/Traj.lean
+++ b/Mathlib/Probability/Kernel/IonescuTulcea/Traj.lean
@@ -256,13 +256,6 @@ lemma trajContent_ne_top {a : ℕ} {x : Π i : Iic a, X i} {s : Set (Π n, X n)}
     trajContent κ x s ≠ ∞ :=
   projectiveFamilyContent_ne_top (isProjectiveMeasureFamily_partialTraj κ x)
 
-theorem nonempty_of_isProbabilityMeasure {α : Type*} {m : MeasurableSpace α} (μ : Measure α)
-    [IsProbabilityMeasure μ] : Nonempty α := by
-  by_contra! maybe_empty
-  have : μ Set.univ = 0 := by
-    rw [Set.univ_eq_empty_iff.mpr maybe_empty, measure_empty]
-  simp at this
-
 /-- This is an auxiliary result for `trajContent_tendsto_zero`. Consider `f` a sequence of bounded
 measurable functions such that `f n` depends only on the first coordinates up to `a n`.
 Assume that when integrating `f n` against `partialTraj (k + 1) (a n)`, one gets a non-increasing

--- a/Mathlib/Probability/ProductMeasure.lean
+++ b/Mathlib/Probability/ProductMeasure.lean
@@ -263,7 +263,7 @@ which allows to extend it to the `σ`-algebra by Carathéodory's theorem. -/
 theorem piContent_tendsto_zero {A : ℕ → Set (Π i, X i)} (A_mem : ∀ n, A n ∈ measurableCylinders X)
     (A_anti : Antitone A) (A_inter : ⋂ n, A n = ∅) :
     Tendsto (fun n ↦ piContent μ (A n)) atTop (𝓝 0) := by
-  have : ∀ i, Nonempty (X i) := fun i ↦ ProbabilityMeasure.nonempty ⟨μ i, hμ i⟩
+  have : ∀ i, Nonempty (X i) := fun i ↦ nonempty_of_isProbabilityMeasure (μ i)
   have A_cyl n : ∃ s S, MeasurableSet S ∧ A n = cylinder s S :=
     (mem_measurableCylinders _).1 (A_mem n)
   choose s S mS A_eq using A_cyl


### PR DESCRIPTION
This file doesn't use the topology on the space of probability measures, so it shouldn't need to import `ProbabilityMeasure`. It did, for a lemma that deserves a version for `IsProbabilityMeasure` but only exists for `ProbabilityMeasure`. This PR adds the lemma, uses it in `IonescuTulcea.traj`, and trims the imports.

---
<!-- Your PR title will become the first line of the commit message.

In this box, the text above the `---` (if not empty) will be appended
to the commit message, and can be used to give additional context or
details. Please leave a blank newline before the `---`, otherwise GitHub
will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

When merging, all the commits will be squashed into a single commit
listing all co-authors.

Co-authors in the squash commit are gathered from two sources:

First, all authors of commits to this PR branch are included. Thus,
one way to add co-authors is to include at least one commit authored by
each co-author among the commits in the pull request. If necessary, you
may create empty commits to indicate co-authorship, using commands like so:

git commit --author="Author Name <author@email.com>" --allow-empty -m "add Author Name as coauthor"

Second, co-authors can also be listed in lines at the very bottom of
the commit message (that is, directly before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines
at the bottom of the commit message (before the `---`, and also before
any "Co-authored-by" lines) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
