### PR TITLE
[Merged by Bors] - doc(MeasureTheory): fix typos and inconsistencies

### DIFF
--- a/Mathlib/MeasureTheory/Constructions/BorelSpace/Basic.lean
+++ b/Mathlib/MeasureTheory/Constructions/BorelSpace/Basic.lean
@@ -28,7 +28,7 @@ public import Mathlib.Topology.Instances.Rat
 * `IsOpen.measurableSet`, `IsClosed.measurableSet`: open and closed sets are measurable;
 * `Continuous.measurable` : a continuous function is measurable;
 * `Continuous.measurable2` : if `f : α → β` and `g : α → γ` are measurable and `op : β × γ → δ`
-  is continuous, then `fun x => op (f x, g y)` is measurable;
+  is continuous, then `fun x => op (f x, g x)` is measurable;
 * `Measurable.add` etc. : dot notation for arithmetic operations on `Measurable` predicates,
   and similarly for `dist` and `edist`;
 * `AEMeasurable.add` : similar dot notation for almost everywhere measurable functions;

--- a/Mathlib/MeasureTheory/Constructions/Cylinders.lean
+++ b/Mathlib/MeasureTheory/Constructions/Cylinders.lean
@@ -55,7 +55,7 @@ section squareCylinders
 /-- Given a finite set `s` of indices, a square cylinder is the product of a set `S` of
 `∀ i : s, α i` and of `univ` on the other indices. The set `S` is a product of sets `t i` such that
 for all `i : s`, `t i ∈ C i`.
-`squareCylinders` is the set of all such `squareCylinders`. -/
+`squareCylinders` is the set of all such square cylinders. -/
 def squareCylinders (C : ∀ i, Set (Set (α i))) : Set (Set (∀ i, α i)) :=
   {S | ∃ s : Finset ι, ∃ t ∈ univ.pi C, S = (s : Set ι).pi t}
 

--- a/Mathlib/MeasureTheory/Constructions/Pi.lean
+++ b/Mathlib/MeasureTheory/Constructions/Pi.lean
@@ -38,7 +38,7 @@ For a collection of σ-finite measures `μ` and a collection of measurable sets 
 `Measure.pi μ (pi univ s) = ∏ i, m i (s i)`. To do this, we follow the following steps:
 * We know that there is some ordering on `ι`, given by an element of `[Countable ι]`.
 * Using this, we have an equivalence `MeasurableEquiv.piMeasurableEquivTProd` between
-  `∀ ι, α i` and an iterated product of `α i`, called `List.tprod α l` for some list `l`.
+  `∀ i, α i` and an iterated product of `α i`, called `List.tprod α l` for some list `l`.
 * On this iterated product we can easily define a product measure `MeasureTheory.Measure.tprod`
   by iterating `MeasureTheory.Measure.prod`
 * Using the previous two steps we construct `MeasureTheory.Measure.pi'` on `(i : ι) → α i` for

--- a/Mathlib/MeasureTheory/Function/ConvergenceInMeasure.lean
+++ b/Mathlib/MeasureTheory/Function/ConvergenceInMeasure.lean
@@ -31,7 +31,7 @@ convergence in measure and other notions of convergence.
 * `MeasureTheory.tendstoInMeasure_of_tendsto_ae`: convergence almost everywhere in a finite
   measure space implies convergence in measure.
 * `MeasureTheory.TendstoInMeasure.exists_seq_tendsto_ae`: if `f` is a sequence of functions
-  which converges in measure to `g`, then `f` has a subsequence which convergence almost
+  which converges in measure to `g`, then `f` has a subsequence which converges almost
   everywhere to `g`.
 * `MeasureTheory.exists_seq_tendstoInMeasure_atTop_iff`: for a sequence of functions `f`,
   convergence in measure is equivalent to the fact that every subsequence has another subsequence

