### PR TITLE
[Merged by Bors] - chore: golf using `grind` and `lia`

### DIFF
--- a/Mathlib/Computability/Ackermann.lean
+++ b/Mathlib/Computability/Ackermann.lean
@@ -230,18 +230,7 @@ theorem ack_succ_right_le_ack_succ_left (m n : ℕ) : ack m (n + 1) ≤ ack (m +
 private theorem sq_le_two_pow_add_one_minus_three (n : ℕ) : n ^ 2 ≤ 2 ^ (n + 1) - 3 := by
   induction n with
   | zero => simp
-  | succ k hk =>
-    rcases k with - | k
-    · simp
-    · rw [add_sq, Nat.pow_succ 2, mul_comm _ 2, two_mul (2 ^ _),
-          add_tsub_assoc_of_le, add_comm (2 ^ _), add_assoc]
-      · apply Nat.add_le_add hk
-        norm_num
-        apply succ_le_of_lt
-        rw [Nat.pow_succ, mul_comm _ 2, mul_lt_mul_iff_right₀ (zero_lt_two' ℕ)]
-        exact Nat.lt_two_pow_self
-      · rw [Nat.pow_succ, Nat.pow_succ]
-        linarith [one_le_pow k 2 zero_lt_two]
+  | succ k => cases k <;> lia
 
 theorem ack_add_one_sq_lt_ack_add_three : ∀ m n, (ack m n + 1) ^ 2 ≤ ack (m + 3) n
   | 0, n => by simpa using sq_le_two_pow_add_one_minus_three (n + 2)

--- a/Mathlib/Data/Fin/SuccPred.lean
+++ b/Mathlib/Data/Fin/SuccPred.lean
@@ -160,9 +160,7 @@ lemma _root_.finCongr_eq_equivCast (h : n = m) : finCongr h = .cast (h ▸ rfl) 
 /-- While in many cases `Fin.cast` is better than `Equiv.cast`/`cast`, sometimes we want to apply
 a generic theorem about `cast`. -/
 theorem cast_eq_cast (h : n = m) : (Fin.cast h : Fin n → Fin m) = _root_.cast (h ▸ rfl) := by
-  subst h
-  ext
-  rfl
+  grind
 
 theorem castSucc_le_succ {n} (i : Fin n) : i.castSucc ≤ i.succ := Nat.le_succ i
 
@@ -239,10 +237,7 @@ theorem succ_ne_last_iff (a : Fin (n + 1)) : succ a ≠ last (n + 1) ↔ a ≠ l
   not_iff_not.mpr <| succ_eq_last_succ
 
 theorem succ_ne_last_of_lt {p i : Fin n} (h : i < p) : succ i ≠ last n := by
-  cases n
-  · exact i.elim0
-  · rw [succ_ne_last_iff, Ne, Fin.ext_iff]
-    exact ((le_last _).trans_lt' h).ne
+  grind
 
 open Fin.NatCast in
 @[norm_cast, simp]

--- a/Mathlib/Data/Holor.lean
+++ b/Mathlib/Data/Holor.lean
@@ -292,10 +292,7 @@ theorem cprankMax_sum [NonUnitalNonAssocSemiring α] {β} {n : ℕ} (s : Finset 
       simp only [Finset.sum_insert h_x_notin_s, Finset.card_insert_of_notMem h_x_notin_s]
       rw [Nat.right_distrib]
       simp only [Nat.one_mul, Nat.add_comm]
-      have ih' : CPRankMax (Finset.card s * n) (∑ x ∈ s, f x) := by
-        apply ih
-        intro (x : β) (h_x_in_s : x ∈ s)
-        simp only [h_cprank, Finset.mem_insert_of_mem, h_x_in_s]
+      have ih' : CPRankMax (Finset.card s * n) (∑ x ∈ s, f x) := by grind
       exact cprankMax_add (h_cprank x (Finset.mem_insert_self x s)) ih')
 
 theorem cprankMax_upper_bound [Semiring α] : ∀ {ds}, ∀ x : Holor α ds, CPRankMax ds.prod x

--- a/Mathlib/Data/Int/Init.lean
+++ b/Mathlib/Data/Int/Init.lean
@@ -300,8 +300,7 @@ lemma le_add_iff_lt_of_dvd_sub (ha : 0 < a) (hab : a ∣ c - b) : a + b ≤ c �
 /-! ### sign -/
 
 lemma sign_add_eq_of_sign_eq : ∀ {m n : ℤ}, m.sign = n.sign → (m + n).sign = n.sign := by
-  have : (1 : ℤ) ≠ -1 := by decide
-  rintro ((_ | m) | m) ((_ | n) | n) <;> simp [this, this.symm] <;> lia
+  lia
 
 /-! ### toNat -/
 

--- a/Mathlib/Geometry/Euclidean/Circumcenter.lean
+++ b/Mathlib/Geometry/Euclidean/Circumcenter.lean
@@ -124,18 +124,7 @@ theorem existsUnique_dist_eq_of_insert {s : AffineSubspace ℝ P}
         (vsub_orthogonalProjection_mem_direction_orthogonal s p),
       Real.norm_eq_abs, abs_mul_abs_self, dist_comm, ← dist_eq_norm_vsub V p,
       Real.mul_self_sqrt (add_nonneg (mul_self_nonneg _) (mul_self_nonneg _))] at hcr₃
-    change x * x + _ * (y * y) = _ at hcr₃
-    rw [show
-        x * x + (1 - t₃) * (1 - t₃) * (y * y) = x * x + y * y - 2 * y * (t₃ * y) + t₃ * y * (t₃ * y)
-        by ring,
-      add_left_inj] at hcr₃
-    have ht₃ : t₃ = ycc₂ / y := by simp [ycc₂, ← hcr₃, hy0]
-    subst ht₃
-    change cc₃ = cc₂ at hcc₃''
-    congr
-    rw [hcr₃val]
-    congr 2
-    field
+    grind
 
 /-- Given a finite nonempty affinely independent family of points,
 there is a unique (circumcenter, circumradius) pair for those points


### PR DESCRIPTION
---
Trace profiling results (shown if ≥10 ms before or after):
* `Fin.cast_eq_cast`: <10 ms before, 23 ms after
* `Fin.succ_ne_last_of_lt`: <10 ms before, 42 ms after
* `Holor.cprankMax_sum`: 24 ms before, 94 ms after
* `Int.sign_add_eq_of_sign_eq`: 26 ms before, 21 ms after  🎉
* `EuclideanGeometry.existsUnique_dist_eq_of_insert`: 886 ms before, 935 ms after

This golfing PR is batched under the following guidelines:
* Up to ~5 changed files per PR
* Up to ~25 changed declarations per PR
* Up to ~100 changed lines per PR

---
<!-- Your PR title will become the first line of the commit message.

In this box, the text above the `---` (if not empty) will be appended
to the commit message, and can be used to give additional context or
details. Please leave a blank newline before the `---`, otherwise GitHub
will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

When merging, all the commits will be squashed into a single commit
listing all co-authors.

Co-authors in the squash commit are gathered from two sources:

First, all authors of commits to this PR branch are included. Thus,
one way to add co-authors is to include at least one commit authored by
each co-author among the commits in the pull request. If necessary, you
may create empty commits to indicate co-authorship, using commands like so:

git commit --author="Author Name <author@email.com>" --allow-empty -m "add Author Name as coauthor"

Second, co-authors can also be listed in lines at the very bottom of
the commit message (that is, directly before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines
at the bottom of the commit message (before the `---`, and also before
any "Co-authored-by" lines) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
