### PR TITLE
[Merged by Bors] - feat(RingTheory/MvPowerSeries): some APIs about `expand`

### DIFF
--- a/Mathlib.lean
+++ b/Mathlib.lean
@@ -6096,6 +6096,7 @@ public import Mathlib.RingTheory.MvPolynomial.Tower
 public import Mathlib.RingTheory.MvPolynomial.WeightedHomogeneous
 public import Mathlib.RingTheory.MvPowerSeries.Basic
 public import Mathlib.RingTheory.MvPowerSeries.Evaluation
+public import Mathlib.RingTheory.MvPowerSeries.Expand
 public import Mathlib.RingTheory.MvPowerSeries.Inverse
 public import Mathlib.RingTheory.MvPowerSeries.LexOrder
 public import Mathlib.RingTheory.MvPowerSeries.LinearTopology
@@ -6192,6 +6193,7 @@ public import Mathlib.RingTheory.PowerSeries.Catalan
 public import Mathlib.RingTheory.PowerSeries.CoeffMulMem
 public import Mathlib.RingTheory.PowerSeries.Derivative
 public import Mathlib.RingTheory.PowerSeries.Evaluation
+public import Mathlib.RingTheory.PowerSeries.Expand
 public import Mathlib.RingTheory.PowerSeries.GaussNorm
 public import Mathlib.RingTheory.PowerSeries.Ideal
 public import Mathlib.RingTheory.PowerSeries.Inverse

--- a/Mathlib/RingTheory/MvPolynomial/Basic.lean
+++ b/Mathlib/RingTheory/MvPolynomial/Basic.lean
@@ -69,6 +69,13 @@ instance [CharZero R] : CharZero (MvPolynomial σ R) where
 
 end CharZero
 
+section ExpChar
+
+instance [h : ExpChar R p] : ExpChar (MvPolynomial σ R) p := by
+  cases h; exacts [ExpChar.zero, ExpChar.prime ‹_›]
+
+end ExpChar
+
 section Homomorphism
 
 theorem mapRange_eq_map {R S : Type*} [CommSemiring R] [CommSemiring S] (p : MvPolynomial σ R)

--- a/Mathlib/RingTheory/MvPowerSeries/Basic.lean
+++ b/Mathlib/RingTheory/MvPowerSeries/Basic.lean
@@ -884,6 +884,20 @@ theorem _root_.MvPowerSeries.monomial_one_eq
   simp only [← coe_X, ← coe_pow, ← coe_monomial, monomial_eq, map_one, one_mul]
   simp only [← coeToMvPowerSeries.ringHom_apply, ← map_finsuppProd]
 
+theorem _root_.MvPowerSeries.monomial_eq' (e : σ →₀ ℕ) (r : R) :
+    MvPowerSeries.monomial e r
+      = MvPowerSeries.C r * e.prod fun s e => (MvPowerSeries.X s) ^ e := by
+  conv_lhs => rw [← mul_one r]
+  rw [← smul_eq_mul, ← MvPowerSeries.smul_eq_C_mul, LinearMap.CompatibleSMul.map_smul,
+    MvPowerSeries.monomial_one_eq]
+
+theorem _root_.MvPowerSeries.monomial_smul_eq (e : σ →₀ ℕ) (p : ℕ) (r : R) :
+    MvPowerSeries.monomial (p • e) r
+      = MvPowerSeries.C r * e.prod fun s e => ((MvPowerSeries.X s) ^ p) ^ e := by
+  rw [MvPowerSeries.monomial_eq',  Finsupp.prod_of_support_subset _ Finsupp.support_smul _
+    (by simp), Finsupp.prod]
+  simp [pow_mul]
+
 section Algebra
 
 variable (A : Type*) [CommSemiring A] [Algebra R A]

--- a/Mathlib/RingTheory/MvPowerSeries/Evaluation.lean
+++ b/Mathlib/RingTheory/MvPowerSeries/Evaluation.lean
@@ -117,6 +117,10 @@ theorem mem_hasEvalIdeal_iff {a : σ → S} :
     a ∈ hasEvalIdeal ↔ HasEval a := by
   simp [hasEvalIdeal]
 
