### PR TITLE
[Merged by Bors] - chore(Algebra/Order): deduplicate material on ordered algebras

### DIFF
--- a/Mathlib/Algebra/Order/Algebra.lean
+++ b/Mathlib/Algebra/Order/Algebra.lean
@@ -5,42 +5,8 @@ Authors: Kim Morrison
 -/
 module
 
-public import Mathlib.Algebra.Algebra.Defs
-public import Mathlib.Algebra.Order.Module.Defs
-
-/-!
-# Ordered algebras
-
-An ordered algebra is an ordered semiring, which is an algebra over an ordered commutative semiring,
-for which scalar multiplication is "compatible" with the two orders.
-
-The prototypical example is 2x2 matrices over the reals or complexes (or indeed any C^* algebra)
-where the ordering the one determined by the positive cone of positive operators,
-i.e. `A ≤ B` iff `B - A = star R * R` for some `R`.
-(We don't yet have this example in mathlib.)
-
-## Implementation
-
-Because the axioms for an ordered algebra are exactly the same as those for the underlying
-module being ordered, we don't actually introduce a new class, but just use the `IsOrderedModule`
-and `IsStrictOrderedModule` mixins.
-
-## Tags
-
-ordered algebra
--/
+public import Mathlib.Algebra.Order.Module.Algebra
 
 @[expose] public section
 
-section OrderedAlgebra
-
-variable {R A : Type*} [CommRing R] [PartialOrder R] [IsOrderedRing R]
-  [Ring A] [PartialOrder A] [IsOrderedRing A] [Algebra R A] [IsOrderedModule R A]
-
-theorem algebraMap_monotone : Monotone (algebraMap R A) := fun a b h => by
-  rw [Algebra.algebraMap_eq_smul_one, Algebra.algebraMap_eq_smul_one, ← sub_nonneg, ← sub_smul]
-  trans (b - a) • (0 : A)
-  · simp
-  · exact smul_le_smul_of_nonneg_left zero_le_one (sub_nonneg.mpr h)
-
-end OrderedAlgebra
+@[deprecated (since := "2025-12-16")] alias algebraMap_monotone := algebraMap_mono

--- a/Mathlib/Algebra/Order/Algebra.lean
+++ b/Mathlib/Algebra/Order/Algebra.lean
@@ -7,6 +7,8 @@ module
 
 public import Mathlib.Algebra.Order.Module.Algebra
 
+deprecated_module (since := "2025-12-16")
+
 @[expose] public section
 
 @[deprecated (since := "2025-12-16")] alias algebraMap_monotone := algebraMap_mono

--- a/Mathlib/Algebra/Order/Algebra.lean
+++ b/Mathlib/Algebra/Order/Algebra.lean
@@ -1,14 +1,134 @@
 /-
-Copyright (c) 2020 Kim Morrison. All rights reserved.
+Copyright (c) 2023 Yaël Dillies. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
-Authors: Kim Morrison
+Authors: Yaël Dillies, Kim Morrison
 -/
 module
 
-public import Mathlib.Algebra.Order.Module.Algebra
+public import Mathlib.Algebra.Algebra.Defs
+public import Mathlib.Algebra.Order.Module.Defs
+public import Mathlib.Tactic.Positivity.Core
 
-deprecated_module (since := "2025-12-16")
+/-!
+# Ordered algebras
+
+An ordered algebra is an ordered semiring, which is an algebra over an ordered commutative semiring,
+for which scalar multiplication is "compatible" with the two orders.
+
+The prototypical example is 2x2 matrices over the reals or complexes (or indeed any C^* algebra)
+where the ordering the one determined by the positive cone of positive operators,
+i.e. `A ≤ B` iff `B - A = star R * R` for some `R`.
+(We don't yet have this example in mathlib.)
+
+## Implementation
+
+Because the axioms for an ordered algebra are exactly the same as those for the underlying
+module being ordered, we don't actually introduce a new class, but just use the `IsOrderedModule`
+and `IsStrictOrderedModule` mixins.
+
+## Tags
+
+ordered algebra
+
+## TODO
+
+`positivity` extension for `algebraMap`
+-/
 
 @[expose] public section
 
-@[deprecated (since := "2025-12-16")] alias algebraMap_monotone := algebraMap_mono
+variable {α β : Type*} [CommSemiring α] [PartialOrder α]
+
+section OrderedSemiring
+variable (β)
+variable [Semiring β] [PartialOrder β] [IsOrderedRing β] [Algebra α β] [SMulPosMono α β] {a : α}
+
+@[gcongr, mono] lemma algebraMap_mono : Monotone (algebraMap α β) :=
+  fun a₁ a₂ ha ↦ by
+    simpa only [Algebra.algebraMap_eq_smul_one] using smul_le_smul_of_nonneg_right ha zero_le_one
+
+lemma algebraMap_nonneg (ha : 0 ≤ a) : 0 ≤ algebraMap α β a := by simpa using algebraMap_mono β ha
+
+end OrderedSemiring
+
+section StrictOrderedSemiring
+variable [Semiring β] [PartialOrder β] [IsStrictOrderedRing β] [Algebra α β]
+
+section SMulPosMono
+variable [SMulPosMono α β] [SMulPosReflectLE α β] {a₁ a₂ : α}
+
+@[simp] lemma algebraMap_le_algebraMap : algebraMap α β a₁ ≤ algebraMap α β a₂ ↔ a₁ ≤ a₂ := by
+  simp [Algebra.algebraMap_eq_smul_one]
+
+end SMulPosMono
+
+section SMulPosStrictMono
+variable [SMulPosStrictMono α β] {a a₁ a₂ : α}
+variable (β)
+
+@[gcongr, mono] lemma algebraMap_strictMono : StrictMono (algebraMap α β) :=
+  fun a₁ a₂ ha ↦ by
+    simpa only [Algebra.algebraMap_eq_smul_one] using smul_lt_smul_of_pos_right ha zero_lt_one
+
+lemma algebraMap_pos (ha : 0 < a) : 0 < algebraMap α β a := by
+  simpa using algebraMap_strictMono β ha
+
+variable {β}
+variable [SMulPosReflectLT α β]
+
+@[simp] lemma algebraMap_lt_algebraMap : algebraMap α β a₁ < algebraMap α β a₂ ↔ a₁ < a₂ := by
+  simp [Algebra.algebraMap_eq_smul_one]
+
+end SMulPosStrictMono
+end StrictOrderedSemiring
+
+namespace Mathlib.Meta.Positivity
+open Lean Meta Qq Function
+
+/-- Extension for `algebraMap`. -/
+@[positivity algebraMap _ _ _]
+meta def evalAlgebraMap : PositivityExt where eval {u β} _zβ _pβ e := do
+  let ~q(@algebraMap $α _ $instα $instβ $instαβ $a) := e | throwError "not `algebraMap`"
+  let pα ← synthInstanceQ q(PartialOrder $α)
+  match ← core q(inferInstance) pα a with
+  | .positive pa =>
+    let _instαSemiring ← synthInstanceQ q(Semiring $α)
+    let _instαPartialOrder ← synthInstanceQ q(PartialOrder $α)
+    try
+      let _instβSemiring ← synthInstanceQ q(Semiring $β)
+      let _instβPartialOrder  ← synthInstanceQ q(PartialOrder $β)
+      let _instβIsStrictOrderedRing ← synthInstanceQ q(IsStrictOrderedRing $β)
+      let _instαβsmul ← synthInstanceQ q(SMulPosStrictMono $α $β)
+      assertInstancesCommute
+      return .positive q(algebraMap_pos $β $pa)
+    catch _ =>
+      let _instβSemiring ← synthInstanceQ q(Semiring $β)
+      let _instβPartialOrder  ← synthInstanceQ q(PartialOrder $β)
+      let _instβIsOrderedRing ← synthInstanceQ q(IsOrderedRing $β)
+      let _instαβsmul ← synthInstanceQ q(SMulPosMono $α $β)
+      assertInstancesCommute
+      return .nonnegative q(algebraMap_nonneg $β <| le_of_lt $pa)
+  | .nonnegative pa =>
+    let _instαSemiring ← synthInstanceQ q(CommSemiring $α)
+    let _instαPartialOrder ← synthInstanceQ q(PartialOrder $α)
+    let _instβSemiring ← synthInstanceQ q(Semiring $β)
+    let _instβPartialOrder  ← synthInstanceQ q(PartialOrder $β)
+    let _instβIsOrderedRing ← synthInstanceQ q(IsOrderedRing $β)
+    let _instαβsmul ← synthInstanceQ q(SMulPosMono $α $β)
+    assertInstancesCommute
+    return .nonnegative q(algebraMap_nonneg $β $pa)
+  | _ => pure .none
+
+example [Semiring β] [PartialOrder β] [IsOrderedRing β] [Algebra α β] [SMulPosMono α β]
+    {a : α} (ha : 0 ≤ a) :
+    0 ≤ algebraMap α β a := by positivity
+
+example [Semiring β] [PartialOrder β] [IsOrderedRing β] [Algebra α β] [SMulPosMono α β]
+    {a : α} (ha : 0 < a) :
+    0 ≤ algebraMap α β a := by positivity
+
+example [Semiring β] [PartialOrder β] [IsStrictOrderedRing β] [Algebra α β] [SMulPosStrictMono α β]
+    {a : α} (ha : 0 < a) :
+    0 < algebraMap α β a := by positivity
+
+end Mathlib.Meta.Positivity

--- a/Mathlib/Algebra/Order/Module/Algebra.lean
+++ b/Mathlib/Algebra/Order/Module/Algebra.lean
@@ -1,7 +1,7 @@
 /-
 Copyright (c) 2023 Yaël Dillies. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
-Authors: Yaël Dillies
+Authors: Yaël Dillies, Kim Morrison
 -/
 module
 
@@ -12,7 +12,23 @@ public import Mathlib.Tactic.Positivity.Core
 /-!
 # Ordered algebras
 
-This file proves properties of algebras where both rings are ordered compatibly.
+An ordered algebra is an ordered semiring, which is an algebra over an ordered commutative semiring,
+for which scalar multiplication is "compatible" with the two orders.
+
+The prototypical example is 2x2 matrices over the reals or complexes (or indeed any C^* algebra)
+where the ordering the one determined by the positive cone of positive operators,
+i.e. `A ≤ B` iff `B - A = star R * R` for some `R`.
+(We don't yet have this example in mathlib.)
+
+## Implementation
+
+Because the axioms for an ordered algebra are exactly the same as those for the underlying
+module being ordered, we don't actually introduce a new class, but just use the `IsOrderedModule`
+and `IsStrictOrderedModule` mixins.
+
+## Tags
+
+ordered algebra
 
 ## TODO
 

--- a/Mathlib/Algebra/Order/Module/Algebra.lean
+++ b/Mathlib/Algebra/Order/Module/Algebra.lean
@@ -1,134 +1,14 @@
 /-
-Copyright (c) 2023 Yaël Dillies. All rights reserved.
+Copyright (c) 2020 Kim Morrison. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
-Authors: Yaël Dillies, Kim Morrison
+Authors: Kim Morrison
 -/
 module
 
-public import Mathlib.Algebra.Algebra.Defs
-public import Mathlib.Algebra.Order.Module.Defs
-public import Mathlib.Tactic.Positivity.Core
+public import Mathlib.Algebra.Order.Algebra
 
-/-!
-# Ordered algebras
-
-An ordered algebra is an ordered semiring, which is an algebra over an ordered commutative semiring,
-for which scalar multiplication is "compatible" with the two orders.
-
-The prototypical example is 2x2 matrices over the reals or complexes (or indeed any C^* algebra)
-where the ordering the one determined by the positive cone of positive operators,
-i.e. `A ≤ B` iff `B - A = star R * R` for some `R`.
-(We don't yet have this example in mathlib.)
-
-## Implementation
-
-Because the axioms for an ordered algebra are exactly the same as those for the underlying
-module being ordered, we don't actually introduce a new class, but just use the `IsOrderedModule`
-and `IsStrictOrderedModule` mixins.
-
-## Tags
-
-ordered algebra
-
-## TODO
-
-`positivity` extension for `algebraMap`
--/
+deprecated_module (since := "2025-12-16")
 
 @[expose] public section
 
-variable {α β : Type*} [CommSemiring α] [PartialOrder α]
-
-section OrderedSemiring
-variable (β)
-variable [Semiring β] [PartialOrder β] [IsOrderedRing β] [Algebra α β] [SMulPosMono α β] {a : α}
-
-@[gcongr, mono] lemma algebraMap_mono : Monotone (algebraMap α β) :=
-  fun a₁ a₂ ha ↦ by
-    simpa only [Algebra.algebraMap_eq_smul_one] using smul_le_smul_of_nonneg_right ha zero_le_one
-
-lemma algebraMap_nonneg (ha : 0 ≤ a) : 0 ≤ algebraMap α β a := by simpa using algebraMap_mono β ha
-
-end OrderedSemiring
-
-section StrictOrderedSemiring
-variable [Semiring β] [PartialOrder β] [IsStrictOrderedRing β] [Algebra α β]
-
-section SMulPosMono
-variable [SMulPosMono α β] [SMulPosReflectLE α β] {a₁ a₂ : α}
-
-@[simp] lemma algebraMap_le_algebraMap : algebraMap α β a₁ ≤ algebraMap α β a₂ ↔ a₁ ≤ a₂ := by
-  simp [Algebra.algebraMap_eq_smul_one]
-
-end SMulPosMono
-
-section SMulPosStrictMono
-variable [SMulPosStrictMono α β] {a a₁ a₂ : α}
-variable (β)
-
-@[gcongr, mono] lemma algebraMap_strictMono : StrictMono (algebraMap α β) :=
-  fun a₁ a₂ ha ↦ by
-    simpa only [Algebra.algebraMap_eq_smul_one] using smul_lt_smul_of_pos_right ha zero_lt_one
-
-lemma algebraMap_pos (ha : 0 < a) : 0 < algebraMap α β a := by
-  simpa using algebraMap_strictMono β ha
-
-variable {β}
-variable [SMulPosReflectLT α β]
-
-@[simp] lemma algebraMap_lt_algebraMap : algebraMap α β a₁ < algebraMap α β a₂ ↔ a₁ < a₂ := by
-  simp [Algebra.algebraMap_eq_smul_one]
-
-end SMulPosStrictMono
-end StrictOrderedSemiring
-
-namespace Mathlib.Meta.Positivity
-open Lean Meta Qq Function
-
-/-- Extension for `algebraMap`. -/
-@[positivity algebraMap _ _ _]
-meta def evalAlgebraMap : PositivityExt where eval {u β} _zβ _pβ e := do
-  let ~q(@algebraMap $α _ $instα $instβ $instαβ $a) := e | throwError "not `algebraMap`"
-  let pα ← synthInstanceQ q(PartialOrder $α)
-  match ← core q(inferInstance) pα a with
-  | .positive pa =>
-    let _instαSemiring ← synthInstanceQ q(Semiring $α)
-    let _instαPartialOrder ← synthInstanceQ q(PartialOrder $α)
-    try
-      let _instβSemiring ← synthInstanceQ q(Semiring $β)
-      let _instβPartialOrder  ← synthInstanceQ q(PartialOrder $β)
-      let _instβIsStrictOrderedRing ← synthInstanceQ q(IsStrictOrderedRing $β)
-      let _instαβsmul ← synthInstanceQ q(SMulPosStrictMono $α $β)
-      assertInstancesCommute
-      return .positive q(algebraMap_pos $β $pa)
-    catch _ =>
-      let _instβSemiring ← synthInstanceQ q(Semiring $β)
-      let _instβPartialOrder  ← synthInstanceQ q(PartialOrder $β)
-      let _instβIsOrderedRing ← synthInstanceQ q(IsOrderedRing $β)
-      let _instαβsmul ← synthInstanceQ q(SMulPosMono $α $β)
-      assertInstancesCommute
-      return .nonnegative q(algebraMap_nonneg $β <| le_of_lt $pa)
-  | .nonnegative pa =>
-    let _instαSemiring ← synthInstanceQ q(CommSemiring $α)
-    let _instαPartialOrder ← synthInstanceQ q(PartialOrder $α)
-    let _instβSemiring ← synthInstanceQ q(Semiring $β)
-    let _instβPartialOrder  ← synthInstanceQ q(PartialOrder $β)
-    let _instβIsOrderedRing ← synthInstanceQ q(IsOrderedRing $β)
-    let _instαβsmul ← synthInstanceQ q(SMulPosMono $α $β)
-    assertInstancesCommute
-    return .nonnegative q(algebraMap_nonneg $β $pa)
-  | _ => pure .none
-
-example [Semiring β] [PartialOrder β] [IsOrderedRing β] [Algebra α β] [SMulPosMono α β]
-    {a : α} (ha : 0 ≤ a) :
-    0 ≤ algebraMap α β a := by positivity
-
-example [Semiring β] [PartialOrder β] [IsOrderedRing β] [Algebra α β] [SMulPosMono α β]
-    {a : α} (ha : 0 < a) :
-    0 ≤ algebraMap α β a := by positivity
-
-example [Semiring β] [PartialOrder β] [IsStrictOrderedRing β] [Algebra α β] [SMulPosStrictMono α β]
-    {a : α} (ha : 0 < a) :
-    0 < algebraMap α β a := by positivity
-
-end Mathlib.Meta.Positivity
+@[deprecated (since := "2025-12-16")] alias algebraMap_monotone := algebraMap_mono

--- a/Mathlib/LinearAlgebra/Ray.lean
+++ b/Mathlib/LinearAlgebra/Ray.lean
@@ -6,7 +6,7 @@ Authors: Joseph Myers
 module
 
 public import Mathlib.Algebra.BigOperators.Fin
-public import Mathlib.Algebra.Order.Module.Algebra
+public import Mathlib.Algebra.Order.Algebra
 public import Mathlib.Algebra.Ring.Subring.Units
 public import Mathlib.LinearAlgebra.LinearIndependent.Defs
 public import Mathlib.Tactic.LinearCombination


### PR DESCRIPTION
---
<!-- Your PR title will become the first line of the commit message.

In this box, the text above the `---` (if not empty) will be appended
to the commit message, and can be used to give additional context or
details. Please leave a blank newline before the `---`, otherwise GitHub
will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

When merging, all the commits will be squashed into a single commit
listing all co-authors.

Co-authors in the squash commit are gathered from two sources:

First, all authors of commits to this PR branch are included. Thus,
one way to add co-authors is to include at least one commit authored by
each co-author among the commits in the pull request. If necessary, you
may create empty commits to indicate co-authorship, using commands like so:

git commit --author="Author Name <author@email.com>" --allow-empty -m "add Author Name as coauthor"

Second, co-authors can also be listed in lines at the very bottom of
the commit message (that is, directly before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines
at the bottom of the commit message (before the `---`, and also before
any "Co-authored-by" lines) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
