### PR TITLE
[Merged by Bors] - chore(Algebra/Order): remove unnecessary @[expose] from public sections

### DIFF
--- a/Mathlib/Algebra/BigOperators/Associated.lean
+++ b/Mathlib/Algebra/BigOperators/Associated.lean
@@ -17,7 +17,7 @@ and products of multisets, finsets, and finsupps.
 
 -/
 
-@[expose] public section
+public section
 
 assert_not_exists Field
 

--- a/Mathlib/Algebra/BigOperators/Field.lean
+++ b/Mathlib/Algebra/BigOperators/Field.lean
@@ -13,7 +13,7 @@ public import Mathlib.Data.Finset.Density
 # Results about big operators with values in a field
 -/
 
-@[expose] public section
+public section
 
 open Fintype
 

--- a/Mathlib/Algebra/BigOperators/Group/Finset/Basic.lean
+++ b/Mathlib/Algebra/BigOperators/Group/Finset/Basic.lean
@@ -15,7 +15,7 @@ public import Mathlib.Data.Finset.Sum
 In this file we prove theorems about products and sums indexed by a `Finset`.
 -/
 
-@[expose] public section
+public section
 
 assert_not_exists AddCommMonoidWithOne
 assert_not_exists MonoidWithZero MulAction IsOrderedMonoid

--- a/Mathlib/Algebra/BigOperators/Group/Finset/Indicator.lean
+++ b/Mathlib/Algebra/BigOperators/Group/Finset/Indicator.lean
@@ -13,7 +13,7 @@ public import Mathlib.Order.CompleteLattice.Finset
 # Interaction of big operators with indicator functions
 -/
 
-@[expose] public section
+public section
 
 namespace Finset
 

