### PR TITLE
[Merged by Bors] - chore(CategoryTheory): remove unnecessary @[expose] from public sections

### DIFF
--- a/Mathlib/CategoryTheory/Abelian/CommSq.lean
+++ b/Mathlib/CategoryTheory/Abelian/CommSq.lean
@@ -25,7 +25,7 @@ We study the associated exact sequence `X₁ ⟶ X₂ ⊞ X₃ ⟶ X₄ ⟶ 0`.
 
 -/
 
-@[expose] public section
+public section
 
 universe v u
 

--- a/Mathlib/CategoryTheory/Abelian/DiagramLemmas/Four.lean
+++ b/Mathlib/CategoryTheory/Abelian/DiagramLemmas/Four.lean
@@ -44,7 +44,7 @@ using duality, but this would require lengthy API developments for `ComposableAr
 four lemma, five lemma, diagram lemma, diagram chase
 -/
 
-@[expose] public section
+public section
 
 
 namespace CategoryTheory

--- a/Mathlib/CategoryTheory/Abelian/Projective/Basic.lean
+++ b/Mathlib/CategoryTheory/Abelian/Projective/Basic.lean
@@ -19,7 +19,7 @@ In an abelian category, an object `P` is projective iff the functor
 
 -/
 
-@[expose] public section
+public section
 
 universe v u
 

--- a/Mathlib/CategoryTheory/Abelian/Refinements.lean
+++ b/Mathlib/CategoryTheory/Abelian/Refinements.lean
@@ -70,7 +70,7 @@ these morphisms and sometimes introducing an auxiliary epimorphism `A' ⟶ A`.
 
 -/
 
-@[expose] public section
+public section
 
 namespace CategoryTheory
 

--- a/Mathlib/CategoryTheory/Abelian/Yoneda.lean
+++ b/Mathlib/CategoryTheory/Abelian/Yoneda.lean
@@ -19,7 +19,7 @@ In this file we give a sufficient criterion for a restriction of the functor
 is a projective separator such that every object in the relevant subcategory is a quotient of `G`.
 -/
 
-@[expose] public section
+public section
 
 open CategoryTheory Opposite Limits
 

--- a/Mathlib/CategoryTheory/Bicategory/Functor/Cat.lean
+++ b/Mathlib/CategoryTheory/Bicategory/Functor/Cat.lean
@@ -15,7 +15,7 @@ for pseudofunctors to `Cat`.
 
 -/
 
-@[expose] public section
+public section
 
 universe w v v' u u'
 

--- a/Mathlib/CategoryTheory/Category/Init.lean
+++ b/Mathlib/CategoryTheory/Category/Init.lean
@@ -16,7 +16,7 @@ This module defines the `CategoryTheory` Aesop rule set which is used by the
 they're declared is imported, so we must put this declaration into its own file.
 -/
 
-@[expose] public section
+public section
 
 declare_aesop_rule_sets [CategoryTheory]
 

--- a/Mathlib/CategoryTheory/Center/NegOnePow.lean
+++ b/Mathlib/CategoryTheory/Center/NegOnePow.lean
@@ -13,7 +13,7 @@ public import Mathlib.Algebra.Ring.NegOnePow
 
 -/
 
-@[expose] public section
+public section
 
 universe v u
 

--- a/Mathlib/CategoryTheory/Center/Preadditive.lean
+++ b/Mathlib/CategoryTheory/Center/Preadditive.lean
@@ -13,7 +13,7 @@ public import Mathlib.CategoryTheory.Center.Basic
 
 -/
 
-@[expose] public section
+public section
 
 universe v u
 

--- a/Mathlib/CategoryTheory/Comma/StructuredArrow/Final.lean
+++ b/Mathlib/CategoryTheory/Comma/StructuredArrow/Final.lean
@@ -16,7 +16,7 @@ public import Mathlib.CategoryTheory.Limits.Final
 * [M. Kashiwara, P. Schapira, *Categories and Sheaves*][Kashiwara2006], Proposition 3.1.8(i)
 -/
 
-@[expose] public section
+public section
 
 universe v₁ v₂ v₃ u₁ u₂ u₃
 

