### PR TITLE
[Merged by Bors] - feat(Analysis/Complex/Trigonometric): `tan⁻¹ = cot`

### DIFF
--- a/Mathlib/Analysis/Complex/Trigonometric.lean
+++ b/Mathlib/Analysis/Complex/Trigonometric.lean
@@ -416,6 +416,14 @@ theorem tan_mul_cos {x : ℂ} (hx : cos x ≠ 0) : tan x * cos x = sin x := by
   rw [tan_eq_sin_div_cos, div_mul_cancel₀ _ hx]
 
 @[simp]
+theorem tan_inv_eq_cot : (tan x)⁻¹ = cot x :=
+  inv_div ..
+
+@[simp]
+theorem cot_inv_eq_tan : (cot x)⁻¹ = tan x :=
+  inv_div ..
+
+@[simp]
 theorem tan_neg : tan (-x) = -tan x := by simp [tan, neg_div]
 
 theorem tan_conj : tan (conj x) = conj (tan x) := by rw [tan, sin_conj, cos_conj, ← map_div₀, tan]
@@ -601,6 +609,14 @@ nonrec theorem cot_eq_cos_div_sin : cot x = cos x / sin x :=
 
 theorem tan_mul_cos {x : ℝ} (hx : cos x ≠ 0) : tan x * cos x = sin x := by
   rw [tan_eq_sin_div_cos, div_mul_cancel₀ _ hx]
+
+@[simp]
+theorem tan_inv_eq_cot : (tan x)⁻¹ = cot x :=
+  ofReal_injective <| by simp
+
+@[simp]
+theorem cot_inv_eq_tan : (cot x)⁻¹ = tan x :=
+  ofReal_injective <| by simp
 
 @[simp]
 theorem tan_zero : tan 0 = 0 := by simp [tan]


### PR DESCRIPTION
---
[Zulip](https://leanprover.zulipchat.com/#narrow/channel/287929-mathlib4/topic/Reciprocal.20trigonometric.20functions/near/564890210)

I think that `funext` versions `tan⁻¹ = cot` without applying to `x` might also be useful, but they don't seem prevalent in the file so I added just the applied versions.

<!-- Your PR title will become the first line of the commit message.

In this box, the text above the `---` (if not empty) will be appended
to the commit message, and can be used to give additional context or
details. Please leave a blank newline before the `---`, otherwise GitHub
will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

When merging, all the commits will be squashed into a single commit
listing all co-authors.

Co-authors in the squash commit are gathered from two sources:

First, all authors of commits to this PR branch are included. Thus,
one way to add co-authors is to include at least one commit authored by
each co-author among the commits in the pull request. If necessary, you
may create empty commits to indicate co-authorship, using commands like so:

git commit --author="Author Name <author@email.com>" --allow-empty -m "add Author Name as coauthor"

Second, co-authors can also be listed in lines at the very bottom of
the commit message (that is, directly before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines
at the bottom of the commit message (before the `---`, and also before
any "Co-authored-by" lines) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
