### PR TITLE
[Merged by Bors] - chore: remove multiGoal false options

### DIFF
--- a/Mathlib/Analysis/Analytic/Within.lean
+++ b/Mathlib/Analysis/Analytic/Within.lean
@@ -110,7 +110,6 @@ result for `AnalyticOn`, as this requires a bit more work to show that local ext
 be stitched together.
 -/
 
-set_option linter.style.multiGoal false in
 /-- `f` has power series `p` at `x` iff some local extension of `f` has that series -/
 lemma hasFPowerSeriesWithinOnBall_iff_exists_hasFPowerSeriesOnBall [CompleteSpace F] {f : E → F}
     {p : FormalMultilinearSeries 𝕜 E F} {s : Set E} {x : E} {r : ℝ≥0∞} :
@@ -123,11 +122,11 @@ lemma hasFPowerSeriesWithinOnBall_iff_exists_hasFPowerSeriesOnBall [CompleteSpac
     · intro y ⟨ys,yb⟩
       simp only [EMetric.mem_ball, edist_eq_enorm_sub] at yb
       have e0 := p.hasSum (x := y - x) ?_
-      have e1 := (h.hasSum (y := y - x) ?_ ?_)
-      · simp only [add_sub_cancel] at e1
-        exact e1.unique e0
-      · simpa only [add_sub_cancel]
-      · simpa only [EMetric.mem_ball, edist_zero_eq_enorm]
+      · have e1 := (h.hasSum (y := y - x) ?_ ?_)
+        · simp only [add_sub_cancel] at e1
+          exact e1.unique e0
+        · simpa only [add_sub_cancel]
+        · simpa only [EMetric.mem_ball, edist_zero_eq_enorm]
       · simp only [EMetric.mem_ball, edist_zero_eq_enorm]
         exact lt_of_lt_of_le yb h.r_le
     · refine ⟨h.r_le, h.r_pos, ?_⟩

--- a/Mathlib/Analysis/CStarAlgebra/ApproximateUnit.lean
+++ b/Mathlib/Analysis/CStarAlgebra/ApproximateUnit.lean
@@ -102,8 +102,6 @@ lemma norm_cfcₙ_one_sub_one_add_inv_lt_one (a : A) :
     ‖cfcₙ (fun x : ℝ≥0 ↦ 1 - (1 + x)⁻¹) a‖ < 1 :=
   nnnorm_cfcₙ_nnreal_lt fun x _ ↦ tsub_lt_self zero_lt_one (by positivity)
 
--- the calls to `fun_prop` with a discharger set off the linter
-set_option linter.style.multiGoal false in
 lemma CStarAlgebra.directedOn_nonneg_ball :
     DirectedOn (· ≤ ·) ({x : A | 0 ≤ x} ∩ Metric.ball 0 1) := by
   let f : ℝ≥0 → ℝ≥0 := fun x => 1 - (1 + x)⁻¹

--- a/Mathlib/Probability/Kernel/Proper.lean
+++ b/Mathlib/Probability/Kernel/Proper.lean
@@ -90,7 +90,6 @@ private lemma IsProper.lintegral_indicator_mul_indicator (hπ : IsProper π) (h�
     Pi.one_apply, one_mul]
   rw [← hπ.inter_eq_indicator_mul h𝓑𝓧 hA hB, inter_comm]
 
-set_option linter.style.multiGoal false in -- false positive
 /-- Auxiliary lemma for `IsProper.lintegral_mul` and
 `IsProper.setLIntegral_eq_indicator_mul_lintegral`. -/
 private lemma IsProper.lintegral_indicator_mul (hπ : IsProper π) (h𝓑𝓧 : 𝓑 ≤ 𝓧)
@@ -107,7 +106,7 @@ private lemma IsProper.lintegral_indicator_mul (hπ : IsProper π) (h𝓑𝓧 : 
   · rintro f' hf'_meas hf'_mono hf'
     simp_rw [ENNReal.mul_iSup]
     rw [lintegral_iSup (by measurability), lintegral_iSup hf'_meas hf'_mono, ENNReal.mul_iSup]
-    simp_rw [hf']
+    · simp_rw [hf']
     · exact hf'_mono.const_mul (zero_le _)
 
 lemma IsProper.setLIntegral_eq_indicator_mul_lintegral (hπ : IsProper π) (h𝓑𝓧 : 𝓑 ≤ 𝓧)


### PR DESCRIPTION
There are 3 such removals and they are removed for 3 different reasons:
* in `Mathlib/Analysis/Analytic/Within.lean`, there are several active goals, so we use the focusing dots;
* in `Mathlib/Analysis/CStarAlgebra/ApproximateUnit.lean`, the linter does not actually flag an issue;
* in `Mathlib/Probability/Kernel/Proper.lean`, the *infoview* hides a goal in the presence of `simp_rw`, but the goal is there ([#mathlib4 > &#96;simp_rw&#96; hides a goal @ 💬](https://leanprover.zulipchat.com/#narrow/channel/287929-mathlib4/topic/.60simp_rw.60.20hides.20a.20goal/near/564013486)).

---
<!-- Your PR title will become the first line of the commit message.

In this box, the text above the `---` (if not empty) will be appended
to the commit message, and can be used to give additional context or
details. Please leave a blank newline before the `---`, otherwise GitHub
will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

When merging, all the commits will be squashed into a single commit
listing all co-authors.

Co-authors in the squash commit are gathered from two sources:

First, all authors of commits to this PR branch are included. Thus,
one way to add co-authors is to include at least one commit authored by
each co-author among the commits in the pull request. If necessary, you
may create empty commits to indicate co-authorship, using commands like so:

git commit --author="Author Name <author@email.com>" --allow-empty -m "add Author Name as coauthor"

Second, co-authors can also be listed in lines at the very bottom of
the commit message (that is, directly before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines
at the bottom of the commit message (before the `---`, and also before
any "Co-authored-by" lines) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
