### PR TITLE
feat(Category Theory): Cartesian Natural Transformation

### DIFF
--- a/Mathlib.lean
+++ b/Mathlib.lean
@@ -2866,6 +2866,7 @@ public import Mathlib.CategoryTheory.MorphismProperty.TransfiniteComposition
 public import Mathlib.CategoryTheory.MorphismProperty.WeakFactorizationSystem
 public import Mathlib.CategoryTheory.NatIso
 public import Mathlib.CategoryTheory.NatTrans
+public import Mathlib.CategoryTheory.NatTransCartesian
 public import Mathlib.CategoryTheory.Noetherian
 public import Mathlib.CategoryTheory.ObjectProperty.Basic
 public import Mathlib.CategoryTheory.ObjectProperty.ClosedUnderIsomorphisms

--- a/Mathlib/CategoryTheory/NatTransCartesian.lean
+++ b/Mathlib/CategoryTheory/NatTransCartesian.lean
@@ -11,7 +11,7 @@ public import Mathlib.CategoryTheory.Limits.Shapes.Pullback.CommSq
 /-!
 # Cartesian natural transformations
 
-Defines natural transformations between functors is cartesian if all their naturality squares are
+A natural transformation between functors is cartesian if all its naturality squares are
 pullback squares.
 
 ## Main results

