### PR TITLE
[Merged by Bors] - chore(Geometry): fix whitespace

### DIFF
--- a/Mathlib/Geometry/RingedSpace/Basic.lean
+++ b/Mathlib/Geometry/RingedSpace/Basic.lean
@@ -40,8 +40,8 @@ namespace AlgebraicGeometry
 
 /-- The type of Ringed spaces, as an abbreviation for `SheafedSpace CommRingCat`. -/
 @[nolint checkUnivs] -- The universes appear together in the type, but separately in the value.
-abbrev RingedSpace : Type max (u+1) (v+1) :=
-  SheafedSpace.{v+1, v, u} CommRingCat.{v}
+abbrev RingedSpace : Type max (u + 1) (v + 1) :=
+  SheafedSpace.{v + 1, v, u} CommRingCat.{v}
 
 namespace RingedSpace
 

--- a/Mathlib/Geometry/RingedSpace/LocallyRingedSpace/HasColimits.lean
+++ b/Mathlib/Geometry/RingedSpace/LocallyRingedSpace/HasColimits.lean
@@ -257,7 +257,7 @@ noncomputable def coequalizerCofork : Cofork f g :=
   Cofork.ofπ (P := coequalizer f g)
     (homMk (coequalizer.π f.toShHom g.toShHom)
       -- Porting note: this used to be automatic
-      (HasCoequalizer.coequalizer_π_stalk_isLocalHom  _ _))
+      (HasCoequalizer.coequalizer_π_stalk_isLocalHom _ _))
     (forgetToSheafedSpace.map_injective (coequalizer.condition f.toShHom g.toShHom))
 
 theorem isLocalHom_stalkMap_congr {X Y : RingedSpace} (f g : X ⟶ Y) (H : f = g) (x)


### PR DESCRIPTION
Found by extending the commandStart linter to proof bodies.

---
<!-- Your PR title will become the first line of the commit message.

In this box, the text above the `---` (if not empty) will be appended
to the commit message, and can be used to give additional context or
details. Please leave a blank newline before the `---`, otherwise GitHub
will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

When merging, all the commits will be squashed into a single commit
listing all co-authors.

Co-authors in the squash commit are gathered from two sources:

First, all authors of commits to this PR branch are included. Thus,
one way to add co-authors is to include at least one commit authored by
each co-author among the commits in the pull request. If necessary, you
may create empty commits to indicate co-authorship, using commands like so:

git commit --author="Author Name <author@email.com>" --allow-empty -m "add Author Name as coauthor"

Second, co-authors can also be listed in lines at the very bottom of
the commit message (that is, directly before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines
at the bottom of the commit message (before the `---`, and also before
any "Co-authored-by" lines) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
