### PR TITLE
[Merged by Bors] - feat(RingTheory): polynomial is integral <-> coeffs are integral

### DIFF
--- a/Mathlib/Algebra/MvPolynomial/Equiv.lean
+++ b/Mathlib/Algebra/MvPolynomial/Equiv.lean
@@ -355,12 +355,15 @@ def optionEquivLeft : MvPolynomial (Option S₁) R ≃ₐ[R] Polynomial (MvPolyn
     (Polynomial.aevalTower (MvPolynomial.rename some) (X none))
     (by ext : 2 <;> simp) (by ext i : 2; cases i <;> simp)
 
+@[simp]
 lemma optionEquivLeft_X_some (x : S₁) : optionEquivLeft R S₁ (X (some x)) = Polynomial.C (X x) := by
   simp [optionEquivLeft_apply, aeval_X]
 
+@[simp]
 lemma optionEquivLeft_X_none : optionEquivLeft R S₁ (X none) = Polynomial.X := by
   simp [optionEquivLeft_apply, aeval_X]
 
+@[simp]
 lemma optionEquivLeft_C (r : R) : optionEquivLeft R S₁ (C r) = Polynomial.C (C r) := by
   simp only [optionEquivLeft_apply, aeval_C, Polynomial.algebraMap_apply, algebraMap_eq]
 
@@ -378,6 +381,14 @@ theorem optionEquivLeft_monomial (m : Option S₁ →₀ ℕ) (r : R) :
 lemma optionEquivLeft_symm_C_X (x : S₁) :
     (optionEquivLeft R S₁).symm (.C (X x)) = .X (.some x) := by
   simp [optionEquivLeft]
+
+@[simp]
+lemma optionEquivLeft_symm_C_C (x : R) :
+    (optionEquivLeft R S₁).symm (.C (.C x)) = .C x := by simp [optionEquivLeft]
+
+@[simp]
+lemma optionEquivLeft_symm_X :
+    (optionEquivLeft R S₁).symm .X = .X .none := by simp [optionEquivLeft]
 
 /-- The coefficient of `n.some` in the `n none`-th coefficient of `optionEquivLeft R S₁ f`
 equals the coefficient of `n` in `f` -/

--- a/Mathlib/Algebra/MvPolynomial/Rename.lean
+++ b/Mathlib/Algebra/MvPolynomial/Rename.lean
@@ -150,6 +150,14 @@ theorem killCompl_comp_rename : (killCompl hf).comp (rename f) = AlgHom.id R _ :
 theorem killCompl_rename_app (p : MvPolynomial σ R) : killCompl hf (rename f p) = p :=
   AlgHom.congr_fun (killCompl_comp_rename hf) p
 
+lemma killCompl_map (φ : R →+* S) (p : MvPolynomial τ R) :
+    (p.map φ).killCompl hf = (p.killCompl hf).map φ := by
+  simp only [← AlgHom.coe_toRingHom, ← RingHom.comp_apply]
+  congr
+  ext i n
+  · simp
+  · by_cases h : i ∈ Set.range f <;> simp [killCompl, h]
+
 end
 
 section

--- a/Mathlib/Algebra/Polynomial/Div.lean
+++ b/Mathlib/Algebra/Polynomial/Div.lean
@@ -619,6 +619,9 @@ theorem sub_dvd_eval_sub (a b : R) (p : R[X]) : a - b ∣ p.eval a - p.eval b :=
       using (_root_.map_dvd (evalRingHom a)) this
   simp [dvd_iff_isRoot]
 
+lemma IsRoot.dvd_coeff_zero {p : R[X]} {x : R} (h : p.IsRoot x) : x ∣ p.coeff 0 := by
+  simpa [h.eq_zero, coeff_zero_eq_eval_zero] using sub_dvd_eval_sub 0 x p
+
 @[simp]
 theorem rootMultiplicity_eq_zero_iff {p : R[X]} {x : R} :
     rootMultiplicity x p = 0 ↔ IsRoot p x → p = 0 := by

--- a/Mathlib/RingTheory/IntegralClosure/IsIntegral/Basic.lean
+++ b/Mathlib/RingTheory/IntegralClosure/IsIntegral/Basic.lean
@@ -23,8 +23,8 @@ open Polynomial Submodule
 
 section Ring
 
-variable {R S A : Type*}
-variable [CommRing R] [Ring A] [Ring S] (f : R →+* S)
+variable {R S A T : Type*}
+variable [CommRing R] [Ring A] [Ring S] [Ring T] (f : R →+* S) (g : S →+* T)
 variable [Algebra R A]
 
 theorem RingHom.isIntegralElem_map {x : R} : f.IsIntegralElem (f x) :=
@@ -33,22 +33,44 @@ theorem RingHom.isIntegralElem_map {x : R} : f.IsIntegralElem (f x) :=
 theorem isIntegral_algebraMap {x : R} : IsIntegral R (algebraMap R A x) :=
   (algebraMap R A).isIntegralElem_map
 
+variable {f} in
+lemma RingHom.IsIntegralElem.map {x : S} (hx : f.IsIntegralElem x) (g : S →+* T) :
+    (g.comp f).IsIntegralElem (g x) := by
+  obtain ⟨p, hp, hx⟩ := hx
+  exact ⟨p, hp, by simp_rw [← hom_eval₂, eval₂_eq_eval_map] at hx ⊢; simp [hx]⟩
+
+variable {f g} in
+lemma RingHom.IsIntegralElem.of_map (hg : Function.Injective g) {x : S}
+    (hx : (g.comp f).IsIntegralElem (g x)) :
+    f.IsIntegralElem x := by
+  obtain ⟨p, hp, hx⟩ := hx
+  exact ⟨p, hp, hg <| by simp [Polynomial.hom_eval₂, hx]⟩
+
+variable {f g} in
+lemma RingHom.IsIntegralElem.map_iff (hg : Function.Injective g) {x : S} :
+    (g.comp f).IsIntegralElem (g x) ↔ f.IsIntegralElem x :=
+  ⟨of_map hg, (map · g)⟩
+
 end Ring
 
 section
 
-variable {R A B S : Type*}
-variable [CommRing R] [CommRing A] [Ring B] [CommRing S]
+variable {R A B S T : Type*}
+variable [CommRing R] [CommRing A] [Ring B] [CommRing S] [Ring T]
 variable [Algebra R A] (f : R →+* S)
+
+variable {f} in
+lemma RingHom.IsIntegralElem.of_comp {g : S →+* T} {x : T} (hx : (g.comp f).IsIntegralElem x) :
+    g.IsIntegralElem x := by
+  obtain ⟨p, hp, hx⟩ := hx
+  exact ⟨p.map f, hp.map _, by simpa only [eval₂_eq_eval_map, map_map] using hx⟩
 
 theorem IsIntegral.map {B C F : Type*} [Ring B] [Ring C] [Algebra R B] [Algebra A B] [Algebra R C]
     [IsScalarTower R A B] [Algebra A C] [IsScalarTower R A C] {b : B}
     [FunLike F B C] [AlgHomClass F A B C] (f : F)
     (hb : IsIntegral R b) : IsIntegral R (f b) := by
-  obtain ⟨P, hP⟩ := hb
-  refine ⟨P, hP.1, ?_⟩
-  rw [← aeval_def, ← aeval_map_algebraMap A,
-    aeval_algHom_apply, aeval_map_algebraMap, aeval_def, hP.2, map_zero]
+  rw [IsIntegral, ← ((AlgHomClass.toAlgHom f).restrictScalars R).comp_algebraMap]
+  exact .map hb (RingHomClass.toRingHom f)
 
 section
 
@@ -56,9 +78,7 @@ variable {A B : Type*} [Ring A] [Ring B] [Algebra R A] [Algebra R B]
 
 theorem isIntegral_algHom_iff (f : A →ₐ[R] B) (hf : Function.Injective f) {x : A} :
     IsIntegral R (f x) ↔ IsIntegral R x := by
-  refine ⟨fun ⟨p, hp, hx⟩ ↦ ⟨p, hp, ?_⟩, IsIntegral.map f⟩
-  rwa [← f.comp_algebraMap, ← AlgHom.coe_toRingHom, ← hom_eval₂, AlgHom.coe_toRingHom,
-    map_eq_zero_iff f hf] at hx
+  simp [IsIntegral, ← RingHom.IsIntegralElem.map_iff (g := (f : A →+* B)) hf]
 
 end
 

--- a/Mathlib/RingTheory/Polynomial/IsIntegral.lean
+++ b/Mathlib/RingTheory/Polynomial/IsIntegral.lean
@@ -6,7 +6,7 @@ Authors: Andrew Yang
 module
 
 public import Mathlib.Data.Multiset.Fintype
-public import Mathlib.FieldTheory.SplittingField.Construction
+public import Mathlib.RingTheory.AdjoinRoot
 public import Mathlib.RingTheory.Polynomial.RationalRoot
 public import Mathlib.RingTheory.IntegralClosure.IsIntegral.AlmostIntegral
 
@@ -17,8 +17,10 @@ public import Mathlib.RingTheory.IntegralClosure.IsIntegral.AlmostIntegral
 ## Main results
 - `Polynomial.isIntegral_coeff_of_dvd`: If a monic polynomial `p` divides another monic polynomial
   with integral coefficients, then the coefficients of `p` are themselves integral.
-- `IsIntegral.coeff_of_isFractionRing`: Let `R` be a domain with fraction ring `K`. If
-  `p : K[X]` is integral over `R[X]`, then the coefficients of `p` are integral over `R`.
+- `Polynomial.isIntegral_iff_isIntegral_coeff`:
+  `p : S[X]` is integral over `R[X]` iff the coefficients of `p` are integral over `R`.
+- `MvPolynomial.isIntegral_iff_isIntegral_coeff`: `p : MvPolynomial σ S` is integral over
+  `MvPolynomial σ R` iff the coefficients of `p` are integral over `R`.
 - We also provide the instance `[IsIntegrallyClosed R] : IsIntegrallyClosed R[X]`.
 
 -/
@@ -39,41 +41,35 @@ lemma isIntegral_coeff_prod
     rw [Finset.prod_insert has, coeff_mul]
     exact IsIntegral.sum _ fun i hi ↦ .mul (H _ (by simp) _) (IH (fun _ _ ↦ H _ (by aesop)) _)
 
-lemma isIntegral_coeff_of_factors [IsDomain S] (p : S[X])
+lemma isIntegral_coeff_of_factors (p : S[X])
     (hpmon : IsIntegral R p.leadingCoeff) (hp : p.Splits)
-    (hpr : ∀ x ∈ p.roots, IsIntegral R x) (i : ℕ) :
+    (hpr : ∀ x, p.IsRoot x → IsIntegral R x) (i : ℕ) :
     IsIntegral R (p.coeff i) := by
   classical
-  rw [hp.eq_prod_roots, Multiset.prod_eq_prod_coe, coeff_C_mul]
+  obtain ⟨m, hm⟩ := Polynomial.splits_iff_exists_multiset.mp hp
+  rw [hm, Multiset.prod_eq_prod_coe, coeff_C_mul]
   refine .mul hpmon (isIntegral_coeff_prod _ _ ?_ _)
+  have H {x} (hx : x ∈ m) : p.IsRoot x := by
+    rw [IsRoot, hm, eval_mul, eval_multiset_prod, Multiset.prod_eq_zero, mul_zero]
+    simpa [sub_eq_zero]
   rintro ⟨a, ⟨i, hi⟩⟩ -
   obtain ⟨x, hx, rfl⟩ := Multiset.mem_map.mp (Multiset.count_pos.mp (i.zero_le.trans_lt hi))
   simp [coeff_X, coeff_C, IsIntegral.sub, apply_ite (IsIntegral R),
-    isIntegral_one, isIntegral_zero, hpr x hx]
+    isIntegral_one, isIntegral_zero, hpr x (H hx)]
 
