### PR TITLE
[Merged by Bors] - chore: fix whitespace

### DIFF
--- a/Mathlib/Logic/Equiv/Fin/Rotate.lean
+++ b/Mathlib/Logic/Equiv/Fin/Rotate.lean
@@ -93,7 +93,7 @@ theorem lt_finRotate_iff_ne_last (i : Fin (n + 1)) :
 theorem lt_finRotate_iff_ne_neg_one [NeZero n] (i : Fin n) :
     i < finRotate _ i ↔ i ≠ -1 := by
   obtain ⟨n, rfl⟩ := exists_eq_succ_of_ne_zero (NeZero.ne n)
-  rw [lt_finRotate_iff_ne_last, ne_eq, not_iff_not, ←Fin.neg_last, neg_neg]
+  rw [lt_finRotate_iff_ne_last, ne_eq, not_iff_not, ← Fin.neg_last, neg_neg]
 
 @[simp] lemma finRotate_succ_symm_apply [NeZero n] (i : Fin n) : (finRotate _).symm i = i - 1 := by
   obtain ⟨n, rfl⟩ := exists_eq_succ_of_ne_zero (NeZero.ne n)

--- a/Mathlib/Probability/Martingale/OptionalSampling.lean
+++ b/Mathlib/Probability/Martingale/OptionalSampling.lean
@@ -100,7 +100,7 @@ theorem stoppedValue_ae_eq_condExp_of_le_const_of_countable_range (h : Martingal
   intro i hi
   have h_top : i ≠ ⊤ := fun h ↦ by
     simp only [h, Set.mem_range] at hi
-    obtain ⟨ω , hω⟩ := hi
+    obtain ⟨ω, hω⟩ := hi
     specialize hτ_le ω
     simp [hω] at hτ_le
   lift i to ι using h_top with i


### PR DESCRIPTION
Extracted from https://github.com/leanprover-community/mathlib4/pull/30658. Found by extending the commandStart linter to proof bodies.

---
<!-- Your PR title will become the first line of the commit message.

In this box, the text above the `---` (if not empty) will be appended
to the commit message, and can be used to give additional context or
details. Please leave a blank newline before the `---`, otherwise GitHub
will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

When merging, all the commits will be squashed into a single commit
listing all co-authors.

Co-authors in the squash commit are gathered from two sources:

First, all authors of commits to this PR branch are included. Thus,
one way to add co-authors is to include at least one commit authored by
each co-author among the commits in the pull request. If necessary, you
may create empty commits to indicate co-authorship, using commands like so:

git commit --author="Author Name <author@email.com>" --allow-empty -m "add Author Name as coauthor"

Second, co-authors can also be listed in lines at the very bottom of
the commit message (that is, directly before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines
at the bottom of the commit message (before the `---`, and also before
any "Co-authored-by" lines) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
