### PR TITLE
feat(FieldTheory): adjoin pth roots

### DIFF
--- a/Mathlib.lean
+++ b/Mathlib.lean
@@ -4108,6 +4108,7 @@ public import Mathlib.FieldTheory.PerfectClosure
 public import Mathlib.FieldTheory.PolynomialGaloisGroup
 public import Mathlib.FieldTheory.PrimeField
 public import Mathlib.FieldTheory.PrimitiveElement
+public import Mathlib.FieldTheory.PurelyInseparable.AdjoinPthRoots
 public import Mathlib.FieldTheory.PurelyInseparable.Basic
 public import Mathlib.FieldTheory.PurelyInseparable.Exponent
 public import Mathlib.FieldTheory.PurelyInseparable.PerfectClosure

--- a/Mathlib/FieldTheory/PurelyInseparable/AdjoinPthRoots.lean
+++ b/Mathlib/FieldTheory/PurelyInseparable/AdjoinPthRoots.lean
@@ -40,24 +40,24 @@ noncomputable section
 variable {k : Type*} [Field k]
 variable (p : ℕ) [ExpChar k p]
 
-private instance : ExpChar (AlgebraicClosure k) p := ExpChar.of_injective_algebraMap' k _
+instance : ExpChar (AlgebraicClosure k) p := ExpChar.of_injective_algebraMap' k _
 
 /-- Given a field `k` of exponential characteristic `p` and a subset `S` of `k`, the field
 `adjoin_pth_roots p S` is obtained by adjoining all `p`-th roots of elements of `S` to `k`. We
 construct this as an object of type `IntermediateField k (AlgebraicClosure k)`, which automatically
 gives us the structure of a field and of a `k`-algebra. -/
-def adjoin_pth_roots (S : Set k) : IntermediateField k (AlgebraicClosure k) :=
+def IntermediateField.adjoinPthRoots (S : Set k) : IntermediateField k (AlgebraicClosure k) :=
   IntermediateField.adjoin k <|
     (frobenius (AlgebraicClosure k) p) ⁻¹' ((algebraMap k (AlgebraicClosure k)) '' S)
 
-lemma adjoin_pth_roots.mono {S T : Set k} (hST : S ⊆ T) :
-    adjoin_pth_roots p S ≤ adjoin_pth_roots p T :=
+lemma adjoinPthRoots_mono {S T : Set k} (hST : S ⊆ T) :
+    adjoinPthRoots p S ≤ adjoinPthRoots p T :=
   IntermediateField.adjoin.mono k _ _ <| Set.preimage_mono <| Set.image_mono hST
 
 /-- If the set `S` whose `p`-th roots we adjoin is finite, then the obtained field extension
 `(adjoin_pth_roots p S) / k` is finite. -/
-lemma adjoin_pth_roots.finite_of_finite (S : Set k) [Finite S] :
-    FiniteDimensional k (adjoin_pth_roots p S) := by
+lemma adjoinPthRoots_finite_of_finite (S : Set k) [Finite S] :
+    FiniteDimensional k (adjoinPthRoots p S) := by
   -- The set of elements to adjoin to `k` is finite:
   have hFin : Finite ((frobenius (AlgebraicClosure k) p) ⁻¹'
       ((algebraMap k (AlgebraicClosure k)) '' S)) := by
@@ -81,9 +81,9 @@ lemma adjoin_pth_roots.finite_of_finite (S : Set k) [Finite S] :
   exact isIntegral_algebraMap
 
 /-- The field extension `(adjoin_pth_roots p S) / k` is purely inseparable. -/
-instance adjoin_pth_roots.purelyInseparable (S : Set k) :
-    IsPurelyInseparable k (adjoin_pth_roots p S) := by
-  unfold adjoin_pth_roots
+instance adjoinPthRoots_purelyInseparable (S : Set k) :
+    IsPurelyInseparable k (adjoinPthRoots p S) := by
+  unfold adjoinPthRoots
   rw [IntermediateField.isPurelyInseparable_adjoin_iff_pow_mem k (AlgebraicClosure k) p]
   intro s hs
   use 1
@@ -95,9 +95,9 @@ instance adjoin_pth_roots.purelyInseparable (S : Set k) :
 
 /-- If `y ∈ S`, then there is an element `x ∈ adjoin_pth_roots p S` with the property that
 `y = x ^ p`. -/
-lemma adjoin_pth_roots.mem_frobenius_img {S : Set k} {y : k} (hy : y ∈ S) :
+lemma adjoinPthRoots_mem_frobenius_img {S : Set k} {y : k} (hy : y ∈ S) :
     algebraMap k (AlgebraicClosure k) y ∈ Subfield.map (frobenius (AlgebraicClosure k) p)
-      (adjoin_pth_roots p S).toSubfield := by
+      (adjoinPthRoots p S).toSubfield := by
   use (frobeniusEquiv (AlgebraicClosure k) p).symm (algebraMap k _ y)
   refine ⟨?_, by simp⟩
   apply Subfield.mem_closure_of_mem
