### PR TITLE
feat: define `∃ x > y, ...` notation to mean `∃ x, y < x ∧ ...`

### DIFF
--- a/Counterexamples/AharoniKorman.lean
+++ b/Counterexamples/AharoniKorman.lean
@@ -310,7 +310,7 @@ theorem scattered {f : ℚ → Hollom} (hf : StrictMono f) : False := by
     rw [antitone_iff_forall_lt]
     intro x y hxy
     have : f x < f y := hf hxy
-    simp only [ge_iff_le, g]
+    simp only [g]
     cases hx : f x with | h x₁ x₂ x₃ =>
     cases hy : f y with | h y₁ y₂ y₃ =>
     rw [hx, hy] at this
@@ -836,7 +836,7 @@ lemma square_subset_above (h : (C ∩ level n).Finite) :
   -- With this pair, we can use the "base" of the square as `max a b + 1`.
   rw [eventually_atTop]
   refine ⟨max a b + 1, ?_⟩
-  simp +contextual only [ge_iff_le, sup_le_iff, embed, RelEmbedding.coe_mk,
+  simp +contextual only [sup_le_iff, embed, RelEmbedding.coe_mk,
     Function.Embedding.coeFn_mk, Set.mem_inter_iff, and_imp, «forall», toHollom_mem_level_iff,
     Prod.forall, Set.subset_def, Set.mem_image, Set.mem_Ici, Prod.exists, Prod.mk_le_mk,
     Set.mem_setOf_eq, forall_exists_index, Prod.mk.injEq,
@@ -954,7 +954,7 @@ lemma square_subset_S_case_1 (h : (C ∩ level n).Finite) (h' : (C ∩ level (n 
   have : ∀ᶠ a in atTop, embed n '' .Ici (a, a) ⊆ {x | ∀ y ∈ C ∩ level (n + 1), x ≤ y ∨ y ≤ x} := by
     rw [eventually_atTop, level_eq]
     refine ⟨max b c, ?_⟩
-    simp only [ge_iff_le, sup_le_iff, embed, RelEmbedding.coe_mk, Function.Embedding.coeFn_mk,
+    simp only [sup_le_iff, embed, RelEmbedding.coe_mk, Function.Embedding.coeFn_mk,
       Set.mem_inter_iff, Set.mem_setOf_eq, and_imp, «forall», Prod.forall,
       Set.subset_def, Set.mem_image, Set.mem_Ici, Prod.exists, Prod.mk_le_mk, forall_exists_index,
       Prod.mk.injEq, Hollom.ext_iff]

--- a/Mathlib/Algebra/Module/ZLattice/Summable.lean
+++ b/Mathlib/Algebra/Module/ZLattice/Summable.lean
@@ -195,7 +195,7 @@ lemma exists_finsetSum_norm_rpow_le_tsum :
         (by simpa using (e.image_symm_image _).symm)⟩
     dsimp
     simp only [EmbeddingLike.apply_eq_iff_eq, implies_true, Set.injOn_of_eq_iff_eq,
-      Finset.sum_image, ge_iff_le]
+      Finset.sum_image]
     obtain ⟨n, hn⟩ : ∃ n : ℕ, u ⊆ Fintype.piFinset fun _ : I ↦ Finset.Icc (-n : ℤ) n := by
       obtain ⟨r, hr, hr'⟩ := u.finite_toSet.isCompact.isBounded.subset_closedBall_lt 0 0
       refine ⟨⌊r⌋.toNat, fun x hx ↦ ?_⟩

--- a/Mathlib/Algebra/Order/Disjointed.lean
+++ b/Mathlib/Algebra/Order/Disjointed.lean
@@ -42,7 +42,7 @@ lemma partialSups_add_one_eq_sup_disjointed (f : ι → α) (i : ι) :
         rw [← Order.succ_eq_add_one]
         apply Order.le_succ
       exact le_antisymm (hi h) h
-    simp only [this, left_eq_sup, ge_iff_le, disjointed, sdiff_le_iff]
+    simp only [this, left_eq_sup, disjointed, sdiff_le_iff]
     apply le_trans (le_partialSups _ _) le_sup_right
   · rw [← Order.succ_eq_add_one, disjointed_succ _ hi]
     simp

--- a/Mathlib/Algebra/Order/Field/Basic.lean
+++ b/Mathlib/Algebra/Order/Field/Basic.lean
@@ -565,7 +565,7 @@ theorem exists_add_lt_and_pos_of_lt (h : b < a) : ∃ c, b + c < a ∧ 0 < c :=
 
 theorem le_of_forall_sub_le (h : ∀ ε > 0, b - ε ≤ a) : b ≤ a := by
   contrapose! h
-  simpa only [@and_comm ((0 : α) < _), lt_sub_iff_add_lt, gt_iff_lt] using
+  simpa only [@and_comm ((0 : α) < _), lt_sub_iff_add_lt] using
     exists_add_lt_and_pos_of_lt h
 
 private lemma exists_lt_mul_left_of_nonneg {a b c : α} (ha : 0 ≤ a) (hc : 0 ≤ c) (h : c < a * b) :

--- a/Mathlib/Algebra/Order/Ring/WithTop.lean
+++ b/Mathlib/Algebra/Order/Ring/WithTop.lean
@@ -100,7 +100,7 @@ protected lemma mul_right_strictMono [PosMulStrictMono α] (h₀ : 0 < a) (hinf 
   match c with
   | ⊤ => simp [← coe_mul, mul_top h₀.ne']
   | (c : α) =>
-  simp only [coe_pos, coe_lt_coe, ← coe_mul, gt_iff_lt] at *
+  simp only [coe_pos, coe_lt_coe, ← coe_mul] at *
   exact mul_lt_mul_of_pos_left hbc h₀
 
 protected lemma mul_left_strictMono [MulPosStrictMono α] (h₀ : 0 < a) (hinf : a ≠ ⊤) :
@@ -111,7 +111,7 @@ protected lemma mul_left_strictMono [MulPosStrictMono α] (h₀ : 0 < a) (hinf :
   match c with
   | ⊤ => simp [← coe_mul, top_mul h₀.ne']
   | (c : α) =>
-  simp only [coe_pos, coe_lt_coe, ← coe_mul, gt_iff_lt] at *
+  simp only [coe_pos, coe_lt_coe, ← coe_mul] at *
   exact mul_lt_mul_of_pos_right hbc h₀
 
 end MulZeroClass

--- a/Mathlib/AlgebraicGeometry/ProjectiveSpectrum/Proper.lean
+++ b/Mathlib/AlgebraicGeometry/ProjectiveSpectrum/Proper.lean
@@ -229,10 +229,10 @@ theorem valuativeCriterion_existence_aux
   induction this using Submodule.span_induction with
   | zero => simp
   | add x y hx hy hhx hhy =>
-    simp only [RingHom.coe_comp, Function.comp_apply, map_add, ge_iff_le]
+    simp only [RingHom.coe_comp, Function.comp_apply, map_add]
     exact ((valuation O K).map_add _ _).trans <| sup_le_iff.mpr ⟨hhx, hhy⟩
   | smul a x₀ hx hx1 =>
-    simp only [Algebra.smul_def, RingHom.coe_comp, Function.comp_apply, map_mul, ge_iff_le]
+    simp only [Algebra.smul_def, RingHom.coe_comp, Function.comp_apply, map_mul]
     refine mul_le_one' ?_ hx1
     rw [RingHom.algebraMap_toAlgebra, awayMap_fromZeroRingHom 𝒜 (hxdi j) (mul_comm (x j) (x i₀)),
       ← awayMap_fromZeroRingHom 𝒜 (hxdi i₀) rfl a, hφ'1]

--- a/Mathlib/Analysis/Analytic/ConvergenceRadius.lean
+++ b/Mathlib/Analysis/Analytic/ConvergenceRadius.lean
@@ -192,7 +192,7 @@ theorem lt_radius_of_isBigO (h₀ : r ≠ 0) {a : ℝ} (ha : a ∈ Ioo (-1 : ℝ
 theorem norm_mul_pow_le_of_lt_radius (p : FormalMultilinearSeries 𝕜 E F) {r : ℝ≥0}
     (h : (r : ℝ≥0∞) < p.radius) : ∃ C > 0, ∀ n, ‖p n‖ * (r : ℝ) ^ n ≤ C :=
   let ⟨_, ha, C, hC, h⟩ := p.norm_mul_pow_le_mul_pow_of_lt_radius h
-  ⟨C, hC, fun n => (h n).trans <| mul_le_of_le_one_right hC.lt.le (pow_le_one₀ ha.1.le ha.2.le)⟩
+  ⟨C, hC, fun n => (h n).trans <| mul_le_of_le_one_right hC.le (pow_le_one₀ ha.1.le ha.2.le)⟩
 
 /-- For `r` strictly smaller than the radius of `p`, then `‖pₙ‖ rⁿ` is bounded. -/
 theorem norm_le_div_pow_of_pos_of_lt_radius (p : FormalMultilinearSeries 𝕜 E F) {r : ℝ≥0}
@@ -204,7 +204,7 @@ theorem norm_le_div_pow_of_pos_of_lt_radius (p : FormalMultilinearSeries 𝕜 E 
 theorem nnnorm_mul_pow_le_of_lt_radius (p : FormalMultilinearSeries 𝕜 E F) {r : ℝ≥0}
     (h : (r : ℝ≥0∞) < p.radius) : ∃ C > 0, ∀ n, ‖p n‖₊ * r ^ n ≤ C :=
   let ⟨C, hC, hp⟩ := p.norm_mul_pow_le_of_lt_radius h
-  ⟨⟨C, hC.lt.le⟩, hC, mod_cast hp⟩
+  ⟨⟨C, hC.le⟩, hC, mod_cast hp⟩
 
 theorem le_radius_of_tendsto (p : FormalMultilinearSeries 𝕜 E F) {l : ℝ}
     (h : Tendsto (fun n => ‖p n‖ * (r : ℝ) ^ n) atTop (𝓝 l)) : ↑r ≤ p.radius :=

--- a/Mathlib/Analysis/Analytic/Inverse.lean
+++ b/Mathlib/Analysis/Analytic/Inverse.lean
@@ -630,7 +630,7 @@ lemma HasFPowerSeriesAt.eventually_hasSum_of_comp {f : E → F} {g : F → G}
   have L : Tendsto (fun n ↦ q.partialSum n (f (x + y) - f x)) atTop (𝓝 (g (f (x + y)))) := by
     apply (closed_nhds_basis (g (f (x + y)))).tendsto_right_iff.2
     rintro u ⟨hu, u_closed⟩
-    simp only [id_eq, eventually_atTop, ge_iff_le]
+    simp only [id_eq, eventually_atTop]
     rcases mem_nhds_iff.1 hu with ⟨v, vu, v_open, hv⟩
     obtain ⟨a₀, b₀, hab⟩ : ∃ a₀ b₀, ∀ (a b : ℕ), a₀ ≤ a → b₀ ≤ b →
         q.partialSum a (p.partialSum b y - (p 0) fun _ ↦ 0) ∈ v := by

--- a/Mathlib/Analysis/BoxIntegral/Basic.lean
+++ b/Mathlib/Analysis/BoxIntegral/Basic.lean
@@ -779,7 +779,7 @@ theorem HasIntegral.of_bRiemann_eq_false_of_forall_isLittleO (hl : l.bRiemann = 
     box `J` in the `δ`-neighborhood of `x`. -/
   refine ((l.hasBasis_toFilteriUnion_top _).tendsto_iff Metric.nhds_basis_closedBall).2 ?_
   intro ε ε0
-  simp only [← exists_prop, gt_iff_lt, Subtype.exists'] at H₁ H₂
+  simp only [← exists_prop, Subtype.exists'] at H₁ H₂
   choose! δ₁ Hδ₁ using H₁
   choose! δ₂ Hδ₂ using H₂
   have ε0' := half_pos ε0; have H0 : 0 < (2 : ℝ) ^ Fintype.card ι := pow_pos zero_lt_two _

--- a/Mathlib/Analysis/CStarAlgebra/ContinuousFunctionalCalculus/Order.lean
+++ b/Mathlib/Analysis/CStarAlgebra/ContinuousFunctionalCalculus/Order.lean
@@ -415,7 +415,7 @@ lemma norm_le_norm_of_nonneg_of_le {a b : A} (ha : 0 ≤ a := by cfc_tac) (hab :
     ‖a‖ ≤ ‖b‖ := by
   suffices ∀ a b : A⁺¹, 0 ≤ a → a ≤ b → ‖a‖ ≤ ‖b‖ by
     have hb := ha.trans hab
-    simpa only [ge_iff_le, Unitization.norm_inr] using
+    simpa only [Unitization.norm_inr] using
       this a b (by simpa) (by rwa [Unitization.inr_le_iff a b])
   intro a b ha hab
   have hb : 0 ≤ b := ha.trans hab

--- a/Mathlib/Analysis/CStarAlgebra/Unitary/Connected.lean
+++ b/Mathlib/Analysis/CStarAlgebra/Unitary/Connected.lean
@@ -288,7 +288,7 @@ noncomputable def Unitary.openPartialHomeomorph :
     rw [← sq_lt_sq₀ (by positivity) (by positivity), norm_sq_expUnitary_sub_one hx.le]
     have : -1 < Real.cos ‖(x : A)‖ :=
       Real.cos_pi ▸ Real.cos_lt_cos_of_nonneg_of_le_pi (by positivity) le_rfl hx
-    simp only [AddSubgroupClass.coe_norm, mul_sub, mul_one, sq, gt_iff_lt]
+    simp only [AddSubgroupClass.coe_norm, mul_sub, mul_one, sq]
     linarith
   left_inv' u hu := expUnitary_argSelfAdjoint <| by
     simpa [Subtype.dist_eq, dist_eq_norm] using hu

--- a/Mathlib/Analysis/CStarAlgebra/Unitization.lean
+++ b/Mathlib/Analysis/CStarAlgebra/Unitization.lean
@@ -35,7 +35,7 @@ lemma opNorm_mul_flip_apply (a : E) : ‖(mul 𝕜 E).flip a‖ = ‖a‖ := by
   refine le_antisymm
     (opNorm_le_bound _ (norm_nonneg _) fun b => by simpa only [mul_comm] using norm_mul_le b a) ?_
   suffices ‖mul 𝕜 E (star a)‖ ≤ ‖(mul 𝕜 E).flip a‖ by
-    simpa only [ge_iff_le, opNorm_mul_apply, norm_star] using this
+    simpa only [opNorm_mul_apply, norm_star] using this
   refine opNorm_le_bound _ (norm_nonneg _) fun b => ?_
   calc ‖mul 𝕜 E (star a) b‖ = ‖(mul 𝕜 E).flip a (star b)‖ := by
         simpa only [mul_apply', flip_apply, star_mul, star_star] using norm_star (star b * a)

--- a/Mathlib/Analysis/Calculus/TangentCone/Basic.lean
+++ b/Mathlib/Analysis/Calculus/TangentCone/Basic.lean
@@ -57,7 +57,7 @@ respect to `𝕜` is contained in the tangent cone of `s` at `x` with respect to
 theorem tangentConeAt_mono_field {𝕜' : Type*} [NontriviallyNormedField 𝕜'] [NormedAlgebra 𝕜 𝕜']
   [Module 𝕜' E] [IsScalarTower 𝕜 𝕜' E] : tangentConeAt 𝕜 s x ⊆ tangentConeAt 𝕜' s x := by
   intro α hα
-  simp only [tangentConeAt, eventually_atTop, ge_iff_le, tendsto_norm_atTop_iff_cobounded,
+  simp only [tangentConeAt, eventually_atTop, tendsto_norm_atTop_iff_cobounded,
     mem_setOf_eq] at hα ⊢
   obtain ⟨c, d, ⟨a, h₁a⟩, h₁, h₂⟩ := hα
   use ((algebraMap 𝕜 𝕜') ∘ c), d

--- a/Mathlib/Analysis/Calculus/TangentCone/DimOne.lean
+++ b/Mathlib/Analysis/Calculus/TangentCone/DimOne.lean
@@ -47,7 +47,7 @@ theorem tangentConeAt_eq_univ {s : Set 𝕜} {x : 𝕜} (hx : AccPt x (𝓟 s)) 
     apply (tendsto_const_mul_atTop_of_pos (by simpa using hy)).2
     apply tendsto_inv_nhdsGT_zero.comp
     simp only [nhdsWithin, tendsto_inf, tendsto_principal, mem_Ioi, norm_pos_iff, ne_eq,
-      eventually_atTop, ge_iff_le]
+      eventually_atTop]
     have B (n : ℕ) : ‖d n‖ ≤ u n := by simpa [dist_eq_norm] using hvu n
     refine ⟨?_, 0, fun n hn ↦ by simpa using d_ne n⟩
     exact squeeze_zero (fun n ↦ by positivity) B u_lim

--- a/Mathlib/Analysis/Calculus/TangentCone/ProperSpace.lean
+++ b/Mathlib/Analysis/Calculus/TangentCone/ProperSpace.lean
@@ -46,7 +46,7 @@ theorem tangentConeAt_nonempty_of_properSpace [ProperSpace E]
   have c_lim : Tendsto (fun n ↦ ‖c n‖) atTop atTop := by
     suffices Tendsto (fun n ↦ ‖c n‖⁻¹ ⁻¹ ) atTop atTop by simpa
     apply tendsto_inv_nhdsGT_zero.comp
-    simp only [nhdsWithin, tendsto_inf, tendsto_principal, mem_Ioi, eventually_atTop, ge_iff_le]
+    simp only [nhdsWithin, tendsto_inf, tendsto_principal, mem_Ioi, eventually_atTop]
     have B (n : ℕ) : ‖c n‖⁻¹ ≤ 1⁻¹ * ‖r‖ * u n := by
       apply (hc n).trans
       gcongr

--- a/Mathlib/Analysis/Convex/Function.lean
+++ b/Mathlib/Analysis/Convex/Function.lean
@@ -1018,7 +1018,7 @@ theorem OrderIso.strictConvexOn_symm (f : α ≃o β) (hf : StrictConcaveOn 𝕜
   obtain ⟨x', hx''⟩ := f.surjective.exists.mp ⟨x, rfl⟩
   obtain ⟨y', hy''⟩ := f.surjective.exists.mp ⟨y, rfl⟩
   have hxy' : x' ≠ y' := by rw [← f.injective.ne_iff, ← hx'', ← hy'']; exact hxy
-  simp only [hx'', hy'', OrderIso.symm_apply_apply, gt_iff_lt]
+  simp only [hx'', hy'', OrderIso.symm_apply_apply]
   rw [← f.lt_iff_lt, OrderIso.apply_symm_apply]
   exact hf.2 (by simp : x' ∈ univ) (by simp : y' ∈ univ) hxy' ha hb hab
 
@@ -1037,7 +1037,7 @@ theorem OrderIso.strictConcaveOn_symm (f : α ≃o β) (hf : StrictConvexOn 𝕜
   obtain ⟨x', hx''⟩ := f.surjective.exists.mp ⟨x, rfl⟩
   obtain ⟨y', hy''⟩ := f.surjective.exists.mp ⟨y, rfl⟩
   have hxy' : x' ≠ y' := by rw [← f.injective.ne_iff, ← hx'', ← hy'']; exact hxy
-  simp only [hx'', hy'', OrderIso.symm_apply_apply, gt_iff_lt]
+  simp only [hx'', hy'', OrderIso.symm_apply_apply]
   rw [← f.lt_iff_lt, OrderIso.apply_symm_apply]
   exact hf.2 (by simp : x' ∈ univ) (by simp : y' ∈ univ) hxy' ha hb hab
 

--- a/Mathlib/Analysis/Convex/StrictCombination.lean
+++ b/Mathlib/Analysis/Convex/StrictCombination.lean
@@ -57,7 +57,7 @@ lemma StrictConvex.centerMass_mem_interior {s : Set V} {t : Finset ι} {w : ι �
         refine LT.lt.ne' ?_
         have hwi : 0 < w i := by grind
         grw [hwi]
-        simp only [lt_add_iff_pos_right, gt_iff_lt]
+        simp only [lt_add_iff_pos_right]
         exact (sum_nonneg hs₀).lt_of_ne' hsum_t
       simp only [hzi, ← add_smul, ← add_div, ne_eq, hwi, not_false_eq_true, div_self, one_smul]
       by_cases! hijt : ∃ i'' j'', i'' ∈ t ∧ j'' ∈ t ∧ z i'' ≠ z j'' ∧ w i'' ≠ 0 ∧ w j'' ≠ 0

--- a/Mathlib/Analysis/Fourier/FourierTransform.lean
+++ b/Mathlib/Analysis/Fourier/FourierTransform.lean
@@ -198,7 +198,7 @@ theorem integral_fourierIntegral_swap
       (M.flip.cont.comp continuous_snd).clm_apply continuous_fst
     apply hM.comp_aestronglyMeasurable A' -- `exact` works, but `apply` is 10x faster!
   · filter_upwards with ⟨ξ, x⟩
-    simp only [Function.uncurry_apply_pair, norm_mul, norm_norm, ge_iff_le, ← mul_assoc]
+    simp only [Function.uncurry_apply_pair, norm_mul, norm_norm, ← mul_assoc]
     convert M.le_opNorm₂ (g ξ) (e (-L x ξ) • f x) using 2
     simp
 

--- a/Mathlib/Analysis/Fourier/FourierTransformDeriv.lean
+++ b/Mathlib/Analysis/Fourier/FourierTransformDeriv.lean
@@ -391,7 +391,7 @@ lemma norm_iteratedFDeriv_fourierPowSMulRight
     E).isBoundedBilinearMap.contDiff.comp₂ (A.of_le hk) (hf.of_le hk)).contDiffAt),
     norm_smul (β := V [×k]→L[ℝ] (W [×n]→L[ℝ] E))]
   simp only [mul_assoc, norm_pow, norm_neg, Complex.norm_mul, Complex.norm_ofNat, norm_real,
-    Real.norm_eq_abs, abs_of_nonneg pi_nonneg, norm_I, mul_one, smulRightL_apply, ge_iff_le]
+    Real.norm_eq_abs, abs_of_nonneg pi_nonneg, norm_I, mul_one, smulRightL_apply]
   gcongr
   -- third step: argue that the scalar multiplication is bilinear to bound the iterated derivatives
   -- of `v ↦ (∏ i, L v (m i)) • f v` in terms of those of `v ↦ (∏ i, L v (m i))` and of `f`.

--- a/Mathlib/Analysis/Normed/Group/FunctionSeries.lean
+++ b/Mathlib/Analysis/Normed/Group/FunctionSeries.lean
@@ -59,8 +59,7 @@ theorem tendstoUniformlyOn_tsum_of_cofinite_eventually {ι : Type*} {f : ι → 
   classical
   refine tendstoUniformlyOn_iff.2 fun ε εpos => ?_
   have := (tendsto_order.1 (tendsto_tsum_compl_atTop_zero u)).2 _ εpos
-  simp only [gt_iff_lt,
-    eventually_atTop, ge_iff_le, Finset.le_eq_subset] at *
+  simp only [eventually_atTop, Finset.le_eq_subset] at *
   obtain ⟨t, ht⟩ := this
   rw [eventually_iff_exists_mem] at hfu
   obtain ⟨N, hN, HN⟩ := hfu

--- a/Mathlib/Analysis/Normed/Unbundled/IsPowMulFaithful.lean
+++ b/Mathlib/Analysis/Normed/Unbundled/IsPowMulFaithful.lean
@@ -42,7 +42,7 @@ theorem contraction_of_isPowMul_of_boundedWrt {F : Type*} {α : outParam (Type*)
     exact ((rpow_zero C ▸ ContinuousAt.tendsto (continuousAt_const_rpow (ne_of_gt hC0))).comp
       (tendsto_const_div_atTop_nhds_zero_nat 1)).mul tendsto_const_nhds
   apply ge_of_tendsto hlim
-  simp only [eventually_atTop, ge_iff_le]
+  simp only [eventually_atTop]
   use 1
   intro n hn
   have h : (C ^ (1 / n : ℝ)) ^ n = C := by

--- a/Mathlib/Analysis/Normed/Unbundled/SeminormFromConst.lean
+++ b/Mathlib/Analysis/Normed/Unbundled/SeminormFromConst.lean
@@ -123,7 +123,7 @@ theorem seminormFromConst_isLimit (x : R) :
 theorem seminormFromConst_one : seminormFromConst' hf1 hc hpm 1 = 1 := by
   apply tendsto_nhds_unique_of_eventuallyEq (seminormFromConst_isLimit hf1 hc hpm 1)
     tendsto_const_nhds
-  simp only [EventuallyEq, eventually_atTop, ge_iff_le]
+  simp only [EventuallyEq, eventually_atTop]
   exact ⟨1, seminormFromConst_seq_one hc hpm⟩
 
 /-- The function `seminormFromConst` is a `RingSeminorm` on `R`. -/
@@ -196,7 +196,7 @@ theorem seminormFromConst_isPowMul : IsPowMul (seminormFromConst' hf1 hc hpm) :=
 /-- The function `seminormFromConst' hf1 hc hpm` is bounded above by `f`. -/
 theorem seminormFromConst_le_seminorm (x : R) : seminormFromConst' hf1 hc hpm x ≤ f x := by
   apply le_of_tendsto (seminormFromConst_isLimit hf1 hc hpm x)
-  simp only [eventually_atTop, ge_iff_le]
+  simp only [eventually_atTop]
   use 1
   intro n hn
   rw [seminormFromConst_seq, div_le_iff₀ (by positivity), ← hpm c hn]

--- a/Mathlib/Analysis/Normed/Unbundled/SmoothingSeminorm.lean
+++ b/Mathlib/Analysis/Normed/Unbundled/SmoothingSeminorm.lean
@@ -247,12 +247,12 @@ theorem tendsto_smoothingFun_of_map_one_le_one (hμ1 : μ 1 ≤ 1) (x : R) :
 /-- If `μ 1 ≤ 1`, then `smoothingFun μ x` is nonnegative. -/
 theorem smoothingFun_nonneg (hμ1 : μ 1 ≤ 1) (x : R) : 0 ≤ smoothingFun μ x := by
   apply ge_of_tendsto (tendsto_smoothingFun_of_map_one_le_one μ hμ1 x)
-  simpa [eventually_atTop, ge_iff_le] using ⟨1, fun _ _ ↦ rpow_nonneg (apply_nonneg μ _) _⟩
+  simpa [eventually_atTop] using ⟨1, fun _ _ ↦ rpow_nonneg (apply_nonneg μ _) _⟩
 
 /-- If `μ 1 ≤ 1`, then `smoothingFun μ 1 ≤ 1`. -/
 theorem smoothingFun_one_le (hμ1 : μ 1 ≤ 1) : smoothingFun μ 1 ≤ 1 := by
   apply le_of_tendsto (tendsto_smoothingFun_of_map_one_le_one μ hμ1 (1 : R))
-  simp only [eventually_atTop, ge_iff_le]
+  simp only [eventually_atTop]
   use 1
   rintro n hn
   simp only [smoothingSeminormSeq]
@@ -302,7 +302,7 @@ private theorem μ_bddBelow (s : ℕ → ℕ) {x : R} (ψ : ℕ → ℕ) :
     BddBelow {a : ℝ |
       ∀ᶠ n : ℝ in map (fun n : ℕ => μ x ^ (↑(s (ψ n)) * (1 / (ψ n : ℝ)))) atTop, n ≤ a} := by
   use 0
-  simp only [mem_lowerBounds, eventually_map, eventually_atTop, ge_iff_le, Set.mem_setOf_eq,
+  simp only [mem_lowerBounds, eventually_map, eventually_atTop, Set.mem_setOf_eq,
     forall_exists_index]
   intro r m hm
   exact le_trans (rpow_nonneg (apply_nonneg μ _) _) (hm m (le_refl _))
@@ -338,11 +338,11 @@ private theorem μ_nonempty {s : ℕ → ℕ} (hs_le : ∀ n : ℕ, s n ≤ n) {
       n ≤ a}.Nonempty := by
   by_cases hμx : μ x < 1
   · use 1
-    simp only [eventually_map, eventually_atTop, ge_iff_le, Set.mem_setOf_eq]
+    simp only [eventually_map, eventually_atTop, Set.mem_setOf_eq]
     exact ⟨0, fun _ _ ↦ rpow_le_one (apply_nonneg _ _) (le_of_lt hμx)
       (mul_nonneg (cast_nonneg _) (one_div_nonneg.mpr (cast_nonneg _)))⟩
   · use μ x
-    simp only [eventually_map, eventually_atTop, ge_iff_le, Set.mem_setOf_eq]
+    simp only [eventually_map, eventually_atTop, Set.mem_setOf_eq]
     use 0
     intro b _
     nth_rw 2 [← rpow_one (μ x)]
@@ -356,7 +356,7 @@ private theorem μ_limsup_le_one {s : ℕ → ℕ} (hs_le : ∀ n : ℕ, s n ≤
   simp only [limsup, limsSup]
   rw [csInf_le_iff (μ_bddBelow μ s ψ) (μ_nonempty μ hs_le ψ)]
   · intro c hc_bd
-    simp only [mem_lowerBounds, eventually_map, eventually_atTop, ge_iff_le, Set.mem_setOf_eq,
+    simp only [mem_lowerBounds, eventually_map, eventually_atTop, Set.mem_setOf_eq,
       forall_exists_index] at hc_bd
     by_cases hμx : μ x < 1
     · apply hc_bd (1 : ℝ) 0
@@ -387,7 +387,7 @@ private theorem limsup_mu_le (hμ1 : μ 1 ≤ 1) {s : ℕ → ℕ} (hs_le : ∀ 
           limsup (fun n : ℕ => μ x ^ ((s (ψ n) : ℝ) * (1 / (ψ n : ℝ)))) atTop := by
           apply csInf_le_csInf _ (μ_nonempty μ hs_le ψ)
           · intro b hb
-            simp only [eventually_map, eventually_atTop, ge_iff_le, Set.mem_setOf_eq] at hb ⊢
+            simp only [eventually_map, eventually_atTop, Set.mem_setOf_eq] at hb ⊢
             obtain ⟨m, hm⟩ := hb
             use m
             intro k hkm
@@ -396,7 +396,7 @@ private theorem limsup_mu_le (hμ1 : μ 1 ≤ 1) {s : ℕ → ℕ} (hs_le : ∀ 
             exact rpow_le_rpow (apply_nonneg μ _) (map_pow_le_pow' hμ1 x _)
               (one_div_nonneg.mpr (cast_nonneg _))
           · use 0
-            simp only [mem_lowerBounds, eventually_map, eventually_atTop, ge_iff_le,
+            simp only [mem_lowerBounds, eventually_map, eventually_atTop,
               Set.mem_setOf_eq, forall_exists_index]
             exact fun _ m hm ↦ le_trans (rpow_nonneg (apply_nonneg μ _) _) (hm m (le_refl _))
       _ ≤ 1 := (μ_limsup_le_one μ hs_le hψ_lim)
@@ -445,7 +445,7 @@ theorem isNonarchimedean_smoothingFun (hμ1 : μ 1 ≤ 1) (hna : IsNonarchimedea
   set b := 1 - a with hb
   have hb_lim : Tendsto ((fun n : ℕ => (nu n : ℝ) / ↑n) ∘ ψ) atTop (𝓝 b) := by
     apply Tendsto.congr' _ (Tendsto.const_sub 1 hψ_lim)
-    simp only [EventuallyEq, Function.comp_apply, eventually_atTop, ge_iff_le]
+    simp only [EventuallyEq, Function.comp_apply, eventually_atTop]
     use 1
     intro m hm
     have h0 : (ψ m : ℝ) ≠ 0 := cast_ne_zero.mpr (_root_.ne_of_gt (lt_of_le_of_lt (_root_.zero_le _)
@@ -521,7 +521,7 @@ def smoothingSeminorm (hμ1 : μ 1 ≤ 1) (hna : IsNonarchimedean μ) : RingSemi
   map_zero' := by
     apply tendsto_nhds_unique_of_eventuallyEq (tendsto_smoothingFun_of_map_one_le_one μ hμ1 0)
       tendsto_const_nhds
-    simp only [EventuallyEq, eventually_atTop, ge_iff_le]
+    simp only [EventuallyEq, eventually_atTop]
     use 1
     intro n hn
     simp only [smoothingSeminormSeq]
@@ -572,7 +572,7 @@ theorem smoothingFun_of_powMul (hμ1 : μ 1 ≤ 1) {x : R}
     (hx : ∀ (n : ℕ) (_hn : 1 ≤ n), μ (x ^ n) = μ x ^ n) : smoothingFun μ x = μ x := by
   apply tendsto_nhds_unique_of_eventuallyEq (tendsto_smoothingFun_of_map_one_le_one μ hμ1 x)
     tendsto_const_nhds
-  simp only [EventuallyEq, eventually_atTop, ge_iff_le]
+  simp only [EventuallyEq, eventually_atTop]
   use 1
   intro n hn
   simp only [smoothingSeminormSeq]
@@ -584,7 +584,7 @@ theorem smoothingFun_apply_of_map_mul_eq_mul (hμ1 : μ 1 ≤ 1) {x : R}
     (hx : ∀ y : R, μ (x * y) = μ x * μ y) : smoothingFun μ x = μ x := by
   apply tendsto_nhds_unique_of_eventuallyEq (tendsto_smoothingFun_of_map_one_le_one μ hμ1 x)
     tendsto_const_nhds
-  simp only [EventuallyEq, eventually_atTop, ge_iff_le]
+  simp only [EventuallyEq, eventually_atTop]
   use 1
   intro n hn
   simp only [smoothingSeminormSeq]
@@ -615,7 +615,7 @@ theorem smoothingFun_of_map_mul_eq_mul (hμ1 : μ 1 ≤ 1) {x : R} (hx : ∀ y :
     exact Tendsto.const_mul _ (tendsto_smoothingFun_of_map_one_le_one μ hμ1 y)
   apply tendsto_nhds_unique_of_eventuallyEq (tendsto_smoothingFun_of_map_one_le_one μ hμ1 (x * y))
     hlim
-  simp only [EventuallyEq, eventually_atTop, ge_iff_le]
+  simp only [EventuallyEq, eventually_atTop]
   use 1
   intro n hn1
   have hn0 : (n : ℝ) ≠ 0 := Nat.cast_ne_zero.mpr (_root_.ne_of_gt (lt_of_lt_of_le zero_lt_one hn1))

--- a/Mathlib/Analysis/Oscillation.lean
+++ b/Mathlib/Analysis/Oscillation.lean
@@ -124,7 +124,7 @@ theorem uniform_oscillationWithin (comp : IsCompact K) (hK : ∀ x ∈ K, oscill
     simp only [oscillationWithin, Filter.mem_map, iInf_lt_iff] at this
     obtain ⟨n, hn₁, hn₂⟩ := this
     obtain ⟨r, r0, hr⟩ := mem_nhdsWithin_iff.1 hn₁
-    simp only [gt_iff_lt, mem_iUnion, exists_prop]
+    simp only [mem_iUnion, exists_prop]
     have : ∀ r', (ENNReal.ofReal r') ≤ r → diam (f '' (ball x (ENNReal.ofReal r') ∩ D)) ≤ ε := by
       intro r' hr'
       grw [← hn₂, ← image_subset_iff.2 hr, hr']

--- a/Mathlib/Analysis/Polynomial/CauchyBound.lean
+++ b/Mathlib/Analysis/Polynomial/CauchyBound.lean
@@ -80,7 +80,7 @@ theorem IsRoot.norm_lt_cauchyBound {p : K[X]} (hp : p ≠ 0) {a : K} (h : p.IsRo
   simp only [nnnorm_mul, nnnorm_pow, nnnorm_neg] at h
   suffices ‖a‖₊ ^ p.natDegree ≤ (cauchyBound p - 1) * ∑ x ∈ range p.natDegree, ‖a‖₊ ^ x by
     rcases eq_or_ne ‖a‖₊ 1 with ha | ha
-    · simp only [ha, one_pow, sum_const, card_range, nsmul_eq_mul, mul_one, gt_iff_lt] at this ⊢
+    · simp only [ha, one_pow, sum_const, card_range, nsmul_eq_mul, mul_one] at this ⊢
       apply lt_of_le_of_ne (by simp)
       intro nh
       simp [← nh, tsub_self] at this

--- a/Mathlib/Analysis/SpecialFunctions/BinaryEntropy.lean
+++ b/Mathlib/Analysis/SpecialFunctions/BinaryEntropy.lean
@@ -378,7 +378,7 @@ lemma qaryEntropy_strictMonoOn (qLe2 : 2 ≤ q) :
       linarith
     simp only [one_div, interior_Icc, mem_Ioo] at hp
     rw [deriv_qaryEntropy (by linarith)]
-    · simp only [sub_pos, gt_iff_lt]
+    · simp only [sub_pos]
       rw [← log_mul (by linarith) (by linarith)]
       apply Real.strictMonoOn_log (mem_Ioi.mpr hp.1)
       · simp_all only [mem_Ioi, mul_pos_iff_of_pos_left, show 0 < (q : ℝ) - 1 by linarith]
@@ -402,14 +402,14 @@ lemma qaryEntropy_strictAntiOn (qLe2 : 2 ≤ q) :
     have zero_lt_1_sub_p : 0 < 1 - p := by simp_all only [sub_pos, interior_Icc, mem_Ioo]
     simp only [one_div, interior_Icc, mem_Ioo] at hp
     rw [deriv_qaryEntropy (by linarith)]
-    · simp only [sub_neg, gt_iff_lt]
+    · simp only [sub_neg]
       rw [← log_mul (by linarith) (by linarith)]
       apply Real.strictMonoOn_log (mem_Ioi.mpr (show 0 < (↑q - 1) * (1 - p) by nlinarith))
       · simp_all only [mem_Ioi]
         linarith
       · have qpos : 0 < (q : ℝ) := by positivity
         ring_nf
-        simp only [add_lt_iff_neg_right, neg_add_lt_iff_lt_add, add_zero, gt_iff_lt]
+        simp only [add_lt_iff_neg_right, neg_add_lt_iff_lt_add, add_zero]
         have : (q : ℝ) - 1 < p * q := by
           have h1 := mul_lt_mul_of_pos_right hp.1 qpos
           have h2 : (1 - (q : ℝ)⁻¹) * ↑q = q - 1 := by calc (1 - (q : ℝ)⁻¹) * ↑q

--- a/Mathlib/Analysis/SpecialFunctions/Exp.lean
+++ b/Mathlib/Analysis/SpecialFunctions/Exp.lean
@@ -126,7 +126,7 @@ lemma UniformContinuousOn.cexp (a : ℝ) : UniformContinuousOn exp {x : ℂ | x.
   have : Continuous (cexp - 1) := Continuous.sub (Continuous.cexp continuous_id') continuous_one
   rw [Metric.uniformContinuousOn_iff, Metric.continuous_iff'] at *
   intro ε hε
-  simp only [gt_iff_lt, Pi.sub_apply, Pi.one_apply, dist_sub_eq_dist_add_right,
+  simp only [Pi.sub_apply, Pi.one_apply, dist_sub_eq_dist_add_right,
     sub_add_cancel] at this
   have ha : 0 < ε / (2 * Real.exp a) := by positivity
   have H := this 0 (ε / (2 * Real.exp a)) ha
@@ -141,7 +141,7 @@ lemma UniformContinuousOn.cexp (a : ℝ) : UniformContinuousOn exp {x : ℂ | x.
     ring_nf
   rw [this, mul_comm]
   have hya : ‖cexp y‖ ≤ Real.exp a := by simpa only [norm_exp, Real.exp_le_exp]
-  simp only [gt_iff_lt, dist_zero_right, Set.mem_setOf_eq, norm_mul, Complex.norm_exp] at *
+  simp only [dist_zero_right, Set.mem_setOf_eq, norm_mul, Complex.norm_exp] at *
   apply lt_of_le_of_lt (mul_le_mul h3.le hya (Real.exp_nonneg y.re) ha.le)
   simp [field]
 

--- a/Mathlib/Analysis/SpecialFunctions/Log/PosLog.lean
+++ b/Mathlib/Analysis/SpecialFunctions/Log/PosLog.lean
@@ -101,7 +101,7 @@ theorem monotoneOn_posLog : MonotoneOn log⁺ (Set.Ici 0) := by
   · tauto
   · right
     have := log_le_log (lt_trans Real.zero_lt_one ((log_pos_iff hx).1 h)) hxy
-    simp only [this, and_true, ge_iff_le]
+    simp only [this, and_true]
     linarith
 
 @[gcongr]

--- a/Mathlib/Analysis/SpecialFunctions/Log/Summable.lean
+++ b/Mathlib/Analysis/SpecialFunctions/Log/Summable.lean
@@ -153,7 +153,7 @@ lemma multipliable_one_add_of_summable [CompleteSpace R]
   obtain ⟨r₁, hr₁, s₁, hs₁⟩ :=
     (multipliable_norm_one_add_of_summable_norm hf).eventually_bounded_finset_prod
   obtain ⟨s₂, hs₂⟩ := prod_vanishing_of_summable_norm hf (show 0 < ε / (2 * r₁) by positivity)
-  simp only [unconditional, Filter.mem_map, mem_atTop_sets, ge_iff_le, le_eq_subset,
+  simp only [unconditional, Filter.mem_map, mem_atTop_sets, le_eq_subset,
     Set.mem_preimage]
   let s := s₁ ∪ s₂
   -- The idea here is that if `s` is a large enough finset, then the product over `s` is bounded

--- a/Mathlib/Analysis/SpecialFunctions/Trigonometric/Bounds.lean
+++ b/Mathlib/Analysis/SpecialFunctions/Trigonometric/Bounds.lean
@@ -185,7 +185,7 @@ theorem lt_tan {x : ℝ} (h1 : 0 < x) (h2 : x < π / 2) : x < tan x := by
   have tan_minus_id_cts : ContinuousOn (fun y : ℝ => tan y - y) U := tan_cts_U.sub continuousOn_id
   have deriv_pos (y : ℝ) (hy : y ∈ interior U) : 0 < deriv (fun y' : ℝ => tan y' - y') y := by
     have := cos_pos (interior_subset hy)
-    simp only [deriv_tan_sub_id y this.ne', one_div, gt_iff_lt, sub_pos]
+    simp only [deriv_tan_sub_id y this.ne', one_div, sub_pos]
     norm_cast
     have bd2 : cos y ^ 2 < 1 := by
       apply lt_of_le_of_ne y.cos_sq_le_one

--- a/Mathlib/Analysis/SpecialFunctions/Trigonometric/Cotangent.lean
+++ b/Mathlib/Analysis/SpecialFunctions/Trigonometric/Cotangent.lean
@@ -309,7 +309,7 @@ private lemma iteratedDerivWithin_cotTerm_bounded_uniformly
     (by norm_cast; lia) ![1, -(n + 1)] hB (z := ⟨a, (hK ha)⟩) (A := A) (by aesop))
   simp only [Fin.isValue, Matrix.cons_val_zero, Int.cast_one, coe_mk_subtype, one_mul,
     Matrix.cons_val_one, Matrix.cons_val_fin_one, Int.cast_add, Int.cast_natCast, neg_add_rev,
-    abs_norm_eq_max_natAbs, Int.reduceNeg, Int.cast_neg, sub_eq_add_neg, ge_iff_le] at h1 h2 ⊢
+    abs_norm_eq_max_natAbs, Int.reduceNeg, Int.cast_neg, sub_eq_add_neg] at h1 h2 ⊢
   refine le_trans (norm_add_le _ _) (add_le_add ?_ ?_) <;>
     {simp only [Int.reduceNeg, norm_zpow]; norm_cast at h1 h2 ⊢}
 

--- a/Mathlib/Analysis/SpecificLimits/Basic.lean
+++ b/Mathlib/Analysis/SpecificLimits/Basic.lean
@@ -300,7 +300,7 @@ protected theorem ENNReal.tendsto_pow_atTop_nhds_top_iff {r : ℝ≥0∞} :
   · contrapose!
     intro r_le_one h_tends
     specialize h_tends (Ioi_mem_nhds one_lt_top)
-    simp only [Filter.mem_map, mem_atTop_sets, ge_iff_le, Set.mem_preimage, Set.mem_Ioi] at h_tends
+    simp only [Filter.mem_map, mem_atTop_sets, Set.mem_preimage, Set.mem_Ioi] at h_tends
     obtain ⟨n, hn⟩ := h_tends
     exact lt_irrefl _ <| lt_of_lt_of_le (hn n le_rfl) <| pow_le_one₀ (zero_le _) r_le_one
   · intro r_gt_one

--- a/Mathlib/Combinatorics/Matroid/Rank/Cardinal.lean
+++ b/Mathlib/Combinatorics/Matroid/Rank/Cardinal.lean
@@ -151,7 +151,7 @@ theorem Indep.cRk_eq_cardinalMk (hI : M.Indep I) : #I = M.cRk I :=
     (hX : X ⊆ M.E := by aesop_mat) : lift.{u,v} ((M.map f hf).cRk (f '' X)) = lift (M.cRk X) := by
   nth_rw 1 [cRk, cRank, le_antisymm_iff, lift_iSup (bddAbove_range _), cRk, cRank, cRk, cRank]
   nth_rw 2 [lift_iSup (bddAbove_range _)]
-  simp only [ciSup_le_iff (bddAbove_range _), ge_iff_le, Subtype.forall, isBase_restrict_iff',
+  simp only [ciSup_le_iff (bddAbove_range _), Subtype.forall, isBase_restrict_iff',
     isBasis'_iff_isBasis hX, isBasis'_iff_isBasis (show f '' X ⊆ (M.map f hf).E from image_mono hX)]
   refine ⟨fun I hI ↦ ?_, fun I hI ↦ ?_⟩
   · obtain ⟨I, X', hIX, rfl, hXX'⟩ := map_isBasis_iff'.1 hI
@@ -174,7 +174,7 @@ theorem cRk_map_eq {β : Type u} {f : α → β} {X : Set β} (M : Matroid α) (
     lift.{v,u} ((M.comap f).cRk X) = lift (M.cRk (f '' X)) := by
   nth_rw 1 [cRk, cRank, le_antisymm_iff, lift_iSup (bddAbove_range _), cRk, cRank, cRk, cRank]
   nth_rw 2 [lift_iSup (bddAbove_range _)]
-  simp only [ciSup_le_iff (bddAbove_range _), ge_iff_le, Subtype.forall, isBase_restrict_iff',
+  simp only [ciSup_le_iff (bddAbove_range _), Subtype.forall, isBase_restrict_iff',
     comap_isBasis'_iff, and_imp]
   refine ⟨fun I hI hfI hIX ↦ ?_, fun I hIX ↦ ?_⟩
   · rw [← mk_image_eq_of_injOn_lift _ _ hfI, lift_le]

--- a/Mathlib/Computability/AkraBazzi/AkraBazzi.lean
+++ b/Mathlib/Computability/AkraBazzi/AkraBazzi.lean
@@ -530,7 +530,7 @@ lemma T_isBigO_smoothingFn_mul_asympBound :
         · exact le_of_lt <| R.a_pos _
         · by_cases! ri_lt_n₀ : r i n < n₀
           · exact h_base _ <| by
-              simp_all only [gt_iff_lt, Nat.ofNat_pos, div_pos_iff_of_pos_right,
+              simp_all only [Nat.ofNat_pos, div_pos_iff_of_pos_right,
                 eventually_atTop, sub_pos, one_div, mem_Ico, and_imp,
                 forall_true_left, mem_univ, and_self, b', C, base_max]
           · exact h_ind (r i n) (R.r_lt_n _ _ (n₀_ge_Rn₀.trans hn)) ri_lt_n₀

--- a/Mathlib/Computability/AkraBazzi/GrowsPolynomially.lean
+++ b/Mathlib/Computability/AkraBazzi/GrowsPolynomially.lean
@@ -336,8 +336,8 @@ protected lemma GrowsPolynomially.mul {f g : ℝ → ℝ} (hf : GrowsPolynomiall
   have hg := hg.abs b hb
   obtain ⟨c₁, hc₁_mem, c₂, hc₂_mem, hf⟩ := hf
   obtain ⟨c₃, hc₃_mem, c₄, hc₄_mem, hg⟩ := hg
-  refine ⟨c₁ * c₃, by change 0 < c₁ * c₃; positivity, ?_⟩
-  refine ⟨c₂ * c₄, by change 0 < c₂ * c₄; positivity, ?_⟩
+  refine ⟨c₁ * c₃, by positivity, ?_⟩
+  refine ⟨c₂ * c₄, by positivity, ?_⟩
   filter_upwards [hf, hg] with x hf hg
   intro u hu
   refine ⟨?lb, ?ub⟩
@@ -366,8 +366,8 @@ protected lemma GrowsPolynomially.add {f g : ℝ → ℝ} (hf : GrowsPolynomiall
   have hg := hg b hb
   obtain ⟨c₁, hc₁_mem, c₂, hc₂_mem, hf⟩ := hf
   obtain ⟨c₃, hc₃_mem, c₄, _, hg⟩ := hg
-  refine ⟨min c₁ c₃, by change 0 < min c₁ c₃; positivity, ?_⟩
-  refine ⟨max c₂ c₄, by change 0 < max c₂ c₄; positivity, ?_⟩
+  refine ⟨min c₁ c₃, by positivity, ?_⟩
+  refine ⟨max c₂ c₄, by positivity, ?_⟩
   filter_upwards [hf, hg,
                   (tendsto_id.const_mul_atTop hb.1).eventually_forall_ge_atTop hf',
                   (tendsto_id.const_mul_atTop hb.1).eventually_forall_ge_atTop hg',
@@ -537,8 +537,8 @@ protected lemma GrowsPolynomially.inv {f : ℝ → ℝ} (hf : GrowsPolynomially 
     intro b hb
     have hb_pos := hb.1
     obtain ⟨c₁, hc₁_mem, c₂, hc₂_mem, hf⟩ := hf b hb
-    refine ⟨c₂⁻¹, by change 0 < c₂⁻¹; positivity, ?_⟩
-    refine ⟨c₁⁻¹, by change 0 < c₁⁻¹; positivity, ?_⟩
+    refine ⟨c₂⁻¹, by positivity, ?_⟩
+    refine ⟨c₁⁻¹, by positivity, ?_⟩
     filter_upwards [hf, hf', (tendsto_id.const_mul_atTop hb_pos).eventually_forall_ge_atTop hf']
       with x hx hx' hx''
     intro u hu

--- a/Mathlib/Data/ENat/Basic.lean
+++ b/Mathlib/Data/ENat/Basic.lean
@@ -440,7 +440,7 @@ lemma add_one_natCast_le_withTop_of_lt {m : ℕ} {n : WithTop ℕ∞} (h : m < n
   match n with
   | ⊤ => exact le_top
   | (⊤ : ℕ∞) => exact WithTop.coe_le_coe.2 (OrderTop.le_top _)
-  | (n : ℕ) => simpa only [Nat.cast_le, ge_iff_le, Nat.cast_lt] using h
+  | (n : ℕ) => simpa only [Nat.cast_le, Nat.cast_lt] using h
 
 @[simp] lemma coe_top_add_one : ((⊤ : ℕ∞) : WithTop ℕ∞) + 1 = (⊤ : ℕ∞) := rfl
 

--- a/Mathlib/Data/Finite/Card.lean
+++ b/Mathlib/Data/Finite/Card.lean
@@ -150,7 +150,7 @@ theorem card_subtype_lt [Finite α] {p : α → Prop} {x : α} (hx : ¬p x) :
     Nat.card { x // p x } < Nat.card α := by
   classical
   haveI := Fintype.ofFinite α
-  simpa only [Nat.card_eq_fintype_card, gt_iff_lt] using Fintype.card_subtype_lt hx
+  simpa only [Nat.card_eq_fintype_card] using Fintype.card_subtype_lt hx
 
 end Finite
 

--- a/Mathlib/Data/Nat/Pairing.lean
+++ b/Mathlib/Data/Nat/Pairing.lean
@@ -87,7 +87,7 @@ theorem pair_eq_pair {a b c d : ℕ} : pair a b = pair c d ↔ a = c ∧ b = d :
 theorem unpair_lt {n : ℕ} (n1 : 1 ≤ n) : (unpair n).1 < n := by
   let s := sqrt n
   simp only [unpair]
-  by_cases h : n - s * s < s <;> simp only [h, ↓reduceIte, gt_iff_lt, s]
+  by_cases h : n - s * s < s <;> simp only [h, ↓reduceIte, s]
   · exact lt_of_lt_of_le h (sqrt_le_self _)
   · simp only [not_lt] at h
     have s0 : 0 < s := sqrt_pos.2 n1

--- a/Mathlib/Data/Ordmap/Invariants.lean
+++ b/Mathlib/Data/Ordmap/Invariants.lean
@@ -611,7 +611,7 @@ theorem balance_eq_balance' {l x r} (hl : Balanced l) (hr : Balanced r) (sl : Si
           · simp [node3R, node']; abel
           · simp [node4R, node', sl.2.2.1]; abel
         · exact not_le_of_gt (Nat.succ_lt_succ (add_pos sl.2.1.pos sl.2.2.pos))
-    · simp only [balance, id_eq, balance', size_node, gt_iff_lt]
+    · simp only [balance, id_eq, balance', size_node]
       symm; rw [if_neg]
       · split_ifs with h h_1
         · have rd : delta ≤ size rl + size rr := by

--- a/Mathlib/Data/Rat/Floor.lean
+++ b/Mathlib/Data/Rat/Floor.lean
@@ -392,7 +392,7 @@ theorem fract_inv_num_lt_num_of_pos {q : ℚ} (q_pos : 0 < q) : (fract q⁻¹).n
   have q_inv_eq : q⁻¹ = q_inv := by rw [q_inv_def, inv_def, divInt_eq_div, Int.cast_natCast]
   suffices (q_inv - ⌊q_inv⌋).num < q.num by rwa [q_inv_eq]
   suffices ((q.den - q.num * ⌊q_inv⌋ : ℚ) / q.num).num < q.num by
-    simp only [gt_iff_lt, q_inv]
+    simp only [q_inv]
     field_simp
     simp [q_inv, this]
   suffices (q.den : ℤ) - q.num * ⌊q_inv⌋ < q.num by

--- a/Mathlib/Data/Rat/Lemmas.lean
+++ b/Mathlib/Data/Rat/Lemmas.lean
@@ -316,8 +316,7 @@ theorem inv_natCast_num (a : ℕ) : (a : ℚ)⁻¹.num = Int.sign a := by simp
 theorem inv_ofNat_num (a : ℕ) [a.AtLeastTwo] : (ofNat(a) : ℚ)⁻¹.num = 1 := by
   -- This proof is quite unpleasant: golf / find better simp lemmas?
   have : 2 ≤ a := Nat.AtLeastTwo.prop
-  simp only [num_inv, num_ofNat, den_ofNat, Nat.cast_one, mul_one, Int.sign_eq_one_iff_pos,
-    gt_iff_lt]
+  simp only [num_inv, num_ofNat, den_ofNat, Nat.cast_one, mul_one, Int.sign_eq_one_iff_pos]
   change 0 < (a : ℤ)
   lia
 

--- a/Mathlib/Data/Real/Archimedean.lean
+++ b/Mathlib/Data/Real/Archimedean.lean
@@ -73,7 +73,7 @@ theorem exists_isLUB (hne : s.Nonempty) (hbdd : BddAbove s) : ∃ x, IsLUB s x :
   have hf₂ : ∀ n > 0, ∀ y ∈ s, (y - ((n : ℕ) : ℝ)⁻¹) < (f n / n : ℚ) := by
     intro n n0 y yS
     have := (Int.sub_one_lt_floor _).trans_le (Int.cast_le.2 <| (hf n).2 _ ⟨y, yS, Int.floor_le _⟩)
-    simp only [Rat.cast_div, Rat.cast_intCast, Rat.cast_natCast, gt_iff_lt]
+    simp only [Rat.cast_div, Rat.cast_intCast, Rat.cast_natCast]
     rwa [lt_div_iff₀ (Nat.cast_pos.2 n0 : (_ : ℝ) < _), sub_mul, inv_mul_cancel₀]
     exact ne_of_gt (Nat.cast_pos.2 n0)
   have hg : IsCauSeq abs (fun n => f n / n : ℕ → ℚ) := by

--- a/Mathlib/Data/Sum/Order.lean
+++ b/Mathlib/Data/Sum/Order.lean
@@ -683,8 +683,7 @@ def sumLexDualAntidistrib (α β : Type*) [LE α] [LE β] : (α ⊕ₗ β)ᵒᵈ
   { Equiv.sumComm α β with
     map_rel_iff' := fun {a b} => by
       rcases a with (a | a) <;> rcases b with (b | b)
-      · simp only [ge_iff_le]
-        change
+      · change
           toLex (inr <| toDual a) ≤ toLex (inr <| toDual b) ↔
             toDual (toLex <| inl a) ≤ toDual (toLex <| inl b)
         simp [toDual_le_toDual]

--- a/Mathlib/Data/ZMod/Basic.lean
+++ b/Mathlib/Data/ZMod/Basic.lean
@@ -1059,7 +1059,7 @@ theorem val_pow {m n : ℕ} {a : ZMod n} [ilt : Fact (1 < n)] (h : a.val ^ m < n
         · cases hm; simp [ilt.out]
         · simp only [val_zero, ne_eq, hm, not_false_eq_true, zero_pow, Nat.zero_lt_of_lt h]
       · exact lt_of_le_of_lt
-         (Nat.pow_le_pow_right (by rwa [gt_iff_lt, ZMod.val_pos]) (Nat.le_succ m)) h
+         (Nat.pow_le_pow_right (by rwa [ZMod.val_pos]) (Nat.le_succ m)) h
     rw [pow_succ, ZMod.val_mul, ih this, ← pow_succ, Nat.mod_eq_of_lt h]
 
 theorem val_pow_le {m n : ℕ} [Fact (1 < n)] {a : ZMod n} : (a ^ m).val ≤ a.val ^ m := by

--- a/Mathlib/Data/ZMod/Basic.lean
+++ b/Mathlib/Data/ZMod/Basic.lean
@@ -1059,7 +1059,7 @@ theorem val_pow {m n : ℕ} {a : ZMod n} [ilt : Fact (1 < n)] (h : a.val ^ m < n
         · cases hm; simp [ilt.out]
         · simp only [val_zero, ne_eq, hm, not_false_eq_true, zero_pow, Nat.zero_lt_of_lt h]
       · exact lt_of_le_of_lt
-         (Nat.pow_le_pow_right (by rwa [ZMod.val_pos]) (Nat.le_succ m)) h
+         (Nat.pow_le_pow_right (by rwa [gt_iff_lt, ZMod.val_pos]) (Nat.le_succ m)) h
     rw [pow_succ, ZMod.val_mul, ih this, ← pow_succ, Nat.mod_eq_of_lt h]
 
 theorem val_pow_le {m n : ℕ} [Fact (1 < n)] {a : ZMod n} : (a ^ m).val ≤ a.val ^ m := by

--- a/Mathlib/Geometry/Manifold/Riemannian/Basic.lean
+++ b/Mathlib/Geometry/Manifold/Riemannian/Basic.lean
@@ -248,7 +248,7 @@ lemma eventually_enorm_mfderiv_extChartAt_lt (x : M) :
     ∃ C > (0 : ℝ≥0), ∀ᶠ y in 𝓝 x, ‖mfderiv I 𝓘(ℝ, E) (extChartAt I x) y‖ₑ < C := by
   rcases eventually_norm_mfderiv_extChartAt_lt I x with ⟨C, C_pos, hC⟩
   lift C to ℝ≥0 using C_pos.le
-  simp only [gt_iff_lt, NNReal.coe_pos] at C_pos
+  simp only [NNReal.coe_pos] at C_pos
   refine ⟨C, C_pos, ?_⟩
   filter_upwards [hC] with y hy
   simp only [enorm, nnnorm]
@@ -286,7 +286,7 @@ lemma eventually_enorm_mfderivWithin_symm_extChartAt_lt (x : M) :
     ‖mfderivWithin 𝓘(ℝ, E) I (extChartAt I x).symm (range I) y‖ₑ < C := by
   rcases eventually_norm_mfderivWithin_symm_extChartAt_lt I x with ⟨C, C_pos, hC⟩
   lift C to ℝ≥0 using C_pos.le
-  simp only [gt_iff_lt, NNReal.coe_pos] at C_pos
+  simp only [NNReal.coe_pos] at C_pos
   refine ⟨C, C_pos, ?_⟩
   filter_upwards [hC] with y hy
   simp only [enorm, nnnorm]
@@ -421,7 +421,7 @@ lemma setOf_riemannianEDist_lt_subset_nhds [RegularSpace M] {x : M} {s : Set M} 
   obtain ⟨r, r_pos, hr⟩ : ∃ r > 0, ball (extChartAt I x x) r ⊆ (extChartAt I x).symm ⁻¹' v :=
     Metric.mem_nhds_iff.1 (extChartAt_preimage_mem_nhds v_mem)
   lift r to ℝ≥0 using r_pos.le
-  simp only [gt_iff_lt, NNReal.coe_pos] at r_pos
+  simp only [NNReal.coe_pos] at r_pos
   -- the desired constant will be `c := r / C`
   refine ⟨r / C, by positivity, ?_⟩
   intro y hy

--- a/Mathlib/GroupTheory/ArchimedeanDensely.lean
+++ b/Mathlib/GroupTheory/ArchimedeanDensely.lean
@@ -454,7 +454,7 @@ lemma LinearOrderedCommGroupWithZero.wellFoundedOn_setOf_ge_gt_iff_nonempty_disc
       and_true]
     refine (inv_le_comm₀ ?_ ?_).mp <;>
     simp [zero_lt_iff, hg, hx]
-  · simp only [mem_setOf_eq, Function.onFun, gt_iff_lt]
+  · simp only [mem_setOf_eq, Function.onFun]
     intro a ha b _
     refine inv_strictAnti₀ ?_
     contrapose! ha
@@ -465,7 +465,7 @@ lemma LinearOrderedCommGroupWithZero.wellFoundedOn_setOf_ge_gt_iff_nonempty_disc
     intro hxg hx
     refine inv_anti₀ ?_ hxg
     simp [zero_lt_iff, hx]
-  · simp only [mem_diff, mem_setOf_eq, mem_singleton_iff, gt_iff_lt, Function.onFun, and_imp]
+  · simp only [mem_diff, mem_setOf_eq, mem_singleton_iff, Function.onFun, and_imp]
     intro a _ _ b _ hb0
     refine inv_strictAnti₀ ?_
     simp [zero_lt_iff, hb0]

--- a/Mathlib/MeasureTheory/Covering/Differentiation.lean
+++ b/Mathlib/MeasureTheory/Covering/Differentiation.lean
@@ -104,7 +104,7 @@ theorem ae_eventually_measure_pos [SecondCountableTopology α] :
   have h : v.FineSubfamilyOn f s := by
     intro x hx ε εpos
     rw [hs] at hx
-    simp only [frequently_filterAt_iff, gt_iff_lt, mem_setOf_eq] at hx
+    simp only [frequently_filterAt_iff, mem_setOf_eq] at hx
     rcases hx ε εpos with ⟨a, a_sets, ax, μa⟩
     exact ⟨a, ⟨a_sets, μa⟩, ax⟩
   refine le_antisymm ?_ bot_le

--- a/Mathlib/MeasureTheory/Function/LpSpace/Basic.lean
+++ b/Mathlib/MeasureTheory/Function/LpSpace/Basic.lean
@@ -380,7 +380,7 @@ instance instNormedAddCommGroup [hp : Fact (1 ≤ p)] : NormedAddCommGroup (Lp E
         add_le' := fun f g => by
           suffices ‖f + g‖ₑ ≤ ‖f‖ₑ + ‖g‖ₑ by
             -- Squeezed for performance reasons
-            simpa only [ge_iff_le, enorm, ←ENNReal.coe_add, ENNReal.coe_le_coe] using this
+            simpa only [enorm, ←ENNReal.coe_add, ENNReal.coe_le_coe] using this
           simp only [Lp.enorm_def]
           exact (eLpNorm_congr_ae (AEEqFun.coeFn_add _ _)).trans_le
             (eLpNorm_add_le (Lp.aestronglyMeasurable _) (Lp.aestronglyMeasurable _) hp.out)

--- a/Mathlib/MeasureTheory/Function/UnifTight.lean
+++ b/Mathlib/MeasureTheory/Function/UnifTight.lean
@@ -215,7 +215,7 @@ private theorem unifTight_of_tendsto_Lp_zero (hp' : p ≠ ∞) (hf : ∀ n, MemL
     (hf_tendsto : Tendsto (fun n ↦ eLpNorm (f n) p μ) atTop (𝓝 0)) : UnifTight f p μ := by
   intro ε hε
   rw [ENNReal.tendsto_atTop_zero] at hf_tendsto
-  obtain ⟨N, hNε⟩ := hf_tendsto ε (by simpa only [gt_iff_lt, ENNReal.coe_pos])
+  obtain ⟨N, hNε⟩ := hf_tendsto ε (by simpa only [ENNReal.coe_pos])
   let F : Fin N → α → β := fun n => f n
   have hF : ∀ n, MemLp (F n) p μ := fun n => hf n
   obtain ⟨s, hμs, hFε⟩ := unifTight_fin hp' hF hε

--- a/Mathlib/MeasureTheory/Function/UniformIntegrable.lean
+++ b/Mathlib/MeasureTheory/Function/UniformIntegrable.lean
@@ -474,7 +474,7 @@ theorem tendsto_Lp_finite_of_tendsto_ae_of_meas [IsFiniteMeasure μ] (hp : 1 ≤
   obtain ⟨t, htm, ht₁, ht₂⟩ := tendstoUniformlyOn_of_ae_tendsto' hf hg hfg (lt_min hδ₁ hδ₂)
   rw [Metric.tendstoUniformlyOn_iff] at ht₂
   specialize ht₂ (ε.toReal / (3 * measureUnivNNReal μ ^ (1 / p.toReal)))
-    (div_pos (ENNReal.toReal_pos hε.ne h.ne) (mul_pos (by simp) hpow))
+    (div_pos (ENNReal.toReal_pos hε.ne.symm h.ne) (mul_pos (by simp) hpow))
   obtain ⟨N, hN⟩ := eventually_atTop.1 ht₂; clear ht₂
   refine ⟨N, fun n hn => ?_⟩
   rw [← t.indicator_self_add_compl (f n - g)]

--- a/Mathlib/MeasureTheory/Function/UniformIntegrable.lean
+++ b/Mathlib/MeasureTheory/Function/UniformIntegrable.lean
@@ -474,7 +474,7 @@ theorem tendsto_Lp_finite_of_tendsto_ae_of_meas [IsFiniteMeasure μ] (hp : 1 ≤
   obtain ⟨t, htm, ht₁, ht₂⟩ := tendstoUniformlyOn_of_ae_tendsto' hf hg hfg (lt_min hδ₁ hδ₂)
   rw [Metric.tendstoUniformlyOn_iff] at ht₂
   specialize ht₂ (ε.toReal / (3 * measureUnivNNReal μ ^ (1 / p.toReal)))
-    (div_pos (ENNReal.toReal_pos (gt_iff_lt.1 hε).ne.symm h.ne) (mul_pos (by simp) hpow))
+    (div_pos (ENNReal.toReal_pos hε.ne h.ne) (mul_pos (by simp) hpow))
   obtain ⟨N, hN⟩ := eventually_atTop.1 ht₂; clear ht₂
   refine ⟨N, fun n hn => ?_⟩
   rw [← t.indicator_self_add_compl (f n - g)]

--- a/Mathlib/MeasureTheory/Integral/Bochner/Set.lean
+++ b/Mathlib/MeasureTheory/Integral/Bochner/Set.lean
@@ -568,7 +568,7 @@ theorem norm_setIntegral_le_of_norm_le_const_ae' {C : ℝ} (hs : μ s < ∞)
       simp [Measure.restrict_eq_zero.mpr hfm]
     rcases (this.and_eventually hC).exists with ⟨x, hx, h'x⟩
     have : 0 ≤ C := (norm_nonneg _).trans (h'x hx)
-    simp only [norm_zero, ge_iff_le]
+    simp only [norm_zero]
     positivity
 
 theorem norm_setIntegral_le_of_norm_le_const {C : ℝ} (hs : μ s < ∞) (hC : ∀ x ∈ s, ‖f x‖ ≤ C) :

--- a/Mathlib/MeasureTheory/Measure/LevyProkhorovMetric.lean
+++ b/Mathlib/MeasureTheory/Measure/LevyProkhorovMetric.lean
@@ -604,7 +604,7 @@ lemma continuous_ofMeasure_probabilityMeasure :
     have rewr : ⋃ i, ⋃ (_ : N ≤ i), Es i = (⋃ i, ⋃ (_ : i < N), Es i)ᶜ := by
       simpa only [mem_Iio, compl_Iio, mem_Ici] using
         (biUnion_compl_eq_of_pairwise_disjoint_of_iUnion_eq_univ Es_cover Es_disjoint (Iio N)).symm
-    simpa only [mem_Iio, ← rewr, gt_iff_lt] using hN N le_rfl
+    simpa only [mem_Iio, ← rewr] using hN N le_rfl
   -- With the finite `N` fixed above, consider the finite collection of open sets of the form
   -- `Gs J = thickening (ε/3) (⋃ j ∈ J, Es j)`, where `J ⊆ {0, 1, ..., N-1}`.
   have Js_finite : Set.Finite {J | J ⊆ Iio N} := Finite.finite_subsets <| finite_Iio N

--- a/Mathlib/MeasureTheory/Measure/Portmanteau.lean
+++ b/Mathlib/MeasureTheory/Measure/Portmanteau.lean
@@ -447,11 +447,11 @@ lemma limsup_measure_closed_le_of_forall_tendsto_measure
   apply ENNReal.le_of_forall_pos_le_add
   intro ε ε_pos μF_finite
   have keyB := tendsto_measure_cthickening_of_isClosed (μ := μ) (s := F)
-                ⟨1, ⟨by simp only [gt_iff_lt, zero_lt_one], measure_ne_top _ _⟩⟩ F_closed
+                ⟨1, ⟨by simp only [zero_lt_one], measure_ne_top _ _⟩⟩ F_closed
   have nhds : Iio (μ F + ε) ∈ 𝓝 (μ F) :=
     Iio_mem_nhds <| ENNReal.lt_add_right μF_finite.ne (ENNReal.coe_pos.mpr ε_pos).ne'
   specialize rs_lim (keyB nhds)
-  simp only [mem_map, mem_atTop_sets, ge_iff_le, mem_preimage, mem_Iio] at rs_lim
+  simp only [mem_map, mem_atTop_sets, mem_preimage, mem_Iio] at rs_lim
   obtain ⟨m, hm⟩ := rs_lim
   have aux : (fun i ↦ (μs i F)) ≤ᶠ[L] (fun i ↦ μs i (Metric.thickening (rs m) F)) :=
     .of_forall <| fun i ↦ measure_mono (Metric.self_subset_thickening (rs_pos m) F)
@@ -522,7 +522,7 @@ lemma integral_le_liminf_integral_of_forall_isOpen_measure_le_liminf_measure
                         f.continuous.measurable.aestronglyMeasurable]
     let g := BoundedContinuousFunction.comp _ Real.lipschitzWith_toNNReal f
     have bound : ∀ i, ∫⁻ x, ENNReal.ofReal (f x) ∂(μs i) ≤ nndist 0 g := fun i ↦ by
-      simpa only [coe_nnreal_ennreal_nndist, measure_univ, mul_one, ge_iff_le] using
+      simpa only [coe_nnreal_ennreal_nndist, measure_univ, mul_one] using
             BoundedContinuousFunction.lintegral_le_edist_mul (μ := μs i) g
     apply ENNReal.liminf_toReal_eq ENNReal.coe_ne_top (Eventually.of_forall bound)
   · apply ne_of_lt
@@ -530,7 +530,7 @@ lemma integral_le_liminf_integral_of_forall_isOpen_measure_le_liminf_measure
     simp only [measure_univ, mul_one] at obs
     apply lt_of_le_of_lt _ (show (‖f‖₊ : ℝ≥0∞) < ∞ from ENNReal.coe_lt_top)
     apply liminf_le_of_le
-    · refine ⟨0, .of_forall (by simp only [ge_iff_le, zero_le, forall_const])⟩
+    · refine ⟨0, .of_forall (by simp only [zero_le, forall_const])⟩
     · intro x hx
       obtain ⟨i, hi⟩ := hx.exists
       apply le_trans hi

--- a/Mathlib/MeasureTheory/Measure/Regular.lean
+++ b/Mathlib/MeasureTheory/Measure/Regular.lean
@@ -418,7 +418,7 @@ protected theorem smul (μ : Measure α) [OuterRegular μ] {x : ℝ≥0∞} (hx 
     exact OuterRegular.zero
   · refine ⟨fun A _ r hr => ?_⟩
     rw [smul_apply, A.measure_eq_iInf_isOpen, smul_eq_mul] at hr
-    simpa only [ENNReal.mul_iInf_of_ne h0 hx, gt_iff_lt, iInf_lt_iff, exists_prop] using hr
+    simpa only [ENNReal.mul_iInf_of_ne h0 hx, iInf_lt_iff, exists_prop] using hr
 
 instance smul_nnreal (μ : Measure α) [OuterRegular μ] (c : ℝ≥0) :
     OuterRegular (c • μ) :=

--- a/Mathlib/MeasureTheory/Measure/RegularityCompacts.lean
+++ b/Mathlib/MeasureTheory/Measure/RegularityCompacts.lean
@@ -129,7 +129,7 @@ theorem exists_isCompact_closure_measure_compl_lt [UniformSpace α] [CompleteSpa
     refine ((measure_iUnion_le _).trans ?_).trans_lt hδ2
     refine ENNReal.tsum_le_tsum (fun n ↦ ?_)
     have h'' n : Prod.swap ⁻¹' t n = t n := by ext; exact (t n).comm
-    simp only [h'', compl_iUnion, ge_iff_le]
+    simp only [h'', compl_iUnion]
     exact (s'bound n (δ n) (hδ1 n)).le
 
 theorem innerRegularWRT_isCompact_closure [UniformSpace α] [CompleteSpace α]

--- a/Mathlib/MeasureTheory/Measure/Tight.lean
+++ b/Mathlib/MeasureTheory/Measure/Tight.lean
@@ -51,7 +51,7 @@ def IsTightMeasureSet (S : Set (Measure 𝓧)) : Prop :=
 for all `μ ∈ S`, `μ Kᶜ ≤ ε`. -/
 lemma isTightMeasureSet_iff_exists_isCompact_measure_compl_le :
     IsTightMeasureSet S ↔ ∀ ε, 0 < ε → ∃ K : Set 𝓧, IsCompact K ∧ ∀ μ ∈ S, μ (Kᶜ) ≤ ε := by
-  simp only [IsTightMeasureSet, ENNReal.tendsto_nhds ENNReal.zero_ne_top, gt_iff_lt, zero_add,
+  simp only [IsTightMeasureSet, ENNReal.tendsto_nhds ENNReal.zero_ne_top, zero_add,
     iSup_apply, mem_Icc, tsub_le_iff_right, zero_le, iSup_le_iff, true_and, eventually_smallSets,
     mem_cocompact]
   refine ⟨fun h ε hε ↦ ?_, fun h ε hε ↦ ?_⟩

--- a/Mathlib/NumberTheory/Divisors.lean
+++ b/Mathlib/NumberTheory/Divisors.lean
@@ -156,7 +156,7 @@ lemma pairwise_divisorsAntidiagonalList_snd {n : ℕ} :
   obtain rfl | hn := eq_or_ne n 0
   · simp
   refine (List.sortedLT_range' _ _ Nat.one_ne_zero).pairwise.filterMap _ ?_
-  simp only [Option.ite_none_right_eq_some, Option.some.injEq,
+  simp only [Option.ite_none_right_eq_some, Option.some.injEq, gt_iff_lt,
     and_imp, Prod.forall, Prod.mk.injEq]
   rintro a b hab _ _ ha rfl rfl _ _ hb rfl rfl
   rwa [Nat.div_lt_div_left hn ⟨_, hb.symm⟩ ⟨_, ha.symm⟩]

--- a/Mathlib/NumberTheory/Divisors.lean
+++ b/Mathlib/NumberTheory/Divisors.lean
@@ -156,7 +156,7 @@ lemma pairwise_divisorsAntidiagonalList_snd {n : ℕ} :
   obtain rfl | hn := eq_or_ne n 0
   · simp
   refine (List.sortedLT_range' _ _ Nat.one_ne_zero).pairwise.filterMap _ ?_
-  simp only [Option.ite_none_right_eq_some, Option.some.injEq, gt_iff_lt,
+  simp only [Option.ite_none_right_eq_some, Option.some.injEq,
     and_imp, Prod.forall, Prod.mk.injEq]
   rintro a b hab _ _ ha rfl rfl _ _ hb rfl rfl
   rwa [Nat.div_lt_div_left hn ⟨_, hb.symm⟩ ⟨_, ha.symm⟩]

--- a/Mathlib/NumberTheory/LSeries/Nonvanishing.lean
+++ b/Mathlib/NumberTheory/LSeries/Nonvanishing.lean
@@ -298,7 +298,7 @@ lemma norm_LSeries_product_ge_one {x : ℝ} (hx : 0 < x) (y : ℝ) :
     re_ofNat, im_ofNat, zero_mul, sub_zero, Real.one_le_exp_iff]
   rw [re_tsum H₀, re_tsum H₁, re_tsum H₂, ← tsum_mul_left, ← tsum_mul_left,
     ← hsum₀.tsum_add hsum₁, ← (hsum₀.add hsum₁).tsum_add hsum₂]
-  simpa only [neg_add_rev, neg_re, mul_neg, χ.pow_apply' two_ne_zero, ge_iff_le, add_re, one_re,
+  simpa only [neg_add_rev, neg_re, mul_neg, χ.pow_apply' two_ne_zero, add_re, one_re,
     ofReal_re, ofReal_add, ofReal_one] using
       tsum_nonneg fun (p : Nat.Primes) ↦ χ.re_log_comb_nonneg p.prop.two_le h₀ y
 

--- a/Mathlib/NumberTheory/ModularForms/EisensteinSeries/QExpansion.lean
+++ b/Mathlib/NumberTheory/ModularForms/EisensteinSeries/QExpansion.lean
@@ -93,7 +93,7 @@ theorem summableLocallyUniformlyOn_iteratedDerivWithin_smul_cexp (k l : ℕ) {f 
   simp only [norm_mkOfCompact, mkOfCompact_apply, ContinuousMap.coe_mk, ← exp_nsmul', Pi.smul_apply,
     iteratedDerivWithin_cexp_aux k n p isOpen_upperHalfPlaneSet (hK hz), smul_eq_mul,
     norm_mul, norm_pow, Complex.norm_div, norm_ofNat, norm_real, Real.norm_eq_abs, norm_I, mul_one,
-    norm_natCast, abs_norm, ge_iff_le, r, c] at *
+    norm_natCast, abs_norm, r, c] at *
   rw [← mul_assoc]
   gcongr
   convert h0
@@ -106,7 +106,7 @@ theorem summableLocallyUniformlyOn_iteratedDerivWithin_cexp (k : ℕ) :
       (fun n ↦ iteratedDerivWithin k (fun z ↦ cexp (2 * π * I * z) ^ n) ℍₒ) ℍₒ := by
   have h0 : (fun n : ℕ ↦ (1 : ℂ)) =O[atTop] fun n ↦ ((n ^ 1) : ℝ) := by
     simp only [Asymptotics.isBigO_iff, norm_one, norm_pow, Real.norm_natCast,
-      eventually_atTop, ge_iff_le]
+      eventually_atTop]
     exact ⟨1, 1, fun b hb ↦ by norm_cast; simp [hb]⟩
   simpa using summableLocallyUniformlyOn_iteratedDerivWithin_smul_cexp k 1 (p := 1)
     (by norm_num) h0

--- a/Mathlib/NumberTheory/PellMatiyasevic.lean
+++ b/Mathlib/NumberTheory/PellMatiyasevic.lean
@@ -351,7 +351,7 @@ theorem strictMono_y : StrictMono (yn a1)
     have : yn a1 m ≤ yn a1 n :=
       Or.elim (lt_or_eq_of_le <| Nat.le_of_succ_le_succ h) (fun hl => le_of_lt <| strictMono_y hl)
         fun e => by rw [e]
-    simp only [yn_succ, gt_iff_lt]; refine lt_of_le_of_lt ?_ (Nat.lt_add_of_pos_left <| x_pos a1 n)
+    simp only [yn_succ]; refine lt_of_le_of_lt ?_ (Nat.lt_add_of_pos_left <| x_pos a1 n)
     rw [← mul_one (yn a1 m)]
     exact mul_le_mul this (le_of_lt a1) (Nat.zero_le _) (Nat.zero_le _)
 
@@ -361,7 +361,7 @@ theorem strictMono_x : StrictMono (xn a1)
     have : xn a1 m ≤ xn a1 n :=
       Or.elim (lt_or_eq_of_le <| Nat.le_of_succ_le_succ h) (fun hl => le_of_lt <| strictMono_x hl)
         fun e => by rw [e]
-    simp only [xn_succ, gt_iff_lt]
+    simp only [xn_succ]
     refine lt_of_lt_of_le (lt_of_le_of_lt this ?_) (Nat.le_add_right _ _)
     have t := Nat.mul_lt_mul_of_pos_left a1 (x_pos a1 n)
     rwa [mul_one] at t

--- a/Mathlib/Order/CompleteLattice/Basic.lean
+++ b/Mathlib/Order/CompleteLattice/Basic.lean
@@ -1012,7 +1012,7 @@ theorem biInf_le_eq_inf : (⨅ j ≤ i, f j) = (⨅ j < i, f j) ⊓ f i :=
 theorem biSup_ge_eq_sup : (⨆ j ≥ i, f j) = f i ⊔ (⨆ j > i, f j) := by
   rw [iSup_split_single _ i]
   -- Squeezed for a ~10x speedup, though it's still reasonably fast unsqueezed.
-  simp only [ge_iff_le, le_refl, iSup_pos, ne_comm, iSup_and', gt_iff_lt, lt_iff_le_and_ne,
+  simp only [le_refl, iSup_pos, ne_comm, iSup_and', lt_iff_le_and_ne,
     and_comm]
 
 theorem biInf_ge_eq_inf : (⨅ j ≥ i, f j) = f i ⊓ (⨅ j > i, f j) :=

--- a/Mathlib/Order/KrullDimension.lean
+++ b/Mathlib/Order/KrullDimension.lean
@@ -843,7 +843,7 @@ lemma height_eq_krullDim_Iic (x : α) : (height x : ℕ∞) = krullDim (Set.Iic 
   · apply iSup_le; intro p; apply iSup_le; intro hp
     let q := LTSeries.mk p.length (fun i ↦ (⟨p.toFun i, le_trans (p.monotone (Fin.le_last _)) hp⟩
      : Set.Iic x)) (fun _ _ h ↦ p.strictMono h)
-    simp only [le_top, iSup_pos, ge_iff_le]
+    simp only [le_top, iSup_pos]
     exact le_iSup (fun p ↦ (p.length : ℕ∞)) q
   · apply iSup_le; intro p; apply iSup_le; intro _
     have mono : StrictMono (fun (y : Set.Iic x) ↦ y.1) := fun _ _ h ↦ h

--- a/Mathlib/Probability/Distributions/Fernique.lean
+++ b/Mathlib/Probability/Distributions/Fernique.lean
@@ -413,7 +413,7 @@ lemma lintegral_exp_mul_sq_norm_le_mul [IsProbabilityMeasure μ]
   -- We dispense with an edge case. If `μ {x | ‖x‖ ≤ a} = 1`, then the integral over
   -- the complement of the ball is zero and we are done.
   by_cases ha : μ {x | ‖x‖ ≤ a} = 1
-  · simp only [ha, one_mul, ENNReal.toReal_div, neg_mul, ge_iff_le, c] at ht_int_zero ⊢
+  · simp only [ha, one_mul, ENNReal.toReal_div, neg_mul, c] at ht_int_zero ⊢
     refine le_add_right ((le_of_eq ?_).trans ht_int_zero)
     rw [← setLIntegral_univ]
     refine setLIntegral_congr ?_

--- a/Mathlib/Probability/Martingale/BorelCantelli.lean
+++ b/Mathlib/Probability/Martingale/BorelCantelli.lean
@@ -88,7 +88,7 @@ theorem stoppedAbove_le (hr : 0 ≤ r) (hf0 : f 0 = 0)
     have h_top : min (i : ℕ∞) (leastGE f r ω) ≠ ⊤ :=
       ne_top_of_le_ne_top (by simp) (min_le_left _ _)
     lift min (i : ℕ∞) (leastGE f r ω) to ℕ using h_top with p
-    simp only [untopD_coe_enat, Nat.cast_lt, gt_iff_lt] at *
+    simp only [untopD_coe_enat, Nat.cast_lt] at *
     lia
 
 @[deprecated (since := "2025-10-25")] alias norm_stoppedValue_leastGE_le := stoppedAbove_le

--- a/Mathlib/Probability/Martingale/OptionalStopping.lean
+++ b/Mathlib/Probability/Martingale/OptionalStopping.lean
@@ -105,7 +105,7 @@ protected theorem Submartingale.stoppedProcess [IsFiniteMeasure μ] (h : Submart
     obtain ⟨n, hπ_le_n⟩ := hπ_bdd
     have hπ_top ω : π ω ≠ ⊤ := ne_top_of_le_ne_top (by simp) (hπ_le_n ω)
     have hσ_top ω : σ ω ≠ ⊤ := ne_top_of_le_ne_top (hπ_top ω) (hσ_le_π ω)
-    simp only [ne_eq, hσ_top, not_false_eq_true, ↓reduceIte, hπ_top, ge_iff_le]
+    simp only [ne_eq, hσ_top, not_false_eq_true, ↓reduceIte, hπ_top]
     exact h.expected_stoppedValue_mono (hσ.min hτ) (hπ.min hτ)
       (fun ω => min_le_min (hσ_le_π ω) le_rfl) fun ω => (min_le_left _ _).trans (hπ_le_n ω)
   · exact Adapted.stoppedProcess_of_discrete h.adapted hτ
@@ -206,7 +206,7 @@ theorem maximal_ineq [IsFiniteMeasure μ] (hsub : Submartingale f 𝒢 μ) (hnon
         intro m hm hεm
         exact False.elim
           ((not_le.2 hω) ((le_sup'_iff _).2 ⟨m, mem_range.2 (Nat.lt_succ_of_le hm.2), hεm⟩))
-      simp only [stoppedValue, this, ge_iff_le]
+      simp only [stoppedValue, this]
       refine le_of_eq ?_
       congr
     _ = ENNReal.ofReal

--- a/Mathlib/Probability/Process/HittingTime.lean
+++ b/Mathlib/Probability/Process/HittingTime.lean
@@ -480,7 +480,7 @@ theorem isStoppingTime_hittingBtwn_isStoppingTime [ConditionallyCompleteLinearOr
     (⋃ i ≤ n, {x | τ x = i} ∩ {x | hittingBtwn u s i N x ≤ n}) ∪
       ⋃ i > n, {x | τ x = i} ∩ {x | hittingBtwn u s i N x ≤ n} := by
     ext x
-    simp only [Set.mem_setOf_eq, gt_iff_lt, Set.mem_union, Set.mem_iUnion, Set.mem_inter_iff,
+    simp only [Set.mem_setOf_eq, Set.mem_union, Set.mem_iUnion, Set.mem_inter_iff,
       exists_and_left, exists_prop]
     specialize hτbdd x
     have h_top : τ x ≠ ⊤ := fun h => by simp [h] at hτbdd
@@ -488,7 +488,7 @@ theorem isStoppingTime_hittingBtwn_isStoppingTime [ConditionallyCompleteLinearOr
     simp [← or_and_right, le_or_gt]
   have h₂ : ⋃ i > n, {x | τ x = i} ∩ {x | hittingBtwn u s i N x ≤ n} = ∅ := by
     ext x
-    simp only [gt_iff_lt, Set.mem_iUnion, Set.mem_inter_iff, Set.mem_setOf_eq, exists_prop,
+    simp only [Set.mem_iUnion, Set.mem_inter_iff, Set.mem_setOf_eq, exists_prop,
       Set.mem_empty_iff_false, iff_false, not_exists, not_and, not_le]
     refine fun m hm hτ ↦ hm.trans_le <| le_hittingBtwn ?_ x
     specialize hτbdd x

--- a/Mathlib/Probability/Process/Stopping.lean
+++ b/Mathlib/Probability/Process/Stopping.lean
@@ -1186,7 +1186,7 @@ theorem stoppedValue_eq {N : ℕ} (hbdd : ∀ ω, τ ω ≤ N) : stoppedValue u 
   lift τ ω to ℕ using h_top with t ht
   simp only [Nat.cast_le] at hbdd
   simp only [ENat.some_eq_coe, Finset.coe_range, Set.mem_image, Set.mem_Iio, Nat.cast_inj,
-    exists_eq_right, gt_iff_lt]
+    exists_eq_right]
   grind
 
 theorem stoppedProcess_eq (n : ℕ) : stoppedProcess u τ n = Set.indicator {a | n ≤ τ a} (u n) +

--- a/Mathlib/RingTheory/Ideal/Prod.lean
+++ b/Mathlib/RingTheory/Ideal/Prod.lean
@@ -99,7 +99,7 @@ def idealProdEquiv : Ideal (R × S) ≃o Ideal R × Ideal S where
   left_inv I := (ideal_prod_eq I).symm
   right_inv := fun ⟨I, J⟩ => by simp
   map_rel_iff' {I J} := by
-    simp only [Equiv.coe_fn_mk, ge_iff_le, Prod.mk_le_mk]
+    simp only [Equiv.coe_fn_mk, Prod.mk_le_mk]
     refine ⟨fun h ↦ ?_, fun h ↦ ⟨map_mono h, map_mono h⟩⟩
     rw [ideal_prod_eq I, ideal_prod_eq J]
     exact inf_le_inf (comap_mono h.1) (comap_mono h.2)

--- a/Mathlib/RingTheory/KrullDimension/Module.lean
+++ b/Mathlib/RingTheory/KrullDimension/Module.lean
@@ -97,7 +97,7 @@ lemma support_of_supportDim_eq_zero [IsLocalRing R]
     have : p < ⟨maximalIdeal R, IsMaximal.isPrime' (maximalIdeal R)⟩ :=
       lt_of_le_of_ne (IsLocalRing.le_maximalIdeal IsPrime.ne_top') nmem
     have : Module.supportDim R N > 0 := by
-      simp only [Module.supportDim, gt_iff_lt, Order.krullDim_pos_iff, Subtype.exists,
+      simp only [Module.supportDim, Order.krullDim_pos_iff, Subtype.exists,
         Subtype.mk_lt_mk, exists_prop]
       use p
       simpa [hp] using ⟨_, IsLocalRing.closedPoint_mem_support R N, this⟩

--- a/Mathlib/RingTheory/LaurentSeries.lean
+++ b/Mathlib/RingTheory/LaurentSeries.lean
@@ -863,7 +863,7 @@ theorem coe_range_dense : DenseRange ((↑) : RatFunc K → K⸨X⸩) := by
   use P
   apply hT₁
   apply hγ
-  simpa only [add_comm, ← sub_eq_add_neg, gt_iff_lt, Set.mem_setOf_eq]
+  simpa only [add_comm, ← sub_eq_add_neg, Set.mem_setOf_eq]
 
 end Dense
 

--- a/Mathlib/RingTheory/MvPowerSeries/PiTopology.lean
+++ b/Mathlib/RingTheory/MvPowerSeries/PiTopology.lean
@@ -300,7 +300,7 @@ theorem summable_pow_of_constantCoeff_eq_zero {f : MvPowerSeries σ R}
   apply summable_of_tendsto_order_atTop_nhds_top
   simp_rw [ENat.tendsto_nhds_top_iff_natCast_lt, Filter.eventually_atTop]
   refine fun n ↦ ⟨n + 1, fun m hm ↦ lt_of_lt_of_le ?_ (le_order_pow _)⟩
-  refine (ENat.coe_lt_coe.mpr (Nat.add_one_le_iff.mp hm.le)).trans_le ?_
+  refine (ENat.coe_lt_coe.mpr (Nat.add_one_le_iff.mp hm)).trans_le ?_
   simpa [nsmul_eq_mul] using ENat.self_le_mul_right m (order_ne_zero_iff_constCoeff_eq_zero.mpr h)
 
 section GeomSeries

--- a/Mathlib/RingTheory/Polynomial/UniversalFactorizationRing.lean
+++ b/Mathlib/RingTheory/Polynomial/UniversalFactorizationRing.lean
@@ -409,7 +409,7 @@ def UniversalFactorizationRing.fromTensor :
 @[simps] def UniversalFactorizationRing.monicDegreeEq :
     MonicDegreeEq 𝓡 n :=
   ⟨p.1.map (algebraMap _ _), by simp +contextual only [Polynomial.coeff_map, p.2,
-    map_one, map_zero, gt_iff_lt, implies_true, and_self]⟩
+    map_one, map_zero, implies_true, and_self]⟩
 
 lemma UniversalFactorizationRing.fromTensor_comp_universalFactorizationMap :
   (fromTensor m k hn p).comp (MvPolynomial.universalFactorizationMap R n m k hn) =

--- a/Mathlib/SetTheory/Ordinal/Notation.lean
+++ b/Mathlib/SetTheory/Ordinal/Notation.lean
@@ -281,7 +281,7 @@ theorem cmp_compares : ∀ (a b : ONote) [NF a] [NF b], (cmp a b).Compares a b
   | o₁@(oadd e₁ n₁ a₁), o₂@(oadd e₂ n₂ a₂), h₁, h₂ => by -- TODO: golf
     rw [cmp]
     have IHe := @cmp_compares _ _ h₁.fst h₂.fst
-    simp only [Ordering.Compares, gt_iff_lt] at IHe; revert IHe
+    simp only [Ordering.Compares] at IHe; revert IHe
     cases cmp e₁ e₂
     case lt => intro IHe; exact oadd_lt_oadd_1 h₁ IHe
     case gt => intro IHe; exact oadd_lt_oadd_1 h₂ IHe
@@ -431,11 +431,11 @@ theorem repr_add : ∀ (o₁ o₂) [NF o₁] [NF o₂], repr (o₁ + o₂) = rep
       simp only [add, addAux, h'.symm, h, add_assoc, repr] at nf h₁ ⊢
     have := h₁.fst; haveI := nf.fst; have ee := cmp_compares e e'
     cases he : cmp e e' <;> simp only [he, Ordering.compares_gt, Ordering.compares_lt,
-        Ordering.compares_eq, repr, gt_iff_lt, PNat.add_coe, Nat.cast_add] at ee ⊢
+        Ordering.compares_eq, repr, PNat.add_coe, Nat.cast_add] at ee ⊢
     · rw [← add_assoc, @add_absorp _ (repr e') (ω ^ repr e' * (n' : ℕ))]
       · have := (h₁.below_of_lt ee).repr_lt
         unfold repr at this
-        cases he' : e' <;> simp only [he', zero_def, opow_zero, repr, gt_iff_lt] at this ⊢ <;>
+        cases he' : e' <;> simp only [he', zero_def, opow_zero, repr] at this ⊢ <;>
         exact lt_of_le_of_lt le_self_add this
       · simpa using (mul_le_mul_iff_right₀ <| opow_pos (repr e') omega0_pos).2
           (Nat.cast_le.2 n'.pos)

--- a/Mathlib/Topology/Algebra/InfiniteSum/ConditionalInt.lean
+++ b/Mathlib/Topology/Algebra/InfiniteSum/ConditionalInt.lean
@@ -115,7 +115,7 @@ lemma symmetricIcc_eq_map_Icc_nat :
 lemma symmetricIcc_eq_symmetricIoo_int : symmetricIcc ℤ = symmetricIoo ℤ := by
   simp only [symmetricIcc, symmetricIoo, mk.injEq]
   ext s
-  simp only [← Nat.map_cast_int_atTop, Filter.map_map, Filter.mem_map, mem_atTop_sets, ge_iff_le,
+  simp only [← Nat.map_cast_int_atTop, Filter.map_map, Filter.mem_map, mem_atTop_sets,
     Set.mem_preimage, comp_apply]
   refine ⟨fun ⟨a, ha⟩ ↦ ⟨a + 1, fun b hb ↦ ?_⟩, fun ⟨a, ha⟩ ↦ ⟨a - 1, fun b hb ↦ ?_⟩⟩ <;>
   [ convert ha (b - 1) (by grind) using 1; convert ha (b + 1) (by grind) using 1 ] <;>

--- a/Mathlib/Topology/Algebra/InfiniteSum/Constructions.lean
+++ b/Mathlib/Topology/Algebra/InfiniteSum/Constructions.lean
@@ -194,7 +194,7 @@ theorem HasProd.of_sigma {γ : β → Type*} {f : (Σ b : β, γ b) → α} {g :
     HasProd f a := by
   classical
   apply le_nhds_of_cauchy_adhp h
-  simp only [← mapClusterPt_def, mapClusterPt_iff_frequently, frequently_atTop, ge_iff_le,
+  simp only [← mapClusterPt_def, mapClusterPt_iff_frequently, frequently_atTop,
     le_eq_subset]
   intro u hu s
   rcases mem_nhds_iff.1 hu with ⟨v, vu, v_open, hv⟩

--- a/Mathlib/Topology/Algebra/InfiniteSum/SummationFilter.lean
+++ b/Mathlib/Topology/Algebra/InfiniteSum/SummationFilter.lean
@@ -183,7 +183,7 @@ instance [Countable β] : IsCountablyGenerated (unconditional β).filter :=
   classical
   simp only [unconditional, comap]
   congr 1 with s
-  simp only [mem_map, mem_atTop_sets, ge_iff_le, Finset.le_eq_subset, mem_preimage]
+  simp only [mem_map, mem_atTop_sets, Finset.le_eq_subset, mem_preimage]
   constructor <;> rintro ⟨t, ht⟩
   · refine ⟨t.preimage f (by simp), fun x hx ↦ ?_⟩
     simpa [Finset.union_eq_right.mpr hx] using ht (t ∪ x.map f) t.subset_union_left

--- a/Mathlib/Topology/Algebra/Valued/NormedValued.lean
+++ b/Mathlib/Topology/Algebra/Valued/NormedValued.lean
@@ -121,7 +121,7 @@ def toNormedField : NormedField L :=
       haveI : Nonempty { ε : ℝ // ε > 0 } := nonempty_Ioi_subtype
       ext U
       rw [hasBasis_iff.mp (Valued.hasBasis_uniformity L Γ₀), iInf_subtype', mem_iInf_of_directed]
-      · simp only [true_and, mem_principal, Subtype.exists, gt_iff_lt, exists_prop]
+      · simp only [true_and, mem_principal, Subtype.exists, exists_prop]
         refine ⟨fun ⟨ε, hε⟩ => ?_, fun ⟨r, hr_pos, hr⟩ => ?_⟩
         · set δ : ℝ≥0 := hv.hom ε with hδ
           have hδ_pos : 0 < δ := by

--- a/Mathlib/Topology/CWComplex/Classical/Finite.lean
+++ b/Mathlib/Topology/CWComplex/Classical/Finite.lean
@@ -308,7 +308,7 @@ variable {X : Type*} [TopologicalSpace X] {C D : Set X} [RelCWComplex C D]
 `C` is finite as a CW complex. -/
 lemma RelCWComplex.finite_of_finite_cells (finite : _root_.Finite (Σ n, cell C n)) : Finite C where
   eventually_isEmpty_cell := by
-    simp only [Filter.eventually_atTop, ge_iff_le]
+    simp only [Filter.eventually_atTop]
     cases isEmpty_or_nonempty (Σ n, cell C n)
     · exact ⟨0, by simp_all⟩
     -- We take the greatest `n` such that there is a `j : cell C n` and show that this fulfills
@@ -334,7 +334,7 @@ lemma RelCWComplex.finite_cells_of_finite [finite : Finite C] : _root_.Finite (�
   -- `Σ (m : {m : ℕ // m < n}), cell C m`.
   have h := finite.eventually_isEmpty_cell
   have _ := finite.finite_cell
-  simp only [Filter.eventually_atTop, ge_iff_le] at h
+  simp only [Filter.eventually_atTop] at h
   rcases h with ⟨n, hn⟩
   have (m) (j : cell C m) : m < n := by
     by_contra h

--- a/Mathlib/Topology/Category/Profinite/Nobeling/Successor.lean
+++ b/Mathlib/Topology/Category/Profinite/Nobeling/Successor.lean
@@ -494,7 +494,7 @@ theorem isChain_cons_of_lt (l : MaxProducts C ho)
     List.IsChain (fun x x_1 ↦ x > x_1) (term I ho :: q.val) := by
   have : Inhabited I := ⟨term I ho⟩
   rw [List.isChain_iff_pairwise]
-  simp only [gt_iff_lt, List.pairwise_cons]
+  simp only [List.pairwise_cons]
   refine ⟨fun a ha ↦ lt_of_le_of_lt (Products.rel_head!_of_mem ha) ?_,
     List.isChain_iff_pairwise.mp q.prop⟩
   refine lt_of_le_of_lt (Products.head!_le_of_lt hq (q.val.ne_nil_of_mem ha)) ?_

--- a/Mathlib/Topology/Compactness/CompactlyGeneratedSpace.lean
+++ b/Mathlib/Topology/Compactness/CompactlyGeneratedSpace.lean
@@ -209,7 +209,7 @@ instance (priority := 100) [SequentialSpace X] : UCompactlyGeneratedSpace.{u} X 
     rw [← Nat.cofinite_eq_atTop, ← cocompact_eq_cofinite, ← coclosedCompact_eq_cocompact]
     exact tendsto_coe_infty
   apply IsClosed.mem_of_tendsto _ ((continuous_uliftUp.tendsto ∞).comp this)
-  · simp only [Function.comp_apply, mem_preimage, eventually_atTop, ge_iff_le]
+  · simp only [Function.comp_apply, mem_preimage, eventually_atTop]
     exact ⟨0, fun b _ ↦ hu b⟩
   · exact h (CompHaus.of (ULift.{u} (OnePoint ℕ))) ⟨g, by fun_prop⟩
 

--- a/Mathlib/Topology/EMetricSpace/PairReduction.lean
+++ b/Mathlib/Topology/EMetricSpace/PairReduction.lean
@@ -113,7 +113,7 @@ lemma exists_radius_le (t : T) (V : Finset T) (ha : 1 < a) (c : ℝ≥0∞) :
     ∃ r : ℕ, 1 ≤ r ∧ #(V.filter fun x ↦ edist t x ≤ r * c) ≤ a ^ r := by
   have := ENNReal.tendsto_nhds_top_iff_nat.1
     ((ENNReal.tendsto_rpow_atTop_of_one_lt_base ha).comp tendsto_natCast_atTop_atTop) #V
-  simp only [Function.comp_apply, ENNReal.rpow_natCast, Filter.eventually_atTop, ge_iff_le] at this
+  simp only [Function.comp_apply, ENNReal.rpow_natCast, Filter.eventually_atTop] at this
   obtain ⟨r, hr⟩ := this
   exact ⟨max r 1, le_max_right r 1,
     le_trans (mod_cast Finset.card_filter_le V _) (hr (max r 1) (le_max_left r 1)).le⟩

--- a/Mathlib/Topology/EMetricSpace/Pi.lean
+++ b/Mathlib/Topology/EMetricSpace/Pi.lean
@@ -66,7 +66,7 @@ instance pseudoEMetricSpacePi [∀ b, PseudoEMetricSpace (X b)] : PseudoEMetricS
     (add_le_add (edist_le_pi_edist _ _ _) (edist_le_pi_edist _ _ _))
   toUniformSpace := Pi.uniformSpace _
   uniformity_edist := by
-    simp only [Pi.uniformity, PseudoEMetricSpace.uniformity_edist, comap_iInf, gt_iff_lt,
+    simp only [Pi.uniformity, PseudoEMetricSpace.uniformity_edist, comap_iInf,
       preimage_setOf_eq, comap_principal, edist_pi_def]
     rw [iInf_comm]; congr; funext ε
     rw [iInf_comm]; congr; funext εpos

--- a/Mathlib/Topology/MetricSpace/CantorScheme.lean
+++ b/Mathlib/Topology/MetricSpace/CantorScheme.lean
@@ -124,7 +124,7 @@ theorem VanishingDiam.dist_lt (hA : VanishingDiam A) (ε : ℝ) (ε_pos : 0 < ε
   specialize hA x
   rw [ENNReal.tendsto_atTop_zero] at hA
   obtain ⟨n, hn⟩ := hA (ENNReal.ofReal (ε / 2)) (by
-    simp only [gt_iff_lt, ENNReal.ofReal_pos]; linarith)
+    simp only [ENNReal.ofReal_pos]; linarith)
   use n
   intro y hy z hz
   rw [← ENNReal.ofReal_lt_ofReal_iff ε_pos, ← edist_dist]

--- a/Mathlib/Topology/MetricSpace/PiNat.lean
+++ b/Mathlib/Topology/MetricSpace/PiNat.lean
@@ -826,7 +826,7 @@ protected def pseudoEMetricSpace : PseudoEMetricSpace (∀ i, F i) where
     _ = _ := ENNReal.tsum_add ..
   toUniformSpace := Pi.uniformSpace _
   uniformity_edist := by
-    simp only [Pi.uniformity, comap_iInf, gt_iff_lt, preimage_setOf_eq, comap_principal,
+    simp only [Pi.uniformity, comap_iInf, preimage_setOf_eq, comap_principal,
       PseudoEMetricSpace.uniformity_edist, le_antisymm_iff, le_iInf_iff, le_principal_iff]
     constructor
     · intro ε hε

--- a/Mathlib/Topology/MetricSpace/Pseudo/Basic.lean
+++ b/Mathlib/Topology/MetricSpace/Pseudo/Basic.lean
@@ -69,7 +69,7 @@ nonrec theorem isUniformInducing_iff [PseudoMetricSpace β] {f : α → β} :
       ∀ δ > 0, ∃ ε > 0, ∀ {a b : α}, dist (f a) (f b) < ε → dist a b < δ :=
   isUniformInducing_iff'.trans <| Iff.rfl.and <|
     ((uniformity_basis_dist.comap _).le_basis_iff uniformity_basis_dist).trans <| by
-      simp only [subset_def, Prod.forall, gt_iff_lt, preimage_setOf_eq, Prod.map_apply, mem_setOf]
+      simp only [subset_def, Prod.forall, preimage_setOf_eq, Prod.map_apply, mem_setOf]
 
 nonrec theorem isUniformEmbedding_iff [PseudoMetricSpace β] {f : α → β} :
     IsUniformEmbedding f ↔ Function.Injective f ∧ UniformContinuous f ∧

--- a/Mathlib/Topology/MetricSpace/Pseudo/Defs.lean
+++ b/Mathlib/Topology/MetricSpace/Pseudo/Defs.lean
@@ -811,7 +811,7 @@ theorem tendsto_nhdsWithin_nhdsWithin [PseudoMetricSpace β] {t : Set β} {f : �
     Tendsto f (𝓝[s] a) (𝓝[t] b) ↔
       ∀ ε > 0, ∃ δ > 0, ∀ ⦃x : α⦄, x ∈ s → dist x a < δ → f x ∈ t ∧ dist (f x) b < ε :=
   (nhdsWithin_basis_ball.tendsto_iff nhdsWithin_basis_ball).trans <| by
-    simp only [inter_comm _ s, inter_comm _ t, mem_inter_iff, and_imp, gt_iff_lt, mem_ball]
+    simp only [inter_comm _ s, inter_comm _ t, mem_inter_iff, and_imp, mem_ball]
 
 theorem tendsto_nhdsWithin_nhds [PseudoMetricSpace β] {f : α → β} {a b} :
     Tendsto f (𝓝[s] a) (𝓝 b) ↔
@@ -871,7 +871,7 @@ uses `∃ N, ∀ n > N, ...` rather than `∃ N, ∀ n ≥ N, ...`
 theorem tendsto_atTop' [Nonempty β] [SemilatticeSup β] [NoMaxOrder β] {u : β → α} {a : α} :
     Tendsto u atTop (𝓝 a) ↔ ∀ ε > 0, ∃ N, ∀ n > N, dist (u n) a < ε :=
   (atTop_basis_Ioi.tendsto_iff nhds_basis_ball).trans <| by
-    simp only [true_and, gt_iff_lt, mem_Ioi, mem_ball]
+    simp only [true_and, mem_Ioi, mem_ball]
 
 theorem isOpen_singleton_iff {α : Type*} [PseudoMetricSpace α] {x : α} :
     IsOpen ({x} : Set α) ↔ ∃ ε > 0, ∀ y, dist y x < ε → y = x := by

--- a/Mathlib/Topology/MetricSpace/Ultra/Basic.lean
+++ b/Mathlib/Topology/MetricSpace/Ultra/Basic.lean
@@ -121,7 +121,7 @@ lemma isClosed_ball (x : X) (r : ℝ) : IsClosed (ball x r) := by
     simp [ball_eq_empty.mpr hr]
   | inr h =>
     rw [← isOpen_compl_iff, isOpen_iff]
-    simp only [Set.mem_compl_iff, gt_iff_lt]
+    simp only [Set.mem_compl_iff]
     intro y hy
     cases ball_eq_or_disjoint x y r with
     | inl hd =>


### PR DESCRIPTION
This PR changes the elaboration of the binders `∃ x > y,` and `∀ x > y,` to use `<` instead of `>`, because we want to avoid working with `>` as much as possible (and similarly for `≥` vs `≤`).

The advantage is that we don't need to worry about rewriting with lemmas like `gt_iff_lt`. The disadvantage is that people might find this confusing.

[#mathlib4 > naming convention for ≤ and < @ 💬](https://leanprover.zulipchat.com/#narrow/channel/287929-mathlib4/topic/naming.20convention.20for.20.E2.89.A4.20and.20.3C/near/522910464)

The main changes are in `Mathlib.Init`, `Mathlib.Util.Delaborators` and `MathlibTest.delaborators`.

PR taken over from #25573.

Co-authored by: Jovan Gerbscheid

---
<!-- Your PR title will become the first line of the commit message.

In this box, the text above the `---` (if not empty) will be appended
to the commit message, and can be used to give additional context or
details. Please leave a blank newline before the `---`, otherwise GitHub
will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

When merging, all the commits will be squashed into a single commit
listing all co-authors.

Co-authors in the squash commit are gathered from two sources:

First, all authors of commits to this PR branch are included. Thus,
one way to add co-authors is to include at least one commit authored by
each co-author among the commits in the pull request. If necessary, you
may create empty commits to indicate co-authorship, using commands like so:

git commit --author="Author Name <author@email.com>" --allow-empty -m "add Author Name as coauthor"

Second, co-authors can also be listed in lines at the very bottom of
the commit message (that is, directly before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines
at the bottom of the commit message (before the `---`, and also before
any "Co-authored-by" lines) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
