### PR TITLE
[Merged by Bors] - feat: `ArchimedeanClass.mk_div`

### DIFF
--- a/Mathlib/Algebra/Order/Ring/Archimedean.lean
+++ b/Mathlib/Algebra/Order/Ring/Archimedean.lean
@@ -72,7 +72,7 @@ private theorem mk_mul_le_of_le {x₁ y₁ x₂ y₂ : R} (hx : mk x₁ ≤ mk x
     simp_rw [ArchimedeanOrder.val_of, abs_mul]
   ring
 
-/-- Multipilication in `R` transfers to Addition in `ArchimedeanClass R`. -/
+/-- Multiplication in `R` transfers to Addition in `ArchimedeanClass R`. -/
 instance : Add (ArchimedeanClass R) where
   add := lift₂ (fun x y ↦ .mk <| x * y) fun _ _ _ _ hx hy ↦ by
     exact (mk_mul_le_of_le hx.le hy.le).antisymm (mk_mul_le_of_le hx.ge hy.ge)

--- a/Mathlib/Algebra/Order/Ring/Archimedean.lean
+++ b/Mathlib/Algebra/Order/Ring/Archimedean.lean
@@ -63,7 +63,6 @@ theorem top_ne_zero [Nontrivial R] : (⊤ : ArchimedeanClass R) ≠ 0 := by
 theorem zero_ne_top [Nontrivial R] : 0 ≠ (⊤ : ArchimedeanClass R) :=
   top_ne_zero.symm
 
-set_option backward.privateInPublic true in
 private theorem mk_mul_le_of_le {x₁ y₁ x₂ y₂ : R} (hx : mk x₁ ≤ mk x₂) (hy : mk y₁ ≤ mk y₂) :
     mk (x₁ * y₁) ≤ mk (x₂ * y₂) := by
   obtain ⟨m, hm⟩ := hx
@@ -73,12 +72,10 @@ private theorem mk_mul_le_of_le {x₁ y₁ x₂ y₂ : R} (hx : mk x₁ ≤ mk x
     simp_rw [ArchimedeanOrder.val_of, abs_mul]
   ring
 
-set_option backward.privateInPublic true in
-set_option backward.privateInPublic.warn false in
 /-- Multipilication in `R` transfers to Addition in `ArchimedeanClass R`. -/
 instance : Add (ArchimedeanClass R) where
-  add := lift₂ (fun x y ↦ .mk <| x * y) fun _ _ _ _ hx hy ↦
-    (mk_mul_le_of_le hx.le hy.le).antisymm (mk_mul_le_of_le hx.ge hy.ge)
+  add := lift₂ (fun x y ↦ .mk <| x * y) fun _ _ _ _ hx hy ↦ by
+    exact (mk_mul_le_of_le hx.le hy.le).antisymm (mk_mul_le_of_le hx.ge hy.ge)
 
 @[simp] theorem mk_mul (x y : R) : mk (x * y) = mk x + mk y := rfl
 
@@ -261,7 +258,6 @@ instance : SMul ℤ (ArchimedeanClass R) where
 
 @[simp] theorem mk_zpow (n : ℤ) (x : R) : mk (x ^ n) = n • mk x := rfl
 
-set_option backward.privateInPublic true in
 private theorem zsmul_succ' (n : ℕ) (x : ArchimedeanClass R) :
     (n.succ : ℤ) • x = (n : ℤ) • x + x := by
   induction x with | mk x
@@ -270,8 +266,6 @@ private theorem zsmul_succ' (n : ℕ) (x : ArchimedeanClass R) :
   · simp [zero_zpow _ n.cast_add_one_ne_zero]
   · rw [zpow_add_one₀ hx, mk_mul, mk_zpow]
 
-set_option backward.privateInPublic true in
-set_option backward.privateInPublic.warn false in
 noncomputable instance : LinearOrderedAddCommGroupWithTop (ArchimedeanClass R) where
   neg_top := by simp [← mk_zero, ← mk_inv]
   add_neg_cancel_of_ne_top x h := by
@@ -279,10 +273,14 @@ noncomputable instance : LinearOrderedAddCommGroupWithTop (ArchimedeanClass R) w
     simp [← mk_inv, ← mk_mul, mul_inv_cancel₀ (mk_eq_top_iff.not.1 h)]
   zsmul n x := n • x
   zsmul_zero' x := by induction x with | mk x => rw [← mk_zpow, zpow_zero, mk_one]
-  zsmul_succ' := zsmul_succ'
+  zsmul_succ' := by exact zsmul_succ'
   zsmul_neg' n x := by
     induction x with | mk x
     rw [← mk_zpow, zpow_negSucc, pow_succ, zsmul_succ', mk_inv, mk_mul, ← zpow_natCast, mk_zpow]
+
+@[simp]
+theorem mk_div (x y : R) : mk (x / y) = mk x - mk y := by
+  rw [div_eq_mul_inv, mk_mul, mk_inv, sub_eq_add_neg]
 
 @[simp]
 theorem mk_ratCast {q : ℚ} (h : q ≠ 0) : mk (q : R) = 0 := by

--- a/Mathlib/Algebra/Order/Ring/Archimedean.lean
+++ b/Mathlib/Algebra/Order/Ring/Archimedean.lean
@@ -72,7 +72,7 @@ private theorem mk_mul_le_of_le {x₁ y₁ x₂ y₂ : R} (hx : mk x₁ ≤ mk x
     simp_rw [ArchimedeanOrder.val_of, abs_mul]
   ring
 
-/-- Multiplication in `R` transfers to Addition in `ArchimedeanClass R`. -/
+/-- Multiplication in `R` transfers to addition in `ArchimedeanClass R`. -/
 instance : Add (ArchimedeanClass R) where
   add := lift₂ (fun x y ↦ .mk <| x * y) fun _ _ _ _ hx hy ↦ by
     exact (mk_mul_le_of_le hx.le hy.le).antisymm (mk_mul_le_of_le hx.ge hy.ge)


### PR DESCRIPTION
...and while we're at it, we remove some `set_option`s

---
<!-- Your PR title will become the first line of the commit message.

In this box, the text above the `---` (if not empty) will be appended
to the commit message, and can be used to give additional context or
details. Please leave a blank newline before the `---`, otherwise GitHub
will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

When merging, all the commits will be squashed into a single commit
listing all co-authors.

Co-authors in the squash commit are gathered from two sources:

First, all authors of commits to this PR branch are included. Thus,
one way to add co-authors is to include at least one commit authored by
each co-author among the commits in the pull request. If necessary, you
may create empty commits to indicate co-authorship, using commands like so:

git commit --author="Author Name <author@email.com>" --allow-empty -m "add Author Name as coauthor"

Second, co-authors can also be listed in lines at the very bottom of
the commit message (that is, directly before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines
at the bottom of the commit message (before the `---`, and also before
any "Co-authored-by" lines) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
