### PR TITLE
[Merged by Bors] - feat(to_fun): generate doc-strings

### DIFF
--- a/Mathlib/Tactic/ToFun.lean
+++ b/Mathlib/Tactic/ToFun.lean
@@ -40,7 +40,8 @@ initialize registerBuiltinAttribute {
   | `(attr| to_fun $[(attr := $stx?,*)]?) => MetaM.run' do
     if (kind != AttributeKind.global) then
       throwError "`to_fun` can only be used as a global attribute"
-    addRelatedDecl src "fun_" "" ref stx? fun value levels => do
+    addRelatedDecl src "fun_" "" ref stx? (docstringPrefix? := s!"Eta-expanded form of `{src}`")
+      fun value levels => do
       let r ← Push.pullCore .lambda (← inferType value) none
       return (← r.mkCast value, levels)
   | _ => throwUnsupportedSyntax }

--- a/Mathlib/Util/AddRelatedDecl.lean
+++ b/Mathlib/Util/AddRelatedDecl.lean
@@ -44,8 +44,8 @@ Arguments:
   We apply it to both declarations, to have the same behavior as `to_additive`, and to shorten some
   attribute commands. Note that `@[elementwise (attr := simp), reassoc (attr := simp)]` will try
   to apply `simp` twice to the current declaration, but that causes no issues.
-* `docstringPrefix` will be prepended to the doc-string of `src` to form the doc-stringg of `tgt`.
-  If it is `none`, only the doc-string of `src` will be used.
+* `docstringPrefix` is prepended to the doc-string of `src` to form the doc-string of `tgt`.
+  If it is `none`, only the doc-string of `src` is used.
 -/
 def addRelatedDecl (src : Name) (prefix_ suffix : String) (ref : Syntax)
     (attrs? : Option (Syntax.TSepArray `Lean.Parser.Term.attrInstance ","))

--- a/Mathlib/Util/AddRelatedDecl.lean
+++ b/Mathlib/Util/AddRelatedDecl.lean
@@ -44,10 +44,13 @@ Arguments:
   We apply it to both declarations, to have the same behavior as `to_additive`, and to shorten some
   attribute commands. Note that `@[elementwise (attr := simp), reassoc (attr := simp)]` will try
   to apply `simp` twice to the current declaration, but that causes no issues.
+* `docstringPrefix` will be prepended to the doc-string of `src` to form the doc-stringg of `tgt`.
+  If it is `none`, only the doc-string of `src` will be used.
 -/
 def addRelatedDecl (src : Name) (prefix_ suffix : String) (ref : Syntax)
     (attrs? : Option (Syntax.TSepArray `Lean.Parser.Term.attrInstance ","))
-    (construct : Expr → List Name → MetaM (Expr × List Name)) :
+    (construct : Expr → List Name → MetaM (Expr × List Name))
+    (docstringPrefix? : Option String := none) :
     MetaM Unit := do
   let tgt := match src with
     | Name.str n s => Name.mkStr n <| prefix_ ++ s ++ suffix
@@ -72,9 +75,13 @@ def addRelatedDecl (src : Name) (prefix_ suffix : String) (ref : Syntax)
   | _ => throwError "Constant {src} is not a theorem or definition."
   if isProtected (← getEnv) src then
     setEnv <| addProtected (← getEnv) tgt
+  match docstringPrefix?, ← findDocString? (← getEnv) src with
+  | none, none => pure ()
+  | some doc, none | none, some doc => addDocStringCore tgt doc
+  | some docPre, some docPost => addDocStringCore tgt s!"{docPre}\n\n---\n\n{docPost}"
   inferDefEqAttr tgt
   let attrs := match attrs? with | some attrs => attrs | none => #[]
-  _ ← Term.TermElabM.run' do
+  Term.TermElabM.run' do
     let attrs ← elabAttrs attrs
     Term.applyAttributes src attrs
     Term.applyAttributes tgt attrs

--- a/MathlibTest/ToFun.lean
+++ b/MathlibTest/ToFun.lean
@@ -7,3 +7,20 @@ theorem Function.mul_comm (f g : ℝ → ℝ) : f * g = g * f := _root_.mul_comm
 /-- info: Function.fun_mul_comm (f g : ℝ → ℝ) : (fun i => f i * g i) = fun i => g i * f i -/
 #guard_msgs in
 #check Function.fun_mul_comm
+
+/-- Look I am the doc-string of `foo`. -/
+@[to_fun]
+theorem foo : 1 = 1 := rfl
+
+open Lean in
+/--
+info: Eta-expanded form of `foo`
+
+---
+
+Look I am the doc-string of `foo`.
+-/
+#guard_msgs in
+run_meta
+  let some doc  ← findDocString? (← getEnv) ``fun_foo | throwError "no docstring found"
+  logInfo doc


### PR DESCRIPTION
This PR improves the `@[to_fun]` attribute by letting it generate a doc-string for the new declaration. The doc-string consists of two parts:
- "Eta-expanded form of `foo`"
- doc-string of `foo`

This is analogous to how `alias` has two parts of the doc-string.

As a side-effect, `reassoc` and friends now also copy over the doc-string if it exists. For those, I have not added a doc-string prefix, but this can be done if desired.

---

requested by @grunweg

<!-- Your PR title will become the first line of the commit message.

In this box, the text above the `---` (if not empty) will be appended
to the commit message, and can be used to give additional context or
details. Please leave a blank newline before the `---`, otherwise GitHub
will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

When merging, all the commits will be squashed into a single commit
listing all co-authors.

Co-authors in the squash commit are gathered from two sources:

First, all authors of commits to this PR branch are included. Thus,
one way to add co-authors is to include at least one commit authored by
each co-author among the commits in the pull request. If necessary, you
may create empty commits to indicate co-authorship, using commands like so:

git commit --author="Author Name <author@email.com>" --allow-empty -m "add Author Name as coauthor"

Second, co-authors can also be listed in lines at the very bottom of
the commit message (that is, directly before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines
at the bottom of the commit message (before the `---`, and also before
any "Co-authored-by" lines) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
