### PR TITLE
[Merged by Bors] - chore(MeasureTheory): remove unnecessary @[expose] from public sections

### DIFF
--- a/Mathlib/MeasureTheory/Constructions/BorelSpace/Metric.lean
+++ b/Mathlib/MeasureTheory/Constructions/BorelSpace/Metric.lean
@@ -25,7 +25,7 @@ public import Mathlib.Topology.MetricSpace.Thickening
 
 -/
 
-@[expose] public section
+public section
 
 open Set Filter MeasureTheory MeasurableSpace TopologicalSpace
 

--- a/Mathlib/MeasureTheory/Constructions/BorelSpace/Metrizable.lean
+++ b/Mathlib/MeasureTheory/Constructions/BorelSpace/Metrizable.lean
@@ -14,7 +14,7 @@ public import Mathlib.Topology.IndicatorConstPointwise
 # Measurable functions in (pseudo-)metrizable Borel spaces
 -/
 
-@[expose] public section
+public section
 
 open Filter MeasureTheory TopologicalSpace Topology NNReal ENNReal MeasureTheory
 

--- a/Mathlib/MeasureTheory/Constructions/Polish/StronglyMeasurable.lean
+++ b/Mathlib/MeasureTheory/Constructions/Polish/StronglyMeasurable.lean
@@ -21,7 +21,7 @@ can be extended to strongly measurable functions without assuming separability o
 The purpose of this file is to collect those results.
 -/
 
-@[expose] public section
+public section
 
 open Filter MeasureTheory Set TopologicalSpace
 

--- a/Mathlib/MeasureTheory/Covering/LiminfLimsup.lean
+++ b/Mathlib/MeasureTheory/Covering/LiminfLimsup.lean
@@ -25,7 +25,7 @@ carrying a uniformly locally doubling measure.
 
 -/
 
-@[expose] public section
+public section
 
 
 open Set Filter Metric MeasureTheory TopologicalSpace

--- a/Mathlib/MeasureTheory/Covering/OneDim.lean
+++ b/Mathlib/MeasureTheory/Covering/OneDim.lean
@@ -16,7 +16,7 @@ in `DensityTheorem.lean`. In this file, we expand the API for this theory in one
 by showing that intervals belong to the relevant Vitali family.
 -/
 
-@[expose] public section
+public section
 
 
 open Set MeasureTheory IsUnifLocDoublingMeasure Filter

--- a/Mathlib/MeasureTheory/Function/AEEqOfIntegral.lean
+++ b/Mathlib/MeasureTheory/Function/AEEqOfIntegral.lean
@@ -44,7 +44,7 @@ Generally useful lemmas which are not related to integrals:
 
 -/
 
-@[expose] public section
+public section
 
 
 open MeasureTheory TopologicalSpace NormedSpace Filter

--- a/Mathlib/MeasureTheory/Function/AEEqOfLIntegral.lean
+++ b/Mathlib/MeasureTheory/Function/AEEqOfLIntegral.lean
@@ -28,7 +28,7 @@ The conclusion is then `f =ᵐ[μ] g`. The main lemmas are:
 
 -/
 
-@[expose] public section
+public section
 
 
 open Filter