@@ -107,13 +107,13 @@ lemma adjoin_pth_roots.mem_frobenius_img {S : Set k} {y : k} (hy : y ∈ S) :
 
 -- a relative version of `adjoin_pth_roots.frob_img_mem`, which allows for
 -- `adjoin_pth_roots` to be embedded in the algebraic closure of a bigger field.
-lemma adjoin_pth_roots.mem_frobenius_img' (K : Type*) [Field K] [Algebra k K] {S : Set k} {y : K}
+lemma adjoinPthRoots_mem_frobenius_img' (K : Type*) [Field K] [Algebra k K] {S : Set k} {y : K}
     (hy : y ∈ (algebraMap k K) '' S) :
     haveI : ExpChar (AlgebraicClosure K) p := ExpChar.of_injective_algebraMap' k _
     algebraMap K (AlgebraicClosure K) y ∈ Subfield.map (frobenius (AlgebraicClosure K) p)
-      ((adjoin_pth_roots p S).map IsAlgClosed.lift).toSubfield := by
+      ((adjoinPthRoots p S).map IsAlgClosed.lift).toSubfield := by
   haveI : ExpChar (AlgebraicClosure K) p := ExpChar.of_injective_algebraMap' k _
-  unfold adjoin_pth_roots
+  unfold adjoinPthRoots
   rw [Subfield.mem_map]
   use (frobeniusEquiv (AlgebraicClosure K) p).symm (algebraMap K _ y)
   refine ⟨?_, by simp⟩

