### PR TITLE
[Merged by Bors] - chore(Algebra): remove unnecessary @[expose] from public sections

### DIFF
--- a/Mathlib/Algebra/Algebra/Field.lean
+++ b/Mathlib/Algebra/Algebra/Field.lean
@@ -12,7 +12,7 @@ public import Mathlib.Data.Rat.Cast.Defs
 # Facts about `algebraMap` when the coefficient ring is a field.
 -/
 
-@[expose] public section
+public section
 
 namespace algebraMap
 

--- a/Mathlib/Algebra/Algebra/Subalgebra/Centralizer.lean
+++ b/Mathlib/Algebra/Algebra/Subalgebra/Centralizer.lean
@@ -24,7 +24,7 @@ Let `R` be a commutative ring and `A` and `B` two `R`-algebras.
   then the centralizer of `1 ⊗ B` in `A ⊗ B` is `A ⊗ C(B)` where `C(B)` is the center of `B`.
 -/
 
-@[expose] public section
+public section
 
 namespace Subalgebra
 

--- a/Mathlib/Algebra/Algebra/Subalgebra/IsSimpleOrder.lean
+++ b/Mathlib/Algebra/Algebra/Subalgebra/IsSimpleOrder.lean
@@ -14,7 +14,7 @@ If `A` is a domain, and a finite-dimensional algebra over a field `F`, with prim
 then there are no non-trivial `F`-subalgebras.
 -/
 
-@[expose] public section
+public section
 
 open Module Submodule
 

--- a/Mathlib/Algebra/Algebra/Subalgebra/Rank.lean
+++ b/Mathlib/Algebra/Algebra/Subalgebra/Rank.lean
@@ -20,7 +20,7 @@ satisfies the strong rank condition, we put them into a separate file.
 
 -/
 
-@[expose] public section
+public section
 
 open Module
 

--- a/Mathlib/Algebra/AlgebraicCard.lean
+++ b/Mathlib/Algebra/AlgebraicCard.lean
@@ -18,7 +18,7 @@ Although this can be used to prove that real or complex transcendental numbers e
 proof is given by `Liouville.transcendental`.
 -/
 
-@[expose] public section
+public section
 
 
 universe u v

--- a/Mathlib/Algebra/Category/Grp/LargeColimits.lean
+++ b/Mathlib/Algebra/Category/Grp/LargeColimits.lean
@@ -18,7 +18,7 @@ by the relations given by the morphisms in the diagram) is `w`-small.
 
 -/
 
-@[expose] public section
+public section
 
 universe w u v
 

--- a/Mathlib/Algebra/Category/ModuleCat/Presheaf/Abelian.lean
+++ b/Mathlib/Algebra/Category/ModuleCat/Presheaf/Abelian.lean
@@ -15,7 +15,7 @@ public import Mathlib.CategoryTheory.Abelian.Basic
 
 -/
 
-@[expose] public section
+public section
 
 universe v v₁ u₁ u
 

--- a/Mathlib/Algebra/Category/Ring/Epi.lean
+++ b/Mathlib/Algebra/Category/Ring/Epi.lean
@@ -16,7 +16,7 @@ public import Mathlib.CategoryTheory.ConcreteCategory.EpiMono
 - `RingHom.surjective_iff_epi_and_finite`: surjective <=> epi + finite
 -/
 
-@[expose] public section
+public section
 
 open CategoryTheory TensorProduct
 

--- a/Mathlib/Algebra/Category/Ring/FinitePresentation.lean
+++ b/Mathlib/Algebra/Category/Ring/FinitePresentation.lean
@@ -21,7 +21,7 @@ i.e. `Hom_R(S, -)` preserves filtered colimits.
 
 -/
 
-@[expose] public section
+public section
 
 open CategoryTheory Limits
 

--- a/Mathlib/Algebra/Category/Ring/LinearAlgebra.lean
+++ b/Mathlib/Algebra/Category/Ring/LinearAlgebra.lean
@@ -20,7 +20,7 @@ public import Mathlib.RingTheory.Flat.FaithfullyFlat.Basic
 
 -/
 
-@[expose] public section
+public section
 
 universe u
 