--- a/Mathlib/MeasureTheory/Function/AEMeasurableOrder.lean
+++ b/Mathlib/MeasureTheory/Function/AEMeasurableOrder.lean
@@ -22,7 +22,7 @@ but the proof would be more painful. Since our only use for now is for `ℝ≥0�
 as possible.
 -/
 
-@[expose] public section
+public section
 
 
 open MeasureTheory Set TopologicalSpace

--- a/Mathlib/MeasureTheory/Function/ConditionalExpectation/Indicator.lean
+++ b/Mathlib/MeasureTheory/Function/ConditionalExpectation/Indicator.lean
@@ -23,7 +23,7 @@ a restricted measure.
 
 -/
 
-@[expose] public section
+public section
 
 
 noncomputable section

--- a/Mathlib/MeasureTheory/Function/ConditionalExpectation/Real.lean
+++ b/Mathlib/MeasureTheory/Function/ConditionalExpectation/Real.lean
@@ -26,7 +26,7 @@ This file proves some results regarding the conditional expectation of real-valu
 
 -/
 
-@[expose] public section
+public section
 
 
 noncomputable section

--- a/Mathlib/MeasureTheory/Function/ConditionalExpectation/Unique.lean
+++ b/Mathlib/MeasureTheory/Function/ConditionalExpectation/Unique.lean
@@ -27,7 +27,7 @@ defined in this file but is introduced in
 
 -/
 
-@[expose] public section
+public section
 
 
 open scoped ENNReal MeasureTheory

--- a/Mathlib/MeasureTheory/Function/ContinuousMapDense.lean
+++ b/Mathlib/MeasureTheory/Function/ContinuousMapDense.lean
@@ -59,7 +59,7 @@ See the Vitali-Carathéodory theorem,
 in the file `Mathlib/MeasureTheory/Integral/Bochner/VitaliCaratheodory.lean`.
 -/
 
-@[expose] public section
+public section
 
 open scoped ENNReal NNReal Topology BoundedContinuousFunction
 

--- a/Mathlib/MeasureTheory/Function/FactorsThrough.lean
+++ b/Mathlib/MeasureTheory/Function/FactorsThrough.lean
@@ -20,7 +20,7 @@ This is the content of the [Doob-Dynkin lemma](https://en.wikipedia.org/wiki/Doo
 see `exists_eq_measurable_comp`.
 -/
 
-@[expose] public section
+public section
 
 namespace MeasureTheory
 

--- a/Mathlib/MeasureTheory/Function/Floor.lean
+++ b/Mathlib/MeasureTheory/Function/Floor.lean
@@ -14,7 +14,7 @@ In this file we prove that `Int.floor`, `Int.ceil`, `Int.fract`, `Nat.floor`, an
 measurable under some assumptions on the (semi)ring.
 -/
 
-@[expose] public section
+public section
 
 
 open Set

--- a/Mathlib/MeasureTheory/Function/Intersectivity.lean
+++ b/Mathlib/MeasureTheory/Function/Intersectivity.lean
@@ -30,7 +30,7 @@ Use the ergodic theorem to deduce the refinement of the Poincaré recurrence the
 Bergelson.
 -/
 
-@[expose] public section
+public section
 
 open Filter Function MeasureTheory Set
 open scoped ENNReal

--- a/Mathlib/MeasureTheory/Function/Jacobian.lean
+++ b/Mathlib/MeasureTheory/Function/Jacobian.lean
@@ -94,7 +94,7 @@ Change of variables in integrals
 [Fremlin, *Measure Theory* (volume 2)][fremlin_vol2]
 -/
 
-@[expose] public section
+public section
 
 open MeasureTheory MeasureTheory.Measure Metric Filter Set Module Asymptotics
   TopologicalSpace

--- a/Mathlib/MeasureTheory/Function/JacobianOneDim.lean
+++ b/Mathlib/MeasureTheory/Function/JacobianOneDim.lean
@@ -24,7 +24,7 @@ the change of variables formula in dimension 1 for non-monotone functions, formu
 the interval integral and with stronger requirements on the integrand.
 -/
 
-@[expose] public section
+public section
 
 
 open MeasureTheory MeasureTheory.Measure Metric Filter Set Module Asymptotics

--- a/Mathlib/MeasureTheory/Function/LpSeminorm/Basic.lean
+++ b/Mathlib/MeasureTheory/Function/LpSeminorm/Basic.lean
@@ -17,7 +17,7 @@ public import Mathlib.MeasureTheory.Integral.Lebesgue.Sub
 # Basic theorems about ℒp space
 -/
 
-@[expose] public section
+public section
 noncomputable section
 
 open TopologicalSpace MeasureTheory Filter

--- a/Mathlib/MeasureTheory/Function/LpSeminorm/ChebyshevMarkov.lean
+++ b/Mathlib/MeasureTheory/Function/LpSeminorm/ChebyshevMarkov.lean
@@ -14,7 +14,7 @@ In this file we formulate several versions of the Chebyshev-Markov inequality
 in terms of the `MeasureTheory.eLpNorm` seminorm.
 -/
 
-@[expose] public section
+public section
 open scoped NNReal ENNReal
 
 namespace MeasureTheory

--- a/Mathlib/MeasureTheory/Function/LpSeminorm/CompareExp.lean
+++ b/Mathlib/MeasureTheory/Function/LpSeminorm/CompareExp.lean
@@ -16,7 +16,7 @@ In this file we compare `MeasureTheory.eLpNorm'` and `MeasureTheory.eLpNorm` for
 exponents.
 -/
 
-@[expose] public section
+public section
 
 open Filter ENNReal
 open scoped Topology

--- a/Mathlib/MeasureTheory/Function/LpSeminorm/Prod.lean
+++ b/Mathlib/MeasureTheory/Function/LpSeminorm/Prod.lean
@@ -13,7 +13,7 @@ public import Mathlib.MeasureTheory.Measure.Prod
 
 -/
 
-@[expose] public section
+public section
 
 open scoped ENNReal
 

--- a/Mathlib/MeasureTheory/Function/LpSeminorm/Trim.lean
+++ b/Mathlib/MeasureTheory/Function/LpSeminorm/Trim.lean
@@ -14,7 +14,7 @@ In this file we prove basic properties of the Lp-seminorm of a function
 with respect to the restriction of a measure to a sub-σ-algebra.
 -/
 
-@[expose] public section
+public section
 
 namespace MeasureTheory
 

