### PR TITLE
[Merged by Bors] - chore(Data): fix whitespace

### DIFF
--- a/Mathlib/Data/List/Sort.lean
+++ b/Mathlib/Data/List/Sort.lean
@@ -330,7 +330,7 @@ variable {r : α → α → Prop} [IsAntisymm α r]
 
 /-- Variant of `Perm.eq_of_pairwise` using relation typeclasses. -/
 theorem Perm.eq_of_pairwise' {l₁ l₂ : List α} :
-    Pairwise r l₁ →  Pairwise r l₂ → (hl : l₁ ~ l₂) → l₁ = l₂ :=
+    Pairwise r l₁ → Pairwise r l₂ → (hl : l₁ ~ l₂) → l₁ = l₂ :=
   eq_of_pairwise (fun _ _ _ _ => antisymm)
 
 @[deprecated (since := "2025-10-11")]

--- a/Mathlib/Data/Nat/BitIndices.lean
+++ b/Mathlib/Data/Nat/BitIndices.lean
@@ -84,7 +84,7 @@ theorem bitIndices_bit_false (n : ℕ) :
   induction n using binaryRec with
   | zero => simp
   | bit b n hs =>
-    have hrw : (fun i ↦ 2^i) ∘ (fun x ↦ x+1) = fun i ↦ 2 * 2 ^ i := by
+    have hrw : (fun i ↦ 2^i) ∘ (fun x ↦ x + 1) = fun i ↦ 2 * 2 ^ i := by
       ext i; simp [pow_add, mul_comm]
     cases b
     · simpa [hrw, List.sum_map_mul_left]

--- a/Mathlib/Data/Nat/Choose/Central.lean
+++ b/Mathlib/Data/Nat/Choose/Central.lean
@@ -104,8 +104,9 @@ theorem four_pow_le_two_mul_self_mul_centralBinom :
   | 3, _ => by simp [centralBinom, choose]
   | n + 4, _ =>
     calc
-      4 ^ (n+4) ≤ (n+4) * centralBinom (n+4) := (four_pow_lt_mul_centralBinom _ le_add_self).le
-      _ ≤ 2 * (n+4) * centralBinom (n+4) := by
+      4 ^ (n + 4) ≤ (n + 4) * centralBinom (n + 4) :=
+        (four_pow_lt_mul_centralBinom _ le_add_self).le
+      _ ≤ 2 * (n + 4) * centralBinom (n + 4) := by
         rw [mul_assoc]; refine Nat.le_mul_of_pos_left _ zero_lt_two
 
 theorem two_dvd_centralBinom_succ (n : ℕ) : 2 ∣ centralBinom (n + 1) := by

