### PR TITLE
[Merged by Bors] - chore(Order/Synonym): use `to_dual`

### DIFF
--- a/Mathlib/Order/Synonym.lean
+++ b/Mathlib/Order/Synonym.lean
@@ -61,19 +61,10 @@ def toDual : α ≃ αᵒᵈ :=
 def ofDual : αᵒᵈ ≃ α :=
   Equiv.refl _
 
-@[simp]
-theorem toDual_symm_eq : (@toDual α).symm = ofDual := rfl
-
-@[simp]
-theorem ofDual_symm_eq : (@ofDual α).symm = toDual := rfl
-
-@[simp]
-theorem toDual_ofDual (a : αᵒᵈ) : toDual (ofDual a) = a :=
-  rfl
-
-@[simp]
-theorem ofDual_toDual (a : α) : ofDual (toDual a) = a :=
-  rfl
+@[simp] theorem toDual_symm_eq : (@toDual α).symm = ofDual := rfl
+@[simp] theorem ofDual_symm_eq : (@ofDual α).symm = toDual := rfl
+@[simp] theorem toDual_ofDual (a : αᵒᵈ) : toDual (ofDual a) = a := rfl
+@[simp] theorem ofDual_toDual (a : α) : ofDual (toDual a) = a := rfl
 
 @[simp] theorem toDual_trans_ofDual : (toDual (α := α)).trans ofDual = Equiv.refl _ := rfl
 @[simp] theorem ofDual_trans_toDual : (ofDual (α := α)).trans toDual = Equiv.refl _ := rfl
@@ -81,59 +72,40 @@ theorem ofDual_toDual (a : α) : ofDual (toDual a) = a :=
 @[simp] theorem ofDual_comp_toDual : (ofDual (α := α)) ∘ toDual = id := rfl
 
 theorem toDual_inj {a b : α} : toDual a = toDual b ↔ a = b := by simp
-
 theorem ofDual_inj {a b : αᵒᵈ} : ofDual a = ofDual b ↔ a = b := by simp
 
 @[ext] lemma ext {a b : αᵒᵈ} (h : ofDual a = ofDual b) : a = b := h
 
-@[simp]
-theorem toDual_le_toDual [LE α] {a b : α} : toDual a ≤ toDual b ↔ b ≤ a :=
-  Iff.rfl
+@[to_dual self, simp]
+theorem toDual_le_toDual [LE α] {a b : α} : toDual a ≤ toDual b ↔ b ≤ a := .rfl
 
-@[simp]
-theorem toDual_lt_toDual [LT α] {a b : α} : toDual a < toDual b ↔ b < a :=
-  Iff.rfl
+@[to_dual self, simp]
+theorem toDual_lt_toDual [LT α] {a b : α} : toDual a < toDual b ↔ b < a := .rfl
 
-@[simp]
-theorem ofDual_le_ofDual [LE α] {a b : αᵒᵈ} : ofDual a ≤ ofDual b ↔ b ≤ a :=
-  Iff.rfl
+@[to_dual self, simp]
+theorem ofDual_le_ofDual [LE α] {a b : αᵒᵈ} : ofDual a ≤ ofDual b ↔ b ≤ a := .rfl
 
-@[simp]
-theorem ofDual_lt_ofDual [LT α] {a b : αᵒᵈ} : ofDual a < ofDual b ↔ b < a :=
-  Iff.rfl
+@[to_dual self, simp]
+theorem ofDual_lt_ofDual [LT α] {a b : αᵒᵈ} : ofDual a < ofDual b ↔ b < a := .rfl
 
-theorem le_toDual [LE α] {a : αᵒᵈ} {b : α} : a ≤ toDual b ↔ b ≤ ofDual a :=
-  Iff.rfl
+@[to_dual toDual_le]
+theorem le_toDual [LE α] {a : αᵒᵈ} {b : α} : a ≤ toDual b ↔ b ≤ ofDual a := .rfl
 
-theorem lt_toDual [LT α] {a : αᵒᵈ} {b : α} : a < toDual b ↔ b < ofDual a :=
-  Iff.rfl
-
-theorem toDual_le [LE α] {a : α} {b : αᵒᵈ} : toDual a ≤ b ↔ ofDual b ≤ a :=
-  Iff.rfl
-
-theorem toDual_lt [LT α] {a : α} {b : αᵒᵈ} : toDual a < b ↔ ofDual b < a :=
-  Iff.rfl
+@[to_dual toDual_lt]
+theorem lt_toDual [LT α] {a : αᵒᵈ} {b : α} : a < toDual b ↔ b < ofDual a := .rfl
 
 /-- Recursor for `αᵒᵈ`. -/
 @[elab_as_elim]
 protected def rec {motive : αᵒᵈ → Sort*} (toDual : ∀ a : α, motive (toDual a)) :
     ∀ a : αᵒᵈ, motive a := toDual
 
-@[simp]
-protected theorem «forall» {p : αᵒᵈ → Prop} : (∀ a, p a) ↔ ∀ a, p (toDual a) :=
-  Iff.rfl
+@[simp] protected theorem «forall» {p : αᵒᵈ → Prop} : (∀ a, p a) ↔ ∀ a, p (toDual a) := .rfl
+@[simp] protected theorem «exists» {p : αᵒᵈ → Prop} : (∃ a, p a) ↔ ∃ a, p (toDual a) := .rfl
 
-@[simp]
-protected theorem «exists» {p : αᵒᵈ → Prop} : (∃ a, p a) ↔ ∃ a, p (toDual a) :=
-  Iff.rfl
-
-alias ⟨_, _root_.LE.le.dual⟩ := toDual_le_toDual
-
-alias ⟨_, _root_.LT.lt.dual⟩ := toDual_lt_toDual
-
-alias ⟨_, _root_.LE.le.ofDual⟩ := ofDual_le_ofDual
-
-alias ⟨_, _root_.LT.lt.ofDual⟩ := ofDual_lt_ofDual
+@[to_dual self] alias ⟨_, _root_.LE.le.dual⟩ := toDual_le_toDual
+@[to_dual self] alias ⟨_, _root_.LT.lt.dual⟩ := toDual_lt_toDual
+@[to_dual self] alias ⟨_, _root_.LE.le.ofDual⟩ := ofDual_le_ofDual
+@[to_dual self] alias ⟨_, _root_.LT.lt.ofDual⟩ := ofDual_lt_ofDual
 
 end OrderDual
 


### PR DESCRIPTION
---
<!-- Your PR title will become the first line of the commit message.

In this box, the text above the `---` (if not empty) will be appended
to the commit message, and can be used to give additional context or
details. Please leave a blank newline before the `---`, otherwise GitHub
will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

When merging, all the commits will be squashed into a single commit
listing all co-authors.

Co-authors in the squash commit are gathered from two sources:

First, all authors of commits to this PR branch are included. Thus,
one way to add co-authors is to include at least one commit authored by
each co-author among the commits in the pull request. If necessary, you
may create empty commits to indicate co-authorship, using commands like so:

git commit --author="Author Name <author@email.com>" --allow-empty -m "add Author Name as coauthor"

Second, co-authors can also be listed in lines at the very bottom of
the commit message (that is, directly before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines
at the bottom of the commit message (before the `---`, and also before
any "Co-authored-by" lines) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

...plus some trivial style improvements.

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