--- a/Mathlib/Algebra/BigOperators/Group/Finset/Interval.lean
+++ b/Mathlib/Algebra/BigOperators/Group/Finset/Interval.lean
@@ -17,7 +17,7 @@ This file contains some lemmas about sums and products over integer intervals `I
 
 -/
 
-@[expose] public section
+public section
 
 namespace Finset
 

--- a/Mathlib/Algebra/BigOperators/Group/Finset/Lemmas.lean
+++ b/Mathlib/Algebra/BigOperators/Group/Finset/Lemmas.lean
@@ -17,7 +17,7 @@ The lemmas in this file have been moved out of
 `Mathlib/Algebra/BigOperators/Group/Finset/Basic.lean` to reduce its imports.
 -/
 
-@[expose] public section
+public section
 
 variable {ι κ M N β : Type*}
 

--- a/Mathlib/Algebra/BigOperators/Group/Finset/Pi.lean
+++ b/Mathlib/Algebra/BigOperators/Group/Finset/Pi.lean
@@ -14,7 +14,7 @@ public import Mathlib.Algebra.BigOperators.Group.Finset.Defs
 
 -/
 
-@[expose] public section
+public section
 
 assert_not_exists MonoidWithZero MulAction IsOrderedMonoid
 

--- a/Mathlib/Algebra/BigOperators/Group/Finset/Piecewise.lean
+++ b/Mathlib/Algebra/BigOperators/Group/Finset/Piecewise.lean
@@ -14,7 +14,7 @@ public import Mathlib.Data.Finset.Piecewise
 This file proves lemmas on the sum and product of piecewise functions, including `ite` and `dite`.
 -/
 
-@[expose] public section
+public section
 
 variable {ι κ M β γ : Type*} {s : Finset ι}
 

--- a/Mathlib/Algebra/BigOperators/Group/Finset/Powerset.lean
+++ b/Mathlib/Algebra/BigOperators/Group/Finset/Powerset.lean
@@ -15,7 +15,7 @@ In this file we prove theorems about products and sums over a `Finset.powerset`.
 
 -/
 
-@[expose] public section
+public section
 
 variable {α β γ : Type*}
 

--- a/Mathlib/Algebra/BigOperators/Group/Finset/Preimage.lean
+++ b/Mathlib/Algebra/BigOperators/Group/Finset/Preimage.lean
@@ -12,7 +12,7 @@ public import Mathlib.Algebra.BigOperators.Group.Finset.Basic
 # Sums and products over preimages of finite sets.
 -/
 
-@[expose] public section
+public section
 
 assert_not_exists MonoidWithZero MulAction IsOrderedMonoid
 

--- a/Mathlib/Algebra/BigOperators/Group/Finset/Sigma.lean
+++ b/Mathlib/Algebra/BigOperators/Group/Finset/Sigma.lean
@@ -13,7 +13,7 @@ public import Mathlib.Algebra.BigOperators.Group.Finset.Basic
 
 -/
 
-@[expose] public section
+public section
 
 variable {ι κ α β γ : Type*}
 

--- a/Mathlib/Algebra/BigOperators/Group/List/Basic.lean
+++ b/Mathlib/Algebra/BigOperators/Group/List/Basic.lean
@@ -25,7 +25,7 @@ of elements of a list and `List.alternatingProd`, `List.alternatingSum`, their a
 counterparts.
 -/
 
-@[expose] public section
+public section
 assert_not_imported Mathlib.Algebra.Order.Group.Nat
 
 variable {ι α β M N P G : Type*}

--- a/Mathlib/Algebra/BigOperators/Group/List/Lemmas.lean
+++ b/Mathlib/Algebra/BigOperators/Group/List/Lemmas.lean
@@ -25,7 +25,7 @@ which calculate the product and sum of elements of a list
 and `List.alternatingProd`, `List.alternatingSum`, their alternating counterparts.
 -/
 
-@[expose] public section
+public section
 assert_not_imported Mathlib.Algebra.Order.Group.Nat
 
 variable {ι α β M N P G : Type*}

--- a/Mathlib/Algebra/BigOperators/GroupWithZero/Action.lean
+++ b/Mathlib/Algebra/BigOperators/GroupWithZero/Action.lean
@@ -24,7 +24,7 @@ This file contains results about two kinds of actions:
 Note that analogous lemmas for `Module`s like `Finset.sum_smul` appear in other files.
 -/
 
-@[expose] public section
+public section
 
 
 variable {M N γ : Type*}

--- a/Mathlib/Algebra/BigOperators/GroupWithZero/Finset.lean
+++ b/Mathlib/Algebra/BigOperators/GroupWithZero/Finset.lean
@@ -17,7 +17,7 @@ This file contains the results concerning the interaction of finset big operator
 zero.
 -/
 
-@[expose] public section
+public section
 
 open Function
 

--- a/Mathlib/Algebra/BigOperators/Intervals.lean
+++ b/Mathlib/Algebra/BigOperators/Intervals.lean
@@ -16,7 +16,7 @@ public import Mathlib.Data.Nat.Factorial.Basic
 We prove results about big operators over intervals.
 -/
 
-@[expose] public section
+public section
 
 open Nat
 

--- a/Mathlib/Algebra/BigOperators/ModEq.lean
+++ b/Mathlib/Algebra/BigOperators/ModEq.lean
@@ -18,7 +18,7 @@ and similarly for sums.
 We prove it for lists, multisets, and finsets, as well as for natural and integer numbers.
 -/
 
-@[expose] public section
+public section
 
 namespace Nat
 

--- a/Mathlib/Algebra/BigOperators/Module.lean
+++ b/Mathlib/Algebra/BigOperators/Module.lean
@@ -13,7 +13,7 @@ public import Mathlib.Tactic.Abel
 # Summation by parts
 -/
 
-@[expose] public section
+public section
 
 namespace Finset
 variable {R M : Type*} [Ring R] [AddCommGroup M] [Module R M] (f : ℕ → R) (g : ℕ → M) {m n : ℕ}

--- a/Mathlib/Algebra/BigOperators/NatAntidiagonal.lean
+++ b/Mathlib/Algebra/BigOperators/NatAntidiagonal.lean
@@ -14,7 +14,7 @@ public import Mathlib.Algebra.BigOperators.Group.Finset.Basic
 This file contains theorems relevant to big operators over `Finset.NatAntidiagonal`.
 -/
 
-@[expose] public section
+public section
 
 variable {M N : Type*} [CommMonoid M] [AddCommMonoid N]
 

--- a/Mathlib/Algebra/BigOperators/Option.lean
+++ b/Mathlib/Algebra/BigOperators/Option.lean
@@ -15,7 +15,7 @@ In this file we prove formulas for products and sums over `Finset.insertNone s` 
 `Finset.eraseNone s`.
 -/
 
-@[expose] public section
+public section
 
 open Function
 

--- a/Mathlib/Algebra/BigOperators/Ring/Finset.lean
+++ b/Mathlib/Algebra/BigOperators/Ring/Finset.lean
@@ -20,7 +20,7 @@ We prove results about big operators that involve some interaction between
 multiplicative and additive structures on the values being combined.
 -/
 
-@[expose] public section
+public section
 
 assert_not_exists Field
 

--- a/Mathlib/Algebra/BigOperators/Ring/List.lean
+++ b/Mathlib/Algebra/BigOperators/Ring/List.lean
@@ -18,7 +18,7 @@ public import Mathlib.Algebra.BigOperators.Group.List.Basic
 This file contains the results concerning the interaction of list big operators with rings.
 -/
 
-@[expose] public section
+public section
 
 open MulOpposite List
 

--- a/Mathlib/Algebra/BigOperators/Ring/Multiset.lean
+++ b/Mathlib/Algebra/BigOperators/Ring/Multiset.lean
@@ -12,7 +12,7 @@ public import Mathlib.Data.Multiset.Sections
 
 /-! # Lemmas about `Multiset.sum` and `Multiset.prod` requiring extra algebra imports -/
 
-@[expose] public section
+public section
 
 
 variable {ι M M₀ R : Type*}

--- a/Mathlib/Algebra/BigOperators/Ring/Nat.lean
+++ b/Mathlib/Algebra/BigOperators/Ring/Nat.lean
@@ -16,7 +16,7 @@ This file contains the results concerning the interaction of finset big operator
 numbers.
 -/
 
-@[expose] public section
+public section
 
 variable {ι : Type*}
 

--- a/Mathlib/Algebra/BigOperators/RingEquiv.lean
+++ b/Mathlib/Algebra/BigOperators/RingEquiv.lean
@@ -13,7 +13,7 @@ public import Mathlib.Algebra.BigOperators.Group.Finset.Defs
 # Results about mapping big operators across ring equivalences
 -/
 
-@[expose] public section
+public section
 
 
 namespace RingEquiv

--- a/Mathlib/Algebra/BigOperators/Sym.lean
+++ b/Mathlib/Algebra/BigOperators/Sym.lean
@@ -13,7 +13,7 @@ public import Mathlib.Algebra.BigOperators.Group.Finset.Basic
 # Lemmas on `Finset.sum` and `Finset.prod` involving `Finset.sym2` or `Finset.sym`.
 -/
 
-@[expose] public section
+public section
 
 namespace Finset
 

--- a/Mathlib/Algebra/BigOperators/WithTop.lean
+++ b/Mathlib/Algebra/BigOperators/WithTop.lean
@@ -14,7 +14,7 @@ public import Mathlib.Algebra.Order.Ring.WithTop
 This file proves results about finite sums over monoids extended by a bottom or top element.
 -/
 
-@[expose] public section
+public section
 
 open Finset
 

--- a/Mathlib/Algebra/Order/Algebra.lean
+++ b/Mathlib/Algebra/Order/Algebra.lean
@@ -35,7 +35,7 @@ ordered algebra
 `positivity` extension for `algebraMap`
 -/
 
-@[expose] public section
+public section
 
 variable {α β : Type*} [CommSemiring α] [PartialOrder α]
 

--- a/Mathlib/Algebra/Order/Archimedean/IndicatorCard.lean
+++ b/Mathlib/Algebra/Order/Archimedean/IndicatorCard.lean
@@ -21,7 +21,7 @@ limsups of sums of indicators.
 finite, indicator, limsup, tendsto
 -/
 
-@[expose] public section
+public section
 
 namespace Set
 

--- a/Mathlib/Algebra/Order/BigOperators/Expect.lean
+++ b/Mathlib/Algebra/Order/BigOperators/Expect.lean
@@ -16,7 +16,7 @@ public import Mathlib.Tactic.GCongr
 # Order properties of the average over a finset
 -/
 
-@[expose] public section
+public section
 
 open Function
 open Fintype (card)

--- a/Mathlib/Algebra/Order/BigOperators/Group/Finset.lean
+++ b/Mathlib/Algebra/Order/BigOperators/Group/Finset.lean
@@ -21,7 +21,7 @@ This file contains the results concerning the interaction of finset big operator
 groups/monoids.
 -/
 
-@[expose] public section
+public section
 
 assert_not_exists Ring
 

--- a/Mathlib/Algebra/Order/BigOperators/Group/List.lean
+++ b/Mathlib/Algebra/Order/BigOperators/Group/List.lean
@@ -16,7 +16,7 @@ This file contains the results concerning the interaction of list big operators 
 groups/monoids.
 -/
 
-@[expose] public section
+public section
 
 variable {ι α M N : Type*}
 

--- a/Mathlib/Algebra/Order/BigOperators/Group/LocallyFinite.lean
+++ b/Mathlib/Algebra/Order/BigOperators/Group/LocallyFinite.lean
@@ -17,7 +17,7 @@ public import Mathlib.Order.Interval.Finset.Nat
 This file proves lemmas about `∏ x ∈ Ixx a b, f x` and `∑ x ∈ Ixx a b, f x`.
 -/
 
-@[expose] public section
+public section
 
 open Order
 

--- a/Mathlib/Algebra/Order/BigOperators/Group/Multiset.lean
+++ b/Mathlib/Algebra/Order/BigOperators/Group/Multiset.lean
@@ -18,7 +18,7 @@ This file contains the results concerning the interaction of multiset big operat
 groups.
 -/
 
-@[expose] public section
+public section
 
 assert_not_exists MonoidWithZero
 

--- a/Mathlib/Algebra/Order/BigOperators/GroupWithZero/List.lean
+++ b/Mathlib/Algebra/Order/BigOperators/GroupWithZero/List.lean
@@ -15,7 +15,7 @@ This file contains the results concerning the interaction of list big operators 
 groups with zeros.
 -/
 
-@[expose] public section
+public section
 
 namespace List
 variable {R : Type*} [CommMonoidWithZero R] [PartialOrder R] [ZeroLEOneClass R] [PosMulMono R]

--- a/Mathlib/Algebra/Order/BigOperators/GroupWithZero/Multiset.lean
+++ b/Mathlib/Algebra/Order/BigOperators/GroupWithZero/Multiset.lean
@@ -15,7 +15,7 @@ This file contains the results concerning the interaction of multiset big operat
 groups with zeros.
 -/
 
-@[expose] public section
+public section
 
 namespace Multiset
 

--- a/Mathlib/Algebra/Order/BigOperators/Ring/Finset.lean
+++ b/Mathlib/Algebra/Order/BigOperators/Ring/Finset.lean
@@ -21,7 +21,7 @@ In particular, this file contains the standard form of the Cauchy-Schwarz inequa
 some of its immediate consequences.
 -/
 
-@[expose] public section
+public section
 
 variable {ι R S : Type*}
 

--- a/Mathlib/Algebra/Order/BigOperators/Ring/List.lean
+++ b/Mathlib/Algebra/Order/BigOperators/Ring/List.lean
@@ -13,7 +13,7 @@ public import Mathlib.Algebra.Order.Ring.Canonical
 This file contains the results concerning the interaction of list big operators with ordered rings.
 -/
 
-@[expose] public section
+public section
 
 variable {R : Type*}
 

--- a/Mathlib/Algebra/Order/BigOperators/Ring/Multiset.lean
+++ b/Mathlib/Algebra/Order/BigOperators/Ring/Multiset.lean
@@ -15,7 +15,7 @@ This file contains the results concerning the interaction of multiset big operat
 rings.
 -/
 
-@[expose] public section
+public section
 
 open Multiset
 

--- a/Mathlib/Algebra/Order/CauSeq/BigOperators.lean
+++ b/Mathlib/Algebra/Order/CauSeq/BigOperators.lean
@@ -16,7 +16,7 @@ public import Mathlib.Algebra.Order.CauSeq.Basic
 This file proves some more lemmas about basic Cauchy sequences that involve finite sums.
 -/
 
-@[expose] public section
+public section
 
 open Finset IsAbsoluteValue
 

--- a/Mathlib/Algebra/Order/Chebyshev.lean
+++ b/Mathlib/Algebra/Order/Chebyshev.lean
@@ -38,7 +38,7 @@ The case for `Monotone`/`Antitone` pairs of functions over a `LinearOrder` is no
 file because it is easily deducible from the `Monovary` API.
 -/
 
-@[expose] public section
+public section
 
 
 open Equiv Equiv.Perm Finset Function OrderDual

--- a/Mathlib/Algebra/Order/Field/GeomSum.lean
+++ b/Mathlib/Algebra/Order/Field/GeomSum.lean
@@ -15,7 +15,7 @@ This file upper- and lower-bounds the values of the geometric series $\sum_{i=0}
 $\sum_{i=0}^{n-1} x^i y^{n-1-i}$ and variants thereof.
 -/
 
-@[expose] public section
+public section
 
 variable {K : Type*}
 

--- a/Mathlib/Algebra/Order/Field/Pi.lean
+++ b/Mathlib/Algebra/Order/Field/Pi.lean
@@ -17,7 +17,7 @@ public import Mathlib.Data.Fintype.Basic
 We split this from `Algebra.Order.Field.Basic` to avoid importing the finiteness hierarchy there.
 -/
 
-@[expose] public section
+public section
 
 variable {α ι : Type*} [AddCommMonoid α] [LinearOrder α] [IsOrderedCancelAddMonoid α]
   [Nontrivial α] [DenselyOrdered α]

--- a/Mathlib/Algebra/Order/Field/Pointwise.lean
+++ b/Mathlib/Algebra/Order/Field/Pointwise.lean
@@ -18,7 +18,7 @@ public import Mathlib.Order.Interval.Set.OrderIso
 This file contains lemmas about the effect of pointwise operations on sets with an order structure.
 -/
 
-@[expose] public section
+public section
 
 open Function Set
 open scoped Pointwise

--- a/Mathlib/Algebra/Order/Field/Power.lean
+++ b/Mathlib/Algebra/Order/Field/Power.lean
@@ -15,7 +15,7 @@ public import Mathlib.Tactic.Positivity.Core
 # Lemmas about powers in ordered fields.
 -/
 
-@[expose] public section
+public section
 
 
 variable {α : Type*}

--- a/Mathlib/Algebra/Order/Field/Rat.lean
+++ b/Mathlib/Algebra/Order/Field/Rat.lean
@@ -23,6 +23,6 @@ See note [foundational algebra order theory].
 rat, rationals, field, ℚ, numerator, denominator, num, denom
 -/
 
-@[expose] public section
+public section
 
 deriving instance LinearOrderedCommGroupWithZero for NNRat

--- a/Mathlib/Algebra/Order/Floor/Ring.lean
+++ b/Mathlib/Algebra/Order/Floor/Ring.lean
@@ -27,7 +27,7 @@ fractional part operator.
 rounding, floor, ceil
 -/
 
-@[expose] public section
+public section
 
 assert_not_exists Finset
 

--- a/Mathlib/Algebra/Order/Floor/Semifield.lean
+++ b/Mathlib/Algebra/Order/Floor/Semifield.lean
@@ -19,7 +19,7 @@ This file contains basic results on the natural-valued floor and ceiling functio
 rounding, floor, ceil
 -/
 
-@[expose] public section
+public section
 
 assert_not_exists Finset
 

--- a/Mathlib/Algebra/Order/Floor/Semiring.lean
+++ b/Mathlib/Algebra/Order/Floor/Semiring.lean
@@ -22,7 +22,7 @@ This file contains basic results on the natural-valued floor and ceiling functio
 rounding, floor, ceil
 -/
 
-@[expose] public section
+public section
 
 assert_not_exists Finset
 

--- a/Mathlib/Algebra/Order/Group/Abs.lean
+++ b/Mathlib/Algebra/Order/Group/Abs.lean
@@ -21,7 +21,7 @@ negation. This generalizes the usual absolute value on real numbers (`|x| = max 
 - `|a|ₘ`: The *absolute value* of an element `a` of a multiplicative lattice ordered group
 -/
 
