### PR TITLE
[Merged by Bors] - fix(CategoryTheory/Basic): fix `cat_disch` in grind mode when `ext` leaves multiple goals

### DIFF
--- a/Mathlib/CategoryTheory/Category/Basic.lean
+++ b/Mathlib/CategoryTheory/Category/Basic.lean
@@ -176,7 +176,7 @@ meta def categoryTheoryDischarger : TacticM Unit := do
     if ← getBoolOption `mathlib.tactic.category.log_grind then
       logInfo "Category theory discharger using `grind`."
     evalTacticSeq (← `(tacticSeq|
-      intros; (try dsimp only) <;> ((try ext); grind (gen := 20) (ematch := 20))))
+      intros; (try dsimp only) <;> ((try ext) <;> grind (gen := 20) (ematch := 20))))
   else
     if ← getBoolOption `mathlib.tactic.category.log_aesop then
       logInfo "Category theory discharger using `aesop`."


### PR DESCRIPTION
Currently, when `grind` is used as a discharger for category-theory through the option `mathlib.tactic.category.grind`, the 
`ext` tactic is tried before calling grind, but the calls are made sequentially as `(try ext); grind`.
As a result, if `ext` leaves more than one open goal, the `grind` call will only act on the first goal, and will not act on the other goals even if it could have solved them.

Here is an example:

```lean
import Mathlib.CategoryTheory.Square
open CategoryTheory
variable {C : Type*} [Category* C] {S₁ S₂ : Square C}
  (f g : S₁ ⟶ S₂)
  (h₁ : f.τ₁ = g.τ₁) (h₂ : f.τ₂ = g.τ₂)
  (h₃ : f.τ₃ = g.τ₃) (h₄ : f.τ₄ = g.τ₄)

example : f = g := by cat_disch -- works

attribute [local grind ext] Square.hom_ext in
example : f = g := by grind -- also works

set_option mathlib.tactic.category.grind true in
example : f = g := by cat_disch -- fails, leaves 3 goals open
```

This is fixed by adding a `<;>` to the sequence of tactic called by `cat_disch`. After this, `cat_disch` works as expected in these
situations.

In the long run, this `ext` call will probably be removed as `grind ext` annotations will tell grind what ext lemmas to use and essentially achieve the same result. However, the category-theory side of the library does not have enough `grind ext` annotations to make this a reality yet, so for the time being, leaving this `(try ext) <;>` is probably the best until we have fully annotated the library.
 
---
<!-- Your PR title will become the first line of the commit message.

In this box, the text above the `---` (if not empty) will be appended
to the commit message, and can be used to give additional context or
details. Please leave a blank newline before the `---`, otherwise GitHub
will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

When merging, all the commits will be squashed into a single commit
listing all co-authors.

Co-authors in the squash commit are gathered from two sources:

First, all authors of commits to this PR branch are included. Thus,
one way to add co-authors is to include at least one commit authored by
each co-author among the commits in the pull request. If necessary, you
may create empty commits to indicate co-authorship, using commands like so:

git commit --author="Author Name <author@email.com>" --allow-empty -m "add Author Name as coauthor"

Second, co-authors can also be listed in lines at the very bottom of
the commit message (that is, directly before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines
at the bottom of the commit message (before the `---`, and also before
any "Co-authored-by" lines) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
