### PR TITLE
chore: cont -> continuous_toFun

### DIFF
--- a/Mathlib/Algebra/Category/ContinuousCohomology/Basic.lean
+++ b/Mathlib/Algebra/Category/ContinuousCohomology/Basic.lean
@@ -63,7 +63,7 @@ abbrev Iobj (rep : Action (TopModuleCat R) G) : Action (TopModuleCat R) G where
       { toFun f := .comp (rep.ρ g).hom (f.comp (Homeomorph.mulLeft g⁻¹))
         map_add' _ _ := by ext; simp
         map_smul' _ _ := by ext; simp
-        cont := (continuous_postcomp _).comp (continuous_precomp _) }
+        continuous_toFun := (continuous_postcomp _).comp (continuous_precomp _) }
     map_one' := ConcreteCategory.ext (by ext; simp)
     map_mul' _ _ := ConcreteCategory.ext (by ext; simp [mul_assoc]) }
 
@@ -143,7 +143,7 @@ def invariants : Action (TopModuleCat R) G ⥤ TopModuleCat R where
   map f := TopModuleCat.ofHom
     { toLinearMap := f.hom.hom.restrict fun x hx g ↦
         congr($(f.comm g) x).symm.trans congr(f.hom.hom $(hx g))
-      cont := continuous_induced_rng.mpr (f.hom.hom.2.comp continuous_subtype_val) }
+      continuous_toFun := continuous_induced_rng.mpr (f.hom.hom.2.comp continuous_subtype_val) }
 
 instance : (invariants R G).Linear R where
 instance : (invariants R G).Additive where
@@ -193,7 +193,8 @@ def kerHomogeneousCochainsZeroEquiv
   continuous_toFun := continuous_induced_rng.mpr ((continuous_eval_const (F := C(G, _)) 1).comp
       (continuous_subtype_val.comp continuous_subtype_val))
   continuous_invFun := continuous_induced_rng.mpr
-    (continuous_induced_rng.mpr ((ContinuousLinearMap.const R G).cont.comp continuous_subtype_val))
+    (continuous_induced_rng.mpr
+      ((ContinuousLinearMap.const R G).continuous_toFun.comp continuous_subtype_val))
 
 open ShortComplex HomologyData in
 /-- `H⁰_cont(G, X) ≅ Xᴳ`. -/

--- a/Mathlib/Algebra/Category/ModuleCat/Topology/Homology.lean
+++ b/Mathlib/Algebra/Category/ModuleCat/Topology/Homology.lean
@@ -84,7 +84,7 @@ def isColimitCoker : IsColimit (CokernelCofork.ofπ (cokerπ φ) (comp_cokerπ �
     { toLinearMap := φ.hom.range.liftQ s.π.hom.toLinearMap
         (LinearMap.range_le_ker_iff.mpr <| show (φ ≫ s.π).hom.toLinearMap = 0 by
           rw [s.condition, hom_zero, ContinuousLinearMap.coe_zero])
-      cont := Continuous.quotient_lift s.π.hom.2 _ })
+      continuous_toFun := Continuous.quotient_lift s.π.hom.2 _ })
   (fun s ↦ rfl)
   (fun s m h ↦ by dsimp at h ⊢; rw [← cancel_epi (cokerπ φ), h]; rfl)
 

--- a/Mathlib/Analysis/Analytic/Composition.lean
+++ b/Mathlib/Analysis/Analytic/Composition.lean
@@ -186,8 +186,8 @@ def compAlongComposition {n : ℕ} (p : FormalMultilinearSeries 𝕜 E F) (c : C
     MultilinearMap.mk' (fun v ↦ f (p.applyComposition c v))
       (fun v i x y ↦ by simp only [applyComposition_update, map_update_add])
       (fun v i c x ↦ by simp only [applyComposition_update, map_update_smul])
-  cont :=
-    f.cont.comp <|
+  continuous_toFun :=
+    f.continuous_toFun.comp <|
       continuous_pi fun _ => (coe_continuous _).comp <| continuous_pi fun _ => continuous_apply _
 
 @[simp]

--- a/Mathlib/Analysis/Analytic/Polynomial.lean
+++ b/Mathlib/Analysis/Analytic/Polynomial.lean
@@ -82,7 +82,8 @@ variable [CompleteSpace 𝕜] [T2Space E] [FiniteDimensional 𝕜 E]
 
 theorem AnalyticOnNhd.eval_linearMap (f : E →ₗ[𝕜] σ → B) (p : MvPolynomial σ B) :
     AnalyticOnNhd 𝕜 (fun x ↦ eval (f x) p) Set.univ :=
-  AnalyticOnNhd.eval_continuousLinearMap { f with cont := f.continuous_of_finiteDimensional } p
+  AnalyticOnNhd.eval_continuousLinearMap { f with
+    continuous_toFun := f.continuous_of_finiteDimensional } p
 
 theorem AnalyticOnNhd.eval_linearMap' (f : σ → E →ₗ[𝕜] B) (p : MvPolynomial σ B) :
     AnalyticOnNhd 𝕜 (fun x ↦ eval (f · x) p) Set.univ := AnalyticOnNhd.eval_linearMap (.pi f) p

--- a/Mathlib/Analysis/CStarAlgebra/CStarMatrix.lean
+++ b/Mathlib/Analysis/CStarAlgebra/CStarMatrix.lean
@@ -474,7 +474,7 @@ noncomputable def toCLM : CStarMatrix m n A →ₗ[ℂ] C⋆ᵐᵒᵈ(A, m → A
   toFun M := { toFun := (WithCStarModule.equivL ℂ).symm ∘ M.vecMul ∘ WithCStarModule.equivL ℂ
                map_add' := M.add_vecMul
                map_smul' := M.smul_vecMul
-               cont := Continuous.comp (by fun_prop) (by fun_prop) }
+               continuous_toFun := Continuous.comp (by fun_prop) (by fun_prop) }
   map_add' M₁ M₂ := by
     ext
     simp only [ContinuousLinearMap.coe_mk', LinearMap.coe_mk, AddHom.coe_mk, Function.comp_apply,

--- a/Mathlib/Analysis/CStarAlgebra/ContinuousFunctionalCalculus/NonUnital.lean
+++ b/Mathlib/Analysis/CStarAlgebra/ContinuousFunctionalCalculus/NonUnital.lean
@@ -197,7 +197,7 @@ noncomputable def cfcₙL {a : A} (ha : p a) : C(σₙ R a, R)₀ →L[R] A :=
   { cfcₙHom ha with
     toFun := cfcₙHom ha
     map_smul' := map_smul _
-    cont := (cfcₙHom_isClosedEmbedding ha).continuous }
+    continuous_toFun := (cfcₙHom_isClosedEmbedding ha).continuous }
 
 end cfcₙL
 

--- a/Mathlib/Analysis/CStarAlgebra/ContinuousFunctionalCalculus/Unital.lean
+++ b/Mathlib/Analysis/CStarAlgebra/ContinuousFunctionalCalculus/Unital.lean
@@ -290,7 +290,7 @@ noncomputable def cfcL {a : A} (ha : p a) : C(spectrum R a, R) →L[R] A :=
   { cfcHom ha with
     toFun := cfcHom ha
     map_smul' := map_smul _
-    cont := (cfcHom_isClosedEmbedding ha).continuous }
+    continuous_toFun := (cfcHom_isClosedEmbedding ha).continuous }
 
 end cfcL
 

