### PR TITLE
refactor: deprecate `LinearIsometryClass`

### DIFF
--- a/Mathlib/Analysis/CStarAlgebra/PositiveLinearMap.lean
+++ b/Mathlib/Analysis/CStarAlgebra/PositiveLinearMap.lean
@@ -128,7 +128,7 @@ lemma exists_norm_apply_le (f : A₁ →ₚ[ℂ] A₂) : ∃ C : ℝ≥0, ∀ a,
     exact x_summable.le_tsum n fun m _ ↦ this m
 
 instance {F : Type*} [FunLike F A₁ A₂] [LinearMapClass F ℂ A₁ A₂] [OrderHomClass F A₁ A₂] :
-    ContinuousLinearMapClass F ℂ A₁ A₂ where
+    ContinuousMapClass F A₁ A₂ where
   map_continuous f := by
     have hbound : ∃ C : ℝ, ∀ a, ‖f a‖ ≤ C * ‖a‖ := by
       obtain ⟨C, h⟩ := exists_norm_apply_le (f : A₁ →ₚ[ℂ] A₂)

--- a/Mathlib/Analysis/CStarAlgebra/Spectrum.lean
+++ b/Mathlib/Analysis/CStarAlgebra/Spectrum.lean
@@ -265,14 +265,13 @@ lemma nnnorm_apply_le (φ : F) (a : A) : ‖φ a‖₊ ≤ ‖a‖₊ := by
 lemma norm_apply_le (φ : F) (a : A) : ‖φ a‖ ≤ ‖a‖ := by
   exact_mod_cast nnnorm_apply_le φ a
 
-/-- Non-unital star algebra homomorphisms between C⋆-algebras are continuous linear maps.
+/-- Non-unital star algebra homomorphisms between C⋆-algebras are continuous maps.
 See note [lower instance priority] -/
-lemma instContinuousLinearMapClassComplex : ContinuousLinearMapClass F ℂ A B :=
-  { NonUnitalAlgHomClass.instLinearMapClass with
-    map_continuous := fun φ =>
-      AddMonoidHomClass.continuous_of_bound φ 1 (by simpa only [one_mul] using nnnorm_apply_le φ) }
+lemma instContinuousMapClassComplex : ContinuousMapClass F A B where
+  map_continuous := fun φ =>
+    AddMonoidHomClass.continuous_of_bound φ 1 (by simpa only [one_mul] using nnnorm_apply_le φ)
 
-scoped[CStarAlgebra] attribute [instance] NonUnitalStarAlgHom.instContinuousLinearMapClassComplex
+scoped[CStarAlgebra] attribute [instance] NonUnitalStarAlgHom.instContinuousMapClassComplex
 
 end NonUnitalStarAlgHom
 

--- a/Mathlib/Analysis/LocallyConvex/WeakOperatorTopology.lean
+++ b/Mathlib/Analysis/LocallyConvex/WeakOperatorTopology.lean
@@ -124,9 +124,11 @@ instance instFunLike : FunLike (E →SWOT[σ] F) E F where
   coe f :=  ((ContinuousLinearMap.toWOT σ E F).symm f : E → F)
   coe_injective' := by intro; simp
 
-instance instContinuousLinearMapClass : ContinuousSemilinearMapClass (E →SWOT[σ] F) σ E F where
+instance instSemilinearMapClass : SemilinearMapClass (E →SWOT[σ] F) σ E F where
   map_add f x y := by simp only [DFunLike.coe]; simp
   map_smulₛₗ f r x := by simp only [DFunLike.coe]; simp
+
+instance instContinuousMapClass : ContinuousMapClass (E →SWOT[σ] F) E F where
   map_continuous f := ContinuousLinearMap.continuous ((ContinuousLinearMap.toWOT σ E F).symm f)
 
 @[simp]

--- a/Mathlib/Analysis/Normed/Affine/Isometry.lean
+++ b/Mathlib/Analysis/Normed/Affine/Isometry.lean
@@ -131,15 +131,14 @@ theorem map_vadd (p : P) (v : V) : f (v +ᵥ p) = f.linearIsometry v +ᵥ f p :=
 theorem map_vsub (p1 p2 : P) : f.linearIsometry (p1 -ᵥ p2) = f p1 -ᵥ f p2 :=
   f.toAffineMap.linearMap_vsub p1 p2
 
-@[simp]
-theorem dist_map (x y : P) : dist (f x) (f y) = dist x y := by
-  rw [dist_eq_norm_vsub V₂, dist_eq_norm_vsub V, ← map_vsub, f.linearIsometry.norm_map]
+instance instIsometryClass : IsometryClass (P →ᵃⁱ[𝕜] P₂) P P₂ where
+  isometry f x y := by simp [edist_dist, dist_eq_norm_vsub, ← map_vsub]
 
-@[simp]
-theorem nndist_map (x y : P) : nndist (f x) (f y) = nndist x y := by simp [nndist_dist]
+theorem dist_map (x y : P) : dist (f x) (f y) = dist x y := IsometryClass.dist_map f x y
 
-@[simp]
-theorem edist_map (x y : P) : edist (f x) (f y) = edist x y := by simp [edist_dist]
+theorem nndist_map (x y : P) : nndist (f x) (f y) = nndist x y := IsometryClass.nndist_map f x y
+
+theorem edist_map (x y : P) : edist (f x) (f y) = edist x y := IsometryClass.edist_map f x y
 
 protected theorem isometry : Isometry f :=
   f.edist_map