-@[expose] public section
+public section
 
 open Function
 

--- a/Mathlib/Algebra/Order/Group/Action.lean
+++ b/Mathlib/Algebra/Order/Group/Action.lean
@@ -17,7 +17,7 @@ When working with group actions rather than modules, we drop the `0 < c` conditi
 Notably these are relevant for pointwise actions on set-like objects.
 -/
 
-@[expose] public section
+public section
 
 variable {ι : Sort*} {M α : Type*}
 

--- a/Mathlib/Algebra/Order/Group/Basic.lean
+++ b/Mathlib/Algebra/Order/Group/Basic.lean
@@ -13,7 +13,7 @@ public import Mathlib.Algebra.Order.Monoid.Unbundled.Pow
 # Lemmas about the interaction of power operations with order
 -/
 
-@[expose] public section
+public section
 
 -- We should need only a minimal development of sets in order to get here.
 assert_not_exists Set.Subsingleton

--- a/Mathlib/Algebra/Order/Group/Bounds.lean
+++ b/Mathlib/Algebra/Order/Group/Bounds.lean
@@ -13,7 +13,7 @@ public import Mathlib.Algebra.Order.Group.Unbundled.Basic
 # Least upper bound and the greatest lower bound in linear ordered additive commutative groups
 -/
 