--- a/Mathlib/MeasureTheory/Function/LpSpace/ContinuousCompMeasurePreserving.lean
+++ b/Mathlib/MeasureTheory/Function/LpSpace/ContinuousCompMeasurePreserving.lean
@@ -23,7 +23,7 @@ defined on `MeasureTheory.Lp E p ν × {f : C(X, Y) // MeasurePreserving f μ ν
 Finally, we provide dot notation convenience lemmas.
 -/
 
-@[expose] public section
+public section
 
 open Filter Set MeasureTheory
 open scoped ENNReal Topology symmDiff

--- a/Mathlib/MeasureTheory/Function/SpecialFunctions/Arctan.lean
+++ b/Mathlib/MeasureTheory/Function/SpecialFunctions/Arctan.lean
@@ -13,7 +13,7 @@ public import Mathlib.MeasureTheory.Constructions.BorelSpace.Basic
 
 -/
 
-@[expose] public section
+public section
 
 
 namespace Real

--- a/Mathlib/MeasureTheory/Function/SpecialFunctions/Inner.lean
+++ b/Mathlib/MeasureTheory/Function/SpecialFunctions/Inner.lean
@@ -12,7 +12,7 @@ public import Mathlib.MeasureTheory.Constructions.BorelSpace.Complex
 # Measurability of scalar products
 -/
 
-@[expose] public section
+public section
 
 
 variable {α : Type*} {𝕜 : Type*} {E : Type*}

--- a/Mathlib/MeasureTheory/Function/SpecialFunctions/RCLike.lean
+++ b/Mathlib/MeasureTheory/Function/SpecialFunctions/RCLike.lean
@@ -13,7 +13,7 @@ public import Mathlib.MeasureTheory.Constructions.BorelSpace.Complex
 
 -/
 
-@[expose] public section
+public section
 
 
 noncomputable section

--- a/Mathlib/MeasureTheory/Function/SpecialFunctions/Sinc.lean
+++ b/Mathlib/MeasureTheory/Function/SpecialFunctions/Sinc.lean
@@ -19,7 +19,7 @@ public import Mathlib.MeasureTheory.Function.L1Space.Integrable
 
 -/
 
-@[expose] public section
+public section
 
 open MeasureTheory
 

--- a/Mathlib/MeasureTheory/Function/StronglyMeasurable/ENNReal.lean
+++ b/Mathlib/MeasureTheory/Function/StronglyMeasurable/ENNReal.lean
@@ -16,7 +16,7 @@ whose support has finite measure.
 
 -/
 
-@[expose] public section
+public section
 
 open MeasureTheory
 open scoped ENNReal

--- a/Mathlib/MeasureTheory/Function/StronglyMeasurable/Inner.lean
+++ b/Mathlib/MeasureTheory/Function/StronglyMeasurable/Inner.lean
@@ -13,7 +13,7 @@ public import Mathlib.MeasureTheory.Function.StronglyMeasurable.AEStronglyMeasur
 
 -/
 
-@[expose] public section
+public section
 
 variable {α 𝕜 E : Type*} [RCLike 𝕜] [NormedAddCommGroup E] [InnerProductSpace 𝕜 E]
 

--- a/Mathlib/MeasureTheory/Function/StronglyMeasurable/Lemmas.lean
+++ b/Mathlib/MeasureTheory/Function/StronglyMeasurable/Lemmas.lean
@@ -24,7 +24,7 @@ functions, started in `Mathlib/MeasureTheory/Function/StronglyMeasurable/Basic.l
 
 -/
 
-@[expose] public section
+public section
 
 open MeasureTheory Filter Set ENNReal NNReal
 

--- a/Mathlib/MeasureTheory/Function/StronglyMeasurable/Lp.lean
+++ b/Mathlib/MeasureTheory/Function/StronglyMeasurable/Lp.lean
@@ -26,7 +26,7 @@ Functions in `Lp` for `0 < p < ∞` are finitely strongly measurable.
 
 -/
 
-@[expose] public section
+public section
 
 
 open MeasureTheory Filter TopologicalSpace Function

--- a/Mathlib/MeasureTheory/Group/AddCircle.lean
+++ b/Mathlib/MeasureTheory/Group/AddCircle.lean
@@ -23,7 +23,7 @@ The file is a place to collect measure-theoretic results about the additive circ
 
 -/
 
-@[expose] public section
+public section
 
 
 open Set Function Filter MeasureTheory MeasureTheory.Measure Metric

--- a/Mathlib/MeasureTheory/Group/GeometryOfNumbers.lean
+++ b/Mathlib/MeasureTheory/Group/GeometryOfNumbers.lean
@@ -35,7 +35,7 @@ Hermann Minkowski.
 * [Pete L. Clark, *Geometry of Numbers with Applications to Number Theory*][clark_gon] p.28
 -/
 
-@[expose] public section
+public section
 
 
 namespace MeasureTheory

--- a/Mathlib/MeasureTheory/Group/Integral.lean
+++ b/Mathlib/MeasureTheory/Group/Integral.lean
@@ -15,7 +15,7 @@ We develop properties of integrals with a group as domain.
 This file contains properties about integrability and Bochner integration.
 -/
 
-@[expose] public section
+public section
 
 namespace MeasureTheory
 

--- a/Mathlib/MeasureTheory/Group/IntegralConvolution.lean
+++ b/Mathlib/MeasureTheory/Group/IntegralConvolution.lean
@@ -25,7 +25,7 @@ integrals over there.
   `∫ x, f x ∂(μ ∗ₘ ν) = ∫ x, ∫ y, f (x + y) ∂ν ∂μ`.
 -/
 
