### PR TITLE
[Merged by Bors] - chore(Data): remove unnecessary @[expose] from public sections

### DIFF
--- a/Mathlib/Data/Array/Extract.lean
+++ b/Mathlib/Data/Array/Extract.lean
@@ -13,7 +13,7 @@ public import Batteries.Data.Array.Lemmas
 Some useful lemmas about Array.extract
 -/
 
-@[expose] public section
+public section
 
 universe u
 variable {α : Type u} {i : Nat}

--- a/Mathlib/Data/Bool/AllAny.lean
+++ b/Mathlib/Data/Bool/AllAny.lean
@@ -15,7 +15,7 @@ This proves a few properties about `List.all` and `List.any`, which are the `Boo
 existential quantifiers. Their definitions are in core Lean.
 -/
 
-@[expose] public section
+public section
 
 
 variable {α : Type*} {p : α → Prop} [DecidablePred p] {l : List α} {a : α}

--- a/Mathlib/Data/Bool/Count.lean
+++ b/Mathlib/Data/Bool/Count.lean
@@ -19,7 +19,7 @@ we prove that in a list with alternating `true`s and `false`s, the number of `tr
 the number of `false`s by at most one. We provide several versions of these statements.
 -/
 
-@[expose] public section
+public section
 
 
 namespace List

--- a/Mathlib/Data/Bool/Set.lean
+++ b/Mathlib/Data/Bool/Set.lean
@@ -13,7 +13,7 @@ public import Mathlib.Data.Set.Insert
 This file contains three trivial lemmas about `Bool`, `Set.univ`, and `Set.range`.
 -/
 
-@[expose] public section
+public section
 
 
 open Set

--- a/Mathlib/Data/Complex/BigOperators.lean
+++ b/Mathlib/Data/Complex/BigOperators.lean
@@ -12,7 +12,7 @@ public import Mathlib.Data.Complex.Basic
 # Finite sums and products of complex numbers
 -/
 
-@[expose] public section
+public section
 
 open Fintype
 open scoped BigOperators

--- a/Mathlib/Data/DFinsupp/Ext.lean
+++ b/Mathlib/Data/DFinsupp/Ext.lean
@@ -17,7 +17,7 @@ public import Mathlib.Data.DFinsupp.Defs
   are equal on each `single a b`, then they are equal.
 -/
 
-@[expose] public section
+public section
 
 
 universe u u₁ u₂ v v₁ v₂ v₃ w x y l

--- a/Mathlib/Data/DFinsupp/Notation.lean
+++ b/Mathlib/Data/DFinsupp/Notation.lean
@@ -19,7 +19,7 @@ Note that this syntax is for `Finsupp` by default, but works for `DFinsupp` if t
 is correct.
 -/
 
-@[expose] public section
+public section
 
 namespace DFinsupp
 

--- a/Mathlib/Data/DFinsupp/Submonoid.lean
+++ b/Mathlib/Data/DFinsupp/Submonoid.lean
@@ -23,7 +23,7 @@ This file mainly concerns the interaction between submonoids and products/sums o
   monoids can be given by taking finite sums of elements of each monoid.
 -/
 
-@[expose] public section
+public section
 
 
 universe u u₁ u₂ v v₁ v₂ v₃ w x y l

--- a/Mathlib/Data/ENNReal/BigOperators.lean
+++ b/Mathlib/Data/ENNReal/BigOperators.lean
@@ -16,7 +16,7 @@ In this file we prove elementary properties of sums and products on `ℝ≥0∞`
 interact with the order structure on `ℝ≥0∞`.
 -/
 
-@[expose] public section
+public section
 
 open Set NNReal ENNReal
 

--- a/Mathlib/Data/ENNReal/Lemmas.lean
+++ b/Mathlib/Data/ENNReal/Lemmas.lean
@@ -16,7 +16,7 @@ These are some lemmas split off from `ENNReal.Basic` because they need a lot mor
 They are probably good targets for further cleanup or moves.
 -/
 
-@[expose] public section
+public section
 
 
 open Function Set NNReal

--- a/Mathlib/Data/ENat/BigOperators.lean
+++ b/Mathlib/Data/ENat/BigOperators.lean
@@ -12,7 +12,7 @@ public import Mathlib.Data.ENat.Lattice
 # Sum of suprema in `ENat`
 -/
 
-@[expose] public section
+public section
 
 assert_not_exists Field
 

--- a/Mathlib/Data/ENat/Lattice.lean
+++ b/Mathlib/Data/ENat/Lattice.lean
@@ -19,7 +19,7 @@ of `WithTop.some`.
 
 -/
 
-@[expose] public section
+public section
 
 assert_not_exists Field
 

--- a/Mathlib/Data/Fin/Parity.lean
+++ b/Mathlib/Data/Fin/Parity.lean
@@ -19,7 +19,7 @@ We also prove a lemma about parity of `Fin.succAbove i j + Fin.predAbove j i`
 which can be used to prove `d ∘ d = 0` for de Rham cohomologies.
 -/
 
-@[expose] public section
+public section
 
 open Fin
 

--- a/Mathlib/Data/Fin/Pigeonhole.lean
+++ b/Mathlib/Data/Fin/Pigeonhole.lean
@@ -14,7 +14,7 @@ This adapts Pigeonhole-like results from `Mathlib.Data.Fintype.Card` to the sett
 has the type `f : Fin m → Fin n`.
 -/
 
-@[expose] public section
+public section
 
 namespace Fin
 

--- a/Mathlib/Data/Fin/Tuple/BubbleSortInduction.lean
+++ b/Mathlib/Data/Fin/Tuple/BubbleSortInduction.lean
@@ -27,7 +27,7 @@ The latter is proved by well-founded induction via `WellFounded.induction_bot'`
 with respect to the lexicographic ordering on the finite set of all permutations of `f`.
 -/
 
-@[expose] public section
+public section
 
 
 namespace Tuple

--- a/Mathlib/Data/Fin/Tuple/Finset.lean
+++ b/Mathlib/Data/Fin/Tuple/Finset.lean
@@ -12,7 +12,7 @@ public import Mathlib.Data.Fintype.Pi
 # Fin-indexed tuples of finsets
 -/
 
-@[expose] public section
+public section
 
 open Fin Fintype
 

--- a/Mathlib/Data/Finite/Perm.lean
+++ b/Mathlib/Data/Finite/Perm.lean
@@ -12,7 +12,7 @@ public import Mathlib.SetTheory.Cardinal.Finite
 
 -/
 
-@[expose] public section
+public section
 
 assert_not_exists Field
 

--- a/Mathlib/Data/Finite/Set.lean
+++ b/Mathlib/Data/Finite/Set.lean
@@ -17,7 +17,7 @@ In this file we prove two lemmas about `Finite` and `Set`s.
 finiteness, finite sets
 -/
 
