### PR TITLE
[Merged by Bors] - chore(LinearAlgebra/Matrix/Kronecker): make notation more consistent

### DIFF
--- a/Mathlib/LinearAlgebra/Matrix/Kronecker.lean
+++ b/Mathlib/LinearAlgebra/Matrix/Kronecker.lean
@@ -434,7 +434,7 @@ def kroneckerTMul : Matrix l m α → Matrix n p β → Matrix (l × n) (m × p)
   kroneckerMap (· ⊗ₜ ·)
 
 @[inherit_doc kroneckerTMul]
-scoped[Kronecker] infixl:100 " ⊗ₖₜ " => Matrix.kroneckerMap (· ⊗ₜ ·)
+scoped[Kronecker] infixl:100 " ⊗ₖₜ " => Matrix.kroneckerMap (TensorProduct.tmul _)
 
 @[inherit_doc kroneckerTMul] scoped[Kronecker] notation:100 x " ⊗ₖₜ[" R "] " y:100 =>
   Matrix.kroneckerMap (TensorProduct.tmul R) x y


### PR DESCRIPTION
Currently, if you look at [Matrix.add_kroneckerTMul](https://leanprover-community.github.io/mathlib4_docs/Mathlib/LinearAlgebra/Matrix/Kronecker.html#Matrix.add_kroneckerTMul) and the like, you'll notice that on the left-hand side `TensorProduct.tmul R` is being used, whereas the right-hand side uses `fun (x1 x2 : α) => x1 ⊗ₜ[R] x2`. And while they are defeq, it just looks strange that they don't print the same thing. This fixes that to make it both print out `TensorProduct.tmul R`.

---
<!-- Your PR title will become the first line of the commit message.

In this box, the text above the `---` (if not empty) will be appended
to the commit message, and can be used to give additional context or
details. Please leave a blank newline before the `---`, otherwise GitHub
will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

When merging, all the commits will be squashed into a single commit
listing all co-authors.

Co-authors in the squash commit are gathered from two sources:

First, all authors of commits to this PR branch are included. Thus,
one way to add co-authors is to include at least one commit authored by
each co-author among the commits in the pull request. If necessary, you
may create empty commits to indicate co-authorship, using commands like so:

git commit --author="Author Name <author@email.com>" --allow-empty -m "add Author Name as coauthor"

Second, co-authors can also be listed in lines at the very bottom of
the commit message (that is, directly before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines
at the bottom of the commit message (before the `---`, and also before
any "Co-authored-by" lines) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
