### PR TITLE
[Merged by Bors] - doc(Tactics): fix file refs

### DIFF
--- a/Mathlib/Tactic/CategoryTheory/Coherence/Normalize.lean
+++ b/Mathlib/Tactic/CategoryTheory/Coherence/Normalize.lean
@@ -13,7 +13,7 @@ public meta import Mathlib.Tactic.CategoryTheory.Coherence.Datatypes
 
 This file provides a function that normalizes 2-morphisms in bicategories. The function also
 used to normalize morphisms in monoidal categories. This is used in the string diagram widget given
-in `Mathlib/Tactic/StringDiagram.lean`, as well as `monoidal` and `bicategory` tactics.
+in `Mathlib/Tactic/Widget/StringDiagram.lean`, as well as `monoidal` and `bicategory` tactics.
 
 We say that the 2-morphism `η` in a bicategory is in normal form if
 1. `η` is of the form `α₀ ≫ η₀ ≫ α₁ ≫ η₁ ≫ ... αₘ ≫ ηₘ ≫ αₘ₊₁` where each `αᵢ` is a

--- a/Mathlib/Tactic/NormNum/PowMod.lean
+++ b/Mathlib/Tactic/NormNum/PowMod.lean
@@ -14,7 +14,8 @@ These expressions can often be evaluated efficiently in cases where first evalua
 then reducing mod `m` is not feasible. We provide a function `evalNatPowMod` which is used by the
 `reduce_mod_char` tactic to efficiently evaluate powers in rings with positive characteristic.
 
-The approach taken here is identical to (and copied from) the development in `NormNum/Pow.lean`.
+The approach taken here is identical to (and copied from) the development in
+`Mathlib/Tactic/NormNum/Pow.lean`.
 
 ## TODO
 

--- a/Mathlib/Tactic/TermCongr.lean
+++ b/Mathlib/Tactic/TermCongr.lean
@@ -108,7 +108,7 @@ We need to decouple these to support letting the proof's elaboration be deferred
 we know whether we want an iff, eq, or heq, while also allowing it to choose
 to elaborate as an iff, eq, or heq.
 Later, the congruence generator handles any discrepancies.
-See `Mathlib/Tactic/TermCongr/CongrResult.lean`. -/
+See `CongrResult` below. -/
 @[reducible, nolint unusedArguments, expose]
 def cHole {α : Sort u} (val : α) {p : Prop} (_pf : p) : α := val
 


### PR DESCRIPTION
Fix some stale documentation file refs.

---
<!-- Your PR title will become the first line of the commit message.

In this box, the text above the `---` (if not empty) will be appended
to the commit message, and can be used to give additional context or
details. Please leave a blank newline before the `---`, otherwise GitHub
will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

When merging, all the commits will be squashed into a single commit
listing all co-authors.

Co-authors in the squash commit are gathered from two sources:

First, all authors of commits to this PR branch are included. Thus,
one way to add co-authors is to include at least one commit authored by
each co-author among the commits in the pull request. If necessary, you
may create empty commits to indicate co-authorship, using commands like so:

git commit --author="Author Name <author@email.com>" --allow-empty -m "add Author Name as coauthor"

Second, co-authors can also be listed in lines at the very bottom of
the commit message (that is, directly before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines
at the bottom of the commit message (before the `---`, and also before
any "Co-authored-by" lines) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
