### PR TITLE
[Merged by Bors] - feat: hasDetPlusMinusOne_iff_abs_det

### DIFF
--- a/Mathlib/Algebra/Ring/Units.lean
+++ b/Mathlib/Algebra/Ring/Units.lean
@@ -43,6 +43,10 @@ protected theorem val_neg (u : αˣ) : (↑(-u) : α) = -u :=
 protected theorem coe_neg_one : ((-1 : αˣ) : α) = -1 :=
   rfl
 
+@[simp, norm_cast]
+theorem val_eq_neg_one {a : αˣ} : (a : α) = -1 ↔ a = -1 := by
+  rw [← Units.coe_neg_one, val_inj]
+
 instance : HasDistribNeg αˣ := val_injective.hasDistribNeg _ Units.val_neg val_mul
 
 theorem neg_divp (a : α) (u : αˣ) : -(a /ₚ u) = -a /ₚ u := by simp only [divp, neg_mul]

--- a/Mathlib/NumberTheory/ModularForms/ArithmeticSubgroups.lean
+++ b/Mathlib/NumberTheory/ModularForms/ArithmeticSubgroups.lean
@@ -45,7 +45,7 @@ lemma HasDetPlusMinusOne.abs_det [LinearOrder R] [IsOrderedRing R] [HasDetPlusMi
 
 lemma hasDetPlusMinusOne_iff_abs_det [LinearOrder R] [IsOrderedRing R] :
     HasDetPlusMinusOne Γ ↔ ∀ {g}, g ∈ Γ → |g.det.val| = 1 := by
-  refine ⟨fun h {g} hg => h.abs_det hg, fun h => ⟨?_⟩⟩
+  refine ⟨fun h {g} hg ↦ h.abs_det hg, fun h ↦ ⟨?_⟩⟩
   simpa [-GeneralLinearGroup.val_det_apply, abs_eq zero_le_one] using @h
 
 /-- Typeclass saying that a subgroup of `GL(n, R)` is contained in `SL(n, R)`. Necessary so that

--- a/Mathlib/NumberTheory/ModularForms/ArithmeticSubgroups.lean
+++ b/Mathlib/NumberTheory/ModularForms/ArithmeticSubgroups.lean
@@ -43,6 +43,11 @@ lemma HasDetPlusMinusOne.abs_det [LinearOrder R] [IsOrderedRing R] [HasDetPlusMi
     {g} (hg : g ∈ Γ) : |g.det.val| = 1 := by
   rcases HasDetPlusMinusOne.det_eq hg with h | h <;> simp [h]
 
+lemma hasDetPlusMinusOne_iff_abs_det [LinearOrder R] [IsOrderedRing R] :
+    HasDetPlusMinusOne Γ ↔ ∀ {g}, g ∈ Γ → |g.det.val| = 1 := by
+  refine ⟨fun h {g} hg => h.abs_det hg, fun h => ⟨?_⟩⟩
+  simpa [-GeneralLinearGroup.val_det_apply, abs_eq zero_le_one] using @h
+
 /-- Typeclass saying that a subgroup of `GL(n, R)` is contained in `SL(n, R)`. Necessary so that
 the typeclass system can detect when the slash action is `ℂ`-linear. -/
 class HasDetOne : Prop where
@@ -102,8 +107,8 @@ instance IsArithmetic.finiteIndex_comap (𝒢 : Subgroup (GL (Fin 2) ℝ)) [IsAr
   ⟨𝒢.index_comap (mapGL (R := ℤ) ℝ) ▸ IsArithmetic.is_commensurable.1⟩
 
 instance {Γ : Subgroup (GL (Fin 2) ℝ)} [h : Γ.IsArithmetic] : HasDetPlusMinusOne Γ := by
-  refine ⟨fun {g} hg ↦ ?_⟩
-  suffices |g.det.val| = 1 by rcases abs_cases g.det.val <;> aesop
+  rw [hasDetPlusMinusOne_iff_abs_det]
+  intro g hg
   obtain ⟨n, hn, _, hgn⟩ := Subgroup.exists_pow_mem_of_relIndex_ne_zero
     Subgroup.IsArithmetic.is_commensurable.2 hg
   suffices |(g.det ^ n).val| = 1 by simpa [← abs_pow, abs_pow_eq_one _ (Nat.ne_zero_of_lt hn)]


### PR DESCRIPTION
This seems like a useful characterization.

---
<!-- Your PR title will become the first line of the commit message.

In this box, the text above the `---` (if not empty) will be appended
to the commit message, and can be used to give additional context or
details. Please leave a blank newline before the `---`, otherwise GitHub
will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

When merging, all the commits will be squashed into a single commit
listing all co-authors.

Co-authors in the squash commit are gathered from two sources:

First, all authors of commits to this PR branch are included. Thus,
one way to add co-authors is to include at least one commit authored by
each co-author among the commits in the pull request. If necessary, you
may create empty commits to indicate co-authorship, using commands like so:

git commit --author="Author Name <author@email.com>" --allow-empty -m "add Author Name as coauthor"

Second, co-authors can also be listed in lines at the very bottom of
the commit message (that is, directly before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines
at the bottom of the commit message (before the `---`, and also before
any "Co-authored-by" lines) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
