### PR TITLE
[Merged by Bors] - chore(NumberTheory): remove unnecessary @[expose] from public sections

### DIFF
--- a/Mathlib/FieldTheory/Cardinality.lean
+++ b/Mathlib/FieldTheory/Cardinality.lean
@@ -28,7 +28,7 @@ a field structure, and so can all types with prime power cardinalities, and this
 
 -/
 
-@[expose] public section
+public section
 
 
 local notation "‖" x "‖" => Fintype.card x

--- a/Mathlib/FieldTheory/ChevalleyWarning.lean
+++ b/Mathlib/FieldTheory/ChevalleyWarning.lean
@@ -35,7 +35,7 @@ and `q` is notation for the cardinality of `K`.
 
 -/
 
-@[expose] public section
+public section
 
 
 universe u v

--- a/Mathlib/FieldTheory/Finite/Trace.lean
+++ b/Mathlib/FieldTheory/Finite/Trace.lean
@@ -26,7 +26,7 @@ We state several lemmas about the trace and norm maps for finite fields.
 finite field, trace, norm
 -/
 
-@[expose] public section
+public section
 
 
 namespace FiniteField

--- a/Mathlib/FieldTheory/Galois/Notation.lean
+++ b/Mathlib/FieldTheory/Galois/Notation.lean
@@ -18,7 +18,7 @@ Although this notation works for all automorphism groups of algebras, we should 
 notation when `L/K` is an extension of fields.
 -/
 
-@[expose] public section
+public section
 
 section Notation
 

--- a/Mathlib/FieldTheory/IntermediateField/Adjoin/Algebra.lean
+++ b/Mathlib/FieldTheory/IntermediateField/Adjoin/Algebra.lean
@@ -15,7 +15,7 @@ public import Mathlib.FieldTheory.IntermediateField.Algebraic
 This file relates `IntermediateField.adjoin` to `Algebra.adjoin`.
 -/
 
-@[expose] public section
+public section
 
 open Module Polynomial
 

--- a/Mathlib/FieldTheory/IsAlgClosed/Spectrum.lean
+++ b/Mathlib/FieldTheory/IsAlgClosed/Spectrum.lean
@@ -35,7 +35,7 @@ eigenvalue.
 * `σ a` : `spectrum R a` of `a : A`
 -/
 
-@[expose] public section
+public section
 
 namespace spectrum
 

--- a/Mathlib/FieldTheory/Isaacs.lean
+++ b/Mathlib/FieldTheory/Isaacs.lean
@@ -29,7 +29,7 @@ The American Mathematical Monthly
 
 -/
 
-@[expose] public section
+public section
 
 namespace Field
 

--- a/Mathlib/FieldTheory/JacobsonNoether.lean
+++ b/Mathlib/FieldTheory/JacobsonNoether.lean
@@ -48,7 +48,7 @@ separate variables constrained by certain relations.
 * <https://ysharifi.wordpress.com/2011/09/30/the-jacobson-noether-theorem/>
 -/
 
-@[expose] public section
+public section
 
 namespace JacobsonNoether
 

--- a/Mathlib/FieldTheory/KummerPolynomial.lean
+++ b/Mathlib/FieldTheory/KummerPolynomial.lean
@@ -17,7 +17,7 @@ public import Mathlib.RingTheory.Norm.Defs
 
 -/
 
-@[expose] public section
+public section
 universe u
 
 variable {K : Type u} [Field K]

--- a/Mathlib/FieldTheory/MvRatFunc/Rank.lean
+++ b/Mathlib/FieldTheory/MvRatFunc/Rank.lean
@@ -15,7 +15,7 @@ public import Mathlib.RingTheory.MvPolynomial
 # Rank of multivariate rational function field
 -/
 
-@[expose] public section
+public section
 
 noncomputable section
 

--- a/Mathlib/FieldTheory/PurelyInseparable/Tower.lean
+++ b/Mathlib/FieldTheory/PurelyInseparable/Tower.lean
@@ -43,7 +43,7 @@ separable degree, degree, separable closure, purely inseparable
 
 -/
 
-@[expose] public section
+public section
 
 open Polynomial IntermediateField Field
 

