### PR TITLE
[Merged by Bors] - feat(AddRelatedDecl): define `optAttrArg` syntax and use it

### DIFF
--- a/Mathlib/Order/Defs/Unbundled.lean
+++ b/Mathlib/Order/Defs/Unbundled.lean
@@ -10,7 +10,7 @@ public import Mathlib.Tactic.ExtendDoc
 public import Mathlib.Tactic.Lemma
 public import Mathlib.Tactic.SplitIfs
 public import Mathlib.Tactic.TypeStar
-public import Mathlib.Tactic.ToDual
+import Mathlib.Tactic.ToDual
 
 /-!
 # Orders

--- a/Mathlib/Tactic/CategoryTheory/Elementwise.lean
+++ b/Mathlib/Tactic/CategoryTheory/Elementwise.lean
@@ -205,18 +205,17 @@ The `[HasForget C]` argument will be omitted if it is possible to synthesize an 
 The name of the produced lemma can be specified with `@[elementwise other_lemma_name]`.
 If `simp` is added first, the generated lemma will also have the `simp` attribute.
 -/
-syntax (name := elementwise) "elementwise"
-  " nosimp"? (" (" &"attr" " := " Parser.Term.attrInstance,* ")")? : attr
+syntax (name := elementwise) "elementwise" " nosimp"? optAttrArg : attr
 
 initialize registerBuiltinAttribute {
   name := `elementwise
   descr := ""
   applicationTime := .afterCompilation
   add := fun src ref kind => match ref with
-  | `(attr| elementwise $[nosimp%$nosimp?]? $[(attr := $stx?,*)]?) => MetaM.run' do
+  | `(attr| elementwise $[nosimp%$nosimp?]? $optAttr) => MetaM.run' do
     if (kind != AttributeKind.global) then
       throwError "`elementwise` can only be used as a global attribute"
-    addRelatedDecl src "" "_apply" ref stx? fun value levels => do
+    addRelatedDecl src "" "_apply" ref optAttr fun value levels => do
       let (newValue, level?) ← elementwiseExpr src value (simpSides := nosimp?.isNone)
       let newLevels ← if let some (levelW, levelUF) := level? then do
         let w := mkUnusedName levels `w

--- a/Mathlib/Tactic/CategoryTheory/Reassoc.lean
+++ b/Mathlib/Tactic/CategoryTheory/Reassoc.lean
@@ -85,7 +85,7 @@ but not `F_assoc` (this is sometimes useful).
 This attribute also works for lemmas of shape `∀ .., f = g` where `f g : X ≅ Y` are
 isomorphisms, provided that `Tactic.CategoryTheory.IsoReassoc` has been imported.
 -/
-syntax (name := reassoc) "reassoc" (" (" &"attr" " := " Parser.Term.attrInstance,* ")")? : attr
+syntax (name := reassoc) "reassoc" optAttrArg : attr
 
 /--
 IO ref for reassociation handlers `reassoc` attribute, so that it can be extended
@@ -136,10 +136,10 @@ initialize registerBuiltinAttribute {
   descr := ""
   applicationTime := .afterCompilation
   add := fun src ref kind => match ref with
-  | `(attr| reassoc $[(attr := $stx?,*)]?) => MetaM.run' do
+  | `(attr| reassoc $optAttr) => MetaM.run' do
     if (kind != AttributeKind.global) then
       throwError "`reassoc` can only be used as a global attribute"
-    addRelatedDecl src "" "_assoc" ref stx? fun value levels => do
+    addRelatedDecl src "" "_assoc" ref optAttr fun value levels => do
       Term.TermElabM.run' <| Term.withSynthesize do
         let pf ← reassocExpr' value
         pure (pf, levels)

--- a/Mathlib/Tactic/CategoryTheory/ToApp.lean
+++ b/Mathlib/Tactic/CategoryTheory/ToApp.lean
@@ -132,17 +132,17 @@ Note that if you want both the lemma and the new lemma to be `simp` lemmas, you 
 `@[to_app (attr := simp)]`. The variant `@[simp, to_app]` on a lemma `F` will tag `F` with
 `@[simp]`, but not `F_app` (this is sometimes useful).
 -/
-syntax (name := to_app) "to_app" (" (" &"attr" " := " Parser.Term.attrInstance,* ")")? : attr
+syntax (name := to_app) "to_app" optAttrArg : attr
 
 initialize registerBuiltinAttribute {
   name := `to_app
   descr := ""
   applicationTime := .afterCompilation
   add := fun src ref kind => match ref with
-  | `(attr| to_app $[(attr := $stx?,*)]?) => MetaM.run' do
+  | `(attr| to_app $optAttr) => MetaM.run' do
     if (kind != AttributeKind.global) then
       throwError "`to_app` can only be used as a global attribute"
-    addRelatedDecl src "" "_app" ref stx? fun value levels => do
+    addRelatedDecl src "" "_app" ref optAttr fun value levels => do
       let levelMVars ← levels.mapM fun _ => mkFreshLevelMVar
       let value := value.instantiateLevelParams levels levelMVars
       let newValue ← toAppExpr (← toNatTransExpr (← toCatExpr value))

--- a/Mathlib/Tactic/Simps/Basic.lean
+++ b/Mathlib/Tactic/Simps/Basic.lean
@@ -10,6 +10,7 @@ public meta import Lean.Elab.App
 public meta import Mathlib.Tactic.Simps.NotationClass
 public meta import Mathlib.Lean.Expr.Basic
 public meta import Mathlib.Tactic.Basic
+public import Mathlib.Util.AddRelatedDecl
 
 /-!
 # Simps attribute
@@ -151,12 +152,9 @@ attribute [notation_class] Neg Dvd LE LT HasEquiv HasSubset HasSSubset Union Int
 attribute [notation_class one Simps.findOneArgs] OfNat
 attribute [notation_class zero Simps.findZeroArgs] OfNat
 
-/-- An `(attr := ...)` option for `simps`. -/
-syntax simpsOptAttrOption := atomic(" (" &"attr" " := " Parser.Term.attrInstance,* ")")?
-
 /-- Arguments to `@[simps]` attribute.
 Currently, a potential `(attr := ...)` argument has to come before other configuration options. -/
-syntax simpsArgsRest := simpsOptAttrOption Tactic.optConfig (ppSpace ident)*
+syntax simpsArgsRest := Mathlib.Tactic.optAttrArg Tactic.optConfig (ppSpace ident)*
 
 /-- The `@[simps]` attribute automatically derives lemmas specifying the projections of this
 declaration.
@@ -883,7 +881,7 @@ structure Config where
   /-- Make generated lemmas simp lemmas -/
   isSimp := true
   /-- Other attributes to apply to generated lemmas. -/
-  attrs : Array Syntax := #[]
+  attrs : Array Attribute := #[]
   /-- simplify the right-hand side of generated simp-lemmas using `dsimp, simp`. -/
   simpRhs := false
   /-- TransparencyMode used to reduce the type in order to detect whether it is a structure. -/
@@ -1009,8 +1007,7 @@ def addProjection (declName : Name) (type lhs rhs : Expr) (args : Array Expr)
   if cfg.isSimp then
     addSimpTheorem simpExtension declName true false .global <| eval_prio default
   TermElabM.run' do
-    let attrs ← elabAttrs cfg.attrs
-    Elab.Term.applyAttributes declName attrs
+    Elab.Term.applyAttributes declName cfg.attrs
 
 /--
 Perform head-structure-eta-reduction on expression `e`. That is, if `e` is of the form
@@ -1223,10 +1220,8 @@ def simpsTac (ref : Syntax) (nm : Name) (cfg : Config := {})
 /-- elaborate the syntax and run `simpsTac`. -/
 def simpsTacFromSyntax (nm : Name) (stx : Syntax) : AttrM (Array Name) :=
   match stx with
-  | `(attr| simps $[!%$bang]? $[?%$trc]? $attrs:simpsOptAttrOption $c:optConfig $[$ids]*) => do
-    let extraAttrs := match attrs with
-      | `(Attr.simpsOptAttrOption| (attr := $[$stxs],*)) => stxs
-      | _ => #[]
+  | `(attr| simps $[!%$bang]? $[?%$trc]? $optAttr $c:optConfig $[$ids]*) => do
+    let extraAttrs ← Mathlib.Tactic.elabOptAttrArg optAttr |>.run' |>.run'
     let cfg ← liftCommandElabM <| elabSimpsConfig c
     let cfg := if bang.isNone then cfg else { cfg with rhsMd := .default, simpRhs := true }
     let cfg := { cfg with attrs := cfg.attrs ++ extraAttrs }

--- a/Mathlib/Tactic/ToFun.lean
+++ b/Mathlib/Tactic/ToFun.lean
@@ -30,17 +30,17 @@ will generate a new lemma `Continuous.fun_mul` with conclusion `Continuous fun x
 
 Use the `to_fun (attr := ...)` syntax to add the same attribute to both declarations.
 -/
-syntax (name := to_fun) "to_fun" (" (" &"attr" " := " Parser.Term.attrInstance,* ")")? : attr
+syntax (name := to_fun) "to_fun" optAttrArg : attr
 
 initialize registerBuiltinAttribute {
   name := `to_fun
   descr := "generate a copy of a lemma where point-free functions are expanded to their `fun` form"
   applicationTime := .afterCompilation
   add := fun src ref kind => match ref with
-  | `(attr| to_fun $[(attr := $stx?,*)]?) => MetaM.run' do
+  | `(attr| to_fun $optAttr) => MetaM.run' do
     if (kind != AttributeKind.global) then
       throwError "`to_fun` can only be used as a global attribute"
-    addRelatedDecl src "fun_" "" ref stx? (docstringPrefix? := s!"Eta-expanded form of `{src}`")
+    addRelatedDecl src "fun_" "" ref optAttr (docstringPrefix? := s!"Eta-expanded form of `{src}`")
       fun value levels => do
       let type ← inferType value
       let r ← Push.pullCore .lambda type none

--- a/Mathlib/Tactic/Translate/Core.lean
+++ b/Mathlib/Tactic/Translate/Core.lean
@@ -253,7 +253,7 @@ structure Config : Type where
   relevantArg? : Option Nat := none
   /-- The attributes which we want to give to the original and translated declaration.
   For `simps` this will also add generated lemmas to the translation dictionary. -/
-  attrs : Array Syntax := #[]
+  attrs : Array Attribute := #[]
   /-- A list of positions of type variables that should not be translated. -/
   dontTranslate : List Nat := []
   /-- The `Syntax` element corresponding to the translation attribute,
@@ -270,10 +270,6 @@ structure Config : Type where
   `attribute [to_additive self] Unit`.
   If `self := true`, we should also have `existing := true`. -/
   self : Bool := false
-  deriving Repr
-
--- See https://github.com/leanprover/lean4/issues/10295
-attribute [nolint unusedArguments] instReprConfig.repr
 
 /-- Eta expands `e` at most `n` times. -/
 def etaExpandN (n : Nat) (e : Expr) : MetaM Expr := do
@@ -945,7 +941,7 @@ def elabArgStx (declName : Name) (argNames : Array Name) (args : Array Expr)
 TODO: Currently, we don't deduce any `dont_translate` arguments based on the type of `declName`.
 In the future we would like that the presence of `MonoidAlgebra k G` will automatically
 flag `k` as a type to not be translated. -/
-def elabTranslationAttr (declName : Name) (stx : Syntax) : CoreM Config := do
+def elabAttr (declName : Name) (stx : Syntax) : CoreM Config := do
   match stx[2] with
   | `(attrArgs| $existing? $[$opts:bracketedOption]* $[$tgt]? $[$doc]?) =>
     MetaM.run' <| forallTelescope (← getConstInfo declName).type fun xs _ => do
@@ -957,7 +953,7 @@ def elabTranslationAttr (declName : Name) (stx : Syntax) : CoreM Config := do
     for opt in opts do
       match opt with
       | `(bracketedOption| (attr := $[$stxs],*)) =>
-        attrs := attrs ++ stxs
+        attrs := attrs ++ (← (elabAttrs stxs : TermElabM _).run' |>.run')
       | `(bracketedOption| (reorder := $[$[$reorders]*],*)) =>
         if reorder?.isSome then
           throwErrorAt opt "cannot specify `reorder` multiple times"
@@ -1029,7 +1025,7 @@ def elabTranslationAttr (declName : Name) (stx : Syntax) : CoreM Config := do
 
 mutual
 /-- Apply attributes to the original and translated declarations. -/
-partial def applyAttributes (t : TranslateData) (stx : Syntax) (rawAttrs : Array Syntax)
+partial def applyAttributes (t : TranslateData) (stx : Syntax) (attrs : Array Attribute)
     (src tgt : Name) (argInfo : ArgInfo) : TermElabM (Array Name) := withoutExporting do
   -- we only copy the `instance` attribute, since it is nice to directly tag `instance` declarations
   copyInstanceAttribute src tgt
@@ -1057,13 +1053,12 @@ partial def applyAttributes (t : TranslateData) (stx : Syntax) (rawAttrs : Array
   -- add attributes
   -- the following is similar to `Term.ApplyAttributesCore`, but we hijack the implementation of
   -- `simps` and `to_additive`.
-  let attrs ← elabAttrs rawAttrs
   let (additiveAttrs, attrs) := attrs.partition (·.name == t.attrName)
   let nestedDecls ←
     match h : additiveAttrs.size with
     | 0 => pure #[]
     | 1 =>
-      let cfg ← elabTranslationAttr src additiveAttrs[0].stx
+      let cfg ← elabAttr src additiveAttrs[0].stx
       addTranslationAttr t tgt cfg additiveAttrs[0].kind
     | _ => throwError "cannot apply {t.attrName} multiple times."
   let allDecls := #[src, tgt] ++ nestedDecls

--- a/Mathlib/Util/AddRelatedDecl.lean
+++ b/Mathlib/Util/AddRelatedDecl.lean
@@ -19,9 +19,10 @@ open Lean Meta Elab
 
 namespace Mathlib.Tactic
 
+/-- An `(attr := ...)` argument for applying the same attributes to multiple declarations. -/
 syntax optAttrArg := atomic(" (" &"attr" " := " Parser.Term.attrInstance,* ")")?
 
-/-- An `(attr := ...)` otion for apply the same attributes to multiple declarations. -/
+/-- Elaborate an `(attr := ...)` argument. -/
 def elabOptAttrArg : TSyntax ``optAttrArg → TermElabM (Array Attribute)
   | `(optAttrArg| (attr := $[$attrs],*)) => elabAttrs attrs
   | _ => pure #[]
@@ -55,7 +56,7 @@ Arguments:
   If it is `none`, only the doc-string of `src` is used.
 -/
 def addRelatedDecl (src : Name) (prefix_ suffix : String) (ref : Syntax)
-    (attrs : (TSyntax ``optAttrArg))
+    (attrs : TSyntax ``optAttrArg)
     (construct : Expr → List Name → MetaM (Expr × List Name))
     (docstringPrefix? : Option String := none) :
     MetaM Unit := do


### PR DESCRIPTION
This PR gives a name to the often used `(attr := ...)` syntax, cleaning up the code

---
<!-- Your PR title will become the first line of the commit message.

In this box, the text above the `---` (if not empty) will be appended
to the commit message, and can be used to give additional context or
details. Please leave a blank newline before the `---`, otherwise GitHub
will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

When merging, all the commits will be squashed into a single commit
listing all co-authors.

Co-authors in the squash commit are gathered from two sources:

First, all authors of commits to this PR branch are included. Thus,
one way to add co-authors is to include at least one commit authored by
each co-author among the commits in the pull request. If necessary, you
may create empty commits to indicate co-authorship, using commands like so:

git commit --author="Author Name <author@email.com>" --allow-empty -m "add Author Name as coauthor"

Second, co-authors can also be listed in lines at the very bottom of
the commit message (that is, directly before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines
at the bottom of the commit message (before the `---`, and also before
any "Co-authored-by" lines) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
