### PR TITLE
feat(Analysis/ODE/Gronwall): Add two easy lemmas

### DIFF
--- a/Mathlib/Analysis/ODE/Gronwall.lean
+++ b/Mathlib/Analysis/ODE/Gronwall.lean
@@ -169,7 +169,7 @@ theorem eq_zero_of_abs_deriv_le_mul_abs_self_of_eq_zero_right {f f' : ℝ → E}
       norm_le_gronwallBound_of_norm_deriv_right_le hf hf' (by simp [ha]) (by simpa using bound) _ hx
     _ = 0 := by rw [gronwallBound_ε0_δ0]
 
-/-- Let `f : [a, b] → E` be a differentiable function such that `f a = 0`
+/-- Let `f : [a, b] → E` be a differentiable function such that `f b = 0`
 and `‖f'(x)‖ ≤ K ‖f(x)‖` for some constant `K`. Then `f = 0` on `[a, b]`. -/
 theorem eq_zero_of_abs_deriv_le_mul_abs_self_of_eq_zero_left {f f' : ℝ → E} {K a b : ℝ}
     (hf : ContinuousOn f (Icc a b)) (hf' : ∀ x ∈ Ioc a b, HasDerivWithinAt f (f' x) (Iic x) x)

--- a/Mathlib/Analysis/ODE/Gronwall.lean
+++ b/Mathlib/Analysis/ODE/Gronwall.lean
@@ -139,6 +139,23 @@ theorem norm_le_gronwallBound_of_norm_deriv_right_le {f f' : ℝ → E} {δ K ε
   le_gronwallBound_of_liminf_deriv_right_le (continuous_norm.comp_continuousOn hf)
     (fun x hx _r hr => (hf' x hx).liminf_right_slope_norm_le hr) ha bound
 
+theorem norm_le_gronwallBound_of_norm_deriv_left_le {f f' : ℝ → E} {δ K ε : ℝ} {a b : ℝ}
+    (hf : ContinuousOn f (Icc a b)) (hf' : ∀ x ∈ Ioc a b, HasDerivWithinAt f (f' x) (Iic x) x)
+    (ha : ‖f b‖ ≤ δ) (bound : ∀ x ∈ Ioc a b, ‖f' x‖ ≤ K * ‖f x‖ + ε) :
+    ∀ x ∈ Icc a b, ‖f x‖ ≤ gronwallBound δ K ε (b - x) := by
+  set F : ℝ → E := fun x => f (a + b - x) with F_def
+  set F' : ℝ → E := fun x => f' (a + b - x) with F'_def
+  have hF : ContinuousOn F (Icc a b) :=
+    hf.comp (continuous_sub_left (a + b)).continuousOn (by simp [Set.mapsTo_iff_image_subset])
+  have hF' (x : ℝ) (hx : x ∈ Ico a b) : HasDerivWithinAt F (- F' x) (Ici x) x := by
+    simpa using (hf' (a + b  - x) (by grind)).scomp x
+      ((hasDerivAt_id' x).const_sub _).hasDerivWithinAt (by simp [Set.mapsTo_iff_image_subset])
+  have bound (x : ℝ) (hx : x ∈ Ico a b) : ‖-F' x‖ ≤ K * ‖F x‖ + ε := by grind [norm_neg]
+  intro x hx
+  have ha : ‖F a‖ ≤ δ := by simpa [F_def, sub_zero]
+  have := norm_le_gronwallBound_of_norm_deriv_right_le hF hF' ha bound (a + b - x) (by grind)
+  grind
+
 /-- Let `f : [a, b] → E` be a differentiable function such that `f a = 0`
 and `‖f'(x)‖ ≤ K ‖f(x)‖` for some constant `K`. Then `f = 0` on `[a, b]`. -/
 theorem eq_zero_of_abs_deriv_le_mul_abs_self_of_eq_zero_right {f f' : ℝ → E} {K a b : ℝ}
@@ -151,6 +168,25 @@ theorem eq_zero_of_abs_deriv_le_mul_abs_self_of_eq_zero_right {f f' : ℝ → E}
     _ ≤ gronwallBound 0 K 0 (x - a) :=
       norm_le_gronwallBound_of_norm_deriv_right_le hf hf' (by simp [ha]) (by simpa using bound) _ hx
     _ = 0 := by rw [gronwallBound_ε0_δ0]
+
+/-- Let `f : [a, b] → E` be a differentiable function such that `f a = 0`
+and `‖f'(x)‖ ≤ K ‖f(x)‖` for some constant `K`. Then `f = 0` on `[a, b]`. -/
+theorem eq_zero_of_abs_deriv_le_mul_abs_self_of_eq_zero_left {f f' : ℝ → E} {K a b : ℝ}
+    (hf : ContinuousOn f (Icc a b)) (hf' : ∀ x ∈ Ioc a b, HasDerivWithinAt f (f' x) (Iic x) x)
+    (hb : f b = 0) (bound : ∀ x ∈ Ioc a b, ‖f' x‖ ≤ K * ‖f x‖) :
+    ∀ x ∈ Set.Icc a b, f x = 0 := by
+  set g := f ∘ (fun x ↦ a + b - x) with g_def
+  set g' := f' ∘ (fun x ↦ a + b - x) with g'_def
+  have hg : ContinuousOn g (Icc a b) :=
+    hf.comp (continuous_sub_left (a + b)).continuousOn (by simp [mapsTo_iff_image_subset])
+  have hg' (x : ℝ) (hx : x ∈ Ico a b) : HasDerivWithinAt g ((-g') x) (Ici x) x := by
+    simpa using (hf' (a + b - x) (by grind)).scomp x
+      ((hasDerivAt_id' x).const_sub _).hasDerivWithinAt (by simp [mapsTo_iff_image_subset])
+  have ha : g a = 0 := by simp [g_def, hb]
+  have bound (x : ℝ) (hx : x ∈ Ico a b) : ‖(-g') x‖ ≤ K * ‖g x‖ := by grind [Pi.neg_apply, norm_neg]
+  intro x hx
+  simpa [g_def] using
+    eq_zero_of_abs_deriv_le_mul_abs_self_of_eq_zero_right hg hg' ha bound (a + b - x) (by grind)
 
 variable {v : ℝ → E → E} {s : ℝ → Set E} {K : ℝ≥0} {f g f' g' : ℝ → E} {a b t₀ : ℝ} {εf εg δ : ℝ}
 


### PR DESCRIPTION
This PR adds two easy lemmas. These are the "left" version of already existing lemmas in the file.


---
<!-- Your PR title will become the first line of the commit message.

In this box, the text above the `---` (if not empty) will be appended
to the commit message, and can be used to give additional context or
details. Please leave a blank newline before the `---`, otherwise GitHub
will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

When merging, all the commits will be squashed into a single commit
listing all co-authors.

Co-authors in the squash commit are gathered from two sources:

First, all authors of commits to this PR branch are included. Thus,
one way to add co-authors is to include at least one commit authored by
each co-author among the commits in the pull request. If necessary, you
may create empty commits to indicate co-authorship, using commands like so:

git commit --author="Author Name <author@email.com>" --allow-empty -m "add Author Name as coauthor"

Second, co-authors can also be listed in lines at the very bottom of
the commit message (that is, directly before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines
at the bottom of the commit message (before the `---`, and also before
any "Co-authored-by" lines) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
