### PR TITLE
[Merged by Bors] - chore: scope `privateInPublic` option more

### DIFF
--- a/Mathlib/CategoryTheory/ComposableArrows/Basic.lean
+++ b/Mathlib/CategoryTheory/ComposableArrows/Basic.lean
@@ -42,6 +42,8 @@ TODO (@joelriou):
 
 @[expose] public section
 
+set_option backward.privateInPublic true
+
 /-!
 New `simprocs` that run even in `dsimp` have caused breakages in this file.
 

--- a/Mathlib/CategoryTheory/ComposableArrows/Basic.lean
+++ b/Mathlib/CategoryTheory/ComposableArrows/Basic.lean
@@ -42,8 +42,6 @@ TODO (@joelriou):
 
 @[expose] public section
 
-set_option backward.privateInPublic true
-
 /-!
 New `simprocs` that run even in `dsimp` have caused breakages in this file.
 

--- a/Mathlib/CategoryTheory/SmallObject/Iteration/ExtendToSucc.lean
+++ b/Mathlib/CategoryTheory/SmallObject/Iteration/ExtendToSucc.lean
@@ -19,7 +19,7 @@ functor `Set.Iic (Order.succ j) ⥤ C` when an object `X : C` and a morphism
 
 @[expose] public section
 
-set_option backward.privateInPublic true
+--set_option backward.privateInPublic true
 
 universe u
 

--- a/Mathlib/CategoryTheory/SmallObject/Iteration/ExtendToSucc.lean
+++ b/Mathlib/CategoryTheory/SmallObject/Iteration/ExtendToSucc.lean
@@ -19,8 +19,6 @@ functor `Set.Iic (Order.succ j) ⥤ C` when an object `X : C` and a morphism
 
 @[expose] public section
 
---set_option backward.privateInPublic true
-
 universe u
 
 namespace CategoryTheory
@@ -39,6 +37,7 @@ namespace extendToSucc
 
 variable (X)
 
+set_option backward.privateInPublic true in
 /-- `extendToSucc`, on objects: it coincides with `F.obj` for `i ≤ j`, and
 it sends `Order.succ j` to the given object `X`. -/
 def obj (i : Set.Iic (Order.succ j)) : C :=

--- a/Mathlib/GroupTheory/OreLocalization/Basic.lean
+++ b/Mathlib/GroupTheory/OreLocalization/Basic.lean
@@ -37,9 +37,6 @@ localization, Ore, non-commutative
 
 @[expose] public section
 
-set_option backward.privateInPublic true
-set_option backward.privateInPublic.warn true
-
 assert_not_exists RelIso MonoidWithZero
 
 universe u
@@ -205,6 +202,8 @@ theorem lift₂Expand_of {C : Sort*} {P : X → S → X → S → C}
     (r₁ : X) (s₁ : S) (r₂ : X) (s₂ : S) : lift₂Expand P hP (r₁ /ₒ s₁) (r₂ /ₒ s₂) = P r₁ s₁ r₂ s₂ :=
   rfl
 
+set_option backward.privateInPublic true in
+set_option backward.privateInPublic.warn false in
 @[to_additive]
 private def smul' (r₁ : R) (s₁ : S) (r₂ : X) (s₂ : S) : X[S⁻¹] :=
   oreNum r₁ s₂ • r₂ /ₒ (oreDenom r₁ s₂ * s₁)

--- a/Mathlib/RingTheory/OreLocalization/Basic.lean
+++ b/Mathlib/RingTheory/OreLocalization/Basic.lean
@@ -28,9 +28,6 @@ localization, Ore, non-commutative
 
 @[expose] public section
 
-set_option backward.privateInPublic true
-set_option backward.privateInPublic.warn true
-
 assert_not_exists RelIso
 
 universe u

--- a/Mathlib/RingTheory/OreLocalization/Basic.lean
+++ b/Mathlib/RingTheory/OreLocalization/Basic.lean
@@ -78,6 +78,7 @@ section DistribMulAction
 variable {R : Type*} [Monoid R] {S : Submonoid R} [OreSet S] {X : Type*} [AddMonoid X]
 variable [DistribMulAction R X]
 
+set_option backward.privateInPublic true in
 private def add'' (r₁ : X) (s₁ : S) (r₂ : X) (s₂ : S) : X[S⁻¹] :=
   (oreDenom (s₁ : R) s₂ • r₁ + oreNum (s₁ : R) s₂ • r₂) /ₒ (oreDenom (s₁ : R) s₂ * s₁)
 
@@ -102,6 +103,7 @@ private theorem add''_char (r₁ : X) (s₁ : S) (r₂ : X) (s₂ : S) (rb : R) 
 
 attribute [local instance] OreLocalization.oreEqv
 
+set_option backward.privateInPublic true in
 private def add' (r₂ : X) (s₂ : S) : X[S⁻¹] → X[S⁻¹] :=
   (--plus tilde
       Quotient.lift

--- a/Mathlib/RingTheory/Spectrum/Maximal/Localization.lean
+++ b/Mathlib/RingTheory/Spectrum/Maximal/Localization.lean
@@ -17,9 +17,6 @@ Localization results.
 
 @[expose] public section
 
-set_option backward.privateInPublic false
-set_option backward.privateInPublic.warn true
-
 noncomputable section
 
 variable (R S P : Type*) [CommSemiring R] [CommSemiring S] [CommSemiring P]


### PR DESCRIPTION
Experimental.

---

<!-- Your PR title will become the first line of the commit message.

In this box, the text above the `---` (if not empty) will be appended
to the commit message, and can be used to give additional context or
details. Please leave a blank newline before the `---`, otherwise GitHub
will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

When merging, all the commits will be squashed into a single commit
listing all co-authors.

Co-authors in the squash commit are gathered from two sources:

First, all authors of commits to this PR branch are included. Thus,
one way to add co-authors is to include at least one commit authored by
each co-author among the commits in the pull request. If necessary, you
may create empty commits to indicate co-authorship, using commands like so:

git commit --author="Author Name <author@email.com>" --allow-empty -m "add Author Name as coauthor"

Second, co-authors can also be listed in lines at the very bottom of
the commit message (that is, directly before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines
at the bottom of the commit message (before the `---`, and also before
any "Co-authored-by" lines) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