-@[expose] public section
+public section
 
 namespace MeasureTheory
 

--- a/Mathlib/MeasureTheory/Group/LIntegral.lean
+++ b/Mathlib/MeasureTheory/Group/LIntegral.lean
@@ -14,7 +14,7 @@ We develop properties of integrals with a group as domain.
 This file contains properties about Lebesgue integration.
 -/
 
-@[expose] public section
+public section
 
 assert_not_exists NormedSpace
 

--- a/Mathlib/MeasureTheory/Group/Pointwise.lean
+++ b/Mathlib/MeasureTheory/Group/Pointwise.lean
@@ -15,7 +15,7 @@ In this file we prove several versions of the following fact: if `s` is a measur
 no `MeasurableSet.mul` etc.
 -/
 
-@[expose] public section
+public section
 
 
 open Pointwise

--- a/Mathlib/MeasureTheory/Integral/Asymptotics.lean
+++ b/Mathlib/MeasureTheory/Integral/Asymptotics.lean
@@ -27,7 +27,7 @@ We establish integrability of `f` from `f = O(g)`.
   `g` integrable `atTop`, then `f` is integrable.
 -/
 
-@[expose] public section
+public section
 
 open Asymptotics MeasureTheory Set Filter
 

--- a/Mathlib/MeasureTheory/Integral/Bochner/ContinuousLinearMap.lean
+++ b/Mathlib/MeasureTheory/Integral/Bochner/ContinuousLinearMap.lean
@@ -19,7 +19,7 @@ the composition, as we are dealing with classes of functions, but it has already
 as `ContinuousLinearMap.compLp`. We take advantage of this construction here.
 -/
 
-@[expose] public section
+public section
 
 open MeasureTheory RCLike
 open scoped ENNReal NNReal

--- a/Mathlib/MeasureTheory/Integral/Bochner/FundThmCalculus.lean
+++ b/Mathlib/MeasureTheory/Integral/Bochner/FundThmCalculus.lean
@@ -21,7 +21,7 @@ as `s` tends to `l.smallSets`, i.e. for any `ε>0` there exists `t ∈ l` such t
 theorem for a locally finite measure `μ` and a function `f` continuous at a point `a`.
 -/
 
-@[expose] public section
+public section
 
 open Filter MeasureTheory Topology Asymptotics Metric
 

--- a/Mathlib/MeasureTheory/Integral/Bochner/VitaliCaratheodory.lean
+++ b/Mathlib/MeasureTheory/Integral/Bochner/VitaliCaratheodory.lean
@@ -71,7 +71,7 @@ See result `MeasureTheory.Lp.boundedContinuousFunction_dense`, in the file
 
 -/
 
-@[expose] public section
+public section
 
 
 open scoped ENNReal NNReal

--- a/Mathlib/MeasureTheory/Integral/BoundedContinuousFunction.lean
+++ b/Mathlib/MeasureTheory/Integral/BoundedContinuousFunction.lean
@@ -18,7 +18,7 @@ specialized form in some other files, in particular in those related to the topo
 convergence of probability measures and finite measures.
 -/
 
-@[expose] public section
+public section
 
 open MeasureTheory Filter
 open scoped ENNReal NNReal BoundedContinuousFunction Topology

--- a/Mathlib/MeasureTheory/Integral/CurveIntegral/Poincare.lean
+++ b/Mathlib/MeasureTheory/Integral/CurveIntegral/Poincare.lean
@@ -32,7 +32,7 @@ A 1-form represented this way is closed
 iff its Fréchet derivative `dω : E → E →L[𝕜] E →L[𝕜] F` is symmetric, `dω a x y = dω a y x`.
 -/
 
-@[expose] public section
+public section
 
 open scoped unitInterval Interval Pointwise Topology
 open AffineMap Filter Function MeasureTheory Set

--- a/Mathlib/MeasureTheory/Integral/DivergenceTheorem.lean
+++ b/Mathlib/MeasureTheory/Integral/DivergenceTheorem.lean
@@ -51,7 +51,7 @@ website shows the actual terms, not those abbreviated using local notations.
 divergence theorem, Bochner integral
 -/
 
-@[expose] public section
+public section
 
 
 open Set Finset TopologicalSpace Function BoxIntegral MeasureTheory Filter

--- a/Mathlib/MeasureTheory/Integral/DominatedConvergence.lean
+++ b/Mathlib/MeasureTheory/Integral/DominatedConvergence.lean
@@ -31,7 +31,7 @@ for the Bochner integral.
 
 -/
 
-@[expose] public section
+public section
 
 open MeasureTheory Metric
 

--- a/Mathlib/MeasureTheory/Integral/ExpDecay.lean
+++ b/Mathlib/MeasureTheory/Integral/ExpDecay.lean
@@ -19,7 +19,7 @@ for integrability:
   exists `b > 0` such that `f(x) = O(exp(-b x))` as `x → ∞`, then `f` is integrable on `(a, ∞)`.
 -/
 
-@[expose] public section
+public section
 
 
 noncomputable section

