### PR TITLE
[Merged by Bors] - feat: lemmas about `Matrix.single` and `diagonal` and `submatrix`

### DIFF
--- a/Mathlib/Data/Matrix/Basis.lean
+++ b/Mathlib/Data/Matrix/Basis.lean
@@ -102,6 +102,7 @@ theorem diagonal_single (i : m) (r : α) :
   dsimp [diagonal, single]
   grind
 
+@[simp]
 theorem submatrix_single_equiv
     (f : l ≃ n) (g : m ≃ o) (i : n) (j : o) (r : α) :
     (single i j r).submatrix f g = single (f.symm i) (g.symm j) r := by

--- a/Mathlib/Data/Matrix/Basis.lean
+++ b/Mathlib/Data/Matrix/Basis.lean
@@ -34,6 +34,26 @@ and zeroes elsewhere.
 def single (i : m) (j : n) (a : α) : Matrix m n α :=
   of <| fun i' j' => if i = i' ∧ j = j' then a else 0
 
+section
+variable (i : m) (j : n) (c : α) (i' : m) (j' : n)
+
+@[simp]
+theorem single_apply_same : single i j c i j = c :=
+  if_pos (And.intro rfl rfl)
+
+@[simp]
+theorem single_apply_of_ne (h : ¬(i = i' ∧ j = j')) : single i j c i' j' = 0 := by
+  simp only [single, and_imp, ite_eq_right_iff, of_apply]
+  tauto
+
+theorem single_apply_of_row_ne {i i' : m} (hi : i ≠ i') (j j' : n) (a : α) :
+    single i j a i' j' = 0 := by simp [hi]
+
+theorem single_apply_of_col_ne (i i' : m) {j j' : n} (hj : j ≠ j') (a : α) :
+    single i j a i' j' = 0 := by simp [hj]
+
+end
+
 /-- See also `single_eq_updateRow_zero` and `single_eq_updateCol_zero`. -/
 theorem single_eq_of_single_single (i : m) (j : n) (a : α) :
     single i j a = Matrix.of (Pi.single i (Pi.single j a)) := by
@@ -75,6 +95,25 @@ theorem single_mem_matrix {S : Set α} (hS : 0 ∈ S) {i : m} {j : n} {a : α} :
   simp only [Set.mem_matrix, single, of_apply]
   conv_lhs => intro _ _; rw [ite_mem]
   simp [hS]
+
+theorem diagonal_single (i : m) (r : α) :
+    diagonal (Pi.single i r) = single i i r := by
+  ext j k
+  dsimp [diagonal, single]
+  grind
+
+theorem submatrix_single_equiv
+    (f : l ≃ n) (g : m ≃ o) (i : n) (j : o) (r : α) :
+    (single i j r).submatrix f g = single (f.symm i) (g.symm j) r := by
+  ext i' j'
+  dsimp
+  obtain hi | rfl := ne_or_eq (f.symm i) i'
+  · rw [single_apply_of_row_ne hi, single_apply_of_row_ne]
+    exact f.symm_apply_eq.not.1 hi
+  obtain hj | rfl := ne_or_eq (g.symm j) j'
+  · rw [single_apply_of_col_ne _ _ hj, single_apply_of_col_ne]
+    exact g.symm_apply_eq.not.1 hj
+  simp
 
 end Zero
 
@@ -210,27 +249,6 @@ theorem liftLinear_singleLinearMap [Module S α] [SMulCommClass R S α] :
 end liftLinear
 
 end ext
-
-section
-
-variable [Zero α] (i : m) (j : n) (c : α) (i' : m) (j' : n)
-
-@[simp]
-theorem single_apply_same : single i j c i j = c :=
-  if_pos (And.intro rfl rfl)
-
-@[simp]
-theorem single_apply_of_ne (h : ¬(i = i' ∧ j = j')) : single i j c i' j' = 0 := by
-  simp only [single, and_imp, ite_eq_right_iff, of_apply]
-  tauto
-
-theorem single_apply_of_row_ne {i i' : m} (hi : i ≠ i') (j j' : n) (a : α) :
-    single i j a i' j' = 0 := by simp [hi]
-
-theorem single_apply_of_col_ne (i i' : m) {j j' : n} (hj : j ≠ j') (a : α) :
-    single i j a i' j' = 0 := by simp [hj]
-
-end
 
 section
 variable [Zero α] (i j : n) (c : α)


### PR DESCRIPTION
This also moves some very basic API lemmas higher up the file.

---
<!-- Your PR title will become the first line of the commit message.

In this box, the text above the `---` (if not empty) will be appended
to the commit message, and can be used to give additional context or
details. Please leave a blank newline before the `---`, otherwise GitHub
will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

When merging, all the commits will be squashed into a single commit
listing all co-authors.

Co-authors in the squash commit are gathered from two sources:

First, all authors of commits to this PR branch are included. Thus,
one way to add co-authors is to include at least one commit authored by
each co-author among the commits in the pull request. If necessary, you
may create empty commits to indicate co-authorship, using commands like so:

git commit --author="Author Name <author@email.com>" --allow-empty -m "add Author Name as coauthor"

Second, co-authors can also be listed in lines at the very bottom of
the commit message (that is, directly before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines
at the bottom of the commit message (before the `---`, and also before
any "Co-authored-by" lines) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
