### PR TITLE
[Merged by Bors] - feat(Combinatorics/SimpleGraph): more about two-reachability

### DIFF
--- a/Mathlib/Combinatorics/SimpleGraph/Connectivity/Connected.lean
+++ b/Mathlib/Combinatorics/SimpleGraph/Connectivity/Connected.lean
@@ -818,17 +818,6 @@ end BridgeEdges
 ### 2-reachability
 
 In this section, we prove results about 2-connected components of a graph, but without naming them.
-
-#### TODO
-
-Should we explicitly have
-```
-def IsEdgeReachable (k : ℕ) (u v : V) : Prop :=
-  ∀ ⦃s : Set (Sym2 V)⦄, s.encard < k → (G.deleteEdges s).Reachable u v
-```
-? `G.IsEdgeReachable 2 u v` would then be equivalent to the less idiomatic condition
-`∃ x, ¬ (G.deleteEdges {s(x, y)}).Reachable u y` we use below.
-See https://github.com/leanprover-community/mathlib4/issues/31691.
 -/
 
 namespace Walk

--- a/Mathlib/Combinatorics/SimpleGraph/Connectivity/EdgeConnectivity.lean
+++ b/Mathlib/Combinatorics/SimpleGraph/Connectivity/EdgeConnectivity.lean
@@ -25,7 +25,7 @@ This file defines k-edge-connectivity for simple graphs.
 
 namespace SimpleGraph
 
-variable {V : Type*} {G H : SimpleGraph V} {k l : ℕ} {u v w : V}
+variable {V : Type*} {G H : SimpleGraph V} {k l : ℕ} {u v w x y : V}
 
 variable (G k u v) in
 /-- Two vertices are `k`-edge-reachable if they remain reachable after removing strictly fewer than
@@ -73,43 +73,32 @@ lemma isEdgeReachable_one : G.IsEdgeReachable 1 u v ↔ G.Reachable u v := by
 lemma isEdgeConnected_one : G.IsEdgeConnected 1 ↔ G.Preconnected := by
   simp [IsEdgeConnected, Preconnected]
 
-lemma isEdgeReachable_add_one :
-    G.IsEdgeReachable (k + 1) u v ↔
-      G.Reachable u v ∧ ∀ e ∈ G.edgeSet, (G.deleteEdges {e}).IsEdgeReachable k u v := by
-  refine ⟨fun h ↦ ⟨G.deleteEdges_empty ▸ h (by simp), fun e he s hk ↦ ?_⟩, ?_⟩
+lemma IsEdgeReachable.reachable (hk : k ≠ 0) (huv : G.IsEdgeReachable k u v) : G.Reachable u v :=
+  isEdgeReachable_one.mp (huv.anti (Nat.one_le_iff_ne_zero.mpr hk))
+
+lemma IsEdgeConnected.preconnected (hk : k ≠ 0) (h : G.IsEdgeConnected k) : G.Preconnected :=
+  fun u v ↦ (h u v).reachable hk
+
+lemma IsEdgeConnected.connected [Nonempty V] (hk : k ≠ 0) (h : G.IsEdgeConnected k) :
+    G.Connected where
+  preconnected := h.preconnected hk
+
+lemma isEdgeReachable_add_one (hk : k ≠ 0) :
+    G.IsEdgeReachable (k + 1) u v ↔ ∀ e, (G.deleteEdges {e}).IsEdgeReachable k u v := by
+  refine ⟨fun h e s hk ↦ ?_, fun h s hs ↦ ?_⟩
   · rw [deleteEdges_deleteEdges, Set.union_comm]
     apply h
     grw [Set.encard_union_le, Set.encard_singleton]
     exact ENat.add_lt_add_iff_right ENat.one_ne_top |>.mpr hk
