### PR TITLE
[Merged by Bors] - chore: tidy various files

### DIFF
--- a/Mathlib/AlgebraicTopology/FundamentalGroupoid/SimplyConnected.lean
+++ b/Mathlib/AlgebraicTopology/FundamentalGroupoid/SimplyConnected.lean
@@ -102,7 +102,7 @@ theorem simply_connected_iff_loops_nullhomotopic {Y : Type*} [TopologicalSpace Y
     exact ⟨hpc, fun x γ => hall γ (Path.refl x)⟩
   · -- Backward: all loops null-homotopic implies all paths homotopic
     intro ⟨hpc, hloops⟩
-    refine ⟨hpc, @fun x y p₁ p₂ => ?_⟩
+    refine ⟨hpc, fun {x y} p₁ p₂ => ?_⟩
     -- Work in the quotient where structural steps can be done by simp
     rw [← eq]
     replace hloops : ∀ (x : Y) (γ : Path x x),

--- a/Mathlib/Analysis/Calculus/ContDiff/Bounds.lean
+++ b/Mathlib/Analysis/Calculus/ContDiff/Bounds.lean
@@ -575,7 +575,7 @@ theorem norm_iteratedFDerivWithin_clm_apply_const {f : E → F →L[𝕜] G} {c 
     (hx : x ∈ s) (hn : n ≤ N) :
     ‖iteratedFDerivWithin 𝕜 n (fun y : E => (f y) c) s x‖ ≤
       ‖c‖ * ‖iteratedFDerivWithin 𝕜 n f s x‖ := by
-  apply ((ContinuousLinearMap.apply 𝕜 G c).norm_iteratedFDerivWithin_comp_left  hf hs hx hn).trans
+  apply ((ContinuousLinearMap.apply 𝕜 G c).norm_iteratedFDerivWithin_comp_left hf hs hx hn).trans
   gcongr
   refine (ContinuousLinearMap.apply 𝕜 G c).opNorm_le_bound (norm_nonneg _) fun f => ?_
   rw [ContinuousLinearMap.apply_apply, mul_comm]

--- a/Mathlib/Analysis/Complex/ValueDistribution/CountingFunction.lean
+++ b/Mathlib/Analysis/Complex/ValueDistribution/CountingFunction.lean
@@ -296,7 +296,7 @@ sum of the logarithmic counting functions for the poles of `f` and `g`, respecti
 -/
 theorem logCounting_add_top_le {f₁ f₂ : 𝕜 → E} {r : ℝ} (h₁f₁ : MeromorphicOn f₁ Set.univ)
     (h₁f₂ : MeromorphicOn f₂ Set.univ) (hr : 1 ≤ r) :
-    logCounting (f₁ + f₂) ⊤ r ≤ ((logCounting f₁ ⊤) + (logCounting f₂ ⊤)) r := by
+    logCounting (f₁ + f₂) ⊤ r ≤ (logCounting f₁ ⊤ + logCounting f₂ ⊤) r := by
   simp only [logCounting, ↓reduceDIte]
   rw [← Function.locallyFinsuppWithin.logCounting.map_add]
   exact Function.locallyFinsuppWithin.logCounting_le (negPart_divisor_add_le_add h₁f₁ h₁f₂) hr
@@ -307,7 +307,7 @@ the sum of the logarithmic counting functions for the poles of `f` and `g`, resp
 -/
 theorem logCounting_add_top_eventuallyLE {f₁ f₂ : 𝕜 → E} (h₁f₁ : MeromorphicOn f₁ Set.univ)
     (h₁f₂ : MeromorphicOn f₂ Set.univ) :
-    logCounting (f₁ + f₂) ⊤ ≤ᶠ[Filter.atTop] (logCounting f₁ ⊤) + (logCounting f₂ ⊤) := by
+    logCounting (f₁ + f₂) ⊤ ≤ᶠ[Filter.atTop] logCounting f₁ ⊤ + logCounting f₂ ⊤ := by
   filter_upwards [Filter.eventually_ge_atTop 1]
   exact fun _ hr ↦ logCounting_add_top_le h₁f₁ h₁f₂ hr
 

--- a/Mathlib/Analysis/Complex/ValueDistribution/ProximityFunction.lean
+++ b/Mathlib/Analysis/Complex/ValueDistribution/ProximityFunction.lean
@@ -159,7 +159,7 @@ The proximity function `f * g` at `⊤` is less than or equal to the sum of the 
 -/
 theorem proximity_mul_top_le {f₁ f₂ : ℂ → ℂ} (h₁f₁ : MeromorphicOn f₁ Set.univ)
     (h₁f₂ : MeromorphicOn f₂ Set.univ) :
-    proximity (f₁ * f₂) ⊤ ≤ (proximity f₁ ⊤) + (proximity f₂ ⊤) := by
+    proximity (f₁ * f₂) ⊤ ≤ proximity f₁ ⊤ + proximity f₂ ⊤ := by
   calc proximity (f₁ * f₂) ⊤
     _ = circleAverage (fun x ↦ log⁺ (‖f₁ x‖ * ‖f₂ x‖)) 0 := by
       simp [proximity]
@@ -168,16 +168,17 @@ theorem proximity_mul_top_le {f₁ f₂ : ℂ → ℂ} (h₁f₁ : MeromorphicOn
       apply circleAverage_mono
       · simp_rw [← norm_mul]
         apply circleIntegrable_posLog_norm_meromorphicOn
-        exact MeromorphicOn.fun_mul (fun x a ↦ h₁f₁ x trivial) fun x a ↦ h₁f₂ x trivial
-      · apply (circleIntegrable_posLog_norm_meromorphicOn (fun x a ↦ h₁f₁ x trivial)).add
-          (circleIntegrable_posLog_norm_meromorphicOn (fun x a ↦ h₁f₂ x trivial))
+        exact MeromorphicOn.fun_mul (fun x a ↦ h₁f₁ x (Set.mem_univ _))
+          fun x a ↦ h₁f₂ x (Set.mem_univ _)
+      · apply (circleIntegrable_posLog_norm_meromorphicOn (fun x a ↦ h₁f₁ x (Set.mem_univ _))).add
+          (circleIntegrable_posLog_norm_meromorphicOn (fun x a ↦ h₁f₂ x (Set.mem_univ _)))
       · exact fun _ _ ↦ posLog_mul
     _ = circleAverage (log⁺ ‖f₁ ·‖) 0 + circleAverage (log⁺ ‖f₂ ·‖) 0:= by
       ext r
       apply circleAverage_add
-      · exact circleIntegrable_posLog_norm_meromorphicOn (fun x a ↦ h₁f₁ x trivial)
-      · exact circleIntegrable_posLog_norm_meromorphicOn (fun x a ↦ h₁f₂ x trivial)
-    _ = (proximity f₁ ⊤) + (proximity f₂ ⊤) := rfl
+      · exact circleIntegrable_posLog_norm_meromorphicOn (fun x a ↦ h₁f₁ x (Set.mem_univ _))
+      · exact circleIntegrable_posLog_norm_meromorphicOn (fun x a ↦ h₁f₂ x (Set.mem_univ _))
+    _ = proximity f₁ ⊤ + proximity f₂ ⊤ := by simp [proximity]
 
 @[deprecated (since := "2025-12-11")] alias proximity_top_mul_le := proximity_mul_top_le
 
@@ -203,10 +204,8 @@ function of `f` at `⊤`.
 -/
 @[simp] theorem proximity_pow_top {f : ℂ → ℂ} {n : ℕ} :
     proximity (f ^ n) ⊤ = n • (proximity f ⊤) := by
-  simp only [proximity, reduceDIte, Pi.pow_apply, norm_pow, posLog_pow, nsmul_eq_mul]
-  ext _
-  rw [Pi.mul_apply, Pi.natCast_apply, ← smul_eq_mul, ← circleAverage_fun_smul]
-  rfl
+  ext x
+  simp [proximity, ← smul_eq_mul, circleAverage_fun_smul]
 
 /--
 For natural numbers `n`, the proximity function of `f ^ n` at `0` equals `n` times the proximity
@@ -214,6 +213,6 @@ function of `f` at `0`.
 -/
 @[simp] theorem proximity_pow_zero {f : ℂ → ℂ} {n : ℕ} :
     proximity (f ^ n) 0 = n • (proximity f 0) := by
-  rw [← proximity_inv, ← proximity_inv, (by aesop : (f ^ n)⁻¹ = f⁻¹ ^ n), proximity_pow_top]
+  rw [← proximity_inv, ← proximity_inv, ← inv_pow, proximity_pow_top]
 
 end ValueDistribution

--- a/Mathlib/Analysis/Convex/Quasiconvex.lean
+++ b/Mathlib/Analysis/Convex/Quasiconvex.lean
@@ -90,11 +90,8 @@ end LE_β
 
 section Composition
 
-variable {𝕜 E β : Type*} [Semiring 𝕜] [PartialOrder 𝕜]
-  [AddCommMonoid E] [SMul 𝕜 E]
-
+variable {𝕜 E : Type*} [Semiring 𝕜] [PartialOrder 𝕜] [AddCommMonoid E] [SMul 𝕜 E]
 variable {β γ : Type*} [LinearOrder β] [Preorder γ]
-
 variable {s : Set E} {f : E → β} {g : β → γ}
 
 theorem QuasiconvexOn.monotone_comp

--- a/Mathlib/Analysis/Distribution/DerivNotation.lean
+++ b/Mathlib/Analysis/Distribution/DerivNotation.lean
@@ -98,7 +98,7 @@ The line derivative is additive, `∂_{v} (x + y) = ∂_{v} x + ∂_{v} y` for a
 Note that `lineDeriv` on functions is not additive.
 -/
 class LineDerivAdd (V : Type u) (E : Type v) (F : outParam (Type w))
-  [AddCommGroup E] [AddCommGroup F] [LineDeriv V E F] where
+    [AddCommGroup E] [AddCommGroup F] [LineDeriv V E F] where
   lineDerivOp_add (v : V) (x y : E) : ∂_{v} (x + y) = ∂_{v} x + ∂_{v} y
 
 /--
@@ -106,14 +106,14 @@ The line derivative commutes with scalar multiplication, `∂_{v} (r • x) = r 
 `r : R` and `x : E`.
 -/
 class LineDerivSMul (R : Type*) (V : Type u) (E : Type v) (F : outParam (Type w))
-  [SMul R E] [SMul R F] [LineDeriv V E F] where
+    [SMul R E] [SMul R F] [LineDeriv V E F] where
   lineDerivOp_smul (v : V) (r : R) (x : E) : ∂_{v} (r • x) = r • ∂_{v} x
 
 /--
 The line derivative is continuous.
 -/
 class ContinuousLineDeriv (V : Type u) (E : Type v) (F : outParam (Type w))
-  [TopologicalSpace E] [TopologicalSpace F] [LineDeriv V E F] where
+    [TopologicalSpace E] [TopologicalSpace F] [LineDeriv V E F] where
   continuous_lineDerivOp (v : V) : Continuous (∂_{v} : E → F)
 
 attribute [fun_prop] ContinuousLineDeriv.continuous_lineDerivOp

--- a/Mathlib/Analysis/Distribution/Distribution.lean
+++ b/Mathlib/Analysis/Distribution/Distribution.lean
@@ -92,7 +92,7 @@ distribution is nothing more than a distribution taking values in the real vecto
 
 ### Order of distributions
 
-Based on established practice in the litterature, a natural way to express the order of a
+Based on established practice in the literature, a natural way to express the order of a
 distribution would be to introduce a predicate `Distribution.HasOrderAtMost` on the space of all
 distributions. Here though, we define a separate space `𝓓'^{n}(Ω, F)` whose elements are precisely
 distributions of order at most `n`.

--- a/Mathlib/Analysis/Normed/Lp/SmoothApprox.lean
+++ b/Mathlib/Analysis/Normed/Lp/SmoothApprox.lean
@@ -32,7 +32,7 @@ variable [NormedAddCommGroup E] [NormedSpace ℝ E] [FiniteDimensional ℝ E] [B
   [NormedSpace ℝ F]
   (μ : Measure E := by volume_tac) [IsFiniteMeasureOnCompacts μ]
 
-/-- For every continuous compactly supported function `f`there exists a smooth compactly supported
+/-- For every continuous compactly supported function `f` there exists a smooth compactly supported
 function `g` such that `f - g` is arbitrary small in the `Lp`-norm for `p < ∞`. -/
 theorem exist_eLpNorm_sub_le_of_continuous {p : ℝ≥0∞} (hp : p ≠ ⊤) {ε : ℝ} (hε : 0 < ε) {f : E → F}
     (h₁ : HasCompactSupport f) (h₂ : Continuous f) :

--- a/Mathlib/Analysis/SpecialFunctions/Arcosh.lean
+++ b/Mathlib/Analysis/SpecialFunctions/Arcosh.lean
@@ -76,7 +76,7 @@ theorem tanh_arcosh {x : ℝ} (hx : 1 ≤ x) : tanh (arcosh x) = √(x ^ 2 - 1) 
 
 /-- `arcosh` is the left inverse of `cosh` over [0, ∞). -/
 theorem arcosh_cosh {x : ℝ} (hx : 0 ≤ x) : arcosh (cosh x) = x := by
-rw [arcosh, ← exp_eq_exp, exp_log (by positivity), ← eq_sub_iff_add_eq', exp_sub_cosh,
+  rw [arcosh, ← exp_eq_exp, exp_log (by positivity), ← eq_sub_iff_add_eq', exp_sub_cosh,
     ← sq_eq_sq₀ (sqrt_nonneg _) (sinh_nonneg_iff.mpr hx), ← sinh_sq, sq_sqrt (pow_two_nonneg _)]
 
 theorem arcosh_nonneg {x : ℝ} (hx : 1 ≤ x) : 0 ≤ arcosh x := by

--- a/Mathlib/Analysis/SpecialFunctions/Elliptic/Weierstrass.lean
+++ b/Mathlib/Analysis/SpecialFunctions/Elliptic/Weierstrass.lean
@@ -167,14 +167,10 @@ lemma hasSumLocallyUniformly_aux (f : L.lattice → ℂ → ℂ)
   exact hR _ hs'.le _ hs _ rfl
 
 -- Only the asymptotics matter and `10` is just a convenient constant to pick.
-lemma weierstrassP_bound (r : ℝ) (hr : r > 0) (s : ℂ) (hs : ‖s‖ < r) (l : ℂ) (h : 2 * r ≤ ‖l‖) :
+lemma weierstrassP_bound (r : ℝ) (hr : 0 < r) (s : ℂ) (hs : ‖s‖ < r) (l : ℂ) (h : 2 * r ≤ ‖l‖) :
     ‖1 / (s - l) ^ 2 - 1 / l ^ 2‖ ≤ 10 * r * ‖l‖ ^ (-3 : ℝ) := by
-  have : s ≠ ↑l := by rintro rfl; exfalso; linarith
-  have : 0 < ‖l‖ := by
-    suffices l ≠ 0 by simpa
-    rintro rfl
-    simp only [norm_zero] at h
-    linarith
+  have : s ≠ ↑l := by rintro rfl; linarith
+  have : 0 < ‖l‖ := by linarith
   calc
     _ = ‖(↑l ^ 2 - (s - ↑l) ^ 2) / ((s - ↑l) ^ 2 * ↑l ^ 2)‖ := by
       rw [div_sub_div, one_mul, mul_one]

--- a/Mathlib/Analysis/SpecialFunctions/Pow/Deriv.lean
+++ b/Mathlib/Analysis/SpecialFunctions/Pow/Deriv.lean
@@ -455,9 +455,8 @@ theorem contDiff_rpow_const_of_le {p : ℝ} {n : ℕ} (h : ↑n ≤ p) :
   | zero => exact contDiff_zero.2 (continuous_id.rpow_const fun x => Or.inr <| by simpa using h)
   | succ n ihn =>
     have h1 : 1 ≤ p := le_trans (by simp) h
-    rw [Nat.cast_succ, ← le_sub_iff_add_le] at h
-    rw [show ((n + 1 : ℕ) : WithTop ℕ∞) = n + 1 from rfl,
-      contDiff_succ_iff_deriv, deriv_rpow_const' p]
+    rw [Nat.cast_add_one, ← le_sub_iff_add_le] at h
+    rw [Nat.cast_add_one, contDiff_succ_iff_deriv, deriv_rpow_const' p]
     simp only [WithTop.natCast_ne_top, analyticOn_univ, IsEmpty.forall_iff, true_and]
     exact ⟨differentiable_rpow_const h1, contDiff_const.mul (ihn h)⟩
 

--- a/Mathlib/CategoryTheory/Localization/SmallShiftedHom.lean
+++ b/Mathlib/CategoryTheory/Localization/SmallShiftedHom.lean
@@ -352,7 +352,7 @@ noncomputable def precompEquiv {X Y Z : C}
   toFun α := (mk₀ _ _ rfl f).comp α (add_zero _)
   invFun β := (mk₀Inv _ rfl _ hf).comp β (add_zero _)
   left_inv α := by simp [← comp_assoc]
-  right_inv β  := by simp [← comp_assoc]
+  right_inv β := by simp [← comp_assoc]
 
 section ChangeOfUniverse
 

--- a/Mathlib/CategoryTheory/Shift/CommShiftTwo.lean
+++ b/Mathlib/CategoryTheory/Shift/CommShiftTwo.lean
@@ -22,7 +22,7 @@ differ by the sign `(-1) ^ (p + q)`.
 This is implemented using a structure `Functor.CommShift₂` which does not depend
 on the preadditive structure on `D`: instead of signs, elements in `(CatCenter D)ˣ`
 are used. These elements are part of a `CommShift₂Setup` structure which extends
-a `TwistShiftData` structure (see the file `CategoryTheory.Shift.Twist`).
+a `TwistShiftData` structure (see the file `Mathlib.CategoryTheory.Shift.Twist`).
 
 ## TODO (@joelriou)
 * Show that `G : C₁ ⥤ C₂ ⥤ D` satisfies `Functor.CommShift₂Int` iff the uncurried

--- a/Mathlib/CategoryTheory/Yoneda.lean
+++ b/Mathlib/CategoryTheory/Yoneda.lean
@@ -18,7 +18,7 @@ the Yoneda embedding as a fully faithful functor `yoneda : C ⥤ Cᵒᵖ ⥤ Typ
 In addition to `yoneda`, we also define `uliftYoneda : C ⥤ Cᵒᵖ ⥤ Type (max w v₁)`
 with the additional universe parameter `w`. When `C` is locally `w`-small,
 one may also use `shrinkYoneda.{w} : C ⥤ Cᵒᵖ ⥤ Type w` from the file
-`CategoryTheory.ShrinkYoneda`.
+`Mathlib/CategoryTheory/ShrinkYoneda.lean`.
 
 The naturality of the bijection `yonedaEquiv` involved in the
 Yoneda lemma is also expressed as a natural isomorphism

--- a/Mathlib/Data/Finsupp/Option.lean
+++ b/Mathlib/Data/Finsupp/Option.lean
@@ -18,7 +18,7 @@ to construct `Option α →₀ M` from a map α →₀ M, and vice versa.
 
 As functions, these behave as `Option.elim'`, and as an application of `some` hence the names.
 
-We prove a variety of API lemmas, see `Data/Finsupp/Fin.lean` for comparison.
+We prove a variety of API lemmas, see `Mathlib/Data/Finsupp/Fin.lean` for comparison.
 
 ## Main declarations
 

--- a/Mathlib/Data/Int/Fib/Basic.lean
+++ b/Mathlib/Data/Int/Fib/Basic.lean
@@ -64,9 +64,9 @@ theorem coe_fib_neg (n : ℤ) : (fib (-n) : ℚ) = (-1) ^ (n + 1) * fib n := by
 theorem fib_add_two (n : ℤ) : fib (n + 2) = fib n + fib (n + 1) := by
   rcases n with (n | n)
   · dsimp
-    rw [show (n : ℤ) + 2 = (n + 2 : ℕ) by rfl, fib_natCast, Nat.fib_add_two]
-    rfl
-  · rw [show negSucc n = -((n + 1 : ℕ) : ℤ) by rfl, fib_neg_natCast]
+    rw [← Nat.cast_ofNat, ← Nat.cast_add, ← Nat.cast_add_one, fib_natCast, fib_natCast,
+      Nat.fib_add_two, Nat.cast_add]
+  · rw [negSucc_eq, ← Nat.cast_add_one, fib_neg_natCast]
     simp only [Nat.cast_add, Nat.cast_one, neg_add_rev, reduceNeg, add_comm,
       add_assoc, reduceAdd, add_neg_cancel_comm_assoc, fib_neg_natCast]
     if hn0 : n = 0 then simp [hn0] else

--- a/Mathlib/Data/List/PeriodicityLemma.lean
+++ b/Mathlib/Data/List/PeriodicityLemma.lean
@@ -124,13 +124,10 @@ lemma HasPeriod.factor {u v w : List α} {p : ℕ} (per : HasPeriod (u ++ v ++ w
   rw [← shift_position', ← shift_position]
   exact this (j + u.length) (by lia)
 
-example (l₁ l₂ : List α) (h : l₁ <:+: l₂) : ∃ s t, s ++ l₁ ++ t = l₂ := by
-  exact h
-
 lemma HasPeriod.infix {u w : List α} {p : ℕ} (per : HasPeriod w p) (h : u <:+: w) :
     HasPeriod u p := by
-  obtain ⟨s, t, eq⟩ := h
-  exact (eq.symm ▸ per).factor
+  obtain ⟨s, t, rfl⟩ := h
+  exact per.factor
 
 lemma HasPeriod.drop_prefix {w : List α} (p : ℕ) (per : HasPeriod w p) :
     drop p w <+: w := by
@@ -145,7 +142,7 @@ lemma HasPeriod.take_append (p n : ℕ) (w : List α) (dvd : p ∣ n)
   · simp_all [HasPeriod]
   rcases Nat.eq_zero_or_pos n with rfl | pos
   · simp_all
-  rw [hasPeriod_iff_forall_getElem?_mod];
+  rw [hasPeriod_iff_forall_getElem?_mod]
   have mod_w : ∀ i < w.length, w[i % p]? = w[i]? := (per.getElem?_mod)
   suffices ∀ i < n + w.length, (take n w ++ w)[i]? = (take n w ++ w)[i % p]? by simp_all
   intro i less_i

--- a/Mathlib/Data/List/Sort.lean
+++ b/Mathlib/Data/List/Sort.lean
@@ -50,8 +50,8 @@ def orderedInsert (a : α) : List α → List α
 @[simp, grind =] theorem orderedInsert_nil (a : α) : [].orderedInsert r a = [a] := .refl _
 
 @[simp, grind =] theorem orderedInsert_cons (a b : α) (l : List α) :
-    (b :: l).orderedInsert r a = if r a b then a :: b :: l else
-    b :: l.orderedInsert r a := .refl _
+    (b :: l).orderedInsert r a = if r a b then a :: b :: l else b :: l.orderedInsert r a :=
+  .refl _
 
 theorem orderedInsert_cons_of_le {a b : α} (l : List α) (h : a ≼ b) :
     orderedInsert r a (b :: l) = a :: b :: l :=
@@ -82,8 +82,8 @@ theorem orderedInsert_length (L : List α) (a : α) :
 
 /-- An alternative definition of `orderedInsert` using `takeWhile` and `dropWhile`. -/
 theorem orderedInsert_eq_take_drop (a : α) (l : List α) :
-      l.orderedInsert r a = (l.takeWhile fun b => ¬a ≼ b) ++ a :: l.dropWhile fun b => ¬a ≼ b := by
-    induction l <;> grind [takeWhile, dropWhile]
+    l.orderedInsert r a = (l.takeWhile fun b => ¬a ≼ b) ++ a :: l.dropWhile fun b => ¬a ≼ b := by
+  induction l <;> grind [takeWhile, dropWhile]
 
 theorem insertionSort_cons_eq_take_drop (a : α) (l : List α) :
     insertionSort r (a :: l) =
@@ -471,11 +471,11 @@ section IsChain
 theorem sortedLE_iff_isChain : l.SortedLE ↔ IsChain (· ≤ ·) l :=
   sortedLE_iff_pairwise.trans isChain_iff_pairwise.symm
 theorem sortedGE_iff_isChain : l.SortedGE ↔ IsChain (· ≥ ·) l :=
-    sortedGE_iff_pairwise.trans isChain_iff_pairwise.symm
+  sortedGE_iff_pairwise.trans isChain_iff_pairwise.symm
 theorem sortedLT_iff_isChain : l.SortedLT ↔ IsChain (· < ·) l :=
-    sortedLT_iff_pairwise.trans isChain_iff_pairwise.symm
+  sortedLT_iff_pairwise.trans isChain_iff_pairwise.symm
 theorem sortedGT_iff_isChain : l.SortedGT ↔ IsChain (· > ·) l :=
-    sortedGT_iff_pairwise.trans isChain_iff_pairwise.symm
+  sortedGT_iff_pairwise.trans isChain_iff_pairwise.symm
 
 protected alias ⟨SortedLE.isChain, IsChain.sortedLE⟩ := sortedLE_iff_isChain
 protected alias ⟨SortedGE.isChain, IsChain.sortedGE⟩ := sortedGE_iff_isChain
@@ -513,13 +513,13 @@ theorem sortedGT_iff_getElem_gt_getElem_of_lt :
   ⟨fun h _ _ _ _ hij => h.strictAnti_get hij, fun h => StrictAnti.sortedGT <| fun _ _ => (h ·)⟩
 
 alias ⟨SortedLE.getElem_le_getElem_of_le, sortedLE_of_getElem_le_getElem_of_le⟩ :=
-    sortedLE_iff_getElem_le_getElem_of_le
+  sortedLE_iff_getElem_le_getElem_of_le
 alias ⟨SortedGE.getElem_ge_getElem_of_le, sortedGE_of_getElem_ge_getElem_of_le⟩ :=
-    sortedGE_iff_getElem_ge_getElem_of_le
+  sortedGE_iff_getElem_ge_getElem_of_le
 alias ⟨SortedLT.getElem_lt_getElem_of_lt, sortedLT_of_getElem_lt_getElem_of_lt⟩ :=
-    sortedLT_iff_getElem_lt_getElem_of_lt
+  sortedLT_iff_getElem_lt_getElem_of_lt
 alias ⟨SortedGT.getElem_gt_getElem_of_lt, sortedGT_of_getElem_gt_getElem_of_lt⟩ :=
-    sortedGT_iff_getElem_gt_getElem_of_lt
+  sortedGT_iff_getElem_gt_getElem_of_lt
 
 end GetElem
 
@@ -542,7 +542,7 @@ theorem sortedLE_replicate {a : α} (n : ℕ) : (replicate n a).SortedLE :=
 @[deprecated (since := "2025-11-27")] alias sorted_le_replicate := sortedLE_replicate
 
 theorem sortedLT_finRange (n : ℕ) : (finRange n).SortedLT :=
-    sortedLT_of_getElem_lt_getElem_of_lt <| by simp
+  sortedLT_of_getElem_lt_getElem_of_lt <| by simp
 
 theorem sortedLT_range (n : ℕ) : (range n).SortedLT := pairwise_lt_range.sortedLT
 

--- a/Mathlib/Data/Sym/Card.lean
+++ b/Mathlib/Data/Sym/Card.lean
@@ -176,8 +176,7 @@ theorem card_subtype_not_diag [Fintype α] :
 
 theorem card_diagSet_compl [Fintype α] :
     Fintype.card ((@Sym2.diagSet α)ᶜ : Set _) = (card α).choose 2 := by
-  simp only [← card_subtype_not_diag, Sym2.diagSet_compl_eq_setOf_not_isDiag]
-  rfl
+  simp only [← card_subtype_not_diag, Sym2.diagSet_compl_eq_setOf_not_isDiag, Set.coe_setOf]
 
 /-- Type **stars and bars** for the case `n = 2`. -/
 protected theorem card {α} [Fintype α] : card (Sym2 α) = Nat.choose (card α + 1) 2 :=

--- a/Mathlib/LinearAlgebra/AffineSpace/Independent.lean
+++ b/Mathlib/LinearAlgebra/AffineSpace/Independent.lean
@@ -542,8 +542,7 @@ private lemma AffineIndependent.vectorSpan_image_ne_of_mem_of_notMem_of_not_subs
     exact sum_congr rfl fun t ht ↦ by simp [w']
   have hs' : p i -ᵥ p j = (fs.map (Embedding.subtype _)).weightedVSub p w' := by
     rw [hs, weightedVSub_map]
-    simp only [Embedding.coe_subtype, Subtype.val_injective, extend_comp, w']
-    rfl
+    simp [w', Function.comp_def]
   let fs' : Finset ι := insert i (insert j (fs.map (Embedding.subtype _)))
   have hfsfs' : fs.map (Embedding.subtype _) ⊆ fs' := by grind
   let w'' : ι → k := Set.indicator (fs.map (Embedding.subtype _)) w'

--- a/Mathlib/LinearAlgebra/DirectSum/TensorProduct.lean
+++ b/Mathlib/LinearAlgebra/DirectSum/TensorProduct.lean
@@ -150,7 +150,7 @@ lemma directSumRight_comp_rTensor (f : M₁' →ₗ[R] M₂') :
 @[simp]
 lemma directSumRight_tmul (m : M₁') (n : ⨁ i, M₂ i) (i : ι₂) :
     directSumRight R M₁' M₂ (m ⊗ₜ[R] n) i = m ⊗ₜ[R] (n i) := by
-  suffices (DirectSum.component R ι₂ _ i) ∘ₗ(directSumRight R M₁' M₂).toLinearMap ∘ₗ
+  suffices (DirectSum.component R ι₂ _ i) ∘ₗ (directSumRight R M₁' M₂).toLinearMap ∘ₗ
       (TensorProduct.mk R M₁' (⨁ i, M₂ i) m) =
         (TensorProduct.mk R M₁' (M₂ i) m) ∘ₗ (DirectSum.component R ι₂ M₂ i) by
     simpa using LinearMap.congr_fun this n

--- a/Mathlib/LinearAlgebra/Matrix/Irreducible/Defs.lean
+++ b/Mathlib/LinearAlgebra/Matrix/Irreducible/Defs.lean
@@ -21,28 +21,28 @@ matrix (like powers) into graph-theoretic properties of its quiver (like the exi
 
 ## Main definitions
 
-*   `Matrix.toQuiver A`: The quiver associated with a matrix `A`, where an edge `i ⟶ j` exists if
-    `0 < A i j`.
-*   `Matrix.IsIrreducible A`: A matrix `A` is defined as irreducible if it is entrywise nonnegative
-    and its associated quiver `toQuiver A` is strongly connected. The theorem
-    `Matrix.isIrreducible_iff_exists_pow_pos` proves this graph-theoretic definition is equivalent
-    to the algebraic one in seneta2006 (Def 1.6, p.18): for every pair of indices `(i, j)`, there
-    exists a positive integer `k` such that `(A ^ k) i j > 0`.
-*   `Matrix.IsPrimitive A`: A matrix `A` is primitive if it is nonnegative and some power `A ^ k`
-    is strictly positive (all entries are `> 0`), (seneta2006, Definition 1.1, p.14).
+* `Matrix.toQuiver A`: The quiver associated with a matrix `A`, where an edge `i ⟶ j` exists if
+  `0 < A i j`.
+* `Matrix.IsIrreducible A`: A matrix `A` is defined as irreducible if it is entrywise nonnegative
+  and its associated quiver `toQuiver A` is strongly connected. The theorem
+  `Matrix.isIrreducible_iff_exists_pow_pos` proves this graph-theoretic definition is equivalent
+  to the algebraic one in seneta2006 (Def 1.6, p.18): for every pair of indices `(i, j)`, there
+  exists a positive integer `k` such that `(A ^ k) i j > 0`.
+* `Matrix.IsPrimitive A`: A matrix `A` is primitive if it is nonnegative and some power `A ^ k`
+  is strictly positive (all entries are `> 0`), (seneta2006, Definition 1.1, p.14).
 
 ## Main results
 
-*   `Matrix.pow_apply_pos_iff_nonempty_path`: Establishes the link between matrix powers and graph
-      theory:
-    `(A ^ k) i j > 0` if and only if there is a path of length `k` from `i` to `j` in `toQuiver A`.
-*   `Matrix.isIrreducible_iff_exists_pow_pos`: Shows the equivalence between the graph-theoretic
-      definition of irreducibility (strong connectivity) and the algebraic one (existence of a
-      positive entry in some power).
-*   `Matrix.IsPrimitive.to_IsIrreducible`: Proves that a primitive matrix is also irreducible
-      (Seneta, p.14).
-*   `Matrix.IsIrreducible.transpose`: Shows that the irreducibility property is preserved under
-    transposition.
+* `Matrix.pow_apply_pos_iff_nonempty_path`: Establishes the link between matrix powers and graph
+  theory:
+  `(A ^ k) i j > 0` if and only if there is a path of length `k` from `i` to `j` in `toQuiver A`.
+* `Matrix.isIrreducible_iff_exists_pow_pos`: Shows the equivalence between the graph-theoretic
+  definition of irreducibility (strong connectivity) and the algebraic one (existence of a
+  positive entry in some power).
+* `Matrix.IsPrimitive.to_IsIrreducible`: Proves that a primitive matrix is also irreducible
+  (Seneta, p.14).
+* `Matrix.IsIrreducible.transpose`: Shows that the irreducibility property is preserved under
+  transposition.
 
 ## Implementation notes
 
@@ -52,7 +52,7 @@ like `PosMulStrictMono R` or `Nontrivial R`. Some statements expand matrix power
 
 ## References
 
-*   [E. Seneta, *Non-negative Matrices and Markov Chains*][seneta2006]
+* [E. Seneta, *Non-negative Matrices and Markov Chains*][seneta2006]
 
 ## Tags
 
@@ -111,8 +111,8 @@ theorem pow_apply_pos_iff_nonempty_path
     (hA : ∀ i j, 0 ≤ A i j) (k : ℕ) (i j : n) :
     letI := toQuiver A
     0 < (A ^ k) i j ↔ Nonempty {p : Path i j // p.length = k} := by
-    letI := toQuiver A
-    induction k generalizing i j with
+  letI := toQuiver A
+  induction k generalizing i j with
   | zero =>
     refine ⟨fun h_pos ↦ ?_, fun ⟨p, hp⟩ ↦ ?_⟩
     · rcases eq_or_ne i j with rfl | h_eq
@@ -168,9 +168,8 @@ theorem isIrreducible_iff_exists_pow_pos
     · exact hA
     · intro i j
       obtain ⟨k, hk_pos, hk_entry⟩ := h_exists i j
-      obtain ⟨⟨p, hp_len⟩⟩ :=
+      obtain ⟨⟨p, rfl⟩⟩ :=
         (pow_apply_pos_iff_nonempty_path (A := A) hA k i j).mp hk_entry
-      subst hp_len
       exact ⟨p, hk_pos⟩
 
 /-- If a nonnegative square matrix `A` is primitive, then `A` is irreducible. -/
@@ -206,14 +205,12 @@ theorem IsIrreducible.transpose (hA : IsIrreducible A) : IsIrreducible Aᵀ := b
   obtain ⟨p, hp_pos⟩ := hA.connected j i
   cases p with
   | nil =>
-      exact False.elim ((lt_irrefl (0 : Nat)) (by simp [Quiver.Path.length] at hp_pos))
+    simp at hp_pos
   | @cons b _ q e =>
-      let qT := transposePath (A := A) (q.cons e)
-      letI : Quiver n := toQuiver Aᵀ
-      have hqT_pos : 0 < qT.length := by
-        have : 0 < Nat.succ ((transposePath (A := A) q).length) := Nat.succ_pos _
-        simp [qT, transposePath, Quiver.Path.length_comp, Quiver.Path.length_toPath]
-      exact ⟨qT, hqT_pos⟩
+    let qT := transposePath (A := A) (q.cons e)
+    letI : Quiver n := toQuiver Aᵀ
+    use qT
+    simp [qT, transposePath, Quiver.Path.length_comp, Quiver.Path.length_toPath]
 
 @[simp]
 theorem isIrreducible_transpose_iff :

--- a/Mathlib/LinearAlgebra/Matrix/PosDef.lean
+++ b/Mathlib/LinearAlgebra/Matrix/PosDef.lean
@@ -148,7 +148,7 @@ theorem posSemidef_sum {ι : Type*} [AddLeftMono R]
     {x : ι → Matrix n n R} (s : Finset ι) (h : ∀ i ∈ s, PosSemidef (x i)) :
     PosSemidef (∑ i ∈ s, x i) := by
   refine ⟨isSelfAdjoint_sum s fun _ hi => h _ hi |>.1, fun y => ?_⟩
-  simp[sum_apply, Finset.mul_sum,Finset.sum_mul, Finsupp.sum_finsetSum_comm,
+  simp [sum_apply, Finset.mul_sum,Finset.sum_mul, Finsupp.sum_finsetSum_comm,
     Finset.sum_nonneg fun _ hi => (h _ hi).2 _]
 
 /-!

--- a/Mathlib/LinearAlgebra/Multilinear/Basis.lean
+++ b/Mathlib/LinearAlgebra/Multilinear/Basis.lean
@@ -70,8 +70,7 @@ theorem multilinearMap_apply (i : (Π i, κ i) × ι') :
     LinearEquiv.multilinearMapCongrLeft_symm_apply, compLinearMap_apply, LinearEquiv.coe_coe,
     LinearMap.compMultilinearMap_apply, freeFinsuppEquiv_single, one_smul,
     Finsupp.linearCombination_single, Basis.coord_apply, mkPiRing_apply, smul_eq_mul, mul_one,
-    LinearMap.coe_smulRight, LinearMap.id_coe, id_eq]
-  convert rfl
+    LinearMap.coe_smulRight, LinearMap.id_coe, id_eq, Subsingleton.elim (Fintype.ofFinite ι)]
 
 /-- The elements of the basis are the maps which scale `b' ii.2` by the
 product of all the `ii.1 ·` coordinates along `b i`. -/

--- a/Mathlib/LinearAlgebra/SpecialLinearGroup.lean
+++ b/Mathlib/LinearAlgebra/SpecialLinearGroup.lean
@@ -460,14 +460,13 @@ noncomputable def centerEquivRootsOfUnity :
     set Hg := (mem_center_iff.mp g.prop)
     set Hh := (mem_center_iff.mp h.prop)
     set Hgh := (mem_center_iff.mp (g * h).prop)
-    simp only [← Subtype.val_inj, ← Units.val_inj, IsUnit.unit_spec,
-      Units.val_mul]
+    simp only [← Subtype.val_inj, ← Units.val_inj, IsUnit.unit_spec, Units.val_mul]
     change Hgh.choose = Hg.choose * Hh.choose
     suffices (Hgh.choose • LinearMap.id : V →ₗ[R] V)
       = (Hg.choose • LinearMap.id) * (Hh.choose • LinearMap.id) by
       apply FaithfulSMul.eq_of_smul_eq_smul (α := V)
       intro x
-      simp  [mul_smul,
+      simp [mul_smul,
         ← mem_center_iff_spec (g * h).prop, ← mem_center_iff_spec h.prop,
         ← mem_center_iff_spec g.prop]
     simp [← Hgh.choose_spec.2, ← Hh.choose_spec.2, ← Hg.choose_spec.2]
@@ -516,7 +515,6 @@ open Subgroup Matrix Matrix.SpecialLinearGroup
 
 variable {n : Type*} [Fintype n] [DecidableEq n] {R : Type*} [CommRing R]
 
--- variable [Nontrivial R]
 variable {V : Type*} [AddCommGroup V] [Module R V] [Module.Free R V] [Module.Finite R V]
 variable {ι : Type*} [Fintype ι] [DecidableEq ι] (b : Module.Basis ι R V)
 

--- a/Mathlib/LinearAlgebra/SymmetricAlgebra/Basic.lean
+++ b/Mathlib/LinearAlgebra/SymmetricAlgebra/Basic.lean
@@ -240,9 +240,9 @@ theorem induction {motive : A → Prop}
   generalize h.equiv.invFun a = y
   change motive (SymmetricAlgebra.lift f y)
   induction y using SymmetricAlgebra.induction with
-    | algebraMap r => simpa using algebraMap r
-    | ι y => simpa using ι y
-    | mul _ _ hx hy => simpa using mul _ _ hx hy
-    | add _ _ hx hy => simpa using add _ _ hx hy
+  | algebraMap r => simpa using algebraMap r
+  | ι y => simpa using ι y
+  | mul _ _ hx hy => simpa using mul _ _ hx hy
+  | add _ _ hx hy => simpa using add _ _ hx hy
 
 end IsSymmetricAlgebra

--- a/Mathlib/RingTheory/MvPolynomial/MonomialOrder.lean
+++ b/Mathlib/RingTheory/MvPolynomial/MonomialOrder.lean
@@ -614,9 +614,7 @@ theorem degree_prod [NoZeroDivisors R] {ι : Type*} {P : ι → MvPolynomial σ 
   | inr _ =>
     apply m.toSyn.injective
     refine le_antisymm degree_prod_le (m.le_degree ?_)
-    rw [mem_support_iff, m.coeff_prod_sum_degree]
-    simp only [ne_eq, Finset.prod_eq_zero_iff, leadingCoeff_eq_zero_iff, not_exists, not_and]
-    exact H
+    simpa [m.coeff_prod_sum_degree, Finset.prod_eq_zero_iff]
 
 lemma degree_mul' [NoZeroDivisors R] {f g : MvPolynomial σ R} (hf : f * g ≠ 0) :
     m.degree (f * g) = m.degree f + m.degree g := by


### PR DESCRIPTION
As usual, `simp`s didn't look noticeably slow.

---
<!-- Your PR title will become the first line of the commit message.

In this box, the text above the `---` (if not empty) will be appended
to the commit message, and can be used to give additional context or
details. Please leave a blank newline before the `---`, otherwise GitHub
will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

When merging, all the commits will be squashed into a single commit
listing all co-authors.

Co-authors in the squash commit are gathered from two sources:

First, all authors of commits to this PR branch are included. Thus,
one way to add co-authors is to include at least one commit authored by
each co-author among the commits in the pull request. If necessary, you
may create empty commits to indicate co-authorship, using commands like so:

git commit --author="Author Name <author@email.com>" --allow-empty -m "add Author Name as coauthor"

Second, co-authors can also be listed in lines at the very bottom of
the commit message (that is, directly before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines
at the bottom of the commit message (before the `---`, and also before
any "Co-authored-by" lines) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
