### PR TITLE
[Merged by Bors] - feat(MetricSpace/Algebra): prove uniform continuity of `(· • ·)`

### DIFF
--- a/Mathlib/Topology/MetricSpace/Algebra.lean
+++ b/Mathlib/Topology/MetricSpace/Algebra.lean
@@ -130,25 +130,29 @@ theorem dist_smul_pair (x : α) (y₁ y₂ : β) : dist (x • y₁) (x • y₂
 theorem dist_pair_smul (x₁ x₂ : α) (y : β) : dist (x₁ • y) (x₂ • y) ≤ dist x₁ x₂ * dist y 0 :=
   IsBoundedSMul.dist_pair_smul' x₁ x₂ y
 
+theorem Bornology.IsBounded.uniformContinuousOn_smul {s : Set (α × β)} (hs : IsBounded s) :
+    UniformContinuousOn (· • ·).uncurry s := by
+  rcases hs.subset_ball_lt 0 0 with ⟨C, hC₀, hC⟩
+  rw [Metric.uniformContinuousOn_iff_le]
+  intro ε hε
+  refine ⟨ε / (2 * C), by positivity, fun ⟨a, b⟩ hab ⟨x, y⟩ hxy h ↦ ?_⟩
+  grw [hC, Metric.mem_ball, Prod.dist_eq, max_lt_iff] at hab hxy
+  rw [Prod.dist_eq, max_le_iff] at h
+  dsimp at hab hxy h ⊢
+  grw [dist_triangle _ (a • y), dist_pair_smul, dist_smul_pair, hab.1, hxy.2, h.2, h.1]
+  field_simp
+  norm_num1
+
 -- see Note [lower instance priority]
 /-- The typeclass `IsBoundedSMul` on a metric-space scalar action implies continuity of the
 action. -/
 instance (priority := 100) IsBoundedSMul.continuousSMul : ContinuousSMul α β where
   continuous_smul := by
-    rw [Metric.continuous_iff]
-    rintro ⟨a, b⟩ ε ε0
-    obtain ⟨δ, δ0, hδε⟩ : ∃ δ > 0, δ * (δ + dist b 0) + dist a 0 * δ < ε := by
-      have : Continuous fun δ ↦ δ * (δ + dist b 0) + dist a 0 * δ := by fun_prop
-      refine ((this.tendsto' _ _ ?_).eventually (gt_mem_nhds ε0)).exists_gt
-      simp
-    refine ⟨δ, δ0, fun (a', b') hab' => ?_⟩
-    obtain ⟨ha, hb⟩ := max_lt_iff.1 hab'
-    calc dist (a' • b') (a • b)
-        ≤ dist (a' • b') (a • b') + dist (a • b') (a • b) := dist_triangle ..
-      _ ≤ dist a' a * dist b' 0 + dist a 0 * dist b' b :=
-        add_le_add (dist_pair_smul _ _ _) (dist_smul_pair _ _ _)
-      _ ≤ δ * (δ + dist b 0) + dist a 0 * δ := by gcongr; grw [dist_triangle b' b 0, hb]
-      _ < ε := hδε
+    rw [continuous_iff_continuousAt]
+    intro x
+    refine Metric.isBounded_ball (x := 0) (r := dist x 0 + 1) |>.uniformContinuousOn_smul
+      |>.continuousOn |>.continuousAt ?_
+    exact Metric.isOpen_ball.mem_nhds (by simp)
 
 instance (priority := 100) IsBoundedSMul.toUniformContinuousConstSMul :
     UniformContinuousConstSMul α β :=


### PR DESCRIPTION
... on any bounded set.

---
<!-- Your PR title will become the first line of the commit message.

In this box, the text above the `---` (if not empty) will be appended
to the commit message, and can be used to give additional context or
details. Please leave a blank newline before the `---`, otherwise GitHub
will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

When merging, all the commits will be squashed into a single commit
listing all co-authors.

Co-authors in the squash commit are gathered from two sources:

First, all authors of commits to this PR branch are included. Thus,
one way to add co-authors is to include at least one commit authored by
each co-author among the commits in the pull request. If necessary, you
may create empty commits to indicate co-authorship, using commands like so:

git commit --author="Author Name <author@email.com>" --allow-empty -m "add Author Name as coauthor"

Second, co-authors can also be listed in lines at the very bottom of
the commit message (that is, directly before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines
at the bottom of the commit message (before the `---`, and also before
any "Co-authored-by" lines) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
