### PR TITLE
[Merged by Bors] - chore(Analysis/SpecialFunctions): remove unnecessary @[expose] from public sections

### DIFF
--- a/Mathlib/Analysis/Fourier/FiniteAbelian/Orthogonality.lean
+++ b/Mathlib/Analysis/Fourier/FiniteAbelian/Orthogonality.lean
@@ -16,7 +16,7 @@ This file proves that characters of a finite abelian group are orthogonal, and i
 there are at most as many characters as there are elements of the group.
 -/
 
-@[expose] public section
+public section
 
 open Finset hiding card
 open Fintype (card)

--- a/Mathlib/Analysis/Fourier/Inversion.lean
+++ b/Mathlib/Analysis/Fourier/Inversion.lean
@@ -39,7 +39,7 @@ To check the concentration property of the middle factor and the fact that it ha
 rely on the explicit computation of the Fourier transform of Gaussians.
 -/
 
-@[expose] public section
+public section
 
 open Filter MeasureTheory Complex Module Metric Real Bornology
 

--- a/Mathlib/Analysis/Fourier/PoissonSummation.lean
+++ b/Mathlib/Analysis/Fourier/PoissonSummation.lean
@@ -27,7 +27,7 @@ easier-to-use result `Real.tsum_eq_tsum_fourierIntegral_of_rpow_decay`, in which
 `𝓕 f` both decay as `|x| ^ (-b)` for some `b > 1`, and the even more specific result
 `SchwartzMap.tsum_eq_tsum_fourierIntegral`, where we assume that `f` is a Schwartz function. -/
 
-@[expose] public section
+public section
 
 
 noncomputable section

--- a/Mathlib/Analysis/Fourier/RiemannLebesgueLemma.lean
+++ b/Mathlib/Analysis/Fourier/RiemannLebesgueLemma.lean
@@ -44,7 +44,7 @@ equivalence to an inner-product space.
   reformulations explicitly using the Fourier integral.
 -/
 
-@[expose] public section
+public section
 
 noncomputable section
 

--- a/Mathlib/Analysis/Real/Pi/Bounds.lean
+++ b/Mathlib/Analysis/Real/Pi/Bounds.lean
@@ -19,7 +19,7 @@ See also `Mathlib/Analysis/Real/Pi/Leibniz.lean` and `Mathlib/Analysis/Real/Pi/W
 infinite formulas for `π`.
 -/
 
-@[expose] public section
+public section
 
 open scoped Real
 

--- a/Mathlib/Analysis/Real/Pi/Irrational.lean
+++ b/Mathlib/Analysis/Real/Pi/Irrational.lean
@@ -34,7 +34,7 @@ The proof idea is as follows.
 
 -/
 
-@[expose] public section
+public section
 
 noncomputable section
 

--- a/Mathlib/Analysis/Real/Pi/Leibniz.lean
+++ b/Mathlib/Analysis/Real/Pi/Leibniz.lean
@@ -10,7 +10,7 @@ public import Mathlib.Analysis.SpecialFunctions.Complex.Arctan
 
 /-! ### Leibniz's series for `π` -/
 
-@[expose] public section
+public section
 
 namespace Real
 

--- a/Mathlib/Analysis/Real/Spectrum.lean
+++ b/Mathlib/Analysis/Real/Spectrum.lean
@@ -14,7 +14,7 @@ public import Mathlib.Tactic.ContinuousFunctionalCalculus
 
 -/
 
-@[expose] public section
+public section
 
 namespace SpectrumRestricts
 

--- a/Mathlib/Analysis/SpecialFunctions/BinaryEntropy.lean
+++ b/Mathlib/Analysis/SpecialFunctions/BinaryEntropy.lean
@@ -50,7 +50,7 @@ The functions are also defined outside the interval `Icc 0 1` due to `log x = lo
 entropy, Shannon, binary, nit, nepit
 -/
 
-@[expose] public section
+public section
 
 namespace Real
 variable {q : ℕ} {p : ℝ}

--- a/Mathlib/Analysis/SpecialFunctions/Choose.lean
+++ b/Mathlib/Analysis/SpecialFunctions/Choose.lean
@@ -21,7 +21,7 @@ This file proves asymptotic theorems for binomial coefficients and factorial var
 * `isTheta_choose` is the proof that `n.choose k = Θ(n^k)` as `n → ∞`.
 -/
 