--- a/Mathlib/Algebra/Central/TensorProduct.lean
+++ b/Mathlib/Algebra/Central/TensorProduct.lean
@@ -29,7 +29,7 @@ algebra and `B, C` nontrivial, then both `B` and `C` are central algebras.
 Central Algebras, Central Simple Algebras, Noncommutative Algebra
 -/
 
-@[expose] public section
+public section
 
 universe u v
 

--- a/Mathlib/Algebra/CharP/CharAndCard.lean
+++ b/Mathlib/Algebra/CharP/CharAndCard.lean
@@ -19,7 +19,7 @@ We prove some results relating characteristic and cardinality of finite rings
 characteristic, cardinality, ring
 -/
 
-@[expose] public section
+public section
 
 
 /-- A prime `p` is a unit in a commutative ring `R` of nonzero characteristic iff it does not divide

--- a/Mathlib/Algebra/CharP/LocalRing.lean
+++ b/Mathlib/Algebra/CharP/LocalRing.lean
@@ -20,7 +20,7 @@ public import Mathlib.RingTheory.LocalRing.ResidueField.Defs
 
 -/
 
-@[expose] public section
+public section
 
 
 /-- In a local ring the characteristic is either zero or a prime power. -/

--- a/Mathlib/Algebra/CharP/Quotient.lean
+++ b/Mathlib/Algebra/CharP/Quotient.lean
@@ -14,7 +14,7 @@ public import Mathlib.RingTheory.Ideal.Quotient.Defs
 # Characteristic of quotient rings
 -/
 
-@[expose] public section
+public section
 
 theorem CharP.ker_intAlgebraMap_eq_span
     {R : Type*} [Ring R] (p : ℕ) [CharP R p] :

--- a/Mathlib/Algebra/CharP/Reduced.lean
+++ b/Mathlib/Algebra/CharP/Reduced.lean
@@ -12,7 +12,7 @@ public import Mathlib.RingTheory.Nilpotent.Defs
 # Results about characteristic p reduced rings
 -/
 
-@[expose] public section
+public section
 
 
 open Finset

