### PR TITLE
refactor: deprecate `ContinuousLinearMapClass`

### DIFF
--- a/Mathlib/Analysis/CStarAlgebra/PositiveLinearMap.lean
+++ b/Mathlib/Analysis/CStarAlgebra/PositiveLinearMap.lean
@@ -128,7 +128,7 @@ lemma exists_norm_apply_le (f : A₁ →ₚ[ℂ] A₂) : ∃ C : ℝ≥0, ∀ a,
     exact x_summable.le_tsum n fun m _ ↦ this m
 
 instance {F : Type*} [FunLike F A₁ A₂] [LinearMapClass F ℂ A₁ A₂] [OrderHomClass F A₁ A₂] :
-    ContinuousLinearMapClass F ℂ A₁ A₂ where
+    ContinuousMapClass F A₁ A₂ where
   map_continuous f := by
     have hbound : ∃ C : ℝ, ∀ a, ‖f a‖ ≤ C * ‖a‖ := by
       obtain ⟨C, h⟩ := exists_norm_apply_le (f : A₁ →ₚ[ℂ] A₂)

--- a/Mathlib/Analysis/CStarAlgebra/Spectrum.lean
+++ b/Mathlib/Analysis/CStarAlgebra/Spectrum.lean
@@ -265,14 +265,13 @@ lemma nnnorm_apply_le (φ : F) (a : A) : ‖φ a‖₊ ≤ ‖a‖₊ := by
 lemma norm_apply_le (φ : F) (a : A) : ‖φ a‖ ≤ ‖a‖ := by
   exact_mod_cast nnnorm_apply_le φ a
 
-/-- Non-unital star algebra homomorphisms between C⋆-algebras are continuous linear maps.
+/-- Non-unital star algebra homomorphisms between C⋆-algebras are continuous maps.
 See note [lower instance priority] -/
-lemma instContinuousLinearMapClassComplex : ContinuousLinearMapClass F ℂ A B :=
-  { NonUnitalAlgHomClass.instLinearMapClass with
-    map_continuous := fun φ =>
-      AddMonoidHomClass.continuous_of_bound φ 1 (by simpa only [one_mul] using nnnorm_apply_le φ) }
+lemma instContinuousMapClassComplex : ContinuousMapClass F A B where
+  map_continuous := fun φ =>
+    AddMonoidHomClass.continuous_of_bound φ 1 (by simpa only [one_mul] using nnnorm_apply_le φ)
 
-scoped[CStarAlgebra] attribute [instance] NonUnitalStarAlgHom.instContinuousLinearMapClassComplex
+scoped[CStarAlgebra] attribute [instance] NonUnitalStarAlgHom.instContinuousMapClassComplex
 
 end NonUnitalStarAlgHom
 

--- a/Mathlib/Analysis/LocallyConvex/WeakOperatorTopology.lean
+++ b/Mathlib/Analysis/LocallyConvex/WeakOperatorTopology.lean
@@ -124,9 +124,11 @@ instance instFunLike : FunLike (E →SWOT[σ] F) E F where
   coe f :=  ((ContinuousLinearMap.toWOT σ E F).symm f : E → F)
   coe_injective' := by intro; simp
 
-instance instContinuousLinearMapClass : ContinuousSemilinearMapClass (E →SWOT[σ] F) σ E F where
+instance instSemilinearMapClass : SemilinearMapClass (E →SWOT[σ] F) σ E F where
   map_add f x y := by simp only [DFunLike.coe]; simp
   map_smulₛₗ f r x := by simp only [DFunLike.coe]; simp
+
+instance instContinuousMapClass : ContinuousMapClass (E →SWOT[σ] F) E F where
   map_continuous f := ContinuousLinearMap.continuous ((ContinuousLinearMap.toWOT σ E F).symm f)
 
 @[simp]