+theorem HasEval.pow (x : σ → S) (ha : HasEval x) {p : ℕ} (hp : 0 < p) :
+    HasEval (x ^ p) :=
+  mem_hasEvalIdeal_iff.mp <| Ideal.pow_mem_of_mem hasEvalIdeal ha p hp
+
 end
 
 /- ## Construction of an evaluation morphism for power series -/

--- a/Mathlib/RingTheory/MvPowerSeries/Expand.lean
+++ b/Mathlib/RingTheory/MvPowerSeries/Expand.lean
@@ -99,9 +99,7 @@ theorem coeff_expand_smul (φ : MvPowerSeries σ R) (m : σ →₀ ℕ) :
   classical
   simp only [expand, substAlgHom_apply, coeff_subst (HasSubst.X_pow hp), smul_eq_mul]
   have {d : σ →₀ ℕ} : (d.prod fun s e ↦ (X s (R := R) ^ p) ^ e) = monomial (p • d) 1 := by
-    rw [monomial_eq', map_one, one_mul, Finsupp.prod_of_support_subset _ Finsupp.support_smul _
-      (by simp), Finsupp.prod]
-    simp [pow_mul]
+    simp [monomial_smul_eq]
   rw [finsum_eq_single _ m]
   · rw [this, coeff_monomial, if_pos rfl, mul_one]
   · intro d hd