-  · intro ⟨h_one, h_succ⟩ s hk
-    rw [G.deleteEdges_eq_inter_edgeSet s]
-    rcases (s ∩ G.edgeSet).eq_empty_or_nonempty with h_empty | ⟨e, he⟩
-    · simpa [h_empty]
-    · rw [← Set.insert_diff_self_of_mem he, Set.insert_eq, ← deleteEdges_deleteEdges]
-      refine h_succ e he.right <| ENat.add_lt_add_iff_right ENat.one_ne_top |>.mp ?_
-      rw [Set.encard_diff_singleton_add_one he]
-      exact Set.encard_mono Set.inter_subset_left |>.trans_lt hk
+  obtain rfl | ⟨e, he⟩ := s.eq_empty_or_nonempty
+  · simpa using (h s(u, u)).reachable hk
+  · rw [← Set.insert_diff_self_of_mem he, Set.insert_eq, ← deleteEdges_deleteEdges]
+    refine h e <| ENat.add_lt_add_iff_right ENat.one_ne_top |>.mp ?_
+    rwa [Set.encard_diff_singleton_add_one he]
 
 lemma isEdgeConnected_add_one (hk : k ≠ 0) :
     G.IsEdgeConnected (k + 1) ↔ ∀ e, (G.deleteEdges {e}).IsEdgeConnected k := by
-  refine ⟨fun h e u v ↦ ?_, fun h u v ↦ isEdgeReachable_add_one.mpr ⟨?_, fun e _ ↦ h e u v⟩⟩
-  · by_cases he : e ∈ G.edgeSet
-    · exact (isEdgeReachable_add_one.mp <| h u v).right e he
-    · rw [G.deleteEdges_eq_self.mpr <| Set.disjoint_singleton_right.mpr he]
-      exact h u v |>.anti <| k.le_succ
-  · refine isEdgeReachable_one.mp ?_ |>.mono <| G.deleteEdges_le {s(u, v)}
-    exact h _ u v |>.anti <| k.one_le_iff_ne_zero.mpr hk
-
-/-- A graph is 2-edge-connected iff it is preconnected and has no bridges. -/
-lemma isEdgeConnected_two : G.IsEdgeConnected 2 ↔ G.Preconnected ∧ ∀ e, ¬G.IsBridge e := by
-  refine ⟨fun h ↦ ⟨fun u v ↦ isEdgeReachable_one.mp <| .anti (Nat.le_succ 1) (h u v), ?_⟩, ?_⟩
-  · rintro ⟨⟩ he_bridge
-    exact he_bridge.right <| h _ _ <| Set.encard_singleton _ ▸ Nat.one_lt_ofNat
-  · refine fun ⟨h_pre, h_bridge⟩ u v ↦ isEdgeReachable_add_one.mpr ⟨h_pre u v, ?_⟩
-    · rintro ⟨⟩ he
-      apply isEdgeReachable_one.mpr
-      have h_conn : G.Connected := { preconnected := h_pre, nonempty := ⟨‹_›⟩ }
-      exact (h_conn.connected_delete_edge_of_not_isBridge <| h_bridge _).preconnected ..
+  simp [IsEdgeConnected, isEdgeReachable_add_one hk, forall_swap (α := Sym2 _)]
 
 /-- An edge is a bridge iff its endpoints are adjacent and not 2-edge-reachable. -/
 lemma isBridge_iff_adj_and_not_isEdgeConnected_two {u v : V} :
@@ -125,14 +114,32 @@ lemma isBridge_iff_adj_and_not_isEdgeConnected_two {u v : V} :
     · exact hx ▸ hr
     exact deleteEdges_adj.mpr ⟨hadj, hx⟩ |>.reachable
 
-lemma IsEdgeReachable.reachable (hk : k ≠ 0) (huv : G.IsEdgeReachable k u v) : G.Reachable u v :=
-  isEdgeReachable_one.mp (huv.anti (Nat.one_le_iff_ne_zero.mpr hk))
+lemma isEdgeReachable_two : G.IsEdgeReachable 2 u v ↔ ∀ e, (G.deleteEdges {e}).Reachable u v := by
+  simp [isEdgeReachable_add_one]
 
-lemma IsEdgeConnected.preconnected (hk : k ≠ 0) (h : G.IsEdgeConnected k) : G.Preconnected :=
-  fun u v ↦ (h u v).reachable hk
+/-- A graph is 2-edge-connected iff it has no bridge. -/
+lemma isEdgeConnected_two : G.IsEdgeConnected 2 ↔ ∀ e, (G.deleteEdges {e}).Preconnected := by
+  simp [isEdgeConnected_add_one]
 
