### PR TITLE
[Merged by Bors] - chore(NumberTheory/NumberField/AdeleRing): split file

### DIFF
--- a/Mathlib.lean
+++ b/Mathlib.lean
@@ -5266,6 +5266,7 @@ public import Mathlib.NumberTheory.NumberField.Ideal
 public import Mathlib.NumberTheory.NumberField.Ideal.Asymptotics
 public import Mathlib.NumberTheory.NumberField.Ideal.Basic
 public import Mathlib.NumberTheory.NumberField.Ideal.KummerDedekind
+public import Mathlib.NumberTheory.NumberField.InfiniteAdeleRing
 public import Mathlib.NumberTheory.NumberField.InfinitePlace.Basic
 public import Mathlib.NumberTheory.NumberField.InfinitePlace.Completion
 public import Mathlib.NumberTheory.NumberField.InfinitePlace.Embeddings

--- a/Mathlib/NumberTheory/NumberField/AdeleRing.lean
+++ b/Mathlib/NumberTheory/NumberField/AdeleRing.lean
@@ -5,35 +5,25 @@ Authors: Salvatore Mercuri, María Inés de Frutos-Fernández
 -/
 module
 
-public import Mathlib.NumberTheory.NumberField.CanonicalEmbedding.Basic
-public import Mathlib.NumberTheory.NumberField.InfinitePlace.Completion
+public import Mathlib.NumberTheory.NumberField.InfiniteAdeleRing
 public import Mathlib.RingTheory.DedekindDomain.FiniteAdeleRing
 
 /-!
 # The adele ring of a number field
 
-This file contains the formalisation of the infinite adele ring of a number field as the
-finite product of completions over its infinite places and the adele ring of a number field as the
+This file contains the formalisation of the adele ring of a number field as the
 direct product of the infinite adele ring and the finite adele ring.
 
 ## Main definitions
 
-- `NumberField.InfiniteAdeleRing` of a number field `K` is defined as the product of
-  the completions of `K` over its infinite places.
-- `NumberField.InfiniteAdeleRing.ringEquiv_mixedSpace` is the ring isomorphism between
-  the infinite adele ring of `K` and `ℝ ^ r₁ × ℂ ^ r₂`, where `(r₁, r₂)` is the signature of `K`.
 - `NumberField.AdeleRing K` is the adele ring of a number field `K`.
 - `NumberField.AdeleRing.principalSubgroup K` is the subgroup of principal adeles `(x)ᵥ`.
-
-## Main results
-- `NumberField.InfiniteAdeleRing.locallyCompactSpace` : the infinite adele ring is a
-  locally compact space.
 
 ## References
 * [J.W.S. Cassels, A. Fröhlich, *Algebraic Number Theory*][cassels1967algebraic]
 
 ## Tags
-infinite adele ring, adele ring, number field
+adele ring, number field
 -/
 
 @[expose] public section
@@ -43,82 +33,6 @@ noncomputable section
 namespace NumberField
 
 open InfinitePlace AbsoluteValue.Completion InfinitePlace.Completion IsDedekindDomain