--- a/Mathlib/Algebra/CharP/Two.lean
+++ b/Mathlib/Algebra/CharP/Two.lean
@@ -17,7 +17,7 @@ The lemmas in this file with a `_sq` suffix are just special cases of the `_pow_
 elsewhere, with a shorter name for ease of discovery, and no need for a `[Fact (Prime 2)]` argument.
 -/
 
-@[expose] public section
+public section
 
 assert_not_exists Algebra LinearMap
 

--- a/Mathlib/Algebra/CharZero/AddMonoidHom.lean
+++ b/Mathlib/Algebra/CharZero/AddMonoidHom.lean
@@ -15,7 +15,7 @@ public import Mathlib.Data.Nat.Cast.Basic
 This file exists in order to avoid adding extra imports to other files in this subdirectory.
 -/
 
-@[expose] public section
+public section
 
 theorem CharZero.of_addMonoidHom {M N : Type*} [AddCommMonoidWithOne M] [AddCommMonoidWithOne N]
     [CharZero M] (e : M →+ N) (he : e 1 = 1) (he' : Function.Injective e) : CharZero N where

--- a/Mathlib/Algebra/CharZero/Quotient.lean
+++ b/Mathlib/Algebra/CharZero/Quotient.lean
@@ -15,7 +15,7 @@ public import Mathlib.Algebra.Group.Subgroup.ZPowers.Basic
 # Lemmas about quotients in characteristic zero
 -/
 
-@[expose] public section
+public section
 
 
 variable {R : Type*} [DivisionRing R] [CharZero R] {p : R}

--- a/Mathlib/Algebra/Colimit/TensorProduct.lean
+++ b/Mathlib/Algebra/Colimit/TensorProduct.lean
@@ -19,7 +19,7 @@ that every module is the direct limit of its finitely generated submodules and t
 product preserves colimits.
 -/
 
-@[expose] public section
+public section
 
 open TensorProduct
 

--- a/Mathlib/Algebra/ContinuedFractions/Computation/ApproximationCorollaries.lean
+++ b/Mathlib/Algebra/ContinuedFractions/Computation/ApproximationCorollaries.lean
@@ -39,7 +39,7 @@ Moreover, we show the convergence of the continued fractions computations, that 
 convergence, fractions
 -/
 
-@[expose] public section
+public section
 
 variable {K : Type*} (v : K) [Field K] [LinearOrder K] [IsStrictOrderedRing K] [FloorRing K]
 

--- a/Mathlib/Algebra/ContinuedFractions/Computation/TerminatesIffRat.lean
+++ b/Mathlib/Algebra/ContinuedFractions/Computation/TerminatesIffRat.lean
@@ -29,7 +29,7 @@ rational number, that is `↑v = q` for some `q : ℚ`.
 rational, continued fraction, termination
 -/
 
-@[expose] public section
+public section
 
 
 namespace GenContFract

--- a/Mathlib/Algebra/ContinuedFractions/Computation/Translations.lean
+++ b/Mathlib/Algebra/ContinuedFractions/Computation/Translations.lean
@@ -40,7 +40,7 @@ The file consists of three sections:
   parts.
 -/
 
-@[expose] public section
+public section
 
 assert_not_exists Finset
 

--- a/Mathlib/Algebra/ContinuedFractions/ContinuantsRecurrence.lean
+++ b/Mathlib/Algebra/ContinuedFractions/ContinuantsRecurrence.lean
@@ -18,7 +18,7 @@ function indeed satisfies the following recurrences:
 - `Bₙ = bₙ * Bₙ₋₁ + aₙ * Bₙ₋₂`.
 -/
 
-@[expose] public section
+public section
 
 
 namespace GenContFract

--- a/Mathlib/Algebra/ContinuedFractions/Determinant.lean
+++ b/Mathlib/Algebra/ContinuedFractions/Determinant.lean
@@ -28,7 +28,7 @@ Generalize this for `GenContFract` version:
 
 -/
 
-@[expose] public section
+public section
 
 open GenContFract
 

--- a/Mathlib/Algebra/ContinuedFractions/TerminatedStable.lean
+++ b/Mathlib/Algebra/ContinuedFractions/TerminatedStable.lean
@@ -15,7 +15,7 @@ public import Mathlib.Algebra.ContinuedFractions.Translations
 We show that the continuants and convergents of a gcf stabilise once the gcf terminates.
 -/
 
-@[expose] public section
+public section
 
 
 namespace GenContFract

--- a/Mathlib/Algebra/ContinuedFractions/Translations.lean
+++ b/Mathlib/Algebra/ContinuedFractions/Translations.lean
@@ -18,7 +18,7 @@ Some simple translation lemmas between the different definitions of functions de
 `Algebra.ContinuedFractions.Basic`.
 -/
 
-@[expose] public section
+public section
 
 
 namespace GenContFract

--- a/Mathlib/Algebra/DirectSum/LinearMap.lean
+++ b/Mathlib/Algebra/DirectSum/LinearMap.lean
@@ -18,7 +18,7 @@ domain and codomain.
 
 -/
 
-@[expose] public section
+public section
 
 open DirectSum Module Set
 

--- a/Mathlib/Algebra/Divisibility/Hom.lean
+++ b/Mathlib/Algebra/Divisibility/Hom.lean
@@ -21,7 +21,7 @@ public import Mathlib.Algebra.Group.Hom.Defs
 divisibility, divides
 -/
 
-@[expose] public section
+public section
 
 attribute [local simp] mul_assoc mul_comm mul_left_comm
 

--- a/Mathlib/Algebra/Field/Equiv.lean
+++ b/Mathlib/Algebra/Field/Equiv.lean
@@ -15,7 +15,7 @@ public import Mathlib.Algebra.GroupWithZero.Equiv
 This is in a separate file to avoid needing to import `Field` in `Mathlib/Algebra/Ring/Equiv.lean`
 -/
 
-@[expose] public section
+public section
 
 variable {A B F : Type*} [Semiring A] [Semiring B]
 

--- a/Mathlib/Algebra/Field/GeomSum.lean
+++ b/Mathlib/Algebra/Field/GeomSum.lean
@@ -24,7 +24,7 @@ Several variants are recorded, generalising in particular to the case of a divis
 which `x` and `y` commute.
 -/
 
-@[expose] public section
+public section
 
 assert_not_exists IsOrderedRing
 

--- a/Mathlib/Algebra/Field/NegOnePow.lean
+++ b/Mathlib/Algebra/Field/NegOnePow.lean
@@ -11,7 +11,7 @@ public import Mathlib.Tactic.NormNum
 
 /-! # Integer powers of `-1` in a field -/
 
-@[expose] public section
+public section
 
 namespace Int
 

--- a/Mathlib/Algebra/Field/Periodic.lean
+++ b/Mathlib/Algebra/Field/Periodic.lean
@@ -30,7 +30,7 @@ Note that any `c`-antiperiodic function will necessarily also be `2 • c`-perio
 period, periodic, periodicity, antiperiodic
 -/
 
-@[expose] public section
+public section
 
 assert_not_exists TwoSidedIdeal
 

--- a/Mathlib/Algebra/Field/Power.lean
+++ b/Mathlib/Algebra/Field/Power.lean
@@ -16,7 +16,7 @@ so it contains some lemmas about powers of elements which need imports
 beyond those needed for the basic definition.
 -/
 
-@[expose] public section
+public section
 
 
 variable {α : Type*}

--- a/Mathlib/Algebra/FiveLemma.lean
+++ b/Mathlib/Algebra/FiveLemma.lean
@@ -41,7 +41,7 @@ In theory, we could prove these in the multiplicative version and let `to_additi
 the additive variants. But `Function.Exact` currently has no multiplicative analogue (yet).
 -/
 