--- a/Mathlib/RingTheory/MvPowerSeries/Expand.lean
+++ b/Mathlib/RingTheory/MvPowerSeries/Expand.lean
@@ -1,0 +1,151 @@
+/-
+Copyright (c) 2025 Wenrong Zou. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Wenrong Zou
+-/
+module
+
+public import Mathlib.RingTheory.MvPowerSeries.Substitution
+
+/-!
+## Expand multivariate power series
+
+Given a multivariate power series `φ`, one may replace every occurrence of `X i` by `X i ^ n`,
+for some nonzero natural number `n`.
+This operation is called `MvPowerSeries.expand` and it is an algebra homomorphism.
+
+### Main declaration
+
+* `MvPowerSeries.expand`: expand a multi variate power series by a factor of p, so `∑ aₙ xⁿ`
+becomes `∑ aₙ xⁿᵖ`.
+-/
+
+@[expose] public section
+
+namespace MvPowerSeries
+
+variable {σ τ R S : Type*} [Finite σ] [Finite τ] [CommRing R] [CommRing S] (p : ℕ) (hp : p ≠ 0)
+
+/-- Expand the power series by a factor of p, so `∑ aₙ xⁿ` becomes `∑ aₙ xⁿᵖ`.
+
+See also `PowerSeries.expand`. -/
+noncomputable def expand : MvPowerSeries σ R →ₐ[R] MvPowerSeries σ R :=
+  substAlgHom (HasSubst.X_pow hp)
+
+theorem expand_C (r : R) : expand p hp (C r : MvPowerSeries σ R) = C r := by
+  conv_lhs => rw [← mul_one (C r), ← smul_eq_C_mul, expand, AlgHom.map_smul_of_tower,
+    map_one, smul_eq_C_mul, mul_one]
+
+@[simp]
+theorem expand_X (i : σ) : expand p hp (X i : MvPowerSeries σ R) = X i ^ p :=
+  substAlgHom_X (HasSubst.X_pow hp) i
+
+@[simp]
+theorem expand_monomial (d : σ →₀ ℕ) (r : R) :
+    expand p hp (monomial d r) = monomial (p • d) r := by
+  rw [expand, substAlgHom_monomial (HasSubst.X_pow hp), monomial_eq', Finsupp.prod,
+    Finsupp.prod_of_support_subset _ Finsupp.support_smul]
+  · simp [pow_mul, algebraMap_apply, Algebra.algebraMap_self]
+  · simp
+
+@[simp]
+theorem expand_one : expand 1 one_ne_zero = AlgHom.id R (MvPowerSeries σ R) := by
+  ext1 i
+  simp [expand, subst_self]
+
+theorem expand_one_apply (f : MvPowerSeries σ R) : expand 1 one_ne_zero f = f := by simp
+
+@[simp]
+theorem map_expand (f : R →+* S) (φ : MvPowerSeries σ R) :
+    map f (expand p hp φ) = expand p hp (map f φ) := by
+  simp [expand, map_subst (HasSubst.X_pow hp)]
+
+section
+
+omit [Finite σ]
+theorem HasSubst.expand {f : σ → MvPowerSeries τ S} (hf : HasSubst f) :
+    HasSubst fun i ↦ expand p hp (f i) := comp hf (HasSubst.X_pow hp)
+
+theorem expand_comp_substAlgHom {f : σ → MvPowerSeries τ S} (hf : HasSubst f) :
+    (expand p hp).comp (substAlgHom hf) = substAlgHom (HasSubst.expand p hp hf) := by
+  ext1 i
+  simp [expand, subst_comp_subst_apply hf (HasSubst.X_pow hp)]
+
+theorem expand_substAlgHom {f : σ → MvPowerSeries τ S} (hf : HasSubst f) {φ : MvPowerSeries σ S} :
+    expand p hp (substAlgHom hf φ) = substAlgHom (HasSubst.expand p hp hf) φ := by
+  rw [← AlgHom.comp_apply, expand_comp_substAlgHom]
+
+end
+
+/- TODO : In the original file of multi variate polynomial, there are two theorem about rename
+here, but we don't have rename for multi variate power series. And for `eval₂Hom`, `eval₂`
+and `aevel`, the expression does't look good. -/
+
+variable (q : ℕ) (hq : q ≠ 0)
+
+theorem expand_mul_eq_comp :
+    expand (σ := σ) (R := R) (p * q) (p.mul_ne_zero hp hq) = (expand p hp).comp (expand q hq) := by
+  ext1 i
+  simp [expand, pow_mul, subst_comp_subst_apply (HasSubst.X_pow hq) (HasSubst.X_pow hp),
+    subst_pow (HasSubst.X_pow hp), subst_X (HasSubst.X_pow hp)]
+
+theorem expand_mul (φ : MvPowerSeries σ R) : φ.expand (p * q) (p.mul_ne_zero hp hq) =
+    (φ.expand q hq).expand p hp :=
+  DFunLike.congr_fun (expand_mul_eq_comp p hp q hq) φ
+
+@[simp]
+theorem coeff_expand_smul (φ : MvPowerSeries σ R) (m : σ →₀ ℕ) :
+    (expand p hp φ).coeff (p • m) = φ.coeff m := by
+  classical
+  simp only [expand, substAlgHom_apply, coeff_subst (HasSubst.X_pow hp), smul_eq_mul]
+  have {d : σ →₀ ℕ} : (d.prod fun s e ↦ (X s (R := R) ^ p) ^ e) = monomial (p • d) 1 := by
+    rw [monomial_eq', map_one, one_mul, Finsupp.prod_of_support_subset _ Finsupp.support_smul _
+      (by simp), Finsupp.prod]
+    simp [pow_mul]
+  rw [finsum_eq_single _ m]
+  · rw [this, coeff_monomial, if_pos rfl, mul_one]
+  · intro d hd
+    rw [this, coeff_monomial, if_neg _, mul_zero]
+    simp [nsmul_right_inj hp, hd.symm]
+
+theorem coeff_expand_of_not_dvd (φ : MvPowerSeries σ R) {m : σ →₀ ℕ} {i : σ} (h : ¬ p ∣ m i) :
+    (expand p hp φ).coeff m = 0 := by
+  classical
+  contrapose! h
+  simp only [expand, substAlgHom_apply, coeff_subst (HasSubst.X_pow hp)] at h
+  have : ∃ (d : σ →₀ ℕ), (coeff m) (d.prod fun s e ↦ ((X s (R := R)) ^ p) ^ e) ≠ 0 := by
+    by_contra! hc
+    rw [finsum_eq_zero_of_forall_eq_zero fun d => by simp [hc d]] at h
+    contradiction
+  obtain ⟨d, hd⟩ := this
+  have : (d.prod fun s e ↦ ((X s (R := R)) ^ p) ^ e) = monomial (p • d) 1 := by
+    simp [monomial_smul_eq]
+  rw [this, coeff_monomial] at hd
+  have meq : m = p • d := by
+    by_contra hc
+    rw [if_neg hc] at hd
+    contradiction
+  simp [meq]
+
+theorem support_expand_subset (φ : MvPowerSeries σ R) :
+    (expand p hp φ).support ⊆ φ.support.image (p • ·) := by
+  intro d hd
+  have : ∀ i, p ∣ d i := fun _ => by_contra fun hc => hd (coeff_expand_of_not_dvd p hp φ hc)
+  letI m := d.mapRange (fun n => n / p) (Nat.zero_div p)
+  have eq_aux : p • m = d := (Finsupp.ext fun a => Nat.eq_mul_of_div_eq_right (this a) rfl).symm
+  rw [Function.mem_support, ← eq_aux, ← coeff_apply (expand p hp φ), coeff_expand_smul,
+    coeff_apply] at hd
+  exact ⟨m, hd, eq_aux⟩
+
+theorem support_expand (φ : MvPowerSeries σ R) :
+    (expand p hp φ).support = φ.support.image (p • ·) := by
+  classical
+  refine (support_expand_subset p hp φ).antisymm ?_
+  intro d hd
+  obtain ⟨n, hn₁, hn₂⟩ := hd
+  simp only [← hn₂, Function.mem_support]
+  by_contra hc
+  rw [Function.mem_support, ← coeff_apply φ, ← coeff_expand_smul p hp, coeff_apply, hc] at hn₁
+  contradiction
+
+end MvPowerSeries

