### PR TITLE
[Merged by Bors] - chore: golf proofs `Basis.piTensorProduct_repr_tprod_apply` and `PiTensorProduct.dualDistrib_apply`

### DIFF
--- a/Mathlib/LinearAlgebra/PiTensorProduct/Basis.lean
+++ b/Mathlib/LinearAlgebra/PiTensorProduct/Basis.lean
@@ -42,11 +42,8 @@ noncomputable def Basis.piTensorProduct [Finite ι] (b : Π i, Basis (κ i) R (M
 theorem Basis.piTensorProduct_repr_tprod_apply [Fintype ι] (b : Π i, Basis (κ i) R (M i))
     (x : Π i, M i) (p : Π i, κ i) :
     (Basis.piTensorProduct b).repr (tprod R x) p = ∏ i : ι, (b i).repr (x i) (p i) := by
-  simp only [piTensorProduct, LinearEquiv.trans_symm, Finsupp.lcongr_symm, Equiv.refl_symm,
-    Basis.map_repr, LinearEquiv.symm_symm, Finsupp.basisSingleOne_repr, LinearEquiv.trans_refl,
-    LinearEquiv.trans_apply, congr_tprod, Finsupp.lcongr_apply_apply, Equiv.refl_apply,
-    ofFinsuppEquiv_apply, AlgEquiv.toLinearEquiv_apply, constantBaseRingEquiv_tprod]
-  convert rfl
+  rw [piTensorProduct, Subsingleton.elim (Fintype.ofFinite ι) ‹_›]
+  simp
 
 @[simp]
 theorem Basis.piTensorProduct_apply [Finite ι] (b : Π i, Basis (κ i) R (M i)) (p : Π i, κ i) :

--- a/Mathlib/LinearAlgebra/PiTensorProduct/Dual.lean
+++ b/Mathlib/LinearAlgebra/PiTensorProduct/Dual.lean
@@ -47,10 +47,8 @@ noncomputable def dualDistrib [Finite ι] : (⨂[R] i, Dual R (M i)) →ₗ[R] D
 @[simp]
 theorem dualDistrib_apply [Fintype ι] (f : Π i, Dual R (M i)) (m : Π i, M i) :
     dualDistrib (⨂ₜ[R] i, f i) (⨂ₜ[R] i, m i) = ∏ i, (f i) (m i) := by
-  simp only [dualDistrib, coe_comp, Function.comp_apply,
-    compRight_apply, piTensorHomMap_tprod_tprod, AlgEquiv.toLinearMap_apply,
-    constantBaseRingEquiv_tprod]
-  convert rfl
+  rw [dualDistrib, Subsingleton.elim (Fintype.ofFinite ι) ‹_›]
+  simp
 
 end SemiRing
 


### PR DESCRIPTION
See [Zulip](https://leanprover.zulipchat.com/#narrow/channel/287929-mathlib4/topic/PiTensorProduct.20basis.20Finite.2FFintype.20switch.20up/near/564365625)

---
<!-- Your PR title will become the first line of the commit message.

In this box, the text above the `---` (if not empty) will be appended
to the commit message, and can be used to give additional context or
details. Please leave a blank newline before the `---`, otherwise GitHub
will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

When merging, all the commits will be squashed into a single commit
listing all co-authors.

Co-authors in the squash commit are gathered from two sources:

First, all authors of commits to this PR branch are included. Thus,
one way to add co-authors is to include at least one commit authored by
each co-author among the commits in the pull request. If necessary, you
may create empty commits to indicate co-authorship, using commands like so:

git commit --author="Author Name <author@email.com>" --allow-empty -m "add Author Name as coauthor"

Second, co-authors can also be listed in lines at the very bottom of
the commit message (that is, directly before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines
at the bottom of the commit message (before the `---`, and also before
any "Co-authored-by" lines) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