-@[expose] public section
+public section
 
 section LinearOrderedAddCommGroup
 

--- a/Mathlib/Algebra/Order/Group/CompleteLattice.lean
+++ b/Mathlib/Algebra/Order/Group/CompleteLattice.lean
@@ -12,7 +12,7 @@ public import Mathlib.Order.ConditionallyCompleteLattice.Indexed
 # Distributivity of group operations over supremum/infimum
 -/
 
-@[expose] public section
+public section
 
 open Function Set
 

--- a/Mathlib/Algebra/Order/Group/DenselyOrdered.lean
+++ b/Mathlib/Algebra/Order/Group/DenselyOrdered.lean
@@ -16,7 +16,7 @@ public import Mathlib.Algebra.Order.Monoid.Unbundled.Pow
 # Lemmas about densely linearly ordered groups.
 -/
 
-@[expose] public section
+public section
 
 variable {α : Type*}
 

--- a/Mathlib/Algebra/Order/Group/Finset.lean
+++ b/Mathlib/Algebra/Order/Group/Finset.lean
@@ -16,7 +16,7 @@ public import Mathlib.Data.Finset.Lattice.Prod
 # `Finset.sup` in a group
 -/
 
-@[expose] public section
+public section
 
 open scoped Finset
 

--- a/Mathlib/Algebra/Order/Group/Indicator.lean
+++ b/Mathlib/Algebra/Order/Group/Indicator.lean
@@ -17,7 +17,7 @@ public import Mathlib.Algebra.Order.Monoid.Canonical.Defs
 This file relates the support of a function to order constructions.
 -/
 