--- a/Mathlib/FieldTheory/Tower.lean
+++ b/Mathlib/FieldTheory/Tower.lean
@@ -24,7 +24,7 @@ tower law
 
 -/
 
-@[expose] public section
+public section
 
 
 universe u v w u₁ v₁ w₁

--- a/Mathlib/NumberTheory/AbelSummation.lean
+++ b/Mathlib/NumberTheory/AbelSummation.lean
@@ -43,7 +43,7 @@ Primed versions of the three results above are also stated for when the endpoint
 
 -/
 
-@[expose] public section
+public section
 
 noncomputable section
 

--- a/Mathlib/NumberTheory/Basic.lean
+++ b/Mathlib/NumberTheory/Basic.lean
@@ -22,7 +22,7 @@ all natural numbers `p` and `k` if `p` divides `a-b` in `R`, then `p ^ (k + 1)` 
 `a ^ (p ^ k) - b ^ (p ^ k)`.
 -/
 
-@[expose] public section
+public section
 
 
 section

--- a/Mathlib/NumberTheory/Bertrand.lean
+++ b/Mathlib/NumberTheory/Bertrand.lean
@@ -39,7 +39,7 @@ binomial coefficient given in `Nat.four_pow_lt_mul_centralBinom`.
 Bertrand, prime, binomial coefficients
 -/
 
-@[expose] public section
+public section
 
 
 section Real

--- a/Mathlib/NumberTheory/Cyclotomic/Discriminant.lean
+++ b/Mathlib/NumberTheory/Cyclotomic/Discriminant.lean
@@ -21,7 +21,7 @@ We compute the discriminant of a `p ^ n`-th cyclotomic extension.
 
 -/
 
-@[expose] public section
+public section
 
 
 universe u v

--- a/Mathlib/NumberTheory/DiophantineApproximation/ContinuedFractions.lean
+++ b/Mathlib/NumberTheory/DiophantineApproximation/ContinuedFractions.lean
@@ -20,7 +20,7 @@ a simple recursive definition of the convergents that is also defined in that fi
 This file provides `Real.exists_convs_eq_rat`, using `GenContFract.convs` of `GenContFract.of ξ`.
 -/
 
-@[expose] public section
+public section
 
 section Convergent
 

--- a/Mathlib/NumberTheory/DirichletCharacter/Bounds.lean
+++ b/Mathlib/NumberTheory/DirichletCharacter/Bounds.lean
@@ -17,7 +17,7 @@ We consider Dirichlet characters `χ` with values in a normed field `F`.
 We show that `‖χ a‖ = 1` if `a` is a unit and `‖χ a‖ ≤ 1` in general.
 -/
 
-@[expose] public section
+public section
 
 variable {F : Type*} [NormedField F] {n : ℕ} (χ : DirichletCharacter F n)
 

--- a/Mathlib/NumberTheory/DirichletCharacter/GaussSum.lean
+++ b/Mathlib/NumberTheory/DirichletCharacter/GaussSum.lean
@@ -12,7 +12,7 @@ public import Mathlib.NumberTheory.GaussSum
 # Gauss sums for Dirichlet characters
 -/
 
-@[expose] public section
+public section
 variable {N : ℕ} [NeZero N] {R : Type*} [CommRing R] (e : AddChar (ZMod N) R)
 
 open AddChar DirichletCharacter

--- a/Mathlib/NumberTheory/DirichletCharacter/Orthogonality.lean
+++ b/Mathlib/NumberTheory/DirichletCharacter/Orthogonality.lean
@@ -19,7 +19,7 @@ when `a ≠ b` and has the value `n.totient` otherwise. This requires `R` to hav
 enough roots of unity (e.g., `R` could be an algebraically closed field of characteristic zero).
 -/
 
-@[expose] public section
+public section
 
 namespace DirichletCharacter
 

--- a/Mathlib/NumberTheory/EulerProduct/Basic.lean
+++ b/Mathlib/NumberTheory/EulerProduct/Basic.lean
@@ -44,7 +44,7 @@ for `s : Finset ℕ`.
 Euler product, multiplicative function
 -/
 
-@[expose] public section
+public section
 
 /-- If `f` is multiplicative and summable, then its values at natural numbers `> 1`
 have norm strictly less than `1`. -/

