### PR TITLE
[Merged by Bors] - fix: fix `#lint` by marking `tacticDocs` as `public`

### DIFF
--- a/Mathlib/Tactic/Linter/TacticDocumentation.lean
+++ b/Mathlib/Tactic/Linter/TacticDocumentation.lean
@@ -5,9 +5,9 @@ Authors: Anne Baanen
 -/
 module
 
-meta import Batteries.Tactic.Lint.Basic
-meta import Lean.Elab.Tactic.Doc
-import Lean.Parser.Tactic.Doc
+public meta import Batteries.Tactic.Lint.Basic
+public meta import Lean.Elab.Tactic.Doc
+public meta import Lean.Parser.Tactic.Doc
 import Mathlib.Tactic.Linter.Header
 
 /-! # The `tacticDocs` linter
@@ -25,7 +25,7 @@ meta def isNonemptyDoc (doc : TacticDoc) : Bool :=
   doc.docString.isSome || doc.extensionDocs.any (! ·.isEmpty)
 
 /-- Check that all tactics available in Mathlib have a docstring. -/
-@[env_linter] meta def tacticDocs : Batteries.Tactic.Lint.Linter where
+@[env_linter] public meta def tacticDocs : Batteries.Tactic.Lint.Linter where
   noErrorsFound := "No tactics are missing documentation."
   errorsFound := "TACTICS ARE MISSING DOCUMENTATION STRINGS:"
   test tac := do

--- a/MathlibTest/HashLint.lean
+++ b/MathlibTest/HashLint.lean
@@ -1,0 +1,14 @@
+module
+
+import Mathlib.Init
+
+/-! Checks that a basic `#lint` works. -/
+
+/--
+info: -- Found 0 errors in 0 declarations (plus 0 automatically generated ones) in the current file with 16 linters
+
+
+-- All linting checks passed!
+-/
+#guard_msgs in
+#lint


### PR DESCRIPTION
This PR fixes `#lint`, which had been reporting

> Unknown constant `_private.Mathlib.Tactic.Linter.TacticDocumentation.0.tacticDocs`

by marking `tacticDocs` as `public`.

See [#mathlib4 > #lint is broken @ 💬](https://leanprover.zulipchat.com/#narrow/channel/287929-mathlib4/topic/.23lint.20is.20broken/near/565443234).

---

Note: I was wary of running all linters in the test file (even on 0 declarations), but `#time` reports that this test only takes ~2ms.

<!-- Your PR title will become the first line of the commit message.

In this box, the text above the `---` (if not empty) will be appended
to the commit message, and can be used to give additional context or
details. Please leave a blank newline before the `---`, otherwise GitHub
will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

When merging, all the commits will be squashed into a single commit
listing all co-authors.

Co-authors in the squash commit are gathered from two sources:

First, all authors of commits to this PR branch are included. Thus,
one way to add co-authors is to include at least one commit authored by
each co-author among the commits in the pull request. If necessary, you
may create empty commits to indicate co-authorship, using commands like so:

git commit --author="Author Name <author@email.com>" --allow-empty -m "add Author Name as coauthor"

Second, co-authors can also be listed in lines at the very bottom of
the commit message (that is, directly before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines
at the bottom of the commit message (before the `---`, and also before
any "Co-authored-by" lines) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