--- a/Mathlib/Data/Nat/Choose/Factorization.lean
+++ b/Mathlib/Data/Nat/Choose/Factorization.lean
@@ -166,7 +166,7 @@ theorem factorization_choose_prime_pow_add_factorization (hp : p.Prime) (hkn : k
     have filter_le_Ico := (Ico 1 n.succ).card_filter_le
       fun x => p ^ x ≤ k % p ^ x + (p ^ n - k) % p ^ x ∨ p ^ x ∣ k
     rwa [card_Ico 1 n.succ] at filter_le_Ico
-  · nth_rewrite 1 [← factorization_pow_self (n:=n) hp]
+  · nth_rewrite 1 [← factorization_pow_self (n := n) hp]
     exact factorization_le_factorization_choose_add hkn hk0
 
 theorem factorization_choose_prime_pow {p n k : ℕ} (hp : p.Prime) (hkn : k ≤ p ^ n) (hk0 : k ≠ 0) :

--- a/Mathlib/Data/Nat/Digits/Lemmas.lean
+++ b/Mathlib/Data/Nat/Digits/Lemmas.lean
@@ -143,7 +143,7 @@ theorem pow_length_le_mul_ofDigits {b : ℕ} {l : List ℕ} (hl : l ≠ []) (hl2
 theorem base_pow_length_digits_le' (b m : ℕ) (hm : m ≠ 0) :
     (b + 2) ^ (digits (b + 2) m).length ≤ (b + 2) * m := by
   have : digits (b + 2) m ≠ [] := digits_ne_nil_iff_ne_zero.mpr hm
-  convert @pow_length_le_mul_ofDigits b (digits (b+2) m)
+  convert @pow_length_le_mul_ofDigits b (digits (b + 2) m)
     this (getLast_digit_ne_zero _ hm)
   rw [ofDigits_digits]
 

--- a/Mathlib/Data/Nat/MaxPowDiv.lean
+++ b/Mathlib/Data/Nat/MaxPowDiv.lean
@@ -33,7 +33,7 @@ def maxPowDiv (p n : ℕ) : ℕ :=
   go 0 p n
 where go (k p n : ℕ) : ℕ :=
   if 1 < p ∧ 0 < n ∧ n % p = 0 then
-    go (k+1) p (n / p)
+    go (k + 1) p (n / p)
   else
     k
   termination_by n
@@ -45,7 +45,7 @@ end Nat
 
 namespace Nat.maxPowDiv
 
-theorem go_succ {k p n : ℕ} : go (k+1) p n = go k p n + 1 := by
+theorem go_succ {k p n : ℕ} : go (k + 1) p n = go k p n + 1 := by
   fun_induction go
   case case1 h ih =>
     conv_lhs => unfold go
@@ -67,7 +67,7 @@ theorem zero {p : ℕ} : maxPowDiv p 0 = 0 := by
   simp
 
 theorem base_mul_eq_succ {p n : ℕ} (hp : 1 < p) (hn : 0 < n) :
-    p.maxPowDiv (p*n) = p.maxPowDiv n + 1 := by
+    p.maxPowDiv (p * n) = p.maxPowDiv n + 1 := by
   have : 0 < p := lt_trans (b := 1) (by simp) hp
   dsimp [maxPowDiv]
   rw [maxPowDiv.go, if_pos, mul_div_right _ this]

--- a/Mathlib/Data/Nat/ModEq.lean
+++ b/Mathlib/Data/Nat/ModEq.lean
@@ -453,7 +453,7 @@ theorem mod_lcm (hn : a ≡ b [MOD n]) (hm : a ≡ b [MOD m]) : a ≡ b [MOD lcm
   Nat.modEq_iff_dvd.mpr <| Int.coe_lcm_dvd (Nat.modEq_iff_dvd.mp hn) (Nat.modEq_iff_dvd.mp hm)
 
 theorem chineseRemainder_modEq_unique (co : n.Coprime m) {a b z}
-    (hzan : z ≡ a [MOD n]) (hzbm : z ≡ b [MOD m]) : z ≡ chineseRemainder co a b [MOD n*m] := by
+    (hzan : z ≡ a [MOD n]) (hzbm : z ≡ b [MOD m]) : z ≡ chineseRemainder co a b [MOD n * m] := by
   simpa [Nat.Coprime.lcm_eq_mul co] using
     mod_lcm (hzan.trans ((chineseRemainder co a b).prop.1).symm)
       (hzbm.trans ((chineseRemainder co a b).prop.2).symm)

--- a/Mathlib/Data/PFunctor/Multivariate/Basic.lean
+++ b/Mathlib/Data/PFunctor/Multivariate/Basic.lean
@@ -158,7 +158,7 @@ theorem liftP_iff' {α : TypeVec n} (p : ∀ ⦃i⦄, α i → Prop) (a : P.A) (
   · rintro ⟨_, _, ⟨⟩, _⟩
     assumption
   · intro
-    repeat' first |constructor|assumption
+    repeat' first | constructor | assumption
 
 theorem liftR_iff {α : TypeVec n} (r : ∀ ⦃i⦄, α i → α i → Prop) (x y : P α) :
     LiftR @r x y ↔ ∃ a f₀ f₁, x = ⟨a, f₀⟩ ∧ y = ⟨a, f₁⟩ ∧ ∀ i j, r (f₀ i j) (f₁ i j) := by

--- a/Mathlib/Data/PFunctor/Univariate/Basic.lean
+++ b/Mathlib/Data/PFunctor/Univariate/Basic.lean
@@ -188,7 +188,7 @@ theorem liftp_iff' {α : Type u} (p : α → Prop) (a : P.A) (f : P.B a → α) 
   · rcases h with ⟨a', f', heq, h'⟩
     cases heq
     assumption
-  repeat' first |constructor|assumption
+  repeat' first | constructor | assumption
 
 theorem liftr_iff {α : Type u} (r : α → α → Prop) (x y : P α) :
     Liftr r x y ↔ ∃ a f₀ f₁, x = ⟨a, f₀⟩ ∧ y = ⟨a, f₁⟩ ∧ ∀ i, r (f₀ i) (f₁ i) := by

--- a/Mathlib/Data/PFunctor/Univariate/M.lean
+++ b/Mathlib/Data/PFunctor/Univariate/M.lean
@@ -546,7 +546,7 @@ theorem nth_of_bisim [Inhabited (M F)] [DecidableEq F.A]
     apply bisim.tail h₀
   | cons i ps ps_ih => ?_
   obtain ⟨a', i⟩ := i
-  obtain rfl : a = a' := by rcases hh with hh|hh <;> cases isPath_cons hh <;> rfl
+  obtain rfl : a = a' := by rcases hh with hh | hh <;> cases isPath_cons hh <;> rfl
   dsimp only [iselect] at ps_ih ⊢
   have h₁ := bisim.tail h₀ i
   induction h : f i using PFunctor.M.casesOn' with | _ a₀ f₀

--- a/Mathlib/Data/Seq/Basic.lean
+++ b/Mathlib/Data/Seq/Basic.lean
@@ -161,7 +161,7 @@ theorem take_succ_cons {n : ℕ} {x : α} {s : Seq α} :
 theorem getElem?_take : ∀ (n k : ℕ) (s : Seq α),
     (s.take k)[n]? = if n < k then s.get? n else none
   | n, 0, s => by simp [take]
-  | n, k+1, s => by
+  | n, k + 1, s => by
     rw [take]
     cases h : destruct s with
     | none =>
@@ -172,7 +172,7 @@ theorem getElem?_take : ∀ (n k : ℕ) (s : Seq α),
         rw [destruct_eq_cons h]
         match n with
         | 0 => simp
-        | n+1 => simp [List.getElem?_cons_succ, getElem?_take]
+        | n + 1 => simp [List.getElem?_cons_succ, getElem?_take]
 
 theorem get?_mem_take {s : Seq α} {m n : ℕ} (h_mn : m < n) {x : α}
     (h_get : s.get? m = some x) : x ∈ s.take n := by

--- a/Mathlib/Data/Set/Prod.lean
+++ b/Mathlib/Data/Set/Prod.lean
@@ -460,7 +460,7 @@ end Diagonal
 theorem range_const_eq_diagonal {α β : Type*} [hβ : Nonempty β] :
     range (const α) = {f : α → β | ∀ x y, f x = f y} := by
   refine (range_eq_iff _ _).mpr ⟨fun _ _ _ ↦ rfl, fun f hf ↦ ?_⟩
-  rcases isEmpty_or_nonempty α with h|⟨⟨a⟩⟩
+  rcases isEmpty_or_nonempty α with h | ⟨⟨a⟩⟩
   · exact hβ.elim fun b ↦ ⟨b, Subsingleton.elim _ _⟩
   · exact ⟨f a, funext fun x ↦ hf _ _⟩
 

--- a/Mathlib/Data/ZMod/Basic.lean
+++ b/Mathlib/Data/ZMod/Basic.lean
@@ -998,9 +998,9 @@ theorem val_cast_of_lt {n : ℕ} {a : ℕ} (h : a < n) : (a : ZMod n).val = a :=
 
 theorem val_cast_zmod_lt {m : ℕ} [NeZero m] (n : ℕ) [NeZero n] (a : ZMod m) :
     (a.cast : ZMod n).val < m := by
-  rcases m with (⟨⟩|⟨m⟩); · cases NeZero.ne 0 rfl
+  rcases m with (⟨⟩ | ⟨m⟩); · cases NeZero.ne 0 rfl
   by_cases! h : m < n
-  · rcases n with (⟨⟩|⟨n⟩); · simp at h
+  · rcases n with (⟨⟩ | ⟨n⟩); · simp at h
     rw [← natCast_val, val_cast_of_lt]
     · apply a.val_lt
     apply lt_of_le_of_lt (Nat.le_of_lt_succ (ZMod.val_lt a)) h


### PR DESCRIPTION
Found by extending the commandStart linter to proof bodies.

---
<!-- Your PR title will become the first line of the commit message.

In this box, the text above the `---` (if not empty) will be appended
to the commit message, and can be used to give additional context or
details. Please leave a blank newline before the `---`, otherwise GitHub
will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

When merging, all the commits will be squashed into a single commit
listing all co-authors.

Co-authors in the squash commit are gathered from two sources:

First, all authors of commits to this PR branch are included. Thus,
one way to add co-authors is to include at least one commit authored by
each co-author among the commits in the pull request. If necessary, you
may create empty commits to indicate co-authorship, using commands like so:

git commit --author="Author Name <author@email.com>" --allow-empty -m "add Author Name as coauthor"

Second, co-authors can also be listed in lines at the very bottom of
the commit message (that is, directly before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines
at the bottom of the commit message (before the `---`, and also before
any "Co-authored-by" lines) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