-@[expose] public section
+public section
 
 assert_not_exists Cardinal
 

--- a/Mathlib/Algebra/FreeAlgebra/Cardinality.lean
+++ b/Mathlib/Algebra/FreeAlgebra/Cardinality.lean
@@ -15,7 +15,7 @@ This file contains some results about the cardinality of `FreeAlgebra`,
 parallel to that of `MvPolynomial`.
 -/
 
-@[expose] public section
+public section
 
 universe u v
 

--- a/Mathlib/Algebra/GCDMonoid/FinsetLemmas.lean
+++ b/Mathlib/Algebra/GCDMonoid/FinsetLemmas.lean
@@ -18,7 +18,7 @@ public import Mathlib.RingTheory.Coprime.Lemmas
 finset, lcm, prod, coprime
 -/
 
-@[expose] public section
+public section
 
 namespace Finset
 

--- a/Mathlib/Algebra/Lie/Semisimple/Lemmas.lean
+++ b/Mathlib/Algebra/Lie/Semisimple/Lemmas.lean
@@ -28,7 +28,7 @@ This file is a home for lemmas about semisimple and reductive Lie algebras.
 
 -/
 
-@[expose] public section
+public section
 
 namespace LieAlgebra
 

--- a/Mathlib/Algebra/MonoidAlgebra/Ideal.lean
+++ b/Mathlib/Algebra/MonoidAlgebra/Ideal.lean
@@ -13,7 +13,7 @@ public import Mathlib.Algebra.MonoidAlgebra.Defs
 # Lemmas about ideals of `MonoidAlgebra` and `AddMonoidAlgebra`
 -/
 
-@[expose] public section
+public section
 
 
 variable {k A G : Type*}

--- a/Mathlib/Algebra/MonoidAlgebra/Support.lean
+++ b/Mathlib/Algebra/MonoidAlgebra/Support.lean
@@ -14,7 +14,7 @@ public import Mathlib.Algebra.Group.Pointwise.Finset.Basic
 # Lemmas about the support of a finitely supported function
 -/
 
-@[expose] public section
+public section
 
 open scoped Pointwise
 

--- a/Mathlib/Algebra/MvPolynomial/Cardinal.lean
+++ b/Mathlib/Algebra/MvPolynomial/Cardinal.lean
@@ -17,7 +17,7 @@ the cardinality of `MvPolynomial σ R` is bounded above by the maximum of `#R`, 
 and `ℵ₀`.
 -/
 
-@[expose] public section
+public section
 
 
 universe u v