--- a/Mathlib/Analysis/Calculus/ContDiff/FaaDiBruno.lean
+++ b/Mathlib/Analysis/Calculus/ContDiff/FaaDiBruno.lean
@@ -788,8 +788,8 @@ def compAlongOrderedFinpartition (f : F [×c.length]→L[𝕜] G) (p : ∀ i, E 
       (fun v i c x ↦ by
         simp only [applyOrderedFinpartition_update_right,
           ContinuousMultilinearMap.map_update_smul])
-  cont := by
-    apply f.cont.comp
+  continuous_toFun := by
+    apply f.continuous_toFun.comp
     change Continuous (fun v m ↦ p m (v ∘ c.emb m))
     fun_prop
 

--- a/Mathlib/Analysis/Calculus/FDeriv/Basic.lean
+++ b/Mathlib/Analysis/Calculus/FDeriv/Basic.lean
@@ -156,7 +156,7 @@ theorem HasFDerivWithinAt.lim (h : HasFDerivWithinAt f f' s x) {α : Type*} (l :
   have L1 : Tendsto (fun n => c n • (f (x + d n) - f x - f' (d n))) l (𝓝 0) :=
     (isLittleO_one_iff ℝ).1 this
   have L2 : Tendsto (fun n => f' (c n • d n)) l (𝓝 (f' v)) :=
-    Tendsto.comp f'.cont.continuousAt cdlim
+    Tendsto.comp f'.continuous_toFun.continuousAt cdlim
   have L3 :
     Tendsto (fun n => c n • (f (x + d n) - f x - f' (d n)) + f' (c n • d n)) l (𝓝 (0 + f' v)) :=
     L1.add L2

--- a/Mathlib/Analysis/Calculus/FDeriv/Extend.lean
+++ b/Mathlib/Analysis/Calculus/FDeriv/Extend.lean
@@ -81,7 +81,7 @@ theorem hasFDerivWithinAt_closure_of_tendsto_fderiv {f : E → F} {s : Set E} {x
     rintro ⟨u, v⟩ uv_in
     have f_cont' : ∀ y ∈ closure s, ContinuousWithinAt (f - ⇑f') s y := by
       intro y y_in
-      exact Tendsto.sub (f_cont y y_in) f'.cont.continuousWithinAt
+      exact Tendsto.sub (f_cont y y_in) f'.continuous_toFun.continuousWithinAt
     refine ContinuousWithinAt.closure_le uv_in ?_ ?_ key
     all_goals
       -- common start for both continuity proofs

--- a/Mathlib/Analysis/Distribution/ContDiffMapSupportedIn.lean
+++ b/Mathlib/Analysis/Distribution/ContDiffMapSupportedIn.lean
@@ -494,7 +494,7 @@ We call these "structure maps" because they define the topology on `𝓓^{n}_{K}
 noncomputable def structureMapCLM (i : ℕ) :
     𝓓^{n}_{K}(E, F) →L[𝕜] E →ᵇ (E [×i]→L[ℝ] F) where
   toLinearMap := structureMapLM 𝕜 n i
-  cont := continuous_iInf_dom continuous_induced_dom
+  continuous_toFun := continuous_iInf_dom continuous_induced_dom
 
 @[simp]
 lemma structureMapCLM_apply_withOrder {i : ℕ} (f : 𝓓^{n}_{K}(E, F)) :
@@ -656,7 +656,7 @@ theorem norm_toBoundedContinuousFunction (f : 𝓓^{n}_{K}(E, F)) :
 functions as a continuous `𝕜`-linear map. -/
 noncomputable def toBoundedContinuousFunctionCLM : 𝓓^{n}_{K}(E, F) →L[𝕜] E →ᵇ F where
   toLinearMap := toBoundedContinuousFunctionLM 𝕜
-  cont := show Continuous (toBoundedContinuousFunctionLM 𝕜) by
+  continuous_toFun := show Continuous (toBoundedContinuousFunctionLM 𝕜) by
     refine continuous_from_bounded (ContDiffMapSupportedIn.withSeminorms _ _ _ _ _)
       (norm_withSeminorms 𝕜 _) _ (fun _ ↦ ⟨{0}, 1, fun f ↦ ?_⟩)
     simp [norm_toBoundedContinuousFunction 𝕜 f]
@@ -701,7 +701,7 @@ variable {𝕜} in
 noncomputable def postcompCLM [LinearMap.CompatibleSMul F F' ℝ 𝕜] (T : F →L[𝕜] F') :
     𝓓^{n}_{K}(E, F) →L[𝕜] 𝓓^{n}_{K}(E, F') where
   toLinearMap := postcompLM T
-  cont := show Continuous (postcompLM T) by
+  continuous_toFun := show Continuous (postcompLM T) by
     refine continuous_from_bounded (ContDiffMapSupportedIn.withSeminorms _ _ _ _ _)
       (ContDiffMapSupportedIn.withSeminorms _ _ _ _ _) _ (fun i ↦ ⟨{i}, ‖T‖₊, fun f ↦ ?_⟩)
     simpa [NNReal.smul_def] using seminorm_postcompLM_le 𝕜 T f

--- a/Mathlib/Analysis/Distribution/DerivNotation.lean
+++ b/Mathlib/Analysis/Distribution/DerivNotation.lean
@@ -136,7 +136,7 @@ def lineDerivOpCLM (m : V) : E →L[R] F where
   toFun := ∂_{m}
   map_add' := lineDerivOp_add m
   map_smul' := lineDerivOp_smul m
-  cont := by fun_prop
+  continuous_toFun := by fun_prop
 
 @[simp]
 theorem lineDerivOpCLM_apply (m : V) (x : E) :
@@ -185,7 +185,7 @@ def iteratedLineDerivOpCLM {n : ℕ} (m : Fin n → V) : E →L[R] E where
   toFun := ∂^{m}
   map_add' := iteratedLineDerivOp_add m
   map_smul' := iteratedLineDerivOp_smul m
-  cont := by fun_prop
+  continuous_toFun := by fun_prop
 
 @[simp]
 theorem iteratedLineDerivOpCLM_apply {n : ℕ} (m : Fin n → V) (x : E) :

--- a/Mathlib/Analysis/Distribution/SchwartzSpace.lean
+++ b/Mathlib/Analysis/Distribution/SchwartzSpace.lean
@@ -590,7 +590,7 @@ def mkCLM [RingHomIsometric σ] (A : 𝓢(D, E) → F → G)
     (hbound : ∀ n : ℕ × ℕ, ∃ (s : Finset (ℕ × ℕ)) (C : ℝ), 0 ≤ C ∧ ∀ (f : 𝓢(D, E)) (x : F),
       ‖x‖ ^ n.fst * ‖iteratedFDeriv ℝ n.snd (A f) x‖ ≤ C * s.sup (schwartzSeminormFamily 𝕜 D E) f) :
     𝓢(D, E) →SL[σ] 𝓢(F, G) where
-  cont := by
+  continuous_toFun := by
     change Continuous (mkLM A hadd hsmul hsmooth hbound : 𝓢(D, E) →ₛₗ[σ] 𝓢(F, G))
     refine
       Seminorm.continuous_from_bounded (schwartz_withSeminorms 𝕜 D E)
@@ -612,7 +612,7 @@ def mkCLMtoNormedSpace [RingHomIsometric σ] (A : 𝓢(D, E) → G)
       map_add' := hadd
       map_smul' := hsmul }
   { toLinearMap := f
-    cont := by
+    continuous_toFun := by
       change Continuous (LinearMap.mk _ _)
       apply Seminorm.cont_withSeminorms_normedSpace G (schwartz_withSeminorms 𝕜 D E)
       rcases hbound with ⟨s, C, hC, h⟩

--- a/Mathlib/Analysis/Distribution/TemperedDistribution.lean
+++ b/Mathlib/Analysis/Distribution/TemperedDistribution.lean
@@ -117,8 +117,8 @@ def toTemperedDistributionCLM (μ : Measure E := by volume_tac) [hμ : μ.HasTem
   toFun f := toPointwiseConvergenceCLM _ _ _ _ <| integralCLM ℂ μ ∘L pairing (lsmul ℂ ℂ).flip f
   map_add' _ _ := by ext; simp
   map_smul' _ _ := by ext; simp
-  cont := PointwiseConvergenceCLM.continuous_of_continuous_eval
-    fun g ↦ (integralCLM ℂ μ).cont.comp <| pairing_continuous_left (lsmul ℂ ℂ).flip g
+  continuous_toFun := PointwiseConvergenceCLM.continuous_of_continuous_eval
+    fun g ↦ (integralCLM ℂ μ).continuous_toFun.comp <| pairing_continuous_left (lsmul ℂ ℂ).flip g
 
 @[simp]
 theorem toTemperedDistributionCLM_apply_apply (μ : Measure E := by volume_tac)
@@ -192,13 +192,14 @@ def toTemperedDistributionCLM (μ : Measure E := by volume_tac) [μ.HasTemperate
   toFun := toTemperedDistribution
   map_add' f g := by simp [Lp.toTemperedDistribution]
   map_smul' a f := by simp [Lp.toTemperedDistribution]
-  cont := by
+  continuous_toFun := by
     apply PointwiseConvergenceCLM.continuous_of_continuous_eval
     intro g
     haveI : Fact (1 ≤ (1 - p⁻¹)⁻¹) := by simp [fact_iff]
     have hpq : ENNReal.HolderConjugate p (1 - p⁻¹)⁻¹ :=
       ENNReal.HolderConjugate.inv_one_sub_inv' hp.out
-    exact (((lsmul ℂ ℂ (E := F)).flip.lpPairing μ p (1 - p⁻¹)⁻¹).flip (g.toLp (1 - p⁻¹)⁻¹ μ)).cont
+    exact (((lsmul ℂ ℂ (E := F)).flip.lpPairing μ p (1 - p⁻¹)⁻¹).flip
+      (g.toLp (1 - p⁻¹)⁻¹ μ)).continuous_toFun
 
 @[simp]
 theorem toTemperedDistributionCLM_apply {p : ℝ≥0∞} [hp : Fact (1 ≤ p)] (f : Lp F p μ) :

--- a/Mathlib/Analysis/Distribution/TestFunction.lean
+++ b/Mathlib/Analysis/Distribution/TestFunction.lean
@@ -303,7 +303,7 @@ def ofSupportedInCLM [SMulCommClass ℝ 𝕜 F] {K : Compacts E} (K_sub_Ω : (K 
   toFun f := ofSupportedIn K_sub_Ω f
   map_add' _ _ := rfl
   map_smul' _ _ := rfl
-  cont := continuous_ofSupportedIn K_sub_Ω
+  continuous_toFun := continuous_ofSupportedIn K_sub_Ω
 
 @[deprecated (since := "2025-12-10")] alias ofSupportedInLM := ofSupportedInCLM
 
@@ -345,7 +345,7 @@ protected def mkCLM [Algebra ℝ 𝕜] [IsScalarTower ℝ 𝕜 F] [Module 𝕜 V
     𝓓^{n}(Ω, F) →L[𝕜] V :=
   letI Φ : 𝓓^{n}(Ω, F) →ₗ[𝕜] V := ⟨⟨toFun, map_add⟩, map_smul⟩
   { toLinearMap := Φ
-    cont := show Continuous Φ by rwa [TestFunction.continuous_iff_continuous_comp] }
+    continuous_toFun := show Continuous Φ by rwa [TestFunction.continuous_iff_continuous_comp] }
 
 end Topology
 

--- a/Mathlib/Analysis/Fourier/FourierTransform.lean
+++ b/Mathlib/Analysis/Fourier/FourierTransform.lean
@@ -195,7 +195,7 @@ theorem integral_fourierIntegral_swap
       (Measure.prod ν μ) := hg.1.comp_fst.prodMk A
     have hM : Continuous (fun q ↦ M q.1 q.2 : F × E → G) :=
       -- There is no `Continuous.clm_apply` for semilinear continuous maps
-      (M.flip.cont.comp continuous_snd).clm_apply continuous_fst
+      (M.flip.continuous_toFun.comp continuous_snd).clm_apply continuous_fst
     apply hM.comp_aestronglyMeasurable A' -- `exact` works, but `apply` is 10x faster!
   · filter_upwards with ⟨ξ, x⟩
     simp only [Function.uncurry_apply_pair, norm_mul, norm_norm, ge_iff_le, ← mul_assoc]

--- a/Mathlib/Analysis/Fourier/LpSpace.lean
+++ b/Mathlib/Analysis/Fourier/LpSpace.lean
@@ -104,8 +104,9 @@ theorem fourier_toTemperedDistribution_eq (f : Lp (α := E) F 2) :
     (SchwartzMap.denseRange_toLpCLM (p := 2) ENNReal.ofNat_ne_top) f
   · apply isClosed_eq
     · exact ((TemperedDistribution.fourierTransformCLM E F) ∘L
-        (toTemperedDistributionCLM F volume 2)).cont
-    · exact (toTemperedDistributionCLM F volume 2).cont.comp (fourierTransformₗᵢ E F).continuous
+        (toTemperedDistributionCLM F volume 2)).continuous_toFun
+    · exact (toTemperedDistributionCLM F volume 2).continuous_toFun.comp
+        (fourierTransformₗᵢ E F).continuous
   intro f
   simp [p, TemperedDistribution.fourierTransform_toTemperedDistributionCLM_eq]
 

--- a/Mathlib/Analysis/InnerProductSpace/LinearPMap.lean
+++ b/Mathlib/Analysis/InnerProductSpace/LinearPMap.lean
@@ -213,7 +213,7 @@ theorem toPMap_adjoint_eq_adjoint_toPMap_of_dense (hp : Dense (p : Set E)) :
   ext x y hxy
   · simp only [LinearMap.toPMap_domain, Submodule.mem_top, iff_true,
       LinearPMap.mem_adjoint_domain_iff, LinearMap.coe_comp, coe_innerₛₗ_apply]
-    exact ((innerSL 𝕜 x).comp <| A.comp <| Submodule.subtypeL _).cont
+    exact ((innerSL 𝕜 x).comp <| A.comp <| Submodule.subtypeL _).continuous_toFun
   refine LinearPMap.adjoint_apply_eq hp _ fun v => ?_
   simp only [adjoint_inner_left, LinearMap.toPMap_apply, coe_coe]
 
@@ -244,7 +244,7 @@ theorem _root_.IsSelfAdjoint.dense_domain (hA : IsSelfAdjoint A) : Dense (A.doma
     rw [← hA, Submodule.eq_top_iff']
     intro x
     rw [mem_adjoint_domain_iff, ← hA]
-    refine (innerSL 𝕜 x).cont.comp ?_
+    refine (innerSL 𝕜 x).continuous_toFun.comp ?_
     simp only [adjoint, h]
     exact continuous_const
   simp [h'] at h

--- a/Mathlib/Analysis/LocallyConvex/Barrelled.lean
+++ b/Mathlib/Analysis/LocallyConvex/Barrelled.lean
@@ -188,7 +188,7 @@ protected def continuousLinearMapOfTendsto (hq : WithSeminorms q)
     [l.NeBot] (g : α → E →SL[σ₁₂] F) {f : E → F} (h : Tendsto (fun n x ↦ g n x) l (𝓝 f)) :
     E →SL[σ₁₂] F where
   toLinearMap := linearMapOfTendsto _ _ h
-  cont := by
+  continuous_toFun := by
     -- Since the filter `l` is countably generated and nontrivial, we can find a sequence
     -- `u : ℕ → α` that tends to `l`. By considering `g ∘ u` instead of `g`, we can thus assume
     -- that `α = ℕ` and `l = atTop`

--- a/Mathlib/Analysis/LocallyConvex/PointwiseConvergence.lean
+++ b/Mathlib/Analysis/LocallyConvex/PointwiseConvergence.lean
@@ -100,7 +100,7 @@ def mkCLM (A : (E →SL[σ] F) →ₗ[𝕜₂] D →SL[τ] G) (hbound : ∀ (f :
     (E →SLₚₜ[σ] F) →L[𝕜₂] D →SLₚₜ[τ] G where
   __ := (toUniformConvergenceCLM _ _ _).toLinearMap.comp
     (A.comp (toUniformConvergenceCLM _ _ _).symm.toLinearMap)
-  cont := by
+  continuous_toFun := by
     apply Seminorm.continuous_from_bounded PointwiseConvergenceCLM.withSeminorms
       PointwiseConvergenceCLM.withSeminorms A
     intro f

--- a/Mathlib/Analysis/LocallyConvex/Separation.lean
+++ b/Mathlib/Analysis/LocallyConvex/Separation.lean
@@ -215,7 +215,8 @@ variable [RCLike 𝕜] [Module 𝕜 E] [IsScalarTower ℝ 𝕜 E]
 noncomputable def extendTo𝕜'ₗ [ContinuousConstSMul 𝕜 E] : StrongDual ℝ E →ₗ[ℝ] StrongDual 𝕜 E :=
   letI to𝕜 (fr : StrongDual ℝ E) : StrongDual 𝕜 E :=
     { toLinearMap := LinearMap.extendTo𝕜' fr
-      cont := show Continuous fun x ↦ (fr x : 𝕜) - (I : 𝕜) * (fr ((I : 𝕜) • x) : 𝕜) by fun_prop }
+      continuous_toFun :=
+        show Continuous fun x ↦ (fr x : 𝕜) - (I : 𝕜) * (fr ((I : 𝕜) • x) : 𝕜) by fun_prop }
   have h fr x : to𝕜 fr x = ((fr x : 𝕜) - (I : 𝕜) * (fr ((I : 𝕜) • x) : 𝕜)) := rfl
   { toFun := to𝕜
     map_add' := by intros; ext; simp [h]; ring

--- a/Mathlib/Analysis/LocallyConvex/WeakOperatorTopology.lean
+++ b/Mathlib/Analysis/LocallyConvex/WeakOperatorTopology.lean
@@ -291,7 +291,7 @@ map is continuous. -/
 lemma ContinuousLinearMap.continuous_toWOT :
     Continuous (ContinuousLinearMap.toWOT σ E F) :=
   ContinuousLinearMapWOT.continuous_of_dual_apply_continuous fun x y ↦
-    y.cont.comp <| continuous_eval_const x
+    y.continuous_toFun.comp <| continuous_eval_const x
 
 /-- The inclusion map from `E →[𝕜] F` to `E →WOT[𝕜] F`, bundled as a continuous linear map. -/
 def ContinuousLinearMap.toWOTCLM : (E →SL[σ] F) →L[𝕜₂] (E →SWOT[σ] F) :=

--- a/Mathlib/Analysis/LocallyConvex/WeakSpace.lean
+++ b/Mathlib/Analysis/LocallyConvex/WeakSpace.lean
@@ -47,7 +47,7 @@ theorem Convex.toWeakSpace_closure {s : Set E} (hs : Convex ℝ s) :
     hs.closure isClosed_closure (by simpa using hx)
   let f' : StrongDual 𝕜 (WeakSpace 𝕜 E) :=
     { toLinearMap := (f : E →ₗ[𝕜] 𝕜).comp ((toWeakSpace 𝕜 E).symm : WeakSpace 𝕜 E →ₗ[𝕜] E)
-      cont := WeakBilin.eval_continuous (topDualPairing 𝕜 E).flip _ }
+      continuous_toFun := WeakBilin.eval_continuous (topDualPairing 𝕜 E).flip _ }
   have hux' : u < RCLike.reCLM.comp (f'.restrictScalars ℝ) (toWeakSpace 𝕜 E x) := by simpa [f']
   have hus' : closure (toWeakSpace 𝕜 E '' s) ⊆
       {y | RCLike.reCLM.comp (f'.restrictScalars ℝ) y ≤ u} := by

--- a/Mathlib/Analysis/Normed/Affine/Isometry.lean
+++ b/Mathlib/Analysis/Normed/Affine/Isometry.lean
@@ -177,7 +177,7 @@ theorem diam_range : Metric.diam (range f) = Metric.diam (univ : Set P) :=
   f.isometry.diam_range
 
 /-- Interpret an affine isometry as a continuous affine map. -/
-def toContinuousAffineMap : P →ᴬ[𝕜] P₂ := { f with cont := f.continuous }
+def toContinuousAffineMap : P →ᴬ[𝕜] P₂ := { f with continuous_toFun := f.continuous }
 
 theorem toContinuousAffineMap_injective :
     Function.Injective (toContinuousAffineMap : _ → P →ᴬ[𝕜] P₂) := fun x _ h =>

--- a/Mathlib/Analysis/Normed/Algebra/Spectrum.lean
+++ b/Mathlib/Analysis/Normed/Algebra/Spectrum.lean
@@ -416,7 +416,7 @@ instance (priority := 100) [FunLike F A 𝕜] [AlgHomClass F 𝕜 A 𝕜] :
 /-- An algebra homomorphism into the base field, as a continuous linear map (since it is
 automatically bounded). -/
 def toContinuousLinearMap (φ : A →ₐ[𝕜] 𝕜) : StrongDual 𝕜 A :=
-  { φ.toLinearMap with cont := map_continuous φ }
+  { φ.toLinearMap with continuous_toFun := map_continuous φ }
 
 @[simp]
 theorem coe_toContinuousLinearMap (φ : A →ₐ[𝕜] 𝕜) : ⇑φ.toContinuousLinearMap = φ :=

--- a/Mathlib/Analysis/Normed/Lp/PiLp.lean
+++ b/Mathlib/Analysis/Normed/Lp/PiLp.lean
@@ -1044,7 +1044,7 @@ variable {𝕜} in
 @[simps!]
 def proj (i : ι) : PiLp p β →L[𝕜] β i where
   __ := projₗ p β i
-  cont := PiLp.continuous_apply ..
+  continuous_toFun := PiLp.continuous_apply ..
 
 end
 

--- a/Mathlib/Analysis/Normed/Lp/ProdLp.lean
+++ b/Mathlib/Analysis/Normed/Lp/ProdLp.lean
@@ -566,13 +566,13 @@ lemma prodContinuousLinearEquiv_symm_apply (x : α × β) :
 @[simps! coe apply]
 def fstL : WithLp p (α × β) →L[𝕜] α where
   __ := fstₗ ..
-  cont := WithLp.continuous_fst ..
+  continuous_toFun := WithLp.continuous_fst ..
 
 /-- `WithLp.snd` as a continuous linear map. -/
 @[simps! coe apply]
 def sndL : WithLp p (α × β) →L[𝕜] β where
   __ := sndₗ ..
-  cont := WithLp.continuous_snd ..
+  continuous_toFun := WithLp.continuous_snd ..
 
 end ContinuousLinearEquiv
 

--- a/Mathlib/Analysis/Normed/Lp/lpSpace.lean
+++ b/Mathlib/Analysis/Normed/Lp/lpSpace.lean
@@ -997,7 +997,7 @@ variable (𝕜 p E) in
 /-- `lp.single` as a continuous linear map. -/
 def singleContinuousLinearMap [Fact (1 ≤ p)] (i : α) : E i →L[𝕜] lp E p where
   __ := lsingle p i
-  cont := isometry_single i |>.continuous
+  continuous_toFun := isometry_single i |>.continuous
 
 @[simp]
 theorem singleContinuousLinearMap_apply [Fact (1 ≤ p)] (i : α) (x : E i) :

--- a/Mathlib/Analysis/Normed/Module/Alternating/Basic.lean
+++ b/Mathlib/Analysis/Normed/Module/Alternating/Basic.lean
@@ -148,7 +148,7 @@ theorem continuous_of_bound (f : E [⋀^ι]→ₗ[𝕜] F) (C : ℝ) (H : ∀ m,
 /-- Construct a continuous alternating map
 from an alternating map satisfying a boundedness condition. -/
 def mkContinuous (f : E [⋀^ι]→ₗ[𝕜] F) (C : ℝ) (H : ∀ m, ‖f m‖ ≤ C * ∏ i, ‖m i‖) : E [⋀^ι]→L[𝕜] F :=
-  { f with cont := f.continuous_of_bound C H }
+  { f with continuous_toFun := f.continuous_of_bound C H }
 
 @[simp] theorem coe_mkContinuous (f : E [⋀^ι]→ₗ[𝕜] F) (C : ℝ) (H : ∀ m, ‖f m‖ ≤ C * ∏ i, ‖m i‖) :
     (f.mkContinuous C H : (ι → E) → F) = f :=
@@ -568,9 +568,9 @@ def ContinuousLinearEquiv.continuousAlternatingMapCongrLeft (f : E ≃L[𝕜] F)
   __ := ContinuousAlternatingMap.compContinuousLinearMapCLM (f.symm : F →L[𝕜] E)
   toFun g := g.compContinuousLinearMap (f.symm : F →L[𝕜] E)
   continuous_invFun :=
-    (ContinuousAlternatingMap.compContinuousLinearMapCLM (f : E →L[𝕜] F)).cont
+    (ContinuousAlternatingMap.compContinuousLinearMapCLM (f : E →L[𝕜] F)).continuous_toFun
   continuous_toFun :=
-    (ContinuousAlternatingMap.compContinuousLinearMapCLM (f.symm : F →L[𝕜] E)).cont
+    (ContinuousAlternatingMap.compContinuousLinearMapCLM (f.symm : F →L[𝕜] E)).continuous_toFun
 
 variable
   {E' : Type*} [NormedAddCommGroup E'] [NormedSpace 𝕜 E']

--- a/Mathlib/Analysis/Normed/Module/Multilinear/Basic.lean
+++ b/Mathlib/Analysis/Normed/Module/Multilinear/Basic.lean
@@ -83,7 +83,8 @@ instance ContinuousMultilinearMap.instContinuousEval :
     let _ := IsTopologicalAddGroup.rightUniformSpace F
     have := isUniformAddGroup_of_addCommGroup (G := F)
     refine (UniformOnFun.continuousOn_eval₂ fun m ↦ ?_).comp_continuous
-      (isEmbedding_toUniformOnFun.continuous.prodMap continuous_id) fun (f, x) ↦ f.cont.continuousAt
+      (isEmbedding_toUniformOnFun.continuous.prodMap continuous_id) fun (f, x) ↦
+        f.continuous_toFun.continuousAt
     exact ⟨ball m 1, NormedSpace.isVonNBounded_of_isBounded _ isBounded_ball,
       ball_mem_nhds _ one_pos⟩
 
@@ -299,7 +300,7 @@ theorem continuous_of_bound (f : MultilinearMap 𝕜 E G) (C : ℝ) (H : ∀ m, 
 condition. -/
 def mkContinuous (f : MultilinearMap 𝕜 E G) (C : ℝ) (H : ∀ m, ‖f m‖ ≤ C * ∏ i, ‖m i‖) :
     ContinuousMultilinearMap 𝕜 E G :=
-  { f with cont := f.continuous_of_bound C H }
+  { f with continuous_toFun := f.continuous_of_bound C H }
 
 @[simp]
 theorem coe_mkContinuous (f : MultilinearMap 𝕜 E G) (C : ℝ) (H : ∀ m, ‖f m‖ ≤ C * ∏ i, ‖m i‖) :

--- a/Mathlib/Analysis/Normed/Module/WeakDual.lean
+++ b/Mathlib/Analysis/Normed/Module/WeakDual.lean
@@ -194,7 +194,7 @@ theorem toWeakDual_continuous : Continuous fun x' : StrongDual 𝕜 E => StrongD
 `StrongDual 𝕜 E → WeakDual 𝕜 E` is continuous. This definition implements it as a continuous linear
 map. -/
 def continuousLinearMapToWeakDual : StrongDual 𝕜 E →L[𝕜] WeakDual 𝕜 E :=
-  { StrongDual.toWeakDual with cont := toWeakDual_continuous }
+  { StrongDual.toWeakDual with continuous_toFun := toWeakDual_continuous }
 
 /-- The weak-star topology is coarser than the dual-norm topology. -/
 theorem dual_norm_topology_le_weak_dual_topology :

--- a/Mathlib/Analysis/Normed/Operator/Banach.lean
+++ b/Mathlib/Analysis/Normed/Operator/Banach.lean
@@ -256,7 +256,8 @@ theorem _root_.AffineMap.isOpenMap {F : Type*} [NormedAddCommGroup F] [NormedSpa
     [NormedAddTorsor F Q] (f : P →ᵃ[𝕜] Q) (hf : Continuous f) (surj : Surjective f) :
     IsOpenMap f :=
   AffineMap.isOpenMap_linear_iff.mp <|
-    ContinuousLinearMap.isOpenMap { f.linear with cont := AffineMap.continuous_linear_iff.mpr hf }
+    ContinuousLinearMap.isOpenMap { f.linear with
+      continuous_toFun := AffineMap.continuous_linear_iff.mpr hf }
       (f.linear_surjective_iff.mpr surj)
 
 /-! ### Applications of the Banach open mapping theorem -/
@@ -520,7 +521,7 @@ namespace ContinuousLinearMap
 /-- Upgrade a `LinearMap` to a `ContinuousLinearMap` using the **closed graph theorem**. -/
 def ofIsClosedGraph (hg : IsClosed (g.graph : Set <| E × F)) : E →L[𝕜] F where
   toLinearMap := g
-  cont := g.continuous_of_isClosed_graph hg
+  continuous_toFun := g.continuous_of_isClosed_graph hg
 
 @[simp]
 theorem coeFn_ofIsClosedGraph (hg : IsClosed (g.graph : Set <| E × F)) :
@@ -538,7 +539,7 @@ def ofSeqClosedGraph
     (hg : ∀ (u : ℕ → E) (x y), Tendsto u atTop (𝓝 x) → Tendsto (g ∘ u) atTop (𝓝 y) → y = g x) :
     E →L[𝕜] F where
   toLinearMap := g
-  cont := g.continuous_of_seq_closed_graph hg
+  continuous_toFun := g.continuous_of_seq_closed_graph hg
 
 @[simp]
 theorem coeFn_ofSeqClosedGraph

--- a/Mathlib/Analysis/Normed/Operator/BoundedLinearMaps.lean
+++ b/Mathlib/Analysis/Normed/Operator/BoundedLinearMaps.lean
@@ -99,7 +99,7 @@ def toLinearMap (f : E → F) (h : IsBoundedLinearMap 𝕜 f) : E →ₗ[𝕜] F
 /-- Construct a continuous linear map from `IsBoundedLinearMap`. -/
 def toContinuousLinearMap {f : E → F} (hf : IsBoundedLinearMap 𝕜 f) : E →L[𝕜] F :=
   { toLinearMap f hf with
-    cont :=
+    continuous_toFun :=
       let ⟨C, _, hC⟩ := hf.bound
       AddMonoidHomClass.continuous_of_bound (toLinearMap f hf) C hC }
 

--- a/Mathlib/Analysis/Normed/Operator/Extend.lean
+++ b/Mathlib/Analysis/Normed/Operator/Extend.lean
@@ -77,7 +77,7 @@ def extend : Eₗ →SL[σ₁₂] F :=
         rw [← map_smul]
         simp only [eq]
         exact map_smulₛₗ _ _ _
-    cont }
+  }
   else 0
 
 variable {e}
@@ -86,7 +86,7 @@ variable {e}
 theorem extend_eq (h_dense : DenseRange e) (h_e : IsUniformInducing e) (x : E) :
     extend f e (e x) = f x := by
   simp only [extend, h_dense, h_e, and_self, ↓reduceDIte, coe_mk', LinearMap.coe_mk, AddHom.coe_mk]
-  exact IsDenseInducing.extend_eq (h_e.isDenseInducing h_dense) f.cont _
+  exact IsDenseInducing.extend_eq (h_e.isDenseInducing h_dense) f.continuous_toFun _
 
 theorem extend_unique (h_dense : DenseRange e) (h_e : IsUniformInducing e) (g : Eₗ →SL[σ₁₂] F)
     (H : g.comp e = f) : extend f e = g := by
@@ -125,7 +125,7 @@ theorem opNorm_extend_le (h_dense : DenseRange e) (h_e : ∀ x, ‖x‖ ≤ N * 
         (h_e x).trans (mul_nonpos_of_nonpos_of_nonneg hN (norm_nonneg _))⟩
       obtain rfl : f = 0 := Subsingleton.elim ..
       simp
-  · exact (cont _).norm
+  · exact (continuous_toFun _).norm
   · exact continuous_const.mul continuous_norm
   · rw [extend_eq _ h_dense (isUniformEmbedding_of_bound _ h_e).isUniformInducing]
     calc

--- a/Mathlib/Analysis/RCLike/Extend.lean
+++ b/Mathlib/Analysis/RCLike/Extend.lean
@@ -124,7 +124,8 @@ Norm properties of this extension can be found in
 `Mathlib/Analysis/Normed/Module/RCLike/Extend.lean`. -/
 noncomputable def extendTo𝕜' (fr : StrongDual ℝ F) : StrongDual 𝕜 F where
   __ := fr.toLinearMap.extendTo𝕜'
-  cont := show Continuous fun x ↦ (fr x : 𝕜) - (I : 𝕜) * (fr ((I : 𝕜) • x) : 𝕜) by fun_prop
+  continuous_toFun :=
+    show Continuous fun x ↦ (fr x : 𝕜) - (I : 𝕜) * (fr ((I : 𝕜) • x) : 𝕜) by fun_prop
 
 theorem extendTo𝕜'_apply (fr : StrongDual ℝ F) (x : F) :
     fr.extendTo𝕜' x = (fr x : 𝕜) - (I : 𝕜) * (fr ((I : 𝕜) • x) : 𝕜) := rfl

--- a/Mathlib/Geometry/Euclidean/Incenter.lean
+++ b/Mathlib/Geometry/Euclidean/Incenter.lean
@@ -876,7 +876,7 @@ lemma ExcenterExists.sign_signedInfDist_lineMap_excenter_touchpoint {signs : Fin
       (Set.Icc 0 1) := by
     refine continuousOn_of_forall_continuousAt
       fun t ht ↦ ((continuousAt_sign_of_ne_zero ?_).comp
-        (((s.signedInfDist j).cont.comp ?_).continuousAt))
+        (((s.signedInfDist j).continuous_toFun.comp ?_).continuousAt))
     · intro h0
       rw [← abs_eq_zero, abs_signedInfDist_eq_dist_of_mem_affineSpan_range] at h0
       · rw [orthogonalProjectionSpan, dist_orthogonalProjection_eq_zero_iff] at h0
@@ -893,7 +893,7 @@ lemma ExcenterExists.sign_signedInfDist_lineMap_excenter_touchpoint {signs : Fin
       · exact AffineMap.lineMap_mem _ h.excenter_mem_affineSpan_range
           (s.touchpoint_mem_affineSpan_simplex _ _)
     · rw [← ContinuousAffineMap.lineMap_toAffineMap]
-      exact ContinuousAffineMap.cont _
+      exact ContinuousAffineMap.continuous_toFun _
   refine ((isConnected_Icc zero_le_one).image _ hc).isPreconnected.subsingleton
     (Set.mem_image_of_mem _ hr) ?_
   convert Set.mem_image_of_mem _ (Set.left_mem_Icc.2 (zero_le_one' ℝ))

--- a/Mathlib/Geometry/Manifold/LocalDiffeomorph.lean
+++ b/Mathlib/Geometry/Manifold/LocalDiffeomorph.lean
@@ -391,8 +391,8 @@ noncomputable def IsLocalDiffeomorphAt.mfderivToContinuousLinearEquiv
       exact hf.mdifferentiableAt hn
     rw [mfderiv_comp _ hf' (hf.localInverse_mdifferentiableAt hn),
       hf.localInverse_left_inv hf.localInverse_mem_target]
-  continuous_toFun := (mfderiv I J f x).cont
-  continuous_invFun := (mfderiv J I hf.localInverse (f x)).cont
+  continuous_toFun := (mfderiv I J f x).continuous_toFun
+  continuous_invFun := (mfderiv J I hf.localInverse (f x)).continuous_toFun
   map_add' := fun x_1 y ↦ map_add _ x_1 y
   map_smul' := by intros; simp
 

--- a/Mathlib/Geometry/Manifold/MFDeriv/Atlas.lean
+++ b/Mathlib/Geometry/Manifold/MFDeriv/Atlas.lean
@@ -180,8 +180,8 @@ protected def mfderiv (he : e.MDifferentiable I I') {x : M} (hx : x ∈ e.source
     TangentSpace I x ≃L[𝕜] TangentSpace I' (e x) :=
   { mfderiv I I' e x with
     invFun := mfderiv I' I e.symm (e x)
-    continuous_toFun := (mfderiv I I' e x).cont
-    continuous_invFun := (mfderiv I' I e.symm (e x)).cont
+    continuous_toFun := (mfderiv I I' e x).continuous_toFun
+    continuous_invFun := (mfderiv I' I e.symm (e x)).continuous_toFun
     left_inv := fun y => by
       have : (ContinuousLinearMap.id _ _ : TangentSpace I x →L[𝕜] TangentSpace I x) y = y := rfl
       conv_rhs => rw [← this, ← he.symm_comp_deriv hx]

--- a/Mathlib/MeasureTheory/Function/ConditionalExpectation/Basic.lean
+++ b/Mathlib/MeasureTheory/Function/ConditionalExpectation/Basic.lean
@@ -353,7 +353,8 @@ theorem _root_.ContinuousLinearMap.comp_condExp_comm {F : Type*} [NormedAddCommG
             T.integral_comp_comm integrable_condExp.restrict
           _ = T (∫ x in s, f x ∂μ) := congrArg T (setIntegral_condExp hm hf_int ms)
           _ = ∫ x in s, (T ∘ f) x ∂μ := (T.integral_comp_comm hf_int.restrict).symm
-      · exact T.cont.comp_aestronglyMeasurable stronglyMeasurable_condExp.aestronglyMeasurable
+      · exact T.continuous_toFun.comp_aestronglyMeasurable
+          stronglyMeasurable_condExp.aestronglyMeasurable
     · simp [condExp_of_not_sigmaFinite hm hμ]
   · simp [condExp_of_not_le hm]
 

--- a/Mathlib/MeasureTheory/Function/ConditionalExpectation/CondexpL1.lean
+++ b/Mathlib/MeasureTheory/Function/ConditionalExpectation/CondexpL1.lean
@@ -228,7 +228,7 @@ def condExpInd {m m0 : MeasurableSpace α} (hm : m ≤ m0) (μ : Measure α) [Si
   toFun := condExpIndL1 hm μ s
   map_add' := condExpIndL1_add
   map_smul' := condExpIndL1_smul
-  cont := continuous_condExpIndL1
+  continuous_toFun := continuous_condExpIndL1
 
 variable {G}
 

--- a/Mathlib/MeasureTheory/Function/SimpleFuncDenseLp.lean
+++ b/Mathlib/MeasureTheory/Function/SimpleFuncDenseLp.lean
@@ -693,7 +693,7 @@ variable (α E 𝕜)
 def coeToLp : Lp.simpleFunc E p μ →L[𝕜] Lp E p μ :=
   { AddSubgroup.subtype (Lp.simpleFunc E p μ) with
     map_smul' := fun _ _ => rfl
-    cont := Lp.simpleFunc.uniformContinuous.continuous }
+    continuous_toFun := Lp.simpleFunc.uniformContinuous.continuous }
 
 variable {α E 𝕜}
 

--- a/Mathlib/MeasureTheory/Integral/Bochner/L1.lean
+++ b/Mathlib/MeasureTheory/Integral/Bochner/L1.lean
@@ -626,7 +626,7 @@ theorem integral_eq_norm_posPart_sub (f : α →₁[μ] ℝ) :
       (fun f : α →₁[μ] ℝ => integral f = ‖Lp.posPart f‖ - ‖Lp.negPart f‖)
       (simpleFunc.denseRange one_ne_top) (isClosed_eq ?_ ?_) ?_ f
   · simp only [integral]
-    exact cont _
+    exact continuous_toFun _
   · refine Continuous.sub (continuous_norm.comp Lp.continuous_posPart)
       (continuous_norm.comp Lp.continuous_negPart)
   -- Show that the property holds for all simple functions in the `L¹` space.

--- a/Mathlib/MeasureTheory/Measure/FiniteMeasure.lean
+++ b/Mathlib/MeasureTheory/Measure/FiniteMeasure.lean
@@ -489,7 +489,7 @@ def toWeakDualBCNN (μ : FiniteMeasure Ω) : WeakDual ℝ≥0 (Ω →ᵇ ℝ≥0
   toFun f := μ.testAgainstNN f
   map_add' := testAgainstNN_add μ
   map_smul' := testAgainstNN_smul μ
-  cont := μ.testAgainstNN_lipschitz.continuous
+  continuous_toFun := μ.testAgainstNN_lipschitz.continuous
 
 @[simp]
 theorem coe_toWeakDualBCNN (μ : FiniteMeasure Ω) : ⇑μ.toWeakDualBCNN = μ.testAgainstNN :=
@@ -980,7 +980,7 @@ noncomputable def mapCLM {f : Ω → Ω'} (f_cont : Continuous f) :
   toFun := fun ν ↦ ν.map f
   map_add' := map_add f_cont.measurable
   map_smul' := map_smul
-  cont := continuous_map f_cont
+  continuous_toFun := continuous_map f_cont
 
 lemma Topology.IsClosedEmbedding.isEmbedding_map_finiteMeasure {Ω : Type*}
     [MeasurableSpace Ω] [TopologicalSpace Ω] [BorelSpace Ω] [NormalSpace Ω']

--- a/Mathlib/NumberTheory/ModularForms/JacobiTheta/TwoVariable.lean
+++ b/Mathlib/NumberTheory/ModularForms/JacobiTheta/TwoVariable.lean
@@ -340,7 +340,7 @@ lemma hasDerivAt_jacobiTheta₂_fst (z : ℂ) {τ : ℂ} (hτ : 0 < im τ) :
   -- through infinite sums of continuous linear maps.
   let eval_fst_CLM : (ℂ × ℂ →L[ℂ] ℂ) →L[ℂ] ℂ :=
   { toFun := fun f ↦ f (1, 0)
-    cont := continuous_id'.clm_apply continuous_const
+    continuous_toFun := continuous_id'.clm_apply continuous_const
     map_add' := by simp only [ContinuousLinearMap.add_apply, forall_const]
     map_smul' := by simp only [ContinuousLinearMap.coe_smul', Pi.smul_apply, smul_eq_mul,
       RingHom.id_apply, forall_const] }

--- a/Mathlib/Probability/Distributions/Fernique.lean
+++ b/Mathlib/Probability/Distributions/Fernique.lean
@@ -106,7 +106,7 @@ def _root_.ContinuousLinearMap.rotation (θ : ℝ) : E × E →L[ℝ] E × E whe
     simp only [Prod.fst_add, smul_add, Prod.snd_add, neg_smul, Prod.mk_add_mk]
     abel_nf
   map_smul' c x := by simp [smul_comm c]
-  cont := by fun_prop
+  continuous_toFun := by fun_prop
 
 lemma _root_.ContinuousLinearMap.rotation_apply (θ : ℝ) (x : E × E) :
     ContinuousLinearMap.rotation θ x

--- a/Mathlib/Probability/Moments/CovarianceBilinDual.lean
+++ b/Mathlib/Probability/Moments/CovarianceBilinDual.lean
@@ -134,7 +134,7 @@ noncomputable
 def toLp (μ : Measure E) (p : ℝ≥0∞) [Fact (1 ≤ p)] :
     StrongDual 𝕜 E →L[𝕜] Lp 𝕜 p μ where
   toLinearMap := StrongDual.toLpₗ μ p
-  cont := by
+  continuous_toFun := by
     refine LinearMap.continuous_of_locally_bounded _ fun s hs ↦ ?_
     rw [image_isVonNBounded_iff]
     simp_rw [isVonNBounded_iff'] at hs

--- a/Mathlib/Topology/Algebra/AffineSubspace.lean
+++ b/Mathlib/Topology/Algebra/AffineSubspace.lean
@@ -32,7 +32,7 @@ variable {R V P : Type*} [Ring R] [AddCommGroup V] [Module R V] [TopologicalSpac
 /-- Embedding of an affine subspace to the ambient space, as a continuous affine map. -/
 def subtypeA (s : AffineSubspace R P) [Nonempty s] : s →ᴬ[R] P where
   toAffineMap := s.subtype
-  cont := continuous_subtype_val
+  continuous_toFun := continuous_subtype_val
 
 @[simp] lemma coe_subtypeA (s : AffineSubspace R P) [Nonempty s] : ⇑s.subtypeA = Subtype.val :=
   rfl

--- a/Mathlib/Topology/Algebra/Algebra.lean
+++ b/Mathlib/Topology/Algebra/Algebra.lean
@@ -71,7 +71,7 @@ variable [ContinuousSMul R A]
 def algebraMapCLM : R →L[R] A :=
   { Algebra.linearMap R A with
     toFun := algebraMap R A
-    cont := continuous_algebraMap R A }
+    continuous_toFun := continuous_algebraMap R A }
 
 theorem coe_algebraMapCLM : ⇑(algebraMapCLM R A) = algebraMap R A :=
   rfl

--- a/Mathlib/Topology/Algebra/ContinuousAffineEquiv.lean
+++ b/Mathlib/Topology/Algebra/ContinuousAffineEquiv.lean
@@ -122,7 +122,6 @@ protected theorem continuous (e : P₁ ≃ᴬ[k] P₂) : Continuous e :=
 /-- A continuous affine equivalence is a continuous affine map. -/
 def toContinuousAffineMap (e : P₁ ≃ᴬ[k] P₂) : P₁ →ᴬ[k] P₂ where
   __ := e
-  cont := e.continuous_toFun
 
 /-- Coerce continuous linear equivs to continuous linear maps. -/
 instance ContinuousAffineMap.coe : Coe (P₁ ≃ᴬ[k] P₂) (P₁ →ᴬ[k] P₂) :=

--- a/Mathlib/Topology/Algebra/ContinuousAffineMap.lean
+++ b/Mathlib/Topology/Algebra/ContinuousAffineMap.lean
@@ -32,7 +32,7 @@ for `ContinuousLinearMap R E F`.
 structure ContinuousAffineMap (R : Type*) {V W : Type*} (P Q : Type*) [Ring R] [AddCommGroup V]
   [Module R V] [TopologicalSpace P] [AddTorsor V P] [AddCommGroup W] [Module R W]
   [TopologicalSpace Q] [AddTorsor W Q] extends P →ᵃ[R] Q where
-  cont : Continuous toFun
+  continuous_toFun : Continuous toFun
 
 /-- A continuous map of affine spaces -/
 notation:25 P " →ᴬ[" R "] " Q => ContinuousAffineMap R P Q
@@ -59,7 +59,7 @@ instance : FunLike (P →ᴬ[R] Q) P Q where
   coe_injective' _ _ h := toAffineMap_injective <| DFunLike.coe_injective h
 
 instance : ContinuousMapClass (P →ᴬ[R] Q) P Q where
-  map_continuous := cont
+  map_continuous := continuous_toFun
 
 theorem toFun_eq_coe (f : P →ᴬ[R] Q) : f.toFun = ⇑f := rfl
 
@@ -75,7 +75,7 @@ theorem congr_fun {f g : P →ᴬ[R] Q} (h : f = g) (x : P) : f x = g x :=
 
 /-- Forgetting its algebraic properties, a continuous affine map is a continuous map. -/
 def toContinuousMap (f : P →ᴬ[R] Q) : C(P, Q) :=
-  ⟨f, f.cont⟩
+  ⟨f, f.continuous_toFun⟩
 
 instance : CoeHead (P →ᴬ[R] Q) C(P, Q) :=
   ⟨toContinuousMap⟩
@@ -115,7 +115,7 @@ variable (R P)
 
 /-- The constant map as a continuous affine map -/
 def const (q : Q) : P →ᴬ[R] Q :=
-  { AffineMap.const R P q with cont := continuous_const }
+  { AffineMap.const R P q with continuous_toFun := continuous_const }
 
 @[simp]
 theorem coe_const (q : Q) : ⇑(const R P q) = Function.const P q := rfl
@@ -124,7 +124,7 @@ noncomputable instance : Inhabited (P →ᴬ[R] Q) :=
   ⟨const R P <| Nonempty.some (by infer_instance : Nonempty Q)⟩
 
 /-- The identity map as a continuous affine map -/
-def id : P →ᴬ[R] P := { AffineMap.id R P with cont := continuous_id }
+def id : P →ᴬ[R] P := { AffineMap.id R P with continuous_toFun := continuous_id }
 
 @[simp, norm_cast]
 theorem coe_id : ⇑(id R P) = _root_.id := rfl
@@ -134,7 +134,8 @@ variable [AddCommGroup W₂] [Module R W₂] [TopologicalSpace Q₂] [AddTorsor 
 
 /-- The composition of continuous affine maps as a continuous affine map -/
 def comp (f : Q →ᴬ[R] Q₂) (g : P →ᴬ[R] Q) : P →ᴬ[R] Q₂ :=
-  { (f : Q →ᵃ[R] Q₂).comp (g : P →ᵃ[R] Q) with cont := f.cont.comp g.cont }
+  { (f : Q →ᵃ[R] Q₂).comp (g : P →ᵃ[R] Q) with
+    continuous_toFun := f.continuous_toFun.comp g.continuous_toFun }
 
 @[simp, norm_cast]
 theorem coe_comp (f : Q →ᴬ[R] Q₂) (g : P →ᴬ[R] Q) : ⇑(f.comp g) = f ∘ g := rfl
@@ -153,7 +154,7 @@ theorem id_comp (f : P →ᴬ[R] Q) : (id R Q).comp f = f :=
 def lineMap (p₀ p₁ : P) [TopologicalSpace R] [TopologicalSpace V]
     [ContinuousSMul R V] [ContinuousVAdd V P] : R →ᴬ[R] P where
   toAffineMap := AffineMap.lineMap p₀ p₁
-  cont := (continuous_id.smul continuous_const).vadd continuous_const
+  continuous_toFun := (continuous_id.smul continuous_const).vadd continuous_const
 
 @[simp] lemma lineMap_toAffineMap (p₀ p₁ : P) [TopologicalSpace R] [TopologicalSpace V]
     [ContinuousSMul R V] [ContinuousVAdd V P] :
@@ -173,7 +174,7 @@ variable [TopologicalSpace W₂] [IsTopologicalAddTorsor Q₂]
 def contLinear (f : P →ᴬ[R] Q) : V →L[R] W :=
   { f.linear with
     toFun := f.linear
-    cont := by rw [AffineMap.continuous_linear_iff]; exact f.cont }
+    continuous_toFun := by rw [AffineMap.continuous_linear_iff]; exact f.continuous_toFun }
 
 @[simp]
 theorem coe_contLinear (f : P →ᴬ[R] Q) : (f.contLinear : V → W) = f.linear :=
@@ -248,7 +249,7 @@ variable [Monoid S] [DistribMulAction S W] [SMulCommClass R S W]
 variable [ContinuousConstSMul S W]
 
 instance : SMul S (P →ᴬ[R] W) where
-  smul t f := { t • (f : P →ᵃ[R] W) with cont := f.continuous.const_smul t }
+  smul t f := { t • (f : P →ᵃ[R] W) with continuous_toFun := f.continuous_toFun.const_smul t }
 
 @[norm_cast, simp]
 theorem coe_smul (t : S) (f : P →ᴬ[R] W) : ⇑(t • f) = t • ⇑f := rfl
@@ -272,7 +273,8 @@ end MulAction
 variable [IsTopologicalAddGroup W]
 
 instance : Add (P →ᴬ[R] W) where
-  add f g := { (f : P →ᵃ[R] W) + (g : P →ᵃ[R] W) with cont := f.continuous.add g.continuous }
+  add f g := { (f : P →ᵃ[R] W) + (g : P →ᵃ[R] W) with
+    continuous_toFun := f.continuous.add g.continuous }
 
 @[norm_cast, simp]
 theorem coe_add (f g : P →ᴬ[R] W) : ⇑(f + g) = f + g := rfl
@@ -280,7 +282,8 @@ theorem coe_add (f g : P →ᴬ[R] W) : ⇑(f + g) = f + g := rfl
 theorem add_apply (f g : P →ᴬ[R] W) (x : P) : (f + g) x = f x + g x := rfl
 
 instance : Sub (P →ᴬ[R] W) where
-  sub f g := { (f : P →ᵃ[R] W) - (g : P →ᵃ[R] W) with cont := f.continuous.sub g.continuous }
+  sub f g := { (f : P →ᵃ[R] W) - (g : P →ᵃ[R] W) with
+    continuous_toFun := f.continuous.sub g.continuous }
 
 @[norm_cast, simp]
 theorem coe_sub (f g : P →ᴬ[R] W) : ⇑(f - g) = f - g := rfl
@@ -288,7 +291,7 @@ theorem coe_sub (f g : P →ᴬ[R] W) : ⇑(f - g) = f - g := rfl
 theorem sub_apply (f g : P →ᴬ[R] W) (x : P) : (f - g) x = f x - g x := rfl
 
 instance : Neg (P →ᴬ[R] W) :=
-  { neg := fun f => { -(f : P →ᵃ[R] W) with cont := f.continuous.neg } }
+  { neg := fun f => { -(f : P →ᵃ[R] W) with continuous_toFun := f.continuous.neg } }
 
 @[norm_cast, simp]
 theorem coe_neg (f : P →ᴬ[R] W) : ⇑(-f) = -f := rfl
@@ -335,10 +338,14 @@ variable [TopologicalSpace W] [IsTopologicalAddGroup W] [IsTopologicalAddTorsor 
 /-- The space of continuous affine maps from `P` to `Q` is an affine space over the space of
 continuous affine maps from `P` to `W`. -/
 instance : AddTorsor (P →ᴬ[R] W) (P →ᴬ[R] Q) where
-  vadd f g := { __ := f.toAffineMap +ᵥ g.toAffineMap, cont := f.cont.vadd g.cont }
+  vadd f g := {
+    __ := f.toAffineMap +ᵥ g.toAffineMap,
+    continuous_toFun := f.continuous_toFun.vadd g.continuous_toFun }
   zero_vadd _ := ext fun _ ↦ zero_vadd _ _
   add_vadd _ _ _ := ext fun _ ↦ add_vadd _ _ _
-  vsub f g := { __ := f.toAffineMap -ᵥ g.toAffineMap, cont := f.cont.vsub g.cont }
+  vsub f g := {
+    __ := f.toAffineMap -ᵥ g.toAffineMap,
+    continuous_toFun := f.continuous_toFun.vsub g.continuous_toFun }
   vsub_vadd' _ _ := ext fun _ ↦ vsub_vadd _ _
   vadd_vsub' _ _ := ext fun _ ↦ vadd_vsub _ _
 
@@ -380,7 +387,7 @@ variable {k P₁ P₂ P₃ P₄ V₁ V₂ V₃ V₄ : Type*} [Ring k]
 @[simps toAffineMap]
 def prod (f : P₁ →ᴬ[k] P₂) (g : P₁ →ᴬ[k] P₃) : P₁ →ᴬ[k] P₂ × P₃ where
   __ := AffineMap.prod f g
-  cont := by eta_expand; dsimp; fun_prop
+  continuous_toFun := by eta_expand; dsimp; fun_prop
 
 theorem coe_prod (f : P₁ →ᴬ[k] P₂) (g : P₁ →ᴬ[k] P₃) : prod f g = Pi.prod f g :=
   rfl
@@ -393,7 +400,7 @@ theorem prod_apply (f : P₁ →ᴬ[k] P₂) (g : P₁ →ᴬ[k] P₃) (p : P₁
 @[simps toAffineMap]
 def prodMap (f : P₁ →ᴬ[k] P₂) (g : P₃ →ᴬ[k] P₄) : P₁ × P₃ →ᴬ[k] P₂ × P₄ where
   __ := AffineMap.prodMap f g
-  cont := by eta_expand; dsimp; fun_prop
+  continuous_toFun := by eta_expand; dsimp; fun_prop
 
 theorem coe_prodMap (f : P₁ →ᴬ[k] P₂) (g : P₃ →ᴬ[k] P₄) : ⇑(f.prodMap g) = Prod.map f g :=
   rfl
@@ -433,7 +440,7 @@ def toContinuousAffineMap (f : V →L[R] W) : V →ᴬ[R] W where
   toFun := f
   linear := f
   map_vadd' := by simp
-  cont := f.cont
+  continuous_toFun := f.continuous
 
 @[simp]
 theorem coe_toContinuousAffineMap (f : V →L[R] W) : ⇑f.toContinuousAffineMap = f := rfl

--- a/Mathlib/Topology/Algebra/Module/Alternating/Basic.lean
+++ b/Mathlib/Topology/Algebra/Module/Alternating/Basic.lean
@@ -76,12 +76,12 @@ instance funLike : FunLike (M [⋀^ι]→L[R] N) (ι → M) N where
   coe_injective' _ _ h := toContinuousMultilinearMap_injective <| DFunLike.ext' h
 
 instance continuousMapClass : ContinuousMapClass (M [⋀^ι]→L[R] N) (ι → M) N where
-  map_continuous f := f.cont
+  map_continuous f := f.continuous_toFun
 
 initialize_simps_projections ContinuousAlternatingMap (toFun → apply)
 
 @[continuity]
-theorem coe_continuous : Continuous f := f.cont
+theorem coe_continuous : Continuous f := f.continuous_toFun
 
 @[simp]
 theorem coe_toContinuousMultilinearMap : ⇑f.toContinuousMultilinearMap = f :=
@@ -107,7 +107,8 @@ theorem toAlternatingMap_injective :
 theorem range_toAlternatingMap :
     Set.range (toAlternatingMap : M [⋀^ι]→L[R] N → (M [⋀^ι]→ₗ[R] N)) =
       {f : M [⋀^ι]→ₗ[R] N | Continuous f} :=
-  Set.ext fun f => ⟨fun ⟨g, hg⟩ => hg ▸ g.cont, fun h => ⟨{ f with cont := h }, DFunLike.ext' rfl⟩⟩
+  Set.ext fun f => ⟨fun ⟨g, hg⟩ => hg ▸ g.continuous_toFun,
+    fun h => ⟨{ f with continuous_toFun := h }, DFunLike.ext' rfl⟩⟩
 
 @[simp]
 theorem map_update_add [DecidableEq ι] (m : ι → M) (i : ι) (x y : M) :

--- a/Mathlib/Topology/Algebra/Module/Alternating/Topology.lean
+++ b/Mathlib/Topology/Algebra/Module/Alternating/Topology.lean
@@ -236,7 +236,7 @@ def liftCLM (f : G →L[𝕜] ContinuousMultilinearMap 𝕜 (fun _ : ι ↦ E) F
   toFun x := ⟨f x, hf x⟩
   map_add' _ _ := by ext; simp
   map_smul' _ _ := by ext; simp
-  cont := continuous_induced_rng.mpr (map_continuous f)
+  continuous_toFun := continuous_induced_rng.mpr (map_continuous f)
 
 @[simp]
 lemma liftCLM_apply (f : G →L[𝕜] ContinuousMultilinearMap 𝕜 (fun _ : ι ↦ E) F)
@@ -252,7 +252,7 @@ def apply (m : ι → E) : E [⋀^ι]→L[𝕜] F →L[𝕜] F where
   toFun c := c m
   map_add' _ _ := rfl
   map_smul' _ _ := rfl
-  cont := continuous_eval_const m
+  continuous_toFun := continuous_eval_const m
 
 variable {𝕜 E F}
 

--- a/Mathlib/Topology/Algebra/Module/CharacterSpace.lean
+++ b/Mathlib/Topology/Algebra/Module/CharacterSpace.lean
@@ -64,7 +64,7 @@ instance instFunLike : FunLike (characterSpace 𝕜 A) A 𝕜 where
 instance instContinuousLinearMapClass : ContinuousLinearMapClass (characterSpace 𝕜 A) 𝕜 A 𝕜 where
   map_smulₛₗ φ := (φ : WeakDual 𝕜 A).map_smul
   map_add φ := (φ : WeakDual 𝕜 A).map_add
-  map_continuous φ := (φ : WeakDual 𝕜 A).cont
+  map_continuous φ := (φ : WeakDual 𝕜 A).continuous_toFun
 
 /-- This has to come after `WeakDual.CharacterSpace.instFunLike`, otherwise the right-hand side
 gets coerced via `Subtype.val` instead of directly via `DFunLike`. -/

--- a/Mathlib/Topology/Algebra/Module/Equiv.lean
+++ b/Mathlib/Topology/Algebra/Module/Equiv.lean
@@ -136,7 +136,7 @@ variable {R₁ : Type*} {R₂ : Type*} {R₃ : Type*} [Semiring R₁] [Semiring 
 /-- A continuous linear equivalence induces a continuous linear map. -/
 @[coe]
 def toContinuousLinearMap (e : M₁ ≃SL[σ₁₂] M₂) : M₁ →SL[σ₁₂] M₂ :=
-  { e.toLinearEquiv.toLinearMap with cont := e.continuous_toFun }
+  { e.toLinearEquiv.toLinearMap with continuous_toFun := e.continuous_toFun }
 
 /-- Coerce continuous linear equivs to continuous linear maps. -/
 instance ContinuousLinearMap.coe : Coe (M₁ ≃SL[σ₁₂] M₂) (M₁ →SL[σ₁₂] M₂) :=

--- a/Mathlib/Topology/Algebra/Module/LinearMap.lean
+++ b/Mathlib/Topology/Algebra/Module/LinearMap.lean
@@ -36,9 +36,9 @@ ring `R`. -/
 structure ContinuousLinearMap {R : Type*} {S : Type*} [Semiring R] [Semiring S] (σ : R →+* S)
     (M : Type*) [TopologicalSpace M] [AddCommMonoid M] (M₂ : Type*) [TopologicalSpace M₂]
     [AddCommMonoid M₂] [Module R M] [Module S M₂] extends M →ₛₗ[σ] M₂ where
-  cont : Continuous toFun := by continuity
+  continuous_toFun : Continuous toFun := by continuity
 
-attribute [inherit_doc ContinuousLinearMap] ContinuousLinearMap.cont
+attribute [inherit_doc ContinuousLinearMap] ContinuousLinearMap.continuous_toFun
 
 @[inherit_doc]
 notation:25 M " →SL[" σ "] " M₂ => ContinuousLinearMap σ M M₂
@@ -157,7 +157,7 @@ theorem ext {f g : M₁ →SL[σ₁₂] M₂} (h : ∀ x, f x = g x) : f = g :=
 definitional equalities. -/
 protected def copy (f : M₁ →SL[σ₁₂] M₂) (f' : M₁ → M₂) (h : f' = ⇑f) : M₁ →SL[σ₁₂] M₂ where
   toLinearMap := f.toLinearMap.copy f' h
-  cont := show Continuous f' from h.symm ▸ f.continuous
+  continuous_toFun := show Continuous f' from h.symm ▸ f.continuous
 
 @[simp]
 theorem coe_copy (f : M₁ →SL[σ₁₂] M₂) (f' : M₁ → M₂) (h : f' = ⇑f) : ⇑(f.copy f' h) = f' :=
@@ -613,7 +613,7 @@ instance completeSpace_eqLocus {M' : Type*} [UniformSpace M'] [CompleteSpace M']
 /-- Restrict codomain of a continuous linear map. -/
 def codRestrict (f : M₁ →SL[σ₁₂] M₂) (p : Submodule R₂ M₂) (h : ∀ x, f x ∈ p) :
     M₁ →SL[σ₁₂] p where
-  cont := f.continuous.subtype_mk _
+  continuous_toFun := f.continuous.subtype_mk _
   toLinearMap := (f : M₁ →ₛₗ[σ₁₂] M₂).codRestrict p h
 
 @[norm_cast]
@@ -643,7 +643,7 @@ theorem coe_rangeRestrict [RingHomSurjective σ₁₂] (f : M₁ →SL[σ₁₂]
 
 /-- `Submodule.subtype` as a `ContinuousLinearMap`. -/
 def _root_.Submodule.subtypeL (p : Submodule R₁ M₁) : p →L[R₁] M₁ where
-  cont := continuous_subtype_val
+  continuous_toFun := continuous_subtype_val
   toLinearMap := p.subtype
 
 @[simp, norm_cast]
@@ -676,7 +676,7 @@ variable {R S : Type*} [Semiring R] [Semiring S] [Module R M₁] [Module R M₂]
 See also `ContinuousLinearMap.smulRightₗ` and `ContinuousLinearMap.smulRightL`. -/
 @[simps coe]
 def smulRight (c : M₁ →L[R] S) (f : M₂) : M₁ →L[R] M₂ :=
-  { c.toLinearMap.smulRight f with cont := c.2.smul continuous_const }
+  { c.toLinearMap.smulRight f with continuous_toFun := c.2.smul continuous_const }
 
 @[simp]
 theorem smulRight_apply {c : M₁ →L[R] S} {f : M₂} {x : M₁} :
@@ -709,7 +709,7 @@ variable [ContinuousSMul R₁ M₁]
 linear map from `R` to `M` by taking multiples of `x`. -/
 def toSpanSingleton (x : M₁) : R₁ →L[R₁] M₁ where
   toLinearMap := LinearMap.toSpanSingleton R₁ M₁ x
-  cont := continuous_id.smul continuous_const
+  continuous_toFun := continuous_id.smul continuous_const
 
 @[simp]
 theorem toSpanSingleton_apply (x : M₁) (r : R₁) : toSpanSingleton R₁ x r = r • x :=

--- a/Mathlib/Topology/Algebra/Module/LinearMapPiProd.lean
+++ b/Mathlib/Topology/Algebra/Module/LinearMapPiProd.lean
@@ -92,12 +92,12 @@ variable (R M₁ M₂)
 
 /-- `Prod.fst` as a `ContinuousLinearMap`. -/
 def fst : M₁ × M₂ →L[R] M₁ where
-  cont := continuous_fst
+  continuous_toFun := continuous_fst
   toLinearMap := LinearMap.fst R M₁ M₂
 
 /-- `Prod.snd` as a `ContinuousLinearMap`. -/
 def snd : M₁ × M₂ →L[R] M₂ where
-  cont := continuous_snd
+  continuous_toFun := continuous_snd
   toLinearMap := LinearMap.snd R M₁ M₂
 
 variable {R M₁ M₂}
@@ -220,7 +220,7 @@ def _root_.Pi.compRightL {α : Type*} (f : α → ι) : ((i : ι) → φ i) →L
   toFun := fun v i ↦ v (f i)
   map_add' := by intros; ext; simp
   map_smul' := by intros; ext; simp
-  cont := by fun_prop
+  continuous_toFun := by fun_prop
 
 @[simp] lemma _root_.Pi.compRightL_apply {α : Type*} (f : α → ι) (v : (i : ι) → φ i) (i : α) :
     Pi.compRightL R φ f v i = v (f i) := rfl
@@ -229,7 +229,7 @@ def _root_.Pi.compRightL {α : Type*} (f : α → ι) : ((i : ι) → φ i) →L
 @[simps! -fullyApplied]
 def single [DecidableEq ι] (i : ι) : φ i →L[R] (∀ i, φ i) where
   toLinearMap := .single R φ i
-  cont := continuous_single _
+  continuous_toFun := continuous_single _
 
 lemma sum_comp_single [Fintype ι] [DecidableEq ι] (L : (Π i, φ i) →L[R] M) (v : Π i, φ i) :
     ∑ i, L.comp (.single R φ i) (v i) = L v := by
@@ -306,7 +306,8 @@ variable [AddCommMonoid M] [Module R M] [ContinuousAdd M] [AddCommMonoid N] [Mod
 /-- The continuous linear map given by `(x, y) ↦ f₁ x + f₂ y`. -/
 @[simps! coe apply]
 def coprod (f₁ : M₁ →L[R] M) (f₂ : M₂ →L[R] M) : M₁ × M₂ →L[R] M :=
-  ⟨.coprod f₁ f₂, (f₁.cont.comp continuous_fst).add (f₂.cont.comp continuous_snd)⟩
+  ⟨.coprod f₁ f₂,
+    (f₁.continuous_toFun.comp continuous_fst).add (f₂.continuous_toFun.comp continuous_snd)⟩
 
 @[simp] lemma coprod_add (f₁ g₁ : M₁ →L[R] M) (f₂ g₂ : M₂ →L[R] M) :
     (f₁ + g₁).coprod (f₂ + g₂) = f₁.coprod f₂ + g₁.coprod g₂ := by ext <;> simp

--- a/Mathlib/Topology/Algebra/Module/Multilinear/Basic.lean
+++ b/Mathlib/Topology/Algebra/Module/Multilinear/Basic.lean
@@ -51,9 +51,9 @@ definition. -/
 structure ContinuousMultilinearMap (R : Type u) {ι : Type v} (M₁ : ι → Type w₁) (M₂ : Type w₂)
   [Semiring R] [∀ i, AddCommMonoid (M₁ i)] [AddCommMonoid M₂] [∀ i, Module R (M₁ i)] [Module R M₂]
   [∀ i, TopologicalSpace (M₁ i)] [TopologicalSpace M₂] extends MultilinearMap R M₁ M₂ where
-  cont : Continuous toFun
+  continuous_toFun : Continuous toFun
 
-attribute [inherit_doc ContinuousMultilinearMap] ContinuousMultilinearMap.cont
+attribute [inherit_doc ContinuousMultilinearMap] ContinuousMultilinearMap.continuous_toFun
 
 @[inherit_doc]
 notation:25 M " [×" n "]→L[" R "] " M' => ContinuousMultilinearMap R (fun i : Fin n => M) M'
@@ -81,7 +81,7 @@ instance funLike : FunLike (ContinuousMultilinearMap R M₁ M₂) (∀ i, M₁ i
 
 instance continuousMapClass :
     ContinuousMapClass (ContinuousMultilinearMap R M₁ M₂) (∀ i, M₁ i) M₂ where
-  map_continuous := ContinuousMultilinearMap.cont
+  map_continuous := ContinuousMultilinearMap.continuous_toFun
 
 /-- See Note [custom simps projection]. We need to specify this projection explicitly in this case,
   because it is a composition of multiple projections. -/
@@ -93,7 +93,7 @@ initialize_simps_projections ContinuousMultilinearMap (-toMultilinearMap,
 
 @[continuity]
 theorem coe_continuous : Continuous (f : (∀ i, M₁ i) → M₂) :=
-  f.cont
+  f.continuous_toFun
 
 @[simp]
 theorem coe_coe : (f.toMultilinearMap : (∀ i, M₁ i) → M₂) = f :=
@@ -121,7 +121,7 @@ theorem map_zero [Nonempty ι] : f 0 = 0 :=
   f.toMultilinearMap.map_zero
 
 instance : Zero (ContinuousMultilinearMap R M₁ M₂) :=
-  ⟨{ (0 : MultilinearMap R M₁ M₂) with cont := continuous_const }⟩
+  ⟨{ (0 : MultilinearMap R M₁ M₂) with continuous_toFun := continuous_const }⟩
 
 instance : Inhabited (ContinuousMultilinearMap R M₁ M₂) :=
   ⟨0⟩
@@ -141,7 +141,7 @@ variable {R' R'' A : Type*} [Monoid R'] [Monoid R''] [Semiring A] [∀ i, Module
   [DistribMulAction R'' M₂] [ContinuousConstSMul R'' M₂] [SMulCommClass A R'' M₂]
 
 instance : SMul R' (ContinuousMultilinearMap A M₁ M₂) :=
-  ⟨fun c f => { c • f.toMultilinearMap with cont := f.cont.const_smul c }⟩
+  ⟨fun c f => { c • f.toMultilinearMap with continuous_toFun := f.continuous_toFun.const_smul c }⟩
 
 @[simp]
 theorem smul_apply (f : ContinuousMultilinearMap A M₁ M₂) (c : R') (m : ∀ i, M₁ i) :
@@ -174,7 +174,8 @@ section ContinuousAdd
 variable [ContinuousAdd M₂]
 
 instance : Add (ContinuousMultilinearMap R M₁ M₂) :=
-  ⟨fun f f' => ⟨f.toMultilinearMap + f'.toMultilinearMap, f.cont.add f'.cont⟩⟩
+  ⟨fun f f' => ⟨f.toMultilinearMap + f'.toMultilinearMap,
+    f.continuous_toFun.add f'.continuous_toFun⟩⟩
 
 @[simp]
 theorem add_apply (m : ∀ i, M₁ i) : (f + f') m = f m + f' m :=
@@ -206,12 +207,13 @@ linear map obtained by fixing all coordinates but `i` equal to those of `m`, and
 `i`-th coordinate. -/
 @[simps!] def toContinuousLinearMap [DecidableEq ι] (m : ∀ i, M₁ i) (i : ι) : M₁ i →L[R] M₂ :=
   { f.toMultilinearMap.toLinearMap m i with
-    cont := f.cont.comp (continuous_const.update i continuous_id) }
+    continuous_toFun := f.continuous_toFun.comp (continuous_const.update i continuous_id) }
 
 /-- The Cartesian product of two continuous multilinear maps, as a continuous multilinear map. -/
 def prod (f : ContinuousMultilinearMap R M₁ M₂) (g : ContinuousMultilinearMap R M₁ M₃) :
     ContinuousMultilinearMap R M₁ (M₂ × M₃) :=
-  { f.toMultilinearMap.prod g.toMultilinearMap with cont := f.cont.prodMk g.cont }
+  { f.toMultilinearMap.prod g.toMultilinearMap with
+    continuous_toFun := f.continuous_toFun.prodMk g.continuous_toFun }
 
 @[simp]
 theorem prod_apply (f : ContinuousMultilinearMap R M₁ M₂) (g : ContinuousMultilinearMap R M₁ M₃)
@@ -223,7 +225,7 @@ continuous multilinear map taking values in the space of functions `∀ i, M' i`
 def pi {ι' : Type*} {M' : ι' → Type*} [∀ i, AddCommMonoid (M' i)] [∀ i, TopologicalSpace (M' i)]
     [∀ i, Module R (M' i)] (f : ∀ i, ContinuousMultilinearMap R M₁ (M' i)) :
     ContinuousMultilinearMap R M₁ (∀ i, M' i) where
-  cont := continuous_pi fun i => (f i).coe_continuous
+  continuous_toFun := continuous_pi fun i => (f i).coe_continuous
   toMultilinearMap := MultilinearMap.pi fun i => (f i).toMultilinearMap
 
 @[simp]
@@ -241,7 +243,7 @@ theorem pi_apply {ι' : Type*} {M' : ι' → Type*} [∀ i, AddCommMonoid (M' i)
 @[simps! toMultilinearMap apply_coe]
 def codRestrict (f : ContinuousMultilinearMap R M₁ M₂) (p : Submodule R M₂) (h : ∀ v, f v ∈ p) :
     ContinuousMultilinearMap R M₁ p :=
-  ⟨f.1.codRestrict p h, f.cont.subtype_mk _⟩
+  ⟨f.1.codRestrict p h, f.continuous_toFun.subtype_mk _⟩
 
 section
 
@@ -265,7 +267,7 @@ variable (M₁) {M₂}
 @[simps! toMultilinearMap apply]
 def constOfIsEmpty [IsEmpty ι] (m : M₂) : ContinuousMultilinearMap R M₁ M₂ where
   toMultilinearMap := MultilinearMap.constOfIsEmpty R _ m
-  cont := continuous_const
+  continuous_toFun := continuous_const
 
 end
 
@@ -275,7 +277,8 @@ then `g (f₁ m₁, ..., fₙ mₙ)` is again a continuous multilinear map, that
 def compContinuousLinearMap (g : ContinuousMultilinearMap R M₁' M₄)
     (f : ∀ i : ι, M₁ i →L[R] M₁' i) : ContinuousMultilinearMap R M₁ M₄ :=
   { g.toMultilinearMap.compLinearMap fun i => (f i).toLinearMap with
-    cont := g.cont.comp <| continuous_pi fun j => (f j).cont.comp <| continuous_apply _ }
+    continuous_toFun := g.continuous_toFun.comp <|
+      continuous_pi fun j => (f j).continuous_toFun.comp <| continuous_apply _ }
 
 @[simp]
 theorem compContinuousLinearMap_apply (g : ContinuousMultilinearMap R M₁' M₄)
@@ -287,7 +290,8 @@ theorem compContinuousLinearMap_apply (g : ContinuousMultilinearMap R M₁' M₄
 continuous multilinear map. -/
 def _root_.ContinuousLinearMap.compContinuousMultilinearMap (g : M₂ →L[R] M₃)
     (f : ContinuousMultilinearMap R M₁ M₂) : ContinuousMultilinearMap R M₁ M₃ :=
-  { g.toLinearMap.compMultilinearMap f.toMultilinearMap with cont := g.cont.comp f.cont }
+  { g.toLinearMap.compMultilinearMap f.toMultilinearMap with
+    continuous_toFun := g.continuous_toFun.comp f.continuous_toFun }
 
 @[simp]
 theorem _root_.ContinuousLinearMap.compContinuousMultilinearMap_coe (g : M₂ →L[R] M₃)
@@ -359,7 +363,7 @@ nonrec def domDomCongr {ι' : Type*} (e : ι ≃ ι')
     (f : ContinuousMultilinearMap R (fun _ : ι => M₂) M₃) :
     ContinuousMultilinearMap R (fun _ : ι' => M₂) M₃ where
   toMultilinearMap := f.domDomCongr e
-  cont := f.cont.comp <| continuous_pi fun _ => continuous_apply _
+  continuous_toFun := f.continuous_toFun.comp <| continuous_pi fun _ => continuous_apply _
 
 /-- An equivalence of the index set defines an equivalence between the spaces of continuous
 multilinear maps. In case of normed spaces, this is a linear isometric equivalence, see
@@ -447,7 +451,7 @@ variable {A : Type*} [Semiring A] [SMul R A] [∀ i : ι, Module A (M₁ i)] [Mo
 and their actions on all involved modules agree with the action of `R` on `A`. -/
 def restrictScalars (f : ContinuousMultilinearMap A M₁ M₂) : ContinuousMultilinearMap R M₁ M₂ where
   toMultilinearMap := f.toMultilinearMap.restrictScalars R
-  cont := f.cont
+  continuous_toFun := f.continuous_toFun
 
 @[simp]
 theorem coe_restrictScalars (f : ContinuousMultilinearMap A M₁ M₂) : ⇑(f.restrictScalars R) = f :=
@@ -472,14 +476,15 @@ section IsTopologicalAddGroup
 variable [IsTopologicalAddGroup M₂]
 
 instance : Neg (ContinuousMultilinearMap R M₁ M₂) :=
-  ⟨fun f => { -f.toMultilinearMap with cont := f.cont.neg }⟩
+  ⟨fun f => { -f.toMultilinearMap with continuous_toFun := f.continuous_toFun.neg }⟩
 
 @[simp]
 theorem neg_apply (m : ∀ i, M₁ i) : (-f) m = -f m :=
   rfl
 
 instance : Sub (ContinuousMultilinearMap R M₁ M₂) :=
-  ⟨fun f g => { f.toMultilinearMap - g.toMultilinearMap with cont := f.cont.sub g.cont }⟩
+  ⟨fun f g => { f.toMultilinearMap - g.toMultilinearMap with
+    continuous_toFun := f.continuous_toFun.sub g.continuous_toFun }⟩
 
 @[simp]
 theorem sub_apply (m : ∀ i, M₁ i) : (f - f') m = f m - f' m :=
@@ -595,7 +600,7 @@ variable (R n) (A : Type*) [CommSemiring R] [Semiring A] [Algebra R A] [Topologi
 
 See also: `ContinuousMultilinearMap.mkPiAlgebra`. -/
 protected def mkPiAlgebraFin : A[×n]→L[R] A where
-  cont := by
+  continuous_toFun := by
     change Continuous fun m => (List.ofFn m).prod
     simp_rw [List.ofFn_eq_map]
     exact continuous_list_prod _ fun i _ => continuous_apply _
@@ -620,7 +625,7 @@ over `𝕜`, associating to `m` the product of all the `m i`.
 
 See also `ContinuousMultilinearMap.mkPiAlgebraFin`. -/
 protected def mkPiAlgebra : ContinuousMultilinearMap R (fun _ : ι => A) A where
-  cont := continuous_finset_prod _ fun _ _ => continuous_apply _
+  continuous_toFun := continuous_finset_prod _ fun _ _ => continuous_apply _
   toMultilinearMap := MultilinearMap.mkPiAlgebra R ι A
 
 @[simp]
@@ -645,7 +650,7 @@ continuous multilinear map sending `m` to `f m • z`. -/
 @[simps! toMultilinearMap apply]
 def smulRight : ContinuousMultilinearMap R M₁ M₂ where
   toMultilinearMap := f.toMultilinearMap.smulRight z
-  cont := f.cont.smul continuous_const
+  continuous_toFun := f.continuous_toFun.smul continuous_const
 
 end SMulRight
 

--- a/Mathlib/Topology/Algebra/Module/Multilinear/Topology.lean
+++ b/Mathlib/Topology/Algebra/Module/Multilinear/Topology.lean
@@ -49,7 +49,7 @@ lemma range_toUniformOnFun [DecidableEq ι] [TopologicalSpace F] :
   ext f
   constructor
   · rintro ⟨f, rfl⟩
-    exact ⟨f.cont, f.map_update_add, f.map_update_smul⟩
+    exact ⟨f.continuous_toFun, f.map_update_add, f.map_update_smul⟩
   · rintro ⟨hcont, hadd, hsmul⟩
     exact ⟨⟨⟨f, by intro; convert hadd, by intro; convert hsmul⟩, hcont⟩, rfl⟩
 
@@ -261,7 +261,7 @@ def apply [ContinuousConstSMul 𝕜 F] (m : Π i, E i) : ContinuousMultilinearMa
   toFun c := c m
   map_add' _ _ := rfl
   map_smul' _ _ := rfl
-  cont := continuous_eval_const m
+  continuous_toFun := continuous_eval_const m
 
 variable {𝕜 E F}
 

--- a/Mathlib/Topology/Algebra/Module/PointwiseConvergence.lean
+++ b/Mathlib/Topology/Algebra/Module/PointwiseConvergence.lean
@@ -120,7 +120,7 @@ variable (σ F) in
 @[simps!]
 def evalCLM [ContinuousConstSMul 𝕜₂ F] (a : E) : (E →SLₚₜ[σ] F) →L[𝕜₂] F where
   toLinearMap := (coeLMₛₗ σ E F).flip a
-  cont := continuous_eval_const a
+  continuous_toFun := continuous_eval_const a
 
 /-- A map to `E →SLₚₜ[σ] F` is continuous if for every `x : E` the evaluation `g · x` is
 continuous. -/
@@ -153,7 +153,7 @@ variable (𝕜₂ σ E F) in
 def _root_.ContinuousLinearMap.toPointwiseConvergenceCLM [ContinuousSMul 𝕜₁ E]
     [ContinuousConstSMul 𝕜₂ F] : (E →SL[σ] F) →L[𝕜₂] (E →SLₚₜ[σ] F) where
   __ := LinearMap.id
-  cont := _root_.ContinuousLinearMap.toUniformConvergenceCLM_continuous σ F _
+  continuous_toFun := _root_.ContinuousLinearMap.toUniformConvergenceCLM_continuous σ F _
     (fun _ ↦ Set.Finite.isVonNBounded)
 
 variable (𝕜 E) in

--- a/Mathlib/Topology/Algebra/Module/Star.lean
+++ b/Mathlib/Topology/Algebra/Module/Star.lean
@@ -73,14 +73,14 @@ theorem continuous_decomposeProdAdjoint_symm [ContinuousAdd A] :
 def selfAdjointPartL [ContinuousAdd A] [ContinuousStar A] [ContinuousConstSMul R A] :
     A →L[R] selfAdjoint A where
   toLinearMap := selfAdjointPart R
-  cont := continuous_selfAdjointPart _ _
+  continuous_toFun := continuous_selfAdjointPart _ _
 
 /-- The skew-adjoint part of an element of a star module, as a continuous linear map. -/
 @[simps!]
 def skewAdjointPartL [ContinuousSub A] [ContinuousStar A] [ContinuousConstSMul R A] :
     A →L[R] skewAdjoint A where
   toLinearMap := skewAdjointPart R
-  cont := continuous_skewAdjointPart _ _
+  continuous_toFun := continuous_skewAdjointPart _ _
 
 /-- The decomposition of elements of a star module into their self- and skew-adjoint parts,
 as a continuous linear equivalence. -/

--- a/Mathlib/Topology/Algebra/Module/StrongTopology.lean
+++ b/Mathlib/Topology/Algebra/Module/StrongTopology.lean
@@ -523,7 +523,7 @@ def precomp_uniformConvergenceCLM [IsTopologicalAddGroup G] [ContinuousConstSMul
   toFun f := f.comp L
   map_add' f g := add_comp f g L
   map_smul' a f := smul_comp a f L
-  cont := by
+  continuous_toFun := by
     letI : UniformSpace G := IsTopologicalAddGroup.rightUniformSpace G
     haveI : IsUniformAddGroup G := isUniformAddGroup_of_addCommGroup
     rw [(UniformConvergenceCLM.isEmbedding_coeFn _ _ _).continuous_iff]
@@ -551,7 +551,7 @@ def postcomp_uniformConvergenceCLM [IsTopologicalAddGroup F] [IsTopologicalAddGr
   toFun f := L.comp f
   map_add' := comp_add L
   map_smul' := comp_smulₛₗ L
-  cont := by
+  continuous_toFun := by
     letI : UniformSpace G := IsTopologicalAddGroup.rightUniformSpace G
     haveI : IsUniformAddGroup G := isUniformAddGroup_of_addCommGroup
     letI : UniformSpace F := IsTopologicalAddGroup.rightUniformSpace F

--- a/Mathlib/Topology/Algebra/Module/WeakDual.lean
+++ b/Mathlib/Topology/Algebra/Module/WeakDual.lean
@@ -163,7 +163,7 @@ variable [AddCommMonoid F] [Module 𝕜 F] [TopologicalSpace F]
 their weak topologies. -/
 def map (f : E →L[𝕜] F) : WeakSpace 𝕜 E →L[𝕜] WeakSpace 𝕜 F :=
   { f with
-    cont :=
+    continuous_toFun :=
       WeakBilin.continuous_of_continuous_eval _ fun l => WeakBilin.eval_continuous _ (l ∘L f) }
 
 theorem map_apply (f : E →L[𝕜] F) (x : E) : WeakSpace.map f x = f x :=
@@ -185,7 +185,7 @@ variable (𝕜 E) in
 This definition implements it as a continuous linear map. -/
 def toWeakSpaceCLM : E →L[𝕜] WeakSpace 𝕜 E where
   __ := toWeakSpace 𝕜 E
-  cont := by
+  continuous_toFun := by
     apply WeakBilin.continuous_of_continuous_eval
     exact ContinuousLinearMap.continuous
 
@@ -200,7 +200,7 @@ theorem toWeakSpaceCLM_bijective :
 
 /-- The canonical map from `WeakSpace 𝕜 E` to `E` is an open map. -/
 theorem isOpenMap_toWeakSpace_symm : IsOpenMap (toWeakSpace 𝕜 E).symm :=
-  IsOpenMap.of_inverse (toWeakSpaceCLM 𝕜 E).cont
+  IsOpenMap.of_inverse (toWeakSpaceCLM 𝕜 E).continuous_toFun
     (toWeakSpace 𝕜 E).left_inv (toWeakSpace 𝕜 E).right_inv
 
 /-- A set in `E` which is open in the weak topology is open. -/

--- a/Mathlib/Topology/ContinuousMap/Algebra.lean
+++ b/Mathlib/Topology/ContinuousMap/Algebra.lean
@@ -600,7 +600,7 @@ protected def _root_.ContinuousLinearMap.compLeftContinuous (α : Type*) [Topolo
     (g : M →L[R] M₂) : C(α, M) →L[R] C(α, M₂) where
   __ := g.toLinearMap.toAddMonoidHom.compLeftContinuous α g.continuous
   map_smul' := fun c _ => ext fun _ => g.map_smul' c _
-  cont := ContinuousMap.continuous_postcomp _
+  continuous_toFun := ContinuousMap.continuous_postcomp _
 
 /-- The constant map `x ↦ y ↦ x` as a `ContinuousLinearMap`. -/
 @[simps!]
@@ -608,7 +608,7 @@ def _root_.ContinuousLinearMap.const (α : Type*) [TopologicalSpace α] : M →L
   toFun m := .const α m
   map_add' _ _ := rfl
   map_smul' _ _ := rfl
-  cont := ContinuousMap.continuous_const'
+  continuous_toFun := ContinuousMap.continuous_const'
 
 /-- Coercion to a function as a `LinearMap`. -/
 @[simps]

--- a/Mathlib/Topology/ContinuousMap/Ideals.lean
+++ b/Mathlib/Topology/ContinuousMap/Ideals.lean
@@ -391,7 +391,7 @@ def continuousMapEval : C(X, characterSpace 𝕜 C(X, 𝕜)) where
     ⟨{  toFun := fun f => f x
         map_add' := fun _ _ => rfl
         map_smul' := fun _ _ => rfl
-        cont := continuous_eval_const x }, by
+        continuous_toFun := continuous_eval_const x }, by
         rw [CharacterSpace.eq_set_map_one_map_mul]; exact ⟨rfl, fun f g => rfl⟩⟩
   continuous_toFun := by
     exact Continuous.subtype_mk (continuous_of_continuous_eval map_continuous) _

--- a/Mathlib/Topology/Instances/TrivSqZeroExt.lean
+++ b/Mathlib/Topology/Instances/TrivSqZeroExt.lean
@@ -85,7 +85,7 @@ def fstCLM [CommSemiring R] [AddCommMonoid M] [Module R M] : StrongDual R (tsze 
 def sndCLM [CommSemiring R] [AddCommMonoid M] [Module R M] : tsze R M →L[R] M :=
   { ContinuousLinearMap.snd R R M with
     toFun := snd
-    cont := continuous_snd }
+    continuous_toFun := continuous_snd }
 
 /-- `TrivSqZeroExt.inl` as a continuous linear map. -/
 @[simps]

--- a/Mathlib/Topology/VectorBundle/Basic.lean
+++ b/Mathlib/Topology/VectorBundle/Basic.lean
@@ -373,7 +373,7 @@ namespace Trivialization
 def continuousLinearMapAt (e : Trivialization F (π F E)) [e.IsLinear R] (b : B) : E b →L[R] F :=
   { e.linearMapAt R b with
     toFun := e.linearMapAt R b -- given explicitly to help `simps`
-    cont := by
+    continuous_toFun := by
       rw [e.coe_linearMapAt b]
       classical
       refine continuous_if_const _ (fun hb => ?_) fun _ => continuous_zero
@@ -385,7 +385,7 @@ def continuousLinearMapAt (e : Trivialization F (π F E)) [e.IsLinear R] (b : B)
 def symmL (e : Trivialization F (π F E)) [e.IsLinear R] (b : B) : F →L[R] E b :=
   { e.symmₗ R b with
     toFun := e.symm b -- given explicitly to help `simps`
-    cont := by
+    continuous_toFun := by
       by_cases hb : b ∈ e.baseSet
       · rw [(FiberBundle.totalSpaceMk_isInducing F E b).continuous_iff]
         exact e.continuousOn_symm.comp_continuous (.prodMk_right _) fun x ↦


### PR DESCRIPTION
This field is sometimes called `cont` and sometimes `continuous_toFun`. I noticed that the `continuity` tactic sometimes takes a lot longer to prove `cont` even if `continuous_toFun` is available so I thought I'd change them all to see if this speed up mathlib.

---
<!-- Your PR title will become the first line of the commit message.

In this box, the text above the `---` (if not empty) will be appended
to the commit message, and can be used to give additional context or
details. Please leave a blank newline before the `---`, otherwise GitHub
will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

When merging, all the commits will be squashed into a single commit
listing all co-authors.

Co-authors in the squash commit are gathered from two sources:

First, all authors of commits to this PR branch are included. Thus,
one way to add co-authors is to include at least one commit authored by
each co-author among the commits in the pull request. If necessary, you
may create empty commits to indicate co-authorship, using commands like so:

git commit --author="Author Name <author@email.com>" --allow-empty -m "add Author Name as coauthor"

Second, co-authors can also be listed in lines at the very bottom of
the commit message (that is, directly before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines
at the bottom of the commit message (before the `---`, and also before
any "Co-authored-by" lines) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
