### PR TITLE
refactor Submodule.map

### DIFF
--- a/Mathlib/Algebra/Module/Submodule/Map.lean
+++ b/Mathlib/Algebra/Module/Submodule/Map.lean
@@ -53,50 +53,43 @@ variable (f : M →ₛₗ[σ₁₂] M₂) (p : Submodule R M)
 /-- The pushforward of a submodule `p ⊆ M` by `f : M → M₂` -/
 def map : Submodule R₂ M₂ := span R₂ (f '' p)
 
-  -- { p.toAddSubmonoid.map f with
-  --   carrier := f '' p
-  --   smul_mem' := by
-  --     rintro c x ⟨y, hy, rfl⟩
-  --     obtain ⟨a, rfl⟩ := σ₁₂.surjective c
-  --     exact ⟨_, p.smul_mem a hy, map_smulₛₗ f _ _⟩ }
+lemma map_def : p.map f = span R₂ (f '' p) := rfl
 
 lemma map_mem {x : M} (hx : x ∈ p) : f x ∈ p.map f := by
   apply mem_span_of_mem
-  refine ⟨_, hx, rfl⟩
+  exact ⟨_, hx, rfl⟩
 
-lemma map_carrier_eq_of_surjective [RingHomSurjective σ₁₂] (f : M →ₛₗ[σ₁₂] M₂) (p : Submodule R M) :
-    (p.map f).carrier =  f '' p := by
+lemma map_eq_of_surjective [RingHomSurjective σ₁₂] (f : M →ₛₗ[σ₁₂] M₂) :
+    p.map f = f '' p := by
   ext x
   refine ⟨fun hx ↦ ?_, mem_span_of_mem⟩
-  · let p' : Submodule R₂ M₂ :=
-    { p.toAddSubmonoid.map f with
-      carrier := f '' p
-      smul_mem' := by
-        rintro c x ⟨y, hy, rfl⟩
-        obtain ⟨a, rfl⟩ := σ₁₂.surjective c
-        exact ⟨_, p.smul_mem a hy, map_smulₛₗ f _ _⟩ }
-    sorry
+  have hn : (f '' p).Nonempty := ⟨f 0, 0, by simp⟩
+  have h_mem : ∀ x₁ ∈ f '' p, ∀ x₂ ∈ f '' p, ∀ (a b : R₂), a • x₁ + b • x₂ ∈ f '' p := by
+    rintro _ ⟨z₁, hz₁⟩ _ ⟨z₂, hz₂⟩ a b
+    obtain ⟨a₀, ha₀⟩ : ∃ a₀ : R, σ₁₂ a₀ = a := σ₁₂.surjective ..
+    obtain ⟨b₀, hb₀⟩ : ∃ b₀ : R, σ₁₂ b₀ = b := σ₁₂.surjective ..
+    exact ⟨_, p.add_mem (p.smul_mem a₀ hz₁.1) (p.smul_mem b₀ hz₂.1), by simp_all⟩
+  rw [← coe_ofLinearComb _ hn h_mem]
+  apply mem_span.mp hx
+  simp only [coe_ofLinearComb, subset_refl]
 
 @[simp]
