### PR TITLE
[Merged by Bors] - chore(Data/Finsupp): rename `finsuppProdEquiv` to `curryEquiv`

### DIFF
--- a/Mathlib/Data/Finsupp/Basic.lean
+++ b/Mathlib/Data/Finsupp/Basic.lean
@@ -953,6 +953,8 @@ def curryEquiv : (α × β →₀ M) ≃ (α →₀ β →₀ M) where
   left_inv := uncurry_curry
   right_inv := curry_uncurry
 
+@[deprecated (since := "2026-01-03")] alias finsuppProdEquiv := curryEquiv
+
 theorem filter_curry (f : α × β →₀ M) (p : α → Prop) [DecidablePred p] :
     (f.filter fun a : α × β => p a.1).curry = f.curry.filter p := by
   ext a b

--- a/Mathlib/Data/Finsupp/Basic.lean
+++ b/Mathlib/Data/Finsupp/Basic.lean
@@ -961,9 +961,8 @@ theorem filter_curry (f : α × β →₀ M) (p : α → Prop) [DecidablePred p]
 end Curry
 
 section
-variable [AddZeroClass M]
+variable [AddZeroClass M] [DecidableEq α]
 
-open scoped Classical in
 /-- The additive monoid isomorphism between `α × β →₀ M` and `α →₀ β →₀ M` given by
 currying/uncurrying. -/
 @[simps! symm_apply]
