### PR TITLE
refactor: standardize spelling of `ℵ₁` as `aleph1`

### DIFF
--- a/Counterexamples/Phillips.lean
+++ b/Counterexamples/Phillips.lean
@@ -472,9 +472,9 @@ theorem sierpinski_pathological_family (Hcont : #ℝ = ℵ₁) :
       · simp only [h, iff_true, or_true]; exact asymm h
     rw [this]
     apply Countable.union _ (countable_singleton _)
-    rw [Cardinal.countable_iff_lt_aleph_one, ← Hcont]
+    rw [Cardinal.countable_iff_lt_aleph1, ← Hcont]
     exact Cardinal.card_typein_lt r x H
-  · rw [Cardinal.countable_iff_lt_aleph_one, ← Hcont]
+  · rw [Cardinal.countable_iff_lt_aleph1, ← Hcont]
     exact Cardinal.card_typein_lt r y H
 
 /-- A family of sets in `ℝ` which only miss countably many points, but such that any point is

--- a/Mathlib/MeasureTheory/MeasurableSpace/Card.lean
+++ b/Mathlib/MeasureTheory/MeasurableSpace/Card.lean
@@ -123,8 +123,8 @@ theorem generateMeasurableRec_omega1 (s : Set (Set α)) :
     simp_rw [exists_prop] at hI
     refine ⟨_, Ordinal.lsub_lt_ord_lift ?_ fun n => (hI n).1,
       iUnion_mem_generateMeasurableRec fun n => ⟨_, Ordinal.lt_lsub I n, (hI n).2⟩⟩
-    rw [mk_nat, lift_aleph0, isRegular_aleph_one.cof_omega_eq]
-    exact aleph0_lt_aleph_one
+    rw [mk_nat, lift_aleph0, isRegular_aleph1.cof_omega_eq]
+    exact aleph0_lt_aleph1
 
 theorem generateMeasurableRec_subset (s : Set (Set α)) (i : Ordinal) :
     generateMeasurableRec s i ⊆ { t | GenerateMeasurable s t } := by
@@ -177,11 +177,11 @@ theorem cardinal_generateMeasurableRec_le (s : Set (Set α)) (i : Ordinal.{v}) :
       rw [← Ordinal.lift_le.{u}, lift_omega, Ordinal.lift_one, ← ord_aleph] at hi
       have H := card_le_of_le_ord hi
       rw [← Ordinal.lift_card] at H
-      apply H.trans <| aleph_one_le_continuum.trans <| power_le_power_right _
+      apply H.trans <| aleph1_le_continuum.trans <| power_le_power_right _
       rw [lift_max, Cardinal.lift_ofNat]
       exact le_max_right _ _
   rw [generateMeasurableRec]
-  apply_rules [(mk_union_le _ _).trans, add_le_of_le (aleph_one_le_continuum.trans A),
+  apply_rules [(mk_union_le _ _).trans, add_le_of_le (aleph1_le_continuum.trans A),
     mk_image_le.trans]
   · exact (self_le_power _ one_le_aleph0).trans (power_le_power_right (le_max_left _ _))
   · rw [mk_singleton]

--- a/Mathlib/Order/Filter/CardinalInter.lean
+++ b/Mathlib/Order/Filter/CardinalInter.lean
@@ -69,13 +69,16 @@ theorem CardinalInterFilter.toCountableInterFilter (l : Filter α) [CardinalInte
 instance CountableInterFilter.toCardinalInterFilter (l : Filter α) [CountableInterFilter l] :
     CardinalInterFilter l ℵ₁ where
   cardinal_sInter_mem S hS a :=
-    CountableInterFilter.countable_sInter_mem S ((countable_iff_lt_aleph_one S).mpr hS) a
+    CountableInterFilter.countable_sInter_mem S ((countable_iff_lt_aleph1 S).mpr hS) a
 
-theorem cardinalInterFilter_aleph_one_iff :
+theorem cardinalInterFilter_aleph1_iff :
     CardinalInterFilter l ℵ₁ ↔ CountableInterFilter l :=
   ⟨fun _ ↦ ⟨fun S h a ↦
-    CardinalInterFilter.cardinal_sInter_mem S ((countable_iff_lt_aleph_one S).1 h) a⟩,
+    CardinalInterFilter.cardinal_sInter_mem S ((countable_iff_lt_aleph1 S).1 h) a⟩,
    fun _ ↦ CountableInterFilter.toCardinalInterFilter l⟩
+
+@[deprecated (since := "2025-12-18")]
+alias cardinalInterFilter_aleph_one_iff := cardinalInterFilter_aleph1_iff
 
 /-- Every `CardinalInterFilter` for some `c` also is a `CardinalInterFilter` for any `a ≤ c`. -/
 theorem CardinalInterFilter.of_cardinalInterFilter_of_le (l : Filter α) [CardinalInterFilter l c]

--- a/Mathlib/Order/Filter/Cocardinal.lean
+++ b/Mathlib/Order/Filter/Cocardinal.lean
@@ -105,10 +105,10 @@ theorem eventually_cocardinal_ne (x : α) : ∀ᶠ a in cocardinal α hreg, a �
   simpa [Set.finite_singleton x] using hreg.nat_lt 1
 
 /-- The filter defined by all sets that have countable complements. -/
-abbrev cocountable : Filter α := cocardinal α Cardinal.isRegular_aleph_one
+abbrev cocountable : Filter α := cocardinal α Cardinal.isRegular_aleph1
 
 theorem mem_cocountable {s : Set α} :
     s ∈ cocountable ↔ (sᶜ : Set α).Countable := by
-  rw [Cardinal.countable_iff_lt_aleph_one, mem_cocardinal]
+  rw [Cardinal.countable_iff_lt_aleph1, mem_cocardinal]
 
 end Filter

--- a/Mathlib/SetTheory/Cardinal/Aleph.lean
+++ b/Mathlib/SetTheory/Cardinal/Aleph.lean
@@ -35,8 +35,7 @@ The following notations are scoped to the `Ordinal` namespace.
 The following notations are scoped to the `Cardinal` namespace.
 
 - `ℵ_ o` is notation for `aleph o`. `ℵ₁` is notation for `ℵ_ 1`.
-- `ℶ_ o` is notation for `beth o`. The value `ℶ_ 1` equals the continuum `𝔠`, which is defined in
-  `Mathlib/SetTheory/Cardinal/Continuum.lean`.
+- `ℶ_ o` is notation for `beth o`. `𝔠` is notation for `ℶ_ 1`.
 -/
 
 @[expose] public section
@@ -198,9 +197,11 @@ def omega : Ordinal ↪o Ordinal :=
 
 @[inherit_doc]
 scoped notation "ω_ " => omega
+recommended_spelling "omega" for "ω_" in [omega, «termω_»]
 
 /-- `ω₁` is the first uncountable ordinal. -/
-scoped notation "ω₁" => ω_ 1
+scoped notation3 "ω₁" => ω_ 1
+recommended_spelling "omega1" for "ω₁" in [«termω₁»]
 
 theorem omega_eq_preOmega (o : Ordinal) : ω_ o = preOmega (ω + o) :=
   rfl
@@ -364,9 +365,11 @@ def aleph : Ordinal ↪o Cardinal :=
 
 @[inherit_doc]
 scoped notation "ℵ_ " => aleph
+recommended_spelling "aleph" for "ℵ_" in [aleph, «termℵ_»]
 
 /-- `ℵ₁` is the first uncountable cardinal. -/
-scoped notation "ℵ₁" => ℵ_ 1
+scoped notation3 "ℵ₁" => ℵ_ 1
+recommended_spelling "aleph1" for "ℵ₁" in [«termℵ₁»]
 
 theorem aleph_eq_preAleph (o : Ordinal) : ℵ_ o = preAleph (ω + o) :=
   rfl
@@ -450,9 +453,12 @@ theorem mem_range_aleph_iff {c : Cardinal} : c ∈ range aleph ↔ ℵ₀ ≤ c 
 theorem succ_aleph0 : succ ℵ₀ = ℵ₁ := by
   rw [← aleph_zero, ← aleph_succ, Ordinal.succ_zero]
 
-theorem aleph0_lt_aleph_one : ℵ₀ < ℵ₁ := by
+theorem aleph0_lt_aleph1 : ℵ₀ < ℵ₁ := by
   rw [← succ_aleph0]
   apply lt_succ
+
+@[deprecated (since := "2025-12-18")]
+alias aleph0_lt_aleph_one := aleph0_lt_aleph1
 
 theorem countable_iff_lt_aleph_one {α : Type*} (s : Set α) : s.Countable ↔ #s < ℵ₁ := by
   rw [← succ_aleph0, lt_succ_iff, le_aleph0_iff_set_countable]

--- a/Mathlib/SetTheory/Cardinal/Aleph.lean
+++ b/Mathlib/SetTheory/Cardinal/Aleph.lean
@@ -460,8 +460,11 @@ theorem aleph0_lt_aleph1 : ℵ₀ < ℵ₁ := by
 @[deprecated (since := "2025-12-18")]
 alias aleph0_lt_aleph_one := aleph0_lt_aleph1
 
-theorem countable_iff_lt_aleph_one {α : Type*} (s : Set α) : s.Countable ↔ #s < ℵ₁ := by
+theorem countable_iff_lt_aleph1 {α : Type*} (s : Set α) : s.Countable ↔ #s < ℵ₁ := by
   rw [← succ_aleph0, lt_succ_iff, le_aleph0_iff_set_countable]
+
+@[deprecated (since := "2025-12-18")]
+alias countable_iff_lt_aleph_one := countable_iff_lt_aleph1
 
 @[simp]
 theorem aleph1_le_lift {c : Cardinal.{u}} : ℵ₁ ≤ lift.{v} c ↔ ℵ₁ ≤ c := by
@@ -605,6 +608,7 @@ def beth (o : Ordinal.{u}) : Cardinal.{u} :=
 
 @[inherit_doc]
 scoped notation "ℶ_ " => beth
+recommended_spelling "beth" for "ℶ_" in [beth, «termℶ_»]
 
 theorem beth_eq_preBeth (o : Ordinal) : beth o = preBeth (ω + o) :=
   rfl

--- a/Mathlib/SetTheory/Cardinal/Aleph.lean
+++ b/Mathlib/SetTheory/Cardinal/Aleph.lean
@@ -35,7 +35,8 @@ The following notations are scoped to the `Ordinal` namespace.
 The following notations are scoped to the `Cardinal` namespace.
 
 - `ℵ_ o` is notation for `aleph o`. `ℵ₁` is notation for `ℵ_ 1`.
-- `ℶ_ o` is notation for `beth o`. `𝔠` is notation for `ℶ_ 1`.
+- `ℶ_ o` is notation for `beth o`. The value `ℶ_ 1` equals the continuum `𝔠`, which is defined in
+  `Mathlib/SetTheory/Cardinal/Continuum.lean`.
 -/
 
 @[expose] public section

--- a/Mathlib/SetTheory/Cardinal/Continuum.lean
+++ b/Mathlib/SetTheory/Cardinal/Continuum.lean
@@ -82,9 +82,12 @@ theorem continuum_pos : 0 < 𝔠 :=
 theorem continuum_ne_zero : 𝔠 ≠ 0 :=
   continuum_pos.ne'
 
-theorem aleph_one_le_continuum : ℵ₁ ≤ 𝔠 := by
+theorem aleph1_le_continuum : ℵ₁ ≤ 𝔠 := by
   rw [← succ_aleph0]
   exact Order.succ_le_of_lt aleph0_lt_continuum
+
+@[deprecated (since := "2025-12-18")]
+alias aleph_one_le_continuum := aleph1_le_continuum
 
 @[simp]
 theorem continuum_toNat : toNat continuum = 0 :=

--- a/Mathlib/SetTheory/Cardinal/Regular.lean
+++ b/Mathlib/SetTheory/Cardinal/Regular.lean
@@ -95,9 +95,12 @@ theorem isRegular_succ {c : Cardinal.{u}} (h : ℵ₀ ≤ c) : IsRegular (succ c
         · rw [← lt_succ_iff, ← lt_ord, ← αe, re]
           apply typein_lt_type)⟩
 
-theorem isRegular_aleph_one : IsRegular ℵ₁ := by
+theorem isRegular_aleph1 : IsRegular ℵ₁ := by
   rw [← succ_aleph0]
   exact isRegular_succ le_rfl
+
+@[deprecated (since := "2025-12-18")]
+alias isRegular_aleph_one := isRegular_aleph1
 
 theorem isRegular_preAleph_succ {o : Ordinal} (h : ω ≤ o) : IsRegular (preAleph (succ o)) := by
   rw [preAleph_succ]
@@ -306,8 +309,8 @@ lemma iSup_sequence_lt_omega1 {α : Type u} [Countable α]
     (o : α → Ordinal.{max u v}) (ho : ∀ n, o n < (aleph 1).ord) :
     iSup o < (aleph 1).ord := by
   apply iSup_lt_ord_lift _ ho
-  rw [Cardinal.isRegular_aleph_one.cof_eq]
-  exact lt_of_le_of_lt mk_le_aleph0 aleph0_lt_aleph_one
+  rw [Cardinal.isRegular_aleph1.cof_eq]
+  exact mk_le_aleph0.trans_lt aleph0_lt_aleph1
 
 end Ordinal
 


### PR DESCRIPTION
...in analogy to how `ℵ₀` is spelled `aleph0`. This matches what we do with `ω₁`.

---
<!-- Your PR title will become the first line of the commit message.

In this box, the text above the `---` (if not empty) will be appended
to the commit message, and can be used to give additional context or
details. Please leave a blank newline before the `---`, otherwise GitHub
will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

When merging, all the commits will be squashed into a single commit
listing all co-authors.

Co-authors in the squash commit are gathered from two sources:

First, all authors of commits to this PR branch are included. Thus,
one way to add co-authors is to include at least one commit authored by
each co-author among the commits in the pull request. If necessary, you
may create empty commits to indicate co-authorship, using commands like so:

git commit --author="Author Name <author@email.com>" --allow-empty -m "add Author Name as coauthor"

Second, co-authors can also be listed in lines at the very bottom of
the commit message (that is, directly before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines
at the bottom of the commit message (before the `---`, and also before
any "Co-authored-by" lines) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

Or should we be doing this the other way around, writing `aleph_one` for `ℵ₁`? 

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