--- a/Mathlib/NumberTheory/EulerProduct/ExpLog.lean
+++ b/Mathlib/NumberTheory/EulerProduct/ExpLog.lean
@@ -18,7 +18,7 @@ under suitable conditions on `f`. This can be seen as a logarithmic version of t
 Euler product for `f`.
 -/
 
-@[expose] public section
+public section
 
 open Complex
 

--- a/Mathlib/NumberTheory/FLT/MasonStothers.lean
+++ b/Mathlib/NumberTheory/FLT/MasonStothers.lean
@@ -20,7 +20,7 @@ but slightly different.
 
 -/
 
-@[expose] public section
+public section
 
 open Polynomial UniqueFactorizationMonoid UniqueFactorizationDomain EuclideanDomain
 

--- a/Mathlib/NumberTheory/FLT/Polynomial.lean
+++ b/Mathlib/NumberTheory/FLT/Polynomial.lean
@@ -30,7 +30,7 @@ The proof uses the Mason-Stothers theorem (Polynomial ABC theorem) and infinite 
 (in the characteristic p case).
 -/
 
-@[expose] public section
+public section
 
 open Polynomial UniqueFactorizationMonoid
 

--- a/Mathlib/NumberTheory/Harmonic/Bounds.lean
+++ b/Mathlib/NumberTheory/Harmonic/Bounds.lean
@@ -15,7 +15,7 @@ This file proves $\log(n + 1) \le H_n \le 1 + \log(n)$ for all natural numbers $
 
 -/
 