--- a/Mathlib/MeasureTheory/Integral/Gamma.lean
+++ b/Mathlib/MeasureTheory/Integral/Gamma.lean
@@ -16,7 +16,7 @@ In this file, we collect several integrals over `ℝ` or `ℂ` that evaluate in 
 
 -/
 
-@[expose] public section
+public section
 
 open Real Set MeasureTheory MeasureTheory.Measure
 

--- a/Mathlib/MeasureTheory/Integral/Indicator.lean
+++ b/Mathlib/MeasureTheory/Integral/Indicator.lean
@@ -28,7 +28,7 @@ moved out of `Mathlib/MeasureTheory/Integral/Lebesgue/Basic.lean`, and the lemma
 be moved to, e.g., `Mathlib/MeasureTheory/Constructions/BorelSpace/Metrizable.lean`.
 -/
 
-@[expose] public section
+public section
 
 namespace MeasureTheory
 

--- a/Mathlib/MeasureTheory/Integral/IntervalAverage.lean
+++ b/Mathlib/MeasureTheory/Integral/IntervalAverage.lean
@@ -27,7 +27,7 @@ We also prove that `⨍ x in a..b, f x = ⨍ x in b..a, f x`, see `interval_aver
 
 -/
 
-@[expose] public section
+public section
 
 
 open MeasureTheory Set TopologicalSpace

--- a/Mathlib/MeasureTheory/Integral/IntervalIntegral/ContDiff.lean
+++ b/Mathlib/MeasureTheory/Integral/IntervalIntegral/ContDiff.lean
@@ -14,7 +14,7 @@ We give versions of the second fundamental theorem of calculus under the strong 
 that the function is `C^1` on the interval. This is restrictive, but satisfied in many situations.
 -/
 
-@[expose] public section
+public section
 
 noncomputable section
 

--- a/Mathlib/MeasureTheory/Integral/IntervalIntegral/DerivIntegrable.lean
+++ b/Mathlib/MeasureTheory/Integral/IntervalIntegral/DerivIntegrable.lean
@@ -27,7 +27,7 @@ then `f'` is interval integrable on `a..b`.
 interval integrable, monotone, bounded variation, absolutely continuous
 -/
 
-@[expose] public section
+public section
 
 open MeasureTheory Set Filter
 

--- a/Mathlib/MeasureTheory/Integral/IntervalIntegral/IntegrationByParts.lean
+++ b/Mathlib/MeasureTheory/Integral/IntervalIntegral/IntegrationByParts.lean
@@ -25,7 +25,7 @@ can be found in `Mathlib/MeasureTheory/Function/JacobianOneDim.lean`
 integration by parts, change of variables in integrals
 -/
 
-@[expose] public section
+public section
 
 open MeasureTheory Set
 

--- a/Mathlib/MeasureTheory/Integral/IntervalIntegral/LebesgueDifferentiationThm.lean
+++ b/Mathlib/MeasureTheory/Integral/IntervalIntegral/LebesgueDifferentiationThm.lean
@@ -24,7 +24,7 @@ is interval integrable on `a..b`, then for almost every `x ∈ uIcc a b`, for an
 derivative of `∫ (t : ℝ) in c..x, f t` at `x` is equal to `f x`.
 -/
 
-@[expose] public section
+public section
 
 open MeasureTheory Set Filter Function IsUnifLocDoublingMeasure
 

--- a/Mathlib/MeasureTheory/Integral/IntervalIntegral/Slope.lean
+++ b/Mathlib/MeasureTheory/Integral/IntervalIntegral/Slope.lean
@@ -24,7 +24,7 @@ at most `f (b + c) - f a`.
 interval integrable, interval integral, monotone, slope
 -/
 
-@[expose] public section
+public section
 
 open MeasureTheory Set
 

--- a/Mathlib/MeasureTheory/Integral/Layercake.lean
+++ b/Mathlib/MeasureTheory/Integral/Layercake.lean
@@ -58,7 +58,7 @@ function, is given in `Mathlib/Analysis/SpecialFunctions/Pow/Integral.lean`.
 layer cake representation, Cavalieri's principle, tail probability formula
 -/
 
-@[expose] public section
+public section
 
 noncomputable section
 

--- a/Mathlib/MeasureTheory/Integral/Lebesgue/Add.lean
+++ b/Mathlib/MeasureTheory/Integral/Lebesgue/Add.lean
@@ -18,7 +18,7 @@ several variants of this theorem, then uses it to show that the Lebesgue integra
 a constant.
 -/
 
-@[expose] public section
+public section
 
 namespace MeasureTheory
 

--- a/Mathlib/MeasureTheory/Integral/Lebesgue/Countable.lean
+++ b/Mathlib/MeasureTheory/Integral/Lebesgue/Countable.lean
@@ -18,7 +18,7 @@ The lemmas in this file require at least one of the following of the Lebesgue in
 * The measure is finite, s-finite or sigma-finite
 -/
 
-@[expose] public section
+public section
 
 namespace MeasureTheory
 

