### PR TITLE
[Merged by Bors] - feat(RingTheory): standard smooth = etale over mvpolynomial

### DIFF
--- a/Mathlib/Algebra/MvPolynomial/Equiv.lean
+++ b/Mathlib/Algebra/MvPolynomial/Equiv.lean
@@ -291,6 +291,12 @@ def sumRingEquiv : MvPolynomial (S₁ ⊕ S₂) R ≃+* MvPolynomial S₁ (MvPol
   · ext1; simp only [RingHom.comp_apply, sumToIter_C, iterToSum_C_C]
   · rintro ⟨⟩ <;> simp only [sumToIter_Xl, iterToSum_X, sumToIter_Xr, iterToSum_C_X]
 
+@[simp] lemma iterToSum_sumToIter (p) :
+    iterToSum R S₁ S₂ (sumToIter R S₁ S₂ p) = p := (sumRingEquiv _ _ _).symm_apply_apply _
+
+@[simp] lemma sumToIter_iterToSum (p) :
+    sumToIter R S₁ S₂ (iterToSum R S₁ S₂ p) = p := (sumRingEquiv _ _ _).apply_symm_apply _
+
 /-- The algebra isomorphism between multivariable polynomials in a sum of two types,
 and multivariable polynomials in one of the types,
 with coefficients in multivariable polynomials in the other type.

--- a/Mathlib/Algebra/MvPolynomial/PDeriv.lean
+++ b/Mathlib/Algebra/MvPolynomial/PDeriv.lean
@@ -6,7 +6,7 @@ Authors: Shing Tak Lam, Yury Kudryashov
 module
 
 public import Mathlib.Algebra.MvPolynomial.Derivation
-public import Mathlib.Algebra.MvPolynomial.Variables
+public import Mathlib.Algebra.MvPolynomial.Equiv
 
 /-!
 # Partial derivatives of polynomials
@@ -148,6 +148,14 @@ lemma aeval_sumElim_pderiv_inl {S τ : Type*} [CommRing S] [Algebra R S]
   | mul_X p q h =>
     simp only [Derivation.leibniz, pderiv_X, smul_eq_mul, map_add, map_mul, aeval_X, h]
     cases q <;> simp [Pi.single_apply]
+
+lemma pderiv_sumToIter {σ ι} (p i) :
+    (sumToIter R σ ι p).pderiv i = sumToIter R σ ι (p.pderiv (.inl i)) := by
+  classical
+  induction p using MvPolynomial.induction_on with
+  | C a => simp
+  | add p q _ _ => simp_all
+  | mul_X p n _ => cases n <;> simp_all [pderiv_X, Pi.single_apply, apply_ite]
 
 end PDeriv
 

--- a/Mathlib/RingTheory/RingHom/StandardSmooth.lean
+++ b/Mathlib/RingTheory/RingHom/StandardSmooth.lean
@@ -6,7 +6,8 @@ Authors: Christian Merten
 module
 
 public import Mathlib.RingTheory.LocalProperties.Basic
-public import Mathlib.RingTheory.Smooth.StandardSmooth
+public import Mathlib.RingTheory.RingHom.Etale
+public import Mathlib.RingTheory.Smooth.StandardSmoothOfFree
 public import Mathlib.Tactic.Algebraize
 
 /-!
@@ -182,5 +183,67 @@ lemma isStandardSmoothOfRelativeDimension_stableUnderCompositionWithLocalization
     have : (algebraMap S T).IsStandardSmoothOfRelativeDimension 0 :=
       IsStandardSmoothOfRelativeDimension.algebraMap_isLocalizationAway s
     zero_add n ▸ IsStandardSmoothOfRelativeDimension.comp this hf
+
+/-- Every standard smooth homomorphism `R → S` factors into `R -> R[X₁,...,Xₙ] → S`
+where `n` is the relative dimension and `R[X₁,...,Xₙ] → S` is etale. -/
+theorem IsStandardSmoothOfRelativeDimension.exists_etale_mvPolynomial
+    {f : R →+* S} {n : ℕ} (hf : f.IsStandardSmoothOfRelativeDimension n) :
+    ∃ g : MvPolynomial (Fin n) R →+* S, g.comp MvPolynomial.C = f ∧ g.Etale := by
+  classical
+  let := Fintype.ofFinite
+  obtain ⟨ι, σ, _, _, P, e⟩ := hf
+  let := f.toAlgebra
+  let e₀ : σ ⊕ Fin n ≃ ι := ((Equiv.ofInjective _ P.map_inj).sumCongr
+      (Finite.equivFinOfCardEq (by rw [Nat.card_coe_set_eq, Set.ncard_compl,
+        Set.ncard_range_of_injective P.map_inj, ← e, Algebra.Presentation.dimension])).symm).trans
+      (Equiv.Set.sumCompl _)
+  let e : MvPolynomial σ (MvPolynomial (Fin n) R) ≃ₐ[R] P.Ring :=
+    (MvPolynomial.sumAlgEquiv R _ _).symm.trans (MvPolynomial.renameEquiv _ e₀)
+  let φ := e.toAlgHom.comp (IsScalarTower.toAlgHom _ (MvPolynomial (Fin n) R) _)
+  algebraize [φ.toRingHom, (algebraMap P.Ring S).comp φ.toRingHom]
+  have := IsScalarTower.of_algebraMap_eq' φ.comp_algebraMap.symm
+  have : IsScalarTower R (MvPolynomial (Fin n) R) S := .to₁₂₄ _ _ P.Ring _
+  refine ⟨algebraMap _ _, (IsScalarTower.algebraMap_eq ..).symm, ?_⟩
+  have H : (MvPolynomial.aeval fun x ↦ (algebraMap P.Ring S) (e (MvPolynomial.X x))).toRingHom =
+      (algebraMap P.Ring S).comp e.toRingHom := by
+    ext
+    · simp [e, IsScalarTower.algebraMap_eq R (MvPolynomial (Fin n) R) S]
+    · simp [e, @RingHom.algebraMap_toAlgebra (MvPolynomial (Fin n) R) S, φ]
+    · simp [e]
+  let P' : Algebra.PreSubmersivePresentation (MvPolynomial (Fin n) R) S σ σ :=
+  { toGenerators := .ofSurjective (algebraMap _ _ <| e <| .X ·) <| by
+      convert P.algebraMap_surjective.comp e.surjective
+      exact congr($H)
+    relation := e.symm ∘ P.relation
+    span_range_relation_eq_ker := by
+      rw [Set.range_comp, ← AlgEquiv.coe_ringEquiv e.symm, AlgEquiv.symm_toRingEquiv,
+        ← Ideal.map_span, P.span_range_relation_eq_ker, Ideal.map_symm]
+      exact congr(RingHom.ker $H).symm
+    map := _
+    map_inj := Function.injective_id }
+  let P' : Algebra.SubmersivePresentation (MvPolynomial (Fin n) R) S σ σ :=
+  { __ := P'
+    jacobian_isUnit := by
+      convert P.jacobian_isUnit using 1
+      simp_rw [Algebra.PreSubmersivePresentation.jacobian_eq_jacobiMatrix_det, map_det]
+      congr 1
+      ext i j
+      trans algebraMap P.Ring S (e ((e.symm (P.relation j)).pderiv i))
+      · simpa [Algebra.PreSubmersivePresentation.jacobiMatrix_apply, P',
+          Algebra.Generators.ofSurjective] using congr($H _)
+      suffices e ((e.symm (P.relation j)).pderiv i) = (P.relation j).pderiv (P.map i) by
+        simp [Algebra.PreSubmersivePresentation.jacobiMatrix_apply, this]
+      simp [e, MvPolynomial.pderiv_sumToIter, ← MvPolynomial.pderiv_rename e₀.injective,
+        show e₀ (Sum.inl i) = P.map i from rfl] }
+  exact etale_algebraMap.mpr (Algebra.Etale.iff_isStandardSmoothOfRelativeDimension_zero.mpr
+    ⟨_, _, _, inferInstance, P', by simp [Algebra.Presentation.dimension]⟩)
+
+theorem IsStandardSmooth.exists_etale_mvPolynomial
+    {f : R →+* S} (hf : f.IsStandardSmooth) :
+    ∃ n, ∃ g : MvPolynomial (Fin n) R →+* S, g.comp MvPolynomial.C = f ∧ g.Etale := by
+  obtain ⟨_, _, _, _, ⟨P⟩⟩ := hf
+  let := f.toAlgebra
+  exact ⟨_, RingHom.IsStandardSmoothOfRelativeDimension.exists_etale_mvPolynomial
+    ⟨_, _, _, ‹_›, P, rfl⟩⟩
 
 end RingHom

--- a/Mathlib/RingTheory/RingHom/StandardSmooth.lean
+++ b/Mathlib/RingTheory/RingHom/StandardSmooth.lean
@@ -184,15 +184,16 @@ lemma isStandardSmoothOfRelativeDimension_stableUnderCompositionWithLocalization
       IsStandardSmoothOfRelativeDimension.algebraMap_isLocalizationAway s
     zero_add n ▸ IsStandardSmoothOfRelativeDimension.comp this hf
 
+variable (R S) in
 /-- Every standard smooth homomorphism `R → S` factors into `R -> R[X₁,...,Xₙ] → S`
 where `n` is the relative dimension and `R[X₁,...,Xₙ] → S` is etale. -/
-theorem IsStandardSmoothOfRelativeDimension.exists_etale_mvPolynomial
-    {f : R →+* S} {n : ℕ} (hf : f.IsStandardSmoothOfRelativeDimension n) :
-    ∃ g : MvPolynomial (Fin n) R →+* S, g.comp MvPolynomial.C = f ∧ g.Etale := by
+theorem _root_.Algebra.IsStandardSmoothOfRelativeDimension.exists_etale_mvPolynomial
+    [Algebra R S] [Algebra.IsStandardSmoothOfRelativeDimension n R S] :
+    ∃ g : MvPolynomial (Fin n) R →ₐ[R] S, g.Etale := by
   classical
   let := Fintype.ofFinite
-  obtain ⟨ι, σ, _, _, P, e⟩ := hf
-  let := f.toAlgebra
+  obtain ⟨ι, σ, _, _, P, e⟩ :=
+    Algebra.IsStandardSmoothOfRelativeDimension.out (R := R) (S := S) (n := n)
   let e₀ : σ ⊕ Fin n ≃ ι := ((Equiv.ofInjective _ P.map_inj).sumCongr
       (Finite.equivFinOfCardEq (by rw [Nat.card_coe_set_eq, Set.ncard_compl,
         Set.ncard_range_of_injective P.map_inj, ← e, Algebra.Presentation.dimension])).symm).trans
@@ -203,7 +204,7 @@ theorem IsStandardSmoothOfRelativeDimension.exists_etale_mvPolynomial
   algebraize [φ.toRingHom, (algebraMap P.Ring S).comp φ.toRingHom]
   have := IsScalarTower.of_algebraMap_eq' φ.comp_algebraMap.symm
   have : IsScalarTower R (MvPolynomial (Fin n) R) S := .to₁₂₄ _ _ P.Ring _
-  refine ⟨algebraMap _ _, (IsScalarTower.algebraMap_eq ..).symm, ?_⟩
+  refine ⟨IsScalarTower.toAlgHom _ _ _, ?_⟩
   have H : (MvPolynomial.aeval fun x ↦ (algebraMap P.Ring S) (e (MvPolynomial.X x))).toRingHom =
       (algebraMap P.Ring S).comp e.toRingHom := by
     ext
@@ -237,6 +238,16 @@ theorem IsStandardSmoothOfRelativeDimension.exists_etale_mvPolynomial
         show e₀ (Sum.inl i) = P.map i from rfl] }
   exact etale_algebraMap.mpr (Algebra.Etale.iff_isStandardSmoothOfRelativeDimension_zero.mpr
     ⟨_, _, _, inferInstance, P', by simp [Algebra.Presentation.dimension]⟩)
+
+/-- Every standard smooth homomorphism `R → S` factors into `R -> R[X₁,...,Xₙ] → S`
+where `n` is the relative dimension and `R[X₁,...,Xₙ] → S` is etale. -/
+theorem IsStandardSmoothOfRelativeDimension.exists_etale_mvPolynomial
+    {f : R →+* S} {n : ℕ} (hf : f.IsStandardSmoothOfRelativeDimension n) :
+    ∃ g : MvPolynomial (Fin n) R →+* S, g.comp MvPolynomial.C = f ∧ g.Etale := by
+  classical
+  algebraize [f]
+  obtain ⟨g, hg⟩ := Algebra.IsStandardSmoothOfRelativeDimension.exists_etale_mvPolynomial n R S
+  exact ⟨_, g.comp_algebraMap, hg⟩
 
 theorem IsStandardSmooth.exists_etale_mvPolynomial
     {f : R →+* S} (hf : f.IsStandardSmooth) :


### PR DESCRIPTION
---
<!-- Your PR title will become the first line of the commit message.

In this box, the text above the `---` (if not empty) will be appended
to the commit message, and can be used to give additional context or
details. Please leave a blank newline before the `---`, otherwise GitHub
will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

When merging, all the commits will be squashed into a single commit
listing all co-authors.

Co-authors in the squash commit are gathered from two sources:

First, all authors of commits to this PR branch are included. Thus,
one way to add co-authors is to include at least one commit authored by
each co-author among the commits in the pull request. If necessary, you
may create empty commits to indicate co-authorship, using commands like so:

git commit --author="Author Name <author@email.com>" --allow-empty -m "add Author Name as coauthor"

Second, co-authors can also be listed in lines at the very bottom of
the commit message (that is, directly before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines
at the bottom of the commit message (before the `---`, and also before
any "Co-authored-by" lines) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