-@[expose] public section
+public section
 
 lemma harmonic_eq_sum_Icc {n : ℕ} : harmonic n = ∑ i ∈ Finset.Icc 1 n, (↑i)⁻¹ := by
   rw [harmonic, Finset.range_eq_Ico, Finset.sum_Ico_add' (fun (i : ℕ) ↦ (i : ℚ)⁻¹) 0 n (c := 1)]

--- a/Mathlib/NumberTheory/Harmonic/GammaDeriv.lean
+++ b/Mathlib/NumberTheory/Harmonic/GammaDeriv.lean
@@ -19,7 +19,7 @@ We prove the formula for the derivative of `Real.Gamma` at a positive integer:
 
 -/
 
-@[expose] public section
+public section
 
 open Nat Set Filter Topology
 

--- a/Mathlib/NumberTheory/Harmonic/Int.lean
+++ b/Mathlib/NumberTheory/Harmonic/Int.lean
@@ -19,7 +19,7 @@ https://kconrad.math.uconn.edu/blurbs/gradnumthy/padicharmonicsum.pdf
 
 -/
 
-@[expose] public section
+public section
 
 lemma harmonic_pos {n : ℕ} (Hn : n ≠ 0) : 0 < harmonic n := by
   unfold harmonic

--- a/Mathlib/NumberTheory/LSeries/Deriv.lean
+++ b/Mathlib/NumberTheory/LSeries/Deriv.lean
@@ -30,7 +30,7 @@ We introduce `LSeries.logMul` as an abbreviation for the point-wise product `log
 the problem that this expression does not type-check.
 -/
 
-@[expose] public section
+public section
 
 open Complex LSeries
 

--- a/Mathlib/NumberTheory/LSeries/Dirichlet.lean
+++ b/Mathlib/NumberTheory/LSeries/Dirichlet.lean
@@ -33,7 +33,7 @@ as special cases.
 Dirichlet L-series, Möbius function, von Mangoldt function, Riemann zeta function
 -/
 
-@[expose] public section
+public section
 
 open scoped LSeries.notation
 

--- a/Mathlib/NumberTheory/LSeries/HurwitzZetaValues.lean
+++ b/Mathlib/NumberTheory/LSeries/HurwitzZetaValues.lean
@@ -37,7 +37,7 @@ sums in the convergence range.)
   methods in the library at the present time (May 2024).
 -/
 
-@[expose] public section
+public section
 
 open Complex Real Set
 

--- a/Mathlib/NumberTheory/LSeries/Injectivity.lean
+++ b/Mathlib/NumberTheory/LSeries/Injectivity.lean
@@ -17,7 +17,7 @@ must agree on all nonzero arguments. See `LSeries_eq_iff_of_abscissaOfAbsConv_lt
 and `LSeries_injOn`.
 -/
 
-@[expose] public section
+public section
 
 open LSeries Complex
 

--- a/Mathlib/NumberTheory/LSeries/Linearity.lean
+++ b/Mathlib/NumberTheory/LSeries/Linearity.lean
@@ -15,7 +15,7 @@ We show that the `LSeries` of `f : ℕ → ℂ` is a linear function of `f` (ass
 of both L-series when adding two functions).
 -/
 
-@[expose] public section
+public section
 
 /-!
 ### Addition

--- a/Mathlib/NumberTheory/LSeries/MellinEqDirichlet.lean
+++ b/Mathlib/NumberTheory/LSeries/MellinEqDirichlet.lean
@@ -13,7 +13,7 @@ Here we prove general results of the form "the Mellin transform of a power serie
 a Dirichlet series".
 -/
 
-@[expose] public section
+public section
 
 open Filter Topology Asymptotics Real Set MeasureTheory
 open Complex

--- a/Mathlib/NumberTheory/LSeries/Positivity.lean
+++ b/Mathlib/NumberTheory/LSeries/Positivity.lean
@@ -25,7 +25,7 @@ The main results of this file are as follows.
   `ArithmeticFunction.LSeries_positive_of_eq_differentiable`.
 -/
 
-@[expose] public section
+public section
 
 open scoped ComplexOrder
 

--- a/Mathlib/NumberTheory/LSeries/SumCoeff.lean
+++ b/Mathlib/NumberTheory/LSeries/SumCoeff.lean
@@ -34,7 +34,7 @@ L-series.
 
 -/
 
-@[expose] public section
+public section
 
 open Finset Filter MeasureTheory Topology Complex Asymptotics
 

--- a/Mathlib/NumberTheory/LegendreSymbol/GaussEisensteinLemmas.lean
+++ b/Mathlib/NumberTheory/LegendreSymbol/GaussEisensteinLemmas.lean
@@ -15,7 +15,7 @@ This file contains the Lemmas of Gauss and Eisenstein on the Legendre symbol.
 The main results are `ZMod.gauss_lemma` and `ZMod.eisenstein_lemma`.
 -/
 
-@[expose] public section
+public section
 
 
 open Finset Nat

--- a/Mathlib/NumberTheory/LegendreSymbol/QuadraticChar/GaussSum.lean
+++ b/Mathlib/NumberTheory/LegendreSymbol/QuadraticChar/GaussSum.lean
@@ -15,7 +15,7 @@ Further facts relying on Gauss sums.
 
 -/
 
-@[expose] public section
+public section
 
 
 /-!

--- a/Mathlib/NumberTheory/LegendreSymbol/QuadraticReciprocity.lean
+++ b/Mathlib/NumberTheory/LegendreSymbol/QuadraticReciprocity.lean
@@ -35,7 +35,7 @@ properties of quadratic Gauss sums as provided by `NumberTheory.LegendreSymbol.G
 quadratic residue, quadratic nonresidue, Legendre symbol, quadratic reciprocity
 -/
 
-@[expose] public section
+public section
 
 
 open Nat

--- a/Mathlib/NumberTheory/LucasPrimality.lean
+++ b/Mathlib/NumberTheory/LucasPrimality.lean
@@ -29,7 +29,7 @@ cases, we can take `q` to be any prime and see that `hd` does not hold, since `a
 to `1`.
 -/
 
-@[expose] public section
+public section
 
 
 /-- If `a^(p-1) = 1 mod p`, but `a^((p-1)/q) ≠ 1 mod p` for all prime factors `q` of `p-1`, then `p`

--- a/Mathlib/NumberTheory/MahlerMeasure.lean
+++ b/Mathlib/NumberTheory/MahlerMeasure.lean
@@ -26,7 +26,7 @@ polynomials, in particular Northcott's Theorem for the Mahler measure.
 - `Polynomial.cyclotomic_mahlerMeasure_eq_one`: the Mahler measure of a cyclotomic polynomial is 1.
 -/
 
-@[expose] public section
+public section
 
 namespace Polynomial
 

--- a/Mathlib/NumberTheory/ModularForms/Bounds.lean
+++ b/Mathlib/NumberTheory/ModularForms/Bounds.lean
@@ -23,7 +23,7 @@ bounds for its q-expansion coefficients. The main results are
 * `CuspFormClass.qExpansion_isBigO`: **Hecke's bound** for a a cusp form of weight `k` (for
   an arithmetic subgroup `Γ`): the `n`-th q-expansion coefficient is `O(n ^ (k / 2))`.
 -/