--- a/Mathlib/FieldTheory/PurelyInseparable/AdjoinPthRoots.lean
+++ b/Mathlib/FieldTheory/PurelyInseparable/AdjoinPthRoots.lean
@@ -1,0 +1,130 @@
+/-
+Copyright (c) 2025 Dion Leijnse. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Dion Leijnse
+-/
+
+module
+
+public import Mathlib.FieldTheory.PurelyInseparable.PerfectClosure
+
+/-!
+# The field extension obtained by adjoining pth roots to a field of characteristic p
+
+In this file we construct the extension of a field of characteristic `p` obtained by adjoining
+the `p`-th roots of a subset.
+
+## Main definitions
+
+- `adjoin_pth_roots`
+
+## Main results
+
+- `adjoin_pth_roots.finite_of_finite`: if `S` is finite, then `(adjoin_pth_roots p S) / k` is a
+  finite field extension
+
+- `adjoin_pth_roots.purelyInseparable`: the field extension `(adjoin_pth_roots p S) / k` is purely
+  inseparable
+
+- `adjoin_pth_roots.mem_frobenius_img`: every element of `S` is in the image of the frobenius
+  morphism on `adjoin_pth_roots p S`.
+
+-/
+
+@[expose] public section
+
+open IntermediateField
+
+noncomputable section
+
+variable {k : Type*} [Field k]
+variable (p : ℕ) [ExpChar k p]
+
+private instance : ExpChar (AlgebraicClosure k) p := ExpChar.of_injective_algebraMap' k _
+
+/-- Given a field `k` of exponential characteristic `p` and a subset `S` of `k`, the field
+`adjoin_pth_roots p S` is obtained by adjoining all `p`-th roots of elements of `S` to `k`. We
+construct this as an object of type `IntermediateField k (AlgebraicClosure k)`, which automatically
+gives us the structure of a field and of a `k`-algebra. -/
+def adjoin_pth_roots (S : Set k) : IntermediateField k (AlgebraicClosure k) :=
+  IntermediateField.adjoin k <|
+    (frobenius (AlgebraicClosure k) p) ⁻¹' ((algebraMap k (AlgebraicClosure k)) '' S)
+
+lemma adjoin_pth_roots.mono {S T : Set k} (hST : S ⊆ T) :
+    adjoin_pth_roots p S ≤ adjoin_pth_roots p T :=
+  IntermediateField.adjoin.mono k _ _ <| Set.preimage_mono <| Set.image_mono hST
+
+/-- If the set `S` whose `p`-th roots we adjoin is finite, then the obtained field extension
+`(adjoin_pth_roots p S) / k` is finite. -/
+lemma adjoin_pth_roots.finite_of_finite (S : Set k) [Finite S] :
+    FiniteDimensional k (adjoin_pth_roots p S) := by
+  -- The set of elements to adjoin to `k` is finite:
+  have hFin : Finite ((frobenius (AlgebraicClosure k) p) ⁻¹'
+      ((algebraMap k (AlgebraicClosure k)) '' S)) := by
+    have hFin' : Finite ((algebraMap k (AlgebraicClosure k)) '' S) := by infer_instance
+    exact Set.Finite.preimage (Set.injOn_of_injective (frobenius_inj _ _)) (hFin')
+  apply IntermediateField.finiteDimensional_adjoin
+  -- It remains to show that every element of the set
+  -- `` ((frobenius (AlgebraicClosure k) p) ⁻¹' ((algebraMap k (AlgebraicClosure k)) '' S))``
+  -- is integral over `k`.
+  intro s hs
+  apply IsIntegral.of_pow (n := p) (expChar_pos k p)
+  have hs_mem : s ^ p ∈ (algebraMap k (AlgebraicClosure k))'' S := by
+    simp_all only [Set.mem_preimage, Set.mem_image]
+    obtain ⟨w, hw⟩ := hs
+    use w
+    rw [hw.2]
+    exact ⟨hw.1, rfl⟩
+  rw [Set.mem_image] at hs_mem
+  obtain ⟨y, hy⟩ := hs_mem
+  rw [← hy.2]
+  exact isIntegral_algebraMap
+
+/-- The field extension `(adjoin_pth_roots p S) / k` is purely inseparable. -/
+instance adjoin_pth_roots.purelyInseparable (S : Set k) :
+    IsPurelyInseparable k (adjoin_pth_roots p S) := by
+  unfold adjoin_pth_roots
+  rw [IntermediateField.isPurelyInseparable_adjoin_iff_pow_mem k (AlgebraicClosure k) p]
+  intro s hs
+  use 1
+  simp_all only [Set.mem_preimage, Set.mem_image, pow_one, RingHom.mem_range]
+  obtain ⟨w, h1, h2⟩ := hs
+  use w
+  rw [h2]
+  rfl
+
+/-- If `y ∈ S`, then there is an element `x ∈ adjoin_pth_roots p S` with the property that
+`y = x ^ p`. -/
+lemma adjoin_pth_roots.mem_frobenius_img {S : Set k} {y : k} (hy : y ∈ S) :
+    algebraMap k (AlgebraicClosure k) y ∈ Subfield.map (frobenius (AlgebraicClosure k) p)
+      (adjoin_pth_roots p S).toSubfield := by
+  use (frobeniusEquiv (AlgebraicClosure k) p).symm (algebraMap k _ y)
+  refine ⟨?_, by simp⟩
+  apply Subfield.mem_closure_of_mem
+  right
+  use y
+  exact ⟨hy, by simp⟩
+
+-- a relative version of `adjoin_pth_roots.frob_img_mem`, which allows for
+-- `adjoin_pth_roots` to be embedded in the algebraic closure of a bigger field.
+lemma adjoin_pth_roots.mem_frobenius_img' (K : Type*) [Field K] [Algebra k K] {S : Set k} {y : K}
+    (hy : y ∈ (algebraMap k K) '' S) :
+    haveI : ExpChar (AlgebraicClosure K) p := ExpChar.of_injective_algebraMap' k _
+    algebraMap K (AlgebraicClosure K) y ∈ Subfield.map (frobenius (AlgebraicClosure K) p)
+      ((adjoin_pth_roots p S).map IsAlgClosed.lift).toSubfield := by
+  haveI : ExpChar (AlgebraicClosure K) p := ExpChar.of_injective_algebraMap' k _
+  unfold adjoin_pth_roots
+  rw [Subfield.mem_map]
+  use (frobeniusEquiv (AlgebraicClosure K) p).symm (algebraMap K _ y)
+  refine ⟨?_, by simp⟩
+  simp only [toSubfield_map, Subfield.mem_map, RingHom.coe_coe]
+  obtain ⟨z, hz⟩ := (Set.mem_image _ _ _).mp hy
+  use (frobeniusEquiv (AlgebraicClosure k) p).symm (algebraMap k _ z)
+  constructor
+  · apply Subfield.mem_closure_of_mem
+    simp only [Set.mem_union, Set.mem_range, Set.mem_preimage, frobenius_apply_frobeniusEquiv_symm,
+      Set.mem_image, algebraMap.coe_inj, exists_eq_right]
+    exact Or.inr hz.left
+  · rw [← hz.2, ← RingHom.coe_coe, RingHom.map_frobeniusEquiv_symm, RingHom.coe_coe,
+      AlgHom.commutes]
+    rfl


### PR DESCRIPTION
For a field `k` of exponential characteristic `p` and a subset `S` of `k`, we define the extension of `k` obtained by adjoining all `p`-th roots of elements of `S`. We prove that this is a purely inseparable extension, and provide some basic API.

---
<!-- Your PR title will become the first line of the commit message.

In this box, the text above the `---` (if not empty) will be appended
to the commit message, and can be used to give additional context or
details. Please leave a blank newline before the `---`, otherwise GitHub
will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

When merging, all the commits will be squashed into a single commit
listing all co-authors.

Co-authors in the squash commit are gathered from two sources:

First, all authors of commits to this PR branch are included. Thus,
one way to add co-authors is to include at least one commit authored by
each co-author among the commits in the pull request. If necessary, you
may create empty commits to indicate co-authorship, using commands like so:

git commit --author="Author Name <author@email.com>" --allow-empty -m "add Author Name as coauthor"

Second, co-authors can also be listed in lines at the very bottom of
the commit message (that is, directly before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines
at the bottom of the commit message (before the `---`, and also before
any "Co-authored-by" lines) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
