### PR TITLE
[Merged by Bors] - feat: zpow left ₀ lemmas

### DIFF
--- a/Mathlib/Algebra/Order/GroupWithZero/Unbundled/Basic.lean
+++ b/Mathlib/Algebra/Order/GroupWithZero/Unbundled/Basic.lean
@@ -1047,12 +1047,10 @@ section MulPosMono
 
 variable [MulPosMono G₀] {n : ℤ}
 
-lemma zpow_left_monoOn₀ (hn : 0 ≤ n) :
-    MonotoneOn (fun a : G₀ ↦ a ^ n) {a | 0 ≤ a} := by
+lemma zpow_left_monoOn₀ (hn : 0 ≤ n) : MonotoneOn (fun a : G₀ ↦ a ^ n) {a | 0 ≤ a} := by
   lift n to ℕ using hn; simpa using pow_left_monotoneOn
 
-lemma zpow_left_strictMonoOn₀ (hn : 0 < n) :
-    StrictMonoOn (fun a : G₀ ↦ a ^ n) {a | 0 ≤ a} := by
+lemma zpow_left_strictMonoOn₀ (hn : 0 < n) : StrictMonoOn (fun a : G₀ ↦ a ^ n) {a | 0 ≤ a} := by
   lift n to ℕ using hn.le; simpa using pow_left_strictMonoOn₀ (by lia)
 
 lemma zpow_le_zpow_left₀ (hn : 0 ≤ n) (ha : 0 ≤ a) (h : a ≤ b) : a ^ n ≤ b ^ n :=
@@ -1338,12 +1336,10 @@ section MulPosMono
 
 variable [PosMulReflectLT G₀] [MulPosMono G₀]
 
-lemma zpow_le_zpow_iff_left₀ (ha : 0 ≤ a) (hb : 0 ≤ b) (hn : 0 < n) :
-    a ^ n ≤ b ^ n ↔ a ≤ b :=
+lemma zpow_le_zpow_iff_left₀ (ha : 0 ≤ a) (hb : 0 ≤ b) (hn : 0 < n) : a ^ n ≤ b ^ n ↔ a ≤ b :=
   (zpow_left_strictMonoOn₀ (G₀ := G₀) hn).le_iff_le ha hb
 
-lemma zpow_lt_zpow_iff_left₀ (ha : 0 ≤ a) (hb : 0 ≤ b) (hn : 0 < n) :
-    a ^ n < b ^ n ↔ a < b :=
+lemma zpow_lt_zpow_iff_left₀ (ha : 0 ≤ a) (hb : 0 ≤ b) (hn : 0 < n) : a ^ n < b ^ n ↔ a < b :=
   (zpow_left_strictMonoOn₀ (G₀ := G₀) hn).lt_iff_lt ha hb
 
 end MulPosMono

--- a/Mathlib/Algebra/Order/GroupWithZero/Unbundled/Basic.lean
+++ b/Mathlib/Algebra/Order/GroupWithZero/Unbundled/Basic.lean
@@ -947,11 +947,6 @@ lemma zpow_pos (ha : 0 < a) : ∀ n : ℤ, 0 < a ^ n
   | (n : ℕ) => by rw [zpow_natCast]; exact pow_pos ha _
   | -(n + 1 : ℕ) => by rw [zpow_neg, inv_pos, zpow_natCast]; exact pow_pos ha _
 
