### PR TITLE
[Merged by Bors] - chore(RingTheory): add `RingHom.Etale.of_bijective`

### DIFF
--- a/Mathlib/RingTheory/FinitePresentation.lean
+++ b/Mathlib/RingTheory/FinitePresentation.lean
@@ -426,6 +426,12 @@ theorem of_surjective (f : A →+* B) (hf : Surjective f) (hker : (RingHom.ker f
   rw [← f.comp_id]
   exact (id A).comp_surjective hf hker
 
+lemma of_bijective {f : A →+* B} (hf : Function.Bijective f) : f.FinitePresentation :=
+  .of_surjective f hf.2 <| by
+    have : ker f = ⊥ := by rw [← RingHom.injective_iff_ker_eq_bot]; exact hf.1
+    rw [this]
+    exact Submodule.fg_bot
+
 theorem of_finiteType [IsNoetherianRing A] {f : A →+* B} : f.FiniteType ↔ f.FinitePresentation :=
   @Algebra.FinitePresentation.of_finiteType A B _ _ f.toAlgebra _
 

--- a/Mathlib/RingTheory/RingHom/Etale.lean
+++ b/Mathlib/RingTheory/RingHom/Etale.lean
@@ -47,6 +47,10 @@ lemma Etale.eq_formallyUnramified_and_smooth :
   ext
   rw [etale_iff_formallyUnramified_and_smooth]
 
+lemma Etale.of_bijective {f : R →+* S} (hf : Function.Bijective f) : f.Etale := by
+  rw [etale_iff_formallyUnramified_and_smooth]
+  exact ⟨.of_surjective hf.2, .of_bijective hf⟩
+
 lemma Etale.isStableUnderBaseChange : IsStableUnderBaseChange Etale := by
   rw [eq_formallyUnramified_and_smooth]
   exact FormallyUnramified.isStableUnderBaseChange.and Smooth.isStableUnderBaseChange

--- a/Mathlib/RingTheory/RingHom/Smooth.lean
+++ b/Mathlib/RingTheory/RingHom/Smooth.lean
@@ -40,6 +40,11 @@ lemma formallySmooth_algebraMap [Algebra R S] :
     (algebraMap R S).FormallySmooth ↔ Algebra.FormallySmooth R S := by
   rw [FormallySmooth, toAlgebra_algebraMap]
 
+lemma FormallySmooth.of_bijective {f : R →+* S} (hf : Function.Bijective f) :
+    f.FormallySmooth := by
+  algebraize [f]
+  exact Algebra.FormallySmooth.of_equiv (AlgEquiv.ofBijective (Algebra.ofId R S) hf)
+
 lemma FormallySmooth.holdsForLocalizationAway : HoldsForLocalizationAway @FormallySmooth :=
   fun _ _ _ _ _ r _ ↦ formallySmooth_algebraMap.mpr <| .of_isLocalization (.powers r)
 
@@ -100,6 +105,10 @@ lemma holdsForLocalizationAway : HoldsForLocalizationAway Smooth := by
   rw [smooth_algebraMap]
   exact ⟨Algebra.FormallySmooth.of_isLocalization (.powers r),
     IsLocalization.Away.finitePresentation r⟩
+
+lemma of_bijective {f : R →+* S} (hf : Function.Bijective f) : f.Smooth := by
+  rw [RingHom.smooth_def]
+  exact ⟨.of_bijective hf, .of_bijective hf⟩
 
 variable (R) in
 /-- The identity of a ring is smooth. -/

--- a/Mathlib/RingTheory/RingHom/Unramified.lean
+++ b/Mathlib/RingTheory/RingHom/Unramified.lean
@@ -35,6 +35,10 @@ lemma formallyUnramified_algebraMap [Algebra R S] :
 
 namespace FormallyUnramified
 
+lemma of_surjective {f : R →+* S} (hf : Function.Surjective f) : f.FormallyUnramified := by
+  algebraize [f]
+  exact Algebra.FormallyUnramified.of_surjective (Algebra.ofId R S) hf
+
 lemma stableUnderComposition :
     StableUnderComposition FormallyUnramified := by
   intro R S T _ _ _ f g _ _
@@ -45,8 +49,7 @@ lemma respectsIso :
     RespectsIso FormallyUnramified := by
   refine stableUnderComposition.respectsIso ?_
   intro R S _ _ e
-  letI := e.toRingHom.toAlgebra
-  exact Algebra.FormallyUnramified.of_surjective (Algebra.ofId R S) e.surjective
+  exact .of_surjective e.surjective
 
 lemma isStableUnderBaseChange :
     IsStableUnderBaseChange FormallyUnramified := by


### PR DESCRIPTION
From Pi1.

---
<!-- Your PR title will become the first line of the commit message.

In this box, the text above the `---` (if not empty) will be appended
to the commit message, and can be used to give additional context or
details. Please leave a blank newline before the `---`, otherwise GitHub
will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

When merging, all the commits will be squashed into a single commit
listing all co-authors.

Co-authors in the squash commit are gathered from two sources:

First, all authors of commits to this PR branch are included. Thus,
one way to add co-authors is to include at least one commit authored by
each co-author among the commits in the pull request. If necessary, you
may create empty commits to indicate co-authorship, using commands like so:

git commit --author="Author Name <author@email.com>" --allow-empty -m "add Author Name as coauthor"

Second, co-authors can also be listed in lines at the very bottom of
the commit message (that is, directly before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines
at the bottom of the commit message (before the `---`, and also before
any "Co-authored-by" lines) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
