### PR TITLE
[Merged by Bors] - ci: refactor daily.yml to notify even if runner fails catastrophically

### DIFF
--- a/.github/workflows/daily.yml
+++ b/.github/workflows/daily.yml
@@ -115,17 +115,12 @@ jobs:
         run: |
           JOB_NAME="check-lean4checker (${{ matrix.branch_type }})"
           
-          # Get job outcome
-          OUTCOME=$(gh run view ${{ github.run_id }} --json jobs --jq \
-            ".jobs[] | select(.name == \"$JOB_NAME\") | .conclusion")
-          
           # Get URL to the specific step
           LEAN4CHECKER_URL=$(gh run view ${{ github.run_id }} --json jobs --jq \
             ".jobs[] | select(.name == \"$JOB_NAME\") \
             | (.url + (.steps[] | select(.name == \"Check environments using lean4checker\") \
               | \"#step:\(.number):1\"))")
           
-          echo "outcome=${OUTCOME}" | tee -a "$GITHUB_OUTPUT"
           echo "lean4checker_url=${LEAN4CHECKER_URL}" | tee -a "$GITHUB_OUTPUT"
 
       - name: Fetch latest tags (if nightly)
@@ -145,7 +140,7 @@ jobs:
           fi
 
       - name: Post success message for lean4checker on Zulip
-        if: steps.get-status.outputs.outcome == 'success'
+        if: needs.check-lean4checker.result == 'success'
         uses: zulip/github-actions-zulip/send-message@e4c8f27c732ba9bd98ac6be0583096dea82feea5 # v1.0.2
         with:
           api-key: ${{ secrets.ZULIP_API_KEY }}
@@ -158,7 +153,7 @@ jobs:
             ✅ lean4checker [succeeded](${{ steps.get-status.outputs.lean4checker_url }}) on ${{ github.sha }} (branch: ${{ env.BRANCH_REF }})
 
       - name: Post failure / cancelled message for lean4checker on Zulip
-        if: steps.get-status.outputs.outcome != 'success'
+        if: needs.check-lean4checker.result != 'success'
         uses: zulip/github-actions-zulip/send-message@e4c8f27c732ba9bd98ac6be0583096dea82feea5 # v1.0.2
         with:
           api-key: ${{ secrets.ZULIP_API_KEY }}
@@ -168,7 +163,7 @@ jobs:
           type: 'stream'
           topic: 'lean4checker failure'
           content: |
-            ❌ lean4checker [${{ steps.get-status.outputs.outcome }}](${{ steps.get-status.outputs.lean4checker_url }}) on ${{ github.sha }} (branch: ${{ env.BRANCH_REF }})
+            ❌ lean4checker [${{ needs.check-lean4checker.result }}](${{ steps.get-status.outputs.lean4checker_url }}) on ${{ github.sha }} (branch: ${{ env.BRANCH_REF }})
 
   check-mathlib_test_executable:
     runs-on: ubuntu-latest
@@ -239,17 +234,12 @@ jobs:
         run: |
           JOB_NAME="check-mathlib_test_executable (${{ matrix.branch_type }})"
           
-          # Get job outcome
-          OUTCOME=$(gh run view ${{ github.run_id }} --json jobs --jq \
-            ".jobs[] | select(.name == \"$JOB_NAME\") | .conclusion")
-          
           # Get URL to the specific step
           MATHLIB_TEST_EXECUTABLE_URL=$(gh run view ${{ github.run_id }} --json jobs --jq \
             ".jobs[] | select(.name == \"$JOB_NAME\") \
             | (.url + (.steps[] | select(.name == \"Run mathlib_test_executable\") \
               | \"#step:\(.number):1\"))")
           
-          echo "outcome=${OUTCOME}" | tee -a "$GITHUB_OUTPUT"
           echo "mathlib_test_executable_url=${MATHLIB_TEST_EXECUTABLE_URL}" | tee -a "$GITHUB_OUTPUT"
 
       - name: Fetch latest tags (if nightly)
@@ -269,7 +259,7 @@ jobs:
           fi
 
       - name: Post success message for mathlib_test_executable on Zulip