-
-/-! ## The infinite adele ring
-
-The infinite adele ring is the finite product of completions of a number field over its
-infinite places. See `NumberField.InfinitePlace` for the definition of an infinite place and
-`NumberField.InfinitePlace.Completion` for the associated completion.
--/
-
-/-- The infinite adele ring of a number field. -/
-def InfiniteAdeleRing (K : Type*) [Field K] := (v : InfinitePlace K) → v.Completion
-
-namespace InfiniteAdeleRing
-
-variable (K : Type*) [Field K]
-
-instance : CommRing (InfiniteAdeleRing K) := Pi.commRing
-
-instance : Inhabited (InfiniteAdeleRing K) := ⟨0⟩
-
-instance [NumberField K] : Nontrivial (InfiniteAdeleRing K) :=
-  (inferInstanceAs <| Nonempty (InfinitePlace K)).elim fun w => Pi.nontrivial_at w
-
-instance : TopologicalSpace (InfiniteAdeleRing K) := Pi.topologicalSpace
-
-instance : IsTopologicalRing (InfiniteAdeleRing K) := Pi.instIsTopologicalRing
-
-instance : Algebra K (InfiniteAdeleRing K) := Pi.algebra _ _
-
-@[simp]
-theorem algebraMap_apply (x : K) (v : InfinitePlace K) :
-    algebraMap K (InfiniteAdeleRing K) x v = x := rfl
-
-/-- The infinite adele ring is locally compact. -/
-instance locallyCompactSpace [NumberField K] : LocallyCompactSpace (InfiniteAdeleRing K) :=
-  Pi.locallyCompactSpace_of_finite
-
-open scoped Classical in
-/-- The ring isomorphism between the infinite adele ring of a number field and the
-space `ℝ ^ r₁ × ℂ ^ r₂`, where `(r₁, r₂)` is the signature of the number field. -/
-abbrev ringEquiv_mixedSpace :
-    InfiniteAdeleRing K ≃+* mixedEmbedding.mixedSpace K :=
-  RingEquiv.trans
-    (RingEquiv.piEquivPiSubtypeProd (fun (v : InfinitePlace K) => IsReal v)
-      (fun (v : InfinitePlace K) => v.Completion))
-    (RingEquiv.prodCongr
-      (RingEquiv.piCongrRight (fun ⟨_, hv⟩ => Completion.ringEquivRealOfIsReal hv))
-      (RingEquiv.trans
-        (RingEquiv.piCongrRight (fun v => Completion.ringEquivComplexOfIsComplex
-          ((not_isReal_iff_isComplex.1 v.2))))
-        (RingEquiv.piCongrLeft (fun _ => ℂ) <|
-          Equiv.subtypeEquivRight (fun _ => not_isReal_iff_isComplex))))
-
-@[simp]
-theorem ringEquiv_mixedSpace_apply (x : InfiniteAdeleRing K) :
-    ringEquiv_mixedSpace K x =
-      (fun (v : {w : InfinitePlace K // IsReal w}) => extensionEmbeddingOfIsReal v.2 (x v),
-       fun (v : {w : InfinitePlace K // IsComplex w}) => extensionEmbedding v.1 (x v)) := rfl
-
-/-- Transfers the embedding of `x ↦ (x)ᵥ` of the number field `K` into its infinite adele
-ring to the mixed embedding `x ↦ (φᵢ(x))ᵢ` of `K` into the space `ℝ ^ r₁ × ℂ ^ r₂`, where
-`(r₁, r₂)` is the signature of `K` and `φᵢ` are the complex embeddings of `K`. -/
-theorem mixedEmbedding_eq_algebraMap_comp {x : K} :
-    mixedEmbedding K x = ringEquiv_mixedSpace K (algebraMap K _ x) := by
-  ext v <;> simp
-
-/--
-*Weak approximation for the infinite adele ring*
-
-The number field $K$ is dense in the infinite adele ring $\prod_v K_v$.
--/
-theorem denseRange_algebraMap [NumberField K] : DenseRange <| algebraMap K (InfiniteAdeleRing K) :=
-  (DenseRange.piMap fun _ => UniformSpace.Completion.denseRange_coe).comp
-    (InfinitePlace.denseRange_algebraMap_pi K)
-      (.piMap fun _ => UniformSpace.Completion.continuous_coe _)
-
-end InfiniteAdeleRing
 
 /-! ## The adele ring  -/
 

--- a/Mathlib/NumberTheory/NumberField/InfiniteAdeleRing.lean
+++ b/Mathlib/NumberTheory/NumberField/InfiniteAdeleRing.lean
@@ -1,0 +1,119 @@
+/-
+Copyright (c) 2024 Salvatore Mercuri, María Inés de Frutos-Fernández. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Salvatore Mercuri, María Inés de Frutos-Fernández
+-/
+module
+
+public import Mathlib.NumberTheory.NumberField.CanonicalEmbedding.Basic
+public import Mathlib.NumberTheory.NumberField.InfinitePlace.Completion
+
+/-!
+# The infinite adele ring of a number field
+
+This file contains the formalisation of the infinite adele ring of a number field as the
+finite product of completions over its infinite places.
+
+## Main definitions
+
+- `NumberField.InfiniteAdeleRing` of a number field `K` is defined as the product of
+  the completions of `K` over its infinite places.
+- `NumberField.InfiniteAdeleRing.ringEquiv_mixedSpace` is the ring isomorphism between
+  the infinite adele ring of `K` and `ℝ ^ r₁ × ℂ ^ r₂`, where `(r₁, r₂)` is the signature of `K`.
+
+## Main results
+- `NumberField.InfiniteAdeleRing.locallyCompactSpace` : the infinite adele ring is a
+  locally compact space.
+
+## References
+* [J.W.S. Cassels, A. Fröhlich, *Algebraic Number Theory*][cassels1967algebraic]
+
+## Tags
+infinite adele ring, number field
+-/
+
+@[expose] public section
+
+noncomputable section
+
+namespace NumberField
+
+open InfinitePlace AbsoluteValue.Completion InfinitePlace.Completion IsDedekindDomain
+
+/-! ## The infinite adele ring
+
+The infinite adele ring is the finite product of completions of a number field over its
+infinite places. See `NumberField.InfinitePlace` for the definition of an infinite place and
+`NumberField.InfinitePlace.Completion` for the associated completion.
+-/
+
+/-- The infinite adele ring of a number field. -/
+def InfiniteAdeleRing (K : Type*) [Field K] := (v : InfinitePlace K) → v.Completion
+
+namespace InfiniteAdeleRing
+
+variable (K : Type*) [Field K]
+
+instance : CommRing (InfiniteAdeleRing K) := Pi.commRing
+
+instance : Inhabited (InfiniteAdeleRing K) := ⟨0⟩
+
+instance [NumberField K] : Nontrivial (InfiniteAdeleRing K) :=
+  (inferInstanceAs <| Nonempty (InfinitePlace K)).elim fun w => Pi.nontrivial_at w
+
+instance : TopologicalSpace (InfiniteAdeleRing K) := Pi.topologicalSpace
+
+instance : IsTopologicalRing (InfiniteAdeleRing K) := Pi.instIsTopologicalRing
+
+instance : Algebra K (InfiniteAdeleRing K) := Pi.algebra _ _
+
+@[simp]
+theorem algebraMap_apply (x : K) (v : InfinitePlace K) :
+    algebraMap K (InfiniteAdeleRing K) x v = x := rfl
+
+/-- The infinite adele ring is locally compact. -/
+instance locallyCompactSpace [NumberField K] : LocallyCompactSpace (InfiniteAdeleRing K) :=
+  Pi.locallyCompactSpace_of_finite
+
+open scoped Classical in
+/-- The ring isomorphism between the infinite adele ring of a number field and the
+space `ℝ ^ r₁ × ℂ ^ r₂`, where `(r₁, r₂)` is the signature of the number field. -/
+abbrev ringEquiv_mixedSpace :
+    InfiniteAdeleRing K ≃+* mixedEmbedding.mixedSpace K :=
+  RingEquiv.trans
+    (RingEquiv.piEquivPiSubtypeProd (fun (v : InfinitePlace K) => IsReal v)
+      (fun (v : InfinitePlace K) => v.Completion))
+    (RingEquiv.prodCongr
+      (RingEquiv.piCongrRight (fun ⟨_, hv⟩ => Completion.ringEquivRealOfIsReal hv))
+      (RingEquiv.trans
+        (RingEquiv.piCongrRight (fun v => Completion.ringEquivComplexOfIsComplex
+          ((not_isReal_iff_isComplex.1 v.2))))
+        (RingEquiv.piCongrLeft (fun _ => ℂ) <|
+          Equiv.subtypeEquivRight (fun _ => not_isReal_iff_isComplex))))
+
+@[simp]
+theorem ringEquiv_mixedSpace_apply (x : InfiniteAdeleRing K) :
+    ringEquiv_mixedSpace K x =
+      (fun (v : {w : InfinitePlace K // IsReal w}) => extensionEmbeddingOfIsReal v.2 (x v),
+       fun (v : {w : InfinitePlace K // IsComplex w}) => extensionEmbedding v.1 (x v)) := rfl
+
+/-- Transfers the embedding of `x ↦ (x)ᵥ` of the number field `K` into its infinite adele
+ring to the mixed embedding `x ↦ (φᵢ(x))ᵢ` of `K` into the space `ℝ ^ r₁ × ℂ ^ r₂`, where
+`(r₁, r₂)` is the signature of `K` and `φᵢ` are the complex embeddings of `K`. -/
+theorem mixedEmbedding_eq_algebraMap_comp {x : K} :
+    mixedEmbedding K x = ringEquiv_mixedSpace K (algebraMap K _ x) := by
+  ext v <;> simp
+
+/--
+*Weak approximation for the infinite adele ring*
+
+The number field $K$ is dense in the infinite adele ring $\prod_v K_v$.
+-/
+theorem denseRange_algebraMap [NumberField K] : DenseRange <| algebraMap K (InfiniteAdeleRing K) :=
+  (DenseRange.piMap fun _ => UniformSpace.Completion.denseRange_coe).comp
+    (InfinitePlace.denseRange_algebraMap_pi K)
+      (.piMap fun _ => UniformSpace.Completion.continuous_coe _)
+
+end InfiniteAdeleRing
+
+end NumberField


### PR DESCRIPTION
The file `NumberTheory/NumberField/AdeleRing.lean` is not long but it's doing two different jobs: developing the theory of the infinite adele ring and of the adele ring. Why not do this in two files? This PR does nothing but the split (adding `NumberTheory/NumberField/InfiniteAdeleRing.lean`).

---
<!-- Your PR title will become the first line of the commit message.

In this box, the text above the `---` (if not empty) will be appended
to the commit message, and can be used to give additional context or
details. Please leave a blank newline before the `---`, otherwise GitHub
will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

When merging, all the commits will be squashed into a single commit
listing all co-authors.

Co-authors in the squash commit are gathered from two sources:

First, all authors of commits to this PR branch are included. Thus,
one way to add co-authors is to include at least one commit authored by
each co-author among the commits in the pull request. If necessary, you
may create empty commits to indicate co-authorship, using commands like so:

git commit --author="Author Name <author@email.com>" --allow-empty -m "add Author Name as coauthor"

Second, co-authors can also be listed in lines at the very bottom of
the commit message (that is, directly before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines
at the bottom of the commit message (before the `---`, and also before
any "Co-authored-by" lines) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)

The FLT project has 1000 lines of API for infinite adele rings and 700 for adele rings (on top of 1000 for finite adele rings), and it's got to the point where I'm thinking about upstreaming it, so this is a highly pre-emptive split.