### PR TITLE
feat(Algebra/Group/Center): add Decidable (IsMulCentral a) instance

### DIFF
--- a/Mathlib/Algebra/Group/Center.lean
+++ b/Mathlib/Algebra/Group/Center.lean
@@ -65,6 +65,13 @@ structure IsMulCentral [Mul M] (z : M) : Prop where
 
 attribute [mk_iff] IsMulCentral IsAddCentral
 attribute [to_additive existing] isMulCentral_iff
+@[to_additive]
+instance decidableIsMulCentral {M : Type*} [Mul M] (a : M)
+    [Decidable (∀ b : M, Commute a b)]
+    [Decidable (∀ b c : M, a * (b * c) = (a * b) * c)]
+    [Decidable (∀ b c : M, (b * c) * a = b * (c * a))] :
+    Decidable (IsMulCentral a) :=
+  decidable_of_iff' _ (isMulCentral_iff a)
 
 namespace IsMulCentral
 


### PR DESCRIPTION
This PR adds a `Decidable` instance for `IsMulCentral a`.

### Summary
The structure `IsMulCentral` was missing a `Decidable` instance. This PR provides the instance by leveraging `isMulCentral_iff`, enabling decidability for both multiplicative and additive (via `to_additive`) structures.

### Verification
- `lake build Mathlib.Algebra.Group.Center` passed.
- `lake exe runLinter Mathlib.Algebra.Group.Center` passed.