### PR TITLE
[Merged by Bors] - feat: introduce predicate `Meromorphic`

### DIFF
--- a/Mathlib/Analysis/Meromorphic/Basic.lean
+++ b/Mathlib/Analysis/Meromorphic/Basic.lean
@@ -8,6 +8,7 @@ module
 public import Mathlib.Analysis.Analytic.IsolatedZeros
 public import Mathlib.Analysis.Calculus.Deriv.ZPow
 public import Mathlib.MeasureTheory.Constructions.BorelSpace.Basic
+import Mathlib.Tactic.ToFun
 
 /-!
 # Meromorphic functions

--- a/Mathlib/Analysis/Meromorphic/Basic.lean
+++ b/Mathlib/Analysis/Meromorphic/Basic.lean
@@ -686,10 +686,11 @@ lemma pow {f : 𝕜 → 𝕜} {n : ℕ} (hf : Meromorphic f) : Meromorphic (f ^ 
 lemma zpow {f : 𝕜 → 𝕜} {n : ℤ} (hf : Meromorphic f) : Meromorphic (f ^ n) := fun x ↦ (hf x).zpow n
 
 @[fun_prop]
-lemma deriv [CompleteSpace E] (hf : Meromorphic f) : Meromorphic (deriv f) := fun x ↦ (hf x).deriv
+protected lemma deriv [CompleteSpace E] (hf : Meromorphic f) : Meromorphic (deriv f) :=
+    fun x ↦ (hf x).deriv
 
 @[fun_prop]
 lemma iterated_deriv [CompleteSpace E] {n : ℕ} (hf : Meromorphic f) :
-    Meromorphic (_root_.deriv^[n] f) := fun x ↦ (hf x).iterated_deriv
+    Meromorphic (deriv^[n] f) := fun x ↦ (hf x).iterated_deriv
 
 end Meromorphic

--- a/Mathlib/Analysis/Meromorphic/Basic.lean
+++ b/Mathlib/Analysis/Meromorphic/Basic.lean
@@ -631,3 +631,102 @@ theorem measurable [MeasurableSpace 𝕜] [SecondCountableTopology 𝕜] [BorelS
     (by simp [- mem_compl_iff]) h₃.restrict.measurable (measurable_of_countable _)
 
 end MeromorphicOn
+
+/-- Meromorphy of a function on all of 𝕜. -/
+@[fun_prop]
+def Meromorphic (f : 𝕜 → E) := ∀ x, MeromorphicAt f x
+
+/-- A function is meromorphic iff it is meromorphic on Set.univ. -/
+@[simp]
+lemma meromorphicOn_univ {f : 𝕜 → E} : MeromorphicOn f Set.univ ↔ Meromorphic f  := by tauto
+
+namespace Meromorphic
+
+variable
+  {ι : Type*} {s : Finset ι}
+  {f g : 𝕜 → E} {F : ι → 𝕜 → 𝕜} {G : ι → 𝕜 → E}
+
+@[fun_prop]
+lemma neg (hf : Meromorphic f) : Meromorphic (-f) := fun x ↦ (hf x).neg
+
+@[fun_prop]
+lemma fun_neg (hf : Meromorphic f) : Meromorphic (fun x ↦ -f x ) := hf.neg
+
+@[fun_prop]
+lemma add (hf : Meromorphic f) (hg : Meromorphic g) :
+    Meromorphic (f + g) := fun x ↦ (hf x).add (hg x)
+
+@[fun_prop]
+lemma fun_add (hf : Meromorphic f) (hg : Meromorphic g) :
+    Meromorphic (fun x ↦ f x + g x) := hf.add hg
+
+@[fun_prop]
+theorem sum (h : ∀ σ, Meromorphic (G σ)) :
+    Meromorphic (∑ n ∈ s, G n) := fun x ↦ MeromorphicAt.sum (h · x)
+
+@[fun_prop]
+theorem fun_sum (h : ∀ σ, Meromorphic (G σ)) :
+    Meromorphic (fun x ↦ ∑ n ∈ s, G n x) := by
+  simpa [← Finset.sum_apply] using (sum h)
+
+@[fun_prop]
+lemma sub (hf : Meromorphic f) (hg : Meromorphic g) :
+    Meromorphic (f - g) := fun x ↦ (hf x).sub (hg x)
+
+@[fun_prop]
+lemma fun_sub (hf : Meromorphic f) (hg : Meromorphic g) :
+    Meromorphic (fun x ↦ f x - g x) := hf.sub hg
+
+@[fun_prop]
+lemma mul {f g : 𝕜 → 𝕜} (hf : Meromorphic f) (hg : Meromorphic g) :
+    Meromorphic (f * g) := fun x ↦ (hf x).mul (hg x)
+
+@[fun_prop]
+lemma fun_mul {f g : 𝕜 → 𝕜} (hf : Meromorphic f) (hg : Meromorphic g) :
+    Meromorphic (fun x ↦ f x * g x) := hf.mul hg
+
+@[fun_prop]
+theorem prod (h : ∀ σ, Meromorphic (F σ)) :
+    Meromorphic (∏ n ∈ s, F n) := fun x ↦ MeromorphicAt.prod (h · x)
+
+@[fun_prop]
+theorem fun_prod (h : ∀ σ, Meromorphic (F σ)) :
+    Meromorphic (fun x ↦ ∏ n ∈ s, F n x) := by
+  simpa [← Finset.prod_apply] using (prod h)
+
+@[fun_prop]
+lemma div {f g : 𝕜 → 𝕜} (hf : Meromorphic f) (hg : Meromorphic g) :
+    Meromorphic (f / g) := fun x ↦ (hf x).div (hg x)
+
+@[fun_prop]
+lemma fun_div {f g : 𝕜 → 𝕜} (hf : Meromorphic f) (hg : Meromorphic g) :
+    Meromorphic (fun x ↦ f x / g x) := hf.div hg
+
+@[fun_prop]
+lemma pow {f : 𝕜 → 𝕜} {n : ℕ} (hf : Meromorphic f) : Meromorphic (f ^ n) := fun x ↦ (hf x).pow n
+
+@[fun_prop]
+lemma fun_pow {f : 𝕜 → 𝕜} {n : ℕ} (hf : Meromorphic f) : Meromorphic (fun x ↦ f x ^ n) := hf.pow
+
+@[fun_prop]
+lemma zpow {f : 𝕜 → 𝕜} {n : ℤ} (hf : Meromorphic f) : Meromorphic (f ^ n) := fun x ↦ (hf x).zpow n
+
+@[fun_prop]
+lemma fun_zpow {f : 𝕜 → 𝕜} {n : ℤ} (hf : Meromorphic f) : Meromorphic (fun x ↦ f x ^ n) := hf.zpow
+
+@[fun_prop]
+lemma deriv [CompleteSpace E] (hf : Meromorphic f) : Meromorphic (deriv f) := fun x ↦ (hf x).deriv
+
+@[fun_prop]
+lemma fun_deriv [CompleteSpace E] (hf : Meromorphic f) :
+    Meromorphic (fun x ↦ _root_.deriv f x) := hf.deriv
+
+@[fun_prop]
+lemma iterated_deriv [CompleteSpace E] {n : ℕ} (hf : Meromorphic f) :
+    Meromorphic (_root_.deriv^[n] f) := fun x ↦ (hf x).iterated_deriv
+
+@[fun_prop]
+lemma fun_iterated_deriv [CompleteSpace E] {n : ℕ} (hf : Meromorphic f) :
+    Meromorphic (fun x ↦ _root_.deriv^[n] f x) := hf.iterated_deriv
+
+end Meromorphic

--- a/Mathlib/Analysis/Meromorphic/Basic.lean
+++ b/Mathlib/Analysis/Meromorphic/Basic.lean
@@ -646,87 +646,44 @@ variable
   {ι : Type*} {s : Finset ι}
   {f g : 𝕜 → E} {F : ι → 𝕜 → 𝕜} {G : ι → 𝕜 → E}
 
-@[fun_prop]
+@[to_fun (attr := fun_prop)]
 lemma neg (hf : Meromorphic f) : Meromorphic (-f) := fun x ↦ (hf x).neg
 
-@[fun_prop]
-lemma fun_neg (hf : Meromorphic f) : Meromorphic (fun x ↦ -f x ) := hf.neg
-
-@[fun_prop]
+@[to_fun (attr := fun_prop)]
 lemma add (hf : Meromorphic f) (hg : Meromorphic g) :
     Meromorphic (f + g) := fun x ↦ (hf x).add (hg x)
 
-@[fun_prop]
-lemma fun_add (hf : Meromorphic f) (hg : Meromorphic g) :
-    Meromorphic (fun x ↦ f x + g x) := hf.add hg
-
-@[fun_prop]
+@[to_fun (attr := fun_prop)]
 theorem sum (h : ∀ σ, Meromorphic (G σ)) :
     Meromorphic (∑ n ∈ s, G n) := fun x ↦ MeromorphicAt.sum (h · x)
 
-@[fun_prop]
-theorem fun_sum (h : ∀ σ, Meromorphic (G σ)) :
-    Meromorphic (fun x ↦ ∑ n ∈ s, G n x) := by
-  simpa [← Finset.sum_apply] using (sum h)
-
-@[fun_prop]
+@[to_fun (attr := fun_prop)]
 lemma sub (hf : Meromorphic f) (hg : Meromorphic g) :
     Meromorphic (f - g) := fun x ↦ (hf x).sub (hg x)
 
-@[fun_prop]
-lemma fun_sub (hf : Meromorphic f) (hg : Meromorphic g) :
-    Meromorphic (fun x ↦ f x - g x) := hf.sub hg
-
-@[fun_prop]
+@[to_fun (attr := fun_prop)]
 lemma mul {f g : 𝕜 → 𝕜} (hf : Meromorphic f) (hg : Meromorphic g) :
     Meromorphic (f * g) := fun x ↦ (hf x).mul (hg x)
 
-@[fun_prop]
-lemma fun_mul {f g : 𝕜 → 𝕜} (hf : Meromorphic f) (hg : Meromorphic g) :
-    Meromorphic (fun x ↦ f x * g x) := hf.mul hg
-
-@[fun_prop]
+@[to_fun (attr := fun_prop)]
 theorem prod (h : ∀ σ, Meromorphic (F σ)) :
     Meromorphic (∏ n ∈ s, F n) := fun x ↦ MeromorphicAt.prod (h · x)
 
-@[fun_prop]
-theorem fun_prod (h : ∀ σ, Meromorphic (F σ)) :
-    Meromorphic (fun x ↦ ∏ n ∈ s, F n x) := by
-  simpa [← Finset.prod_apply] using (prod h)
-
-@[fun_prop]
+@[to_fun (attr := fun_prop)]
 lemma div {f g : 𝕜 → 𝕜} (hf : Meromorphic f) (hg : Meromorphic g) :
     Meromorphic (f / g) := fun x ↦ (hf x).div (hg x)
 
-@[fun_prop]
-lemma fun_div {f g : 𝕜 → 𝕜} (hf : Meromorphic f) (hg : Meromorphic g) :
-    Meromorphic (fun x ↦ f x / g x) := hf.div hg
-
-@[fun_prop]
+@[to_fun (attr := fun_prop)]
 lemma pow {f : 𝕜 → 𝕜} {n : ℕ} (hf : Meromorphic f) : Meromorphic (f ^ n) := fun x ↦ (hf x).pow n
 
-@[fun_prop]
-lemma fun_pow {f : 𝕜 → 𝕜} {n : ℕ} (hf : Meromorphic f) : Meromorphic (fun x ↦ f x ^ n) := hf.pow
-
-@[fun_prop]
+@[to_fun (attr := fun_prop)]
 lemma zpow {f : 𝕜 → 𝕜} {n : ℤ} (hf : Meromorphic f) : Meromorphic (f ^ n) := fun x ↦ (hf x).zpow n
 
-@[fun_prop]
-lemma fun_zpow {f : 𝕜 → 𝕜} {n : ℤ} (hf : Meromorphic f) : Meromorphic (fun x ↦ f x ^ n) := hf.zpow
-
-@[fun_prop]
+@[to_fun (attr := fun_prop)]
 lemma deriv [CompleteSpace E] (hf : Meromorphic f) : Meromorphic (deriv f) := fun x ↦ (hf x).deriv
 
-@[fun_prop]
-lemma fun_deriv [CompleteSpace E] (hf : Meromorphic f) :
-    Meromorphic (fun x ↦ _root_.deriv f x) := hf.deriv
-
-@[fun_prop]
+@[to_fun (attr := fun_prop)]
 lemma iterated_deriv [CompleteSpace E] {n : ℕ} (hf : Meromorphic f) :
     Meromorphic (_root_.deriv^[n] f) := fun x ↦ (hf x).iterated_deriv
-
-@[fun_prop]
-lemma fun_iterated_deriv [CompleteSpace E] {n : ℕ} (hf : Meromorphic f) :
-    Meromorphic (fun x ↦ _root_.deriv^[n] f x) := hf.iterated_deriv
 
 end Meromorphic

--- a/Mathlib/Analysis/Meromorphic/Basic.lean
+++ b/Mathlib/Analysis/Meromorphic/Basic.lean
@@ -639,13 +639,18 @@ def Meromorphic (f : 𝕜 → E) := ∀ x, MeromorphicAt f x
 
 /-- A function is meromorphic iff it is meromorphic on Set.univ. -/
 @[simp]
-lemma meromorphicOn_univ {f : 𝕜 → E} : MeromorphicOn f Set.univ ↔ Meromorphic f  := by tauto
+lemma meromorphicOn_univ {f : 𝕜 → E} : MeromorphicOn f Set.univ ↔ Meromorphic f := by tauto
 
 namespace Meromorphic
 
 variable
   {ι : Type*} {s : Finset ι}
   {f g : 𝕜 → E} {F : ι → 𝕜 → 𝕜} {G : ι → 𝕜 → E}
+
+@[fun_prop]
+lemma meromorphicAt {x : 𝕜} (hf : Meromorphic f) : MeromorphicAt f x := hf x
+
+lemma meromorphicOn {s : Set 𝕜} (hf : Meromorphic f) : MeromorphicOn f s := fun x _ ↦ hf x
 
 @[to_fun (attr := fun_prop)]
 lemma neg (hf : Meromorphic f) : Meromorphic (-f) := fun x ↦ (hf x).neg
@@ -680,10 +685,10 @@ lemma pow {f : 𝕜 → 𝕜} {n : ℕ} (hf : Meromorphic f) : Meromorphic (f ^ 
 @[to_fun (attr := fun_prop)]
 lemma zpow {f : 𝕜 → 𝕜} {n : ℤ} (hf : Meromorphic f) : Meromorphic (f ^ n) := fun x ↦ (hf x).zpow n
 
-@[to_fun (attr := fun_prop)]
+@[fun_prop]
 lemma deriv [CompleteSpace E] (hf : Meromorphic f) : Meromorphic (deriv f) := fun x ↦ (hf x).deriv
 
-@[to_fun (attr := fun_prop)]
+@[fun_prop]
 lemma iterated_deriv [CompleteSpace E] {n : ℕ} (hf : Meromorphic f) :
     Meromorphic (_root_.deriv^[n] f) := fun x ↦ (hf x).iterated_deriv
 


### PR DESCRIPTION
Following a discussion of Zulip, introduce the predicate `Meromorphic` as a shorthand for functions that are `MeromorphicOn … Set.univ`

[#mathlib4 > Introducing &#96;Meromorphic&#96; @ 💬](https://leanprover.zulipchat.com/#narrow/channel/287929-mathlib4/topic/Introducing.20.60Meromorphic.60/near/564522177)

---
<!-- Your PR title will become the first line of the commit message.

In this box, the text above the `---` (if not empty) will be appended
to the commit message, and can be used to give additional context or
details. Please leave a blank newline before the `---`, otherwise GitHub
will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

When merging, all the commits will be squashed into a single commit
listing all co-authors.

Co-authors in the squash commit are gathered from two sources:

First, all authors of commits to this PR branch are included. Thus,
one way to add co-authors is to include at least one commit authored by
each co-author among the commits in the pull request. If necessary, you
may create empty commits to indicate co-authorship, using commands like so:

git commit --author="Author Name <author@email.com>" --allow-empty -m "add Author Name as coauthor"

Second, co-authors can also be listed in lines at the very bottom of
the commit message (that is, directly before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines
at the bottom of the commit message (before the `---`, and also before
any "Co-authored-by" lines) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