--- a/Mathlib/Algebra/MvPolynomial/Funext.lean
+++ b/Mathlib/Algebra/MvPolynomial/Funext.lean
@@ -24,7 +24,7 @@ if they are equal upon evaluating them on an arbitrary assignment of the variabl
 
 -/
 
-@[expose] public section
+public section
 
 namespace MvPolynomial
 

--- a/Mathlib/Algebra/MvPolynomial/Invertible.lean
+++ b/Mathlib/Algebra/MvPolynomial/Invertible.lean
@@ -15,7 +15,7 @@ This file is a stub containing some basic facts about
 invertible elements in the ring of polynomials.
 -/
 
-@[expose] public section
+public section
 
 
 open MvPolynomial

--- a/Mathlib/Algebra/MvPolynomial/NoZeroDivisors.lean
+++ b/Mathlib/Algebra/MvPolynomial/NoZeroDivisors.lean
@@ -17,7 +17,7 @@ that hold when the coefficient (semi)ring has no zero divisors.
 
 -/
 
-@[expose] public section
+public section
 
 open Finset Equiv
 

--- a/Mathlib/Algebra/MvPolynomial/Polynomial.lean
+++ b/Mathlib/Algebra/MvPolynomial/Polynomial.lean
@@ -11,7 +11,7 @@ public import Mathlib.Algebra.MvPolynomial.Equiv
 # Some lemmas relating polynomials and multivariable polynomials.
 -/
 
-@[expose] public section
+public section
 
 namespace MvPolynomial
 

--- a/Mathlib/Algebra/MvPolynomial/SchwartzZippel.lean
+++ b/Mathlib/Algebra/MvPolynomial/SchwartzZippel.lean
@@ -52,7 +52,7 @@ of the field. This lemma is useful as a probabilistic polynomial identity test.
 * [zippel_1979]
 -/
 
-@[expose] public section
+public section
 
 open Fin Finset Fintype
 

--- a/Mathlib/Algebra/NeZero.lean
+++ b/Mathlib/Algebra/NeZero.lean
@@ -15,7 +15,7 @@ We give basic facts about the `NeZero n` typeclass.
 
 -/
 
-@[expose] public section
+public section
 
 variable {R : Type*} [Zero R]
 

--- a/Mathlib/Algebra/Notation/FiniteSupport.lean
+++ b/Mathlib/Algebra/Notation/FiniteSupport.lean
@@ -12,7 +12,7 @@ public import Mathlib.Data.Set.Finite.Basic
 # Finiteness of support
 -/
 
-@[expose] public section
+public section
 
 assert_not_exists Monoid
 

--- a/Mathlib/Algebra/Notation/Lemmas.lean
+++ b/Mathlib/Algebra/Notation/Lemmas.lean
@@ -13,7 +13,7 @@ public import Mathlib.Util.AssertExists
 
 /-! # Lemmas about inequalities with `1`. -/
 
-@[expose] public section
+public section
 
 assert_not_exists Monoid
 

--- a/Mathlib/Algebra/Pointwise/Stabilizer.lean
+++ b/Mathlib/Algebra/Pointwise/Stabilizer.lean
@@ -15,7 +15,7 @@ public import Mathlib.Order.ConditionallyCompleteLattice.Basic
 This file characterises the stabilizer of a set/finset under the pointwise action of a group.
 -/
 
-@[expose] public section
+public section
 
 open Function MulOpposite Set
 open scoped Pointwise

--- a/Mathlib/Algebra/Prime/Lemmas.lean
+++ b/Mathlib/Algebra/Prime/Lemmas.lean
@@ -28,7 +28,7 @@ Then we show that the quotient type `Associates` is a monoid
 and prove basic properties of this quotient.
 -/
 
-@[expose] public section
+public section
 
 assert_not_exists IsOrderedMonoid Multiset
 

--- a/Mathlib/Algebra/QuadraticAlgebra/NormDeterminant.lean
+++ b/Mathlib/Algebra/QuadraticAlgebra/NormDeterminant.lean
@@ -15,7 +15,7 @@ We prove that the expression for the norm of an element in a quadratic algebra c
 the endomorphism defined by left multiplication by that element and taking its determinant.
 -/
 
-@[expose] public section
+public section
 
 namespace QuadraticAlgebra
 

