### PR TITLE
[Merged by Bors] - feat(Algebra/Order/AddGroupWithTop): more monotonicity/injectivity lemmas

### DIFF
--- a/Mathlib/Algebra/Order/AddGroupWithTop.lean
+++ b/Mathlib/Algebra/Order/AddGroupWithTop.lean
@@ -10,7 +10,6 @@ public import Mathlib.Algebra.Group.Hom.Defs
 public import Mathlib.Algebra.Order.Monoid.Canonical.Defs
 public import Mathlib.Algebra.Order.Monoid.WithTop
 
-import Mathlib.Tactic.Tauto
 import Mathlib.Tactic.TermCongr
 
 /-!
@@ -217,8 +216,8 @@ lemma sub_le_sub_iff_left_of_ne_top {a b c : α} (h : a ≠ ⊤) : b - a ≤ c -
 lemma sub_pos (a b : α) : 0 < a - b ↔ b < a ∨ b = ⊤ := by
   obtain rfl | hb := eq_or_ne b ⊤
   · simp
-  · rw [← sub_self_eq_zero_of_ne_top hb, sub_lt_sub_iff_left_of_ne_top hb]
-    tauto
+  · rw [← sub_self_eq_zero_of_ne_top hb]
+    simp [hb]
 
 end LinearOrderedAddCommGroupWithTop
 

--- a/Mathlib/Algebra/Order/AddGroupWithTop.lean
+++ b/Mathlib/Algebra/Order/AddGroupWithTop.lean
@@ -10,6 +10,7 @@ public import Mathlib.Algebra.Group.Hom.Defs
 public import Mathlib.Algebra.Order.Monoid.Canonical.Defs
 public import Mathlib.Algebra.Order.Monoid.WithTop
 
+import Mathlib.Tactic.Tauto
 import Mathlib.Tactic.TermCongr
 
 /-!
@@ -140,28 +141,84 @@ instance (priority := 100) toSubtractionMonoid : SubtractionMonoid α where
     have ha : a ≠ ⊤ := by rintro rfl; simp at h
     exact left_neg_eq_right_neg (a := a) (by simp [neg_add_cancel_of_ne_top, *]) h
 
-lemma injective_add_left_of_ne_top (b : α) (h : b ≠ ⊤) : Function.Injective (fun x ↦ x + b) :=
+lemma add_left_injective_of_ne_top (b : α) (h : b ≠ ⊤) : Function.Injective fun x ↦ x + b :=
   fun x y hxy ↦ by simpa [h] using congr($hxy - b)
 
-lemma injective_add_right_of_ne_top (b : α) (h : b ≠ ⊤) : Function.Injective (fun x ↦ b + x) := by
-  simpa [add_comm] using injective_add_left_of_ne_top b h
+@[deprecated (since := "2025-12-27")]
+alias injective_add_left_of_ne_top := add_left_injective_of_ne_top
 
-lemma strictMono_add_left_of_ne_top (b : α) (h : b ≠ ⊤) : StrictMono (fun x ↦ x + b) := by
-  apply Monotone.strictMono_of_injective
-  · apply Monotone.add_const monotone_id
-  · apply injective_add_left_of_ne_top _ h
+lemma add_right_injective_of_ne_top (b : α) (h : b ≠ ⊤) : Function.Injective fun x ↦ b + x := by
+  simpa [add_comm] using add_left_injective_of_ne_top b h
 
-lemma strictMono_add_right_of_ne_top (b : α) (h : b ≠ ⊤) : StrictMono (fun x ↦ b + x) := by
-  simpa [add_comm] using strictMono_add_left_of_ne_top b h
+@[deprecated (since := "2025-12-27")]
+alias injective_add_right_of_ne_top := add_right_injective_of_ne_top
 