+open scoped TensorProduct in
 @[stacks 00H6 "(1)"]
-lemma isIntegral_coeff_of_dvd [IsDomain S] (p : R[X]) (q : S[X]) (hp : p.Monic)
-    (hq : IsIntegral R q.leadingCoeff)
+lemma isIntegral_coeff_of_dvd (p : R[X]) (q : S[X]) (hp : p.Monic) (hq : q.Monic)
     (H : q ∣ p.map (algebraMap R S)) (i : ℕ) : IsIntegral R (q.coeff i) := by
-  wlog hS : IsField S
-  · let L := FractionRing S
-    refine (isIntegral_algHom_iff (IsScalarTower.toAlgHom R S L)
-      (FaithfulSMul.algebraMap_injective _ _)).mp ?_
-    rw [IsScalarTower.coe_toAlgHom', ← coeff_map]
-    refine this p (q.map (algebraMap _ L)) hp ?_ ?_ _ (Field.toIsField L)
-    · rw [leadingCoeff_map_of_injective (FaithfulSMul.algebraMap_injective _ _)]
-      exact .algebraMap hq
-    · rw [IsScalarTower.algebraMap_eq R S, ← Polynomial.map_map]
-      exact Polynomial.map_dvd _ H
-  letI := hS.toField
-  let L := (p.map (algebraMap R S)).SplittingField
-  refine (isIntegral_algHom_iff (IsScalarTower.toAlgHom R S L) (algebraMap S L).injective).mp ?_
+  nontriviality S
+  obtain ⟨T, _, _, _, _, _, hqT⟩ := hq.exists_splits_map
+  algebraize [(algebraMap S T).comp (algebraMap R S)]
+  refine (isIntegral_algHom_iff (IsScalarTower.toAlgHom R S T)
+    (FaithfulSMul.algebraMap_injective S _)).mp ?_
   rw [IsScalarTower.coe_toAlgHom', ← coeff_map]
-  refine Polynomial.isIntegral_coeff_of_factors _ (by simpa using .algebraMap hq) ?_ ?_ i
-  · refine .of_dvd ?_ ((hp.map _).map _).ne_zero (Polynomial.map_dvd _ H)
-    exact SplittingField.splits (p.map (algebraMap R S))
-  · intro x hx
-    exact ⟨p, hp, by simpa using aeval_eq_zero_of_dvd_aeval_eq_zero (a := x) H (by simp_all)⟩
+  refine Polynomial.isIntegral_coeff_of_factors _ (by simp [hq.map, isIntegral_one]) hqT ?_ i
+  intro x hx
+  exact ⟨p, hp, by simpa using aeval_eq_zero_of_dvd_aeval_eq_zero (a := x) H (by simp_all)⟩
 
 end Polynomial
 
@@ -121,49 +117,63 @@ lemma IsAlmostIntegral.coeff [IsDomain R] [FaithfulSMul R S]
   simpa [hi, eraseLead_coeff_of_ne] using
     IH (p := p.eraseLead) _ (p.eraseLead_natDegree_le.trans_lt (by lia)) this rfl
 
-lemma IsIntegral.coeff_of_exists_smul_mem_lifts
-    [FaithfulSMul R S] [IsDomain S]
-    {p : S[X]} (hp : IsIntegral R[X] p) (hp' : ∃ r ∈ R⁰, r • p ∈ lifts (algebraMap R S)) (i : ℕ) :
-    IsIntegral R (p.coeff i) := by
-  classical
-  have := (FaithfulSMul.algebraMap_injective R S).isDomain
-  obtain ⟨r, hr, q, hq⟩ := hp'
-  let R' := Algebra.adjoin ℤ
-    (↑((minpoly R[X] p).coeffs.biUnion coeffs ∪ (insert r q.coeffs)) : Set R)
-  have : Algebra.FiniteType ℤ R' := ⟨(Subalgebra.fg_top _).mpr <| Subalgebra.fg_adjoin_finset _⟩
-  have := Algebra.FiniteType.isNoetherianRing ℤ R'
-  have : IsIntegral R'[X] p := by
-    suffices minpoly R[X] p ∈ lifts (mapRingHom (algebraMap R' R)) by
-      obtain ⟨q, hq, -, hq'⟩ := lifts_and_degree_eq_and_monic this (minpoly.monic hp)
-      refine ⟨q, hq', ?_⟩
-      simpa only [algebraMap_def, IsScalarTower.algebraMap_eq R' R S, ← mapRingHom_comp,
-        ← eval₂_map, hq] using minpoly.aeval R[X] p
-    refine (lifts_iff_coeff_lifts _).mpr fun n ↦ (lifts_iff_coeff_lifts _).mpr fun m ↦ ?_
-    simp only [Subalgebra.setRange_algebraMap, SetLike.mem_coe]
-    by_cases h : ((minpoly R[X] p).coeff n).coeff m = 0
-    · simp [h]
-    refine Algebra.subset_adjoin (Finset.mem_union_left _ ?_)
-    exact Finset.mem_biUnion.mpr ⟨_, coeff_mem_coeffs (by aesop), coeff_mem_coeffs h⟩
-  refine ((this.isAlmostIntegral_of_exists_smul_mem_range ?_).coeff i).isIntegral.tower_top
-  refine ⟨C ⟨r, Algebra.subset_adjoin (Finset.mem_union_right _ (by simp))⟩, ?_, ?_⟩
-  · simpa [← SetLike.coe_eq_coe] using hr
-  · simp only [algebraMap_def, IsScalarTower.algebraMap_eq R' R S, ← mapRingHom_comp,
-      ← RingHom.map_range]
-    refine ⟨q, (lifts_iff_coeff_lifts _).mpr fun n ↦ ?_, by simpa [Algebra.smul_def] using hq⟩
-    simp only [Subalgebra.setRange_algebraMap, SetLike.mem_coe]
-    by_cases h : q.coeff n = 0
-    · simp [h]
-    · exact Algebra.subset_adjoin (Finset.mem_union_right _ (by simp [coeff_mem_coeffs h]))
-
 @[stacks 00H0 "(2)"]
-lemma IsIntegral.coeff_of_isFractionRing
-    [IsFractionRing R S] [IsDomain R]
-    {p : S[X]} (hp : IsIntegral R[X] p) (i : ℕ) :
-    IsIntegral R (p.coeff i) := by
-  have := IsFractionRing.isDomain R (K := S)
-  refine hp.coeff_of_exists_smul_mem_lifts ?_ i
-  obtain ⟨r, hr⟩ := IsLocalization.integerNormalization_map_to_map R⁰ p
-  exact ⟨r, r.2, ⟨_, hr⟩⟩
+protected lemma IsIntegral.coeff
+    {p : S[X]} (hp : IsIntegral R[X] p) (i : ℕ) : IsIntegral R (p.coeff i) := by
+  nontriviality R
+  nontriviality S
+  obtain rfl | hp0 := eq_or_ne p 0; · simp [isIntegral_zero]
+  let q := minpoly R[X] p
+  let m := (q.support.sup fun i ↦ (q.coeff i).natDegree) + p.natDegree + 1
+  have hm₁ (i) : (q.coeff i).natDegree < m := by
+    by_cases hi : i ∈ q.support
+    · exact (Finset.le_sup (f := fun i ↦ (q.coeff i).natDegree) hi).trans_lt (by lia)
+    · simp_all [m]
+  have hm₁' : (q.eval (X ^ m)).Monic := by
+    rw [eval_eq_sum_range, Finset.sum_range_succ]
+    refine .add_of_right (by simp [q, minpoly.monic hp, ← pow_mul]) (degree_lt_degree ?_)
+    refine lt_of_lt_of_eq (b := m * q.natDegree) ?_ (by simp [q, minpoly.monic hp, ← pow_mul])
+    refine (natDegree_sum_le ..).trans_lt ((Finset.fold_max_lt _).mpr
+      ⟨by simpa using ⟨by lia, minpoly.natDegree_pos hp⟩, fun i hi ↦ ?_⟩)
+    dsimp
+    simp only [Finset.mem_range] at hi
+    grw [← pow_mul, natDegree_mul_le, natDegree_X_pow, ← Nat.add_one_le_iff.mpr hi]
+    have := hm₁ i
+    lia
+  have hm₂ : p.natDegree < m := by grind
+  have h₀ : algebraMap R[X] S[X] X = X := by simp
+  have : (((taylor (X ^ m)) q).map (algebraMap R[X] S[X])).IsRoot (p - X ^ m) := by
+    simpa [-algebraMap_def, q, h₀] using ((q.map (algebraMap _ _)).taylor_eval (X ^ m) (p - X ^ m):)
+  have : X ^ m - p ∣ (eval (X ^ m) q).map (algebraMap _ _) := by
+    change X ^ m - p ∣ Algebra.ofId R[X] S[X] _
+    rw [← coe_aeval_eq_eval, ← aeval_algHom_apply, ← neg_dvd, neg_sub]
+    simpa [Polynomial.taylor_coeff_zero, -algebraMap_def, h₀] using this.dvd_coeff_zero
+  have := (isIntegral_coeff_of_dvd _ _ hm₁'
+    ((monic_X_pow _).sub_of_left (by simpa [← natDegree_lt_iff_degree_lt, hp0])) this i).neg
+  obtain hi | hi := le_or_gt i p.natDegree
+  · simpa [show i ≠ m by lia] using this
+  · simp [coeff_eq_zero_of_natDegree_lt hi, isIntegral_zero]
+
+@[deprecated (since := "2026-01-01")]
+alias IsIntegral.coeff_of_exists_smul_mem_lifts := IsIntegral.coeff
+
+@[deprecated (since := "2026-01-01")] alias IsIntegral.coeff_of_isFractionRing := IsIntegral.coeff
+
+theorem Polynomial.isIntegral_iff_isIntegral_coeff {f : S[X]} :
+    IsIntegral R[X] f ↔ ∀ n, IsIntegral R (f.coeff n) := by
+  refine ⟨IsIntegral.coeff, fun H ↦ ?_⟩
+  rw [← f.sum_monomial_eq, Polynomial.sum]
+  simp only [← C_mul_X_pow_eq_monomial, ← map_X (algebraMap R S)]
+  exact .sum _ fun i _ ↦ ((H i).map (CAlgHom (R := R))).tower_top.mul (.pow isIntegral_algebraMap _)
+
+lemma IsIntegral.of_aeval_monic_of_isIntegral_coeff {R A : Type*} [CommRing R] [CommRing A]
+    [Algebra R A] {x : A} {p : A[X]} (monic : p.Monic) (deg : p.natDegree ≠ 0)
+    (hx : IsIntegral R (eval x p)) (hp : ∀ i, IsIntegral R (p.coeff i)) : IsIntegral R x := by
+  obtain ⟨q, hqp, hdeg, hq⟩ :=
+    lifts_and_natDegree_eq_and_monic (p := p) (f := algebraMap (integralClosure R A) _)
+    (p.lifts_iff_coeff_lifts.mpr (by simpa)) monic
+  exact isIntegral_trans _ (.of_aeval_monic hq (hdeg ▸ deg)
+    (by simpa [← eval_map_algebraMap, hqp] using hx.tower_top))
 
 @[stacks 030A]
 instance {R : Type*} [CommRing R] [IsDomain R] [IsIntegrallyClosed R] :
@@ -173,6 +183,67 @@ instance {R : Type*} [CommRing R] [IsDomain R] [IsIntegrallyClosed R] :
   suffices IsIntegrallyClosedIn R[X] K[X] from .of_isIntegrallyClosed_of_isIntegrallyClosedIn _ K[X]
   refine isIntegrallyClosedIn_iff.mpr ⟨map_injective _ (IsFractionRing.injective _ _), ?_⟩
   refine fun {p} hp ↦ (lifts_iff_coeff_lifts _).mpr fun n ↦ ?_
-  exact IsIntegrallyClosed.isIntegral_iff.mp (hp.coeff_of_isFractionRing _)
+  exact IsIntegrallyClosed.isIntegral_iff.mp (hp.coeff _)
+
+end
+
+attribute [local instance] MvPolynomial.algebraMvPolynomial in
+attribute [-simp] AlgEquiv.symm_toRingEquiv in
+theorem MvPolynomial.isIntegral_iff_isIntegral_coeff.{w} {σ : Type w} {f : MvPolynomial σ S} :
+    IsIntegral (MvPolynomial σ R) f ↔ ∀ n, IsIntegral R (f.coeff n) := by
+  classical
+  refine ⟨fun H n ↦ ?mp, fun H ↦ ?mpr⟩
+  case mpr =>
+    rw [← f.support_sum_monomial_coeff]
+    simp_rw [monomial_eq]
+    refine IsIntegral.sum _ fun n _ ↦ .mul ((H n).map (Algebra.ofId _ _)).tower_top
+      (.prod _ fun i _ ↦ .pow ?_ _)
+    convert isIntegral_algebraMap (x := MvPolynomial.X i)
+    simp only [algebraMap_def, map_X]
+  unfold IsIntegral at H
+  wlog hσ : Finite σ generalizing σ
+  · obtain ⟨g, hg⟩ := MvPolynomial.exists_rename_eq_of_vars_subset_range (τ := f.vars) f _
+      Subtype.val_injective (by simp)
+    by_cases hn : n ∈ Set.range (Finsupp.mapDomain ((↑) : f.vars → σ))
+    · obtain ⟨n, rfl⟩ := hn
+      simp_rw [← hg, coeff_rename_mapDomain _ Subtype.val_injective]
+      exact this (f := g) (RingHom.IsIntegralElem.of_map
+        (g := (rename ((↑) : f.vars → σ)).toRingHom) (rename_injective _ Subtype.val_injective)
+        (.of_comp (f := (killCompl (f := ((↑) : f.vars → σ)) Subtype.val_injective).toRingHom) <| by
+        simp only [AlgHom.toRingHom_eq_coe, algebraMap_def, RingHom.coe_coe, hg]
+        convert H.map ((rename Subtype.val).comp
+          (killCompl (f := ((↑) : f.vars → σ)) Subtype.val_injective)).toRingHom
+        · exact RingHom.ext (by simp [MvPolynomial.killCompl_map])
+        · nth_rw 1 11 [← hg]; simp)) n (.of_fintype _)
+    · rw [← hg, coeff_rename_eq_zero _ _ _ (by grind)]
+      exact isIntegral_zero
+  revert f n
+  apply Finite.induction_empty_option _ _ _ σ
+  · intro α β e IH f H n
+    have := @IH (rename e.symm f) (.of_map (g := (rename e).toRingHom)
+      (rename_injective _ e.injective) <| .of_comp (f := (rename e.symm).toRingHom)
+        (by convert H <;> aesop)) (n.embDomain e.symm)
+    simpa [Finsupp.embDomain_eq_mapDomain, coeff_rename_mapDomain _ e.symm.injective] using this
+  · intro f H n
+    refine .of_map (g := (isEmptyAlgEquiv _ PEmpty).symm.toRingHom)
+      (isEmptyAlgEquiv _ PEmpty).symm.injective
+      (.of_comp (f := (isEmptyAlgEquiv _ PEmpty).toRingHom) ?_)
+    convert H
+    · aesop (add simp MvPolynomial.isEmptyAlgEquiv)
+    · obtain rfl := Subsingleton.elim n 0
+      have : constantCoeff = (isEmptyAlgEquiv S PEmpty).toRingHom := by aesop
+      simpa [-EmbeddingLike.apply_eq_iff_eq, -isEmptyAlgEquiv_apply] using
+        congr((isEmptyAlgEquiv S PEmpty.{w + 1}).symm ($this f))
+  · intro α _ IH f H n
+    have := IH (IsIntegral.coeff (R := MvPolynomial α R)
+      (p := optionEquivLeft _ _ f) (.of_map
+      (g := (optionEquivLeft _ _).symm.toRingHom) (optionEquivLeft _ _).symm.injective
+      (.of_comp (f := (optionEquivLeft _ _).toRingHom) (by
+        convert H
+        · ext i m
+          · aesop
+          · cases i <;> aesop
+        · aesop))) (n .none)) n.some
+    rwa [optionEquivLeft_coeff_some_coeff_none] at this
 
 end

--- a/Mathlib/RingTheory/Polynomial/UniversalFactorizationRing.lean
+++ b/Mathlib/RingTheory/Polynomial/UniversalFactorizationRing.lean
@@ -345,8 +345,7 @@ lemma finite_universalFactorizationMap :
   have H₁ (i : _) : (universalFactorizationMap R n m k hn).IsIntegralElem (.X i ⊗ₜ 1) := by
     obtain ⟨p, hp, hp'⟩ : (universalFactorizationMap ℤ n m k hn).IsIntegralElem (.X i ⊗ₜ 1) := by
       simpa [coeff_freeMonic] using Polynomial.isIntegral_coeff_of_dvd _ _ (monic_freeMonic _ _)
-        (by simp [((monic_freeMonic _ _).map _).leadingCoeff, isIntegral_one])
-        ⟨_, universalFactorizationMap_freeMonic ℤ n m k hn⟩ i
+        ((monic_freeMonic _ _).map _) ⟨_, universalFactorizationMap_freeMonic ℤ n m k hn⟩ i
     refine ⟨p.map (MvPolynomial.map (algebraMap ℤ R)), hp.map _, ?_⟩
     apply_fun F.toRingHom at hp'
     rw [Polynomial.hom_eval₂, ← MvPolynomial.universalFactorizationMap_comp_map] at hp'
@@ -354,7 +353,7 @@ lemma finite_universalFactorizationMap :
   have H₂ (i : _) : (universalFactorizationMap R n m k hn).IsIntegralElem (1 ⊗ₜ .X i) := by
     obtain ⟨p, hp, hp'⟩ : (universalFactorizationMap ℤ n m k hn).IsIntegralElem (1 ⊗ₜ .X i) := by
       simpa [coeff_freeMonic] using Polynomial.isIntegral_coeff_of_dvd _ _ (monic_freeMonic _ _)
-        (by simp [((monic_freeMonic _ _).map _).leadingCoeff, isIntegral_one])
+        ((monic_freeMonic _ _).map _)
         ⟨_, (universalFactorizationMap_freeMonic ℤ n m k hn).trans (mul_comm _ _)⟩ i
     refine ⟨p.map (MvPolynomial.map (algebraMap ℤ R)), hp.map _, ?_⟩
     apply_fun F.toRingHom at hp'


### PR DESCRIPTION

---
<!-- Your PR title will become the first line of the commit message.

In this box, the text above the `---` (if not empty) will be appended
to the commit message, and can be used to give additional context or
details. Please leave a blank newline before the `---`, otherwise GitHub
will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

When merging, all the commits will be squashed into a single commit
listing all co-authors.

Co-authors in the squash commit are gathered from two sources:

First, all authors of commits to this PR branch are included. Thus,
one way to add co-authors is to include at least one commit authored by
each co-author among the commits in the pull request. If necessary, you
may create empty commits to indicate co-authorship, using commands like so:

git commit --author="Author Name <author@email.com>" --allow-empty -m "add Author Name as coauthor"

Second, co-authors can also be listed in lines at the very bottom of
the commit message (that is, directly before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines
at the bottom of the commit message (before the `---`, and also before
any "Co-authored-by" lines) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