--- a/Mathlib/MeasureTheory/Function/Jacobian.lean
+++ b/Mathlib/MeasureTheory/Function/Jacobian.lean
@@ -51,7 +51,7 @@ For the next statements, `s` is a measurable set and `f` is differentiable on `s
 * `integral_image_eq_integral_abs_det_fderiv_smul`: for `g : E → F`, one has
     `∫ x in f '' s, g x ∂μ = ∫ x in s, |(f' x).det| • g (f x) ∂μ`.
 * `integrableOn_image_iff_integrableOn_abs_det_fderiv_smul`: for `g : E → F`, the function `g` is
-  integrable on `f '' s` if and only if `|(f' x).det| • g (f x))` is integrable on `s`.
+  integrable on `f '' s` if and only if `|(f' x).det| • g (f x)` is integrable on `s`.
 
 ## Implementation
 

--- a/Mathlib/MeasureTheory/Function/SimpleFuncDense.lean
+++ b/Mathlib/MeasureTheory/Function/SimpleFuncDense.lean
@@ -55,7 +55,7 @@ variable [MeasurableSpace α] [PseudoEMetricSpace α] [OpensMeasurableSpace α]
 
 /-- `nearestPtInd e N x` is the index `k` such that `e k` is the nearest point to `x` among the
 points `e 0`, ..., `e N`. If more than one point are at the same distance from `x`, then
-`nearestPtInd e N x` returns the least of their indexes. -/
+`nearestPtInd e N x` returns the least of their indices. -/
 noncomputable def nearestPtInd (e : ℕ → α) : ℕ → α →ₛ ℕ
   | 0 => const α 0
   | N + 1 =>

--- a/Mathlib/MeasureTheory/Function/UnifTight.lean
+++ b/Mathlib/MeasureTheory/Function/UnifTight.lean
@@ -49,7 +49,7 @@ variable {α β ι : Type*} {m : MeasurableSpace α} {μ : Measure α} [NormedAd
 section UnifTight
 
 /- This follows closely the `UnifIntegrable` section
-from `Mathlib/MeasureTheory/Functions/UniformIntegrable.lean`. -/
+from `Mathlib/MeasureTheory/Function/UniformIntegrable.lean`. -/
 
 variable {f g : ι → α → β} {p : ℝ≥0∞}
 

--- a/Mathlib/MeasureTheory/Group/Arithmetic.lean
+++ b/Mathlib/MeasureTheory/Group/Arithmetic.lean
@@ -30,7 +30,7 @@ For instances relating, e.g., `ContinuousMul` to `MeasurableMul` see file
 ## Implementation notes
 
 For the heuristics of `@[to_additive]` it is important that the type with a multiplication
-(or another multiplicative operations) is the first (implicit) argument of all declarations.
+(or another multiplicative operation) is the first (implicit) argument of all declarations.
 
 ## Tags
 

--- a/Mathlib/MeasureTheory/Group/FundamentalDomain.lean
+++ b/Mathlib/MeasureTheory/Group/FundamentalDomain.lean
@@ -57,7 +57,7 @@ open MeasureTheory MeasureTheory.Measure Set Function TopologicalSpace Filter
 namespace MeasureTheory
 
 /-- A measurable set `s` is a *fundamental domain* for an additive action of an additive group `G`
-on a measurable space `α` with respect to a measure `α` if the sets `g +ᵥ s`, `g : G`, are pairwise
+on a measurable space `α` with respect to a measure `μ` if the sets `g +ᵥ s`, `g : G`, are pairwise
 a.e. disjoint and cover the whole space. -/
 structure IsAddFundamentalDomain (G : Type*) {α : Type*} [Zero G] [VAdd G α] [MeasurableSpace α]
     (s : Set α) (μ : Measure α := by volume_tac) : Prop where
@@ -66,7 +66,7 @@ structure IsAddFundamentalDomain (G : Type*) {α : Type*} [Zero G] [VAdd G α] [
   protected aedisjoint : Pairwise <| (AEDisjoint μ on fun g : G => g +ᵥ s)
 
 /-- A measurable set `s` is a *fundamental domain* for an action of a group `G` on a measurable
-space `α` with respect to a measure `α` if the sets `g • s`, `g : G`, are pairwise a.e. disjoint and
+space `α` with respect to a measure `μ` if the sets `g • s`, `g : G`, are pairwise a.e. disjoint and
 cover the whole space. -/
 @[to_additive IsAddFundamentalDomain]
 structure IsFundamentalDomain (G : Type*) {α : Type*} [One G] [SMul G α] [MeasurableSpace α]

--- a/Mathlib/MeasureTheory/Integral/Bochner/L1.lean
+++ b/Mathlib/MeasureTheory/Integral/Bochner/L1.lean
@@ -42,7 +42,7 @@ The Bochner integral is defined through the extension process described in the f
 * `α →₁[μ] E` : functions in L1 space, i.e., equivalence classes of integrable functions (defined in
                 `Mathlib/MeasureTheory/Function/LpSpace/Basic.lean`)
 * `α →₁ₛ[μ] E` : simple functions in L1 space, i.e., equivalence classes of integrable simple
-                 functions (defined in `Mathlib/MeasureTheory/Function/SimpleFuncDense`)
+                 functions (defined in `Mathlib/MeasureTheory/Function/SimpleFuncDenseLp.lean`)
 
 We also define notations for integral on a set, which are described in the file
 `Mathlib/MeasureTheory/Integral/SetIntegral.lean`.

--- a/Mathlib/MeasureTheory/Integral/Prod.lean
+++ b/Mathlib/MeasureTheory/Integral/Prod.lean
@@ -26,7 +26,7 @@ In this file we prove Fubini's theorem.
   Tonelli's theorem (see `MeasureTheory.lintegral_prod`). The lemma
   `MeasureTheory.Integrable.integral_prod_right` states that the inner integral of the right-hand
   side is integrable.
-* `MeasureTheory.integral_integral_swap_of_hasCompactSupport`: a version of Fubini theorem for
+* `MeasureTheory.integral_integral_swap_of_hasCompactSupport`: a version of Fubini's theorem for
   continuous functions with compact support, which does not assume that the measures are σ-finite
   contrary to all the usual versions of Fubini.
 

--- a/Mathlib/MeasureTheory/MeasurableSpace/Invariants.lean
+++ b/Mathlib/MeasureTheory/MeasurableSpace/Invariants.lean
@@ -12,7 +12,7 @@ public import Mathlib.MeasureTheory.MeasurableSpace.Defs
 In this file we define `MeasurableSpace.invariants (f : α → α)`
 to be the σ-algebra of sets `s : Set α` such that
 - `s` is measurable w.r.t. the canonical σ-algebra on `α`;
-- and `f ⁻ˢ' s = s`.
+- and `f ⁻¹' s = s`.
 -/
 
 @[expose] public section

--- a/Mathlib/MeasureTheory/Measure/Complex.lean
+++ b/Mathlib/MeasureTheory/Measure/Complex.lean
@@ -22,7 +22,7 @@ a complex measure is always in the form `s + it` where `s` and `t` are signed me
 * `MeasureTheory.ComplexMeasure.im`: obtains a signed measure `s` from a complex measure `c`
   such that `s i = (c i).im` for all measurable sets `i`.
 * `MeasureTheory.SignedMeasure.toComplexMeasure`: given two signed measures `s` and `t`,
-  `s.to_complex_measure t` provides a complex measure of the form `s + it`.
+  `s.toComplexMeasure t` provides a complex measure of the form `s + it`.
 * `MeasureTheory.ComplexMeasure.equivSignedMeasure`: is the equivalence between the complex
   measures and the type of the product of the signed measures with itself.
 

--- a/Mathlib/MeasureTheory/Measure/Haar/Unique.lean
+++ b/Mathlib/MeasureTheory/Measure/Haar/Unique.lean
@@ -32,7 +32,7 @@ To get genuine equality of measures, we typically need additional regularity ass
 
 * `isMulLeftInvariant_eq_smul_of_innerRegular`: two left invariant measures which are
   inner regular coincide up to a scalar.
-* `isMulLeftInvariant_eq_smul_of_regular`: two left invariant measure which are
+* `isMulLeftInvariant_eq_smul_of_regular`: two left invariant measures which are
   regular coincide up to a scalar.
 * `isHaarMeasure_eq_smul`: in a second countable space, two Haar measures coincide up to a
   scalar.

--- a/Mathlib/MeasureTheory/Measure/HasOuterApproxClosedProd.lean
+++ b/Mathlib/MeasureTheory/Measure/HasOuterApproxClosedProd.lean
@@ -17,7 +17,7 @@ the values `∫ p, (Π i, f i (p.1 i)) * (Π j, g j (p.2 j)) ∂μ`, for
 `f : (i : ι) → X i → ℝ` and `g : (j : κ) → Y j → ℝ`
 any families of bounded continuous functions.
 
-In particular, If `μ` and `ν` and two finite measures over `Π i, X i` and `Π j, Y j` respectively,
+In particular, if `μ` and `ν` are two finite measures over `Π i, X i` and `Π j, Y j` respectively,
 then their product is the only finite measure `ξ` over `(Π i, X i) × (Π j, Y j)`
 such that for any two families bounded continuous functions
 `f : (i : ι) → X i → ℝ` and `g : (j : κ) → Y j → ℝ` we have

--- a/Mathlib/MeasureTheory/Measure/Hausdorff.lean
+++ b/Mathlib/MeasureTheory/Measure/Hausdorff.lean
@@ -17,7 +17,7 @@ public import Mathlib.Topology.MetricSpace.MetricSeparated
 In this file we define the `d`-dimensional Hausdorff measure on an (extended) metric space `X` and
 the Hausdorff dimension of a set in an (extended) metric space. Let `μ d δ` be the maximal outer
 measure such that `μ d δ s ≤ (EMetric.diam s) ^ d` for every set of diameter less than `δ`. Then
-the Hausdorff measure `μH[d] s` of `s` is defined as `⨆ δ > 0, μ d δ s`. By Caratheodory theorem
+the Hausdorff measure `μH[d] s` of `s` is defined as `⨆ δ > 0, μ d δ s`. By Carathéodory theorem
 `MeasureTheory.OuterMeasure.IsMetric.borel_le_caratheodory`, this is a Borel measure on `X`.
 
 The value of `μH[d]`, `d > 0`, on a set `s` (measurable or not) is given by
@@ -40,7 +40,7 @@ applied to `MeasureTheory.extend m`.
 
 We also define a predicate `MeasureTheory.OuterMeasure.IsMetric` which says that an outer measure
 is additive on metric separated pairs of sets: `μ (s ∪ t) = μ s + μ t` provided that
-`⨅ (x ∈ s) (y ∈ t), edist x y ≠ 0`. This is the property required for the Caratheodory theorem
+`⨅ (x ∈ s) (y ∈ t), edist x y ≠ 0`. This is the property required for the Carathéodory theorem
 `MeasureTheory.OuterMeasure.IsMetric.borel_le_caratheodory`, so we prove this theorem for any
 metric outer measure, then prove that outer measures constructed using `mkMetric'` are metric outer
 measures.
@@ -49,7 +49,7 @@ measures.
 
 * `MeasureTheory.OuterMeasure.IsMetric`: an outer measure `μ` is called *metric* if
   `μ (s ∪ t) = μ s + μ t` for any two metric separated sets `s` and `t`. A metric outer measure in a
-  Borel extended metric space is guaranteed to satisfy the Caratheodory condition, see
+  Borel extended metric space is guaranteed to satisfy the Carathéodory condition, see
   `MeasureTheory.OuterMeasure.IsMetric.borel_le_caratheodory`.
 * `MeasureTheory.OuterMeasure.mkMetric'` and its particular case
   `MeasureTheory.OuterMeasure.mkMetric`: a construction of an outer measure that is guaranteed to
@@ -70,7 +70,7 @@ measures.
 
 * `MeasureTheory.OuterMeasure.IsMetric.borel_le_caratheodory`: if `μ` is a metric outer measure
   on an extended metric space `X` (that is, it is additive on pairs of metric separated sets), then
-  every Borel set is Caratheodory measurable (hence, `μ` defines an actual
+  every Borel set is Carathéodory measurable (hence, `μ` defines an actual
   `MeasureTheory.Measure`). See also `MeasureTheory.Measure.mkMetric`.
 * `MeasureTheory.Measure.hausdorffMeasure_mono`: `μH[d] s` is an antitone function
   of `d`.
@@ -126,8 +126,8 @@ namespace OuterMeasure
 /-!
 ### Metric outer measures
 
-In this section we define metric outer measures and prove Caratheodory theorem: a metric outer
-measure has the Caratheodory property.
+In this section we define metric outer measures and prove Carathéodory theorem: a metric outer
+measure has the Carathéodory property.
 -/
 
 
@@ -154,8 +154,8 @@ theorem finset_iUnion_of_pairwise_separated (hm : IsMetric μ) {I : Finset ι} {
       Metric.AreSeparated.finset_iUnion_right fun j hj =>
         hI i (Or.inl rfl) j (Or.inr hj) (ne_of_mem_of_not_mem hj hiI).symm]
 
-/-- Caratheodory theorem. If `m` is a metric outer measure, then every Borel measurable set `t` is
-Caratheodory measurable: for any (not necessarily measurable) set `s` we have
+/-- Carathéodory theorem. If `m` is a metric outer measure, then every Borel measurable set `t` is
+Carathéodory measurable: for any (not necessarily measurable) set `s` we have
 `μ (s ∩ t) + μ (s \ t) = μ s`. -/
 theorem borel_le_caratheodory (hm : IsMetric μ) : borel X ≤ μ.caratheodory := by
   rw [borel_eq_generateFrom_isClosed]

--- a/Mathlib/MeasureTheory/Measure/Map.lean
+++ b/Mathlib/MeasureTheory/Measure/Map.lean
@@ -41,7 +41,7 @@ variable {mα : MeasurableSpace α} {mβ : MeasurableSpace β} {mγ : Measurable
 namespace Measure
 
 /-- Lift a linear map between `OuterMeasure` spaces such that for each measure `μ` every measurable
-set is caratheodory-measurable w.r.t. `f μ` to a linear map between `Measure` spaces. -/
+set is Carathéodory-measurable w.r.t. `f μ` to a linear map between `Measure` spaces. -/
 noncomputable
 def liftLinear [MeasurableSpace β] (f : OuterMeasure α →ₗ[ℝ≥0∞] OuterMeasure β)
     (hf : ∀ μ : Measure α, ‹_› ≤ (f μ.toOuterMeasure).caratheodory) :

--- a/Mathlib/MeasureTheory/Measure/MeasureSpaceDef.lean
+++ b/Mathlib/MeasureTheory/Measure/MeasureSpaceDef.lean
@@ -37,7 +37,7 @@ This conveniently allows us to apply the measure to sets without proving that th
 We get countable subadditivity for all sets, but only countable additivity for measurable sets.
 
 See the documentation of `MeasureTheory.MeasureSpace` for ways to construct measures and proving
-that two measure are equal.
+that two measures are equal.
 
 A `MeasureSpace` is a class that is a measurable space with a canonical measure.
 The measure is denoted `volume`.

--- a/Mathlib/MeasureTheory/Measure/Stieltjes.lean
+++ b/Mathlib/MeasureTheory/Measure/Stieltjes.lean
@@ -42,8 +42,8 @@ These definitions are just handy tools for some proofs of this file, so they are
 there, and not exported.
 
 Note that the theory of Stieltjes measures is not completely satisfactory when there is a bot
-element `x`: any Stieljes measure gives zero mass to `{x}` in this case, so the Dirac mass at `x`
-is not representable as a Stieljes measure.
+element `x`: any Stieltjes measure gives zero mass to `{x}` in this case, so the Dirac mass at `x`
+is not representable as a Stieltjes measure.
 -/
 
 noncomputable section
@@ -175,7 +175,7 @@ theorem id_leftLim (x : ℝ) : leftLim StieltjesFunction.id x = x :=
   continuousWithinAt_id.leftLim_eq
 
 variable (R) in
-/-- Constant functions are Stieltjes function. -/
+/-- A constant function is a Stieltjes function. -/
 protected def const (c : ℝ) : StieltjesFunction R where
   toFun := fun _ ↦ c
   mono' _ _ := by simp

--- a/Mathlib/MeasureTheory/Measure/WithDensityFinite.lean
+++ b/Mathlib/MeasureTheory/Measure/WithDensityFinite.lean
@@ -53,7 +53,7 @@ noncomputable def Measure.toFiniteAux (μ : Measure α) [SFinite μ] : Measure �
   if IsFiniteMeasure μ then μ else (exists_isFiniteMeasure_absolutelyContinuous μ).choose
 
 /-- A finite measure obtained from an s-finite measure `μ`, such that
-`μ = μ.toFinite.withDensity (μ.rnDeriv µ.toFinite)`
+`μ = μ.toFinite.withDensity (μ.rnDeriv μ.toFinite)`
 (see `MeasureTheory.Measure.withDensity_rnDeriv_eq` along with
 `MeasureTheory.absolutelyContinuous_toFinite`). If `μ` is non-zero, then `μ.toFinite` is a
 probability measure. -/

--- a/Mathlib/MeasureTheory/Order/UpperLower.lean
+++ b/Mathlib/MeasureTheory/Order/UpperLower.lean
@@ -57,8 +57,8 @@ variable {ι : Type*} [Fintype ι] {s : Set (ι → ℝ)} {x : ι → ℝ}
 /-- If we can fit a small ball inside a set `s` intersected with any neighborhood of `x`, then the
 density of `s` near `x` is not `0`.
 
-Along with `aux₁`, this proves that `x` is a Lebesgue point of `s`. This will be used to prove that
-the frontier of an order-connected set is null. -/
+Along with `aux₁`, this proves that `x` is not a Lebesgue point of `s`. This will be used to prove
+that the frontier of an order-connected set is null. -/
 private lemma aux₀
     (h : ∀ δ, 0 < δ →
       ∃ y, closedBall y (δ / 4) ⊆ closedBall x δ ∧ closedBall y (δ / 4) ⊆ interior s) :
@@ -86,8 +86,8 @@ private lemma aux₀
 /-- If we can fit a small ball inside a set `sᶜ` intersected with any neighborhood of `x`, then the
 density of `s` near `x` is not `1`.
 
-Along with `aux₀`, this proves that `x` is a Lebesgue point of `s`. This will be used to prove that
-the frontier of an order-connected set is null. -/
+Along with `aux₀`, this proves that `x` is not a Lebesgue point of `s`. This will be used to prove
+that the frontier of an order-connected set is null. -/
 private lemma aux₁
     (h : ∀ δ, 0 < δ →
       ∃ y, closedBall y (δ / 4) ⊆ closedBall x δ ∧ closedBall y (δ / 4) ⊆ interior sᶜ) :

--- a/Mathlib/MeasureTheory/OuterMeasure/Caratheodory.lean
+++ b/Mathlib/MeasureTheory/OuterMeasure/Caratheodory.lean
@@ -9,7 +9,7 @@ public import Mathlib.MeasureTheory.OuterMeasure.OfFunction
 public import Mathlib.MeasureTheory.PiSystem
 
 /-!
-# The Caratheodory σ-algebra of an outer measure
+# The Carathéodory σ-algebra of an outer measure
 
 Given an outer measure `m`, the Carathéodory-measurable sets are the sets `s` such that
 for all sets `t` we have `m t = m (t ∩ s) + m (t \ s)`. This forms a measurable space.

--- a/Mathlib/MeasureTheory/VectorMeasure/Basic.lean
+++ b/Mathlib/MeasureTheory/VectorMeasure/Basic.lean
@@ -22,7 +22,7 @@ Similarly, when `M = ℂ`, we call the measure a complex measure and write `Comp
 ## Main definitions
 
 * `MeasureTheory.VectorMeasure` is a vector-valued, σ-additive function that maps the empty
-  and non-measurable set to zero.
+  and non-measurable sets to zero.
 * `MeasureTheory.VectorMeasure.map` is the pushforward of a vector measure along a function.
 * `MeasureTheory.VectorMeasure.restrict` is the restriction of a vector measure on some set.
 

--- a/Mathlib/MeasureTheory/VectorMeasure/Decomposition/Hahn.lean
+++ b/Mathlib/MeasureTheory/VectorMeasure/Decomposition/Hahn.lean
@@ -66,7 +66,7 @@ such that, for all $n$, $s(A_{n + 1})$ is close to maximal among subsets of
 $i \setminus \bigcup_{k \le n} A_k$.
 
 This sequence of sets does not necessarily exist. However, if this sequence terminates; that is,
-there does not exists any sets satisfying the property, the last $A_n$ will be a negative subset
+there does not exist any set satisfying the property, the last $A_n$ will be a negative subset
 of negative measure, hence proving our claim.
 
 In the case that the sequence does not terminate, it is easy to see that
@@ -86,7 +86,7 @@ To implement this in Lean, we define several auxiliary definitions.
   `restrictNonposSeq s i (n + 1) = someExistsOneDivLT s (i \ ⋃ k ≤ n, restrictNonposSeq k)`.
   This definition represents the sequence $(A_n)$ in the proof as described above.
 
-With these definitions, we are able consider the case where the sequence terminates separately,
+With these definitions, we are able to consider the case where the sequence terminates separately,
 allowing us to prove `exists_subset_restrict_nonpos`.
 -/
 

--- a/Mathlib/MeasureTheory/VectorMeasure/Decomposition/Lebesgue.lean
+++ b/Mathlib/MeasureTheory/VectorMeasure/Decomposition/Lebesgue.lean
@@ -20,9 +20,9 @@ to `ν`.
 
 ## Main definitions
 
-* `MeasureTheory.SignedMeasure.HaveLebesgueDecomposition` : A signed measure `s` and a
-  measure `μ` is said to `HaveLebesgueDecomposition` if both the positive part and negative
-  part of `s` `HaveLebesgueDecomposition` with respect to `μ`.
+* `MeasureTheory.SignedMeasure.HaveLebesgueDecomposition` : A signed measure `s` is said to have
+  Lebesgue decomposition with respect to a measure `μ` if both the positive part and negative part
+  of `s` have Lebesgue decomposition with respect to `μ`.
 * `MeasureTheory.SignedMeasure.singularPart` : The singular part between a signed measure `s`
   and a measure `μ` is simply the singular part of the positive part of `s` with respect to `μ`
   minus the singular part of the negative part of `s` with respect to `μ`.

--- a/Mathlib/MeasureTheory/VectorMeasure/WithDensity.lean
+++ b/Mathlib/MeasureTheory/VectorMeasure/WithDensity.lean
@@ -13,7 +13,7 @@ public import Mathlib.MeasureTheory.Function.AEEqOfIntegral
 # Vector measure defined by an integral
 
 Given a measure `μ` and an integrable function `f : α → E`, we can define a vector measure `v` such
-that for all measurable set `s`, `v i = ∫ x in s, f x ∂μ`. This definition is useful for
+that for all measurable sets `s`, `v s = ∫ x in s, f x ∂μ`. This definition is useful for
 the Radon-Nikodym theorem for signed measures.
 
 ## Main definitions


### PR DESCRIPTION
Typos found and fixed by Codex.

---
<!-- Your PR title will become the first line of the commit message.

In this box, the text above the `---` (if not empty) will be appended
to the commit message, and can be used to give additional context or
details. Please leave a blank newline before the `---`, otherwise GitHub
will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

When merging, all the commits will be squashed into a single commit
listing all co-authors.

Co-authors in the squash commit are gathered from two sources:

First, all authors of commits to this PR branch are included. Thus,
one way to add co-authors is to include at least one commit authored by
each co-author among the commits in the pull request. If necessary, you
may create empty commits to indicate co-authorship, using commands like so:

git commit --author="Author Name <author@email.com>" --allow-empty -m "add Author Name as coauthor"

Second, co-authors can also be listed in lines at the very bottom of
the commit message (that is, directly before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines
at the bottom of the commit message (before the `---`, and also before
any "Co-authored-by" lines) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
