### PR TITLE
[Merged by Bors] - feat(CategoryTheory): `FinCategory` instance on `Pairwise`

### DIFF
--- a/Mathlib/CategoryTheory/Category/Pairwise.lean
+++ b/Mathlib/CategoryTheory/Category/Pairwise.lean
@@ -64,6 +64,9 @@ inductive Hom : Pairwise ι → Pairwise ι → Type v
   | right : ∀ i j, Hom (pair i j) (single j)
   deriving DecidableEq
 
+-- False positive?
+attribute [nolint unusedArguments] instDecidableEqHom.decEq
+
 open Hom
 
 instance homInhabited [Inhabited ι] : Inhabited (Hom (single (default : ι)) (single default)) :=

--- a/Mathlib/CategoryTheory/Category/Pairwise.lean
+++ b/Mathlib/CategoryTheory/Category/Pairwise.lean
@@ -7,7 +7,9 @@ module
 
 public import Mathlib.CategoryTheory.Category.Preorder
 public import Mathlib.CategoryTheory.Limits.IsLimit
+public import Mathlib.CategoryTheory.FinCategory.Basic
 public import Mathlib.Order.CompleteLattice.Basic
+public import Mathlib.Tactic.DeriveFintype
 
 /-!
 # The category of "pairwise intersections".
@@ -43,6 +45,7 @@ We use this as the objects of a category to describe the sheaf condition.
 inductive Pairwise (ι : Type v)
   | single : ι → Pairwise ι
   | pair : ι → ι → Pairwise ι
+  deriving Fintype, DecidableEq
 
 variable {ι : Type v}
 
@@ -59,6 +62,7 @@ inductive Hom : Pairwise ι → Pairwise ι → Type v
   | id_pair : ∀ i j, Hom (pair i j) (pair i j)
   | left : ∀ i j, Hom (pair i j) (single i)
   | right : ∀ i j, Hom (pair i j) (single j)
+  deriving DecidableEq
 
 open Hom
 
@@ -94,6 +98,20 @@ attribute [local aesop safe tactic (rule_sets := [CategoryTheory])] pairwiseCase
 instance : Category (Pairwise ι) where
 
 end
+
+instance {i j : Pairwise ι} [DecidableEq ι] : DecidableEq (i ⟶ j) :=
+  inferInstanceAs (DecidableEq (Pairwise.Hom i j))
+
+instance [Fintype ι] [DecidableEq ι] : FinCategory (Pairwise ι) where
+  fintypeHom
+  | .single i, .single j => ⟨if h : i = j then {eqToHom (h ▸ rfl)} else ∅, by rintro ⟨⟩; cat_disch⟩
+  | .single i, .pair j k => ⟨∅, by rintro ⟨⟩⟩
+  | .pair i j, .single k =>
+    ⟨(if h : i = k then {Hom.left i j ≫ eqToHom (h ▸ rfl)} else ∅) ∪
+      (if h : j = k then {Hom.right i j ≫ eqToHom (h ▸ rfl)} else ∅),
+        by rintro ⟨⟩ <;> cat_disch⟩
+  | .pair i j, .pair k l =>
+    ⟨if h : i = k ∧ j = l then {eqToHom (h.1 ▸ h.2 ▸ rfl)} else ∅, by rintro ⟨⟩; cat_disch⟩
 
 variable {α : Type u} (U : ι → α)
 


### PR DESCRIPTION

---
<!-- Your PR title will become the first line of the commit message.

In this box, the text above the `---` (if not empty) will be appended
to the commit message, and can be used to give additional context or
details. Please leave a blank newline before the `---`, otherwise GitHub
will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

When merging, all the commits will be squashed into a single commit
listing all co-authors.

Co-authors in the squash commit are gathered from two sources:

First, all authors of commits to this PR branch are included. Thus,
one way to add co-authors is to include at least one commit authored by
each co-author among the commits in the pull request. If necessary, you
may create empty commits to indicate co-authorship, using commands like so:

git commit --author="Author Name <author@email.com>" --allow-empty -m "add Author Name as coauthor"

Second, co-authors can also be listed in lines at the very bottom of
the commit message (that is, directly before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines
at the bottom of the commit message (before the `---`, and also before
any "Co-authored-by" lines) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