-@[expose] public section
+public section
 
 
 open Set

--- a/Mathlib/Data/Finset/Attr.lean
+++ b/Mathlib/Data/Finset/Attr.lean
@@ -15,7 +15,7 @@ public import Qq
 This file defines `finsetNonempty`, an aesop rule set to prove that a given finset is nonempty.
 -/
 
-@[expose] public section
+public section
 
 -- `finsetNonempty` rules try to prove that a given finset is nonempty,
 -- for use in positivity extensions.

--- a/Mathlib/Data/Finset/CastCard.lean
+++ b/Mathlib/Data/Finset/CastCard.lean
@@ -22,7 +22,7 @@ cardinality as element of an `AddGroupWithOne`.
 * `Finset.cast_card_sdiff`: cardinality of `t \ s` is the difference of cardinalities if `s ⊆ t`.
 -/
 
-@[expose] public section
+public section
 
 assert_not_exists MonoidWithZero IsOrderedMonoid
 

--- a/Mathlib/Data/Finset/Lattice/Lemmas.lean
+++ b/Mathlib/Data/Finset/Lattice/Lemmas.lean
@@ -20,7 +20,7 @@ finite sets, finset
 
 -/
 
-@[expose] public section
+public section
 
 -- Assert that we define `Finset` without the material on `List.sublists`.
 -- Note that we cannot use `List.sublists` itself as that is defined very early.

--- a/Mathlib/Data/Finset/Lattice/Pi.lean
+++ b/Mathlib/Data/Finset/Lattice/Pi.lean
@@ -14,7 +14,7 @@ public import Mathlib.Data.Finset.Pi
 This file is concerned with folding binary lattice operations over finsets.
 -/
 
-@[expose] public section
+public section
 
 assert_not_exists IsOrderedMonoid MonoidWithZero
 

--- a/Mathlib/Data/Finset/Lattice/Prod.lean
+++ b/Mathlib/Data/Finset/Lattice/Prod.lean
@@ -14,7 +14,7 @@ public import Mathlib.Data.Finset.Prod
 This file is concerned with folding binary lattice operations over finsets.
 -/
 
-@[expose] public section
+public section
 
 assert_not_exists IsOrderedMonoid MonoidWithZero
 

--- a/Mathlib/Data/Finset/Lattice/Union.lean
+++ b/Mathlib/Data/Finset/Lattice/Union.lean
@@ -18,7 +18,7 @@ This file shows `Finset.biUnion` could alternatively be defined in terms of `Fin
 Remove `Finset.biUnion` in favour of `Finset.sup`.
 -/
 
-@[expose] public section
+public section
 
 open Function Multiset OrderDual
 

--- a/Mathlib/Data/Finset/Order.lean
+++ b/Mathlib/Data/Finset/Order.lean
@@ -13,7 +13,7 @@ public import Mathlib.Order.Directed
 # Finsets of ordered types
 -/
 
-@[expose] public section
+public section
 
 
 universe u v w

--- a/Mathlib/Data/Finset/PiInduction.lean
+++ b/Mathlib/Data/Finset/PiInduction.lean
@@ -27,7 +27,7 @@ finite type.
 finite set, finite type, induction, function
 -/
 
-@[expose] public section
+public section
 
 
 open Function

--- a/Mathlib/Data/Finset/SymmDiff.lean
+++ b/Mathlib/Data/Finset/SymmDiff.lean
@@ -19,7 +19,7 @@ finite sets, finset
 
 -/
 
-@[expose] public section
+public section
 
 -- Assert that we define `Finset` without the material on `List.sublists`.
 -- Note that we cannot use `List.sublists` itself as that is defined very early.

--- a/Mathlib/Data/Finsupp/BigOperators.lean
+++ b/Mathlib/Data/Finsupp/BigOperators.lean
@@ -33,7 +33,7 @@ it is a member of the support of a member of the collection:
 
 -/
 
-@[expose] public section
+public section
 
 
 variable {ι M : Type*} [DecidableEq ι]

--- a/Mathlib/Data/Finsupp/Ext.lean
+++ b/Mathlib/Data/Finsupp/Ext.lean
@@ -21,7 +21,7 @@ These have been moved to their own file to avoid depending on submonoids when de
 * `Finsupp.addHom_ext`: additive homomorphisms that are equal on each `single` are equal everywhere
 -/
 
-@[expose] public section
+public section
 
 variable {α M N : Type*}
 

--- a/Mathlib/Data/Finsupp/Notation.lean
+++ b/Mathlib/Data/Finsupp/Notation.lean
@@ -15,7 +15,7 @@ This file provides `fun₀ | 3 => a | 7 => b` notation for `Finsupp`, which desu
 `singleton`.
 -/
 
-@[expose] public section
+public section
 
 namespace Finsupp
 

--- a/Mathlib/Data/Fintype/BigOperators.lean
+++ b/Mathlib/Data/Fintype/BigOperators.lean
@@ -27,7 +27,7 @@ However many of the results here really belong in `Algebra.BigOperators.Group.Fi
 and should be moved at some point.
 -/
 
-@[expose] public section
+public section
 
 assert_not_exists MulAction
 

--- a/Mathlib/Data/Fintype/CardEmbedding.lean
+++ b/Mathlib/Data/Fintype/CardEmbedding.lean
@@ -16,7 +16,7 @@ public import Mathlib.Logic.Equiv.Embedding
 This file establishes the cardinality of `α ↪ β` in full generality.
 -/
 
-@[expose] public section
+public section
 
 
 local notation "|" x "|" => Finset.card x

--- a/Mathlib/Data/Fintype/Fin.lean
+++ b/Mathlib/Data/Fintype/Fin.lean
@@ -15,7 +15,7 @@ This file contains some basic results about the `Fintype` instance for `Fin`,
 especially properties of `Finset.univ : Finset (Fin n)`.
 -/
 
-@[expose] public section
+public section
 
 open List (Vector)
 

--- a/Mathlib/Data/Fintype/Lattice.lean
+++ b/Mathlib/Data/Fintype/Lattice.lean
@@ -12,7 +12,7 @@ public import Mathlib.Data.Fintype.Basic
 # Lemmas relating fintypes and order/lattice structure.
 -/
 
-@[expose] public section
+public section
 
 
 open Function

--- a/Mathlib/Data/Fintype/Pigeonhole.lean
+++ b/Mathlib/Data/Fintype/Pigeonhole.lean
@@ -24,7 +24,7 @@ We provide the following versions of the pigeonholes principle.
 Some more pigeonhole-like statements can be found in `Data.Fintype.CardEmbedding`.
 -/
 
-@[expose] public section
+public section
 
 assert_not_exists MonoidWithZero MulAction
 

