### PR TITLE
[Merged by Bors] - feat(RingTheory/Nilpotent/Exp): add isNilpotent_exp_sub_one

### DIFF
--- a/Mathlib/RingTheory/Nilpotent/Defs.lean
+++ b/Mathlib/RingTheory/Nilpotent/Defs.lean
@@ -23,6 +23,7 @@ and `Mathlib/RingTheory/Nilpotent/Lemmas.lean`.
   * `Commute.isNilpotent_mul_left`
   * `Commute.isNilpotent_mul_right`
   * `nilpotencyClass`
+  * `IsUnipotent`
 
 -/
 
@@ -255,3 +256,13 @@ theorem isNilpotent_mul_left (h_comm : Commute x y) (h : IsNilpotent y) : IsNilp
 end Semiring
 
 end Commute
+
+-- An element is said to be unipotent if one less than it is a nilpotent element.
+def IsUnipotent [Zero R] [Pow R ℕ] [One R] [Sub R] (r : R) := IsNilpotent (r - 1)
+
+theorem IsUnipotent.one [Ring R] : IsUnipotent (1 : R) := by
+  rw [IsUnipotent, sub_self]
+  exact IsNilpotent.zero
+
+lemma add_one_isUnipotent_iff_isNilpotent [Ring R] (r : R) :
+    IsUnipotent (r + 1) ↔ IsNilpotent r := by rw [IsUnipotent, add_sub_cancel_right]

--- a/Mathlib/RingTheory/Nilpotent/Defs.lean
+++ b/Mathlib/RingTheory/Nilpotent/Defs.lean
@@ -23,7 +23,6 @@ and `Mathlib/RingTheory/Nilpotent/Lemmas.lean`.
   * `Commute.isNilpotent_mul_left`
   * `Commute.isNilpotent_mul_right`
   * `nilpotencyClass`
-  * `IsUnipotent`
 
 -/
 
@@ -256,13 +255,3 @@ theorem isNilpotent_mul_left (h_comm : Commute x y) (h : IsNilpotent y) : IsNilp
 end Semiring
 
 end Commute
-
--- An element is said to be unipotent if one less than it is a nilpotent element.
-def IsUnipotent [Zero R] [Pow R ℕ] [One R] [Sub R] (r : R) := IsNilpotent (r - 1)
-
-theorem IsUnipotent.one [Ring R] : IsUnipotent (1 : R) := by
-  rw [IsUnipotent, sub_self]
-  exact IsNilpotent.zero
-
-lemma add_one_isUnipotent_iff_isNilpotent [Ring R] (r : R) :
-    IsUnipotent (r + 1) ↔ IsNilpotent r := by rw [IsUnipotent, add_sub_cancel_right]

--- a/Mathlib/RingTheory/Nilpotent/Exp.lean
+++ b/Mathlib/RingTheory/Nilpotent/Exp.lean
@@ -199,7 +199,7 @@ theorem exp_smul {G : Type*} [Monoid G] [MulSemiringAction G A]
     exp (g • a) = g • exp a :=
   (map_exp ha (MulSemiringAction.toRingHom G A g)).symm
 