-lemma IsEdgeConnected.connected [Nonempty V] (hk : k ≠ 0) (h : G.IsEdgeConnected k) :
-    G.Connected where
-  preconnected := h.preconnected hk
+/-!
+### 2-reachability
 
-end SimpleGraph
+In this section, we prove results about 2-connected components of a graph, but without naming them.
+-/
+
+namespace Walk
+variable {w : G.Walk u v}
+
+/-- A trail doesn't go through a vertex that is not 2-edge-reachable from its 2-edge-reachable
+endpoints. -/
+lemma IsTrail.not_mem_edges_of_not_isEdgeReachable_two (hw : w.IsTrail)
+    (huv : G.IsEdgeReachable 2 u v) (huy : ¬ G.IsEdgeReachable 2 u y) : y ∉ w.support := by
+  classical
+  obtain ⟨e, he⟩ := by simpa [isEdgeReachable_two] using huy
+  have he' : ¬ (G.deleteEdges {e}).Reachable v y := fun hvy ↦
+    he <| (isEdgeReachable_two.1 huv _).trans hvy
+  exact fun hy ↦ hw.disjoint_edges_takeUntil_dropUntil hy
+    ((w.takeUntil y _).mem_edges_of_not_reachable_deleteEdges he)
+    (by simpa using (w.dropUntil y _).reverse.mem_edges_of_not_reachable_deleteEdges he')
+
+end SimpleGraph.Walk

--- a/Mathlib/Combinatorics/SimpleGraph/Connectivity/EdgeConnectivity.lean
+++ b/Mathlib/Combinatorics/SimpleGraph/Connectivity/EdgeConnectivity.lean
@@ -118,6 +118,8 @@ lemma isEdgeReachable_two : G.IsEdgeReachable 2 u v ↔ ∀ e, (G.deleteEdges {e
   simp [isEdgeReachable_add_one]
 
 /-- A graph is 2-edge-connected iff it has no bridge. -/
+-- TODO: This should be `G.IsEdgeConnected 2 ↔ ∀ e, ¬G.IsBridge e` after
+-- https://github.com/leanprover-community/mathlib4/pull/32583
 lemma isEdgeConnected_two : G.IsEdgeConnected 2 ↔ ∀ e, (G.deleteEdges {e}).Preconnected := by
   simp [isEdgeConnected_add_one]
 

--- a/Mathlib/Combinatorics/SimpleGraph/Connectivity/EdgeConnectivity.lean
+++ b/Mathlib/Combinatorics/SimpleGraph/Connectivity/EdgeConnectivity.lean
@@ -25,7 +25,7 @@ This file defines k-edge-connectivity for simple graphs.
 
 namespace SimpleGraph
 
-variable {V : Type*} {G H : SimpleGraph V} {k l : ℕ} {u v w x y : V}
+variable {V : Type*} {G H : SimpleGraph V} {k l : ℕ} {u v w x : V}
 
 variable (G k u v) in
 /-- Two vertices are `k`-edge-reachable if they remain reachable after removing strictly fewer than
@@ -135,13 +135,13 @@ variable {w : G.Walk u v}
 /-- A trail doesn't go through a vertex that is not 2-edge-reachable from its 2-edge-reachable
 endpoints. -/
 lemma IsTrail.not_mem_edges_of_not_isEdgeReachable_two (hw : w.IsTrail)
-    (huv : G.IsEdgeReachable 2 u v) (huy : ¬ G.IsEdgeReachable 2 u y) : y ∉ w.support := by
+    (huv : G.IsEdgeReachable 2 u v) (huy : ¬ G.IsEdgeReachable 2 u x) : x ∉ w.support := by
   classical
   obtain ⟨e, he⟩ := by simpa [isEdgeReachable_two] using huy
-  have he' : ¬ (G.deleteEdges {e}).Reachable v y := fun hvy ↦
+  have he' : ¬ (G.deleteEdges {e}).Reachable v x := fun hvy ↦
     he <| (isEdgeReachable_two.1 huv _).trans hvy
   exact fun hy ↦ hw.disjoint_edges_takeUntil_dropUntil hy
-    ((w.takeUntil y _).mem_edges_of_not_reachable_deleteEdges he)
-    (by simpa using (w.dropUntil y _).reverse.mem_edges_of_not_reachable_deleteEdges he')
+    ((w.takeUntil x _).mem_edges_of_not_reachable_deleteEdges he)
+    (by simpa using (w.dropUntil x _).reverse.mem_edges_of_not_reachable_deleteEdges he')
 
 end SimpleGraph.Walk

--- a/Mathlib/Combinatorics/SimpleGraph/DeleteEdges.lean
+++ b/Mathlib/Combinatorics/SimpleGraph/DeleteEdges.lean
@@ -61,7 +61,8 @@ instance [DecidableRel G.Adj] [DecidablePred (· ∈ s)] [DecidableEq V] :
 theorem deleteEdges_deleteEdges (s s' : Set (Sym2 V)) :
     (G.deleteEdges s).deleteEdges s' = G.deleteEdges (s ∪ s') := by simp [deleteEdges, sdiff_sdiff]
 
-@[simp] lemma deleteEdges_empty : G.deleteEdges ∅ = G := by simp [deleteEdges]
+-- This is not marked `simp` since `deleteEdges_of_subset_diagSet` already proves it
+lemma deleteEdges_empty : G.deleteEdges ∅ = G := by simp [deleteEdges]
 @[simp] lemma deleteEdges_univ : G.deleteEdges Set.univ = ⊥ := by simp [deleteEdges]
 
 lemma deleteEdges_le (s : Set (Sym2 V)) : G.deleteEdges s ≤ G := sdiff_le
@@ -78,6 +79,9 @@ theorem deleteEdges_eq_inter_edgeSet (s : Set (Sym2 V)) :
     G.deleteEdges s = G.deleteEdges (s ∩ G.edgeSet) := by
   ext
   simp +contextual [imp_false]
+
+@[simp] lemma deleteEdges_of_subset_diagSet (G : SimpleGraph V) (hs : s ⊆ Sym2.diagSet) :
+    G.deleteEdges s = G := by ext u v; simpa using (·.ne <| Sym2.mem_diagSet_iff_eq.mp <| hs ·)
 
 theorem deleteEdges_sdiff_eq_of_le {H : SimpleGraph V} (h : H ≤ G) :
     G.deleteEdges (G.edgeSet \ H.edgeSet) = H := by

--- a/Mathlib/Combinatorics/SimpleGraph/DeleteEdges.lean
+++ b/Mathlib/Combinatorics/SimpleGraph/DeleteEdges.lean
@@ -81,7 +81,7 @@ theorem deleteEdges_eq_inter_edgeSet (s : Set (Sym2 V)) :
   simp +contextual [imp_false]
 
 @[simp] lemma deleteEdges_of_subset_diagSet (G : SimpleGraph V) (hs : s ⊆ Sym2.diagSet) :
-    G.deleteEdges s = G := by ext u v; simpa using (·.ne <| Sym2.mem_diagSet_iff_eq.mp <| hs ·)
+    G.deleteEdges s = G := by ext u v; simpa using (·.ne <| hs ·)
 
 theorem deleteEdges_sdiff_eq_of_le {H : SimpleGraph V} (h : H ≤ G) :
     G.deleteEdges (G.edgeSet \ H.edgeSet) = H := by


### PR DESCRIPTION
---
<!-- Your PR title will become the first line of the commit message.

In this box, the text above the `---` (if not empty) will be appended
to the commit message, and can be used to give additional context or
details. Please leave a blank newline before the `---`, otherwise GitHub
will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

When merging, all the commits will be squashed into a single commit
listing all co-authors.

Co-authors in the squash commit are gathered from two sources:

First, all authors of commits to this PR branch are included. Thus,
one way to add co-authors is to include at least one commit authored by
each co-author among the commits in the pull request. If necessary, you
may create empty commits to indicate co-authorship, using commands like so:

git commit --author="Author Name <author@email.com>" --allow-empty -m "add Author Name as coauthor"

Second, co-authors can also be listed in lines at the very bottom of
the commit message (that is, directly before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines
at the bottom of the commit message (before the `---`, and also before
any "Co-authored-by" lines) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