--- a/Mathlib/CategoryTheory/NatTransCartesian.lean
+++ b/Mathlib/CategoryTheory/NatTransCartesian.lean
@@ -1,0 +1,150 @@
+/-
+Copyright (c) 2025 Sina Hazratpour. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Sina Hazratpour, Wojciech Nawrocki
+-/
+module
+
+import Mathlib.CategoryTheory.NatTrans
+import Mathlib.CategoryTheory.Functor.TwoSquare
+import Mathlib.CategoryTheory.Limits.Shapes.Pullback.CommSq
+
+/-!
+# Cartesian natural transformations
+
+Defines natural transformations between functors is cartesian if all their naturality squares are
+pullback squares.
+
+## Main results
+
+- `NatTrans.isCartesian_of_discrete` shows that any natural transformation between functors from a
+  discrete category is cartesian.
+
+- `NatTrans.isCartesian_of_isIso` shows that any natural isomorphism is cartesian.
+
+- `NatTrans.isIso_of_isCartesian_of_isIso_app_terminal` shows that a cartesian natural
+  transformation is an isomorphism if its component at a terminal object is an isomorphism.
+
+- `NatTrans.isCartesian_of_isPullback_isTerminal_from` shows that a natural transformation is
+  cartesian if all its naturality squares to the terminal object are pullback squares.
+
+- `NatTrans.IsCartesian.comp` shows that the composition of two cartesian natural transformations is
+
+### References
+
+The content here is based on our work on the formalization of polynomial functors project at the
+Trimester "Prospect of Formal Mathematics" at the Hausdorff Institute (HIM) in Bonn:
+
+https://github.com/sinhp/Poly
+
+-/
+
+
+open CategoryTheory Limits IsPullback
+
+namespace CategoryTheory
+
+universe v' u' v u
+
+variable {J : Type v'} [Category.{u'} J] {C : Type u} [Category.{v} C]
+variable {K : Type*} [Category K] {D : Type*} [Category D]
+
+namespace NatTrans
+
+open Functor
+
+/-- A natural transformation is cartesian if all its naturality squares are pullbacks. -/
+def IsCartesian {F G : J ⥤ C} (α : F ⟶ G) : Prop :=
+  ∀ ⦃X Y : J⦄ (f : X ⟶ Y), IsPullback (F.map f) (α.app X) (α.app Y) (G.map f)
+
+theorem isCartesian_of_discrete {ι : Type*} {F G : Discrete ι ⥤ C}
+    (α : F ⟶ G) : IsCartesian α := by
+  rintro ⟨X⟩ ⟨Y⟩ ⟨⟨rfl : X = Y⟩⟩
+  simp only [Discrete.functor_map_id]
+  exact IsPullback.of_horiz_isIso ⟨by rw [Category.id_comp, Category.comp_id]⟩
+
+theorem isCartesian_of_isIso {F G : J ⥤ C} (α : F ⟶ G) [IsIso α] : IsCartesian α :=
+  fun _ _ f => IsPullback.of_vert_isIso ⟨NatTrans.naturality _ f⟩
+
+theorem isIso_of_isCartesian_of_isIso_app_terminal {F G : J ⥤ C} (α : F ⟶ G) (hα : IsCartesian α)
+    (T : J) (hT : IsTerminal T) [IsIso (α.app T)] : IsIso α :=
+  @NatIso.isIso_of_isIso_app _ _ _ _ _ _ α
+    (fun j ↦ isIso_snd_of_isIso <| hα <| hT.from j)
+
+theorem isCartesian_of_isPullback_isTerminal_from {F G : J ⥤ C} (α : F ⟶ G)
+    (T : J) (hT : IsTerminal T)
+    (pb : ∀ Y, IsPullback (F.map (hT.from Y)) (α.app Y) (α.app T) (G.map (hT.from Y))) :
+    IsCartesian α := by
+  intro X Y f
+  apply IsPullback.of_right (h₁₂ := F.map (hT.from Y)) (h₂₂ := G.map (hT.from Y))
+  · simpa [← F.map_comp, ← G.map_comp] using (pb X)
+  · exact α.naturality f
+  · exact pb Y
+
+namespace IsCartesian
+
+theorem comp {F G H : J ⥤ C} {α : F ⟶ G} {β : G ⟶ H} (hα : IsCartesian α) (hβ : IsCartesian β) :
+    IsCartesian (α ≫ β) :=
+  fun _ _ f => (hα f).paste_vert (hβ f)
+
+theorem whiskerRight {F G : J ⥤ C} {α : F ⟶ G} (hα : IsCartesian α) (H : C ⥤ D)
+    [∀ (X Y : J) (f : Y ⟶ X), PreservesLimit (cospan (α.app X) (G.map f)) H] :
+    IsCartesian (whiskerRight α H) :=
+  fun _ _ f => (hα f).map H
+
+theorem whiskerLeft {K : Type*} [Category K] {F G : J ⥤ C}
+    {α : F ⟶ G} (hα : IsCartesian α) (H : K ⥤ J) : IsCartesian (whiskerLeft H α) :=
+  fun _ _ f => hα (H.map f)
+
+theorem hcomp {K : Type*} [Category K] {F G : J ⥤ C} {M N : C ⥤ K} {α : F ⟶ G} {β : M ⟶ N}
+    (hα : IsCartesian α) (hβ : IsCartesian β)
+    [∀ (X Y : J) (f : Y ⟶ X), PreservesLimit (cospan (α.app X) (G.map f)) M] :
+    IsCartesian (NatTrans.hcomp α β) := by
+  have ha := hα.whiskerRight M
+  have hb := hβ.whiskerLeft G
+  have hc := ha.comp hb
+  unfold IsCartesian
+  intros X Y f
+  specialize hc f
+  simp only [Functor.comp_obj, Functor.comp_map, comp_app,
+    whiskerRight_app, whiskerLeft_app,
+    naturality] at hc
+  exact hc
+
+open TwoSquare
+
+universe v₁ v₂ v₃ v₄ v₅ v₆ v₇ v₈ u₁ u₂ u₃ u₄ u₅ u₆ u₇ u₈
+
+variable {C₁ : Type u₁} {C₂ : Type u₂} {C₃ : Type u₃} {C₄ : Type u₄}
+  [Category.{v₁} C₁] [Category.{v₂} C₂] [Category.{v₃} C₃] [Category.{v₄} C₄]
+  {T : C₁ ⥤ C₂} {L : C₁ ⥤ C₃} {R : C₂ ⥤ C₄} {B : C₃ ⥤ C₄}
+
+variable {C₅ : Type u₅} {C₆ : Type u₆} {C₇ : Type u₇} {C₈ : Type u₈}
+  [Category.{v₅} C₅] [Category.{v₆} C₆] [Category.{v₇} C₇] [Category.{v₈} C₈]
+  {T' : C₂ ⥤ C₅} {R' : C₅ ⥤ C₆} {B' : C₄ ⥤ C₆} {L' : C₃ ⥤ C₇} {R'' : C₄ ⥤ C₈} {B'' : C₇ ⥤ C₈}
+
+theorem vComp {w : TwoSquare T L R B} {w' : TwoSquare B L' R'' B''}
+    [∀ (X Y : C₁) (f : Y ⟶ X), PreservesLimit (cospan (w.app X) ((L ⋙ B).map f)) R''] :
+    IsCartesian w → IsCartesian w' → IsCartesian (w ≫ᵥ w') :=
+  fun cw cw' =>
+    (isCartesian_of_isIso _).comp <|
+    (cw.whiskerRight _).comp <|
+    (isCartesian_of_isIso _).comp <|
+    (cw'.whiskerLeft _).comp <|
+    (isCartesian_of_isIso _)
+
+theorem hComp {w : TwoSquare T L R B} {w' : TwoSquare T' R R' B'}
+    [∀ (X Y : C₁) (f : Y ⟶ X), PreservesLimit (cospan (w.app X) ((L ⋙ B).map f)) B'] :
+    IsCartesian w → IsCartesian w' → IsCartesian (w ≫ₕ w') :=
+  fun cw cw' =>
+    (isCartesian_of_isIso _).comp <|
+    (cw'.whiskerLeft _).comp <|
+    (isCartesian_of_isIso _).comp <|
+    (cw.whiskerRight _).comp <|
+    (isCartesian_of_isIso _)
+
+end IsCartesian
+
+end NatTrans
+
+end CategoryTheory

--- a/Mathlib/CategoryTheory/NatTransCartesian.lean
+++ b/Mathlib/CategoryTheory/NatTransCartesian.lean
@@ -68,7 +68,7 @@ theorem isCartesian_of_isIso {F G : J ⥤ C} (α : F ⟶ G) [IsIso α] : IsCarte
 
 theorem isIso_of_isCartesian_of_isIso_app_terminal {F G : J ⥤ C} (α : F ⟶ G) (hα : IsCartesian α)
     (T : J) (hT : IsTerminal T) [IsIso (α.app T)] : IsIso α :=
-  have := fun j ↦ isIso_snd_of_isIso <| hα <| hT.from j 
+  have := fun j ↦ isIso_snd_of_isIso <| hα <| hT.from j
   NatIso.isIso_of_isIso_app _
 
 theorem isCartesian_of_isPullback_isTerminal_from {F G : J ⥤ C} (α : F ⟶ G)

--- a/Mathlib/CategoryTheory/NatTransCartesian.lean
+++ b/Mathlib/CategoryTheory/NatTransCartesian.lean
@@ -5,9 +5,8 @@ Authors: Sina Hazratpour, Wojciech Nawrocki
 -/
 module
 
-import Mathlib.CategoryTheory.NatTrans
-import Mathlib.CategoryTheory.Functor.TwoSquare
-import Mathlib.CategoryTheory.Limits.Shapes.Pullback.CommSq
+public import Mathlib.CategoryTheory.Functor.TwoSquare
+public import Mathlib.CategoryTheory.Limits.Shapes.Pullback.CommSq
 
 /-!
 # Cartesian natural transformations
@@ -39,12 +38,13 @@ https://github.com/sinhp/Poly
 
 -/
 
+@[expose] public section
+
+universe v' u' v u
 
 open CategoryTheory Limits IsPullback
 
 namespace CategoryTheory
-
-universe v' u' v u
 
 variable {J : Type v'} [Category.{u'} J] {C : Type u} [Category.{v} C]
 variable {K : Type*} [Category K] {D : Type*} [Category D]

--- a/Mathlib/CategoryTheory/NatTransCartesian.lean
+++ b/Mathlib/CategoryTheory/NatTransCartesian.lean
@@ -32,8 +32,8 @@ pullback squares.
 
 ### References
 
-The content here is based on our work on the formalization of polynomial functors project at the
-Trimester "Prospect of Formal Mathematics" at the Hausdorff Institute (HIM) in Bonn:
+This material is adapted from the polynomial functors project developed during the
+Trimester "Prospects of Formal Mathematics" at the Hausdorff Institute (HIM) in Bonn:
 
 https://github.com/sinhp/Poly
 

--- a/Mathlib/CategoryTheory/NatTransCartesian.lean
+++ b/Mathlib/CategoryTheory/NatTransCartesian.lean
@@ -109,14 +109,12 @@ theorem hcomp {K : Type*} [Category K] {F G : J ⥤ C} {M N : C ⥤ K} {α : F �
 
 open TwoSquare
 
-universe v₁ v₂ v₃ v₄ v₅ v₆ v₇ v₈ u₁ u₂ u₃ u₄ u₅ u₆ u₇ u₈
-
-variable {C₁ : Type u₁} {C₂ : Type u₂} {C₃ : Type u₃} {C₄ : Type u₄}
-  [Category.{v₁} C₁] [Category.{v₂} C₂] [Category.{v₃} C₃] [Category.{v₄} C₄]
+variable {C₁ C₂ C₃ C₄ : Type*}
+  [Category* C₁] [Category* C₂] [Category* C₃] [Category* C₄]
   {T : C₁ ⥤ C₂} {L : C₁ ⥤ C₃} {R : C₂ ⥤ C₄} {B : C₃ ⥤ C₄}
 
-variable {C₅ : Type u₅} {C₆ : Type u₆} {C₇ : Type u₇} {C₈ : Type u₈}
-  [Category.{v₅} C₅] [Category.{v₆} C₆] [Category.{v₇} C₇] [Category.{v₈} C₈]
+variable {C₅ C₆ C₇ C₈ : Type*}
+  [Category* C₅] [Category* C₆] [Category* C₇] [Category* C₈]
   {T' : C₂ ⥤ C₅} {R' : C₅ ⥤ C₆} {B' : C₄ ⥤ C₆} {L'' : C₃ ⥤ C₇} {R'' : C₄ ⥤ C₈} {B'' : C₇ ⥤ C₈}
 
 theorem vComp {w : TwoSquare T L R B} {w' : TwoSquare B L'' R'' B''}

--- a/Mathlib/CategoryTheory/NatTransCartesian.lean
+++ b/Mathlib/CategoryTheory/NatTransCartesian.lean
@@ -87,29 +87,25 @@ theorem comp {F G H : J ⥤ C} {α : F ⟶ G} {β : G ⟶ H} (hα : IsCartesian 
     IsCartesian (α ≫ β) :=
   fun _ _ f => (hα f).paste_vert (hβ f)
 
-theorem whiskerRight {F G : J ⥤ C} {α : F ⟶ G} (hα : IsCartesian α) (H : C ⥤ D)
-    [∀ (X Y : J) (f : Y ⟶ X), PreservesLimit (cospan (α.app X) (G.map f)) H] :
-    IsCartesian (whiskerRight α H) :=
-  fun _ _ f => (hα f).map H
-
 theorem whiskerLeft {K : Type*} [Category K] {F G : J ⥤ C}
     {α : F ⟶ G} (hα : IsCartesian α) (H : K ⥤ J) : IsCartesian (whiskerLeft H α) :=
   fun _ _ f => hα (H.map f)
+
+theorem whiskerRight {F G : J ⥤ C} {α : F ⟶ G} (hα : IsCartesian α) (H : C ⥤ D)
+    [∀ (X Y : J) (f : X ⟶ Y), PreservesLimit (cospan (α.app Y) (G.map f)) H] :
+    IsCartesian (whiskerRight α H) :=
+  fun _ _ f => (hα f).map H
 
 theorem hcomp {K : Type*} [Category K] {F G : J ⥤ C} {M N : C ⥤ K} {α : F ⟶ G} {β : M ⟶ N}
     (hα : IsCartesian α) (hβ : IsCartesian β)
     [∀ (X Y : J) (f : Y ⟶ X), PreservesLimit (cospan (α.app X) (G.map f)) M] :
     IsCartesian (NatTrans.hcomp α β) := by
-  have ha := hα.whiskerRight M
-  have hb := hβ.whiskerLeft G
-  have hc := ha.comp hb
-  unfold IsCartesian
+  have H := hα.whiskerRight M |>.comp (hβ.whiskerLeft G)
   intros X Y f
-  specialize hc f
-  simp only [Functor.comp_obj, Functor.comp_map, comp_app,
-    whiskerRight_app, whiskerLeft_app,
-    naturality] at hc
-  exact hc
+  specialize H f
+  simp only [Functor.comp_obj, Functor.comp_map, comp_app, whiskerRight_app, whiskerLeft_app,
+  naturality] at H
+  exact H
 
 open TwoSquare
 

--- a/Mathlib/CategoryTheory/NatTransCartesian.lean
+++ b/Mathlib/CategoryTheory/NatTransCartesian.lean
@@ -68,8 +68,8 @@ theorem isCartesian_of_isIso {F G : J ⥤ C} (α : F ⟶ G) [IsIso α] : IsCarte
 
 theorem isIso_of_isCartesian_of_isIso_app_terminal {F G : J ⥤ C} (α : F ⟶ G) (hα : IsCartesian α)
     (T : J) (hT : IsTerminal T) [IsIso (α.app T)] : IsIso α :=
-  @NatIso.isIso_of_isIso_app _ _ _ _ _ _ α
-    (fun j ↦ isIso_snd_of_isIso <| hα <| hT.from j)
+  have := fun j ↦ isIso_snd_of_isIso <| hα <| hT.from j 
+  NatIso.isIso_of_isIso_app _
 
 theorem isCartesian_of_isPullback_isTerminal_from {F G : J ⥤ C} (α : F ⟶ G)
     (T : J) (hT : IsTerminal T)

--- a/Mathlib/CategoryTheory/NatTransCartesian.lean
+++ b/Mathlib/CategoryTheory/NatTransCartesian.lean
@@ -83,29 +83,29 @@ theorem isCartesian_of_isPullback_isTerminal_from {F G : J ⥤ C} (α : F ⟶ G)
 
 namespace IsCartesian
 
-theorem comp {F G H : J ⥤ C} {α : F ⟶ G} {β : G ⟶ H} (hα : IsCartesian α) (hβ : IsCartesian β) :
-    IsCartesian (α ≫ β) :=
-  fun _ _ f => (hα f).paste_vert (hβ f)
+theorem comp {F G H : J ⥤ C} {α : F ⟶ G} {β : G ⟶ H} :
+    IsCartesian α → IsCartesian β → IsCartesian (α ≫ β) :=
+  fun cα cβ _ _ f => (cα f).paste_vert (cβ f)
 
 theorem whiskerLeft {K : Type*} [Category K] {F G : J ⥤ C}
-    {α : F ⟶ G} (hα : IsCartesian α) (H : K ⥤ J) : IsCartesian (whiskerLeft H α) :=
-  fun _ _ f => hα (H.map f)
+    {α : F ⟶ G} (H : K ⥤ J) :
+  IsCartesian α → IsCartesian (whiskerLeft H α) :=
+  fun cα _ _ f => cα (H.map f)
 
-theorem whiskerRight {F G : J ⥤ C} {α : F ⟶ G} (hα : IsCartesian α) (H : C ⥤ D)
+theorem whiskerRight {F G : J ⥤ C} {α : F ⟶ G} (H : C ⥤ D)
     [∀ (X Y : J) (f : X ⟶ Y), PreservesLimit (cospan (α.app Y) (G.map f)) H] :
-    IsCartesian (whiskerRight α H) :=
-  fun _ _ f => (hα f).map H
+    IsCartesian α → IsCartesian (whiskerRight α H) :=
+  fun cα _ _ f => (cα f).map H
 
 theorem hcomp {K : Type*} [Category K] {F G : J ⥤ C} {M N : C ⥤ K} {α : F ⟶ G} {β : M ⟶ N}
-    (hα : IsCartesian α) (hβ : IsCartesian β)
     [∀ (X Y : J) (f : Y ⟶ X), PreservesLimit (cospan (α.app X) (G.map f)) M] :
-    IsCartesian (NatTrans.hcomp α β) := by
-  have H := hα.whiskerRight M |>.comp (hβ.whiskerLeft G)
-  intros X Y f
-  specialize H f
-  simp only [Functor.comp_obj, Functor.comp_map, comp_app, whiskerRight_app, whiskerLeft_app,
-  naturality] at H
-  exact H
+    IsCartesian α → IsCartesian β → IsCartesian (α ◫ β) :=
+  fun cα cβ => by
+    have H := cα.whiskerRight M |>.comp (cβ.whiskerLeft G)
+    intro X Y f
+    specialize H f
+    simpa [Functor.comp_obj, Functor.comp_map, comp_app, whiskerRight_app, whiskerLeft_app,
+    naturality] using H
 
 open TwoSquare
 
@@ -117,9 +117,9 @@ variable {C₁ : Type u₁} {C₂ : Type u₂} {C₃ : Type u₃} {C₄ : Type u
 
 variable {C₅ : Type u₅} {C₆ : Type u₆} {C₇ : Type u₇} {C₈ : Type u₈}
   [Category.{v₅} C₅] [Category.{v₆} C₆] [Category.{v₇} C₇] [Category.{v₈} C₈]
-  {T' : C₂ ⥤ C₅} {R' : C₅ ⥤ C₆} {B' : C₄ ⥤ C₆} {L' : C₃ ⥤ C₇} {R'' : C₄ ⥤ C₈} {B'' : C₇ ⥤ C₈}
+  {T' : C₂ ⥤ C₅} {R' : C₅ ⥤ C₆} {B' : C₄ ⥤ C₆} {L'' : C₃ ⥤ C₇} {R'' : C₄ ⥤ C₈} {B'' : C₇ ⥤ C₈}
 
-theorem vComp {w : TwoSquare T L R B} {w' : TwoSquare B L' R'' B''}
+theorem vComp {w : TwoSquare T L R B} {w' : TwoSquare B L'' R'' B''}
     [∀ (X Y : C₁) (f : Y ⟶ X), PreservesLimit (cospan (w.app X) ((L ⋙ B).map f)) R''] :
     IsCartesian w → IsCartesian w' → IsCartesian (w ≫ᵥ w') :=
   fun cw cw' =>


### PR DESCRIPTION
This PR defines cartesian natural transformations between functors and proves they are closed under horizontal and vertical composition. Also we prove the following results: 

- `NatTrans.isCartesian_of_discrete` shows that any natural transformation between functors from a
  discrete category is cartesian.

- `NatTrans.isCartesian_of_isIso` shows that any natural isomorphism is cartesian.

- `NatTrans.isIso_of_isCartesian_of_isIso_app_terminal` shows that a cartesian natural
  transformation is an isomorphism if its component at a terminal object is an isomorphism.

- `NatTrans.isCartesian_of_isPullback_isTerminal_from` shows that a natural transformation is
  cartesian if all its naturality squares to the terminal object are pullback squares.

This material is adapted from the polynomial functors project developed during the
Trimester "Prospects of Formal Mathematics" at the Hausdorff Institute (HIM) in Bonn:

https://github.com/sinhp/Poly


Co-authored-by: Wojciech Nawrocki <wjnawrocki+gh@protonmail.com>

---
<!-- Your PR title will become the first line of the commit message.

In this box, the text above the `---` (if not empty) will be appended
to the commit message, and can be used to give additional context or
details. Please leave a blank newline before the `---`, otherwise GitHub
will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

When merging, all the commits will be squashed into a single commit
listing all co-authors.

Co-authors in the squash commit are gathered from two sources:

First, all authors of commits to this PR branch are included. Thus,
one way to add co-authors is to include at least one commit authored by
each co-author among the commits in the pull request. If necessary, you
may create empty commits to indicate co-authorship, using commands like so:

git commit --author="Author Name <author@email.com>" --allow-empty -m "add Author Name as coauthor"

Second, co-authors can also be listed in lines at the very bottom of
the commit message (that is, directly before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines
at the bottom of the commit message (before the `---`, and also before
any "Co-authored-by" lines) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