--- a/Mathlib/Data/Int/AbsoluteValue.lean
+++ b/Mathlib/Data/Int/AbsoluteValue.lean
@@ -18,7 +18,7 @@ This file contains some results on absolute values applied to integers.
 * `AbsoluteValue.map_units_int`: an absolute value sends all units of `ℤ` to `1`
 -/
 
-@[expose] public section
+public section
 
 variable {R S : Type*} [Ring R] [CommRing S] [LinearOrder S] [IsStrictOrderedRing S]
 

--- a/Mathlib/Data/Int/Associated.lean
+++ b/Mathlib/Data/Int/Associated.lean
@@ -17,7 +17,7 @@ This file contains some results on equality up to units in the integers.
 * `Int.natAbs_eq_iff_associated`: the absolute value is equal iff integers are associated
 -/
 
-@[expose] public section
+public section
 
 
 theorem Int.natAbs_eq_iff_associated {a b : ℤ} : a.natAbs = b.natAbs ↔ Associated a b := by

--- a/Mathlib/Data/Int/CardIntervalMod.lean
+++ b/Mathlib/Data/Int/CardIntervalMod.lean
@@ -19,7 +19,7 @@ The theorems in this file generalise `Nat.card_multiples` in
 zero, which reduces to the multiples). Theorems are given for `Ico` and `Ioc` intervals.
 -/
 
-@[expose] public section
+public section
 
 
 open Finset Int

--- a/Mathlib/Data/Int/Cast/Basic.lean
+++ b/Mathlib/Data/Int/Cast/Basic.lean
@@ -23,7 +23,7 @@ By contrast, this file's only import beyond `Mathlib.Data.Int.Cast.Defs` is
 `Mathlib.Algebra.Group.Basic`.
 -/
 
-@[expose] public section
+public section
 
 
 universe u

--- a/Mathlib/Data/Int/Cast/Field.lean
+++ b/Mathlib/Data/Int/Cast/Field.lean
@@ -18,7 +18,7 @@ This file concerns the canonical homomorphism `ℤ → F`, where `F` is a field.
 * `Int.cast_div`: if `n` divides `m`, then `↑(m / n) = ↑m / ↑n`
 -/
 
-@[expose] public section
+public section
 
 
 namespace Int

--- a/Mathlib/Data/Int/CharZero.lean
+++ b/Mathlib/Data/Int/CharZero.lean
@@ -15,7 +15,7 @@ public import Mathlib.Data.Int.Cast.Pi
 
 -/
 
-@[expose] public section
+public section
 
 open Nat Set
 

--- a/Mathlib/Data/Int/DivMod.lean
+++ b/Mathlib/Data/Int/DivMod.lean
@@ -13,7 +13,7 @@ public import Mathlib.Init
 
 -/
 
-@[expose] public section
+public section
 
 namespace Int
 

--- a/Mathlib/Data/Int/Lemmas.lean
+++ b/Mathlib/Data/Int/Lemmas.lean
@@ -17,7 +17,7 @@ This file contains lemmas about integers, which require further imports than
 
 -/
 
-@[expose] public section
+public section
 
 
 open Nat

--- a/Mathlib/Data/Int/NatPrime.lean
+++ b/Mathlib/Data/Int/NatPrime.lean
@@ -13,7 +13,7 @@ public import Mathlib.Data.Int.Basic
 # Lemmas about `Nat.Prime` using `Int`s
 -/
 
-@[expose] public section
+public section
 
 
 open Nat

--- a/Mathlib/Data/Int/Notation.lean
+++ b/Mathlib/Data/Int/Notation.lean
@@ -10,6 +10,6 @@ public import Mathlib.Init
 # Notation `ℤ` for the integers.
 -/
 
-@[expose] public section
+public section
 
 @[inherit_doc] notation "ℤ" => Int

--- a/Mathlib/Data/Int/Order/Lemmas.lean
+++ b/Mathlib/Data/Int/Order/Lemmas.lean
@@ -15,7 +15,7 @@ They are separated by now to minimize the porting requirements for tactics durin
 mathlib4. Please feel free to reorganize these two files.
 -/
 
-@[expose] public section
+public section
 
 open Function Nat
 

--- a/Mathlib/Data/Int/Order/Units.lean
+++ b/Mathlib/Data/Int/Order/Units.lean
@@ -11,7 +11,7 @@ public import Mathlib.Algebra.Order.Ring.Abs
 # Lemmas about units in `ℤ`, which interact with the order structure.
 -/
 
-@[expose] public section
+public section
 
 
 namespace Int

--- a/Mathlib/Data/List/ChainOfFn.lean
+++ b/Mathlib/Data/List/ChainOfFn.lean
@@ -14,7 +14,7 @@ public import Mathlib.Data.List.OfFn
 This file provides lemmas involving both `List.IsChain` and `List.ofFn`.
 -/
 
-@[expose] public section
+public section
 
 open Nat
 

--- a/Mathlib/Data/List/Count.lean
+++ b/Mathlib/Data/List/Count.lean
@@ -15,7 +15,7 @@ This file proves basic properties of `List.countP` and `List.count`, which count
 elements of a list satisfying a predicate and equal to a given element respectively.
 -/
 
-@[expose] public section
+public section
 
 assert_not_exists Monoid Set.range
 

--- a/Mathlib/Data/List/Dedup.lean
+++ b/Mathlib/Data/List/Dedup.lean
@@ -21,7 +21,7 @@ occurrence of each.
 duplicate, multiplicity, nodup, `nub`
 -/
 
-@[expose] public section
+public section
 
 
 universe u

--- a/Mathlib/Data/List/Destutter.lean
+++ b/Mathlib/Data/List/Destutter.lean
@@ -28,7 +28,7 @@ Note that we make no guarantees of being the longest sublist with this property;
 adjacent, chain, duplicates, remove, list, stutter, destutter
 -/
 
-@[expose] public section
+public section
 
 open Function
 

--- a/Mathlib/Data/List/Enum.lean
+++ b/Mathlib/Data/List/Enum.lean
@@ -11,7 +11,7 @@ public import Mathlib.Data.List.Basic
 # Properties of `List.enum`
 -/
 
-@[expose] public section
+public section
 
 namespace List
 

--- a/Mathlib/Data/List/FinRange.lean
+++ b/Mathlib/Data/List/FinRange.lean
@@ -15,7 +15,7 @@ public import Mathlib.Data.List.Nodup
 This file develops some results on `finRange n`.
 -/
 
-@[expose] public section
+public section
 
 assert_not_exists Monoid
 

--- a/Mathlib/Data/List/Flatten.lean
+++ b/Mathlib/Data/List/Flatten.lean
@@ -15,7 +15,7 @@ This file proves basic properties of `List.flatten`, which concatenates a list o
 defined in `Init.Prelude`.
 -/
 
-@[expose] public section
+public section
 
 -- Make sure we don't import algebra
 assert_not_exists Monoid