--- a/Mathlib/CategoryTheory/ConcreteCategory/Elementwise.lean
+++ b/Mathlib/CategoryTheory/ConcreteCategory/Elementwise.lean
@@ -17,7 +17,7 @@ import all Mathlib.CategoryTheory.Limits.Shapes.Kernels
 In this file we provide various simp lemmas in its elementwise form via `Tactic.Elementwise`.
 -/
 
-@[expose] public section
+public section
 
 
 open CategoryTheory CategoryTheory.Limits

--- a/Mathlib/CategoryTheory/Elementwise.lean
+++ b/Mathlib/CategoryTheory/Elementwise.lean
@@ -17,7 +17,7 @@ however some early parts of the category theory library are imported by `Tactic.
 so we need to add the attribute after the fact.
 -/
 
-@[expose] public section
+public section
 
 
 /-! We now add some `elementwise` attributes to lemmas that were proved earlier. -/

--- a/Mathlib/CategoryTheory/Filtered/Connected.lean
+++ b/Mathlib/CategoryTheory/Filtered/Connected.lean
@@ -12,7 +12,7 @@ public import Mathlib.CategoryTheory.IsConnected
 # Filtered categories are connected
 -/
 
-@[expose] public section
+public section
 
 universe v u
 

--- a/Mathlib/CategoryTheory/Filtered/CostructuredArrow.lean
+++ b/Mathlib/CategoryTheory/Filtered/CostructuredArrow.lean
@@ -20,7 +20,7 @@ public import Mathlib.CategoryTheory.Limits.Final
 
 -/
 
-@[expose] public section
+public section
 
 universe v₁ v₂ v₃ u₁ u₂ u₃
 

--- a/Mathlib/CategoryTheory/Filtered/Flat.lean
+++ b/Mathlib/CategoryTheory/Filtered/Flat.lean
@@ -20,7 +20,7 @@ Transferring (co)filteredness *along* representably (co)flat functors is given b
 representably coflat functor is initial.
 -/
 
-@[expose] public section
+public section
 
 universe v₁ v₂ u₁ u₂
 

--- a/Mathlib/CategoryTheory/Filtered/OfColimitCommutesFiniteLimit.lean
+++ b/Mathlib/CategoryTheory/Filtered/OfColimitCommutesFiniteLimit.lean
@@ -13,7 +13,7 @@ public import Mathlib.CategoryTheory.Limits.Yoneda
 # If colimits of shape `K` commute with finite limits, then `K` is filtered.
 -/
 
-@[expose] public section
+public section
 
 universe v u
 

--- a/Mathlib/CategoryTheory/Functor/TypeValuedFlat.lean
+++ b/Mathlib/CategoryTheory/Functor/TypeValuedFlat.lean
@@ -29,7 +29,7 @@ then `F.Elements` is cofiltered.
 
 -/
 
-@[expose] public section
+public section
 
 universe w v u
 

--- a/Mathlib/CategoryTheory/Galois/Decomposition.lean
+++ b/Mathlib/CategoryTheory/Galois/Decomposition.lean
@@ -33,7 +33,7 @@ is represented by a Galois object.
 
 -/
 
-@[expose] public section
+public section
 
 universe u₁ u₂ w
 

--- a/Mathlib/CategoryTheory/Generator/Abelian.lean
+++ b/Mathlib/CategoryTheory/Generator/Abelian.lean
@@ -23,7 +23,7 @@ public import Mathlib.CategoryTheory.Abelian.Opposite
 
 -/
 
-@[expose] public section
+public section
 
 
 open CategoryTheory CategoryTheory.Limits Opposite

--- a/Mathlib/CategoryTheory/Generator/Indization.lean
+++ b/Mathlib/CategoryTheory/Generator/Indization.lean
@@ -17,7 +17,7 @@ and additive, then `Ind C` has a separator.
 
 -/
 
-@[expose] public section
+public section
 
 universe v u
 

--- a/Mathlib/CategoryTheory/Generator/Preadditive.lean
+++ b/Mathlib/CategoryTheory/Generator/Preadditive.lean
@@ -16,7 +16,7 @@ preadditive categories.
 
 -/
 
-@[expose] public section
+public section
 
 
 universe v u

--- a/Mathlib/CategoryTheory/Generator/Type.lean
+++ b/Mathlib/CategoryTheory/Generator/Type.lean
@@ -14,7 +14,7 @@ In this file, we show that `PUnit` is a separator of the category `Type u`.
 
 -/
 
-@[expose] public section
+public section
 
 universe u
 

--- a/Mathlib/CategoryTheory/LiftingProperties/Over.lean
+++ b/Mathlib/CategoryTheory/LiftingProperties/Over.lean
@@ -21,7 +21,7 @@ the left lifting property with respect to `p.left`.
 
 -/
 
-@[expose] public section
+public section
 
 universe v u
 

--- a/Mathlib/CategoryTheory/Limits/ConcreteCategory/WithAlgebraicStructures.lean
+++ b/Mathlib/CategoryTheory/Limits/ConcreteCategory/WithAlgebraicStructures.lean
@@ -33,7 +33,7 @@ In the future they might be generalized by assuming a `HasForget₂ C (ModuleCat
 plus assertions that the module structures induced by `HasForget₂` coincide.
 -/
 
-@[expose] public section
+public section
 
 universe t w v u r
 

--- a/Mathlib/CategoryTheory/Limits/Constructions/Pullbacks.lean
+++ b/Mathlib/CategoryTheory/Limits/Constructions/Pullbacks.lean
@@ -16,7 +16,7 @@ If a category has binary products and equalizers, then it has pullbacks.
 Also, if a category has binary coproducts and coequalizers, then it has pushouts.
 -/
 
-@[expose] public section
+public section
 
 
 universe v u

--- a/Mathlib/CategoryTheory/Limits/Constructions/WeaklyInitial.lean
+++ b/Mathlib/CategoryTheory/Limits/Constructions/WeaklyInitial.lean
@@ -20,7 +20,7 @@ This file gives constructions related to weakly initial objects, namely:
 These are primarily useful to show the General Adjoint Functor Theorem.
 -/
 
-@[expose] public section
+public section
 
 
 universe v u

--- a/Mathlib/CategoryTheory/Limits/EpiMono.lean
+++ b/Mathlib/CategoryTheory/Limits/EpiMono.lean
@@ -27,7 +27,7 @@ is a pullback square.
 
 -/
 
-@[expose] public section
+public section
 
 namespace CategoryTheory
 

--- a/Mathlib/CategoryTheory/Limits/EssentiallySmall.lean
+++ b/Mathlib/CategoryTheory/Limits/EssentiallySmall.lean
@@ -17,7 +17,7 @@ See also the file `FinallySmall.lean` for more general results.
 
 -/
 
-@[expose] public section
+public section
 
 
 universe w₁ w₂ v₁ v₂ u₁ u₂

--- a/Mathlib/CategoryTheory/Limits/Final/ParallelPair.lean
+++ b/Mathlib/CategoryTheory/Limits/Final/ParallelPair.lean
@@ -18,7 +18,7 @@ parallel morphisms out of `X` factor through the parallel pair `f`, `g`
 (`h₂ : ∀ ⦃Z : C⦄ (i j : X ⟶ Z), ∃ (a : Y ⟶ Z), i = f ≫ a ∧ j = g ≫ a`).
 -/
 
-@[expose] public section
+public section
 
 namespace CategoryTheory.Limits
 

--- a/Mathlib/CategoryTheory/Limits/FunctorToTypes.lean
+++ b/Mathlib/CategoryTheory/Limits/FunctorToTypes.lean
@@ -15,7 +15,7 @@ Some of the concrete descriptions of (co)limits in `Type v` extend to (co)limits
 category `K ⥤ Type v`.
 -/
 
-@[expose] public section
+public section
 
 namespace CategoryTheory.FunctorToTypes
 

--- a/Mathlib/CategoryTheory/Limits/Indization/Products.lean
+++ b/Mathlib/CategoryTheory/Limits/Indization/Products.lean
@@ -19,7 +19,7 @@ creates products indexed by `α` and that the functor `C ⥤ Ind C` preserves th
 * [M. Kashiwara, P. Schapira, *Categories and Sheaves*][Kashiwara2006], Prop. 6.1.16(ii)
 -/
 
-@[expose] public section
+public section
 
 universe v u
 

--- a/Mathlib/CategoryTheory/Limits/Preserves/Creates/Pullbacks.lean
+++ b/Mathlib/CategoryTheory/Limits/Preserves/Creates/Pullbacks.lean
@@ -14,7 +14,7 @@ public import Mathlib.CategoryTheory.Limits.Shapes.Pullback.HasPullback
 We show some lemmas relating creation of (co)limits and pullbacks (resp. pushouts).
 -/
 
-@[expose] public section
+public section
 
 namespace CategoryTheory.Limits
 

--- a/Mathlib/CategoryTheory/Limits/Preserves/Opposites.lean
+++ b/Mathlib/CategoryTheory/Limits/Preserves/Opposites.lean
@@ -16,7 +16,7 @@ preserve certain (co)limits and vice versa.
 
 -/
 
-@[expose] public section
+public section
 
 
 universe w w' v₁ v₂ u₁ u₂

--- a/Mathlib/CategoryTheory/Limits/Preserves/Shapes/Square.lean
+++ b/Mathlib/CategoryTheory/Limits/Preserves/Shapes/Square.lean
@@ -25,7 +25,7 @@ functor `yoneda.obj X` for all `X : C`.
 
 -/
 
-@[expose] public section
+public section
 
 universe v v' u u'
 

--- a/Mathlib/CategoryTheory/Limits/Shapes/Equivalence.lean
+++ b/Mathlib/CategoryTheory/Limits/Shapes/Equivalence.lean
@@ -15,7 +15,7 @@ For now, we only treat the case of initial and terminal objects, but other speci
 added in the future.
 -/
 
-@[expose] public section
+public section
 
 
 open CategoryTheory CategoryTheory.Limits

--- a/Mathlib/CategoryTheory/Limits/Shapes/Pullback/Equalizer.lean
+++ b/Mathlib/CategoryTheory/Limits/Shapes/Pullback/Equalizer.lean
@@ -14,7 +14,7 @@ Also see `CategoryTheory.Limits.Constructions.Equalizers` for very similar resul
 
 -/
 
-@[expose] public section
+public section
 
 universe v u
 

--- a/Mathlib/CategoryTheory/Limits/Types/ColimitTypeFiltered.lean
+++ b/Mathlib/CategoryTheory/Limits/Types/ColimitTypeFiltered.lean
@@ -22,7 +22,7 @@ important step when proving `c.IsColimit`.
 
 -/
 
-@[expose] public section
+public section
 
 universe w₁ w₀ v u
 

--- a/Mathlib/CategoryTheory/Localization/CalculusOfFractions/ComposableArrows.lean
+++ b/Mathlib/CategoryTheory/Localization/CalculusOfFractions/ComposableArrows.lean
@@ -17,7 +17,7 @@ is essentially surjective for any `n : ℕ`.
 
 -/
 
-@[expose] public section
+public section
 
 namespace CategoryTheory
 

--- a/Mathlib/CategoryTheory/Localization/CalculusOfFractions/OfAdjunction.lean
+++ b/Mathlib/CategoryTheory/Localization/CalculusOfFractions/OfAdjunction.lean
@@ -25,7 +25,7 @@ the class of isomorphisms by `G`.
 
 -/
 
-@[expose] public section
+public section
 
 namespace CategoryTheory
 

--- a/Mathlib/CategoryTheory/Localization/Preadditive.lean
+++ b/Mathlib/CategoryTheory/Localization/Preadditive.lean
@@ -13,7 +13,7 @@ public import Mathlib.CategoryTheory.Preadditive.FunctorCategory
 
 -/
 
-@[expose] public section
+public section
 
 namespace CategoryTheory
 

--- a/Mathlib/CategoryTheory/Monoidal/Cartesian/CommMon_.lean
+++ b/Mathlib/CategoryTheory/Monoidal/Cartesian/CommMon_.lean
@@ -11,7 +11,7 @@ public import Mathlib.CategoryTheory.Monoidal.Cartesian.Mon_
 # Yoneda embedding of `CommMon C`
 -/
 
-@[expose] public section
+public section
 
 assert_not_exists MonoidWithZero
 

--- a/Mathlib/CategoryTheory/Monoidal/Closed/Enrichment.lean
+++ b/Mathlib/CategoryTheory/Monoidal/Closed/Enrichment.lean
@@ -23,7 +23,7 @@ All structure field values are defined in `Mathlib/CategoryTheory/Closed/Monoida
 
 -/
 
-@[expose] public section
+public section
 
 universe u v
 

--- a/Mathlib/CategoryTheory/Monoidal/Closed/Transport.lean
+++ b/Mathlib/CategoryTheory/Monoidal/Closed/Transport.lean
@@ -13,7 +13,7 @@ public import Mathlib.CategoryTheory.Monoidal.Transport
 # Transporting a closed monoidal structure along an equivalence of categories
 -/
 
-@[expose] public section
+public section
 
 open CategoryTheory Monoidal
 

--- a/Mathlib/CategoryTheory/Monoidal/CoherenceLemmas.lean
+++ b/Mathlib/CategoryTheory/Monoidal/CoherenceLemmas.lean
@@ -17,7 +17,7 @@ Investigate whether these lemmas are really needed,
 or if they can be replaced by use of the `coherence` tactic.
 -/
 
-@[expose] public section
+public section
 
 
 open CategoryTheory Category Iso

--- a/Mathlib/CategoryTheory/Preadditive/LiftToFinset.lean
+++ b/Mathlib/CategoryTheory/Preadditive/LiftToFinset.lean
@@ -18,7 +18,7 @@ is preadditive, then we can describe the legs of this cocone as finite sums of p
 by inclusions.
 -/
 
-@[expose] public section
+public section
 
 universe w v u
 

--- a/Mathlib/CategoryTheory/Preadditive/Yoneda/Injective.lean
+++ b/Mathlib/CategoryTheory/Preadditive/Yoneda/Injective.lean
@@ -14,7 +14,7 @@ public import Mathlib.Algebra.Category.ModuleCat.EpiMono
 An object is injective iff the preadditive yoneda functor on it preserves epimorphisms.
 -/
 
-@[expose] public section
+public section
 
 
 universe v u

--- a/Mathlib/CategoryTheory/Preadditive/Yoneda/Projective.lean
+++ b/Mathlib/CategoryTheory/Preadditive/Yoneda/Projective.lean
@@ -14,7 +14,7 @@ public import Mathlib.Algebra.Category.ModuleCat.EpiMono
 An object is projective iff the preadditive coyoneda functor on it preserves epimorphisms.
 -/
 
-@[expose] public section
+public section
 
 
 universe v u

--- a/Mathlib/CategoryTheory/Presentable/Adjunction.lean
+++ b/Mathlib/CategoryTheory/Presentable/Adjunction.lean
@@ -22,7 +22,7 @@ In particular, if `e : C ≌ D` is an equivalence of categories and
 
 -/
 
-@[expose] public section
+public section
 
 universe w v v' u u'
 

--- a/Mathlib/CategoryTheory/Presentable/EssentiallyLarge.lean
+++ b/Mathlib/CategoryTheory/Presentable/EssentiallyLarge.lean
@@ -17,7 +17,7 @@ of objects is in `Type (w + 1)` and whose types of morphisms are in `Type w`.
 
 -/
 
-@[expose] public section
+public section
 
 universe w v u
 

--- a/Mathlib/CategoryTheory/Products/Bifunctor.lean
+++ b/Mathlib/CategoryTheory/Products/Bifunctor.lean
@@ -11,7 +11,7 @@ public import Mathlib.CategoryTheory.Products.Basic
 # Lemmas about functors out of product categories.
 -/
 
-@[expose] public section
+public section
 
 
 open CategoryTheory

--- a/Mathlib/CategoryTheory/Sites/CartesianMonoidal.lean
+++ b/Mathlib/CategoryTheory/Sites/CartesianMonoidal.lean
@@ -15,7 +15,7 @@ In this file, we put a `CartesianMonoidalCategory` instance on `A`-valued sheave
 `GrothendieckTopology` whenever `A` has a `CartesianMonoidalCategory` instance.
 -/
 
-@[expose] public section
+public section
 
 universe v₁ v₂ u₁ u₂
 

--- a/Mathlib/CategoryTheory/Sites/Coherent/ExtensiveTopology.lean
+++ b/Mathlib/CategoryTheory/Sites/Coherent/ExtensiveTopology.lean
@@ -20,7 +20,7 @@ This file characterises the covering sieves of the extensive topology.
   exhibiting the target as a coproduct of the sources.
 -/
 
-@[expose] public section
+public section
 
 open CategoryTheory Limits
 

--- a/Mathlib/CategoryTheory/Sites/Coherent/LocallySurjective.lean
+++ b/Mathlib/CategoryTheory/Sites/Coherent/LocallySurjective.lean
@@ -29,7 +29,7 @@ and extensive topologies.
   finitary extensive category is locally surjective iff it is objectwise surjective.
 -/
 
-@[expose] public section
+public section
 
 universe w
 

--- a/Mathlib/CategoryTheory/Sites/Coherent/ReflectsPrecoherent.lean
+++ b/Mathlib/CategoryTheory/Sites/Coherent/ReflectsPrecoherent.lean
@@ -17,7 +17,7 @@ effective epimorphic families, such that for every object `X` of `D` there exist
 `C` with an effective epi `π : F.obj W ⟶ X`, the category `C` is `Precoherent` whenever `D` is.
 -/
 
-@[expose] public section
+public section
 
 namespace CategoryTheory
 

--- a/Mathlib/CategoryTheory/Sites/Coherent/ReflectsPreregular.lean
+++ b/Mathlib/CategoryTheory/Sites/Coherent/ReflectsPreregular.lean
@@ -17,7 +17,7 @@ object `X` of `D` there exists an object `W` of `C` with an effective epi `π : 
 category `C` is `Preregular`.
 -/
 
-@[expose] public section
+public section
 
 namespace CategoryTheory
 

--- a/Mathlib/CategoryTheory/Sites/Coherent/SequentialLimit.lean
+++ b/Mathlib/CategoryTheory/Sites/Coherent/SequentialLimit.lean
@@ -27,7 +27,7 @@ This is deduced from the corresponding statement about locally surjective morphi
 (see `coherentTopology.isLocallySurjective_π_app_zero_of_isLocallySurjective_map`).
 -/
 
-@[expose] public section
+public section
 
 universe w v u
 

--- a/Mathlib/CategoryTheory/Sites/PreservesLocallyBijective.lean
+++ b/Mathlib/CategoryTheory/Sites/PreservesLocallyBijective.lean
@@ -16,7 +16,7 @@ surjectivity of morphisms of presheaves, and that precomposition with a cover-pr
 cover-dense functor reflects the same properties.
 -/
 
-@[expose] public section
+public section
 
 open CategoryTheory Functor
 

--- a/Mathlib/CategoryTheory/Subobject/HasCardinalLT.lean
+++ b/Mathlib/CategoryTheory/Subobject/HasCardinalLT.lean
@@ -16,7 +16,7 @@ is `< κ`, then the cardinality of `Subobject X` is also `< κ`.
 
 -/
 
-@[expose] public section
+public section
 
 universe w v u
 

--- a/Mathlib/CategoryTheory/Triangulated/Opposite/Triangulated.lean
+++ b/Mathlib/CategoryTheory/Triangulated/Opposite/Triangulated.lean
@@ -19,7 +19,7 @@ that `Cᵒᵖ` is triangulated if `C` is triangulated.
 
 -/
 
-@[expose] public section
+public section
 
 namespace CategoryTheory
 


### PR DESCRIPTION
Removes `@[expose]` from 59 files in CategoryTheory.

🤖 Prepared with Claude Code