### PR TITLE
[Merged by Bors] - chore: use `to_dual` on `IsSuccPrelimit` / `IsSuccLimit`

### DIFF
--- a/Mathlib/Order/Cover.lean
+++ b/Mathlib/Order/Cover.lean
@@ -184,6 +184,7 @@ section LT
 
 variable [LT α] {a b : α}
 
+@[to_dual self]
 theorem CovBy.lt (h : a ⋖ b) : a < b :=
   h.1
 
@@ -196,6 +197,7 @@ alias ⟨exists_lt_lt_of_not_covBy, _⟩ := not_covBy_iff
 alias LT.lt.exists_lt_lt := exists_lt_lt_of_not_covBy
 
 /-- In a dense order, nothing covers anything. -/
+@[to_dual self]
 theorem not_covBy [DenselyOrdered α] : ¬a ⋖ b := fun h =>
   let ⟨_, hc⟩ := exists_between h.1
   h.2 hc.1 hc.2
@@ -204,16 +206,18 @@ theorem denselyOrdered_iff_forall_not_covBy : DenselyOrdered α ↔ ∀ a b : α
   ⟨fun h _ _ => @not_covBy _ _ _ _ h, fun h =>
     ⟨fun _ _ hab => exists_lt_lt_of_not_covBy hab <| h _ _⟩⟩
 
-@[simp]
+@[to_dual self, simp]
 theorem toDual_covBy_toDual_iff : toDual b ⋖ toDual a ↔ a ⋖ b :=
   and_congr_right' <| forall_congr' fun _ => forall_swap
 
-@[simp]
+@[to_dual self, simp]
 theorem ofDual_covBy_ofDual_iff {a b : αᵒᵈ} : ofDual a ⋖ ofDual b ↔ b ⋖ a :=
   and_congr_right' <| forall_congr' fun _ => forall_swap
 
+@[to_dual self]
 alias ⟨_, CovBy.toDual⟩ := toDual_covBy_toDual_iff
 
+@[to_dual self]
 alias ⟨_, CovBy.ofDual⟩ := ofDual_covBy_ofDual_iff
 
 end LT

--- a/Mathlib/Order/SuccPred/Basic.lean
+++ b/Mathlib/Order/SuccPred/Basic.lean
@@ -674,8 +674,10 @@ variable [NoMinOrder α]
 @[deprecated (since := "2025-12-04")]
 alias pred_le_pred_of_le := pred_mono
 
+@[to_dual existing]
 theorem pred_strictMono : StrictMono (pred : α → α) := fun _ _ => pred_lt_pred
 
+@[to_dual existing covBy_succ]
 theorem pred_covBy (a : α) : pred a ⋖ a :=
   pred_covBy_of_not_isMin <| not_isMin a
 
@@ -713,10 +715,13 @@ variable [PartialOrder α] [PredOrder α] {a b : α}
 alias pred_le_le_iff := pred_le_and_le_iff
 
 /-- See also `Order.pred_le_of_wcovBy`. -/
+@[to_dual existing]
 lemma pred_eq_of_covBy (h : a ⋖ b) : pred b = a := h.wcovBy.pred_le.antisymm (le_pred_of_lt h.lt)
 
+@[to_dual existing]
 alias _root_.CovBy.pred_eq := pred_eq_of_covBy
 
+@[to_dual existing]
 theorem _root_.OrderIso.map_pred {β : Type*} [PartialOrder β] [PredOrder β] (f : α ≃o β) (a : α) :
     f (pred a) = pred (f a) :=
   f.dual.map_succ a
@@ -725,6 +730,7 @@ section NoMinOrder
 
 variable [NoMinOrder α]
 
+@[to_dual existing]
 theorem pred_eq_iff_covBy : pred b = a ↔ a ⋖ b :=
   ⟨by
     rintro rfl
@@ -803,6 +809,7 @@ end NoMinOrder
 end LinearOrder
 
 /-- There is at most one way to define the predecessors in a `PartialOrder`. -/
+@[to_dual existing]
 instance [PartialOrder α] : Subsingleton (PredOrder α) :=
   ⟨by
     intro h₀ h₁

--- a/Mathlib/Order/SuccPred/Basic.lean
+++ b/Mathlib/Order/SuccPred/Basic.lean
@@ -387,13 +387,15 @@ section OrderTop
 
 variable [OrderTop α]
 
-@[simp]
+@[to_dual (attr := simp)]
 theorem succ_top : succ (⊤ : α) = ⊤ := by
   rw [succ_eq_iff_isMax, isMax_iff_eq_top]
 
+@[to_dual le_pred_iff_eq_bot]
 theorem succ_le_iff_eq_top : succ a ≤ a ↔ a = ⊤ :=
   succ_le_iff_isMax.trans isMax_iff_eq_top
 
+@[to_dual pred_lt_iff_ne_bot]
 theorem lt_succ_iff_ne_top : a < succ a ↔ a ≠ ⊤ :=
   lt_succ_iff_not_isMax.trans not_isMax_iff_ne_top
 
@@ -403,9 +405,11 @@ section OrderBot
 
 variable [OrderBot α] [Nontrivial α]
 
+@[to_dual pred_lt_top]
 theorem bot_lt_succ (a : α) : ⊥ < succ a :=
-  (lt_succ_of_not_isMax not_isMax_bot).trans_le <| succ_mono bot_le
+  (lt_succ_of_not_isMax not_isMax_bot).trans_le <| succ_le_succ bot_le
 
+@[to_dual]
 theorem succ_ne_bot (a : α) : succ a ≠ ⊥ :=
   (bot_lt_succ a).ne'
 
@@ -560,8 +564,10 @@ section OrderBot
 
 variable [OrderBot α]
 
+@[to_dual pred_top_lt_iff]
 theorem lt_succ_bot_iff [NoMaxOrder α] : a < succ ⊥ ↔ a = ⊥ := by rw [lt_succ_iff, le_bot_iff]
 
+@[to_dual pred_top_le_iff]
 theorem le_succ_bot_iff : a ≤ succ ⊥ ↔ a = ⊥ ∨ a = succ ⊥ := by
   rw [le_succ_iff_eq_or_le, le_bot_iff, or_comm]
 
@@ -726,34 +732,6 @@ theorem pred_eq_iff_covBy : pred b = a ↔ a ⋖ b :=
 
 end NoMinOrder
 
-section OrderBot
-
-variable [OrderBot α]
-
-@[simp]
-theorem pred_bot : pred (⊥ : α) = ⊥ :=
-  isMin_bot.pred_eq
-
-theorem le_pred_iff_eq_bot : a ≤ pred a ↔ a = ⊥ :=
-  @succ_le_iff_eq_top αᵒᵈ _ _ _ _
-
-theorem pred_lt_iff_ne_bot : pred a < a ↔ a ≠ ⊥ :=
-  @lt_succ_iff_ne_top αᵒᵈ _ _ _ _
-
-end OrderBot
-
-section OrderTop
-
-variable [OrderTop α] [Nontrivial α]
-
-theorem pred_lt_top (a : α) : pred a < ⊤ :=
-  (pred_mono le_top).trans_lt <| pred_lt_of_not_isMin not_isMin_top
-
-theorem pred_ne_top (a : α) : pred a ≠ ⊤ :=
-  (pred_lt_top a).ne
-
-end OrderTop
-
 end PartialOrder
 
 section LinearOrder
