### PR TITLE
[Merged by Bors] - fix(WithLp): use correct namespace for `withLpProdCongr`

### DIFF
--- a/Mathlib/Analysis/Normed/Lp/ProdLp.lean
+++ b/Mathlib/Analysis/Normed/Lp/ProdLp.lean
@@ -1180,28 +1180,24 @@ variable [hp : Fact (1 ≤ p)] [Semiring 𝕜]
   [SeminormedAddCommGroup α'] [Module 𝕜 α']
   [SeminormedAddCommGroup β'] [Module 𝕜 β']
 
-namespace LinearIsometry
-
-variable {𝕜 α β}
-
+variable {𝕜 α β} in
 /-- The `L^p` product of two linear isometries. -/
 @[simps! apply]
-def withLpProdMap (f : α →ₗᵢ[𝕜] α') (g : β →ₗᵢ[𝕜] β') :
+def LinearIsometry.withLpProdMap (f : α →ₗᵢ[𝕜] α') (g : β →ₗᵢ[𝕜] β') :
     WithLp p (α × β) →ₗᵢ[𝕜] WithLp p (α' × β') where
   __ := (f.toLinearMap.prodMap g.toLinearMap).withLpMap p
   norm_map' := (f.isometry.withLpProdMap p g.isometry).norm_map_of_map_zero
     ((f.toLinearMap.prodMap g.toLinearMap).withLpMap p).map_zero
 
+namespace LinearIsometryEquiv
+
+variable {𝕜 α β} in
 /-- The `L^p` product of two linear isometric equivalences. -/
 @[simps! apply symm_apply]
 def withLpProdCongr (f : α ≃ₗᵢ[𝕜] α') (g : β ≃ₗᵢ[𝕜] β') :
     WithLp p (α × β) ≃ₗᵢ[𝕜] WithLp p (α' × β') where
   __ := (f.toLinearEquiv.prodCongr g.toLinearEquiv).withLpCongr p
   norm_map' := (f.toLinearIsometry.withLpProdMap p g.toLinearIsometry).norm_map
-
-end LinearIsometry
-
-namespace LinearIsometryEquiv
 
 /-- Commutativity of the `L^p` product as a linear isometric equivalence. -/
 def withLpProdComm : WithLp p (α × β) ≃ₗᵢ[𝕜] WithLp p (β × α) where


### PR DESCRIPTION
This definition involving `LinearIsometryEquiv`s was in the `LinearIsometry` namespace by mistake.

I did not add deprecations because it was added recently.


---
<!-- Your PR title will become the first line of the commit message.

In this box, the text above the `---` (if not empty) will be appended
to the commit message, and can be used to give additional context or
details. Please leave a blank newline before the `---`, otherwise GitHub
will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

When merging, all the commits will be squashed into a single commit
listing all co-authors.

Co-authors in the squash commit are gathered from two sources:

First, all authors of commits to this PR branch are included. Thus,
one way to add co-authors is to include at least one commit authored by
each co-author among the commits in the pull request. If necessary, you
may create empty commits to indicate co-authorship, using commands like so:

git commit --author="Author Name <author@email.com>" --allow-empty -m "add Author Name as coauthor"

Second, co-authors can also be listed in lines at the very bottom of
the commit message (that is, directly before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines
at the bottom of the commit message (before the `---`, and also before
any "Co-authored-by" lines) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
