### PR TITLE
[Merged by Bors] - feat: rename `HasCompl` to `Compl`

### DIFF
--- a/Mathlib/Algebra/Order/Ring/Idempotent.lean
+++ b/Mathlib/Algebra/Order/Ring/Idempotent.lean
@@ -24,7 +24,7 @@ is uniquely determined by either `a` or `b`).
 variable {R : Type*}
 
 instance [CommMonoid R] [AddCommMonoid R] :
-    HasCompl {a : R × R // a.1 * a.2 = 0 ∧ a.1 + a.2 = 1} where
+    Compl {a : R × R // a.1 * a.2 = 0 ∧ a.1 + a.2 = 1} where
   compl a := ⟨(a.1.2, a.1.1), (mul_comm ..).trans a.2.1, (add_comm ..).trans a.2.2⟩
 
 lemma eq_of_mul_eq_add_eq_one [NonAssocSemiring R] (a : R) {b c : R}

--- a/Mathlib/Algebra/Ring/Idempotent.lean
+++ b/Mathlib/Algebra/Ring/Idempotent.lean
@@ -50,7 +50,7 @@ lemma _root_.isIdempotentElem_iff_one_sub_mul_self :
     IsIdempotentElem a ↔ (1 - a) * a = 0 := by
   rw [sub_mul, one_mul, sub_eq_zero, eq_comm, IsIdempotentElem]
 
-instance : HasCompl {a : R // IsIdempotentElem a} where compl a := ⟨1 - a, a.prop.one_sub⟩
+instance : Compl {a : R // IsIdempotentElem a} where compl a := ⟨1 - a, a.prop.one_sub⟩
 
 @[simp] lemma coe_compl (a : {a : R // IsIdempotentElem a}) : ↑aᶜ = (1 : R) - ↑a := rfl
 

--- a/Mathlib/Analysis/Normed/Module/MStructure.lean
+++ b/Mathlib/Analysis/Normed/Module/MStructure.lean
@@ -158,7 +158,7 @@ theorem join [FaithfulSMul M X] {P Q : M} (h₁ : IsLprojection X P) (h₂ : IsL
   convert (Lcomplement_iff _).mp (h₁.Lcomplement.mul h₂.Lcomplement) using 1
   noncomm_ring
 
-instance Subtype.instCompl : HasCompl { f : M // IsLprojection X f } :=
+instance Subtype.instCompl : Compl { f : M // IsLprojection X f } :=
   ⟨fun P => ⟨1 - P, P.prop.Lcomplement⟩⟩
 
 @[simp]

--- a/Mathlib/Analysis/Normed/Module/MStructure.lean
+++ b/Mathlib/Analysis/Normed/Module/MStructure.lean
@@ -158,7 +158,7 @@ theorem join [FaithfulSMul M X] {P Q : M} (h₁ : IsLprojection X P) (h₂ : IsL
   convert (Lcomplement_iff _).mp (h₁.Lcomplement.mul h₂.Lcomplement) using 1
   noncomm_ring
 
-instance Subtype.hasCompl : HasCompl { f : M // IsLprojection X f } :=
+instance Subtype.instCompl : HasCompl { f : M // IsLprojection X f } :=
   ⟨fun P => ⟨1 - P, P.prop.Lcomplement⟩⟩
 
 @[simp]
@@ -293,7 +293,7 @@ instance Subtype.distribLattice [FaithfulSMul M X] :
 
 instance Subtype.BooleanAlgebra [FaithfulSMul M X] :
     BooleanAlgebra { P : M // IsLprojection X P } :=
-  { IsLprojection.Subtype.hasCompl,
+  { IsLprojection.Subtype.instCompl,
     IsLprojection.Subtype.sdiff,
     IsLprojection.Subtype.boundedOrder with
     inf_compl_le_bot := fun P =>

--- a/Mathlib/Combinatorics/Digraph/Basic.lean
+++ b/Mathlib/Combinatorics/Digraph/Basic.lean
@@ -136,7 +136,7 @@ theorem inf_adj (x y : Digraph V) (v w : V) : (x ⊓ y).Adj v w ↔ x.Adj v w �
 
 /-- We define `Gᶜ` to be the `Digraph V` such that no two adjacent vertices in `G`
 are adjacent in the complement, and every nonadjacent pair of vertices is adjacent. -/
-instance : HasCompl (Digraph V) where
+instance : Compl (Digraph V) where
   compl G := { Adj := fun v w ↦ ¬G.Adj v w }
 
 @[simp] theorem compl_adj (G : Digraph V) (v w : V) : Gᶜ.Adj v w ↔ ¬G.Adj v w := Iff.rfl

--- a/Mathlib/Combinatorics/Digraph/Basic.lean
+++ b/Mathlib/Combinatorics/Digraph/Basic.lean
@@ -136,7 +136,7 @@ theorem inf_adj (x y : Digraph V) (v w : V) : (x ⊓ y).Adj v w ↔ x.Adj v w �
 
 /-- We define `Gᶜ` to be the `Digraph V` such that no two adjacent vertices in `G`
 are adjacent in the complement, and every nonadjacent pair of vertices is adjacent. -/
-instance hasCompl : HasCompl (Digraph V) where
+instance : HasCompl (Digraph V) where
   compl G := { Adj := fun v w ↦ ¬G.Adj v w }
 
 @[simp] theorem compl_adj (G : Digraph V) (v w : V) : Gᶜ.Adj v w ↔ ¬G.Adj v w := Iff.rfl

--- a/Mathlib/Combinatorics/SimpleGraph/Basic.lean
+++ b/Mathlib/Combinatorics/SimpleGraph/Basic.lean
@@ -234,7 +234,7 @@ theorem inf_adj (x y : SimpleGraph V) (v w : V) : (x ⊓ y).Adj v w ↔ x.Adj v 
 /-- We define `Gᶜ` to be the `SimpleGraph V` such that no two adjacent vertices in `G`
 are adjacent in the complement, and every nonadjacent pair of vertices is adjacent
 (still ensuring that vertices are not adjacent to themselves). -/
-instance hasCompl : HasCompl (SimpleGraph V) where
+instance : HasCompl (SimpleGraph V) where
   compl G :=
     { Adj := fun v w => v ≠ w ∧ ¬G.Adj v w
       symm := fun v w ⟨hne, _⟩ => ⟨hne.symm, by rwa [adj_comm]⟩

--- a/Mathlib/Combinatorics/SimpleGraph/Basic.lean
+++ b/Mathlib/Combinatorics/SimpleGraph/Basic.lean
@@ -234,7 +234,7 @@ theorem inf_adj (x y : SimpleGraph V) (v w : V) : (x ⊓ y).Adj v w ↔ x.Adj v 
 /-- We define `Gᶜ` to be the `SimpleGraph V` such that no two adjacent vertices in `G`
 are adjacent in the complement, and every nonadjacent pair of vertices is adjacent
 (still ensuring that vertices are not adjacent to themselves). -/
-instance : HasCompl (SimpleGraph V) where
+instance : Compl (SimpleGraph V) where
   compl G :=
     { Adj := fun v w => v ≠ w ∧ ¬G.Adj v w
       symm := fun v w ⟨hne, _⟩ => ⟨hne.symm, by rwa [adj_comm]⟩

--- a/Mathlib/Combinatorics/SimpleGraph/Finsubgraph.lean
+++ b/Mathlib/Combinatorics/SimpleGraph/Finsubgraph.lean
@@ -86,7 +86,7 @@ section Finite
 variable [Finite V]
 
 instance instTop : Top G.Finsubgraph where top := ⟨⊤, finite_univ⟩
-instance instHasCompl : HasCompl G.Finsubgraph where compl G' := ⟨G'ᶜ, Set.toFinite _⟩
+instance instHasCompl : Compl G.Finsubgraph where compl G' := ⟨G'ᶜ, Set.toFinite _⟩
 instance instHNot : HNot G.Finsubgraph where hnot G' := ⟨￢G', Set.toFinite _⟩
 instance instHImp : HImp G.Finsubgraph where himp G₁ G₂ := ⟨G₁ ⇨ G₂, Set.toFinite _⟩
 instance instSupSet : SupSet G.Finsubgraph where sSup s := ⟨⨆ G ∈ s, ↑G, Set.toFinite _⟩

--- a/Mathlib/Combinatorics/SimpleGraph/Finsubgraph.lean
+++ b/Mathlib/Combinatorics/SimpleGraph/Finsubgraph.lean
@@ -86,7 +86,7 @@ section Finite
 variable [Finite V]
 
 instance instTop : Top G.Finsubgraph where top := ⟨⊤, finite_univ⟩
-instance instHasCompl : Compl G.Finsubgraph where compl G' := ⟨G'ᶜ, Set.toFinite _⟩
+instance instCompl : Compl G.Finsubgraph where compl G' := ⟨G'ᶜ, Set.toFinite _⟩
 instance instHNot : HNot G.Finsubgraph where hnot G' := ⟨￢G', Set.toFinite _⟩
 instance instHImp : HImp G.Finsubgraph where himp G₁ G₂ := ⟨G₁ ⇨ G₂, Set.toFinite _⟩
 instance instSupSet : SupSet G.Finsubgraph where sSup s := ⟨⨆ G ∈ s, ↑G, Set.toFinite _⟩

--- a/Mathlib/Computability/DFA.lean
+++ b/Mathlib/Computability/DFA.lean
@@ -269,7 +269,7 @@ section compl
 
 /-- DFAs are closed under complement:
 Given a DFA `M`, `Mᶜ` is also a DFA such that `L(Mᶜ) = {x ∣ x ∉ L(M)}`. -/
-instance : HasCompl (DFA α σ) where
+instance : Compl (DFA α σ) where
   compl M := ⟨M.step, M.start, M.acceptᶜ⟩
 
 theorem compl_def : Mᶜ = ⟨M.step, M.start, M.acceptᶜ⟩ :=

--- a/Mathlib/Data/Fintype/Defs.lean
+++ b/Mathlib/Data/Fintype/Defs.lean
@@ -181,7 +181,7 @@ to show the domain type when the filter is over `Finset.univ`. -/
     else
       `({$i:ident | $p})
   -- check if `t` is of the form `s₀ᶜ`, in which case we display `x ∉ s₀` instead
-  else if t.isAppOfArity ``HasCompl.compl 3 then
+  else if t.isAppOfArity ``Compl.compl 3 then
     let #[_, _, s₀] := t.getAppArgs | failure
     -- if `s₀` is a singleton, we can even use the notation `x ≠ a`
     if s₀.isAppOfArity ``Singleton.singleton 4 then

--- a/Mathlib/Data/Set/Image.lean
+++ b/Mathlib/Data/Set/Image.lean
@@ -275,13 +275,13 @@ theorem image_eq_empty {α β} {f : α → β} {s : Set α} : f '' s = ∅ ↔ s
   exact ⟨fun H a ha => H _ ⟨_, ha, rfl⟩, fun H b ⟨_, ha, _⟩ => H _ ha⟩
 
 theorem preimage_compl_eq_image_compl [BooleanAlgebra α] (s : Set α) :
-    HasCompl.compl ⁻¹' s = HasCompl.compl '' s :=
+    Compl.compl ⁻¹' s = Compl.compl '' s :=
   Set.ext fun x =>
     ⟨fun h => ⟨xᶜ, h, compl_compl x⟩, fun h =>
       Exists.elim h fun _ hy => (compl_eq_comm.mp hy.2).symm.subst hy.1⟩
 
 theorem mem_compl_image [BooleanAlgebra α] (t : α) (s : Set α) :
-    t ∈ HasCompl.compl '' s ↔ tᶜ ∈ s := by
+    t ∈ Compl.compl '' s ↔ tᶜ ∈ s := by
   simp [← preimage_compl_eq_image_compl]
 
 @[simp]
@@ -301,7 +301,7 @@ lemma image_iterate_eq {f : α → α} {n : ℕ} : image (f^[n]) = (image f)^[n]
   | succ n ih => rw [iterate_succ', iterate_succ', ← ih, image_comp_eq]
 
 theorem compl_compl_image [BooleanAlgebra α] (s : Set α) :
-    HasCompl.compl '' (HasCompl.compl '' s) = s := by
+    Compl.compl '' (Compl.compl '' s) = s := by
   rw [← image_comp, compl_comp_compl, image_id]
 
 theorem image_insert_eq {f : α → β} {a : α} {s : Set α} :

--- a/Mathlib/Data/Set/Operations.lean
+++ b/Mathlib/Data/Set/Operations.lean
@@ -98,7 +98,7 @@ theorem mem_univ (x : α) : x ∈ @univ α := trivial
 
 /-! ### Operations -/
 
-instance : HasCompl (Set α) := ⟨fun s ↦ {x | x ∉ s}⟩
+instance : Compl (Set α) := ⟨fun s ↦ {x | x ∉ s}⟩
 
 @[simp, grind =]
 theorem mem_compl_iff (s : Set α) (x : α) : x ∈ sᶜ ↔ x ∉ s := Iff.rfl

--- a/Mathlib/GroupTheory/GroupAction/SubMulAction.lean
+++ b/Mathlib/GroupTheory/GroupAction/SubMulAction.lean
@@ -453,7 +453,7 @@ theorem stabilizer_of_subMul {p : SubMulAction R M} (m : p) :
 
 /-- SubMulAction on the complement of an invariant subset -/
 @[to_additive /-- SubAddAction on the complement of an invariant subset -/]
-instance : HasCompl (SubMulAction R M) where
+instance : Compl (SubMulAction R M) where
   compl s := ⟨sᶜ, by simp⟩
 
 @[to_additive]

--- a/Mathlib/MeasureTheory/MeasurableSpace/MeasurablyGenerated.lean
+++ b/Mathlib/MeasureTheory/MeasurableSpace/MeasurablyGenerated.lean
@@ -217,7 +217,7 @@ instance Subtype.instLawfulSingleton [MeasurableSingletonClass α] :
     LawfulSingleton α (Subtype (MeasurableSet : Set α → Prop)) :=
   ⟨fun _ => Subtype.ext <| insert_empty_eq _⟩
 
-instance Subtype.instHasCompl : Compl (Subtype (MeasurableSet : Set α → Prop)) :=
+instance Subtype.instCompl : Compl (Subtype (MeasurableSet : Set α → Prop)) :=
   ⟨fun x => ⟨xᶜ, x.prop.compl⟩⟩
 
 @[simp]

--- a/Mathlib/MeasureTheory/MeasurableSpace/MeasurablyGenerated.lean
+++ b/Mathlib/MeasureTheory/MeasurableSpace/MeasurablyGenerated.lean
@@ -217,7 +217,7 @@ instance Subtype.instLawfulSingleton [MeasurableSingletonClass α] :
     LawfulSingleton α (Subtype (MeasurableSet : Set α → Prop)) :=
   ⟨fun _ => Subtype.ext <| insert_empty_eq _⟩
 
-instance Subtype.instHasCompl : HasCompl (Subtype (MeasurableSet : Set α → Prop)) :=
+instance Subtype.instHasCompl : Compl (Subtype (MeasurableSet : Set α → Prop)) :=
   ⟨fun x => ⟨xᶜ, x.prop.compl⟩⟩
 
 @[simp]

--- a/Mathlib/ModelTheory/Definability.lean
+++ b/Mathlib/ModelTheory/Definability.lean
@@ -307,7 +307,7 @@ instance instSup : Max (L.DefinableSet A α) :=
 instance instInf : Min (L.DefinableSet A α) :=
   ⟨fun s t => ⟨s ∩ t, s.2.inter t.2⟩⟩
 
-instance instHasCompl : Compl (L.DefinableSet A α) :=
+instance instCompl : Compl (L.DefinableSet A α) :=
   ⟨fun s => ⟨sᶜ, s.2.compl⟩⟩
 
 instance instSDiff : SDiff (L.DefinableSet A α) :=

--- a/Mathlib/ModelTheory/Definability.lean
+++ b/Mathlib/ModelTheory/Definability.lean
@@ -307,7 +307,7 @@ instance instSup : Max (L.DefinableSet A α) :=
 instance instInf : Min (L.DefinableSet A α) :=
   ⟨fun s t => ⟨s ∩ t, s.2.inter t.2⟩⟩
 
-instance instHasCompl : HasCompl (L.DefinableSet A α) :=
+instance instHasCompl : Compl (L.DefinableSet A α) :=
   ⟨fun s => ⟨sᶜ, s.2.compl⟩⟩
 
 instance instSDiff : SDiff (L.DefinableSet A α) :=

--- a/Mathlib/Order/Basic.lean
+++ b/Mathlib/Order/Basic.lean
@@ -582,22 +582,22 @@ theorem instLinearOrder.dual_dual (α : Type*) [H : LinearOrder α] :
 
 end OrderDual
 
-/-! ### `HasCompl` -/
+/-! ### `Compl` -/
 
 
-instance Prop.instCompl : HasCompl Prop :=
+instance Prop.instCompl : Compl Prop :=
   ⟨Not⟩
 
-instance Pi.instCompl [∀ i, HasCompl (π i)] : HasCompl (∀ i, π i) :=
+instance Pi.instCompl [∀ i, Compl (π i)] : Compl (∀ i, π i) :=
   ⟨fun x i ↦ (x i)ᶜ⟩
 
 @[push ←]
-theorem Pi.compl_def [∀ i, HasCompl (π i)] (x : ∀ i, π i) :
+theorem Pi.compl_def [∀ i, Compl (π i)] (x : ∀ i, π i) :
     xᶜ = fun i ↦ (x i)ᶜ :=
   rfl
 
 @[simp]
-theorem Pi.compl_apply [∀ i, HasCompl (π i)] (x : ∀ i, π i) (i : ι) :
+theorem Pi.compl_apply [∀ i, Compl (π i)] (x : ∀ i, π i) (i : ι) :
     xᶜ i = (x i)ᶜ :=
   rfl
 

--- a/Mathlib/Order/Basic.lean
+++ b/Mathlib/Order/Basic.lean
@@ -585,10 +585,10 @@ end OrderDual
 /-! ### `HasCompl` -/
 
 
-instance Prop.hasCompl : HasCompl Prop :=
+instance Prop.instCompl : HasCompl Prop :=
   ⟨Not⟩
 
-instance Pi.hasCompl [∀ i, HasCompl (π i)] : HasCompl (∀ i, π i) :=
+instance Pi.instCompl [∀ i, HasCompl (π i)] : HasCompl (∀ i, π i) :=
   ⟨fun x i ↦ (x i)ᶜ⟩
 
 @[push ←]

--- a/Mathlib/Order/BooleanAlgebra/Basic.lean
+++ b/Mathlib/Order/BooleanAlgebra/Basic.lean
@@ -630,7 +630,7 @@ protected abbrev Function.Injective.generalizedBooleanAlgebra [Max α] [Min α] 
 
 -- See note [reducible non-instances]
 /-- Pullback a `BooleanAlgebra` along an injection. -/
-protected abbrev Function.Injective.booleanAlgebra [Max α] [Min α] [Top α] [Bot α] [HasCompl α]
+protected abbrev Function.Injective.booleanAlgebra [Max α] [Min α] [Top α] [Bot α] [Compl α]
     [SDiff α] [HImp α] [BooleanAlgebra β] (f : α → β) (hf : Injective f)
     (map_sup : ∀ a b, f (a ⊔ b) = f a ⊔ f b) (map_inf : ∀ a b, f (a ⊓ b) = f a ⊓ f b)
     (map_top : f ⊤ = ⊤) (map_bot : f ⊥ = ⊥) (map_compl : ∀ a, f aᶜ = (f a)ᶜ)

--- a/Mathlib/Order/BooleanAlgebra/Defs.lean
+++ b/Mathlib/Order/BooleanAlgebra/Defs.lean
@@ -100,7 +100,7 @@ Instead, we extend using the underlying `Bot` and `Top` data typeclasses, and re
 order axioms of those classes here. A "forgetful" instance back to `BoundedOrder` is provided.
 -/
 class BooleanAlgebra (α : Type u) extends
-    DistribLattice α, HasCompl α, SDiff α, HImp α, Top α, Bot α where
+    DistribLattice α, Compl α, SDiff α, HImp α, Top α, Bot α where
   /-- The infimum of `x` and `xᶜ` is at most `⊥` -/
   inf_compl_le_bot : ∀ x : α, x ⊓ xᶜ ≤ ⊥
   /-- The supremum of `x` and `xᶜ` is at least `⊤` -/
@@ -141,7 +141,7 @@ theorem Bool.sup_eq_bor : (· ⊔ ·) = or := by dsimp
 theorem Bool.inf_eq_band : (· ⊓ ·) = and := by dsimp
 
 @[simp]
-theorem Bool.compl_eq_bnot : HasCompl.compl = not :=
+theorem Bool.compl_eq_bnot : Compl.compl = not :=
   rfl
 
 instance PUnit.instBooleanAlgebra : BooleanAlgebra PUnit where

--- a/Mathlib/Order/BooleanSubalgebra.lean
+++ b/Mathlib/Order/BooleanSubalgebra.lean
@@ -91,7 +91,7 @@ instance instSupCoe : Max L where max a b := ⟨a ⊔ b, L.supClosed a.2 b.2⟩
 instance instInfCoe : Min L where min a b := ⟨a ⊓ b, L.infClosed a.2 b.2⟩
 
 /-- A Boolean subalgebra of a lattice inherits a complement. -/
-instance instHasComplCoe : HasCompl L where compl a := ⟨aᶜ, compl_mem a.2⟩
+instance instHasComplCoe : Compl L where compl a := ⟨aᶜ, compl_mem a.2⟩
 
 /-- A Boolean subalgebra of a lattice inherits a difference. -/
 instance instSDiffCoe : SDiff L where sdiff a b := ⟨a \ b, sdiff_mem a.2 b.2⟩

--- a/Mathlib/Order/BooleanSubalgebra.lean
+++ b/Mathlib/Order/BooleanSubalgebra.lean
@@ -91,7 +91,7 @@ instance instSupCoe : Max L where max a b := ⟨a ⊔ b, L.supClosed a.2 b.2⟩
 instance instInfCoe : Min L where min a b := ⟨a ⊓ b, L.infClosed a.2 b.2⟩
 
 /-- A Boolean subalgebra of a lattice inherits a complement. -/
-instance instHasComplCoe : Compl L where compl a := ⟨aᶜ, compl_mem a.2⟩
+instance instComplCoe : Compl L where compl a := ⟨aᶜ, compl_mem a.2⟩
 
 /-- A Boolean subalgebra of a lattice inherits a difference. -/
 instance instSDiffCoe : SDiff L where sdiff a b := ⟨a \ b, sdiff_mem a.2 b.2⟩

--- a/Mathlib/Order/Booleanisation.lean
+++ b/Mathlib/Order/Booleanisation.lean
@@ -55,7 +55,7 @@ algebra. -/
 @[match_pattern] def comp : α → Booleanisation α := Sum.inr
 
 /-- The complement operator on `Booleanisation α` sends `a` to `aᶜ` and `aᶜ` to `a`, for `a : α`. -/
-instance instCompl : HasCompl (Booleanisation α) where
+instance instCompl : Compl (Booleanisation α) where
   compl
     | lift a => comp a
     | comp a => lift a

--- a/Mathlib/Order/CompleteBooleanAlgebra.lean
+++ b/Mathlib/Order/CompleteBooleanAlgebra.lean
@@ -626,7 +626,7 @@ variable [CompleteBooleanAlgebra α] {s : Set α} {f : ι → α}
 theorem compl_iInf : (iInf f)ᶜ = ⨆ i, (f i)ᶜ :=
   le_antisymm
     (compl_le_of_compl_le <| le_iInf fun i => compl_le_of_compl_le <|
-      le_iSup (HasCompl.compl ∘ f) i)
+      le_iSup (Compl.compl ∘ f) i)
     (iSup_le fun _ => compl_le_compl <| iInf_le _ _)
 
 theorem compl_iSup : (iSup f)ᶜ = ⨅ i, (f i)ᶜ :=
@@ -636,10 +636,10 @@ theorem compl_sInf : (sInf s)ᶜ = ⨆ i ∈ s, iᶜ := by simp only [sInf_eq_iI
 
 theorem compl_sSup : (sSup s)ᶜ = ⨅ i ∈ s, iᶜ := by simp only [sSup_eq_iSup, compl_iSup]
 
-theorem compl_sInf' : (sInf s)ᶜ = sSup (HasCompl.compl '' s) :=
+theorem compl_sInf' : (sInf s)ᶜ = sSup (Compl.compl '' s) :=
   compl_sInf.trans sSup_image.symm
 
-theorem compl_sSup' : (sSup s)ᶜ = sInf (HasCompl.compl '' s) :=
+theorem compl_sSup' : (sSup s)ᶜ = sInf (Compl.compl '' s) :=
   compl_sSup.trans sInf_image.symm
 
 open scoped symmDiff in
@@ -731,7 +731,7 @@ protected abbrev Function.Injective.coframeMinimalAxioms [Max α] [Min α] [SupS
 -- See note [reducible non-instances]
 /-- Pullback an `Order.Frame` along an injection. -/
 protected abbrev Function.Injective.frame [Max α] [Min α] [SupSet α] [InfSet α] [Top α] [Bot α]
-    [HasCompl α] [HImp α] [Frame β] (f : α → β) (hf : Injective f)
+    [Compl α] [HImp α] [Frame β] (f : α → β) (hf : Injective f)
     (map_sup : ∀ a b, f (a ⊔ b) = f a ⊔ f b) (map_inf : ∀ a b, f (a ⊓ b) = f a ⊓ f b)
     (map_sSup : ∀ s, f (sSup s) = ⨆ a ∈ s, f a) (map_sInf : ∀ s, f (sInf s) = ⨅ a ∈ s, f a)
     (map_top : f ⊤ = ⊤) (map_bot : f ⊥ = ⊥) (map_compl : ∀ a, f aᶜ = (f a)ᶜ)
@@ -768,7 +768,7 @@ protected abbrev Function.Injective.completeDistribLatticeMinimalAxioms [Max α]
 -- See note [reducible non-instances]
 /-- Pullback a `CompleteDistribLattice` along an injection. -/
 protected abbrev Function.Injective.completeDistribLattice [Max α] [Min α] [SupSet α] [InfSet α]
-    [Top α] [Bot α] [HasCompl α] [HImp α] [HNot α] [SDiff α] [CompleteDistribLattice β] (f : α → β)
+    [Top α] [Bot α] [Compl α] [HImp α] [HNot α] [SDiff α] [CompleteDistribLattice β] (f : α → β)
     (hf : Injective f)
     (map_sup : ∀ a b, f (a ⊔ b) = f a ⊔ f b) (map_inf : ∀ a b, f (a ⊓ b) = f a ⊓ f b)
     (map_sSup : ∀ s, f (sSup s) = ⨆ a ∈ s, f a) (map_sInf : ∀ s, f (sInf s) = ⨅ a ∈ s, f a)
@@ -800,7 +800,7 @@ protected abbrev Function.Injective.completelyDistribLatticeMinimalAxioms [Max �
 -- See note [reducible non-instances]
 /-- Pullback a `CompletelyDistribLattice` along an injection. -/
 protected abbrev Function.Injective.completelyDistribLattice [Max α] [Min α] [SupSet α] [InfSet α]
-    [Top α] [Bot α] [HasCompl α] [HImp α] [HNot α] [SDiff α] [CompletelyDistribLattice β]
+    [Top α] [Bot α] [Compl α] [HImp α] [HNot α] [SDiff α] [CompletelyDistribLattice β]
     (f : α → β) (hf : Injective f)
     (map_sup : ∀ a b, f (a ⊔ b) = f a ⊔ f b) (map_inf : ∀ a b, f (a ⊓ b) = f a ⊓ f b)
     (map_sSup : ∀ s, f (sSup s) = ⨆ a ∈ s, f a) (map_sInf : ∀ s, f (sInf s) = ⨅ a ∈ s, f a)
@@ -817,7 +817,7 @@ protected abbrev Function.Injective.completelyDistribLattice [Max α] [Min α] [
 -- See note [reducible non-instances]
 /-- Pullback a `CompleteBooleanAlgebra` along an injection. -/
 protected abbrev Function.Injective.completeBooleanAlgebra [Max α] [Min α] [SupSet α] [InfSet α]
-    [Top α] [Bot α] [HasCompl α] [HImp α] [SDiff α] [CompleteBooleanAlgebra β] (f : α → β)
+    [Top α] [Bot α] [Compl α] [HImp α] [SDiff α] [CompleteBooleanAlgebra β] (f : α → β)
     (hf : Injective f) (map_sup : ∀ a b, f (a ⊔ b) = f a ⊔ f b)
     (map_inf : ∀ a b, f (a ⊓ b) = f a ⊓ f b) (map_sSup : ∀ s, f (sSup s) = ⨆ a ∈ s, f a)
     (map_sInf : ∀ s, f (sInf s) = ⨅ a ∈ s, f a) (map_top : f ⊤ = ⊤) (map_bot : f ⊥ = ⊥)
@@ -830,7 +830,7 @@ protected abbrev Function.Injective.completeBooleanAlgebra [Max α] [Min α] [Su
 -- See note [reducible non-instances]
 /-- Pullback a `CompleteAtomicBooleanAlgebra` along an injection. -/
 protected abbrev Function.Injective.completeAtomicBooleanAlgebra [Max α] [Min α] [SupSet α]
-    [InfSet α] [Top α] [Bot α] [HasCompl α] [HImp α] [HNot α] [SDiff α]
+    [InfSet α] [Top α] [Bot α] [Compl α] [HImp α] [HNot α] [SDiff α]
     [CompleteAtomicBooleanAlgebra β] (f : α → β) (hf : Injective f)
     (map_sup : ∀ a b, f (a ⊔ b) = f a ⊔ f b) (map_inf : ∀ a b, f (a ⊓ b) = f a ⊓ f b)
     (map_sSup : ∀ s, f (sSup s) = ⨆ a ∈ s, f a) (map_sInf : ∀ s, f (sInf s) = ⨅ a ∈ s, f a)

--- a/Mathlib/Order/Copy.lean
+++ b/Mathlib/Order/Copy.lean
@@ -115,7 +115,7 @@ def HeytingAlgebra.copy (c : HeytingAlgebra α)
     (sup : α → α → α) (eq_sup : sup = (by infer_instance : Max α).max)
     (inf : α → α → α) (eq_inf : inf = (by infer_instance : Min α).min)
     (himp : α → α → α) (eq_himp : himp = (by infer_instance : HImp α).himp)
-    (compl : α → α) (eq_compl : compl = (by infer_instance : HasCompl α).compl) :
+    (compl : α → α) (eq_compl : compl = (by infer_instance : Compl α).compl) :
     HeytingAlgebra α where
   toGeneralizedHeytingAlgebra := GeneralizedHeytingAlgebra.copy
     (@HeytingAlgebra.toGeneralizedHeytingAlgebra α c) le eq_le top eq_top sup eq_sup inf eq_inf himp
@@ -155,7 +155,7 @@ def BiheytingAlgebra.copy (c : BiheytingAlgebra α)
     (sdiff : α → α → α) (eq_sdiff : sdiff = (by infer_instance : SDiff α).sdiff)
     (hnot : α → α) (eq_hnot : hnot = (by infer_instance : HNot α).hnot)
     (himp : α → α → α) (eq_himp : himp = (by infer_instance : HImp α).himp)
-    (compl : α → α) (eq_compl : compl = (by infer_instance : HasCompl α).compl) :
+    (compl : α → α) (eq_compl : compl = (by infer_instance : Compl α).compl) :
     BiheytingAlgebra α where
   toHeytingAlgebra := HeytingAlgebra.copy (@BiheytingAlgebra.toHeytingAlgebra α c) le eq_le top
     eq_top bot eq_bot sup eq_sup inf eq_inf himp eq_himp compl eq_compl
@@ -193,7 +193,7 @@ def Frame.copy (c : Frame α) (le : α → α → Prop) (eq_le : le = (by infer_
     (sup : α → α → α) (eq_sup : sup = (by infer_instance : Max α).max)
     (inf : α → α → α) (eq_inf : inf = (by infer_instance : Min α).min)
     (himp : α → α → α) (eq_himp : himp = (by infer_instance : HImp α).himp)
-    (compl : α → α) (eq_compl : compl = (by infer_instance : HasCompl α).compl)
+    (compl : α → α) (eq_compl : compl = (by infer_instance : Compl α).compl)
     (sSup : Set α → α) (eq_sSup : sSup = (by infer_instance : SupSet α).sSup)
     (sInf : Set α → α) (eq_sInf : sInf = (by infer_instance : InfSet α).sInf) : Frame α where
   toCompleteLattice := CompleteLattice.copy (@Frame.toCompleteLattice α c)
@@ -228,7 +228,7 @@ def CompleteDistribLattice.copy (c : CompleteDistribLattice α)
     (sdiff : α → α → α) (eq_sdiff : sdiff = (by infer_instance : SDiff α).sdiff)
     (hnot : α → α) (eq_hnot : hnot = (by infer_instance : HNot α).hnot)
     (himp : α → α → α) (eq_himp : himp = (by infer_instance : HImp α).himp)
-    (compl : α → α) (eq_compl : compl = (by infer_instance : HasCompl α).compl)
+    (compl : α → α) (eq_compl : compl = (by infer_instance : Compl α).compl)
     (sSup : Set α → α) (eq_sSup : sSup = (by infer_instance : SupSet α).sSup)
     (sInf : Set α → α) (eq_sInf : sInf = (by infer_instance : InfSet α).sInf) :
     CompleteDistribLattice α where

--- a/Mathlib/Order/Heyting/Basic.lean
+++ b/Mathlib/Order/Heyting/Basic.lean
@@ -67,7 +67,7 @@ instance Prod.instHNot [HNot α] [HNot β] : HNot (α × β) :=
 instance Prod.instSDiff [SDiff α] [SDiff β] : SDiff (α × β) :=
   ⟨fun a b => (a.1 \ b.1, a.2 \ b.2)⟩
 
-instance Prod.instHasCompl [Compl α] [Compl β] : Compl (α × β) :=
+instance Prod.instCompl [Compl α] [Compl β] : Compl (α × β) :=
   ⟨fun a => (a.1ᶜ, a.2ᶜ)⟩
 
 end

--- a/Mathlib/Order/Heyting/Basic.lean
+++ b/Mathlib/Order/Heyting/Basic.lean
@@ -67,7 +67,7 @@ instance Prod.instHNot [HNot α] [HNot β] : HNot (α × β) :=
 instance Prod.instSDiff [SDiff α] [SDiff β] : SDiff (α × β) :=
   ⟨fun a b => (a.1 \ b.1, a.2 \ b.2)⟩
 
-instance Prod.instHasCompl [HasCompl α] [HasCompl β] : HasCompl (α × β) :=
+instance Prod.instHasCompl [Compl α] [Compl β] : Compl (α × β) :=
   ⟨fun a => (a.1ᶜ, a.2ᶜ)⟩
 
 end
@@ -97,11 +97,11 @@ theorem snd_sdiff [SDiff α] [SDiff β] (a b : α × β) : (a \ b).2 = a.2 \ b.2
   rfl
 
 @[simp]
-theorem fst_compl [HasCompl α] [HasCompl β] (a : α × β) : aᶜ.1 = a.1ᶜ :=
+theorem fst_compl [Compl α] [Compl β] (a : α × β) : aᶜ.1 = a.1ᶜ :=
   rfl
 
 @[simp]
-theorem snd_compl [HasCompl α] [HasCompl β] (a : α × β) : aᶜ.2 = a.2ᶜ :=
+theorem snd_compl [Compl α] [Compl β] (a : α × β) : aᶜ.2 = a.2ᶜ :=
   rfl
 
 namespace Pi
@@ -150,7 +150,7 @@ class GeneralizedCoheytingAlgebra (α : Type*) extends Lattice α, OrderBot α, 
 
 /-- A Heyting algebra is a bounded lattice with an additional binary operation `⇨` called Heyting
 implication such that `(a ⇨ ·)` is right adjoint to `(a ⊓ ·)`. -/
-class HeytingAlgebra (α : Type*) extends GeneralizedHeytingAlgebra α, OrderBot α, HasCompl α where
+class HeytingAlgebra (α : Type*) extends GeneralizedHeytingAlgebra α, OrderBot α, Compl α where
   /-- `aᶜ` is defined as `a ⇨ ⊥` -/
   himp_bot (a : α) : a ⇨ ⊥ = aᶜ
 
@@ -1025,13 +1025,13 @@ protected abbrev Function.Injective.generalizedCoheytingAlgebra [Max α] [Min α
 -- See note [reducible non-instances]
 /-- Pullback a `HeytingAlgebra` along an injection. -/
 protected abbrev Function.Injective.heytingAlgebra [Max α] [Min α] [Top α] [Bot α]
-    [HasCompl α] [HImp α] [HeytingAlgebra β] (f : α → β) (hf : Injective f)
+    [Compl α] [HImp α] [HeytingAlgebra β] (f : α → β) (hf : Injective f)
     (map_sup : ∀ a b, f (a ⊔ b) = f a ⊔ f b) (map_inf : ∀ a b, f (a ⊓ b) = f a ⊓ f b)
     (map_top : f ⊤ = ⊤) (map_bot : f ⊥ = ⊥) (map_compl : ∀ a, f aᶜ = (f a)ᶜ)
     (map_himp : ∀ a b, f (a ⇨ b) = f a ⇨ f b) : HeytingAlgebra α :=
   { __ := hf.generalizedHeytingAlgebra f map_sup map_inf map_top map_himp
     __ := ‹Bot α›
-    __ := ‹HasCompl α›
+    __ := ‹Compl α›
     bot_le := fun a => by
       change f _ ≤ _
       rw [map_bot]
@@ -1057,7 +1057,7 @@ protected abbrev Function.Injective.coheytingAlgebra [Max α] [Min α] [Top α] 
 -- See note [reducible non-instances]
 /-- Pullback a `BiheytingAlgebra` along an injection. -/
 protected abbrev Function.Injective.biheytingAlgebra [Max α] [Min α] [Top α] [Bot α]
-    [HasCompl α] [HNot α] [HImp α] [SDiff α] [BiheytingAlgebra β] (f : α → β)
+    [Compl α] [HNot α] [HImp α] [SDiff α] [BiheytingAlgebra β] (f : α → β)
     (hf : Injective f) (map_sup : ∀ a b, f (a ⊔ b) = f a ⊔ f b)
     (map_inf : ∀ a b, f (a ⊓ b) = f a ⊓ f b) (map_top : f ⊤ = ⊤) (map_bot : f ⊥ = ⊥)
     (map_compl : ∀ a, f aᶜ = (f a)ᶜ) (map_hnot : ∀ a, f (￢a) = ￢f a)

--- a/Mathlib/Order/Heyting/Regular.lean
+++ b/Mathlib/Order/Heyting/Regular.lean
@@ -38,9 +38,9 @@ variable {α : Type*}
 
 namespace Heyting
 
-section HasCompl
+section Compl
 
-variable [HasCompl α] {a : α}
+variable [Compl α] {a : α}
 
 /-- An element of a Heyting algebra is regular if its double complement is itself. -/
 def IsRegular (a : α) : Prop :=
@@ -52,7 +52,7 @@ protected theorem IsRegular.eq : IsRegular a → aᶜᶜ = a :=
 instance IsRegular.decidablePred [DecidableEq α] : @DecidablePred α IsRegular := fun _ =>
   ‹DecidableEq α› _ _
 
-end HasCompl
+end Compl
 
 section HeytingAlgebra
 
@@ -127,7 +127,7 @@ instance inf : Min (Regular α) :=
 instance himp : HImp (Regular α) :=
   ⟨fun a b => ⟨a ⇨ b, a.2.himp b.2⟩⟩
 
-instance : HasCompl (Regular α) :=
+instance : Compl (Regular α) :=
   ⟨fun a => ⟨aᶜ, isRegular_compl _⟩⟩
 
 @[simp, norm_cast]

--- a/Mathlib/Order/Heyting/Regular.lean
+++ b/Mathlib/Order/Heyting/Regular.lean
@@ -127,7 +127,7 @@ instance inf : Min (Regular α) :=
 instance himp : HImp (Regular α) :=
   ⟨fun a b => ⟨a ⇨ b, a.2.himp b.2⟩⟩
 
-instance hasCompl : HasCompl (Regular α) :=
+instance : HasCompl (Regular α) :=
   ⟨fun a => ⟨aᶜ, isRegular_compl _⟩⟩
 
 @[simp, norm_cast]
@@ -198,7 +198,7 @@ theorem coe_sup (a b : Regular α) : (↑(a ⊔ b) : α) = ((a : α) ⊔ b)ᶜ�
 
 instance : BooleanAlgebra (Regular α) :=
   { Regular.lattice, Regular.boundedOrder, Regular.himp,
-    Regular.hasCompl with
+    Regular.instCompl with
     le_sup_inf := fun a b c =>
       coe_le_coe.1 <| by
         dsimp

--- a/Mathlib/Order/Hom/Set.lean
+++ b/Mathlib/Order/Hom/Set.lean
@@ -216,8 +216,8 @@ variable (α) [BooleanAlgebra α]
 /-- Taking complements as an order isomorphism to the order dual. -/
 @[simps!]
 def OrderIso.compl : α ≃o αᵒᵈ where
-  toFun := OrderDual.toDual ∘ HasCompl.compl
-  invFun := HasCompl.compl ∘ OrderDual.ofDual
+  toFun := OrderDual.toDual ∘ Compl.compl
+  invFun := Compl.compl ∘ OrderDual.ofDual
   left_inv := compl_compl
   right_inv := compl_compl (α := αᵒᵈ)
   map_rel_iff' := compl_le_compl_iff_le

--- a/Mathlib/Order/Notation.lean
+++ b/Mathlib/Order/Notation.lean
@@ -18,7 +18,7 @@ In this file we introduce typeclasses and definitions for lattice operations.
 
 ## Main definitions
 
-* `HasCompl`: type class for the `ᶜ` notation
+* `Compl`: type class for the `ᶜ` notation
 * `Top`: type class for the `⊤` notation
 * `Bot`: type class for the `⊥` notation
 
@@ -41,11 +41,11 @@ Lemmas about the operators `⊔` and `⊓` should use the names `sup` and `inf` 
 
 /-- Set / lattice complement -/
 @[notation_class]
-class HasCompl (α : Type*) where
+class Compl (α : Type*) where
   /-- Set / lattice complement -/
   compl : α → α
 
-export HasCompl (compl)
+export Compl (compl)
 
 @[inherit_doc]
 postfix:1024 "ᶜ" => compl
@@ -137,7 +137,7 @@ class HImp (α : Type*) where
 
 /-- Syntax typeclass for Heyting negation `￢`.
 
-The difference between `HasCompl` and `HNot` is that the former belongs to Heyting algebras,
+The difference between `Compl` and `HNot` is that the former belongs to Heyting algebras,
 while the latter belongs to co-Heyting algebras. They are both pseudo-complements, but `compl`
 underestimates while `HNot` overestimates. In Boolean algebras, they are equal.
 See `hnot_eq_compl`.

--- a/Mathlib/Order/Notation.lean
+++ b/Mathlib/Order/Notation.lean
@@ -47,6 +47,14 @@ class Compl (α : Type*) where
 
 export Compl (compl)
 
+/-- Set / lattice complement -/
+@[deprecated Compl (since := "2026-01-04")]
+class HasCompl (α : Type*) where
+  /-- Set / lattice complement -/
+  compl : α → α
+
+attribute [deprecated Compl.compl (since := "2026-01-04")] HasCompl.compl
+
 @[inherit_doc]
 postfix:1024 "ᶜ" => compl
 

--- a/Mathlib/Order/ULift.lean
+++ b/Mathlib/Order/ULift.lean
@@ -59,10 +59,10 @@ instance [SDiff α] : SDiff (ULift.{v} α) where sdiff x y := up <| x.down \ y.d
 @[simp] theorem up_sdiff [SDiff α] (a b : α) : up (a \ b) = up a \ up b := rfl
 @[simp] theorem down_sdiff [SDiff α] (a b : ULift α) : down (a \ b) = down a \ down b := rfl
 
-instance [HasCompl α] : HasCompl (ULift.{v} α) where compl x := up <| x.downᶜ
+instance [Compl α] : Compl (ULift.{v} α) where compl x := up <| x.downᶜ
 
-@[simp] theorem up_compl [HasCompl α] (a : α) : up (aᶜ) = (up a)ᶜ := rfl
-@[simp] theorem down_compl [HasCompl α] (a : ULift α) : down aᶜ = (down a)ᶜ := rfl
+@[simp] theorem up_compl [Compl α] (a : α) : up (aᶜ) = (up a)ᶜ := rfl
+@[simp] theorem down_compl [Compl α] (a : ULift α) : down aᶜ = (down a)ᶜ := rfl
 
 instance [Ord α] [inst : Std.OrientedOrd α] : Std.OrientedOrd (ULift.{v} α) where
   eq_swap := inst.eq_swap

--- a/Mathlib/SetTheory/ZFC/Class.lean
+++ b/Mathlib/SetTheory/ZFC/Class.lean
@@ -33,7 +33,7 @@ practice, we treat it as (the definitionally equal) `ZFSet → Prop`. This means
 state that `x : ZFSet` belongs to `A : Class` is to write `A x`. -/
 @[pp_with_univ]
 def Class :=
-  Set ZFSet deriving HasSubset, EmptyCollection, Nonempty, Union, Inter, HasCompl, SDiff
+  Set ZFSet deriving HasSubset, EmptyCollection, Nonempty, Union, Inter, Compl, SDiff
 
 instance : Insert ZFSet Class :=
   ⟨Set.insert⟩

--- a/Mathlib/Topology/Sets/Closeds.lean
+++ b/Mathlib/Topology/Sets/Closeds.lean
@@ -336,7 +336,7 @@ instance : Top (Clopens α) := ⟨⟨⊤, isClopen_univ⟩⟩
 instance : Bot (Clopens α) := ⟨⟨⊥, isClopen_empty⟩⟩
 instance : SDiff (Clopens α) := ⟨fun s t => ⟨s \ t, s.isClopen.diff t.isClopen⟩⟩
 instance : HImp (Clopens α) where himp s t := ⟨s ⇨ t, s.isClopen.himp t.isClopen⟩
-instance : HasCompl (Clopens α) := ⟨fun s => ⟨sᶜ, s.isClopen.compl⟩⟩
+instance : Compl (Clopens α) := ⟨fun s => ⟨sᶜ, s.isClopen.compl⟩⟩
 
 @[simp, norm_cast] lemma coe_sup (s t : Clopens α) : ↑(s ⊔ t) = (s ∪ t : Set α) := rfl
 @[simp, norm_cast] lemma coe_inf (s t : Clopens α) : ↑(s ⊓ t) = (s ∩ t : Set α) := rfl

--- a/Mathlib/Topology/Sets/Compacts.lean
+++ b/Mathlib/Topology/Sets/Compacts.lean
@@ -723,7 +723,7 @@ instance instBoundedOrder : BoundedOrder (CompactOpens α) :=
 section Compl
 variable [T2Space α]
 
-instance instHasCompl : Compl (CompactOpens α) where
+instance instCompl : Compl (CompactOpens α) where
   compl s := ⟨⟨sᶜ, s.isOpen.isClosed_compl.isCompact⟩, s.isCompact.isClosed.isOpen_compl⟩
 
 instance instHImp : HImp (CompactOpens α) where

--- a/Mathlib/Topology/Sets/Compacts.lean
+++ b/Mathlib/Topology/Sets/Compacts.lean
@@ -723,7 +723,7 @@ instance instBoundedOrder : BoundedOrder (CompactOpens α) :=
 section Compl
 variable [T2Space α]
 
-instance instHasCompl : HasCompl (CompactOpens α) where
+instance instHasCompl : Compl (CompactOpens α) where
   compl s := ⟨⟨sᶜ, s.isOpen.isClosed_compl.isCompact⟩, s.isCompact.isClosed.isOpen_compl⟩
 
 instance instHImp : HImp (CompactOpens α) where

--- a/MathlibTest/Delab/FinsetBuilder.lean
+++ b/MathlibTest/Delab/FinsetBuilder.lean
@@ -1,7 +1,7 @@
 import Mathlib.Data.Fintype.Defs
 
 variable {α : Type*} [Fintype α] {p : α → Prop} {s : Finset α} {a : α}
-    [DecidablePred p] [DecidableEq α] [Singleton α (Finset α)] [HasCompl (Finset α)]
+    [DecidablePred p] [DecidableEq α] [Singleton α (Finset α)] [Compl (Finset α)]
 
 /-- info: {x | p x} : Finset α -/
 #guard_msgs in


### PR DESCRIPTION
This PR renames the `HasCompl` type class to `Compl`. This is consistent with all other notation classes, where the class name is the same as the operator name, but capitalized. (e.g. `HAdd.hAdd`, `Max.max`, `Bot.bot`).

This also helps the automatic name translation in `to_dual` generate dual names (`Compl` is dual to `HNot`).

---
<!-- Your PR title will become the first line of the commit message.

In this box, the text above the `---` (if not empty) will be appended
to the commit message, and can be used to give additional context or
details. Please leave a blank newline before the `---`, otherwise GitHub
will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

When merging, all the commits will be squashed into a single commit
listing all co-authors.

Co-authors in the squash commit are gathered from two sources:

First, all authors of commits to this PR branch are included. Thus,
one way to add co-authors is to include at least one commit authored by
each co-author among the commits in the pull request. If necessary, you
may create empty commits to indicate co-authorship, using commands like so:

git commit --author="Author Name <author@email.com>" --allow-empty -m "add Author Name as coauthor"

Second, co-authors can also be listed in lines at the very bottom of
the commit message (that is, directly before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines
at the bottom of the commit message (before the `---`, and also before
any "Co-authored-by" lines) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
