### PR TITLE
[Merged by Bors] - feat(to_fun): show the generated declaration when hovering

### DIFF
--- a/Mathlib/Tactic/ToFun.lean
+++ b/Mathlib/Tactic/ToFun.lean
@@ -41,7 +41,7 @@ initialize registerBuiltinAttribute {
     if (kind != AttributeKind.global) then
       throwError "`to_fun` can only be used as a global attribute"
     addRelatedDecl src "fun_" "" ref stx? (docstringPrefix? := s!"Eta-expanded form of `{src}`")
-      fun value levels => do
+      (hoverInfo := true) fun value levels => do
       let type ← inferType value
       let r ← Push.pullCore .lambda type none
       if r.expr == type then

--- a/Mathlib/Util/AddRelatedDecl.lean
+++ b/Mathlib/Util/AddRelatedDecl.lean
@@ -44,13 +44,17 @@ Arguments:
   We apply it to both declarations, to have the same behavior as `to_additive`, and to shorten some
   attribute commands. Note that `@[elementwise (attr := simp), reassoc (attr := simp)]` will try
   to apply `simp` twice to the current declaration, but that causes no issues.
-* `docstringPrefix` is prepended to the doc-string of `src` to form the doc-string of `tgt`.
+* `docstringPrefix?` is prepended to the doc-string of `src` to form the doc-string of `tgt`.
   If it is `none`, only the doc-string of `src` is used.
+* When `hoverInfo := true`, the generated constant will be shown as the hover information on `ref`.
+  Warning: As a result, the original doc-string of `ref` will not be visible,
+  and go-to-def on `ref` will not go to the definition of `ref`.
 -/
 def addRelatedDecl (src : Name) (prefix_ suffix : String) (ref : Syntax)
     (attrs? : Option (Syntax.TSepArray `Lean.Parser.Term.attrInstance ","))
     (construct : Expr → List Name → MetaM (Expr × List Name))
-    (docstringPrefix? : Option String := none) :
+    (docstringPrefix? : Option String := none)
+    (hoverInfo : Bool := false) :
     MetaM Unit := do
   let tgt := match src with
     | Name.str n s => Name.mkStr n <| prefix_ ++ s ++ suffix
@@ -85,5 +89,7 @@ def addRelatedDecl (src : Name) (prefix_ suffix : String) (ref : Syntax)
     let attrs ← elabAttrs attrs
     Term.applyAttributes src attrs
     Term.applyAttributes tgt attrs
+    if hoverInfo then
+      Term.addTermInfo' ref (← mkConstWithLevelParams tgt) (isBinder := true)
 
 end Mathlib.Tactic


### PR DESCRIPTION
This PR modifies `@[to_fun]` so that the generated declaration shows up when hovering over `to_fun`.

---
<!-- Your PR title will become the first line of the commit message.

In this box, the text above the `---` (if not empty) will be appended
to the commit message, and can be used to give additional context or
details. Please leave a blank newline before the `---`, otherwise GitHub
will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

When merging, all the commits will be squashed into a single commit
listing all co-authors.

Co-authors in the squash commit are gathered from two sources:

First, all authors of commits to this PR branch are included. Thus,
one way to add co-authors is to include at least one commit authored by
each co-author among the commits in the pull request. If necessary, you
may create empty commits to indicate co-authorship, using commands like so:

git commit --author="Author Name <author@email.com>" --allow-empty -m "add Author Name as coauthor"

Second, co-authors can also be listed in lines at the very bottom of
the commit message (that is, directly before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines
at the bottom of the commit message (before the `---`, and also before
any "Co-authored-by" lines) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
