### PR TITLE
[Merged by Bors] - doc(LinearAlgebra): fix file refs

### DIFF
--- a/Mathlib/LinearAlgebra/Dimension/FreeAndStrongRankCondition.lean
+++ b/Mathlib/LinearAlgebra/Dimension/FreeAndStrongRankCondition.lean
@@ -13,9 +13,9 @@ public import Mathlib.LinearAlgebra.Dimension.Subsingleton
 # Some results on free modules over rings satisfying strong rank condition
 
 This file contains some results on free modules over rings satisfying strong rank condition.
-Most of them are generalized from the same result assuming the base ring being division ring,
+Most of them are generalized from the same result assuming the base ring being a division ring,
 and are moved from the files `Mathlib/LinearAlgebra/Dimension/DivisionRing.lean`
-and `Mathlib/LinearAlgebra/FiniteDimensional.lean`.
+and `Mathlib/LinearAlgebra/FiniteDimensional/Basic.lean`.
 
 -/
 

--- a/Mathlib/LinearAlgebra/FiniteDimensional/Basic.lean
+++ b/Mathlib/LinearAlgebra/FiniteDimensional/Basic.lean
@@ -20,7 +20,7 @@ of linear maps on such spaces.
 Preservation of finite-dimensionality and formulas for the dimension are given for
 - submodules (`FiniteDimensional.finiteDimensional_submodule`)
 - quotients (for the dimension of a quotient, see `Submodule.finrank_quotient_add_finrank` in
-  `Mathlib/LinearAlgebra/FiniteDimensional.lean`)
+  `Mathlib/LinearAlgebra/Dimension/RankNullity.lean`)
 - linear equivs, in `LinearEquiv.finiteDimensional`
 
 Basic properties of linear maps of a finite-dimensional vector space are given. Notably, the
@@ -32,8 +32,9 @@ and `LinearMap.comp_eq_id_comm`.
 
 You should not assume that there has been any effort to state lemmas as generally as possible.
 
-Plenty of the results hold for general fg modules or Noetherian modules, and they can be found in
-`Mathlib/LinearAlgebra/FreeModule/Finite/Rank.lean` and `Mathlib/RingTheory/Noetherian.lean`.
+Plenty of the results hold for general finitely generated modules (see
+`Mathlib/RingTheory/Finiteness/Basic.lean`) or Noetherian modules (see
+`Mathlib/RingTheory/Noetherian/Basic.lean`).
 -/
 
 @[expose] public section

--- a/Mathlib/LinearAlgebra/FiniteDimensional/Defs.lean
+++ b/Mathlib/LinearAlgebra/FiniteDimensional/Defs.lean
@@ -47,7 +47,7 @@ We make use of `finrank`, the dimension of a finite-dimensional space, returning
 opposed to `Module.rank`, which returns a `Cardinal`. When the space has infinite dimension, its
 `finrank` is by convention set to `0`. `finrank` is not defined using `FiniteDimensional`.
 For basic results that do not need the `FiniteDimensional` class, import
-`Mathlib/LinearAlgebra/Finrank.lean`.
+`Mathlib/LinearAlgebra/Dimension/Finrank.lean`.
 
 Preservation of finite-dimensionality and formulas for the dimension are given for
 - submodules (`FiniteDimensional.finiteDimensional_submodule`)
@@ -57,8 +57,9 @@ Preservation of finite-dimensionality and formulas for the dimension are given f
 
 You should not assume that there has been any effort to state lemmas as generally as possible.
 
-Plenty of the results hold for general fg modules or Noetherian modules, and they can be found in
-`Mathlib/LinearAlgebra/FreeModule/Finite/Rank.lean` and `Mathlib/RingTheory/Noetherian.lean`.
+Plenty of the results hold for general finitely generated modules (see
+`Mathlib/RingTheory/Finiteness/Basic.lean`) or Noetherian modules (see
+`Mathlib/RingTheory/Noetherian/Basic.lean`).
 -/
 
 @[expose] public section

--- a/Mathlib/LinearAlgebra/InvariantBasisNumber.lean
+++ b/Mathlib/LinearAlgebra/InvariantBasisNumber.lean
@@ -40,7 +40,7 @@ It is also useful to consider the following stronger conditions:
 
 ## Instances
 
-- `IsNoetherianRing.orzechProperty` (defined in `Mathlib/RingTheory/Noetherian.lean`) :
+- `IsNoetherianRing.orzechProperty` (defined in `Mathlib/RingTheory/Noetherian/Orzech.lean`) :
   any left-Noetherian ring satisfies the Orzech property.
   This applies in particular to division rings.
 
@@ -260,7 +260,7 @@ end
   We construct the isomorphism in two steps:
   1. We construct the ring `R^n/I^n`, show that it is an `R/I`-module and show that there is an
      isomorphism of `R/I`-modules `R^n/I^n ≃ (R/I)^n`. This isomorphism is called
-    `Ideal.piQuotEquiv` and is located in the file `RingTheory/Ideals.lean`.
+    `Ideal.piQuotEquiv` and is located in the file `Mathlib/RingTheory/Ideal/Quotient/Basic.lean`.
   2. We construct an isomorphism of `R/I`-modules `R^n/I^n ≃ R^m/I^m` using the isomorphism
      `R^n ≃ R^m`.
 -/

--- a/Mathlib/LinearAlgebra/Matrix/Defs.lean
+++ b/Mathlib/LinearAlgebra/Matrix/Defs.lean
@@ -29,7 +29,7 @@ The scope `Matrix` gives the following notation:
 
 * `ᵀ` for `Matrix.transpose`
 
-See `Mathlib/Data/Matrix/ConjTranspose.lean` for
+See `Mathlib/LinearAlgebra/Matrix/ConjTranspose.lean` for
 
 * `ᴴ` for `Matrix.conjTranspose`
 

--- a/Mathlib/LinearAlgebra/PiTensorProduct.lean
+++ b/Mathlib/LinearAlgebra/PiTensorProduct.lean
@@ -15,7 +15,7 @@ public import Mathlib.LinearAlgebra.Multilinear.Curry
 We define the tensor product of an indexed family `s : ι → Type*` of modules over commutative
 semirings. We denote this space by `⨂[R] i, s i` and define it as `FreeAddMonoid (R × Π i, s i)`
 quotiented by the appropriate equivalence relation. The treatment follows very closely that of the
-binary tensor product in `LinearAlgebra/TensorProduct.lean`.
+binary tensor product in `Mathlib/LinearAlgebra/TensorProduct/Basic.lean`.
 
 ## Main definitions
 


### PR DESCRIPTION
Fix some stale documentation file refs.

---
<!-- Your PR title will become the first line of the commit message.

In this box, the text above the `---` (if not empty) will be appended
to the commit message, and can be used to give additional context or
details. Please leave a blank newline before the `---`, otherwise GitHub
will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

When merging, all the commits will be squashed into a single commit
listing all co-authors.

Co-authors in the squash commit are gathered from two sources:

First, all authors of commits to this PR branch are included. Thus,
one way to add co-authors is to include at least one commit authored by
each co-author among the commits in the pull request. If necessary, you
may create empty commits to indicate co-authorship, using commands like so:

git commit --author="Author Name <author@email.com>" --allow-empty -m "add Author Name as coauthor"

Second, co-authors can also be listed in lines at the very bottom of
the commit message (that is, directly before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines
at the bottom of the commit message (before the `---`, and also before
any "Co-authored-by" lines) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
