### PR TITLE
[Merged by Bors] - chore(AlgebraicTopology): fix whitespace

### DIFF
--- a/Mathlib/AlgebraicTopology/DoldKan/EquivalencePseudoabelian.lean
+++ b/Mathlib/AlgebraicTopology/DoldKan/EquivalencePseudoabelian.lean
@@ -109,7 +109,7 @@ theorem hη :
         (N₁Γ₀ : Γ ⋙ N₁ ≅ (toKaroubiEquivalence (ChainComplex C ℕ)).functor) := by
   ext K : 3
   simp only [Compatibility.τ₀_hom_app, Compatibility.τ₁_hom_app]
-  exact (N₂Γ₂_compatible_with_N₁Γ₀ K).trans (by simp )
+  exact (N₂Γ₂_compatible_with_N₁Γ₀ K).trans (by simp)
 
 /-- The counit isomorphism induced by `N₁Γ₀` -/
 @[simps!]

--- a/Mathlib/AlgebraicTopology/ModelCategory/Basic.lean
+++ b/Mathlib/AlgebraicTopology/ModelCategory/Basic.lean
@@ -76,7 +76,7 @@ variable [ModelCategory C]
 
 instance : MorphismProperty.IsWeakFactorizationSystem (trivialCofibrations C) (fibrations C) :=
   MorphismProperty.IsWeakFactorizationSystem.mk' _ _ (fun {A B X Y} i p hi hp ↦ by
-    obtain ⟨_, _⟩ := mem_trivialCofibrations_iff i|>.mp hi
+    obtain ⟨_, _⟩ := mem_trivialCofibrations_iff i |>.mp hi
     rw [← fibration_iff] at hp
     infer_instance)
 