--- a/Mathlib/RingTheory/MvPowerSeries/Substitution.lean
+++ b/Mathlib/RingTheory/MvPowerSeries/Substitution.lean
@@ -150,6 +150,10 @@ theorem hasSubst_of_constantCoeff_zero [Finite σ]
     HasSubst a :=
   hasSubst_of_constantCoeff_nilpotent (fun s ↦ by simp only [ha s, IsNilpotent.zero])
 
+protected theorem HasSubst.X_pow [Finite σ] {n : ℕ} (hn : n ≠ 0) :
+    HasSubst (fun (s : σ) ↦ (X s : MvPowerSeries σ S) ^ n) :=
+  hasSubst_of_constantCoeff_zero (by simp [hn])
+
 /-- Substitution of power series into a power series
 
 It coincides with evaluation when `f` is a polynomial, or under `HasSubst a`.
@@ -287,6 +291,19 @@ theorem map_algebraMap_eq_subst_X (f : MvPowerSeries σ R) :
       algebra_compatible_smul S, smul_eq_mul, mul_one]
   · intro d hd
     rw [← MvPowerSeries.monomial_one_eq, coeff_monomial_ne hd.symm, smul_zero]
+
+omit [Algebra R S] in
+theorem map_subst [Finite σ] {a : σ → MvPowerSeries τ R} (ha : HasSubst a) {h : R →+* S}
+    (f : MvPowerSeries σ R) :
+    (f.subst a).map h = (f.map h).subst (fun i => (a i).map h) := by
+  ext n
+  have {r : R} : h r = h.toAddMonoidHom r := rfl
+  rw [coeff_subst <| hasSubst_of_constantCoeff_nilpotent fun s => (ha.const_coeff s).map h,
+    coeff_map, coeff_subst ha, this, AddMonoidHom.map_finsum _ (coeff_subst_finite ha _ _),
+      finsum_congr]
+  intro d
+  simp [smul_eq_mul, RingHom.toAddMonoidHom_eq_coe, AddMonoidHom.coe_coe, map_mul,
+    ← coeff_map, Finsupp.prod]
 
 variable
     {T : Type*} [CommRing T]

