### PR TITLE
[Merged by Bors] - feat(LinearAlgebra/Transvection): relax commutativity assumption

### DIFF
--- a/Mathlib/LinearAlgebra/Transvection.lean
+++ b/Mathlib/LinearAlgebra/Transvection.lean
@@ -38,7 +38,7 @@ namespace LinearMap
 
 open Module
 
-variable {R V : Type*} [CommSemiring R] [AddCommMonoid V] [Module R V]
+variable {R V : Type*} [Semiring R] [AddCommMonoid V] [Module R V]
 
 /-- The transvection associated with a linear form `f` and a vector `v`.
 
@@ -46,8 +46,8 @@ NB. In mathematics, these linear maps are only called “transvections” when `
 See also `Module.preReflection` for a similar definition, up to a sign. -/
 def transvection (f : Dual R V) (v : V) : V →ₗ[R] V where
   toFun x := x + f x • v
-  map_add' x y := by simp only [map_add]; module
-  map_smul' r x := by simp only [map_smul, RingHom.id_apply, smul_eq_mul]; module
+  map_add' x y := by simp only [map_add, add_smul]; abel
+  map_smul' r x := by simp only [map_smul, RingHom.id_apply, smul_eq_mul, mul_smul, smul_add]
 
 namespace transvection
 
@@ -57,8 +57,9 @@ theorem apply (f : Dual R V) (v x : V) :
 
 theorem comp_of_left_eq_apply {f : Dual R V} {v w : V} {x : V} (hw : f w = 0) :
     transvection f v (transvection f w x) = transvection f (v + w) x := by
-  simp only [transvection, coe_mk, AddHom.coe_mk, map_add, map_smul, hw, smul_add]
-  module
+  simp only [transvection, coe_mk, AddHom.coe_mk, map_add, map_smul,
+    hw, smul_add, zero_smul, smul_zero]
+  abel
 
 theorem comp_of_left_eq {f : Dual R V} {v w : V} (hw : f w = 0) :
     (transvection f v) ∘ₗ (transvection f w) = transvection f (v + w) := by
@@ -66,8 +67,9 @@ theorem comp_of_left_eq {f : Dual R V} {v w : V} (hw : f w = 0) :
 
 theorem comp_of_right_eq_apply {f g : Dual R V} {v : V} {x : V} (hf : f v = 0) :
     (transvection f v) (transvection g v x) = transvection (f + g) v x := by
-  simp only [transvection, coe_mk, AddHom.coe_mk, map_add, map_smul, hf, add_apply]
-  module
+  simp only [transvection, coe_mk, AddHom.coe_mk, map_add, map_smul,
+    hf, add_apply, zero_smul, add_smul, smul_add, smul_zero]
+  abel
 
 theorem comp_of_right_eq {f g : Dual R V} {v : V} (hf : f v = 0) :
     (transvection f v) ∘ₗ (transvection g v) = transvection (f + g) v := by
@@ -86,6 +88,7 @@ theorem of_right_eq_zero (f : Dual R V) :
   simp [transvection]
 
 theorem eq_id_of_finrank_le_one
+    {R V : Type*} [CommSemiring R] [AddCommMonoid V] [Module R V]
     [Free R V] [Module.Finite R V] [StrongRankCondition R]
     {f : Dual R V} {v : V} (hfv : f v = 0) (h1 : finrank R V ≤ 1) :
     transvection f v = LinearMap.id := by
@@ -111,7 +114,7 @@ theorem congr {W : Type*} [AddCommMonoid W] [Module R W]
 
 end LinearMap.transvection
 
-variable {R V : Type*} [CommRing R] [AddCommGroup V] [Module R V]
+variable {R V : Type*} [Ring R] [AddCommGroup V] [Module R V]
 
 namespace LinearEquiv
 
@@ -185,7 +188,8 @@ namespace LinearMap.transvection
 
 open LinearMap LinearEquiv Module
 
-variable {A : Type*} [CommRing A] [Algebra R A]
+variable {R V : Type*} [CommRing R] [AddCommGroup V] [Module R V]
+  {A : Type*} [CommRing A] [Algebra R A]
 
 theorem baseChange (f : Dual R V) (v : V) :
     (transvection f v).baseChange A = transvection (f.baseChange A) (1 ⊗ₜ[R] v) := by


### PR DESCRIPTION
Relax the commutativity assumption on the base ring for a transvection. 
Only one lemma needs commutativity.
The proofs are essentially unchanged, except that the `module` tactic doesn't work anymore,
and its uses are replaced by the tactic `abel`, after preliminary reductions.

---
<!-- Your PR title will become the first line of the commit message.

In this box, the text above the `---` (if not empty) will be appended
to the commit message, and can be used to give additional context or
details. Please leave a blank newline before the `---`, otherwise GitHub
will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

When merging, all the commits will be squashed into a single commit
listing all co-authors.

Co-authors in the squash commit are gathered from two sources:

First, all authors of commits to this PR branch are included. Thus,
one way to add co-authors is to include at least one commit authored by
each co-author among the commits in the pull request. If necessary, you
may create empty commits to indicate co-authorship, using commands like so:

git commit --author="Author Name <author@email.com>" --allow-empty -m "add Author Name as coauthor"

Second, co-authors can also be listed in lines at the very bottom of
the commit message (that is, directly before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines
at the bottom of the commit message (before the `---`, and also before
any "Co-authored-by" lines) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
