### PR TITLE
[Merged by Bors] - chore(Analysis/Normed): remove unnecessary @[expose] from public sections

### DIFF
--- a/Mathlib/Analysis/Analytic/IsolatedZeros.lean
+++ b/Mathlib/Analysis/Analytic/IsolatedZeros.lean
@@ -38,7 +38,7 @@ in this setup.
   within `f '' U` is codiscrete within `U`.
 -/
 
-@[expose] public section
+public section
 
 open Filter Function Nat FormalMultilinearSeries EMetric Set
 

--- a/Mathlib/Analysis/Analytic/Polynomial.lean
+++ b/Mathlib/Analysis/Analytic/Polynomial.lean
@@ -17,7 +17,7 @@ This file combines the analysis and algebra libraries and shows that evaluation 
 is an analytic function.
 -/
 
-@[expose] public section
+public section
 
 variable {𝕜 E A B : Type*} [NontriviallyNormedField 𝕜] [NormedAddCommGroup E] [NormedSpace 𝕜 E]
   [CommSemiring A] {z : E} {s : Set E}

--- a/Mathlib/Analysis/Analytic/RadiusLiminf.lean
+++ b/Mathlib/Analysis/Analytic/RadiusLiminf.lean
@@ -16,7 +16,7 @@ because this would create a circular dependency once we redefine `exp` using
 `FormalMultilinearSeries`.
 -/
 
-@[expose] public section
+public section
 
 
 variable {𝕜 : Type*} [NontriviallyNormedField 𝕜] {E : Type*} [NormedAddCommGroup E]

--- a/Mathlib/Analysis/Analytic/Uniqueness.lean
+++ b/Mathlib/Analysis/Analytic/Uniqueness.lean
@@ -18,7 +18,7 @@ We show that two analytic functions which coincide around a point coincide on wh
 in `AnalyticOnNhd.eqOn_of_preconnected_of_eventuallyEq`.
 -/
 
-@[expose] public section
+public section
 
 
 variable {𝕜 : Type*} [NontriviallyNormedField 𝕜] {E : Type*} [NormedAddCommGroup E]

--- a/Mathlib/Analysis/Analytic/WithLp.lean
+++ b/Mathlib/Analysis/Analytic/WithLp.lean
@@ -12,7 +12,7 @@ public import Mathlib.Analysis.Normed.Lp.PiLp
 # Analyticity on `WithLp`
 -/
 
-@[expose] public section
+public section
 
 open WithLp
 

--- a/Mathlib/Analysis/Analytic/Within.lean
+++ b/Mathlib/Analysis/Analytic/Within.lean
@@ -23,7 +23,7 @@ Here we prove basic properties of these definitions. Where convenient we assume 
 ambient space, which allows us to relate `AnalyticWithinAt` to analyticity of a local extension.
 -/
 
-@[expose] public section
+public section
 
 noncomputable section
 

--- a/Mathlib/Analysis/Asymptotics/Completion.lean
+++ b/Mathlib/Analysis/Asymptotics/Completion.lean
@@ -15,7 +15,7 @@ In this file we prove lemmas relating `f = O(g)` etc
 for composition of functions with coercion of a seminormed group to its completion.
 -/
 
-@[expose] public section
+public section
 
 variable {α E F : Type*} [Norm E] [SeminormedAddCommGroup F]
   {f : α → E} {g : α → F} {l : Filter α}

--- a/Mathlib/Analysis/Asymptotics/Lemmas.lean
+++ b/Mathlib/Analysis/Asymptotics/Lemmas.lean
@@ -16,7 +16,7 @@ public import Mathlib.Topology.OpenPartialHomeomorph.Continuity
 
 -/
 
-@[expose] public section
+public section
 
 open Set Topology Filter NNReal
 

--- a/Mathlib/Analysis/Asymptotics/SpecificAsymptotics.lean
+++ b/Mathlib/Analysis/Asymptotics/SpecificAsymptotics.lean
@@ -16,7 +16,7 @@ theory developed in `Mathlib/Analysis/Asymptotics/Defs.lean` and
 `Mathlib/Analysis/Asymptotics/Lemmas.lean`.
 -/
 
-@[expose] public section
+public section
 
 
 open Filter Asymptotics

