### PR TITLE
[Merged by Bors] - feat(Algebra): leading coeff of sum of polynomials with same degree is sum of leading coeffs

### DIFF
--- a/Mathlib/Algebra/Polynomial/BigOperators.lean
+++ b/Mathlib/Algebra/Polynomial/BigOperators.lean
@@ -70,16 +70,13 @@ the sum of the leading coefficients, provided that this sum is nonzero.
 theorem leadingCoeff_sum_of_degree_eq {f : ι → S[X]} {s : Finset ι} {d}
     (hd : ∀ k ∈ s, (f k).degree = d) (hf : ∑ k ∈ s, (f k).leadingCoeff ≠ 0) :
     (∑ k ∈ s, f k).leadingCoeff = ∑ k ∈ s, (f k).leadingCoeff := by
-  obtain d | d := d
-  · replace hd k (hk : k ∈ s) : f k = 0 := by simpa [← degree_eq_bot] using hd k hk
-    simp_all only [leadingCoeff_zero, Finset.sum_const_zero]
-  · replace hd k (hk : k ∈ s) : (f k).natDegree = d := by simp [natDegree, hd k hk]; rfl
-    simp only [leadingCoeff, finset_sum_coeff]
-    congr! 2 with k hk
-    rw [natDegree_eq_of_le_of_coeff_ne_zero]
-    · apply natDegree_sum_le_of_forall_le
-      simp_all only [le_refl, implies_true]
-    · simp_all only [leadingCoeff, ne_eq, finset_sum_coeff, not_false_eq_true]
+  obtain _ | d := d
+  · simp_all [WithBot.none_eq_bot]
+  · replace hd k (hk : k ∈ s) : (f k).natDegree = d := natDegree_eq_of_degree_eq_some <| hd k hk
+    suffices (∑ k ∈ s, f k).natDegree = d by simp_all [leadingCoeff]
+    apply natDegree_eq_of_le_of_coeff_ne_zero
+    · aesop (add safe natDegree_sum_le_of_forall_le)
+    · simp_all [leadingCoeff]
 
 theorem degree_list_sum_le_of_forall_degree_le (l : List S[X])
     (n : WithBot ℕ) (hl : ∀ p ∈ l, degree p ≤ n) :

--- a/Mathlib/Algebra/Polynomial/BigOperators.lean
+++ b/Mathlib/Algebra/Polynomial/BigOperators.lean
@@ -64,6 +64,23 @@ lemma natDegree_sum_le_of_forall_le {n : ℕ} (f : ι → S[X]) (h : ∀ i ∈ s
     natDegree (∑ i ∈ s, f i) ≤ n :=
   le_trans (natDegree_sum_le s f) <| (Finset.fold_max_le n).mpr <| by simpa
 
+/-- The leading coefficient of a sum of polynomials with the same degree is
+the sum of the leading coefficients, provided that this sum is nonzero.
+-/
+theorem leadingCoeff_sum_of_degree_eq {f : ι → S[X]} {s : Finset ι} {d}
+    (hd : ∀ k ∈ s, (f k).degree = d) (hf : ∑ k ∈ s, (f k).leadingCoeff ≠ 0) :
+    (∑ k ∈ s, f k).leadingCoeff = ∑ k ∈ s, (f k).leadingCoeff := by
+  obtain d | d := d
+  · replace hd k (hk : k ∈ s) : f k = 0 := by simpa [← degree_eq_bot] using hd k hk
+    simp_all only [leadingCoeff_zero, Finset.sum_const_zero]
+  · replace hd k (hk : k ∈ s) : (f k).natDegree = d := by simp [natDegree, hd k hk]; rfl
+    simp only [leadingCoeff, finset_sum_coeff]
+    congr! 2 with k hk
+    rw [natDegree_eq_of_le_of_coeff_ne_zero]
+    · apply natDegree_sum_le_of_forall_le
+      simp_all only [le_refl, implies_true]
+    · simp_all only [leadingCoeff, ne_eq, finset_sum_coeff, not_false_eq_true]
+
 theorem degree_list_sum_le_of_forall_degree_le (l : List S[X])
     (n : WithBot ℕ) (hl : ∀ p ∈ l, degree p ≤ n) :
     degree l.sum ≤ n := by


### PR DESCRIPTION
Adds one lemma: The leading coefficient of a sum of polynomials with the same degree is
the sum of the leading coefficients, provided that the sum of leading coefficients is nonzero.
This generalizes `leadingCoeff_add_of_degree_eq` to the finset sum case.

---
<!-- Your PR title will become the first line of the commit message.

In this box, the text above the `---` (if not empty) will be appended
to the commit message, and can be used to give additional context or
details. Please leave a blank newline before the `---`, otherwise GitHub
will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

When merging, all the commits will be squashed into a single commit
listing all co-authors.

Co-authors in the squash commit are gathered from two sources:

First, all authors of commits to this PR branch are included. Thus,
one way to add co-authors is to include at least one commit authored by
each co-author among the commits in the pull request. If necessary, you
may create empty commits to indicate co-authorship, using commands like so:

git commit --author="Author Name <author@email.com>" --allow-empty -m "add Author Name as coauthor"

Second, co-authors can also be listed in lines at the very bottom of
the commit message (that is, directly before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines
at the bottom of the commit message (before the `---`, and also before
any "Co-authored-by" lines) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
