### PR TITLE
[Merged by Bors] - chore(Algebra/Central/End): generalize `Algebra.IsCentral.instEnd`

### DIFF
--- a/Mathlib/Algebra/Central/End.lean
+++ b/Mathlib/Algebra/Central/End.lean
@@ -31,9 +31,8 @@ namespace Algebra.IsCentral
 
 /-- The center of endomorphisms on a free module is trivial,
 in other words, it is a central algebra. -/
-public instance [IsCentral S R] : IsCentral S (End R M) where
-  out T hT :=
-    have ⟨_, ⟨y, _⟩, _⟩ := center_eq_bot S R ▸ T.mem_subalgebraCenter_iff.mp hT
-    ⟨y, by aesop⟩
+public instance [IsCentral S R] : IsCentral S (End R M) where out T hT :=
+  have ⟨_, ⟨y, _⟩, _⟩ := center_eq_bot S R ▸ T.mem_subalgebraCenter_iff.mp hT
+  ⟨y, by aesop⟩
 
 end Algebra.IsCentral

--- a/Mathlib/Algebra/Central/End.lean
+++ b/Mathlib/Algebra/Central/End.lean
@@ -19,11 +19,11 @@ open Module Free
 variable {S R M : Type*} [Semiring R] [AddCommMonoid M] [Module R M] [Free R M]
   [CommSemiring S] [Module S M] [SMulCommClass R S M] [Algebra S R] [IsScalarTower S R M]
 
-theorem Module.End.mem_subsemiringCenter_iff {f : End R M} :
+public theorem Module.End.mem_subsemiringCenter_iff {f : End R M} :
     f ∈ Subsemiring.center (End R M) ↔ ∃ α ∈ Subsemiring.center R, ∀ x : M, f x = α • x :=
   mem_center_iff
 
-theorem Module.End.mem_subalgebraCenter_iff {f : End R M} :
+public theorem Module.End.mem_subalgebraCenter_iff {f : End R M} :
     f ∈ Subalgebra.center S (End R M) ↔ ∃ α ∈ Subalgebra.center S R, ∀ x : M, f x = α • x :=
   mem_center_iff
 

--- a/Mathlib/Algebra/Central/End.lean
+++ b/Mathlib/Algebra/Central/End.lean
@@ -33,8 +33,7 @@ namespace Algebra.IsCentral
 in other words, it is a central algebra. -/
 public instance [IsCentral S R] : IsCentral S (End R M) where
   out _ hT :=
-    have ⟨α, h⟩ := mem_subalgebraCenter_iff.mp hT
-    have ⟨y, hy⟩ := center_eq_bot S R ▸ h.1
+    have ⟨_, ⟨y, _⟩, _⟩ := center_eq_bot S R ▸ mem_subalgebraCenter_iff.mp hT
     ⟨y, by aesop⟩
 
 end Algebra.IsCentral

--- a/Mathlib/Algebra/Central/End.lean
+++ b/Mathlib/Algebra/Central/End.lean
@@ -14,9 +14,9 @@ public import Mathlib.LinearAlgebra.FreeModule.Basic
 This file shows that the algebra of endomorphisms on a free module is central.
 -/
 
-open Module Free End
+open Module
 
-variable {S R M : Type*} [Semiring R] [AddCommMonoid M] [Module R M] [Free R M]
+variable {R S M : Type*} [Semiring R] [AddCommMonoid M] [Module R M] [Free R M]
   [CommSemiring S] [Module S M] [SMulCommClass R S M] [Algebra S R] [IsScalarTower S R M]
 
 public theorem Module.End.mem_subsemiringCenter_iff {f : End R M} :
@@ -32,8 +32,8 @@ namespace Algebra.IsCentral
 /-- The center of endomorphisms on a free module is trivial,
 in other words, it is a central algebra. -/
 public instance [IsCentral S R] : IsCentral S (End R M) where