--- a/Mathlib/RingTheory/PowerSeries/Expand.lean
+++ b/Mathlib/RingTheory/PowerSeries/Expand.lean
@@ -79,7 +79,7 @@ and `aevel`, the expression does't look good. -/
 variable (q : ℕ) (hq : 0 < q)
 
 @[simp]
-theorem coeff_expand_smul (φ : PowerSeries R) (m : ℕ) :
+theorem coeff_expand_mul (φ : PowerSeries R) (m : ℕ) :
     (expand p hp φ).coeff (p * m) = φ.coeff m := by
   classical
   erw [coeff, ← smul_eq_mul, (Finsupp.smul_single p () m).symm, MvPowerSeries.coeff_expand_smul]

--- a/Mathlib/RingTheory/PowerSeries/Expand.lean
+++ b/Mathlib/RingTheory/PowerSeries/Expand.lean
@@ -1,0 +1,103 @@
+/-
+Copyright (c) 2025 Wenrong Zou. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Wenrong Zou
+-/
+module
+
+public import Mathlib.RingTheory.PowerSeries.Substitution
+public import Mathlib.RingTheory.MvPowerSeries.Expand
+
+/-!
+## Expand power series
+
+Given a power series `φ`, one may replace every occurrence of `X i` by `X i ^ n`,
+for some nonzero natural number `n`.
+This operation is called `PowerSeries.expand` and it is an algebra homomorphism.
+
+### Main declaration
+
+* `PowerSeries.expand`: expand a power series by a factor of p, so `∑ aₙ xⁿ` becomes `∑ aₙ xⁿᵖ`.
+-/
+
+@[expose] public section
+
+namespace PowerSeries
+
+variable {τ R S : Type*} [CommRing R] [CommRing S] (p : ℕ) (hp : p ≠ 0)
+
+/-- Expand the power series by a factor of p, so `∑ aₙ xⁿ` becomes `∑ aₙ xⁿᵖ`.
+
+See also `PowerSeries.expand`. -/
+noncomputable def expand : PowerSeries R →ₐ[R] PowerSeries R :=
+  MvPowerSeries.expand p hp
+
+theorem expand_apply (f : PowerSeries R) : expand p hp f = subst (X ^ p) f := by
+  simp only [expand, MvPowerSeries.expand, MvPowerSeries.substAlgHom_apply]
+  rfl
+
+theorem expand_C (r : R) : expand p hp (C r : PowerSeries R) = C r := by
+  conv_lhs => rw [← mul_one (C r), ← smul_eq_C_mul, expand, AlgHom.map_smul_of_tower,
+    map_one, smul_eq_C_mul, mul_one]
+
+theorem expand_mul_eq_comp (q : ℕ) (hq : q ≠ 0) :
+    expand (p * q) (p.mul_ne_zero hp hq) = (expand p hp (R := R)).comp (expand q hq) := by
+  ext1 i
+  unfold expand
+  erw [MvPowerSeries.expand_mul_eq_comp p hp q hq]
+
+theorem expand_mul (q : ℕ) (hq : q ≠ 0) (φ : PowerSeries R) :
+    φ.expand (p * q) (p.mul_ne_zero hp hq) = (φ.expand q hq).expand p hp :=
+  DFunLike.congr_fun (expand_mul_eq_comp p hp q hq) φ
+
+@[simp]
+theorem expand_X : expand p hp (X (R := R)) = X ^ p :=
+  substAlgHom_X (HasSubst.X_pow hp)
+
+@[simp]
+theorem expand_monomial (d : ℕ) (r : R) :
+    expand p hp (monomial d r) = monomial (p * d) r := by
+  unfold expand
+  erw [MvPowerSeries.expand_monomial]
+  simp [monomial]
+
+@[simp]
+theorem expand_one : expand 1 one_ne_zero = AlgHom.id R (PowerSeries R) := by
+  simp [expand]
+
+theorem expand_one_apply (f : PowerSeries R) : expand 1 one_ne_zero f = f := by simp
+
+@[simp]
+theorem map_expand (f : R →+* S) (φ : PowerSeries R) :
+    map f (expand p hp φ) = expand p hp (map f φ) := by
+  erw [expand_apply, map_subst (HasSubst.X_pow hp), map_pow, map_X, expand_apply]
+
+/- TODO : In the original file of multi variate polynomial, there are two theorem about rename
+here, but we don't have rename for multi variate power series. And for `eval₂Hom`, `eval₂`
+and `aevel`, the expression does't look good. -/
+
+variable (q : ℕ) (hq : 0 < q)
+
+@[simp]
+theorem coeff_expand_smul (φ : PowerSeries R) (m : ℕ) :
+    (expand p hp φ).coeff (p * m) = φ.coeff m := by
+  classical
+  erw [coeff, ← smul_eq_mul, (Finsupp.smul_single p () m).symm, MvPowerSeries.coeff_expand_smul]
+  rfl
+
+theorem coeff_expand_of_not_dvd (φ : PowerSeries R) {m : ℕ} (h : ¬ p ∣ m) :
+    (expand p hp φ).coeff m = 0 := by
+  classical
+  erw [coeff, MvPowerSeries.coeff_expand_of_not_dvd p hp φ (i := ())]
+  simpa
+
+theorem support_expand_subset (φ : PowerSeries R) :
+    (expand p hp φ).support ⊆ φ.support.image (p • ·) := by
+  erw [MvPowerSeries.support_expand]
+
+theorem support_expand (φ : PowerSeries R) :
+    (expand p hp φ).support = φ.support.image (p • ·) := by
+  classical
+  erw [MvPowerSeries.support_expand]
+
+end PowerSeries

