### PR TITLE
[Merged by Bors] -  feat: use new predicate `Meromorphic` in Value Distribution Theory

### DIFF
--- a/Mathlib/Analysis/Complex/ValueDistribution/CharacteristicFunction.lean
+++ b/Mathlib/Analysis/Complex/ValueDistribution/CharacteristicFunction.lean
@@ -61,8 +61,7 @@ The difference between the characteristic functions for the poles of `f` and `f 
 to the difference between the proximity functions.
 -/
 @[simp]
-lemma characteristic_sub_characteristic_eq_proximity_sub_proximity (h : MeromorphicOn f Set.univ)
-    (a₀ : E) :
+lemma characteristic_sub_characteristic_eq_proximity_sub_proximity (h : Meromorphic f) (a₀ : E) :
     characteristic f ⊤ - characteristic (f · - a₀) ⊤ = proximity f ⊤ - proximity (f · - a₀) ⊤ := by
   simp [← Pi.sub_def, characteristic, logCounting_sub_const h]
 
@@ -75,8 +74,8 @@ For `1 ≤ r`, the characteristic function for the zeros of `f * g` is less than
 of the characteristic functions for the zeros of `f` and `g`, respectively.
 -/
 theorem characteristic_mul_zero_le {f₁ f₂ : ℂ → ℂ} {r : ℝ} (hr : 1 ≤ r)
-    (h₁f₁ : MeromorphicOn f₁ Set.univ) (h₂f₁ : ∀ z, meromorphicOrderAt f₁ z ≠ ⊤)
-    (h₁f₂ : MeromorphicOn f₂ Set.univ) (h₂f₂ : ∀ z, meromorphicOrderAt f₂ z ≠ ⊤) :
+    (h₁f₁ : Meromorphic f₁) (h₂f₁ : ∀ z, meromorphicOrderAt f₁ z ≠ ⊤)
+    (h₁f₂ : Meromorphic f₂) (h₂f₂ : ∀ z, meromorphicOrderAt f₂ z ≠ ⊤) :
     characteristic (f₁ * f₂) 0 r ≤ (characteristic f₁ 0 + characteristic f₂ 0) r := by
   simp only [characteristic, Pi.add_apply]
   rw [add_add_add_comm]
@@ -90,8 +89,8 @@ Asymptotically, the characteristic function for the zeros of `f * g` is less tha
 sum of the characteristic functions for the zeros of `f` and `g`, respectively.
 -/
 theorem characteristic_mul_zero_eventuallyLE {f₁ f₂ : ℂ → ℂ}
-    (h₁f₁ : MeromorphicOn f₁ Set.univ) (h₂f₁ : ∀ z, meromorphicOrderAt f₁ z ≠ ⊤)
-    (h₁f₂ : MeromorphicOn f₂ Set.univ) (h₂f₂ : ∀ z, meromorphicOrderAt f₂ z ≠ ⊤) :
+    (h₁f₁ : Meromorphic f₁) (h₂f₁ : ∀ z, meromorphicOrderAt f₁ z ≠ ⊤)
+    (h₁f₂ : Meromorphic f₂) (h₂f₂ : ∀ z, meromorphicOrderAt f₂ z ≠ ⊤) :
     characteristic (f₁ * f₂) 0 ≤ᶠ[Filter.atTop] characteristic f₁ 0 + characteristic f₂ 0 := by
   filter_upwards [Filter.eventually_ge_atTop 1]
   exact fun _ hr ↦ characteristic_mul_zero_le hr h₁f₁ h₂f₁ h₁f₂ h₂f₂
@@ -104,8 +103,8 @@ For `1 ≤ r`, the characteristic function for the poles of `f * g` is less than
 of the characteristic functions for the poles of `f` and `g`, respectively.
 -/
 theorem characteristic_mul_top_le {f₁ f₂ : ℂ → ℂ} {r : ℝ} (hr : 1 ≤ r)
-    (h₁f₁ : MeromorphicOn f₁ Set.univ) (h₂f₁ : ∀ z, meromorphicOrderAt f₁ z ≠ ⊤)
-    (h₁f₂ : MeromorphicOn f₂ Set.univ) (h₂f₂ : ∀ z, meromorphicOrderAt f₂ z ≠ ⊤) :
+    (h₁f₁ : Meromorphic f₁) (h₂f₁ : ∀ z, meromorphicOrderAt f₁ z ≠ ⊤)
+    (h₁f₂ : Meromorphic f₂) (h₂f₂ : ∀ z, meromorphicOrderAt f₂ z ≠ ⊤) :
     characteristic (f₁ * f₂) ⊤ r ≤ (characteristic f₁ ⊤ + characteristic f₂ ⊤) r := by
   simp only [characteristic, Pi.add_apply]
   rw [add_add_add_comm]
@@ -119,8 +118,8 @@ Asymptotically, the characteristic function for the poles of `f * g` is less tha
 sum of the characteristic functions for the poles of `f` and `g`, respectively.
 -/
 theorem characteristic_mul_top_eventuallyLE {f₁ f₂ : ℂ → ℂ}
-    (h₁f₁ : MeromorphicOn f₁ Set.univ) (h₂f₁ : ∀ z, meromorphicOrderAt f₁ z ≠ ⊤)
-    (h₁f₂ : MeromorphicOn f₂ Set.univ) (h₂f₂ : ∀ z, meromorphicOrderAt f₂ z ≠ ⊤) :
+    (h₁f₁ : Meromorphic f₁) (h₂f₁ : ∀ z, meromorphicOrderAt f₁ z ≠ ⊤)
+    (h₁f₂ : Meromorphic f₂) (h₂f₂ : ∀ z, meromorphicOrderAt f₂ z ≠ ⊤) :
     characteristic (f₁ * f₂) ⊤ ≤ᶠ[Filter.atTop] characteristic f₁ ⊤ + characteristic f₂ ⊤ := by
   filter_upwards [Filter.eventually_ge_atTop 1]
   exact fun _ hr ↦ characteristic_mul_top_le hr h₁f₁ h₂f₁ h₁f₂ h₂f₂
@@ -133,7 +132,7 @@ For natural numbers `n`, the characteristic function for the zeros of `f ^ n` eq
 characteristic counting function for the zeros of `f`.
 -/
 @[simp]
-theorem characteristic_pow_zero {f : ℂ → ℂ} {n : ℕ} (hf : MeromorphicOn f Set.univ) :
+theorem characteristic_pow_zero {f : ℂ → ℂ} {n : ℕ} (hf : Meromorphic f) :
     characteristic (f ^ n) 0 = n • characteristic f 0 := by
   simp_all [characteristic]
 
@@ -142,7 +141,7 @@ For natural numbers `n`, the characteristic function for the poles of `f ^ n` eq
 characteristic function for the poles of `f`.
 -/
 @[simp]
-theorem characteristic_pow_top {f : ℂ → ℂ} {n : ℕ} (hf : MeromorphicOn f Set.univ) :
+theorem characteristic_pow_top {f : ℂ → ℂ} {n : ℕ} (hf : Meromorphic f) :
     characteristic (f ^ n) ⊤ = n • characteristic f ⊤ := by
   simp_all [characteristic]
 

--- a/Mathlib/Analysis/Complex/ValueDistribution/CountingFunction.lean
+++ b/Mathlib/Analysis/Complex/ValueDistribution/CountingFunction.lean
@@ -67,7 +67,7 @@ lemma toClosedBall_eval_within {r : ℝ} {z : E} (f : locallyFinsuppWithin (univ
   simp_all [restrict_apply]
 
 @[simp]
-lemma toClosedBall_divisor {r : ℝ} {f : ℂ → ℂ} (h : MeromorphicOn f univ) :
+lemma toClosedBall_divisor {r : ℝ} {f : ℂ → ℂ} (h : Meromorphic f) :
     (divisor f (closedBall 0 |r|)) = (locallyFinsuppWithin.toClosedBall r) (divisor f univ) := by
   simp_all [locallyFinsuppWithin.toClosedBall]
 
@@ -265,16 +265,17 @@ Relation between the logarithmic counting functions of `f` and of `f⁻¹`.
 /--
 Adding an analytic function does not change the logarithmic counting function for the poles.
 -/
-theorem logCounting_add_analyticOn (hf : MeromorphicOn f univ) (hg : AnalyticOn 𝕜 g univ) :
+theorem logCounting_add_analyticOn (hf : Meromorphic f) (hg : AnalyticOn 𝕜 g univ) :
     logCounting (f + g) ⊤ = logCounting f ⊤ := by
   simp only [logCounting, ↓reduceDIte]
-  rw [hf.negPart_divisor_add_of_analyticNhdOn_right (isOpen_univ.analyticOn_iff_analyticOnNhd.1 hg)]
+  rw [hf.meromorphicOn.negPart_divisor_add_of_analyticNhdOn_right
+    (isOpen_univ.analyticOn_iff_analyticOnNhd.1 hg)]
 
 /--
 Special case of `logCounting_add_analyticOn`: Adding a constant does not change the logarithmic
 counting function for the poles.
 -/
-@[simp] theorem logCounting_add_const (hf : MeromorphicOn f univ) :
+@[simp] theorem logCounting_add_const (hf : Meromorphic f) :
     logCounting (f + fun _ ↦ a₀) ⊤ = logCounting f ⊤ := by
   apply logCounting_add_analyticOn hf analyticOn_const
 
@@ -282,7 +283,7 @@ counting function for the poles.
 Special case of `logCounting_add_analyticOn`: Subtracting a constant does not change the logarithmic
 counting function for the poles.
 -/
-@[simp] theorem logCounting_sub_const (hf : MeromorphicOn f univ) :
+@[simp] theorem logCounting_sub_const (hf : Meromorphic f) :
     logCounting (f - fun _ ↦ a₀) ⊤ = logCounting f ⊤ := by
   simpa [sub_eq_add_neg] using logCounting_add_const hf
 
@@ -294,19 +295,20 @@ counting function for the poles.
 For `1 ≤ r`, the logarithmic counting function for the poles of `f + g` is less than or equal to the
 sum of the logarithmic counting functions for the poles of `f` and `g`, respectively.
 -/
-theorem logCounting_add_top_le {f₁ f₂ : 𝕜 → E} {r : ℝ} (h₁f₁ : MeromorphicOn f₁ Set.univ)
-    (h₁f₂ : MeromorphicOn f₂ Set.univ) (hr : 1 ≤ r) :
+theorem logCounting_add_top_le {f₁ f₂ : 𝕜 → E} {r : ℝ} (h₁f₁ : Meromorphic f₁)
+    (h₁f₂ : Meromorphic f₂) (hr : 1 ≤ r) :
     logCounting (f₁ + f₂) ⊤ r ≤ (logCounting f₁ ⊤ + logCounting f₂ ⊤) r := by
   simp only [logCounting, ↓reduceDIte]
   rw [← Function.locallyFinsuppWithin.logCounting.map_add]
-  exact Function.locallyFinsuppWithin.logCounting_le (negPart_divisor_add_le_add h₁f₁ h₁f₂) hr
+  exact Function.locallyFinsuppWithin.logCounting_le
+    (negPart_divisor_add_le_add h₁f₁.meromorphicOn h₁f₂.meromorphicOn) hr
 
 /--
 Asymptotically, the logarithmic counting function for the poles of `f + g` is less than or equal to
 the sum of the logarithmic counting functions for the poles of `f` and `g`, respectively.
 -/
-theorem logCounting_add_top_eventuallyLE {f₁ f₂ : 𝕜 → E} (h₁f₁ : MeromorphicOn f₁ Set.univ)
-    (h₁f₂ : MeromorphicOn f₂ Set.univ) :
+theorem logCounting_add_top_eventuallyLE {f₁ f₂ : 𝕜 → E} (h₁f₁ : Meromorphic f₁)
+    (h₁f₂ : Meromorphic f₂) :
     logCounting (f₁ + f₂) ⊤ ≤ᶠ[Filter.atTop] logCounting f₁ ⊤ + logCounting f₂ ⊤ := by
   filter_upwards [Filter.eventually_ge_atTop 1]
   exact fun _ hr ↦ logCounting_add_top_le h₁f₁ h₁f₂ hr
@@ -316,7 +318,7 @@ For `1 ≤ r`, the logarithmic counting function for the poles of a sum `∑ a �
 equal to the sum of the logarithmic counting functions for the poles of the `f ·`.
 -/
 theorem logCounting_sum_top_le {α : Type*} (s : Finset α) (f : α → 𝕜 → E) {r : ℝ}
