### PR TITLE
[Merged by Bors] - chore(Algebra): fix whitespace

### DIFF
--- a/Mathlib/Algebra/Category/ModuleCat/Semi.lean
+++ b/Mathlib/Algebra/Category/ModuleCat/Semi.lean
@@ -90,7 +90,7 @@ structure Hom (M N : SemimoduleCat.{v} R) where
   /-- The underlying linear map. -/
   hom' : M →ₗ[R] N
 
-instance moduleCategory : Category.{v, max (v+1) u} (SemimoduleCat.{v} R) where
+instance moduleCategory : Category.{v, max (v + 1) u} (SemimoduleCat.{v} R) where
   Hom M N := Hom M N
   id _ := ⟨LinearMap.id⟩
   comp f g := ⟨g.hom'.comp f.hom'⟩

--- a/Mathlib/Algebra/Category/ModuleCat/Sheaf/Free.lean
+++ b/Mathlib/Algebra/Category/ModuleCat/Sheaf/Free.lean
@@ -148,7 +148,7 @@ lemma map_ιFree_mapFree_hom :
     F.map (ιFree i) ≫ (mapFree F η I).hom = η.hom ≫ ιFree i := by
   have : η.inv ≫ η.hom ≫ ιFree i = (η.inv ≫ F.map (ιFree i)) ≫ (mapFree F η I).hom := by
     simp [← ιFree_mapFree_inv]
-  rw [←Iso.hom_inv_id_assoc η (η.hom ≫ ιFree i)]
+  rw [← Iso.hom_inv_id_assoc η (η.hom ≫ ιFree i)]
   simp [this]
 
 end

--- a/Mathlib/Algebra/Category/MonCat/Colimits.lean
+++ b/Mathlib/Algebra/Category/MonCat/Colimits.lean
@@ -89,18 +89,18 @@ open Prequotient
 because of the monoid laws, or
 because one element is mapped to another by a morphism in the diagram.
 -/
-inductive Relation : Prequotient F → Prequotient F → Prop-- Make it an equivalence relation:
+inductive Relation : Prequotient F → Prequotient F → Prop -- Make it an equivalence relation:
   | refl : ∀ x, Relation x x
   | symm : ∀ (x y) (_ : Relation x y), Relation y x
   | trans : ∀ (x y z) (_ : Relation x y) (_ : Relation y z),