-@[expose] public section
+public section
 
 assert_not_exists MonoidWithZero
 

--- a/Mathlib/Algebra/Order/Group/Int/Sum.lean
+++ b/Mathlib/Algebra/Order/Group/Int/Sum.lean
@@ -18,7 +18,7 @@ a sharper upper bound than `#s * c`, because the elements are distinct.
 This file provides these sharp bounds, both in the upper-bounded and analogous lower-bounded cases.
 -/
 
-@[expose] public section
+public section
 
 
 namespace Finset

--- a/Mathlib/Algebra/Order/Group/MinMax.lean
+++ b/Mathlib/Algebra/Order/Group/MinMax.lean
@@ -12,7 +12,7 @@ public import Mathlib.Algebra.Order.Monoid.Unbundled.MinMax
 # `min` and `max` in linearly ordered groups.
 -/
 
-@[expose] public section
+public section
 
 
 section

--- a/Mathlib/Algebra/Order/Group/PartialSups.lean
+++ b/Mathlib/Algebra/Order/Group/PartialSups.lean
@@ -12,7 +12,7 @@ public import Mathlib.Order.PartialSups
 # Results about `partialSups` of functions taking values in a `Group`
 -/
 
-@[expose] public section
+public section
 
 variable {α ι : Type*}
 

--- a/Mathlib/Algebra/Order/Group/Pointwise/Bounds.lean
+++ b/Mathlib/Algebra/Order/Group/Pointwise/Bounds.lean
@@ -18,7 +18,7 @@ In this file we prove a few facts like “`-s` is bounded above iff `s` is bound
 (`bddAbove_neg`).
 -/
 
