### PR TITLE
[Merged by Bors] - chore(RingTheory): fix whitespace

### DIFF
--- a/Mathlib/RingTheory/Congruence/Hom.lean
+++ b/Mathlib/RingTheory/Congruence/Hom.lean
@@ -358,7 +358,7 @@ noncomputable def comapQuotientEquivRangeS (f : N →+* M)
 @[simp] theorem comapQuotientEquivRangeS_symm_mk (f : N →+* M)
     {d : RingCon N} (hcd : d = comap c f) (x : N) :
     (c.comapQuotientEquivRangeS f hcd).symm
-      (⟨f x, RingHom.mem_rangeS_self (c.mk'.comp f) x ⟩) = x :=  by
+      (⟨f x, RingHom.mem_rangeS_self (c.mk'.comp f) x ⟩) = x := by
   simp [RingEquiv.symm_apply_eq]
 
 /-- The **third isomorphism theorem for (semi-)rings**. -/
@@ -436,7 +436,7 @@ theorem comapQuotientEquivRange_mk
 @[simp] theorem comapQuotientEquivRange_symm_mk (f : N →+* M)
     {d : RingCon N} (hcd : d = comap c f) (x : N) :
     (c.comapQuotientEquivRange f hcd).symm
-      (⟨f x, RingHom.mem_range_self (c.mk'.comp f) x ⟩) = x :=  by
+      (⟨f x, RingHom.mem_range_self (c.mk'.comp f) x ⟩) = x := by
   simp [RingEquiv.symm_apply_eq, ← Subtype.coe_inj]
 
 end

--- a/Mathlib/RingTheory/Coprime/Lemmas.lean
+++ b/Mathlib/RingTheory/Coprime/Lemmas.lean
@@ -68,7 +68,7 @@ theorem Int.isCoprime_gcdA {x y : ℤ} (h : IsCoprime x y) : IsCoprime (x.gcdA y
 
 theorem Int.isCoprime_gcdB {x y : ℤ} (h : IsCoprime x y) : IsCoprime (x.gcdB y) x := by
   use y, x.gcdA y
-  rwa [add_comm, mul_comm , ← Int.gcd_eq_gcd_ab, Nat.cast_eq_one, ← Int.isCoprime_iff_gcd_eq_one]
+  rwa [add_comm, mul_comm, ← Int.gcd_eq_gcd_ab, Nat.cast_eq_one, ← Int.isCoprime_iff_gcd_eq_one]
 
 theorem ne_zero_or_ne_zero_of_nat_coprime {A : Type u} [CommRing A] [Nontrivial A] {a b : ℕ}
     (h : Nat.Coprime a b) : (a : A) ≠ 0 ∨ (b : A) ≠ 0 :=

--- a/Mathlib/RingTheory/DedekindDomain/Ideal/Lemmas.lean
+++ b/Mathlib/RingTheory/DedekindDomain/Ideal/Lemmas.lean
@@ -811,8 +811,7 @@ noncomputable def IsDedekindDomain.quotientEquivPiFactors {I : Ideal R} (hI : I 
         (factors I).toFinset.prod_coe_sort fun P => P ^ (factors I).count P
       _ = ((factors I).map fun P => P).prod := (Finset.prod_multiset_map_count (factors I) id).symm
       _ = (factors I).prod := by rw [Multiset.map_id']
-      _ = I := associated_iff_eq.mp (factors_prod hI)
-      )
+      _ = I := associated_iff_eq.mp (factors_prod hI))
 
 @[simp]
 theorem IsDedekindDomain.quotientEquivPiFactors_mk {I : Ideal R} (hI : I ≠ ⊥) (x : R) :

--- a/Mathlib/RingTheory/Etale/StandardEtale.lean
+++ b/Mathlib/RingTheory/Etale/StandardEtale.lean
@@ -202,7 +202,7 @@ def equivAwayAdjoinRoot :
   · rw [aeval_algebraMap_apply, AdjoinRoot.aeval_eq]
     exact IsLocalization.Away.algebraMap_isUnit ..
   · change Submonoid.powers _ ≤ (IsUnit.submonoid _).comap _
-    simpa [Submonoid.powers_le,  IsUnit.mem_submonoid_iff] using P.hasMap_X.2
+    simpa [Submonoid.powers_le, IsUnit.mem_submonoid_iff] using P.hasMap_X.2
   · ext; simp [Algebra.algHom]
   · ext; simp
 
@@ -219,7 +219,7 @@ def equivAwayQuotient :
       aeval_X_left_apply]
     exact (IsLocalization.Away.algebraMap_isUnit ..).map _
   · change Submonoid.powers _ ≤ (IsUnit.submonoid _).comap _
-    simpa [Submonoid.powers_le,  IsUnit.mem_submonoid_iff] using P.hasMap_X.2
+    simpa [Submonoid.powers_le, IsUnit.mem_submonoid_iff] using P.hasMap_X.2
   · change Ideal.span _ ≤ RingHom.ker _
     simpa [Ideal.span_le] using P.hasMap_X.1
   · apply Ideal.Quotient.algHom_ext

--- a/Mathlib/RingTheory/Extension/Presentation/Basic.lean
+++ b/Mathlib/RingTheory/Extension/Presentation/Basic.lean
@@ -280,7 +280,7 @@ private lemma span_range_relation_eq_ker_baseChange :
 obtain a natural presentation of `T ⊗[R] S` over `T`. -/
 @[simps relation]
 noncomputable
-def baseChange : Presentation T (T ⊗[R] S) ι σ  where
+def baseChange : Presentation T (T ⊗[R] S) ι σ where
   __ := P.toGenerators.baseChange T
   relation i := MvPolynomial.map (algebraMap R T) (P.relation i)
   span_range_relation_eq_ker := P.span_range_relation_eq_ker_baseChange T

--- a/Mathlib/RingTheory/Flat/Basic.lean
+++ b/Mathlib/RingTheory/Flat/Basic.lean
@@ -308,7 +308,7 @@ lemma lTensor_exact [Flat R M] ⦃N N' N'' : Type*⦄
   suffices exact1 : Function.Exact (f.lTensor M) (π.lTensor M) by
     rw [show g = ι.comp π from rfl, lTensor_comp]
     exact exact1.comp_injective _ (lTensor_preserves_injective_linearMap ι <| by
-      simpa [ι, - Subtype.val_injective] using Subtype.val_injective) (map_zero _)
+      simpa [ι, -Subtype.val_injective] using Subtype.val_injective) (map_zero _)
   exact _root_.lTensor_exact _ (fun x ↦ by simp [π]) Quotient.mk''_surjective
 
 variable (M) in
@@ -325,7 +325,7 @@ lemma rTensor_exact [Flat R M] ⦃N N' N'' : Type*⦄
   suffices exact1 : Function.Exact (f.rTensor M) (π.rTensor M) by
     rw [show g = ι.comp π from rfl, rTensor_comp]
     exact exact1.comp_injective _ (rTensor_preserves_injective_linearMap ι <| by
-      simpa [ι, - Subtype.val_injective] using Subtype.val_injective) (map_zero _)
+      simpa [ι, -Subtype.val_injective] using Subtype.val_injective) (map_zero _)
   exact _root_.rTensor_exact M (fun x ↦ by simp [π]) Quotient.mk''_surjective
 
 /-- `M` is flat if and only if `M ⊗ -` is an exact functor. See
@@ -339,7 +339,7 @@ theorem iff_lTensor_exact' [Small.{v'} R] : Flat R M ↔
       fun x (hx : _ = 0) ↦ ?_⟩
   simpa [Eq.comm] using @H PUnit N' N'' _ _ _ _ _ _ 0 L (fun x ↦ by
     simp_rw [Set.mem_range, LinearMap.zero_apply, exists_const]
-    exact (L.map_eq_zero_iff hL).trans eq_comm) x |>.mp  hx
+    exact (L.map_eq_zero_iff hL).trans eq_comm) x |>.mp hx
 
 /-- `M` is flat if and only if `M ⊗ -` is an exact functor.
   See `Module.Flat.iff_lTensor_exact'` to generalize the universe of
@@ -599,7 +599,7 @@ theorem IsReduced.tensorProduct_of_flat_of_forall_fg {R C A : Type*}
   obtain ⟨x, hx⟩ := exists_isNilpotent_of_not_isReduced h_contra
   obtain ⟨D, hD⟩ := exists_fg_and_mem_baseChange x
   have h_inj : Function.Injective
-      (Algebra.TensorProduct.map (AlgHom.id C C ) D.val) :=
+      (Algebra.TensorProduct.map (AlgHom.id C C) D.val) :=
     Module.Flat.lTensor_preserves_injective_linearMap _ Subtype.val_injective
   obtain ⟨z, rfl⟩ := hD.2
   have h_notReduced : ¬IsReduced (C ⊗[R] D) := by

--- a/Mathlib/RingTheory/Flat/FaithfullyFlat/Basic.lean
+++ b/Mathlib/RingTheory/Flat/FaithfullyFlat/Basic.lean
@@ -295,7 +295,7 @@ lemma range_le_ker_of_exact_rTensor [fl : FaithfullyFlat R M]
     rw [← TensorProduct.span_tmul_eq_top, Submodule.mem_span_set] at mem
     obtain ⟨c, hc, rfl⟩ := mem
     choose b a hy using hc
-    let r :  ⦃a : E ⊗[R] M⦄ → a ∈ ↑c.support → R := fun a ha =>
+    let r : ⦃a : E ⊗[R] M⦄ → a ∈ ↑c.support → R := fun a ha =>
       Submodule.mem_span_singleton.1 (b ha).2 |>.choose
     have hr : ∀ ⦃i : E ⊗[R] M⦄ (hi : i ∈ c.support), b hi =
         r hi • ⟨l23 (l12 n1), Submodule.mem_span_singleton_self _⟩ := fun a ha =>

--- a/Mathlib/RingTheory/FractionalIdeal/Extended.lean
+++ b/Mathlib/RingTheory/FractionalIdeal/Extended.lean
@@ -163,7 +163,7 @@ theorem extended_coeIdeal_eq_map (I₀ : Ideal A) :
   · rintro _ ⟨_, ⟨a, ha, rfl⟩, rfl⟩
     exact Submodule.subset_span
       ⟨f a, Set.mem_image_of_mem f ha, by rw [Algebra.linearMap_apply, IsLocalization.map_eq hf a]⟩
-  · rintro _ ⟨_ , ⟨a, ha, rfl⟩, rfl⟩
+  · rintro _ ⟨_, ⟨a, ha, rfl⟩, rfl⟩
     exact Submodule.subset_span
       ⟨algebraMap A K a, mem_coeIdeal_of_mem M ha, IsLocalization.map_eq hf a⟩
 

--- a/Mathlib/RingTheory/HahnSeries/Summable.lean
+++ b/Mathlib/RingTheory/HahnSeries/Summable.lean
@@ -298,13 +298,13 @@ theorem le_hsum_support_mem {s : SummableFamily Γ R α} {g g' : Γ}
   exact hg i g' hi
 
 theorem hsum_orderTop_of_le {s : SummableFamily Γ R α} {g : Γ} {a : α} (ha : g = (s a).orderTop)
-    (hg : ∀ b : α, ∀ g' ∈ (s b).support, g ≤ g') (hna : ∀b : α, b ≠ a → (s b).coeff g = 0) :
+    (hg : ∀ b : α, ∀ g' ∈ (s b).support, g ≤ g') (hna : ∀ b : α, b ≠ a → (s b).coeff g = 0) :
     s.hsum.orderTop = g :=
   orderTop_eq_of_le (ne_of_eq_of_ne (by rw [coeff_hsum, finsum_eq_single (fun i ↦ (s i).coeff g) a
     hna]) (coeff_orderTop_ne ha.symm)) fun _ hg' => le_hsum_support_mem hg hg'
 
 theorem hsum_leadingCoeff_of_le {s : SummableFamily Γ R α} {g : Γ} {a : α} (ha : g = (s a).orderTop)
-    (hg : ∀ b : α, ∀ g' ∈ (s b).support, g ≤ g') (hna : ∀b : α, b ≠ a → (s b).coeff g = 0) :
+    (hg : ∀ b : α, ∀ g' ∈ (s b).support, g ≤ g') (hna : ∀ b : α, b ≠ a → (s b).coeff g = 0) :
     s.hsum.leadingCoeff = (s a).coeff g := by
   have := hsum_orderTop_of_le ha hg hna
   rw [orderTop] at this

--- a/Mathlib/RingTheory/Ideal/Cotangent.lean
+++ b/Mathlib/RingTheory/Ideal/Cotangent.lean
@@ -81,7 +81,7 @@ def cotangentToQuotientSquare : I.Cotangent →ₗ[R] R ⧸ I ^ 2 :=
   Submodule.mapQ (I • ⊤) (I ^ 2) I.subtype
     (by
       rw [← Submodule.map_le_iff_le_comap, Submodule.map_smul'', Submodule.map_top,
-        Submodule.range_subtype, smul_eq_mul, pow_two] )
+        Submodule.range_subtype, smul_eq_mul, pow_two])
 
 theorem to_quotient_square_comp_toCotangent :
     I.cotangentToQuotientSquare.comp I.toCotangent = (I ^ 2).mkQ.comp (Submodule.subtype I) :=
@@ -103,7 +103,7 @@ lemma isTorsionBySet_cotangent :
 
 /-- `I ⧸ I ^ 2` as an ideal of `R ⧸ I ^ 2`. -/
 def cotangentIdeal (I : Ideal R) : Ideal (R ⧸ I ^ 2) :=
-  Submodule.map (Quotient.mk (I ^ 2)|>.toSemilinearMap) I
+  Submodule.map (Quotient.mk (I ^ 2) |>.toSemilinearMap) I
 
 theorem cotangentIdeal_square (I : Ideal R) : I.cotangentIdeal ^ 2 = ⊥ := by
   rw [eq_bot_iff, pow_two I.cotangentIdeal, ← smul_eq_mul]

--- a/Mathlib/RingTheory/Ideal/GoingUp.lean
+++ b/Mathlib/RingTheory/Ideal/GoingUp.lean
@@ -287,7 +287,7 @@ theorem exists_ideal_over_prime_of_isIntegral_of_isDomain [Algebra.IsIntegral R 
   rw [comap_comap, ← IsLocalRing.eq_maximalIdeal Qₚ_max,
     ← IsLocalization.map_comp (P := S) (Q := Sₚ) (g := algebraMap R S)
     (M := P.primeCompl) (T := Algebra.algebraMapSubmonoid S P.primeCompl) (S := Rₚ)
-    (fun p hp => Algebra.mem_algebraMapSubmonoid_of_mem ⟨p, hp⟩) ]
+    (fun p hp => Algebra.mem_algebraMapSubmonoid_of_mem ⟨p, hp⟩)]
   rfl
 
 end

--- a/Mathlib/RingTheory/Ideal/Maximal.lean
+++ b/Mathlib/RingTheory/Ideal/Maximal.lean
@@ -88,7 +88,7 @@ theorem ne_top_iff_exists_maximal {I : Ideal α} : I ≠ ⊤ ↔ ∃ M : Ideal �
   exact IsMaximal.ne_top hMmax
 
 instance [Nontrivial α] : Nontrivial (Ideal α) := by
-  rcases@exists_maximal α _ _ with ⟨M, hM, _⟩
+  rcases @exists_maximal α _ _ with ⟨M, hM, _⟩
   exact nontrivial_of_ne M ⊤ hM
 
 /-- If P is not properly contained in any maximal ideal then it is not properly contained

--- a/Mathlib/RingTheory/Ideal/Norm/RelNorm.lean
+++ b/Mathlib/RingTheory/Ideal/Norm/RelNorm.lean
@@ -437,7 +437,7 @@ theorem relNorm_eq_pow_of_isMaximal [PerfectField (FractionRing R)] [P.IsMaximal
     exists_maximal_ideal_liesOver_of_isIntegral P
   have : Q.LiesOver p := LiesOver.trans Q P p
   have h := relNorm_eq_pow_of_isPrime_isGalois Q p
-  have :  IsGalois (FractionRing S) (FractionRing T) :=
+  have : IsGalois (FractionRing S) (FractionRing T) :=
     IsGalois.tower_top_of_isGalois (FractionRing R) (FractionRing S) (FractionRing T)
   rwa [← relNorm_relNorm R S, relNorm_eq_pow_of_isPrime_isGalois Q P, map_pow,
     inertiaDeg_algebra_tower p P Q, pow_mul, pow_left_inj] at h

--- a/Mathlib/RingTheory/Ideal/Operations.lean
+++ b/Mathlib/RingTheory/Ideal/Operations.lean
@@ -783,10 +783,10 @@ theorem isCoprime_biInf {J : ι → Ideal R} {s : Finset ι}
       rw [Finset.iInf_insert, inf_comm, one_eq_top, eq_top_iff, ← one_eq_top]
       set K := ⨅ j ∈ s, J j
       calc
-        1 = I + K            := (hs fun j hj ↦ hf j (Finset.mem_insert_of_mem hj)).symm
-        _ = I + K*(I + J i)  := by rw [hf i (Finset.mem_insert_self i s), mul_one]
-        _ = (1+K)*I + K*J i  := by ring
-        _ ≤ I + K ⊓ J i      := add_le_add mul_le_left mul_le_inf
+        1 = I + K           := (hs fun j hj ↦ hf j (Finset.mem_insert_of_mem hj)).symm
+        _ = I + K*(I + J i) := by rw [hf i (Finset.mem_insert_self i s), mul_one]
+        _ = (1+K)*I + K*J i := by ring
+        _ ≤ I + K ⊓ J i     := add_le_add mul_le_left mul_le_inf
 
 /-- The radical of an ideal `I` consists of the elements `r` such that `r ^ n ∈ I` for some `n`. -/
 def radical (I : Ideal R) : Ideal R where

--- a/Mathlib/RingTheory/Ideal/Over.lean
+++ b/Mathlib/RingTheory/Ideal/Over.lean
@@ -173,7 +173,7 @@ variable {A : Type*} [CommSemiring A] {B : Type*} [CommSemiring B] {C : Type*} [
   (𝔓 : Ideal C) (P : Ideal B) (p : Ideal A)
 
 @[simp]
-theorem under_under : (𝔓.under B).under A  = 𝔓.under A := by
+theorem under_under : (𝔓.under B).under A = 𝔓.under A := by
   simp_rw [comap_comap, ← IsScalarTower.algebraMap_eq]
 
 theorem LiesOver.trans [𝔓.LiesOver P] [P.LiesOver p] : 𝔓.LiesOver p where

--- a/Mathlib/RingTheory/Ideal/Pointwise.lean
+++ b/Mathlib/RingTheory/Ideal/Pointwise.lean
@@ -98,7 +98,7 @@ theorem pointwise_smul_toAddSubmonoid (a : M) (S : Ideal R)
 
 @[simp]
 theorem pointwise_smul_toAddSubgroup {R : Type*} [Ring R] [MulSemiringAction M R]
-    (a : M) (S : Ideal R) (ha : Function.Surjective fun r : R => a • r)  :
+    (a : M) (S : Ideal R) (ha : Function.Surjective fun r : R => a • r) :
     (a • S).toAddSubgroup = a • S.toAddSubgroup := by
   ext
   exact Ideal.mem_map_iff_of_surjective _ <| by exact ha

--- a/Mathlib/RingTheory/IntegralClosure/Algebra/Ideal.lean
+++ b/Mathlib/RingTheory/IntegralClosure/Algebra/Ideal.lean
@@ -79,7 +79,7 @@ lemma exists_monic_aeval_eq_zero_forall_mem_pow_of_mem_map [Algebra.IsIntegral R
   refine exists_monic_aeval_eq_zero_forall_mem_pow_of_isIntegral ?_
   induction hx using Submodule.span_induction with
   | zero => simp [isIntegral_zero]
-  | add x y _ _ hx hy  => simpa [add_mul] using hx.add hy
+  | add x y _ _ hx hy => simpa [add_mul] using hx.add hy
   | mem x h =>
     obtain ⟨x, hx, rfl⟩ := h
     simpa using isIntegral_algebraMap (R := A) (A := S[X])

--- a/Mathlib/RingTheory/IntegralClosure/IntegralRestrict.lean
+++ b/Mathlib/RingTheory/IntegralClosure/IntegralRestrict.lean
@@ -87,7 +87,7 @@ def galLift (σ : B →ₐ[A] B₂) : L →ₐ[K] L₂ :=
   haveI := (IsFractionRing.injective A K).isDomain
   haveI := NoZeroSMulDivisors.trans_faithfulSMul A K L₂
   haveI := IsIntegralClosure.isLocalization A K L B
-  haveI H : ∀ (y :  Algebra.algebraMapSubmonoid B A⁰),
+  haveI H : ∀ (y : Algebra.algebraMapSubmonoid B A⁰),
       IsUnit (((algebraMap B₂ L₂).comp σ) (y : B)) := by
     rintro ⟨_, x, hx, rfl⟩
     simpa only [RingHom.coe_comp, RingHom.coe_coe, Function.comp_apply, AlgHom.commutes,

--- a/Mathlib/RingTheory/IsAdjoinRoot.lean
+++ b/Mathlib/RingTheory/IsAdjoinRoot.lean
@@ -666,7 +666,7 @@ variable {T : Type*} [CommRing T] [Algebra R T] (h' : IsAdjoinRoot T f) {U : Typ
 
 @[simp]
 theorem lift_algEquiv (i : R →+* U) (x hx z) :
-    h'.lift i x hx (h.algEquiv h' z) = h.lift i x hx z := by rw [← h.map_repr z]; simp [- map_repr]
+    h'.lift i x hx (h.algEquiv h' z) = h.lift i x hx z := by rw [← h.map_repr z]; simp [-map_repr]
 
 @[deprecated (since := "2025-08-13")] alias lift_aequiv := lift_algEquiv
 

--- a/Mathlib/RingTheory/LocalRing/Module.lean
+++ b/Mathlib/RingTheory/LocalRing/Module.lean
@@ -413,7 +413,7 @@ at every maximal ideal, then `M` is free of rank `n`. -/
   rw [← (AlgebraTensorModule.cancelBaseChange _ _ P.ResidueField ..).comp_bijective,
     ← (AlgebraTensorModule.cancelBaseChange R (R ⧸ P) P.ResidueField ..).symm.comp_bijective]
   convert ((b' ⟨P, ‹_›⟩).repr.lTensor _ ≪≫ₗ finsuppScalarRight _ P.ResidueField _).symm.bijective
-  refine funext fun r ↦ Finsupp.induction_linear r (by simp) (by simp+contextual) fun _ _ ↦ ?_
+  refine funext fun r ↦ Finsupp.induction_linear r (by simp) (by simp +contextual) fun _ _ ↦ ?_
   simp [smul_tmul', ← funext_iff.mp (hb _)]
 
 @[stacks 02M9] theorem free_of_flat_of_finrank_eq [Module.Finite R M] [Flat R M]

--- a/Mathlib/RingTheory/Localization/Algebra.lean
+++ b/Mathlib/RingTheory/Localization/Algebra.lean
@@ -112,7 +112,7 @@ noncomputable def mapₐ (f : A →ₐ[R] B) : Aₚ →ₐ[Rₚ] Bₚ :=
 
 @[simp]
 lemma mapₐ_coe (f : A →ₐ[R] B) :
-    (mapₐ M Rₚ Aₚ Bₚ f : Aₚ → Bₚ) = map Bₚ f.toRingHom (algebraMapSubmonoid_le_comap M f)  :=
+    (mapₐ M Rₚ Aₚ Bₚ f : Aₚ → Bₚ) = map Bₚ f.toRingHom (algebraMapSubmonoid_le_comap M f) :=
   rfl
 
 lemma mapₐ_injective_of_injective (f : A →ₐ[R] B) (hf : Function.Injective f) :

--- a/Mathlib/RingTheory/Localization/BaseChange.lean
+++ b/Mathlib/RingTheory/Localization/BaseChange.lean
@@ -113,7 +113,7 @@ instance (N N') [AddCommMonoid N] [Module R N] [AddCommMonoid N'] [Module R N'] 
   convert IsLocalizedModule.of_linearEquiv S (TensorProduct.mk R (Localization S) (M ⊗[R] N) 1) <|
     (AlgebraTensorModule.distribBaseChange R (Localization S) ..).restrictScalars R ≪≫ₗ
     (congr eM eN ≪≫ₗ TensorProduct.equivOfCompatibleSMul ..).symm
-  ext; congrm(?_ ⊗ₜ ?_) <;> simp [LinearEquiv.eq_symm_apply, eM, eN]
+  ext; congrm (?_ ⊗ₜ ?_) <;> simp [LinearEquiv.eq_symm_apply, eM, eN]
 
 /-- If `A` is a localization of `R`, tensoring two `A`-modules over `A` is the same as
 tensoring them over `R`. -/

--- a/Mathlib/RingTheory/Localization/Integer.lean
+++ b/Mathlib/RingTheory/Localization/Integer.lean
@@ -92,7 +92,7 @@ theorem exist_integer_multiples {ι : Type*} (s : Finset ι) (f : ι → S) :
   rw [map_mul, sec_spec', ← mul_assoc, ← (algebraMap R S).map_mul, ← Algebra.smul_def]
   congr 2
   refine _root_.trans ?_ (map_prod (Submonoid.subtype M) _ _).symm
-  rw [mul_comm,Submonoid.coe_finset_prod,
+  rw [mul_comm, Submonoid.coe_finset_prod,
     -- Porting note: explicitly supplied `f`
     ← Finset.prod_insert (f := fun i => ((sec M (f i)).snd : R)) (s.notMem_erase i),
     Finset.insert_erase hi]

--- a/Mathlib/RingTheory/Localization/Module.lean
+++ b/Mathlib/RingTheory/Localization/Module.lean
@@ -49,7 +49,7 @@ theorem span_eq_top_of_isLocalizedModule {v : Set M} (hv : span R v = ⊤) :
   obtain ⟨⟨m, s⟩, h⟩ := IsLocalizedModule.surj S f x
   rw [Submonoid.smul_def, ← algebraMap_smul Rₛ, ← Units.smul_isUnit (IsLocalization.map_units Rₛ s),
     eq_comm, ← inv_smul_eq_iff] at h
-  refine h ▸ smul_mem _ _  (span_subset_span R Rₛ _ ?_)
+  refine h ▸ smul_mem _ _ (span_subset_span R Rₛ _ ?_)
   rw [← LinearMap.coe_restrictScalars R, ← LinearMap.map_span, hv]
   exact mem_map_of_mem mem_top
 

--- a/Mathlib/RingTheory/MatrixPolynomialAlgebra.lean
+++ b/Mathlib/RingTheory/MatrixPolynomialAlgebra.lean
@@ -75,7 +75,7 @@ theorem matPolyEquiv_coeff_apply_aux_1 (i j : n) (k : ℕ) (x : R) :
     matPolyEquiv (single i j <| monomial k x) = monomial k (single i j x) := by
   simp only [matPolyEquiv, AlgEquiv.trans_apply, matrixEquivTensor_apply_single]
   apply (polyEquivTensor R (Matrix n n R)).injective
-  simp only [AlgEquiv.apply_symm_apply,Algebra.TensorProduct.comm_tmul,
+  simp only [AlgEquiv.apply_symm_apply, Algebra.TensorProduct.comm_tmul,
     polyEquivTensor_apply, eval₂_monomial]
   simp only [one_pow,
     Algebra.TensorProduct.tmul_pow]
@@ -175,7 +175,7 @@ variable {S : Type*} [CommSemiring S] (f : S →+* Matrix n n R)
 
 lemma evalRingHom_mapMatrix_comp_polyToMatrix :
     (evalRingHom 0).mapMatrix.comp f.polyToMatrix = f.comp (evalRingHom 0) := by
-  ext <;> simp [RingHom.polyToMatrix, - AlgEquiv.symm_toRingEquiv, diagonal, apply_ite]
+  ext <;> simp [RingHom.polyToMatrix, -AlgEquiv.symm_toRingEquiv, diagonal, apply_ite]
 
 lemma evalRingHom_mapMatrix_comp_compRingEquiv {m} [Fintype m] [DecidableEq m] :
     (evalRingHom 0).mapMatrix.comp (compRingEquiv m n R[X]) =

--- a/Mathlib/RingTheory/MvPolynomial.lean
+++ b/Mathlib/RingTheory/MvPolynomial.lean
@@ -44,7 +44,7 @@ variable {σ K} [CommRing K] [Nontrivial K]
 open Cardinal
 
 theorem rank_eq_lift : Module.rank K (MvPolynomial σ K) = lift.{v} #(σ →₀ ℕ) := by
-  rw [← Cardinal.lift_inj, ← (basisMonomials σ K).mk_eq_rank, lift_lift, lift_umax.{u,v}]
+  rw [← Cardinal.lift_inj, ← (basisMonomials σ K).mk_eq_rank, lift_lift, lift_umax.{u, v}]
 
 theorem rank_eq {σ : Type v} : Module.rank K (MvPolynomial σ K) = #(σ →₀ ℕ) := by
   rw [← Cardinal.lift_inj, ← (basisMonomials σ K).mk_eq_rank]

--- a/Mathlib/RingTheory/MvPolynomial/Groebner.lean
+++ b/Mathlib/RingTheory/MvPolynomial/Groebner.lean
@@ -187,10 +187,10 @@ theorem div {ι : Type*} {b : ι → MvPolynomial σ R}
     · exact H'.2.2
   · suffices ∃ (g' : ι →₀ MvPolynomial σ R), ∃ r',
         (m.subLTerm f = Finsupp.linearCombination (MvPolynomial σ R) b g' + r') ∧
-        (∀ i, m.degree ((b  i) * (g' i)) ≼[m] m.degree (m.subLTerm f)) ∧
+        (∀ i, m.degree ((b i) * (g' i)) ≼[m] m.degree (m.subLTerm f)) ∧
         (∀ c ∈ r'.support, ∀ i, ¬ m.degree (b i) ≤ c) by
       obtain ⟨g', r', H'⟩ := this
-      use g', r' +  monomial (m.degree f) (m.leadingCoeff f)
+      use g', r' + monomial (m.degree f) (m.leadingCoeff f)
       constructor
       · simp [← add_assoc, ← H'.1, subLTerm]
       constructor

--- a/Mathlib/RingTheory/MvPolynomial/MonomialOrder.lean
+++ b/Mathlib/RingTheory/MvPolynomial/MonomialOrder.lean
@@ -403,7 +403,7 @@ theorem coeff_mul_of_add_of_degree_le {f g : MvPolynomial σ R} {a b : σ →₀
     (ha : m.degree f ≼[m] a) (hb : m.degree g ≼[m] b) :
     (f * g).coeff (a + b) = f.coeff a * g.coeff b := by
   classical
-  rw [coeff_mul, Finset.sum_eq_single (a,b)]
+  rw [coeff_mul, Finset.sum_eq_single (a, b)]
   · rintro ⟨c, d⟩ hcd h
     simp only [Finset.mem_antidiagonal] at hcd
     by_cases hf : m.degree f ≺[m] c

--- a/Mathlib/RingTheory/MvPowerSeries/NoZeroDivisors.lean
+++ b/Mathlib/RingTheory/MvPowerSeries/NoZeroDivisors.lean
@@ -161,7 +161,7 @@ theorem weightedOrder_mul (w : σ → ℕ) (f g : MvPowerSeries σ R) :
       have : f.weightedHomogeneousComponent w p * g.weightedHomogeneousComponent w q ≠ 0 := by
         simp only [ne_eq, mul_eq_zero]
         intro H
-        rcases H with  H | H <;>
+        rcases H with H | H <;>
         · refine weightedHomogeneousComponent_of_weightedOrder ?_ H
           simp only [ENat.coe_toNat_eq_self, ne_eq, weightedOrder_eq_top_iff, p, q]
           rw [← ne_eq, ne_zero_iff_weightedOrder_finite w]

--- a/Mathlib/RingTheory/MvPowerSeries/Substitution.lean
+++ b/Mathlib/RingTheory/MvPowerSeries/Substitution.lean
@@ -417,7 +417,7 @@ theorem le_order_subst (ha : HasSubst a) (f : MvPowerSeries σ R) :
   simp only [ne_eq, le_iInf_iff]
   intro i hi
   trans (⨅ (i : σ), (order ∘ a) i) * ↑i.degree
-  · refine mul_le_mul_right (order_le hi ) _
+  · refine mul_le_mul_right (order_le hi) _
   · simp only [Function.comp_apply, order, Finsupp.degree, AddMonoidHom.coe_mk, ZeroHom.coe_mk,
       Nat.cast_sum, Finset.mul_sum, Finsupp.weight_apply, nsmul_eq_mul]
     exact Finset.sum_le_sum fun j hj => by

--- a/Mathlib/RingTheory/NormalClosure.lean
+++ b/Mathlib/RingTheory/NormalClosure.lean
@@ -90,7 +90,7 @@ local instance : IsScalarTower R L E := IsScalarTower.to₁₃₄ R K L E
 
 local instance : IsScalarTower R S E := IsScalarTower.to₁₂₄ R S L E
 
-local instance : IsScalarTower R T E :=  IsScalarTower.to₁₃₄ R S T E
+local instance : IsScalarTower R T E := IsScalarTower.to₁₃₄ R S T E
 
 local instance : FaithfulSMul S E := (faithfulSMul_iff_algebraMap_injective S E).mpr <|
       (FaithfulSMul.algebraMap_injective L E).comp (FaithfulSMul.algebraMap_injective S L)

--- a/Mathlib/RingTheory/Polynomial/Basic.lean
+++ b/Mathlib/RingTheory/Polynomial/Basic.lean
@@ -236,7 +236,7 @@ theorem not_finite [Nontrivial R] : ¬ Module.Finite R R[X] := by
   rw [Module.finite_def, Submodule.fg_def]
   push_neg
   intro s hs contra
-  rcases span_le_degreeLE_of_finite hs with ⟨n,hn⟩
+  rcases span_le_degreeLE_of_finite hs with ⟨n, hn⟩
   have : ((X : R[X]) ^ (n + 1)) ∈ Polynomial.degreeLE R ↑n := by
     rw [contra] at hn
     exact hn Submodule.mem_top
@@ -665,7 +665,7 @@ theorem isPrime_map_C_iff_isPrime (P : Ideal R) :
         let m := Nat.find hf
         let n := Nat.find hg
         refine ⟨m + n, ?_⟩
-        rw [coeff_mul, ← Finset.insert_erase ((Finset.mem_antidiagonal (a := (m,n))).mpr rfl),
+        rw [coeff_mul, ← Finset.insert_erase ((Finset.mem_antidiagonal (a := (m, n))).mpr rfl),
           Finset.sum_insert (Finset.notMem_erase _ _), (P.add_mem_iff_left _).not]
         · apply mt h.2
           rw [not_or]

--- a/Mathlib/RingTheory/Polynomial/Cyclotomic/Basic.lean
+++ b/Mathlib/RingTheory/Polynomial/Cyclotomic/Basic.lean
@@ -638,7 +638,7 @@ theorem _root_.IsPrimitiveRoot.pow_sub_pow_eq_prod_sub_mul (hpos : 0 < n)
   refine (prod_nbij (algebraMap R K) (fun a ha ↦ map_mem_nthRootsFinset_one ha _)
     (fun a _ b _ H ↦ FaithfulSMul.algebraMap_injective R K H) (fun a ha ↦ ?_) (fun _ _ ↦ rfl)).symm
   have := Set.surj_on_of_inj_on_of_ncard_le (s := nthRootsFinset n (1 : R))
-    (t := nthRootsFinset n (1: K)) _ (fun _ hr ↦ map_mem_nthRootsFinset_one hr _)
+    (t := nthRootsFinset n (1 : K)) _ (fun _ hr ↦ map_mem_nthRootsFinset_one hr _)
     (fun a _ b _ H ↦ FaithfulSMul.algebraMap_injective R K H)
     (by simp [h.card_nthRootsFinset, h'.card_nthRootsFinset])
   obtain ⟨x, hx, hx1⟩ := this _ ha

--- a/Mathlib/RingTheory/Polynomial/Eisenstein/Criterion.lean
+++ b/Mathlib/RingTheory/Polynomial/Eisenstein/Criterion.lean
@@ -80,7 +80,7 @@ private lemma generalizedEisenstein_aux {q f g : R[X]} {p : ℕ}
     simp only [leadingCoeff_mul, map_mul, ne_eq, mul_eq_zero, not_or] at hf_lC
     exact hf_lC.1
   have map_dvd_pow_q :
-      g.map  (algebraMap R K) ∣ q.map (algebraMap R K) ^ p := by
+      g.map (algebraMap R K) ∣ q.map (algebraMap R K) ^ p := by
     rw [← IsUnit.dvd_mul_left _, ← hfmodP]
     · exact Polynomial.map_dvd _ hg_div
     · simp_all

--- a/Mathlib/RingTheory/Polynomial/Nilpotent.lean
+++ b/Mathlib/RingTheory/Polynomial/Nilpotent.lean
@@ -168,7 +168,7 @@ theorem isUnit_iff_coeff_isUnit_isNilpotent :
     ← Polynomial.isNilpotent_iff]
 
 lemma isUnit_iff' :
-    IsUnit P ↔ IsUnit (eval 0 P) ∧ IsNilpotent (P /ₘ X)  := by
+    IsUnit P ↔ IsUnit (eval 0 P) ∧ IsNilpotent (P /ₘ X) := by
   suffices P = C (eval 0 P) + X * (P /ₘ X) by
     conv_lhs => rw [this]; simp
   conv_lhs => rw [← modByMonic_add_div P monic_X]

--- a/Mathlib/RingTheory/Polynomial/UniversalFactorizationRing.lean
+++ b/Mathlib/RingTheory/Polynomial/UniversalFactorizationRing.lean
@@ -318,8 +318,8 @@ lemma universalFactorizationMapPresentation_jacobian :
   rw [← (aeval _).coe_toRingHom, ← Polynomial.resultant_map_map,
     Polynomial.map_map, Polynomial.map_map]
   congr 2
-  · ext <;> simp [- algebraMap_apply, ← algebraMap_eq]
-  · ext <;> simp [- algebraMap_apply, ← algebraMap_eq]
+  · ext <;> simp [-algebraMap_apply, ← algebraMap_eq]
+  · ext <;> simp [-algebraMap_apply, ← algebraMap_eq]
   · rw [(monic_freeMonic ..).natDegree_map, natDegree_freeMonic]
   · rw [(monic_freeMonic ..).natDegree_map, natDegree_freeMonic]
 

--- a/Mathlib/RingTheory/PolynomialLaw/Basic.lean
+++ b/Mathlib/RingTheory/PolynomialLaw/Basic.lean
@@ -352,7 +352,7 @@ theorem toFun'_eq_of_diagram
   let θ := (quotientKerEquivRangeₐ (R := R) ψ).symm.toAlgHom.comp
     (h'.comp (quotientKerEquivRangeₐ φ).toAlgHom)
   have ht : (h.comp φ.range.val).comp (quotientKerEquivRangeₐ φ).toAlgHom =
-      ψ.range.val.comp ((quotientKerEquivRangeₐ ψ).toAlgHom.comp  θ) := by
+      ψ.range.val.comp ((quotientKerEquivRangeₐ ψ).toAlgHom.comp θ) := by
     simp only [θ, ← AlgHom.comp_assoc, ← hh']
     simp [AlgHom.comp_assoc]
   rw [← φ.val_comp_rangeRestrict, ← quotientKerEquivRangeₐ_comp_mkₐ φ,
@@ -428,7 +428,7 @@ theorem exists_lift_of_mem_range_rTensor
     (ht : t ∈ range ((Subalgebra.val A).toLinearMap.rTensor M)) :
     ∃ s : S ⊗[R] M, φ.toLinearMap.rTensor M s = t := by
   obtain ⟨u, hu⟩ := ht
-  suffices h_surj: Function.Surjective ((φ.rangeRestrict.toLinearMap).rTensor M) by
+  suffices h_surj : Function.Surjective ((φ.rangeRestrict.toLinearMap).rTensor M) by
     obtain ⟨p, hp⟩ := h_surj ((Subalgebra.inclusion hφ).toLinearMap.rTensor M u)
     use p
     rw [← hu, ← Subalgebra.val_comp_inclusion hφ, comp_toLinearMap, rTensor_comp,
@@ -464,7 +464,7 @@ theorem exists_lift' (t : S ⊗[R] M) (s : S) : ∃ (n : ℕ) (ψ : MvPolynomial
   have hAB : A ≤ A ⊔ Algebra.adjoin R ({s} : Finset S) := le_sup_left
   rw [← hgen] at hAB
   obtain ⟨p, hp⟩ := exists_lift_of_mem_range_rTensor _ hAB ht
-  have hs : s ∈ (φ R gen).range  := by
+  have hs : s ∈ (φ R gen).range := by
     rw [hgen]
     apply Algebra.subset_adjoin
     simp only [Finset.coe_singleton, Set.sup_eq_union, Set.mem_union, SetLike.mem_coe]
@@ -502,7 +502,7 @@ theorem isCompat_apply {T : Type w} [CommSemiring T] [Algebra R T] (h : S →ₐ
     congr
     ext n
     simp only [Function.comp_apply, Equiv.symm_apply_apply, j]
-  let p' := rTensor M (rename j).toLinearMap  p
+  let p' := rTensor M (rename j).toLinearMap p
   have ha' : π R M T (⟨s', p'⟩ : lifts R M T) = rTensor M h.toLinearMap t := by
     simp only [← ha, π, p', ← LinearMap.comp_apply, ← rTensor_comp, ← comp_toLinearMap, eq_h_comp]
   rw [toFun_eq_rTensor_φ_toFun' f ha, toFun_eq_rTensor_φ_toFun' f ha', ← LinearMap.comp_apply,

--- a/Mathlib/RingTheory/PowerSeries/Order.lean
+++ b/Mathlib/RingTheory/PowerSeries/Order.lean
@@ -143,7 +143,7 @@ theorem order_eq_order {φ : R⟦X⟧} : φ.order = MvPowerSeries.order φ := by
       have eq_aux : d.degree = d () := Finset.sum_eq_single _ (by simp) (by simp)
       exact (PowerSeries.coeff_def rfl (R := R)) ▸ (eq_aux ▸ this)
   · refine le_order φ (MvPowerSeries.order φ) fun i hi => by
-      rw [←Finsupp.degree_single () i] at hi
+      rw [← Finsupp.degree_single () i] at hi
       exact MvPowerSeries.coeff_of_lt_order hi
 
 /-- The order of the sum of two formal power series

--- a/Mathlib/RingTheory/Smooth/Kaehler.lean
+++ b/Mathlib/RingTheory/Smooth/Kaehler.lean
@@ -332,7 +332,7 @@ def retractionKerCotangentToTensorEquivSection :
   let e₂ : S ⊗[P'] Ω[P'⁄R] ≃ₗ[P] S ⊗[P] Ω[P⁄R] :=
     (tensorKaehlerQuotKerSqEquiv R P S).restrictScalars P
   have H : kerCotangentToTensor R P S =
-      e₂.toLinearMap ∘ₗ (kerToTensor R P' S ).restrictScalars P ∘ₗ e₁.toLinearMap := by
+      e₂.toLinearMap ∘ₗ (kerToTensor R P' S).restrictScalars P ∘ₗ e₁.toLinearMap := by
     ext x
     obtain ⟨x, rfl⟩ := Ideal.toCotangent_surjective _ x
     exact (tensorKaehlerQuotKerSqEquiv_tmul_D 1 x.1).symm
@@ -373,7 +373,7 @@ lemma CotangentSpace.map_toInfinitesimal_bijective (P : Extension.{u} R S) :
     Function.Bijective (CotangentSpace.map P.toInfinitesimal) := by
   suffices CotangentSpace.map P.toInfinitesimal =
       (tensorKaehlerQuotKerSqEquiv _ _ _).symm.toLinearMap by
-    rw [this]; exact(tensorKaehlerQuotKerSqEquiv _ _ _).symm.bijective
+    rw [this]; exact (tensorKaehlerQuotKerSqEquiv _ _ _).symm.bijective
   letI : Algebra P.Ring P.infinitesimal.Ring := inferInstanceAs (Algebra P.Ring (P.Ring ⧸ _))
   have : IsScalarTower P.Ring P.infinitesimal.Ring S := .of_algebraMap_eq' rfl
   apply LinearMap.restrictScalars_injective P.Ring

--- a/Mathlib/RingTheory/Spectrum/Prime/ChevalleyComplexity.lean
+++ b/Mathlib/RingTheory/Spectrum/Prime/ChevalleyComplexity.lean
@@ -507,7 +507,7 @@ private lemma statement : ∀ S : InductionObj R n, Statement R₀ R n S := by
             · subst hkj; gcongr; exact (degree_modByMonic_le _ hi).trans hle
             · rfl
           · gcongr; simpa using (degree_modByMonic_lt _ hi).trans_le hle
-        calc  (c.val j).degree.succ * c'.degBound ^ c'.degBound
+        calc (c.val j).degree.succ * c'.degBound ^ c'.degBound
           _ ≤ c.degBound * c.degBound ^ c'.degBound := by
             gcongr
             delta InductionObj.degBound

--- a/Mathlib/RingTheory/Spectrum/Prime/ConstructibleSet.lean
+++ b/Mathlib/RingTheory/Spectrum/Prime/ConstructibleSet.lean
@@ -129,7 +129,7 @@ lemma exists_constructibleSetData_iff {s : Set (PrimeSpectrum R)} :
         compl_sdiff_compl, ← zeroLocus_iUnion₂, Set.biUnion_of_singleton]
     congr! 2
     ext
-    simp [← (Finite.equivFin s).exists_congr_right, - Nat.card_coe_set_eq]
+    simp [← (Finite.equivFin s).exists_congr_right, -Nat.card_coe_set_eq]
   | union s hs t ht Hs Ht =>
     obtain ⟨S, rfl⟩ := Hs
     obtain ⟨T, rfl⟩ := Ht

--- a/Mathlib/RingTheory/Spectrum/Prime/Topology.lean
+++ b/Mathlib/RingTheory/Spectrum/Prime/Topology.lean
@@ -306,7 +306,7 @@ theorem discreteTopology_iff_finite_isMaximal_and_sInf_le_nilradical :
     (equivSubtype R).finite_iff, ← Set.coe_setOf, Set.finite_coe_iff, Set.finite_coe_iff]
   refine ⟨fun h ↦ ⟨h.1.subset fun _ h ↦ h.isPrime, nilradical_eq_sInf R ▸ sInf_le_sInf h.2⟩,
     fun ⟨fin, le⟩ ↦ ?_⟩
-  have hpm (I : Ideal R) (hI : I.IsPrime): I.IsMaximal := by
+  have hpm (I : Ideal R) (hI : I.IsPrime) : I.IsMaximal := by
     replace le := le.trans (nilradical_le_prime I)
     rw [← fin.coe_toFinset, ← Finset.inf_id_eq_sInf, hI.inf_le'] at le
     have ⟨M, hM, hMI⟩ := le

--- a/Mathlib/RingTheory/TensorProduct/IsBaseChangeFree.lean
+++ b/Mathlib/RingTheory/TensorProduct/IsBaseChangeFree.lean
@@ -44,7 +44,7 @@ theorem basis_apply (i) : ibc.basis b i = ε (b i) := by
   simp [this, IsBaseChange.equiv_tmul]
 
 theorem basis_repr_comp_apply (v i) :
-    (ibc.basis b).repr (ε v) i = algebraMap R S (b.repr v i):= by
+    (ibc.basis b).repr (ε v) i = algebraMap R S (b.repr v i) := by
   conv_lhs => rw [← b.linearCombination_repr v, Finsupp.linearCombination_apply,
     map_finsuppSum, map_finsuppSum]
   simp only [map_smul, Finsupp.sum_apply]

--- a/Mathlib/RingTheory/TensorProduct/MvPolynomial.lean
+++ b/Mathlib/RingTheory/TensorProduct/MvPolynomial.lean
@@ -268,7 +268,7 @@ variable (S σ ι) in
 def tensorEquivSum :
     MvPolynomial σ S ⊗[R] MvPolynomial ι R ≃ₐ[S] MvPolynomial (σ ⊕ ι) S :=
   ((algebraTensorAlgEquiv _ _).restrictScalars _).trans
-    ((sumAlgEquiv _ _ _).symm.trans  (renameEquiv _ (.sumComm ι σ)))
+    ((sumAlgEquiv _ _ _).symm.trans (renameEquiv _ (.sumComm ι σ)))
 
 variable {R}
 

--- a/Mathlib/RingTheory/UniqueFactorizationDomain/Basic.lean
+++ b/Mathlib/RingTheory/UniqueFactorizationDomain/Basic.lean
@@ -198,8 +198,7 @@ theorem exists_mem_factors_of_dvd {a p : α} (ha0 : a ≠ 0) (hp : Irreducible p
           Multiset.prod (factors a) ~ᵤ a := factors_prod ha0
           _ = p * b := hb
           _ ~ᵤ Multiset.prod (p ::ₘ factors b) := by
-            rw [Multiset.prod_cons]; exact (factors_prod hb0).symm.mul_left _
-          )
+            rw [Multiset.prod_cons]; exact (factors_prod hb0).symm.mul_left _)
   Multiset.exists_mem_of_rel_of_mem this (by simp)
 
 theorem exists_mem_factors {x : α} (hx : x ≠ 0) (h : ¬IsUnit x) : ∃ p, p ∈ factors x := by
@@ -371,7 +370,7 @@ theorem MulEquiv.uniqueFactorizationMonoid (e : α ≃* β) (hα : UniqueFactori
   obtain ⟨w, hp, u, h⟩ :=
     hα (e.symm a) fun h =>
       ha <| by
-        convert← map_zero e
+        convert ← map_zero e
         simp [← h]
   exact
     ⟨w.map e, fun b hb =>

--- a/Mathlib/RingTheory/UniqueFactorizationDomain/NormalizedFactors.lean
+++ b/Mathlib/RingTheory/UniqueFactorizationDomain/NormalizedFactors.lean
@@ -112,8 +112,7 @@ theorem exists_mem_normalizedFactors_of_dvd {a p : α} (ha0 : a ≠ 0) (hp : Irr
           _ = p * b := hb
           _ ~ᵤ Multiset.prod (p ::ₘ normalizedFactors b) := by
             rw [Multiset.prod_cons]
-            exact (prod_normalizedFactors hb0).symm.mul_left _
-          )
+            exact (prod_normalizedFactors hb0).symm.mul_left _)
   Multiset.exists_mem_of_rel_of_mem this (by simp)
 
 theorem exists_mem_normalizedFactors {x : α} (hx : x ≠ 0) (h : ¬IsUnit x) :

--- a/Mathlib/RingTheory/Valuation/Basic.lean
+++ b/Mathlib/RingTheory/Valuation/Basic.lean
@@ -523,7 +523,7 @@ lemma IsNontrivial.exists_lt_one {Γ₀ : Type*} [LinearOrderedCommGroupWithZero
   · use x
     simp [hx]
   · use x⁻¹
-    simp [- map_inv₀, ← one_lt_val_iff, hx]
+    simp [-map_inv₀, ← one_lt_val_iff, hx]
 
 theorem isNontrivial_iff_exists_lt_one {Γ₀ : Type*}
     [LinearOrderedCommGroupWithZero Γ₀] (v : Valuation K Γ₀) :
@@ -991,7 +991,7 @@ section Group
 variable [LinearOrderedAddCommGroupWithTop Γ₀] [Ring R] (v : AddValuation R Γ₀) {x y : R}
 
 @[simp]
-theorem map_inv (v : AddValuation K Γ₀) {x : K} : v x⁻¹ = - (v x) :=
+theorem map_inv (v : AddValuation K Γ₀) {x : K} : v x⁻¹ = -(v x) :=
   map_inv₀ (toValuation v) x
 
 @[simp]

--- a/Mathlib/RingTheory/Valuation/Discrete/Basic.lean
+++ b/Mathlib/RingTheory/Valuation/Discrete/Basic.lean
@@ -282,7 +282,7 @@ variable {v} [hv : v.IsRankOneDiscrete]
 theorem IsUniformizer.of_associated {π₁ π₂ : K₀} (h1 : IsUniformizer v π₁)
     (H : Associated π₁ π₂) : IsUniformizer v π₂ := by
   obtain ⟨u, hu⟩ := H
-  have : v (u.1 : K) = 1 := (Integers.isUnit_iff_valuation_eq_one <|integer.integers v).mp u.isUnit
+  have : v (u.1 : K) = 1 := (Integers.isUnit_iff_valuation_eq_one <| integer.integers v).mp u.isUnit
   rwa [IsUniformizer.iff, ← hu, Subring.coe_mul, map_mul, this, mul_one, ← IsUniformizer.iff]
 
 /-- If two elements of `K₀` are uniformizers, then they are associated. -/
@@ -397,7 +397,7 @@ theorem ideal_isPrincipal [IsCyclic (valueGroup v)] [Nontrivial (valueGroup v)] 
     · rw [← Subring.coe_mul, SetLike.coe_eq_coe] at hu
       rw [hu, Ideal.mul_unit_mem_iff_mem P u.isUnit,
         IsPrime.pow_mem_iff_mem hP _ (pos_iff_ne_zero.mpr hn), ← Ideal.span_singleton_le_iff_mem,
-        ← π.is_generator ] at hx_mem
+        ← π.is_generator] at hx_mem
       rw [← Ideal.IsMaximal.eq_of_le (IsLocalRing.maximalIdeal.isMaximal K₀) hP.ne_top hx_mem]
       exact ⟨π.1, π.is_generator⟩
 
@@ -433,9 +433,9 @@ instance isRankOneDiscrete :
     IsRankOneDiscrete ((maximalIdeal A).valuation K) := by
   have : Nontrivial ↥(valueGroup (valuation K (maximalIdeal A))) := by
     let v := (maximalIdeal A).valuation K
-    let π := valuation_exists_uniformizer K (maximalIdeal A)|>.choose
+    let π := valuation_exists_uniformizer K (maximalIdeal A) |>.choose
     have hπ : v π = ↑(ofAdd (-1 : ℤ)) :=
-      valuation_exists_uniformizer K (maximalIdeal A)|>.choose_spec
+      valuation_exists_uniformizer K (maximalIdeal A) |>.choose_spec
     rw [Subgroup.nontrivial_iff_exists_ne_one]
     use Units.mk0 (v π) (by simp [hπ])
     constructor

--- a/Mathlib/RingTheory/Valuation/DiscreteValuativeRel.lean
+++ b/Mathlib/RingTheory/Valuation/DiscreteValuativeRel.lean
@@ -34,7 +34,7 @@ lemma nonempty_orderIso_withZeroMul_int_iff :
   · rintro ⟨e⟩
     let x := e.symm (exp (-1))
     have hx0 : x ≠ 0 := by simp [x]
-    have hx1 : x < 1 := by simp [- exp_neg, x, ← lt_map_inv_iff, ← exp_zero]
+    have hx1 : x < 1 := by simp [-exp_neg, x, ← lt_map_inv_iff, ← exp_zero]
     refine ⟨⟨x, hx1, fun y hy ↦ ?_⟩, ⟨x, hx0, hx1.ne⟩, .comap e.toMonoidHom e.strictMono⟩
     rcases eq_or_ne y 0 with rfl | hy0
     · simp


### PR DESCRIPTION
Found by extending the commandStart linter to proof bodies.

---
<!-- Your PR title will become the first line of the commit message.

In this box, the text above the `---` (if not empty) will be appended
to the commit message, and can be used to give additional context or
details. Please leave a blank newline before the `---`, otherwise GitHub
will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

When merging, all the commits will be squashed into a single commit
listing all co-authors.

Co-authors in the squash commit are gathered from two sources:

First, all authors of commits to this PR branch are included. Thus,
one way to add co-authors is to include at least one commit authored by
each co-author among the commits in the pull request. If necessary, you
may create empty commits to indicate co-authorship, using commands like so:

git commit --author="Author Name <author@email.com>" --allow-empty -m "add Author Name as coauthor"

Second, co-authors can also be listed in lines at the very bottom of
the commit message (that is, directly before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines
at the bottom of the commit message (before the `---`, and also before
any "Co-authored-by" lines) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