-    (h₁f : ∀ a, MeromorphicOn (f a) Set.univ) (hr : 1 ≤ r) :
+    (h₁f : ∀ a, Meromorphic (f a)) (hr : 1 ≤ r) :
     logCounting (∑ a ∈ s, f a) ⊤ r ≤ (∑ a ∈ s, (logCounting (f a) ⊤)) r := by
   classical
   induction s using Finset.induction with
@@ -326,7 +328,7 @@ theorem logCounting_sum_top_le {α : Type*} (s : Finset α) (f : α → 𝕜 →
     rw [Finset.sum_insert ha, Finset.sum_insert ha]
     calc logCounting (f a + ∑ x ∈ s, f x) ⊤ r
       _ ≤ (logCounting (f a) ⊤ + logCounting (∑ x ∈ s, f x) ⊤) r :=
-        logCounting_add_top_le (h₁f a) (MeromorphicOn.sum h₁f) hr
+        logCounting_add_top_le (h₁f a) (Meromorphic.sum h₁f) hr
       _ ≤ (logCounting (f a) ⊤ + ∑ x ∈ s, logCounting (f x) ⊤) r :=
         add_le_add (by trivial) hs
 
@@ -335,7 +337,7 @@ Asymptotically, the logarithmic counting function for the poles of a sum `∑ a 
 or equal to the sum of the logarithmic counting functions for the poles of the `f ·`.
 -/
 theorem logCounting_sum_top_eventuallyLE {α : Type*} (s : Finset α) (f : α → 𝕜 → E)
-    (h₁f : ∀ a, MeromorphicOn (f a) Set.univ) :
+    (h₁f : ∀ a, Meromorphic (f a)) :
     logCounting (∑ a ∈ s, f a) ⊤ ≤ᶠ[Filter.atTop] ∑ a ∈ s, (logCounting (f a) ⊤) := by
   filter_upwards [Filter.eventually_ge_atTop 1]
   exact fun _ hr ↦ logCounting_sum_top_le s f h₁f hr
@@ -357,11 +359,11 @@ Then,
 But `log r` is negative for small `r`.
 -/
 theorem logCounting_mul_zero_le {f₁ f₂ : 𝕜 → 𝕜} {r : ℝ} (hr : 1 ≤ r)
-    (h₁f₁ : MeromorphicOn f₁ Set.univ) (h₂f₁ : ∀ z, meromorphicOrderAt f₁ z ≠ ⊤)
-    (h₁f₂ : MeromorphicOn f₂ Set.univ) (h₂f₂ : ∀ z, meromorphicOrderAt f₂ z ≠ ⊤) :
+    (h₁f₁ : Meromorphic f₁) (h₂f₁ : ∀ z, meromorphicOrderAt f₁ z ≠ ⊤)
+    (h₁f₂ : Meromorphic f₂) (h₂f₂ : ∀ z, meromorphicOrderAt f₂ z ≠ ⊤) :
     logCounting (f₁ * f₂) 0 r ≤ (logCounting f₁ 0 + logCounting f₂ 0) r := by
   simp only [logCounting, WithTop.zero_ne_top, reduceDIte, WithTop.untop₀_zero, sub_zero]
-  rw [divisor_mul h₁f₁ h₁f₂ (fun z _ ↦ h₂f₁ z) (fun z _ ↦ h₂f₂ z),
+  rw [divisor_mul h₁f₁.meromorphicOn h₁f₂.meromorphicOn (fun z _ ↦ h₂f₁ z) (fun z _ ↦ h₂f₂ z),
     ← Function.locallyFinsuppWithin.logCounting.map_add]
   apply Function.locallyFinsuppWithin.logCounting_le _ hr
   apply Function.locallyFinsuppWithin.posPart_add
@@ -373,8 +375,8 @@ Asymptotically, the logarithmic counting function for the zeros of `f * g` is le
 the sum of the logarithmic counting functions for the zeros of `f` and `g`, respectively.
 -/
 theorem logCounting_mul_zero_eventuallyLE {f₁ f₂ : 𝕜 → 𝕜}
-    (h₁f₁ : MeromorphicOn f₁ Set.univ) (h₂f₁ : ∀ z, meromorphicOrderAt f₁ z ≠ ⊤)
-    (h₁f₂ : MeromorphicOn f₂ Set.univ) (h₂f₂ : ∀ z, meromorphicOrderAt f₂ z ≠ ⊤) :
+    (h₁f₁ : Meromorphic f₁) (h₂f₁ : ∀ z, meromorphicOrderAt f₁ z ≠ ⊤)
+    (h₁f₂ : Meromorphic f₂) (h₂f₂ : ∀ z, meromorphicOrderAt f₂ z ≠ ⊤) :
     logCounting (f₁ * f₂) 0 ≤ᶠ[Filter.atTop] logCounting f₁ 0 + logCounting f₂ 0 := by
   filter_upwards [Filter.eventually_ge_atTop 1]
   exact fun _ hr ↦ logCounting_mul_zero_le hr h₁f₁ h₂f₁ h₁f₂ h₂f₂
@@ -387,11 +389,11 @@ For `1 ≤ r`, the logarithmic counting function for the poles of `f * g` is les
 sum of the logarithmic counting functions for the poles of `f` and `g`, respectively.
 -/
 theorem logCounting_mul_top_le {f₁ f₂ : 𝕜 → 𝕜} {r : ℝ} (hr : 1 ≤ r)
-    (h₁f₁ : MeromorphicOn f₁ Set.univ) (h₂f₁ : ∀ z, meromorphicOrderAt f₁ z ≠ ⊤)
-    (h₁f₂ : MeromorphicOn f₂ Set.univ) (h₂f₂ : ∀ z, meromorphicOrderAt f₂ z ≠ ⊤) :
+    (h₁f₁ : Meromorphic f₁) (h₂f₁ : ∀ z, meromorphicOrderAt f₁ z ≠ ⊤)
+    (h₁f₂ : Meromorphic f₂) (h₂f₂ : ∀ z, meromorphicOrderAt f₂ z ≠ ⊤) :
     logCounting (f₁ * f₂) ⊤ r ≤ (logCounting f₁ ⊤ + logCounting f₂ ⊤) r := by
   simp only [logCounting, reduceDIte]
-  rw [divisor_mul h₁f₁ h₁f₂ (fun z _ ↦ h₂f₁ z) (fun z _ ↦ h₂f₂ z),
+  rw [divisor_mul h₁f₁.meromorphicOn h₁f₂.meromorphicOn (fun z _ ↦ h₂f₁ z) (fun z _ ↦ h₂f₂ z),
     ← Function.locallyFinsuppWithin.logCounting.map_add]
   apply Function.locallyFinsuppWithin.logCounting_le _ hr
   apply Function.locallyFinsuppWithin.negPart_add
@@ -403,8 +405,8 @@ Asymptotically, the logarithmic counting function for the zeros of `f * g` is le
 the sum of the logarithmic counting functions for the zeros of `f` and `g`, respectively.
 -/
 theorem logCounting_mul_top_eventuallyLE {f₁ f₂ : 𝕜 → 𝕜}
-    (h₁f₁ : MeromorphicOn f₁ Set.univ) (h₂f₁ : ∀ z, meromorphicOrderAt f₁ z ≠ ⊤)
-    (h₁f₂ : MeromorphicOn f₂ Set.univ) (h₂f₂ : ∀ z, meromorphicOrderAt f₂ z ≠ ⊤) :
+    (h₁f₁ : Meromorphic f₁) (h₂f₁ : ∀ z, meromorphicOrderAt f₁ z ≠ ⊤)
+    (h₁f₂ : Meromorphic f₂) (h₂f₂ : ∀ z, meromorphicOrderAt f₂ z ≠ ⊤) :
     logCounting (f₁ * f₂) ⊤ ≤ᶠ[Filter.atTop] logCounting f₁ ⊤ + logCounting f₂ ⊤ := by
   filter_upwards [Filter.eventually_ge_atTop 1]
   exact fun _ hr ↦ logCounting_mul_top_le hr h₁f₁ h₂f₁ h₁f₂ h₂f₂
@@ -416,17 +418,17 @@ alias logCounting_top_mul_eventually_le := logCounting_mul_top_eventuallyLE
 For natural numbers `n`, the logarithmic counting function for the zeros of `f ^ n` equals `n`
 times the logarithmic counting function for the zeros of `f`.
 -/
-@[simp] theorem logCounting_pow_zero {f : 𝕜 → 𝕜} {n : ℕ} (hf : MeromorphicOn f Set.univ) :
+@[simp] theorem logCounting_pow_zero {f : 𝕜 → 𝕜} {n : ℕ} (hf : Meromorphic f) :
     logCounting (f ^ n) 0 = n • logCounting f 0 := by
-  simp [logCounting, divisor_fun_pow hf n]
+  simp [logCounting, divisor_fun_pow hf.meromorphicOn n]
 
 /--
 For natural numbers `n`, the logarithmic counting function for the poles of `f ^ n` equals `n` times
 the logarithmic counting function for the poles of `f`.
 -/
-@[simp] theorem logCounting_pow_top {f : 𝕜 → 𝕜} {n : ℕ} (hf : MeromorphicOn f Set.univ) :
+@[simp] theorem logCounting_pow_top {f : 𝕜 → 𝕜} {n : ℕ} (hf : Meromorphic f) :
     logCounting (f ^ n) ⊤ = n • logCounting f ⊤ := by
-  simp [logCounting, divisor_pow hf n]
+  simp [logCounting, divisor_pow hf.meromorphicOn n]
 
 end ValueDistribution
 
@@ -445,7 +447,7 @@ This is a reformulation of Jensen's formula of complex analysis. See
 `MeromorphicOn.circleAverage_log_norm` for Jensen's formula in the original context.
 -/
 theorem Function.locallyFinsuppWithin.logCounting_divisor_eq_circleAverage_sub_const {R : ℝ}
-    {f : ℂ → ℂ} (h : MeromorphicOn f ⊤) (hR : R ≠ 0) :
+    {f : ℂ → ℂ} (h : Meromorphic f) (hR : R ≠ 0) :
     locallyFinsuppWithin.logCounting (divisor f ⊤) R =
       circleAverage (log ‖f ·‖) 0 R - log ‖meromorphicTrailingCoeffAt f 0‖ := by
   have h₁f : MeromorphicOn f (closedBall 0 |R|) := by tauto
@@ -461,7 +463,7 @@ Variant of `locallyFinsuppWithin.logCounting_divisor_eq_circleAverage_sub_const`
 `ValueDistribution.logCounting` instead of `locallyFinsuppWithin.logCounting`.
 -/
 theorem ValueDistribution.logCounting_zero_sub_logCounting_top_eq_circleAverage_sub_const {R : ℝ}
-    {f : ℂ → ℂ} (h : MeromorphicOn f ⊤) (hR : R ≠ 0) :
+    {f : ℂ → ℂ} (h : Meromorphic f) (hR : R ≠ 0) :
     (logCounting f 0 - logCounting f ⊤) R =
       circleAverage (log ‖f ·‖) 0 R - log ‖meromorphicTrailingCoeffAt f 0‖ := by
   rw [← locallyFinsuppWithin.logCounting_divisor]

--- a/Mathlib/Analysis/Complex/ValueDistribution/FirstMainTheorem.lean
+++ b/Mathlib/Analysis/Complex/ValueDistribution/FirstMainTheorem.lean
@@ -73,7 +73,7 @@ lemma characteristic_sub_characteristic_inv_of_ne_zero
     rw [MeromorphicOn.circleAverage_log_norm hR hf.meromorphicOn]
     unfold Function.locallyFinsuppWithin.logCounting
     have : (divisor f (closedBall 0 |R|)) = (divisor f Set.univ).toClosedBall R :=
-      (divisor_restrict hf (by tauto)).symm
+      (divisor_restrict hf.meromorphicOn (by tauto)).symm
     simp [this, toClosedBall, restrictMonoidHom, restrict_apply]
 
 /--

--- a/Mathlib/Analysis/Complex/ValueDistribution/FirstMainTheorem.lean
+++ b/Mathlib/Analysis/Complex/ValueDistribution/FirstMainTheorem.lean
@@ -44,7 +44,7 @@ variable {f : ℂ → ℂ} {R : ℝ}
 Helper lemma for the first part of the First Main Theorem: Given a meromorphic function `f`, compute
 difference between the characteristic functions of `f` and of its inverse.
 -/
-lemma characteristic_sub_characteristic_inv (h : MeromorphicOn f ⊤) :
+lemma characteristic_sub_characteristic_inv (h : Meromorphic f) :
     characteristic f ⊤ - characteristic f⁻¹ ⊤ =
       circleAverage (log ‖f ·‖) 0 - (divisor f Set.univ).logCounting := by
   calc characteristic f ⊤ - characteristic f⁻¹ ⊤
@@ -63,14 +63,14 @@ Helper lemma for the first part of the First Main Theorem: Away from zero, the d
 the characteristic functions of `f` and `f⁻¹` equals `log ‖meromorphicTrailingCoeffAt f 0‖`.
 -/
 lemma characteristic_sub_characteristic_inv_of_ne_zero
-    (hf : MeromorphicOn f Set.univ) (hR : R ≠ 0) :
+    (hf : Meromorphic f) (hR : R ≠ 0) :
     characteristic f ⊤ R - characteristic f⁻¹ ⊤ R = log ‖meromorphicTrailingCoeffAt f 0‖ := by
   calc characteristic f ⊤ R - characteristic f⁻¹ ⊤ R
   _ = (characteristic f ⊤ - characteristic f⁻¹ ⊤) R := by simp
   _ = circleAverage (log ‖f ·‖) 0 R - (divisor f Set.univ).logCounting R := by
     rw [characteristic_sub_characteristic_inv hf, Pi.sub_apply]
   _ = log ‖meromorphicTrailingCoeffAt f 0‖ := by
-    rw [MeromorphicOn.circleAverage_log_norm hR (hf.mono_set (by tauto))]
+    rw [MeromorphicOn.circleAverage_log_norm hR hf.meromorphicOn]
     unfold Function.locallyFinsuppWithin.logCounting
     have : (divisor f (closedBall 0 |R|)) = (divisor f Set.univ).toClosedBall R :=
       (divisor_restrict hf (by tauto)).symm
@@ -80,7 +80,7 @@ lemma characteristic_sub_characteristic_inv_of_ne_zero
 Helper lemma for the first part of the First Main Theorem: At 0, the difference between the
 characteristic functions of `f` and `f⁻¹` equals `log ‖f 0‖`.
 -/
-lemma characteristic_sub_characteristic_inv_at_zero (h : MeromorphicOn f Set.univ) :
+lemma characteristic_sub_characteristic_inv_at_zero (h : Meromorphic f) :
     characteristic f ⊤ 0 - characteristic f⁻¹ ⊤ 0 = log ‖f 0‖ := by
   calc characteristic f ⊤ 0 - characteristic f⁻¹ ⊤ 0
   _ = (characteristic f ⊤ - characteristic f⁻¹ ⊤) 0 := by simp
@@ -94,7 +94,7 @@ First part of the First Main Theorem, quantitative version: If `f` is meromorphi
 plane, then the difference between the characteristic functions of `f` and `f⁻¹` is bounded by an
 explicit constant.
 -/
-theorem characteristic_sub_characteristic_inv_le (hf : MeromorphicOn f Set.univ) :
+theorem characteristic_sub_characteristic_inv_le (hf : Meromorphic f) :
     |characteristic f ⊤ R - characteristic f⁻¹ ⊤ R|
       ≤ max |log ‖f 0‖| |log ‖meromorphicTrailingCoeffAt f 0‖| := by
   by_cases h : R = 0
@@ -106,7 +106,7 @@ First part of the First Main Theorem, qualitative version: If `f` is meromorphic
 plane, then the characteristic functions of `f` and `f⁻¹` agree asymptotically up to a bounded
 function.
 -/
-theorem isBigO_characteristic_sub_characteristic_inv (h : MeromorphicOn f ⊤) :
+theorem isBigO_characteristic_sub_characteristic_inv (h : Meromorphic f) :
     (characteristic f ⊤ - characteristic f⁻¹ ⊤) =O[atTop] (1 : ℝ → ℝ) :=
   isBigO_of_le' (c := max |log ‖f 0‖| |log ‖meromorphicTrailingCoeffAt f 0‖|) _
     (fun R ↦ by simpa using characteristic_sub_characteristic_inv_le h (R := R))
@@ -128,13 +128,13 @@ Second part of the First Main Theorem of Value Distribution Theory, quantitative
 meromorphic on the complex plane, then the characteristic functions (for value `⊤`) of `f` and
 `f - a₀` differ at most by `log⁺ ‖a₀‖ + log 2`.
 -/
-theorem abs_characteristic_sub_characteristic_shift_le {r : ℝ} (h : MeromorphicOn f ⊤) :
+theorem abs_characteristic_sub_characteristic_shift_le {r : ℝ} (h : Meromorphic f) :
     |characteristic f ⊤ r - characteristic (f · - a₀) ⊤ r| ≤ log⁺ ‖a₀‖ + log 2 := by
   have h₁f : CircleIntegrable (fun x ↦ log⁺ ‖f x‖) 0 r :=
-    circleIntegrable_posLog_norm_meromorphicOn (fun x a ↦ h x trivial)
+    circleIntegrable_posLog_norm_meromorphicOn h.meromorphicOn
   have h₂f : CircleIntegrable (fun x ↦ log⁺ ‖f x - a₀‖) 0 r := by
     apply circleIntegrable_posLog_norm_meromorphicOn
-    apply MeromorphicOn.sub (fun x a => h x trivial) (MeromorphicOn.const a₀)
+    apply h.meromorphicOn.sub (MeromorphicOn.const a₀)
   rw [← Pi.sub_apply, characteristic_sub_characteristic_eq_proximity_sub_proximity h]
   simp only [proximity, reduceDIte, Pi.sub_apply, ← circleAverage_sub h₁f h₂f]
   apply le_trans abs_circleAverage_le_circleAverage_abs
@@ -157,7 +157,7 @@ Second part of the First Main Theorem of Value Distribution Theory, qualitative 
 meromorphic on the complex plane, then the characteristic functions for the value `⊤` of the
 function `f` and `f - a₀` agree asymptotically up to a bounded function.
 -/
-theorem isBigO_characteristic_sub_characteristic_shift (h : MeromorphicOn f ⊤) :
+theorem isBigO_characteristic_sub_characteristic_shift (h : Meromorphic f) :
     (characteristic f ⊤ - characteristic (f · - a₀) ⊤) =O[atTop] (1 : ℝ → ℝ) :=
   isBigO_of_le' (c := log⁺ ‖a₀‖ + log 2) _
     (fun R ↦ by simpa using abs_characteristic_sub_characteristic_shift_le h)

--- a/Mathlib/Analysis/Complex/ValueDistribution/ProximityFunction.lean
+++ b/Mathlib/Analysis/Complex/ValueDistribution/ProximityFunction.lean
@@ -100,15 +100,15 @@ theorem proximity_inv {f : ℂ → ℂ} : proximity f⁻¹ ⊤ = proximity f 0 :
 For complex-valued `f`, the difference between `proximity f ⊤` and `proximity f⁻¹ ⊤` is the circle
 average of `log ‖f ·‖`.
 -/
-theorem proximity_sub_proximity_inv_eq_circleAverage {f : ℂ → ℂ} (h₁f : MeromorphicOn f ⊤) :
+theorem proximity_sub_proximity_inv_eq_circleAverage {f : ℂ → ℂ} (h₁f : Meromorphic f) :
     proximity f ⊤ - proximity f⁻¹ ⊤ = circleAverage (log ‖f ·‖) 0 := by
   ext R
   simp only [proximity, ↓reduceDIte, Pi.inv_apply, norm_inv, Pi.sub_apply]
   rw [← circleAverage_sub]
   · simp_rw [← posLog_sub_posLog_inv, Pi.sub_def]
-  · apply circleIntegrable_posLog_norm_meromorphicOn (h₁f.mono_set (by tauto))
+  · apply circleIntegrable_posLog_norm_meromorphicOn h₁f.meromorphicOn
   · simp_rw [← norm_inv]
-    apply circleIntegrable_posLog_norm_meromorphicOn (h₁f.inv.mono_set (by tauto))
+    apply circleIntegrable_posLog_norm_meromorphicOn h₁f.inv.meromorphicOn
 
 /-!
 ## Behaviour under Arithmetic Operations
@@ -119,18 +119,19 @@ The proximity function of a sum of functions at `⊤` is less than or equal to t
 proximity functions of the summand, plus `log` of the number of summands.
 -/
 theorem proximity_sum_top_le [NormedSpace ℂ E] {α : Type*} (s : Finset α) (f : α → ℂ → E)
-    (hf : ∀ a, MeromorphicOn (f a) Set.univ) :
+    (hf : ∀ a, Meromorphic (f a)) :
     proximity (∑ a ∈ s, f a) ⊤ ≤ ∑ a ∈ s, (proximity (f a) ⊤) + (fun _ ↦ log s.card) := by
   simp only [proximity_top, Finset.sum_apply]
   intro r
   have h₂f : ∀ i ∈ s, CircleIntegrable (log⁺ ‖f i ·‖) 0 r :=
-    fun i _ ↦ circleIntegrable_posLog_norm_meromorphicOn (fun x _ ↦ hf i x trivial)
+    fun i _ ↦ circleIntegrable_posLog_norm_meromorphicOn (fun x _ ↦ hf i x)
   simp only [Pi.add_apply, Finset.sum_apply]
   calc circleAverage (log⁺ ‖∑ c ∈ s, f c ·‖) 0 r
     _ ≤ circleAverage (∑ c ∈ s, log⁺ ‖f c ·‖ + log s.card) 0 r := by
       apply circleAverage_mono
       · apply circleIntegrable_posLog_norm_meromorphicOn
-        apply (MeromorphicOn.fun_sum (hf ·)).mono_set (by tauto)
+        apply Meromorphic.meromorphicOn
+        fun_prop
       · apply (CircleIntegrable.fun_sum s h₂f).add (circleIntegrable_const _ _ _)
       · intro x hx
         rw [add_comm]
@@ -147,8 +148,8 @@ theorem proximity_sum_top_le [NormedSpace ℂ E] {α : Type*} (s : Finset α) (f
 The proximity function of `f + g` at `⊤` is less than or equal to the sum of the proximity functions
 of `f` and `g`, plus `log 2` (where `2` is the number of summands).
 -/
-theorem proximity_add_top_le [NormedSpace ℂ E] {f₁ f₂ : ℂ → E} (h₁f₁ : MeromorphicOn f₁ Set.univ)
-    (h₁f₂ : MeromorphicOn f₂ Set.univ) :
+theorem proximity_add_top_le [NormedSpace ℂ E] {f₁ f₂ : ℂ → E} (h₁f₁ : Meromorphic f₁)
+    (h₁f₂ : Meromorphic f₂) :
     proximity (f₁ + f₂) ⊤ ≤ (proximity f₁ ⊤) + (proximity f₂ ⊤) + (fun _ ↦ log 2) := by
   simpa using proximity_sum_top_le Finset.univ ![f₁, f₂]
     (fun i ↦ by fin_cases i <;> assumption)
@@ -157,8 +158,7 @@ theorem proximity_add_top_le [NormedSpace ℂ E] {f₁ f₂ : ℂ → E} (h₁f�
 The proximity function `f * g` at `⊤` is less than or equal to the sum of the proximity functions of
 `f` and `g`, respectively.
 -/
-theorem proximity_mul_top_le {f₁ f₂ : ℂ → ℂ} (h₁f₁ : MeromorphicOn f₁ Set.univ)
-    (h₁f₂ : MeromorphicOn f₂ Set.univ) :
+theorem proximity_mul_top_le {f₁ f₂ : ℂ → ℂ} (h₁f₁ : Meromorphic f₁) (h₁f₂ : Meromorphic f₂) :
     proximity (f₁ * f₂) ⊤ ≤ proximity f₁ ⊤ + proximity f₂ ⊤ := by
   calc proximity (f₁ * f₂) ⊤
     _ = circleAverage (fun x ↦ log⁺ (‖f₁ x‖ * ‖f₂ x‖)) 0 := by
@@ -168,16 +168,16 @@ theorem proximity_mul_top_le {f₁ f₂ : ℂ → ℂ} (h₁f₁ : MeromorphicOn
       apply circleAverage_mono
       · simp_rw [← norm_mul]
         apply circleIntegrable_posLog_norm_meromorphicOn
-        exact MeromorphicOn.fun_mul (fun x a ↦ h₁f₁ x (Set.mem_univ _))
-          fun x a ↦ h₁f₂ x (Set.mem_univ _)
-      · apply (circleIntegrable_posLog_norm_meromorphicOn (fun x a ↦ h₁f₁ x (Set.mem_univ _))).add
-          (circleIntegrable_posLog_norm_meromorphicOn (fun x a ↦ h₁f₂ x (Set.mem_univ _)))
+        apply Meromorphic.meromorphicOn
+        fun_prop
+      · apply (circleIntegrable_posLog_norm_meromorphicOn (fun x a ↦ h₁f₁ x)).add
+          (circleIntegrable_posLog_norm_meromorphicOn (fun x a ↦ h₁f₂ x))
       · exact fun _ _ ↦ posLog_mul
     _ = circleAverage (log⁺ ‖f₁ ·‖) 0 + circleAverage (log⁺ ‖f₂ ·‖) 0:= by
       ext r
       apply circleAverage_add
-      · exact circleIntegrable_posLog_norm_meromorphicOn (fun x a ↦ h₁f₁ x (Set.mem_univ _))
-      · exact circleIntegrable_posLog_norm_meromorphicOn (fun x a ↦ h₁f₂ x (Set.mem_univ _))
+      · exact circleIntegrable_posLog_norm_meromorphicOn (fun x a ↦ h₁f₁ x)
+      · exact circleIntegrable_posLog_norm_meromorphicOn (fun x a ↦ h₁f₂ x)
     _ = proximity f₁ ⊤ + proximity f₂ ⊤ := by simp [proximity]
 
 @[deprecated (since := "2025-12-11")] alias proximity_top_mul_le := proximity_mul_top_le
@@ -186,13 +186,12 @@ theorem proximity_mul_top_le {f₁ f₂ : ℂ → ℂ} (h₁f₁ : MeromorphicOn
 The proximity function `f * g` at `0` is less than or equal to the sum of the proximity functions of
 `f` and `g`, respectively.
 -/
-theorem proximity_mul_zero_le {f₁ f₂ : ℂ → ℂ} (h₁f₁ : MeromorphicOn f₁ Set.univ)
-    (h₁f₂ : MeromorphicOn f₂ Set.univ) :
+theorem proximity_mul_zero_le {f₁ f₂ : ℂ → ℂ} (h₁f₁ : Meromorphic f₁) (h₁f₂ : Meromorphic f₂) :
     proximity (f₁ * f₂) 0 ≤ (proximity f₁ 0) + (proximity f₂ 0) := by
   calc proximity (f₁ * f₂) 0
     _ ≤ (proximity f₁⁻¹ ⊤) + (proximity f₂⁻¹ ⊤) := by
       rw [← proximity_inv, mul_inv]
-      apply proximity_mul_top_le (MeromorphicOn.inv_iff.mpr h₁f₁) (MeromorphicOn.inv_iff.mpr h₁f₂)
+      apply proximity_mul_top_le h₁f₁.inv h₁f₂.inv
     _ = (proximity f₁ 0) + (proximity f₂ 0) := by
       rw [proximity_inv, proximity_inv]
 

--- a/Mathlib/Analysis/Meromorphic/Basic.lean
+++ b/Mathlib/Analysis/Meromorphic/Basic.lean
@@ -560,10 +560,6 @@ theorem prod (h : ∀ σ, Meromorphic (F σ)) :
     Meromorphic (∏ n ∈ s, F n) := fun x ↦ MeromorphicAt.prod (h · x)
 
 @[to_fun (attr := fun_prop)]
-lemma inv {f : 𝕜 → 𝕜} (hf : Meromorphic f) :
-    Meromorphic (f⁻¹) := fun x ↦ (hf x).inv
-
-@[to_fun (attr := fun_prop)]
 lemma div {f g : 𝕜 → 𝕜} (hf : Meromorphic f) (hg : Meromorphic g) :
     Meromorphic (f / g) := fun x ↦ (hf x).div (hg x)
 

--- a/Mathlib/Analysis/Meromorphic/Basic.lean
+++ b/Mathlib/Analysis/Meromorphic/Basic.lean
@@ -608,6 +608,10 @@ theorem prod (h : ∀ σ, Meromorphic (F σ)) :
     Meromorphic (∏ n ∈ s, F n) := fun x ↦ MeromorphicAt.prod (h · x)
 
 @[to_fun (attr := fun_prop)]
+lemma inv {f : 𝕜 → 𝕜} (hf : Meromorphic f) :
+    Meromorphic (f⁻¹) := fun x ↦ (hf x).inv
+
+@[to_fun (attr := fun_prop)]
 lemma div {f g : 𝕜 → 𝕜} (hf : Meromorphic f) (hg : Meromorphic g) :
     Meromorphic (f / g) := fun x ↦ (hf x).div (hg x)
 


### PR DESCRIPTION
Following a discussion of Zulip, port the matlib section on Value Distribution Theory to use the new predicate Meromorphic.

[#mathlib4 > Introducing Meromorphic @ 💬](https://leanprover.zulipchat.com/#narrow/channel/287929-mathlib4/topic/Introducing.20.60Meromorphic.60/near/564522177)

---

<!-- Your PR title will become the first line of the commit message.

In this box, the text above the `---` (if not empty) will be appended
to the commit message, and can be used to give additional context or
details. Please leave a blank newline before the `---`, otherwise GitHub
will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

When merging, all the commits will be squashed into a single commit
listing all co-authors.

Co-authors in the squash commit are gathered from two sources:

First, all authors of commits to this PR branch are included. Thus,
one way to add co-authors is to include at least one commit authored by
each co-author among the commits in the pull request. If necessary, you
may create empty commits to indicate co-authorship, using commands like so:

git commit --author="Author Name <author@email.com>" --allow-empty -m "add Author Name as coauthor"

Second, co-authors can also be listed in lines at the very bottom of
the commit message (that is, directly before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines
at the bottom of the commit message (before the `---`, and also before
any "Co-authored-by" lines) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