-theorem map_coe (g : M →ₛₗ[σ₁₂] M₂)(p : Submodule R M) : ((map' g p).carrier : Set M₂) = g '' p :=
-  rfl
+lemma mem_map_of_surjective [RingHomSurjective σ₁₂] {f : M →ₛₗ[σ₁₂] M₂} (x : M₂) :
+    x ∈ p.map f ↔ x ∈ f '' p := by
+  change x ∈ ((p.map f) : Set _) ↔ ∃ x_1 ∈ ↑p, f x_1 = x
+  simp [map_eq_of_surjective]
 
-@[simp]
-theorem map_coe_toLinearMap (f : F) (p : Submodule R M) : map (f : M →ₛₗ[σ₁₂] M₂) p = map f p := rfl
+variable [RingHomSurjective σ₁₂] (f : M →ₛₗ[σ₁₂] M₂)
 
-theorem map_toAddSubmonoid (f : M →ₛₗ[σ₁₂] M₂) (p : Submodule R M) :
-    (p.map f).toAddSubmonoid = p.toAddSubmonoid.map (f : M →+ M₂) :=
-  SetLike.coe_injective rfl
-
-theorem map_toAddSubmonoid' (f : M →ₛₗ[σ₁₂] M₂) (p : Submodule R M) :
-    (p.map f).toAddSubmonoid = p.toAddSubmonoid.map f :=
-  SetLike.coe_injective rfl
+theorem map_toAddSubmonoid (p : Submodule R M) :
+    (p.map f).toAddSubmonoid = p.toAddSubmonoid.map (f : M →+ M₂) := by
+  ext x; simp
 
 @[simp]
 theorem _root_.AddMonoidHom.coe_toIntLinearMap_map {A A₂ : Type*} [AddCommGroup A] [AddCommGroup A₂]
     (f : A →+ A₂) (s : AddSubgroup A) :
     (AddSubgroup.toIntSubmodule s).map f.toIntLinearMap =
-      AddSubgroup.toIntSubmodule (s.map f) := rfl
+      AddSubgroup.toIntSubmodule (s.map f) := by sorry--rfl
 
 @[simp]
 theorem _root_.MonoidHom.coe_toAdditive_map {G G₂ : Type*} [Group G] [Group G₂] (f : G →* G₂)

--- a/Mathlib/Algebra/Module/Submodule/Map.lean
+++ b/Mathlib/Algebra/Module/Submodule/Map.lean
@@ -10,6 +10,7 @@ public import Mathlib.Algebra.Group.Subgroup.Map
 public import Mathlib.Algebra.Module.Submodule.Basic
 public import Mathlib.Algebra.Module.Submodule.Lattice
 public import Mathlib.Algebra.Module.Submodule.LinearMap
+public import Mathlib.LinearAlgebra.Span.Defs
 
 /-!
 # `map` and `comap` for `Submodule`s
@@ -47,19 +48,37 @@ variable {x : M}
 
 section
 
-variable [RingHomSurjective σ₁₂] {F : Type*} [FunLike F M M₂] [SemilinearMapClass F σ₁₂ M M₂]
+variable (f : M →ₛₗ[σ₁₂] M₂) (p : Submodule R M)
 
 /-- The pushforward of a submodule `p ⊆ M` by `f : M → M₂` -/
-def map (f : F) (p : Submodule R M) : Submodule R₂ M₂ :=
-  { p.toAddSubmonoid.map f with
-    carrier := f '' p
-    smul_mem' := by
-      rintro c x ⟨y, hy, rfl⟩
-      obtain ⟨a, rfl⟩ := σ₁₂.surjective c
-      exact ⟨_, p.smul_mem a hy, map_smulₛₗ f _ _⟩ }
+def map : Submodule R₂ M₂ := span R₂ (f '' p)
+
+  -- { p.toAddSubmonoid.map f with
+  --   carrier := f '' p
+  --   smul_mem' := by
+  --     rintro c x ⟨y, hy, rfl⟩
+  --     obtain ⟨a, rfl⟩ := σ₁₂.surjective c
+  --     exact ⟨_, p.smul_mem a hy, map_smulₛₗ f _ _⟩ }
+
+lemma map_mem {x : M} (hx : x ∈ p) : f x ∈ p.map f := by
+  apply mem_span_of_mem
+  refine ⟨_, hx, rfl⟩
+
+lemma map_carrier_eq_of_surjective [RingHomSurjective σ₁₂] (f : M →ₛₗ[σ₁₂] M₂) (p : Submodule R M) :
+    (p.map f).carrier =  f '' p := by
+  ext x
+  refine ⟨fun hx ↦ ?_, mem_span_of_mem⟩
+  · let p' : Submodule R₂ M₂ :=
+    { p.toAddSubmonoid.map f with
+      carrier := f '' p
+      smul_mem' := by
+        rintro c x ⟨y, hy, rfl⟩
+        obtain ⟨a, rfl⟩ := σ₁₂.surjective c
+        exact ⟨_, p.smul_mem a hy, map_smulₛₗ f _ _⟩ }
+    sorry
 
 @[simp]
-theorem map_coe (f : F) (p : Submodule R M) : (map f p : Set M₂) = f '' p :=
+theorem map_coe (g : M →ₛₗ[σ₁₂] M₂)(p : Submodule R M) : ((map' g p).carrier : Set M₂) = g '' p :=
   rfl
 
 @[simp]


### PR DESCRIPTION
Following [#mathlib4 > on the definition of Submodule.map](https://leanprover.zulipchat.com/#narrow/channel/287929-mathlib4/topic/on.20the.20definition.20of.20Submodule.2Emap/with/563900347) this PR refactors the definition of `Submodule.map`  removing the requirement that the underlying ring homomorphism be surjective.

---
<!-- Your PR title will become the first line of the commit message.

In this box, the text above the `---` (if not empty) will be appended
to the commit message, and can be used to give additional context or
details. Please leave a blank newline before the `---`, otherwise GitHub
will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

When merging, all the commits will be squashed into a single commit
listing all co-authors.

Co-authors in the squash commit are gathered from two sources:

First, all authors of commits to this PR branch are included. Thus,
one way to add co-authors is to include at least one commit authored by
each co-author among the commits in the pull request. If necessary, you
may create empty commits to indicate co-authorship, using commands like so:

git commit --author="Author Name <author@email.com>" --allow-empty -m "add Author Name as coauthor"

Second, co-authors can also be listed in lines at the very bottom of
the commit message (that is, directly before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines
at the bottom of the commit message (before the `---`, and also before
any "Co-authored-by" lines) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
