### PR TITLE
[Merged by Bors] - chore: Fix Dihedral comments

### DIFF
--- a/Mathlib/GroupTheory/SpecificGroups/Dihedral.lean
+++ b/Mathlib/GroupTheory/SpecificGroups/Dihedral.lean
@@ -176,7 +176,7 @@ theorem r_one_pow_n : r (1 : ZMod n) ^ n = 1 := by
 theorem sr_mul_self (i : ZMod n) : sr i * sr i = 1 := by
   simp
 
-/-- If `0 < n`, then `sr i` has order 2.
+/-- `sr i` has order 2.
 -/
 @[simp]
 theorem orderOf_sr (i : ZMod n) : orderOf (sr i) = 2 := by
@@ -184,7 +184,7 @@ theorem orderOf_sr (i : ZMod n) : orderOf (sr i) = 2 := by
   · rw [sq, sr_mul_self]
   · simp [← r_zero]
 
-/-- If `0 < n`, then `r 1` has order `n`.
+/-- `r 1` has order `n`.
 -/
 @[simp]
 theorem orderOf_r_one : orderOf (r 1 : DihedralGroup n) = n := by
@@ -203,7 +203,7 @@ theorem orderOf_r_one : orderOf (r 1 : DihedralGroup n) = n := by
     rw [← ZMod.val_eq_zero, ZMod.val_natCast, Nat.mod_eq_of_lt h] at h2
     exact absurd h2.symm (orderOf_pos _).ne
 
-/-- If `0 < n`, then `i : ZMod n` has order `n / gcd n i`.
+/-- If `0 < n`, then `r i` has order `n / gcd n i`.
 -/
 theorem orderOf_r [NeZero n] (i : ZMod n) : orderOf (r i) = n / Nat.gcd n i.val := by
   conv_lhs => rw [← ZMod.natCast_zmod_val i]


### PR DESCRIPTION
Fix incorrect comments


---
<!-- Your PR title will become the first line of the commit message.

In this box, the text above the `---` (if not empty) will be appended
to the commit message, and can be used to give additional context or
details. Please leave a blank newline before the `---`, otherwise GitHub
will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

When merging, all the commits will be squashed into a single commit
listing all co-authors.

Co-authors in the squash commit are gathered from two sources:

First, all authors of commits to this PR branch are included. Thus,
one way to add co-authors is to include at least one commit authored by
each co-author among the commits in the pull request. If necessary, you
may create empty commits to indicate co-authorship, using commands like so:

git commit --author="Author Name <author@email.com>" --allow-empty -m "add Author Name as coauthor"

Second, co-authors can also be listed in lines at the very bottom of
the commit message (that is, directly before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines
at the bottom of the commit message (before the `---`, and also before
any "Co-authored-by" lines) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