-        if: steps.get-status.outputs.outcome == 'success'
+        if: needs.check-mathlib_test_executable.result == 'success'
         uses: zulip/github-actions-zulip/send-message@e4c8f27c732ba9bd98ac6be0583096dea82feea5 # v1.0.2
         with:
           api-key: ${{ secrets.ZULIP_API_KEY }}
@@ -282,7 +272,7 @@ jobs:
             ✅ mathlib_test_executable [succeeded](${{ steps.get-status.outputs.mathlib_test_executable_url }}) on ${{ github.sha }} (branch: ${{ env.BRANCH_REF }})
 
       - name: Post failure / cancelled message for mathlib_test_executable on Zulip
-        if: steps.get-status.outputs.outcome != 'success'
+        if: needs.check-mathlib_test_executable.result != 'success'
         uses: zulip/github-actions-zulip/send-message@e4c8f27c732ba9bd98ac6be0583096dea82feea5 # v1.0.2
         with:
           api-key: ${{ secrets.ZULIP_API_KEY }}
@@ -292,4 +282,4 @@ jobs:
           type: 'stream'
           topic: 'mathlib test executable failure'
           content: |
-            ❌ mathlib_test_executable [${{ steps.get-status.outputs.outcome }}](${{ steps.get-status.outputs.mathlib_test_executable_url }}) on ${{ github.sha }} (branch: ${{ env.BRANCH_REF }})
+            ❌ mathlib_test_executable [${{ needs.check-mathlib_test_executable.result }}](${{ steps.get-status.outputs.mathlib_test_executable_url }}) on ${{ github.sha }} (branch: ${{ env.BRANCH_REF }})

