### PR TITLE
[Merged by Bors] - chore(Algebra/Group): remove unnecessary @[expose] from public sections

### DIFF
--- a/Mathlib/Algebra/Group/Action/Pointwise/Set/Finite.lean
+++ b/Mathlib/Algebra/Group/Action/Pointwise/Set/Finite.lean
@@ -11,7 +11,7 @@ public import Mathlib.Data.Set.Finite.Basic
 
 /-! # Finiteness lemmas for pointwise operations on sets -/
 
-@[expose] public section
+public section
 
 open scoped Pointwise
 

--- a/Mathlib/Algebra/Group/Commute/Basic.lean
+++ b/Mathlib/Algebra/Group/Commute/Basic.lean
@@ -13,7 +13,7 @@ public import Mathlib.Algebra.Group.Semiconj.Basic
 
 -/
 
-@[expose] public section
+public section
 
 assert_not_exists MonoidWithZero DenselyOrdered
 

--- a/Mathlib/Algebra/Group/Commute/Hom.lean
+++ b/Mathlib/Algebra/Group/Commute/Hom.lean
@@ -13,7 +13,7 @@ public import Mathlib.Algebra.Group.Hom.Defs
 # Multiplicative homomorphisms respect semiconjugation and commutation.
 -/
 
-@[expose] public section
+public section
 
 assert_not_exists MonoidWithZero DenselyOrdered
 

--- a/Mathlib/Algebra/Group/Ext.lean
+++ b/Mathlib/Algebra/Group/Ext.lean
@@ -27,7 +27,7 @@ former uses `HMul.hMul` which is the canonical spelling.
 monoid, group, extensionality
 -/
 
-@[expose] public section
+public section
 
 assert_not_exists MonoidWithZero DenselyOrdered
 

--- a/Mathlib/Algebra/Group/Fin/Tuple.lean
+++ b/Mathlib/Algebra/Group/Fin/Tuple.lean
@@ -13,7 +13,7 @@ public import Mathlib.Data.Fin.VecNotation
 # Algebraic properties of tuples
 -/
 
-@[expose] public section
+public section
 
 namespace Fin
 variable {n : ℕ} {α : Fin (n + 1) → Type*}

--- a/Mathlib/Algebra/Group/Int/TypeTags.lean
+++ b/Mathlib/Algebra/Group/Int/TypeTags.lean
@@ -12,7 +12,7 @@ public import Mathlib.Algebra.Group.TypeTags.Basic
 # Lemmas about `Multiplicative ℤ`.
 -/
 
-@[expose] public section
+public section
 
 
 open Nat

--- a/Mathlib/Algebra/Group/Int/Units.lean
+++ b/Mathlib/Algebra/Group/Int/Units.lean
@@ -14,7 +14,7 @@ public import Mathlib.Algebra.Group.Nat.Units
 # Units in the integers
 -/
 
-@[expose] public section
+public section
 
 
 open Nat

--- a/Mathlib/Algebra/Group/Irreducible/Lemmas.lean
+++ b/Mathlib/Algebra/Group/Irreducible/Lemmas.lean
@@ -14,7 +14,7 @@ public import Mathlib.Algebra.Group.Units.Equiv
 # More lemmas about irreducible elements
 -/
 
-@[expose] public section
+public section
 
 assert_not_exists MonoidWithZero IsOrderedMonoid Multiset
 

--- a/Mathlib/Algebra/Group/Nat/Range.lean
+++ b/Mathlib/Algebra/Group/Nat/Range.lean
@@ -13,7 +13,7 @@ public import Mathlib.Data.Finset.Image
 # `Finset.range` and addition of natural numbers
 -/
 
-@[expose] public section
+public section
 assert_not_exists MonoidWithZero MulAction IsOrderedMonoid
 
 variable {α β γ : Type*}

--- a/Mathlib/Algebra/Group/Nat/TypeTags.lean
+++ b/Mathlib/Algebra/Group/Nat/TypeTags.lean
@@ -12,7 +12,7 @@ public import Mathlib.Algebra.Group.TypeTags.Basic
 # Lemmas about `Multiplicative ℕ`
 -/
 
-@[expose] public section
+public section
 
 assert_not_exists MonoidWithZero DenselyOrdered
 