@@ -822,18 +800,6 @@ theorem Ioo_eq_empty_iff_pred_le : Ioo a b = ∅ ↔ pred b ≤ a := by
 
 end NoMinOrder
 
-section OrderTop
-
-variable [OrderTop α]
-
-theorem pred_top_lt_iff [NoMinOrder α] : pred ⊤ < a ↔ a = ⊤ :=
-  @lt_succ_bot_iff αᵒᵈ _ _ _ _ _
-
-theorem pred_top_le_iff : pred ⊤ ≤ a ↔ a = ⊤ ∨ a = pred ⊤ :=
-  @le_succ_bot_iff αᵒᵈ _ _ _ _
-
-end OrderTop
-
 end LinearOrder
 
 /-- There is at most one way to define the predecessors in a `PartialOrder`. -/
@@ -862,12 +828,13 @@ section SuccPredOrder
 section Preorder
 variable [Preorder α] [SuccOrder α] [PredOrder α] {a b : α}
 
+@[to_dual pred_succ_le]
 lemma le_succ_pred (a : α) : a ≤ succ (pred a) := (pred_wcovBy _).le_succ
-lemma pred_succ_le (a : α) : pred (succ a) ≤ a := (wcovBy_succ _).pred_le
 
+@[to_dual]
 lemma pred_le_iff_le_succ : pred a ≤ b ↔ a ≤ succ b where
-  mp hab := (le_succ_pred _).trans (succ_mono hab)
-  mpr hab := (pred_mono hab).trans (pred_succ_le _)
+  mp hab := (le_succ_pred _).trans (succ_le_succ hab)
+  mpr hab := (pred_le_pred hab).trans (pred_succ_le _)
 
 lemma gc_pred_succ : GaloisConnection (pred : α → α) succ := fun _ _ ↦ pred_le_iff_le_succ
 
@@ -1029,6 +996,7 @@ section Pred
 
 variable [Preorder α] [NoMaxOrder α]
 
+@[to_dual]
 instance [hα : Nonempty α] : IsEmpty (PredOrder (WithTop α)) :=
   ⟨by
     intro
@@ -1051,6 +1019,7 @@ section Succ
 
 variable [Preorder α] [OrderBot α] [SuccOrder α]
 
+@[to_dual existing]
 instance : SuccOrder (WithBot α) where
   succ a :=
     match a with
@@ -1090,6 +1059,7 @@ section Pred
 
 variable [PartialOrder α] [PredOrder α] [∀ a : α, Decidable (pred a = a)]
 
+@[to_dual existing]
 instance : PredOrder (WithBot α) where
   pred a :=
     match a with