--- a/Mathlib/Algebra/Regular/Basic.lean
+++ b/Mathlib/Algebra/Regular/Basic.lean
@@ -25,7 +25,7 @@ by adding one further `0`.
 The final goal is to develop part of the API to prove, eventually, results about non-zero-divisors.
 -/
 
-@[expose] public section
+public section
 
 variable {R : Type*}
 

--- a/Mathlib/Algebra/Regular/Opposite.lean
+++ b/Mathlib/Algebra/Regular/Opposite.lean
@@ -11,7 +11,7 @@ public import Mathlib.Algebra.Opposites
 # Results about `IsRegular` and `MulOpposite`
 -/
 
-@[expose] public section
+public section
 
 variable {R} [Mul R]
 open MulOpposite

--- a/Mathlib/Algebra/Regular/Pi.lean
+++ b/Mathlib/Algebra/Regular/Pi.lean
@@ -11,7 +11,7 @@ public import Mathlib.Algebra.Regular.SMul
 # Results about `IsRegular` and pi types
 -/
 
-@[expose] public section
+public section
 
 variable {ι α : Type*} {R : ι → Type*}
 

--- a/Mathlib/Algebra/Regular/Pow.lean
+++ b/Mathlib/Algebra/Regular/Pow.lean
@@ -16,7 +16,7 @@ public import Mathlib.Algebra.Regular.Basic
 Move to `Mathlib/Algebra/BigOperators/Group/Finset/Basic.lean`?
 -/
 
-@[expose] public section
+public section
 
 
 variable {R : Type*} {a b : R}

--- a/Mathlib/Algebra/Regular/Prod.lean
+++ b/Mathlib/Algebra/Regular/Prod.lean
@@ -12,7 +12,7 @@ public import Mathlib.Algebra.Regular.SMul
 # Results about `IsRegular` and `Prod`
 -/
 
-@[expose] public section
+public section
 
 variable {α R S : Type*}
 

--- a/Mathlib/Algebra/Regular/ULift.lean
+++ b/Mathlib/Algebra/Regular/ULift.lean
@@ -12,7 +12,7 @@ public import Mathlib.Algebra.Regular.SMul
 # Results about `IsRegular` and `ULift`
 -/
 
-@[expose] public section
+public section
 
 universe u v
 

--- a/Mathlib/Algebra/SkewMonoidAlgebra/Support.lean
+++ b/Mathlib/Algebra/SkewMonoidAlgebra/Support.lean
@@ -14,7 +14,7 @@ public import Mathlib.Algebra.SkewMonoidAlgebra.Basic
 For `f : SkewMonoidAlgebra k G`, `f.support` is the set of all `a ∈ G` such that `f.coeff a ≠ 0`.
 -/
 
-@[expose] public section
+public section
 
 open scoped Pointwise
 

--- a/Mathlib/Algebra/Star/BigOperators.lean
+++ b/Mathlib/Algebra/Star/BigOperators.lean
@@ -14,7 +14,7 @@ public import Mathlib.Algebra.Star.SelfAdjoint
 These results are kept separate from `Algebra.Star.Basic` to avoid it needing to import `Finset`.
 -/
 
-@[expose] public section
+public section
 
 
 variable {R : Type*}

--- a/Mathlib/Algebra/Star/Center.lean
+++ b/Mathlib/Algebra/Star/Center.lean
@@ -11,7 +11,7 @@ public import Mathlib.Algebra.Group.Center
 
 /-! # `Set.center`, `Set.centralizer` and the `star` operation -/
 
-@[expose] public section
+public section
 
 variable {R : Type*} [Mul R] [StarMul R] {a : R} {s : Set R}
 

--- a/Mathlib/Algebra/Tropical/BigOperators.lean
+++ b/Mathlib/Algebra/Tropical/BigOperators.lean
@@ -33,7 +33,7 @@ directly transfer to minima over multisets or finsets.
 
 -/
 
-@[expose] public section
+public section
 
 variable {R S : Type*}
 


### PR DESCRIPTION
Removes `@[expose]` from 62 files in remaining Algebra subdirectories.

🤖 Prepared with Claude Code