### PR TITLE
[Merged by Bors] - chore: remove `[NeZero n]` assumptions in lemmas about `Fin n`

### DIFF
--- a/Mathlib/Data/Fin/Basic.lean
+++ b/Mathlib/Data/Fin/Basic.lean
@@ -336,7 +336,7 @@ lemma castLT_sub_nezero {n : ℕ} {i j : Fin n} (hij : i < j) :
 lemma one_le_of_ne_zero {n : ℕ} {k : Fin n} :
     haveI : NeZero n := k.neZero_of_exists
     k ≠ 0 → 1 ≤ k := by
-  let _ : NeZero n := k.neZero_of_exists
+  have : NeZero n := k.neZero_of_exists
   intro hk
   obtain ⟨n, rfl⟩ := Nat.exists_eq_succ_of_ne_zero (NeZero.ne n)
   cases n with
@@ -346,9 +346,8 @@ lemma one_le_of_ne_zero {n : ℕ} {k : Fin n} :
 lemma val_sub_one_of_ne_zero {i : Fin n} :
     haveI : NeZero n := i.neZero_of_exists
     i ≠ 0 → (i - 1).val = i - 1 := by
-  haveI : NeZero n := i.neZero_of_exists
+  have : NeZero n := i.neZero_of_exists
   intro hi
-  let _ : NeZero n := i.neZero_of_exists
   obtain ⟨n, rfl⟩ := Nat.exists_eq_succ_of_ne_zero (NeZero.ne n)
   rw [Fin.sub_val_of_le (one_le_of_ne_zero hi), Fin.val_one', Nat.mod_eq_of_lt
     (Nat.succ_le_iff.mpr (nontrivial_iff_two_le.mp <| nontrivial_of_ne i 0 hi))]
@@ -376,7 +375,7 @@ theorem val_cast_of_lt {n : ℕ} [NeZero n] {a : ℕ} (h : a < n) : (a : Fin n).
 @[simp, norm_cast] theorem cast_val_eq_self {n : ℕ} (a : Fin n) :
     have : NeZero n := a.neZero_of_exists
     (a.val : Fin n) = a :=
-  let _ : NeZero n := a.neZero_of_exists
+  have : NeZero n := a.neZero_of_exists
   Fin.ext <| val_cast_of_lt a.isLt
 
 -- This is a special case of `CharP.cast_eq_zero` that doesn't require typeclass search

--- a/Mathlib/Data/Fin/Basic.lean
+++ b/Mathlib/Data/Fin/Basic.lean
@@ -330,8 +330,8 @@ lemma castLT_sub_nezero {n : ℕ} {i j : Fin n} (hij : i < j) :
   simpa [coe_sub_iff_le.mpr (Fin.le_of_lt hij)] using by lia
 
 lemma one_le_of_ne_zero {n : ℕ} {k : Fin n} :
-    haveI : NeZero n := k.neZero
-    k ≠ 0 → 1 ≤ k := by
+    haveI := k.neZero
+    (hk : k ≠ 0) → 1 ≤ k := by
   have : NeZero n := k.neZero
   intro hk
   obtain ⟨n, rfl⟩ := Nat.exists_eq_succ_of_ne_zero (NeZero.ne n)
@@ -340,9 +340,9 @@ lemma one_le_of_ne_zero {n : ℕ} {k : Fin n} :
   | succ n => rwa [Fin.le_iff_val_le_val, Fin.val_one, Nat.one_le_iff_ne_zero, val_ne_zero_iff]
 
 lemma val_sub_one_of_ne_zero {i : Fin n} :
-    haveI : NeZero n := i.neZero
+    haveI := i.neZero
     i ≠ 0 → (i - 1).val = i - 1 := by