-  out _ hT :=
-    have ⟨_, ⟨y, _⟩, _⟩ := center_eq_bot S R ▸ mem_subalgebraCenter_iff.mp hT
+  out T hT :=
+    have ⟨_, ⟨y, _⟩, _⟩ := center_eq_bot S R ▸ T.mem_subalgebraCenter_iff.mp hT
     ⟨y, by aesop⟩
 
 end Algebra.IsCentral

--- a/Mathlib/Algebra/Central/End.lean
+++ b/Mathlib/Algebra/Central/End.lean
@@ -14,7 +14,7 @@ public import Mathlib.LinearAlgebra.FreeModule.Basic
 This file shows that the algebra of endomorphisms on a free module is central.
 -/
 
-open Module Free
+open Module Free End
 
 variable {S R M : Type*} [Semiring R] [AddCommMonoid M] [Module R M] [Free R M]
   [CommSemiring S] [Module S M] [SMulCommClass R S M] [Algebra S R] [IsScalarTower S R M]
@@ -32,8 +32,8 @@ namespace Algebra.IsCentral
 /-- The center of endomorphisms on a free module is trivial,
 in other words, it is a central algebra. -/
 public instance [IsCentral S R] : IsCentral S (End R M) where
-  out x hT :=
-    have ⟨α, h⟩ := End.mem_subalgebraCenter_iff.mp hT
+  out _ hT :=
+    have ⟨α, h⟩ := mem_subalgebraCenter_iff.mp hT
     have ⟨y, hy⟩ := center_eq_bot S R ▸ h.1
     ⟨y, by aesop⟩
 

--- a/Mathlib/Algebra/Central/End.lean
+++ b/Mathlib/Algebra/Central/End.lean
@@ -20,11 +20,13 @@ variable {R S M : Type*} [Semiring R] [AddCommMonoid M] [Module R M] [Free R M]
   [CommSemiring S] [Module S M] [SMulCommClass R S M] [Algebra S R] [IsScalarTower S R M]
 
 public theorem Module.End.mem_subsemiringCenter_iff {f : End R M} :
-    f ∈ Subsemiring.center (End R M) ↔ ∃ α ∈ Subsemiring.center R, ∀ x : M, f x = α • x :=
+    f ∈ Subsemiring.center (End R M) ↔
+      ∃ (α : R) (hα : α ∈ Subsemiring.center R), f = smulLeft α hα :=
   mem_center_iff
 
 public theorem Module.End.mem_subalgebraCenter_iff {f : End R M} :
-    f ∈ Subalgebra.center S (End R M) ↔ ∃ α ∈ Subalgebra.center S R, ∀ x : M, f x = α • x :=
+    f ∈ Subalgebra.center S (End R M) ↔
+      ∃ (α : R) (hα : α ∈ Subalgebra.center S R), f = smulLeft α hα :=
   mem_center_iff
 
 namespace Algebra.IsCentral
@@ -32,7 +34,8 @@ namespace Algebra.IsCentral
 /-- The center of endomorphisms on a free module is trivial,
 in other words, it is a central algebra. -/
 public instance [IsCentral S R] : IsCentral S (End R M) where out T hT :=
-  have ⟨_, ⟨y, _⟩, _⟩ := center_eq_bot S R ▸ T.mem_subalgebraCenter_iff.mp hT
+  have ⟨_, h, _⟩ := T.mem_subalgebraCenter_iff.mp hT
+  have ⟨y, _⟩ := center_eq_bot S R ▸ h
   ⟨y, by aesop⟩
 
 end Algebra.IsCentral

--- a/Mathlib/Algebra/Central/End.lean
+++ b/Mathlib/Algebra/Central/End.lean
@@ -5,7 +5,7 @@ Authors: Monica Omar
 -/
 module
 
-public import Mathlib.Algebra.Central.Defs
+public import Mathlib.Algebra.Central.Basic
 public import Mathlib.LinearAlgebra.FreeModule.Basic
 
 /-!
@@ -16,17 +16,25 @@ This file shows that the algebra of endomorphisms on a free module is central.
 
 open Module Free
 