--- a/.github/workflows/daily.yml
+++ b/.github/workflows/daily.yml
@@ -125,8 +125,8 @@ jobs:
             | (.url + (.steps[] | select(.name == \"Check environments using lean4checker\") \
               | \"#step:\(.number):1\"))")
           
-          echo "outcome=${OUTCOME}" >> "$GITHUB_OUTPUT"
-          echo "lean4checker_url=${LEAN4CHECKER_URL}" >> "$GITHUB_OUTPUT"
+          echo "outcome=${OUTCOME}" | tee -a "$GITHUB_OUTPUT"
+          echo "lean4checker_url=${LEAN4CHECKER_URL}" | tee -a "$GITHUB_OUTPUT"
 
       - name: Fetch latest tags (if nightly)
         if: matrix.branch_type == 'nightly'
@@ -134,7 +134,7 @@ jobs:
           git remote add nightly-testing https://github.com/leanprover-community/mathlib4-nightly-testing.git
           git fetch nightly-testing --tags
           LATEST_TAG=$(git tag | grep -E "${{ env.TAG_PATTERN }}" | sort -r | head -n 1)
-          echo "LATEST_TAG=${LATEST_TAG}" >> "$GITHUB_ENV"
+          echo "LATEST_TAG=${LATEST_TAG}" | tee -a "$GITHUB_ENV"
 
       - name: Set branch ref
         run: |
@@ -249,8 +249,8 @@ jobs:
             | (.url + (.steps[] | select(.name == \"Run mathlib_test_executable\") \
               | \"#step:\(.number):1\"))")
           
-          echo "outcome=${OUTCOME}" >> "$GITHUB_OUTPUT"
-          echo "mathlib_test_executable_url=${MATHLIB_TEST_EXECUTABLE_URL}" >> "$GITHUB_OUTPUT"
+          echo "outcome=${OUTCOME}" | tee -a "$GITHUB_OUTPUT"
+          echo "mathlib_test_executable_url=${MATHLIB_TEST_EXECUTABLE_URL}" | tee -a "$GITHUB_OUTPUT"
 
       - name: Fetch latest tags (if nightly)
         if: matrix.branch_type == 'nightly'
@@ -258,7 +258,7 @@ jobs:
           git remote add nightly-testing https://github.com/leanprover-community/mathlib4-nightly-testing.git
           git fetch nightly-testing --tags
           LATEST_TAG=$(git tag | grep -E "${{ env.TAG_PATTERN }}" | sort -r | head -n 1)
-          echo "LATEST_TAG=${LATEST_TAG}" >> "$GITHUB_ENV"
+          echo "LATEST_TAG=${LATEST_TAG}" | tee -a "$GITHUB_ENV"
 
       - name: Set branch ref
         run: |

--- a/.github/workflows/daily.yml
+++ b/.github/workflows/daily.yml
@@ -33,20 +33,6 @@ jobs:
       - name: Checkout branch or tag
         uses: actions/checkout@1af3b93b6815bc44a9784bd300feb67ff0d1eeb3 # v6.0.0
 
-      # this step needs to be run here while we have `mathlib4` checked out,
-      # or else `gh run view` will try to look for runs in `mathlib4-nightly-testing`
-      - name: Get URLs
-        id: urls
-        env:
-          GH_TOKEN: ${{ github.token }}
-        run: |
-          # adapted from https://cmbuckley.co.uk/blog/2024/04/09/deep-links-to-github-actions-job-logs/
-          lean4checker_url=$(gh run view ${{ github.run_id }} --json jobs --jq '
-            .jobs[] | select(.name == "check-lean4checker (${{ matrix.branch_type }})")
-            | (.url + (.steps[] | select(.name == "Check environments using lean4checker")
-              | "#step:\(.number):1"))')
-          echo "lean4checker_url=$lean4checker_url" | tee -a "$GITHUB_OUTPUT"
-
       - name: Fetch latest tags (if nightly)
         if: matrix.branch_type == 'nightly'
         run: |
@@ -79,7 +65,7 @@ jobs:
           use-mathlib-cache: true
           reinstall-transient-toolchain: true
 
-      - name: Check environments using lean4checker # make sure this name is consistent with "Get URLs"
+      - name: Check environments using lean4checker # make sure this name is consistent with "Get job status and URLs" in the notify job
         id: lean4checker
         continue-on-error: true
         run: |
@@ -110,8 +96,56 @@ jobs:
           # so we explicitly check Batteries as well here.
           lake env lean4checker/.lake/build/bin/lean4checker Batteries Mathlib
 
+  notify-lean4checker:
+    runs-on: ubuntu-latest
+    needs: check-lean4checker
+    if: always()
+    strategy:
+      fail-fast: false
+      matrix:
+        branch_type: [master, nightly]
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@1af3b93b6815bc44a9784bd300feb67ff0d1eeb3 # v6.0.0
+
+      - name: Get job status and URLs
+        id: get-status
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          JOB_NAME="check-lean4checker (${{ matrix.branch_type }})"
+          
+          # Get job outcome
+          OUTCOME=$(gh run view ${{ github.run_id }} --json jobs --jq \
+            ".jobs[] | select(.name == \"$JOB_NAME\") | .conclusion")
+          
+          # Get URL to the specific step
+          LEAN4CHECKER_URL=$(gh run view ${{ github.run_id }} --json jobs --jq \
+            ".jobs[] | select(.name == \"$JOB_NAME\") \
+            | (.url + (.steps[] | select(.name == \"Check environments using lean4checker\") \
+              | \"#step:\(.number):1\"))")
+          
+          echo "outcome=${OUTCOME}" >> "$GITHUB_OUTPUT"
+          echo "lean4checker_url=${LEAN4CHECKER_URL}" >> "$GITHUB_OUTPUT"
+
+      - name: Fetch latest tags (if nightly)
+        if: matrix.branch_type == 'nightly'
+        run: |
+          git remote add nightly-testing https://github.com/leanprover-community/mathlib4-nightly-testing.git
+          git fetch nightly-testing --tags
+          LATEST_TAG=$(git tag | grep -E "${{ env.TAG_PATTERN }}" | sort -r | head -n 1)
+          echo "LATEST_TAG=${LATEST_TAG}" >> "$GITHUB_ENV"
+
+      - name: Set branch ref
+        run: |
+          if [ "${{ matrix.branch_type }}" == "master" ]; then
+            echo "BRANCH_REF=${{ env.DEFAULT_BRANCH }}" >> "$GITHUB_ENV"
+          else
+            echo "BRANCH_REF=${{ env.LATEST_TAG }}" >> "$GITHUB_ENV"
+          fi
+
       - name: Post success message for lean4checker on Zulip
-        if: steps.lean4checker.outcome == 'success'
+        if: steps.get-status.outputs.outcome == 'success'
         uses: zulip/github-actions-zulip/send-message@e4c8f27c732ba9bd98ac6be0583096dea82feea5 # v1.0.2
         with:
           api-key: ${{ secrets.ZULIP_API_KEY }}
@@ -121,10 +155,10 @@ jobs:
           type: 'stream'
           topic: 'lean4checker'
           content: |
-            ✅ lean4checker [succeeded](${{ steps.urls.outputs.lean4checker_url }}) on ${{ github.sha }} (branch: ${{ env.BRANCH_REF }})
+            ✅ lean4checker [succeeded](${{ steps.get-status.outputs.lean4checker_url }}) on ${{ github.sha }} (branch: ${{ env.BRANCH_REF }})
 
       - name: Post failure / cancelled message for lean4checker on Zulip
-        if: steps.lean4checker.outcome == 'failure' || steps.lean4checker.outcome == 'cancelled'
+        if: steps.get-status.outputs.outcome != 'success'
         uses: zulip/github-actions-zulip/send-message@e4c8f27c732ba9bd98ac6be0583096dea82feea5 # v1.0.2
         with:
           api-key: ${{ secrets.ZULIP_API_KEY }}
@@ -134,7 +168,7 @@ jobs:
           type: 'stream'
           topic: 'lean4checker failure'
           content: |
-            ❌ lean4checker [$${{ steps.lean4checker.outcome }}](${{ steps.urls.outputs.lean4checker_url }}) on ${{ github.sha }} (branch: ${{ env.BRANCH_REF }})
+            ❌ lean4checker [${{ steps.get-status.outputs.outcome }}](${{ steps.get-status.outputs.lean4checker_url }}) on ${{ github.sha }} (branch: ${{ env.BRANCH_REF }})
 
   check-mathlib_test_executable:
     runs-on: ubuntu-latest
@@ -147,20 +181,6 @@ jobs:
       # Checkout repository, so that we can fetch tags to decide which branch we want.
       - name: Checkout branch or tag
         uses: actions/checkout@1af3b93b6815bc44a9784bd300feb67ff0d1eeb3 # v6.0.0
-
-      # this step needs to be run here while we have `mathlib4` checked out,
-      # or else `gh run view` will try to look for runs in `mathlib4-nightly-testing`
-      - name: Get URLs
-        id: urls
-        env:
-          GH_TOKEN: ${{ github.token }}
-        run: |
-          # adapted from https://cmbuckley.co.uk/blog/2024/04/09/deep-links-to-github-actions-job-logs/
-          mathlib_test_executable_url=$(gh run view ${{ github.run_id }} --json jobs --jq '
-            .jobs[] | select(.name == "check-lean4checker (${{ matrix.branch_type }})")
-            | (.url + (.steps[] | select(.name == "Run mathlib_test_executable")
-              | "#step:\(.number):1"))')
-          echo "mathlib_test_executable_url=$mathlib_test_executable_url" | tee -a "$GITHUB_OUTPUT"
 
       - name: Fetch latest tags (if nightly)
         if: matrix.branch_type == 'nightly'
@@ -194,14 +214,62 @@ jobs:
           use-mathlib-cache: true
           reinstall-transient-toolchain: true
 
-      - name: Run mathlib_test_executable # make sure this name is consistent with "Get URLs"
+      - name: Run mathlib_test_executable # make sure this name is consistent with "Get job status and URLs" in the notify job
         id: mathlib-test
         continue-on-error: true
         run: |
           lake exe mathlib_test_executable
 
+  notify-mathlib_test_executable:
+    runs-on: ubuntu-latest
+    needs: check-mathlib_test_executable
+    if: always()
+    strategy:
+      fail-fast: false
+      matrix:
+        branch_type: [master, nightly]
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@1af3b93b6815bc44a9784bd300feb67ff0d1eeb3 # v6.0.0
+
+      - name: Get job status and URLs
+        id: get-status
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          JOB_NAME="check-mathlib_test_executable (${{ matrix.branch_type }})"
+          
+          # Get job outcome
+          OUTCOME=$(gh run view ${{ github.run_id }} --json jobs --jq \
+            ".jobs[] | select(.name == \"$JOB_NAME\") | .conclusion")
+          
+          # Get URL to the specific step
+          MATHLIB_TEST_EXECUTABLE_URL=$(gh run view ${{ github.run_id }} --json jobs --jq \
+            ".jobs[] | select(.name == \"$JOB_NAME\") \
+            | (.url + (.steps[] | select(.name == \"Run mathlib_test_executable\") \
+              | \"#step:\(.number):1\"))")
+          
+          echo "outcome=${OUTCOME}" >> "$GITHUB_OUTPUT"
+          echo "mathlib_test_executable_url=${MATHLIB_TEST_EXECUTABLE_URL}" >> "$GITHUB_OUTPUT"
+
+      - name: Fetch latest tags (if nightly)
+        if: matrix.branch_type == 'nightly'
+        run: |
+          git remote add nightly-testing https://github.com/leanprover-community/mathlib4-nightly-testing.git
+          git fetch nightly-testing --tags
+          LATEST_TAG=$(git tag | grep -E "${{ env.TAG_PATTERN }}" | sort -r | head -n 1)
+          echo "LATEST_TAG=${LATEST_TAG}" >> "$GITHUB_ENV"
+
+      - name: Set branch ref
+        run: |
+          if [ "${{ matrix.branch_type }}" == "master" ]; then
+            echo "BRANCH_REF=${{ env.DEFAULT_BRANCH }}" >> "$GITHUB_ENV"
+          else
+            echo "BRANCH_REF=${{ env.LATEST_TAG }}" >> "$GITHUB_ENV"
+          fi
+
       - name: Post success message for mathlib_test_executable on Zulip
-        if: steps.mathlib-test.outcome == 'success'
+        if: steps.get-status.outputs.outcome == 'success'
         uses: zulip/github-actions-zulip/send-message@e4c8f27c732ba9bd98ac6be0583096dea82feea5 # v1.0.2
         with:
           api-key: ${{ secrets.ZULIP_API_KEY }}
@@ -211,10 +279,10 @@ jobs:
           type: 'stream'
           topic: 'mathlib test executable'
           content: |
-            ✅ mathlib_test_executable [succeeded](${{ steps.urls.outputs.mathlib_test_executable_url }}) on ${{ github.sha }} (branch: ${{ env.BRANCH_REF }})
+            ✅ mathlib_test_executable [succeeded](${{ steps.get-status.outputs.mathlib_test_executable_url }}) on ${{ github.sha }} (branch: ${{ env.BRANCH_REF }})
 
       - name: Post failure / cancelled message for mathlib_test_executable on Zulip
-        if: steps.mathlib-test.outcome == 'failure' || steps.mathlib-test.outcome == 'cancelled'
+        if: steps.get-status.outputs.outcome != 'success'
         uses: zulip/github-actions-zulip/send-message@e4c8f27c732ba9bd98ac6be0583096dea82feea5 # v1.0.2
         with:
           api-key: ${{ secrets.ZULIP_API_KEY }}
@@ -224,4 +292,4 @@ jobs:
           type: 'stream'
           topic: 'mathlib test executable failure'
           content: |
-            ❌ mathlib_test_executable [${{ steps.mathlib-test.outcome }}](${{ steps.urls.outputs.mathlib_test_executable_url }}) on ${{ github.sha }} (branch: ${{ env.BRANCH_REF }})
+            ❌ mathlib_test_executable [${{ steps.get-status.outputs.outcome }}](${{ steps.get-status.outputs.mathlib_test_executable_url }}) on ${{ github.sha }} (branch: ${{ env.BRANCH_REF }})


### PR DESCRIPTION
The lean4checker job has been failing in such a way that the runner loses connection with GitHub (see e.g. [the annotations on this page](https://github.com/leanprover-community/mathlib4/actions/runs/20418072968)). When this happens the rest of the steps in the job never get run so we never get a notification about it on Zulip. (cf. [#nightly-testing > lean4checker failure @ 💬](https://leanprover.zulipchat.com/#narrow/channel/428973-nightly-testing/topic/lean4checker.20failure/near/565086478))

To fix this, we move the notification steps into a dependent job which should always run, even if the `check` job brings down the runner.

Along the way we also fix a bug that was causing links to the workflow to be blank for the `mathlib_test_executable` notifications: [#nightly-testing > mathlib test executable @ 💬](https://leanprover.zulipchat.com/#narrow/channel/428973-nightly-testing/topic/mathlib.20test.20executable/near/565085825).

written with help from Claude.

---