--- a/Mathlib/Algebra/Group/Pointwise/Finset/BigOperators.lean
+++ b/Mathlib/Algebra/Group/Pointwise/Finset/BigOperators.lean
@@ -26,7 +26,7 @@ finset multiplication, finset addition, pointwise addition, pointwise multiplica
 pointwise subtraction
 -/
 
-@[expose] public section
+public section
 
 open scoped Pointwise
 

--- a/Mathlib/Algebra/Group/Pointwise/Finset/Density.lean
+++ b/Mathlib/Algebra/Group/Pointwise/Finset/Density.lean
@@ -14,7 +14,7 @@ public import Mathlib.Data.Finset.Density
 # Theorems about the density of pointwise operations on finsets.
 -/
 
-@[expose] public section
+public section
 
 open scoped Pointwise
 

--- a/Mathlib/Algebra/Group/Pointwise/Finset/Interval.lean
+++ b/Mathlib/Algebra/Group/Pointwise/Finset/Interval.lean
@@ -14,7 +14,7 @@ public import Mathlib.Algebra.Group.Pointwise.Finset.Basic
 This should be kept in sync with `Mathlib/Data/Set/Pointwise/Interval.lean`.
 -/
 
-@[expose] public section
+public section
 
 variable {α : Type*}
 

--- a/Mathlib/Algebra/Group/Pointwise/Set/BigOperators.lean
+++ b/Mathlib/Algebra/Group/Pointwise/Set/BigOperators.lean
@@ -13,7 +13,7 @@ public import Mathlib.Data.Fintype.Card
 # Results about pointwise operations on sets and big operators.
 -/
 
-@[expose] public section
+public section
 
 
 namespace Set

--- a/Mathlib/Algebra/Group/Pointwise/Set/Card.lean
+++ b/Mathlib/Algebra/Group/Pointwise/Set/Card.lean
@@ -13,7 +13,7 @@ public import Mathlib.Data.Set.Card
 # Cardinalities of pointwise operations on sets
 -/
 
-@[expose] public section
+public section
 
 assert_not_exists Field
 

--- a/Mathlib/Algebra/Group/Pointwise/Set/Lattice.lean
+++ b/Mathlib/Algebra/Group/Pointwise/Set/Lattice.lean
@@ -21,7 +21,7 @@ set multiplication, set addition, pointwise addition, pointwise multiplication,
 pointwise subtraction
 -/
 
-@[expose] public section
+public section
 
 assert_not_exists MulAction MonoidWithZero
 

--- a/Mathlib/Algebra/Group/Pointwise/Set/ListOfFn.lean
+++ b/Mathlib/Algebra/Group/Pointwise/Set/ListOfFn.lean
@@ -15,7 +15,7 @@ public import Mathlib.Algebra.Group.Pointwise.Set.Basic
 This file proves some lemmas about pointwise algebraic operations with lists of sets.
 -/
 
-@[expose] public section
+public section
 
 namespace Set
 

--- a/Mathlib/Algebra/Group/Semiconj/Basic.lean
+++ b/Mathlib/Algebra/Group/Semiconj/Basic.lean
@@ -13,7 +13,7 @@ public import Mathlib.Algebra.Group.Basic
 
 -/
 
-@[expose] public section
+public section
 
 assert_not_exists MonoidWithZero DenselyOrdered
 