@@ -971,11 +970,7 @@ noncomputable def curryAddEquiv : (α × β →₀ M) ≃+ (α →₀ β →₀ 
   __ := curryEquiv
   map_add' _ _ := by ext; simp
 
-variable [DecidableEq α]
-
-@[simp] lemma coe_curryAddEquiv :
-    (curryAddEquiv : (α × β →₀ M) → α →₀ β →₀ M) = .curry := by
-  dsimp [curryAddEquiv, curryEquiv]; convert rfl
+@[simp] lemma coe_curryAddEquiv : (curryAddEquiv : (α × β →₀ M) → α →₀ β →₀ M) = .curry := rfl
 
 end
 

--- a/Mathlib/Data/Finsupp/Basic.lean
+++ b/Mathlib/Data/Finsupp/Basic.lean
@@ -963,7 +963,7 @@ theorem filter_curry (f : α × β →₀ M) (p : α → Prop) [DecidablePred p]
 end Curry
 
 section
-variable [AddZeroClass M] [DecidableEq α]
+variable [DecidableEq α] [AddZeroClass M]
 
 /-- The additive monoid isomorphism between `α × β →₀ M` and `α →₀ β →₀ M` given by
 currying/uncurrying. -/

--- a/Mathlib/Data/Finsupp/Basic.lean
+++ b/Mathlib/Data/Finsupp/Basic.lean
@@ -945,10 +945,9 @@ theorem sum_curry_index [AddCommMonoid N] (f : α × β →₀ M) (g : α → β
     (f.curry.sum fun a f => f.sum (g a)) = f.sum fun p c => g p.1 p.2 c := by
   rw [← sum_uncurry_index', uncurry_curry]
 
-/-- `finsuppProdEquiv` defines the `Equiv` between `((α × β) →₀ M)` and `(α →₀ (β →₀ M))` given by
-currying and uncurrying. -/
+/-- The equivalence between `α × β →₀ M` and `α →₀ β →₀ M` given by currying/uncurrying. -/
 @[simps]
-def finsuppProdEquiv : (α × β →₀ M) ≃ (α →₀ β →₀ M) where
+def curryEquiv : (α × β →₀ M) ≃ (α →₀ β →₀ M) where
   toFun := Finsupp.curry
   invFun := Finsupp.uncurry
   left_inv := uncurry_curry
@@ -960,6 +959,25 @@ theorem filter_curry (f : α × β →₀ M) (p : α → Prop) [DecidablePred p]
   simp [filter_apply, apply_ite (DFunLike.coe · b)]
 
 end Curry
+
+section
+variable [AddZeroClass M]
+
+open scoped Classical in
+/-- The additive monoid isomorphism between `α × β →₀ M` and `α →₀ β →₀ M` given by
+currying/uncurrying. -/
+@[simps! symm_apply]
+noncomputable def curryAddEquiv : (α × β →₀ M) ≃+ (α →₀ β →₀ M) where
+  __ := curryEquiv
+  map_add' _ _ := by ext; simp
+
+variable [DecidableEq α]
+
+@[simp] lemma coe_curryAddEquiv :
+    (curryAddEquiv : (α × β →₀ M) → α →₀ β →₀ M) = .curry := by
+  dsimp [curryAddEquiv, curryEquiv]; convert rfl
+
+end
 
 /-! ### Declarations about finitely supported functions whose support is a `Sum` type -/
 

--- a/Mathlib/LinearAlgebra/DFinsupp.lean
+++ b/Mathlib/LinearAlgebra/DFinsupp.lean
@@ -127,7 +127,7 @@ def domLCongr (e : ι ≃ ι') : (Π₀ i, M i) ≃ₗ[R] (Π₀ i, M (e.symm i)
 
 /-- `DFinsupp.sigmaCurryEquiv` as a linear equivalence.
 
-This is the `DFinsupp` version of `Finsupp.finsuppProdLEquiv`. -/
+This is the `DFinsupp` version of `Finsupp.curryLinearEquiv`. -/
 @[simps! apply symm_apply]
 def sigmaCurryLEquiv {α : ι → Type*} {M : (i : ι) → α i → Type*}
     [Π i j, AddCommMonoid (M i j)] [Π i j, Module R (M i j)] [DecidableEq ι] :

--- a/Mathlib/LinearAlgebra/Finsupp/Defs.lean
+++ b/Mathlib/LinearAlgebra/Finsupp/Defs.lean
@@ -282,9 +282,14 @@ noncomputable def curryLinearEquiv : (α × β →₀ M) ≃ₗ[R] α →₀ β 
   toAddEquiv := curryAddEquiv
   map_smul' c f := by ext; simp
 
+@[deprecated (since := "2026-01-03")] alias finsuppProdLEquiv := curryLinearEquiv
+
 theorem curryLinearEquiv_symm_apply_apply (f : α →₀ β →₀ M) (xy) :
     (curryLinearEquiv R).symm f xy = f xy.1 xy.2 :=
   rfl
+
+@[deprecated (since := "2026-01-03")]
+alias finsuppProdLEquiv_symm_apply_apply := curryLinearEquiv_symm_apply_apply
 
 end Prod
 

--- a/Mathlib/LinearAlgebra/Finsupp/Defs.lean
+++ b/Mathlib/LinearAlgebra/Finsupp/Defs.lean
@@ -276,15 +276,14 @@ variable {α β R M : Type*} [DecidableEq α] [Semiring R] [AddCommMonoid M] [Mo
 variable (R) in
 /-- The linear equivalence between `α × β →₀ M` and `α →₀ β →₀ M`.
 
-This is the `LinearEquiv` version of `Finsupp.finsuppProdEquiv`. -/
+This is the `LinearEquiv` version of `Finsupp.curryEquiv`. -/
 @[simps +simpRhs]
-noncomputable def finsuppProdLEquiv : (α × β →₀ M) ≃ₗ[R] α →₀ β →₀ M :=
-  { finsuppProdEquiv with
-    map_add' f g := by ext; simp
-    map_smul' c f := by ext; simp }
+noncomputable def curryLinearEquiv : (α × β →₀ M) ≃ₗ[R] α →₀ β →₀ M where
+  toAddEquiv := curryAddEquiv
+  map_smul' c f := by ext; simp
 
-theorem finsuppProdLEquiv_symm_apply_apply (f : α →₀ β →₀ M) (xy) :
-    (finsuppProdLEquiv R).symm f xy = f xy.1 xy.2 :=
+theorem curryLinearEquiv_symm_apply_apply (f : α →₀ β →₀ M) (xy) :
+    (curryLinearEquiv R).symm f xy = f xy.1 xy.2 :=
   rfl
 
 end Prod

--- a/Mathlib/LinearAlgebra/Finsupp/LinearCombination.lean
+++ b/Mathlib/LinearAlgebra/Finsupp/LinearCombination.lean
@@ -223,7 +223,7 @@ theorem linearCombination_linearCombination {α β : Type*} (A : α → M) (B : 
 theorem linearCombination_smul [DecidableEq α] [Module R S] [Module S M] [IsScalarTower R S M]
     {w : α' → S} :
     linearCombination R (fun i : α × α' ↦ w i.2 • v i.1) = (linearCombination S v).restrictScalars R
-      ∘ₗ mapRange.linearMap (linearCombination R w) ∘ₗ (finsuppProdLEquiv R).toLinearMap := by
+      ∘ₗ mapRange.linearMap (linearCombination R w) ∘ₗ (curryLinearEquiv R).toLinearMap := by
   ext; simp
 
 @[simp]

--- a/Mathlib/RepresentationTheory/Homological/GroupHomology/Functoriality.lean
+++ b/Mathlib/RepresentationTheory/Homological/GroupHomology/Functoriality.lean
@@ -525,8 +525,8 @@ theorem comap_coinvariantsKer_pOpcycles_range_subtype_pOpcycles_eq_top :
   apply (moduleCat_pOpcycles_eq_iff _ _ _).2 ⟨Z, ?_⟩
   change d₂₁ A Z = mapRange id rfl (lmapDomain _ k Subtype.val Y) -
     mapRange.linearMap (Submodule.subtype _) (mapDomain id x)
-  simpa [map_finsuppSum, mapDomain, map_sub, ← hX, sum_single_index, finsuppProdLEquiv,
-    finsuppProdEquiv, Finsupp.uncurry, d₂₁, Y, Z, sum_mapRange_index,
+  simpa [map_finsuppSum, mapDomain, map_sub, ← hX, sum_single_index, curryLinearEquiv,
+    curryEquiv, Finsupp.uncurry, d₂₁, Y, Z, sum_mapRange_index,
     chains₁ToCoinvariantsKer, d₁₀, single_sum, mul_assoc, sub_add_eq_add_sub,
     sum_sum_index, add_smul, sub_sub_sub_eq, lsingle, singleAddHom] using add_comm _ _
 

--- a/Mathlib/RepresentationTheory/Rep.lean
+++ b/Mathlib/RepresentationTheory/Rep.lean
@@ -430,7 +430,7 @@ variable {α} [DecidableEq α]
 def freeLift (f : α → A) :
     free k G α ⟶ A where
   hom := ModuleCat.ofHom <| linearCombination k (fun x => A.ρ x.2 (f x.1)) ∘ₗ
-    (finsuppProdLEquiv k).symm.toLinearMap
+    (curryLinearEquiv k).symm.toLinearMap
   comm _ := by
     ext; simp [ModuleCat.endRingEquiv]
 
@@ -499,7 +499,7 @@ variable (k G) in
 def leftRegularTensorTrivialIsoFree :
     leftRegular k G ⊗ trivial k G (α →₀ k) ≅ free k G α :=
   Action.mkIso (finsuppTensorFinsupp' k G α ≪≫ₗ Finsupp.domLCongr (Equiv.prodComm G α) ≪≫ₗ
-    finsuppProdLEquiv k).toModuleIso fun _ =>
+    curryLinearEquiv k).toModuleIso fun _ =>
       ModuleCat.hom_ext <| TensorProduct.ext <| lhom_ext fun _ _ => lhom_ext fun _ _ => by
         ext
         simp [Action_ρ_eq_ρ, tensorObj_carrier, ModuleCat.endRingEquiv]

--- a/Mathlib/RingTheory/AlgebraTower.lean
+++ b/Mathlib/RingTheory/AlgebraTower.lean
@@ -123,7 +123,7 @@ def smulTower : Basis (ι × ι') R A :=
   .ofRepr
     (c.repr.restrictScalars R ≪≫ₗ
       (Finsupp.lcongr (Equiv.refl _) b.repr ≪≫ₗ
-        ((finsuppProdLEquiv R).symm ≪≫ₗ
+        ((curryLinearEquiv R).symm ≪≫ₗ
           Finsupp.lcongr (Equiv.prodComm ι' ι) (LinearEquiv.refl _ _))))
 
 @[simp]

--- a/Mathlib/RingTheory/Unramified/Finite.lean
+++ b/Mathlib/RingTheory/Unramified/Finite.lean
@@ -196,7 +196,7 @@ lemma finite_of_free [Module.Free R S] : Module.Finite R S := by
   -- Then `∑ Fᵢⱼ(bⱼ ⊗ bᵢ) = ∑ fⱼx ⊗ bᵢ = ∑ fⱼ ⊗ xbᵢ = ∑ aᵢⱼ(fⱼ ⊗ bᵢ) = ∑ Gᵢⱼ(bⱼ ⊗ bᵢ)`.
   -- Since `bⱼ ⊗ bᵢ` forms an `R`-basis of `S ⊗ S`, we conclude that `F = G`.
   have : F = G := by
-    apply Finsupp.finsuppProdEquiv.symm.injective
+    apply Finsupp.curryEquiv.symm.injective
     apply (Finsupp.equivCongrLeft (Equiv.prodComm I I)).injective
     apply (b.tensorProduct b).repr.symm.injective
     suffices (F.sum fun a f ↦ f.sum fun b' c ↦ c • b b' ⊗ₜ[R] b a) =


### PR DESCRIPTION
This matches both the `DFinsupp` name and more generally the practice of naming bundlings of a function after the function.

Also add the missing intermediate bundling as an `AddEquiv`.

---
<!-- Your PR title will become the first line of the commit message.

In this box, the text above the `---` (if not empty) will be appended
to the commit message, and can be used to give additional context or
details. Please leave a blank newline before the `---`, otherwise GitHub
will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

When merging, all the commits will be squashed into a single commit
listing all co-authors.

Co-authors in the squash commit are gathered from two sources:

First, all authors of commits to this PR branch are included. Thus,
one way to add co-authors is to include at least one commit authored by
each co-author among the commits in the pull request. If necessary, you
may create empty commits to indicate co-authorship, using commands like so:

git commit --author="Author Name <author@email.com>" --allow-empty -m "add Author Name as coauthor"

Second, co-authors can also be listed in lines at the very bottom of
the commit message (that is, directly before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines
at the bottom of the commit message (before the `---`, and also before
any "Co-authored-by" lines) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