@@ -1134,24 +1104,6 @@ theorem pred_coe [NoMinOrder α] {a : α} : pred (↑a : WithBot α) = ↑(pred 
   pred_coe_of_not_isMin <| not_isMin a
 
 end Pred
-
-/-! #### Adding a `⊥` to a `NoMinOrder` -/
-
-section Succ
-
-variable [Preorder α] [NoMinOrder α]
-
-instance [hα : Nonempty α] : IsEmpty (SuccOrder (WithBot α)) :=
-  ⟨by
-    intro
-    cases h : succ (⊥ : WithBot α) with
-    | bot => exact hα.elim fun a => (max_of_succ_le h.le).not_lt <| bot_lt_coe a
-    | coe a =>
-      obtain ⟨c, hc⟩ := exists_lt a
-      rw [← coe_lt_coe, ← h] at hc
-      exact (succ_le_of_lt (bot_lt_coe _)).not_gt hc⟩
-
-end Succ
 
 end WithBot
 

--- a/Mathlib/Order/SuccPred/Limit.lean
+++ b/Mathlib/Order/SuccPred/Limit.lean
@@ -42,14 +42,29 @@ It's so named because in a successor order, a successor pre-limit can't be the s
 smaller.
 
 Use `IsSuccLimit` if you want to exclude the case of a minimal element. -/
+@[to_dual
+/-- A predecessor pre-limit is a value that isn't covered by any other.
+
+It's so named because in a predecessor order, a predecessor pre-limit can't be the predecessor of
+anything smaller.
+
+Use `IsPredLimit` to exclude the case of a maximal element. -/]
 def IsSuccPrelimit (a : α) : Prop :=
   ∀ b, ¬b ⋖ a
 
+@[to_dual]
 theorem not_isSuccPrelimit_iff_exists_covBy (a : α) : ¬IsSuccPrelimit a ↔ ∃ b, b ⋖ a := by
   simp [IsSuccPrelimit]
 
-@[simp]
+@[to_dual (attr := simp)]
 theorem IsSuccPrelimit.of_dense [DenselyOrdered α] (a : α) : IsSuccPrelimit a := fun _ => not_covBy
+
+@[to_dual (attr := simp)]
+theorem isSuccPrelimit_toDual_iff : IsSuccPrelimit (toDual a) ↔ IsPredPrelimit a := by
+  simp [IsSuccPrelimit, IsPredPrelimit]
+
+@[to_dual]
+alias ⟨_, IsPredPrelimit.dual⟩ := isSuccPrelimit_toDual_iff
 
 end LT
 
@@ -62,61 +77,85 @@ variable [Preorder α]
 It's so named because in a successor order, a successor limit can't be the successor of anything
 smaller.
 
-This previously allowed the element to be minimal. This usage is now covered by `IsSuccPrelimit`. -/
+Use `IsSuccPrelimit` if you want to include the case of a minimal element. -/
+@[to_dual
+/-- A predecessor limit is a value that isn't maximal and doesn't cover any other.
+
+It's so named because in a predecessor order, a predecessor limit can't be the predecessor of
+anything larger.
+
+Use `IsPredPrelimit` if you want to include the case of a maximal element. -/]
 def IsSuccLimit (a : α) : Prop :=
   ¬ IsMin a ∧ IsSuccPrelimit a
 
+@[to_dual]
 protected theorem IsSuccLimit.not_isMin (h : IsSuccLimit a) : ¬ IsMin a := h.1
+
+@[to_dual]
 protected theorem IsSuccLimit.isSuccPrelimit (h : IsSuccLimit a) : IsSuccPrelimit a := h.2
 
+@[to_dual]
 theorem IsSuccPrelimit.isSuccLimit_of_not_isMin (h : IsSuccPrelimit a) (ha : ¬ IsMin a) :
     IsSuccLimit a :=
   ⟨ha, h⟩
 
+@[to_dual]
 theorem IsSuccPrelimit.isSuccLimit [NoMinOrder α] (h : IsSuccPrelimit a) : IsSuccLimit a :=
   h.isSuccLimit_of_not_isMin (not_isMin a)
 
+@[to_dual]
 theorem isSuccPrelimit_iff_isSuccLimit_of_not_isMin (h : ¬ IsMin a) :
     IsSuccPrelimit a ↔ IsSuccLimit a :=
   ⟨fun ha ↦ ha.isSuccLimit_of_not_isMin h, IsSuccLimit.isSuccPrelimit⟩
 
+@[to_dual]
 theorem isSuccPrelimit_iff_isSuccLimit [NoMinOrder α] : IsSuccPrelimit a ↔ IsSuccLimit a :=
   isSuccPrelimit_iff_isSuccLimit_of_not_isMin (not_isMin a)
 
+@[to_dual]
 protected theorem _root_.IsMin.not_isSuccLimit (h : IsMin a) : ¬ IsSuccLimit a :=
   fun ha ↦ ha.not_isMin h
 
+@[to_dual]
 protected theorem _root_.IsMin.isSuccPrelimit : IsMin a → IsSuccPrelimit a := fun h _ hab =>
   not_isMin_of_lt hab.lt h
 
 theorem IsSuccLimit.nonempty_Iio (h : IsSuccLimit a) : (Set.Iio a).Nonempty :=
   not_isMin_iff.1 h.1
 
+@[to_dual]
 theorem isSuccPrelimit_bot [OrderBot α] : IsSuccPrelimit (⊥ : α) :=
   isMin_bot.isSuccPrelimit
 
+@[to_dual]
 theorem not_isSuccLimit_bot [OrderBot α] : ¬ IsSuccLimit (⊥ : α) :=
   isMin_bot.not_isSuccLimit
 
+@[to_dual]
 theorem IsSuccLimit.ne_bot [OrderBot α] (h : IsSuccLimit a) : a ≠ ⊥ := by
   rintro rfl
   exact not_isSuccLimit_bot h
 
+@[to_dual]
 theorem not_isSuccLimit_iff : ¬ IsSuccLimit a ↔ IsMin a ∨ ¬ IsSuccPrelimit a := by
   rw [IsSuccLimit, not_and_or, not_not]
 
 variable [SuccOrder α]
 
+@[to_dual]
 protected theorem IsSuccPrelimit.isMax (h : IsSuccPrelimit (succ a)) : IsMax a := by
   by_contra H
   exact h a (covBy_succ_of_not_isMax H)
 
+@[to_dual]
 protected theorem IsSuccLimit.isMax (h : IsSuccLimit (succ a)) : IsMax a :=
   h.isSuccPrelimit.isMax
 
+@[to_dual]
 theorem not_isSuccPrelimit_succ_of_not_isMax (ha : ¬ IsMax a) : ¬ IsSuccPrelimit (succ a) :=
   mt IsSuccPrelimit.isMax ha
 
+@[to_dual]
 theorem not_isSuccLimit_succ_of_not_isMax (ha : ¬ IsMax a) : ¬ IsSuccLimit (succ a) :=
   mt IsSuccLimit.isMax ha
 
@@ -130,17 +169,19 @@ section NoMaxOrder
 
 variable [NoMaxOrder α]
 
+@[to_dual]
 theorem IsSuccPrelimit.succ_ne (h : IsSuccPrelimit a) (b : α) : succ b ≠ a := by
   rintro rfl
   exact not_isMax _ h.isMax
 
+@[to_dual]
 theorem IsSuccLimit.succ_ne (h : IsSuccLimit a) (b : α) : succ b ≠ a :=
   h.isSuccPrelimit.succ_ne b
 
-@[simp]
+@[to_dual (attr := simp)]
 theorem not_isSuccPrelimit_succ (a : α) : ¬IsSuccPrelimit (succ a) := fun h => h.succ_ne _ rfl
 
-@[simp]
+@[to_dual (attr := simp)]
 theorem not_isSuccLimit_succ (a : α) : ¬IsSuccLimit (succ a) := fun h => h.succ_ne _ rfl
 
 end NoMaxOrder
@@ -174,17 +215,21 @@ section PartialOrder
 
 variable [PartialOrder α]
 
+@[to_dual]
 theorem isSuccLimit_iff [OrderBot α] : IsSuccLimit a ↔ a ≠ ⊥ ∧ IsSuccPrelimit a := by
   rw [IsSuccLimit, isMin_iff_eq_bot]
 
+@[to_dual lt_top]
 theorem IsSuccLimit.bot_lt [OrderBot α] (h : IsSuccLimit a) : ⊥ < a :=
   h.ne_bot.bot_lt
 
 variable [SuccOrder α]
 
+@[to_dual]
 theorem isSuccPrelimit_of_succ_ne (h : ∀ b, succ b ≠ a) : IsSuccPrelimit a := fun b hba =>
   h b (CovBy.succ_eq hba)
 
+@[to_dual]
 theorem not_isSuccPrelimit_iff : ¬ IsSuccPrelimit a ↔ ∃ b, ¬ IsMax b ∧ succ b = a := by
   rw [not_isSuccPrelimit_iff_exists_covBy]
   refine exists_congr fun b => ⟨fun hba => ⟨hba.lt.not_isMax, (CovBy.succ_eq hba)⟩, ?_⟩
@@ -193,23 +238,31 @@ theorem not_isSuccPrelimit_iff : ¬ IsSuccPrelimit a ↔ ∃ b, ¬ IsMax b ∧ s
 
 /-- See `not_isSuccPrelimit_iff` for a version that states that `a` is a successor of a value other
 than itself. -/
+@[to_dual]
 theorem mem_range_succ_of_not_isSuccPrelimit (h : ¬ IsSuccPrelimit a) :
     a ∈ range (succ : α → α) := by
   obtain ⟨b, hb⟩ := not_isSuccPrelimit_iff.1 h
   exact ⟨b, hb.2⟩
 
+@[to_dual]
 theorem mem_range_succ_or_isSuccPrelimit (a) : a ∈ range (succ : α → α) ∨ IsSuccPrelimit a :=
   or_iff_not_imp_right.2 <| mem_range_succ_of_not_isSuccPrelimit
 
+@[to_dual]
 theorem isMin_or_mem_range_succ_or_isSuccLimit (a) :
     IsMin a ∨ a ∈ range (succ : α → α) ∨ IsSuccLimit a := by
   rw [IsSuccLimit]
   have := mem_range_succ_or_isSuccPrelimit a
   tauto
 
+@[to_dual isPredPrelimit_of_lt_pred]
 theorem isSuccPrelimit_of_succ_lt (H : ∀ a < b, succ a < b) : IsSuccPrelimit b := fun a hab =>
   (H a hab.lt).ne (CovBy.succ_eq hab)
 
+@[deprecated (since := "2025-12-20")]
+alias isPredPrelimit_of_pred_lt := isPredPrelimit_of_lt_pred
+
+@[to_dual lt_pred]
 theorem IsSuccPrelimit.succ_lt (hb : IsSuccPrelimit b) (ha : a < b) : succ a < b := by
   by_cases h : IsMax a
   · rwa [h.succ_eq]
@@ -218,15 +271,19 @@ theorem IsSuccPrelimit.succ_lt (hb : IsSuccPrelimit b) (ha : a < b) : succ a < b
     subst hab
     exact (h hb.isMax).elim
 
+@[to_dual lt_pred]
 theorem IsSuccLimit.succ_lt (hb : IsSuccLimit b) (ha : a < b) : succ a < b :=
   hb.isSuccPrelimit.succ_lt ha
 
+@[to_dual lt_pred_iff]
 theorem IsSuccPrelimit.succ_lt_iff (hb : IsSuccPrelimit b) : succ a < b ↔ a < b :=
   ⟨fun h => (le_succ a).trans_lt h, hb.succ_lt⟩
 
+@[to_dual lt_pred_iff]
 theorem IsSuccLimit.succ_lt_iff (hb : IsSuccLimit b) : succ a < b ↔ a < b :=
   hb.isSuccPrelimit.succ_lt_iff
 
+@[to_dual isPredPrelimit_iff_lt_pred]
 theorem isSuccPrelimit_iff_succ_lt : IsSuccPrelimit b ↔ ∀ a < b, succ a < b :=
   ⟨fun hb _ => hb.succ_lt, isSuccPrelimit_of_succ_lt⟩
 
@@ -234,9 +291,11 @@ section NoMaxOrder
 
 variable [NoMaxOrder α]
 
+@[to_dual]
 theorem isSuccPrelimit_iff_succ_ne : IsSuccPrelimit a ↔ ∀ b, succ b ≠ a :=
   ⟨IsSuccPrelimit.succ_ne, isSuccPrelimit_of_succ_ne⟩
 
+@[to_dual]
 theorem not_isSuccPrelimit_iff' : ¬ IsSuccPrelimit a ↔ a ∈ range (succ : α → α) := by
   simp_rw [isSuccPrelimit_iff_succ_ne, not_forall, not_ne_iff, mem_range]
 
@@ -294,9 +353,6 @@ lemma _root_.IsLUB.isSuccPrelimit_of_notMem {s : Set α} (hs : IsLUB s a) (ha : 
   obtain rfl := (hb.ge_of_gt hbc).antisymm hca
   contradiction
 
-@[deprecated (since := "2025-05-23")]
-alias _root_.IsLUB.isSuccPrelimit_of_not_mem := _root_.IsLUB.isSuccPrelimit_of_notMem
-
 lemma _root_.IsLUB.mem_of_not_isSuccPrelimit {s : Set α} (hs : IsLUB s a) (ha : ¬IsSuccPrelimit a) :
     a ∈ s :=
   ha.imp_symm hs.isSuccPrelimit_of_notMem
@@ -308,9 +364,6 @@ lemma _root_.IsLUB.isSuccLimit_of_notMem {s : Set α} (hs : IsLUB s a) (hs' : s.
   obtain rfl | hb := (hs.1 hb).eq_or_lt
   · contradiction
   · exact hb.not_isMin
-
-@[deprecated (since := "2025-05-23")]
-alias _root_.IsLUB.isSuccLimit_of_not_mem := _root_.IsLUB.isSuccLimit_of_notMem
 
 lemma _root_.IsLUB.mem_of_not_isSuccLimit {s : Set α} (hs : IsLUB s a) (hs' : s.Nonempty)
     (ha : ¬IsSuccLimit a) : a ∈ s :=
@@ -332,9 +385,11 @@ theorem isLUB_Iio_iff_isSuccPrelimit : IsLUB (Iio a) a ↔ IsSuccPrelimit a := b
 
 variable [SuccOrder α]
 
+@[to_dual pred_le_iff]
 theorem IsSuccPrelimit.le_succ_iff (hb : IsSuccPrelimit b) : b ≤ succ a ↔ b ≤ a :=
   le_iff_le_iff_lt_iff_lt.2 hb.succ_lt_iff
 
+@[to_dual pred_le_iff]
 theorem IsSuccLimit.le_succ_iff (hb : IsSuccLimit b) : b ≤ succ a ↔ b ≤ a :=
   hb.isSuccPrelimit.le_succ_iff
 
@@ -342,54 +397,17 @@ end LinearOrder
 
 /-! ### Predecessor limits -/
 
+-- TODO: generate all of this through `to_dual`.
 
 section LT
 
 variable [LT α]
-
-/-- A predecessor pre-limit is a value that isn't covered by any other.
-
-It's so named because in a predecessor order, a predecessor pre-limit can't be the predecessor of
-anything smaller.
-
-Use `IsPredLimit` to exclude the case of a maximal element. -/
-def IsPredPrelimit (a : α) : Prop :=
-  ∀ b, ¬ a ⋖ b
-
-theorem not_isPredPrelimit_iff_exists_covBy (a : α) : ¬IsPredPrelimit a ↔ ∃ b, a ⋖ b := by
-  simp [IsPredPrelimit]
-
-@[simp]
-theorem IsPredPrelimit.of_dense [DenselyOrdered α] (a : α) : IsPredPrelimit a := fun _ => not_covBy
-
-@[simp]
-theorem isSuccPrelimit_toDual_iff : IsSuccPrelimit (toDual a) ↔ IsPredPrelimit a := by
-  simp [IsSuccPrelimit, IsPredPrelimit]
-
-@[simp]
-theorem isPredPrelimit_toDual_iff : IsPredPrelimit (toDual a) ↔ IsSuccPrelimit a := by
-  simp [IsSuccPrelimit, IsPredPrelimit]
-
-alias ⟨_, IsPredPrelimit.dual⟩ := isSuccPrelimit_toDual_iff
-alias ⟨_, IsSuccPrelimit.dual⟩ := isPredPrelimit_toDual_iff
 
 end LT
 
 section Preorder
 
 variable [Preorder α]
-
-/-- A predecessor limit is a value that isn't maximal and doesn't cover any other.
-
-It's so named because in a predecessor order, a predecessor limit can't be the predecessor of
-anything larger.
-
-This previously allowed the element to be maximal. This usage is now covered by `IsPredPreLimit`. -/
-def IsPredLimit (a : α) : Prop :=
-  ¬ IsMax a ∧ IsPredPrelimit a
-
-protected theorem IsPredLimit.not_isMax (h : IsPredLimit a) : ¬ IsMax a := h.1
-protected theorem IsPredLimit.isPredPrelimit (h : IsPredLimit a) : IsPredPrelimit a := h.2
 
 @[simp]
 theorem isSuccLimit_toDual_iff : IsSuccLimit (toDual a) ↔ IsPredLimit a := by
@@ -402,75 +420,13 @@ theorem isPredLimit_toDual_iff : IsPredLimit (toDual a) ↔ IsSuccLimit a := by
 alias ⟨_, IsPredLimit.dual⟩ := isSuccLimit_toDual_iff
 alias ⟨_, IsSuccLimit.dual⟩ := isPredLimit_toDual_iff
 
-theorem IsPredPrelimit.isPredLimit_of_not_isMax (h : IsPredPrelimit a) (ha : ¬ IsMax a) :
-    IsPredLimit a :=
-  ⟨ha, h⟩
-
-theorem IsPredPrelimit.isPredLimit [NoMaxOrder α] (h : IsPredPrelimit a) : IsPredLimit a :=
-  h.isPredLimit_of_not_isMax (not_isMax a)
-
-theorem isPredPrelimit_iff_isPredLimit_of_not_isMax (h : ¬ IsMax a) :
-    IsPredPrelimit a ↔ IsPredLimit a :=
-  ⟨fun ha ↦ ha.isPredLimit_of_not_isMax h, IsPredLimit.isPredPrelimit⟩
-
-theorem isPredPrelimit_iff_isPredLimit [NoMaxOrder α] : IsPredPrelimit a ↔ IsPredLimit a :=
-  isPredPrelimit_iff_isPredLimit_of_not_isMax (not_isMax a)
-
-protected theorem _root_.IsMax.not_isPredLimit (h : IsMax a) : ¬ IsPredLimit a :=
-  fun ha ↦ ha.not_isMax h
-
-protected theorem _root_.IsMax.isPredPrelimit : IsMax a → IsPredPrelimit a := fun h _ hab =>
-  not_isMax_of_lt hab.lt h
-
 theorem IsPredLimit.nonempty_Ioi (h : IsPredLimit a) : (Set.Ioi a).Nonempty :=
   not_isMax_iff.1 h.1
-
-theorem isPredPrelimit_top [OrderTop α] : IsPredPrelimit (⊤ : α) :=
-  isMax_top.isPredPrelimit
-
-theorem not_isPredLimit_top [OrderTop α] : ¬ IsPredLimit (⊤ : α) :=
-  isMax_top.not_isPredLimit
-
-theorem IsPredLimit.ne_top [OrderTop α] (h : IsPredLimit a) : a ≠ ⊤ :=
-  h.dual.ne_bot
-
-theorem not_isPredLimit_iff : ¬ IsPredLimit a ↔ IsMax a ∨ ¬ IsPredPrelimit a := by
-  rw [IsPredLimit, not_and_or, not_not]
 
 theorem not_isPredLimit_of_not_isPredPrelimit (h : ¬ IsPredPrelimit a) : ¬ IsPredLimit a :=
   not_isPredLimit_iff.2 (Or.inr h)
 
 variable [PredOrder α]
-
-protected theorem IsPredPrelimit.isMin (h : IsPredPrelimit (pred a)) : IsMin a :=
-  h.dual.isMax
-
-protected theorem IsPredLimit.isMin (h : IsPredLimit (pred a)) : IsMin a :=
-  h.dual.isMax
-
-theorem not_isPredPrelimit_pred_of_not_isMin (ha : ¬ IsMin a) : ¬ IsPredPrelimit (pred a) :=
-  mt IsPredPrelimit.isMin ha
-
-theorem not_isPredLimit_pred_of_not_isMin (ha : ¬ IsMin a) : ¬ IsPredLimit (pred a) :=
-  mt IsPredLimit.isMin ha
-
-section NoMinOrder
-
-variable [NoMinOrder α]
-
-theorem IsPredPrelimit.pred_ne (h : IsPredPrelimit a) (b : α) : pred b ≠ a :=
-  h.dual.succ_ne b
-
-theorem IsPredLimit.pred_ne (h : IsPredLimit a) (b : α) : pred b ≠ a :=
-  h.isPredPrelimit.pred_ne b
-
-@[simp]
-theorem not_isPredPrelimit_pred (a : α) : ¬ IsPredPrelimit (pred a) := fun h => h.pred_ne _ rfl
-
-@[simp]
-theorem not_isPredLimit_pred (a : α) : ¬ IsPredLimit (pred a) := fun h => h.pred_ne _ rfl
-
-end NoMinOrder
 
 section IsPredArchimedean
 
@@ -497,60 +453,7 @@ section PartialOrder
 
 variable [PartialOrder α]
 
-theorem isPredLimit_iff [OrderTop α] : IsPredLimit a ↔ a ≠ ⊤ ∧ IsPredPrelimit a := by
-  rw [IsPredLimit, isMax_iff_eq_top]
-
-theorem IsPredLimit.lt_top [OrderTop α] (h : IsPredLimit a) : a < ⊤ :=
-  h.ne_top.lt_top
-
 variable [PredOrder α]
-
-theorem isPredPrelimit_of_pred_ne (h : ∀ b, pred b ≠ a) : IsPredPrelimit a := fun b hba =>
-  h b (CovBy.pred_eq hba)
-
-theorem not_isPredPrelimit_iff : ¬ IsPredPrelimit a ↔ ∃ b, ¬ IsMin b ∧ pred b = a := by
-  rw [← isSuccPrelimit_toDual_iff]
-  exact not_isSuccPrelimit_iff
-
-/-- See `not_isPredPrelimit_iff` for a version that states that `a` is a successor of a value other
-than itself. -/
-theorem mem_range_pred_of_not_isPredPrelimit (h : ¬ IsPredPrelimit a) :
-    a ∈ range (pred : α → α) := by
-  obtain ⟨b, hb⟩ := not_isPredPrelimit_iff.1 h
-  exact ⟨b, hb.2⟩
-
-theorem mem_range_pred_or_isPredPrelimit (a) : a ∈ range (pred : α → α) ∨ IsPredPrelimit a :=
-  or_iff_not_imp_right.2 <| mem_range_pred_of_not_isPredPrelimit
-
-theorem isPredPrelimit_of_pred_lt (H : ∀ b > a, a < pred b) : IsPredPrelimit a := fun a hab =>
-  (H a hab.lt).ne (CovBy.pred_eq hab).symm
-
-theorem IsPredPrelimit.lt_pred (ha : IsPredPrelimit a) (hb : a < b) : a < pred b :=
-  ha.dual.succ_lt hb
-
-theorem IsPredLimit.lt_pred (ha : IsPredLimit a) (hb : a < b) : a < pred b :=
-  ha.isPredPrelimit.lt_pred hb
-
-theorem IsPredPrelimit.lt_pred_iff (ha : IsPredPrelimit a) : a < pred b ↔ a < b :=
-  ha.dual.succ_lt_iff
-
-theorem IsPredLimit.lt_pred_iff (ha : IsPredLimit a) : a < pred b ↔ a < b :=
-  ha.dual.succ_lt_iff
-
-theorem isPredPrelimit_iff_lt_pred : IsPredPrelimit a ↔ ∀ b > a, a < pred b :=
-  ⟨fun hb _ => hb.lt_pred, isPredPrelimit_of_pred_lt⟩
-
-section NoMinOrder
-
-variable [NoMinOrder α]
-
-theorem isPredPrelimit_iff_pred_ne : IsPredPrelimit a ↔ ∀ b, pred b ≠ a :=
-  ⟨IsPredPrelimit.pred_ne, isPredPrelimit_of_pred_ne⟩
-
-theorem not_isPredPrelimit_iff' : ¬ IsPredPrelimit a ↔ a ∈ range (pred : α → α) := by
-  simp_rw [isPredPrelimit_iff_pred_ne, not_forall, not_ne_iff, mem_range]
-
-end NoMinOrder
 
 section IsPredArchimedean
 
@@ -577,15 +480,19 @@ section LinearOrder
 
 variable [LinearOrder α]
 
+@[to_dual existing]
 theorem IsPredPrelimit.le_iff_forall_le (h : IsPredPrelimit a) : b ≤ a ↔ ∀ ⦃c⦄, a < c → b ≤ c :=
   h.dual.le_iff_forall_le
 
+@[to_dual existing]
 theorem IsPredLimit.le_iff_forall_le (h : IsPredLimit a) : b ≤ a ↔ ∀ ⦃c⦄, a < c → b ≤ c :=
   h.dual.le_iff_forall_le
 
+@[to_dual existing]
 theorem IsPredPrelimit.lt_iff_exists_lt (h : IsPredPrelimit b) : b < a ↔ ∃ c, b < c ∧ c < a :=
   h.dual.lt_iff_exists_lt
 
+@[to_dual existing]
 theorem IsPredLimit.lt_iff_exists_lt (h : IsPredLimit b) : b < a ↔ ∃ c, b < c ∧ c < a :=
   h.dual.lt_iff_exists_lt
 
@@ -620,14 +527,6 @@ theorem IsPredLimit.isGLB_Ioi (ha : IsPredLimit a) : IsGLB (Ioi a) a :=
 theorem isGLB_Ioi_iff_isPredPrelimit : IsGLB (Ioi a) a ↔ IsPredPrelimit a := by
   simpa using isLUB_Iio_iff_isSuccPrelimit (a := toDual a)
 
-variable [PredOrder α]
-
-theorem IsPredPrelimit.pred_le_iff (hb : IsPredPrelimit b) : pred a ≤ b ↔ a ≤ b :=
-  hb.dual.le_succ_iff
-
-theorem IsPredLimit.pred_le_iff (hb : IsPredLimit b) : pred a ≤ b ↔ a ≤ b :=
-  hb.dual.le_succ_iff
-
 end LinearOrder
 
 end Order
@@ -649,12 +548,14 @@ variable [PartialOrder α] [SuccOrder α]
 variable (b) in
 open Classical in
 /-- A value can be built by building it on successors and successor pre-limits. -/
-@[elab_as_elim]
+@[to_dual (attr := elab_as_elim)
+/-- A value can be built by building it on predecessors and predecessor pre-limits. -/]
 noncomputable def isSuccPrelimitRecOn : motive b :=
   if hb : IsSuccPrelimit b then isSuccPrelimit b hb else
     haveI H := Classical.choose_spec (not_isSuccPrelimit_iff.1 hb)
     cast (congr_arg motive H.2) (succ _ H.1)
 
+@[to_dual]
 theorem isSuccPrelimitRecOn_of_isSuccPrelimit (hb : IsSuccPrelimit b) :
     isSuccPrelimitRecOn b succ isSuccPrelimit = isSuccPrelimit b hb :=
   dif_pos hb
@@ -666,59 +567,23 @@ section LinearOrder
 variable [LinearOrder α] [SuccOrder α]
   (succ : ∀ a, ¬IsMax a → motive (succ a)) (isSuccPrelimit : ∀ a, IsSuccPrelimit a → motive a)
 
+@[to_dual]
 theorem isSuccPrelimitRecOn_succ_of_not_isMax (hb : ¬IsMax b) :
     isSuccPrelimitRecOn (Order.succ b) succ isSuccPrelimit = succ b hb := by
   have hb' := not_isSuccPrelimit_succ_of_not_isMax hb
   have H := Classical.choose_spec (not_isSuccPrelimit_iff.1 hb')
   rw [isSuccPrelimitRecOn, dif_neg hb', cast_eq_iff_heq]
-  congr
-  exacts [(succ_eq_succ_iff_of_not_isMax H.1 hb).1 H.2, proof_irrel_heq _ _]
+  congr!
+  exact (succ_eq_succ_iff_of_not_isMax H.1 hb).1 H.2
 
-@[simp]
+@[to_dual (attr := simp)]
 theorem isSuccPrelimitRecOn_succ [NoMaxOrder α] (b : α) :
     isSuccPrelimitRecOn (Order.succ b) succ isSuccPrelimit = succ b (not_isMax b) :=
-  isSuccPrelimitRecOn_succ_of_not_isMax _ _ _
+  isSuccPrelimitRecOn_succ_of_not_isMax ..
 
 end LinearOrder
 
 end isSuccPrelimitRecOn
-
-section isPredPrelimitRecOn
-
-section PartialOrder
-
-variable [PartialOrder α] [PredOrder α]
-  (pred : ∀ a, ¬IsMin a → motive (pred a)) (isPredPrelimit : ∀ a, IsPredPrelimit a → motive a)
-
-variable (b) in
-/-- A value can be built by building it on predecessors and predecessor pre-limits. -/
-@[elab_as_elim]
-noncomputable def isPredPrelimitRecOn : motive b :=
-  isSuccPrelimitRecOn (α := αᵒᵈ) b pred (fun a ha ↦ isPredPrelimit a ha.dual)
-
-theorem isPredPrelimitRecOn_of_isPredPrelimit (hb : IsPredPrelimit b) :
-    isPredPrelimitRecOn b pred isPredPrelimit = isPredPrelimit b hb :=
-  isSuccPrelimitRecOn_of_isSuccPrelimit _ _ hb.dual
-
-end PartialOrder
-
-section LinearOrder
-
-variable [LinearOrder α] [PredOrder α]
-  (pred : ∀ a, ¬IsMin a → motive (pred a)) (isPredPrelimit : ∀ a, IsPredPrelimit a → motive a)
-
-theorem isPredPrelimitRecOn_pred_of_not_isMin (hb : ¬IsMin b) :
-    isPredPrelimitRecOn (Order.pred b) pred isPredPrelimit = pred b hb :=
-  isSuccPrelimitRecOn_succ_of_not_isMax (α := αᵒᵈ) _ _ _
-
-@[simp]
-theorem isPredPrelimitRecOn_pred [NoMinOrder α] (b : α) :
-    isPredPrelimitRecOn (Order.pred b) pred isPredPrelimit = pred b (not_isMin b) :=
-  isPredPrelimitRecOn_pred_of_not_isMin _ _ _
-
-end LinearOrder
-
-end isPredPrelimitRecOn
 
 section isSuccLimitRecOn
 
@@ -730,13 +595,16 @@ variable [PartialOrder α] [SuccOrder α]
 
 variable (b) in
 open Classical in
-/-- A value can be built by building it on minimal elements, successors, and successor limits. -/
-@[elab_as_elim]
+/-- A value can be built by building it on minimal elements, successors,
+and successor limits. -/
+@[to_dual (attr := elab_as_elim)
+/-- A value can be built by building it on maximal elements, predecessors,
+and predecessor limits. -/]
 noncomputable def isSuccLimitRecOn : motive b :=
   isSuccPrelimitRecOn b succ fun a ha ↦
     if h : IsMin a then isMin a h else isSuccLimit a (ha.isSuccLimit_of_not_isMin h)
 
-@[simp]
+@[to_dual (attr := simp)]
 theorem isSuccLimitRecOn_of_isSuccLimit (hb : IsSuccLimit b) :
     isSuccLimitRecOn b isMin succ isSuccLimit = isSuccLimit b hb := by
   rw [isSuccLimitRecOn, isSuccPrelimitRecOn_of_isSuccPrelimit _ _ hb.isSuccPrelimit,
@@ -750,15 +618,17 @@ variable [LinearOrder α] [SuccOrder α]
   (isMin : ∀ a, IsMin a → motive a) (succ : ∀ a, ¬IsMax a → motive (succ a))
   (isSuccLimit : ∀ a, IsSuccLimit a → motive a)
 
+@[to_dual]
 theorem isSuccLimitRecOn_succ_of_not_isMax (hb : ¬IsMax b) :
     isSuccLimitRecOn (Order.succ b) isMin succ isSuccLimit = succ b hb := by
   rw [isSuccLimitRecOn, isSuccPrelimitRecOn_succ_of_not_isMax]
 
-@[simp]
+@[to_dual (attr := simp)]
 theorem isSuccLimitRecOn_succ [NoMaxOrder α] (b : α) :
     isSuccLimitRecOn (Order.succ b) isMin succ isSuccLimit = succ b (not_isMax b) :=
   isSuccLimitRecOn_succ_of_not_isMax isMin succ isSuccLimit _
 
+@[to_dual]
 theorem isSuccLimitRecOn_of_isMin (hb : IsMin b) :
     isSuccLimitRecOn b isMin succ isSuccLimit = isMin b hb := by
   rw [isSuccLimitRecOn, isSuccPrelimitRecOn_of_isSuccPrelimit _ _ hb.isSuccPrelimit, dif_pos hb]
@@ -766,51 +636,6 @@ theorem isSuccLimitRecOn_of_isMin (hb : IsMin b) :
 end LinearOrder
 
 end isSuccLimitRecOn
-
-section isPredLimitRecOn
-
-section PartialOrder
-
-variable [PartialOrder α] [PredOrder α]
-  (isMax : ∀ a, IsMax a → motive a) (pred : ∀ a, ¬IsMin a → motive (pred a))
-  (isPredLimit : ∀ a, IsPredLimit a → motive a)
-
-variable (b) in
-/-- A value can be built by building it on maximal elements, predecessors,
-and predecessor limits. -/
-@[elab_as_elim]
-noncomputable def isPredLimitRecOn : motive b :=
-  isSuccLimitRecOn (α := αᵒᵈ) b isMax pred (fun a ha => isPredLimit a ha.dual)
-
-@[simp]
-theorem isPredLimitRecOn_of_isPredLimit (hb : IsPredLimit b) :
-    isPredLimitRecOn b isMax pred isPredLimit = isPredLimit b hb :=
-  isSuccLimitRecOn_of_isSuccLimit (α := αᵒᵈ) isMax pred _ hb.dual
-
-end PartialOrder
-
-section LinearOrder
-
-variable [LinearOrder α] [PredOrder α]
-  (isMax : ∀ a, IsMax a → motive a) (pred : ∀ a, ¬IsMin a → motive (pred a))
-  (isPredLimit : ∀ a, IsPredLimit a → motive a)
-
-theorem isPredLimitRecOn_pred_of_not_isMin (hb : ¬IsMin b) :
-    isPredLimitRecOn (Order.pred b) isMax pred isPredLimit = pred b hb :=
-  isSuccLimitRecOn_succ_of_not_isMax (α := αᵒᵈ) isMax pred _ hb
-
-@[simp]
-theorem isPredLimitRecOn_pred [NoMinOrder α] :
-    isPredLimitRecOn (Order.pred b) isMax pred isPredLimit = pred b (not_isMin b) :=
-  isSuccLimitRecOn_succ (α := αᵒᵈ) isMax pred _ b
-
-theorem isPredLimitRecOn_of_isMax (hb : IsMax b) :
-    isPredLimitRecOn b isMax pred isPredLimit = isMax b hb :=
-  isSuccLimitRecOn_of_isMin (α := αᵒᵈ) isMax pred _ hb
-
-end LinearOrder
-
-end isPredLimitRecOn
 
 end Order
 
@@ -829,14 +654,16 @@ variable [PartialOrder α] [SuccOrder α] [WellFoundedLT α]
 variable (b) in
 open Classical in
 /-- Recursion principle on a well-founded partial `SuccOrder`. -/
-@[elab_as_elim] noncomputable def prelimitRecOn : motive b :=
+@[to_dual (attr := elab_as_elim)
+/-- Recursion principle on a well-founded partial `PredOrder`. -/]
+noncomputable def prelimitRecOn : motive b :=
   wellFounded_lt.fix
     (fun a IH ↦ if h : IsSuccPrelimit a then isSuccPrelimit a h IH else
       haveI H := Classical.choose_spec (not_isSuccPrelimit_iff.1 h)
       cast (congr_arg motive H.2) (succ _ H.1 <| IH _ <| H.2.subst <| lt_succ_of_not_isMax H.1))
     b
 
-@[simp]
+@[to_dual (attr := simp)]
 theorem prelimitRecOn_of_isSuccPrelimit (hb : IsSuccPrelimit b) :
     prelimitRecOn b succ isSuccPrelimit =
       isSuccPrelimit b hb fun x _ ↦ SuccOrder.prelimitRecOn x succ isSuccPrelimit := by
@@ -850,6 +677,7 @@ variable [LinearOrder α] [SuccOrder α] [WellFoundedLT α]
   (succ : ∀ a, ¬IsMax a → motive a → motive (Order.succ a))
   (isSuccPrelimit : ∀ a, IsSuccPrelimit a → (∀ b < a, motive b) → motive a)
 
+@[to_dual]
 theorem prelimitRecOn_succ_of_not_isMax (hb : ¬IsMax b) :
     prelimitRecOn (Order.succ b) succ isSuccPrelimit =
       succ b hb (prelimitRecOn b succ isSuccPrelimit) := by
@@ -860,7 +688,7 @@ theorem prelimitRecOn_succ_of_not_isMax (hb : ¬IsMax b) :
     cast (congr_arg (motive ∘ Order.succ) h) (succ a ha (x a)) = succ c hc (x c) := by subst h; rfl
   exact this <| (succ_eq_succ_iff_of_not_isMax H.1 hb).1 H.2
 
-@[simp]
+@[to_dual (attr := simp)]
 theorem prelimitRecOn_succ [NoMaxOrder α] (b : α) :
     prelimitRecOn (Order.succ b) succ isSuccPrelimit =
       succ b (not_isMax b) (prelimitRecOn b succ isSuccPrelimit) :=
@@ -882,15 +710,18 @@ variable (b) in
 open Classical in
 /-- Recursion principle on a well-founded partial `SuccOrder`, separating out the case of a
 minimal element. -/
-@[elab_as_elim] noncomputable def limitRecOn : motive b :=
+@[to_dual (attr := elab_as_elim)
+/-- Recursion principle on a well-founded partial `PredOrder`, separating out the case of a
+minimal element. -/]
+noncomputable def limitRecOn : motive b :=
   prelimitRecOn b succ fun a ha IH ↦
     if h : IsMin a then isMin a h else isSuccLimit a (ha.isSuccLimit_of_not_isMin h) IH
 
-@[simp]
+@[to_dual (attr := simp)]
 theorem limitRecOn_isMin (hb : IsMin b) : limitRecOn b isMin succ isSuccLimit = isMin b hb := by
   rw [limitRecOn, prelimitRecOn_of_isSuccPrelimit _ _ hb.isSuccPrelimit, dif_pos hb]
 
-@[simp]
+@[to_dual (attr := simp)]
 theorem limitRecOn_of_isSuccLimit (hb : IsSuccLimit b) :
     limitRecOn b isMin succ isSuccLimit =
       isSuccLimit b hb fun x _ ↦ limitRecOn x isMin succ isSuccLimit := by
@@ -904,12 +735,13 @@ variable [LinearOrder α] [SuccOrder α] [WellFoundedLT α] (isMin : ∀ a, IsMi
   (succ : ∀ a, ¬IsMax a → motive a → motive (Order.succ a))
   (isSuccLimit : ∀ a, IsSuccLimit a → (∀ b < a, motive b) → motive a)
 
+@[to_dual]
 theorem limitRecOn_succ_of_not_isMax (hb : ¬IsMax b) :
     limitRecOn (Order.succ b) isMin succ isSuccLimit =
       succ b hb (limitRecOn b isMin succ isSuccLimit) := by
   rw [limitRecOn, prelimitRecOn_succ_of_not_isMax]; rfl
 
-@[simp]
+@[to_dual (attr := simp)]
 theorem limitRecOn_succ [NoMaxOrder α] (b : α) :
     limitRecOn (Order.succ b) isMin succ isSuccLimit =
       succ b (not_isMax b) (limitRecOn b isMin succ isSuccLimit) :=
@@ -920,97 +752,3 @@ end LinearOrder
 end limitRecOn
 
 end SuccOrder
-
-namespace PredOrder
-
-section prelimitRecOn
-
-section PartialOrder
-
-variable [PartialOrder α] [PredOrder α] [WellFoundedGT α]
-  (pred : ∀ a, ¬IsMin a → motive a → motive (Order.pred a))
-  (isPredPrelimit : ∀ a, IsPredPrelimit a → (∀ b > a, motive b) → motive a)
-
-variable (b) in
-/-- Recursion principle on a well-founded partial `PredOrder`. -/
-@[elab_as_elim] noncomputable def prelimitRecOn : motive b :=
-  SuccOrder.prelimitRecOn (α := αᵒᵈ) b pred (fun a ha => isPredPrelimit a ha.dual)
-
-@[simp]
-theorem prelimitRecOn_of_isPredPrelimit (hb : IsPredPrelimit b) :
-    prelimitRecOn b pred isPredPrelimit =
-      isPredPrelimit b hb fun x _ ↦ prelimitRecOn x pred isPredPrelimit :=
-  SuccOrder.prelimitRecOn_of_isSuccPrelimit _ _ hb.dual
-
-end PartialOrder
-
-section LinearOrder
-
-variable [LinearOrder α] [PredOrder α] [WellFoundedGT α]
-  (pred : ∀ a, ¬IsMin a → motive a → motive (Order.pred a))
-  (isPredPrelimit : ∀ a, IsPredPrelimit a → (∀ b > a, motive b) → motive a)
-
-theorem prelimitRecOn_pred_of_not_isMin (hb : ¬IsMin b) :
-    prelimitRecOn (Order.pred b) pred isPredPrelimit =
-      pred b hb (prelimitRecOn b pred isPredPrelimit) :=
-  SuccOrder.prelimitRecOn_succ_of_not_isMax _ _ _
-
-@[simp]
-theorem prelimitRecOn_pred [NoMinOrder α] (b : α) :
-    prelimitRecOn (Order.pred b) pred isPredPrelimit =
-      pred b (not_isMin b) (prelimitRecOn b pred isPredPrelimit) :=
-  prelimitRecOn_pred_of_not_isMin _ _ _
-
-end LinearOrder
-
-end prelimitRecOn
-
-section limitRecOn
-
-section PartialOrder
-
-variable [PartialOrder α] [PredOrder α] [WellFoundedGT α] (isMax : ∀ a, IsMax a → motive a)
-  (pred : ∀ a, ¬IsMin a → motive a → motive (Order.pred a))
-  (isPredLimit : ∀ a, IsPredLimit a → (∀ b > a, motive b) → motive a)
-
-variable (b) in
-open Classical in
-/-- Recursion principle on a well-founded partial `PredOrder`, separating out the case of a
-maximal element. -/
-@[elab_as_elim] noncomputable def limitRecOn : motive b :=
-  SuccOrder.limitRecOn (α := αᵒᵈ) b isMax pred (fun a ha => isPredLimit a ha.dual)
-
-@[simp]
-theorem limitRecOn_isMax (hb : IsMax b) : limitRecOn b isMax pred isPredLimit = isMax b hb :=
-  SuccOrder.limitRecOn_isMin (α := αᵒᵈ) isMax pred _ hb
-
-@[simp]
-theorem limitRecOn_of_isPredLimit (hb : IsPredLimit b) :
-    limitRecOn b isMax pred isPredLimit =
-      isPredLimit b hb fun x _ ↦ limitRecOn x isMax pred isPredLimit :=
-  SuccOrder.limitRecOn_of_isSuccLimit (α := αᵒᵈ) isMax pred _ hb.dual
-
-end PartialOrder
-
-section LinearOrder
-
-variable [LinearOrder α] [PredOrder α] [WellFoundedGT α] (isMax : ∀ a, IsMax a → motive a)
-  (pred : ∀ a, ¬IsMin a → motive a → motive (Order.pred a))
-  (isPredLimit : ∀ a, IsPredLimit a → (∀ b > a, motive b) → motive a)
-
-theorem limitRecOn_pred_of_not_isMin (hb : ¬IsMin b) :
-    limitRecOn (Order.pred b) isMax pred isPredLimit =
-      pred b hb (limitRecOn b isMax pred isPredLimit) :=
-  SuccOrder.limitRecOn_succ_of_not_isMax (α := αᵒᵈ) isMax pred _ hb
-
-@[simp]
-theorem limitRecOn_pred [NoMinOrder α] (b : α) :
-    limitRecOn (Order.pred b) isMax pred isPredLimit =
-      pred b (not_isMin b) (limitRecOn b isMax pred isPredLimit) :=
-  SuccOrder.limitRecOn_succ (α := αᵒᵈ) isMax pred _ b
-
-end LinearOrder
-
-end limitRecOn
-
-end PredOrder

--- a/Mathlib/Order/SuccPred/Limit.lean
+++ b/Mathlib/Order/SuccPred/Limit.lean
@@ -399,12 +399,6 @@ end LinearOrder
 
 -- TODO: generate all of this through `to_dual`.
 
-section LT
-
-variable [LT α]
-
-end LT
-
 section Preorder
 
 variable [Preorder α]

--- a/Mathlib/Tactic/Translate/ToDual.lean
+++ b/Mathlib/Tactic/Translate/ToDual.lean
@@ -153,10 +153,8 @@ def nameDict : Std.HashMap String (List String) := .ofList [
   ("cocones", ["Cones"]),
   ("fan", ["Cofan"]),
   ("cofan", ["Fan"]),
-
-  /- These cause problem with `IsSuccLimit` and `IsPredLimit`. -/
-  -- ("limit", ["Colimit"]),
-  -- ("colimit", ["Limit"]),
+  ("limit", ["Colimit"]),
+  ("colimit", ["Limit"]),
   ("limits", ["Colimits"]),
   ("colimits", ["Limits"]),
   ("product", ["Coproduct"]),
@@ -183,7 +181,9 @@ def nameDict : Std.HashMap String (List String) := .ofList [
 @[inherit_doc GuessName.GuessNameData.abbreviationDict]
 def abbreviationDict : Std.HashMap String String := .ofList [
   ("wellFoundedLT", "WellFoundedGT"),
-  ("wellFoundedGT", "WellFoundedLT")
+  ("wellFoundedGT", "WellFoundedLT"),
+  ("succColimit", "SuccLimit"),
+  ("predColimit", "PredLimit")
 ]
 
 /-- The bundle of environment extensions for `to_dual` -/

--- a/Mathlib/Tactic/Translate/ToDual.lean
+++ b/Mathlib/Tactic/Translate/ToDual.lean
@@ -151,8 +151,10 @@ def nameDict : Std.HashMap String (List String) := .ofList [
   ("cocones", ["Cones"]),
   ("fan", ["Cofan"]),
   ("cofan", ["Fan"]),
-  ("limit", ["Colimit"]),
-  ("colimit", ["Limit"]),
+
+  /- These cause problem with `IsSuccLimit` and `IsPredLimit`. -/
+  -- ("limit", ["Colimit"]),
+  -- ("colimit", ["Limit"]),
   ("limits", ["Colimits"]),
   ("colimits", ["Limits"]),
   ("product", ["Coproduct"]),


### PR DESCRIPTION


---
<!-- Your PR title will become the first line of the commit message.

In this box, the text above the `---` (if not empty) will be appended
to the commit message, and can be used to give additional context or
details. Please leave a blank newline before the `---`, otherwise GitHub
will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

When merging, all the commits will be squashed into a single commit
listing all co-authors.

Co-authors in the squash commit are gathered from two sources:

First, all authors of commits to this PR branch are included. Thus,
one way to add co-authors is to include at least one commit authored by
each co-author among the commits in the pull request. If necessary, you
may create empty commits to indicate co-authorship, using commands like so:

git commit --author="Author Name <author@email.com>" --allow-empty -m "add Author Name as coauthor"

Second, co-authors can also be listed in lines at the very bottom of
the commit message (that is, directly before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines
at the bottom of the commit message (before the `---`, and also before
any "Co-authored-by" lines) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->
- [x] depends on: #33150

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
