### PR TITLE
[Merged by Bors] - feat(CategoryTheory/Monoidal/Rigid): define dual functors

### DIFF
--- a/Mathlib.lean
+++ b/Mathlib.lean
@@ -2832,6 +2832,7 @@ public import Mathlib.CategoryTheory.Monoidal.Opposite.Mon_
 public import Mathlib.CategoryTheory.Monoidal.Preadditive
 public import Mathlib.CategoryTheory.Monoidal.Rigid.Basic
 public import Mathlib.CategoryTheory.Monoidal.Rigid.Braided
+public import Mathlib.CategoryTheory.Monoidal.Rigid.Functor
 public import Mathlib.CategoryTheory.Monoidal.Rigid.FunctorCategory
 public import Mathlib.CategoryTheory.Monoidal.Rigid.OfEquivalence
 public import Mathlib.CategoryTheory.Monoidal.Skeleton

--- a/Mathlib/CategoryTheory/Monoidal/Rigid/Functor.lean
+++ b/Mathlib/CategoryTheory/Monoidal/Rigid/Functor.lean
@@ -1,0 +1,75 @@
+/-
+Copyright (c) 2025 Kim Morrison. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Kim Morrison
+-/
+import Mathlib.CategoryTheory.Monoidal.Rigid.Basic
+import Mathlib.CategoryTheory.Monoidal.Opposite
+
+/-!
+# Dual Functors for Rigid Categories
+
+This file defines the left and right dual functors from a rigid monoidal category
+to `(Cᵒᵖ)ᴹᵒᵖ` (the monoidal opposite of the opposite category).
+
+## Main definitions
+
+* `leftDualFunctor C`: For a left rigid category, the functor `C ⥤ (Cᵒᵖ)ᴹᵒᵖ` sending
+  `X` to `ᘁX` and `f` to `ᘁf`.
+* `rightDualFunctor C`: For a right rigid category, the functor `C ⥤ (Cᵒᵖ)ᴹᵒᵖ` sending
+  `X` to `Xᘁ` and `f` to `fᘁ`.
+
+## Future work
+
+* Show that in a `RigidCategory`, these functors are monoidal equivalences.
+-/
+
+namespace CategoryTheory
+
+open Category MonoidalCategory MonoidalOpposite Opposite
+
+universe v u
+
+variable (C : Type u) [Category.{v} C] [MonoidalCategory C]
+
+section LeftRigid
+
+variable [LeftRigidCategory C]
+
+/-- The left dual functor from `C` to `(Cᵒᵖ)ᴹᵒᵖ`. -/
+def leftDualFunctor : C ⥤ (Cᵒᵖ)ᴹᵒᵖ where
+  obj X := mop (op (ᘁX))
+  map f := (ᘁf).op.mop
+  map_id X := by simp [leftAdjointMate_id]
+  map_comp f g := by simp [comp_leftAdjointMate]
+
+@[simp]
+lemma leftDualFunctor_obj (X : C) : (leftDualFunctor C).obj X = mop (op (ᘁX)) := rfl
+
+@[simp]
+lemma leftDualFunctor_map {X Y : C} (f : X ⟶ Y) :
+    (leftDualFunctor C).map f = (ᘁf).op.mop := rfl
+
+end LeftRigid
+
+section RightRigid
+
+variable [RightRigidCategory C]
+
+/-- The right dual functor from `C` to `(Cᵒᵖ)ᴹᵒᵖ`. -/
+def rightDualFunctor : C ⥤ (Cᵒᵖ)ᴹᵒᵖ where
+  obj X := mop (op (Xᘁ))
+  map f := (fᘁ).op.mop
+  map_id X := by simp [rightAdjointMate_id]
+  map_comp f g := by simp [comp_rightAdjointMate]
+
+@[simp]
+lemma rightDualFunctor_obj (X : C) : (rightDualFunctor C).obj X = mop (op (Xᘁ)) := rfl
+
+@[simp]
+lemma rightDualFunctor_map {X Y : C} (f : X ⟶ Y) :
+    (rightDualFunctor C).map f = (fᘁ).op.mop := rfl
+
+end RightRigid
+
+end CategoryTheory

--- a/Mathlib/CategoryTheory/Monoidal/Rigid/Functor.lean
+++ b/Mathlib/CategoryTheory/Monoidal/Rigid/Functor.lean
@@ -5,8 +5,8 @@ Authors: Kim Morrison
 -/
 module
 
-import Mathlib.CategoryTheory.Monoidal.Rigid.Basic
-import Mathlib.CategoryTheory.Monoidal.Opposite
+public import Mathlib.CategoryTheory.Monoidal.Rigid.Basic
+public import Mathlib.CategoryTheory.Monoidal.Opposite
 
 /-!
 # Dual Functors for Rigid Categories