-@[expose] public section
+public section
 
 
 open Asymptotics Filter Nat Topology

--- a/Mathlib/Analysis/SpecialFunctions/Complex/Analytic.lean
+++ b/Mathlib/Analysis/SpecialFunctions/Complex/Analytic.lean
@@ -16,7 +16,7 @@ public import Mathlib.Analysis.SpecialFunctions.Complex.LogDeriv
 `log`, and `cpow` are analytic, since they are differentiable.
 -/
 
-@[expose] public section
+public section
 
 open Complex Set
 open scoped Topology

--- a/Mathlib/Analysis/SpecialFunctions/ContinuousFunctionalCalculus/ExpLog/Order.lean
+++ b/Mathlib/Analysis/SpecialFunctions/ContinuousFunctionalCalculus/ExpLog/Order.lean
@@ -29,7 +29,7 @@ the strictly positive elements of a unital C⋆-algebra.
 * Show that `x => x * log x` is operator convex
 -/
 
-@[expose] public section
+public section
 
 open scoped Topology
 

--- a/Mathlib/Analysis/SpecialFunctions/ContinuousFunctionalCalculus/PosPart/Basic.lean
+++ b/Mathlib/Analysis/SpecialFunctions/ContinuousFunctionalCalculus/PosPart/Basic.lean
@@ -16,7 +16,7 @@ the continuous functional calculus and develops the basic API, including the uni
 positive and negative parts.
 -/
 
-@[expose] public section
+public section
 
 open scoped NNReal
 

--- a/Mathlib/Analysis/SpecialFunctions/ContinuousFunctionalCalculus/PosPart/Isometric.lean
+++ b/Mathlib/Analysis/SpecialFunctions/ContinuousFunctionalCalculus/PosPart/Isometric.lean
@@ -20,7 +20,7 @@ C⋆-algebra that involve the norm.
   respectively.
 -/
 
-@[expose] public section
+public section
 
 variable {A : Type*} [NonUnitalNormedRing A] [NormedSpace ℝ A] [SMulCommClass ℝ A A]
   [IsScalarTower ℝ A A] [StarRing A]

--- a/Mathlib/Analysis/SpecialFunctions/ContinuousFunctionalCalculus/Rpow/Isometric.lean
+++ b/Mathlib/Analysis/SpecialFunctions/ContinuousFunctionalCalculus/Rpow/Isometric.lean
@@ -22,7 +22,7 @@ rely on an isometric continuous functional calculus.
 continuous functional calculus, rpow, sqrt
 -/
 
-@[expose] public section
+public section
 
 open scoped NNReal
 

--- a/Mathlib/Analysis/SpecialFunctions/ContinuousFunctionalCalculus/Rpow/Order.lean
+++ b/Mathlib/Analysis/SpecialFunctions/ContinuousFunctionalCalculus/Rpow/Order.lean
@@ -33,7 +33,7 @@ C⋆-algebra. The proof makes use of the integral representation of `rpow` in
   (see Lemma 2.8)
 -/
 
-@[expose] public section
+public section
 
 open Set
 open scoped NNReal

--- a/Mathlib/Analysis/SpecialFunctions/ExpDeriv.lean
+++ b/Mathlib/Analysis/SpecialFunctions/ExpDeriv.lean
@@ -21,7 +21,7 @@ In this file we prove that `Complex.exp` and `Real.exp` are analytic functions.
 exp, derivative
 -/
 
-@[expose] public section
+public section
 
 assert_not_exists IsConformalMap Conformal
 

