### PR TITLE
[Merged by Bors] - chore(Analysis/Calculus): remove unnecessary @[expose] from public sections

### DIFF
--- a/Mathlib/Analysis/BoundedVariation.lean
+++ b/Mathlib/Analysis/BoundedVariation.lean
@@ -31,7 +31,7 @@ We also give several variations around these results.
 
 -/
 
-@[expose] public section
+public section
 
 open scoped NNReal Topology
 open Set MeasureTheory Filter

--- a/Mathlib/Analysis/Calculus/AddTorsor/AffineMap.lean
+++ b/Mathlib/Analysis/Calculus/AddTorsor/AffineMap.lean
@@ -20,7 +20,7 @@ This file contains results about smoothness of affine maps.
 
 -/
 
-@[expose] public section
+public section
 namespace ContinuousAffineMap
 
 variable {𝕜 V W : Type*} [NontriviallyNormedField 𝕜]

--- a/Mathlib/Analysis/Calculus/AddTorsor/Coord.lean
+++ b/Mathlib/Analysis/Calculus/AddTorsor/Coord.lean
@@ -12,7 +12,7 @@ public import Mathlib.Analysis.Normed.Affine.AddTorsorBases
 # Barycentric coordinates are smooth
 -/
 
-@[expose] public section
+public section
 
 variable {ι 𝕜 E P : Type*} [NontriviallyNormedField 𝕜] [CompleteSpace 𝕜]
 variable [NormedAddCommGroup E] [NormedSpace 𝕜 E]

--- a/Mathlib/Analysis/Calculus/BumpFunction/Convolution.lean
+++ b/Mathlib/Analysis/Calculus/BumpFunction/Convolution.lean
@@ -39,7 +39,7 @@ We also provide estimates in the case if `g x` is close to `g x₀` on this ball
 convolution, smooth function, bump function
 -/
 
-@[expose] public section
+public section
 
 universe uG uE'
 

--- a/Mathlib/Analysis/Calculus/BumpFunction/SmoothApprox.lean
+++ b/Mathlib/Analysis/Calculus/BumpFunction/SmoothApprox.lean
@@ -21,7 +21,7 @@ and `HasCompactSupport.contDiff_convolution_left`.
 Here we wrap these results removing measure-related arguments from the assumptions.
 -/
 
-@[expose] public section
+public section
 
 variable {E F : Type*} [NormedAddCommGroup E] [NormedSpace ℝ E] [FiniteDimensional ℝ E]
   [NormedAddCommGroup F] [NormedSpace ℝ F] [CompleteSpace F] {f : E → F} {ε : ℝ}

--- a/Mathlib/Analysis/Calculus/ContDiff/Basic.lean
+++ b/Mathlib/Analysis/Calculus/ContDiff/Basic.lean
@@ -34,7 +34,7 @@ In this file, we denote `(⊤ : ℕ∞) : WithTop ℕ∞` with `∞` and `⊤ : 
 derivative, differentiability, higher derivative, `C^n`, multilinear, Taylor series, formal series
 -/
 
-@[expose] public section
+public section
 
 noncomputable section
 

--- a/Mathlib/Analysis/Calculus/ContDiff/Bounds.lean
+++ b/Mathlib/Analysis/Calculus/ContDiff/Bounds.lean
@@ -18,7 +18,7 @@ public import Mathlib.Data.Nat.Choose.Multinomial
   derivative of `f` is bounded by `D ^ i`.
 -/
 
-@[expose] public section
+public section
 
 noncomputable section
 

--- a/Mathlib/Analysis/Calculus/ContDiff/CPolynomial.lean
+++ b/Mathlib/Analysis/Calculus/ContDiff/CPolynomial.lean
@@ -15,7 +15,7 @@ We prove that continuously polynomial functions are `C^∞`. In particular, this
 of continuous multilinear maps.
 -/
 
-@[expose] public section
+public section
 
 open Filter Asymptotics
 

--- a/Mathlib/Analysis/Calculus/ContDiff/FiniteDimension.lean
+++ b/Mathlib/Analysis/Calculus/ContDiff/FiniteDimension.lean
@@ -13,7 +13,7 @@ public import Mathlib.Analysis.Normed.Module.FiniteDimension
 
 -/
 
-@[expose] public section
+public section
 
 
 noncomputable section

--- a/Mathlib/Analysis/Calculus/ContDiff/Polynomial.lean
+++ b/Mathlib/Analysis/Calculus/ContDiff/Polynomial.lean
@@ -14,7 +14,7 @@ public import Mathlib.Analysis.Calculus.ContDiff.Operations
 We prove that polynomials are `C^∞`.
 -/
 
-@[expose] public section
+public section
 
 namespace Polynomial
 

--- a/Mathlib/Analysis/Calculus/ContDiff/RCLike.lean
+++ b/Mathlib/Analysis/Calculus/ContDiff/RCLike.lean
@@ -12,7 +12,7 @@ public import Mathlib.Analysis.Calculus.MeanValue
 # Higher differentiability over `ℝ` or `ℂ`
 -/
 
-@[expose] public section
+public section
 
 noncomputable section
 

--- a/Mathlib/Analysis/Calculus/ContDiff/RestrictScalars.lean
+++ b/Mathlib/Analysis/Calculus/ContDiff/RestrictScalars.lean
@@ -17,7 +17,7 @@ a subfield `𝕜 ⊆ 𝕜'`. The results are analogous to those found in
 `Mathlib.Analysis.Calculus.FDeriv.RestrictScalars`.
 -/
 