--- a/Mathlib/MeasureTheory/Integral/Lebesgue/DominatedConvergence.lean
+++ b/Mathlib/MeasureTheory/Integral/Lebesgue/DominatedConvergence.lean
@@ -16,7 +16,7 @@ a sequence of (almost everywhere) measurable functions can be swapped if the fun
 pointwise dominated by a fixed function. This file provides a few variants of the result.
 -/
 
-@[expose] public section
+public section
 
 open Filter ENNReal Topology
 

--- a/Mathlib/MeasureTheory/Integral/Lebesgue/Map.lean
+++ b/Mathlib/MeasureTheory/Integral/Lebesgue/Map.lean
@@ -12,7 +12,7 @@ public import Mathlib.MeasureTheory.Integral.Lebesgue.Add
 # Behavior of the Lebesgue integral under maps
 -/
 
-@[expose] public section
+public section
 
 namespace MeasureTheory
 

--- a/Mathlib/MeasureTheory/Integral/Lebesgue/Markov.lean
+++ b/Mathlib/MeasureTheory/Integral/Lebesgue/Markov.lean
@@ -19,7 +19,7 @@ the measure-theoretic form:
 This file proves a few variants of the inequality and other lemmas that depend on it.
 -/
 
-@[expose] public section
+public section
 
 namespace MeasureTheory
 

--- a/Mathlib/MeasureTheory/Integral/Lebesgue/Norm.lean
+++ b/Mathlib/MeasureTheory/Integral/Lebesgue/Norm.lean
@@ -12,7 +12,7 @@ public import Mathlib.MeasureTheory.Integral.Lebesgue.Basic
 # Interactions between the Lebesgue integral and norms
 -/
 
-@[expose] public section
+public section
 
 namespace MeasureTheory
 

--- a/Mathlib/MeasureTheory/Integral/Lebesgue/Sub.lean
+++ b/Mathlib/MeasureTheory/Integral/Lebesgue/Sub.lean
@@ -15,7 +15,7 @@ In this file we first show that Lebesgue integrals can be subtracted with the ex
 the monotone convergence theorem that use this subtraction in their proofs.
 -/
 
-@[expose] public section
+public section
 
 open Filter ENNReal Topology
 

--- a/Mathlib/MeasureTheory/Integral/LebesgueNormedSpace.lean
+++ b/Mathlib/MeasureTheory/Integral/LebesgueNormedSpace.lean
@@ -10,7 +10,7 @@ public import Mathlib.Analysis.Normed.Module.Basic
 
 /-! # A lemma about measurability with density under scalar multiplication in normed spaces -/
 
-@[expose] public section
+public section
 
 
 open MeasureTheory Filter ENNReal Set

--- a/Mathlib/MeasureTheory/Integral/PeakFunction.lean
+++ b/Mathlib/MeasureTheory/Integral/PeakFunction.lean
@@ -35,7 +35,7 @@ Note that there are related results about convolution with respect to peak funct
 `Mathlib/Analysis/Convolution.lean`, such as `MeasureTheory.convolution_tendsto_right` there.
 -/
 
-@[expose] public section
+public section
 
 open Set Filter MeasureTheory MeasureTheory.Measure TopologicalSpace Metric
 

--- a/Mathlib/MeasureTheory/Integral/Pi.lean
+++ b/Mathlib/MeasureTheory/Integral/Pi.lean
@@ -16,7 +16,7 @@ that its integral is the product of the individual integrals,
 in `MeasureTheory.integral_fintype_prod_eq_prod`.
 -/
 
-@[expose] public section
+public section
 
 open Fintype MeasureTheory MeasureTheory.Measure
 

--- a/Mathlib/MeasureTheory/Integral/Prod.lean
+++ b/Mathlib/MeasureTheory/Integral/Prod.lean
@@ -35,7 +35,7 @@ In this file we prove Fubini's theorem.
 product measure, Fubini's theorem, Fubini-Tonelli theorem
 -/
 
-@[expose] public section
+public section
 
 
 noncomputable section

--- a/Mathlib/MeasureTheory/Integral/Regular.lean
+++ b/Mathlib/MeasureTheory/Integral/Regular.lean
@@ -16,7 +16,7 @@ in terms of the integral of continuous functions equal to 1 on the compact set, 
 of the open set respectively.
 -/
 
-@[expose] public section
+public section
 
 open Filter Set MeasureTheory Measure
 

--- a/Mathlib/MeasureTheory/MeasurableSpace/NCard.lean
+++ b/Mathlib/MeasureTheory/MeasurableSpace/NCard.lean
@@ -15,7 +15,7 @@ In this file we prove that `Set.encard` and `Set.ncard` are measurable functions
 provided that the ambient space is countable.
 -/
 
-@[expose] public section
+public section
 
 open Set
 

--- a/Mathlib/MeasureTheory/MeasurableSpace/Pi.lean
+++ b/Mathlib/MeasureTheory/MeasurableSpace/Pi.lean
@@ -19,7 +19,7 @@ then the sets `{x | ∀ i, x i ∈ s i}`, where `s i ∈ C i`,
 generate the σ-algebra on the indexed product of `α i`s.
 -/
 
-@[expose] public section
+public section
 
 noncomputable section
 