--- a/Mathlib/Analysis/SpecialFunctions/Exponential.lean
+++ b/Mathlib/Analysis/SpecialFunctions/Exponential.lean
@@ -55,7 +55,7 @@ We prove most results for an arbitrary field `ğ•‚`, and then specialize to `ğ•
 
 -/
 
-@[expose] public section
+public section
 
 
 open Filter RCLike ContinuousMultilinearMap NormedField NormedSpace Asymptotics

--- a/Mathlib/Analysis/SpecialFunctions/Gamma/Deriv.lean
+++ b/Mathlib/Analysis/SpecialFunctions/Gamma/Deriv.lean
@@ -26,7 +26,7 @@ This file shows that the (complex) `Γ` function is complex-differentiable at al
 Gamma
 -/
 
-@[expose] public section
+public section
 
 
 noncomputable section

--- a/Mathlib/Analysis/SpecialFunctions/Gaussian/GaussianIntegral.lean
+++ b/Mathlib/Analysis/SpecialFunctions/Gaussian/GaussianIntegral.lean
@@ -21,7 +21,7 @@ We prove various versions of the formula for the Gaussian integral:
 * `Complex.Gamma_one_half_eq`: the formula `Γ (1 / 2) = √π`.
 -/
 
-@[expose] public section
+public section
 
 noncomputable section
 

--- a/Mathlib/Analysis/SpecialFunctions/Gaussian/PoissonSummation.lean
+++ b/Mathlib/Analysis/SpecialFunctions/Gaussian/PoissonSummation.lean
@@ -20,7 +20,7 @@ for positive real `a`, or complex `a` with positive real part. (See also
 `NumberTheory.ModularForms.JacobiTheta`.)
 -/
 
-@[expose] public section
+public section
 
 open Real Set MeasureTheory Filter Asymptotics intervalIntegral
 

--- a/Mathlib/Analysis/SpecialFunctions/ImproperIntegrals.lean
+++ b/Mathlib/Analysis/SpecialFunctions/ImproperIntegrals.lean
@@ -27,7 +27,7 @@ mathlib's conventions for integrals over finite intervals (see `intervalIntegral
 - `Mathlib/Analysis/SpecialFunctions/JapaneseBracket.lean`-- integrability of `(1+‖x‖)^(-r)`.
 -/
 
-@[expose] public section
+public section
 
 
 open Real Set Filter MeasureTheory intervalIntegral

--- a/Mathlib/Analysis/SpecialFunctions/Integrability/Basic.lean
+++ b/Mathlib/Analysis/SpecialFunctions/Integrability/Basic.lean
@@ -16,7 +16,7 @@ This file establishes basic facts about the interval integrability of special fu
 powers and the logarithm.
 -/
 
-@[expose] public section
+public section
 
 open Interval MeasureTheory Real Set
 

--- a/Mathlib/Analysis/SpecialFunctions/Integrability/LogMeromorphic.lean
+++ b/Mathlib/Analysis/SpecialFunctions/Integrability/LogMeromorphic.lean
@@ -21,7 +21,7 @@ that logarithms of trigonometric functions are interval integrable. In the compl
 functions are circle integrable over every circle in the complex plane.
 -/
 
-@[expose] public section
+public section
 
 open Filter Interval MeasureTheory MeromorphicOn Metric Real
 

--- a/Mathlib/Analysis/SpecialFunctions/Integrals/Basic.lean
+++ b/Mathlib/Analysis/SpecialFunctions/Integrals/Basic.lean
@@ -33,7 +33,7 @@ This file is still being developed.
 integrate, integration, integrable
 -/
 
-@[expose] public section
+public section
 
 
 open Real Set Finset

--- a/Mathlib/Analysis/SpecialFunctions/Integrals/LogTrigonometric.lean
+++ b/Mathlib/Analysis/SpecialFunctions/Integrals/LogTrigonometric.lean
@@ -14,7 +14,7 @@ This file computes special values of the integral of `log ∘ sin`. Given that t
 involves the dilogarithm, this can be seen as computing special values of `Li₂`.
 -/
 
-@[expose] public section
+public section
 
 open Filter Interval Real
 

--- a/Mathlib/Analysis/SpecialFunctions/Integrals/PosLogEqCircleAverage.lean
+++ b/Mathlib/Analysis/SpecialFunctions/Integrals/PosLogEqCircleAverage.lean
@@ -18,7 +18,7 @@ If `a` is any complex number, `circleAverage_log_norm_sub_const_eq_posLog` repre
 the circle average of `log ‖· - a‖` over the unit circle.
 -/
 
-@[expose] public section
+public section
 
 open Filter Interval intervalIntegral MeasureTheory Metric Real
 

--- a/Mathlib/Analysis/SpecialFunctions/JapaneseBracket.lean
+++ b/Mathlib/Analysis/SpecialFunctions/JapaneseBracket.lean
@@ -24,7 +24,7 @@ than the dimension.
 
 -/
 
-@[expose] public section
+public section
 
 
 noncomputable section

