### PR TITLE
[Merged by Bors] - feat(Analysis/InnerProductSpace): orthogonal decomposition as a `LinearIsometryEquiv`

### DIFF
--- a/Mathlib/Analysis/InnerProductSpace/ProdL2.lean
+++ b/Mathlib/Analysis/InnerProductSpace/ProdL2.lean
@@ -79,21 +79,68 @@ def prod (v : OrthonormalBasis ι₁ 𝕜 E) (w : OrthonormalBasis ι₂ 𝕜 F)
 
 end OrthonormalBasis
 
+namespace Submodule
+
+variable (K : Submodule 𝕜 E) [K.HasOrthogonalProjection] (x : E)
+
 /-- If a subspace `K` of an inner product space `E` admits an orthogonal projection, then `E` is
 isometrically isomorphic to the `L²` product of `K` and `Kᗮ`. -/
-@[simps! apply symm_apply]
-def Submodule.orthogonalDecomposition (K : Submodule 𝕜 E) [K.HasOrthogonalProjection] :
-    E ≃ₗᵢ[𝕜] WithLp 2 (K × Kᗮ) where
-  __ := LinearEquiv.ofLinear
-    ((K.prodEquivOfIsCompl Kᗮ isCompl_orthogonal_of_hasOrthogonalProjection).symm.copy
-      (Pi.prod K.orthogonalProjection Kᗮ.orthogonalProjection)
-      (funext <| by simp [orthogonalProjection_eq_linearProjOfIsCompl]))
-    (K.prodEquivOfIsCompl Kᗮ isCompl_orthogonal_of_hasOrthogonalProjection)
-    (by rw [LinearMap.copy_eq, LinearEquiv.symm_comp])
-    (by rw [LinearMap.copy_eq, LinearEquiv.comp_symm])
-    ≪≫ₗ (WithLp.linearEquiv 2 _ _).symm
+@[simps! symm_apply]
+def orthogonalDecomposition : E ≃ₗᵢ[𝕜] WithLp 2 (K × Kᗮ) where
+  __ := (K.prodEquivOfIsCompl Kᗮ isCompl_orthogonal_of_hasOrthogonalProjection).symm
+    ≪≫ₗ (WithLp.linearEquiv 2 𝕜 (K × Kᗮ)).symm
   norm_map' _ := by
-    rw [← sq_eq_sq₀ (by positivity) (by positivity), WithLp.prod_norm_sq_eq_of_L2]
-    exact (K.norm_sq_eq_add_norm_sq_starProjection _).symm
+    rw [← sq_eq_sq₀ (by positivity) (by positivity), WithLp.prod_norm_sq_eq_of_L2,
+      K.norm_sq_eq_add_norm_sq_projection]
+    simp [starProjection_eq_isCompl_projection]
+
+@[simp]
+theorem orthogonalDecomposition_apply :
+    K.orthogonalDecomposition x =
+      .toLp 2 (K.orthogonalProjection x, Kᗮ.orthogonalProjection x) := by
+  simp [orthogonalDecomposition, orthogonalProjection_eq_linearProjOfIsCompl]
+
+theorem toLinearEquiv_orthogonalDecomposition :
+    K.orthogonalDecomposition.toLinearEquiv =
+      (K.prodEquivOfIsCompl Kᗮ isCompl_orthogonal_of_hasOrthogonalProjection).symm ≪≫ₗ
+        (WithLp.linearEquiv 2 𝕜 (K × Kᗮ)).symm :=
+  rfl
+
+theorem toLinearEquiv_orthogonalDecomposition_symm :
+    K.orthogonalDecomposition.symm.toLinearEquiv =
+      WithLp.linearEquiv 2 𝕜 (K × Kᗮ) ≪≫ₗ
+        K.prodEquivOfIsCompl Kᗮ isCompl_orthogonal_of_hasOrthogonalProjection :=
+  rfl
+
+@[simp]
+theorem coe_orthogonalDecomposition :
+    (K.orthogonalDecomposition : E →L[𝕜] WithLp 2 (K × Kᗮ)) =
+      (WithLp.prodContinuousLinearEquiv 2 𝕜 K Kᗮ).symm ∘L
+        K.orthogonalProjection.prod Kᗮ.orthogonalProjection := by
+  ext; simp
+
+@[simp]
+theorem coe_orthogonalDecomposition_symm :
+    (K.orthogonalDecomposition.symm : WithLp 2 (K × Kᗮ) →L[𝕜] E) =
+      K.subtypeL.coprod Kᗮ.subtypeL ∘L WithLp.prodContinuousLinearEquiv 2 𝕜 K Kᗮ :=
+  rfl
+
+theorem fst_orthogonalDecomposition :
+    (K.orthogonalDecomposition x).fst = K.orthogonalProjection x := by
+  simp
+
+theorem snd_orthogonalDecomposition :
+    (K.orthogonalDecomposition x).snd = Kᗮ.orthogonalProjection x := by
+  simp
+
+theorem fstL_comp_coe_orthogonalDecomposition :
+    WithLp.fstL 2 𝕜 K Kᗮ ∘L K.orthogonalDecomposition = K.orthogonalProjection := by
+  ext; simp
+
+theorem sndL_comp_coe_orthogonalDecomposition :
+    WithLp.sndL 2 𝕜 K Kᗮ ∘L K.orthogonalDecomposition = Kᗮ.orthogonalProjection := by
+  ext; simp
+
+end Submodule
 
 end

