### PR TITLE
[Merged by Bors] - feat(CategoryTheory): adjunctions in Cat

### DIFF
--- a/Mathlib.lean
+++ b/Mathlib.lean
@@ -2257,6 +2257,7 @@ public import Mathlib.CategoryTheory.Adjunction.Whiskering
 public import Mathlib.CategoryTheory.Balanced
 public import Mathlib.CategoryTheory.Bicategory.Adjunction.Adj
 public import Mathlib.CategoryTheory.Bicategory.Adjunction.Basic
+public import Mathlib.CategoryTheory.Bicategory.Adjunction.Cat
 public import Mathlib.CategoryTheory.Bicategory.Adjunction.Mate
 public import Mathlib.CategoryTheory.Bicategory.Basic
 public import Mathlib.CategoryTheory.Bicategory.CatEnriched

--- a/Mathlib/CategoryTheory/Bicategory/Adjunction/Basic.lean
+++ b/Mathlib/CategoryTheory/Bicategory/Adjunction/Basic.lean
@@ -81,6 +81,7 @@ theorem rightZigzag_idempotent_of_left_triangle
       rw [h]; bicategory
 
 /-- Adjunction between two 1-morphisms. -/
+@[ext]
 structure Adjunction (f : a ⟶ b) (g : b ⟶ a) where
   /-- The unit of an adjunction. -/
   unit : 𝟙 a ⟶ f ≫ g

--- a/Mathlib/CategoryTheory/Bicategory/Adjunction/Cat.lean
+++ b/Mathlib/CategoryTheory/Bicategory/Adjunction/Cat.lean
@@ -1,0 +1,108 @@
+/-
+Copyright (c) 2025 Joël Riou. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Joël Riou
+-/
+module
+
+public import Mathlib.CategoryTheory.Adjunction.Mates
+public import Mathlib.CategoryTheory.Bicategory.Adjunction.Mate
+public import Mathlib.CategoryTheory.Category.Cat
+
+/-!
+# Adjunctions in `Cat`
+
+We show that adjunctions in the bicategory `Cat` correspond to
+adjunctions between functors in the usual categorical sense.
+
+-/
+
+@[expose] public section
+
+universe v u
+
+namespace CategoryTheory
+
+open Bicategory
+
+section
+
+variable {C D E : Type u} [Category.{v} C] [Category.{v} D] [Category.{v} E]
+  {F : C ⥤ D} {G : D ⥤ C} (adj : F ⊣ G)
+  {F' : D ⥤ E} {G' : E ⥤ D} (adj' : F' ⊣ G')
+
+namespace Adjunction
+
+attribute [local simp] bicategoricalComp
+
+/-- The adjunction in the bicategorical sense attached to an adjunction between functors. -/
+@[simps]
+def toCat : Bicategory.Adjunction F.toCatHom G.toCatHom where
+  unit := .ofNatTrans adj.unit
+  counit := .ofNatTrans adj.counit
+
+/-- The adjunction of functors corresponding to an adjunction in the bicategory `Cat`. -/
+@[simps]
+def ofCat {C D : Cat} {F : C ⟶ D} {G : D ⟶ C}
+    (adj : Bicategory.Adjunction F G) :
+    F.toFunctor ⊣ G.toFunctor where
+  unit := adj.unit.toNatTrans
+  counit := adj.counit.toNatTrans
+  left_triangle_components X := by
+    simpa using congr($(adj.left_triangle).toNatTrans.app X)
+  right_triangle_components X := by
+    simpa using congr($(adj.right_triangle).toNatTrans.app X)
+
+@[simp]
+lemma toCat_ofCat
+    {C D : Cat} {F : C ⟶ D} {G : D ⟶ C} (adj : Bicategory.Adjunction F G) :
+    (Adjunction.ofCat adj).toCat = adj := rfl
+
+@[simp]
+lemma ofCat_toCat :
+    Adjunction.ofCat adj.toCat = adj := rfl
+
+lemma toCat_comp_toCat : adj.toCat.comp adj'.toCat = (adj.comp adj').toCat := by
+  cat_disch
+
+end Adjunction
+
+end
+
+namespace Bicategory
+
+@[simp]
+lemma Adjunction.ofCat_id (C : Cat.{v, u}) :
+    Adjunction.ofCat (Adjunction.id C) = CategoryTheory.Adjunction.id :=
+  rfl
+
+lemma Adjunction.ofCat_comp {C D E : Cat.{v, u}}
+    {F : C ⟶ D} {G : D ⟶ C} (adj : F ⊣ G)
+    {F' : D ⟶ E} {G' : E ⟶ D} (adj' : F' ⊣ G') :
+    Adjunction.ofCat (adj.comp adj') = (Adjunction.ofCat adj).comp (Adjunction.ofCat adj') := by
+  ext
+  simp [bicategoricalComp]
+
+lemma toNatTrans_mateEquiv {C D E F : Cat}
+    {G : C ⟶ E} {H : D ⟶ F} {L₁ : C ⟶ D} {R₁ : D ⟶ C} {L₂ : E ⟶ F} {R₂ : F ⟶ E}
+    (adj₁ : Bicategory.Adjunction L₁ R₁) (adj₂ : Bicategory.Adjunction L₂ R₂)
+    (f : G ≫ L₂ ⟶ L₁ ≫ H) :
+    (Bicategory.mateEquiv adj₁ adj₂ f).toNatTrans =
+      CategoryTheory.mateEquiv (Adjunction.ofCat adj₁) (Adjunction.ofCat adj₂) f.toNatTrans := by
+  ext X
+  simp [mateEquiv, Adjunction.homEquiv₁, Adjunction.homEquiv₂]
+
+lemma toNatTrans_conjugateEquiv {C D : Cat}
+    {L₁ L₂ : C ⟶ D} {R₁ R₂ : D ⟶ C}
+    (adj₁ : Bicategory.Adjunction L₁ R₁) (adj₂ : Bicategory.Adjunction L₂ R₂) (f : L₂ ⟶ L₁) :
+    (Bicategory.conjugateEquiv adj₁ adj₂ f).toNatTrans =
+      CategoryTheory.conjugateEquiv
+        (Adjunction.ofCat adj₁) (Adjunction.ofCat adj₂) f.toNatTrans := by
+  dsimp [Bicategory.conjugateEquiv]
+  rw [toNatTrans_mateEquiv]
+  ext X
+  simp [CategoryTheory.conjugateEquiv]
+
+end Bicategory
+
+end CategoryTheory


### PR DESCRIPTION
We show that adjunctions in the bicategory `Cat` correspond to adjunctions between functors in the usual categorical sense.

---

<!-- Your PR title will become the first line of the commit message.

In this box, the text above the `---` (if not empty) will be appended
to the commit message, and can be used to give additional context or
details. Please leave a blank newline before the `---`, otherwise GitHub
will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

When merging, all the commits will be squashed into a single commit
listing all co-authors.

Co-authors in the squash commit are gathered from two sources:

First, all authors of commits to this PR branch are included. Thus,
one way to add co-authors is to include at least one commit authored by
each co-author among the commits in the pull request. If necessary, you
may create empty commits to indicate co-authorship, using commands like so:

git commit --author="Author Name <author@email.com>" --allow-empty -m "add Author Name as coauthor"

Second, co-authors can also be listed in lines at the very bottom of
the commit message (that is, directly before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines
at the bottom of the commit message (before the `---`, and also before
any "Co-authored-by" lines) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