--- a/Mathlib/Analysis/SpecialFunctions/Log/Deriv.lean
+++ b/Mathlib/Analysis/SpecialFunctions/Log/Deriv.lean
@@ -24,7 +24,7 @@ that the series `∑' n : ℕ, x ^ (n + 1) / (n + 1)` converges to `(-Real.log (
 logarithm, derivative
 -/
 
-@[expose] public section
+public section
 
 
 open Filter Finset Set

--- a/Mathlib/Analysis/SpecialFunctions/Log/InvLog.lean
+++ b/Mathlib/Analysis/SpecialFunctions/Log/InvLog.lean
@@ -19,7 +19,7 @@ We prove properties of the function `x ↦ (log x)⁻¹`.
 - `deriv_inv_log` gives a formula for the derivative which holds for all values.
 -/
 
-@[expose] public section
+public section
 
 namespace Real
 

--- a/Mathlib/Analysis/SpecialFunctions/Log/Monotone.lean
+++ b/Mathlib/Analysis/SpecialFunctions/Log/Monotone.lean
@@ -18,7 +18,7 @@ form `x ^ a`.
 logarithm, tonality
 -/
 
-@[expose] public section
+public section
 
 
 open Set Filter Function

--- a/Mathlib/Analysis/SpecialFunctions/Log/RpowTendsto.lean
+++ b/Mathlib/Analysis/SpecialFunctions/Log/RpowTendsto.lean
@@ -21,7 +21,7 @@ This file shows that the logarithm can be expressed as a limit of powers, namely
   convergence.
 -/
 
-@[expose] public section
+public section
 
 open scoped Topology
 open Real Filter

--- a/Mathlib/Analysis/SpecialFunctions/Log/Summable.lean
+++ b/Mathlib/Analysis/SpecialFunctions/Log/Summable.lean
@@ -16,7 +16,7 @@ to relate summability of `f` to multipliability of `1 + f`.
 
 -/
 
-@[expose] public section
+public section
 
 variable {ι : Type*}
 

--- a/Mathlib/Analysis/SpecialFunctions/MulExpNegMulSqIntegral.lean
+++ b/Mathlib/Analysis/SpecialFunctions/MulExpNegMulSqIntegral.lean
@@ -39,7 +39,7 @@ This is a key ingredient in the proof of theorem `ext_of_forall_mem_subalgebra_i
 it is shown that a subalgebra of functions that separates points separates finite measures.
 -/
 
-@[expose] public section
+public section
 
 open MeasureTheory Real NNReal ENNReal BoundedContinuousFunction Filter
 

