### PR TITLE
[Merged by Bors] - chore: remove March and April 2025 deprecated declarations

### DIFF
--- a/Mathlib/Algebra/Algebra/Basic.lean
+++ b/Mathlib/Algebra/Algebra/Basic.lean
@@ -221,9 +221,6 @@ theorem End.algebraMap_isUnit_inv_apply_eq_iff {x : R}
       apply_fun ⇑h.unit.val using ((isUnit_iff _).mp h).injective
       simpa using Module.End.isUnit_apply_inv_apply_of_isUnit h (x • m')
 
-@[deprecated (since := "2025-04-28")]
-alias End_algebraMap_isUnit_inv_apply_eq_iff := End.algebraMap_isUnit_inv_apply_eq_iff
-
 theorem End.algebraMap_isUnit_inv_apply_eq_iff' {x : R}
     (h : IsUnit (algebraMap R (Module.End S M) x)) (m m' : M) :
     m' = (↑h.unit⁻¹ : Module.End S M) m ↔ m = x • m' where
@@ -232,9 +229,6 @@ theorem End.algebraMap_isUnit_inv_apply_eq_iff' {x : R}
     H.symm ▸ by
       apply_fun (↑h.unit : M → M) using ((isUnit_iff _).mp h).injective
       simpa using isUnit_apply_inv_apply_of_isUnit h (x • m') |>.symm
-
-@[deprecated (since := "2025-04-28")]
-alias End_algebraMap_isUnit_inv_apply_eq_iff' := End.algebraMap_isUnit_inv_apply_eq_iff'
 
 end
 

--- a/Mathlib/Algebra/GroupWithZero/Commute.lean
+++ b/Mathlib/Algebra/GroupWithZero/Commute.lean
@@ -53,9 +53,6 @@ theorem Commute.ringInverse_ringInverse {a b : M₀} (h : Commute a b) :
   (Ring.mul_inverse_rev' h.symm).symm.trans <| (congr_arg _ h.symm.eq).trans <|
     Ring.mul_inverse_rev' h
 
-@[deprecated (since := "2025-04-22")]
-alias Commute.ring_inverse_ring_inverse := Commute.ringInverse_ringInverse
-
 namespace Commute
 
 @[simp]

--- a/Mathlib/Algebra/GroupWithZero/Units/Basic.lean
+++ b/Mathlib/Algebra/GroupWithZero/Units/Basic.lean
@@ -138,9 +138,6 @@ end Ring
 theorem IsUnit.ringInverse {a : M₀} : IsUnit a → IsUnit (Ring.inverse a)
   | ⟨u, hu⟩ => hu ▸ ⟨u⁻¹, (Ring.inverse_unit u).symm⟩
 
-@[deprecated (since := "2025-04-22")] alias IsUnit.ring_inverse := IsUnit.ringInverse
-@[deprecated (since := "2025-04-22")] protected alias Ring.IsUnit.ringInverse := IsUnit.ringInverse
-
 @[simp]
 theorem isUnit_ringInverse {a : M₀} : IsUnit (Ring.inverse a) ↔ IsUnit a :=
   ⟨fun h => by
@@ -150,8 +147,6 @@ theorem isUnit_ringInverse {a : M₀} : IsUnit (Ring.inverse a) ↔ IsUnit a :=
       rw [Ring.inverse_non_unit _ h]
       exact not_isUnit_zero,
     IsUnit.ringInverse⟩
-
-@[deprecated (since := "2025-04-22")] alias isUnit_ring_inverse := isUnit_ringInverse
 
 namespace Units
 

--- a/Mathlib/Algebra/Module/Equiv/Basic.lean
+++ b/Mathlib/Algebra/Module/Equiv/Basic.lean
@@ -74,9 +74,6 @@ theorem _root_.Module.End.isUnit_iff [Module R M] (f : Module.End R M) :
     let e : M ≃ₗ[R] M := { f, Equiv.ofBijective f H with }
     ⟨⟨_, e.symm, LinearMap.ext e.right_inv, LinearMap.ext e.left_inv⟩, rfl⟩⟩
 
-@[deprecated (since := "2025-04-28")]
-alias _root_.Module.End_isUnit_iff := _root_.Module.End.isUnit_iff
-
 section Automorphisms
 
 variable [Module R M]

--- a/Mathlib/Algebra/Module/LinearMap/End.lean
+++ b/Mathlib/Algebra/Module/LinearMap/End.lean
@@ -120,15 +120,9 @@ theorem isUnit_apply_inv_apply_of_isUnit {f : End R M} (h : IsUnit f) (x : M) :
     f (h.unit.inv x) = x :=
   show (f * h.unit.inv) x = x by simp
 
-@[deprecated (since := "2025-04-28")]
-alias _root_.Module.End_isUnit_apply_inv_apply_of_isUnit := isUnit_apply_inv_apply_of_isUnit
-
 theorem isUnit_inv_apply_apply_of_isUnit {f : End R M} (h : IsUnit f) (x : M) :
     h.unit.inv (f x) = x :=
   (by simp : (h.unit.inv * f) x = x)
-
-@[deprecated (since := "2025-04-28")]
-alias _root_.Module.End_isUnit_inv_apply_apply_of_isUnit := isUnit_inv_apply_apply_of_isUnit
 
 theorem coe_pow (f : End R M) (n : ℕ) : ⇑(f ^ n) = f^[n] := hom_coe_pow _ rfl (fun _ _ ↦ rfl) _ _
 

--- a/Mathlib/Algebra/Ring/Basic.lean
+++ b/Mathlib/Algebra/Ring/Basic.lean
@@ -297,9 +297,6 @@ lemma div_neg_eq_neg_div' (a : R) : a / -b = -a / b := neg_div b a ▸ div_neg _
 @[simp]
 lemma inv_neg : (-a)⁻¹ = -a⁻¹ := by rw [neg_inv]
 
-@[deprecated (since := "2025-04-24")]
-alias inv_neg' := inv_neg
-
 lemma inv_neg_one : (-1 : R)⁻¹ = -1 := by rw [← neg_inv, inv_one]
 
 end DivisionMonoid

--- a/Mathlib/Analysis/Calculus/ContDiff/Operations.lean
+++ b/Mathlib/Analysis/Calculus/ContDiff/Operations.lean
@@ -676,8 +676,6 @@ theorem contDiffAt_ringInverse [HasSummableGeomSeries R] (x : Rˣ) :
     Units.isOpen.uniqueDiffOn x x.isUnit
   exact this.contDiffAt (Units.isOpen.mem_nhds x.isUnit)
 
-@[deprecated (since := "2025-04-22")] alias contDiffAt_ring_inverse := contDiffAt_ringInverse
-
 variable {𝕜' : Type*} [NormedField 𝕜'] [NormedAlgebra 𝕜 𝕜']
 
 @[fun_prop]

--- a/Mathlib/Analysis/Calculus/FDeriv/Mul.lean
+++ b/Mathlib/Analysis/Calculus/FDeriv/Mul.lean
@@ -728,8 +728,6 @@ theorem hasFDerivAt_ringInverse (x : Rˣ) :
     (inverse_add_norm_diff_second_order x).trans_isLittleO (isLittleO_norm_pow_id one_lt_two)
   by simpa [hasFDerivAt_iff_isLittleO_nhds_zero] using this
 
-@[deprecated (since := "2025-04-22")] alias hasFDerivAt_ring_inverse := hasFDerivAt_ringInverse
-
 @[fun_prop]
 theorem differentiableAt_inverse {x : R} (hx : IsUnit x) :
     DifferentiableAt 𝕜 (@Ring.inverse R _) x :=
@@ -751,9 +749,6 @@ theorem hasStrictFDerivAt_ringInverse (x : Rˣ) :
     HasStrictFDerivAt Ring.inverse (-mulLeftRight 𝕜 R ↑x⁻¹ ↑x⁻¹) x := by
   convert (analyticAt_inverse (𝕜 := 𝕜) x).hasStrictFDerivAt
   exact (fderiv_inverse x).symm
-
-@[deprecated (since := "2025-04-22")]
-alias hasStrictFDerivAt_ring_inverse := hasStrictFDerivAt_ringInverse
 
 variable {h : E → R} {z : E} {S : Set E}
 

--- a/Mathlib/Analysis/Calculus/TangentCone/Basic.lean
+++ b/Mathlib/Analysis/Calculus/TangentCone/Basic.lean
@@ -41,14 +41,10 @@ theorem tangentConeAt_univ : tangentConeAt 𝕜 univ x = univ :=
   eq_univ_of_forall fun _ ↦ mem_tangentConeAt_of_pow_smul (norm_pos_iff.1 hr₀) hr <|
     Eventually.of_forall fun _ ↦ mem_univ _
 
-@[deprecated (since := "2025-04-27")] alias tangentCone_univ := tangentConeAt_univ
-
 @[gcongr]
 theorem tangentConeAt_mono (h : s ⊆ t) : tangentConeAt 𝕜 s x ⊆ tangentConeAt 𝕜 t x := by
   rintro y ⟨c, d, ds, ctop, clim⟩
   exact ⟨c, d, mem_of_superset ds fun n hn => h hn, ctop, clim⟩
-
-@[deprecated (since := "2025-04-27")] alias tangentCone_mono := tangentConeAt_mono
 
 /--
 Given `x ∈ s` and a field extension `𝕜 ⊆ 𝕜'`, the tangent cone of `s` at `x` with
@@ -94,19 +90,13 @@ theorem tangentConeAt_mono_nhds (h : 𝓝[s] x ≤ 𝓝[t] x) :
   refine (tendsto_inf.2 ⟨?_, tendsto_principal.2 ds⟩).mono_right h
   simpa only [add_zero] using tendsto_const_nhds.add (tangentConeAt.lim_zero atTop ctop clim)
 
-@[deprecated (since := "2025-04-27")] alias tangentCone_mono_nhds := tangentConeAt_mono_nhds
-
 /-- Tangent cone of `s` at `x` depends only on `𝓝[s] x`. -/
 theorem tangentConeAt_congr (h : 𝓝[s] x = 𝓝[t] x) : tangentConeAt 𝕜 s x = tangentConeAt 𝕜 t x :=
   Subset.antisymm (tangentConeAt_mono_nhds h.le) (tangentConeAt_mono_nhds h.ge)
 
-@[deprecated (since := "2025-04-27")] alias tangentCone_congr := tangentConeAt_congr
-
 /-- Intersecting with a neighborhood of the point does not change the tangent cone. -/
 theorem tangentConeAt_inter_nhds (ht : t ∈ 𝓝 x) : tangentConeAt 𝕜 (s ∩ t) x = tangentConeAt 𝕜 s x :=
   tangentConeAt_congr (nhdsWithin_restrict' _ ht).symm
-
-@[deprecated (since := "2025-04-27")] alias tangentCone_inter_nhds := tangentConeAt_inter_nhds
 
 theorem tangentConeAt_of_mem_nhds (h : s ∈ 𝓝 x) : tangentConeAt 𝕜 s x = univ := by
   rw [← univ_inter s, tangentConeAt_inter_nhds h, tangentConeAt_univ]

--- a/Mathlib/Analysis/Calculus/TangentCone/Defs.lean
+++ b/Mathlib/Analysis/Calculus/TangentCone/Defs.lean
@@ -57,9 +57,6 @@ structure UniqueDiffWithinAt (s : Set E) (x : E) : Prop where
   dense_tangentConeAt : Dense (Submodule.span 𝕜 (tangentConeAt 𝕜 s x) : Set E)
   mem_closure : x ∈ closure s
 
-@[deprecated (since := "2025-04-27")]
-alias UniqueDiffWithinAt.dense_tangentCone := UniqueDiffWithinAt.dense_tangentConeAt
-
 /-- A property ensuring that the tangent cone to `s` at any of its points spans a dense subset of
 the whole space. The main role of this property is to ensure that the differential along `s` is
 unique, hence this name. The uniqueness it asserts is proved in `UniqueDiffOn.eq` in

--- a/Mathlib/Analysis/Calculus/TangentCone/DimOne.lean
+++ b/Mathlib/Analysis/Calculus/TangentCone/DimOne.lean
@@ -54,8 +54,6 @@ theorem tangentConeAt_eq_univ {s : Set 𝕜} {x : 𝕜} (hx : AccPt x (𝓟 s)) 
   · convert tendsto_const_nhds (α := ℕ) (x := y) with n
     simp [mul_assoc, inv_mul_cancel₀ (d_ne n)]
 
-@[deprecated (since := "2025-04-27")] alias tangentCone_eq_univ := tangentConeAt_eq_univ
-
 /-- In one dimension, a point is a point of unique differentiability of a set
 iff it is an accumulation point of the set. -/
 theorem uniqueDiffWithinAt_iff_accPt {s : Set 𝕜} {x : 𝕜} :

--- a/Mathlib/Analysis/Calculus/TangentCone/Pi.lean
+++ b/Mathlib/Analysis/Calculus/TangentCone/Pi.lean
@@ -44,8 +44,6 @@ theorem mapsTo_tangentConeAt_pi [DecidableEq ι] {i : ι} (hi : ∀ j ≠ i, x j
       refine squeeze_zero_norm (fun n => (hcd' n j hj).le) ?_
       exact tendsto_pow_atTop_nhds_zero_of_lt_one one_half_pos.le one_half_lt_one
 
-@[deprecated (since := "2025-04-27")] alias mapsTo_tangentCone_pi := mapsTo_tangentConeAt_pi
-
 variable (ι E)
 variable [Finite ι]
 

--- a/Mathlib/Analysis/Calculus/TangentCone/Prod.lean
+++ b/Mathlib/Analysis/Calculus/TangentCone/Prod.lean
@@ -45,9 +45,6 @@ theorem subset_tangentConeAt_prod_left (ht : y ∈ closure t) :
     refine squeeze_zero_norm (fun n => (hd' n).2.le) ?_
     exact tendsto_pow_atTop_nhds_zero_of_lt_one one_half_pos.le one_half_lt_one
 
-@[deprecated (since := "2025-04-27")]
-alias subset_tangentCone_prod_left := subset_tangentConeAt_prod_left
-
 /-- The tangent cone of a product contains the tangent cone of its right factor. -/
 theorem subset_tangentConeAt_prod_right (hs : x ∈ closure s) :
     LinearMap.inr 𝕜 E F '' tangentConeAt 𝕜 t y ⊆ tangentConeAt 𝕜 (s ×ˢ t) (x, y) := by
@@ -66,9 +63,6 @@ theorem subset_tangentConeAt_prod_right (hs : x ∈ closure s) :
   · apply Tendsto.prodMk_nhds _ hy
     refine squeeze_zero_norm (fun n => (hd' n).2.le) ?_
     exact tendsto_pow_atTop_nhds_zero_of_lt_one one_half_pos.le one_half_lt_one
-
-@[deprecated (since := "2025-04-27")]
-alias subset_tangentCone_prod_right := subset_tangentConeAt_prod_right
 
 /-- The product of two sets of unique differentiability at points `x` and `y` has unique
 differentiability at `(x, y)`. -/

--- a/Mathlib/Analysis/Calculus/TangentCone/ProperSpace.lean
+++ b/Mathlib/Analysis/Calculus/TangentCone/ProperSpace.lean
@@ -72,5 +72,3 @@ theorem tangentConeAt_nonempty_of_properSpace [ProperSpace E]
   · simpa [d] using hvs (φ n)
   · exact c_lim.comp φ_strict.tendsto_atTop
 
-@[deprecated (since := "2025-04-27")]
-alias tangentCone_nonempty_of_properSpace := tangentConeAt_nonempty_of_properSpace

--- a/Mathlib/Analysis/Calculus/TangentCone/ProperSpace.lean
+++ b/Mathlib/Analysis/Calculus/TangentCone/ProperSpace.lean
@@ -71,4 +71,3 @@ theorem tangentConeAt_nonempty_of_properSpace [ProperSpace E]
   refine ⟨c ∘ φ, d ∘ φ, .of_forall fun n ↦ ?_, ?_, hφ⟩
   · simpa [d] using hvs (φ n)
   · exact c_lim.comp φ_strict.tendsto_atTop
-

--- a/Mathlib/Analysis/Calculus/TangentCone/Real.lean
+++ b/Mathlib/Analysis/Calculus/TangentCone/Real.lean
@@ -39,17 +39,11 @@ theorem mem_tangentConeAt_of_openSegment_subset {s : Set E} {x y : E} (h : openS
   · exact pow_lt_one₀ one_half_pos.le one_half_lt_one hn
   · simp only [sub_smul, one_smul, smul_sub]; abel
 
-@[deprecated (since := "2025-04-27")]
-alias mem_tangentCone_of_openSegment_subset := mem_tangentConeAt_of_openSegment_subset
-
 /-- If a subset of a real vector space contains a segment, then the direction of this
 segment belongs to the tangent cone at its endpoints. -/
 theorem mem_tangentConeAt_of_segment_subset {s : Set E} {x y : E} (h : segment ℝ x y ⊆ s) :
     y - x ∈ tangentConeAt ℝ s x :=
   mem_tangentConeAt_of_openSegment_subset ((openSegment_subset_segment ℝ x y).trans h)
-
-@[deprecated (since := "2025-04-27")]
-alias mem_tangentCone_of_segment_subset := mem_tangentConeAt_of_segment_subset
 
 theorem Convex.span_tangentConeAt {s : Set E} (conv : Convex ℝ s) (hs : (interior s).Nonempty)
     {x : E} (hx : x ∈ closure s) : Submodule.span ℝ (tangentConeAt ℝ s x) = ⊤ := by

--- a/Mathlib/Analysis/InnerProductSpace/Basic.lean
+++ b/Mathlib/Analysis/InnerProductSpace/Basic.lean
@@ -322,9 +322,6 @@ theorem re_inner_self_nonpos {x : E} : re ⟪x, x⟫ ≤ 0 ↔ x = 0 := by
 lemma re_inner_self_pos {x : E} : 0 < re ⟪x, x⟫ ↔ x ≠ 0 := by
   simp [sq_pos_iff]
 
-@[deprecated (since := "2025-04-22")] alias inner_self_nonpos := re_inner_self_nonpos
-@[deprecated (since := "2025-04-22")] alias inner_self_pos := re_inner_self_pos
-
 open scoped InnerProductSpace in
 theorem real_inner_self_nonpos {x : F} : ⟪x, x⟫_ℝ ≤ 0 ↔ x = 0 := re_inner_self_nonpos (𝕜 := ℝ)
 
@@ -364,8 +361,6 @@ theorem norm_eq_sqrt_re_inner (x : E) : ‖x‖ = √(re ⟪x, x⟫) :=
   calc
     ‖x‖ = √(‖x‖ ^ 2) := (sqrt_sq (norm_nonneg _)).symm
     _ = √(re ⟪x, x⟫) := congr_arg _ (norm_sq_eq_re_inner _)
-
-@[deprecated (since := "2025-04-22")] alias norm_eq_sqrt_inner := norm_eq_sqrt_re_inner
 
 theorem norm_eq_sqrt_real_inner (x : F) : ‖x‖ = √⟪x, x⟫_ℝ :=
   @norm_eq_sqrt_re_inner ℝ _ _ _ _ x

--- a/Mathlib/Analysis/InnerProductSpace/Defs.lean
+++ b/Mathlib/Analysis/InnerProductSpace/Defs.lean
@@ -144,12 +144,6 @@ structure PreInnerProductSpace.Core (𝕜 : Type*) (F : Type*) [RCLike 𝕜] [Ad
   /-- The inner product is conjugate linear in the first coordinate. -/
   smul_left x y r : inner (r • x) y = conj r * inner x y
 
-@[deprecated (since := "2025-04-22")]
-alias PreInnerProductSpace.Core.conj_symm := PreInnerProductSpace.Core.conj_inner_symm
-
-@[deprecated (since := "2025-04-22")]
-alias PreInnerProductSpace.Core.inner_nonneg := PreInnerProductSpace.Core.re_inner_nonneg
-
 attribute [class] PreInnerProductSpace.Core
 
 /-- A structure requiring that a scalar product is positive definite. Some theorems that
@@ -379,8 +373,6 @@ def toNorm : Norm F where norm x := √(re ⟪x, x⟫)
 attribute [local instance] toNorm
 
 theorem norm_eq_sqrt_re_inner (x : F) : ‖x‖ = √(re ⟪x, x⟫) := rfl
-
-@[deprecated (since := "2025-04-22")] alias norm_eq_sqrt_inner := norm_eq_sqrt_re_inner
 
 theorem inner_self_eq_norm_mul_norm (x : F) : re ⟪x, x⟫ = ‖x‖ * ‖x‖ := by
   rw [norm_eq_sqrt_re_inner, ← sqrt_mul inner_self_nonneg, sqrt_mul_self inner_self_nonneg]

--- a/Mathlib/Analysis/Meromorphic/Order.lean
+++ b/Mathlib/Analysis/Meromorphic/Order.lean
@@ -627,9 +627,6 @@ theorem meromorphicOrderAt_add_of_ne
 @[deprecated (since := "2025-05-22")]
 alias MeromorphicAt.order_add_of_order_ne := meromorphicOrderAt_add_of_ne
 
-@[deprecated (since := "2025-04-27")]
-alias MeromorphicAt.meromorphicOrderAt_add_of_unequal_order := meromorphicOrderAt_add_of_ne
-
 /-!
 ## Level Sets of the Order Function
 -/
@@ -687,9 +684,6 @@ theorem isClopen_setOf_meromorphicOrderAt_eq_top (hf : MeromorphicOn f U) :
     · apply (mem_diff w).1
       exact ⟨hw, mem_singleton_iff.not.1 (Subtype.coe_ne_coe.2 h₁w)⟩
 
-@[deprecated (since := "2025-04-27")]
-alias isClopen_setOf_order_eq_top := isClopen_setOf_meromorphicOrderAt_eq_top
-
 /-- On a connected set, there exists a point where a meromorphic function `f` has finite order iff
 `f` has finite order at every point. -/
 theorem exists_meromorphicOrderAt_ne_top_iff_forall (hf : MeromorphicOn f U) (hU : IsConnected U) :
@@ -710,9 +704,6 @@ theorem exists_meromorphicOrderAt_ne_top_iff_forall (hf : MeromorphicOn f U) (hU
     obtain ⟨v, hv⟩ := hU.nonempty
     use ⟨v, hv⟩, h₂f ⟨v, hv⟩
 
-@[deprecated (since := "2025-04-27")]
-alias exists_order_ne_top_iff_forall := exists_meromorphicOrderAt_ne_top_iff_forall
-
 /-- On a preconnected set, a meromorphic function has finite order at one point if it has finite
 order at another point. -/
 theorem meromorphicOrderAt_ne_top_of_isPreconnected (hf : MeromorphicOn f U) {y : 𝕜}
@@ -720,9 +711,6 @@ theorem meromorphicOrderAt_ne_top_of_isPreconnected (hf : MeromorphicOn f U) {y 
     meromorphicOrderAt f y ≠ ⊤ :=
   (hf.exists_meromorphicOrderAt_ne_top_iff_forall ⟨nonempty_of_mem h₁x, hU⟩).1
     (by use ⟨x, h₁x⟩) ⟨y, hy⟩
-
-@[deprecated (since := "2025-04-27")]
-alias order_ne_top_of_isPreconnected := meromorphicOrderAt_ne_top_of_isPreconnected
 
 /-- If a function is meromorphic on a set `U`, then for each point in `U`, it is analytic at nearby
 points in `U`. When the target space is complete, this can be strengthened to analyticity at all
@@ -780,9 +768,6 @@ theorem codiscrete_setOf_meromorphicOrderAt_eq_zero_or_top (hf : MeromorphicOn f
     rcases h₁a with h' | h'
     · simp +contextual [h'.meromorphicOrderAt_eq, h'.analyticOrderAt_eq_zero.2, h'₁a]
     · exact fun ha ↦ (h' ha).elim
-
-@[deprecated (since := "2025-04-27")]
-alias codiscrete_setOf_order_eq_zero_or_top := codiscrete_setOf_meromorphicOrderAt_eq_zero_or_top
 
 end MeromorphicOn
 

--- a/Mathlib/CategoryTheory/Bicategory/NaturalTransformation/Oplax.lean
+++ b/Mathlib/CategoryTheory/Bicategory/NaturalTransformation/Oplax.lean
@@ -208,8 +208,6 @@ structure OplaxTrans (F G : B ⥤ᵒᵖᴸ C) where
 attribute [reassoc (attr := simp)] OplaxTrans.naturality_naturality OplaxTrans.naturality_id
   OplaxTrans.naturality_comp
 
-@[deprecated (since := "2025-04-23")] alias _root_.CategoryTheory.OplaxNatTrans := OplaxTrans
-
 namespace OplaxTrans
 
 variable {F : B ⥤ᵒᵖᴸ C} {G H : B ⥤ᵒᵖᴸ C} (η : OplaxTrans F G) (θ : OplaxTrans G H)
@@ -331,8 +329,6 @@ structure StrongTrans (F G : B ⥤ᵒᵖᴸ C) where
         F.mapComp f g ▷ app c ≫ (α_ _ _ _).hom ≫ F.map f ◁ (naturality g).hom ≫
         (α_ _ _ _).inv ≫ (naturality f).hom ▷ G.map g ≫ (α_ _ _ _).hom := by
     cat_disch
-
-@[deprecated (since := "2025-04-23")] alias StrongOplaxNatTrans := StrongTrans
 
 attribute [nolint docBlame] CategoryTheory.Oplax.StrongTrans.app
   CategoryTheory.Oplax.StrongTrans.naturality

--- a/Mathlib/CategoryTheory/Limits/Constructions/FiniteProductsOfBinaryProducts.lean
+++ b/Mathlib/CategoryTheory/Limits/Constructions/FiniteProductsOfBinaryProducts.lean
@@ -157,11 +157,6 @@ lemma Limits.PreservesFiniteProducts.of_preserves_binary_and_terminal :
     haveI := preservesFinOfPreservesBinaryAndTerminal F n fun n => K.obj ⟨n⟩
     apply preservesLimit_of_iso_diagram F that
 
-@[deprecated PreservesFiniteProducts.of_preserves_binary_and_terminal (since := "2025-04-22")]
-lemma preservesShape_fin_of_preserves_binary_and_terminal (n : ℕ) :
-    PreservesLimitsOfShape (Discrete (Fin n)) F :=
-  have : PreservesFiniteProducts F := .of_preserves_binary_and_terminal _; inferInstance
-
 end Preserves
 
 /-- Given `n+1` objects of `C`, a cofan for the last `n` with point `c₁.pt`

--- a/Mathlib/CategoryTheory/Monoidal/Cartesian/Basic.lean
+++ b/Mathlib/CategoryTheory/Monoidal/Cartesian/Basic.lean
@@ -964,15 +964,6 @@ instance : Subsingleton F.Braided := (Braided.toMonoidal_injective F).subsinglet
 
 end Braided
 
-@[deprecated (since := "2025-04-24")]
-alias oplaxMonoidalOfChosenFiniteProducts := OplaxMonoidal.ofChosenFiniteProducts
-
-@[deprecated (since := "2025-04-24")]
-alias monoidalOfChosenFiniteProducts := Monoidal.ofChosenFiniteProducts
-
-@[deprecated (since := "2025-04-24")]
-alias braidedOfChosenFiniteProducts := Braided.ofChosenFiniteProducts
-
 namespace EssImageSubcategory
 variable [F.Full] [F.Faithful] [PreservesFiniteProducts F] {T X Y Z : F.EssImageSubcategory}
 

--- a/Mathlib/CategoryTheory/Monoidal/Closed/Ideal.lean
+++ b/Mathlib/CategoryTheory/Monoidal/Closed/Ideal.lean
@@ -330,9 +330,6 @@ lemma Limits.PreservesFiniteProducts.of_exponentialIdeal : PreservesFiniteProduc
   have : PreservesLimitsOfShape _ (reflector i) := leftAdjoint_preservesTerminal_of_reflective.{0} i
   .of_preserves_binary_and_terminal _
 
-@[deprecated (since := "2025-04-22")]
-alias preservesFiniteProducts_of_exponentialIdeal := PreservesFiniteProducts.of_exponentialIdeal
-
 end
 
 end CategoryTheory

--- a/Mathlib/Combinatorics/Additive/CauchyDavenport.lean
+++ b/Mathlib/Combinatorics/Additive/CauchyDavenport.lean
@@ -192,9 +192,6 @@ lemma cauchy_davenport_of_isMulTorsionFree [DecidableEq G] [Group G] [IsMulTorsi
   simpa only [Monoid.minOrder_eq_top, min_eq_right, le_top, Nat.cast_le]
     using cauchy_davenport_minOrder_mul hs ht
 
-@[to_additive (attr := deprecated cauchy_davenport_of_isMulTorsionFree (since := "2025-04-23"))]
-alias cauchy_davenport_mul_of_isTorsionFree := cauchy_davenport_of_isMulTorsionFree
-
 /-! ### $ℤ/nℤ$ -/
 
 /-- The **Cauchy-Davenport Theorem**. If `s`, `t` are nonempty sets in `ℤ/pℤ`, then the size of

--- a/Mathlib/Combinatorics/SimpleGraph/LapMatrix.lean
+++ b/Mathlib/Combinatorics/SimpleGraph/LapMatrix.lean
@@ -218,8 +218,4 @@ theorem card_connectedComponent_eq_finrank_ker_toLin'_lapMatrix :
   classical
   rw [Module.finrank_eq_card_basis (lapMatrix_ker_basis G)]
 
-@[deprecated (since := "2025-04-29")]
-alias card_ConnectedComponent_eq_rank_ker_lapMatrix :=
-  card_connectedComponent_eq_finrank_ker_toLin'_lapMatrix
-
 end SimpleGraph

--- a/Mathlib/Combinatorics/SimpleGraph/Paths.lean
+++ b/Mathlib/Combinatorics/SimpleGraph/Paths.lean
@@ -461,9 +461,6 @@ lemma IsCycle.getVert_sub_one_ne_getVert_add_one {i : ℕ} {p : G.Walk u u} (hpc
     (by simp only [Set.mem_setOf_eq]; lia) h'
   lia
 
-@[deprecated (since := "2025-04-27")]
-alias IsCycle.getVert_sub_one_neq_getVert_add_one := IsCycle.getVert_sub_one_ne_getVert_add_one
-
 /-! ### Walk decompositions -/
 
 section WalkDecomp

--- a/Mathlib/Data/ENNReal/Operations.lean
+++ b/Mathlib/Data/ENNReal/Operations.lean
@@ -244,8 +244,6 @@ lemma pow_ne_top_iff : a ^ n ≠ ∞ ↔ a ≠ ∞ ∨ n = 0 := WithTop.pow_ne_t
 
 lemma eq_top_of_pow (n : ℕ) (ha : a ^ n = ∞) : a = ∞ := WithTop.eq_top_of_pow n ha
 
-@[deprecated (since := "2025-04-24")] alias pow_eq_top := eq_top_of_pow
-
 @[aesop (rule_sets := [finiteness]) safe apply]
 lemma pow_ne_top (ha : a ≠ ∞) : a ^ n ≠ ∞ := WithTop.pow_ne_top ha
 lemma pow_lt_top (ha : a < ∞) : a ^ n < ∞ := WithTop.pow_lt_top ha

--- a/Mathlib/Data/Fin/Basic.lean
+++ b/Mathlib/Data/Fin/Basic.lean
@@ -457,9 +457,6 @@ theorem eq_zero (n : Fin 1) : n = 0 := Subsingleton.elim _ _
 
 lemma eq_one_of_ne_zero (i : Fin 2) (hi : i ≠ 0) : i = 1 := by lia
 
-@[deprecated (since := "2025-04-27")]
-alias eq_one_of_neq_zero := eq_one_of_ne_zero
-
 @[simp]
 theorem coe_neg_one : ↑(-1 : Fin (n + 1)) = n := by
   cases n

--- a/Mathlib/Data/List/Sigma.lean
+++ b/Mathlib/Data/List/Sigma.lean
@@ -78,9 +78,6 @@ theorem notMem_keys {a} {l : List (Sigma β)} : a ∉ l.keys ↔ ∀ b : β a, S
 theorem ne_key {a} {l : List (Sigma β)} : a ∉ l.keys ↔ ∀ s : Sigma β, s ∈ l → a ≠ s.1 := by
   grind
 
-@[deprecated (since := "2025-04-27")]
-alias not_eq_key := ne_key
-
 /-! ### `NodupKeys` -/
 
 

--- a/Mathlib/Dynamics/PeriodicPts/Defs.lean
+++ b/Mathlib/Dynamics/PeriodicPts/Defs.lean
@@ -214,9 +214,6 @@ theorem periodicPts_subset_range : periodicPts f ⊆ range f := by
   rw [← iterate_add_apply, Nat.add_sub_cancel' (by lia)]
   exact h
 
-@[deprecated (since := "2025-04-27")]
-alias periodicPts_subset_image := periodicPts_subset_range
-
 theorem isPeriodicPt_of_mem_periodicPts_of_isPeriodicPt_iterate (hx : x ∈ periodicPts f)
     (hm : IsPeriodicPt f m (f^[n] x)) : IsPeriodicPt f m x := by
   rcases hx with ⟨r, hr, hr'⟩
@@ -234,9 +231,6 @@ theorem bUnion_ptsOfPeriod : ⋃ n > 0, ptsOfPeriod f n = periodicPts f :=
 
 theorem iUnion_pnat_ptsOfPeriod : ⋃ n : ℕ+, ptsOfPeriod f n = periodicPts f :=
   iSup_subtype.trans <| bUnion_ptsOfPeriod f
-
-@[deprecated (since := "2025-04-27")]
-alias iUnion_pNat_ptsOfPeriod := iUnion_pnat_ptsOfPeriod
 
 variable {f}
 

--- a/Mathlib/Dynamics/PeriodicPts/Lemmas.lean
+++ b/Mathlib/Dynamics/PeriodicPts/Lemmas.lean
@@ -31,9 +31,6 @@ open Function (Commute)
 theorem directed_ptsOfPeriod_pnat (f : α → α) : Directed (· ⊆ ·) fun n : ℕ+ => ptsOfPeriod f n :=
   fun m n => ⟨m * n, fun _ hx => hx.mul_const n, fun _ hx => hx.const_mul m⟩
 
-@[deprecated (since := "2025-04-27")]
-alias directed_ptsOfPeriod_pNat := directed_ptsOfPeriod_pnat
-
 variable (f) in
 theorem bijOn_periodicPts : BijOn f (periodicPts f) (periodicPts f) :=
   iUnion_pnat_ptsOfPeriod f ▸
@@ -106,16 +103,10 @@ theorem Injective.mem_periodicPts [Finite α] (h : Injective f) (x : α) : x ∈
   · exact mk_mem_periodicPts (by lia) (iterate_cancel h heq.symm)
   · exact mk_mem_periodicPts (by lia) (iterate_cancel h heq)
 
-@[deprecated (since := "2025-04-27")]
-alias mem_periodicPts_of_injective := Injective.mem_periodicPts
-
 theorem injective_iff_periodicPts_eq_univ [Finite α] : Injective f ↔ periodicPts f = univ := by
   refine ⟨fun h ↦ eq_univ_iff_forall.mpr h.mem_periodicPts, fun h ↦ ?_⟩
   rw [Finite.injective_iff_surjective, ← range_eq_univ, ← univ_subset_iff, ← h]
   apply periodicPts_subset_range
-
-@[deprecated (since := "2025-04-27")]
-alias injective_iff_forall_mem_periodicPts := injective_iff_periodicPts_eq_univ
 
 theorem injective_iff_iterate_factorial_card_eq_id [Fintype α] :
     Injective f ↔ f^[(card α)!] = id := by

--- a/Mathlib/Geometry/Manifold/IsManifold/Basic.lean
+++ b/Mathlib/Geometry/Manifold/IsManifold/Basic.lean
@@ -806,9 +806,6 @@ instance instIsManifoldModelSpace {𝕜 : Type*} [NontriviallyNormedField 𝕜] 
     {I : ModelWithCorners 𝕜 E H} {n : WithTop ℕ∞} : IsManifold I n H :=
   { hasGroupoid_model_space _ _ with }
 
-@[deprecated (since := "2025-04-22")]
-alias intIsManifoldModelSpace := instIsManifoldModelSpace
-
 end IsManifold
 
 namespace IsManifold

--- a/Mathlib/LinearAlgebra/Matrix/NonsingularInverse.lean
+++ b/Mathlib/LinearAlgebra/Matrix/NonsingularInverse.lean
@@ -194,9 +194,6 @@ theorem nonsing_inv_eq_ringInverse : A⁻¹ = Ring.inverse A := by
   · have h := mt A.isUnit_iff_isUnit_det.mp h_det
     rw [Ring.inverse_non_unit _ h, nonsing_inv_apply_not_isUnit A h_det]
 
-@[deprecated (since := "2025-04-22")]
-alias nonsing_inv_eq_ring_inverse := nonsing_inv_eq_ringInverse
-
 theorem transpose_nonsing_inv : A⁻¹ᵀ = Aᵀ⁻¹ := by
   rw [inv_def, inv_def, transpose_smul, det_transpose, adjugate_transpose]
 

--- a/Mathlib/LinearAlgebra/Multilinear/Curry.lean
+++ b/Mathlib/LinearAlgebra/Multilinear/Curry.lean
@@ -303,8 +303,6 @@ lemma uncurrySum_smul
     uncurrySum (r • g) = r • uncurrySum g :=
   rfl
 
-@[deprecated (since := "2025-04-23")] alias uncurrySum_aux_apply := uncurrySum_apply
-
 @[simp]
 lemma uncurrySum_currySum (f : MultilinearMap R N M₂) :
     uncurrySum (currySum f) = f := by

--- a/Mathlib/LinearAlgebra/Projectivization/Independence.lean
+++ b/Mathlib/LinearAlgebra/Projectivization/Independence.lean
@@ -112,7 +112,4 @@ theorem dependent_pair_iff_eq (u v : ℙ K V) : Dependent ![u, v] ↔ u = v := b
 theorem independent_pair_iff_ne (u v : ℙ K V) : Independent ![u, v] ↔ u ≠ v := by
   rw [independent_iff_not_dependent, dependent_pair_iff_eq u v]
 
-@[deprecated (since := "2025-04-27")]
-alias independent_pair_iff_neq := independent_pair_iff_ne
-
 end Projectivization

--- a/Mathlib/MeasureTheory/Function/L2Space.lean
+++ b/Mathlib/MeasureTheory/Function/L2Space.lean
@@ -164,8 +164,6 @@ private theorem norm_sq_eq_re_inner (f : α →₂[μ] E) : ‖f‖ ^ 2 = RCLike
     rw [← h_two, ← eLpNorm_eq_eLpNorm' two_ne_zero ENNReal.ofNat_ne_top]
     finiteness
 
-@[deprecated (since := "2025-04-22")] alias norm_sq_eq_inner' := norm_sq_eq_re_inner
-
 theorem mem_L1_inner (f g : α →₂[μ] E) :
     AEEqFun.mk (fun x => ⟪f x, g x⟫)
         ((Lp.aestronglyMeasurable f).inner (Lp.aestronglyMeasurable g)) ∈

--- a/Mathlib/MeasureTheory/Group/Arithmetic.lean
+++ b/Mathlib/MeasureTheory/Group/Arithmetic.lean
@@ -531,13 +531,9 @@ lemma Measurable.fun_const_smul {g : α → β → X} {h : α → β} (hg : Meas
     (c : M) : Measurable fun a ↦ (c • g a) (h a) :=
   (hg.comp <| measurable_id.prodMk hh).const_smul _
 
-@[deprecated (since := "2025-04-23")] alias Measurable.const_smul' := Measurable.fun_const_smul
-
 @[to_additive (attr := fun_prop)]
 lemma AEMeasurable.fun_const_smul (hg : AEMeasurable g μ) (c : M) : AEMeasurable (c • g ·) μ :=
   (measurable_const_smul c).comp_aemeasurable hg
-
-@[deprecated (since := "2025-04-23")] alias AEMeasurable.const_smul' := AEMeasurable.fun_const_smul
 
 @[to_additive (attr := fun_prop)]
 lemma AEMeasurable.const_smul (hf : AEMeasurable g μ) (c : M) : AEMeasurable (c • g) μ :=

--- a/Mathlib/MeasureTheory/Integral/Average.lean
+++ b/Mathlib/MeasureTheory/Integral/Average.lean
@@ -127,13 +127,9 @@ theorem measure_mul_laverage [IsFiniteMeasure μ] (f : α → ℝ≥0∞) :
 theorem setLAverage_eq (f : α → ℝ≥0∞) (s : Set α) :
     ⨍⁻ x in s, f x ∂μ = (∫⁻ x in s, f x ∂μ) / μ s := by rw [laverage_eq, restrict_apply_univ]
 
-@[deprecated (since := "2025-04-22")] alias setLaverage_eq := setLAverage_eq
-
 theorem setLAverage_eq' (f : α → ℝ≥0∞) (s : Set α) :
     ⨍⁻ x in s, f x ∂μ = ∫⁻ x, f x ∂(μ s)⁻¹ • μ.restrict s := by
   simp only [laverage_eq', restrict_apply_univ]
-
-@[deprecated (since := "2025-04-22")] alias setLaverage_eq' := setLAverage_eq'
 
 variable {μ}
 
@@ -143,8 +139,6 @@ theorem laverage_congr {f g : α → ℝ≥0∞} (h : f =ᵐ[μ] g) : ⨍⁻ x, 
 theorem setLAverage_congr (h : s =ᵐ[μ] t) : ⨍⁻ x in s, f x ∂μ = ⨍⁻ x in t, f x ∂μ := by
   simp only [setLAverage_eq, setLIntegral_congr h, measure_congr h]
 
-@[deprecated (since := "2025-04-22")] alias setLaverage_congr := setLAverage_congr
-
 theorem setLAverage_congr_fun_ae (hs : MeasurableSet s) (h : ∀ᵐ x ∂μ, x ∈ s → f x = g x) :
     ⨍⁻ x in s, f x ∂μ = ⨍⁻ x in s, g x ∂μ := by
   simp only [laverage_eq, setLIntegral_congr_fun_ae hs h]
@@ -152,8 +146,6 @@ theorem setLAverage_congr_fun_ae (hs : MeasurableSet s) (h : ∀ᵐ x ∂μ, x �
 theorem setLAverage_congr_fun (hs : MeasurableSet s) (h : EqOn f g s) :
     ⨍⁻ x in s, f x ∂μ = ⨍⁻ x in s, g x ∂μ := by
   simp only [laverage_eq, setLIntegral_congr_fun hs h]
-
-@[deprecated (since := "2025-04-22")] alias setLaverage_congr_fun := setLAverage_congr_fun
 
 theorem laverage_lt_top (hf : ∫⁻ x, f x ∂μ ≠ ∞) : ⨍⁻ x, f x ∂μ < ∞ := by
   obtain rfl | hμ := eq_or_ne μ 0
@@ -164,8 +156,6 @@ theorem laverage_lt_top (hf : ∫⁻ x, f x ∂μ ≠ ∞) : ⨍⁻ x, f x ∂μ
 
 theorem setLAverage_lt_top : ∫⁻ x in s, f x ∂μ ≠ ∞ → ⨍⁻ x in s, f x ∂μ < ∞ :=
   laverage_lt_top
-
-@[deprecated (since := "2025-04-22")] alias setLaverage_lt_top := setLAverage_lt_top
 
 theorem laverage_add_measure :
     ⨍⁻ x, f x ∂(μ + ν) =
@@ -183,8 +173,6 @@ theorem measure_mul_setLAverage (f : α → ℝ≥0∞) (h : μ s ≠ ∞) :
     μ s * ⨍⁻ x in s, f x ∂μ = ∫⁻ x in s, f x ∂μ := by
   have := Fact.mk h.lt_top
   rw [← measure_mul_laverage, restrict_apply_univ]
-
-@[deprecated (since := "2025-04-22")] alias measure_mul_setLaverage := measure_mul_setLAverage
 
 theorem laverage_union (hd : AEDisjoint μ s t) (ht : NullMeasurableSet t μ) :
     ⨍⁻ x in s ∪ t, f x ∂μ =
@@ -228,15 +216,11 @@ theorem setLAverage_const (hs₀ : μ s ≠ 0) (hs : μ s ≠ ∞) (c : ℝ≥0�
   simp only [setLAverage_eq, lintegral_const, Measure.restrict_apply, MeasurableSet.univ,
     univ_inter, div_eq_mul_inv, mul_assoc, ENNReal.mul_inv_cancel hs₀ hs, mul_one]
 
-@[deprecated (since := "2025-04-22")] alias setLaverage_const := setLAverage_const
-
 theorem laverage_one [IsFiniteMeasure μ] [NeZero μ] : ⨍⁻ _x, (1 : ℝ≥0∞) ∂μ = 1 :=
   laverage_const _ _
 
 theorem setLAverage_one (hs₀ : μ s ≠ 0) (hs : μ s ≠ ∞) : ⨍⁻ _x in s, (1 : ℝ≥0∞) ∂μ = 1 :=
   setLAverage_const hs₀ hs _
-
-@[deprecated (since := "2025-04-22")] alias setLaverage_one := setLAverage_one
 
 @[simp]
 theorem laverage_mul_measure_univ (μ : Measure α) [IsFiniteMeasure μ] (f : α → ℝ≥0∞) :
@@ -252,8 +236,6 @@ theorem lintegral_laverage (μ : Measure α) [IsFiniteMeasure μ] (f : α → �
 theorem setLIntegral_setLAverage (μ : Measure α) [IsFiniteMeasure μ] (f : α → ℝ≥0∞) (s : Set α) :
     ∫⁻ _x in s, ⨍⁻ a in s, f a ∂μ ∂μ = ∫⁻ x in s, f x ∂μ :=
   lintegral_laverage _ _
-
-@[deprecated (since := "2025-04-22")] alias setLintegral_setLaverage := setLIntegral_setLAverage
 
 end ENNReal
 
@@ -481,8 +463,6 @@ theorem toReal_setLAverage {f : α → ℝ≥0∞} (hf : AEMeasurable f (μ.rest
     (⨍⁻ x in s, f x ∂μ).toReal = ⨍ x in s, (f x).toReal ∂μ := by
   simpa [laverage_eq] using toReal_laverage hf hf'
 
-@[deprecated (since := "2025-04-22")] alias toReal_setLaverage := toReal_setLAverage
-
 /-! ### First moment method -/
 
 section FirstMomentReal
@@ -645,8 +625,6 @@ theorem measure_le_setLAverage_pos (hμ : μ s ≠ 0) (hμ₁ : μ s ≠ ∞)
   simp_rw [ae_iff, not_ne_iff]
   exact measure_eq_top_of_lintegral_ne_top hf h
 
-@[deprecated (since := "2025-04-22")] alias measure_le_setLaverage_pos := measure_le_setLAverage_pos
-
 /-- **First moment method**. A measurable function is greater than its mean on a set of positive
 measure. -/
 theorem measure_setLAverage_le_pos (hμ : μ s ≠ 0) (hs : NullMeasurableSet s μ)
@@ -669,23 +647,17 @@ theorem measure_setLAverage_le_pos (hμ : μ s ≠ 0) (hs : NullMeasurableSet s 
   · simp_rw [ae_iff, not_ne_iff]
     exact measure_eq_top_of_lintegral_ne_top hg.aemeasurable hint
 
-@[deprecated (since := "2025-04-22")] alias measure_setLaverage_le_pos := measure_setLAverage_le_pos
-
 /-- **First moment method**. The minimum of a measurable function is smaller than its mean. -/
 theorem exists_le_setLAverage (hμ : μ s ≠ 0) (hμ₁ : μ s ≠ ∞) (hf : AEMeasurable f (μ.restrict s)) :
     ∃ x ∈ s, f x ≤ ⨍⁻ a in s, f a ∂μ :=
   let ⟨x, hx, h⟩ := nonempty_of_measure_ne_zero (measure_le_setLAverage_pos hμ hμ₁ hf).ne'
   ⟨x, hx, h⟩
 
-@[deprecated (since := "2025-04-22")] alias exists_le_setLaverage := exists_le_setLAverage
-
 /-- **First moment method**. The maximum of a measurable function is greater than its mean. -/
 theorem exists_setLAverage_le (hμ : μ s ≠ 0) (hs : NullMeasurableSet s μ)
     (hint : ∫⁻ a in s, f a ∂μ ≠ ∞) : ∃ x ∈ s, ⨍⁻ a in s, f a ∂μ ≤ f x :=
   let ⟨x, hx, h⟩ := nonempty_of_measure_ne_zero (measure_setLAverage_le_pos hμ hs hint).ne'
   ⟨x, hx, h⟩
-
-@[deprecated (since := "2025-04-22")] alias exists_setLaverage_le := exists_setLAverage_le
 
 /-- **First moment method**. A measurable function is greater than its mean on a set of positive
 measure. -/

--- a/Mathlib/MeasureTheory/Integral/Bochner/Basic.lean
+++ b/Mathlib/MeasureTheory/Integral/Bochner/Basic.lean
@@ -298,14 +298,8 @@ theorem integral_const_mul {L : Type*} [RCLike L] (r : L) (f : α → L) :
     ∫ a, r * f a ∂μ = r * ∫ a, f a ∂μ :=
   integral_smul r f
 
-@[deprecated (since := "2025-04-27")]
-alias integral_mul_left := integral_const_mul
-
 theorem integral_mul_const {L : Type*} [RCLike L] (r : L) (f : α → L) :
     ∫ a, f a * r ∂μ = (∫ a, f a ∂μ) * r := by simp only [mul_comm, integral_const_mul r f]
-
-@[deprecated (since := "2025-04-27")]
-alias integral_mul_right := integral_mul_const
 
 theorem integral_div {L : Type*} [RCLike L] (r : L) (f : α → L) :
     ∫ a, f a / r ∂μ = (∫ a, f a ∂μ) / r := by

--- a/Mathlib/MeasureTheory/Integral/Lebesgue/Basic.lean
+++ b/Mathlib/MeasureTheory/Integral/Lebesgue/Basic.lean
@@ -361,8 +361,6 @@ theorem setLIntegral_pos_iff {f : α → ℝ≥0∞} (hf : Measurable f) {s : Se
     0 < ∫⁻ a in s, f a ∂μ ↔ 0 < μ (Function.support f ∩ s) := by
   rw [lintegral_pos_iff_support hf, Measure.restrict_apply (measurableSet_support hf)]
 
-@[deprecated (since := "2025-04-22")] alias setLintegral_pos_iff := setLIntegral_pos_iff
-
 end
 
 /-- If `f` has finite integral, then `∫⁻ x in s, f x ∂μ` is absolutely continuous in `s`: it tends
@@ -642,8 +640,6 @@ theorem setLIntegral_compl {f : α → ℝ≥0∞} {s : Set α} (hsm : Measurabl
     (hfs : ∫⁻ x in s, f x ∂μ ≠ ∞) :
     ∫⁻ x in sᶜ, f x ∂μ = ∫⁻ x, f x ∂μ - ∫⁻ x in s, f x ∂μ := by
   rw [← lintegral_add_compl (μ := μ) f hsm, ENNReal.add_sub_cancel_left hfs]
-
-@[deprecated (since := "2025-04-22")] alias setLintegral_compl := setLIntegral_compl
 
 theorem setLIntegral_iUnion_of_directed {ι : Type*} [Countable ι]
     (f : α → ℝ≥0∞) {s : ι → Set α} (hd : Directed (· ⊆ ·) s) :

--- a/Mathlib/MeasureTheory/Integral/Lebesgue/Markov.lean
+++ b/Mathlib/MeasureTheory/Integral/Lebesgue/Markov.lean
@@ -91,9 +91,6 @@ theorem setLIntegral_eq_top_of_measure_eq_top_ne_zero {f : α → ℝ≥0∞} {s
   lintegral_eq_top_of_measure_eq_top_ne_zero hf <|
     mt (eq_bot_mono <| by rw [← setOf_inter_eq_sep]; exact Measure.le_restrict_apply _ _) hμf
 
-@[deprecated (since := "2025-04-22")]
-alias setLintegral_eq_top_of_measure_eq_top_ne_zero := setLIntegral_eq_top_of_measure_eq_top_ne_zero
-
 theorem measure_eq_top_of_lintegral_ne_top {f : α → ℝ≥0∞}
     (hf : AEMeasurable f μ) (hμf : ∫⁻ x, f x ∂μ ≠ ∞) : μ {x | f x = ∞} = 0 :=
   of_not_not fun h => hμf <| lintegral_eq_top_of_measure_eq_top_ne_zero hf h
@@ -102,9 +99,6 @@ theorem measure_eq_top_of_setLIntegral_ne_top {f : α → ℝ≥0∞} {s : Set �
     (hf : AEMeasurable f (μ.restrict s)) (hμf : ∫⁻ x in s, f x ∂μ ≠ ∞) :
     μ ({x ∈ s | f x = ∞}) = 0 :=
   of_not_not fun h => hμf <| setLIntegral_eq_top_of_measure_eq_top_ne_zero hf h
-
-@[deprecated (since := "2025-04-22")]
-alias measure_eq_top_of_setLintegral_ne_top := measure_eq_top_of_setLIntegral_ne_top
 
 /-- **Markov's inequality**, also known as **Chebyshev's first inequality**. -/
 theorem meas_ge_le_lintegral_div {f : α → ℝ≥0∞} (hf : AEMeasurable f μ) {ε : ℝ≥0∞} (hε : ε ≠ 0)

--- a/Mathlib/MeasureTheory/Integral/Lebesgue/Sub.lean
+++ b/Mathlib/MeasureTheory/Integral/Lebesgue/Sub.lean
@@ -178,9 +178,6 @@ theorem exists_setLIntegral_compl_lt {f : α → ℝ≥0∞} (hf : ∫⁻ a, f a
     _ < ε := ENNReal.sub_lt_of_lt_add (lintegral_mono hgf) <|
       ENNReal.lt_add_of_sub_lt_left (.inl hf) hgε
 
-@[deprecated (since := "2025-04-22")]
-alias exists_setLintegral_compl_lt := exists_setLIntegral_compl_lt
-
 /-- For any function `f : α → ℝ≥0∞`, there exists a measurable function `g ≤ f` with the same
 integral over any measurable set. -/
 theorem exists_measurable_le_setLIntegral_eq_of_integrable {f : α → ℝ≥0∞} (hf : ∫⁻ a, f a ∂μ ≠ ∞) :
@@ -194,10 +191,6 @@ theorem exists_measurable_le_setLIntegral_eq_of_integrable {f : α → ℝ≥0�
   · rw [hifg] at hf
     exact ne_top_of_le_ne_top hf (setLIntegral_le_lintegral _ _)
   · exact ne_top_of_le_ne_top hf (setLIntegral_le_lintegral _ _)
-
-@[deprecated (since := "2025-04-22")]
-alias exists_measurable_le_setLintegral_eq_of_integrable :=
-  exists_measurable_le_setLIntegral_eq_of_integrable
 
 end UnifTight
 

--- a/Mathlib/Order/Filter/AtTopBot/Basic.lean
+++ b/Mathlib/Order/Filter/AtTopBot/Basic.lean
@@ -459,18 +459,6 @@ theorem not_bddAbove_of_tendsto_atTop [NoMaxOrder β] (h : Tendsto f l atTop) :
 theorem not_bddBelow_of_tendsto_atBot [NoMinOrder β] (h : Tendsto f l atBot) :
     ¬BddBelow (range f) := not_bddAbove_of_tendsto_atTop (β := βᵒᵈ) h
 
-@[deprecated (since := "2025-04-28")]
-alias unbounded_of_tendsto_atTop := not_bddAbove_of_tendsto_atTop
-
-@[deprecated (since := "2025-04-28")]
-alias unbounded_of_tendsto_atBot := not_bddBelow_of_tendsto_atBot
-
-@[deprecated (since := "2025-04-28")]
-alias unbounded_of_tendsto_atTop' := not_bddAbove_of_tendsto_atTop
-
-@[deprecated (since := "2025-04-28")]
-alias unbounded_of_tendsto_atBot' := not_bddBelow_of_tendsto_atBot
-
 end NeBot
 
 theorem HasAntitoneBasis.eventually_subset [Preorder ι] {l : Filter α} {s : ι → Set α}

--- a/Mathlib/Order/Interval/Finset/Nat.lean
+++ b/Mathlib/Order/Interval/Finset/Nat.lean
@@ -95,10 +95,11 @@ theorem card_Iio : #(Iio b) = b := by rw [Iio_eq_Ico, card_Ico, Nat.bot_eq_zero,
 @[simp]
 theorem Ico_succ_singleton : Ico a (a + 1) = {a} := by grind
 
-set_option linter.deprecated false in
 @[simp]
 theorem Ico_pred_singleton {a : ℕ} (h : 0 < a) : Ico (a - 1) a = {a - 1} := by
-  rw [← Icc_pred_right _ h, Icc_self]
+  ext x
+  rw [mem_Ico, mem_singleton]
+  lia
 
 @[simp]
 theorem Ioc_succ_singleton : Ioc b (b + 1) = {b + 1} := by grind
@@ -126,11 +127,15 @@ theorem Ico_image_const_sub_eq_Ico (hac : a ≤ c) :
   rintro ⟨x, hx, rfl⟩
   lia
 
-set_option linter.deprecated false in
 theorem Ico_succ_left_eq_erase_Ico : Ico a.succ b = erase (Ico a b) a := by
   ext x
-  rw [Ico_succ_left, mem_erase, mem_Ico, mem_Ioo, ← and_assoc, ne_comm,
-    and_comm (a := a ≠ x), lt_iff_le_and_ne]
+  simp_rw [mem_erase, mem_Ico]
+  lia
+
+theorem Ico_succ_right_eq_insert_Ico (h : a ≤ b) : Ico a b.succ = insert b (Ico a b) := by
+  ext x
+  simp_rw [mem_insert, mem_Ico]
+  lia
 
 set_option linter.deprecated false in
 theorem mod_injOn_Ico (n a : ℕ) : Set.InjOn (· % a) (Finset.Ico n (n + a)) := by

--- a/Mathlib/Order/Interval/Finset/Nat.lean
+++ b/Mathlib/Order/Interval/Finset/Nat.lean
@@ -90,31 +90,6 @@ lemma card_Iic : #(Iic b) = b + 1 := by rw [Iic_eq_Icc, card_Icc, Nat.bot_eq_zer
 @[simp]
 theorem card_Iio : #(Iio b) = b := by rw [Iio_eq_Ico, card_Ico, Nat.bot_eq_zero, Nat.sub_zero]
 
-@[deprecated Finset.Icc_succ_left_eq_Ioc (since := "2025-04-24")]
-theorem Icc_succ_left : Icc a.succ b = Ioc a b := by
-  ext x
-  rw [mem_Icc, mem_Ioc, succ_le_iff]
-
-@[deprecated Finset.Ico_succ_right_eq_Icc (since := "2025-04-24")]
-theorem Ico_succ_right : Ico a b.succ = Icc a b := by
-  ext x
-  rw [mem_Ico, mem_Icc, Nat.lt_succ_iff]
-
-@[deprecated Finset.Ico_succ_left_eq_Ioo (since := "2025-04-24")]
-theorem Ico_succ_left : Ico a.succ b = Ioo a b := by
-  ext x
-  rw [mem_Ico, mem_Ioo, succ_le_iff]
-
-@[deprecated Finset.Icc_pred_right_eq_Ico (since := "2025-04-24")]
-theorem Icc_pred_right {b : ℕ} (h : 0 < b) : Icc a (b - 1) = Ico a b := by
-  ext x
-  rw [mem_Icc, mem_Ico, lt_iff_le_pred h]
-
-@[deprecated Finset.Ico_succ_succ_eq_Ioc (since := "2025-04-24")]
-theorem Ico_succ_succ : Ico a.succ b.succ = Ioc a b := by
-  ext x
-  rw [mem_Ico, mem_Ioc, succ_le_iff, Nat.lt_succ_iff]
-
 -- TODO: Generalise the following series of lemmas.
 
 @[simp]
@@ -134,28 +109,6 @@ lemma mem_Ioc_succ : a ∈ Ioc b (b + 1) ↔ a = b + 1 := by simp
 
 lemma mem_Ioc_succ' (a : Ioc b (b + 1)) : a = ⟨b + 1, mem_Ioc.2 (by lia)⟩ :=
   Subtype.val_inj.1 (mem_Ioc_succ.1 a.2)
-
-set_option linter.deprecated false in
-@[deprecated Finset.insert_Ico_right_eq_Ico_succ (since := "2025-04-24")]
-theorem Ico_succ_right_eq_insert_Ico (h : a ≤ b) : Ico a (b + 1) = insert b (Ico a b) := by
-  rw [Ico_succ_right, ← Ico_insert_right h]
-
-set_option linter.deprecated false in
-@[deprecated Finset.insert_Ico_succ_left_eq_Ico (since := "2025-04-24")]
-theorem Ico_insert_succ_left (h : a < b) : insert a (Ico a.succ b) = Ico a b := by
-  rw [Ico_succ_left, ← Ioo_insert_left h]
-
-@[deprecated Finset.insert_Icc_succ_left_eq_Icc (since := "2025-04-24")]
-lemma Icc_insert_succ_left (h : a ≤ b) : insert a (Icc (a + 1) b) = Icc a b := by
-  ext x
-  simp only [mem_insert, mem_Icc]
-  lia
-
-@[deprecated Finset.insert_Icc_right_eq_Icc_succ (since := "2025-04-24")]
-lemma Icc_insert_succ_right (h : a ≤ b + 1) : insert (b + 1) (Icc a b) = Icc a (b + 1) := by
-  ext x
-  simp only [mem_insert, mem_Icc]
-  lia
 
 theorem image_sub_const_Ico (h : c ≤ a) :
     ((Ico a b).image fun x => x - c) = Ico (a - c) (b - c) := by

--- a/Mathlib/RepresentationTheory/Tannaka.lean
+++ b/Mathlib/RepresentationTheory/Tannaka.lean
@@ -117,9 +117,6 @@ lemma equivHom_injective [Nontrivial k] : Function.Injective (equivHom k G) := b
   apply_fun (fun x ↦ (x.hom.hom.app rightFDRep).hom (single t 1) 1) at h
   simp_all [single_apply]
 
-@[deprecated (since := "2025-04-27")]
-alias equivHom_inj := equivHom_injective
-
 /-- The `FDRep k G` morphism induced by multiplication on `G → k`. -/
 def mulRepHom : rightFDRep (k := k) (G := G) ⊗ rightFDRep ⟶ rightFDRep where
   hom := ofHom (LinearMap.mul' k (G → k))

--- a/Mathlib/RingTheory/DedekindDomain/AdicValuation.lean
+++ b/Mathlib/RingTheory/DedekindDomain/AdicValuation.lean
@@ -181,10 +181,6 @@ theorem intValuation_def {r : R} :
     exp (-(Associates.mk v.asIdeal).count (Associates.mk (Ideal.span {r} : Ideal R)).factors : ℤ) :=
   rfl
 
-@[deprecated intValuation_apply (since := "2025-04-26")]
-theorem intValuation_toFun (r : R) :
-    v.intValuation r = v.intValuationDef r := rfl
-
 open scoped Classical in
 theorem intValuation_if_neg {r : R} (hr : r ≠ 0) :
     v.intValuation r = exp

--- a/Mathlib/RingTheory/Polynomial/Eisenstein/Distinguished.lean
+++ b/Mathlib/RingTheory/Polynomial/Eisenstein/Distinguished.lean
@@ -47,9 +47,6 @@ lemma map_eq_X_pow {f : R[X]} {I : Ideal R} (distinguish : f.IsDistinguishedAt I
     · simpa [ne, eq_zero_iff_mem] using (distinguish.mem lt)
     · simp [ne, Polynomial.coeff_eq_zero_of_natDegree_lt gt]
 
-@[deprecated (since := "2025-04-27")]
-alias _root_.IsDistinguishedAt.map_eq_X_pow := map_eq_X_pow
-
 section degree_eq_order_map
 
 variable {I : Ideal R} (f h : R⟦X⟧) {g : R[X]}
@@ -78,9 +75,6 @@ lemma degree_eq_coe_lift_order_map (distinguish : g.IsDistinguishedAt I)
   · simp [mapf, PowerSeries.coeff_X_pow_mul', eq_zero_iff_mem, notMem]
   · intro i hi
     simp [mapf, PowerSeries.coeff_X_pow_mul', hi]
-
-@[deprecated (since := "2025-04-27")]
-alias _root_.IsDistinguishedAt.degree_eq_order_map := degree_eq_coe_lift_order_map
 
 @[deprecated (since := "2025-05-19")]
 alias degree_eq_order_map := degree_eq_coe_lift_order_map

--- a/Mathlib/SetTheory/Cardinal/Basic.lean
+++ b/Mathlib/SetTheory/Cardinal/Basic.lean
@@ -599,9 +599,6 @@ theorem mk_int : #ℤ = ℵ₀ :=
 theorem mk_pnat : #ℕ+ = ℵ₀ :=
   mk_denumerable ℕ+
 
-@[deprecated (since := "2025-04-27")]
-alias mk_pNat := mk_pnat
-
 /-! ### Cardinalities of basic sets and types -/
 
 @[simp] theorem mk_additive : #(Additive α) = #α := rfl

--- a/Mathlib/Topology/Algebra/Module/Equiv.lean
+++ b/Mathlib/Topology/Algebra/Module/Equiv.lean
@@ -1177,8 +1177,6 @@ theorem ringInverse_equiv (e : M ≃L[R] M) : Ring.inverse ↑e = inverse (e : M
   simp
   rfl
 
-@[deprecated (since := "2025-04-22")] alias ring_inverse_equiv := ringInverse_equiv
-
 /-- The function `ContinuousLinearEquiv.inverse` can be written in terms of `Ring.inverse` for the
 ring of self-maps of the domain. -/
 theorem inverse_eq_ringInverse (e : M ≃L[R] M₂) (f : M →L[R] M₂) :
@@ -1198,14 +1196,9 @@ theorem inverse_eq_ringInverse (e : M ≃L[R] M₂) (f : M →L[R] M₂) :
     rw [hF]
     simp
 
-@[deprecated (since := "2025-04-22")] alias to_ring_inverse := inverse_eq_ringInverse
-
 theorem ringInverse_eq_inverse : Ring.inverse = inverse (R := R) (M := M) := by
   ext
   simp [inverse_eq_ringInverse (ContinuousLinearEquiv.refl R M)]
-
-@[deprecated (since := "2025-04-22")]
-alias ring_inverse_eq_map_inverse := ringInverse_eq_inverse
 
 @[simp] theorem inverse_id : (ContinuousLinearMap.id R M).inverse = .id R M := by
   rw [← ringInverse_eq_inverse]

--- a/Mathlib/Topology/Algebra/Order/Field.lean
+++ b/Mathlib/Topology/Algebra/Order/Field.lean
@@ -193,15 +193,9 @@ lemma inv_nhdsLT_zero : (𝓝[<] (0 : 𝕜))⁻¹ = atBot := by
 theorem tendsto_inv_nhdsLT_zero : Tendsto (fun x : 𝕜 => x⁻¹) (𝓝[<] (0 : 𝕜)) atBot :=
   inv_nhdsLT_zero.le
 
-@[deprecated (since := "2025-04-23")]
-alias tendsto_inv_zero_atBot := tendsto_inv_nhdsLT_zero
-
 /-- The function `r ↦ r⁻¹` tends to `0` on the left as `r → -∞`. -/
 theorem tendsto_inv_atBot_nhdsLT_zero : Tendsto (fun r : 𝕜 => r⁻¹) atBot (𝓝[<] (0 : 𝕜)) :=
   inv_atBot₀.le
-
-@[deprecated (since := "2025-04-23")]
-alias tendsto_inv_atBot_zero' := tendsto_inv_atBot_nhdsLT_zero
 
 theorem tendsto_inv_atBot_zero : Tendsto (fun r : 𝕜 => r⁻¹) atBot (𝓝 0) :=
   tendsto_inv_atBot_nhdsLT_zero.mono_right inf_le_left

--- a/Mathlib/Topology/Algebra/Valued/ValuationTopology.lean
+++ b/Mathlib/Topology/Algebra/Valued/ValuationTopology.lean
@@ -266,9 +266,6 @@ theorem isClosed_sphere (r : Γ₀) : IsClosed (X := R) {x | v x = r} := by
 theorem isOpen_integer : IsOpen (_i.v.integer : Set R) :=
   isOpen_closedBall _ one_ne_zero
 
-@[deprecated (since := "2025-04-25")]
-alias integer_isOpen := isOpen_integer
-
 /-- The closed unit ball of a valued ring is closed. -/
 theorem isClosed_integer : IsClosed (_i.v.integer : Set R) :=
   isClosed_closedBall _ _
@@ -281,9 +278,6 @@ theorem isClopen_integer : IsClopen (_i.v.integer : Set R) :=
 theorem isOpen_valuationSubring (K : Type u) [Field K] [hv : Valued K Γ₀] :
     IsOpen (hv.v.valuationSubring : Set K) :=
   isOpen_integer K
-
-@[deprecated (since := "2025-04-25")]
-alias valuationSubring_isOpen := isOpen_valuationSubring
 
 /-- The valuation subring of a valued field is closed. -/
 theorem isClosed_valuationSubring (K : Type u) [Field K] [hv : Valued K Γ₀] :

--- a/Mathlib/Topology/UniformSpace/Defs.lean
+++ b/Mathlib/Topology/UniformSpace/Defs.lean
@@ -176,8 +176,6 @@ theorem Monotone.compRel [Preorder β] {f g : β → SetRel α α} (hf : Monoton
 @[deprecated (since := "2025-10-17")] alias compRel_left_mono := SetRel.comp_subset_comp_left
 @[deprecated (since := "2025-10-17")] alias compRel_right_mono := SetRel.comp_subset_comp_right
 @[deprecated (since := "2025-10-17")] alias prodMk_mem_compRel := SetRel.prodMk_mem_comp
-@[deprecated (since := "2025-03-10")] alias prod_mk_mem_compRel := SetRel.prodMk_mem_comp
-
 set_option linter.deprecated false in
 @[deprecated SetRel.id_comp (since := "2025-10-17")]
 theorem id_compRel {r : SetRel α α} : idRel ○ r = r :=


### PR DESCRIPTION
I undeprecate `Nat.Ico_succ_right_eq_insert_Ico`, since it is a natural counterpart to the nondeprecated `Nat.Ico_succ_left_eq_erase_Ico`.