### PR TITLE
[Merged by Bors] - feat(Algebra/Group/Action): add `smul_set_eq_univ`

### DIFF
--- a/Mathlib/Algebra/Group/Action/Pointwise/Finset.lean
+++ b/Mathlib/Algebra/Group/Action/Pointwise/Finset.lean
@@ -209,6 +209,10 @@ theorem smul_finset_univ [Fintype β] : a • (univ : Finset β) = univ :=
   image_univ_of_surjective <| MulAction.surjective a
 
 @[to_additive (attr := simp)]
+theorem smul_finset_eq_univ [Fintype β] : a • (univ : Finset β) = univ := by
+  rw [smul_eq_iff_eq_inv_smul, smul_finset_univ]
+
+@[to_additive (attr := simp)]
 theorem smul_univ [Fintype β] {s : Finset α} (hs : s.Nonempty) : s • (univ : Finset β) = univ :=
   coe_injective <| by
     push_cast

--- a/Mathlib/Algebra/Group/Action/Pointwise/Finset.lean
+++ b/Mathlib/Algebra/Group/Action/Pointwise/Finset.lean
@@ -209,7 +209,7 @@ theorem smul_finset_univ [Fintype β] : a • (univ : Finset β) = univ :=
   image_univ_of_surjective <| MulAction.surjective a
 
 @[to_additive (attr := simp)]
-theorem smul_finset_eq_univ [Fintype β] : a • (univ : Finset β) = univ := by
+theorem smul_finset_eq_univ [Fintype β] : a • s = univ ↔ s = univ := by
   rw [smul_eq_iff_eq_inv_smul, smul_finset_univ]
 
 @[to_additive (attr := simp)]

--- a/Mathlib/Algebra/Group/Action/Pointwise/Set/Basic.lean
+++ b/Mathlib/Algebra/Group/Action/Pointwise/Set/Basic.lean
@@ -250,6 +250,10 @@ theorem smul_set_univ : a • (univ : Set β) = univ :=
   image_univ_of_surjective <| MulAction.surjective a
 
 @[to_additive (attr := simp)]
+theorem smul_set_eq_univ : a • s = univ ↔ s = univ := by
+  rw [smul_eq_iff_eq_inv_smul, smul_set_univ]
+
+@[to_additive (attr := simp)]
 theorem smul_univ {s : Set α} (hs : s.Nonempty) : s • (univ : Set β) = univ :=
   let ⟨a, ha⟩ := hs
   eq_univ_of_forall fun b ↦ ⟨a, ha, a⁻¹ • b, trivial, smul_inv_smul _ _⟩


### PR DESCRIPTION
Also add additive and `Finset` versions.

---
<!-- Your PR title will become the first line of the commit message.

In this box, the text above the `---` (if not empty) will be appended
to the commit message, and can be used to give additional context or
details. Please leave a blank newline before the `---`, otherwise GitHub
will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

When merging, all the commits will be squashed into a single commit
listing all co-authors.

Co-authors in the squash commit are gathered from two sources:

First, all authors of commits to this PR branch are included. Thus,
one way to add co-authors is to include at least one commit authored by
each co-author among the commits in the pull request. If necessary, you
may create empty commits to indicate co-authorship, using commands like so:

git commit --author="Author Name <author@email.com>" --allow-empty -m "add Author Name as coauthor"

Second, co-authors can also be listed in lines at the very bottom of
the commit message (that is, directly before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines
at the bottom of the commit message (before the `---`, and also before
any "Co-authored-by" lines) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
