### PR TITLE
feat: teach `fun_prop` about `ContinousMultilinearMap.compContinuousLinearMap`

### DIFF
--- a/Mathlib/Analysis/Normed/Module/Multilinear/Basic.lean
+++ b/Mathlib/Analysis/Normed/Module/Multilinear/Basic.lean
@@ -1143,6 +1143,22 @@ theorem compContinuousLinearMapLRight_apply (g : ContinuousMultilinearMap 𝕜 E
     (f : ∀ i, E i →L[𝕜] E₁ i) : compContinuousLinearMapLRight g f = g.compContinuousLinearMap f :=
   rfl
 
+@[fun_prop]
+theorem _root_.ContinuousOn.const_compContinuousLinearMap [TopologicalSpace α]
+    {g : ContinuousMultilinearMap 𝕜 E₁ G} {f : α → ∀ i, E i →L[𝕜] E₁ i}
+    {s} (hf : ContinuousOn f s) :
+    ContinuousOn (fun x => g.compContinuousLinearMap (f x)) s := by
+  simp_rw [← compContinuousLinearMapLRight_apply]
+  fun_prop
+
+@[fun_prop]
+theorem _root_.Continuous.const_compContinuousLinearMap [TopologicalSpace α]
+    {g : ContinuousMultilinearMap 𝕜 E₁ G} {f : α → ∀ i, E i →L[𝕜] E₁ i}
+    (hf : Continuous f) :
+    Continuous (fun x => g.compContinuousLinearMap (f x)) := by
+  simp_rw [← compContinuousLinearMapLRight_apply]
+  fun_prop
+
 variable (E) in
 theorem norm_compContinuousLinearMapLRight_le (g : ContinuousMultilinearMap 𝕜 E₁ G) :
     ‖compContinuousLinearMapLRight (E := E) g‖ ≤ ‖g‖ :=
@@ -1184,6 +1200,36 @@ noncomputable def compContinuousLinearMapContinuousMultilinear :
     (compContinuousLinearMapMultilinear 𝕜 E E₁ G) 1 fun f ↦ by
       rw [one_mul]
       apply norm_compContinuousLinearMapL_le
+
+@[fun_prop]
+theorem _root_.ContinuousOn.compContinuousLinearMap_const [TopologicalSpace α]
+    {g : α → ContinuousMultilinearMap 𝕜 E₁ G} {f : ∀ i, E i →L[𝕜] E₁ i}
+    {s} (hg : ContinuousOn g s) :
+    ContinuousOn (fun x => (g x).compContinuousLinearMap f) s := by
+  simp_rw [← compContinuousLinearMapContinuousMultilinear_apply_apply]
+  fun_prop
+
+@[fun_prop]
+theorem _root_.Continuous.compContinuousLinearMap_const [TopologicalSpace α]
+    {g : α → ContinuousMultilinearMap 𝕜 E₁ G} {f : ∀ i, E i →L[𝕜] E₁ i}
+    (hg : Continuous g) :
+    Continuous (fun x => (g x).compContinuousLinearMap f) := by
+  simp_rw [← compContinuousLinearMapContinuousMultilinear_apply_apply]
+  fun_prop
+
+omit [Fintype ι] in
+-- probably needs `ContinuousMultilinearMap.uncurrySum_apply` from later files
+proof_wanted _root_.ContinuousOn.compContinuousLinearMap [TopologicalSpace α]
+    {g : α → ContinuousMultilinearMap 𝕜 E₁ G} {f : α → ∀ i, E i →L[𝕜] E₁ i}
+    {s} (hg : ContinuousOn g s) (hf : ContinuousOn f s) :
+    ContinuousOn (fun x => (g x).compContinuousLinearMap (f x)) s
+
+omit [Fintype ι] in
+-- probably needs `ContinuousMultilinearMap.uncurrySum_apply` from later files
+proof_wanted _root_.Continuous.compContinuousLinearMap [TopologicalSpace α]
+    {g : α → ContinuousMultilinearMap 𝕜 E₁ G} {f : α → ∀ i, E i →L[𝕜] E₁ i}
+    (hg : Continuous g) (hf : Continuous f) :
+    Continuous (fun x => (g x).compContinuousLinearMap (f x))
 
 variable {𝕜 E E₁ G}
 


### PR DESCRIPTION
For now I've omitted the curried version


---
<!-- Your PR title will become the first line of the commit message.

In this box, the text above the `---` (if not empty) will be appended
to the commit message, and can be used to give additional context or
details. Please leave a blank newline before the `---`, otherwise GitHub
will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

When merging, all the commits will be squashed into a single commit
listing all co-authors.

Co-authors in the squash commit are gathered from two sources:

First, all authors of commits to this PR branch are included. Thus,
one way to add co-authors is to include at least one commit authored by
each co-author among the commits in the pull request. If necessary, you
may create empty commits to indicate co-authorship, using commands like so:

git commit --author="Author Name <author@email.com>" --allow-empty -m "add Author Name as coauthor"

Second, co-authors can also be listed in lines at the very bottom of
the commit message (that is, directly before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines
at the bottom of the commit message (before the `---`, and also before
any "Co-authored-by" lines) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
