### PR TITLE
[Merged by Bors] - fix: definition of `Rat.IsIntegralClosure.intEquiv`

### DIFF
--- a/Mathlib/NumberTheory/Padics/HeightOneSpectrum.lean
+++ b/Mathlib/NumberTheory/Padics/HeightOneSpectrum.lean
@@ -62,7 +62,7 @@ variable (R : Type*) [CommRing R] [Algebra R ℚ]
 theorem Rat.int_algebraMap_injective : Function.Injective (algebraMap ℤ R) :=
   .of_comp (IsScalarTower.algebraMap_eq ℤ R ℚ ▸ RingHom.injective_int (algebraMap ℤ ℚ))
 
-variable [IsIntegralClosure R ℤ ℚ] [IsFractionRing R ℚ]
+variable [IsFractionRing R ℚ] [IsIntegralClosure R ℤ ℚ]
 
 theorem Rat.int_algebraMap_surjective : Function.Surjective (algebraMap ℤ R) := by
   intro x

--- a/Mathlib/NumberTheory/Padics/HeightOneSpectrum.lean
+++ b/Mathlib/NumberTheory/Padics/HeightOneSpectrum.lean
@@ -62,9 +62,10 @@ variable (R : Type*) [CommRing R] [Algebra R ℚ]
 theorem Rat.int_algebraMap_injective : Function.Injective (algebraMap ℤ R) :=
   .of_comp (IsScalarTower.algebraMap_eq ℤ R ℚ ▸ RingHom.injective_int (algebraMap ℤ ℚ))
 
-variable [IsFractionRing R ℚ] [IsIntegralClosure R ℤ ℚ]
+variable [IsIntegralClosure R ℤ ℚ]
 
-theorem Rat.int_algebraMap_surjective : Function.Surjective (algebraMap ℤ R) := by
+theorem Rat.int_algebraMap_surjective [IsFractionRing R ℚ] :
+    Function.Surjective (algebraMap ℤ R) := by
   intro x
   obtain ⟨y, hy⟩ := IsIntegrallyClosed.isIntegral_iff.1 <|
     IsIntegral.algebraMap (B := ℚ) (IsIntegralClosure.isIntegral ℤ ℚ x)

--- a/Mathlib/NumberTheory/Padics/HeightOneSpectrum.lean
+++ b/Mathlib/NumberTheory/Padics/HeightOneSpectrum.lean
@@ -62,7 +62,7 @@ variable (R : Type*) [CommRing R] [Algebra R ℚ]
 theorem Rat.int_algebraMap_injective : Function.Injective (algebraMap ℤ R) :=
   .of_comp (IsScalarTower.algebraMap_eq ℤ R ℚ ▸ RingHom.injective_int (algebraMap ℤ ℚ))
 
-variable [IsFractionRing R ℚ] [IsIntegralClosure R ℤ ℚ]
+variable [IsIntegralClosure R ℤ ℚ] [IsFractionRing R ℚ]
 
 theorem Rat.int_algebraMap_surjective : Function.Surjective (algebraMap ℤ R) := by
   intro x
@@ -70,13 +70,20 @@ theorem Rat.int_algebraMap_surjective : Function.Surjective (algebraMap ℤ R) :
     IsIntegral.algebraMap (B := ℚ) (IsIntegralClosure.isIntegral ℤ ℚ x)
   exact ⟨y, IsFractionRing.injective R ℚ <| by simp only [← IsScalarTower.algebraMap_apply, hy]⟩
 
-/-- If `R : CommRing` has field of fractions `ℚ` then it is isomorphic to `ℤ`. -/
+/-- If `R` has field of fractions `ℚ` and is the integral closure of `ℤ` in `ℚ` then it is
+isomorphic to `ℤ`. -/
 noncomputable def Rat.intEquiv : R ≃+* ℤ :=
