### PR TITLE
feat(Data/Nat/Choose): Binomial inversion

### DIFF
--- a/Mathlib.lean
+++ b/Mathlib.lean
@@ -3750,6 +3750,7 @@ public import Mathlib.Data.Nat.Choose.Cast
 public import Mathlib.Data.Nat.Choose.Central
 public import Mathlib.Data.Nat.Choose.Dvd
 public import Mathlib.Data.Nat.Choose.Factorization
+public import Mathlib.Data.Nat.Choose.Inversion
 public import Mathlib.Data.Nat.Choose.Lucas
 public import Mathlib.Data.Nat.Choose.Mul
 public import Mathlib.Data.Nat.Choose.Multinomial

--- a/Mathlib/Algebra/Ring/Units.lean
+++ b/Mathlib/Algebra/Ring/Units.lean
@@ -100,11 +100,6 @@ theorem IsUnit.neg_iff [Monoid α] [HasDistribNeg α] (a : α) : IsUnit (-a) ↔
 
 theorem isUnit_neg_one [Monoid α] [HasDistribNeg α] : IsUnit (-1 : α) := isUnit_one.neg
 
-theorem isUnit_neg_one_pow [Monoid R] [HasDistribNeg R] (n : ℕ) : IsUnit ((-1 : R) ^ n) := by
-  induction n with
-  | zero => simp
-  | succ => simpa [pow_succ]
-
 theorem IsUnit.sub_iff [Ring α] {x y : α} : IsUnit (x - y) ↔ IsUnit (y - x) :=
   (IsUnit.neg_iff _).symm.trans <| neg_sub x y ▸ Iff.rfl
 

--- a/Mathlib/Algebra/Ring/Units.lean
+++ b/Mathlib/Algebra/Ring/Units.lean
@@ -100,6 +100,11 @@ theorem IsUnit.neg_iff [Monoid α] [HasDistribNeg α] (a : α) : IsUnit (-a) ↔
 
 theorem isUnit_neg_one [Monoid α] [HasDistribNeg α] : IsUnit (-1 : α) := isUnit_one.neg
 
+theorem isUnit_neg_one_pow [Monoid R] [HasDistribNeg R] (n : ℕ) : IsUnit ((-1 : R) ^ n) := by
+  induction n with
+  | zero => simp
+  | succ => simpa [pow_succ]
+
 theorem IsUnit.sub_iff [Ring α] {x y : α} : IsUnit (x - y) ↔ IsUnit (y - x) :=
   (IsUnit.neg_iff _).symm.trans <| neg_sub x y ▸ Iff.rfl
 

--- a/Mathlib/Data/Nat/Choose/Inversion.lean
+++ b/Mathlib/Data/Nat/Choose/Inversion.lean
@@ -82,13 +82,13 @@ theorem alternating_sum_choose_mul_eq_iff' (f g : ℕ → G) :
     ring_nf
     simp
   · rw [alternating_sum_choose_mul_eq_iff (fun n ↦ (-1) ^ n • f n) g]
-    refine forall_congr' ?_
+    apply forall_congr'
     intro n
     rw [← IsUnit.smul_left_cancel (y := f n) (isUnit_neg_one_pow (R := ℤ) n)]
     refine Eq.congr ?_ rfl
     rw [smul_sum]
     congr! 1
-    rw [smul_smul, ← mul_assoc, ← pow_add, ← add_assoc, ← Nat.two_mul n, pow_add]
+    rw [smul_smul, ← mul_assoc, ← pow_add, ← add_assoc, ← Nat.two_mul, pow_add]
     simp
 
 theorem alternating_sum_choose_mul_choose (n m : ℕ) :

