### PR TITLE
[Merged by Bors] - chore(MeasureTheory): avoid `all_goals first` anti-pattern

### DIFF
--- a/Mathlib/MeasureTheory/VectorMeasure/Decomposition/Jordan.lean
+++ b/Mathlib/MeasureTheory/VectorMeasure/Decomposition/Jordan.lean
@@ -279,7 +279,10 @@ theorem of_diff_eq_zero_of_symmDiff_eq_zero_positive (hu : MeasurableSet u) (hv 
         (hu.diff hv) (hv.diff hu)] at hs
     rw [zero_apply] at a b
     constructor
-  all_goals first | linarith | assumption
+  · linarith
+  · linarith
+  · assumption
+  · assumption
 
 /-- If the symmetric difference of two negative sets is a null-set, then so are the differences
 between the two sets. -/


### PR DESCRIPTION
This PR replaces `all_goals first | linarith | assumption` with explicit focused tactics in `of_diff_eq_zero_of_symmDiff_eq_zero_positive`.

Using `first` with `all_goals` is problematic:
1. **Obfuscatory**: hides which tactic actually closes each goal
2. **Potentially slow**: tries each alternative on every goal
3. **Fragile**: changes to goal order or number silently change behavior

The explicit version makes it clear that two goals are closed by `linarith` and two by `assumption`.

🤖 Prepared with Claude Code