-  RingEquiv.ofBijective _ ⟨int_algebraMap_injective R, int_algebraMap_surjective R⟩ |>.symm
+  (NumberField.RingOfIntegers.equiv R).symm.trans ringOfIntegersEquiv
+
+@[simp]
+theorem Rat.intEquiv_apply_eq_ringOfIntegersEquiv (x : 𝓞 ℚ) :
+    intEquiv (𝓞 ℚ) x = ringOfIntegersEquiv x := by
+  simp [intEquiv, RingOfIntegers.equiv, IsIntegralClosure.equiv, IsIntegralClosure.lift,
+    IsIntegralClosure.mk']
 
 namespace Rat.HeightOneSpectrum
 
-variable {R : Type*} [CommRing R] [Algebra R ℚ] [IsFractionRing R ℚ] [IsIntegralClosure R ℤ ℚ]
+variable {R : Type*} [CommRing R] [Algebra R ℚ] [IsIntegralClosure R ℤ ℚ]
 
 /-- If `v : HeightOneSpectrum R` then `natGenerator v` is the generator in `ℕ` of the corresponding
 ideal in `ℤ`. -/
@@ -96,7 +103,7 @@ theorem prime_natGenerator (v : HeightOneSpectrum R) : Nat.Prime (natGenerator v
   Int.prime_iff_natAbs_prime.1 <| Submodule.IsPrincipal.prime_generator_of_isPrime _
     ((Ideal.map_eq_bot_iff_of_injective (intEquiv R).injective).not.2 v.ne_bot)
 
-variable [IsDedekindDomain R]
+variable [IsDedekindDomain R] [IsFractionRing R ℚ]
 
 /-- The equivalence between height-one prime ideals of `R` and primes in `ℕ`. -/
 noncomputable def primesEquiv : HeightOneSpectrum R ≃ Nat.Primes where

--- a/Mathlib/NumberTheory/Padics/HeightOneSpectrum.lean
+++ b/Mathlib/NumberTheory/Padics/HeightOneSpectrum.lean
@@ -72,16 +72,20 @@ theorem Rat.int_algebraMap_surjective : Function.Surjective (algebraMap ℤ R) :
 
 /-- If `R` has field of fractions `ℚ` and is the integral closure of `ℤ` in `ℚ` then it is
 isomorphic to `ℤ`. -/
-noncomputable def Rat.intEquiv : R ≃+* ℤ :=
+noncomputable def Rat.IsIntegralClosure.intEquiv : R ≃+* ℤ :=
   (NumberField.RingOfIntegers.equiv R).symm.trans ringOfIntegersEquiv
 
+@[deprecated (since := "2025-12-22")] alias Rat.intEquiv := Rat.IsIntegralClosure.intEquiv
+
 @[simp]
-theorem Rat.intEquiv_apply_eq_ringOfIntegersEquiv (x : 𝓞 ℚ) :
+theorem Rat.IsIntegralClosure.intEquiv_apply_eq_ringOfIntegersEquiv (x : 𝓞 ℚ) :
     intEquiv (𝓞 ℚ) x = ringOfIntegersEquiv x := by
   simp [intEquiv, RingOfIntegers.equiv, IsIntegralClosure.equiv, IsIntegralClosure.lift,
     IsIntegralClosure.mk']
 
 namespace Rat.HeightOneSpectrum
+
+open Rat.IsIntegralClosure
 
 variable {R : Type*} [CommRing R] [Algebra R ℚ] [IsIntegralClosure R ℤ ℚ]
 

--- a/Mathlib/NumberTheory/Padics/HeightOneSpectrum.lean
+++ b/Mathlib/NumberTheory/Padics/HeightOneSpectrum.lean
@@ -85,27 +85,25 @@ theorem Rat.IsIntegralClosure.intEquiv_apply_eq_ringOfIntegersEquiv (x : 𝓞 �
 
 namespace Rat.HeightOneSpectrum
 
-open Rat.IsIntegralClosure
-
 variable {R : Type*} [CommRing R] [Algebra R ℚ] [IsIntegralClosure R ℤ ℚ]
 
 /-- If `v : HeightOneSpectrum R` then `natGenerator v` is the generator in `ℕ` of the corresponding
 ideal in `ℤ`. -/
 noncomputable def natGenerator (v : HeightOneSpectrum R) : ℕ :=
-  Submodule.IsPrincipal.generator (v.asIdeal.map <| intEquiv R) |>.natAbs
+  Submodule.IsPrincipal.generator (v.asIdeal.map <| IsIntegralClosure.intEquiv R) |>.natAbs
 
 theorem span_natGenerator (v : HeightOneSpectrum R) :
-    Ideal.span {(natGenerator v : ℤ)} = v.asIdeal.map (intEquiv R) := by
+    Ideal.span {(natGenerator v : ℤ)} = v.asIdeal.map (IsIntegralClosure.intEquiv R) := by
   simp [natGenerator]
 
 theorem natGenerator_dvd_iff (v : HeightOneSpectrum R) {n : ℕ} :
-    natGenerator v ∣ n ↔ ↑n ∈ v.asIdeal.map (intEquiv R) := by
+    natGenerator v ∣ n ↔ ↑n ∈ v.asIdeal.map (IsIntegralClosure.intEquiv R) := by
   rw [← span_natGenerator, Ideal.mem_span_singleton]
   exact Int.ofNat_dvd.symm
 
 theorem prime_natGenerator (v : HeightOneSpectrum R) : Nat.Prime (natGenerator v) :=
   Int.prime_iff_natAbs_prime.1 <| Submodule.IsPrincipal.prime_generator_of_isPrime _
-    ((Ideal.map_eq_bot_iff_of_injective (intEquiv R).injective).not.2 v.ne_bot)
+    ((Ideal.map_eq_bot_iff_of_injective (IsIntegralClosure.intEquiv R).injective).not.2 v.ne_bot)
 
 variable [IsDedekindDomain R] [IsFractionRing R ℚ]
 
@@ -113,24 +111,25 @@ variable [IsDedekindDomain R] [IsFractionRing R ℚ]
 noncomputable def primesEquiv : HeightOneSpectrum R ≃ Nat.Primes where
   toFun v := ⟨natGenerator v, prime_natGenerator v⟩
   invFun p :=
-    have h : Prime ((Ideal.span {(p.1 : ℤ)}).map (intEquiv R).symm) :=
+    have h : Prime ((Ideal.span {(p.1 : ℤ)}).map (IsIntegralClosure.intEquiv R).symm) :=
       map_prime_of_equiv _ (by simp [← Nat.prime_iff_prime_int, p.2]) (by simp [p.2.ne_zero])
     .ofPrime h
   left_inv v := by
     simp only [Ideal.map_symm]
     congr
-    rw [← v.asIdeal.comap_map_of_bijective _ (intEquiv R).bijective, ← span_natGenerator]
+    rw [← v.asIdeal.comap_map_of_bijective _ (IsIntegralClosure.intEquiv R).bijective,
+      ← span_natGenerator]
   right_inv p := by
     simp only [Ideal.map_symm, natGenerator, HeightOneSpectrum.ofPrime_asIdeal]
     congr
-    simp [Ideal.map_comap_of_surjective _ (intEquiv R).surjective,
+    simp [Ideal.map_comap_of_surjective _ (IsIntegralClosure.intEquiv R).surjective,
       Int.associated_iff_natAbs.1 (Submodule.IsPrincipal.associated_generator_span_self _)]
 
 theorem valuation_equiv_padicValuation (v : HeightOneSpectrum R) :
     (v.valuation ℚ).IsEquiv (padicValuation (primesEquiv v)) := by
   simp [primesEquiv, Valuation.isEquiv_iff_val_le_one, valuation_le_one_iff_den,
     padicValuation_le_one_iff, natGenerator_dvd_iff,
-    map_natCast (intEquiv R) _ ▸ Ideal.apply_mem_of_equiv_iff]
+    map_natCast (IsIntegralClosure.intEquiv R) _ ▸ Ideal.apply_mem_of_equiv_iff]
 
 open Valuation
 


### PR DESCRIPTION
`Rat.IsIntegralClosure.intEquiv R` (formerly `Rat.intEquiv`) defined an isomorphism between an integral closure `R` of `ℤ` in `ℚ` abstractly using bijectivity. This turns out to be not very usable in light of the fact that this isomorphism can be constructed alternatively by composing `RingOfIntegers.equiv` and `Rat.ringOfIntegersEquiv`. 

This PR redefines as the composition to ensure compabitility. Namely, when specialising to `R =  𝓞 ℚ` we have that `Rat.IsIntegralClosure.intEquiv (𝓞 ℚ) : 𝓞 ℚ ≃+* ℤ` and `Rat.ringOfIntegersEquiv` define the same isomorphism.

---
<!-- Your PR title will become the first line of the commit message.

In this box, the text above the `---` (if not empty) will be appended
to the commit message, and can be used to give additional context or
details. Please leave a blank newline before the `---`, otherwise GitHub
will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

When merging, all the commits will be squashed into a single commit
listing all co-authors.

Co-authors in the squash commit are gathered from two sources:

First, all authors of commits to this PR branch are included. Thus,
one way to add co-authors is to include at least one commit authored by
each co-author among the commits in the pull request. If necessary, you
may create empty commits to indicate co-authorship, using commands like so:

git commit --author="Author Name <author@email.com>" --allow-empty -m "add Author Name as coauthor"

Second, co-authors can also be listed in lines at the very bottom of
the commit message (that is, directly before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines
at the bottom of the commit message (before the `---`, and also before
any "Co-authored-by" lines) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