--- a/Mathlib/Data/Nat/Choose/Inversion.lean
+++ b/Mathlib/Data/Nat/Choose/Inversion.lean
@@ -62,14 +62,14 @@ theorem alternating_sum_choose_smul_of_alternating_sum_choose_smul {f g : ℕ �
 /-- **Binomial inversion**, symmetric version. -/
 theorem alternating_sum_choose_smul_eq_iff (f g : ℕ → G) :
     (∀ n, ∑ k ∈ Finset.range (n + 1), ((-1) ^ k * (↑(n.choose k) : ℤ)) • f k = g n) ↔
-    ∀ n, ∑ k ∈ Finset.range (n + 1), ((-1) ^ k * (↑(n.choose k) : ℤ)) • g k = f n :=
+      ∀ n, ∑ k ∈ Finset.range (n + 1), ((-1) ^ k * (↑(n.choose k) : ℤ)) • g k = f n :=
   ⟨fun h _ ↦ alternating_sum_choose_smul_of_alternating_sum_choose_smul _ h,
   fun h _ ↦ alternating_sum_choose_smul_of_alternating_sum_choose_smul _ h⟩
 
 /-- **Binomial inversion**, asymmetric version. -/
 theorem sum_choose_smul_eq_iff (f g : ℕ → G) :
     (∀ n, ∑ k ∈ Finset.range (n + 1), (n.choose k) • f k = g n) ↔
-    ∀ n, ∑ k ∈ Finset.range (n + 1), ((- 1) ^ (n + k) * (↑(n.choose k) : ℤ)) • g k = f n := by
+      ∀ n, ∑ k ∈ Finset.range (n + 1), ((- 1) ^ (n + k) * (↑(n.choose k) : ℤ)) • g k = f n := by
   apply Iff.trans (b := ∀ (n : ℕ),
     ∑ k ∈ Finset.range (n + 1), ((-1) ^ k *(↑(n.choose k) : ℤ)) • (-1) ^ k • f k = g n)
   · congr! 3
@@ -88,7 +88,7 @@ theorem sum_choose_smul_eq_iff (f g : ℕ → G) :
 
 theorem alternating_sum_choose_mul_choose (n m : ℕ) :
     ∑ k ∈ Finset.range (n + 1), (-1) ^ k * (↑(n.choose k) : ℤ) * (k.choose m)
-    = (-1) ^ m * if n = m then 1 else 0 := by
+      = (-1) ^ m * if n = m then 1 else 0 := by
   apply alternating_sum_choose_smul_of_alternating_sum_choose_smul
   intro k
   by_cases h : m < k + 1 <;> simp only [reduceNeg, mul_ite, mul_one, mul_zero, Int.zsmul_eq_mul,

--- a/Mathlib/Data/Nat/Choose/Inversion.lean
+++ b/Mathlib/Data/Nat/Choose/Inversion.lean
@@ -24,7 +24,7 @@ namespace Int
 
 variable {G : Type*} [AddCommGroup G]
 
-theorem alternating_sum_choose_mul_of_alternating_sum_choose_mul {f g : ℕ → G} (m : ℕ)
+theorem alternating_sum_choose_smul_of_alternating_sum_choose_smul {f g : ℕ → G} (m : ℕ)
     (h : ∀ n, ∑ k ∈ Finset.range (n + 1), (((-1) ^ k * ↑(n.choose k) : ℤ)) • f k = g n) :
     ∑ k ∈ Finset.range (m + 1), ((-1) ^ k * (↑(m.choose k) : ℤ)) • g k = f m :=
   calc
@@ -62,26 +62,23 @@ theorem alternating_sum_choose_mul_of_alternating_sum_choose_mul {f g : ℕ → 
     _ = f m := by simp
 
 /-- **Binomial inversion**, symmetric version. -/
-theorem alternating_sum_choose_mul_eq_iff (f g : ℕ → G) :
+theorem alternating_sum_choose_smul_eq_iff (f g : ℕ → G) :
     (∀ n, ∑ k ∈ Finset.range (n + 1), ((-1) ^ k * (↑(n.choose k) : ℤ)) • f k = g n) ↔
     ∀ n, ∑ k ∈ Finset.range (n + 1), ((-1) ^ k * (↑(n.choose k) : ℤ)) • g k = f n :=
-  ⟨fun h _ ↦ alternating_sum_choose_mul_of_alternating_sum_choose_mul _ h,
-  fun h _ ↦ alternating_sum_choose_mul_of_alternating_sum_choose_mul _ h⟩
+  ⟨fun h _ ↦ alternating_sum_choose_smul_of_alternating_sum_choose_smul _ h,
+  fun h _ ↦ alternating_sum_choose_smul_of_alternating_sum_choose_smul _ h⟩
 
 /-- **Binomial inversion**, asymmetric version. -/
-theorem alternating_sum_choose_mul_eq_iff' (f g : ℕ → G) :
+theorem sum_choose_smul_eq_iff (f g : ℕ → G) :
     (∀ n, ∑ k ∈ Finset.range (n + 1), (n.choose k) • f k = g n) ↔
     ∀ n, ∑ k ∈ Finset.range (n + 1), ((- 1) ^ (n + k) * (↑(n.choose k) : ℤ)) • g k = f n := by
   apply Iff.trans (b := ∀ (n : ℕ),
     ∑ k ∈ Finset.range (n + 1), ((-1) ^ k *(↑(n.choose k) : ℤ)) • (-1) ^ k • f k = g n)
-  · refine forall_congr' ?_
-    intro
-    refine Eq.congr ?_ rfl
-    congr! 1
+  · congr! 3
     rw [smul_smul, ← Lean.Grind.IntModule.zsmul_natCast_eq_nsmul]
     ring_nf
     simp
-  · rw [alternating_sum_choose_mul_eq_iff (fun n ↦ (-1) ^ n • f n) g]
+  · rw [alternating_sum_choose_smul_eq_iff (fun n ↦ (-1) ^ n • f n) g]
     apply forall_congr'
     intro n
     rw [← IsUnit.smul_left_cancel (y := f n) (isUnit_neg_one_pow (R := ℤ) n)]
@@ -94,7 +91,7 @@ theorem alternating_sum_choose_mul_eq_iff' (f g : ℕ → G) :
 theorem alternating_sum_choose_mul_choose (n m : ℕ) :
     ∑ k ∈ Finset.range (n + 1), (-1) ^ k * (↑(n.choose k) : ℤ) * (k.choose m)
     = (-1) ^ m * if n = m then 1 else 0 := by
-  apply alternating_sum_choose_mul_of_alternating_sum_choose_mul
+  apply alternating_sum_choose_smul_of_alternating_sum_choose_smul
   intro k
   by_cases h : m < k + 1 <;> simp only [reduceNeg, mul_ite, mul_one, mul_zero, Int.zsmul_eq_mul,
     Finset.sum_ite_eq', Finset.mem_range, h, ↓reduceIte]

--- a/Mathlib/Data/Nat/Choose/Inversion.lean
+++ b/Mathlib/Data/Nat/Choose/Inversion.lean
@@ -6,8 +6,6 @@ Authors: Felix Pernegger
 module
 
 public import Mathlib.Algebra.Module.BigOperators
-public import Mathlib.Algebra.Order.Star.Basic
-public import Mathlib.Analysis.Normed.Ring.Lemmas
 public import Mathlib.Data.Nat.Choose.Sum
 
 /-! # Binomial inversion

--- a/Mathlib/Data/Nat/Choose/Inversion.lean
+++ b/Mathlib/Data/Nat/Choose/Inversion.lean
@@ -61,14 +61,14 @@ theorem alternating_sum_choose_mul_of_alternating_sum_choose_mul {f g : ℕ → 
       rw [mul_comm n 2, Even.neg_one_pow (even_two_mul n), mul_one]
     _ = f m := by simp
 
-/-- **Binomial inversion**, symmetric version -/
+/-- **Binomial inversion**, symmetric version. -/
 theorem alternating_sum_choose_mul_eq_iff (f g : ℕ → G) :
     (∀ n, ∑ k ∈ Finset.range (n + 1), ((-1) ^ k * (↑(n.choose k) : ℤ)) • f k = g n) ↔
     ∀ n, ∑ k ∈ Finset.range (n + 1), ((-1) ^ k * (↑(n.choose k) : ℤ)) • g k = f n :=
   ⟨fun h _ ↦ alternating_sum_choose_mul_of_alternating_sum_choose_mul _ h,
   fun h _ ↦ alternating_sum_choose_mul_of_alternating_sum_choose_mul _ h⟩
 
-/-- **Binomial inversion**, asymmetric version -/
+/-- **Binomial inversion**, asymmetric version. -/
 theorem alternating_sum_choose_mul_eq_iff' (f g : ℕ → G) :
     (∀ n, ∑ k ∈ Finset.range (n + 1), (n.choose k) • f k = g n) ↔
     ∀ n, ∑ k ∈ Finset.range (n + 1), ((- 1) ^ (n + k) * (↑(n.choose k) : ℤ)) • g k = f n := by

--- a/Mathlib/Data/Nat/Choose/Inversion.lean
+++ b/Mathlib/Data/Nat/Choose/Inversion.lean
@@ -79,7 +79,7 @@ theorem sum_choose_smul_eq_iff (f g : ℕ → G) :
   · rw [alternating_sum_choose_smul_eq_iff (fun n ↦ (-1) ^ n • f n) g]
     apply forall_congr'
     intro n
-    rw [← IsUnit.smul_left_cancel (y := f n) (isUnit_neg_one_pow (R := ℤ) n)]
+    rw [← ((isUnit_neg_one (α := ℤ)).pow n) |>.smul_left_cancel (y := f n)]
     refine Eq.congr ?_ rfl
     rw [smul_sum]
     congr! 1

--- a/Mathlib/Data/Nat/Choose/Inversion.lean
+++ b/Mathlib/Data/Nat/Choose/Inversion.lean
@@ -1,0 +1,103 @@
+/-
+Copyright (c) 2025 Felix Pernegger. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Felix Pernegger
+-/
+module
+
+public import Mathlib.Data.Nat.Choose.Basic
+public import Mathlib.Tactic.Ring.RingNF
+
+/-! # Binomial inversion
+
+This file includes two versions of binomial inversion and a simple application thereof.
+
+-/
+
+@[expose] public section
+
+namespace Int
+
+theorem Int.alternating_sum_choose_mul_of_alternating_sum_choose_mul {f g : ℕ → G} (m : ℕ)
+    (h : ∀ n, ∑ k ∈ Finset.range (n + 1), (((-1) ^ k * ↑(choose n k) : ℤ)) • f k = g n) :
+    ∑ k ∈ Finset.range (m + 1), ((-1) ^ k * (↑(choose m k) : ℤ)) • g k = f m :=
+  calc
+    _ = ∑ k ∈ Finset.range (m + 1), ∑ i ∈ Finset.range (k + 1),
+          ((-1) ^ k * (↑(choose m k) : ℤ)) • ((-1) ^ i * (↑(choose k i) : ℤ)) • f i := by
+      congr!
+      rw [← h, sum_zsmul]
+    _ = ∑ i ∈ Finset.range (m + 1), ∑ k ∈ Ico i (m + 1),
+          ((-1) ^ k * (↑(choose m k) : ℤ)) • ((-1) ^ i * (↑(choose k i) : ℤ)) • f i := by
+        rw [range_eq_Ico, sum_Ico_Ico_comm]
+    _ = ∑ i ∈ Finset.range (m + 1), ∑ k ∈ Ico i (m + 1), ((-1) ^ k *
+          ((↑(choose m i) : ℤ) * ((-1) ^ i * ↑(choose (m - i) (k - i) : ℤ)))) • f i := by
+      congr! 2 with a _ b h'
+      rw [← mul_zsmul, mul_assoc, ← mul_assoc, mul_assoc ((-1) ^ _), mul_left_comm _ ((-1) ^ a),
+        ← Nat.cast_mul, choose_mul (List.left_le_of_mem_range' h'), Nat.cast_mul,
+        mul_left_comm (↑(m.choose a) : ℤ)]
+    _ = ∑ i ∈ Finset.range (m + 1), (choose m i *
+          if i = m then (1 : ℤ) else 0) • f i := by
+      congr! 1 with n hn
+      have : (if n = m then (1 : ℤ) else (0 : ℤ)) = if m - n = 0 then 1 else 0 := by
+        refine ite_cond_congr ?_
+        simp only [Nat.sub_eq_zero_iff_le, eq_iff_iff]
+        constructor <;> intro h
+        · rw [h]
+        · exact le_antisymm (mem_range_succ_iff.mp hn) h
+      rw [this, ← Int.alternating_sum_range_choose, mul_sum, sum_smul]
+      nth_rw 1 [← zero_add n]
+      rw [← Nat.sub_add_cancel (mem_range_le hn), Nat.sub_add_comm (mem_range_succ_iff.mp hn),
+        ← Finset.sum_Ico_add, Ico_zero_eq_range]
+      congr! 1
+      nth_rw 2 [add_comm n]
+      rw [Nat.add_sub_cancel]
+      ring_nf
+      rw [mul_comm n 2, Even.neg_one_pow (even_two_mul n), mul_one]
+    _ = f m := by simp
+
+theorem Int.alternating_sum_choose_mul_eq_iff (f g : ℕ → G) :
+    (∀ n, ∑ k ∈ Finset.range (n + 1), ((-1) ^ k * (↑(choose n k) : ℤ)) • f k = g n) ↔
+    ∀ n, ∑ k ∈ Finset.range (n + 1), ((-1) ^ k * (↑(choose n k) : ℤ)) • g k = f n :=
+  ⟨fun h _ ↦ Int.alternating_sum_choose_mul_of_alternating_sum_choose_mul _ h,
+  fun h _ ↦ Int.alternating_sum_choose_mul_of_alternating_sum_choose_mul _ h⟩
+
+theorem Int.alternating_sum_choose_mul_eq_iff' (f g : ℕ → G) :
+    (∀ n, ∑ k ∈ Finset.range (n + 1), (choose n k) • f k = g n) ↔
+    ∀ n, ∑ k ∈ Finset.range (n + 1), ((- 1) ^ (n + k) * (↑(choose n k) : ℤ)) • g k = f n := by
+  apply Iff.trans (b := ∀ (n : ℕ),
+    ∑ k ∈ Finset.range (n + 1), ((-1) ^ k *(↑(n.choose k) : ℤ)) • (-1) ^ k • f k = g n)
+  · refine forall_congr' ?_
+    intro
+    refine Eq.congr ?_ rfl
+    congr! 1
+    rw [smul_smul, ← Lean.Grind.IntModule.zsmul_natCast_eq_nsmul]
+    ring_nf
+    simp
+  · rw [Int.alternating_sum_choose_mul_eq_iff (fun n ↦ (-1) ^ n • f n) g]
+    refine forall_congr' ?_
+    intro n
+    rw [← IsUnit.smul_left_cancel (y := f n) (isUnit_neg_one_pow ℤ n)]
+    refine Eq.congr ?_ rfl
+    rw [smul_sum]
+    congr! 1
+    rw [smul_smul, ← mul_assoc, ← pow_add, ← add_assoc, ← Nat.two_mul n, pow_add]
+    simp
+
+theorem Int.alternating_sum_choose_mul_choose (n m : ℕ) :
+    ∑ k ∈ Finset.range (n + 1), (-1) ^ k * (↑(n.choose k) : ℤ) * (k.choose m)
+    = (-1) ^ m * if n = m then 1 else 0 := by
+  apply Int.alternating_sum_choose_mul_of_alternating_sum_choose_mul
+  intro k
+  by_cases h : m < k + 1 <;> simp only [Int.reduceNeg, mul_ite, mul_one, mul_zero, Int.zsmul_eq_mul,
+    sum_ite_eq', Finset.mem_range, h, ↓reduceIte]
+  · rw [mul_right_comm, ← pow_add, ← Nat.two_mul m, Even.neg_one_pow (even_two_mul m), one_mul]
+  · rw [choose_eq_zero_of_lt (lt_of_succ_le (Nat.le_of_not_lt h)), Int.natCast_zero]
+
+theorem Int.alternating_sum_id_mul_choose (n : ℕ) :
+    ∑ k ∈ Finset.range (n + 1), (-1) ^ k * ((n.choose k) : ℤ) * k = - if n = 1 then 1 else 0 := by
+  rw [← neg_one_mul (if n = 1 then 1 else 0), ← pow_one (-1),
+    ← Int.alternating_sum_choose_mul_choose n 1]
+  congr! 1
+  simp
+
+end Int

--- a/Mathlib/Data/Nat/Choose/Inversion.lean
+++ b/Mathlib/Data/Nat/Choose/Inversion.lean
@@ -79,7 +79,7 @@ theorem sum_choose_smul_eq_iff (f g : ℕ → G) :
   · rw [alternating_sum_choose_smul_eq_iff (fun n ↦ (-1) ^ n • f n) g]
     apply forall_congr'
     intro n
-    rw [← ((isUnit_neg_one (α := ℤ)).pow n) |>.smul_left_cancel (y := f n)]
+    rw [← (isUnit_neg_one (α := ℤ)).pow n |>.smul_left_cancel (y := f n)]
     refine Eq.congr ?_ rfl
     rw [smul_sum]
     congr! 1


### PR DESCRIPTION
This PR adds binomial inversion (also called binomial transform), which is a useful method for proving binomial identities.

It is tricky to find direct references to binomial inversion, but for example [this](https://en.wikipedia.org/wiki/Binomial_transform#Binomial_convolution) Wikipedia article mentions it ("The formula"). 

The first theorem ```alternating_sum_choose_mul_of_alternating_sum_choose_mul``` could be refined (we only need the hypothesis ```h``` up to some point), but this seems to needlessly complicate it.