-@[expose] public section
+public section
 
 open Function Set
 open scoped Pointwise

--- a/Mathlib/Algebra/Order/Group/Pointwise/CompleteLattice.lean
+++ b/Mathlib/Algebra/Order/Group/Pointwise/CompleteLattice.lean
@@ -19,7 +19,7 @@ In this file we prove a few facts like “The infimum of `-s` is `-` the supremu
 `CovariantClass` is currently not polymorphic enough to state it.
 -/
 
-@[expose] public section
+public section
 
 open Function Set
 open scoped Pointwise

--- a/Mathlib/Algebra/Order/Group/Pointwise/Interval.lean
+++ b/Mathlib/Algebra/Order/Group/Pointwise/Interval.lean
@@ -23,7 +23,7 @@ lemmas about preimages and images of all intervals. We also prove a few lemmas a
 `x ↦ a * x`, `x ↦ x * a` and `x ↦ x⁻¹`.
 -/
 
-@[expose] public section
+public section
 
 
 open Interval Pointwise

--- a/Mathlib/Algebra/Order/Group/Unbundled/Int.lean
+++ b/Mathlib/Algebra/Order/Group/Unbundled/Int.lean
@@ -24,7 +24,7 @@ See note [foundational algebra order theory].
   induction on numbers less than `b`.
 -/
 
-@[expose] public section
+public section
 
 -- We should need only a minimal development of sets in order to get here.
 assert_not_exists Set.Subsingleton Ring

--- a/Mathlib/Algebra/Order/GroupWithZero/Bounds.lean
+++ b/Mathlib/Algebra/Order/GroupWithZero/Bounds.lean
@@ -13,7 +13,7 @@ public import Mathlib.Order.Bounds.Image
 # Lemmas about `BddAbove`
 -/
 
-@[expose] public section
+public section
 
 open Set
 

--- a/Mathlib/Algebra/Order/GroupWithZero/Finset.lean
+++ b/Mathlib/Algebra/Order/GroupWithZero/Finset.lean
@@ -13,7 +13,7 @@ public import Mathlib.Data.Finset.Lattice.Fold
 # `Finset.sup` in a group with zero
 -/
 
-@[expose] public section
+public section
 
 namespace Finset
 variable {ι M₀ G₀ : Type*}

--- a/Mathlib/Algebra/Order/Interval/Finset/Basic.lean
+++ b/Mathlib/Algebra/Order/Interval/Finset/Basic.lean
@@ -15,7 +15,7 @@ public import Mathlib.Order.Interval.Finset.Defs
 This file provides results about the interaction of algebra with `Finset.Ixx`.
 -/
 
-@[expose] public section
+public section
 
 open Function OrderDual
 

--- a/Mathlib/Algebra/Order/Interval/Finset/SuccPred.lean
+++ b/Mathlib/Algebra/Order/Interval/Finset/SuccPred.lean
@@ -26,7 +26,7 @@ Please keep in sync with:
 Copy over `insert` lemmas from `Mathlib/Order/Interval/Finset/Nat.lean`.
 -/
 
-@[expose] public section
+public section
 
 open Function Order OrderDual
 

--- a/Mathlib/Algebra/Order/Interval/Multiset.lean
+++ b/Mathlib/Algebra/Order/Interval/Multiset.lean
@@ -14,7 +14,7 @@ public import Mathlib.Order.Interval.Multiset
 This file provides results about the interaction of algebra with `Multiset.Ixx`.
 -/
 
-@[expose] public section
+public section
 
 variable {α : Type*}
 

--- a/Mathlib/Algebra/Order/Interval/Set/Group.lean
+++ b/Mathlib/Algebra/Order/Interval/Set/Group.lean
@@ -14,7 +14,7 @@ public import Mathlib.Logic.Pairwise
 
 /-! ### Lemmas about arithmetic operations and intervals. -/
 
-@[expose] public section
+public section
 
 
 variable {α : Type*}

--- a/Mathlib/Algebra/Order/Interval/Set/Monoid.lean
+++ b/Mathlib/Algebra/Order/Interval/Set/Monoid.lean
@@ -20,7 +20,7 @@ The lemmas in this file state that addition maps intervals bijectively. The type
 `OrderedAddCommGroup`, but also to `ℕ` and `ℝ≥0`, which are not groups.
 -/
 
-@[expose] public section
+public section
 
 
 namespace Set

--- a/Mathlib/Algebra/Order/Interval/Set/SuccPred.lean
+++ b/Mathlib/Algebra/Order/Interval/Set/SuccPred.lean
@@ -26,7 +26,7 @@ Please keep in sync with:
 Copy over `insert` lemmas from `Mathlib/Order/Interval/Finset/Nat.lean`.
 -/
 
-@[expose] public section
+public section
 
 open Function Order OrderDual
 

--- a/Mathlib/Algebra/Order/Invertible.lean
+++ b/Mathlib/Algebra/Order/Invertible.lean
@@ -13,7 +13,7 @@ public import Mathlib.Data.Nat.Cast.Order.Ring
 # Lemmas about `invOf` in ordered (semi)rings.
 -/
 
