### PR TITLE
[Merged by Bors] - feat(Analysis/Deriv): Add `iteratedDeriv_comp_sub_const`

### DIFF
--- a/Mathlib/Analysis/Calculus/IteratedDeriv/Lemmas.lean
+++ b/Mathlib/Analysis/Calculus/IteratedDeriv/Lemmas.lean
@@ -234,4 +234,13 @@ lemma iteratedDeriv_comp_add_const (n : ℕ) (f : 𝕜 → F) (s : 𝕜) :
   | succ n IH =>
     simpa only [iteratedDeriv_succ, IH] using funext <| deriv_comp_add_const _ s
 
+lemma iteratedDeriv_comp_sub_const (n : ℕ) (f : 𝕜 → F) (s : 𝕜) :
+    iteratedDeriv n (fun z ↦ f (s - z)) = fun t ↦ (-1 : 𝕜) ^ n • iteratedDeriv n f (s - t) := by
+  induction n with
+  | zero => simp [iteratedDeriv_zero]
+  | succ n IH =>
+    simpa [iteratedDeriv_succ, IH] using funext <| fun _ ↦ by
+      rw [deriv_fun_const_smul', deriv_comp_const_sub]
+      module
+
 end shift_invariance

--- a/Mathlib/Analysis/Calculus/IteratedDeriv/Lemmas.lean
+++ b/Mathlib/Analysis/Calculus/IteratedDeriv/Lemmas.lean
@@ -237,11 +237,7 @@ lemma iteratedDeriv_comp_add_const :
 
 lemma iteratedDeriv_comp_sub_const :
     iteratedDeriv n (fun z ↦ f (z - s)) = fun t ↦ iteratedDeriv n f (t - s) := by
-  induction n with
-  | zero => simp [iteratedDeriv_zero]
-  | succ n IH =>
-    simpa [iteratedDeriv_succ, IH] using funext <| fun _ ↦
-      deriv_comp_sub_const (iteratedDeriv n f) s _
+  simp [sub_eq_add_neg, iteratedDeriv_comp_add_const]
 
 lemma iteratedDeriv_comp_const_sub :
     iteratedDeriv n (fun z ↦ f (s - z)) = fun t ↦ (-1 : 𝕜) ^ n • iteratedDeriv n f (s - t) := by

--- a/Mathlib/Analysis/Calculus/IteratedDeriv/Lemmas.lean
+++ b/Mathlib/Analysis/Calculus/IteratedDeriv/Lemmas.lean
@@ -217,9 +217,10 @@ end one_dimensional
 section shift_invariance
 
 variable {𝕜 F} [NontriviallyNormedField 𝕜] [NormedAddCommGroup F] [NormedSpace 𝕜 F]
+variable (n : ℕ) (f : 𝕜 → F) (s : 𝕜)
 
 /-- The iterated derivative commutes with shifting the function by a constant on the left. -/
-lemma iteratedDeriv_comp_const_add (n : ℕ) (f : 𝕜 → F) (s : 𝕜) :
+lemma iteratedDeriv_comp_const_add :
     iteratedDeriv n (fun z ↦ f (s + z)) = fun t ↦ iteratedDeriv n f (s + t) := by
   induction n with
   | zero => simp only [iteratedDeriv_zero]
@@ -227,14 +228,22 @@ lemma iteratedDeriv_comp_const_add (n : ℕ) (f : 𝕜 → F) (s : 𝕜) :
     simpa only [iteratedDeriv_succ, IH] using funext <| deriv_comp_const_add _ s
 
 /-- The iterated derivative commutes with shifting the function by a constant on the right. -/
-lemma iteratedDeriv_comp_add_const (n : ℕ) (f : 𝕜 → F) (s : 𝕜) :
+lemma iteratedDeriv_comp_add_const :
     iteratedDeriv n (fun z ↦ f (z + s)) = fun t ↦ iteratedDeriv n f (t + s) := by
   induction n with
   | zero => simp only [iteratedDeriv_zero]
   | succ n IH =>
     simpa only [iteratedDeriv_succ, IH] using funext <| deriv_comp_add_const _ s
 
-lemma iteratedDeriv_comp_sub_const (n : ℕ) (f : 𝕜 → F) (s : 𝕜) :
+lemma iteratedDeriv_comp_sub_const :
+    iteratedDeriv n (fun z ↦ f (z - s)) = fun t ↦ iteratedDeriv n f (t - s) := by
+  induction n with
+  | zero => simp [iteratedDeriv_zero]
+  | succ n IH =>
+    simpa [iteratedDeriv_succ, IH] using funext <| fun _ ↦
+      deriv_comp_sub_const (iteratedDeriv n f) s _
+
+lemma iteratedDeriv_comp_const_sub :
     iteratedDeriv n (fun z ↦ f (s - z)) = fun t ↦ (-1 : 𝕜) ^ n • iteratedDeriv n f (s - t) := by
   induction n with
   | zero => simp [iteratedDeriv_zero]

--- a/Mathlib/Analysis/Calculus/IteratedDeriv/Lemmas.lean
+++ b/Mathlib/Analysis/Calculus/IteratedDeriv/Lemmas.lean
@@ -241,11 +241,7 @@ lemma iteratedDeriv_comp_sub_const :
 
 lemma iteratedDeriv_comp_const_sub :
     iteratedDeriv n (fun z ↦ f (s - z)) = fun t ↦ (-1 : 𝕜) ^ n • iteratedDeriv n f (s - t) := by
-  induction n with
-  | zero => simp [iteratedDeriv_zero]
-  | succ n IH =>
-    simpa [iteratedDeriv_succ, IH] using funext <| fun _ ↦ by
-      rw [deriv_fun_const_smul', deriv_comp_const_sub]
-      module
+  simpa [funext_iff, neg_add_eq_sub, iteratedDeriv_comp_add_const] using
+    iteratedDeriv_comp_neg n (fun z => f (z + s))
 
 end shift_invariance


### PR DESCRIPTION
---
<!-- Your PR title will become the first line of the commit message.

In this box, the text above the `---` (if not empty) will be appended
to the commit message, and can be used to give additional context or
details. Please leave a blank newline before the `---`, otherwise GitHub
will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

When merging, all the commits will be squashed into a single commit
listing all co-authors.

Co-authors in the squash commit are gathered from two sources:

First, all authors of commits to this PR branch are included. Thus,
one way to add co-authors is to include at least one commit authored by
each co-author among the commits in the pull request. If necessary, you
may create empty commits to indicate co-authorship, using commands like so:

git commit --author="Author Name <author@email.com>" --allow-empty -m "add Author Name as coauthor"

Second, co-authors can also be listed in lines at the very bottom of
the commit message (that is, directly before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines
at the bottom of the commit message (before the `---`, and also before
any "Co-authored-by" lines) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