-@[expose] public section
+public section
 
 open Filter Topology Asymptotics Matrix.SpecialLinearGroup Matrix.GeneralLinearGroup
 

--- a/Mathlib/NumberTheory/ModularForms/EisensteinSeries/IsBoundedAtImInfty.lean
+++ b/Mathlib/NumberTheory/ModularForms/EisensteinSeries/IsBoundedAtImInfty.lean
@@ -26,7 +26,7 @@ We can then, first observe that the slash action just changes our `a` to `(a ᵥ
 we then use our bounds for Eisenstein series in these vertical strips to get the result.
 -/
 
-@[expose] public section
+public section
 
 noncomputable section
 

--- a/Mathlib/NumberTheory/ModularForms/EisensteinSeries/MDifferentiable.lean
+++ b/Mathlib/NumberTheory/ModularForms/EisensteinSeries/MDifferentiable.lean
@@ -18,7 +18,7 @@ We show that Eisenstein series of weight `k` and level `Γ(N)` with congruence c
 MDifferentiable.
 -/
 
-@[expose] public section
+public section
 
 noncomputable section
 

--- a/Mathlib/NumberTheory/ModularForms/EisensteinSeries/QExpansion.lean
+++ b/Mathlib/NumberTheory/ModularForms/EisensteinSeries/QExpansion.lean
@@ -32,7 +32,7 @@ gives the q-expansion with a Riemann zeta factor, which we simplify using the fo
 
 -/
 
-@[expose] public section
+public section
 
 open Set Metric TopologicalSpace Function Filter Complex ArithmeticFunction
   ModularForm EisensteinSeries

--- a/Mathlib/NumberTheory/ModularForms/EisensteinSeries/UniformConvergence.lean
+++ b/Mathlib/NumberTheory/ModularForms/EisensteinSeries/UniformConvergence.lean
@@ -26,7 +26,7 @@ We then show in `summable_one_div_rpow_max` that the sum of `max (|c|, |d|) ^ (-
 `Finset.box` lemmas.
 -/
 
-@[expose] public section
+public section
 
 noncomputable section
 

--- a/Mathlib/NumberTheory/ModularForms/Identities.lean
+++ b/Mathlib/NumberTheory/ModularForms/Identities.lean
@@ -15,7 +15,7 @@ public import Mathlib.NumberTheory.ModularForms.Cusps
 Collection of useful identities of modular forms.
 -/
 
-@[expose] public section
+public section
 
 noncomputable section
 

--- a/Mathlib/NumberTheory/ModularForms/JacobiTheta/Manifold.lean
+++ b/Mathlib/NumberTheory/ModularForms/JacobiTheta/Manifold.lean
@@ -20,7 +20,7 @@ differentiability.
 Prove smoothness (in terms of `Smooth`).
 -/
 
-@[expose] public section
+public section
 
 
 open scoped UpperHalfPlane Manifold

--- a/Mathlib/NumberTheory/ModularForms/LevelOne.lean
+++ b/Mathlib/NumberTheory/ModularForms/LevelOne.lean
@@ -18,7 +18,7 @@ TODO: Add finite-dimensionality of these spaces of modular forms.
 
 -/
 
-@[expose] public section
+public section
 
 open UpperHalfPlane ModularGroup SlashInvariantForm ModularForm Complex
   CongruenceSubgroup Real Function SlashInvariantFormClass ModularFormClass Periodic

--- a/Mathlib/NumberTheory/Multiplicity.lean
+++ b/Mathlib/NumberTheory/Multiplicity.lean
@@ -26,7 +26,7 @@ This file contains results in number theory relating to multiplicity.
   (https://en.wikipedia.org/wiki/Lifting-the-exponent_lemma)
 -/
 
-@[expose] public section
+public section
 
 
 open Ideal Ideal.Quotient Finset

--- a/Mathlib/NumberTheory/Niven.lean
+++ b/Mathlib/NumberTheory/Niven.lean
@@ -19,7 +19,7 @@ by π. Equivalently, the only rational numbers that occur as `cos(π * p / q)` a
 values `{-1, -1/2, 0, 1/2, 1}`.
 -/
 
-@[expose] public section
+public section
 
 namespace IsIntegral
 

--- a/Mathlib/NumberTheory/NumberField/Cyclotomic/Embeddings.lean
+++ b/Mathlib/NumberTheory/NumberField/Cyclotomic/Embeddings.lean
@@ -18,7 +18,7 @@ We prove that cyclotomic extensions of `ℚ` are totally complex, meaning that
   then there are no real places of `K`.
 -/
 
-@[expose] public section
+public section
 
 universe u
 

--- a/Mathlib/NumberTheory/NumberField/Cyclotomic/PID.lean
+++ b/Mathlib/NumberTheory/NumberField/Cyclotomic/PID.lean
@@ -19,7 +19,7 @@ but the proof is more and more involved.
 * `five_pid`: If `IsCyclotomicExtension {5} ℚ K` then `𝓞 K` is a principal ideal domain.
 -/
 
-@[expose] public section
+public section
 
 universe u
 

--- a/Mathlib/NumberTheory/NumberField/Cyclotomic/Three.lean
+++ b/Mathlib/NumberTheory/NumberField/Cyclotomic/Three.lean
@@ -28,7 +28,7 @@ This is a special case of the so-called *Kummer's lemma* (see for example [washi
 Theorem 5.36).
 -/
 
-@[expose] public section
+public section
 
 open NumberField Units InfinitePlace nonZeroDivisors Polynomial
 

--- a/Mathlib/NumberTheory/NumberField/Discriminant/Basic.lean
+++ b/Mathlib/NumberTheory/NumberField/Discriminant/Basic.lean
@@ -29,7 +29,7 @@ This file defines the discriminant of a number field.
 number field, discriminant
 -/
 
-@[expose] public section
+public section
 
 -- TODO. Rewrite some of the FLT results on the discriminant using the definitions and results of
 -- this file

--- a/Mathlib/NumberTheory/NumberField/Discriminant/Defs.lean
+++ b/Mathlib/NumberTheory/NumberField/Discriminant/Defs.lean
@@ -24,7 +24,7 @@ This file defines the discriminant of a number field.
 number field, discriminant
 -/
 
-@[expose] public section
+public section
 
 open Module
 

--- a/Mathlib/NumberTheory/NumberField/Discriminant/Different.lean
+++ b/Mathlib/NumberTheory/NumberField/Discriminant/Different.lean
@@ -25,7 +25,7 @@ public import Mathlib.RingTheory.Ideal.Norm.RelNorm
 
 -/
 
-@[expose] public section
+public section
 
 namespace NumberField
 

--- a/Mathlib/NumberTheory/NumberField/ProductFormula.lean
+++ b/Mathlib/NumberTheory/NumberField/ProductFormula.lean
@@ -31,7 +31,7 @@ ideal of `𝓞 K` raised to the power of the `v`-adic valuation of `x`.
 number field, embeddings, places, infinite places, finite places, product formula
 -/
 
-@[expose] public section
+public section
 
 namespace NumberField
 

--- a/Mathlib/NumberTheory/Padics/Hensel.lean
+++ b/Mathlib/NumberTheory/Padics/Hensel.lean
@@ -33,7 +33,7 @@ The proof and motivation are described in the paper
 p-adic, p adic, padic, p-adic integer
 -/
 
-@[expose] public section
+public section
 
 
 noncomputable section

--- a/Mathlib/NumberTheory/PowModTotient.lean
+++ b/Mathlib/NumberTheory/PowModTotient.lean
@@ -27,7 +27,7 @@ function when the base is coprime to the modulus.
 
 -/
 
-@[expose] public section
+public section
 
 namespace Nat
 

--- a/Mathlib/NumberTheory/PrimesCongruentOne.lean
+++ b/Mathlib/NumberTheory/PrimesCongruentOne.lean
@@ -14,7 +14,7 @@ We prove that, for any positive `k : ℕ`, there are infinitely many primes `p` 
 `p ≡ 1 [MOD k]`.
 -/
 
-@[expose] public section
+public section
 
 
 namespace Nat

--- a/Mathlib/NumberTheory/RamificationInertia/Unramified.lean
+++ b/Mathlib/NumberTheory/RamificationInertia/Unramified.lean
@@ -22,7 +22,7 @@ We connect `Ideal.ramificationIdx` to the commutative algebra notion predicate o
 
 -/
 
-@[expose] public section
+public section
 
 variable {R S T : Type*} [CommRing R] [CommRing S] [CommRing T]
 variable [Algebra R S] [Algebra S T] [Algebra R T] [IsScalarTower R S T]

--- a/Mathlib/NumberTheory/SiegelsLemma.lean
+++ b/Mathlib/NumberTheory/SiegelsLemma.lean
@@ -33,7 +33,7 @@ the entries of the matrix
 See [M. Hindry and J. Silverman, Diophantine Geometry: an Introduction][hindrysilverman00].
 -/
 
-@[expose] public section
+public section
 
 /- We set ‖⬝‖ to be Matrix.seminormedAddCommGroup  -/
 attribute [local instance] Matrix.seminormedAddCommGroup

--- a/Mathlib/NumberTheory/SumFourSquares.lean
+++ b/Mathlib/NumberTheory/SumFourSquares.lean
@@ -18,7 +18,7 @@ a proof that every natural number is the sum of four square numbers.
 The proof used is close to Lagrange's original proof.
 -/
 
-@[expose] public section
+public section
 
 
 open Finset Polynomial FiniteField Equiv

--- a/Mathlib/NumberTheory/SumPrimeReciprocals.lean
+++ b/Mathlib/NumberTheory/SumPrimeReciprocals.lean
@@ -25,7 +25,7 @@ See the sixth proof for the infinity of primes in Chapter 1 of [aigner1999proofs
 The proof is due to Erdős.
 -/
 
-@[expose] public section
+public section
 
 open Set Nat
 open scoped Topology

--- a/Mathlib/NumberTheory/Transcendental/Lindemann/AnalyticalPart.lean
+++ b/Mathlib/NumberTheory/Transcendental/Lindemann/AnalyticalPart.lean
@@ -16,7 +16,7 @@ public import Mathlib.Topology.Algebra.Polynomial
 # Analytic part of the Lindemann-Weierstrass theorem
 -/
 
-@[expose] public section
+public section
 
 namespace LindemannWeierstrass
 

--- a/Mathlib/NumberTheory/Transcendental/Liouville/Measure.lean
+++ b/Mathlib/NumberTheory/Transcendental/Liouville/Measure.lean
@@ -27,7 +27,7 @@ measure. The fact that the filters are disjoint means that two mutually exclusiv
 Liouville number, Lebesgue measure, residual, generic property
 -/
 
-@[expose] public section
+public section
 
 open scoped Filter ENNReal Topology NNReal
 

--- a/Mathlib/NumberTheory/Transcendental/Liouville/Residual.lean
+++ b/Mathlib/NumberTheory/Transcendental/Liouville/Residual.lean
@@ -17,7 +17,7 @@ In this file we prove that the set of Liouville numbers form a dense `Gδ` set. 
 similar statement about irrational numbers.
 -/
 
-@[expose] public section
+public section
 
 
 open scoped Filter

--- a/Mathlib/NumberTheory/Wilson.lean
+++ b/Mathlib/NumberTheory/Wilson.lean
@@ -26,7 +26,7 @@ This could be generalized to similar results about finite abelian groups.
 * Give `wilsons_lemma` a descriptive name.
 -/
 
-@[expose] public section
+public section
 
 assert_not_exists legendreSym.quadratic_reciprocity
 

--- a/Mathlib/NumberTheory/Zsqrtd/QuadraticReciprocity.lean
+++ b/Mathlib/NumberTheory/Zsqrtd/QuadraticReciprocity.lean
@@ -18,7 +18,7 @@ A prime natural number is prime in `ℤ[i]` if and only if it is `3` mod `4`
 
 -/
 
-@[expose] public section
+public section
 
 
 open Zsqrtd Complex


### PR DESCRIPTION
Removes `@[expose]` from 69 files in NumberTheory and FieldTheory.

🤖 Prepared with Claude Code