### PR TITLE
[Merged by Bors] - fix(Algebra/BigOperators/Group/Finset): Add missing binder annotation with pp.analyze in Finset.sum

### DIFF
--- a/Mathlib/Algebra/BigOperators/Group/Finset/Defs.lean
+++ b/Mathlib/Algebra/BigOperators/Group/Finset/Defs.lean
@@ -265,7 +265,7 @@ to show the domain type when the product is over `Finset.univ`. -/
   whenPPOption getPPNotation <| withOverApp 5 do
   let #[_, _, _, _, f] := (← getExpr).getAppArgs | failure
   guard f.isLambda
-  let ppDomain ← withAppArg do return getPPFunBinderTypes (← getOptionsAtCurrPos)
+  let ppDomain ← withAppArg <| getPPOption getPPFunBinderTypes
   let (i, body) ← withAppArg <| withBindingBodyUnusedName fun i => do
     return (⟨i⟩, ← delab)
   let res ← withNaryArg 3 <| delabFinsetArg i
@@ -296,7 +296,7 @@ to show the domain type when the sum is over `Finset.univ`. -/
   whenPPOption getPPNotation <| withOverApp 5 do
   let #[_, _, _, _, f] := (← getExpr).getAppArgs | failure
   guard f.isLambda
-  let ppDomain ← withAppArg do return getPPFunBinderTypes (← getOptionsAtCurrPos)
+  let ppDomain ← withAppArg <| getPPOption getPPFunBinderTypes
   let (i, body) ← withAppArg <| withBindingBodyUnusedName fun i => do
     return ((⟨i⟩ : Ident), ← delab)
   let res ← withNaryArg 3 <| delabFinsetArg i

--- a/Mathlib/Algebra/BigOperators/Group/Finset/Defs.lean
+++ b/Mathlib/Algebra/BigOperators/Group/Finset/Defs.lean
@@ -265,7 +265,7 @@ to show the domain type when the product is over `Finset.univ`. -/
   whenPPOption getPPNotation <| withOverApp 5 do
   let #[_, _, _, _, f] := (← getExpr).getAppArgs | failure
   guard f.isLambda
-  let ppDomain ← getPPOption getPPFunBinderTypes
+  let ppDomain ← withAppArg do return getPPFunBinderTypes (← getOptionsAtCurrPos)
   let (i, body) ← withAppArg <| withBindingBodyUnusedName fun i => do
     return (⟨i⟩, ← delab)
   let res ← withNaryArg 3 <| delabFinsetArg i
@@ -296,7 +296,7 @@ to show the domain type when the sum is over `Finset.univ`. -/
   whenPPOption getPPNotation <| withOverApp 5 do
   let #[_, _, _, _, f] := (← getExpr).getAppArgs | failure
   guard f.isLambda
-  let ppDomain ← getPPOption getPPFunBinderTypes
+  let ppDomain ← withAppArg do return getPPFunBinderTypes (← getOptionsAtCurrPos)
   let (i, body) ← withAppArg <| withBindingBodyUnusedName fun i => do
     return ((⟨i⟩ : Ident), ← delab)
   let res ← withNaryArg 3 <| delabFinsetArg i

--- a/MathlibTest/BigOps.lean
+++ b/MathlibTest/BigOps.lean
@@ -1,4 +1,5 @@
 import Mathlib.Algebra.BigOperators.Group.Finset.Basic
+import Mathlib.Data.Fintype.Basic
 
 section
 variable {ι M : Type*} [CommMonoid M] [AddCommMonoid M] [Fintype ι] {s : Finset ι} {p : ι → Prop}
@@ -60,6 +61,66 @@ set_option pp.funBinderTypes false
 
 /-- info: ∏ i with p i, f i : M -/
 #guard_msgs in
+#check Finset.prod {j | p j} fun i ↦ f i
+
+/-! ### Big operators over a finset with `pp.analyze` on -/
+
+/-- info: ∑ i, i.toNat : ℕ -/
+#guard_msgs in
+#check ∑ i : Fin 3, i.toNat
+
+/-- info: ∏ i, i.toNat : ℕ -/
+#guard_msgs in
+#check ∏ i : Fin 3, i.toNat
+
+/-- info: ∑ i : Fin 3, i.toNat : ℕ -/
+#guard_msgs in
+set_option pp.analyze true in
+#check ∑ i : Fin 3, i.toNat
+
+/-- info: ∏ i : Fin 3, i.toNat : ℕ -/
+#guard_msgs in
+set_option pp.analyze true in
+#check ∏ i : Fin 3, i.toNat
+
+/-- info: ∑ i ∈ s, f i : M -/
+#guard_msgs in
+set_option pp.analyze true in
+#check Finset.sum s fun i ↦ f i
+
+/-- info: ∏ i ∈ s, f i : M -/
+#guard_msgs in
+set_option pp.analyze true in
+#check Finset.prod s fun i ↦ f i
+
+/-- info: ∑ i ∈ s with p i, f i : M -/
+#guard_msgs in
+set_option pp.analyze true in
+#check Finset.sum {j ∈ s | p j} fun i ↦ f i
+
+/-- info: ∏ i ∈ s with p i, f i : M -/
+#guard_msgs in
+set_option pp.analyze true in
+#check Finset.prod {j ∈ s | p j} fun i ↦ f i
+
+/-- info: ∑ i : ι, f i : M -/
+#guard_msgs in
+set_option pp.analyze true in
+#check Finset.sum Finset.univ fun i ↦ f i
+
+/-- info: ∏ i : ι, f i : M -/
+#guard_msgs in
+set_option pp.analyze true in
+#check Finset.prod Finset.univ fun i ↦ f i
+
+/-- info: ∑ i : ι with p i, f i : M -/
+#guard_msgs in
+set_option pp.analyze true in
+#check Finset.sum {j | p j} fun i ↦ f i
+
+/-- info: ∏ i : ι with p i, f i : M -/
+#guard_msgs in
+set_option pp.analyze true in
 #check Finset.prod {j | p j} fun i ↦ f i
 
 end


### PR DESCRIPTION
---

[#mathlib4 > pp.analyze for summation notation](https://leanprover.zulipchat.com/#narrow/channel/287929-mathlib4/topic/pp.2Eanalyze.20for.20summation.20notation/with/564627202)

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