--- a/Mathlib/Algebra/Group/Semiconj/Units.lean
+++ b/Mathlib/Algebra/Group/Semiconj/Units.lean
@@ -28,7 +28,7 @@ This file provides only basic operations (`mul_left`, `mul_right`, `inv_right` e
 operations (`pow_right`, field inverse etc) are in the files that define corresponding notions.
 -/
 
-@[expose] public section
+public section
 
 assert_not_exists MonoidWithZero DenselyOrdered
 

--- a/Mathlib/Algebra/Group/Subgroup/Finsupp.lean
+++ b/Mathlib/Algebra/Group/Subgroup/Finsupp.lean
@@ -10,7 +10,7 @@ public import Mathlib.Algebra.Group.Subgroup.Lattice
 
 /-! # Connection between `Subgroup.closure` and `Finsupp.prod` -/
 
-@[expose] public section
+public section
 
 assert_not_exists Field
 

--- a/Mathlib/Algebra/Group/Submonoid/BigOperators.lean
+++ b/Mathlib/Algebra/Group/Submonoid/BigOperators.lean
@@ -24,7 +24,7 @@ In this file we prove various facts about membership in a submonoid:
 submonoid, submonoids
 -/
 
-@[expose] public section
+public section
 
 -- We don't need ordered structures to establish basic membership facts for submonoids
 assert_not_exists IsOrderedRing

--- a/Mathlib/Algebra/Group/Submonoid/Finite.lean
+++ b/Mathlib/Algebra/Group/Submonoid/Finite.lean
@@ -14,7 +14,7 @@ public import Mathlib.Data.Fintype.Basic
 This file provides some results on multiplicative and additive submonoids in the finite context.
 -/
 
-@[expose] public section
+public section
 
 namespace Submonoid
 

--- a/Mathlib/Algebra/Group/Submonoid/Finsupp.lean
+++ b/Mathlib/Algebra/Group/Submonoid/Finsupp.lean
@@ -9,7 +9,7 @@ public import Mathlib.Algebra.BigOperators.Finsupp.Basic
 
 /-! # Connection between `Submonoid.closure` and `Finsupp.prod` -/
 
-@[expose] public section
+public section
 
 assert_not_exists Field
 

--- a/Mathlib/Algebra/Group/Subsemigroup/Membership.lean
+++ b/Mathlib/Algebra/Group/Subsemigroup/Membership.lean
@@ -29,7 +29,7 @@ stub and only provides rudimentary support.
 subsemigroup
 -/
 
-@[expose] public section
+public section
 
 assert_not_exists MonoidWithZero
 

--- a/Mathlib/Algebra/Group/Support.lean
+++ b/Mathlib/Algebra/Group/Support.lean
@@ -15,7 +15,7 @@ In this file we prove basic properties of `Function.support f = {x | f x ≠ 0}`
 `Function.mulSupport f = {x | f x ≠ 1}`.
 -/
 
-@[expose] public section
+public section
 
 assert_not_exists CompleteLattice MonoidWithZero
 

--- a/Mathlib/Algebra/GroupWithZero/Center.lean
+++ b/Mathlib/Algebra/GroupWithZero/Center.lean
@@ -12,7 +12,7 @@ public import Mathlib.Algebra.GroupWithZero.Units.Basic
 # Center of a group with zero
 -/
 
-@[expose] public section
+public section
 
 assert_not_exists RelIso Finset Ring Subsemigroup
 

--- a/Mathlib/Algebra/GroupWithZero/Commute.lean
+++ b/Mathlib/Algebra/GroupWithZero/Commute.lean
@@ -14,7 +14,7 @@ public import Mathlib.Tactic.Nontriviality
 
 -/
 
-@[expose] public section
+public section
 
 assert_not_exists DenselyOrdered Ring
 

--- a/Mathlib/Algebra/GroupWithZero/Conj.lean
+++ b/Mathlib/Algebra/GroupWithZero/Conj.lean
@@ -12,7 +12,7 @@ public import Mathlib.Algebra.GroupWithZero.Units.Basic
 # Conjugacy in a group with zero
 -/
 
-@[expose] public section
+public section
 
 assert_not_exists Multiset Ring
 -- TODO

--- a/Mathlib/Algebra/GroupWithZero/Indicator.lean
+++ b/Mathlib/Algebra/GroupWithZero/Indicator.lean
@@ -14,7 +14,7 @@ public import Mathlib.Algebra.Notation.Indicator
 # Indicator functions and support of a function in groups with zero
 -/
 
-@[expose] public section
+public section
 
 assert_not_exists Ring
 

--- a/Mathlib/Algebra/GroupWithZero/Pointwise/Finset.lean
+++ b/Mathlib/Algebra/GroupWithZero/Pointwise/Finset.lean
@@ -14,7 +14,7 @@ public import Mathlib.Algebra.Group.Pointwise.Finset.Basic
 This file proves properties of pointwise operations of finsets in a group with zero.
 -/
 
-@[expose] public section
+public section
 
 assert_not_exists MulAction Ring
 

--- a/Mathlib/Algebra/GroupWithZero/Pointwise/Set/Basic.lean
+++ b/Mathlib/Algebra/GroupWithZero/Pointwise/Set/Basic.lean
@@ -19,7 +19,7 @@ set multiplication, set addition, pointwise addition, pointwise multiplication,
 pointwise subtraction
 -/
 
-@[expose] public section
+public section
 
 assert_not_exists MulAction IsOrderedMonoid Ring
 

--- a/Mathlib/Algebra/GroupWithZero/Pointwise/Set/Card.lean
+++ b/Mathlib/Algebra/GroupWithZero/Pointwise/Set/Card.lean
@@ -13,7 +13,7 @@ public import Mathlib.SetTheory.Cardinal.Finite
 # Cardinality of sets under pointwise group with zero operations
 -/
 
-@[expose] public section
+public section
 
 assert_not_exists Field
 

--- a/Mathlib/Algebra/GroupWithZero/Regular.lean
+++ b/Mathlib/Algebra/GroupWithZero/Regular.lean
@@ -12,7 +12,7 @@ public import Mathlib.Tactic.Push
 # Results about `IsRegular` and `0`
 -/
 
-@[expose] public section
+public section
 
 variable {R}
 

--- a/Mathlib/Algebra/GroupWithZero/Semiconj.lean
+++ b/Mathlib/Algebra/GroupWithZero/Semiconj.lean
@@ -13,7 +13,7 @@ public import Mathlib.Algebra.Group.Semiconj.Units
 
 -/
 
-@[expose] public section
+public section
 
 assert_not_exists DenselyOrdered Ring
 

--- a/Mathlib/Algebra/Homology/DerivedCategory/Ext/EnoughInjectives.lean
+++ b/Mathlib/Algebra/Homology/DerivedCategory/Ext/EnoughInjectives.lean
@@ -25,7 +25,7 @@ Note: this file dualizes the results in `HasEnoughProjectives.lean`.
 
 -/
 
-@[expose] public section
+public section
 
 universe w v u
 

--- a/Mathlib/Algebra/Homology/DerivedCategory/Ext/EnoughProjectives.lean
+++ b/Mathlib/Algebra/Homology/DerivedCategory/Ext/EnoughProjectives.lean
@@ -23,7 +23,7 @@ So we must be very selective regarding `HasExt` instances.
 
 -/
 
-@[expose] public section
+public section
 
 universe w v u
 

--- a/Mathlib/Algebra/Homology/HomologicalComplexAbelian.lean
+++ b/Mathlib/Algebra/Homology/HomologicalComplexAbelian.lean
@@ -19,7 +19,7 @@ is exact (resp. short exact) iff degreewise it is so.
 
 -/
 
-@[expose] public section
+public section
 
 open CategoryTheory Category Limits
 

--- a/Mathlib/Algebra/Homology/Refinements.lean
+++ b/Mathlib/Algebra/Homology/Refinements.lean
@@ -18,7 +18,7 @@ in the file `Mathlib/CategoryTheory/Abelian/Refinements.lean`.
 
 -/
 
-@[expose] public section
+public section
 
 open CategoryTheory
 

--- a/Mathlib/Algebra/Homology/ShortComplex/ExactFunctor.lean
+++ b/Mathlib/Algebra/Homology/ShortComplex/ExactFunctor.lean
@@ -53,7 +53,7 @@ If we further assume that `C` and `D` are abelian categories, then we have:
 
 -/
 
-@[expose] public section
+public section
 
 namespace CategoryTheory
 

--- a/Mathlib/Algebra/Homology/ShortComplex/Retract.lean
+++ b/Mathlib/Algebra/Homology/ShortComplex/Retract.lean
@@ -13,7 +13,7 @@ public import Mathlib.CategoryTheory.MorphismProperty.Retract
 
 -/
 
-@[expose] public section
+public section
 
 namespace CategoryTheory
 

--- a/Mathlib/Algebra/Module/Basic.lean
+++ b/Mathlib/Algebra/Module/Basic.lean
@@ -18,7 +18,7 @@ public import Mathlib.Algebra.Ring.Invertible
 
 -/
 
-@[expose] public section
+public section
 
 assert_not_exists Nonneg.inv Multiset
 

--- a/Mathlib/Algebra/Module/BigOperators.lean
+++ b/Mathlib/Algebra/Module/BigOperators.lean
@@ -13,7 +13,7 @@ public import Mathlib.Data.Fintype.BigOperators
 # Finite sums over modules over a ring
 -/
 
-@[expose] public section
+public section
 
 variable {ι κ α β R M : Type*}
 

--- a/Mathlib/Algebra/Module/Card.lean
+++ b/Mathlib/Algebra/Module/Card.lean
@@ -15,7 +15,7 @@ This file proves that the cardinality of a module without zero divisors is at le
 of its base ring.
 -/
 
-@[expose] public section
+public section
 
 open Function
 

--- a/Mathlib/Algebra/Module/DedekindDomain.lean
+++ b/Mathlib/Algebra/Module/DedekindDomain.lean
@@ -17,7 +17,7 @@ Therefore, as any finitely generated torsion module is `I`-torsion for some `I`,
 direct sum of its `p i ^ e i`-torsion submodules for some prime ideals `p i` and numbers `e i`.
 -/
 
-@[expose] public section
+public section
 
 
 universe u v

--- a/Mathlib/Algebra/Module/LinearMap/DivisionRing.lean
+++ b/Mathlib/Algebra/Module/LinearMap/DivisionRing.lean
@@ -20,7 +20,7 @@ This file proves some results on linear functionals on division semirings.
   the range of `f.smulRight x` is the span of the set `{x}`.
 -/
 
-@[expose] public section
+public section
 
 namespace LinearMap
 variable {R M M₁ : Type*} [AddCommMonoid M] [AddCommMonoid M₁]

--- a/Mathlib/Algebra/Module/LinearMap/Prod.lean
+++ b/Mathlib/Algebra/Module/LinearMap/Prod.lean
@@ -19,7 +19,7 @@ linear algebra, vector space, module
 
 -/
 
-@[expose] public section
+public section
 
 variable {R : Type*} {M : Type*} [Semiring R]
 

--- a/Mathlib/Algebra/Module/LinearMap/Star.lean
+++ b/Mathlib/Algebra/Module/LinearMap/Star.lean
@@ -15,7 +15,7 @@ This is in a separate file as it is not needed until much later,
 and avoids importing the theory of star operations unnecessarily early.
 -/
 
-@[expose] public section
+public section
 
 /-- `M →ₗ⋆[R] N` is the type of `R`-conjugate-linear maps from `M` to `N`. -/
 notation:25 M " →ₗ⋆[" R:25 "] " M₂:0 => LinearMap (starRingEnd R) M M₂

--- a/Mathlib/Algebra/Module/LocalizedModule/Exact.lean
+++ b/Mathlib/Algebra/Module/LocalizedModule/Exact.lean
@@ -18,7 +18,7 @@ public import Mathlib.Algebra.Module.LocalizedModule.Basic
 
 -/
 
-@[expose] public section
+public section
 
 section
 

--- a/Mathlib/Algebra/Module/PID.lean
+++ b/Mathlib/Algebra/Module/PID.lean
@@ -47,7 +47,7 @@ Then we get the general result using that a torsion free module is free (which h
 Finitely generated module, principal ideal domain, classification, structure theorem
 -/
 
-@[expose] public section
+public section
 
 -- We shouldn't need to know about topology to prove
 -- the structure theorem for finitely generated modules over a PID.

--- a/Mathlib/Algebra/Module/PointwisePi.lean
+++ b/Mathlib/Algebra/Module/PointwisePi.lean
@@ -20,7 +20,7 @@ set multiplication, set addition, pointwise addition, pointwise multiplication, 
 
 -/
 
-@[expose] public section
+public section
 
 open Pointwise
 

--- a/Mathlib/Algebra/Module/Presentation/Finite.lean
+++ b/Mathlib/Algebra/Module/Presentation/Finite.lean
@@ -16,7 +16,7 @@ it admits a presentation with finitely many generators and relations.
 
 -/
 
-@[expose] public section
+public section
 
 universe w₀ w₁ v u
 

--- a/Mathlib/Algebra/Module/Submodule/Union.lean
+++ b/Mathlib/Algebra/Module/Submodule/Union.lean
@@ -23,7 +23,7 @@ a proper subset, provided the coefficients are a sufficiently large field.
 
 -/
 
-@[expose] public section
+public section
 
 open Function Set
 

--- a/Mathlib/Algebra/Polynomial/BigOperators.lean
+++ b/Mathlib/Algebra/Polynomial/BigOperators.lean
@@ -25,7 +25,7 @@ Recall that `∑` and `∏` are notation for `Finset.sum` and `Finset.prod` resp
   the second coefficient of the characteristic polynomial.
 -/
 
-@[expose] public section
+public section
 
 
 open Finset

--- a/Mathlib/Algebra/Polynomial/Cardinal.lean
+++ b/Mathlib/Algebra/Polynomial/Cardinal.lean
@@ -15,7 +15,7 @@ The result in this file is that the cardinality of `R[X]` is at most the maximum
 of `#R` and `ℵ₀`.
 -/
 
-@[expose] public section
+public section
 
 
 universe u

--- a/Mathlib/Algebra/Polynomial/CoeffMem.lean
+++ b/Mathlib/Algebra/Polynomial/CoeffMem.lean
@@ -19,7 +19,7 @@ Precisely, we show that each summand needs at most one coefficient of `p` and `d
 of `q`.
 -/
 
-@[expose] public section
+public section
 
 namespace Polynomial
 variable {ι R S : Type*} [CommRing R] [Ring S] [Algebra R S]

--- a/Mathlib/Algebra/Polynomial/Degree/Domain.lean
+++ b/Mathlib/Algebra/Polynomial/Degree/Domain.lean
@@ -16,7 +16,7 @@ public import Mathlib.Algebra.Polynomial.Degree.Operations
 * `Polynomial.instDomain`: `R[X]` is a domain if `R` is
 -/
 
-@[expose] public section
+public section
 
 noncomputable section
 

--- a/Mathlib/Algebra/Polynomial/Degree/Lemmas.lean
+++ b/Mathlib/Algebra/Polynomial/Degree/Lemmas.lean
@@ -16,7 +16,7 @@ Some of the main results include
 
 -/
 
-@[expose] public section
+public section
 
 
 noncomputable section

--- a/Mathlib/Algebra/Polynomial/Degree/Monomial.lean
+++ b/Mathlib/Algebra/Polynomial/Degree/Monomial.lean
@@ -13,7 +13,7 @@ public import Mathlib.Data.Nat.SuccPred
 # Degree of univariate monomials
 -/
 
-@[expose] public section
+public section
 
 noncomputable section
 

--- a/Mathlib/Algebra/Polynomial/Degree/SmallDegree.lean
+++ b/Mathlib/Algebra/Polynomial/Degree/SmallDegree.lean
@@ -12,7 +12,7 @@ public import Mathlib.Data.Nat.WithBot
 # Results on polynomials of specific small degrees
 -/
 
-@[expose] public section
+public section
 
 open Finsupp Finset
 

--- a/Mathlib/Algebra/Polynomial/Degree/Support.lean
+++ b/Mathlib/Algebra/Polynomial/Degree/Support.lean
@@ -17,7 +17,7 @@ public import Mathlib.Algebra.Polynomial.Degree.Operations
 * `Polynomial.natDegree_mem_support_of_nonzero`: `natDegree p ∈ support p` if `p ≠ 0`
 -/
 
-@[expose] public section
+public section
 
 noncomputable section
 

--- a/Mathlib/Algebra/Polynomial/Degree/Units.lean
+++ b/Mathlib/Algebra/Polynomial/Degree/Units.lean
@@ -12,7 +12,7 @@ public import Mathlib.Algebra.Polynomial.Degree.SmallDegree
 # Degree of polynomials that are units
 -/
 
-@[expose] public section
+public section
 
 noncomputable section
 

--- a/Mathlib/Algebra/Polynomial/Eval/Algebra.lean
+++ b/Mathlib/Algebra/Polynomial/Eval/Algebra.lean
@@ -16,7 +16,7 @@ This file concerns evaluating polynomials where the map is `algebraMap`
 TODO: merge with parts of `Mathlib/Algebra/Polynomial/AlgebraMap.lean`?
 -/
 
-@[expose] public section
+public section
 
 noncomputable section
 

--- a/Mathlib/Algebra/Polynomial/Eval/Irreducible.lean
+++ b/Mathlib/Algebra/Polynomial/Eval/Irreducible.lean
@@ -18,7 +18,7 @@ public import Mathlib.Algebra.Prime.Defs
   by mapping it to another integral domain and checking for irreducibility there.
 -/
 
-@[expose] public section
+public section
 
 noncomputable section
 

--- a/Mathlib/Algebra/Polynomial/Eval/Subring.lean
+++ b/Mathlib/Algebra/Polynomial/Eval/Subring.lean
@@ -19,7 +19,7 @@ public import Mathlib.Algebra.Ring.Subring.Basic
 
 -/
 
-@[expose] public section
+public section
 
 namespace Polynomial
 

--- a/Mathlib/Algebra/Polynomial/Module/FiniteDimensional.lean
+++ b/Mathlib/Algebra/Polynomial/Module/FiniteDimensional.lean
@@ -21,7 +21,7 @@ by an `R`-linear endomorphism, which require the concept of finite-dimensionalit
 
 -/
 
-@[expose] public section
+public section
 
 open Polynomial
 

--- a/Mathlib/Algebra/Polynomial/PartialFractions.lean
+++ b/Mathlib/Algebra/Polynomial/PartialFractions.lean
@@ -42,7 +42,7 @@ of Patrick Massot.
 
 -/
 
-@[expose] public section
+public section
 
 
 variable (R : Type*) [CommRing R] [IsDomain R]

--- a/Mathlib/Algebra/Polynomial/SpecificDegree.lean
+++ b/Mathlib/Algebra/Polynomial/SpecificDegree.lean
@@ -15,7 +15,7 @@ public import Mathlib.Algebra.Polynomial.FieldDivision
 Facts about polynomials that have a specific integer degree.
 -/
 
-@[expose] public section
+public section
 
 namespace Polynomial
 

--- a/Mathlib/Algebra/Ring/Action/Field.lean
+++ b/Mathlib/Algebra/Ring/Action/Field.lean
@@ -13,7 +13,7 @@ public import Mathlib.Algebra.GroupWithZero.Units.Lemmas
 # Group action on fields
 -/
 
-@[expose] public section
+public section
 
 variable {M} [Monoid M] {F} [DivisionRing F]
 

--- a/Mathlib/Algebra/Ring/Action/Pointwise/Finset.lean
+++ b/Mathlib/Algebra/Ring/Action/Pointwise/Finset.lean
@@ -20,7 +20,7 @@ set multiplication, set addition, pointwise addition, pointwise multiplication,
 pointwise subtraction
 -/
 
-@[expose] public section
+public section
 
 open scoped Pointwise
 

--- a/Mathlib/Algebra/Ring/Action/Pointwise/Set.lean
+++ b/Mathlib/Algebra/Ring/Action/Pointwise/Set.lean
@@ -20,7 +20,7 @@ set multiplication, set addition, pointwise addition, pointwise multiplication,
 pointwise subtraction
 -/
 
-@[expose] public section
+public section
 
 assert_not_exists IsOrderedMonoid Field
 

--- a/Mathlib/Algebra/Ring/Associated.lean
+++ b/Mathlib/Algebra/Ring/Associated.lean
@@ -12,7 +12,7 @@ public import Mathlib.Algebra.Ring.Units
 # Associated elements in rings
 -/
 
-@[expose] public section
+public section
 
 assert_not_exists IsOrderedMonoid Multiset Field
 

--- a/Mathlib/Algebra/Ring/Center.lean
+++ b/Mathlib/Algebra/Ring/Center.lean
@@ -13,7 +13,7 @@ public import Mathlib.Data.Int.Cast.Lemmas
 
 -/
 
-@[expose] public section
+public section
 
 assert_not_exists RelIso Finset Subsemigroup Field
 

--- a/Mathlib/Algebra/Ring/Centralizer.lean
+++ b/Mathlib/Algebra/Ring/Centralizer.lean
@@ -12,7 +12,7 @@ public import Mathlib.Algebra.Ring.Defs
 # Centralizers of rings
 -/
 
-@[expose] public section
+public section
 
 assert_not_exists RelIso
 

--- a/Mathlib/Algebra/Ring/Divisibility/Lemmas.lean
+++ b/Mathlib/Algebra/Ring/Divisibility/Lemmas.lean
@@ -20,7 +20,7 @@ public import Mathlib.Algebra.GCDMonoid.Basic
   `x ^ m ∣ (x + y) ^ p` for sufficiently large `p` (together with many variations for convenience).
 -/
 
-@[expose] public section
+public section
 
 variable {R : Type*}
 

--- a/Mathlib/Algebra/Ring/Ext.lean
+++ b/Mathlib/Algebra/Ring/Ext.lean
@@ -29,7 +29,7 @@ sometimes we don't need them to prove extensionality.
 semiring, ring, extensionality
 -/
 
-@[expose] public section
+public section
 
 local macro:max "local_hAdd[" type:term ", " inst:term "]" : term =>
   `(term| (letI := $inst; HAdd.hAdd : $type → $type → $type))

--- a/Mathlib/Algebra/Ring/GeomSum.lean
+++ b/Mathlib/Algebra/Ring/GeomSum.lean
@@ -20,7 +20,7 @@ which `x` and `y` commute. Even versions not using division or subtraction, vali
 are recorded.
 -/
 
-@[expose] public section
+public section
 
 assert_not_exists Field IsOrderedRing
 

--- a/Mathlib/Algebra/Ring/Hom/InjSurj.lean
+++ b/Mathlib/Algebra/Ring/Hom/InjSurj.lean
@@ -13,7 +13,7 @@ public import Mathlib.Algebra.Ring.Defs
 # Pulling back rings along injective maps, and pushing them forward along surjective maps
 -/
 
-@[expose] public section
+public section
 
 open Function
 

--- a/Mathlib/Algebra/Ring/Identities.lean
+++ b/Mathlib/Algebra/Ring/Identities.lean
@@ -13,7 +13,7 @@ public import Mathlib.Tactic.Ring
 This file contains some "named" commutative ring identities.
 -/
 
-@[expose] public section
+public section
 
 
 variable {R : Type*} [CommRing R] {a b x₁ x₂ x₃ x₄ x₅ x₆ x₇ x₈ y₁ y₂ y₃ y₄ y₅ y₆ y₇ y₈ n : R}

--- a/Mathlib/Algebra/Ring/Int/Units.lean
+++ b/Mathlib/Algebra/Ring/Int/Units.lean
@@ -21,7 +21,7 @@ This file contains lemmas on the units of `ℤ`.
 See note [foundational algebra order theory].
 -/
 
-@[expose] public section
+public section
 
 assert_not_exists DenselyOrdered Set.Subsingleton
 

--- a/Mathlib/Algebra/Ring/NonZeroDivisors.lean
+++ b/Mathlib/Algebra/Ring/NonZeroDivisors.lean
@@ -14,7 +14,7 @@ public import Mathlib.Algebra.Ring.Basic
 # Non-zero divisors in a ring
 -/
 
-@[expose] public section
+public section
 
 assert_not_exists Field
 

--- a/Mathlib/Algebra/Ring/Semiconj.lean
+++ b/Mathlib/Algebra/Ring/Semiconj.lean
@@ -20,7 +20,7 @@ For the definitions of semirings and rings see `Mathlib/Algebra/Ring/Defs.lean`.
 
 -/
 
-@[expose] public section
+public section
 
 
 universe u

--- a/Mathlib/Algebra/Ring/Submonoid/Basic.lean
+++ b/Mathlib/Algebra/Ring/Submonoid/Basic.lean
@@ -11,7 +11,7 @@ public import Mathlib.Algebra.Ring.Defs
 
 /-! # Lemmas about additive closures of `Subsemigroup`. -/
 
-@[expose] public section
+public section
 
 open AddSubmonoid
 

--- a/Mathlib/Algebra/Ring/Torsion.lean
+++ b/Mathlib/Algebra/Ring/Torsion.lean
@@ -15,7 +15,7 @@ public import Mathlib.Algebra.Ring.Regular
 A characteristic zero domain is torsion-free.
 -/
 
-@[expose] public section
+public section
 
 namespace IsDomain
 


### PR DESCRIPTION
Removes `@[expose]` from 86 files in Algebra/Group, Homology, Polynomial, Ring, Module.

🤖 Prepared with Claude Code