--- a/Mathlib/AlgebraicTopology/SimplexCategory/GeneratorsRelations/EpiMono.lean
+++ b/Mathlib/AlgebraicTopology/SimplexCategory/GeneratorsRelations/EpiMono.lean
@@ -147,7 +147,7 @@ private lemma factor_P_δ_σ {n : ℕ} (i : Fin (n + 1)) {x : SimplexCategoryGen
   induction n generalizing x with
   | zero => cases hf with
     | of _ h => cases h; exact factor_δ_σ _ _
-    | id  => exact ⟨_, _, _, P_σ.σ i, P_δ.id_mem _, by simp⟩
+    | id => exact ⟨_, _, _, P_σ.σ i, P_δ.id_mem _, by simp⟩
     | comp_of j f hf hg =>
       obtain ⟨k⟩ := hg
       obtain ⟨rfl, rfl⟩ | hf' := eq_or_len_le_of_P_δ hf

--- a/Mathlib/AlgebraicTopology/SimplexCategory/GeneratorsRelations/NormalForms.lean
+++ b/Mathlib/AlgebraicTopology/SimplexCategory/GeneratorsRelations/NormalForms.lean
@@ -121,7 +121,7 @@ theorem sortedLT {m L} (hL : IsAdmissible m L) : L.SortedLT :=
 
 @[deprecated (since := "2025-11-27")] alias pairwise := sortedLT
 
-@[deprecated  (since := "2025-10-16")]
+@[deprecated (since := "2025-10-16")]
 alias sorted := pairwise
 
 /-- If `(a :: l)` is `m`-admissible then a is less than all elements of `l` -/
@@ -232,7 +232,7 @@ def simplicialEvalσ (L : List ℕ) : ℕ → ℕ :=
 lemma simplicialEvalσ_of_le_mem (j : ℕ) (hj : ∀ k ∈ L, j ≤ k) : simplicialEvalσ L j = j := by
   induction L with | nil => grind | cons _ _ _ => simp only [List.forall_mem_cons] at hj; grind
 
-@[deprecated  (since := "2025-10-16")]
+@[deprecated (since := "2025-10-16")]
 alias simplicialEvalσ_of_lt_mem := simplicialEvalσ_of_le_mem
 
 lemma simplicialEvalσ_monotone (L : List ℕ) : Monotone (simplicialEvalσ L) := by
@@ -322,7 +322,7 @@ lemma IsAdmissible.simplicialEvalσ_succ_getElem (hL : IsAdmissible m L)
   induction L generalizing m k <;> grind [→ IsAdmissible.singleton]
 
 local grind_pattern IsAdmissible.simplicialEvalσ_succ_getElem =>
-  IsAdmissible m L, simplicialEvalσ L L[k]
+  IsAdmissible m L,simplicialEvalσ L L[k]
 
 lemma mem_isAdmissible_of_lt_and_eval_eq_eval_add_one (hL : IsAdmissible m L)
     (j : ℕ) (hj₁ : j < m + L.length) (hj₂ : simplicialEvalσ L j = simplicialEvalσ L (j + 1)) :

--- a/Mathlib/AlgebraicTopology/SimplexCategory/GeneratorsRelations/NormalForms.lean
+++ b/Mathlib/AlgebraicTopology/SimplexCategory/GeneratorsRelations/NormalForms.lean
@@ -322,7 +322,7 @@ lemma IsAdmissible.simplicialEvalσ_succ_getElem (hL : IsAdmissible m L)
   induction L generalizing m k <;> grind [→ IsAdmissible.singleton]
 
 local grind_pattern IsAdmissible.simplicialEvalσ_succ_getElem =>
-  IsAdmissible m L,simplicialEvalσ L L[k]
+  IsAdmissible m L, simplicialEvalσ L L[k]
 
 lemma mem_isAdmissible_of_lt_and_eval_eq_eval_add_one (hL : IsAdmissible m L)
     (j : ℕ) (hj₁ : j < m + L.length) (hj₂ : simplicialEvalσ L j = simplicialEvalσ L (j + 1)) :

--- a/Mathlib/AlgebraicTopology/SimplicialCategory/SimplicialObject.lean
+++ b/Mathlib/AlgebraicTopology/SimplicialCategory/SimplicialObject.lean
@@ -31,7 +31,7 @@ variable {D : Type u} [Category.{v} D]
 
 namespace SimplicialObject
 
-instance : EnrichedCategory SSet.{v} (SimplicialObject D)  :=
+instance : EnrichedCategory SSet.{v} (SimplicialObject D) :=
   inferInstanceAs (EnrichedCategory (_ ⥤ Type v) (_ ⥤ D))
 
 instance : SimplicialCategory (SimplicialObject D) where

--- a/Mathlib/AlgebraicTopology/SimplicialObject/Split.lean
+++ b/Mathlib/AlgebraicTopology/SimplicialObject/Split.lean
@@ -225,7 +225,7 @@ def isColimit (Δ : SimplexCategoryᵒᵖ) : IsColimit (s.cofan Δ) := s.isColim
 
 @[reassoc]
 theorem cofan_inj_eq {Δ : SimplexCategoryᵒᵖ} (A : IndexSet Δ) :
-    (s.cofan Δ).inj  A = s.ι A.1.unop.len ≫ X.map A.e.op := rfl
+    (s.cofan Δ).inj A = s.ι A.1.unop.len ≫ X.map A.e.op := rfl
 
 theorem cofan_inj_id (n : ℕ) : (s.cofan _).inj (IndexSet.id (op ⦋n⦌)) = s.ι n := by
   simp [IndexSet.id, IndexSet.e, cofan_inj_eq]

--- a/Mathlib/AlgebraicTopology/SimplicialSet/Degenerate.lean
+++ b/Mathlib/AlgebraicTopology/SimplicialSet/Degenerate.lean
@@ -318,11 +318,11 @@ lemma degenerate_app_apply {n : ℕ} {x : X _⦋n⦌} (hx : x ∈ X.degenerate n
   exact ⟨m, hm, g, f.app _ y, by rw [FunctorToTypes.naturality]⟩
 
 lemma degenerate_le_preimage (f : X ⟶ Y) (n : ℕ) :
-    X.degenerate n ⊆ (f.app _)⁻¹' (Y.degenerate n) :=
+    X.degenerate n ⊆ (f.app _) ⁻¹' (Y.degenerate n) :=
   fun _ hx ↦ degenerate_app_apply hx f
 
 lemma image_degenerate_le (f : X ⟶ Y) (n : ℕ) :
-    (f.app _)'' (X.degenerate n) ⊆ Y.degenerate n := by
+    (f.app _) '' (X.degenerate n) ⊆ Y.degenerate n := by
   simpa using degenerate_le_preimage f n
 
 lemma degenerate_iff_of_isIso (f : X ⟶ Y) [IsIso f] {n : ℕ} (x : X _⦋n⦌) :

--- a/Mathlib/AlgebraicTopology/SimplicialSet/HomotopyCat.lean
+++ b/Mathlib/AlgebraicTopology/SimplicialSet/HomotopyCat.lean
@@ -126,7 +126,7 @@ lemma nerveHomEquiv_id (X : OneTruncation₂ ((SSet.truncation 2).obj (nerve C))
 /-- The refl quiver underlying a nerve is isomorphic to the refl quiver underlying the category. -/
 def ofNerve₂ (C : Type u) [Category.{u} C] :
     ReflQuiv.of (OneTruncation₂ ((truncation 2).obj (nerve C))) ≅ ReflQuiv.of C :=
-  ReflQuiv.isoOfEquiv.{u,u} OneTruncation₂.nerveEquiv
+  ReflQuiv.isoOfEquiv.{u, u} OneTruncation₂.nerveEquiv
     (fun _ _ ↦ OneTruncation₂.nerveHomEquiv) nerveHomEquiv_id
 
 lemma nerve_hom_ext {X : (SSet.Truncated 2)} {C : Type u} [Category.{u} C]
@@ -145,7 +145,7 @@ end OneTruncation₂
 category. -/
 @[simps! hom_app_obj hom_app_map inv_app_obj_obj inv_app_obj_map inv_app_map]
 def OneTruncation₂.ofNerve₂.natIso :
-    nerveFunctor₂.{u,u} ⋙ SSet.oneTruncation₂ ≅ ReflQuiv.forget :=
+    nerveFunctor₂.{u, u} ⋙ SSet.oneTruncation₂ ≅ ReflQuiv.forget :=
   NatIso.ofComponents (fun C => OneTruncation₂.ofNerve₂ C)
     (fun F ↦ ReflPrefunctor.ext (by cat_disch) (fun x y f ↦ by
       obtain ⟨f, rfl, rfl⟩ := f
@@ -456,7 +456,7 @@ lemma mapHomotopyCategory_homMk {x y : V _⦋0⦌₂} (e : Edge x y) :
 end
 
 /-- The functor that takes a 2-truncated simplicial set to its homotopy category. -/
-def hoFunctor₂ : SSet.Truncated.{u} 2 ⥤ Cat.{u,u} where
+def hoFunctor₂ : SSet.Truncated.{u} 2 ⥤ Cat.{u, u} where
   obj V := Cat.of V.HomotopyCategory
   map F := mapHomotopyCategory F
   map_id _ := HomotopyCategory.functor_ext (by simp) (by cat_disch)
@@ -482,7 +482,7 @@ def hoFunctor : SSet.{u} ⥤ Cat.{u, u} := SSet.truncation 2 ⋙ Truncated.hoFun
 
 /-- For a simplicial set `X`, the underlying type of `hoFunctor.obj X` is equivalent to `X _⦋0⦌`. -/
 def hoFunctor.obj.equiv (X : SSet) : hoFunctor.obj X ≃ X _⦋0⦌ :=
-  (Quotient.equiv.{u,u} _).trans (Quotient.equiv _)
+  (Quotient.equiv.{u, u} _).trans (Quotient.equiv _)
 
 /-- Since `⦋0⦌ : SimplexCategory` is terminal, `Δ[0]` has a unique point and thus
 `OneTruncation₂ ((truncation 2).obj Δ[0])` has a unique inhabitant. -/

--- a/Mathlib/AlgebraicTopology/SimplicialSet/HornColimits.lean
+++ b/Mathlib/AlgebraicTopology/SimplicialSet/HornColimits.lean
@@ -86,7 +86,7 @@ abbrev ι₁₂ : Δ[1] ⟶ Λ[2, 1] := horn.ι.{u} 1 0 (by simp)
 lemma isPushout :
     IsPushout (stdSimplex.{u}.δ (0 : Fin 2))
       (stdSimplex.{u}.δ (1 : Fin 2)) ι₀₁ ι₁₂ := by
-  apply sq.{u}.isPushout.of_iso' (stdSimplex.faceSingletonIso _ )
+  apply sq.{u}.isPushout.of_iso' (stdSimplex.faceSingletonIso _)
     (stdSimplex.facePairIso _ _ (by simp)) (stdSimplex.facePairIso _ _ (by simp))
     (Iso.refl _)
   all_goals decide
@@ -119,7 +119,7 @@ abbrev ι₁₂ : Δ[1] ⟶ Λ[2, 2] := horn.ι.{u} 2 0 (by simp)
 lemma isPushout :
     IsPushout (stdSimplex.{u}.δ (0 : Fin 2))
       (stdSimplex.{u}.δ (0 : Fin 2)) ι₀₂ ι₁₂ := by
-  fapply sq.{u}.isPushout.of_iso' (stdSimplex.faceSingletonIso _ )
+  fapply sq.{u}.isPushout.of_iso' (stdSimplex.faceSingletonIso _)
     (stdSimplex.facePairIso _ _ (by simp)) (stdSimplex.facePairIso _ _ (by simp))
     (Iso.refl _)
   all_goals decide
@@ -135,7 +135,7 @@ of all `1`-codimensional faces of the standard simplex but one
 along suitable `2`-codimensional faces. -/
 lemma multicoequalizerDiagram :
     Subcomplex.MulticoequalizerDiagram Λ[n, i]
-      (ι := ({i}ᶜ : Set (Fin (n +1)))) (fun j ↦ stdSimplex.face {j.1}ᶜ)
+      (ι := ({i}ᶜ : Set (Fin (n + 1)))) (fun j ↦ stdSimplex.face {j.1}ᶜ)
       (fun j k ↦ stdSimplex.face {j.1, k.1}ᶜ) where
   iSup_eq := by rw [horn_eq_iSup]
   eq_inf j k := by

--- a/Mathlib/AlgebraicTopology/SimplicialSet/Nerve.lean
+++ b/Mathlib/AlgebraicTopology/SimplicialSet/Nerve.lean
@@ -135,7 +135,7 @@ lemma left_edge {x y : ComposableArrows C 0} (e : (nerve C).Edge x y) :
 
 @[simp]
 lemma right_edge {x y : ComposableArrows C 0} (e : (nerve C).Edge x y) :
-    ComposableArrows.right  (n := 1) e.edge = nerveEquiv y := by
+    ComposableArrows.right (n := 1) e.edge = nerveEquiv y := by
   simp only [← e.tgt_eq]
   rfl
 

--- a/Mathlib/AlgebraicTopology/SimplicialSet/StdSimplex.lean
+++ b/Mathlib/AlgebraicTopology/SimplicialSet/StdSimplex.lean
@@ -128,7 +128,7 @@ lemma yonedaEquiv_map {n m : SimplexCategory} (f : n ⟶ m) :
 
 /-- The (degenerate) `m`-simplex in the standard simplex concentrated in vertex `k`. -/
 def const (n : ℕ) (k : Fin (n + 1)) (m : SimplexCategoryᵒᵖ) : Δ[n].obj m :=
-  objMk (OrderHom.const _ k )
+  objMk (OrderHom.const _ k)
 
 @[simp]
 lemma const_down_toOrderHom (n : ℕ) (k : Fin (n + 1)) (m : SimplexCategoryᵒᵖ) :


### PR DESCRIPTION
Found by extending the commandStart linter to proof bodies.

---
<!-- Your PR title will become the first line of the commit message.

In this box, the text above the `---` (if not empty) will be appended
to the commit message, and can be used to give additional context or
details. Please leave a blank newline before the `---`, otherwise GitHub
will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

When merging, all the commits will be squashed into a single commit
listing all co-authors.

Co-authors in the squash commit are gathered from two sources:

First, all authors of commits to this PR branch are included. Thus,
one way to add co-authors is to include at least one commit authored by
each co-author among the commits in the pull request. If necessary, you
may create empty commits to indicate co-authorship, using commands like so:

git commit --author="Author Name <author@email.com>" --allow-empty -m "add Author Name as coauthor"

Second, co-authors can also be listed in lines at the very bottom of
the commit message (that is, directly before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines
at the bottom of the commit message (before the `---`, and also before
any "Co-authored-by" lines) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