--- a/Mathlib/Analysis/Normed/Algebra/Spectrum.lean
+++ b/Mathlib/Analysis/Normed/Algebra/Spectrum.lean
@@ -407,11 +407,10 @@ variable {F : Type*} [NormedField 𝕜] [NormedRing A] [NormedAlgebra 𝕜 A] [C
 local notation "↑ₐ" => algebraMap 𝕜 A
 
 instance (priority := 100) [FunLike F A 𝕜] [AlgHomClass F 𝕜 A 𝕜] :
-    ContinuousLinearMapClass F 𝕜 A 𝕜 :=
-  { AlgHomClass.linearMapClass with
-    map_continuous := fun φ =>
-      AddMonoidHomClass.continuous_of_bound φ ‖(1 : A)‖ fun a =>
-        mul_comm ‖a‖ ‖(1 : A)‖ ▸ spectrum.norm_le_norm_mul_of_mem (apply_mem_spectrum φ _) }
+    ContinuousMapClass F A 𝕜 where
+  map_continuous φ :=
+    AddMonoidHomClass.continuous_of_bound φ ‖(1 : A)‖ fun a =>
+      mul_comm ‖a‖ ‖(1 : A)‖ ▸ spectrum.norm_le_norm_mul_of_mem (apply_mem_spectrum φ _)
 
 /-- An algebra homomorphism into the base field, as a continuous linear map (since it is
 automatically bounded). -/

--- a/Mathlib/Analysis/Normed/Group/Uniform.lean
+++ b/Mathlib/Analysis/Normed/Group/Uniform.lean
@@ -45,6 +45,11 @@ theorem nnnorm_map' [FunLike 𝓕 E F] [IsometryClass 𝓕 E F] [OneHomClass �
     ‖f x‖₊ = ‖x‖₊ :=
   NNReal.eq <| norm_map' f x
 
+@[to_additive (attr := simp) enorm_map]
+theorem enorm_map' [FunLike 𝓕 E F] [IsometryClass 𝓕 E F] [OneHomClass 𝓕 E F] (f : 𝓕) (x : E) :
+    ‖f x‖ₑ = ‖x‖ₑ := by
+  simp [enorm]
+
 @[to_additive (attr := simp) IsometryClass.isComplete_image_iff]
 theorem IsometryClass.isComplete_image_iff' [FunLike 𝓕 E F] [IsometryClass 𝓕 E F]
     (f : 𝓕) {s : Set E} :

--- a/Mathlib/Analysis/Normed/Group/Uniform.lean
+++ b/Mathlib/Analysis/Normed/Group/Uniform.lean
@@ -45,6 +45,12 @@ theorem nnnorm_map' [FunLike 𝓕 E F] [IsometryClass 𝓕 E F] [OneHomClass �
     ‖f x‖₊ = ‖x‖₊ :=
   NNReal.eq <| norm_map' f x
 
+@[to_additive (attr := simp) IsometryClass.isComplete_image_iff]
+theorem IsometryClass.isComplete_image_iff' [FunLike 𝓕 E F] [IsometryClass 𝓕 E F]
+    (f : 𝓕) {s : Set E} :
+    IsComplete (f '' s) ↔ IsComplete s :=
+  _root_.isComplete_image_iff (IsometryClass.isometry f).isUniformInducing
+
 @[to_additive (attr := simp)]
 theorem dist_mul_self_right (a b : E) : dist b (a * b) = ‖a‖ := by
   rw [← dist_one_left, ← dist_mul_right 1 a b, one_mul]

--- a/Mathlib/Analysis/Normed/Operator/LinearIsometry.lean
+++ b/Mathlib/Analysis/Normed/Operator/LinearIsometry.lean
@@ -123,8 +123,8 @@ theorem diam_range [SemilinearIsometryClass 𝓕 σ₁₂ E E₂] (f : 𝓕) :
     Metric.diam (range f) = Metric.diam (univ : Set E) :=
   (SemilinearIsometryClass.isometry f).diam_range
 
-instance (priority := 100) toContinuousSemilinearMapClass
-    [SemilinearIsometryClass 𝓕 σ₁₂ E E₂] : ContinuousSemilinearMapClass 𝓕 σ₁₂ E E₂ where
+instance (priority := 100) toSemilinearIsometryClass
+    [SemilinearIsometryClass 𝓕 σ₁₂ E E₂] : ContinuousMapClass 𝓕 E E₂ where
   map_continuous := SemilinearIsometryClass.continuous
 
 end SemilinearIsometryClass

--- a/Mathlib/Analysis/Normed/Operator/LinearIsometry.lean
+++ b/Mathlib/Analysis/Normed/Operator/LinearIsometry.lean
@@ -206,13 +206,9 @@ instance completeSpace_map [RingHomSurjective σ₁₂] (p : Submodule R E) [Com
     CompleteSpace (p.map (f : E →ₛₗ[σ₁₂] E₂)) :=
   ((isComplete_map_iff f).2 <| completeSpace_coe_iff_isComplete.1 ‹_›).completeSpace_coe
 
-@[simp]
-theorem dist_map (x y : E) : dist (f x) (f y) = dist x y :=
-  f.isometry.dist_eq x y
+theorem dist_map (x y : E) : dist (f x) (f y) = dist x y := _root_.dist_map f x y
 
-@[simp]
-theorem edist_map (x y : E) : edist (f x) (f y) = edist x y :=
-  f.isometry.edist_eq x y
+theorem edist_map (x y : E) : edist (f x) (f y) = edist x y := _root_.edist_map f x y
 
 protected theorem injective : Injective f₁ :=
   Isometry.injective (LinearIsometry.isometry f₁)
@@ -841,7 +837,6 @@ theorem map_smulₛₗ (c : R) (x : E) : e (c • x) = σ₁₂ c • e x :=
 theorem map_smul [Module R E₂] {e : E ≃ₗᵢ[R] E₂} (c : R) (x : E) : e (c • x) = c • e x :=
   e.1.map_smul c x
 
-@[simp] -- Should be replaced with `SemilinearIsometryClass.nnorm_map` when https://github.com/leanprover/lean4/issues/3107 is fixed.
 theorem nnnorm_map (x : E) : ‖e x‖₊ = ‖x‖₊ :=
   _root_.nnnorm_map e x
 

--- a/Mathlib/Analysis/Normed/Operator/LinearIsometry.lean
+++ b/Mathlib/Analysis/Normed/Operator/LinearIsometry.lean
@@ -174,13 +174,11 @@ protected theorem map_smul [Module R E₂] (f : E →ₗᵢ[R] E₂) (c : R) (x 
 theorem norm_map (x : E) : ‖f x‖ = ‖x‖ :=
   _root_.norm_map f x
 
-@[simp] -- Should be replaced with `SemilinearIsometryClass.nnorm_map` when https://github.com/leanprover/lean4/issues/3107 is fixed.
 theorem nnnorm_map (x : E) : ‖f x‖₊ = ‖x‖₊ :=
-  NNReal.eq <| norm_map f x
+  _root_.nnnorm_map f x
 
-@[simp] -- Should be replaced with `SemilinearIsometryClass.enorm_map` when https://github.com/leanprover/lean4/issues/3107 is fixed.
-theorem enorm_map (x : E) : ‖f x‖ₑ = ‖x‖ₑ := by
-  simp [enorm]
+theorem enorm_map (x : E) : ‖f x‖ₑ = ‖x‖ₑ :=
+  _root_.enorm_map f x
 
 protected theorem isometry : Isometry f :=
   AddMonoidHomClass.isometry_of_norm f.toLinearMap (norm_map _)

--- a/Mathlib/Analysis/Normed/Operator/LinearIsometry.lean
+++ b/Mathlib/Analysis/Normed/Operator/LinearIsometry.lean
@@ -69,17 +69,21 @@ See also `LinearIsometryClass F R E E₂` for the case where `σ` is the identit
 A map `f` between an `R`-module and an `S`-module over a ring homomorphism `σ : R →+* S`
 is semilinear if it satisfies the two properties `f (x + y) = f x + f y` and
 `f (c • x) = (σ c) • f x`. -/
-class SemilinearIsometryClass (𝓕 : Type*) {R R₂ : outParam Type*} [Semiring R] [Semiring R₂]
+@[deprecated "Use `[SemilinearMapClass 𝓕 σ E E₂] [IsometryClass 𝓕 E E₂]` instead."
+  (since := "2026-01-01")]
+structure SemilinearIsometryClass (𝓕 : Type*) {R R₂ : outParam Type*} [Semiring R] [Semiring R₂]
     (σ₁₂ : outParam <| R →+* R₂) (E E₂ : outParam Type*) [SeminormedAddCommGroup E]
     [SeminormedAddCommGroup E₂] [Module R E] [Module R₂ E₂] [FunLike 𝓕 E E₂] : Prop
     extends SemilinearMapClass 𝓕 σ₁₂ E E₂ where
   norm_map : ∀ (f : 𝓕) (x : E), ‖f x‖ = ‖x‖
 
+set_option linter.deprecated false in
 /-- `LinearIsometryClass F R E E₂` asserts `F` is a type of bundled `R`-linear isometries
 `M → M₂`.
 
-This is an abbreviation for `SemilinearIsometryClass F (RingHom.id R) E E₂`.
--/
+This is an abbreviation for `SemilinearIsometryClass F (RingHom.id R) E E₂`. -/
+@[deprecated "Use `[LinearMapClass 𝓕 R E E₂] [IsometryClass 𝓕 E E₂]` instead."
+  (since := "2026-01-01")]
 abbrev LinearIsometryClass (𝓕 : Type*) (R E E₂ : outParam Type*) [Semiring R]
     [SeminormedAddCommGroup E] [SeminormedAddCommGroup E₂] [Module R E] [Module R E₂]
     [FunLike 𝓕 E E₂] :=
@@ -89,43 +93,15 @@ namespace SemilinearIsometryClass
 
 variable [FunLike 𝓕 E E₂]
 
-protected theorem isometry [SemilinearIsometryClass 𝓕 σ₁₂ E E₂] (f : 𝓕) : Isometry f :=
-  AddMonoidHomClass.isometry_of_norm _ (norm_map _)
-
-@[continuity]
-protected theorem continuous [SemilinearIsometryClass 𝓕 σ₁₂ E E₂] (f : 𝓕) : Continuous f :=
-  (SemilinearIsometryClass.isometry f).continuous
-
--- Should be `@[simp]` but it doesn't fire due to https://github.com/leanprover/lean4/issues/3107.
-theorem nnnorm_map [SemilinearIsometryClass 𝓕 σ₁₂ E E₂] (f : 𝓕) (x : E) : ‖f x‖₊ = ‖x‖₊ :=
-  NNReal.eq <| norm_map f x
-
-protected theorem lipschitz [SemilinearIsometryClass 𝓕 σ₁₂ E E₂] (f : 𝓕) : LipschitzWith 1 f :=
-  (SemilinearIsometryClass.isometry f).lipschitz
-
-protected theorem antilipschitz [SemilinearIsometryClass 𝓕 σ₁₂ E E₂] (f : 𝓕) :
-    AntilipschitzWith 1 f :=
-  (SemilinearIsometryClass.isometry f).antilipschitz
-
-theorem ediam_image [SemilinearIsometryClass 𝓕 σ₁₂ E E₂] (f : 𝓕) (s : Set E) :
-    EMetric.diam (f '' s) = EMetric.diam s :=
-  (SemilinearIsometryClass.isometry f).ediam_image s
-
-theorem ediam_range [SemilinearIsometryClass 𝓕 σ₁₂ E E₂] (f : 𝓕) :
-    EMetric.diam (range f) = EMetric.diam (univ : Set E) :=
-  (SemilinearIsometryClass.isometry f).ediam_range
-
-theorem diam_image [SemilinearIsometryClass 𝓕 σ₁₂ E E₂] (f : 𝓕) (s : Set E) :
-    Metric.diam (f '' s) = Metric.diam s :=
-  (SemilinearIsometryClass.isometry f).diam_image s
-
-theorem diam_range [SemilinearIsometryClass 𝓕 σ₁₂ E E₂] (f : 𝓕) :
-    Metric.diam (range f) = Metric.diam (univ : Set E) :=
-  (SemilinearIsometryClass.isometry f).diam_range
-
-instance (priority := 100) toContinuousSemilinearMapClass
-    [SemilinearIsometryClass 𝓕 σ₁₂ E E₂] : ContinuousSemilinearMapClass 𝓕 σ₁₂ E E₂ where
-  map_continuous := SemilinearIsometryClass.continuous
+@[deprecated (since := "2026-01-01")] protected alias isometry := IsometryClass.isometry
+@[deprecated (since := "2026-01-01")] protected alias continuous := IsometryClass.continuous
+@[deprecated (since := "2026-01-01")] alias nnnorm_map := nnnorm_map
+@[deprecated (since := "2026-01-01")] protected alias lipschitz := IsometryClass.lipschitz
+@[deprecated (since := "2026-01-01")] protected alias antilipschitz := IsometryClass.antilipschitz
+@[deprecated (since := "2026-01-01")] alias ediam_image := IsometryClass.ediam_image
+@[deprecated (since := "2026-01-01")] alias ediam_range := IsometryClass.ediam_range
+@[deprecated (since := "2026-01-01")] alias diam_image := IsometryClass.diam_image
+@[deprecated (since := "2026-01-01")] alias diam_range := IsometryClass.diam_range
 
 end SemilinearIsometryClass
 
@@ -144,10 +120,12 @@ instance instFunLike : FunLike (E →ₛₗᵢ[σ₁₂] E₂) E E₂ where
   coe f := f.toFun
   coe_injective' _ _ h := toLinearMap_injective (DFunLike.coe_injective h)
 
-instance instSemilinearIsometryClass : SemilinearIsometryClass (E →ₛₗᵢ[σ₁₂] E₂) σ₁₂ E E₂ where
+instance instSemilinearMapClass : SemilinearMapClass (E →ₛₗᵢ[σ₁₂] E₂) σ₁₂ E E₂ where
   map_add f := map_add f.toLinearMap
   map_smulₛₗ f := map_smulₛₗ f.toLinearMap
-  norm_map f := f.norm_map'
+
+instance instIsometryClass : IsometryClass (E →ₛₗᵢ[σ₁₂] E₂) E E₂ where
+  isometry f := AddMonoidHomClass.isometry_of_norm f f.norm_map'
 
 @[simp]
 theorem coe_toLinearMap : ⇑f.toLinearMap = f :=
@@ -193,9 +171,8 @@ protected theorem map_smulₛₗ (c : R) (x : E) : f (c • x) = σ₁₂ c • 
 protected theorem map_smul [Module R E₂] (f : E →ₗᵢ[R] E₂) (c : R) (x : E) : f (c • x) = c • f x :=
   f.toLinearMap.map_smul c x
 
-@[simp]
 theorem norm_map (x : E) : ‖f x‖ = ‖x‖ :=
-  SemilinearIsometryClass.norm_map f x
+  _root_.norm_map f x
 
 @[simp] -- Should be replaced with `SemilinearIsometryClass.nnorm_map` when https://github.com/leanprover/lean4/issues/3107 is fixed.
 theorem nnnorm_map (x : E) : ‖f x‖₊ = ‖x‖₊ :=
@@ -210,19 +187,19 @@ protected theorem isometry : Isometry f :=
 
 lemma isEmbedding (f : F →ₛₗᵢ[σ₁₂] E₂) : IsEmbedding f := f.isometry.isEmbedding
 
-@[simp]
-theorem isComplete_image_iff [SemilinearIsometryClass 𝓕 σ₁₂ E E₂] (f : 𝓕) {s : Set E} :
+@[deprecated IsometryClass.isComplete_image_iff (since := "2026-01-01")]
+theorem isComplete_image_iff [IsometryClass 𝓕 E E₂] (f : 𝓕) {s : Set E} :
     IsComplete (f '' s) ↔ IsComplete s :=
-  _root_.isComplete_image_iff (SemilinearIsometryClass.isometry f).isUniformInducing
+  IsometryClass.isComplete_image_iff f
 
-@[deprecated LinearIsometry.isComplete_image_iff (since := "2025-12-25")]
+@[deprecated IsometryClass.isComplete_image_iff (since := "2025-12-25")]
 theorem isComplete_image_iff' (f : LinearIsometry σ₁₂ E E₂) {s : Set E} :
     IsComplete (f '' s) ↔ IsComplete s :=
-  LinearIsometry.isComplete_image_iff _
+  IsometryClass.isComplete_image_iff _
 
 theorem isComplete_map_iff [RingHomSurjective σ₁₂] {p : Submodule R E} :
     IsComplete (p.map f.toLinearMap : Set E₂) ↔ IsComplete (p : Set E) :=
-  isComplete_image_iff f
+  IsometryClass.isComplete_image_iff f
 
 @[deprecated (since := "2025-12-25")]
 alias isComplete_map_iff' := isComplete_map_iff
@@ -444,18 +421,22 @@ See also `LinearIsometryEquivClass F R E E₂` for the case where `σ` is the id
 A map `f` between an `R`-module and an `S`-module over a ring homomorphism `σ : R →+* S`
 is semilinear if it satisfies the two properties `f (x + y) = f x + f y` and
 `f (c • x) = (σ c) • f x`. -/
-class SemilinearIsometryEquivClass (𝓕 : Type*) {R R₂ : outParam Type*} [Semiring R]
+@[deprecated "Use `[SemilinearEquivClass F σ E E₂] [IsometryClass F E E₂]` instead."
+  (since := "2026-01-01")]
+structure SemilinearIsometryEquivClass (𝓕 : Type*) {R R₂ : outParam Type*} [Semiring R]
   [Semiring R₂] (σ₁₂ : outParam <| R →+* R₂) {σ₂₁ : outParam <| R₂ →+* R} [RingHomInvPair σ₁₂ σ₂₁]
   [RingHomInvPair σ₂₁ σ₁₂] (E E₂ : outParam Type*) [SeminormedAddCommGroup E]
   [SeminormedAddCommGroup E₂] [Module R E] [Module R₂ E₂] [EquivLike 𝓕 E E₂] : Prop
   extends SemilinearEquivClass 𝓕 σ₁₂ E E₂ where
   norm_map : ∀ (f : 𝓕) (x : E), ‖f x‖ = ‖x‖
 
+set_option linter.deprecated false in
 /-- `LinearIsometryEquivClass F R E E₂` asserts `F` is a type of bundled `R`-linear isometries
 `M → M₂`.
 
-This is an abbreviation for `SemilinearIsometryEquivClass F (RingHom.id R) E E₂`.
--/
+This is an abbreviation for `SemilinearIsometryEquivClass F (RingHom.id R) E E₂`. -/
+@[deprecated "Use `[LinearEquivClass F R E E₂] [IsometryClass F E E₂]` instead."
+  (since := "2026-01-01")]
 abbrev LinearIsometryEquivClass (𝓕 : Type*) (R E E₂ : outParam Type*) [Semiring R]
     [SeminormedAddCommGroup E] [SeminormedAddCommGroup E₂] [Module R E] [Module R E₂]
     [EquivLike 𝓕 E E₂] :=
@@ -464,11 +445,6 @@ abbrev LinearIsometryEquivClass (𝓕 : Type*) (R E E₂ : outParam Type*) [Semi
 namespace SemilinearIsometryEquivClass
 
 variable (𝓕)
-
--- `σ₂₁` becomes a metavariable, but it's OK since it's an outparam
-instance (priority := 100) toSemilinearIsometryClass [EquivLike 𝓕 E E₂]
-    [s : SemilinearIsometryEquivClass 𝓕 σ₁₂ E E₂] : SemilinearIsometryClass 𝓕 σ₁₂ E E₂ :=
-  { s with }
 
 end SemilinearIsometryEquivClass
 
@@ -496,11 +472,14 @@ instance instEquivLike : EquivLike (E ≃ₛₗᵢ[σ₁₂] E₂) E E₂ where
   left_inv e := e.left_inv
   right_inv e := e.right_inv
 
-instance instSemilinearIsometryEquivClass :
-    SemilinearIsometryEquivClass (E ≃ₛₗᵢ[σ₁₂] E₂) σ₁₂ E E₂ where
+instance instSemilinearEquivClass :
+    SemilinearEquivClass (E ≃ₛₗᵢ[σ₁₂] E₂) σ₁₂ E E₂ where
   map_add f := map_add f.toLinearEquiv
   map_smulₛₗ e := map_smulₛₗ e.toLinearEquiv
-  norm_map e := e.norm_map'
+
+instance instIsometryClass :
+    IsometryClass (E ≃ₛₗᵢ[σ₁₂] E₂) E E₂ where
+  isometry e := AddMonoidHomClass.isometry_of_norm e e.norm_map'
 
 /-- Shortcut instance, saving 8.5% of compilation time in
 `Mathlib/Analysis/InnerProductSpace/Adjoint.lean`.
@@ -537,7 +516,6 @@ def ofBounds (e : E ≃ₛₗ[σ₁₂] E₂) (h₁ : ∀ x, ‖e x‖ ≤ ‖x�
     E ≃ₛₗᵢ[σ₁₂] E₂ :=
   ⟨e, fun x => le_antisymm (h₁ x) <| by simpa only [e.symm_apply_apply] using h₂ (e x)⟩
 
-@[simp]
 theorem norm_map (x : E) : ‖e x‖ = ‖x‖ :=
   e.norm_map' x
 
@@ -867,7 +845,7 @@ theorem map_smul [Module R E₂] {e : E ≃ₗᵢ[R] E₂} (c : R) (x : E) : e (
 
 @[simp] -- Should be replaced with `SemilinearIsometryClass.nnorm_map` when https://github.com/leanprover/lean4/issues/3107 is fixed.
 theorem nnnorm_map (x : E) : ‖e x‖₊ = ‖x‖₊ :=
-  SemilinearIsometryClass.nnnorm_map e x
+  _root_.nnnorm_map e x
 
 @[simp]
 theorem dist_map (x y : E) : dist (e x) (e y) = dist x y :=

--- a/Mathlib/Analysis/Normed/Operator/LinearIsometry.lean
+++ b/Mathlib/Analysis/Normed/Operator/LinearIsometry.lean
@@ -206,9 +206,9 @@ instance completeSpace_map [RingHomSurjective σ₁₂] (p : Submodule R E) [Com
     CompleteSpace (p.map (f : E →ₛₗ[σ₁₂] E₂)) :=
   ((isComplete_map_iff f).2 <| completeSpace_coe_iff_isComplete.1 ‹_›).completeSpace_coe
 
-theorem dist_map (x y : E) : dist (f x) (f y) = dist x y := _root_.dist_map f x y
+theorem dist_map (x y : E) : dist (f x) (f y) = dist x y := IsometryClass.dist_map f x y
 
-theorem edist_map (x y : E) : edist (f x) (f y) = edist x y := _root_.edist_map f x y
+theorem edist_map (x y : E) : edist (f x) (f y) = edist x y := IsometryClass.edist_map f x y
 
 protected theorem injective : Injective f₁ :=
   Isometry.injective (LinearIsometry.isometry f₁)

--- a/Mathlib/Topology/Algebra/Module/CharacterSpace.lean
+++ b/Mathlib/Topology/Algebra/Module/CharacterSpace.lean
@@ -60,10 +60,13 @@ instance instFunLike : FunLike (characterSpace 𝕜 A) A 𝕜 where
   coe φ := ((φ : WeakDual 𝕜 A) : A → 𝕜)
   coe_injective' φ ψ h := by ext1; apply DFunLike.ext; exact congr_fun h
 
-/-- Elements of the character space are continuous linear maps. -/
-instance instContinuousLinearMapClass : ContinuousLinearMapClass (characterSpace 𝕜 A) 𝕜 A 𝕜 where
+/-- Elements of the character space are linear maps. -/
+instance instLinearMapClass : LinearMapClass (characterSpace 𝕜 A) 𝕜 A 𝕜 where
   map_smulₛₗ φ := (φ : WeakDual 𝕜 A).map_smul
   map_add φ := (φ : WeakDual 𝕜 A).map_add
+
+/-- Elements of the character space are continuous maps. -/
+instance instContinuousMapClass : ContinuousMapClass (characterSpace 𝕜 A) A 𝕜 where
   map_continuous φ := (φ : WeakDual 𝕜 A).cont
 
 /-- This has to come after `WeakDual.CharacterSpace.instFunLike`, otherwise the right-hand side
@@ -86,7 +89,7 @@ theorem coe_toCLM (φ : characterSpace 𝕜 A) : ⇑(toCLM φ) = φ :=
 
 /-- Elements of the character space are non-unital algebra homomorphisms. -/
 instance instNonUnitalAlgHomClass : NonUnitalAlgHomClass (characterSpace 𝕜 A) 𝕜 A 𝕜 :=
-  { CharacterSpace.instContinuousLinearMapClass with
+  { CharacterSpace.instLinearMapClass with
     map_smulₛₗ := fun φ => map_smul φ
     map_zero := fun φ => map_zero φ
     map_mul := fun φ => φ.prop.2 }

--- a/Mathlib/Topology/Algebra/Module/Equiv.lean
+++ b/Mathlib/Topology/Algebra/Module/Equiv.lean
@@ -50,7 +50,9 @@ notation:50 M " ≃L[" R "] " M₂ => ContinuousLinearEquiv (RingHom.id R) M M�
 where `σ` is the identity map on `R`.  A map `f` between an `R`-module and an `S`-module over a ring
 homomorphism `σ : R →+* S` is semilinear if it satisfies the two properties `f (x + y) = f x + f y`
 and `f (c • x) = (σ c) • f x`. -/
-class ContinuousSemilinearEquivClass (F : Type*) {R : outParam Type*} {S : outParam Type*}
+@[deprecated "Use `[SemilinearEquivClass F σ M M₂] [HomeomorphClass F M M₂]` instead."
+  (since := "2026-01-01")]
+structure ContinuousSemilinearEquivClass (F : Type*) {R : outParam Type*} {S : outParam Type*}
     [Semiring R] [Semiring S] (σ : outParam <| R →+* S) {σ' : outParam <| S →+* R}
     [RingHomInvPair σ σ'] [RingHomInvPair σ' σ] (M : outParam Type*) [TopologicalSpace M]
     [AddCommMonoid M] (M₂ : outParam Type*) [TopologicalSpace M₂] [AddCommMonoid M₂] [Module R M]
@@ -62,9 +64,12 @@ attribute [inherit_doc ContinuousSemilinearEquivClass]
 ContinuousSemilinearEquivClass.map_continuous
 ContinuousSemilinearEquivClass.inv_continuous
 
+set_option linter.deprecated false in
 /-- `ContinuousLinearEquivClass F σ M M₂` asserts `F` is a type of bundled continuous
 `R`-linear equivs `M → M₂`. This is an abbreviation for
 `ContinuousSemilinearEquivClass F (RingHom.id R) M M₂`. -/
+@[deprecated "Use `[LinearEquivClass F R M M₂] [HomeomorphClass F M M₂]` instead."
+  (since := "2026-01-01")]
 abbrev ContinuousLinearEquivClass (F : Type*) (R : outParam Type*) [Semiring R]
     (M : outParam Type*) [TopologicalSpace M] [AddCommMonoid M] (M₂ : outParam Type*)
     [TopologicalSpace M₂] [AddCommMonoid M₂] [Module R M] [Module R M₂] [EquivLike F M M₂] :=
@@ -77,15 +82,6 @@ variable (F : Type*) {R : Type*} {S : Type*} [Semiring R] [Semiring S] (σ : R �
   (M : Type*) [TopologicalSpace M] [AddCommMonoid M]
   (M₂ : Type*) [TopologicalSpace M₂] [AddCommMonoid M₂]
   [Module R M] [Module S M₂]
-
--- `σ'` becomes a metavariable, but it's OK since it's an outparam
-instance (priority := 100) continuousSemilinearMapClass [EquivLike F M M₂]
-    [s : ContinuousSemilinearEquivClass F σ M M₂] : ContinuousSemilinearMapClass F σ M M₂ :=
-  { s with }
-
-instance (priority := 100) [EquivLike F M M₂]
-    [s : ContinuousSemilinearEquivClass F σ M M₂] : HomeomorphClass F M M₂ :=
-  { s with }
 
 end ContinuousSemilinearEquivClass
 
@@ -155,10 +151,13 @@ instance equivLike :
   left_inv f := f.left_inv
   right_inv f := f.right_inv
 
-instance continuousSemilinearEquivClass :
-    ContinuousSemilinearEquivClass (M₁ ≃SL[σ₁₂] M₂) σ₁₂ M₁ M₂ where
+instance semilinearEquivClass :
+    SemilinearEquivClass (M₁ ≃SL[σ₁₂] M₂) σ₁₂ M₁ M₂ where
   map_add f := f.map_add'
   map_smulₛₗ f := f.map_smul'
+
+instance homeomorphClass :
+    HomeomorphClass (M₁ ≃SL[σ₁₂] M₂) M₁ M₂ where
   map_continuous := continuous_toFun
   inv_continuous := continuous_invFun
 

--- a/Mathlib/Topology/Algebra/Module/FiniteDimension.lean
+++ b/Mathlib/Topology/Algebra/Module/FiniteDimension.lean
@@ -275,9 +275,9 @@ theorem LinearMap.continuous_of_finiteDimensional [T2Space E] [FiniteDimensional
     (f : E →ₗ[𝕜] F') : Continuous f :=
   IsModuleTopology.continuous_of_linearMap f
 
-instance LinearMap.continuousLinearMapClassOfFiniteDimensional [T2Space E] [FiniteDimensional 𝕜 E] :
-    ContinuousLinearMapClass (E →ₗ[𝕜] F') 𝕜 E F' :=
-  { LinearMap.semilinearMapClass with map_continuous := fun f => f.continuous_of_finiteDimensional }
+instance LinearMap.continuousMapClassOfFiniteDimensional [T2Space E] [FiniteDimensional 𝕜 E] :
+    ContinuousMapClass (E →ₗ[𝕜] F') E F' where
+  map_continuous := continuous_of_finiteDimensional
 
 /-- In finite dimensions over a non-discrete complete normed field, the canonical identification
 (in terms of a basis) with `𝕜^n` (endowed with the product topology) is continuous.

--- a/Mathlib/Topology/Algebra/Module/LinearMap.lean
+++ b/Mathlib/Topology/Algebra/Module/LinearMap.lean
@@ -51,15 +51,20 @@ notation:25 M " →L[" R "] " M₂ => ContinuousLinearMap (RingHom.id R) M M₂
 `σ` is the identity map on `R`.  A map `f` between an `R`-module and an `S`-module over a ring
 homomorphism `σ : R →+* S` is semilinear if it satisfies the two properties `f (x + y) = f x + f y`
 and `f (c • x) = (σ c) • f x`. -/
-class ContinuousSemilinearMapClass (F : Type*) {R S : outParam Type*} [Semiring R] [Semiring S]
+@[deprecated "Use `[SemilinearMapClass F σ M M₂] [ContinuousMapClass F M M₂]` instead."
+  (since := "2026-01-01")]
+structure ContinuousSemilinearMapClass (F : Type*) {R S : outParam Type*} [Semiring R] [Semiring S]
     (σ : outParam <| R →+* S) (M : outParam Type*) [TopologicalSpace M] [AddCommMonoid M]
     (M₂ : outParam Type*) [TopologicalSpace M₂] [AddCommMonoid M₂] [Module R M]
     [Module S M₂] [FunLike F M M₂] : Prop
     extends SemilinearMapClass F σ M M₂, ContinuousMapClass F M M₂
 
+set_option linter.deprecated false in
 /-- `ContinuousLinearMapClass F R M M₂` asserts `F` is a type of bundled continuous
 `R`-linear maps `M → M₂`.  This is an abbreviation for
 `ContinuousSemilinearMapClass F (RingHom.id R) M M₂`. -/
+@[deprecated "Use `[LinearMapClass F R M M₂] [ContinuousMapClass F M M₂]` instead."
+  (since := "2026-01-01")]
 abbrev ContinuousLinearMapClass (F : Type*) (R : outParam Type*) [Semiring R]
     (M : outParam Type*) [TopologicalSpace M] [AddCommMonoid M] (M₂ : outParam Type*)
     [TopologicalSpace M₂] [AddCommMonoid M₂] [Module R M] [Module R M₂] [FunLike F M M₂] :=
@@ -100,11 +105,14 @@ instance funLike : FunLike (M₁ →SL[σ₁₂] M₂) M₁ M₂ where
   coe f := f.toLinearMap
   coe_injective' _ _ h := coe_injective (DFunLike.coe_injective h)
 
-instance continuousSemilinearMapClass :
-    ContinuousSemilinearMapClass (M₁ →SL[σ₁₂] M₂) σ₁₂ M₁ M₂ where
+instance semilinearMapClass :
+    SemilinearMapClass (M₁ →SL[σ₁₂] M₂) σ₁₂ M₁ M₂ where
   map_add f := map_add f.toLinearMap
-  map_continuous f := f.2
   map_smulₛₗ f := f.toLinearMap.map_smul'
+
+instance continuousMapClass :
+    ContinuousMapClass (M₁ →SL[σ₁₂] M₂) M₁ M₂ where
+  map_continuous f := f.2
 
 theorem coe_mk (f : M₁ →ₛₗ[σ₁₂] M₂) (h) : (mk f h : M₁ →ₛₗ[σ₁₂] M₂) = f :=
   rfl

--- a/Mathlib/Topology/Algebra/Module/StrongTopology.lean
+++ b/Mathlib/Topology/Algebra/Module/StrongTopology.lean
@@ -94,9 +94,13 @@ theorem ext [TopologicalSpace F] {𝔖 : Set (Set E)} {f g : UniformConvergenceC
     (h : ∀ x, f x = g x) : f = g :=
   DFunLike.ext f g h
 
-instance instContinuousSemilinearMapClass [TopologicalSpace F] (𝔖 : Set (Set E)) :
-    ContinuousSemilinearMapClass (UniformConvergenceCLM σ F 𝔖) σ E F :=
-  ContinuousLinearMap.continuousSemilinearMapClass
+instance instSemilinearMapClass [TopologicalSpace F] (𝔖 : Set (Set E)) :
+    SemilinearMapClass (UniformConvergenceCLM σ F 𝔖) σ E F :=
+  ContinuousLinearMap.semilinearMapClass
+
+instance instContinuousMapClass [TopologicalSpace F] (𝔖 : Set (Set E)) :
+    ContinuousMapClass (UniformConvergenceCLM σ F 𝔖) E F :=
+  ContinuousLinearMap.continuousMapClass
 
 instance instTopologicalSpace [TopologicalSpace F] [IsTopologicalAddGroup F] (𝔖 : Set (Set E)) :
     TopologicalSpace (UniformConvergenceCLM σ F 𝔖) :=

--- a/Mathlib/Topology/Algebra/Module/WeakDual.lean
+++ b/Mathlib/Topology/Algebra/Module/WeakDual.lean
@@ -62,7 +62,7 @@ def WeakDual (𝕜 E : Type*) [CommSemiring 𝕜] [TopologicalSpace 𝕜] [Conti
     [ContinuousConstSMul 𝕜 𝕜] [AddCommMonoid E] [Module 𝕜 E] [TopologicalSpace E] :=
   WeakBilin (topDualPairing 𝕜 E)
 deriving AddCommMonoid, Module 𝕜, TopologicalSpace, ContinuousAdd, Inhabited,
-  FunLike, ContinuousLinearMapClass
+  FunLike, LinearMapClass, ContinuousMapClass
 
 namespace WeakDual
 

--- a/Mathlib/Topology/MetricSpace/DilationEquiv.lean
+++ b/Mathlib/Topology/MetricSpace/DilationEquiv.lean
@@ -184,7 +184,7 @@ theorem coe_pow (e : X ≃ᵈ X) (n : ℕ) : ⇑(e ^ n) = e^[n] := by
 -- of `DilationEquivClass` assuming `IsometryEquivClass`.
 /-- Every isometry equivalence is a dilation equivalence of ratio `1`. -/
 def _root_.IsometryEquiv.toDilationEquiv (e : X ≃ᵢ Y) : X ≃ᵈ Y where
-  edist_eq' := ⟨1, one_ne_zero, by simpa using e.isometry⟩
+  edist_eq' := ⟨1, one_ne_zero, by simp⟩
   __ := e.toEquiv
 
 @[simp]

--- a/Mathlib/Topology/MetricSpace/Isometry.lean
+++ b/Mathlib/Topology/MetricSpace/Isometry.lean
@@ -293,7 +293,7 @@ section
 variable [FunLike F α β] [IsometryClass F α β] (f : F)
 
 @[simp]
-theorem _root_.edist_map (x y : α) : edist (f x) (f y) = edist x y :=
+theorem edist_map (x y : α) : edist (f x) (f y) = edist x y :=
   (IsometryClass.isometry f).edist_eq x y
 
 @[deprecated (since := "2026-01-01")] protected alias edist_eq := edist_map
@@ -328,11 +328,11 @@ section PseudoMetricSpace
 variable [PseudoMetricSpace α] [PseudoMetricSpace β] [FunLike F α β] [IsometryClass F α β] (f : F)
 
 @[simp]
-theorem _root_.dist_map (x y : α) : dist (f x) (f y) = dist x y :=
+theorem dist_map (x y : α) : dist (f x) (f y) = dist x y :=
   (IsometryClass.isometry f).dist_eq x y
 
 @[simp]
-theorem _root_.nndist_map (x y : α) : nndist (f x) (f y) = nndist x y :=
+theorem nndist_map (x y : α) : nndist (f x) (f y) = nndist x y :=
   (IsometryClass.isometry f).nndist_eq x y
 
 @[deprecated (since := "2026-01-01")] protected alias dist_eq := dist_map

--- a/Mathlib/Topology/MetricSpace/Isometry.lean
+++ b/Mathlib/Topology/MetricSpace/Isometry.lean
@@ -292,8 +292,11 @@ variable [PseudoEMetricSpace α] [PseudoEMetricSpace β]
 section
 variable [FunLike F α β] [IsometryClass F α β] (f : F)
 
-protected theorem edist_eq (x y : α) : edist (f x) (f y) = edist x y :=
+@[simp]
+theorem _root_.edist_map (x y : α) : edist (f x) (f y) = edist x y :=
   (IsometryClass.isometry f).edist_eq x y
+
+@[deprecated (since := "2026-01-01")] protected alias edist_eq := edist_map
 
 protected theorem continuous : Continuous f :=
   (IsometryClass.isometry f).continuous
@@ -324,11 +327,16 @@ end PseudoEMetricSpace
 section PseudoMetricSpace
 variable [PseudoMetricSpace α] [PseudoMetricSpace β] [FunLike F α β] [IsometryClass F α β] (f : F)
 
-protected theorem dist_eq (x y : α) : dist (f x) (f y) = dist x y :=
+@[simp]
+theorem _root_.dist_map (x y : α) : dist (f x) (f y) = dist x y :=
   (IsometryClass.isometry f).dist_eq x y
 
-protected theorem nndist_eq (x y : α) : nndist (f x) (f y) = nndist x y :=
+@[simp]
+theorem _root_.nndist_map (x y : α) : nndist (f x) (f y) = nndist x y :=
   (IsometryClass.isometry f).nndist_eq x y
+
+@[deprecated (since := "2026-01-01")] protected alias dist_eq := dist_map
+@[deprecated (since := "2026-01-01")] protected alias nndist_eq := nndist_map
 
 theorem diam_image (s : Set α) : Metric.diam (f '' s) = Metric.diam s :=
   (IsometryClass.isometry f).diam_image s


### PR DESCRIPTION
---

- [ ] depends on: #33448
- [ ] depends on: #33454

This PR continues the work from #18755.

Original PR: https://github.com/leanprover-community/mathlib4/pull/18755