-@[expose] public section
+public section
 
 variable
   {𝕜 𝕜' : Type*} [NontriviallyNormedField 𝕜] [NontriviallyNormedField 𝕜'] [NormedAlgebra 𝕜 𝕜']

--- a/Mathlib/Analysis/Calculus/ContDiff/WithLp.lean
+++ b/Mathlib/Analysis/Calculus/ContDiff/WithLp.lean
@@ -12,7 +12,7 @@ public import Mathlib.Analysis.Normed.Lp.PiLp
 # Derivatives on `WithLp`
 -/
 
-@[expose] public section
+public section
 
 open scoped ENNReal
 

--- a/Mathlib/Analysis/Calculus/Darboux.lean
+++ b/Mathlib/Analysis/Calculus/Darboux.lean
@@ -17,7 +17,7 @@ intermediate values. The proof is based on the
 [Wikipedia](https://en.wikipedia.org/wiki/Darboux%27s_theorem_(analysis)) page about this theorem.
 -/
 
-@[expose] public section
+public section
 
 open Filter Set
 

--- a/Mathlib/Analysis/Calculus/Deriv/Abs.lean
+++ b/Mathlib/Analysis/Calculus/Deriv/Abs.lean
@@ -20,7 +20,7 @@ from an inner product space.
 absolute value, derivative
 -/
 
-@[expose] public section
+public section
 
 open Filter Real Set
 

--- a/Mathlib/Analysis/Calculus/Deriv/Add.lean
+++ b/Mathlib/Analysis/Calculus/Deriv/Add.lean
@@ -22,7 +22,7 @@ For a more detailed overview of one-dimensional derivatives in mathlib, see the 
 derivative
 -/
 
-@[expose] public section
+public section
 
 universe u v w
 

--- a/Mathlib/Analysis/Calculus/Deriv/AffineMap.lean
+++ b/Mathlib/Analysis/Calculus/Deriv/AffineMap.lean
@@ -25,7 +25,7 @@ Mathlib 4.
 affine map, derivative, differentiability
 -/
 
-@[expose] public section
+public section
 
 variable {𝕜 : Type*} [NontriviallyNormedField 𝕜]
   {E : Type*} [NormedAddCommGroup E] [NormedSpace 𝕜 E]

--- a/Mathlib/Analysis/Calculus/Deriv/Comp.lean
+++ b/Mathlib/Analysis/Calculus/Deriv/Comp.lean
@@ -33,7 +33,7 @@ For a more detailed overview of one-dimensional derivatives in mathlib, see the 
 derivative, chain rule
 -/
 
-@[expose] public section
+public section
 
 
 universe u v w

--- a/Mathlib/Analysis/Calculus/Deriv/CompMul.lean
+++ b/Mathlib/Analysis/Calculus/Deriv/CompMul.lean
@@ -19,7 +19,7 @@ the theorems in this file require neither differentiability of `f`,
 nor assumptions like `UniqueDiffWithinAt 𝕜 s x`.
 -/
 
-@[expose] public section
+public section
 
 open Set
 open scoped Pointwise

--- a/Mathlib/Analysis/Calculus/Deriv/Inv.lean
+++ b/Mathlib/Analysis/Calculus/Deriv/Inv.lean
@@ -22,7 +22,7 @@ For a more detailed overview of one-dimensional derivatives in mathlib, see the 
 derivative
 -/
 
-@[expose] public section
+public section
 
 
 universe u

--- a/Mathlib/Analysis/Calculus/Deriv/Inverse.lean
+++ b/Mathlib/Analysis/Calculus/Deriv/Inverse.lean
@@ -23,7 +23,7 @@ For a more detailed overview of one-dimensional derivatives in mathlib, see the 
 derivative, inverse function
 -/
 
-@[expose] public section
+public section
 
 
 universe u v

--- a/Mathlib/Analysis/Calculus/Deriv/Linear.lean
+++ b/Mathlib/Analysis/Calculus/Deriv/Linear.lean
@@ -21,7 +21,7 @@ For a more detailed overview of one-dimensional derivatives in mathlib, see the 
 derivative, linear map
 -/
 
-@[expose] public section
+public section
 
 
 universe u v w

--- a/Mathlib/Analysis/Calculus/Deriv/MeanValue.lean
+++ b/Mathlib/Analysis/Calculus/Deriv/MeanValue.lean
@@ -63,7 +63,7 @@ is not differentiable on the right at that point, and similarly differentiabilit
 
 -/
 
-@[expose] public section
+public section
 
 open Set Function Filter
 open scoped Topology

--- a/Mathlib/Analysis/Calculus/Deriv/Mul.lean
+++ b/Mathlib/Analysis/Calculus/Deriv/Mul.lean
@@ -23,7 +23,7 @@ For a more detailed overview of one-dimensional derivatives in mathlib, see the 
 derivative, multiplication
 -/
 
-@[expose] public section
+public section
 
 universe u v w
 

--- a/Mathlib/Analysis/Calculus/Deriv/Pi.lean
+++ b/Mathlib/Analysis/Calculus/Deriv/Pi.lean
@@ -12,7 +12,7 @@ public import Mathlib.Analysis.Calculus.Deriv.Basic
 # One-dimensional derivatives on pi-types.
 -/
 
-@[expose] public section
+public section
 
 variable {𝕜 ι : Type*} [DecidableEq ι] [Finite ι] [NontriviallyNormedField 𝕜]
 

--- a/Mathlib/Analysis/Calculus/Deriv/Polynomial.lean
+++ b/Mathlib/Analysis/Calculus/Deriv/Polynomial.lean
@@ -30,7 +30,7 @@ For a more detailed overview of one-dimensional derivatives in mathlib, see the 
 derivative, polynomial
 -/
 
-@[expose] public section
+public section
 
 
 universe u

--- a/Mathlib/Analysis/Calculus/Deriv/Pow.lean
+++ b/Mathlib/Analysis/Calculus/Deriv/Pow.lean
@@ -23,7 +23,7 @@ For a more detailed overview of one-dimensional derivatives in mathlib, see the 
 derivative, power
 -/
 
-@[expose] public section
+public section
 
 variable {𝕜 𝔸 : Type*}
 

--- a/Mathlib/Analysis/Calculus/Deriv/Prod.lean
+++ b/Mathlib/Analysis/Calculus/Deriv/Prod.lean
@@ -22,7 +22,7 @@ For a more detailed overview of one-dimensional derivatives in mathlib, see the 
 derivative
 -/
 
-@[expose] public section
+public section
 
 universe u v w
 

--- a/Mathlib/Analysis/Calculus/Deriv/Shift.lean
+++ b/Mathlib/Analysis/Calculus/Deriv/Shift.lean
@@ -16,7 +16,7 @@ We show that if a function `f` has derivative `f'` at a point `a + x`, then `f (
 has derivative `f'` at `x`. Similarly for `x + a`.
 -/
 
-@[expose] public section
+public section
 
 open scoped Pointwise
 

--- a/Mathlib/Analysis/Calculus/Deriv/Slope.lean
+++ b/Mathlib/Analysis/Calculus/Deriv/Slope.lean
@@ -27,7 +27,7 @@ For a more detailed overview of one-dimensional derivatives in mathlib, see the 
 derivative, slope
 -/
 
-@[expose] public section
+public section
 
 universe u v
 

--- a/Mathlib/Analysis/Calculus/Deriv/Star.lean
+++ b/Mathlib/Analysis/Calculus/Deriv/Star.lean
@@ -20,7 +20,7 @@ trivial star operation; which as should be expected rules out `𝕜 = ℂ`. The 
 differentiable when `f` is (and giving a formula for its derivative).
 -/
 
-@[expose] public section
+public section
 
 universe u v w
 

--- a/Mathlib/Analysis/Calculus/Deriv/Support.lean
+++ b/Mathlib/Analysis/Calculus/Deriv/Support.lean
@@ -19,7 +19,7 @@ compact support.
 derivative, support
 -/
 
-@[expose] public section
+public section
 
 
 universe u v

--- a/Mathlib/Analysis/Calculus/Deriv/ZPow.lean
+++ b/Mathlib/Analysis/Calculus/Deriv/ZPow.lean
@@ -22,7 +22,7 @@ For a more detailed overview of one-dimensional derivatives in mathlib, see the 
 derivative, power
 -/
 
-@[expose] public section
+public section
 
 universe u v w
 

--- a/Mathlib/Analysis/Calculus/DerivativeTest.lean
+++ b/Mathlib/Analysis/Calculus/DerivativeTest.lean
@@ -46,7 +46,7 @@ Source: [Wikipedia](https://en.wikipedia.org/wiki/Derivative_test#Proof_of_the_s
 derivative test, first-derivative test, second-derivative test, calculus
 -/
 
-@[expose] public section
+public section
 
 
 open Set Topology

--- a/Mathlib/Analysis/Calculus/FDeriv/Add.lean
+++ b/Mathlib/Analysis/Calculus/FDeriv/Add.lean
@@ -23,7 +23,7 @@ This file contains the usual formulas (and existence assertions) for the derivat
 * subtraction of two functions
 -/
 
-@[expose] public section
+public section
 
 
 open Filter Asymptotics ContinuousLinearMap

--- a/Mathlib/Analysis/Calculus/FDeriv/Affine.lean
+++ b/Mathlib/Analysis/Calculus/FDeriv/Affine.lean
@@ -19,7 +19,7 @@ This file contains the usual formulas (and existence assertions) for the derivat
 continuous affine maps.
 -/
 
-@[expose] public section
+public section
 
 variable {𝕜 : Type*} [NontriviallyNormedField 𝕜]
   {E : Type*} [NormedAddCommGroup E] [NormedSpace 𝕜 E]

--- a/Mathlib/Analysis/Calculus/FDeriv/Analytic.lean
+++ b/Mathlib/Analysis/Calculus/FDeriv/Analytic.lean
@@ -63,7 +63,7 @@ differentiability at points in a neighborhood of `s`. Therefore, the theorem tha
 
 -/
 
-@[expose] public section
+public section
 
 open Filter Asymptotics Set
 

--- a/Mathlib/Analysis/Calculus/FDeriv/Basic.lean
+++ b/Mathlib/Analysis/Calculus/FDeriv/Basic.lean
@@ -108,7 +108,7 @@ derivative, differentiable, Fréchet, calculus
 
 -/
 
-@[expose] public section
+public section
 
 open Filter Asymptotics ContinuousLinearMap Set Metric Topology NNReal ENNReal
 

--- a/Mathlib/Analysis/Calculus/FDeriv/Bilinear.lean
+++ b/Mathlib/Analysis/Calculus/FDeriv/Bilinear.lean
@@ -17,7 +17,7 @@ This file contains the usual formulas (and existence assertions) for the derivat
 bounded bilinear maps.
 -/
 
-@[expose] public section
+public section
 
 
 open Asymptotics Topology

--- a/Mathlib/Analysis/Calculus/FDeriv/Comp.lean
+++ b/Mathlib/Analysis/Calculus/FDeriv/Comp.lean
@@ -17,7 +17,7 @@ This file contains the usual formulas (and existence assertions) for the derivat
 composition of functions (the chain rule).
 -/
 
-@[expose] public section
+public section
 
 
 open Filter Asymptotics ContinuousLinearMap Set Metric Topology NNReal ENNReal

--- a/Mathlib/Analysis/Calculus/FDeriv/CompCLM.lean
+++ b/Mathlib/Analysis/Calculus/FDeriv/CompCLM.lean
@@ -20,7 +20,7 @@ This file contains the usual formulas (and existence assertions) for the derivat
 * application of continuous (multi)linear maps to a constant
 -/
 
-@[expose] public section
+public section
 
 
 open Asymptotics ContinuousLinearMap Topology

--- a/Mathlib/Analysis/Calculus/FDeriv/Congr.lean
+++ b/Mathlib/Analysis/Calculus/FDeriv/Congr.lean
@@ -18,7 +18,7 @@ derivative, differentiable, Fréchet, calculus
 
 -/
 
-@[expose] public section
+public section
 
 open Filter Asymptotics ContinuousLinearMap Set Metric Topology NNReal ENNReal
 

--- a/Mathlib/Analysis/Calculus/FDeriv/Const.lean
+++ b/Mathlib/Analysis/Calculus/FDeriv/Const.lean
@@ -20,7 +20,7 @@ derivative, differentiable, Fréchet, calculus
 
 -/
 
-@[expose] public section
+public section
 
 open Filter Asymptotics ContinuousLinearMap Set Metric Topology NNReal ENNReal
 

--- a/Mathlib/Analysis/Calculus/FDeriv/ContinuousAlternatingMap.lean
+++ b/Mathlib/Analysis/Calculus/FDeriv/ContinuousAlternatingMap.lean
@@ -18,7 +18,7 @@ In this file we prove formulas for the derivatives of
 - application of a `ContinuousAlternatingMap` as a function of both the map and the vectors.
 -/
 
-@[expose] public section
+public section
 
 variable {𝕜 ι E F G H : Type*}
   [NontriviallyNormedField 𝕜]

--- a/Mathlib/Analysis/Calculus/FDeriv/ContinuousMultilinearMap.lean
+++ b/Mathlib/Analysis/Calculus/FDeriv/ContinuousMultilinearMap.lean
@@ -38,7 +38,7 @@ All statements in the first section are claiming this, for various notions of di
 The second section deduces the corresponding differentiability results when `ι` is finite.
 -/
 
-@[expose] public section
+public section
 
 variable {𝕜 ι E : Type*} {F G : ι → Type*} {H : Type*}
   [NontriviallyNormedField 𝕜]

--- a/Mathlib/Analysis/Calculus/FDeriv/Equiv.lean
+++ b/Mathlib/Analysis/Calculus/FDeriv/Equiv.lean
@@ -23,7 +23,7 @@ We also prove the usual formula for the derivative of the inverse function, assu
 The inverse function theorem is in `Mathlib/Analysis/Calculus/InverseFunctionTheorem/FDeriv.lean`.
 -/
 
-@[expose] public section
+public section
 
 open Filter Asymptotics ContinuousLinearMap Set Metric Topology NNReal ENNReal
 

--- a/Mathlib/Analysis/Calculus/FDeriv/Extend.lean
+++ b/Mathlib/Analysis/Calculus/FDeriv/Extend.lean
@@ -20,7 +20,7 @@ the right endpoint of an interval, are given in `hasDerivWithinAt_Ici_of_tendsto
 one-dimensional derivative `deriv ℝ f`.
 -/
 
-@[expose] public section
+public section
 
 
 variable {E : Type*} [NormedAddCommGroup E] [NormedSpace ℝ E] {F : Type*} [NormedAddCommGroup F]

--- a/Mathlib/Analysis/Calculus/FDeriv/Linear.lean
+++ b/Mathlib/Analysis/Calculus/FDeriv/Linear.lean
@@ -18,7 +18,7 @@ This file contains the usual formulas (and existence assertions) for the derivat
 bounded linear maps.
 -/
 
-@[expose] public section
+public section
 
 
 open Asymptotics

--- a/Mathlib/Analysis/Calculus/FDeriv/Mul.lean
+++ b/Mathlib/Analysis/Calculus/FDeriv/Mul.lean
@@ -22,7 +22,7 @@ This file contains the usual formulas (and existence assertions) for the derivat
 * taking the pointwise multiplicative inverse (i.e. `Inv.inv` or `Ring.inverse`) of a function
 -/
 
-@[expose] public section
+public section
 
 
 open Asymptotics ContinuousLinearMap Topology

--- a/Mathlib/Analysis/Calculus/FDeriv/Norm.lean
+++ b/Mathlib/Analysis/Calculus/FDeriv/Norm.lean
@@ -37,7 +37,7 @@ differentiability, norm
 
 -/
 
-@[expose] public section
+public section
 
 open ContinuousLinearMap Filter NNReal Real Set
 

--- a/Mathlib/Analysis/Calculus/FDeriv/Pi.lean
+++ b/Mathlib/Analysis/Calculus/FDeriv/Pi.lean
@@ -12,7 +12,7 @@ public import Mathlib.Analysis.Calculus.FDeriv.Const
 # Derivatives on pi-types.
 -/
 
-@[expose] public section
+public section
 
 variable {𝕜 ι : Type*} [DecidableEq ι] [Finite ι] [NontriviallyNormedField 𝕜]
 variable {E : ι → Type*} [∀ i, NormedAddCommGroup (E i)] [∀ i, NormedSpace 𝕜 (E i)]

--- a/Mathlib/Analysis/Calculus/FDeriv/Pow.lean
+++ b/Mathlib/Analysis/Calculus/FDeriv/Pow.lean
@@ -24,7 +24,7 @@ see the module docstring of `Mathlib/Analysis/Calculus/FDeriv/Basic.lean`.
 derivative, power
 -/
 
-@[expose] public section
+public section
 
 variable {𝕜 𝔸 E : Type*}
 

--- a/Mathlib/Analysis/Calculus/FDeriv/Prod.lean
+++ b/Mathlib/Analysis/Calculus/FDeriv/Prod.lean
@@ -19,7 +19,7 @@ This file contains the usual formulas (and existence assertions) for the derivat
 Cartesian products of functions, and functions into Pi-types.
 -/
 
-@[expose] public section
+public section
 
 
 open Filter Asymptotics ContinuousLinearMap Set Metric Topology NNReal ENNReal

--- a/Mathlib/Analysis/Calculus/FDeriv/RestrictScalars.lean
+++ b/Mathlib/Analysis/Calculus/FDeriv/RestrictScalars.lean
@@ -17,7 +17,7 @@ This file contains the usual formulas (and existence assertions) for the derivat
 the scalar restriction of a linear map.
 -/
 
-@[expose] public section
+public section
 
 
 open Filter Asymptotics ContinuousLinearMap Set Metric Topology NNReal ENNReal

--- a/Mathlib/Analysis/Calculus/FDeriv/Star.lean
+++ b/Mathlib/Analysis/Calculus/FDeriv/Star.lean
@@ -24,7 +24,7 @@ trivial star operation; which as should be expected rules out `𝕜 = ℂ`. The 
 differentiable when `f` is (and giving a formula for its derivative).
 -/
 
-@[expose] public section
+public section
 
 
 variable {𝕜 : Type*} [NontriviallyNormedField 𝕜] [StarRing 𝕜]

--- a/Mathlib/Analysis/Calculus/FDeriv/WithLp.lean
+++ b/Mathlib/Analysis/Calculus/FDeriv/WithLp.lean
@@ -13,7 +13,7 @@ public import Mathlib.Analysis.Normed.Lp.PiLp
 # Derivatives on `WithLp`
 -/
 
-@[expose] public section
+public section
 
 open ContinuousLinearMap PiLp WithLp
 

--- a/Mathlib/Analysis/Calculus/InverseFunctionTheorem/FiniteDimensional.lean
+++ b/Mathlib/Analysis/Calculus/InverseFunctionTheorem/FiniteDimensional.lean
@@ -19,7 +19,7 @@ This used to be the only lemma in `Mathlib/Analysis/Calculus/Inverse`
 depending on `FiniteDimensional`, so it was moved to a new file when the original file got split.
 -/
 
-@[expose] public section
+public section
 
 open Set
 open scoped NNReal

--- a/Mathlib/Analysis/Calculus/IteratedDeriv/ConvergenceOnBall.lean
+++ b/Mathlib/Analysis/Calculus/IteratedDeriv/ConvergenceOnBall.lean
@@ -17,7 +17,7 @@ In this file we prove that if a function `f` is analytic on the ball of converge
 series, then the series converges to `f` on this ball.
 -/
 
-@[expose] public section
+public section
 
 variable {𝕜 : Type*} [RCLike 𝕜] {f : 𝕜 → 𝕜} {x : 𝕜}
 

--- a/Mathlib/Analysis/Calculus/IteratedDeriv/FaaDiBruno.lean
+++ b/Mathlib/Analysis/Calculus/IteratedDeriv/FaaDiBruno.lean
@@ -32,7 +32,7 @@ Before starting to work on these TODOs, please contact Yury Kudryashov
 who may have partial progress towards some of them.
 -/
 
-@[expose] public section
+public section
 
 open Function Set
 open scoped ContDiff

--- a/Mathlib/Analysis/Calculus/IteratedDeriv/Lemmas.lean
+++ b/Mathlib/Analysis/Calculus/IteratedDeriv/Lemmas.lean
@@ -17,7 +17,7 @@ This file contains a number of further results on `iteratedDerivWithin` that nee
 than are available in `Mathlib/Analysis/Calculus/IteratedDeriv/Defs.lean`.
 -/
 
-@[expose] public section
+public section
 
 section one_dimensional
 

--- a/Mathlib/Analysis/Calculus/IteratedDeriv/WithinZpow.lean
+++ b/Mathlib/Analysis/Calculus/IteratedDeriv/WithinZpow.lean
@@ -18,7 +18,7 @@ In this file we prove theorems about iterated derivatives of `x ^ m`, `m : ℤ` 
 iterated, derivative, power, open set
 -/
 
-@[expose] public section
+public section
 
 open scoped Nat
 

--- a/Mathlib/Analysis/Calculus/LHopital.lean
+++ b/Mathlib/Analysis/Calculus/LHopital.lean
@@ -31,7 +31,7 @@ namespace.
 L'Hôpital's rule, L'Hopital's rule
 -/
 
-@[expose] public section
+public section
 
 
 open Filter Set

--- a/Mathlib/Analysis/Calculus/LagrangeMultipliers.lean
+++ b/Mathlib/Analysis/Calculus/LagrangeMultipliers.lean
@@ -29,7 +29,7 @@ lagrange multiplier, local extremum
 
 -/
 
-@[expose] public section
+public section
 
 
 open Filter Set

--- a/Mathlib/Analysis/Calculus/LineDeriv/IntegrationByParts.lean
+++ b/Mathlib/Analysis/Calculus/LineDeriv/IntegrationByParts.lean
@@ -46,7 +46,7 @@ TODO: prove similar theorems assuming that the functions tend to zero at infinit
 integrable derivatives.
 -/
 
-@[expose] public section
+public section
 
 open MeasureTheory Measure Module Topology
 

--- a/Mathlib/Analysis/Calculus/LineDeriv/Measurable.lean
+++ b/Mathlib/Analysis/Calculus/LineDeriv/Measurable.lean
@@ -21,7 +21,7 @@ way between differentiable and non-differentiable functions along the various li
 directed by `v`.
 -/
 
-@[expose] public section
+public section
 
 open MeasureTheory
 

--- a/Mathlib/Analysis/Calculus/LineDeriv/QuadraticMap.lean
+++ b/Mathlib/Analysis/Calculus/LineDeriv/QuadraticMap.lean
@@ -18,7 +18,7 @@ Note that this statement does not need topology on the domain.
 In particular, it applies to discontinuous quadratic forms on infinite-dimensional spaces.
 -/
 
-@[expose] public section
+public section
 
 variable {𝕜 E F : Type*} [NontriviallyNormedField 𝕜] [AddCommGroup E] [Module 𝕜 E]
   [NormedAddCommGroup F] [NormedSpace 𝕜 F]

--- a/Mathlib/Analysis/Calculus/LocalExtr/LineDeriv.lean
+++ b/Mathlib/Analysis/Calculus/LocalExtr/LineDeriv.lean
@@ -15,7 +15,7 @@ If `f` has a local extremum at a point, then the derivative at this point is zer
 In this file we prove several versions of this fact for line derivatives.
 -/
 
-@[expose] public section
+public section
 
 open Function Set Filter
 open scoped Topology

--- a/Mathlib/Analysis/Calculus/LocalExtr/Polynomial.lean
+++ b/Mathlib/Analysis/Calculus/LocalExtr/Polynomial.lean
@@ -29,7 +29,7 @@ Namely, we prove the following facts.
 polynomial, Rolle's Theorem, root
 -/
 
-@[expose] public section
+public section
 
 namespace Polynomial
 

--- a/Mathlib/Analysis/Calculus/LocalExtr/Rolle.lean
+++ b/Mathlib/Analysis/Calculus/LocalExtr/Rolle.lean
@@ -42,7 +42,7 @@ We prove four versions of this theorem.
 local extremum, Rolle's Theorem
 -/
 
-@[expose] public section
+public section
 
 open Set Filter Topology
 

--- a/Mathlib/Analysis/Calculus/LogDerivUniformlyOn.lean
+++ b/Mathlib/Analysis/Calculus/LogDerivUniformlyOn.lean
@@ -17,7 +17,7 @@ individual functions.
 
 -/
 
-@[expose] public section
+public section
 
 open Complex
 

--- a/Mathlib/Analysis/Calculus/Monotone.lean
+++ b/Mathlib/Analysis/Calculus/Monotone.lean
@@ -31,7 +31,7 @@ limit of `(f y - f x) / (y - x)` by a lower and upper approximation argument fro
 behavior of `μ [x, y]`.
 -/
 
-@[expose] public section
+public section
 
 
 open Set Filter Function Metric MeasureTheory MeasureTheory.Measure IsUnifLocDoublingMeasure

--- a/Mathlib/Analysis/Calculus/ParametricIntegral.lean
+++ b/Mathlib/Analysis/Calculus/ParametricIntegral.lean
@@ -55,7 +55,7 @@ We also provide versions of these theorems for set integrals.
 integral, derivative
 -/
 
-@[expose] public section
+public section
 
 
 noncomputable section

--- a/Mathlib/Analysis/Calculus/ParametricIntervalIntegral.lean
+++ b/Mathlib/Analysis/Calculus/ParametricIntervalIntegral.lean
@@ -14,7 +14,7 @@ public import Mathlib.MeasureTheory.Integral.IntervalIntegral.Basic
 In this file we restate theorems about derivatives of integrals depending on parameters for interval
 integrals. -/
 
-@[expose] public section
+public section
 
 
 open TopologicalSpace MeasureTheory Filter Metric

--- a/Mathlib/Analysis/Calculus/Rademacher.lean
+++ b/Mathlib/Analysis/Calculus/Rademacher.lean
@@ -44,7 +44,7 @@ elementary but maybe the most elegant once necessary prerequisites are set up.
 * [Pertti Mattila, Geometry of sets and measures in Euclidean spaces, Theorem 7.3][Federer1996]
 -/
 
-@[expose] public section
+public section
 
 open Filter MeasureTheory Measure Module Metric Set Asymptotics
 

--- a/Mathlib/Analysis/Calculus/TangentCone/Basic.lean
+++ b/Mathlib/Analysis/Calculus/TangentCone/Basic.lean
@@ -16,7 +16,7 @@ In this file we prove basic lemmas about `tangentConeAt`, `UniqueDiffWithinAt`,
 and `UniqueDiffOn`.
 -/
 
-@[expose] public section
+public section
 
 open Filter Set Metric NormedField
 open scoped Topology Pointwise

--- a/Mathlib/Analysis/Calculus/TangentCone/DimOne.lean
+++ b/Mathlib/Analysis/Calculus/TangentCone/DimOne.lean
@@ -14,7 +14,7 @@ In this file we prove that a set in the base field has the unique differentiabil
 iff `x` is an accumulation point of the set, see `uniqueDiffWithinAt_iff_accPt`.
 -/
 
-@[expose] public section
+public section
 
 open Filter Metric Set
 open scoped Topology

--- a/Mathlib/Analysis/Calculus/TangentCone/Pi.lean
+++ b/Mathlib/Analysis/Calculus/TangentCone/Pi.lean
@@ -15,7 +15,7 @@ of a family sets with unique differentiability property
 has the same property, see `UniqueDiffOn.pi` and  `UniqueDiffOn.univ_pi`.
 -/
 
-@[expose] public section
+public section
 
 open Filter Set
 open scoped Topology

--- a/Mathlib/Analysis/Calculus/TangentCone/Prod.lean
+++ b/Mathlib/Analysis/Calculus/TangentCone/Prod.lean
@@ -16,7 +16,7 @@ In this file we prove that the product of two sets with unique differentiability
 has the same property, see `UniqueDiffOn.prod`.
 -/
 
-@[expose] public section
+public section
 
 open Filter Set
 open scoped Topology

--- a/Mathlib/Analysis/Calculus/TangentCone/ProperSpace.lean
+++ b/Mathlib/Analysis/Calculus/TangentCone/ProperSpace.lean
@@ -15,7 +15,7 @@ In this file we prove that the tangent cone of a set in a proper normed space
 at an accumulation point of this set is nontrivial.
 -/
 
-@[expose] public section
+public section
 
 open Filter Set Metric NormedField
 open scoped Topology

--- a/Mathlib/Analysis/Calculus/TangentCone/Real.lean
+++ b/Mathlib/Analysis/Calculus/TangentCone/Real.lean
@@ -18,7 +18,7 @@ In this file we prove that
 - `uniqueDiffOn_Ioc` etc: intervals on the real line have the unique differentiability property.
 -/
 
-@[expose] public section
+public section
 
 open Filter Set
 open scoped Topology

--- a/Mathlib/Analysis/Calculus/UniformLimitsDeriv.lean
+++ b/Mathlib/Analysis/Calculus/UniformLimitsDeriv.lean
@@ -94,7 +94,7 @@ continuous, then you can avoid the mean value theorem and much of the work aroun
 uniform convergence, limits of derivatives
 -/
 
-@[expose] public section
+public section
 
 
 open Filter

--- a/Mathlib/Analysis/Hofer.lean
+++ b/Mathlib/Analysis/Hofer.lean
@@ -20,7 +20,7 @@ example of a proof needing to construct a sequence by induction in the middle of
 * H. Hofer and C. Viterbo, *The Weinstein conjecture in the presence of holomorphic spheres*
 -/
 
-@[expose] public section
+public section
 
 open Topology Filter Finset
 

--- a/Mathlib/Analysis/MeanInequalities.lean
+++ b/Mathlib/Analysis/MeanInequalities.lean
@@ -106,7 +106,7 @@ less than or equal to the sum of the maximum values of the summands.
 
 -/
 
-@[expose] public section
+public section
 
 
 universe u v

--- a/Mathlib/Analysis/MeanInequalitiesPow.lean
+++ b/Mathlib/Analysis/MeanInequalitiesPow.lean
@@ -42,7 +42,7 @@ in order to avoid using real exponents. For real exponents we prove both this an
 
 -/
 
-@[expose] public section
+public section
 
 
 universe u v

--- a/Mathlib/Analysis/MellinInversion.lean
+++ b/Mathlib/Analysis/MellinInversion.lean
@@ -17,7 +17,7 @@ We derive the Mellin inversion formula as a consequence of the Fourier inversion
 - `mellin_inversion`: The inverse Mellin transform of the Mellin transform applied to `x > 0` is x.
 -/
 
-@[expose] public section
+public section
 
 open Real Complex Set MeasureTheory
 

--- a/Mathlib/Analysis/PSeriesComplex.lean
+++ b/Mathlib/Analysis/PSeriesComplex.lean
@@ -20,7 +20,7 @@ rather than in `Analysis.PSeries` in order to keep the prerequisites of the form
 p-series, Cauchy condensation test
 -/
 
-@[expose] public section
+public section
 
 lemma Complex.summable_one_div_nat_cpow {p : ℂ} :
     Summable (fun n : ℕ ↦ 1 / (n : ℂ) ^ p) ↔ 1 < re p := by

--- a/Mathlib/Analysis/SumIntegralComparisons.lean
+++ b/Mathlib/Analysis/SumIntegralComparisons.lean
@@ -42,7 +42,7 @@ At the moment it contains several lemmas in this direction, for antitone or mono
 analysis, comparison, asymptotics
 -/
 
-@[expose] public section
+public section
 
 
 open Set MeasureTheory MeasureSpace


### PR DESCRIPTION
This PR removes `@[expose]` from `public section` declarations in 87 files under `Mathlib/Analysis/Calculus/` and related directories.

These files only contain theorems/lemmas (no definitions, instances, or other computational content that requires exposed bodies). The `@[expose]` attribute explicitly exposes definition bodies, but theorems have their proofs erased when exported, so `@[expose]` is not needed for them.

This is part of a larger effort to clean up unnecessary `@[expose]` attributes across Mathlib (~1400 files identified as candidates).

🤖 Prepared with Claude Code