### PR TITLE
[Merged by Bors] - feat(RingTheory/WittVector): isomorphism of Witt vectors mod p with base ring

### DIFF
--- a/Mathlib/RingTheory/WittVector/Complete.lean
+++ b/Mathlib/RingTheory/WittVector/Complete.lean
@@ -7,6 +7,7 @@ module
 
 public import Mathlib.RingTheory.WittVector.Domain
 public import Mathlib.RingTheory.WittVector.Truncated
+public import Mathlib.RingTheory.WittVector.Teichmuller
 public import Mathlib.RingTheory.AdicCompletion.Basic
 
 /-!
@@ -21,9 +22,6 @@ when `k` is a perfect ring of characteristic `p`.
   then the Witt vector `𝕎 k` is `p`-torsion free.
 * `isAdicCompleteIdealSpanP` : If `k` is a perfect ring of characteristic `p`,
   then the Witt vector `𝕎 k` is `p`-adically complete.
-
-## TODO
-Define the map `𝕎 k / p ≃+* k`.
 -/
 
 @[expose] public section
@@ -96,6 +94,19 @@ theorem mem_span_p_pow_iff_le_coeff_eq_zero (x : 𝕎 k) (n : ℕ) :
         simp
       · rw [Function.Commute, Function.Semiconj, ← WittVector.frobeniusEquiv_apply]
         simp only [RingEquiv.apply_symm_apply, RingEquiv.symm_apply_apply, implies_true]
+
+/-- If `k` is a perfect ring of characteristic `p`, there is an isomorphism between the quotient
+`𝕎 k / p` and `k`.
+-/
+noncomputable def quotientPEquiv : (𝕎 k) ⧸ (Ideal.span {(p : 𝕎 k)}) ≃+* k := by
+  have kernel_eq : (Ideal.span {(p : 𝕎 k)}) = RingHom.ker constantCoeff := by
+    ext
+    simp [mem_span_p_iff_coeff_zero_eq_zero]
+  rw [kernel_eq]
+  apply RingHom.quotientKerEquivOfSurjective
+  intro r
+  use teichmuller p r
+  simp
 
 /--
 If `k` is a perfect ring of characteristic `p`, then the ring of Witt vectors `𝕎 k`

--- a/Mathlib/RingTheory/WittVector/Complete.lean
+++ b/Mathlib/RingTheory/WittVector/Complete.lean
@@ -95,18 +95,19 @@ theorem mem_span_p_pow_iff_le_coeff_eq_zero (x : 𝕎 k) (n : ℕ) :
       · rw [Function.Commute, Function.Semiconj, ← WittVector.frobeniusEquiv_apply]
         simp only [RingEquiv.apply_symm_apply, RingEquiv.symm_apply_apply, implies_true]
 
+lemma ker_constantCoeff : RingHom.ker constantCoeff = Ideal.span {(p : 𝕎 k)} := by
+  ext
+  simp [mem_span_p_iff_coeff_zero_eq_zero]
+
 /-- If `k` is a perfect ring of characteristic `p`, there is an isomorphism between the quotient
 `𝕎 k / p` and `k`.
 -/
-noncomputable def quotientPEquiv : (𝕎 k) ⧸ (Ideal.span {(p : 𝕎 k)}) ≃+* k := by
-  have kernel_eq : (Ideal.span {(p : 𝕎 k)}) = RingHom.ker constantCoeff := by
-    ext
-    simp [mem_span_p_iff_coeff_zero_eq_zero]
-  rw [kernel_eq]
-  apply RingHom.quotientKerEquivOfSurjective
-  intro r
-  use teichmuller p r
-  simp
+noncomputable def quotientPEquiv : 𝕎 k ⧸ Ideal.span {(p : 𝕎 k)} ≃+* k :=
+  (Ideal.quotEquivOfEq ker_constantCoeff.symm).trans
+    (RingHom.quotientKerEquivOfSurjective (constantCoeff_surjective p))
+
+@[simp]
+lemma quotientPEquiv_mk (x : 𝕎 k) : quotientPEquiv (Quot.mk _ x) = constantCoeff x := rfl
 
 /--
 If `k` is a perfect ring of characteristic `p`, then the ring of Witt vectors `𝕎 k`

--- a/Mathlib/RingTheory/WittVector/Teichmuller.lean
+++ b/Mathlib/RingTheory/WittVector/Teichmuller.lean
@@ -125,4 +125,9 @@ theorem ghostComponent_teichmuller (r : R) (n : ℕ) :
     ghostComponent n (teichmuller p r) = r ^ p ^ n :=
   ghostComponent_teichmullerFun _ _ _
 
+/-- The Teichmüller lift is set-theoretically right inverse to the constant coefficient map,
+showing that the latter is surjective. -/
+lemma constantCoeff_surjective : Function.Surjective (constantCoeff: 𝕎 R → R) :=
+  fun r ↦ ⟨teichmuller p r, rfl⟩
+
 end WittVector

--- a/Mathlib/RingTheory/WittVector/Teichmuller.lean
+++ b/Mathlib/RingTheory/WittVector/Teichmuller.lean
@@ -127,7 +127,7 @@ theorem ghostComponent_teichmuller (r : R) (n : ℕ) :
 
 /-- The Teichmüller lift is set-theoretically right inverse to the constant coefficient map,
 showing that the latter is surjective. -/
-lemma constantCoeff_surjective : Function.Surjective (constantCoeff: 𝕎 R → R) :=
+lemma constantCoeff_surjective : Function.Surjective (constantCoeff : 𝕎 R → R) :=
   fun r ↦ ⟨teichmuller p r, rfl⟩
 
 end WittVector


### PR DESCRIPTION
This resolves a TODO in the basic theory of Witt vectors, giving an isomorphism between `W(k)/p` and `k` where `k` is a perfect ring of characteristic `p`.

--- 

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