+variable {S R M : Type*} [Semiring R] [AddCommMonoid M] [Module R M] [Free R M]
+  [CommSemiring S] [Module S M] [SMulCommClass R S M] [Algebra S R] [IsScalarTower S R M]
+
+theorem Module.End.mem_subsemiringCenter_iff {f : End R M} :
+    f ∈ Subsemiring.center (End R M) ↔ ∃ α ∈ Subsemiring.center R, ∀ x : M, f x = α • x :=
+  mem_center_iff
+
+theorem Module.End.mem_subalgebraCenter_iff {f : End R M} :
+    f ∈ Subalgebra.center S (End R M) ↔ ∃ α ∈ Subalgebra.center S R, ∀ x : M, f x = α • x :=
+  mem_center_iff
+
 namespace Algebra.IsCentral
-variable {R M : Type*} [CommSemiring R] [AddCommMonoid M] [Module R M] [Free R M]
 
 /-- The center of endomorphisms on a free module is trivial,
 in other words, it is a central algebra. -/
-public instance : IsCentral R (End R M) where
-  out T hT := by
-    nontriviality M
-    let b := chooseBasis R M
-    let i := b.index_nonempty.some
-    refine ⟨b.coord i (T (b i)), LinearMap.ext fun y ↦ ?_⟩
-    simpa using congr($(Subalgebra.mem_center_iff.mp hT <| (b.coord i).smulRight y) (b i))
+public instance [IsCentral S R] : IsCentral S (End R M) where
+  out x hT :=
+    have ⟨α, h⟩ := End.mem_subalgebraCenter_iff.mp hT
+    have ⟨y, hy⟩ := center_eq_bot S R ▸ h.1
+    ⟨y, by aesop⟩
 
 end Algebra.IsCentral

--- a/Mathlib/Algebra/Module/Hom.lean
+++ b/Mathlib/Algebra/Module/Hom.lean
@@ -112,7 +112,9 @@ end AddMonoid.End
 
 namespace AddMonoidHom
 
-/-- Scalar multiplication on the left as an additive monoid homomorphism. -/
+/-- Scalar multiplication on the left as an additive monoid homomorphism.
+
+See also the linear map version of this `Module.End.smulLeft`. -/
 @[simps! -fullyApplied]
 protected def smulLeft [Monoid M] [AddMonoid A] [DistribMulAction M A] (c : M) : A →+ A :=
   DistribMulAction.toAddMonoidHom _ c

--- a/Mathlib/Algebra/Module/LinearMap/End.lean
+++ b/Mathlib/Algebra/Module/LinearMap/End.lean
@@ -8,6 +8,7 @@ module
 
 public import Mathlib.Algebra.Group.Center
 public import Mathlib.Algebra.Module.Equiv.Opposite
+public import Mathlib.Algebra.Module.Hom
 public import Mathlib.Algebra.NoZeroSMulDivisors.Defs
 
 /-!
