### PR TITLE
[Merged by Bors] - fix: don't use `addConstInfo` on constant defining syntax

### DIFF
--- a/Mathlib/Tactic/HigherOrder.lean
+++ b/Mathlib/Tactic/HigherOrder.lean
@@ -95,7 +95,7 @@ def higherOrderGetParam (thm : Name) (stx : Syntax) : AttrM Name := do
           type := hot
           value := prf }
       addDeclarationRangesFromSyntax hothmName (← getRef) ref
-      addConstInfo ref hothmName
+      addTermInfo' ref (← mkConstWithLevelParams hothmName) (isBinder := true)
       let hsm := simpExtension.getState (← getEnv) |>.lemmaNames.contains (.decl thm)
       if hsm then
         addSimpTheorem simpExtension hothmName true false .global 1000

--- a/Mathlib/Tactic/MkIffOfInductiveProp.lean
+++ b/Mathlib/Tactic/MkIffOfInductiveProp.lean
@@ -333,7 +333,7 @@ def mkIffOfInductivePropImpl (ind : Name) (rel : Name) (relStx : Syntax) : MetaM
     value := ← instantiateMVars mvar
   }
   addDeclarationRangesFromSyntax rel (← getRef) relStx
-  addConstInfo relStx rel
+  Term.addTermInfo' relStx (← mkConstWithLevelParams rel) (isBinder := true) |>.run'
 
 /--
 Applying the `mk_iff` attribute to an inductively-defined proposition `mk_iff` makes an `iff` rule

--- a/Mathlib/Tactic/Recall.lean
+++ b/Mathlib/Tactic/Recall.lean
@@ -44,7 +44,7 @@ open Lean Meta Elab Command Term
 elab_rules : command
   | `(recall $id $sig:optDeclSig $[$val?]?) => withoutModifyingEnv do
     let declName := id.getId
-    addConstInfo id declName
+    addTermInfo' id (← mkConstWithLevelParams declName) (isBinder := true)
     let info ← getConstInfo declName
     let declConst : Expr := mkConst declName <| info.levelParams.map Level.param
     let newId := ({ namePrefix := declName : DeclNameGenerator }.mkUniqueName (← getEnv) `recall).1

--- a/Mathlib/Tactic/Recall.lean
+++ b/Mathlib/Tactic/Recall.lean
@@ -44,7 +44,7 @@ open Lean Meta Elab Command Term
 elab_rules : command
   | `(recall $id $sig:optDeclSig $[$val?]?) => withoutModifyingEnv do
     let declName := id.getId
-    addTermInfo' id (← mkConstWithLevelParams declName) (isBinder := true)
+    addConstInfo id declName
     let info ← getConstInfo declName
     let declConst : Expr := mkConst declName <| info.levelParams.map Level.param
     let newId := ({ namePrefix := declName : DeclNameGenerator }.mkUniqueName (← getEnv) `recall).1

--- a/Mathlib/Tactic/Sat/FromLRAT.lean
+++ b/Mathlib/Tactic/Sat/FromLRAT.lean
@@ -626,7 +626,7 @@ elab "lrat_proof " n:(ident <|> "example")
     let lrat ← unsafe evalTerm String (mkConst ``String) lrat
     let go := do
       fromLRAT cnf lrat name
-      addConstInfo n name
+      addTermInfo' n (← mkConstWithLevelParams name) (isBinder := true) |>.run'
     if n.1.isIdent then go else withoutModifyingEnv go
 
 lrat_proof example

--- a/Mathlib/Tactic/Simps/Basic.lean
+++ b/Mathlib/Tactic/Simps/Basic.lean
@@ -1002,7 +1002,7 @@ def addProjection (declName : Name) (type lhs rhs : Expr) (args : Array Expr)
   inferDefEqAttr declName
   -- add term info and apply attributes
   addDeclarationRangesFromSyntax declName (← getRef) ref
-  addConstInfo ref declName
+  addTermInfo' ref (← mkConstWithLevelParams declName) (isBinder := true) |>.run'
   if cfg.isSimp then
     addSimpTheorem simpExtension declName true false .global <| eval_prio default
   TermElabM.run' do

--- a/Mathlib/Tactic/Translate/Core.lean
+++ b/Mathlib/Tactic/Translate/Core.lean
@@ -1178,7 +1178,8 @@ partial def addTranslationAttr (t : TranslateData) (src : Name) (cfg : Config)
   let nestedNames ← copyMetaData t cfg src tgt argInfo
   -- add pop-up information when mousing over the given translated name
   -- (the information will be over the attribute if no translated name is given)
-  addConstInfo cfg.ref tgt
+  Term.addTermInfo' cfg.ref (← mkConstWithLevelParams tgt) (isBinder := !alreadyExists)
+    |>.run' |>.run'
   if let some doc := cfg.doc then
     addDocStringCore tgt doc
   return nestedNames.push tgt

--- a/Mathlib/Util/AliasIn.lean
+++ b/Mathlib/Util/AliasIn.lean
@@ -55,5 +55,5 @@ initialize registerBuiltinAttribute {
         components.take (components.length - 1 - num) ++ newNamespace ++ [components.getLast!]
       liftCommandElabM <| elabCommand <| ← `(command| alias $(mkIdent tgtName) := $(mkIdent src))
       -- add mouse-over text
-      addConstInfo nm tgtName
+      Term.addTermInfo' nm (← mkConstWithLevelParams tgtName) (isBinder := true) |>.run' |>.run'
     | _, _, _ => throwUnsupportedSyntax }


### PR DESCRIPTION
As pointed out by `fpvandoorn`, `addConstInfo` doesn't use `isBinder := true`, so the information that this constant is defined at the syntax is not available in the VSCode UI. So we revert back to using `addTermInfo'`.

---
<!-- Your PR title will become the first line of the commit message.

In this box, the text above the `---` (if not empty) will be appended
to the commit message, and can be used to give additional context or
details. Please leave a blank newline before the `---`, otherwise GitHub
will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

When merging, all the commits will be squashed into a single commit
listing all co-authors.

Co-authors in the squash commit are gathered from two sources:

First, all authors of commits to this PR branch are included. Thus,
one way to add co-authors is to include at least one commit authored by
each co-author among the commits in the pull request. If necessary, you
may create empty commits to indicate co-authorship, using commands like so:

git commit --author="Author Name <author@email.com>" --allow-empty -m "add Author Name as coauthor"

Second, co-authors can also be listed in lines at the very bottom of
the commit message (that is, directly before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines
at the bottom of the commit message (before the `---`, and also before
any "Co-authored-by" lines) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