-omit [ZeroLEOneClass G₀] in
-lemma zpow_left_strictMonoOn₀ [MulPosMono G₀] (hn : 0 < n) :
-    StrictMonoOn (fun a : G₀ ↦ a ^ n) {a | 0 ≤ a} := by
-  lift n to ℕ using hn.le; simpa using pow_left_strictMonoOn₀ (by lia)
-
 lemma zpow_right_mono₀ (ha : 1 ≤ a) : Monotone fun n : ℤ ↦ a ^ n := by
   refine monotone_int_of_le_succ fun n ↦ ?_
   rw [zpow_add_one₀ (zero_lt_one.trans_le ha).ne']
@@ -1047,6 +1042,26 @@ lemma zpow_lt_zpow_iff_right_of_lt_one₀ (ha₀ : 0 < a) (ha₁ : a < 1) :
 end ZPow
 
 end ZeroLEOneClass
+
+section MulPosMono
+
+variable [MulPosMono G₀] {n : ℤ}
+
+lemma zpow_left_monoOn₀ (hn : 0 ≤ n) :
+    MonotoneOn (fun a : G₀ ↦ a ^ n) {a | 0 ≤ a} := by
+  lift n to ℕ using hn; simpa using pow_left_monotoneOn
+
+lemma zpow_left_strictMonoOn₀ (hn : 0 < n) :
+    StrictMonoOn (fun a : G₀ ↦ a ^ n) {a | 0 ≤ a} := by
+  lift n to ℕ using hn.le; simpa using pow_left_strictMonoOn₀ (by lia)
+
+lemma zpow_le_zpow_left₀ (hn : 0 ≤ n) (ha : 0 ≤ a) (h : a ≤ b) : a ^ n ≤ b ^ n :=
+  zpow_left_monoOn₀ (G₀ := G₀) hn ha (by grind) h
+
+lemma zpow_lt_zpow_left₀ (hn : 0 < n) (ha : 0 ≤ a) (h : a < b) : a ^ n < b ^ n :=
+  zpow_left_strictMonoOn₀ (G₀ := G₀) hn ha (by grind) h
+
+end MulPosMono
 
 end PosMulReflectLT
 
@@ -1290,9 +1305,11 @@ lemma neg_of_div_neg_left (h : a / b < 0) (hb : 0 ≤ b) : a < 0 :=
 
 end PosMulMono
 
-variable [PosMulStrictMono G₀] {m n : ℤ}
+variable {m n : ℤ}
 
 section ZeroLEOne
+
+variable [PosMulStrictMono G₀]
 
 variable [ZeroLEOneClass G₀]
 
@@ -1316,6 +1333,20 @@ lemma zpow_eq_one_iff_right₀ (ha₀ : 0 ≤ a) (ha₁ : a ≠ 1) {n : ℤ} : a
   simpa using zpow_right_inj₀ ha₀ ha₁ (n := 0)
 
 end ZeroLEOne
+
+section MulPosMono
+
+variable [PosMulReflectLT G₀] [MulPosMono G₀]
+
+lemma zpow_le_zpow_iff_left₀ (ha : 0 ≤ a) (hb : 0 ≤ b) (hn : 0 < n) :
+    a ^ n ≤ b ^ n ↔ a ≤ b :=
+  (zpow_left_strictMonoOn₀ (G₀ := G₀) hn).le_iff_le ha hb
+
+lemma zpow_lt_zpow_iff_left₀ (ha : 0 ≤ a) (hb : 0 ≤ b) (hn : 0 < n) :
+    a ^ n < b ^ n ↔ a < b :=
+  (zpow_left_strictMonoOn₀ (G₀ := G₀) hn).lt_iff_lt ha hb
+
+end MulPosMono
 
 variable [MulPosStrictMono G₀]
 


### PR DESCRIPTION
Add the `•₀` version of : `zpow_le_zpow_left`, `zpow_lt_zpow_left`, `zpow_le_zpow_iff_left` and `zpow_lt_zpow_iff_left`.

I also moved `zpow_left_strictMonoOn₀` to be in the new section I created, avoiding the use of `omit`.

Co-authored-by: María Inés de Frutos Fernández <[mariaines.dff@gmail.com](mailto:mariaines.dff@gmail.com)>

---
<!-- Your PR title will become the first line of the commit message.

In this box, the text above the `---` (if not empty) will be appended
to the commit message, and can be used to give additional context or
details. Please leave a blank newline before the `---`, otherwise GitHub
will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

When merging, all the commits will be squashed into a single commit
listing all co-authors.

Co-authors in the squash commit are gathered from two sources:

First, all authors of commits to this PR branch are included. Thus,
one way to add co-authors is to include at least one commit authored by
each co-author among the commits in the pull request. If necessary, you
may create empty commits to indicate co-authorship, using commands like so:

git commit --author="Author Name <author@email.com>" --allow-empty -m "add Author Name as coauthor"

Second, co-authors can also be listed in lines at the very bottom of
the commit message (that is, directly before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines
at the bottom of the commit message (before the `---`, and also before
any "Co-authored-by" lines) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