--- a/Mathlib/Data/List/Indexes.lean
+++ b/Mathlib/Data/List/Indexes.lean
@@ -22,7 +22,7 @@ Anyone wanting to restore this material is welcome to do so, but will need to up
 However, note that this material will later be implemented in the Lean standard library.
 -/
 
-@[expose] public section
+public section
 
 assert_not_exists MonoidWithZero
 

--- a/Mathlib/Data/List/InsertIdx.lean
+++ b/Mathlib/Data/List/InsertIdx.lean
@@ -13,7 +13,7 @@ public import Mathlib.Data.List.Basic
 Proves various lemmas about `List.insertIdx`.
 -/
 
-@[expose] public section
+public section
 
 assert_not_exists Set.range Preorder
 

--- a/Mathlib/Data/List/InsertNth.lean
+++ b/Mathlib/Data/List/InsertNth.lean
@@ -14,4 +14,4 @@ which has been renamed to `Mathlib/Data/List/InsertIdx.lean`.
 This file can be removed once the deprecation for `List.insertNth` is removed.
 -/
 
-@[expose] public section
+public section

--- a/Mathlib/Data/List/Iterate.lean
+++ b/Mathlib/Data/List/Iterate.lean
@@ -15,7 +15,7 @@ public import Mathlib.Data.Set.Function
 Proves various lemmas about `List.iterate`.
 -/
 
-@[expose] public section
+public section
 
 variable {α : Type*}
 

--- a/Mathlib/Data/List/Lattice.lean
+++ b/Mathlib/Data/List/Lattice.lean
@@ -26,7 +26,7 @@ As opposed to `List.inter`, `List.bagInter` copes well with multiplicity. For ex
 `bagInter [0, 1, 2, 3, 2, 1, 0] [1, 0, 1, 4, 3] = [0, 1, 3, 1]`.
 -/
 
-@[expose] public section
+public section
 
 
 open Nat

--- a/Mathlib/Data/List/Lemmas.lean
+++ b/Mathlib/Data/List/Lemmas.lean
@@ -13,7 +13,7 @@ public import Mathlib.Data.List.InsertIdx
 Split out from `Data.List.Basic` to reduce its dependencies.
 -/
 
-@[expose] public section
+public section
 
 variable {α β γ : Type*}
 

--- a/Mathlib/Data/List/Lookmap.lean
+++ b/Mathlib/Data/List/Lookmap.lean
@@ -12,7 +12,7 @@ import all Init.Data.Array.Basic
 
 /-! ### lookmap -/
 
-@[expose] public section
+public section
 
 variable {α β : Type*}
 

--- a/Mathlib/Data/List/Map2.lean
+++ b/Mathlib/Data/List/Map2.lean
@@ -22,7 +22,7 @@ Lists together. In particular, we include lemmas about:
 
 -/
 
-@[expose] public section
+public section
 
 assert_not_exists GroupWithZero
 assert_not_exists Lattice

--- a/Mathlib/Data/List/ModifyLast.lean
+++ b/Mathlib/Data/List/ModifyLast.lean
@@ -12,7 +12,7 @@ import all Init.Data.Array.Basic
 
 /-! ### List.modifyLast -/
 
-@[expose] public section
+public section
 
 variable {α : Type*}
 

--- a/Mathlib/Data/List/Nodup.lean
+++ b/Mathlib/Data/List/Nodup.lean
@@ -16,7 +16,7 @@ public import Mathlib.Order.Basic
 predicate.
 -/
 
-@[expose] public section
+public section
 
 universe u v
 

--- a/Mathlib/Data/List/Pairwise.lean
+++ b/Mathlib/Data/List/Pairwise.lean
@@ -26,7 +26,7 @@ the pairwiseness of the list we have so far. It thus yields `l'` a maximal subli
 sorted, nodup
 -/
 
-@[expose] public section
+public section
 
 
 open Nat Function

--- a/Mathlib/Data/List/Perm/Lattice.lean
+++ b/Mathlib/Data/List/Perm/Lattice.lean
@@ -16,7 +16,7 @@ public import Mathlib.Data.List.Nodup
 This file develops theory about the `List.Perm` relation and the lattice structure on lists.
 -/
 
-@[expose] public section
+public section
 
 -- Make sure we don't import algebra
 assert_not_exists Monoid

--- a/Mathlib/Data/List/Perm/Subperm.lean
+++ b/Mathlib/Data/List/Perm/Subperm.lean
@@ -18,7 +18,7 @@ This file develops theory about the `List.Subperm` relation.
 The notation `<+~` is used for sub-permutations.
 -/
 
-@[expose] public section
+public section
 
 open Nat
 

--- a/Mathlib/Data/List/Permutation.lean
+++ b/Mathlib/Data/List/Permutation.lean
@@ -47,7 +47,7 @@ all positions. Hence, to build `[0, 1, 2, 3].permutations'`, it does
    `[0, 3, 2, 1], [3, 0, 2, 1], [3, 2, 0, 1], [3, 2, 1, 0]]`
 -/
 
-@[expose] public section
+public section
 
 -- Make sure we don't import algebra
 assert_not_exists Monoid

--- a/Mathlib/Data/List/Prime.lean
+++ b/Mathlib/Data/List/Prime.lean
@@ -15,7 +15,7 @@ This file contains some theorems relating `Prime` and products of `List`s.
 
 -/
 
-@[expose] public section
+public section
 
 
 open List

--- a/Mathlib/Data/List/ProdSigma.lean
+++ b/Mathlib/Data/List/ProdSigma.lean
@@ -15,7 +15,7 @@ living in `Prod` and `Sigma` types respectively. Their definitions can be found 
 [`Data.List.Defs`](./defs). Beware, this is not about `List.prod`, the multiplicative product.
 -/
 
-@[expose] public section
+public section
 
 
 variable {α β : Type*}

--- a/Mathlib/Data/List/ReduceOption.lean
+++ b/Mathlib/Data/List/ReduceOption.lean
@@ -13,7 +13,7 @@ public import Mathlib.Data.List.Basic
 In this file we prove basic lemmas about `List.reduceOption`.
 -/
 
-@[expose] public section
+public section
 
 namespace List
 