-      Relation x z-- There's always a `map` relation
+      Relation x z -- There's always a `map` relation
   | map :
     ∀ (j j' : J) (f : j ⟶ j') (x : F.obj j),
       Relation (Prequotient.of j' ((F.map f) x))
-        (Prequotient.of j x)-- Then one relation per operation, describing the interaction with `of`
+        (Prequotient.of j x) -- Then one relation per operation, describing the interaction with `of`
   | mul : ∀ (j) (x y : F.obj j), Relation (Prequotient.of j (x * y))
       (mul (Prequotient.of j x) (Prequotient.of j y))
-  | one : ∀ j, Relation (Prequotient.of j 1) one-- Then one relation per argument of each operation
+  | one : ∀ j, Relation (Prequotient.of j 1) one -- Then one relation per argument of each operation
   | mul_1 : ∀ (x x' y) (_ : Relation x x'), Relation (mul x y) (mul x' y)
   | mul_2 : ∀ (x y y') (_ : Relation y y'), Relation (mul x y) (mul x y')
     -- And one relation per axiom

--- a/Mathlib/Algebra/Category/MonCat/Colimits.lean
+++ b/Mathlib/Algebra/Category/MonCat/Colimits.lean
@@ -97,7 +97,7 @@ inductive Relation : Prequotient F → Prequotient F → Prop -- Make it an equi
   | map :
     ∀ (j j' : J) (f : j ⟶ j') (x : F.obj j),
       Relation (Prequotient.of j' ((F.map f) x))
-        (Prequotient.of j x) -- Then one relation per operation, describing the interaction with `of`
+        (Prequotient.of j x)-- Then one relation per operation, describing the interaction with `of`
   | mul : ∀ (j) (x y : F.obj j), Relation (Prequotient.of j (x * y))
       (mul (Prequotient.of j x) (Prequotient.of j y))
   | one : ∀ j, Relation (Prequotient.of j 1) one -- Then one relation per argument of each operation

--- a/Mathlib/Algebra/GradedMonoid.lean
+++ b/Mathlib/Algebra/GradedMonoid.lean
@@ -602,7 +602,7 @@ instance SetLike.gMonoid {S : Type*} [SetLike S R] [Monoid R] [AddMonoid ι] (A 
 @[simp]
 theorem SetLike.coe_gnpow {S : Type*} [SetLike S R] [Monoid R] [AddMonoid ι] (A : ι → S)
     [SetLike.GradedMonoid A] {i : ι} (x : A i) (n : ℕ) :
-    ↑(@GradedMonoid.GMonoid.gnpow _ (fun i => A i) _ _ n _ x) = (x:R)^n :=
+    ↑(@GradedMonoid.GMonoid.gnpow _ (fun i => A i) _ _ n _ x) = (x : R)^n :=
   rfl
 
 /-- Build a `GCommMonoid` instance for a collection of subobjects. -/

--- a/Mathlib/Algebra/Homology/Embedding/Extend.lean
+++ b/Mathlib/Algebra/Homology/Embedding/Extend.lean
@@ -156,7 +156,7 @@ lemma extend_d_eq {i' j' : ι'} {i j : ι} (hi : e.f i = i') (hj : e.f j = j') :
 
 lemma extend_d_from_eq_zero (i' j' : ι') (i : ι) (hi : e.f i = i') (hi' : ¬ c.Rel i (c.next i)) :
     (K.extend e).d i' j' = 0 := by
-  obtain hj'|⟨j, hj⟩ := (e.r j').eq_none_or_eq_some
+  obtain hj' | ⟨j, hj⟩ := (e.r j').eq_none_or_eq_some
   · exact extend.d_none_eq_zero' _ _ _ hj'
   · rw [extend_d_eq K e hi (e.f_eq_of_r_eq_some hj), K.shape, zero_comp, comp_zero]
     intro hij
@@ -165,7 +165,7 @@ lemma extend_d_from_eq_zero (i' j' : ι') (i : ι) (hi : e.f i = i') (hi' : ¬ c
 
 lemma extend_d_to_eq_zero (i' j' : ι') (j : ι) (hj : e.f j = j') (hj' : ¬ c.Rel (c.prev j) j) :
     (K.extend e).d i' j' = 0 := by
-  obtain hi'|⟨i, hi⟩ := (e.r i').eq_none_or_eq_some
+  obtain hi' | ⟨i, hi⟩ := (e.r i').eq_none_or_eq_some
   · exact extend.d_none_eq_zero _ _ _ hi'
   · rw [extend_d_eq K e (e.f_eq_of_r_eq_some hi) hj, K.shape, zero_comp, comp_zero]
     intro hij

--- a/Mathlib/Algebra/Homology/HomologicalComplex.lean
+++ b/Mathlib/Algebra/Homology/HomologicalComplex.lean
@@ -779,7 +779,7 @@ theorem mk'_d_1_0 : (mk' X₀ X₁ d₀ succ').d 1 0 = d₀ := by
 the inductive construction. -/
 def mk'XIso (n : ℕ) :
     (mk' X₀ X₁ d₀ succ').X (n + 2) ≅ (succ' ((mk' X₀ X₁ d₀ succ').d (n + 1) n)).1 := by
-  obtain _|n := n
+  obtain _ | n := n
   · apply eqToIso
     dsimp [mk', mk, of, mkAux]
     rw [id_comp]
@@ -793,7 +793,7 @@ lemma mk'_congr_succ'_d {X Y : V} (f g : X ⟶ Y) (h : f = g) :
 lemma mk'_d (n : ℕ) :
     (mk' X₀ X₁ d₀ succ').d (n + 2) (n + 1) = (mk'XIso X₀ X₁ d₀ succ' n).hom ≫
       (succ' ((mk' X₀ X₁ d₀ succ').d (n + 1) n)).2.1 := by
-  obtain _|n := n
+  obtain _ | n := n
   · dsimp [mk'XIso, mk']
     rw [mk_d_2_1]
     apply mk'_congr_succ'_d

--- a/Mathlib/Algebra/Homology/HomotopyCategory/HomComplexShift.lean
+++ b/Mathlib/Algebra/Homology/HomotopyCategory/HomComplexShift.lean
@@ -62,8 +62,8 @@ lemma rightShift_v (a n' : ℤ) (hn' : n' + a = n) (p q : ℤ) (hpq : p + n' = q
 
 /-- The map `Cochain K L n → Cochain (K⟦a⟧) L n'` when `n + a = n'`. -/
 def leftShift (a n' : ℤ) (hn' : n + a = n') : Cochain (K⟦a⟧) L n' :=
-  Cochain.mk (fun p q hpq => (a * n' + ((a * (a-1))/2)).negOnePow •
-    (K.shiftFunctorObjXIso a p (p + a) rfl).hom ≫ γ.v (p+a) q (by lia))
+  Cochain.mk (fun p q hpq => (a * n' + ((a * (a - 1)) / 2)).negOnePow •
+    (K.shiftFunctorObjXIso a p (p + a) rfl).hom ≫ γ.v (p + a) q (by lia))
 
 lemma leftShift_v (a n' : ℤ) (hn' : n + a = n') (p q : ℤ) (hpq : p + n' = q)
     (p' : ℤ) (hp' : p' + n = q) :
@@ -91,12 +91,12 @@ lemma rightUnshift_v {n' a : ℤ} (γ : Cochain K (L⟦a⟧) n') (n : ℤ) (hn :
 /-- The map `Cochain (K⟦a⟧) L n' → Cochain K L n` when `n + a = n'`. -/
 def leftUnshift {n' a : ℤ} (γ : Cochain (K⟦a⟧) L n') (n : ℤ) (hn : n + a = n') :
     Cochain K L n :=
-  Cochain.mk (fun p q hpq => (a * n' + ((a * (a-1))/2)).negOnePow •
-    (K.shiftFunctorObjXIso a (p - a) p (by lia)).inv ≫ γ.v (p-a) q (by lia))
+  Cochain.mk (fun p q hpq => (a * n' + ((a * (a - 1)) / 2)).negOnePow •
+    (K.shiftFunctorObjXIso a (p - a) p (by lia)).inv ≫ γ.v (p - a) q (by lia))
 
 lemma leftUnshift_v {n' a : ℤ} (γ : Cochain (K⟦a⟧) L n') (n : ℤ) (hn : n + a = n')
     (p q : ℤ) (hpq : p + n = q) (p' : ℤ) (hp' : p' + n' = q) :
-    (γ.leftUnshift n hn).v p q hpq = (a * n' + ((a * (a-1))/2)).negOnePow •
+    (γ.leftUnshift n hn).v p q hpq = (a * n' + ((a * (a - 1)) / 2)).negOnePow •
       (K.shiftFunctorObjXIso a p' p (by lia)).inv ≫ γ.v p' q (by lia) := by
   obtain rfl : p' = p - a := by lia
   rfl
@@ -139,16 +139,16 @@ lemma rightShift_rightUnshift {a n' : ℤ} (γ : Cochain K (L⟦a⟧) n') (n : �
 lemma leftUnshift_leftShift (a n' : ℤ) (hn' : n + a = n') :
     (γ.leftShift a n' hn').leftUnshift n hn' = γ := by
   ext p q hpq
-  rw [(γ.leftShift a n' hn').leftUnshift_v n hn' p q hpq (q-n') (by lia),
-    γ.leftShift_v a n' hn' (q-n') q (by lia) p hpq, Linear.comp_units_smul,
+  rw [(γ.leftShift a n' hn').leftUnshift_v n hn' p q hpq (q - n') (by lia),
+    γ.leftShift_v a n' hn' (q - n') q (by lia) p hpq, Linear.comp_units_smul,
     Iso.inv_hom_id_assoc, smul_smul, Int.units_mul_self, one_smul]
 
 @[simp]
 lemma leftShift_leftUnshift {a n' : ℤ} (γ : Cochain (K⟦a⟧) L n') (n : ℤ) (hn' : n + a = n') :
     (γ.leftUnshift n hn').leftShift a n' hn' = γ := by
   ext p q hpq
-  rw [(γ.leftUnshift n hn').leftShift_v a n' hn' p q hpq (q-n) (by lia),
-    γ.leftUnshift_v n hn' (q-n) q (by lia) p hpq, Linear.comp_units_smul, smul_smul,
+  rw [(γ.leftUnshift n hn').leftShift_v a n' hn' p q hpq (q - n) (by lia),
+    γ.leftUnshift_v n hn' (q - n) q (by lia) p hpq, Linear.comp_units_smul, smul_smul,
     Iso.hom_inv_id_assoc, Int.units_mul_self, one_smul]
 
 @[simp]
@@ -403,10 +403,10 @@ lemma δ_rightShift (a n' m' : ℤ) (hn' : n' + a = n) (m : ℤ) (hm' : m' + a =
     ext p q hpq
     dsimp
     rw [(δ n m γ).rightShift_v a m' hm' p q hpq _ rfl,
-      δ_v n m hnm _ p (p+m) rfl (p+n) (p+1) (by lia) rfl,
-      δ_v n' m' hnm' _ p q hpq (p+n') (p+1) (by lia) rfl,
-      γ.rightShift_v a n' hn' p (p+n') rfl (p+n) rfl,
-      γ.rightShift_v a n' hn' (p+1) q _ (p+m) (by lia)]
+      δ_v n m hnm _ p (p + m) rfl (p + n) (p + 1) (by lia) rfl,
+      δ_v n' m' hnm' _ p q hpq (p + n') (p + 1) (by lia) rfl,
+      γ.rightShift_v a n' hn' p (p + n') rfl (p + n) rfl,
+      γ.rightShift_v a n' hn' (p + 1) q _ (p + m) (by lia)]
     simp only [shiftFunctorObjXIso, shiftFunctor_obj_d',
       Linear.comp_units_smul, assoc, HomologicalComplex.XIsoOfEq_inv_comp_d,
       add_comp, HomologicalComplex.d_comp_XIsoOfEq_inv, Linear.units_smul_comp, smul_add,
@@ -430,11 +430,11 @@ lemma δ_leftShift (a n' m' : ℤ) (hn' : n + a = n') (m : ℤ) (hm' : m + a = m
   · have hnm' : n' + 1 = m' := by lia
     ext p q hpq
     dsimp
-    rw [(δ n m γ).leftShift_v a m' hm' p q hpq (p+a) (by lia),
-      δ_v n m hnm _ (p+a) q (by lia) (p+n') (p+1+a) (by lia) (by lia),
-      δ_v n' m' hnm' _ p q hpq (p+n') (p+1) (by lia) rfl,
-      γ.leftShift_v a n' hn' p (p+n') rfl (p+a) (by lia),
-      γ.leftShift_v a n' hn' (p+1) q (by lia) (p+1+a) (by lia)]
+    rw [(δ n m γ).leftShift_v a m' hm' p q hpq (p + a) (by lia),
+      δ_v n m hnm _ (p + a) q (by lia) (p + n') (p + 1 + a) (by lia) (by lia),
+      δ_v n' m' hnm' _ p q hpq (p + n') (p + 1) (by lia) rfl,
+      γ.leftShift_v a n' hn' p (p + n') rfl (p + a) (by lia),
+      γ.leftShift_v a n' hn' (p + 1) q (by lia) (p + 1 + a) (by lia)]
     simp only [shiftFunctor_obj_X, shiftFunctorObjXIso, HomologicalComplex.XIsoOfEq_rfl,
       Iso.refl_hom, id_comp, Linear.units_smul_comp, shiftFunctor_obj_d',
       Linear.comp_units_smul, smul_add, smul_smul]

--- a/Mathlib/Algebra/Homology/HomotopyCategory/KInjective.lean
+++ b/Mathlib/Algebra/Homology/HomotopyCategory/KInjective.lean
@@ -106,7 +106,7 @@ lemma isKInjective_of_injective_aux {K L : CochainComplex C ℤ}
   subst hnm
   let u := f.f (n + 1) - α.v (n + 1) n (by lia) ≫ L.d n (n + 1) -
     K.d (n + 1) (n + 2) ≫ α.v (n + 2) (n + 1) (by lia)
-  have hu : K.d n (n+1) ≫ u = 0 := by
+  have hu : K.d n (n + 1) ≫ u = 0 := by
     have eq := hα n n (add_zero n) (by rfl)
     simp only [δ_v (-1) 0 (neg_add_cancel 1) α n n (add_zero _) (n - 1) (n + 1)
       (by lia) (by lia), Int.negOnePow_zero, one_smul, Cochain.ofHom_v] at eq

--- a/Mathlib/Algebra/Homology/HomotopyCategory/MappingCone.lean
+++ b/Mathlib/Algebra/Homology/HomotopyCategory/MappingCone.lean
@@ -110,7 +110,7 @@ lemma inr_f_snd_v (p : ℤ) :
 lemma inl_fst :
     (inl φ).comp (fst φ).1 (neg_add_cancel 1) = Cochain.ofHom (𝟙 F) := by
   ext p
-  simp [Cochain.comp_v _ _ (neg_add_cancel 1) p (p-1) p rfl (by lia)]
+  simp [Cochain.comp_v _ _ (neg_add_cancel 1) p (p - 1) p rfl (by lia)]
 
 @[simp]
 lemma inl_snd :
@@ -475,7 +475,7 @@ noncomputable def liftCocycle {K : CochainComplex C ℤ} {n m : ℤ}
     (eq : δ n m β + α.1.comp (Cochain.ofHom φ) (add_zero m) = 0) :
     Cocycle K (mappingCone φ) n :=
   Cocycle.mk (liftCochain φ α β h) m h (by
-    simp only [δ_liftCochain φ α β h (m+1) rfl, eq,
+    simp only [δ_liftCochain φ α β h (m + 1) rfl, eq,
       Cocycle.δ_eq_zero, Cochain.zero_comp, neg_zero, add_zero])
 
 section

--- a/Mathlib/Algebra/Homology/HomotopyCategory/Triangulated.lean
+++ b/Mathlib/Algebra/Homology/HomotopyCategory/Triangulated.lean
@@ -78,7 +78,7 @@ noncomputable def hom :
     (descCochain _ 0 (Cochain.ofHom (inr (f ≫ g))) (neg_add_cancel 1)) (by
       ext p _ rfl
       dsimp [mappingConeCompTriangle, map]
-      simp [ext_from_iff _ _ _ rfl, inl_v_d_assoc _ (p+1) p (p+2) (by lia) (by lia)])
+      simp [ext_from_iff _ _ _ rfl, inl_v_d_assoc _ (p + 1) p (p + 2) (by lia) (by lia)])
 
 /-- Given two composable morphisms `f` and `g` in the category of cochain complexes, this
 is the canonical morphism (which is a homotopy equivalence) from the mapping cone of
@@ -89,7 +89,7 @@ noncomputable def inv : mappingCone (mappingConeCompTriangle f g).mor₁ ⟶ map
       ext p
       rw [ext_from_iff _ (p + 1) _ rfl, ext_to_iff _ _ (p + 1) rfl]
       simp [map, δ_zero_cochain_comp,
-        Cochain.comp_v _ _ (add_neg_cancel 1) p (p+1) p (by lia) (by lia)])
+        Cochain.comp_v _ _ (add_neg_cancel 1) p (p + 1) p (by lia) (by lia)])
 @[reassoc (attr := simp)]
 lemma hom_inv_id : hom f g ≫ inv f g = 𝟙 _ := by
   ext n

--- a/Mathlib/Algebra/Homology/LeftResolution/Basic.lean
+++ b/Mathlib/Algebra/Homology/LeftResolution/Basic.lean
@@ -164,7 +164,7 @@ lemma chainComplexMap_zero [Λ.F.PreservesZeroMorphisms] :
   ext n
   induction n with
   | zero => simp
-  | succ n hn => obtain _|n := n <;> simp [hn]
+  | succ n hn => obtain _ | n := n <;> simp [hn]
 
 @[reassoc, simp]
 lemma chainComplexMap_comp :

--- a/Mathlib/Algebra/Homology/LocalCohomology.lean
+++ b/Mathlib/Algebra/Homology/LocalCohomology.lean
@@ -222,7 +222,7 @@ def isoSelfLERadical (J : Ideal.{u} R) [IsNoetherian.{u, u} R R] (i : ℕ) :
     localCohomology.ofSelfLERadical.{u} J i ≅ localCohomology.{u} J i :=
   (localCohomology.isoOfFinal.{u, u, 0} (idealPowersToSelfLERadical.{u} J)
     (selfLERadicalDiagram.{u} J) i).symm ≪≫
-      HasColimit.isoOfNatIso.{0,0,u+1,u+1} (Iso.refl.{u+1,u+1} _)
+      HasColimit.isoOfNatIso.{0, 0, u + 1, u + 1} (Iso.refl.{u + 1, u + 1} _)
 
 /-- Casting from the full subcategory of ideals with radical containing `J` to the full
 subcategory of ideals with radical containing `K`. -/

--- a/Mathlib/Algebra/Lie/CartanExists.lean
+++ b/Mathlib/Algebra/Lie/CartanExists.lean
@@ -159,7 +159,7 @@ lemma engel_isBot_of_isMin (hLK : finrank K L ≤ #K) (U : LieSubalgebra K L)
   let Q := L ⧸ E
   let r := finrank K E
   -- If `r = finrank K L`, then `E = L`, and the statement is trivial.
-  obtain hr|hr : r = finrank K L ∨ r < finrank K L := (Submodule.finrank_le _).eq_or_lt
+  obtain hr | hr : r = finrank K L ∨ r < finrank K L := (Submodule.finrank_le _).eq_or_lt
   · suffices engel K y ≤ engel K x from hmin Ey this
     suffices engel K x = ⊤ by simp_rw [this, le_top]
     apply LieSubalgebra.toSubmodule_injective
@@ -217,7 +217,7 @@ lemma engel_isBot_of_isMin (hLK : finrank K L ≤ #K) (U : LieSubalgebra K L)
       ← constantCoeff_apply, LinearMap.charpoly_constantCoeff_eq_zero_iff]
     -- We consider `z = α • u + x`, and split into the cases `z = 0` and `z ≠ 0`.
     let z := α • u + x'
-    obtain hz₀|hz₀ := eq_or_ne z 0
+    obtain hz₀ | hz₀ := eq_or_ne z 0
     · -- If `z = 0`, then `⁅α • u + x, x⁆` vanishes and we use our assumption `x ≠ 0`.
       refine ⟨⟨x, self_mem_engel K x⟩, ?_, ?_⟩
       · exact Subtype.coe_ne_coe.mp hx₀
@@ -337,7 +337,7 @@ lemma engel_isBot_of_isMin (hLK : finrank K L ≤ #K) (U : LieSubalgebra K L)
   set n := Nat.find hz' with _hn
   have hn : (toEnd K U Q v ^ n) z' = 0 := Nat.find_spec hz'
   -- If `n = 0`, then we are done.
-  obtain hn₀|⟨k, hk⟩ : n = 0 ∨ ∃ k, n = k + 1 := by cases n <;> simp
+  obtain hn₀ | ⟨k, hk⟩ : n = 0 ∨ ∃ k, n = k + 1 := by cases n <;> simp
   · simpa only [hn₀, pow_zero, Module.End.one_apply] using hn
   -- If `n = k + 1`, then we can write `⁅v, _⁆ ^ n = ⁅v, _⁆ ∘ ⁅v, _⁆ ^ k`.
   -- Recall that `constantCoeff ψ` is non-zero on `α`, and `v = α • u + x`.

--- a/Mathlib/Algebra/Lie/Classical.lean
+++ b/Mathlib/Algebra/Lie/Classical.lean
@@ -194,7 +194,7 @@ def Pso (i : R) : Matrix (p ⊕ q) (p ⊕ q) R :=
 variable [Fintype p] [Fintype q]
 
 theorem pso_inv {i : R} (hi : i * i = -1) : Pso p q R i * Pso p q R (-i) = 1 := by
-  ext (x y); rcases x with ⟨x⟩|⟨x⟩ <;> rcases y with ⟨y⟩|⟨y⟩
+  ext (x y); rcases x with ⟨x⟩ | ⟨x⟩ <;> rcases y with ⟨y⟩ | ⟨y⟩
   · -- x y : p
     by_cases h : x = y <;>
     simp [Pso, h, one_apply]
@@ -212,7 +212,7 @@ def invertiblePso {i : R} (hi : i * i = -1) : Invertible (Pso p q R i) :=
 
 theorem indefiniteDiagonal_transform {i : R} (hi : i * i = -1) :
     (Pso p q R i)ᵀ * indefiniteDiagonal p q R * Pso p q R i = 1 := by
-  ext (x y); rcases x with ⟨x⟩|⟨x⟩ <;> rcases y with ⟨y⟩|⟨y⟩
+  ext (x y); rcases x with ⟨x⟩ | ⟨x⟩ <;> rcases y with ⟨y⟩ | ⟨y⟩
   · -- x y : p
     by_cases h : x = y <;>
     simp [Pso, indefiniteDiagonal, h, one_apply]

--- a/Mathlib/Algebra/Lie/EngelSubalgebra.lean
+++ b/Mathlib/Algebra/Lie/EngelSubalgebra.lean
@@ -119,7 +119,7 @@ lemma normalizer_eq_self_of_engel_le [IsArtinian R L]
   let dx : N →ₗ[R] N := (ad R L x).restrict aux₂
   obtain ⟨k, hk⟩ : ∃ a, ∀ b ≥ a, Codisjoint (LinearMap.ker (dx ^ b)) (LinearMap.range (dx ^ b)) :=
     eventually_atTop.mp <| dx.eventually_codisjoint_ker_pow_range_pow
-  specialize hk (k+1) (Nat.le_add_right k 1)
+  specialize hk (k + 1) (Nat.le_add_right k 1)
   rw [← Submodule.map_subtype_top N.toSubmodule, Submodule.map_le_iff_le_comap]
   apply hk
   · rw [← Submodule.map_le_iff_le_comap]
@@ -127,9 +127,9 @@ lemma normalizer_eq_self_of_engel_le [IsArtinian R L]
     rw [Submodule.map_le_iff_le_comap]
     intro y hy
     simp only [Submodule.mem_comap, mem_engel_iff, mem_toSubmodule]
-    use k+1
+    use k + 1
     clear hk; revert hy
-    generalize k+1 = k
+    generalize k + 1 = k
     induction k generalizing y with
     | zero =>
       cases y; intro hy; simp only [pow_zero, Module.End.one_apply]
@@ -163,7 +163,7 @@ lemma isNilpotent_of_forall_le_engel [IsNoetherian R L]
   specialize h x x.2 y.2
   rw [mem_engel_iff] at h
   obtain ⟨m, hm⟩ := h
-  obtain (hmn|hmn) : m ≤ n ∨ n ≤ m := le_total m n
+  obtain (hmn | hmn) : m ≤ n ∨ n ≤ m := le_total m n
   · exact Module.End.pow_map_zero_of_le hmn hm
   · have : ∀ k : ℕ, ((ad R L) x ^ k) y = 0 ↔ y ∈ K k := by simp [K, Subtype.ext_iff, coe_ad_pow]
     rwa [this, ← hn m hmn, ← this] at hm

--- a/Mathlib/Algebra/Lie/LieTheorem.lean
+++ b/Mathlib/Algebra/Lie/LieTheorem.lean
@@ -132,7 +132,7 @@ private lemma weightSpaceOfIsLieTower_aux (z : L) (v : V) (hv : v ∈ weightSpac
     · simp_all [U']
     obtain ⟨j, hj, hj'⟩ := key i hi
     obtain ⟨k, hk⟩ := ih j hj (hj' <| Submodule.mem_map_of_mem hx)
-    use k+1
+    use k + 1
     rw [pow_succ, Module.End.mul_apply, hk]
   have trace_za : (toEnd R A _ ⁅z, a⁆).trace R U = χ ⁅z, a⁆ • (finrank R U) := by
     simpa [T, sub_eq_zero] using trace_T_U_zero ⁅z, a⁆
@@ -211,7 +211,7 @@ private lemma exists_forall_lie_eq_smul_of_isSolvable_of_finite
     (L : Type*) [LieRing L] [LieAlgebra k L] [LieRingModule L V] [LieModule k L V]
     [IsSolvable L] [LieModule.IsTriangularizable k L V] [Module.Finite k L] :
     ∃ χ : Module.Dual k L, Nontrivial (weightSpace V χ) := by
-  obtain H|⟨A, hA, hAL⟩ := eq_top_or_exists_le_coatom (derivedSeries k L 1).toSubmodule
+  obtain H | ⟨A, hA, hAL⟩ := eq_top_or_exists_le_coatom (derivedSeries k L 1).toSubmodule
   · obtain _ | _ := subsingleton_or_nontrivial L
     · use 0
       simpa [mem_weightSpace, nontrivial_iff] using exists_pair_ne V

--- a/Mathlib/Algebra/Lie/TraceForm.lean
+++ b/Mathlib/Algebra/Lie/TraceForm.lean
@@ -283,7 +283,7 @@ lemma lowerCentralSeries_one_inf_center_le_ker_traceForm [Module.Free R M] [Modu
   apply LinearMap.trace_comp_eq_zero_of_commute_of_trace_restrict_eq_zero
   · exact IsTriangularizable.maxGenEigenspace_eq_top (1 ⊗ₜ[R] x)
   · exact fun μ ↦ trace_toEnd_eq_zero_of_mem_lcs A (A ⊗[R] L)
-      (genWeightSpaceOf (A ⊗[R] M) μ ((1:A) ⊗ₜ[R] x)) (le_refl 1) hz
+      (genWeightSpaceOf (A ⊗[R] M) μ ((1 : A) ⊗ₜ[R] x)) (le_refl 1) hz
   · exact commute_toEnd_of_mem_center_right (A ⊗[R] M) hzc (1 ⊗ₜ x)
 
 /-- A nilpotent Lie algebra with a representation whose trace form is non-singular is Abelian. -/

--- a/Mathlib/Algebra/Lie/Weights/RootSystem.lean
+++ b/Mathlib/Algebra/Lie/Weights/RootSystem.lean
@@ -321,7 +321,7 @@ lemma eq_neg_one_or_eq_zero_or_eq_one_of_eq_smul
   have H := apply_coroot_eq_cast' α β
   rw [h] at H
   simp only [Pi.smul_apply, root_apply_coroot hα] at H
-  rcases (chainLength α β).even_or_odd with (⟨n, hn⟩|⟨n, hn⟩)
+  rcases (chainLength α β).even_or_odd with (⟨n, hn⟩ | ⟨n, hn⟩)
   · rw [hn, ← two_mul] at H
     simp only [smul_eq_mul, Nat.cast_mul, Nat.cast_ofNat, ← mul_sub, ← mul_comm (2 : K),
       Int.cast_sub, Int.cast_mul, Int.cast_ofNat, Int.cast_natCast,

--- a/Mathlib/Algebra/Module/GradedModule.lean
+++ b/Mathlib/Algebra/Module/GradedModule.lean
@@ -126,7 +126,7 @@ private theorem mul_smul' [DecidableEq ιA] [DecidableEq ιB] [GSemiring A] [Gmo
         (DirectSum.mulHom A) =
       (AddMonoidHom.compHom AddMonoidHom.flipHom <|
           (smulAddMonoidHom A M).flip.compHom.comp <| smulAddMonoidHom A M).flip
-    from-- `fun a b c ↦ a • (b • c)` as a bundled hom
+    from -- `fun a b c ↦ a • (b • c)` as a bundled hom
       DFunLike.congr_fun (DFunLike.congr_fun (DFunLike.congr_fun this a) b) c
   ext ai ax bi bx ci cx : 6
   dsimp only [coe_comp, Function.comp_apply, compHom_apply_apply, flip_apply, flipHom_apply]

--- a/Mathlib/Algebra/Module/Submodule/Pointwise.lean
+++ b/Mathlib/Algebra/Module/Submodule/Pointwise.lean
@@ -541,7 +541,7 @@ scoped[Pointwise] attribute [instance] Submodule.pointwiseSetDistribMulAction
 lemma sup_set_smul (s t : Set S) :
     (s ⊔ t) • N = s • N ⊔ t • N :=
   set_smul_eq_of_le _ _ _
-    (by rintro _ _ (hr|hr) hn
+    (by rintro _ _ (hr | hr) hn
         · exact Submodule.mem_sup_left (mem_set_smul_of_mem_mem hr hn)
         · exact Submodule.mem_sup_right (mem_set_smul_of_mem_mem hr hn))
     (sup_le (set_smul_mono_left _ le_sup_left) (set_smul_mono_left _ le_sup_right))

--- a/Mathlib/Algebra/Module/Torsion/Basic.lean
+++ b/Mathlib/Algebra/Module/Torsion/Basic.lean
@@ -557,22 +557,22 @@ def quotientAnnihilator : Module (R ⧸ Module.annihilator R M) M :=
   (isTorsionBySet_annihilator R M).module
 
 theorem isTorsionBy_quotient_iff (N : Submodule R M) (r : R) :
-    IsTorsionBy R (M⧸N) r ↔ ∀ x, r • x ∈ N :=
+    IsTorsionBy R (M ⧸ N) r ↔ ∀ x, r • x ∈ N :=
   Iff.trans N.mkQ_surjective.forall <| forall_congr' fun _ =>
     Submodule.Quotient.mk_eq_zero N
 
 theorem IsTorsionBy.quotient (N : Submodule R M) {r : R}
-    (h : IsTorsionBy R M r) : IsTorsionBy R (M⧸N) r :=
+    (h : IsTorsionBy R M r) : IsTorsionBy R (M ⧸ N) r :=
   (isTorsionBy_quotient_iff N r).mpr fun x => @h x ▸ N.zero_mem
 
 theorem isTorsionBySet_quotient_iff (N : Submodule R M) (s : Set R) :
-    IsTorsionBySet R (M⧸N) s ↔ ∀ x, ∀ r ∈ s, r • x ∈ N :=
+    IsTorsionBySet R (M ⧸ N) s ↔ ∀ x, ∀ r ∈ s, r • x ∈ N :=
   Iff.trans N.mkQ_surjective.forall <| forall_congr' fun _ =>
     Iff.trans Subtype.forall <| forall₂_congr fun _ _ =>
       Submodule.Quotient.mk_eq_zero N
 
 theorem IsTorsionBySet.quotient (N : Submodule R M) {s}
-    (h : IsTorsionBySet R M s) : IsTorsionBySet R (M⧸N) s :=
+    (h : IsTorsionBySet R M s) : IsTorsionBySet R (M ⧸ N) s :=
   (isTorsionBySet_quotient_iff N s).mpr fun x r h' => @h x ⟨r, h'⟩ ▸ N.zero_mem
 
 variable (M I) (s : Set R) (r : R)
@@ -580,12 +580,12 @@ variable (M I) (s : Set R) (r : R)
 open Pointwise Submodule
 
 lemma isTorsionBySet_quotient_set_smul :
-    IsTorsionBySet R (M⧸s • (⊤ : Submodule R M)) s :=
+    IsTorsionBySet R (M ⧸ s • (⊤ : Submodule R M)) s :=
   (isTorsionBySet_quotient_iff _ _).mpr fun _ _ h =>
     mem_set_smul_of_mem_mem h mem_top
 
 lemma isTorsionBySet_quotient_ideal_smul :
-    IsTorsionBySet R (M⧸I • (⊤ : Submodule R M)) I :=
+    IsTorsionBySet R (M ⧸ I • (⊤ : Submodule R M)) I :=
   (isTorsionBySet_quotient_iff _ _).mpr fun _ _ h => smul_mem_smul h ⟨⟩
 
 instance [I.IsTwoSided] : Module (R ⧸ I) (M ⧸ I • (⊤ : Submodule R M)) :=
@@ -606,7 +606,7 @@ variable (M) [CommRing R] [AddCommGroup M] [Module R M] (s : Set R) (r : R)
 open Pointwise
 
 lemma isTorsionBy_quotient_element_smul :
-    IsTorsionBy R (M⧸r • (⊤ : Submodule R M)) r :=
+    IsTorsionBy R (M ⧸ r • (⊤ : Submodule R M)) r :=
   (isTorsionBy_quotient_iff _ _).mpr (Submodule.smul_mem_pointwise_smul · r ⊤ ⟨⟩)
 
 instance : Module (R ⧸ Ideal.span s) (M ⧸ s • (⊤ : Submodule R M)) :=

--- a/Mathlib/Algebra/Order/Antidiag/Nat.lean
+++ b/Mathlib/Algebra/Order/Antidiag/Nat.lean
@@ -219,7 +219,7 @@ private theorem primeFactorsPiBij_surj (d n : ℕ) (hn : Squarefree n)
   · rw [Nat.primeFactorsPiBij, ← prod_filter]
     congr
     grind
-  rw [prod_attach (f:=fun p => if p ∣ t i then p else 1), ← Finset.prod_filter]
+  rw [prod_attach (f := fun p => if p ∣ t i then p else 1), ← Finset.prod_filter]
   rw [primeFactors_filter_dvd_of_dvd hn.ne_zero this]
   exact prod_primeFactors_of_squarefree <| hn.squarefree_of_dvd this
 
@@ -284,7 +284,7 @@ private theorem f_surj {n : ℕ} (hn : n ≠ 0) (b : ℕ × ℕ)
     ∃ (a : Fin 3 → ℕ) (ha : a ∈ finMulAntidiag 3 n), f a ha = b := by
   dsimp only at hb
   let g := b.fst.gcd b.snd
-  let a := ![g, b.fst/g, b.snd/g]
+  let a := ![g, b.fst / g, b.snd / g]
   have ha : a ∈ finMulAntidiag 3 n := by
     rw [mem_finMulAntidiag]
     rw [mem_filter, Finset.mem_product] at hb

--- a/Mathlib/Algebra/Order/Archimedean/Class.lean
+++ b/Mathlib/Algebra/Order/Archimedean/Class.lean
@@ -400,7 +400,7 @@ theorem mk_prod {ι : Type*} [LinearOrder ι] {s : Finset ι} (hnonempty : s.Non
       rw [eq] at hi
       exact hi (Finset.min'_mem _ hs)
     rw [← ih] at hne
-    obtain hlt|hlt := lt_or_gt_of_ne hne
+    obtain hlt | hlt := lt_or_gt_of_ne hne
     · rw [mk_mul_eq_mk_left hlt]
       congr
       apply le_antisymm (Finset.le_min' _ _ _ ?_) (Finset.min'_le _ _ (by simp))

--- a/Mathlib/Algebra/Polynomial/Degree/Domain.lean
+++ b/Mathlib/Algebra/Polynomial/Degree/Domain.lean
@@ -34,7 +34,7 @@ section Semiring
 
 variable [Semiring R] [NoZeroDivisors R] {p q : R[X]}
 
-lemma natDegree_mul (hp : p ≠ 0) (hq : q ≠ 0) : (p*q).natDegree = p.natDegree + q.natDegree := by
+lemma natDegree_mul (hp : p ≠ 0) (hq : q ≠ 0) : (p * q).natDegree = p.natDegree + q.natDegree := by
   rw [← Nat.cast_inj (R := WithBot ℕ), ← degree_eq_natDegree (mul_ne_zero hp hq),
     Nat.cast_add, ← degree_eq_natDegree hp, ← degree_eq_natDegree hq, degree_mul]
 

--- a/Mathlib/Algebra/Polynomial/Degree/Lemmas.lean
+++ b/Mathlib/Algebra/Polynomial/Degree/Lemmas.lean
@@ -258,7 +258,7 @@ theorem coe_lt_degree {p : R[X]} {n : ℕ} : (n : WithBot ℕ) < degree p ↔ n 
 @[simp]
 theorem degree_map_eq_iff {f : R →+* S} {p : Polynomial R} :
     degree (map f p) = degree p ↔ f (leadingCoeff p) ≠ 0 ∨ p = 0 := by
-  rcases eq_or_ne p 0 with h|h
+  rcases eq_or_ne p 0 with h | h
   · simp [h]
   simp only [h, or_false]
   refine ⟨fun h2 ↦ ?_, degree_map_eq_of_leadingCoeff_ne_zero f⟩
@@ -270,7 +270,7 @@ theorem degree_map_eq_iff {f : R →+* S} {p : Polynomial R} :
 @[simp]
 theorem natDegree_map_eq_iff {f : R →+* S} {p : Polynomial R} :
     natDegree (map f p) = natDegree p ↔ f (p.leadingCoeff) ≠ 0 ∨ natDegree p = 0 := by
-  rcases eq_or_ne (natDegree p) 0 with h|h
+  rcases eq_or_ne (natDegree p) 0 with h | h
   · simp_rw [h, ne_eq, or_true, iff_true, ← Nat.le_zero, ← h, natDegree_map_le]
   simp_all [natDegree, WithBot.unbotD_eq_unbotD_iff]
 

--- a/Mathlib/Algebra/Polynomial/HasseDeriv.lean
+++ b/Mathlib/Algebra/Polynomial/HasseDeriv.lean
@@ -139,7 +139,7 @@ theorem factorial_smul_hasseDeriv : ⇑(k ! • @hasseDeriv R _ k) = (@derivativ
   simp only [← mul_assoc]
   norm_cast
   congr 2
-  rw [mul_comm (k+1) _, mul_assoc, mul_assoc]
+  rw [mul_comm (k + 1) _, mul_assoc, mul_assoc]
   congr 1
   have : n + k + 1 = n + (k + 1) := by apply add_assoc
   rw [← choose_symm_of_eq_add this, choose_succ_right_eq, mul_comm]

--- a/Mathlib/Algebra/Polynomial/Inductions.lean
+++ b/Mathlib/Algebra/Polynomial/Inductions.lean
@@ -170,7 +170,7 @@ theorem degree_pos_induction_on {P : R[X] → Prop} (p : R[X]) (h0 : 0 < degree 
       (have : 0 < degree p :=
         (lt_of_not_ge fun h =>
           not_lt_of_ge (degree_C_le (a := a)) <|
-            by rwa [eq_C_of_degree_le_zero h, ← C_add,heq0,zero_add] at h0)
+            by rwa [eq_C_of_degree_le_zero h, ← C_add, heq0, zero_add] at h0)
       hadd this (ih this)))
     (fun p _ ih h0' =>
       if h0 : 0 < degree p then hX h0 (ih h0)

--- a/Mathlib/Algebra/Polynomial/Roots.lean
+++ b/Mathlib/Algebra/Polynomial/Roots.lean
@@ -668,7 +668,7 @@ lemma eq_zero_of_natDegree_lt_card_of_eval_eq_zero' {R} [CommRing R] [IsDomain R
 open Cardinal in
 lemma eq_zero_of_forall_eval_zero_of_natDegree_lt_card
     (f : R[X]) (hf : ∀ r, f.eval r = 0) (hfR : f.natDegree < #R) : f = 0 := by
-  obtain hR|hR := finite_or_infinite R
+  obtain hR | hR := finite_or_infinite R
   · have := Fintype.ofFinite R
     apply eq_zero_of_natDegree_lt_card_of_eval_eq_zero f Function.injective_id hf
     simpa only [mk_fintype, Nat.cast_lt] using hfR

--- a/Mathlib/Algebra/Polynomial/RuleOfSigns.lean
+++ b/Mathlib/Algebra/Polynomial/RuleOfSigns.lean
@@ -131,7 +131,7 @@ variable {R : Type*} [Ring R] [LinearOrder R] [IsOrderedRing R] (P : Polynomial 
 theorem signVariations_neg : signVariations (-P) = signVariations P := by
   rw [signVariations, signVariations, coeffList_neg]
   simp only [List.map_map, List.filter_map]
-  have hsc : SignType.sign ∘ (fun (x:R) => -x) = (fun x => -x) ∘ SignType.sign := by
+  have hsc : SignType.sign ∘ (fun (x : R) => -x) = (fun x => -x) ∘ SignType.sign := by
     grind [Left.sign_neg]
   have h_neg_destutter (l : List SignType) :
       (l.destutter (¬· = ·)).map (- ·) = (l.map (- ·)).destutter (¬· = ·) := by

--- a/Mathlib/Algebra/Ring/Divisibility/Lemmas.lean
+++ b/Mathlib/Algebra/Ring/Divisibility/Lemmas.lean
@@ -114,7 +114,7 @@ lemma dvd_mul_sub_mul_mul_right_of_dvd {p a b c d x y : R}
 
 lemma dvd_mul_sub_mul_mul_gcd_of_dvd {p a b c d x y : R} [IsDomain R] [GCDMonoid R]
     (h1 : p ∣ a * x + b * y) (h2 : p ∣ c * x + d * y) : p ∣ (a * d - b * c) * gcd x y := by
-  rw [← (gcd_mul_left' (a*d - b*c) x y).dvd_iff_dvd_right]
+  rw [← (gcd_mul_left' (a * d - b * c) x y).dvd_iff_dvd_right]
   exact (dvd_gcd_iff _ _ _).2 ⟨dvd_mul_sub_mul_mul_left_of_dvd h1 h2,
     dvd_mul_sub_mul_mul_right_of_dvd h1 h2⟩
 

--- a/Mathlib/Algebra/Ring/NegOnePow.lean
+++ b/Mathlib/Algebra/Ring/NegOnePow.lean
@@ -89,7 +89,7 @@ lemma negOnePow_neg (n : ℤ) : (-n).negOnePow = n.negOnePow := by
 
 @[simp]
 lemma negOnePow_abs (n : ℤ) : |n|.negOnePow = n.negOnePow := by
-  obtain h|h := abs_choice n <;> simp only [h, negOnePow_neg]
+  obtain h | h := abs_choice n <;> simp only [h, negOnePow_neg]
 
 lemma negOnePow_sub (n₁ n₂ : ℤ) :
     (n₁ - n₂).negOnePow = n₁.negOnePow * n₂.negOnePow := by

--- a/Mathlib/Algebra/Star/StarAlgHom.lean
+++ b/Mathlib/Algebra/Star/StarAlgHom.lean
@@ -847,7 +847,7 @@ theorem coe_symm_toAlgEquiv (f : A ≃⋆ₐ[R] B) : ⇑f.toAlgEquiv.symm = ⇑f
 theorem toAlgEquiv_trans {C : Type*} [Semiring C] [Algebra R C] [Star C] (f : A ≃⋆ₐ[R] B)
     (g : B ≃⋆ₐ[R] C) : (f.trans g).toAlgEquiv = f.toAlgEquiv.trans g.toAlgEquiv := rfl
 
-theorem toAlgEquiv_injective : Function.Injective (toAlgEquiv (R:=R) (A:=A) (B:=B)) :=
+theorem toAlgEquiv_injective : Function.Injective (toAlgEquiv (R := R) (A := A) (B := B)) :=
   fun _ _ h => ext <| AlgEquiv.congr_fun h
 
 @[simp]


### PR DESCRIPTION
Found by extending the commandStart linter to proof bodies.

---
<!-- Your PR title will become the first line of the commit message.

In this box, the text above the `---` (if not empty) will be appended
to the commit message, and can be used to give additional context or
details. Please leave a blank newline before the `---`, otherwise GitHub
will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

When merging, all the commits will be squashed into a single commit
listing all co-authors.

Co-authors in the squash commit are gathered from two sources:

First, all authors of commits to this PR branch are included. Thus,
one way to add co-authors is to include at least one commit authored by
each co-author among the commits in the pull request. If necessary, you
may create empty commits to indicate co-authorship, using commands like so:

git commit --author="Author Name <author@email.com>" --allow-empty -m "add Author Name as coauthor"

Second, co-authors can also be listed in lines at the very bottom of
the commit message (that is, directly before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines
at the bottom of the commit message (before the `---`, and also before
any "Co-authored-by" lines) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