--- a/Mathlib/Analysis/SpecialFunctions/NonIntegrable.lean
+++ b/Mathlib/Analysis/SpecialFunctions/NonIntegrable.lean
@@ -38,7 +38,7 @@ latter lemma to prove that the function `fun x => x⁻¹` is integrable on `a..b
 integrable function
 -/
 
-@[expose] public section
+public section
 
 
 open scoped MeasureTheory Topology Interval NNReal ENNReal

--- a/Mathlib/Analysis/SpecialFunctions/Pochhammer.lean
+++ b/Mathlib/Analysis/SpecialFunctions/Pochhammer.lean
@@ -30,7 +30,7 @@ This file proves analysis theorems for Pochhammer polynomials.
   for `Nat.choose`.
 -/
 
-@[expose] public section
+public section
 
 
 section DescPochhammer

--- a/Mathlib/Analysis/SpecialFunctions/PolynomialExp.lean
+++ b/Mathlib/Analysis/SpecialFunctions/PolynomialExp.lean
@@ -21,7 +21,7 @@ Add more similar lemmas: limit at `-∞`, versions with $e^{cx}$ etc.
 polynomial, limit, exponential
 -/
 
-@[expose] public section
+public section
 
 open Filter Topology Real
 

--- a/Mathlib/Analysis/SpecialFunctions/Pow/Asymptotics.lean
+++ b/Mathlib/Analysis/SpecialFunctions/Pow/Asymptotics.lean
@@ -16,7 +16,7 @@ some results on asymptotics as `x → 0` (those which are not just continuity st
 located here.
 -/
 
-@[expose] public section
+public section
 
 
 noncomputable section

--- a/Mathlib/Analysis/SpecialFunctions/Pow/Continuity.lean
+++ b/Mathlib/Analysis/SpecialFunctions/Pow/Continuity.lean
@@ -14,7 +14,7 @@ public import Mathlib.Analysis.SpecialFunctions.Pow.Asymptotics
 This file contains lemmas about continuity of the power functions on `ℂ`, `ℝ`, `ℝ≥0`, and `ℝ≥0∞`.
 -/
 
-@[expose] public section
+public section
 
 
 noncomputable section

--- a/Mathlib/Analysis/SpecialFunctions/Pow/Deriv.lean
+++ b/Mathlib/Analysis/SpecialFunctions/Pow/Deriv.lean
@@ -19,7 +19,7 @@ public import Mathlib.Analysis.SpecialFunctions.Trigonometric.Deriv
 We also prove differentiability and provide derivatives for the power functions `x ^ y`.
 -/
 
-@[expose] public section
+public section
 
 
 noncomputable section

--- a/Mathlib/Analysis/SpecialFunctions/Pow/Integral.lean
+++ b/Mathlib/Analysis/SpecialFunctions/Pow/Integral.lean
@@ -31,7 +31,7 @@ A variant of the formula with measures of sets of the form `{ω | f(ω) > t}` in
 layer cake representation, Cavalieri's principle, tail probability formula
 -/
 
-@[expose] public section
+public section
 
 open Set
 

--- a/Mathlib/Analysis/SpecialFunctions/Trigonometric/ArctanDeriv.lean
+++ b/Mathlib/Analysis/SpecialFunctions/Trigonometric/ArctanDeriv.lean
@@ -14,7 +14,7 @@ public import Mathlib.Analysis.SpecialFunctions.Trigonometric.ComplexDeriv
 Continuity and derivatives of the tangent and arctangent functions.
 -/
 
-@[expose] public section
+public section
 
 
 noncomputable section

--- a/Mathlib/Analysis/SpecialFunctions/Trigonometric/Bounds.lean
+++ b/Mathlib/Analysis/SpecialFunctions/Trigonometric/Bounds.lean
@@ -31,7 +31,7 @@ Here we prove the following:
 sin, cos, tan, angle
 -/
 
-@[expose] public section
+public section
 
 open Set
 

--- a/Mathlib/Analysis/SpecialFunctions/Trigonometric/Chebyshev/Basic.lean
+++ b/Mathlib/Analysis/SpecialFunctions/Trigonometric/Chebyshev/Basic.lean
@@ -17,7 +17,7 @@ This file gives the trigonometric characterizations of Chebyshev polynomials, fo
 (`Complex.cosh`) hyperbolic cosine.
 -/
 
-@[expose] public section
+public section
 
 
 namespace Polynomial.Chebyshev

--- a/Mathlib/Analysis/SpecialFunctions/Trigonometric/Chebyshev/RootsExtrema.lean
+++ b/Mathlib/Analysis/SpecialFunctions/Trigonometric/Chebyshev/RootsExtrema.lean
@@ -24,7 +24,7 @@ import Mathlib.Analysis.SpecialFunctions.Trigonometric.Complex
 * Local extrema of T: `isLocalExtr_T_real_iff`, `isExtrOn_T_real_iff`
 -/
 
-@[expose] public section
+public section
 
 namespace Polynomial.Chebyshev
 

--- a/Mathlib/Analysis/SpecialFunctions/Trigonometric/Complex.lean
+++ b/Mathlib/Analysis/SpecialFunctions/Trigonometric/Complex.lean
@@ -19,7 +19,7 @@ as they are most easily proved by appealing to the corresponding fact for comple
 functions, or require additional imports which are not available in that file.
 -/
 
-@[expose] public section
+public section
 
 
 noncomputable section

--- a/Mathlib/Analysis/SpecialFunctions/Trigonometric/ComplexDeriv.lean
+++ b/Mathlib/Analysis/SpecialFunctions/Trigonometric/ComplexDeriv.lean
@@ -14,7 +14,7 @@ public import Mathlib.Analysis.SpecialFunctions.Trigonometric.Deriv
 Basic facts and derivatives for the complex trigonometric functions.
 -/
 
-@[expose] public section
+public section
 
 
 noncomputable section

--- a/Mathlib/Analysis/SpecialFunctions/Trigonometric/Cotangent.lean
+++ b/Mathlib/Analysis/SpecialFunctions/Trigonometric/Cotangent.lean
@@ -25,7 +25,7 @@ as well as the infinite sum representation of cotangent (also known as the Mitta
 expansion): `π * cot (π * z) = 1 / z + ∑' n : ℕ+, (1 / (z - n) + 1 / (z + n))`.
 -/
 
