### PR TITLE
[Merged by Bors] - refactor(Order/Interval/Set/Basic): review some basic `Ixx` theorems

### DIFF
--- a/Counterexamples/SorgenfreyLine.lean
+++ b/Counterexamples/SorgenfreyLine.lean
@@ -155,8 +155,8 @@ theorem isClopen_Ico (a b : ℝₗ) : IsClopen (Ico a b) :=
 
 instance : TotallyDisconnectedSpace ℝₗ :=
   ⟨fun _ _ hs x hx y hy =>
-    le_antisymm (hs.subset_isClopen (isClopen_Ici x) ⟨x, hx, left_mem_Ici⟩ hy)
-      (hs.subset_isClopen (isClopen_Ici y) ⟨y, hy, left_mem_Ici⟩ hx)⟩
+    le_antisymm (hs.subset_isClopen (isClopen_Ici x) ⟨x, hx, self_mem_Ici⟩ hy)
+      (hs.subset_isClopen (isClopen_Ici y) ⟨y, hy, self_mem_Ici⟩ hx)⟩
 
 instance : FirstCountableTopology ℝₗ :=
   ⟨fun x => (nhds_basis_Ico_rat x).isCountablyGenerated⟩
@@ -221,7 +221,7 @@ theorem isClosed_of_subset_antidiagonal {s : Set (ℝₗ × ℝₗ)} {c : ℝₗ
   obtain rfl : x + y = c := by
     change (x, y) ∈ {p : ℝₗ × ℝₗ | p.1 + p.2 = c}
     exact closure_minimal (hs : s ⊆ {x | x.1 + x.2 = c}) (isClosed_antidiagonal c) H
-  rcases mem_closure_iff.1 H (Ici (x, y)) (isClopen_Ici_prod _).2 left_mem_Ici with
+  rcases mem_closure_iff.1 H (Ici (x, y)) (isClopen_Ici_prod _).2 self_mem_Ici with
     ⟨⟨x', y'⟩, ⟨hx : x ≤ x', hy : y ≤ y'⟩, H⟩
   convert H
   · refine hx.antisymm ?_

--- a/Mathlib/Algebra/Order/UpperLower.lean
+++ b/Mathlib/Algebra/Order/UpperLower.lean
@@ -140,7 +140,7 @@ set_option backward.privateInPublic true in
 @[to_additive]
 private theorem one_mul (s : UpperSet α) : 1 * s = s :=
   SetLike.coe_injective <|
-    (subset_mul_right _ left_mem_Ici).antisymm' <| by
+    (subset_mul_right _ self_mem_Ici).antisymm' <| by
       rw [← smul_eq_mul, ← Set.iUnion_smul_set]
       exact Set.iUnion₂_subset fun _ ↦ s.upper.smul_subset
 
@@ -199,7 +199,7 @@ set_option backward.privateInPublic true in
 @[to_additive]
 private theorem one_mul (s : LowerSet α) : 1 * s = s :=
   SetLike.coe_injective <|
-    (subset_mul_right _ right_mem_Iic).antisymm' <| by
+    (subset_mul_right _ self_mem_Iic).antisymm' <| by
       rw [← smul_eq_mul, ← Set.iUnion_smul_set]
       exact Set.iUnion₂_subset fun _ ↦ s.lower.smul_subset
 

--- a/Mathlib/Analysis/Calculus/Deriv/Abs.lean
+++ b/Mathlib/Analysis/Calculus/Deriv/Abs.lean
@@ -184,11 +184,11 @@ theorem Differentiable.abs (hf : Differentiable ℝ f) (h₀ : ∀ x, f x ≠ 0)
 theorem not_differentiableAt_abs_zero : ¬ DifferentiableAt ℝ (abs : ℝ → ℝ) 0 := by
   intro h
   have h₁ : deriv abs (0 : ℝ) = 1 :=
-    (uniqueDiffOn_Ici _ _ Set.left_mem_Ici).eq_deriv _ h.hasDerivAt.hasDerivWithinAt <|
-      (hasDerivWithinAt_id _ _).congr_of_mem (fun _ h ↦ abs_of_nonneg h) Set.left_mem_Ici
+    (uniqueDiffOn_Ici _ _ Set.self_mem_Ici).eq_deriv _ h.hasDerivAt.hasDerivWithinAt <|
+      (hasDerivWithinAt_id _ _).congr_of_mem (fun _ h ↦ abs_of_nonneg h) Set.self_mem_Ici
   have h₂ : deriv abs (0 : ℝ) = -1 :=
-    (uniqueDiffOn_Iic _ _ Set.right_mem_Iic).eq_deriv _ h.hasDerivAt.hasDerivWithinAt <|
-      (hasDerivWithinAt_neg _ _).congr_of_mem (fun _ h ↦ abs_of_nonpos h) Set.right_mem_Iic
+    (uniqueDiffOn_Iic _ _ Set.self_mem_Iic).eq_deriv _ h.hasDerivAt.hasDerivWithinAt <|
+      (hasDerivWithinAt_neg _ _).congr_of_mem (fun _ h ↦ abs_of_nonpos h) Set.self_mem_Iic
   linarith
 
 theorem deriv_abs_neg {x : ℝ} (hx : x < 0) : deriv (|·|) x = -1 := (hasDerivAt_abs_neg hx).deriv

--- a/Mathlib/Analysis/Calculus/Deriv/Basic.lean
+++ b/Mathlib/Analysis/Calculus/Deriv/Basic.lean
@@ -517,7 +517,7 @@ theorem derivWithin_Ioi_eq_Ici {E : Type*} [NormedAddCommGroup E] [NormedSpace �
   by_cases H : DifferentiableWithinAt ℝ f (Ioi x) x
   · have A := H.hasDerivWithinAt.Ici_of_Ioi
     have B := (differentiableWithinAt_Ioi_iff_Ici.1 H).hasDerivWithinAt
-    simpa using (uniqueDiffOn_Ici x).eq left_mem_Ici A B
+    simpa using (uniqueDiffOn_Ici x).eq self_mem_Ici A B
   · rw [derivWithin_zero_of_not_differentiableWithinAt H,
       derivWithin_zero_of_not_differentiableWithinAt]
     rwa [differentiableWithinAt_Ioi_iff_Ici] at H

--- a/Mathlib/Analysis/Calculus/FDeriv/Measurable.lean
+++ b/Mathlib/Analysis/Calculus/FDeriv/Measurable.lean
@@ -671,7 +671,7 @@ theorem D_subset_differentiable_set {K : Set F} (hK : IsComplete K) :
       _ ≤ 16 * ‖y - x‖ * (ε / 16) := by gcongr
       _ = ε * ‖y - x‖ := by ring
   -- Conclusion of the proof
-  rw [← this.derivWithin (uniqueDiffOn_Ici x x Set.left_mem_Ici)] at f'K
+  rw [← this.derivWithin (uniqueDiffOn_Ici x x Set.self_mem_Ici)] at f'K
   exact ⟨this.differentiableWithinAt, f'K⟩
 
 theorem differentiable_set_eq_D (hK : IsComplete K) :

--- a/Mathlib/Analysis/Complex/UpperHalfPlane/Topology.lean
+++ b/Mathlib/Analysis/Complex/UpperHalfPlane/Topology.lean
@@ -66,7 +66,7 @@ instance : NoncompactSpace ℍ := by
   have : IsCompact (Complex.im ⁻¹' Ioi 0) := isCompact_iff_isCompact_univ.2 h
   replace := this.isClosed.closure_eq
   rw [closure_preimage_im, closure_Ioi, Set.ext_iff] at this
-  exact absurd ((this 0).1 (@left_mem_Ici ℝ _ 0)) (@lt_irrefl ℝ _ 0)
+  exact absurd ((this 0).1 (@self_mem_Ici ℝ _ 0)) (@lt_irrefl ℝ _ 0)
 
 instance : LocallyCompactSpace ℍ :=
   isOpenEmbedding_coe.locallyCompactSpace

--- a/Mathlib/Analysis/Convex/Piecewise.lean
+++ b/Mathlib/Analysis/Convex/Piecewise.lean
@@ -55,34 +55,34 @@ theorem convexOn_univ_piecewise_Iic_of_antitoneOn_Iic_monotoneOn_Ici
     · rw [Set.piecewise_eq_of_mem (Set.Iic e) f g hc]
       have hc' : a • x + b • e ≤ a • x + b • y := by gcongr
       trans a • f x + b • f e
-      · exact (h_anti (hc'.trans hc) hc hc').trans (hf.2 hx Set.right_mem_Iic ha hb hab)
+      · exact (h_anti (hc'.trans hc) hc hc').trans (hf.2 hx Set.self_mem_Iic ha hb hab)
       · rw [h_eq]
         gcongr
-        exact h_mono Set.left_mem_Ici hy.le hy.le
+        exact h_mono Set.self_mem_Ici hy.le hy.le
     · rw [Set.piecewise_eq_of_notMem (Set.Iic e) f g (Set.notMem_Iic.mpr hc)]
       have hc' : a • x + b • y ≤ a • e + b • y := by gcongr
       trans a • g e + b • g y
-      · exact (h_mono hc.le (hc.le.trans hc') hc').trans (hg.2 Set.left_mem_Ici hy.le ha hb hab)
+      · exact (h_mono hc.le (hc.le.trans hc') hc').trans (hg.2 Set.self_mem_Ici hy.le ha hb hab)
       · rw [← h_eq]
         gcongr
-        exact h_anti hx Set.right_mem_Iic hx
+        exact h_anti hx Set.self_mem_Iic hx
   · rw [Set.piecewise_eq_of_notMem (Set.Iic e) f g (Set.notMem_Iic.mpr hx),
       Set.piecewise_eq_of_mem (Set.Iic e) f g hy]
     obtain hc | hc := le_or_gt (a • x + b • y) e
     · rw [Set.piecewise_eq_of_mem (Set.Iic e) f g hc]
       have hc' : a • e + b • y ≤ a • x + b • y := by gcongr
       trans a • f e + b • f y
-      · exact (h_anti (hc'.trans hc) hc hc').trans (hf.2 Set.right_mem_Iic hy ha hb hab)
+      · exact (h_anti (hc'.trans hc) hc hc').trans (hf.2 Set.self_mem_Iic hy ha hb hab)
       · rw [h_eq]
         gcongr
-        exact h_mono Set.left_mem_Ici hx.le hx.le
+        exact h_mono Set.self_mem_Ici hx.le hx.le
     · rw [Set.piecewise_eq_of_notMem (Set.Iic e) f g (Set.notMem_Iic.mpr hc)]
       have hc' : a • x + b • y ≤ a • x + b • e := by gcongr
       trans a • g x + b • g e
-      · exact (h_mono hc.le (hc.le.trans hc') hc').trans (hg.2 hx.le Set.left_mem_Ici ha hb hab)
+      · exact (h_mono hc.le (hc.le.trans hc') hc').trans (hg.2 hx.le Set.self_mem_Ici ha hb hab)
       · rw [← h_eq]
         gcongr
-        exact h_anti hy Set.right_mem_Iic hy
+        exact h_anti hy Set.self_mem_Iic hy
   · have hc : e < a • x + b • y :=
         (lt_min hx hy).trans_le (Convex.min_le_combo x y ha hb hab)
     rw [(Set.Iic e).piecewise_eq_of_notMem f g (Set.notMem_Iic.mpr hx),

--- a/Mathlib/Analysis/Convex/Topology.lean
+++ b/Mathlib/Analysis/Convex/Topology.lean
@@ -462,7 +462,7 @@ private lemma diff_singleton_eventually_mem_nhds_left {s : Set 𝕜} {a : 𝕜}
   have : Ioo b a ⊆ s := h b (subset_closure hbs)
   apply eventually_of_mem (U := Ioo b a) ?_ fun x hx ↦ ?_
   · exact mem_nhdsWithin.2 ⟨Ioi b, isOpen_Ioi, hba, fun _ ⟨h₁, _, h₂⟩ ↦ ⟨h₁, h₂⟩⟩
-  · exact mem_nhds_iff.2 ⟨Ioo b a, subset_diff_singleton this right_mem_Ioo.mp, isOpen_Ioo, hx⟩
+  · exact mem_nhds_iff.2 ⟨Ioo b a, subset_diff_singleton this right_notMem_Ioo, isOpen_Ioo, hx⟩
 
 theorem Convex.diff_singleton_eventually_mem_nhds {s : Set 𝕜} (hs : Convex 𝕜 s) (a : 𝕜) :
     ∀ᶠ x in 𝓝[s \ {a}] a, s \ {a} ∈ 𝓝 x := by

--- a/Mathlib/Analysis/ODE/Gronwall.lean
+++ b/Mathlib/Analysis/ODE/Gronwall.lean
@@ -125,7 +125,7 @@ theorem le_gronwallBound_of_liminf_deriv_right_le {f f' : ℝ → ℝ} {δ K ε 
   intro x hx
   change f x ≤ (fun ε' => gronwallBound δ K ε' (x - a)) ε
   convert continuousWithinAt_const.closure_le _ _ (H x hx)
-  · simp only [closure_Ioi, left_mem_Ici]
+  · simp only [closure_Ioi, self_mem_Ici]
   exact (gronwallBound_continuous_ε δ K (x - a)).continuousWithinAt
 
 /-- A Grönwall-like inequality: if `f : ℝ → E` is continuous on `[a, b]`, has right derivative

--- a/Mathlib/Analysis/SpecialFunctions/Trigonometric/InverseDeriv.lean
+++ b/Mathlib/Analysis/SpecialFunctions/Trigonometric/InverseDeriv.lean
@@ -79,7 +79,7 @@ theorem differentiableWithinAt_arcsin_Ici {x : ℝ} :
   have : sin ∘ arcsin =ᶠ[𝓝[≥] (-1 : ℝ)] id := by
     filter_upwards [Icc_mem_nhdsGE (neg_lt_self zero_lt_one)] with x using sin_arcsin'
   have := h.hasDerivWithinAt.sin.congr_of_eventuallyEq this.symm (by simp)
-  simpa using (uniqueDiffOn_Ici _ _ left_mem_Ici).eq_deriv _ this (hasDerivWithinAt_id _ _)
+  simpa using (uniqueDiffOn_Ici _ _ self_mem_Ici).eq_deriv _ this (hasDerivWithinAt_id _ _)
 
 theorem differentiableWithinAt_arcsin_Iic {x : ℝ} :
     DifferentiableWithinAt ℝ arcsin (Iic x) x ↔ x ≠ 1 := by

--- a/Mathlib/Geometry/Manifold/Instances/Real.lean
+++ b/Mathlib/Geometry/Manifold/Instances/Real.lean
@@ -454,10 +454,7 @@ lemma boundary_Icc : (𝓡∂ 1).boundary (Icc x y) = {⊥, ⊤} := by
   · apply iff_of_false
     · simpa [← mem_compl_iff, ModelWithCorners.compl_boundary] using
         Icc_isInteriorPoint_interior hp
-    · rw [mem_insert_iff, mem_singleton_iff]
-      push_neg
-      constructor <;> by_contra h <;> rw [congrArg Subtype.val h] at hp
-      exacts [left_mem_Ioo.mp hp, right_mem_Ioo.mp hp]
+    · rintro (rfl | rfl) <;> simp at hp
 
 variable {E : Type*} [NormedAddCommGroup E] [NormedSpace ℝ E]
   {H : Type*} [TopologicalSpace H] (I : ModelWithCorners ℝ E H)

--- a/Mathlib/MeasureTheory/Integral/IntegralEqImproper.lean
+++ b/Mathlib/MeasureTheory/Integral/IntegralEqImproper.lean
@@ -335,7 +335,7 @@ variable {α ι : Type*} [Countable ι] [MeasurableSpace α] {μ : Measure α}
 
 theorem AECover.biUnion_Iic_aecover [Preorder ι] {φ : ι → Set α} (hφ : AECover μ atTop φ) :
     AECover μ atTop fun n : ι => ⋃ (k) (_h : k ∈ Iic n), φ k :=
-  hφ.superset (fun _ ↦ subset_biUnion_of_mem right_mem_Iic) fun _ ↦ .biUnion (to_countable _)
+  hφ.superset (fun _ ↦ subset_biUnion_of_mem self_mem_Iic) fun _ ↦ .biUnion (to_countable _)
     fun _ _ ↦ (hφ.2 _)
 
 theorem AECover.biInter_Ici_aecover [Preorder ι] {φ : ι → Set α}
@@ -368,8 +368,8 @@ theorem AECover.lintegral_tendsto_of_nat {φ : ℕ → Set α} (hφ : AECover μ
   have lim₂ := lintegral_tendsto_of_monotone_of_nat hφ.biUnion_Iic_aecover
     (fun i j hij => biUnion_subset_biUnion_left (Iic_subset_Iic.mpr hij)) hfm
   refine tendsto_of_tendsto_of_tendsto_of_le_of_le lim₁ lim₂ (fun n ↦ ?_) fun n ↦ ?_
-  exacts [lintegral_mono_set (biInter_subset_of_mem left_mem_Ici),
-    lintegral_mono_set (subset_biUnion_of_mem right_mem_Iic)]
+  exacts [lintegral_mono_set (biInter_subset_of_mem self_mem_Ici),
+    lintegral_mono_set (subset_biUnion_of_mem self_mem_Iic)]
 
 theorem AECover.lintegral_tendsto_of_countably_generated [l.IsCountablyGenerated] {φ : ι → Set α}
     (hφ : AECover μ l φ) {f : α → ℝ≥0∞} (hfm : AEMeasurable f μ) :
@@ -741,7 +741,7 @@ theorem integral_Ioi_of_hasDerivAt_of_tendsto' (hderiv : ∀ x ∈ Ici a, HasDer
     ∫ x in Ioi a, f' x = m - f a := by
   refine integral_Ioi_of_hasDerivAt_of_tendsto ?_ (fun x hx => hderiv x hx.out.le)
     f'int hf
-  exact (hderiv a left_mem_Ici).continuousAt.continuousWithinAt
+  exact (hderiv a self_mem_Ici).continuousAt.continuousWithinAt
 
 /-- A special case of `integral_Ioi_of_hasDerivAt_of_tendsto` where we assume that `f` is C^1 with
 compact support. -/
@@ -791,7 +791,7 @@ on `[a, +∞)`. -/
 theorem integrableOn_Ioi_deriv_of_nonneg' (hderiv : ∀ x ∈ Ici a, HasDerivAt g (g' x) x)
     (g'pos : ∀ x ∈ Ioi a, 0 ≤ g' x) (hg : Tendsto g atTop (𝓝 l)) : IntegrableOn g' (Ioi a) := by
   refine integrableOn_Ioi_deriv_of_nonneg ?_ (fun x hx => hderiv x hx.out.le) g'pos hg
-  exact (hderiv a left_mem_Ici).continuousAt.continuousWithinAt
+  exact (hderiv a self_mem_Ici).continuousAt.continuousWithinAt
 
 /-- When a function has a limit at infinity `l`, and its derivative is nonnegative, then the
 integral of the derivative on `(a, +∞)` is `l - g a` (and the derivative is integrable, see
@@ -827,7 +827,7 @@ on `[a, +∞)`. -/
 theorem integrableOn_Ioi_deriv_of_nonpos' (hderiv : ∀ x ∈ Ici a, HasDerivAt g (g' x) x)
     (g'neg : ∀ x ∈ Ioi a, g' x ≤ 0) (hg : Tendsto g atTop (𝓝 l)) : IntegrableOn g' (Ioi a) := by
   refine integrableOn_Ioi_deriv_of_nonpos ?_ (fun x hx ↦ hderiv x hx.out.le) g'neg hg
-  exact (hderiv a left_mem_Ici).continuousAt.continuousWithinAt
+  exact (hderiv a self_mem_Ici).continuousAt.continuousWithinAt
 
 /-- When a function has a limit at infinity `l`, and its derivative is nonpositive, then the
 integral of the derivative on `(a, +∞)` is `l - g a` (and the derivative is integrable, see
@@ -936,7 +936,7 @@ theorem integral_Iic_of_hasDerivAt_of_tendsto'
     (hf : Tendsto f atBot (𝓝 m)) : ∫ x in Iic a, f' x = f a - m := by
   refine integral_Iic_of_hasDerivAt_of_tendsto ?_ (fun x hx => hderiv x hx.out.le)
     f'int hf
-  exact (hderiv a right_mem_Iic).continuousAt.continuousWithinAt
+  exact (hderiv a self_mem_Iic).continuousAt.continuousWithinAt
 
 /-- A special case of `integral_Iic_of_hasDerivAt_of_tendsto` where we assume that `f` is C^1 with
 compact support. -/
@@ -1035,7 +1035,7 @@ theorem integral_comp_smul_deriv_Ioi {f f' : ℝ → ℝ} {g : ℝ → E} {a : �
   have t2 := intervalIntegral_tendsto_integral_Ioi _ hg2 tendsto_id
   have : Ioi (f a) ⊆ f '' Ici a :=
     Ioi_subset_Ici_self.trans <|
-      IsPreconnected.intermediate_value_Ici isPreconnected_Ici left_mem_Ici
+      IsPreconnected.intermediate_value_Ici isPreconnected_Ici self_mem_Ici
         (le_principal_iff.mpr <| Ici_mem_atTop _) hf hft
   have t1 := (intervalIntegral_tendsto_integral_Ioi _ (hg1.mono_set this) tendsto_id).comp hft
   exact tendsto_nhds_unique (Tendsto.congr' (eventuallyEq_of_mem (Ioi_mem_atTop a) eq) t2) t1

--- a/Mathlib/MeasureTheory/Integral/IntervalIntegral/FundThmCalculus.lean
+++ b/Mathlib/MeasureTheory/Integral/IntervalIntegral/FundThmCalculus.lean
@@ -223,11 +223,11 @@ instance nhds (a : ℝ) : FTCFilter a (𝓝 a) (𝓝 a) where
 instance nhdsUniv (a : ℝ) : FTCFilter a (𝓝[univ] a) (𝓝 a) := by rw [nhdsWithin_univ]; infer_instance
 
 instance nhdsLeft (a : ℝ) : FTCFilter a (𝓝[≤] a) (𝓝[≤] a) where
-  pure_le := pure_le_nhdsWithin right_mem_Iic
+  pure_le := pure_le_nhdsWithin self_mem_Iic
   le_nhds := inf_le_left
 
 instance nhdsRight (a : ℝ) : FTCFilter a (𝓝[≥] a) (𝓝[>] a) where
-  pure_le := pure_le_nhdsWithin left_mem_Ici
+  pure_le := pure_le_nhdsWithin self_mem_Ici
   le_nhds := inf_le_left
 
 instance nhdsIcc {x a b : ℝ} [h : Fact (x ∈ Icc a b)] :
@@ -828,8 +828,8 @@ theorem integral_hasFDerivWithinAt (hf : IntervalIntegrable f volume a b)
 /-- An auxiliary tactic closing goals `UniqueDiffWithinAt ℝ s a` where
 `s ∈ {Iic a, Ici a, univ}`. -/
 macro "uniqueDiffWithinAt_Ici_Iic_univ" : tactic =>
-  `(tactic| (first | exact uniqueDiffOn_Ici _ _ left_mem_Ici |
-    exact uniqueDiffOn_Iic _ _ right_mem_Iic | exact uniqueDiffWithinAt_univ (𝕜 := ℝ) (E := ℝ)))
+  `(tactic| (first | exact uniqueDiffOn_Ici _ _ self_mem_Ici |
+    exact uniqueDiffOn_Iic _ _ self_mem_Iic | exact uniqueDiffWithinAt_univ (𝕜 := ℝ) (E := ℝ)))
 
 /-- Let `f` be a measurable function integrable on `a..b`. Choose `s ∈ {Iic a, Ici a, univ}`
 and `t ∈ {Iic b, Ici b, univ}`. Suppose that `f` tends to `ca` and `cb` almost surely at the filters

--- a/Mathlib/NumberTheory/Harmonic/ZetaAsymp.lean
+++ b/Mathlib/NumberTheory/Harmonic/ZetaAsymp.lean
@@ -311,7 +311,7 @@ lemma tendsto_riemannZeta_sub_one_div_nhds_right :
   · apply tendsto_const_nhds.sub
     rw [← one_mul (term_tsum 1)]
     apply (tendsto_id.mono_left nhdsWithin_le_nhds).mul
-    have := continuousOn_term_tsum.continuousWithinAt left_mem_Ici
+    have := continuousOn_term_tsum.continuousWithinAt self_mem_Ici
     exact Tendsto.mono_left this (nhdsWithin_mono _ Ioi_subset_Ici_self)
 
 /-- The function `ζ s - 1 / (s - 1)` tends to `γ` as `s → 1`. -/

--- a/Mathlib/Order/Bounds/Basic.lean
+++ b/Mathlib/Order/Bounds/Basic.lean
@@ -440,10 +440,10 @@ theorem BddBelow.exists_le [SemilatticeInf γ] {s : Set γ} (hs : BddBelow s) (x
 
 
 theorem isLeast_Ici : IsLeast (Ici a) a :=
-  ⟨left_mem_Ici, fun _ => id⟩
+  ⟨self_mem_Ici, fun _ => id⟩
 
 theorem isGreatest_Iic : IsGreatest (Iic a) a :=
-  ⟨right_mem_Iic, fun _ => id⟩
+  ⟨self_mem_Iic, fun _ => id⟩
 
 theorem isLUB_Iic : IsLUB (Iic a) a :=
   isGreatest_Iic.isLUB

--- a/Mathlib/Order/Filter/AtTopBot/CompleteLattice.lean
+++ b/Mathlib/Order/Filter/AtTopBot/CompleteLattice.lean
@@ -26,7 +26,7 @@ namespace Filter
 theorem Subsingleton.atTop_eq (α) [Subsingleton α] [Preorder α] : (atTop : Filter α) = ⊤ := by
   refine top_unique fun s hs x => ?_
   rw [atTop, ciInf_subsingleton x, mem_principal] at hs
-  exact hs left_mem_Ici
+  exact hs self_mem_Ici
 
 @[nontriviality]
 theorem Subsingleton.atBot_eq (α) [Subsingleton α] [Preorder α] : (atBot : Filter α) = ⊤ :=

--- a/Mathlib/Order/Filter/AtTopBot/Disjoint.lean
+++ b/Mathlib/Order/Filter/AtTopBot/Disjoint.lean
@@ -39,7 +39,7 @@ theorem disjoint_atBot_principal_Ici [Preorder α] [NoBotOrder α] (x : α) :
 
 theorem disjoint_pure_atTop [Preorder α] [NoTopOrder α] (x : α) : Disjoint (pure x) atTop :=
   Disjoint.symm <| (disjoint_atTop_principal_Iic x).mono_right <| le_principal_iff.2 <|
-    mem_pure.2 right_mem_Iic
+    mem_pure.2 self_mem_Iic
 
 theorem disjoint_pure_atBot [Preorder α] [NoBotOrder α] (x : α) : Disjoint (pure x) atBot :=
   @disjoint_pure_atTop αᵒᵈ _ _ _

--- a/Mathlib/Order/Filter/EventuallyConst.lean
+++ b/Mathlib/Order/Filter/EventuallyConst.lean
@@ -159,7 +159,7 @@ end EventuallyConst
 
 lemma eventuallyConst_atTop [SemilatticeSup α] [Nonempty α] :
     EventuallyConst f atTop ↔ (∃ i, ∀ j, i ≤ j → f j = f i) :=
-  (atTop_basis.eventuallyConst_iff' fun _ _ ↦ left_mem_Ici).trans <| by
+  (atTop_basis.eventuallyConst_iff' fun _ _ ↦ self_mem_Ici).trans <| by
     simp only [true_and, mem_Ici]
 
 lemma eventuallyConst_atTop_nat {f : ℕ → α} :

--- a/Mathlib/Order/Filter/Map.lean
+++ b/Mathlib/Order/Filter/Map.lean
@@ -991,7 +991,7 @@ variable {α β : Type*} {F : Filter α} {G : Filter β}
 theorem Filter.map_surjOn_Iic_iff_le_map {m : α → β} :
     SurjOn (map m) (Iic F) (Iic G) ↔ G ≤ map m F := by
   refine ⟨fun hm ↦ ?_, fun hm ↦ ?_⟩
-  · rcases hm right_mem_Iic with ⟨H, (hHF : H ≤ F), rfl⟩
+  · rcases hm self_mem_Iic with ⟨H, (hHF : H ≤ F), rfl⟩
     exact map_mono hHF
   · have : RightInvOn (F ⊓ comap m ·) (map m) (Iic G) :=
       fun H (hHG : H ≤ G) ↦ by simpa [Filter.push_pull] using hHG.trans hm

--- a/Mathlib/Order/Filter/Tendsto.lean
+++ b/Mathlib/Order/Filter/Tendsto.lean
@@ -300,7 +300,7 @@ variable {F : Filter α} {G : Filter β}
 
 theorem Filter.map_mapsTo_Iic_iff_tendsto {m : α → β} :
     MapsTo (map m) (Iic F) (Iic G) ↔ Tendsto m F G :=
-  ⟨fun hm ↦ hm right_mem_Iic, fun hm _ ↦ hm.mono_left⟩
+  ⟨fun hm ↦ hm self_mem_Iic, fun hm _ ↦ hm.mono_left⟩
 
 alias ⟨_, Filter.Tendsto.map_mapsTo_Iic⟩ := Filter.map_mapsTo_Iic_iff_tendsto
 

--- a/Mathlib/Order/Interval/Set/Basic.lean
+++ b/Mathlib/Order/Interval/Set/Basic.lean
@@ -69,25 +69,41 @@ instance decidableMemIci [Decidable (a ≤ x)] : Decidable (x ∈ Ici a) := by a
 
 instance decidableMemIoi [Decidable (a < x)] : Decidable (x ∈ Ioi a) := by assumption
 
+theorem left_notMem_Ioo (a b : α) : a ∉ Ioo a b := by simp
+theorem left_notMem_Ioc (a b : α) : a ∉ Ioc a b := by simp
+
+@[deprecated left_notMem_Ioo (since := "2025-12-26")]
 theorem left_mem_Ioo : a ∈ Ioo a b ↔ False := by simp
 
-theorem left_mem_Ico : a ∈ Ico a b ↔ a < b := by simp [le_refl]
-
-theorem left_mem_Icc : a ∈ Icc a b ↔ a ≤ b := by simp [le_refl]
-
+@[deprecated left_notMem_Ioc (since := "2025-12-26")]
 theorem left_mem_Ioc : a ∈ Ioc a b ↔ False := by simp
 
-theorem left_mem_Ici : a ∈ Ici a := by simp
+theorem left_mem_Ico : a ∈ Ico a b ↔ a < b := by simp
+theorem left_mem_Icc : a ∈ Icc a b ↔ a ≤ b := by simp
 
+theorem self_notMem_Ioi : a ∉ Ioi a := by simp
+theorem self_mem_Ici : a ∈ Ici a := by simp
+
+@[deprecated (since := "2025-12-26")]
+alias left_mem_Ici := self_mem_Ici
+
+theorem right_notMem_Ioo : b ∉ Ioo a b := by simp
+theorem right_notMem_Ico : b ∉ Ico a b := by simp
+
+@[deprecated right_notMem_Ioo (since := "2025-12-26")]
 theorem right_mem_Ioo : b ∈ Ioo a b ↔ False := by simp
 
+@[deprecated right_notMem_Ico (since := "2025-12-26")]
 theorem right_mem_Ico : b ∈ Ico a b ↔ False := by simp
 
-theorem right_mem_Icc : b ∈ Icc a b ↔ a ≤ b := by simp [le_refl]
+theorem right_mem_Ioc : b ∈ Ioc a b ↔ a < b := by simp
+theorem right_mem_Icc : b ∈ Icc a b ↔ a ≤ b := by simp
 
-theorem right_mem_Ioc : b ∈ Ioc a b ↔ a < b := by simp [le_refl]
+theorem self_notMem_Iio : a ∉ Iio a := by simp
+theorem self_mem_Iic : a ∈ Iic a := by simp
 
-theorem right_mem_Iic : a ∈ Iic a := by simp
+@[deprecated (since := "2025-12-26")]
+alias right_mem_Iic := self_mem_Iic
 
 @[simp]
 theorem Ici_toDual : Ici (toDual a) = ofDual ⁻¹' Iic a :=
@@ -167,11 +183,11 @@ theorem nonempty_Ioc : (Ioc a b).Nonempty ↔ a < b :=
 
 @[simp]
 theorem nonempty_Ici : (Ici a).Nonempty :=
-  ⟨a, left_mem_Ici⟩
+  ⟨a, self_mem_Ici⟩
 
 @[simp]
 theorem nonempty_Iic : (Iic a).Nonempty :=
-  ⟨a, right_mem_Iic⟩
+  ⟨a, self_mem_Iic⟩
 
 @[simp]
 theorem nonempty_Ioo [DenselyOrdered α] : (Ioo a b).Nonempty ↔ a < b :=
@@ -272,7 +288,7 @@ theorem Ioo_self (a : α) : Ioo a a = ∅ :=
 
 @[simp]
 theorem Ici_subset_Ici : Ici a ⊆ Ici b ↔ b ≤ a :=
-  ⟨fun h => h <| left_mem_Ici, fun h _ hx => h.trans hx⟩
+  ⟨fun h ↦ h self_mem_Ici, fun h _ ↦ h.trans⟩
 
 @[gcongr] alias ⟨_, _root_.GCongr.Ici_subset_Ici_of_le⟩ := Ici_subset_Ici
 
@@ -282,7 +298,7 @@ theorem Ici_ssubset_Ici : Ici a ⊂ Ici b ↔ b < a where
     obtain ⟨ab, c, cb, ac⟩ := ssubset_iff_exists.mp h
     exact lt_of_le_not_ge (Ici_subset_Ici.mp ab) (fun h' ↦ ac (h'.trans cb))
   mpr h := (ssubset_iff_of_subset (Ici_subset_Ici.mpr h.le)).mpr
-    ⟨b, right_mem_Iic, fun h' => h.not_ge h'⟩
+    ⟨b, self_mem_Iic, fun h' => h.not_ge h'⟩
 
 @[gcongr] alias ⟨_, _root_.GCongr.Ici_ssubset_Ici_of_le⟩ := Ici_ssubset_Ici
 
@@ -300,11 +316,11 @@ theorem Iic_ssubset_Iic : Iic a ⊂ Iic b ↔ a < b :=
 
 @[simp]
 theorem Ici_subset_Ioi : Ici a ⊆ Ioi b ↔ b < a :=
-  ⟨fun h => h left_mem_Ici, fun h _ hx => h.trans_le hx⟩
+  ⟨fun h => h self_mem_Ici, fun h _ hx => h.trans_le hx⟩
 
 @[simp]
 theorem Iic_subset_Iio : Iic a ⊆ Iio b ↔ a < b :=
-  ⟨fun h => h right_mem_Iic, fun h _ hx => lt_of_le_of_lt hx h⟩
+  ⟨fun h => h self_mem_Iic, fun h _ hx => lt_of_le_of_lt hx h⟩
 
 @[gcongr]
 theorem Ioo_subset_Ioo (h₁ : a₂ ≤ a₁) (h₂ : b₁ ≤ b₂) : Ioo a₁ b₁ ⊆ Ioo a₂ b₂ := fun _ ⟨hx₁, hx₂⟩ =>
@@ -714,11 +730,11 @@ theorem Icc_diff_Ioo_same (h : a ≤ b) : Icc a b \ Ioo a b = {a, b} := by
 
 @[simp]
 theorem Ici_diff_Ioi_same : Ici a \ Ioi a = {a} := by
-  rw [← Ici_diff_left, diff_diff_cancel_left (singleton_subset_iff.2 left_mem_Ici)]
+  rw [← Ici_diff_left, diff_diff_cancel_left (singleton_subset_iff.2 self_mem_Ici)]
 
 @[simp]
 theorem Iic_diff_Iio_same : Iic a \ Iio a = {a} := by
-  rw [← Iic_diff_right, diff_diff_cancel_left (singleton_subset_iff.2 right_mem_Iic)]
+  rw [← Iic_diff_right, diff_diff_cancel_left (singleton_subset_iff.2 self_mem_Iic)]
 
 theorem Ioi_union_left : Ioi a ∪ {a} = Ici a :=
   ext fun x => by simp [eq_comm, le_iff_eq_or_lt]
@@ -812,7 +828,7 @@ theorem eq_endpoints_or_mem_Ioo_of_mem_Icc {x : α} (hmem : x ∈ Icc a b) :
   hmem.1.eq_or_lt'.imp_right fun h => eq_right_or_mem_Ioo_of_mem_Ioc ⟨h, hmem.2⟩
 
 theorem _root_.IsMax.Ici_eq (h : IsMax a) : Ici a = {a} :=
-  eq_singleton_iff_unique_mem.2 ⟨left_mem_Ici, fun _ => h.eq_of_ge⟩
+  eq_singleton_iff_unique_mem.2 ⟨self_mem_Ici, fun _ => h.eq_of_ge⟩
 
 theorem _root_.IsMin.Iic_eq (h : IsMin a) : Iic a = {a} :=
   h.toDual.Ici_eq

--- a/Mathlib/Order/Interval/Set/Basic.lean
+++ b/Mathlib/Order/Interval/Set/Basic.lean
@@ -288,7 +288,7 @@ theorem Ioo_self (a : α) : Ioo a a = ∅ :=
 
 @[simp]
 theorem Ici_subset_Ici : Ici a ⊆ Ici b ↔ b ≤ a :=
-  ⟨fun h ↦ h self_mem_Ici, fun h _ ↦ h.trans⟩
+  ⟨fun h => h self_mem_Ici, fun h _ => h.trans⟩
 
 @[gcongr] alias ⟨_, _root_.GCongr.Ici_subset_Ici_of_le⟩ := Ici_subset_Ici
 
@@ -316,7 +316,7 @@ theorem Iic_ssubset_Iic : Iic a ⊂ Iic b ↔ a < b :=
 
 @[simp]
 theorem Ici_subset_Ioi : Ici a ⊆ Ioi b ↔ b < a :=
-  ⟨fun h => h self_mem_Ici, fun h _ hx => h.trans_le hx⟩
+  ⟨fun h => h self_mem_Ici, fun h _ => h.trans_le⟩
 
 @[simp]
 theorem Iic_subset_Iio : Iic a ⊆ Iio b ↔ a < b :=

--- a/Mathlib/Order/Interval/Set/Disjoint.lean
+++ b/Mathlib/Order/Interval/Set/Disjoint.lean
@@ -103,11 +103,11 @@ theorem Iio_disjoint_Ioi_iff [DenselyOrdered α] : Disjoint (Iio a) (Ioi b) ↔ 
 
 @[simp]
 theorem iUnion_Iic : ⋃ a : α, Iic a = univ :=
-  iUnion_eq_univ_iff.2 fun x => ⟨x, right_mem_Iic⟩
+  iUnion_eq_univ_iff.2 fun x => ⟨x, self_mem_Iic⟩
 
 @[simp]
 theorem iUnion_Ici : ⋃ a : α, Ici a = univ :=
-  iUnion_eq_univ_iff.2 fun x => ⟨x, left_mem_Ici⟩
+  iUnion_eq_univ_iff.2 fun x => ⟨x, self_mem_Ici⟩
 
 @[simp]
 theorem iUnion_Icc_right (a : α) : ⋃ b, Icc a b = Ici a := by

--- a/Mathlib/Order/Monotone/Extension.lean
+++ b/Mathlib/Order/Monotone/Extension.lean
@@ -36,7 +36,7 @@ theorem MonotoneOn.exists_monotone_extension (h : MonotoneOn f s) (hl : BddBelow
     have hgs : EqOn f g s := by
       intro x hx
       simp only [g]
-      have : IsGreatest (Iic x ∩ s) x := ⟨⟨right_mem_Iic, hx⟩, fun y hy => hy.1⟩
+      have : IsGreatest (Iic x ∩ s) x := ⟨⟨self_mem_Iic, hx⟩, fun y hy => hy.1⟩
       rw [if_neg this.nonempty.not_disjoint,
         ((h.mono inter_subset_right).map_isGreatest this).csSup_eq]
     refine ⟨g, fun x y hxy => ?_, hgs⟩

--- a/Mathlib/Topology/Order/MonotoneContinuity.lean
+++ b/Mathlib/Topology/Order/MonotoneContinuity.lean
@@ -44,8 +44,7 @@ function `f : ℝ → ℝ` given by `f x = if x ≤ 0 then x else x + 1` would b
 theorem StrictMonoOn.continuousWithinAt_right_of_exists_between {f : α → β} {s : Set α} {a : α}
     (h_mono : StrictMonoOn f s) (hs : s ∈ 𝓝[≥] a) (hfs : ∀ b > f a, ∃ c ∈ s, f c ∈ Ioc (f a) b) :
     ContinuousWithinAt f (Ici a) a := by
-  have ha : a ∈ Ici a := left_mem_Ici
-  have has : a ∈ s := mem_of_mem_nhdsWithin ha hs
+  have has : a ∈ s := mem_of_mem_nhdsWithin self_mem_Ici hs
   refine tendsto_order.2 ⟨fun b hb => ?_, fun b hb => ?_⟩
   · filter_upwards [hs, @self_mem_nhdsWithin _ _ a (Ici a)] with _ hxs hxa using hb.trans_le
       ((h_mono.le_iff_le has hxs).2 hxa)
@@ -64,8 +63,7 @@ because otherwise the function `ceil : ℝ → ℤ` would be a counter-example a
 theorem continuousWithinAt_right_of_monotoneOn_of_exists_between {f : α → β} {s : Set α} {a : α}
     (h_mono : MonotoneOn f s) (hs : s ∈ 𝓝[≥] a) (hfs : ∀ b > f a, ∃ c ∈ s, f c ∈ Ioo (f a) b) :
     ContinuousWithinAt f (Ici a) a := by
-  have ha : a ∈ Ici a := left_mem_Ici
-  have has : a ∈ s := mem_of_mem_nhdsWithin ha hs
+  have has : a ∈ s := mem_of_mem_nhdsWithin self_mem_Ici hs
   refine tendsto_order.2 ⟨fun b hb => ?_, fun b hb => ?_⟩
   · filter_upwards [hs, @self_mem_nhdsWithin _ _ a (Ici a)] with _ hxs hxa using hb.trans_le
       (h_mono has hxs hxa)

--- a/Mathlib/Topology/UniformSpace/Cauchy.lean
+++ b/Mathlib/Topology/UniformSpace/Cauchy.lean
@@ -745,7 +745,7 @@ theorem setSeq_mono ⦃m n : ℕ⦄ (h : m ≤ n) : setSeq hf U_mem n ⊆ setSeq
   biInter_subset_biInter_left <| Iic_subset_Iic.2 h
 
 theorem setSeq_sub_aux (n : ℕ) : setSeq hf U_mem n ⊆ setSeqAux hf U_mem n :=
-  biInter_subset_of_mem right_mem_Iic
+  biInter_subset_of_mem self_mem_Iic
 
 theorem setSeq_prod_subset {N m n} (hm : N ≤ m) (hn : N ≤ n) :
     setSeq hf U_mem m ×ˢ setSeq hf U_mem n ⊆ U N := fun p hp => by


### PR DESCRIPTION
This PR does the following:

- Deprecate various lemmas of the form `x ∈ Ixx a b ↔ False` in favor of new lemmas `x ∉ Ixx a b`.
- Rename lemmas `left_mem_Ixi` and `right_mem_Iix` to simply `self_mem_Ixi` or `self_mem_Iix`.

---
<!-- Your PR title will become the first line of the commit message.

In this box, the text above the `---` (if not empty) will be appended
to the commit message, and can be used to give additional context or
details. Please leave a blank newline before the `---`, otherwise GitHub
will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

When merging, all the commits will be squashed into a single commit
listing all co-authors.

Co-authors in the squash commit are gathered from two sources:

First, all authors of commits to this PR branch are included. Thus,
one way to add co-authors is to include at least one commit authored by
each co-author among the commits in the pull request. If necessary, you
may create empty commits to indicate co-authorship, using commands like so:

git commit --author="Author Name <author@email.com>" --allow-empty -m "add Author Name as coauthor"

Second, co-authors can also be listed in lines at the very bottom of
the commit message (that is, directly before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines
at the bottom of the commit message (before the `---`, and also before
any "Co-authored-by" lines) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

I get what, say, `left_mem_Ici` is going for, but we generally reserve left/right for two-argument functions, and this is not one of them.

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
