### PR TITLE
[Merged by Bors] - fix(CI): prevent empty grep pattern from matching all lean-pr-testing branches

### DIFF
--- a/.github/workflows/discover-lean-pr-testing.yml
+++ b/.github/workflows/discover-lean-pr-testing.yml
@@ -114,6 +114,17 @@ jobs:
         PRS="${{ steps.get-prs.outputs.prs }}"
         echo "=== PRS ========================="
         echo "$PRS"
+
+        # CRITICAL: If no PRs were found, skip branch matching entirely.
+        # An empty prs.txt causes `grep -f prs.txt` to match ALL lines,
+        # which would incorrectly select every lean-pr-testing branch!
+        if [ -z "$PRS" ]; then
+          echo "No PRs found between old and new nightlies. Skipping branch discovery."
+          echo "branches_exist=false" >> "$GITHUB_ENV"
+          printf "branches<<EOF\n\nEOF" >> "$GITHUB_OUTPUT"
+          exit 0
+        fi
+
         echo "$PRS" | tr ' ' '\n' > prs.txt
         echo "=== prs.txt ====================="
         cat prs.txt


### PR DESCRIPTION
When no PRs are found between old and new nightlies, the `prs.txt` file is empty. An empty pattern file causes `grep -f prs.txt` to match ALL lines, which incorrectly selects every `lean-pr-testing-*` branch for merging.

This caused a catastrophic failure on 2026-01-04 where the workflow attempted to merge 600+ old adaptation branches into nightly-testing, including branches for PRs that aren't even in the nightly (like lean-pr-testing-10387 from September 2025, and lean-pr-testing-2714 from October 2023!).

The fix checks if PRS is empty and exits early, setting `branches_exist=false`.

See workflow run: https://github.com/leanprover-community/mathlib4-nightly-testing/actions/runs/20690417192

🤖 Generated with [Claude Code](https://claude.com/claude-code)