-lemma sub_pos (a b : α) : 0 < a - b ↔ b < a ∨ b = ⊤ where
-  mp h := or_iff_not_imp_right.mpr fun hb ↦ by
-    simpa [sub_eq_add_neg, add_assoc, hb] using strictMono_add_left_of_ne_top _ hb h
-  mpr := by
-    rintro (h | rfl)
-    · simpa [sub_eq_add_neg, h.ne_top]
-        using strictMono_add_left_of_ne_top (-b) (by simp [h.ne_top]) h
-    · simp
+@[simp]
+lemma add_left_inj_of_ne_top {a b c : α} (h : a ≠ ⊤) : b + a = c + a ↔ b = c :=
+  (add_left_injective_of_ne_top _ h).eq_iff
+
+@[simp]
+lemma add_right_inj_of_ne_top {a b c : α} (h : a ≠ ⊤) : a + b = a + c ↔ b = c :=
+  (add_right_injective_of_ne_top _ h).eq_iff
+
+lemma sub_left_injective_of_ne_top (b : α) (h : b ≠ ⊤) : Function.Injective fun x ↦ x - b := by
+  simpa [sub_eq_add_neg] using add_left_injective_of_ne_top (-b) (by simpa)
+
+lemma sub_right_injective_of_ne_top (b : α) (h : b ≠ ⊤) : Function.Injective fun x ↦ b - x := by
+  simpa [sub_eq_add_neg] using (add_right_injective_of_ne_top b h).comp neg_injective
+
+@[simp]
+lemma sub_left_inj_of_ne_top {a b c : α} (h : a ≠ ⊤) : b - a = c - a ↔ b = c :=
+  (sub_left_injective_of_ne_top _ h).eq_iff
+
+@[simp]
+lemma sub_right_inj_of_ne_top {a b c : α} (h : a ≠ ⊤) : a - b = a - c ↔ b = c :=
+  (sub_right_injective_of_ne_top _ h).eq_iff
+
+lemma add_left_strictMono_of_ne_top (b : α) (h : b ≠ ⊤) : StrictMono fun x ↦ x + b :=
+  (Monotone.add_const monotone_id _).strictMono_of_injective (add_left_injective_of_ne_top _ h)
+
+@[deprecated (since := "2025-12-27")]
+alias strictMono_add_left_of_ne_top := add_left_strictMono_of_ne_top
+
+lemma add_right_strictMono_of_ne_top (b : α) (h : b ≠ ⊤) : StrictMono fun x ↦ b + x := by
+  simpa [add_comm] using add_left_strictMono_of_ne_top b h
+
+@[deprecated (since := "2025-12-27")]
+alias strictMono_add_right_of_ne_top := add_right_strictMono_of_ne_top
+
+@[simp]
+lemma add_lt_add_iff_left_of_ne_top {a b c : α} (h : a ≠ ⊤) : b + a < c + a ↔ b < c :=
+  (add_left_strictMono_of_ne_top _ h).lt_iff_lt
+
+@[simp]
+lemma add_lt_add_iff_right_of_ne_top {a b c : α} (h : a ≠ ⊤) : a + b < a + c ↔ b < c :=
+  (add_right_strictMono_of_ne_top _ h).lt_iff_lt
+
+@[simp]
+lemma add_le_add_iff_left_of_ne_top {a b c : α} (h : a ≠ ⊤) : b + a ≤ c + a ↔ b ≤ c :=
+  (add_left_strictMono_of_ne_top _ h).le_iff_le
+
+@[simp]
+lemma add_le_add_iff_right_of_ne_top {a b c : α} (h : a ≠ ⊤) : a + b ≤ a + c ↔ b ≤ c :=
+  (add_right_strictMono_of_ne_top _ h).le_iff_le
+
+lemma sub_left_strictMono_of_ne_top (b : α) (h : b ≠ ⊤) : StrictMono fun x ↦ x - b := by
+  simpa [sub_eq_add_neg] using add_left_strictMono_of_ne_top (-b) (by simpa)
+
+@[simp]
+lemma sub_lt_sub_iff_left_of_ne_top {a b c : α} (h : a ≠ ⊤) : b - a < c - a ↔ b < c :=
+  (sub_left_strictMono_of_ne_top _ h).lt_iff_lt
+
+@[simp]
+lemma sub_le_sub_iff_left_of_ne_top {a b c : α} (h : a ≠ ⊤) : b - a ≤ c - a ↔ b ≤ c :=
+  (sub_left_strictMono_of_ne_top _ h).le_iff_le
+
+lemma sub_pos (a b : α) : 0 < a - b ↔ b < a ∨ b = ⊤ := by
+  obtain rfl | hb := eq_or_ne b ⊤
+  · simp
+  · rw [← sub_self_eq_zero_of_ne_top hb, sub_lt_sub_iff_left_of_ne_top hb]
+    tauto
 
 end LinearOrderedAddCommGroupWithTop
 

--- a/Mathlib/Algebra/Order/AddGroupWithTop.lean
+++ b/Mathlib/Algebra/Order/AddGroupWithTop.lean
@@ -41,7 +41,7 @@ class LinearOrderedAddCommMonoidWithTop (α : Type*) extends
 /-- A linearly ordered commutative group with an additively absorbing `⊤` element.
   Instances should include number systems with an infinite element adjoined. -/
 class LinearOrderedAddCommGroupWithTop (α : Type*) extends LinearOrderedAddCommMonoidWithTop α,
-  SubNegMonoid α, Nontrivial α where
+    SubNegMonoid α, Nontrivial α where
   neg_top : -(⊤ : α) = ⊤
   add_neg_cancel_of_ne_top ⦃x : α⦄ : x ≠ ⊤ → x + -x = 0
 