--- a/Mathlib/Analysis/Normed/Algebra/Spectrum.lean
+++ b/Mathlib/Analysis/Normed/Algebra/Spectrum.lean
@@ -407,11 +407,10 @@ variable {F : Type*} [NormedField 𝕜] [NormedRing A] [NormedAlgebra 𝕜 A] [C
 local notation "↑ₐ" => algebraMap 𝕜 A
 
 instance (priority := 100) [FunLike F A 𝕜] [AlgHomClass F 𝕜 A 𝕜] :
-    ContinuousLinearMapClass F 𝕜 A 𝕜 :=
-  { AlgHomClass.linearMapClass with
-    map_continuous := fun φ =>
-      AddMonoidHomClass.continuous_of_bound φ ‖(1 : A)‖ fun a =>
-        mul_comm ‖a‖ ‖(1 : A)‖ ▸ spectrum.norm_le_norm_mul_of_mem (apply_mem_spectrum φ _) }
+    ContinuousMapClass F A 𝕜 where
+  map_continuous φ :=
+    AddMonoidHomClass.continuous_of_bound φ ‖(1 : A)‖ fun a =>
+      mul_comm ‖a‖ ‖(1 : A)‖ ▸ spectrum.norm_le_norm_mul_of_mem (apply_mem_spectrum φ _)
 
 /-- An algebra homomorphism into the base field, as a continuous linear map (since it is
 automatically bounded). -/

--- a/Mathlib/Analysis/Normed/Operator/LinearIsometry.lean
+++ b/Mathlib/Analysis/Normed/Operator/LinearIsometry.lean
@@ -123,8 +123,8 @@ theorem diam_range [SemilinearIsometryClass 𝓕 σ₁₂ E E₂] (f : 𝓕) :
     Metric.diam (range f) = Metric.diam (univ : Set E) :=
   (SemilinearIsometryClass.isometry f).diam_range
 
-instance (priority := 100) toContinuousSemilinearMapClass
-    [SemilinearIsometryClass 𝓕 σ₁₂ E E₂] : ContinuousSemilinearMapClass 𝓕 σ₁₂ E E₂ where
+instance (priority := 100) toSemilinearIsometryClass
+    [SemilinearIsometryClass 𝓕 σ₁₂ E E₂] : ContinuousMapClass 𝓕 E E₂ where
   map_continuous := SemilinearIsometryClass.continuous
 
 end SemilinearIsometryClass

--- a/Mathlib/Topology/Algebra/Module/CharacterSpace.lean
+++ b/Mathlib/Topology/Algebra/Module/CharacterSpace.lean
@@ -60,10 +60,13 @@ instance instFunLike : FunLike (characterSpace 𝕜 A) A 𝕜 where
   coe φ := ((φ : WeakDual 𝕜 A) : A → 𝕜)
   coe_injective' φ ψ h := by ext1; apply DFunLike.ext; exact congr_fun h
 
-/-- Elements of the character space are continuous linear maps. -/
-instance instContinuousLinearMapClass : ContinuousLinearMapClass (characterSpace 𝕜 A) 𝕜 A 𝕜 where
+/-- Elements of the character space are linear maps. -/
+instance instLinearMapClass : LinearMapClass (characterSpace 𝕜 A) 𝕜 A 𝕜 where
   map_smulₛₗ φ := (φ : WeakDual 𝕜 A).map_smul
   map_add φ := (φ : WeakDual 𝕜 A).map_add
+
+/-- Elements of the character space are continuous maps. -/
+instance instContinuousMapClass : ContinuousMapClass (characterSpace 𝕜 A) A 𝕜 where
   map_continuous φ := (φ : WeakDual 𝕜 A).cont
 
 /-- This has to come after `WeakDual.CharacterSpace.instFunLike`, otherwise the right-hand side
@@ -86,7 +89,7 @@ theorem coe_toCLM (φ : characterSpace 𝕜 A) : ⇑(toCLM φ) = φ :=
 
 /-- Elements of the character space are non-unital algebra homomorphisms. -/
 instance instNonUnitalAlgHomClass : NonUnitalAlgHomClass (characterSpace 𝕜 A) 𝕜 A 𝕜 :=
-  { CharacterSpace.instContinuousLinearMapClass with
+  { CharacterSpace.instLinearMapClass with
     map_smulₛₗ := fun φ => map_smul φ
     map_zero := fun φ => map_zero φ
     map_mul := fun φ => φ.prop.2 }

--- a/Mathlib/Topology/Algebra/Module/Equiv.lean
+++ b/Mathlib/Topology/Algebra/Module/Equiv.lean
@@ -50,7 +50,9 @@ notation:50 M " ≃L[" R "] " M₂ => ContinuousLinearEquiv (RingHom.id R) M M�
 where `σ` is the identity map on `R`.  A map `f` between an `R`-module and an `S`-module over a ring
 homomorphism `σ : R →+* S` is semilinear if it satisfies the two properties `f (x + y) = f x + f y`
 and `f (c • x) = (σ c) • f x`. -/
-class ContinuousSemilinearEquivClass (F : Type*) {R : outParam Type*} {S : outParam Type*}
+@[deprecated "Use `[SemilinearEquivClass F σ M M₂] [HomeomorphClass F M M₂]` instead."
+  (since := "2026-01-01")]
+structure ContinuousSemilinearEquivClass (F : Type*) {R : outParam Type*} {S : outParam Type*}
     [Semiring R] [Semiring S] (σ : outParam <| R →+* S) {σ' : outParam <| S →+* R}
     [RingHomInvPair σ σ'] [RingHomInvPair σ' σ] (M : outParam Type*) [TopologicalSpace M]
     [AddCommMonoid M] (M₂ : outParam Type*) [TopologicalSpace M₂] [AddCommMonoid M₂] [Module R M]
@@ -62,9 +64,12 @@ attribute [inherit_doc ContinuousSemilinearEquivClass]
 ContinuousSemilinearEquivClass.map_continuous
 ContinuousSemilinearEquivClass.inv_continuous
 
+set_option linter.deprecated false in
 /-- `ContinuousLinearEquivClass F σ M M₂` asserts `F` is a type of bundled continuous
 `R`-linear equivs `M → M₂`. This is an abbreviation for
 `ContinuousSemilinearEquivClass F (RingHom.id R) M M₂`. -/
+@[deprecated "Use `[LinearEquivClass F R M M₂] [HomeomorphClass F M M₂]` instead."
+  (since := "2026-01-01")]
 abbrev ContinuousLinearEquivClass (F : Type*) (R : outParam Type*) [Semiring R]
     (M : outParam Type*) [TopologicalSpace M] [AddCommMonoid M] (M₂ : outParam Type*)
     [TopologicalSpace M₂] [AddCommMonoid M₂] [Module R M] [Module R M₂] [EquivLike F M M₂] :=
@@ -77,15 +82,6 @@ variable (F : Type*) {R : Type*} {S : Type*} [Semiring R] [Semiring S] (σ : R �
   (M : Type*) [TopologicalSpace M] [AddCommMonoid M]
   (M₂ : Type*) [TopologicalSpace M₂] [AddCommMonoid M₂]
   [Module R M] [Module S M₂]
-
--- `σ'` becomes a metavariable, but it's OK since it's an outparam
-instance (priority := 100) continuousSemilinearMapClass [EquivLike F M M₂]
-    [s : ContinuousSemilinearEquivClass F σ M M₂] : ContinuousSemilinearMapClass F σ M M₂ :=
-  { s with }
-
-instance (priority := 100) [EquivLike F M M₂]
-    [s : ContinuousSemilinearEquivClass F σ M M₂] : HomeomorphClass F M M₂ :=
-  { s with }
 
 end ContinuousSemilinearEquivClass
 
@@ -155,10 +151,13 @@ instance equivLike :
   left_inv f := f.left_inv
   right_inv f := f.right_inv
 
-instance continuousSemilinearEquivClass :
-    ContinuousSemilinearEquivClass (M₁ ≃SL[σ₁₂] M₂) σ₁₂ M₁ M₂ where
+instance semilinearEquivClass :
+    SemilinearEquivClass (M₁ ≃SL[σ₁₂] M₂) σ₁₂ M₁ M₂ where
   map_add f := f.map_add'
   map_smulₛₗ f := f.map_smul'
+
+instance homeomorphClass :
+    HomeomorphClass (M₁ ≃SL[σ₁₂] M₂) M₁ M₂ where
   map_continuous := continuous_toFun
   inv_continuous := continuous_invFun
 

--- a/Mathlib/Topology/Algebra/Module/FiniteDimension.lean
+++ b/Mathlib/Topology/Algebra/Module/FiniteDimension.lean
@@ -275,9 +275,9 @@ theorem LinearMap.continuous_of_finiteDimensional [T2Space E] [FiniteDimensional
     (f : E →ₗ[𝕜] F') : Continuous f :=
   IsModuleTopology.continuous_of_linearMap f
 
-instance LinearMap.continuousLinearMapClassOfFiniteDimensional [T2Space E] [FiniteDimensional 𝕜 E] :
-    ContinuousLinearMapClass (E →ₗ[𝕜] F') 𝕜 E F' :=
-  { LinearMap.semilinearMapClass with map_continuous := fun f => f.continuous_of_finiteDimensional }
+instance LinearMap.continuousMapClassOfFiniteDimensional [T2Space E] [FiniteDimensional 𝕜 E] :
+    ContinuousMapClass (E →ₗ[𝕜] F') E F' where
+  map_continuous := continuous_of_finiteDimensional
 
 /-- In finite dimensions over a non-discrete complete normed field, the canonical identification
 (in terms of a basis) with `𝕜^n` (endowed with the product topology) is continuous.

--- a/Mathlib/Topology/Algebra/Module/LinearMap.lean
+++ b/Mathlib/Topology/Algebra/Module/LinearMap.lean
@@ -51,15 +51,20 @@ notation:25 M " →L[" R "] " M₂ => ContinuousLinearMap (RingHom.id R) M M₂
 `σ` is the identity map on `R`.  A map `f` between an `R`-module and an `S`-module over a ring
 homomorphism `σ : R →+* S` is semilinear if it satisfies the two properties `f (x + y) = f x + f y`
 and `f (c • x) = (σ c) • f x`. -/
-class ContinuousSemilinearMapClass (F : Type*) {R S : outParam Type*} [Semiring R] [Semiring S]
+@[deprecated "Use `[SemilinearMapClass F σ M M₂] [ContinuousMapClass F M M₂]` instead."
+  (since := "2026-01-01")]
+structure ContinuousSemilinearMapClass (F : Type*) {R S : outParam Type*} [Semiring R] [Semiring S]
     (σ : outParam <| R →+* S) (M : outParam Type*) [TopologicalSpace M] [AddCommMonoid M]
     (M₂ : outParam Type*) [TopologicalSpace M₂] [AddCommMonoid M₂] [Module R M]
     [Module S M₂] [FunLike F M M₂] : Prop
     extends SemilinearMapClass F σ M M₂, ContinuousMapClass F M M₂
 
+set_option linter.deprecated false in
 /-- `ContinuousLinearMapClass F R M M₂` asserts `F` is a type of bundled continuous
 `R`-linear maps `M → M₂`.  This is an abbreviation for
 `ContinuousSemilinearMapClass F (RingHom.id R) M M₂`. -/
+@[deprecated "Use `[LinearMapClass F R M M₂] [ContinuousMapClass F M M₂]` instead."
+  (since := "2026-01-01")]
 abbrev ContinuousLinearMapClass (F : Type*) (R : outParam Type*) [Semiring R]
     (M : outParam Type*) [TopologicalSpace M] [AddCommMonoid M] (M₂ : outParam Type*)
     [TopologicalSpace M₂] [AddCommMonoid M₂] [Module R M] [Module R M₂] [FunLike F M M₂] :=
@@ -100,11 +105,14 @@ instance funLike : FunLike (M₁ →SL[σ₁₂] M₂) M₁ M₂ where
   coe f := f.toLinearMap
   coe_injective' _ _ h := coe_injective (DFunLike.coe_injective h)
 
-instance continuousSemilinearMapClass :
-    ContinuousSemilinearMapClass (M₁ →SL[σ₁₂] M₂) σ₁₂ M₁ M₂ where
+instance semilinearMapClass :
+    SemilinearMapClass (M₁ →SL[σ₁₂] M₂) σ₁₂ M₁ M₂ where
   map_add f := map_add f.toLinearMap
-  map_continuous f := f.2
   map_smulₛₗ f := f.toLinearMap.map_smul'
+
+instance continuousMapClass :
+    ContinuousMapClass (M₁ →SL[σ₁₂] M₂) M₁ M₂ where
+  map_continuous f := f.2
 
 theorem coe_mk (f : M₁ →ₛₗ[σ₁₂] M₂) (h) : (mk f h : M₁ →ₛₗ[σ₁₂] M₂) = f :=
   rfl

--- a/Mathlib/Topology/Algebra/Module/StrongTopology.lean
+++ b/Mathlib/Topology/Algebra/Module/StrongTopology.lean
@@ -94,9 +94,13 @@ theorem ext [TopologicalSpace F] {𝔖 : Set (Set E)} {f g : UniformConvergenceC
     (h : ∀ x, f x = g x) : f = g :=
   DFunLike.ext f g h
 
-instance instContinuousSemilinearMapClass [TopologicalSpace F] (𝔖 : Set (Set E)) :
-    ContinuousSemilinearMapClass (UniformConvergenceCLM σ F 𝔖) σ E F :=
-  ContinuousLinearMap.continuousSemilinearMapClass
+instance instSemilinearMapClass [TopologicalSpace F] (𝔖 : Set (Set E)) :
+    SemilinearMapClass (UniformConvergenceCLM σ F 𝔖) σ E F :=
+  ContinuousLinearMap.semilinearMapClass
+
+instance instContinuousMapClass [TopologicalSpace F] (𝔖 : Set (Set E)) :
+    ContinuousMapClass (UniformConvergenceCLM σ F 𝔖) E F :=
+  ContinuousLinearMap.continuousMapClass
 
 instance instTopologicalSpace [TopologicalSpace F] [IsTopologicalAddGroup F] (𝔖 : Set (Set E)) :
     TopologicalSpace (UniformConvergenceCLM σ F 𝔖) :=

--- a/Mathlib/Topology/Algebra/Module/WeakDual.lean
+++ b/Mathlib/Topology/Algebra/Module/WeakDual.lean
@@ -62,7 +62,7 @@ def WeakDual (𝕜 E : Type*) [CommSemiring 𝕜] [TopologicalSpace 𝕜] [Conti
     [ContinuousConstSMul 𝕜 𝕜] [AddCommMonoid E] [Module 𝕜 E] [TopologicalSpace E] :=
   WeakBilin (topDualPairing 𝕜 E)
 deriving AddCommMonoid, Module 𝕜, TopologicalSpace, ContinuousAdd, Inhabited,
-  FunLike, ContinuousLinearMapClass
+  FunLike, LinearMapClass, ContinuousMapClass
 
 namespace WeakDual
 


### PR DESCRIPTION
This PR continues the work from #18748.

Original PR: https://github.com/leanprover-community/mathlib4/pull/18748