-theorem isNilpotent_exp_sub_one {a : A} (ha : IsNilpotent a) : IsNilpotent ((exp a) - 1) := by
+theorem isNilpotent_exp_sub_one {a : A} (ha : IsNilpotent a) : IsNilpotent (exp a - 1) := by
   nontriviality A
   rw [exp, ← Nat.sub_add_cancel (pos_nilpotencyClass_iff.2 ha), Finset.sum_range_succ']
   norm_num

--- a/Mathlib/RingTheory/Nilpotent/Exp.lean
+++ b/Mathlib/RingTheory/Nilpotent/Exp.lean
@@ -202,7 +202,7 @@ theorem exp_smul {G : Type*} [Monoid G] [MulSemiringAction G A]
 theorem isNilpotent_exp_sub_one {a : A} (ha : IsNilpotent a) : IsNilpotent ((exp a) - 1) := by
   cases subsingleton_or_nontrivial A
   · exact isNilpotent_of_subsingleton
-  rw [exp, ← Nat.sub_add_cancel (pos_nilpotencyClass_iff.mpr ha), Finset.sum_range_succ']
+  rw [exp, ← Nat.sub_add_cancel (pos_nilpotencyClass_iff.2 ha), Finset.sum_range_succ']
   norm_num
   apply Commute.isNilpotent_sum fun _ _ ↦ smul (pow_of_pos ha <| by positivity) _
   simp [Nat.factorial_ne_zero]

--- a/Mathlib/RingTheory/Nilpotent/Exp.lean
+++ b/Mathlib/RingTheory/Nilpotent/Exp.lean
@@ -200,8 +200,7 @@ theorem exp_smul {G : Type*} [Monoid G] [MulSemiringAction G A]
   (map_exp ha (MulSemiringAction.toRingHom G A g)).symm
 
 theorem isNilpotent_exp_sub_one {a : A} (ha : IsNilpotent a) : IsNilpotent ((exp a) - 1) := by
-  cases subsingleton_or_nontrivial A
-  · exact isNilpotent_of_subsingleton
+  nontriviality A
   rw [exp, ← Nat.sub_add_cancel (pos_nilpotencyClass_iff.2 ha), Finset.sum_range_succ']
   norm_num
   apply Commute.isNilpotent_sum fun _ _ ↦ smul (pow_of_pos ha <| by positivity) _

--- a/Mathlib/RingTheory/Nilpotent/Exp.lean
+++ b/Mathlib/RingTheory/Nilpotent/Exp.lean
@@ -199,6 +199,18 @@ theorem exp_smul {G : Type*} [Monoid G] [MulSemiringAction G A]
     exp (g • a) = g • exp a :=
   (map_exp ha (MulSemiringAction.toRingHom G A g)).symm
 
+theorem exp_isUnipotent {a : A} (ha : IsNilpotent a) : IsUnipotent (exp a) := by
+  cases subsingleton_or_nontrivial A; · exact isNilpotent_of_subsingleton
+  rw [exp, ← Nat.sub_add_cancel (pos_nilpotencyClass_iff.mpr ha), Finset.sum_range_succ',
+    Nat.factorial_zero, Nat.cast_one, inv_one, pow_zero, one_smul,
+    add_one_isUnipotent_iff_isNilpotent]
+  exact Commute.isNilpotent_sum (by intros; apply smul; exact pow_of_pos ha (by positivity)) (by
+    intros
+    have h (n : ℕ) : (n.factorial : ℚ)⁻¹ ≠ 0 := by norm_num; exact Nat.factorial_ne_zero n
+    simp only [Commute.refl, Commute.smul_left_iff₀ (h _), Commute.smul_right_iff₀ (h _),
+      Commute.pow_left, Commute.pow_right]
+  )
+
 end IsNilpotent
 
 namespace Module.End

--- a/Mathlib/RingTheory/Nilpotent/Exp.lean
+++ b/Mathlib/RingTheory/Nilpotent/Exp.lean
@@ -199,11 +199,10 @@ theorem exp_smul {G : Type*} [Monoid G] [MulSemiringAction G A]
     exp (g • a) = g • exp a :=
   (map_exp ha (MulSemiringAction.toRingHom G A g)).symm
 
-theorem exp_isUnipotent {a : A} (ha : IsNilpotent a) : IsUnipotent (exp a) := by
+theorem exp_sub_one_isNilpotent {a : A} (ha : IsNilpotent a) : IsNilpotent ((exp a) - 1) := by
   cases subsingleton_or_nontrivial A; · exact isNilpotent_of_subsingleton
   rw [exp, ← Nat.sub_add_cancel (pos_nilpotencyClass_iff.mpr ha), Finset.sum_range_succ',
-    Nat.factorial_zero, Nat.cast_one, inv_one, pow_zero, one_smul,
-    add_one_isUnipotent_iff_isNilpotent]
+    Nat.factorial_zero, Nat.cast_one, inv_one, pow_zero, one_smul, add_sub_cancel_right]
   exact Commute.isNilpotent_sum (by intros; apply smul; exact pow_of_pos ha (by positivity)) (by
     intros
     have h (n : ℕ) : (n.factorial : ℚ)⁻¹ ≠ 0 := by norm_num; exact Nat.factorial_ne_zero n

--- a/Mathlib/RingTheory/Nilpotent/Exp.lean
+++ b/Mathlib/RingTheory/Nilpotent/Exp.lean
@@ -200,14 +200,12 @@ theorem exp_smul {G : Type*} [Monoid G] [MulSemiringAction G A]
   (map_exp ha (MulSemiringAction.toRingHom G A g)).symm
 
 theorem isNilpotent_exp_sub_one {a : A} (ha : IsNilpotent a) : IsNilpotent ((exp a) - 1) := by
-  cases subsingleton_or_nontrivial A; · exact isNilpotent_of_subsingleton
+  cases subsingleton_or_nontrivial A
+  · exact isNilpotent_of_subsingleton
   rw [exp, ← Nat.sub_add_cancel (pos_nilpotencyClass_iff.mpr ha), Finset.sum_range_succ']
   norm_num
-  exact Commute.isNilpotent_sum (by intros; apply smul; exact pow_of_pos ha (by positivity)) (by
-    intros
-    have h (n : ℕ) : (n.factorial : ℚ)⁻¹ ≠ 0 := by norm_num; exact Nat.factorial_ne_zero n
-    simp [h, Commute.smul_left_iff₀, Commute.smul_right_iff₀]
-  )
+  apply Commute.isNilpotent_sum <| fun _ _ ↦ smul (pow_of_pos ha <| by positivity) _
+  simp [Nat.factorial_ne_zero]
 
 end IsNilpotent
 

--- a/Mathlib/RingTheory/Nilpotent/Exp.lean
+++ b/Mathlib/RingTheory/Nilpotent/Exp.lean
@@ -201,13 +201,12 @@ theorem exp_smul {G : Type*} [Monoid G] [MulSemiringAction G A]
 
 theorem isNilpotent_exp_sub_one {a : A} (ha : IsNilpotent a) : IsNilpotent ((exp a) - 1) := by
   cases subsingleton_or_nontrivial A; · exact isNilpotent_of_subsingleton
-  rw [exp, ← Nat.sub_add_cancel (pos_nilpotencyClass_iff.mpr ha), Finset.sum_range_succ',
-    Nat.factorial_zero, Nat.cast_one, inv_one, pow_zero, one_smul, add_sub_cancel_right]
+  rw [exp, ← Nat.sub_add_cancel (pos_nilpotencyClass_iff.mpr ha), Finset.sum_range_succ']
+  norm_num
   exact Commute.isNilpotent_sum (by intros; apply smul; exact pow_of_pos ha (by positivity)) (by
     intros
     have h (n : ℕ) : (n.factorial : ℚ)⁻¹ ≠ 0 := by norm_num; exact Nat.factorial_ne_zero n
-    simp only [Commute.refl, Commute.smul_left_iff₀ (h _), Commute.smul_right_iff₀ (h _),
-      Commute.pow_left, Commute.pow_right]
+    simp [h, Commute.smul_left_iff₀, Commute.smul_right_iff₀]
   )
 
 end IsNilpotent

--- a/Mathlib/RingTheory/Nilpotent/Exp.lean
+++ b/Mathlib/RingTheory/Nilpotent/Exp.lean
@@ -199,7 +199,7 @@ theorem exp_smul {G : Type*} [Monoid G] [MulSemiringAction G A]
     exp (g • a) = g • exp a :=
   (map_exp ha (MulSemiringAction.toRingHom G A g)).symm
 
-theorem exp_sub_one_isNilpotent {a : A} (ha : IsNilpotent a) : IsNilpotent ((exp a) - 1) := by
+theorem isNilpotent_exp_sub_one {a : A} (ha : IsNilpotent a) : IsNilpotent ((exp a) - 1) := by
   cases subsingleton_or_nontrivial A; · exact isNilpotent_of_subsingleton
   rw [exp, ← Nat.sub_add_cancel (pos_nilpotencyClass_iff.mpr ha), Finset.sum_range_succ',
     Nat.factorial_zero, Nat.cast_one, inv_one, pow_zero, one_smul, add_sub_cancel_right]

--- a/Mathlib/RingTheory/Nilpotent/Exp.lean
+++ b/Mathlib/RingTheory/Nilpotent/Exp.lean
@@ -204,7 +204,7 @@ theorem isNilpotent_exp_sub_one {a : A} (ha : IsNilpotent a) : IsNilpotent ((exp
   · exact isNilpotent_of_subsingleton
   rw [exp, ← Nat.sub_add_cancel (pos_nilpotencyClass_iff.mpr ha), Finset.sum_range_succ']
   norm_num
-  apply Commute.isNilpotent_sum <| fun _ _ ↦ smul (pow_of_pos ha <| by positivity) _
+  apply Commute.isNilpotent_sum fun _ _ ↦ smul (pow_of_pos ha <| by positivity) _
   simp [Nat.factorial_ne_zero]
 
 end IsNilpotent


### PR DESCRIPTION
---
<!-- Your PR title will become the first line of the commit message.

In this box, the text above the `---` (if not empty) will be appended
to the commit message, and can be used to give additional context or
details. Please leave a blank newline before the `---`, otherwise GitHub
will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

When merging, all the commits will be squashed into a single commit
listing all co-authors.

Co-authors in the squash commit are gathered from two sources:

First, all authors of commits to this PR branch are included. Thus,
one way to add co-authors is to include at least one commit authored by
each co-author among the commits in the pull request. If necessary, you
may create empty commits to indicate co-authorship, using commands like so:

git commit --author="Author Name <author@email.com>" --allow-empty -m "add Author Name as coauthor"

Second, co-authors can also be listed in lines at the very bottom of
the commit message (that is, directly before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines
at the bottom of the commit message (before the `---`, and also before
any "Co-authored-by" lines) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
