### PR TITLE
[Merged by Bors] - chore: reduce reliance on Nat.card definition

### DIFF
--- a/Mathlib/FieldTheory/CardinalEmb.lean
+++ b/Mathlib/FieldTheory/CardinalEmb.lean
@@ -191,7 +191,7 @@ instance (i : ι) : FiniteDimensional (E⟮<i⟯) (E⟮<i⟯⟮b (φ i)⟯) :=
   adjoin.finiteDimensional ((Algebra.IsAlgebraic.tower_top (K := F) _).isAlgebraic _).isIntegral
 
 theorem deg_lt_aleph0 (i : ι) : #(X i) < ℵ₀ :=
-  (toNat_ne_zero.mp (Field.instNeZeroFinSepDegree (E⟮<i⟯) <| E⟮<i⟯⟮b (φ i)⟯).out).2
+  lt_aleph0_of_finite _
 
 open WithTop in
 /-- Extend the family `E⟮<i⟯, i : ι` by adjoining a top element. -/

--- a/Mathlib/FieldTheory/SeparableDegree.lean
+++ b/Mathlib/FieldTheory/SeparableDegree.lean
@@ -169,10 +169,8 @@ theorem finSepDegree_eq_of_equiv (i : E ≃ₐ[F] K) :
 
 @[simp]
 theorem finSepDegree_self : finSepDegree F F = 1 := by
-  have : Cardinal.mk (Emb F F) = 1 := le_antisymm
-    (Cardinal.le_one_iff_subsingleton.2 AlgHom.subsingleton)
-    (Cardinal.one_le_iff_ne_zero.2 <| Cardinal.mk_ne_zero _)
-  rw [finSepDegree, Nat.card, this, Cardinal.one_toNat]
+  rw [finSepDegree, Nat.card_eq_one_iff_unique]
+  constructor <;> infer_instance
 
 end Field
 

--- a/Mathlib/GroupTheory/Commensurable.lean
+++ b/Mathlib/GroupTheory/Commensurable.lean
@@ -82,8 +82,8 @@ theorem equivalence : Equivalence (@Commensurable G _) :=
 
 theorem commensurable_conj {H K : Subgroup G} (g : ConjAct G) :
     Commensurable H K ↔ Commensurable (g • H) (g • K) :=
-  and_congr (not_iff_not.mpr (Eq.congr_left (Cardinal.toNat_congr (quotConjEquiv H K g))))
-    (not_iff_not.mpr (Eq.congr_left (Cardinal.toNat_congr (quotConjEquiv K H g))))
+  and_congr (not_iff_not.mpr (Eq.congr_left (Nat.card_congr (quotConjEquiv H K g))))
+    (not_iff_not.mpr (Eq.congr_left (Nat.card_congr (quotConjEquiv K H g))))
 
 /-- Alias for the forward direction of `commensurable_conj` to allow dot-notation -/
 theorem conj {H K : Subgroup G} (h : Commensurable H K) (g : ConjAct G) :

--- a/Mathlib/GroupTheory/GroupAction/SubMulAction/OfStabilizer.lean
+++ b/Mathlib/GroupTheory/GroupAction/SubMulAction/OfStabilizer.lean
@@ -93,11 +93,11 @@ alias Enat_card_ofStabilizer_eq_add_one := ENat_card_ofStabilizer_add_one_eq
 @[to_additive]
 lemma nat_card_ofStabilizer_add_one_eq [Finite α] (a : α) :
     Nat.card (ofStabilizer G a) + 1 = Nat.card α := by
-  dsimp only [Nat.card]
-  rw [← Cardinal.mk_sum_compl {a},
-    Cardinal.toNat_add Cardinal.mk_lt_aleph0 Cardinal.mk_lt_aleph0]
-  simp only [Cardinal.mk_fintype, Fintype.card_unique, Nat.cast_one, map_one, add_comm]
-  congr
+  classical
+  let := Fintype.ofFinite α
+  rw [Nat.subtype_card {a}ᶜ, ← Finset.card_singleton a, Finset.card_compl_add_card,
+    Nat.card_eq_fintype_card]
+  simp [mem_ofStabilizer_iff]
 
 @[deprecated (since := "2025-10-03")]
 alias nat_card_ofStabilizer_eq_add_one := nat_card_ofStabilizer_add_one_eq