@@ -39,8 +39,8 @@ section LeftRigid
 variable [LeftRigidCategory C]
 
 /-- The left dual functor from `C` to `(Cᵒᵖ)ᴹᵒᵖ`. -/
-@[simps obj map]
-def leftDualFunctor : C ⥤ (Cᵒᵖ)ᴹᵒᵖ where
+@[simps obj map, expose]
+public def leftDualFunctor : C ⥤ (Cᵒᵖ)ᴹᵒᵖ where
   obj X := mop (op (ᘁX))
   map f := (ᘁf).op.mop
   map_id X := by simp [leftAdjointMate_id]
@@ -53,8 +53,8 @@ section RightRigid
 variable [RightRigidCategory C]
 
 /-- The right dual functor from `C` to `(Cᵒᵖ)ᴹᵒᵖ`. -/
-@[simps obj map]
-def rightDualFunctor : C ⥤ (Cᵒᵖ)ᴹᵒᵖ where
+@[simps obj map, expose]
+public def rightDualFunctor : C ⥤ (Cᵒᵖ)ᴹᵒᵖ where
   obj X := mop (op (Xᘁ))
   map f := (fᘁ).op.mop
   map_id X := by simp [rightAdjointMate_id]

--- a/Mathlib/CategoryTheory/Monoidal/Rigid/Functor.lean
+++ b/Mathlib/CategoryTheory/Monoidal/Rigid/Functor.lean
@@ -3,6 +3,8 @@ Copyright (c) 2025 Kim Morrison. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Kim Morrison
 -/
+module
+
 import Mathlib.CategoryTheory.Monoidal.Rigid.Basic
 import Mathlib.CategoryTheory.Monoidal.Opposite
 

--- a/Mathlib/CategoryTheory/Monoidal/Rigid/Functor.lean
+++ b/Mathlib/CategoryTheory/Monoidal/Rigid/Functor.lean
@@ -37,18 +37,12 @@ section LeftRigid
 variable [LeftRigidCategory C]
 
 /-- The left dual functor from `C` to `(Cᵒᵖ)ᴹᵒᵖ`. -/
+@[simps obj map]
 def leftDualFunctor : C ⥤ (Cᵒᵖ)ᴹᵒᵖ where
   obj X := mop (op (ᘁX))
   map f := (ᘁf).op.mop
   map_id X := by simp [leftAdjointMate_id]
   map_comp f g := by simp [comp_leftAdjointMate]
-
-@[simp]
-lemma leftDualFunctor_obj (X : C) : (leftDualFunctor C).obj X = mop (op (ᘁX)) := rfl
-
-@[simp]
-lemma leftDualFunctor_map {X Y : C} (f : X ⟶ Y) :
-    (leftDualFunctor C).map f = (ᘁf).op.mop := rfl
 
 end LeftRigid
 
@@ -57,18 +51,12 @@ section RightRigid
 variable [RightRigidCategory C]
 
 /-- The right dual functor from `C` to `(Cᵒᵖ)ᴹᵒᵖ`. -/
+@[simps obj map]
 def rightDualFunctor : C ⥤ (Cᵒᵖ)ᴹᵒᵖ where
   obj X := mop (op (Xᘁ))
   map f := (fᘁ).op.mop
   map_id X := by simp [rightAdjointMate_id]
   map_comp f g := by simp [comp_rightAdjointMate]
-
-@[simp]
-lemma rightDualFunctor_obj (X : C) : (rightDualFunctor C).obj X = mop (op (Xᘁ)) := rfl
-
-@[simp]
-lemma rightDualFunctor_map {X Y : C} (f : X ⟶ Y) :
-    (rightDualFunctor C).map f = (fᘁ).op.mop := rfl
 
 end RightRigid
 


### PR DESCRIPTION
This PR defines the left and right dual functors from a rigid monoidal category to `(Cᵒᵖ)ᴹᵒᵖ` (the monoidal opposite of the opposite category).

- `leftDualFunctor C`: For a left rigid category, the functor `C ⥤ (Cᵒᵖ)ᴹᵒᵖ` sending `X` to `ᘁX` and `f` to `ᘁf`.
- `rightDualFunctor C`: For a right rigid category, the functor `C ⥤ (Cᵒᵖ)ᴹᵒᵖ` sending `X` to `Xᘁ` and `f` to `fᘁ`.

Future work: Show that in a `RigidCategory`, these functors are monoidal equivalences.

🤖 Prepared with Claude Code