-@[expose] public section
+public section
 
 variable {R : Type*} [Semiring R] [LinearOrder R] [IsStrictOrderedRing R] {a : R}
 

--- a/Mathlib/Algebra/Order/Module/Algebra.lean
+++ b/Mathlib/Algebra/Order/Module/Algebra.lean
@@ -9,6 +9,6 @@ public import Mathlib.Algebra.Order.Algebra
 
 deprecated_module (since := "2025-12-16")
 
-@[expose] public section
+public section
 
 @[deprecated (since := "2025-12-16")] alias algebraMap_monotone := algebraMap_mono

--- a/Mathlib/Algebra/Order/Module/Basic.lean
+++ b/Mathlib/Algebra/Order/Module/Basic.lean
@@ -14,7 +14,7 @@ public import Mathlib.Algebra.Order.Module.Defs
 # Further lemmas about monotonicity of scalar multiplication
 -/
 
-@[expose] public section
+public section
 
 variable {𝕜 R M : Type*}
 

--- a/Mathlib/Algebra/Order/Module/Pointwise.lean
+++ b/Mathlib/Algebra/Order/Module/Pointwise.lean
@@ -16,7 +16,7 @@ public import Mathlib.Order.GaloisConnection.Basic
 This file proves order properties of pointwise operations of sets.
 -/
 
-@[expose] public section
+public section
 
 open scoped Pointwise
 

--- a/Mathlib/Algebra/Order/Monoid/Canonical/Basic.lean
+++ b/Mathlib/Algebra/Order/Monoid/Canonical/Basic.lean
@@ -12,7 +12,7 @@ public import Mathlib.Data.Finset.Lattice.Fold
 # Extra lemmas about canonically ordered monoids
 -/
 
-@[expose] public section
+public section
 
 namespace Finset
 variable {ι α : Type*} [AddCommMonoid α] [LinearOrder α] [OrderBot α] [CanonicallyOrderedAdd α]

--- a/Mathlib/Algebra/Order/Monoid/Unbundled/MinMax.lean
+++ b/Mathlib/Algebra/Order/Monoid/Unbundled/MinMax.lean
@@ -11,7 +11,7 @@ public import Mathlib.Algebra.Order.Monoid.Unbundled.Basic
 # Lemmas about `min` and `max` in an ordered monoid.
 -/
 
-@[expose] public section
+public section
 
 
 open Function

--- a/Mathlib/Algebra/Order/Monoid/Unbundled/Units.lean
+++ b/Mathlib/Algebra/Order/Monoid/Unbundled/Units.lean
@@ -12,7 +12,7 @@ public import Mathlib.Algebra.Order.Monoid.Unbundled.Basic
 # Lemmas for units in an ordered monoid
 -/
 
-@[expose] public section
+public section
 
 variable {M : Type*} [Monoid M] [LE M]
 

--- a/Mathlib/Algebra/Order/Monovary.lean
+++ b/Mathlib/Algebra/Order/Monovary.lean
@@ -22,7 +22,7 @@ of functions.
 `Mathlib.Algebra.Order.Rearrangement` for the n-ary rearrangement inequality
 -/
 
-@[expose] public section
+public section
 
 variable {ι α β : Type*}
 

--- a/Mathlib/Algebra/Order/Rearrangement.lean
+++ b/Mathlib/Algebra/Order/Rearrangement.lean
@@ -48,7 +48,7 @@ Add equality cases for when the permute function is injective. This comes from t
 If `Monovary f g`, `Injective g` and `σ` is a permutation, then `Monovary f (g ∘ σ) ↔ σ = 1`.
 -/
 
-@[expose] public section
+public section
 
 
 open Equiv Equiv.Perm Finset Function OrderDual

--- a/Mathlib/Algebra/Order/Ring/Finset.lean
+++ b/Mathlib/Algebra/Order/Ring/Finset.lean
@@ -13,7 +13,7 @@ public import Mathlib.Data.Nat.Cast.Order.Ring
 # `Finset.sup` and ring operations
 -/
 
-@[expose] public section
+public section
 
 open Finset
 

--- a/Mathlib/Algebra/Order/Ring/GeomSum.lean
+++ b/Mathlib/Algebra/Order/Ring/GeomSum.lean
@@ -17,7 +17,7 @@ $\sum_{i=0}^{n-1} x^i y^{n-1-i}$ and variants thereof. We also provide some boun
 "geometric" sum of `a/b^i` where `a b : ℕ`.
 -/
 
-@[expose] public section
+public section
 
 assert_not_exists Field
 

--- a/Mathlib/Algebra/Order/Ring/InjSurj.lean
+++ b/Mathlib/Algebra/Order/Ring/InjSurj.lean
@@ -12,7 +12,7 @@ public import Mathlib.Algebra.Order.Ring.Defs
 # Pulling back ordered rings along injective maps
 -/
 
-@[expose] public section
+public section
 
 variable {R S : Type*}
 

