### PR TITLE
[Merged by Bors] - refactor(Geometry/Euclidean/Projection): revert everything back to metric space

### DIFF
--- a/Mathlib/Geometry/Euclidean/Projection.lean
+++ b/Mathlib/Geometry/Euclidean/Projection.lean
@@ -37,9 +37,7 @@ variable {V₂ P₂ : Type*} [NormedAddCommGroup V₂] [InnerProductSpace 𝕜 V
 
 open AffineSubspace
 
-section PseudoMetricSpace
-
-variable [PseudoMetricSpace P] [NormedAddTorsor V P]
+variable [MetricSpace P] [NormedAddTorsor V P]
 
 /-- The orthogonal projection of a point onto a nonempty affine subspace. -/
 def orthogonalProjection (s : AffineSubspace 𝕜 P) [Nonempty s]
@@ -176,6 +174,19 @@ theorem eq_orthogonalProjection_of_eq_subspace {s s' : AffineSubspace 𝕜 P} [N
     orthogonalProjection (affineSpan 𝕜 {p₁}) p₂ = p₁ := by
   have h := SetLike.coe_mem (orthogonalProjection (affineSpan 𝕜 {p₁}) p₂)
   rwa [mem_affineSpan_singleton] at h
+
+/-- The distance to a point's orthogonal projection is 0 iff it lies in the subspace. -/
+theorem dist_orthogonalProjection_eq_zero_iff {s : AffineSubspace 𝕜 P} [Nonempty s]
+    [s.direction.HasOrthogonalProjection] {p : P} :
+    dist p (orthogonalProjection s p) = 0 ↔ p ∈ s := by
+  rw [dist_comm, dist_eq_zero, orthogonalProjection_eq_self_iff]
+
+/-- The distance between a point and its orthogonal projection is
+nonzero if it does not lie in the subspace. -/
+theorem dist_orthogonalProjection_ne_zero_of_notMem {s : AffineSubspace 𝕜 P} [Nonempty s]
+    [s.direction.HasOrthogonalProjection] {p : P} (hp : p ∉ s) :
+    dist p (orthogonalProjection s p) ≠ 0 :=
+  mt dist_orthogonalProjection_eq_zero_iff.mp hp
 
 /-- Subtracting `p` from its `orthogonalProjection` produces a result
 in the orthogonal direction. -/
@@ -505,11 +516,6 @@ theorem reflection_vadd_smul_vsub_orthogonalProjection {s : AffineSubspace 𝕜 
   reflection_orthogonal_vadd hp₁
     (Submodule.smul_mem _ _ (vsub_orthogonalProjection_mem_direction_orthogonal s _))
 
-end PseudoMetricSpace
-
-section MetricSpace
-
-variable [MetricSpace P] [NormedAddTorsor V P]
 variable [MetricSpace P₂] [NormedAddTorsor V₂ P₂]
 
 @[simp] lemma orthogonalProjection_map (s : AffineSubspace 𝕜 P) [Nonempty s]
@@ -537,19 +543,6 @@ lemma orthogonalProjection_subtype (s : AffineSubspace 𝕜 P) [Nonempty s] (s' 
     infer_instance
   convert orthogonalProjection_map s' s.subtypeₐᵢ p
 
-/-- The distance to a point's orthogonal projection is 0 iff it lies in the subspace. -/
-theorem dist_orthogonalProjection_eq_zero_iff {s : AffineSubspace 𝕜 P} [Nonempty s]
-    [s.direction.HasOrthogonalProjection] {p : P} :
-    dist p (orthogonalProjection s p) = 0 ↔ p ∈ s := by
-  rw [dist_comm, dist_eq_zero, orthogonalProjection_eq_self_iff]
-
-/-- The distance between a point and its orthogonal projection is
-nonzero if it does not lie in the subspace. -/
-theorem dist_orthogonalProjection_ne_zero_of_notMem {s : AffineSubspace 𝕜 P} [Nonempty s]
-    [s.direction.HasOrthogonalProjection] {p : P} (hp : p ∉ s) :
-    dist p (orthogonalProjection s p) ≠ 0 :=
-  mt dist_orthogonalProjection_eq_zero_iff.mp hp
-
 @[simp] lemma reflection_map (s : AffineSubspace 𝕜 P) [Nonempty s]
     [s.direction.HasOrthogonalProjection] (f : P →ᵃⁱ[𝕜] P₂)
     [(s.map f.toAffineMap).direction.HasOrthogonalProjection] (p : P) :
@@ -561,8 +554,6 @@ lemma reflection_subtype (s : AffineSubspace 𝕜 P) [Nonempty s] (s' : AffineSu
     [(s'.map s.subtype).direction.HasOrthogonalProjection] (p : s) :
     (reflection s' p : P) = reflection (s'.map s.subtype) p := by
   simp [reflection_apply', orthogonalProjection_subtype]
-
-end MetricSpace
 
 end EuclideanGeometry
 
@@ -576,9 +567,7 @@ variable {𝕜 : Type*} {V : Type*} {P : Type*} [RCLike 𝕜]
 variable [NormedAddCommGroup V] [InnerProductSpace 𝕜 V]
 variable {V₂ P₂ : Type*} [NormedAddCommGroup V₂] [InnerProductSpace 𝕜 V₂]
 
-section PseudoMetricSpace
-
-variable [PseudoMetricSpace P] [NormedAddTorsor V P]
+variable [MetricSpace P] [NormedAddTorsor V P]
 
 /-- The orthogonal projection of a point `p` onto the hyperplane spanned by the simplex's points. -/
 def orthogonalProjectionSpan {n : ℕ} (s : Simplex 𝕜 P n) :
@@ -627,11 +616,6 @@ lemma orthogonalProjectionSpan_faceOpposite_eq_point_rev (s : Simplex 𝕜 P 1) 
     (p : P) : (s.faceOpposite i).orthogonalProjectionSpan p = s.points i.rev := by
   simp [faceOpposite_point_eq_point_rev]
 
-end PseudoMetricSpace
-
-section MetricSpace
-
-variable [MetricSpace P] [NormedAddTorsor V P]
 variable [MetricSpace P₂] [NormedAddTorsor V₂ P₂]
 
 lemma orthogonalProjectionSpan_map {n : ℕ} (s : Simplex 𝕜 P n) (f : P →ᵃⁱ[𝕜] P₂) (p : P) :
@@ -647,8 +631,6 @@ lemma orthogonalProjectionSpan_map {n : ℕ} (s : Simplex 𝕜 P n) (f : P →�
     ((s.restrict S hS).orthogonalProjectionSpan p : P) = s.orthogonalProjectionSpan p := by
   rw [eq_comm]
   convert (s.restrict S hS).orthogonalProjectionSpan_map S.subtypeₐᵢ p
-
-end MetricSpace
 
 end Simplex
 


### PR DESCRIPTION
After #27378 was merged, @jsm28 noted that `[NormedAddCommGroup V] [PseudoMetricSpace P] [NormedAddTorsor V P]` implies `[MetricSpace P]` anyways so there's no point distinguishing between `PseudoMetricSpace` and `MetricSpace`.

---
<!-- Your PR title will become the first line of the commit message.

In this box, the text above the `---` (if not empty) will be appended
to the commit message, and can be used to give additional context or
details. Please leave a blank newline before the `---`, otherwise GitHub
will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

When merging, all the commits will be squashed into a single commit
listing all co-authors.

Co-authors in the squash commit are gathered from two sources:

First, all authors of commits to this PR branch are included. Thus,
one way to add co-authors is to include at least one commit authored by
each co-author among the commits in the pull request. If necessary, you
may create empty commits to indicate co-authorship, using commands like so:

git commit --author="Author Name <author@email.com>" --allow-empty -m "add Author Name as coauthor"

Second, co-authors can also be listed in lines at the very bottom of
the commit message (that is, directly before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines
at the bottom of the commit message (before the `---`, and also before
any "Co-authored-by" lines) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