--- a/Mathlib/Analysis/BoxIntegral/DivergenceTheorem.lean
+++ b/Mathlib/Analysis/BoxIntegral/DivergenceTheorem.lean
@@ -40,7 +40,7 @@ Henstock-Kurzweil integral.
 Henstock-Kurzweil integral, integral, Stokes theorem, divergence theorem
 -/
 
-@[expose] public section
+public section
 
 open scoped NNReal ENNReal Topology BoxIntegral
 

--- a/Mathlib/Analysis/BoxIntegral/Integrability.lean
+++ b/Mathlib/Analysis/BoxIntegral/Integrability.lean
@@ -23,7 +23,7 @@ We deduce that the same is true for the Riemann integral for continuous function
 integral, McShane integral, Bochner integral
 -/
 
-@[expose] public section
+public section
 
 open scoped NNReal ENNReal Topology
 

--- a/Mathlib/Analysis/Convex/Birkhoff.lean
+++ b/Mathlib/Analysis/Convex/Birkhoff.lean
@@ -35,7 +35,7 @@ public import Mathlib.Tactic.Linarith
 Doubly stochastic, Birkhoff's theorem, Birkhoff-von Neumann theorem
 -/
 
-@[expose] public section
+public section
 
 open Finset Function Matrix
 

--- a/Mathlib/Analysis/Convex/Cone/Extension.lean
+++ b/Mathlib/Analysis/Convex/Cone/Extension.lean
@@ -27,7 +27,7 @@ We prove two extension theorems:
 
 -/
 
-@[expose] public section
+public section
 
 open Set LinearMap
 

--- a/Mathlib/Analysis/Convex/Continuous.lean
+++ b/Mathlib/Analysis/Convex/Continuous.lean
@@ -14,7 +14,7 @@ This file proves that a convex function from a finite-dimensional real normed sp
 continuous.
 -/
 
-@[expose] public section
+public section
 
 open FiniteDimensional Metric Set List Bornology
 open scoped Topology

--- a/Mathlib/Analysis/Convex/ContinuousLinearEquiv.lean
+++ b/Mathlib/Analysis/Convex/ContinuousLinearEquiv.lean
@@ -15,7 +15,7 @@ In this file we prove that the (pre)image of a strict convex set
 under a continuous linear equivalence is a strict convex set.
 -/
 
-@[expose] public section
+public section
 
 variable {𝕜 E F : Type*}
   [Field 𝕜] [PartialOrder 𝕜]

--- a/Mathlib/Analysis/Convex/Deriv.lean
+++ b/Mathlib/Analysis/Convex/Deriv.lean
@@ -21,7 +21,7 @@ Here we relate convexity of functions `ℝ → ℝ` to properties of their deriv
   monotone.
 -/
 
-@[expose] public section
+public section
 
 open Metric Set Asymptotics ContinuousLinearMap Filter
 open scoped Topology NNReal

--- a/Mathlib/Analysis/Convex/Extrema.lean
+++ b/Mathlib/Analysis/Convex/Extrema.lean
@@ -17,7 +17,7 @@ We show that if a function `f : E → β` is convex, then a local minimum is als
 a global minimum, and likewise for concave functions.
 -/
 
-@[expose] public section
+public section
 
 
 variable {E β : Type*} [AddCommGroup E] [TopologicalSpace E] [Module ℝ E] [IsTopologicalAddGroup E]

--- a/Mathlib/Analysis/Convex/Integral.lean
+++ b/Mathlib/Analysis/Convex/Integral.lean
@@ -36,7 +36,7 @@ In this file we prove several forms of Jensen's inequality for integrals.
 convex, integral, center mass, average value, Jensen's inequality
 -/
 
-@[expose] public section
+public section
 
 
 open MeasureTheory MeasureTheory.Measure Metric Set Filter TopologicalSpace Function

--- a/Mathlib/Analysis/Convex/Jensen.lean
+++ b/Mathlib/Analysis/Convex/Jensen.lean
@@ -32,7 +32,7 @@ As corollaries, we get:
 * `ConcaveOn.exists_le_of_mem_convexHull`: Minimum principle for concave functions.
 -/
 
-@[expose] public section
+public section
 
 
 open Finset LinearMap Set Convex Pointwise