--- a/Mathlib/Analysis/InnerProductSpace/ProdL2.lean
+++ b/Mathlib/Analysis/InnerProductSpace/ProdL2.lean
@@ -123,11 +123,11 @@ theorem coe_orthogonalDecomposition_symm :
       K.subtypeL.coprod Kᗮ.subtypeL ∘L WithLp.prodContinuousLinearEquiv 2 𝕜 K Kᗮ :=
   rfl
 
-theorem fst_orthogonalDecomposition :
+theorem fst_orthogonalDecomposition_apply :
     (K.orthogonalDecomposition x).fst = K.orthogonalProjection x := by
   simp
 
-theorem snd_orthogonalDecomposition :
+theorem snd_orthogonalDecomposition_apply :
     (K.orthogonalDecomposition x).snd = Kᗮ.orthogonalProjection x := by
   simp
 

--- a/Mathlib/Analysis/InnerProductSpace/ProdL2.lean
+++ b/Mathlib/Analysis/InnerProductSpace/ProdL2.lean
@@ -98,7 +98,7 @@ def orthogonalDecomposition : E ≃ₗᵢ[𝕜] WithLp 2 (K × Kᗮ) where
 theorem orthogonalDecomposition_apply :
     K.orthogonalDecomposition x =
       .toLp 2 (K.orthogonalProjection x, Kᗮ.orthogonalProjection x) := by
-  simp [orthogonalDecomposition, orthogonalProjection_eq_linearProjOfIsCompl]
+  simp [orthogonalDecomposition, orthogonalProjection_apply_eq_linearProjOfIsCompl]
 
 theorem toLinearEquiv_orthogonalDecomposition :
     K.orthogonalDecomposition.toLinearEquiv =

--- a/Mathlib/Analysis/InnerProductSpace/ProdL2.lean
+++ b/Mathlib/Analysis/InnerProductSpace/ProdL2.lean
@@ -112,14 +112,12 @@ theorem toLinearEquiv_orthogonalDecomposition_symm :
         K.prodEquivOfIsCompl Kᗮ isCompl_orthogonal_of_hasOrthogonalProjection :=
   rfl
 
-@[simp]
 theorem coe_orthogonalDecomposition :
     (K.orthogonalDecomposition : E →L[𝕜] WithLp 2 (K × Kᗮ)) =
       (WithLp.prodContinuousLinearEquiv 2 𝕜 K Kᗮ).symm ∘L
         K.orthogonalProjection.prod Kᗮ.orthogonalProjection := by
   ext; simp
 
-@[simp]
 theorem coe_orthogonalDecomposition_symm :
     (K.orthogonalDecomposition.symm : WithLp 2 (K × Kᗮ) →L[𝕜] E) =
       K.subtypeL.coprod Kᗮ.subtypeL ∘L WithLp.prodContinuousLinearEquiv 2 𝕜 K Kᗮ :=

--- a/Mathlib/Analysis/InnerProductSpace/ProdL2.lean
+++ b/Mathlib/Analysis/InnerProductSpace/ProdL2.lean
@@ -78,4 +78,23 @@ def prod (v : OrthonormalBasis ι₁ 𝕜 E) (w : OrthonormalBasis ι₂ 𝕜 F)
   aesop
 
 end OrthonormalBasis