-@[expose] public section
+public section
 
 open Real Complex
 

--- a/Mathlib/Analysis/SpecialFunctions/Trigonometric/Deriv.lean
+++ b/Mathlib/Analysis/SpecialFunctions/Trigonometric/Deriv.lean
@@ -21,7 +21,7 @@ computed.
 sin, cos, tan, angle
 -/
 
-@[expose] public section
+public section
 
 noncomputable section
 

--- a/Mathlib/Analysis/SpecialFunctions/Trigonometric/DerivHyp.lean
+++ b/Mathlib/Analysis/SpecialFunctions/Trigonometric/DerivHyp.lean
@@ -24,7 +24,7 @@ computed.
 sinh, cosh, tanh
 -/
 
-@[expose] public section
+public section
 
 noncomputable section
 

--- a/Mathlib/Analysis/SpecialFunctions/Trigonometric/EulerSineProd.lean
+++ b/Mathlib/Analysis/SpecialFunctions/Trigonometric/EulerSineProd.lean
@@ -20,7 +20,7 @@ is to prove a recurrence relation for the integrals `∫ x in 0..π/2, cos 2 z x
 generalising the arguments used to prove Wallis' limit formula for `π`.
 -/
 
-@[expose] public section
+public section
 
 open scoped Real Topology
 

--- a/Mathlib/Analysis/SpecialFunctions/Trigonometric/InverseDeriv.lean
+++ b/Mathlib/Analysis/SpecialFunctions/Trigonometric/InverseDeriv.lean
@@ -14,7 +14,7 @@ public import Mathlib.Analysis.SpecialFunctions.Trigonometric.Deriv
 Derivatives of `arcsin` and `arccos`.
 -/
 
-@[expose] public section
+public section
 
 noncomputable section
 

--- a/Mathlib/Analysis/SpecialFunctions/Trigonometric/Series.lean
+++ b/Mathlib/Analysis/SpecialFunctions/Trigonometric/Series.lean
@@ -21,7 +21,7 @@ In this file we express trigonometric functions in terms of their series expansi
 * `Real.hasSum_sin`, `Real.sin_eq_tsum`: `Real.sin` as the sum of an infinite series.
 -/
 
-@[expose] public section
+public section
 
 open NormedSpace
 

--- a/Mathlib/Analysis/SpecificLimits/Fibonacci.lean
+++ b/Mathlib/Analysis/SpecificLimits/Fibonacci.lean
@@ -14,7 +14,7 @@ public import Mathlib.NumberTheory.Real.GoldenRatio
 We prove that the ratio of consecutive Fibonacci numbers tends to the golden ratio.
 -/
 
-@[expose] public section
+public section
 
 open Nat Real Filter Tendsto
 open scoped Topology goldenRatio

--- a/Mathlib/Analysis/SpecificLimits/FloorPow.lean
+++ b/Mathlib/Analysis/SpecificLimits/FloorPow.lean
@@ -20,7 +20,7 @@ We state several auxiliary results pertaining to sequences of the form `âŒŠc^nâŒ
   to `1/j^2`, up to a multiplicative constant.
 -/
 
-@[expose] public section
+public section
 
 open Filter Finset
 

--- a/Mathlib/Analysis/SpecificLimits/RCLike.lean
+++ b/Mathlib/Analysis/SpecificLimits/RCLike.lean
@@ -13,7 +13,7 @@ public import Mathlib.Analysis.RCLike.Basic
 
 -/
 
-@[expose] public section
+public section
 
 open Set Algebra Filter
 open scoped Topology


### PR DESCRIPTION
This PR removes `@[expose]` from `public section` declarations in 56 files under `Mathlib/Analysis/SpecialFunctions/`, `Mathlib/Analysis/Fourier/`, `Mathlib/Analysis/Real/`, and related directories.

Part of a larger cleanup effort (~1400 files identified).

🤖 Prepared with Claude Code