@@ -179,10 +180,12 @@ theorem surjective_of_iterate_surjective {n : ℕ} (hn : n ≠ 0) (h : Surjectiv
   exact Surjective.of_comp h
 
 /-- Scalar multiplication on the left, as a linear map. -/
-@[simps] def smulLeft (α : R) (hα : α ∈ Set.center R) : End R M where
-  toFun x := α • x
-  map_add' := smul_add _
-  map_smul' β x := by simp [smul_smul, ((Set.mem_center_iff.mp hα).comm β).eq]
+@[simps!] def smulLeft (α : R) (hα : α ∈ Set.center R) : End R M where
+  __ := AddMonoidHom.smulLeft α
+  map_smul' β _ := by simp [smul_smul, ((Set.mem_center_iff.mp hα).comm β).eq]
+
+@[simp] lemma toAddMonoidHom_smulLeft (α : R) (hα : α ∈ Set.center R) :
+    (smulLeft α hα (M := M)).toAddMonoidHom = AddMonoidHom.smulLeft α := rfl
 
 @[simp] lemma smulLeft_eq {R : Type*} [CommSemiring R] [Module R M] (α : R)
     (hα : α ∈ Set.center R := by simp) : smulLeft α hα = α • .id (M := M) := rfl

--- a/Mathlib/Algebra/Module/LinearMap/End.lean
+++ b/Mathlib/Algebra/Module/LinearMap/End.lean
@@ -8,7 +8,6 @@ module
 
 public import Mathlib.Algebra.Group.Center
 public import Mathlib.Algebra.Module.Equiv.Opposite
-public import Mathlib.Algebra.Module.Hom
 public import Mathlib.Algebra.NoZeroSMulDivisors.Defs
 
 /-!
@@ -180,12 +179,10 @@ theorem surjective_of_iterate_surjective {n : ℕ} (hn : n ≠ 0) (h : Surjectiv
   exact Surjective.of_comp h
 
 /-- Scalar multiplication on the left, as a linear map. -/
-@[simps!] def smulLeft (α : R) (hα : α ∈ Set.center R) : End R M where
-  __ := AddMonoidHom.smulLeft α
+@[simps] def smulLeft (α : R) (hα : α ∈ Set.center R) : End R M where
+  toFun x := α • x
+  map_add' := smul_add _
   map_smul' β _ := by simp [smul_smul, ((Set.mem_center_iff.mp hα).comm β).eq]
-
-@[simp] lemma toAddMonoidHom_smulLeft (α : R) (hα : α ∈ Set.center R) :
-    (smulLeft α hα (M := M)).toAddMonoidHom = AddMonoidHom.smulLeft α := rfl
 
 @[simp] lemma smulLeft_eq {R : Type*} [CommSemiring R] [Module R M] (α : R)
     (hα : α ∈ Set.center R := by simp) : smulLeft α hα = α • .id (M := M) := rfl

--- a/Mathlib/Algebra/Module/LinearMap/End.lean
+++ b/Mathlib/Algebra/Module/LinearMap/End.lean
@@ -6,6 +6,7 @@ Authors: Nathaniel Thomas, Jeremy Avigad, Johannes Hölzl, Mario Carneiro, Anne 
 -/
 module
 
+public import Mathlib.Algebra.Group.Center
 public import Mathlib.Algebra.Module.Equiv.Opposite
 public import Mathlib.Algebra.NoZeroSMulDivisors.Defs
 
@@ -176,6 +177,15 @@ theorem surjective_of_iterate_surjective {n : ℕ} (hn : n ≠ 0) (h : Surjectiv
     Surjective f' := by
   rw [← Nat.succ_pred_eq_of_pos (Nat.pos_iff_ne_zero.mpr hn), pow_succ', coe_mul] at h
   exact Surjective.of_comp h
+
+/-- Scalar multiplication on the left, as a linear map. -/
+@[simps] def smulLeft (α : R) (hα : α ∈ Set.center R) : End R M where
+  toFun x := α • x
+  map_add' := smul_add _
+  map_smul' β x := by simp [smul_smul, ((Set.mem_center_iff.mp hα).comm β).eq]
+
+@[simp] lemma smulLeft_eq {R : Type*} [CommSemiring R] [Module R M] (α : R)
+    (hα : α ∈ Set.center R := by simp) : smulLeft α hα = α • .id (M := M) := rfl
 
 end
 

--- a/Mathlib/LinearAlgebra/FreeModule/Basic.lean
+++ b/Mathlib/LinearAlgebra/FreeModule/Basic.lean
@@ -196,8 +196,8 @@ theorem mem_center_iff {f : End R M} :
   · exact ⟨0, by simp, fun _ ↦ Subsingleton.allEq _ _⟩
   let b := Free.chooseBasis R M
   let i := b.index_nonempty.some
-  have (x : M) := by simpa using h (b.coord i |>.smulRight x) (b i) |>.symm
-  exact ⟨b.coord i <| f <| b i, fun r ↦ by simpa using congr(b.coord i $(this <| r • b i)), this⟩
+  have H x : f x = b.repr (f (b i)) i • x := by simpa using (h ((b.coord i).smulRight x) (b i)).symm
+  exact ⟨b.coord i <| f <| b i, fun r ↦ by simpa using congr(b.coord i $(H <| r • b i)), H⟩
 
 theorem mem_submonoidCenter_iff {f : End R M} :
     f ∈ Submonoid.center (End R M) ↔ ∃ α ∈ Submonoid.center R, ∀ x : M, f x = α • x :=

--- a/Mathlib/LinearAlgebra/FreeModule/Basic.lean
+++ b/Mathlib/LinearAlgebra/FreeModule/Basic.lean
@@ -186,9 +186,9 @@ theorem repr_algebraMap {ι : Type*} {B : Basis ι R S} {i : ι} (hBi : B i = 1)
 end Basis
 
 namespace End
-variable {R M : Type*} [Semiring R] [AddCommMonoid M] [Module R M] [Module.Free R M]
+variable {R M : Type*} [Semiring R] [AddCommMonoid M] [Module R M] [Free R M]
 
-theorem mem_center_iff {f : Module.End R M} :
+theorem mem_center_iff {f : End R M} :
     f ∈ Set.center (End R M) ↔ ∃ α ∈ Set.center R, ∀ x : M, f x = α • x := by
   simp only [Semigroup.mem_center_iff, LinearMap.ext_iff, mul_apply]
   refine ⟨fun h ↦ ?_, by simp_all⟩
@@ -199,11 +199,11 @@ theorem mem_center_iff {f : Module.End R M} :
   have (x : M) := by simpa using h ((b.coord i).smulRight x) (b i) |>.symm
   exact ⟨b.coord i (f (b i)), fun r ↦ by simpa using congr(b.coord i $(this (r • b i))), this⟩
 
-theorem mem_submonoidCenter_iff {f : Module.End R M} :
+theorem mem_submonoidCenter_iff {f : End R M} :
     f ∈ Submonoid.center (End R M) ↔ ∃ α ∈ Submonoid.center R, ∀ x : M, f x = α • x :=
   mem_center_iff
 
-theorem mem_subsemigroupCenter_iff {f : Module.End R M} :
+theorem mem_subsemigroupCenter_iff {f : End R M} :
     f ∈ Subsemigroup.center (End R M) ↔ ∃ α ∈ Subsemigroup.center R, ∀ x : M, f x = α • x :=
   mem_center_iff
 

--- a/Mathlib/LinearAlgebra/FreeModule/Basic.lean
+++ b/Mathlib/LinearAlgebra/FreeModule/Basic.lean
@@ -196,8 +196,8 @@ theorem mem_center_iff {f : End R M} :
   · exact ⟨0, by simp, fun _ ↦ Subsingleton.allEq _ _⟩
   let b := Free.chooseBasis R M
   let i := b.index_nonempty.some
-  have (x : M) := by simpa using h ((b.coord i).smulRight x) (b i) |>.symm
-  exact ⟨b.coord i (f (b i)), fun r ↦ by simpa using congr(b.coord i $(this (r • b i))), this⟩
+  have (x : M) := by simpa using h (b.coord i |>.smulRight x) (b i) |>.symm
+  exact ⟨b.coord i <| f <| b i, fun r ↦ by simpa using congr(b.coord i $(this <| r • b i)), this⟩
 
 theorem mem_submonoidCenter_iff {f : End R M} :
     f ∈ Submonoid.center (End R M) ↔ ∃ α ∈ Submonoid.center R, ∀ x : M, f x = α • x :=

--- a/Mathlib/LinearAlgebra/FreeModule/Basic.lean
+++ b/Mathlib/LinearAlgebra/FreeModule/Basic.lean
@@ -183,4 +183,28 @@ theorem repr_algebraMap {ι : Type*} {B : Basis ι R S} {i : ι} (hBi : B i = 1)
     B.repr (algebraMap R S r) = Finsupp.single i r := by
   ext j; simp [Algebra.algebraMap_eq_smul_one, ← hBi]
 
-end Module.Basis
+end Basis
+
+namespace End
+variable {R M : Type*} [Semiring R] [AddCommMonoid M] [Module R M] [Module.Free R M]
+
+theorem mem_center_iff {f : Module.End R M} :
+    f ∈ Set.center (End R M) ↔ ∃ α ∈ Set.center R, ∀ x : M, f x = α • x := by
+  simp only [Semigroup.mem_center_iff, LinearMap.ext_iff, mul_apply]
+  refine ⟨fun h ↦ ?_, by simp_all⟩
+  by_cases! Subsingleton M
+  · exact ⟨0, by simp, fun _ ↦ Subsingleton.allEq _ _⟩
+  let b := Free.chooseBasis R M
+  let i := b.index_nonempty.some
+  have (x : M) := by simpa using h ((b.coord i).smulRight x) (b i) |>.symm
+  exact ⟨b.coord i (f (b i)), fun r ↦ by simpa using congr(b.coord i $(this (r • b i))), this⟩
+
+theorem mem_submonoidCenter_iff {f : Module.End R M} :
+    f ∈ Submonoid.center (End R M) ↔ ∃ α ∈ Submonoid.center R, ∀ x : M, f x = α • x :=
+  mem_center_iff
+
+theorem mem_subsemigroupCenter_iff {f : Module.End R M} :
+    f ∈ Subsemigroup.center (End R M) ↔ ∃ α ∈ Subsemigroup.center R, ∀ x : M, f x = α • x :=
+  mem_center_iff
+
+end Module.End

--- a/Mathlib/LinearAlgebra/FreeModule/Basic.lean
+++ b/Mathlib/LinearAlgebra/FreeModule/Basic.lean
@@ -189,7 +189,7 @@ namespace End
 variable {R M : Type*} [Semiring R] [AddCommMonoid M] [Module R M] [Free R M]
 
 theorem mem_center_iff {f : End R M} :
-    f ∈ Set.center (End R M) ↔ ∃ α ∈ Set.center R, ∀ x : M, f x = α • x := by
+    f ∈ Set.center (End R M) ↔ ∃ (α : R) (hα : α ∈ Set.center R), f = smulLeft α hα := by
   simp only [Semigroup.mem_center_iff, LinearMap.ext_iff, mul_apply]
   refine ⟨fun h ↦ ?_, by simp_all⟩
   by_cases! Subsingleton M
@@ -200,11 +200,12 @@ theorem mem_center_iff {f : End R M} :
   exact ⟨b.coord i <| f <| b i, fun r ↦ by simpa using congr(b.coord i $(H <| r • b i)), H⟩
 
 theorem mem_submonoidCenter_iff {f : End R M} :
-    f ∈ Submonoid.center (End R M) ↔ ∃ α ∈ Submonoid.center R, ∀ x : M, f x = α • x :=
+    f ∈ Submonoid.center (End R M) ↔ ∃ (α : R) (hα : α ∈ Submonoid.center R), f = smulLeft α hα :=
   mem_center_iff
 
 theorem mem_subsemigroupCenter_iff {f : End R M} :
-    f ∈ Subsemigroup.center (End R M) ↔ ∃ α ∈ Subsemigroup.center R, ∀ x : M, f x = α • x :=
+    f ∈ Subsemigroup.center (End R M) ↔
+      ∃ (α : R) (hα : α ∈ Subsemigroup.center R), f = smulLeft α hα :=
   mem_center_iff
 
 end Module.End


### PR DESCRIPTION

---
<!-- Your PR title will become the first line of the commit message.

In this box, the text above the `---` (if not empty) will be appended
to the commit message, and can be used to give additional context or
details. Please leave a blank newline before the `---`, otherwise GitHub
will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

When merging, all the commits will be squashed into a single commit
listing all co-authors.

Co-authors in the squash commit are gathered from two sources:

First, all authors of commits to this PR branch are included. Thus,
one way to add co-authors is to include at least one commit authored by
each co-author among the commits in the pull request. If necessary, you
may create empty commits to indicate co-authorship, using commands like so:

git commit --author="Author Name <author@email.com>" --allow-empty -m "add Author Name as coauthor"

Second, co-authors can also be listed in lines at the very bottom of
the commit message (that is, directly before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines
at the bottom of the commit message (before the `---`, and also before
any "Co-authored-by" lines) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

This came up during review of #33282.

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