+
+/-- If a subspace `K` of an inner product space `E` admits an orthogonal projection, then `E` is
+isometrically isomorphic to the `L²` product of `K` and `Kᗮ`. -/
+@[simps! apply symm_apply]
+def Submodule.orthogonalDecomposition (K : Submodule 𝕜 E) [K.HasOrthogonalProjection] :
+    E ≃ₗᵢ[𝕜] WithLp 2 (K × Kᗮ) where
+  __ := LinearEquiv.ofLinear
+    (K.orthogonalProjection.toLinearMap.prod Kᗮ.orthogonalProjection.toLinearMap)
+    (K.subtype.coprod Kᗮ.subtype)
+    (by
+      ext ⟨x, hx⟩ <;> simp only [LinearMap.comp_assoc, LinearMap.coprod_inl, LinearMap.coprod_inr]
+      exacts [K.starProjection_eq_self_iff.mpr hx, K.starProjection_orthogonal_apply_eq_zero hx,
+        K.starProjection_apply_eq_zero_iff.mpr hx, Kᗮ.starProjection_eq_self_iff.mpr hx])
+    (LinearMap.ext K.starProjection_add_starProjection_orthogonal)
+    ≪≫ₗ (WithLp.linearEquiv 2 _ _).symm
+  norm_map' _ := by
+    rw [← sq_eq_sq₀ (by positivity) (by positivity), WithLp.prod_norm_sq_eq_of_L2]
+    exact (K.norm_sq_eq_add_norm_sq_starProjection _).symm
+
 end

--- a/Mathlib/Analysis/InnerProductSpace/ProdL2.lean
+++ b/Mathlib/Analysis/InnerProductSpace/ProdL2.lean
@@ -85,13 +85,12 @@ isometrically isomorphic to the `L²` product of `K` and `Kᗮ`. -/
 def Submodule.orthogonalDecomposition (K : Submodule 𝕜 E) [K.HasOrthogonalProjection] :
     E ≃ₗᵢ[𝕜] WithLp 2 (K × Kᗮ) where
   __ := LinearEquiv.ofLinear
-    (K.orthogonalProjection.toLinearMap.prod Kᗮ.orthogonalProjection.toLinearMap)
-    (K.subtype.coprod Kᗮ.subtype)
-    (by
-      ext ⟨x, hx⟩ <;> simp only [LinearMap.comp_assoc, LinearMap.coprod_inl, LinearMap.coprod_inr]
-      exacts [K.starProjection_eq_self_iff.mpr hx, K.starProjection_orthogonal_apply_eq_zero hx,
-        K.starProjection_apply_eq_zero_iff.mpr hx, Kᗮ.starProjection_eq_self_iff.mpr hx])
-    (LinearMap.ext K.starProjection_add_starProjection_orthogonal)
+    ((K.prodEquivOfIsCompl Kᗮ isCompl_orthogonal_of_hasOrthogonalProjection).symm.copy
+      (Pi.prod K.orthogonalProjection Kᗮ.orthogonalProjection)
+      (funext <| by simp [orthogonalProjection_eq_linearProjOfIsCompl]))
+    (K.prodEquivOfIsCompl Kᗮ isCompl_orthogonal_of_hasOrthogonalProjection)
+    (by rw [LinearMap.copy_eq, LinearEquiv.symm_comp])
+    (by rw [LinearMap.copy_eq, LinearEquiv.comp_symm])
     ≪≫ₗ (WithLp.linearEquiv 2 _ _).symm
   norm_map' _ := by
     rw [← sq_eq_sq₀ (by positivity) (by positivity), WithLp.prod_norm_sq_eq_of_L2]

--- a/Mathlib/Analysis/InnerProductSpace/ProdL2.lean
+++ b/Mathlib/Analysis/InnerProductSpace/ProdL2.lean
@@ -92,7 +92,7 @@ def orthogonalDecomposition : E ≃ₗᵢ[𝕜] WithLp 2 (K × Kᗮ) where
   norm_map' _ := by
     rw [← sq_eq_sq₀ (by positivity) (by positivity), WithLp.prod_norm_sq_eq_of_L2,
       K.norm_sq_eq_add_norm_sq_projection]
-    simp [starProjection_eq_isCompl_projection]
+    simp [starProjection_apply_eq_isComplProjection]
 
 @[simp]
 theorem orthogonalDecomposition_apply :