--- a/Mathlib/Data/List/Sections.lean
+++ b/Mathlib/Data/List/Sections.lean
@@ -13,7 +13,7 @@ This file proves some stuff about `List.sections` (definition in `Data.List.Defs
 list of lists `[l₁, ..., lₙ]` is a list whose `i`-th element comes from the `i`-th list.
 -/
 
-@[expose] public section
+public section
 
 
 open Nat Function

--- a/Mathlib/Data/List/SplitBy.lean
+++ b/Mathlib/Data/List/SplitBy.lean
@@ -21,7 +21,7 @@ The main results are the following:
   related to the first element of the next list.
 -/
 
-@[expose] public section
+public section
 
 namespace List
 

--- a/Mathlib/Data/List/SplitOn.lean
+++ b/Mathlib/Data/List/SplitOn.lean
@@ -9,7 +9,7 @@ public import Mathlib.Data.List.Basic
 
 /-! ### List.splitOn -/
 
-@[expose] public section
+public section
 
 namespace List
 

--- a/Mathlib/Data/List/TakeDrop.lean
+++ b/Mathlib/Data/List/TakeDrop.lean
@@ -14,7 +14,7 @@ public import Mathlib.Tactic.Common
 This file provides lemmas about `List.take` and `List.drop` and related functions.
 -/
 
-@[expose] public section
+public section
 
 assert_not_exists GroupWithZero
 assert_not_exists Lattice

--- a/Mathlib/Data/List/TakeWhile.lean
+++ b/Mathlib/Data/List/TakeWhile.lean
@@ -11,7 +11,7 @@ public import Mathlib.Tactic.Set
 
 /-! ### List.takeWhile and List.dropWhile -/
 
-@[expose] public section
+public section
 
 namespace List
 

--- a/Mathlib/Data/Matrix/Auto.lean
+++ b/Mathlib/Data/Matrix/Auto.lean
@@ -26,4 +26,4 @@ TODO: These magic lemmas have been skipped for now, though the plumbing lemmas i
 They should probably be implemented as simprocs.
 -/
 
-@[expose] public section
+public section

--- a/Mathlib/Data/Multiset/Pairwise.lean
+++ b/Mathlib/Data/Multiset/Pairwise.lean
@@ -15,7 +15,7 @@ This file provides basic results about `Multiset.Pairwise` (definitions are in
 `Mathlib/Data/Multiset/Defs.lean`).
 -/
 
-@[expose] public section
+public section
 
 namespace Multiset
 

--- a/Mathlib/Data/NNRat/BigOperators.lean
+++ b/Mathlib/Data/NNRat/BigOperators.lean
@@ -11,7 +11,7 @@ public import Mathlib.Data.NNRat.Defs
 /-! # Casting lemmas for non-negative rational numbers involving sums and products
 -/
 
-@[expose] public section
+public section
 
 variable {α : Type*}
 

--- a/Mathlib/Data/NNReal/Basic.lean
+++ b/Mathlib/Data/NNReal/Basic.lean
@@ -24,7 +24,7 @@ As a consequence, it is a bit of a random collection of results, and is a good t
 This file uses `ℝ≥0` as a localized notation for `NNReal`.
 -/
 
-@[expose] public section
+public section
 
 assert_not_exists TrivialStar
 

--- a/Mathlib/Data/Nat/Bitwise.lean
+++ b/Mathlib/Data/Nat/Bitwise.lean
@@ -42,7 +42,7 @@ should be connected.
 bitwise, and, or, xor
 -/
 
-@[expose] public section
+public section
 
 open Function
 

--- a/Mathlib/Data/Nat/Cast/Commute.lean
+++ b/Mathlib/Data/Nat/Cast/Commute.lean
@@ -13,7 +13,7 @@ public import Mathlib.Algebra.Ring.Commute
 
 -/
 
-@[expose] public section
+public section
 
 variable {α : Type*}
 

--- a/Mathlib/Data/Nat/Cast/Field.lean
+++ b/Mathlib/Data/Nat/Cast/Field.lean
@@ -21,7 +21,7 @@ This file concerns the canonical homomorphism `ℕ → F`, where `F` is a field.
 * `Nat.cast_div`: if `n` divides `m`, then `↑(m / n) = ↑m / ↑n`
 -/
 
-@[expose] public section
+public section
 
 
 namespace Nat

--- a/Mathlib/Data/Nat/Cast/NeZero.lean
+++ b/Mathlib/Data/Nat/Cast/NeZero.lean
@@ -11,7 +11,7 @@ public import Mathlib.Data.Nat.Cast.Defs
 # Lemmas about nonzero elements of an `AddMonoidWithOne`
 -/
 
-@[expose] public section
+public section
 
 open Nat
 

--- a/Mathlib/Data/Nat/Cast/Order/Field.lean
+++ b/Mathlib/Data/Nat/Cast/Order/Field.lean
@@ -17,7 +17,7 @@ This file concerns the canonical homomorphism `ℕ → F`, where `F` is a `Linea
 * `Nat.cast_div_le`: in all cases, `↑(m / n) ≤ ↑m / ↑ n`
 -/
 
-@[expose] public section
+public section
 
 
 namespace Nat

--- a/Mathlib/Data/Nat/Cast/Order/Ring.lean
+++ b/Mathlib/Data/Nat/Cast/Order/Ring.lean
@@ -15,7 +15,7 @@ public import Mathlib.Data.Nat.Cast.Order.Basic
 
 -/
 
-@[expose] public section
+public section
 
 variable {R α : Type*}
 

--- a/Mathlib/Data/Nat/Cast/SetInterval.lean
+++ b/Mathlib/Data/Nat/Cast/SetInterval.lean
@@ -18,7 +18,7 @@ In this file we prove that the image of each `Set.Ixx` interval under `Nat.cast 
 is the corresponding interval in `ℤ`.
 -/
 
-@[expose] public section
+public section
 
 open Set
 

--- a/Mathlib/Data/Nat/Choose/Bounds.lean
+++ b/Mathlib/Data/Nat/Choose/Bounds.lean
@@ -22,7 +22,7 @@ bounds `n^r/r^r ≤ n.choose r ≤ e^r n^r/r^r` in the future.
 * `Nat.pow_le_choose`: `(n + 1 - r)^r / r! ≤ n.choose r`. Beware of the fishy ℕ-subtraction.
 -/
 
-@[expose] public section
+public section
 
 
 open Nat

--- a/Mathlib/Data/Nat/Choose/Cast.lean
+++ b/Mathlib/Data/Nat/Choose/Cast.lean
@@ -17,7 +17,7 @@ This file allows calculating the binomial coefficient `a.choose b` as an element
 of characteristic `0`.
 -/
 
-@[expose] public section
+public section
 
 
 open Nat

--- a/Mathlib/Data/Nat/Choose/Dvd.lean
+++ b/Mathlib/Data/Nat/Choose/Dvd.lean
@@ -12,7 +12,7 @@ public import Mathlib.Data.Nat.Prime.Factorial
 # Divisibility properties of binomial coefficients
 -/
 
-@[expose] public section
+public section
 
 
 namespace Nat

--- a/Mathlib/Data/Nat/Choose/Factorization.lean
+++ b/Mathlib/Data/Nat/Choose/Factorization.lean
@@ -28,7 +28,7 @@ bounds in binomial coefficients. These include:
 These results appear in the [Erdős proof of Bertrand's postulate](aigner1999proofs).
 -/
 
-@[expose] public section
+public section
 
 open Finset List Finsupp
 

--- a/Mathlib/Data/Nat/Choose/Lucas.lean
+++ b/Mathlib/Data/Nat/Choose/Lucas.lean
@@ -23,7 +23,7 @@ respectively.
   k_i` modulo `p`, where `n_i` and `k_i` are the base-`p` digits of `n` and `k`, respectively.
 -/
 
-@[expose] public section
+public section
 
 open Finset hiding choose
 

--- a/Mathlib/Data/Nat/Choose/Sum.lean
+++ b/Mathlib/Data/Nat/Choose/Sum.lean
@@ -20,7 +20,7 @@ coefficients. Theorems whose proofs depend on such sums may also go in this file
 reasons.
 -/
 
-@[expose] public section
+public section
 
 open Nat Finset
 

--- a/Mathlib/Data/Nat/Choose/Vandermonde.lean
+++ b/Mathlib/Data/Nat/Choose/Vandermonde.lean
@@ -20,7 +20,7 @@ https://en.wikipedia.org/wiki/Vandermonde%27s_identity#Algebraic_proof .
 
 -/
 
-@[expose] public section
+public section
 
 
 open Polynomial Finset Finset.Nat

--- a/Mathlib/Data/Nat/Digits/Div.lean
+++ b/Mathlib/Data/Nat/Digits/Div.lean
@@ -16,7 +16,7 @@ Theorem #85 from https://www.cs.ru.nl/~freek/100/.
 
 -/
 
-@[expose] public section
+public section
 
 namespace Nat
 

--- a/Mathlib/Data/Nat/Digits/Lemmas.lean
+++ b/Mathlib/Data/Nat/Digits/Lemmas.lean
@@ -19,7 +19,7 @@ public import Mathlib.Data.Nat.Digits.Defs
 This provides lemma about the digits of natural numbers.
 -/
 
-@[expose] public section
+public section
 
 namespace Nat
 

--- a/Mathlib/Data/Nat/Factorial/BigOperators.lean
+++ b/Mathlib/Data/Nat/Factorial/BigOperators.lean
@@ -18,7 +18,7 @@ While in terms of semantics they could be in the `Basic.lean` file, importing
 
 -/
 
-@[expose] public section
+public section
 
 
 open Finset Nat

--- a/Mathlib/Data/Nat/Factorial/Cast.lean
+++ b/Mathlib/Data/Nat/Factorial/Cast.lean
@@ -20,7 +20,7 @@ to subtraction on a general semiring. For example, we can't rely on existing cas
 to `↑a - 1`, the other factor is `0` anyway.
 -/
 
-@[expose] public section
+public section
 
 
 open Nat

--- a/Mathlib/Data/Nat/Factorial/NatCast.lean
+++ b/Mathlib/Data/Nat/Factorial/NatCast.lean
@@ -18,7 +18,7 @@ to be a unit.
 
 -/
 
-@[expose] public section
+public section
 
 namespace IsUnit
 

--- a/Mathlib/Data/Nat/Factorization/Basic.lean
+++ b/Mathlib/Data/Nat/Factorization/Basic.lean
@@ -13,7 +13,7 @@ public import Mathlib.Order.Interval.Finset.Nat
 # Basic lemmas on prime factorizations
 -/
 
-@[expose] public section
+public section
 
 open Finset List Finsupp
 

--- a/Mathlib/Data/Nat/Factorization/LCM.lean
+++ b/Mathlib/Data/Nat/Factorization/LCM.lean
@@ -15,7 +15,7 @@ This file contains some lemmas about `factorizationLCMLeft`.
 These were split from `Mathlib.Data.Nat.Factorization.Basic` to reduce transitive imports.
 -/
 
-@[expose] public section
+public section
 
 open Finset List Finsupp
 

--- a/Mathlib/Data/Nat/GCD/Basic.lean
+++ b/Mathlib/Data/Nat/GCD/Basic.lean
@@ -23,7 +23,7 @@ Note that the global `IsCoprime` is not a straightforward generalization of `Nat
 Most of this file could be moved to batteries as well.
 -/
 
-@[expose] public section
+public section
 
 assert_not_exists IsOrderedMonoid
 

--- a/Mathlib/Data/Nat/GCD/BigOperators.lean
+++ b/Mathlib/Data/Nat/GCD/BigOperators.lean
@@ -12,7 +12,7 @@ public import Mathlib.Algebra.BigOperators.Group.Finset.Defs
 These lemmas are kept separate from `Data.Nat.GCD.Basic` in order to minimize imports.
 -/
 
-@[expose] public section
+public section
 
 
 namespace Nat

--- a/Mathlib/Data/Nat/GCD/Prime.lean
+++ b/Mathlib/Data/Nat/GCD/Prime.lean
@@ -22,7 +22,7 @@ These lemmas are kept separate from `Mathlib/Data/Nat/GCD/Basic.lean` in order t
 
 -/
 
-@[expose] public section
+public section
 
 namespace Nat
 

--- a/Mathlib/Data/Nat/Multiplicity.lean
+++ b/Mathlib/Data/Nat/Multiplicity.lean
@@ -45,7 +45,7 @@ Derive results from the corresponding ones `Mathlib.Data.Nat.Factorization.Multi
 Legendre, p-adic
 -/
 
-@[expose] public section
+public section
 
 open Finset
 

--- a/Mathlib/Data/Nat/Notation.lean
+++ b/Mathlib/Data/Nat/Notation.lean
@@ -11,6 +11,6 @@ public import Mathlib.Init
 # Notation `ℕ` for the natural numbers.
 -/
 
-@[expose] public section
+public section
 
 @[inherit_doc] notation "ℕ" => Nat

--- a/Mathlib/Data/Nat/Periodic.lean
+++ b/Mathlib/Data/Nat/Periodic.lean
@@ -15,7 +15,7 @@ This file identifies a few functions on `ℕ` which are periodic, and also prove
 periodic predicates which helps determine their cardinality when filtering intervals over them.
 -/
 
-@[expose] public section
+public section
 
 assert_not_exists TwoSidedIdeal
 

--- a/Mathlib/Data/Nat/Prime/Basic.lean
+++ b/Mathlib/Data/Nat/Prime/Basic.lean
@@ -17,7 +17,7 @@ This file develops the theory of prime numbers: natural numbers `p ≥ 2` whose 
 
 -/
 
-@[expose] public section
+public section
 
 namespace Nat
 variable {n : ℕ}

--- a/Mathlib/Data/Nat/Prime/Factorial.lean
+++ b/Mathlib/Data/Nat/Prime/Factorial.lean
@@ -12,7 +12,7 @@ public import Mathlib.Data.Nat.Prime.Basic
 
 -/
 
-@[expose] public section
+public section
 
 open Bool Subtype
 

--- a/Mathlib/Data/Nat/Prime/Infinite.lean
+++ b/Mathlib/Data/Nat/Prime/Infinite.lean
@@ -18,7 +18,7 @@ public import Mathlib.Order.Bounds.Basic
 
 -/
 
-@[expose] public section
+public section
 
 open Bool Subtype
 

--- a/Mathlib/Data/Nat/Prime/Int.lean
+++ b/Mathlib/Data/Nat/Prime/Int.lean
@@ -16,7 +16,7 @@ public import Mathlib.Data.Int.Basic
 TODO: This file can probably be merged with `Mathlib/Data/Int/NatPrime.lean`.
 -/
 
-@[expose] public section
+public section
 
 
 namespace Nat

--- a/Mathlib/Data/Nat/Prime/Nth.lean
+++ b/Mathlib/Data/Nat/Prime/Nth.lean
@@ -12,7 +12,7 @@ public import Mathlib.Data.Nat.Nth
 # The Nth primes
 -/
 
-@[expose] public section
+public section
 
 namespace Nat
 

--- a/Mathlib/Data/Nat/Prime/Pow.lean
+++ b/Mathlib/Data/Nat/Prime/Pow.lean
@@ -16,7 +16,7 @@ This file develops the theory of prime numbers: natural numbers `p ≥ 2` whose 
 
 -/
 
-@[expose] public section
+public section
 
 namespace Nat
 

--- a/Mathlib/Data/Nat/Set.lean
+++ b/Mathlib/Data/Nat/Set.lean
@@ -11,7 +11,7 @@ public import Mathlib.Data.Set.Image
 ### Recursion on the natural numbers and `Set.range`
 -/
 
-@[expose] public section
+public section
 
 
 namespace Nat

--- a/Mathlib/Data/Nat/Size.lean
+++ b/Mathlib/Data/Nat/Size.lean
@@ -12,7 +12,7 @@ public import Mathlib.Data.Nat.Basic
 
 /-! Lemmas about `size`. -/
 
-@[expose] public section
+public section
 
 namespace Nat
 

--- a/Mathlib/Data/Nat/Sqrt.lean
+++ b/Mathlib/Data/Nat/Sqrt.lean
@@ -12,7 +12,7 @@ public import Batteries.Data.Nat.Basic
 # Properties of the natural number square root function.
 -/
 
-@[expose] public section
+public section
 
 namespace Nat
 

--- a/Mathlib/Data/Ordering/Lemmas.lean
+++ b/Mathlib/Data/Ordering/Lemmas.lean
@@ -12,7 +12,7 @@ public import Mathlib.Order.Defs.Unbundled
 # Some `Ordering` lemmas
 -/
 
-@[expose] public section
+public section
 
 universe u
 

--- a/Mathlib/Data/Rat/BigOperators.lean
+++ b/Mathlib/Data/Rat/BigOperators.lean
@@ -11,7 +11,7 @@ public import Mathlib.Algebra.BigOperators.Group.Finset.Defs
 /-! # Casting lemmas for rational numbers involving sums and products
 -/
 
-@[expose] public section
+public section
 
 variable {ι α : Type*}
 

--- a/Mathlib/Data/Rat/Cardinal.lean
+++ b/Mathlib/Data/Rat/Cardinal.lean
@@ -16,7 +16,7 @@ public import Mathlib.SetTheory.Cardinal.Basic
 This file proves that the Cardinality of ℚ is ℵ₀
 -/
 
-@[expose] public section
+public section
 
 assert_not_exists Module Field
 

--- a/Mathlib/Data/Rat/Cast/Lemmas.lean
+++ b/Mathlib/Data/Rat/Cast/Lemmas.lean
@@ -19,7 +19,7 @@ In fact, these lemmas don't appear to be used anywhere in Mathlib,
 so perhaps this file can simply be deleted.
 -/
 
-@[expose] public section
+public section
 
 namespace Rat
 

--- a/Mathlib/Data/Rat/NatSqrt/Real.lean
+++ b/Mathlib/Data/Rat/NatSqrt/Real.lean
@@ -13,7 +13,7 @@ Comparisons between rational approximations to the square root of a natural numb
 and the real square root.
 -/
 
-@[expose] public section
+public section
 
 namespace Nat
 

--- a/Mathlib/Data/Real/Pointwise.lean
+++ b/Mathlib/Data/Real/Pointwise.lean
@@ -23,7 +23,7 @@ This is true more generally for conditionally complete linear order whose defaul
 don't have those yet.
 -/
 
-@[expose] public section
+public section
 
 assert_not_exists Finset
 

--- a/Mathlib/Data/Set/Card/Arithmetic.lean
+++ b/Mathlib/Data/Set/Card/Arithmetic.lean
@@ -22,7 +22,7 @@ It has been separated out to not burden `Mathlib/Data/Set/Card.lean` with extra 
 - `exists_union_disjoint_cardinal_eq_iff` is the same, except using cardinal notation.
 -/
 
-@[expose] public section
+public section
 
 variable {α ι : Type*}
 

--- a/Mathlib/Data/Set/Disjoint.lean
+++ b/Mathlib/Data/Set/Disjoint.lean
@@ -11,7 +11,7 @@ public import Mathlib.Data.Set.Basic
 # Theorems about the `Disjoint` relation on `Set`.
 -/
 
-@[expose] public section
+public section
 
 assert_not_exists HeytingAlgebra RelIso
 

--- a/Mathlib/Data/Set/Finite/Lemmas.lean
+++ b/Mathlib/Data/Set/Finite/Lemmas.lean
@@ -22,7 +22,7 @@ If your proof has as *result* `Set.Finite`, then it should go to a more specific
 finite sets
 -/
 
-@[expose] public section
+public section
 
 assert_not_exists IsOrderedRing MonoidWithZero
 

--- a/Mathlib/Data/Set/Finite/List.lean
+++ b/Mathlib/Data/Set/Finite/List.lean
@@ -19,7 +19,7 @@ public import Mathlib.Data.Finite.Vector
 finite sets
 -/
 
-@[expose] public section
+public section
 
 assert_not_exists IsOrderedRing MonoidWithZero
 

--- a/Mathlib/Data/Set/Finite/Powerset.lean
+++ b/Mathlib/Data/Set/Finite/Powerset.lean
@@ -21,7 +21,7 @@ and a `Set.Finite` constructor.
 finite sets
 -/
 
-@[expose] public section
+public section
 
 assert_not_exists IsOrderedRing MonoidWithZero
 

--- a/Mathlib/Data/Set/Lattice/Image.lean
+++ b/Mathlib/Data/Set/Lattice/Image.lean
@@ -37,7 +37,7 @@ In lemma names,
 * `⋂₀`: `Set.sInter`
 -/
 
-@[expose] public section
+public section
 
 open Function Set
 

--- a/Mathlib/Data/Set/Monotone.lean
+++ b/Mathlib/Data/Set/Monotone.lean
@@ -11,7 +11,7 @@ public import Mathlib.Data.Set.Function
 # Monotone functions over sets
 -/
 
-@[expose] public section
+public section
 
 variable {α β γ : Type*}
 

--- a/Mathlib/Data/Set/NAry.lean
+++ b/Mathlib/Data/Set/NAry.lean
@@ -19,7 +19,7 @@ This file is very similar to `Mathlib/Data/Finset/NAry.lean`, `Mathlib/Order/Fil
 `Mathlib/Data/Option/NAry.lean`. Please keep them in sync.
 -/
 
-@[expose] public section
+public section
 
 open Function
 

--- a/Mathlib/Data/Set/Order.lean
+++ b/Mathlib/Data/Set/Order.lean
@@ -11,7 +11,7 @@ public import Mathlib.Data.Set.Basic
 # Order structures and monotonicity lemmas for `Set`
 -/
 
-@[expose] public section
+public section
 
 open Function
 

--- a/Mathlib/Data/Set/Pairwise/Chain.lean
+++ b/Mathlib/Data/Set/Pairwise/Chain.lean
@@ -14,7 +14,7 @@ public import Mathlib.Order.Preorder.Chain
 In this file `Pairwise` results are applied to chains of sets.
 -/
 
-@[expose] public section
+public section
 
 open Set
 

--- a/Mathlib/Data/Set/Pairwise/List.lean
+++ b/Mathlib/Data/Set/Pairwise/List.lean
@@ -14,7 +14,7 @@ public import Mathlib.Data.Set.Pairwise.Basic
 On a list with no duplicates, the condition of `Set.Pairwise` and `List.Pairwise` are equivalent.
 -/
 
-@[expose] public section
+public section
 
 
 variable {α : Type*} {r : α → α → Prop}

--- a/Mathlib/Data/Set/Piecewise.lean
+++ b/Mathlib/Data/Set/Piecewise.lean
@@ -13,7 +13,7 @@ public import Mathlib.Data.Set.Function
 This file contains basic results on piecewise defined functions.
 -/
 
-@[expose] public section
+public section
 
 variable {α β γ δ : Type*} {ι : Sort*} {π : α → Type*}
 

--- a/Mathlib/Data/Set/Pointwise/Support.lean
+++ b/Mathlib/Data/Set/Pointwise/Support.lean
@@ -14,7 +14,7 @@ public import Mathlib.Algebra.Notation.Support
 We show that the support of `x ↦ f (c⁻¹ • x)` is equal to `c • support f`.
 -/
 
-@[expose] public section
+public section
 
 
 open Pointwise

--- a/Mathlib/Data/Set/Subset.lean
+++ b/Mathlib/Data/Set/Subset.lean
@@ -39,7 +39,7 @@ Theorem names refer to `↓∩` as `preimage_val`.
 subsets
 -/
 
-@[expose] public section
+public section
 
 open Set
 

--- a/Mathlib/Data/Set/SymmDiff.lean
+++ b/Mathlib/Data/Set/SymmDiff.lean
@@ -10,7 +10,7 @@ public import Mathlib.Order.SymmDiff
 
 /-! # Symmetric differences of sets -/
 
-@[expose] public section
+public section
 
 assert_not_exists RelIso
 

--- a/Mathlib/Data/Setoid/Partition/Card.lean
+++ b/Mathlib/Data/Setoid/Partition/Card.lean
@@ -16,7 +16,7 @@ public import Mathlib.Data.Setoid.Partition
 
 -/
 
-@[expose] public section
+public section
 
 section Finite
 

--- a/Mathlib/Data/String/Lemmas.lean
+++ b/Mathlib/Data/String/Lemmas.lean
@@ -14,7 +14,7 @@ public import Batteries.Tactic.Alias
 # Miscellaneous lemmas about strings
 -/
 
-@[expose] public section
+public section
 
 namespace String
 

--- a/Mathlib/Data/Sym/Sym2/Init.lean
+++ b/Mathlib/Data/Sym/Sym2/Init.lean
@@ -16,6 +16,6 @@ visible once the file in which they're declared is imported, so we must put this
 declaration into its own file.
 -/
 
-@[expose] public section
+public section
 
 declare_aesop_rule_sets [Sym2]

--- a/Mathlib/Data/Tree/RBMap.lean
+++ b/Mathlib/Data/Tree/RBMap.lean
@@ -23,7 +23,7 @@ Implement a `Traversable` instance for `Tree`.
 <https://leanprover-community.github.io/archive/stream/113488-general/topic/tactic.20question.html>
 -/
 
-@[expose] public section
+public section
 
 namespace Tree
 

--- a/Mathlib/Data/Vector/MapLemmas.lean
+++ b/Mathlib/Data/Vector/MapLemmas.lean
@@ -12,7 +12,7 @@ public import Mathlib.Data.Vector.Snoc
   This file establishes a set of normalization lemmas for `map`/`mapAccumr` operations on vectors
 -/
 
-@[expose] public section
+public section
 
 variable {α β γ ζ σ σ₁ σ₂ φ : Type*} {n : ℕ} {s : σ} {s₁ : σ₁} {s₂ : σ₂}
 

--- a/Mathlib/Data/Vector/Mem.lean
+++ b/Mathlib/Data/Vector/Mem.lean
@@ -17,7 +17,7 @@ In particular we can avoid some assumptions about types being `Inhabited`,
   and make more general statements about `head` and `tail`.
 -/
 
-@[expose] public section
+public section
 
 namespace List
 

--- a/Mathlib/Data/W/Cardinal.lean
+++ b/Mathlib/Data/W/Cardinal.lean
@@ -24,7 +24,7 @@ this surjection can be used to put an upper bound on the cardinality of `MvPolyn
 W, W type, cardinal, first order
 -/
 
-@[expose] public section
+public section
 
 
 universe u v

--- a/Mathlib/Data/ZMod/Coprime.lean
+++ b/Mathlib/Data/ZMod/Coprime.lean
@@ -18,7 +18,7 @@ We show that for prime `p`, the image of an integer `a` in `ZMod p` vanishes if 
 `a` and `p` are not coprime.
 -/
 
-@[expose] public section
+public section
 
 assert_not_exists TwoSidedIdeal
 

--- a/Mathlib/Data/ZMod/Factorial.lean
+++ b/Mathlib/Data/ZMod/Factorial.lean
@@ -25,7 +25,7 @@ For the prime case and involving `factorial` rather than `descFactorial`, see Wi
 
 -/
 
-@[expose] public section
+public section
 
 assert_not_exists TwoSidedIdeal
 


### PR DESCRIPTION
Removes `@[expose]` from 146 files in Data.

🤖 Prepared with Claude Code