--- a/Mathlib/Algebra/Order/Ring/Interval.lean
+++ b/Mathlib/Algebra/Order/Ring/Interval.lean
@@ -17,7 +17,7 @@ functions), but for now these are the ones that have found utility in practice (
 about `Real.Angle`).
 -/
 
-@[expose] public section
+public section
 
 variable {R : Type*} [Ring R] [LinearOrder R] [IsStrictOrderedRing R]
 

--- a/Mathlib/Algebra/Order/Ring/IsNonarchimedean.lean
+++ b/Mathlib/Algebra/Order/Ring/IsNonarchimedean.lean
@@ -16,7 +16,7 @@ A function `f : α → R` is nonarchimedean if it satisfies the strong triangle 
 nonarchimedean functions.
 -/
 
-@[expose] public section
+public section
 
 namespace IsNonarchimedean
 

--- a/Mathlib/Algebra/Order/Ring/Pow.lean
+++ b/Mathlib/Algebra/Order/Ring/Pow.lean
@@ -19,7 +19,7 @@ which can be regarded as Bernoulli's inequality for `b / a` multiplied by `a ^ n
 Also, we prove versions for different typeclass assumptions on the (semi)ring.
 -/
 
-@[expose] public section
+public section
 
 variable {R : Type*}
 

--- a/Mathlib/Algebra/Order/Ring/Unbundled/Basic.lean
+++ b/Mathlib/Algebra/Order/Ring/Unbundled/Basic.lean
@@ -114,7 +114,7 @@ TODO: the mixin assumptions can be relaxed in most cases
 
 -/
 
-@[expose] public section
+public section
 
 assert_not_exists IsOrderedMonoid MonoidHom
 

--- a/Mathlib/Algebra/Order/Ring/Units.lean
+++ b/Mathlib/Algebra/Order/Ring/Units.lean
@@ -10,7 +10,7 @@ public import Mathlib.GroupTheory.Index
 
 /-! # Lemmas about units of ordered rings -/
 
-@[expose] public section
+public section
 
 lemma Units.index_posSubgroup (R : Type*) [Ring R] [LinearOrder R] [IsStrictOrderedRing R] :
     (posSubgroup R).index = 2 := by

--- a/Mathlib/Algebra/Order/Star/Conjneg.lean
+++ b/Mathlib/Algebra/Order/Star/Conjneg.lean
@@ -13,7 +13,7 @@ public import Mathlib.Algebra.Star.Conjneg
 # Order properties of conjugation-negation
 -/
 
-@[expose] public section
+public section
 
 open scoped ComplexConjugate
 

--- a/Mathlib/Algebra/Order/Sub/Unbundled/Basic.lean
+++ b/Mathlib/Algebra/Order/Sub/Unbundled/Basic.lean
@@ -12,7 +12,7 @@ public import Mathlib.Algebra.Order.Monoid.Unbundled.ExistsOfLE
 # Lemmas about subtraction in an unbundled canonically ordered monoids
 -/
 
-@[expose] public section
+public section
 
 -- These are about *unbundled* canonically ordered monoids
 assert_not_exists IsOrderedMonoid

--- a/Mathlib/Algebra/Order/Sub/Unbundled/Hom.lean
+++ b/Mathlib/Algebra/Order/Sub/Unbundled/Hom.lean
@@ -13,7 +13,7 @@ public import Mathlib.Order.Hom.Basic
 # Lemmas about subtraction in unbundled canonically ordered monoids
 -/
 
-@[expose] public section
+public section
 
 
 variable {α β : Type*}

--- a/Mathlib/Algebra/Order/SuccPred/PartialSups.lean
+++ b/Mathlib/Algebra/Order/SuccPred/PartialSups.lean
@@ -16,7 +16,7 @@ Basic results concerning `PartialSups` which follow with minimal assumptions bey
 the `PartialSup` is defined over a `SuccAddOrder`.
 -/
 
-@[expose] public section
+public section
 
 open Finset
 

--- a/Mathlib/Algebra/Order/SuccPred/WithBot.lean
+++ b/Mathlib/Algebra/Order/SuccPred/WithBot.lean
@@ -13,7 +13,7 @@ public import Mathlib.Order.SuccPred.WithBot
 # Algebraic properties of the successor function on `WithBot`
 -/
 
-@[expose] public section
+public section
 
 namespace WithBot
 variable {α : Type*} [Preorder α] [OrderBot α] [AddMonoidWithOne α] [SuccAddOrder α]

--- a/Mathlib/Algebra/Order/Sum.lean
+++ b/Mathlib/Algebra/Order/Sum.lean
@@ -14,7 +14,7 @@ public import Mathlib.Order.Basic
 This file provides basic API for part-wise comparison of `Sum.elim` vectors against `0` or `1`.
 -/
 
-@[expose] public section
+public section
 
 namespace Sum
 


### PR DESCRIPTION
This PR removes `@[expose]` from `public section` declarations in 95 files under `Mathlib/Algebra/Order/` and `Mathlib/Algebra/BigOperators/`.

Part of a larger cleanup effort (~1400 files identified).

🤖 Prepared with Claude Code