--- a/Mathlib/Algebra/Order/AddGroupWithTop.lean
+++ b/Mathlib/Algebra/Order/AddGroupWithTop.lean
@@ -41,7 +41,7 @@ class LinearOrderedAddCommMonoidWithTop (α : Type*) extends
 /-- A linearly ordered commutative group with an additively absorbing `⊤` element.
   Instances should include number systems with an infinite element adjoined. -/
 class LinearOrderedAddCommGroupWithTop (α : Type*) extends LinearOrderedAddCommMonoidWithTop α,
-    SubNegMonoid α, Nontrivial α where
+  SubNegMonoid α, Nontrivial α where
   neg_top : -(⊤ : α) = ⊤
   add_neg_cancel_of_ne_top ⦃x : α⦄ : x ≠ ⊤ → x + -x = 0
 
@@ -187,14 +187,6 @@ lemma add_right_strictMono_of_ne_top (b : α) (h : b ≠ ⊤) : StrictMono fun x
 alias strictMono_add_right_of_ne_top := add_right_strictMono_of_ne_top
 
 @[simp]
-lemma add_lt_add_iff_left_of_ne_top {a b c : α} (h : a ≠ ⊤) : b + a < c + a ↔ b < c :=
-  (add_left_strictMono_of_ne_top _ h).lt_iff_lt
-
-@[simp]
-lemma add_lt_add_iff_right_of_ne_top {a b c : α} (h : a ≠ ⊤) : a + b < a + c ↔ b < c :=
-  (add_right_strictMono_of_ne_top _ h).lt_iff_lt
-
-@[simp]
 lemma add_le_add_iff_left_of_ne_top {a b c : α} (h : a ≠ ⊤) : b + a ≤ c + a ↔ b ≤ c :=
   (add_left_strictMono_of_ne_top _ h).le_iff_le
 
@@ -202,16 +194,24 @@ lemma add_le_add_iff_left_of_ne_top {a b c : α} (h : a ≠ ⊤) : b + a ≤ c +
 lemma add_le_add_iff_right_of_ne_top {a b c : α} (h : a ≠ ⊤) : a + b ≤ a + c ↔ b ≤ c :=
   (add_right_strictMono_of_ne_top _ h).le_iff_le
 
+@[simp]
+lemma add_lt_add_iff_left_of_ne_top {a b c : α} (h : a ≠ ⊤) : b + a < c + a ↔ b < c :=
+  (add_left_strictMono_of_ne_top _ h).lt_iff_lt
+
+@[simp]
+lemma add_lt_add_iff_right_of_ne_top {a b c : α} (h : a ≠ ⊤) : a + b < a + c ↔ b < c :=
+  (add_right_strictMono_of_ne_top _ h).lt_iff_lt
+
 lemma sub_left_strictMono_of_ne_top (b : α) (h : b ≠ ⊤) : StrictMono fun x ↦ x - b := by
   simpa [sub_eq_add_neg] using add_left_strictMono_of_ne_top (-b) (by simpa)
 
 @[simp]
-lemma sub_lt_sub_iff_left_of_ne_top {a b c : α} (h : a ≠ ⊤) : b - a < c - a ↔ b < c :=
-  (sub_left_strictMono_of_ne_top _ h).lt_iff_lt
-
-@[simp]
 lemma sub_le_sub_iff_left_of_ne_top {a b c : α} (h : a ≠ ⊤) : b - a ≤ c - a ↔ b ≤ c :=
   (sub_left_strictMono_of_ne_top _ h).le_iff_le
+
+@[simp]
+lemma sub_lt_sub_iff_left_of_ne_top {a b c : α} (h : a ≠ ⊤) : b - a < c - a ↔ b < c :=
+  (sub_left_strictMono_of_ne_top _ h).lt_iff_lt
 
 lemma sub_pos (a b : α) : 0 < a - b ↔ b < a ∨ b = ⊤ := by
   obtain rfl | hb := eq_or_ne b ⊤


### PR DESCRIPTION
We also deprecate some `injective_foo` lemmas in favor of `foo_injective` counterparts, as per the naming conventions.

---
<!-- Your PR title will become the first line of the commit message.

In this box, the text above the `---` (if not empty) will be appended
to the commit message, and can be used to give additional context or
details. Please leave a blank newline before the `---`, otherwise GitHub
will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

When merging, all the commits will be squashed into a single commit
listing all co-authors.

Co-authors in the squash commit are gathered from two sources:

First, all authors of commits to this PR branch are included. Thus,
one way to add co-authors is to include at least one commit authored by
each co-author among the commits in the pull request. If necessary, you
may create empty commits to indicate co-authorship, using commands like so:

git commit --author="Author Name <author@email.com>" --allow-empty -m "add Author Name as coauthor"

Second, co-authors can also be listed in lines at the very bottom of
the commit message (that is, directly before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines
at the bottom of the commit message (before the `---`, and also before
any "Co-authored-by" lines) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