--- a/Mathlib/RingTheory/PowerSeries/Substitution.lean
+++ b/Mathlib/RingTheory/PowerSeries/Substitution.lean
@@ -257,6 +257,16 @@ theorem subst_X (ha : HasSubst a) :
     subst a (X : R⟦X⟧) = a := by
   rw [← coe_substAlgHom ha, substAlgHom_X]
 
+omit [Algebra R S] in
+theorem map_subst {a : MvPowerSeries τ R} (ha : HasSubst a) {h : R →+* S} (f : PowerSeries R) :
+    (f.subst a).map h = (f.map h).subst (a.map h) := by
+  ext n
+  have {r : R} : h r = h.toAddMonoidHom r := rfl
+  rw [MvPowerSeries.coeff_map, coeff_subst ha, coeff_subst (IsNilpotent.map ha h), this,
+    AddMonoidHom.map_finsum _ (coeff_subst_finite ha _ _), finsum_congr]
+  intro d
+  simp [←map_pow]
+
 section
 
 theorem le_weightedOrder_subst (w : τ → ℕ) (ha : HasSubst a) (f : PowerSeries R) :


### PR DESCRIPTION
I define an algebraic homomorphism for (mv) power series that expanding a (multi) variate power series by a non-zero factor of `p` and add some theorems following the (mv) Polynomial as inspiration. Also, I add some missing theorems in the file `MvPolynomial.Expand` compared to `Polynomial.Expand`. 

---
<!-- Your PR title will become the first line of the commit message.

In this box, the text above the `---` (if not empty) will be appended
to the commit message, and can be used to give additional context or
details. Please leave a blank newline before the `---`, otherwise GitHub
will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

When merging, all the commits will be squashed into a single commit
listing all co-authors.

Co-authors in the squash commit are gathered from two sources:

First, all authors of commits to this PR branch are included. Thus,
one way to add co-authors is to include at least one commit authored by
each co-author among the commits in the pull request. If necessary, you
may create empty commits to indicate co-authorship, using commands like so:

git commit --author="Author Name <author@email.com>" --allow-empty -m "add Author Name as coauthor"

Second, co-authors can also be listed in lines at the very bottom of
the commit message (that is, directly before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines
at the bottom of the commit message (before the `---`, and also before
any "Co-authored-by" lines) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
