### PR TITLE
[Merged by Bors] - feat(AlgebraicGeometry): fpqc descent implies fppf descent

### DIFF
--- a/Mathlib/AlgebraicGeometry/Morphisms/FlatDescent.lean
+++ b/Mathlib/AlgebraicGeometry/Morphisms/FlatDescent.lean
@@ -153,4 +153,19 @@ instance descendsAlong_isOpenImmersion_surjective_inf_flat_inf_quasicompact' :
   rw [← IsOpenImmersion.lift_fac U.ι g (by simp [U])]
   infer_instance
 
+/-- fpqc descent implies fppf descent -/
+instance (P : MorphismProperty Scheme) [P.DescendsAlong (@Surjective ⊓ @Flat ⊓ @QuasiCompact)]
+    [IsZariskiLocalAtTarget P] :
+    P.DescendsAlong (@Surjective ⊓ @Flat ⊓ @LocallyOfFinitePresentation) := by
+  apply IsZariskiLocalAtTarget.descendsAlong
+  rintro R X Y f g ⟨⟨h₁, h₂⟩, h₃⟩ H
+  obtain ⟨V : X.Opens, hV, e⟩ := f.isOpenMap.exists_opens_image_eq_of_prespectralSpace
+    f.continuous (by simp) isOpen_univ isCompact_univ
+  refine MorphismProperty.of_isPullback_of_descendsAlong (Q := @Surjective ⊓ @Flat ⊓ @QuasiCompact)
+    (.paste_vert (.of_hasPullback V.ι _) (.of_hasPullback f g)) ⟨⟨?_, inferInstance⟩,
+      (quasiCompact_iff_compactSpace _).mpr (isCompact_iff_compactSpace.mp hV)⟩ ?_
+  · exact ⟨fun x ↦ have ⟨y, hyV, e⟩ := e.ge (Set.mem_univ x); ⟨⟨y, hyV⟩, e⟩⟩
+  dsimp [MorphismProperty.isomorphisms] at H ⊢
+  exact IsZariskiLocalAtTarget.of_isPullback (.flip <| .of_hasPullback _ _) H
+
 end AlgebraicGeometry

--- a/Mathlib/AlgebraicGeometry/Morphisms/FlatDescent.lean
+++ b/Mathlib/AlgebraicGeometry/Morphisms/FlatDescent.lean
@@ -165,7 +165,7 @@ instance (P : MorphismProperty Scheme) [P.DescendsAlong (@Surjective ⊓ @Flat �
     (.paste_vert (.of_hasPullback V.ι _) (.of_hasPullback f g)) ⟨⟨?_, inferInstance⟩,
       (quasiCompact_iff_compactSpace _).mpr (isCompact_iff_compactSpace.mp hV)⟩ ?_
   · exact ⟨fun x ↦ have ⟨y, hyV, e⟩ := e.ge (Set.mem_univ x); ⟨⟨y, hyV⟩, e⟩⟩
-  dsimp [MorphismProperty.isomorphisms] at H ⊢
-  exact IsZariskiLocalAtTarget.of_isPullback (.flip <| .of_hasPullback _ _) H
+  · dsimp [MorphismProperty.isomorphisms] at H ⊢
+    exact IsZariskiLocalAtTarget.of_isPullback (.flip <| .of_hasPullback _ _) H
 
 end AlgebraicGeometry


### PR DESCRIPTION

---
<!-- Your PR title will become the first line of the commit message.

In this box, the text above the `---` (if not empty) will be appended
to the commit message, and can be used to give additional context or
details. Please leave a blank newline before the `---`, otherwise GitHub
will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

When merging, all the commits will be squashed into a single commit
listing all co-authors.

Co-authors in the squash commit are gathered from two sources:

First, all authors of commits to this PR branch are included. Thus,
one way to add co-authors is to include at least one commit authored by
each co-author among the commits in the pull request. If necessary, you
may create empty commits to indicate co-authorship, using commands like so:

git commit --author="Author Name <author@email.com>" --allow-empty -m "add Author Name as coauthor"

Second, co-authors can also be listed in lines at the very bottom of
the commit message (that is, directly before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines
at the bottom of the commit message (before the `---`, and also before
any "Co-authored-by" lines) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