--- a/Mathlib/MeasureTheory/MeasurableSpace/PreorderRestrict.lean
+++ b/Mathlib/MeasureTheory/MeasurableSpace/PreorderRestrict.lean
@@ -15,7 +15,7 @@ We prove that the map which restricts a function `f : (i : α) → X i` to eleme
 measurable.
 -/
 
-@[expose] public section
+public section
 
 open MeasureTheory
 

--- a/Mathlib/MeasureTheory/MeasurableSpace/Prod.lean
+++ b/Mathlib/MeasureTheory/MeasurableSpace/Prod.lean
@@ -14,7 +14,7 @@ public import Mathlib.MeasureTheory.PiSystem
 This file talks about the measurability of operations on binary functions.
 -/
 
-@[expose] public section
+public section
 
 assert_not_exists MeasureTheory.Measure
 

--- a/Mathlib/MeasureTheory/Measure/ContinuousPreimage.lean
+++ b/Mathlib/MeasureTheory/Measure/ContinuousPreimage.lean
@@ -22,7 +22,7 @@ a null measurable set `s`, and a null measurable set `t` of finite measure,
 the set of parameters `z` such that `f z ⁻¹' t` is a.e. equal to `s` is a closed set.
 -/
 
-@[expose] public section
+public section
 
 open Filter Set
 open scoped ENNReal symmDiff Topology

--- a/Mathlib/MeasureTheory/Measure/Decomposition/IntegralRNDeriv.lean
+++ b/Mathlib/MeasureTheory/Measure/Decomposition/IntegralRNDeriv.lean
@@ -20,7 +20,7 @@ public import Mathlib.MeasureTheory.Measure.Decomposition.RadonNikodym
 
 -/
 
-@[expose] public section
+public section
 
 
 open Set

--- a/Mathlib/MeasureTheory/Measure/Decomposition/RadonNikodym.lean
+++ b/Mathlib/MeasureTheory/Measure/Decomposition/RadonNikodym.lean
@@ -42,7 +42,7 @@ The file also contains properties of `rnDeriv` that use the Radon-Nikodym theore
 Radon-Nikodym theorem
 -/
 
-@[expose] public section
+public section
 
 assert_not_exists InnerProductSpace
 assert_not_exists MeasureTheory.VectorMeasure

--- a/Mathlib/MeasureTheory/Measure/FiniteMeasureExt.lean
+++ b/Mathlib/MeasureTheory/Measure/FiniteMeasureExt.lean
@@ -18,7 +18,7 @@ the integrals of all elements of `A` with respect to two finite measures `P, P'`
 measures coincide. In other words: If a subalgebra separates points, it separates finite measures.
 -/
 
-@[expose] public section
+public section
 
 open MeasureTheory Filter Real RCLike BoundedContinuousFunction
 

--- a/Mathlib/MeasureTheory/Measure/HasOuterApproxClosedProd.lean
+++ b/Mathlib/MeasureTheory/Measure/HasOuterApproxClosedProd.lean
@@ -53,7 +53,7 @@ We specialize these results to the cases where one of the families contains only
 bounded continuous function, product measure
 -/
 
-@[expose] public section
+public section
 
 open BoundedContinuousFunction MeasureTheory Topology Filter Set ENNReal NNReal MeasurableSpace
 open scoped Topology ENNReal NNReal

--- a/Mathlib/MeasureTheory/Measure/IntegralCharFun.lean
+++ b/Mathlib/MeasureTheory/Measure/IntegralCharFun.lean
@@ -31,7 +31,7 @@ relating the measure of some sets to integrals of characteristic functions.
 
 -/
 
-@[expose] public section
+public section
 
 open RealInnerProductSpace Real Complex NormedSpace
 

--- a/Mathlib/MeasureTheory/Measure/Lebesgue/Integral.lean
+++ b/Mathlib/MeasureTheory/Measure/Lebesgue/Integral.lean
@@ -11,7 +11,7 @@ public import Mathlib.MeasureTheory.Measure.Haar.Unique
 
 /-! # Properties of integration with respect to the Lebesgue measure -/
 
-@[expose] public section
+public section
 
 
 open Set Filter MeasureTheory MeasureTheory.Measure TopologicalSpace

--- a/Mathlib/MeasureTheory/Measure/Lebesgue/VolumeOfBalls.lean
+++ b/Mathlib/MeasureTheory/Measure/Lebesgue/VolumeOfBalls.lean
@@ -41,7 +41,7 @@ Using these formulas, we compute the volume of the unit balls in several cases.
 * `Complex.volume_ball` / `Complex.volume_closedBall`: volume of open and closed balls in `ℂ`.
 -/
 
-@[expose] public section
+public section
 
 section general_case
 

--- a/Mathlib/MeasureTheory/Measure/Portmanteau.lean
+++ b/Mathlib/MeasureTheory/Measure/Portmanteau.lean
@@ -82,7 +82,7 @@ probability measure
 
 -/
 
-@[expose] public section
+public section
 
 
 noncomputable section

--- a/Mathlib/MeasureTheory/Measure/Real.lean
+++ b/Mathlib/MeasureTheory/Measure/Real.lean
@@ -28,7 +28,7 @@ more painful with reals than nonnegative extended reals. They should probably be
 run.
 -/
 
