### PR TITLE
[Merged by Bors] - chore: skip running maintainer merge workflow for most comments

### DIFF
--- a/.github/workflows/maintainer_merge.yml
+++ b/.github/workflows/maintainer_merge.yml
@@ -29,7 +29,12 @@ jobs:
       EVENT_NAME: ${{ github.event_name }}
     name: Ping maintainers on Zulip
     runs-on: ubuntu-latest
-    if: github.repository == 'leanprover-community/mathlib4'
+    if: >- # crude check to skip running this on most reviews / comments
+      github.repository == 'leanprover-community/mathlib4' && 
+      (
+        contains(format('{0}{1}', github.event.comment.body, github.event.review.body), 'maintainer merge') || 
+        contains(format('{0}{1}', github.event.comment.body, github.event.review.body), 'maintainer delegate')
+      )
     steps:
       - name: Find maintainer merge/delegate
         id: merge_or_delegate


### PR DESCRIPTION
Currently the [maintainer merge](https://github.com/leanprover-community/mathlib4/actions/workflows/maintainer_merge.yml) workflow runs on every comment / PR review on mathlib4. We can skip most of these since most of those comments / reviews don't even contain the string "maintainer merge" or "maintainer delegate".

(This is a conservative check -- the more accurate regex in the bash script (see the definition of `m_or_d`) is untouched.)

---

inspired by [#mathlib4 > Connection error?](https://leanprover.zulipchat.com/#narrow/channel/287929-mathlib4/topic/Connection.20error.3F/with/564465132)