### PR TITLE
[Merged by Bors] - refactor(RingTheory/Ideal/Basic): clean up proofs

### DIFF
--- a/Mathlib/RingTheory/Ideal/Basic.lean
+++ b/Mathlib/RingTheory/Ideal/Basic.lean
@@ -255,28 +255,35 @@ theorem exists_not_isUnit_of_not_isField [Nontrivial R] (hf : ¬IsField R) :
   obtain ⟨x, hx, not_unit⟩ := this
   exact ⟨x, hx, not_unit⟩
 
+open Ideal in
+theorem isField_iff_maximal_bot [Nontrivial R] : IsField R ↔ (⊥ : Ideal R).IsMaximal := by
+  refine ⟨fun h ↦ let := h.toSemifield; bot_isMaximal, fun hmax ↦ ?_⟩
+  by_contra hf
+  obtain ⟨x, hx0, hxu⟩ := exists_not_isUnit_of_not_isField hf
+  exact hx0 <| span_singleton_eq_bot.mp (hmax.eq_of_le (span_singleton_ne_top hxu) bot_le).symm
+
+theorem exists_maximal_of_not_isField [Nontrivial R] (h : ¬ IsField R) :
+    ∃ p : Ideal R, p ≠ ⊥ ∧ p.IsMaximal := by
+  contrapose! h
+  simp only [← bot_lt_iff_ne_bot] at h
+  refine isField_iff_maximal_bot.mpr ⟨⟨bot_ne_top, Ideal.maximal_of_no_maximal h⟩⟩
+
+theorem not_isField_of_ne_of_ne [Nontrivial R] {I : Ideal R} (h_bot : I ≠ ⊥) (h_top : I ≠ ⊤) :
+    ¬ IsField R := by
+  contrapose! h_bot
+  exact ((isField_iff_maximal_bot.mp h_bot).eq_of_le h_top bot_le).symm
+
 theorem not_isField_iff_exists_ideal_bot_lt_and_lt_top [Nontrivial R] :
     ¬IsField R ↔ ∃ I : Ideal R, ⊥ < I ∧ I < ⊤ := by
-  constructor
-  · intro h
-    obtain ⟨x, nz, nu⟩ := exists_not_isUnit_of_not_isField h
-    use Ideal.span {x}
-    rw [bot_lt_iff_ne_bot, lt_top_iff_ne_top]
-    exact ⟨mt Ideal.span_singleton_eq_bot.mp nz, mt Ideal.span_singleton_eq_top.mp nu⟩
-  · rintro ⟨I, bot_lt, lt_top⟩ hf
-    obtain ⟨x, mem, ne_zero⟩ := SetLike.exists_of_lt bot_lt
-    rw [Submodule.mem_bot] at ne_zero
-    obtain ⟨y, hy⟩ := hf.mul_inv_cancel ne_zero
-    rw [lt_top_iff_ne_top, Ne, Ideal.eq_top_iff_one, ← hy] at lt_top
-    exact lt_top (I.mul_mem_right _ mem)
+  refine ⟨fun h ↦ ?_, fun ⟨I, h_bot, h_top⟩ ↦ not_isField_of_ne_of_ne h_bot.ne' h_top.ne⟩
+  obtain ⟨I, hI, hIm⟩ := exists_maximal_of_not_isField h
+  exact ⟨I, bot_lt_iff_ne_bot.mpr hI, lt_top_iff_ne_top.mpr hIm.ne_top⟩
 
 theorem not_isField_iff_exists_prime [Nontrivial R] :
-    ¬IsField R ↔ ∃ p : Ideal R, p ≠ ⊥ ∧ p.IsPrime :=
-  not_isField_iff_exists_ideal_bot_lt_and_lt_top.trans
-    ⟨fun ⟨I, bot_lt, lt_top⟩ =>
-      let ⟨p, hp, le_p⟩ := I.exists_le_maximal (lt_top_iff_ne_top.mp lt_top)
-      ⟨p, bot_lt_iff_ne_bot.mp (lt_of_lt_of_le bot_lt le_p), hp.isPrime⟩,
-      fun ⟨p, ne_bot, Prime⟩ => ⟨p, bot_lt_iff_ne_bot.mpr ne_bot, lt_top_iff_ne_top.mpr Prime.1⟩⟩
+    ¬IsField R ↔ ∃ p : Ideal R, p ≠ ⊥ ∧ p.IsPrime := by
+  refine ⟨fun h ↦ ?_, fun ⟨I, h_bot, h_top⟩ ↦ not_isField_of_ne_of_ne h_bot h_top.ne_top⟩
+  obtain ⟨I, hI, hIm⟩ := exists_maximal_of_not_isField h
+  exact ⟨I, hI, hIm.isPrime⟩
 
 /-- Also see `Ideal.isSimpleOrder` for the forward direction as an instance when `R` is a
 division (semi)ring.