-@[expose] public section
+public section
 
 open MeasureTheory Measure Set
 open scoped ENNReal NNReal Function symmDiff

--- a/Mathlib/MeasureTheory/Measure/TightNormed.lean
+++ b/Mathlib/MeasureTheory/Measure/TightNormed.lean
@@ -24,7 +24,7 @@ Criteria for tightness of sets of measures in normed and inner product spaces.
 
 -/
 
-@[expose] public section
+public section
 
 open Filter
 

--- a/Mathlib/MeasureTheory/Order/Group/Lattice.lean
+++ b/Mathlib/MeasureTheory/Order/Group/Lattice.lean
@@ -17,7 +17,7 @@ public import Mathlib.MeasureTheory.Order.Lattice
 measurable function, group, lattice operation
 -/
 
-@[expose] public section
+public section
 
 variable {α β : Type*} [Lattice α] [Group α] [MeasurableSpace α]
   [MeasurableSpace β] {f : β → α}

--- a/Mathlib/MeasureTheory/Order/UpperLower.lean
+++ b/Mathlib/MeasureTheory/Order/UpperLower.lean
@@ -47,7 +47,7 @@ any subset of the antidiagonal `{(x, y) | x + y = 0}`) is order-connected.
 Generalize so that it also applies to `ℝ × ℝ`, for example.
 -/
 
-@[expose] public section
+public section
 
 open Filter MeasureTheory Metric Set
 open scoped Topology

--- a/Mathlib/MeasureTheory/OuterMeasure/Basic.lean
+++ b/Mathlib/MeasureTheory/OuterMeasure/Basic.lean
@@ -32,7 +32,7 @@ Note that we do not need `α` to be measurable to define an outer measure.
 outer measure
 -/
 
-@[expose] public section
+public section
 
 
 noncomputable section

--- a/Mathlib/MeasureTheory/OuterMeasure/BorelCantelli.lean
+++ b/Mathlib/MeasureTheory/OuterMeasure/BorelCantelli.lean
@@ -26,7 +26,7 @@ For the *second* Borel-Cantelli lemma (applying to independent sets in a probabi
 see `ProbabilityTheory.measure_limsup_eq_one`.
 -/
 
-@[expose] public section
+public section
 
 open Filter Set
 open scoped ENNReal Topology

--- a/Mathlib/MeasureTheory/SpecificCodomains/ContinuousMap.lean
+++ b/Mathlib/MeasureTheory/SpecificCodomains/ContinuousMap.lean
@@ -50,7 +50,7 @@ to approach integration valued in a functional space `ℱ`. More precisely:
 
 -/
 
-@[expose] public section
+public section
 
 open MeasureTheory
 

--- a/Mathlib/MeasureTheory/SpecificCodomains/ContinuousMapZero.lean
+++ b/Mathlib/MeasureTheory/SpecificCodomains/ContinuousMapZero.lean
@@ -21,7 +21,7 @@ module docstring.
 
 -/
 
-@[expose] public section
+public section
 
 open MeasureTheory
 

--- a/Mathlib/MeasureTheory/SpecificCodomains/Pi.lean
+++ b/Mathlib/MeasureTheory/SpecificCodomains/Pi.lean
@@ -14,7 +14,7 @@ We prove that `f : X → Π i, E i` is in `Lᵖ` if and only if for all `i`, `f 
 We do the same for `f : X → (E × F)`.
 -/
 
-@[expose] public section
+public section
 
 namespace MeasureTheory
 

--- a/Mathlib/MeasureTheory/SpecificCodomains/WithLp.lean
+++ b/Mathlib/MeasureTheory/SpecificCodomains/WithLp.lean
@@ -15,7 +15,7 @@ We prove that `f : X → PiLp q E` is in `Lᵖ` if and only if for all `i`, `f �
 We do the same for `f : X → WithLp q (E × F)`.
 -/
 
-@[expose] public section
+public section
 
 open scoped ENNReal
 

--- a/Mathlib/MeasureTheory/Topology.lean
+++ b/Mathlib/MeasureTheory/Topology.lean
@@ -15,7 +15,7 @@ This file gathers theorems that combine measure theory and topology, and cannot 
 the existing files without introducing massive dependencies between the subjects.
 -/
 
-@[expose] public section
+public section
 open Filter MeasureTheory
 
 /-- Under reasonable assumptions, sets that are codiscrete within `U` are contained in the "almost

--- a/Mathlib/MeasureTheory/VectorMeasure/Decomposition/RadonNikodym.lean
+++ b/Mathlib/MeasureTheory/VectorMeasure/Decomposition/RadonNikodym.lean
@@ -16,7 +16,7 @@ that depend both on the Lebesgue decomposition of signed measures
 and the theory of Radon-Nikodym derivatives of usual measures.
 -/
 
-@[expose] public section
+public section
 
 namespace MeasureTheory
 


### PR DESCRIPTION
Removes `@[expose]` from 94 files in MeasureTheory.

🤖 Prepared with Claude Code