--- a/Mathlib/Analysis/Convex/KreinMilman.lean
+++ b/Mathlib/Analysis/Convex/KreinMilman.lean
@@ -52,7 +52,7 @@ See chapter 8 of [Barry Simon, *Convexity*][simon2011]
 
 -/
 
-@[expose] public section
+public section
 
 open Set
 

--- a/Mathlib/Analysis/Convex/Measure.lean
+++ b/Mathlib/Analysis/Convex/Measure.lean
@@ -17,7 +17,7 @@ convex set in `E`. Then the frontier of `s` has measure zero (see `Convex.addHaa
 `s` is a `NullMeasurableSet` (see `Convex.nullMeasurableSet`).
 -/
 
-@[expose] public section
+public section
 
 
 open MeasureTheory MeasureTheory.Measure Set Metric Filter Bornology

--- a/Mathlib/Analysis/Convex/Mul.lean
+++ b/Mathlib/Analysis/Convex/Mul.lean
@@ -21,7 +21,7 @@ As corollaries, we also prove that `x ↦ x ^ n` is convex
 * `convexOn_zpow`: over $(0, +∞)$ For `n : ℤ`.
 -/
 
-@[expose] public section
+public section
 
 open Set
 

--- a/Mathlib/Analysis/Convex/NNReal.lean
+++ b/Mathlib/Analysis/Convex/NNReal.lean
@@ -15,7 +15,7 @@ This file collects some specific results about convexity over the ring `ℝ≥0`
 Expand as needed.
 -/
 
-@[expose] public section
+public section
 
 open Set
 open scoped NNReal

--- a/Mathlib/Analysis/Convex/PartitionOfUnity.lean
+++ b/Mathlib/Analysis/Convex/PartitionOfUnity.lean
@@ -26,7 +26,7 @@ assumes that local functions `g` are constants.
 partition of unity
 -/
 
-@[expose] public section
+public section
 
 
 open Set Function

--- a/Mathlib/Analysis/Convex/Piecewise.lean
+++ b/Mathlib/Analysis/Convex/Piecewise.lean
@@ -28,7 +28,7 @@ This file proves convex and concave theorems for piecewise functions.
   and `concaveOn_univ_piecewise_Ici_of_antitoneOn_Ici_monotoneOn_Iic`.
 -/
 
-@[expose] public section
+public section
 
 
 variable {𝕜 E β : Type*} [Semiring 𝕜] [PartialOrder 𝕜]

--- a/Mathlib/Analysis/Convex/Radon.lean
+++ b/Mathlib/Analysis/Convex/Radon.lean
@@ -28,7 +28,7 @@ compactness of sets (see `helly_theorem_compact`).
 convex hull, affine independence, Radon, Helly
 -/
 
-@[expose] public section
+public section
 
 open Fintype Finset Set
 

--- a/Mathlib/Analysis/Convex/Slope.lean
+++ b/Mathlib/Analysis/Convex/Slope.lean
@@ -19,7 +19,7 @@ of their slopes.
 The main use is to show convexity/concavity from monotonicity of the derivative.
 -/
 
-@[expose] public section
+public section
 
 variable {𝕜 : Type*} [Field 𝕜] [LinearOrder 𝕜] [IsStrictOrderedRing 𝕜] {s : Set 𝕜} {f : 𝕜 → 𝕜}
 

--- a/Mathlib/Analysis/Convex/SpecificFunctions/Basic.lean
+++ b/Mathlib/Analysis/Convex/SpecificFunctions/Basic.lean
@@ -33,7 +33,7 @@ theory.
 `Mathlib/Analysis/Convex/Mul.lean` for convexity of `x ↦ x ^ n`
 -/
 
-@[expose] public section
+public section
 
 open Real Set NNReal
 

--- a/Mathlib/Analysis/Convex/SpecificFunctions/Deriv.lean
+++ b/Mathlib/Analysis/Convex/SpecificFunctions/Deriv.lean
@@ -32,7 +32,7 @@ of these could also be switched to elementary proofs, like in
 
 -/
 
-@[expose] public section
+public section
 
 
 open Real Set

--- a/Mathlib/Analysis/Convex/SpecificFunctions/Pow.lean
+++ b/Mathlib/Analysis/Convex/SpecificFunctions/Pow.lean
@@ -28,7 +28,7 @@ requires slightly less imports.
 * Prove convexity for negative powers.
 -/
 
-@[expose] public section
+public section
 
 open Set
 

--- a/Mathlib/Analysis/Convex/StoneSeparation.lean
+++ b/Mathlib/Analysis/Convex/StoneSeparation.lean
@@ -19,7 +19,7 @@ stronger statements: one may find a separating hyperplane, instead of merely a c
 complement is convex.
 -/
 
-@[expose] public section
+public section
 
 
 open Set

--- a/Mathlib/Analysis/Convex/StrictCombination.lean
+++ b/Mathlib/Analysis/Convex/StrictCombination.lean
@@ -17,7 +17,7 @@ convex spaces.
 
 -/
 
-@[expose] public section
+public section
 
 
 open Finset Metric

--- a/Mathlib/Analysis/Convex/TotallyBounded.lean
+++ b/Mathlib/Analysis/Convex/TotallyBounded.lean
@@ -26,7 +26,7 @@ public import Mathlib.Topology.Algebra.Module.LocallyConvex
 convex, totally bounded
 -/
 
-@[expose] public section
+public section
 
 open Set Pointwise
 

--- a/Mathlib/Analysis/LocallyConvex/WeakSpace.lean
+++ b/Mathlib/Analysis/LocallyConvex/WeakSpace.lean
@@ -19,7 +19,7 @@ Of course, we phrase this in terms of linear maps between locally convex spaces,
 creating two separate topologies on the same space.
 -/
 
-@[expose] public section
+public section
 
 variable {𝕜 E F : Type*}
 variable [RCLike 𝕜] [AddCommGroup E] [Module 𝕜 E] [AddCommGroup F] [Module 𝕜 F]

--- a/Mathlib/Analysis/Matrix/Hermitian.lean
+++ b/Mathlib/Analysis/Matrix/Hermitian.lean
@@ -19,7 +19,7 @@ linear map is self-adjoint.
 self-adjoint matrix, hermitian matrix
 -/
 
-@[expose] public section
+public section
 
 -- TODO:
 -- assert_not_exists MonoidAlgebra

--- a/Mathlib/Analysis/Normed/Affine/AddTorsorBases.lean
+++ b/Mathlib/Analysis/Normed/Affine/AddTorsorBases.lean
@@ -22,7 +22,7 @@ This file contains results about bases in normed affine spaces.
 * `interior_convexHull_nonempty_iff_affineSpan_eq_top`
 -/
 
-@[expose] public section
+public section
 
 assert_not_exists HasFDerivAt
 

--- a/Mathlib/Analysis/Normed/Affine/AsymptoticCone.lean
+++ b/Mathlib/Analysis/Normed/Affine/AsymptoticCone.lean
@@ -15,7 +15,7 @@ In this file, we prove that the asymptotic cone of a set is non-trivial if and o
 unbounded.
 -/
 
-@[expose] public section
+public section
 
 open AffineSpace Bornology Filter Topology
 

--- a/Mathlib/Analysis/Normed/Affine/Convex.lean
+++ b/Mathlib/Analysis/Normed/Affine/Convex.lean
@@ -20,7 +20,7 @@ We prove the following facts:
   polytope between a compact convex set and one of its neighborhoods.
 -/
 
-@[expose] public section
+public section
 
 variable {E P : Type*}
 

--- a/Mathlib/Analysis/Normed/Algebra/DualNumber.lean
+++ b/Mathlib/Analysis/Normed/Algebra/DualNumber.lean
@@ -19,7 +19,7 @@ These are just restatements of similar statements about `TrivSqZeroExt R M`.
 
 -/
 
-@[expose] public section
+public section
 
 open NormedSpace -- For `NormedSpace.exp`.
 

--- a/Mathlib/Analysis/Normed/Algebra/MatrixExponential.lean
+++ b/Mathlib/Analysis/Normed/Algebra/MatrixExponential.lean
@@ -61,7 +61,7 @@ results for general rings are instead stated about `Ring.inverse`:
 * https://en.wikipedia.org/wiki/Matrix_exponential
 -/
 
-@[expose] public section
+public section
 
 open scoped Matrix
 

--- a/Mathlib/Analysis/Normed/Algebra/QuaternionExponential.lean
+++ b/Mathlib/Analysis/Normed/Algebra/QuaternionExponential.lean
@@ -24,7 +24,7 @@ This file contains results about `NormedSpace.exp` on `Quaternion ℝ`.
 
 -/
 
-@[expose] public section
+public section
 
 open scoped Quaternion Nat
 

--- a/Mathlib/Analysis/Normed/Algebra/Ultra.lean
+++ b/Mathlib/Analysis/Normed/Algebra/Ultra.lean
@@ -14,7 +14,7 @@ public import Mathlib.Analysis.Normed.Module.Basic
 This file contains the proof that a normed division ring over an ultrametric field is ultrametric.
 -/
 
-@[expose] public section
+public section
 
 variable {K L : Type*} [NormedField K]
 

--- a/Mathlib/Analysis/Normed/Field/ProperSpace.lean
+++ b/Mathlib/Analysis/Normed/Field/ProperSpace.lean
@@ -25,7 +25,7 @@ This is a special case of `ProperSpace.of_locallyCompactSpace` from
 with a proof that requires fewer imports.
 -/
 
-@[expose] public section
+public section
 
 assert_not_exists FiniteDimensional
 

--- a/Mathlib/Analysis/Normed/Field/Ultra.lean
+++ b/Mathlib/Analysis/Normed/Field/Ultra.lean
@@ -33,7 +33,7 @@ to be able to be applied in noncommutative division rings.
 ultrametric, nonarchimedean
 -/
 
-@[expose] public section
+public section
 open Metric NNReal
 
 namespace IsUltrametricDist

--- a/Mathlib/Analysis/Normed/Group/Bounded.lean
+++ b/Mathlib/Analysis/Normed/Group/Bounded.lean
@@ -19,7 +19,7 @@ This file rephrases metric boundedness in terms of norms.
 normed group
 -/
 
-@[expose] public section
+public section
 
 open Filter Metric Bornology
 open scoped Pointwise Topology

--- a/Mathlib/Analysis/Normed/Group/CocompactMap.lean
+++ b/Mathlib/Analysis/Normed/Group/CocompactMap.lean
@@ -22,7 +22,7 @@ This file gives a characterization of cocompact maps in terms of norm estimates.
 
 -/
 
-@[expose] public section
+public section
 
 open Filter Metric
 

--- a/Mathlib/Analysis/Normed/Group/Completeness.lean
+++ b/Mathlib/Analysis/Normed/Group/Completeness.lean
@@ -30,7 +30,7 @@ series.
 CompleteSpace, CauchySeq
 -/
 
-@[expose] public section
+public section
 
 open scoped Topology
 open Filter Finset

--- a/Mathlib/Analysis/Normed/Group/ControlledClosure.lean
+++ b/Mathlib/Analysis/Normed/Group/ControlledClosure.lean
@@ -16,7 +16,7 @@ Possible TODO (from the PR's review, https://github.com/leanprover-community/mat
 lemmas in this file]."
 -/
 
-@[expose] public section
+public section
 
 
 open Filter Finset

--- a/Mathlib/Analysis/Normed/Group/FunctionSeries.lean
+++ b/Mathlib/Analysis/Normed/Group/FunctionSeries.lean
@@ -20,7 +20,7 @@ TODO: update this to use `SummableUniformlyOn`.
 
 -/
 
-@[expose] public section
+public section
 
 open Set Metric TopologicalSpace Function Filter
 

--- a/Mathlib/Analysis/Normed/Group/Indicator.lean
+++ b/Mathlib/Analysis/Normed/Group/Indicator.lean
@@ -18,7 +18,7 @@ This file contains a few simple lemmas about `Set.indicator`, `norm` and `enorm`
 indicator, norm
 -/
 
-@[expose] public section
+public section
 
 open Set
 

--- a/Mathlib/Analysis/Normed/Group/InfiniteSum.lean
+++ b/Mathlib/Analysis/Normed/Group/InfiniteSum.lean
@@ -33,7 +33,7 @@ In a complete (semi)normed group,
 infinite series, absolute convergence, normed group
 -/
 
-@[expose] public section
+public section
 
 open Topology ENNReal NNReal
 

--- a/Mathlib/Analysis/Normed/Group/Lemmas.lean
+++ b/Mathlib/Analysis/Normed/Group/Lemmas.lean
@@ -19,7 +19,7 @@ This file contains further lemmas about normed groups, requiring heavier imports
 
 -/
 
-@[expose] public section
+public section
 
 variable {E : Type*} [SeminormedAddCommGroup E]
 open NNReal Topology

--- a/Mathlib/Analysis/Normed/Group/Pointwise.lean
+++ b/Mathlib/Analysis/Normed/Group/Pointwise.lean
@@ -16,7 +16,7 @@ We explore the relationships between pointwise addition of sets in normed groups
 Notably, we show that the sum of bounded sets remain bounded.
 -/
 
-@[expose] public section
+public section
 
 
 open Metric Set Pointwise Topology

--- a/Mathlib/Analysis/Normed/Group/Tannery.lean
+++ b/Mathlib/Analysis/Normed/Group/Tannery.lean
@@ -19,7 +19,7 @@ order to avoid some unnecessary hypotheses that appear when specialising the gen
 measure-theoretic result.
 -/
 
-@[expose] public section
+public section
 
 open Filter Topology
 

--- a/Mathlib/Analysis/Normed/Group/ZeroAtInfty.lean
+++ b/Mathlib/Analysis/Normed/Group/ZeroAtInfty.lean
@@ -16,7 +16,7 @@ for every `ε > 0` there exists a `r : ℝ` such that for all `x : E` with `r < 
 `‖f x‖ < ε`.
 -/
 
-@[expose] public section
+public section
 
 open Topology Filter
 

--- a/Mathlib/Analysis/Normed/Lp/SmoothApprox.lean
+++ b/Mathlib/Analysis/Normed/Lp/SmoothApprox.lean
@@ -19,7 +19,7 @@ functions for `p < ∞`.
 This result is recorded in `MeasureTheory.MemLp.exist_sub_eLpNorm_le`.
 -/
 
-@[expose] public section
+public section
 
 variable {α β E F : Type*} [MeasurableSpace E] [NormedAddCommGroup F]
 

--- a/Mathlib/Analysis/Normed/Module/Ball/Pointwise.lean
+++ b/Mathlib/Analysis/Normed/Module/Ball/Pointwise.lean
@@ -16,7 +16,7 @@ Notably, we express arbitrary balls as rescaling of other balls, and we show tha
 multiplication of bounded sets remain bounded.
 -/
 
-@[expose] public section
+public section
 
 
 open Metric Set

--- a/Mathlib/Analysis/Normed/Module/Connected.lean
+++ b/Mathlib/Analysis/Normed/Module/Connected.lean
@@ -26,7 +26,7 @@ We show several results related to the (path)-connectedness of subsets of real v
 Statements with connectedness instead of path-connectedness are also given.
 -/
 
-@[expose] public section
+public section
 
 assert_not_exists Subgroup.index Nat.divisors
 -- TODO assert_not_exists Cardinal

--- a/Mathlib/Analysis/Normed/Module/Extr.lean
+++ b/Mathlib/Analysis/Normed/Module/Extr.lean
@@ -23,7 +23,7 @@ Then we specialize it to the case `y = f c` and to different special cases of `I
 local maximum, normed space
 -/
 
-@[expose] public section
+public section
 
 
 variable {α X E : Type*} [SeminormedAddCommGroup E] [NormedSpace ℝ E] [TopologicalSpace X]

--- a/Mathlib/Analysis/Normed/Module/HahnBanach.lean
+++ b/Mathlib/Analysis/Normed/Module/HahnBanach.lean
@@ -29,7 +29,7 @@ linear form `g` of norm `1` with `g x = ‖x‖` (where the norm has to be inter
 of `𝕜`).
 -/
 
-@[expose] public section
+public section
 
 
 universe u v

--- a/Mathlib/Analysis/Normed/Module/MultipliableUniformlyOn.lean
+++ b/Mathlib/Analysis/Normed/Module/MultipliableUniformlyOn.lean
@@ -17,7 +17,7 @@ We gather some results about the uniform convergence of infinite products, in pa
 the form `∏' i, (1 + f i x)` for a sequence `f` of complex-valued functions.
 -/
 
-@[expose] public section
+public section
 
 open Filter Function Complex Finset Topology
 

--- a/Mathlib/Analysis/Normed/Module/RCLike/Basic.lean
+++ b/Mathlib/Analysis/Normed/Module/RCLike/Basic.lean
@@ -28,7 +28,7 @@ None.
 This file exists mainly to avoid importing `RCLike` in the main normed space theory files.
 -/
 
-@[expose] public section
+public section
 
 
 open Metric

--- a/Mathlib/Analysis/Normed/Module/RCLike/Extend.lean
+++ b/Mathlib/Analysis/Normed/Module/RCLike/Extend.lean
@@ -14,7 +14,7 @@ public import Mathlib.Analysis.Normed.Operator.Basic
 This file shows that `ContinuousLinearMap.extendTo𝕜` preserves the norm of the functional.
 -/
 
-@[expose] public section
+public section
 
 open RCLike
 open scoped ComplexConjugate

--- a/Mathlib/Analysis/Normed/Module/Ray.lean
+++ b/Mathlib/Analysis/Normed/Module/Ray.lean
@@ -17,7 +17,7 @@ this case, for two vectors `x y` in the same ray, the norm of their sum is equal
 norms and `‖y‖ • x = ‖x‖ • y`.
 -/
 
-@[expose] public section
+public section
 
 
 open Real

--- a/Mathlib/Analysis/Normed/Module/RieszLemma.lean
+++ b/Mathlib/Analysis/Normed/Module/RieszLemma.lean
@@ -23,7 +23,7 @@ A further lemma, `Metric.closedBall_infDist_compl_subset_closure`, finds a *clos
 the closure of a set `s` of optimal distance from a point in `x` to the frontier of `s`.
 -/
 
-@[expose] public section
+public section
 
 
 open Set Metric

--- a/Mathlib/Analysis/Normed/Operator/Asymptotics.lean
+++ b/Mathlib/Analysis/Normed/Operator/Asymptotics.lean
@@ -14,7 +14,7 @@ This file contains lemmas about how operator norm on continuous linear maps inte
 
 -/
 
-@[expose] public section
+public section
 
 open Asymptotics
 

--- a/Mathlib/Analysis/Normed/Operator/CompleteCodomain.lean
+++ b/Mathlib/Analysis/Normed/Operator/CompleteCodomain.lean
@@ -19,7 +19,7 @@ linear maps from `E` to `F` is equivalent to the completeness of `F`.
 A similar statement holds for spaces of continuous multilinear maps
 -/
 
-@[expose] public section
+public section
 
 open Filter
 open scoped Topology

--- a/Mathlib/Analysis/Normed/Operator/NNNorm.lean
+++ b/Mathlib/Analysis/Normed/Operator/NNNorm.lean
@@ -15,7 +15,7 @@ Operator norm as an `NNNorm`, i.e. taking values in non-negative reals.
 
 -/
 
-@[expose] public section
+public section
 
 suppress_compilation
 

--- a/Mathlib/Analysis/Normed/Order/Basic.lean
+++ b/Mathlib/Analysis/Normed/Order/Basic.lean
@@ -14,7 +14,7 @@ In this file, we define classes for fields and groups that are both normed and o
 These are mostly useful to avoid diamonds during type class inference.
 -/
 
-@[expose] public section
+public section
 
 
 open Filter Set

--- a/Mathlib/Analysis/Normed/Order/Hom/Ultra.lean
+++ b/Mathlib/Analysis/Normed/Order/Hom/Ultra.lean
@@ -22,7 +22,7 @@ hom-based `AddGroupSeminormClass.toSeminormedAddGroup f` construction. To help a
 the argument is an autoparam that resolves by definitional equality when using these constructions.
 -/
 
-@[expose] public section
+public section
 
 variable {F α : Type*} [FunLike F α ℝ]
 

--- a/Mathlib/Analysis/Normed/Order/UpperLower.lean
+++ b/Mathlib/Analysis/Normed/Order/UpperLower.lean
@@ -30,7 +30,7 @@ from the other possible lemmas, but we will want there to be a single set of lem
 situations.
 -/
 
-@[expose] public section
+public section
 
 open Bornology Function Metric Set
 open scoped Pointwise

--- a/Mathlib/Analysis/Normed/Ring/Finite.lean
+++ b/Mathlib/Analysis/Normed/Ring/Finite.lean
@@ -20,7 +20,7 @@ The values of additive characters on finite cancellative monoids have norm 1.
 
 -/
 
-@[expose] public section
+public section
 
 variable {α β : Type*}
 

--- a/Mathlib/Analysis/Normed/Ring/InfiniteSum.lean
+++ b/Mathlib/Analysis/Normed/Ring/InfiniteSum.lean
@@ -20,7 +20,7 @@ We first establish results about arbitrary index types, `ι` and `ι'`, and then
 (see `tsum_mul_tsum_eq_tsum_sum_antidiagonal_of_summable_norm`).
 -/
 
-@[expose] public section
+public section
 
 
 variable {R : Type*} {ι : Type*} {ι' : Type*} [NormedRing R]

--- a/Mathlib/Analysis/Normed/Ring/Int.lean
+++ b/Mathlib/Analysis/Normed/Ring/Int.lean
@@ -18,7 +18,7 @@ to obtain a term of type `NNReal` (the nonnegative real numbers).
 The resulting nonnegative real number is denoted by `‖n‖₊`.
 -/
 
-@[expose] public section
+public section
 
 
 namespace Int

--- a/Mathlib/Analysis/Normed/Ring/Ultra.lean
+++ b/Mathlib/Analysis/Normed/Ring/Ultra.lean
@@ -38,7 +38,7 @@ Instead, we use weakest pre-existing typeclass that implies both
 ultrametric, nonarchimedean
 -/
 
-@[expose] public section
+public section
 open Metric NNReal
 
 namespace IsUltrametricDist

--- a/Mathlib/Analysis/Normed/Unbundled/IsPowMulFaithful.lean
+++ b/Mathlib/Analysis/Normed/Unbundled/IsPowMulFaithful.lean
@@ -26,7 +26,7 @@ commutative ring and `f₁` and `f₂` are two power-multiplicative `R`-algebra 
 norm, equivalent, power-multiplicative
 -/
 
-@[expose] public section
+public section
 
 open Filter Real
 open scoped Topology

--- a/Mathlib/Analysis/Polynomial/Basic.lean
+++ b/Mathlib/Analysis/Polynomial/Basic.lean
@@ -22,7 +22,7 @@ functions, depending on the degrees and leading coefficients of the considered
 polynomials.
 -/
 
-@[expose] public section
+public section
 
 
 open Filter Finset Asymptotics

--- a/Mathlib/Analysis/Polynomial/Factorization.lean
+++ b/Mathlib/Analysis/Polynomial/Factorization.lean
@@ -22,7 +22,7 @@ This file contains two main results:
   a monic polynomial of degree two times another monic factor.
 -/
 
-@[expose] public section
+public section
 
 namespace Polynomial.IsMonicOfDegree
 

--- a/Mathlib/Analysis/RCLike/BoundedContinuous.lean
+++ b/Mathlib/Analysis/RCLike/BoundedContinuous.lean
@@ -12,7 +12,7 @@ public import Mathlib.Topology.ContinuousMap.Bounded.Star
 
 /-! # Results on bounded continuous functions with `RCLike` values -/
 
-@[expose] public section
+public section
 
 open Filter Real RCLike BoundedContinuousFunction
 

--- a/Mathlib/Analysis/RCLike/TangentCone.lean
+++ b/Mathlib/Analysis/RCLike/TangentCone.lean
@@ -15,7 +15,7 @@ A set of unique differentiability for `ℝ` is also a set of unique differentiab
 (or for a general field satisfying `IsRCLikeNormedField 𝕜`).
 -/
 
-@[expose] public section
+public section
 
 variable {𝕜 : Type*} [NontriviallyNormedField 𝕜] [h𝕜 : IsRCLikeNormedField 𝕜]
   {E : Type*} [NormedAddCommGroup E] [NormedSpace 𝕜 E] [NormedSpace ℝ E]


### PR DESCRIPTION
This PR removes `@[expose]` from `public section` declarations in 80 files under `Mathlib/Analysis/Normed/`, `Mathlib/Analysis/Convex/`, `Mathlib/Analysis/Analytic/`, and related directories.

Part of a larger cleanup effort (~1400 files identified).

🤖 Prepared with Claude Code