### PR TITLE
chore: golf proofs

### DIFF
--- a/Mathlib/Data/Nat/ChineseRemainder.lean
+++ b/Mathlib/Data/Nat/ChineseRemainder.lean
@@ -154,7 +154,6 @@ theorem chineseRemainderOfMultiset_lt_prod {m : Multiset ι}
     (nod : m.Nodup) (hs : ∀ i ∈ m, s i ≠ 0) (pp : Set.Pairwise {x | x ∈ m} (Coprime on s)) :
     chineseRemainderOfMultiset a s nod hs pp < (m.map s).prod := by
   induction m using Quot.ind with | _ l
-  unfold chineseRemainderOfMultiset
   simpa using chineseRemainderOfList_lt_prod a s l
     (List.Nodup.pairwise_of_forall_ne nod pp) (by simpa using hs)
 

--- a/Mathlib/FieldTheory/Differential/Basic.lean
+++ b/Mathlib/FieldTheory/Differential/Basic.lean
@@ -76,7 +76,6 @@ lemma logDeriv_prod (ι : Type*) (s : Finset ι) (f : ι → R) (h : ∀ x ∈ s
 
 lemma logDeriv_prod_of_eq_zero (ι : Type*) (s : Finset ι) (f : ι → R) (h : ∀ x ∈ s, f x = 0) :
     logDeriv (∏ x ∈ s, f x) = ∑ x ∈ s, logDeriv (f x) := by
-  unfold logDeriv
   simp_all
 
 lemma logDeriv_algebraMap {F K : Type*} [Field F] [Field K] [Differential F] [Differential K]

--- a/Mathlib/Probability/Distributions/Uniform.lean
+++ b/Mathlib/Probability/Distributions/Uniform.lean
@@ -193,9 +193,8 @@ def uniformPDF (s : Set E) (x : E) (μ : Measure E := by volume_tac) : ℝ≥0�
 
 /-- Check that indeed any uniform random variable has the uniformPDF. -/
 lemma uniformPDF_eq_pdf {s : Set E} (hs : MeasurableSet s) (hu : pdf.IsUniform X s ℙ μ) :
-    (fun x ↦ uniformPDF s x μ) =ᵐ[μ] pdf X ℙ μ := by
-  unfold uniformPDF
-  exact Filter.EventuallyEq.trans (pdf.IsUniform.pdf_eq hs hu).symm (ae_eq_refl _)
+    (fun x ↦ uniformPDF s x μ) =ᵐ[μ] pdf X ℙ μ := Filter.EventuallyEq.trans
+  (pdf.IsUniform.pdf_eq hs hu).symm (ae_eq_refl _)
 
 open scoped Classical in
 /-- Alternative way of writing the uniformPDF. -/

--- a/Mathlib/Probability/Kernel/Disintegration/StandardBorel.lean
+++ b/Mathlib/Probability/Kernel/Disintegration/StandardBorel.lean
@@ -298,7 +298,6 @@ lemma compProd_fst_borelMarkovFromReal (κ : Kernel α (β × Ω)) [IsSFiniteKer
     MeasurableEmbedding.id.prodMap he
   have : κ = comapRight κ' h_prod_embed := by
     ext c t : 2
-    unfold κ'
     rw [comapRight_apply, map_apply _ (by fun_prop), h_prod_embed.comap_map]
   conv_rhs => rw [this, ← hη']
   exact compProd_fst_borelMarkovFromReal_eq_comapRight_compProd κ η hη

--- a/Mathlib/RingTheory/Ideal/Height.lean
+++ b/Mathlib/RingTheory/Ideal/Height.lean
@@ -91,9 +91,7 @@ lemma Ideal.primeHeight_mono {I J : Ideal R} [I.IsPrime] [J.IsPrime] (h : I ≤ 
   exact h
 
 lemma Ideal.primeHeight_add_one_le_of_lt {I J : Ideal R} [I.IsPrime] [J.IsPrime] (h : I < J) :
-    I.primeHeight + 1 ≤ J.primeHeight := by
-  unfold primeHeight
-  exact Order.height_add_one_le h
+    I.primeHeight + 1 ≤ J.primeHeight := Order.height_add_one_le h
 
 @[simp]
 theorem Ideal.height_top : (⊤ : Ideal R).height = ⊤ := by


### PR DESCRIPTION
---
The goal of this golfing PR is to decrease the number of times lemmas or definitions are explicitly referenced. Any decrease in compilation time is a welcome side effect, although it is not a primary objective.

Trace profiling results (shown if ≥10 ms before or after):
* `Nat.chineseRemainderOfMultiset_lt_prod`: 36 ms before, 35 ms after  🎉
* `Differential.logDeriv_prod_of_eq_zero`: 124 ms before, 56 ms after  🎉
* `MeasureTheory.pdf.uniformPDF_eq_pdf`: <10 ms before, <10 ms after  🎉
* `ProbabilityTheory.Kernel.compProd_fst_borelMarkovFromReal`: 18 ms before, 17 ms after  🎉
* `Ideal.primeHeight_add_one_le_of_lt`: <10 ms before, <10 ms after  🎉

This golfing PR is batched under the following guidelines:
* Up to ~5 changed files per PR
* Up to ~25 changed declarations per PR
* Up to ~100 changed lines per PR

---
<!-- Your PR title will become the first line of the commit message.

In this box, the text above the `---` (if not empty) will be appended
to the commit message, and can be used to give additional context or
details. Please leave a blank newline before the `---`, otherwise GitHub
will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

When merging, all the commits will be squashed into a single commit
listing all co-authors.

Co-authors in the squash commit are gathered from two sources:

First, all authors of commits to this PR branch are included. Thus,
one way to add co-authors is to include at least one commit authored by
each co-author among the commits in the pull request. If necessary, you
may create empty commits to indicate co-authorship, using commands like so:

git commit --author="Author Name <author@email.com>" --allow-empty -m "add Author Name as coauthor"

Second, co-authors can also be listed in lines at the very bottom of
the commit message (that is, directly before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines
at the bottom of the commit message (before the `---`, and also before
any "Co-authored-by" lines) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