@@ -296,8 +303,8 @@ theorem isField_iff_isSimpleOrder_ideal : IsField R ↔ IsSimpleOrder (Ideal R) 
 theorem ne_bot_of_isMaximal_of_not_isField [Nontrivial R] {M : Ideal R} (max : M.IsMaximal)
     (not_field : ¬IsField R) : M ≠ ⊥ := by
   rintro rfl
-  obtain ⟨I, hIbot, hItop⟩ := not_isField_iff_exists_ideal_bot_lt_and_lt_top.mp not_field
-  exact hIbot.ne (max.eq_of_le hItop.ne bot_le)
+  obtain ⟨I, hIbot, hItop⟩ := exists_maximal_of_not_isField not_field
+  exact hIbot (max.eq_of_le hItop.ne_top bot_le).symm
 
 end Ring
 

--- a/Mathlib/RingTheory/Ideal/Basic.lean
+++ b/Mathlib/RingTheory/Ideal/Basic.lean
@@ -303,8 +303,8 @@ theorem isField_iff_isSimpleOrder_ideal : IsField R ↔ IsSimpleOrder (Ideal R) 
 theorem ne_bot_of_isMaximal_of_not_isField [Nontrivial R] {M : Ideal R} (max : M.IsMaximal)
     (not_field : ¬IsField R) : M ≠ ⊥ := by
   rintro rfl
-  obtain ⟨I, hIbot, hItop⟩ := exists_maximal_of_not_isField not_field
-  exact hIbot (max.eq_of_le hItop.ne_top bot_le).symm
+  obtain ⟨I, hIbot, hItop⟩ := not_isField_iff_exists_ideal_bot_lt_and_lt_top.mp not_field
+  exact hIbot.ne (max.eq_of_le hItop.ne bot_le)
 
 end Ring
 

--- a/Mathlib/RingTheory/Ideal/Basic.lean
+++ b/Mathlib/RingTheory/Ideal/Basic.lean
@@ -295,11 +295,9 @@ theorem isField_iff_isSimpleOrder_ideal : IsField R ↔ IsSimpleOrder (Ideal R) 
 /-- When a ring is not a field, the maximal ideals are nontrivial. -/
 theorem ne_bot_of_isMaximal_of_not_isField [Nontrivial R] {M : Ideal R} (max : M.IsMaximal)
     (not_field : ¬IsField R) : M ≠ ⊥ := by
-  rintro h
-  rw [h] at max
-  rcases max with ⟨⟨_h1, h2⟩⟩
+  rintro rfl
   obtain ⟨I, hIbot, hItop⟩ := not_isField_iff_exists_ideal_bot_lt_and_lt_top.mp not_field
-  exact ne_of_lt hItop (h2 I hIbot)
+  exact hIbot.ne (max.eq_of_le hItop.ne bot_le)
 
 end Ring
 
@@ -307,13 +305,7 @@ namespace Ideal
 
 variable {R : Type*} [CommSemiring R] [Nontrivial R]
 
-theorem bot_lt_of_maximal (M : Ideal R) [hm : M.IsMaximal] (non_field : ¬IsField R) : ⊥ < M := by
-  rcases Ring.not_isField_iff_exists_ideal_bot_lt_and_lt_top.1 non_field with ⟨I, Ibot, Itop⟩
-  constructor; · simp
-  intro mle
-  apply lt_irrefl (⊤ : Ideal R)
-  have : M = ⊥ := eq_bot_iff.mpr mle
-  rw [← this] at Ibot
-  rwa [hm.1.2 I Ibot] at Itop
+theorem bot_lt_of_maximal (M : Ideal R) [hm : M.IsMaximal] (non_field : ¬IsField R) : ⊥ < M :=
+  (Ring.ne_bot_of_isMaximal_of_not_isField hm non_field).bot_lt
 
 end Ideal


### PR DESCRIPTION
This PR cleans up `RingTheory/Ideal/Basic` by introducing some intermediate results `isField_iff_maximal_bot`, `exists_maximal_of_not_isField`, `not_isField_of_ne_of_ne`.

---
<!-- Your PR title will become the first line of the commit message.

In this box, the text above the `---` (if not empty) will be appended
to the commit message, and can be used to give additional context or
details. Please leave a blank newline before the `---`, otherwise GitHub
will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

When merging, all the commits will be squashed into a single commit
listing all co-authors.

Co-authors in the squash commit are gathered from two sources:

First, all authors of commits to this PR branch are included. Thus,
one way to add co-authors is to include at least one commit authored by
each co-author among the commits in the pull request. If necessary, you
may create empty commits to indicate co-authorship, using commands like so:

git commit --author="Author Name <author@email.com>" --allow-empty -m "add Author Name as coauthor"

Second, co-authors can also be listed in lines at the very bottom of
the commit message (that is, directly before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines
at the bottom of the commit message (before the `---`, and also before
any "Co-authored-by" lines) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
