### PR TITLE
feat(Ring

### DIFF
--- a/Mathlib/RingTheory/WittVector/Complete.lean
+++ b/Mathlib/RingTheory/WittVector/Complete.lean
@@ -7,6 +7,7 @@ module
 
 public import Mathlib.RingTheory.WittVector.Domain
 public import Mathlib.RingTheory.WittVector.Truncated
+public import Mathlib.RingTheory.WittVector.Teichmuller
 public import Mathlib.RingTheory.AdicCompletion.Basic
 
 /-!
@@ -21,9 +22,6 @@ when `k` is a perfect ring of characteristic `p`.
   then the Witt vector `𝕎 k` is `p`-torsion free.
 * `isAdicCompleteIdealSpanP` : If `k` is a perfect ring of characteristic `p`,
   then the Witt vector `𝕎 k` is `p`-adically complete.
-
-## TODO
-Define the map `𝕎 k / p ≃+* k`.
 -/
 
 @[expose] public section
@@ -96,6 +94,19 @@ theorem mem_span_p_pow_iff_le_coeff_eq_zero (x : 𝕎 k) (n : ℕ) :
         simp
       · rw [Function.Commute, Function.Semiconj, ← WittVector.frobeniusEquiv_apply]
         simp only [RingEquiv.apply_symm_apply, RingEquiv.symm_apply_apply, implies_true]
+
+/-- If `k` is a perfect ring of characteristic `p`, there is an isomorphism between the quotient
+`𝕎 k / p` and `k`.
+-/
+noncomputable def quotientPEquiv : (𝕎 k) ⧸ (Ideal.span {(p : 𝕎 k)}) ≃+* k := by
+  have kernel_eq : (Ideal.span {(p : 𝕎 k)}) = RingHom.ker constantCoeff := by
+    ext
+    simp [mem_span_p_iff_coeff_zero_eq_zero]
+  rw [kernel_eq]
+  apply RingHom.quotientKerEquivOfSurjective
+  intro r
+  use teichmuller p r
+  simp
 
 /--
 If `k` is a perfect ring of characteristic `p`, then the ring of Witt vectors `𝕎 k`


### PR DESCRIPTION
---
<!-- Your PR title will become the first line of the commit message.

In this box, the text above the `---` (if not empty) will be appended
to the commit message, and can be used to give additional context or
details. Please leave a blank newline before the `---`, otherwise GitHub
will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

When merging, all the commits will be squashed into a single commit
listing all co-authors.

Co-authors in the squash commit are gathered from two sources:

First, all authors of commits to this PR branch are included. Thus,
one way to add co-authors is to include at least one commit authored by
each co-author among the commits in the pull request. If necessary, you
may create empty commits to indicate co-authorship, using commands like so:

git commit --author="Author Name <author@email.com>" --allow-empty -m "add Author Name as coauthor"

Second, co-authors can also be listed in lines at the very bottom of
the commit message (that is, directly before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines
at the bottom of the commit message (before the `---`, and also before
any "Co-authored-by" lines) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
