### PR TITLE
chore: make various constructions on `Hyperreal` computable

### DIFF
--- a/Mathlib/Analysis/Real/Hyperreal.lean
+++ b/Mathlib/Analysis/Real/Hyperreal.lean
@@ -138,7 +138,7 @@ theorem coe_min (x y : ℝ) : ((min x y : ℝ) : ℝ*) = min ↑x ↑y :=
   Germ.const_min _ _
 
 /-- Construct a hyperreal number from a sequence of real numbers. -/
-noncomputable def ofSeq (f : ℕ → ℝ) : ℝ* := (↑f : Germ (hyperfilter ℕ : Filter ℕ) ℝ)
+def ofSeq (f : ℕ → ℝ) : ℝ* := (↑f : Germ (hyperfilter ℕ : Filter ℕ) ℝ)
 
 theorem ofSeq_surjective : Function.Surjective ofSeq := Quot.exists_rep
 
@@ -150,7 +150,7 @@ noncomputable def epsilon : ℝ* :=
   ofSeq fun n => n⁻¹
 
 /-- A sample infinite hyperreal -/
-noncomputable def omega : ℝ* := ofSeq Nat.cast
+def omega : ℝ* := ofSeq Nat.cast
 
 @[inherit_doc] scoped notation "ε" => Hyperreal.epsilon
 @[inherit_doc] scoped notation "ω" => Hyperreal.omega

--- a/Mathlib/Analysis/Real/Hyperreal.lean
+++ b/Mathlib/Analysis/Real/Hyperreal.lean
@@ -25,27 +25,34 @@ namespace Hyperreal
 
 @[inherit_doc] notation "ℝ*" => Hyperreal
 
-/-- Natural embedding `ℝ → ℝ*`. -/
-@[coe] def ofReal (r : ℝ) : ℝ* :=
-  ofFun <| Function.const _ r
+/-- Construct a hyperreal number from a sequence of real numbers. -/
+def ofSeq (f : ℕ → ℝ) : ℝ* := (↑f : Germ (hyperfilter ℕ : Filter ℕ) ℝ)
+
+theorem ofSeq_surjective : Function.Surjective ofSeq := Quot.exists_rep
 
 instance : Zero ℝ* where
-  zero := ofReal 0
+  zero := ofSeq 0
 
 instance : One ℝ* where
-  one := ofReal 1
+  one := ofSeq 1
 
 instance : Inhabited ℝ* where
   default := 0
 
-noncomputable instance : Field ℝ* :=
-  inferInstanceAs (Field (Germ _ _))
+noncomputable instance : Field ℝ* where
+  zero := 0
+  one := 1
+  __ := inferInstanceAs (Field (Germ _ _))
 
 noncomputable instance : LinearOrder ℝ* :=
   inferInstanceAs (LinearOrder (Germ _ _))
 
 instance : IsStrictOrderedRing ℝ* :=
   inferInstanceAs (IsStrictOrderedRing (Germ _ _))
+
+/-- Natural embedding `ℝ → ℝ*`. -/
+@[coe] def ofReal (r : ℝ) : ℝ* :=
+  ofSeq (Function.const _ r)
 
 noncomputable instance : CoeTC ℝ ℝ* := ⟨ofReal⟩
 
@@ -136,11 +143,6 @@ theorem coe_max (x y : ℝ) : ((max x y : ℝ) : ℝ*) = max ↑x ↑y :=
 @[simp, norm_cast]
 theorem coe_min (x y : ℝ) : ((min x y : ℝ) : ℝ*) = min ↑x ↑y :=
   Germ.const_min _ _
-
-/-- Construct a hyperreal number from a sequence of real numbers. -/
-def ofSeq (f : ℕ → ℝ) : ℝ* := (↑f : Germ (hyperfilter ℕ : Filter ℕ) ℝ)
-
-theorem ofSeq_surjective : Function.Surjective ofSeq := Quot.exists_rep
 
 theorem ofSeq_lt_ofSeq {f g : ℕ → ℝ} : ofSeq f < ofSeq g ↔ ∀ᶠ n in hyperfilter ℕ, f n < g n :=
   Germ.coe_lt

--- a/Mathlib/Analysis/Real/Hyperreal.lean
+++ b/Mathlib/Analysis/Real/Hyperreal.lean
@@ -21,15 +21,22 @@ open Filter Germ Topology
 def Hyperreal : Type :=
   Germ (hyperfilter ℕ : Filter ℕ) ℝ
 
-#adaptation_note
-/-- After nightly-2025-05-07 we had to remove `deriving Inhabited` on `Hyperreal` above,
-as there is a new error about this instance having to be noncomputable, and `deriving` doesn't allow
-for adding this! -/
 namespace Hyperreal
 
-
-
 @[inherit_doc] notation "ℝ*" => Hyperreal
+
+/-- Natural embedding `ℝ → ℝ*`. -/
+@[coe] def ofReal (r : ℝ) : ℝ* :=
+  ofFun <| Function.const _ r
+
+instance : Zero ℝ* where
+  zero := ofReal 0
+
+instance : One ℝ* where
+  one := ofReal 1
+
+instance : Inhabited ℝ* where
+  default := 0
 
 noncomputable instance : Field ℝ* :=
   inferInstanceAs (Field (Germ _ _))
@@ -39,9 +46,6 @@ noncomputable instance : LinearOrder ℝ* :=
 
 instance : IsStrictOrderedRing ℝ* :=
   inferInstanceAs (IsStrictOrderedRing (Germ _ _))
-
-/-- Natural embedding `ℝ → ℝ*`. -/
-@[coe] noncomputable def ofReal : ℝ → ℝ* := const
 
 noncomputable instance : CoeTC ℝ ℝ* := ⟨ofReal⟩
 


### PR DESCRIPTION
---
<!-- Your PR title will become the first line of the commit message.

In this box, the text above the `---` (if not empty) will be appended
to the commit message, and can be used to give additional context or
details. Please leave a blank newline before the `---`, otherwise GitHub
will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

When merging, all the commits will be squashed into a single commit
listing all co-authors.

Co-authors in the squash commit are gathered from two sources:

First, all authors of commits to this PR branch are included. Thus,
one way to add co-authors is to include at least one commit authored by
each co-author among the commits in the pull request. If necessary, you
may create empty commits to indicate co-authorship, using commands like so:

git commit --author="Author Name <author@email.com>" --allow-empty -m "add Author Name as coauthor"

Second, co-authors can also be listed in lines at the very bottom of
the commit message (that is, directly before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines
at the bottom of the commit message (before the `---`, and also before
any "Co-authored-by" lines) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

Whatever practical use this has I don't know, but it gets rid of an adaptation note.

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