--- a/Mathlib/Analysis/InnerProductSpace/Projection/Submodule.lean
+++ b/Mathlib/Analysis/InnerProductSpace/Projection/Submodule.lean
@@ -216,7 +216,7 @@ theorem toLinearMap_starProjection_eq_isComplProjection [K.HasOrthogonalProjecti
 open Submodule in
 theorem starProjection_apply_eq_isComplProjection [K.HasOrthogonalProjection] (x : E) :
     K.starProjection x = K.isCompl_orthogonal_of_hasOrthogonalProjection.projection x :=
-  congr($starProjection_coe_eq_isCompl_projection x)
+  congr($toLinearMap_starProjection_eq_isComplProjection x)
 
 end Submodule
 

--- a/Mathlib/Analysis/InnerProductSpace/Projection/Submodule.lean
+++ b/Mathlib/Analysis/InnerProductSpace/Projection/Submodule.lean
@@ -214,7 +214,7 @@ theorem toLinearMap_starProjection_eq_isComplProjection [K.HasOrthogonalProjecti
   toLinearMap_starProjection_eq_isComplProjection
 
 open Submodule in
-theorem starProjection_eq_isCompl_projection [K.HasOrthogonalProjection] (x : E) :
+theorem starProjection_apply_eq_isComplProjection [K.HasOrthogonalProjection] (x : E) :
     K.starProjection x = K.isCompl_orthogonal_of_hasOrthogonalProjection.projection x :=
   congr($starProjection_coe_eq_isCompl_projection x)
 

--- a/Mathlib/Analysis/InnerProductSpace/Projection/Submodule.lean
+++ b/Mathlib/Analysis/InnerProductSpace/Projection/Submodule.lean
@@ -213,6 +213,11 @@ theorem toLinearMap_starProjection_eq_isComplProjection [K.HasOrthogonalProjecti
 @[deprecated (since := "2025-12-26")] alias starProjection_coe_eq_isCompl_projection :=
   toLinearMap_starProjection_eq_isComplProjection
 
+open Submodule in
+theorem starProjection_eq_isCompl_projection [K.HasOrthogonalProjection] (x : E) :
+    K.starProjection x = K.isCompl_orthogonal_of_hasOrthogonalProjection.projection x :=
+  congr($starProjection_coe_eq_isCompl_projection x)
+
 end Submodule
 
 namespace Dense

--- a/Mathlib/LinearAlgebra/Projection.lean
+++ b/Mathlib/LinearAlgebra/Projection.lean
@@ -275,7 +275,7 @@ theorem prodEquivOfIsCompl_symm_apply (hpq : IsCompl p q) (x : E) :
   Prod.ext rfl congr(($(prodComm_trans_prodEquivOfIsCompl p q hpq).symm x).1)
 
 @[simp]
-theorem toLinearMap_prodEquivOfIsCompl_symm (hpq : IsCompl p q) (x : E) :
+theorem toLinearMap_prodEquivOfIsCompl_symm (hpq : IsCompl p q) :
     (p.prodEquivOfIsCompl q hpq).symm.toLinearMap =
       (p.linearProjOfIsCompl q hpq).prod (q.linearProjOfIsCompl p hpq.symm) :=
   LinearMap.ext <| by simp

--- a/Mathlib/LinearAlgebra/Projection.lean
+++ b/Mathlib/LinearAlgebra/Projection.lean
@@ -274,6 +274,12 @@ theorem prodEquivOfIsCompl_symm_apply (hpq : IsCompl p q) (x : E) :
       (p.linearProjOfIsCompl q hpq x, q.linearProjOfIsCompl p hpq.symm x) :=
   Prod.ext rfl congr(($(prodComm_trans_prodEquivOfIsCompl p q hpq).symm x).1)
 
+@[simp]
+theorem toLinearMap_prodEquivOfIsCompl_symm (hpq : IsCompl p q) (x : E) :
+    (p.prodEquivOfIsCompl q hpq).symm.toLinearMap =
+      (p.linearProjOfIsCompl q hpq).prod (q.linearProjOfIsCompl p hpq.symm) :=
+  LinearMap.ext <| by simp
+
 end Submodule
 
 namespace LinearMap

--- a/Mathlib/LinearAlgebra/Projection.lean
+++ b/Mathlib/LinearAlgebra/Projection.lean
@@ -270,6 +270,12 @@ lemma IsCompl.projection_eq_self_sub_projection (hpq : IsCompl p q) (x : E) :
 @[deprecated (since := "2025-07-29")] alias linearProjOfIsCompl_eq_self_iff :=
   IsCompl.projection_eq_self_iff
 
+@[simp]
+theorem prodEquivOfIsCompl_symm_apply (hpq : IsCompl p q) (x : E) :
+    (p.prodEquivOfIsCompl q hpq).symm x =
+      (p.linearProjOfIsCompl q hpq x, q.linearProjOfIsCompl p hpq.symm x) :=
+  Prod.ext rfl congr(($(prodComm_trans_prodEquivOfIsCompl p q hpq).symm x).1)
+
 end Submodule
 
 namespace LinearMap

--- a/Mathlib/LinearAlgebra/Projection.lean
+++ b/Mathlib/LinearAlgebra/Projection.lean
@@ -109,24 +109,20 @@ theorem coe_prodEquivOfIsCompl (h : IsCompl p q) :
 theorem coe_prodEquivOfIsCompl' (h : IsCompl p q) (x : p × q) :
     prodEquivOfIsCompl p q h x = x.1 + x.2 := rfl
 
-@[simp]
 theorem prodEquivOfIsCompl_symm_apply_left (h : IsCompl p q) (x : p) :
     (prodEquivOfIsCompl p q h).symm x = (x, 0) :=
   (prodEquivOfIsCompl p q h).symm_apply_eq.2 <| by simp
 
-@[simp]
 theorem prodEquivOfIsCompl_symm_apply_right (h : IsCompl p q) (x : q) :
     (prodEquivOfIsCompl p q h).symm x = (0, x) :=
   (prodEquivOfIsCompl p q h).symm_apply_eq.2 <| by simp
 
-@[simp]
 theorem prodEquivOfIsCompl_symm_apply_fst_eq_zero (h : IsCompl p q) {x : E} :
     ((prodEquivOfIsCompl p q h).symm x).1 = 0 ↔ x ∈ q := by
   conv_rhs => rw [← (prodEquivOfIsCompl p q h).apply_symm_apply x]
   rw [coe_prodEquivOfIsCompl', Submodule.add_mem_iff_left _ (Submodule.coe_mem _),
     mem_right_iff_eq_zero_of_disjoint h.disjoint]
 
-@[simp]
 theorem prodEquivOfIsCompl_symm_apply_snd_eq_zero (h : IsCompl p q) {x : E} :
     ((prodEquivOfIsCompl p q h).symm x).2 = 0 ↔ x ∈ p := by
   conv_rhs => rw [← (prodEquivOfIsCompl p q h).apply_symm_apply x]
@@ -172,7 +168,8 @@ theorem IsCompl.projection_apply_mem (hpq : IsCompl p q) (x : E) :
 
 @[simp]
 theorem linearProjOfIsCompl_apply_left (h : IsCompl p q) (x : p) :
-    linearProjOfIsCompl p q h x = x := by simp [linearProjOfIsCompl]
+    linearProjOfIsCompl p q h x = x := by
+  simp [linearProjOfIsCompl, prodEquivOfIsCompl_symm_apply_left]
 
 @[simp]
 theorem IsCompl.projection_apply_left (hpq : IsCompl p q) (x : p) :
@@ -192,7 +189,8 @@ theorem linearProjOfIsCompl_surjective (h : IsCompl p q) :
 
 @[simp]
 theorem linearProjOfIsCompl_apply_eq_zero_iff (h : IsCompl p q) {x : E} :
-    linearProjOfIsCompl p q h x = 0 ↔ x ∈ q := by simp [linearProjOfIsCompl]
+    linearProjOfIsCompl p q h x = 0 ↔ x ∈ q := by
+  simp [linearProjOfIsCompl, prodEquivOfIsCompl_symm_apply_fst_eq_zero]
 
 @[simp]
 theorem IsCompl.projection_apply_eq_zero_iff (hpq : IsCompl p q) {x : E} :


### PR DESCRIPTION

---
<!-- Your PR title will become the first line of the commit message.

In this box, the text above the `---` (if not empty) will be appended
to the commit message, and can be used to give additional context or
details. Please leave a blank newline before the `---`, otherwise GitHub
will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

When merging, all the commits will be squashed into a single commit
listing all co-authors.

Co-authors in the squash commit are gathered from two sources:

First, all authors of commits to this PR branch are included. Thus,
one way to add co-authors is to include at least one commit authored by
each co-author among the commits in the pull request. If necessary, you
may create empty commits to indicate co-authorship, using commands like so:

git commit --author="Author Name <author@email.com>" --allow-empty -m "add Author Name as coauthor"

Second, co-authors can also be listed in lines at the very bottom of
the commit message (that is, directly before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines
at the bottom of the commit message (before the `---`, and also before
any "Co-authored-by" lines) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
