### PR TITLE
[Merged by Bors] - chore(LinearAlgebra/QuadraticForm): deduplicate proof

### DIFF
--- a/Mathlib/LinearAlgebra/QuadraticForm/Dual.lean
+++ b/Mathlib/LinearAlgebra/QuadraticForm/Dual.lean
@@ -169,41 +169,27 @@ lemma LinearMap.BilinForm.linearIndependent_of_pairwise_le_zero {ι R M : Type*}
     (hn : Pairwise fun i j ↦ B (v i) (v j) ≤ 0) :
     LinearIndependent R v := by
   refine linearIndependent_iff'.mpr fun s c hc ↦ ?_
-  set x := ∑ i ∈ s with 0 ≤ c i, c i • v i with hx
-  set y := ∑ i ∈ s with c i < 0, (-c i) • v i with hy
+  set x := ∑ i ∈ s with 0 < c i, c i • v i with hx
+  set y := ∑ i ∈ s with 0 < -c i, (-c i) • v i with hy
   replace hc : x = y := by
-    simp_rw [hx, hy, neg_smul, Finset.sum_neg_distrib, ← add_eq_zero_iff_eq_neg, ← hc]
-    simp [← s.sum_filter_add_sum_filter_not (p := fun i ↦ 0 ≤ c i) (f := fun i ↦ c i • v i)]
+    classical
+    simp_rw [hx, hy, neg_smul, Finset.sum_neg_distrib, ← add_eq_zero_iff_eq_neg]
+    rw [← hc, ← Finset.sum_union, Finset.sum_subset]
+    · grind only [= Finset.subset_iff, = Finset.mem_union, = Finset.mem_filter]
+    · simp +contextual [eq_comm (a := (0 : R))]
+    · grind only [Finset.disjoint_filter]
   have hx₀ : x = 0 := by
     suffices B x y ≤ 0 by simpa [hc, ← hB.le_zero_iff, B.toQuadraticMap_apply]
-    suffices 0 ≤ ∑ x ∈ s with c x < 0, ∑ i ∈ s with 0 ≤ c i, c x * (c i * (B (v i)) (v x)) by
+    suffices 0 ≤ ∑ x ∈ s with c x < 0, ∑ i ∈ s with 0 < c i, c x * (c i * (B (v i)) (v x)) by
       simpa [hx, hy, map_neg, Finset.mul_sum]
     refine Finset.sum_nonneg fun i hi ↦ Finset.sum_nonneg fun j hj ↦ ?_
-    rcases eq_or_ne i j with rfl | hij
-    · rw [← mul_assoc]
-      exact mul_nonneg (mul_self_nonneg _) (hB.nonneg _)
-    · specialize hn hij.symm
-      grind [mul_nonneg_iff, mul_nonpos_iff]
-  replace hx : ∑ i ∈ s with 0 ≤ c i, c i * f (v i) = 0 := by
-    rw [hx₀] at hx
-    simpa using (congr(f $hx)).symm
-  replace hx (i : ι) (hi : i ∈ s) : c i ≤ 0 := by
-    have aux (j : ι) (hj : j ∈ {i ∈ s | 0 ≤ c i}) : 0 ≤ c j * f (v j) := by
-      obtain ⟨hjs : j ∈ s, hj₀ : 0 ≤ c j⟩ := by simpa using hj
-      nlinarith [hp j]
-    rw [Finset.sum_eq_zero_iff_of_nonneg aux] at hx
+    grind [Pairwise, mul_nonneg_iff, mul_nonpos_iff]
+  have H (c : ι → R) (h : ∑ i ∈ s with 0 < c i, c i • v i = 0) (i : ι) (hi : i ∈ s) : c i ≤ 0 := by
+    have : ∑ i ∈ s with 0 < c i, c i * f (v i) = 0 := by simpa using (congr(f $h))
+    rw [Finset.sum_eq_zero_iff_of_nonneg (by grind [mul_nonneg])] at this
     by_contra! hi'
     have : 0 < c i * f (v i) := mul_pos hi' (hp i)
     grind
-  replace hy : ∑ i ∈ s with c i < 0, c i * f (v i) = 0 := by
-    rw [← hc, hx₀] at hy
-    simpa using (congr(f $hy)).symm
-  replace hy (i : ι) (hi : i ∈ s) : 0 ≤ c i := by
-    have aux (j : ι) (hj : j ∈ {i ∈ s | c i < 0}) : c j * f (v j) ≤ 0 := by
-      obtain ⟨hjs : j ∈ s, hj₀ : c j < 0⟩ := by simpa using hj
-      nlinarith [hp j]
-    rw [Finset.sum_eq_zero_iff_of_nonpos aux] at hy
-    by_contra! hi'
-    have : c i * f (v i) < 0 := mul_neg_of_neg_of_pos hi' (hp i)
-    grind
-  exact fun i hi ↦ le_antisymm (hx i hi) (hy i hi)
+  replace hx (i : ι) (hi : i ∈ s) : c i ≤ 0 := H _ (by grind) i hi
+  replace hy (i : ι) (hi : i ∈ s) : -c i ≤ 0 := H (-c ·) (by grind) i hi
+  grind


### PR DESCRIPTION

---
<!-- Your PR title will become the first line of the commit message.

In this box, the text above the `---` (if not empty) will be appended
to the commit message, and can be used to give additional context or
details. Please leave a blank newline before the `---`, otherwise GitHub
will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

When merging, all the commits will be squashed into a single commit
listing all co-authors.

Co-authors in the squash commit are gathered from two sources:

First, all authors of commits to this PR branch are included. Thus,
one way to add co-authors is to include at least one commit authored by
each co-author among the commits in the pull request. If necessary, you
may create empty commits to indicate co-authorship, using commands like so:

git commit --author="Author Name <author@email.com>" --allow-empty -m "add Author Name as coauthor"

Second, co-authors can also be listed in lines at the very bottom of
the commit message (that is, directly before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines
at the bottom of the commit message (before the `---`, and also before
any "Co-authored-by" lines) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
