### PR TITLE
[Merged by Bors] - feat(Homotopy/Lifting): add a lemma about `IsCoveringMapOn`

### DIFF
--- a/Mathlib/Topology/Homotopy/Lifting.lean
+++ b/Mathlib/Topology/Homotopy/Lifting.lean
@@ -464,3 +464,32 @@ theorem existsUnique_continuousMap_lifts_of_range_le
 end homotopy_lifting
 
 end IsCoveringMap
+
+/-- A version of `IsCoveringMap.existsUnique_continuousMap_lifts` for maps
+that are covering on a subset of the codomain.
+
+Let `p` be a covering map on `s`.
+Let `f` be a continuous map with a simply connected locally path connected domain
+such that all values of `f` belong to `s`.
+Given a point `a₀` in the domain of `f` and a lift `e₀` of `f a₀` along `p`,
+there exists a unique lift `F` of `f` along `p` such that `F a₀ = e₀`.
+-/
+theorem IsCoveringMapOn.existsUnique_continuousMap_lifts [SimplyConnectedSpace A]
+    [LocPathConnectedSpace A] {s : Set X} (cov : IsCoveringMapOn p s) (f : C(A, X)) {a₀ : A}
+    {e₀ : E} (he : p e₀ = f a₀) (hs : ∀ a, f a ∈ s) :
+    ∃! F : C(A, E), F a₀ = e₀ ∧ p ∘ F = f := by
+  obtain ⟨f, rfl⟩ : ∃ f' : C(A, s), f = .comp ⟨Subtype.val, by fun_prop⟩ f' :=
+    ⟨⟨fun a ↦ ⟨f a, hs a⟩, by fun_prop⟩, rfl⟩
+  lift e₀ to p ⁻¹' s using by rw [Set.mem_preimage, he]; apply hs
+  rcases cov.isCoveringMap_restrictPreimage.existsUnique_continuousMap_lifts f a₀ e₀
+    (Subtype.ext he) with ⟨F, ⟨rfl, hF⟩, hF_unique⟩
+  refine ⟨.comp ⟨Subtype.val, by fun_prop⟩ F, ⟨rfl, ?_⟩, ?_⟩
+  · simp [← hF, Function.comp_def]
+  · rintro F' ⟨hF'₁, hF'₂⟩
+    simp only [ContinuousMap.coe_comp, ContinuousMap.coe_mk, funext_iff,
+      Function.comp_apply] at hF'₂
+    specialize hF_unique
+      ⟨fun a ↦ ⟨F' a, by rw [Set.mem_preimage, hF'₂]; exact (f a).2⟩, by fun_prop⟩
+      ⟨Subtype.ext hF'₁, ?_⟩
+    · ext; simp [← hF'₂]
+    · ext; simp [← hF_unique]


### PR DESCRIPTION
Some important maps (e.g., `Complex.exp` or `x ↦ x ^ n`)
aren't covering maps over the whole space.

---
<!-- Your PR title will become the first line of the commit message.

In this box, the text above the `---` (if not empty) will be appended
to the commit message, and can be used to give additional context or
details. Please leave a blank newline before the `---`, otherwise GitHub
will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

When merging, all the commits will be squashed into a single commit
listing all co-authors.

Co-authors in the squash commit are gathered from two sources:

First, all authors of commits to this PR branch are included. Thus,
one way to add co-authors is to include at least one commit authored by
each co-author among the commits in the pull request. If necessary, you
may create empty commits to indicate co-authorship, using commands like so:

git commit --author="Author Name <author@email.com>" --allow-empty -m "add Author Name as coauthor"

Second, co-authors can also be listed in lines at the very bottom of
the commit message (that is, directly before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines
at the bottom of the commit message (before the `---`, and also before
any "Co-authored-by" lines) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)

<!-- Message of single commit: -->