-  have : NeZero n := i.neZero
+  have := i.neZero
   intro hi
   obtain ⟨n, rfl⟩ := Nat.exists_eq_succ_of_ne_zero (NeZero.ne n)
   rw [Fin.sub_val_of_le (one_le_of_ne_zero hi), Fin.val_one', Nat.mod_eq_of_lt
@@ -369,9 +369,9 @@ theorem val_cast_of_lt {n : ℕ} [NeZero n] {a : ℕ} (h : a < n) : (a : Fin n).
 
 /-- Converting the value of a `Fin n` to `Fin n` results in the same value. -/
 @[simp, norm_cast] theorem cast_val_eq_self {n : ℕ} (a : Fin n) :
-    have : NeZero n := a.neZero
+    have := a.neZero
     (a.val : Fin n) = a :=
-  have : NeZero n := a.neZero
+  have := a.neZero
   Fin.ext <| val_cast_of_lt a.isLt
 
 -- This is a special case of `CharP.cast_eq_zero` that doesn't require typeclass search
@@ -517,7 +517,7 @@ theorem coe_ofNat_eq_mod (m n : ℕ) [NeZero m] :
   rfl
 
 theorem val_add_one_of_lt' {n : ℕ} {i : Fin n} (h : i + 1 < n) :
-    haveI : NeZero n := i.neZero
+    haveI := i.neZero
     (i + 1).val = i.val + 1 := by
   simpa [add_def] using Nat.mod_eq_of_lt (by lia)
 

--- a/Mathlib/Data/Fin/Basic.lean
+++ b/Mathlib/Data/Fin/Basic.lean
@@ -90,11 +90,7 @@ def equivSubtype : Fin n ≃ { i // i < n } where
   toFun a := ⟨a.1, a.2⟩
   invFun a := ⟨a.1, a.2⟩
 
-lemma neZero {n : ℕ} (i : Fin n) : NeZero n := by
-  rw [neZero_iff]
-  intro h
-  rw [h] at i
-  exact i.elim0
+lemma neZero {n : ℕ} (i : Fin n) : NeZero n := ⟨Nat.ne_zero_of_lt i.isLt⟩
 
 section coe
 

--- a/Mathlib/Data/Fin/Basic.lean
+++ b/Mathlib/Data/Fin/Basic.lean
@@ -341,7 +341,7 @@ lemma one_le_of_ne_zero {n : ℕ} {k : Fin n} :
 
 lemma val_sub_one_of_ne_zero {i : Fin n} :
     haveI := i.neZero
-    i ≠ 0 → (i - 1).val = i - 1 := by
+    (hi : i ≠ 0) → (i - 1).val = i - 1 := by
   have := i.neZero
   intro hi
   obtain ⟨n, rfl⟩ := Nat.exists_eq_succ_of_ne_zero (NeZero.ne n)
@@ -369,7 +369,7 @@ theorem val_cast_of_lt {n : ℕ} [NeZero n] {a : ℕ} (h : a < n) : (a : Fin n).
 
 /-- Converting the value of a `Fin n` to `Fin n` results in the same value. -/
 @[simp, norm_cast] theorem cast_val_eq_self {n : ℕ} (a : Fin n) :
-    have := a.neZero
+    haveI := a.neZero
     (a.val : Fin n) = a :=
   have := a.neZero
   Fin.ext <| val_cast_of_lt a.isLt

--- a/Mathlib/Data/Fin/Basic.lean
+++ b/Mathlib/Data/Fin/Basic.lean
@@ -90,7 +90,7 @@ def equivSubtype : Fin n ≃ { i // i < n } where
   toFun a := ⟨a.1, a.2⟩
   invFun a := ⟨a.1, a.2⟩
 
-lemma neZero_of_exists {n : ℕ} (i : Fin n) : NeZero n := by
+lemma neZero {n : ℕ} (i : Fin n) : NeZero n := by
   rw [neZero_iff]
   intro h
   rw [h] at i
@@ -334,9 +334,9 @@ lemma castLT_sub_nezero {n : ℕ} {i j : Fin n} (hij : i < j) :
   simpa [coe_sub_iff_le.mpr (Fin.le_of_lt hij)] using by lia
 
 lemma one_le_of_ne_zero {n : ℕ} {k : Fin n} :
-    haveI : NeZero n := k.neZero_of_exists
+    haveI : NeZero n := k.neZero
     k ≠ 0 → 1 ≤ k := by
-  have : NeZero n := k.neZero_of_exists
+  have : NeZero n := k.neZero
   intro hk
   obtain ⟨n, rfl⟩ := Nat.exists_eq_succ_of_ne_zero (NeZero.ne n)
   cases n with
@@ -344,9 +344,9 @@ lemma one_le_of_ne_zero {n : ℕ} {k : Fin n} :
   | succ n => rwa [Fin.le_iff_val_le_val, Fin.val_one, Nat.one_le_iff_ne_zero, val_ne_zero_iff]
 
 lemma val_sub_one_of_ne_zero {i : Fin n} :
-    haveI : NeZero n := i.neZero_of_exists
+    haveI : NeZero n := i.neZero
     i ≠ 0 → (i - 1).val = i - 1 := by
-  have : NeZero n := i.neZero_of_exists
+  have : NeZero n := i.neZero
   intro hi
   obtain ⟨n, rfl⟩ := Nat.exists_eq_succ_of_ne_zero (NeZero.ne n)
   rw [Fin.sub_val_of_le (one_le_of_ne_zero hi), Fin.val_one', Nat.mod_eq_of_lt
@@ -373,9 +373,9 @@ theorem val_cast_of_lt {n : ℕ} [NeZero n] {a : ℕ} (h : a < n) : (a : Fin n).
 
 /-- Converting the value of a `Fin n` to `Fin n` results in the same value. -/
 @[simp, norm_cast] theorem cast_val_eq_self {n : ℕ} (a : Fin n) :
-    have : NeZero n := a.neZero_of_exists
+    have : NeZero n := a.neZero
     (a.val : Fin n) = a :=
-  have : NeZero n := a.neZero_of_exists
+  have : NeZero n := a.neZero
   Fin.ext <| val_cast_of_lt a.isLt
 
 -- This is a special case of `CharP.cast_eq_zero` that doesn't require typeclass search
@@ -521,7 +521,7 @@ theorem coe_ofNat_eq_mod (m n : ℕ) [NeZero m] :
   rfl
 
 theorem val_add_one_of_lt' {n : ℕ} {i : Fin n} (h : i + 1 < n) :
-    haveI : NeZero n := i.neZero_of_exists
+    haveI : NeZero n := i.neZero
     (i + 1).val = i.val + 1 := by
   simpa [add_def] using Nat.mod_eq_of_lt (by lia)
 

--- a/Mathlib/Data/Fin/Basic.lean
+++ b/Mathlib/Data/Fin/Basic.lean
@@ -90,6 +90,12 @@ def equivSubtype : Fin n ≃ { i // i < n } where
   toFun a := ⟨a.1, a.2⟩
   invFun a := ⟨a.1, a.2⟩
 
+lemma neZero_of_exists {n : ℕ} (i : Fin n) : NeZero n := by
+  rw [neZero_iff]
+  intro h
+  rw [h] at i
+  exact i.elim0
+
 section coe
 
 /-!
@@ -322,18 +328,27 @@ lemma sub_val_lt_sub {n : ℕ} {i j : Fin n} (hij : i ≤ j) : (j - i).val < n -
   simp [sub_val_of_le hij, Nat.sub_lt_sub_right hij j.isLt]
 
 lemma castLT_sub_nezero {n : ℕ} {i j : Fin n} (hij : i < j) :
-    letI : NeZero (n - i.1) := neZero_iff.mpr (by lia)
+    haveI : NeZero (n - i.1) := neZero_iff.mpr (by lia)
     (j - i).castLT (sub_val_lt_sub (Fin.le_of_lt hij)) ≠ 0 := by
   refine Ne.symm (ne_of_val_ne ?_)
   simpa [coe_sub_iff_le.mpr (Fin.le_of_lt hij)] using by lia
 
-lemma one_le_of_ne_zero {n : ℕ} [NeZero n] {k : Fin n} (hk : k ≠ 0) : 1 ≤ k := by
+lemma one_le_of_ne_zero {n : ℕ} {k : Fin n} :
+    haveI : NeZero n := k.neZero_of_exists
+    k ≠ 0 → 1 ≤ k := by
+  let _ : NeZero n := k.neZero_of_exists
+  intro hk
   obtain ⟨n, rfl⟩ := Nat.exists_eq_succ_of_ne_zero (NeZero.ne n)
   cases n with
   | zero => simp only [Fin.isValue, Fin.zero_le]
   | succ n => rwa [Fin.le_iff_val_le_val, Fin.val_one, Nat.one_le_iff_ne_zero, val_ne_zero_iff]
 
-lemma val_sub_one_of_ne_zero [NeZero n] {i : Fin n} (hi : i ≠ 0) : (i - 1).val = i - 1 := by
+lemma val_sub_one_of_ne_zero {i : Fin n} :
+    haveI : NeZero n := i.neZero_of_exists
+    i ≠ 0 → (i - 1).val = i - 1 := by
+  haveI : NeZero n := i.neZero_of_exists
+  intro hi
+  let _ : NeZero n := i.neZero_of_exists
   obtain ⟨n, rfl⟩ := Nat.exists_eq_succ_of_ne_zero (NeZero.ne n)
   rw [Fin.sub_val_of_le (one_le_of_ne_zero hi), Fin.val_one', Nat.mod_eq_of_lt
     (Nat.succ_le_iff.mpr (nontrivial_iff_two_le.mp <| nontrivial_of_ne i 0 hi))]
@@ -357,9 +372,11 @@ whose value is the original number. -/
 theorem val_cast_of_lt {n : ℕ} [NeZero n] {a : ℕ} (h : a < n) : (a : Fin n).val = a :=
   Nat.mod_eq_of_lt h
 
-/-- If `n` is non-zero, converting the value of a `Fin n` to `Fin n` results
-in the same value. -/
-@[simp, norm_cast] theorem cast_val_eq_self {n : ℕ} [NeZero n] (a : Fin n) : (a.val : Fin n) = a :=
+/-- Converting the value of a `Fin n` to `Fin n` results in the same value. -/
+@[simp, norm_cast] theorem cast_val_eq_self {n : ℕ} (a : Fin n) :
+    have : NeZero n := a.neZero_of_exists
+    (a.val : Fin n) = a :=
+  let _ : NeZero n := a.neZero_of_exists
   Fin.ext <| val_cast_of_lt a.isLt
 
 -- This is a special case of `CharP.cast_eq_zero` that doesn't require typeclass search
@@ -400,7 +417,7 @@ lemma natCast_strictMono (hbn : b ≤ n) (hab : a < b) : (a : Fin (n + 1)) < b :
 
 @[simp]
 lemma castLE_natCast {m n : ℕ} [NeZero m] (h : m ≤ n) (a : ℕ) :
-    letI : NeZero n := ⟨Nat.pos_iff_ne_zero.mp (lt_of_lt_of_le m.pos_of_neZero h)⟩
+    haveI : NeZero n := ⟨Nat.pos_iff_ne_zero.mp (lt_of_lt_of_le m.pos_of_neZero h)⟩
     Fin.castLE h (a.cast : Fin m) = (a % m : ℕ) := by
   ext
   simp only [val_castLE, val_natCast]
@@ -504,7 +521,8 @@ theorem coe_ofNat_eq_mod (m n : ℕ) [NeZero m] :
     ((ofNat(n) : Fin m) : ℕ) = ofNat(n) % m :=
   rfl
 
-theorem val_add_one_of_lt' {n : ℕ} [NeZero n] {i : Fin n} (h : i + 1 < n) :
+theorem val_add_one_of_lt' {n : ℕ} {i : Fin n} (h : i + 1 < n) :
+    haveI : NeZero n := i.neZero_of_exists
     (i + 1).val = i.val + 1 := by
   simpa [add_def] using Nat.mod_eq_of_lt (by lia)
 


### PR DESCRIPTION
This PR removes `[NeZero n]` assumptions in lemmas about `Fin n`, in contexts where the lemmas have a parameter of type `Fin n`, whose existence implies that `n` can't be zero. This makes the statements a bit uglier with the `haveI`s but they're much easier to apply.

---
<!-- Your PR title will become the first line of the commit message.

In this box, the text above the `---` (if not empty) will be appended
to the commit message, and can be used to give additional context or
details. Please leave a blank newline before the `---`, otherwise GitHub
will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

When merging, all the commits will be squashed into a single commit
listing all co-authors.

Co-authors in the squash commit are gathered from two sources:

First, all authors of commits to this PR branch are included. Thus,
one way to add co-authors is to include at least one commit authored by
each co-author among the commits in the pull request. If necessary, you
may create empty commits to indicate co-authorship, using commands like so:

git commit --author="Author Name <author@email.com>" --allow-empty -m "add Author Name as coauthor"

Second, co-authors can also be listed in lines at the very bottom of
the commit message (that is, directly before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines
at the bottom of the commit message (before the `---`, and also before
any "Co-authored-by" lines) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