--- a/Mathlib/GroupTheory/Index.lean
+++ b/Mathlib/GroupTheory/Index.lean
@@ -73,7 +73,7 @@ theorem index_comap_of_surjective {f : G' →* G} (hf : Function.Surjective f) :
       QuotientGroup.leftRel (H.comap f) x y ↔ QuotientGroup.leftRel H (f x) (f y) := by
     simp only [QuotientGroup.leftRel_apply]
     exact fun x y => iff_of_eq (congr_arg (· ∈ H) (by rw [f.map_mul, f.map_inv]))
-  refine Cardinal.toNat_congr (Equiv.ofBijective (Quotient.map' f fun x y => (key x y).mp) ⟨?_, ?_⟩)
+  refine Nat.card_congr (Equiv.ofBijective (Quotient.map' f fun x y => (key x y).mp) ⟨?_, ?_⟩)
   · simp_rw [← Quotient.eq''] at key
     refine Quotient.ind' fun x => ?_
     refine Quotient.ind' fun y => ?_
@@ -111,9 +111,9 @@ theorem relIndex_map_map (f : G →* G') (H K : Subgroup G) :
 variable {H K L}
 
 @[to_additive relIndex_mul_index]
-theorem relIndex_mul_index (h : H ≤ K) : H.relIndex K * K.index = H.index :=
-  ((mul_comm _ _).trans (Cardinal.toNat_mul _ _).symm).trans
-    (congr_arg Cardinal.toNat (Equiv.cardinal_eq (quotientEquivProdOfLE h))).symm
+theorem relIndex_mul_index (h : H ≤ K) : H.relIndex K * K.index = H.index := by
+  rw [mul_comm]
+  simp_rw [relIndex, index, ← Nat.card_prod, Nat.card_congr <| quotientEquivProdOfLE h]
 
 @[deprecated (since := "2025-08-12")] alias relindex_mul_index := relIndex_mul_index
 
@@ -288,7 +288,7 @@ theorem index_top : (⊤ : Subgroup G).index = 1 :=
 
 @[to_additive (attr := simp)]
 theorem index_bot : (⊥ : Subgroup G).index = Nat.card G :=
-  Cardinal.toNat_congr QuotientGroup.quotientBot.toEquiv
+  Nat.card_congr QuotientGroup.quotientBot.toEquiv
 
 @[to_additive (attr := simp)]
 theorem relIndex_top_left : (⊤ : Subgroup G).relIndex H = 1 :=

--- a/Mathlib/GroupTheory/SchurZassenhaus.lean
+++ b/Mathlib/GroupTheory/SchurZassenhaus.lean
@@ -279,15 +279,14 @@ theorem exists_right_complement'_of_coprime {N : Subgroup G} [N.Normal]
     rw [hN]
     exact ⟨⊥, isComplement'_top_bot⟩
   by_cases hN2 : N.index = 0
-  · rw [hN2, Nat.coprime_zero_right] at hN
-    haveI := (Cardinal.toNat_eq_one_iff_unique.mp hN).1
+  · rw [hN2, Nat.coprime_zero_right, Nat.card_eq_one_iff_unique] at hN
+    have := hN.1
     rw [N.eq_bot_of_subsingleton]
     exact ⟨⊤, isComplement'_bot_top⟩
-  have hN3 : Nat.card G ≠ 0 := by
+  have hN3 : Finite G := by
+    apply Nat.finite_of_card_ne_zero
     rw [← N.card_mul_index]
     exact mul_ne_zero hN1 hN2
-  haveI := (Cardinal.lt_aleph0_iff_fintype.mp
-    (lt_of_not_ge (mt Cardinal.toNat_apply_of_aleph0_le hN3))).some
   exact exists_right_complement'_of_coprime_aux' rfl hN
 
 /-- **Schur-Zassenhaus** for normal subgroups:


### PR DESCRIPTION
The new proofs don't rely on Nat.card being defined in terms of cardinals, and are cleaner anyway.


---
<!-- Your PR title will become the first line of the commit message.

In this box, the text above the `---` (if not empty) will be appended
to the commit message, and can be used to give additional context or
details. Please leave a blank newline before the `---`, otherwise GitHub
will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

When merging, all the commits will be squashed into a single commit
listing all co-authors.

Co-authors in the squash commit are gathered from two sources:

First, all authors of commits to this PR branch are included. Thus,
one way to add co-authors is to include at least one commit authored by
each co-author among the commits in the pull request. If necessary, you
may create empty commits to indicate co-authorship, using commands like so:

git commit --author="Author Name <author@email.com>" --allow-empty -m "add Author Name as coauthor"

Second, co-authors can also be listed in lines at the very bottom of
the commit message (that is, directly before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines
at the bottom of the commit message (before the `---`, and also before
any "Co-authored-by" lines) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
